### PR TITLE
Remove LOG(INFO) from math_cpu.cc

### DIFF
--- a/caffe2/utils/math_cpu.cc
+++ b/caffe2/utils/math_cpu.cc
@@ -430,8 +430,6 @@ C10_EXPORT void GemmStridedBatched<float, CPUContext>(
     B_array[i] = B + i * B_stride;
     C_array[i] = C + i * C_stride;
   }
-  LOG(INFO) << "M " << M << " N " << N << " K " << K << " lda " << lda
-            << " ldb " << ldb << " ldc " << ldc << " batch_size " << batch_size;
   cblas_sgemm_batch(
       CblasRowMajor,
       &trans_A,


### PR DESCRIPTION
Summary: This unconditional log line spams the logs enough that it's a drag on cpu and will eventually fill up logs.

Test Plan: Allow unit test and automated testing to give feedback.

Differential Revision: D17638140

