### PR TITLE
Use FunctionSchema instead of char* for dispatch

### DIFF
--- a/aten/src/ATen/test/CMakeLists.txt
+++ b/aten/src/ATen/test/CMakeLists.txt
@@ -26,6 +26,7 @@ list(APPEND ATen_CPU_TEST_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/weakref_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/quantized_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/extension_backend_test.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/boxed_fallback_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/xla_tensor_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/tensor_iterator_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/cpu_generator_test.cpp

--- a/aten/src/ATen/test/boxed_fallback_test.cpp
+++ b/aten/src/ATen/test/boxed_fallback_test.cpp
@@ -1,0 +1,159 @@
+#include <gtest/gtest.h>
+
+#include <ATen/ATen.h>
+#include <ATen/NativeFunctions.h>
+#include <ATen/core/op_registration/op_registration.h>
+
+#include <ATen/core/ATenDispatch.h>
+
+#include <torch/csrc/jit/operator.h>
+
+using namespace at;
+
+// This test file gives an example of a simple use case for "wrapper"
+// and "mode" style tensor type ids.  In both cases, the implementation
+// of the wrapper/mode simply passes through the call to underlying JIT
+// implementation (so the wrapper/mode doesn't actually do anything),
+// but this could be used as a starting point to do more interesting things.
+
+// TODO: This to be rewritten when bwasti sets up direct access to
+// JIT data structures
+std::shared_ptr<torch::jit::Operator> getOperator(const char* schema_str) {
+  auto schema = torch::jit::parseSchema(schema_str);
+  auto s = Symbol::fromQualString(schema.name());
+  auto operators = torch::jit::getAllOperatorsFor(s);
+  // Find the exact match
+  std::shared_ptr<torch::jit::Operator> op;
+  for (const auto& candidate_op : operators) {
+    auto candidate_schema = candidate_op->schema();
+    // NB: this is a VERY slow equality test
+    if (candidate_schema == schema) {
+      op = candidate_op;
+      break;
+    }
+  }
+  TORCH_INTERNAL_ASSERT(op);
+  return op;
+}
+
+// Global counter for ease of testing
+static int64_t override_call_count = 0;
+
+// Mode implementation
+
+template <bool enabled>
+struct SetGenericMode {
+  bool mode_;
+  SetGenericMode()
+    : mode_(c10::impl::TESTING_ONLY_tls_generic_mode_is_enabled()) {
+    c10::impl::TESTING_ONLY_tls_generic_mode_set_enabled(enabled);
+  }
+  ~SetGenericMode() {
+    c10::impl::TESTING_ONLY_tls_generic_mode_set_enabled(mode_);
+  }
+};
+
+using EnableGenericMode = SetGenericMode<true>;
+using DisableGenericMode = SetGenericMode<false>;
+
+void generic_mode_fallback(const FunctionSchema& schema, torch::jit::Stack* stack) {
+  override_call_count++;
+  auto operation = getOperator(toString(schema).c_str())->getOperation();
+  DisableGenericMode guard;
+  auto offset = operation(*stack);
+  TORCH_INTERNAL_ASSERT(offset == 0);
+}
+
+// Wrapper implementation
+
+struct GenericWrapperTensorImpl : public c10::TensorImpl {
+  explicit GenericWrapperTensorImpl(at::Tensor rep)
+    : TensorImpl(
+        c10::TensorTypeSet(c10::TensorTypeId::TESTING_ONLY_GenericWrapperTensorId),
+        rep.dtype(),
+        rep.device()
+        // TODO: propagate size!
+      )
+    , rep_(std::move(rep)) {}
+
+  at::Tensor rep_;
+};
+
+void generic_wrapper_fallback(const torch::jit::FunctionSchema& schema, torch::jit::Stack* stack) {
+  override_call_count++;
+  auto op = getOperator(toString(schema).c_str());
+  auto operation = op->getOperation();
+
+  auto num_arguments = schema.arguments().size();
+  auto num_returns = schema.returns().size();
+
+  // Unwrap all arguments
+  auto args = torch::jit::pop(*stack, num_arguments);
+  for (size_t i = 0; i < num_arguments; i++) {
+    // TODO: Handle tensor list
+    if (args[i].isTensor()) {
+      auto* impl = args[i].unsafeToTensorImpl();
+      if (impl->type_set().has(TensorTypeId::TESTING_ONLY_GenericWrapperTensorId)) {
+        auto* wrapper = static_cast<GenericWrapperTensorImpl*>(impl);
+        torch::jit::push(*stack, wrapper->rep_);  // no move!
+      } else {
+        torch::jit::push(*stack, std::move(args[i]));
+      }
+    } else {
+      torch::jit::push(*stack, std::move(args[i]));
+    }
+  }
+
+  auto offset = operation(*stack);
+
+  // Rewrap outputs
+  auto rets = torch::jit::pop(*stack, num_returns);
+  for (size_t i = 0; i < num_returns; i++) {
+    // TODO: Handle tensor list
+    if (args[i].isTensor()) {
+      torch::jit::push(*stack, at::detail::make_tensor<GenericWrapperTensorImpl>(std::move(std::move(args[i]).toTensor())) );  // yes move!
+    } else {
+      torch::jit::push(*stack, std::move(args[i]));
+    }
+  }
+
+  TORCH_INTERNAL_ASSERT(offset == 0);
+}
+
+// As the current API does not support unregistering fallback boxed ops,
+// settings of these values are PROCESS global.  Therefore the environment
+// here.
+class Environment : public ::testing::Environment {
+ public:
+  virtual ~Environment() {}
+
+  void SetUp() override {
+    globalATenDispatch().registerFallbackBoxedOp(TensorTypeId::TESTING_ONLY_GenericWrapperTensorId, &generic_wrapper_fallback);
+    globalATenDispatch().registerFallbackBoxedOp(TensorTypeId::TESTING_ONLY_GenericModeTensorId, &generic_mode_fallback);
+  }
+
+  void TearDown() override {}
+};
+
+::testing::Environment* const env =
+    ::testing::AddGlobalTestEnvironment(new Environment);
+
+// There's a case to be made that a more comprehensive test suite would be able
+// to capture many more edge cases.  This test suite is just to show that
+// basic functionality works.
+
+TEST(BoxedFallbackTest, TestBoxedFallbackWithMode) {
+  EnableGenericMode guard;
+
+  override_call_count = 0;
+  Tensor a = ones({5, 5}, kDouble);
+  Tensor b = batch_norm(a, {}, {}, {}, {}, true, 0.1, 1e-05, false);
+  ASSERT_EQ(override_call_count, 2);
+}
+
+TEST(BoxedFallbackTest, TestBoxedFallbackWithWrapper) {
+  override_call_count = 0;
+  Tensor a = at::detail::make_tensor<GenericWrapperTensorImpl>(ones({5, 5}, kDouble));
+  Tensor b = batch_norm(a, {}, {}, {}, {}, true, 0.1, 1e-05, false);
+  ASSERT_EQ(override_call_count, 1);
+}

--- a/aten/src/ATen/test/extension_backend_test.cpp
+++ b/aten/src/ATen/test/extension_backend_test.cpp
@@ -4,6 +4,10 @@
 #include <ATen/NativeFunctions.h>
 #include <ATen/core/op_registration/op_registration.h>
 
+#include <ATen/core/ATenDispatch.h>
+
+#include <torch/csrc/jit/operator.h>
+
 using namespace at;
 
 static int test_int;

--- a/c10/core/TensorTypeId.cpp
+++ b/c10/core/TensorTypeId.cpp
@@ -40,6 +40,10 @@ const char* toString(TensorTypeId t) {
       return "ComplexCUDATensorId";
     case TensorTypeId::VariableTensorId:
       return "VariableTensorId";
+    case TensorTypeId::TESTING_ONLY_GenericModeTensorId:
+      return "TESTING_ONLY_GenericModeTensorId";
+    case TensorTypeId::TESTING_ONLY_GenericWrapperTensorId:
+      return "TESTING_ONLY_GenericWrapperTensorId";
     default:
       return "UNKNOWN_TENSOR_TYPE_ID";
   }

--- a/c10/core/TensorTypeId.h
+++ b/c10/core/TensorTypeId.h
@@ -49,6 +49,19 @@ enum class TensorTypeId : uint8_t {
 
   VariableTensorId,
 
+  // TESTING: This is intended to be a generic testing tensor type id.
+  // Don't use it for anything real; its only acceptible use is within a single
+  // process test.  Use it by creating a TensorImpl with this TensorTypeId, and
+  // then registering operators to operate on this type id.
+  TESTING_ONLY_GenericWrapperTensorId,
+
+  // TESTING: This is intended to be a generic testing tensor type id.
+  // Don't use it for anything real; its only acceptible use is within a ingle
+  // process test.  Use it by toggling the mode on and off via
+  // TESTING_ONLY_tls_generic_mode_set_enabled and then registering operators
+  // to operate on this type id.
+  TESTING_ONLY_GenericModeTensorId,
+
   NumTensorIds, // Sentinel
 };
 

--- a/c10/core/impl/LocalTensorTypeSet.cpp
+++ b/c10/core/impl/LocalTensorTypeSet.cpp
@@ -14,12 +14,30 @@ namespace {
 
 // NB: Zero initialized!
 thread_local uint64_t raw_excluded;
+thread_local uint64_t raw_included;
 
 #else // defined(CAFFE2_FB_LIMITED_MOBILE_CAPABILITY)
 
 uint64_t raw_excluded = 0;
+uint64_t raw_included = 0;
 
 #endif
+
+void set_enabled_via_excluded(TensorTypeId tid, bool enabled) {
+  if (enabled) {
+    raw_excluded = tls_excluded_tensor_type_set().remove(tid).raw_repr();
+  } else {
+    raw_excluded = tls_excluded_tensor_type_set().add(tid).raw_repr();
+  }
+}
+
+void set_enabled_via_included(TensorTypeId tid, bool enabled) {
+  if (enabled) {
+    raw_included = tls_included_tensor_type_set().add(tid).raw_repr();
+  } else {
+    raw_included = tls_included_tensor_type_set().remove(tid).raw_repr();
+  }
+}
 
 }
 
@@ -27,16 +45,24 @@ TensorTypeSet tls_excluded_tensor_type_set() {
   return TensorTypeSet(TensorTypeSet::RAW, raw_excluded);
 }
 
+TensorTypeSet tls_included_tensor_type_set() {
+  return TensorTypeSet(TensorTypeSet::RAW, raw_included);
+}
+
 bool tls_variable_is_enabled() {
   return !tls_excluded_tensor_type_set().has(TensorTypeId::VariableTensorId);
 }
 
 void tls_variable_set_enabled(bool enabled) {
-  if (enabled) {
-    raw_excluded = tls_excluded_tensor_type_set().remove(TensorTypeId::VariableTensorId).raw_repr();
-  } else {
-    raw_excluded = tls_excluded_tensor_type_set().add(TensorTypeId::VariableTensorId).raw_repr();
-  }
+  set_enabled_via_excluded(TensorTypeId::VariableTensorId, enabled);
+}
+
+bool TESTING_ONLY_tls_generic_mode_is_enabled() {
+  return tls_included_tensor_type_set().has(TensorTypeId::TESTING_ONLY_GenericModeTensorId);
+}
+
+void TESTING_ONLY_tls_generic_mode_set_enabled(bool enabled) {
+  set_enabled_via_included(TensorTypeId::TESTING_ONLY_GenericModeTensorId, enabled);
 }
 
 }} // namespace c10::impl

--- a/c10/core/impl/LocalTensorTypeSet.h
+++ b/c10/core/impl/LocalTensorTypeSet.h
@@ -15,8 +15,74 @@
 namespace c10 {
 namespace impl {
 
+C10_API TensorTypeSet tls_excluded_tensor_type_set();
+C10_API TensorTypeSet tls_included_tensor_type_set();
+
+// TODO: There is a semantic distinction here which is not made clear in
+// the naming, and will need to be resolved at some point.  What
+// is the difference between a mode like "Variable" and a mode
+// like "Profiling" or "Tracing"?
+//
+//  - Variable is both a *tensor type* and a *mode*.  Variable is
+//    selected if you have a "variable" tensor (which is most tensors
+//    in PyTorch, except in weird cases like mobile), but after we handle
+//    variable business, we turn it off (putting it in the excluded
+//    set) so that we can process the insides without trigger variable.
+//
+//  - Profiling is a *mode* only.  There is no such thing as a
+//    "profiling" tensor.  By default, profiling is turned off.  If
+//    you turn it on, you want to turn it off once you instrument
+//    a call (unless you're interested in getting nested profiling
+//    ranges, in which case you delegate down the dispatch chain
+//    for the immediate forwarding call, but don't turn it off.)
+//
+//    In the case of turning off profiling inside the body of
+//    a profiled region, there is a degree of freedom: you can either
+//    *disable* profiling, or you can *remove it from the enabled set*.
+//    These two cases are distinguished by what happens if you "enable"
+//    profiling inside of a disabled region (the reentrant case): in the former
+//    case, you can reenable it; in the latter case, "enabling" inside a
+//    disabled region wouldn't actually do anything.
+//
+//    {
+//      EnableProfiling g1;
+//      {
+//        DisableProfiling g2;
+//        {
+//          EnableProfiling g3;
+//          // is profiling on or off here?
+//        }
+//      }
+//    }
+//
+//    There's probably a decent case to be made that "enabling" is a user
+//    visible construct, while "disabling" is an implementation level construct.
+//    So a user will have the tool (guards) to enable profiling, but not
+//    disable it.
+//
+//    Unfortunately, I don't have a good answer for what should happen
+//    in this case, especially for profiling.  For now, disabling profiling
+//    simply removes it from the enabled set, because enabling profiling
+//    MUST add it to the enabled set, and the disable function must
+//    be an inverse (following the rule of minimal API.)
+//
+//  - Tracing is like profiling.  However, if you have turned off tracing
+//    in the body of a function, it doesn't make very much sense to turn
+//    it back on for the current tracing session.  This is because you've
+//    traced a single node that represents all of its body, what are you
+//    going to do with an inner trace?
+//
+//    (This is distinct from reentrant tracing, where you start a completely
+//    different tracing session while in the midst of one tracing session.
+//    This is not really something we support.)
+//
+// So for now, we just mix this all up.  But this all deserves a bigger
+// rethink when it becomes relevant.
+
 C10_API bool tls_variable_is_enabled();
 C10_API void tls_variable_set_enabled(bool enabled);
-C10_API TensorTypeSet tls_excluded_tensor_type_set();
+
+C10_API bool TESTING_ONLY_tls_generic_mode_is_enabled();
+C10_API void TESTING_ONLY_tls_generic_mode_set_enabled(bool enabled);
 
 }} // namespace c10::impl


### PR DESCRIPTION
Depends on landing #26719 first

Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#27178 Use FunctionSchema instead of char* for dispatch**

