### PR TITLE
[v1.3.0] Fix test_overwrite_module_params_on_conversion_cpu_cuda after comparison ops type promotion was introduced

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1793,8 +1793,8 @@ class TestNN(NNTestCase):
             # Without using `torch.no_grad()`, this will leak CUDA memory.
             # (Issue is filed at https://github.com/pytorch/pytorch/issues/21875)
             mw[0][0] = 5
-        with self.assertRaisesRegex(RuntimeError, "Expected object of device type cuda but got device type cpu"):
-            mw[0][0] == mw._base[0][0]
+            self.assertTrue(mw[0][0].device.type == "cpu")
+            self.assertTrue(mw._base[0][0].device.type == "cuda")
 
         try:
             torch.__future__.set_overwrite_module_params_on_conversion(True)


### PR DESCRIPTION
Summary:
Pull Request resolved: #27017

This is a result of squashing of two commits:
https://github.com/pytorch/pytorch/commit/8858f42aa467dcf73281a9daa1523c81fc85377d
https://github.com/pytorch/pytorch/commit/ee2c79d699603facd2df415c0209da765bb16472

