### PR TITLE
make default string arguments  in schemas human readable

### DIFF
--- a/aten/src/ATen/core/function_schema.h
+++ b/aten/src/ATen/core/function_schema.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <c10/util/StringUtil.h>
 #include <ATen/core/jit_type.h>
 #include <ATen/core/interned_strings.h>
 #include <ATen/core/ivalue.h>
@@ -322,15 +323,7 @@ inline std::ostream& operator<<(std::ostream& out, const Argument& arg) {
   if (arg.default_value()) {
     out << "=";
     if (arg.type()->kind() == c10::TypeKind::StringType) {
-        // TODO prettify the result, such as using \n to represent \012
-        out << "\'";
-        std::ios_base::fmtflags flags(out.flags());
-        for (unsigned char c : arg.default_value().value().toStringRef()) {
-          out << "\\" << std::oct << std::setfill('0') << std::setw(3)
-            << static_cast<uint64_t>(c);
-        }
-        out.flags(flags);
-        out << "\'";
+        printQuotedString(out, arg.default_value().value().toStringRef());
     } else {
       out << arg.default_value().value();
     }

--- a/c10/util/StringUtil.h
+++ b/c10/util/StringUtil.h
@@ -74,6 +74,65 @@ struct C10_API SourceLocation {
 
 std::ostream& operator<<(std::ostream& out, const SourceLocation& loc);
 
+// unix isprint but insensitive to locale
+inline static bool isPrint(char s) {
+  return s > 0x1f && s < 0x7f;
+}
+
+inline void printQuotedString(std::ostream& stmt, const std::string& str) {
+  stmt << "\"";
+  for (auto s : str) {
+    switch (s) {
+      case '\\':
+        stmt << "\\\\";
+        break;
+      case '\'':
+        stmt << "\\'";
+        break;
+      case '\"':
+        stmt << "\\\"";
+        break;
+      case '\a':
+        stmt << "\\a";
+        break;
+      case '\b':
+        stmt << "\\b";
+        break;
+      case '\f':
+        stmt << "\\f";
+        break;
+      case '\n':
+        stmt << "\\n";
+        break;
+      case '\r':
+        stmt << "\\r";
+        break;
+      case '\t':
+        stmt << "\\t";
+        break;
+      case '\v':
+        stmt << "\\v";
+        break;
+      default:
+        if (isPrint(s)) {
+          stmt << s;
+        } else {
+          // C++ io has stateful formatting settings. Messing with
+          // them is probably worse than doing this manually.
+          char buf[4] = "000";
+          buf[2] += s % 8;
+          s /= 8;
+          buf[1] += s % 8;
+          s /= 8;
+          buf[0] += s;
+          stmt << "\\" << buf;
+        }
+        break;
+    }
+  }
+  stmt << "\"";
+}
+
 } // namespace c10
 
 #endif // C10_UTIL_STRINGUTIL_H_

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -19079,6 +19079,12 @@ class TestClassType(JitTestCase):
                     self.bar = y  # can't assign to non-initialized attr
 
     def test_schema_human_readable(self):
+        """ 
+        Make sure that the schema is human readable, ie the mode parameter should read "nearest" instead of being displayed in octal
+        aten::__interpolate(Tensor input, int? size=None, float[]? scale_factor=None, 
+        str mode='\156\145\141\162\145\163\164', bool? align_corners=None) -> (Tensor): 
+        Expected a value of type 'Optional[int]' for argument 'size' but instead found type 'Tensor'.
+        """
         with self.assertRaisesRegex(RuntimeError, "nearest"):
             @torch.jit.script
             def FooTest(x):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -19078,6 +19078,12 @@ class TestClassType(JitTestCase):
                 def set_non_initialized(self, y):
                     self.bar = y  # can't assign to non-initialized attr
 
+    def test_schema_human_readable(self):
+        with self.assertRaisesRegex(RuntimeError, "nearest"):
+            @torch.jit.script
+            def FooTest(x):
+                return torch.nn.functional.interpolate(x, 'bad')
+
     def test_type_annotations(self):
         with self.assertRaisesRegex(RuntimeError, "Expected a value of type \'bool"):
             @torch.jit.script  # noqa: B903

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -20,8 +20,6 @@
 namespace torch {
 namespace jit {
 
-void printQuotedString(std::ostream& stmt, const std::string& str);
-
 // Constants relating to maintaining the topological index of nodes.
 //
 // Lower and upper bounds of the index. Inclusive range.

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -1,6 +1,7 @@
 #include <torch/csrc/jit/ir.h>
 
 #include <c10/util/Exception.h>
+#include <c10/util/StringUtil.h>
 #include <torch/csrc/jit/constants.h>
 #include <torch/csrc/jit/function.h>
 #include <torch/csrc/jit/operator.h>

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -117,7 +117,7 @@ static void printStrList(
   for (auto& item : items) {
     if (i++ > 0)
       out << ", ";
-    printQuotedString(out, item);
+    c10::printQuotedString(out, item);
   }
   out << "]";
 }
@@ -137,7 +137,7 @@ void Node::printAttrValue(std::ostream& out, const Symbol& name) const {
       printPrimList(out, is(name));
       break;
     case AttributeKind::s:
-      printQuotedString(out, s(name));
+      c10::printQuotedString(out, s(name));
       break;
     case AttributeKind::ss:
       printStrList(out, ss(name));

--- a/torch/csrc/jit/passes/python_print.cpp
+++ b/torch/csrc/jit/passes/python_print.cpp
@@ -1,6 +1,7 @@
 #include <torch/csrc/jit/passes/python_print.h>
 #include <ATen/core/qualified_name.h>
 #include <c10/util/Exception.h>
+#include <c10/util/StringUtil.h>
 #include <torch/csrc/jit/attributes.h>
 #include <torch/csrc/jit/ir.h>
 #include <torch/csrc/jit/ir_views.h>
@@ -12,65 +13,6 @@ using c10::QualifiedName;
 
 namespace torch {
 namespace jit {
-
-// unix isprint but insensitive to locale
-static bool isPrint(char s) {
-  return s > 0x1f && s < 0x7f;
-}
-
-void printQuotedString(std::ostream& stmt, const std::string& str) {
-  stmt << "\"";
-  for (auto s : str) {
-    switch (s) {
-      case '\\':
-        stmt << "\\\\";
-        break;
-      case '\'':
-        stmt << "\\'";
-        break;
-      case '\"':
-        stmt << "\\\"";
-        break;
-      case '\a':
-        stmt << "\\a";
-        break;
-      case '\b':
-        stmt << "\\b";
-        break;
-      case '\f':
-        stmt << "\\f";
-        break;
-      case '\n':
-        stmt << "\\n";
-        break;
-      case '\r':
-        stmt << "\\r";
-        break;
-      case '\t':
-        stmt << "\\t";
-        break;
-      case '\v':
-        stmt << "\\v";
-        break;
-      default:
-        if (isPrint(s)) {
-          stmt << s;
-        } else {
-          // C++ io has stateful formatting settings. Messing with
-          // them is probably worse than doing this manually.
-          char buf[4] = "000";
-          buf[2] += s % 8;
-          s /= 8;
-          buf[1] += s % 8;
-          s /= 8;
-          buf[0] += s;
-          stmt << "\\" << buf;
-        }
-        break;
-    }
-  }
-  stmt << "\"";
-}
 
 static bool isValidIdentifierChar(char c, size_t pos) {
   return islower(c) || isupper(c) || c == '_' || (pos > 0 && isdigit(c));
@@ -891,12 +833,12 @@ struct PythonPrintPass {
     if (v.isTensor()) {
       ss << "CONSTANTS.c" << getOrAddTensorConstant(v.toTensor());
     } else if (v.isString()) {
-      printQuotedString(ss, v.toStringRef());
+      c10::printQuotedString(ss, v.toStringRef());
     } else if (v.isDevice()) {
       std::stringstream device_stream;
       device_stream << v.toDevice();
       ss << "torch.device(";
-      printQuotedString(ss, device_stream.str());
+      c10::printQuotedString(ss, device_stream.str());
       ss << ")";
     } else if (v.isTensorList()) {
       ss << "[";
@@ -1067,7 +1009,7 @@ struct PythonPrintPass {
         } else {
           stmt << "getattr(" << useOf(obj) << ", ";
           std::stringstream field_stream;
-          printQuotedString(field_stream, field);
+          c10::printQuotedString(field_stream, field);
           stmt << field_stream.str() << ")";
         }
       } break;

--- a/torch/csrc/jit/script/schema_matching.cpp
+++ b/torch/csrc/jit/script/schema_matching.cpp
@@ -264,7 +264,7 @@ c10::optional<MatchedSchema> tryMatchSchema(
     std::ostream* failure_messages,
     bool allow_conversions) {
   auto err = [&]() -> std::ostream& {
-    *failure_messages << "Hi Egor\n" << schema << ":Bye 'test' Egor\n";
+    *failure_messages << "\n" << schema << ":\n";
     return *failure_messages;
   };
 

--- a/torch/csrc/jit/script/schema_matching.cpp
+++ b/torch/csrc/jit/script/schema_matching.cpp
@@ -264,7 +264,7 @@ c10::optional<MatchedSchema> tryMatchSchema(
     std::ostream* failure_messages,
     bool allow_conversions) {
   auto err = [&]() -> std::ostream& {
-    *failure_messages << "\n" << schema << ":\n";
+    *failure_messages << "Hi Egor\n" << schema << ":Bye 'test' Egor\n";
     return *failure_messages;
   };
 

--- a/torch/csrc/jit/testing/file_check.cpp
+++ b/torch/csrc/jit/testing/file_check.cpp
@@ -11,6 +11,7 @@
 
 #include <c10/util/Exception.h>
 #include <c10/util/Optional.h>
+#include <c10/util/StringUtil.h>
 #include <torch/csrc/WindowsTorchApiMacro.h>
 #include <torch/csrc/jit/source_range.h>
 #include <algorithm>

--- a/torch/csrc/jit/testing/file_check.cpp
+++ b/torch/csrc/jit/testing/file_check.cpp
@@ -25,8 +25,6 @@
 namespace torch {
 namespace jit {
 
-void printQuotedString(std::ostream& stmt, const std::string& str);
-
 namespace testing {
 
 enum CheckType {

--- a/torch/csrc/jit/testing/file_check.cpp
+++ b/torch/csrc/jit/testing/file_check.cpp
@@ -91,7 +91,7 @@ size_t assertFind(
         SourceRange(search_range.source(), search_range.start(), sub.size());
     std::stringstream ss;
     ss << "Expected to find ";
-    printQuotedString(ss, sub);
+    c10::printQuotedString(ss, sub);
     ss << " but did not find it\n";
     found_range.highlight(ss);
     if (extra_msg) {
@@ -130,7 +130,7 @@ void assertNotFind(
         SourceRange(search_range.source(), pos, sub.size() + pos);
     std::stringstream ss;
     ss << "Expected to not find ";
-    printQuotedString(ss, sub);
+    c10::printQuotedString(ss, sub);
     ss << " but found it\n";
     found_range.highlight(ss);
     ss << "From " << check << "\n";


### PR DESCRIPTION
 [jit] String default args get printed as ascii values #25804 
https://github.com/pytorch/pytorch/issues/25804