### PR TITLE
Rename distributed autograd test to avoid "test" prefix

### DIFF
--- a/test/dist_autograd_test.py
+++ b/test/dist_autograd_test.py
@@ -33,7 +33,7 @@ def dist_init(func):
 
 @unittest.skipIf(not six.PY3, "Pytorch distributed autograd package "
                  "does not support python2")
-class TestDistAutograd(object):
+class DistAutogradTest(object):
 
     @property
     def world_size(self):

--- a/test/test_dist_autograd_fork.py
+++ b/test/test_dist_autograd_fork.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python3
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from dist_autograd_test import TestDistAutograd
+from dist_autograd_test import DistAutogradTest
 from common_distributed import MultiProcessTestCase
 from common_utils import run_tests
 
 
-class TestDistAutogradWithFork(MultiProcessTestCase, TestDistAutograd):
+class DistAutogradWithForkTest(MultiProcessTestCase, DistAutogradTest):
 
     def setUp(self):
-        super(TestDistAutogradWithFork, self).setUp()
+        super(DistAutogradWithForkTest, self).setUp()
         self._fork_processes()
 
 if __name__ == '__main__':

--- a/test/test_dist_autograd_fork.py
+++ b/test/test_dist_autograd_fork.py
@@ -6,10 +6,10 @@ from common_distributed import MultiProcessTestCase
 from common_utils import run_tests
 
 
-class DistAutogradWithForkTest(MultiProcessTestCase, DistAutogradTest):
+class DistAutogradTestWithFork(MultiProcessTestCase, DistAutogradTest):
 
     def setUp(self):
-        super(DistAutogradWithForkTest, self).setUp()
+        super(DistAutogradTestWithFork, self).setUp()
         self._fork_processes()
 
 if __name__ == '__main__':

--- a/test/test_dist_autograd_spawn.py
+++ b/test/test_dist_autograd_spawn.py
@@ -1,17 +1,17 @@
 #!/usr/bin/env python3
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from dist_autograd_test import TestDistAutograd
+from dist_autograd_test import DistAutogradTest
 from common_distributed import MultiProcessTestCase
 from common_utils import TEST_WITH_ASAN, run_tests
 
 import unittest
 
 @unittest.skipIf(TEST_WITH_ASAN, "Skip ASAN as torch + multiprocessing spawn have known issues")
-class TestDistAutogradWithSpawn(MultiProcessTestCase, TestDistAutograd):
+class DistAutogradWithSpawnTest(MultiProcessTestCase, DistAutogradTest):
 
     def setUp(self):
-        super(TestDistAutogradWithSpawn, self).setUp()
+        super(DistAutogradWithSpawnTest, self).setUp()
         self._spawn_processes()
 
 if __name__ == '__main__':

--- a/test/test_dist_autograd_spawn.py
+++ b/test/test_dist_autograd_spawn.py
@@ -8,10 +8,10 @@ from common_utils import run_tests
 import unittest
 
 @unittest.skip("Test is flaky, see https://github.com/pytorch/pytorch/issues/27157")
-class DistAutogradWithSpawnTest(MultiProcessTestCase, DistAutogradTest):
+class DistAutogradTestWithSpawn(MultiProcessTestCase, DistAutogradTest):
 
     def setUp(self):
-        super(DistAutogradWithSpawnTest, self).setUp()
+        super(DistAutogradTestWithSpawn, self).setUp()
         self._spawn_processes()
 
 if __name__ == '__main__':


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#27161 Rename distributed autograd test to avoid "test" prefix**

If the base class starts with "Test", pytest would detect it as a
test class to run. However, the base class does not have a proper
`setUp` method to launch processes. As a result, when I execute 
the following command, I run into test failures:

```
py.test test_dist_autograd_fork.py -k test -vs
```

outputs:

```
test/test_dist_autograd_fork.py::TestDistAutograd::test_autograd_context FAILED
test/test_dist_autograd_fork.py::TestDistAutograd::test_autograd_send_function FAILED
test/test_dist_autograd_fork.py::TestDistAutograd::test_rpc_complex_args FAILED
test/test_dist_autograd_fork.py::DistAutogradTestWithFork::test_autograd_context PASSED
test/test_dist_autograd_fork.py::DistAutogradTestWithFork::test_autograd_send_function PASSED
test/test_dist_autograd_fork.py::DistAutogradTestWithFork::test_rpc_complex_args PASSED
```

Differential Revision: [D17694165](https://our.internmc.facebook.com/intern/diff/D17694165)