### PR TITLE
[quant][graphmode][fix] insert_prepack_unpack pattern

### DIFF
--- a/torch/csrc/jit/passes/quantization.cpp
+++ b/torch/csrc/jit/passes/quantization.cpp
@@ -889,7 +889,9 @@ graph(%linear, %a_dequant, %w, %b, %w_scale, %w_zero_point, %w_dtype):
                    const std::unordered_map<std::string, Value*>& vmap) {
      const auto& match_vmap = match.values_map;
      auto linear_node = match_vmap.at(vmap.at("linear"))->node();
-     if (linear_node->kind() == prim::Constant && linear_node->s(attr::name) == "linear") {
+     auto func = linear_node->output()->type()->expect<FunctionType>()->function();
+     auto func_name = getFuncName(func->qualname());
+     if (linear_node->kind() == prim::Constant && func_name == "linear") {
        return true;
      }
      return false;

--- a/torch/csrc/jit/passes/quantization.cpp
+++ b/torch/csrc/jit/passes/quantization.cpp
@@ -879,7 +879,7 @@ graph(%a_dequant, %w, %b, %w_scale, %w_zero_point, %w_dtype):
   std::string linear_with_quant_prepack = R"(
 graph(%a_dequant, %w, %b, %w_scale, %w_zero_point, %w_dtype):
         %w_quant = aten::quantize_per_tensor(%w, %w_scale, %w_zero_point, %w_dtype)
-        %packed_params = quantized::linear_prepack(%w, %b)
+        %packed_params = quantized::linear_prepack(%w_quant, %b)
         %w_quant_unpacked : Tensor, %b_unpacked : Tensor? = quantized::linear_unpack(%packed_params)
         %w_dequant = aten::dequantize(%w_quant_unpacked)
         %linear = prim::Constant[name="linear"]()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #27119 [WIP][quant][graphmode] Prepack folding for conv2d
* #27118 [quant][graphmode] Add insert_prepack_unpack for conv2d
* #27103 [quant][graphmode] Enable tests
* **#27102 [quant][graphmode][fix] insert_prepack_unpack pattern**
* #27093 [quant][graphmode] API - add more passes to graph mode

Summary:
We need to prepack the quantized weight rather then original weight

Test Plan:
.

Reviewers:
mvz

Subscribers:

Tasks:

Tags:

Differential Revision: [D17678264](https://our.internmc.facebook.com/intern/diff/D17678264)