### PR TITLE
Remove reserve from push_list_elements on JIT stack.

### DIFF
--- a/aten/src/ATen/core/stack.h
+++ b/aten/src/ATen/core/stack.h
@@ -95,7 +95,6 @@ static inline void push(Stack& stack, Types&&... args) {
 }
 template <class T>
 static inline void push_list_elements(Stack& stack, const c10::List<T>& elements) {
-  stack.reserve(stack.size() + elements.size());
   for (T elem : elements) {
     stack.push_back(std::move(elem));
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#27140 Remove reserve from push_list_elements on JIT stack.**

Reserve will issue a (non-binding) request to shrink stack size
to the amount you requested to be reserved.  But the whole
point of a stack is that you can extra space if you need to
do nested calls.  Getting rid of the space is a bad idea!
Another failure mode: if we repeatedly push lists of size one,
we'll have quadratic behavior.  Bad.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D17712765](https://our.internmc.facebook.com/intern/diff/D17712765)