### PR TITLE
Disable flaky distributed autograd test under spawn mode

### DIFF
--- a/test/test_dist_autograd_spawn.py
+++ b/test/test_dist_autograd_spawn.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from dist_autograd_test import TestDistAutograd
 from common_distributed import MultiProcessTestCase
-from common_utils import TEST_WITH_ASAN, run_tests
+from common_utils import run_tests
 
 import unittest
 

--- a/test/test_dist_autograd_spawn.py
+++ b/test/test_dist_autograd_spawn.py
@@ -7,7 +7,7 @@ from common_utils import TEST_WITH_ASAN, run_tests
 
 import unittest
 
-@unittest.skipIf(TEST_WITH_ASAN, "Skip ASAN as torch + multiprocessing spawn have known issues")
+@unittest.skip("Test is flaky, see https://github.com/pytorch/pytorch/issues/27157")
 class TestDistAutogradWithSpawn(MultiProcessTestCase, TestDistAutograd):
 
     def setUp(self):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#27158 Disable flaky distributed autograd test under spawn mode**

Differential Revision: [D17693184](https://our.internmc.facebook.com/intern/diff/D17693184)