### PR TITLE
Move imports to after is_available in test_rpc to fix windows builds

### DIFF
--- a/test/test_rpc.py
+++ b/test/test_rpc.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import sys
 import unittest
+from os import getenv
 
 import torch
 import torch.distributed as dist
@@ -15,7 +16,6 @@ if not dist.is_available():
 from torch.distributed.rpc import RpcBackend
 from common_distributed import MultiProcessTestCase
 from common_utils import load_tests, run_tests
-from os import getenv
 
 
 BACKEND = getenv("RPC_BACKEND", RpcBackend.PROCESS_GROUP)

--- a/test/test_rpc.py
+++ b/test/test_rpc.py
@@ -5,16 +5,17 @@ import sys
 import unittest
 from os import getenv
 
-import torch
-import torch.distributed as dist
-from common_distributed import MultiProcessTestCase
-from common_utils import load_tests, run_tests
-from torch.distributed.rpc import RpcBackend
 
 
 if not dist.is_available():
     print("c10d not available, skipping tests")
     sys.exit(0)
+
+import torch
+import torch.distributed as dist
+from common_distributed import MultiProcessTestCase
+from common_utils import load_tests, run_tests
+from torch.distributed.rpc import RpcBackend
 
 
 BACKEND = getenv("RPC_BACKEND", RpcBackend.PROCESS_GROUP)

--- a/test/test_rpc.py
+++ b/test/test_rpc.py
@@ -3,19 +3,19 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import sys
 import unittest
-from os import getenv
 
+import torch
+import torch.distributed as dist
 
 
 if not dist.is_available():
     print("c10d not available, skipping tests")
     sys.exit(0)
 
-import torch
-import torch.distributed as dist
+from torch.distributed.rpc import RpcBackend
 from common_distributed import MultiProcessTestCase
 from common_utils import load_tests, run_tests
-from torch.distributed.rpc import RpcBackend
+from os import getenv
 
 
 BACKEND = getenv("RPC_BACKEND", RpcBackend.PROCESS_GROUP)


### PR DESCRIPTION
These imports need to go after the check to not break windows since rpc is not supported on windows. I ran the linter and that moved it to before the check in #26570. This wasn't caught by the windows tests in the PR since it was failing due to a JIT-related reason: (https://ci.pytorch.org/jenkins/job/pytorch-builds/job/pytorch-win-ws2016-cuda9-cudnn7-py3-test2/49433/console). In the future, we should probably have a warning/a comment/some message about discouraging running linters? Thanks to @peterjc123 for flagging this.