### PR TITLE
make python udf serialization format to be binary plus tensor tables

### DIFF
--- a/test/rpc_test.py
+++ b/test/rpc_test.py
@@ -7,6 +7,8 @@ from os import getenv
 
 import torch
 import torch.distributed as dist
+from collections import namedtuple
+from torch.distributed.internal_rpc_utils import _internal_rpc_pickler, PythonUDF
 
 
 if not dist.is_available():
@@ -19,12 +21,77 @@ from common_utils import load_tests
 BACKEND = getenv("RPC_BACKEND", RpcBackend.PROCESS_GROUP)
 RPC_INIT_URL = getenv("RPC_INIT_URL", "")
 
-# it is used to test python user defined function over rpc
+
+# classes and functions are used to test python user defined class and
+# methods over rpc
+TensorClass = namedtuple("TensorClass", ["tensors"])
+
+
+class MyPickleClass:
+    def __init__(self):
+        self.t = None
+
+    def __getstate__(self):
+        (pickled_python_udf, tensors) = _internal_rpc_pickler.serialize(
+            PythonUDF(my_tensor_function,
+                      (torch.ones(2, 2), torch.ones(2, 2)),
+                      None))
+        return (pickled_python_udf, tensors)
+
+    def __setstate__(self, obj):
+        python_udf = _internal_rpc_pickler.deserialize(obj[0], obj[1])
+        result = python_udf.func(python_udf.args[0], python_udf.args[1])
+        self.t = result
+
+    def set(self, val):
+        self.t = val
+
+
+class MyClass:
+    def __init__(self, a):
+        self.a = a
+
+    def my_instance_method(self, b):
+        return self.a + b
+
+    @classmethod
+    def my_class_method(cls, d, e):
+        return d + e
+
+    @staticmethod
+    def my_static_method(f):
+        return f > 10
+
+def run_nested_pickle(pickle_cls_instance, tensor):
+    return pickle_cls_instance.t + tensor
+
+def build_complex_tensors():
+    a = torch.ones(3, 3)
+    b = [a, a]
+    c = [b, b]
+    d = [a, b]
+    e = {a : d}
+    return [a, b, c, d, e]
+
+
 def my_function(a, b, c):
     return a + b + c
 
 
-# it is used to test python user defined function over rpc
+def my_tensor_function(a, b):
+    return a + b
+
+
+def my_complex_tensor_function(list_input, tensor_class_input, dict_input):
+    res = list_input[0]
+    for t in list_input:
+        res += t
+    for k, v in dict_input.items():
+        res += v
+    complex_tensors = tensor_class_input.tensors
+    return (res, complex_tensors[0], complex_tensors[1], complex_tensors[2])
+
+
 def no_result():
     print("do nothing")
 
@@ -44,26 +111,8 @@ def heavy_rpc(tensor):
     return 0
 
 
-# it is used to test python user defined function over rpc
 def raise_func():
     raise ValueError("Expected error")
-
-
-# it is used to test python user defined class and methods over rpc
-class my_class:
-    def __init__(self, a):
-        self.a = a
-
-    def my_instance_method(self, b):
-        return self.a + b
-
-    @classmethod
-    def my_class_method(cls, d, e):
-        return d + e
-
-    @staticmethod
-    def my_static_method(f):
-        return f > 10
 
 
 # load_tests from common_utils is used to automatically filter tests for
@@ -328,7 +377,7 @@ class RpcTest(object):
     def test_py_class_constructor(self):
         n = self.rank + 1
         dst_rank = n % self.world_size
-        ret = dist.rpc_sync("worker{}".format(dst_rank), my_class, args=(n,))
+        ret = dist.rpc_sync("worker{}".format(dst_rank), MyClass, args=(n,))
         self.assertEqual(ret.a, n)
 
     @_wrap_with_rpc
@@ -336,36 +385,36 @@ class RpcTest(object):
         n = self.rank + 1
         dst_rank = n % self.world_size
         ret = dist.rpc_sync(
-            "worker{}".format(dst_rank), my_class(2).my_instance_method, args=(n,)
+            "worker{}".format(dst_rank), MyClass(2).my_instance_method, args=(n,)
         )
-        self.assertEqual(ret, my_class(2).my_instance_method(n))
+        self.assertEqual(ret, MyClass(2).my_instance_method(n))
 
     @_wrap_with_rpc
     def test_py_class_method(self):
         n = self.rank + 1
         dst_rank = n % self.world_size
         ret = dist.rpc_sync(
-            "worker{}".format(dst_rank), my_class.my_class_method, args=(n, n + 1)
+            "worker{}".format(dst_rank), MyClass.my_class_method, args=(n, n + 1)
         )
-        self.assertEqual(ret, my_class.my_class_method(n, n + 1))
+        self.assertEqual(ret, MyClass.my_class_method(n, n + 1))
 
     @_wrap_with_rpc
     def test_py_class_static_method(self):
         n = self.rank + 1
         dst_rank = n % self.world_size
         ret = dist.rpc_sync(
-            "worker{}".format(dst_rank), my_class.my_static_method, args=(n + 10,)
+            "worker{}".format(dst_rank), MyClass.my_static_method, args=(n + 10,)
         )
-        self.assertEqual(ret, my_class.my_static_method(n + 10))
+        self.assertEqual(ret, MyClass.my_static_method(n + 10))
 
     @_wrap_with_rpc
     def test_py_multi_async_call(self):
         n = self.rank + 1
         dst_rank = n % self.world_size
         dst_worker_id = dist.get_worker_id("worker{}".format(dst_rank))
-        fut1 = dist.rpc_async(dst_worker_id, my_class.my_static_method, args=(n + 10,))
+        fut1 = dist.rpc_async(dst_worker_id, MyClass.my_static_method, args=(n + 10,))
         fut2 = dist.rpc_async(dst_worker_id, min, args=(n, n + 1, n + 2))
-        self.assertEqual(fut1.wait(), my_class.my_static_method(n + 10))
+        self.assertEqual(fut1.wait(), MyClass.my_static_method(n + 10))
         self.assertEqual(fut2.wait(), min(n, n + 1, n + 2))
 
     @_wrap_with_rpc
@@ -374,6 +423,61 @@ class RpcTest(object):
         dst_rank = n % self.world_size
         ret = dist.rpc_sync("worker{}".format(dst_rank), no_result)
         self.assertEqual(ret, no_result())
+
+    @_wrap_with_rpc
+    def test_py_tensors(self):
+        n = self.rank + 1
+        dst_rank = n % self.world_size
+        ret = dist.rpc("worker{}".format(dst_rank),
+                       my_tensor_function,
+                       args=(torch.ones(n, n), torch.ones(n, n)))
+        self.assertEqual(ret,
+                         my_tensor_function(torch.ones(n, n),
+                                            torch.ones(n, n)))
+
+    @_wrap_with_rpc
+    def test_py_tensors_multi_async_call(self):
+        futs = []
+        n = self.rank + 1
+        dst_rank = n % self.world_size
+        for i in range(100):
+            fut = dist.rpc("worker{}".format(dst_rank),
+                           my_tensor_function,
+                           args=(torch.ones(i, i), torch.ones(i, i)),
+                           async_call=True)
+            futs.append(fut)
+
+        j = 0
+        for fut in futs:
+            self.assertEqual(fut.wait(),
+                             my_tensor_function(torch.ones(j, j),
+                                                torch.ones(j, j)))
+            j += 1
+
+    @_wrap_with_rpc
+    def test_py_tensors_in_container(self):
+        n = self.rank + 1
+        dst_rank = n % self.world_size
+        a = [torch.ones(n, n), torch.ones(n, n)]
+        b = TensorClass(build_complex_tensors())
+        c = {"foo": torch.ones(n, n), "bar": torch.ones(n, n)}
+        ret = dist.rpc("worker{}".format(dst_rank),
+                       my_complex_tensor_function,
+                       args=(a, b, c))
+        self.assertEqual(ret, my_complex_tensor_function(a, b, c))
+
+    @_wrap_with_rpc
+    def test_py_nested_pickle(self):
+        n = self.rank + 1
+        dst_rank = n % self.world_size
+
+        ret = dist.rpc("worker{}".format(dst_rank),
+                       run_nested_pickle,
+                       args=(MyPickleClass(), torch.ones(2, 2)))
+
+        m = MyPickleClass()
+        m.set(my_tensor_function(torch.ones(2, 2), torch.ones(2, 2)))
+        self.assertEqual(ret, run_nested_pickle(m, torch.ones(2, 2)))
 
     @_wrap_with_rpc
     def test_py_function_exception(self):

--- a/torch/csrc/distributed/rpc/functions.cpp
+++ b/torch/csrc/distributed/rpc/functions.cpp
@@ -50,11 +50,12 @@ Message processRequestBlocking(Message&& request) {
     }
     case MessageType::PYTHON_CALL: {
       try {
-        auto payload =
-            PythonRpcHandler::getInstance().generatePythonUDFResult(request);
+        std::vector<torch::Tensor> tensorTable;
+        auto payload = PythonRpcHandler::getInstance().generatePythonUDFResult(
+            request, tensorTable);
         return Message(
             std::move(payload),
-            std::vector<torch::Tensor>(),
+            std::move(tensorTable),
             MessageType::PYTHON_RET,
             request.id());
       } catch (std::exception& e) {

--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -101,8 +101,9 @@ PyObject* rpc_init(PyObject* /* unused */) {
       "invoke_rpc_python_udf",
       [](RpcAgent& agent,
          const WorkerId& dst,
-         const std::string& pickledPythonUDF) {
-        return pyRpcPythonUdf(agent, dst, pickledPythonUDF);
+         const std::string& pickledPythonUDF,
+         std::vector<torch::Tensor>& tensors) {
+        return pyRpcPythonUdf(agent, dst, pickledPythonUDF, tensors);
       });
 
   module.def(

--- a/torch/csrc/distributed/rpc/python_functions.cpp
+++ b/torch/csrc/distributed/rpc/python_functions.cpp
@@ -109,14 +109,13 @@ std::shared_ptr<RRef> pyRemoteBuiltin(
 std::shared_ptr<FutureMessage> pyRpcPythonUdf(
     RpcAgent& agent,
     const WorkerId& dst,
-    const std::string& pickledPythonUDF) {
+    const std::string& pickledPythonUDF,
+    std::vector<torch::Tensor>& tensors) {
   std::vector<char> data(pickledPythonUDF.begin(), pickledPythonUDF.end());
-  std::vector<torch::Tensor> tensor_table;
 
   return agent.send(
       dst,
-      Message(
-          std::move(data), std::move(tensor_table), MessageType::PYTHON_CALL));
+      Message(std::move(data), std::move(tensors), MessageType::PYTHON_CALL));
 }
 
 } // namespace rpc

--- a/torch/csrc/distributed/rpc/python_functions.h
+++ b/torch/csrc/distributed/rpc/python_functions.h
@@ -28,7 +28,8 @@ std::shared_ptr<FutureMessage> pyRpcBuiltin(
 std::shared_ptr<FutureMessage> pyRpcPythonUdf(
     RpcAgent& agent,
     const WorkerId& dst,
-    const std::string& pickledPythonUDF);
+    const std::string& pickledPythonUDF,
+    std::vector<torch::Tensor>& tensors);
 
 std::shared_ptr<RRef> pyRemoteBuiltin(
     RpcAgent& agent,

--- a/torch/csrc/distributed/rpc/python_rpc_handler.h
+++ b/torch/csrc/distributed/rpc/python_rpc_handler.h
@@ -17,7 +17,9 @@ class PYBIND11_EXPORT PythonRpcHandler {
  public:
   static PythonRpcHandler& getInstance();
   // Execute python UDF, result is pickled to binary string
-  std::vector<char> generatePythonUDFResult(const Message& request);
+  std::vector<char> generatePythonUDFResult(
+      const Message& request,
+      std::vector<torch::Tensor>& tensorTable);
   // Returned python UDF result is pickled binary string, so run python
   // function to unpickle the python UDF result and return py::object to user
   py::object loadPythonUDFResult(const Message& message);

--- a/torch/distributed/internal_rpc_utils.py
+++ b/torch/distributed/internal_rpc_utils.py
@@ -4,30 +4,125 @@ import collections
 import copyreg
 import io
 import pickle
+import six
+import threading
 import traceback
 
+import torch
 
-def serialize(obj):
-    f = io.BytesIO()
-    p = pickle.Pickler(f)
-    p.dispatch_table = copyreg.dispatch_table.copy()
-    p.dump(obj)
-    return f.getvalue()
+# Thread local tensor tables to store tensors while pickling torch.Tensor
+# objects
+_thread_local_tensor_tables = threading.local()
 
 
-def run_python_udf_internal(pickled_python_udf):
-    python_udf = pickle.loads(pickled_python_udf)
+class _InternalRPCPickler:
+    r"""
+    This class provides serialize() and deserialize() interfaces to serialize
+    data to be "binary string + tensor table" format
+    So for RPC python UDF function and args, non tensor data will be serialized
+    into regular binary string, tensor data will be put into thread local tensor
+    tables, this serialization format is consistent with builtin operator and args
+    using JIT pickler. This format will make tensor handling in C++ much easier,
+    e.g. attach tensor to distributed autograd graph in C++
+    """
+    def __init__(self):
+        # python2 does not have dispatch_table, add "if six.PY3" condition,
+        # as _InternalRPCPickler still got build in python2 even
+        # we skipped python 2 tests for rpc_test
+        if six.PY3:
+            self._dispatch_table = copyreg.dispatch_table.copy()
+            self._dispatch_table[torch.Tensor] = self._tensor_reducer
+
+    @classmethod
+    def _tensor_receiver(cls, tensor_index):
+        global _thread_local_tensor_tables
+        return _thread_local_tensor_tables.recv_tables[tensor_index]
+
+    def _tensor_reducer(self, obj):
+        global _thread_local_tensor_tables
+        _thread_local_tensor_tables.send_tables.append(obj)
+        tensor_index = len(_thread_local_tensor_tables.send_tables) - 1
+        return (_InternalRPCPickler._tensor_receiver, (tensor_index, ))
+
+    def serialize(self, obj):
+        r"""
+        Serialize non tensor data into binary string, tensor data into
+        tensor table
+        """
+        f = io.BytesIO()
+        p = pickle.Pickler(f)
+        p.dispatch_table = self._dispatch_table
+
+        # save _thread_local_tensor_tables.send_tables if it is in nested call
+        global _thread_local_tensor_tables
+        if hasattr(_thread_local_tensor_tables, "send_tables"):
+            old_send_tables = _thread_local_tensor_tables.send_tables
+        else:
+            old_send_tables = None
+        _thread_local_tensor_tables.send_tables = []
+
+        p.dump(obj)
+
+        # restore _thread_local_tensor_tables.send_tables if return
+        # from nested call, otherwise clean up the table
+        tensors = _thread_local_tensor_tables.send_tables
+        if old_send_tables is not None:
+            _thread_local_tensor_tables.send_tables = old_send_tables
+        else:
+            del _thread_local_tensor_tables.send_tables
+
+        return (f.getvalue(), tensors)
+
+    def deserialize(self, binary_data, tensor_table):
+        r"""
+        Deserilize binary string + tensor table to original obj
+        """
+        # save _thread_local_tensor_tables.recv_tables if it is in nested call
+        global _thread_local_tensor_tables
+        if hasattr(_thread_local_tensor_tables, "recv_tables"):
+            old_recv_tables = _thread_local_tensor_tables.recv_tables
+        else:
+            old_recv_tables = None
+        _thread_local_tensor_tables.recv_tables = tensor_table
+
+        ret = pickle.loads(binary_data)
+
+        # restore _thread_local_tensor_tables.recv_tables if return
+        # from nested call, otherwise clean up the table
+        if old_recv_tables is not None:
+            _thread_local_tensor_tables.recv_tables = old_recv_tables
+        else:
+            del _thread_local_tensor_tables.recv_tables
+
+        return ret
+
+
+# Create _internal_rpc_pickler only once to initialize _dispatch_table only once
+_internal_rpc_pickler = _InternalRPCPickler()
+
+
+def run_python_udf_internal(pickled_python_udf, tensors):
+    r"""
+    Internal python function will be imported and executed in C++ land
+    it unpickles pickled python udf strings and tensors and run the python
+    udf, return serialized result and tensor tables
+    """
+    python_udf = _internal_rpc_pickler.deserialize(pickled_python_udf, tensors)
     try:
         result = python_udf.func(*python_udf.args, **python_udf.kwargs)
     except Exception as e:
         # except str = exception info + traceback string
         except_str = "{}\n{}".format(repr(e), traceback.format_exc())
         result = RemoteException(except_str)
-    return serialize(result)
+    return _internal_rpc_pickler.serialize(result)
 
 
-def load_python_udf_result_internal(pickled_python_result):
-    result = pickle.loads(pickled_python_result)
+def load_python_udf_result_internal(pickled_python_result, tensors):
+    r"""
+    Internal python function will be imported and executed in C++ land
+    it unpickled pickled python udf result and tensor tables, return python object
+    """
+    result = _internal_rpc_pickler.deserialize(pickled_python_result, tensors)
     if isinstance(result, RemoteException):
         raise Exception(result.msg)
     return result

--- a/torch/distributed/rpc.py
+++ b/torch/distributed/rpc.py
@@ -4,8 +4,8 @@ from . import invoke_rpc_builtin, invoke_rpc_python_udf, invoke_remote_builtin
 from . import init_rref_context
 from . import ProcessGroupAgent
 from . import WorkerId
-from .internal_rpc_utils import serialize, PythonUDF
 from .rpc_backend_registry import is_rpc_backend_registered, init_rpc_backend
+from .internal_rpc_utils import _internal_rpc_pickler, PythonUDF
 
 import sys
 import warnings
@@ -175,9 +175,10 @@ def _invoke_rpc(to, func, args=None, kwargs=None):
             _agent, _to_worker_id(to), qualified_name, *args, **kwargs
         )
     else:
+        (pickled_python_udf, tensors) = _internal_rpc_pickler.serialize(
+            PythonUDF(func, args, kwargs))
         fut = invoke_rpc_python_udf(
-            _agent, _to_worker_id(to), serialize(PythonUDF(func, args, kwargs))
-        )
+            _agent, _to_worker_id(to), pickled_python_udf, tensors)
     return fut
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #27191 skip all rpc and dist autograd spawn tests for <PY36
* **#27136 make python udf serialization format to be binary plus tensor tables**

make python udf serialization format to be binary plus tensor tables, so that tensors can be attached to autograd graph, handled in the same way as builtin operators

Differential Revision: [D17405686](https://our.internmc.facebook.com/intern/diff/D17405686/)