### PR TITLE
[android][gradle] Fix fbjni packaging, exclude for publishing, include by default

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,6 +34,8 @@ allprojects {
     }
 }
 
+ext.isPublishing = { ['uploadArchives', 'bintrayUpload'].any { gradle.startParameter.taskNames.contains(it) } }
+
 ext.deps = [
         jsr305: 'com.google.code.findbugs:jsr305:3.0.1',
 ]

--- a/android/pytorch_android/build.gradle
+++ b/android/pytorch_android/build.gradle
@@ -19,6 +19,7 @@ android {
     buildTypes {
         debug {
             minifyEnabled false
+            debuggable true
         }
         release {
             minifyEnabled false
@@ -36,7 +37,11 @@ android {
     }
 
     packagingOptions {
-        exclude '**/libfbjni.so'
+        if (rootProject.isPublishing()) {
+            exclude '**/libfbjni.so'
+        } else {
+            pickFirst '**/libfbjni.so'
+        }
     }
 
     useLibrary 'android.test.runner'

--- a/android/pytorch_android_torchvision/build.gradle
+++ b/android/pytorch_android_torchvision/build.gradle
@@ -19,6 +19,7 @@ android {
     buildTypes {
         debug {
             minifyEnabled false
+            debuggable true
         }
         release {
             minifyEnabled false


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#26995 [android][gradle] Fix fbjni packaging, exclude for publishing, include by default**

Fix current setup, exclude fbjni - we can not use independently pytorch_android:package, for example for testing `gradle pytorch_android:cAT`

But for publishing it works as pytorch_android has dep on fbjni that will be also published

For other cases - we have 2 fbjni.so - one from native build (CMakeLists.txt does add_subdirectory(fbjni_dir)), and from dependency ':fbjni'
We need both of them as ':fbjni' also contains java classes

As a fix: keep excluding for publishing tasks (bintrayUpload, uploadArchives), but else - pickFirst (as we have 2 sources of fbjni.so) 

# Testing

gradle cAT works, fbjni.so included
gradle bintrayUpload (dryRun==true) - no fbjni.so

Differential Revision: [D17637775](https://our.internmc.facebook.com/intern/diff/D17637775)