### PR TITLE
Fix race condition in Function::optimized_graph().

### DIFF
--- a/torch/csrc/jit/function.h
+++ b/torch/csrc/jit/function.h
@@ -37,10 +37,10 @@ struct TORCH_API Function {
   }
 
   std::shared_ptr<Graph> optimized_graph() const {
+    std::lock_guard<std::recursive_mutex> lock(compile_mutex);
     if (optimized_graph_) {
       return *optimized_graph_;
     }
-    std::lock_guard<std::recursive_mutex> lock(compile_mutex);
     optimized_graph_ = graph_->copy();
     preoptimizeGraph(*optimized_graph_);
     return *optimized_graph_;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#27012 Fix race condition in Function::optimized_graph().**

The current logic is buggy, and will fail in the following situation:

Thread A: check optimized_graph_, it is empty.
Thread A: claim the mutex in order to initialize optimized_graph_.
Thread A: copy graph_ into optimized_graph_.
Thread A: start running optimizations on optimized_graph_.
Thread B: check optimized_graph_, it is not empty.
Thread B: start using optimized_graph_.

BUG: Thread B is using the graph while it's still being mutated by
Thread A.

Differential Revision: [D17649149](https://our.internmc.facebook.com/intern/diff/D17649149)