### PR TITLE
[pytorch][perf] Use NNPACK for strided convolutions.

### DIFF
--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -193,7 +193,6 @@ auto ConvParams::use_nnpack(const at::Tensor& input) const -> bool {
   return at::_nnpack_available() &&
          input.type().backend() == at::Backend::CPU &&
          input.scalar_type() == kFloat && // only on CPU Float Tensors
-         !is_strided() && // doesn't support strides
          !is_dilated() && // or dilation
          !transposed &&   // or transposed tensors
          input.ndimension() == 4 // must be in NCHW format
@@ -648,7 +647,7 @@ at::Tensor _convolution(
   } else if (input.device().type() == c10::DeviceType::CPU || input.device().type() == c10::DeviceType::CUDA) {
     if (params.use_cpu_depthwise3x3_winograd(input, weight)) {
       output = convolution_depthwise3x3_winograd_stub(
-        input.device().type(), input, weight, bias, params.padding, params.stride, params.groups);
+        input.device().type(), input, weight, bias, params.stride, params.padding, params.groups);
     } else if (params.groups == 1) {
       output = at::_convolution_nogroup(
           input, weight, bias, params.stride, params.padding, params.dilation, params.transposed, params.output_padding);
@@ -717,7 +716,7 @@ at::Tensor _convolution_nogroup(
         if (params.use_nnpack(input)) {
 #if AT_NNPACK_ENABLED()
           return at::_nnpack_spatial_convolution(
-              input, weight, bias, padding);
+              input, weight, bias, stride, padding);
 #endif
         } else {
           /* CPU implementation has specialized MM kernels

--- a/aten/src/ATen/native/NNPACK.cpp
+++ b/aten/src/ATen/native/NNPACK.cpp
@@ -10,7 +10,8 @@ at::Tensor _nnpack_spatial_convolution(
     const at::Tensor& input,
     const at::Tensor& weight,
     const at::Tensor& bias,
-    IntArrayRef padding) {
+    const IntArrayRef stride,
+    const IntArrayRef padding) {
   throw std::runtime_error(
       "nnpack_spatial_convolution: ATen not compiled with NNPACK support");
 }
@@ -135,24 +136,32 @@ constexpr int output_height_dim = 2;
 constexpr int output_width_dim = 3;
 constexpr int weight_output_channels_dim = 0;
 // constexpr int weight_input_channels_dim = 1;
-// constexpr int weight_height_dim = 2;
-// constexpr int weight_width_dim = 3;
+constexpr int weight_height_dim = 2;
+constexpr int weight_width_dim = 3;
 
 // Often written as 2 + max_dim (extra dims for batch size and channels)
 // constexpr int max_dim = 3;
 
 std::vector<int64_t> conv_output_size(
-    IntArrayRef input_size,
-    IntArrayRef weight_size,
-    IntArrayRef padding) {
-  auto dim = input_size.size();
+    const IntArrayRef input_size,
+    const IntArrayRef weight_size,
+    const IntArrayRef stride,
+    const IntArrayRef padding) {
+  const auto calc_output_dimension = [](
+    const int64_t input, const int64_t kernel, const int64_t stride, const int64_t padding) {
+    return 1 + (input - kernel + 2 * padding) / stride;
+  };
+
+  const auto dim = input_size.size();
   std::vector<int64_t> output_size(dim);
+
   output_size[output_batch_size_dim] = input_size[input_batch_size_dim];
   output_size[output_channels_dim] = weight_size[weight_output_channels_dim];
-  output_size[output_height_dim] =
-      input_size[input_height_dim] + 2 * padding[0] - (weight_size[2] - 1);
-  output_size[output_width_dim] =
-      input_size[input_width_dim] + 2 * padding[1] - (weight_size[3] - 1);
+  output_size[output_height_dim] = calc_output_dimension(
+    input_size[input_height_dim], weight_size[weight_height_dim], stride[0], padding[0]);
+  output_size[output_width_dim] = calc_output_dimension(
+    input_size[input_width_dim], weight_size[weight_width_dim], stride[1], padding[1]);
+
   return output_size;
 }
 
@@ -160,9 +169,10 @@ Tensor _nnpack_spatial_convolution(
     const at::Tensor& input,
     const at::Tensor& weight,
     const at::Tensor& bias,
-    IntArrayRef padding) {
+    const IntArrayRef stride,
+    const IntArrayRef padding) {
   at::Tensor output = at::empty(
-      conv_output_size(input.sizes(), weight.sizes(), padding),
+      conv_output_size(input.sizes(), weight.sizes(), stride, padding),
       input.options());
 
   // Our input Tensor must be in the form N,C,H,W
@@ -261,7 +271,7 @@ Tensor _nnpack_spatial_convolution(
   };
 
   auto single = [&]() -> nnp_status {
-    const nnp_size output_subsample = {.width = 1, .height = 1};
+    const nnp_size output_subsample = {.width = stride[0], .height = stride[1]};
     auto input_ = input.contiguous();
     return nnp_convolution_inference(
         algorithm,

--- a/aten/src/ATen/native/cpu/DepthwiseConvKernel.cpp
+++ b/aten/src/ATen/native/cpu/DepthwiseConvKernel.cpp
@@ -27,18 +27,18 @@ struct Arguments final {
 inline std::vector<int64_t> calculate_conv_output_size(
     const IntArrayRef input_size,
     const IntArrayRef weight_size,
-    const IntArrayRef padding,
-    const IntArrayRef stride) {
+    const IntArrayRef stride,
+    const IntArrayRef padding) {
   const auto calc_output_dimension = [](
-    const int64_t input, const int64_t kernel, const int64_t padding, const int64_t stride) {
+    const int64_t input, const int64_t kernel, const int64_t stride, const int64_t padding) {
     return 1 + (input - kernel + 2 * padding) / stride;
   };
 
   return std::vector<int64_t> {
     input_size[0],
     weight_size[0],
-    calc_output_dimension(input_size[2], weight_size[2], padding[0], stride[0]),
-    calc_output_dimension(input_size[3], weight_size[3], padding[1], stride[1]),
+    calc_output_dimension(input_size[2], weight_size[2], stride[0], padding[0]),
+    calc_output_dimension(input_size[3], weight_size[3], stride[1], padding[1]),
   };
 }
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2029,7 +2029,7 @@
 - func: _nnpack_available() -> bool
   use_c10_dispatcher: full
 
-- func: _nnpack_spatial_convolution(Tensor input, Tensor weight, Tensor? bias, int[2] padding) -> Tensor
+- func: _nnpack_spatial_convolution(Tensor input, Tensor weight, Tensor? bias, int[2] stride, int[2] padding) -> Tensor
   variants: function
 
 - func: _nnpack_spatial_convolution_backward(Tensor input, Tensor grad_output, Tensor weight, int[2] padding, bool[3] output_mask) -> (Tensor, Tensor, Tensor)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -8550,8 +8550,8 @@ class TestNN(NNTestCase):
     @unittest.skipIf(not torch._nnpack_available(), "NNPACK unavailable")
     def test_nnpack_conv(self):
         for kern, inp_size in [(3, 6), (3, 7), (4, 9)]:
-            for batch, padding, chan_in, chan_out in \
-                    product([1, 2], [0, 1, 2], [2], [3]):
+            for batch, stride, padding, chan_in, chan_out in \
+                    product([1, 2], [1, 2], [0, 1, 2], [2], [3]):
 
                 for has_bias in [True, False]:
                     input_shape = [batch, chan_in]
@@ -8564,8 +8564,8 @@ class TestNN(NNTestCase):
                     weight = torch.randn(weight_shape, requires_grad=True, dtype=torch.float)
                     if has_bias:
                         bias = torch.randn([chan_out], requires_grad=True, dtype=torch.float)
-                    output = torch._nnpack_spatial_convolution(input, weight, padding=padding, bias=bias)
-                    output_expected = torch.nn.functional.conv2d(input, weight, padding=padding, bias=bias)
+                    output = torch._nnpack_spatial_convolution(input, weight, stirde=stride, padding=padding, bias=bias)
+                    output_expected = torch.nn.functional.conv2d(input, weight, stirde=stride, padding=padding, bias=bias)
                     self.assertAlmostEqual(output, output_expected, delta=3e-4)
 
                     gradient_o = torch.randn(output.shape, dtype=torch.float)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -1441,7 +1441,7 @@
 
 # nnpack
 
-- name: _nnpack_spatial_convolution(Tensor input, Tensor weight, Tensor? bias, int[2] padding) -> Tensor
+- name: _nnpack_spatial_convolution(Tensor input, Tensor weight, Tensor? bias, int[2] stride, int[2] padding) -> Tensor
   input: _nnpack_spatial_convolution_backward_input(input, grad, weight, padding)
   weight: _nnpack_spatial_convolution_backward_weight(input, weight.sizes(), grad, padding)
   bias: grad.contiguous().view({grad.size(0), grad.size(1), -1}).sum(0).sum(1)


### PR DESCRIPTION
Currently fp32 strided convolutions go through a code path that necessitates an im2col (THNN_Floatunfolded_copy) followed by GEMM (THFloatBlas_gemm).  Using NNPACK to achieve the same end goal (via compute_input_packing + compute_matrix_multiplication)
) seems to be more efficient and have better multi-threaded scaling.

All timings are on Pixel 2.

_Before_

Single-threaded: Main run finished. Milliseconds per iter: **353.043**. Iters per second: 2.83252

Multi-threaded: Main run finished. Milliseconds per iter: **361.032**. Iters per second: 2.76984

_After_

Single-threaded: Main run finished. Milliseconds per iter: **333.176**. Iters per second: 3.00141

Multi-threaded: Main run finished. Milliseconds per iter: **247.567**. Iters per second: 4.03931