### PR TITLE
[pytorch][distributed] add function to get nccl version for error messages

### DIFF
--- a/torch/lib/c10d/CMakeLists.txt
+++ b/torch/lib/c10d/CMakeLists.txt
@@ -52,7 +52,7 @@ set(C10D_SRCS
 set(C10D_LIBS torch)
 
 if(USE_C10D_NCCL)
-  list(APPEND C10D_SRCS ProcessGroupNCCL.cpp)
+  list(APPEND C10D_SRCS ProcessGroupNCCL.cpp NCCLUtils.cpp)
   list(APPEND C10D_LIBS __caffe2_nccl)
 endif()
 

--- a/torch/lib/c10d/NCCLUtils.cpp
+++ b/torch/lib/c10d/NCCLUtils.cpp
@@ -1,0 +1,31 @@
+#include <c10d/NCCLUtils.hpp>
+#include <mutex>
+
+namespace c10d {
+
+std::string getNcclVersion() {
+  static std::once_flag ncclGetVersionFlag;
+  static std::string versionString;
+
+  std::call_once(ncclGetVersionFlag, []() {
+    int version;
+    ncclResult_t status = ncclGetVersion(&version);
+    if (status != ncclSuccess) {
+      versionString = "Unknown NCCL version";
+    }
+    auto ncclMajor = version / 1000;
+    auto ncclMinor = (version % 1000) / 100;
+    auto ncclPatch = version % (ncclMajor * 1000 + ncclMinor * 100);
+    versionString = std::to_string(ncclMajor) + "." +
+        std::to_string(ncclMinor) + "." + std::to_string(ncclPatch);
+  });
+
+  return versionString;
+}
+
+std::string ncclGetErrorWithVersion(ncclResult_t error) {
+  return std::string(ncclGetErrorString(error)) + ", NCCL version " +
+      getNcclVersion();
+}
+
+} // namespace c10d

--- a/torch/lib/c10d/NCCLUtils.hpp
+++ b/torch/lib/c10d/NCCLUtils.hpp
@@ -10,18 +10,20 @@
 #include <nccl.h>
 #include <memory>
 
-#define C10D_NCCL_CHECK(cmd)                                              \
-  do {                                                                    \
-    ncclResult_t error = cmd;                                             \
-    if (error != ncclSuccess) {                                           \
-      std::string err = "NCCL error in: " + std::string(__FILE__) + ":" + \
-          std::to_string(__LINE__) + ", " +                               \
-          std::string(ncclGetErrorString(error));                         \
-      throw std::runtime_error(err);                                      \
-    }                                                                     \
+#define C10D_NCCL_CHECK(cmd)                                                \
+  do {                                                                      \
+    ncclResult_t error = cmd;                                               \
+    if (error != ncclSuccess) {                                             \
+      std::string err = "NCCL error in: " + std::string(__FILE__) + ":" +   \
+          std::to_string(__LINE__) + ", " + ncclGetErrorWithVersion(error); \
+      throw std::runtime_error(err);                                        \
+    }                                                                       \
   } while (0)
 
 namespace c10d {
+
+std::string getNcclVersion();
+std::string ncclGetErrorWithVersion(ncclResult_t error);
 
 // RAII wrapper for NCCL communicator
 class NCCLComm {

--- a/torch/lib/c10d/ProcessGroupNCCL.cpp
+++ b/torch/lib/c10d/ProcessGroupNCCL.cpp
@@ -314,7 +314,7 @@ std::exception_ptr ProcessGroupNCCL::checkForNCCLErrorsInternal(
     ncclResult_t ncclAsyncErr = ncclComm->checkForNcclError();
     if (ncclAsyncErr != ncclSuccess) {
       return std::make_exception_ptr(std::runtime_error(
-          "NCCL error: " + std::string(ncclGetErrorString(ncclAsyncErr))));
+          "NCCL error: " + ncclGetErrorWithVersion(ncclAsyncErr)));
     }
   }
 


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#27170 [pytorch][distributed] add function to get nccl version for error messages**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D17639476/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #27169 [distributed] clearly distinguish between cpu and gpu-only builds in c10d&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D17623948/)

Adds a function that uses ncclGetVersion from the NCCL API to retrieve the NCCL version. Converts it into a readable string, and is called in NCCL-related error messages to log the NCCL version. Hopefully this will help with debugging NCCL errors.

Differential Revision: [D17639476](https://our.internmc.facebook.com/intern/diff/D17639476/)