### PR TITLE
Fix zero_grad on view grads

### DIFF
--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -161,7 +161,7 @@ class Optimizer(object):
         for group in self.param_groups:
             for p in group['params']:
                 if p.grad is not None:
-                    p.grad.detach_()
+                    p.grad = p.grad.detach()
                     p.grad.zero_()
 
     def step(self, closure):


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/25814. This changes behavior in the sense that previously if a backward is run with `create_graph=True` and the `.grad` is stored elsewhere as a reference, this `zero_grad()` call will detach that reference as well. However, I find that behavior unintuitive and unlikely to happen in practice. Hence I made this BC breaking change.

