### PR TITLE
Use FunctionSchema instead of char* for dispatch

### DIFF
--- a/aten/src/ATen/core/ATenDispatch.h
+++ b/aten/src/ATen/core/ATenDispatch.h
@@ -14,6 +14,7 @@
 #include <mutex>
 #include <ATen/core/interned_strings.h>
 #include <ATen/core/stack.h>
+#include <torch/csrc/jit/script/function_schema_parser.h>
 
 // TODO: Rewrite this comment
 //
@@ -73,7 +74,7 @@ namespace detail {
   }
 }
 
-using FallbackBoxedFunction = void(const char* schema, torch::jit::Stack*);
+using FallbackBoxedFunction = void(const c10::FunctionSchema& schema, torch::jit::Stack*);
 
 // Assume T is decayed
 template <typename T>
@@ -128,9 +129,17 @@ class CAFFE2_API ATenOpTable {
 
   C10_NORETURN void reportError(TensorTypeId tid) const;
 
+  const FunctionSchema& function_schema() const {
+    if (!parsed_schema_.has_value()) {
+      parsed_schema_ = torch::jit::parseSchema(schema_);
+    }
+    return *parsed_schema_;
+  }
+
   friend class ATenDispatch;
 
   std::string schema_;
+  mutable c10::optional<c10::FunctionSchema> parsed_schema_;
   void* function_table_[static_cast<int64_t>(TensorTypeId::NumTensorIds)] = {nullptr};
 };
 
@@ -172,7 +181,7 @@ class CAFFE2_API ATenDispatch {
 CAFFE2_API ATenDispatch& globalATenDispatch();
 
 template<class Result, class... Args>
-Result callBoxedFallback(const char* schema, FallbackBoxedFunction* boxed_fallback_fn, Args&&... args,
+Result callBoxedFallback(const c10::FunctionSchema& schema, FallbackBoxedFunction* boxed_fallback_fn, Args&&... args,
   // NB: enable_if must occur in function parameter, because MSVC
   // doesn't like it when it's a template argument next to
   // a parameter pack
@@ -188,7 +197,7 @@ Result callBoxedFallback(const char* schema, FallbackBoxedFunction* boxed_fallba
 
 template<
   class Result, class... Args>
-Result callBoxedFallback(const char* schema, FallbackBoxedFunction* boxed_fallback_fn, Args&&... args,
+Result callBoxedFallback(const c10::FunctionSchema& schema, FallbackBoxedFunction* boxed_fallback_fn, Args&&... args,
   typename c10::guts::enable_if_t<
     supports_boxed_fallback<Result, Args...>::value,
     std::nullptr_t
@@ -231,7 +240,7 @@ Result ATenOpTable::callUnboxed(Args... args) const {
   auto* boxed_fallback_fn = globalATenDispatch().getFallbackBoxedOp(tid);
   if (C10_UNLIKELY(boxed_fallback_fn)) {
     if (supports_boxed_fallback<Result, Args...>::value) {
-      return callBoxedFallback<Result, Args...>(schema_.c_str(), boxed_fallback_fn, std::forward<Args>(args)...);
+      return callBoxedFallback<Result, Args...>(function_schema(), boxed_fallback_fn, std::forward<Args>(args)...);
     } else {
       TORCH_INTERNAL_ASSERT(0, schema_, " does not support boxed fallback, but boxed fallback for ", tid, " was available");
     }


### PR DESCRIPTION
This is useful to make things run a bit faster.  It is tested (implicitly) in the diff stacked above.

Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#27159 Use FunctionSchema instead of char* for dispatch**

Differential Revision: [D17693481](https://our.internmc.facebook.com/intern/diff/D17693481)