### PR TITLE
[docs] Add docstring to torch.nn.functional.softplus

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1160,6 +1160,13 @@ def softsign(input):
 
 softplus = _add_docstr(torch._C._nn.softplus, r"""
 softplus(input, beta=1, threshold=20) -> Tensor
+
+Applies element-wise, the function:
+
+    .. math::
+        \text{Softplus}(x) = \frac{1}{\beta} * \log(1 + \exp(\beta * x))
+
+See :class:`~torch.nn.Softplus` for more details.
 """)
 
 


### PR DESCRIPTION
My first PR! As requested in issue #9886.

The docstring uses the LaTeX from `torch.nn.softplus` and gives a link to that class.