### PR TITLE
Relax restrictions on set_num_threads

### DIFF
--- a/aten/src/ATen/ParallelNative.cpp
+++ b/aten/src/ATen/ParallelNative.cpp
@@ -179,8 +179,9 @@ void set_num_threads(int nthreads) {
   TORCH_CHECK(nthreads > 0, "Expected positive number of threads");
   int no_value = NOT_SET;
   TORCH_CHECK(num_intraop_threads.compare_exchange_strong(no_value, nthreads),
-      "Error: cannot set number of interop threads "
-      "after parallel work has started or after set_num_threads call");
+      "Error: cannot set number of intraop threads "
+      "after parallel work has started or after set_num_threads call "
+      "when using native parallel backend");
 #else
   TORCH_CHECK(false, "set_num_threads is not supported for mobile.");
 #endif // C10_MOBILE

--- a/aten/src/ATen/ParallelNativeTBB.cpp
+++ b/aten/src/ATen/ParallelNativeTBB.cpp
@@ -21,11 +21,11 @@ namespace at {
 
 namespace {
 static thread_local tbb::task_scheduler_init tbb_init_(intraop_default_num_threads());
-std::atomic<int> num_intraop_threads_{-1};
 static thread_local tbb::task_group tg_;
 
 std::mutex global_thread_mutex_;
 std::shared_ptr<tbb::global_control> global_thread_limit_ = nullptr;
+std::atomic<int> num_intraop_threads_{-1};
 
 void _internal_set_num_threads(int nthreads) {
   TORCH_INTERNAL_ASSERT(nthreads > 0);
@@ -33,6 +33,7 @@ void _internal_set_num_threads(int nthreads) {
     std::unique_lock<std::mutex> lk(global_thread_mutex_);
     global_thread_limit_ = std::make_shared<tbb::global_control>(
         tbb::global_control::max_allowed_parallelism, nthreads);
+    num_intraop_threads_.store(nthreads);
   }
   if (tbb_init_.is_active()) {
     tbb_init_.terminate();
@@ -59,14 +60,8 @@ void init_num_threads() {
 
 void set_num_threads(int nthreads) {
   TORCH_CHECK(nthreads > 0);
-  int no_value = -1;
-  if (num_intraop_threads_.compare_exchange_strong(no_value, nthreads)) {
-    _internal_set_num_threads(nthreads);
-    return;
-  }
-  TORCH_CHECK(false,
-    "Error: cannot set number of interop threads "
-    "after parallel work has started or after set_num_threads call");
+
+  _internal_set_num_threads(nthreads);
 }
 
 int get_num_threads() {

--- a/aten/src/ATen/test/test_parallel.cpp
+++ b/aten/src/ATen/test/test_parallel.cpp
@@ -69,3 +69,12 @@ TEST(TestParallel, IntraOpLaunchFuture) {
 
   ASSERT_TRUE(v1 == 1 && v2 == 2);
 }
+
+TEST(TestParallel, MultipleSetNumThreadsCalls) {
+#if !AT_PARALLEL_NATIVE
+  set_num_threads(5);
+  ASSERT_TRUE(get_num_threads() == 5);
+  set_num_threads(10);
+  ASSERT_TRUE(get_num_threads() == 10);
+#endif
+}

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -899,12 +899,12 @@ cdist(x1, x2, p=2) -> Tensor
 
 Computes the p-norm distance between each pair of the two collections of row vectors.
 
-If x1 has shape :math:`P \times M` and x2 has shape :math:`R \times M` then the 
+If x1 has shape :math:`P \times M` and x2 has shape :math:`R \times M` then the
 output will have shape :math:`P \times R`.
 
-This function is equivalent to `scipy.spatial.distance.cdist(input,'minkowski', p=p)` 
-if :math:`p \in (0, \infty)`. When :math:`p = 0` it is equivalent to 
-`scipy.spatial.distance.cdist(input, 'hamming') * M`. When :math:`p = \infty`, the closest 
+This function is equivalent to `scipy.spatial.distance.cdist(input,'minkowski', p=p)`
+if :math:`p \in (0, \infty)`. When :math:`p = 0` it is equivalent to
+`scipy.spatial.distance.cdist(input, 'hamming') * M`. When :math:`p = \infty`, the closest
 scipy function is `scipy.spatial.distance.cdist(xn, lambda x, y: np.abs(x - y).max())`.
 
 Args:
@@ -4569,7 +4569,7 @@ add_docstr(torch.set_num_threads,
            r"""
 set_num_threads(int)
 
-Sets the number of threads used for parallelizing CPU operations.
+Sets the number of threads used for intraop parallelism on CPU.
 WARNING:
 To ensure that the correct number of threads is used, set_num_threads
 must be called before running eager, JIT or autograd code.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#27190 Relax restrictions on set_num_threads**

Summary:
Allow set_num_threads to be called multiple times in case of TBB
parallel backend

Test Plan:
BUILD_BINARY=1 USE_TBB=1 ATEN_THREADING=TBB python setup.py develop
install  --cmake
./build/bin/test_parallel
./build/bin/thread_init_test

Differential Revision: [D17704236](https://our.internmc.facebook.com/intern/diff/D17704236)