### PR TITLE
Make RpcTest class re-usable by other RPC backends

### DIFF
--- a/test/common_distributed.py
+++ b/test/common_distributed.py
@@ -149,7 +149,7 @@ class MultiProcessTestCase(TestCase):
 
         # self.id() == e.g. '__main__.TestDistributed.test_get_rank'
         # We're retreiving a corresponding test and executing it.
-        getattr(self, self.id().split(".")[2])()
+        getattr(self, self.id().split(".")[-1])()
         sys.exit(0)
 
     def _join_processes(self, fn):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#27114 Make RpcTest class re-usable by other RPC backends**

# Problem

Number of splits in test_method_name differs in a test class at a different module import path.

# Solution

Make it general to test classes located at any path.

Differential Revision: [D17074897](https://our.internmc.facebook.com/intern/diff/D17074897/)