### PR TITLE
[android] Module method destroy

### DIFF
--- a/android/pytorch_android/src/main/java/org/pytorch/Module.java
+++ b/android/pytorch_android/src/main/java/org/pytorch/Module.java
@@ -47,6 +47,20 @@ public class Module {
     return mNativePeer.runMethod(methodName, inputs);
   }
 
+  /**
+   * Explicitly destructs native part. Current instance can not be used after this call. This
+   * method may be called multiple times safely. As fbjni library destructs native part
+   * automatically when current instance will be
+   * collected by Java GC, the instance will not leak if this method is not called,
+   * but timing of deletion and the thread will be at the whim of the Java GC.
+   * If you want to control the thread and timing of the destructor, you should call this method
+   * explicitly.
+   * {@link com.facebook.jni.HybridData#resetNative}
+   */
+  public void destroy() {
+    mNativePeer.mHybridData.resetNative();
+  }
+
   private static class NativePeer {
     static {
       System.loadLibrary("pytorch");


### PR DESCRIPTION
cherry-pick for https://github.com/pytorch/pytorch/pull/27090
android api `org.pytorch.Module#destroy()` method that is used by demo-app  and mentioned in tutorials and docs for 1.3.0