### PR TITLE
Don't apply should_run to the nightly/postnightly branches.

### DIFF
--- a/.circleci/scripts/should_run_job.sh
+++ b/.circleci/scripts/should_run_job.sh
@@ -18,7 +18,7 @@ if ! [ -e "$SCRIPT_DIR/COMMIT_MSG" ]; then
   exit 1
 fi
 if [ -n "${CIRCLE_PULL_REQUEST:-}" ]; then
-  if [[ $CIRCLE_BRANCH != "ci-all/"* ]]; then
+  if [[ $CIRCLE_BRANCH != "ci-all/"* ]] && [[ $CIRCLE_BRANCH != "nightly" ]] &&  [[ $CIRCLE_BRANCH != "postnightly" ]] ; then
     # Don't swallow "script doesn't exist
     [ -e "$SCRIPT_DIR/should_run_job.py"  ]
     if ! python "$SCRIPT_DIR/should_run_job.py" "${BUILD_ENVIRONMENT:-}" < "$SCRIPT_DIR/COMMIT_MSG" ; then


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#27061 Don't apply should_run to the nightly/postnightly branches.**

Previously the cronjobs were run on master, but now the nightly builds
count as "PRs" so we must whitelist them from should_run calculation.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D17669066](https://our.internmc.facebook.com/intern/diff/D17669066)