### PR TITLE
Fix race condition in torch::jit::Function

### DIFF
--- a/torch/csrc/jit/function.h
+++ b/torch/csrc/jit/function.h
@@ -94,10 +94,10 @@ struct TORCH_API Function {
 
   GraphExecutor& get_executor() {
     ensure_defined();
+    std::lock_guard<std::recursive_mutex> lock(compile_mutex);
     if (executor_) {
       return executor_;
     }
-    std::lock_guard<std::recursive_mutex> lock(compile_mutex);
     check_single_output();
     executor_ = GraphExecutor(optimized_graph());
     return executor_;


### PR DESCRIPTION
Summary:
JIT can be called concurrently from two threads, so even the read from GraphExecutor has to be guarded by the lock.

This was a recent regression introduced by https://github.com/pytorch/pytorch/pull/26571/files#diff-40af5094abe4f522e8a78adb591dde19

Reviewed By: jamesr66a, wanchaol

Differential Revision: D17645407

