### PR TITLE
Cleanup c10/ folder

### DIFF
--- a/c10/core/Allocator.h
+++ b/c10/core/Allocator.h
@@ -4,8 +4,8 @@
 #include <memory>
 
 #include <c10/core/Device.h>
-#include <c10/util/UniqueVoidPtr.h>
 #include <c10/util/Exception.h>
+#include <c10/util/UniqueVoidPtr.h>
 
 namespace c10 {
 
@@ -93,7 +93,9 @@ class C10_API DataPtr {
    * be; be sure to read the source code of the Allocator
    * in question to confirm this.
    */
-  C10_NODISCARD bool compare_exchange_deleter(DeleterFnPtr expected_deleter, DeleterFnPtr new_deleter) {
+  C10_NODISCARD bool compare_exchange_deleter(
+      DeleterFnPtr expected_deleter,
+      DeleterFnPtr new_deleter) {
     return ptr_.compare_exchange_deleter(expected_deleter, new_deleter);
   }
   Device device() const {
@@ -209,8 +211,8 @@ struct AllocatorRegisterer {
   }
 };
 
-#define REGISTER_ALLOCATOR(t, f)                    \
-  namespace {                                       \
+#define REGISTER_ALLOCATOR(t, f)                  \
+  namespace {                                     \
   static AllocatorRegisterer<t> g_allocator_d(f); \
   }
 

--- a/c10/core/Backend.h
+++ b/c10/core/Backend.h
@@ -25,7 +25,22 @@ namespace c10 {
  * or "SparseCUDA"; backend in torch.backends is something like "MKL" or
  * "CUDNN".
  */
-enum class Backend { CPU, CUDA, HIP, SparseCPU, SparseCUDA, SparseHIP, MSNPU, XLA, QuantizedCPU, ComplexCPU, ComplexCUDA, Undefined, MkldnnCPU, NumOptions };
+enum class Backend {
+  CPU,
+  CUDA,
+  HIP,
+  SparseCPU,
+  SparseCUDA,
+  SparseHIP,
+  MSNPU,
+  XLA,
+  QuantizedCPU,
+  ComplexCPU,
+  ComplexCUDA,
+  Undefined,
+  MkldnnCPU,
+  NumOptions
+};
 
 static inline Backend toSparse(Backend b) {
   switch (b) {

--- a/c10/core/CPUAllocator.cpp
+++ b/c10/core/CPUAllocator.cpp
@@ -43,8 +43,9 @@ void* alloc_cpu(size_t nbytes) {
   // We might have clowny upstream code that tries to alloc a negative number
   // of bytes. Let's catch it early.
   CAFFE_ENFORCE(
-    ((ptrdiff_t)nbytes) >= 0,
-    "alloc_cpu() seems to have been called with negative number: ", nbytes);
+      ((ptrdiff_t)nbytes) >= 0,
+      "alloc_cpu() seems to have been called with negative number: ",
+      nbytes);
 
   void* data;
 #ifdef __ANDROID__
@@ -76,7 +77,7 @@ void* alloc_cpu(size_t nbytes) {
   CHECK(
       !FLAGS_caffe2_cpu_allocator_do_zero_fill ||
       !FLAGS_caffe2_cpu_allocator_do_junk_fill)
-    << "Cannot request both zero-fill and junk-fill at the same time";
+      << "Cannot request both zero-fill and junk-fill at the same time";
   if (FLAGS_caffe2_cpu_allocator_do_zero_fill) {
     memset(data, 0, nbytes);
   } else if (FLAGS_caffe2_cpu_allocator_do_junk_fill) {
@@ -140,7 +141,6 @@ struct C10_API DefaultCPUAllocator final : at::Allocator {
     static MemoryAllocationReporter reporter_;
     return reporter_;
   }
-
 };
 
 void NoDelete(void*) {}

--- a/c10/core/CopyBytes.cpp
+++ b/c10/core/CopyBytes.cpp
@@ -46,4 +46,4 @@ void CopyBytes(
   ptr(nbytes, src, src_device, dst, dst_device);
 }
 
-}
+} // namespace c10

--- a/c10/core/DefaultDtype.cpp
+++ b/c10/core/DefaultDtype.cpp
@@ -1,5 +1,5 @@
-#include <c10/util/typeid.h>
 #include <c10/core/DefaultDtype.h>
+#include <c10/util/typeid.h>
 
 namespace c10 {
 static auto default_dtype = caffe2::TypeMeta::Make<float>();

--- a/c10/core/DefaultTensorOptions.h
+++ b/c10/core/DefaultTensorOptions.h
@@ -13,21 +13,31 @@ struct TensorOptions;
 struct DefaultTensorOptions {
   DefaultTensorOptions() = default;
 
-  caffe2::TypeMeta dtype() const noexcept { return dtype_; }
-  Device device()          const noexcept { return device_; }
-  Layout layout()          const noexcept { return layout_; }
-  bool requires_grad()     const noexcept { return requires_grad_; }
-  bool is_variable()       const noexcept { return is_variable_; }
+  caffe2::TypeMeta dtype() const noexcept {
+    return dtype_;
+  }
+  Device device() const noexcept {
+    return device_;
+  }
+  Layout layout() const noexcept {
+    return layout_;
+  }
+  bool requires_grad() const noexcept {
+    return requires_grad_;
+  }
+  bool is_variable() const noexcept {
+    return is_variable_;
+  }
 
   // Defined in TensorOptions.h
   inline DefaultTensorOptions& merge(const TensorOptions& options);
 
  private:
   caffe2::TypeMeta dtype_ = caffe2::TypeMeta::Make<float>(); // 64-bit
-  Device device_          = at::kCPU;                        // 32-bit
-  Layout layout_          = at::kStrided;                    // 8-bit
-  bool requires_grad_     = false;                           // 8-bit
-  bool is_variable_       = false;                           // 8-bit
+  Device device_ = at::kCPU; // 32-bit
+  Layout layout_ = at::kStrided; // 8-bit
+  bool requires_grad_ = false; // 8-bit
+  bool is_variable_ = false; // 8-bit
 };
 
 inline const DefaultTensorOptions& getDefaultTensorOptions() {

--- a/c10/core/Device.cpp
+++ b/c10/core/Device.cpp
@@ -34,7 +34,8 @@ DeviceType parse_type(const std::string& device_string) {
     return device->second;
   }
   AT_ERROR(
-      "Expected one of cpu, cuda, mkldnn, opengl, opencl, ideep, hip, msnpu device type at start of device string: ", device_string);
+      "Expected one of cpu, cuda, mkldnn, opengl, opencl, ideep, hip, msnpu device type at start of device string: ",
+      device_string);
 }
 } // namespace
 
@@ -75,12 +76,15 @@ Device::Device(const std::string& device_string) : Device(Type::CPU) {
     std::string device_index = device_string.substr(index + 1);
     try {
       index_ = c10::stoi(device_index);
-    } catch (const std::exception &) {
-      AT_ERROR("Could not parse device index '", device_index,
-               "' in device string '", device_string, "'");
+    } catch (const std::exception&) {
+      AT_ERROR(
+          "Could not parse device index '",
+          device_index,
+          "' in device string '",
+          device_string,
+          "'");
     }
-    TORCH_CHECK(index_ >= 0,
-             "Device index must be non-negative, got ", index_);
+    TORCH_CHECK(index_ >= 0, "Device index must be non-negative, got ", index_);
   }
   validate();
 }

--- a/c10/core/Device.h
+++ b/c10/core/Device.h
@@ -90,16 +90,18 @@ struct C10_API Device final {
   DeviceType type_;
   DeviceIndex index_ = -1;
   void validate() {
-    TORCH_CHECK(index_ == -1 || index_ >= 0,
-        "Device index must be -1 or non-negative, got ", index_);
-    TORCH_CHECK(!is_cpu() || index_ <= 0,
-        "CPU device index must be -1 or zero, got ", index_);
+    TORCH_CHECK(
+        index_ == -1 || index_ >= 0,
+        "Device index must be -1 or non-negative, got ",
+        index_);
+    TORCH_CHECK(
+        !is_cpu() || index_ <= 0,
+        "CPU device index must be -1 or zero, got ",
+        index_);
   }
 };
 
-C10_API std::ostream& operator<<(
-    std::ostream& stream,
-    const Device& device);
+C10_API std::ostream& operator<<(std::ostream& stream, const Device& device);
 
 } // namespace c10
 
@@ -119,10 +121,11 @@ struct hash<c10::Device> {
     // half of the resulting integer.
     //
     // Technically, by C/C++ integer promotion rules, we only need one of the
-    // uint32_t casts to the result type, but we put in both for explicitness's sake.
-    uint32_t bits =
-        static_cast<uint32_t>(static_cast<uint16_t>(d.type())) << 16
-      | static_cast<uint32_t>(static_cast<uint16_t>(d.index()));
+    // uint32_t casts to the result type, but we put in both for explicitness's
+    // sake.
+    uint32_t bits = static_cast<uint32_t>(static_cast<uint16_t>(d.type()))
+            << 16 |
+        static_cast<uint32_t>(static_cast<uint16_t>(d.index()));
     return std::hash<uint32_t>{}(bits);
   }
 };

--- a/c10/core/DeviceGuard.h
+++ b/c10/core/DeviceGuard.h
@@ -17,7 +17,7 @@ namespace c10 {
 /// want to setup a guard (i.e., are looking for the moral equivalent
 /// of optional<DeviceGuard>), see OptionalDeviceGuard.
 class DeviceGuard {
-public:
+ public:
   /// No default constructor; see Note [Omitted default constructor from RAII]
   explicit DeviceGuard() = delete;
 
@@ -25,7 +25,10 @@ public:
   explicit DeviceGuard(Device device) : guard_(device) {}
 
   /// This constructor is for testing only.
-  explicit DeviceGuard(Device device, const impl::DeviceGuardImplInterface* impl) : guard_(device, impl) {}
+  explicit DeviceGuard(
+      Device device,
+      const impl::DeviceGuardImplInterface* impl)
+      : guard_(device, impl) {}
 
   /// Copy is disallowed
   DeviceGuard(const DeviceGuard&) = delete;
@@ -48,7 +51,9 @@ public:
   }
 
   /// This method is for testing only.
-  void reset_device(at::Device device, const impl::DeviceGuardImplInterface* impl) {
+  void reset_device(
+      at::Device device,
+      const impl::DeviceGuardImplInterface* impl) {
     guard_.reset_device(device, impl);
   }
 
@@ -69,7 +74,7 @@ public:
     return guard_.current_device();
   }
 
-private:
+ private:
   impl::InlineDeviceGuard<impl::VirtualGuardImpl> guard_;
 };
 
@@ -79,8 +84,8 @@ private:
  * Morally, a OptionalDeviceGuard is equivalent to optional<DeviceGuard>, but
  * with extra constructors and methods as appropriate.
  *
- * Besides its obvious use (optionally applying a DeviceGuard), OptionalDeviceGuard
- * is often also used for the following idiom:
+ * Besides its obvious use (optionally applying a DeviceGuard),
+ * OptionalDeviceGuard is often also used for the following idiom:
  *
  *    OptionalDeviceGuard g;
  *    for (const auto& t : tensors) {
@@ -117,7 +122,7 @@ private:
  * DeviceGuard will still reset the device to original_device_.
  */
 class OptionalDeviceGuard {
-public:
+ public:
   /// Create an uninitialized guard.  Set the guard later using reset_device.
   explicit OptionalDeviceGuard() : guard_() {}
 
@@ -129,7 +134,10 @@ public:
   explicit OptionalDeviceGuard(optional<Device> device) : guard_(device) {}
 
   /// Constructor for testing only.
-  explicit OptionalDeviceGuard(Device device, const impl::DeviceGuardImplInterface* impl) : guard_(device, impl) {}
+  explicit OptionalDeviceGuard(
+      Device device,
+      const impl::DeviceGuardImplInterface* impl)
+      : guard_(device, impl) {}
 
   /// Copy is disallowed
   OptionalDeviceGuard(const OptionalDeviceGuard&) = delete;
@@ -149,7 +157,9 @@ public:
   }
 
   /// For testing only
-  void reset_device(at::Device device, const impl::DeviceGuardImplInterface* impl) {
+  void reset_device(
+      at::Device device,
+      const impl::DeviceGuardImplInterface* impl) {
     guard_.reset_device(device, impl);
   }
 
@@ -164,7 +174,7 @@ public:
     return guard_.current_device();
   }
 
-private:
+ private:
   impl::InlineOptionalDeviceGuard<impl::VirtualGuardImpl> guard_;
 };
 
@@ -173,7 +183,8 @@ private:
 // Design note: in principle, we could avoid these wrappers using:
 //
 // using DeviceGuard = impl::InlineDeviceGuard<impl::VirtualGuardImpl>;
-// using OptionalDeviceGuard = impl::InlineOptionalDeviceGuard<impl::VirtualGuardImpl>;
+// using OptionalDeviceGuard =
+// impl::InlineOptionalDeviceGuard<impl::VirtualGuardImpl>;
 //
 // But the error messages are worse, and our users can't just look at the
 // header file to find out what's going on.  Furthermore, for specializations

--- a/c10/core/DeviceType.h
+++ b/c10/core/DeviceType.h
@@ -7,8 +7,8 @@
 
 #include <c10/macros/Macros.h>
 
-#include <ostream>
 #include <functional>
+#include <ostream>
 
 namespace c10 {
 
@@ -41,7 +41,8 @@ constexpr DeviceType kXLA = DeviceType::XLA;
 constexpr int COMPILE_TIME_MAX_DEVICE_TYPES =
     static_cast<int>(DeviceType::COMPILE_TIME_MAX_DEVICE_TYPES);
 
-static_assert(COMPILE_TIME_MAX_DEVICE_TYPES <= 16,
+static_assert(
+    COMPILE_TIME_MAX_DEVICE_TYPES <= 16,
     "Hey!  You seem to be adding a lot of new DeviceTypes.  The intent was "
     "for this constant to reflect the actual number of DeviceTypes we support "
     "in PyTorch; it's important that this number is not too large as we "
@@ -51,9 +52,7 @@ static_assert(COMPILE_TIME_MAX_DEVICE_TYPES <= 16,
     "types registration, please be aware that you are affecting code that "
     "this number is small.  Try auditing uses of this constant.");
 
-C10_API std::string DeviceTypeName(
-    DeviceType d,
-    bool lower_case = false);
+C10_API std::string DeviceTypeName(DeviceType d, bool lower_case = false);
 
 C10_API bool isValidDeviceType(DeviceType d);
 
@@ -62,7 +61,8 @@ C10_API std::ostream& operator<<(std::ostream& stream, DeviceType type);
 } // namespace c10
 
 namespace std {
-template <> struct hash<c10::DeviceType> {
+template <>
+struct hash<c10::DeviceType> {
   std::size_t operator()(c10::DeviceType k) const {
     return std::hash<int>()(static_cast<int>(k));
   }

--- a/c10/core/Event.h
+++ b/c10/core/Event.h
@@ -41,18 +41,18 @@ struct Event final {
   // Constructors
   Event() = delete;
   Event(
-    const DeviceType _device_type,
-    const EventFlag _flag = EventFlag::PYTORCH_DEFAULT)
-  : impl_{_device_type, _flag} { }
+      const DeviceType _device_type,
+      const EventFlag _flag = EventFlag::PYTORCH_DEFAULT)
+      : impl_{_device_type, _flag} {}
 
   // Copy constructor and copy assignment operator (deleted)
   Event(const Event&) = delete;
   Event& operator=(const Event&) = delete;
 
   // Move constructor and move assignment operator
-  Event(Event&& other) : impl_{std::move(other.impl_)} { }
+  Event(Event&& other) : impl_{std::move(other.impl_)} {}
   Event& operator=(Event&& other) {
-  impl_.swap(std::move(other.impl_));
+    impl_.swap(std::move(other.impl_));
     return *this;
   }
 
@@ -60,54 +60,62 @@ struct Event final {
   ~Event() = default;
 
   // Getters
-  DeviceType device_type() const noexcept { return impl_.device_type(); }
-  DeviceIndex device_index() const noexcept { return impl_.device_index(); }
-  EventFlag flag() const noexcept { return impl_.flag(); }
-  bool was_marked_for_recording() const noexcept { return impl_.was_marked_for_recording(); }
+  DeviceType device_type() const noexcept {
+    return impl_.device_type();
+  }
+  DeviceIndex device_index() const noexcept {
+    return impl_.device_index();
+  }
+  EventFlag flag() const noexcept {
+    return impl_.flag();
+  }
+  bool was_marked_for_recording() const noexcept {
+    return impl_.was_marked_for_recording();
+  }
 
-/**
- * Calls record() if and only if record() has never been called for this event.
- * Note: because Event is not thread-safe recordOnce() may call record()
- * multiple times if called from multiple threads.
- */
+  /**
+   * Calls record() if and only if record() has never been called for this
+   * event. Note: because Event is not thread-safe recordOnce() may call
+   * record() multiple times if called from multiple threads.
+   */
   void recordOnce(const Stream& stream) {
     impl_.recordOnce(stream);
   }
 
-/**
- * Increments the event's version and enqueues a job with this version
- * in the stream's work queue. When the stream process that job
- * it nofifies all streams waiting on / blocked by that version of the
- * event to continue and marks that version as recorded.
- * */
+  /**
+   * Increments the event's version and enqueues a job with this version
+   * in the stream's work queue. When the stream process that job
+   * it nofifies all streams waiting on / blocked by that version of the
+   * event to continue and marks that version as recorded.
+   * */
   void record(const Stream& stream) {
     impl_.record(stream);
   }
 
-/**
- * Does nothing if the event has not been scheduled to be recorded.
- * If the event was previously enqueued to be recorded, a command
- * to wait for the version of the event that exists at the time of this call
- * is inserted in the stream's work queue.
- * When the stream reaches this command it will stop processing
- * additional commands until that version of the event is marked as recorded.
- */
+  /**
+   * Does nothing if the event has not been scheduled to be recorded.
+   * If the event was previously enqueued to be recorded, a command
+   * to wait for the version of the event that exists at the time of this call
+   * is inserted in the stream's work queue.
+   * When the stream reaches this command it will stop processing
+   * additional commands until that version of the event is marked as recorded.
+   */
   void block(const Stream& stream) const {
     impl_.block(stream);
   }
 
-/**
- * Returns true if (and only if)
- *  (1) the event has never been scheduled to be recorded
- *  (2) the current version is marked as recorded.
- * Returns false otherwise.
- */
+  /**
+   * Returns true if (and only if)
+   *  (1) the event has never been scheduled to be recorded
+   *  (2) the current version is marked as recorded.
+   * Returns false otherwise.
+   */
   bool query() const {
     return impl_.query();
   }
 
-private:
+ private:
   impl::InlineEvent<impl::VirtualGuardImpl> impl_;
 };
 
-} // c10
+} // namespace c10

--- a/c10/core/MemoryFormat.h
+++ b/c10/core/MemoryFormat.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <c10/core/Backend.h>
-#include <c10/util/Exception.h>
 #include <c10/util/ArrayRef.h>
+#include <c10/util/Exception.h>
 
 #include <iostream>
 
@@ -17,11 +17,12 @@
 //    should be in channels_last format
 //
 //  Contiguous:
-//    Regardless of input tensors format, the output should be contiguous Tensor.
+//    Regardless of input tensors format, the output should be contiguous
+//    Tensor.
 //
 //  ChannelsLast:
-//    Regardless of input tensors format, the output should be in channels_last format.
-
+//    Regardless of input tensors format, the output should be in channels_last
+//    format.
 
 namespace c10 {
 enum class MemoryFormat : int8_t { Contiguous, Preserve, ChannelsLast };

--- a/c10/core/QEngine.h
+++ b/c10/core/QEngine.h
@@ -31,9 +31,7 @@ inline std::string toString(QEngine qengine) {
       return "QNNPACK";
     default:
       TORCH_CHECK(
-          false,
-          "Unrecognized Quantized Engine: ",
-          static_cast<int>(qengine));
+          false, "Unrecognized Quantized Engine: ", static_cast<int>(qengine));
   }
 }
 

--- a/c10/core/QScheme.h
+++ b/c10/core/QScheme.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <c10/core/TensorTypeId.h>
 #include <c10/core/DeviceType.h>
+#include <c10/core/TensorTypeId.h>
 #include <c10/util/Exception.h>
 
 namespace c10 {
@@ -25,10 +25,10 @@ constexpr auto kPerChannelAffine = QScheme::PER_CHANNEL_AFFINE;
 constexpr auto kPerTensorSymmetric = QScheme::PER_TENSOR_SYMMETRIC;
 constexpr auto kPerChannelSymmetric = QScheme::PER_CHANNEL_SYMMETRIC;
 constexpr int COMPILE_TIME_NUM_QSCHEMES =
-  static_cast<int>(QScheme::COMPILE_TIME_NUM_QSCHEMES);
+    static_cast<int>(QScheme::COMPILE_TIME_NUM_QSCHEMES);
 
 inline std::string toString(QScheme qscheme) {
-  switch(qscheme) {
+  switch (qscheme) {
     case kPerTensorAffine:
       return "per_tensor_affine";
     case kPerChannelAffine:

--- a/c10/core/Scalar.cpp
+++ b/c10/core/Scalar.cpp
@@ -3,7 +3,9 @@
 namespace c10 {
 
 Scalar Scalar::operator-() const {
-  TORCH_CHECK(!isBoolean(), "torch boolean negative, the `-` operator, is not suppported.");
+  TORCH_CHECK(
+      !isBoolean(),
+      "torch boolean negative, the `-` operator, is not suppported.");
   if (isFloatingPoint()) {
     return Scalar(-v.d);
   } else if (isComplex()) {
@@ -13,4 +15,4 @@ Scalar Scalar::operator-() const {
   }
 }
 
-}  // namespace c10
+} // namespace c10

--- a/c10/core/Scalar.h
+++ b/c10/core/Scalar.h
@@ -24,8 +24,8 @@ class C10_API Scalar {
  public:
   Scalar() : Scalar(int64_t(0)) {}
 
-#define DEFINE_IMPLICIT_CTOR(type, name)      \
-  Scalar(type vv) : Scalar(vv, true) { }
+#define DEFINE_IMPLICIT_CTOR(type, name) \
+  Scalar(type vv) : Scalar(vv, true) {}
 
   AT_FORALL_SCALAR_TYPES_AND2(Half, BFloat16, DEFINE_IMPLICIT_CTOR)
 
@@ -61,7 +61,8 @@ class C10_API Scalar {
     } else if (Tag::HAS_z == tag) {                       \
       return checked_convert<type, std::complex<double>>( \
           {v.z[0], v.z[1]}, #type);                       \
-    } if (Tag::HAS_b == tag) {                            \
+    }                                                     \
+    if (Tag::HAS_b == tag) {                              \
       return checked_convert<type, bool>(v.i, #type);     \
     } else {                                              \
       return checked_convert<type, int64_t>(v.i, #type);  \
@@ -80,7 +81,8 @@ class C10_API Scalar {
     return Tag::HAS_d == tag;
   }
 
-  C10_DEPRECATED_MESSAGE("isIntegral is deprecated. Please use the overload with 'includeBool' parameter instead.")
+  C10_DEPRECATED_MESSAGE(
+      "isIntegral is deprecated. Please use the overload with 'includeBool' parameter instead.")
   bool isIntegral() const {
     return Tag::HAS_i == tag;
   }
@@ -98,19 +100,22 @@ class C10_API Scalar {
   Scalar operator-() const;
 
  private:
-    template<typename T,
-             typename std::enable_if<std::numeric_limits<T>::is_integer && ! std::is_same<T, bool>::value, bool>::type* =
-                 nullptr>
-    Scalar(T vv, bool) : tag(Tag::HAS_i) {
-      v.i = convert<decltype(v.i), T>(vv);
-    }
+  template <
+      typename T,
+      typename std::enable_if<
+          std::numeric_limits<T>::is_integer && !std::is_same<T, bool>::value,
+          bool>::type* = nullptr>
+  Scalar(T vv, bool) : tag(Tag::HAS_i) {
+    v.i = convert<decltype(v.i), T>(vv);
+  }
 
-    template<typename T,
-             typename std::enable_if<!std::numeric_limits<T>::is_integer, bool>::type* =
-                 nullptr>
-    Scalar(T vv, bool) : tag(Tag::HAS_d) {
-      v.d = convert<decltype(v.d), T>(vv);
-    }
+  template <
+      typename T,
+      typename std::enable_if<!std::numeric_limits<T>::is_integer, bool>::
+          type* = nullptr>
+  Scalar(T vv, bool) : tag(Tag::HAS_d) {
+    v.d = convert<decltype(v.d), T>(vv);
+  }
 
   // We can't set v in the initializer list using the
   // syntax v{ .member = ... } because it doesn't work on MSVC
@@ -133,10 +138,10 @@ inline T Scalar::to() const {
   throw std::runtime_error("to() cast to unexpected type.");
 }
 
-#define DEFINE_TO(T, name)    \
-  template <>                 \
-  inline T Scalar::to<T>() const {  \
-    return to##name();        \
+#define DEFINE_TO(T, name)         \
+  template <>                      \
+  inline T Scalar::to<T>() const { \
+    return to##name();             \
   }
 AT_FORALL_SCALAR_TYPES_WITH_COMPLEX_EXCEPT_COMPLEX_HALF(DEFINE_TO)
 #undef DEFINE_TO

--- a/c10/core/ScalarType.h
+++ b/c10/core/ScalarType.h
@@ -38,7 +38,6 @@ namespace c10 {
   _(c10::qint32, QInt32) /* 14 */                        \
   _(at::BFloat16, BFloat16) /* 15 */
 
-
 // If you want to support ComplexHalf for real, add ComplexHalf
 // into this macro (and change the name).  But beware: convert()
 // doesn't work for all the conversions you need...
@@ -56,7 +55,6 @@ namespace c10 {
   _(bool, Bool)                                                    \
   _(at::BFloat16, BFloat16)
 
-
 enum class ScalarType : int8_t {
 #define DEFINE_ENUM(_1, n) n,
   AT_FORALL_SCALAR_TYPES_WITH_COMPLEX_AND_QINTS(DEFINE_ENUM)
@@ -67,57 +65,65 @@ enum class ScalarType : int8_t {
 
 namespace impl {
 
-// These are used to map ScalarTypes to C++ types.  Feel free to add more or even
-// macro generate this; the examples here are just those we have found to be
-// necessary.
+// These are used to map ScalarTypes to C++ types.  Feel free to add more or
+// even macro generate this; the examples here are just those we have found to
+// be necessary.
 
 template <c10::ScalarType N>
 struct ScalarTypeToCPPType;
 
-template<>
+template <>
 struct ScalarTypeToCPPType<c10::ScalarType::Half> {
   using type = c10::Half;
 
-  // This is a workaround for the CUDA bug which prevents ::detail::ScalarTypeToCType<T>::type being used directly
-  // due to ambiguous reference which can't to be resolved. For some reason it cant pick between at::detail and at::cuda::detail.
-  // For repro example, please see: https://gist.github.com/izdeby/952ae7cf256ddb740a73776d39a7e7ba
+  // This is a workaround for the CUDA bug which prevents
+  // ::detail::ScalarTypeToCType<T>::type being used directly due to ambiguous
+  // reference which can't to be resolved. For some reason it cant pick between
+  // at::detail and at::cuda::detail. For repro example, please see:
+  // https://gist.github.com/izdeby/952ae7cf256ddb740a73776d39a7e7ba
   // TODO: remove once the bug is fixed.
   static type t;
 };
 
-template<>
+template <>
 struct ScalarTypeToCPPType<c10::ScalarType::BFloat16> {
   using type = c10::BFloat16;
 
-  // This is a workaround for the CUDA bug which prevents ::detail::ScalarTypeToCType<T>::type being used directly
-  // due to ambiguous reference which can't to be resolved. For some reason it cant pick between at::detail and at::cuda::detail.
-  // For repro example, please see: https://gist.github.com/izdeby/952ae7cf256ddb740a73776d39a7e7ba
+  // This is a workaround for the CUDA bug which prevents
+  // ::detail::ScalarTypeToCType<T>::type being used directly due to ambiguous
+  // reference which can't to be resolved. For some reason it cant pick between
+  // at::detail and at::cuda::detail. For repro example, please see:
+  // https://gist.github.com/izdeby/952ae7cf256ddb740a73776d39a7e7ba
   // TODO: remove once the bug is fixed.
   static type t;
 };
 
-template<>
+template <>
 struct ScalarTypeToCPPType<c10::ScalarType::Bool> {
   using type = bool;
 
-  // This is a workaround for the CUDA bug which prevents ::detail::ScalarTypeToCType<T>::type being used directly
-  // due to ambiguous reference which can't to be resolved. For some reason it cant pick between at::detail and at::cuda::detail.
-  // For repro example, please see: https://gist.github.com/izdeby/952ae7cf256ddb740a73776d39a7e7ba
+  // This is a workaround for the CUDA bug which prevents
+  // ::detail::ScalarTypeToCType<T>::type being used directly due to ambiguous
+  // reference which can't to be resolved. For some reason it cant pick between
+  // at::detail and at::cuda::detail. For repro example, please see:
+  // https://gist.github.com/izdeby/952ae7cf256ddb740a73776d39a7e7ba
   // TODO: remove once the bug is fixed.
   static type t;
 };
 
-template<>
+template <>
 struct ScalarTypeToCPPType<c10::ScalarType::Long> {
   using type = int64_t;
 
-  // This is a workaround for the CUDA bug which prevents ::detail::ScalarTypeToCType<T>::type being used directly
-  // due to ambiguous reference which can't to be resolved. For some reason it cant pick between at::detail and at::cuda::detail.
-  // For repro example, please see: https://gist.github.com/izdeby/952ae7cf256ddb740a73776d39a7e7ba
+  // This is a workaround for the CUDA bug which prevents
+  // ::detail::ScalarTypeToCType<T>::type being used directly due to ambiguous
+  // reference which can't to be resolved. For some reason it cant pick between
+  // at::detail and at::cuda::detail. For repro example, please see:
+  // https://gist.github.com/izdeby/952ae7cf256ddb740a73776d39a7e7ba
   // TODO: remove once the bug is fixed.
   static type t;
 };
-}
+} // namespace impl
 
 #define AT_FORALL_SCALAR_TYPES(_) \
   _(uint8_t, Byte)                \
@@ -128,42 +134,54 @@ struct ScalarTypeToCPPType<c10::ScalarType::Long> {
   _(float, Float)                 \
   _(double, Double)
 
-#define AT_FORALL_SCALAR_TYPES_AND(SCALARTYPE, _)                          \
-  _(uint8_t, Byte)                                                         \
-  _(int8_t, Char)                                                          \
-  _(int16_t, Short)                                                        \
-  _(int, Int)                                                              \
-  _(int64_t, Long)                                                         \
-  _(float, Float)                                                          \
-  _(double, Double)                                                        \
-  _(decltype(::c10::impl::ScalarTypeToCPPType<::c10::ScalarType::SCALARTYPE>::t), SCALARTYPE)
+#define AT_FORALL_SCALAR_TYPES_AND(SCALARTYPE, _)                            \
+  _(uint8_t, Byte)                                                           \
+  _(int8_t, Char)                                                            \
+  _(int16_t, Short)                                                          \
+  _(int, Int)                                                                \
+  _(int64_t, Long)                                                           \
+  _(float, Float)                                                            \
+  _(double, Double)                                                          \
+  _(decltype(                                                                \
+        ::c10::impl::ScalarTypeToCPPType<::c10::ScalarType::SCALARTYPE>::t), \
+    SCALARTYPE)
 
-#define AT_FORALL_SCALAR_TYPES_AND2(SCALARTYPE1, SCALARTYPE2, _)                                \
-  _(uint8_t, Byte)                                                                              \
-  _(int8_t, Char)                                                                               \
-  _(int16_t, Short)                                                                             \
-  _(int, Int)                                                                                   \
-  _(int64_t, Long)                                                                              \
-  _(float, Float)                                                                               \
-  _(double, Double)                                                                             \
-  _(decltype(::c10::impl::ScalarTypeToCPPType<::c10::ScalarType::SCALARTYPE1>::t), SCALARTYPE1) \
-  _(decltype(::c10::impl::ScalarTypeToCPPType<::c10::ScalarType::SCALARTYPE2>::t), SCALARTYPE2)
+#define AT_FORALL_SCALAR_TYPES_AND2(SCALARTYPE1, SCALARTYPE2, _)              \
+  _(uint8_t, Byte)                                                            \
+  _(int8_t, Char)                                                             \
+  _(int16_t, Short)                                                           \
+  _(int, Int)                                                                 \
+  _(int64_t, Long)                                                            \
+  _(float, Float)                                                             \
+  _(double, Double)                                                           \
+  _(decltype(                                                                 \
+        ::c10::impl::ScalarTypeToCPPType<::c10::ScalarType::SCALARTYPE1>::t), \
+    SCALARTYPE1)                                                              \
+  _(decltype(                                                                 \
+        ::c10::impl::ScalarTypeToCPPType<::c10::ScalarType::SCALARTYPE2>::t), \
+    SCALARTYPE2)
 
-#define AT_FORALL_SCALAR_TYPES_AND3(SCALARTYPE1, SCALARTYPE2, SCALARTYPE3, _)                   \
-  _(uint8_t, Byte)                                                                              \
-  _(int8_t, Char)                                                                               \
-  _(int16_t, Short)                                                                             \
-  _(int, Int)                                                                                   \
-  _(int64_t, Long)                                                                              \
-  _(float, Float)                                                                               \
-  _(double, Double)                                                                             \
-  _(decltype(::c10::impl::ScalarTypeToCPPType<::c10::ScalarType::SCALARTYPE1>::t), SCALARTYPE1) \
-  _(decltype(::c10::impl::ScalarTypeToCPPType<::c10::ScalarType::SCALARTYPE2>::t), SCALARTYPE2) \
-  _(decltype(::c10::impl::ScalarTypeToCPPType<::c10::ScalarType::SCALARTYPE3>::t), SCALARTYPE3)
+#define AT_FORALL_SCALAR_TYPES_AND3(SCALARTYPE1, SCALARTYPE2, SCALARTYPE3, _) \
+  _(uint8_t, Byte)                                                            \
+  _(int8_t, Char)                                                             \
+  _(int16_t, Short)                                                           \
+  _(int, Int)                                                                 \
+  _(int64_t, Long)                                                            \
+  _(float, Float)                                                             \
+  _(double, Double)                                                           \
+  _(decltype(                                                                 \
+        ::c10::impl::ScalarTypeToCPPType<::c10::ScalarType::SCALARTYPE1>::t), \
+    SCALARTYPE1)                                                              \
+  _(decltype(                                                                 \
+        ::c10::impl::ScalarTypeToCPPType<::c10::ScalarType::SCALARTYPE2>::t), \
+    SCALARTYPE2)                                                              \
+  _(decltype(                                                                 \
+        ::c10::impl::ScalarTypeToCPPType<::c10::ScalarType::SCALARTYPE3>::t), \
+    SCALARTYPE3)
 
-#define AT_FORALL_QINT_TYPES(_)  \
-  _(c10::qint8, QInt8)           \
-  _(c10::quint8, QUInt8)         \
+#define AT_FORALL_QINT_TYPES(_) \
+  _(c10::qint8, QInt8)          \
+  _(c10::quint8, QUInt8)        \
   _(c10::qint32, QInt32)
 
 static inline caffe2::TypeMeta scalarTypeToTypeMeta(ScalarType scalar_type) {
@@ -249,7 +267,8 @@ static inline size_t elementSize(ScalarType t) {
 #undef CASE_ELEMENTSIZE_CASE
 }
 
-C10_DEPRECATED_MESSAGE("isIntegralType is deprecated. Please use the overload with 'includeBool' parameter instead.")
+C10_DEPRECATED_MESSAGE(
+    "isIntegralType is deprecated. Please use the overload with 'includeBool' parameter instead.")
 static inline bool isIntegralType(ScalarType t) {
   return (
       t == ScalarType::Byte || t == ScalarType::Char || t == ScalarType::Int ||
@@ -257,9 +276,9 @@ static inline bool isIntegralType(ScalarType t) {
 }
 
 static inline bool isIntegralType(ScalarType t, bool includeBool) {
-  bool isIntegral = (
-      t == ScalarType::Byte || t == ScalarType::Char || t == ScalarType::Int ||
-      t == ScalarType::Long || t == ScalarType::Short);
+  bool isIntegral =
+      (t == ScalarType::Byte || t == ScalarType::Char || t == ScalarType::Int ||
+       t == ScalarType::Long || t == ScalarType::Short);
 
   return includeBool ? isIntegral || (t == ScalarType::Bool) : isIntegral;
 }
@@ -278,7 +297,8 @@ static inline bool isComplexType(ScalarType t) {
 
 static inline bool isQIntType(ScalarType t) {
   // Don't forget to extend this when adding new QInt types
-  return t == ScalarType:: QInt8 || t == ScalarType::QUInt8 || t == ScalarType::QInt32;
+  return t == ScalarType::QInt8 || t == ScalarType::QUInt8 ||
+      t == ScalarType::QInt32;
 }
 
 static inline ScalarType toQIntType(ScalarType t) {
@@ -308,16 +328,16 @@ static inline ScalarType toUnderlying(ScalarType t) {
 }
 
 static inline bool isSignedType(ScalarType t) {
-  #define CASE_SIGNED(ctype, name) \
-    case ScalarType::name:                       \
-      return std::numeric_limits<ctype>::is_signed;
+#define CASE_SIGNED(ctype, name) \
+  case ScalarType::name:         \
+    return std::numeric_limits<ctype>::is_signed;
 
-    switch (t) {
-      AT_FORALL_SCALAR_TYPES_AND(Half, CASE_SIGNED)
-      default:
-        AT_ERROR("Unknown ScalarType");
-    }
-  #undef CASE_SIGNED
+  switch (t) {
+    AT_FORALL_SCALAR_TYPES_AND(Half, CASE_SIGNED)
+    default:
+      AT_ERROR("Unknown ScalarType");
+  }
+#undef CASE_SIGNED
 }
 
 static inline bool isUnderlying(ScalarType type, ScalarType qtype) {
@@ -333,13 +353,14 @@ static inline bool canCast(const ScalarType from, const ScalarType to) {
   }
 
   // Treat bool as a distinct "category," to be consistent with type promotion
-  // rules (e.g. `bool_tensor + 5 -> int64_tensor`). If `5` was in the same category
-  // as `bool_tensor`, we would not promote.
-  // Differing categories implies `bool_tensor += 5` is disallowed.
+  // rules (e.g. `bool_tensor + 5 -> int64_tensor`). If `5` was in the same
+  // category as `bool_tensor`, we would not promote. Differing categories
+  // implies `bool_tensor += 5` is disallowed.
   //
   // NB: numpy distinguishes "unsigned" as a category to get the desired
   // `bool_tensor + 5 -> int64_tensor` behavior. We don't, because:
-  // * We don't want the performance hit of checking the runtime sign of Scalars.
+  // * We don't want the performance hit of checking the runtime sign of
+  // Scalars.
   // * `uint8_tensor + 5 -> int64_tensor` would be undesirable.
   if (from != ScalarType::Bool && to == ScalarType::Bool) {
     return false;
@@ -367,7 +388,10 @@ static inline ScalarType promoteTypes(ScalarType a, ScalarType b) {
   }
   if (isComplexType(a) || isComplexType(b)) {
     AT_ERROR(
-        "promoteTypes with complex numbers is not handled yet; figure out what the correct rules should be for ", toString(a), " and ", toString(b));
+        "promoteTypes with complex numbers is not handled yet; figure out what the correct rules should be for ",
+        toString(a),
+        " and ",
+        toString(b));
   }
 
   // For QInt types, we only allow exact match
@@ -388,23 +412,23 @@ static inline ScalarType promoteTypes(ScalarType a, ScalarType b) {
   // corrent values for the type promotions in complex type cases.
   static constexpr ScalarType _promoteTypesLookup[static_cast<int>(
       ScalarType::NumOptions)][static_cast<int>(ScalarType::NumOptions)] = {
-        /*        u1  i1  i2  i4  i8  f2  f4  f8  c2  c4  c8  b1  q1  q2  q3  bf*/
-        /* u1 */ {u1, i2, i2, i4, i8, f2, f4, f8, ud, c4, c8, u1, ud, ud, ud, ud},
-        /* i1 */ {i2, i1, i2, i4, i8, f2, f4, f8, ud, c4, c8, i1, ud, ud, ud, ud},
-        /* i2 */ {i2, i2, i2, i4, i8, f2, f4, f8, ud, c4, c8, i2, ud, ud, ud, ud},
-        /* i4 */ {i4, i4, i4, i4, i8, f2, f4, f8, ud, c4, c8, i4, ud, ud, ud, ud},
-        /* i8 */ {i8, i8, i8, i8, i8, f2, f4, f8, ud, c4, c8, i8, ud, ud, ud, ud},
-        /* f2 */ {f2, f2, f2, f2, f2, f2, f4, f8, ud, c4, c8, f2, ud, ud, ud, ud},
-        /* f4 */ {f4, f4, f4, f4, f4, f4, f4, f8, ud, c4, c8, f4, ud, ud, ud, ud},
-        /* f8 */ {f8, f8, f8, f8, f8, f8, f8, f8, ud, c8, c8, f8, ud, ud, ud, ud},
-        /* c2 */ {ud, ud, ud, ud, ud, ud, ud, ud, ud, c4, c8, ud, ud, ud, ud, ud},
-        /* c4 */ {c4, c4, c4, c4, c4, c4, c4, c8, c4, c4, c8, ud, ud, ud, ud, ud},
-        /* c8 */ {c8, c8, c8, c8, c8, c8, c8, c8, c8, c8, c8, ud, ud, ud, ud, ud},
-        /* b1 */ {u1, i1, i2, i4, i8, f2, f4, f8, ud, ud, ud, b1, ud, ud, ud, ud},
-        /* q1 */ {ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud},
-        /* q1 */ {ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud},
-        /* q2 */ {ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud},
-        /* bf */ {ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, bf},
+      /*        u1  i1  i2  i4  i8  f2  f4  f8  c2  c4  c8  b1  q1  q2  q3  bf*/
+      /* u1 */ {u1, i2, i2, i4, i8, f2, f4, f8, ud, c4, c8, u1, ud, ud, ud, ud},
+      /* i1 */ {i2, i1, i2, i4, i8, f2, f4, f8, ud, c4, c8, i1, ud, ud, ud, ud},
+      /* i2 */ {i2, i2, i2, i4, i8, f2, f4, f8, ud, c4, c8, i2, ud, ud, ud, ud},
+      /* i4 */ {i4, i4, i4, i4, i8, f2, f4, f8, ud, c4, c8, i4, ud, ud, ud, ud},
+      /* i8 */ {i8, i8, i8, i8, i8, f2, f4, f8, ud, c4, c8, i8, ud, ud, ud, ud},
+      /* f2 */ {f2, f2, f2, f2, f2, f2, f4, f8, ud, c4, c8, f2, ud, ud, ud, ud},
+      /* f4 */ {f4, f4, f4, f4, f4, f4, f4, f8, ud, c4, c8, f4, ud, ud, ud, ud},
+      /* f8 */ {f8, f8, f8, f8, f8, f8, f8, f8, ud, c8, c8, f8, ud, ud, ud, ud},
+      /* c2 */ {ud, ud, ud, ud, ud, ud, ud, ud, ud, c4, c8, ud, ud, ud, ud, ud},
+      /* c4 */ {c4, c4, c4, c4, c4, c4, c4, c8, c4, c4, c8, ud, ud, ud, ud, ud},
+      /* c8 */ {c8, c8, c8, c8, c8, c8, c8, c8, c8, c8, c8, ud, ud, ud, ud, ud},
+      /* b1 */ {u1, i1, i2, i4, i8, f2, f4, f8, ud, ud, ud, b1, ud, ud, ud, ud},
+      /* q1 */ {ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud},
+      /* q1 */ {ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud},
+      /* q2 */ {ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud},
+      /* bf */ {ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, bf},
   };
   return _promoteTypesLookup[static_cast<int>(a)][static_cast<int>(b)];
 }

--- a/c10/core/Storage.cpp
+++ b/c10/core/Storage.cpp
@@ -1,5 +1,3 @@
 #include <c10/core/Storage.h>
 
-namespace c10 {
-
-} // namespace c10
+namespace c10 {} // namespace c10

--- a/c10/core/Storage.h
+++ b/c10/core/Storage.h
@@ -7,7 +7,8 @@ namespace c10 {
 struct C10_API Storage {
  public:
   Storage() {}
-  Storage(c10::intrusive_ptr<StorageImpl> ptr) : storage_impl_(std::move(ptr)) {}
+  Storage(c10::intrusive_ptr<StorageImpl> ptr)
+      : storage_impl_(std::move(ptr)) {}
 
   // Allocates memory buffer using given allocator and creates a storage with it
   Storage(
@@ -43,11 +44,11 @@ struct C10_API Storage {
   static Storage create_legacy(at::Device device, caffe2::TypeMeta data_type) {
     auto allocator = GetAllocator(device.type());
     return Storage(c10::make_intrusive<StorageImpl>(
-            data_type,
-            0,
-            allocator->allocate(0), // materialize a non-default Device.
-            allocator,
-            true));
+        data_type,
+        0,
+        allocator->allocate(0), // materialize a non-default Device.
+        allocator,
+        true));
   }
 
   template <typename T>
@@ -56,10 +57,14 @@ struct C10_API Storage {
   }
 
   template <typename T>
-  T* data() const { return storage_impl_->data<T>(); }
+  T* data() const {
+    return storage_impl_->data<T>();
+  }
 
   template <typename T>
-  T* unsafe_data() const { return storage_impl_->unsafe_data<T>(); }
+  T* unsafe_data() const {
+    return storage_impl_->unsafe_data<T>();
+  }
 
   size_t elementSize() const {
     return storage_impl_->itemsize();

--- a/c10/core/Stream.h
+++ b/c10/core/Stream.h
@@ -55,10 +55,11 @@ using StreamId = int32_t;
  * wrapper classes which provide this functionality, e.g., CUDAStream.
  */
 class Stream final {
-private:
+ private:
   Device device_;
   StreamId id_;
-public:
+
+ public:
   enum Unsafe { UNSAFE };
   enum Default { DEFAULT };
 
@@ -69,16 +70,13 @@ public:
   /// we don't require backends to give any guarantees about non-zero
   /// StreamIds; they are welcome to allocate in whatever way they like.
   explicit Stream(Unsafe, Device device, StreamId id)
-    : device_(device)
-    , id_(id) {}
+      : device_(device), id_(id) {}
 
   /// Construct the default stream of a Device.  The default stream is
   /// NOT the same as the current stream; default stream is a fixed stream
   /// that never changes, whereas the current stream may be changed by
   /// StreamGuard.
-  explicit Stream(Default, Device device)
-    : device_(device)
-    , id_(0) {}
+  explicit Stream(Default, Device device) : device_(device), id_(0) {}
 
   bool operator==(const Stream& other) const noexcept {
     return this->device_ == other.device_ && this->id_ == other.id_;
@@ -87,10 +85,18 @@ public:
     return !(*this == other);
   }
 
-  Device device() const noexcept { return device_; }
-  DeviceType device_type() const noexcept { return device_.type(); }
-  DeviceIndex device_index() const noexcept { return device_.index(); }
-  StreamId id() const noexcept { return id_; }
+  Device device() const noexcept {
+    return device_;
+  }
+  DeviceType device_type() const noexcept {
+    return device_.type();
+  }
+  DeviceIndex device_index() const noexcept {
+    return device_.index();
+  }
+  StreamId id() const noexcept {
+    return id_;
+  }
 
   // Enqueues a wait instruction in the stream's work queue.
   // This instruction is a no-op unless the event is marked
@@ -116,10 +122,10 @@ public:
     static_assert(sizeof(StreamId) == 4, "DeviceIndex is not 32-bit");
     // Concat these together into a 64-bit integer
     // See Note [Hazard when concatenating signed integers]
-    uint64_t bits =
-        static_cast<uint64_t>(static_cast<uint16_t>(device_type())) << 48
-      | static_cast<uint64_t>(static_cast<uint16_t>(device_index())) << 32
-      | static_cast<uint64_t>(static_cast<uint32_t>(id()));
+    uint64_t bits = static_cast<uint64_t>(static_cast<uint16_t>(device_type()))
+            << 48 |
+        static_cast<uint64_t>(static_cast<uint16_t>(device_index())) << 32 |
+        static_cast<uint64_t>(static_cast<uint32_t>(id()));
     return bits;
   }
 
@@ -145,10 +151,10 @@ C10_API std::ostream& operator<<(std::ostream& stream, const Stream& s);
 } // namespace c10
 
 namespace std {
-  template <>
-  struct hash<c10::Stream> {
-    size_t operator()(c10::Stream s) const noexcept {
-      return std::hash<uint64_t>{}(s.pack());
-    }
-  };
+template <>
+struct hash<c10::Stream> {
+  size_t operator()(c10::Stream s) const noexcept {
+    return std::hash<uint64_t>{}(s.pack());
+  }
+};
 } // namespace std

--- a/c10/core/StreamGuard.h
+++ b/c10/core/StreamGuard.h
@@ -47,7 +47,9 @@ struct StreamGuard {
   /// WARNING: reset_stream does NOT preserve previously set streams on
   /// different devices.  If you need to set streams on multiple devices
   /// on , use MultiStreamGuard instead.
-  void reset_stream(Stream stream) { guard_.reset_stream(stream); }
+  void reset_stream(Stream stream) {
+    guard_.reset_stream(stream);
+  }
 
   /// Returns the stream that was set at the time the guard was constructed.
   Stream original_stream() const {
@@ -62,13 +64,17 @@ struct StreamGuard {
 
   /// Returns the most recent device that was set using this device guard,
   /// either from construction, or via set_device/reset_device/set_index.
-  Device current_device() const { return guard_.current_device(); }
+  Device current_device() const {
+    return guard_.current_device();
+  }
 
   /// Returns the device that was set at the most recent reset_stream(),
   /// or otherwise the device at construction time.
-  Device original_device() const { return guard_.original_device(); }
+  Device original_device() const {
+    return guard_.original_device();
+  }
 
-private:
+ private:
   c10::impl::InlineStreamGuard<impl::VirtualGuardImpl> guard_;
 };
 
@@ -88,7 +94,8 @@ struct OptionalStreamGuard {
   /// Set the current device to the device associated with the passed stream,
   /// and set the current stream on that device to the passed stream,
   /// if the passed stream is not nullopt.
-  explicit OptionalStreamGuard(optional<Stream> stream_opt) : guard_(stream_opt) {}
+  explicit OptionalStreamGuard(optional<Stream> stream_opt)
+      : guard_(stream_opt) {}
 
   /// Copy is disallowed
   OptionalStreamGuard(const OptionalStreamGuard&) = delete;
@@ -105,21 +112,30 @@ struct OptionalStreamGuard {
   /// set the current device to the device associated with the passed stream,
   /// and set the current stream on that device to the passed stream.
   /// Initializes the guard if it was not previously initialized.
-  void reset_stream(Stream stream) { guard_.reset_stream(stream); }
+  void reset_stream(Stream stream) {
+    guard_.reset_stream(stream);
+  }
 
   /// Returns the stream that was set at the time the guard was most recently
   /// initialized, or nullopt if the guard is uninitialized.
-  optional<Stream> original_stream() const { return guard_.original_stream(); }
+  optional<Stream> original_stream() const {
+    return guard_.original_stream();
+  }
 
   /// Returns the most recent  stream that was set using this stream guard,
-  /// either from construction, or via reset_stream, if the guard is initialized,
-  /// or nullopt if the guard is uninitialized.
-  optional<Stream> current_stream() const { return guard_.current_stream(); }
+  /// either from construction, or via reset_stream, if the guard is
+  /// initialized, or nullopt if the guard is uninitialized.
+  optional<Stream> current_stream() const {
+    return guard_.current_stream();
+  }
 
-  /// Restore the original  device and stream, resetting this guard to uninitialized state.
-  void reset() { guard_.reset(); }
+  /// Restore the original  device and stream, resetting this guard to
+  /// uninitialized state.
+  void reset() {
+    guard_.reset();
+  }
 
-private:
+ private:
   c10::impl::InlineOptionalStreamGuard<impl::VirtualGuardImpl> guard_;
 };
 

--- a/c10/core/TensorImpl.cpp
+++ b/c10/core/TensorImpl.cpp
@@ -18,7 +18,7 @@ C10_DEFINE_int64(
 
 namespace c10 {
 
-const char * const TensorImpl::err_msg_tensor_metadata_change_not_allowed =
+const char* const TensorImpl::err_msg_tensor_metadata_change_not_allowed =
     "is not allowed on a Tensor created from .data or .detach().\n"
     "If your intent is to change the metadata of a Tensor (such as sizes / strides / storage / storage_offset)\n"
     "without autograd tracking the change, remove the .data / .detach() call and wrap the change in a `with torch.no_grad():` block.\n"
@@ -45,13 +45,23 @@ const at::Tensor& TensorImpl::grad() const {
 }
 
 TensorImpl::TensorImpl(Storage&& storage, TensorTypeSet type_set)
-    : TensorImpl(std::move(storage), type_set, storage.dtype(), storage.device()) {}
+    : TensorImpl(
+          std::move(storage),
+          type_set,
+          storage.dtype(),
+          storage.device()) {}
 
-TensorImpl::TensorImpl(TensorTypeSet type_set, const caffe2::TypeMeta& data_type, c10::optional<c10::Device> device_opt)
+TensorImpl::TensorImpl(
+    TensorTypeSet type_set,
+    const caffe2::TypeMeta& data_type,
+    c10::optional<c10::Device> device_opt)
     : TensorImpl({}, type_set, data_type, std::move(device_opt)) {}
 
-TensorImpl::TensorImpl(Storage&& storage, TensorTypeSet type_set, const caffe2::TypeMeta& data_type,
-                       c10::optional<c10::Device> device_opt)
+TensorImpl::TensorImpl(
+    Storage&& storage,
+    TensorTypeSet type_set,
+    const caffe2::TypeMeta& data_type,
+    c10::optional<c10::Device> device_opt)
     : storage_(std::move(storage)),
       sizes_{0},
       storage_offset_(0),
@@ -60,13 +70,14 @@ TensorImpl::TensorImpl(Storage&& storage, TensorTypeSet type_set, const caffe2::
       device_opt_(device_opt),
       type_set_(type_set.remove(TensorTypeId::VariableTensorId)) {
   if (!type_set.empty()) {
-    AT_ASSERT(data_type.id() ==  caffe2::TypeIdentifier::uninitialized() ||
-              device_opt_.has_value());
+    AT_ASSERT(
+        data_type.id() == caffe2::TypeIdentifier::uninitialized() ||
+        device_opt_.has_value());
     // UndefinedTensorImpl is a singleton, so we skip logging it
     C10_LOG_API_USAGE_ONCE("tensor.create");
   }
-  // we would also like to check that non-cpu devices have an index, but some Caffe2 operators create
-  // Storages with default devices.
+  // we would also like to check that non-cpu devices have an index, but some
+  // Caffe2 operators create Storages with default devices.
   strides_.push_back(1);
 }
 
@@ -152,7 +163,8 @@ int64_t TensorImpl::stride(int64_t d) const {
 }
 
 TensorImpl* TensorImpl::maybe_zero_dim(bool condition_when_zero_dim) {
-  bool set_zero_dim = condition_when_zero_dim && this->sizes().size() == 1 && this->size(0) == 1;
+  bool set_zero_dim = condition_when_zero_dim && this->sizes().size() == 1 &&
+      this->size(0) == 1;
   if (set_zero_dim) {
     resize_dim(0);
   }
@@ -168,7 +180,7 @@ bool TensorImpl::is_contiguous(at::MemoryFormat memory_format) const {
   AT_ASSERT(compute_contiguous() == is_contiguous_);
 #endif
   if (memory_format == at::MemoryFormat::ChannelsLast) {
-      return is_channels_last_contiguous_;
+    return is_channels_last_contiguous_;
   }
   return is_contiguous_;
 }

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -5,16 +5,16 @@
 #include <numeric>
 
 #include <c10/core/Backend.h>
+#include <c10/core/CopyBytes.h>
 #include <c10/core/MemoryFormat.h>
 #include <c10/core/Storage.h>
 #include <c10/core/TensorOptions.h>
 #include <c10/core/TensorTypeSet.h>
-#include <c10/core/CopyBytes.h>
 
 #include <c10/util/Exception.h>
-#include <c10/util/Optional.h>
 #include <c10/util/Flags.h>
 #include <c10/util/Logging.h>
+#include <c10/util/Optional.h>
 #include <c10/util/python_stub.h>
 
 // A global boolean variable to control whether we free memory when a Tensor
@@ -31,7 +31,6 @@ C10_DECLARE_bool(caffe2_keep_on_shrink);
 // is larger than this flag in bytes.  This only applies to functions which
 // respect caffe2_keep_on_shrink.
 C10_DECLARE_int64(caffe2_max_keep_on_shrink_memory);
-
 
 namespace at {
 class Tensor;
@@ -131,7 +130,9 @@ struct C10_API PlacementDeleteContext {
 struct TensorImpl;
 
 struct C10_API AutogradMetaInterface {
-  virtual void set_requires_grad(bool requires_grad, at::TensorImpl* self_impl) = 0;
+  virtual void set_requires_grad(
+      bool requires_grad,
+      at::TensorImpl* self_impl) = 0;
   virtual bool requires_grad() const = 0;
   virtual at::Tensor& grad() = 0;
   virtual const at::Tensor& grad() const = 0;
@@ -144,25 +145,24 @@ struct C10_API NonVariableTypeMode {
 };
 
 struct C10_API NamedTensorMetaInterface {
-  virtual ~NamedTensorMetaInterface() {};
+  virtual ~NamedTensorMetaInterface(){};
   virtual std::unique_ptr<NamedTensorMetaInterface> clone() const {
     TORCH_INTERNAL_ASSERT(
-      false,
-      "Not implemented: NamedTensorMetaInterface::clone");
+        false, "Not implemented: NamedTensorMetaInterface::clone");
   };
   virtual int64_t slow_dim() const {
     TORCH_INTERNAL_ASSERT(
-      false,
-      "Not implemented: NamedTensorMetaInterface::slow_dim");
+        false, "Not implemented: NamedTensorMetaInterface::slow_dim");
   };
 };
 
 // NOTE [ Version Counter Sharing ]
 //
-// Every Tensor has a version counter. Version counters are incremented whenever the
-// data or size of a tensor changes through in-place Variable operations. Version
-// counters are used to detect modifications to saved variables which would result in
-// incorrect gradient calculations. Version counters may be shared between Variables:
+// Every Tensor has a version counter. Version counters are incremented whenever
+// the data or size of a tensor changes through in-place Variable operations.
+// Version counters are used to detect modifications to saved variables which
+// would result in incorrect gradient calculations. Version counters may be
+// shared between Variables:
 //
 // 1. A view shares the version counter of the base Variable,
 // 2. `x.detach()` shares the version counter of `x`,
@@ -170,27 +170,32 @@ struct C10_API NamedTensorMetaInterface {
 //
 // Version counters are not shared in these scenarios:
 //
-// 1. When we replace a `Variable`'s underlying `Tensor` by calling `set_data(...)`,
+// 1. When we replace a `Variable`'s underlying `Tensor` by calling
+// `set_data(...)`,
 // 2. `x.data` does not share the version counter of `x`. (See discussion at
 // https://github.com/pytorch/pytorch/issues/5396)
 //
-// Question: Why do we put the version counter in TensorImpl instead of AutogradMeta?
+// Question: Why do we put the version counter in TensorImpl instead of
+// AutogradMeta?
 //
-// Answer: After the Variable/Tensor merge, a tensor will not have AutogradMeta when
-// its `requires_grad_` is false, but when we use this tensor in the forward pass of
-// a function that requires saving this tensor for backward, we need to keep track of
-// this tensor's version to make sure it's always valid in the autograd graph.
+// Answer: After the Variable/Tensor merge, a tensor will not have AutogradMeta
+// when its `requires_grad_` is false, but when we use this tensor in the
+// forward pass of a function that requires saving this tensor for backward, we
+// need to keep track of this tensor's version to make sure it's always valid in
+// the autograd graph.
 //
-// To achieve this goal, we put the version counter in TensorImpl instead of AutogradMeta,
-// and have it always be available. This allows us to have the optimization of not
-// carrying AutogradMeta when a tensor doesn't require gradient.
+// To achieve this goal, we put the version counter in TensorImpl instead of
+// AutogradMeta, and have it always be available. This allows us to have the
+// optimization of not carrying AutogradMeta when a tensor doesn't require
+// gradient.
 //
-// A hypothetical alternative way to achieve this goal is to initialize AutogradMeta and
-// create the version counter for the non-requires-grad tensor only when it's saved for
-// backward. However, since saving a tensor for backward happens in the forward pass, and
-// our invariant is that forward pass needs to be thread-safe, lazy-initializing AutogradMeta
-// when saving a tensor can introduce race conditions when we are running the forward
-// pass in multi-thread scenarios, thus making the forward pass not thread-safe anymore,
+// A hypothetical alternative way to achieve this goal is to initialize
+// AutogradMeta and create the version counter for the non-requires-grad tensor
+// only when it's saved for backward. However, since saving a tensor for
+// backward happens in the forward pass, and our invariant is that forward pass
+// needs to be thread-safe, lazy-initializing AutogradMeta when saving a tensor
+// can introduce race conditions when we are running the forward pass in
+// multi-thread scenarios, thus making the forward pass not thread-safe anymore,
 // which breaks the invariant.
 struct C10_API VariableVersion {
  private:
@@ -301,21 +306,31 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   /**
    * Construct a 1-dim 0 size tensor that doesn't have a storage.
    */
-  TensorImpl(TensorTypeSet, const caffe2::TypeMeta& data_type, c10::optional<c10::Device> device_opt);
+  TensorImpl(
+      TensorTypeSet,
+      const caffe2::TypeMeta& data_type,
+      c10::optional<c10::Device> device_opt);
 
   // Legacy constructors so I don't have to go update call sites.
   // TODO: When Variable is added, delete these constructors
   TensorImpl(Storage&& storage, TensorTypeId type_id)
-    : TensorImpl(std::move(storage), TensorTypeSet(type_id)) {}
-  TensorImpl(TensorTypeId type_id, const caffe2::TypeMeta& data_type, c10::optional<c10::Device> device_opt)
-    : TensorImpl(TensorTypeSet(type_id), data_type, device_opt) {}
+      : TensorImpl(std::move(storage), TensorTypeSet(type_id)) {}
+  TensorImpl(
+      TensorTypeId type_id,
+      const caffe2::TypeMeta& data_type,
+      c10::optional<c10::Device> device_opt)
+      : TensorImpl(TensorTypeSet(type_id), data_type, device_opt) {}
 
  private:
   // This constructor is private, because the data_type is redundant with
   // storage.  Still, we pass it in separately because it's easier to write
   // the initializer list if we're not worried about storage being moved out
   // from under us.
-  TensorImpl(Storage&& storage, TensorTypeSet, const caffe2::TypeMeta& data_type, c10::optional<c10::Device>);
+  TensorImpl(
+      Storage&& storage,
+      TensorTypeSet,
+      const caffe2::TypeMeta& data_type,
+      c10::optional<c10::Device>);
 
  public:
   TensorImpl(const TensorImpl&) = delete;
@@ -335,7 +350,9 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
    * all of the TensorTypeIds that this Tensor identifies as.  This is the
    * information used to dispatch operations on this tensor.
    */
-  TensorTypeSet type_set() const { return type_set_; }
+  TensorTypeSet type_set() const {
+    return type_set_;
+  }
 
   /**
    * Return a reference to the sizes of this tensor.  This reference remains
@@ -396,38 +413,39 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
    * compute_contiguous() for the exact definition of whether or not
    * a tensor is contiguous or not.
    */
-  virtual bool is_contiguous(at::MemoryFormat memory_format=at::MemoryFormat::Contiguous) const;
+  virtual bool is_contiguous(
+      at::MemoryFormat memory_format = at::MemoryFormat::Contiguous) const;
 
   bool is_sparse() const {
-    // NB: This method is not virtual and avoid dispatches for performance reasons.
-    // NB: At the moment, variables have the same TensorTypeId as their
+    // NB: This method is not virtual and avoid dispatches for performance
+    // reasons. NB: At the moment, variables have the same TensorTypeId as their
     // corresponding tensor, but if this ever changes, we need to modify this.
     return type_set_.has(TensorTypeId::SparseCPUTensorId) ||
-           type_set_.has(TensorTypeId::SparseCUDATensorId) ||
-           type_set_.has(TensorTypeId::SparseHIPTensorId);
+        type_set_.has(TensorTypeId::SparseCUDATensorId) ||
+        type_set_.has(TensorTypeId::SparseHIPTensorId);
   }
 
   bool is_quantized() const {
-    // NB: This method is not virtual and avoid dispatches for performance reasons.
-    // NB: At the moment, variables have the same TensorTypeId as their
+    // NB: This method is not virtual and avoid dispatches for performance
+    // reasons. NB: At the moment, variables have the same TensorTypeId as their
     // corresponding tensor, but if this ever changes, we need to modify this.
     return type_set_.has(TensorTypeId::QuantizedCPUTensorId);
   }
 
   bool is_cuda() const {
-    // NB: This method is not virtual and avoid dispatches for performance reasons.
-    // NB: At the moment, variables have the same TensorTypeId as their
+    // NB: This method is not virtual and avoid dispatches for performance
+    // reasons. NB: At the moment, variables have the same TensorTypeId as their
     // corresponding tensor, but if this ever changes, we need to modify this.
     return type_set_.has(TensorTypeId::CUDATensorId) ||
-           type_set_.has(TensorTypeId::SparseCUDATensorId);
+        type_set_.has(TensorTypeId::SparseCUDATensorId);
   }
 
   bool is_hip() const {
-    // NB: This method is not virtual and avoid dispatches for performance reasons.
-    // NB: At the moment, variables have the same TensorTypeId as their
+    // NB: This method is not virtual and avoid dispatches for performance
+    // reasons. NB: At the moment, variables have the same TensorTypeId as their
     // corresponding tensor, but if this ever changes, we need to modify this.
     return type_set_.has(TensorTypeId::HIPTensorId) ||
-           type_set_.has(TensorTypeId::SparseHIPTensorId);
+        type_set_.has(TensorTypeId::SparseHIPTensorId);
   }
 
   bool is_mkldnn() const {
@@ -435,17 +453,13 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   }
 
   int64_t get_device() const {
-    TORCH_CHECK(
-        device_opt_.has_value(),
-        "tensor does not have a device");
+    TORCH_CHECK(device_opt_.has_value(), "tensor does not have a device");
     // See NOTE [c10::optional operator usage in CUDA]
     return (*device_opt_).index();
   }
 
   Device device() const {
-    TORCH_CHECK(
-        device_opt_.has_value(),
-        "tensor does not have a device");
+    TORCH_CHECK(device_opt_.has_value(), "tensor does not have a device");
     // See NOTE [c10::optional operator usage in CUDA]
     return *device_opt_;
   }
@@ -474,9 +488,10 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
    * correctly resetting the dimension to 0 when when the inputs had 0-dim.
    *
    * As we teach more and more of TH to handle 0-dim correctly, this function
-   * will become less necessary.  At the moment, it is often called from functions
-   * that correctly handle the 0-dim case, and is just dead code in this case.
-   * In the glorious future, this function will be eliminated entirely.
+   * will become less necessary.  At the moment, it is often called from
+   * functions that correctly handle the 0-dim case, and is just dead code in
+   * this case. In the glorious future, this function will be eliminated
+   * entirely.
    */
   virtual TensorImpl* maybe_zero_dim(bool condition_when_zero_dim);
 
@@ -530,7 +545,8 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
    * See Note [Tensor versus Variable in C++].
    */
   void set_requires_grad(bool requires_grad) {
-    TORCH_INTERNAL_ASSERT(autograd_meta(), "set_requires_grad is not implemented for Tensor");
+    TORCH_INTERNAL_ASSERT(
+        autograd_meta(), "set_requires_grad is not implemented for Tensor");
     autograd_meta()->set_requires_grad(requires_grad, this);
   }
 
@@ -545,7 +561,8 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
    * See Note [Tensor versus Variable in C++].
    */
   bool requires_grad() const {
-    TORCH_INTERNAL_ASSERT(autograd_meta(), "requires_grad is not implemented for Tensor");
+    TORCH_INTERNAL_ASSERT(
+        autograd_meta(), "requires_grad is not implemented for Tensor");
     return autograd_meta()->requires_grad();
   }
 
@@ -581,8 +598,9 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
    * for you; this class is available from 'Tensor'.
    */
   template <typename T>
-  inline T * data() const {
-    TORCH_CHECK(has_storage(),
+  inline T* data() const {
+    TORCH_CHECK(
+        has_storage(),
         "Cannot access data pointer of Tensor that doesn't have storage");
     TORCH_CHECK(
         storage_initialized(),
@@ -611,9 +629,11 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
    * can be validly read from this tensor.
    */
   inline void* data() const {
-    TORCH_CHECK(has_storage(),
+    TORCH_CHECK(
+        has_storage(),
         "Cannot access data pointer of Tensor that doesn't have storage");
-    TORCH_CHECK(dtype_initialized(),
+    TORCH_CHECK(
+        dtype_initialized(),
         "Cannot access data pointer of Tensor that doesn't have initialized dtype "
         "(e.g., caffe2::Tensor x(CPU), prior to calling mutable_data<T>() on x)");
     return static_cast<void*>(
@@ -626,7 +646,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
    * that all invariants required by data() are upheld here.
    */
   template <typename T>
-  inline T * unsafe_data() const {
+  inline T* unsafe_data() const {
     return storage_.unsafe_data<T>() + storage_offset_;
   }
 
@@ -642,7 +662,8 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
    * Return the size of a single element of this tensor in bytes.
    */
   size_t itemsize() const {
-    TORCH_CHECK(dtype_initialized(),
+    TORCH_CHECK(
+        dtype_initialized(),
         "Cannot report itemsize of Tensor that doesn't have initialized dtype "
         "(e.g., caffe2::Tensor x(CPU), prior to calling mutable_data<T>() on x)");
     return data_type_.itemsize();
@@ -680,7 +701,10 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
    * which is harder to misuse.
    */
   virtual void resize_dim(int64_t ndim) {
-    TORCH_CHECK(allow_tensor_metadata_change(), "resize_dim ", err_msg_tensor_metadata_change_not_allowed);
+    TORCH_CHECK(
+        allow_tensor_metadata_change(),
+        "resize_dim ",
+        err_msg_tensor_metadata_change_not_allowed);
     sizes_.resize(ndim, 0);
     strides_.resize(ndim, 0);
     refresh_numel();
@@ -696,7 +720,10 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
    * which is harder to misuse.
    */
   virtual void set_size(int64_t dim, int64_t new_size) {
-    TORCH_CHECK(allow_tensor_metadata_change(), "set_size ", err_msg_tensor_metadata_change_not_allowed);
+    TORCH_CHECK(
+        allow_tensor_metadata_change(),
+        "set_size ",
+        err_msg_tensor_metadata_change_not_allowed);
     sizes_.at(dim) = new_size;
     refresh_numel();
     refresh_contiguous();
@@ -709,7 +736,10 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
    * which is harder to misuse.
    */
   virtual void set_stride(int64_t dim, int64_t new_stride) {
-    TORCH_CHECK(allow_tensor_metadata_change(), "set_stride ", err_msg_tensor_metadata_change_not_allowed);
+    TORCH_CHECK(
+        allow_tensor_metadata_change(),
+        "set_stride ",
+        err_msg_tensor_metadata_change_not_allowed);
     strides_[dim] = new_stride;
     refresh_numel();
     refresh_contiguous();
@@ -723,7 +753,10 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
    * (and resizing if necessary.)
    */
   virtual void set_storage_offset(int64_t storage_offset) {
-    TORCH_CHECK(allow_tensor_metadata_change(), "set_storage_offset ", err_msg_tensor_metadata_change_not_allowed);
+    TORCH_CHECK(
+        allow_tensor_metadata_change(),
+        "set_storage_offset ",
+        err_msg_tensor_metadata_change_not_allowed);
     storage_offset_ = storage_offset;
   }
 
@@ -735,7 +768,10 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
    * this is the responsibility of the caller
    */
   void set_sizes_contiguous(IntArrayRef new_size) {
-    TORCH_CHECK(allow_tensor_metadata_change(), "set_sizes_contiguous ", err_msg_tensor_metadata_change_not_allowed);
+    TORCH_CHECK(
+        allow_tensor_metadata_change(),
+        "set_sizes_contiguous ",
+        err_msg_tensor_metadata_change_not_allowed);
     auto new_dim = new_size.size();
 
     sizes_.resize(new_dim);
@@ -755,7 +791,10 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
    * this is the responsibility of the caller
    */
   void set_sizes_and_strides(IntArrayRef new_size, IntArrayRef new_stride) {
-    TORCH_CHECK(allow_tensor_metadata_change(), "set_sizes_and_strides ", err_msg_tensor_metadata_change_not_allowed);
+    TORCH_CHECK(
+        allow_tensor_metadata_change(),
+        "set_sizes_and_strides ",
+        err_msg_tensor_metadata_change_not_allowed);
     TORCH_CHECK(
         new_size.size() == new_stride.size(),
         "dimensionality of sizes (",
@@ -772,7 +811,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
 
     strides_.resize(new_dim);
     if (new_dim > 0) {
-      for (size_t dim = new_dim - 1; ; dim--) {
+      for (size_t dim = new_dim - 1;; dim--) {
         if (new_stride[dim] >= 0) {
           strides_[dim] = new_stride[dim];
         } else {
@@ -783,10 +822,12 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
             strides_[dim] = 1;
           } else {
             // Keep stride monotonically increasing to match NumPy.
-            strides_[dim] = std::max<int64_t>(sizes_[dim + 1], 1) * strides_[dim + 1];
+            strides_[dim] =
+                std::max<int64_t>(sizes_[dim + 1], 1) * strides_[dim + 1];
           }
         }
-        if (dim == 0) break;
+        if (dim == 0)
+          break;
       }
     }
 
@@ -812,16 +853,18 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   }
 
   /**
-   * Set whether a tensor allows changes to its metadata (e.g. sizes / strides / storage / storage_offset).
-   * See NOTE [ Metadata Change for a Detached Tensor ] for details.
+   * Set whether a tensor allows changes to its metadata (e.g. sizes / strides /
+   * storage / storage_offset). See NOTE [ Metadata Change for a Detached Tensor
+   * ] for details.
    */
   virtual void set_allow_tensor_metadata_change(bool value) {
     allow_tensor_metadata_change_ = value;
   }
 
   /**
-   * True if a tensor allows changes to its metadata (e.g. sizes / strides / storage / storage_offset).
-   * See NOTE [ Metadata Change for a Detached Tensor ] for details.
+   * True if a tensor allows changes to its metadata (e.g. sizes / strides /
+   * storage / storage_offset). See NOTE [ Metadata Change for a Detached Tensor
+   * ] for details.
    */
   virtual bool allow_tensor_metadata_change() const {
     return allow_tensor_metadata_change_;
@@ -830,7 +873,8 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   /**
    * Set the pointer to autograd metadata.
    */
-  void set_autograd_meta(std::unique_ptr<c10::AutogradMetaInterface> autograd_meta) {
+  void set_autograd_meta(
+      std::unique_ptr<c10::AutogradMetaInterface> autograd_meta) {
     autograd_meta_ = std::move(autograd_meta);
     if (autograd_meta_) {
       type_set_ = type_set_.add(TensorTypeId::VariableTensorId);
@@ -857,7 +901,8 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   /**
    * Set the pointer to named tensor metadata.
    */
-  void set_named_tensor_meta(std::unique_ptr<c10::NamedTensorMetaInterface> named_tensor_meta) {
+  void set_named_tensor_meta(
+      std::unique_ptr<c10::NamedTensorMetaInterface> named_tensor_meta) {
     TORCH_WARN_ONCE(
         "Named tensors and all their associated APIs are an experimental feature ",
         "and subject to change. Please do not use them for anything important ",
@@ -881,34 +926,44 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
     return named_tensor_meta_.get();
   }
 
-
   // NOTE [ TensorImpl Shallow-Copying ]
   //
-  // TensorImpl shallow-copying is used when we want to have two Variables share the same tensor metadata
-  // (e.g. sizes / strides / storage pointer / storage_offset), but each with a different autograd history.
-  // Example call sites:
+  // TensorImpl shallow-copying is used when we want to have two Variables share
+  // the same tensor metadata (e.g. sizes / strides / storage pointer /
+  // storage_offset), but each with a different autograd history. Example call
+  // sites:
   //
-  // 1. `var_detached = var.detach()` uses `shallow_copy_and_detach()` to create `var_detached` that shares
-  // the same tensor metadata with `var`, but with a completely new autograd history.
-  // 2. `var.set_data(tensor)` uses `shallow_copy_from()` to copy tensor metadata from
-  // `tensor` into `var`, while keeping `var`'s original AutogradMeta.
+  // 1. `var_detached = var.detach()` uses `shallow_copy_and_detach()` to create
+  // `var_detached` that shares the same tensor metadata with `var`, but with a
+  // completely new autograd history.
+  // 2. `var.set_data(tensor)` uses `shallow_copy_from()` to copy tensor
+  // metadata from `tensor` into `var`, while keeping `var`'s original
+  // AutogradMeta.
   //
-  // Functions that shallow-copy a TensorImpl (such as `shallow_copy_and_detach()` / `shallow_copy_from()` /
-  // `copy_tensor_metadata()`) copy the tensor metadata fields (e.g. sizes / strides / storage pointer /
-  // storage_offset) by value. However, the following fields are not copied:
+  // Functions that shallow-copy a TensorImpl (such as
+  // `shallow_copy_and_detach()` / `shallow_copy_from()` /
+  // `copy_tensor_metadata()`) copy the tensor metadata fields (e.g. sizes /
+  // strides / storage pointer / storage_offset) by value. However, the
+  // following fields are not copied:
   //
   // 1. the AutogradMeta pointer, because it is unique for each Variable.
-  // 2. the version counter, because the destination TensorImpl's version counter is either set to the
-  // passed-in `version_counter` (in `shallow_copy_and_detach()` and `copy_tensor_metadata()`), or it is kept
-  // intact (in `shallow_copy_from()`). See NOTE [ Version Counter Sharing ] for details.
+  // 2. the version counter, because the destination TensorImpl's version
+  // counter is either set to the passed-in `version_counter` (in
+  // `shallow_copy_and_detach()` and `copy_tensor_metadata()`), or it is kept
+  // intact (in `shallow_copy_from()`). See NOTE [ Version Counter Sharing ] for
+  // details.
   //
-  // In `shallow_copy_and_detach()` and `copy_tensor_metadata()`, the passed-in `allow_tensor_metadata_change`
-  // determines whether the TensorImpl shallow-copy allows changes to its metadata (e.g. sizes / strides /
-  // storage / storage_offset). See NOTE [ Metadata Change for a Detached Tensor ] for details.
+  // In `shallow_copy_and_detach()` and `copy_tensor_metadata()`, the passed-in
+  // `allow_tensor_metadata_change` determines whether the TensorImpl
+  // shallow-copy allows changes to its metadata (e.g. sizes / strides / storage
+  // / storage_offset). See NOTE [ Metadata Change for a Detached Tensor ] for
+  // details.
   //
-  // In `shallow_copy_from()`, we don't check the destination TensorImpl's `allow_tensor_metadata_change_`,
-  // because `shallow_copy_from()` is used for implementing functions such as `var.set_data(tensor)`, which
-  // changes `var`'s tensor metadata and expects its `allow_tensor_metadata_change_` to be ignored.
+  // In `shallow_copy_from()`, we don't check the destination TensorImpl's
+  // `allow_tensor_metadata_change_`, because `shallow_copy_from()` is used for
+  // implementing functions such as `var.set_data(tensor)`, which changes
+  // `var`'s tensor metadata and expects its `allow_tensor_metadata_change_` to
+  // be ignored.
 
   /**
    * One TensorImpl can be copied to another TensorImpl if they have the same
@@ -919,18 +974,19 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   inline bool has_compatible_shallow_copy_type(TensorTypeSet from) {
     auto is_dense = [](TensorTypeSet ts) {
       return ts.has(TensorTypeId::CPUTensorId) ||
-             ts.has(TensorTypeId::CUDATensorId) ||
-             ts.has(TensorTypeId::HIPTensorId);
+          ts.has(TensorTypeId::CUDATensorId) ||
+          ts.has(TensorTypeId::HIPTensorId);
     };
     auto is_sparse = [](TensorTypeSet ts) {
       return ts.has(TensorTypeId::SparseCPUTensorId) ||
-             ts.has(TensorTypeId::SparseCUDATensorId) ||
-             ts.has(TensorTypeId::SparseHIPTensorId);
+          ts.has(TensorTypeId::SparseCUDATensorId) ||
+          ts.has(TensorTypeId::SparseHIPTensorId);
     };
     // TODO: This is going to be wrong when we introduce Variable; need to
     // factor this to be agnostic to Variable.  Maybe the correct fix
     // is to introduce another RTTI code for subclasses.
-    return (type_set_ == from) || (is_dense(type_set_) && is_dense(from)) || (is_sparse(type_set_) && is_sparse(from));
+    return (type_set_ == from) || (is_dense(type_set_) && is_dense(from)) ||
+        (is_sparse(type_set_) && is_sparse(from));
   }
 
   /**
@@ -944,10 +1000,10 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
       bool allow_tensor_metadata_change) const {
     auto impl = c10::make_intrusive<TensorImpl>(Storage(storage()), type_set_);
     copy_tensor_metadata(
-      /*src_impl=*/this,
-      /*dest_impl=*/impl.get(),
-      /*version_counter=*/version_counter,
-      /*allow_tensor_metadata_change=*/allow_tensor_metadata_change);
+        /*src_impl=*/this,
+        /*dest_impl=*/impl.get(),
+        /*version_counter=*/version_counter,
+        /*allow_tensor_metadata_change=*/allow_tensor_metadata_change);
     impl->refresh_numel();
     impl->refresh_contiguous();
     return impl;
@@ -956,21 +1012,21 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   /**
    * Shallow-copies data from another TensorImpl into this TensorImpl.
    *
-   * For why this function doesn't check this TensorImpl's `allow_tensor_metadata_change_`,
-   * see NOTE [ TensorImpl Shallow-Copying ].
+   * For why this function doesn't check this TensorImpl's
+   * `allow_tensor_metadata_change_`, see NOTE [ TensorImpl Shallow-Copying ].
    */
   virtual void shallow_copy_from(const c10::intrusive_ptr<TensorImpl>& impl) {
     copy_tensor_metadata(
-      /*src_impl=*/impl.get(),
-      /*dest_impl=*/this,
-      /*version_counter=*/version_counter(),
-      /*allow_tensor_metadata_change=*/allow_tensor_metadata_change());
+        /*src_impl=*/impl.get(),
+        /*dest_impl=*/this,
+        /*version_counter=*/version_counter(),
+        /*allow_tensor_metadata_change=*/allow_tensor_metadata_change());
     refresh_numel();
     refresh_contiguous();
   }
 
   void set_version_counter(
-    const c10::VariableVersion& version_counter) noexcept {
+      const c10::VariableVersion& version_counter) noexcept {
     version_counter_ = version_counter;
   }
 
@@ -999,14 +1055,15 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   }
 
  public:
-
   /**
    * The device type of a Tensor, e.g., DeviceType::CPU or DeviceType::CUDA.
    */
   DeviceType device_type() const {
     // TODO: A useful internal assert would be to show that device_opt_ is null
     // only if you are an undefined tensor
-    TORCH_CHECK(device_opt_.has_value(), "device_type cannot be run on undefined Tensor");
+    TORCH_CHECK(
+        device_opt_.has_value(),
+        "device_type cannot be run on undefined Tensor");
     // See NOTE [c10::optional operator usage in CUDA]
     return (*device_opt_).type();
   }
@@ -1054,8 +1111,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
     auto* newData = raw_mutable_data(data_type_);
     if (data_type_.copy()) {
       TORCH_CHECK(
-          device_type() == DeviceType::CPU,
-          "non-POD types work only on CPU");
+          device_type() == DeviceType::CPU, "non-POD types work only on CPU");
       data_type_.copy()(oldData.get(), newData, oldSize);
     } else {
       // The following copy uses the current (thread local) stream for copying
@@ -1141,7 +1197,8 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
       if (reserved_) {
         // If tensor is reserved then don't claim its memeory unless capacity()
         // is smaller than new size
-        reset_tensor = storage_.capacity() < (storage_offset_ + numel_) * storage_.itemsize();
+        reset_tensor = storage_.capacity() <
+            (storage_offset_ + numel_) * storage_.itemsize();
       } else {
         reset_tensor = storage_.capacity() <
                 (storage_offset_ + numel_) * storage_.itemsize() ||
@@ -1194,7 +1251,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
     storage_offset_ = 0;
   }
 
-   /**
+  /**
    * @brief Shares the data with another tensor.
    *
    * To share data between two tensors, the sizes of the two tensors must be
@@ -1219,10 +1276,11 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
     // know what to share yet.
     // TODO: Add the assert after all uninitialized states are eliminated
     // TORCH_CHECK(src.dtype_initialized(),
-    //            "Source tensor don't have a data type (did you call mutable_data<T> on the tensor?)");
+    //            "Source tensor don't have a data type (did you call
+    //            mutable_data<T> on the tensor?)");
     if (!src.dtype_initialized()) {
-      C10_LOG_EVERY_MS(WARNING, 1000) <<
-                   "Source tensor don't have a data type (did you call mutable_data<T> on the tensor?)";
+      C10_LOG_EVERY_MS(WARNING, 1000)
+          << "Source tensor don't have a data type (did you call mutable_data<T> on the tensor?)";
     }
     TORCH_CHECK(
         src.storage_initialized(),
@@ -1283,7 +1341,9 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   inline void* raw_mutable_data(const caffe2::TypeMeta& meta) {
     // For 0-size tensors it's fine to return any pointer (including nullptr)
     if (data_type_ == meta && storage_initialized()) {
-      return static_cast<void*>(static_cast<char*>(storage_.data()) + storage_offset_ * meta.itemsize());
+      return static_cast<void*>(
+          static_cast<char*>(storage_.data()) +
+          storage_offset_ * meta.itemsize());
     } else {
       bool had_special_dtor = data_type_.placementDelete() != nullptr;
       storage_offset_ = 0;
@@ -1303,7 +1363,8 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
       if (numel_ == 0 ||
           (meta.placementNew() == nullptr && !had_special_dtor &&
            storage_.numel() >= numel_)) {
-        TORCH_INTERNAL_ASSERT(storage_offset_ == 0); // because we just reallocated
+        TORCH_INTERNAL_ASSERT(
+            storage_offset_ == 0); // because we just reallocated
         return storage_.data();
       }
       const Allocator* allocator = storage_.allocator();
@@ -1330,7 +1391,8 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
             allocator->allocate(numel_ * storage_.itemsize()));
       }
       storage_.set_numel(numel_);
-      TORCH_INTERNAL_ASSERT(storage_offset_ == 0); // because we just reallocated
+      TORCH_INTERNAL_ASSERT(
+          storage_offset_ == 0); // because we just reallocated
       device_opt_ = storage_.device();
       return storage_.data();
     }
@@ -1360,7 +1422,9 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
    * storage UNINITIALIZED after a Resize() or FreeMemory()
    */
   bool storage_initialized() const {
-    TORCH_CHECK(has_storage(), "cannot call storage_initialized on tensor that does not have storage");
+    TORCH_CHECK(
+        has_storage(),
+        "cannot call storage_initialized on tensor that does not have storage");
     return storage_.data() || numel_ == 0;
   }
 
@@ -1374,7 +1438,10 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   }
 
   void set_storage(at::Storage storage) {
-    TORCH_CHECK(allow_tensor_metadata_change(), "set_storage ", err_msg_tensor_metadata_change_not_allowed);
+    TORCH_CHECK(
+        allow_tensor_metadata_change(),
+        "set_storage ",
+        err_msg_tensor_metadata_change_not_allowed);
     storage_ = std::move(storage);
     data_type_ = storage_.dtype();
     device_opt_ = storage_.device();
@@ -1383,8 +1450,8 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   /**
    * Set the strides of the tensor to match memory_format
    *
-   * WARNING: This function doesn't rearrange data and assumes tensor is a memory
-   * contiguous
+   * WARNING: This function doesn't rearrange data and assumes tensor is a
+   * memory contiguous
    */
   virtual void empty_tensor_restride(MemoryFormat memory_format) {
     is_contiguous_ = false;
@@ -1405,8 +1472,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
       }
       case MemoryFormat::ChannelsLast: {
         TORCH_CHECK(
-            dim() == 4,
-            "required rank 4 tensor to use channels_last format");
+            dim() == 4, "required rank 4 tensor to use channels_last format");
         set_sizes_and_strides(sizes(), get_channels_last_strides(sizes()));
         is_channels_last_contiguous_ = true;
         is_channels_last_ = true;
@@ -1421,8 +1487,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
     return is_channels_last_;
   }
 
-private:
-
+ private:
   // The Caffe2 Resize() method supports being called both as Resize({2,2}) as
   // well as variadic with Resize(2, 2).  These overloads provide all of the
   // supported calling configurations, while being overloads (and not templates)
@@ -1476,7 +1541,11 @@ private:
     return SetDims(IntArrayRef{d0, d1, d2});
   }
 
-  bool SetDims(const int64_t d0, const int64_t d1, const int64_t d2, const int64_t d3) {
+  bool SetDims(
+      const int64_t d0,
+      const int64_t d1,
+      const int64_t d2,
+      const int64_t d3) {
     return SetDims(IntArrayRef{d0, d1, d2, d3});
   }
 
@@ -1501,7 +1570,7 @@ private:
 
   bool compute_strides_like_channels_last() const;
 
-protected:
+ protected:
   /**
    * Recompute the cached numel of a tensor.  Call this if you modify sizes.
    */
@@ -1516,14 +1585,16 @@ protected:
   void refresh_contiguous() {
     is_contiguous_ = compute_contiguous();
     is_channels_last_contiguous_ = compute_channels_last_contiguous();
-    is_channels_last_ = is_channels_last_contiguous_ || compute_strides_like_channels_last();
+    is_channels_last_ =
+        is_channels_last_contiguous_ || compute_strides_like_channels_last();
   }
 
   /**
-   * Copy the tensor metadata fields (e.g. sizes / strides / storage pointer / storage_offset)
-   * from one TensorImpl to another TensorImpl.
+   * Copy the tensor metadata fields (e.g. sizes / strides / storage pointer /
+   * storage_offset) from one TensorImpl to another TensorImpl.
    *
-   * For usage of `version_counter` and `allow_tensor_metadata_change`, see NOTE [ TensorImpl Shallow-Copying ].
+   * For usage of `version_counter` and `allow_tensor_metadata_change`, see NOTE
+   * [ TensorImpl Shallow-Copying ].
    */
   static void copy_tensor_metadata(
       const TensorImpl* src_impl,
@@ -1541,9 +1612,11 @@ protected:
     dest_impl->type_set_ = src_impl->type_set_;
     // ...so refresh Variable in autograd_meta_
     if (dest_impl->autograd_meta_) {
-      dest_impl->type_set_ = dest_impl->type_set_.add(TensorTypeId::VariableTensorId);
+      dest_impl->type_set_ =
+          dest_impl->type_set_.add(TensorTypeId::VariableTensorId);
     } else {
-      dest_impl->type_set_ = dest_impl->type_set_.remove(TensorTypeId::VariableTensorId);
+      dest_impl->type_set_ =
+          dest_impl->type_set_.remove(TensorTypeId::VariableTensorId);
     }
     dest_impl->is_contiguous_ = src_impl->is_contiguous_;
     dest_impl->is_wrapped_number_ = src_impl->is_wrapped_number_;
@@ -1555,25 +1628,24 @@ protected:
     }
   }
 
-protected:
+ protected:
   // Error message to show when the user tries to change tensor metadata on
   // Tensor created from .data or .detach().
   //
   // See NOTE [ Metadata Change for a Detached Tensor ] for details.
-  static const char * const err_msg_tensor_metadata_change_not_allowed;
+  static const char* const err_msg_tensor_metadata_change_not_allowed;
 
   Storage storage_;
 
-private:
-  // This pointer points to an AutogradMeta struct that stores autograd-specific fields
-  // (such as grad_ / grad_fn_ / grad_accumulator_).
-  // This pointer always has unique ownership (meaning only one TensorImpl can own it
-  // at a time).
+ private:
+  // This pointer points to an AutogradMeta struct that stores autograd-specific
+  // fields (such as grad_ / grad_fn_ / grad_accumulator_). This pointer always
+  // has unique ownership (meaning only one TensorImpl can own it at a time).
   // This is private because we must maintain dispatcher invariants on it
   // in type_set_.
   std::unique_ptr<c10::AutogradMetaInterface> autograd_meta_ = nullptr;
 
-protected:
+ protected:
   std::unique_ptr<c10::NamedTensorMetaInterface> named_tensor_meta_ = nullptr;
 
   c10::VariableVersion version_counter_;
@@ -1595,9 +1667,10 @@ protected:
   // We could save a word or two by combining the SmallVector structs,
   // since their size is redundant, and if we need to overflow the buffer space
   // we could keep the two pointers together. However, that would require
-  // implementing another struct from scratch, so only do this if we're desperate.
-  SmallVector<int64_t,5> sizes_;
-  SmallVector<int64_t,5> strides_;
+  // implementing another struct from scratch, so only do this if we're
+  // desperate.
+  SmallVector<int64_t, 5> sizes_;
+  SmallVector<int64_t, 5> strides_;
 
   int64_t storage_offset_ = 0;
   // If sizes and strides are empty, the numel is 1!!  However, most of the
@@ -1665,7 +1738,6 @@ protected:
   // The logic is that if Extend() or ReserveSpace() were ever called,
   // then subsequent Resize()s will not free up Storage.
   bool reserved_ = false;
-
 };
 
 // Note [TensorImpl size constraints]
@@ -1723,9 +1795,10 @@ protected:
 //    tensor type id
 //    miscellaneous bitfield
 //
-static_assert(sizeof(void*) != sizeof(int64_t) || // if 64-bit...
-              sizeof(TensorImpl) == sizeof(int64_t) * 30,
-              "You changed the size of TensorImpl on 64-bit arch."
-              "See Note [TensorImpl size constraints] on how to proceed.");
+static_assert(
+    sizeof(void*) != sizeof(int64_t) || // if 64-bit...
+        sizeof(TensorImpl) == sizeof(int64_t) * 30,
+    "You changed the size of TensorImpl on 64-bit arch."
+    "See Note [TensorImpl size constraints] on how to proceed.");
 
 } // namespace c10

--- a/c10/core/TensorOptions.cpp
+++ b/c10/core/TensorOptions.cpp
@@ -9,9 +9,7 @@
 
 namespace c10 {
 
-std::ostream& operator<<(
-    std::ostream& stream,
-    const TensorOptions& options) {
+std::ostream& operator<<(std::ostream& stream, const TensorOptions& options) {
   return stream << "TensorOptions(dtype=" << options.dtype()
                 << ", device=" << options.device()
                 << ", layout=" << options.layout()

--- a/c10/core/TensorOptions.h
+++ b/c10/core/TensorOptions.h
@@ -1,15 +1,15 @@
 #pragma once
 
-#include <c10/core/DefaultDtype.h>
 #include <c10/core/Backend.h>
+#include <c10/core/DefaultDtype.h>
+#include <c10/core/Device.h>
 #include <c10/core/Layout.h>
 #include <c10/core/ScalarType.h>
-#include <c10/core/Device.h>
 #include <c10/core/TensorTypeSet.h>
 
-#include <c10/util/Optional.h>
-#include <c10/util/C++17.h>
 #include <c10/macros/Macros.h>
+#include <c10/util/C++17.h>
+#include <c10/util/Optional.h>
 
 #include <cstddef>
 #include <iosfwd>
@@ -40,7 +40,8 @@ namespace c10 {
 ///     at::dtype(at::kInt)
 ///
 /// Additionally, anywhere a TensorOptions is expected, you can directly
-/// pass at::kCUDA / at::kInt, and it will implicitly convert to a TensorOptions.
+/// pass at::kCUDA / at::kInt, and it will implicitly convert to a
+/// TensorOptions.
 ///
 /// Here are some recommended ways to create a 2x2 tensor of zeros
 /// with certain properties.  These all *implicitly* make use of
@@ -83,7 +84,8 @@ namespace c10 {
 ///    }
 ///
 ///    template <typename... Args,
-///             typename = std::enable_if_t<std::is_constructible<Device, Args&&...>::value>>
+///             typename = std::enable_if_t<std::is_constructible<Device,
+///             Args&&...>::value>>
 ///    /* implicit */  TensorOptions(Args&&... args)
 ///     : TensorOptions(Device(std::forward<Args>(args)...)) {}
 ///
@@ -96,19 +98,17 @@ namespace c10 {
 /// To get around this, we templatize the `Device` constructor. Since overload
 /// resolution is done before template resolution, our problem is solved.
 
-
 struct C10_API TensorOptions {
   TensorOptions()
-    : requires_grad_(false)
-    , is_variable_(false)
-    , pinned_memory_(false)
-    , has_device_(false)
-    , has_dtype_(false)
-    , has_layout_(false)
-    , has_requires_grad_(false)
-    , has_is_variable_(false)
-    , has_pinned_memory_(false)
-    {}
+      : requires_grad_(false),
+        is_variable_(false),
+        pinned_memory_(false),
+        has_device_(false),
+        has_dtype_(false),
+        has_layout_(false),
+        has_requires_grad_(false),
+        has_is_variable_(false),
+        has_pinned_memory_(false) {}
 
   /// Constructs a `TensorOptions` object with the given layout.
   /* implicit */ TensorOptions(Layout layout) : TensorOptions() {
@@ -117,8 +117,10 @@ struct C10_API TensorOptions {
 
   /// Constructs a `TensorOptions` object with the given device.
   /// See NOTE [ TensorOptions Constructors ] on why this is templatized.
-  template<typename T,
-           typename = c10::guts::enable_if_t<std::is_same<c10::guts::decay_t<T>, Device>::value>>
+  template <
+      typename T,
+      typename = c10::guts::enable_if_t<
+          std::is_same<c10::guts::decay_t<T>, Device>::value>>
   /* implicit */ TensorOptions(T&& device) : TensorOptions() {
     this->set_device(std::forward<T>(device));
   }
@@ -131,10 +133,12 @@ struct C10_API TensorOptions {
   /// NB: Ideally we only allow implicit constructors here. But there is no easy
   ///     way to detect them. So we have this one that allows explicit
   ///     constructors too.
-  template <typename... Args,
-            typename = c10::guts::enable_if_t<std::is_constructible<Device, Args&&...>::value>>
-   /* implicit */ TensorOptions(Args&&... args)
-    : TensorOptions(Device(std::forward<Args>(args)...)) {}
+  template <
+      typename... Args,
+      typename = c10::guts::enable_if_t<
+          std::is_constructible<Device, Args&&...>::value>>
+  /* implicit */ TensorOptions(Args&&... args)
+      : TensorOptions(Device(std::forward<Args>(args)...)) {}
 
   /// Constructs a `TensorOptions` object with the given dtype.
   /* implicit */ TensorOptions(caffe2::TypeMeta dtype) : TensorOptions() {
@@ -148,9 +152,7 @@ struct C10_API TensorOptions {
 
   /// True if all elements of the `TensorOptions` match that of the other.
   bool operator==(const TensorOptions& other) const noexcept {
-    return
-        has_dtype_ == other.has_dtype_ &&
-        has_layout_ == other.has_layout_ &&
+    return has_dtype_ == other.has_dtype_ && has_layout_ == other.has_layout_ &&
         has_device_ == other.has_device_ &&
         has_requires_grad_ == other.has_requires_grad_ &&
         has_is_variable_ == other.has_is_variable_ &&
@@ -169,7 +171,8 @@ struct C10_API TensorOptions {
 
   /// Return a copy of `TensorOptions` with `device` set to the given one, or
   /// cleared if `device` is `nullopt`.
-  C10_NODISCARD TensorOptions device(c10::optional<Device> device) const noexcept {
+  C10_NODISCARD TensorOptions device(c10::optional<Device> device) const
+      noexcept {
     TensorOptions r = *this;
     r.set_device(device);
     return r;
@@ -178,9 +181,10 @@ struct C10_API TensorOptions {
   /// Return a copy of `TensorOptions` with `device` set to the given one.
   /// (This overload ensures that variadic template c10::optional constructor
   /// for Device work correctly.)
-  template<typename ... Args>
+  template <typename... Args>
   C10_NODISCARD TensorOptions device(Args&&... args) const noexcept {
-    return device(c10::optional<Device>(c10::in_place, std::forward<Args>(args)...));
+    return device(
+        c10::optional<Device>(c10::in_place, std::forward<Args>(args)...));
   }
 
   /// Return a copy of `TensorOptions`, but with device set to CUDA, and the
@@ -188,19 +192,22 @@ struct C10_API TensorOptions {
   ///
   /// TODO: This function encourages bad behavior (assuming CUDA is
   /// the only device that matters).  Get rid of it / rename it.
-  C10_NODISCARD TensorOptions device_index(int16_t device_index) const noexcept {
+  C10_NODISCARD TensorOptions device_index(int16_t device_index) const
+      noexcept {
     return device(Device::Type::CUDA, device_index);
   }
 
   /// Return a copy of `TensorOptions` with `dtype` set to the given one.
-  C10_NODISCARD TensorOptions dtype(c10::optional<caffe2::TypeMeta> dtype) const noexcept {
+  C10_NODISCARD TensorOptions dtype(c10::optional<caffe2::TypeMeta> dtype) const
+      noexcept {
     TensorOptions r = *this;
     r.set_dtype(dtype);
     return r;
   }
 
   // legacy function to support ScalarType
-  C10_NODISCARD TensorOptions dtype(c10::optional<ScalarType> dtype) const noexcept {
+  C10_NODISCARD TensorOptions dtype(c10::optional<ScalarType> dtype) const
+      noexcept {
     TensorOptions r = *this;
     r.set_dtype(dtype);
     return r;
@@ -215,29 +222,32 @@ struct C10_API TensorOptions {
   }
 
   /// Sets the layout of the `TensorOptions`.
-  C10_NODISCARD TensorOptions layout(c10::optional<Layout> layout) const noexcept {
+  C10_NODISCARD TensorOptions layout(c10::optional<Layout> layout) const
+      noexcept {
     TensorOptions r = *this;
     r.set_layout(layout);
     return r;
   }
 
   /// Sets the `requires_grad` property of the `TensorOptions`.
-  C10_NODISCARD TensorOptions requires_grad(c10::optional<bool> requires_grad) const noexcept {
+  C10_NODISCARD TensorOptions
+  requires_grad(c10::optional<bool> requires_grad) const noexcept {
     TensorOptions r = *this;
     r.set_requires_grad(requires_grad);
     return r;
   }
 
   /// Sets the `is_variable` property on the `TensorOptions`.
-  C10_NODISCARD TensorOptions is_variable(c10::optional<bool> is_variable) const noexcept {
+  C10_NODISCARD TensorOptions is_variable(c10::optional<bool> is_variable) const
+      noexcept {
     TensorOptions r = *this;
     r.set_is_variable(is_variable);
     return r;
   }
 
-
   /// Sets the `pinned_memory` property on the `TensorOptions`.
-  C10_NODISCARD TensorOptions pinned_memory(c10::optional<bool> pinned_memory) const noexcept {
+  C10_NODISCARD TensorOptions
+  pinned_memory(c10::optional<bool> pinned_memory) const noexcept {
     TensorOptions r = *this;
     r.set_pinned_memory(pinned_memory);
     return r;
@@ -323,7 +333,6 @@ struct C10_API TensorOptions {
     return has_is_variable_;
   }
 
-
   /// Returns the `pinned_memory` property of the `TensorOptions`.
   bool pinned_memory() const noexcept {
     return has_pinned_memory_ ? pinned_memory_ : false;
@@ -334,18 +343,17 @@ struct C10_API TensorOptions {
     return has_pinned_memory_;
   }
 
-
   /// Returns the `is_variable` property of the `TensorOptions`, or
   /// `c10::nullopt` if `is_variable` is not specified.
   c10::optional<bool> is_variable_opt() const noexcept {
     return has_is_variable_ ? c10::make_optional(is_variable_) : c10::nullopt;
   }
 
-
   /// Returns the `pinned_memory` property of the `TensorOptions`, or
   /// `c10::nullopt` if `pinned_memory` is not specified.
   c10::optional<bool> pinned_memory_opt() const noexcept {
-    return has_pinned_memory_ ? c10::make_optional(pinned_memory_) : c10::nullopt;
+    return has_pinned_memory_ ? c10::make_optional(pinned_memory_)
+                              : c10::nullopt;
   }
 
   // Resolves the ATen backend specified by the current construction axes.
@@ -366,20 +374,27 @@ struct C10_API TensorOptions {
   ///
   TensorOptions merge_in(TensorOptions options) const noexcept {
     TensorOptions r = options;
-    if (!r.has_device()) r.set_device(device());
-    if (!r.has_dtype()) r.set_dtype(dtype());
-    if (!r.has_layout()) r.set_layout(layout());
+    if (!r.has_device())
+      r.set_device(device());
+    if (!r.has_dtype())
+      r.set_dtype(dtype());
+    if (!r.has_layout())
+      r.set_layout(layout());
     // NB: requires grad is right biased; not a logical AND/OR!
-    if (!r.has_requires_grad()) r.set_requires_grad(requires_grad());
-    if (!r.has_is_variable()) r.set_is_variable(is_variable());
-    if (!r.has_pinned_memory()) r.set_pinned_memory(pinned_memory());
+    if (!r.has_requires_grad())
+      r.set_requires_grad(requires_grad());
+    if (!r.has_is_variable())
+      r.set_is_variable(is_variable());
+    if (!r.has_pinned_memory())
+      r.set_pinned_memory(pinned_memory());
     return r;
   }
 
   // Resolves the tensor type set specified by the current construction axes.
   TensorTypeSet type_set() const noexcept {
     auto r = TensorTypeSet(computeTensorTypeId());
-    if (is_variable()) r = r.add(TensorTypeId::VariableTensorId);
+    if (is_variable())
+      r = r.add(TensorTypeId::VariableTensorId);
     return r;
   }
 
@@ -415,7 +430,8 @@ struct C10_API TensorOptions {
           case DeviceType::XLA:
             return TensorTypeId::XLATensorId;
           default:
-            AT_ERROR("Unsupported device type for dense layout: ", device().type());
+            AT_ERROR(
+                "Unsupported device type for dense layout: ", device().type());
         }
       case Layout::Sparse:
         switch (device().type()) {
@@ -426,14 +442,16 @@ struct C10_API TensorOptions {
           case DeviceType::HIP:
             return TensorTypeId::SparseHIPTensorId;
           default:
-            AT_ERROR("Unsupported device type for sparse layout: ", device().type());
+            AT_ERROR(
+                "Unsupported device type for sparse layout: ", device().type());
         }
       case Layout::Mkldnn:
         switch (device().type()) {
           case DeviceType::CPU:
             return TensorTypeId::MkldnnCPUTensorId;
           default:
-            AT_ERROR("Unsupported device type for mkldnn layout: ", device().type());
+            AT_ERROR(
+                "Unsupported device type for mkldnn layout: ", device().type());
         }
       default:
         AT_ERROR("Unsupported layout: ", layout());
@@ -441,7 +459,6 @@ struct C10_API TensorOptions {
   }
 
  private:
-
   // These methods are currently private because I'm not sure if it's wise
   // to actually publish them.  They are methods because I need them in
   // the constructor and the functional API implementation.
@@ -537,24 +554,24 @@ struct C10_API TensorOptions {
   // Bitmask required here to get this to fit inside 32 bits (or even 64 bits,
   // for that matter)
 
-  bool requires_grad_     : 1;
-  bool is_variable_       : 1;
-  bool pinned_memory_     : 1;
+  bool requires_grad_ : 1;
+  bool is_variable_ : 1;
+  bool pinned_memory_ : 1;
 
-
-  bool has_device_        : 1;
-  bool has_dtype_         : 1;
-  bool has_layout_        : 1;
+  bool has_device_ : 1;
+  bool has_dtype_ : 1;
+  bool has_layout_ : 1;
   bool has_requires_grad_ : 1;
-  bool has_is_variable_   : 1;
+  bool has_is_variable_ : 1;
   bool has_pinned_memory_ : 1;
 };
 
 // We should aspire to fit in one machine-size word; but a size greater than two
 // words is too much.  (We are doing terribly on 32-bit archs, where we require
 // three machine size words to store tensor options.  Eek!)
-static_assert( sizeof(TensorOptions) <= sizeof(int64_t) * 2,
-               "TensorOptions must fit in 128-bits" );
+static_assert(
+    sizeof(TensorOptions) <= sizeof(int64_t) * 2,
+    "TensorOptions must fit in 128-bits");
 
 /// Convenience function that returns a `TensorOptions` object with the `dtype`
 /// set to the given one.

--- a/c10/core/TensorTypeId.h
+++ b/c10/core/TensorTypeId.h
@@ -53,8 +53,8 @@ enum class TensorTypeId : uint8_t {
 };
 
 static_assert(
-  static_cast<uint8_t>(TensorTypeId::NumTensorIds) < 64,
-  "TensorTypeId is used as index into 64-bit bitmask; you must have less than 64 entries");
+    static_cast<uint8_t>(TensorTypeId::NumTensorIds) < 64,
+    "TensorTypeId is used as index into 64-bit bitmask; you must have less than 64 entries");
 
 C10_API const char* toString(TensorTypeId);
 C10_API std::ostream& operator<<(std::ostream&, TensorTypeId);
@@ -77,4 +77,4 @@ struct hash<c10::TensorTypeId> {
     return static_cast<size_t>(x);
   }
 };
-}
+} // namespace std

--- a/c10/core/TensorTypeSet.cpp
+++ b/c10/core/TensorTypeSet.cpp
@@ -16,7 +16,8 @@ std::ostream& operator<<(std::ostream& os, TensorTypeSet ts) {
   os << "TensorTypeSet(";
   TensorTypeId tid;
   bool first = true;
-  while ((tid = ts.highestPriorityTypeId()) != TensorTypeId::UndefinedTensorId) {
+  while ((tid = ts.highestPriorityTypeId()) !=
+         TensorTypeId::UndefinedTensorId) {
     if (!first) {
       os << ", ";
     }
@@ -28,4 +29,4 @@ std::ostream& operator<<(std::ostream& os, TensorTypeSet ts) {
   return os;
 }
 
-}
+} // namespace c10

--- a/c10/core/TensorTypeSet.h
+++ b/c10/core/TensorTypeSet.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <c10/core/TensorTypeId.h>
-#include <c10/util/llvmMathExtras.h>
 #include <c10/util/Exception.h>
+#include <c10/util/llvmMathExtras.h>
 #include <ostream>
 
 namespace c10 {
@@ -32,24 +32,22 @@ namespace c10 {
 //
 // An undefined tensor is one with an empty tensor type set.
 class TensorTypeSet final {
-public:
+ public:
   enum Full { FULL };
   enum Raw { RAW };
 
   // NB: default constructor representation as zero is MANDATORY as
   // use of TensorTypeSet in TLS requires this.
-  TensorTypeSet()
-    : repr_(0) {}
-  TensorTypeSet(Full)
-    : repr_(-1) {}
+  TensorTypeSet() : repr_(0) {}
+  TensorTypeSet(Full) : repr_(-1) {}
   // Public version of TensorTypeSet(uint64_t) API; external users
   // must be explicit when they do this!
-  TensorTypeSet(Raw, uint64_t x)
-    : repr_(x) {}
+  TensorTypeSet(Raw, uint64_t x) : repr_(x) {}
   explicit TensorTypeSet(TensorTypeId t)
-    : repr_(t == TensorTypeId::UndefinedTensorId
-              ? 0
-              : 1ULL << (static_cast<uint8_t>(t) - 1)) {}
+      : repr_(
+            t == TensorTypeId::UndefinedTensorId
+                ? 0
+                : 1ULL << (static_cast<uint8_t>(t) - 1)) {}
   // Test if a TensorTypeId is in the set
   bool has(TensorTypeId t) const {
     TORCH_INTERNAL_ASSERT(t != TensorTypeId::UndefinedTensorId);
@@ -86,7 +84,9 @@ public:
   bool empty() const {
     return repr_ == 0;
   }
-  uint64_t raw_repr() { return repr_; }
+  uint64_t raw_repr() {
+    return repr_;
+  }
   // Return the type id in this set with the highest priority (i.e.,
   // is the largest in the TensorTypeId enum).  Intuitively, this
   // type id is the one that should handle dispatch (assuming there
@@ -98,7 +98,8 @@ public:
     // didn't do it for now.
     return static_cast<TensorTypeId>(64 - llvm::countLeadingZeros(repr_));
   }
-private:
+
+ private:
   TensorTypeSet(uint64_t repr) : repr_(repr) {}
   uint64_t repr_ = 0;
 };
@@ -125,4 +126,4 @@ static inline TensorTypeId legacyExtractTypeId(TensorTypeSet s) {
   return s.remove(TensorTypeId::VariableTensorId).highestPriorityTypeId();
 }
 
-}
+} // namespace c10

--- a/c10/core/UndefinedTensorImpl.cpp
+++ b/c10/core/UndefinedTensorImpl.cpp
@@ -5,8 +5,10 @@ namespace c10 {
 
 // should this use the globalContext?  Can it get a context passed in somehow?
 UndefinedTensorImpl::UndefinedTensorImpl()
-: TensorImpl(TensorTypeId::UndefinedTensorId, caffe2::TypeMeta(), c10::nullopt) {
-}
+    : TensorImpl(
+          TensorTypeId::UndefinedTensorId,
+          caffe2::TypeMeta(),
+          c10::nullopt) {}
 
 IntArrayRef UndefinedTensorImpl::sizes() const {
   AT_ERROR("sizes() called on undefined Tensor");
@@ -41,4 +43,4 @@ IntArrayRef UndefinedTensorImpl::strides() const {
 }
 UndefinedTensorImpl UndefinedTensorImpl::_singleton;
 
-}
+} // namespace c10

--- a/c10/core/UndefinedTensorImpl.h
+++ b/c10/core/UndefinedTensorImpl.h
@@ -7,13 +7,14 @@ namespace c10 {
 struct C10_API UndefinedTensorImpl final : public TensorImpl {
  public:
   // Without this, we get:
-  //  error: identifier "at::UndefinedTensorImpl::_singleton" is undefined in device code
+  //  error: identifier "at::UndefinedTensorImpl::_singleton" is undefined in
+  //  device code
   // (ostensibly because the constexpr tricks MSVC into trying to compile this
   // function for device as well).
 #ifdef _WIN32
-  static inline TensorImpl * singleton() {
+  static inline TensorImpl* singleton() {
 #else
-  static constexpr inline TensorImpl * singleton() {
+  static constexpr inline TensorImpl* singleton() {
 #endif
     return &_singleton;
   }
@@ -25,10 +26,12 @@ struct C10_API UndefinedTensorImpl final : public TensorImpl {
   bool has_storage() const override;
   const Storage& storage() const override;
   int64_t storage_offset() const override;
-private:
+
+ private:
   UndefinedTensorImpl();
   static UndefinedTensorImpl _singleton;
-public:
+
+ public:
   friend struct UndefinedType;
 };
 

--- a/c10/core/WrapDimMinimal.h
+++ b/c10/core/WrapDimMinimal.h
@@ -4,10 +4,14 @@
 
 namespace c10 {
 
-static inline int64_t maybe_wrap_dim(int64_t dim, int64_t dim_post_expr, bool wrap_scalar=true) {
+static inline int64_t maybe_wrap_dim(
+    int64_t dim,
+    int64_t dim_post_expr,
+    bool wrap_scalar = true) {
   if (dim_post_expr <= 0) {
     if (!wrap_scalar) {
-      AT_INDEX_ERROR("dimension specified as ", dim, " but tensor has no dimensions");
+      AT_INDEX_ERROR(
+          "dimension specified as ", dim, " but tensor has no dimensions");
     }
     dim_post_expr = 1; // this will make range [-1, 0]
   }
@@ -16,11 +20,17 @@ static inline int64_t maybe_wrap_dim(int64_t dim, int64_t dim_post_expr, bool wr
   int64_t max = dim_post_expr - 1;
   if (dim < min || dim > max) {
     AT_INDEX_ERROR(
-      "Dimension out of range (expected to be in range of [",
-      min, ", ", max, "], but got ", dim, ")");
+        "Dimension out of range (expected to be in range of [",
+        min,
+        ", ",
+        max,
+        "], but got ",
+        dim,
+        ")");
   }
-  if (dim < 0) dim += dim_post_expr;
+  if (dim < 0)
+    dim += dim_post_expr;
   return dim;
 }
 
-}
+} // namespace c10

--- a/c10/core/impl/DeviceGuardImplInterface.cpp
+++ b/c10/core/impl/DeviceGuardImplInterface.cpp
@@ -4,10 +4,14 @@ namespace c10 {
 namespace impl {
 
 std::atomic<const DeviceGuardImplInterface*>
-device_guard_impl_registry[static_cast<size_t>(DeviceType::COMPILE_TIME_MAX_DEVICE_TYPES)];
+    device_guard_impl_registry[static_cast<size_t>(
+        DeviceType::COMPILE_TIME_MAX_DEVICE_TYPES)];
 
-DeviceGuardImplRegistrar::DeviceGuardImplRegistrar(DeviceType type, const DeviceGuardImplInterface* impl) {
+DeviceGuardImplRegistrar::DeviceGuardImplRegistrar(
+    DeviceType type,
+    const DeviceGuardImplInterface* impl) {
   device_guard_impl_registry[static_cast<size_t>(type)].store(impl);
 }
 
-}} // namespace c10::impl
+} // namespace impl
+} // namespace c10

--- a/c10/core/impl/DeviceGuardImplInterface.h
+++ b/c10/core/impl/DeviceGuardImplInterface.h
@@ -27,16 +27,16 @@ namespace c10 {
  * should map one-to-one with actual event flags for those backends.
  */
 enum class EventFlag {
-    PYTORCH_DEFAULT,
-    BACKEND_DEFAULT,
-    // CUDA flags
-    CUDA_EVENT_DEFAULT,
-    CUDA_EVENT_DISABLE_TIMING, // PyTorch-default for CUDA
-    // HIP flags
-    HIP_EVENT_DEFAULT,
-    HIP_EVENT_DISABLE_TIMING, // PyTorch-default for HIP
-    // FOR TESTING ONLY
-    INVALID
+  PYTORCH_DEFAULT,
+  BACKEND_DEFAULT,
+  // CUDA flags
+  CUDA_EVENT_DEFAULT,
+  CUDA_EVENT_DISABLE_TIMING, // PyTorch-default for CUDA
+  // HIP flags
+  HIP_EVENT_DEFAULT,
+  HIP_EVENT_DISABLE_TIMING, // PyTorch-default for HIP
+  // FOR TESTING ONLY
+  INVALID
 };
 
 namespace impl {
@@ -116,47 +116,44 @@ struct C10_API DeviceGuardImplInterface {
    */
   virtual Stream exchangeStream(Stream) const noexcept = 0;
 
-/**
- * Destroys the given event.
- */
-  virtual void destroyEvent (
-    void* event,
-    const DeviceIndex device_index) const noexcept { }
+  /**
+   * Destroys the given event.
+   */
+  virtual void destroyEvent(void* event, const DeviceIndex device_index) const
+      noexcept {}
 
-/**
- * Increments the event's version and enqueues a job with this version
- * in the stream's work queue. When the stream process that job
- * it nofifies all streams waiting on / blocked by that version of the
- * event to continue and marks that version as recorded.
- * */
+  /**
+   * Increments the event's version and enqueues a job with this version
+   * in the stream's work queue. When the stream process that job
+   * it nofifies all streams waiting on / blocked by that version of the
+   * event to continue and marks that version as recorded.
+   * */
   virtual void record(
-    void** event,
-    const Stream& stream,
-    const DeviceIndex device_index,
-    const c10::EventFlag flag) const {
+      void** event,
+      const Stream& stream,
+      const DeviceIndex device_index,
+      const c10::EventFlag flag) const {
     TORCH_CHECK(false, "Backend doesn't support events.");
   }
 
-/**
- * Does nothing if the event has not been scheduled to be recorded.
- * If the event was previously enqueued to be recorded, a command
- * to wait for the version of the event that exists at the time of this call
- * is inserted in the stream's work queue.
- * When the stream reaches this command it will stop processing
- * additional commands until that version of the event is marked as recorded.
- */
-  virtual void block(
-    void* event,
-    const Stream& stream) const {
+  /**
+   * Does nothing if the event has not been scheduled to be recorded.
+   * If the event was previously enqueued to be recorded, a command
+   * to wait for the version of the event that exists at the time of this call
+   * is inserted in the stream's work queue.
+   * When the stream reaches this command it will stop processing
+   * additional commands until that version of the event is marked as recorded.
+   */
+  virtual void block(void* event, const Stream& stream) const {
     TORCH_CHECK(false, "Backend doesn't support events.");
   }
 
-/**
- * Returns true if (and only if)
- *  (1) the event has never been scheduled to be recorded
- *  (2) the current version is marked as recorded.
- * Returns false otherwise.
- */
+  /**
+   * Returns true if (and only if)
+   *  (1) the event has never been scheduled to be recorded
+   *  (2) the current version is marked as recorded.
+   * Returns false otherwise.
+   */
   virtual bool queryEvent(void* event) const {
     TORCH_CHECK(false, "Backend doesn't support events.");
   }
@@ -190,7 +187,8 @@ struct C10_API DeviceGuardImplInterface {
 // putting them in the registry.  This is done by deleting the destructor
 // on DeviceGuardImplInterface.
 extern C10_API std::atomic<const DeviceGuardImplInterface*>
-device_guard_impl_registry[static_cast<size_t>(DeviceType::COMPILE_TIME_MAX_DEVICE_TYPES)];
+    device_guard_impl_registry[static_cast<size_t>(
+        DeviceType::COMPILE_TIME_MAX_DEVICE_TYPES)];
 
 // I can't conveniently use c10/util/Registry.h for the following reason:
 // c10/util/Registry.h gives me a slow way of Create'ing a object of some
@@ -201,12 +199,13 @@ device_guard_impl_registry[static_cast<size_t>(DeviceType::COMPILE_TIME_MAX_DEVI
 // into device_guard_impl_registry.
 
 class C10_API DeviceGuardImplRegistrar {
-public:
+ public:
   DeviceGuardImplRegistrar(DeviceType, const DeviceGuardImplInterface*);
 };
 
-#define C10_REGISTER_GUARD_IMPL(DevType, DeviceGuardImpl) \
-  static ::c10::impl::DeviceGuardImplRegistrar C10_ANONYMOUS_VARIABLE(g_##DeviceType)(::c10::DeviceType::DevType, new DeviceGuardImpl());
+#define C10_REGISTER_GUARD_IMPL(DevType, DeviceGuardImpl)              \
+  static ::c10::impl::DeviceGuardImplRegistrar C10_ANONYMOUS_VARIABLE( \
+      g_##DeviceType)(::c10::DeviceType::DevType, new DeviceGuardImpl());
 
 inline const DeviceGuardImplInterface* getDeviceGuardImpl(DeviceType type) {
   auto p = device_guard_impl_registry[static_cast<size_t>(type)].load();
@@ -218,4 +217,5 @@ inline bool hasDeviceGuardImpl(DeviceType type) {
   return device_guard_impl_registry[static_cast<size_t>(type)].load();
 }
 
-}} // namespace c10::impl
+} // namespace impl
+} // namespace c10

--- a/c10/core/impl/FakeGuardImpl.h
+++ b/c10/core/impl/FakeGuardImpl.h
@@ -60,17 +60,16 @@ struct FakeGuardImpl final : public DeviceGuardImplInterface {
 
   // Event-related functions
   void record(
-    void** event,
-    const Stream& stream,
-    const DeviceIndex device_index,
-    const EventFlag flag) const override { }
-  void block(
-    void* event,
-    const Stream& stream) const override { }
-  bool queryEvent(void* event) const override { return true; }
-  void destroyEvent(
-    void* event,
-    const DeviceIndex device_index) const noexcept override { }
+      void** event,
+      const Stream& stream,
+      const DeviceIndex device_index,
+      const EventFlag flag) const override {}
+  void block(void* event, const Stream& stream) const override {}
+  bool queryEvent(void* event) const override {
+    return true;
+  }
+  void destroyEvent(void* event, const DeviceIndex device_index) const
+      noexcept override {}
 
   // Convenience methods for testing
   static DeviceIndex getDeviceIndex() {
@@ -87,9 +86,11 @@ struct FakeGuardImpl final : public DeviceGuardImplInterface {
   static void resetStreams() {
     current_streams_.fill(0);
   }
-private:
+
+ private:
   thread_local static DeviceIndex current_device_;
-  thread_local static std::array<StreamId, kFakeGuardImplMaxDevices> current_streams_;
+  thread_local static std::array<StreamId, kFakeGuardImplMaxDevices>
+      current_streams_;
 };
 
 template <DeviceType T>
@@ -99,7 +100,8 @@ template <DeviceType T>
 constexpr DeviceType FakeGuardImpl<T>::static_type;
 
 template <DeviceType T>
-thread_local std::array<StreamId, kFakeGuardImplMaxDevices> FakeGuardImpl<T>::current_streams_ = {0,0,0,0,0,0,0,0};
+thread_local std::array<StreamId, kFakeGuardImplMaxDevices>
+    FakeGuardImpl<T>::current_streams_ = {0, 0, 0, 0, 0, 0, 0, 0};
 
-
-}} // namespace c10::impl
+} // namespace impl
+} // namespace c10

--- a/c10/core/impl/InlineDeviceGuard.h
+++ b/c10/core/impl/InlineDeviceGuard.h
@@ -1,17 +1,16 @@
 #pragma once
 
-// This file provides implementations of InlineDeviceGuard and InlineOptionalDeviceGuard.
+// This file provides implementations of InlineDeviceGuard and
+// InlineOptionalDeviceGuard.
 
 #include <c10/core/Device.h>
 #include <c10/core/impl/DeviceGuardImplInterface.h>
 #include <c10/core/impl/VirtualGuardImpl.h>
-#include <c10/util/Optional.h>
 #include <c10/util/C++17.h>
+#include <c10/util/Optional.h>
 
 namespace c10 {
 namespace impl {
-
-
 
 /**
  * A DeviceGuard is an RAII class that sets a device to some value
@@ -54,7 +53,7 @@ namespace impl {
  */
 template <typename T>
 class InlineDeviceGuard {
-public:
+ public:
   // Note [Omitted default constructor from RAII]
   // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   // In principle, we could add a default constructor to
@@ -69,25 +68,36 @@ public:
 
   /// Set the current device to the passed Device.
   explicit InlineDeviceGuard(Device device)
-    : impl_(device.type())
-    , original_device_(device.index() == -1 ? impl_.getDevice() : impl_.exchangeDevice(device))
-    , current_device_(device.index() == -1 ? original_device_ : device)
-    {}
+      : impl_(device.type()),
+        original_device_(
+            device.index() == -1 ? impl_.getDevice()
+                                 : impl_.exchangeDevice(device)),
+        current_device_(device.index() == -1 ? original_device_ : device) {}
 
   /// Set the current device index to the passed DeviceIndex.  (The
   /// device type is inferred from the template parameter T).
-  template <typename U=T, typename=typename std::enable_if<!std::is_same<U, VirtualGuardImpl>::value>::type>
+  template <
+      typename U = T,
+      typename = typename std::enable_if<
+          !std::is_same<U, VirtualGuardImpl>::value>::type>
   explicit InlineDeviceGuard(DeviceIndex device_index)
-    : InlineDeviceGuard(Device(U::static_type, device_index)) {}
+      : InlineDeviceGuard(Device(U::static_type, device_index)) {}
 
   /// Construct an InlineDeviceGuard using VirtualGuardImpl with an explicit
   /// DeviceGuardImplInterface pointer.
-  template <typename U=T, typename=typename std::enable_if<std::is_same<U, VirtualGuardImpl>::value>::type>
-  explicit InlineDeviceGuard(Device device, const DeviceGuardImplInterface* impl)
-    : impl_(VirtualGuardImpl(impl ? impl : getDeviceGuardImpl(device.type())))
-    , original_device_(device.index() == -1 ? impl_.getDevice() : impl_.exchangeDevice(device))
-    , current_device_(device.index() == -1 ? original_device_ : device)
-    {}
+  template <
+      typename U = T,
+      typename = typename std::enable_if<
+          std::is_same<U, VirtualGuardImpl>::value>::type>
+  explicit InlineDeviceGuard(
+      Device device,
+      const DeviceGuardImplInterface* impl)
+      : impl_(
+            VirtualGuardImpl(impl ? impl : getDeviceGuardImpl(device.type()))),
+        original_device_(
+            device.index() == -1 ? impl_.getDevice()
+                                 : impl_.exchangeDevice(device)),
+        current_device_(device.index() == -1 ? original_device_ : device) {}
 
   /// Copy is disallowed
   InlineDeviceGuard(const InlineDeviceGuard<T>&) = delete;
@@ -103,12 +113,18 @@ public:
   }
 
   /// Sets the device to the given one.
-  template <typename U=T, typename std::enable_if<!std::is_same<U, VirtualGuardImpl>::value, int>::type = 0>
+  template <
+      typename U = T,
+      typename std::enable_if<!std::is_same<U, VirtualGuardImpl>::value, int>::
+          type = 0>
   void set_device(at::Device device) {
-    AT_ASSERT((U::static_type == DeviceType::HIP && device.type() == DeviceType::CUDA) ||
-              device.type() == U::static_type);
+    AT_ASSERT(
+        (U::static_type == DeviceType::HIP &&
+         device.type() == DeviceType::CUDA) ||
+        device.type() == U::static_type);
     auto index = device.index();
-    if (index == -1) return;
+    if (index == -1)
+      return;
     impl_.setDevice(device);
     current_device_ = device;
   }
@@ -116,8 +132,8 @@ public:
   /// Resets the currently set device to its original device, and then sets the
   /// current device to the passed device.  This is effectively equivalent to
   /// set_device when a guard supports only a single device type.
-  template <typename U=T>
-  typename std::enable_if<!std::is_same<U, VirtualGuardImpl>::value >::type
+  template <typename U = T>
+  typename std::enable_if<!std::is_same<U, VirtualGuardImpl>::value>::type
   reset_device(at::Device device) {
     set_device(device);
   }
@@ -139,11 +155,14 @@ public:
   /// that it is unnecessary.
   ///
   /// Optional argument is for testing only.
-  template <typename U=T>
-  typename std::enable_if<std::is_same<U, VirtualGuardImpl>::value >::type
-  reset_device(at::Device device, const impl::DeviceGuardImplInterface* impl = nullptr) {
+  template <typename U = T>
+  typename std::enable_if<std::is_same<U, VirtualGuardImpl>::value>::type
+  reset_device(
+      at::Device device,
+      const impl::DeviceGuardImplInterface* impl = nullptr) {
     auto index = device.index();
-    if (index == -1) return;
+    if (index == -1)
+      return;
     if (device.type() == original_device_.type()) {
       AT_ASSERT(impl == nullptr || impl->type() == device.type());
       impl_.setDevice(device);
@@ -175,10 +194,10 @@ public:
     return current_device_;
   }
 
-protected:
+ protected:
   T impl_;
 
-private:
+ private:
   Device original_device_;
   Device current_device_;
 };
@@ -193,29 +212,33 @@ private:
  */
 template <typename T>
 class InlineOptionalDeviceGuard {
-public:
+ public:
   // Note [Explicit initialization of optional fields]
   // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   // Explicit initialization of optional fields
-  // required to workaround an nvcc bug; see https://github.com/pytorch/pytorch/issues/12117
+  // required to workaround an nvcc bug; see
+  // https://github.com/pytorch/pytorch/issues/12117
 
   /// Creates an uninitialized OptionalDeviceGuard.
   explicit InlineOptionalDeviceGuard()
-    : guard_() // See Note [Explicit initialization of optional fields]
-    {}
+      : guard_() // See Note [Explicit initialization of optional fields]
+  {}
 
   /// Set the current device to the passed Device, if it is not nullopt.
   explicit InlineOptionalDeviceGuard(optional<Device> device_opt)
-    : guard_() { // See Note [Explicit initialization of optional fields]
+      : guard_() { // See Note [Explicit initialization of optional fields]
     if (device_opt.has_value()) {
       guard_.emplace(device_opt.value());
     }
   }
 
   /// Set the current device to the passed DeviceIndex, if it is not nullopt.
-  template <typename U=T, typename=typename std::enable_if<!std::is_same<U, VirtualGuardImpl>::value>::type>
+  template <
+      typename U = T,
+      typename = typename std::enable_if<
+          !std::is_same<U, VirtualGuardImpl>::value>::type>
   explicit InlineOptionalDeviceGuard(optional<DeviceIndex> device_index_opt)
-    : guard_() { // See Note [Explicit initialization of optional fields]
+      : guard_() { // See Note [Explicit initialization of optional fields]
     if (device_index_opt.has_value()) {
       guard_.emplace(device_index_opt.value());
     }
@@ -225,7 +248,7 @@ public:
   /// and result in initialized OptionalDeviceGuard.
   template <typename... Args>
   explicit InlineOptionalDeviceGuard(Args&&... args)
-    : guard_(in_place, std::forward<Args>(args)...) {}
+      : guard_(in_place, std::forward<Args>(args)...) {}
 
   // TODO: Consider readding Tensor and TensorList constructors here, when
   // Tensor moves to c10.  (These are only valid on OptionalDeviceGuard,
@@ -313,11 +336,15 @@ public:
   //
   // We could solve this with an extra thread-local variable.  But no one is
   // actually using move-assignment.  So just get rid of it.
-  InlineOptionalDeviceGuard& operator=(InlineOptionalDeviceGuard&& other) = delete;
+  InlineOptionalDeviceGuard& operator=(InlineOptionalDeviceGuard&& other) =
+      delete;
 
   /// Sets the device to the given one.  Initializes OptionalDeviceGuard if it
   /// is not already initialized.
-  template <typename U=T, typename=typename std::enable_if<!std::is_same<U, VirtualGuardImpl>::value>::type>
+  template <
+      typename U = T,
+      typename = typename std::enable_if<
+          !std::is_same<U, VirtualGuardImpl>::value>::type>
   void set_device(at::Device device) {
     if (!guard_.has_value()) {
       guard_.emplace(device);
@@ -333,8 +360,13 @@ public:
   /// See notes on why this is called reset_device on InlineDeviceGuard.
   ///
   /// Optional argument is for testing only.
-  template <typename U=T, typename=typename std::enable_if<std::is_same<U, VirtualGuardImpl>::value>::type>
-  void reset_device(at::Device device, const DeviceGuardImplInterface* impl = nullptr) {
+  template <
+      typename U = T,
+      typename = typename std::enable_if<
+          std::is_same<U, VirtualGuardImpl>::value>::type>
+  void reset_device(
+      at::Device device,
+      const DeviceGuardImplInterface* impl = nullptr) {
     if (!guard_.has_value()) {
       guard_.emplace(device, impl);
     } else {
@@ -346,7 +378,10 @@ public:
   /// current device to the passed device.  Initializes the guard if it is
   /// not already initialized.  This is effectively equivalent to set_device
   /// when a guard supports only a single device type.
-  template <typename U=T, typename=typename std::enable_if<!std::is_same<U, VirtualGuardImpl>::value>::type>
+  template <
+      typename U = T,
+      typename = typename std::enable_if<
+          !std::is_same<U, VirtualGuardImpl>::value>::type>
   void reset_device(at::Device device) {
     if (!guard_.has_value()) {
       guard_.emplace(device);
@@ -357,7 +392,10 @@ public:
 
   /// Sets the device index to the given one.  The device type is statically
   /// known.
-  template <typename U=T, typename=typename std::enable_if<!std::is_same<U, VirtualGuardImpl>::value >::type>
+  template <
+      typename U = T,
+      typename = typename std::enable_if<
+          !std::is_same<U, VirtualGuardImpl>::value>::type>
   void set_index(DeviceIndex index) {
     if (!guard_.has_value()) {
       guard_.emplace(index);
@@ -366,17 +404,19 @@ public:
     }
   }
 
-  /// Returns the device that was set immediately prior to initialization of the,
-  /// guard, or nullopt if the guard is uninitialized.
+  /// Returns the device that was set immediately prior to initialization of
+  /// the, guard, or nullopt if the guard is uninitialized.
   optional<Device> original_device() const {
-    return guard_.has_value() ? make_optional(guard_->original_device()) : nullopt;
+    return guard_.has_value() ? make_optional(guard_->original_device())
+                              : nullopt;
   }
 
   /// Returns the most recent device that was set using this device guard,
   /// either from construction, or via set_device, if the guard is initialized,
   /// or nullopt if the guard is uninitialized.
   optional<Device> current_device() const {
-    return guard_.has_value() ? make_optional(guard_->current_device()) : nullopt;
+    return guard_.has_value() ? make_optional(guard_->current_device())
+                              : nullopt;
   }
 
   /// Restore the original device, resetting this guard to uninitialized state.
@@ -384,8 +424,9 @@ public:
     guard_.reset();
   }
 
-private:
+ private:
   optional<InlineDeviceGuard<T>> guard_;
 };
 
-}} // namespace c10::impl
+} // namespace impl
+} // namespace c10

--- a/c10/core/impl/InlineEvent.h
+++ b/c10/core/impl/InlineEvent.h
@@ -2,22 +2,19 @@
 
 #include "c10/core/DeviceType.h"
 #include "c10/core/Stream.h"
-#include "c10/util/Exception.h"
 #include "c10/core/impl/DeviceGuardImplInterface.h"
+#include "c10/util/Exception.h"
 
 namespace c10 {
 namespace impl {
 
 template <typename T>
 struct InlineEvent final {
-
   InlineEvent() = delete;
   InlineEvent(
-    const DeviceType _device_type,
-    const EventFlag _flag = EventFlag::PYTORCH_DEFAULT)
-  : backend_{_device_type},
-    device_type_{_device_type},
-    flag_{_flag} { }
+      const DeviceType _device_type,
+      const EventFlag _flag = EventFlag::PYTORCH_DEFAULT)
+      : backend_{_device_type}, device_type_{_device_type}, flag_{_flag} {}
 
   // Copy constructor and copy assignment operator (deleted)
   InlineEvent(const InlineEvent&) = delete;
@@ -25,7 +22,7 @@ struct InlineEvent final {
 
   // Move constructor and move assignment operator
   InlineEvent(InlineEvent&& other)
-  : InlineEvent(other.device_type_, other.flag_) {
+      : InlineEvent(other.device_type_, other.flag_) {
     swap(std::move(other));
   }
   InlineEvent& operator=(InlineEvent&& other) {
@@ -43,27 +40,36 @@ struct InlineEvent final {
   }
 
   ~InlineEvent() noexcept {
-    if (event_) backend_.destroyEvent(event_, device_index_);
+    if (event_)
+      backend_.destroyEvent(event_, device_index_);
   }
 
-  DeviceType device_type() const noexcept { return device_type_; }
-  DeviceIndex device_index() const noexcept { return device_index_; }
-  EventFlag flag() const noexcept { return flag_; }
-  bool was_marked_for_recording() const noexcept { return was_marked_for_recording_; }
-
+  DeviceType device_type() const noexcept {
+    return device_type_;
+  }
+  DeviceIndex device_index() const noexcept {
+    return device_index_;
+  }
+  EventFlag flag() const noexcept {
+    return flag_;
+  }
+  bool was_marked_for_recording() const noexcept {
+    return was_marked_for_recording_;
+  }
 
   void recordOnce(const Stream& stream) {
-    if (!was_marked_for_recording_) record(stream);
+    if (!was_marked_for_recording_)
+      record(stream);
   }
 
   void record(const Stream& stream) {
     TORCH_CHECK(
-      stream.device_type() == device_type_,
-      "Event device type ",
-      DeviceTypeName(device_type_),
-      " does not match recording stream's device type ",
-      DeviceTypeName(stream.device_type()),
-      ".");
+        stream.device_type() == device_type_,
+        "Event device type ",
+        DeviceTypeName(device_type_),
+        " does not match recording stream's device type ",
+        DeviceTypeName(stream.device_type()),
+        ".");
 
     backend_.record(&event_, stream, device_index_, flag_);
     was_marked_for_recording_ = true;
@@ -71,25 +77,27 @@ struct InlineEvent final {
   }
 
   void block(const Stream& stream) const {
-    if (!was_marked_for_recording_) return;
+    if (!was_marked_for_recording_)
+      return;
 
     TORCH_CHECK(
-      stream.device_type() == device_type_,
-      "Event device type ",
-      DeviceTypeName(device_type_),
-      " does not match blocking stream's device type ",
-      DeviceTypeName(stream.device_type()),
-      ".");
+        stream.device_type() == device_type_,
+        "Event device type ",
+        DeviceTypeName(device_type_),
+        " does not match blocking stream's device type ",
+        DeviceTypeName(stream.device_type()),
+        ".");
 
     backend_.block(event_, stream);
   }
 
   bool query() const {
-    if (!was_marked_for_recording_) return true;
+    if (!was_marked_for_recording_)
+      return true;
     return backend_.queryEvent(event_);
   }
 
-private:
+ private:
   void* event_ = nullptr;
   T backend_;
   DeviceType device_type_;
@@ -98,5 +106,5 @@ private:
   bool was_marked_for_recording_ = false;
 };
 
-} // impl
-} // c10
+} // namespace impl
+} // namespace c10

--- a/c10/core/impl/InlineStreamGuard.h
+++ b/c10/core/impl/InlineStreamGuard.h
@@ -15,27 +15,34 @@ namespace impl {
  */
 template <typename T>
 class InlineStreamGuard : private InlineDeviceGuard<T> {
-public:
+ public:
   /// No default constructor, see Note [Omitted default constructor from RAII]
   explicit InlineStreamGuard() = delete;
 
   /// Set the current device to the device associated with the passed stream,
   /// and set the current stream on that device to the passed stream.
   explicit InlineStreamGuard(Stream stream)
-    : InlineDeviceGuard<T>(stream.device())
-    , original_stream_of_original_device_(this->impl_.getStream(original_device()))
-    , original_stream_of_current_device_(this->impl_.exchangeStream(stream))
-    , current_stream_(stream)
-    {}
+      : InlineDeviceGuard<T>(stream.device()),
+        original_stream_of_original_device_(
+            this->impl_.getStream(original_device())),
+        original_stream_of_current_device_(this->impl_.exchangeStream(stream)),
+        current_stream_(stream) {}
 
   /// This constructor exists purely for testing
-  template <typename U=T, typename=typename std::enable_if<std::is_same<U, VirtualGuardImpl>::value>::type>
-  explicit InlineStreamGuard(Stream stream, const DeviceGuardImplInterface* impl)
-    : InlineDeviceGuard<T>(stream.device(), impl ? impl : getDeviceGuardImpl(stream.device_type()))
-    , original_stream_of_original_device_(this->impl_.getStream(original_device()))
-    , original_stream_of_current_device_(this->impl_.exchangeStream(stream))
-    , current_stream_(stream)
-    {}
+  template <
+      typename U = T,
+      typename = typename std::enable_if<
+          std::is_same<U, VirtualGuardImpl>::value>::type>
+  explicit InlineStreamGuard(
+      Stream stream,
+      const DeviceGuardImplInterface* impl)
+      : InlineDeviceGuard<T>(
+            stream.device(),
+            impl ? impl : getDeviceGuardImpl(stream.device_type())),
+        original_stream_of_original_device_(
+            this->impl_.getStream(original_device())),
+        original_stream_of_current_device_(this->impl_.exchangeStream(stream)),
+        current_stream_(stream) {}
 
   /// Copy is disallowed
   InlineStreamGuard(const InlineStreamGuard<T>&) = delete;
@@ -109,8 +116,9 @@ public:
     return InlineDeviceGuard<T>::original_device();
   }
 
-private:
-  Stream original_stream_of_original_device_; // what the user probably cares about
+ private:
+  Stream
+      original_stream_of_original_device_; // what the user probably cares about
   Stream original_stream_of_current_device_; // what we need to restore
   Stream current_stream_;
 };
@@ -122,17 +130,16 @@ private:
  */
 template <typename T>
 class InlineOptionalStreamGuard {
-public:
+ public:
   /// Creates an uninitialized stream guard.
   explicit InlineOptionalStreamGuard()
-    : guard_() // See Note [Explicit initialization of optional fields]
-    {}
+      : guard_() // See Note [Explicit initialization of optional fields]
+  {}
 
   /// Set the current device to the device associated with the passed stream,
   /// and set the current stream on that device to the passed stream,
   /// if the passed stream is not nullopt.
-  explicit InlineOptionalStreamGuard(optional<Stream> stream_opt)
-    : guard_() {
+  explicit InlineOptionalStreamGuard(optional<Stream> stream_opt) : guard_() {
     if (stream_opt.has_value()) {
       guard_.emplace(stream_opt.value());
     }
@@ -141,13 +148,14 @@ public:
   /// All constructors of StreamGuard are valid for OptionalStreamGuard
   template <typename... Args>
   explicit InlineOptionalStreamGuard(Args&&... args)
-    : guard_(in_place, std::forward<Args>(args)...) {}
+      : guard_(in_place, std::forward<Args>(args)...) {}
 
   // See Note [Move construction for RAII guards is tricky]
   InlineOptionalStreamGuard(InlineOptionalStreamGuard<T>&& other) = delete;
 
   // See Note [Move assignment for RAII guards is tricky]
-  InlineOptionalStreamGuard& operator=(InlineOptionalStreamGuard&& other) = delete;
+  InlineOptionalStreamGuard& operator=(InlineOptionalStreamGuard&& other) =
+      delete;
 
   /// Resets the currently set stream to the original stream and
   /// the currently set device to the original device.  Then,
@@ -165,23 +173,27 @@ public:
   /// Returns the stream that was set at the time the guard was most recently
   /// initialized, or nullopt if the guard is uninitialized.
   optional<Stream> original_stream() const {
-    return guard_.has_value() ? make_optional(guard_->original_stream()) : nullopt;
+    return guard_.has_value() ? make_optional(guard_->original_stream())
+                              : nullopt;
   }
 
   /// Returns the most recent stream that was set using this stream guard,
-  /// either from construction, or via reset_stream, if the guard is initialized,
-  /// or nullopt if the guard is uninitialized.
+  /// either from construction, or via reset_stream, if the guard is
+  /// initialized, or nullopt if the guard is uninitialized.
   optional<Stream> current_stream() const {
-    return guard_.has_value() ? make_optional(guard_->current_stream()) : nullopt;
+    return guard_.has_value() ? make_optional(guard_->current_stream())
+                              : nullopt;
   }
 
-  /// Restore the original device and stream, resetting this guard to uninitialized state.
+  /// Restore the original device and stream, resetting this guard to
+  /// uninitialized state.
   void reset() {
     guard_.reset();
   }
 
-private:
+ private:
   optional<InlineStreamGuard<T>> guard_;
 };
 
-}} // namespace c10::impl
+} // namespace impl
+} // namespace c10

--- a/c10/core/impl/LocalTensorTypeSet.cpp
+++ b/c10/core/impl/LocalTensorTypeSet.cpp
@@ -21,7 +21,7 @@ uint64_t raw_excluded = 0;
 
 #endif
 
-}
+} // namespace
 
 TensorTypeSet tls_excluded_tensor_type_set() {
   return TensorTypeSet(TensorTypeSet::RAW, raw_excluded);
@@ -33,10 +33,15 @@ bool tls_variable_is_enabled() {
 
 void tls_variable_set_enabled(bool enabled) {
   if (enabled) {
-    raw_excluded = tls_excluded_tensor_type_set().remove(TensorTypeId::VariableTensorId).raw_repr();
+    raw_excluded = tls_excluded_tensor_type_set()
+                       .remove(TensorTypeId::VariableTensorId)
+                       .raw_repr();
   } else {
-    raw_excluded = tls_excluded_tensor_type_set().add(TensorTypeId::VariableTensorId).raw_repr();
+    raw_excluded = tls_excluded_tensor_type_set()
+                       .add(TensorTypeId::VariableTensorId)
+                       .raw_repr();
   }
 }
 
-}} // namespace c10::impl
+} // namespace impl
+} // namespace c10

--- a/c10/core/impl/LocalTensorTypeSet.h
+++ b/c10/core/impl/LocalTensorTypeSet.h
@@ -19,4 +19,5 @@ C10_API bool tls_variable_is_enabled();
 C10_API void tls_variable_set_enabled(bool enabled);
 C10_API TensorTypeSet tls_excluded_tensor_type_set();
 
-}} // namespace c10::impl
+} // namespace impl
+} // namespace c10

--- a/c10/core/impl/VirtualGuardImpl.h
+++ b/c10/core/impl/VirtualGuardImpl.h
@@ -10,12 +10,11 @@ namespace impl {
  * to virtual dispatch on the DeviceGuardImpl registry.
  */
 class VirtualGuardImpl final : public DeviceGuardImplInterface {
-public:
+ public:
   VirtualGuardImpl(DeviceType device_type)
-    : impl_(getDeviceGuardImpl(device_type)) {}
+      : impl_(getDeviceGuardImpl(device_type)) {}
   // This constructor exists purely for testing
-  VirtualGuardImpl(const DeviceGuardImplInterface* impl)
-    : impl_(impl) {}
+  VirtualGuardImpl(const DeviceGuardImplInterface* impl) : impl_(impl) {}
 
   // Copying and moving is OK!
 
@@ -48,28 +47,27 @@ public:
   }
 
   // Event functions
-  void record(void** event,
-    const Stream& stream,
-    const DeviceIndex device_index,
-    const EventFlag flag) const override {
+  void record(
+      void** event,
+      const Stream& stream,
+      const DeviceIndex device_index,
+      const EventFlag flag) const override {
     impl_->record(event, stream, device_index, flag);
   }
-  void block(
-    void* event,
-    const Stream& stream) const override {
+  void block(void* event, const Stream& stream) const override {
     impl_->block(event, stream);
   }
   bool queryEvent(void* event) const override {
     return impl_->queryEvent(event);
   }
-  void destroyEvent(
-    void* event,
-    const DeviceIndex device_index) const noexcept override {
+  void destroyEvent(void* event, const DeviceIndex device_index) const
+      noexcept override {
     impl_->destroyEvent(event, device_index);
   }
 
-private:
+ private:
   const DeviceGuardImplInterface* impl_ = nullptr;
 };
 
-}} // namespace c10::impl
+} // namespace impl
+} // namespace c10

--- a/c10/core/thread_pool.cpp
+++ b/c10/core/thread_pool.cpp
@@ -3,9 +3,9 @@
 namespace c10 {
 
 ThreadPool::ThreadPool(
-      int pool_size,
-      int numa_node_id,
-      std::function<void()> init_thread)
+    int pool_size,
+    int numa_node_id,
+    std::function<void()> init_thread)
     : threads_(pool_size < 0 ? defaultNumThreads() : pool_size),
       running_(true),
       complete_(true),
@@ -13,7 +13,7 @@ ThreadPool::ThreadPool(
       total_(threads_.size()),
       numa_node_id_(numa_node_id) {
   for (std::size_t i = 0; i < threads_.size(); ++i) {
-    threads_[i] = std::thread([this, i, init_thread](){
+    threads_[i] = std::thread([this, i, init_thread]() {
       if (init_thread) {
         init_thread();
       }

--- a/c10/core/thread_pool.h
+++ b/c10/core/thread_pool.h
@@ -110,13 +110,11 @@ class C10_API ThreadPool : public c10::TaskThreadPoolBase {
 
 class C10_API TaskThreadPool : public c10::ThreadPool {
  public:
-  explicit TaskThreadPool(
-      std::size_t pool_size,
-      int numa_node_id = -1)
-      : ThreadPool(pool_size, numa_node_id, [numa_node_id](){
-        setThreadName("CaffeTaskThread");
-        NUMABind(numa_node_id);
-      }) {}
+  explicit TaskThreadPool(std::size_t pool_size, int numa_node_id = -1)
+      : ThreadPool(pool_size, numa_node_id, [numa_node_id]() {
+          setThreadName("CaffeTaskThread");
+          NUMABind(numa_node_id);
+        }) {}
 };
 
 C10_DECLARE_SHARED_REGISTRY(

--- a/c10/cuda/CUDACachingAllocator.h
+++ b/c10/cuda/CUDACachingAllocator.h
@@ -1,9 +1,9 @@
 #ifndef THC_DEVICE_ALLOCATOR_INC
 #define THC_DEVICE_ALLOCATOR_INC
 
-#include <c10/cuda/CUDAStream.h>
 #include <c10/core/Allocator.h>
 #include <c10/cuda/CUDAMacros.h>
+#include <c10/cuda/CUDAStream.h>
 #include <c10/util/Registry.h>
 
 #include <mutex>
@@ -14,7 +14,7 @@ namespace c10 {
 // block inside of already allocated area.
 class C10_CUDA_API FreeMemoryCallback {
  public:
-  virtual ~FreeMemoryCallback() {};
+  virtual ~FreeMemoryCallback(){};
   virtual bool Execute() = 0;
 };
 
@@ -44,15 +44,18 @@ C10_CUDA_API void raw_delete(void* ptr);
 
 C10_CUDA_API Allocator* get();
 C10_CUDA_API void emptyCache();
-C10_CUDA_API void cacheInfo(int dev_id, size_t* cachedAndFree, size_t* largestBlock);
-C10_CUDA_API void* getBaseAllocation(void *ptr, size_t *size);
-C10_CUDA_API void recordStream(void *ptr, CUDAStream stream);
+C10_CUDA_API void cacheInfo(
+    int dev_id,
+    size_t* cachedAndFree,
+    size_t* largestBlock);
+C10_CUDA_API void* getBaseAllocation(void* ptr, size_t* size);
+C10_CUDA_API void recordStream(void* ptr, CUDAStream stream);
 C10_CUDA_API uint64_t currentMemoryAllocated(int device);
 C10_CUDA_API uint64_t maxMemoryAllocated(int device);
-C10_CUDA_API void     resetMaxMemoryAllocated(int device);
+C10_CUDA_API void resetMaxMemoryAllocated(int device);
 C10_CUDA_API uint64_t currentMemoryCached(int device);
 C10_CUDA_API uint64_t maxMemoryCached(int device);
-C10_CUDA_API void     resetMaxMemoryCached(int device);
+C10_CUDA_API void resetMaxMemoryCached(int device);
 
 C10_CUDA_API std::mutex* getFreeMutex();
 
@@ -60,6 +63,7 @@ C10_CUDA_API std::shared_ptr<void> getIpcDevPtr(std::string handle);
 
 } // namespace CUDACachingAllocator
 
-}} // namespace c10::cuda
+} // namespace cuda
+} // namespace c10
 
 #endif

--- a/c10/cuda/CUDAException.h
+++ b/c10/cuda/CUDAException.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <c10/util/Exception.h>
 #include <c10/macros/Macros.h>
+#include <c10/util/Exception.h>
 #include <cuda.h>
 
 // Note [CHECK macro]
@@ -21,7 +21,7 @@
     }                                                                \
   } while (0)
 
-  #define C10_CUDA_CHECK_WARN(EXPR)                            \
+#define C10_CUDA_CHECK_WARN(EXPR)                              \
   do {                                                         \
     cudaError_t __err = EXPR;                                  \
     if (__err != cudaSuccess) {                                \

--- a/c10/cuda/CUDAFunctions.h
+++ b/c10/cuda/CUDAFunctions.h
@@ -9,9 +9,9 @@
 
 #include <cuda_runtime_api.h>
 
-#include <c10/macros/Macros.h>
 #include <c10/core/Device.h>
 #include <c10/cuda/CUDAException.h>
+#include <c10/macros/Macros.h>
 
 namespace c10 {
 namespace cuda {
@@ -45,4 +45,5 @@ inline void set_device(DeviceIndex device) {
   C10_CUDA_CHECK(cudaSetDevice(static_cast<int>(device)));
 }
 
-}} // namespace c10::cuda
+} // namespace cuda
+} // namespace c10

--- a/c10/cuda/CUDAGuard.h
+++ b/c10/cuda/CUDAGuard.h
@@ -1,16 +1,18 @@
 #pragma once
 
-#include <c10/cuda/impl/CUDAGuardImpl.h>
-#include <c10/cuda/CUDAMacros.h>
 #include <c10/core/DeviceType.h>
 #include <c10/core/impl/InlineDeviceGuard.h>
 #include <c10/core/impl/InlineStreamGuard.h>
+#include <c10/cuda/CUDAMacros.h>
+#include <c10/cuda/impl/CUDAGuardImpl.h>
 
 #include <cstddef>
 
-namespace c10 { namespace cuda {
+namespace c10 {
+namespace cuda {
 
-// This code is kind of boilerplatey.  See Note [Whither the DeviceGuard boilerplate]
+// This code is kind of boilerplatey.  See Note [Whither the DeviceGuard
+// boilerplate]
 
 /// A variant of DeviceGuard that is specialized for CUDA.  It accepts
 /// integer indices (interpreting them as CUDA devices) and is a little
@@ -38,22 +40,32 @@ struct CUDAGuard {
 
   /// Sets the CUDA device to the given device.  Errors if the given device
   /// is not a CUDA device.
-  void set_device(Device device) { guard_.set_device(device); }
+  void set_device(Device device) {
+    guard_.set_device(device);
+  }
 
   /// Sets the CUDA device to the given device.  Errors if the given device
   /// is not a CUDA device.  (This method is provided for uniformity with
   /// DeviceGuard).
-  void reset_device(Device device) { guard_.reset_device(device); }
+  void reset_device(Device device) {
+    guard_.reset_device(device);
+  }
 
   /// Sets the CUDA device to the given device index.
-  void set_index(DeviceIndex device_index) { guard_.set_index(device_index); }
+  void set_index(DeviceIndex device_index) {
+    guard_.set_index(device_index);
+  }
 
   /// Returns the device that was set upon construction of the guard
-  Device original_device() const { return guard_.original_device(); }
+  Device original_device() const {
+    return guard_.original_device();
+  }
 
-  /// Returns the last device that was set via `set_device`, if any, otherwise the
-  /// device passed during construction.
-  Device current_device() const { return guard_.current_device(); }
+  /// Returns the last device that was set via `set_device`, if any, otherwise
+  /// the device passed during construction.
+  Device current_device() const {
+    return guard_.current_device();
+  }
 
  private:
   /// The guard for the current device.
@@ -67,11 +79,13 @@ struct OptionalCUDAGuard {
   explicit OptionalCUDAGuard() : guard_() {}
 
   /// Set the current CUDA device to the passed Device, if it is not nullopt.
-  explicit OptionalCUDAGuard(optional<Device> device_opt) : guard_(device_opt) {}
+  explicit OptionalCUDAGuard(optional<Device> device_opt)
+      : guard_(device_opt) {}
 
   /// Set the current CUDA device to the passed device index, if it is not
   /// nullopt
-  explicit OptionalCUDAGuard(optional<DeviceIndex> device_index_opt) : guard_(device_index_opt) {}
+  explicit OptionalCUDAGuard(optional<DeviceIndex> device_index_opt)
+      : guard_(device_index_opt) {}
 
   // Copy is not allowed
   OptionalCUDAGuard(const OptionalCUDAGuard&) = delete;
@@ -84,31 +98,45 @@ struct OptionalCUDAGuard {
   OptionalCUDAGuard& operator=(OptionalCUDAGuard&& other) = delete;
 
   /// Sets the CUDA device to the given device, initializing the guard if it
-  /// is not already initialized.  Errors if the given device is not a CUDA device.
-  void set_device(Device device) { guard_.set_device(device); }
+  /// is not already initialized.  Errors if the given device is not a CUDA
+  /// device.
+  void set_device(Device device) {
+    guard_.set_device(device);
+  }
 
   /// Sets the CUDA device to the given device, initializing the guard if it is
   /// not already initialized.  Errors if the given device is not a CUDA device.
   /// (This method is provided for uniformity with OptionalDeviceGuard).
-  void reset_device(Device device) { guard_.reset_device(device); }
+  void reset_device(Device device) {
+    guard_.reset_device(device);
+  }
 
   /// Sets the CUDA device to the given device index, initializing the guard if
   /// it is not already initialized.
-  void set_index(DeviceIndex device_index) { guard_.set_index(device_index); }
+  void set_index(DeviceIndex device_index) {
+    guard_.set_index(device_index);
+  }
 
   /// Returns the device that was set immediately prior to initialization of the
   /// guard, or nullopt if the guard is uninitialized.
-  optional<Device> original_device() const { return guard_.original_device(); }
+  optional<Device> original_device() const {
+    return guard_.original_device();
+  }
 
   /// Returns the most recent device that was set using this device guard,
   /// either from construction, or via set_device, if the guard is initialized,
   /// or nullopt if the guard is uninitialized.
-  optional<Device> current_device() const { return guard_.current_device(); }
+  optional<Device> current_device() const {
+    return guard_.current_device();
+  }
 
-  /// Restore the original CUDA device, resetting this guard to uninitialized state.
-  void reset() { guard_.reset(); }
+  /// Restore the original CUDA device, resetting this guard to uninitialized
+  /// state.
+  void reset() {
+    guard_.reset();
+  }
 
-private:
+ private:
   c10::impl::InlineOptionalDeviceGuard<impl::CUDAGuardImpl> guard_;
 };
 
@@ -118,17 +146,17 @@ struct CUDAStreamGuard {
   /// No default constructor, see Note [Omitted default constructor from RAII]
   explicit CUDAStreamGuard() = delete;
 
-  /// Set the current CUDA device to the device associated with the passed stream,
-  /// and set the current CUDA stream on that device to the passed stream.
-  /// Errors if the Stream is not a CUDA stream.
+  /// Set the current CUDA device to the device associated with the passed
+  /// stream, and set the current CUDA stream on that device to the passed
+  /// stream. Errors if the Stream is not a CUDA stream.
   explicit CUDAStreamGuard(Stream stream) : guard_(stream) {}
 
   /// Copy is disallowed
   CUDAStreamGuard(const CUDAStreamGuard&) = delete;
   CUDAStreamGuard& operator=(const CUDAStreamGuard&) = delete;
 
-  /// Move is disallowed, as CUDAStreamGuard does not have an uninitialized state,
-  /// which is required for moves on types with nontrivial destructors.
+  /// Move is disallowed, as CUDAStreamGuard does not have an uninitialized
+  /// state, which is required for moves on types with nontrivial destructors.
   CUDAStreamGuard(CUDAStreamGuard&& other) = delete;
   CUDAStreamGuard& operator=(CUDAStreamGuard&& other) = delete;
 
@@ -144,9 +172,12 @@ struct CUDAStreamGuard {
   /// WARNING: reset_stream does NOT preserve previously set streams on
   /// different devices.  If you need to set streams on multiple devices
   /// on CUDA, use CUDAMultiStreamGuard instead.
-  void reset_stream(Stream stream) { guard_.reset_stream(stream); }
+  void reset_stream(Stream stream) {
+    guard_.reset_stream(stream);
+  }
 
-  /// Returns the CUDA stream that was set at the time the guard was constructed.
+  /// Returns the CUDA stream that was set at the time the guard was
+  /// constructed.
   CUDAStream original_stream() const {
     return CUDAStream(CUDAStream::UNCHECKED, guard_.original_stream());
   }
@@ -159,31 +190,36 @@ struct CUDAStreamGuard {
 
   /// Returns the most recent CUDA device that was set using this device guard,
   /// either from construction, or via set_device/reset_device/set_index.
-  Device current_device() const { return guard_.current_device(); }
+  Device current_device() const {
+    return guard_.current_device();
+  }
 
   /// Returns the CUDA device that was set at the most recent reset_stream(),
   /// or otherwise the device at construction time.
-  Device original_device() const { return guard_.original_device(); }
+  Device original_device() const {
+    return guard_.original_device();
+  }
 
-private:
+ private:
   c10::impl::InlineStreamGuard<impl::CUDAGuardImpl> guard_;
 };
 
-/// A variant of OptionalStreamGuard that is specialized for CUDA.  See CUDAGuard
-/// for when you can use this.
+/// A variant of OptionalStreamGuard that is specialized for CUDA.  See
+/// CUDAGuard for when you can use this.
 struct OptionalCUDAStreamGuard {
   /// Create an uninitialized guard.
   explicit OptionalCUDAStreamGuard() : guard_() {}
 
-  /// Set the current CUDA device to the device associated with the passed stream,
-  /// and set the current CUDA stream on that device to the passed stream.
-  /// Errors if the Stream is not a CUDA stream.
+  /// Set the current CUDA device to the device associated with the passed
+  /// stream, and set the current CUDA stream on that device to the passed
+  /// stream. Errors if the Stream is not a CUDA stream.
   explicit OptionalCUDAStreamGuard(Stream stream) : guard_(stream) {}
 
   /// Set the current device to the device associated with the passed stream,
   /// and set the current stream on that device to the passed stream,
   /// if the passed stream is not nullopt.
-  explicit OptionalCUDAStreamGuard(optional<Stream> stream_opt) : guard_(stream_opt) {}
+  explicit OptionalCUDAStreamGuard(optional<Stream> stream_opt)
+      : guard_(stream_opt) {}
 
   /// Copy is disallowed
   OptionalCUDAStreamGuard(const OptionalCUDAStreamGuard&) = delete;
@@ -200,10 +236,12 @@ struct OptionalCUDAStreamGuard {
   /// set the current device to the device associated with the passed stream,
   /// and set the current stream on that device to the passed stream.
   /// Initializes the guard if it was not previously initialized.
-  void reset_stream(Stream stream) { guard_.reset_stream(stream); }
+  void reset_stream(Stream stream) {
+    guard_.reset_stream(stream);
+  }
 
-  /// Returns the CUDA stream that was set at the time the guard was most recently
-  /// initialized, or nullopt if the guard is uninitialized.
+  /// Returns the CUDA stream that was set at the time the guard was most
+  /// recently initialized, or nullopt if the guard is uninitialized.
   optional<CUDAStream> original_stream() const {
     auto r = guard_.original_stream();
     if (r.has_value()) {
@@ -214,8 +252,8 @@ struct OptionalCUDAStreamGuard {
   }
 
   /// Returns the most recent CUDA stream that was set using this stream guard,
-  /// either from construction, or via reset_stream, if the guard is initialized,
-  /// or nullopt if the guard is uninitialized.
+  /// either from construction, or via reset_stream, if the guard is
+  /// initialized, or nullopt if the guard is uninitialized.
   optional<CUDAStream> current_stream() const {
     auto r = guard_.current_stream();
     if (r.has_value()) {
@@ -225,10 +263,13 @@ struct OptionalCUDAStreamGuard {
     }
   }
 
-  /// Restore the original CUDA device and stream, resetting this guard to uninitialized state.
-  void reset() { guard_.reset(); }
+  /// Restore the original CUDA device and stream, resetting this guard to
+  /// uninitialized state.
+  void reset() {
+    guard_.reset();
+  }
 
-private:
+ private:
   c10::impl::InlineOptionalStreamGuard<impl::CUDAGuardImpl> guard_;
 };
 

--- a/c10/cuda/CUDAStream.cpp
+++ b/c10/cuda/CUDAStream.cpp
@@ -1,6 +1,6 @@
-#include <c10/cuda/CUDAStream.h>
 #include <c10/cuda/CUDAFunctions.h>
 #include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAStream.h>
 #include <c10/util/Exception.h>
 
 #include <array>

--- a/c10/cuda/impl/CUDAGuardImpl.cpp
+++ b/c10/cuda/impl/CUDAGuardImpl.cpp
@@ -8,4 +8,6 @@ constexpr DeviceType CUDAGuardImpl::static_type;
 
 C10_REGISTER_GUARD_IMPL(CUDA, CUDAGuardImpl);
 
-}}} // namespace c10::cuda::detail
+} // namespace impl
+} // namespace cuda
+} // namespace c10

--- a/c10/cuda/impl/CUDAGuardImpl.h
+++ b/c10/cuda/impl/CUDAGuardImpl.h
@@ -5,8 +5,8 @@
 #include <c10/util/Exception.h>
 
 #include <c10/cuda/CUDAException.h>
-#include <c10/cuda/CUDAStream.h>
 #include <c10/cuda/CUDAFunctions.h>
+#include <c10/cuda/CUDAStream.h>
 
 #include <cuda_runtime_api.h>
 
@@ -62,9 +62,7 @@ struct CUDAGuardImpl final : public c10::impl::DeviceGuardImplInterface {
   }
 
   // Event-related functions
-  void createEvent(
-    cudaEvent_t* cuda_event,
-    const EventFlag flag) const {
+  void createEvent(cudaEvent_t* cuda_event, const EventFlag flag) const {
     // Maps PyTorch's Event::Flag to CUDA flag
     auto cuda_flag = cudaEventDefault;
     switch (flag) {
@@ -83,10 +81,10 @@ struct CUDAGuardImpl final : public c10::impl::DeviceGuardImplInterface {
     C10_CUDA_CHECK(cudaEventCreateWithFlags(cuda_event, cuda_flag));
   }
 
-  void destroyEvent(
-    void* event,
-    const DeviceIndex device_index) const noexcept override {
-    if (!event) return;
+  void destroyEvent(void* event, const DeviceIndex device_index) const
+      noexcept override {
+    if (!event)
+      return;
     auto cuda_event = static_cast<cudaEvent_t>(event);
     int orig_device;
     C10_CUDA_CHECK_WARN(cudaGetDevice(&orig_device));
@@ -96,16 +94,17 @@ struct CUDAGuardImpl final : public c10::impl::DeviceGuardImplInterface {
   }
 
   void record(
-    void** event,
-    const Stream& stream,
-    const DeviceIndex device_index,
-    const EventFlag flag) const override {
-    TORCH_CHECK(device_index == -1 || device_index == stream.device_index(),
-      "Event device index ",
-      device_index,
-      " does not match recording stream's device index ",
-      stream.device_index(),
-      ".");
+      void** event,
+      const Stream& stream,
+      const DeviceIndex device_index,
+      const EventFlag flag) const override {
+    TORCH_CHECK(
+        device_index == -1 || device_index == stream.device_index(),
+        "Event device index ",
+        device_index,
+        " does not match recording stream's device index ",
+        stream.device_index(),
+        ".");
 
     cudaEvent_t cuda_event = static_cast<cudaEvent_t>(*event);
     CUDAStream cuda_stream{stream};
@@ -115,7 +114,8 @@ struct CUDAGuardImpl final : public c10::impl::DeviceGuardImplInterface {
     setDevice(stream.device());
 
     // Creates the event (lazily)
-    if (!cuda_event) createEvent(&cuda_event, flag);
+    if (!cuda_event)
+      createEvent(&cuda_event, flag);
     C10_CUDA_CHECK(cudaEventRecord(cuda_event, cuda_stream));
     // Makes the void* point to the (possibly just allocated) CUDA event
     *event = cuda_event;
@@ -124,24 +124,24 @@ struct CUDAGuardImpl final : public c10::impl::DeviceGuardImplInterface {
     setDevice(orig_device);
   }
 
-  void block(
-    void* event,
-    const Stream& stream) const override {
-    if (!event) return;
+  void block(void* event, const Stream& stream) const override {
+    if (!event)
+      return;
     cudaEvent_t cuda_event = static_cast<cudaEvent_t>(event);
     CUDAStream cuda_stream{stream};
     const auto orig_device = getDevice();
     setDevice(stream.device());
     C10_CUDA_CHECK(cudaStreamWaitEvent(
-      cuda_stream,
-      cuda_event,
-      /*flags (must be zero)=*/ 0));
+        cuda_stream,
+        cuda_event,
+        /*flags (must be zero)=*/0));
     setDevice(orig_device);
   }
 
   // May be called from any device
   bool queryEvent(void* event) const override {
-    if (!event) return true;
+    if (!event)
+      return true;
     cudaEvent_t cuda_event = static_cast<cudaEvent_t>(event);
     const cudaError_t err = cudaEventQuery(cuda_event);
     if (err != cudaErrorNotReady) {
@@ -151,4 +151,6 @@ struct CUDAGuardImpl final : public c10::impl::DeviceGuardImplInterface {
   }
 };
 
-}}} // namespace c10::cuda::impl
+} // namespace impl
+} // namespace cuda
+} // namespace c10

--- a/c10/cuda/impl/CUDATest.cpp
+++ b/c10/cuda/impl/CUDATest.cpp
@@ -29,4 +29,6 @@ int c10_cuda_private_test() {
   return 2;
 }
 
-}}} // namespace c10::cuda::impl
+} // namespace impl
+} // namespace cuda
+} // namespace c10

--- a/c10/cuda/impl/CUDATest.h
+++ b/c10/cuda/impl/CUDATest.h
@@ -8,4 +8,6 @@ namespace impl {
 
 C10_CUDA_API int c10_cuda_test();
 
-}}} /// namespace c10::cuda::impl
+}
+} // namespace cuda
+} // namespace c10

--- a/c10/macros/Macros.h
+++ b/c10/macros/Macros.h
@@ -44,7 +44,6 @@
 #define C10_ANONYMOUS_VARIABLE(str) C10_CONCATENATE(str, __LINE__)
 #endif
 
-
 /// C10_NODISCARD - Warn if a type or return value is discarded.
 
 // Technically, we should check if __cplusplus > 201402L here, because
@@ -68,19 +67,20 @@
 //  - gcc 8.3: https://godbolt.org/z/4tLMQS (always advertises support)
 #define C10_NODISCARD
 #if defined(__has_cpp_attribute)
-# if __has_cpp_attribute(nodiscard)
-#  undef C10_NODISCARD
-#  define C10_NODISCARD [[nodiscard]]
-# endif
+#if __has_cpp_attribute(nodiscard)
+#undef C10_NODISCARD
+#define C10_NODISCARD [[nodiscard]]
+#endif
 // Workaround for llvm.org/PR23435, since clang 3.6 and below emit a spurious
 // error when __has_cpp_attribute is given a scoped attribute in C mode.
 #elif __cplusplus && defined(__has_cpp_attribute)
-# if __has_cpp_attribute(clang::warn_unused_result)
-// TODO: It's possible this is still triggering https://github.com/pytorch/pytorch/issues/13118
-// on Windows; if it is, better fix it.
-#  undef C10_NODISCARD
-#  define C10_NODISCARD [[clang::warn_unused_result]]
-# endif
+#if __has_cpp_attribute(clang::warn_unused_result)
+// TODO: It's possible this is still triggering
+// https://github.com/pytorch/pytorch/issues/13118 on Windows; if it is, better
+// fix it.
+#undef C10_NODISCARD
+#define C10_NODISCARD [[clang::warn_unused_result]]
+#endif
 #endif
 
 // suppress an unused variable.
@@ -95,16 +95,28 @@
 // Simply define the namespace, in case a dependent library want to refer to
 // the c10 namespace but not any nontrivial files.
 namespace c10 {} // namespace c10
-namespace c10 { namespace cuda {} }
-namespace c10 { namespace hip {} }
+namespace c10 {
+namespace cuda {}
+} // namespace c10
+namespace c10 {
+namespace hip {}
+} // namespace c10
 
 // Since C10 is the core library for caffe2 (and aten), we will simply reroute
 // all abstractions defined in c10 to be available in caffe2 as well.
 // This is only for backwards compatibility. Please use the symbols from the
 // c10 namespace where possible.
-namespace caffe2 { using namespace c10; }
-namespace at { using namespace c10; }
-namespace at { namespace cuda { using namespace c10::cuda; }}
+namespace caffe2 {
+using namespace c10;
+}
+namespace at {
+using namespace c10;
+}
+namespace at {
+namespace cuda {
+using namespace c10::cuda;
+}
+} // namespace at
 
 // WARNING!!! THIS IS A GIANT HACK!!!
 // This line means you cannot simultaneously include c10/hip
@@ -114,7 +126,11 @@ namespace at { namespace cuda { using namespace c10::cuda; }}
 // from at::cuda.  This namespace makes that happen.  When
 // HIPIFY is no longer out-of-place, we can switch the cuda
 // here to hip and everyone is happy.
-namespace at { namespace cuda { using namespace c10::hip; }}
+namespace at {
+namespace cuda {
+using namespace c10::hip;
+}
+} // namespace at
 
 // C10_NORETURN
 #if defined(_MSC_VER)
@@ -136,11 +152,11 @@ namespace at { namespace cuda { using namespace c10::hip; }}
 // without it.
 //
 #if defined(__GNUC__) || defined(__ICL) || defined(__clang__)
-#define C10_LIKELY(expr)    (__builtin_expect(static_cast<bool>(expr), 1))
-#define C10_UNLIKELY(expr)  (__builtin_expect(static_cast<bool>(expr), 0))
+#define C10_LIKELY(expr) (__builtin_expect(static_cast<bool>(expr), 1))
+#define C10_UNLIKELY(expr) (__builtin_expect(static_cast<bool>(expr), 0))
 #else
-#define C10_LIKELY(expr)    (expr)
-#define C10_UNLIKELY(expr)  (expr)
+#define C10_LIKELY(expr) (expr)
+#define C10_UNLIKELY(expr) (expr)
 #endif
 
 #include <sstream>
@@ -151,10 +167,12 @@ namespace at { namespace cuda { using namespace c10::hip; }}
 #define C10_HOST_DEVICE __host__ __device__
 #define C10_DEVICE __device__
 #define C10_HOST __host__
-// constants from (https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#features-and-technical-specifications)
-// The maximum number of threads per multiprocessor is 1024 for Turing architecture (7.5)
-// but 2048 for previous architectures. You'll get warnings if you exceed these constants.
-// Hence, the following macros adjust the input values from the user to resolve potential warnings.
+// constants from
+// (https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#features-and-technical-specifications)
+// The maximum number of threads per multiprocessor is 1024 for Turing
+// architecture (7.5) but 2048 for previous architectures. You'll get warnings
+// if you exceed these constants. Hence, the following macros adjust the input
+// values from the user to resolve potential warnings.
 #if __CUDA_ARCH__ >= 750
 constexpr uint32_t CUDA_MAX_THREADS_PER_SM = 1024;
 #else
@@ -162,25 +180,39 @@ constexpr uint32_t CUDA_MAX_THREADS_PER_SM = 2048;
 #endif
 // CUDA_MAX_THREADS_PER_BLOCK is same for all architectures currently
 constexpr uint32_t CUDA_MAX_THREADS_PER_BLOCK = 1024;
-// CUDA_THREADS_PER_BLOCK_FALLBACK is the "canonical fallback" choice of block size.
-// 256 is a good number for this fallback and should give good occupancy and
-// versatility across all architectures.
+// CUDA_THREADS_PER_BLOCK_FALLBACK is the "canonical fallback" choice of block
+// size. 256 is a good number for this fallback and should give good occupancy
+// and versatility across all architectures.
 constexpr uint32_t CUDA_THREADS_PER_BLOCK_FALLBACK = 256;
 // NOTE: if you are thinking of constexpr-ify the inputs to launch bounds, it
 //       turns out that although __launch_bounds__ can take constexpr, it
 //       can't take a constexpr that has anything to do with templates.
 //       Currently we use launch_bounds that depend on template arguments in
-//       Loops.cuh, Reduce.cuh and LossCTC.cuh. Hence, C10_MAX_THREADS_PER_BLOCK and
-//       C10_MIN_BLOCKS_PER_SM are kept as macros.
-// Suppose you were planning to write __launch_bounds__(a, b), based on your performance tuning on a modern GPU.
-// Instead, you should write __launch_bounds__(C10_MAX_THREADS_PER_BLOCK(a), C10_MIN_BLOCKS_PER_SM(a, b)),
+//       Loops.cuh, Reduce.cuh and LossCTC.cuh. Hence, C10_MAX_THREADS_PER_BLOCK
+//       and C10_MIN_BLOCKS_PER_SM are kept as macros.
+// Suppose you were planning to write __launch_bounds__(a, b), based on your
+// performance tuning on a modern GPU. Instead, you should write
+// __launch_bounds__(C10_MAX_THREADS_PER_BLOCK(a), C10_MIN_BLOCKS_PER_SM(a, b)),
 // which will also properly respect limits on old architectures.
-#define C10_MAX_THREADS_PER_BLOCK(val) (((val) <= CUDA_MAX_THREADS_PER_BLOCK) ? (val) : CUDA_THREADS_PER_BLOCK_FALLBACK)
-#define C10_MIN_BLOCKS_PER_SM(threads_per_block, blocks_per_sm) ((((threads_per_block)*(blocks_per_sm) <= CUDA_MAX_THREADS_PER_SM) ? (blocks_per_sm) : ((CUDA_MAX_THREADS_PER_SM + (threads_per_block) - 1) / (threads_per_block))))
+#define C10_MAX_THREADS_PER_BLOCK(val)           \
+  (((val) <= CUDA_MAX_THREADS_PER_BLOCK) ? (val) \
+                                         : CUDA_THREADS_PER_BLOCK_FALLBACK)
+#define C10_MIN_BLOCKS_PER_SM(threads_per_block, blocks_per_sm)        \
+  ((((threads_per_block) * (blocks_per_sm) <= CUDA_MAX_THREADS_PER_SM) \
+        ? (blocks_per_sm)                                              \
+        : ((CUDA_MAX_THREADS_PER_SM + (threads_per_block)-1) /         \
+           (threads_per_block))))
 // C10_LAUNCH_BOUNDS is analogous to __launch_bounds__
-#define C10_LAUNCH_BOUNDS_0 __launch_bounds__(256, 4) // default launch bounds that should give good occupancy and versatility across all architectures.
-#define C10_LAUNCH_BOUNDS_1(max_threads_per_block) __launch_bounds__((C10_MAX_THREADS_PER_BLOCK((max_threads_per_block))))
-#define C10_LAUNCH_BOUNDS_2(max_threads_per_block, min_blocks_per_sm) __launch_bounds__((C10_MAX_THREADS_PER_BLOCK((max_threads_per_block))), (C10_MIN_BLOCKS_PER_SM((max_threads_per_block), (min_blocks_per_sm))))
+#define C10_LAUNCH_BOUNDS_0 \
+  __launch_bounds__(        \
+      256, 4) // default launch bounds that should give good occupancy and
+              // versatility across all architectures.
+#define C10_LAUNCH_BOUNDS_1(max_threads_per_block) \
+  __launch_bounds__((C10_MAX_THREADS_PER_BLOCK((max_threads_per_block))))
+#define C10_LAUNCH_BOUNDS_2(max_threads_per_block, min_blocks_per_sm) \
+  __launch_bounds__(                                                  \
+      (C10_MAX_THREADS_PER_BLOCK((max_threads_per_block))),           \
+      (C10_MIN_BLOCKS_PER_SM((max_threads_per_block), (min_blocks_per_sm))))
 #else
 #define C10_HOST_DEVICE
 #define C10_HOST

--- a/c10/test/core/TensorTypeSet_test.cpp
+++ b/c10/test/core/TensorTypeSet_test.cpp
@@ -6,7 +6,8 @@ using namespace c10;
 
 TEST(TensorTypeSet, Empty) {
   TensorTypeSet empty_set;
-  for (uint8_t i = 1; i < static_cast<uint8_t>(TensorTypeId::NumTensorIds); i++) {
+  for (uint8_t i = 1; i < static_cast<uint8_t>(TensorTypeId::NumTensorIds);
+       i++) {
     auto tid = static_cast<TensorTypeId>(i);
     ASSERT_FALSE(empty_set.has(tid));
   }
@@ -17,7 +18,8 @@ TEST(TensorTypeSet, Empty) {
 }
 
 TEST(TensorTypeSet, Singleton) {
-  for (uint8_t i = 1; i < static_cast<uint8_t>(TensorTypeId::NumTensorIds); i++) {
+  for (uint8_t i = 1; i < static_cast<uint8_t>(TensorTypeId::NumTensorIds);
+       i++) {
     auto tid = static_cast<TensorTypeId>(i);
     TensorTypeSet sing(tid);
     ASSERT_EQ(sing, sing);
@@ -32,8 +34,11 @@ TEST(TensorTypeSet, Singleton) {
 }
 
 TEST(TensorTypeSet, Doubleton) {
-  for (uint8_t i = 1; i < static_cast<uint8_t>(TensorTypeId::NumTensorIds); i++) {
-    for (uint8_t j = i + 1; j < static_cast<uint8_t>(TensorTypeId::NumTensorIds); j++) {
+  for (uint8_t i = 1; i < static_cast<uint8_t>(TensorTypeId::NumTensorIds);
+       i++) {
+    for (uint8_t j = i + 1;
+         j < static_cast<uint8_t>(TensorTypeId::NumTensorIds);
+         j++) {
       ASSERT_LT(i, j);
       auto tid1 = static_cast<TensorTypeId>(i);
       auto tid2 = static_cast<TensorTypeId>(j);
@@ -41,14 +46,15 @@ TEST(TensorTypeSet, Doubleton) {
       ASSERT_EQ(doub, TensorTypeSet(tid1) | TensorTypeSet(tid2));
       ASSERT_TRUE(doub.has(tid1));
       ASSERT_TRUE(doub.has(tid2));
-      ASSERT_EQ(doub.highestPriorityTypeId(), tid2);  // relies on i < j
+      ASSERT_EQ(doub.highestPriorityTypeId(), tid2); // relies on i < j
     }
   }
 }
 
 TEST(TensorTypeSet, Full) {
   TensorTypeSet full(TensorTypeSet::FULL);
-  for (uint8_t i = 1; i < static_cast<uint8_t>(TensorTypeId::NumTensorIds); i++) {
+  for (uint8_t i = 1; i < static_cast<uint8_t>(TensorTypeId::NumTensorIds);
+       i++) {
     auto tid = static_cast<TensorTypeId>(i);
     ASSERT_TRUE(full.has(tid));
   }

--- a/c10/test/core/impl/InlineDeviceGuard_test.cpp
+++ b/c10/test/core/impl/InlineDeviceGuard_test.cpp
@@ -1,7 +1,7 @@
 #include <gtest/gtest.h>
 
-#include "c10/core/impl/InlineDeviceGuard.h"
 #include "c10/core/impl/FakeGuardImpl.h"
+#include "c10/core/impl/InlineDeviceGuard.h"
 
 using namespace c10;
 using namespace c10::impl;
@@ -52,8 +52,8 @@ TEST(InlineDeviceGuard, Constructor) {
 }
 
 TEST(InlineDeviceGuard, ConstructorError) {
-  EXPECT_ANY_THROW(InlineDeviceGuard<FakeGuardImpl<DeviceType::CUDA>>
-                   g(Device(DeviceType::HIP, 1)));
+  EXPECT_ANY_THROW(InlineDeviceGuard<FakeGuardImpl<DeviceType::CUDA>> g(
+      Device(DeviceType::HIP, 1)));
 }
 
 TEST(InlineDeviceGuard, SetDevice) {
@@ -104,7 +104,8 @@ TEST(InlineDeviceGuard, SetIndex) {
   ASSERT_EQ(TestGuardImpl::getDeviceIndex(), i2);
 }
 
-// -- InlineOptionalDeviceGuard --------------------------------------------------
+// -- InlineOptionalDeviceGuard
+// --------------------------------------------------
 
 using MaybeTestGuard = InlineOptionalDeviceGuard<TestGuardImpl>;
 

--- a/c10/test/core/impl/InlineStreamGuard_test.cpp
+++ b/c10/test/core/impl/InlineStreamGuard_test.cpp
@@ -1,7 +1,7 @@
 #include <gtest/gtest.h>
 
-#include <c10/core/impl/InlineStreamGuard.h>
 #include <c10/core/impl/FakeGuardImpl.h>
+#include <c10/core/impl/InlineStreamGuard.h>
 
 using namespace c10;
 using namespace c10::impl;
@@ -38,7 +38,6 @@ TEST(InlineStreamGuard, Constructor) {
   ASSERT_EQ(TestGuardImpl::getCurrentStreamIdFor(1), 0);
   ASSERT_EQ(TestGuardImpl::getCurrentStreamIdFor(0), 0);
 }
-
 
 TEST(InlineStreamGuard, ResetStreamSameSameDevice) {
   TestGuardImpl::setDeviceIndex(0);
@@ -97,7 +96,8 @@ TEST(InlineStreamGuard, ResetStreamDifferentDevice) {
   ASSERT_EQ(TestGuardImpl::getCurrentStreamIdFor(0), 0);
 }
 
-// -- OptionalInlineStreamGuard -------------------------------------------------------
+// -- OptionalInlineStreamGuard
+// -------------------------------------------------------
 
 using OptionalTestGuard = InlineOptionalStreamGuard<TestGuardImpl>;
 

--- a/c10/test/util/Array_test.cpp
+++ b/c10/test/util/Array_test.cpp
@@ -6,87 +6,89 @@ using c10::guts::to_array;
 
 namespace {
 namespace test_equals {
-  static_assert(array<int, 0>{{}} == array<int, 0>{{}}, "");
-  static_assert(array<int, 3>{{2, 3, 4}} == array<int, 3>{{2, 3, 4}}, "");
-  static_assert(!(array<int, 3>{{2, 3, 4}} == array<int, 3>{{1, 3, 4}}), "");
-  static_assert(!(array<int, 3>{{2, 3, 4}} == array<int, 3>{{2, 1, 4}}), "");
-  static_assert(!(array<int, 3>{{2, 3, 4}} == array<int, 3>{{2, 3, 1}}), "");
-}
+static_assert(array<int, 0>{{}} == array<int, 0>{{}}, "");
+static_assert(array<int, 3>{{2, 3, 4}} == array<int, 3>{{2, 3, 4}}, "");
+static_assert(!(array<int, 3>{{2, 3, 4}} == array<int, 3>{{1, 3, 4}}), "");
+static_assert(!(array<int, 3>{{2, 3, 4}} == array<int, 3>{{2, 1, 4}}), "");
+static_assert(!(array<int, 3>{{2, 3, 4}} == array<int, 3>{{2, 3, 1}}), "");
+} // namespace test_equals
 
 namespace test_notequals {
-  static_assert(!(array<int, 0>{{}} != array<int, 0>{{}}), "");
-  static_assert(!(array<int, 3>{{2, 3, 4}} != array<int, 3>{{2, 3, 4}}), "");
-  static_assert(array<int, 3>{{2, 3, 4}} != array<int, 3>{{1, 3, 4}}, "");
-  static_assert(array<int, 3>{{2, 3, 4}} != array<int, 3>{{2, 1, 4}}, "");
-  static_assert(array<int, 3>{{2, 3, 4}} != array<int, 3>{{2, 3, 1}}, "");
-}
+static_assert(!(array<int, 0>{{}} != array<int, 0>{{}}), "");
+static_assert(!(array<int, 3>{{2, 3, 4}} != array<int, 3>{{2, 3, 4}}), "");
+static_assert(array<int, 3>{{2, 3, 4}} != array<int, 3>{{1, 3, 4}}, "");
+static_assert(array<int, 3>{{2, 3, 4}} != array<int, 3>{{2, 1, 4}}, "");
+static_assert(array<int, 3>{{2, 3, 4}} != array<int, 3>{{2, 3, 1}}, "");
+} // namespace test_notequals
 
 namespace test_lessthan {
-  static_assert(!(array<int, 0>{{}} < array<int, 0>{{}}), "");
-  static_assert(!(array<int, 1>{{2}} < array<int, 1>{{1}}), "");
-  static_assert(array<int, 1>{{1}} < array<int, 1>{{2}}, "");
-  static_assert(!(array<int, 3>{{1, 2, 3}} < array<int, 3>{{1, 2, 3}}), "");
-  static_assert(array<int, 3>{{1, 2, 3}} < array<int, 3>{{2, 2, 3}}, "");
-  static_assert(!(array<int, 3>{{1, 2, 3}} < array<int, 3>{{0, 2, 3}}), "");
-  static_assert(array<int, 3>{{1, 2, 3}} < array<int, 3>{{1, 3, 3}}, "");
-  static_assert(!(array<int, 3>{{1, 2, 3}} < array<int, 3>{{1, 1, 3}}), "");
-  static_assert(array<int, 3>{{1, 2, 3}} < array<int, 3>{{1, 2, 4}}, "");
-  static_assert(!(array<int, 3>{{1, 2, 3}} < array<int, 3>{{1, 2, 2}}), "");
-}
+static_assert(!(array<int, 0>{{}} < array<int, 0>{{}}), "");
+static_assert(!(array<int, 1>{{2}} < array<int, 1>{{1}}), "");
+static_assert(array<int, 1>{{1}} < array<int, 1>{{2}}, "");
+static_assert(!(array<int, 3>{{1, 2, 3}} < array<int, 3>{{1, 2, 3}}), "");
+static_assert(array<int, 3>{{1, 2, 3}} < array<int, 3>{{2, 2, 3}}, "");
+static_assert(!(array<int, 3>{{1, 2, 3}} < array<int, 3>{{0, 2, 3}}), "");
+static_assert(array<int, 3>{{1, 2, 3}} < array<int, 3>{{1, 3, 3}}, "");
+static_assert(!(array<int, 3>{{1, 2, 3}} < array<int, 3>{{1, 1, 3}}), "");
+static_assert(array<int, 3>{{1, 2, 3}} < array<int, 3>{{1, 2, 4}}, "");
+static_assert(!(array<int, 3>{{1, 2, 3}} < array<int, 3>{{1, 2, 2}}), "");
+} // namespace test_lessthan
 
 namespace test_greaterthan {
-  static_assert(!(array<int, 0>{{}} > array<int, 0>{{}}), "");
-  static_assert(!(array<int, 1>{{1}} > array<int, 1>{{2}}), "");
-  static_assert(array<int, 1>{{2}} > array<int, 1>{{1}}, "");
-  static_assert(!(array<int, 3>{{1, 2, 3}} > array<int, 3>{{1, 2, 3}}), "");
-  static_assert(array<int, 3>{{2, 2, 3}} > array<int, 3>{{1, 2, 3}}, "");
-  static_assert(!(array<int, 3>{{0, 2, 3}} > array<int, 3>{{1, 2, 3}}), "");
-  static_assert(array<int, 3>{{1, 3, 3}} > array<int, 3>{{1, 2, 3}}, "");
-  static_assert(!(array<int, 3>{{1, 1, 3}} > array<int, 3>{{1, 2, 3}}), "");
-  static_assert(array<int, 3>{{1, 2, 4}} > array<int, 3>{{1, 2, 3}}, "");
-  static_assert(!(array<int, 3>{{1, 2, 2}} > array<int, 3>{{1, 2, 3}}), "");
-}
+static_assert(!(array<int, 0>{{}} > array<int, 0>{{}}), "");
+static_assert(!(array<int, 1>{{1}} > array<int, 1>{{2}}), "");
+static_assert(array<int, 1>{{2}} > array<int, 1>{{1}}, "");
+static_assert(!(array<int, 3>{{1, 2, 3}} > array<int, 3>{{1, 2, 3}}), "");
+static_assert(array<int, 3>{{2, 2, 3}} > array<int, 3>{{1, 2, 3}}, "");
+static_assert(!(array<int, 3>{{0, 2, 3}} > array<int, 3>{{1, 2, 3}}), "");
+static_assert(array<int, 3>{{1, 3, 3}} > array<int, 3>{{1, 2, 3}}, "");
+static_assert(!(array<int, 3>{{1, 1, 3}} > array<int, 3>{{1, 2, 3}}), "");
+static_assert(array<int, 3>{{1, 2, 4}} > array<int, 3>{{1, 2, 3}}, "");
+static_assert(!(array<int, 3>{{1, 2, 2}} > array<int, 3>{{1, 2, 3}}), "");
+} // namespace test_greaterthan
 
 namespace test_lessequals {
-  static_assert(array<int, 0>{{}} <= array<int, 0>{{}}, "");
-  static_assert(!(array<int, 1>{{2}} <= array<int, 1>{{1}}), "");
-  static_assert(array<int, 1>{{1}} <= array<int, 1>{{2}}, "");
-  static_assert(array<int, 3>{{1, 2, 3}} <= array<int, 3>{{1, 2, 3}}, "");
-  static_assert(array<int, 3>{{1, 2, 3}} <= array<int, 3>{{2, 2, 3}}, "");
-  static_assert(!(array<int, 3>{{1, 2, 3}} <= array<int, 3>{{0, 2, 3}}), "");
-  static_assert(array<int, 3>{{1, 2, 3}} <= array<int, 3>{{1, 3, 3}}, "");
-  static_assert(!(array<int, 3>{{1, 2, 3}} <= array<int, 3>{{1, 1, 3}}), "");
-  static_assert(array<int, 3>{{1, 2, 3}} <= array<int, 3>{{1, 2, 4}}, "");
-  static_assert(!(array<int, 3>{{1, 2, 3}} <= array<int, 3>{{1, 2, 2}}), "");
-}
+static_assert(array<int, 0>{{}} <= array<int, 0>{{}}, "");
+static_assert(!(array<int, 1>{{2}} <= array<int, 1>{{1}}), "");
+static_assert(array<int, 1>{{1}} <= array<int, 1>{{2}}, "");
+static_assert(array<int, 3>{{1, 2, 3}} <= array<int, 3>{{1, 2, 3}}, "");
+static_assert(array<int, 3>{{1, 2, 3}} <= array<int, 3>{{2, 2, 3}}, "");
+static_assert(!(array<int, 3>{{1, 2, 3}} <= array<int, 3>{{0, 2, 3}}), "");
+static_assert(array<int, 3>{{1, 2, 3}} <= array<int, 3>{{1, 3, 3}}, "");
+static_assert(!(array<int, 3>{{1, 2, 3}} <= array<int, 3>{{1, 1, 3}}), "");
+static_assert(array<int, 3>{{1, 2, 3}} <= array<int, 3>{{1, 2, 4}}, "");
+static_assert(!(array<int, 3>{{1, 2, 3}} <= array<int, 3>{{1, 2, 2}}), "");
+} // namespace test_lessequals
 
 namespace test_greaterequals {
-  static_assert(array<int, 0>{{}} >= array<int, 0>{{}}, "");
-  static_assert(!(array<int, 1>{{1}} >= array<int, 1>{{2}}), "");
-  static_assert(array<int, 1>{{2}} >= array<int, 1>{{1}}, "");
-  static_assert(array<int, 3>{{1, 2, 3}} >= array<int, 3>{{1, 2, 3}}, "");
-  static_assert(array<int, 3>{{2, 2, 3}} >= array<int, 3>{{1, 2, 3}}, "");
-  static_assert(!(array<int, 3>{{0, 2, 3}} >= array<int, 3>{{1, 2, 3}}), "");
-  static_assert(array<int, 3>{{1, 3, 3}} >= array<int, 3>{{1, 2, 3}}, "");
-  static_assert(!(array<int, 3>{{1, 1, 3}} >= array<int, 3>{{1, 2, 3}}), "");
-  static_assert(array<int, 3>{{1, 2, 4}} >= array<int, 3>{{1, 2, 3}}, "");
-  static_assert(!(array<int, 3>{{1, 2, 2}} >= array<int, 3>{{1, 2, 3}}), "");
-}
+static_assert(array<int, 0>{{}} >= array<int, 0>{{}}, "");
+static_assert(!(array<int, 1>{{1}} >= array<int, 1>{{2}}), "");
+static_assert(array<int, 1>{{2}} >= array<int, 1>{{1}}, "");
+static_assert(array<int, 3>{{1, 2, 3}} >= array<int, 3>{{1, 2, 3}}, "");
+static_assert(array<int, 3>{{2, 2, 3}} >= array<int, 3>{{1, 2, 3}}, "");
+static_assert(!(array<int, 3>{{0, 2, 3}} >= array<int, 3>{{1, 2, 3}}), "");
+static_assert(array<int, 3>{{1, 3, 3}} >= array<int, 3>{{1, 2, 3}}, "");
+static_assert(!(array<int, 3>{{1, 1, 3}} >= array<int, 3>{{1, 2, 3}}), "");
+static_assert(array<int, 3>{{1, 2, 4}} >= array<int, 3>{{1, 2, 3}}, "");
+static_assert(!(array<int, 3>{{1, 2, 2}} >= array<int, 3>{{1, 2, 3}}), "");
+} // namespace test_greaterequals
 
 namespace test_tail {
-    static_assert(array < int, 2 > {{3, 4}} == tail(array < int, 3 > {{2, 3, 4}}), "");
-    static_assert(array < int, 0 > {{}} == tail(array < int, 1 > {{3}}), "");
-}
+static_assert(array<int, 2>{{3, 4}} == tail(array<int, 3>{{2, 3, 4}}), "");
+static_assert(array<int, 0>{{}} == tail(array<int, 1>{{3}}), "");
+} // namespace test_tail
 
 namespace test_prepend {
-    static_assert(array < int, 3 > {{2, 3, 4}} == prepend(2, array < int, 2 > {{3, 4}}), "");
-    static_assert(array < int, 1 > {{3}} == prepend(3, array < int, 0 > {{}}), "");
-}
+static_assert(
+    array<int, 3>{{2, 3, 4}} == prepend(2, array<int, 2>{{3, 4}}),
+    "");
+static_assert(array<int, 1>{{3}} == prepend(3, array<int, 0>{{}}), "");
+} // namespace test_prepend
 
 namespace test_to_std_array {
-    constexpr int obj2[3] = {3, 5, 6};
-    static_assert(array < int, 3 > {{3, 5, 6}} == to_array(obj2), "");
-    static_assert(array < int, 3 > {{3, 5, 6}} == to_array<int, 3>({3, 5, 6}), "");
-}
+constexpr int obj2[3] = {3, 5, 6};
+static_assert(array<int, 3>{{3, 5, 6}} == to_array(obj2), "");
+static_assert(array<int, 3>{{3, 5, 6}} == to_array<int, 3>({3, 5, 6}), "");
+} // namespace test_to_std_array
 
-}
+} // namespace

--- a/c10/test/util/LeftRight_test.cpp
+++ b/c10/test/util/LeftRight_test.cpp
@@ -8,236 +8,234 @@ using std::vector;
 TEST(LeftRightTest, givenInt_whenWritingAndReading_thenChangesArePresent) {
   LeftRight<int> obj;
 
-  obj.write([] (int& obj) {obj = 5;});
-  int read = obj.read([] (const int& obj) {return obj;});
+  obj.write([](int& obj) { obj = 5; });
+  int read = obj.read([](const int& obj) { return obj; });
   EXPECT_EQ(5, read);
 
   // check changes are also present in background copy
-  obj.write([] (int&) {}); // this switches to the background copy
-  read = obj.read([] (const int& obj) {return obj;});
+  obj.write([](int&) {}); // this switches to the background copy
+  read = obj.read([](const int& obj) { return obj; });
   EXPECT_EQ(5, read);
 }
 
 TEST(LeftRightTest, givenVector_whenWritingAndReading_thenChangesArePresent) {
-    LeftRight<vector<int>> obj;
+  LeftRight<vector<int>> obj;
 
-    obj.write([] (vector<int>& obj) {obj.push_back(5);});
-    vector<int> read = obj.read([] (const vector<int>& obj) {return obj;});
-    EXPECT_EQ((vector<int>{5}), read);
+  obj.write([](vector<int>& obj) { obj.push_back(5); });
+  vector<int> read = obj.read([](const vector<int>& obj) { return obj; });
+  EXPECT_EQ((vector<int>{5}), read);
 
-    obj.write([] (vector<int>& obj) {obj.push_back(6);});
-    read = obj.read([] (const vector<int>& obj) {return obj;});
-    EXPECT_EQ((vector<int>{5, 6}), read);
+  obj.write([](vector<int>& obj) { obj.push_back(6); });
+  read = obj.read([](const vector<int>& obj) { return obj; });
+  EXPECT_EQ((vector<int>{5, 6}), read);
 }
 
 TEST(LeftRightTest, givenVector_whenWritingReturnsValue_thenValueIsReturned) {
-    LeftRight<vector<int>> obj;
+  LeftRight<vector<int>> obj;
 
-    auto a = obj.write([] (vector<int>&) -> int {return 5;});
-    static_assert(std::is_same<int, decltype(a)>::value, "");
-    EXPECT_EQ(5, a);
+  auto a = obj.write([](vector<int>&) -> int { return 5; });
+  static_assert(std::is_same<int, decltype(a)>::value, "");
+  EXPECT_EQ(5, a);
 }
 
 TEST(LeftRightTest, readsCanBeConcurrent) {
-    LeftRight<int> obj;
-    std::atomic<int> num_running_readers{0};
+  LeftRight<int> obj;
+  std::atomic<int> num_running_readers{0};
 
-    std::thread reader1([&] () {
-       obj.read([&] (const int&) {
-           ++num_running_readers;
-           while(num_running_readers.load() < 2) {}
-       });
+  std::thread reader1([&]() {
+    obj.read([&](const int&) {
+      ++num_running_readers;
+      while (num_running_readers.load() < 2) {
+      }
     });
+  });
 
-    std::thread reader2([&] () {
-        obj.read([&] (const int&) {
-            ++num_running_readers;
-            while(num_running_readers.load() < 2) {}
-        });
+  std::thread reader2([&]() {
+    obj.read([&](const int&) {
+      ++num_running_readers;
+      while (num_running_readers.load() < 2) {
+      }
     });
+  });
 
-    // the threads only finish after both entered the read function.
-    // if LeftRight didn't allow concurrency, this would cause a deadlock.
-    reader1.join();
-    reader2.join();
+  // the threads only finish after both entered the read function.
+  // if LeftRight didn't allow concurrency, this would cause a deadlock.
+  reader1.join();
+  reader2.join();
 }
 
 TEST(LeftRightTest, writesCanBeConcurrentWithReads_readThenWrite) {
-    LeftRight<int> obj;
-    std::atomic<bool> reader_running{false};
-    std::atomic<bool> writer_running{false};
+  LeftRight<int> obj;
+  std::atomic<bool> reader_running{false};
+  std::atomic<bool> writer_running{false};
 
-    std::thread reader([&] () {
-        obj.read([&] (const int&) {
-            reader_running = true;
-            while(!writer_running.load()) {}
-        });
+  std::thread reader([&]() {
+    obj.read([&](const int&) {
+      reader_running = true;
+      while (!writer_running.load()) {
+      }
     });
+  });
 
-    std::thread writer([&] () {
-        // run read first, write second
-        while (!reader_running.load()) {}
+  std::thread writer([&]() {
+    // run read first, write second
+    while (!reader_running.load()) {
+    }
 
-        obj.write([&] (int&) {
-            writer_running = true;
-        });
-    });
+    obj.write([&](int&) { writer_running = true; });
+  });
 
-    // the threads only finish after both entered the read function.
-    // if LeftRight didn't allow concurrency, this would cause a deadlock.
-    reader.join();
-    writer.join();
+  // the threads only finish after both entered the read function.
+  // if LeftRight didn't allow concurrency, this would cause a deadlock.
+  reader.join();
+  writer.join();
 }
 
 TEST(LeftRightTest, writesCanBeConcurrentWithReads_writeThenRead) {
-    LeftRight<int> obj;
-    std::atomic<bool> writer_running{false};
-    std::atomic<bool> reader_running{false};
+  LeftRight<int> obj;
+  std::atomic<bool> writer_running{false};
+  std::atomic<bool> reader_running{false};
 
-    std::thread writer([&] () {
-        obj.read([&] (const int&) {
-            writer_running = true;
-            while(!reader_running.load()) {}
-        });
+  std::thread writer([&]() {
+    obj.read([&](const int&) {
+      writer_running = true;
+      while (!reader_running.load()) {
+      }
     });
+  });
 
-    std::thread reader([&] () {
-        // run write first, read second
-        while (!writer_running.load()) {}
+  std::thread reader([&]() {
+    // run write first, read second
+    while (!writer_running.load()) {
+    }
 
-        obj.read([&] (const int&) {
-            reader_running = true;
-        });
-    });
+    obj.read([&](const int&) { reader_running = true; });
+  });
 
-    // the threads only finish after both entered the read function.
-    // if LeftRight didn't allow concurrency, this would cause a deadlock.
-    writer.join();
-    reader.join();
+  // the threads only finish after both entered the read function.
+  // if LeftRight didn't allow concurrency, this would cause a deadlock.
+  writer.join();
+  reader.join();
 }
 
 TEST(LeftRightTest, writesCannotBeConcurrentWithWrites) {
-    LeftRight<int> obj;
-    std::atomic<bool> first_writer_started{false};
-    std::atomic<bool> first_writer_finished{false};
+  LeftRight<int> obj;
+  std::atomic<bool> first_writer_started{false};
+  std::atomic<bool> first_writer_finished{false};
 
-    std::thread writer1([&] () {
-        obj.write([&] (int&) {
-            first_writer_started = true;
-            std::this_thread::sleep_for(std::chrono::milliseconds(50));
-            first_writer_finished = true;
-        });
+  std::thread writer1([&]() {
+    obj.write([&](int&) {
+      first_writer_started = true;
+      std::this_thread::sleep_for(std::chrono::milliseconds(50));
+      first_writer_finished = true;
     });
+  });
 
-    std::thread writer2([&] () {
-        // make sure the other writer runs first
-        while (!first_writer_started.load()) {}
+  std::thread writer2([&]() {
+    // make sure the other writer runs first
+    while (!first_writer_started.load()) {
+    }
 
-        obj.write([&] (int&) {
-            // expect the other writer finished before this one starts
-            EXPECT_TRUE(first_writer_finished.load());
-        });
+    obj.write([&](int&) {
+      // expect the other writer finished before this one starts
+      EXPECT_TRUE(first_writer_finished.load());
     });
+  });
 
-    writer1.join();
-    writer2.join();
+  writer1.join();
+  writer2.join();
 }
 
 namespace {
 class MyException : public std::exception {};
-}
+} // namespace
 
 TEST(LeftRightTest, whenReadThrowsException_thenThrowsThrough) {
-    LeftRight<int> obj;
+  LeftRight<int> obj;
 
-    EXPECT_THROW(
-        obj.read([](const int&) {throw MyException();}),
-        MyException
-    );
+  EXPECT_THROW(obj.read([](const int&) { throw MyException(); }), MyException);
 }
 
 TEST(LeftRightTest, whenWriteThrowsException_thenThrowsThrough) {
-    LeftRight<int> obj;
+  LeftRight<int> obj;
 
-    EXPECT_THROW(
-        obj.write([](int&) {throw MyException();}),
-        MyException
-    );
+  EXPECT_THROW(obj.write([](int&) { throw MyException(); }), MyException);
 }
 
-TEST(LeftRightTest, givenInt_whenWriteThrowsExceptionOnFirstCall_thenResetsToOldState) {
-    LeftRight<int> obj;
+TEST(
+    LeftRightTest,
+    givenInt_whenWriteThrowsExceptionOnFirstCall_thenResetsToOldState) {
+  LeftRight<int> obj;
 
-    obj.write([](int& obj) {obj = 5;});
+  obj.write([](int& obj) { obj = 5; });
 
-    EXPECT_THROW(
-        obj.write([](int& obj) {
-            obj = 6;
-            throw MyException();
-        }),
-        MyException
-    );
+  EXPECT_THROW(
+      obj.write([](int& obj) {
+        obj = 6;
+        throw MyException();
+      }),
+      MyException);
 
-    // check reading it returns old value
-    int read = obj.read([] (const int& obj) {return obj;});
-    EXPECT_EQ(5, read);
+  // check reading it returns old value
+  int read = obj.read([](const int& obj) { return obj; });
+  EXPECT_EQ(5, read);
 
-    // check changes are also present in background copy
-    obj.write([] (int&) {}); // this switches to the background copy
-    read = obj.read([] (const int& obj) {return obj;});
-    EXPECT_EQ(5, read);
+  // check changes are also present in background copy
+  obj.write([](int&) {}); // this switches to the background copy
+  read = obj.read([](const int& obj) { return obj; });
+  EXPECT_EQ(5, read);
 }
 
 // note: each write is executed twice, on the foreground and background copy.
 // We need to test a thrown exception in either call is handled correctly.
-TEST(LeftRightTest, givenInt_whenWriteThrowsExceptionOnSecondCall_thenKeepsNewState) {
-    LeftRight<int> obj;
+TEST(
+    LeftRightTest,
+    givenInt_whenWriteThrowsExceptionOnSecondCall_thenKeepsNewState) {
+  LeftRight<int> obj;
 
-    obj.write([](int& obj) {obj = 5;});
-    bool write_called = false;
+  obj.write([](int& obj) { obj = 5; });
+  bool write_called = false;
 
-    EXPECT_THROW(
-        obj.write([&](int& obj) {
-            obj = 6;
-            if (write_called) {
-                // this is the second time the write callback is executed
-                throw MyException();
-            } else {
-                write_called = true;
-            }
-        }),
-        MyException
-    );
+  EXPECT_THROW(
+      obj.write([&](int& obj) {
+        obj = 6;
+        if (write_called) {
+          // this is the second time the write callback is executed
+          throw MyException();
+        } else {
+          write_called = true;
+        }
+      }),
+      MyException);
 
-    // check reading it returns new value
-    int read = obj.read([] (const int& obj) {return obj;});
-    EXPECT_EQ(6, read);
+  // check reading it returns new value
+  int read = obj.read([](const int& obj) { return obj; });
+  EXPECT_EQ(6, read);
 
-    // check changes are also present in background copy
-    obj.write([] (int&) {}); // this switches to the background copy
-    read = obj.read([] (const int& obj) {return obj;});
-    EXPECT_EQ(6, read);
+  // check changes are also present in background copy
+  obj.write([](int&) {}); // this switches to the background copy
+  read = obj.read([](const int& obj) { return obj; });
+  EXPECT_EQ(6, read);
 }
 
 TEST(LeftRightTest, givenVector_whenWriteThrowsException_thenResetsToOldState) {
-    LeftRight<vector<int>> obj;
+  LeftRight<vector<int>> obj;
 
-    obj.write([](vector<int>& obj) {obj.push_back(5);});
+  obj.write([](vector<int>& obj) { obj.push_back(5); });
 
-    EXPECT_THROW(
-            obj.write([](vector<int>& obj) {
-                obj.push_back(6);
-                throw MyException();
-            }),
-            MyException
-    );
+  EXPECT_THROW(
+      obj.write([](vector<int>& obj) {
+        obj.push_back(6);
+        throw MyException();
+      }),
+      MyException);
 
-    // check reading it returns old value
-    vector<int> read = obj.read([] (const vector<int>& obj) {return obj;});
-    EXPECT_EQ((vector<int>{5}), read);
+  // check reading it returns old value
+  vector<int> read = obj.read([](const vector<int>& obj) { return obj; });
+  EXPECT_EQ((vector<int>{5}), read);
 
-    // check changes are also present in background copy
-    obj.write([] (vector<int>&) {}); // this switches to the background copy
-    read = obj.read([] (const vector<int>& obj) {return obj;});
-    EXPECT_EQ((vector<int>{5}), read);
+  // check changes are also present in background copy
+  obj.write([](vector<int>&) {}); // this switches to the background copy
+  read = obj.read([](const vector<int>& obj) { return obj; });
+  EXPECT_EQ((vector<int>{5}), read);
 }

--- a/c10/test/util/Metaprogramming_test.cpp
+++ b/c10/test/util/Metaprogramming_test.cpp
@@ -6,212 +6,290 @@ using namespace c10::guts;
 namespace {
 
 namespace test_function_traits {
-    static_assert(std::is_same<void, typename function_traits<void(int, float)>::return_type>::value, "");
-    static_assert(std::is_same<int, typename function_traits<int(int, float)>::return_type>::value, "");
-    static_assert(std::is_same<typelist::typelist<int, float>, typename function_traits<void(int, float)>::parameter_types>::value, "");
-    static_assert(std::is_same<typelist::typelist<int, float>, typename function_traits<int(int, float)>::parameter_types>::value, "");
-}
+static_assert(
+    std::is_same<
+        void,
+        typename function_traits<void(int, float)>::return_type>::value,
+    "");
+static_assert(
+    std::is_same<int, typename function_traits<int(int, float)>::return_type>::
+        value,
+    "");
+static_assert(
+    std::is_same<
+        typelist::typelist<int, float>,
+        typename function_traits<void(int, float)>::parameter_types>::value,
+    "");
+static_assert(
+    std::is_same<
+        typelist::typelist<int, float>,
+        typename function_traits<int(int, float)>::parameter_types>::value,
+    "");
+} // namespace test_function_traits
 
 struct MovableOnly {
-    constexpr MovableOnly(int val_): val(val_) {/* no default constructor */}
-    MovableOnly(const MovableOnly&) = delete;
-    MovableOnly(MovableOnly&&) = default;
-    MovableOnly& operator=(const MovableOnly&) = delete;
-    MovableOnly& operator=(MovableOnly&&) = default;
+  constexpr MovableOnly(int val_) : val(val_) { /* no default constructor */
+  }
+  MovableOnly(const MovableOnly&) = delete;
+  MovableOnly(MovableOnly&&) = default;
+  MovableOnly& operator=(const MovableOnly&) = delete;
+  MovableOnly& operator=(MovableOnly&&) = default;
 
-    friend bool operator==(const MovableOnly& lhs, const MovableOnly& rhs) {return lhs.val == rhs.val;}
-private:
-    int val;
+  friend bool operator==(const MovableOnly& lhs, const MovableOnly& rhs) {
+    return lhs.val == rhs.val;
+  }
+
+ private:
+  int val;
 };
 
-template<class T> using is_my_movable_only_class = std::is_same<MovableOnly, remove_cv_t<remove_reference_t<T>>>;
+template <class T>
+using is_my_movable_only_class =
+    std::is_same<MovableOnly, remove_cv_t<remove_reference_t<T>>>;
 
 struct CopyCounting {
-    int move_count;
-    int copy_count;
+  int move_count;
+  int copy_count;
 
-    CopyCounting(): move_count(0), copy_count(0) {}
-    CopyCounting(const CopyCounting& rhs): move_count(rhs.move_count), copy_count(rhs.copy_count + 1) {}
-    CopyCounting(CopyCounting&& rhs): move_count(rhs.move_count + 1), copy_count(rhs.copy_count) {}
-    CopyCounting& operator=(const CopyCounting& rhs) {
-        move_count = rhs.move_count;
-        copy_count = rhs.copy_count + 1;
-        return *this;
-    }
-    CopyCounting& operator=(CopyCounting&& rhs) {
-        move_count = rhs.move_count + 1;
-        copy_count = rhs.copy_count;
-        return *this;
-    }
+  CopyCounting() : move_count(0), copy_count(0) {}
+  CopyCounting(const CopyCounting& rhs)
+      : move_count(rhs.move_count), copy_count(rhs.copy_count + 1) {}
+  CopyCounting(CopyCounting&& rhs)
+      : move_count(rhs.move_count + 1), copy_count(rhs.copy_count) {}
+  CopyCounting& operator=(const CopyCounting& rhs) {
+    move_count = rhs.move_count;
+    copy_count = rhs.copy_count + 1;
+    return *this;
+  }
+  CopyCounting& operator=(CopyCounting&& rhs) {
+    move_count = rhs.move_count + 1;
+    copy_count = rhs.copy_count;
+    return *this;
+  }
 };
 
-template<class T> using is_my_copy_counting_class = std::is_same<CopyCounting, remove_cv_t<remove_reference_t<T>>>;
+template <class T>
+using is_my_copy_counting_class =
+    std::is_same<CopyCounting, remove_cv_t<remove_reference_t<T>>>;
 
 namespace test_extract_arg_by_filtered_index {
-    class MyClass {};
+class MyClass {};
 
-    TEST(MetaprogrammingTest, ExtractArgByFilteredIndex) {
-        auto a1 = extract_arg_by_filtered_index<std::is_integral, 0>(3, "bla", MyClass(), 4, nullptr, 5);
-        auto a2 = extract_arg_by_filtered_index<std::is_integral, 1>(3, "bla", MyClass(), 4, nullptr, 5);
-        auto a3 = extract_arg_by_filtered_index<std::is_integral, 2>(3, "bla", MyClass(), 4, nullptr, 5);
-        EXPECT_EQ(3, a1);
-        EXPECT_EQ(4, a2);
-        EXPECT_EQ(5, a3);
-    }
-
-    TEST(MetaprogrammingTest, ExtractArgByFilteredIndex_singleInput) {
-        auto a1 = extract_arg_by_filtered_index<std::is_integral, 0>(3);
-        EXPECT_EQ(3, a1);
-    }
-
-    TEST(MetaprogrammingTest, ExtractArgByFilteredIndex_movableOnly) {
-        MovableOnly a1 = extract_arg_by_filtered_index<is_my_movable_only_class, 0>(3, MovableOnly(3), "test", MovableOnly(1));
-        MovableOnly a2 = extract_arg_by_filtered_index<is_my_movable_only_class, 1>(3, MovableOnly(3), "test", MovableOnly(1));
-        EXPECT_EQ(MovableOnly(3), a1);
-        EXPECT_EQ(MovableOnly(1), a2);
-    }
-
-    TEST(MetaprogrammingTest, ExtractArgByFilteredIndex_onlyCopiesIfNecessary) {
-        CopyCounting source;
-        CopyCounting source2;
-        CopyCounting a1 = extract_arg_by_filtered_index<is_my_copy_counting_class, 0>(3, CopyCounting(), "test", source, std::move(source2));
-        CopyCounting a2 = extract_arg_by_filtered_index<is_my_copy_counting_class, 1>(3, CopyCounting(), "test", source, std::move(source2));
-        CopyCounting a3 = extract_arg_by_filtered_index<is_my_copy_counting_class, 2>(3, CopyCounting(), "test", source, std::move(source2));
-        EXPECT_EQ(1, a1.move_count);
-        EXPECT_EQ(0, a1.copy_count);
-        EXPECT_EQ(0, a2.move_count);
-        EXPECT_EQ(1, a3.move_count);
-        EXPECT_EQ(0, a3.copy_count);
-        EXPECT_EQ(1, a2.copy_count);
-    }
-
-    TEST(MetaprogrammingTest, ExtractArgByFilteredIndex_onlyMovesIfNecessary) {
-        CopyCounting source;
-        CopyCounting source2;
-        CopyCounting&& a1 = extract_arg_by_filtered_index<is_my_copy_counting_class , 0>(3, std::move(source), "test", std::move(source2));
-        CopyCounting a2 = extract_arg_by_filtered_index<is_my_copy_counting_class , 1>(3, std::move(source), "test", std::move(source2));
-        EXPECT_EQ(0, a1.move_count);
-        EXPECT_EQ(0, a1.copy_count);
-        EXPECT_EQ(1, a2.move_count);
-        EXPECT_EQ(0, a2.copy_count);
-    }
-
-    template<class T> using is_true = std::true_type;
-
-    TEST(MetaprogrammingTest, ExtractArgByFilteredIndex_keepsLValueReferencesIntact) {
-        MyClass obj;
-        MyClass& a1 = extract_arg_by_filtered_index<is_true, 1>(3, obj, "test", obj);
-        EXPECT_EQ(&obj, &a1);
-    }
+TEST(MetaprogrammingTest, ExtractArgByFilteredIndex) {
+  auto a1 = extract_arg_by_filtered_index<std::is_integral, 0>(
+      3, "bla", MyClass(), 4, nullptr, 5);
+  auto a2 = extract_arg_by_filtered_index<std::is_integral, 1>(
+      3, "bla", MyClass(), 4, nullptr, 5);
+  auto a3 = extract_arg_by_filtered_index<std::is_integral, 2>(
+      3, "bla", MyClass(), 4, nullptr, 5);
+  EXPECT_EQ(3, a1);
+  EXPECT_EQ(4, a2);
+  EXPECT_EQ(5, a3);
 }
+
+TEST(MetaprogrammingTest, ExtractArgByFilteredIndex_singleInput) {
+  auto a1 = extract_arg_by_filtered_index<std::is_integral, 0>(3);
+  EXPECT_EQ(3, a1);
+}
+
+TEST(MetaprogrammingTest, ExtractArgByFilteredIndex_movableOnly) {
+  MovableOnly a1 = extract_arg_by_filtered_index<is_my_movable_only_class, 0>(
+      3, MovableOnly(3), "test", MovableOnly(1));
+  MovableOnly a2 = extract_arg_by_filtered_index<is_my_movable_only_class, 1>(
+      3, MovableOnly(3), "test", MovableOnly(1));
+  EXPECT_EQ(MovableOnly(3), a1);
+  EXPECT_EQ(MovableOnly(1), a2);
+}
+
+TEST(MetaprogrammingTest, ExtractArgByFilteredIndex_onlyCopiesIfNecessary) {
+  CopyCounting source;
+  CopyCounting source2;
+  CopyCounting a1 = extract_arg_by_filtered_index<is_my_copy_counting_class, 0>(
+      3, CopyCounting(), "test", source, std::move(source2));
+  CopyCounting a2 = extract_arg_by_filtered_index<is_my_copy_counting_class, 1>(
+      3, CopyCounting(), "test", source, std::move(source2));
+  CopyCounting a3 = extract_arg_by_filtered_index<is_my_copy_counting_class, 2>(
+      3, CopyCounting(), "test", source, std::move(source2));
+  EXPECT_EQ(1, a1.move_count);
+  EXPECT_EQ(0, a1.copy_count);
+  EXPECT_EQ(0, a2.move_count);
+  EXPECT_EQ(1, a3.move_count);
+  EXPECT_EQ(0, a3.copy_count);
+  EXPECT_EQ(1, a2.copy_count);
+}
+
+TEST(MetaprogrammingTest, ExtractArgByFilteredIndex_onlyMovesIfNecessary) {
+  CopyCounting source;
+  CopyCounting source2;
+  CopyCounting&& a1 =
+      extract_arg_by_filtered_index<is_my_copy_counting_class, 0>(
+          3, std::move(source), "test", std::move(source2));
+  CopyCounting a2 = extract_arg_by_filtered_index<is_my_copy_counting_class, 1>(
+      3, std::move(source), "test", std::move(source2));
+  EXPECT_EQ(0, a1.move_count);
+  EXPECT_EQ(0, a1.copy_count);
+  EXPECT_EQ(1, a2.move_count);
+  EXPECT_EQ(0, a2.copy_count);
+}
+
+template <class T>
+using is_true = std::true_type;
+
+TEST(
+    MetaprogrammingTest,
+    ExtractArgByFilteredIndex_keepsLValueReferencesIntact) {
+  MyClass obj;
+  MyClass& a1 = extract_arg_by_filtered_index<is_true, 1>(3, obj, "test", obj);
+  EXPECT_EQ(&obj, &a1);
+}
+} // namespace test_extract_arg_by_filtered_index
 
 namespace test_filter_map {
-    class MyClass {};
+class MyClass {};
 
-    struct map_to_double {
-      template<class T> constexpr double operator()(T a) const {
-        return static_cast<double>(a);
-      }
-    };
+struct map_to_double {
+  template <class T>
+  constexpr double operator()(T a) const {
+    return static_cast<double>(a);
+  }
+};
 
-    TEST(MetaprogrammingTest, FilterMap) {
-        auto result = filter_map<double, std::is_integral>(map_to_double(), 3, "bla", MyClass(), 4, nullptr, 5);
-        static_assert(std::is_same<array<double, 3>, decltype(result)>::value, "");
-        constexpr array<double, 3> expected{{3.0, 4.0, 5.0}};
-        EXPECT_EQ(expected, result);
-    }
-
-    TEST(MetaprogrammingTest, FilterMap_emptyInput) {
-        auto result = filter_map<double, std::is_integral>(map_to_double());
-        static_assert(std::is_same<array<double, 0>, decltype(result)>::value, "");
-        constexpr array<double, 0> expected{{}};
-        EXPECT_EQ(expected, result);
-    }
-
-    TEST(MetaprogrammingTest, FilterMap_emptyOutput) {
-        auto result = filter_map<double, std::is_integral>(map_to_double(), "bla", MyClass(), nullptr);
-        static_assert(std::is_same<array<double, 0>, decltype(result)>::value, "");
-        constexpr array<double, 0> expected{{}};
-        EXPECT_EQ(expected, result);
-    }
-
-    TEST(MetaprogrammingTest, FilterMap_movableOnly_byRValue) {
-        struct map_movable_by_rvalue {
-          MovableOnly operator()(MovableOnly&& a) const {
-            return std::move(a);
-          }
-        };
-
-        auto result = filter_map<MovableOnly, is_my_movable_only_class>(map_movable_by_rvalue(), MovableOnly(5), "bla", nullptr, 3, MovableOnly(2));
-        static_assert(std::is_same<array<MovableOnly, 2>, decltype(result)>::value, "");
-        constexpr array<MovableOnly, 2> expected {{MovableOnly(5), MovableOnly(2)}};
-        EXPECT_EQ(expected, result);
-    }
-
-    TEST(MetaprogrammingTest, FilterMap_movableOnly_byValue) {
-        struct map_movable_by_lvalue {
-          MovableOnly operator()(MovableOnly a) const {
-            return a;
-          }
-        };
-
-        auto result = filter_map<MovableOnly, is_my_movable_only_class>(map_movable_by_lvalue(), MovableOnly(5), "bla", nullptr, 3, MovableOnly(2));
-        static_assert(std::is_same<array<MovableOnly, 2>, decltype(result)>::value, "");
-        constexpr array<MovableOnly, 2> expected {{MovableOnly(5), MovableOnly(2)}};
-        EXPECT_EQ(expected, result);
-    }
-
-    TEST(MetaprogrammingTest, FilterMap_onlyCopiesIfNecessary) {
-        struct map_copy_counting_by_copy {
-          CopyCounting operator()(CopyCounting v) const {
-            return v;
-          }
-        };
-
-        CopyCounting source;
-        CopyCounting source2;
-        auto result = filter_map<CopyCounting, is_my_copy_counting_class>(map_copy_counting_by_copy(), CopyCounting(), "bla", nullptr, 3, source, std::move(source2));
-        static_assert(std::is_same<array<CopyCounting, 3>, decltype(result)>::value, "");
-        EXPECT_EQ(0, result[0].copy_count);
-        EXPECT_EQ(2, result[0].move_count);
-        EXPECT_EQ(1, result[1].copy_count);
-        EXPECT_EQ(1, result[1].move_count);
-        EXPECT_EQ(0, result[2].copy_count);
-        EXPECT_EQ(2, result[2].move_count);
-    }
-
-    TEST(MetaprogrammingTest, FilterMap_onlyMovesIfNecessary_1) {
-        struct map_copy_counting_by_move {
-          CopyCounting operator()(CopyCounting&& v) const {
-            return std::move(v);
-          }
-        };
-
-        CopyCounting source;
-        auto result = filter_map<CopyCounting, is_my_copy_counting_class>(map_copy_counting_by_move(), CopyCounting(), "bla", nullptr, 3, std::move(source));
-        static_assert(std::is_same<array<CopyCounting, 2>, decltype(result)>::value, "");
-        EXPECT_EQ(0, result[0].copy_count);
-        EXPECT_EQ(1, result[0].move_count);
-        EXPECT_EQ(0, result[1].copy_count);
-        EXPECT_EQ(1, result[1].move_count);
-    }
-
-    TEST(MetaprogrammingTest, FilterMap_onlyMovesIfNecessary_2) {
-        struct map_copy_counting_by_pointer {
-          const CopyCounting* operator()(const CopyCounting& v) const {
-            return &v;
-          }
-        };
-
-        CopyCounting source1;
-        CopyCounting source2;
-        auto result = filter_map<const CopyCounting*, is_my_copy_counting_class>(map_copy_counting_by_pointer(), "bla", nullptr, 3, source1, std::move(source2));
-        static_assert(std::is_same<array<const CopyCounting*, 2>, decltype(result)>::value, "");
-        EXPECT_EQ(0, result[0]->copy_count);
-        EXPECT_EQ(0, result[0]->move_count);
-        EXPECT_EQ(0, result[1]->copy_count);
-        EXPECT_EQ(0, result[1]->move_count);
-    }
+TEST(MetaprogrammingTest, FilterMap) {
+  auto result = filter_map<double, std::is_integral>(
+      map_to_double(), 3, "bla", MyClass(), 4, nullptr, 5);
+  static_assert(std::is_same<array<double, 3>, decltype(result)>::value, "");
+  constexpr array<double, 3> expected{{3.0, 4.0, 5.0}};
+  EXPECT_EQ(expected, result);
 }
 
+TEST(MetaprogrammingTest, FilterMap_emptyInput) {
+  auto result = filter_map<double, std::is_integral>(map_to_double());
+  static_assert(std::is_same<array<double, 0>, decltype(result)>::value, "");
+  constexpr array<double, 0> expected{{}};
+  EXPECT_EQ(expected, result);
 }
+
+TEST(MetaprogrammingTest, FilterMap_emptyOutput) {
+  auto result = filter_map<double, std::is_integral>(
+      map_to_double(), "bla", MyClass(), nullptr);
+  static_assert(std::is_same<array<double, 0>, decltype(result)>::value, "");
+  constexpr array<double, 0> expected{{}};
+  EXPECT_EQ(expected, result);
+}
+
+TEST(MetaprogrammingTest, FilterMap_movableOnly_byRValue) {
+  struct map_movable_by_rvalue {
+    MovableOnly operator()(MovableOnly&& a) const {
+      return std::move(a);
+    }
+  };
+
+  auto result = filter_map<MovableOnly, is_my_movable_only_class>(
+      map_movable_by_rvalue(),
+      MovableOnly(5),
+      "bla",
+      nullptr,
+      3,
+      MovableOnly(2));
+  static_assert(
+      std::is_same<array<MovableOnly, 2>, decltype(result)>::value, "");
+  constexpr array<MovableOnly, 2> expected{{MovableOnly(5), MovableOnly(2)}};
+  EXPECT_EQ(expected, result);
+}
+
+TEST(MetaprogrammingTest, FilterMap_movableOnly_byValue) {
+  struct map_movable_by_lvalue {
+    MovableOnly operator()(MovableOnly a) const {
+      return a;
+    }
+  };
+
+  auto result = filter_map<MovableOnly, is_my_movable_only_class>(
+      map_movable_by_lvalue(),
+      MovableOnly(5),
+      "bla",
+      nullptr,
+      3,
+      MovableOnly(2));
+  static_assert(
+      std::is_same<array<MovableOnly, 2>, decltype(result)>::value, "");
+  constexpr array<MovableOnly, 2> expected{{MovableOnly(5), MovableOnly(2)}};
+  EXPECT_EQ(expected, result);
+}
+
+TEST(MetaprogrammingTest, FilterMap_onlyCopiesIfNecessary) {
+  struct map_copy_counting_by_copy {
+    CopyCounting operator()(CopyCounting v) const {
+      return v;
+    }
+  };
+
+  CopyCounting source;
+  CopyCounting source2;
+  auto result = filter_map<CopyCounting, is_my_copy_counting_class>(
+      map_copy_counting_by_copy(),
+      CopyCounting(),
+      "bla",
+      nullptr,
+      3,
+      source,
+      std::move(source2));
+  static_assert(
+      std::is_same<array<CopyCounting, 3>, decltype(result)>::value, "");
+  EXPECT_EQ(0, result[0].copy_count);
+  EXPECT_EQ(2, result[0].move_count);
+  EXPECT_EQ(1, result[1].copy_count);
+  EXPECT_EQ(1, result[1].move_count);
+  EXPECT_EQ(0, result[2].copy_count);
+  EXPECT_EQ(2, result[2].move_count);
+}
+
+TEST(MetaprogrammingTest, FilterMap_onlyMovesIfNecessary_1) {
+  struct map_copy_counting_by_move {
+    CopyCounting operator()(CopyCounting&& v) const {
+      return std::move(v);
+    }
+  };
+
+  CopyCounting source;
+  auto result = filter_map<CopyCounting, is_my_copy_counting_class>(
+      map_copy_counting_by_move(),
+      CopyCounting(),
+      "bla",
+      nullptr,
+      3,
+      std::move(source));
+  static_assert(
+      std::is_same<array<CopyCounting, 2>, decltype(result)>::value, "");
+  EXPECT_EQ(0, result[0].copy_count);
+  EXPECT_EQ(1, result[0].move_count);
+  EXPECT_EQ(0, result[1].copy_count);
+  EXPECT_EQ(1, result[1].move_count);
+}
+
+TEST(MetaprogrammingTest, FilterMap_onlyMovesIfNecessary_2) {
+  struct map_copy_counting_by_pointer {
+    const CopyCounting* operator()(const CopyCounting& v) const {
+      return &v;
+    }
+  };
+
+  CopyCounting source1;
+  CopyCounting source2;
+  auto result = filter_map<const CopyCounting*, is_my_copy_counting_class>(
+      map_copy_counting_by_pointer(),
+      "bla",
+      nullptr,
+      3,
+      source1,
+      std::move(source2));
+  static_assert(
+      std::is_same<array<const CopyCounting*, 2>, decltype(result)>::value, "");
+  EXPECT_EQ(0, result[0]->copy_count);
+  EXPECT_EQ(0, result[0]->move_count);
+  EXPECT_EQ(0, result[1]->copy_count);
+  EXPECT_EQ(0, result[1]->move_count);
+}
+} // namespace test_filter_map
+
+} // namespace

--- a/c10/test/util/TypeList_test.cpp
+++ b/c10/test/util/TypeList_test.cpp
@@ -5,150 +5,254 @@
 using namespace c10::guts::typelist;
 
 namespace test_size {
-    class MyClass {};
-    static_assert(0 == size<typelist<>>::value, "");
-    static_assert(1 == size<typelist<int>>::value, "");
-    static_assert(3 == size<typelist<int, float&, const MyClass&&>>::value, "");
-}
+class MyClass {};
+static_assert(0 == size<typelist<>>::value, "");
+static_assert(1 == size<typelist<int>>::value, "");
+static_assert(3 == size<typelist<int, float&, const MyClass&&>>::value, "");
+} // namespace test_size
 
 namespace test_from_tuple {
-    class MyClass {};
-    static_assert(std::is_same<typelist<int, float&, const MyClass&&>, from_tuple_t<std::tuple<int, float&, const MyClass&&>>>::value, "");
-    static_assert(std::is_same<typelist<>, from_tuple_t<std::tuple<>>>::value, "");
-}
+class MyClass {};
+static_assert(
+    std::is_same<
+        typelist<int, float&, const MyClass&&>,
+        from_tuple_t<std::tuple<int, float&, const MyClass&&>>>::value,
+    "");
+static_assert(std::is_same<typelist<>, from_tuple_t<std::tuple<>>>::value, "");
+} // namespace test_from_tuple
 
 namespace test_to_tuple {
-    class MyClass {};
-    static_assert(std::is_same<std::tuple<int, float&, const MyClass&&>, to_tuple_t<typelist<int, float&, const MyClass&&>>>::value, "");
-    static_assert(std::is_same<std::tuple<>, to_tuple_t<typelist<>>>::value, "");
-}
+class MyClass {};
+static_assert(
+    std::is_same<
+        std::tuple<int, float&, const MyClass&&>,
+        to_tuple_t<typelist<int, float&, const MyClass&&>>>::value,
+    "");
+static_assert(std::is_same<std::tuple<>, to_tuple_t<typelist<>>>::value, "");
+} // namespace test_to_tuple
 
 namespace test_concat {
-    class MyClass {};
-    static_assert(std::is_same<typelist<>, concat_t<>>::value, "");
-    static_assert(std::is_same<typelist<>, concat_t<typelist<>>>::value, "");
-    static_assert(std::is_same<typelist<>, concat_t<typelist<>, typelist<>>>::value, "");
-    static_assert(std::is_same<typelist<int>, concat_t<typelist<int>>>::value, "");
-    static_assert(std::is_same<typelist<int>, concat_t<typelist<int>, typelist<>>>::value, "");
-    static_assert(std::is_same<typelist<int>, concat_t<typelist<>, typelist<int>>>::value, "");
-    static_assert(std::is_same<typelist<int>, concat_t<typelist<>, typelist<int>, typelist<>>>::value, "");
-    static_assert(std::is_same<typelist<int, float&>, concat_t<typelist<int>, typelist<float&>>>::value, "");
-    static_assert(std::is_same<typelist<int, float&>, concat_t<typelist<>, typelist<int, float&>, typelist<>>>::value, "");
-    static_assert(std::is_same<typelist<int, float&, const MyClass&&>, concat_t<typelist<>, typelist<int, float&>, typelist<const MyClass&&>>>::value, "");
-}
+class MyClass {};
+static_assert(std::is_same<typelist<>, concat_t<>>::value, "");
+static_assert(std::is_same<typelist<>, concat_t<typelist<>>>::value, "");
+static_assert(
+    std::is_same<typelist<>, concat_t<typelist<>, typelist<>>>::value,
+    "");
+static_assert(std::is_same<typelist<int>, concat_t<typelist<int>>>::value, "");
+static_assert(
+    std::is_same<typelist<int>, concat_t<typelist<int>, typelist<>>>::value,
+    "");
+static_assert(
+    std::is_same<typelist<int>, concat_t<typelist<>, typelist<int>>>::value,
+    "");
+static_assert(
+    std::is_same<
+        typelist<int>,
+        concat_t<typelist<>, typelist<int>, typelist<>>>::value,
+    "");
+static_assert(
+    std::is_same<
+        typelist<int, float&>,
+        concat_t<typelist<int>, typelist<float&>>>::value,
+    "");
+static_assert(
+    std::is_same<
+        typelist<int, float&>,
+        concat_t<typelist<>, typelist<int, float&>, typelist<>>>::value,
+    "");
+static_assert(
+    std::is_same<
+        typelist<int, float&, const MyClass&&>,
+        concat_t<
+            typelist<>,
+            typelist<int, float&>,
+            typelist<const MyClass&&>>>::value,
+    "");
+} // namespace test_concat
 
 namespace test_filter {
-    class MyClass {};
-    static_assert(std::is_same<typelist<>, filter_t<std::is_reference, typelist<>>>::value, "");
-    static_assert(std::is_same<typelist<>, filter_t<std::is_reference, typelist<int, float, double, MyClass>>>::value, "");
-    static_assert(std::is_same<typelist<float&, const MyClass&&>, filter_t<std::is_reference, typelist<int, float&, double, const MyClass&&>>>::value, "");
-}
+class MyClass {};
+static_assert(
+    std::is_same<typelist<>, filter_t<std::is_reference, typelist<>>>::value,
+    "");
+static_assert(
+    std::is_same<
+        typelist<>,
+        filter_t<std::is_reference, typelist<int, float, double, MyClass>>>::
+        value,
+    "");
+static_assert(
+    std::is_same<
+        typelist<float&, const MyClass&&>,
+        filter_t<
+            std::is_reference,
+            typelist<int, float&, double, const MyClass&&>>>::value,
+    "");
+} // namespace test_filter
 
 namespace test_count_if {
-    class MyClass final {};
-    static_assert(count_if<std::is_reference, typelist<int, bool&, const MyClass&&, float, double>>::value == 2, "");
-    static_assert(count_if<std::is_reference, typelist<int, bool>>::value == 0, "");
-    static_assert(count_if<std::is_reference, typelist<>>::value == 0, "");
-}
+class MyClass final {};
+static_assert(
+    count_if<
+        std::is_reference,
+        typelist<int, bool&, const MyClass&&, float, double>>::value == 2,
+    "");
+static_assert(count_if<std::is_reference, typelist<int, bool>>::value == 0, "");
+static_assert(count_if<std::is_reference, typelist<>>::value == 0, "");
+} // namespace test_count_if
 
 namespace test_true_for_each_type {
-    template<class> class Test;
-    class MyClass {};
-    static_assert(true_for_each_type<std::is_reference, typelist<int&, const float&&, const MyClass&>>::value, "");
-    static_assert(!true_for_each_type<std::is_reference, typelist<int&, const float, const MyClass&>>::value, "");
-    static_assert(true_for_each_type<std::is_reference, typelist<>>::value, "");
-}
+template <class>
+class Test;
+class MyClass {};
+static_assert(
+    true_for_each_type<
+        std::is_reference,
+        typelist<int&, const float&&, const MyClass&>>::value,
+    "");
+static_assert(
+    !true_for_each_type<
+        std::is_reference,
+        typelist<int&, const float, const MyClass&>>::value,
+    "");
+static_assert(true_for_each_type<std::is_reference, typelist<>>::value, "");
+} // namespace test_true_for_each_type
 
 namespace test_map {
-    class MyClass {};
-    static_assert(std::is_same<typelist<>, map_t<c10::guts::add_lvalue_reference_t, typelist<>>>::value, "");
-    static_assert(std::is_same<typelist<int&>, map_t<c10::guts::add_lvalue_reference_t, typelist<int>>>::value, "");
-    static_assert(std::is_same<typelist<int&, double&, const MyClass&>, map_t<c10::guts::add_lvalue_reference_t, typelist<int, double, const MyClass>>>::value, "");
-}
+class MyClass {};
+static_assert(
+    std::is_same<
+        typelist<>,
+        map_t<c10::guts::add_lvalue_reference_t, typelist<>>>::value,
+    "");
+static_assert(
+    std::is_same<
+        typelist<int&>,
+        map_t<c10::guts::add_lvalue_reference_t, typelist<int>>>::value,
+    "");
+static_assert(
+    std::is_same<
+        typelist<int&, double&, const MyClass&>,
+        map_t<
+            c10::guts::add_lvalue_reference_t,
+            typelist<int, double, const MyClass>>>::value,
+    "");
+} // namespace test_map
 
 namespace test_head {
-    class MyClass {};
-    static_assert(std::is_same<int, head_t<typelist<int, double>>>::value, "");
-    static_assert(std::is_same<const MyClass&, head_t<typelist<const MyClass&, double>>>::value, "");
-    static_assert(std::is_same<MyClass&&, head_t<typelist<MyClass&&, MyClass>>>::value, "");
-    static_assert(std::is_same<bool, head_t<typelist<bool>>>::value, "");
-}
+class MyClass {};
+static_assert(std::is_same<int, head_t<typelist<int, double>>>::value, "");
+static_assert(
+    std::is_same<const MyClass&, head_t<typelist<const MyClass&, double>>>::
+        value,
+    "");
+static_assert(
+    std::is_same<MyClass&&, head_t<typelist<MyClass&&, MyClass>>>::value,
+    "");
+static_assert(std::is_same<bool, head_t<typelist<bool>>>::value, "");
+} // namespace test_head
 
 namespace test_reverse {
-    class MyClass {};
-    static_assert(std::is_same<
-            typelist<int, double, MyClass*, const MyClass&&>,
-            reverse_t<typelist<const MyClass&&, MyClass*, double, int>>
-    >::value, "");
-    static_assert(std::is_same<
-            typelist<>,
-            reverse_t<typelist<>>
-    >::value, "");
-}
+class MyClass {};
+static_assert(
+    std::is_same<
+        typelist<int, double, MyClass*, const MyClass&&>,
+        reverse_t<typelist<const MyClass&&, MyClass*, double, int>>>::value,
+    "");
+static_assert(std::is_same<typelist<>, reverse_t<typelist<>>>::value, "");
+} // namespace test_reverse
 
 namespace test_map_types_to_values {
-    struct map_to_size {
-      template<class T> constexpr size_t operator()(T) const {return sizeof(typename T::type);}
-    };
+struct map_to_size {
+  template <class T>
+  constexpr size_t operator()(T) const {
+    return sizeof(typename T::type);
+  }
+};
 
-    TEST(TypeListTest, MapTypesToValues_sametype) {
-        auto sizes =
-            map_types_to_values<typelist<int64_t, bool, uint32_t>>(map_to_size());
-        std::tuple<size_t, size_t, size_t> expected(8, 1, 4);
-        static_assert(std::is_same<decltype(expected), decltype(sizes)>::value, "");
-        EXPECT_EQ(expected, sizes);
-    }
-
-    struct map_make_shared {
-      template<class T> std::shared_ptr<typename T::type> operator()(T) {
-        return std::make_shared<typename T::type>();
-      }
-    };
-
-    TEST(TypeListTest, MapTypesToValues_differenttypes) {
-        auto shared_ptrs =
-                map_types_to_values<typelist<int, double>>(map_make_shared());
-        static_assert(std::is_same<std::tuple<std::shared_ptr<int>, std::shared_ptr<double>>, decltype(shared_ptrs)>::value, "");
-    }
-
-    struct Class1 {static int func() {return 3;}};
-    struct Class2 {static double func() {return 2.0;}};
-
-    struct mapper_call_func {
-      template<class T> auto operator()(T) -> decltype(T::type::func()) { return T::type::func(); }
-    };
-
-    TEST(TypeListTest, MapTypesToValues_members) {
-        auto result =
-                map_types_to_values<typelist<Class1, Class2>>(mapper_call_func());
-        std::tuple<int, double> expected(3, 2.0);
-        static_assert(std::is_same<decltype(expected), decltype(result)>::value, "");
-        EXPECT_EQ(expected, result);
-    }
-
-    struct mapper_call_nonexistent_function {
-      template<class T> auto operator()(T) -> decltype(T::type::this_doesnt_exist()) { return T::type::this_doesnt_exist(); }
-    };
-
-    TEST(TypeListTest, MapTypesToValues_empty) {
-        auto result =
-                map_types_to_values<typelist<>>(mapper_call_nonexistent_function());
-        std::tuple<> expected;
-        static_assert(std::is_same<decltype(expected), decltype(result)>::value, "");
-        EXPECT_EQ(expected, result);
-    }
+TEST(TypeListTest, MapTypesToValues_sametype) {
+  auto sizes =
+      map_types_to_values<typelist<int64_t, bool, uint32_t>>(map_to_size());
+  std::tuple<size_t, size_t, size_t> expected(8, 1, 4);
+  static_assert(std::is_same<decltype(expected), decltype(sizes)>::value, "");
+  EXPECT_EQ(expected, sizes);
 }
+
+struct map_make_shared {
+  template <class T>
+  std::shared_ptr<typename T::type> operator()(T) {
+    return std::make_shared<typename T::type>();
+  }
+};
+
+TEST(TypeListTest, MapTypesToValues_differenttypes) {
+  auto shared_ptrs =
+      map_types_to_values<typelist<int, double>>(map_make_shared());
+  static_assert(
+      std::is_same<
+          std::tuple<std::shared_ptr<int>, std::shared_ptr<double>>,
+          decltype(shared_ptrs)>::value,
+      "");
+}
+
+struct Class1 {
+  static int func() {
+    return 3;
+  }
+};
+struct Class2 {
+  static double func() {
+    return 2.0;
+  }
+};
+
+struct mapper_call_func {
+  template <class T>
+  auto operator()(T) -> decltype(T::type::func()) {
+    return T::type::func();
+  }
+};
+
+TEST(TypeListTest, MapTypesToValues_members) {
+  auto result =
+      map_types_to_values<typelist<Class1, Class2>>(mapper_call_func());
+  std::tuple<int, double> expected(3, 2.0);
+  static_assert(std::is_same<decltype(expected), decltype(result)>::value, "");
+  EXPECT_EQ(expected, result);
+}
+
+struct mapper_call_nonexistent_function {
+  template <class T>
+  auto operator()(T) -> decltype(T::type::this_doesnt_exist()) {
+    return T::type::this_doesnt_exist();
+  }
+};
+
+TEST(TypeListTest, MapTypesToValues_empty) {
+  auto result =
+      map_types_to_values<typelist<>>(mapper_call_nonexistent_function());
+  std::tuple<> expected;
+  static_assert(std::is_same<decltype(expected), decltype(result)>::value, "");
+  EXPECT_EQ(expected, result);
+}
+} // namespace test_map_types_to_values
 
 namespace test_find_if {
-  static_assert(0 == find_if<typelist<char&>, std::is_reference>::value, "");
-  static_assert(0 == find_if<typelist<char&, int, char&, int&>, std::is_reference>::value, "");
-  static_assert(2 == find_if<typelist<char, int, char&, int&>, std::is_reference>::value, "");
-  static_assert(3 == find_if<typelist<char, int, char, int&>, std::is_reference>::value, "");
-}
+static_assert(0 == find_if<typelist<char&>, std::is_reference>::value, "");
+static_assert(
+    0 == find_if<typelist<char&, int, char&, int&>, std::is_reference>::value,
+    "");
+static_assert(
+    2 == find_if<typelist<char, int, char&, int&>, std::is_reference>::value,
+    "");
+static_assert(
+    3 == find_if<typelist<char, int, char, int&>, std::is_reference>::value,
+    "");
+} // namespace test_find_if
 
 namespace test_contains {
-  static_assert(contains<typelist<double>, double>::value, "");
-  static_assert(contains<typelist<int, double>, double>::value, "");
-  static_assert(!contains<typelist<int, double>, float>::value, "");
-  static_assert(!contains<typelist<>, double>::value, "");
-}
+static_assert(contains<typelist<double>, double>::value, "");
+static_assert(contains<typelist<int, double>, double>::value, "");
+static_assert(!contains<typelist<int, double>, float>::value, "");
+static_assert(!contains<typelist<>, double>::value, "");
+} // namespace test_contains

--- a/c10/test/util/TypeTraits_test.cpp
+++ b/c10/test/util/TypeTraits_test.cpp
@@ -6,150 +6,188 @@ using namespace c10::guts;
 namespace {
 
 namespace test_is_equality_comparable {
-    class NotEqualityComparable {};
-    class EqualityComparable {};
+class NotEqualityComparable {};
+class EqualityComparable {};
 
-    inline bool operator==(const EqualityComparable &, const EqualityComparable &) { return false; }
-
-    static_assert(!is_equality_comparable<NotEqualityComparable>::value, "");
-    static_assert(is_equality_comparable<EqualityComparable>::value, "");
-    static_assert(is_equality_comparable<int>::value, "");
-
-    // v_ just exists to silence a compiler warning about operator==(EqualityComparable, EqualityComparable) not being needed
-    const bool v_ = EqualityComparable() == EqualityComparable();
+inline bool operator==(const EqualityComparable&, const EqualityComparable&) {
+  return false;
 }
+
+static_assert(!is_equality_comparable<NotEqualityComparable>::value, "");
+static_assert(is_equality_comparable<EqualityComparable>::value, "");
+static_assert(is_equality_comparable<int>::value, "");
+
+// v_ just exists to silence a compiler warning about
+// operator==(EqualityComparable, EqualityComparable) not being needed
+const bool v_ = EqualityComparable() == EqualityComparable();
+} // namespace test_is_equality_comparable
 
 namespace test_is_hashable {
-    class NotHashable {};
-    class Hashable {};
-}
-}
+class NotHashable {};
+class Hashable {};
+} // namespace test_is_hashable
+} // namespace
 namespace std {
-    template<> struct hash<test_is_hashable::Hashable> final {
-        size_t operator()(const test_is_hashable::Hashable &) { return 0; }
-    };
-}
+template <>
+struct hash<test_is_hashable::Hashable> final {
+  size_t operator()(const test_is_hashable::Hashable&) {
+    return 0;
+  }
+};
+} // namespace std
 namespace {
 namespace test_is_hashable {
-    static_assert(is_hashable<int>::value, "");
-    static_assert(is_hashable<Hashable>::value, "");
-    static_assert(!is_hashable<NotHashable>::value, "");
-}
+static_assert(is_hashable<int>::value, "");
+static_assert(is_hashable<Hashable>::value, "");
+static_assert(!is_hashable<NotHashable>::value, "");
+} // namespace test_is_hashable
 
 namespace test_is_function_type {
-    class MyClass {};
-    struct Functor {
-        void operator()() {}
-    };
-    auto lambda = [] () {};
-    // func() and func__ just exists to silence a compiler warning about lambda being unused
-    bool func() {
-        lambda();
-        return true;
-    }
-    bool func__ = func();
-
-    static_assert(is_function_type<void()>::value, "");
-    static_assert(is_function_type<int()>::value, "");
-    static_assert(is_function_type<MyClass()>::value, "");
-    static_assert(is_function_type<void(MyClass)>::value, "");
-    static_assert(is_function_type<void(int)>::value, "");
-    static_assert(is_function_type<void(void*)>::value, "");
-    static_assert(is_function_type<int()>::value, "");
-    static_assert(is_function_type<int(MyClass)>::value, "");
-    static_assert(is_function_type<int(const MyClass&)>::value, "");
-    static_assert(is_function_type<int(MyClass&&)>::value, "");
-    static_assert(is_function_type<MyClass&&()>::value, "");
-    static_assert(is_function_type<MyClass&&(MyClass&&)>::value, "");
-    static_assert(is_function_type<const MyClass&(int, float, MyClass)>::value, "");
-
-    static_assert(!is_function_type<void>::value, "");
-    static_assert(!is_function_type<int>::value, "");
-    static_assert(!is_function_type<MyClass>::value, "");
-    static_assert(!is_function_type<void*>::value, "");
-    static_assert(!is_function_type<const MyClass&>::value, "");
-    static_assert(!is_function_type<MyClass&&>::value, "");
-
-    static_assert(!is_function_type<void (*)()>::value, "function pointers aren't plain functions");
-    static_assert(!is_function_type<Functor>::value, "Functors aren't plain functions");
-    static_assert(!is_function_type<decltype(lambda)>::value, "Lambdas aren't plain functions");
+class MyClass {};
+struct Functor {
+  void operator()() {}
+};
+auto lambda = []() {};
+// func() and func__ just exists to silence a compiler warning about lambda
+// being unused
+bool func() {
+  lambda();
+  return true;
 }
+bool func__ = func();
+
+static_assert(is_function_type<void()>::value, "");
+static_assert(is_function_type<int()>::value, "");
+static_assert(is_function_type<MyClass()>::value, "");
+static_assert(is_function_type<void(MyClass)>::value, "");
+static_assert(is_function_type<void(int)>::value, "");
+static_assert(is_function_type<void(void*)>::value, "");
+static_assert(is_function_type<int()>::value, "");
+static_assert(is_function_type<int(MyClass)>::value, "");
+static_assert(is_function_type<int(const MyClass&)>::value, "");
+static_assert(is_function_type<int(MyClass&&)>::value, "");
+static_assert(is_function_type < MyClass && () > ::value, "");
+static_assert(is_function_type < MyClass && (MyClass &&) > ::value, "");
+static_assert(is_function_type<const MyClass&(int, float, MyClass)>::value, "");
+
+static_assert(!is_function_type<void>::value, "");
+static_assert(!is_function_type<int>::value, "");
+static_assert(!is_function_type<MyClass>::value, "");
+static_assert(!is_function_type<void*>::value, "");
+static_assert(!is_function_type<const MyClass&>::value, "");
+static_assert(!is_function_type<MyClass&&>::value, "");
+
+static_assert(
+    !is_function_type<void (*)()>::value,
+    "function pointers aren't plain functions");
+static_assert(
+    !is_function_type<Functor>::value,
+    "Functors aren't plain functions");
+static_assert(
+    !is_function_type<decltype(lambda)>::value,
+    "Lambdas aren't plain functions");
+} // namespace test_is_function_type
 
 namespace test_is_instantiation_of {
-    class MyClass {};
-    template<class T> class Single {};
-    template<class T1, class T2> class Double {};
-    template<class... T> class Multiple {};
+class MyClass {};
+template <class T>
+class Single {};
+template <class T1, class T2>
+class Double {};
+template <class... T>
+class Multiple {};
 
-    static_assert(is_instantiation_of<Single, Single<void>>::value, "");
-    static_assert(is_instantiation_of<Single, Single<MyClass>>::value, "");
-    static_assert(is_instantiation_of<Single, Single<int>>::value, "");
-    static_assert(is_instantiation_of<Single, Single<void*>>::value, "");
-    static_assert(is_instantiation_of<Single, Single<int*>>::value, "");
-    static_assert(is_instantiation_of<Single, Single<const MyClass&>>::value, "");
-    static_assert(is_instantiation_of<Single, Single<MyClass&&>>::value, "");
-    static_assert(is_instantiation_of<Double, Double<int, void>>::value, "");
-    static_assert(is_instantiation_of<Double, Double<const int&, MyClass*>>::value, "");
-    static_assert(is_instantiation_of<Multiple, Multiple<>>::value, "");
-    static_assert(is_instantiation_of<Multiple, Multiple<int>>::value, "");
-    static_assert(is_instantiation_of<Multiple, Multiple<MyClass&, int>>::value, "");
-    static_assert(is_instantiation_of<Multiple, Multiple<MyClass&, int, MyClass>>::value, "");
-    static_assert(is_instantiation_of<Multiple, Multiple<MyClass&, int, MyClass, void*>>::value, "");
+static_assert(is_instantiation_of<Single, Single<void>>::value, "");
+static_assert(is_instantiation_of<Single, Single<MyClass>>::value, "");
+static_assert(is_instantiation_of<Single, Single<int>>::value, "");
+static_assert(is_instantiation_of<Single, Single<void*>>::value, "");
+static_assert(is_instantiation_of<Single, Single<int*>>::value, "");
+static_assert(is_instantiation_of<Single, Single<const MyClass&>>::value, "");
+static_assert(is_instantiation_of<Single, Single<MyClass&&>>::value, "");
+static_assert(is_instantiation_of<Double, Double<int, void>>::value, "");
+static_assert(
+    is_instantiation_of<Double, Double<const int&, MyClass*>>::value,
+    "");
+static_assert(is_instantiation_of<Multiple, Multiple<>>::value, "");
+static_assert(is_instantiation_of<Multiple, Multiple<int>>::value, "");
+static_assert(
+    is_instantiation_of<Multiple, Multiple<MyClass&, int>>::value,
+    "");
+static_assert(
+    is_instantiation_of<Multiple, Multiple<MyClass&, int, MyClass>>::value,
+    "");
+static_assert(
+    is_instantiation_of<Multiple, Multiple<MyClass&, int, MyClass, void*>>::
+        value,
+    "");
 
-    static_assert(!is_instantiation_of<Single, Double<int, int>>::value, "");
-    static_assert(!is_instantiation_of<Single, Double<int, void>>::value, "");
-    static_assert(!is_instantiation_of<Single, Multiple<int>>::value, "");
-    static_assert(!is_instantiation_of<Double, Single<int>>::value, "");
-    static_assert(!is_instantiation_of<Double, Multiple<int, int>>::value, "");
-    static_assert(!is_instantiation_of<Double, Multiple<>>::value, "");
-    static_assert(!is_instantiation_of<Multiple, Double<int, int>>::value, "");
-    static_assert(!is_instantiation_of<Multiple, Single<int>>::value, "");
-}
+static_assert(!is_instantiation_of<Single, Double<int, int>>::value, "");
+static_assert(!is_instantiation_of<Single, Double<int, void>>::value, "");
+static_assert(!is_instantiation_of<Single, Multiple<int>>::value, "");
+static_assert(!is_instantiation_of<Double, Single<int>>::value, "");
+static_assert(!is_instantiation_of<Double, Multiple<int, int>>::value, "");
+static_assert(!is_instantiation_of<Double, Multiple<>>::value, "");
+static_assert(!is_instantiation_of<Multiple, Double<int, int>>::value, "");
+static_assert(!is_instantiation_of<Multiple, Single<int>>::value, "");
+} // namespace test_is_instantiation_of
 
 namespace test_is_type_condition {
-    template<class> class NotATypeCondition {};
-    static_assert(is_type_condition<std::is_reference>::value, "");
-    static_assert(!is_type_condition<NotATypeCondition>::value, "");
-}
-}
+template <class>
+class NotATypeCondition {};
+static_assert(is_type_condition<std::is_reference>::value, "");
+static_assert(!is_type_condition<NotATypeCondition>::value, "");
+} // namespace test_is_type_condition
+} // namespace
 
 namespace test_lambda_is_stateless {
-  template<class Result, class... Args>
-  struct MyStatelessFunctor final {
-    Result operator()(Args...) {}
-  };
+template <class Result, class... Args>
+struct MyStatelessFunctor final {
+  Result operator()(Args...) {}
+};
 
-  template<class Result, class... Args>
-  struct MyStatelessConstFunctor final {
-    Result operator()(Args...) const {}
-  };
+template <class Result, class... Args>
+struct MyStatelessConstFunctor final {
+  Result operator()(Args...) const {}
+};
 
-  void func() {
-    auto stateless_lambda = [] (int a) {return a;};
-    static_assert(is_stateless_lambda<decltype(stateless_lambda)>::value, "");
+void func() {
+  auto stateless_lambda = [](int a) { return a; };
+  static_assert(is_stateless_lambda<decltype(stateless_lambda)>::value, "");
 
-    int b = 4;
-    auto stateful_lambda_1 = [&] (int a) {return a + b;};
-    static_assert(!is_stateless_lambda<decltype(stateful_lambda_1)>::value, "");
+  int b = 4;
+  auto stateful_lambda_1 = [&](int a) { return a + b; };
+  static_assert(!is_stateless_lambda<decltype(stateful_lambda_1)>::value, "");
 
-    auto stateful_lambda_2 = [=] (int a) {return a + b;};
-    static_assert(!is_stateless_lambda<decltype(stateful_lambda_2)>::value, "");
+  auto stateful_lambda_2 = [=](int a) { return a + b; };
+  static_assert(!is_stateless_lambda<decltype(stateful_lambda_2)>::value, "");
 
-    auto stateful_lambda_3 = [b] (int a) {return a + b;};
-    static_assert(!is_stateless_lambda<decltype(stateful_lambda_3)>::value, "");
+  auto stateful_lambda_3 = [b](int a) { return a + b; };
+  static_assert(!is_stateless_lambda<decltype(stateful_lambda_3)>::value, "");
 
-    static_assert(!is_stateless_lambda<MyStatelessFunctor<int, int>>::value, "even if stateless, a functor is not a lambda, so it's false");
-    static_assert(!is_stateless_lambda<MyStatelessFunctor<void, int>>::value, "even if stateless, a functor is not a lambda, so it's false");
-    static_assert(!is_stateless_lambda<MyStatelessConstFunctor<int, int>>::value, "even if stateless, a functor is not a lambda, so it's false");
-    static_assert(!is_stateless_lambda<MyStatelessConstFunctor<void, int>>::value, "even if stateless, a functor is not a lambda, so it's false");
+  static_assert(
+      !is_stateless_lambda<MyStatelessFunctor<int, int>>::value,
+      "even if stateless, a functor is not a lambda, so it's false");
+  static_assert(
+      !is_stateless_lambda<MyStatelessFunctor<void, int>>::value,
+      "even if stateless, a functor is not a lambda, so it's false");
+  static_assert(
+      !is_stateless_lambda<MyStatelessConstFunctor<int, int>>::value,
+      "even if stateless, a functor is not a lambda, so it's false");
+  static_assert(
+      !is_stateless_lambda<MyStatelessConstFunctor<void, int>>::value,
+      "even if stateless, a functor is not a lambda, so it's false");
 
-    class Dummy final {};
-    static_assert(!is_stateless_lambda<Dummy>::value, "A non-functor type is also not a lambda");
+  class Dummy final {};
+  static_assert(
+      !is_stateless_lambda<Dummy>::value,
+      "A non-functor type is also not a lambda");
 
-    static_assert(!is_stateless_lambda<int>::value, "An int is not a lambda");
+  static_assert(!is_stateless_lambda<int>::value, "An int is not a lambda");
 
-    using Func = int(int);
-    static_assert(!is_stateless_lambda<Func>::value, "A function is not a lambda");
-    static_assert(!is_stateless_lambda<Func*>::value, "A function pointer is not a lambda");
-  }
+  using Func = int(int);
+  static_assert(
+      !is_stateless_lambda<Func>::value, "A function is not a lambda");
+  static_assert(
+      !is_stateless_lambda<Func*>::value, "A function pointer is not a lambda");
 }
+} // namespace test_lambda_is_stateless

--- a/c10/test/util/bfloat16_test.cpp
+++ b/c10/test/util/bfloat16_test.cpp
@@ -2,161 +2,159 @@
 #include <gtest/gtest.h>
 
 namespace {
-  float float_from_bytes(
-      uint32_t sign,
-      uint32_t exponent,
-      uint32_t fraction
-  ) {
-      uint32_t bytes;
-      bytes = 0;
-      bytes |= sign;
-      bytes <<= 8;
-      bytes |= exponent;
-      bytes <<= 23;
-      bytes |= fraction;
+float float_from_bytes(uint32_t sign, uint32_t exponent, uint32_t fraction) {
+  uint32_t bytes;
+  bytes = 0;
+  bytes |= sign;
+  bytes <<= 8;
+  bytes |= exponent;
+  bytes <<= 23;
+  bytes |= fraction;
 
-      float res;
-      std::memcpy(&res, &bytes, sizeof(res));
-      return res;
+  float res;
+  std::memcpy(&res, &bytes, sizeof(res));
+  return res;
+}
+
+TEST(BFloat16Conversion, FloatToBFloat16AndBack) {
+  float in[100];
+  for (int i = 0; i < 100; ++i) {
+    in[i] = i + 1.25;
   }
 
-  TEST(BFloat16Conversion, FloatToBFloat16AndBack) {
-    float in[100];
-    for (int i = 0; i < 100; ++i) {
-      in[i] = i + 1.25;
-    }
+  c10::BFloat16 bfloats[100];
+  float out[100];
 
-    c10::BFloat16 bfloats[100];
-    float out[100];
+  for (int i = 0; i < 100; ++i) {
+    bfloats[i].x = c10::detail::bits_from_f32(in[i]);
+    out[i] = c10::detail::f32_from_bits(bfloats[i].x);
 
-    for (int i = 0; i < 100; ++i) {
-      bfloats[i].x = c10::detail::bits_from_f32(in[i]);
-      out[i] = c10::detail::f32_from_bits(bfloats[i].x);
+    // The relative error should be less than 1/(2^7) since BFloat16
+    // has 7 bits mantissa.
+    EXPECT_LE(fabs(out[i] - in[i]) / in[i], 1.0 / 128);
+  }
+}
 
-      // The relative error should be less than 1/(2^7) since BFloat16
-      // has 7 bits mantissa.
-      EXPECT_LE(fabs(out[i] - in[i]) / in[i], 1.0 / 128);
-    }
+TEST(BFloat16Conversion, FloatToBFloat16RNEAndBack) {
+  float in[100];
+  for (int i = 0; i < 100; ++i) {
+    in[i] = i + 1.25;
   }
 
-  TEST(BFloat16Conversion, FloatToBFloat16RNEAndBack) {
-    float in[100];
-    for (int i = 0; i < 100; ++i) {
-      in[i] = i + 1.25;
-    }
+  c10::BFloat16 bfloats[100];
+  float out[100];
 
-    c10::BFloat16 bfloats[100];
-    float out[100];
+  for (int i = 0; i < 100; ++i) {
+    bfloats[i].x = c10::detail::round_to_nearest_even(in[i]);
+    out[i] = c10::detail::f32_from_bits(bfloats[i].x);
 
-    for (int i = 0; i < 100; ++i) {
-      bfloats[i].x = c10::detail::round_to_nearest_even(in[i]);
-      out[i] = c10::detail::f32_from_bits(bfloats[i].x);
-
-      // The relative error should be less than 1/(2^7) since BFloat16
-      // has 7 bits mantissa.
-      EXPECT_LE(fabs(out[i] - in[i]) / in[i], 1.0 / 128);
-    }
+    // The relative error should be less than 1/(2^7) since BFloat16
+    // has 7 bits mantissa.
+    EXPECT_LE(fabs(out[i] - in[i]) / in[i], 1.0 / 128);
   }
+}
 
-  TEST(BFloat16Conversion, NaN) {
-    float inNaN = float_from_bytes(0, 0xFF, 0x7FFFFF);
-    EXPECT_TRUE(std::isnan(inNaN));
+TEST(BFloat16Conversion, NaN) {
+  float inNaN = float_from_bytes(0, 0xFF, 0x7FFFFF);
+  EXPECT_TRUE(std::isnan(inNaN));
 
-    c10::BFloat16 a = c10::BFloat16(inNaN);
-    float out = c10::detail::f32_from_bits(a.x);
+  c10::BFloat16 a = c10::BFloat16(inNaN);
+  float out = c10::detail::f32_from_bits(a.x);
 
-    EXPECT_TRUE(std::isnan(out));
-  }
+  EXPECT_TRUE(std::isnan(out));
+}
 
-  TEST(BFloat16Conversion, Inf) {
-    float inInf = float_from_bytes(0, 0xFF, 0);
-    EXPECT_TRUE(std::isinf(inInf));
+TEST(BFloat16Conversion, Inf) {
+  float inInf = float_from_bytes(0, 0xFF, 0);
+  EXPECT_TRUE(std::isinf(inInf));
 
-    c10::BFloat16 a = c10::BFloat16(inInf);
-    float out = c10::detail::f32_from_bits(a.x);
+  c10::BFloat16 a = c10::BFloat16(inInf);
+  float out = c10::detail::f32_from_bits(a.x);
 
-    EXPECT_TRUE(std::isinf(out));
-  }
+  EXPECT_TRUE(std::isinf(out));
+}
 
-  TEST(BFloat16Conversion, SmallestDenormal) {
-    float in =  std::numeric_limits<float>::denorm_min(); // The smallest non-zero subnormal number
-    c10::BFloat16 a = c10::BFloat16(in);
-    float out = c10::detail::f32_from_bits(a.x);
+TEST(BFloat16Conversion, SmallestDenormal) {
+  float in = std::numeric_limits<float>::denorm_min(); // The smallest non-zero
+                                                       // subnormal number
+  c10::BFloat16 a = c10::BFloat16(in);
+  float out = c10::detail::f32_from_bits(a.x);
 
-    EXPECT_FLOAT_EQ(in, out);
-  }
+  EXPECT_FLOAT_EQ(in, out);
+}
 
-  TEST(BFloat16Math, Addition) {
-    // This test verifies that if only first 7 bits of float's mantisa are
-    // changed after addition, we should have no loss in precision.
+TEST(BFloat16Math, Addition) {
+  // This test verifies that if only first 7 bits of float's mantisa are
+  // changed after addition, we should have no loss in precision.
 
-    // input bits
-    // S | Exponent | Mantissa
-    // 0 | 10000000 | 10010000000000000000000 = 3.125
-    float input = float_from_bytes(0, 0, 0x40480000);
+  // input bits
+  // S | Exponent | Mantissa
+  // 0 | 10000000 | 10010000000000000000000 = 3.125
+  float input = float_from_bytes(0, 0, 0x40480000);
 
-    // expected bits
-    // S | Exponent | Mantissa
-    // 0 | 10000001 | 10010000000000000000000 = 6.25
-    float expected = float_from_bytes(0, 0, 0x40c80000);
+  // expected bits
+  // S | Exponent | Mantissa
+  // 0 | 10000001 | 10010000000000000000000 = 6.25
+  float expected = float_from_bytes(0, 0, 0x40c80000);
 
-    c10::BFloat16 b;
-    b.x = c10::detail::bits_from_f32(input);
-    b = b + b;
+  c10::BFloat16 b;
+  b.x = c10::detail::bits_from_f32(input);
+  b = b + b;
 
-    float res = c10::detail::f32_from_bits(b.x);
-    EXPECT_EQ(res, expected);
-  }
+  float res = c10::detail::f32_from_bits(b.x);
+  EXPECT_EQ(res, expected);
+}
 
-  TEST(BFloat16Math, Substraction) {
-    // This test verifies that if only first 7 bits of float's mantisa are
-    // changed after substraction, we should have no loss in precision.
+TEST(BFloat16Math, Substraction) {
+  // This test verifies that if only first 7 bits of float's mantisa are
+  // changed after substraction, we should have no loss in precision.
 
-    // input bits
-    // S | Exponent | Mantissa
-    // 0 | 10000001 | 11101000000000000000000 = 7.625
-    float input = float_from_bytes(0, 0, 0x40f40000);
+  // input bits
+  // S | Exponent | Mantissa
+  // 0 | 10000001 | 11101000000000000000000 = 7.625
+  float input = float_from_bytes(0, 0, 0x40f40000);
 
-    // expected bits
-    // S | Exponent | Mantissa
-    // 0 | 10000000 | 01010000000000000000000 = 2.625
-    float expected = float_from_bytes(0, 0, 0x40280000);
+  // expected bits
+  // S | Exponent | Mantissa
+  // 0 | 10000000 | 01010000000000000000000 = 2.625
+  float expected = float_from_bytes(0, 0, 0x40280000);
 
-    c10::BFloat16 b;
-    b.x = c10::detail::bits_from_f32(input);
-    b = b - 5;
+  c10::BFloat16 b;
+  b.x = c10::detail::bits_from_f32(input);
+  b = b - 5;
 
-    float res = c10::detail::f32_from_bits(b.x);
-    EXPECT_EQ(res, expected);
-  }
+  float res = c10::detail::f32_from_bits(b.x);
+  EXPECT_EQ(res, expected);
+}
 
-  float BinaryToFloat(uint32_t bytes) {
-    float res;
-    std::memcpy(&res, &bytes, sizeof(res));
-    return res;
-  }
+float BinaryToFloat(uint32_t bytes) {
+  float res;
+  std::memcpy(&res, &bytes, sizeof(res));
+  return res;
+}
 
-  struct BFloat16TestParam {
-    uint32_t input;
-    uint16_t rne;
-  };
+struct BFloat16TestParam {
+  uint32_t input;
+  uint16_t rne;
+};
 
-  class BFloat16Test : public ::testing::Test,
-                       public ::testing::WithParamInterface<BFloat16TestParam> {
-  };
+class BFloat16Test : public ::testing::Test,
+                     public ::testing::WithParamInterface<BFloat16TestParam> {};
 
-  TEST_P(BFloat16Test, BFloat16RNETest) {
-    float value = BinaryToFloat(GetParam().input);
-    uint16_t rounded = c10::detail::round_to_nearest_even(value);
-    EXPECT_EQ(GetParam().rne, rounded);
-  }
+TEST_P(BFloat16Test, BFloat16RNETest) {
+  float value = BinaryToFloat(GetParam().input);
+  uint16_t rounded = c10::detail::round_to_nearest_even(value);
+  EXPECT_EQ(GetParam().rne, rounded);
+}
 
-  INSTANTIATE_TEST_CASE_P(
-      BFloat16Test_Instantiation, BFloat16Test,
-      ::testing::Values(BFloat16TestParam{0x3F848000, 0x3F84},
-                        BFloat16TestParam{0x3F848010, 0x3F85},
-                        BFloat16TestParam{0x3F850000, 0x3F85},
-                        BFloat16TestParam{0x3F858000, 0x3F86},
-                        BFloat16TestParam{0x3FFF8000, 0x4000}));
+INSTANTIATE_TEST_CASE_P(
+    BFloat16Test_Instantiation,
+    BFloat16Test,
+    ::testing::Values(
+        BFloat16TestParam{0x3F848000, 0x3F84},
+        BFloat16TestParam{0x3F848010, 0x3F85},
+        BFloat16TestParam{0x3F850000, 0x3F85},
+        BFloat16TestParam{0x3F858000, 0x3F86},
+        BFloat16TestParam{0x3FFF8000, 0x4000}));
 
 } // namespace

--- a/c10/test/util/either_test.cpp
+++ b/c10/test/util/either_test.cpp
@@ -1,1040 +1,996 @@
-// Originally taken from https://raw.githubusercontent.com/cryfs/cryfs/14ad22570ddacef22d5ff139cdff68a54fc8234d/test/cpp-utils/either_test.cpp
+// Originally taken from
+// https://raw.githubusercontent.com/cryfs/cryfs/14ad22570ddacef22d5ff139cdff68a54fc8234d/test/cpp-utils/either_test.cpp
 
-#include <c10/util/either.h>
 #include <c10/macros/Macros.h>
-#include <gtest/gtest.h>
+#include <c10/util/either.h>
 #include <gmock/gmock.h>
-#include <vector>
+#include <gtest/gtest.h>
 #include <sstream>
+#include <vector>
 
-using std::string;
-using std::vector;
-using std::pair;
-using std::tuple;
-using std::ostringstream;
 using c10::either;
 using c10::make_left;
 using c10::make_right;
+using std::ostringstream;
+using std::pair;
+using std::string;
+using std::tuple;
+using std::vector;
 
 namespace {
 class MovableOnly final {
-public:
-    explicit MovableOnly(int value): _value(value) {}
-    MovableOnly(const MovableOnly&) = delete;
-    MovableOnly& operator=(const MovableOnly&) = delete;
+ public:
+  explicit MovableOnly(int value) : _value(value) {}
+  MovableOnly(const MovableOnly&) = delete;
+  MovableOnly& operator=(const MovableOnly&) = delete;
 
-    MovableOnly(MovableOnly&& rhs): _value(rhs._value) {
-      rhs._value = 0;
-    }
+  MovableOnly(MovableOnly&& rhs) : _value(rhs._value) {
+    rhs._value = 0;
+  }
 
-    MovableOnly& operator=(MovableOnly&& rhs) {
-      _value = rhs._value;
-      rhs._value = 0;
-      return *this;
-    }
+  MovableOnly& operator=(MovableOnly&& rhs) {
+    _value = rhs._value;
+    rhs._value = 0;
+    return *this;
+  }
 
-    int value() const {
-        return _value;
-    }
+  int value() const {
+    return _value;
+  }
 
-private:
-    int _value;
+ private:
+  int _value;
 };
 
 bool operator==(const MovableOnly& lhs, const MovableOnly& rhs) {
   return lhs.value() == rhs.value();
 }
 
-template<class T>
-void test_with_matrix(std::vector<std::function<void(std::function<void(T&)>)>> setups, std::vector<std::function<void(T&)>> expectations) {
-  for (const auto& setup: setups) {
-    for (const auto& expectation: expectations) {
+template <class T>
+void test_with_matrix(
+    std::vector<std::function<void(std::function<void(T&)>)>> setups,
+    std::vector<std::function<void(T&)>> expectations) {
+  for (const auto& setup : setups) {
+    for (const auto& expectation : expectations) {
       setup(expectation);
     }
   }
 }
 
-template<class Left, class Right>
-std::vector<std::function<void(either<Left, Right>&)>> EXPECT_IS_LEFT(const Left& expected) {
-  return {
-    [&] (either<Left, Right>& obj) {
-      EXPECT_TRUE(obj.is_left());
-    }, [&] (either<Left, Right>& obj) {
-      EXPECT_FALSE(obj.is_right());
-    }, [&] (either<Left, Right>& obj) {
-      EXPECT_EQ(expected, obj.left());
-    }, [&] (either<Left, Right>& obj) {
-      EXPECT_EQ(expected, std::move(obj).left());
-    }, [&] (either<Left, Right>& obj) {
-      EXPECT_ANY_THROW(obj.right());
-    }, [&] (either<Left, Right>& obj) {
-      EXPECT_ANY_THROW(std::move(obj).right());
-    }
-  };
+template <class Left, class Right>
+std::vector<std::function<void(either<Left, Right>&)>> EXPECT_IS_LEFT(
+    const Left& expected) {
+  return {[&](either<Left, Right>& obj) { EXPECT_TRUE(obj.is_left()); },
+          [&](either<Left, Right>& obj) { EXPECT_FALSE(obj.is_right()); },
+          [&](either<Left, Right>& obj) { EXPECT_EQ(expected, obj.left()); },
+          [&](either<Left, Right>& obj) {
+            EXPECT_EQ(expected, std::move(obj).left());
+          },
+          [&](either<Left, Right>& obj) { EXPECT_ANY_THROW(obj.right()); },
+          [&](either<Left, Right>& obj) {
+            EXPECT_ANY_THROW(std::move(obj).right());
+          }};
 }
 
-template<class Left, class Right>
-std::vector<std::function<void(either<Left, Right>&)>> EXPECT_IS_RIGHT(const Right& expected) {
-  return {
-      [&] (either<Left, Right>& obj) {
-        EXPECT_FALSE(obj.is_left());
-      }, [&] (either<Left, Right>& obj) {
-        EXPECT_TRUE(obj.is_right());
-      }, [&] (either<Left, Right>& obj) {
-        EXPECT_EQ(expected, obj.right());
-      }, [&] (either<Left, Right>& obj) {
-        EXPECT_EQ(expected, std::move(obj).right());
-      }, [&] (either<Left, Right>& obj) {
-        EXPECT_ANY_THROW(obj.left());
-      }, [&] (either<Left, Right>& obj) {
-        EXPECT_ANY_THROW(std::move(obj).left());
-      }
-  };
+template <class Left, class Right>
+std::vector<std::function<void(either<Left, Right>&)>> EXPECT_IS_RIGHT(
+    const Right& expected) {
+  return {[&](either<Left, Right>& obj) { EXPECT_FALSE(obj.is_left()); },
+          [&](either<Left, Right>& obj) { EXPECT_TRUE(obj.is_right()); },
+          [&](either<Left, Right>& obj) { EXPECT_EQ(expected, obj.right()); },
+          [&](either<Left, Right>& obj) {
+            EXPECT_EQ(expected, std::move(obj).right());
+          },
+          [&](either<Left, Right>& obj) { EXPECT_ANY_THROW(obj.left()); },
+          [&](either<Left, Right>& obj) {
+            EXPECT_ANY_THROW(std::move(obj).left());
+          }};
 }
 
-template<class Value>
+template <class Value>
 std::vector<std::function<void(Value&)>> EXPECT_IS(const Value& v) {
-  return {
-    [&] (Value& obj) {
-      return obj == v;
-    }
-  };
+  return {[&](Value& obj) { return obj == v; }};
 }
 
-template<typename T>
+template <typename T>
 struct StoreWith1ByteFlag {
   T val;
   char flag;
 };
 
-template<typename Left, typename Right>
+template <typename Left, typename Right>
 void TestSpaceUsage() {
-    EXPECT_EQ(std::max(sizeof(StoreWith1ByteFlag<Left>), sizeof(StoreWith1ByteFlag<Right>)), sizeof(either<Left, Right>));
+  EXPECT_EQ(
+      std::max(
+          sizeof(StoreWith1ByteFlag<Left>), sizeof(StoreWith1ByteFlag<Right>)),
+      sizeof(either<Left, Right>));
 }
-}
+} // namespace
 
 TEST(EitherTest, SpaceUsage) {
-    TestSpaceUsage<char, int>();
-    TestSpaceUsage<int, short>();
-    TestSpaceUsage<char, short>();
-    TestSpaceUsage<int, string>();
-    TestSpaceUsage<string, vector<string>>();
+  TestSpaceUsage<char, int>();
+  TestSpaceUsage<int, short>();
+  TestSpaceUsage<char, short>();
+  TestSpaceUsage<int, string>();
+  TestSpaceUsage<string, vector<string>>();
 }
 
 TEST(EitherTest, givenLeft) {
-  test_with_matrix({
-      [] (std::function<void(either<int, string>&)> test) {
-        either<int, string> a(4);
-        test(a);
-      }, [] (std::function<void(either<int, string>&)> test) {
-        either<int, string> a = 4;
-        test(a);
+  test_with_matrix(
+      {
+          [](std::function<void(either<int, string>&)> test) {
+            either<int, string> a(4);
+            test(a);
+          },
+          [](std::function<void(either<int, string>&)> test) {
+            either<int, string> a = 4;
+            test(a);
+          },
       },
-    },
-    EXPECT_IS_LEFT<int, string>(4)
-  );
+      EXPECT_IS_LEFT<int, string>(4));
 }
 
 TEST(EitherTest, givenRight) {
-  test_with_matrix({
-      [] (std::function<void(either<int, string>&)> test) {
-        either<int, string> a("4");
-        test(a);
-      }, [] (std::function<void(either<int, string>&)> test) {
-        either<int, string> a = string("4");
-        test(a);
-      }
-    },
-    EXPECT_IS_RIGHT<int, string>("4")
-  );
+  test_with_matrix(
+      {[](std::function<void(either<int, string>&)> test) {
+         either<int, string> a("4");
+         test(a);
+       },
+       [](std::function<void(either<int, string>&)> test) {
+         either<int, string> a = string("4");
+         test(a);
+       }},
+      EXPECT_IS_RIGHT<int, string>("4"));
 }
 
 TEST(EitherTest, givenMakeLeft) {
-    test_with_matrix({
-      [] (std::function<void(either<int, string>&)> test) {
-        either<int, string> a = make_left<int, string>(4);
-        test(a);
-      }, [] (std::function<void(either<int, string>&)> test) {
-        auto a = make_left<int, string>(4);
-        test(a);
+  test_with_matrix(
+      {
+          [](std::function<void(either<int, string>&)> test) {
+            either<int, string> a = make_left<int, string>(4);
+            test(a);
+          },
+          [](std::function<void(either<int, string>&)> test) {
+            auto a = make_left<int, string>(4);
+            test(a);
+          },
       },
-    },
-    EXPECT_IS_LEFT<int, string>(4)
-  );
+      EXPECT_IS_LEFT<int, string>(4));
 }
 
 TEST(EitherTest, givenMakeLeftWithSameType) {
-  test_with_matrix({
-      [] (std::function<void(either<int, int>&)> test) {
-        either<int, int> a = make_left<int, int>(4);
-        test(a);
-      }, [] (std::function<void(either<int, int>&)> test) {
-        auto a = make_left<int, int>(4);
-        test(a);
+  test_with_matrix(
+      {
+          [](std::function<void(either<int, int>&)> test) {
+            either<int, int> a = make_left<int, int>(4);
+            test(a);
+          },
+          [](std::function<void(either<int, int>&)> test) {
+            auto a = make_left<int, int>(4);
+            test(a);
+          },
       },
-    },
-    EXPECT_IS_LEFT<int, int>(4)
-  );
+      EXPECT_IS_LEFT<int, int>(4));
 }
 
 TEST(EitherTest, givenMakeRight) {
-  test_with_matrix({
-      [] (std::function<void(either<int, string>&)> test) {
-        either<int, string> a = make_right<int, string>("4");
-        test(a);
-      }, [] (std::function<void(either<int, string>&)> test) {
-        auto a = make_right<int, string>("4");
-        test(a);
-      }
-    },
-    EXPECT_IS_RIGHT<int, string>("4")
-  );
+  test_with_matrix(
+      {[](std::function<void(either<int, string>&)> test) {
+         either<int, string> a = make_right<int, string>("4");
+         test(a);
+       },
+       [](std::function<void(either<int, string>&)> test) {
+         auto a = make_right<int, string>("4");
+         test(a);
+       }},
+      EXPECT_IS_RIGHT<int, string>("4"));
 }
 
 TEST(EitherTest, givenMakeRightWithSameType) {
-  test_with_matrix({
-      [] (std::function<void(either<string, string>&)> test) {
-        either<string, string> a = make_right<string, string>("4");
-        test(a);
-      }, [] (std::function<void(either<string, string>&)> test) {
-        auto a = make_right<string, string>("4");
-        test(a);
-      }
-    },
-    EXPECT_IS_RIGHT<string, string>("4")
-  );
+  test_with_matrix(
+      {[](std::function<void(either<string, string>&)> test) {
+         either<string, string> a = make_right<string, string>("4");
+         test(a);
+       },
+       [](std::function<void(either<string, string>&)> test) {
+         auto a = make_right<string, string>("4");
+         test(a);
+       }},
+      EXPECT_IS_RIGHT<string, string>("4"));
 }
 
 TEST(EitherTest, givenMovableOnlyMakeLeft) {
-  test_with_matrix({
-      [] (std::function<void(either<MovableOnly, string>&)> test) {
-        either<MovableOnly, string> a = make_left<MovableOnly, string>(3);
-        test(a);
-      }, [] (std::function<void(either<MovableOnly, string>&)> test) {
-        auto a = make_left<MovableOnly, string>(3);
-        test(a);
+  test_with_matrix(
+      {
+          [](std::function<void(either<MovableOnly, string>&)> test) {
+            either<MovableOnly, string> a = make_left<MovableOnly, string>(3);
+            test(a);
+          },
+          [](std::function<void(either<MovableOnly, string>&)> test) {
+            auto a = make_left<MovableOnly, string>(3);
+            test(a);
+          },
       },
-    },
-    EXPECT_IS_LEFT<MovableOnly, string>(MovableOnly(3))
-  );
+      EXPECT_IS_LEFT<MovableOnly, string>(MovableOnly(3)));
 }
 
 TEST(EitherTest, givenMovableOnlyMakeRight) {
-  test_with_matrix({
-      [] (std::function<void(either<int, MovableOnly>&)> test) {
-        either<int, MovableOnly> a = make_right<int, MovableOnly>(3);
-        test(a);
-      }, [] (std::function<void(either<int, MovableOnly>&)> test) {
-        auto a = make_right<int, MovableOnly>(3);
-        test(a);
-      }
-    },
-    EXPECT_IS_RIGHT<int, MovableOnly>(MovableOnly(3))
-  );
+  test_with_matrix(
+      {[](std::function<void(either<int, MovableOnly>&)> test) {
+         either<int, MovableOnly> a = make_right<int, MovableOnly>(3);
+         test(a);
+       },
+       [](std::function<void(either<int, MovableOnly>&)> test) {
+         auto a = make_right<int, MovableOnly>(3);
+         test(a);
+       }},
+      EXPECT_IS_RIGHT<int, MovableOnly>(MovableOnly(3)));
 }
 
 TEST(EitherTest, givenMultiParamMakeLeft) {
-  test_with_matrix({
-      [] (std::function<void(either<pair<int, int>, string>&)> test) {
-        either<pair<int, int>, string> a = make_left<pair<int, int>, string>(5, 6);
-        test(a);
-      }, [] (std::function<void(either<pair<int, int>, string>&)> test) {
-        auto a = make_left<pair<int, int>, string>(5, 6);
-        test(a);
+  test_with_matrix(
+      {
+          [](std::function<void(either<pair<int, int>, string>&)> test) {
+            either<pair<int, int>, string> a =
+                make_left<pair<int, int>, string>(5, 6);
+            test(a);
+          },
+          [](std::function<void(either<pair<int, int>, string>&)> test) {
+            auto a = make_left<pair<int, int>, string>(5, 6);
+            test(a);
+          },
       },
-    },
-    EXPECT_IS_LEFT<pair<int, int>, string>(pair<int, int>(5, 6))
-  );
+      EXPECT_IS_LEFT<pair<int, int>, string>(pair<int, int>(5, 6)));
 }
 
 TEST(EitherTest, givenMultiParamMakeRight) {
-  test_with_matrix({
-      [] (std::function<void(either<int, pair<int, int>>&)> test) {
-        either<int, pair<int, int>> a = make_right<int, pair<int, int>>(5, 6);
-        test(a);
-      }, [] (std::function<void(either<int, pair<int, int>>&)> test) {
-        auto a = make_right<int, pair<int, int>>(5, 6);
-        test(a);
-      }
-    },
-    EXPECT_IS_RIGHT<int, pair<int, int>>(pair<int, int>(5, 6))
-  );
+  test_with_matrix(
+      {[](std::function<void(either<int, pair<int, int>>&)> test) {
+         either<int, pair<int, int>> a = make_right<int, pair<int, int>>(5, 6);
+         test(a);
+       },
+       [](std::function<void(either<int, pair<int, int>>&)> test) {
+         auto a = make_right<int, pair<int, int>>(5, 6);
+         test(a);
+       }},
+      EXPECT_IS_RIGHT<int, pair<int, int>>(pair<int, int>(5, 6)));
 }
 
 TEST(EitherTest, givenLeftCopyConstructedFromValue_thenNewIsCorrect) {
-  test_with_matrix({
-      [] (std::function<void(either<string, int>&)> test) {
+  test_with_matrix(
+      {[](std::function<void(either<string, int>&)> test) {
         string a = "4";
         either<string, int> b(a);
         test(b);
-      }
-    },
-    EXPECT_IS_LEFT<string, int>("4")
-  );
+      }},
+      EXPECT_IS_LEFT<string, int>("4"));
 }
 
 TEST(EitherTest, givenLeftCopyConstructedFromValue_thenOldIsCorrect) {
-  test_with_matrix({
-      [] (std::function<void(string&)> test) {
+  test_with_matrix(
+      {[](std::function<void(string&)> test) {
         string a = "4";
         either<string, int> b(a);
         test(a);
-      }
-    },
-    EXPECT_IS<string>("4")
-  );
+      }},
+      EXPECT_IS<string>("4"));
 }
 
 TEST(EitherTest, givenRightCopyConstructedFromValue_thenNewIsCorrect) {
-  test_with_matrix({
-      [] (std::function<void(either<int, string>&)> test) {
+  test_with_matrix(
+      {[](std::function<void(either<int, string>&)> test) {
         string a = "4";
         either<int, string> b(a);
         test(b);
-      }
-    },
-    EXPECT_IS_RIGHT<int, string>("4")
-  );
+      }},
+      EXPECT_IS_RIGHT<int, string>("4"));
 }
 
 TEST(EitherTest, givenRightCopyConstructedFromValue_thenOldIsCorrect) {
-  test_with_matrix({
-      [] (std::function<void(string&)> test) {
+  test_with_matrix(
+      {[](std::function<void(string&)> test) {
         string a = "4";
         either<int, string> b(a);
         test(a);
-      }
-    },
-    EXPECT_IS<string>("4")
-  );
+      }},
+      EXPECT_IS<string>("4"));
 }
 
 TEST(EitherTest, givenLeftMoveConstructedFromValue_thenNewIsCorrect) {
-  test_with_matrix({
-      [] (std::function<void(either<MovableOnly, int>&)> test) {
+  test_with_matrix(
+      {[](std::function<void(either<MovableOnly, int>&)> test) {
         MovableOnly a(3);
         either<MovableOnly, int> b(std::move(a));
         test(b);
-      }
-    },
-    EXPECT_IS_LEFT<MovableOnly, int>(MovableOnly(3))
-  );
+      }},
+      EXPECT_IS_LEFT<MovableOnly, int>(MovableOnly(3)));
 }
 
 TEST(EitherTest, givenLeftMoveConstructedFromValue_thenOldIsCorrect) {
-  test_with_matrix({
-      [] (std::function<void(MovableOnly&)> test) {
+  test_with_matrix(
+      {[](std::function<void(MovableOnly&)> test) {
         MovableOnly a(3);
         either<MovableOnly, int> b(std::move(a));
-        test(a);  // NOLINT(bugprone-use-after-move)
-      }
-    },
-    EXPECT_IS<MovableOnly>(MovableOnly(0))  // 0 is moved-from value
+        test(a); // NOLINT(bugprone-use-after-move)
+      }},
+      EXPECT_IS<MovableOnly>(MovableOnly(0)) // 0 is moved-from value
   );
 }
 
 TEST(EitherTest, givenRightMoveConstructedFromValue_thenNewIsCorrect) {
-  test_with_matrix({
-      [] (std::function<void(either<int, MovableOnly>&)> test) {
+  test_with_matrix(
+      {[](std::function<void(either<int, MovableOnly>&)> test) {
         MovableOnly a(3);
         either<int, MovableOnly> b(std::move(a));
         test(b);
-      }
-    },
-    EXPECT_IS_RIGHT<int, MovableOnly>(MovableOnly(3))
-  );
+      }},
+      EXPECT_IS_RIGHT<int, MovableOnly>(MovableOnly(3)));
 }
 
 TEST(EitherTest, givenRightMoveConstructedFromValue_thenOldIsCorrect) {
-  test_with_matrix({
-      [] (std::function<void(MovableOnly&)> test) {
+  test_with_matrix(
+      {[](std::function<void(MovableOnly&)> test) {
         MovableOnly a(3);
         either<int, MovableOnly> b(std::move(a));
-        test(a);  // NOLINT(bugprone-use-after-move)
-      }
-    },
-    EXPECT_IS<MovableOnly>(MovableOnly(0))  // 0 is moved-from value
+        test(a); // NOLINT(bugprone-use-after-move)
+      }},
+      EXPECT_IS<MovableOnly>(MovableOnly(0)) // 0 is moved-from value
   );
 }
 
 TEST(EitherTest, givenLeftCopyAssignedFromValue_thenNewIsCorrect) {
-  test_with_matrix({
-      [] (std::function<void(either<string, int>&)> test) {
-        string a = "4";
-        either<string, int> b(2);
-        b = a;
-        test(b);
-      }, [] (std::function<void(either<string, int>&)> test) {
-        string a = "4";
-        either<string, int> b("2");
-        b = a;
-        test(b);
-      }
-    },
-    EXPECT_IS_LEFT<string, int>("4")
-  );
+  test_with_matrix(
+      {[](std::function<void(either<string, int>&)> test) {
+         string a = "4";
+         either<string, int> b(2);
+         b = a;
+         test(b);
+       },
+       [](std::function<void(either<string, int>&)> test) {
+         string a = "4";
+         either<string, int> b("2");
+         b = a;
+         test(b);
+       }},
+      EXPECT_IS_LEFT<string, int>("4"));
 }
 
 TEST(EitherTest, givenLeftCopyAssignedFromValue_thenOldIsCorrect) {
-  test_with_matrix({
-      [] (std::function<void(string&)> test) {
-        string a = "4";
-        either<string, int> b(2);
-        b = a;
-        test(a);
-      }, [] (std::function<void(string&)> test) {
-        string a = "4";
-        either<string, int> b("2");
-        b = a;
-        test(a);
-      }
-    },
-    EXPECT_IS<string>("4")
-  );
+  test_with_matrix(
+      {[](std::function<void(string&)> test) {
+         string a = "4";
+         either<string, int> b(2);
+         b = a;
+         test(a);
+       },
+       [](std::function<void(string&)> test) {
+         string a = "4";
+         either<string, int> b("2");
+         b = a;
+         test(a);
+       }},
+      EXPECT_IS<string>("4"));
 }
 
 TEST(EitherTest, givenRightCopyAssignedFromValue_thenNewIsCorrect) {
-  test_with_matrix({
-      [] (std::function<void(either<int, string>&)> test) {
-        string a = "4";
-        either<int, string> b(2);
-        b = a;
-        test(b);
-      }, [] (std::function<void(either<int, string>&)> test) {
-        string a = "4";
-        either<int, string> b("2");
-        b = a;
-        test(b);
-      }
-    },
-    EXPECT_IS_RIGHT<int, string>("4")
-  );
+  test_with_matrix(
+      {[](std::function<void(either<int, string>&)> test) {
+         string a = "4";
+         either<int, string> b(2);
+         b = a;
+         test(b);
+       },
+       [](std::function<void(either<int, string>&)> test) {
+         string a = "4";
+         either<int, string> b("2");
+         b = a;
+         test(b);
+       }},
+      EXPECT_IS_RIGHT<int, string>("4"));
 }
 
 TEST(EitherTest, givenRightCopyAssignedFromValue_thenOldIsCorrect) {
-  test_with_matrix({
-      [] (std::function<void(string&)> test) {
-        string a = "4";
-        either<int, string> b(2);
-        b = a;
-        test(a);
-      }, [] (std::function<void(string&)> test) {
-        string a = "4";
-        either<int, string> b("2");
-        b = a;
-        test(a);
-      }
-    },
-    EXPECT_IS<string>("4")
-  );
+  test_with_matrix(
+      {[](std::function<void(string&)> test) {
+         string a = "4";
+         either<int, string> b(2);
+         b = a;
+         test(a);
+       },
+       [](std::function<void(string&)> test) {
+         string a = "4";
+         either<int, string> b("2");
+         b = a;
+         test(a);
+       }},
+      EXPECT_IS<string>("4"));
 }
 
 TEST(EitherTest, givenLeftMoveAssignedFromValue_thenNewIsCorrect) {
-  test_with_matrix({
-      [] (std::function<void(either<MovableOnly, string>&)> test) {
-        MovableOnly a(3);
-        either<MovableOnly, string> b(2);
-        b = std::move(a);
-        test(b);
-      }, [] (std::function<void(either<MovableOnly, string>&)> test) {
-        MovableOnly a(3);
-        either<MovableOnly, string> b(MovableOnly(2));
-        b = std::move(a);
-        test(b);
-      }
-    },
-    EXPECT_IS_LEFT<MovableOnly, string>(MovableOnly(3))
-  );
+  test_with_matrix(
+      {[](std::function<void(either<MovableOnly, string>&)> test) {
+         MovableOnly a(3);
+         either<MovableOnly, string> b(2);
+         b = std::move(a);
+         test(b);
+       },
+       [](std::function<void(either<MovableOnly, string>&)> test) {
+         MovableOnly a(3);
+         either<MovableOnly, string> b(MovableOnly(2));
+         b = std::move(a);
+         test(b);
+       }},
+      EXPECT_IS_LEFT<MovableOnly, string>(MovableOnly(3)));
 }
 
 TEST(EitherTest, givenLeftMoveAssignedFromValue_thenOldIsCorrect) {
-  test_with_matrix({
-      [] (std::function<void(MovableOnly&)> test) {
-        MovableOnly a(3);
-        either<MovableOnly, string> b("2");
-        b = std::move(a);
-        test(a);  // NOLINT(bugprone-use-after-move)
-      }, [] (std::function<void(MovableOnly&)> test) {
-        MovableOnly a(3);
-        either<MovableOnly, string> b(MovableOnly(0));
-        b = std::move(a);
-        test(a);  // NOLINT(bugprone-use-after-move)
-      }
-    },
-    EXPECT_IS<MovableOnly>(MovableOnly(0))
-  );
+  test_with_matrix(
+      {[](std::function<void(MovableOnly&)> test) {
+         MovableOnly a(3);
+         either<MovableOnly, string> b("2");
+         b = std::move(a);
+         test(a); // NOLINT(bugprone-use-after-move)
+       },
+       [](std::function<void(MovableOnly&)> test) {
+         MovableOnly a(3);
+         either<MovableOnly, string> b(MovableOnly(0));
+         b = std::move(a);
+         test(a); // NOLINT(bugprone-use-after-move)
+       }},
+      EXPECT_IS<MovableOnly>(MovableOnly(0)));
 }
 
 TEST(EitherTest, givenRightMoveAssignedFromValue_thenNewIsCorrect) {
-  test_with_matrix({
-      [] (std::function<void(either<string, MovableOnly>&)> test) {
-        MovableOnly a(3);
-        either<string, MovableOnly> b("2");
-        b = std::move(a);
-        test(b);
-      }, [] (std::function<void(either<string, MovableOnly>&)> test) {
-        MovableOnly a(3);
-        either<string, MovableOnly> b(MovableOnly(2));
-        b = std::move(a);
-        test(b);
-      }
-    },
-    EXPECT_IS_RIGHT<string, MovableOnly>(MovableOnly(3))
-  );
+  test_with_matrix(
+      {[](std::function<void(either<string, MovableOnly>&)> test) {
+         MovableOnly a(3);
+         either<string, MovableOnly> b("2");
+         b = std::move(a);
+         test(b);
+       },
+       [](std::function<void(either<string, MovableOnly>&)> test) {
+         MovableOnly a(3);
+         either<string, MovableOnly> b(MovableOnly(2));
+         b = std::move(a);
+         test(b);
+       }},
+      EXPECT_IS_RIGHT<string, MovableOnly>(MovableOnly(3)));
 }
 
 TEST(EitherTest, givenRightMoveAssignedFromValue_thenOldIsCorrect) {
-  test_with_matrix({
-      [] (std::function<void(MovableOnly&)> test) {
-        MovableOnly a(3);
-        either<string, MovableOnly> b("2");
-        b = std::move(a);
-        test(a);  // NOLINT(bugprone-use-after-move)
-      }, [] (std::function<void(MovableOnly&)> test) {
-        MovableOnly a(3);
-        either<string, MovableOnly> b(MovableOnly(2));
-        b = std::move(a);
-        test(a);  // NOLINT(bugprone-use-after-move)
-      }
-    },
-    EXPECT_IS<MovableOnly>(MovableOnly(0))  // 0 is moved-from value
+  test_with_matrix(
+      {[](std::function<void(MovableOnly&)> test) {
+         MovableOnly a(3);
+         either<string, MovableOnly> b("2");
+         b = std::move(a);
+         test(a); // NOLINT(bugprone-use-after-move)
+       },
+       [](std::function<void(MovableOnly&)> test) {
+         MovableOnly a(3);
+         either<string, MovableOnly> b(MovableOnly(2));
+         b = std::move(a);
+         test(a); // NOLINT(bugprone-use-after-move)
+       }},
+      EXPECT_IS<MovableOnly>(MovableOnly(0)) // 0 is moved-from value
   );
 }
 
 TEST(EitherTest, givenLeftCopyConstructed_thenNewIsCorrect) {
-  test_with_matrix({
-      [] (std::function<void(either<string, int>&)> test) {
+  test_with_matrix(
+      {[](std::function<void(either<string, int>&)> test) {
         either<string, int> a("4");
         either<string, int> b(a);
         test(b);
-      }
-    },
-    EXPECT_IS_LEFT<string, int>("4")
-  );
+      }},
+      EXPECT_IS_LEFT<string, int>("4"));
 }
 
 TEST(EitherTest, givenLeftCopyConstructed_thenOldIsCorrect) {
-  test_with_matrix({
-      [] (std::function<void(either<string, int>&)> test) {
+  test_with_matrix(
+      {[](std::function<void(either<string, int>&)> test) {
         either<string, int> a("4");
         either<string, int> b(a);
         test(a);
-      }
-    },
-    EXPECT_IS_LEFT<string, int>("4")
-  );
+      }},
+      EXPECT_IS_LEFT<string, int>("4"));
 }
 
 TEST(EitherTest, givenLeftCopyConstructed_withSameType_thenNewIsCorrect) {
-  test_with_matrix({
-      [] (std::function<void(either<string, string>&)> test) {
+  test_with_matrix(
+      {[](std::function<void(either<string, string>&)> test) {
         either<string, string> a = make_left<string, string>("4");
         either<string, string> b(a);
         test(b);
-      }
-    },
-    EXPECT_IS_LEFT<string, string>("4")
-  );
+      }},
+      EXPECT_IS_LEFT<string, string>("4"));
 }
 
 TEST(EitherTest, givenLeftCopyConstructed_withSameType_thenOldIsCorrect) {
-  test_with_matrix({
-      [] (std::function<void(either<string, string>&)> test) {
+  test_with_matrix(
+      {[](std::function<void(either<string, string>&)> test) {
         either<string, string> a = make_left<string, string>("4");
         either<string, string> b(a);
         test(a);
-      }
-    },
-    EXPECT_IS_LEFT<string, string>("4")
-  );
+      }},
+      EXPECT_IS_LEFT<string, string>("4"));
 }
 
 TEST(EitherTest, givenRightCopyConstructed_thenNewIsCorrect) {
-  test_with_matrix({
-      [] (std::function<void(either<int, string>&)> test) {
+  test_with_matrix(
+      {[](std::function<void(either<int, string>&)> test) {
         either<int, string> a("4");
         either<int, string> b(a);
         test(b);
-      }
-    },
-    EXPECT_IS_RIGHT<int, string>("4")
-  );
+      }},
+      EXPECT_IS_RIGHT<int, string>("4"));
 }
 
-
 TEST(EitherTest, givenRightCopyConstructed_thenOldIsCorrect) {
-  test_with_matrix({
-      [] (std::function<void(either<int, string>&)> test) {
+  test_with_matrix(
+      {[](std::function<void(either<int, string>&)> test) {
         either<int, string> a("4");
         either<int, string> b(a);
         test(a);
-      }
-    },
-    EXPECT_IS_RIGHT<int, string>("4")
-  );
+      }},
+      EXPECT_IS_RIGHT<int, string>("4"));
 }
 
 TEST(EitherTest, givenRightCopyConstructed_withSameType_thenNewIsCorrect) {
-  test_with_matrix({
-      [] (std::function<void(either<string, string>&)> test) {
+  test_with_matrix(
+      {[](std::function<void(either<string, string>&)> test) {
         either<string, string> a = make_right<string, string>("4");
         either<string, string> b(a);
         test(b);
-      }
-    },
-    EXPECT_IS_RIGHT<string, string>("4")
-  );
+      }},
+      EXPECT_IS_RIGHT<string, string>("4"));
 }
 
-
 TEST(EitherTest, givenRightCopyConstructed_withSameType_thenOldIsCorrect) {
-  test_with_matrix({
-      [] (std::function<void(either<string, string>&)> test) {
+  test_with_matrix(
+      {[](std::function<void(either<string, string>&)> test) {
         either<string, string> a = make_right<string, string>("4");
         either<string, string> b(a);
         test(a);
-      }
-    },
-    EXPECT_IS_RIGHT<string, string>("4")
-  );
+      }},
+      EXPECT_IS_RIGHT<string, string>("4"));
 }
 
 TEST(EitherTest, givenLeftMoveConstructed_thenNewIsCorrect) {
-  test_with_matrix({
-      [] (std::function<void(either<MovableOnly, int>&)> test) {
+  test_with_matrix(
+      {[](std::function<void(either<MovableOnly, int>&)> test) {
         either<MovableOnly, int> a(MovableOnly(3));
         either<MovableOnly, int> b(std::move(a));
         test(b);
-      }
-    },
-    EXPECT_IS_LEFT<MovableOnly, int>(MovableOnly(3))
-  );
+      }},
+      EXPECT_IS_LEFT<MovableOnly, int>(MovableOnly(3)));
 }
 
 TEST(EitherTest, givenLeftMoveConstructed_thenOldIsCorrect) {
-  test_with_matrix({
-      [] (std::function<void(either<MovableOnly, int>&)> test) {
+  test_with_matrix(
+      {[](std::function<void(either<MovableOnly, int>&)> test) {
         either<MovableOnly, int> a(MovableOnly(3));
         either<MovableOnly, int> b(std::move(a));
-        test(a);  // NOLINT(bugprone-use-after-move)
-      }
-    },
-    EXPECT_IS_LEFT<MovableOnly, int>(MovableOnly(0))  // 0 is moved-from value
+        test(a); // NOLINT(bugprone-use-after-move)
+      }},
+      EXPECT_IS_LEFT<MovableOnly, int>(MovableOnly(0)) // 0 is moved-from value
   );
 }
 
 TEST(EitherTest, givenLeftMoveConstructed_withSameType_thenNewIsCorrect) {
-  test_with_matrix({
-      [] (std::function<void(either<MovableOnly, MovableOnly>&)> test) {
-        either<MovableOnly, MovableOnly> a = make_left<MovableOnly, MovableOnly>(MovableOnly(3));
+  test_with_matrix(
+      {[](std::function<void(either<MovableOnly, MovableOnly>&)> test) {
+        either<MovableOnly, MovableOnly> a =
+            make_left<MovableOnly, MovableOnly>(MovableOnly(3));
         either<MovableOnly, MovableOnly> b(std::move(a));
         test(b);
-      }
-    },
-    EXPECT_IS_LEFT<MovableOnly, MovableOnly>(MovableOnly(3))
-  );
+      }},
+      EXPECT_IS_LEFT<MovableOnly, MovableOnly>(MovableOnly(3)));
 }
 
 TEST(EitherTest, givenLeftMoveConstructed_withSameType_thenOldIsCorrect) {
-  test_with_matrix({
-      [] (std::function<void(either<MovableOnly, MovableOnly>&)> test) {
-        either<MovableOnly, MovableOnly> a = make_left<MovableOnly, MovableOnly>(MovableOnly(3));
+  test_with_matrix(
+      {[](std::function<void(either<MovableOnly, MovableOnly>&)> test) {
+        either<MovableOnly, MovableOnly> a =
+            make_left<MovableOnly, MovableOnly>(MovableOnly(3));
         either<MovableOnly, MovableOnly> b(std::move(a));
-        test(a);  // NOLINT(bugprone-use-after-move)
-      }
-    },
-    EXPECT_IS_LEFT<MovableOnly, MovableOnly>(MovableOnly(0))  // 0 is moved-from value
+        test(a); // NOLINT(bugprone-use-after-move)
+      }},
+      EXPECT_IS_LEFT<MovableOnly, MovableOnly>(
+          MovableOnly(0)) // 0 is moved-from value
   );
 }
 
 TEST(EitherTest, givenRightMoveConstructed_thenNewIsCorrect) {
-  test_with_matrix({
-      [] (std::function<void(either<int, MovableOnly>&)> test) {
+  test_with_matrix(
+      {[](std::function<void(either<int, MovableOnly>&)> test) {
         either<int, MovableOnly> a(MovableOnly(3));
         either<int, MovableOnly> b(std::move(a));
         test(b);
-      }
-    },
-    EXPECT_IS_RIGHT<int, MovableOnly>(MovableOnly(3))
-  );
+      }},
+      EXPECT_IS_RIGHT<int, MovableOnly>(MovableOnly(3)));
 }
 
 TEST(EitherTest, givenRightMoveConstructed_thenOldIsCorrect) {
-  test_with_matrix({
-      [] (std::function<void(either<int, MovableOnly>&)> test) {
+  test_with_matrix(
+      {[](std::function<void(either<int, MovableOnly>&)> test) {
         either<int, MovableOnly> a(MovableOnly(3));
         either<int, MovableOnly> b(std::move(a));
-        test(a);  // NOLINT(bugprone-use-after-move)
-      }
-    },
-    EXPECT_IS_RIGHT<int, MovableOnly>(MovableOnly(0))  // 0 is moved-from value
+        test(a); // NOLINT(bugprone-use-after-move)
+      }},
+      EXPECT_IS_RIGHT<int, MovableOnly>(MovableOnly(0)) // 0 is moved-from value
   );
 }
 
 TEST(EitherTest, givenRightMoveConstructed_withSameType_thenNewIsCorrect) {
-  test_with_matrix({
-      [] (std::function<void(either<MovableOnly, MovableOnly>&)> test) {
-        either<MovableOnly, MovableOnly> a = make_right<MovableOnly, MovableOnly>(MovableOnly(3));
+  test_with_matrix(
+      {[](std::function<void(either<MovableOnly, MovableOnly>&)> test) {
+        either<MovableOnly, MovableOnly> a =
+            make_right<MovableOnly, MovableOnly>(MovableOnly(3));
         either<MovableOnly, MovableOnly> b(std::move(a));
         test(b);
-      }
-    },
-    EXPECT_IS_RIGHT<MovableOnly, MovableOnly>(MovableOnly(3))
-  );
+      }},
+      EXPECT_IS_RIGHT<MovableOnly, MovableOnly>(MovableOnly(3)));
 }
 
 TEST(EitherTest, givenRightMoveConstructed_withSameType_thenOldIsCorrect) {
-  test_with_matrix({
-      [] (std::function<void(either<MovableOnly, MovableOnly>&)> test) {
-        either<MovableOnly, MovableOnly> a = make_right<MovableOnly, MovableOnly>(MovableOnly(3));
+  test_with_matrix(
+      {[](std::function<void(either<MovableOnly, MovableOnly>&)> test) {
+        either<MovableOnly, MovableOnly> a =
+            make_right<MovableOnly, MovableOnly>(MovableOnly(3));
         either<MovableOnly, MovableOnly> b(std::move(a));
-        test(a);  // NOLINT(bugprone-use-after-move)
-      }
-    },
-    EXPECT_IS_RIGHT<MovableOnly, MovableOnly>(MovableOnly(0))  // 0 is moved-from value
+        test(a); // NOLINT(bugprone-use-after-move)
+      }},
+      EXPECT_IS_RIGHT<MovableOnly, MovableOnly>(
+          MovableOnly(0)) // 0 is moved-from value
   );
 }
 
 TEST(EitherTest, givenLeftCopyAssigned_thenNewIsCorrect) {
-  test_with_matrix({
-      [] (std::function<void(either<string, int>&)> test) {
-        either<string, int> a("4");
-        either<string, int> b(2);
-        b = a;
-        test(b);
-      }, [] (std::function<void(either<string, int>&)> test) {
-        either<string, int> a("4");
-        either<string, int> b("2");
-        b = a;
-        test(b);
-      }
-    },
-    EXPECT_IS_LEFT<string, int>("4")
-  );
+  test_with_matrix(
+      {[](std::function<void(either<string, int>&)> test) {
+         either<string, int> a("4");
+         either<string, int> b(2);
+         b = a;
+         test(b);
+       },
+       [](std::function<void(either<string, int>&)> test) {
+         either<string, int> a("4");
+         either<string, int> b("2");
+         b = a;
+         test(b);
+       }},
+      EXPECT_IS_LEFT<string, int>("4"));
 }
 
 TEST(EitherTest, givenLeftCopyAssigned_thenOldIsCorrect) {
-  test_with_matrix({
-      [] (std::function<void(either<string, int>&)> test) {
-        either<string, int> a("4");
-        either<string, int> b(2);
-        b = a;
-        test(a);
-      }, [] (std::function<void(either<string, int>&)> test) {
-        either<string, int> a("4");
-        either<string, int> b("2");
-        b = a;
-        test(a);
-      }
-    },
-    EXPECT_IS_LEFT<string, int>("4")
-  );
+  test_with_matrix(
+      {[](std::function<void(either<string, int>&)> test) {
+         either<string, int> a("4");
+         either<string, int> b(2);
+         b = a;
+         test(a);
+       },
+       [](std::function<void(either<string, int>&)> test) {
+         either<string, int> a("4");
+         either<string, int> b("2");
+         b = a;
+         test(a);
+       }},
+      EXPECT_IS_LEFT<string, int>("4"));
 }
 
 TEST(EitherTest, givenLeftCopyAssigned_withSameType_thenNewIsCorrect) {
-  test_with_matrix({
-      [] (std::function<void(either<string, string>&)> test) {
-        either<string, string> a = make_left<string, string>("4");
-        either<string, string> b = make_right<string, string>("2");
-        b = a;
-        test(b);
-      }, [] (std::function<void(either<string, string>&)> test) {
-        either<string, string> a = make_left<string, string>("4");
-        either<string, string> b = make_left<string, string>("2");
-        b = a;
-        test(b);
-      }
-    },
-    EXPECT_IS_LEFT<string, string>("4")
-  );
+  test_with_matrix(
+      {[](std::function<void(either<string, string>&)> test) {
+         either<string, string> a = make_left<string, string>("4");
+         either<string, string> b = make_right<string, string>("2");
+         b = a;
+         test(b);
+       },
+       [](std::function<void(either<string, string>&)> test) {
+         either<string, string> a = make_left<string, string>("4");
+         either<string, string> b = make_left<string, string>("2");
+         b = a;
+         test(b);
+       }},
+      EXPECT_IS_LEFT<string, string>("4"));
 }
 
 TEST(EitherTest, givenLeftCopyAssigned_withSameType_thenOldIsCorrect) {
-  test_with_matrix({
-      [] (std::function<void(either<string, string>&)> test) {
-        either<string, string> a = make_left<string, string>("4");
-        either<string, string> b = make_right<string, string>("2");
-        b = a;
-        test(a);
-      }, [] (std::function<void(either<string, string>&)> test) {
-        either<string, string> a = make_left<string, string>("4");
-        either<string, string> b = make_left<string, string>("2");
-        b = a;
-        test(a);
-      }
-    },
-    EXPECT_IS_LEFT<string, string>("4")
-  );
+  test_with_matrix(
+      {[](std::function<void(either<string, string>&)> test) {
+         either<string, string> a = make_left<string, string>("4");
+         either<string, string> b = make_right<string, string>("2");
+         b = a;
+         test(a);
+       },
+       [](std::function<void(either<string, string>&)> test) {
+         either<string, string> a = make_left<string, string>("4");
+         either<string, string> b = make_left<string, string>("2");
+         b = a;
+         test(a);
+       }},
+      EXPECT_IS_LEFT<string, string>("4"));
 }
 
 TEST(EitherTest, givenRightCopyAssigned_thenNewIsCorrect) {
-  test_with_matrix({
-      [] (std::function<void(either<int, string>&)> test) {
-        either<int, string> a("4");
-        either<int, string> b(2);
-        b = a;
-        test(b);
-      }, [] (std::function<void(either<int, string>&)> test) {
-        either<int, string> a("4");
-        either<int, string> b("2");
-        b = a;
-        test(b);
-      }
-    },
-    EXPECT_IS_RIGHT<int, string>("4")
-  );
+  test_with_matrix(
+      {[](std::function<void(either<int, string>&)> test) {
+         either<int, string> a("4");
+         either<int, string> b(2);
+         b = a;
+         test(b);
+       },
+       [](std::function<void(either<int, string>&)> test) {
+         either<int, string> a("4");
+         either<int, string> b("2");
+         b = a;
+         test(b);
+       }},
+      EXPECT_IS_RIGHT<int, string>("4"));
 }
 
 TEST(EitherTest, givenRightCopyAssigned_thenOldIsCorrect) {
-  test_with_matrix({
-      [] (std::function<void(either<int, string>&)> test) {
-        either<int, string> a("4");
-        either<int, string> b(2);
-        b = a;
-        test(a);
-      }, [] (std::function<void(either<int, string>&)> test) {
-        either<int, string> a("4");
-        either<int, string> b("2");
-        b = a;
-        test(a);
-      }
-    },
-    EXPECT_IS_RIGHT<int, string>("4")
-  );
+  test_with_matrix(
+      {[](std::function<void(either<int, string>&)> test) {
+         either<int, string> a("4");
+         either<int, string> b(2);
+         b = a;
+         test(a);
+       },
+       [](std::function<void(either<int, string>&)> test) {
+         either<int, string> a("4");
+         either<int, string> b("2");
+         b = a;
+         test(a);
+       }},
+      EXPECT_IS_RIGHT<int, string>("4"));
 }
 
 TEST(EitherTest, givenRightCopyAssigned_withSameType_thenNewIsCorrect) {
-  test_with_matrix({
-      [] (std::function<void(either<string, string>&)> test) {
-        either<string, string> a = make_right<string, string>("4");
-        either<string, string> b = make_left<string, string>("2");
-        b = a;
-        test(b);
-      }, [] (std::function<void(either<string, string>&)> test) {
-        either<string, string> a = make_right<string, string>("4");
-        either<string, string> b = make_right<string, string>("2");
-        b = a;
-        test(b);
-      }
-    },
-    EXPECT_IS_RIGHT<string, string>("4")
-  );
+  test_with_matrix(
+      {[](std::function<void(either<string, string>&)> test) {
+         either<string, string> a = make_right<string, string>("4");
+         either<string, string> b = make_left<string, string>("2");
+         b = a;
+         test(b);
+       },
+       [](std::function<void(either<string, string>&)> test) {
+         either<string, string> a = make_right<string, string>("4");
+         either<string, string> b = make_right<string, string>("2");
+         b = a;
+         test(b);
+       }},
+      EXPECT_IS_RIGHT<string, string>("4"));
 }
 
 TEST(EitherTest, givenRightCopyAssigned_withSameType_thenOldIsCorrect) {
-  test_with_matrix({
-      [] (std::function<void(either<string, string>&)> test) {
-        either<string, string> a = make_right<string, string>("4");
-        either<string, string> b = make_left<string, string>("2");
-        b = a;
-        test(a);
-      }, [] (std::function<void(either<string, string>&)> test) {
-        either<string, string> a = make_right<string, string>("4");
-        either<string, string> b = make_right<string, string>("2");
-        b = a;
-        test(a);
-      }
-    },
-    EXPECT_IS_RIGHT<string, string>("4")
-  );
+  test_with_matrix(
+      {[](std::function<void(either<string, string>&)> test) {
+         either<string, string> a = make_right<string, string>("4");
+         either<string, string> b = make_left<string, string>("2");
+         b = a;
+         test(a);
+       },
+       [](std::function<void(either<string, string>&)> test) {
+         either<string, string> a = make_right<string, string>("4");
+         either<string, string> b = make_right<string, string>("2");
+         b = a;
+         test(a);
+       }},
+      EXPECT_IS_RIGHT<string, string>("4"));
 }
 
 TEST(EitherTest, givenLeftMoveAssigned_thenNewIsCorrect) {
-  test_with_matrix({
-      [] (std::function<void(either<MovableOnly, string>&)> test) {
-        either<MovableOnly, string> a(MovableOnly(3));
-        either<MovableOnly, string> b(2);
-        b = std::move(a);
-        test(b);
-      }, [] (std::function<void(either<MovableOnly, string>&)> test) {
-        either<MovableOnly, string> a(MovableOnly(3));
-        either<MovableOnly, string> b(MovableOnly(2));
-        b = std::move(a);
-        test(b);
-      }
-    },
-    EXPECT_IS_LEFT<MovableOnly, string>(MovableOnly(3))
-  );
+  test_with_matrix(
+      {[](std::function<void(either<MovableOnly, string>&)> test) {
+         either<MovableOnly, string> a(MovableOnly(3));
+         either<MovableOnly, string> b(2);
+         b = std::move(a);
+         test(b);
+       },
+       [](std::function<void(either<MovableOnly, string>&)> test) {
+         either<MovableOnly, string> a(MovableOnly(3));
+         either<MovableOnly, string> b(MovableOnly(2));
+         b = std::move(a);
+         test(b);
+       }},
+      EXPECT_IS_LEFT<MovableOnly, string>(MovableOnly(3)));
 }
 
 TEST(EitherTest, givenLeftMoveAssigned_thenOldIsCorrect) {
-  test_with_matrix({
-      [] (std::function<void(either<MovableOnly, string>&)> test) {
-        either<MovableOnly, string> a(MovableOnly(3));
-        either<MovableOnly, string> b(2);
-        b = std::move(a);
-        test(a);  // NOLINT(bugprone-use-after-move)
-      }, [] (std::function<void(either<MovableOnly, string>&)> test) {
-        either<MovableOnly, string> a(MovableOnly(3));
-        either<MovableOnly, string> b(MovableOnly(2));
-        b = std::move(a);
-        test(a);  // NOLINT(bugprone-use-after-move)
-      }
-    },
-    EXPECT_IS_LEFT<MovableOnly, string>(MovableOnly(0)) // 0 is moved-from value
+  test_with_matrix(
+      {[](std::function<void(either<MovableOnly, string>&)> test) {
+         either<MovableOnly, string> a(MovableOnly(3));
+         either<MovableOnly, string> b(2);
+         b = std::move(a);
+         test(a); // NOLINT(bugprone-use-after-move)
+       },
+       [](std::function<void(either<MovableOnly, string>&)> test) {
+         either<MovableOnly, string> a(MovableOnly(3));
+         either<MovableOnly, string> b(MovableOnly(2));
+         b = std::move(a);
+         test(a); // NOLINT(bugprone-use-after-move)
+       }},
+      EXPECT_IS_LEFT<MovableOnly, string>(
+          MovableOnly(0)) // 0 is moved-from value
   );
 }
 
 TEST(EitherTest, givenLeftMoveAssigned_withSameType_thenNewIsCorrect) {
-  test_with_matrix({
-      [] (std::function<void(either<MovableOnly, MovableOnly>&)> test) {
-        either<MovableOnly, MovableOnly> a = make_left<MovableOnly, MovableOnly>(3);
-        either<MovableOnly, MovableOnly> b = make_right<MovableOnly, MovableOnly>(2);
-        b = std::move(a);
-        test(b);
-      }, [] (std::function<void(either<MovableOnly, MovableOnly>&)> test) {
-        either<MovableOnly, MovableOnly> a = make_left<MovableOnly, MovableOnly>(3);
-        either<MovableOnly, MovableOnly> b = make_left<MovableOnly, MovableOnly>(2);
-        b = std::move(a);
-        test(b);
-      }
-    },
-    EXPECT_IS_LEFT<MovableOnly, MovableOnly>(MovableOnly(3))
-  );
+  test_with_matrix(
+      {[](std::function<void(either<MovableOnly, MovableOnly>&)> test) {
+         either<MovableOnly, MovableOnly> a =
+             make_left<MovableOnly, MovableOnly>(3);
+         either<MovableOnly, MovableOnly> b =
+             make_right<MovableOnly, MovableOnly>(2);
+         b = std::move(a);
+         test(b);
+       },
+       [](std::function<void(either<MovableOnly, MovableOnly>&)> test) {
+         either<MovableOnly, MovableOnly> a =
+             make_left<MovableOnly, MovableOnly>(3);
+         either<MovableOnly, MovableOnly> b =
+             make_left<MovableOnly, MovableOnly>(2);
+         b = std::move(a);
+         test(b);
+       }},
+      EXPECT_IS_LEFT<MovableOnly, MovableOnly>(MovableOnly(3)));
 }
 
 TEST(EitherTest, givenLeftMoveAssigned_withSameType_thenOldIsCorrect) {
-  test_with_matrix({
-      [] (std::function<void(either<MovableOnly, MovableOnly>&)> test) {
-        either<MovableOnly, MovableOnly> a = make_left<MovableOnly, MovableOnly>(3);
-        either<MovableOnly, MovableOnly> b = make_right<MovableOnly, MovableOnly>(2);
-        b = std::move(a);
-        test(a);  // NOLINT(bugprone-use-after-move)
-      }, [] (std::function<void(either<MovableOnly, MovableOnly>&)> test) {
-        either<MovableOnly, MovableOnly> a = make_left<MovableOnly, MovableOnly>(3);
-        either<MovableOnly, MovableOnly> b = make_left<MovableOnly, MovableOnly>(2);
-        b = std::move(a);
-        test(a);  // NOLINT(bugprone-use-after-move)
-      }
-    },
-    EXPECT_IS_LEFT<MovableOnly, MovableOnly>(MovableOnly(0)) // 0 is moved-from value
+  test_with_matrix(
+      {[](std::function<void(either<MovableOnly, MovableOnly>&)> test) {
+         either<MovableOnly, MovableOnly> a =
+             make_left<MovableOnly, MovableOnly>(3);
+         either<MovableOnly, MovableOnly> b =
+             make_right<MovableOnly, MovableOnly>(2);
+         b = std::move(a);
+         test(a); // NOLINT(bugprone-use-after-move)
+       },
+       [](std::function<void(either<MovableOnly, MovableOnly>&)> test) {
+         either<MovableOnly, MovableOnly> a =
+             make_left<MovableOnly, MovableOnly>(3);
+         either<MovableOnly, MovableOnly> b =
+             make_left<MovableOnly, MovableOnly>(2);
+         b = std::move(a);
+         test(a); // NOLINT(bugprone-use-after-move)
+       }},
+      EXPECT_IS_LEFT<MovableOnly, MovableOnly>(
+          MovableOnly(0)) // 0 is moved-from value
   );
 }
 
 TEST(EitherTest, givenRightMoveAssigned_thenNewIsCorrect) {
-  test_with_matrix({
-      [] (std::function<void(either<string, MovableOnly>&)> test) {
-        either<string, MovableOnly> a(MovableOnly(3));
-        either<string, MovableOnly> b("2");
-        b = std::move(a);
-        test(b);
-      }, [] (std::function<void(either<string, MovableOnly>&)> test) {
-        either<string, MovableOnly> a(MovableOnly(3));
-        either<string, MovableOnly> b(MovableOnly(2));
-        b = std::move(a);
-        test(b);
-      }
-    },
-    EXPECT_IS_RIGHT<string, MovableOnly>(MovableOnly(3))
-  );
+  test_with_matrix(
+      {[](std::function<void(either<string, MovableOnly>&)> test) {
+         either<string, MovableOnly> a(MovableOnly(3));
+         either<string, MovableOnly> b("2");
+         b = std::move(a);
+         test(b);
+       },
+       [](std::function<void(either<string, MovableOnly>&)> test) {
+         either<string, MovableOnly> a(MovableOnly(3));
+         either<string, MovableOnly> b(MovableOnly(2));
+         b = std::move(a);
+         test(b);
+       }},
+      EXPECT_IS_RIGHT<string, MovableOnly>(MovableOnly(3)));
 }
 
 TEST(EitherTest, givenRightMoveAssigned_thenOldIsCorrect) {
-  test_with_matrix({
-      [] (std::function<void(either<string, MovableOnly>&)> test) {
-        either<string, MovableOnly> a(MovableOnly(3));
-        either<string, MovableOnly> b("2");
-        b = std::move(a);
-        test(a);  // NOLINT(bugprone-use-after-move)
-      }, [] (std::function<void(either<string, MovableOnly>&)> test) {
-        either<string, MovableOnly> a(MovableOnly(3));
-        either<string, MovableOnly> b(MovableOnly(2));
-        b = std::move(a);
-        test(a);  // NOLINT(bugprone-use-after-move)
-      }
-    },
-    EXPECT_IS_RIGHT<string, MovableOnly>(MovableOnly(0)) // 0 is moved-from value
+  test_with_matrix(
+      {[](std::function<void(either<string, MovableOnly>&)> test) {
+         either<string, MovableOnly> a(MovableOnly(3));
+         either<string, MovableOnly> b("2");
+         b = std::move(a);
+         test(a); // NOLINT(bugprone-use-after-move)
+       },
+       [](std::function<void(either<string, MovableOnly>&)> test) {
+         either<string, MovableOnly> a(MovableOnly(3));
+         either<string, MovableOnly> b(MovableOnly(2));
+         b = std::move(a);
+         test(a); // NOLINT(bugprone-use-after-move)
+       }},
+      EXPECT_IS_RIGHT<string, MovableOnly>(
+          MovableOnly(0)) // 0 is moved-from value
   );
 }
 
 TEST(EitherTest, givenRightMoveAssigned_withSameType_thenNewIsCorrect) {
-  test_with_matrix({
-      [] (std::function<void(either<MovableOnly, MovableOnly>&)> test) {
-        either<MovableOnly, MovableOnly> a = make_right<MovableOnly, MovableOnly>(3);
-        either<MovableOnly, MovableOnly> b = make_left<MovableOnly, MovableOnly>(2);
-        b = std::move(a);
-        test(b);
-      }, [] (std::function<void(either<MovableOnly, MovableOnly>&)> test) {
-        either<MovableOnly, MovableOnly> a = make_right<MovableOnly, MovableOnly>(3);
-        either<MovableOnly, MovableOnly> b = make_right<MovableOnly, MovableOnly>(2);
-        b = std::move(a);
-        test(b);
-      }
-    },
-    EXPECT_IS_RIGHT<MovableOnly, MovableOnly>(MovableOnly(3))
-  );
+  test_with_matrix(
+      {[](std::function<void(either<MovableOnly, MovableOnly>&)> test) {
+         either<MovableOnly, MovableOnly> a =
+             make_right<MovableOnly, MovableOnly>(3);
+         either<MovableOnly, MovableOnly> b =
+             make_left<MovableOnly, MovableOnly>(2);
+         b = std::move(a);
+         test(b);
+       },
+       [](std::function<void(either<MovableOnly, MovableOnly>&)> test) {
+         either<MovableOnly, MovableOnly> a =
+             make_right<MovableOnly, MovableOnly>(3);
+         either<MovableOnly, MovableOnly> b =
+             make_right<MovableOnly, MovableOnly>(2);
+         b = std::move(a);
+         test(b);
+       }},
+      EXPECT_IS_RIGHT<MovableOnly, MovableOnly>(MovableOnly(3)));
 }
 
 TEST(EitherTest, givenRightMoveAssigned_withSameType_thenOldIsCorrect) {
-  test_with_matrix({
-      [] (std::function<void(either<MovableOnly, MovableOnly>&)> test) {
-        either<MovableOnly, MovableOnly> a = make_right<MovableOnly, MovableOnly>(3);
-        either<MovableOnly, MovableOnly> b = make_left<MovableOnly, MovableOnly>(2);
-        b = std::move(a);
-        test(a);  // NOLINT(bugprone-use-after-move)
-      }, [] (std::function<void(either<MovableOnly, MovableOnly>&)> test) {
-        either<MovableOnly, MovableOnly> a = make_right<MovableOnly, MovableOnly>(3);
-        either<MovableOnly, MovableOnly> b = make_right<MovableOnly, MovableOnly>(2);
-        b = std::move(a);
-        test(a);  // NOLINT(bugprone-use-after-move)
-      }
-    },
-    EXPECT_IS_RIGHT<MovableOnly, MovableOnly>(MovableOnly(0)) // 0 is moved-from value
+  test_with_matrix(
+      {[](std::function<void(either<MovableOnly, MovableOnly>&)> test) {
+         either<MovableOnly, MovableOnly> a =
+             make_right<MovableOnly, MovableOnly>(3);
+         either<MovableOnly, MovableOnly> b =
+             make_left<MovableOnly, MovableOnly>(2);
+         b = std::move(a);
+         test(a); // NOLINT(bugprone-use-after-move)
+       },
+       [](std::function<void(either<MovableOnly, MovableOnly>&)> test) {
+         either<MovableOnly, MovableOnly> a =
+             make_right<MovableOnly, MovableOnly>(3);
+         either<MovableOnly, MovableOnly> b =
+             make_right<MovableOnly, MovableOnly>(2);
+         b = std::move(a);
+         test(a); // NOLINT(bugprone-use-after-move)
+       }},
+      EXPECT_IS_RIGHT<MovableOnly, MovableOnly>(
+          MovableOnly(0)) // 0 is moved-from value
   );
 }
 
 TEST(EitherTest, givenLeft_whenModified_thenValueIsChanged) {
-  test_with_matrix({
-      [] (std::function<void(either<int, string>&)> test) {
-        either<int, string> a(4);
-        a.left() = 5;
-        test(a);
-      }, [] (std::function<void(either<int, string>&)> test) {
-        either<int, string> a(4);
-        a.left() = 5;
-        test(a);
-      }
-    },
-    EXPECT_IS_LEFT<int, string>(5)
-  );
+  test_with_matrix(
+      {[](std::function<void(either<int, string>&)> test) {
+         either<int, string> a(4);
+         a.left() = 5;
+         test(a);
+       },
+       [](std::function<void(either<int, string>&)> test) {
+         either<int, string> a(4);
+         a.left() = 5;
+         test(a);
+       }},
+      EXPECT_IS_LEFT<int, string>(5));
 }
 
 TEST(EitherTest, givenRight_whenModified_thenValueIsChanged) {
-  test_with_matrix({
-      [] (std::function<void(either<int, string>&)> test) {
-        either<int, string> a("4");
-        a.right() = "5";
-        test(a);
-      }, [] (std::function<void(either<int, string>&)> test) {
-        either<int, string> a("4");
-        a.right() = "5";
-        test(a);
-      }
-    },
-    EXPECT_IS_RIGHT<int, string>("5")
-  );
+  test_with_matrix(
+      {[](std::function<void(either<int, string>&)> test) {
+         either<int, string> a("4");
+         a.right() = "5";
+         test(a);
+       },
+       [](std::function<void(either<int, string>&)> test) {
+         either<int, string> a("4");
+         a.right() = "5";
+         test(a);
+       }},
+      EXPECT_IS_RIGHT<int, string>("5"));
 }
 
 TEST(EitherTest, canEmplaceConstructLeft) {
-  test_with_matrix({
-      [] (std::function<void(either<tuple<int, int>, tuple<int, string, int>>&)> test) {
+  test_with_matrix(
+      {[](std::function<void(either<tuple<int, int>, tuple<int, string, int>>&)>
+              test) {
         either<tuple<int, int>, tuple<int, string, int>> a(2, 3);
         test(a);
-      }
-    },
-    EXPECT_IS_LEFT<tuple<int, int>, tuple<int, string, int>>(tuple<int, int>(2, 3))
-  );
+      }},
+      EXPECT_IS_LEFT<tuple<int, int>, tuple<int, string, int>>(
+          tuple<int, int>(2, 3)));
 }
 
 TEST(EitherTest, canEmplaceConstructRight) {
-  test_with_matrix({
-      [] (std::function<void(either<tuple<int, int>, tuple<int, string, int>>&)> test) {
+  test_with_matrix(
+      {[](std::function<void(either<tuple<int, int>, tuple<int, string, int>>&)>
+              test) {
         either<tuple<int, int>, tuple<int, string, int>> a(2, "3", 4);
         test(a);
-      }
-    },
-    EXPECT_IS_RIGHT<tuple<int, int>, tuple<int, string, int>>(tuple<int, string, int>(2, "3", 4))
-  );
+      }},
+      EXPECT_IS_RIGHT<tuple<int, int>, tuple<int, string, int>>(
+          tuple<int, string, int>(2, "3", 4)));
 }
 
 TEST(EitherTest, givenEqualLefts_thenAreEqual) {
@@ -1101,10 +1057,9 @@ TEST(EitherTest, givenLeftAndRightWithSameType_thenAreUnequal) {
   EXPECT_TRUE(b != a);
 }
 
-
 namespace {
 class DestructorCallback {
-public:
+ public:
   MOCK_CONST_METHOD0(call, void());
 
   void EXPECT_CALLED(int times = 1) {
@@ -1112,135 +1067,168 @@ public:
   }
 };
 class ClassWithDestructorCallback {
-public:
-  ClassWithDestructorCallback(const DestructorCallback *destructorCallback) : _destructorCallback(destructorCallback) {}
-  ClassWithDestructorCallback(const ClassWithDestructorCallback &rhs): _destructorCallback(rhs._destructorCallback) {}
+ public:
+  ClassWithDestructorCallback(const DestructorCallback* destructorCallback)
+      : _destructorCallback(destructorCallback) {}
+  ClassWithDestructorCallback(const ClassWithDestructorCallback& rhs)
+      : _destructorCallback(rhs._destructorCallback) {}
 
   ~ClassWithDestructorCallback() {
     _destructorCallback->call();
   }
 
-private:
-  const DestructorCallback *_destructorCallback;
+ private:
+  const DestructorCallback* _destructorCallback;
 
-  ClassWithDestructorCallback &operator=(const ClassWithDestructorCallback &rhs) = delete;
+  ClassWithDestructorCallback& operator=(
+      const ClassWithDestructorCallback& rhs) = delete;
 };
 class OnlyMoveableClassWithDestructorCallback {
-public:
-  OnlyMoveableClassWithDestructorCallback(const DestructorCallback *destructorCallback) : _destructorCallback(destructorCallback) { }
-  OnlyMoveableClassWithDestructorCallback(OnlyMoveableClassWithDestructorCallback &&source): _destructorCallback(source._destructorCallback) {}
+ public:
+  OnlyMoveableClassWithDestructorCallback(
+      const DestructorCallback* destructorCallback)
+      : _destructorCallback(destructorCallback) {}
+  OnlyMoveableClassWithDestructorCallback(
+      OnlyMoveableClassWithDestructorCallback&& source)
+      : _destructorCallback(source._destructorCallback) {}
 
   ~OnlyMoveableClassWithDestructorCallback() {
     _destructorCallback->call();
   }
 
-private:
+ private:
   C10_DISABLE_COPY_AND_ASSIGN(OnlyMoveableClassWithDestructorCallback);
-  const DestructorCallback *_destructorCallback;
+  const DestructorCallback* _destructorCallback;
 };
 
-}
+} // namespace
 
 TEST(EitherTest_Destructor, LeftDestructorIsCalled) {
-    DestructorCallback destructorCallback;
-    destructorCallback.EXPECT_CALLED(2);  //Once for the temp object, once when the either class destructs
+  DestructorCallback destructorCallback;
+  destructorCallback.EXPECT_CALLED(
+      2); // Once for the temp object, once when the either class destructs
 
-    ClassWithDestructorCallback temp(&destructorCallback);
-    either<ClassWithDestructorCallback, string> var = temp;
+  ClassWithDestructorCallback temp(&destructorCallback);
+  either<ClassWithDestructorCallback, string> var = temp;
 }
 
 TEST(EitherTest_Destructor, RightDestructorIsCalled) {
-    DestructorCallback destructorCallback;
-    destructorCallback.EXPECT_CALLED(2);  //Once for the temp object, once when the either class destructs
+  DestructorCallback destructorCallback;
+  destructorCallback.EXPECT_CALLED(
+      2); // Once for the temp object, once when the either class destructs
 
-    ClassWithDestructorCallback temp(&destructorCallback);
-    either<string, ClassWithDestructorCallback> var = temp;
+  ClassWithDestructorCallback temp(&destructorCallback);
+  either<string, ClassWithDestructorCallback> var = temp;
 }
 
 TEST(EitherTest_Destructor, LeftDestructorIsCalledAfterCopying) {
-    DestructorCallback destructorCallback;
-    destructorCallback.EXPECT_CALLED(3);  //Once for the temp object, once for var1 and once for var2
+  DestructorCallback destructorCallback;
+  destructorCallback.EXPECT_CALLED(
+      3); // Once for the temp object, once for var1 and once for var2
 
-    ClassWithDestructorCallback temp(&destructorCallback);
-    either<ClassWithDestructorCallback, string> var1 = temp;
-    either<ClassWithDestructorCallback, string> var2 = var1;
+  ClassWithDestructorCallback temp(&destructorCallback);
+  either<ClassWithDestructorCallback, string> var1 = temp;
+  either<ClassWithDestructorCallback, string> var2 = var1;
 }
 
 TEST(EitherTest_Destructor, RightDestructorIsCalledAfterCopying) {
-    DestructorCallback destructorCallback;
-    destructorCallback.EXPECT_CALLED(3);  //Once for the temp object, once for var1 and once for var2
+  DestructorCallback destructorCallback;
+  destructorCallback.EXPECT_CALLED(
+      3); // Once for the temp object, once for var1 and once for var2
 
-    ClassWithDestructorCallback temp(&destructorCallback);
-    either<string, ClassWithDestructorCallback> var1 = temp;
-    either<string, ClassWithDestructorCallback> var2 = var1;
+  ClassWithDestructorCallback temp(&destructorCallback);
+  either<string, ClassWithDestructorCallback> var1 = temp;
+  either<string, ClassWithDestructorCallback> var2 = var1;
 }
 
 TEST(EitherTest_Destructor, LeftDestructorIsCalledAfterMoving) {
-    DestructorCallback destructorCallback;
-    destructorCallback.EXPECT_CALLED(3);  //Once for the temp object, once for var1 and once for var2
+  DestructorCallback destructorCallback;
+  destructorCallback.EXPECT_CALLED(
+      3); // Once for the temp object, once for var1 and once for var2
 
-    OnlyMoveableClassWithDestructorCallback temp(&destructorCallback);
-    either<OnlyMoveableClassWithDestructorCallback, string> var1 = std::move(temp);
-    either<OnlyMoveableClassWithDestructorCallback, string> var2 = std::move(var1);
+  OnlyMoveableClassWithDestructorCallback temp(&destructorCallback);
+  either<OnlyMoveableClassWithDestructorCallback, string> var1 =
+      std::move(temp);
+  either<OnlyMoveableClassWithDestructorCallback, string> var2 =
+      std::move(var1);
 }
 
 TEST(EitherTest_Destructor, RightDestructorIsCalledAfterMoving) {
-    DestructorCallback destructorCallback;
-    destructorCallback.EXPECT_CALLED(3);  //Once for the temp object, once for var1 and once for var2
+  DestructorCallback destructorCallback;
+  destructorCallback.EXPECT_CALLED(
+      3); // Once for the temp object, once for var1 and once for var2
 
-    OnlyMoveableClassWithDestructorCallback temp(&destructorCallback);
-    either<string, OnlyMoveableClassWithDestructorCallback> var1 = std::move(temp);
-    either<string, OnlyMoveableClassWithDestructorCallback> var2 = std::move(var1);
+  OnlyMoveableClassWithDestructorCallback temp(&destructorCallback);
+  either<string, OnlyMoveableClassWithDestructorCallback> var1 =
+      std::move(temp);
+  either<string, OnlyMoveableClassWithDestructorCallback> var2 =
+      std::move(var1);
 }
 
 TEST(EitherTest_Destructor, LeftDestructorIsCalledAfterAssignment) {
-    DestructorCallback destructorCallback1;
-    DestructorCallback destructorCallback2;
-    destructorCallback1.EXPECT_CALLED(2); //Once for the temp1 object, once at the assignment
-    destructorCallback2.EXPECT_CALLED(3); //Once for the temp2 object, once in destructor of var2, once in destructor of var1
+  DestructorCallback destructorCallback1;
+  DestructorCallback destructorCallback2;
+  destructorCallback1.EXPECT_CALLED(
+      2); // Once for the temp1 object, once at the assignment
+  destructorCallback2.EXPECT_CALLED(
+      3); // Once for the temp2 object, once in destructor of var2, once in
+          // destructor of var1
 
-    ClassWithDestructorCallback temp1(&destructorCallback1);
-    either<ClassWithDestructorCallback, string> var1 = temp1;
-    ClassWithDestructorCallback temp2(&destructorCallback2);
-    either<ClassWithDestructorCallback, string> var2 = temp2;
-    var1 = var2;
+  ClassWithDestructorCallback temp1(&destructorCallback1);
+  either<ClassWithDestructorCallback, string> var1 = temp1;
+  ClassWithDestructorCallback temp2(&destructorCallback2);
+  either<ClassWithDestructorCallback, string> var2 = temp2;
+  var1 = var2;
 }
 
 TEST(EitherTest_Destructor, RightDestructorIsCalledAfterAssignment) {
-    DestructorCallback destructorCallback1;
-    DestructorCallback destructorCallback2;
-    destructorCallback1.EXPECT_CALLED(2); //Once for the temp1 object, once at the assignment
-    destructorCallback2.EXPECT_CALLED(3); //Once for the temp2 object, once in destructor of var2, once in destructor of var1
+  DestructorCallback destructorCallback1;
+  DestructorCallback destructorCallback2;
+  destructorCallback1.EXPECT_CALLED(
+      2); // Once for the temp1 object, once at the assignment
+  destructorCallback2.EXPECT_CALLED(
+      3); // Once for the temp2 object, once in destructor of var2, once in
+          // destructor of var1
 
-    ClassWithDestructorCallback temp1(&destructorCallback1);
-    either<string, ClassWithDestructorCallback> var1 = temp1;
-    ClassWithDestructorCallback temp2(&destructorCallback2);
-    either<string, ClassWithDestructorCallback> var2 = temp2;
-    var1 = var2;
+  ClassWithDestructorCallback temp1(&destructorCallback1);
+  either<string, ClassWithDestructorCallback> var1 = temp1;
+  ClassWithDestructorCallback temp2(&destructorCallback2);
+  either<string, ClassWithDestructorCallback> var2 = temp2;
+  var1 = var2;
 }
 
 TEST(EitherTest_Destructor, LeftDestructorIsCalledAfterMoveAssignment) {
-    DestructorCallback destructorCallback1;
-    DestructorCallback destructorCallback2;
-    destructorCallback1.EXPECT_CALLED(2); //Once for the temp1 object, once at the assignment
-    destructorCallback2.EXPECT_CALLED(3); //Once for the temp2 object, once in destructor of var2, once in destructor of var1
+  DestructorCallback destructorCallback1;
+  DestructorCallback destructorCallback2;
+  destructorCallback1.EXPECT_CALLED(
+      2); // Once for the temp1 object, once at the assignment
+  destructorCallback2.EXPECT_CALLED(
+      3); // Once for the temp2 object, once in destructor of var2, once in
+          // destructor of var1
 
-    OnlyMoveableClassWithDestructorCallback temp1(&destructorCallback1);
-    either<OnlyMoveableClassWithDestructorCallback, string> var1 = std::move(temp1);
-    OnlyMoveableClassWithDestructorCallback temp2(&destructorCallback2);
-    either<OnlyMoveableClassWithDestructorCallback, string> var2 = std::move(temp2);
-    var1 = std::move(var2);
+  OnlyMoveableClassWithDestructorCallback temp1(&destructorCallback1);
+  either<OnlyMoveableClassWithDestructorCallback, string> var1 =
+      std::move(temp1);
+  OnlyMoveableClassWithDestructorCallback temp2(&destructorCallback2);
+  either<OnlyMoveableClassWithDestructorCallback, string> var2 =
+      std::move(temp2);
+  var1 = std::move(var2);
 }
 
 TEST(EitherTest_Destructor, RightDestructorIsCalledAfterMoveAssignment) {
-    DestructorCallback destructorCallback1;
-    DestructorCallback destructorCallback2;
-    destructorCallback1.EXPECT_CALLED(2); //Once for the temp1 object, once at the assignment
-    destructorCallback2.EXPECT_CALLED(3); //Once for the temp2 object, once in destructor of var2, once in destructor of var1
+  DestructorCallback destructorCallback1;
+  DestructorCallback destructorCallback2;
+  destructorCallback1.EXPECT_CALLED(
+      2); // Once for the temp1 object, once at the assignment
+  destructorCallback2.EXPECT_CALLED(
+      3); // Once for the temp2 object, once in destructor of var2, once in
+          // destructor of var1
 
-    OnlyMoveableClassWithDestructorCallback temp1(&destructorCallback1);
-    either<string, OnlyMoveableClassWithDestructorCallback> var1 = std::move(temp1);
-    OnlyMoveableClassWithDestructorCallback temp2(&destructorCallback2);
-    either<string, OnlyMoveableClassWithDestructorCallback> var2 = std::move(temp2);
-    var1 = std::move(var2);
+  OnlyMoveableClassWithDestructorCallback temp1(&destructorCallback1);
+  either<string, OnlyMoveableClassWithDestructorCallback> var1 =
+      std::move(temp1);
+  OnlyMoveableClassWithDestructorCallback temp2(&destructorCallback2);
+  either<string, OnlyMoveableClassWithDestructorCallback> var2 =
+      std::move(temp2);
+  var1 = std::move(var2);
 }

--- a/c10/test/util/intrusive_ptr_test.cpp
+++ b/c10/test/util/intrusive_ptr_test.cpp
@@ -65,7 +65,8 @@ class ChildDestructableMock final : public DestructableMock {
 };
 class NullType1 final {
   static SomeClass singleton_;
-public:
+
+ public:
   static constexpr SomeClass* singleton() {
     return &singleton_;
   }
@@ -73,7 +74,8 @@ public:
 SomeClass NullType1::singleton_;
 class NullType2 final {
   static SomeClass singleton_;
-public:
+
+ public:
   static constexpr SomeClass* singleton() {
     return &singleton_;
   }
@@ -799,7 +801,8 @@ TEST(IntrusivePtrTest, givenPtr_whenDestructed_thenDestructsObject) {
   bool resourcesReleased = false;
   bool wasDestructed = false;
   {
-    auto obj = make_intrusive<DestructableMock>(&resourcesReleased, &wasDestructed);
+    auto obj =
+        make_intrusive<DestructableMock>(&resourcesReleased, &wasDestructed);
     EXPECT_FALSE(resourcesReleased);
     EXPECT_FALSE(wasDestructed);
   }
@@ -812,7 +815,8 @@ TEST(
     givenPtr_whenMoveConstructed_thenDestructsObjectAfterSecondDestructed) {
   bool resourcesReleased = false;
   bool wasDestructed = false;
-  auto obj = make_intrusive<DestructableMock>(&resourcesReleased, &wasDestructed);
+  auto obj =
+      make_intrusive<DestructableMock>(&resourcesReleased, &wasDestructed);
   {
     auto obj2 = std::move(obj);
     EXPECT_FALSE(resourcesReleased);
@@ -827,7 +831,8 @@ TEST(
     givenPtr_whenMoveConstructedToBaseClass_thenDestructsObjectAfterSecondDestructed) {
   bool resourcesReleased = false;
   bool wasDestructed = false;
-  auto obj = make_intrusive<ChildDestructableMock>(&resourcesReleased, &wasDestructed);
+  auto obj =
+      make_intrusive<ChildDestructableMock>(&resourcesReleased, &wasDestructed);
   {
     intrusive_ptr<DestructableMock> obj2 = std::move(obj);
     EXPECT_FALSE(resourcesReleased);
@@ -843,7 +848,8 @@ TEST(IntrusivePtrTest, givenPtr_whenMoveAssigned_thenDestructsOldObject) {
   bool wasDestructed = false;
   auto obj = make_intrusive<DestructableMock>(&dummy, &dummy);
   {
-    auto obj2 = make_intrusive<DestructableMock>(&resourcesReleased, &wasDestructed);
+    auto obj2 =
+        make_intrusive<DestructableMock>(&resourcesReleased, &wasDestructed);
     EXPECT_FALSE(resourcesReleased);
     EXPECT_FALSE(wasDestructed);
     obj2 = std::move(obj);
@@ -860,7 +866,8 @@ TEST(
   bool wasDestructed = false;
   auto obj = make_intrusive<ChildDestructableMock>(&dummy, &dummy);
   {
-    auto obj2 = make_intrusive<DestructableMock>(&resourcesReleased, &wasDestructed);
+    auto obj2 =
+        make_intrusive<DestructableMock>(&resourcesReleased, &wasDestructed);
     EXPECT_FALSE(resourcesReleased);
     EXPECT_FALSE(wasDestructed);
     obj2 = std::move(obj);
@@ -877,7 +884,8 @@ TEST(
   bool wasDestructed = false;
   auto obj = make_intrusive<DestructableMock>(&dummy, &dummy);
   {
-    auto obj2 = make_intrusive<DestructableMock>(&resourcesReleased, &wasDestructed);
+    auto obj2 =
+        make_intrusive<DestructableMock>(&resourcesReleased, &wasDestructed);
     {
       auto copy = obj2;
       EXPECT_FALSE(resourcesReleased);
@@ -899,8 +907,8 @@ TEST(
   bool wasDestructed = false;
   auto obj = make_intrusive<ChildDestructableMock>(&dummy, &dummy);
   {
-    auto obj2 =
-        make_intrusive<ChildDestructableMock>(&resourcesReleased, &wasDestructed);
+    auto obj2 = make_intrusive<ChildDestructableMock>(
+        &resourcesReleased, &wasDestructed);
     {
       intrusive_ptr<DestructableMock> copy = obj2;
       EXPECT_FALSE(resourcesReleased);
@@ -922,7 +930,8 @@ TEST(
   bool wasDestructed = false;
   auto obj = make_intrusive<ChildDestructableMock>(&dummy, &dummy);
   {
-    auto obj2 = make_intrusive<DestructableMock>(&resourcesReleased, &wasDestructed);
+    auto obj2 =
+        make_intrusive<DestructableMock>(&resourcesReleased, &wasDestructed);
     {
       intrusive_ptr<DestructableMock> copy = obj2;
       EXPECT_FALSE(resourcesReleased);
@@ -942,7 +951,8 @@ TEST(
   bool dummy = false;
   bool resourcesReleased = false;
   bool wasDestructed = false;
-  auto obj = make_intrusive<DestructableMock>(&resourcesReleased, &wasDestructed);
+  auto obj =
+      make_intrusive<DestructableMock>(&resourcesReleased, &wasDestructed);
   {
     auto obj2 = make_intrusive<DestructableMock>(&dummy, &dummy);
     obj2 = std::move(obj);
@@ -959,7 +969,8 @@ TEST(
   bool dummy = false;
   bool resourcesReleased = false;
   bool wasDestructed = false;
-  auto obj = make_intrusive<ChildDestructableMock>(&resourcesReleased, &wasDestructed);
+  auto obj =
+      make_intrusive<ChildDestructableMock>(&resourcesReleased, &wasDestructed);
   {
     auto obj2 = make_intrusive<DestructableMock>(&dummy, &dummy);
     obj2 = std::move(obj);
@@ -976,7 +987,8 @@ TEST(
   bool resourcesReleased = false;
   bool wasDestructed = false;
   {
-    auto obj = make_intrusive<DestructableMock>(&resourcesReleased, &wasDestructed);
+    auto obj =
+        make_intrusive<DestructableMock>(&resourcesReleased, &wasDestructed);
     {
       intrusive_ptr<DestructableMock> copy = obj;
       EXPECT_FALSE(resourcesReleased);
@@ -995,7 +1007,8 @@ TEST(
   bool resourcesReleased = false;
   bool wasDestructed = false;
   {
-    auto obj = make_intrusive<ChildDestructableMock>(&resourcesReleased, &wasDestructed);
+    auto obj = make_intrusive<ChildDestructableMock>(
+        &resourcesReleased, &wasDestructed);
     {
       intrusive_ptr<DestructableMock> copy = obj;
       EXPECT_FALSE(resourcesReleased);
@@ -1014,7 +1027,8 @@ TEST(
   bool resourcesReleased = false;
   bool wasDestructed = false;
   {
-    auto obj = make_intrusive<DestructableMock>(&resourcesReleased, &wasDestructed);
+    auto obj =
+        make_intrusive<DestructableMock>(&resourcesReleased, &wasDestructed);
     intrusive_ptr<DestructableMock> copy = obj;
     obj.reset();
     EXPECT_FALSE(resourcesReleased);
@@ -1030,7 +1044,8 @@ TEST(
   bool resourcesReleased = false;
   bool wasDestructed = false;
   {
-    auto obj = make_intrusive<ChildDestructableMock>(&resourcesReleased, &wasDestructed);
+    auto obj = make_intrusive<ChildDestructableMock>(
+        &resourcesReleased, &wasDestructed);
     intrusive_ptr<DestructableMock> copy = obj;
     obj.reset();
     EXPECT_FALSE(resourcesReleased);
@@ -1047,7 +1062,8 @@ TEST(
   bool wasDestructed = false;
   bool dummy = false;
   {
-    auto obj = make_intrusive<DestructableMock>(&resourcesReleased, &wasDestructed);
+    auto obj =
+        make_intrusive<DestructableMock>(&resourcesReleased, &wasDestructed);
     {
       intrusive_ptr<DestructableMock> copy =
           make_intrusive<DestructableMock>(&dummy, &dummy);
@@ -1069,7 +1085,8 @@ TEST(
   bool wasDestructed = false;
   bool dummy = false;
   {
-    auto obj = make_intrusive<ChildDestructableMock>(&resourcesReleased, &wasDestructed);
+    auto obj = make_intrusive<ChildDestructableMock>(
+        &resourcesReleased, &wasDestructed);
     {
       intrusive_ptr<DestructableMock> copy =
           make_intrusive<DestructableMock>(&dummy, &dummy);
@@ -1093,7 +1110,8 @@ TEST(
   {
     auto copy = make_intrusive<DestructableMock>(&dummy, &dummy);
     {
-      auto obj = make_intrusive<DestructableMock>(&resourcesReleased, &wasDestructed);
+      auto obj =
+          make_intrusive<DestructableMock>(&resourcesReleased, &wasDestructed);
       copy = obj;
       EXPECT_FALSE(resourcesReleased);
       EXPECT_FALSE(wasDestructed);
@@ -1114,8 +1132,8 @@ TEST(
   {
     auto copy = make_intrusive<DestructableMock>(&dummy, &dummy);
     {
-      auto obj =
-          make_intrusive<ChildDestructableMock>(&resourcesReleased, &wasDestructed);
+      auto obj = make_intrusive<ChildDestructableMock>(
+          &resourcesReleased, &wasDestructed);
       copy = obj;
       EXPECT_FALSE(resourcesReleased);
       EXPECT_FALSE(wasDestructed);
@@ -1133,7 +1151,8 @@ TEST(IntrusivePtrTest, givenPtr_whenCopyAssigned_thenDestructsOldObject) {
   bool wasDestructed = false;
   auto obj = make_intrusive<DestructableMock>(&dummy, &dummy);
   {
-    auto obj2 = make_intrusive<DestructableMock>(&resourcesReleased, &wasDestructed);
+    auto obj2 =
+        make_intrusive<DestructableMock>(&resourcesReleased, &wasDestructed);
     EXPECT_FALSE(resourcesReleased);
     EXPECT_FALSE(wasDestructed);
     obj2 = obj;
@@ -1150,7 +1169,8 @@ TEST(
   bool wasDestructed = false;
   auto obj = make_intrusive<ChildDestructableMock>(&dummy, &dummy);
   {
-    auto obj2 = make_intrusive<DestructableMock>(&resourcesReleased, &wasDestructed);
+    auto obj2 =
+        make_intrusive<DestructableMock>(&resourcesReleased, &wasDestructed);
     EXPECT_FALSE(resourcesReleased);
     EXPECT_FALSE(wasDestructed);
     obj2 = obj;
@@ -1167,7 +1187,8 @@ TEST(
   bool wasDestructed = false;
   auto obj = make_intrusive<DestructableMock>(&dummy, &dummy);
   {
-    auto obj2 = make_intrusive<DestructableMock>(&resourcesReleased, &wasDestructed);
+    auto obj2 =
+        make_intrusive<DestructableMock>(&resourcesReleased, &wasDestructed);
     {
       auto copy = obj2;
       EXPECT_FALSE(resourcesReleased);
@@ -1189,8 +1210,8 @@ TEST(
   bool wasDestructed = false;
   auto obj = make_intrusive<ChildDestructableMock>(&dummy, &dummy);
   {
-    auto obj2 =
-        make_intrusive<ChildDestructableMock>(&resourcesReleased, &wasDestructed);
+    auto obj2 = make_intrusive<ChildDestructableMock>(
+        &resourcesReleased, &wasDestructed);
     {
       intrusive_ptr<DestructableMock> copy = obj2;
       EXPECT_FALSE(resourcesReleased);
@@ -1212,7 +1233,8 @@ TEST(
   bool wasDestructed = false;
   auto obj = make_intrusive<ChildDestructableMock>(&dummy, &dummy);
   {
-    auto obj2 = make_intrusive<DestructableMock>(&resourcesReleased, &wasDestructed);
+    auto obj2 =
+        make_intrusive<DestructableMock>(&resourcesReleased, &wasDestructed);
     {
       intrusive_ptr<DestructableMock> copy = obj2;
       EXPECT_FALSE(resourcesReleased);
@@ -1229,7 +1251,8 @@ TEST(
 TEST(IntrusivePtrTest, givenPtr_whenCallingReset_thenDestructs) {
   bool resourcesReleased = false;
   bool wasDestructed = false;
-  auto obj = make_intrusive<DestructableMock>(&resourcesReleased, &wasDestructed);
+  auto obj =
+      make_intrusive<DestructableMock>(&resourcesReleased, &wasDestructed);
   EXPECT_FALSE(resourcesReleased);
   EXPECT_FALSE(wasDestructed);
   obj.reset();
@@ -1242,7 +1265,8 @@ TEST(
     givenPtrWithCopy_whenCallingReset_thenDestructsAfterCopyDestructed) {
   bool resourcesReleased = false;
   bool wasDestructed = false;
-  auto obj = make_intrusive<DestructableMock>(&resourcesReleased, &wasDestructed);
+  auto obj =
+      make_intrusive<DestructableMock>(&resourcesReleased, &wasDestructed);
   {
     auto copy = obj;
     obj.reset();
@@ -1259,7 +1283,8 @@ TEST(
     givenPtrWithCopy_whenCallingResetOnCopy_thenDestructsAfterOriginalDestructed) {
   bool resourcesReleased = false;
   bool wasDestructed = false;
-  auto obj = make_intrusive<DestructableMock>(&resourcesReleased, &wasDestructed);
+  auto obj =
+      make_intrusive<DestructableMock>(&resourcesReleased, &wasDestructed);
   {
     auto copy = obj;
     copy.reset();
@@ -1276,7 +1301,8 @@ TEST(
     givenPtrWithMoved_whenCallingReset_thenDestructsAfterMovedDestructed) {
   bool resourcesReleased = false;
   bool wasDestructed = false;
-  auto obj = make_intrusive<DestructableMock>(&resourcesReleased, &wasDestructed);
+  auto obj =
+      make_intrusive<DestructableMock>(&resourcesReleased, &wasDestructed);
   {
     auto moved = std::move(obj);
     obj.reset();
@@ -1293,7 +1319,8 @@ TEST(
     givenPtrWithMoved_whenCallingResetOnMoved_thenDestructsImmediately) {
   bool resourcesReleased = false;
   bool wasDestructed = false;
-  auto obj = make_intrusive<DestructableMock>(&resourcesReleased, &wasDestructed);
+  auto obj =
+      make_intrusive<DestructableMock>(&resourcesReleased, &wasDestructed);
   {
     auto moved = std::move(obj);
     moved.reset();
@@ -1585,9 +1612,7 @@ TEST(IntrusivePtrTest, givenPtr_whenNonOwningReclaimed_thenDoesntCrash) {
   EXPECT_EQ(reclaimed.get(), obj.get());
 }
 
-TEST(
-    IntrusivePtrTest,
-    givenPtr_whenNonOwningReclaimed_thenIsDestructedAtEnd) {
+TEST(IntrusivePtrTest, givenPtr_whenNonOwningReclaimed_thenIsDestructedAtEnd) {
   bool resourcesReleased = false;
   bool wasDestructed = false;
   {
@@ -1625,7 +1650,9 @@ weak_intrusive_ptr<T> make_weak_only(Args&&... args) {
   auto intrusive = make_intrusive<T>(std::forward<Args>(args)...);
   return weak_intrusive_ptr<T>(intrusive);
 }
-template <class T, class NullType = c10::detail::intrusive_target_default_null_type<T>>
+template <
+    class T,
+    class NullType = c10::detail::intrusive_target_default_null_type<T>>
 weak_intrusive_ptr<T, NullType> make_invalid_weak() {
   return weak_intrusive_ptr<T, NullType>(intrusive_ptr<T, NullType>());
 }
@@ -1860,8 +1887,10 @@ TEST(
 TEST(
     WeakIntrusivePtrTest,
     givenNullPtr_whenMoveAssigningToDifferentNullptr_thenHasNewNullptr) {
-  weak_intrusive_ptr<SomeClass, NullType1> obj1 = make_invalid_weak<SomeClass, NullType1>();
-  weak_intrusive_ptr<SomeClass, NullType2> obj2 = make_invalid_weak<SomeClass, NullType2>();
+  weak_intrusive_ptr<SomeClass, NullType1> obj1 =
+      make_invalid_weak<SomeClass, NullType1>();
+  weak_intrusive_ptr<SomeClass, NullType2> obj2 =
+      make_invalid_weak<SomeClass, NullType2>();
   obj2 = std::move(obj1);
   EXPECT_NE(NullType1::singleton(), NullType2::singleton());
   EXPECT_TRUE(obj1.expired());
@@ -2049,8 +2078,10 @@ TEST(
 TEST(
     WeakIntrusivePtrTest,
     givenNullPtr_whenCopyAssigningToDifferentNullptr_thenHasNewNullptr) {
-  weak_intrusive_ptr<SomeClass, NullType1> obj1 = make_invalid_weak<SomeClass, NullType1>();
-  weak_intrusive_ptr<SomeClass, NullType2> obj2 = make_invalid_weak<SomeClass, NullType2>();
+  weak_intrusive_ptr<SomeClass, NullType1> obj1 =
+      make_invalid_weak<SomeClass, NullType1>();
+  weak_intrusive_ptr<SomeClass, NullType2> obj2 =
+      make_invalid_weak<SomeClass, NullType2>();
   obj2 = obj1;
   EXPECT_NE(NullType1::singleton(), NullType2::singleton());
   EXPECT_TRUE(obj1.expired());
@@ -2144,7 +2175,8 @@ TEST(
 TEST(
     WeakIntrusivePtrTest,
     givenNullPtr_whenMoveConstructingToDifferentNullptr_thenHasNewNullptr) {
-  weak_intrusive_ptr<SomeClass, NullType1> obj1 = make_invalid_weak<SomeClass, NullType1>();
+  weak_intrusive_ptr<SomeClass, NullType1> obj1 =
+      make_invalid_weak<SomeClass, NullType1>();
   weak_intrusive_ptr<SomeClass, NullType2> obj2 = std::move(obj1);
   EXPECT_NE(NullType1::singleton(), NullType2::singleton());
   EXPECT_TRUE(obj1.expired());
@@ -2237,7 +2269,8 @@ TEST(
 TEST(
     WeakIntrusivePtrTest,
     givenNullPtr_whenCopyConstructingToDifferentNullptr_thenHasNewNullptr) {
-  weak_intrusive_ptr<SomeClass, NullType1> obj1 = make_invalid_weak<SomeClass, NullType1>();
+  weak_intrusive_ptr<SomeClass, NullType1> obj1 =
+      make_invalid_weak<SomeClass, NullType1>();
   weak_intrusive_ptr<SomeClass, NullType2> obj2 = obj1;
   EXPECT_NE(NullType1::singleton(), NullType2::singleton());
   EXPECT_TRUE(obj1.expired());
@@ -2756,7 +2789,8 @@ TEST(
     givenPtr_whenLastStrongPointerResets_thenReleasesResources) {
   bool resourcesReleased = false;
   bool wasDestructed = false;
-  auto obj = make_weak_intrusive<DestructableMock>(&resourcesReleased, &wasDestructed);
+  auto obj =
+      make_weak_intrusive<DestructableMock>(&resourcesReleased, &wasDestructed);
   EXPECT_FALSE(resourcesReleased);
   EXPECT_FALSE(wasDestructed);
   obj.ptr.reset();
@@ -2772,7 +2806,8 @@ TEST(
     givenPtr_whenDestructedButStillHasStrongPointers_thenDoesntReleaseResources) {
   bool resourcesReleased = false;
   bool wasDestructed = false;
-  auto obj = make_weak_intrusive<DestructableMock>(&resourcesReleased, &wasDestructed);
+  auto obj =
+      make_weak_intrusive<DestructableMock>(&resourcesReleased, &wasDestructed);
   EXPECT_FALSE(resourcesReleased);
   EXPECT_FALSE(wasDestructed);
   obj.weak.reset();
@@ -2787,7 +2822,8 @@ TEST(WeakIntrusivePtrTest, givenPtr_whenDestructed_thenDestructsObject) {
   bool resourcesReleased = false;
   bool wasDestructed = false;
   {
-    auto obj = make_weak_only<DestructableMock>(&resourcesReleased, &wasDestructed);
+    auto obj =
+        make_weak_only<DestructableMock>(&resourcesReleased, &wasDestructed);
     EXPECT_TRUE(resourcesReleased);
     EXPECT_FALSE(wasDestructed);
   }
@@ -2800,7 +2836,8 @@ TEST(
     givenPtr_whenMoveConstructed_thenDestructsObjectAfterSecondDestructed) {
   bool resourcesReleased = false;
   bool wasDestructed = false;
-  auto obj = make_weak_only<DestructableMock>(&resourcesReleased, &wasDestructed);
+  auto obj =
+      make_weak_only<DestructableMock>(&resourcesReleased, &wasDestructed);
   {
     auto obj2 = std::move(obj);
     EXPECT_TRUE(resourcesReleased);
@@ -2815,7 +2852,8 @@ TEST(
     givenPtr_whenMoveConstructedToBaseClass_thenDestructsObjectAfterSecondDestructed) {
   bool resourcesReleased = false;
   bool wasDestructed = false;
-  auto obj = make_weak_only<ChildDestructableMock>(&resourcesReleased, &wasDestructed);
+  auto obj =
+      make_weak_only<ChildDestructableMock>(&resourcesReleased, &wasDestructed);
   {
     weak_intrusive_ptr<DestructableMock> obj2 = std::move(obj);
     EXPECT_TRUE(resourcesReleased);
@@ -2831,7 +2869,8 @@ TEST(WeakIntrusivePtrTest, givenPtr_whenMoveAssigned_thenDestructsOldObject) {
   bool wasDestructed = false;
   auto obj = make_weak_only<DestructableMock>(&dummy, &dummy);
   {
-    auto obj2 = make_weak_only<DestructableMock>(&resourcesReleased, &wasDestructed);
+    auto obj2 =
+        make_weak_only<DestructableMock>(&resourcesReleased, &wasDestructed);
     EXPECT_TRUE(resourcesReleased);
     EXPECT_FALSE(wasDestructed);
     obj2 = std::move(obj);
@@ -2848,7 +2887,8 @@ TEST(
   bool wasDestructed = false;
   auto obj = make_weak_only<ChildDestructableMock>(&dummy, &dummy);
   {
-    auto obj2 = make_weak_only<DestructableMock>(&resourcesReleased, &wasDestructed);
+    auto obj2 =
+        make_weak_only<DestructableMock>(&resourcesReleased, &wasDestructed);
     EXPECT_TRUE(resourcesReleased);
     EXPECT_FALSE(wasDestructed);
     obj2 = std::move(obj);
@@ -2865,7 +2905,8 @@ TEST(
   bool wasDestructed = false;
   auto obj = make_weak_only<DestructableMock>(&dummy, &dummy);
   {
-    auto obj2 = make_weak_only<DestructableMock>(&resourcesReleased, &wasDestructed);
+    auto obj2 =
+        make_weak_only<DestructableMock>(&resourcesReleased, &wasDestructed);
     {
       auto copy = obj2;
       EXPECT_TRUE(resourcesReleased);
@@ -2887,8 +2928,8 @@ TEST(
   bool wasDestructed = false;
   auto obj = make_weak_only<ChildDestructableMock>(&dummy, &dummy);
   {
-    auto obj2 =
-        make_weak_only<ChildDestructableMock>(&resourcesReleased, &wasDestructed);
+    auto obj2 = make_weak_only<ChildDestructableMock>(
+        &resourcesReleased, &wasDestructed);
     {
       weak_intrusive_ptr<DestructableMock> copy = obj2;
       EXPECT_TRUE(resourcesReleased);
@@ -2910,7 +2951,8 @@ TEST(
   bool wasDestructed = false;
   auto obj = make_weak_only<ChildDestructableMock>(&dummy, &dummy);
   {
-    auto obj2 = make_weak_only<DestructableMock>(&resourcesReleased, &wasDestructed);
+    auto obj2 =
+        make_weak_only<DestructableMock>(&resourcesReleased, &wasDestructed);
     {
       weak_intrusive_ptr<DestructableMock> copy = obj2;
       EXPECT_TRUE(resourcesReleased);
@@ -2930,7 +2972,8 @@ TEST(
   bool dummy = false;
   bool resourcesReleased = false;
   bool wasDestructed = false;
-  auto obj = make_weak_only<DestructableMock>(&resourcesReleased, &wasDestructed);
+  auto obj =
+      make_weak_only<DestructableMock>(&resourcesReleased, &wasDestructed);
   {
     auto obj2 = make_weak_only<DestructableMock>(&dummy, &dummy);
     obj2 = std::move(obj);
@@ -2947,7 +2990,8 @@ TEST(
   bool dummy = false;
   bool resourcesReleased = false;
   bool wasDestructed = false;
-  auto obj = make_weak_only<ChildDestructableMock>(&resourcesReleased, &wasDestructed);
+  auto obj =
+      make_weak_only<ChildDestructableMock>(&resourcesReleased, &wasDestructed);
   {
     auto obj2 = make_weak_only<DestructableMock>(&dummy, &dummy);
     obj2 = std::move(obj);
@@ -2964,7 +3008,8 @@ TEST(
   bool resourcesReleased = false;
   bool wasDestructed = false;
   {
-    auto obj = make_weak_only<DestructableMock>(&resourcesReleased, &wasDestructed);
+    auto obj =
+        make_weak_only<DestructableMock>(&resourcesReleased, &wasDestructed);
     {
       weak_intrusive_ptr<DestructableMock> copy = obj;
       EXPECT_TRUE(resourcesReleased);
@@ -2983,7 +3028,8 @@ TEST(
   bool resourcesReleased = false;
   bool wasDestructed = false;
   {
-    auto obj = make_weak_only<ChildDestructableMock>(&resourcesReleased, &wasDestructed);
+    auto obj = make_weak_only<ChildDestructableMock>(
+        &resourcesReleased, &wasDestructed);
     {
       weak_intrusive_ptr<DestructableMock> copy = obj;
       EXPECT_TRUE(resourcesReleased);
@@ -3002,7 +3048,8 @@ TEST(
   bool resourcesReleased = false;
   bool wasDestructed = false;
   {
-    auto obj = make_weak_only<DestructableMock>(&resourcesReleased, &wasDestructed);
+    auto obj =
+        make_weak_only<DestructableMock>(&resourcesReleased, &wasDestructed);
     weak_intrusive_ptr<DestructableMock> copy = obj;
     obj.reset();
     EXPECT_TRUE(resourcesReleased);
@@ -3018,7 +3065,8 @@ TEST(
   bool resourcesReleased = false;
   bool wasDestructed = false;
   {
-    auto obj = make_weak_only<ChildDestructableMock>(&resourcesReleased, &wasDestructed);
+    auto obj = make_weak_only<ChildDestructableMock>(
+        &resourcesReleased, &wasDestructed);
     weak_intrusive_ptr<DestructableMock> copy = obj;
     obj.reset();
     EXPECT_TRUE(resourcesReleased);
@@ -3035,7 +3083,8 @@ TEST(
   bool wasDestructed = false;
   bool dummy = false;
   {
-    auto obj = make_weak_only<DestructableMock>(&resourcesReleased, &wasDestructed);
+    auto obj =
+        make_weak_only<DestructableMock>(&resourcesReleased, &wasDestructed);
     {
       weak_intrusive_ptr<DestructableMock> copy =
           make_weak_only<DestructableMock>(&dummy, &dummy);
@@ -3057,7 +3106,8 @@ TEST(
   bool wasDestructed = false;
   bool dummy = false;
   {
-    auto obj = make_weak_only<ChildDestructableMock>(&resourcesReleased, &wasDestructed);
+    auto obj = make_weak_only<ChildDestructableMock>(
+        &resourcesReleased, &wasDestructed);
     {
       weak_intrusive_ptr<DestructableMock> copy =
           make_weak_only<DestructableMock>(&dummy, &dummy);
@@ -3081,7 +3131,8 @@ TEST(
   {
     auto copy = make_weak_only<DestructableMock>(&dummy, &dummy);
     {
-      auto obj = make_weak_only<DestructableMock>(&resourcesReleased, &wasDestructed);
+      auto obj =
+          make_weak_only<DestructableMock>(&resourcesReleased, &wasDestructed);
       copy = obj;
       EXPECT_TRUE(resourcesReleased);
       EXPECT_FALSE(wasDestructed);
@@ -3102,8 +3153,8 @@ TEST(
   {
     auto copy = make_weak_only<DestructableMock>(&dummy, &dummy);
     {
-      auto obj =
-          make_weak_only<ChildDestructableMock>(&resourcesReleased, &wasDestructed);
+      auto obj = make_weak_only<ChildDestructableMock>(
+          &resourcesReleased, &wasDestructed);
       copy = obj;
       EXPECT_TRUE(resourcesReleased);
       EXPECT_FALSE(wasDestructed);
@@ -3121,7 +3172,8 @@ TEST(WeakIntrusivePtrTest, givenPtr_whenCopyAssigned_thenDestructsOldObject) {
   bool wasDestructed = false;
   auto obj = make_weak_only<DestructableMock>(&dummy, &dummy);
   {
-    auto obj2 = make_weak_only<DestructableMock>(&resourcesReleased, &wasDestructed);
+    auto obj2 =
+        make_weak_only<DestructableMock>(&resourcesReleased, &wasDestructed);
     EXPECT_TRUE(resourcesReleased);
     EXPECT_FALSE(wasDestructed);
     obj2 = obj;
@@ -3138,7 +3190,8 @@ TEST(
   bool wasDestructed = false;
   auto obj = make_weak_only<ChildDestructableMock>(&dummy, &dummy);
   {
-    auto obj2 = make_weak_only<DestructableMock>(&resourcesReleased, &wasDestructed);
+    auto obj2 =
+        make_weak_only<DestructableMock>(&resourcesReleased, &wasDestructed);
     EXPECT_TRUE(resourcesReleased);
     EXPECT_FALSE(wasDestructed);
     obj2 = obj;
@@ -3155,7 +3208,8 @@ TEST(
   bool wasDestructed = false;
   auto obj = make_weak_only<DestructableMock>(&dummy, &dummy);
   {
-    auto obj2 = make_weak_only<DestructableMock>(&resourcesReleased, &wasDestructed);
+    auto obj2 =
+        make_weak_only<DestructableMock>(&resourcesReleased, &wasDestructed);
     {
       auto copy = obj2;
       EXPECT_TRUE(resourcesReleased);
@@ -3177,8 +3231,8 @@ TEST(
   bool wasDestructed = false;
   auto obj = make_weak_only<ChildDestructableMock>(&dummy, &dummy);
   {
-    auto obj2 =
-        make_weak_only<ChildDestructableMock>(&resourcesReleased, &wasDestructed);
+    auto obj2 = make_weak_only<ChildDestructableMock>(
+        &resourcesReleased, &wasDestructed);
     {
       weak_intrusive_ptr<DestructableMock> copy = obj2;
       EXPECT_TRUE(resourcesReleased);
@@ -3200,7 +3254,8 @@ TEST(
   bool wasDestructed = false;
   auto obj = make_weak_only<ChildDestructableMock>(&dummy, &dummy);
   {
-    auto obj2 = make_weak_only<DestructableMock>(&resourcesReleased, &wasDestructed);
+    auto obj2 =
+        make_weak_only<DestructableMock>(&resourcesReleased, &wasDestructed);
     {
       weak_intrusive_ptr<DestructableMock> copy = obj2;
       EXPECT_TRUE(resourcesReleased);
@@ -3217,7 +3272,8 @@ TEST(
 TEST(WeakIntrusivePtrTest, givenPtr_whenCallingReset_thenDestructs) {
   bool resourcesReleased = false;
   bool wasDestructed = false;
-  auto obj = make_weak_only<DestructableMock>(&resourcesReleased, &wasDestructed);
+  auto obj =
+      make_weak_only<DestructableMock>(&resourcesReleased, &wasDestructed);
   EXPECT_TRUE(resourcesReleased);
   EXPECT_FALSE(wasDestructed);
   obj.reset();
@@ -3230,7 +3286,8 @@ TEST(
     givenPtrWithCopy_whenCallingReset_thenDestructsAfterCopyDestructed) {
   bool resourcesReleased = false;
   bool wasDestructed = false;
-  auto obj = make_weak_only<DestructableMock>(&resourcesReleased, &wasDestructed);
+  auto obj =
+      make_weak_only<DestructableMock>(&resourcesReleased, &wasDestructed);
   {
     auto copy = obj;
     obj.reset();
@@ -3247,7 +3304,8 @@ TEST(
     givenPtrWithCopy_whenCallingResetOnCopy_thenDestructsAfterOriginalDestructed) {
   bool resourcesReleased = false;
   bool wasDestructed = false;
-  auto obj = make_weak_only<DestructableMock>(&resourcesReleased, &wasDestructed);
+  auto obj =
+      make_weak_only<DestructableMock>(&resourcesReleased, &wasDestructed);
   {
     auto copy = obj;
     copy.reset();
@@ -3264,7 +3322,8 @@ TEST(
     givenPtrWithMoved_whenCallingReset_thenDestructsAfterMovedDestructed) {
   bool resourcesReleased = false;
   bool wasDestructed = false;
-  auto obj = make_weak_only<DestructableMock>(&resourcesReleased, &wasDestructed);
+  auto obj =
+      make_weak_only<DestructableMock>(&resourcesReleased, &wasDestructed);
   {
     auto moved = std::move(obj);
     obj.reset();
@@ -3281,7 +3340,8 @@ TEST(
     givenPtrWithMoved_whenCallingResetOnMoved_thenDestructsImmediately) {
   bool resourcesReleased = false;
   bool wasDestructed = false;
-  auto obj = make_weak_only<DestructableMock>(&resourcesReleased, &wasDestructed);
+  auto obj =
+      make_weak_only<DestructableMock>(&resourcesReleased, &wasDestructed);
   {
     auto moved = std::move(obj);
     moved.reset();

--- a/c10/test/util/logging_test.cpp
+++ b/c10/test/util/logging_test.cpp
@@ -1,7 +1,7 @@
 #include <algorithm>
 
-#include <gtest/gtest.h>
 #include <c10/util/Logging.h>
+#include <gtest/gtest.h>
 
 namespace c10_test {
 

--- a/c10/test/util/ordered_preserving_dict_test.cpp
+++ b/c10/test/util/ordered_preserving_dict_test.cpp
@@ -1,6 +1,6 @@
-#include <vector>
-#include <unordered_set>
 #include <algorithm>
+#include <unordered_set>
+#include <vector>
 
 #include <c10/macros/Macros.h>
 #include <c10/util/Exception.h>
@@ -11,7 +11,8 @@ namespace {
 
 #define ASSERT_EQUAL_PRIM(t1, t2) ASSERT_TRUE(t1 == t2);
 
-using dict_int_int = ska_ordered::order_preserving_flat_hash_map<int64_t, int64_t>;
+using dict_int_int =
+    ska_ordered::order_preserving_flat_hash_map<int64_t, int64_t>;
 
 dict_int_int test_dict(dict_int_int& dict) {
   for (int64_t i = 0; i < 100; ++i) {
@@ -19,14 +20,14 @@ dict_int_int test_dict(dict_int_int& dict) {
   }
 
   int64_t i = 0;
-  for (auto entry: dict) {
+  for (auto entry : dict) {
     TORCH_INTERNAL_ASSERT(entry.first == i && entry.second == i + 1);
     ++i;
   }
 
   // erase a few entries by themselves
   std::unordered_set<int64_t> erase_set = {0, 2, 9, 71};
-  for (auto erase: erase_set) {
+  for (auto erase : erase_set) {
     dict.erase(erase);
   }
 
@@ -50,7 +51,7 @@ dict_int_int test_dict(dict_int_int& dict) {
   }
 
   i = 0;
-  for (auto entry: dict) {
+  for (auto entry : dict) {
     TORCH_INTERNAL_ASSERT(order[i] == entry.first);
     TORCH_INTERNAL_ASSERT(dict[order[i]] == entry.second);
     TORCH_INTERNAL_ASSERT(entry.second == order[i] + 1);
@@ -82,10 +83,10 @@ TEST(OrderedPreservingDictTest, InsertExistingDoesntAffectOrder) {
   TORCH_INTERNAL_ASSERT(dict.begin()->first == 1);
 }
 
-
 TEST(OrderedPreservingDictTest, testRefType) {
   std::shared_ptr<int64_t> t;
-  using dict_references = ska_ordered::order_preserving_flat_hash_map<int64_t, std::shared_ptr<int64_t>>;
+  using dict_references = ska_ordered::
+      order_preserving_flat_hash_map<int64_t, std::shared_ptr<int64_t>>;
 
   dict_references dict;
 
@@ -99,7 +100,6 @@ TEST(OrderedPreservingDictTest, testRefType) {
   dict.clear();
   TORCH_INTERNAL_ASSERT(ptr.use_count() == 1);
 }
-
 
 TEST(OrderedPreservingDictTest, DictCollisions) {
   struct BadHash {
@@ -159,263 +159,298 @@ TEST(OrderedPreservingDictTest, DictCollisions) {
   }
 }
 
-
-// Tests taken from https://github.com/Tessil/ordered-map/blob/master/tests/ordered_map_tests.cpp
+// Tests taken from
+// https://github.com/Tessil/ordered-map/blob/master/tests/ordered_map_tests.cpp
 
 TEST(OrderedPreservingDictTest, test_range_insert) {
-    // insert x values in vector, range insert x-15 values from vector to map, check values
-    const int nb_values = 1000;
-    std::vector<std::pair<int, int>> values;
-    for(int i = 0; i < nb_values; i++) {
-        values.push_back(std::make_pair(i, i+1));
-    }
+  // insert x values in vector, range insert x-15 values from vector to map,
+  // check values
+  const int nb_values = 1000;
+  std::vector<std::pair<int, int>> values;
+  for (int i = 0; i < nb_values; i++) {
+    values.push_back(std::make_pair(i, i + 1));
+  }
 
-    dict_int_int map = {{-1, 0}, {-2, 0}};
-    map.insert(values.begin() + 10, values.end() - 5);
+  dict_int_int map = {{-1, 0}, {-2, 0}};
+  map.insert(values.begin() + 10, values.end() - 5);
 
-    TORCH_INTERNAL_ASSERT(map.size(), 987);
+  TORCH_INTERNAL_ASSERT(map.size(), 987);
 
-    ASSERT_EQUAL_PRIM(map.at(-1), 0);
+  ASSERT_EQUAL_PRIM(map.at(-1), 0);
 
-    ASSERT_EQUAL_PRIM(map.at(-2), 0);
+  ASSERT_EQUAL_PRIM(map.at(-2), 0);
 
-    for(int i = 10, j = 2; i < nb_values - 5; i++, j++) {
-        ASSERT_EQUAL_PRIM(map.at(i), i+1);
-    }
+  for (int i = 10, j = 2; i < nb_values - 5; i++, j++) {
+    ASSERT_EQUAL_PRIM(map.at(i), i + 1);
+  }
 }
 
 TEST(OrderedPreservingDictTest, test_range_erase_all) {
-    // insert x values, delete all
-    const std::size_t nb_values = 1000;
-    dict_int_int map;
-    for (size_t i = 0; i < nb_values; ++i) {
-      map[i] = i + 1;
-    }
-    auto it = map.erase(map.begin(), map.end());
-    ASSERT_TRUE(it == map.end());
-    ASSERT_TRUE(map.empty());
+  // insert x values, delete all
+  const std::size_t nb_values = 1000;
+  dict_int_int map;
+  for (size_t i = 0; i < nb_values; ++i) {
+    map[i] = i + 1;
+  }
+  auto it = map.erase(map.begin(), map.end());
+  ASSERT_TRUE(it == map.end());
+  ASSERT_TRUE(map.empty());
 }
 
 TEST(OrderedPreservingDictTest, test_range_erase) {
-    // insert x values, delete all with iterators except 10 first and 780 last values
-    using HMap = ska_ordered::order_preserving_flat_hash_map<std::string, std::int64_t>;
+  // insert x values, delete all with iterators except 10 first and 780 last
+  // values
+  using HMap =
+      ska_ordered::order_preserving_flat_hash_map<std::string, std::int64_t>;
 
-    const std::size_t nb_values = 1000;
-    HMap map;
-    for (size_t i = 0; i < nb_values; ++i) {
-      map[c10::guts::to_string(i)] = i;
-      auto begin = map.begin();
-      for (size_t j = 0; j <= i; ++j, begin++) {
-        TORCH_INTERNAL_ASSERT(begin->second == j);
-      }
+  const std::size_t nb_values = 1000;
+  HMap map;
+  for (size_t i = 0; i < nb_values; ++i) {
+    map[c10::guts::to_string(i)] = i;
+    auto begin = map.begin();
+    for (size_t j = 0; j <= i; ++j, begin++) {
+      TORCH_INTERNAL_ASSERT(begin->second == j);
     }
+  }
 
-    auto it_first = std::next(map.begin(), 10);
-    auto it_last = std::next(map.begin(), 220);
+  auto it_first = std::next(map.begin(), 10);
+  auto it_last = std::next(map.begin(), 220);
 
-    auto it = map.erase(it_first, it_last);
-    ASSERT_EQUAL_PRIM(std::distance(it, map.end()), 780);
-    ASSERT_EQUAL_PRIM(map.size(), 790);
-    ASSERT_EQUAL_PRIM(std::distance(map.begin(), map.end()), 790);
+  auto it = map.erase(it_first, it_last);
+  ASSERT_EQUAL_PRIM(std::distance(it, map.end()), 780);
+  ASSERT_EQUAL_PRIM(map.size(), 790);
+  ASSERT_EQUAL_PRIM(std::distance(map.begin(), map.end()), 790);
 
-    for(auto& val: map) {
-        ASSERT_EQUAL_PRIM(map.count(val.first), 1);
+  for (auto& val : map) {
+    ASSERT_EQUAL_PRIM(map.count(val.first), 1);
+  }
+
+  // Check order
+  it = map.begin();
+  for (std::size_t i = 0; i < nb_values; i++) {
+    if (i >= 10 && i < 220) {
+      continue;
     }
-
-    // Check order
-    it = map.begin();
-    for(std::size_t i = 0; i < nb_values; i++) {
-        if(i >= 10 && i < 220) {
-            continue;
-        }
-        auto exp_it = std::pair<std::string, std::int64_t>(c10::guts::to_string(i), i);
-        TORCH_INTERNAL_ASSERT(*it == exp_it);
-        ++it;
-    }
+    auto exp_it =
+        std::pair<std::string, std::int64_t>(c10::guts::to_string(i), i);
+    TORCH_INTERNAL_ASSERT(*it == exp_it);
+    ++it;
+  }
 }
 
 TEST(OrderedPreservingDictTest, test_move_constructor_empty) {
-    ska_ordered::order_preserving_flat_hash_map<std::string, int64_t> map(0);
-    ska_ordered::order_preserving_flat_hash_map<std::string, int64_t> map_move(std::move(map));
+  ska_ordered::order_preserving_flat_hash_map<std::string, int64_t> map(0);
+  ska_ordered::order_preserving_flat_hash_map<std::string, int64_t> map_move(
+      std::move(map));
 
-    TORCH_INTERNAL_ASSERT(map.empty());
-    TORCH_INTERNAL_ASSERT(map_move.empty());
+  TORCH_INTERNAL_ASSERT(map.empty());
+  TORCH_INTERNAL_ASSERT(map_move.empty());
 
-    TORCH_INTERNAL_ASSERT(map.find("") == map.end());
-    TORCH_INTERNAL_ASSERT(map_move.find("") == map_move.end());
+  TORCH_INTERNAL_ASSERT(map.find("") == map.end());
+  TORCH_INTERNAL_ASSERT(map_move.find("") == map_move.end());
 }
 
 TEST(OrderedPreservingDictTest, test_move_operator_empty) {
-    ska_ordered::order_preserving_flat_hash_map<std::string, int64_t> map(0);
-    ska_ordered::order_preserving_flat_hash_map<std::string, int64_t> map_move;
-    map_move = (std::move(map));
+  ska_ordered::order_preserving_flat_hash_map<std::string, int64_t> map(0);
+  ska_ordered::order_preserving_flat_hash_map<std::string, int64_t> map_move;
+  map_move = (std::move(map));
 
-    TORCH_INTERNAL_ASSERT(map.empty());
-    TORCH_INTERNAL_ASSERT(map_move.empty());
+  TORCH_INTERNAL_ASSERT(map.empty());
+  TORCH_INTERNAL_ASSERT(map_move.empty());
 
-    TORCH_INTERNAL_ASSERT(map.find("") == map.end());
-    TORCH_INTERNAL_ASSERT(map_move.find("") == map_move.end());
+  TORCH_INTERNAL_ASSERT(map.find("") == map.end());
+  TORCH_INTERNAL_ASSERT(map_move.find("") == map_move.end());
 }
 
 TEST(OrderedPreservingDictTest, test_reassign_moved_object_move_constructor) {
-    using HMap = ska_ordered::order_preserving_flat_hash_map<std::string, std::string>;
+  using HMap =
+      ska_ordered::order_preserving_flat_hash_map<std::string, std::string>;
 
-    HMap map = {{"Key1", "Value1"}, {"Key2", "Value2"}, {"Key3", "Value3"}};
-    HMap map_move(std::move(map));
+  HMap map = {{"Key1", "Value1"}, {"Key2", "Value2"}, {"Key3", "Value3"}};
+  HMap map_move(std::move(map));
 
-    ASSERT_EQUAL_PRIM(map_move.size(), 3);
-    ASSERT_EQUAL_PRIM(map.size(), 0);
+  ASSERT_EQUAL_PRIM(map_move.size(), 3);
+  ASSERT_EQUAL_PRIM(map.size(), 0);
 
-    map = {{"Key4", "Value4"}, {"Key5", "Value5"}};
-    TORCH_INTERNAL_ASSERT(map == (HMap({{"Key4", "Value4"}, {"Key5", "Value5"}})));
+  map = {{"Key4", "Value4"}, {"Key5", "Value5"}};
+  TORCH_INTERNAL_ASSERT(
+      map == (HMap({{"Key4", "Value4"}, {"Key5", "Value5"}})));
 }
 
 TEST(OrderedPreservingDictTest, test_reassign_moved_object_move_operator) {
-    using HMap = ska_ordered::order_preserving_flat_hash_map<std::string, std::string>;
+  using HMap =
+      ska_ordered::order_preserving_flat_hash_map<std::string, std::string>;
 
-    HMap map = {{"Key1", "Value1"}, {"Key2", "Value2"}, {"Key3", "Value3"}};
-    HMap map_move = std::move(map);
+  HMap map = {{"Key1", "Value1"}, {"Key2", "Value2"}, {"Key3", "Value3"}};
+  HMap map_move = std::move(map);
 
-    ASSERT_EQUAL_PRIM(map_move.size(), 3);
-    ASSERT_EQUAL_PRIM(map.size(), 0);
+  ASSERT_EQUAL_PRIM(map_move.size(), 3);
+  ASSERT_EQUAL_PRIM(map.size(), 0);
 
-    map = {{"Key4", "Value4"}, {"Key5", "Value5"}};
-    TORCH_INTERNAL_ASSERT(map == (HMap({{"Key4", "Value4"}, {"Key5", "Value5"}})));
+  map = {{"Key4", "Value4"}, {"Key5", "Value5"}};
+  TORCH_INTERNAL_ASSERT(
+      map == (HMap({{"Key4", "Value4"}, {"Key5", "Value5"}})));
 }
 
 TEST(OrderedPreservingDictTest, test_copy_constructor_and_operator) {
-    using HMap = ska_ordered::order_preserving_flat_hash_map<std::string, std::string>;
+  using HMap =
+      ska_ordered::order_preserving_flat_hash_map<std::string, std::string>;
 
+  const std::size_t nb_values = 100;
+  HMap map;
+  for (size_t i = 0; i < nb_values; ++i) {
+    map[c10::guts::to_string(i)] = c10::guts::to_string(i);
+  }
 
-    const std::size_t nb_values = 100;
-    HMap map;
-    for (size_t i = 0; i < nb_values; ++i) {
-      map[c10::guts::to_string(i)] = c10::guts::to_string(i);
-    }
+  HMap map_copy = map;
+  HMap map_copy2(map);
+  HMap map_copy3;
+  map_copy3[c10::guts::to_string(0)] = c10::guts::to_string(0);
 
+  map_copy3 = map;
 
-    HMap map_copy = map;
-    HMap map_copy2(map);
-    HMap map_copy3;
-    map_copy3[c10::guts::to_string(0)] = c10::guts::to_string(0);
+  TORCH_INTERNAL_ASSERT(map == map_copy);
+  map.clear();
 
-    map_copy3 = map;
-
-    TORCH_INTERNAL_ASSERT(map == map_copy);
-    map.clear();
-
-    TORCH_INTERNAL_ASSERT(map_copy == map_copy2);
-    TORCH_INTERNAL_ASSERT(map_copy == map_copy3);
+  TORCH_INTERNAL_ASSERT(map_copy == map_copy2);
+  TORCH_INTERNAL_ASSERT(map_copy == map_copy3);
 }
 
 TEST(OrderedPreservingDictTest, test_copy_constructor_empty) {
-    ska_ordered::order_preserving_flat_hash_map<std::string, int> map(0);
-    ska_ordered::order_preserving_flat_hash_map<std::string, int> map_copy(map);
+  ska_ordered::order_preserving_flat_hash_map<std::string, int> map(0);
+  ska_ordered::order_preserving_flat_hash_map<std::string, int> map_copy(map);
 
-    TORCH_INTERNAL_ASSERT(map.empty());
-    TORCH_INTERNAL_ASSERT(map_copy.empty());
+  TORCH_INTERNAL_ASSERT(map.empty());
+  TORCH_INTERNAL_ASSERT(map_copy.empty());
 
-    TORCH_INTERNAL_ASSERT(map.find("") == map.end());
-    TORCH_INTERNAL_ASSERT(map_copy.find("") == map_copy.end());
+  TORCH_INTERNAL_ASSERT(map.find("") == map.end());
+  TORCH_INTERNAL_ASSERT(map_copy.find("") == map_copy.end());
 }
 
 TEST(OrderedPreservingDictTest, test_copy_operator_empty) {
-    ska_ordered::order_preserving_flat_hash_map<std::string, int> map(0);
-    ska_ordered::order_preserving_flat_hash_map<std::string, int> map_copy(16);
-    map_copy = map;
+  ska_ordered::order_preserving_flat_hash_map<std::string, int> map(0);
+  ska_ordered::order_preserving_flat_hash_map<std::string, int> map_copy(16);
+  map_copy = map;
 
-    TORCH_INTERNAL_ASSERT(map.empty());
-    TORCH_INTERNAL_ASSERT(map_copy.empty());
+  TORCH_INTERNAL_ASSERT(map.empty());
+  TORCH_INTERNAL_ASSERT(map_copy.empty());
 
-    TORCH_INTERNAL_ASSERT(map.find("") == map.end());
-    TORCH_INTERNAL_ASSERT(map_copy.find("") == map_copy.end());
+  TORCH_INTERNAL_ASSERT(map.find("") == map.end());
+  TORCH_INTERNAL_ASSERT(map_copy.find("") == map_copy.end());
 }
-
 
 /**
  * at
  */
 TEST(OrderedPreservingDictTest, test_at) {
-    // insert x values, use at for known and unknown values.
-    const ska_ordered::order_preserving_flat_hash_map<std::int64_t, std::int64_t> map = {{0, 10}, {-2, 20}};
+  // insert x values, use at for known and unknown values.
+  const ska_ordered::order_preserving_flat_hash_map<std::int64_t, std::int64_t>
+      map = {{0, 10}, {-2, 20}};
 
-    ASSERT_EQUAL_PRIM(map.at(0), 10);
-    ASSERT_EQUAL_PRIM(map.at(-2), 20);
-    bool thrown = false;
-    try {
-      map.at(1);
-    } catch (...) {
-      thrown = true;
-    }
-    ASSERT_TRUE(thrown);
+  ASSERT_EQUAL_PRIM(map.at(0), 10);
+  ASSERT_EQUAL_PRIM(map.at(-2), 20);
+  bool thrown = false;
+  try {
+    map.at(1);
+  } catch (...) {
+    thrown = true;
+  }
+  ASSERT_TRUE(thrown);
 }
-
 
 /**
  * equal_range
  */
 TEST(OrderedPreservingDictTest, test_equal_range) {
-    ska_ordered::order_preserving_flat_hash_map<std::int64_t, std::int64_t> map = {{0, 10}, {-2, 20}};
+  ska_ordered::order_preserving_flat_hash_map<std::int64_t, std::int64_t> map =
+      {{0, 10}, {-2, 20}};
 
-    auto it_pair = map.equal_range(0);
-    ASSERT_EQUAL_PRIM(std::distance(it_pair.first, it_pair.second), 1);
-    ASSERT_EQUAL_PRIM(it_pair.first->second, 10);
+  auto it_pair = map.equal_range(0);
+  ASSERT_EQUAL_PRIM(std::distance(it_pair.first, it_pair.second), 1);
+  ASSERT_EQUAL_PRIM(it_pair.first->second, 10);
 
-    it_pair = map.equal_range(1);
-    TORCH_INTERNAL_ASSERT(it_pair.first == it_pair.second);
-    TORCH_INTERNAL_ASSERT(it_pair.first == map.end());
+  it_pair = map.equal_range(1);
+  TORCH_INTERNAL_ASSERT(it_pair.first == it_pair.second);
+  TORCH_INTERNAL_ASSERT(it_pair.first == map.end());
 }
-
 
 /**
  * operator[]
  */
 TEST(OrderedPreservingDictTest, test_access_operator) {
-    // insert x values, use at for known and unknown values.
-    ska_ordered::order_preserving_flat_hash_map<std::int64_t, std::int64_t> map = {{0, 10}, {-2, 20}};
+  // insert x values, use at for known and unknown values.
+  ska_ordered::order_preserving_flat_hash_map<std::int64_t, std::int64_t> map =
+      {{0, 10}, {-2, 20}};
 
-    ASSERT_EQUAL_PRIM(map[0], 10);
-    ASSERT_EQUAL_PRIM(map[-2], 20);
-    ASSERT_EQUAL_PRIM(map[2], std::int64_t());
+  ASSERT_EQUAL_PRIM(map[0], 10);
+  ASSERT_EQUAL_PRIM(map[-2], 20);
+  ASSERT_EQUAL_PRIM(map[2], std::int64_t());
 
-    ASSERT_EQUAL_PRIM(map.size(), 3);
+  ASSERT_EQUAL_PRIM(map.size(), 3);
 }
 
 /**
  * swap
  */
 TEST(OrderedPreservingDictTest, test_swap) {
-    ska_ordered::order_preserving_flat_hash_map<std::int64_t, std::int64_t> map = {{1, 10}, {8, 80}, {3, 30}};
-    ska_ordered::order_preserving_flat_hash_map<std::int64_t, std::int64_t> map2 = {{4, 40}, {5, 50}};
+  ska_ordered::order_preserving_flat_hash_map<std::int64_t, std::int64_t> map =
+      {{1, 10}, {8, 80}, {3, 30}};
+  ska_ordered::order_preserving_flat_hash_map<std::int64_t, std::int64_t> map2 =
+      {{4, 40}, {5, 50}};
 
-    using std::swap;
-    swap(map, map2);
+  using std::swap;
+  swap(map, map2);
 
-    TORCH_INTERNAL_ASSERT(map == (ska_ordered::order_preserving_flat_hash_map<std::int64_t, std::int64_t>{{4, 40}, {5, 50}}));
-    TORCH_INTERNAL_ASSERT(map2 == (ska_ordered::order_preserving_flat_hash_map<std::int64_t, std::int64_t>{{1, 10}, {8, 80}, {3, 30}}));
+  TORCH_INTERNAL_ASSERT(
+      map ==
+      (ska_ordered::order_preserving_flat_hash_map<std::int64_t, std::int64_t>{
+          {4, 40}, {5, 50}}));
+  TORCH_INTERNAL_ASSERT(
+      map2 ==
+      (ska_ordered::order_preserving_flat_hash_map<std::int64_t, std::int64_t>{
+          {1, 10}, {8, 80}, {3, 30}}));
 
-    map.insert({6, 60});
-    map2.insert({4, 40});
+  map.insert({6, 60});
+  map2.insert({4, 40});
 
-    TORCH_INTERNAL_ASSERT(map == (ska_ordered::order_preserving_flat_hash_map<std::int64_t, std::int64_t>{{4, 40}, {5, 50}, {6, 60}}));
-    TORCH_INTERNAL_ASSERT(map2 == (ska_ordered::order_preserving_flat_hash_map<std::int64_t, std::int64_t>{{1, 10}, {8, 80}, {3, 30}, {4, 40}}));
+  TORCH_INTERNAL_ASSERT(
+      map ==
+      (ska_ordered::order_preserving_flat_hash_map<std::int64_t, std::int64_t>{
+          {4, 40}, {5, 50}, {6, 60}}));
+  TORCH_INTERNAL_ASSERT(
+      map2 ==
+      (ska_ordered::order_preserving_flat_hash_map<std::int64_t, std::int64_t>{
+          {1, 10}, {8, 80}, {3, 30}, {4, 40}}));
 }
 
 TEST(OrderedPreservingDictTest, test_swap_empty) {
-    ska_ordered::order_preserving_flat_hash_map<std::int64_t, std::int64_t> map = {{1, 10}, {8, 80}, {3, 30}};
-    ska_ordered::order_preserving_flat_hash_map<std::int64_t, std::int64_t> map2;
+  ska_ordered::order_preserving_flat_hash_map<std::int64_t, std::int64_t> map =
+      {{1, 10}, {8, 80}, {3, 30}};
+  ska_ordered::order_preserving_flat_hash_map<std::int64_t, std::int64_t> map2;
 
-    using std::swap;
-    swap(map, map2);
+  using std::swap;
+  swap(map, map2);
 
-    TORCH_INTERNAL_ASSERT(map == (ska_ordered::order_preserving_flat_hash_map<std::int64_t, std::int64_t>{}));
-    TORCH_INTERNAL_ASSERT(map2 == (ska_ordered::order_preserving_flat_hash_map<std::int64_t, std::int64_t>{{1, 10}, {8, 80}, {3, 30}}));
+  TORCH_INTERNAL_ASSERT(
+      map ==
+      (ska_ordered::
+           order_preserving_flat_hash_map<std::int64_t, std::int64_t>{}));
+  TORCH_INTERNAL_ASSERT(
+      map2 ==
+      (ska_ordered::order_preserving_flat_hash_map<std::int64_t, std::int64_t>{
+          {1, 10}, {8, 80}, {3, 30}}));
 
-    map.insert({6, 60});
-    map2.insert({4, 40});
+  map.insert({6, 60});
+  map2.insert({4, 40});
 
-    TORCH_INTERNAL_ASSERT(map == (ska_ordered::order_preserving_flat_hash_map<std::int64_t, std::int64_t>{{6, 60}}));
-    TORCH_INTERNAL_ASSERT(map2 == (ska_ordered::order_preserving_flat_hash_map<std::int64_t, std::int64_t>{{1, 10}, {8, 80}, {3, 30}, {4, 40}}));
+  TORCH_INTERNAL_ASSERT(
+      map ==
+      (ska_ordered::order_preserving_flat_hash_map<std::int64_t, std::int64_t>{
+          {6, 60}}));
+  TORCH_INTERNAL_ASSERT(
+      map2 ==
+      (ska_ordered::order_preserving_flat_hash_map<std::int64_t, std::int64_t>{
+          {1, 10}, {8, 80}, {3, 30}, {4, 40}}));
 }
 
-}
+} // namespace

--- a/c10/test/util/typeid_test.cpp
+++ b/c10/test/util/typeid_test.cpp
@@ -1,5 +1,5 @@
-#include "c10/util/typeid.h"
 #include <gtest/gtest.h>
+#include "c10/util/typeid.h"
 
 using std::string;
 
@@ -8,7 +8,7 @@ namespace {
 
 class TypeMetaTestFoo {};
 class TypeMetaTestBar {};
-}
+} // namespace
 
 CAFFE_KNOWN_TYPE(TypeMetaTestFoo);
 CAFFE_KNOWN_TYPE(TypeMetaTestBar);
@@ -35,11 +35,10 @@ TEST(TypeMetaTest, Names) {
 #ifdef __GXX_RTTI
   TypeMeta string_meta = TypeMeta::Make<string>();
   // For string, we should have a demangled name.
-  EXPECT_TRUE(
-      string(string_meta.name()) != typeid(string).name());
+  EXPECT_TRUE(string(string_meta.name()) != typeid(string).name());
   EXPECT_TRUE(
       string(string_meta.name()) == c10::demangle(typeid(string).name()));
-#endif  // __GXX_RTTI
+#endif // __GXX_RTTI
 }
 
 TEST(TypeMetaTest, TypeMeta) {
@@ -80,7 +79,6 @@ TEST(TypeMetaTest, TypeMeta) {
 #endif
 }
 
-
 class ClassAllowAssignment {
  public:
   ClassAllowAssignment() : x(42) {}
@@ -96,7 +94,7 @@ class ClassNoAssignment {
   ClassNoAssignment& operator=(const ClassNoAssignment& src) = delete;
   int x;
 };
-}
+} // namespace
 
 CAFFE_KNOWN_TYPE(ClassAllowAssignment);
 CAFFE_KNOWN_TYPE(ClassNoAssignment);
@@ -136,5 +134,5 @@ TEST(TypeMetaTest, Float16IsNotUint16) {
   EXPECT_NE(TypeMeta::Id<uint16_t>(), TypeMeta::Id<at::Half>());
 }
 
-}  // namespace
-}  // namespace caffe2
+} // namespace
+} // namespace caffe2

--- a/c10/util/Array.h
+++ b/c10/util/Array.h
@@ -1,18 +1,20 @@
 /**
-* This file is based on the std::array implementation of libstdc++ at
-* https://gcc.gnu.org/onlinedocs/gcc-7.1.0/libstdc++/api/a01056_source.html
-*
-* Changes:
-*  - isolate, i.e. remove dependencies on internal libstdc++ stuff
-*  - use c++17 behavior even in c++11 or c++14
-*  - remove std::swappable special case because that doesn't work with MSVC
-*  - constexpr more things
-*  - add some features like prepend/tail
-*
-* If using std::array at runtime, feel free to either keep using std::array or use this one - it doesn't really matter.
-* For compile time computations, this one here is preferred because std::array in C++11
-* misses some constexpr specifiers, forcing these methods to be called at runtime instead of compile time.
-*/
+ * This file is based on the std::array implementation of libstdc++ at
+ * https://gcc.gnu.org/onlinedocs/gcc-7.1.0/libstdc++/api/a01056_source.html
+ *
+ * Changes:
+ *  - isolate, i.e. remove dependencies on internal libstdc++ stuff
+ *  - use c++17 behavior even in c++11 or c++14
+ *  - remove std::swappable special case because that doesn't work with MSVC
+ *  - constexpr more things
+ *  - add some features like prepend/tail
+ *
+ * If using std::array at runtime, feel free to either keep using std::array or
+ * use this one - it doesn't really matter. For compile time computations, this
+ * one here is preferred because std::array in C++11 misses some constexpr
+ * specifiers, forcing these methods to be called at runtime instead of compile
+ * time.
+ */
 
 // Copyright (C) 2007-2017 Free Software Foundation, Inc.
 //
@@ -38,16 +40,17 @@
 
 #pragma once
 
-#include <algorithm>
 #include <c10/util/C++17.h>
+#include <algorithm>
 #include <stdexcept>
 #include <string>
 #include <utility>
 
-namespace c10 { namespace guts {
+namespace c10 {
+namespace guts {
 
 namespace detail {
-template<typename _Tp, std::size_t _Nm>
+template <typename _Tp, std::size_t _Nm>
 struct __array_traits final {
   using _Type = _Tp[_Nm];
 
@@ -60,7 +63,7 @@ struct __array_traits final {
   }
 };
 
-template<typename _Tp>
+template <typename _Tp>
 struct __array_traits<_Tp, 0> final {
   struct _Type final {};
 
@@ -76,11 +79,11 @@ struct __array_traits<_Tp, 0> final {
 [[noreturn]] inline void __throw_out_of_range(std::string msg) {
   throw std::out_of_range(std::move(msg));
 }
-}
+} // namespace detail
 
-template<typename _Tp, std::size_t _Nm>
+template <typename _Tp, std::size_t _Nm>
 class array final {
-public:
+ public:
   using value_type = _Tp;
   using pointer = value_type*;
   using const_pointer = const value_type*;
@@ -93,76 +96,99 @@ public:
   using reverse_iterator = std::reverse_iterator<iterator>;
   using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
-private:
+ private:
   using _AT_Type = detail::__array_traits<_Tp, _Nm>;
-public: // needs to be public member for aggregate initialization
+
+ public: // needs to be public member for aggregate initialization
   typename _AT_Type::_Type _M_elems;
 
-public:
+ public:
   // No explicit construct/copy/destroy for aggregate type.
 
   // DR 776.
-  AT_CPP14_CONSTEXPR void fill(const value_type& __u)
-  { std::fill_n(begin(), size(), __u); }
+  AT_CPP14_CONSTEXPR void fill(const value_type& __u) {
+    std::fill_n(begin(), size(), __u);
+  }
 
-  AT_CPP14_CONSTEXPR void swap(array& __other)
-  { std::swap_ranges(begin(), end(), __other.begin()); }
+  AT_CPP14_CONSTEXPR void swap(array& __other) {
+    std::swap_ranges(begin(), end(), __other.begin());
+  }
 
   // Iterators.
-  AT_CPP14_CONSTEXPR iterator begin() noexcept
-  { return iterator(data()); }
+  AT_CPP14_CONSTEXPR iterator begin() noexcept {
+    return iterator(data());
+  }
 
-  constexpr const_iterator begin() const noexcept
-  { return const_iterator(data()); }
+  constexpr const_iterator begin() const noexcept {
+    return const_iterator(data());
+  }
 
-  AT_CPP14_CONSTEXPR iterator end() noexcept
-  { return iterator(data() + _Nm); }
+  AT_CPP14_CONSTEXPR iterator end() noexcept {
+    return iterator(data() + _Nm);
+  }
 
-  constexpr const_iterator end() const noexcept
-  { return const_iterator(data() + _Nm); }
+  constexpr const_iterator end() const noexcept {
+    return const_iterator(data() + _Nm);
+  }
 
-  AT_CPP14_CONSTEXPR reverse_iterator rbegin() noexcept
-  { return reverse_iterator(end()); }
+  AT_CPP14_CONSTEXPR reverse_iterator rbegin() noexcept {
+    return reverse_iterator(end());
+  }
 
-  constexpr const_reverse_iterator rbegin() const noexcept
-  { return const_reverse_iterator(end()); }
+  constexpr const_reverse_iterator rbegin() const noexcept {
+    return const_reverse_iterator(end());
+  }
 
-  AT_CPP14_CONSTEXPR reverse_iterator rend() noexcept
-  { return reverse_iterator(begin()); }
+  AT_CPP14_CONSTEXPR reverse_iterator rend() noexcept {
+    return reverse_iterator(begin());
+  }
 
-  constexpr const_reverse_iterator rend() const noexcept
-  { return const_reverse_iterator(begin()); }
+  constexpr const_reverse_iterator rend() const noexcept {
+    return const_reverse_iterator(begin());
+  }
 
-  constexpr const_iterator cbegin() const noexcept
-  { return const_iterator(data()); }
+  constexpr const_iterator cbegin() const noexcept {
+    return const_iterator(data());
+  }
 
-  constexpr const_iterator cend() const noexcept
-  { return const_iterator(data() + _Nm); }
+  constexpr const_iterator cend() const noexcept {
+    return const_iterator(data() + _Nm);
+  }
 
-  constexpr const_reverse_iterator crbegin() const noexcept
-  { return const_reverse_iterator(end()); }
+  constexpr const_reverse_iterator crbegin() const noexcept {
+    return const_reverse_iterator(end());
+  }
 
-  constexpr const_reverse_iterator crend() const noexcept
-  { return const_reverse_iterator(begin()); }
+  constexpr const_reverse_iterator crend() const noexcept {
+    return const_reverse_iterator(begin());
+  }
 
   // Capacity.
-  constexpr size_type size() const noexcept { return _Nm; }
+  constexpr size_type size() const noexcept {
+    return _Nm;
+  }
 
-  constexpr size_type max_size() const noexcept { return _Nm; }
+  constexpr size_type max_size() const noexcept {
+    return _Nm;
+  }
 
-  constexpr bool empty() const noexcept { return size() == 0; }
+  constexpr bool empty() const noexcept {
+    return size() == 0;
+  }
 
   // Element access.
-  AT_CPP14_CONSTEXPR reference operator[](size_type __n) noexcept
-  { return _AT_Type::_S_ref(_M_elems, __n); }
+  AT_CPP14_CONSTEXPR reference operator[](size_type __n) noexcept {
+    return _AT_Type::_S_ref(_M_elems, __n);
+  }
 
-  constexpr const_reference operator[](size_type __n) const noexcept
-  { return _AT_Type::_S_ref(_M_elems, __n); }
+  constexpr const_reference operator[](size_type __n) const noexcept {
+    return _AT_Type::_S_ref(_M_elems, __n);
+  }
 
   AT_CPP14_CONSTEXPR reference at(size_type __n) {
     if (__n >= _Nm) {
-      detail::__throw_out_of_range(std::string() +
-          "array::at: __n (which is " + to_string(__n) + ") " +
+      detail::__throw_out_of_range(
+          std::string() + "array::at: __n (which is " + to_string(__n) + ") " +
           ">= _Nm (which is " + to_string(_Nm) + ")");
     }
     return _AT_Type::_S_ref(_M_elems, __n);
@@ -171,101 +197,134 @@ public:
   constexpr const_reference at(size_type __n) const {
     // Result of conditional expression must be an lvalue so use
     // boolean ? lvalue : (throw-expr, lvalue)
-    return __n < _Nm ? _AT_Type::_S_ref(_M_elems, __n)
-      : (detail::__throw_out_of_range(std::string() +
-            "array::at: __n (which is " + to_string(__n) + ") " +
-            ">= _Nm (which is " + to_string(_Nm) + ")"),
-         _AT_Type::_S_ref(_M_elems, 0));
-     }
-
-  AT_CPP14_CONSTEXPR reference front() noexcept
-  { return *begin(); }
-
-  constexpr const_reference front() const noexcept
-  { return _AT_Type::_S_ref(_M_elems, 0); }
-
-  AT_CPP14_CONSTEXPR reference back() noexcept
-  { return _Nm ? *(end() - 1) : *end(); }
-
-  constexpr const_reference back() const noexcept
-  {
-    return _Nm ? _AT_Type::_S_ref(_M_elems, _Nm - 1)
-            : _AT_Type::_S_ref(_M_elems, 0);
+    return __n < _Nm
+        ? _AT_Type::_S_ref(_M_elems, __n)
+        : (detail::__throw_out_of_range(
+               std::string() + "array::at: __n (which is " + to_string(__n) +
+               ") " + ">= _Nm (which is " + to_string(_Nm) + ")"),
+           _AT_Type::_S_ref(_M_elems, 0));
   }
 
-  AT_CPP14_CONSTEXPR pointer data() noexcept
-  { return _AT_Type::_S_ptr(_M_elems); }
+  AT_CPP14_CONSTEXPR reference front() noexcept {
+    return *begin();
+  }
 
-  constexpr const_pointer data() const noexcept
-  { return _AT_Type::_S_ptr(_M_elems); }
+  constexpr const_reference front() const noexcept {
+    return _AT_Type::_S_ref(_M_elems, 0);
+  }
+
+  AT_CPP14_CONSTEXPR reference back() noexcept {
+    return _Nm ? *(end() - 1) : *end();
+  }
+
+  constexpr const_reference back() const noexcept {
+    return _Nm ? _AT_Type::_S_ref(_M_elems, _Nm - 1)
+               : _AT_Type::_S_ref(_M_elems, 0);
+  }
+
+  AT_CPP14_CONSTEXPR pointer data() noexcept {
+    return _AT_Type::_S_ptr(_M_elems);
+  }
+
+  constexpr const_pointer data() const noexcept {
+    return _AT_Type::_S_ptr(_M_elems);
+  }
 };
 
 #if defined(__cpp_deduction_guides) && __cpp_deduction_guides >= 201606
-  template<typename _Tp, typename... _Up>
-  array(_Tp, _Up...) ->
-    array<enable_if_t<(std::is_same<_Tp, _Up>::value && ...), _Tp>, 1 + sizeof...(_Up)>;
+template <typename _Tp, typename... _Up>
+array(_Tp, _Up...)
+    ->array<
+        enable_if_t<(std::is_same<_Tp, _Up>::value && ...), _Tp>,
+        1 + sizeof...(_Up)>;
 #endif
 
 // Array comparisons.
 namespace detail {
-template<class T, size_t N>
-constexpr inline bool array_equals_(const array<T, N>& lhs, const array<T, N>& rhs, size_t current_index) {
+template <class T, size_t N>
+constexpr inline bool array_equals_(
+    const array<T, N>& lhs,
+    const array<T, N>& rhs,
+    size_t current_index) {
   return (current_index == N)
-         ? true
-         : (lhs.at(current_index) == rhs.at(current_index) && array_equals_(lhs, rhs, current_index + 1));
+      ? true
+      : (lhs.at(current_index) == rhs.at(current_index) &&
+         array_equals_(lhs, rhs, current_index + 1));
 }
-template<class T, size_t N>
-constexpr inline bool array_less_(const array<T, N>& lhs, const array<T, N>& rhs, size_t current_index) {
+template <class T, size_t N>
+constexpr inline bool array_less_(
+    const array<T, N>& lhs,
+    const array<T, N>& rhs,
+    size_t current_index) {
   return (current_index == N)
-         ? false
-         : (lhs.at(current_index) < rhs.at(current_index) || array_less_(lhs, rhs, current_index + 1));
+      ? false
+      : (lhs.at(current_index) < rhs.at(current_index) ||
+         array_less_(lhs, rhs, current_index + 1));
 }
+} // namespace detail
+template <typename _Tp, std::size_t _Nm>
+constexpr inline bool operator==(
+    const array<_Tp, _Nm>& __one,
+    const array<_Tp, _Nm>& __two) {
+  return detail::array_equals_(__one, __two, 0);
 }
-template<typename _Tp, std::size_t _Nm>
-constexpr inline bool operator==(const array<_Tp, _Nm>& __one, const array<_Tp, _Nm>& __two)
-{ return detail::array_equals_(__one, __two, 0); }
 
-template<typename _Tp, std::size_t _Nm>
-constexpr inline bool operator!=(const array<_Tp, _Nm>& __one, const array<_Tp, _Nm>& __two)
-{ return !(__one == __two); }
+template <typename _Tp, std::size_t _Nm>
+constexpr inline bool operator!=(
+    const array<_Tp, _Nm>& __one,
+    const array<_Tp, _Nm>& __two) {
+  return !(__one == __two);
+}
 
-template<typename _Tp, std::size_t _Nm>
-constexpr inline bool operator<(const array<_Tp, _Nm>& __a, const array<_Tp, _Nm>& __b)
-{ return detail::array_less_(__a, __b, 0); }
+template <typename _Tp, std::size_t _Nm>
+constexpr inline bool operator<(
+    const array<_Tp, _Nm>& __a,
+    const array<_Tp, _Nm>& __b) {
+  return detail::array_less_(__a, __b, 0);
+}
 
-template<typename _Tp, std::size_t _Nm>
-constexpr inline bool operator>(const array<_Tp, _Nm>& __one, const array<_Tp, _Nm>& __two)
-{ return __two < __one; }
+template <typename _Tp, std::size_t _Nm>
+constexpr inline bool operator>(
+    const array<_Tp, _Nm>& __one,
+    const array<_Tp, _Nm>& __two) {
+  return __two < __one;
+}
 
-template<typename _Tp, std::size_t _Nm>
-constexpr inline bool operator<=(const array<_Tp, _Nm>& __one, const array<_Tp, _Nm>& __two)
-{ return !(__one > __two); }
+template <typename _Tp, std::size_t _Nm>
+constexpr inline bool operator<=(
+    const array<_Tp, _Nm>& __one,
+    const array<_Tp, _Nm>& __two) {
+  return !(__one > __two);
+}
 
-template<typename _Tp, std::size_t _Nm>
-constexpr inline bool operator>=(const array<_Tp, _Nm>& __one, const array<_Tp, _Nm>& __two)
-{ return !(__one < __two); }
+template <typename _Tp, std::size_t _Nm>
+constexpr inline bool operator>=(
+    const array<_Tp, _Nm>& __one,
+    const array<_Tp, _Nm>& __two) {
+  return !(__one < __two);
+}
 
 // Specialized algorithms.
-template<typename _Tp, std::size_t _Nm>
-inline void swap(array<_Tp, _Nm>& __one, array<_Tp, _Nm>& __two) noexcept(noexcept(__one.swap(__two)))
-{ __one.swap(__two); }
-
-template<std::size_t _Int, typename _Tp, std::size_t _Nm>
-constexpr _Tp& get(array<_Tp, _Nm>& __arr) noexcept {
-   static_assert(_Int < _Nm, "array index is within bounds");
-   return detail::__array_traits<_Tp, _Nm>::_S_ref(__arr._M_elems, _Int);
+template <typename _Tp, std::size_t _Nm>
+inline void swap(array<_Tp, _Nm>& __one, array<_Tp, _Nm>& __two) noexcept(
+    noexcept(__one.swap(__two))) {
+  __one.swap(__two);
 }
 
-template<std::size_t _Int, typename _Tp, std::size_t _Nm>
-constexpr _Tp&& get(array<_Tp, _Nm>&& __arr) noexcept
-{
+template <std::size_t _Int, typename _Tp, std::size_t _Nm>
+constexpr _Tp& get(array<_Tp, _Nm>& __arr) noexcept {
+  static_assert(_Int < _Nm, "array index is within bounds");
+  return detail::__array_traits<_Tp, _Nm>::_S_ref(__arr._M_elems, _Int);
+}
+
+template <std::size_t _Int, typename _Tp, std::size_t _Nm>
+constexpr _Tp&& get(array<_Tp, _Nm>&& __arr) noexcept {
   static_assert(_Int < _Nm, "array index is within bounds");
   return guts::move(get<_Int>(__arr));
 }
 
-template<std::size_t _Int, typename _Tp, std::size_t _Nm>
-constexpr const _Tp& get(const array<_Tp, _Nm>& __arr) noexcept
-{
+template <std::size_t _Int, typename _Tp, std::size_t _Nm>
+constexpr const _Tp& get(const array<_Tp, _Nm>& __arr) noexcept {
   static_assert(_Int < _Nm, "array index is within bounds");
   return detail::__array_traits<_Tp, _Nm>::_S_ref(__arr._M_elems, _Int);
 }
@@ -278,27 +337,34 @@ constexpr const _Tp& get(const array<_Tp, _Nm>& __arr) noexcept
  *  prepend(2, {3, 4}) == {2, 3, 4}
  */
 namespace detail {
-template<class T, size_t N, size_t... I>
-constexpr inline array<T, N-1> tail_(const array<T, N>& arg, guts::index_sequence<I...>) {
-  static_assert(sizeof...(I) == N-1, "invariant");
-  return {{get<I+1>(arg)...}};
+template <class T, size_t N, size_t... I>
+constexpr inline array<T, N - 1> tail_(
+    const array<T, N>& arg,
+    guts::index_sequence<I...>) {
+  static_assert(sizeof...(I) == N - 1, "invariant");
+  return {{get<I + 1>(arg)...}};
 }
-}
-template<class T, size_t N>
-constexpr inline array<T, N-1> tail(const array<T, N>& arg) {
-  static_assert(N > 0, "Can only call tail() on an array with at least one element");
-  return detail::tail_(arg, guts::make_index_sequence<N-1>());
+} // namespace detail
+template <class T, size_t N>
+constexpr inline array<T, N - 1> tail(const array<T, N>& arg) {
+  static_assert(
+      N > 0, "Can only call tail() on an array with at least one element");
+  return detail::tail_(arg, guts::make_index_sequence<N - 1>());
 }
 
 namespace detail {
-template<class T, size_t N, size_t... I>
-constexpr inline array<T, N+1> prepend_(T&& head, const array<T, N>& tail, guts::index_sequence<I...>) {
+template <class T, size_t N, size_t... I>
+constexpr inline array<T, N + 1> prepend_(
+    T&& head,
+    const array<T, N>& tail,
+    guts::index_sequence<I...>) {
   return {{guts::forward<T>(head), get<I>(tail)...}};
 }
-}
-template<class T, size_t N>
-constexpr inline array<T, N+1> prepend(T&& head, const array<T, N>& tail) {
-  return detail::prepend_(guts::forward<T>(head), tail, guts::make_index_sequence<N>());
+} // namespace detail
+template <class T, size_t N>
+constexpr inline array<T, N + 1> prepend(T&& head, const array<T, N>& tail) {
+  return detail::prepend_(
+      guts::forward<T>(head), tail, guts::make_index_sequence<N>());
 }
 
 /**
@@ -309,15 +375,16 @@ constexpr inline array<T, N+1> prepend(T&& head, const array<T, N>& tail) {
  */
 
 namespace detail {
-template<class T, size_t N, size_t... I>
+template <class T, size_t N, size_t... I>
 constexpr array<T, N> to_array_(const T (&arr)[N], guts::index_sequence<I...>) {
   return {{arr[I]...}};
 }
-}
+} // namespace detail
 
-template<class T, size_t N>
+template <class T, size_t N>
 constexpr array<T, N> to_array(const T (&arr)[N]) {
   return detail::to_array_(arr, guts::make_index_sequence<N>());
 }
 
-}}
+} // namespace guts
+} // namespace c10

--- a/c10/util/ArrayRef.h
+++ b/c10/util/ArrayRef.h
@@ -15,10 +15,10 @@
 
 #pragma once
 
-#include <c10/util/SmallVector.h>
 #include <c10/util/C++17.h>
-#include <c10/util/Exception.h>
 #include <c10/util/Deprecated.h>
+#include <c10/util/Exception.h>
+#include <c10/util/SmallVector.h>
 
 #include <array>
 #include <iterator>
@@ -81,12 +81,15 @@ class ArrayRef final {
       : Data(Vec.data()), Length(Vec.size()) {}
 
   /// Construct an ArrayRef from a std::vector.
-  // The enable_if stuff here makes sure that this isn't used for std::vector<bool>,
-  // because ArrayRef can't work on a std::vector<bool> bitfield.
+  // The enable_if stuff here makes sure that this isn't used for
+  // std::vector<bool>, because ArrayRef can't work on a std::vector<bool>
+  // bitfield.
   template <typename A>
   /* implicit */ ArrayRef(const std::vector<T, A>& Vec)
       : Data(Vec.data()), Length(Vec.size()) {
-    static_assert(!std::is_same<T, bool>::value, "ArrayRef<bool> cannot be constructed from a std::vector<bool> bitfield.");
+    static_assert(
+        !std::is_same<T, bool>::value,
+        "ArrayRef<bool> cannot be constructed from a std::vector<bool> bitfield.");
   }
 
   /// Construct an ArrayRef from a std::array
@@ -100,7 +103,9 @@ class ArrayRef final {
 
   /// Construct an ArrayRef from a std::initializer_list.
   /* implicit */ constexpr ArrayRef(const std::initializer_list<T>& Vec)
-      : Data(std::begin(Vec) == std::end(Vec) ? static_cast<T*>(nullptr) : std::begin(Vec)),
+      : Data(
+            std::begin(Vec) == std::end(Vec) ? static_cast<T*>(nullptr)
+                                             : std::begin(Vec)),
         Length(Vec.size()) {}
 
   /// @}
@@ -146,7 +151,8 @@ class ArrayRef final {
 
   /// front - Get the first element.
   C10_CPP14_HOST_CONSTEXPR const T& front() const {
-    TORCH_CHECK(!empty(), "ArrayRef: attempted to access front() of empty list");
+    TORCH_CHECK(
+        !empty(), "ArrayRef: attempted to access front() of empty list");
     return Data[0];
   }
 
@@ -225,10 +231,10 @@ class ArrayRef final {
 };
 
 template <typename T>
-std::ostream& operator<<(std::ostream & out, ArrayRef<T> list) {
+std::ostream& operator<<(std::ostream& out, ArrayRef<T> list) {
   int i = 0;
   out << "[";
-  for(auto e : list) {
+  for (auto e : list) {
     if (i++ > 0)
       out << ", ";
     out << e;

--- a/c10/util/BFloat16-inl.h
+++ b/c10/util/BFloat16-inl.h
@@ -18,19 +18,23 @@ inline C10_HOST_DEVICE BFloat16::operator float() const {
 
 /// Arithmetic
 
-inline C10_HOST_DEVICE BFloat16 operator+(const BFloat16& a, const BFloat16& b) {
+inline C10_HOST_DEVICE BFloat16
+operator+(const BFloat16& a, const BFloat16& b) {
   return static_cast<float>(a) + static_cast<float>(b);
 }
 
-inline C10_HOST_DEVICE BFloat16 operator-(const BFloat16& a, const BFloat16& b) {
+inline C10_HOST_DEVICE BFloat16
+operator-(const BFloat16& a, const BFloat16& b) {
   return static_cast<float>(a) - static_cast<float>(b);
 }
 
-inline C10_HOST_DEVICE BFloat16 operator*(const BFloat16& a, const BFloat16& b) {
+inline C10_HOST_DEVICE BFloat16
+operator*(const BFloat16& a, const BFloat16& b) {
   return static_cast<float>(a) * static_cast<float>(b);
 }
 
-inline C10_HOST_DEVICE BFloat16 operator/(const BFloat16& a, const BFloat16& b) {
+inline C10_HOST_DEVICE BFloat16
+operator/(const BFloat16& a, const BFloat16& b) {
   return static_cast<float>(a) / static_cast<float>(b);
 }
 
@@ -204,7 +208,7 @@ namespace std {
 
 template <>
 class numeric_limits<c10::BFloat16> {
-public:
+ public:
   static constexpr bool is_signed = true;
   static constexpr bool is_specialized = true;
   static constexpr bool is_integer = false;
@@ -261,7 +265,11 @@ public:
 };
 
 /// Used by vec256<c10::BFloat16>::map
-inline c10::BFloat16 exp(c10::BFloat16 a) { return std::exp(float(a)); }
-inline c10::BFloat16 log(c10::BFloat16 a) { return std::log(float(a)); }
+inline c10::BFloat16 exp(c10::BFloat16 a) {
+  return std::exp(float(a));
+}
+inline c10::BFloat16 log(c10::BFloat16 a) {
+  return std::log(float(a));
+}
 
 } // namespace std

--- a/c10/util/BFloat16.h
+++ b/c10/util/BFloat16.h
@@ -10,54 +10,54 @@
 namespace c10 {
 
 namespace detail {
-  inline C10_HOST_DEVICE float f32_from_bits(uint16_t src) {
-    float res = 0;
-    uint32_t tmp = src;
-    tmp <<= 16;
+inline C10_HOST_DEVICE float f32_from_bits(uint16_t src) {
+  float res = 0;
+  uint32_t tmp = src;
+  tmp <<= 16;
 
 #ifdef __HIP_PLATFORM_HCC__
-    float* tempRes;
+  float* tempRes;
 
-    // We should be using memcpy in order to respect the strict aliasing rule
-    // but it fails in the HIP environment.
-    tempRes = reinterpret_cast<float*>(&tmp);
-    res = *tempRes;
+  // We should be using memcpy in order to respect the strict aliasing rule
+  // but it fails in the HIP environment.
+  tempRes = reinterpret_cast<float*>(&tmp);
+  res = *tempRes;
 #else
-    std::memcpy(&res, &tmp, sizeof(tmp));
+  std::memcpy(&res, &tmp, sizeof(tmp));
 #endif
 
-    return res;
-  }
+  return res;
+}
 
-  inline C10_HOST_DEVICE uint16_t bits_from_f32(float src) {
-    uint32_t res = 0;
+inline C10_HOST_DEVICE uint16_t bits_from_f32(float src) {
+  uint32_t res = 0;
 
 #ifdef __HIP_PLATFORM_HCC__
-    // We should be using memcpy in order to respect the strict aliasing rule
-    // but it fails in the HIP environment.
-    uint32_t* tempRes = reinterpret_cast<uint32_t*>(&src);
-    res = *tempRes;
+  // We should be using memcpy in order to respect the strict aliasing rule
+  // but it fails in the HIP environment.
+  uint32_t* tempRes = reinterpret_cast<uint32_t*>(&src);
+  res = *tempRes;
 #else
-    std::memcpy(&res, &src, sizeof(res));
+  std::memcpy(&res, &src, sizeof(res));
 #endif
 
-    return res >> 16;
-  }
+  return res >> 16;
+}
 
-  inline C10_HOST_DEVICE uint16_t round_to_nearest_even(float src) {
-    if (std::isnan(src)) {
-      return 0x7FC0;
-    } else {
-      union {
-        uint32_t U32;
-        float F32;
-      };
+inline C10_HOST_DEVICE uint16_t round_to_nearest_even(float src) {
+  if (std::isnan(src)) {
+    return 0x7FC0;
+  } else {
+    union {
+      uint32_t U32;
+      float F32;
+    };
 
-      F32 = src;
-      uint32_t rounding_bias = ((U32 >> 16) & 1) + 0x7FFF;
-      return static_cast<uint16_t>((U32 + rounding_bias) >> 16);
-    }
+    F32 = src;
+    uint32_t rounding_bias = ((U32 >> 16) & 1) + 0x7FFF;
+    return static_cast<uint16_t>((U32 + rounding_bias) >> 16);
   }
+}
 } // namespace detail
 
 struct alignas(2) BFloat16 {
@@ -75,12 +75,12 @@ struct alignas(2) BFloat16 {
     return from_bits_t();
   }
 
-  constexpr C10_HOST_DEVICE BFloat16(unsigned short bits, from_bits_t) : x(bits){};
+  constexpr C10_HOST_DEVICE BFloat16(unsigned short bits, from_bits_t)
+      : x(bits){};
   inline C10_HOST_DEVICE BFloat16(float value);
   inline C10_HOST_DEVICE operator float() const;
 };
 
 } // namespace c10
-
 
 #include <c10/util/BFloat16-inl.h>

--- a/c10/util/C++17.h
+++ b/c10/util/C++17.h
@@ -2,72 +2,88 @@
 #ifndef C10_UTIL_CPP17_H_
 #define C10_UTIL_CPP17_H_
 
-#include <type_traits>
-#include <utility>
+#include <c10/macros/Macros.h>
+#include <cstdlib>
+#include <functional>
 #include <memory>
 #include <sstream>
 #include <string>
-#include <cstdlib>
-#include <functional>
-#include <c10/macros/Macros.h>
+#include <type_traits>
+#include <utility>
 
 /*
  * This header adds some polyfills with C++14 and C++17 functionality
  */
 
-namespace c10 { namespace guts {
-
-
+namespace c10 {
+namespace guts {
 
 #ifdef __cpp_lib_transformation_trait_aliases
-template<bool B, class T, class F> using conditional_t = std::conditional_t<B, T, F>;
-template<bool B, class T = void> using enable_if_t = std::enable_if_t<B, T>;
-template<class T> using add_lvalue_reference_t = std::add_lvalue_reference_t<T>;
-template<class T> using remove_reference_t = std::remove_reference_t<T>;
-template<class T> using remove_cv_t = std::remove_cv_t<T>;
-template<class T> using result_of_t = std::result_of_t<T>;
-template<class T> using decay_t = std::decay_t<T>;
-template<class T> using remove_const_t = std::remove_const_t<T>;
-template<class T> using remove_pointer_t = std::remove_pointer_t<T>;
-template<class... T> using common_type_t = std::common_type_t<T...>;
+template <bool B, class T, class F>
+using conditional_t = std::conditional_t<B, T, F>;
+template <bool B, class T = void>
+using enable_if_t = std::enable_if_t<B, T>;
+template <class T>
+using add_lvalue_reference_t = std::add_lvalue_reference_t<T>;
+template <class T>
+using remove_reference_t = std::remove_reference_t<T>;
+template <class T>
+using remove_cv_t = std::remove_cv_t<T>;
+template <class T>
+using result_of_t = std::result_of_t<T>;
+template <class T>
+using decay_t = std::decay_t<T>;
+template <class T>
+using remove_const_t = std::remove_const_t<T>;
+template <class T>
+using remove_pointer_t = std::remove_pointer_t<T>;
+template <class... T>
+using common_type_t = std::common_type_t<T...>;
 #else
-template<bool B, class T, class F> using conditional_t = typename std::conditional<B, T, F>::type;
-template<bool B, class T = void> using enable_if_t = typename std::enable_if<B, T>::type;
-template<class T> using add_lvalue_reference_t = typename std::add_lvalue_reference<T>::type;
-template<class T> using remove_reference_t = typename std::remove_reference<T>::type;
-template<class T> using remove_cv_t = typename std::remove_cv<T>::type;
-template<class T> using result_of_t = typename std::result_of<T>::type;
-template<class T> using decay_t = typename std::decay<T>::type;
-template<class T> using remove_const_t = typename std::remove_const<T>::type;
-template<class T> using remove_pointer_t = typename std::remove_pointer<T>::type;
-template<class... T> using common_type_t = typename std::common_type<T...>::type;
+template <bool B, class T, class F>
+using conditional_t = typename std::conditional<B, T, F>::type;
+template <bool B, class T = void>
+using enable_if_t = typename std::enable_if<B, T>::type;
+template <class T>
+using add_lvalue_reference_t = typename std::add_lvalue_reference<T>::type;
+template <class T>
+using remove_reference_t = typename std::remove_reference<T>::type;
+template <class T>
+using remove_cv_t = typename std::remove_cv<T>::type;
+template <class T>
+using result_of_t = typename std::result_of<T>::type;
+template <class T>
+using decay_t = typename std::decay<T>::type;
+template <class T>
+using remove_const_t = typename std::remove_const<T>::type;
+template <class T>
+using remove_pointer_t = typename std::remove_pointer<T>::type;
+template <class... T>
+using common_type_t = typename std::common_type<T...>::type;
 #endif
-
-
-
 
 // C++11 doesn't have constexpr std::move / std::forward.
 // Implementation taken from libc++.
-template<class T>
+template <class T>
 constexpr inline guts::remove_reference_t<T>&& move(T&& t) noexcept {
   return static_cast<guts::remove_reference_t<T>&&>(t);
 }
 template <class T>
 constexpr inline T&& forward(guts::remove_reference_t<T>& t) noexcept {
-    return static_cast<T&&>(t);
+  return static_cast<T&&>(t);
 }
 template <class T>
 constexpr inline T&& forward(guts::remove_reference_t<T>&& t) noexcept {
-    static_assert(!std::is_lvalue_reference<T>::value,
-                  "can not forward an rvalue as an lvalue.");
-    return static_cast<T&&>(t);
+  static_assert(
+      !std::is_lvalue_reference<T>::value,
+      "can not forward an rvalue as an lvalue.");
+  return static_cast<T&&>(t);
 }
 
-
-
-
-#if __cplusplus >= 201402L || defined(__cpp_lib_make_unique) && __cpp_lib_make_unique >= 201304L || \
-  (defined(__ANDROID__) && __ANDROID__ && __cplusplus >= 201300L) || defined(_MSC_VER) && _MSC_VER >= 1900
+#if __cplusplus >= 201402L ||                                             \
+    defined(__cpp_lib_make_unique) && __cpp_lib_make_unique >= 201304L || \
+    (defined(__ANDROID__) && __ANDROID__ && __cplusplus >= 201300L) ||    \
+    defined(_MSC_VER) && _MSC_VER >= 1900
 
 /* using override */ using std::make_unique;
 
@@ -93,48 +109,63 @@ make_unique(Args&&...) = delete;
 #endif
 
 template <typename Base, typename Child, typename... Args>
-typename std::enable_if<!std::is_array<Base>::value && !std::is_array<Base>::value && std::is_base_of<Base, Child>::value, std::unique_ptr<Base>>::type
+typename std::enable_if<
+    !std::is_array<Base>::value && !std::is_array<Base>::value &&
+        std::is_base_of<Base, Child>::value,
+    std::unique_ptr<Base>>::type
 make_unique_base(Args&&... args) {
   return std::unique_ptr<Base>(new Child(c10::guts::forward<Args>(args)...));
 }
 
-
-
 #ifdef __cpp_lib_integer_sequence
 
-template<class T, T... Ints> using integer_sequence = std::integer_sequence<T, Ints...>;
-template<std::size_t... Ints> using index_sequence = std::index_sequence<Ints...>;
-template<class T, T N> using make_integer_sequence = std::make_integer_sequence<T, N>;
-template<std::size_t N> using make_index_sequence = std::make_index_sequence<N>;
-template<class... T> using index_sequence_for = std::index_sequence_for<T...>;
+template <class T, T... Ints>
+using integer_sequence = std::integer_sequence<T, Ints...>;
+template <std::size_t... Ints>
+using index_sequence = std::index_sequence<Ints...>;
+template <class T, T N>
+using make_integer_sequence = std::make_integer_sequence<T, N>;
+template <std::size_t N>
+using make_index_sequence = std::make_index_sequence<N>;
+template <class... T>
+using index_sequence_for = std::index_sequence_for<T...>;
 
 #else
 
-template<class T, T... Ints> struct integer_sequence {
+template <class T, T... Ints>
+struct integer_sequence {
   using value_type = T;
-  static constexpr std::size_t size() noexcept {return sizeof...(Ints);}
+  static constexpr std::size_t size() noexcept {
+    return sizeof...(Ints);
+  }
 };
-template<std::size_t... Ints> using index_sequence = integer_sequence<std::size_t, Ints...>;
+template <std::size_t... Ints>
+using index_sequence = integer_sequence<std::size_t, Ints...>;
 namespace detail {
-  template<class T, std::size_t I, std::size_t N, T... Ints>
-  struct make_integer_sequence_ {
-    using type = typename make_integer_sequence_<T, I+1, N, Ints..., I>::type;
-  };
-  template<class T, std::size_t N, T... Ints>
-  struct make_integer_sequence_<T, N, N, Ints...> {
-    using type = integer_sequence<T, Ints...>;
-  };
-}
-template<class T, T N> using make_integer_sequence = typename detail::make_integer_sequence_<T, 0, N>::type;
-template<std::size_t N> using make_index_sequence = make_integer_sequence<std::size_t, N>;
-static_assert(std::is_same<index_sequence<>, make_index_sequence<0>>::value, "");
-static_assert(std::is_same<index_sequence<0, 1, 2>, make_index_sequence<3>>::value, "");
-template<class... T> using index_sequence_for = make_index_sequence<sizeof...(T)>;
+template <class T, std::size_t I, std::size_t N, T... Ints>
+struct make_integer_sequence_ {
+  using type = typename make_integer_sequence_<T, I + 1, N, Ints..., I>::type;
+};
+template <class T, std::size_t N, T... Ints>
+struct make_integer_sequence_<T, N, N, Ints...> {
+  using type = integer_sequence<T, Ints...>;
+};
+} // namespace detail
+template <class T, T N>
+using make_integer_sequence =
+    typename detail::make_integer_sequence_<T, 0, N>::type;
+template <std::size_t N>
+using make_index_sequence = make_integer_sequence<std::size_t, N>;
+static_assert(
+    std::is_same<index_sequence<>, make_index_sequence<0>>::value,
+    "");
+static_assert(
+    std::is_same<index_sequence<0, 1, 2>, make_index_sequence<3>>::value,
+    "");
+template <class... T>
+using index_sequence_for = make_index_sequence<sizeof...(T)>;
 
 #endif
-
-
-
 
 #ifdef __cpp_lib_logical_traits
 
@@ -150,45 +181,51 @@ using negation = std::negation<B>;
 #else
 
 // Implementation taken from http://en.cppreference.com/w/cpp/types/conjunction
-template<class...> struct conjunction : std::true_type { };
-template<class B1> struct conjunction<B1> : B1 { };
-template<class B1, class... Bn>
+template <class...>
+struct conjunction : std::true_type {};
+template <class B1>
+struct conjunction<B1> : B1 {};
+template <class B1, class... Bn>
 struct conjunction<B1, Bn...>
     : conditional_t<bool(B1::value), conjunction<Bn...>, B1> {};
 
 // Implementation taken from http://en.cppreference.com/w/cpp/types/disjunction
-template<class...> struct disjunction : std::false_type { };
-template<class B1> struct disjunction<B1> : B1 { };
-template<class B1, class... Bn>
+template <class...>
+struct disjunction : std::false_type {};
+template <class B1>
+struct disjunction<B1> : B1 {};
+template <class B1, class... Bn>
 struct disjunction<B1, Bn...>
-    : conditional_t<bool(B1::value), B1, disjunction<Bn...>>  { };
+    : conditional_t<bool(B1::value), B1, disjunction<Bn...>> {};
 
-// Implementation taken from http://en.cppreference.com/w/cpp/types/integral_constant
+// Implementation taken from
+// http://en.cppreference.com/w/cpp/types/integral_constant
 template <bool B>
 using bool_constant = std::integral_constant<bool, B>;
 
 // Implementation taken from http://en.cppreference.com/w/cpp/types/negation
-template<class B>
-struct negation : bool_constant<!bool(B::value)> { };
+template <class B>
+struct negation : bool_constant<!bool(B::value)> {};
 
 #endif
 
-
-
 #ifdef __cpp_lib_void_t
 
-template<class T> using void_t = std::void_t<T>;
+template <class T>
+using void_t = std::void_t<T>;
 
 #else
 
 // Implementation taken from http://en.cppreference.com/w/cpp/types/void_t
 // (it takes CWG1558 into account and also works for older compilers)
-template<typename... Ts> struct make_void { typedef void type;};
-template<typename... Ts> using void_t = typename make_void<Ts...>::type;
+template <typename... Ts>
+struct make_void {
+  typedef void type;
+};
+template <typename... Ts>
+using void_t = typename make_void<Ts...>::type;
 
 #endif
-
-
 
 #ifdef __cpp_lib_apply
 
@@ -199,41 +236,49 @@ inline constexpr decltype(auto) apply(F&& f, Tuple&& t) {
 
 #else
 
-// Implementation from http://en.cppreference.com/w/cpp/utility/apply (but modified)
-// TODO This is an incomplete implementation of std::apply, not working for member functions.
+// Implementation from http://en.cppreference.com/w/cpp/utility/apply (but
+// modified)
+// TODO This is an incomplete implementation of std::apply, not working for
+// member functions.
 namespace detail {
 template <class F, class Tuple, std::size_t... I>
 #if defined(_MSC_VER)
-// MSVC has a problem with the decltype() return type, but it also doesn't need it
-// Also, nvcc on Windows needs C10_HOST_DEVICE here.
-C10_HOST_DEVICE constexpr auto apply_impl(F&& f, Tuple&& t, guts::index_sequence<I...>)
+// MSVC has a problem with the decltype() return type, but it also doesn't need
+// it Also, nvcc on Windows needs C10_HOST_DEVICE here.
+C10_HOST_DEVICE constexpr auto apply_impl(
+    F&& f,
+    Tuple&& t,
+    guts::index_sequence<I...>)
 #else
-// GCC/Clang need the decltype() return type and rocm doesn't like the C10_HOST_DEVICE
+// GCC/Clang need the decltype() return type and rocm doesn't like the
+// C10_HOST_DEVICE
 constexpr auto apply_impl(F&& f, Tuple&& t, guts::index_sequence<I...>)
--> decltype(c10::guts::forward<F>(f)(std::get<I>(c10::guts::forward<Tuple>(t))...))
+    -> decltype(
+        c10::guts::forward<F>(f)(std::get<I>(c10::guts::forward<Tuple>(t))...))
 #endif
 {
-    return c10::guts::forward<F>(f)(std::get<I>(c10::guts::forward<Tuple>(t))...);
+  return c10::guts::forward<F>(f)(std::get<I>(c10::guts::forward<Tuple>(t))...);
 }
-}  // namespace detail
+} // namespace detail
 
 template <class F, class Tuple>
 #if defined(_MSC_VER)
 C10_HOST_DEVICE // rocm doesn't like the C10_HOST_DEVICE
 #endif
-constexpr auto apply(F&& f, Tuple&& t) -> decltype(detail::apply_impl(
-    c10::guts::forward<F>(f), c10::guts::forward<Tuple>(t),
-    guts::make_index_sequence<std::tuple_size<guts::remove_reference_t<Tuple>>::value>{}))
-{
-    return detail::apply_impl(
-        c10::guts::forward<F>(f), c10::guts::forward<Tuple>(t),
-        guts::make_index_sequence<std::tuple_size<guts::remove_reference_t<Tuple>>::value>{});
+    constexpr auto
+    apply(F&& f, Tuple&& t) -> decltype(detail::apply_impl(
+        c10::guts::forward<F>(f),
+        c10::guts::forward<Tuple>(t),
+        guts::make_index_sequence<
+            std::tuple_size<guts::remove_reference_t<Tuple>>::value>{})) {
+  return detail::apply_impl(
+      c10::guts::forward<F>(f),
+      c10::guts::forward<Tuple>(t),
+      guts::make_index_sequence<
+          std::tuple_size<guts::remove_reference_t<Tuple>>::value>{});
 }
 
 #endif
-
-
-
 
 template <typename Functor, typename... Args>
 typename std::enable_if<
@@ -251,43 +296,51 @@ invoke(Functor&& f, Args&&... args) {
   return std::forward<Functor>(f)(std::forward<Args>(args)...);
 }
 
-
-
-// GCC 4.8 doesn't define std::to_string, even though that's in C++11. Let's define it.
+// GCC 4.8 doesn't define std::to_string, even though that's in C++11. Let's
+// define it.
 namespace detail {
 class DummyClassForToString final {};
-}}}
+} // namespace detail
+} // namespace guts
+} // namespace c10
 namespace std {
-// We use SFINAE to detect if std::to_string exists for a type, but that only works
-// if the function name is defined. So let's define a std::to_string for a dummy type.
-// If you're getting an error here saying that this overload doesn't match your
-// std::to_string() call, then you're calling std::to_string() but should be calling
-// c10::guts::to_string().
-inline std::string to_string(c10::guts::detail::DummyClassForToString) { return ""; }
-
+// We use SFINAE to detect if std::to_string exists for a type, but that only
+// works if the function name is defined. So let's define a std::to_string for a
+// dummy type. If you're getting an error here saying that this overload doesn't
+// match your std::to_string() call, then you're calling std::to_string() but
+// should be calling c10::guts::to_string().
+inline std::string to_string(c10::guts::detail::DummyClassForToString) {
+  return "";
 }
-namespace c10 { namespace guts { namespace detail {
 
-template<class T, class Enable = void>
+} // namespace std
+namespace c10 {
+namespace guts {
+namespace detail {
+
+template <class T, class Enable = void>
 struct to_string_ final {
-    static std::string call(T value) {
-        std::ostringstream str;
-        str << value;
-        return str.str();
-    }
+  static std::string call(T value) {
+    std::ostringstream str;
+    str << value;
+    return str.str();
+  }
 };
 // If a std::to_string exists, use that instead
-template<class T>
-struct to_string_<T, void_t<decltype(std::to_string(std::declval<T>()))>> final {
-    static std::string call(T value) {
-        return std::to_string(value);
-    }
+template <class T>
+struct to_string_<T, void_t<decltype(std::to_string(std::declval<T>()))>>
+    final {
+  static std::string call(T value) {
+    return std::to_string(value);
+  }
 };
-}
-template<class T> inline std::string to_string(T value) {
-    return detail::to_string_<T>::call(value);
+} // namespace detail
+template <class T>
+inline std::string to_string(T value) {
+  return detail::to_string_<T>::call(value);
 }
 
-}}
+} // namespace guts
+} // namespace c10
 
 #endif // C10_UTIL_CPP17_H_

--- a/c10/util/Deprecated.h
+++ b/c10/util/Deprecated.h
@@ -20,25 +20,24 @@
 // to use this version, because as of C++14 it is the correct and
 // portable way to declare something deprecated.
 // NB: __cplusplus doesn't work for MSVC, so for now MSVC always uses
-// the "__declspec(deprecated)" implementation and not the C++14 "[[deprecated]]"
-// attribute. We tried enabling "[[deprecated]]" for C++14 on MSVC, but
-// ran into issues with some older MSVC versions.
+// the "__declspec(deprecated)" implementation and not the C++14
+// "[[deprecated]]" attribute. We tried enabling "[[deprecated]]" for C++14 on
+// MSVC, but ran into issues with some older MSVC versions.
 #if (defined(__cplusplus) && __cplusplus >= 201402L)
-# define C10_DEPRECATED [[deprecated]]
-# define C10_DEPRECATED_MESSAGE(message) [[deprecated(message)]]
+#define C10_DEPRECATED [[deprecated]]
+#define C10_DEPRECATED_MESSAGE(message) [[deprecated(message)]]
 #elif defined(__GNUC__)
-# define C10_DEPRECATED __attribute__((deprecated))
+#define C10_DEPRECATED __attribute__((deprecated))
 // TODO Is there some way to implement this?
-# define C10_DEPRECATED_MESSAGE(message) __attribute__((deprecated))
+#define C10_DEPRECATED_MESSAGE(message) __attribute__((deprecated))
 
 #elif defined(_MSC_VER)
-# define C10_DEPRECATED __declspec(deprecated)
-# define C10_DEPRECATED_MESSAGE(message) __declspec(deprecated(message))
+#define C10_DEPRECATED __declspec(deprecated)
+#define C10_DEPRECATED_MESSAGE(message) __declspec(deprecated(message))
 #else
-# warning "You need to implement C10_DEPRECATED for this compiler"
-# define C10_DEPRECATED
+#warning "You need to implement C10_DEPRECATED for this compiler"
+#define C10_DEPRECATED
 #endif
-
 
 // Sample usage:
 //
@@ -52,7 +51,8 @@
 // many compilers.
 #if defined(__has_cpp_attribute)
 #if __has_cpp_attribute(deprecated)
-# define C10_DEFINE_DEPRECATED_USING(TypeName, TypeThingy) using TypeName [[deprecated]] = TypeThingy;
+#define C10_DEFINE_DEPRECATED_USING(TypeName, TypeThingy) \
+  using TypeName [[deprecated]] = TypeThingy;
 #endif
 #endif
 
@@ -65,18 +65,21 @@
 //
 // So we just turn the macro off in this case.
 #if defined(C10_DEFINE_DEPRECATED_USING)
-# undef C10_DEFINE_DEPRECATED_USING
+#undef C10_DEFINE_DEPRECATED_USING
 #endif
-# define C10_DEFINE_DEPRECATED_USING(TypeName, TypeThingy) using TypeName = TypeThingy;
+#define C10_DEFINE_DEPRECATED_USING(TypeName, TypeThingy) \
+  using TypeName = TypeThingy;
 #else
 // [[deprecated]] does work in windows without nvcc, though msc doesn't support
-// `__has_cpp_attribute` when c++14 is supported, otherwise __declspec(deprecated)
-// is used as the alternative.
+// `__has_cpp_attribute` when c++14 is supported, otherwise
+// __declspec(deprecated) is used as the alternative.
 #ifndef C10_DEFINE_DEPRECATED_USING
 #if defined(_MSVC_LANG) && _MSVC_LANG >= 201402L
-# define C10_DEFINE_DEPRECATED_USING(TypeName, TypeThingy) using TypeName [[deprecated]] = TypeThingy;
+#define C10_DEFINE_DEPRECATED_USING(TypeName, TypeThingy) \
+  using TypeName [[deprecated]] = TypeThingy;
 #else
-# define C10_DEFINE_DEPRECATED_USING(TypeName, TypeThingy) using TypeName = __declspec(deprecated) TypeThingy;
+#define C10_DEFINE_DEPRECATED_USING(TypeName, TypeThingy) \
+  using TypeName = __declspec(deprecated) TypeThingy;
 #endif
 #endif
 #endif
@@ -88,14 +91,16 @@
 // attribute when not cuda, and when using a GCC compiler that doesn't support
 // the c++14 syntax we checked for above (availble in __GNUC__ >= 5)
 #if !defined(__CUDACC__)
-# define C10_DEFINE_DEPRECATED_USING(TypeName, TypeThingy) using TypeName __attribute__((deprecated)) = TypeThingy;
+#define C10_DEFINE_DEPRECATED_USING(TypeName, TypeThingy) \
+  using TypeName __attribute__((deprecated)) = TypeThingy;
 #else
 // using cuda + gcc < 5, neither deprecated syntax is available so turning off.
-# define C10_DEFINE_DEPRECATED_USING(TypeName, TypeThingy) using TypeName = TypeThingy;
+#define C10_DEFINE_DEPRECATED_USING(TypeName, TypeThingy) \
+  using TypeName = TypeThingy;
 #endif
 #endif
 
-#if ! defined(C10_DEFINE_DEPRECATED_USING)
-# warning "You need to implement C10_DEFINE_DEPRECATED_USING for this compiler"
-# define C10_DEFINE_DEPRECATED_USING
+#if !defined(C10_DEFINE_DEPRECATED_USING)
+#warning "You need to implement C10_DEFINE_DEPRECATED_USING for this compiler"
+#define C10_DEFINE_DEPRECATED_USING
 #endif

--- a/c10/util/Exception.cpp
+++ b/c10/util/Exception.cpp
@@ -1,7 +1,7 @@
 #include "c10/util/Exception.h"
 #include "c10/util/Backtrace.h"
-#include "c10/util/Type.h"
 #include "c10/util/Logging.h"
+#include "c10/util/Type.h"
 
 #include <iostream>
 #include <numeric>

--- a/c10/util/Flags.h
+++ b/c10/util/Flags.h
@@ -115,7 +115,7 @@ namespace gflags = google;
 // flags defined in C10. This is done via a global reference, so the flag
 // itself is not duplicated - under the hood it is the same global gflags flag.
 #define C10_GFLAGS_DEF_WRAPPER(type, real_type, name, default_value, help_str) \
-  DEFINE_##type(name, default_value, help_str);                                \
+  DEFINE_##type(name, default_value, help_str);
 
 #define C10_DEFINE_int(name, default_value, help_str) \
   C10_GFLAGS_DEF_WRAPPER(int32, gflags::int32, name, default_value, help_str)
@@ -131,8 +131,7 @@ namespace gflags = google;
   C10_GFLAGS_DEF_WRAPPER(string, ::fLS::clstring, name, default_value, help_str)
 
 // DECLARE_typed_var should be used in header files and in the global namespace.
-#define C10_GFLAGS_DECLARE_WRAPPER(type, real_type, name) \
-  DECLARE_##type(name);                                   \
+#define C10_GFLAGS_DECLARE_WRAPPER(type, real_type, name) DECLARE_##type(name);
 
 #define C10_DECLARE_int(name) \
   C10_GFLAGS_DECLARE_WRAPPER(int32, gflags::int32, name)

--- a/c10/util/FunctionRef.h
+++ b/c10/util/FunctionRef.h
@@ -26,40 +26,43 @@ namespace c10 {
 ///
 /// This class does not own the callable, so it is not in general safe to store
 /// a function_ref.
-template<typename Fn> class function_ref;
+template <typename Fn>
+class function_ref;
 
-template<typename Ret, typename ...Params>
+template <typename Ret, typename... Params>
 class function_ref<Ret(Params...)> {
-Ret (*callback)(intptr_t callable, Params ...params) = nullptr;
-intptr_t callable;
+  Ret (*callback)(intptr_t callable, Params... params) = nullptr;
+  intptr_t callable;
 
-template<typename Callable>
-static Ret callback_fn(intptr_t callable, Params ...params) {
+  template <typename Callable>
+  static Ret callback_fn(intptr_t callable, Params... params) {
     return (*reinterpret_cast<Callable*>(callable))(
         std::forward<Params>(params)...);
-}
+  }
 
-public:
-function_ref() = default;
-function_ref(std::nullptr_t) {}
+ public:
+  function_ref() = default;
+  function_ref(std::nullptr_t) {}
 
-template <typename Callable>
-function_ref(Callable &&callable,
-            typename std::enable_if<
-                !std::is_same<typename std::remove_reference<Callable>::type,
-                                function_ref>::value>::type * = nullptr,
-            typename std::enable_if<
-                 std::is_convertible<
-                   typename std::result_of<Callable&&(Params&&...)>::type,
-                   Ret>::value>::type * = nullptr)
-    : callback(callback_fn<typename std::remove_reference<Callable>::type>),
+  template <typename Callable>
+  function_ref(
+      Callable&& callable,
+      typename std::enable_if<!std::is_same<
+          typename std::remove_reference<Callable>::type,
+          function_ref>::value>::type* = nullptr,
+      typename std::enable_if<std::is_convertible<
+          typename std::result_of<Callable && (Params && ...)>::type,
+          Ret>::value>::type* = nullptr)
+      : callback(callback_fn<typename std::remove_reference<Callable>::type>),
         callable(reinterpret_cast<intptr_t>(&callable)) {}
 
-Ret operator()(Params ...params) const {
+  Ret operator()(Params... params) const {
     return callback(callable, std::forward<Params>(params)...);
-}
+  }
 
-operator bool() const { return callback; }
+  operator bool() const {
+    return callback;
+  }
 };
- 
-}
+
+} // namespace c10

--- a/c10/util/Half-inl.h
+++ b/c10/util/Half-inl.h
@@ -1,8 +1,8 @@
 #pragma once
 
+#include <c10/macros/Macros.h>
 #include <cstring>
 #include <limits>
-#include <c10/macros/Macros.h>
 
 #ifdef __CUDACC__
 #include <cuda_fp16.h>
@@ -47,7 +47,7 @@ inline C10_HOST_DEVICE Half::operator __half() const {
 
 #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 350)
 inline __device__ Half __ldg(const Half* ptr) {
-    return __ldg(reinterpret_cast<const __half*>(ptr));
+  return __ldg(reinterpret_cast<const __half*>(ptr));
 }
 #endif
 
@@ -70,7 +70,8 @@ inline C10_HOST_DEVICE Half operator/(const Half& a, const Half& b) {
 }
 
 inline C10_HOST_DEVICE Half operator-(const Half& a) {
-#if (defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 530) || defined(__HIP_DEVICE_COMPILE__)
+#if (defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 530) || \
+    defined(__HIP_DEVICE_COMPILE__)
   return __hneg(a);
 #else
   return -static_cast<float>(a);

--- a/c10/util/Half.h
+++ b/c10/util/Half.h
@@ -25,8 +25,8 @@
 #endif
 
 #include <complex>
-#include <cstring>
 #include <cstdint>
+#include <cstring>
 #include <iosfwd>
 #include <limits>
 #include <sstream>
@@ -46,278 +46,307 @@ namespace c10 {
 
 namespace detail {
 
-  inline float fp32_from_bits(uint32_t w) {
-  #if defined(__OPENCL_VERSION__)
-    return as_float(w);
-  #elif defined(__CUDA_ARCH__)
-    return __uint_as_float((unsigned int)w);
-  #elif defined(__INTEL_COMPILER)
-    return _castu32_f32(w);
-  #else
-    union {
-      uint32_t as_bits;
-      float as_value;
-    } fp32 = {w};
-    return fp32.as_value;
-  #endif
-  }
-
-  inline uint32_t fp32_to_bits(float f) {
-  #if defined(__OPENCL_VERSION__)
-    return as_uint(f);
-  #elif defined(__CUDA_ARCH__)
-    return (uint32_t)__float_as_uint(f);
-  #elif defined(__INTEL_COMPILER)
-    return _castf32_u32(f);
-  #else
-    union {
-      float as_value;
-      uint32_t as_bits;
-    } fp32 = {f};
-    return fp32.as_bits;
-  #endif
-  }
-
-  /*
-   * Convert a 16-bit floating-point number in IEEE half-precision format, in bit representation, to
-   * a 32-bit floating-point number in IEEE single-precision format, in bit representation.
-   *
-   * @note The implementation doesn't use any floating-point operations.
-   */
-  inline uint32_t fp16_ieee_to_fp32_bits(uint16_t h) {
-          /*
-           * Extend the half-precision floating-point number to 32 bits and shift to the upper part of the 32-bit word:
-           *      +---+-----+------------+-------------------+
-           *      | S |EEEEE|MM MMMM MMMM|0000 0000 0000 0000|
-           *      +---+-----+------------+-------------------+
-           * Bits  31  26-30    16-25            0-15
-           *
-           * S - sign bit, E - bits of the biased exponent, M - bits of the mantissa, 0 - zero bits.
-           */
-          const uint32_t w = (uint32_t) h << 16;
-          /*
-           * Extract the sign of the input number into the high bit of the 32-bit word:
-           *
-           *      +---+----------------------------------+
-           *      | S |0000000 00000000 00000000 00000000|
-           *      +---+----------------------------------+
-           * Bits  31                 0-31
-           */
-          const uint32_t sign = w & UINT32_C(0x80000000);
-          /*
-           * Extract mantissa and biased exponent of the input number into the bits 0-30 of the 32-bit word:
-           *
-           *      +---+-----+------------+-------------------+
-           *      | 0 |EEEEE|MM MMMM MMMM|0000 0000 0000 0000|
-           *      +---+-----+------------+-------------------+
-           * Bits  30  27-31     17-26            0-16
-           */
-          const uint32_t nonsign = w & UINT32_C(0x7FFFFFFF);
-          /*
-           * Renorm shift is the number of bits to shift mantissa left to make the half-precision number normalized.
-           * If the initial number is normalized, some of its high 6 bits (sign == 0 and 5-bit exponent) equals one.
-           * In this case renorm_shift == 0. If the number is denormalize, renorm_shift > 0. Note that if we shift
-           * denormalized nonsign by renorm_shift, the unit bit of mantissa will shift into exponent, turning the
-           * biased exponent into 1, and making mantissa normalized (i.e. without leading 1).
-           */
-#ifdef _MSC_VER
-        unsigned long nonsign_bsr;
-        _BitScanReverse(&nonsign_bsr, (unsigned long)nonsign);
-        uint32_t renorm_shift = (uint32_t)nonsign_bsr ^ 31;
+inline float fp32_from_bits(uint32_t w) {
+#if defined(__OPENCL_VERSION__)
+  return as_float(w);
+#elif defined(__CUDA_ARCH__)
+  return __uint_as_float((unsigned int)w);
+#elif defined(__INTEL_COMPILER)
+  return _castu32_f32(w);
 #else
-        uint32_t renorm_shift = __builtin_clz(nonsign);
+  union {
+    uint32_t as_bits;
+    float as_value;
+  } fp32 = {w};
+  return fp32.as_value;
 #endif
-        renorm_shift = renorm_shift > 5 ? renorm_shift - 5 : 0;
-        /*
-         * Iff half-precision number has exponent of 15, the addition overflows
-         * it into bit 31, and the subsequent shift turns the high 9 bits
-         * into 1. Thus inf_nan_mask == 0x7F800000 if the half-precision number
-         * had exponent of 15 (i.e. was NaN or infinity) 0x00000000 otherwise
-         */
-        const int32_t inf_nan_mask =
-            ((int32_t)(nonsign + 0x04000000) >> 8) & INT32_C(0x7F800000);
-        /*
-         * Iff nonsign is 0, it overflows into 0xFFFFFFFF, turning bit 31
-         * into 1. Otherwise, bit 31 remains 0. The signed shift right by 31
-         * broadcasts bit 31 into all bits of the zero_mask. Thus zero_mask ==
-         * 0xFFFFFFFF if the half-precision number was zero (+0.0h or -0.0h)
-         * 0x00000000 otherwise
-         */
-        const int32_t zero_mask = (int32_t)(nonsign - 1) >> 31;
-        /*
-         * 1. Shift nonsign left by renorm_shift to normalize it (if the input
-         * was denormal)
-         * 2. Shift nonsign right by 3 so the exponent (5 bits originally)
-         * becomes an 8-bit field and 10-bit mantissa shifts into the 10 high
-         * bits of the 23-bit mantissa of IEEE single-precision number.
-         * 3. Add 0x70 to the exponent (starting at bit 23) to compensate the
-         * different in exponent bias (0x7F for single-precision number less 0xF
-         * for half-precision number).
-         * 4. Subtract renorm_shift from the exponent (starting at bit 23) to
-         * account for renormalization. As renorm_shift is less than 0x70, this
-         * can be combined with step 3.
-         * 5. Binary OR with inf_nan_mask to turn the exponent into 0xFF if the
-         * input was NaN or infinity.
-         * 6. Binary ANDNOT with zero_mask to turn the mantissa and exponent
-         * into zero if the input was zero.
-         * 7. Combine with the sign of the input number.
-         */
-        return sign |
-            ((((nonsign << renorm_shift >> 3) + ((0x70 - renorm_shift) << 23)) |
-              inf_nan_mask) &
-             ~zero_mask);
-  }
+}
+
+inline uint32_t fp32_to_bits(float f) {
+#if defined(__OPENCL_VERSION__)
+  return as_uint(f);
+#elif defined(__CUDA_ARCH__)
+  return (uint32_t)__float_as_uint(f);
+#elif defined(__INTEL_COMPILER)
+  return _castf32_u32(f);
+#else
+  union {
+    float as_value;
+    uint32_t as_bits;
+  } fp32 = {f};
+  return fp32.as_bits;
+#endif
+}
+
+/*
+ * Convert a 16-bit floating-point number in IEEE half-precision format, in bit
+ * representation, to a 32-bit floating-point number in IEEE single-precision
+ * format, in bit representation.
+ *
+ * @note The implementation doesn't use any floating-point operations.
+ */
+inline uint32_t fp16_ieee_to_fp32_bits(uint16_t h) {
+  /*
+   * Extend the half-precision floating-point number to 32 bits and shift to the
+   * upper part of the 32-bit word:
+   *      +---+-----+------------+-------------------+
+   *      | S |EEEEE|MM MMMM MMMM|0000 0000 0000 0000|
+   *      +---+-----+------------+-------------------+
+   * Bits  31  26-30    16-25            0-15
+   *
+   * S - sign bit, E - bits of the biased exponent, M - bits of the mantissa, 0
+   * - zero bits.
+   */
+  const uint32_t w = (uint32_t)h << 16;
+  /*
+   * Extract the sign of the input number into the high bit of the 32-bit word:
+   *
+   *      +---+----------------------------------+
+   *      | S |0000000 00000000 00000000 00000000|
+   *      +---+----------------------------------+
+   * Bits  31                 0-31
+   */
+  const uint32_t sign = w & UINT32_C(0x80000000);
+  /*
+   * Extract mantissa and biased exponent of the input number into the bits 0-30
+   * of the 32-bit word:
+   *
+   *      +---+-----+------------+-------------------+
+   *      | 0 |EEEEE|MM MMMM MMMM|0000 0000 0000 0000|
+   *      +---+-----+------------+-------------------+
+   * Bits  30  27-31     17-26            0-16
+   */
+  const uint32_t nonsign = w & UINT32_C(0x7FFFFFFF);
+  /*
+   * Renorm shift is the number of bits to shift mantissa left to make the
+   * half-precision number normalized. If the initial number is normalized, some
+   * of its high 6 bits (sign == 0 and 5-bit exponent) equals one. In this case
+   * renorm_shift == 0. If the number is denormalize, renorm_shift > 0. Note
+   * that if we shift denormalized nonsign by renorm_shift, the unit bit of
+   * mantissa will shift into exponent, turning the biased exponent into 1, and
+   * making mantissa normalized (i.e. without leading 1).
+   */
+#ifdef _MSC_VER
+  unsigned long nonsign_bsr;
+  _BitScanReverse(&nonsign_bsr, (unsigned long)nonsign);
+  uint32_t renorm_shift = (uint32_t)nonsign_bsr ^ 31;
+#else
+  uint32_t renorm_shift = __builtin_clz(nonsign);
+#endif
+  renorm_shift = renorm_shift > 5 ? renorm_shift - 5 : 0;
+  /*
+   * Iff half-precision number has exponent of 15, the addition overflows
+   * it into bit 31, and the subsequent shift turns the high 9 bits
+   * into 1. Thus inf_nan_mask == 0x7F800000 if the half-precision number
+   * had exponent of 15 (i.e. was NaN or infinity) 0x00000000 otherwise
+   */
+  const int32_t inf_nan_mask =
+      ((int32_t)(nonsign + 0x04000000) >> 8) & INT32_C(0x7F800000);
+  /*
+   * Iff nonsign is 0, it overflows into 0xFFFFFFFF, turning bit 31
+   * into 1. Otherwise, bit 31 remains 0. The signed shift right by 31
+   * broadcasts bit 31 into all bits of the zero_mask. Thus zero_mask ==
+   * 0xFFFFFFFF if the half-precision number was zero (+0.0h or -0.0h)
+   * 0x00000000 otherwise
+   */
+  const int32_t zero_mask = (int32_t)(nonsign - 1) >> 31;
+  /*
+   * 1. Shift nonsign left by renorm_shift to normalize it (if the input
+   * was denormal)
+   * 2. Shift nonsign right by 3 so the exponent (5 bits originally)
+   * becomes an 8-bit field and 10-bit mantissa shifts into the 10 high
+   * bits of the 23-bit mantissa of IEEE single-precision number.
+   * 3. Add 0x70 to the exponent (starting at bit 23) to compensate the
+   * different in exponent bias (0x7F for single-precision number less 0xF
+   * for half-precision number).
+   * 4. Subtract renorm_shift from the exponent (starting at bit 23) to
+   * account for renormalization. As renorm_shift is less than 0x70, this
+   * can be combined with step 3.
+   * 5. Binary OR with inf_nan_mask to turn the exponent into 0xFF if the
+   * input was NaN or infinity.
+   * 6. Binary ANDNOT with zero_mask to turn the mantissa and exponent
+   * into zero if the input was zero.
+   * 7. Combine with the sign of the input number.
+   */
+  return sign |
+      ((((nonsign << renorm_shift >> 3) + ((0x70 - renorm_shift) << 23)) |
+        inf_nan_mask) &
+       ~zero_mask);
+}
+
+/*
+ * Convert a 16-bit floating-point number in IEEE half-precision format, in bit
+ * representation, to a 32-bit floating-point number in IEEE single-precision
+ * format.
+ *
+ * @note The implementation relies on IEEE-like (no assumption about rounding
+ * mode and no operations on denormals) floating-point operations and bitcasts
+ * between integer and floating-point variables.
+ */
+inline float fp16_ieee_to_fp32_value(uint16_t h) {
+  /*
+   * Extend the half-precision floating-point number to 32 bits and shift to the
+   * upper part of the 32-bit word:
+   *      +---+-----+------------+-------------------+
+   *      | S |EEEEE|MM MMMM MMMM|0000 0000 0000 0000|
+   *      +---+-----+------------+-------------------+
+   * Bits  31  26-30    16-25            0-15
+   *
+   * S - sign bit, E - bits of the biased exponent, M - bits of the mantissa, 0
+   * - zero bits.
+   */
+  const uint32_t w = (uint32_t)h << 16;
+  /*
+   * Extract the sign of the input number into the high bit of the 32-bit word:
+   *
+   *      +---+----------------------------------+
+   *      | S |0000000 00000000 00000000 00000000|
+   *      +---+----------------------------------+
+   * Bits  31                 0-31
+   */
+  const uint32_t sign = w & UINT32_C(0x80000000);
+  /*
+   * Extract mantissa and biased exponent of the input number into the high bits
+   * of the 32-bit word:
+   *
+   *      +-----+------------+---------------------+
+   *      |EEEEE|MM MMMM MMMM|0 0000 0000 0000 0000|
+   *      +-----+------------+---------------------+
+   * Bits  27-31    17-26            0-16
+   */
+  const uint32_t two_w = w + w;
 
   /*
-   * Convert a 16-bit floating-point number in IEEE half-precision format, in bit representation, to
-   * a 32-bit floating-point number in IEEE single-precision format.
+   * Shift mantissa and exponent into bits 23-28 and bits 13-22 so they become
+   * mantissa and exponent of a single-precision floating-point number:
    *
-   * @note The implementation relies on IEEE-like (no assumption about rounding mode and no operations on denormals)
-   * floating-point operations and bitcasts between integer and floating-point variables.
+   *       S|Exponent |          Mantissa
+   *      +-+---+-----+------------+----------------+
+   *      |0|000|EEEEE|MM MMMM MMMM|0 0000 0000 0000|
+   *      +-+---+-----+------------+----------------+
+   * Bits   | 23-31   |           0-22
+   *
+   * Next, there are some adjustments to the exponent:
+   * - The exponent needs to be corrected by the difference in exponent bias
+   * between single-precision and half-precision formats (0x7F - 0xF = 0x70)
+   * - Inf and NaN values in the inputs should become Inf and NaN values after
+   * conversion to the single-precision number. Therefore, if the biased
+   * exponent of the half-precision input was 0x1F (max possible value), the
+   * biased exponent of the single-precision output must be 0xFF (max possible
+   * value). We do this correction in two steps:
+   *   - First, we adjust the exponent by (0xFF - 0x1F) = 0xE0 (see exp_offset
+   * below) rather than by 0x70 suggested by the difference in the exponent bias
+   * (see above).
+   *   - Then we multiply the single-precision result of exponent adjustment by
+   * 2**(-112) to reverse the effect of exponent adjustment by 0xE0 less the
+   * necessary exponent adjustment by 0x70 due to difference in exponent bias.
+   *     The floating-point multiplication hardware would ensure than Inf and
+   * NaN would retain their value on at least partially IEEE754-compliant
+   * implementations.
+   *
+   * Note that the above operations do not handle denormal inputs (where biased
+   * exponent == 0). However, they also do not operate on denormal inputs, and
+   * do not produce denormal results.
    */
-  inline float fp16_ieee_to_fp32_value(uint16_t h) {
-          /*
-           * Extend the half-precision floating-point number to 32 bits and shift to the upper part of the 32-bit word:
-           *      +---+-----+------------+-------------------+
-           *      | S |EEEEE|MM MMMM MMMM|0000 0000 0000 0000|
-           *      +---+-----+------------+-------------------+
-           * Bits  31  26-30    16-25            0-15
-           *
-           * S - sign bit, E - bits of the biased exponent, M - bits of the mantissa, 0 - zero bits.
-           */
-          const uint32_t w = (uint32_t) h << 16;
-          /*
-           * Extract the sign of the input number into the high bit of the 32-bit word:
-           *
-           *      +---+----------------------------------+
-           *      | S |0000000 00000000 00000000 00000000|
-           *      +---+----------------------------------+
-           * Bits  31                 0-31
-           */
-          const uint32_t sign = w & UINT32_C(0x80000000);
-          /*
-           * Extract mantissa and biased exponent of the input number into the high bits of the 32-bit word:
-           *
-           *      +-----+------------+---------------------+
-           *      |EEEEE|MM MMMM MMMM|0 0000 0000 0000 0000|
-           *      +-----+------------+---------------------+
-           * Bits  27-31    17-26            0-16
-           */
-          const uint32_t two_w = w + w;
-
-          /*
-           * Shift mantissa and exponent into bits 23-28 and bits 13-22 so they become mantissa and exponent
-           * of a single-precision floating-point number:
-           *
-           *       S|Exponent |          Mantissa
-           *      +-+---+-----+------------+----------------+
-           *      |0|000|EEEEE|MM MMMM MMMM|0 0000 0000 0000|
-           *      +-+---+-----+------------+----------------+
-           * Bits   | 23-31   |           0-22
-           *
-           * Next, there are some adjustments to the exponent:
-           * - The exponent needs to be corrected by the difference in exponent bias between single-precision and half-precision
-           *   formats (0x7F - 0xF = 0x70)
-           * - Inf and NaN values in the inputs should become Inf and NaN values after conversion to the single-precision number.
-           *   Therefore, if the biased exponent of the half-precision input was 0x1F (max possible value), the biased exponent
-           *   of the single-precision output must be 0xFF (max possible value). We do this correction in two steps:
-           *   - First, we adjust the exponent by (0xFF - 0x1F) = 0xE0 (see exp_offset below) rather than by 0x70 suggested
-           *     by the difference in the exponent bias (see above).
-           *   - Then we multiply the single-precision result of exponent adjustment by 2**(-112) to reverse the effect of
-           *     exponent adjustment by 0xE0 less the necessary exponent adjustment by 0x70 due to difference in exponent bias.
-           *     The floating-point multiplication hardware would ensure than Inf and NaN would retain their value on at least
-           *     partially IEEE754-compliant implementations.
-           *
-           * Note that the above operations do not handle denormal inputs (where biased exponent == 0). However, they also do not
-           * operate on denormal inputs, and do not produce denormal results.
-           */
-          const uint32_t exp_offset = UINT32_C(0xE0) << 23;
-    // const float exp_scale = 0x1.0p-112f;
-    uint32_t scale_bits = (uint32_t) 15 << 23;
-    float exp_scale_val;
-    std::memcpy(&exp_scale_val, &scale_bits, sizeof(exp_scale_val));
-    const float exp_scale = exp_scale_val;
-    const float normalized_value = fp32_from_bits((two_w >> 4) + exp_offset) * exp_scale;
-
-          /*
-           * Convert denormalized half-precision inputs into single-precision results (always normalized).
-           * Zero inputs are also handled here.
-           *
-           * In a denormalized number the biased exponent is zero, and mantissa has on-zero bits.
-           * First, we shift mantissa into bits 0-9 of the 32-bit word.
-           *
-           *                  zeros           |  mantissa
-           *      +---------------------------+------------+
-           *      |0000 0000 0000 0000 0000 00|MM MMMM MMMM|
-           *      +---------------------------+------------+
-           * Bits             10-31                0-9
-           *
-           * Now, remember that denormalized half-precision numbers are represented as:
-           *    FP16 = mantissa * 2**(-24).
-           * The trick is to construct a normalized single-precision number with the same mantissa and thehalf-precision input
-           * and with an exponent which would scale the corresponding mantissa bits to 2**(-24).
-           * A normalized single-precision floating-point number is represented as:
-           *    FP32 = (1 + mantissa * 2**(-23)) * 2**(exponent - 127)
-           * Therefore, when the biased exponent is 126, a unit change in the mantissa of the input denormalized half-precision
-           * number causes a change of the constructud single-precision number by 2**(-24), i.e. the same ammount.
-           *
-           * The last step is to adjust the bias of the constructed single-precision number. When the input half-precision number
-           * is zero, the constructed single-precision number has the value of
-           *    FP32 = 1 * 2**(126 - 127) = 2**(-1) = 0.5
-           * Therefore, we need to subtract 0.5 from the constructed single-precision number to get the numerical equivalent of
-           * the input half-precision number.
-           */
-          const uint32_t magic_mask = UINT32_C(126) << 23;
-          const float magic_bias = 0.5f;
-          const float denormalized_value = fp32_from_bits((two_w >> 17) | magic_mask) - magic_bias;
-
-          /*
-           * - Choose either results of conversion of input as a normalized number, or as a denormalized number, depending on the
-           *   input exponent. The variable two_w contains input exponent in bits 27-31, therefore if its smaller than 2**27, the
-           *   input is either a denormal number, or zero.
-           * - Combine the result of conversion of exponent and mantissa with the sign of the input number.
-           */
-          const uint32_t denormalized_cutoff = UINT32_C(1) << 27;
-          const uint32_t result = sign |
-                  (two_w < denormalized_cutoff ? fp32_to_bits(denormalized_value) : fp32_to_bits(normalized_value));
-          return fp32_from_bits(result);
-  }
+  const uint32_t exp_offset = UINT32_C(0xE0) << 23;
+  // const float exp_scale = 0x1.0p-112f;
+  uint32_t scale_bits = (uint32_t)15 << 23;
+  float exp_scale_val;
+  std::memcpy(&exp_scale_val, &scale_bits, sizeof(exp_scale_val));
+  const float exp_scale = exp_scale_val;
+  const float normalized_value =
+      fp32_from_bits((two_w >> 4) + exp_offset) * exp_scale;
 
   /*
-   * Convert a 32-bit floating-point number in IEEE single-precision format to a 16-bit floating-point number in
-   * IEEE half-precision format, in bit representation.
+   * Convert denormalized half-precision inputs into single-precision results
+   * (always normalized). Zero inputs are also handled here.
    *
-   * @note The implementation relies on IEEE-like (no assumption about rounding mode and no operations on denormals)
-   * floating-point operations and bitcasts between integer and floating-point variables.
+   * In a denormalized number the biased exponent is zero, and mantissa has
+   * on-zero bits. First, we shift mantissa into bits 0-9 of the 32-bit word.
+   *
+   *                  zeros           |  mantissa
+   *      +---------------------------+------------+
+   *      |0000 0000 0000 0000 0000 00|MM MMMM MMMM|
+   *      +---------------------------+------------+
+   * Bits             10-31                0-9
+   *
+   * Now, remember that denormalized half-precision numbers are represented as:
+   *    FP16 = mantissa * 2**(-24).
+   * The trick is to construct a normalized single-precision number with the
+   * same mantissa and thehalf-precision input and with an exponent which would
+   * scale the corresponding mantissa bits to 2**(-24). A normalized
+   * single-precision floating-point number is represented as: FP32 = (1 +
+   * mantissa * 2**(-23)) * 2**(exponent - 127) Therefore, when the biased
+   * exponent is 126, a unit change in the mantissa of the input denormalized
+   * half-precision number causes a change of the constructud single-precision
+   * number by 2**(-24), i.e. the same ammount.
+   *
+   * The last step is to adjust the bias of the constructed single-precision
+   * number. When the input half-precision number is zero, the constructed
+   * single-precision number has the value of FP32 = 1 * 2**(126 - 127) =
+   * 2**(-1) = 0.5 Therefore, we need to subtract 0.5 from the constructed
+   * single-precision number to get the numerical equivalent of the input
+   * half-precision number.
    */
-  inline uint16_t fp16_ieee_from_fp32_value(float f) {
-    // const float scale_to_inf = 0x1.0p+112f;
-    // const float scale_to_zero = 0x1.0p-110f;
-    uint32_t scale_to_inf_bits = (uint32_t) 239 << 23;
-    uint32_t scale_to_zero_bits = (uint32_t) 17 << 23;
-    float scale_to_inf_val, scale_to_zero_val;
-    std::memcpy(&scale_to_inf_val, &scale_to_inf_bits, sizeof(scale_to_inf_val));
-    std::memcpy(&scale_to_zero_val, &scale_to_zero_bits, sizeof(scale_to_zero_val));
-    const float scale_to_inf = scale_to_inf_val;
-    const float scale_to_zero = scale_to_zero_val;
+  const uint32_t magic_mask = UINT32_C(126) << 23;
+  const float magic_bias = 0.5f;
+  const float denormalized_value =
+      fp32_from_bits((two_w >> 17) | magic_mask) - magic_bias;
 
-          float base = (fabsf(f) * scale_to_inf) * scale_to_zero;
+  /*
+   * - Choose either results of conversion of input as a normalized number, or
+   * as a denormalized number, depending on the input exponent. The variable
+   * two_w contains input exponent in bits 27-31, therefore if its smaller than
+   * 2**27, the input is either a denormal number, or zero.
+   * - Combine the result of conversion of exponent and mantissa with the sign
+   * of the input number.
+   */
+  const uint32_t denormalized_cutoff = UINT32_C(1) << 27;
+  const uint32_t result = sign |
+      (two_w < denormalized_cutoff ? fp32_to_bits(denormalized_value)
+                                   : fp32_to_bits(normalized_value));
+  return fp32_from_bits(result);
+}
 
-          const uint32_t w = fp32_to_bits(f);
-          const uint32_t shl1_w = w + w;
-          const uint32_t sign = w & UINT32_C(0x80000000);
-          uint32_t bias = shl1_w & UINT32_C(0xFF000000);
-          if (bias < UINT32_C(0x71000000)) {
-                  bias = UINT32_C(0x71000000);
-          }
+/*
+ * Convert a 32-bit floating-point number in IEEE single-precision format to a
+ * 16-bit floating-point number in IEEE half-precision format, in bit
+ * representation.
+ *
+ * @note The implementation relies on IEEE-like (no assumption about rounding
+ * mode and no operations on denormals) floating-point operations and bitcasts
+ * between integer and floating-point variables.
+ */
+inline uint16_t fp16_ieee_from_fp32_value(float f) {
+  // const float scale_to_inf = 0x1.0p+112f;
+  // const float scale_to_zero = 0x1.0p-110f;
+  uint32_t scale_to_inf_bits = (uint32_t)239 << 23;
+  uint32_t scale_to_zero_bits = (uint32_t)17 << 23;
+  float scale_to_inf_val, scale_to_zero_val;
+  std::memcpy(&scale_to_inf_val, &scale_to_inf_bits, sizeof(scale_to_inf_val));
+  std::memcpy(
+      &scale_to_zero_val, &scale_to_zero_bits, sizeof(scale_to_zero_val));
+  const float scale_to_inf = scale_to_inf_val;
+  const float scale_to_zero = scale_to_zero_val;
 
-          base = fp32_from_bits((bias >> 1) + UINT32_C(0x07800000)) + base;
-          const uint32_t bits = fp32_to_bits(base);
-          const uint32_t exp_bits = (bits >> 13) & UINT32_C(0x00007C00);
-          const uint32_t mantissa_bits = bits & UINT32_C(0x00000FFF);
-          const uint32_t nonsign = exp_bits + mantissa_bits;
-          return (sign >> 16) | (shl1_w > UINT32_C(0xFF000000) ? UINT16_C(0x7E00) : nonsign);
+  float base = (fabsf(f) * scale_to_inf) * scale_to_zero;
+
+  const uint32_t w = fp32_to_bits(f);
+  const uint32_t shl1_w = w + w;
+  const uint32_t sign = w & UINT32_C(0x80000000);
+  uint32_t bias = shl1_w & UINT32_C(0xFF000000);
+  if (bias < UINT32_C(0x71000000)) {
+    bias = UINT32_C(0x71000000);
   }
+
+  base = fp32_from_bits((bias >> 1) + UINT32_C(0x07800000)) + base;
+  const uint32_t bits = fp32_to_bits(base);
+  const uint32_t exp_bits = (bits >> 13) & UINT32_C(0x00007C00);
+  const uint32_t mantissa_bits = bits & UINT32_C(0x00000FFF);
+  const uint32_t nonsign = exp_bits + mantissa_bits;
+  return (sign >> 16) |
+      (shl1_w > UINT32_C(0xFF000000) ? UINT16_C(0x7E00) : nonsign);
+}
 
 } // namespace detail
 
@@ -422,11 +451,10 @@ struct Converter<
 // C4804: unsafe use of type 'bool' in operation
 // It can be addressed by disabling the following warning.
 #ifdef _MSC_VER
-#pragma warning( push )
-#pragma warning( disable : 4146 )
-#pragma warning( disable : 4804 )
+#pragma warning(push)
+#pragma warning(disable : 4146)
+#pragma warning(disable : 4804)
 #endif
-
 
 // bool can be converted to any type.
 // Without specializing on bool, in pytorch_linux_trusty_py2_7_9_build:
@@ -440,8 +468,10 @@ typename std::enable_if<std::is_same<From, bool>::value, bool>::type overflows(
 
 // skip isnan and isinf check for integral types
 template <typename To, typename From>
-typename std::enable_if<std::is_integral<From>::value && !std::is_same<From, bool>::value, bool>::type overflows(
-    From f) {
+typename std::enable_if<
+    std::is_integral<From>::value && !std::is_same<From, bool>::value,
+    bool>::type
+overflows(From f) {
   using limit = std::numeric_limits<typename scalar_value_type<To>::type>;
   if (!limit::is_signed && std::numeric_limits<From>::is_signed) {
     // allow for negative numbers to wrap using two's complement arithmetic.
@@ -468,7 +498,7 @@ overflows(From f) {
 }
 
 #ifdef _MSC_VER
-#pragma warning( pop )
+#pragma warning(pop)
 #endif
 
 template <typename To, typename From>

--- a/c10/util/IdWrapper.h
+++ b/c10/util/IdWrapper.h
@@ -66,12 +66,12 @@ class IdWrapper {
 
 } // namespace c10
 
-#define C10_DEFINE_HASH_FOR_IDWRAPPER(ClassName)\
-  namespace std {                               \
-  template <>                                   \
-  struct hash<ClassName> {                      \
-    size_t operator()(ClassName x) const {      \
-      return hash_value(x);                     \
-    }                                           \
-  };                                            \
+#define C10_DEFINE_HASH_FOR_IDWRAPPER(ClassName) \
+  namespace std {                                \
+  template <>                                    \
+  struct hash<ClassName> {                       \
+    size_t operator()(ClassName x) const {       \
+      return hash_value(x);                      \
+    }                                            \
+  };                                             \
   }

--- a/c10/util/LeftRight.h
+++ b/c10/util/LeftRight.h
@@ -1,177 +1,188 @@
+#include <c10/macros/Macros.h>
+#include <array>
 #include <atomic>
 #include <functional>
 #include <mutex>
 #include <thread>
-#include <array>
-#include <c10/macros/Macros.h>
 
 namespace c10 {
 
 namespace detail {
 
 struct IncrementRAII final {
-public:
-    explicit IncrementRAII(std::atomic<int32_t> *counter): _counter(counter) {
-        ++(*_counter);
-    }
+ public:
+  explicit IncrementRAII(std::atomic<int32_t>* counter) : _counter(counter) {
+    ++(*_counter);
+  }
 
-    ~IncrementRAII() {
-        --(*_counter);
-    }
-private:
-    std::atomic<int32_t> *_counter;
+  ~IncrementRAII() {
+    --(*_counter);
+  }
 
-    C10_DISABLE_COPY_AND_ASSIGN(IncrementRAII);
+ private:
+  std::atomic<int32_t>* _counter;
+
+  C10_DISABLE_COPY_AND_ASSIGN(IncrementRAII);
 };
 
-}
+} // namespace detail
 
 // LeftRight wait-free readers synchronization primitive
 // https://hal.archives-ouvertes.fr/hal-01207881/document
 template <class T>
 class LeftRight final {
-public:
-    template<class... Args>
-    explicit LeftRight(const Args& ...args)
-    : _counters{{{0}, {0}}}
-    , _foregroundCounterIndex(0)
-    , _foregroundDataIndex(0)
-    , _inDestruction(false)
-    , _data{{T{args...}, T{args...}}}
-    , _writeMutex()
-    {}
+ public:
+  template <class... Args>
+  explicit LeftRight(const Args&... args)
+      : _counters{{{0}, {0}}},
+        _foregroundCounterIndex(0),
+        _foregroundDataIndex(0),
+        _inDestruction(false),
+        _data{{T{args...}, T{args...}}},
+        _writeMutex() {}
 
-    // Copying and moving would not be threadsafe.
-    // Needs more thought and careful design to make that work.
-    LeftRight(const LeftRight&) = delete;
-    LeftRight(LeftRight&&) noexcept = delete;
-    LeftRight& operator=(const LeftRight&) = delete;
-    LeftRight& operator=(LeftRight&&) noexcept= delete;
+  // Copying and moving would not be threadsafe.
+  // Needs more thought and careful design to make that work.
+  LeftRight(const LeftRight&) = delete;
+  LeftRight(LeftRight&&) noexcept = delete;
+  LeftRight& operator=(const LeftRight&) = delete;
+  LeftRight& operator=(LeftRight&&) noexcept = delete;
 
-    ~LeftRight() {
-        // from now on, no new readers/writers will be accepted (see asserts in read()/write())
-        _inDestruction = true;
+  ~LeftRight() {
+    // from now on, no new readers/writers will be accepted (see asserts in
+    // read()/write())
+    _inDestruction = true;
 
-        // wait until any potentially running writers are finished
-        {
-            std::unique_lock<std::mutex> lock(_writeMutex);
-        }
+    // wait until any potentially running writers are finished
+    { std::unique_lock<std::mutex> lock(_writeMutex); }
 
-        // wait until any potentially running readers are finished
-        while (_counters[0].load() != 0 || _counters[1].load() != 0) {
-            std::this_thread::yield();
-        }
+    // wait until any potentially running readers are finished
+    while (_counters[0].load() != 0 || _counters[1].load() != 0) {
+      std::this_thread::yield();
+    }
+  }
+
+  template <typename F>
+  auto read(F&& readFunc) const -> typename std::result_of<F(const T&)>::type {
+    detail::IncrementRAII _increment_counter(
+        &_counters[_foregroundCounterIndex.load()]);
+
+    if (C10_UNLIKELY(_inDestruction.load())) {
+      throw std::logic_error(
+          "Issued LeftRight::read() after the destructor started running");
     }
 
-    template <typename F>
-    auto read(F&& readFunc) const -> typename std::result_of<F(const T&)>::type {
-        detail::IncrementRAII _increment_counter(&_counters[_foregroundCounterIndex.load()]);
+    return readFunc(_data[_foregroundDataIndex.load()]);
+  }
 
-        if(C10_UNLIKELY(_inDestruction.load())) {
-            throw std::logic_error("Issued LeftRight::read() after the destructor started running");
-        }
+  // Throwing an exception in writeFunc is ok but causes the state to be either
+  // the old or the new state, depending on if the first or the second call to
+  // writeFunc threw.
+  template <typename F>
+  auto write(F&& writeFunc) -> typename std::result_of<F(T&)>::type {
+    std::unique_lock<std::mutex> lock(_writeMutex);
 
-        return readFunc(_data[_foregroundDataIndex.load()]);
+    if (C10_UNLIKELY(_inDestruction.load())) {
+      throw std::logic_error(
+          "Issued LeftRight::write() after the destructor started running");
     }
 
-    // Throwing an exception in writeFunc is ok but causes the state to be either the old or the new state,
-    // depending on if the first or the second call to writeFunc threw.
-    template <typename F>
-    auto write(F&& writeFunc) -> typename std::result_of<F(T&)>::type {
-        std::unique_lock<std::mutex> lock(_writeMutex);
+    return _write(writeFunc);
+  }
 
-        if(C10_UNLIKELY(_inDestruction.load())) {
-            throw std::logic_error("Issued LeftRight::write() after the destructor started running");
-        }
+ private:
+  template <class F>
+  auto _write(const F& writeFunc) -> typename std::result_of<F(T&)>::type {
+    /*
+     * Assume, A is in background and B in foreground. In simplified terms, we
+     * want to do the following:
+     * 1. Write to A (old background)
+     * 2. Switch A/B
+     * 3. Write to B (new background)
+     *
+     * More detailed algorithm (explanations on why this is important are below
+     * in code):
+     * 1. Write to A
+     * 2. Switch A/B data pointers
+     * 3. Wait until A counter is zero
+     * 4. Switch A/B counters
+     * 5. Wait until B counter is zero
+     * 6. Write to B
+     */
 
-        return _write(writeFunc);
+    auto localDataIndex = _foregroundDataIndex.load();
+
+    // 1. Write to A
+    _callWriteFuncOnBackgroundInstance(writeFunc, localDataIndex);
+
+    // 2. Switch A/B data pointers
+    localDataIndex = localDataIndex ^ 1;
+    _foregroundDataIndex = localDataIndex;
+
+    /*
+     * 3. Wait until A counter is zero
+     *
+     * In the previous write run, A was foreground and B was background.
+     * There was a time after switching _foregroundDataIndex (B to foreground)
+     * and before switching _foregroundCounterIndex, in which new readers could
+     * have read B but incremented A's counter.
+     *
+     * In this current run, we just switched _foregroundDataIndex (A back to
+     * foreground), but before writing to the new background B, we have to make
+     * sure A's counter was zero briefly, so all these old readers are gone.
+     */
+    auto localCounterIndex = _foregroundCounterIndex.load();
+    _waitForBackgroundCounterToBeZero(localCounterIndex);
+
+    /*
+     * 4. Switch A/B counters
+     *
+     * Now that we know all readers on B are really gone, we can switch the
+     * counters and have new readers increment A's counter again, which is the
+     * correct counter since they're reading A.
+     */
+    localCounterIndex = localCounterIndex ^ 1;
+    _foregroundCounterIndex = localCounterIndex;
+
+    /*
+     * 5. Wait until B counter is zero
+     *
+     * This waits for all the readers on B that came in while both data and
+     * counter for B was in foreground, i.e. normal readers that happened
+     * outside of that brief gap between switching data and counter.
+     */
+    _waitForBackgroundCounterToBeZero(localCounterIndex);
+
+    // 6. Write to B
+    return _callWriteFuncOnBackgroundInstance(writeFunc, localDataIndex);
+  }
+
+  template <class F>
+  auto _callWriteFuncOnBackgroundInstance(
+      const F& writeFunc,
+      uint8_t localDataIndex) -> typename std::result_of<F(T&)>::type {
+    try {
+      return writeFunc(_data[localDataIndex ^ 1]);
+    } catch (...) {
+      // recover invariant by copying from the foreground instance
+      _data[localDataIndex ^ 1] = _data[localDataIndex];
+      // rethrow
+      throw;
     }
+  }
 
-private:
-    template <class F>
-    auto _write(const F& writeFunc) -> typename std::result_of<F(T&)>::type {
-        /*
-         * Assume, A is in background and B in foreground. In simplified terms, we want to do the following:
-         * 1. Write to A (old background)
-         * 2. Switch A/B
-         * 3. Write to B (new background)
-         *
-         * More detailed algorithm (explanations on why this is important are below in code):
-         * 1. Write to A
-         * 2. Switch A/B data pointers
-         * 3. Wait until A counter is zero
-         * 4. Switch A/B counters
-         * 5. Wait until B counter is zero
-         * 6. Write to B
-         */
-
-        auto localDataIndex = _foregroundDataIndex.load();
-
-        // 1. Write to A
-        _callWriteFuncOnBackgroundInstance(writeFunc, localDataIndex);
-
-        // 2. Switch A/B data pointers
-        localDataIndex = localDataIndex ^ 1;
-        _foregroundDataIndex = localDataIndex;
-
-        /*
-         * 3. Wait until A counter is zero
-         *
-         * In the previous write run, A was foreground and B was background.
-         * There was a time after switching _foregroundDataIndex (B to foreground) and before switching _foregroundCounterIndex,
-         * in which new readers could have read B but incremented A's counter.
-         *
-         * In this current run, we just switched _foregroundDataIndex (A back to foreground), but before writing to
-         * the new background B, we have to make sure A's counter was zero briefly, so all these old readers are gone.
-         */
-        auto localCounterIndex = _foregroundCounterIndex.load();
-        _waitForBackgroundCounterToBeZero(localCounterIndex);
-
-        /*
-         * 4. Switch A/B counters
-         *
-         * Now that we know all readers on B are really gone, we can switch the counters and have new readers
-         * increment A's counter again, which is the correct counter since they're reading A.
-         */
-        localCounterIndex = localCounterIndex ^ 1;
-        _foregroundCounterIndex = localCounterIndex;
-
-        /*
-         * 5. Wait until B counter is zero
-         *
-         * This waits for all the readers on B that came in while both data and counter for B was in foreground,
-         * i.e. normal readers that happened outside of that brief gap between switching data and counter.
-         */
-        _waitForBackgroundCounterToBeZero(localCounterIndex);
-
-        // 6. Write to B
-        return _callWriteFuncOnBackgroundInstance(writeFunc, localDataIndex);
+  void _waitForBackgroundCounterToBeZero(uint8_t counterIndex) {
+    while (_counters[counterIndex ^ 1].load() != 0) {
+      std::this_thread::yield();
     }
+  }
 
-    template<class F>
-    auto _callWriteFuncOnBackgroundInstance(const F& writeFunc, uint8_t localDataIndex) -> typename std::result_of<F(T&)>::type {
-        try {
-            return writeFunc(_data[localDataIndex ^ 1]);
-        } catch (...) {
-            // recover invariant by copying from the foreground instance
-            _data[localDataIndex ^ 1] = _data[localDataIndex];
-            // rethrow
-            throw;
-        }
-    }
-
-    void _waitForBackgroundCounterToBeZero(uint8_t counterIndex) {
-        while (_counters[counterIndex ^ 1].load() != 0) {
-            std::this_thread::yield();
-        }
-    }
-
-    mutable std::array<std::atomic<int32_t>, 2> _counters;
-    std::atomic<uint8_t> _foregroundCounterIndex;
-    std::atomic<uint8_t> _foregroundDataIndex;
-    std::atomic<bool> _inDestruction;
-    std::array<T, 2> _data;
-    std::mutex _writeMutex;
+  mutable std::array<std::atomic<int32_t>, 2> _counters;
+  std::atomic<uint8_t> _foregroundCounterIndex;
+  std::atomic<uint8_t> _foregroundDataIndex;
+  std::atomic<bool> _inDestruction;
+  std::array<T, 2> _data;
+  std::mutex _writeMutex;
 };
 
-}
+} // namespace c10

--- a/c10/util/Logging.h
+++ b/c10/util/Logging.h
@@ -270,7 +270,7 @@ BINARY_COMP_HELPER(LessEquals, <=)
  *   // Logs caller info with an arbitrary text event, if there is a usage.
  *   C10_LOG_API_USAGE_ONCE("my_api");
  */
-#define C10_LOG_API_USAGE_ONCE(...)             \
+#define C10_LOG_API_USAGE_ONCE(...)                        \
   C10_UNUSED static bool C10_ANONYMOUS_VARIABLE(logFlag) = \
       ::c10::detail::LogAPIUsageFakeReturn(__VA_ARGS__);
 
@@ -281,7 +281,7 @@ C10_API void LogAPIUsage(const std::string& context);
 namespace detail {
 // Return value is needed to do the static variable initialization trick
 C10_API bool LogAPIUsageFakeReturn(const std::string& context);
-}
+} // namespace detail
 
 } // namespace c10
 

--- a/c10/util/Metaprogramming.h
+++ b/c10/util/Metaprogramming.h
@@ -1,25 +1,30 @@
 #pragma once
 
-#include <type_traits>
+#include <c10/util/Array.h>
+#include <c10/util/TypeList.h>
 #include <array>
 #include <functional>
-#include <c10/util/TypeList.h>
-#include <c10/util/Array.h>
+#include <type_traits>
 
-namespace c10 { namespace guts {
+namespace c10 {
+namespace guts {
 
 /**
  * Access information about result type or arguments from a function type.
  * Example:
  * using A = function_traits<int (float, double)>::return_type // A == int
- * using A = function_traits<int (float, double)>::parameter_types::tuple_type // A == tuple<float, double>
+ * using A = function_traits<int (float, double)>::parameter_types::tuple_type
+ * // A == tuple<float, double>
  */
-template<class Func> struct function_traits {
-  static_assert(!std::is_same<Func, Func>::value, "In function_traits<Func>, Func must be a plain function type.");
+template <class Func>
+struct function_traits {
+  static_assert(
+      !std::is_same<Func, Func>::value,
+      "In function_traits<Func>, Func must be a plain function type.");
 };
-template<class Result, class... Args>
-struct function_traits<Result (Args...)> {
-  using func_type = Result (Args...);
+template <class Result, class... Args>
+struct function_traits<Result(Args...)> {
+  using func_type = Result(Args...);
   using return_type = Result;
   using parameter_types = typelist::typelist<Args...>;
   static constexpr auto number_of_parameters = sizeof...(Args);
@@ -33,7 +38,8 @@ struct function_traits<Result (Args...)> {
 
 template <typename Functor>
 struct infer_function_traits {
-  using type = function_traits<c10::guts::detail::strip_class_t<decltype(&Functor::operator())>>;
+  using type = function_traits<
+      c10::guts::detail::strip_class_t<decltype(&Functor::operator())>>;
 };
 
 template <typename Result, typename... Args>
@@ -42,7 +48,7 @@ struct infer_function_traits<Result (*)(Args...)> {
 };
 
 template <typename Result, typename... Args>
-struct infer_function_traits<Result (Args...)> {
+struct infer_function_traits<Result(Args...)> {
   using type = function_traits<Result(Args...)>;
 };
 
@@ -56,58 +62,106 @@ using infer_function_traits_t = typename infer_function_traits<T>::type;
  * Example:
  * std::string arg1 = "Hello";
  * std::string arg2 = "World";
- * std::string&& result = extract_arg_by_filtered_index<is_string, 1>(0, arg1, 2.0, std::move(arg2));
+ * std::string&& result = extract_arg_by_filtered_index<is_string, 1>(0,
+ * arg1, 2.0, std::move(arg2));
  *
- * Warning: Taking the result by rvalue reference can cause segfaults because ownership will not be passed on
- *          from the original reference. The original reference dies after the expression and the resulting
+ * Warning: Taking the result by rvalue reference can cause segfaults because
+ * ownership will not be passed on from the original reference. The original
+ * reference dies after the expression and the resulting
  */
 namespace detail {
-template<template <class> class Condition, size_t index, class Enable, class... Args> struct extract_arg_by_filtered_index_;
-template<template <class> class Condition, size_t index, class Head, class... Tail>
-struct extract_arg_by_filtered_index_<Condition, index, guts::enable_if_t<!Condition<Head>::value>, Head, Tail...> {
-  static auto call(Head&& /*head*/, Tail&&... tail)
-  -> decltype(extract_arg_by_filtered_index_<Condition, index, void, Tail...>::call(std::forward<Tail>(tail)...)) {
-    return extract_arg_by_filtered_index_<Condition, index, void, Tail...>::call(std::forward<Tail>(tail)...);
+template <
+    template <class>
+    class Condition,
+    size_t index,
+    class Enable,
+    class... Args>
+struct extract_arg_by_filtered_index_;
+template <
+    template <class>
+    class Condition,
+    size_t index,
+    class Head,
+    class... Tail>
+struct extract_arg_by_filtered_index_<
+    Condition,
+    index,
+    guts::enable_if_t<!Condition<Head>::value>,
+    Head,
+    Tail...> {
+  static auto call(Head&& /*head*/, Tail&&... tail) -> decltype(
+      extract_arg_by_filtered_index_<Condition, index, void, Tail...>::call(
+          std::forward<Tail>(tail)...)) {
+    return extract_arg_by_filtered_index_<Condition, index, void, Tail...>::
+        call(std::forward<Tail>(tail)...);
   }
 };
-template<template <class> class Condition, size_t index, class Head, class... Tail>
-struct extract_arg_by_filtered_index_<Condition, index, guts::enable_if_t<Condition<Head>::value && index != 0>, Head, Tail...> {
-  static auto call(Head&& /*head*/, Tail&&... tail)
-  -> decltype(extract_arg_by_filtered_index_<Condition, index-1, void, Tail...>::call(std::forward<Tail>(tail)...)) {
-    return extract_arg_by_filtered_index_<Condition, index-1, void, Tail...>::call(std::forward<Tail>(tail)...);
+template <
+    template <class>
+    class Condition,
+    size_t index,
+    class Head,
+    class... Tail>
+struct extract_arg_by_filtered_index_<
+    Condition,
+    index,
+    guts::enable_if_t<Condition<Head>::value && index != 0>,
+    Head,
+    Tail...> {
+  static auto call(Head&& /*head*/, Tail&&... tail) -> decltype(
+      extract_arg_by_filtered_index_<Condition, index - 1, void, Tail...>::call(
+          std::forward<Tail>(tail)...)) {
+    return extract_arg_by_filtered_index_<Condition, index - 1, void, Tail...>::
+        call(std::forward<Tail>(tail)...);
   }
 };
-template<template <class> class Condition, size_t index>
+template <template <class> class Condition, size_t index>
 struct extract_arg_by_filtered_index_<Condition, index, void> {
   static void call() {
-    static_assert(index != index, "extract_arg_by_filtered_index out of range.");
+    static_assert(
+        index != index, "extract_arg_by_filtered_index out of range.");
   }
 };
-template<template <class> class Condition, size_t index, class Head, class... Tail>
-struct extract_arg_by_filtered_index_<Condition, index, guts::enable_if_t<Condition<Head>::value && index == 0>, Head, Tail...> {
+template <
+    template <class>
+    class Condition,
+    size_t index,
+    class Head,
+    class... Tail>
+struct extract_arg_by_filtered_index_<
+    Condition,
+    index,
+    guts::enable_if_t<Condition<Head>::value && index == 0>,
+    Head,
+    Tail...> {
   static auto call(Head&& head, Tail&&... /*tail*/)
-  -> decltype(std::forward<Head>(head)) {
+      -> decltype(std::forward<Head>(head)) {
     return std::forward<Head>(head);
   }
 };
+} // namespace detail
+template <template <class> class Condition, size_t index, class... Args>
+auto extract_arg_by_filtered_index(Args&&... args) -> decltype(
+    detail::extract_arg_by_filtered_index_<Condition, index, void, Args...>::
+        call(std::forward<Args>(args)...)) {
+  static_assert(
+      is_type_condition<Condition>::value,
+      "In extract_arg_by_filtered_index, the Condition argument must be a condition type trait, i.e. have a static constexpr bool ::value member.");
+  return detail::
+      extract_arg_by_filtered_index_<Condition, index, void, Args...>::call(
+          std::forward<Args>(args)...);
 }
-template<template <class> class Condition, size_t index, class... Args>
-auto extract_arg_by_filtered_index(Args&&... args)
--> decltype(detail::extract_arg_by_filtered_index_<Condition, index, void, Args...>::call(std::forward<Args>(args)...)) {
-  static_assert(is_type_condition<Condition>::value, "In extract_arg_by_filtered_index, the Condition argument must be a condition type trait, i.e. have a static constexpr bool ::value member.");
-  return detail::extract_arg_by_filtered_index_<Condition, index, void, Args...>::call(std::forward<Args>(args)...);
-}
-
-
 
 /**
  * Use filter_map to map a subset of the arguments to values.
  * The subset is defined by type traits, and will be evaluated at compile time.
- * At runtime, it will just loop over the pre-filtered arguments to create an std::array.
+ * At runtime, it will just loop over the pre-filtered arguments to create an
+ * std::array.
  *
  * Example:
  *  // in C++14
- *  std::array<double, 2> result = filter_map<double, std::is_integral>([] (auto a) {return (double)a;}, 3, "bla", 4);
+ *  std::array<double, 2> result = filter_map<double, std::is_integral>([] (auto
+ * a) {return (double)a;}, 3, "bla", 4);
  *  // result == {3.0, 4.0}
  *
  *  // same example in C++11
@@ -116,31 +170,74 @@ auto extract_arg_by_filtered_index(Args&&... args)
  *      return (double)a;
  *    }
  *  };
- *  std::array<double, 2> result = filter_map<double, std::is_integral>(my_map(), 3, "bla", 4);
+ *  std::array<double, 2> result = filter_map<double,
+ * std::is_integral>(my_map(), 3, "bla", 4);
  *  // result == {3.0, 4.0}
  */
 namespace detail {
 
-template<class ResultType, size_t num_results> struct filter_map_ {
-   template<template <class> class Condition, class Mapper, class... Args, size_t... I>
-   static guts::array<ResultType, num_results> call(const Mapper& mapper, guts::index_sequence<I...>, Args&&... args) {
-     return guts::array<ResultType, num_results> { mapper(extract_arg_by_filtered_index<Condition, I>(std::forward<Args>(args)...))... };
-   }
-};
-template<class ResultType> struct filter_map_<ResultType, 0> {
-  template<template <class> class Condition, class Mapper, class... Args, size_t... I>
-  static guts::array<ResultType, 0> call(const Mapper& /*mapper*/, guts::index_sequence<I...>, Args&&... /*args*/) {
-    return guts::array<ResultType, 0> { };
+template <class ResultType, size_t num_results>
+struct filter_map_ {
+  template <
+      template <class>
+      class Condition,
+      class Mapper,
+      class... Args,
+      size_t... I>
+  static guts::array<ResultType, num_results> call(
+      const Mapper& mapper,
+      guts::index_sequence<I...>,
+      Args&&... args) {
+    return guts::array<ResultType, num_results>{
+        mapper(extract_arg_by_filtered_index<Condition, I>(
+            std::forward<Args>(args)...))...};
   }
 };
+template <class ResultType>
+struct filter_map_<ResultType, 0> {
+  template <
+      template <class>
+      class Condition,
+      class Mapper,
+      class... Args,
+      size_t... I>
+  static guts::array<ResultType, 0> call(
+      const Mapper& /*mapper*/,
+      guts::index_sequence<I...>,
+      Args&&... /*args*/) {
+    return guts::array<ResultType, 0>{};
+  }
+};
+} // namespace detail
+
+template <
+    class ResultType,
+    template <class>
+    class Condition,
+    class Mapper,
+    class... Args>
+auto filter_map(const Mapper& mapper, Args&&... args) -> decltype(
+    detail::filter_map_<
+        ResultType,
+        typelist::count_if<Condition, typelist::typelist<Args...>>::value>::
+        template call<Condition, Mapper, Args...>(
+            mapper,
+            guts::make_index_sequence<typelist::count_if<
+                Condition,
+                typelist::typelist<Args...>>::value>(),
+            std::forward<Args>(args)...)) {
+  static_assert(
+      is_type_condition<Condition>::value,
+      "In filter_map<Result, Condition>, the Condition argument must be a condition type trait, i.e. have a static constexpr bool ::value member.");
+
+  static constexpr size_t num_results =
+      typelist::count_if<Condition, typelist::typelist<Args...>>::value;
+  return detail::filter_map_<ResultType, num_results>::
+      template call<Condition, Mapper, Args...>(
+          mapper,
+          guts::make_index_sequence<num_results>(),
+          std::forward<Args>(args)...);
 }
 
-template<class ResultType, template <class> class Condition, class Mapper, class... Args> auto filter_map(const Mapper& mapper, Args&&... args)
--> decltype(detail::filter_map_<ResultType, typelist::count_if<Condition, typelist::typelist<Args...>>::value>::template call<Condition, Mapper, Args...>(mapper, guts::make_index_sequence<typelist::count_if<Condition, typelist::typelist<Args...>>::value>(), std::forward<Args>(args)...)) {
-  static_assert(is_type_condition<Condition>::value, "In filter_map<Result, Condition>, the Condition argument must be a condition type trait, i.e. have a static constexpr bool ::value member.");
-
-  static constexpr size_t num_results = typelist::count_if<Condition, typelist::typelist<Args...>>::value;
-  return detail::filter_map_<ResultType, num_results>::template call<Condition, Mapper, Args...>(mapper, guts::make_index_sequence<num_results>(), std::forward<Args>(args)...);
-}
-
-}}
+} // namespace guts
+} // namespace c10

--- a/c10/util/Optional.h
+++ b/c10/util/Optional.h
@@ -13,11 +13,12 @@
 // - Move to `c10` namespace.
 // - Remove macro use in line 478 because the nvcc device compiler cannot handle
 // it.
-// - revise constructor logic so that it is consistent with c++ 17 standard documented
-// here in (8): https://en.cppreference.com/w/cpp/utility/optional/optional, and
-// could be able to support initialization of optionals from convertible type U, also
-// remove two old constructors optional(const T&) and optional(T&&) as it could be
-// handled by the template<U=T> case with default template argument.
+// - revise constructor logic so that it is consistent with c++ 17 standard
+// documented here in (8):
+// https://en.cppreference.com/w/cpp/utility/optional/optional, and could be
+// able to support initialization of optionals from convertible type U, also
+// remove two old constructors optional(const T&) and optional(T&&) as it could
+// be handled by the template<U=T> case with default template argument.
 
 #ifndef C10_UTIL_OPTIONAL_H_
 #define C10_UTIL_OPTIONAL_H_
@@ -418,27 +419,23 @@ class optional : private OptionalBase<T> {
   // of optionals from convertible type U
   //
   // 8 - implicit move construct from value
-  template<
+  template <
       typename U = T,
       TR2_OPTIONAL_REQUIRES(
-          std::is_constructible<T, U&&>::value
-          && !std::is_same<typename std::decay<U>::type, in_place_t>::value
-          && !std::is_same<typename std::decay<U>::type, optional<T>>::value
-          && std::is_convertible<U&&, T>
-      )
-    >
+          std::is_constructible<T, U&&>::value &&
+          !std::is_same<typename std::decay<U>::type, in_place_t>::value &&
+          !std::is_same<typename std::decay<U>::type, optional<T>>::value &&
+          std::is_convertible<U&&, T>)>
   constexpr optional(U&& u) : OptionalBase<T>(std::forward<U>(u)) {}
 
   // 8 - explicit move construct from value
-  template<
+  template <
       typename U = T,
       TR2_OPTIONAL_REQUIRES(
-          std::is_constructible<T, U&&>::value
-          && !std::is_same<typename std::decay<U>::type, in_place_t>::value
-          && !std::is_same<typename std::decay<U>::type, optional<T>>::value
-          && !std::is_convertible<U&&, T>
-      )
-    >
+          std::is_constructible<T, U&&>::value &&
+          !std::is_same<typename std::decay<U>::type, in_place_t>::value &&
+          !std::is_same<typename std::decay<U>::type, optional<T>>::value &&
+          !std::is_convertible<U&&, T>)>
   explicit constexpr optional(U&& u) : OptionalBase<T>(std::forward<U>(u)) {}
 
   template <class... Args>
@@ -486,12 +483,13 @@ class optional : private OptionalBase<T> {
     return *this;
   }
 
-  template<class U = T>
+  template <class U = T>
   auto operator=(U&& v) -> typename std::enable_if<
-          std::is_constructible<T, U>::value
-          && !std::is_same<typename std::decay<U>::type, optional<T>>::value
-          && (std::is_scalar<T>::value || std::is_same<typename std::decay<U>::type, T>::value)
-          && std::is_assignable<T&, U>::value,
+      std::is_constructible<T, U>::value &&
+          !std::is_same<typename std::decay<U>::type, optional<T>>::value &&
+          (std::is_scalar<T>::value ||
+           std::is_same<typename std::decay<U>::type, T>::value) &&
+          std::is_assignable<T&, U>::value,
       optional&>::type {
     if (initialized()) {
       contained_val() = std::forward<U>(v);
@@ -655,18 +653,21 @@ class optional : private OptionalBase<T> {
   }
 };
 
-
 // XXX: please refrain from using optional<T&>, since it is being against with
 // the optional standard in c++ 17, see the debate and the details here:
 // http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2012/n3406#rationale.refs
-// if you need it, consider using optional<std::reference_wrapper<T>> or * pointer
+// if you need it, consider using optional<std::reference_wrapper<T>> or *
+// pointer
 //
-// we leave the implementation here in case we want to reconsider using it in the
-// future if it becomes a definitely necessary case.
+// we leave the implementation here in case we want to reconsider using it in
+// the future if it becomes a definitely necessary case.
 template <class T>
 class optional<T&> {
-  // add this assert to prevent user from using optional reference as indicated above
-  static_assert(sizeof(T) == 0, "optional references is ill-formed, \
+  // add this assert to prevent user from using optional reference as indicated
+  // above
+  static_assert(
+      sizeof(T) == 0,
+      "optional references is ill-formed, \
     consider use optional of a std::reference_wrapper of type T to \
     hold a reference if you really need to");
 
@@ -680,10 +681,10 @@ class optional<T&> {
 
   constexpr optional(nullopt_t) noexcept : ref(nullptr) {}
 
-  template<typename U = T>
+  template <typename U = T>
   constexpr optional(U& u) noexcept : ref(detail_::static_addressof(u)) {}
 
-  template<typename U = T>
+  template <typename U = T>
   optional(U&&) = delete;
 
   constexpr optional(const optional& rhs) noexcept : ref(rhs.ref) {}

--- a/c10/util/Registry.h
+++ b/c10/util/Registry.h
@@ -71,11 +71,11 @@ class Registry {
     if (registry_.count(key) != 0) {
       auto cur_priority = priority_[key];
       if (priority > cur_priority) {
-  #ifdef DEBUG
+#ifdef DEBUG
         std::string warn_msg =
             "Overwriting already registered item for key " + KeyStrRepr(key);
         fprintf(stderr, "%s\n", warn_msg.c_str());
-  #endif
+#endif
         registry_[key] = creator;
         priority_[key] = priority;
       } else if (priority == cur_priority) {

--- a/c10/util/SmallVector.h
+++ b/c10/util/SmallVector.h
@@ -20,8 +20,8 @@
 
 #pragma once
 
-#include <c10/util/AlignOf.h>
 #include <c10/macros/Macros.h>
+#include <c10/util/AlignOf.h>
 
 #include <algorithm>
 #include <cassert>
@@ -391,8 +391,8 @@ class SmallVectorImpl
  protected:
   // Default ctor - Initialize to empty.
   explicit SmallVectorImpl(unsigned N)
-      : SmallVectorTemplateBase<T, C10_IS_TRIVIALLY_COPYABLE(T)>(N * sizeof(T)) {
-  }
+      : SmallVectorTemplateBase<T, C10_IS_TRIVIALLY_COPYABLE(T)>(
+            N * sizeof(T)) {}
 
  public:
   SmallVectorImpl(const SmallVectorImpl&) = delete;
@@ -1020,10 +1020,10 @@ inline size_t capacity_in_bytes(const SmallVector<T, N>& X) {
 }
 
 template <typename T, unsigned N>
-std::ostream& operator<<(std::ostream & out, const SmallVector<T, N>& list) {
+std::ostream& operator<<(std::ostream& out, const SmallVector<T, N>& list) {
   int i = 0;
   out << "[";
-  for(auto e : list) {
+  for (auto e : list) {
     if (i++ > 0)
       out << ", ";
     out << e;

--- a/c10/util/TypeList.h
+++ b/c10/util/TypeList.h
@@ -3,134 +3,158 @@
 #include <c10/util/C++17.h>
 #include <c10/util/TypeTraits.h>
 
-namespace c10 { namespace guts {
+namespace c10 {
+namespace guts {
 
-template<class... T> struct false_t : std::false_type {};
-template<template<class> class... T> struct false_higher_t : std::false_type {};
+template <class... T>
+struct false_t : std::false_type {};
+template <template <class> class... T>
+struct false_higher_t : std::false_type {};
 
 namespace typelist {
-
-
 
 /**
  * Type holding a list of types for compile time type computations
  */
-template<class... Items> struct typelist final {
-private:
-    typelist() = delete; // not for instantiation
+template <class... Items>
+struct typelist final {
+ private:
+  typelist() = delete; // not for instantiation
 };
-
-
 
 /**
  * Returns the number of types in a typelist
  * Example:
  *   3  ==  size<typelist<int, int, double>>::value
  */
-template<class TypeList> struct size final {
-    static_assert(false_t<TypeList>::value, "In typelist::size<T>, T must be typelist<...>.");
+template <class TypeList>
+struct size final {
+  static_assert(
+      false_t<TypeList>::value,
+      "In typelist::size<T>, T must be typelist<...>.");
 };
-template<class... Types> struct size<typelist<Types...>> final {
-    static constexpr size_t value = sizeof...(Types);
+template <class... Types>
+struct size<typelist<Types...>> final {
+  static constexpr size_t value = sizeof...(Types);
 };
-
-
 
 /**
  * Transforms a list of types into a tuple holding these types.
  * Example:
  *   std::tuple<int, string>  ==  to_tuple_t<typelist<int, string>>
  */
-template<class TypeList> struct to_tuple final {
-    static_assert(false_t<TypeList>::value, "In typelist::to_tuple<T>, T must be typelist<...>.");
+template <class TypeList>
+struct to_tuple final {
+  static_assert(
+      false_t<TypeList>::value,
+      "In typelist::to_tuple<T>, T must be typelist<...>.");
 };
-template<class... Types> struct to_tuple<typelist<Types...>> final {
-    using type = std::tuple<Types...>;
+template <class... Types>
+struct to_tuple<typelist<Types...>> final {
+  using type = std::tuple<Types...>;
 };
-template<class TypeList> using to_tuple_t = typename to_tuple<TypeList>::type;
-
-
-
+template <class TypeList>
+using to_tuple_t = typename to_tuple<TypeList>::type;
 
 /**
  * Creates a typelist containing the types of a given tuple.
  * Example:
  *   typelist<int, string>  ==  from_tuple_t<std::tuple<int, string>>
  */
-template<class Tuple> struct from_tuple final {
-    static_assert(false_t<Tuple>::value, "In typelist::from_tuple<T>, T must be std::tuple<...>.");
+template <class Tuple>
+struct from_tuple final {
+  static_assert(
+      false_t<Tuple>::value,
+      "In typelist::from_tuple<T>, T must be std::tuple<...>.");
 };
-template<class... Types> struct from_tuple<std::tuple<Types...>> final {
+template <class... Types>
+struct from_tuple<std::tuple<Types...>> final {
   using type = typelist<Types...>;
 };
-template<class Tuple> using from_tuple_t = typename from_tuple<Tuple>::type;
-
-
+template <class Tuple>
+using from_tuple_t = typename from_tuple<Tuple>::type;
 
 /**
  * Concatenates multiple type lists.
  * Example:
- *   typelist<int, string, int>  ==  concat_t<typelist<int, string>, typelist<int>>
+ *   typelist<int, string, int>  ==  concat_t<typelist<int, string>,
+ * typelist<int>>
  */
-template<class... TypeLists> struct concat final {
-    static_assert(false_t<TypeLists...>::value, "In typelist::concat<T1, ...>, the T arguments each must be typelist<...>.");
+template <class... TypeLists>
+struct concat final {
+  static_assert(
+      false_t<TypeLists...>::value,
+      "In typelist::concat<T1, ...>, the T arguments each must be typelist<...>.");
 };
-template<class... Head1Types, class... Head2Types, class... TailLists>
-struct concat<typelist<Head1Types...>, typelist<Head2Types...>, TailLists...> final {
-  using type = typename concat<typelist<Head1Types..., Head2Types...>, TailLists...>::type;
+template <class... Head1Types, class... Head2Types, class... TailLists>
+struct concat<typelist<Head1Types...>, typelist<Head2Types...>, TailLists...>
+    final {
+  using type =
+      typename concat<typelist<Head1Types..., Head2Types...>, TailLists...>::
+          type;
 };
-template<class... HeadTypes>
+template <class... HeadTypes>
 struct concat<typelist<HeadTypes...>> final {
   using type = typelist<HeadTypes...>;
 };
-template<>
+template <>
 struct concat<> final {
   using type = typelist<>;
 };
-template<class... TypeLists> using concat_t = typename concat<TypeLists...>::type;
-
-
+template <class... TypeLists>
+using concat_t = typename concat<TypeLists...>::type;
 
 /**
  * Filters the types in a type list by a type trait.
  * Examples:
- *   typelist<int&, const string&&>  ==  filter_t<std::is_reference, typelist<void, string, int&, bool, const string&&, int>>
+ *   typelist<int&, const string&&>  ==  filter_t<std::is_reference,
+ * typelist<void, string, int&, bool, const string&&, int>>
  */
-template<template <class> class Condition, class TypeList> struct filter final {
-  static_assert(false_t<TypeList>::value, "In typelist::filter<Condition, TypeList>, the TypeList argument must be typelist<...>.");
+template <template <class> class Condition, class TypeList>
+struct filter final {
+  static_assert(
+      false_t<TypeList>::value,
+      "In typelist::filter<Condition, TypeList>, the TypeList argument must be typelist<...>.");
 };
-template<template <class> class Condition, class Head, class... Tail>
+template <template <class> class Condition, class Head, class... Tail>
 struct filter<Condition, typelist<Head, Tail...>> final {
-  static_assert(is_type_condition<Condition>::value, "In typelist::filter<Condition, TypeList>, the Condition argument must be a condition type trait, i.e. have a static constexpr bool ::value member.");
+  static_assert(
+      is_type_condition<Condition>::value,
+      "In typelist::filter<Condition, TypeList>, the Condition argument must be a condition type trait, i.e. have a static constexpr bool ::value member.");
   using type = guts::conditional_t<
-    Condition<Head>::value,
-    concat_t<typelist<Head>, typename filter<Condition, typelist<Tail...>>::type>,
-    typename filter<Condition, typelist<Tail...>>::type
-  >;
+      Condition<Head>::value,
+      concat_t<
+          typelist<Head>,
+          typename filter<Condition, typelist<Tail...>>::type>,
+      typename filter<Condition, typelist<Tail...>>::type>;
 };
-template<template <class> class Condition>
+template <template <class> class Condition>
 struct filter<Condition, typelist<>> final {
-  static_assert(is_type_condition<Condition>::value, "In typelist::filter<Condition, TypeList>, the Condition argument must be a condition type trait, i.e. have a static constexpr bool ::value member.");
+  static_assert(
+      is_type_condition<Condition>::value,
+      "In typelist::filter<Condition, TypeList>, the Condition argument must be a condition type trait, i.e. have a static constexpr bool ::value member.");
   using type = typelist<>;
 };
-template<template <class> class Condition, class TypeList>
+template <template <class> class Condition, class TypeList>
 using filter_t = typename filter<Condition, TypeList>::type;
-
-
 
 /**
  * Counts how many types in the list fulfill a type trait
  * Examples:
- *   2  ==  count_if<std::is_reference, typelist<void, string, int&, bool, const string&&, int>>
+ *   2  ==  count_if<std::is_reference, typelist<void, string, int&, bool, const
+ * string&&, int>>
  */
-template<template <class> class Condition, class TypeList>
+template <template <class> class Condition, class TypeList>
 struct count_if final {
-  static_assert(is_type_condition<Condition>::value, "In typelist::count_if<Condition, TypeList>, the Condition argument must be a condition type trait, i.e. have a static constexpr bool ::value member.");
-  static_assert(is_instantiation_of<typelist, TypeList>::value, "In typelist::count_if<Condition, TypeList>, the TypeList argument must be typelist<...>.");
+  static_assert(
+      is_type_condition<Condition>::value,
+      "In typelist::count_if<Condition, TypeList>, the Condition argument must be a condition type trait, i.e. have a static constexpr bool ::value member.");
+  static_assert(
+      is_instantiation_of<typelist, TypeList>::value,
+      "In typelist::count_if<Condition, TypeList>, the TypeList argument must be typelist<...>.");
   // TODO Direct implementation might be faster
   static constexpr size_t value = size<filter_t<Condition, TypeList>>::value;
 };
-
 
 /**
  * Checks if a typelist contains a certain type.
@@ -139,63 +163,83 @@ struct count_if final {
  *  contains<typelist<int, string>, double> == false_type
  */
 namespace detail {
-template<class TypeList, class Type, class Enable = void> struct contains {};
-template<class Type> struct contains<typelist<>, Type, void> : std::false_type {};
-template<class Type, class Head, class... Tail>
-struct contains<typelist<Head, Tail...>, Type, guts::enable_if_t<std::is_same<Head, Type>::value>> : std::true_type {};
-template<class Type, class Head, class... Tail>
-struct contains<typelist<Head, Tail...>, Type, guts::enable_if_t<!std::is_same<Head, Type>::value>> : contains<typelist<Tail...>, Type> {};
-}
-template<class TypeList, class Type>
+template <class TypeList, class Type, class Enable = void>
+struct contains {};
+template <class Type>
+struct contains<typelist<>, Type, void> : std::false_type {};
+template <class Type, class Head, class... Tail>
+struct contains<
+    typelist<Head, Tail...>,
+    Type,
+    guts::enable_if_t<std::is_same<Head, Type>::value>> : std::true_type {};
+template <class Type, class Head, class... Tail>
+struct contains<
+    typelist<Head, Tail...>,
+    Type,
+    guts::enable_if_t<!std::is_same<Head, Type>::value>>
+    : contains<typelist<Tail...>, Type> {};
+} // namespace detail
+template <class TypeList, class Type>
 using contains = typename detail::contains<TypeList, Type>::type;
-
 
 /**
  * Returns true iff the type trait is true for all types in the type list
  * Examples:
- *   true   ==  true_for_each_type<std::is_reference, typelist<int&, const float&&, const MyClass&>>::value
- *   false  ==  true_for_each_type<std::is_reference, typelist<int&, const float&&, MyClass>>::value
+ *   true   ==  true_for_each_type<std::is_reference, typelist<int&, const
+ * float&&, const MyClass&>>::value false  ==
+ * true_for_each_type<std::is_reference, typelist<int&, const float&&,
+ * MyClass>>::value
  */
-template<template <class> class Condition, class TypeList> struct true_for_each_type final {
-    static_assert(false_t<TypeList>::value, "In typelist::true_for_each_type<Condition, TypeList>, the TypeList argument must be typelist<...>.");
+template <template <class> class Condition, class TypeList>
+struct true_for_each_type final {
+  static_assert(
+      false_t<TypeList>::value,
+      "In typelist::true_for_each_type<Condition, TypeList>, the TypeList argument must be typelist<...>.");
 };
-template<template <class> class Condition, class... Types>
+template <template <class> class Condition, class... Types>
 struct true_for_each_type<Condition, typelist<Types...>> final
-: guts::conjunction<Condition<Types>...> {
-    static_assert(is_type_condition<Condition>::value, "In typelist::true_for_each_type<Condition, TypeList>, the Condition argument must be a condition type trait, i.e. have a static constexpr bool ::value member.");
+    : guts::conjunction<Condition<Types>...> {
+  static_assert(
+      is_type_condition<Condition>::value,
+      "In typelist::true_for_each_type<Condition, TypeList>, the Condition argument must be a condition type trait, i.e. have a static constexpr bool ::value member.");
 };
-
-
 
 /**
  * Maps types of a type list using a type trait
  * Example:
- *  typelist<int&, double&, string&>  ==  map_t<std::add_lvalue_reference_t, typelist<int, double, string>>
+ *  typelist<int&, double&, string&>  ==  map_t<std::add_lvalue_reference_t,
+ * typelist<int, double, string>>
  */
-template<template <class> class Mapper, class TypeList> struct map final {
-    static_assert(false_t<TypeList>::value, "In typelist::map<Mapper, TypeList>, the TypeList argument must be typelist<...>.");
+template <template <class> class Mapper, class TypeList>
+struct map final {
+  static_assert(
+      false_t<TypeList>::value,
+      "In typelist::map<Mapper, TypeList>, the TypeList argument must be typelist<...>.");
 };
-template<template <class> class Mapper, class... Types>
+template <template <class> class Mapper, class... Types>
 struct map<Mapper, typelist<Types...>> final {
   using type = typelist<Mapper<Types>...>;
 };
-template<template <class> class Mapper, class TypeList>
+template <template <class> class Mapper, class TypeList>
 using map_t = typename map<Mapper, TypeList>::type;
-
-
 
 /**
  * Returns the first element of a type list.
  * Example:
  *   int  ==  head_t<typelist<int, string>>
  */
-template<class TypeList> struct head final {
-    static_assert(false_t<TypeList>::value, "In typelist::head<T>, the T argument must be typelist<...>.");
+template <class TypeList>
+struct head final {
+  static_assert(
+      false_t<TypeList>::value,
+      "In typelist::head<T>, the T argument must be typelist<...>.");
 };
-template<class Head, class... Tail> struct head<typelist<Head, Tail...>> final {
+template <class Head, class... Tail>
+struct head<typelist<Head, Tail...>> final {
   using type = Head;
 };
-template<class TypeList> using head_t = typename head<TypeList>::type;
+template <class TypeList>
+using head_t = typename head<TypeList>::type;
 
 /**
  * Returns the N-th element of a type list.
@@ -204,25 +248,36 @@ template<class TypeList> using head_t = typename head<TypeList>::type;
  */
 
 /// Base template.
-template<size_t Index, class TypeList> struct element final {
-    static_assert(false_t<TypeList>::value, "In typelist::element<T>, the T argument must be typelist<...>.");
+template <size_t Index, class TypeList>
+struct element final {
+  static_assert(
+      false_t<TypeList>::value,
+      "In typelist::element<T>, the T argument must be typelist<...>.");
 };
 
-/// Successful case, we have reached the zero index and can "return" the head type.
-template<class Head, class... Tail> struct element<0, typelist<Head, Tail...>> { using type = Head; };
+/// Successful case, we have reached the zero index and can "return" the head
+/// type.
+template <class Head, class... Tail>
+struct element<0, typelist<Head, Tail...>> {
+  using type = Head;
+};
 
 /// Error case, we have an index but ran out of types! It will only be selected
 /// if `Ts...` is actually empty!
 template <size_t Index, class... Ts>
 struct element<Index, typelist<Ts...>> {
-  static_assert(Index < sizeof...(Ts), "Index is out of bounds in typelist::element");
+  static_assert(
+      Index < sizeof...(Ts),
+      "Index is out of bounds in typelist::element");
 };
 
 /// Shave off types until we hit the <0, Head, Tail...> or <Index> case.
-template<size_t Index, class Head, class... Tail> struct element<Index, typelist<Head, Tail...>> : element<Index-1, typelist<Tail...>> { };
+template <size_t Index, class Head, class... Tail>
+struct element<Index, typelist<Head, Tail...>>
+    : element<Index - 1, typelist<Tail...>> {};
 
 /// Convenience alias.
-template<size_t Index, class TypeList>
+template <size_t Index, class TypeList>
 using element_t = typename element<Index, TypeList>::type;
 
 /**
@@ -255,40 +310,59 @@ static_assert(
  * Example:
  *   typelist<int, string>  == reverse_t<typelist<string, int>>
  */
-template<class TypeList> struct reverse final {
-    static_assert(false_t<TypeList>::value, "In typelist::reverse<T>, the T argument must be typelist<...>.");
+template <class TypeList>
+struct reverse final {
+  static_assert(
+      false_t<TypeList>::value,
+      "In typelist::reverse<T>, the T argument must be typelist<...>.");
 };
-template<class Head, class... Tail> struct reverse<typelist<Head, Tail...>> final {
-  using type = concat_t<typename reverse<typelist<Tail...>>::type, typelist<Head>>;
+template <class Head, class... Tail>
+struct reverse<typelist<Head, Tail...>> final {
+  using type =
+      concat_t<typename reverse<typelist<Tail...>>::type, typelist<Head>>;
 };
-template<> struct reverse<typelist<>> final {
+template <>
+struct reverse<typelist<>> final {
   using type = typelist<>;
 };
-template<class TypeList> using reverse_t = typename reverse<TypeList>::type;
-
+template <class TypeList>
+using reverse_t = typename reverse<TypeList>::type;
 
 /**
- * Find the index of the first type in a typelist fulfilling a type trait condition.
- * Example:
+ * Find the index of the first type in a typelist fulfilling a type trait
+ * condition. Example:
  *
  * 2 == find_if<typelist<char, int, char&, int&>, std::is_reference>::value
  */
-template<class TypeList, template<class> class Condition, class Enable = void> struct find_if final {
-  static_assert(false_t<TypeList>::value, "In typelist::find_if<TypeList, Condition>, the TypeList argument must be typelist<...>.");
+template <class TypeList, template <class> class Condition, class Enable = void>
+struct find_if final {
+  static_assert(
+      false_t<TypeList>::value,
+      "In typelist::find_if<TypeList, Condition>, the TypeList argument must be typelist<...>.");
 };
-template<template<class> class Condition> struct find_if<typelist<>, Condition, void> final {
-  static_assert(false_higher_t<Condition>::value, "In typelist::find_if<Type/List, Condition>, didn't find any type fulfilling the Condition.");
+template <template <class> class Condition>
+struct find_if<typelist<>, Condition, void> final {
+  static_assert(
+      false_higher_t<Condition>::value,
+      "In typelist::find_if<Type/List, Condition>, didn't find any type fulfilling the Condition.");
 };
-template<class Head, class... Tail, template<class> class Condition>
-struct find_if<typelist<Head, Tail...>, Condition, enable_if_t<Condition<Head>::value>> final {
+template <class Head, class... Tail, template <class> class Condition>
+struct find_if<
+    typelist<Head, Tail...>,
+    Condition,
+    enable_if_t<Condition<Head>::value>>
+    final {
   static constexpr size_t value = 0;
 };
-template<class Head, class... Tail, template<class> class Condition>
-struct find_if<typelist<Head, Tail...>, Condition, enable_if_t<!Condition<Head>::value>> final {
-  static constexpr size_t value = 1 + find_if<typelist<Tail...>, Condition>::value;
+template <class Head, class... Tail, template <class> class Condition>
+struct find_if<
+    typelist<Head, Tail...>,
+    Condition,
+    enable_if_t<!Condition<Head>::value>>
+    final {
+  static constexpr size_t value =
+      1 + find_if<typelist<Tail...>, Condition>::value;
 };
-
-
 
 /**
  * Maps a list of types into a list of values.
@@ -320,24 +394,33 @@ struct find_if<typelist<Head, Tail...>, Condition, enable_if_t<!Condition<Head>:
  *   //  sizes  ==  std::tuple<size_t, size_t, size_t>{8, 1, 4}
  */
 namespace detail {
-template<class T> struct type_ final {
-    using type = T;
+template <class T>
+struct type_ final {
+  using type = T;
 };
-template<class TypeList> struct map_types_to_values final {
-    static_assert(false_t<TypeList>::value, "In typelist::map_types_to_values<T>, the T argument must be typelist<...>.");
+template <class TypeList>
+struct map_types_to_values final {
+  static_assert(
+      false_t<TypeList>::value,
+      "In typelist::map_types_to_values<T>, the T argument must be typelist<...>.");
 };
-template<class... Types> struct map_types_to_values<typelist<Types...>> final {
-  template<class Func>
-  static std::tuple<guts::result_of_t<Func(type_<Types>)>...> call(Func&& func) {
-    return std::tuple<guts::result_of_t<Func(type_<Types>)>...> { std::forward<Func>(func)(type_<Types>())... };
+template <class... Types>
+struct map_types_to_values<typelist<Types...>> final {
+  template <class Func>
+  static std::tuple<guts::result_of_t<Func(type_<Types>)>...> call(
+      Func&& func) {
+    return std::tuple<guts::result_of_t<Func(type_<Types>)>...>{
+        std::forward<Func>(func)(type_<Types>())...};
   }
 };
-}
+} // namespace detail
 
-template<class TypeList, class Func> auto map_types_to_values(Func&& func)
--> decltype(detail::map_types_to_values<TypeList>::call(std::forward<Func>(func))) {
+template <class TypeList, class Func>
+auto map_types_to_values(Func&& func) -> decltype(
+    detail::map_types_to_values<TypeList>::call(std::forward<Func>(func))) {
   return detail::map_types_to_values<TypeList>::call(std::forward<Func>(func));
 }
 
-
-}}}
+} // namespace typelist
+} // namespace guts
+} // namespace c10

--- a/c10/util/TypeTraits.h
+++ b/c10/util/TypeTraits.h
@@ -6,39 +6,45 @@
 namespace c10 {
 namespace guts {
 
-
 /**
- * is_equality_comparable<T> is true_type iff the equality operator is defined for T.
+ * is_equality_comparable<T> is true_type iff the equality operator is defined
+ * for T.
  */
-template<class T, class Enable = void> struct is_equality_comparable : std::false_type {};
-template<class T> struct is_equality_comparable<T, void_t<decltype(std::declval<T&>() == std::declval<T&>())>> : std::true_type {};
-template<class T> using is_equality_comparable_t = typename is_equality_comparable<T>::type;
-
-
+template <class T, class Enable = void>
+struct is_equality_comparable : std::false_type {};
+template <class T>
+struct is_equality_comparable<
+    T,
+    void_t<decltype(std::declval<T&>() == std::declval<T&>())>>
+    : std::true_type {};
+template <class T>
+using is_equality_comparable_t = typename is_equality_comparable<T>::type;
 
 /**
  * is_hashable<T> is true_type iff std::hash is defined for T
  */
-template<class T, class Enable = void> struct is_hashable : std::false_type {};
-template<class T> struct is_hashable<T, void_t<decltype(std::hash<T>()(std::declval<T&>()))>> : std::true_type {};
-template<class T> using is_hashable_t = typename is_hashable<T>::type;
-
-
+template <class T, class Enable = void>
+struct is_hashable : std::false_type {};
+template <class T>
+struct is_hashable<T, void_t<decltype(std::hash<T>()(std::declval<T&>()))>>
+    : std::true_type {};
+template <class T>
+using is_hashable_t = typename is_hashable<T>::type;
 
 /**
- * is_function_type<T> is true_type iff T is a plain function type (i.e. "Result(Args...)")
+ * is_function_type<T> is true_type iff T is a plain function type (i.e.
+ * "Result(Args...)")
  */
-template<class T>
+template <class T>
 struct is_function_type : std::false_type {};
-template<class Result, class... Args>
-struct is_function_type<Result (Args...)> : std::true_type {};
-template<class T> using is_function_type_t = typename is_function_type<T>::type;
-
-
+template <class Result, class... Args>
+struct is_function_type<Result(Args...)> : std::true_type {};
+template <class T>
+using is_function_type_t = typename is_function_type<T>::type;
 
 /**
- * is_instantiation_of<T, I> is true_type iff I is a template instantiation of T (e.g. vector<int> is an instantiation of vector)
- *  Example:
+ * is_instantiation_of<T, I> is true_type iff I is a template instantiation of T
+ * (e.g. vector<int> is an instantiation of vector) Example:
  *    is_instantiation_of_t<vector, vector<int>> // true
  *    is_instantiation_of_t<pair, pair<int, string>> // true
  *    is_instantiation_of_t<vector, pair<int, string>> // false
@@ -47,7 +53,8 @@ template <template <class...> class Template, class T>
 struct is_instantiation_of : std::false_type {};
 template <template <class...> class Template, class... Args>
 struct is_instantiation_of<Template, Template<Args...>> : std::true_type {};
-template<template<class...> class Template, class T> using is_instantiation_of_t = typename is_instantiation_of<Template, T>::type;
+template <template <class...> class Template, class T>
+using is_instantiation_of_t = typename is_instantiation_of<Template, T>::type;
 
 namespace detail {
 /**
@@ -73,11 +80,14 @@ using strip_class_t = typename strip_class<T>::type;
  * (i.e. has a call operator with some set of arguments)
  */
 
-template<class Functor, class Enable = void>
+template <class Functor, class Enable = void>
 struct is_functor : std::false_type {};
-template<class Functor>
-struct is_functor<Functor, guts::enable_if_t<is_function_type<detail::strip_class_t<decltype(&Functor::operator())>>::value>> : std::true_type {};
-
+template <class Functor>
+struct is_functor<
+    Functor,
+    guts::enable_if_t<is_function_type<
+        detail::strip_class_t<decltype(&Functor::operator())>>::value>>
+    : std::true_type {};
 
 /**
  * lambda_is_stateless<T> is true iff the lambda type T is stateless
@@ -89,36 +99,47 @@ struct is_functor<Functor, guts::enable_if_t<is_function_type<detail::strip_clas
  *  lambda_is_stateless<decltype(stateful_lambda)> // false
  */
 namespace detail {
-template<class LambdaType, class FuncType> struct is_stateless_lambda__ final {
-    static_assert(!std::is_same<LambdaType, LambdaType>::value, "Base case shouldn't be hit");
+template <class LambdaType, class FuncType>
+struct is_stateless_lambda__ final {
+  static_assert(
+      !std::is_same<LambdaType, LambdaType>::value,
+      "Base case shouldn't be hit");
 };
-// implementation idea: According to the C++ standard, stateless lambdas are convertible to function pointers
-template<class LambdaType, class C, class Result, class... Args>
-struct is_stateless_lambda__<LambdaType, Result (C::*)(Args...) const> : std::is_convertible<LambdaType, Result(*)(Args...)> {};
-template<class LambdaType, class C, class Result, class... Args>
-struct is_stateless_lambda__<LambdaType, Result (C::*)(Args...)> : std::is_convertible<LambdaType, Result(*)(Args...)> {};
+// implementation idea: According to the C++ standard, stateless lambdas are
+// convertible to function pointers
+template <class LambdaType, class C, class Result, class... Args>
+struct is_stateless_lambda__<LambdaType, Result (C::*)(Args...) const>
+    : std::is_convertible<LambdaType, Result (*)(Args...)> {};
+template <class LambdaType, class C, class Result, class... Args>
+struct is_stateless_lambda__<LambdaType, Result (C::*)(Args...)>
+    : std::is_convertible<LambdaType, Result (*)(Args...)> {};
 
 // case where LambdaType is not even a functor
-template<class LambdaType, class Enable = void> struct is_stateless_lambda_ final : std::false_type {};
+template <class LambdaType, class Enable = void>
+struct is_stateless_lambda_ final : std::false_type {};
 // case where LambdaType is a functor
-template<class LambdaType> struct is_stateless_lambda_<LambdaType, guts::enable_if_t<is_functor<LambdaType>::value>>
-: is_stateless_lambda__<LambdaType, decltype(&LambdaType::operator())> {};
-}
-template<class T>
+template <class LambdaType>
+struct is_stateless_lambda_<
+    LambdaType,
+    guts::enable_if_t<is_functor<LambdaType>::value>>
+    : is_stateless_lambda__<LambdaType, decltype(&LambdaType::operator())> {};
+} // namespace detail
+template <class T>
 using is_stateless_lambda = detail::is_stateless_lambda_<guts::decay_t<T>>;
 
-
-
 /**
- * is_type_condition<C> is true_type iff C<...> is a type trait representing a condition (i.e. has a constexpr static bool ::value member)
- * Example:
+ * is_type_condition<C> is true_type iff C<...> is a type trait representing a
+ * condition (i.e. has a constexpr static bool ::value member) Example:
  *   is_type_condition<std::is_reference>  // true
  */
-template<template<class> class C, class Enable = void>
+template <template <class> class C, class Enable = void>
 struct is_type_condition : std::false_type {};
-template<template<class> class C>
-struct is_type_condition<C, guts::enable_if_t<std::is_same<bool, guts::remove_cv_t<decltype(C<int>::value)>>::value>> : std::true_type {};
+template <template <class> class C>
+struct is_type_condition<
+    C,
+    guts::enable_if_t<
+        std::is_same<bool, guts::remove_cv_t<decltype(C<int>::value)>>::value>>
+    : std::true_type {};
 
-
-}
-}
+} // namespace guts
+} // namespace c10

--- a/c10/util/UniqueVoidPtr.h
+++ b/c10/util/UniqueVoidPtr.h
@@ -66,8 +66,11 @@ class UniqueVoidPtr {
   std::unique_ptr<void, DeleterFnPtr>&& move_context() {
     return std::move(ctx_);
   }
-  C10_NODISCARD bool compare_exchange_deleter(DeleterFnPtr expected_deleter, DeleterFnPtr new_deleter) {
-    if (get_deleter() != expected_deleter) return false;
+  C10_NODISCARD bool compare_exchange_deleter(
+      DeleterFnPtr expected_deleter,
+      DeleterFnPtr new_deleter) {
+    if (get_deleter() != expected_deleter)
+      return false;
     ctx_ = std::unique_ptr<void, DeleterFnPtr>(ctx_.release(), new_deleter);
     return true;
   }

--- a/c10/util/either.h
+++ b/c10/util/either.h
@@ -130,7 +130,7 @@ class either final {
     return std::move(right());
   }
 
-  template<class Result, class LeftMapFunc, class RightMapFunc>
+  template <class Result, class LeftMapFunc, class RightMapFunc>
   Result map(LeftMapFunc&& leftMapFunc, RightMapFunc&& rightMapFunc) const {
     if (Side::left == _side) {
       return std::forward<LeftMapFunc>(leftMapFunc)(_left);

--- a/c10/util/flat_hash_map.h
+++ b/c10/util/flat_hash_map.h
@@ -1,10 +1,12 @@
-// Taken from https://github.com/skarupke/flat_hash_map/blob/2c4687431f978f02a3780e24b8b701d22aa32d9c/flat_hash_map.hpp
+// Taken from
+// https://github.com/skarupke/flat_hash_map/blob/2c4687431f978f02a3780e24b8b701d22aa32d9c/flat_hash_map.hpp
 // with fixes applied:
 // - https://github.com/skarupke/flat_hash_map/pull/25
 // - https://github.com/skarupke/flat_hash_map/pull/26
 // - replace size_t with uint64_t to fix it for 32bit
 // - add "GCC diagnostic" pragma to ignore -Wshadow
-// - make sherwood_v3_table::convertible_to_iterator public because GCC5 seems to have issues with it otherwise
+// - make sherwood_v3_table::convertible_to_iterator public because GCC5 seems
+// to have issues with it otherwise
 // - fix compiler warnings in operator templated_iterator<const value_type>
 
 //          Copyright Malte Skarupke 2017.
@@ -13,14 +15,14 @@
 
 #pragma once
 
-#include <cstdint>
-#include <cstddef>
-#include <functional>
-#include <cmath>
 #include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
 #include <iterator>
-#include <utility>
 #include <type_traits>
+#include <utility>
 
 #ifndef _MSC_VER
 #pragma GCC diagnostic push
@@ -33,1487 +35,2065 @@
 #define SKA_NOINLINE(...) __VA_ARGS__ __attribute__((noinline))
 #endif
 
-namespace ska
-{
+namespace ska {
 struct prime_number_hash_policy;
 struct power_of_two_hash_policy;
 struct fibonacci_hash_policy;
 
-namespace detailv3
-{
-template<typename Result, typename Functor>
-struct functor_storage : Functor
-{
-    functor_storage() = default;
-    functor_storage(const Functor & functor)
-        : Functor(functor)
-    {
-    }
-    template<typename... Args>
-    Result operator()(Args &&... args)
-    {
-        return static_cast<Functor &>(*this)(std::forward<Args>(args)...);
-    }
-    template<typename... Args>
-    Result operator()(Args &&... args) const
-    {
-        return static_cast<const Functor &>(*this)(std::forward<Args>(args)...);
-    }
+namespace detailv3 {
+template <typename Result, typename Functor>
+struct functor_storage : Functor {
+  functor_storage() = default;
+  functor_storage(const Functor& functor) : Functor(functor) {}
+  template <typename... Args>
+  Result operator()(Args&&... args) {
+    return static_cast<Functor&>(*this)(std::forward<Args>(args)...);
+  }
+  template <typename... Args>
+  Result operator()(Args&&... args) const {
+    return static_cast<const Functor&>(*this)(std::forward<Args>(args)...);
+  }
 };
-template<typename Result, typename... Args>
-struct functor_storage<Result, Result (*)(Args...)>
-{
-    typedef Result (*function_ptr)(Args...);
-    function_ptr function;
-    functor_storage(function_ptr function)
-        : function(function)
-    {
-    }
-    Result operator()(Args... args) const
-    {
-        return function(std::forward<Args>(args)...);
-    }
-    operator function_ptr &()
-    {
-        return function;
-    }
-    operator const function_ptr &()
-    {
-        return function;
-    }
+template <typename Result, typename... Args>
+struct functor_storage<Result, Result (*)(Args...)> {
+  typedef Result (*function_ptr)(Args...);
+  function_ptr function;
+  functor_storage(function_ptr function) : function(function) {}
+  Result operator()(Args... args) const {
+    return function(std::forward<Args>(args)...);
+  }
+  operator function_ptr&() {
+    return function;
+  }
+  operator const function_ptr&() {
+    return function;
+  }
 };
-template<typename key_type, typename value_type, typename hasher>
-struct KeyOrValueHasher : functor_storage<uint64_t, hasher>
-{
-    typedef functor_storage<uint64_t, hasher> hasher_storage;
-    KeyOrValueHasher() = default;
-    KeyOrValueHasher(const hasher & hash)
-        : hasher_storage(hash)
-    {
-    }
-    uint64_t operator()(const key_type & key)
-    {
-        return static_cast<hasher_storage &>(*this)(key);
-    }
-    uint64_t operator()(const key_type & key) const
-    {
-        return static_cast<const hasher_storage &>(*this)(key);
-    }
-    uint64_t operator()(const value_type & value)
-    {
-        return static_cast<hasher_storage &>(*this)(value.first);
-    }
-    uint64_t operator()(const value_type & value) const
-    {
-        return static_cast<const hasher_storage &>(*this)(value.first);
-    }
-    template<typename F, typename S>
-    uint64_t operator()(const std::pair<F, S> & value)
-    {
-        return static_cast<hasher_storage &>(*this)(value.first);
-    }
-    template<typename F, typename S>
-    uint64_t operator()(const std::pair<F, S> & value) const
-    {
-        return static_cast<const hasher_storage &>(*this)(value.first);
-    }
+template <typename key_type, typename value_type, typename hasher>
+struct KeyOrValueHasher : functor_storage<uint64_t, hasher> {
+  typedef functor_storage<uint64_t, hasher> hasher_storage;
+  KeyOrValueHasher() = default;
+  KeyOrValueHasher(const hasher& hash) : hasher_storage(hash) {}
+  uint64_t operator()(const key_type& key) {
+    return static_cast<hasher_storage&>(*this)(key);
+  }
+  uint64_t operator()(const key_type& key) const {
+    return static_cast<const hasher_storage&>(*this)(key);
+  }
+  uint64_t operator()(const value_type& value) {
+    return static_cast<hasher_storage&>(*this)(value.first);
+  }
+  uint64_t operator()(const value_type& value) const {
+    return static_cast<const hasher_storage&>(*this)(value.first);
+  }
+  template <typename F, typename S>
+  uint64_t operator()(const std::pair<F, S>& value) {
+    return static_cast<hasher_storage&>(*this)(value.first);
+  }
+  template <typename F, typename S>
+  uint64_t operator()(const std::pair<F, S>& value) const {
+    return static_cast<const hasher_storage&>(*this)(value.first);
+  }
 };
-template<typename key_type, typename value_type, typename key_equal>
-struct KeyOrValueEquality : functor_storage<bool, key_equal>
-{
-    typedef functor_storage<bool, key_equal> equality_storage;
-    KeyOrValueEquality() = default;
-    KeyOrValueEquality(const key_equal & equality)
-        : equality_storage(equality)
-    {
-    }
-    bool operator()(const key_type & lhs, const key_type & rhs)
-    {
-        return static_cast<equality_storage &>(*this)(lhs, rhs);
-    }
-    bool operator()(const key_type & lhs, const value_type & rhs)
-    {
-        return static_cast<equality_storage &>(*this)(lhs, rhs.first);
-    }
-    bool operator()(const value_type & lhs, const key_type & rhs)
-    {
-        return static_cast<equality_storage &>(*this)(lhs.first, rhs);
-    }
-    bool operator()(const value_type & lhs, const value_type & rhs)
-    {
-        return static_cast<equality_storage &>(*this)(lhs.first, rhs.first);
-    }
-    template<typename F, typename S>
-    bool operator()(const key_type & lhs, const std::pair<F, S> & rhs)
-    {
-        return static_cast<equality_storage &>(*this)(lhs, rhs.first);
-    }
-    template<typename F, typename S>
-    bool operator()(const std::pair<F, S> & lhs, const key_type & rhs)
-    {
-        return static_cast<equality_storage &>(*this)(lhs.first, rhs);
-    }
-    template<typename F, typename S>
-    bool operator()(const value_type & lhs, const std::pair<F, S> & rhs)
-    {
-        return static_cast<equality_storage &>(*this)(lhs.first, rhs.first);
-    }
-    template<typename F, typename S>
-    bool operator()(const std::pair<F, S> & lhs, const value_type & rhs)
-    {
-        return static_cast<equality_storage &>(*this)(lhs.first, rhs.first);
-    }
-    template<typename FL, typename SL, typename FR, typename SR>
-    bool operator()(const std::pair<FL, SL> & lhs, const std::pair<FR, SR> & rhs)
-    {
-        return static_cast<equality_storage &>(*this)(lhs.first, rhs.first);
-    }
+template <typename key_type, typename value_type, typename key_equal>
+struct KeyOrValueEquality : functor_storage<bool, key_equal> {
+  typedef functor_storage<bool, key_equal> equality_storage;
+  KeyOrValueEquality() = default;
+  KeyOrValueEquality(const key_equal& equality) : equality_storage(equality) {}
+  bool operator()(const key_type& lhs, const key_type& rhs) {
+    return static_cast<equality_storage&>(*this)(lhs, rhs);
+  }
+  bool operator()(const key_type& lhs, const value_type& rhs) {
+    return static_cast<equality_storage&>(*this)(lhs, rhs.first);
+  }
+  bool operator()(const value_type& lhs, const key_type& rhs) {
+    return static_cast<equality_storage&>(*this)(lhs.first, rhs);
+  }
+  bool operator()(const value_type& lhs, const value_type& rhs) {
+    return static_cast<equality_storage&>(*this)(lhs.first, rhs.first);
+  }
+  template <typename F, typename S>
+  bool operator()(const key_type& lhs, const std::pair<F, S>& rhs) {
+    return static_cast<equality_storage&>(*this)(lhs, rhs.first);
+  }
+  template <typename F, typename S>
+  bool operator()(const std::pair<F, S>& lhs, const key_type& rhs) {
+    return static_cast<equality_storage&>(*this)(lhs.first, rhs);
+  }
+  template <typename F, typename S>
+  bool operator()(const value_type& lhs, const std::pair<F, S>& rhs) {
+    return static_cast<equality_storage&>(*this)(lhs.first, rhs.first);
+  }
+  template <typename F, typename S>
+  bool operator()(const std::pair<F, S>& lhs, const value_type& rhs) {
+    return static_cast<equality_storage&>(*this)(lhs.first, rhs.first);
+  }
+  template <typename FL, typename SL, typename FR, typename SR>
+  bool operator()(const std::pair<FL, SL>& lhs, const std::pair<FR, SR>& rhs) {
+    return static_cast<equality_storage&>(*this)(lhs.first, rhs.first);
+  }
 };
 static constexpr int8_t min_lookups = 4;
-template<typename T>
-struct sherwood_v3_entry
-{
-    sherwood_v3_entry()
-    {
-    }
-    sherwood_v3_entry(int8_t distance_from_desired)
-        : distance_from_desired(distance_from_desired)
-    {
-    }
-    ~sherwood_v3_entry()
-    {
-    }
+template <typename T>
+struct sherwood_v3_entry {
+  sherwood_v3_entry() {}
+  sherwood_v3_entry(int8_t distance_from_desired)
+      : distance_from_desired(distance_from_desired) {}
+  ~sherwood_v3_entry() {}
 
-    bool has_value() const
-    {
-        return distance_from_desired >= 0;
-    }
-    bool is_empty() const
-    {
-        return distance_from_desired < 0;
-    }
-    bool is_at_desired_position() const
-    {
-        return distance_from_desired <= 0;
-    }
-    template<typename... Args>
-    void emplace(int8_t distance, Args &&... args)
-    {
-        new (std::addressof(value)) T(std::forward<Args>(args)...);
-        distance_from_desired = distance;
-    }
+  bool has_value() const {
+    return distance_from_desired >= 0;
+  }
+  bool is_empty() const {
+    return distance_from_desired < 0;
+  }
+  bool is_at_desired_position() const {
+    return distance_from_desired <= 0;
+  }
+  template <typename... Args>
+  void emplace(int8_t distance, Args&&... args) {
+    new (std::addressof(value)) T(std::forward<Args>(args)...);
+    distance_from_desired = distance;
+  }
 
-    void destroy_value()
-    {
-        value.~T();
-        distance_from_desired = -1;
-    }
+  void destroy_value() {
+    value.~T();
+    distance_from_desired = -1;
+  }
 
-    int8_t distance_from_desired = -1;
-    static constexpr int8_t special_end_value = 0;
-    union { T value; };
+  int8_t distance_from_desired = -1;
+  static constexpr int8_t special_end_value = 0;
+  union {
+    T value;
+  };
 };
 
-inline int8_t log2(uint64_t value)
-{
-    static constexpr int8_t table[64] =
-    {
-        63,  0, 58,  1, 59, 47, 53,  2,
-        60, 39, 48, 27, 54, 33, 42,  3,
-        61, 51, 37, 40, 49, 18, 28, 20,
-        55, 30, 34, 11, 43, 14, 22,  4,
-        62, 57, 46, 52, 38, 26, 32, 41,
-        50, 36, 17, 19, 29, 10, 13, 21,
-        56, 45, 25, 31, 35, 16,  9, 12,
-        44, 24, 15,  8, 23,  7,  6,  5
-    };
-    value |= value >> 1;
-    value |= value >> 2;
-    value |= value >> 4;
-    value |= value >> 8;
-    value |= value >> 16;
-    value |= value >> 32;
-    return table[((value - (value >> 1)) * 0x07EDD5E59A4E28C2) >> 58];
+inline int8_t log2(uint64_t value) {
+  static constexpr int8_t table[64] = {
+      63, 0,  58, 1,  59, 47, 53, 2,  60, 39, 48, 27, 54, 33, 42, 3,
+      61, 51, 37, 40, 49, 18, 28, 20, 55, 30, 34, 11, 43, 14, 22, 4,
+      62, 57, 46, 52, 38, 26, 32, 41, 50, 36, 17, 19, 29, 10, 13, 21,
+      56, 45, 25, 31, 35, 16, 9,  12, 44, 24, 15, 8,  23, 7,  6,  5};
+  value |= value >> 1;
+  value |= value >> 2;
+  value |= value >> 4;
+  value |= value >> 8;
+  value |= value >> 16;
+  value |= value >> 32;
+  return table[((value - (value >> 1)) * 0x07EDD5E59A4E28C2) >> 58];
 }
 
-template<typename T, bool>
-struct AssignIfTrue
-{
-    void operator()(T & lhs, const T & rhs)
-    {
-        lhs = rhs;
-    }
-    void operator()(T & lhs, T && rhs)
-    {
-        lhs = std::move(rhs);
-    }
+template <typename T, bool>
+struct AssignIfTrue {
+  void operator()(T& lhs, const T& rhs) {
+    lhs = rhs;
+  }
+  void operator()(T& lhs, T&& rhs) {
+    lhs = std::move(rhs);
+  }
 };
-template<typename T>
-struct AssignIfTrue<T, false>
-{
-    void operator()(T &, const T &)
-    {
-    }
-    void operator()(T &, T &&)
-    {
-    }
+template <typename T>
+struct AssignIfTrue<T, false> {
+  void operator()(T&, const T&) {}
+  void operator()(T&, T&&) {}
 };
 
-inline uint64_t next_power_of_two(uint64_t i)
-{
-    --i;
-    i |= i >> 1;
-    i |= i >> 2;
-    i |= i >> 4;
-    i |= i >> 8;
-    i |= i >> 16;
-    i |= i >> 32;
-    ++i;
-    return i;
+inline uint64_t next_power_of_two(uint64_t i) {
+  --i;
+  i |= i >> 1;
+  i |= i >> 2;
+  i |= i >> 4;
+  i |= i >> 8;
+  i |= i >> 16;
+  i |= i >> 32;
+  ++i;
+  return i;
 }
 
 // Implementation taken from http://en.cppreference.com/w/cpp/types/void_t
 // (it takes CWG1558 into account and also works for older compilers)
-template<typename... Ts> struct make_void { typedef void type;};
-template<typename... Ts> using void_t = typename make_void<Ts...>::type;
-
-template<typename T, typename = void>
-struct HashPolicySelector
-{
-    typedef fibonacci_hash_policy type;
+template <typename... Ts>
+struct make_void {
+  typedef void type;
 };
-template<typename T>
-struct HashPolicySelector<T, void_t<typename T::hash_policy>>
-{
-    typedef typename T::hash_policy type;
+template <typename... Ts>
+using void_t = typename make_void<Ts...>::type;
+
+template <typename T, typename = void>
+struct HashPolicySelector {
+  typedef fibonacci_hash_policy type;
+};
+template <typename T>
+struct HashPolicySelector<T, void_t<typename T::hash_policy>> {
+  typedef typename T::hash_policy type;
 };
 
-template<typename T, typename FindKey, typename ArgumentHash, typename Hasher, typename ArgumentEqual, typename Equal, typename ArgumentAlloc, typename EntryAlloc>
-class sherwood_v3_table : private EntryAlloc, private Hasher, private Equal
-{
-    using Entry = detailv3::sherwood_v3_entry<T>;
-    using AllocatorTraits = std::allocator_traits<EntryAlloc>;
-    using EntryPointer = typename AllocatorTraits::pointer;
+template <
+    typename T,
+    typename FindKey,
+    typename ArgumentHash,
+    typename Hasher,
+    typename ArgumentEqual,
+    typename Equal,
+    typename ArgumentAlloc,
+    typename EntryAlloc>
+class sherwood_v3_table : private EntryAlloc, private Hasher, private Equal {
+  using Entry = detailv3::sherwood_v3_entry<T>;
+  using AllocatorTraits = std::allocator_traits<EntryAlloc>;
+  using EntryPointer = typename AllocatorTraits::pointer;
 
-public:
-    struct convertible_to_iterator;
+ public:
+  struct convertible_to_iterator;
 
-    using value_type = T;
-    using size_type = uint64_t;
-    using difference_type = std::ptrdiff_t;
-    using hasher = ArgumentHash;
-    using key_equal = ArgumentEqual;
-    using allocator_type = EntryAlloc;
-    using reference = value_type &;
-    using const_reference = const value_type &;
-    using pointer = value_type *;
-    using const_pointer = const value_type *;
+  using value_type = T;
+  using size_type = uint64_t;
+  using difference_type = std::ptrdiff_t;
+  using hasher = ArgumentHash;
+  using key_equal = ArgumentEqual;
+  using allocator_type = EntryAlloc;
+  using reference = value_type&;
+  using const_reference = const value_type&;
+  using pointer = value_type*;
+  using const_pointer = const value_type*;
 
-    sherwood_v3_table()
-    {
+  sherwood_v3_table() {}
+  explicit sherwood_v3_table(
+      size_type bucket_count,
+      const ArgumentHash& hash = ArgumentHash(),
+      const ArgumentEqual& equal = ArgumentEqual(),
+      const ArgumentAlloc& alloc = ArgumentAlloc())
+      : EntryAlloc(alloc), Hasher(hash), Equal(equal) {
+    rehash(bucket_count);
+  }
+  sherwood_v3_table(size_type bucket_count, const ArgumentAlloc& alloc)
+      : sherwood_v3_table(
+            bucket_count,
+            ArgumentHash(),
+            ArgumentEqual(),
+            alloc) {}
+  sherwood_v3_table(
+      size_type bucket_count,
+      const ArgumentHash& hash,
+      const ArgumentAlloc& alloc)
+      : sherwood_v3_table(bucket_count, hash, ArgumentEqual(), alloc) {}
+  explicit sherwood_v3_table(const ArgumentAlloc& alloc) : EntryAlloc(alloc) {}
+  template <typename It>
+  sherwood_v3_table(
+      It first,
+      It last,
+      size_type bucket_count = 0,
+      const ArgumentHash& hash = ArgumentHash(),
+      const ArgumentEqual& equal = ArgumentEqual(),
+      const ArgumentAlloc& alloc = ArgumentAlloc())
+      : sherwood_v3_table(bucket_count, hash, equal, alloc) {
+    insert(first, last);
+  }
+  template <typename It>
+  sherwood_v3_table(
+      It first,
+      It last,
+      size_type bucket_count,
+      const ArgumentAlloc& alloc)
+      : sherwood_v3_table(
+            first,
+            last,
+            bucket_count,
+            ArgumentHash(),
+            ArgumentEqual(),
+            alloc) {}
+  template <typename It>
+  sherwood_v3_table(
+      It first,
+      It last,
+      size_type bucket_count,
+      const ArgumentHash& hash,
+      const ArgumentAlloc& alloc)
+      : sherwood_v3_table(
+            first,
+            last,
+            bucket_count,
+            hash,
+            ArgumentEqual(),
+            alloc) {}
+  sherwood_v3_table(
+      std::initializer_list<T> il,
+      size_type bucket_count = 0,
+      const ArgumentHash& hash = ArgumentHash(),
+      const ArgumentEqual& equal = ArgumentEqual(),
+      const ArgumentAlloc& alloc = ArgumentAlloc())
+      : sherwood_v3_table(bucket_count, hash, equal, alloc) {
+    if (bucket_count == 0)
+      rehash(il.size());
+    insert(il.begin(), il.end());
+  }
+  sherwood_v3_table(
+      std::initializer_list<T> il,
+      size_type bucket_count,
+      const ArgumentAlloc& alloc)
+      : sherwood_v3_table(
+            il,
+            bucket_count,
+            ArgumentHash(),
+            ArgumentEqual(),
+            alloc) {}
+  sherwood_v3_table(
+      std::initializer_list<T> il,
+      size_type bucket_count,
+      const ArgumentHash& hash,
+      const ArgumentAlloc& alloc)
+      : sherwood_v3_table(il, bucket_count, hash, ArgumentEqual(), alloc) {}
+  sherwood_v3_table(const sherwood_v3_table& other)
+      : sherwood_v3_table(
+            other,
+            AllocatorTraits::select_on_container_copy_construction(
+                other.get_allocator())) {}
+  sherwood_v3_table(const sherwood_v3_table& other, const ArgumentAlloc& alloc)
+      : EntryAlloc(alloc),
+        Hasher(other),
+        Equal(other),
+        _max_load_factor(other._max_load_factor) {
+    rehash_for_other_container(other);
+    try {
+      insert(other.begin(), other.end());
+    } catch (...) {
+      clear();
+      deallocate_data(entries, num_slots_minus_one, max_lookups);
+      throw;
     }
-    explicit sherwood_v3_table(size_type bucket_count, const ArgumentHash & hash = ArgumentHash(), const ArgumentEqual & equal = ArgumentEqual(), const ArgumentAlloc & alloc = ArgumentAlloc())
-        : EntryAlloc(alloc), Hasher(hash), Equal(equal)
-    {
-        rehash(bucket_count);
-    }
-    sherwood_v3_table(size_type bucket_count, const ArgumentAlloc & alloc)
-        : sherwood_v3_table(bucket_count, ArgumentHash(), ArgumentEqual(), alloc)
-    {
-    }
-    sherwood_v3_table(size_type bucket_count, const ArgumentHash & hash, const ArgumentAlloc & alloc)
-        : sherwood_v3_table(bucket_count, hash, ArgumentEqual(), alloc)
-    {
-    }
-    explicit sherwood_v3_table(const ArgumentAlloc & alloc)
-        : EntryAlloc(alloc)
-    {
-    }
-    template<typename It>
-    sherwood_v3_table(It first, It last, size_type bucket_count = 0, const ArgumentHash & hash = ArgumentHash(), const ArgumentEqual & equal = ArgumentEqual(), const ArgumentAlloc & alloc = ArgumentAlloc())
-        : sherwood_v3_table(bucket_count, hash, equal, alloc)
-    {
-        insert(first, last);
-    }
-    template<typename It>
-    sherwood_v3_table(It first, It last, size_type bucket_count, const ArgumentAlloc & alloc)
-        : sherwood_v3_table(first, last, bucket_count, ArgumentHash(), ArgumentEqual(), alloc)
-    {
-    }
-    template<typename It>
-    sherwood_v3_table(It first, It last, size_type bucket_count, const ArgumentHash & hash, const ArgumentAlloc & alloc)
-        : sherwood_v3_table(first, last, bucket_count, hash, ArgumentEqual(), alloc)
-    {
-    }
-    sherwood_v3_table(std::initializer_list<T> il, size_type bucket_count = 0, const ArgumentHash & hash = ArgumentHash(), const ArgumentEqual & equal = ArgumentEqual(), const ArgumentAlloc & alloc = ArgumentAlloc())
-        : sherwood_v3_table(bucket_count, hash, equal, alloc)
-    {
-        if (bucket_count == 0)
-            rehash(il.size());
-        insert(il.begin(), il.end());
-    }
-    sherwood_v3_table(std::initializer_list<T> il, size_type bucket_count, const ArgumentAlloc & alloc)
-        : sherwood_v3_table(il, bucket_count, ArgumentHash(), ArgumentEqual(), alloc)
-    {
-    }
-    sherwood_v3_table(std::initializer_list<T> il, size_type bucket_count, const ArgumentHash & hash, const ArgumentAlloc & alloc)
-        : sherwood_v3_table(il, bucket_count, hash, ArgumentEqual(), alloc)
-    {
-    }
-    sherwood_v3_table(const sherwood_v3_table & other)
-        : sherwood_v3_table(other, AllocatorTraits::select_on_container_copy_construction(other.get_allocator()))
-    {
-    }
-    sherwood_v3_table(const sherwood_v3_table & other, const ArgumentAlloc & alloc)
-        : EntryAlloc(alloc), Hasher(other), Equal(other), _max_load_factor(other._max_load_factor)
-    {
-        rehash_for_other_container(other);
-        try
-        {
-            insert(other.begin(), other.end());
-        }
-        catch(...)
-        {
-            clear();
-            deallocate_data(entries, num_slots_minus_one, max_lookups);
-            throw;
-        }
-    }
-    sherwood_v3_table(sherwood_v3_table && other) noexcept
-        : EntryAlloc(std::move(other)), Hasher(std::move(other)), Equal(std::move(other))
-    {
-        swap_pointers(other);
-    }
-    sherwood_v3_table(sherwood_v3_table && other, const ArgumentAlloc & alloc) noexcept
-        : EntryAlloc(alloc), Hasher(std::move(other)), Equal(std::move(other))
-    {
-        swap_pointers(other);
-    }
-    sherwood_v3_table & operator=(const sherwood_v3_table & other)
-    {
-        if (this == std::addressof(other))
-            return *this;
+  }
+  sherwood_v3_table(sherwood_v3_table&& other) noexcept
+      : EntryAlloc(std::move(other)),
+        Hasher(std::move(other)),
+        Equal(std::move(other)) {
+    swap_pointers(other);
+  }
+  sherwood_v3_table(
+      sherwood_v3_table&& other,
+      const ArgumentAlloc& alloc) noexcept
+      : EntryAlloc(alloc), Hasher(std::move(other)), Equal(std::move(other)) {
+    swap_pointers(other);
+  }
+  sherwood_v3_table& operator=(const sherwood_v3_table& other) {
+    if (this == std::addressof(other))
+      return *this;
 
-        clear();
-        if (AllocatorTraits::propagate_on_container_copy_assignment::value)
-        {
-            if (static_cast<EntryAlloc &>(*this) != static_cast<const EntryAlloc &>(other))
-            {
-                reset_to_empty_state();
-            }
-            AssignIfTrue<EntryAlloc, AllocatorTraits::propagate_on_container_copy_assignment::value>()(*this, other);
-        }
-        _max_load_factor = other._max_load_factor;
-        static_cast<Hasher &>(*this) = other;
-        static_cast<Equal &>(*this) = other;
-        rehash_for_other_container(other);
-        insert(other.begin(), other.end());
-        return *this;
+    clear();
+    if (AllocatorTraits::propagate_on_container_copy_assignment::value) {
+      if (static_cast<EntryAlloc&>(*this) !=
+          static_cast<const EntryAlloc&>(other)) {
+        reset_to_empty_state();
+      }
+      AssignIfTrue<
+          EntryAlloc,
+          AllocatorTraits::propagate_on_container_copy_assignment::value>()(
+          *this, other);
     }
-    sherwood_v3_table & operator=(sherwood_v3_table && other) noexcept
-    {
-        if (this == std::addressof(other))
-            return *this;
-        else if (AllocatorTraits::propagate_on_container_move_assignment::value)
-        {
-            clear();
-            reset_to_empty_state();
-            AssignIfTrue<EntryAlloc, AllocatorTraits::propagate_on_container_move_assignment::value>()(*this, std::move(other));
-            swap_pointers(other);
-        }
-        else if (static_cast<EntryAlloc &>(*this) == static_cast<EntryAlloc &>(other))
-        {
-            swap_pointers(other);
-        }
-        else
-        {
-            clear();
-            _max_load_factor = other._max_load_factor;
-            rehash_for_other_container(other);
-            for (T & elem : other)
-                emplace(std::move(elem));
-            other.clear();
-        }
-        static_cast<Hasher &>(*this) = std::move(other);
-        static_cast<Equal &>(*this) = std::move(other);
-        return *this;
+    _max_load_factor = other._max_load_factor;
+    static_cast<Hasher&>(*this) = other;
+    static_cast<Equal&>(*this) = other;
+    rehash_for_other_container(other);
+    insert(other.begin(), other.end());
+    return *this;
+  }
+  sherwood_v3_table& operator=(sherwood_v3_table&& other) noexcept {
+    if (this == std::addressof(other))
+      return *this;
+    else if (AllocatorTraits::propagate_on_container_move_assignment::value) {
+      clear();
+      reset_to_empty_state();
+      AssignIfTrue<
+          EntryAlloc,
+          AllocatorTraits::propagate_on_container_move_assignment::value>()(
+          *this, std::move(other));
+      swap_pointers(other);
+    } else if (
+        static_cast<EntryAlloc&>(*this) == static_cast<EntryAlloc&>(other)) {
+      swap_pointers(other);
+    } else {
+      clear();
+      _max_load_factor = other._max_load_factor;
+      rehash_for_other_container(other);
+      for (T& elem : other)
+        emplace(std::move(elem));
+      other.clear();
     }
-    ~sherwood_v3_table()
-    {
-        clear();
-        deallocate_data(entries, num_slots_minus_one, max_lookups);
-    }
+    static_cast<Hasher&>(*this) = std::move(other);
+    static_cast<Equal&>(*this) = std::move(other);
+    return *this;
+  }
+  ~sherwood_v3_table() {
+    clear();
+    deallocate_data(entries, num_slots_minus_one, max_lookups);
+  }
 
-    const allocator_type & get_allocator() const
-    {
-        return static_cast<const allocator_type &>(*this);
-    }
-    const ArgumentEqual & key_eq() const
-    {
-        return static_cast<const ArgumentEqual &>(*this);
-    }
-    const ArgumentHash & hash_function() const
-    {
-        return static_cast<const ArgumentHash &>(*this);
-    }
+  const allocator_type& get_allocator() const {
+    return static_cast<const allocator_type&>(*this);
+  }
+  const ArgumentEqual& key_eq() const {
+    return static_cast<const ArgumentEqual&>(*this);
+  }
+  const ArgumentHash& hash_function() const {
+    return static_cast<const ArgumentHash&>(*this);
+  }
 
-    template<typename ValueType>
-    struct templated_iterator
-    {
-        templated_iterator() = default;
-        templated_iterator(EntryPointer current)
-            : current(current)
-        {
-        }
-        EntryPointer current = EntryPointer();
+  template <typename ValueType>
+  struct templated_iterator {
+    templated_iterator() = default;
+    templated_iterator(EntryPointer current) : current(current) {}
+    EntryPointer current = EntryPointer();
 
-        using iterator_category = std::forward_iterator_tag;
-        using value_type = ValueType;
-        using difference_type = ptrdiff_t;
-        using pointer = ValueType *;
-        using reference = ValueType &;
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = ValueType;
+    using difference_type = ptrdiff_t;
+    using pointer = ValueType*;
+    using reference = ValueType&;
 
-        friend bool operator==(const templated_iterator & lhs, const templated_iterator & rhs)
-        {
-            return lhs.current == rhs.current;
-        }
-        friend bool operator!=(const templated_iterator & lhs, const templated_iterator & rhs)
-        {
-            return !(lhs == rhs);
-        }
-
-        templated_iterator & operator++()
-        {
-            do
-            {
-                ++current;
-            }
-            while(current->is_empty());
-            return *this;
-        }
-        templated_iterator operator++(int)
-        {
-            templated_iterator copy(*this);
-            ++*this;
-            return copy;
-        }
-
-        ValueType & operator*() const
-        {
-            return current->value;
-        }
-        ValueType * operator->() const
-        {
-            return std::addressof(current->value);
-        }
-
-        // the template automatically disables the operator when value_type is already
-        // const, because that would cause a lot of compiler warnings otherwise.
-        template<class target_type = const value_type, class = typename std::enable_if<std::is_same<target_type, const value_type>::value && !std::is_same<target_type, value_type>::value>::type>
-        operator templated_iterator<target_type>() const
-        {
-            return { current };
-        }
-    };
-    using iterator = templated_iterator<value_type>;
-    using const_iterator = templated_iterator<const value_type>;
-
-    iterator begin()
-    {
-        for (EntryPointer it = entries;; ++it)
-        {
-            if (it->has_value())
-                return { it };
-        }
+    friend bool operator==(
+        const templated_iterator& lhs,
+        const templated_iterator& rhs) {
+      return lhs.current == rhs.current;
     }
-    const_iterator begin() const
-    {
-        for (EntryPointer it = entries;; ++it)
-        {
-            if (it->has_value())
-                return { it };
-        }
-    }
-    const_iterator cbegin() const
-    {
-        return begin();
-    }
-    iterator end()
-    {
-        return { entries + static_cast<ptrdiff_t>(num_slots_minus_one + max_lookups) };
-    }
-    const_iterator end() const
-    {
-        return { entries + static_cast<ptrdiff_t>(num_slots_minus_one + max_lookups) };
-    }
-    const_iterator cend() const
-    {
-        return end();
+    friend bool operator!=(
+        const templated_iterator& lhs,
+        const templated_iterator& rhs) {
+      return !(lhs == rhs);
     }
 
-    iterator find(const FindKey & key)
-    {
-        uint64_t index = hash_policy.index_for_hash(hash_object(key), num_slots_minus_one);
-        EntryPointer it = entries + ptrdiff_t(index);
-        for (int8_t distance = 0; it->distance_from_desired >= distance; ++distance, ++it)
-        {
-            if (compares_equal(key, it->value))
-                return { it };
-        }
-        return end();
+    templated_iterator& operator++() {
+      do {
+        ++current;
+      } while (current->is_empty());
+      return *this;
     }
-    const_iterator find(const FindKey & key) const
-    {
-        return const_cast<sherwood_v3_table *>(this)->find(key);
-    }
-    uint64_t count(const FindKey & key) const
-    {
-        return find(key) == end() ? 0 : 1;
-    }
-    std::pair<iterator, iterator> equal_range(const FindKey & key)
-    {
-        iterator found = find(key);
-        if (found == end())
-            return { found, found };
-        else
-            return { found, std::next(found) };
-    }
-    std::pair<const_iterator, const_iterator> equal_range(const FindKey & key) const
-    {
-        const_iterator found = find(key);
-        if (found == end())
-            return { found, found };
-        else
-            return { found, std::next(found) };
+    templated_iterator operator++(int) {
+      templated_iterator copy(*this);
+      ++*this;
+      return copy;
     }
 
-    template<typename Key, typename... Args>
-    std::pair<iterator, bool> emplace(Key && key, Args &&... args)
-    {
-        uint64_t index = hash_policy.index_for_hash(hash_object(key), num_slots_minus_one);
-        EntryPointer current_entry = entries + ptrdiff_t(index);
-        int8_t distance_from_desired = 0;
-        for (; current_entry->distance_from_desired >= distance_from_desired; ++current_entry, ++distance_from_desired)
-        {
-            if (compares_equal(key, current_entry->value))
-                return { { current_entry }, false };
-        }
-        return emplace_new_key(distance_from_desired, current_entry, std::forward<Key>(key), std::forward<Args>(args)...);
+    ValueType& operator*() const {
+      return current->value;
+    }
+    ValueType* operator->() const {
+      return std::addressof(current->value);
     }
 
-    std::pair<iterator, bool> insert(const value_type & value)
-    {
-        return emplace(value);
+    // the template automatically disables the operator when value_type is
+    // already const, because that would cause a lot of compiler warnings
+    // otherwise.
+    template <
+        class target_type = const value_type,
+        class = typename std::enable_if<
+            std::is_same<target_type, const value_type>::value &&
+            !std::is_same<target_type, value_type>::value>::type>
+    operator templated_iterator<target_type>() const {
+      return {current};
     }
-    std::pair<iterator, bool> insert(value_type && value)
-    {
-        return emplace(std::move(value));
-    }
-    template<typename... Args>
-    iterator emplace_hint(const_iterator, Args &&... args)
-    {
-        return emplace(std::forward<Args>(args)...).first;
-    }
-    iterator insert(const_iterator, const value_type & value)
-    {
-        return emplace(value).first;
-    }
-    iterator insert(const_iterator, value_type && value)
-    {
-        return emplace(std::move(value)).first;
-    }
+  };
+  using iterator = templated_iterator<value_type>;
+  using const_iterator = templated_iterator<const value_type>;
 
-    template<typename It>
-    void insert(It begin, It end)
-    {
-        for (; begin != end; ++begin)
-        {
-            emplace(*begin);
-        }
+  iterator begin() {
+    for (EntryPointer it = entries;; ++it) {
+      if (it->has_value())
+        return {it};
     }
-    void insert(std::initializer_list<value_type> il)
-    {
-        insert(il.begin(), il.end());
+  }
+  const_iterator begin() const {
+    for (EntryPointer it = entries;; ++it) {
+      if (it->has_value())
+        return {it};
     }
+  }
+  const_iterator cbegin() const {
+    return begin();
+  }
+  iterator end() {
+    return {entries +
+            static_cast<ptrdiff_t>(num_slots_minus_one + max_lookups)};
+  }
+  const_iterator end() const {
+    return {entries +
+            static_cast<ptrdiff_t>(num_slots_minus_one + max_lookups)};
+  }
+  const_iterator cend() const {
+    return end();
+  }
 
-    void rehash(uint64_t num_buckets)
-    {
-        num_buckets = std::max(num_buckets, static_cast<uint64_t>(std::ceil(num_elements / static_cast<double>(_max_load_factor))));
-        if (num_buckets == 0)
-        {
-            reset_to_empty_state();
-            return;
-        }
-        auto new_prime_index = hash_policy.next_size_over(num_buckets);
-        if (num_buckets == bucket_count())
-            return;
-        int8_t new_max_lookups = compute_max_lookups(num_buckets);
-        EntryPointer new_buckets(AllocatorTraits::allocate(*this, num_buckets + new_max_lookups));
-        EntryPointer special_end_item = new_buckets + static_cast<ptrdiff_t>(num_buckets + new_max_lookups - 1);
-        for (EntryPointer it = new_buckets; it != special_end_item; ++it)
-            it->distance_from_desired = -1;
-        special_end_item->distance_from_desired = Entry::special_end_value;
-        std::swap(entries, new_buckets);
-        std::swap(num_slots_minus_one, num_buckets);
-        --num_slots_minus_one;
-        hash_policy.commit(new_prime_index);
-        int8_t old_max_lookups = max_lookups;
-        max_lookups = new_max_lookups;
-        num_elements = 0;
-        for (EntryPointer it = new_buckets, end = it + static_cast<ptrdiff_t>(num_buckets + old_max_lookups); it != end; ++it)
-        {
-            if (it->has_value())
-            {
-                emplace(std::move(it->value));
-                it->destroy_value();
-            }
-        }
-        deallocate_data(new_buckets, num_buckets, old_max_lookups);
+  iterator find(const FindKey& key) {
+    uint64_t index =
+        hash_policy.index_for_hash(hash_object(key), num_slots_minus_one);
+    EntryPointer it = entries + ptrdiff_t(index);
+    for (int8_t distance = 0; it->distance_from_desired >= distance;
+         ++distance, ++it) {
+      if (compares_equal(key, it->value))
+        return {it};
     }
+    return end();
+  }
+  const_iterator find(const FindKey& key) const {
+    return const_cast<sherwood_v3_table*>(this)->find(key);
+  }
+  uint64_t count(const FindKey& key) const {
+    return find(key) == end() ? 0 : 1;
+  }
+  std::pair<iterator, iterator> equal_range(const FindKey& key) {
+    iterator found = find(key);
+    if (found == end())
+      return {found, found};
+    else
+      return {found, std::next(found)};
+  }
+  std::pair<const_iterator, const_iterator> equal_range(
+      const FindKey& key) const {
+    const_iterator found = find(key);
+    if (found == end())
+      return {found, found};
+    else
+      return {found, std::next(found)};
+  }
 
-    void reserve(uint64_t num_elements)
-    {
-        uint64_t required_buckets = num_buckets_for_reserve(num_elements);
-        if (required_buckets > bucket_count())
-            rehash(required_buckets);
+  template <typename Key, typename... Args>
+  std::pair<iterator, bool> emplace(Key&& key, Args&&... args) {
+    uint64_t index =
+        hash_policy.index_for_hash(hash_object(key), num_slots_minus_one);
+    EntryPointer current_entry = entries + ptrdiff_t(index);
+    int8_t distance_from_desired = 0;
+    for (; current_entry->distance_from_desired >= distance_from_desired;
+         ++current_entry, ++distance_from_desired) {
+      if (compares_equal(key, current_entry->value))
+        return {{current_entry}, false};
     }
+    return emplace_new_key(
+        distance_from_desired,
+        current_entry,
+        std::forward<Key>(key),
+        std::forward<Args>(args)...);
+  }
 
-    // the return value is a type that can be converted to an iterator
-    // the reason for doing this is that it's not free to find the
-    // iterator pointing at the next element. if you care about the
-    // next iterator, turn the return value into an iterator
-    convertible_to_iterator erase(const_iterator to_erase)
-    {
-        EntryPointer current = to_erase.current;
-        current->destroy_value();
+  std::pair<iterator, bool> insert(const value_type& value) {
+    return emplace(value);
+  }
+  std::pair<iterator, bool> insert(value_type&& value) {
+    return emplace(std::move(value));
+  }
+  template <typename... Args>
+  iterator emplace_hint(const_iterator, Args&&... args) {
+    return emplace(std::forward<Args>(args)...).first;
+  }
+  iterator insert(const_iterator, const value_type& value) {
+    return emplace(value).first;
+  }
+  iterator insert(const_iterator, value_type&& value) {
+    return emplace(std::move(value)).first;
+  }
+
+  template <typename It>
+  void insert(It begin, It end) {
+    for (; begin != end; ++begin) {
+      emplace(*begin);
+    }
+  }
+  void insert(std::initializer_list<value_type> il) {
+    insert(il.begin(), il.end());
+  }
+
+  void rehash(uint64_t num_buckets) {
+    num_buckets = std::max(
+        num_buckets,
+        static_cast<uint64_t>(
+            std::ceil(num_elements / static_cast<double>(_max_load_factor))));
+    if (num_buckets == 0) {
+      reset_to_empty_state();
+      return;
+    }
+    auto new_prime_index = hash_policy.next_size_over(num_buckets);
+    if (num_buckets == bucket_count())
+      return;
+    int8_t new_max_lookups = compute_max_lookups(num_buckets);
+    EntryPointer new_buckets(
+        AllocatorTraits::allocate(*this, num_buckets + new_max_lookups));
+    EntryPointer special_end_item =
+        new_buckets + static_cast<ptrdiff_t>(num_buckets + new_max_lookups - 1);
+    for (EntryPointer it = new_buckets; it != special_end_item; ++it)
+      it->distance_from_desired = -1;
+    special_end_item->distance_from_desired = Entry::special_end_value;
+    std::swap(entries, new_buckets);
+    std::swap(num_slots_minus_one, num_buckets);
+    --num_slots_minus_one;
+    hash_policy.commit(new_prime_index);
+    int8_t old_max_lookups = max_lookups;
+    max_lookups = new_max_lookups;
+    num_elements = 0;
+    for (EntryPointer
+             it = new_buckets,
+             end = it + static_cast<ptrdiff_t>(num_buckets + old_max_lookups);
+         it != end;
+         ++it) {
+      if (it->has_value()) {
+        emplace(std::move(it->value));
+        it->destroy_value();
+      }
+    }
+    deallocate_data(new_buckets, num_buckets, old_max_lookups);
+  }
+
+  void reserve(uint64_t num_elements) {
+    uint64_t required_buckets = num_buckets_for_reserve(num_elements);
+    if (required_buckets > bucket_count())
+      rehash(required_buckets);
+  }
+
+  // the return value is a type that can be converted to an iterator
+  // the reason for doing this is that it's not free to find the
+  // iterator pointing at the next element. if you care about the
+  // next iterator, turn the return value into an iterator
+  convertible_to_iterator erase(const_iterator to_erase) {
+    EntryPointer current = to_erase.current;
+    current->destroy_value();
+    --num_elements;
+    for (EntryPointer next = current + ptrdiff_t(1);
+         !next->is_at_desired_position();
+         ++current, ++next) {
+      current->emplace(next->distance_from_desired - 1, std::move(next->value));
+      next->destroy_value();
+    }
+    return {to_erase.current};
+  }
+
+  iterator erase(const_iterator begin_it, const_iterator end_it) {
+    if (begin_it == end_it)
+      return {begin_it.current};
+    for (EntryPointer it = begin_it.current, end = end_it.current; it != end;
+         ++it) {
+      if (it->has_value()) {
+        it->destroy_value();
         --num_elements;
-        for (EntryPointer next = current + ptrdiff_t(1); !next->is_at_desired_position(); ++current, ++next)
-        {
-            current->emplace(next->distance_from_desired - 1, std::move(next->value));
-            next->destroy_value();
-        }
-        return { to_erase.current };
+      }
     }
+    if (end_it == this->end())
+      return this->end();
+    ptrdiff_t num_to_move = std::min(
+        static_cast<ptrdiff_t>(end_it.current->distance_from_desired),
+        end_it.current - begin_it.current);
+    EntryPointer to_return = end_it.current - num_to_move;
+    for (EntryPointer it = end_it.current; !it->is_at_desired_position();) {
+      EntryPointer target = it - num_to_move;
+      target->emplace(
+          it->distance_from_desired - num_to_move, std::move(it->value));
+      it->destroy_value();
+      ++it;
+      num_to_move = std::min(
+          static_cast<ptrdiff_t>(it->distance_from_desired), num_to_move);
+    }
+    return {to_return};
+  }
 
-    iterator erase(const_iterator begin_it, const_iterator end_it)
-    {
-        if (begin_it == end_it)
-            return { begin_it.current };
-        for (EntryPointer it = begin_it.current, end = end_it.current; it != end; ++it)
-        {
-            if (it->has_value())
-            {
-                it->destroy_value();
-                --num_elements;
-            }
-        }
-        if (end_it == this->end())
-            return this->end();
-        ptrdiff_t num_to_move = std::min(static_cast<ptrdiff_t>(end_it.current->distance_from_desired), end_it.current - begin_it.current);
-        EntryPointer to_return = end_it.current - num_to_move;
-        for (EntryPointer it = end_it.current; !it->is_at_desired_position();)
-        {
-            EntryPointer target = it - num_to_move;
-            target->emplace(it->distance_from_desired - num_to_move, std::move(it->value));
-            it->destroy_value();
-            ++it;
-            num_to_move = std::min(static_cast<ptrdiff_t>(it->distance_from_desired), num_to_move);
-        }
-        return { to_return };
+  uint64_t erase(const FindKey& key) {
+    auto found = find(key);
+    if (found == end())
+      return 0;
+    else {
+      erase(found);
+      return 1;
     }
+  }
 
-    uint64_t erase(const FindKey & key)
-    {
-        auto found = find(key);
-        if (found == end())
-            return 0;
-        else
-        {
-            erase(found);
-            return 1;
-        }
+  void clear() {
+    for (EntryPointer it = entries,
+                      end = it +
+             static_cast<ptrdiff_t>(num_slots_minus_one + max_lookups);
+         it != end;
+         ++it) {
+      if (it->has_value())
+        it->destroy_value();
     }
+    num_elements = 0;
+  }
 
-    void clear()
-    {
-        for (EntryPointer it = entries, end = it + static_cast<ptrdiff_t>(num_slots_minus_one + max_lookups); it != end; ++it)
-        {
-            if (it->has_value())
-                it->destroy_value();
-        }
-        num_elements = 0;
-    }
+  void shrink_to_fit() {
+    rehash_for_other_container(*this);
+  }
 
-    void shrink_to_fit()
-    {
-        rehash_for_other_container(*this);
-    }
+  void swap(sherwood_v3_table& other) {
+    using std::swap;
+    swap_pointers(other);
+    swap(static_cast<ArgumentHash&>(*this), static_cast<ArgumentHash&>(other));
+    swap(
+        static_cast<ArgumentEqual&>(*this), static_cast<ArgumentEqual&>(other));
+    if (AllocatorTraits::propagate_on_container_swap::value)
+      swap(static_cast<EntryAlloc&>(*this), static_cast<EntryAlloc&>(other));
+  }
 
-    void swap(sherwood_v3_table & other)
-    {
-        using std::swap;
-        swap_pointers(other);
-        swap(static_cast<ArgumentHash &>(*this), static_cast<ArgumentHash &>(other));
-        swap(static_cast<ArgumentEqual &>(*this), static_cast<ArgumentEqual &>(other));
-        if (AllocatorTraits::propagate_on_container_swap::value)
-            swap(static_cast<EntryAlloc &>(*this), static_cast<EntryAlloc &>(other));
-    }
+  uint64_t size() const {
+    return num_elements;
+  }
+  uint64_t max_size() const {
+    return (AllocatorTraits::max_size(*this)) / sizeof(Entry);
+  }
+  uint64_t bucket_count() const {
+    return num_slots_minus_one ? num_slots_minus_one + 1 : 0;
+  }
+  size_type max_bucket_count() const {
+    return (AllocatorTraits::max_size(*this) - min_lookups) / sizeof(Entry);
+  }
+  uint64_t bucket(const FindKey& key) const {
+    return hash_policy.index_for_hash(hash_object(key), num_slots_minus_one);
+  }
+  float load_factor() const {
+    uint64_t buckets = bucket_count();
+    if (buckets)
+      return static_cast<float>(num_elements) / bucket_count();
+    else
+      return 0;
+  }
+  void max_load_factor(float value) {
+    _max_load_factor = value;
+  }
+  float max_load_factor() const {
+    return _max_load_factor;
+  }
 
-    uint64_t size() const
-    {
-        return num_elements;
-    }
-    uint64_t max_size() const
-    {
-        return (AllocatorTraits::max_size(*this)) / sizeof(Entry);
-    }
-    uint64_t bucket_count() const
-    {
-        return num_slots_minus_one ? num_slots_minus_one + 1 : 0;
-    }
-    size_type max_bucket_count() const
-    {
-        return (AllocatorTraits::max_size(*this) - min_lookups) / sizeof(Entry);
-    }
-    uint64_t bucket(const FindKey & key) const
-    {
-        return hash_policy.index_for_hash(hash_object(key), num_slots_minus_one);
-    }
-    float load_factor() const
-    {
-        uint64_t buckets = bucket_count();
-        if (buckets)
-            return static_cast<float>(num_elements) / bucket_count();
-        else
-            return 0;
-    }
-    void max_load_factor(float value)
-    {
-        _max_load_factor = value;
-    }
-    float max_load_factor() const
-    {
-        return _max_load_factor;
-    }
+  bool empty() const {
+    return num_elements == 0;
+  }
 
-    bool empty() const
-    {
-        return num_elements == 0;
-    }
+ private:
+  EntryPointer entries = empty_default_table();
+  uint64_t num_slots_minus_one = 0;
+  typename HashPolicySelector<ArgumentHash>::type hash_policy;
+  int8_t max_lookups = detailv3::min_lookups - 1;
+  float _max_load_factor = 0.5f;
+  uint64_t num_elements = 0;
 
-private:
-    EntryPointer entries = empty_default_table();
-    uint64_t num_slots_minus_one = 0;
-    typename HashPolicySelector<ArgumentHash>::type hash_policy;
-    int8_t max_lookups = detailv3::min_lookups - 1;
-    float _max_load_factor = 0.5f;
-    uint64_t num_elements = 0;
+  EntryPointer empty_default_table() {
+    EntryPointer result =
+        AllocatorTraits::allocate(*this, detailv3::min_lookups);
+    EntryPointer special_end_item =
+        result + static_cast<ptrdiff_t>(detailv3::min_lookups - 1);
+    for (EntryPointer it = result; it != special_end_item; ++it)
+      it->distance_from_desired = -1;
+    special_end_item->distance_from_desired = Entry::special_end_value;
+    return result;
+  }
 
-    EntryPointer empty_default_table()
-    {
-        EntryPointer result = AllocatorTraits::allocate(*this, detailv3::min_lookups);
-        EntryPointer special_end_item = result + static_cast<ptrdiff_t>(detailv3::min_lookups - 1);
-        for (EntryPointer it = result; it != special_end_item; ++it)
-            it->distance_from_desired = -1;
-        special_end_item->distance_from_desired = Entry::special_end_value;
-        return result;
-    }
+  static int8_t compute_max_lookups(uint64_t num_buckets) {
+    int8_t desired = detailv3::log2(num_buckets);
+    return std::max(detailv3::min_lookups, desired);
+  }
 
-    static int8_t compute_max_lookups(uint64_t num_buckets)
-    {
-        int8_t desired = detailv3::log2(num_buckets);
-        return std::max(detailv3::min_lookups, desired);
-    }
+  uint64_t num_buckets_for_reserve(uint64_t num_elements) const {
+    return static_cast<uint64_t>(std::ceil(
+        num_elements / std::min(0.5, static_cast<double>(_max_load_factor))));
+  }
+  void rehash_for_other_container(const sherwood_v3_table& other) {
+    rehash(
+        std::min(num_buckets_for_reserve(other.size()), other.bucket_count()));
+  }
 
-    uint64_t num_buckets_for_reserve(uint64_t num_elements) const
-    {
-        return static_cast<uint64_t>(std::ceil(num_elements / std::min(0.5, static_cast<double>(_max_load_factor))));
-    }
-    void rehash_for_other_container(const sherwood_v3_table & other)
-    {
-        rehash(std::min(num_buckets_for_reserve(other.size()), other.bucket_count()));
-    }
+  void swap_pointers(sherwood_v3_table& other) {
+    using std::swap;
+    swap(hash_policy, other.hash_policy);
+    swap(entries, other.entries);
+    swap(num_slots_minus_one, other.num_slots_minus_one);
+    swap(num_elements, other.num_elements);
+    swap(max_lookups, other.max_lookups);
+    swap(_max_load_factor, other._max_load_factor);
+  }
 
-    void swap_pointers(sherwood_v3_table & other)
-    {
-        using std::swap;
-        swap(hash_policy, other.hash_policy);
-        swap(entries, other.entries);
-        swap(num_slots_minus_one, other.num_slots_minus_one);
-        swap(num_elements, other.num_elements);
-        swap(max_lookups, other.max_lookups);
-        swap(_max_load_factor, other._max_load_factor);
+  template <typename Key, typename... Args>
+  SKA_NOINLINE(std::pair<iterator, bool>)
+  emplace_new_key(
+      int8_t distance_from_desired,
+      EntryPointer current_entry,
+      Key&& key,
+      Args&&... args) {
+    using std::swap;
+    if (num_slots_minus_one == 0 || distance_from_desired == max_lookups ||
+        num_elements + 1 >
+            (num_slots_minus_one + 1) * static_cast<double>(_max_load_factor)) {
+      grow();
+      return emplace(std::forward<Key>(key), std::forward<Args>(args)...);
+    } else if (current_entry->is_empty()) {
+      current_entry->emplace(
+          distance_from_desired,
+          std::forward<Key>(key),
+          std::forward<Args>(args)...);
+      ++num_elements;
+      return {{current_entry}, true};
     }
-
-    template<typename Key, typename... Args>
-    SKA_NOINLINE(std::pair<iterator, bool>) emplace_new_key(int8_t distance_from_desired, EntryPointer current_entry, Key && key, Args &&... args)
-    {
-        using std::swap;
-        if (num_slots_minus_one == 0 || distance_from_desired == max_lookups || num_elements + 1 > (num_slots_minus_one + 1) * static_cast<double>(_max_load_factor))
-        {
-            grow();
-            return emplace(std::forward<Key>(key), std::forward<Args>(args)...);
-        }
-        else if (current_entry->is_empty())
-        {
-            current_entry->emplace(distance_from_desired, std::forward<Key>(key), std::forward<Args>(args)...);
-            ++num_elements;
-            return { { current_entry }, true };
-        }
-        value_type to_insert(std::forward<Key>(key), std::forward<Args>(args)...);
+    value_type to_insert(std::forward<Key>(key), std::forward<Args>(args)...);
+    swap(distance_from_desired, current_entry->distance_from_desired);
+    swap(to_insert, current_entry->value);
+    iterator result = {current_entry};
+    for (++distance_from_desired, ++current_entry;; ++current_entry) {
+      if (current_entry->is_empty()) {
+        current_entry->emplace(distance_from_desired, std::move(to_insert));
+        ++num_elements;
+        return {result, true};
+      } else if (current_entry->distance_from_desired < distance_from_desired) {
         swap(distance_from_desired, current_entry->distance_from_desired);
         swap(to_insert, current_entry->value);
-        iterator result = { current_entry };
-        for (++distance_from_desired, ++current_entry;; ++current_entry)
-        {
-            if (current_entry->is_empty())
-            {
-                current_entry->emplace(distance_from_desired, std::move(to_insert));
-                ++num_elements;
-                return { result, true };
-            }
-            else if (current_entry->distance_from_desired < distance_from_desired)
-            {
-                swap(distance_from_desired, current_entry->distance_from_desired);
-                swap(to_insert, current_entry->value);
-                ++distance_from_desired;
-            }
-            else
-            {
-                ++distance_from_desired;
-                if (distance_from_desired == max_lookups)
-                {
-                    swap(to_insert, result.current->value);
-                    grow();
-                    return emplace(std::move(to_insert));
-                }
-            }
+        ++distance_from_desired;
+      } else {
+        ++distance_from_desired;
+        if (distance_from_desired == max_lookups) {
+          swap(to_insert, result.current->value);
+          grow();
+          return emplace(std::move(to_insert));
         }
+      }
     }
+  }
 
-    void grow()
-    {
-        rehash(std::max(uint64_t(4), 2 * bucket_count()));
+  void grow() {
+    rehash(std::max(uint64_t(4), 2 * bucket_count()));
+  }
+
+  void deallocate_data(
+      EntryPointer begin,
+      uint64_t num_slots_minus_one,
+      int8_t max_lookups) {
+    AllocatorTraits::deallocate(
+        *this, begin, num_slots_minus_one + max_lookups + 1);
+  }
+
+  void reset_to_empty_state() {
+    deallocate_data(entries, num_slots_minus_one, max_lookups);
+    entries = empty_default_table();
+    num_slots_minus_one = 0;
+    hash_policy.reset();
+    max_lookups = detailv3::min_lookups - 1;
+  }
+
+  template <typename U>
+  uint64_t hash_object(const U& key) {
+    return static_cast<Hasher&>(*this)(key);
+  }
+  template <typename U>
+  uint64_t hash_object(const U& key) const {
+    return static_cast<const Hasher&>(*this)(key);
+  }
+  template <typename L, typename R>
+  bool compares_equal(const L& lhs, const R& rhs) {
+    return static_cast<Equal&>(*this)(lhs, rhs);
+  }
+
+ public:
+  struct convertible_to_iterator {
+    EntryPointer it;
+
+    operator iterator() {
+      if (it->has_value())
+        return {it};
+      else
+        return ++iterator{it};
     }
-
-    void deallocate_data(EntryPointer begin, uint64_t num_slots_minus_one, int8_t max_lookups)
-    {
-        AllocatorTraits::deallocate(*this, begin, num_slots_minus_one + max_lookups + 1);
+    operator const_iterator() {
+      if (it->has_value())
+        return {it};
+      else
+        return ++const_iterator{it};
     }
-
-    void reset_to_empty_state()
-    {
-        deallocate_data(entries, num_slots_minus_one, max_lookups);
-        entries = empty_default_table();
-        num_slots_minus_one = 0;
-        hash_policy.reset();
-        max_lookups = detailv3::min_lookups - 1;
-    }
-
-    template<typename U>
-    uint64_t hash_object(const U & key)
-    {
-        return static_cast<Hasher &>(*this)(key);
-    }
-    template<typename U>
-    uint64_t hash_object(const U & key) const
-    {
-        return static_cast<const Hasher &>(*this)(key);
-    }
-    template<typename L, typename R>
-    bool compares_equal(const L & lhs, const R & rhs)
-    {
-        return static_cast<Equal &>(*this)(lhs, rhs);
-    }
-
-public:
-    struct convertible_to_iterator
-    {
-        EntryPointer it;
-
-        operator iterator()
-        {
-            if (it->has_value())
-                return { it };
-            else
-                return ++iterator{it};
-        }
-        operator const_iterator()
-        {
-            if (it->has_value())
-                return { it };
-            else
-                return ++const_iterator{it};
-        }
-    };
-
+  };
 };
-}
+} // namespace detailv3
 
-struct prime_number_hash_policy
-{
-    static uint64_t mod0(uint64_t) { return 0llu; }
-    static uint64_t mod2(uint64_t hash) { return hash % 2llu; }
-    static uint64_t mod3(uint64_t hash) { return hash % 3llu; }
-    static uint64_t mod5(uint64_t hash) { return hash % 5llu; }
-    static uint64_t mod7(uint64_t hash) { return hash % 7llu; }
-    static uint64_t mod11(uint64_t hash) { return hash % 11llu; }
-    static uint64_t mod13(uint64_t hash) { return hash % 13llu; }
-    static uint64_t mod17(uint64_t hash) { return hash % 17llu; }
-    static uint64_t mod23(uint64_t hash) { return hash % 23llu; }
-    static uint64_t mod29(uint64_t hash) { return hash % 29llu; }
-    static uint64_t mod37(uint64_t hash) { return hash % 37llu; }
-    static uint64_t mod47(uint64_t hash) { return hash % 47llu; }
-    static uint64_t mod59(uint64_t hash) { return hash % 59llu; }
-    static uint64_t mod73(uint64_t hash) { return hash % 73llu; }
-    static uint64_t mod97(uint64_t hash) { return hash % 97llu; }
-    static uint64_t mod127(uint64_t hash) { return hash % 127llu; }
-    static uint64_t mod151(uint64_t hash) { return hash % 151llu; }
-    static uint64_t mod197(uint64_t hash) { return hash % 197llu; }
-    static uint64_t mod251(uint64_t hash) { return hash % 251llu; }
-    static uint64_t mod313(uint64_t hash) { return hash % 313llu; }
-    static uint64_t mod397(uint64_t hash) { return hash % 397llu; }
-    static uint64_t mod499(uint64_t hash) { return hash % 499llu; }
-    static uint64_t mod631(uint64_t hash) { return hash % 631llu; }
-    static uint64_t mod797(uint64_t hash) { return hash % 797llu; }
-    static uint64_t mod1009(uint64_t hash) { return hash % 1009llu; }
-    static uint64_t mod1259(uint64_t hash) { return hash % 1259llu; }
-    static uint64_t mod1597(uint64_t hash) { return hash % 1597llu; }
-    static uint64_t mod2011(uint64_t hash) { return hash % 2011llu; }
-    static uint64_t mod2539(uint64_t hash) { return hash % 2539llu; }
-    static uint64_t mod3203(uint64_t hash) { return hash % 3203llu; }
-    static uint64_t mod4027(uint64_t hash) { return hash % 4027llu; }
-    static uint64_t mod5087(uint64_t hash) { return hash % 5087llu; }
-    static uint64_t mod6421(uint64_t hash) { return hash % 6421llu; }
-    static uint64_t mod8089(uint64_t hash) { return hash % 8089llu; }
-    static uint64_t mod10193(uint64_t hash) { return hash % 10193llu; }
-    static uint64_t mod12853(uint64_t hash) { return hash % 12853llu; }
-    static uint64_t mod16193(uint64_t hash) { return hash % 16193llu; }
-    static uint64_t mod20399(uint64_t hash) { return hash % 20399llu; }
-    static uint64_t mod25717(uint64_t hash) { return hash % 25717llu; }
-    static uint64_t mod32401(uint64_t hash) { return hash % 32401llu; }
-    static uint64_t mod40823(uint64_t hash) { return hash % 40823llu; }
-    static uint64_t mod51437(uint64_t hash) { return hash % 51437llu; }
-    static uint64_t mod64811(uint64_t hash) { return hash % 64811llu; }
-    static uint64_t mod81649(uint64_t hash) { return hash % 81649llu; }
-    static uint64_t mod102877(uint64_t hash) { return hash % 102877llu; }
-    static uint64_t mod129607(uint64_t hash) { return hash % 129607llu; }
-    static uint64_t mod163307(uint64_t hash) { return hash % 163307llu; }
-    static uint64_t mod205759(uint64_t hash) { return hash % 205759llu; }
-    static uint64_t mod259229(uint64_t hash) { return hash % 259229llu; }
-    static uint64_t mod326617(uint64_t hash) { return hash % 326617llu; }
-    static uint64_t mod411527(uint64_t hash) { return hash % 411527llu; }
-    static uint64_t mod518509(uint64_t hash) { return hash % 518509llu; }
-    static uint64_t mod653267(uint64_t hash) { return hash % 653267llu; }
-    static uint64_t mod823117(uint64_t hash) { return hash % 823117llu; }
-    static uint64_t mod1037059(uint64_t hash) { return hash % 1037059llu; }
-    static uint64_t mod1306601(uint64_t hash) { return hash % 1306601llu; }
-    static uint64_t mod1646237(uint64_t hash) { return hash % 1646237llu; }
-    static uint64_t mod2074129(uint64_t hash) { return hash % 2074129llu; }
-    static uint64_t mod2613229(uint64_t hash) { return hash % 2613229llu; }
-    static uint64_t mod3292489(uint64_t hash) { return hash % 3292489llu; }
-    static uint64_t mod4148279(uint64_t hash) { return hash % 4148279llu; }
-    static uint64_t mod5226491(uint64_t hash) { return hash % 5226491llu; }
-    static uint64_t mod6584983(uint64_t hash) { return hash % 6584983llu; }
-    static uint64_t mod8296553(uint64_t hash) { return hash % 8296553llu; }
-    static uint64_t mod10453007(uint64_t hash) { return hash % 10453007llu; }
-    static uint64_t mod13169977(uint64_t hash) { return hash % 13169977llu; }
-    static uint64_t mod16593127(uint64_t hash) { return hash % 16593127llu; }
-    static uint64_t mod20906033(uint64_t hash) { return hash % 20906033llu; }
-    static uint64_t mod26339969(uint64_t hash) { return hash % 26339969llu; }
-    static uint64_t mod33186281(uint64_t hash) { return hash % 33186281llu; }
-    static uint64_t mod41812097(uint64_t hash) { return hash % 41812097llu; }
-    static uint64_t mod52679969(uint64_t hash) { return hash % 52679969llu; }
-    static uint64_t mod66372617(uint64_t hash) { return hash % 66372617llu; }
-    static uint64_t mod83624237(uint64_t hash) { return hash % 83624237llu; }
-    static uint64_t mod105359939(uint64_t hash) { return hash % 105359939llu; }
-    static uint64_t mod132745199(uint64_t hash) { return hash % 132745199llu; }
-    static uint64_t mod167248483(uint64_t hash) { return hash % 167248483llu; }
-    static uint64_t mod210719881(uint64_t hash) { return hash % 210719881llu; }
-    static uint64_t mod265490441(uint64_t hash) { return hash % 265490441llu; }
-    static uint64_t mod334496971(uint64_t hash) { return hash % 334496971llu; }
-    static uint64_t mod421439783(uint64_t hash) { return hash % 421439783llu; }
-    static uint64_t mod530980861(uint64_t hash) { return hash % 530980861llu; }
-    static uint64_t mod668993977(uint64_t hash) { return hash % 668993977llu; }
-    static uint64_t mod842879579(uint64_t hash) { return hash % 842879579llu; }
-    static uint64_t mod1061961721(uint64_t hash) { return hash % 1061961721llu; }
-    static uint64_t mod1337987929(uint64_t hash) { return hash % 1337987929llu; }
-    static uint64_t mod1685759167(uint64_t hash) { return hash % 1685759167llu; }
-    static uint64_t mod2123923447(uint64_t hash) { return hash % 2123923447llu; }
-    static uint64_t mod2675975881(uint64_t hash) { return hash % 2675975881llu; }
-    static uint64_t mod3371518343(uint64_t hash) { return hash % 3371518343llu; }
-    static uint64_t mod4247846927(uint64_t hash) { return hash % 4247846927llu; }
-    static uint64_t mod5351951779(uint64_t hash) { return hash % 5351951779llu; }
-    static uint64_t mod6743036717(uint64_t hash) { return hash % 6743036717llu; }
-    static uint64_t mod8495693897(uint64_t hash) { return hash % 8495693897llu; }
-    static uint64_t mod10703903591(uint64_t hash) { return hash % 10703903591llu; }
-    static uint64_t mod13486073473(uint64_t hash) { return hash % 13486073473llu; }
-    static uint64_t mod16991387857(uint64_t hash) { return hash % 16991387857llu; }
-    static uint64_t mod21407807219(uint64_t hash) { return hash % 21407807219llu; }
-    static uint64_t mod26972146961(uint64_t hash) { return hash % 26972146961llu; }
-    static uint64_t mod33982775741(uint64_t hash) { return hash % 33982775741llu; }
-    static uint64_t mod42815614441(uint64_t hash) { return hash % 42815614441llu; }
-    static uint64_t mod53944293929(uint64_t hash) { return hash % 53944293929llu; }
-    static uint64_t mod67965551447(uint64_t hash) { return hash % 67965551447llu; }
-    static uint64_t mod85631228929(uint64_t hash) { return hash % 85631228929llu; }
-    static uint64_t mod107888587883(uint64_t hash) { return hash % 107888587883llu; }
-    static uint64_t mod135931102921(uint64_t hash) { return hash % 135931102921llu; }
-    static uint64_t mod171262457903(uint64_t hash) { return hash % 171262457903llu; }
-    static uint64_t mod215777175787(uint64_t hash) { return hash % 215777175787llu; }
-    static uint64_t mod271862205833(uint64_t hash) { return hash % 271862205833llu; }
-    static uint64_t mod342524915839(uint64_t hash) { return hash % 342524915839llu; }
-    static uint64_t mod431554351609(uint64_t hash) { return hash % 431554351609llu; }
-    static uint64_t mod543724411781(uint64_t hash) { return hash % 543724411781llu; }
-    static uint64_t mod685049831731(uint64_t hash) { return hash % 685049831731llu; }
-    static uint64_t mod863108703229(uint64_t hash) { return hash % 863108703229llu; }
-    static uint64_t mod1087448823553(uint64_t hash) { return hash % 1087448823553llu; }
-    static uint64_t mod1370099663459(uint64_t hash) { return hash % 1370099663459llu; }
-    static uint64_t mod1726217406467(uint64_t hash) { return hash % 1726217406467llu; }
-    static uint64_t mod2174897647073(uint64_t hash) { return hash % 2174897647073llu; }
-    static uint64_t mod2740199326961(uint64_t hash) { return hash % 2740199326961llu; }
-    static uint64_t mod3452434812973(uint64_t hash) { return hash % 3452434812973llu; }
-    static uint64_t mod4349795294267(uint64_t hash) { return hash % 4349795294267llu; }
-    static uint64_t mod5480398654009(uint64_t hash) { return hash % 5480398654009llu; }
-    static uint64_t mod6904869625999(uint64_t hash) { return hash % 6904869625999llu; }
-    static uint64_t mod8699590588571(uint64_t hash) { return hash % 8699590588571llu; }
-    static uint64_t mod10960797308051(uint64_t hash) { return hash % 10960797308051llu; }
-    static uint64_t mod13809739252051(uint64_t hash) { return hash % 13809739252051llu; }
-    static uint64_t mod17399181177241(uint64_t hash) { return hash % 17399181177241llu; }
-    static uint64_t mod21921594616111(uint64_t hash) { return hash % 21921594616111llu; }
-    static uint64_t mod27619478504183(uint64_t hash) { return hash % 27619478504183llu; }
-    static uint64_t mod34798362354533(uint64_t hash) { return hash % 34798362354533llu; }
-    static uint64_t mod43843189232363(uint64_t hash) { return hash % 43843189232363llu; }
-    static uint64_t mod55238957008387(uint64_t hash) { return hash % 55238957008387llu; }
-    static uint64_t mod69596724709081(uint64_t hash) { return hash % 69596724709081llu; }
-    static uint64_t mod87686378464759(uint64_t hash) { return hash % 87686378464759llu; }
-    static uint64_t mod110477914016779(uint64_t hash) { return hash % 110477914016779llu; }
-    static uint64_t mod139193449418173(uint64_t hash) { return hash % 139193449418173llu; }
-    static uint64_t mod175372756929481(uint64_t hash) { return hash % 175372756929481llu; }
-    static uint64_t mod220955828033581(uint64_t hash) { return hash % 220955828033581llu; }
-    static uint64_t mod278386898836457(uint64_t hash) { return hash % 278386898836457llu; }
-    static uint64_t mod350745513859007(uint64_t hash) { return hash % 350745513859007llu; }
-    static uint64_t mod441911656067171(uint64_t hash) { return hash % 441911656067171llu; }
-    static uint64_t mod556773797672909(uint64_t hash) { return hash % 556773797672909llu; }
-    static uint64_t mod701491027718027(uint64_t hash) { return hash % 701491027718027llu; }
-    static uint64_t mod883823312134381(uint64_t hash) { return hash % 883823312134381llu; }
-    static uint64_t mod1113547595345903(uint64_t hash) { return hash % 1113547595345903llu; }
-    static uint64_t mod1402982055436147(uint64_t hash) { return hash % 1402982055436147llu; }
-    static uint64_t mod1767646624268779(uint64_t hash) { return hash % 1767646624268779llu; }
-    static uint64_t mod2227095190691797(uint64_t hash) { return hash % 2227095190691797llu; }
-    static uint64_t mod2805964110872297(uint64_t hash) { return hash % 2805964110872297llu; }
-    static uint64_t mod3535293248537579(uint64_t hash) { return hash % 3535293248537579llu; }
-    static uint64_t mod4454190381383713(uint64_t hash) { return hash % 4454190381383713llu; }
-    static uint64_t mod5611928221744609(uint64_t hash) { return hash % 5611928221744609llu; }
-    static uint64_t mod7070586497075177(uint64_t hash) { return hash % 7070586497075177llu; }
-    static uint64_t mod8908380762767489(uint64_t hash) { return hash % 8908380762767489llu; }
-    static uint64_t mod11223856443489329(uint64_t hash) { return hash % 11223856443489329llu; }
-    static uint64_t mod14141172994150357(uint64_t hash) { return hash % 14141172994150357llu; }
-    static uint64_t mod17816761525534927(uint64_t hash) { return hash % 17816761525534927llu; }
-    static uint64_t mod22447712886978529(uint64_t hash) { return hash % 22447712886978529llu; }
-    static uint64_t mod28282345988300791(uint64_t hash) { return hash % 28282345988300791llu; }
-    static uint64_t mod35633523051069991(uint64_t hash) { return hash % 35633523051069991llu; }
-    static uint64_t mod44895425773957261(uint64_t hash) { return hash % 44895425773957261llu; }
-    static uint64_t mod56564691976601587(uint64_t hash) { return hash % 56564691976601587llu; }
-    static uint64_t mod71267046102139967(uint64_t hash) { return hash % 71267046102139967llu; }
-    static uint64_t mod89790851547914507(uint64_t hash) { return hash % 89790851547914507llu; }
-    static uint64_t mod113129383953203213(uint64_t hash) { return hash % 113129383953203213llu; }
-    static uint64_t mod142534092204280003(uint64_t hash) { return hash % 142534092204280003llu; }
-    static uint64_t mod179581703095829107(uint64_t hash) { return hash % 179581703095829107llu; }
-    static uint64_t mod226258767906406483(uint64_t hash) { return hash % 226258767906406483llu; }
-    static uint64_t mod285068184408560057(uint64_t hash) { return hash % 285068184408560057llu; }
-    static uint64_t mod359163406191658253(uint64_t hash) { return hash % 359163406191658253llu; }
-    static uint64_t mod452517535812813007(uint64_t hash) { return hash % 452517535812813007llu; }
-    static uint64_t mod570136368817120201(uint64_t hash) { return hash % 570136368817120201llu; }
-    static uint64_t mod718326812383316683(uint64_t hash) { return hash % 718326812383316683llu; }
-    static uint64_t mod905035071625626043(uint64_t hash) { return hash % 905035071625626043llu; }
-    static uint64_t mod1140272737634240411(uint64_t hash) { return hash % 1140272737634240411llu; }
-    static uint64_t mod1436653624766633509(uint64_t hash) { return hash % 1436653624766633509llu; }
-    static uint64_t mod1810070143251252131(uint64_t hash) { return hash % 1810070143251252131llu; }
-    static uint64_t mod2280545475268481167(uint64_t hash) { return hash % 2280545475268481167llu; }
-    static uint64_t mod2873307249533267101(uint64_t hash) { return hash % 2873307249533267101llu; }
-    static uint64_t mod3620140286502504283(uint64_t hash) { return hash % 3620140286502504283llu; }
-    static uint64_t mod4561090950536962147(uint64_t hash) { return hash % 4561090950536962147llu; }
-    static uint64_t mod5746614499066534157(uint64_t hash) { return hash % 5746614499066534157llu; }
-    static uint64_t mod7240280573005008577(uint64_t hash) { return hash % 7240280573005008577llu; }
-    static uint64_t mod9122181901073924329(uint64_t hash) { return hash % 9122181901073924329llu; }
-    static uint64_t mod11493228998133068689(uint64_t hash) { return hash % 11493228998133068689llu; }
-    static uint64_t mod14480561146010017169(uint64_t hash) { return hash % 14480561146010017169llu; }
-    static uint64_t mod18446744073709551557(uint64_t hash) { return hash % 18446744073709551557llu; }
+struct prime_number_hash_policy {
+  static uint64_t mod0(uint64_t) {
+    return 0llu;
+  }
+  static uint64_t mod2(uint64_t hash) {
+    return hash % 2llu;
+  }
+  static uint64_t mod3(uint64_t hash) {
+    return hash % 3llu;
+  }
+  static uint64_t mod5(uint64_t hash) {
+    return hash % 5llu;
+  }
+  static uint64_t mod7(uint64_t hash) {
+    return hash % 7llu;
+  }
+  static uint64_t mod11(uint64_t hash) {
+    return hash % 11llu;
+  }
+  static uint64_t mod13(uint64_t hash) {
+    return hash % 13llu;
+  }
+  static uint64_t mod17(uint64_t hash) {
+    return hash % 17llu;
+  }
+  static uint64_t mod23(uint64_t hash) {
+    return hash % 23llu;
+  }
+  static uint64_t mod29(uint64_t hash) {
+    return hash % 29llu;
+  }
+  static uint64_t mod37(uint64_t hash) {
+    return hash % 37llu;
+  }
+  static uint64_t mod47(uint64_t hash) {
+    return hash % 47llu;
+  }
+  static uint64_t mod59(uint64_t hash) {
+    return hash % 59llu;
+  }
+  static uint64_t mod73(uint64_t hash) {
+    return hash % 73llu;
+  }
+  static uint64_t mod97(uint64_t hash) {
+    return hash % 97llu;
+  }
+  static uint64_t mod127(uint64_t hash) {
+    return hash % 127llu;
+  }
+  static uint64_t mod151(uint64_t hash) {
+    return hash % 151llu;
+  }
+  static uint64_t mod197(uint64_t hash) {
+    return hash % 197llu;
+  }
+  static uint64_t mod251(uint64_t hash) {
+    return hash % 251llu;
+  }
+  static uint64_t mod313(uint64_t hash) {
+    return hash % 313llu;
+  }
+  static uint64_t mod397(uint64_t hash) {
+    return hash % 397llu;
+  }
+  static uint64_t mod499(uint64_t hash) {
+    return hash % 499llu;
+  }
+  static uint64_t mod631(uint64_t hash) {
+    return hash % 631llu;
+  }
+  static uint64_t mod797(uint64_t hash) {
+    return hash % 797llu;
+  }
+  static uint64_t mod1009(uint64_t hash) {
+    return hash % 1009llu;
+  }
+  static uint64_t mod1259(uint64_t hash) {
+    return hash % 1259llu;
+  }
+  static uint64_t mod1597(uint64_t hash) {
+    return hash % 1597llu;
+  }
+  static uint64_t mod2011(uint64_t hash) {
+    return hash % 2011llu;
+  }
+  static uint64_t mod2539(uint64_t hash) {
+    return hash % 2539llu;
+  }
+  static uint64_t mod3203(uint64_t hash) {
+    return hash % 3203llu;
+  }
+  static uint64_t mod4027(uint64_t hash) {
+    return hash % 4027llu;
+  }
+  static uint64_t mod5087(uint64_t hash) {
+    return hash % 5087llu;
+  }
+  static uint64_t mod6421(uint64_t hash) {
+    return hash % 6421llu;
+  }
+  static uint64_t mod8089(uint64_t hash) {
+    return hash % 8089llu;
+  }
+  static uint64_t mod10193(uint64_t hash) {
+    return hash % 10193llu;
+  }
+  static uint64_t mod12853(uint64_t hash) {
+    return hash % 12853llu;
+  }
+  static uint64_t mod16193(uint64_t hash) {
+    return hash % 16193llu;
+  }
+  static uint64_t mod20399(uint64_t hash) {
+    return hash % 20399llu;
+  }
+  static uint64_t mod25717(uint64_t hash) {
+    return hash % 25717llu;
+  }
+  static uint64_t mod32401(uint64_t hash) {
+    return hash % 32401llu;
+  }
+  static uint64_t mod40823(uint64_t hash) {
+    return hash % 40823llu;
+  }
+  static uint64_t mod51437(uint64_t hash) {
+    return hash % 51437llu;
+  }
+  static uint64_t mod64811(uint64_t hash) {
+    return hash % 64811llu;
+  }
+  static uint64_t mod81649(uint64_t hash) {
+    return hash % 81649llu;
+  }
+  static uint64_t mod102877(uint64_t hash) {
+    return hash % 102877llu;
+  }
+  static uint64_t mod129607(uint64_t hash) {
+    return hash % 129607llu;
+  }
+  static uint64_t mod163307(uint64_t hash) {
+    return hash % 163307llu;
+  }
+  static uint64_t mod205759(uint64_t hash) {
+    return hash % 205759llu;
+  }
+  static uint64_t mod259229(uint64_t hash) {
+    return hash % 259229llu;
+  }
+  static uint64_t mod326617(uint64_t hash) {
+    return hash % 326617llu;
+  }
+  static uint64_t mod411527(uint64_t hash) {
+    return hash % 411527llu;
+  }
+  static uint64_t mod518509(uint64_t hash) {
+    return hash % 518509llu;
+  }
+  static uint64_t mod653267(uint64_t hash) {
+    return hash % 653267llu;
+  }
+  static uint64_t mod823117(uint64_t hash) {
+    return hash % 823117llu;
+  }
+  static uint64_t mod1037059(uint64_t hash) {
+    return hash % 1037059llu;
+  }
+  static uint64_t mod1306601(uint64_t hash) {
+    return hash % 1306601llu;
+  }
+  static uint64_t mod1646237(uint64_t hash) {
+    return hash % 1646237llu;
+  }
+  static uint64_t mod2074129(uint64_t hash) {
+    return hash % 2074129llu;
+  }
+  static uint64_t mod2613229(uint64_t hash) {
+    return hash % 2613229llu;
+  }
+  static uint64_t mod3292489(uint64_t hash) {
+    return hash % 3292489llu;
+  }
+  static uint64_t mod4148279(uint64_t hash) {
+    return hash % 4148279llu;
+  }
+  static uint64_t mod5226491(uint64_t hash) {
+    return hash % 5226491llu;
+  }
+  static uint64_t mod6584983(uint64_t hash) {
+    return hash % 6584983llu;
+  }
+  static uint64_t mod8296553(uint64_t hash) {
+    return hash % 8296553llu;
+  }
+  static uint64_t mod10453007(uint64_t hash) {
+    return hash % 10453007llu;
+  }
+  static uint64_t mod13169977(uint64_t hash) {
+    return hash % 13169977llu;
+  }
+  static uint64_t mod16593127(uint64_t hash) {
+    return hash % 16593127llu;
+  }
+  static uint64_t mod20906033(uint64_t hash) {
+    return hash % 20906033llu;
+  }
+  static uint64_t mod26339969(uint64_t hash) {
+    return hash % 26339969llu;
+  }
+  static uint64_t mod33186281(uint64_t hash) {
+    return hash % 33186281llu;
+  }
+  static uint64_t mod41812097(uint64_t hash) {
+    return hash % 41812097llu;
+  }
+  static uint64_t mod52679969(uint64_t hash) {
+    return hash % 52679969llu;
+  }
+  static uint64_t mod66372617(uint64_t hash) {
+    return hash % 66372617llu;
+  }
+  static uint64_t mod83624237(uint64_t hash) {
+    return hash % 83624237llu;
+  }
+  static uint64_t mod105359939(uint64_t hash) {
+    return hash % 105359939llu;
+  }
+  static uint64_t mod132745199(uint64_t hash) {
+    return hash % 132745199llu;
+  }
+  static uint64_t mod167248483(uint64_t hash) {
+    return hash % 167248483llu;
+  }
+  static uint64_t mod210719881(uint64_t hash) {
+    return hash % 210719881llu;
+  }
+  static uint64_t mod265490441(uint64_t hash) {
+    return hash % 265490441llu;
+  }
+  static uint64_t mod334496971(uint64_t hash) {
+    return hash % 334496971llu;
+  }
+  static uint64_t mod421439783(uint64_t hash) {
+    return hash % 421439783llu;
+  }
+  static uint64_t mod530980861(uint64_t hash) {
+    return hash % 530980861llu;
+  }
+  static uint64_t mod668993977(uint64_t hash) {
+    return hash % 668993977llu;
+  }
+  static uint64_t mod842879579(uint64_t hash) {
+    return hash % 842879579llu;
+  }
+  static uint64_t mod1061961721(uint64_t hash) {
+    return hash % 1061961721llu;
+  }
+  static uint64_t mod1337987929(uint64_t hash) {
+    return hash % 1337987929llu;
+  }
+  static uint64_t mod1685759167(uint64_t hash) {
+    return hash % 1685759167llu;
+  }
+  static uint64_t mod2123923447(uint64_t hash) {
+    return hash % 2123923447llu;
+  }
+  static uint64_t mod2675975881(uint64_t hash) {
+    return hash % 2675975881llu;
+  }
+  static uint64_t mod3371518343(uint64_t hash) {
+    return hash % 3371518343llu;
+  }
+  static uint64_t mod4247846927(uint64_t hash) {
+    return hash % 4247846927llu;
+  }
+  static uint64_t mod5351951779(uint64_t hash) {
+    return hash % 5351951779llu;
+  }
+  static uint64_t mod6743036717(uint64_t hash) {
+    return hash % 6743036717llu;
+  }
+  static uint64_t mod8495693897(uint64_t hash) {
+    return hash % 8495693897llu;
+  }
+  static uint64_t mod10703903591(uint64_t hash) {
+    return hash % 10703903591llu;
+  }
+  static uint64_t mod13486073473(uint64_t hash) {
+    return hash % 13486073473llu;
+  }
+  static uint64_t mod16991387857(uint64_t hash) {
+    return hash % 16991387857llu;
+  }
+  static uint64_t mod21407807219(uint64_t hash) {
+    return hash % 21407807219llu;
+  }
+  static uint64_t mod26972146961(uint64_t hash) {
+    return hash % 26972146961llu;
+  }
+  static uint64_t mod33982775741(uint64_t hash) {
+    return hash % 33982775741llu;
+  }
+  static uint64_t mod42815614441(uint64_t hash) {
+    return hash % 42815614441llu;
+  }
+  static uint64_t mod53944293929(uint64_t hash) {
+    return hash % 53944293929llu;
+  }
+  static uint64_t mod67965551447(uint64_t hash) {
+    return hash % 67965551447llu;
+  }
+  static uint64_t mod85631228929(uint64_t hash) {
+    return hash % 85631228929llu;
+  }
+  static uint64_t mod107888587883(uint64_t hash) {
+    return hash % 107888587883llu;
+  }
+  static uint64_t mod135931102921(uint64_t hash) {
+    return hash % 135931102921llu;
+  }
+  static uint64_t mod171262457903(uint64_t hash) {
+    return hash % 171262457903llu;
+  }
+  static uint64_t mod215777175787(uint64_t hash) {
+    return hash % 215777175787llu;
+  }
+  static uint64_t mod271862205833(uint64_t hash) {
+    return hash % 271862205833llu;
+  }
+  static uint64_t mod342524915839(uint64_t hash) {
+    return hash % 342524915839llu;
+  }
+  static uint64_t mod431554351609(uint64_t hash) {
+    return hash % 431554351609llu;
+  }
+  static uint64_t mod543724411781(uint64_t hash) {
+    return hash % 543724411781llu;
+  }
+  static uint64_t mod685049831731(uint64_t hash) {
+    return hash % 685049831731llu;
+  }
+  static uint64_t mod863108703229(uint64_t hash) {
+    return hash % 863108703229llu;
+  }
+  static uint64_t mod1087448823553(uint64_t hash) {
+    return hash % 1087448823553llu;
+  }
+  static uint64_t mod1370099663459(uint64_t hash) {
+    return hash % 1370099663459llu;
+  }
+  static uint64_t mod1726217406467(uint64_t hash) {
+    return hash % 1726217406467llu;
+  }
+  static uint64_t mod2174897647073(uint64_t hash) {
+    return hash % 2174897647073llu;
+  }
+  static uint64_t mod2740199326961(uint64_t hash) {
+    return hash % 2740199326961llu;
+  }
+  static uint64_t mod3452434812973(uint64_t hash) {
+    return hash % 3452434812973llu;
+  }
+  static uint64_t mod4349795294267(uint64_t hash) {
+    return hash % 4349795294267llu;
+  }
+  static uint64_t mod5480398654009(uint64_t hash) {
+    return hash % 5480398654009llu;
+  }
+  static uint64_t mod6904869625999(uint64_t hash) {
+    return hash % 6904869625999llu;
+  }
+  static uint64_t mod8699590588571(uint64_t hash) {
+    return hash % 8699590588571llu;
+  }
+  static uint64_t mod10960797308051(uint64_t hash) {
+    return hash % 10960797308051llu;
+  }
+  static uint64_t mod13809739252051(uint64_t hash) {
+    return hash % 13809739252051llu;
+  }
+  static uint64_t mod17399181177241(uint64_t hash) {
+    return hash % 17399181177241llu;
+  }
+  static uint64_t mod21921594616111(uint64_t hash) {
+    return hash % 21921594616111llu;
+  }
+  static uint64_t mod27619478504183(uint64_t hash) {
+    return hash % 27619478504183llu;
+  }
+  static uint64_t mod34798362354533(uint64_t hash) {
+    return hash % 34798362354533llu;
+  }
+  static uint64_t mod43843189232363(uint64_t hash) {
+    return hash % 43843189232363llu;
+  }
+  static uint64_t mod55238957008387(uint64_t hash) {
+    return hash % 55238957008387llu;
+  }
+  static uint64_t mod69596724709081(uint64_t hash) {
+    return hash % 69596724709081llu;
+  }
+  static uint64_t mod87686378464759(uint64_t hash) {
+    return hash % 87686378464759llu;
+  }
+  static uint64_t mod110477914016779(uint64_t hash) {
+    return hash % 110477914016779llu;
+  }
+  static uint64_t mod139193449418173(uint64_t hash) {
+    return hash % 139193449418173llu;
+  }
+  static uint64_t mod175372756929481(uint64_t hash) {
+    return hash % 175372756929481llu;
+  }
+  static uint64_t mod220955828033581(uint64_t hash) {
+    return hash % 220955828033581llu;
+  }
+  static uint64_t mod278386898836457(uint64_t hash) {
+    return hash % 278386898836457llu;
+  }
+  static uint64_t mod350745513859007(uint64_t hash) {
+    return hash % 350745513859007llu;
+  }
+  static uint64_t mod441911656067171(uint64_t hash) {
+    return hash % 441911656067171llu;
+  }
+  static uint64_t mod556773797672909(uint64_t hash) {
+    return hash % 556773797672909llu;
+  }
+  static uint64_t mod701491027718027(uint64_t hash) {
+    return hash % 701491027718027llu;
+  }
+  static uint64_t mod883823312134381(uint64_t hash) {
+    return hash % 883823312134381llu;
+  }
+  static uint64_t mod1113547595345903(uint64_t hash) {
+    return hash % 1113547595345903llu;
+  }
+  static uint64_t mod1402982055436147(uint64_t hash) {
+    return hash % 1402982055436147llu;
+  }
+  static uint64_t mod1767646624268779(uint64_t hash) {
+    return hash % 1767646624268779llu;
+  }
+  static uint64_t mod2227095190691797(uint64_t hash) {
+    return hash % 2227095190691797llu;
+  }
+  static uint64_t mod2805964110872297(uint64_t hash) {
+    return hash % 2805964110872297llu;
+  }
+  static uint64_t mod3535293248537579(uint64_t hash) {
+    return hash % 3535293248537579llu;
+  }
+  static uint64_t mod4454190381383713(uint64_t hash) {
+    return hash % 4454190381383713llu;
+  }
+  static uint64_t mod5611928221744609(uint64_t hash) {
+    return hash % 5611928221744609llu;
+  }
+  static uint64_t mod7070586497075177(uint64_t hash) {
+    return hash % 7070586497075177llu;
+  }
+  static uint64_t mod8908380762767489(uint64_t hash) {
+    return hash % 8908380762767489llu;
+  }
+  static uint64_t mod11223856443489329(uint64_t hash) {
+    return hash % 11223856443489329llu;
+  }
+  static uint64_t mod14141172994150357(uint64_t hash) {
+    return hash % 14141172994150357llu;
+  }
+  static uint64_t mod17816761525534927(uint64_t hash) {
+    return hash % 17816761525534927llu;
+  }
+  static uint64_t mod22447712886978529(uint64_t hash) {
+    return hash % 22447712886978529llu;
+  }
+  static uint64_t mod28282345988300791(uint64_t hash) {
+    return hash % 28282345988300791llu;
+  }
+  static uint64_t mod35633523051069991(uint64_t hash) {
+    return hash % 35633523051069991llu;
+  }
+  static uint64_t mod44895425773957261(uint64_t hash) {
+    return hash % 44895425773957261llu;
+  }
+  static uint64_t mod56564691976601587(uint64_t hash) {
+    return hash % 56564691976601587llu;
+  }
+  static uint64_t mod71267046102139967(uint64_t hash) {
+    return hash % 71267046102139967llu;
+  }
+  static uint64_t mod89790851547914507(uint64_t hash) {
+    return hash % 89790851547914507llu;
+  }
+  static uint64_t mod113129383953203213(uint64_t hash) {
+    return hash % 113129383953203213llu;
+  }
+  static uint64_t mod142534092204280003(uint64_t hash) {
+    return hash % 142534092204280003llu;
+  }
+  static uint64_t mod179581703095829107(uint64_t hash) {
+    return hash % 179581703095829107llu;
+  }
+  static uint64_t mod226258767906406483(uint64_t hash) {
+    return hash % 226258767906406483llu;
+  }
+  static uint64_t mod285068184408560057(uint64_t hash) {
+    return hash % 285068184408560057llu;
+  }
+  static uint64_t mod359163406191658253(uint64_t hash) {
+    return hash % 359163406191658253llu;
+  }
+  static uint64_t mod452517535812813007(uint64_t hash) {
+    return hash % 452517535812813007llu;
+  }
+  static uint64_t mod570136368817120201(uint64_t hash) {
+    return hash % 570136368817120201llu;
+  }
+  static uint64_t mod718326812383316683(uint64_t hash) {
+    return hash % 718326812383316683llu;
+  }
+  static uint64_t mod905035071625626043(uint64_t hash) {
+    return hash % 905035071625626043llu;
+  }
+  static uint64_t mod1140272737634240411(uint64_t hash) {
+    return hash % 1140272737634240411llu;
+  }
+  static uint64_t mod1436653624766633509(uint64_t hash) {
+    return hash % 1436653624766633509llu;
+  }
+  static uint64_t mod1810070143251252131(uint64_t hash) {
+    return hash % 1810070143251252131llu;
+  }
+  static uint64_t mod2280545475268481167(uint64_t hash) {
+    return hash % 2280545475268481167llu;
+  }
+  static uint64_t mod2873307249533267101(uint64_t hash) {
+    return hash % 2873307249533267101llu;
+  }
+  static uint64_t mod3620140286502504283(uint64_t hash) {
+    return hash % 3620140286502504283llu;
+  }
+  static uint64_t mod4561090950536962147(uint64_t hash) {
+    return hash % 4561090950536962147llu;
+  }
+  static uint64_t mod5746614499066534157(uint64_t hash) {
+    return hash % 5746614499066534157llu;
+  }
+  static uint64_t mod7240280573005008577(uint64_t hash) {
+    return hash % 7240280573005008577llu;
+  }
+  static uint64_t mod9122181901073924329(uint64_t hash) {
+    return hash % 9122181901073924329llu;
+  }
+  static uint64_t mod11493228998133068689(uint64_t hash) {
+    return hash % 11493228998133068689llu;
+  }
+  static uint64_t mod14480561146010017169(uint64_t hash) {
+    return hash % 14480561146010017169llu;
+  }
+  static uint64_t mod18446744073709551557(uint64_t hash) {
+    return hash % 18446744073709551557llu;
+  }
 
-    using mod_function = uint64_t (*)(uint64_t);
+  using mod_function = uint64_t (*)(uint64_t);
 
-    mod_function next_size_over(uint64_t & size) const
-    {
-        // prime numbers generated by the following method:
-        // 1. start with a prime p = 2
-        // 2. go to wolfram alpha and get p = NextPrime(2 * p)
-        // 3. repeat 2. until you overflow 64 bits
-        // you now have large gaps which you would hit if somebody called reserve() with an unlucky number.
-        // 4. to fill the gaps for every prime p go to wolfram alpha and get ClosestPrime(p * 2^(1/3)) and ClosestPrime(p * 2^(2/3)) and put those in the gaps
-        // 5. get PrevPrime(2^64) and put it at the end
-        static constexpr const uint64_t prime_list[] =
-        {
-            2llu, 3llu, 5llu, 7llu, 11llu, 13llu, 17llu, 23llu, 29llu, 37llu, 47llu,
-            59llu, 73llu, 97llu, 127llu, 151llu, 197llu, 251llu, 313llu, 397llu,
-            499llu, 631llu, 797llu, 1009llu, 1259llu, 1597llu, 2011llu, 2539llu,
-            3203llu, 4027llu, 5087llu, 6421llu, 8089llu, 10193llu, 12853llu, 16193llu,
-            20399llu, 25717llu, 32401llu, 40823llu, 51437llu, 64811llu, 81649llu,
-            102877llu, 129607llu, 163307llu, 205759llu, 259229llu, 326617llu,
-            411527llu, 518509llu, 653267llu, 823117llu, 1037059llu, 1306601llu,
-            1646237llu, 2074129llu, 2613229llu, 3292489llu, 4148279llu, 5226491llu,
-            6584983llu, 8296553llu, 10453007llu, 13169977llu, 16593127llu, 20906033llu,
-            26339969llu, 33186281llu, 41812097llu, 52679969llu, 66372617llu,
-            83624237llu, 105359939llu, 132745199llu, 167248483llu, 210719881llu,
-            265490441llu, 334496971llu, 421439783llu, 530980861llu, 668993977llu,
-            842879579llu, 1061961721llu, 1337987929llu, 1685759167llu, 2123923447llu,
-            2675975881llu, 3371518343llu, 4247846927llu, 5351951779llu, 6743036717llu,
-            8495693897llu, 10703903591llu, 13486073473llu, 16991387857llu,
-            21407807219llu, 26972146961llu, 33982775741llu, 42815614441llu,
-            53944293929llu, 67965551447llu, 85631228929llu, 107888587883llu,
-            135931102921llu, 171262457903llu, 215777175787llu, 271862205833llu,
-            342524915839llu, 431554351609llu, 543724411781llu, 685049831731llu,
-            863108703229llu, 1087448823553llu, 1370099663459llu, 1726217406467llu,
-            2174897647073llu, 2740199326961llu, 3452434812973llu, 4349795294267llu,
-            5480398654009llu, 6904869625999llu, 8699590588571llu, 10960797308051llu,
-            13809739252051llu, 17399181177241llu, 21921594616111llu, 27619478504183llu,
-            34798362354533llu, 43843189232363llu, 55238957008387llu, 69596724709081llu,
-            87686378464759llu, 110477914016779llu, 139193449418173llu,
-            175372756929481llu, 220955828033581llu, 278386898836457llu,
-            350745513859007llu, 441911656067171llu, 556773797672909llu,
-            701491027718027llu, 883823312134381llu, 1113547595345903llu,
-            1402982055436147llu, 1767646624268779llu, 2227095190691797llu,
-            2805964110872297llu, 3535293248537579llu, 4454190381383713llu,
-            5611928221744609llu, 7070586497075177llu, 8908380762767489llu,
-            11223856443489329llu, 14141172994150357llu, 17816761525534927llu,
-            22447712886978529llu, 28282345988300791llu, 35633523051069991llu,
-            44895425773957261llu, 56564691976601587llu, 71267046102139967llu,
-            89790851547914507llu, 113129383953203213llu, 142534092204280003llu,
-            179581703095829107llu, 226258767906406483llu, 285068184408560057llu,
-            359163406191658253llu, 452517535812813007llu, 570136368817120201llu,
-            718326812383316683llu, 905035071625626043llu, 1140272737634240411llu,
-            1436653624766633509llu, 1810070143251252131llu, 2280545475268481167llu,
-            2873307249533267101llu, 3620140286502504283llu, 4561090950536962147llu,
-            5746614499066534157llu, 7240280573005008577llu, 9122181901073924329llu,
-            11493228998133068689llu, 14480561146010017169llu, 18446744073709551557llu
-        };
-        static constexpr uint64_t (* const mod_functions[])(uint64_t) =
-        {
-            &mod0, &mod2, &mod3, &mod5, &mod7, &mod11, &mod13, &mod17, &mod23, &mod29, &mod37,
-            &mod47, &mod59, &mod73, &mod97, &mod127, &mod151, &mod197, &mod251, &mod313, &mod397,
-            &mod499, &mod631, &mod797, &mod1009, &mod1259, &mod1597, &mod2011, &mod2539, &mod3203,
-            &mod4027, &mod5087, &mod6421, &mod8089, &mod10193, &mod12853, &mod16193, &mod20399,
-            &mod25717, &mod32401, &mod40823, &mod51437, &mod64811, &mod81649, &mod102877,
-            &mod129607, &mod163307, &mod205759, &mod259229, &mod326617, &mod411527, &mod518509,
-            &mod653267, &mod823117, &mod1037059, &mod1306601, &mod1646237, &mod2074129,
-            &mod2613229, &mod3292489, &mod4148279, &mod5226491, &mod6584983, &mod8296553,
-            &mod10453007, &mod13169977, &mod16593127, &mod20906033, &mod26339969, &mod33186281,
-            &mod41812097, &mod52679969, &mod66372617, &mod83624237, &mod105359939, &mod132745199,
-            &mod167248483, &mod210719881, &mod265490441, &mod334496971, &mod421439783,
-            &mod530980861, &mod668993977, &mod842879579, &mod1061961721, &mod1337987929,
-            &mod1685759167, &mod2123923447, &mod2675975881, &mod3371518343, &mod4247846927,
-            &mod5351951779, &mod6743036717, &mod8495693897, &mod10703903591, &mod13486073473,
-            &mod16991387857, &mod21407807219, &mod26972146961, &mod33982775741, &mod42815614441,
-            &mod53944293929, &mod67965551447, &mod85631228929, &mod107888587883, &mod135931102921,
-            &mod171262457903, &mod215777175787, &mod271862205833, &mod342524915839,
-            &mod431554351609, &mod543724411781, &mod685049831731, &mod863108703229,
-            &mod1087448823553, &mod1370099663459, &mod1726217406467, &mod2174897647073,
-            &mod2740199326961, &mod3452434812973, &mod4349795294267, &mod5480398654009,
-            &mod6904869625999, &mod8699590588571, &mod10960797308051, &mod13809739252051,
-            &mod17399181177241, &mod21921594616111, &mod27619478504183, &mod34798362354533,
-            &mod43843189232363, &mod55238957008387, &mod69596724709081, &mod87686378464759,
-            &mod110477914016779, &mod139193449418173, &mod175372756929481, &mod220955828033581,
-            &mod278386898836457, &mod350745513859007, &mod441911656067171, &mod556773797672909,
-            &mod701491027718027, &mod883823312134381, &mod1113547595345903, &mod1402982055436147,
-            &mod1767646624268779, &mod2227095190691797, &mod2805964110872297, &mod3535293248537579,
-            &mod4454190381383713, &mod5611928221744609, &mod7070586497075177, &mod8908380762767489,
-            &mod11223856443489329, &mod14141172994150357, &mod17816761525534927,
-            &mod22447712886978529, &mod28282345988300791, &mod35633523051069991,
-            &mod44895425773957261, &mod56564691976601587, &mod71267046102139967,
-            &mod89790851547914507, &mod113129383953203213, &mod142534092204280003,
-            &mod179581703095829107, &mod226258767906406483, &mod285068184408560057,
-            &mod359163406191658253, &mod452517535812813007, &mod570136368817120201,
-            &mod718326812383316683, &mod905035071625626043, &mod1140272737634240411,
-            &mod1436653624766633509, &mod1810070143251252131, &mod2280545475268481167,
-            &mod2873307249533267101, &mod3620140286502504283, &mod4561090950536962147,
-            &mod5746614499066534157, &mod7240280573005008577, &mod9122181901073924329,
-            &mod11493228998133068689, &mod14480561146010017169, &mod18446744073709551557
-        };
-        const uint64_t * found = std::lower_bound(std::begin(prime_list), std::end(prime_list) - 1, size);
-        size = *found;
-        return mod_functions[1 + found - prime_list];
-    }
-    void commit(mod_function new_mod_function)
-    {
-        current_mod_function = new_mod_function;
-    }
-    void reset()
-    {
-        current_mod_function = &mod0;
-    }
+  mod_function next_size_over(uint64_t& size) const {
+    // prime numbers generated by the following method:
+    // 1. start with a prime p = 2
+    // 2. go to wolfram alpha and get p = NextPrime(2 * p)
+    // 3. repeat 2. until you overflow 64 bits
+    // you now have large gaps which you would hit if somebody called reserve()
+    // with an unlucky number.
+    // 4. to fill the gaps for every prime p go to wolfram alpha and get
+    // ClosestPrime(p * 2^(1/3)) and ClosestPrime(p * 2^(2/3)) and put those in
+    // the gaps
+    // 5. get PrevPrime(2^64) and put it at the end
+    static constexpr const uint64_t prime_list[] = {2llu,
+                                                    3llu,
+                                                    5llu,
+                                                    7llu,
+                                                    11llu,
+                                                    13llu,
+                                                    17llu,
+                                                    23llu,
+                                                    29llu,
+                                                    37llu,
+                                                    47llu,
+                                                    59llu,
+                                                    73llu,
+                                                    97llu,
+                                                    127llu,
+                                                    151llu,
+                                                    197llu,
+                                                    251llu,
+                                                    313llu,
+                                                    397llu,
+                                                    499llu,
+                                                    631llu,
+                                                    797llu,
+                                                    1009llu,
+                                                    1259llu,
+                                                    1597llu,
+                                                    2011llu,
+                                                    2539llu,
+                                                    3203llu,
+                                                    4027llu,
+                                                    5087llu,
+                                                    6421llu,
+                                                    8089llu,
+                                                    10193llu,
+                                                    12853llu,
+                                                    16193llu,
+                                                    20399llu,
+                                                    25717llu,
+                                                    32401llu,
+                                                    40823llu,
+                                                    51437llu,
+                                                    64811llu,
+                                                    81649llu,
+                                                    102877llu,
+                                                    129607llu,
+                                                    163307llu,
+                                                    205759llu,
+                                                    259229llu,
+                                                    326617llu,
+                                                    411527llu,
+                                                    518509llu,
+                                                    653267llu,
+                                                    823117llu,
+                                                    1037059llu,
+                                                    1306601llu,
+                                                    1646237llu,
+                                                    2074129llu,
+                                                    2613229llu,
+                                                    3292489llu,
+                                                    4148279llu,
+                                                    5226491llu,
+                                                    6584983llu,
+                                                    8296553llu,
+                                                    10453007llu,
+                                                    13169977llu,
+                                                    16593127llu,
+                                                    20906033llu,
+                                                    26339969llu,
+                                                    33186281llu,
+                                                    41812097llu,
+                                                    52679969llu,
+                                                    66372617llu,
+                                                    83624237llu,
+                                                    105359939llu,
+                                                    132745199llu,
+                                                    167248483llu,
+                                                    210719881llu,
+                                                    265490441llu,
+                                                    334496971llu,
+                                                    421439783llu,
+                                                    530980861llu,
+                                                    668993977llu,
+                                                    842879579llu,
+                                                    1061961721llu,
+                                                    1337987929llu,
+                                                    1685759167llu,
+                                                    2123923447llu,
+                                                    2675975881llu,
+                                                    3371518343llu,
+                                                    4247846927llu,
+                                                    5351951779llu,
+                                                    6743036717llu,
+                                                    8495693897llu,
+                                                    10703903591llu,
+                                                    13486073473llu,
+                                                    16991387857llu,
+                                                    21407807219llu,
+                                                    26972146961llu,
+                                                    33982775741llu,
+                                                    42815614441llu,
+                                                    53944293929llu,
+                                                    67965551447llu,
+                                                    85631228929llu,
+                                                    107888587883llu,
+                                                    135931102921llu,
+                                                    171262457903llu,
+                                                    215777175787llu,
+                                                    271862205833llu,
+                                                    342524915839llu,
+                                                    431554351609llu,
+                                                    543724411781llu,
+                                                    685049831731llu,
+                                                    863108703229llu,
+                                                    1087448823553llu,
+                                                    1370099663459llu,
+                                                    1726217406467llu,
+                                                    2174897647073llu,
+                                                    2740199326961llu,
+                                                    3452434812973llu,
+                                                    4349795294267llu,
+                                                    5480398654009llu,
+                                                    6904869625999llu,
+                                                    8699590588571llu,
+                                                    10960797308051llu,
+                                                    13809739252051llu,
+                                                    17399181177241llu,
+                                                    21921594616111llu,
+                                                    27619478504183llu,
+                                                    34798362354533llu,
+                                                    43843189232363llu,
+                                                    55238957008387llu,
+                                                    69596724709081llu,
+                                                    87686378464759llu,
+                                                    110477914016779llu,
+                                                    139193449418173llu,
+                                                    175372756929481llu,
+                                                    220955828033581llu,
+                                                    278386898836457llu,
+                                                    350745513859007llu,
+                                                    441911656067171llu,
+                                                    556773797672909llu,
+                                                    701491027718027llu,
+                                                    883823312134381llu,
+                                                    1113547595345903llu,
+                                                    1402982055436147llu,
+                                                    1767646624268779llu,
+                                                    2227095190691797llu,
+                                                    2805964110872297llu,
+                                                    3535293248537579llu,
+                                                    4454190381383713llu,
+                                                    5611928221744609llu,
+                                                    7070586497075177llu,
+                                                    8908380762767489llu,
+                                                    11223856443489329llu,
+                                                    14141172994150357llu,
+                                                    17816761525534927llu,
+                                                    22447712886978529llu,
+                                                    28282345988300791llu,
+                                                    35633523051069991llu,
+                                                    44895425773957261llu,
+                                                    56564691976601587llu,
+                                                    71267046102139967llu,
+                                                    89790851547914507llu,
+                                                    113129383953203213llu,
+                                                    142534092204280003llu,
+                                                    179581703095829107llu,
+                                                    226258767906406483llu,
+                                                    285068184408560057llu,
+                                                    359163406191658253llu,
+                                                    452517535812813007llu,
+                                                    570136368817120201llu,
+                                                    718326812383316683llu,
+                                                    905035071625626043llu,
+                                                    1140272737634240411llu,
+                                                    1436653624766633509llu,
+                                                    1810070143251252131llu,
+                                                    2280545475268481167llu,
+                                                    2873307249533267101llu,
+                                                    3620140286502504283llu,
+                                                    4561090950536962147llu,
+                                                    5746614499066534157llu,
+                                                    7240280573005008577llu,
+                                                    9122181901073924329llu,
+                                                    11493228998133068689llu,
+                                                    14480561146010017169llu,
+                                                    18446744073709551557llu};
+    static constexpr uint64_t (*const mod_functions[])(uint64_t) = {
+        &mod0,
+        &mod2,
+        &mod3,
+        &mod5,
+        &mod7,
+        &mod11,
+        &mod13,
+        &mod17,
+        &mod23,
+        &mod29,
+        &mod37,
+        &mod47,
+        &mod59,
+        &mod73,
+        &mod97,
+        &mod127,
+        &mod151,
+        &mod197,
+        &mod251,
+        &mod313,
+        &mod397,
+        &mod499,
+        &mod631,
+        &mod797,
+        &mod1009,
+        &mod1259,
+        &mod1597,
+        &mod2011,
+        &mod2539,
+        &mod3203,
+        &mod4027,
+        &mod5087,
+        &mod6421,
+        &mod8089,
+        &mod10193,
+        &mod12853,
+        &mod16193,
+        &mod20399,
+        &mod25717,
+        &mod32401,
+        &mod40823,
+        &mod51437,
+        &mod64811,
+        &mod81649,
+        &mod102877,
+        &mod129607,
+        &mod163307,
+        &mod205759,
+        &mod259229,
+        &mod326617,
+        &mod411527,
+        &mod518509,
+        &mod653267,
+        &mod823117,
+        &mod1037059,
+        &mod1306601,
+        &mod1646237,
+        &mod2074129,
+        &mod2613229,
+        &mod3292489,
+        &mod4148279,
+        &mod5226491,
+        &mod6584983,
+        &mod8296553,
+        &mod10453007,
+        &mod13169977,
+        &mod16593127,
+        &mod20906033,
+        &mod26339969,
+        &mod33186281,
+        &mod41812097,
+        &mod52679969,
+        &mod66372617,
+        &mod83624237,
+        &mod105359939,
+        &mod132745199,
+        &mod167248483,
+        &mod210719881,
+        &mod265490441,
+        &mod334496971,
+        &mod421439783,
+        &mod530980861,
+        &mod668993977,
+        &mod842879579,
+        &mod1061961721,
+        &mod1337987929,
+        &mod1685759167,
+        &mod2123923447,
+        &mod2675975881,
+        &mod3371518343,
+        &mod4247846927,
+        &mod5351951779,
+        &mod6743036717,
+        &mod8495693897,
+        &mod10703903591,
+        &mod13486073473,
+        &mod16991387857,
+        &mod21407807219,
+        &mod26972146961,
+        &mod33982775741,
+        &mod42815614441,
+        &mod53944293929,
+        &mod67965551447,
+        &mod85631228929,
+        &mod107888587883,
+        &mod135931102921,
+        &mod171262457903,
+        &mod215777175787,
+        &mod271862205833,
+        &mod342524915839,
+        &mod431554351609,
+        &mod543724411781,
+        &mod685049831731,
+        &mod863108703229,
+        &mod1087448823553,
+        &mod1370099663459,
+        &mod1726217406467,
+        &mod2174897647073,
+        &mod2740199326961,
+        &mod3452434812973,
+        &mod4349795294267,
+        &mod5480398654009,
+        &mod6904869625999,
+        &mod8699590588571,
+        &mod10960797308051,
+        &mod13809739252051,
+        &mod17399181177241,
+        &mod21921594616111,
+        &mod27619478504183,
+        &mod34798362354533,
+        &mod43843189232363,
+        &mod55238957008387,
+        &mod69596724709081,
+        &mod87686378464759,
+        &mod110477914016779,
+        &mod139193449418173,
+        &mod175372756929481,
+        &mod220955828033581,
+        &mod278386898836457,
+        &mod350745513859007,
+        &mod441911656067171,
+        &mod556773797672909,
+        &mod701491027718027,
+        &mod883823312134381,
+        &mod1113547595345903,
+        &mod1402982055436147,
+        &mod1767646624268779,
+        &mod2227095190691797,
+        &mod2805964110872297,
+        &mod3535293248537579,
+        &mod4454190381383713,
+        &mod5611928221744609,
+        &mod7070586497075177,
+        &mod8908380762767489,
+        &mod11223856443489329,
+        &mod14141172994150357,
+        &mod17816761525534927,
+        &mod22447712886978529,
+        &mod28282345988300791,
+        &mod35633523051069991,
+        &mod44895425773957261,
+        &mod56564691976601587,
+        &mod71267046102139967,
+        &mod89790851547914507,
+        &mod113129383953203213,
+        &mod142534092204280003,
+        &mod179581703095829107,
+        &mod226258767906406483,
+        &mod285068184408560057,
+        &mod359163406191658253,
+        &mod452517535812813007,
+        &mod570136368817120201,
+        &mod718326812383316683,
+        &mod905035071625626043,
+        &mod1140272737634240411,
+        &mod1436653624766633509,
+        &mod1810070143251252131,
+        &mod2280545475268481167,
+        &mod2873307249533267101,
+        &mod3620140286502504283,
+        &mod4561090950536962147,
+        &mod5746614499066534157,
+        &mod7240280573005008577,
+        &mod9122181901073924329,
+        &mod11493228998133068689,
+        &mod14480561146010017169,
+        &mod18446744073709551557};
+    const uint64_t* found = std::lower_bound(
+        std::begin(prime_list), std::end(prime_list) - 1, size);
+    size = *found;
+    return mod_functions[1 + found - prime_list];
+  }
+  void commit(mod_function new_mod_function) {
+    current_mod_function = new_mod_function;
+  }
+  void reset() {
+    current_mod_function = &mod0;
+  }
 
-    uint64_t index_for_hash(uint64_t hash, uint64_t /*num_slots_minus_one*/) const
-    {
-        return current_mod_function(hash);
-    }
-    uint64_t keep_in_range(uint64_t index, uint64_t num_slots_minus_one) const
-    {
-        return index > num_slots_minus_one ? current_mod_function(index) : index;
-    }
+  uint64_t index_for_hash(uint64_t hash, uint64_t /*num_slots_minus_one*/)
+      const {
+    return current_mod_function(hash);
+  }
+  uint64_t keep_in_range(uint64_t index, uint64_t num_slots_minus_one) const {
+    return index > num_slots_minus_one ? current_mod_function(index) : index;
+  }
 
-private:
-    mod_function current_mod_function = &mod0;
+ private:
+  mod_function current_mod_function = &mod0;
 };
 
-struct power_of_two_hash_policy
-{
-    uint64_t index_for_hash(uint64_t hash, uint64_t num_slots_minus_one) const
-    {
-        return hash & num_slots_minus_one;
-    }
-    uint64_t keep_in_range(uint64_t index, uint64_t num_slots_minus_one) const
-    {
-        return index_for_hash(index, num_slots_minus_one);
-    }
-    int8_t next_size_over(uint64_t & size) const
-    {
-        size = detailv3::next_power_of_two(size);
-        return 0;
-    }
-    void commit(int8_t)
-    {
-    }
-    void reset()
-    {
-    }
-
+struct power_of_two_hash_policy {
+  uint64_t index_for_hash(uint64_t hash, uint64_t num_slots_minus_one) const {
+    return hash & num_slots_minus_one;
+  }
+  uint64_t keep_in_range(uint64_t index, uint64_t num_slots_minus_one) const {
+    return index_for_hash(index, num_slots_minus_one);
+  }
+  int8_t next_size_over(uint64_t& size) const {
+    size = detailv3::next_power_of_two(size);
+    return 0;
+  }
+  void commit(int8_t) {}
+  void reset() {}
 };
 
-struct fibonacci_hash_policy
-{
-    uint64_t index_for_hash(uint64_t hash, uint64_t /*num_slots_minus_one*/) const
-    {
-        return (11400714819323198485ull * hash) >> shift;
-    }
-    uint64_t keep_in_range(uint64_t index, uint64_t num_slots_minus_one) const
-    {
-        return index & num_slots_minus_one;
-    }
+struct fibonacci_hash_policy {
+  uint64_t index_for_hash(uint64_t hash, uint64_t /*num_slots_minus_one*/)
+      const {
+    return (11400714819323198485ull * hash) >> shift;
+  }
+  uint64_t keep_in_range(uint64_t index, uint64_t num_slots_minus_one) const {
+    return index & num_slots_minus_one;
+  }
 
-    int8_t next_size_over(uint64_t & size) const
-    {
-        size = std::max(uint64_t(2), detailv3::next_power_of_two(size));
-        return 64 - detailv3::log2(size);
-    }
-    void commit(int8_t shift)
-    {
-        this->shift = shift;
-    }
-    void reset()
-    {
-        shift = 63;
-    }
+  int8_t next_size_over(uint64_t& size) const {
+    size = std::max(uint64_t(2), detailv3::next_power_of_two(size));
+    return 64 - detailv3::log2(size);
+  }
+  void commit(int8_t shift) {
+    this->shift = shift;
+  }
+  void reset() {
+    shift = 63;
+  }
 
-private:
-    int8_t shift = 63;
+ private:
+  int8_t shift = 63;
 };
 
-template<typename K, typename V, typename H = std::hash<K>, typename E = std::equal_to<K>, typename A = std::allocator<std::pair<K, V> > >
+template <
+    typename K,
+    typename V,
+    typename H = std::hash<K>,
+    typename E = std::equal_to<K>,
+    typename A = std::allocator<std::pair<K, V>>>
 class flat_hash_map
-        : public detailv3::sherwood_v3_table
-        <
-            std::pair<K, V>,
-            K,
-            H,
-            detailv3::KeyOrValueHasher<K, std::pair<K, V>, H>,
-            E,
-            detailv3::KeyOrValueEquality<K, std::pair<K, V>, E>,
-            A,
-            typename std::allocator_traits<A>::template rebind_alloc<detailv3::sherwood_v3_entry<std::pair<K, V>>>
-        >
-{
-    using Table = detailv3::sherwood_v3_table
-    <
-        std::pair<K, V>,
-        K,
-        H,
-        detailv3::KeyOrValueHasher<K, std::pair<K, V>, H>,
-        E,
-        detailv3::KeyOrValueEquality<K, std::pair<K, V>, E>,
-        A,
-        typename std::allocator_traits<A>::template rebind_alloc<detailv3::sherwood_v3_entry<std::pair<K, V>>>
-    >;
-public:
+    : public detailv3::sherwood_v3_table<
+          std::pair<K, V>,
+          K,
+          H,
+          detailv3::KeyOrValueHasher<K, std::pair<K, V>, H>,
+          E,
+          detailv3::KeyOrValueEquality<K, std::pair<K, V>, E>,
+          A,
+          typename std::allocator_traits<A>::template rebind_alloc<
+              detailv3::sherwood_v3_entry<std::pair<K, V>>>> {
+  using Table = detailv3::sherwood_v3_table<
+      std::pair<K, V>,
+      K,
+      H,
+      detailv3::KeyOrValueHasher<K, std::pair<K, V>, H>,
+      E,
+      detailv3::KeyOrValueEquality<K, std::pair<K, V>, E>,
+      A,
+      typename std::allocator_traits<A>::template rebind_alloc<
+          detailv3::sherwood_v3_entry<std::pair<K, V>>>>;
 
-    using key_type = K;
-    using mapped_type = V;
+ public:
+  using key_type = K;
+  using mapped_type = V;
 
-    using Table::Table;
-    flat_hash_map()
-    {
-    }
+  using Table::Table;
+  flat_hash_map() {}
 
-    inline V & operator[](const K & key)
-    {
-        return emplace(key, convertible_to_value()).first->second;
-    }
-    inline V & operator[](K && key)
-    {
-        return emplace(std::move(key), convertible_to_value()).first->second;
-    }
-    V & at(const K & key)
-    {
-        auto found = this->find(key);
-        if (found == this->end())
-            throw std::out_of_range("Argument passed to at() was not in the map.");
-        return found->second;
-    }
-    const V & at(const K & key) const
-    {
-        auto found = this->find(key);
-        if (found == this->end())
-            throw std::out_of_range("Argument passed to at() was not in the map.");
-        return found->second;
-    }
+  inline V& operator[](const K& key) {
+    return emplace(key, convertible_to_value()).first->second;
+  }
+  inline V& operator[](K&& key) {
+    return emplace(std::move(key), convertible_to_value()).first->second;
+  }
+  V& at(const K& key) {
+    auto found = this->find(key);
+    if (found == this->end())
+      throw std::out_of_range("Argument passed to at() was not in the map.");
+    return found->second;
+  }
+  const V& at(const K& key) const {
+    auto found = this->find(key);
+    if (found == this->end())
+      throw std::out_of_range("Argument passed to at() was not in the map.");
+    return found->second;
+  }
 
-    using Table::emplace;
-    std::pair<typename Table::iterator, bool> emplace()
-    {
-        return emplace(key_type(), convertible_to_value());
-    }
-    template<typename M>
-    std::pair<typename Table::iterator, bool> insert_or_assign(const key_type & key, M && m)
-    {
-        auto emplace_result = emplace(key, std::forward<M>(m));
-        if (!emplace_result.second)
-            emplace_result.first->second = std::forward<M>(m);
-        return emplace_result;
-    }
-    template<typename M>
-    std::pair<typename Table::iterator, bool> insert_or_assign(key_type && key, M && m)
-    {
-        auto emplace_result = emplace(std::move(key), std::forward<M>(m));
-        if (!emplace_result.second)
-            emplace_result.first->second = std::forward<M>(m);
-        return emplace_result;
-    }
-    template<typename M>
-    typename Table::iterator insert_or_assign(typename Table::const_iterator, const key_type & key, M && m)
-    {
-        return insert_or_assign(key, std::forward<M>(m)).first;
-    }
-    template<typename M>
-    typename Table::iterator insert_or_assign(typename Table::const_iterator, key_type && key, M && m)
-    {
-        return insert_or_assign(std::move(key), std::forward<M>(m)).first;
-    }
+  using Table::emplace;
+  std::pair<typename Table::iterator, bool> emplace() {
+    return emplace(key_type(), convertible_to_value());
+  }
+  template <typename M>
+  std::pair<typename Table::iterator, bool> insert_or_assign(
+      const key_type& key,
+      M&& m) {
+    auto emplace_result = emplace(key, std::forward<M>(m));
+    if (!emplace_result.second)
+      emplace_result.first->second = std::forward<M>(m);
+    return emplace_result;
+  }
+  template <typename M>
+  std::pair<typename Table::iterator, bool> insert_or_assign(
+      key_type&& key,
+      M&& m) {
+    auto emplace_result = emplace(std::move(key), std::forward<M>(m));
+    if (!emplace_result.second)
+      emplace_result.first->second = std::forward<M>(m);
+    return emplace_result;
+  }
+  template <typename M>
+  typename Table::iterator insert_or_assign(
+      typename Table::const_iterator,
+      const key_type& key,
+      M&& m) {
+    return insert_or_assign(key, std::forward<M>(m)).first;
+  }
+  template <typename M>
+  typename Table::iterator insert_or_assign(
+      typename Table::const_iterator,
+      key_type&& key,
+      M&& m) {
+    return insert_or_assign(std::move(key), std::forward<M>(m)).first;
+  }
 
-    friend bool operator==(const flat_hash_map & lhs, const flat_hash_map & rhs)
-    {
-        if (lhs.size() != rhs.size())
-            return false;
-        for (const typename Table::value_type & value : lhs)
-        {
-            auto found = rhs.find(value.first);
-            if (found == rhs.end())
-                return false;
-            else if (value.second != found->second)
-                return false;
-        }
-        return true;
+  friend bool operator==(const flat_hash_map& lhs, const flat_hash_map& rhs) {
+    if (lhs.size() != rhs.size())
+      return false;
+    for (const typename Table::value_type& value : lhs) {
+      auto found = rhs.find(value.first);
+      if (found == rhs.end())
+        return false;
+      else if (value.second != found->second)
+        return false;
     }
-    friend bool operator!=(const flat_hash_map & lhs, const flat_hash_map & rhs)
-    {
-        return !(lhs == rhs);
-    }
+    return true;
+  }
+  friend bool operator!=(const flat_hash_map& lhs, const flat_hash_map& rhs) {
+    return !(lhs == rhs);
+  }
 
-private:
-    struct convertible_to_value
-    {
-        operator V() const
-        {
-            return V();
-        }
-    };
+ private:
+  struct convertible_to_value {
+    operator V() const {
+      return V();
+    }
+  };
 };
 
-template<typename T, typename H = std::hash<T>, typename E = std::equal_to<T>, typename A = std::allocator<T> >
+template <
+    typename T,
+    typename H = std::hash<T>,
+    typename E = std::equal_to<T>,
+    typename A = std::allocator<T>>
 class flat_hash_set
-        : public detailv3::sherwood_v3_table
-        <
-            T,
-            T,
-            H,
-            detailv3::functor_storage<uint64_t, H>,
-            E,
-            detailv3::functor_storage<bool, E>,
-            A,
-            typename std::allocator_traits<A>::template rebind_alloc<detailv3::sherwood_v3_entry<T>>
-        >
-{
-    using Table = detailv3::sherwood_v3_table
-    <
-        T,
-        T,
-        H,
-        detailv3::functor_storage<uint64_t, H>,
-        E,
-        detailv3::functor_storage<bool, E>,
-        A,
-        typename std::allocator_traits<A>::template rebind_alloc<detailv3::sherwood_v3_entry<T>>
-    >;
-public:
+    : public detailv3::sherwood_v3_table<
+          T,
+          T,
+          H,
+          detailv3::functor_storage<uint64_t, H>,
+          E,
+          detailv3::functor_storage<bool, E>,
+          A,
+          typename std::allocator_traits<A>::template rebind_alloc<
+              detailv3::sherwood_v3_entry<T>>> {
+  using Table = detailv3::sherwood_v3_table<
+      T,
+      T,
+      H,
+      detailv3::functor_storage<uint64_t, H>,
+      E,
+      detailv3::functor_storage<bool, E>,
+      A,
+      typename std::allocator_traits<A>::template rebind_alloc<
+          detailv3::sherwood_v3_entry<T>>>;
 
-    using key_type = T;
+ public:
+  using key_type = T;
 
-    using Table::Table;
-    flat_hash_set()
-    {
-    }
+  using Table::Table;
+  flat_hash_set() {}
 
-    template<typename... Args>
-    std::pair<typename Table::iterator, bool> emplace(Args &&... args)
-    {
-        return Table::emplace(T(std::forward<Args>(args)...));
-    }
-    std::pair<typename Table::iterator, bool> emplace(const key_type & arg)
-    {
-        return Table::emplace(arg);
-    }
-    std::pair<typename Table::iterator, bool> emplace(key_type & arg)
-    {
-        return Table::emplace(arg);
-    }
-    std::pair<typename Table::iterator, bool> emplace(const key_type && arg)
-    {
-        return Table::emplace(std::move(arg));
-    }
-    std::pair<typename Table::iterator, bool> emplace(key_type && arg)
-    {
-        return Table::emplace(std::move(arg));
-    }
+  template <typename... Args>
+  std::pair<typename Table::iterator, bool> emplace(Args&&... args) {
+    return Table::emplace(T(std::forward<Args>(args)...));
+  }
+  std::pair<typename Table::iterator, bool> emplace(const key_type& arg) {
+    return Table::emplace(arg);
+  }
+  std::pair<typename Table::iterator, bool> emplace(key_type& arg) {
+    return Table::emplace(arg);
+  }
+  std::pair<typename Table::iterator, bool> emplace(const key_type&& arg) {
+    return Table::emplace(std::move(arg));
+  }
+  std::pair<typename Table::iterator, bool> emplace(key_type&& arg) {
+    return Table::emplace(std::move(arg));
+  }
 
-    friend bool operator==(const flat_hash_set & lhs, const flat_hash_set & rhs)
-    {
-        if (lhs.size() != rhs.size())
-            return false;
-        for (const T & value : lhs)
-        {
-            if (rhs.find(value) == rhs.end())
-                return false;
-        }
-        return true;
+  friend bool operator==(const flat_hash_set& lhs, const flat_hash_set& rhs) {
+    if (lhs.size() != rhs.size())
+      return false;
+    for (const T& value : lhs) {
+      if (rhs.find(value) == rhs.end())
+        return false;
     }
-    friend bool operator!=(const flat_hash_set & lhs, const flat_hash_set & rhs)
-    {
-        return !(lhs == rhs);
-    }
+    return true;
+  }
+  friend bool operator!=(const flat_hash_set& lhs, const flat_hash_set& rhs) {
+    return !(lhs == rhs);
+  }
 };
 
-
-template<typename T>
-struct power_of_two_std_hash : std::hash<T>
-{
-    typedef ska::power_of_two_hash_policy hash_policy;
+template <typename T>
+struct power_of_two_std_hash : std::hash<T> {
+  typedef ska::power_of_two_hash_policy hash_policy;
 };
 
 } // end namespace ska

--- a/c10/util/llvmMathExtras.h
+++ b/c10/util/llvmMathExtras.h
@@ -1,854 +1,889 @@
 //===-- llvm/Support/MathExtras.h - Useful math functions -------*- C++ -*-===//
- //
- // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
- // See https://llvm.org/LICENSE.txt for license information.
- // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
- //
- //===----------------------------------------------------------------------===//
- //
- // This file contains some functions that are useful for math stuff.
- //
- //===----------------------------------------------------------------------===//
-
- #ifndef LLVM_SUPPORT_MATHEXTRAS_H
- #define LLVM_SUPPORT_MATHEXTRAS_H
-
- #include <algorithm>
- #include <cmath>
- #include <cassert>
- #include <climits>
- #include <cstring>
- #include <limits>
- #include <type_traits>
-
- #ifdef __ANDROID_NDK__
- #include <android/api-level.h>
- #endif
-
- #ifndef __has_builtin
- # define __has_builtin(x) 0
- #endif
-
- #ifndef LLVM_GNUC_PREREQ
- # if defined(__GNUC__) && defined(__GNUC_MINOR__) && defined(__GNUC_PATCHLEVEL__)
- #  define LLVM_GNUC_PREREQ(maj, min, patch) \
-     ((__GNUC__ << 20) + (__GNUC_MINOR__ << 10) + __GNUC_PATCHLEVEL__ >= \
-      ((maj) << 20) + ((min) << 10) + (patch))
- # elif defined(__GNUC__) && defined(__GNUC_MINOR__)
- #  define LLVM_GNUC_PREREQ(maj, min, patch) \
-     ((__GNUC__ << 20) + (__GNUC_MINOR__ << 10) >= ((maj) << 20) + ((min) << 10))
- # else
- #  define LLVM_GNUC_PREREQ(maj, min, patch) 0
- # endif
- #endif
-
- #ifdef _MSC_VER
- // Declare these intrinsics manually rather including intrin.h. It's very
- // expensive, and MathExtras.h is popular.
- // #include <intrin.h>
- extern "C" {
- unsigned char _BitScanForward(unsigned long *_Index, unsigned long _Mask);
- unsigned char _BitScanForward64(unsigned long *_Index, unsigned __int64 _Mask);
- unsigned char _BitScanReverse(unsigned long *_Index, unsigned long _Mask);
- unsigned char _BitScanReverse64(unsigned long *_Index, unsigned __int64 _Mask);
- }
- #endif
-
- namespace llvm {
- /// The behavior an operation has on an input of 0.
- enum ZeroBehavior {
-   /// The returned value is undefined.
-   ZB_Undefined,
-   /// The returned value is numeric_limits<T>::max()
-   ZB_Max,
-   /// The returned value is numeric_limits<T>::digits
-   ZB_Width
- };
-
- namespace detail {
- template <typename T, std::size_t SizeOfT> struct TrailingZerosCounter {
-   static std::size_t count(T Val, ZeroBehavior) {
-     if (!Val)
-       return std::numeric_limits<T>::digits;
-     if (Val & 0x1)
-       return 0;
-
-     // Bisection method.
-     std::size_t ZeroBits = 0;
-     T Shift = std::numeric_limits<T>::digits >> 1;
-     T Mask = std::numeric_limits<T>::max() >> Shift;
-     while (Shift) {
-       if ((Val & Mask) == 0) {
-         Val >>= Shift;
-         ZeroBits |= Shift;
-       }
-       Shift >>= 1;
-       Mask >>= Shift;
-     }
-     return ZeroBits;
-   }
- };
-
- #if __GNUC__ >= 4 || defined(_MSC_VER)
- template <typename T> struct TrailingZerosCounter<T, 4> {
-   static std::size_t count(T Val, ZeroBehavior ZB) {
-     if (ZB != ZB_Undefined && Val == 0)
-       return 32;
-
- #if __has_builtin(__builtin_ctz) || LLVM_GNUC_PREREQ(4, 0, 0)
-     return __builtin_ctz(Val);
- #elif defined(_MSC_VER)
-     unsigned long Index;
-     _BitScanForward(&Index, Val);
-     return Index;
- #endif
-   }
- };
-
- #if !defined(_MSC_VER) || defined(_M_X64)
- template <typename T> struct TrailingZerosCounter<T, 8> {
-   static std::size_t count(T Val, ZeroBehavior ZB) {
-     if (ZB != ZB_Undefined && Val == 0)
-       return 64;
-
- #if __has_builtin(__builtin_ctzll) || LLVM_GNUC_PREREQ(4, 0, 0)
-     return __builtin_ctzll(Val);
- #elif defined(_MSC_VER)
-     unsigned long Index;
-     _BitScanForward64(&Index, Val);
-     return Index;
- #endif
-   }
- };
- #endif
- #endif
- } // namespace detail
-
- /// Count number of 0's from the least significant bit to the most
- ///   stopping at the first 1.
- ///
- /// Only unsigned integral types are allowed.
- ///
- /// \param ZB the behavior on an input of 0. Only ZB_Width and ZB_Undefined are
- ///   valid arguments.
- template <typename T>
- std::size_t countTrailingZeros(T Val, ZeroBehavior ZB = ZB_Width) {
-   static_assert(std::numeric_limits<T>::is_integer &&
-                     !std::numeric_limits<T>::is_signed,
-                 "Only unsigned integral types are allowed.");
-   return llvm::detail::TrailingZerosCounter<T, sizeof(T)>::count(Val, ZB);
- }
-
- namespace detail {
- template <typename T, std::size_t SizeOfT> struct LeadingZerosCounter {
-   static std::size_t count(T Val, ZeroBehavior) {
-     if (!Val)
-       return std::numeric_limits<T>::digits;
-
-     // Bisection method.
-     std::size_t ZeroBits = 0;
-     for (T Shift = std::numeric_limits<T>::digits >> 1; Shift; Shift >>= 1) {
-       T Tmp = Val >> Shift;
-       if (Tmp)
-         Val = Tmp;
-       else
-         ZeroBits |= Shift;
-     }
-     return ZeroBits;
-   }
- };
-
- #if __GNUC__ >= 4 || defined(_MSC_VER)
- template <typename T> struct LeadingZerosCounter<T, 4> {
-   static std::size_t count(T Val, ZeroBehavior ZB) {
-     if (ZB != ZB_Undefined && Val == 0)
-       return 32;
-
- #if __has_builtin(__builtin_clz) || LLVM_GNUC_PREREQ(4, 0, 0)
-     return __builtin_clz(Val);
- #elif defined(_MSC_VER)
-     unsigned long Index;
-     _BitScanReverse(&Index, Val);
-     return Index ^ 31;
- #endif
-   }
- };
-
- #if !defined(_MSC_VER) || defined(_M_X64)
- template <typename T> struct LeadingZerosCounter<T, 8> {
-   static std::size_t count(T Val, ZeroBehavior ZB) {
-     if (ZB != ZB_Undefined && Val == 0)
-       return 64;
-
- #if __has_builtin(__builtin_clzll) || LLVM_GNUC_PREREQ(4, 0, 0)
-     return __builtin_clzll(Val);
- #elif defined(_MSC_VER)
-     unsigned long Index;
-     _BitScanReverse64(&Index, Val);
-     return Index ^ 63;
- #endif
-   }
- };
- #endif
- #endif
- } // namespace detail
-
- /// Count number of 0's from the most significant bit to the least
- ///   stopping at the first 1.
- ///
- /// Only unsigned integral types are allowed.
- ///
- /// \param ZB the behavior on an input of 0. Only ZB_Width and ZB_Undefined are
- ///   valid arguments.
- template <typename T>
- std::size_t countLeadingZeros(T Val, ZeroBehavior ZB = ZB_Width) {
-   static_assert(std::numeric_limits<T>::is_integer &&
-                     !std::numeric_limits<T>::is_signed,
-                 "Only unsigned integral types are allowed.");
-   return llvm::detail::LeadingZerosCounter<T, sizeof(T)>::count(Val, ZB);
- }
-
- /// Get the index of the first set bit starting from the least
- ///   significant bit.
- ///
- /// Only unsigned integral types are allowed.
- ///
- /// \param ZB the behavior on an input of 0. Only ZB_Max and ZB_Undefined are
- ///   valid arguments.
- template <typename T> T findFirstSet(T Val, ZeroBehavior ZB = ZB_Max) {
-   if (ZB == ZB_Max && Val == 0)
-     return std::numeric_limits<T>::max();
-
-   return countTrailingZeros(Val, ZB_Undefined);
- }
-
- /// Create a bitmask with the N right-most bits set to 1, and all other
- /// bits set to 0.  Only unsigned types are allowed.
- template <typename T> T maskTrailingOnes(unsigned N) {
-   static_assert(std::is_unsigned<T>::value, "Invalid type!");
-   const unsigned Bits = CHAR_BIT * sizeof(T);
-   assert(N <= Bits && "Invalid bit index");
-   return N == 0 ? 0 : (T(-1) >> (Bits - N));
- }
-
- /// Create a bitmask with the N left-most bits set to 1, and all other
- /// bits set to 0.  Only unsigned types are allowed.
- template <typename T> T maskLeadingOnes(unsigned N) {
-   return ~maskTrailingOnes<T>(CHAR_BIT * sizeof(T) - N);
- }
-
- /// Create a bitmask with the N right-most bits set to 0, and all other
- /// bits set to 1.  Only unsigned types are allowed.
- template <typename T> T maskTrailingZeros(unsigned N) {
-   return maskLeadingOnes<T>(CHAR_BIT * sizeof(T) - N);
- }
-
- /// Create a bitmask with the N left-most bits set to 0, and all other
- /// bits set to 1.  Only unsigned types are allowed.
- template <typename T> T maskLeadingZeros(unsigned N) {
-   return maskTrailingOnes<T>(CHAR_BIT * sizeof(T) - N);
- }
-
- /// Get the index of the last set bit starting from the least
- ///   significant bit.
- ///
- /// Only unsigned integral types are allowed.
- ///
- /// \param ZB the behavior on an input of 0. Only ZB_Max and ZB_Undefined are
- ///   valid arguments.
- template <typename T> T findLastSet(T Val, ZeroBehavior ZB = ZB_Max) {
-   if (ZB == ZB_Max && Val == 0)
-     return std::numeric_limits<T>::max();
-
-   // Use ^ instead of - because both gcc and llvm can remove the associated ^
-   // in the __builtin_clz intrinsic on x86.
-   return countLeadingZeros(Val, ZB_Undefined) ^
-          (std::numeric_limits<T>::digits - 1);
- }
-
- /// Macro compressed bit reversal table for 256 bits.
- ///
- /// http://graphics.stanford.edu/~seander/bithacks.html#BitReverseTable
- static const unsigned char BitReverseTable256[256] = {
- #define R2(n) n, n + 2 * 64, n + 1 * 64, n + 3 * 64
- #define R4(n) R2(n), R2(n + 2 * 16), R2(n + 1 * 16), R2(n + 3 * 16)
- #define R6(n) R4(n), R4(n + 2 * 4), R4(n + 1 * 4), R4(n + 3 * 4)
-   R6(0), R6(2), R6(1), R6(3)
- #undef R2
- #undef R4
- #undef R6
- };
-
- /// Reverse the bits in \p Val.
- template <typename T>
- T reverseBits(T Val) {
-   unsigned char in[sizeof(Val)];
-   unsigned char out[sizeof(Val)];
-   std::memcpy(in, &Val, sizeof(Val));
-   for (unsigned i = 0; i < sizeof(Val); ++i)
-     out[(sizeof(Val) - i) - 1] = BitReverseTable256[in[i]];
-   std::memcpy(&Val, out, sizeof(Val));
-   return Val;
- }
-
- // NOTE: The following support functions use the _32/_64 extensions instead of
- // type overloading so that signed and unsigned integers can be used without
- // ambiguity.
-
- /// Return the high 32 bits of a 64 bit value.
- constexpr inline uint32_t Hi_32(uint64_t Value) {
-   return static_cast<uint32_t>(Value >> 32);
- }
-
- /// Return the low 32 bits of a 64 bit value.
- constexpr inline uint32_t Lo_32(uint64_t Value) {
-   return static_cast<uint32_t>(Value);
- }
-
- /// Make a 64-bit integer from a high / low pair of 32-bit integers.
- constexpr inline uint64_t Make_64(uint32_t High, uint32_t Low) {
-   return ((uint64_t)High << 32) | (uint64_t)Low;
- }
-
- /// Checks if an integer fits into the given bit width.
- template <unsigned N> constexpr inline bool isInt(int64_t x) {
-   return N >= 64 || (-(INT64_C(1)<<(N-1)) <= x && x < (INT64_C(1)<<(N-1)));
- }
- // Template specializations to get better code for common cases.
- template <> constexpr inline bool isInt<8>(int64_t x) {
-   return static_cast<int8_t>(x) == x;
- }
- template <> constexpr inline bool isInt<16>(int64_t x) {
-   return static_cast<int16_t>(x) == x;
- }
- template <> constexpr inline bool isInt<32>(int64_t x) {
-   return static_cast<int32_t>(x) == x;
- }
-
- /// Checks if a signed integer is an N bit number shifted left by S.
- template <unsigned N, unsigned S>
- constexpr inline bool isShiftedInt(int64_t x) {
-   static_assert(
-       N > 0, "isShiftedInt<0> doesn't make sense (refers to a 0-bit number.");
-   static_assert(N + S <= 64, "isShiftedInt<N, S> with N + S > 64 is too wide.");
-   return isInt<N + S>(x) && (x % (UINT64_C(1) << S) == 0);
- }
-
- /// Checks if an unsigned integer fits into the given bit width.
- ///
- /// This is written as two functions rather than as simply
- ///
- ///   return N >= 64 || X < (UINT64_C(1) << N);
- ///
- /// to keep MSVC from (incorrectly) warning on isUInt<64> that we're shifting
- /// left too many places.
- template <unsigned N>
- constexpr inline typename std::enable_if<(N < 64), bool>::type
- isUInt(uint64_t X) {
-   static_assert(N > 0, "isUInt<0> doesn't make sense");
-   return X < (UINT64_C(1) << (N));
- }
- template <unsigned N>
- constexpr inline typename std::enable_if<N >= 64, bool>::type
- isUInt(uint64_t X) {
-   return true;
- }
-
- // Template specializations to get better code for common cases.
- template <> constexpr inline bool isUInt<8>(uint64_t x) {
-   return static_cast<uint8_t>(x) == x;
- }
- template <> constexpr inline bool isUInt<16>(uint64_t x) {
-   return static_cast<uint16_t>(x) == x;
- }
- template <> constexpr inline bool isUInt<32>(uint64_t x) {
-   return static_cast<uint32_t>(x) == x;
- }
-
- /// Checks if a unsigned integer is an N bit number shifted left by S.
- template <unsigned N, unsigned S>
- constexpr inline bool isShiftedUInt(uint64_t x) {
-   static_assert(
-       N > 0, "isShiftedUInt<0> doesn't make sense (refers to a 0-bit number)");
-   static_assert(N + S <= 64,
-                 "isShiftedUInt<N, S> with N + S > 64 is too wide.");
-   // Per the two static_asserts above, S must be strictly less than 64.  So
-   // 1 << S is not undefined behavior.
-   return isUInt<N + S>(x) && (x % (UINT64_C(1) << S) == 0);
- }
-
- /// Gets the maximum value for a N-bit unsigned integer.
- inline uint64_t maxUIntN(uint64_t N) {
-   assert(N > 0 && N <= 64 && "integer width out of range");
-
-   // uint64_t(1) << 64 is undefined behavior, so we can't do
-   //   (uint64_t(1) << N) - 1
-   // without checking first that N != 64.  But this works and doesn't have a
-   // branch.
-   return UINT64_MAX >> (64 - N);
- }
-
- /// Gets the minimum value for a N-bit signed integer.
- inline int64_t minIntN(int64_t N) {
-   assert(N > 0 && N <= 64 && "integer width out of range");
-
-   return -(UINT64_C(1)<<(N-1));
- }
-
- /// Gets the maximum value for a N-bit signed integer.
- inline int64_t maxIntN(int64_t N) {
-   assert(N > 0 && N <= 64 && "integer width out of range");
-
-   // This relies on two's complement wraparound when N == 64, so we convert to
-   // int64_t only at the very end to avoid UB.
-   return (UINT64_C(1) << (N - 1)) - 1;
- }
-
- /// Checks if an unsigned integer fits into the given (dynamic) bit width.
- inline bool isUIntN(unsigned N, uint64_t x) {
-   return N >= 64 || x <= maxUIntN(N);
- }
-
- /// Checks if an signed integer fits into the given (dynamic) bit width.
- inline bool isIntN(unsigned N, int64_t x) {
-   return N >= 64 || (minIntN(N) <= x && x <= maxIntN(N));
- }
-
- /// Return true if the argument is a non-empty sequence of ones starting at the
- /// least significant bit with the remainder zero (32 bit version).
- /// Ex. isMask_32(0x0000FFFFU) == true.
- constexpr inline bool isMask_32(uint32_t Value) {
-   return Value && ((Value + 1) & Value) == 0;
- }
-
- /// Return true if the argument is a non-empty sequence of ones starting at the
- /// least significant bit with the remainder zero (64 bit version).
- constexpr inline bool isMask_64(uint64_t Value) {
-   return Value && ((Value + 1) & Value) == 0;
- }
-
- /// Return true if the argument contains a non-empty sequence of ones with the
- /// remainder zero (32 bit version.) Ex. isShiftedMask_32(0x0000FF00U) == true.
- constexpr inline bool isShiftedMask_32(uint32_t Value) {
-   return Value && isMask_32((Value - 1) | Value);
- }
-
- /// Return true if the argument contains a non-empty sequence of ones with the
- /// remainder zero (64 bit version.)
- constexpr inline bool isShiftedMask_64(uint64_t Value) {
-   return Value && isMask_64((Value - 1) | Value);
- }
-
- /// Return true if the argument is a power of two > 0.
- /// Ex. isPowerOf2_32(0x00100000U) == true (32 bit edition.)
- constexpr inline bool isPowerOf2_32(uint32_t Value) {
-   return Value && !(Value & (Value - 1));
- }
-
- /// Return true if the argument is a power of two > 0 (64 bit edition.)
- constexpr inline bool isPowerOf2_64(uint64_t Value) {
-   return Value && !(Value & (Value - 1));
- }
-
- /// Count the number of ones from the most significant bit to the first
- /// zero bit.
- ///
- /// Ex. countLeadingOnes(0xFF0FFF00) == 8.
- /// Only unsigned integral types are allowed.
- ///
- /// \param ZB the behavior on an input of all ones. Only ZB_Width and
- /// ZB_Undefined are valid arguments.
- template <typename T>
- std::size_t countLeadingOnes(T Value, ZeroBehavior ZB = ZB_Width) {
-   static_assert(std::numeric_limits<T>::is_integer &&
-                     !std::numeric_limits<T>::is_signed,
-                 "Only unsigned integral types are allowed.");
-   return countLeadingZeros<T>(~Value, ZB);
- }
-
- /// Count the number of ones from the least significant bit to the first
- /// zero bit.
- ///
- /// Ex. countTrailingOnes(0x00FF00FF) == 8.
- /// Only unsigned integral types are allowed.
- ///
- /// \param ZB the behavior on an input of all ones. Only ZB_Width and
- /// ZB_Undefined are valid arguments.
- template <typename T>
- std::size_t countTrailingOnes(T Value, ZeroBehavior ZB = ZB_Width) {
-   static_assert(std::numeric_limits<T>::is_integer &&
-                     !std::numeric_limits<T>::is_signed,
-                 "Only unsigned integral types are allowed.");
-   return countTrailingZeros<T>(~Value, ZB);
- }
-
- namespace detail {
- template <typename T, std::size_t SizeOfT> struct PopulationCounter {
-   static unsigned count(T Value) {
-     // Generic version, forward to 32 bits.
-     static_assert(SizeOfT <= 4, "Not implemented!");
- #if __GNUC__ >= 4
-     return __builtin_popcount(Value);
- #else
-     uint32_t v = Value;
-     v = v - ((v >> 1) & 0x55555555);
-     v = (v & 0x33333333) + ((v >> 2) & 0x33333333);
-     return ((v + (v >> 4) & 0xF0F0F0F) * 0x1010101) >> 24;
- #endif
-   }
- };
-
- template <typename T> struct PopulationCounter<T, 8> {
-   static unsigned count(T Value) {
- #if __GNUC__ >= 4
-     return __builtin_popcountll(Value);
- #else
-     uint64_t v = Value;
-     v = v - ((v >> 1) & 0x5555555555555555ULL);
-     v = (v & 0x3333333333333333ULL) + ((v >> 2) & 0x3333333333333333ULL);
-     v = (v + (v >> 4)) & 0x0F0F0F0F0F0F0F0FULL;
-     return unsigned((uint64_t)(v * 0x0101010101010101ULL) >> 56);
- #endif
-   }
- };
- } // namespace detail
-
- /// Count the number of set bits in a value.
- /// Ex. countPopulation(0xF000F000) = 8
- /// Returns 0 if the word is zero.
- template <typename T>
- inline unsigned countPopulation(T Value) {
-   static_assert(std::numeric_limits<T>::is_integer &&
-                     !std::numeric_limits<T>::is_signed,
-                 "Only unsigned integral types are allowed.");
-   return detail::PopulationCounter<T, sizeof(T)>::count(Value);
- }
-
- /// Return the log base 2 of the specified value.
- inline double Log2(double Value) {
- #if defined(__ANDROID_API__) && __ANDROID_API__ < 18
-   return __builtin_log(Value) / __builtin_log(2.0);
- #else
-   return log2(Value);
- #endif
- }
-
- /// Return the floor log base 2 of the specified value, -1 if the value is zero.
- /// (32 bit edition.)
- /// Ex. Log2_32(32) == 5, Log2_32(1) == 0, Log2_32(0) == -1, Log2_32(6) == 2
- inline unsigned Log2_32(uint32_t Value) {
-   return 31 - countLeadingZeros(Value);
- }
-
- /// Return the floor log base 2 of the specified value, -1 if the value is zero.
- /// (64 bit edition.)
- inline unsigned Log2_64(uint64_t Value) {
-   return 63 - countLeadingZeros(Value);
- }
-
- /// Return the ceil log base 2 of the specified value, 32 if the value is zero.
- /// (32 bit edition).
- /// Ex. Log2_32_Ceil(32) == 5, Log2_32_Ceil(1) == 0, Log2_32_Ceil(6) == 3
- inline unsigned Log2_32_Ceil(uint32_t Value) {
-   return 32 - countLeadingZeros(Value - 1);
- }
-
- /// Return the ceil log base 2 of the specified value, 64 if the value is zero.
- /// (64 bit edition.)
- inline unsigned Log2_64_Ceil(uint64_t Value) {
-   return 64 - countLeadingZeros(Value - 1);
- }
-
- /// Return the greatest common divisor of the values using Euclid's algorithm.
- inline uint64_t GreatestCommonDivisor64(uint64_t A, uint64_t B) {
-   while (B) {
-     uint64_t T = B;
-     B = A % B;
-     A = T;
-   }
-   return A;
- }
-
- /// This function takes a 64-bit integer and returns the bit equivalent double.
- inline double BitsToDouble(uint64_t Bits) {
-   double D;
-   static_assert(sizeof(uint64_t) == sizeof(double), "Unexpected type sizes");
-   memcpy(&D, &Bits, sizeof(Bits));
-   return D;
- }
-
- /// This function takes a 32-bit integer and returns the bit equivalent float.
- inline float BitsToFloat(uint32_t Bits) {
-   float F;
-   static_assert(sizeof(uint32_t) == sizeof(float), "Unexpected type sizes");
-   memcpy(&F, &Bits, sizeof(Bits));
-   return F;
- }
-
- /// This function takes a double and returns the bit equivalent 64-bit integer.
- /// Note that copying doubles around changes the bits of NaNs on some hosts,
- /// notably x86, so this routine cannot be used if these bits are needed.
- inline uint64_t DoubleToBits(double Double) {
-   uint64_t Bits;
-   static_assert(sizeof(uint64_t) == sizeof(double), "Unexpected type sizes");
-   memcpy(&Bits, &Double, sizeof(Double));
-   return Bits;
- }
-
- /// This function takes a float and returns the bit equivalent 32-bit integer.
- /// Note that copying floats around changes the bits of NaNs on some hosts,
- /// notably x86, so this routine cannot be used if these bits are needed.
- inline uint32_t FloatToBits(float Float) {
-   uint32_t Bits;
-   static_assert(sizeof(uint32_t) == sizeof(float), "Unexpected type sizes");
-   memcpy(&Bits, &Float, sizeof(Float));
-   return Bits;
- }
-
- /// A and B are either alignments or offsets. Return the minimum alignment that
- /// may be assumed after adding the two together.
- constexpr inline uint64_t MinAlign(uint64_t A, uint64_t B) {
-   // The largest power of 2 that divides both A and B.
-   //
-   // Replace "-Value" by "1+~Value" in the following commented code to avoid
-   // MSVC warning C4146
-   //    return (A | B) & -(A | B);
-   return (A | B) & (1 + ~(A | B));
- }
-
- /// Aligns \c Addr to \c Alignment bytes, rounding up.
- ///
- /// Alignment should be a power of two.  This method rounds up, so
- /// alignAddr(7, 4) == 8 and alignAddr(8, 4) == 8.
- inline uintptr_t alignAddr(const void *Addr, size_t Alignment) {
-   assert(Alignment && isPowerOf2_64((uint64_t)Alignment) &&
-          "Alignment is not a power of two!");
-
-   assert((uintptr_t)Addr + Alignment - 1 >= (uintptr_t)Addr);
-
-   return (((uintptr_t)Addr + Alignment - 1) & ~(uintptr_t)(Alignment - 1));
- }
-
- /// Returns the necessary adjustment for aligning \c Ptr to \c Alignment
- /// bytes, rounding up.
- inline size_t alignmentAdjustment(const void *Ptr, size_t Alignment) {
-   return alignAddr(Ptr, Alignment) - (uintptr_t)Ptr;
- }
-
- /// Returns the next power of two (in 64-bits) that is strictly greater than A.
- /// Returns zero on overflow.
- inline uint64_t NextPowerOf2(uint64_t A) {
-   A |= (A >> 1);
-   A |= (A >> 2);
-   A |= (A >> 4);
-   A |= (A >> 8);
-   A |= (A >> 16);
-   A |= (A >> 32);
-   return A + 1;
- }
-
- /// Returns the power of two which is less than or equal to the given value.
- /// Essentially, it is a floor operation across the domain of powers of two.
- inline uint64_t PowerOf2Floor(uint64_t A) {
-   if (!A) return 0;
-   return 1ull << (63 - countLeadingZeros(A, ZB_Undefined));
- }
-
- /// Returns the power of two which is greater than or equal to the given value.
- /// Essentially, it is a ceil operation across the domain of powers of two.
- inline uint64_t PowerOf2Ceil(uint64_t A) {
-   if (!A)
-     return 0;
-   return NextPowerOf2(A - 1);
- }
-
- /// Returns the next integer (mod 2**64) that is greater than or equal to
- /// \p Value and is a multiple of \p Align. \p Align must be non-zero.
- ///
- /// If non-zero \p Skew is specified, the return value will be a minimal
- /// integer that is greater than or equal to \p Value and equal to
- /// \p Align * N + \p Skew for some integer N. If \p Skew is larger than
- /// \p Align, its value is adjusted to '\p Skew mod \p Align'.
- ///
- /// Examples:
- /// \code
- ///   alignTo(5, 8) = 8
- ///   alignTo(17, 8) = 24
- ///   alignTo(~0LL, 8) = 0
- ///   alignTo(321, 255) = 510
- ///
- ///   alignTo(5, 8, 7) = 7
- ///   alignTo(17, 8, 1) = 17
- ///   alignTo(~0LL, 8, 3) = 3
- ///   alignTo(321, 255, 42) = 552
- /// \endcode
- inline uint64_t alignTo(uint64_t Value, uint64_t Align, uint64_t Skew = 0) {
-   assert(Align != 0u && "Align can't be 0.");
-   Skew %= Align;
-   return (Value + Align - 1 - Skew) / Align * Align + Skew;
- }
-
- /// Returns the next integer (mod 2**64) that is greater than or equal to
- /// \p Value and is a multiple of \c Align. \c Align must be non-zero.
- template <uint64_t Align> constexpr inline uint64_t alignTo(uint64_t Value) {
-   static_assert(Align != 0u, "Align must be non-zero");
-   return (Value + Align - 1) / Align * Align;
- }
-
- /// Returns the integer ceil(Numerator / Denominator).
- inline uint64_t divideCeil(uint64_t Numerator, uint64_t Denominator) {
-   return alignTo(Numerator, Denominator) / Denominator;
- }
-
- /// \c alignTo for contexts where a constant expression is required.
- /// \sa alignTo
- ///
- /// \todo FIXME: remove when \c constexpr becomes really \c constexpr
- template <uint64_t Align>
- struct AlignTo {
-   static_assert(Align != 0u, "Align must be non-zero");
-   template <uint64_t Value>
-   struct from_value {
-     static const uint64_t value = (Value + Align - 1) / Align * Align;
-   };
- };
-
- /// Returns the largest uint64_t less than or equal to \p Value and is
- /// \p Skew mod \p Align. \p Align must be non-zero
- inline uint64_t alignDown(uint64_t Value, uint64_t Align, uint64_t Skew = 0) {
-   assert(Align != 0u && "Align can't be 0.");
-   Skew %= Align;
-   return (Value - Skew) / Align * Align + Skew;
- }
-
- /// Returns the offset to the next integer (mod 2**64) that is greater than
- /// or equal to \p Value and is a multiple of \p Align. \p Align must be
- /// non-zero.
- inline uint64_t OffsetToAlignment(uint64_t Value, uint64_t Align) {
-   return alignTo(Value, Align) - Value;
- }
-
- /// Sign-extend the number in the bottom B bits of X to a 32-bit integer.
- /// Requires 0 < B <= 32.
- template <unsigned B> constexpr inline int32_t SignExtend32(uint32_t X) {
-   static_assert(B > 0, "Bit width can't be 0.");
-   static_assert(B <= 32, "Bit width out of range.");
-   return int32_t(X << (32 - B)) >> (32 - B);
- }
-
- /// Sign-extend the number in the bottom B bits of X to a 32-bit integer.
- /// Requires 0 < B < 32.
- inline int32_t SignExtend32(uint32_t X, unsigned B) {
-   assert(B > 0 && "Bit width can't be 0.");
-   assert(B <= 32 && "Bit width out of range.");
-   return int32_t(X << (32 - B)) >> (32 - B);
- }
-
- /// Sign-extend the number in the bottom B bits of X to a 64-bit integer.
- /// Requires 0 < B < 64.
- template <unsigned B> constexpr inline int64_t SignExtend64(uint64_t x) {
-   static_assert(B > 0, "Bit width can't be 0.");
-   static_assert(B <= 64, "Bit width out of range.");
-   return int64_t(x << (64 - B)) >> (64 - B);
- }
-
- /// Sign-extend the number in the bottom B bits of X to a 64-bit integer.
- /// Requires 0 < B < 64.
- inline int64_t SignExtend64(uint64_t X, unsigned B) {
-   assert(B > 0 && "Bit width can't be 0.");
-   assert(B <= 64 && "Bit width out of range.");
-   return int64_t(X << (64 - B)) >> (64 - B);
- }
-
- /// Subtract two unsigned integers, X and Y, of type T and return the absolute
- /// value of the result.
- template <typename T>
- typename std::enable_if<std::is_unsigned<T>::value, T>::type
- AbsoluteDifference(T X, T Y) {
-   return std::max(X, Y) - std::min(X, Y);
- }
-
- /// Add two unsigned integers, X and Y, of type T.  Clamp the result to the
- /// maximum representable value of T on overflow.  ResultOverflowed indicates if
- /// the result is larger than the maximum representable value of type T.
- template <typename T>
- typename std::enable_if<std::is_unsigned<T>::value, T>::type
- SaturatingAdd(T X, T Y, bool *ResultOverflowed = nullptr) {
-   bool Dummy;
-   bool &Overflowed = ResultOverflowed ? *ResultOverflowed : Dummy;
-   // Hacker's Delight, p. 29
-   T Z = X + Y;
-   Overflowed = (Z < X || Z < Y);
-   if (Overflowed)
-     return std::numeric_limits<T>::max();
-   else
-     return Z;
- }
-
- /// Multiply two unsigned integers, X and Y, of type T.  Clamp the result to the
- /// maximum representable value of T on overflow.  ResultOverflowed indicates if
- /// the result is larger than the maximum representable value of type T.
- template <typename T>
- typename std::enable_if<std::is_unsigned<T>::value, T>::type
- SaturatingMultiply(T X, T Y, bool *ResultOverflowed = nullptr) {
-   bool Dummy;
-   bool &Overflowed = ResultOverflowed ? *ResultOverflowed : Dummy;
-
-   // Hacker's Delight, p. 30 has a different algorithm, but we don't use that
-   // because it fails for uint16_t (where multiplication can have undefined
-   // behavior due to promotion to int), and requires a division in addition
-   // to the multiplication.
-
-   Overflowed = false;
-
-   // Log2(Z) would be either Log2Z or Log2Z + 1.
-   // Special case: if X or Y is 0, Log2_64 gives -1, and Log2Z
-   // will necessarily be less than Log2Max as desired.
-   int Log2Z = Log2_64(X) + Log2_64(Y);
-   const T Max = std::numeric_limits<T>::max();
-   int Log2Max = Log2_64(Max);
-   if (Log2Z < Log2Max) {
-     return X * Y;
-   }
-   if (Log2Z > Log2Max) {
-     Overflowed = true;
-     return Max;
-   }
-
-   // We're going to use the top bit, and maybe overflow one
-   // bit past it. Multiply all but the bottom bit then add
-   // that on at the end.
-   T Z = (X >> 1) * Y;
-   if (Z & ~(Max >> 1)) {
-     Overflowed = true;
-     return Max;
-   }
-   Z <<= 1;
-   if (X & 1)
-     return SaturatingAdd(Z, Y, ResultOverflowed);
-
-   return Z;
- }
-
- /// Multiply two unsigned integers, X and Y, and add the unsigned integer, A to
- /// the product. Clamp the result to the maximum representable value of T on
- /// overflow. ResultOverflowed indicates if the result is larger than the
- /// maximum representable value of type T.
- template <typename T>
- typename std::enable_if<std::is_unsigned<T>::value, T>::type
- SaturatingMultiplyAdd(T X, T Y, T A, bool *ResultOverflowed = nullptr) {
-   bool Dummy;
-   bool &Overflowed = ResultOverflowed ? *ResultOverflowed : Dummy;
-
-   T Product = SaturatingMultiply(X, Y, &Overflowed);
-   if (Overflowed)
-     return Product;
-
-   return SaturatingAdd(A, Product, &Overflowed);
- }
-
- /// Use this rather than HUGE_VALF; the latter causes warnings on MSVC.
- extern const float huge_valf;
- } // End llvm namespace
-
- #endif
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file contains some functions that are useful for math stuff.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_SUPPORT_MATHEXTRAS_H
+#define LLVM_SUPPORT_MATHEXTRAS_H
+
+#include <algorithm>
+#include <cassert>
+#include <climits>
+#include <cmath>
+#include <cstring>
+#include <limits>
+#include <type_traits>
+
+#ifdef __ANDROID_NDK__
+#include <android/api-level.h>
+#endif
+
+#ifndef __has_builtin
+#define __has_builtin(x) 0
+#endif
+
+#ifndef LLVM_GNUC_PREREQ
+#if defined(__GNUC__) && defined(__GNUC_MINOR__) && defined(__GNUC_PATCHLEVEL__)
+#define LLVM_GNUC_PREREQ(maj, min, patch)                             \
+  ((__GNUC__ << 20) + (__GNUC_MINOR__ << 10) + __GNUC_PATCHLEVEL__ >= \
+   ((maj) << 20) + ((min) << 10) + (patch))
+#elif defined(__GNUC__) && defined(__GNUC_MINOR__)
+#define LLVM_GNUC_PREREQ(maj, min, patch) \
+  ((__GNUC__ << 20) + (__GNUC_MINOR__ << 10) >= ((maj) << 20) + ((min) << 10))
+#else
+#define LLVM_GNUC_PREREQ(maj, min, patch) 0
+#endif
+#endif
+
+#ifdef _MSC_VER
+// Declare these intrinsics manually rather including intrin.h. It's very
+// expensive, and MathExtras.h is popular.
+// #include <intrin.h>
+extern "C" {
+unsigned char _BitScanForward(unsigned long* _Index, unsigned long _Mask);
+unsigned char _BitScanForward64(unsigned long* _Index, unsigned __int64 _Mask);
+unsigned char _BitScanReverse(unsigned long* _Index, unsigned long _Mask);
+unsigned char _BitScanReverse64(unsigned long* _Index, unsigned __int64 _Mask);
+}
+#endif
+
+namespace llvm {
+/// The behavior an operation has on an input of 0.
+enum ZeroBehavior {
+  /// The returned value is undefined.
+  ZB_Undefined,
+  /// The returned value is numeric_limits<T>::max()
+  ZB_Max,
+  /// The returned value is numeric_limits<T>::digits
+  ZB_Width
+};
+
+namespace detail {
+template <typename T, std::size_t SizeOfT>
+struct TrailingZerosCounter {
+  static std::size_t count(T Val, ZeroBehavior) {
+    if (!Val)
+      return std::numeric_limits<T>::digits;
+    if (Val & 0x1)
+      return 0;
+
+    // Bisection method.
+    std::size_t ZeroBits = 0;
+    T Shift = std::numeric_limits<T>::digits >> 1;
+    T Mask = std::numeric_limits<T>::max() >> Shift;
+    while (Shift) {
+      if ((Val & Mask) == 0) {
+        Val >>= Shift;
+        ZeroBits |= Shift;
+      }
+      Shift >>= 1;
+      Mask >>= Shift;
+    }
+    return ZeroBits;
+  }
+};
+
+#if __GNUC__ >= 4 || defined(_MSC_VER)
+template <typename T>
+struct TrailingZerosCounter<T, 4> {
+  static std::size_t count(T Val, ZeroBehavior ZB) {
+    if (ZB != ZB_Undefined && Val == 0)
+      return 32;
+
+#if __has_builtin(__builtin_ctz) || LLVM_GNUC_PREREQ(4, 0, 0)
+    return __builtin_ctz(Val);
+#elif defined(_MSC_VER)
+    unsigned long Index;
+    _BitScanForward(&Index, Val);
+    return Index;
+#endif
+  }
+};
+
+#if !defined(_MSC_VER) || defined(_M_X64)
+template <typename T>
+struct TrailingZerosCounter<T, 8> {
+  static std::size_t count(T Val, ZeroBehavior ZB) {
+    if (ZB != ZB_Undefined && Val == 0)
+      return 64;
+
+#if __has_builtin(__builtin_ctzll) || LLVM_GNUC_PREREQ(4, 0, 0)
+    return __builtin_ctzll(Val);
+#elif defined(_MSC_VER)
+    unsigned long Index;
+    _BitScanForward64(&Index, Val);
+    return Index;
+#endif
+  }
+};
+#endif
+#endif
+} // namespace detail
+
+/// Count number of 0's from the least significant bit to the most
+///   stopping at the first 1.
+///
+/// Only unsigned integral types are allowed.
+///
+/// \param ZB the behavior on an input of 0. Only ZB_Width and ZB_Undefined are
+///   valid arguments.
+template <typename T>
+std::size_t countTrailingZeros(T Val, ZeroBehavior ZB = ZB_Width) {
+  static_assert(
+      std::numeric_limits<T>::is_integer && !std::numeric_limits<T>::is_signed,
+      "Only unsigned integral types are allowed.");
+  return llvm::detail::TrailingZerosCounter<T, sizeof(T)>::count(Val, ZB);
+}
+
+namespace detail {
+template <typename T, std::size_t SizeOfT>
+struct LeadingZerosCounter {
+  static std::size_t count(T Val, ZeroBehavior) {
+    if (!Val)
+      return std::numeric_limits<T>::digits;
+
+    // Bisection method.
+    std::size_t ZeroBits = 0;
+    for (T Shift = std::numeric_limits<T>::digits >> 1; Shift; Shift >>= 1) {
+      T Tmp = Val >> Shift;
+      if (Tmp)
+        Val = Tmp;
+      else
+        ZeroBits |= Shift;
+    }
+    return ZeroBits;
+  }
+};
+
+#if __GNUC__ >= 4 || defined(_MSC_VER)
+template <typename T>
+struct LeadingZerosCounter<T, 4> {
+  static std::size_t count(T Val, ZeroBehavior ZB) {
+    if (ZB != ZB_Undefined && Val == 0)
+      return 32;
+
+#if __has_builtin(__builtin_clz) || LLVM_GNUC_PREREQ(4, 0, 0)
+    return __builtin_clz(Val);
+#elif defined(_MSC_VER)
+    unsigned long Index;
+    _BitScanReverse(&Index, Val);
+    return Index ^ 31;
+#endif
+  }
+};
+
+#if !defined(_MSC_VER) || defined(_M_X64)
+template <typename T>
+struct LeadingZerosCounter<T, 8> {
+  static std::size_t count(T Val, ZeroBehavior ZB) {
+    if (ZB != ZB_Undefined && Val == 0)
+      return 64;
+
+#if __has_builtin(__builtin_clzll) || LLVM_GNUC_PREREQ(4, 0, 0)
+    return __builtin_clzll(Val);
+#elif defined(_MSC_VER)
+    unsigned long Index;
+    _BitScanReverse64(&Index, Val);
+    return Index ^ 63;
+#endif
+  }
+};
+#endif
+#endif
+} // namespace detail
+
+/// Count number of 0's from the most significant bit to the least
+///   stopping at the first 1.
+///
+/// Only unsigned integral types are allowed.
+///
+/// \param ZB the behavior on an input of 0. Only ZB_Width and ZB_Undefined are
+///   valid arguments.
+template <typename T>
+std::size_t countLeadingZeros(T Val, ZeroBehavior ZB = ZB_Width) {
+  static_assert(
+      std::numeric_limits<T>::is_integer && !std::numeric_limits<T>::is_signed,
+      "Only unsigned integral types are allowed.");
+  return llvm::detail::LeadingZerosCounter<T, sizeof(T)>::count(Val, ZB);
+}
+
+/// Get the index of the first set bit starting from the least
+///   significant bit.
+///
+/// Only unsigned integral types are allowed.
+///
+/// \param ZB the behavior on an input of 0. Only ZB_Max and ZB_Undefined are
+///   valid arguments.
+template <typename T>
+T findFirstSet(T Val, ZeroBehavior ZB = ZB_Max) {
+  if (ZB == ZB_Max && Val == 0)
+    return std::numeric_limits<T>::max();
+
+  return countTrailingZeros(Val, ZB_Undefined);
+}
+
+/// Create a bitmask with the N right-most bits set to 1, and all other
+/// bits set to 0.  Only unsigned types are allowed.
+template <typename T>
+T maskTrailingOnes(unsigned N) {
+  static_assert(std::is_unsigned<T>::value, "Invalid type!");
+  const unsigned Bits = CHAR_BIT * sizeof(T);
+  assert(N <= Bits && "Invalid bit index");
+  return N == 0 ? 0 : (T(-1) >> (Bits - N));
+}
+
+/// Create a bitmask with the N left-most bits set to 1, and all other
+/// bits set to 0.  Only unsigned types are allowed.
+template <typename T>
+T maskLeadingOnes(unsigned N) {
+  return ~maskTrailingOnes<T>(CHAR_BIT * sizeof(T) - N);
+}
+
+/// Create a bitmask with the N right-most bits set to 0, and all other
+/// bits set to 1.  Only unsigned types are allowed.
+template <typename T>
+T maskTrailingZeros(unsigned N) {
+  return maskLeadingOnes<T>(CHAR_BIT * sizeof(T) - N);
+}
+
+/// Create a bitmask with the N left-most bits set to 0, and all other
+/// bits set to 1.  Only unsigned types are allowed.
+template <typename T>
+T maskLeadingZeros(unsigned N) {
+  return maskTrailingOnes<T>(CHAR_BIT * sizeof(T) - N);
+}
+
+/// Get the index of the last set bit starting from the least
+///   significant bit.
+///
+/// Only unsigned integral types are allowed.
+///
+/// \param ZB the behavior on an input of 0. Only ZB_Max and ZB_Undefined are
+///   valid arguments.
+template <typename T>
+T findLastSet(T Val, ZeroBehavior ZB = ZB_Max) {
+  if (ZB == ZB_Max && Val == 0)
+    return std::numeric_limits<T>::max();
+
+  // Use ^ instead of - because both gcc and llvm can remove the associated ^
+  // in the __builtin_clz intrinsic on x86.
+  return countLeadingZeros(Val, ZB_Undefined) ^
+      (std::numeric_limits<T>::digits - 1);
+}
+
+/// Macro compressed bit reversal table for 256 bits.
+///
+/// http://graphics.stanford.edu/~seander/bithacks.html#BitReverseTable
+static const unsigned char BitReverseTable256[256] = {
+#define R2(n) n, n + 2 * 64, n + 1 * 64, n + 3 * 64
+#define R4(n) R2(n), R2(n + 2 * 16), R2(n + 1 * 16), R2(n + 3 * 16)
+#define R6(n) R4(n), R4(n + 2 * 4), R4(n + 1 * 4), R4(n + 3 * 4)
+    R6(0),
+    R6(2),
+    R6(1),
+    R6(3)
+#undef R2
+#undef R4
+#undef R6
+};
+
+/// Reverse the bits in \p Val.
+template <typename T>
+T reverseBits(T Val) {
+  unsigned char in[sizeof(Val)];
+  unsigned char out[sizeof(Val)];
+  std::memcpy(in, &Val, sizeof(Val));
+  for (unsigned i = 0; i < sizeof(Val); ++i)
+    out[(sizeof(Val) - i) - 1] = BitReverseTable256[in[i]];
+  std::memcpy(&Val, out, sizeof(Val));
+  return Val;
+}
+
+// NOTE: The following support functions use the _32/_64 extensions instead of
+// type overloading so that signed and unsigned integers can be used without
+// ambiguity.
+
+/// Return the high 32 bits of a 64 bit value.
+constexpr inline uint32_t Hi_32(uint64_t Value) {
+  return static_cast<uint32_t>(Value >> 32);
+}
+
+/// Return the low 32 bits of a 64 bit value.
+constexpr inline uint32_t Lo_32(uint64_t Value) {
+  return static_cast<uint32_t>(Value);
+}
+
+/// Make a 64-bit integer from a high / low pair of 32-bit integers.
+constexpr inline uint64_t Make_64(uint32_t High, uint32_t Low) {
+  return ((uint64_t)High << 32) | (uint64_t)Low;
+}
+
+/// Checks if an integer fits into the given bit width.
+template <unsigned N>
+constexpr inline bool isInt(int64_t x) {
+  return N >= 64 ||
+      (-(INT64_C(1) << (N - 1)) <= x && x < (INT64_C(1) << (N - 1)));
+}
+// Template specializations to get better code for common cases.
+template <>
+constexpr inline bool isInt<8>(int64_t x) {
+  return static_cast<int8_t>(x) == x;
+}
+template <>
+constexpr inline bool isInt<16>(int64_t x) {
+  return static_cast<int16_t>(x) == x;
+}
+template <>
+constexpr inline bool isInt<32>(int64_t x) {
+  return static_cast<int32_t>(x) == x;
+}
+
+/// Checks if a signed integer is an N bit number shifted left by S.
+template <unsigned N, unsigned S>
+constexpr inline bool isShiftedInt(int64_t x) {
+  static_assert(
+      N > 0, "isShiftedInt<0> doesn't make sense (refers to a 0-bit number.");
+  static_assert(N + S <= 64, "isShiftedInt<N, S> with N + S > 64 is too wide.");
+  return isInt<N + S>(x) && (x % (UINT64_C(1) << S) == 0);
+}
+
+/// Checks if an unsigned integer fits into the given bit width.
+///
+/// This is written as two functions rather than as simply
+///
+///   return N >= 64 || X < (UINT64_C(1) << N);
+///
+/// to keep MSVC from (incorrectly) warning on isUInt<64> that we're shifting
+/// left too many places.
+template <unsigned N>
+constexpr inline typename std::enable_if<(N < 64), bool>::type isUInt(
+    uint64_t X) {
+  static_assert(N > 0, "isUInt<0> doesn't make sense");
+  return X < (UINT64_C(1) << (N));
+}
+template <unsigned N>
+constexpr inline typename std::enable_if<N >= 64, bool>::type isUInt(
+    uint64_t X) {
+  return true;
+}
+
+// Template specializations to get better code for common cases.
+template <>
+constexpr inline bool isUInt<8>(uint64_t x) {
+  return static_cast<uint8_t>(x) == x;
+}
+template <>
+constexpr inline bool isUInt<16>(uint64_t x) {
+  return static_cast<uint16_t>(x) == x;
+}
+template <>
+constexpr inline bool isUInt<32>(uint64_t x) {
+  return static_cast<uint32_t>(x) == x;
+}
+
+/// Checks if a unsigned integer is an N bit number shifted left by S.
+template <unsigned N, unsigned S>
+constexpr inline bool isShiftedUInt(uint64_t x) {
+  static_assert(
+      N > 0, "isShiftedUInt<0> doesn't make sense (refers to a 0-bit number)");
+  static_assert(
+      N + S <= 64, "isShiftedUInt<N, S> with N + S > 64 is too wide.");
+  // Per the two static_asserts above, S must be strictly less than 64.  So
+  // 1 << S is not undefined behavior.
+  return isUInt<N + S>(x) && (x % (UINT64_C(1) << S) == 0);
+}
+
+/// Gets the maximum value for a N-bit unsigned integer.
+inline uint64_t maxUIntN(uint64_t N) {
+  assert(N > 0 && N <= 64 && "integer width out of range");
+
+  // uint64_t(1) << 64 is undefined behavior, so we can't do
+  //   (uint64_t(1) << N) - 1
+  // without checking first that N != 64.  But this works and doesn't have a
+  // branch.
+  return UINT64_MAX >> (64 - N);
+}
+
+/// Gets the minimum value for a N-bit signed integer.
+inline int64_t minIntN(int64_t N) {
+  assert(N > 0 && N <= 64 && "integer width out of range");
+
+  return -(UINT64_C(1) << (N - 1));
+}
+
+/// Gets the maximum value for a N-bit signed integer.
+inline int64_t maxIntN(int64_t N) {
+  assert(N > 0 && N <= 64 && "integer width out of range");
+
+  // This relies on two's complement wraparound when N == 64, so we convert to
+  // int64_t only at the very end to avoid UB.
+  return (UINT64_C(1) << (N - 1)) - 1;
+}
+
+/// Checks if an unsigned integer fits into the given (dynamic) bit width.
+inline bool isUIntN(unsigned N, uint64_t x) {
+  return N >= 64 || x <= maxUIntN(N);
+}
+
+/// Checks if an signed integer fits into the given (dynamic) bit width.
+inline bool isIntN(unsigned N, int64_t x) {
+  return N >= 64 || (minIntN(N) <= x && x <= maxIntN(N));
+}
+
+/// Return true if the argument is a non-empty sequence of ones starting at the
+/// least significant bit with the remainder zero (32 bit version).
+/// Ex. isMask_32(0x0000FFFFU) == true.
+constexpr inline bool isMask_32(uint32_t Value) {
+  return Value && ((Value + 1) & Value) == 0;
+}
+
+/// Return true if the argument is a non-empty sequence of ones starting at the
+/// least significant bit with the remainder zero (64 bit version).
+constexpr inline bool isMask_64(uint64_t Value) {
+  return Value && ((Value + 1) & Value) == 0;
+}
+
+/// Return true if the argument contains a non-empty sequence of ones with the
+/// remainder zero (32 bit version.) Ex. isShiftedMask_32(0x0000FF00U) == true.
+constexpr inline bool isShiftedMask_32(uint32_t Value) {
+  return Value && isMask_32((Value - 1) | Value);
+}
+
+/// Return true if the argument contains a non-empty sequence of ones with the
+/// remainder zero (64 bit version.)
+constexpr inline bool isShiftedMask_64(uint64_t Value) {
+  return Value && isMask_64((Value - 1) | Value);
+}
+
+/// Return true if the argument is a power of two > 0.
+/// Ex. isPowerOf2_32(0x00100000U) == true (32 bit edition.)
+constexpr inline bool isPowerOf2_32(uint32_t Value) {
+  return Value && !(Value & (Value - 1));
+}
+
+/// Return true if the argument is a power of two > 0 (64 bit edition.)
+constexpr inline bool isPowerOf2_64(uint64_t Value) {
+  return Value && !(Value & (Value - 1));
+}
+
+/// Count the number of ones from the most significant bit to the first
+/// zero bit.
+///
+/// Ex. countLeadingOnes(0xFF0FFF00) == 8.
+/// Only unsigned integral types are allowed.
+///
+/// \param ZB the behavior on an input of all ones. Only ZB_Width and
+/// ZB_Undefined are valid arguments.
+template <typename T>
+std::size_t countLeadingOnes(T Value, ZeroBehavior ZB = ZB_Width) {
+  static_assert(
+      std::numeric_limits<T>::is_integer && !std::numeric_limits<T>::is_signed,
+      "Only unsigned integral types are allowed.");
+  return countLeadingZeros<T>(~Value, ZB);
+}
+
+/// Count the number of ones from the least significant bit to the first
+/// zero bit.
+///
+/// Ex. countTrailingOnes(0x00FF00FF) == 8.
+/// Only unsigned integral types are allowed.
+///
+/// \param ZB the behavior on an input of all ones. Only ZB_Width and
+/// ZB_Undefined are valid arguments.
+template <typename T>
+std::size_t countTrailingOnes(T Value, ZeroBehavior ZB = ZB_Width) {
+  static_assert(
+      std::numeric_limits<T>::is_integer && !std::numeric_limits<T>::is_signed,
+      "Only unsigned integral types are allowed.");
+  return countTrailingZeros<T>(~Value, ZB);
+}
+
+namespace detail {
+template <typename T, std::size_t SizeOfT>
+struct PopulationCounter {
+  static unsigned count(T Value) {
+    // Generic version, forward to 32 bits.
+    static_assert(SizeOfT <= 4, "Not implemented!");
+#if __GNUC__ >= 4
+    return __builtin_popcount(Value);
+#else
+    uint32_t v = Value;
+    v = v - ((v >> 1) & 0x55555555);
+    v = (v & 0x33333333) + ((v >> 2) & 0x33333333);
+    return ((v + (v >> 4) & 0xF0F0F0F) * 0x1010101) >> 24;
+#endif
+  }
+};
+
+template <typename T>
+struct PopulationCounter<T, 8> {
+  static unsigned count(T Value) {
+#if __GNUC__ >= 4
+    return __builtin_popcountll(Value);
+#else
+    uint64_t v = Value;
+    v = v - ((v >> 1) & 0x5555555555555555ULL);
+    v = (v & 0x3333333333333333ULL) + ((v >> 2) & 0x3333333333333333ULL);
+    v = (v + (v >> 4)) & 0x0F0F0F0F0F0F0F0FULL;
+    return unsigned((uint64_t)(v * 0x0101010101010101ULL) >> 56);
+#endif
+  }
+};
+} // namespace detail
+
+/// Count the number of set bits in a value.
+/// Ex. countPopulation(0xF000F000) = 8
+/// Returns 0 if the word is zero.
+template <typename T>
+inline unsigned countPopulation(T Value) {
+  static_assert(
+      std::numeric_limits<T>::is_integer && !std::numeric_limits<T>::is_signed,
+      "Only unsigned integral types are allowed.");
+  return detail::PopulationCounter<T, sizeof(T)>::count(Value);
+}
+
+/// Return the log base 2 of the specified value.
+inline double Log2(double Value) {
+#if defined(__ANDROID_API__) && __ANDROID_API__ < 18
+  return __builtin_log(Value) / __builtin_log(2.0);
+#else
+  return log2(Value);
+#endif
+}
+
+/// Return the floor log base 2 of the specified value, -1 if the value is zero.
+/// (32 bit edition.)
+/// Ex. Log2_32(32) == 5, Log2_32(1) == 0, Log2_32(0) == -1, Log2_32(6) == 2
+inline unsigned Log2_32(uint32_t Value) {
+  return 31 - countLeadingZeros(Value);
+}
+
+/// Return the floor log base 2 of the specified value, -1 if the value is zero.
+/// (64 bit edition.)
+inline unsigned Log2_64(uint64_t Value) {
+  return 63 - countLeadingZeros(Value);
+}
+
+/// Return the ceil log base 2 of the specified value, 32 if the value is zero.
+/// (32 bit edition).
+/// Ex. Log2_32_Ceil(32) == 5, Log2_32_Ceil(1) == 0, Log2_32_Ceil(6) == 3
+inline unsigned Log2_32_Ceil(uint32_t Value) {
+  return 32 - countLeadingZeros(Value - 1);
+}
+
+/// Return the ceil log base 2 of the specified value, 64 if the value is zero.
+/// (64 bit edition.)
+inline unsigned Log2_64_Ceil(uint64_t Value) {
+  return 64 - countLeadingZeros(Value - 1);
+}
+
+/// Return the greatest common divisor of the values using Euclid's algorithm.
+inline uint64_t GreatestCommonDivisor64(uint64_t A, uint64_t B) {
+  while (B) {
+    uint64_t T = B;
+    B = A % B;
+    A = T;
+  }
+  return A;
+}
+
+/// This function takes a 64-bit integer and returns the bit equivalent double.
+inline double BitsToDouble(uint64_t Bits) {
+  double D;
+  static_assert(sizeof(uint64_t) == sizeof(double), "Unexpected type sizes");
+  memcpy(&D, &Bits, sizeof(Bits));
+  return D;
+}
+
+/// This function takes a 32-bit integer and returns the bit equivalent float.
+inline float BitsToFloat(uint32_t Bits) {
+  float F;
+  static_assert(sizeof(uint32_t) == sizeof(float), "Unexpected type sizes");
+  memcpy(&F, &Bits, sizeof(Bits));
+  return F;
+}
+
+/// This function takes a double and returns the bit equivalent 64-bit integer.
+/// Note that copying doubles around changes the bits of NaNs on some hosts,
+/// notably x86, so this routine cannot be used if these bits are needed.
+inline uint64_t DoubleToBits(double Double) {
+  uint64_t Bits;
+  static_assert(sizeof(uint64_t) == sizeof(double), "Unexpected type sizes");
+  memcpy(&Bits, &Double, sizeof(Double));
+  return Bits;
+}
+
+/// This function takes a float and returns the bit equivalent 32-bit integer.
+/// Note that copying floats around changes the bits of NaNs on some hosts,
+/// notably x86, so this routine cannot be used if these bits are needed.
+inline uint32_t FloatToBits(float Float) {
+  uint32_t Bits;
+  static_assert(sizeof(uint32_t) == sizeof(float), "Unexpected type sizes");
+  memcpy(&Bits, &Float, sizeof(Float));
+  return Bits;
+}
+
+/// A and B are either alignments or offsets. Return the minimum alignment that
+/// may be assumed after adding the two together.
+constexpr inline uint64_t MinAlign(uint64_t A, uint64_t B) {
+  // The largest power of 2 that divides both A and B.
+  //
+  // Replace "-Value" by "1+~Value" in the following commented code to avoid
+  // MSVC warning C4146
+  //    return (A | B) & -(A | B);
+  return (A | B) & (1 + ~(A | B));
+}
+
+/// Aligns \c Addr to \c Alignment bytes, rounding up.
+///
+/// Alignment should be a power of two.  This method rounds up, so
+/// alignAddr(7, 4) == 8 and alignAddr(8, 4) == 8.
+inline uintptr_t alignAddr(const void* Addr, size_t Alignment) {
+  assert(
+      Alignment && isPowerOf2_64((uint64_t)Alignment) &&
+      "Alignment is not a power of two!");
+
+  assert((uintptr_t)Addr + Alignment - 1 >= (uintptr_t)Addr);
+
+  return (((uintptr_t)Addr + Alignment - 1) & ~(uintptr_t)(Alignment - 1));
+}
+
+/// Returns the necessary adjustment for aligning \c Ptr to \c Alignment
+/// bytes, rounding up.
+inline size_t alignmentAdjustment(const void* Ptr, size_t Alignment) {
+  return alignAddr(Ptr, Alignment) - (uintptr_t)Ptr;
+}
+
+/// Returns the next power of two (in 64-bits) that is strictly greater than A.
+/// Returns zero on overflow.
+inline uint64_t NextPowerOf2(uint64_t A) {
+  A |= (A >> 1);
+  A |= (A >> 2);
+  A |= (A >> 4);
+  A |= (A >> 8);
+  A |= (A >> 16);
+  A |= (A >> 32);
+  return A + 1;
+}
+
+/// Returns the power of two which is less than or equal to the given value.
+/// Essentially, it is a floor operation across the domain of powers of two.
+inline uint64_t PowerOf2Floor(uint64_t A) {
+  if (!A)
+    return 0;
+  return 1ull << (63 - countLeadingZeros(A, ZB_Undefined));
+}
+
+/// Returns the power of two which is greater than or equal to the given value.
+/// Essentially, it is a ceil operation across the domain of powers of two.
+inline uint64_t PowerOf2Ceil(uint64_t A) {
+  if (!A)
+    return 0;
+  return NextPowerOf2(A - 1);
+}
+
+/// Returns the next integer (mod 2**64) that is greater than or equal to
+/// \p Value and is a multiple of \p Align. \p Align must be non-zero.
+///
+/// If non-zero \p Skew is specified, the return value will be a minimal
+/// integer that is greater than or equal to \p Value and equal to
+/// \p Align * N + \p Skew for some integer N. If \p Skew is larger than
+/// \p Align, its value is adjusted to '\p Skew mod \p Align'.
+///
+/// Examples:
+/// \code
+///   alignTo(5, 8) = 8
+///   alignTo(17, 8) = 24
+///   alignTo(~0LL, 8) = 0
+///   alignTo(321, 255) = 510
+///
+///   alignTo(5, 8, 7) = 7
+///   alignTo(17, 8, 1) = 17
+///   alignTo(~0LL, 8, 3) = 3
+///   alignTo(321, 255, 42) = 552
+/// \endcode
+inline uint64_t alignTo(uint64_t Value, uint64_t Align, uint64_t Skew = 0) {
+  assert(Align != 0u && "Align can't be 0.");
+  Skew %= Align;
+  return (Value + Align - 1 - Skew) / Align * Align + Skew;
+}
+
+/// Returns the next integer (mod 2**64) that is greater than or equal to
+/// \p Value and is a multiple of \c Align. \c Align must be non-zero.
+template <uint64_t Align>
+constexpr inline uint64_t alignTo(uint64_t Value) {
+  static_assert(Align != 0u, "Align must be non-zero");
+  return (Value + Align - 1) / Align * Align;
+}
+
+/// Returns the integer ceil(Numerator / Denominator).
+inline uint64_t divideCeil(uint64_t Numerator, uint64_t Denominator) {
+  return alignTo(Numerator, Denominator) / Denominator;
+}
+
+/// \c alignTo for contexts where a constant expression is required.
+/// \sa alignTo
+///
+/// \todo FIXME: remove when \c constexpr becomes really \c constexpr
+template <uint64_t Align>
+struct AlignTo {
+  static_assert(Align != 0u, "Align must be non-zero");
+  template <uint64_t Value>
+  struct from_value {
+    static const uint64_t value = (Value + Align - 1) / Align * Align;
+  };
+};
+
+/// Returns the largest uint64_t less than or equal to \p Value and is
+/// \p Skew mod \p Align. \p Align must be non-zero
+inline uint64_t alignDown(uint64_t Value, uint64_t Align, uint64_t Skew = 0) {
+  assert(Align != 0u && "Align can't be 0.");
+  Skew %= Align;
+  return (Value - Skew) / Align * Align + Skew;
+}
+
+/// Returns the offset to the next integer (mod 2**64) that is greater than
+/// or equal to \p Value and is a multiple of \p Align. \p Align must be
+/// non-zero.
+inline uint64_t OffsetToAlignment(uint64_t Value, uint64_t Align) {
+  return alignTo(Value, Align) - Value;
+}
+
+/// Sign-extend the number in the bottom B bits of X to a 32-bit integer.
+/// Requires 0 < B <= 32.
+template <unsigned B>
+constexpr inline int32_t SignExtend32(uint32_t X) {
+  static_assert(B > 0, "Bit width can't be 0.");
+  static_assert(B <= 32, "Bit width out of range.");
+  return int32_t(X << (32 - B)) >> (32 - B);
+}
+
+/// Sign-extend the number in the bottom B bits of X to a 32-bit integer.
+/// Requires 0 < B < 32.
+inline int32_t SignExtend32(uint32_t X, unsigned B) {
+  assert(B > 0 && "Bit width can't be 0.");
+  assert(B <= 32 && "Bit width out of range.");
+  return int32_t(X << (32 - B)) >> (32 - B);
+}
+
+/// Sign-extend the number in the bottom B bits of X to a 64-bit integer.
+/// Requires 0 < B < 64.
+template <unsigned B>
+constexpr inline int64_t SignExtend64(uint64_t x) {
+  static_assert(B > 0, "Bit width can't be 0.");
+  static_assert(B <= 64, "Bit width out of range.");
+  return int64_t(x << (64 - B)) >> (64 - B);
+}
+
+/// Sign-extend the number in the bottom B bits of X to a 64-bit integer.
+/// Requires 0 < B < 64.
+inline int64_t SignExtend64(uint64_t X, unsigned B) {
+  assert(B > 0 && "Bit width can't be 0.");
+  assert(B <= 64 && "Bit width out of range.");
+  return int64_t(X << (64 - B)) >> (64 - B);
+}
+
+/// Subtract two unsigned integers, X and Y, of type T and return the absolute
+/// value of the result.
+template <typename T>
+typename std::enable_if<std::is_unsigned<T>::value, T>::type AbsoluteDifference(
+    T X,
+    T Y) {
+  return std::max(X, Y) - std::min(X, Y);
+}
+
+/// Add two unsigned integers, X and Y, of type T.  Clamp the result to the
+/// maximum representable value of T on overflow.  ResultOverflowed indicates if
+/// the result is larger than the maximum representable value of type T.
+template <typename T>
+typename std::enable_if<std::is_unsigned<T>::value, T>::type SaturatingAdd(
+    T X,
+    T Y,
+    bool* ResultOverflowed = nullptr) {
+  bool Dummy;
+  bool& Overflowed = ResultOverflowed ? *ResultOverflowed : Dummy;
+  // Hacker's Delight, p. 29
+  T Z = X + Y;
+  Overflowed = (Z < X || Z < Y);
+  if (Overflowed)
+    return std::numeric_limits<T>::max();
+  else
+    return Z;
+}
+
+/// Multiply two unsigned integers, X and Y, of type T.  Clamp the result to the
+/// maximum representable value of T on overflow.  ResultOverflowed indicates if
+/// the result is larger than the maximum representable value of type T.
+template <typename T>
+typename std::enable_if<std::is_unsigned<T>::value, T>::type SaturatingMultiply(
+    T X,
+    T Y,
+    bool* ResultOverflowed = nullptr) {
+  bool Dummy;
+  bool& Overflowed = ResultOverflowed ? *ResultOverflowed : Dummy;
+
+  // Hacker's Delight, p. 30 has a different algorithm, but we don't use that
+  // because it fails for uint16_t (where multiplication can have undefined
+  // behavior due to promotion to int), and requires a division in addition
+  // to the multiplication.
+
+  Overflowed = false;
+
+  // Log2(Z) would be either Log2Z or Log2Z + 1.
+  // Special case: if X or Y is 0, Log2_64 gives -1, and Log2Z
+  // will necessarily be less than Log2Max as desired.
+  int Log2Z = Log2_64(X) + Log2_64(Y);
+  const T Max = std::numeric_limits<T>::max();
+  int Log2Max = Log2_64(Max);
+  if (Log2Z < Log2Max) {
+    return X * Y;
+  }
+  if (Log2Z > Log2Max) {
+    Overflowed = true;
+    return Max;
+  }
+
+  // We're going to use the top bit, and maybe overflow one
+  // bit past it. Multiply all but the bottom bit then add
+  // that on at the end.
+  T Z = (X >> 1) * Y;
+  if (Z & ~(Max >> 1)) {
+    Overflowed = true;
+    return Max;
+  }
+  Z <<= 1;
+  if (X & 1)
+    return SaturatingAdd(Z, Y, ResultOverflowed);
+
+  return Z;
+}
+
+/// Multiply two unsigned integers, X and Y, and add the unsigned integer, A to
+/// the product. Clamp the result to the maximum representable value of T on
+/// overflow. ResultOverflowed indicates if the result is larger than the
+/// maximum representable value of type T.
+template <typename T>
+typename std::enable_if<std::is_unsigned<T>::value, T>::type
+SaturatingMultiplyAdd(T X, T Y, T A, bool* ResultOverflowed = nullptr) {
+  bool Dummy;
+  bool& Overflowed = ResultOverflowed ? *ResultOverflowed : Dummy;
+
+  T Product = SaturatingMultiply(X, Y, &Overflowed);
+  if (Overflowed)
+    return Product;
+
+  return SaturatingAdd(A, Product, &Overflowed);
+}
+
+/// Use this rather than HUGE_VALF; the latter causes warnings on MSVC.
+extern const float huge_valf;
+} // namespace llvm
+
+#endif

--- a/c10/util/numa.cpp
+++ b/c10/util/numa.cpp
@@ -109,8 +109,7 @@ bool IsNUMAEnabled() {
   return false;
 }
 
-void NUMABind(int numa_node_id) {
-}
+void NUMABind(int numa_node_id) {}
 
 int GetNUMANode(const void* ptr) {
   return -1;
@@ -120,8 +119,7 @@ int GetNumNUMANodes() {
   return -1;
 }
 
-void NUMAMove(void* ptr, size_t size, int numa_node_id) {
-}
+void NUMAMove(void* ptr, size_t size, int numa_node_id) {}
 
 int GetCurrentNUMANode() {
   return -1;

--- a/c10/util/order_preserving_flat_hash_map.h
+++ b/c10/util/order_preserving_flat_hash_map.h
@@ -1,29 +1,32 @@
-// Taken from https://github.com/skarupke/flat_hash_map/blob/2c4687431f978f02a3780e24b8b701d22aa32d9c/flat_hash_map.hpp
+// Taken from
+// https://github.com/skarupke/flat_hash_map/blob/2c4687431f978f02a3780e24b8b701d22aa32d9c/flat_hash_map.hpp
 // with fixes applied:
 // - https://github.com/skarupke/flat_hash_map/pull/25
 // - https://github.com/skarupke/flat_hash_map/pull/26
 // - replace size_t with uint64_t to fix it for 32bit
 // - add "GCC diagnostic" pragma to ignore -Wshadow
-// - make sherwood_v3_table::convertible_to_iterator public because GCC5 seems to have issues with it otherwise
+// - make sherwood_v3_table::convertible_to_iterator public because GCC5 seems
+// to have issues with it otherwise
 // - fix compiler warnings in operator templated_iterator<const value_type>
 
 //          Copyright Malte Skarupke 2017.
 // Distributed under the Boost Software License, Version 1.0.
 //    (See http://www.boost.org/LICENSE_1_0.txt)
 
-// Modified to maintain insertion and deletion order through a doubly-linked list
+// Modified to maintain insertion and deletion order through a doubly-linked
+// list
 
 #pragma once
 
-#include <cstdint>
-#include <cstddef>
-#include <functional>
-#include <cmath>
-#include <algorithm>
-#include <iterator>
-#include <utility>
-#include <type_traits>
 #include <c10/util/C++17.h>
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <iterator>
+#include <type_traits>
+#include <utility>
 
 #ifndef _MSC_VER
 #pragma GCC diagnostic push
@@ -36,1607 +39,2194 @@
 #define SKA_NOINLINE(...) __VA_ARGS__ __attribute__((noinline))
 #endif
 
-namespace ska_ordered
-{
+namespace ska_ordered {
 
 struct prime_number_hash_policy;
 struct power_of_two_hash_policy;
 struct fibonacci_hash_policy;
 
-namespace detailv3
-{
-template<typename Result, typename Functor>
-struct functor_storage : Functor
-{
-    functor_storage() = default;
-    functor_storage(const Functor & functor)
-        : Functor(functor)
-    {
-    }
-    template<typename... Args>
-    Result operator()(Args &&... args)
-    {
-        return static_cast<Functor &>(*this)(std::forward<Args>(args)...);
-    }
-    template<typename... Args>
-    Result operator()(Args &&... args) const
-    {
-        return static_cast<const Functor &>(*this)(std::forward<Args>(args)...);
-    }
+namespace detailv3 {
+template <typename Result, typename Functor>
+struct functor_storage : Functor {
+  functor_storage() = default;
+  functor_storage(const Functor& functor) : Functor(functor) {}
+  template <typename... Args>
+  Result operator()(Args&&... args) {
+    return static_cast<Functor&>(*this)(std::forward<Args>(args)...);
+  }
+  template <typename... Args>
+  Result operator()(Args&&... args) const {
+    return static_cast<const Functor&>(*this)(std::forward<Args>(args)...);
+  }
 };
-template<typename Result, typename... Args>
-struct functor_storage<Result, Result (*)(Args...)>
-{
-    typedef Result (*function_ptr)(Args...);
-    function_ptr function;
-    functor_storage(function_ptr function)
-        : function(function)
-    {
-    }
-    Result operator()(Args... args) const
-    {
-        return function(std::forward<Args>(args)...);
-    }
-    operator function_ptr &()
-    {
-        return function;
-    }
-    operator const function_ptr &()
-    {
-        return function;
-    }
+template <typename Result, typename... Args>
+struct functor_storage<Result, Result (*)(Args...)> {
+  typedef Result (*function_ptr)(Args...);
+  function_ptr function;
+  functor_storage(function_ptr function) : function(function) {}
+  Result operator()(Args... args) const {
+    return function(std::forward<Args>(args)...);
+  }
+  operator function_ptr&() {
+    return function;
+  }
+  operator const function_ptr&() {
+    return function;
+  }
 };
-template<typename key_type, typename value_type, typename hasher>
-struct KeyOrValueHasher : functor_storage<uint64_t, hasher>
-{
-    typedef functor_storage<uint64_t, hasher> hasher_storage;
-    KeyOrValueHasher() = default;
-    KeyOrValueHasher(const hasher & hash)
-        : hasher_storage(hash)
-    {
-    }
-    uint64_t operator()(const key_type & key)
-    {
-        return static_cast<hasher_storage &>(*this)(key);
-    }
-    uint64_t operator()(const key_type & key) const
-    {
-        return static_cast<const hasher_storage &>(*this)(key);
-    }
-    uint64_t operator()(const value_type & value)
-    {
-        return static_cast<hasher_storage &>(*this)(value.first);
-    }
-    uint64_t operator()(const value_type & value) const
-    {
-        return static_cast<const hasher_storage &>(*this)(value.first);
-    }
-    template<typename F, typename S>
-    uint64_t operator()(const std::pair<F, S> & value)
-    {
-        return static_cast<hasher_storage &>(*this)(value.first);
-    }
-    template<typename F, typename S>
-    uint64_t operator()(const std::pair<F, S> & value) const
-    {
-        return static_cast<const hasher_storage &>(*this)(value.first);
-    }
+template <typename key_type, typename value_type, typename hasher>
+struct KeyOrValueHasher : functor_storage<uint64_t, hasher> {
+  typedef functor_storage<uint64_t, hasher> hasher_storage;
+  KeyOrValueHasher() = default;
+  KeyOrValueHasher(const hasher& hash) : hasher_storage(hash) {}
+  uint64_t operator()(const key_type& key) {
+    return static_cast<hasher_storage&>(*this)(key);
+  }
+  uint64_t operator()(const key_type& key) const {
+    return static_cast<const hasher_storage&>(*this)(key);
+  }
+  uint64_t operator()(const value_type& value) {
+    return static_cast<hasher_storage&>(*this)(value.first);
+  }
+  uint64_t operator()(const value_type& value) const {
+    return static_cast<const hasher_storage&>(*this)(value.first);
+  }
+  template <typename F, typename S>
+  uint64_t operator()(const std::pair<F, S>& value) {
+    return static_cast<hasher_storage&>(*this)(value.first);
+  }
+  template <typename F, typename S>
+  uint64_t operator()(const std::pair<F, S>& value) const {
+    return static_cast<const hasher_storage&>(*this)(value.first);
+  }
 };
-template<typename key_type, typename value_type, typename key_equal>
-struct KeyOrValueEquality : functor_storage<bool, key_equal>
-{
-    typedef functor_storage<bool, key_equal> equality_storage;
-    KeyOrValueEquality() = default;
-    KeyOrValueEquality(const key_equal & equality)
-        : equality_storage(equality)
-    {
-    }
-    bool operator()(const key_type & lhs, const key_type & rhs)
-    {
-        return static_cast<equality_storage &>(*this)(lhs, rhs);
-    }
-    bool operator()(const key_type & lhs, const value_type & rhs)
-    {
-        return static_cast<equality_storage &>(*this)(lhs, rhs.first);
-    }
-    bool operator()(const value_type & lhs, const key_type & rhs)
-    {
-        return static_cast<equality_storage &>(*this)(lhs.first, rhs);
-    }
-    bool operator()(const value_type & lhs, const value_type & rhs)
-    {
-        return static_cast<equality_storage &>(*this)(lhs.first, rhs.first);
-    }
-    template<typename F, typename S>
-    bool operator()(const key_type & lhs, const std::pair<F, S> & rhs)
-    {
-        return static_cast<equality_storage &>(*this)(lhs, rhs.first);
-    }
-    template<typename F, typename S>
-    bool operator()(const std::pair<F, S> & lhs, const key_type & rhs)
-    {
-        return static_cast<equality_storage &>(*this)(lhs.first, rhs);
-    }
-    template<typename F, typename S>
-    bool operator()(const value_type & lhs, const std::pair<F, S> & rhs)
-    {
-        return static_cast<equality_storage &>(*this)(lhs.first, rhs.first);
-    }
-    template<typename F, typename S>
-    bool operator()(const std::pair<F, S> & lhs, const value_type & rhs)
-    {
-        return static_cast<equality_storage &>(*this)(lhs.first, rhs.first);
-    }
-    template<typename FL, typename SL, typename FR, typename SR>
-    bool operator()(const std::pair<FL, SL> & lhs, const std::pair<FR, SR> & rhs)
-    {
-        return static_cast<equality_storage &>(*this)(lhs.first, rhs.first);
-    }
+template <typename key_type, typename value_type, typename key_equal>
+struct KeyOrValueEquality : functor_storage<bool, key_equal> {
+  typedef functor_storage<bool, key_equal> equality_storage;
+  KeyOrValueEquality() = default;
+  KeyOrValueEquality(const key_equal& equality) : equality_storage(equality) {}
+  bool operator()(const key_type& lhs, const key_type& rhs) {
+    return static_cast<equality_storage&>(*this)(lhs, rhs);
+  }
+  bool operator()(const key_type& lhs, const value_type& rhs) {
+    return static_cast<equality_storage&>(*this)(lhs, rhs.first);
+  }
+  bool operator()(const value_type& lhs, const key_type& rhs) {
+    return static_cast<equality_storage&>(*this)(lhs.first, rhs);
+  }
+  bool operator()(const value_type& lhs, const value_type& rhs) {
+    return static_cast<equality_storage&>(*this)(lhs.first, rhs.first);
+  }
+  template <typename F, typename S>
+  bool operator()(const key_type& lhs, const std::pair<F, S>& rhs) {
+    return static_cast<equality_storage&>(*this)(lhs, rhs.first);
+  }
+  template <typename F, typename S>
+  bool operator()(const std::pair<F, S>& lhs, const key_type& rhs) {
+    return static_cast<equality_storage&>(*this)(lhs.first, rhs);
+  }
+  template <typename F, typename S>
+  bool operator()(const value_type& lhs, const std::pair<F, S>& rhs) {
+    return static_cast<equality_storage&>(*this)(lhs.first, rhs.first);
+  }
+  template <typename F, typename S>
+  bool operator()(const std::pair<F, S>& lhs, const value_type& rhs) {
+    return static_cast<equality_storage&>(*this)(lhs.first, rhs.first);
+  }
+  template <typename FL, typename SL, typename FR, typename SR>
+  bool operator()(const std::pair<FL, SL>& lhs, const std::pair<FR, SR>& rhs) {
+    return static_cast<equality_storage&>(*this)(lhs.first, rhs.first);
+  }
 };
 static constexpr int8_t min_lookups = 4;
-template<typename T>
-struct sherwood_v3_entry
-{
-    sherwood_v3_entry()
-    {
-    }
-    sherwood_v3_entry(int8_t distance_from_desired)
-        : distance_from_desired(distance_from_desired)
-    {
-    }
-    ~sherwood_v3_entry()
-    {
-    }
+template <typename T>
+struct sherwood_v3_entry {
+  sherwood_v3_entry() {}
+  sherwood_v3_entry(int8_t distance_from_desired)
+      : distance_from_desired(distance_from_desired) {}
+  ~sherwood_v3_entry() {}
 
-    bool has_value() const
-    {
-        return distance_from_desired >= 0;
-    }
-    bool is_empty() const
-    {
-        return distance_from_desired < 0;
-    }
-    bool is_at_desired_position() const
-    {
-        return distance_from_desired <= 0;
-    }
-    template<typename... Args>
-    void emplace(int8_t distance, Args &&... args)
-    {
-        new (std::addressof(value)) T(std::forward<Args>(args)...);
-        distance_from_desired = distance;
-    }
+  bool has_value() const {
+    return distance_from_desired >= 0;
+  }
+  bool is_empty() const {
+    return distance_from_desired < 0;
+  }
+  bool is_at_desired_position() const {
+    return distance_from_desired <= 0;
+  }
+  template <typename... Args>
+  void emplace(int8_t distance, Args&&... args) {
+    new (std::addressof(value)) T(std::forward<Args>(args)...);
+    distance_from_desired = distance;
+  }
 
-    void destroy_value()
-    {
-        value.~T();
-        distance_from_desired = -1;
-    }
+  void destroy_value() {
+    value.~T();
+    distance_from_desired = -1;
+  }
 
-    sherwood_v3_entry<T> * prev = nullptr;
-    sherwood_v3_entry<T> * next = nullptr;
-    int8_t distance_from_desired = -1;
-    static constexpr int8_t special_end_value = 0;
-    union { T value; };
+  sherwood_v3_entry<T>* prev = nullptr;
+  sherwood_v3_entry<T>* next = nullptr;
+  int8_t distance_from_desired = -1;
+  static constexpr int8_t special_end_value = 0;
+  union {
+    T value;
+  };
 };
 
-inline int8_t log2(uint64_t value)
-{
-    static constexpr int8_t table[64] =
-    {
-        63,  0, 58,  1, 59, 47, 53,  2,
-        60, 39, 48, 27, 54, 33, 42,  3,
-        61, 51, 37, 40, 49, 18, 28, 20,
-        55, 30, 34, 11, 43, 14, 22,  4,
-        62, 57, 46, 52, 38, 26, 32, 41,
-        50, 36, 17, 19, 29, 10, 13, 21,
-        56, 45, 25, 31, 35, 16,  9, 12,
-        44, 24, 15,  8, 23,  7,  6,  5
-    };
-    value |= value >> 1;
-    value |= value >> 2;
-    value |= value >> 4;
-    value |= value >> 8;
-    value |= value >> 16;
-    value |= value >> 32;
-    return table[((value - (value >> 1)) * 0x07EDD5E59A4E28C2) >> 58];
+inline int8_t log2(uint64_t value) {
+  static constexpr int8_t table[64] = {
+      63, 0,  58, 1,  59, 47, 53, 2,  60, 39, 48, 27, 54, 33, 42, 3,
+      61, 51, 37, 40, 49, 18, 28, 20, 55, 30, 34, 11, 43, 14, 22, 4,
+      62, 57, 46, 52, 38, 26, 32, 41, 50, 36, 17, 19, 29, 10, 13, 21,
+      56, 45, 25, 31, 35, 16, 9,  12, 44, 24, 15, 8,  23, 7,  6,  5};
+  value |= value >> 1;
+  value |= value >> 2;
+  value |= value >> 4;
+  value |= value >> 8;
+  value |= value >> 16;
+  value |= value >> 32;
+  return table[((value - (value >> 1)) * 0x07EDD5E59A4E28C2) >> 58];
 }
 
-template<typename T, bool>
-struct AssignIfTrue
-{
-    void operator()(T & lhs, const T & rhs)
-    {
-        lhs = rhs;
-    }
-    void operator()(T & lhs, T && rhs)
-    {
-        lhs = std::move(rhs);
-    }
+template <typename T, bool>
+struct AssignIfTrue {
+  void operator()(T& lhs, const T& rhs) {
+    lhs = rhs;
+  }
+  void operator()(T& lhs, T&& rhs) {
+    lhs = std::move(rhs);
+  }
 };
-template<typename T>
-struct AssignIfTrue<T, false>
-{
-    void operator()(T &, const T &)
-    {
-    }
-    void operator()(T &, T &&)
-    {
-    }
+template <typename T>
+struct AssignIfTrue<T, false> {
+  void operator()(T&, const T&) {}
+  void operator()(T&, T&&) {}
 };
 
-inline uint64_t next_power_of_two(uint64_t i)
-{
-    --i;
-    i |= i >> 1;
-    i |= i >> 2;
-    i |= i >> 4;
-    i |= i >> 8;
-    i |= i >> 16;
-    i |= i >> 32;
-    ++i;
-    return i;
+inline uint64_t next_power_of_two(uint64_t i) {
+  --i;
+  i |= i >> 1;
+  i |= i >> 2;
+  i |= i >> 4;
+  i |= i >> 8;
+  i |= i >> 16;
+  i |= i >> 32;
+  ++i;
+  return i;
 }
 
 // Implementation taken from http://en.cppreference.com/w/cpp/types/void_t
 // (it takes CWG1558 into account and also works for older compilers)
-template<typename... Ts> struct make_void { typedef void type;};
-template<typename... Ts> using void_t = typename make_void<Ts...>::type;
-
-template<typename T, typename = void>
-struct HashPolicySelector
-{
-    typedef fibonacci_hash_policy type;
+template <typename... Ts>
+struct make_void {
+  typedef void type;
 };
-template<typename T>
-struct HashPolicySelector<T, void_t<typename T::hash_policy>>
-{
-    typedef typename T::hash_policy type;
+template <typename... Ts>
+using void_t = typename make_void<Ts...>::type;
+
+template <typename T, typename = void>
+struct HashPolicySelector {
+  typedef fibonacci_hash_policy type;
+};
+template <typename T>
+struct HashPolicySelector<T, void_t<typename T::hash_policy>> {
+  typedef typename T::hash_policy type;
 };
 
-template<typename T, typename FindKey, typename ArgumentHash, typename Hasher, typename ArgumentEqual, typename Equal, typename ArgumentAlloc, typename EntryAlloc>
-class sherwood_v3_table : private EntryAlloc, private Hasher, private Equal
-{
-    using Entry = detailv3::sherwood_v3_entry<T>;
-    using AllocatorTraits = std::allocator_traits<EntryAlloc>;
-    using EntryPointer = typename AllocatorTraits::pointer;
+template <
+    typename T,
+    typename FindKey,
+    typename ArgumentHash,
+    typename Hasher,
+    typename ArgumentEqual,
+    typename Equal,
+    typename ArgumentAlloc,
+    typename EntryAlloc>
+class sherwood_v3_table : private EntryAlloc, private Hasher, private Equal {
+  using Entry = detailv3::sherwood_v3_entry<T>;
+  using AllocatorTraits = std::allocator_traits<EntryAlloc>;
+  using EntryPointer = typename AllocatorTraits::pointer;
 
-public:
-    struct convertible_to_iterator;
+ public:
+  struct convertible_to_iterator;
 
-    using value_type = T;
-    using size_type = uint64_t;
-    using difference_type = std::ptrdiff_t;
-    using hasher = ArgumentHash;
-    using key_equal = ArgumentEqual;
-    using allocator_type = EntryAlloc;
-    using reference = value_type &;
-    using const_reference = const value_type &;
-    using pointer = value_type *;
-    using const_pointer = const value_type *;
+  using value_type = T;
+  using size_type = uint64_t;
+  using difference_type = std::ptrdiff_t;
+  using hasher = ArgumentHash;
+  using key_equal = ArgumentEqual;
+  using allocator_type = EntryAlloc;
+  using reference = value_type&;
+  using const_reference = const value_type&;
+  using pointer = value_type*;
+  using const_pointer = const value_type*;
 
-    sherwood_v3_table()
-    {
+  sherwood_v3_table() {}
+  explicit sherwood_v3_table(
+      size_type bucket_count,
+      const ArgumentHash& hash = ArgumentHash(),
+      const ArgumentEqual& equal = ArgumentEqual(),
+      const ArgumentAlloc& alloc = ArgumentAlloc())
+      : EntryAlloc(alloc), Hasher(hash), Equal(equal) {
+    rehash(bucket_count);
+  }
+  sherwood_v3_table(size_type bucket_count, const ArgumentAlloc& alloc)
+      : sherwood_v3_table(
+            bucket_count,
+            ArgumentHash(),
+            ArgumentEqual(),
+            alloc) {}
+  sherwood_v3_table(
+      size_type bucket_count,
+      const ArgumentHash& hash,
+      const ArgumentAlloc& alloc)
+      : sherwood_v3_table(bucket_count, hash, ArgumentEqual(), alloc) {}
+  explicit sherwood_v3_table(const ArgumentAlloc& alloc) : EntryAlloc(alloc) {}
+  template <typename It>
+  sherwood_v3_table(
+      It first,
+      It last,
+      size_type bucket_count = 0,
+      const ArgumentHash& hash = ArgumentHash(),
+      const ArgumentEqual& equal = ArgumentEqual(),
+      const ArgumentAlloc& alloc = ArgumentAlloc())
+      : sherwood_v3_table(bucket_count, hash, equal, alloc) {
+    insert(first, last);
+  }
+  template <typename It>
+  sherwood_v3_table(
+      It first,
+      It last,
+      size_type bucket_count,
+      const ArgumentAlloc& alloc)
+      : sherwood_v3_table(
+            first,
+            last,
+            bucket_count,
+            ArgumentHash(),
+            ArgumentEqual(),
+            alloc) {}
+  template <typename It>
+  sherwood_v3_table(
+      It first,
+      It last,
+      size_type bucket_count,
+      const ArgumentHash& hash,
+      const ArgumentAlloc& alloc)
+      : sherwood_v3_table(
+            first,
+            last,
+            bucket_count,
+            hash,
+            ArgumentEqual(),
+            alloc) {}
+  sherwood_v3_table(
+      std::initializer_list<T> il,
+      size_type bucket_count = 0,
+      const ArgumentHash& hash = ArgumentHash(),
+      const ArgumentEqual& equal = ArgumentEqual(),
+      const ArgumentAlloc& alloc = ArgumentAlloc())
+      : sherwood_v3_table(bucket_count, hash, equal, alloc) {
+    if (bucket_count == 0)
+      rehash(il.size());
+    insert(il.begin(), il.end());
+  }
+  sherwood_v3_table(
+      std::initializer_list<T> il,
+      size_type bucket_count,
+      const ArgumentAlloc& alloc)
+      : sherwood_v3_table(
+            il,
+            bucket_count,
+            ArgumentHash(),
+            ArgumentEqual(),
+            alloc) {}
+  sherwood_v3_table(
+      std::initializer_list<T> il,
+      size_type bucket_count,
+      const ArgumentHash& hash,
+      const ArgumentAlloc& alloc)
+      : sherwood_v3_table(il, bucket_count, hash, ArgumentEqual(), alloc) {}
+  sherwood_v3_table(const sherwood_v3_table& other)
+      : sherwood_v3_table(
+            other,
+            AllocatorTraits::select_on_container_copy_construction(
+                other.get_allocator())) {}
+  sherwood_v3_table(const sherwood_v3_table& other, const ArgumentAlloc& alloc)
+      : EntryAlloc(alloc),
+        Hasher(other),
+        Equal(other),
+        _max_load_factor(other._max_load_factor) {
+    rehash_for_other_container(other);
+    try {
+      insert(other.begin(), other.end());
+    } catch (...) {
+      clear();
+      deallocate_data(entries, num_slots_minus_one, max_lookups);
+      throw;
     }
-    explicit sherwood_v3_table(size_type bucket_count, const ArgumentHash & hash = ArgumentHash(), const ArgumentEqual & equal = ArgumentEqual(), const ArgumentAlloc & alloc = ArgumentAlloc())
-        : EntryAlloc(alloc), Hasher(hash), Equal(equal)
-    {
-        rehash(bucket_count);
-    }
-    sherwood_v3_table(size_type bucket_count, const ArgumentAlloc & alloc)
-        : sherwood_v3_table(bucket_count, ArgumentHash(), ArgumentEqual(), alloc)
-    {
-    }
-    sherwood_v3_table(size_type bucket_count, const ArgumentHash & hash, const ArgumentAlloc & alloc)
-        : sherwood_v3_table(bucket_count, hash, ArgumentEqual(), alloc)
-    {
-    }
-    explicit sherwood_v3_table(const ArgumentAlloc & alloc)
-        : EntryAlloc(alloc)
-    {
-    }
-    template<typename It>
-    sherwood_v3_table(It first, It last, size_type bucket_count = 0, const ArgumentHash & hash = ArgumentHash(), const ArgumentEqual & equal = ArgumentEqual(), const ArgumentAlloc & alloc = ArgumentAlloc())
-        : sherwood_v3_table(bucket_count, hash, equal, alloc)
-    {
-        insert(first, last);
-    }
-    template<typename It>
-    sherwood_v3_table(It first, It last, size_type bucket_count, const ArgumentAlloc & alloc)
-        : sherwood_v3_table(first, last, bucket_count, ArgumentHash(), ArgumentEqual(), alloc)
-    {
-    }
-    template<typename It>
-    sherwood_v3_table(It first, It last, size_type bucket_count, const ArgumentHash & hash, const ArgumentAlloc & alloc)
-        : sherwood_v3_table(first, last, bucket_count, hash, ArgumentEqual(), alloc)
-    {
-    }
-    sherwood_v3_table(std::initializer_list<T> il, size_type bucket_count = 0, const ArgumentHash & hash = ArgumentHash(), const ArgumentEqual & equal = ArgumentEqual(), const ArgumentAlloc & alloc = ArgumentAlloc())
-        : sherwood_v3_table(bucket_count, hash, equal, alloc)
-    {
-        if (bucket_count == 0)
-            rehash(il.size());
-        insert(il.begin(), il.end());
-    }
-    sherwood_v3_table(std::initializer_list<T> il, size_type bucket_count, const ArgumentAlloc & alloc)
-        : sherwood_v3_table(il, bucket_count, ArgumentHash(), ArgumentEqual(), alloc)
-    {
-    }
-    sherwood_v3_table(std::initializer_list<T> il, size_type bucket_count, const ArgumentHash & hash, const ArgumentAlloc & alloc)
-        : sherwood_v3_table(il, bucket_count, hash, ArgumentEqual(), alloc)
-    {
-    }
-    sherwood_v3_table(const sherwood_v3_table & other)
-        : sherwood_v3_table(other, AllocatorTraits::select_on_container_copy_construction(other.get_allocator()))
-    {
-    }
-    sherwood_v3_table(const sherwood_v3_table & other, const ArgumentAlloc & alloc)
-        : EntryAlloc(alloc), Hasher(other), Equal(other), _max_load_factor(other._max_load_factor)
-    {
-        rehash_for_other_container(other);
-        try
-        {
-            insert(other.begin(), other.end());
-        }
-        catch(...)
-        {
-            clear();
-            deallocate_data(entries, num_slots_minus_one, max_lookups);
-            throw;
-        }
-    }
-    sherwood_v3_table(sherwood_v3_table && other) noexcept
-        : EntryAlloc(std::move(other)), Hasher(std::move(other)), Equal(std::move(other))
-    {
-        swap_pointers(other);
-    }
-    sherwood_v3_table(sherwood_v3_table && other, const ArgumentAlloc & alloc) noexcept
-        : EntryAlloc(alloc), Hasher(std::move(other)), Equal(std::move(other))
-    {
-        swap_pointers(other);
-    }
-    sherwood_v3_table & operator=(const sherwood_v3_table & other)
-    {
-        if (this == std::addressof(other))
-            return *this;
+  }
+  sherwood_v3_table(sherwood_v3_table&& other) noexcept
+      : EntryAlloc(std::move(other)),
+        Hasher(std::move(other)),
+        Equal(std::move(other)) {
+    swap_pointers(other);
+  }
+  sherwood_v3_table(
+      sherwood_v3_table&& other,
+      const ArgumentAlloc& alloc) noexcept
+      : EntryAlloc(alloc), Hasher(std::move(other)), Equal(std::move(other)) {
+    swap_pointers(other);
+  }
+  sherwood_v3_table& operator=(const sherwood_v3_table& other) {
+    if (this == std::addressof(other))
+      return *this;
 
-        clear();
-        if (AllocatorTraits::propagate_on_container_copy_assignment::value)
-        {
-            if (static_cast<EntryAlloc &>(*this) != static_cast<const EntryAlloc &>(other))
-            {
-                reset_to_empty_state();
-            }
-            AssignIfTrue<EntryAlloc, AllocatorTraits::propagate_on_container_copy_assignment::value>()(*this, other);
-        }
-        _max_load_factor = other._max_load_factor;
-        static_cast<Hasher &>(*this) = other;
-        static_cast<Equal &>(*this) = other;
-        rehash_for_other_container(other);
-        insert(other.begin(), other.end());
-        return *this;
-    }
-    sherwood_v3_table & operator=(sherwood_v3_table && other) noexcept
-    {
-        if (this == std::addressof(other))
-            return *this;
-        else if (AllocatorTraits::propagate_on_container_move_assignment::value)
-        {
-            clear();
-            reset_to_empty_state();
-            AssignIfTrue<EntryAlloc, AllocatorTraits::propagate_on_container_move_assignment::value>()(*this, std::move(other));
-            swap_pointers(other);
-        }
-        else if (static_cast<EntryAlloc &>(*this) == static_cast<EntryAlloc &>(other))
-        {
-            swap_pointers(other);
-        }
-        else
-        {
-            clear();
-            _max_load_factor = other._max_load_factor;
-            rehash_for_other_container(other);
-            for (T & elem : other)
-                emplace(std::move(elem));
-            other.clear();
-        }
-        static_cast<Hasher &>(*this) = std::move(other);
-        static_cast<Equal &>(*this) = std::move(other);
-        return *this;
-    }
-    ~sherwood_v3_table()
-    {
-        clear();
-        deallocate_data(entries, num_slots_minus_one, max_lookups);
-    }
-
-    const allocator_type & get_allocator() const
-    {
-        return static_cast<const allocator_type &>(*this);
-    }
-    const ArgumentEqual & key_eq() const
-    {
-        return static_cast<const ArgumentEqual &>(*this);
-    }
-    const ArgumentHash & hash_function() const
-    {
-        return static_cast<const ArgumentHash &>(*this);
-    }
-
-    template<typename ValueType>
-    struct templated_iterator
-    {
-        templated_iterator() = default;
-        templated_iterator(EntryPointer current)
-            : current(current)
-        {
-        }
-        EntryPointer current = EntryPointer();
-
-        using iterator_category = std::forward_iterator_tag;
-        using value_type = ValueType;
-        using difference_type = ptrdiff_t;
-        using pointer = ValueType *;
-        using reference = ValueType &;
-
-        friend bool operator==(const templated_iterator & lhs, const templated_iterator & rhs)
-        {
-            return lhs.current == rhs.current;
-        }
-        friend bool operator!=(const templated_iterator & lhs, const templated_iterator & rhs)
-        {
-            return !(lhs == rhs);
-        }
-
-        templated_iterator & operator++()
-        {
-            current = current->next;
-            return *this;
-        }
-        templated_iterator operator++(int)
-        {
-            templated_iterator copy(*this);
-            ++*this;
-            return copy;
-        }
-
-        ValueType & operator*() const
-        {
-            return current->value;
-        }
-        ValueType * operator->() const
-        {
-            return std::addressof(current->value);
-        }
-
-        // the template automatically disables the operator when value_type is already
-        // const, because that would cause a lot of compiler warnings otherwise.
-        template<class target_type = const value_type, class = typename std::enable_if<std::is_same<target_type, const value_type>::value && !std::is_same<target_type, value_type>::value>::type>
-        operator templated_iterator<target_type>() const
-        {
-            return { current };
-        }
-    };
-    using iterator = templated_iterator<value_type>;
-    using const_iterator = templated_iterator<const value_type>;
-
-    iterator begin()
-    {
-        return sentinel->next;
-    }
-    const_iterator begin() const
-    {
-        return sentinel->next;
-    }
-    const_iterator cbegin() const
-    {
-        return begin();
-    }
-    iterator end()
-    {
-        return sentinel;
-    }
-    const_iterator end() const
-    {
-        return sentinel;
-    }
-    const_iterator cend() const
-    {
-        return end();
-    }
-
-    iterator find(const FindKey & key)
-    {
-        uint64_t index = hash_policy.index_for_hash(hash_object(key), num_slots_minus_one);
-        EntryPointer it = entries + ptrdiff_t(index);
-        for (int8_t distance = 0; it->distance_from_desired >= distance; ++distance, ++it)
-        {
-            if (compares_equal(key, it->value))
-                return { it };
-        }
-        return end();
-    }
-    const_iterator find(const FindKey & key) const
-    {
-        return const_cast<sherwood_v3_table *>(this)->find(key);
-    }
-    uint64_t count(const FindKey & key) const
-    {
-        return find(key) == end() ? 0 : 1;
-    }
-    std::pair<iterator, iterator> equal_range(const FindKey & key)
-    {
-        iterator found = find(key);
-        if (found == end())
-            return { found, found };
-        else
-            return { found, std::next(found) };
-    }
-    std::pair<const_iterator, const_iterator> equal_range(const FindKey & key) const
-    {
-        const_iterator found = find(key);
-        if (found == end())
-            return { found, found };
-        else
-            return { found, std::next(found) };
-    }
-
-    template<typename Key, typename... Args>
-    std::pair<iterator, bool> emplace(Key && key, Args &&... args)
-    {
-        uint64_t index = hash_policy.index_for_hash(hash_object(key), num_slots_minus_one);
-        EntryPointer current_entry = entries + ptrdiff_t(index);
-        int8_t distance_from_desired = 0;
-        for (; current_entry->distance_from_desired >= distance_from_desired; ++current_entry, ++distance_from_desired)
-        {
-            // insertion of an existing key does not change ordering
-            if (compares_equal(key, current_entry->value))
-                return { { current_entry }, false };
-        }
-        return emplace_new_key(distance_from_desired, current_entry, std::forward<Key>(key), std::forward<Args>(args)...);
-    }
-
-    std::pair<iterator, bool> insert(const value_type & value)
-    {
-        return emplace(value);
-    }
-    std::pair<iterator, bool> insert(value_type && value)
-    {
-        return emplace(std::move(value));
-    }
-    template<typename... Args>
-    iterator emplace_hint(const_iterator, Args &&... args)
-    {
-        return emplace(std::forward<Args>(args)...).first;
-    }
-    iterator insert(const_iterator, const value_type & value)
-    {
-        return emplace(value).first;
-    }
-    iterator insert(const_iterator, value_type && value)
-    {
-        return emplace(std::move(value)).first;
-    }
-
-    template<typename It>
-    void insert(It begin, It end)
-    {
-        for (; begin != end; ++begin)
-        {
-            emplace(*begin);
-        }
-    }
-    void insert(std::initializer_list<value_type> il)
-    {
-        insert(il.begin(), il.end());
-    }
-
-    void rehash(uint64_t num_buckets)
-    {
-        num_buckets = std::max(num_buckets, static_cast<uint64_t>(std::ceil(num_elements / static_cast<double>(_max_load_factor))));
-        if (num_buckets == 0)
-        {
-            reset_to_empty_state();
-            return;
-        }
-        auto new_prime_index = hash_policy.next_size_over(num_buckets);
-        if (num_buckets == bucket_count())
-            return;
-        int8_t new_max_lookups = compute_max_lookups(num_buckets);
-        EntryPointer new_buckets(AllocatorTraits::allocate(*this, num_buckets + new_max_lookups));
-        EntryPointer special_end_item = new_buckets + static_cast<ptrdiff_t>(num_buckets + new_max_lookups - 1);
-        for (EntryPointer it = new_buckets; it != special_end_item; ++it)
-            it->distance_from_desired = -1;
-        special_end_item->distance_from_desired = Entry::special_end_value;
-        std::swap(entries, new_buckets);
-        std::swap(num_slots_minus_one, num_buckets);
-        --num_slots_minus_one;
-        hash_policy.commit(new_prime_index);
-        int8_t old_max_lookups = max_lookups;
-        max_lookups = new_max_lookups;
-        num_elements = 0;
-
-        auto start = sentinel->next;
-        // point sentinel to itself;
-        reset_list();
-        // reinsert list
-        for (EntryPointer it = start; it != sentinel;) {
-          auto next = it->next;
-          emplace(std::move(it->value));
-          it->destroy_value();
-          it = next;
-        }
-
-        deallocate_data(new_buckets, num_buckets, old_max_lookups);
-    }
-
-    void reserve(uint64_t num_elements)
-    {
-        uint64_t required_buckets = num_buckets_for_reserve(num_elements);
-        if (required_buckets > bucket_count())
-            rehash(required_buckets);
-    }
-
-    void replace_linked_list_position(EntryPointer to_be_replaced, EntryPointer new_node) {
-      remove_from_list(new_node);
-      insert_after(new_node, to_be_replaced->prev);
-      remove_from_list(to_be_replaced);
-    }
-
-    // the return value is a type that can be converted to an iterator
-    // the reason for doing this is that it's not free to find the
-    // iterator pointing at the next element. if you care about the
-    // next iterator, turn the return value into an iterator
-    convertible_to_iterator erase(const_iterator to_erase)
-    {
-        EntryPointer current = to_erase.current;
-        remove_from_list(current);
-        current->destroy_value();
-        --num_elements;
-
-        for (EntryPointer next = current + ptrdiff_t(1); !next->is_at_desired_position(); ++current, ++next)
-        {
-            // if an entry is being removed, and there are other entries with the
-            // same hash, the other entries get moved to their desired position by
-            // reinserting.
-            current->emplace(next->distance_from_desired - 1, std::move(next->value));
-            replace_linked_list_position(next, current);
-            next->destroy_value();
-        }
-        return { to_erase.current };
-    }
-
-    iterator erase(const_iterator begin_it, const_iterator end_it)
-    {
-        // whenever an entry is removed and there are other entries with the same
-        // hash, the other entries must get moved to their desired position.
-        // any reference to a moved entry is invalidated.
-        // here, we iterate through the range, and make sure that we update
-        // the pointer to our next entry in the list or the end of the iterator
-        // when it is invalidated.
-
-        auto curr_iter = begin_it.current;
-        auto next_iter = curr_iter->next;
-        auto end_iter = end_it.current;
-
-        while (curr_iter != end_iter) {
-          remove_from_list(curr_iter);
-          curr_iter->destroy_value();
-          --num_elements;
-
-          for (EntryPointer next_hash_slot = curr_iter + ptrdiff_t(1); !next_hash_slot->is_at_desired_position(); ++curr_iter, ++next_hash_slot)
-            {
-              curr_iter->emplace(next_hash_slot->distance_from_desired - 1, std::move(next_hash_slot->value));
-              replace_linked_list_position(next_hash_slot, curr_iter);
-              next_hash_slot->destroy_value();
-
-              // we are invalidating next_iter or end_iter
-              if (next_hash_slot == end_iter) {
-                end_iter = curr_iter;
-              } else if (next_hash_slot == next_iter) {
-                next_iter = curr_iter;
-              }
-          }
-          curr_iter = next_iter;
-          next_iter = curr_iter->next;
-        }
-
-        return { end_iter };
-    }
-
-    uint64_t erase(const FindKey & key)
-    {
-        auto found = find(key);
-        if (found == end())
-            return 0;
-        else
-        {
-            erase(found);
-            return 1;
-        }
-    }
-
-    void clear()
-    {
-        for (EntryPointer it = entries, end = it + static_cast<ptrdiff_t>(num_slots_minus_one + max_lookups); it != end; ++it)
-        {
-            if (it->has_value())
-                it->destroy_value();
-        }
-        reset_list();
-        num_elements = 0;
-    }
-
-    void shrink_to_fit()
-    {
-        rehash_for_other_container(*this);
-    }
-
-    void swap(sherwood_v3_table & other)
-    {
-        using std::swap;
-        swap_pointers(other);
-        swap(static_cast<ArgumentHash &>(*this), static_cast<ArgumentHash &>(other));
-        swap(static_cast<ArgumentEqual &>(*this), static_cast<ArgumentEqual &>(other));
-        if (AllocatorTraits::propagate_on_container_swap::value)
-            swap(static_cast<EntryAlloc &>(*this), static_cast<EntryAlloc &>(other));
-    }
-
-    uint64_t size() const
-    {
-        return num_elements;
-    }
-    uint64_t max_size() const
-    {
-        return (AllocatorTraits::max_size(*this)) / sizeof(Entry);
-    }
-    uint64_t bucket_count() const
-    {
-        return num_slots_minus_one ? num_slots_minus_one + 1 : 0;
-    }
-    size_type max_bucket_count() const
-    {
-        return (AllocatorTraits::max_size(*this) - min_lookups) / sizeof(Entry);
-    }
-    uint64_t bucket(const FindKey & key) const
-    {
-        return hash_policy.index_for_hash(hash_object(key), num_slots_minus_one);
-    }
-    float load_factor() const
-    {
-        uint64_t buckets = bucket_count();
-        if (buckets)
-            return static_cast<float>(num_elements) / bucket_count();
-        else
-            return 0;
-    }
-    void max_load_factor(float value)
-    {
-        _max_load_factor = value;
-    }
-    float max_load_factor() const
-    {
-        return _max_load_factor;
-    }
-
-    bool empty() const
-    {
-        return num_elements == 0;
-    }
-
-private:
-    EntryPointer entries = empty_default_table();
-    uint64_t num_slots_minus_one = 0;
-    typename HashPolicySelector<ArgumentHash>::type hash_policy;
-    int8_t max_lookups = detailv3::min_lookups - 1;
-    float _max_load_factor = 0.5f;
-    uint64_t num_elements = 0;
-    std::unique_ptr<sherwood_v3_entry<T>> sentinel_val;
-
-    // head of doubly linked list
-    EntryPointer sentinel = initSentinel();
-
-    EntryPointer initSentinel() {
-      // needs to be a pointer so that hash map can be used with forward declared types
-      sentinel_val = c10::guts::make_unique<sherwood_v3_entry<T>>();
-      sentinel = sentinel_val.get();
-      reset_list();
-      return sentinel;
-    }
-
-    EntryPointer empty_default_table()
-    {
-        EntryPointer result = AllocatorTraits::allocate(*this, detailv3::min_lookups);
-        EntryPointer special_end_item = result + static_cast<ptrdiff_t>(detailv3::min_lookups - 1);
-        for (EntryPointer it = result; it != special_end_item; ++it)
-            it->distance_from_desired = -1;
-        special_end_item->distance_from_desired = Entry::special_end_value;
-        return result;
-    }
-
-    static int8_t compute_max_lookups(uint64_t num_buckets)
-    {
-        int8_t desired = detailv3::log2(num_buckets);
-        return std::max(detailv3::min_lookups, desired);
-    }
-
-    uint64_t num_buckets_for_reserve(uint64_t num_elements) const
-    {
-        return static_cast<uint64_t>(std::ceil(num_elements / std::min(0.5, static_cast<double>(_max_load_factor))));
-    }
-    void rehash_for_other_container(const sherwood_v3_table & other)
-    {
-        rehash(std::min(num_buckets_for_reserve(other.size()), other.bucket_count()));
-    }
-
-    void swap_pointers(sherwood_v3_table & other)
-    {
-        using std::swap;
-        swap(hash_policy, other.hash_policy);
-        swap(entries, other.entries);
-        swap(num_slots_minus_one, other.num_slots_minus_one);
-        swap(num_elements, other.num_elements);
-        swap(max_lookups, other.max_lookups);
-        swap(_max_load_factor, other._max_load_factor);
-        swap(sentinel, other.sentinel);
-        swap(sentinel_val, other.sentinel_val);
-    }
-
-    void reset_list() {
-      sentinel->next = sentinel;
-      sentinel->prev = sentinel;
-    }
-
-    void remove_from_list(EntryPointer elem) {
-      elem->prev->next = elem->next;
-      elem->next->prev = elem->prev;
-    }
-
-    void insert_after(EntryPointer new_elem, EntryPointer prev) {
-      auto next = prev->next;
-
-      prev->next = new_elem;
-      new_elem->prev = prev;
-
-      new_elem->next = next;
-      next->prev = new_elem;
-    }
-
-    void swap_adjacent_nodes(EntryPointer before, EntryPointer after) {
-      // sentinel stays consant, so before->prev cannot equal after
-      auto before_prev = before->prev;
-      auto after_next = after->next;
-
-      before_prev->next = after;
-      after->prev = before_prev;
-
-      after_next->prev = before;
-      before->next = after_next;
-
-      before->prev = after;
-      after->next = before;
-    }
-
-    void swap_positions(EntryPointer p1, EntryPointer p2) {
-      if (p1 == p2) {
-        return;
+    clear();
+    if (AllocatorTraits::propagate_on_container_copy_assignment::value) {
+      if (static_cast<EntryAlloc&>(*this) !=
+          static_cast<const EntryAlloc&>(other)) {
+        reset_to_empty_state();
       }
-      if (p1->next == p2) {
-        return swap_adjacent_nodes(p1, p2);
-      } else if (p2->next == p1) {
-        return swap_adjacent_nodes(p2, p1);
+      AssignIfTrue<
+          EntryAlloc,
+          AllocatorTraits::propagate_on_container_copy_assignment::value>()(
+          *this, other);
+    }
+    _max_load_factor = other._max_load_factor;
+    static_cast<Hasher&>(*this) = other;
+    static_cast<Equal&>(*this) = other;
+    rehash_for_other_container(other);
+    insert(other.begin(), other.end());
+    return *this;
+  }
+  sherwood_v3_table& operator=(sherwood_v3_table&& other) noexcept {
+    if (this == std::addressof(other))
+      return *this;
+    else if (AllocatorTraits::propagate_on_container_move_assignment::value) {
+      clear();
+      reset_to_empty_state();
+      AssignIfTrue<
+          EntryAlloc,
+          AllocatorTraits::propagate_on_container_move_assignment::value>()(
+          *this, std::move(other));
+      swap_pointers(other);
+    } else if (
+        static_cast<EntryAlloc&>(*this) == static_cast<EntryAlloc&>(other)) {
+      swap_pointers(other);
+    } else {
+      clear();
+      _max_load_factor = other._max_load_factor;
+      rehash_for_other_container(other);
+      for (T& elem : other)
+        emplace(std::move(elem));
+      other.clear();
+    }
+    static_cast<Hasher&>(*this) = std::move(other);
+    static_cast<Equal&>(*this) = std::move(other);
+    return *this;
+  }
+  ~sherwood_v3_table() {
+    clear();
+    deallocate_data(entries, num_slots_minus_one, max_lookups);
+  }
+
+  const allocator_type& get_allocator() const {
+    return static_cast<const allocator_type&>(*this);
+  }
+  const ArgumentEqual& key_eq() const {
+    return static_cast<const ArgumentEqual&>(*this);
+  }
+  const ArgumentHash& hash_function() const {
+    return static_cast<const ArgumentHash&>(*this);
+  }
+
+  template <typename ValueType>
+  struct templated_iterator {
+    templated_iterator() = default;
+    templated_iterator(EntryPointer current) : current(current) {}
+    EntryPointer current = EntryPointer();
+
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = ValueType;
+    using difference_type = ptrdiff_t;
+    using pointer = ValueType*;
+    using reference = ValueType&;
+
+    friend bool operator==(
+        const templated_iterator& lhs,
+        const templated_iterator& rhs) {
+      return lhs.current == rhs.current;
+    }
+    friend bool operator!=(
+        const templated_iterator& lhs,
+        const templated_iterator& rhs) {
+      return !(lhs == rhs);
+    }
+
+    templated_iterator& operator++() {
+      current = current->next;
+      return *this;
+    }
+    templated_iterator operator++(int) {
+      templated_iterator copy(*this);
+      ++*this;
+      return copy;
+    }
+
+    ValueType& operator*() const {
+      return current->value;
+    }
+    ValueType* operator->() const {
+      return std::addressof(current->value);
+    }
+
+    // the template automatically disables the operator when value_type is
+    // already const, because that would cause a lot of compiler warnings
+    // otherwise.
+    template <
+        class target_type = const value_type,
+        class = typename std::enable_if<
+            std::is_same<target_type, const value_type>::value &&
+            !std::is_same<target_type, value_type>::value>::type>
+    operator templated_iterator<target_type>() const {
+      return {current};
+    }
+  };
+  using iterator = templated_iterator<value_type>;
+  using const_iterator = templated_iterator<const value_type>;
+
+  iterator begin() {
+    return sentinel->next;
+  }
+  const_iterator begin() const {
+    return sentinel->next;
+  }
+  const_iterator cbegin() const {
+    return begin();
+  }
+  iterator end() {
+    return sentinel;
+  }
+  const_iterator end() const {
+    return sentinel;
+  }
+  const_iterator cend() const {
+    return end();
+  }
+
+  iterator find(const FindKey& key) {
+    uint64_t index =
+        hash_policy.index_for_hash(hash_object(key), num_slots_minus_one);
+    EntryPointer it = entries + ptrdiff_t(index);
+    for (int8_t distance = 0; it->distance_from_desired >= distance;
+         ++distance, ++it) {
+      if (compares_equal(key, it->value))
+        return {it};
+    }
+    return end();
+  }
+  const_iterator find(const FindKey& key) const {
+    return const_cast<sherwood_v3_table*>(this)->find(key);
+  }
+  uint64_t count(const FindKey& key) const {
+    return find(key) == end() ? 0 : 1;
+  }
+  std::pair<iterator, iterator> equal_range(const FindKey& key) {
+    iterator found = find(key);
+    if (found == end())
+      return {found, found};
+    else
+      return {found, std::next(found)};
+  }
+  std::pair<const_iterator, const_iterator> equal_range(
+      const FindKey& key) const {
+    const_iterator found = find(key);
+    if (found == end())
+      return {found, found};
+    else
+      return {found, std::next(found)};
+  }
+
+  template <typename Key, typename... Args>
+  std::pair<iterator, bool> emplace(Key&& key, Args&&... args) {
+    uint64_t index =
+        hash_policy.index_for_hash(hash_object(key), num_slots_minus_one);
+    EntryPointer current_entry = entries + ptrdiff_t(index);
+    int8_t distance_from_desired = 0;
+    for (; current_entry->distance_from_desired >= distance_from_desired;
+         ++current_entry, ++distance_from_desired) {
+      // insertion of an existing key does not change ordering
+      if (compares_equal(key, current_entry->value))
+        return {{current_entry}, false};
+    }
+    return emplace_new_key(
+        distance_from_desired,
+        current_entry,
+        std::forward<Key>(key),
+        std::forward<Args>(args)...);
+  }
+
+  std::pair<iterator, bool> insert(const value_type& value) {
+    return emplace(value);
+  }
+  std::pair<iterator, bool> insert(value_type&& value) {
+    return emplace(std::move(value));
+  }
+  template <typename... Args>
+  iterator emplace_hint(const_iterator, Args&&... args) {
+    return emplace(std::forward<Args>(args)...).first;
+  }
+  iterator insert(const_iterator, const value_type& value) {
+    return emplace(value).first;
+  }
+  iterator insert(const_iterator, value_type&& value) {
+    return emplace(std::move(value)).first;
+  }
+
+  template <typename It>
+  void insert(It begin, It end) {
+    for (; begin != end; ++begin) {
+      emplace(*begin);
+    }
+  }
+  void insert(std::initializer_list<value_type> il) {
+    insert(il.begin(), il.end());
+  }
+
+  void rehash(uint64_t num_buckets) {
+    num_buckets = std::max(
+        num_buckets,
+        static_cast<uint64_t>(
+            std::ceil(num_elements / static_cast<double>(_max_load_factor))));
+    if (num_buckets == 0) {
+      reset_to_empty_state();
+      return;
+    }
+    auto new_prime_index = hash_policy.next_size_over(num_buckets);
+    if (num_buckets == bucket_count())
+      return;
+    int8_t new_max_lookups = compute_max_lookups(num_buckets);
+    EntryPointer new_buckets(
+        AllocatorTraits::allocate(*this, num_buckets + new_max_lookups));
+    EntryPointer special_end_item =
+        new_buckets + static_cast<ptrdiff_t>(num_buckets + new_max_lookups - 1);
+    for (EntryPointer it = new_buckets; it != special_end_item; ++it)
+      it->distance_from_desired = -1;
+    special_end_item->distance_from_desired = Entry::special_end_value;
+    std::swap(entries, new_buckets);
+    std::swap(num_slots_minus_one, num_buckets);
+    --num_slots_minus_one;
+    hash_policy.commit(new_prime_index);
+    int8_t old_max_lookups = max_lookups;
+    max_lookups = new_max_lookups;
+    num_elements = 0;
+
+    auto start = sentinel->next;
+    // point sentinel to itself;
+    reset_list();
+    // reinsert list
+    for (EntryPointer it = start; it != sentinel;) {
+      auto next = it->next;
+      emplace(std::move(it->value));
+      it->destroy_value();
+      it = next;
+    }
+
+    deallocate_data(new_buckets, num_buckets, old_max_lookups);
+  }
+
+  void reserve(uint64_t num_elements) {
+    uint64_t required_buckets = num_buckets_for_reserve(num_elements);
+    if (required_buckets > bucket_count())
+      rehash(required_buckets);
+  }
+
+  void replace_linked_list_position(
+      EntryPointer to_be_replaced,
+      EntryPointer new_node) {
+    remove_from_list(new_node);
+    insert_after(new_node, to_be_replaced->prev);
+    remove_from_list(to_be_replaced);
+  }
+
+  // the return value is a type that can be converted to an iterator
+  // the reason for doing this is that it's not free to find the
+  // iterator pointing at the next element. if you care about the
+  // next iterator, turn the return value into an iterator
+  convertible_to_iterator erase(const_iterator to_erase) {
+    EntryPointer current = to_erase.current;
+    remove_from_list(current);
+    current->destroy_value();
+    --num_elements;
+
+    for (EntryPointer next = current + ptrdiff_t(1);
+         !next->is_at_desired_position();
+         ++current, ++next) {
+      // if an entry is being removed, and there are other entries with the
+      // same hash, the other entries get moved to their desired position by
+      // reinserting.
+      current->emplace(next->distance_from_desired - 1, std::move(next->value));
+      replace_linked_list_position(next, current);
+      next->destroy_value();
+    }
+    return {to_erase.current};
+  }
+
+  iterator erase(const_iterator begin_it, const_iterator end_it) {
+    // whenever an entry is removed and there are other entries with the same
+    // hash, the other entries must get moved to their desired position.
+    // any reference to a moved entry is invalidated.
+    // here, we iterate through the range, and make sure that we update
+    // the pointer to our next entry in the list or the end of the iterator
+    // when it is invalidated.
+
+    auto curr_iter = begin_it.current;
+    auto next_iter = curr_iter->next;
+    auto end_iter = end_it.current;
+
+    while (curr_iter != end_iter) {
+      remove_from_list(curr_iter);
+      curr_iter->destroy_value();
+      --num_elements;
+
+      for (EntryPointer next_hash_slot = curr_iter + ptrdiff_t(1);
+           !next_hash_slot->is_at_desired_position();
+           ++curr_iter, ++next_hash_slot) {
+        curr_iter->emplace(
+            next_hash_slot->distance_from_desired - 1,
+            std::move(next_hash_slot->value));
+        replace_linked_list_position(next_hash_slot, curr_iter);
+        next_hash_slot->destroy_value();
+
+        // we are invalidating next_iter or end_iter
+        if (next_hash_slot == end_iter) {
+          end_iter = curr_iter;
+        } else if (next_hash_slot == next_iter) {
+          next_iter = curr_iter;
+        }
       }
-
-      auto p1_prev = p1->prev;
-      auto p1_next = p1->next;
-
-      auto p2_prev = p2->prev;
-      auto p2_next = p2->next;
-
-      p1_prev->next = p2;
-      p2->prev = p1_prev;
-
-      p1_next->prev = p2;
-      p2->next = p1_next;
-
-      p2_prev->next = p1;
-      p1->prev = p2_prev;
-
-      p2_next->prev = p1;
-      p1->next = p2_next;
+      curr_iter = next_iter;
+      next_iter = curr_iter->next;
     }
 
-    void append_to_list(EntryPointer new_tail) {
-      insert_after(new_tail, sentinel->prev);
+    return {end_iter};
+  }
+
+  uint64_t erase(const FindKey& key) {
+    auto found = find(key);
+    if (found == end())
+      return 0;
+    else {
+      erase(found);
+      return 1;
+    }
+  }
+
+  void clear() {
+    for (EntryPointer it = entries,
+                      end = it +
+             static_cast<ptrdiff_t>(num_slots_minus_one + max_lookups);
+         it != end;
+         ++it) {
+      if (it->has_value())
+        it->destroy_value();
+    }
+    reset_list();
+    num_elements = 0;
+  }
+
+  void shrink_to_fit() {
+    rehash_for_other_container(*this);
+  }
+
+  void swap(sherwood_v3_table& other) {
+    using std::swap;
+    swap_pointers(other);
+    swap(static_cast<ArgumentHash&>(*this), static_cast<ArgumentHash&>(other));
+    swap(
+        static_cast<ArgumentEqual&>(*this), static_cast<ArgumentEqual&>(other));
+    if (AllocatorTraits::propagate_on_container_swap::value)
+      swap(static_cast<EntryAlloc&>(*this), static_cast<EntryAlloc&>(other));
+  }
+
+  uint64_t size() const {
+    return num_elements;
+  }
+  uint64_t max_size() const {
+    return (AllocatorTraits::max_size(*this)) / sizeof(Entry);
+  }
+  uint64_t bucket_count() const {
+    return num_slots_minus_one ? num_slots_minus_one + 1 : 0;
+  }
+  size_type max_bucket_count() const {
+    return (AllocatorTraits::max_size(*this) - min_lookups) / sizeof(Entry);
+  }
+  uint64_t bucket(const FindKey& key) const {
+    return hash_policy.index_for_hash(hash_object(key), num_slots_minus_one);
+  }
+  float load_factor() const {
+    uint64_t buckets = bucket_count();
+    if (buckets)
+      return static_cast<float>(num_elements) / bucket_count();
+    else
+      return 0;
+  }
+  void max_load_factor(float value) {
+    _max_load_factor = value;
+  }
+  float max_load_factor() const {
+    return _max_load_factor;
+  }
+
+  bool empty() const {
+    return num_elements == 0;
+  }
+
+ private:
+  EntryPointer entries = empty_default_table();
+  uint64_t num_slots_minus_one = 0;
+  typename HashPolicySelector<ArgumentHash>::type hash_policy;
+  int8_t max_lookups = detailv3::min_lookups - 1;
+  float _max_load_factor = 0.5f;
+  uint64_t num_elements = 0;
+  std::unique_ptr<sherwood_v3_entry<T>> sentinel_val;
+
+  // head of doubly linked list
+  EntryPointer sentinel = initSentinel();
+
+  EntryPointer initSentinel() {
+    // needs to be a pointer so that hash map can be used with forward declared
+    // types
+    sentinel_val = c10::guts::make_unique<sherwood_v3_entry<T>>();
+    sentinel = sentinel_val.get();
+    reset_list();
+    return sentinel;
+  }
+
+  EntryPointer empty_default_table() {
+    EntryPointer result =
+        AllocatorTraits::allocate(*this, detailv3::min_lookups);
+    EntryPointer special_end_item =
+        result + static_cast<ptrdiff_t>(detailv3::min_lookups - 1);
+    for (EntryPointer it = result; it != special_end_item; ++it)
+      it->distance_from_desired = -1;
+    special_end_item->distance_from_desired = Entry::special_end_value;
+    return result;
+  }
+
+  static int8_t compute_max_lookups(uint64_t num_buckets) {
+    int8_t desired = detailv3::log2(num_buckets);
+    return std::max(detailv3::min_lookups, desired);
+  }
+
+  uint64_t num_buckets_for_reserve(uint64_t num_elements) const {
+    return static_cast<uint64_t>(std::ceil(
+        num_elements / std::min(0.5, static_cast<double>(_max_load_factor))));
+  }
+  void rehash_for_other_container(const sherwood_v3_table& other) {
+    rehash(
+        std::min(num_buckets_for_reserve(other.size()), other.bucket_count()));
+  }
+
+  void swap_pointers(sherwood_v3_table& other) {
+    using std::swap;
+    swap(hash_policy, other.hash_policy);
+    swap(entries, other.entries);
+    swap(num_slots_minus_one, other.num_slots_minus_one);
+    swap(num_elements, other.num_elements);
+    swap(max_lookups, other.max_lookups);
+    swap(_max_load_factor, other._max_load_factor);
+    swap(sentinel, other.sentinel);
+    swap(sentinel_val, other.sentinel_val);
+  }
+
+  void reset_list() {
+    sentinel->next = sentinel;
+    sentinel->prev = sentinel;
+  }
+
+  void remove_from_list(EntryPointer elem) {
+    elem->prev->next = elem->next;
+    elem->next->prev = elem->prev;
+  }
+
+  void insert_after(EntryPointer new_elem, EntryPointer prev) {
+    auto next = prev->next;
+
+    prev->next = new_elem;
+    new_elem->prev = prev;
+
+    new_elem->next = next;
+    next->prev = new_elem;
+  }
+
+  void swap_adjacent_nodes(EntryPointer before, EntryPointer after) {
+    // sentinel stays consant, so before->prev cannot equal after
+    auto before_prev = before->prev;
+    auto after_next = after->next;
+
+    before_prev->next = after;
+    after->prev = before_prev;
+
+    after_next->prev = before;
+    before->next = after_next;
+
+    before->prev = after;
+    after->next = before;
+  }
+
+  void swap_positions(EntryPointer p1, EntryPointer p2) {
+    if (p1 == p2) {
+      return;
+    }
+    if (p1->next == p2) {
+      return swap_adjacent_nodes(p1, p2);
+    } else if (p2->next == p1) {
+      return swap_adjacent_nodes(p2, p1);
     }
 
-    template<typename Key, typename... Args>
-    SKA_NOINLINE(std::pair<iterator, bool>) emplace_new_key(int8_t distance_from_desired, EntryPointer current_entry, Key && key, Args &&... args)
-    {
-        using std::swap;
-        if (num_slots_minus_one == 0 || distance_from_desired == max_lookups || num_elements + 1 > (num_slots_minus_one + 1) * static_cast<double>(_max_load_factor))
-        {
-            grow();
-            return emplace(std::forward<Key>(key), std::forward<Args>(args)...);
-        }
-        else if (current_entry->is_empty())
-        {
-            current_entry->emplace(distance_from_desired, std::forward<Key>(key), std::forward<Args>(args)...);
-            ++num_elements;
-            append_to_list(current_entry);
-            return { { current_entry }, true };
-        }
-        value_type to_insert(std::forward<Key>(key), std::forward<Args>(args)...);
+    auto p1_prev = p1->prev;
+    auto p1_next = p1->next;
+
+    auto p2_prev = p2->prev;
+    auto p2_next = p2->next;
+
+    p1_prev->next = p2;
+    p2->prev = p1_prev;
+
+    p1_next->prev = p2;
+    p2->next = p1_next;
+
+    p2_prev->next = p1;
+    p1->prev = p2_prev;
+
+    p2_next->prev = p1;
+    p1->next = p2_next;
+  }
+
+  void append_to_list(EntryPointer new_tail) {
+    insert_after(new_tail, sentinel->prev);
+  }
+
+  template <typename Key, typename... Args>
+  SKA_NOINLINE(std::pair<iterator, bool>)
+  emplace_new_key(
+      int8_t distance_from_desired,
+      EntryPointer current_entry,
+      Key&& key,
+      Args&&... args) {
+    using std::swap;
+    if (num_slots_minus_one == 0 || distance_from_desired == max_lookups ||
+        num_elements + 1 >
+            (num_slots_minus_one + 1) * static_cast<double>(_max_load_factor)) {
+      grow();
+      return emplace(std::forward<Key>(key), std::forward<Args>(args)...);
+    } else if (current_entry->is_empty()) {
+      current_entry->emplace(
+          distance_from_desired,
+          std::forward<Key>(key),
+          std::forward<Args>(args)...);
+      ++num_elements;
+      append_to_list(current_entry);
+      return {{current_entry}, true};
+    }
+    value_type to_insert(std::forward<Key>(key), std::forward<Args>(args)...);
+    swap(distance_from_desired, current_entry->distance_from_desired);
+    // We maintain the invariant that:
+    // - result.current_entry contains the new value we're inserting
+    //   and is in the LinkedList position of to_insert
+    // - to_insert contains the value that reprseents the position of
+    //   result.current_entry
+    swap(to_insert, current_entry->value);
+    iterator result = {current_entry};
+    for (++distance_from_desired, ++current_entry;; ++current_entry) {
+      if (current_entry->is_empty()) {
+        current_entry->emplace(distance_from_desired, std::move(to_insert));
+        append_to_list(current_entry);
+        // now we can swap back the displaced value to its correct position,
+        // putting the new value we're inserting to the front of the list
+        swap_positions(current_entry, result.current);
+        ++num_elements;
+        return {result, true};
+      } else if (current_entry->distance_from_desired < distance_from_desired) {
         swap(distance_from_desired, current_entry->distance_from_desired);
-        // We maintain the invariant that:
-        // - result.current_entry contains the new value we're inserting
-        //   and is in the LinkedList position of to_insert
-        // - to_insert contains the value that reprseents the position of
-        //   result.current_entry
         swap(to_insert, current_entry->value);
-        iterator result = { current_entry };
-        for (++distance_from_desired, ++current_entry;; ++current_entry)
-        {
-            if (current_entry->is_empty())
-            {
-                current_entry->emplace(distance_from_desired, std::move(to_insert));
-                append_to_list(current_entry);
-                // now we can swap back the displaced value to its correct position,
-                // putting the new value we're inserting to the front of the list
-                swap_positions(current_entry, result.current);
-                ++num_elements;
-                return { result, true };
-            }
-            else if (current_entry->distance_from_desired < distance_from_desired)
-            {
-                swap(distance_from_desired, current_entry->distance_from_desired);
-                swap(to_insert, current_entry->value);
-                // to maintain our invariants we need to swap positions
-                // of result.current & current_entry:
-                swap_positions(result.current, current_entry);
-                ++distance_from_desired;
-            }
-            else
-            {
-                ++distance_from_desired;
-                if (distance_from_desired == max_lookups)
-                {
-                    // the displaced element gets put back into its correct position
-                    // we grow the hash table, and then try again to reinsert the new element
-                    swap(to_insert, result.current->value);
-                    grow();
-                    return emplace(std::move(to_insert));
-                }
-            }
+        // to maintain our invariants we need to swap positions
+        // of result.current & current_entry:
+        swap_positions(result.current, current_entry);
+        ++distance_from_desired;
+      } else {
+        ++distance_from_desired;
+        if (distance_from_desired == max_lookups) {
+          // the displaced element gets put back into its correct position
+          // we grow the hash table, and then try again to reinsert the new
+          // element
+          swap(to_insert, result.current->value);
+          grow();
+          return emplace(std::move(to_insert));
         }
+      }
     }
+  }
 
-    void grow()
-    {
-        rehash(std::max(uint64_t(4), 2 * bucket_count()));
+  void grow() {
+    rehash(std::max(uint64_t(4), 2 * bucket_count()));
+  }
+
+  void deallocate_data(
+      EntryPointer begin,
+      uint64_t num_slots_minus_one,
+      int8_t max_lookups) {
+    AllocatorTraits::deallocate(
+        *this, begin, num_slots_minus_one + max_lookups + 1);
+  }
+
+  void reset_to_empty_state() {
+    deallocate_data(entries, num_slots_minus_one, max_lookups);
+    entries = empty_default_table();
+    num_slots_minus_one = 0;
+    hash_policy.reset();
+    max_lookups = detailv3::min_lookups - 1;
+  }
+
+  template <typename U>
+  uint64_t hash_object(const U& key) {
+    return static_cast<Hasher&>(*this)(key);
+  }
+  template <typename U>
+  uint64_t hash_object(const U& key) const {
+    return static_cast<const Hasher&>(*this)(key);
+  }
+  template <typename L, typename R>
+  bool compares_equal(const L& lhs, const R& rhs) {
+    return static_cast<Equal&>(*this)(lhs, rhs);
+  }
+
+ public:
+  struct convertible_to_iterator {
+    EntryPointer it;
+
+    operator iterator() {
+      if (it->has_value())
+        return {it};
+      else
+        return ++iterator{it};
     }
-
-    void deallocate_data(EntryPointer begin, uint64_t num_slots_minus_one, int8_t max_lookups)
-    {
-        AllocatorTraits::deallocate(*this, begin, num_slots_minus_one + max_lookups + 1);
+    operator const_iterator() {
+      if (it->has_value())
+        return {it};
+      else
+        return ++const_iterator{it};
     }
-
-    void reset_to_empty_state()
-    {
-        deallocate_data(entries, num_slots_minus_one, max_lookups);
-        entries = empty_default_table();
-        num_slots_minus_one = 0;
-        hash_policy.reset();
-        max_lookups = detailv3::min_lookups - 1;
-    }
-
-    template<typename U>
-    uint64_t hash_object(const U & key)
-    {
-        return static_cast<Hasher &>(*this)(key);
-    }
-    template<typename U>
-    uint64_t hash_object(const U & key) const
-    {
-        return static_cast<const Hasher &>(*this)(key);
-    }
-    template<typename L, typename R>
-    bool compares_equal(const L & lhs, const R & rhs)
-    {
-        return static_cast<Equal &>(*this)(lhs, rhs);
-    }
-
-public:
-    struct convertible_to_iterator
-    {
-        EntryPointer it;
-
-        operator iterator()
-        {
-            if (it->has_value())
-                return { it };
-            else
-                return ++iterator{it};
-        }
-        operator const_iterator()
-        {
-            if (it->has_value())
-                return { it };
-            else
-                return ++const_iterator{it};
-        }
-    };
-
+  };
 };
-}
+} // namespace detailv3
 
-struct prime_number_hash_policy
-{
-    static uint64_t mod0(uint64_t) { return 0llu; }
-    static uint64_t mod2(uint64_t hash) { return hash % 2llu; }
-    static uint64_t mod3(uint64_t hash) { return hash % 3llu; }
-    static uint64_t mod5(uint64_t hash) { return hash % 5llu; }
-    static uint64_t mod7(uint64_t hash) { return hash % 7llu; }
-    static uint64_t mod11(uint64_t hash) { return hash % 11llu; }
-    static uint64_t mod13(uint64_t hash) { return hash % 13llu; }
-    static uint64_t mod17(uint64_t hash) { return hash % 17llu; }
-    static uint64_t mod23(uint64_t hash) { return hash % 23llu; }
-    static uint64_t mod29(uint64_t hash) { return hash % 29llu; }
-    static uint64_t mod37(uint64_t hash) { return hash % 37llu; }
-    static uint64_t mod47(uint64_t hash) { return hash % 47llu; }
-    static uint64_t mod59(uint64_t hash) { return hash % 59llu; }
-    static uint64_t mod73(uint64_t hash) { return hash % 73llu; }
-    static uint64_t mod97(uint64_t hash) { return hash % 97llu; }
-    static uint64_t mod127(uint64_t hash) { return hash % 127llu; }
-    static uint64_t mod151(uint64_t hash) { return hash % 151llu; }
-    static uint64_t mod197(uint64_t hash) { return hash % 197llu; }
-    static uint64_t mod251(uint64_t hash) { return hash % 251llu; }
-    static uint64_t mod313(uint64_t hash) { return hash % 313llu; }
-    static uint64_t mod397(uint64_t hash) { return hash % 397llu; }
-    static uint64_t mod499(uint64_t hash) { return hash % 499llu; }
-    static uint64_t mod631(uint64_t hash) { return hash % 631llu; }
-    static uint64_t mod797(uint64_t hash) { return hash % 797llu; }
-    static uint64_t mod1009(uint64_t hash) { return hash % 1009llu; }
-    static uint64_t mod1259(uint64_t hash) { return hash % 1259llu; }
-    static uint64_t mod1597(uint64_t hash) { return hash % 1597llu; }
-    static uint64_t mod2011(uint64_t hash) { return hash % 2011llu; }
-    static uint64_t mod2539(uint64_t hash) { return hash % 2539llu; }
-    static uint64_t mod3203(uint64_t hash) { return hash % 3203llu; }
-    static uint64_t mod4027(uint64_t hash) { return hash % 4027llu; }
-    static uint64_t mod5087(uint64_t hash) { return hash % 5087llu; }
-    static uint64_t mod6421(uint64_t hash) { return hash % 6421llu; }
-    static uint64_t mod8089(uint64_t hash) { return hash % 8089llu; }
-    static uint64_t mod10193(uint64_t hash) { return hash % 10193llu; }
-    static uint64_t mod12853(uint64_t hash) { return hash % 12853llu; }
-    static uint64_t mod16193(uint64_t hash) { return hash % 16193llu; }
-    static uint64_t mod20399(uint64_t hash) { return hash % 20399llu; }
-    static uint64_t mod25717(uint64_t hash) { return hash % 25717llu; }
-    static uint64_t mod32401(uint64_t hash) { return hash % 32401llu; }
-    static uint64_t mod40823(uint64_t hash) { return hash % 40823llu; }
-    static uint64_t mod51437(uint64_t hash) { return hash % 51437llu; }
-    static uint64_t mod64811(uint64_t hash) { return hash % 64811llu; }
-    static uint64_t mod81649(uint64_t hash) { return hash % 81649llu; }
-    static uint64_t mod102877(uint64_t hash) { return hash % 102877llu; }
-    static uint64_t mod129607(uint64_t hash) { return hash % 129607llu; }
-    static uint64_t mod163307(uint64_t hash) { return hash % 163307llu; }
-    static uint64_t mod205759(uint64_t hash) { return hash % 205759llu; }
-    static uint64_t mod259229(uint64_t hash) { return hash % 259229llu; }
-    static uint64_t mod326617(uint64_t hash) { return hash % 326617llu; }
-    static uint64_t mod411527(uint64_t hash) { return hash % 411527llu; }
-    static uint64_t mod518509(uint64_t hash) { return hash % 518509llu; }
-    static uint64_t mod653267(uint64_t hash) { return hash % 653267llu; }
-    static uint64_t mod823117(uint64_t hash) { return hash % 823117llu; }
-    static uint64_t mod1037059(uint64_t hash) { return hash % 1037059llu; }
-    static uint64_t mod1306601(uint64_t hash) { return hash % 1306601llu; }
-    static uint64_t mod1646237(uint64_t hash) { return hash % 1646237llu; }
-    static uint64_t mod2074129(uint64_t hash) { return hash % 2074129llu; }
-    static uint64_t mod2613229(uint64_t hash) { return hash % 2613229llu; }
-    static uint64_t mod3292489(uint64_t hash) { return hash % 3292489llu; }
-    static uint64_t mod4148279(uint64_t hash) { return hash % 4148279llu; }
-    static uint64_t mod5226491(uint64_t hash) { return hash % 5226491llu; }
-    static uint64_t mod6584983(uint64_t hash) { return hash % 6584983llu; }
-    static uint64_t mod8296553(uint64_t hash) { return hash % 8296553llu; }
-    static uint64_t mod10453007(uint64_t hash) { return hash % 10453007llu; }
-    static uint64_t mod13169977(uint64_t hash) { return hash % 13169977llu; }
-    static uint64_t mod16593127(uint64_t hash) { return hash % 16593127llu; }
-    static uint64_t mod20906033(uint64_t hash) { return hash % 20906033llu; }
-    static uint64_t mod26339969(uint64_t hash) { return hash % 26339969llu; }
-    static uint64_t mod33186281(uint64_t hash) { return hash % 33186281llu; }
-    static uint64_t mod41812097(uint64_t hash) { return hash % 41812097llu; }
-    static uint64_t mod52679969(uint64_t hash) { return hash % 52679969llu; }
-    static uint64_t mod66372617(uint64_t hash) { return hash % 66372617llu; }
-    static uint64_t mod83624237(uint64_t hash) { return hash % 83624237llu; }
-    static uint64_t mod105359939(uint64_t hash) { return hash % 105359939llu; }
-    static uint64_t mod132745199(uint64_t hash) { return hash % 132745199llu; }
-    static uint64_t mod167248483(uint64_t hash) { return hash % 167248483llu; }
-    static uint64_t mod210719881(uint64_t hash) { return hash % 210719881llu; }
-    static uint64_t mod265490441(uint64_t hash) { return hash % 265490441llu; }
-    static uint64_t mod334496971(uint64_t hash) { return hash % 334496971llu; }
-    static uint64_t mod421439783(uint64_t hash) { return hash % 421439783llu; }
-    static uint64_t mod530980861(uint64_t hash) { return hash % 530980861llu; }
-    static uint64_t mod668993977(uint64_t hash) { return hash % 668993977llu; }
-    static uint64_t mod842879579(uint64_t hash) { return hash % 842879579llu; }
-    static uint64_t mod1061961721(uint64_t hash) { return hash % 1061961721llu; }
-    static uint64_t mod1337987929(uint64_t hash) { return hash % 1337987929llu; }
-    static uint64_t mod1685759167(uint64_t hash) { return hash % 1685759167llu; }
-    static uint64_t mod2123923447(uint64_t hash) { return hash % 2123923447llu; }
-    static uint64_t mod2675975881(uint64_t hash) { return hash % 2675975881llu; }
-    static uint64_t mod3371518343(uint64_t hash) { return hash % 3371518343llu; }
-    static uint64_t mod4247846927(uint64_t hash) { return hash % 4247846927llu; }
-    static uint64_t mod5351951779(uint64_t hash) { return hash % 5351951779llu; }
-    static uint64_t mod6743036717(uint64_t hash) { return hash % 6743036717llu; }
-    static uint64_t mod8495693897(uint64_t hash) { return hash % 8495693897llu; }
-    static uint64_t mod10703903591(uint64_t hash) { return hash % 10703903591llu; }
-    static uint64_t mod13486073473(uint64_t hash) { return hash % 13486073473llu; }
-    static uint64_t mod16991387857(uint64_t hash) { return hash % 16991387857llu; }
-    static uint64_t mod21407807219(uint64_t hash) { return hash % 21407807219llu; }
-    static uint64_t mod26972146961(uint64_t hash) { return hash % 26972146961llu; }
-    static uint64_t mod33982775741(uint64_t hash) { return hash % 33982775741llu; }
-    static uint64_t mod42815614441(uint64_t hash) { return hash % 42815614441llu; }
-    static uint64_t mod53944293929(uint64_t hash) { return hash % 53944293929llu; }
-    static uint64_t mod67965551447(uint64_t hash) { return hash % 67965551447llu; }
-    static uint64_t mod85631228929(uint64_t hash) { return hash % 85631228929llu; }
-    static uint64_t mod107888587883(uint64_t hash) { return hash % 107888587883llu; }
-    static uint64_t mod135931102921(uint64_t hash) { return hash % 135931102921llu; }
-    static uint64_t mod171262457903(uint64_t hash) { return hash % 171262457903llu; }
-    static uint64_t mod215777175787(uint64_t hash) { return hash % 215777175787llu; }
-    static uint64_t mod271862205833(uint64_t hash) { return hash % 271862205833llu; }
-    static uint64_t mod342524915839(uint64_t hash) { return hash % 342524915839llu; }
-    static uint64_t mod431554351609(uint64_t hash) { return hash % 431554351609llu; }
-    static uint64_t mod543724411781(uint64_t hash) { return hash % 543724411781llu; }
-    static uint64_t mod685049831731(uint64_t hash) { return hash % 685049831731llu; }
-    static uint64_t mod863108703229(uint64_t hash) { return hash % 863108703229llu; }
-    static uint64_t mod1087448823553(uint64_t hash) { return hash % 1087448823553llu; }
-    static uint64_t mod1370099663459(uint64_t hash) { return hash % 1370099663459llu; }
-    static uint64_t mod1726217406467(uint64_t hash) { return hash % 1726217406467llu; }
-    static uint64_t mod2174897647073(uint64_t hash) { return hash % 2174897647073llu; }
-    static uint64_t mod2740199326961(uint64_t hash) { return hash % 2740199326961llu; }
-    static uint64_t mod3452434812973(uint64_t hash) { return hash % 3452434812973llu; }
-    static uint64_t mod4349795294267(uint64_t hash) { return hash % 4349795294267llu; }
-    static uint64_t mod5480398654009(uint64_t hash) { return hash % 5480398654009llu; }
-    static uint64_t mod6904869625999(uint64_t hash) { return hash % 6904869625999llu; }
-    static uint64_t mod8699590588571(uint64_t hash) { return hash % 8699590588571llu; }
-    static uint64_t mod10960797308051(uint64_t hash) { return hash % 10960797308051llu; }
-    static uint64_t mod13809739252051(uint64_t hash) { return hash % 13809739252051llu; }
-    static uint64_t mod17399181177241(uint64_t hash) { return hash % 17399181177241llu; }
-    static uint64_t mod21921594616111(uint64_t hash) { return hash % 21921594616111llu; }
-    static uint64_t mod27619478504183(uint64_t hash) { return hash % 27619478504183llu; }
-    static uint64_t mod34798362354533(uint64_t hash) { return hash % 34798362354533llu; }
-    static uint64_t mod43843189232363(uint64_t hash) { return hash % 43843189232363llu; }
-    static uint64_t mod55238957008387(uint64_t hash) { return hash % 55238957008387llu; }
-    static uint64_t mod69596724709081(uint64_t hash) { return hash % 69596724709081llu; }
-    static uint64_t mod87686378464759(uint64_t hash) { return hash % 87686378464759llu; }
-    static uint64_t mod110477914016779(uint64_t hash) { return hash % 110477914016779llu; }
-    static uint64_t mod139193449418173(uint64_t hash) { return hash % 139193449418173llu; }
-    static uint64_t mod175372756929481(uint64_t hash) { return hash % 175372756929481llu; }
-    static uint64_t mod220955828033581(uint64_t hash) { return hash % 220955828033581llu; }
-    static uint64_t mod278386898836457(uint64_t hash) { return hash % 278386898836457llu; }
-    static uint64_t mod350745513859007(uint64_t hash) { return hash % 350745513859007llu; }
-    static uint64_t mod441911656067171(uint64_t hash) { return hash % 441911656067171llu; }
-    static uint64_t mod556773797672909(uint64_t hash) { return hash % 556773797672909llu; }
-    static uint64_t mod701491027718027(uint64_t hash) { return hash % 701491027718027llu; }
-    static uint64_t mod883823312134381(uint64_t hash) { return hash % 883823312134381llu; }
-    static uint64_t mod1113547595345903(uint64_t hash) { return hash % 1113547595345903llu; }
-    static uint64_t mod1402982055436147(uint64_t hash) { return hash % 1402982055436147llu; }
-    static uint64_t mod1767646624268779(uint64_t hash) { return hash % 1767646624268779llu; }
-    static uint64_t mod2227095190691797(uint64_t hash) { return hash % 2227095190691797llu; }
-    static uint64_t mod2805964110872297(uint64_t hash) { return hash % 2805964110872297llu; }
-    static uint64_t mod3535293248537579(uint64_t hash) { return hash % 3535293248537579llu; }
-    static uint64_t mod4454190381383713(uint64_t hash) { return hash % 4454190381383713llu; }
-    static uint64_t mod5611928221744609(uint64_t hash) { return hash % 5611928221744609llu; }
-    static uint64_t mod7070586497075177(uint64_t hash) { return hash % 7070586497075177llu; }
-    static uint64_t mod8908380762767489(uint64_t hash) { return hash % 8908380762767489llu; }
-    static uint64_t mod11223856443489329(uint64_t hash) { return hash % 11223856443489329llu; }
-    static uint64_t mod14141172994150357(uint64_t hash) { return hash % 14141172994150357llu; }
-    static uint64_t mod17816761525534927(uint64_t hash) { return hash % 17816761525534927llu; }
-    static uint64_t mod22447712886978529(uint64_t hash) { return hash % 22447712886978529llu; }
-    static uint64_t mod28282345988300791(uint64_t hash) { return hash % 28282345988300791llu; }
-    static uint64_t mod35633523051069991(uint64_t hash) { return hash % 35633523051069991llu; }
-    static uint64_t mod44895425773957261(uint64_t hash) { return hash % 44895425773957261llu; }
-    static uint64_t mod56564691976601587(uint64_t hash) { return hash % 56564691976601587llu; }
-    static uint64_t mod71267046102139967(uint64_t hash) { return hash % 71267046102139967llu; }
-    static uint64_t mod89790851547914507(uint64_t hash) { return hash % 89790851547914507llu; }
-    static uint64_t mod113129383953203213(uint64_t hash) { return hash % 113129383953203213llu; }
-    static uint64_t mod142534092204280003(uint64_t hash) { return hash % 142534092204280003llu; }
-    static uint64_t mod179581703095829107(uint64_t hash) { return hash % 179581703095829107llu; }
-    static uint64_t mod226258767906406483(uint64_t hash) { return hash % 226258767906406483llu; }
-    static uint64_t mod285068184408560057(uint64_t hash) { return hash % 285068184408560057llu; }
-    static uint64_t mod359163406191658253(uint64_t hash) { return hash % 359163406191658253llu; }
-    static uint64_t mod452517535812813007(uint64_t hash) { return hash % 452517535812813007llu; }
-    static uint64_t mod570136368817120201(uint64_t hash) { return hash % 570136368817120201llu; }
-    static uint64_t mod718326812383316683(uint64_t hash) { return hash % 718326812383316683llu; }
-    static uint64_t mod905035071625626043(uint64_t hash) { return hash % 905035071625626043llu; }
-    static uint64_t mod1140272737634240411(uint64_t hash) { return hash % 1140272737634240411llu; }
-    static uint64_t mod1436653624766633509(uint64_t hash) { return hash % 1436653624766633509llu; }
-    static uint64_t mod1810070143251252131(uint64_t hash) { return hash % 1810070143251252131llu; }
-    static uint64_t mod2280545475268481167(uint64_t hash) { return hash % 2280545475268481167llu; }
-    static uint64_t mod2873307249533267101(uint64_t hash) { return hash % 2873307249533267101llu; }
-    static uint64_t mod3620140286502504283(uint64_t hash) { return hash % 3620140286502504283llu; }
-    static uint64_t mod4561090950536962147(uint64_t hash) { return hash % 4561090950536962147llu; }
-    static uint64_t mod5746614499066534157(uint64_t hash) { return hash % 5746614499066534157llu; }
-    static uint64_t mod7240280573005008577(uint64_t hash) { return hash % 7240280573005008577llu; }
-    static uint64_t mod9122181901073924329(uint64_t hash) { return hash % 9122181901073924329llu; }
-    static uint64_t mod11493228998133068689(uint64_t hash) { return hash % 11493228998133068689llu; }
-    static uint64_t mod14480561146010017169(uint64_t hash) { return hash % 14480561146010017169llu; }
-    static uint64_t mod18446744073709551557(uint64_t hash) { return hash % 18446744073709551557llu; }
+struct prime_number_hash_policy {
+  static uint64_t mod0(uint64_t) {
+    return 0llu;
+  }
+  static uint64_t mod2(uint64_t hash) {
+    return hash % 2llu;
+  }
+  static uint64_t mod3(uint64_t hash) {
+    return hash % 3llu;
+  }
+  static uint64_t mod5(uint64_t hash) {
+    return hash % 5llu;
+  }
+  static uint64_t mod7(uint64_t hash) {
+    return hash % 7llu;
+  }
+  static uint64_t mod11(uint64_t hash) {
+    return hash % 11llu;
+  }
+  static uint64_t mod13(uint64_t hash) {
+    return hash % 13llu;
+  }
+  static uint64_t mod17(uint64_t hash) {
+    return hash % 17llu;
+  }
+  static uint64_t mod23(uint64_t hash) {
+    return hash % 23llu;
+  }
+  static uint64_t mod29(uint64_t hash) {
+    return hash % 29llu;
+  }
+  static uint64_t mod37(uint64_t hash) {
+    return hash % 37llu;
+  }
+  static uint64_t mod47(uint64_t hash) {
+    return hash % 47llu;
+  }
+  static uint64_t mod59(uint64_t hash) {
+    return hash % 59llu;
+  }
+  static uint64_t mod73(uint64_t hash) {
+    return hash % 73llu;
+  }
+  static uint64_t mod97(uint64_t hash) {
+    return hash % 97llu;
+  }
+  static uint64_t mod127(uint64_t hash) {
+    return hash % 127llu;
+  }
+  static uint64_t mod151(uint64_t hash) {
+    return hash % 151llu;
+  }
+  static uint64_t mod197(uint64_t hash) {
+    return hash % 197llu;
+  }
+  static uint64_t mod251(uint64_t hash) {
+    return hash % 251llu;
+  }
+  static uint64_t mod313(uint64_t hash) {
+    return hash % 313llu;
+  }
+  static uint64_t mod397(uint64_t hash) {
+    return hash % 397llu;
+  }
+  static uint64_t mod499(uint64_t hash) {
+    return hash % 499llu;
+  }
+  static uint64_t mod631(uint64_t hash) {
+    return hash % 631llu;
+  }
+  static uint64_t mod797(uint64_t hash) {
+    return hash % 797llu;
+  }
+  static uint64_t mod1009(uint64_t hash) {
+    return hash % 1009llu;
+  }
+  static uint64_t mod1259(uint64_t hash) {
+    return hash % 1259llu;
+  }
+  static uint64_t mod1597(uint64_t hash) {
+    return hash % 1597llu;
+  }
+  static uint64_t mod2011(uint64_t hash) {
+    return hash % 2011llu;
+  }
+  static uint64_t mod2539(uint64_t hash) {
+    return hash % 2539llu;
+  }
+  static uint64_t mod3203(uint64_t hash) {
+    return hash % 3203llu;
+  }
+  static uint64_t mod4027(uint64_t hash) {
+    return hash % 4027llu;
+  }
+  static uint64_t mod5087(uint64_t hash) {
+    return hash % 5087llu;
+  }
+  static uint64_t mod6421(uint64_t hash) {
+    return hash % 6421llu;
+  }
+  static uint64_t mod8089(uint64_t hash) {
+    return hash % 8089llu;
+  }
+  static uint64_t mod10193(uint64_t hash) {
+    return hash % 10193llu;
+  }
+  static uint64_t mod12853(uint64_t hash) {
+    return hash % 12853llu;
+  }
+  static uint64_t mod16193(uint64_t hash) {
+    return hash % 16193llu;
+  }
+  static uint64_t mod20399(uint64_t hash) {
+    return hash % 20399llu;
+  }
+  static uint64_t mod25717(uint64_t hash) {
+    return hash % 25717llu;
+  }
+  static uint64_t mod32401(uint64_t hash) {
+    return hash % 32401llu;
+  }
+  static uint64_t mod40823(uint64_t hash) {
+    return hash % 40823llu;
+  }
+  static uint64_t mod51437(uint64_t hash) {
+    return hash % 51437llu;
+  }
+  static uint64_t mod64811(uint64_t hash) {
+    return hash % 64811llu;
+  }
+  static uint64_t mod81649(uint64_t hash) {
+    return hash % 81649llu;
+  }
+  static uint64_t mod102877(uint64_t hash) {
+    return hash % 102877llu;
+  }
+  static uint64_t mod129607(uint64_t hash) {
+    return hash % 129607llu;
+  }
+  static uint64_t mod163307(uint64_t hash) {
+    return hash % 163307llu;
+  }
+  static uint64_t mod205759(uint64_t hash) {
+    return hash % 205759llu;
+  }
+  static uint64_t mod259229(uint64_t hash) {
+    return hash % 259229llu;
+  }
+  static uint64_t mod326617(uint64_t hash) {
+    return hash % 326617llu;
+  }
+  static uint64_t mod411527(uint64_t hash) {
+    return hash % 411527llu;
+  }
+  static uint64_t mod518509(uint64_t hash) {
+    return hash % 518509llu;
+  }
+  static uint64_t mod653267(uint64_t hash) {
+    return hash % 653267llu;
+  }
+  static uint64_t mod823117(uint64_t hash) {
+    return hash % 823117llu;
+  }
+  static uint64_t mod1037059(uint64_t hash) {
+    return hash % 1037059llu;
+  }
+  static uint64_t mod1306601(uint64_t hash) {
+    return hash % 1306601llu;
+  }
+  static uint64_t mod1646237(uint64_t hash) {
+    return hash % 1646237llu;
+  }
+  static uint64_t mod2074129(uint64_t hash) {
+    return hash % 2074129llu;
+  }
+  static uint64_t mod2613229(uint64_t hash) {
+    return hash % 2613229llu;
+  }
+  static uint64_t mod3292489(uint64_t hash) {
+    return hash % 3292489llu;
+  }
+  static uint64_t mod4148279(uint64_t hash) {
+    return hash % 4148279llu;
+  }
+  static uint64_t mod5226491(uint64_t hash) {
+    return hash % 5226491llu;
+  }
+  static uint64_t mod6584983(uint64_t hash) {
+    return hash % 6584983llu;
+  }
+  static uint64_t mod8296553(uint64_t hash) {
+    return hash % 8296553llu;
+  }
+  static uint64_t mod10453007(uint64_t hash) {
+    return hash % 10453007llu;
+  }
+  static uint64_t mod13169977(uint64_t hash) {
+    return hash % 13169977llu;
+  }
+  static uint64_t mod16593127(uint64_t hash) {
+    return hash % 16593127llu;
+  }
+  static uint64_t mod20906033(uint64_t hash) {
+    return hash % 20906033llu;
+  }
+  static uint64_t mod26339969(uint64_t hash) {
+    return hash % 26339969llu;
+  }
+  static uint64_t mod33186281(uint64_t hash) {
+    return hash % 33186281llu;
+  }
+  static uint64_t mod41812097(uint64_t hash) {
+    return hash % 41812097llu;
+  }
+  static uint64_t mod52679969(uint64_t hash) {
+    return hash % 52679969llu;
+  }
+  static uint64_t mod66372617(uint64_t hash) {
+    return hash % 66372617llu;
+  }
+  static uint64_t mod83624237(uint64_t hash) {
+    return hash % 83624237llu;
+  }
+  static uint64_t mod105359939(uint64_t hash) {
+    return hash % 105359939llu;
+  }
+  static uint64_t mod132745199(uint64_t hash) {
+    return hash % 132745199llu;
+  }
+  static uint64_t mod167248483(uint64_t hash) {
+    return hash % 167248483llu;
+  }
+  static uint64_t mod210719881(uint64_t hash) {
+    return hash % 210719881llu;
+  }
+  static uint64_t mod265490441(uint64_t hash) {
+    return hash % 265490441llu;
+  }
+  static uint64_t mod334496971(uint64_t hash) {
+    return hash % 334496971llu;
+  }
+  static uint64_t mod421439783(uint64_t hash) {
+    return hash % 421439783llu;
+  }
+  static uint64_t mod530980861(uint64_t hash) {
+    return hash % 530980861llu;
+  }
+  static uint64_t mod668993977(uint64_t hash) {
+    return hash % 668993977llu;
+  }
+  static uint64_t mod842879579(uint64_t hash) {
+    return hash % 842879579llu;
+  }
+  static uint64_t mod1061961721(uint64_t hash) {
+    return hash % 1061961721llu;
+  }
+  static uint64_t mod1337987929(uint64_t hash) {
+    return hash % 1337987929llu;
+  }
+  static uint64_t mod1685759167(uint64_t hash) {
+    return hash % 1685759167llu;
+  }
+  static uint64_t mod2123923447(uint64_t hash) {
+    return hash % 2123923447llu;
+  }
+  static uint64_t mod2675975881(uint64_t hash) {
+    return hash % 2675975881llu;
+  }
+  static uint64_t mod3371518343(uint64_t hash) {
+    return hash % 3371518343llu;
+  }
+  static uint64_t mod4247846927(uint64_t hash) {
+    return hash % 4247846927llu;
+  }
+  static uint64_t mod5351951779(uint64_t hash) {
+    return hash % 5351951779llu;
+  }
+  static uint64_t mod6743036717(uint64_t hash) {
+    return hash % 6743036717llu;
+  }
+  static uint64_t mod8495693897(uint64_t hash) {
+    return hash % 8495693897llu;
+  }
+  static uint64_t mod10703903591(uint64_t hash) {
+    return hash % 10703903591llu;
+  }
+  static uint64_t mod13486073473(uint64_t hash) {
+    return hash % 13486073473llu;
+  }
+  static uint64_t mod16991387857(uint64_t hash) {
+    return hash % 16991387857llu;
+  }
+  static uint64_t mod21407807219(uint64_t hash) {
+    return hash % 21407807219llu;
+  }
+  static uint64_t mod26972146961(uint64_t hash) {
+    return hash % 26972146961llu;
+  }
+  static uint64_t mod33982775741(uint64_t hash) {
+    return hash % 33982775741llu;
+  }
+  static uint64_t mod42815614441(uint64_t hash) {
+    return hash % 42815614441llu;
+  }
+  static uint64_t mod53944293929(uint64_t hash) {
+    return hash % 53944293929llu;
+  }
+  static uint64_t mod67965551447(uint64_t hash) {
+    return hash % 67965551447llu;
+  }
+  static uint64_t mod85631228929(uint64_t hash) {
+    return hash % 85631228929llu;
+  }
+  static uint64_t mod107888587883(uint64_t hash) {
+    return hash % 107888587883llu;
+  }
+  static uint64_t mod135931102921(uint64_t hash) {
+    return hash % 135931102921llu;
+  }
+  static uint64_t mod171262457903(uint64_t hash) {
+    return hash % 171262457903llu;
+  }
+  static uint64_t mod215777175787(uint64_t hash) {
+    return hash % 215777175787llu;
+  }
+  static uint64_t mod271862205833(uint64_t hash) {
+    return hash % 271862205833llu;
+  }
+  static uint64_t mod342524915839(uint64_t hash) {
+    return hash % 342524915839llu;
+  }
+  static uint64_t mod431554351609(uint64_t hash) {
+    return hash % 431554351609llu;
+  }
+  static uint64_t mod543724411781(uint64_t hash) {
+    return hash % 543724411781llu;
+  }
+  static uint64_t mod685049831731(uint64_t hash) {
+    return hash % 685049831731llu;
+  }
+  static uint64_t mod863108703229(uint64_t hash) {
+    return hash % 863108703229llu;
+  }
+  static uint64_t mod1087448823553(uint64_t hash) {
+    return hash % 1087448823553llu;
+  }
+  static uint64_t mod1370099663459(uint64_t hash) {
+    return hash % 1370099663459llu;
+  }
+  static uint64_t mod1726217406467(uint64_t hash) {
+    return hash % 1726217406467llu;
+  }
+  static uint64_t mod2174897647073(uint64_t hash) {
+    return hash % 2174897647073llu;
+  }
+  static uint64_t mod2740199326961(uint64_t hash) {
+    return hash % 2740199326961llu;
+  }
+  static uint64_t mod3452434812973(uint64_t hash) {
+    return hash % 3452434812973llu;
+  }
+  static uint64_t mod4349795294267(uint64_t hash) {
+    return hash % 4349795294267llu;
+  }
+  static uint64_t mod5480398654009(uint64_t hash) {
+    return hash % 5480398654009llu;
+  }
+  static uint64_t mod6904869625999(uint64_t hash) {
+    return hash % 6904869625999llu;
+  }
+  static uint64_t mod8699590588571(uint64_t hash) {
+    return hash % 8699590588571llu;
+  }
+  static uint64_t mod10960797308051(uint64_t hash) {
+    return hash % 10960797308051llu;
+  }
+  static uint64_t mod13809739252051(uint64_t hash) {
+    return hash % 13809739252051llu;
+  }
+  static uint64_t mod17399181177241(uint64_t hash) {
+    return hash % 17399181177241llu;
+  }
+  static uint64_t mod21921594616111(uint64_t hash) {
+    return hash % 21921594616111llu;
+  }
+  static uint64_t mod27619478504183(uint64_t hash) {
+    return hash % 27619478504183llu;
+  }
+  static uint64_t mod34798362354533(uint64_t hash) {
+    return hash % 34798362354533llu;
+  }
+  static uint64_t mod43843189232363(uint64_t hash) {
+    return hash % 43843189232363llu;
+  }
+  static uint64_t mod55238957008387(uint64_t hash) {
+    return hash % 55238957008387llu;
+  }
+  static uint64_t mod69596724709081(uint64_t hash) {
+    return hash % 69596724709081llu;
+  }
+  static uint64_t mod87686378464759(uint64_t hash) {
+    return hash % 87686378464759llu;
+  }
+  static uint64_t mod110477914016779(uint64_t hash) {
+    return hash % 110477914016779llu;
+  }
+  static uint64_t mod139193449418173(uint64_t hash) {
+    return hash % 139193449418173llu;
+  }
+  static uint64_t mod175372756929481(uint64_t hash) {
+    return hash % 175372756929481llu;
+  }
+  static uint64_t mod220955828033581(uint64_t hash) {
+    return hash % 220955828033581llu;
+  }
+  static uint64_t mod278386898836457(uint64_t hash) {
+    return hash % 278386898836457llu;
+  }
+  static uint64_t mod350745513859007(uint64_t hash) {
+    return hash % 350745513859007llu;
+  }
+  static uint64_t mod441911656067171(uint64_t hash) {
+    return hash % 441911656067171llu;
+  }
+  static uint64_t mod556773797672909(uint64_t hash) {
+    return hash % 556773797672909llu;
+  }
+  static uint64_t mod701491027718027(uint64_t hash) {
+    return hash % 701491027718027llu;
+  }
+  static uint64_t mod883823312134381(uint64_t hash) {
+    return hash % 883823312134381llu;
+  }
+  static uint64_t mod1113547595345903(uint64_t hash) {
+    return hash % 1113547595345903llu;
+  }
+  static uint64_t mod1402982055436147(uint64_t hash) {
+    return hash % 1402982055436147llu;
+  }
+  static uint64_t mod1767646624268779(uint64_t hash) {
+    return hash % 1767646624268779llu;
+  }
+  static uint64_t mod2227095190691797(uint64_t hash) {
+    return hash % 2227095190691797llu;
+  }
+  static uint64_t mod2805964110872297(uint64_t hash) {
+    return hash % 2805964110872297llu;
+  }
+  static uint64_t mod3535293248537579(uint64_t hash) {
+    return hash % 3535293248537579llu;
+  }
+  static uint64_t mod4454190381383713(uint64_t hash) {
+    return hash % 4454190381383713llu;
+  }
+  static uint64_t mod5611928221744609(uint64_t hash) {
+    return hash % 5611928221744609llu;
+  }
+  static uint64_t mod7070586497075177(uint64_t hash) {
+    return hash % 7070586497075177llu;
+  }
+  static uint64_t mod8908380762767489(uint64_t hash) {
+    return hash % 8908380762767489llu;
+  }
+  static uint64_t mod11223856443489329(uint64_t hash) {
+    return hash % 11223856443489329llu;
+  }
+  static uint64_t mod14141172994150357(uint64_t hash) {
+    return hash % 14141172994150357llu;
+  }
+  static uint64_t mod17816761525534927(uint64_t hash) {
+    return hash % 17816761525534927llu;
+  }
+  static uint64_t mod22447712886978529(uint64_t hash) {
+    return hash % 22447712886978529llu;
+  }
+  static uint64_t mod28282345988300791(uint64_t hash) {
+    return hash % 28282345988300791llu;
+  }
+  static uint64_t mod35633523051069991(uint64_t hash) {
+    return hash % 35633523051069991llu;
+  }
+  static uint64_t mod44895425773957261(uint64_t hash) {
+    return hash % 44895425773957261llu;
+  }
+  static uint64_t mod56564691976601587(uint64_t hash) {
+    return hash % 56564691976601587llu;
+  }
+  static uint64_t mod71267046102139967(uint64_t hash) {
+    return hash % 71267046102139967llu;
+  }
+  static uint64_t mod89790851547914507(uint64_t hash) {
+    return hash % 89790851547914507llu;
+  }
+  static uint64_t mod113129383953203213(uint64_t hash) {
+    return hash % 113129383953203213llu;
+  }
+  static uint64_t mod142534092204280003(uint64_t hash) {
+    return hash % 142534092204280003llu;
+  }
+  static uint64_t mod179581703095829107(uint64_t hash) {
+    return hash % 179581703095829107llu;
+  }
+  static uint64_t mod226258767906406483(uint64_t hash) {
+    return hash % 226258767906406483llu;
+  }
+  static uint64_t mod285068184408560057(uint64_t hash) {
+    return hash % 285068184408560057llu;
+  }
+  static uint64_t mod359163406191658253(uint64_t hash) {
+    return hash % 359163406191658253llu;
+  }
+  static uint64_t mod452517535812813007(uint64_t hash) {
+    return hash % 452517535812813007llu;
+  }
+  static uint64_t mod570136368817120201(uint64_t hash) {
+    return hash % 570136368817120201llu;
+  }
+  static uint64_t mod718326812383316683(uint64_t hash) {
+    return hash % 718326812383316683llu;
+  }
+  static uint64_t mod905035071625626043(uint64_t hash) {
+    return hash % 905035071625626043llu;
+  }
+  static uint64_t mod1140272737634240411(uint64_t hash) {
+    return hash % 1140272737634240411llu;
+  }
+  static uint64_t mod1436653624766633509(uint64_t hash) {
+    return hash % 1436653624766633509llu;
+  }
+  static uint64_t mod1810070143251252131(uint64_t hash) {
+    return hash % 1810070143251252131llu;
+  }
+  static uint64_t mod2280545475268481167(uint64_t hash) {
+    return hash % 2280545475268481167llu;
+  }
+  static uint64_t mod2873307249533267101(uint64_t hash) {
+    return hash % 2873307249533267101llu;
+  }
+  static uint64_t mod3620140286502504283(uint64_t hash) {
+    return hash % 3620140286502504283llu;
+  }
+  static uint64_t mod4561090950536962147(uint64_t hash) {
+    return hash % 4561090950536962147llu;
+  }
+  static uint64_t mod5746614499066534157(uint64_t hash) {
+    return hash % 5746614499066534157llu;
+  }
+  static uint64_t mod7240280573005008577(uint64_t hash) {
+    return hash % 7240280573005008577llu;
+  }
+  static uint64_t mod9122181901073924329(uint64_t hash) {
+    return hash % 9122181901073924329llu;
+  }
+  static uint64_t mod11493228998133068689(uint64_t hash) {
+    return hash % 11493228998133068689llu;
+  }
+  static uint64_t mod14480561146010017169(uint64_t hash) {
+    return hash % 14480561146010017169llu;
+  }
+  static uint64_t mod18446744073709551557(uint64_t hash) {
+    return hash % 18446744073709551557llu;
+  }
 
-    using mod_function = uint64_t (*)(uint64_t);
+  using mod_function = uint64_t (*)(uint64_t);
 
-    mod_function next_size_over(uint64_t & size) const
-    {
-        // prime numbers generated by the following method:
-        // 1. start with a prime p = 2
-        // 2. go to wolfram alpha and get p = NextPrime(2 * p)
-        // 3. repeat 2. until you overflow 64 bits
-        // you now have large gaps which you would hit if somebody called reserve() with an unlucky number.
-        // 4. to fill the gaps for every prime p go to wolfram alpha and get ClosestPrime(p * 2^(1/3)) and ClosestPrime(p * 2^(2/3)) and put those in the gaps
-        // 5. get PrevPrime(2^64) and put it at the end
-        static constexpr const uint64_t prime_list[] =
-        {
-            2llu, 3llu, 5llu, 7llu, 11llu, 13llu, 17llu, 23llu, 29llu, 37llu, 47llu,
-            59llu, 73llu, 97llu, 127llu, 151llu, 197llu, 251llu, 313llu, 397llu,
-            499llu, 631llu, 797llu, 1009llu, 1259llu, 1597llu, 2011llu, 2539llu,
-            3203llu, 4027llu, 5087llu, 6421llu, 8089llu, 10193llu, 12853llu, 16193llu,
-            20399llu, 25717llu, 32401llu, 40823llu, 51437llu, 64811llu, 81649llu,
-            102877llu, 129607llu, 163307llu, 205759llu, 259229llu, 326617llu,
-            411527llu, 518509llu, 653267llu, 823117llu, 1037059llu, 1306601llu,
-            1646237llu, 2074129llu, 2613229llu, 3292489llu, 4148279llu, 5226491llu,
-            6584983llu, 8296553llu, 10453007llu, 13169977llu, 16593127llu, 20906033llu,
-            26339969llu, 33186281llu, 41812097llu, 52679969llu, 66372617llu,
-            83624237llu, 105359939llu, 132745199llu, 167248483llu, 210719881llu,
-            265490441llu, 334496971llu, 421439783llu, 530980861llu, 668993977llu,
-            842879579llu, 1061961721llu, 1337987929llu, 1685759167llu, 2123923447llu,
-            2675975881llu, 3371518343llu, 4247846927llu, 5351951779llu, 6743036717llu,
-            8495693897llu, 10703903591llu, 13486073473llu, 16991387857llu,
-            21407807219llu, 26972146961llu, 33982775741llu, 42815614441llu,
-            53944293929llu, 67965551447llu, 85631228929llu, 107888587883llu,
-            135931102921llu, 171262457903llu, 215777175787llu, 271862205833llu,
-            342524915839llu, 431554351609llu, 543724411781llu, 685049831731llu,
-            863108703229llu, 1087448823553llu, 1370099663459llu, 1726217406467llu,
-            2174897647073llu, 2740199326961llu, 3452434812973llu, 4349795294267llu,
-            5480398654009llu, 6904869625999llu, 8699590588571llu, 10960797308051llu,
-            13809739252051llu, 17399181177241llu, 21921594616111llu, 27619478504183llu,
-            34798362354533llu, 43843189232363llu, 55238957008387llu, 69596724709081llu,
-            87686378464759llu, 110477914016779llu, 139193449418173llu,
-            175372756929481llu, 220955828033581llu, 278386898836457llu,
-            350745513859007llu, 441911656067171llu, 556773797672909llu,
-            701491027718027llu, 883823312134381llu, 1113547595345903llu,
-            1402982055436147llu, 1767646624268779llu, 2227095190691797llu,
-            2805964110872297llu, 3535293248537579llu, 4454190381383713llu,
-            5611928221744609llu, 7070586497075177llu, 8908380762767489llu,
-            11223856443489329llu, 14141172994150357llu, 17816761525534927llu,
-            22447712886978529llu, 28282345988300791llu, 35633523051069991llu,
-            44895425773957261llu, 56564691976601587llu, 71267046102139967llu,
-            89790851547914507llu, 113129383953203213llu, 142534092204280003llu,
-            179581703095829107llu, 226258767906406483llu, 285068184408560057llu,
-            359163406191658253llu, 452517535812813007llu, 570136368817120201llu,
-            718326812383316683llu, 905035071625626043llu, 1140272737634240411llu,
-            1436653624766633509llu, 1810070143251252131llu, 2280545475268481167llu,
-            2873307249533267101llu, 3620140286502504283llu, 4561090950536962147llu,
-            5746614499066534157llu, 7240280573005008577llu, 9122181901073924329llu,
-            11493228998133068689llu, 14480561146010017169llu, 18446744073709551557llu
-        };
-        static constexpr uint64_t (* const mod_functions[])(uint64_t) =
-        {
-            &mod0, &mod2, &mod3, &mod5, &mod7, &mod11, &mod13, &mod17, &mod23, &mod29, &mod37,
-            &mod47, &mod59, &mod73, &mod97, &mod127, &mod151, &mod197, &mod251, &mod313, &mod397,
-            &mod499, &mod631, &mod797, &mod1009, &mod1259, &mod1597, &mod2011, &mod2539, &mod3203,
-            &mod4027, &mod5087, &mod6421, &mod8089, &mod10193, &mod12853, &mod16193, &mod20399,
-            &mod25717, &mod32401, &mod40823, &mod51437, &mod64811, &mod81649, &mod102877,
-            &mod129607, &mod163307, &mod205759, &mod259229, &mod326617, &mod411527, &mod518509,
-            &mod653267, &mod823117, &mod1037059, &mod1306601, &mod1646237, &mod2074129,
-            &mod2613229, &mod3292489, &mod4148279, &mod5226491, &mod6584983, &mod8296553,
-            &mod10453007, &mod13169977, &mod16593127, &mod20906033, &mod26339969, &mod33186281,
-            &mod41812097, &mod52679969, &mod66372617, &mod83624237, &mod105359939, &mod132745199,
-            &mod167248483, &mod210719881, &mod265490441, &mod334496971, &mod421439783,
-            &mod530980861, &mod668993977, &mod842879579, &mod1061961721, &mod1337987929,
-            &mod1685759167, &mod2123923447, &mod2675975881, &mod3371518343, &mod4247846927,
-            &mod5351951779, &mod6743036717, &mod8495693897, &mod10703903591, &mod13486073473,
-            &mod16991387857, &mod21407807219, &mod26972146961, &mod33982775741, &mod42815614441,
-            &mod53944293929, &mod67965551447, &mod85631228929, &mod107888587883, &mod135931102921,
-            &mod171262457903, &mod215777175787, &mod271862205833, &mod342524915839,
-            &mod431554351609, &mod543724411781, &mod685049831731, &mod863108703229,
-            &mod1087448823553, &mod1370099663459, &mod1726217406467, &mod2174897647073,
-            &mod2740199326961, &mod3452434812973, &mod4349795294267, &mod5480398654009,
-            &mod6904869625999, &mod8699590588571, &mod10960797308051, &mod13809739252051,
-            &mod17399181177241, &mod21921594616111, &mod27619478504183, &mod34798362354533,
-            &mod43843189232363, &mod55238957008387, &mod69596724709081, &mod87686378464759,
-            &mod110477914016779, &mod139193449418173, &mod175372756929481, &mod220955828033581,
-            &mod278386898836457, &mod350745513859007, &mod441911656067171, &mod556773797672909,
-            &mod701491027718027, &mod883823312134381, &mod1113547595345903, &mod1402982055436147,
-            &mod1767646624268779, &mod2227095190691797, &mod2805964110872297, &mod3535293248537579,
-            &mod4454190381383713, &mod5611928221744609, &mod7070586497075177, &mod8908380762767489,
-            &mod11223856443489329, &mod14141172994150357, &mod17816761525534927,
-            &mod22447712886978529, &mod28282345988300791, &mod35633523051069991,
-            &mod44895425773957261, &mod56564691976601587, &mod71267046102139967,
-            &mod89790851547914507, &mod113129383953203213, &mod142534092204280003,
-            &mod179581703095829107, &mod226258767906406483, &mod285068184408560057,
-            &mod359163406191658253, &mod452517535812813007, &mod570136368817120201,
-            &mod718326812383316683, &mod905035071625626043, &mod1140272737634240411,
-            &mod1436653624766633509, &mod1810070143251252131, &mod2280545475268481167,
-            &mod2873307249533267101, &mod3620140286502504283, &mod4561090950536962147,
-            &mod5746614499066534157, &mod7240280573005008577, &mod9122181901073924329,
-            &mod11493228998133068689, &mod14480561146010017169, &mod18446744073709551557
-        };
-        const uint64_t * found = std::lower_bound(std::begin(prime_list), std::end(prime_list) - 1, size);
-        size = *found;
-        return mod_functions[1 + found - prime_list];
-    }
-    void commit(mod_function new_mod_function)
-    {
-        current_mod_function = new_mod_function;
-    }
-    void reset()
-    {
-        current_mod_function = &mod0;
-    }
+  mod_function next_size_over(uint64_t& size) const {
+    // prime numbers generated by the following method:
+    // 1. start with a prime p = 2
+    // 2. go to wolfram alpha and get p = NextPrime(2 * p)
+    // 3. repeat 2. until you overflow 64 bits
+    // you now have large gaps which you would hit if somebody called reserve()
+    // with an unlucky number.
+    // 4. to fill the gaps for every prime p go to wolfram alpha and get
+    // ClosestPrime(p * 2^(1/3)) and ClosestPrime(p * 2^(2/3)) and put those in
+    // the gaps
+    // 5. get PrevPrime(2^64) and put it at the end
+    static constexpr const uint64_t prime_list[] = {2llu,
+                                                    3llu,
+                                                    5llu,
+                                                    7llu,
+                                                    11llu,
+                                                    13llu,
+                                                    17llu,
+                                                    23llu,
+                                                    29llu,
+                                                    37llu,
+                                                    47llu,
+                                                    59llu,
+                                                    73llu,
+                                                    97llu,
+                                                    127llu,
+                                                    151llu,
+                                                    197llu,
+                                                    251llu,
+                                                    313llu,
+                                                    397llu,
+                                                    499llu,
+                                                    631llu,
+                                                    797llu,
+                                                    1009llu,
+                                                    1259llu,
+                                                    1597llu,
+                                                    2011llu,
+                                                    2539llu,
+                                                    3203llu,
+                                                    4027llu,
+                                                    5087llu,
+                                                    6421llu,
+                                                    8089llu,
+                                                    10193llu,
+                                                    12853llu,
+                                                    16193llu,
+                                                    20399llu,
+                                                    25717llu,
+                                                    32401llu,
+                                                    40823llu,
+                                                    51437llu,
+                                                    64811llu,
+                                                    81649llu,
+                                                    102877llu,
+                                                    129607llu,
+                                                    163307llu,
+                                                    205759llu,
+                                                    259229llu,
+                                                    326617llu,
+                                                    411527llu,
+                                                    518509llu,
+                                                    653267llu,
+                                                    823117llu,
+                                                    1037059llu,
+                                                    1306601llu,
+                                                    1646237llu,
+                                                    2074129llu,
+                                                    2613229llu,
+                                                    3292489llu,
+                                                    4148279llu,
+                                                    5226491llu,
+                                                    6584983llu,
+                                                    8296553llu,
+                                                    10453007llu,
+                                                    13169977llu,
+                                                    16593127llu,
+                                                    20906033llu,
+                                                    26339969llu,
+                                                    33186281llu,
+                                                    41812097llu,
+                                                    52679969llu,
+                                                    66372617llu,
+                                                    83624237llu,
+                                                    105359939llu,
+                                                    132745199llu,
+                                                    167248483llu,
+                                                    210719881llu,
+                                                    265490441llu,
+                                                    334496971llu,
+                                                    421439783llu,
+                                                    530980861llu,
+                                                    668993977llu,
+                                                    842879579llu,
+                                                    1061961721llu,
+                                                    1337987929llu,
+                                                    1685759167llu,
+                                                    2123923447llu,
+                                                    2675975881llu,
+                                                    3371518343llu,
+                                                    4247846927llu,
+                                                    5351951779llu,
+                                                    6743036717llu,
+                                                    8495693897llu,
+                                                    10703903591llu,
+                                                    13486073473llu,
+                                                    16991387857llu,
+                                                    21407807219llu,
+                                                    26972146961llu,
+                                                    33982775741llu,
+                                                    42815614441llu,
+                                                    53944293929llu,
+                                                    67965551447llu,
+                                                    85631228929llu,
+                                                    107888587883llu,
+                                                    135931102921llu,
+                                                    171262457903llu,
+                                                    215777175787llu,
+                                                    271862205833llu,
+                                                    342524915839llu,
+                                                    431554351609llu,
+                                                    543724411781llu,
+                                                    685049831731llu,
+                                                    863108703229llu,
+                                                    1087448823553llu,
+                                                    1370099663459llu,
+                                                    1726217406467llu,
+                                                    2174897647073llu,
+                                                    2740199326961llu,
+                                                    3452434812973llu,
+                                                    4349795294267llu,
+                                                    5480398654009llu,
+                                                    6904869625999llu,
+                                                    8699590588571llu,
+                                                    10960797308051llu,
+                                                    13809739252051llu,
+                                                    17399181177241llu,
+                                                    21921594616111llu,
+                                                    27619478504183llu,
+                                                    34798362354533llu,
+                                                    43843189232363llu,
+                                                    55238957008387llu,
+                                                    69596724709081llu,
+                                                    87686378464759llu,
+                                                    110477914016779llu,
+                                                    139193449418173llu,
+                                                    175372756929481llu,
+                                                    220955828033581llu,
+                                                    278386898836457llu,
+                                                    350745513859007llu,
+                                                    441911656067171llu,
+                                                    556773797672909llu,
+                                                    701491027718027llu,
+                                                    883823312134381llu,
+                                                    1113547595345903llu,
+                                                    1402982055436147llu,
+                                                    1767646624268779llu,
+                                                    2227095190691797llu,
+                                                    2805964110872297llu,
+                                                    3535293248537579llu,
+                                                    4454190381383713llu,
+                                                    5611928221744609llu,
+                                                    7070586497075177llu,
+                                                    8908380762767489llu,
+                                                    11223856443489329llu,
+                                                    14141172994150357llu,
+                                                    17816761525534927llu,
+                                                    22447712886978529llu,
+                                                    28282345988300791llu,
+                                                    35633523051069991llu,
+                                                    44895425773957261llu,
+                                                    56564691976601587llu,
+                                                    71267046102139967llu,
+                                                    89790851547914507llu,
+                                                    113129383953203213llu,
+                                                    142534092204280003llu,
+                                                    179581703095829107llu,
+                                                    226258767906406483llu,
+                                                    285068184408560057llu,
+                                                    359163406191658253llu,
+                                                    452517535812813007llu,
+                                                    570136368817120201llu,
+                                                    718326812383316683llu,
+                                                    905035071625626043llu,
+                                                    1140272737634240411llu,
+                                                    1436653624766633509llu,
+                                                    1810070143251252131llu,
+                                                    2280545475268481167llu,
+                                                    2873307249533267101llu,
+                                                    3620140286502504283llu,
+                                                    4561090950536962147llu,
+                                                    5746614499066534157llu,
+                                                    7240280573005008577llu,
+                                                    9122181901073924329llu,
+                                                    11493228998133068689llu,
+                                                    14480561146010017169llu,
+                                                    18446744073709551557llu};
+    static constexpr uint64_t (*const mod_functions[])(uint64_t) = {
+        &mod0,
+        &mod2,
+        &mod3,
+        &mod5,
+        &mod7,
+        &mod11,
+        &mod13,
+        &mod17,
+        &mod23,
+        &mod29,
+        &mod37,
+        &mod47,
+        &mod59,
+        &mod73,
+        &mod97,
+        &mod127,
+        &mod151,
+        &mod197,
+        &mod251,
+        &mod313,
+        &mod397,
+        &mod499,
+        &mod631,
+        &mod797,
+        &mod1009,
+        &mod1259,
+        &mod1597,
+        &mod2011,
+        &mod2539,
+        &mod3203,
+        &mod4027,
+        &mod5087,
+        &mod6421,
+        &mod8089,
+        &mod10193,
+        &mod12853,
+        &mod16193,
+        &mod20399,
+        &mod25717,
+        &mod32401,
+        &mod40823,
+        &mod51437,
+        &mod64811,
+        &mod81649,
+        &mod102877,
+        &mod129607,
+        &mod163307,
+        &mod205759,
+        &mod259229,
+        &mod326617,
+        &mod411527,
+        &mod518509,
+        &mod653267,
+        &mod823117,
+        &mod1037059,
+        &mod1306601,
+        &mod1646237,
+        &mod2074129,
+        &mod2613229,
+        &mod3292489,
+        &mod4148279,
+        &mod5226491,
+        &mod6584983,
+        &mod8296553,
+        &mod10453007,
+        &mod13169977,
+        &mod16593127,
+        &mod20906033,
+        &mod26339969,
+        &mod33186281,
+        &mod41812097,
+        &mod52679969,
+        &mod66372617,
+        &mod83624237,
+        &mod105359939,
+        &mod132745199,
+        &mod167248483,
+        &mod210719881,
+        &mod265490441,
+        &mod334496971,
+        &mod421439783,
+        &mod530980861,
+        &mod668993977,
+        &mod842879579,
+        &mod1061961721,
+        &mod1337987929,
+        &mod1685759167,
+        &mod2123923447,
+        &mod2675975881,
+        &mod3371518343,
+        &mod4247846927,
+        &mod5351951779,
+        &mod6743036717,
+        &mod8495693897,
+        &mod10703903591,
+        &mod13486073473,
+        &mod16991387857,
+        &mod21407807219,
+        &mod26972146961,
+        &mod33982775741,
+        &mod42815614441,
+        &mod53944293929,
+        &mod67965551447,
+        &mod85631228929,
+        &mod107888587883,
+        &mod135931102921,
+        &mod171262457903,
+        &mod215777175787,
+        &mod271862205833,
+        &mod342524915839,
+        &mod431554351609,
+        &mod543724411781,
+        &mod685049831731,
+        &mod863108703229,
+        &mod1087448823553,
+        &mod1370099663459,
+        &mod1726217406467,
+        &mod2174897647073,
+        &mod2740199326961,
+        &mod3452434812973,
+        &mod4349795294267,
+        &mod5480398654009,
+        &mod6904869625999,
+        &mod8699590588571,
+        &mod10960797308051,
+        &mod13809739252051,
+        &mod17399181177241,
+        &mod21921594616111,
+        &mod27619478504183,
+        &mod34798362354533,
+        &mod43843189232363,
+        &mod55238957008387,
+        &mod69596724709081,
+        &mod87686378464759,
+        &mod110477914016779,
+        &mod139193449418173,
+        &mod175372756929481,
+        &mod220955828033581,
+        &mod278386898836457,
+        &mod350745513859007,
+        &mod441911656067171,
+        &mod556773797672909,
+        &mod701491027718027,
+        &mod883823312134381,
+        &mod1113547595345903,
+        &mod1402982055436147,
+        &mod1767646624268779,
+        &mod2227095190691797,
+        &mod2805964110872297,
+        &mod3535293248537579,
+        &mod4454190381383713,
+        &mod5611928221744609,
+        &mod7070586497075177,
+        &mod8908380762767489,
+        &mod11223856443489329,
+        &mod14141172994150357,
+        &mod17816761525534927,
+        &mod22447712886978529,
+        &mod28282345988300791,
+        &mod35633523051069991,
+        &mod44895425773957261,
+        &mod56564691976601587,
+        &mod71267046102139967,
+        &mod89790851547914507,
+        &mod113129383953203213,
+        &mod142534092204280003,
+        &mod179581703095829107,
+        &mod226258767906406483,
+        &mod285068184408560057,
+        &mod359163406191658253,
+        &mod452517535812813007,
+        &mod570136368817120201,
+        &mod718326812383316683,
+        &mod905035071625626043,
+        &mod1140272737634240411,
+        &mod1436653624766633509,
+        &mod1810070143251252131,
+        &mod2280545475268481167,
+        &mod2873307249533267101,
+        &mod3620140286502504283,
+        &mod4561090950536962147,
+        &mod5746614499066534157,
+        &mod7240280573005008577,
+        &mod9122181901073924329,
+        &mod11493228998133068689,
+        &mod14480561146010017169,
+        &mod18446744073709551557};
+    const uint64_t* found = std::lower_bound(
+        std::begin(prime_list), std::end(prime_list) - 1, size);
+    size = *found;
+    return mod_functions[1 + found - prime_list];
+  }
+  void commit(mod_function new_mod_function) {
+    current_mod_function = new_mod_function;
+  }
+  void reset() {
+    current_mod_function = &mod0;
+  }
 
-    uint64_t index_for_hash(uint64_t hash, uint64_t /*num_slots_minus_one*/) const
-    {
-        return current_mod_function(hash);
-    }
-    uint64_t keep_in_range(uint64_t index, uint64_t num_slots_minus_one) const
-    {
-        return index > num_slots_minus_one ? current_mod_function(index) : index;
-    }
+  uint64_t index_for_hash(uint64_t hash, uint64_t /*num_slots_minus_one*/)
+      const {
+    return current_mod_function(hash);
+  }
+  uint64_t keep_in_range(uint64_t index, uint64_t num_slots_minus_one) const {
+    return index > num_slots_minus_one ? current_mod_function(index) : index;
+  }
 
-private:
-    mod_function current_mod_function = &mod0;
+ private:
+  mod_function current_mod_function = &mod0;
 };
 
-struct power_of_two_hash_policy
-{
-    uint64_t index_for_hash(uint64_t hash, uint64_t num_slots_minus_one) const
-    {
-        return hash & num_slots_minus_one;
-    }
-    uint64_t keep_in_range(uint64_t index, uint64_t num_slots_minus_one) const
-    {
-        return index_for_hash(index, num_slots_minus_one);
-    }
-    int8_t next_size_over(uint64_t & size) const
-    {
-        size = detailv3::next_power_of_two(size);
-        return 0;
-    }
-    void commit(int8_t)
-    {
-    }
-    void reset()
-    {
-    }
-
+struct power_of_two_hash_policy {
+  uint64_t index_for_hash(uint64_t hash, uint64_t num_slots_minus_one) const {
+    return hash & num_slots_minus_one;
+  }
+  uint64_t keep_in_range(uint64_t index, uint64_t num_slots_minus_one) const {
+    return index_for_hash(index, num_slots_minus_one);
+  }
+  int8_t next_size_over(uint64_t& size) const {
+    size = detailv3::next_power_of_two(size);
+    return 0;
+  }
+  void commit(int8_t) {}
+  void reset() {}
 };
 
-struct fibonacci_hash_policy
-{
-    uint64_t index_for_hash(uint64_t hash, uint64_t /*num_slots_minus_one*/) const
-    {
-        return (11400714819323198485ull * hash) >> shift;
-    }
-    uint64_t keep_in_range(uint64_t index, uint64_t num_slots_minus_one) const
-    {
-        return index & num_slots_minus_one;
-    }
+struct fibonacci_hash_policy {
+  uint64_t index_for_hash(uint64_t hash, uint64_t /*num_slots_minus_one*/)
+      const {
+    return (11400714819323198485ull * hash) >> shift;
+  }
+  uint64_t keep_in_range(uint64_t index, uint64_t num_slots_minus_one) const {
+    return index & num_slots_minus_one;
+  }
 
-    int8_t next_size_over(uint64_t & size) const
-    {
-        size = std::max(uint64_t(2), detailv3::next_power_of_two(size));
-        return 64 - detailv3::log2(size);
-    }
-    void commit(int8_t shift)
-    {
-        this->shift = shift;
-    }
-    void reset()
-    {
-        shift = 63;
-    }
+  int8_t next_size_over(uint64_t& size) const {
+    size = std::max(uint64_t(2), detailv3::next_power_of_two(size));
+    return 64 - detailv3::log2(size);
+  }
+  void commit(int8_t shift) {
+    this->shift = shift;
+  }
+  void reset() {
+    shift = 63;
+  }
 
-private:
-    int8_t shift = 63;
+ private:
+  int8_t shift = 63;
 };
 
-template<typename K, typename V, typename H = std::hash<K>, typename E = std::equal_to<K>, typename A = std::allocator<std::pair<K, V> > >
+template <
+    typename K,
+    typename V,
+    typename H = std::hash<K>,
+    typename E = std::equal_to<K>,
+    typename A = std::allocator<std::pair<K, V>>>
 class order_preserving_flat_hash_map
-        : public detailv3::sherwood_v3_table
-        <
-            std::pair<K, V>,
-            K,
-            H,
-            detailv3::KeyOrValueHasher<K, std::pair<K, V>, H>,
-            E,
-            detailv3::KeyOrValueEquality<K, std::pair<K, V>, E>,
-            A,
-            typename std::allocator_traits<A>::template rebind_alloc<detailv3::sherwood_v3_entry<std::pair<K, V>>>
-        >
-{
-    using Table = detailv3::sherwood_v3_table
-    <
-        std::pair<K, V>,
-        K,
-        H,
-        detailv3::KeyOrValueHasher<K, std::pair<K, V>, H>,
-        E,
-        detailv3::KeyOrValueEquality<K, std::pair<K, V>, E>,
-        A,
-        typename std::allocator_traits<A>::template rebind_alloc<detailv3::sherwood_v3_entry<std::pair<K, V>>>
-    >;
-public:
+    : public detailv3::sherwood_v3_table<
+          std::pair<K, V>,
+          K,
+          H,
+          detailv3::KeyOrValueHasher<K, std::pair<K, V>, H>,
+          E,
+          detailv3::KeyOrValueEquality<K, std::pair<K, V>, E>,
+          A,
+          typename std::allocator_traits<A>::template rebind_alloc<
+              detailv3::sherwood_v3_entry<std::pair<K, V>>>> {
+  using Table = detailv3::sherwood_v3_table<
+      std::pair<K, V>,
+      K,
+      H,
+      detailv3::KeyOrValueHasher<K, std::pair<K, V>, H>,
+      E,
+      detailv3::KeyOrValueEquality<K, std::pair<K, V>, E>,
+      A,
+      typename std::allocator_traits<A>::template rebind_alloc<
+          detailv3::sherwood_v3_entry<std::pair<K, V>>>>;
 
-    using key_type = K;
-    using mapped_type = V;
+ public:
+  using key_type = K;
+  using mapped_type = V;
 
-    using Table::Table;
-    order_preserving_flat_hash_map()
-    {
-    }
+  using Table::Table;
+  order_preserving_flat_hash_map() {}
 
-    inline V & operator[](const K & key)
-    {
-        return emplace(key, convertible_to_value()).first->second;
-    }
-    inline V & operator[](K && key)
-    {
-        return emplace(std::move(key), convertible_to_value()).first->second;
-    }
-    V & at(const K & key)
-    {
-        auto found = this->find(key);
-        if (found == this->end())
-            throw std::out_of_range("Argument passed to at() was not in the map.");
-        return found->second;
-    }
-    const V & at(const K & key) const
-    {
-        auto found = this->find(key);
-        if (found == this->end())
-            throw std::out_of_range("Argument passed to at() was not in the map.");
-        return found->second;
-    }
+  inline V& operator[](const K& key) {
+    return emplace(key, convertible_to_value()).first->second;
+  }
+  inline V& operator[](K&& key) {
+    return emplace(std::move(key), convertible_to_value()).first->second;
+  }
+  V& at(const K& key) {
+    auto found = this->find(key);
+    if (found == this->end())
+      throw std::out_of_range("Argument passed to at() was not in the map.");
+    return found->second;
+  }
+  const V& at(const K& key) const {
+    auto found = this->find(key);
+    if (found == this->end())
+      throw std::out_of_range("Argument passed to at() was not in the map.");
+    return found->second;
+  }
 
-    using Table::emplace;
-    std::pair<typename Table::iterator, bool> emplace()
-    {
-        return emplace(key_type(), convertible_to_value());
-    }
-    template<typename M>
-    std::pair<typename Table::iterator, bool> insert_or_assign(const key_type & key, M && m)
-    {
-        auto emplace_result = emplace(key, std::forward<M>(m));
-        if (!emplace_result.second)
-            emplace_result.first->second = std::forward<M>(m);
-        return emplace_result;
-    }
-    template<typename M>
-    std::pair<typename Table::iterator, bool> insert_or_assign(key_type && key, M && m)
-    {
-        auto emplace_result = emplace(std::move(key), std::forward<M>(m));
-        if (!emplace_result.second)
-            emplace_result.first->second = std::forward<M>(m);
-        return emplace_result;
-    }
-    template<typename M>
-    typename Table::iterator insert_or_assign(typename Table::const_iterator, const key_type & key, M && m)
-    {
-        return insert_or_assign(key, std::forward<M>(m)).first;
-    }
-    template<typename M>
-    typename Table::iterator insert_or_assign(typename Table::const_iterator, key_type && key, M && m)
-    {
-        return insert_or_assign(std::move(key), std::forward<M>(m)).first;
-    }
+  using Table::emplace;
+  std::pair<typename Table::iterator, bool> emplace() {
+    return emplace(key_type(), convertible_to_value());
+  }
+  template <typename M>
+  std::pair<typename Table::iterator, bool> insert_or_assign(
+      const key_type& key,
+      M&& m) {
+    auto emplace_result = emplace(key, std::forward<M>(m));
+    if (!emplace_result.second)
+      emplace_result.first->second = std::forward<M>(m);
+    return emplace_result;
+  }
+  template <typename M>
+  std::pair<typename Table::iterator, bool> insert_or_assign(
+      key_type&& key,
+      M&& m) {
+    auto emplace_result = emplace(std::move(key), std::forward<M>(m));
+    if (!emplace_result.second)
+      emplace_result.first->second = std::forward<M>(m);
+    return emplace_result;
+  }
+  template <typename M>
+  typename Table::iterator insert_or_assign(
+      typename Table::const_iterator,
+      const key_type& key,
+      M&& m) {
+    return insert_or_assign(key, std::forward<M>(m)).first;
+  }
+  template <typename M>
+  typename Table::iterator insert_or_assign(
+      typename Table::const_iterator,
+      key_type&& key,
+      M&& m) {
+    return insert_or_assign(std::move(key), std::forward<M>(m)).first;
+  }
 
-    friend bool operator==(const order_preserving_flat_hash_map & lhs, const order_preserving_flat_hash_map & rhs)
-    {
-        if (lhs.size() != rhs.size())
-            return false;
-        for (const typename Table::value_type & value : lhs)
-        {
-            auto found = rhs.find(value.first);
-            if (found == rhs.end())
-                return false;
-            else if (value.second != found->second)
-                return false;
-        }
-        return true;
+  friend bool operator==(
+      const order_preserving_flat_hash_map& lhs,
+      const order_preserving_flat_hash_map& rhs) {
+    if (lhs.size() != rhs.size())
+      return false;
+    for (const typename Table::value_type& value : lhs) {
+      auto found = rhs.find(value.first);
+      if (found == rhs.end())
+        return false;
+      else if (value.second != found->second)
+        return false;
     }
-    friend bool operator!=(const order_preserving_flat_hash_map & lhs, const order_preserving_flat_hash_map & rhs)
-    {
-        return !(lhs == rhs);
-    }
+    return true;
+  }
+  friend bool operator!=(
+      const order_preserving_flat_hash_map& lhs,
+      const order_preserving_flat_hash_map& rhs) {
+    return !(lhs == rhs);
+  }
 
-private:
-    struct convertible_to_value
-    {
-        operator V() const
-        {
-            return V();
-        }
-    };
+ private:
+  struct convertible_to_value {
+    operator V() const {
+      return V();
+    }
+  };
 };
 
-template<typename T, typename H = std::hash<T>, typename E = std::equal_to<T>, typename A = std::allocator<T> >
+template <
+    typename T,
+    typename H = std::hash<T>,
+    typename E = std::equal_to<T>,
+    typename A = std::allocator<T>>
 class flat_hash_set
-        : public detailv3::sherwood_v3_table
-        <
-            T,
-            T,
-            H,
-            detailv3::functor_storage<uint64_t, H>,
-            E,
-            detailv3::functor_storage<bool, E>,
-            A,
-            typename std::allocator_traits<A>::template rebind_alloc<detailv3::sherwood_v3_entry<T>>
-        >
-{
-    using Table = detailv3::sherwood_v3_table
-    <
-        T,
-        T,
-        H,
-        detailv3::functor_storage<uint64_t, H>,
-        E,
-        detailv3::functor_storage<bool, E>,
-        A,
-        typename std::allocator_traits<A>::template rebind_alloc<detailv3::sherwood_v3_entry<T>>
-    >;
-public:
+    : public detailv3::sherwood_v3_table<
+          T,
+          T,
+          H,
+          detailv3::functor_storage<uint64_t, H>,
+          E,
+          detailv3::functor_storage<bool, E>,
+          A,
+          typename std::allocator_traits<A>::template rebind_alloc<
+              detailv3::sherwood_v3_entry<T>>> {
+  using Table = detailv3::sherwood_v3_table<
+      T,
+      T,
+      H,
+      detailv3::functor_storage<uint64_t, H>,
+      E,
+      detailv3::functor_storage<bool, E>,
+      A,
+      typename std::allocator_traits<A>::template rebind_alloc<
+          detailv3::sherwood_v3_entry<T>>>;
 
-    using key_type = T;
+ public:
+  using key_type = T;
 
-    using Table::Table;
-    flat_hash_set()
-    {
-    }
+  using Table::Table;
+  flat_hash_set() {}
 
-    template<typename... Args>
-    std::pair<typename Table::iterator, bool> emplace(Args &&... args)
-    {
-        return Table::emplace(T(std::forward<Args>(args)...));
-    }
-    std::pair<typename Table::iterator, bool> emplace(const key_type & arg)
-    {
-        return Table::emplace(arg);
-    }
-    std::pair<typename Table::iterator, bool> emplace(key_type & arg)
-    {
-        return Table::emplace(arg);
-    }
-    std::pair<typename Table::iterator, bool> emplace(const key_type && arg)
-    {
-        return Table::emplace(std::move(arg));
-    }
-    std::pair<typename Table::iterator, bool> emplace(key_type && arg)
-    {
-        return Table::emplace(std::move(arg));
-    }
+  template <typename... Args>
+  std::pair<typename Table::iterator, bool> emplace(Args&&... args) {
+    return Table::emplace(T(std::forward<Args>(args)...));
+  }
+  std::pair<typename Table::iterator, bool> emplace(const key_type& arg) {
+    return Table::emplace(arg);
+  }
+  std::pair<typename Table::iterator, bool> emplace(key_type& arg) {
+    return Table::emplace(arg);
+  }
+  std::pair<typename Table::iterator, bool> emplace(const key_type&& arg) {
+    return Table::emplace(std::move(arg));
+  }
+  std::pair<typename Table::iterator, bool> emplace(key_type&& arg) {
+    return Table::emplace(std::move(arg));
+  }
 
-    friend bool operator==(const flat_hash_set & lhs, const flat_hash_set & rhs)
-    {
-        if (lhs.size() != rhs.size())
-            return false;
-        for (const T & value : lhs)
-        {
-            if (rhs.find(value) == rhs.end())
-                return false;
-        }
-        return true;
+  friend bool operator==(const flat_hash_set& lhs, const flat_hash_set& rhs) {
+    if (lhs.size() != rhs.size())
+      return false;
+    for (const T& value : lhs) {
+      if (rhs.find(value) == rhs.end())
+        return false;
     }
-    friend bool operator!=(const flat_hash_set & lhs, const flat_hash_set & rhs)
-    {
-        return !(lhs == rhs);
-    }
+    return true;
+  }
+  friend bool operator!=(const flat_hash_set& lhs, const flat_hash_set& rhs) {
+    return !(lhs == rhs);
+  }
 };
 
-
-template<typename T>
-struct power_of_two_std_hash : std::hash<T>
-{
-    typedef ska_ordered::power_of_two_hash_policy hash_policy;
+template <typename T>
+struct power_of_two_std_hash : std::hash<T> {
+  typedef ska_ordered::power_of_two_hash_policy hash_policy;
 };
 
-} // end namespace ska
+} // namespace ska_ordered
 
 #ifndef _MSC_VER
 #pragma GCC diagnostic pop

--- a/c10/util/sparse_bitset.h
+++ b/c10/util/sparse_bitset.h
@@ -1,897 +1,894 @@
 //===- llvm/ADT/SparseBitVector.h - Efficient Sparse BitVector --*- C++ -*-===//
- //
- // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
- // See https://llvm.org/LICENSE.txt for license information.
- // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
- //
- //===----------------------------------------------------------------------===//
- //
- // This file defines the SparseBitVector class.  See the doxygen comment for
- // SparseBitVector for more details on the algorithm used.
- //
- //===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the SparseBitVector class.  See the doxygen comment for
+// SparseBitVector for more details on the algorithm used.
+//
+//===----------------------------------------------------------------------===//
 
 #pragma once
- #include <cassert>
- #include <climits>
- #include <cstring>
- #include <iterator>
- #include <list>
- #include "./llvmMathExtras.h"
+#include <cassert>
+#include <climits>
+#include <cstring>
+#include <iterator>
+#include <list>
+#include "./llvmMathExtras.h"
 
- namespace c10 {
+namespace c10 {
 
- /// SparseBitVector is an implementation of a bitvector that is sparse by only
- /// storing the elements that have non-zero bits set.  In order to make this
- /// fast for the most common cases, SparseBitVector is implemented as a linked
- /// list of SparseBitVectorElements.  We maintain a pointer to the last
- /// SparseBitVectorElement accessed (in the form of a list iterator), in order
- /// to make multiple in-order test/set constant time after the first one is
- /// executed.  Note that using vectors to store SparseBitVectorElement's does
- /// not work out very well because it causes insertion in the middle to take
- /// enormous amounts of time with a large amount of bits.  Other structures that
- /// have better worst cases for insertion in the middle (various balanced trees,
- /// etc) do not perform as well in practice as a linked list with this iterator
- /// kept up to date.  They are also significantly more memory intensive.
+/// SparseBitVector is an implementation of a bitvector that is sparse by only
+/// storing the elements that have non-zero bits set.  In order to make this
+/// fast for the most common cases, SparseBitVector is implemented as a linked
+/// list of SparseBitVectorElements.  We maintain a pointer to the last
+/// SparseBitVectorElement accessed (in the form of a list iterator), in order
+/// to make multiple in-order test/set constant time after the first one is
+/// executed.  Note that using vectors to store SparseBitVectorElement's does
+/// not work out very well because it causes insertion in the middle to take
+/// enormous amounts of time with a large amount of bits.  Other structures that
+/// have better worst cases for insertion in the middle (various balanced trees,
+/// etc) do not perform as well in practice as a linked list with this iterator
+/// kept up to date.  They are also significantly more memory intensive.
 
- template <unsigned ElementSize = 128> struct SparseBitVectorElement {
+template <unsigned ElementSize = 128>
+struct SparseBitVectorElement {
  public:
-   using BitWord = unsigned long;
-   using size_type = unsigned;
-   enum {
-     BITWORD_SIZE = sizeof(BitWord) * CHAR_BIT,
-     BITWORDS_PER_ELEMENT = (ElementSize + BITWORD_SIZE - 1) / BITWORD_SIZE,
-     BITS_PER_ELEMENT = ElementSize
-   };
+  using BitWord = unsigned long;
+  using size_type = unsigned;
+  enum {
+    BITWORD_SIZE = sizeof(BitWord) * CHAR_BIT,
+    BITWORDS_PER_ELEMENT = (ElementSize + BITWORD_SIZE - 1) / BITWORD_SIZE,
+    BITS_PER_ELEMENT = ElementSize
+  };
 
  private:
-   // Index of Element in terms of where first bit starts.
-   unsigned ElementIndex;
-   BitWord Bits[BITWORDS_PER_ELEMENT];
+  // Index of Element in terms of where first bit starts.
+  unsigned ElementIndex;
+  BitWord Bits[BITWORDS_PER_ELEMENT];
 
-   SparseBitVectorElement() {
-     ElementIndex = ~0U;
-     memset(&Bits[0], 0, sizeof (BitWord) * BITWORDS_PER_ELEMENT);
-   }
+  SparseBitVectorElement() {
+    ElementIndex = ~0U;
+    memset(&Bits[0], 0, sizeof(BitWord) * BITWORDS_PER_ELEMENT);
+  }
 
  public:
-   explicit SparseBitVectorElement(unsigned Idx) {
-     ElementIndex = Idx;
-     memset(&Bits[0], 0, sizeof (BitWord) * BITWORDS_PER_ELEMENT);
-   }
+  explicit SparseBitVectorElement(unsigned Idx) {
+    ElementIndex = Idx;
+    memset(&Bits[0], 0, sizeof(BitWord) * BITWORDS_PER_ELEMENT);
+  }
 
-   // Comparison.
-   bool operator==(const SparseBitVectorElement &RHS) const {
-     if (ElementIndex != RHS.ElementIndex)
-       return false;
-     for (unsigned i = 0; i < BITWORDS_PER_ELEMENT; ++i)
-       if (Bits[i] != RHS.Bits[i])
-         return false;
-     return true;
-   }
+  // Comparison.
+  bool operator==(const SparseBitVectorElement& RHS) const {
+    if (ElementIndex != RHS.ElementIndex)
+      return false;
+    for (unsigned i = 0; i < BITWORDS_PER_ELEMENT; ++i)
+      if (Bits[i] != RHS.Bits[i])
+        return false;
+    return true;
+  }
 
-   bool operator!=(const SparseBitVectorElement &RHS) const {
-     return !(*this == RHS);
-   }
+  bool operator!=(const SparseBitVectorElement& RHS) const {
+    return !(*this == RHS);
+  }
 
-   // Return the bits that make up word Idx in our element.
-   BitWord word(unsigned Idx) const {
-     assert(Idx < BITWORDS_PER_ELEMENT);
-     return Bits[Idx];
-   }
+  // Return the bits that make up word Idx in our element.
+  BitWord word(unsigned Idx) const {
+    assert(Idx < BITWORDS_PER_ELEMENT);
+    return Bits[Idx];
+  }
 
-   unsigned index() const {
-     return ElementIndex;
-   }
+  unsigned index() const {
+    return ElementIndex;
+  }
 
-   bool empty() const {
-     for (unsigned i = 0; i < BITWORDS_PER_ELEMENT; ++i)
-       if (Bits[i])
-         return false;
-     return true;
-   }
+  bool empty() const {
+    for (unsigned i = 0; i < BITWORDS_PER_ELEMENT; ++i)
+      if (Bits[i])
+        return false;
+    return true;
+  }
 
-   void set(unsigned Idx) {
-     Bits[Idx / BITWORD_SIZE] |= 1L << (Idx % BITWORD_SIZE);
-   }
+  void set(unsigned Idx) {
+    Bits[Idx / BITWORD_SIZE] |= 1L << (Idx % BITWORD_SIZE);
+  }
 
-   bool test_and_set(unsigned Idx) {
-     bool old = test(Idx);
-     if (!old) {
-       set(Idx);
-       return true;
-     }
-     return false;
-   }
+  bool test_and_set(unsigned Idx) {
+    bool old = test(Idx);
+    if (!old) {
+      set(Idx);
+      return true;
+    }
+    return false;
+  }
 
-   void reset(unsigned Idx) {
-     Bits[Idx / BITWORD_SIZE] &= ~(1L << (Idx % BITWORD_SIZE));
-   }
+  void reset(unsigned Idx) {
+    Bits[Idx / BITWORD_SIZE] &= ~(1L << (Idx % BITWORD_SIZE));
+  }
 
-   bool test(unsigned Idx) const {
-     return Bits[Idx / BITWORD_SIZE] & (1L << (Idx % BITWORD_SIZE));
-   }
+  bool test(unsigned Idx) const {
+    return Bits[Idx / BITWORD_SIZE] & (1L << (Idx % BITWORD_SIZE));
+  }
 
-   size_type count() const {
-     unsigned NumBits = 0;
-     for (unsigned i = 0; i < BITWORDS_PER_ELEMENT; ++i)
-       NumBits += llvm::countPopulation(Bits[i]);
-     return NumBits;
-   }
+  size_type count() const {
+    unsigned NumBits = 0;
+    for (unsigned i = 0; i < BITWORDS_PER_ELEMENT; ++i)
+      NumBits += llvm::countPopulation(Bits[i]);
+    return NumBits;
+  }
 
-   /// find_first - Returns the index of the first set bit.
-   int find_first() const {
-     for (unsigned i = 0; i < BITWORDS_PER_ELEMENT; ++i)
-       if (Bits[i] != 0)
-         return i * BITWORD_SIZE + llvm::countTrailingZeros(Bits[i]);
-      throw std::runtime_error("Illegal empty element");
-   }
+  /// find_first - Returns the index of the first set bit.
+  int find_first() const {
+    for (unsigned i = 0; i < BITWORDS_PER_ELEMENT; ++i)
+      if (Bits[i] != 0)
+        return i * BITWORD_SIZE + llvm::countTrailingZeros(Bits[i]);
+    throw std::runtime_error("Illegal empty element");
+  }
 
-   /// find_last - Returns the index of the last set bit.
-   int find_last() const {
-     for (unsigned I = 0; I < BITWORDS_PER_ELEMENT; ++I) {
-       unsigned Idx = BITWORDS_PER_ELEMENT - I - 1;
-       if (Bits[Idx] != 0)
-         return Idx * BITWORD_SIZE + BITWORD_SIZE -
-                 llvm::countLeadingZeros(Bits[Idx]);
-     }
-      throw std::runtime_error("Illegal empty element");
-   }
+  /// find_last - Returns the index of the last set bit.
+  int find_last() const {
+    for (unsigned I = 0; I < BITWORDS_PER_ELEMENT; ++I) {
+      unsigned Idx = BITWORDS_PER_ELEMENT - I - 1;
+      if (Bits[Idx] != 0)
+        return Idx * BITWORD_SIZE + BITWORD_SIZE -
+            llvm::countLeadingZeros(Bits[Idx]);
+    }
+    throw std::runtime_error("Illegal empty element");
+  }
 
-   /// find_next - Returns the index of the next set bit starting from the
-   /// "Curr" bit. Returns -1 if the next set bit is not found.
-   int find_next(unsigned Curr) const {
-     if (Curr >= BITS_PER_ELEMENT)
-       return -1;
+  /// find_next - Returns the index of the next set bit starting from the
+  /// "Curr" bit. Returns -1 if the next set bit is not found.
+  int find_next(unsigned Curr) const {
+    if (Curr >= BITS_PER_ELEMENT)
+      return -1;
 
-     unsigned WordPos = Curr / BITWORD_SIZE;
-     unsigned BitPos = Curr % BITWORD_SIZE;
-     BitWord Copy = Bits[WordPos];
-     assert(WordPos <= BITWORDS_PER_ELEMENT
-            && "Word Position outside of element");
+    unsigned WordPos = Curr / BITWORD_SIZE;
+    unsigned BitPos = Curr % BITWORD_SIZE;
+    BitWord Copy = Bits[WordPos];
+    assert(
+        WordPos <= BITWORDS_PER_ELEMENT && "Word Position outside of element");
 
-     // Mask off previous bits.
-     Copy &= ~0UL << BitPos;
+    // Mask off previous bits.
+    Copy &= ~0UL << BitPos;
 
-     if (Copy != 0)
-       return WordPos * BITWORD_SIZE + llvm::countTrailingZeros(Copy);
+    if (Copy != 0)
+      return WordPos * BITWORD_SIZE + llvm::countTrailingZeros(Copy);
 
-     // Check subsequent words.
-     for (unsigned i = WordPos+1; i < BITWORDS_PER_ELEMENT; ++i)
-       if (Bits[i] != 0)
-         return i * BITWORD_SIZE + llvm::countTrailingZeros(Bits[i]);
-     return -1;
-   }
+    // Check subsequent words.
+    for (unsigned i = WordPos + 1; i < BITWORDS_PER_ELEMENT; ++i)
+      if (Bits[i] != 0)
+        return i * BITWORD_SIZE + llvm::countTrailingZeros(Bits[i]);
+    return -1;
+  }
 
-   // Union this element with RHS and return true if this one changed.
-   bool unionWith(const SparseBitVectorElement &RHS) {
-     bool changed = false;
-     for (unsigned i = 0; i < BITWORDS_PER_ELEMENT; ++i) {
-       BitWord old = changed ? 0 : Bits[i];
+  // Union this element with RHS and return true if this one changed.
+  bool unionWith(const SparseBitVectorElement& RHS) {
+    bool changed = false;
+    for (unsigned i = 0; i < BITWORDS_PER_ELEMENT; ++i) {
+      BitWord old = changed ? 0 : Bits[i];
 
-       Bits[i] |= RHS.Bits[i];
-       if (!changed && old != Bits[i])
-         changed = true;
-     }
-     return changed;
-   }
+      Bits[i] |= RHS.Bits[i];
+      if (!changed && old != Bits[i])
+        changed = true;
+    }
+    return changed;
+  }
 
-   // Return true if we have any bits in common with RHS
-   bool intersects(const SparseBitVectorElement &RHS) const {
-     for (unsigned i = 0; i < BITWORDS_PER_ELEMENT; ++i) {
-       if (RHS.Bits[i] & Bits[i])
-         return true;
-     }
-     return false;
-   }
+  // Return true if we have any bits in common with RHS
+  bool intersects(const SparseBitVectorElement& RHS) const {
+    for (unsigned i = 0; i < BITWORDS_PER_ELEMENT; ++i) {
+      if (RHS.Bits[i] & Bits[i])
+        return true;
+    }
+    return false;
+  }
 
-   // Intersect this Element with RHS and return true if this one changed.
-   // BecameZero is set to true if this element became all-zero bits.
-   bool intersectWith(const SparseBitVectorElement &RHS,
-                      bool &BecameZero) {
-     bool changed = false;
-     bool allzero = true;
+  // Intersect this Element with RHS and return true if this one changed.
+  // BecameZero is set to true if this element became all-zero bits.
+  bool intersectWith(const SparseBitVectorElement& RHS, bool& BecameZero) {
+    bool changed = false;
+    bool allzero = true;
 
-     BecameZero = false;
-     for (unsigned i = 0; i < BITWORDS_PER_ELEMENT; ++i) {
-       BitWord old = changed ? 0 : Bits[i];
+    BecameZero = false;
+    for (unsigned i = 0; i < BITWORDS_PER_ELEMENT; ++i) {
+      BitWord old = changed ? 0 : Bits[i];
 
-       Bits[i] &= RHS.Bits[i];
-       if (Bits[i] != 0)
-         allzero = false;
+      Bits[i] &= RHS.Bits[i];
+      if (Bits[i] != 0)
+        allzero = false;
 
-       if (!changed && old != Bits[i])
-         changed = true;
-     }
-     BecameZero = allzero;
-     return changed;
-   }
+      if (!changed && old != Bits[i])
+        changed = true;
+    }
+    BecameZero = allzero;
+    return changed;
+  }
 
-   // Intersect this Element with the complement of RHS and return true if this
-   // one changed.  BecameZero is set to true if this element became all-zero
-   // bits.
-   bool intersectWithComplement(const SparseBitVectorElement &RHS,
-                                bool &BecameZero) {
-     bool changed = false;
-     bool allzero = true;
+  // Intersect this Element with the complement of RHS and return true if this
+  // one changed.  BecameZero is set to true if this element became all-zero
+  // bits.
+  bool intersectWithComplement(
+      const SparseBitVectorElement& RHS,
+      bool& BecameZero) {
+    bool changed = false;
+    bool allzero = true;
 
-     BecameZero = false;
-     for (unsigned i = 0; i < BITWORDS_PER_ELEMENT; ++i) {
-       BitWord old = changed ? 0 : Bits[i];
+    BecameZero = false;
+    for (unsigned i = 0; i < BITWORDS_PER_ELEMENT; ++i) {
+      BitWord old = changed ? 0 : Bits[i];
 
-       Bits[i] &= ~RHS.Bits[i];
-       if (Bits[i] != 0)
-         allzero = false;
+      Bits[i] &= ~RHS.Bits[i];
+      if (Bits[i] != 0)
+        allzero = false;
 
-       if (!changed && old != Bits[i])
-         changed = true;
-     }
-     BecameZero = allzero;
-     return changed;
-   }
+      if (!changed && old != Bits[i])
+        changed = true;
+    }
+    BecameZero = allzero;
+    return changed;
+  }
 
-   // Three argument version of intersectWithComplement that intersects
-   // RHS1 & ~RHS2 into this element
-   void intersectWithComplement(const SparseBitVectorElement &RHS1,
-                                const SparseBitVectorElement &RHS2,
-                                bool &BecameZero) {
-     bool allzero = true;
+  // Three argument version of intersectWithComplement that intersects
+  // RHS1 & ~RHS2 into this element
+  void intersectWithComplement(
+      const SparseBitVectorElement& RHS1,
+      const SparseBitVectorElement& RHS2,
+      bool& BecameZero) {
+    bool allzero = true;
 
-     BecameZero = false;
-     for (unsigned i = 0; i < BITWORDS_PER_ELEMENT; ++i) {
-       Bits[i] = RHS1.Bits[i] & ~RHS2.Bits[i];
-       if (Bits[i] != 0)
-         allzero = false;
-     }
-     BecameZero = allzero;
-   }
- };
+    BecameZero = false;
+    for (unsigned i = 0; i < BITWORDS_PER_ELEMENT; ++i) {
+      Bits[i] = RHS1.Bits[i] & ~RHS2.Bits[i];
+      if (Bits[i] != 0)
+        allzero = false;
+    }
+    BecameZero = allzero;
+  }
+};
 
- template <unsigned ElementSize = 128>
- class SparseBitVector {
-   using ElementList = std::list<SparseBitVectorElement<ElementSize>>;
-   using ElementListIter = typename ElementList::iterator;
-   using ElementListConstIter = typename ElementList::const_iterator;
-   enum {
-     BITWORD_SIZE = SparseBitVectorElement<ElementSize>::BITWORD_SIZE
-   };
+template <unsigned ElementSize = 128>
+class SparseBitVector {
+  using ElementList = std::list<SparseBitVectorElement<ElementSize>>;
+  using ElementListIter = typename ElementList::iterator;
+  using ElementListConstIter = typename ElementList::const_iterator;
+  enum { BITWORD_SIZE = SparseBitVectorElement<ElementSize>::BITWORD_SIZE };
 
-   ElementList Elements;
-   // Pointer to our current Element. This has no visible effect on the external
-   // state of a SparseBitVector, it's just used to improve performance in the
-   // common case of testing/modifying bits with similar indices.
-   mutable ElementListIter CurrElementIter;
+  ElementList Elements;
+  // Pointer to our current Element. This has no visible effect on the external
+  // state of a SparseBitVector, it's just used to improve performance in the
+  // common case of testing/modifying bits with similar indices.
+  mutable ElementListIter CurrElementIter;
 
-   // This is like std::lower_bound, except we do linear searching from the
-   // current position.
-   ElementListIter FindLowerBoundImpl(unsigned ElementIndex) const {
+  // This is like std::lower_bound, except we do linear searching from the
+  // current position.
+  ElementListIter FindLowerBoundImpl(unsigned ElementIndex) const {
+    // We cache a non-const iterator so we're forced to resort to const_cast to
+    // get the begin/end in the case where 'this' is const. To avoid duplication
+    // of code with the only difference being whether the const cast is present
+    // 'this' is always const in this particular function and we sort out the
+    // difference in FindLowerBound and FindLowerBoundConst.
+    ElementListIter Begin =
+        const_cast<SparseBitVector<ElementSize>*>(this)->Elements.begin();
+    ElementListIter End =
+        const_cast<SparseBitVector<ElementSize>*>(this)->Elements.end();
 
-     // We cache a non-const iterator so we're forced to resort to const_cast to
-     // get the begin/end in the case where 'this' is const. To avoid duplication
-     // of code with the only difference being whether the const cast is present
-     // 'this' is always const in this particular function and we sort out the
-     // difference in FindLowerBound and FindLowerBoundConst.
-     ElementListIter Begin =
-         const_cast<SparseBitVector<ElementSize> *>(this)->Elements.begin();
-     ElementListIter End =
-         const_cast<SparseBitVector<ElementSize> *>(this)->Elements.end();
+    if (Elements.empty()) {
+      CurrElementIter = Begin;
+      return CurrElementIter;
+    }
 
-     if (Elements.empty()) {
-       CurrElementIter = Begin;
-       return CurrElementIter;
-     }
+    // Make sure our current iterator is valid.
+    if (CurrElementIter == End)
+      --CurrElementIter;
 
-     // Make sure our current iterator is valid.
-     if (CurrElementIter == End)
-       --CurrElementIter;
+    // Search from our current iterator, either backwards or forwards,
+    // depending on what element we are looking for.
+    ElementListIter ElementIter = CurrElementIter;
+    if (CurrElementIter->index() == ElementIndex) {
+      return ElementIter;
+    } else if (CurrElementIter->index() > ElementIndex) {
+      while (ElementIter != Begin && ElementIter->index() > ElementIndex)
+        --ElementIter;
+    } else {
+      while (ElementIter != End && ElementIter->index() < ElementIndex)
+        ++ElementIter;
+    }
+    CurrElementIter = ElementIter;
+    return ElementIter;
+  }
+  ElementListConstIter FindLowerBoundConst(unsigned ElementIndex) const {
+    return FindLowerBoundImpl(ElementIndex);
+  }
+  ElementListIter FindLowerBound(unsigned ElementIndex) {
+    return FindLowerBoundImpl(ElementIndex);
+  }
 
-     // Search from our current iterator, either backwards or forwards,
-     // depending on what element we are looking for.
-     ElementListIter ElementIter = CurrElementIter;
-     if (CurrElementIter->index() == ElementIndex) {
-       return ElementIter;
-     } else if (CurrElementIter->index() > ElementIndex) {
-       while (ElementIter != Begin
-              && ElementIter->index() > ElementIndex)
-         --ElementIter;
-     } else {
-       while (ElementIter != End &&
-              ElementIter->index() < ElementIndex)
-         ++ElementIter;
-     }
-     CurrElementIter = ElementIter;
-     return ElementIter;
-   }
-   ElementListConstIter FindLowerBoundConst(unsigned ElementIndex) const {
-     return FindLowerBoundImpl(ElementIndex);
-   }
-   ElementListIter FindLowerBound(unsigned ElementIndex) {
-     return FindLowerBoundImpl(ElementIndex);
-   }
-
-   // Iterator to walk set bits in the bitmap.  This iterator is a lot uglier
-   // than it would be, in order to be efficient.
-   class SparseBitVectorIterator {
+  // Iterator to walk set bits in the bitmap.  This iterator is a lot uglier
+  // than it would be, in order to be efficient.
+  class SparseBitVectorIterator {
    private:
-     bool AtEnd;
+    bool AtEnd;
 
-     const SparseBitVector<ElementSize> *BitVector = nullptr;
+    const SparseBitVector<ElementSize>* BitVector = nullptr;
 
-     // Current element inside of bitmap.
-     ElementListConstIter Iter;
+    // Current element inside of bitmap.
+    ElementListConstIter Iter;
 
-     // Current bit number inside of our bitmap.
-     unsigned BitNumber;
+    // Current bit number inside of our bitmap.
+    unsigned BitNumber;
 
-     // Current word number inside of our element.
-     unsigned WordNumber;
+    // Current word number inside of our element.
+    unsigned WordNumber;
 
-     // Current bits from the element.
-     typename SparseBitVectorElement<ElementSize>::BitWord Bits;
+    // Current bits from the element.
+    typename SparseBitVectorElement<ElementSize>::BitWord Bits;
 
-     // Move our iterator to the first non-zero bit in the bitmap.
-     void AdvanceToFirstNonZero() {
-       if (AtEnd)
-         return;
-       if (BitVector->Elements.empty()) {
-         AtEnd = true;
-         return;
-       }
-       Iter = BitVector->Elements.begin();
-       BitNumber = Iter->index() * ElementSize;
-       unsigned BitPos = Iter->find_first();
-       BitNumber += BitPos;
-       WordNumber = (BitNumber % ElementSize) / BITWORD_SIZE;
-       Bits = Iter->word(WordNumber);
-       Bits >>= BitPos % BITWORD_SIZE;
-     }
+    // Move our iterator to the first non-zero bit in the bitmap.
+    void AdvanceToFirstNonZero() {
+      if (AtEnd)
+        return;
+      if (BitVector->Elements.empty()) {
+        AtEnd = true;
+        return;
+      }
+      Iter = BitVector->Elements.begin();
+      BitNumber = Iter->index() * ElementSize;
+      unsigned BitPos = Iter->find_first();
+      BitNumber += BitPos;
+      WordNumber = (BitNumber % ElementSize) / BITWORD_SIZE;
+      Bits = Iter->word(WordNumber);
+      Bits >>= BitPos % BITWORD_SIZE;
+    }
 
-     // Move our iterator to the next non-zero bit.
-     void AdvanceToNextNonZero() {
-       if (AtEnd)
-         return;
+    // Move our iterator to the next non-zero bit.
+    void AdvanceToNextNonZero() {
+      if (AtEnd)
+        return;
 
-       while (Bits && !(Bits & 1)) {
-         Bits >>= 1;
-         BitNumber += 1;
-       }
+      while (Bits && !(Bits & 1)) {
+        Bits >>= 1;
+        BitNumber += 1;
+      }
 
-       // See if we ran out of Bits in this word.
-       if (!Bits) {
-         int NextSetBitNumber = Iter->find_next(BitNumber % ElementSize) ;
-         // If we ran out of set bits in this element, move to next element.
-         if (NextSetBitNumber == -1 || (BitNumber % ElementSize == 0)) {
-           ++Iter;
-           WordNumber = 0;
+      // See if we ran out of Bits in this word.
+      if (!Bits) {
+        int NextSetBitNumber = Iter->find_next(BitNumber % ElementSize);
+        // If we ran out of set bits in this element, move to next element.
+        if (NextSetBitNumber == -1 || (BitNumber % ElementSize == 0)) {
+          ++Iter;
+          WordNumber = 0;
 
-           // We may run out of elements in the bitmap.
-           if (Iter == BitVector->Elements.end()) {
-             AtEnd = true;
-             return;
-           }
-           // Set up for next non-zero word in bitmap.
-           BitNumber = Iter->index() * ElementSize;
-           NextSetBitNumber = Iter->find_first();
-           BitNumber += NextSetBitNumber;
-           WordNumber = (BitNumber % ElementSize) / BITWORD_SIZE;
-           Bits = Iter->word(WordNumber);
-           Bits >>= NextSetBitNumber % BITWORD_SIZE;
-         } else {
-           WordNumber = (NextSetBitNumber % ElementSize) / BITWORD_SIZE;
-           Bits = Iter->word(WordNumber);
-           Bits >>= NextSetBitNumber % BITWORD_SIZE;
-           BitNumber = Iter->index() * ElementSize;
-           BitNumber += NextSetBitNumber;
-         }
-       }
-     }
+          // We may run out of elements in the bitmap.
+          if (Iter == BitVector->Elements.end()) {
+            AtEnd = true;
+            return;
+          }
+          // Set up for next non-zero word in bitmap.
+          BitNumber = Iter->index() * ElementSize;
+          NextSetBitNumber = Iter->find_first();
+          BitNumber += NextSetBitNumber;
+          WordNumber = (BitNumber % ElementSize) / BITWORD_SIZE;
+          Bits = Iter->word(WordNumber);
+          Bits >>= NextSetBitNumber % BITWORD_SIZE;
+        } else {
+          WordNumber = (NextSetBitNumber % ElementSize) / BITWORD_SIZE;
+          Bits = Iter->word(WordNumber);
+          Bits >>= NextSetBitNumber % BITWORD_SIZE;
+          BitNumber = Iter->index() * ElementSize;
+          BitNumber += NextSetBitNumber;
+        }
+      }
+    }
 
    public:
-     SparseBitVectorIterator() = default;
+    SparseBitVectorIterator() = default;
 
-     SparseBitVectorIterator(const SparseBitVector<ElementSize> *RHS,
-                             bool end = false):BitVector(RHS) {
-       Iter = BitVector->Elements.begin();
-       BitNumber = 0;
-       Bits = 0;
-       WordNumber = ~0;
-       AtEnd = end;
-       AdvanceToFirstNonZero();
-     }
+    SparseBitVectorIterator(
+        const SparseBitVector<ElementSize>* RHS,
+        bool end = false)
+        : BitVector(RHS) {
+      Iter = BitVector->Elements.begin();
+      BitNumber = 0;
+      Bits = 0;
+      WordNumber = ~0;
+      AtEnd = end;
+      AdvanceToFirstNonZero();
+    }
 
-     // Preincrement.
-     inline SparseBitVectorIterator& operator++() {
-       ++BitNumber;
-       Bits >>= 1;
-       AdvanceToNextNonZero();
-       return *this;
-     }
+    // Preincrement.
+    inline SparseBitVectorIterator& operator++() {
+      ++BitNumber;
+      Bits >>= 1;
+      AdvanceToNextNonZero();
+      return *this;
+    }
 
-     // Postincrement.
-     inline SparseBitVectorIterator operator++(int) {
-       SparseBitVectorIterator tmp = *this;
-       ++*this;
-       return tmp;
-     }
+    // Postincrement.
+    inline SparseBitVectorIterator operator++(int) {
+      SparseBitVectorIterator tmp = *this;
+      ++*this;
+      return tmp;
+    }
 
-     // Return the current set bit number.
-     unsigned operator*() const {
-       return BitNumber;
-     }
+    // Return the current set bit number.
+    unsigned operator*() const {
+      return BitNumber;
+    }
 
-     bool operator==(const SparseBitVectorIterator &RHS) const {
-       // If they are both at the end, ignore the rest of the fields.
-       if (AtEnd && RHS.AtEnd)
-         return true;
-       // Otherwise they are the same if they have the same bit number and
-       // bitmap.
-       return AtEnd == RHS.AtEnd && RHS.BitNumber == BitNumber;
-     }
+    bool operator==(const SparseBitVectorIterator& RHS) const {
+      // If they are both at the end, ignore the rest of the fields.
+      if (AtEnd && RHS.AtEnd)
+        return true;
+      // Otherwise they are the same if they have the same bit number and
+      // bitmap.
+      return AtEnd == RHS.AtEnd && RHS.BitNumber == BitNumber;
+    }
 
-     bool operator!=(const SparseBitVectorIterator &RHS) const {
-       return !(*this == RHS);
-     }
-   };
+    bool operator!=(const SparseBitVectorIterator& RHS) const {
+      return !(*this == RHS);
+    }
+  };
 
  public:
-   using iterator = SparseBitVectorIterator;
-
-   SparseBitVector() : Elements(), CurrElementIter(Elements.begin()) {}
-
-   SparseBitVector(const SparseBitVector &RHS)
-       : Elements(RHS.Elements), CurrElementIter(Elements.begin()) {}
-   SparseBitVector(SparseBitVector &&RHS)
-       : Elements(std::move(RHS.Elements)), CurrElementIter(Elements.begin()) {}
-
-   // Clear.
-   void clear() {
-     Elements.clear();
-   }
-
-   // Assignment
-   SparseBitVector& operator=(const SparseBitVector& RHS) {
-     if (this == &RHS)
-       return *this;
-
-     Elements = RHS.Elements;
-     CurrElementIter = Elements.begin();
-     return *this;
-   }
-   SparseBitVector &operator=(SparseBitVector &&RHS) {
-     Elements = std::move(RHS.Elements);
-     CurrElementIter = Elements.begin();
-     return *this;
-   }
-
-   // Test, Reset, and Set a bit in the bitmap.
-   bool test(unsigned Idx) const {
-     if (Elements.empty())
-       return false;
-
-     unsigned ElementIndex = Idx / ElementSize;
-     ElementListConstIter ElementIter = FindLowerBoundConst(ElementIndex);
-
-     // If we can't find an element that is supposed to contain this bit, there
-     // is nothing more to do.
-     if (ElementIter == Elements.end() ||
-         ElementIter->index() != ElementIndex)
-       return false;
-     return ElementIter->test(Idx % ElementSize);
-   }
-
-   void reset(unsigned Idx) {
-     if (Elements.empty())
-       return;
-
-     unsigned ElementIndex = Idx / ElementSize;
-     ElementListIter ElementIter = FindLowerBound(ElementIndex);
-
-     // If we can't find an element that is supposed to contain this bit, there
-     // is nothing more to do.
-     if (ElementIter == Elements.end() ||
-         ElementIter->index() != ElementIndex)
-       return;
-     ElementIter->reset(Idx % ElementSize);
-
-     // When the element is zeroed out, delete it.
-     if (ElementIter->empty()) {
-       ++CurrElementIter;
-       Elements.erase(ElementIter);
-     }
-   }
-
-   void set(unsigned Idx) {
-     unsigned ElementIndex = Idx / ElementSize;
-     ElementListIter ElementIter;
-     if (Elements.empty()) {
-       ElementIter = Elements.emplace(Elements.end(), ElementIndex);
-     } else {
-       ElementIter = FindLowerBound(ElementIndex);
-
-       if (ElementIter == Elements.end() ||
-           ElementIter->index() != ElementIndex) {
-         // We may have hit the beginning of our SparseBitVector, in which case,
-         // we may need to insert right after this element, which requires moving
-         // the current iterator forward one, because insert does insert before.
-         if (ElementIter != Elements.end() &&
-             ElementIter->index() < ElementIndex)
-           ++ElementIter;
-         ElementIter = Elements.emplace(ElementIter, ElementIndex);
-       }
-     }
-     CurrElementIter = ElementIter;
-
-     ElementIter->set(Idx % ElementSize);
-   }
-
-   bool test_and_set(unsigned Idx) {
-     bool old = test(Idx);
-     if (!old) {
-       set(Idx);
-       return true;
-     }
-     return false;
-   }
-
-   bool operator!=(const SparseBitVector &RHS) const {
-     return !(*this == RHS);
-   }
-
-   bool operator==(const SparseBitVector &RHS) const {
-     ElementListConstIter Iter1 = Elements.begin();
-     ElementListConstIter Iter2 = RHS.Elements.begin();
-
-     for (; Iter1 != Elements.end() && Iter2 != RHS.Elements.end();
-          ++Iter1, ++Iter2) {
-       if (*Iter1 != *Iter2)
-         return false;
-     }
-     return Iter1 == Elements.end() && Iter2 == RHS.Elements.end();
-   }
-
-   // Union our bitmap with the RHS and return true if we changed.
-   bool operator|=(const SparseBitVector &RHS) {
-     if (this == &RHS)
-       return false;
-
-     bool changed = false;
-     ElementListIter Iter1 = Elements.begin();
-     ElementListConstIter Iter2 = RHS.Elements.begin();
-
-     // If RHS is empty, we are done
-     if (RHS.Elements.empty())
-       return false;
-
-     while (Iter2 != RHS.Elements.end()) {
-       if (Iter1 == Elements.end() || Iter1->index() > Iter2->index()) {
-         Elements.insert(Iter1, *Iter2);
-         ++Iter2;
-         changed = true;
-       } else if (Iter1->index() == Iter2->index()) {
-         changed |= Iter1->unionWith(*Iter2);
-         ++Iter1;
-         ++Iter2;
-       } else {
-         ++Iter1;
-       }
-     }
-     CurrElementIter = Elements.begin();
-     return changed;
-   }
-
-   // Intersect our bitmap with the RHS and return true if ours changed.
-   bool operator-=(const SparseBitVector &RHS) {
-     return intersectWithComplement(RHS);
-   }
-
-   // Intersect our bitmap with the RHS and return true if ours changed.
-   bool operator&=(const SparseBitVector &RHS) {
-     if (this == &RHS)
-       return false;
-
-     bool changed = false;
-     ElementListIter Iter1 = Elements.begin();
-     ElementListConstIter Iter2 = RHS.Elements.begin();
-
-     // Check if both bitmaps are empty.
-     if (Elements.empty() && RHS.Elements.empty())
-       return false;
-
-     // Loop through, intersecting as we go, erasing elements when necessary.
-     while (Iter2 != RHS.Elements.end()) {
-       if (Iter1 == Elements.end()) {
-         CurrElementIter = Elements.begin();
-         return changed;
-       }
-
-       if (Iter1->index() > Iter2->index()) {
-         ++Iter2;
-       } else if (Iter1->index() == Iter2->index()) {
-         bool BecameZero;
-         changed |= Iter1->intersectWith(*Iter2, BecameZero);
-         if (BecameZero) {
-           ElementListIter IterTmp = Iter1;
-           ++Iter1;
-           Elements.erase(IterTmp);
-         } else {
-           ++Iter1;
-         }
-         ++Iter2;
-       } else {
-         ElementListIter IterTmp = Iter1;
-         ++Iter1;
-         Elements.erase(IterTmp);
-         changed = true;
-       }
-     }
-     if (Iter1 != Elements.end()) {
-       Elements.erase(Iter1, Elements.end());
-       changed = true;
-     }
-     CurrElementIter = Elements.begin();
-     return changed;
-   }
-
-   // Intersect our bitmap with the complement of the RHS and return true
-   // if ours changed.
-   bool intersectWithComplement(const SparseBitVector &RHS) {
-     if (this == &RHS) {
-       if (!empty()) {
-         clear();
-         return true;
-       }
-       return false;
-     }
-
-     bool changed = false;
-     ElementListIter Iter1 = Elements.begin();
-     ElementListConstIter Iter2 = RHS.Elements.begin();
-
-     // If either our bitmap or RHS is empty, we are done
-     if (Elements.empty() || RHS.Elements.empty())
-       return false;
-
-     // Loop through, intersecting as we go, erasing elements when necessary.
-     while (Iter2 != RHS.Elements.end()) {
-       if (Iter1 == Elements.end()) {
-         CurrElementIter = Elements.begin();
-         return changed;
-       }
-
-       if (Iter1->index() > Iter2->index()) {
-         ++Iter2;
-       } else if (Iter1->index() == Iter2->index()) {
-         bool BecameZero;
-         changed |= Iter1->intersectWithComplement(*Iter2, BecameZero);
-         if (BecameZero) {
-           ElementListIter IterTmp = Iter1;
-           ++Iter1;
-           Elements.erase(IterTmp);
-         } else {
-           ++Iter1;
-         }
-         ++Iter2;
-       } else {
-         ++Iter1;
-       }
-     }
-     CurrElementIter = Elements.begin();
-     return changed;
-   }
-
-   bool intersectWithComplement(const SparseBitVector<ElementSize> *RHS) const {
-     return intersectWithComplement(*RHS);
-   }
-
-   //  Three argument version of intersectWithComplement.
-   //  Result of RHS1 & ~RHS2 is stored into this bitmap.
-   void intersectWithComplement(const SparseBitVector<ElementSize> &RHS1,
-                                const SparseBitVector<ElementSize> &RHS2)
-   {
-     if (this == &RHS1) {
-       intersectWithComplement(RHS2);
-       return;
-     } else if (this == &RHS2) {
-       SparseBitVector RHS2Copy(RHS2);
-       intersectWithComplement(RHS1, RHS2Copy);
-       return;
-     }
-
-     Elements.clear();
-     CurrElementIter = Elements.begin();
-     ElementListConstIter Iter1 = RHS1.Elements.begin();
-     ElementListConstIter Iter2 = RHS2.Elements.begin();
-
-     // If RHS1 is empty, we are done
-     // If RHS2 is empty, we still have to copy RHS1
-     if (RHS1.Elements.empty())
-       return;
-
-     // Loop through, intersecting as we go, erasing elements when necessary.
-     while (Iter2 != RHS2.Elements.end()) {
-       if (Iter1 == RHS1.Elements.end())
-         return;
-
-       if (Iter1->index() > Iter2->index()) {
-         ++Iter2;
-       } else if (Iter1->index() == Iter2->index()) {
-         bool BecameZero = false;
-         Elements.emplace_back(Iter1->index());
-         Elements.back().intersectWithComplement(*Iter1, *Iter2, BecameZero);
-         if (BecameZero)
-           Elements.pop_back();
-         ++Iter1;
-         ++Iter2;
-       } else {
-         Elements.push_back(*Iter1++);
-       }
-     }
-
-     // copy the remaining elements
-     std::copy(Iter1, RHS1.Elements.end(), std::back_inserter(Elements));
-   }
-
-   void intersectWithComplement(const SparseBitVector<ElementSize> *RHS1,
-                                const SparseBitVector<ElementSize> *RHS2) {
-     intersectWithComplement(*RHS1, *RHS2);
-   }
-
-   bool intersects(const SparseBitVector<ElementSize> *RHS) const {
-     return intersects(*RHS);
-   }
-
-   // Return true if we share any bits in common with RHS
-   bool intersects(const SparseBitVector<ElementSize> &RHS) const {
-     ElementListConstIter Iter1 = Elements.begin();
-     ElementListConstIter Iter2 = RHS.Elements.begin();
-
-     // Check if both bitmaps are empty.
-     if (Elements.empty() && RHS.Elements.empty())
-       return false;
-
-     // Loop through, intersecting stopping when we hit bits in common.
-     while (Iter2 != RHS.Elements.end()) {
-       if (Iter1 == Elements.end())
-         return false;
-
-       if (Iter1->index() > Iter2->index()) {
-         ++Iter2;
-       } else if (Iter1->index() == Iter2->index()) {
-         if (Iter1->intersects(*Iter2))
-           return true;
-         ++Iter1;
-         ++Iter2;
-       } else {
-         ++Iter1;
-       }
-     }
-     return false;
-   }
-
-   // Return true iff all bits set in this SparseBitVector are
-   // also set in RHS.
-   bool contains(const SparseBitVector<ElementSize> &RHS) const {
-     SparseBitVector<ElementSize> Result(*this);
-     Result &= RHS;
-     return (Result == RHS);
-   }
-
-   // Return the first set bit in the bitmap.  Return -1 if no bits are set.
-   int find_first() const {
-     if (Elements.empty())
-       return -1;
-     const SparseBitVectorElement<ElementSize> &First = *(Elements.begin());
-     return (First.index() * ElementSize) + First.find_first();
-   }
-
-   // Return the last set bit in the bitmap.  Return -1 if no bits are set.
-   int find_last() const {
-     if (Elements.empty())
-       return -1;
-     const SparseBitVectorElement<ElementSize> &Last = *(Elements.rbegin());
-     return (Last.index() * ElementSize) + Last.find_last();
-   }
-
-   // Return true if the SparseBitVector is empty
-   bool empty() const {
-     return Elements.empty();
-   }
-
-   unsigned count() const {
-     unsigned BitCount = 0;
-     for (ElementListConstIter Iter = Elements.begin();
-          Iter != Elements.end();
-          ++Iter)
-       BitCount += Iter->count();
-
-     return BitCount;
-   }
-
-   iterator begin() const {
-     return iterator(this);
-   }
-
-   iterator end() const {
-     return iterator(this, true);
-   }
- };
-
- // Convenience functions to allow Or and And without dereferencing in the user
- // code.
-
- template <unsigned ElementSize>
- inline bool operator |=(SparseBitVector<ElementSize> &LHS,
-                         const SparseBitVector<ElementSize> *RHS) {
-   return LHS |= *RHS;
- }
-
- template <unsigned ElementSize>
- inline bool operator |=(SparseBitVector<ElementSize> *LHS,
-                         const SparseBitVector<ElementSize> &RHS) {
-   return LHS->operator|=(RHS);
- }
-
- template <unsigned ElementSize>
- inline bool operator &=(SparseBitVector<ElementSize> *LHS,
-                         const SparseBitVector<ElementSize> &RHS) {
-   return LHS->operator&=(RHS);
- }
-
- template <unsigned ElementSize>
- inline bool operator &=(SparseBitVector<ElementSize> &LHS,
-                         const SparseBitVector<ElementSize> *RHS) {
-   return LHS &= *RHS;
- }
-
- // Convenience functions for infix union, intersection, difference operators.
-
- template <unsigned ElementSize>
- inline SparseBitVector<ElementSize>
- operator|(const SparseBitVector<ElementSize> &LHS,
-           const SparseBitVector<ElementSize> &RHS) {
-   SparseBitVector<ElementSize> Result(LHS);
-   Result |= RHS;
-   return Result;
- }
-
- template <unsigned ElementSize>
- inline SparseBitVector<ElementSize>
- operator&(const SparseBitVector<ElementSize> &LHS,
-           const SparseBitVector<ElementSize> &RHS) {
-   SparseBitVector<ElementSize> Result(LHS);
-   Result &= RHS;
-   return Result;
- }
-
- template <unsigned ElementSize>
- inline SparseBitVector<ElementSize>
- operator-(const SparseBitVector<ElementSize> &LHS,
-           const SparseBitVector<ElementSize> &RHS) {
-   SparseBitVector<ElementSize> Result;
-   Result.intersectWithComplement(LHS, RHS);
-   return Result;
- }
-
- template <unsigned ElementSize>
- std::ostream& operator<<(std::ostream& stream, const SparseBitVector<ElementSize>& vec) {
-
-   bool first = true;
-   stream << "{";
-   for (auto el : vec)
-   {
-     if (first)
-     {
-       first = false;
-     }
-     else
-     {
-       stream << ", ";
-     }
-     stream << el;
-   }
-   stream << "}";
-   return stream;
- }
-
+  using iterator = SparseBitVectorIterator;
+
+  SparseBitVector() : Elements(), CurrElementIter(Elements.begin()) {}
+
+  SparseBitVector(const SparseBitVector& RHS)
+      : Elements(RHS.Elements), CurrElementIter(Elements.begin()) {}
+  SparseBitVector(SparseBitVector&& RHS)
+      : Elements(std::move(RHS.Elements)), CurrElementIter(Elements.begin()) {}
+
+  // Clear.
+  void clear() {
+    Elements.clear();
+  }
+
+  // Assignment
+  SparseBitVector& operator=(const SparseBitVector& RHS) {
+    if (this == &RHS)
+      return *this;
+
+    Elements = RHS.Elements;
+    CurrElementIter = Elements.begin();
+    return *this;
+  }
+  SparseBitVector& operator=(SparseBitVector&& RHS) {
+    Elements = std::move(RHS.Elements);
+    CurrElementIter = Elements.begin();
+    return *this;
+  }
+
+  // Test, Reset, and Set a bit in the bitmap.
+  bool test(unsigned Idx) const {
+    if (Elements.empty())
+      return false;
+
+    unsigned ElementIndex = Idx / ElementSize;
+    ElementListConstIter ElementIter = FindLowerBoundConst(ElementIndex);
+
+    // If we can't find an element that is supposed to contain this bit, there
+    // is nothing more to do.
+    if (ElementIter == Elements.end() || ElementIter->index() != ElementIndex)
+      return false;
+    return ElementIter->test(Idx % ElementSize);
+  }
+
+  void reset(unsigned Idx) {
+    if (Elements.empty())
+      return;
+
+    unsigned ElementIndex = Idx / ElementSize;
+    ElementListIter ElementIter = FindLowerBound(ElementIndex);
+
+    // If we can't find an element that is supposed to contain this bit, there
+    // is nothing more to do.
+    if (ElementIter == Elements.end() || ElementIter->index() != ElementIndex)
+      return;
+    ElementIter->reset(Idx % ElementSize);
+
+    // When the element is zeroed out, delete it.
+    if (ElementIter->empty()) {
+      ++CurrElementIter;
+      Elements.erase(ElementIter);
+    }
+  }
+
+  void set(unsigned Idx) {
+    unsigned ElementIndex = Idx / ElementSize;
+    ElementListIter ElementIter;
+    if (Elements.empty()) {
+      ElementIter = Elements.emplace(Elements.end(), ElementIndex);
+    } else {
+      ElementIter = FindLowerBound(ElementIndex);
+
+      if (ElementIter == Elements.end() ||
+          ElementIter->index() != ElementIndex) {
+        // We may have hit the beginning of our SparseBitVector, in which case,
+        // we may need to insert right after this element, which requires moving
+        // the current iterator forward one, because insert does insert before.
+        if (ElementIter != Elements.end() &&
+            ElementIter->index() < ElementIndex)
+          ++ElementIter;
+        ElementIter = Elements.emplace(ElementIter, ElementIndex);
+      }
+    }
+    CurrElementIter = ElementIter;
+
+    ElementIter->set(Idx % ElementSize);
+  }
+
+  bool test_and_set(unsigned Idx) {
+    bool old = test(Idx);
+    if (!old) {
+      set(Idx);
+      return true;
+    }
+    return false;
+  }
+
+  bool operator!=(const SparseBitVector& RHS) const {
+    return !(*this == RHS);
+  }
+
+  bool operator==(const SparseBitVector& RHS) const {
+    ElementListConstIter Iter1 = Elements.begin();
+    ElementListConstIter Iter2 = RHS.Elements.begin();
+
+    for (; Iter1 != Elements.end() && Iter2 != RHS.Elements.end();
+         ++Iter1, ++Iter2) {
+      if (*Iter1 != *Iter2)
+        return false;
+    }
+    return Iter1 == Elements.end() && Iter2 == RHS.Elements.end();
+  }
+
+  // Union our bitmap with the RHS and return true if we changed.
+  bool operator|=(const SparseBitVector& RHS) {
+    if (this == &RHS)
+      return false;
+
+    bool changed = false;
+    ElementListIter Iter1 = Elements.begin();
+    ElementListConstIter Iter2 = RHS.Elements.begin();
+
+    // If RHS is empty, we are done
+    if (RHS.Elements.empty())
+      return false;
+
+    while (Iter2 != RHS.Elements.end()) {
+      if (Iter1 == Elements.end() || Iter1->index() > Iter2->index()) {
+        Elements.insert(Iter1, *Iter2);
+        ++Iter2;
+        changed = true;
+      } else if (Iter1->index() == Iter2->index()) {
+        changed |= Iter1->unionWith(*Iter2);
+        ++Iter1;
+        ++Iter2;
+      } else {
+        ++Iter1;
+      }
+    }
+    CurrElementIter = Elements.begin();
+    return changed;
+  }
+
+  // Intersect our bitmap with the RHS and return true if ours changed.
+  bool operator-=(const SparseBitVector& RHS) {
+    return intersectWithComplement(RHS);
+  }
+
+  // Intersect our bitmap with the RHS and return true if ours changed.
+  bool operator&=(const SparseBitVector& RHS) {
+    if (this == &RHS)
+      return false;
+
+    bool changed = false;
+    ElementListIter Iter1 = Elements.begin();
+    ElementListConstIter Iter2 = RHS.Elements.begin();
+
+    // Check if both bitmaps are empty.
+    if (Elements.empty() && RHS.Elements.empty())
+      return false;
+
+    // Loop through, intersecting as we go, erasing elements when necessary.
+    while (Iter2 != RHS.Elements.end()) {
+      if (Iter1 == Elements.end()) {
+        CurrElementIter = Elements.begin();
+        return changed;
+      }
+
+      if (Iter1->index() > Iter2->index()) {
+        ++Iter2;
+      } else if (Iter1->index() == Iter2->index()) {
+        bool BecameZero;
+        changed |= Iter1->intersectWith(*Iter2, BecameZero);
+        if (BecameZero) {
+          ElementListIter IterTmp = Iter1;
+          ++Iter1;
+          Elements.erase(IterTmp);
+        } else {
+          ++Iter1;
+        }
+        ++Iter2;
+      } else {
+        ElementListIter IterTmp = Iter1;
+        ++Iter1;
+        Elements.erase(IterTmp);
+        changed = true;
+      }
+    }
+    if (Iter1 != Elements.end()) {
+      Elements.erase(Iter1, Elements.end());
+      changed = true;
+    }
+    CurrElementIter = Elements.begin();
+    return changed;
+  }
+
+  // Intersect our bitmap with the complement of the RHS and return true
+  // if ours changed.
+  bool intersectWithComplement(const SparseBitVector& RHS) {
+    if (this == &RHS) {
+      if (!empty()) {
+        clear();
+        return true;
+      }
+      return false;
+    }
+
+    bool changed = false;
+    ElementListIter Iter1 = Elements.begin();
+    ElementListConstIter Iter2 = RHS.Elements.begin();
+
+    // If either our bitmap or RHS is empty, we are done
+    if (Elements.empty() || RHS.Elements.empty())
+      return false;
+
+    // Loop through, intersecting as we go, erasing elements when necessary.
+    while (Iter2 != RHS.Elements.end()) {
+      if (Iter1 == Elements.end()) {
+        CurrElementIter = Elements.begin();
+        return changed;
+      }
+
+      if (Iter1->index() > Iter2->index()) {
+        ++Iter2;
+      } else if (Iter1->index() == Iter2->index()) {
+        bool BecameZero;
+        changed |= Iter1->intersectWithComplement(*Iter2, BecameZero);
+        if (BecameZero) {
+          ElementListIter IterTmp = Iter1;
+          ++Iter1;
+          Elements.erase(IterTmp);
+        } else {
+          ++Iter1;
+        }
+        ++Iter2;
+      } else {
+        ++Iter1;
+      }
+    }
+    CurrElementIter = Elements.begin();
+    return changed;
+  }
+
+  bool intersectWithComplement(const SparseBitVector<ElementSize>* RHS) const {
+    return intersectWithComplement(*RHS);
+  }
+
+  //  Three argument version of intersectWithComplement.
+  //  Result of RHS1 & ~RHS2 is stored into this bitmap.
+  void intersectWithComplement(
+      const SparseBitVector<ElementSize>& RHS1,
+      const SparseBitVector<ElementSize>& RHS2) {
+    if (this == &RHS1) {
+      intersectWithComplement(RHS2);
+      return;
+    } else if (this == &RHS2) {
+      SparseBitVector RHS2Copy(RHS2);
+      intersectWithComplement(RHS1, RHS2Copy);
+      return;
+    }
+
+    Elements.clear();
+    CurrElementIter = Elements.begin();
+    ElementListConstIter Iter1 = RHS1.Elements.begin();
+    ElementListConstIter Iter2 = RHS2.Elements.begin();
+
+    // If RHS1 is empty, we are done
+    // If RHS2 is empty, we still have to copy RHS1
+    if (RHS1.Elements.empty())
+      return;
+
+    // Loop through, intersecting as we go, erasing elements when necessary.
+    while (Iter2 != RHS2.Elements.end()) {
+      if (Iter1 == RHS1.Elements.end())
+        return;
+
+      if (Iter1->index() > Iter2->index()) {
+        ++Iter2;
+      } else if (Iter1->index() == Iter2->index()) {
+        bool BecameZero = false;
+        Elements.emplace_back(Iter1->index());
+        Elements.back().intersectWithComplement(*Iter1, *Iter2, BecameZero);
+        if (BecameZero)
+          Elements.pop_back();
+        ++Iter1;
+        ++Iter2;
+      } else {
+        Elements.push_back(*Iter1++);
+      }
+    }
+
+    // copy the remaining elements
+    std::copy(Iter1, RHS1.Elements.end(), std::back_inserter(Elements));
+  }
+
+  void intersectWithComplement(
+      const SparseBitVector<ElementSize>* RHS1,
+      const SparseBitVector<ElementSize>* RHS2) {
+    intersectWithComplement(*RHS1, *RHS2);
+  }
+
+  bool intersects(const SparseBitVector<ElementSize>* RHS) const {
+    return intersects(*RHS);
+  }
+
+  // Return true if we share any bits in common with RHS
+  bool intersects(const SparseBitVector<ElementSize>& RHS) const {
+    ElementListConstIter Iter1 = Elements.begin();
+    ElementListConstIter Iter2 = RHS.Elements.begin();
+
+    // Check if both bitmaps are empty.
+    if (Elements.empty() && RHS.Elements.empty())
+      return false;
+
+    // Loop through, intersecting stopping when we hit bits in common.
+    while (Iter2 != RHS.Elements.end()) {
+      if (Iter1 == Elements.end())
+        return false;
+
+      if (Iter1->index() > Iter2->index()) {
+        ++Iter2;
+      } else if (Iter1->index() == Iter2->index()) {
+        if (Iter1->intersects(*Iter2))
+          return true;
+        ++Iter1;
+        ++Iter2;
+      } else {
+        ++Iter1;
+      }
+    }
+    return false;
+  }
+
+  // Return true iff all bits set in this SparseBitVector are
+  // also set in RHS.
+  bool contains(const SparseBitVector<ElementSize>& RHS) const {
+    SparseBitVector<ElementSize> Result(*this);
+    Result &= RHS;
+    return (Result == RHS);
+  }
+
+  // Return the first set bit in the bitmap.  Return -1 if no bits are set.
+  int find_first() const {
+    if (Elements.empty())
+      return -1;
+    const SparseBitVectorElement<ElementSize>& First = *(Elements.begin());
+    return (First.index() * ElementSize) + First.find_first();
+  }
+
+  // Return the last set bit in the bitmap.  Return -1 if no bits are set.
+  int find_last() const {
+    if (Elements.empty())
+      return -1;
+    const SparseBitVectorElement<ElementSize>& Last = *(Elements.rbegin());
+    return (Last.index() * ElementSize) + Last.find_last();
+  }
+
+  // Return true if the SparseBitVector is empty
+  bool empty() const {
+    return Elements.empty();
+  }
+
+  unsigned count() const {
+    unsigned BitCount = 0;
+    for (ElementListConstIter Iter = Elements.begin(); Iter != Elements.end();
+         ++Iter)
+      BitCount += Iter->count();
+
+    return BitCount;
+  }
+
+  iterator begin() const {
+    return iterator(this);
+  }
+
+  iterator end() const {
+    return iterator(this, true);
+  }
+};
+
+// Convenience functions to allow Or and And without dereferencing in the user
+// code.
+
+template <unsigned ElementSize>
+inline bool operator|=(
+    SparseBitVector<ElementSize>& LHS,
+    const SparseBitVector<ElementSize>* RHS) {
+  return LHS |= *RHS;
+}
+
+template <unsigned ElementSize>
+inline bool operator|=(
+    SparseBitVector<ElementSize>* LHS,
+    const SparseBitVector<ElementSize>& RHS) {
+  return LHS->operator|=(RHS);
+}
+
+template <unsigned ElementSize>
+inline bool operator&=(
+    SparseBitVector<ElementSize>* LHS,
+    const SparseBitVector<ElementSize>& RHS) {
+  return LHS->operator&=(RHS);
+}
+
+template <unsigned ElementSize>
+inline bool operator&=(
+    SparseBitVector<ElementSize>& LHS,
+    const SparseBitVector<ElementSize>* RHS) {
+  return LHS &= *RHS;
+}
+
+// Convenience functions for infix union, intersection, difference operators.
+
+template <unsigned ElementSize>
+inline SparseBitVector<ElementSize> operator|(
+    const SparseBitVector<ElementSize>& LHS,
+    const SparseBitVector<ElementSize>& RHS) {
+  SparseBitVector<ElementSize> Result(LHS);
+  Result |= RHS;
+  return Result;
+}
+
+template <unsigned ElementSize>
+inline SparseBitVector<ElementSize> operator&(
+    const SparseBitVector<ElementSize>& LHS,
+    const SparseBitVector<ElementSize>& RHS) {
+  SparseBitVector<ElementSize> Result(LHS);
+  Result &= RHS;
+  return Result;
+}
+
+template <unsigned ElementSize>
+inline SparseBitVector<ElementSize> operator-(
+    const SparseBitVector<ElementSize>& LHS,
+    const SparseBitVector<ElementSize>& RHS) {
+  SparseBitVector<ElementSize> Result;
+  Result.intersectWithComplement(LHS, RHS);
+  return Result;
+}
+
+template <unsigned ElementSize>
+std::ostream& operator<<(
+    std::ostream& stream,
+    const SparseBitVector<ElementSize>& vec) {
+  bool first = true;
+  stream << "{";
+  for (auto el : vec) {
+    if (first) {
+      first = false;
+    } else {
+      stream << ", ";
+    }
+    stream << el;
+  }
+  stream << "}";
+  return stream;
+}
 
 } // end namespace c10

--- a/c10/util/string_utils.h
+++ b/c10/util/string_utils.h
@@ -67,8 +67,8 @@ inline long long stoll(const std::string& str) {
 #define CAFFE2_TESTONLY_WE_ARE_USING_CUSTOM_STRING_FUNCTIONS 0
 using std::stod;
 using std::stoi;
-using std::stoull;
 using std::stoll;
+using std::stoull;
 using std::to_string;
 #endif // defined(__ANDROID__) || defined(CAFFE2_FORCE_STD_STRING_FALLBACK_TEST)
 

--- a/c10/util/typeid.cpp
+++ b/c10/util/typeid.cpp
@@ -1,5 +1,5 @@
-#include <c10/util/typeid.h>
 #include <c10/util/Exception.h>
+#include <c10/util/typeid.h>
 
 #include <atomic>
 

--- a/c10/util/typeid.h
+++ b/c10/util/typeid.h
@@ -18,6 +18,7 @@
 #include <exception>
 
 #include <c10/macros/Macros.h>
+#include <c10/util/BFloat16.h>
 #include <c10/util/Backtrace.h>
 #include <c10/util/C++17.h>
 #include <c10/util/Exception.h>
@@ -27,7 +28,6 @@
 #include <c10/util/qint32.h>
 #include <c10/util/qint8.h>
 #include <c10/util/quint8.h>
-#include <c10/util/BFloat16.h>
 
 /*
  * TypeIdentifier is a small type containing an id.

--- a/c10/util/variant.h
+++ b/c10/util/variant.h
@@ -3,7 +3,8 @@
 // Copyright Michael Park, 2015-2017
 //
 // Distributed under the Boost Software License, Version 1.0.
-// (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+// (See accompanying file LICENSE.md or copy at
+// http://boost.org/LICENSE_1_0.txt)
 //
 // From https://github.com/mpark/variant
 //
@@ -216,7 +217,8 @@ namespace std {
 // Copyright Michael Park, 2015-2017
 //
 // Distributed under the Boost Software License, Version 1.0.
-// (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+// (See accompanying file LICENSE.md or copy at
+// http://boost.org/LICENSE_1_0.txt)
 
 #ifndef MPARK_CONFIG_HPP
 #define MPARK_CONFIG_HPP
@@ -301,958 +303,990 @@ namespace std {
 #define MPARK_VARIABLE_TEMPLATES
 #endif
 
-#if !defined(__GLIBCXX__) || __has_include(<codecvt>)  // >= libstdc++-5
+#if !defined(__GLIBCXX__) || __has_include(<codecvt>) // >= libstdc++-5
 #define MPARK_TRIVIALITY_TYPE_TRAITS
 #define MPARK_INCOMPLETE_TYPE_TRAITS
 #endif
 
-#endif  // MPARK_CONFIG_HPP
+#endif // MPARK_CONFIG_HPP
 
 // MPark.Variant
 //
 // Copyright Michael Park, 2015-2017
 //
 // Distributed under the Boost Software License, Version 1.0.
-// (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+// (See accompanying file LICENSE.md or copy at
+// http://boost.org/LICENSE_1_0.txt)
 
 #ifndef MPARK_IN_PLACE_HPP
 #define MPARK_IN_PLACE_HPP
 
 #include <cstddef>
 
-
 namespace c10 {
 
-  struct variant_in_place_t { explicit variant_in_place_t() = default; };
+struct variant_in_place_t {
+  explicit variant_in_place_t() = default;
+};
 
-  template <std::size_t I>
-  struct in_place_index_t { explicit in_place_index_t() = default; };
+template <std::size_t I>
+struct in_place_index_t {
+  explicit in_place_index_t() = default;
+};
 
-  template <typename T>
-  struct in_place_type_t { explicit in_place_type_t() = default; };
+template <typename T>
+struct in_place_type_t {
+  explicit in_place_type_t() = default;
+};
 
 #ifdef MPARK_VARIABLE_TEMPLATES
-  constexpr variant_in_place_t in_place{};
+constexpr variant_in_place_t in_place{};
 
-  template <std::size_t I> constexpr in_place_index_t<I> in_place_index{};
+template <std::size_t I>
+constexpr in_place_index_t<I> in_place_index{};
 
-  template <typename T> constexpr in_place_type_t<T> in_place_type{};
+template <typename T>
+constexpr in_place_type_t<T> in_place_type{};
 #endif
 
-}  // namespace c10
+} // namespace c10
 
-#endif  // MPARK_IN_PLACE_HPP
+#endif // MPARK_IN_PLACE_HPP
 
 // MPark.Variant
 //
 // Copyright Michael Park, 2015-2017
 //
 // Distributed under the Boost Software License, Version 1.0.
-// (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+// (See accompanying file LICENSE.md or copy at
+// http://boost.org/LICENSE_1_0.txt)
 
 #ifndef MPARK_LIB_HPP
 #define MPARK_LIB_HPP
 
-#include <memory>
 #include <functional>
+#include <memory>
 #include <type_traits>
 #include <utility>
 
-
-#define MPARK_RETURN(...) \
-  noexcept(noexcept(__VA_ARGS__)) -> decltype(__VA_ARGS__) { return __VA_ARGS__; }
+#define MPARK_RETURN(...)                                  \
+  noexcept(noexcept(__VA_ARGS__))->decltype(__VA_ARGS__) { \
+    return __VA_ARGS__;                                    \
+  }
 
 namespace c10 {
-  namespace lib {
-    template <typename T>
-    struct identity { using type = T; };
+namespace lib {
+template <typename T>
+struct identity {
+  using type = T;
+};
 
-    inline namespace cpp14 {
-      template <typename T, std::size_t N>
-      struct array {
-        constexpr const T &operator[](std::size_t index) const {
-          return data[index];
-        }
+inline namespace cpp14 {
+template <typename T, std::size_t N>
+struct array {
+  constexpr const T& operator[](std::size_t index) const {
+    return data[index];
+  }
 
-        T data[N == 0 ? 1 : N];
-      };
+  T data[N == 0 ? 1 : N];
+};
 
-      template <typename T>
-      using add_pointer_t = typename std::add_pointer<T>::type;
+template <typename T>
+using add_pointer_t = typename std::add_pointer<T>::type;
 
-      template <typename... Ts>
-      using common_type_t = typename std::common_type<Ts...>::type;
+template <typename... Ts>
+using common_type_t = typename std::common_type<Ts...>::type;
 
-      template <typename T>
-      using decay_t = typename std::decay<T>::type;
+template <typename T>
+using decay_t = typename std::decay<T>::type;
 
-      template <bool B, typename T = void>
-      using enable_if_t = typename std::enable_if<B, T>::type;
+template <bool B, typename T = void>
+using enable_if_t = typename std::enable_if<B, T>::type;
 
-      template <typename T>
-      using remove_const_t = typename std::remove_const<T>::type;
+template <typename T>
+using remove_const_t = typename std::remove_const<T>::type;
 
-      template <typename T>
-      using remove_reference_t = typename std::remove_reference<T>::type;
+template <typename T>
+using remove_reference_t = typename std::remove_reference<T>::type;
 
-      template <typename T>
-      inline constexpr T &&forward(remove_reference_t<T> &t) noexcept {
-        return static_cast<T &&>(t);
-      }
+template <typename T>
+inline constexpr T&& forward(remove_reference_t<T>& t) noexcept {
+  return static_cast<T&&>(t);
+}
 
-      template <typename T>
-      inline constexpr T &&forward(remove_reference_t<T> &&t) noexcept {
-        static_assert(!std::is_lvalue_reference<T>::value,
-                      "can not forward an rvalue as an lvalue");
-        return static_cast<T &&>(t);
-      }
+template <typename T>
+inline constexpr T&& forward(remove_reference_t<T>&& t) noexcept {
+  static_assert(
+      !std::is_lvalue_reference<T>::value,
+      "can not forward an rvalue as an lvalue");
+  return static_cast<T&&>(t);
+}
 
-      template <typename T>
-      inline constexpr remove_reference_t<T> &&move(T &&t) noexcept {
-        return static_cast<remove_reference_t<T> &&>(t);
-      }
+template <typename T>
+inline constexpr remove_reference_t<T>&& move(T&& t) noexcept {
+  return static_cast<remove_reference_t<T>&&>(t);
+}
 
 #ifdef MPARK_INTEGER_SEQUENCE
-      using std::integer_sequence;
-      using std::index_sequence;
-      using std::make_index_sequence;
-      using std::index_sequence_for;
+using std::index_sequence;
+using std::index_sequence_for;
+using std::integer_sequence;
+using std::make_index_sequence;
 #else
-      template <typename T, T... Is>
-      struct integer_sequence {
-        using value_type = T;
-        static constexpr std::size_t size() noexcept { return sizeof...(Is); }
-      };
+template <typename T, T... Is>
+struct integer_sequence {
+  using value_type = T;
+  static constexpr std::size_t size() noexcept {
+    return sizeof...(Is);
+  }
+};
 
-      template <std::size_t... Is>
-      using index_sequence = integer_sequence<std::size_t, Is...>;
+template <std::size_t... Is>
+using index_sequence = integer_sequence<std::size_t, Is...>;
 
-      template <typename Lhs, typename Rhs>
-      struct make_index_sequence_concat;
+template <typename Lhs, typename Rhs>
+struct make_index_sequence_concat;
 
-      template <std::size_t... Lhs, std::size_t... Rhs>
-      struct make_index_sequence_concat<index_sequence<Lhs...>,
-                                        index_sequence<Rhs...>>
-          : identity<index_sequence<Lhs..., (sizeof...(Lhs) + Rhs)...>> {};
+template <std::size_t... Lhs, std::size_t... Rhs>
+struct make_index_sequence_concat<
+    index_sequence<Lhs...>,
+    index_sequence<Rhs...>>
+    : identity<index_sequence<Lhs..., (sizeof...(Lhs) + Rhs)...>> {};
 
-      template <std::size_t N>
-      struct make_index_sequence_impl;
+template <std::size_t N>
+struct make_index_sequence_impl;
 
-      template <std::size_t N>
-      using make_index_sequence = typename make_index_sequence_impl<N>::type;
+template <std::size_t N>
+using make_index_sequence = typename make_index_sequence_impl<N>::type;
 
-      template <std::size_t N>
-      struct make_index_sequence_impl
-          : make_index_sequence_concat<make_index_sequence<N / 2>,
-                                       make_index_sequence<N - (N / 2)>> {};
+template <std::size_t N>
+struct make_index_sequence_impl : make_index_sequence_concat<
+                                      make_index_sequence<N / 2>,
+                                      make_index_sequence<N - (N / 2)>> {};
 
-      template <>
-      struct make_index_sequence_impl<0> : identity<index_sequence<>> {};
+template <>
+struct make_index_sequence_impl<0> : identity<index_sequence<>> {};
 
-      template <>
-      struct make_index_sequence_impl<1> : identity<index_sequence<0>> {};
+template <>
+struct make_index_sequence_impl<1> : identity<index_sequence<0>> {};
 
-      template <typename... Ts>
-      using index_sequence_for = make_index_sequence<sizeof...(Ts)>;
+template <typename... Ts>
+using index_sequence_for = make_index_sequence<sizeof...(Ts)>;
 #endif
 
-      // <functional>
+// <functional>
 #ifdef MPARK_TRANSPARENT_OPERATORS
-      using equal_to = std::equal_to<>;
+using equal_to = std::equal_to<>;
 #else
-      struct equal_to {
-        template <typename Lhs, typename Rhs>
-        inline constexpr auto operator()(Lhs &&lhs, Rhs &&rhs) const
-          MPARK_RETURN(lib::forward<Lhs>(lhs) == lib::forward<Rhs>(rhs))
-      };
-#endif
-
-#ifdef MPARK_TRANSPARENT_OPERATORS
-      using not_equal_to = std::not_equal_to<>;
-#else
-      struct not_equal_to {
-        template <typename Lhs, typename Rhs>
-        inline constexpr auto operator()(Lhs &&lhs, Rhs &&rhs) const
-          MPARK_RETURN(lib::forward<Lhs>(lhs) != lib::forward<Rhs>(rhs))
-      };
+struct equal_to {
+  template <typename Lhs, typename Rhs>
+  inline constexpr auto operator()(Lhs&& lhs, Rhs&& rhs) const
+      MPARK_RETURN(lib::forward<Lhs>(lhs) == lib::forward<Rhs>(rhs))
+};
 #endif
 
 #ifdef MPARK_TRANSPARENT_OPERATORS
-      using less = std::less<>;
+using not_equal_to = std::not_equal_to<>;
 #else
-      struct less {
-        template <typename Lhs, typename Rhs>
-        inline constexpr auto operator()(Lhs &&lhs, Rhs &&rhs) const
-          MPARK_RETURN(lib::forward<Lhs>(lhs) < lib::forward<Rhs>(rhs))
-      };
+struct not_equal_to {
+  template <typename Lhs, typename Rhs>
+  inline constexpr auto operator()(Lhs&& lhs, Rhs&& rhs) const
+      MPARK_RETURN(lib::forward<Lhs>(lhs) != lib::forward<Rhs>(rhs))
+};
 #endif
 
 #ifdef MPARK_TRANSPARENT_OPERATORS
-      using greater = std::greater<>;
+using less = std::less<>;
 #else
-      struct greater {
-        template <typename Lhs, typename Rhs>
-        inline constexpr auto operator()(Lhs &&lhs, Rhs &&rhs) const
-          MPARK_RETURN(lib::forward<Lhs>(lhs) > lib::forward<Rhs>(rhs))
-      };
+struct less {
+  template <typename Lhs, typename Rhs>
+  inline constexpr auto operator()(Lhs&& lhs, Rhs&& rhs) const
+      MPARK_RETURN(lib::forward<Lhs>(lhs) < lib::forward<Rhs>(rhs))
+};
 #endif
 
 #ifdef MPARK_TRANSPARENT_OPERATORS
-      using less_equal = std::less_equal<>;
+using greater = std::greater<>;
 #else
-      struct less_equal {
-        template <typename Lhs, typename Rhs>
-        inline constexpr auto operator()(Lhs &&lhs, Rhs &&rhs) const
-          MPARK_RETURN(lib::forward<Lhs>(lhs) <= lib::forward<Rhs>(rhs))
-      };
+struct greater {
+  template <typename Lhs, typename Rhs>
+  inline constexpr auto operator()(Lhs&& lhs, Rhs&& rhs) const
+      MPARK_RETURN(lib::forward<Lhs>(lhs) > lib::forward<Rhs>(rhs))
+};
 #endif
 
 #ifdef MPARK_TRANSPARENT_OPERATORS
-      using greater_equal = std::greater_equal<>;
+using less_equal = std::less_equal<>;
 #else
-      struct greater_equal {
-        template <typename Lhs, typename Rhs>
-        inline constexpr auto operator()(Lhs &&lhs, Rhs &&rhs) const
-          MPARK_RETURN(lib::forward<Lhs>(lhs) >= lib::forward<Rhs>(rhs))
-      };
+struct less_equal {
+  template <typename Lhs, typename Rhs>
+  inline constexpr auto operator()(Lhs&& lhs, Rhs&& rhs) const
+      MPARK_RETURN(lib::forward<Lhs>(lhs) <= lib::forward<Rhs>(rhs))
+};
 #endif
-    }  // namespace cpp14
 
-    inline namespace cpp17 {
+#ifdef MPARK_TRANSPARENT_OPERATORS
+using greater_equal = std::greater_equal<>;
+#else
+struct greater_equal {
+  template <typename Lhs, typename Rhs>
+  inline constexpr auto operator()(Lhs&& lhs, Rhs&& rhs) const
+      MPARK_RETURN(lib::forward<Lhs>(lhs) >= lib::forward<Rhs>(rhs))
+};
+#endif
+} // namespace cpp14
 
-      // <type_traits>
-      template <bool B>
-      using bool_constant = std::integral_constant<bool, B>;
+inline namespace cpp17 {
+// <type_traits>
+template <bool B>
+using bool_constant = std::integral_constant<bool, B>;
 
-      template <typename...>
-      struct voider : identity<void> {};
+template <typename...>
+struct voider : identity<void> {};
 
-      template <typename... Ts>
-      using void_t = typename voider<Ts...>::type;
+template <typename... Ts>
+using void_t = typename voider<Ts...>::type;
 
-      namespace detail_ {
-        namespace swappable {
+namespace detail_ {
+namespace swappable {
 
-          using std::swap;
+using std::swap;
 
-          template <typename T>
-          struct is_swappable {
-            private:
-            template <typename U,
-                      typename = decltype(swap(std::declval<U &>(),
-                                               std::declval<U &>()))>
-            inline static std::true_type test(int);
+template <typename T>
+struct is_swappable {
+ private:
+  template <
+      typename U,
+      typename = decltype(swap(std::declval<U&>(), std::declval<U&>()))>
+  inline static std::true_type test(int);
 
-            template <typename U>
-            inline static std::false_type test(...);
+  template <typename U>
+  inline static std::false_type test(...);
 
-            public:
-            static constexpr bool value = decltype(test<T>(0))::value;
-          };
+ public:
+  static constexpr bool value = decltype(test<T>(0))::value;
+};
 
-          template <bool IsSwappable, typename T>
-          struct is_nothrow_swappable {
-            static constexpr bool value =
-                noexcept(swap(std::declval<T &>(), std::declval<T &>()));
-          };
+template <bool IsSwappable, typename T>
+struct is_nothrow_swappable {
+  static constexpr bool value =
+      noexcept(swap(std::declval<T&>(), std::declval<T&>()));
+};
 
-          template <typename T>
-          struct is_nothrow_swappable<false, T> : std::false_type {};
+template <typename T>
+struct is_nothrow_swappable<false, T> : std::false_type {};
 
-        }  // namespace swappable
-      }  // namespace detail_
+} // namespace swappable
+} // namespace detail_
 
-      using detail_::swappable::is_swappable;
+using detail_::swappable::is_swappable;
 
-      template <typename T>
-      using is_nothrow_swappable =
-          detail_::swappable::is_nothrow_swappable<is_swappable<T>::value, T>;
+template <typename T>
+using is_nothrow_swappable =
+    detail_::swappable::is_nothrow_swappable<is_swappable<T>::value, T>;
 
-      // <functional>
-      namespace detail_ {
+// <functional>
+namespace detail_ {
 
-        template <typename T>
-        struct is_reference_wrapper : std::false_type {};
+template <typename T>
+struct is_reference_wrapper : std::false_type {};
 
-        template <typename T>
-        struct is_reference_wrapper<std::reference_wrapper<T>>
-            : std::true_type {};
+template <typename T>
+struct is_reference_wrapper<std::reference_wrapper<T>> : std::true_type {};
 
-        template <bool, int>
-        struct Invoke;
+template <bool, int>
+struct Invoke;
 
-        template <>
-        struct Invoke<true /* pmf */, 0 /* is_base_of */> {
-          template <typename R, typename T, typename Arg, typename... Args>
-          inline static constexpr auto invoke(R T::*pmf, Arg &&arg, Args &&... args)
-            MPARK_RETURN((lib::forward<Arg>(arg).*pmf)(lib::forward<Args>(args)...))
-        };
+template <>
+struct Invoke<true /* pmf */, 0 /* is_base_of */> {
+  template <typename R, typename T, typename Arg, typename... Args>
+  inline static constexpr auto invoke(R T::*pmf, Arg&& arg, Args&&... args)
+      MPARK_RETURN((lib::forward<Arg>(arg).*pmf)(lib::forward<Args>(args)...))
+};
 
-        template <>
-        struct Invoke<true /* pmf */, 1 /* is_reference_wrapper */> {
-          template <typename R, typename T, typename Arg, typename... Args>
-          inline static constexpr auto invoke(R T::*pmf, Arg &&arg, Args &&... args)
-            MPARK_RETURN((lib::forward<Arg>(arg).get().*pmf)(lib::forward<Args>(args)...))
-        };
+template <>
+struct Invoke<true /* pmf */, 1 /* is_reference_wrapper */> {
+  template <typename R, typename T, typename Arg, typename... Args>
+  inline static constexpr auto invoke(R T::*pmf, Arg&& arg, Args&&... args)
+      MPARK_RETURN(
+          (lib::forward<Arg>(arg).get().*pmf)(lib::forward<Args>(args)...))
+};
 
-        template <>
-        struct Invoke<true /* pmf */, 2 /* otherwise */> {
-          template <typename R, typename T, typename Arg, typename... Args>
-          inline static constexpr auto invoke(R T::*pmf, Arg &&arg, Args &&... args)
-            MPARK_RETURN(((*lib::forward<Arg>(arg)).*pmf)(lib::forward<Args>(args)...))
-        };
+template <>
+struct Invoke<true /* pmf */, 2 /* otherwise */> {
+  template <typename R, typename T, typename Arg, typename... Args>
+  inline static constexpr auto invoke(R T::*pmf, Arg&& arg, Args&&... args)
+      MPARK_RETURN(
+          ((*lib::forward<Arg>(arg)).*pmf)(lib::forward<Args>(args)...))
+};
 
-        template <>
-        struct Invoke<false /* pmo */, 0 /* is_base_of */> {
-          template <typename R, typename T, typename Arg>
-          inline static constexpr auto invoke(R T::*pmo, Arg &&arg)
-            MPARK_RETURN(lib::forward<Arg>(arg).*pmo)
-        };
+template <>
+struct Invoke<false /* pmo */, 0 /* is_base_of */> {
+  template <typename R, typename T, typename Arg>
+  inline static constexpr auto invoke(R T::*pmo, Arg&& arg)
+      MPARK_RETURN(lib::forward<Arg>(arg).*pmo)
+};
 
-        template <>
-        struct Invoke<false /* pmo */, 1 /* is_reference_wrapper */> {
-          template <typename R, typename T, typename Arg>
-          inline static constexpr auto invoke(R T::*pmo, Arg &&arg)
-            MPARK_RETURN(lib::forward<Arg>(arg).get().*pmo)
-        };
+template <>
+struct Invoke<false /* pmo */, 1 /* is_reference_wrapper */> {
+  template <typename R, typename T, typename Arg>
+  inline static constexpr auto invoke(R T::*pmo, Arg&& arg)
+      MPARK_RETURN(lib::forward<Arg>(arg).get().*pmo)
+};
 
-        template <>
-        struct Invoke<false /* pmo */, 2 /* otherwise */> {
-          template <typename R, typename T, typename Arg>
-          inline static constexpr auto invoke(R T::*pmo, Arg &&arg)
-              MPARK_RETURN((*lib::forward<Arg>(arg)).*pmo)
-        };
+template <>
+struct Invoke<false /* pmo */, 2 /* otherwise */> {
+  template <typename R, typename T, typename Arg>
+  inline static constexpr auto invoke(R T::*pmo, Arg&& arg)
+      MPARK_RETURN((*lib::forward<Arg>(arg)).*pmo)
+};
 
-        template <typename R, typename T, typename Arg, typename... Args>
-        inline constexpr auto invoke(R T::*f, Arg &&arg, Args &&... args)
-          MPARK_RETURN(
-              Invoke<std::is_function<R>::value,
-                     (std::is_base_of<T, lib::decay_t<Arg>>::value
-                          ? 0
-                          : is_reference_wrapper<lib::decay_t<Arg>>::value
-                                ? 1
-                                : 2)>::invoke(f,
-                                              lib::forward<Arg>(arg),
-                                              lib::forward<Args>(args)...))
+template <typename R, typename T, typename Arg, typename... Args>
+inline constexpr auto invoke(R T::*f, Arg&& arg, Args&&... args) MPARK_RETURN(
+    Invoke<
+        std::is_function<R>::value,
+        (std::is_base_of<T, lib::decay_t<Arg>>::value
+             ? 0
+             : is_reference_wrapper<lib::decay_t<Arg>>::value ? 1 : 2)>::
+        invoke(f, lib::forward<Arg>(arg), lib::forward<Args>(args)...))
 
 #ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable : 4100)
 #endif
-        template <typename F, typename... Args>
-        inline constexpr auto invoke(F &&f, Args &&... args)
-          MPARK_RETURN(lib::forward<F>(f)(lib::forward<Args>(args)...))
+    template <typename F, typename... Args>
+    inline constexpr auto invoke(F&& f, Args&&... args)
+        MPARK_RETURN(lib::forward<F>(f)(lib::forward<Args>(args)...))
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif
-      }  // namespace detail_
+} // namespace detail_
 
-      template <typename F, typename... Args>
-      inline constexpr auto invoke(F &&f, Args &&... args)
-        MPARK_RETURN(detail_::invoke(lib::forward<F>(f),
-                                    lib::forward<Args>(args)...))
+template <typename F, typename... Args>
+inline constexpr auto invoke(F&& f, Args&&... args) MPARK_RETURN(
+    detail_::invoke(lib::forward<F>(f), lib::forward<Args>(args)...))
 
-      namespace detail_ {
+    namespace detail_ {
+  template <typename Void, typename, typename...>
+  struct invoke_result {};
 
-        template <typename Void, typename, typename...>
-        struct invoke_result {};
+  template <typename F, typename... Args>
+  struct invoke_result<
+      void_t<decltype(lib::invoke(std::declval<F>(), std::declval<Args>()...))>,
+      F,
+      Args...>
+      : identity<decltype(
+            lib::invoke(std::declval<F>(), std::declval<Args>()...))> {};
 
-        template <typename F, typename... Args>
-        struct invoke_result<void_t<decltype(lib::invoke(
-                                 std::declval<F>(), std::declval<Args>()...))>,
-                             F,
-                             Args...>
-            : identity<decltype(
-                  lib::invoke(std::declval<F>(), std::declval<Args>()...))> {};
+} // namespace detail_
 
-      }  // namespace detail_
+template <typename F, typename... Args>
+using invoke_result = detail_::invoke_result<void, F, Args...>;
 
-      template <typename F, typename... Args>
-      using invoke_result = detail_::invoke_result<void, F, Args...>;
+template <typename F, typename... Args>
+using invoke_result_t = typename invoke_result<F, Args...>::type;
 
-      template <typename F, typename... Args>
-      using invoke_result_t = typename invoke_result<F, Args...>::type;
+namespace detail_ {
 
-      namespace detail_ {
+template <typename Void, typename, typename...>
+struct is_invocable : std::false_type {};
 
-        template <typename Void, typename, typename...>
-        struct is_invocable : std::false_type {};
+template <typename F, typename... Args>
+struct is_invocable<void_t<invoke_result_t<F, Args...>>, F, Args...>
+    : std::true_type {};
 
-        template <typename F, typename... Args>
-        struct is_invocable<void_t<invoke_result_t<F, Args...>>, F, Args...>
-            : std::true_type {};
+template <typename Void, typename, typename, typename...>
+struct is_invocable_r : std::false_type {};
 
-        template <typename Void, typename, typename, typename...>
-        struct is_invocable_r : std::false_type {};
+template <typename R, typename F, typename... Args>
+struct is_invocable_r<void_t<invoke_result_t<F, Args...>>, R, F, Args...>
+    : std::is_convertible<invoke_result_t<F, Args...>, R> {};
 
-        template <typename R, typename F, typename... Args>
-        struct is_invocable_r<void_t<invoke_result_t<F, Args...>>,
-                              R,
-                              F,
-                              Args...>
-            : std::is_convertible<invoke_result_t<F, Args...>, R> {};
+} // namespace detail_
 
-      }  // namespace detail_
+template <typename F, typename... Args>
+using is_invocable = detail_::is_invocable<void, F, Args...>;
 
-      template <typename F, typename... Args>
-      using is_invocable = detail_::is_invocable<void, F, Args...>;
+template <typename R, typename F, typename... Args>
+using is_invocable_r = detail_::is_invocable_r<void, R, F, Args...>;
 
-      template <typename R, typename F, typename... Args>
-      using is_invocable_r = detail_::is_invocable_r<void, R, F, Args...>;
+namespace detail_ {
 
-      namespace detail_ {
+template <bool Invocable, typename F, typename... Args>
+struct is_nothrow_invocable {
+  static constexpr bool value =
+      noexcept(lib::invoke(std::declval<F>(), std::declval<Args>()...));
+};
 
-        template <bool Invocable, typename F, typename... Args>
-        struct is_nothrow_invocable {
-          static constexpr bool value =
-              noexcept(lib::invoke(std::declval<F>(), std::declval<Args>()...));
-        };
+template <typename F, typename... Args>
+struct is_nothrow_invocable<false, F, Args...> : std::false_type {};
 
-        template <typename F, typename... Args>
-        struct is_nothrow_invocable<false, F, Args...> : std::false_type {};
+template <bool Invocable, typename R, typename F, typename... Args>
+struct is_nothrow_invocable_r {
+ private:
+  inline static R impl() {
+    return lib::invoke(std::declval<F>(), std::declval<Args>()...);
+  }
 
-        template <bool Invocable, typename R, typename F, typename... Args>
-        struct is_nothrow_invocable_r {
-          private:
-          inline static R impl() {
-            return lib::invoke(std::declval<F>(), std::declval<Args>()...);
-          }
+ public:
+  static constexpr bool value = noexcept(impl());
+};
 
-          public:
-          static constexpr bool value = noexcept(impl());
-        };
+template <typename R, typename F, typename... Args>
+struct is_nothrow_invocable_r<false, R, F, Args...> : std::false_type {};
 
-        template <typename R, typename F, typename... Args>
-        struct is_nothrow_invocable_r<false, R, F, Args...> : std::false_type {};
+} // namespace detail_
 
-      }  // namespace detail_
+template <typename F, typename... Args>
+using is_nothrow_invocable =
+    detail_::is_nothrow_invocable<is_invocable<F, Args...>::value, F, Args...>;
 
-      template <typename F, typename... Args>
-      using is_nothrow_invocable = detail_::
-          is_nothrow_invocable<is_invocable<F, Args...>::value, F, Args...>;
+template <typename R, typename F, typename... Args>
+using is_nothrow_invocable_r = detail_::
+    is_nothrow_invocable_r<is_invocable_r<R, F, Args...>::value, R, F, Args...>;
 
-      template <typename R, typename F, typename... Args>
-      using is_nothrow_invocable_r =
-          detail_::is_nothrow_invocable_r<is_invocable_r<R, F, Args...>::value,
-                                         R,
-                                         F,
-                                         Args...>;
-
-      // <memory>
+// <memory>
 #ifdef MPARK_BUILTIN_ADDRESSOF
-      template <typename T>
-      inline constexpr T *addressof(T &arg) noexcept {
-        return __builtin_addressof(arg);
-      }
+template <typename T>
+inline constexpr T* addressof(T& arg) noexcept {
+  return __builtin_addressof(arg);
+}
 #else
-      namespace detail_ {
+namespace detail_ {
 
-        namespace has_addressof_impl {
+namespace has_addressof_impl {
 
-          struct fail;
+struct fail;
 
-          template <typename T>
-          inline fail operator&(T &&);
+template <typename T>
+inline fail operator&(T&&);
 
-          template <typename T>
-          inline static constexpr bool impl() {
-            return (std::is_class<T>::value || std::is_union<T>::value) &&
-                   !std::is_same<decltype(&std::declval<T &>()), fail>::value;
-          }
+template <typename T>
+inline static constexpr bool impl() {
+  return (std::is_class<T>::value || std::is_union<T>::value) &&
+      !std::is_same<decltype(&std::declval<T&>()), fail>::value;
+}
 
-        }  // namespace has_addressof_impl
+} // namespace has_addressof_impl
 
-        template <typename T>
-        using has_addressof = bool_constant<has_addressof_impl::impl<T>()>;
+template <typename T>
+using has_addressof = bool_constant<has_addressof_impl::impl<T>()>;
 
-        template <typename T>
-        inline constexpr T *addressof(T &arg, std::true_type) noexcept {
-          return std::addressof(arg);
-        }
+template <typename T>
+inline constexpr T* addressof(T& arg, std::true_type) noexcept {
+  return std::addressof(arg);
+}
 
-        template <typename T>
-        inline constexpr T *addressof(T &arg, std::false_type) noexcept {
-          return &arg;
-        }
+template <typename T>
+inline constexpr T* addressof(T& arg, std::false_type) noexcept {
+  return &arg;
+}
 
-      }  // namespace detail_
+} // namespace detail_
 
-      template <typename T>
-      inline constexpr T *addressof(T &arg) noexcept {
-        return detail_::addressof(arg, detail_::has_addressof<T>{});
-      }
+template <typename T>
+inline constexpr T* addressof(T& arg) noexcept {
+  return detail_::addressof(arg, detail_::has_addressof<T>{});
+}
 #endif
 
-      template <typename T>
-      inline constexpr T *addressof(const T &&) = delete;
+template <typename T>
+inline constexpr T* addressof(const T&&) = delete;
 
-    }  // namespace cpp17
+} // namespace cpp17
 
-    template <typename T>
-    struct remove_all_extents : identity<T> {};
+template <typename T>
+struct remove_all_extents : identity<T> {};
 
-    template <typename T, std::size_t N>
-    struct remove_all_extents<array<T, N>> : remove_all_extents<T> {};
+template <typename T, std::size_t N>
+struct remove_all_extents<array<T, N>> : remove_all_extents<T> {};
 
-    template <typename T>
-    using remove_all_extents_t = typename remove_all_extents<T>::type;
+template <typename T>
+using remove_all_extents_t = typename remove_all_extents<T>::type;
 
-    template <std::size_t N>
-    using size_constant = std::integral_constant<std::size_t, N>;
+template <std::size_t N>
+using size_constant = std::integral_constant<std::size_t, N>;
 
-    template <std::size_t I, typename T>
-    struct indexed_type : size_constant<I> { using type = T; };
+template <std::size_t I, typename T>
+struct indexed_type : size_constant<I> {
+  using type = T;
+};
 
-    template <bool... Bs>
-    using all = std::is_same<integer_sequence<bool, true, Bs...>,
-                             integer_sequence<bool, Bs..., true>>;
+template <bool... Bs>
+using all = std::is_same<
+    integer_sequence<bool, true, Bs...>,
+    integer_sequence<bool, Bs..., true>>;
 
 #ifdef MPARK_TYPE_PACK_ELEMENT
-    template <std::size_t I, typename... Ts>
-    using type_pack_element_t = __type_pack_element<I, Ts...>;
+template <std::size_t I, typename... Ts>
+using type_pack_element_t = __type_pack_element<I, Ts...>;
 #else
-    template <std::size_t I, typename... Ts>
-    struct type_pack_element_impl {
-      private:
-      template <typename>
-      struct set;
+template <std::size_t I, typename... Ts>
+struct type_pack_element_impl {
+ private:
+  template <typename>
+  struct set;
 
-      template <std::size_t... Is>
-      struct set<index_sequence<Is...>> : indexed_type<Is, Ts>... {};
+  template <std::size_t... Is>
+  struct set<index_sequence<Is...>> : indexed_type<Is, Ts>... {};
 
-      template <typename T>
-      inline static std::enable_if<true, T> impl(indexed_type<I, T>);
+  template <typename T>
+  inline static std::enable_if<true, T> impl(indexed_type<I, T>);
 
-      inline static std::enable_if<false> impl(...);
+  inline static std::enable_if<false> impl(...);
 
-      public:
-      using type = decltype(impl(set<index_sequence_for<Ts...>>{}));
-    };
+ public:
+  using type = decltype(impl(set<index_sequence_for<Ts...>>{}));
+};
 
-    template <std::size_t I, typename... Ts>
-    using type_pack_element = typename type_pack_element_impl<I, Ts...>::type;
+template <std::size_t I, typename... Ts>
+using type_pack_element = typename type_pack_element_impl<I, Ts...>::type;
 
-    template <std::size_t I, typename... Ts>
-    using type_pack_element_t = typename type_pack_element<I, Ts...>::type;
+template <std::size_t I, typename... Ts>
+using type_pack_element_t = typename type_pack_element<I, Ts...>::type;
 #endif
 
 #ifdef MPARK_TRIVIALITY_TYPE_TRAITS
-    using std::is_trivially_copy_constructible;
-    using std::is_trivially_move_constructible;
-    using std::is_trivially_copy_assignable;
-    using std::is_trivially_move_assignable;
+using std::is_trivially_copy_assignable;
+using std::is_trivially_copy_constructible;
+using std::is_trivially_move_assignable;
+using std::is_trivially_move_constructible;
 #else
-    template <typename T>
-    struct is_trivially_copy_constructible
-        : bool_constant<
-              std::is_copy_constructible<T>::value && __has_trivial_copy(T)> {};
+template <typename T>
+struct is_trivially_copy_constructible
+    : bool_constant<std::is_copy_constructible<T>::value&& __has_trivial_copy(
+          T)> {};
 
-    template <typename T>
-    struct is_trivially_move_constructible : bool_constant<__is_trivial(T)> {};
+template <typename T>
+struct is_trivially_move_constructible : bool_constant<__is_trivial(T)> {};
 
-    template <typename T>
-    struct is_trivially_copy_assignable
-        : bool_constant<
-              std::is_copy_assignable<T>::value && __has_trivial_assign(T)> {};
+template <typename T>
+struct is_trivially_copy_assignable
+    : bool_constant<std::is_copy_assignable<T>::value&& __has_trivial_assign(
+          T)> {};
 
-    template <typename T>
-    struct is_trivially_move_assignable : bool_constant<__is_trivial(T)> {};
+template <typename T>
+struct is_trivially_move_assignable : bool_constant<__is_trivial(T)> {};
 #endif
 
-    template <typename T, bool>
-    struct dependent_type : T {};
+template <typename T, bool>
+struct dependent_type : T {};
 
-    template <typename Is, std::size_t J>
-    struct push_back;
+template <typename Is, std::size_t J>
+struct push_back;
 
-    template <typename Is, std::size_t J>
-    using push_back_t = typename push_back<Is, J>::type;
+template <typename Is, std::size_t J>
+using push_back_t = typename push_back<Is, J>::type;
 
-    template <std::size_t... Is, std::size_t J>
-    struct push_back<index_sequence<Is...>, J> {
-      using type = index_sequence<Is..., J>;
-    };
+template <std::size_t... Is, std::size_t J>
+struct push_back<index_sequence<Is...>, J> {
+  using type = index_sequence<Is..., J>;
+};
 
-  }  // namespace lib
-}  // namespace c10
+} // namespace lib
+} // namespace c10
 
 #undef MPARK_RETURN
 
-#endif  // MPARK_LIB_HPP
-
+#endif // MPARK_LIB_HPP
 
 namespace c10 {
 
 #ifdef MPARK_RETURN_TYPE_DEDUCTION
 
 #define AUTO auto
-#define AUTO_RETURN(...) { return __VA_ARGS__; }
+#define AUTO_RETURN(...) \
+  { return __VA_ARGS__; }
 
-#define AUTO_REFREF auto &&
-#define AUTO_REFREF_RETURN(...) { return __VA_ARGS__; }
+#define AUTO_REFREF auto&&
+#define AUTO_REFREF_RETURN(...) \
+  { return __VA_ARGS__; }
 
 #define DECLTYPE_AUTO decltype(auto)
-#define DECLTYPE_AUTO_RETURN(...) { return __VA_ARGS__; }
+#define DECLTYPE_AUTO_RETURN(...) \
+  { return __VA_ARGS__; }
 
 #else
 
 #define AUTO auto
-#define AUTO_RETURN(...) \
-  -> lib::decay_t<decltype(__VA_ARGS__)> { return __VA_ARGS__; }
+#define AUTO_RETURN(...)                  \
+  ->lib::decay_t<decltype(__VA_ARGS__)> { \
+    return __VA_ARGS__;                   \
+  }
 
 #define AUTO_REFREF auto
 #define AUTO_REFREF_RETURN(...)                                           \
-  -> decltype((__VA_ARGS__)) {                                            \
+  ->decltype((__VA_ARGS__)) {                                             \
     static_assert(std::is_reference<decltype((__VA_ARGS__))>::value, ""); \
     return __VA_ARGS__;                                                   \
   }
 
 #define DECLTYPE_AUTO auto
 #define DECLTYPE_AUTO_RETURN(...) \
-  -> decltype(__VA_ARGS__) { return __VA_ARGS__; }
-
-#endif
-
-  class bad_variant_access : public std::exception {
-    public:
-    virtual const char *what() const noexcept override { return "bad_variant_access"; }
-  };
-
-  [[noreturn]] inline void throw_bad_variant_access() {
-#ifdef MPARK_EXCEPTIONS
-    throw bad_variant_access{};
-#else
-    std::terminate();
-    MPARK_BUILTIN_UNREACHABLE;
-#endif
+  ->decltype(__VA_ARGS__) {       \
+    return __VA_ARGS__;           \
   }
 
-  template <typename... Ts>
-  class variant;
+#endif
 
-  template <typename T>
-  struct variant_size;
+class bad_variant_access : public std::exception {
+ public:
+  virtual const char* what() const noexcept override {
+    return "bad_variant_access";
+  }
+};
+
+[[noreturn]] inline void throw_bad_variant_access() {
+#ifdef MPARK_EXCEPTIONS
+  throw bad_variant_access{};
+#else
+  std::terminate();
+  MPARK_BUILTIN_UNREACHABLE;
+#endif
+}
+
+template <typename... Ts>
+class variant;
+
+template <typename T>
+struct variant_size;
 
 #ifdef MPARK_VARIABLE_TEMPLATES
-  template <typename T>
-  constexpr std::size_t variant_size_v = variant_size<T>::value;
+template <typename T>
+constexpr std::size_t variant_size_v = variant_size<T>::value;
 #endif
 
-  template <typename T>
-  struct variant_size<const T> : variant_size<T> {};
+template <typename T>
+struct variant_size<const T> : variant_size<T> {};
 
-  template <typename T>
-  struct variant_size<volatile T> : variant_size<T> {};
+template <typename T>
+struct variant_size<volatile T> : variant_size<T> {};
 
-  template <typename T>
-  struct variant_size<const volatile T> : variant_size<T> {};
+template <typename T>
+struct variant_size<const volatile T> : variant_size<T> {};
 
-  template <typename... Ts>
-  struct variant_size<variant<Ts...>> : lib::size_constant<sizeof...(Ts)> {};
+template <typename... Ts>
+struct variant_size<variant<Ts...>> : lib::size_constant<sizeof...(Ts)> {};
 
-  template <std::size_t I, typename T>
-  struct variant_alternative;
+template <std::size_t I, typename T>
+struct variant_alternative;
 
-  template <std::size_t I, typename T>
-  using variant_alternative_t = typename variant_alternative<I, T>::type;
+template <std::size_t I, typename T>
+using variant_alternative_t = typename variant_alternative<I, T>::type;
 
-  template <std::size_t I, typename T>
-  struct variant_alternative<I, const T>
-      : std::add_const<variant_alternative_t<I, T>> {};
+template <std::size_t I, typename T>
+struct variant_alternative<I, const T>
+    : std::add_const<variant_alternative_t<I, T>> {};
 
-  template <std::size_t I, typename T>
-  struct variant_alternative<I, volatile T>
-      : std::add_volatile<variant_alternative_t<I, T>> {};
+template <std::size_t I, typename T>
+struct variant_alternative<I, volatile T>
+    : std::add_volatile<variant_alternative_t<I, T>> {};
 
-  template <std::size_t I, typename T>
-  struct variant_alternative<I, const volatile T>
-      : std::add_cv<variant_alternative_t<I, T>> {};
+template <std::size_t I, typename T>
+struct variant_alternative<I, const volatile T>
+    : std::add_cv<variant_alternative_t<I, T>> {};
 
-  template <std::size_t I, typename... Ts>
-  struct variant_alternative<I, variant<Ts...>> {
-    static_assert(I < sizeof...(Ts),
-                  "index out of bounds in `std::variant_alternative<>`");
-    using type = lib::type_pack_element_t<I, Ts...>;
+template <std::size_t I, typename... Ts>
+struct variant_alternative<I, variant<Ts...>> {
+  static_assert(
+      I < sizeof...(Ts),
+      "index out of bounds in `std::variant_alternative<>`");
+  using type = lib::type_pack_element_t<I, Ts...>;
+};
+
+constexpr std::size_t variant_npos = static_cast<std::size_t>(-1);
+
+namespace detail_ {
+
+constexpr std::size_t not_found = static_cast<std::size_t>(-1);
+constexpr std::size_t ambiguous = static_cast<std::size_t>(-2);
+
+#ifdef MPARK_CPP14_CONSTEXPR
+template <typename T, typename... Ts>
+inline constexpr std::size_t find_index() {
+  constexpr lib::array<bool, sizeof...(Ts)> matches = {
+      {std::is_same<T, Ts>::value...}};
+  std::size_t result = not_found;
+  for (std::size_t i = 0; i < sizeof...(Ts); ++i) {
+    if (matches[i]) {
+      if (result != not_found) {
+        return ambiguous;
+      }
+      result = i;
+    }
+  }
+  return result;
+}
+#else
+inline constexpr std::size_t find_index_impl(std::size_t result, std::size_t) {
+  return result;
+}
+
+template <typename... Bs>
+inline constexpr std::size_t find_index_impl(
+    std::size_t result,
+    std::size_t idx,
+    bool b,
+    Bs... bs) {
+  return b
+      ? (result != not_found ? ambiguous : find_index_impl(idx, idx + 1, bs...))
+      : find_index_impl(result, idx + 1, bs...);
+}
+
+template <typename T, typename... Ts>
+inline constexpr std::size_t find_index() {
+  return find_index_impl(not_found, 0, std::is_same<T, Ts>::value...);
+}
+#endif
+
+template <std::size_t I>
+using find_index_sfinae_impl =
+    lib::enable_if_t<I != not_found && I != ambiguous, lib::size_constant<I>>;
+
+template <typename T, typename... Ts>
+using find_index_sfinae = find_index_sfinae_impl<find_index<T, Ts...>()>;
+
+template <std::size_t I>
+struct find_index_checked_impl : lib::size_constant<I> {
+  static_assert(I != not_found, "the specified type is not found.");
+  static_assert(I != ambiguous, "the specified type is ambiguous.");
+};
+
+template <typename T, typename... Ts>
+using find_index_checked = find_index_checked_impl<find_index<T, Ts...>()>;
+
+struct valueless_t {};
+
+enum class Trait { TriviallyAvailable, Available, Unavailable };
+
+template <
+    typename T,
+    template <typename>
+    class IsTriviallyAvailable,
+    template <typename>
+    class IsAvailable>
+inline constexpr Trait trait() {
+  return IsTriviallyAvailable<T>::value
+      ? Trait::TriviallyAvailable
+      : IsAvailable<T>::value ? Trait::Available : Trait::Unavailable;
+}
+
+#ifdef MPARK_CPP14_CONSTEXPR
+template <typename... Traits>
+inline constexpr Trait common_trait(Traits... traits_) {
+  Trait result = Trait::TriviallyAvailable;
+  lib::array<Trait, sizeof...(Traits)> traits = {{traits_...}};
+  for (std::size_t i = 0; i < sizeof...(Traits); ++i) {
+    Trait t = traits[i];
+    if (static_cast<int>(t) > static_cast<int>(result)) {
+      result = t;
+    }
+  }
+  return result;
+}
+#else
+inline constexpr Trait common_trait_impl(Trait result) {
+  return result;
+}
+
+template <typename... Traits>
+inline constexpr Trait common_trait_impl(Trait result, Trait t, Traits... ts) {
+  return static_cast<int>(t) > static_cast<int>(result)
+      ? common_trait_impl(t, ts...)
+      : common_trait_impl(result, ts...);
+}
+
+template <typename... Traits>
+inline constexpr Trait common_trait(Traits... ts) {
+  return common_trait_impl(Trait::TriviallyAvailable, ts...);
+}
+#endif
+
+template <typename... Ts>
+struct traits {
+  static constexpr Trait copy_constructible_trait =
+      common_trait(trait<
+                   Ts,
+                   lib::is_trivially_copy_constructible,
+                   std::is_copy_constructible>()...);
+
+  static constexpr Trait move_constructible_trait =
+      common_trait(trait<
+                   Ts,
+                   lib::is_trivially_move_constructible,
+                   std::is_move_constructible>()...);
+
+  static constexpr Trait copy_assignable_trait = common_trait(
+      copy_constructible_trait,
+      trait<
+          Ts,
+          lib::is_trivially_copy_assignable,
+          std::is_copy_assignable>()...);
+
+  static constexpr Trait move_assignable_trait = common_trait(
+      move_constructible_trait,
+      trait<
+          Ts,
+          lib::is_trivially_move_assignable,
+          std::is_move_assignable>()...);
+
+  static constexpr Trait destructible_trait = common_trait(
+      trait<Ts, std::is_trivially_destructible, std::is_destructible>()...);
+};
+
+namespace access {
+
+struct recursive_union {
+#ifdef MPARK_RETURN_TYPE_DEDUCTION
+  template <typename V>
+  inline static constexpr auto&& get_alt(V&& v, in_place_index_t<0>) {
+    return lib::forward<V>(v).head_;
+  }
+
+  template <typename V, std::size_t I>
+  inline static constexpr auto&& get_alt(V&& v, in_place_index_t<I>) {
+    return get_alt(lib::forward<V>(v).tail_, in_place_index_t<I - 1>{});
+  }
+#else
+  template <std::size_t I, bool Dummy = true>
+  struct get_alt_impl {
+    template <typename V>
+    inline constexpr AUTO_REFREF operator()(V&& v) const
+        AUTO_REFREF_RETURN(get_alt_impl<I - 1>{}(lib::forward<V>(v).tail_))
   };
 
-  constexpr std::size_t variant_npos = static_cast<std::size_t>(-1);
+  template <bool Dummy>
+  struct get_alt_impl<0, Dummy> {
+    template <typename V>
+    inline constexpr AUTO_REFREF operator()(V&& v) const
+        AUTO_REFREF_RETURN(lib::forward<V>(v).head_)
+  };
 
-  namespace detail_ {
-
-    constexpr std::size_t not_found = static_cast<std::size_t>(-1);
-    constexpr std::size_t ambiguous = static_cast<std::size_t>(-2);
-
-#ifdef MPARK_CPP14_CONSTEXPR
-    template <typename T, typename... Ts>
-    inline constexpr std::size_t find_index() {
-      constexpr lib::array<bool, sizeof...(Ts)> matches = {
-          {std::is_same<T, Ts>::value...}
-      };
-      std::size_t result = not_found;
-      for (std::size_t i = 0; i < sizeof...(Ts); ++i) {
-        if (matches[i]) {
-          if (result != not_found) {
-            return ambiguous;
-          }
-          result = i;
-        }
-      }
-      return result;
-    }
-#else
-    inline constexpr std::size_t find_index_impl(std::size_t result,
-                                                 std::size_t) {
-      return result;
-    }
-
-    template <typename... Bs>
-    inline constexpr std::size_t find_index_impl(std::size_t result,
-                                                 std::size_t idx,
-                                                 bool b,
-                                                 Bs... bs) {
-      return b ? (result != not_found ? ambiguous
-                                      : find_index_impl(idx, idx + 1, bs...))
-               : find_index_impl(result, idx + 1, bs...);
-    }
-
-    template <typename T, typename... Ts>
-    inline constexpr std::size_t find_index() {
-      return find_index_impl(not_found, 0, std::is_same<T, Ts>::value...);
-    }
+  template <typename V, std::size_t I>
+  inline static constexpr AUTO_REFREF get_alt(V&& v, in_place_index_t<I>)
+      AUTO_REFREF_RETURN(get_alt_impl<I>{}(lib::forward<V>(v)))
 #endif
+};
 
-    template <std::size_t I>
-    using find_index_sfinae_impl =
-        lib::enable_if_t<I != not_found && I != ambiguous,
-                         lib::size_constant<I>>;
-
-    template <typename T, typename... Ts>
-    using find_index_sfinae = find_index_sfinae_impl<find_index<T, Ts...>()>;
-
-    template <std::size_t I>
-    struct find_index_checked_impl : lib::size_constant<I> {
-      static_assert(I != not_found, "the specified type is not found.");
-      static_assert(I != ambiguous, "the specified type is ambiguous.");
-    };
-
-    template <typename T, typename... Ts>
-    using find_index_checked = find_index_checked_impl<find_index<T, Ts...>()>;
-
-    struct valueless_t {};
-
-    enum class Trait { TriviallyAvailable, Available, Unavailable };
-
-    template <typename T,
-              template <typename> class IsTriviallyAvailable,
-              template <typename> class IsAvailable>
-    inline constexpr Trait trait() {
-      return IsTriviallyAvailable<T>::value
-                 ? Trait::TriviallyAvailable
-                 : IsAvailable<T>::value ? Trait::Available
-                                         : Trait::Unavailable;
-    }
-
-#ifdef MPARK_CPP14_CONSTEXPR
-    template <typename... Traits>
-    inline constexpr Trait common_trait(Traits... traits_) {
-      Trait result = Trait::TriviallyAvailable;
-      lib::array<Trait, sizeof...(Traits)> traits = {{traits_...}};
-      for (std::size_t i = 0; i < sizeof...(Traits); ++i) {
-        Trait t = traits[i];
-        if (static_cast<int>(t) > static_cast<int>(result)) {
-          result = t;
-        }
-      }
-      return result;
-    }
-#else
-    inline constexpr Trait common_trait_impl(Trait result) { return result; }
-
-    template <typename... Traits>
-    inline constexpr Trait common_trait_impl(Trait result,
-                                             Trait t,
-                                             Traits... ts) {
-      return static_cast<int>(t) > static_cast<int>(result)
-                 ? common_trait_impl(t, ts...)
-                 : common_trait_impl(result, ts...);
-    }
-
-    template <typename... Traits>
-    inline constexpr Trait common_trait(Traits... ts) {
-      return common_trait_impl(Trait::TriviallyAvailable, ts...);
-    }
-#endif
-
-    template <typename... Ts>
-    struct traits {
-      static constexpr Trait copy_constructible_trait =
-          common_trait(trait<Ts,
-                             lib::is_trivially_copy_constructible,
-                             std::is_copy_constructible>()...);
-
-      static constexpr Trait move_constructible_trait =
-          common_trait(trait<Ts,
-                             lib::is_trivially_move_constructible,
-                             std::is_move_constructible>()...);
-
-      static constexpr Trait copy_assignable_trait =
-          common_trait(copy_constructible_trait,
-                       trait<Ts,
-                             lib::is_trivially_copy_assignable,
-                             std::is_copy_assignable>()...);
-
-      static constexpr Trait move_assignable_trait =
-          common_trait(move_constructible_trait,
-                       trait<Ts,
-                             lib::is_trivially_move_assignable,
-                             std::is_move_assignable>()...);
-
-      static constexpr Trait destructible_trait =
-          common_trait(trait<Ts,
-                             std::is_trivially_destructible,
-                             std::is_destructible>()...);
-    };
-
-    namespace access {
-
-      struct recursive_union {
-#ifdef MPARK_RETURN_TYPE_DEDUCTION
-        template <typename V>
-        inline static constexpr auto &&get_alt(V &&v, in_place_index_t<0>) {
-          return lib::forward<V>(v).head_;
-        }
-
-        template <typename V, std::size_t I>
-        inline static constexpr auto &&get_alt(V &&v, in_place_index_t<I>) {
-          return get_alt(lib::forward<V>(v).tail_, in_place_index_t<I - 1>{});
-        }
-#else
-        template <std::size_t I, bool Dummy = true>
-        struct get_alt_impl {
-          template <typename V>
-          inline constexpr AUTO_REFREF operator()(V &&v) const
-            AUTO_REFREF_RETURN(get_alt_impl<I - 1>{}(lib::forward<V>(v).tail_))
-        };
-
-        template <bool Dummy>
-        struct get_alt_impl<0, Dummy> {
-          template <typename V>
-          inline constexpr AUTO_REFREF operator()(V &&v) const
-            AUTO_REFREF_RETURN(lib::forward<V>(v).head_)
-        };
-
-        template <typename V, std::size_t I>
-        inline static constexpr AUTO_REFREF get_alt(V &&v, in_place_index_t<I>)
-          AUTO_REFREF_RETURN(get_alt_impl<I>{}(lib::forward<V>(v)))
-#endif
-      };
-
-      struct base {
-        template <std::size_t I, typename V>
-        inline static constexpr AUTO_REFREF get_alt(V &&v)
+struct base {
+  template <std::size_t I, typename V>
+  inline static constexpr AUTO_REFREF get_alt(V&& v)
 #ifdef _MSC_VER
-          AUTO_REFREF_RETURN(recursive_union::get_alt(
-              lib::forward<V>(v).data_, in_place_index_t<I>{}))
+      AUTO_REFREF_RETURN(recursive_union::get_alt(
+          lib::forward<V>(v).data_,
+          in_place_index_t<I>{}))
 #else
-          AUTO_REFREF_RETURN(recursive_union::get_alt(
-              data(lib::forward<V>(v)), in_place_index_t<I>{}))
+      AUTO_REFREF_RETURN(recursive_union::get_alt(
+          data(lib::forward<V>(v)),
+          in_place_index_t<I>{}))
 #endif
-      };
+};
 
-      struct variant {
-        template <std::size_t I, typename V>
-        inline static constexpr AUTO_REFREF get_alt(V &&v)
-          AUTO_REFREF_RETURN(base::get_alt<I>(lib::forward<V>(v).impl_))
-      };
+struct variant {
+  template <std::size_t I, typename V>
+  inline static constexpr AUTO_REFREF get_alt(V&& v)
+      AUTO_REFREF_RETURN(base::get_alt<I>(lib::forward<V>(v).impl_))
+};
 
-    }  // namespace access
+} // namespace access
 
-    namespace visitation {
+namespace visitation {
 
 #if defined(MPARK_CPP14_CONSTEXPR) && !defined(_MSC_VER)
 #define MPARK_VARIANT_SWITCH_VISIT
 #endif
 
-      struct base {
-        template <typename Visitor, typename... Vs>
-        using dispatch_result_t = decltype(
-            lib::invoke(std::declval<Visitor>(),
-                        access::base::get_alt<0>(std::declval<Vs>())...));
+struct base {
+  template <typename Visitor, typename... Vs>
+  using dispatch_result_t = decltype(lib::invoke(
+      std::declval<Visitor>(),
+      access::base::get_alt<0>(std::declval<Vs>())...));
 
-        template <typename Expected>
-        struct expected {
-          template <typename Actual>
-          inline static constexpr bool but_got() {
-            return std::is_same<Expected, Actual>::value;
-          }
-        };
+  template <typename Expected>
+  struct expected {
+    template <typename Actual>
+    inline static constexpr bool but_got() {
+      return std::is_same<Expected, Actual>::value;
+    }
+  };
 
-        template <typename Expected, typename Actual>
-        struct visit_return_type_check {
-          static_assert(
-              expected<Expected>::template but_got<Actual>(),
-              "`visit` requires the visitor to have a single return type");
+  template <typename Expected, typename Actual>
+  struct visit_return_type_check {
+    static_assert(
+        expected<Expected>::template but_got<Actual>(),
+        "`visit` requires the visitor to have a single return type");
 
-          template <typename Visitor, typename... Alts>
-          inline static constexpr DECLTYPE_AUTO invoke(Visitor &&visitor,
-                                                       Alts &&... alts)
-            DECLTYPE_AUTO_RETURN(lib::invoke(lib::forward<Visitor>(visitor),
-                                             lib::forward<Alts>(alts)...))
-        };
+    template <typename Visitor, typename... Alts>
+    inline static constexpr DECLTYPE_AUTO invoke(
+        Visitor&& visitor,
+        Alts&&... alts)
+        DECLTYPE_AUTO_RETURN(lib::invoke(
+            lib::forward<Visitor>(visitor),
+            lib::forward<Alts>(alts)...))
+  };
 
 #ifdef MPARK_VARIANT_SWITCH_VISIT
-        template <bool B, typename R, typename... ITs>
-        struct dispatcher;
+  template <bool B, typename R, typename... ITs>
+  struct dispatcher;
 
-        template <typename R, typename... ITs>
-        struct dispatcher<false, R, ITs...> {
-          template <std::size_t B, typename F, typename... Vs>
-          MPARK_ALWAYS_INLINE static constexpr R dispatch(
-              F &&, typename ITs::type &&..., Vs &&...) {
-            MPARK_BUILTIN_UNREACHABLE;
-          }
+  template <typename R, typename... ITs>
+  struct dispatcher<false, R, ITs...> {
+    template <std::size_t B, typename F, typename... Vs>
+    MPARK_ALWAYS_INLINE static constexpr R dispatch(
+        F&&,
+        typename ITs::type&&...,
+        Vs&&...) {
+      MPARK_BUILTIN_UNREACHABLE;
+    }
 
-          template <std::size_t I, typename F, typename... Vs>
-          MPARK_ALWAYS_INLINE static constexpr R dispatch_case(F &&, Vs &&...) {
-            MPARK_BUILTIN_UNREACHABLE;
-          }
+    template <std::size_t I, typename F, typename... Vs>
+    MPARK_ALWAYS_INLINE static constexpr R dispatch_case(F&&, Vs&&...) {
+      MPARK_BUILTIN_UNREACHABLE;
+    }
 
-          template <std::size_t B, typename F, typename... Vs>
-          MPARK_ALWAYS_INLINE static constexpr R dispatch_at(std::size_t,
-                                                             F &&,
-                                                             Vs &&...) {
-            MPARK_BUILTIN_UNREACHABLE;
-          }
-        };
+    template <std::size_t B, typename F, typename... Vs>
+    MPARK_ALWAYS_INLINE static constexpr R dispatch_at(
+        std::size_t,
+        F&&,
+        Vs&&...) {
+      MPARK_BUILTIN_UNREACHABLE;
+    }
+  };
 
-        template <typename R, typename... ITs>
-        struct dispatcher<true, R, ITs...> {
-          template <std::size_t B, typename F>
-          MPARK_ALWAYS_INLINE static constexpr R dispatch(
-              F &&f, typename ITs::type &&... visited_vs) {
-            using Expected = R;
-            using Actual = decltype(lib::invoke(
-                lib::forward<F>(f),
-                access::base::get_alt<ITs::value>(
-                    lib::forward<typename ITs::type>(visited_vs))...));
-            return visit_return_type_check<Expected, Actual>::invoke(
-                lib::forward<F>(f),
-                access::base::get_alt<ITs::value>(
-                    lib::forward<typename ITs::type>(visited_vs))...);
-          }
+  template <typename R, typename... ITs>
+  struct dispatcher<true, R, ITs...> {
+    template <std::size_t B, typename F>
+    MPARK_ALWAYS_INLINE static constexpr R dispatch(
+        F&& f,
+        typename ITs::type&&... visited_vs) {
+      using Expected = R;
+      using Actual = decltype(lib::invoke(
+          lib::forward<F>(f),
+          access::base::get_alt<ITs::value>(
+              lib::forward<typename ITs::type>(visited_vs))...));
+      return visit_return_type_check<Expected, Actual>::invoke(
+          lib::forward<F>(f),
+          access::base::get_alt<ITs::value>(
+              lib::forward<typename ITs::type>(visited_vs))...);
+    }
 
-          template <std::size_t B, typename F, typename V, typename... Vs>
-          MPARK_ALWAYS_INLINE static constexpr R dispatch(
-              F &&f, typename ITs::type &&... visited_vs, V &&v, Vs &&... vs) {
-#define MPARK_DISPATCH(I)                                                   \
-  dispatcher<(I < lib::decay_t<V>::size()),                                 \
-             R,                                                             \
-             ITs...,                                                        \
-             lib::indexed_type<I, V>>::                                     \
-      template dispatch<0>(lib::forward<F>(f),                              \
-                           lib::forward<typename ITs::type>(visited_vs)..., \
-                           lib::forward<V>(v),                              \
-                           lib::forward<Vs>(vs)...)
+    template <std::size_t B, typename F, typename V, typename... Vs>
+    MPARK_ALWAYS_INLINE static constexpr R dispatch(
+        F&& f,
+        typename ITs::type&&... visited_vs,
+        V&& v,
+        Vs&&... vs) {
+#define MPARK_DISPATCH(I)                                  \
+  dispatcher<                                              \
+      (I < lib::decay_t<V>::size()),                       \
+      R,                                                   \
+      ITs...,                                              \
+      lib::indexed_type<I, V>>::                           \
+      template dispatch<0>(                                \
+          lib::forward<F>(f),                              \
+          lib::forward<typename ITs::type>(visited_vs)..., \
+          lib::forward<V>(v),                              \
+          lib::forward<Vs>(vs)...)
 
 #define MPARK_DEFAULT(I)                                                      \
   dispatcher<(I < lib::decay_t<V>::size()), R, ITs...>::template dispatch<I>( \
@@ -1261,66 +1295,100 @@ namespace c10 {
       lib::forward<V>(v),                                                     \
       lib::forward<Vs>(vs)...)
 
-            switch (v.index()) {
-              case B + 0: return MPARK_DISPATCH(B + 0);
-              case B + 1: return MPARK_DISPATCH(B + 1);
-              case B + 2: return MPARK_DISPATCH(B + 2);
-              case B + 3: return MPARK_DISPATCH(B + 3);
-              case B + 4: return MPARK_DISPATCH(B + 4);
-              case B + 5: return MPARK_DISPATCH(B + 5);
-              case B + 6: return MPARK_DISPATCH(B + 6);
-              case B + 7: return MPARK_DISPATCH(B + 7);
-              case B + 8: return MPARK_DISPATCH(B + 8);
-              case B + 9: return MPARK_DISPATCH(B + 9);
-              case B + 10: return MPARK_DISPATCH(B + 10);
-              case B + 11: return MPARK_DISPATCH(B + 11);
-              case B + 12: return MPARK_DISPATCH(B + 12);
-              case B + 13: return MPARK_DISPATCH(B + 13);
-              case B + 14: return MPARK_DISPATCH(B + 14);
-              case B + 15: return MPARK_DISPATCH(B + 15);
-              case B + 16: return MPARK_DISPATCH(B + 16);
-              case B + 17: return MPARK_DISPATCH(B + 17);
-              case B + 18: return MPARK_DISPATCH(B + 18);
-              case B + 19: return MPARK_DISPATCH(B + 19);
-              case B + 20: return MPARK_DISPATCH(B + 20);
-              case B + 21: return MPARK_DISPATCH(B + 21);
-              case B + 22: return MPARK_DISPATCH(B + 22);
-              case B + 23: return MPARK_DISPATCH(B + 23);
-              case B + 24: return MPARK_DISPATCH(B + 24);
-              case B + 25: return MPARK_DISPATCH(B + 25);
-              case B + 26: return MPARK_DISPATCH(B + 26);
-              case B + 27: return MPARK_DISPATCH(B + 27);
-              case B + 28: return MPARK_DISPATCH(B + 28);
-              case B + 29: return MPARK_DISPATCH(B + 29);
-              case B + 30: return MPARK_DISPATCH(B + 30);
-              case B + 31: return MPARK_DISPATCH(B + 31);
-              default: return MPARK_DEFAULT(B + 32);
-            }
+      switch (v.index()) {
+        case B + 0:
+          return MPARK_DISPATCH(B + 0);
+        case B + 1:
+          return MPARK_DISPATCH(B + 1);
+        case B + 2:
+          return MPARK_DISPATCH(B + 2);
+        case B + 3:
+          return MPARK_DISPATCH(B + 3);
+        case B + 4:
+          return MPARK_DISPATCH(B + 4);
+        case B + 5:
+          return MPARK_DISPATCH(B + 5);
+        case B + 6:
+          return MPARK_DISPATCH(B + 6);
+        case B + 7:
+          return MPARK_DISPATCH(B + 7);
+        case B + 8:
+          return MPARK_DISPATCH(B + 8);
+        case B + 9:
+          return MPARK_DISPATCH(B + 9);
+        case B + 10:
+          return MPARK_DISPATCH(B + 10);
+        case B + 11:
+          return MPARK_DISPATCH(B + 11);
+        case B + 12:
+          return MPARK_DISPATCH(B + 12);
+        case B + 13:
+          return MPARK_DISPATCH(B + 13);
+        case B + 14:
+          return MPARK_DISPATCH(B + 14);
+        case B + 15:
+          return MPARK_DISPATCH(B + 15);
+        case B + 16:
+          return MPARK_DISPATCH(B + 16);
+        case B + 17:
+          return MPARK_DISPATCH(B + 17);
+        case B + 18:
+          return MPARK_DISPATCH(B + 18);
+        case B + 19:
+          return MPARK_DISPATCH(B + 19);
+        case B + 20:
+          return MPARK_DISPATCH(B + 20);
+        case B + 21:
+          return MPARK_DISPATCH(B + 21);
+        case B + 22:
+          return MPARK_DISPATCH(B + 22);
+        case B + 23:
+          return MPARK_DISPATCH(B + 23);
+        case B + 24:
+          return MPARK_DISPATCH(B + 24);
+        case B + 25:
+          return MPARK_DISPATCH(B + 25);
+        case B + 26:
+          return MPARK_DISPATCH(B + 26);
+        case B + 27:
+          return MPARK_DISPATCH(B + 27);
+        case B + 28:
+          return MPARK_DISPATCH(B + 28);
+        case B + 29:
+          return MPARK_DISPATCH(B + 29);
+        case B + 30:
+          return MPARK_DISPATCH(B + 30);
+        case B + 31:
+          return MPARK_DISPATCH(B + 31);
+        default:
+          return MPARK_DEFAULT(B + 32);
+      }
 
 #undef MPARK_DEFAULT
 #undef MPARK_DISPATCH
-          }
+    }
 
-          template <std::size_t I, typename F, typename... Vs>
-          MPARK_ALWAYS_INLINE static constexpr R dispatch_case(F &&f,
-                                                               Vs &&... vs) {
-            using Expected = R;
-            using Actual = decltype(
-                lib::invoke(lib::forward<F>(f),
-                            access::base::get_alt<I>(lib::forward<Vs>(vs))...));
-            return visit_return_type_check<Expected, Actual>::invoke(
-                lib::forward<F>(f),
-                access::base::get_alt<I>(lib::forward<Vs>(vs))...);
-          }
+    template <std::size_t I, typename F, typename... Vs>
+    MPARK_ALWAYS_INLINE static constexpr R dispatch_case(F&& f, Vs&&... vs) {
+      using Expected = R;
+      using Actual = decltype(lib::invoke(
+          lib::forward<F>(f),
+          access::base::get_alt<I>(lib::forward<Vs>(vs))...));
+      return visit_return_type_check<Expected, Actual>::invoke(
+          lib::forward<F>(f),
+          access::base::get_alt<I>(lib::forward<Vs>(vs))...);
+    }
 
-          template <std::size_t B, typename F, typename V, typename... Vs>
-          MPARK_ALWAYS_INLINE static constexpr R dispatch_at(std::size_t index,
-                                                             F &&f,
-                                                             V &&v,
-                                                             Vs &&... vs) {
-            static_assert(lib::all<(lib::decay_t<V>::size() ==
-                                    lib::decay_t<Vs>::size())...>::value,
-                          "all of the variants must be the same size.");
+    template <std::size_t B, typename F, typename V, typename... Vs>
+    MPARK_ALWAYS_INLINE static constexpr R dispatch_at(
+        std::size_t index,
+        F&& f,
+        V&& v,
+        Vs&&... vs) {
+      static_assert(
+          lib::all<(
+              lib::decay_t<V>::size() == lib::decay_t<Vs>::size())...>::value,
+          "all of the variants must be the same size.");
 #define MPARK_DISPATCH_AT(I)                                               \
   dispatcher<(I < lib::decay_t<V>::size()), R>::template dispatch_case<I>( \
       lib::forward<F>(f), lib::forward<V>(v), lib::forward<Vs>(vs)...)
@@ -1329,365 +1397,408 @@ namespace c10 {
   dispatcher<(I < lib::decay_t<V>::size()), R>::template dispatch_at<I>( \
       index, lib::forward<F>(f), lib::forward<V>(v), lib::forward<Vs>(vs)...)
 
-            switch (index) {
-              case B + 0: return MPARK_DISPATCH_AT(B + 0);
-              case B + 1: return MPARK_DISPATCH_AT(B + 1);
-              case B + 2: return MPARK_DISPATCH_AT(B + 2);
-              case B + 3: return MPARK_DISPATCH_AT(B + 3);
-              case B + 4: return MPARK_DISPATCH_AT(B + 4);
-              case B + 5: return MPARK_DISPATCH_AT(B + 5);
-              case B + 6: return MPARK_DISPATCH_AT(B + 6);
-              case B + 7: return MPARK_DISPATCH_AT(B + 7);
-              case B + 8: return MPARK_DISPATCH_AT(B + 8);
-              case B + 9: return MPARK_DISPATCH_AT(B + 9);
-              case B + 10: return MPARK_DISPATCH_AT(B + 10);
-              case B + 11: return MPARK_DISPATCH_AT(B + 11);
-              case B + 12: return MPARK_DISPATCH_AT(B + 12);
-              case B + 13: return MPARK_DISPATCH_AT(B + 13);
-              case B + 14: return MPARK_DISPATCH_AT(B + 14);
-              case B + 15: return MPARK_DISPATCH_AT(B + 15);
-              case B + 16: return MPARK_DISPATCH_AT(B + 16);
-              case B + 17: return MPARK_DISPATCH_AT(B + 17);
-              case B + 18: return MPARK_DISPATCH_AT(B + 18);
-              case B + 19: return MPARK_DISPATCH_AT(B + 19);
-              case B + 20: return MPARK_DISPATCH_AT(B + 20);
-              case B + 21: return MPARK_DISPATCH_AT(B + 21);
-              case B + 22: return MPARK_DISPATCH_AT(B + 22);
-              case B + 23: return MPARK_DISPATCH_AT(B + 23);
-              case B + 24: return MPARK_DISPATCH_AT(B + 24);
-              case B + 25: return MPARK_DISPATCH_AT(B + 25);
-              case B + 26: return MPARK_DISPATCH_AT(B + 26);
-              case B + 27: return MPARK_DISPATCH_AT(B + 27);
-              case B + 28: return MPARK_DISPATCH_AT(B + 28);
-              case B + 29: return MPARK_DISPATCH_AT(B + 29);
-              case B + 30: return MPARK_DISPATCH_AT(B + 30);
-              case B + 31: return MPARK_DISPATCH_AT(B + 31);
-              default: return MPARK_DEFAULT(B + 32);
-            }
+      switch (index) {
+        case B + 0:
+          return MPARK_DISPATCH_AT(B + 0);
+        case B + 1:
+          return MPARK_DISPATCH_AT(B + 1);
+        case B + 2:
+          return MPARK_DISPATCH_AT(B + 2);
+        case B + 3:
+          return MPARK_DISPATCH_AT(B + 3);
+        case B + 4:
+          return MPARK_DISPATCH_AT(B + 4);
+        case B + 5:
+          return MPARK_DISPATCH_AT(B + 5);
+        case B + 6:
+          return MPARK_DISPATCH_AT(B + 6);
+        case B + 7:
+          return MPARK_DISPATCH_AT(B + 7);
+        case B + 8:
+          return MPARK_DISPATCH_AT(B + 8);
+        case B + 9:
+          return MPARK_DISPATCH_AT(B + 9);
+        case B + 10:
+          return MPARK_DISPATCH_AT(B + 10);
+        case B + 11:
+          return MPARK_DISPATCH_AT(B + 11);
+        case B + 12:
+          return MPARK_DISPATCH_AT(B + 12);
+        case B + 13:
+          return MPARK_DISPATCH_AT(B + 13);
+        case B + 14:
+          return MPARK_DISPATCH_AT(B + 14);
+        case B + 15:
+          return MPARK_DISPATCH_AT(B + 15);
+        case B + 16:
+          return MPARK_DISPATCH_AT(B + 16);
+        case B + 17:
+          return MPARK_DISPATCH_AT(B + 17);
+        case B + 18:
+          return MPARK_DISPATCH_AT(B + 18);
+        case B + 19:
+          return MPARK_DISPATCH_AT(B + 19);
+        case B + 20:
+          return MPARK_DISPATCH_AT(B + 20);
+        case B + 21:
+          return MPARK_DISPATCH_AT(B + 21);
+        case B + 22:
+          return MPARK_DISPATCH_AT(B + 22);
+        case B + 23:
+          return MPARK_DISPATCH_AT(B + 23);
+        case B + 24:
+          return MPARK_DISPATCH_AT(B + 24);
+        case B + 25:
+          return MPARK_DISPATCH_AT(B + 25);
+        case B + 26:
+          return MPARK_DISPATCH_AT(B + 26);
+        case B + 27:
+          return MPARK_DISPATCH_AT(B + 27);
+        case B + 28:
+          return MPARK_DISPATCH_AT(B + 28);
+        case B + 29:
+          return MPARK_DISPATCH_AT(B + 29);
+        case B + 30:
+          return MPARK_DISPATCH_AT(B + 30);
+        case B + 31:
+          return MPARK_DISPATCH_AT(B + 31);
+        default:
+          return MPARK_DEFAULT(B + 32);
+      }
 
 #undef MPARK_DEFAULT
 #undef MPARK_DISPATCH_AT
-          }
-        };
+    }
+  };
 #else
-        template <typename T>
-        inline static constexpr const T &at(const T &elem) noexcept {
-          return elem;
-        }
+  template <typename T>
+  inline static constexpr const T& at(const T& elem) noexcept {
+    return elem;
+  }
 
-        template <typename T, std::size_t N, typename... Is>
-        inline static constexpr const lib::remove_all_extents_t<T> &at(
-            const lib::array<T, N> &elems, std::size_t i, Is... is) noexcept {
-          return at(elems[i], is...);
-        }
+  template <typename T, std::size_t N, typename... Is>
+  inline static constexpr const lib::remove_all_extents_t<T>& at(
+      const lib::array<T, N>& elems,
+      std::size_t i,
+      Is... is) noexcept {
+    return at(elems[i], is...);
+  }
 
-        template <typename F, typename... Fs>
-        inline static constexpr lib::array<lib::decay_t<F>, sizeof...(Fs) + 1>
-        make_farray(F &&f, Fs &&... fs) {
-          return {{lib::forward<F>(f), lib::forward<Fs>(fs)...}};
-        }
+  template <typename F, typename... Fs>
+  inline static constexpr lib::array<lib::decay_t<F>, sizeof...(Fs) + 1>
+  make_farray(F&& f, Fs&&... fs) {
+    return {{lib::forward<F>(f), lib::forward<Fs>(fs)...}};
+  }
 
-        template <typename F, typename... Vs>
-        struct make_fmatrix_impl {
-
-          template <std::size_t... Is>
-          inline static constexpr dispatch_result_t<F, Vs...> dispatch(
-              F &&f, Vs &&... vs) {
-            using Expected = dispatch_result_t<F, Vs...>;
-            using Actual = decltype(lib::invoke(
-                lib::forward<F>(f),
-                access::base::get_alt<Is>(lib::forward<Vs>(vs))...));
-            return visit_return_type_check<Expected, Actual>::invoke(
-                lib::forward<F>(f),
-                access::base::get_alt<Is>(lib::forward<Vs>(vs))...);
-          }
+  template <typename F, typename... Vs>
+  struct make_fmatrix_impl {
+    template <std::size_t... Is>
+    inline static constexpr dispatch_result_t<F, Vs...> dispatch(
+        F&& f,
+        Vs&&... vs) {
+      using Expected = dispatch_result_t<F, Vs...>;
+      using Actual = decltype(lib::invoke(
+          lib::forward<F>(f),
+          access::base::get_alt<Is>(lib::forward<Vs>(vs))...));
+      return visit_return_type_check<Expected, Actual>::invoke(
+          lib::forward<F>(f),
+          access::base::get_alt<Is>(lib::forward<Vs>(vs))...);
+    }
 
 #ifdef MPARK_RETURN_TYPE_DEDUCTION
-          template <std::size_t... Is>
-          inline static constexpr auto impl(lib::index_sequence<Is...>) {
-            return &dispatch<Is...>;
-          }
+    template <std::size_t... Is>
+    inline static constexpr auto impl(lib::index_sequence<Is...>) {
+      return &dispatch<Is...>;
+    }
 
-          template <typename Is, std::size_t... Js, typename... Ls>
-          inline static constexpr auto impl(Is,
-                                            lib::index_sequence<Js...>,
-                                            Ls... ls) {
-            return make_farray(impl(lib::push_back_t<Is, Js>{}, ls...)...);
-          }
+    template <typename Is, std::size_t... Js, typename... Ls>
+    inline static constexpr auto impl(
+        Is,
+        lib::index_sequence<Js...>,
+        Ls... ls) {
+      return make_farray(impl(lib::push_back_t<Is, Js>{}, ls...)...);
+    }
 #else
-          template <typename...>
-          struct impl;
+    template <typename...>
+    struct impl;
 
-          template <std::size_t... Is>
-          struct impl<lib::index_sequence<Is...>> {
-            inline constexpr AUTO operator()() const
-              AUTO_RETURN(&dispatch<Is...>)
-          };
+    template <std::size_t... Is>
+    struct impl<lib::index_sequence<Is...>> {
+      inline constexpr AUTO operator()() const AUTO_RETURN(&dispatch<Is...>)
+    };
 
-          template <typename Is, std::size_t... Js, typename... Ls>
-          struct impl<Is, lib::index_sequence<Js...>, Ls...> {
-            inline constexpr AUTO operator()() const
-              AUTO_RETURN(
-                  make_farray(impl<lib::push_back_t<Is, Js>, Ls...>{}()...))
-          };
+    template <typename Is, std::size_t... Js, typename... Ls>
+    struct impl<Is, lib::index_sequence<Js...>, Ls...> {
+      inline constexpr AUTO operator()() const
+          AUTO_RETURN(make_farray(impl<lib::push_back_t<Is, Js>, Ls...>{}()...))
+    };
 #endif
-        };
+  };
 
 #ifdef MPARK_RETURN_TYPE_DEDUCTION
-        template <typename F, typename... Vs>
-        inline static constexpr auto make_fmatrix() {
-          return make_fmatrix_impl<F, Vs...>::impl(
-              lib::index_sequence<>{},
-              lib::make_index_sequence<lib::decay_t<Vs>::size()>{}...);
-        }
+  template <typename F, typename... Vs>
+  inline static constexpr auto make_fmatrix() {
+    return make_fmatrix_impl<F, Vs...>::impl(
+        lib::index_sequence<>{},
+        lib::make_index_sequence<lib::decay_t<Vs>::size()>{}...);
+  }
 #else
-        template <typename F, typename... Vs>
-        inline static constexpr AUTO make_fmatrix()
-          AUTO_RETURN(
-              typename make_fmatrix_impl<F, Vs...>::template impl<
+  template <typename F, typename... Vs>
+  inline static constexpr AUTO make_fmatrix()
+      AUTO_RETURN(typename make_fmatrix_impl<F, Vs...>::template impl<
                   lib::index_sequence<>,
                   lib::make_index_sequence<lib::decay_t<Vs>::size()>...>{}())
 #endif
 
-        template <typename F, typename... Vs>
-        struct make_fdiagonal_impl {
-          template <std::size_t I>
-          inline static constexpr dispatch_result_t<F, Vs...> dispatch(
-              F &&f, Vs &&... vs) {
-            using Expected = dispatch_result_t<F, Vs...>;
-            using Actual = decltype(
-                lib::invoke(lib::forward<F>(f),
-                            access::base::get_alt<I>(lib::forward<Vs>(vs))...));
-            return visit_return_type_check<Expected, Actual>::invoke(
-                lib::forward<F>(f),
-                access::base::get_alt<I>(lib::forward<Vs>(vs))...);
-          }
+  template <typename F, typename... Vs>
+  struct make_fdiagonal_impl {
+    template <std::size_t I>
+    inline static constexpr dispatch_result_t<F, Vs...> dispatch(
+        F&& f,
+        Vs&&... vs) {
+      using Expected = dispatch_result_t<F, Vs...>;
+      using Actual = decltype(lib::invoke(
+          lib::forward<F>(f),
+          access::base::get_alt<I>(lib::forward<Vs>(vs))...));
+      return visit_return_type_check<Expected, Actual>::invoke(
+          lib::forward<F>(f),
+          access::base::get_alt<I>(lib::forward<Vs>(vs))...);
+    }
 
-          template <std::size_t... Is>
-          inline static constexpr AUTO impl(lib::index_sequence<Is...>)
-            AUTO_RETURN(make_farray(&dispatch<Is>...))
-        };
+    template <std::size_t... Is>
+    inline static constexpr AUTO impl(lib::index_sequence<Is...>)
+        AUTO_RETURN(make_farray(&dispatch<Is>...))
+  };
 
-        template <typename F, typename V, typename... Vs>
-        inline static constexpr auto make_fdiagonal()
-            -> decltype(make_fdiagonal_impl<F, V, Vs...>::impl(
-                lib::make_index_sequence<lib::decay_t<V>::size()>{})) {
-          static_assert(lib::all<(lib::decay_t<V>::size() ==
-                                  lib::decay_t<Vs>::size())...>::value,
-                        "all of the variants must be the same size.");
-          return make_fdiagonal_impl<F, V, Vs...>::impl(
-              lib::make_index_sequence<lib::decay_t<V>::size()>{});
-        }
+  template <typename F, typename V, typename... Vs>
+  inline static constexpr auto make_fdiagonal()
+      -> decltype(make_fdiagonal_impl<F, V, Vs...>::impl(
+          lib::make_index_sequence<lib::decay_t<V>::size()>{})) {
+    static_assert(
+        lib::all<(
+            lib::decay_t<V>::size() == lib::decay_t<Vs>::size())...>::value,
+        "all of the variants must be the same size.");
+    return make_fdiagonal_impl<F, V, Vs...>::impl(
+        lib::make_index_sequence<lib::decay_t<V>::size()>{});
+  }
 #endif
-      };
+};
 
 #if !defined(MPARK_VARIANT_SWITCH_VISIT) && \
     (!defined(_MSC_VER) || _MSC_VER >= 1910)
-      template <typename F, typename... Vs>
-      using fmatrix_t = decltype(base::make_fmatrix<F, Vs...>());
+template <typename F, typename... Vs>
+using fmatrix_t = decltype(base::make_fmatrix<F, Vs...>());
 
-      template <typename F, typename... Vs>
-      struct fmatrix {
-        static constexpr fmatrix_t<F, Vs...> value =
-            base::make_fmatrix<F, Vs...>();
-      };
+template <typename F, typename... Vs>
+struct fmatrix {
+  static constexpr fmatrix_t<F, Vs...> value = base::make_fmatrix<F, Vs...>();
+};
 
-      template <typename F, typename... Vs>
-      constexpr fmatrix_t<F, Vs...> fmatrix<F, Vs...>::value;
+template <typename F, typename... Vs>
+constexpr fmatrix_t<F, Vs...> fmatrix<F, Vs...>::value;
 
-      template <typename F, typename... Vs>
-      using fdiagonal_t = decltype(base::make_fdiagonal<F, Vs...>());
+template <typename F, typename... Vs>
+using fdiagonal_t = decltype(base::make_fdiagonal<F, Vs...>());
 
-      template <typename F, typename... Vs>
-      struct fdiagonal {
-        static constexpr fdiagonal_t<F, Vs...> value =
-            base::make_fdiagonal<F, Vs...>();
-      };
+template <typename F, typename... Vs>
+struct fdiagonal {
+  static constexpr fdiagonal_t<F, Vs...> value =
+      base::make_fdiagonal<F, Vs...>();
+};
 
-      template <typename F, typename... Vs>
-      constexpr fdiagonal_t<F, Vs...> fdiagonal<F, Vs...>::value;
+template <typename F, typename... Vs>
+constexpr fdiagonal_t<F, Vs...> fdiagonal<F, Vs...>::value;
 #endif
 
-      struct alt {
-        template <typename Visitor, typename... Vs>
-        inline static constexpr DECLTYPE_AUTO visit_alt(Visitor &&visitor,
-                                                        Vs &&... vs)
+struct alt {
+  template <typename Visitor, typename... Vs>
+  inline static constexpr DECLTYPE_AUTO visit_alt(Visitor&& visitor, Vs&&... vs)
+#ifdef MPARK_VARIANT_SWITCH_VISIT
+      DECLTYPE_AUTO_RETURN(base::dispatcher<
+                           true,
+                           base::dispatch_result_t<
+                               Visitor,
+                               decltype(as_base(lib::forward<Vs>(vs)))...>>::
+                               template dispatch<0>(
+                                   lib::forward<Visitor>(visitor),
+                                   as_base(lib::forward<Vs>(vs))...))
+#elif !defined(_MSC_VER) || _MSC_VER >= 1910
+      DECLTYPE_AUTO_RETURN(base::at(
+          fmatrix<Visitor&&, decltype(as_base(lib::forward<Vs>(vs)))...>::value,
+          vs.index()...)(
+          lib::forward<Visitor>(visitor),
+          as_base(lib::forward<Vs>(vs))...))
+#else
+      DECLTYPE_AUTO_RETURN(base::at(
+          base::make_fmatrix<
+              Visitor&&,
+              decltype(as_base(lib::forward<Vs>(vs)))...>(),
+          vs.index()...)(
+          lib::forward<Visitor>(visitor),
+          as_base(lib::forward<Vs>(vs))...))
+#endif
+
+          template <typename Visitor, typename... Vs>
+          inline static constexpr DECLTYPE_AUTO
+      visit_alt_at(std::size_t index, Visitor&& visitor, Vs&&... vs)
 #ifdef MPARK_VARIANT_SWITCH_VISIT
           DECLTYPE_AUTO_RETURN(
               base::dispatcher<
                   true,
-                  base::dispatch_result_t<Visitor,
-                                          decltype(as_base(
-                                              lib::forward<Vs>(vs)))...>>::
-                  template dispatch<0>(lib::forward<Visitor>(visitor),
-                                       as_base(lib::forward<Vs>(vs))...))
+                  base::dispatch_result_t<
+                      Visitor,
+                      decltype(as_base(lib::forward<Vs>(vs)))...>>::
+                  template dispatch_at<0>(
+                      index,
+                      lib::forward<Visitor>(visitor),
+                      as_base(lib::forward<Vs>(vs))...))
 #elif !defined(_MSC_VER) || _MSC_VER >= 1910
           DECLTYPE_AUTO_RETURN(base::at(
-              fmatrix<Visitor &&,
-                      decltype(as_base(lib::forward<Vs>(vs)))...>::value,
-              vs.index()...)(lib::forward<Visitor>(visitor),
-                             as_base(lib::forward<Vs>(vs))...))
+              fdiagonal<Visitor&&, decltype(as_base(lib::forward<Vs>(vs)))...>::
+                  value,
+              index)(
+              lib::forward<Visitor>(visitor),
+              as_base(lib::forward<Vs>(vs))...))
 #else
           DECLTYPE_AUTO_RETURN(base::at(
-              base::make_fmatrix<Visitor &&,
-                      decltype(as_base(lib::forward<Vs>(vs)))...>(),
-              vs.index()...)(lib::forward<Visitor>(visitor),
-                             as_base(lib::forward<Vs>(vs))...))
+              base::make_fdiagonal<
+                  Visitor&&,
+                  decltype(as_base(lib::forward<Vs>(vs)))...>(),
+              index)(
+              lib::forward<Visitor>(visitor),
+              as_base(lib::forward<Vs>(vs))...))
 #endif
+};
 
-        template <typename Visitor, typename... Vs>
-        inline static constexpr DECLTYPE_AUTO visit_alt_at(std::size_t index,
-                                                           Visitor &&visitor,
-                                                           Vs &&... vs)
-#ifdef MPARK_VARIANT_SWITCH_VISIT
-          DECLTYPE_AUTO_RETURN(
-              base::dispatcher<
-                  true,
-                  base::dispatch_result_t<Visitor,
-                                          decltype(as_base(
-                                              lib::forward<Vs>(vs)))...>>::
-                  template dispatch_at<0>(index,
-                                          lib::forward<Visitor>(visitor),
-                                          as_base(lib::forward<Vs>(vs))...))
-#elif !defined(_MSC_VER) || _MSC_VER >= 1910
-          DECLTYPE_AUTO_RETURN(base::at(
-              fdiagonal<Visitor &&,
-                        decltype(as_base(lib::forward<Vs>(vs)))...>::value,
-              index)(lib::forward<Visitor>(visitor),
-                     as_base(lib::forward<Vs>(vs))...))
-#else
-          DECLTYPE_AUTO_RETURN(base::at(
-              base::make_fdiagonal<Visitor &&,
-                        decltype(as_base(lib::forward<Vs>(vs)))...>(),
-              index)(lib::forward<Visitor>(visitor),
-                     as_base(lib::forward<Vs>(vs))...))
-#endif
-      };
+struct variant {
+ private:
+  template <typename Visitor>
+  struct visitor {
+    template <typename... Values>
+    inline static constexpr bool does_not_handle() {
+      return lib::is_invocable<Visitor, Values...>::value;
+    }
+  };
 
-      struct variant {
-        private:
-        template <typename Visitor>
-        struct visitor {
-          template <typename... Values>
-          inline static constexpr bool does_not_handle() {
-            return lib::is_invocable<Visitor, Values...>::value;
-          }
-        };
+  template <typename Visitor, typename... Values>
+  struct visit_exhaustiveness_check {
+    static_assert(
+        visitor<Visitor>::template does_not_handle<Values...>(),
+        "`visit` requires the visitor to be exhaustive.");
 
-        template <typename Visitor, typename... Values>
-        struct visit_exhaustiveness_check {
-          static_assert(visitor<Visitor>::template does_not_handle<Values...>(),
-                        "`visit` requires the visitor to be exhaustive.");
+    inline static constexpr DECLTYPE_AUTO invoke(
+        Visitor&& visitor,
+        Values&&... values)
+        DECLTYPE_AUTO_RETURN(lib::invoke(
+            lib::forward<Visitor>(visitor),
+            lib::forward<Values>(values)...))
+  };
 
-          inline static constexpr DECLTYPE_AUTO invoke(Visitor &&visitor,
-                                                       Values &&... values)
-            DECLTYPE_AUTO_RETURN(lib::invoke(lib::forward<Visitor>(visitor),
-                                             lib::forward<Values>(values)...))
-        };
+  template <typename Visitor>
+  struct value_visitor {
+    Visitor&& visitor_;
 
-        template <typename Visitor>
-        struct value_visitor {
-          Visitor &&visitor_;
+    template <typename... Alts>
+    inline constexpr DECLTYPE_AUTO operator()(Alts&&... alts) const
+        DECLTYPE_AUTO_RETURN(visit_exhaustiveness_check<
+                             Visitor,
+                             decltype((lib::forward<Alts>(alts).value))...>::
+                                 invoke(
+                                     lib::forward<Visitor>(visitor_),
+                                     lib::forward<Alts>(alts).value...))
+  };
 
-          template <typename... Alts>
-          inline constexpr DECLTYPE_AUTO operator()(Alts &&... alts) const
-            DECLTYPE_AUTO_RETURN(
-                visit_exhaustiveness_check<
-                    Visitor,
-                    decltype((lib::forward<Alts>(alts).value))...>::
-                    invoke(lib::forward<Visitor>(visitor_),
-                           lib::forward<Alts>(alts).value...))
-        };
+  template <typename Visitor>
+  inline static constexpr AUTO make_value_visitor(Visitor&& visitor)
+      AUTO_RETURN(value_visitor<Visitor>{lib::forward<Visitor>(visitor)})
 
-        template <typename Visitor>
-        inline static constexpr AUTO make_value_visitor(Visitor &&visitor)
-          AUTO_RETURN(value_visitor<Visitor>{lib::forward<Visitor>(visitor)})
+          public
+      : template <typename Visitor, typename... Vs>
+        inline static constexpr DECLTYPE_AUTO
+        visit_alt(Visitor&& visitor, Vs&&... vs)
+            DECLTYPE_AUTO_RETURN(alt::visit_alt(
+                lib::forward<Visitor>(visitor),
+                lib::forward<Vs>(vs).impl_...))
 
-        public:
-        template <typename Visitor, typename... Vs>
-        inline static constexpr DECLTYPE_AUTO visit_alt(Visitor &&visitor,
-                                                        Vs &&... vs)
-          DECLTYPE_AUTO_RETURN(alt::visit_alt(lib::forward<Visitor>(visitor),
-                                              lib::forward<Vs>(vs).impl_...))
+                template <typename Visitor, typename... Vs>
+                inline static constexpr DECLTYPE_AUTO
+        visit_alt_at(std::size_t index, Visitor&& visitor, Vs&&... vs)
+            DECLTYPE_AUTO_RETURN(alt::visit_alt_at(
+                index,
+                lib::forward<Visitor>(visitor),
+                lib::forward<Vs>(vs).impl_...))
 
-        template <typename Visitor, typename... Vs>
-        inline static constexpr DECLTYPE_AUTO visit_alt_at(std::size_t index,
-                                                           Visitor &&visitor,
-                                                           Vs &&... vs)
-          DECLTYPE_AUTO_RETURN(
-              alt::visit_alt_at(index,
-                                lib::forward<Visitor>(visitor),
-                                lib::forward<Vs>(vs).impl_...))
+                template <typename Visitor, typename... Vs>
+                inline static constexpr DECLTYPE_AUTO
+        visit_value(Visitor&& visitor, Vs&&... vs)
+            DECLTYPE_AUTO_RETURN(visit_alt(
+                make_value_visitor(lib::forward<Visitor>(visitor)),
+                lib::forward<Vs>(vs)...))
 
-        template <typename Visitor, typename... Vs>
-        inline static constexpr DECLTYPE_AUTO visit_value(Visitor &&visitor,
-                                                          Vs &&... vs)
-          DECLTYPE_AUTO_RETURN(
-              visit_alt(make_value_visitor(lib::forward<Visitor>(visitor)),
-                        lib::forward<Vs>(vs)...))
+                template <typename Visitor, typename... Vs>
+                inline static constexpr DECLTYPE_AUTO
+        visit_value_at(std::size_t index, Visitor&& visitor, Vs&&... vs)
+            DECLTYPE_AUTO_RETURN(visit_alt_at(
+                index,
+                make_value_visitor(lib::forward<Visitor>(visitor)),
+                lib::forward<Vs>(vs)...))
+};
 
-        template <typename Visitor, typename... Vs>
-        inline static constexpr DECLTYPE_AUTO visit_value_at(std::size_t index,
-                                                             Visitor &&visitor,
-                                                             Vs &&... vs)
-          DECLTYPE_AUTO_RETURN(
-              visit_alt_at(index,
-                           make_value_visitor(lib::forward<Visitor>(visitor)),
-                           lib::forward<Vs>(vs)...))
-      };
+} // namespace visitation
 
-    }  // namespace visitation
-
-    template <std::size_t Index, typename T>
-    struct alt {
-      using value_type = T;
+template <std::size_t Index, typename T>
+struct alt {
+  using value_type = T;
 
 #ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable : 4244)
 #endif
-      template <typename... Args>
-      inline explicit constexpr alt(variant_in_place_t, Args &&... args)
-          : value(lib::forward<Args>(args)...) {}
+  template <typename... Args>
+  inline explicit constexpr alt(variant_in_place_t, Args&&... args)
+      : value(lib::forward<Args>(args)...) {}
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif
 
-      T value;
-    };
+  T value;
+};
 
-    template <Trait DestructibleTrait, std::size_t Index, typename... Ts>
-    union recursive_union;
+template <Trait DestructibleTrait, std::size_t Index, typename... Ts>
+union recursive_union;
 
-    template <Trait DestructibleTrait, std::size_t Index>
-    union recursive_union<DestructibleTrait, Index> {};
+template <Trait DestructibleTrait, std::size_t Index>
+union recursive_union<DestructibleTrait, Index> {};
 
 #define MPARK_VARIANT_RECURSIVE_UNION(destructible_trait, destructor)      \
   template <std::size_t Index, typename T, typename... Ts>                 \
   union recursive_union<destructible_trait, Index, T, Ts...> {             \
-    public:                                                                \
+   public:                                                                 \
     inline explicit constexpr recursive_union(valueless_t) noexcept        \
         : dummy_{} {}                                                      \
                                                                            \
     template <typename... Args>                                            \
-    inline explicit constexpr recursive_union(in_place_index_t<0>,         \
-                                              Args &&... args)             \
-        : head_(variant_in_place_t{}, lib::forward<Args>(args)...) {}              \
+    inline explicit constexpr recursive_union(                             \
+        in_place_index_t<0>,                                               \
+        Args&&... args)                                                    \
+        : head_(variant_in_place_t{}, lib::forward<Args>(args)...) {}      \
                                                                            \
     template <std::size_t I, typename... Args>                             \
-    inline explicit constexpr recursive_union(in_place_index_t<I>,         \
-                                              Args &&... args)             \
+    inline explicit constexpr recursive_union(                             \
+        in_place_index_t<I>,                                               \
+        Args&&... args)                                                    \
         : tail_(in_place_index_t<I - 1>{}, lib::forward<Args>(args)...) {} \
                                                                            \
-    recursive_union(const recursive_union &) = default;                    \
-    recursive_union(recursive_union &&) = default;                         \
+    recursive_union(const recursive_union&) = default;                     \
+    recursive_union(recursive_union&&) = default;                          \
                                                                            \
     destructor                                                             \
                                                                            \
-    recursive_union &operator=(const recursive_union &) = default;         \
-    recursive_union &operator=(recursive_union &&) = default;              \
+        recursive_union&                                                   \
+        operator=(const recursive_union&) = default;                       \
+    recursive_union& operator=(recursive_union&&) = default;               \
                                                                            \
-    private:                                                               \
+   private:                                                                \
     char dummy_;                                                           \
     alt<Index, T> head_;                                                   \
     recursive_union<destructible_trait, Index + 1, Ts...> tail_;           \
@@ -1695,81 +1806,98 @@ namespace c10 {
     friend struct access::recursive_union;                                 \
   }
 
-    MPARK_VARIANT_RECURSIVE_UNION(Trait::TriviallyAvailable,
-                                  ~recursive_union() = default;);
-    MPARK_VARIANT_RECURSIVE_UNION(Trait::Available,
-                                  ~recursive_union() {});
-    MPARK_VARIANT_RECURSIVE_UNION(Trait::Unavailable,
-                                  ~recursive_union() = delete;);
+MPARK_VARIANT_RECURSIVE_UNION(Trait::TriviallyAvailable,
+                              ~recursive_union() = default;);
+MPARK_VARIANT_RECURSIVE_UNION(Trait::Available, ~recursive_union(){});
+MPARK_VARIANT_RECURSIVE_UNION(Trait::Unavailable, ~recursive_union() = delete;);
 
 #undef MPARK_VARIANT_RECURSIVE_UNION
 
-    using index_t = unsigned int;
+using index_t = unsigned int;
 
-    template <Trait DestructibleTrait, typename... Ts>
-    class base {
-      public:
-      inline explicit constexpr base(valueless_t tag) noexcept
-          : data_(tag), index_(static_cast<index_t>(-1)) {}
+template <Trait DestructibleTrait, typename... Ts>
+class base {
+ public:
+  inline explicit constexpr base(valueless_t tag) noexcept
+      : data_(tag), index_(static_cast<index_t>(-1)) {}
 
-      template <std::size_t I, typename... Args>
-      inline explicit constexpr base(in_place_index_t<I>, Args &&... args)
-          : data_(in_place_index_t<I>{}, lib::forward<Args>(args)...),
-            index_(I) {}
+  template <std::size_t I, typename... Args>
+  inline explicit constexpr base(in_place_index_t<I>, Args&&... args)
+      : data_(in_place_index_t<I>{}, lib::forward<Args>(args)...), index_(I) {}
 
-      inline constexpr bool valueless_by_exception() const noexcept {
-        return index_ == static_cast<index_t>(-1);
-      }
+  inline constexpr bool valueless_by_exception() const noexcept {
+    return index_ == static_cast<index_t>(-1);
+  }
 
-      inline constexpr std::size_t index() const noexcept {
-        return valueless_by_exception() ? variant_npos : index_;
-      }
+  inline constexpr std::size_t index() const noexcept {
+    return valueless_by_exception() ? variant_npos : index_;
+  }
 
-      protected:
-      using data_t = recursive_union<DestructibleTrait, 0, Ts...>;
+ protected:
+  using data_t = recursive_union<DestructibleTrait, 0, Ts...>;
 
-      friend inline constexpr base &as_base(base &b) { return b; }
-      friend inline constexpr const base &as_base(const base &b) { return b; }
-      friend inline constexpr base &&as_base(base &&b) { return lib::move(b); }
-      friend inline constexpr const base &&as_base(const base &&b) { return lib::move(b); }
+  friend inline constexpr base& as_base(base& b) {
+    return b;
+  }
+  friend inline constexpr const base& as_base(const base& b) {
+    return b;
+  }
+  friend inline constexpr base&& as_base(base&& b) {
+    return lib::move(b);
+  }
+  friend inline constexpr const base&& as_base(const base&& b) {
+    return lib::move(b);
+  }
 
-      friend inline constexpr data_t &data(base &b) { return b.data_; }
-      friend inline constexpr const data_t &data(const base &b) { return b.data_; }
-      friend inline constexpr data_t &&data(base &&b) { return lib::move(b).data_; }
-      friend inline constexpr const data_t &&data(const base &&b) { return lib::move(b).data_; }
+  friend inline constexpr data_t& data(base& b) {
+    return b.data_;
+  }
+  friend inline constexpr const data_t& data(const base& b) {
+    return b.data_;
+  }
+  friend inline constexpr data_t&& data(base&& b) {
+    return lib::move(b).data_;
+  }
+  friend inline constexpr const data_t&& data(const base&& b) {
+    return lib::move(b).data_;
+  }
 
-      inline static constexpr std::size_t size() { return sizeof...(Ts); }
+  inline static constexpr std::size_t size() {
+    return sizeof...(Ts);
+  }
 
-      data_t data_;
-      index_t index_;
+  data_t data_;
+  index_t index_;
 
-      friend struct access::base;
-      friend struct visitation::base;
-    };
+  friend struct access::base;
+  friend struct visitation::base;
+};
 
-    struct dtor {
+struct dtor {
 #ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable : 4100)
 #endif
-      template <typename Alt>
-      inline void operator()(Alt &alt) const noexcept { alt.~Alt(); }
+  template <typename Alt>
+  inline void operator()(Alt& alt) const noexcept {
+    alt.~Alt();
+  }
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif
-    };
+};
 
 #if !defined(_MSC_VER) || _MSC_VER >= 1910
 #define MPARK_INHERITING_CTOR(type, base) using base::base;
 #else
-#define MPARK_INHERITING_CTOR(type, base)         \
-  template <typename... Args>                     \
-  inline explicit constexpr type(Args &&... args) \
+#define MPARK_INHERITING_CTOR(type, base)        \
+  template <typename... Args>                    \
+  inline explicit constexpr type(Args&&... args) \
       : base(lib::forward<Args>(args)...) {}
 #endif
 
-    template <typename Traits, Trait = Traits::destructible_trait>
-    class destructor;
+template <typename Traits, Trait = Traits::destructible_trait>
+class destructor;
 
 #define MPARK_VARIANT_DESTRUCTOR(destructible_trait, definition, destroy) \
   template <typename... Ts>                                               \
@@ -1777,94 +1905,88 @@ namespace c10 {
       : public base<destructible_trait, Ts...> {                          \
     using super = base<destructible_trait, Ts...>;                        \
                                                                           \
-    public:                                                               \
+   public:                                                                \
     MPARK_INHERITING_CTOR(destructor, super)                              \
     using super::operator=;                                               \
                                                                           \
-    destructor(const destructor &) = default;                             \
-    destructor(destructor &&) = default;                                  \
-    definition                                                            \
-    destructor &operator=(const destructor &) = default;                  \
-    destructor &operator=(destructor &&) = default;                       \
+    destructor(const destructor&) = default;                              \
+    destructor(destructor&&) = default;                                   \
+    definition destructor& operator=(const destructor&) = default;        \
+    destructor& operator=(destructor&&) = default;                        \
                                                                           \
-    protected:                                                            \
+   protected:                                                             \
     destroy                                                               \
   }
 
-    MPARK_VARIANT_DESTRUCTOR(
-        Trait::TriviallyAvailable,
-        ~destructor() = default;,
-        inline void destroy() noexcept {
-          this->index_ = static_cast<index_t>(-1);
-        });
+MPARK_VARIANT_DESTRUCTOR(Trait::TriviallyAvailable, ~destructor() = default;
+                         , inline void destroy() noexcept {
+                           this->index_ = static_cast<index_t>(-1);
+                         });
 
-    MPARK_VARIANT_DESTRUCTOR(
-        Trait::Available,
-        ~destructor() { destroy(); },
-        inline void destroy() noexcept {
-          if (!this->valueless_by_exception()) {
-            visitation::alt::visit_alt(dtor{}, *this);
-          }
-          this->index_ = static_cast<index_t>(-1);
-        });
+MPARK_VARIANT_DESTRUCTOR(
+    Trait::Available,
+    ~destructor() { destroy(); },
+    inline void destroy() noexcept {
+      if (!this->valueless_by_exception()) {
+        visitation::alt::visit_alt(dtor{}, *this);
+      }
+      this->index_ = static_cast<index_t>(-1);
+    });
 
-    MPARK_VARIANT_DESTRUCTOR(
-        Trait::Unavailable,
-        ~destructor() = delete;,
-        inline void destroy() noexcept = delete;);
+MPARK_VARIANT_DESTRUCTOR(Trait::Unavailable, ~destructor() = delete;
+                         , inline void destroy() noexcept = delete;);
 
 #undef MPARK_VARIANT_DESTRUCTOR
 
-    template <typename Traits>
-    class constructor : public destructor<Traits> {
-      using super = destructor<Traits>;
+template <typename Traits>
+class constructor : public destructor<Traits> {
+  using super = destructor<Traits>;
 
-      public:
-      MPARK_INHERITING_CTOR(constructor, super)
-      using super::operator=;
+ public:
+  MPARK_INHERITING_CTOR(constructor, super)
+  using super::operator=;
 
-      protected:
+ protected:
 #ifndef MPARK_GENERIC_LAMBDAS
-      struct ctor {
-        template <typename LhsAlt, typename RhsAlt>
-        inline void operator()(LhsAlt &lhs_alt, RhsAlt &&rhs_alt) const {
-          constructor::construct_alt(lhs_alt,
-                                     lib::forward<RhsAlt>(rhs_alt).value);
-        }
-      };
+  struct ctor {
+    template <typename LhsAlt, typename RhsAlt>
+    inline void operator()(LhsAlt& lhs_alt, RhsAlt&& rhs_alt) const {
+      constructor::construct_alt(lhs_alt, lib::forward<RhsAlt>(rhs_alt).value);
+    }
+  };
 #endif
 
-      template <std::size_t I, typename T, typename... Args>
-      inline static T &construct_alt(alt<I, T> &a, Args &&... args) {
-        auto *result = ::new (static_cast<void *>(lib::addressof(a)))
-            alt<I, T>(variant_in_place_t{}, lib::forward<Args>(args)...);
-        return result->value;
-      }
+  template <std::size_t I, typename T, typename... Args>
+  inline static T& construct_alt(alt<I, T>& a, Args&&... args) {
+    auto* result = ::new (static_cast<void*>(lib::addressof(a)))
+        alt<I, T>(variant_in_place_t{}, lib::forward<Args>(args)...);
+    return result->value;
+  }
 
-      template <typename Rhs>
-      inline static void generic_construct(constructor &lhs, Rhs &&rhs) {
-        lhs.destroy();
-        if (!rhs.valueless_by_exception()) {
-          visitation::alt::visit_alt_at(
-              rhs.index(),
+  template <typename Rhs>
+  inline static void generic_construct(constructor& lhs, Rhs&& rhs) {
+    lhs.destroy();
+    if (!rhs.valueless_by_exception()) {
+      visitation::alt::visit_alt_at(
+          rhs.index(),
 #ifdef MPARK_GENERIC_LAMBDAS
-              [](auto &lhs_alt, auto &&rhs_alt) {
-                constructor::construct_alt(
-                    lhs_alt, lib::forward<decltype(rhs_alt)>(rhs_alt).value);
-              }
+          [](auto& lhs_alt, auto&& rhs_alt) {
+            constructor::construct_alt(
+                lhs_alt, lib::forward<decltype(rhs_alt)>(rhs_alt).value);
+          }
 #else
-              ctor{}
+          ctor {}
 #endif
-              ,
-              lhs,
-              lib::forward<Rhs>(rhs));
-          lhs.index_ = rhs.index_;
-        }
-      }
-    };
+          ,
+          lhs,
+          lib::forward<Rhs>(rhs));
+      lhs.index_ = rhs.index_;
+    }
+  }
+};
 
-    template <typename Traits, Trait = Traits::move_constructible_trait>
-    class move_constructor;
+template <typename Traits, Trait = Traits::move_constructible_trait>
+class move_constructor;
 
 #define MPARK_VARIANT_MOVE_CONSTRUCTOR(move_constructible_trait, definition) \
   template <typename... Ts>                                                  \
@@ -1872,37 +1994,35 @@ namespace c10 {
       : public constructor<traits<Ts...>> {                                  \
     using super = constructor<traits<Ts...>>;                                \
                                                                              \
-    public:                                                                  \
+   public:                                                                   \
     MPARK_INHERITING_CTOR(move_constructor, super)                           \
     using super::operator=;                                                  \
                                                                              \
-    move_constructor(const move_constructor &) = default;                    \
-    definition                                                               \
-    ~move_constructor() = default;                                           \
-    move_constructor &operator=(const move_constructor &) = default;         \
-    move_constructor &operator=(move_constructor &&) = default;              \
+    move_constructor(const move_constructor&) = default;                     \
+    definition ~move_constructor() = default;                                \
+    move_constructor& operator=(const move_constructor&) = default;          \
+    move_constructor& operator=(move_constructor&&) = default;               \
   }
 
-    MPARK_VARIANT_MOVE_CONSTRUCTOR(
-        Trait::TriviallyAvailable,
-        move_constructor(move_constructor &&that) = default;);
+MPARK_VARIANT_MOVE_CONSTRUCTOR(
+    Trait::TriviallyAvailable,
+    move_constructor(move_constructor&& that) = default;);
 
-    MPARK_VARIANT_MOVE_CONSTRUCTOR(
-        Trait::Available,
-        move_constructor(move_constructor &&that) noexcept(
-            lib::all<std::is_nothrow_move_constructible<Ts>::value...>::value)
-            : move_constructor(valueless_t{}) {
-          this->generic_construct(*this, lib::move(that));
-        });
+MPARK_VARIANT_MOVE_CONSTRUCTOR(
+    Trait::Available,
+    move_constructor(move_constructor&& that) noexcept(
+        lib::all<std::is_nothrow_move_constructible<Ts>::value...>::value)
+    : move_constructor(valueless_t{}) {
+      this->generic_construct(*this, lib::move(that));
+    });
 
-    MPARK_VARIANT_MOVE_CONSTRUCTOR(
-        Trait::Unavailable,
-        move_constructor(move_constructor &&) = delete;);
+MPARK_VARIANT_MOVE_CONSTRUCTOR(Trait::Unavailable,
+                               move_constructor(move_constructor&&) = delete;);
 
 #undef MPARK_VARIANT_MOVE_CONSTRUCTOR
 
-    template <typename Traits, Trait = Traits::copy_constructible_trait>
-    class copy_constructor;
+template <typename Traits, Trait = Traits::copy_constructible_trait>
+class copy_constructor;
 
 #define MPARK_VARIANT_COPY_CONSTRUCTOR(copy_constructible_trait, definition) \
   template <typename... Ts>                                                  \
@@ -1910,119 +2030,117 @@ namespace c10 {
       : public move_constructor<traits<Ts...>> {                             \
     using super = move_constructor<traits<Ts...>>;                           \
                                                                              \
-    public:                                                                  \
+   public:                                                                   \
     MPARK_INHERITING_CTOR(copy_constructor, super)                           \
     using super::operator=;                                                  \
                                                                              \
-    definition                                                               \
-    copy_constructor(copy_constructor &&) = default;                         \
+    definition copy_constructor(copy_constructor&&) = default;               \
     ~copy_constructor() = default;                                           \
-    copy_constructor &operator=(const copy_constructor &) = default;         \
-    copy_constructor &operator=(copy_constructor &&) = default;              \
+    copy_constructor& operator=(const copy_constructor&) = default;          \
+    copy_constructor& operator=(copy_constructor&&) = default;               \
   }
 
-    MPARK_VARIANT_COPY_CONSTRUCTOR(
-        Trait::TriviallyAvailable,
-        copy_constructor(const copy_constructor &that) = default;);
+MPARK_VARIANT_COPY_CONSTRUCTOR(
+    Trait::TriviallyAvailable,
+    copy_constructor(const copy_constructor& that) = default;);
 
-    MPARK_VARIANT_COPY_CONSTRUCTOR(
-        Trait::Available,
-        copy_constructor(const copy_constructor &that)
-            : copy_constructor(valueless_t{}) {
-          this->generic_construct(*this, that);
-        });
+MPARK_VARIANT_COPY_CONSTRUCTOR(Trait::Available,
+                               copy_constructor(const copy_constructor& that)
+                               : copy_constructor(valueless_t{}) {
+                                 this->generic_construct(*this, that);
+                               });
 
-    MPARK_VARIANT_COPY_CONSTRUCTOR(
-        Trait::Unavailable,
-        copy_constructor(const copy_constructor &) = delete;);
+MPARK_VARIANT_COPY_CONSTRUCTOR(
+    Trait::Unavailable, copy_constructor(const copy_constructor&) = delete;);
 
 #undef MPARK_VARIANT_COPY_CONSTRUCTOR
 
-    template <typename Traits>
-    class assignment : public copy_constructor<Traits> {
-      using super = copy_constructor<Traits>;
+template <typename Traits>
+class assignment : public copy_constructor<Traits> {
+  using super = copy_constructor<Traits>;
 
-      public:
-      MPARK_INHERITING_CTOR(assignment, super)
-      using super::operator=;
+ public:
+  MPARK_INHERITING_CTOR(assignment, super)
+  using super::operator=;
 
-      template <std::size_t I, typename... Args>
-      inline /* auto & */ auto emplace(Args &&... args)
-          -> decltype(this->construct_alt(access::base::get_alt<I>(*this),
-                                          lib::forward<Args>(args)...)) {
-        this->destroy();
-        auto &result = this->construct_alt(access::base::get_alt<I>(*this),
-                                           lib::forward<Args>(args)...);
-        this->index_ = I;
-        return result;
-      }
+  template <std::size_t I, typename... Args>
+  inline /* auto & */ auto emplace(Args&&... args)
+      -> decltype(this->construct_alt(
+          access::base::get_alt<I>(*this),
+          lib::forward<Args>(args)...)) {
+    this->destroy();
+    auto& result = this->construct_alt(
+        access::base::get_alt<I>(*this), lib::forward<Args>(args)...);
+    this->index_ = I;
+    return result;
+  }
 
-      protected:
+ protected:
 #ifndef MPARK_GENERIC_LAMBDAS
-      template <typename That>
-      struct assigner {
-        template <typename ThisAlt, typename ThatAlt>
-        inline void operator()(ThisAlt &this_alt, ThatAlt &&that_alt) const {
-          self->assign_alt(this_alt, lib::forward<ThatAlt>(that_alt).value);
-        }
-        assignment *self;
-      };
+  template <typename That>
+  struct assigner {
+    template <typename ThisAlt, typename ThatAlt>
+    inline void operator()(ThisAlt& this_alt, ThatAlt&& that_alt) const {
+      self->assign_alt(this_alt, lib::forward<ThatAlt>(that_alt).value);
+    }
+    assignment* self;
+  };
 #endif
 
-      template <std::size_t I, typename T, typename Arg>
-      inline void assign_alt(alt<I, T> &a, Arg &&arg) {
-        if (this->index() == I) {
+  template <std::size_t I, typename T, typename Arg>
+  inline void assign_alt(alt<I, T>& a, Arg&& arg) {
+    if (this->index() == I) {
 #ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable : 4244)
 #endif
-          a.value = lib::forward<Arg>(arg);
+      a.value = lib::forward<Arg>(arg);
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif
-        } else {
-          struct {
-            void operator()(std::true_type) const {
-              this_->emplace<I>(lib::forward<Arg>(arg_));
-            }
-            void operator()(std::false_type) const {
-              this_->emplace<I>(T(lib::forward<Arg>(arg_)));
-            }
-            assignment *this_;
-            Arg &&arg_;
-          } impl{this, lib::forward<Arg>(arg)};
-          impl(lib::bool_constant<
-                   std::is_nothrow_constructible<T, Arg>::value ||
-                   !std::is_nothrow_move_constructible<T>::value>{});
+    } else {
+      struct {
+        void operator()(std::true_type) const {
+          this_->emplace<I>(lib::forward<Arg>(arg_));
         }
-      }
+        void operator()(std::false_type) const {
+          this_->emplace<I>(T(lib::forward<Arg>(arg_)));
+        }
+        assignment* this_;
+        Arg&& arg_;
+      } impl{this, lib::forward<Arg>(arg)};
+      impl(
+          lib::bool_constant < std::is_nothrow_constructible<T, Arg>::value ||
+          !std::is_nothrow_move_constructible<T>::value > {});
+    }
+  }
 
-      template <typename That>
-      inline void generic_assign(That &&that) {
-        if (this->valueless_by_exception() && that.valueless_by_exception()) {
-          // do nothing.
-        } else if (that.valueless_by_exception()) {
-          this->destroy();
-        } else {
-          visitation::alt::visit_alt_at(
-              that.index(),
+  template <typename That>
+  inline void generic_assign(That&& that) {
+    if (this->valueless_by_exception() && that.valueless_by_exception()) {
+      // do nothing.
+    } else if (that.valueless_by_exception()) {
+      this->destroy();
+    } else {
+      visitation::alt::visit_alt_at(
+          that.index(),
 #ifdef MPARK_GENERIC_LAMBDAS
-              [this](auto &this_alt, auto &&that_alt) {
-                this->assign_alt(
-                    this_alt, lib::forward<decltype(that_alt)>(that_alt).value);
-              }
+          [this](auto& this_alt, auto&& that_alt) {
+            this->assign_alt(
+                this_alt, lib::forward<decltype(that_alt)>(that_alt).value);
+          }
 #else
-              assigner<That>{this}
+          assigner<That> { this }
 #endif
-              ,
-              *this,
-              lib::forward<That>(that));
-        }
-      }
-    };
+          ,
+          *this,
+          lib::forward<That>(that));
+    }
+  }
+};
 
-    template <typename Traits, Trait = Traits::move_assignable_trait>
-    class move_assignment;
+template <typename Traits, Trait = Traits::move_assignable_trait>
+class move_assignment;
 
 #define MPARK_VARIANT_MOVE_ASSIGNMENT(move_assignable_trait, definition) \
   template <typename... Ts>                                              \
@@ -2030,39 +2148,40 @@ namespace c10 {
       : public assignment<traits<Ts...>> {                               \
     using super = assignment<traits<Ts...>>;                             \
                                                                          \
-    public:                                                              \
+   public:                                                               \
     MPARK_INHERITING_CTOR(move_assignment, super)                        \
     using super::operator=;                                              \
                                                                          \
-    move_assignment(const move_assignment &) = default;                  \
-    move_assignment(move_assignment &&) = default;                       \
+    move_assignment(const move_assignment&) = default;                   \
+    move_assignment(move_assignment&&) = default;                        \
     ~move_assignment() = default;                                        \
-    move_assignment &operator=(const move_assignment &) = default;       \
+    move_assignment& operator=(const move_assignment&) = default;        \
     definition                                                           \
   }
 
-    MPARK_VARIANT_MOVE_ASSIGNMENT(
-        Trait::TriviallyAvailable,
-        move_assignment &operator=(move_assignment &&that) = default;);
+MPARK_VARIANT_MOVE_ASSIGNMENT(
+    Trait::TriviallyAvailable,
+    move_assignment& operator=(move_assignment&& that) = default;);
 
-    MPARK_VARIANT_MOVE_ASSIGNMENT(
-        Trait::Available,
-        move_assignment &
-        operator=(move_assignment &&that) noexcept(
-            lib::all<(std::is_nothrow_move_constructible<Ts>::value &&
-                      std::is_nothrow_move_assignable<Ts>::value)...>::value) {
-          this->generic_assign(lib::move(that));
-          return *this;
-        });
+MPARK_VARIANT_MOVE_ASSIGNMENT(
+    Trait::Available,
+    move_assignment&
+    operator=(move_assignment&& that) noexcept(
+        lib::all<
+            (std::is_nothrow_move_constructible<Ts>::value &&
+             std::is_nothrow_move_assignable<Ts>::value)...>::value) {
+      this->generic_assign(lib::move(that));
+      return *this;
+    });
 
-    MPARK_VARIANT_MOVE_ASSIGNMENT(
-        Trait::Unavailable,
-        move_assignment &operator=(move_assignment &&) = delete;);
+MPARK_VARIANT_MOVE_ASSIGNMENT(
+    Trait::Unavailable,
+    move_assignment& operator=(move_assignment&&) = delete;);
 
 #undef MPARK_VARIANT_MOVE_ASSIGNMENT
 
-    template <typename Traits, Trait = Traits::copy_assignable_trait>
-    class copy_assignment;
+template <typename Traits, Trait = Traits::copy_assignable_trait>
+class copy_assignment;
 
 #define MPARK_VARIANT_COPY_ASSIGNMENT(copy_assignable_trait, definition) \
   template <typename... Ts>                                              \
@@ -2070,682 +2189,706 @@ namespace c10 {
       : public move_assignment<traits<Ts...>> {                          \
     using super = move_assignment<traits<Ts...>>;                        \
                                                                          \
-    public:                                                              \
+   public:                                                               \
     MPARK_INHERITING_CTOR(copy_assignment, super)                        \
     using super::operator=;                                              \
                                                                          \
-    copy_assignment(const copy_assignment &) = default;                  \
-    copy_assignment(copy_assignment &&) = default;                       \
+    copy_assignment(const copy_assignment&) = default;                   \
+    copy_assignment(copy_assignment&&) = default;                        \
     ~copy_assignment() = default;                                        \
-    definition                                                           \
-    copy_assignment &operator=(copy_assignment &&) = default;            \
+    definition copy_assignment& operator=(copy_assignment&&) = default;  \
   }
 
-    MPARK_VARIANT_COPY_ASSIGNMENT(
-        Trait::TriviallyAvailable,
-        copy_assignment &operator=(const copy_assignment &that) = default;);
+MPARK_VARIANT_COPY_ASSIGNMENT(
+    Trait::TriviallyAvailable,
+    copy_assignment& operator=(const copy_assignment& that) = default;);
 
-    MPARK_VARIANT_COPY_ASSIGNMENT(
-        Trait::Available,
-        copy_assignment &operator=(const copy_assignment &that) {
-          this->generic_assign(that);
-          return *this;
-        });
+MPARK_VARIANT_COPY_ASSIGNMENT(
+    Trait::Available,
+    copy_assignment&
+    operator=(const copy_assignment& that) {
+      this->generic_assign(that);
+      return *this;
+    });
 
-    MPARK_VARIANT_COPY_ASSIGNMENT(
-        Trait::Unavailable,
-        copy_assignment &operator=(const copy_assignment &) = delete;);
+MPARK_VARIANT_COPY_ASSIGNMENT(
+    Trait::Unavailable,
+    copy_assignment& operator=(const copy_assignment&) = delete;);
 
 #undef MPARK_VARIANT_COPY_ASSIGNMENT
 
-    template <typename... Ts>
-    class impl : public copy_assignment<traits<Ts...>> {
-      using super = copy_assignment<traits<Ts...>>;
+template <typename... Ts>
+class impl : public copy_assignment<traits<Ts...>> {
+  using super = copy_assignment<traits<Ts...>>;
 
-      public:
-      MPARK_INHERITING_CTOR(impl, super)
-      using super::operator=;
+ public:
+  MPARK_INHERITING_CTOR(impl, super)
+  using super::operator=;
 
-      template <std::size_t I, typename Arg>
-      inline void assign(Arg &&arg) {
-        this->assign_alt(access::base::get_alt<I>(*this),
-                         lib::forward<Arg>(arg));
-      }
+  template <std::size_t I, typename Arg>
+  inline void assign(Arg&& arg) {
+    this->assign_alt(access::base::get_alt<I>(*this), lib::forward<Arg>(arg));
+  }
 
-      inline void swap(impl &that) {
-        if (this->valueless_by_exception() && that.valueless_by_exception()) {
-          // do nothing.
-        } else if (this->index() == that.index()) {
-          visitation::alt::visit_alt_at(this->index(),
+  inline void swap(impl& that) {
+    if (this->valueless_by_exception() && that.valueless_by_exception()) {
+      // do nothing.
+    } else if (this->index() == that.index()) {
+      visitation::alt::visit_alt_at(
+          this->index(),
 #ifdef MPARK_GENERIC_LAMBDAS
-                                        [](auto &this_alt, auto &that_alt) {
-                                          using std::swap;
-                                          swap(this_alt.value,
-                                               that_alt.value);
-                                        }
-#else
-                                        swapper{}
-#endif
-                                        ,
-                                        *this,
-                                        that);
-        } else {
-          impl *lhs = this;
-          impl *rhs = lib::addressof(that);
-          if (lhs->move_nothrow() && !rhs->move_nothrow()) {
-            std::swap(lhs, rhs);
+          [](auto& this_alt, auto& that_alt) {
+            using std::swap;
+            swap(this_alt.value, that_alt.value);
           }
-          impl tmp(lib::move(*rhs));
+#else
+          swapper {}
+#endif
+          ,
+          *this,
+          that);
+    } else {
+      impl* lhs = this;
+      impl* rhs = lib::addressof(that);
+      if (lhs->move_nothrow() && !rhs->move_nothrow()) {
+        std::swap(lhs, rhs);
+      }
+      impl tmp(lib::move(*rhs));
 #ifdef MPARK_EXCEPTIONS
-          // EXTENSION: When the move construction of `lhs` into `rhs` throws
-          // and `tmp` is nothrow move constructible then we move `tmp` back
-          // into `rhs` and provide the strong exception safety guarantee.
-          try {
-            this->generic_construct(*rhs, lib::move(*lhs));
-          } catch (...) {
-            if (tmp.move_nothrow()) {
-              this->generic_construct(*rhs, lib::move(tmp));
-            }
-            throw;
-          }
+      // EXTENSION: When the move construction of `lhs` into `rhs` throws
+      // and `tmp` is nothrow move constructible then we move `tmp` back
+      // into `rhs` and provide the strong exception safety guarantee.
+      try {
+        this->generic_construct(*rhs, lib::move(*lhs));
+      } catch (...) {
+        if (tmp.move_nothrow()) {
+          this->generic_construct(*rhs, lib::move(tmp));
+        }
+        throw;
+      }
 #else
-          this->generic_construct(*rhs, lib::move(*lhs));
+      this->generic_construct(*rhs, lib::move(*lhs));
 #endif
-          this->generic_construct(*lhs, lib::move(tmp));
-        }
-      }
+      this->generic_construct(*lhs, lib::move(tmp));
+    }
+  }
 
-      private:
+ private:
 #ifndef MPARK_GENERIC_LAMBDAS
-      struct swapper {
-        template <typename ThisAlt, typename ThatAlt>
-        inline void operator()(ThisAlt &this_alt, ThatAlt &that_alt) const {
-          using std::swap;
-          swap(this_alt.value, that_alt.value);
-        }
-      };
+  struct swapper {
+    template <typename ThisAlt, typename ThatAlt>
+    inline void operator()(ThisAlt& this_alt, ThatAlt& that_alt) const {
+      using std::swap;
+      swap(this_alt.value, that_alt.value);
+    }
+  };
 #endif
 
-      inline constexpr bool move_nothrow() const {
-        return this->valueless_by_exception() ||
-               lib::array<bool, sizeof...(Ts)>{
-                   {std::is_nothrow_move_constructible<Ts>::value...}
-               }[this->index()];
-      }
-    };
+  inline constexpr bool move_nothrow() const {
+    return this->valueless_by_exception() ||
+        lib::array<bool, sizeof...(Ts)>{
+            {std::is_nothrow_move_constructible<Ts>::value...}}[this->index()];
+  }
+};
 
 #undef MPARK_INHERITING_CTOR
 
-    template <std::size_t I, typename T>
-    struct overload_leaf {
-      using F = lib::size_constant<I> (*)(T);
-      operator F() const { return nullptr; }
-    };
+template <std::size_t I, typename T>
+struct overload_leaf {
+  using F = lib::size_constant<I> (*)(T);
+  operator F() const {
+    return nullptr;
+  }
+};
 
-    template <typename... Ts>
-    struct overload_impl {
-      private:
-      template <typename>
-      struct impl;
+template <typename... Ts>
+struct overload_impl {
+ private:
+  template <typename>
+  struct impl;
 
-      template <std::size_t... Is>
-      struct impl<lib::index_sequence<Is...>> : overload_leaf<Is, Ts>... {};
+  template <std::size_t... Is>
+  struct impl<lib::index_sequence<Is...>> : overload_leaf<Is, Ts>... {};
 
-      public:
-      using type = impl<lib::index_sequence_for<Ts...>>;
-    };
+ public:
+  using type = impl<lib::index_sequence_for<Ts...>>;
+};
 
-    template <typename... Ts>
-    using overload = typename overload_impl<Ts...>::type;
+template <typename... Ts>
+using overload = typename overload_impl<Ts...>::type;
 
-    template <typename T, typename... Ts>
-    using best_match = lib::invoke_result_t<overload<Ts...>, T &&>;
+template <typename T, typename... Ts>
+using best_match = lib::invoke_result_t<overload<Ts...>, T&&>;
 
-    template <typename T>
-    struct is_in_place_index : std::false_type {};
+template <typename T>
+struct is_in_place_index : std::false_type {};
 
-    template <std::size_t I>
-    struct is_in_place_index<in_place_index_t<I>> : std::true_type {};
+template <std::size_t I>
+struct is_in_place_index<in_place_index_t<I>> : std::true_type {};
 
-    template <typename T>
-    struct is_in_place_type : std::false_type {};
+template <typename T>
+struct is_in_place_type : std::false_type {};
 
-    template <typename T>
-    struct is_in_place_type<in_place_type_t<T>> : std::true_type {};
+template <typename T>
+struct is_in_place_type<in_place_type_t<T>> : std::true_type {};
 
-  }  // detail_
+} // namespace detail_
 
-  template <typename... Ts>
-  class variant {
-    static_assert(0 < sizeof...(Ts),
-                  "variant must consist of at least one alternative.");
+template <typename... Ts>
+class variant {
+  static_assert(
+      0 < sizeof...(Ts),
+      "variant must consist of at least one alternative.");
 
-    static_assert(lib::all<!std::is_array<Ts>::value...>::value,
-                  "variant can not have an array type as an alternative.");
+  static_assert(
+      lib::all<!std::is_array<Ts>::value...>::value,
+      "variant can not have an array type as an alternative.");
 
-    static_assert(lib::all<!std::is_reference<Ts>::value...>::value,
-                  "variant can not have a reference type as an alternative.");
+  static_assert(
+      lib::all<!std::is_reference<Ts>::value...>::value,
+      "variant can not have a reference type as an alternative.");
 
-    static_assert(lib::all<!std::is_void<Ts>::value...>::value,
-                  "variant can not have a void type as an alternative.");
+  static_assert(
+      lib::all<!std::is_void<Ts>::value...>::value,
+      "variant can not have a void type as an alternative.");
 
-    public:
-    template <
-        typename Front = lib::type_pack_element_t<0, Ts...>,
-        lib::enable_if_t<std::is_default_constructible<Front>::value, int> = 0>
-    inline constexpr variant() noexcept(
-        std::is_nothrow_default_constructible<Front>::value)
-        : impl_(in_place_index_t<0>{}) {}
+ public:
+  template <
+      typename Front = lib::type_pack_element_t<0, Ts...>,
+      lib::enable_if_t<std::is_default_constructible<Front>::value, int> = 0>
+  inline constexpr variant() noexcept(
+      std::is_nothrow_default_constructible<Front>::value)
+      : impl_(in_place_index_t<0>{}) {}
 
-    variant(const variant &) = default;
-    variant(variant &&) = default;
+  variant(const variant&) = default;
+  variant(variant&&) = default;
 
-    template <
-        typename Arg,
-        typename Decayed = lib::decay_t<Arg>,
-        lib::enable_if_t<!std::is_same<Decayed, variant>::value, int> = 0,
-        lib::enable_if_t<!detail_::is_in_place_index<Decayed>::value, int> = 0,
-        lib::enable_if_t<!detail_::is_in_place_type<Decayed>::value, int> = 0,
-        std::size_t I = detail_::best_match<Arg, Ts...>::value,
-        typename T = lib::type_pack_element_t<I, Ts...>,
-        lib::enable_if_t<std::is_constructible<T, Arg>::value, int> = 0>
-    inline constexpr variant(Arg &&arg) noexcept(
-        std::is_nothrow_constructible<T, Arg>::value)
-        : impl_(in_place_index_t<I>{}, lib::forward<Arg>(arg)) {}
+  template <
+      typename Arg,
+      typename Decayed = lib::decay_t<Arg>,
+      lib::enable_if_t<!std::is_same<Decayed, variant>::value, int> = 0,
+      lib::enable_if_t<!detail_::is_in_place_index<Decayed>::value, int> = 0,
+      lib::enable_if_t<!detail_::is_in_place_type<Decayed>::value, int> = 0,
+      std::size_t I = detail_::best_match<Arg, Ts...>::value,
+      typename T = lib::type_pack_element_t<I, Ts...>,
+      lib::enable_if_t<std::is_constructible<T, Arg>::value, int> = 0>
+  inline constexpr variant(Arg&& arg) noexcept(
+      std::is_nothrow_constructible<T, Arg>::value)
+      : impl_(in_place_index_t<I>{}, lib::forward<Arg>(arg)) {}
 
-    template <
-        std::size_t I,
-        typename... Args,
-        typename T = lib::type_pack_element_t<I, Ts...>,
-        lib::enable_if_t<std::is_constructible<T, Args...>::value, int> = 0>
-    inline explicit constexpr variant(
-        in_place_index_t<I>,
-        Args &&... args) noexcept(std::is_nothrow_constructible<T,
-                                                                Args...>::value)
-        : impl_(in_place_index_t<I>{}, lib::forward<Args>(args)...) {}
+  template <
+      std::size_t I,
+      typename... Args,
+      typename T = lib::type_pack_element_t<I, Ts...>,
+      lib::enable_if_t<std::is_constructible<T, Args...>::value, int> = 0>
+  inline explicit constexpr variant(
+      in_place_index_t<I>,
+      Args&&... args) noexcept(std::is_nothrow_constructible<T, Args...>::value)
+      : impl_(in_place_index_t<I>{}, lib::forward<Args>(args)...) {}
 
-    template <
-        std::size_t I,
-        typename Up,
-        typename... Args,
-        typename T = lib::type_pack_element_t<I, Ts...>,
-        lib::enable_if_t<std::is_constructible<T,
-                                               std::initializer_list<Up> &,
-                                               Args...>::value,
-                         int> = 0>
-    inline explicit constexpr variant(
-        in_place_index_t<I>,
-        std::initializer_list<Up> il,
-        Args &&... args) noexcept(std::
-                                      is_nothrow_constructible<
-                                          T,
-                                          std::initializer_list<Up> &,
-                                          Args...>::value)
-        : impl_(in_place_index_t<I>{}, il, lib::forward<Args>(args)...) {}
+  template <
+      std::size_t I,
+      typename Up,
+      typename... Args,
+      typename T = lib::type_pack_element_t<I, Ts...>,
+      lib::enable_if_t<
+          std::is_constructible<T, std::initializer_list<Up>&, Args...>::value,
+          int> = 0>
+  inline explicit constexpr variant(
+      in_place_index_t<I>,
+      std::initializer_list<Up> il,
+      Args&&... args) noexcept(std::
+                                   is_nothrow_constructible<
+                                       T,
+                                       std::initializer_list<Up>&,
+                                       Args...>::value)
+      : impl_(in_place_index_t<I>{}, il, lib::forward<Args>(args)...) {}
 
-    template <
-        typename T,
-        typename... Args,
-        std::size_t I = detail_::find_index_sfinae<T, Ts...>::value,
-        lib::enable_if_t<std::is_constructible<T, Args...>::value, int> = 0>
-    inline explicit constexpr variant(
-        in_place_type_t<T>,
-        Args &&... args) noexcept(std::is_nothrow_constructible<T,
-                                                                Args...>::value)
-        : impl_(in_place_index_t<I>{}, lib::forward<Args>(args)...) {}
+  template <
+      typename T,
+      typename... Args,
+      std::size_t I = detail_::find_index_sfinae<T, Ts...>::value,
+      lib::enable_if_t<std::is_constructible<T, Args...>::value, int> = 0>
+  inline explicit constexpr variant(
+      in_place_type_t<T>,
+      Args&&... args) noexcept(std::is_nothrow_constructible<T, Args...>::value)
+      : impl_(in_place_index_t<I>{}, lib::forward<Args>(args)...) {}
 
-    template <
-        typename T,
-        typename Up,
-        typename... Args,
-        std::size_t I = detail_::find_index_sfinae<T, Ts...>::value,
-        lib::enable_if_t<std::is_constructible<T,
-                                               std::initializer_list<Up> &,
-                                               Args...>::value,
-                         int> = 0>
-    inline explicit constexpr variant(
-        in_place_type_t<T>,
-        std::initializer_list<Up> il,
-        Args &&... args) noexcept(std::
-                                      is_nothrow_constructible<
-                                          T,
-                                          std::initializer_list<Up> &,
-                                          Args...>::value)
-        : impl_(in_place_index_t<I>{}, il, lib::forward<Args>(args)...) {}
+  template <
+      typename T,
+      typename Up,
+      typename... Args,
+      std::size_t I = detail_::find_index_sfinae<T, Ts...>::value,
+      lib::enable_if_t<
+          std::is_constructible<T, std::initializer_list<Up>&, Args...>::value,
+          int> = 0>
+  inline explicit constexpr variant(
+      in_place_type_t<T>,
+      std::initializer_list<Up> il,
+      Args&&... args) noexcept(std::
+                                   is_nothrow_constructible<
+                                       T,
+                                       std::initializer_list<Up>&,
+                                       Args...>::value)
+      : impl_(in_place_index_t<I>{}, il, lib::forward<Args>(args)...) {}
 
-    ~variant() = default;
+  ~variant() = default;
 
-    variant &operator=(const variant &) = default;
-    variant &operator=(variant &&) = default;
+  variant& operator=(const variant&) = default;
+  variant& operator=(variant&&) = default;
 
-    template <typename Arg,
-              lib::enable_if_t<!std::is_same<lib::decay_t<Arg>, variant>::value,
-                               int> = 0,
-              std::size_t I = detail_::best_match<Arg, Ts...>::value,
-              typename T = lib::type_pack_element_t<I, Ts...>,
-              lib::enable_if_t<(std::is_assignable<T &, Arg>::value &&
-                                std::is_constructible<T, Arg>::value),
-                               int> = 0>
-    inline variant &operator=(Arg &&arg) noexcept(
-        (std::is_nothrow_assignable<T &, Arg>::value &&
-         std::is_nothrow_constructible<T, Arg>::value)) {
-      impl_.template assign<I>(lib::forward<Arg>(arg));
-      return *this;
-    }
-
-    template <
-        std::size_t I,
-        typename... Args,
-        typename T = lib::type_pack_element_t<I, Ts...>,
-        lib::enable_if_t<std::is_constructible<T, Args...>::value, int> = 0>
-    inline T &emplace(Args &&... args) {
-      return impl_.template emplace<I>(lib::forward<Args>(args)...);
-    }
-
-    template <
-        std::size_t I,
-        typename Up,
-        typename... Args,
-        typename T = lib::type_pack_element_t<I, Ts...>,
-        lib::enable_if_t<std::is_constructible<T,
-                                               std::initializer_list<Up> &,
-                                               Args...>::value,
-                         int> = 0>
-    inline T &emplace(std::initializer_list<Up> il, Args &&... args) {
-      return impl_.template emplace<I>(il, lib::forward<Args>(args)...);
-    }
-
-    template <
-        typename T,
-        typename... Args,
-        std::size_t I = detail_::find_index_sfinae<T, Ts...>::value,
-        lib::enable_if_t<std::is_constructible<T, Args...>::value, int> = 0>
-    inline T &emplace(Args &&... args) {
-      return impl_.template emplace<I>(lib::forward<Args>(args)...);
-    }
-
-    template <
-        typename T,
-        typename Up,
-        typename... Args,
-        std::size_t I = detail_::find_index_sfinae<T, Ts...>::value,
-        lib::enable_if_t<std::is_constructible<T,
-                                               std::initializer_list<Up> &,
-                                               Args...>::value,
-                         int> = 0>
-    inline T &emplace(std::initializer_list<Up> il, Args &&... args) {
-      return impl_.template emplace<I>(il, lib::forward<Args>(args)...);
-    }
-
-    inline constexpr bool valueless_by_exception() const noexcept {
-      return impl_.valueless_by_exception();
-    }
-
-    inline constexpr std::size_t index() const noexcept {
-      return impl_.index();
-    }
-
-    template <bool Dummy = true,
-              lib::enable_if_t<
-                  lib::all<Dummy,
-                           (lib::dependent_type<std::is_move_constructible<Ts>,
-                                                Dummy>::value &&
-                            lib::dependent_type<lib::is_swappable<Ts>,
-                                                Dummy>::value)...>::value,
-                  int> = 0>
-    inline void swap(variant &that) noexcept(
-        lib::all<(std::is_nothrow_move_constructible<Ts>::value &&
-                  lib::is_nothrow_swappable<Ts>::value)...>::value) {
-      impl_.swap(that.impl_);
-    }
-
-    private:
-    detail_::impl<Ts...> impl_;
-
-    friend struct detail_::access::variant;
-    friend struct detail_::visitation::variant;
-  };
-
-  template <std::size_t I, typename... Ts>
-  inline constexpr bool holds_alternative(const variant<Ts...> &v) noexcept {
-    return v.index() == I;
+  template <
+      typename Arg,
+      lib::enable_if_t<!std::is_same<lib::decay_t<Arg>, variant>::value, int> =
+          0,
+      std::size_t I = detail_::best_match<Arg, Ts...>::value,
+      typename T = lib::type_pack_element_t<I, Ts...>,
+      lib::enable_if_t<
+          (std::is_assignable<T&, Arg>::value &&
+           std::is_constructible<T, Arg>::value),
+          int> = 0>
+  inline variant& operator=(Arg&& arg) noexcept(
+      (std::is_nothrow_assignable<T&, Arg>::value &&
+       std::is_nothrow_constructible<T, Arg>::value)) {
+    impl_.template assign<I>(lib::forward<Arg>(arg));
+    return *this;
   }
 
-  template <typename T, typename... Ts>
-  inline constexpr bool holds_alternative(const variant<Ts...> &v) noexcept {
-    return holds_alternative<detail_::find_index_checked<T, Ts...>::value>(v);
+  template <
+      std::size_t I,
+      typename... Args,
+      typename T = lib::type_pack_element_t<I, Ts...>,
+      lib::enable_if_t<std::is_constructible<T, Args...>::value, int> = 0>
+  inline T& emplace(Args&&... args) {
+    return impl_.template emplace<I>(lib::forward<Args>(args)...);
   }
 
-  namespace detail_ {
-    template <std::size_t I, typename V>
-    struct generic_get_impl {
-      constexpr generic_get_impl(int) noexcept {}
-
-      constexpr AUTO_REFREF operator()(V &&v) const
-        AUTO_REFREF_RETURN(
-            access::variant::get_alt<I>(lib::forward<V>(v)).value)
-    };
-
-    template <std::size_t I, typename V>
-    inline constexpr AUTO_REFREF generic_get(V &&v)
-      AUTO_REFREF_RETURN(generic_get_impl<I, V>(
-          holds_alternative<I>(v) ? 0 : (throw_bad_variant_access(), 0))(
-          lib::forward<V>(v)))
-  }  // namespace detail_
-
-  template <std::size_t I, typename... Ts>
-  inline constexpr variant_alternative_t<I, variant<Ts...>> &get(
-      variant<Ts...> &v) {
-    return detail_::generic_get<I>(v);
+  template <
+      std::size_t I,
+      typename Up,
+      typename... Args,
+      typename T = lib::type_pack_element_t<I, Ts...>,
+      lib::enable_if_t<
+          std::is_constructible<T, std::initializer_list<Up>&, Args...>::value,
+          int> = 0>
+  inline T& emplace(std::initializer_list<Up> il, Args&&... args) {
+    return impl_.template emplace<I>(il, lib::forward<Args>(args)...);
   }
 
-  template <std::size_t I, typename... Ts>
-  inline constexpr variant_alternative_t<I, variant<Ts...>> &&get(
-      variant<Ts...> &&v) {
-    return detail_::generic_get<I>(lib::move(v));
+  template <
+      typename T,
+      typename... Args,
+      std::size_t I = detail_::find_index_sfinae<T, Ts...>::value,
+      lib::enable_if_t<std::is_constructible<T, Args...>::value, int> = 0>
+  inline T& emplace(Args&&... args) {
+    return impl_.template emplace<I>(lib::forward<Args>(args)...);
   }
 
-  template <std::size_t I, typename... Ts>
-  inline constexpr const variant_alternative_t<I, variant<Ts...>> &get(
-      const variant<Ts...> &v) {
-    return detail_::generic_get<I>(v);
+  template <
+      typename T,
+      typename Up,
+      typename... Args,
+      std::size_t I = detail_::find_index_sfinae<T, Ts...>::value,
+      lib::enable_if_t<
+          std::is_constructible<T, std::initializer_list<Up>&, Args...>::value,
+          int> = 0>
+  inline T& emplace(std::initializer_list<Up> il, Args&&... args) {
+    return impl_.template emplace<I>(il, lib::forward<Args>(args)...);
   }
 
-  template <std::size_t I, typename... Ts>
-  inline constexpr const variant_alternative_t<I, variant<Ts...>> &&get(
-      const variant<Ts...> &&v) {
-    return detail_::generic_get<I>(lib::move(v));
+  inline constexpr bool valueless_by_exception() const noexcept {
+    return impl_.valueless_by_exception();
   }
 
-  template <typename T, typename... Ts>
-  inline constexpr T &get(variant<Ts...> &v) {
-    return get<detail_::find_index_checked<T, Ts...>::value>(v);
+  inline constexpr std::size_t index() const noexcept {
+    return impl_.index();
   }
 
-  template <typename T, typename... Ts>
-  inline constexpr T &&get(variant<Ts...> &&v) {
-    return get<detail_::find_index_checked<T, Ts...>::value>(lib::move(v));
+  template <
+      bool Dummy = true,
+      lib::enable_if_t<
+          lib::all<
+              Dummy,
+              (lib::dependent_type<std::is_move_constructible<Ts>, Dummy>::
+                   value &&
+               lib::dependent_type<lib::is_swappable<Ts>, Dummy>::value)...>::
+              value,
+          int> = 0>
+  inline void swap(variant& that) noexcept(
+      lib::all<
+          (std::is_nothrow_move_constructible<Ts>::value &&
+           lib::is_nothrow_swappable<Ts>::value)...>::value) {
+    impl_.swap(that.impl_);
   }
 
-  template <typename T, typename... Ts>
-  inline constexpr const T &get(const variant<Ts...> &v) {
-    return get<detail_::find_index_checked<T, Ts...>::value>(v);
+ private:
+  detail_::impl<Ts...> impl_;
+
+  friend struct detail_::access::variant;
+  friend struct detail_::visitation::variant;
+};
+
+template <std::size_t I, typename... Ts>
+inline constexpr bool holds_alternative(const variant<Ts...>& v) noexcept {
+  return v.index() == I;
+}
+
+template <typename T, typename... Ts>
+inline constexpr bool holds_alternative(const variant<Ts...>& v) noexcept {
+  return holds_alternative<detail_::find_index_checked<T, Ts...>::value>(v);
+}
+
+namespace detail_ {
+template <std::size_t I, typename V>
+struct generic_get_impl {
+  constexpr generic_get_impl(int) noexcept {}
+
+  constexpr AUTO_REFREF operator()(V&& v) const
+      AUTO_REFREF_RETURN(access::variant::get_alt<I>(lib::forward<V>(v)).value)
+};
+
+template <std::size_t I, typename V>
+inline constexpr AUTO_REFREF generic_get(V&& v)
+    AUTO_REFREF_RETURN(generic_get_impl<I, V>(
+        holds_alternative<I>(v)
+            ? 0
+            : (throw_bad_variant_access(), 0))(lib::forward<V>(v)))
+} // namespace detail_
+
+template <std::size_t I, typename... Ts>
+inline constexpr variant_alternative_t<I, variant<Ts...>>& get(
+    variant<Ts...>& v) {
+  return detail_::generic_get<I>(v);
+}
+
+template <std::size_t I, typename... Ts>
+inline constexpr variant_alternative_t<I, variant<Ts...>>&& get(
+    variant<Ts...>&& v) {
+  return detail_::generic_get<I>(lib::move(v));
+}
+
+template <std::size_t I, typename... Ts>
+inline constexpr const variant_alternative_t<I, variant<Ts...>>& get(
+    const variant<Ts...>& v) {
+  return detail_::generic_get<I>(v);
+}
+
+template <std::size_t I, typename... Ts>
+inline constexpr const variant_alternative_t<I, variant<Ts...>>&& get(
+    const variant<Ts...>&& v) {
+  return detail_::generic_get<I>(lib::move(v));
+}
+
+template <typename T, typename... Ts>
+inline constexpr T& get(variant<Ts...>& v) {
+  return get<detail_::find_index_checked<T, Ts...>::value>(v);
+}
+
+template <typename T, typename... Ts>
+inline constexpr T&& get(variant<Ts...>&& v) {
+  return get<detail_::find_index_checked<T, Ts...>::value>(lib::move(v));
+}
+
+template <typename T, typename... Ts>
+inline constexpr const T& get(const variant<Ts...>& v) {
+  return get<detail_::find_index_checked<T, Ts...>::value>(v);
+}
+
+template <typename T, typename... Ts>
+inline constexpr const T&& get(const variant<Ts...>&& v) {
+  return get<detail_::find_index_checked<T, Ts...>::value>(lib::move(v));
+}
+
+namespace detail_ {
+
+template <std::size_t I, typename V>
+inline constexpr /* auto * */ AUTO generic_get_if(V* v) noexcept AUTO_RETURN(
+    v&& holds_alternative<I>(*v)
+        ? lib::addressof(access::variant::get_alt<I>(*v).value)
+        : nullptr)
+
+} // namespace detail_
+
+template <std::size_t I, typename... Ts>
+inline constexpr lib::add_pointer_t<variant_alternative_t<I, variant<Ts...>>>
+get_if(variant<Ts...>* v) noexcept {
+  return detail_::generic_get_if<I>(v);
+}
+
+template <std::size_t I, typename... Ts>
+inline constexpr lib::add_pointer_t<
+    const variant_alternative_t<I, variant<Ts...>>>
+get_if(const variant<Ts...>* v) noexcept {
+  return detail_::generic_get_if<I>(v);
+}
+
+template <typename T, typename... Ts>
+inline constexpr lib::add_pointer_t<T> get_if(variant<Ts...>* v) noexcept {
+  return get_if<detail_::find_index_checked<T, Ts...>::value>(v);
+}
+
+template <typename T, typename... Ts>
+inline constexpr lib::add_pointer_t<const T> get_if(
+    const variant<Ts...>* v) noexcept {
+  return get_if<detail_::find_index_checked<T, Ts...>::value>(v);
+}
+
+namespace detail_ {
+template <typename RelOp>
+struct convert_to_bool {
+  template <typename Lhs, typename Rhs>
+  inline constexpr bool operator()(Lhs&& lhs, Rhs&& rhs) const {
+    static_assert(
+        std::is_convertible<lib::invoke_result_t<RelOp, Lhs, Rhs>, bool>::value,
+        "relational operators must return a type"
+        " implicitly convertible to bool");
+    return lib::invoke(RelOp{}, lib::forward<Lhs>(lhs), lib::forward<Rhs>(rhs));
   }
+};
+} // namespace detail_
 
-  template <typename T, typename... Ts>
-  inline constexpr const T &&get(const variant<Ts...> &&v) {
-    return get<detail_::find_index_checked<T, Ts...>::value>(lib::move(v));
-  }
-
-  namespace detail_ {
-
-    template <std::size_t I, typename V>
-    inline constexpr /* auto * */ AUTO generic_get_if(V *v) noexcept
-      AUTO_RETURN(v && holds_alternative<I>(*v)
-                      ? lib::addressof(access::variant::get_alt<I>(*v).value)
-                      : nullptr)
-
-  }  // namespace detail_
-
-  template <std::size_t I, typename... Ts>
-  inline constexpr lib::add_pointer_t<variant_alternative_t<I, variant<Ts...>>>
-  get_if(variant<Ts...> *v) noexcept {
-    return detail_::generic_get_if<I>(v);
-  }
-
-  template <std::size_t I, typename... Ts>
-  inline constexpr lib::add_pointer_t<
-      const variant_alternative_t<I, variant<Ts...>>>
-  get_if(const variant<Ts...> *v) noexcept {
-    return detail_::generic_get_if<I>(v);
-  }
-
-  template <typename T, typename... Ts>
-  inline constexpr lib::add_pointer_t<T>
-  get_if(variant<Ts...> *v) noexcept {
-    return get_if<detail_::find_index_checked<T, Ts...>::value>(v);
-  }
-
-  template <typename T, typename... Ts>
-  inline constexpr lib::add_pointer_t<const T>
-  get_if(const variant<Ts...> *v) noexcept {
-    return get_if<detail_::find_index_checked<T, Ts...>::value>(v);
-  }
-
-  namespace detail_ {
-    template <typename RelOp>
-    struct convert_to_bool {
-      template <typename Lhs, typename Rhs>
-      inline constexpr bool operator()(Lhs &&lhs, Rhs &&rhs) const {
-        static_assert(std::is_convertible<lib::invoke_result_t<RelOp, Lhs, Rhs>,
-                                          bool>::value,
-                      "relational operators must return a type"
-                      " implicitly convertible to bool");
-        return lib::invoke(
-            RelOp{}, lib::forward<Lhs>(lhs), lib::forward<Rhs>(rhs));
-      }
-    };
-  }  // namespace detail_
-
-  template <typename... Ts>
-  inline constexpr bool operator==(const variant<Ts...> &lhs,
-                                   const variant<Ts...> &rhs) {
-    using detail_::visitation::variant;
-    using equal_to = detail_::convert_to_bool<lib::equal_to>;
+template <typename... Ts>
+inline constexpr bool operator==(
+    const variant<Ts...>& lhs,
+    const variant<Ts...>& rhs) {
+  using detail_::visitation::variant;
+  using equal_to = detail_::convert_to_bool<lib::equal_to>;
 #ifdef MPARK_CPP14_CONSTEXPR
-    if (lhs.index() != rhs.index()) return false;
-    if (lhs.valueless_by_exception()) return true;
-    return variant::visit_value_at(lhs.index(), equal_to{}, lhs, rhs);
-#else
-    return lhs.index() == rhs.index() &&
-           (lhs.valueless_by_exception() ||
-            variant::visit_value_at(lhs.index(), equal_to{}, lhs, rhs));
-#endif
-  }
-
-  template <typename... Ts>
-  inline constexpr bool operator!=(const variant<Ts...> &lhs,
-                                   const variant<Ts...> &rhs) {
-    using detail_::visitation::variant;
-    using not_equal_to = detail_::convert_to_bool<lib::not_equal_to>;
-#ifdef MPARK_CPP14_CONSTEXPR
-    if (lhs.index() != rhs.index()) return true;
-    if (lhs.valueless_by_exception()) return false;
-    return variant::visit_value_at(lhs.index(), not_equal_to{}, lhs, rhs);
-#else
-    return lhs.index() != rhs.index() ||
-           (!lhs.valueless_by_exception() &&
-            variant::visit_value_at(lhs.index(), not_equal_to{}, lhs, rhs));
-#endif
-  }
-
-  template <typename... Ts>
-  inline constexpr bool operator<(const variant<Ts...> &lhs,
-                                  const variant<Ts...> &rhs) {
-    using detail_::visitation::variant;
-    using less = detail_::convert_to_bool<lib::less>;
-#ifdef MPARK_CPP14_CONSTEXPR
-    if (rhs.valueless_by_exception()) return false;
-    if (lhs.valueless_by_exception()) return true;
-    if (lhs.index() < rhs.index()) return true;
-    if (lhs.index() > rhs.index()) return false;
-    return variant::visit_value_at(lhs.index(), less{}, lhs, rhs);
-#else
-    return !rhs.valueless_by_exception() &&
-           (lhs.valueless_by_exception() || lhs.index() < rhs.index() ||
-            (lhs.index() == rhs.index() &&
-             variant::visit_value_at(lhs.index(), less{}, lhs, rhs)));
-#endif
-  }
-
-  template <typename... Ts>
-  inline constexpr bool operator>(const variant<Ts...> &lhs,
-                                  const variant<Ts...> &rhs) {
-    using detail_::visitation::variant;
-    using greater = detail_::convert_to_bool<lib::greater>;
-#ifdef MPARK_CPP14_CONSTEXPR
-    if (lhs.valueless_by_exception()) return false;
-    if (rhs.valueless_by_exception()) return true;
-    if (lhs.index() > rhs.index()) return true;
-    if (lhs.index() < rhs.index()) return false;
-    return variant::visit_value_at(lhs.index(), greater{}, lhs, rhs);
-#else
-    return !lhs.valueless_by_exception() &&
-           (rhs.valueless_by_exception() || lhs.index() > rhs.index() ||
-            (lhs.index() == rhs.index() &&
-             variant::visit_value_at(lhs.index(), greater{}, lhs, rhs)));
-#endif
-  }
-
-  template <typename... Ts>
-  inline constexpr bool operator<=(const variant<Ts...> &lhs,
-                                   const variant<Ts...> &rhs) {
-    using detail_::visitation::variant;
-    using less_equal = detail_::convert_to_bool<lib::less_equal>;
-#ifdef MPARK_CPP14_CONSTEXPR
-    if (lhs.valueless_by_exception()) return true;
-    if (rhs.valueless_by_exception()) return false;
-    if (lhs.index() < rhs.index()) return true;
-    if (lhs.index() > rhs.index()) return false;
-    return variant::visit_value_at(lhs.index(), less_equal{}, lhs, rhs);
-#else
-    return lhs.valueless_by_exception() ||
-           (!rhs.valueless_by_exception() &&
-            (lhs.index() < rhs.index() ||
-             (lhs.index() == rhs.index() &&
-              variant::visit_value_at(lhs.index(), less_equal{}, lhs, rhs))));
-#endif
-  }
-
-  template <typename... Ts>
-  inline constexpr bool operator>=(const variant<Ts...> &lhs,
-                                   const variant<Ts...> &rhs) {
-    using detail_::visitation::variant;
-    using greater_equal = detail_::convert_to_bool<lib::greater_equal>;
-#ifdef MPARK_CPP14_CONSTEXPR
-    if (rhs.valueless_by_exception()) return true;
-    if (lhs.valueless_by_exception()) return false;
-    if (lhs.index() > rhs.index()) return true;
-    if (lhs.index() < rhs.index()) return false;
-    return variant::visit_value_at(lhs.index(), greater_equal{}, lhs, rhs);
-#else
-    return rhs.valueless_by_exception() ||
-           (!lhs.valueless_by_exception() &&
-            (lhs.index() > rhs.index() ||
-             (lhs.index() == rhs.index() &&
-              variant::visit_value_at(
-                  lhs.index(), greater_equal{}, lhs, rhs))));
-#endif
-  }
-
-  struct monostate {};
-
-  inline constexpr bool operator<(monostate, monostate) noexcept {
+  if (lhs.index() != rhs.index())
     return false;
-  }
+  if (lhs.valueless_by_exception())
+    return true;
+  return variant::visit_value_at(lhs.index(), equal_to{}, lhs, rhs);
+#else
+  return lhs.index() == rhs.index() &&
+      (lhs.valueless_by_exception() ||
+       variant::visit_value_at(lhs.index(), equal_to{}, lhs, rhs));
+#endif
+}
 
-  inline constexpr bool operator>(monostate, monostate) noexcept {
+template <typename... Ts>
+inline constexpr bool operator!=(
+    const variant<Ts...>& lhs,
+    const variant<Ts...>& rhs) {
+  using detail_::visitation::variant;
+  using not_equal_to = detail_::convert_to_bool<lib::not_equal_to>;
+#ifdef MPARK_CPP14_CONSTEXPR
+  if (lhs.index() != rhs.index())
+    return true;
+  if (lhs.valueless_by_exception())
     return false;
-  }
+  return variant::visit_value_at(lhs.index(), not_equal_to{}, lhs, rhs);
+#else
+  return lhs.index() != rhs.index() ||
+      (!lhs.valueless_by_exception() &&
+       variant::visit_value_at(lhs.index(), not_equal_to{}, lhs, rhs));
+#endif
+}
 
-  inline constexpr bool operator<=(monostate, monostate) noexcept {
-    return true;
-  }
-
-  inline constexpr bool operator>=(monostate, monostate) noexcept {
-    return true;
-  }
-
-  inline constexpr bool operator==(monostate, monostate) noexcept {
-    return true;
-  }
-
-  inline constexpr bool operator!=(monostate, monostate) noexcept {
+template <typename... Ts>
+inline constexpr bool operator<(
+    const variant<Ts...>& lhs,
+    const variant<Ts...>& rhs) {
+  using detail_::visitation::variant;
+  using less = detail_::convert_to_bool<lib::less>;
+#ifdef MPARK_CPP14_CONSTEXPR
+  if (rhs.valueless_by_exception())
     return false;
-  }
+  if (lhs.valueless_by_exception())
+    return true;
+  if (lhs.index() < rhs.index())
+    return true;
+  if (lhs.index() > rhs.index())
+    return false;
+  return variant::visit_value_at(lhs.index(), less{}, lhs, rhs);
+#else
+  return !rhs.valueless_by_exception() &&
+      (lhs.valueless_by_exception() || lhs.index() < rhs.index() ||
+       (lhs.index() == rhs.index() &&
+        variant::visit_value_at(lhs.index(), less{}, lhs, rhs)));
+#endif
+}
+
+template <typename... Ts>
+inline constexpr bool operator>(
+    const variant<Ts...>& lhs,
+    const variant<Ts...>& rhs) {
+  using detail_::visitation::variant;
+  using greater = detail_::convert_to_bool<lib::greater>;
+#ifdef MPARK_CPP14_CONSTEXPR
+  if (lhs.valueless_by_exception())
+    return false;
+  if (rhs.valueless_by_exception())
+    return true;
+  if (lhs.index() > rhs.index())
+    return true;
+  if (lhs.index() < rhs.index())
+    return false;
+  return variant::visit_value_at(lhs.index(), greater{}, lhs, rhs);
+#else
+  return !lhs.valueless_by_exception() &&
+      (rhs.valueless_by_exception() || lhs.index() > rhs.index() ||
+       (lhs.index() == rhs.index() &&
+        variant::visit_value_at(lhs.index(), greater{}, lhs, rhs)));
+#endif
+}
+
+template <typename... Ts>
+inline constexpr bool operator<=(
+    const variant<Ts...>& lhs,
+    const variant<Ts...>& rhs) {
+  using detail_::visitation::variant;
+  using less_equal = detail_::convert_to_bool<lib::less_equal>;
+#ifdef MPARK_CPP14_CONSTEXPR
+  if (lhs.valueless_by_exception())
+    return true;
+  if (rhs.valueless_by_exception())
+    return false;
+  if (lhs.index() < rhs.index())
+    return true;
+  if (lhs.index() > rhs.index())
+    return false;
+  return variant::visit_value_at(lhs.index(), less_equal{}, lhs, rhs);
+#else
+  return lhs.valueless_by_exception() ||
+      (!rhs.valueless_by_exception() &&
+       (lhs.index() < rhs.index() ||
+        (lhs.index() == rhs.index() &&
+         variant::visit_value_at(lhs.index(), less_equal{}, lhs, rhs))));
+#endif
+}
+
+template <typename... Ts>
+inline constexpr bool operator>=(
+    const variant<Ts...>& lhs,
+    const variant<Ts...>& rhs) {
+  using detail_::visitation::variant;
+  using greater_equal = detail_::convert_to_bool<lib::greater_equal>;
+#ifdef MPARK_CPP14_CONSTEXPR
+  if (rhs.valueless_by_exception())
+    return true;
+  if (lhs.valueless_by_exception())
+    return false;
+  if (lhs.index() > rhs.index())
+    return true;
+  if (lhs.index() < rhs.index())
+    return false;
+  return variant::visit_value_at(lhs.index(), greater_equal{}, lhs, rhs);
+#else
+  return rhs.valueless_by_exception() ||
+      (!lhs.valueless_by_exception() &&
+       (lhs.index() > rhs.index() ||
+        (lhs.index() == rhs.index() &&
+         variant::visit_value_at(lhs.index(), greater_equal{}, lhs, rhs))));
+#endif
+}
+
+struct monostate {};
+
+inline constexpr bool operator<(monostate, monostate) noexcept {
+  return false;
+}
+
+inline constexpr bool operator>(monostate, monostate) noexcept {
+  return false;
+}
+
+inline constexpr bool operator<=(monostate, monostate) noexcept {
+  return true;
+}
+
+inline constexpr bool operator>=(monostate, monostate) noexcept {
+  return true;
+}
+
+inline constexpr bool operator==(monostate, monostate) noexcept {
+  return true;
+}
+
+inline constexpr bool operator!=(monostate, monostate) noexcept {
+  return false;
+}
 
 #ifdef MPARK_CPP14_CONSTEXPR
-  namespace detail_ {
+namespace detail_ {
 
-    inline constexpr bool all(std::initializer_list<bool> bs) {
-      for (bool b : bs) {
-        if (!b) {
-          return false;
-        }
-      }
-      return true;
+inline constexpr bool all(std::initializer_list<bool> bs) {
+  for (bool b : bs) {
+    if (!b) {
+      return false;
     }
-
-  }  // namespace detail_
-
-  template <typename Visitor, typename... Vs>
-  inline constexpr decltype(auto) visit(Visitor &&visitor, Vs &&... vs) {
-    return (detail_::all({!vs.valueless_by_exception()...})
-                ? (void)0
-                : throw_bad_variant_access()),
-           detail_::visitation::variant::visit_value(
-               lib::forward<Visitor>(visitor), lib::forward<Vs>(vs)...);
   }
+  return true;
+}
+
+} // namespace detail_
+
+template <typename Visitor, typename... Vs>
+inline constexpr decltype(auto) visit(Visitor&& visitor, Vs&&... vs) {
+  return (detail_::all({!vs.valueless_by_exception()...})
+              ? (void)0
+              : throw_bad_variant_access()),
+         detail_::visitation::variant::visit_value(
+             lib::forward<Visitor>(visitor), lib::forward<Vs>(vs)...);
+}
 #else
-  namespace detail_ {
+namespace detail_ {
 
-    template <std::size_t N>
-    inline constexpr bool all_impl(const lib::array<bool, N> &bs,
-                                   std::size_t idx) {
-      return idx >= N || (bs[idx] && all_impl(bs, idx + 1));
-    }
+template <std::size_t N>
+inline constexpr bool all_impl(const lib::array<bool, N>& bs, std::size_t idx) {
+  return idx >= N || (bs[idx] && all_impl(bs, idx + 1));
+}
 
-    template <std::size_t N>
-    inline constexpr bool all(const lib::array<bool, N> &bs) {
-      return all_impl(bs, 0);
-    }
+template <std::size_t N>
+inline constexpr bool all(const lib::array<bool, N>& bs) {
+  return all_impl(bs, 0);
+}
 
-  }  // namespace detail_
+} // namespace detail_
 
-  template <typename Visitor, typename... Vs>
-  inline constexpr DECLTYPE_AUTO visit(Visitor &&visitor, Vs &&... vs)
+template <typename Visitor, typename... Vs>
+inline constexpr DECLTYPE_AUTO visit(Visitor&& visitor, Vs&&... vs)
     DECLTYPE_AUTO_RETURN(
-        (detail_::all(
-             lib::array<bool, sizeof...(Vs)>{{!vs.valueless_by_exception()...}})
+        (detail_::all(lib::array<bool, sizeof...(Vs)>{
+             {!vs.valueless_by_exception()...}})
              ? (void)0
              : throw_bad_variant_access()),
-        detail_::visitation::variant::visit_value(lib::forward<Visitor>(visitor),
-                                                 lib::forward<Vs>(vs)...))
+        detail_::visitation::variant::visit_value(
+            lib::forward<Visitor>(visitor),
+            lib::forward<Vs>(vs)...))
 #endif
 
-  template <typename... Ts>
-  inline auto swap(variant<Ts...> &lhs,
-                   variant<Ts...> &rhs) noexcept(noexcept(lhs.swap(rhs)))
-      -> decltype(lhs.swap(rhs)) {
-    lhs.swap(rhs);
-  }
+template <typename... Ts>
+inline auto swap(variant<Ts...>& lhs, variant<Ts...>& rhs) noexcept(
+    noexcept(lhs.swap(rhs))) -> decltype(lhs.swap(rhs)) {
+  lhs.swap(rhs);
+}
 
-  namespace detail_ {
+namespace detail_ {
 
-    template <typename T, typename...>
-    using enabled_type = T;
+template <typename T, typename...>
+using enabled_type = T;
 
-    namespace hash {
+namespace hash {
 
-      template <typename H, typename K>
-      constexpr bool meets_requirements() noexcept {
-        return std::is_copy_constructible<H>::value &&
-               std::is_move_constructible<H>::value &&
-               lib::is_invocable_r<std::size_t, H, const K &>::value;
-      }
+template <typename H, typename K>
+constexpr bool meets_requirements() noexcept {
+  return std::is_copy_constructible<H>::value &&
+      std::is_move_constructible<H>::value &&
+      lib::is_invocable_r<std::size_t, H, const K&>::value;
+}
 
-      template <typename K>
-      constexpr bool is_enabled() noexcept {
-        using H = std::hash<K>;
-        return meets_requirements<H, K>() &&
-               std::is_default_constructible<H>::value &&
-               std::is_copy_assignable<H>::value &&
-               std::is_move_assignable<H>::value;
-      }
+template <typename K>
+constexpr bool is_enabled() noexcept {
+  using H = std::hash<K>;
+  return meets_requirements<H, K>() &&
+      std::is_default_constructible<H>::value &&
+      std::is_copy_assignable<H>::value && std::is_move_assignable<H>::value;
+}
 
-    }  // namespace hash
+} // namespace hash
 
-  }  // namespace detail_
+} // namespace detail_
 
 #undef AUTO
 #undef AUTO_RETURN
@@ -2756,67 +2899,66 @@ namespace c10 {
 #undef DECLTYPE_AUTO
 #undef DECLTYPE_AUTO_RETURN
 
-}  // namespace c10
+} // namespace c10
 
 namespace std {
 
-  template <typename... Ts>
-  struct hash<c10::detail_::enabled_type<
-      c10::variant<Ts...>,
-      c10::lib::enable_if_t<c10::lib::all<c10::detail_::hash::is_enabled<
-          c10::lib::remove_const_t<Ts>>()...>::value>>> {
-    using argument_type = c10::variant<Ts...>;
-    using result_type = std::size_t;
+template <typename... Ts>
+struct hash<c10::detail_::enabled_type<
+    c10::variant<Ts...>,
+    c10::lib::enable_if_t<c10::lib::all<c10::detail_::hash::is_enabled<
+        c10::lib::remove_const_t<Ts>>()...>::value>>> {
+  using argument_type = c10::variant<Ts...>;
+  using result_type = std::size_t;
 
-    inline result_type operator()(const argument_type &v) const {
-      using c10::detail_::visitation::variant;
-      std::size_t result =
-          v.valueless_by_exception()
-              ? 299792458  // Random value chosen by the universe upon creation
-              : variant::visit_alt(
+  inline result_type operator()(const argument_type& v) const {
+    using c10::detail_::visitation::variant;
+    std::size_t result = v.valueless_by_exception()
+        ? 299792458 // Random value chosen by the universe upon creation
+        : variant::visit_alt(
 #ifdef MPARK_GENERIC_LAMBDAS
-                    [](const auto &alt) {
-                      using alt_type = c10::lib::decay_t<decltype(alt)>;
-                      using value_type = c10::lib::remove_const_t<
-                          typename alt_type::value_type>;
-                      return hash<value_type>{}(alt.value);
-                    }
+              [](const auto& alt) {
+                using alt_type = c10::lib::decay_t<decltype(alt)>;
+                using value_type =
+                    c10::lib::remove_const_t<typename alt_type::value_type>;
+                return hash<value_type>{}(alt.value);
+              }
 #else
-                    hasher{}
+              hasher {}
 #endif
-                    ,
-                    v);
-      return hash_combine(result, hash<std::size_t>{}(v.index()));
-    }
+              ,
+              v);
+    return hash_combine(result, hash<std::size_t>{}(v.index()));
+  }
 
-    private:
+ private:
 #ifndef MPARK_GENERIC_LAMBDAS
-    struct hasher {
-      template <typename Alt>
-      inline std::size_t operator()(const Alt &alt) const {
-        using alt_type = c10::lib::decay_t<Alt>;
-        using value_type =
-            c10::lib::remove_const_t<typename alt_type::value_type>;
-        return hash<value_type>{}(alt.value);
-      }
-    };
+  struct hasher {
+    template <typename Alt>
+    inline std::size_t operator()(const Alt& alt) const {
+      using alt_type = c10::lib::decay_t<Alt>;
+      using value_type =
+          c10::lib::remove_const_t<typename alt_type::value_type>;
+      return hash<value_type>{}(alt.value);
+    }
+  };
 #endif
 
-    static std::size_t hash_combine(std::size_t lhs, std::size_t rhs) {
-      return lhs ^= rhs + 0x9e3779b9 + (lhs << 6) + (lhs >> 2);
-    }
-  };
+  static std::size_t hash_combine(std::size_t lhs, std::size_t rhs) {
+    return lhs ^= rhs + 0x9e3779b9 + (lhs << 6) + (lhs >> 2);
+  }
+};
 
-  template <>
-  struct hash<c10::monostate> {
-    using argument_type = c10::monostate;
-    using result_type = std::size_t;
+template <>
+struct hash<c10::monostate> {
+  using argument_type = c10::monostate;
+  using result_type = std::size_t;
 
-    inline result_type operator()(const argument_type &) const noexcept {
-      return 66740831;  // return a fundamentally attractive random value.
-    }
-  };
+  inline result_type operator()(const argument_type&) const noexcept {
+    return 66740831; // return a fundamentally attractive random value.
+  }
+};
 
-}  // namespace std
+} // namespace std
 
-#endif  // C10_UTIL_VARIANT_H_
+#endif // C10_UTIL_VARIANT_H_


### PR DESCRIPTION
c10 doesn't follow the clang-format style used throughout PyTorch.  This PR fixes that

I ran
```
find c10 -type f \( -name \*.h -o -name \*.cpp \) -exec clang-format-7 -i {} \;
```

This will obviously take a huge amount of coordination to land, but I'm putting it up to get the discussion rolling