### PR TITLE
Add C++ torch::nn::HingeEmbeddingLoss

### DIFF
--- a/test/cpp/api/functional.cpp
+++ b/test/cpp/api/functional.cpp
@@ -133,3 +133,13 @@ TEST_F(FunctionalTest, AdaptiveAvgPool3d) {
   ASSERT_TRUE(torch::allclose(y, torch::ones({2, 3, 3, 3})));
   ASSERT_EQ(y.sizes(), torch::IntArrayRef({2, 3, 3, 3}));
 }
+
+TEST_F(FunctionalTest, HingeEmbeddingLoss) {
+  auto input = torch::tensor({{2, 22, 4}, {20, 10, 0}}, torch::kFloat);
+  auto target = torch::tensor({{2, 6, 4}, {1, 10, 0}}, torch::kFloat);
+  auto output = F::hinge_embedding_loss(
+      input, target, HingeEmbeddingLossOptions().margin(2));
+  auto expected = torch::tensor({10}, torch::kFloat);
+
+  ASSERT_TRUE(output.allclose(expected));
+}

--- a/test/cpp/api/modules.cpp
+++ b/test/cpp/api/modules.cpp
@@ -800,6 +800,19 @@ TEST_F(ModulesTest, L1Loss) {
   ASSERT_EQ(input.sizes(), input.grad().sizes());
 }
 
+TEST_F(ModulesTest, HingeEmbeddingLoss) {
+  HingeEmbeddingLoss loss(HingeEmbeddingLossOptions().margin(2));
+  auto input = torch::tensor({{2, 22, 4}, {20, 10, 0}}, torch::requires_grad());
+  auto target = torch::tensor({{2, 6, 4}, {1, 10, 0}}, torch::kFloat);
+  auto output = loss->forward(input, target);
+  auto expected = torch::tensor({10}, torch::kFloat);
+  auto s = output.sum();
+  s.backward();
+
+  ASSERT_TRUE(output.allclose(expected));
+  ASSERT_EQ(input.sizes(), input.grad().sizes());
+}
+
 TEST_F(ModulesTest, CosineSimilarity) {
   CosineSimilarity cos(CosineSimilarityOptions().dim(1));
   auto input1 = torch::tensor({{1, 2, 3}, {4, 5, 6}}, torch::requires_grad());
@@ -968,6 +981,12 @@ TEST_F(ModulesTest, PrettyPrintEmbedding) {
   ASSERT_EQ(
       c10::str(Embedding(10, 2)),
       "torch::nn::Embedding(count=10, dimension=2)");
+}
+
+TEST_F(ModulesTest, PrettyPrintHingeEmbeddingLoss) {
+  ASSERT_EQ(
+      c10::str(HingeEmbeddingLoss(HingeEmbeddingLossOptions().margin(4))),
+      "torch::nn::HingeEmbeddingLoss(margin=4)");
 }
 
 TEST_F(ModulesTest, PrettyPrintCosineSimilarity) {

--- a/torch/csrc/api/include/torch/nn/functional.h
+++ b/torch/csrc/api/include/torch/nn/functional.h
@@ -1,4 +1,5 @@
 #pragma once
 
 #include <torch/nn/functional/distance.h>
+#include <torch/nn/functional/loss.h>
 #include <torch/nn/functional/pooling.h>

--- a/torch/csrc/api/include/torch/nn/functional/loss.h
+++ b/torch/csrc/api/include/torch/nn/functional/loss.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <torch/nn/options/loss.h>
+
+namespace torch {
+namespace nn {
+namespace functional {
+
+inline Tensor hinge_embedding_loss(
+    const Tensor& x1,
+    const Tensor& x2,
+    const HingeEmbeddingLossOptions& options) {
+  return torch::hinge_embedding_loss(
+      x1,
+      x2,
+      options.margin(),
+      options.reduction());
+}
+
+} // namespace functional
+} // namespace nn
+} // namespace torch

--- a/torch/csrc/api/include/torch/nn/modules/loss.h
+++ b/torch/csrc/api/include/torch/nn/modules/loss.h
@@ -2,6 +2,7 @@
 
 #include <torch/expanding_array.h>
 #include <torch/nn/cloneable.h>
+#include <torch/nn/functional/loss.h>
 #include <torch/nn/options/loss.h>
 #include <torch/nn/pimpl.h>
 #include <torch/types.h>
@@ -33,6 +34,32 @@ struct TORCH_API L1LossImpl : Module {
 /// provides, or the documentation for `ModuleHolder` to learn about PyTorch's
 /// module storage semantics.
 TORCH_MODULE(L1Loss);
+
+// ============================================================================
+
+/// Creates a criterion that measures the loss given an input tensor :math:`x`
+/// and a labels tensor :math:`y` (containing 1 or -1). This is usually used for
+/// measuring whether two inputs are similar or dissimilar, e.g. using the L1
+/// pairwise distance as :math:`x`, and is typically used for learning nonlinear
+/// embeddings or semi-supervised learning.
+struct TORCH_API HingeEmbeddingLossImpl : Module {
+  explicit HingeEmbeddingLossImpl(
+      const HingeEmbeddingLossOptions& options_ = {});
+
+  /// Pretty prints the `HingeEmbeddingLoss` module into the given `stream`.
+  void pretty_print(std::ostream& stream) const override;
+
+  Tensor forward(const Tensor& input, const Tensor& target);
+
+  /// The options with which this `Module` was constructed.
+  HingeEmbeddingLossOptions options;
+};
+
+/// A `ModuleHolder` subclass for `HingeEmbeddingLossImpl`.
+/// See the documentation for `HingeEmbeddingLossImpl` class to learn what
+/// methods it provides, or the documentation for `ModuleHolder` to learn about
+/// PyTorch's module storage semantics.
+TORCH_MODULE(HingeEmbeddingLoss);
 
 } // namespace nn
 } // namespace torch

--- a/torch/csrc/api/include/torch/nn/options/loss.h
+++ b/torch/csrc/api/include/torch/nn/options/loss.h
@@ -16,5 +16,16 @@ struct TORCH_API L1LossOptions {
   TORCH_ARG(Reduction::Reduction, reduction);
 };
 
+// ============================================================================
+
+/// Options for a Hinge Embedding loss functional and module.
+struct TORCH_API HingeEmbeddingLossOptions {
+  /// Specifies the threshold for which the distance of a negative sample must
+  /// reach in order to incur zero loss. Default: 1
+  TORCH_ARG(double, margin) = 1.0;
+  /// Specifies the reduction to apply to the output. Default: Mean
+  TORCH_ARG(Reduction::Reduction, reduction) = Reduction::Mean;
+};
+
 } // namespace nn
 } // namespace torch

--- a/torch/csrc/api/src/nn/modules/loss.cpp
+++ b/torch/csrc/api/src/nn/modules/loss.cpp
@@ -1,5 +1,7 @@
 #include <torch/nn/modules/loss.h>
 
+namespace F = torch::nn::functional;
+
 namespace torch {
 namespace nn {
 
@@ -12,6 +14,22 @@ void L1LossImpl::pretty_print(std::ostream& stream) const {
 
 Tensor L1LossImpl::forward(const Tensor& input, const Tensor& target) {
   return torch::l1_loss(input, target, options.reduction());
+}
+
+// ============================================================================
+
+HingeEmbeddingLossImpl::HingeEmbeddingLossImpl(
+    const HingeEmbeddingLossOptions& options_)
+    : options(options_) {}
+
+void HingeEmbeddingLossImpl::pretty_print(std::ostream& stream) const {
+  stream << "torch::nn::HingeEmbeddingLoss(margin=" << options.margin() << ")";
+}
+
+Tensor HingeEmbeddingLossImpl::forward(
+    const Tensor& input,
+    const Tensor& target) {
+  return F::hinge_embedding_loss(input, target, options);
 }
 
 } // namespace nn


### PR DESCRIPTION
Adds `torch::nn::HingeEmbeddingLoss` module support for the C++ API.

**Issue**: #25883

**Reviewer**: @yf225