### PR TITLE
[pt1][quant] Fix empty_like to add more support when input_tensor has dtype as q(u)int8

### DIFF
--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -211,7 +211,7 @@ Tensor empty_like(
     }
   }
 
-  if (self.is_quantized()) {
+  if (self.is_quantized() && options.dtype() == self.dtype()) {
     // We could check if dtype is still quantized?  But then should we shift/scale
     // the q_zero_point / q_scale or not?
     TORCH_CHECK(!options.has_dtype() || options.dtype() == self.dtype(),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#27092 [pt1][quant] Fix empty_like to add more support when input_tensor has dtype as q(u)int8**
* #27005 [quant][pt1] Uninitialize the accumulation buffer to save some overhead

We would like to add the support for `empty_like` for the case where input_tensor has dtype of q(u)int8 and options has a different type.

Differential Revision: [D17672685](https://our.internmc.facebook.com/intern/diff/D17672685/)