### PR TITLE
Turn on named tensor testing for v1.3.0

### DIFF
--- a/test/test_namedtensor.py
+++ b/test/test_namedtensor.py
@@ -1824,11 +1824,6 @@ class TestNamedTensor(TestCase):
                 args=(create('C:2'), create('W:2')),
                 expected_names=[])
 
-# Disable all tests if named tensor is not available.
-for attr in dir(TestNamedTensor):
-    if attr.startswith('test_'):
-        new_test = skipIfNamedTensorDisabled(skipIfNotTestingNamedTensor(getattr(TestNamedTensor, attr)))
-        setattr(TestNamedTensor, attr, new_test)
 
 if __name__ == '__main__':
     run_tests()


### PR DESCRIPTION
Previously, we would only test named tensors if:
1) we built with BUILD_NAMEDTENSOR=1
2) TEST_NAMEDTENSOR=1 is in the environment.

This PR makes it so that we ALWAYS test named tensors. This is OK
because all the release binaries should be able to run the named tensor
tests and be green; otherwise, there is something wrong.

NOTE: this PR doesn't exist in master. That is because we still want to maintain the named tensor CI / regular CI split.
