### PR TITLE
[quantization] Dont zero out buffers in dynamic linear

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp
@@ -127,8 +127,8 @@ class QLinearDynamicInt8 final : public torch::OperatorKernel {
     std::vector<int64_t> out_sizes = input.sizes().vec();
     out_sizes.back() = N;
     // Allocate output Tensor and a buffer for fbgemmPacked to use
-    auto output = at::zeros(out_sizes, input.options().dtype(at::kFloat));
-    auto buffer = at::zeros_like(output, output.options().dtype(at::kInt));
+    auto output = at::empty(out_sizes, input.options().dtype(at::kFloat));
+    auto buffer = at::empty_like(output, output.options().dtype(at::kInt));
 
     if (pack_ptr.q_scheme == kPerTensorAffine) {
       // Process the per tensor quantization.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #27008 [quantization] Improve repr for quantized modules
* **#27002 [quantization] Dont zero out buffers in dynamic linear**

This was taking a significant amount of time in my benchmarks with larger output sizes (e.g. final output projection in a language classification model)

Differential Revision: [D17641765](https://our.internmc.facebook.com/intern/diff/D17641765)