### PR TITLE
[quant][graphmode] Add insert_prepack_unpack for conv2d

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1137,6 +1137,20 @@ graph(%x : Tensor,
                    .check("quantized::linear_unpack") \
                    .run(get_forward_graph(m._c))
 
+        conv2d_input_str = """
+graph(%a, %w, %b, %a_scale, %a_zero_point, %a_dtype, %w_scale, %w_zero_point, %w_dtype, %stride, %padding, %dilation, %groups):
+        %a_quant = aten::quantize_per_tensor(%a, %a_scale, %a_zero_point, %a_dtype)
+        %a_dequant = aten::dequantize(%a_quant)
+        %w_quant = aten::quantize_per_tensor(%w, %w_scale, %w_zero_point, %w_dtype)
+        # CHECK: quantized::conv2d_prepack
+        # CHECK: quantized::conv2d_unpack
+        %w_dequant = aten::dequantize(%w_quant)
+        %r = aten::conv2d(%a_dequant, %w_dequant, %b, %stride, %padding, %dilation, %groups)
+        return (%r)"""
+        graph = parse_ir(conv2d_input_str)
+        torch._C._jit_pass_insert_prepack_unpack(graph)
+        FileCheck().run(conv2d_input_str, graph)
+
     def test_quant_fusion(self):
         input_strs = [
             # aten::conv2d --> quantized::conv2d

--- a/torch/csrc/jit/passes/quantization.cpp
+++ b/torch/csrc/jit/passes/quantization.cpp
@@ -615,6 +615,29 @@ void InsertQuantDeQuantImpl(
 
   qh.destroyNodes();
 }
+
+void insertPrepackUnpackForConv2d(std::shared_ptr<Graph>& graph) {
+  std::string conv2d_with_quant = R"(
+graph(%a_dequant, %w, %b, %w_scale, %w_zero_point, %w_dtype, %stride, %padding, %dilation, %groups):
+        %w_quant = aten::quantize_per_tensor(%w, %w_scale, %w_zero_point, %w_dtype)
+        %w_dequant = aten::dequantize(%w_quant)
+        %r = aten::conv2d(%a_dequant, %w_dequant, %b, %stride, %padding, %dilation, %groups)
+        return (%r))";
+
+  std::string conv2d_with_quant_prepack = R"(
+graph(%a_dequant, %w, %b, %w_scale, %w_zero_point, %w_dtype, %stride, %padding, %dilation, %groups):
+        %w_quant = aten::quantize_per_tensor(%w, %w_scale, %w_zero_point, %w_dtype)
+        %packed_params = quantized::conv2d_prepack(%w_quant, %b, %stride, %padding, %dilation, %groups)
+        %w_quant_unpacked : Tensor, %b_unpacked : Tensor? = quantized::conv2d_unpack(%packed_params)
+        %w_dequant = aten::dequantize(%w_quant_unpacked)
+        %r = aten::conv2d(%a_dequant, %w_dequant, %b, %stride, %padding, %dilation, %groups)
+        return (%r))";
+
+  SubgraphRewriter rewriter;
+  rewriter.RegisterRewritePattern(conv2d_with_quant, conv2d_with_quant_prepack);
+  rewriter.runOnGraph(graph);
+}
+
 } // namespace
 
 TORCH_API script::Module InsertObservers(
@@ -898,6 +921,8 @@ graph(%linear, %a_dequant, %w, %b, %w_scale, %w_zero_point, %w_dtype):
   SubgraphRewriter rewriter;
   rewriter.RegisterRewritePattern(linear_with_quant, linear_with_quant_prepack);
   rewriter.runOnGraph(graph, filter);
+
+  insertPrepackUnpackForConv2d(graph);
 }
 
 void InsertPrepackUnpack(script::Module& module) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #27239 [refactor] Factor out insertPrepackUnpackForLinear
* #27238 [refactor] InsertObservers
* #27237 [quant][graphmode][fix] Make inserted child module names unique
* #27119 [quant][graphmode] Prepack folding for conv2d
* **#27118 [quant][graphmode] Add insert_prepack_unpack for conv2d**

Summary:
att

Test Plan:
test_jit.py

Reviewers:
mvz

Subscribers:

Tasks:

Tags:

Differential Revision: [D17717637](https://our.internmc.facebook.com/intern/diff/D17717637)