### PR TITLE
[ATEN->C10] Migrate return type void to () for native functions.

### DIFF
--- a/aten/src/ATen/core/OpsAlreadyMovedToC10.cpp
+++ b/aten/src/ATen/core/OpsAlreadyMovedToC10.cpp
@@ -38,6 +38,7 @@ bool aten_op_is_already_moved_to_c10(const c10::OperatorName& opName) {
         {"aten::_cast_Long", ""},
         {"aten::_cast_Short", ""},
         {"aten::_cast_Half", ""},
+        {"aten::set_data", ""},
         {"aten::data", ""},
     #ifdef BUILD_NAMEDTENSOR
         {"aten::align_as", ""},
@@ -196,6 +197,8 @@ bool aten_op_is_already_moved_to_c10(const c10::OperatorName& opName) {
         {"aten::_fft_with_size", ""},
         {"aten::_cufft_get_plan_cache_size", ""},
         {"aten::_cufft_get_plan_cache_max_size", ""},
+        {"aten::_cufft_set_plan_cache_max_size", ""},
+        {"aten::_cufft_clear_plan_cache", ""},
         {"aten::index_copy_", ""},
         {"aten::index_copy", ""},
         {"aten::inverse", ""},
@@ -776,7 +779,6 @@ bool aten_op_is_already_moved_to_c10(const c10::OperatorName& opName) {
 bool aten_op_is_not_moved_to_c10_yet(const c10::OperatorName& opName) {
   static std::unordered_set<std::pair<const char*, const char*>, OpNameHash, OpNameEquals> ops {
         {"aten::backward", ""},
-        {"aten::set_data", ""},
         {"aten::is_leaf", ""},
         {"aten::output_nr", ""},
         {"aten::_version", ""},
@@ -943,8 +945,6 @@ bool aten_op_is_not_moved_to_c10_yet(const c10::OperatorName& opName) {
         {"aten::hamming_window", "periodic_alpha_beta"},
         {"aten::ger", "out"},
         {"aten::group_norm", ""},
-        {"aten::_cufft_set_plan_cache_max_size", ""},
-        {"aten::_cufft_clear_plan_cache", ""},
         {"aten::index", "Tensor"},
     #ifdef BUILD_NAMEDTENSOR
         {"aten::index_copy_", "dimname"},

--- a/aten/src/ATen/core/TensorMethods.h
+++ b/aten/src/ATen/core/TensorMethods.h
@@ -63,7 +63,7 @@ inline void Tensor::backward(const Tensor & gradient, bool keep_graph, bool crea
     at::AutoNonVariableTypeMode _var_guard(true);
      TypeDefault::backward(const_cast<Tensor&>(*this), gradient, keep_graph, create_graph);
 #else
-    static auto table = globalATenDispatch().getOpTable("aten::backward(Tensor self, Tensor? gradient=None, bool keep_graph=False, bool create_graph=False) -> void");
+    static auto table = globalATenDispatch().getOpTable("aten::backward(Tensor self, Tensor? gradient=None, bool keep_graph=False, bool create_graph=False) -> ()");
     return table->callUnboxed<void, const Tensor &, const Tensor &, bool, bool>(const_cast<Tensor&>(*this), gradient, keep_graph, create_graph);
 #endif
 }
@@ -72,8 +72,9 @@ inline void Tensor::set_data(const Tensor & new_data) const {
     at::AutoNonVariableTypeMode _var_guard(true);
      TypeDefault::set_data(const_cast<Tensor&>(*this), new_data);
 #else
-    static auto table = globalATenDispatch().getOpTable("aten::set_data(Tensor(a!) self, Tensor new_data) -> void");
-    return table->callUnboxed<void, const Tensor &, const Tensor &>(const_cast<Tensor&>(*this), new_data);
+    static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::set_data", ""}).value();
+    return c10::Dispatcher::singleton().callUnboxedOnly<void, const Tensor &, const Tensor &>(
+        op, impl::dispatchTypeId(at::detail::multi_dispatch_tensor_type_set(*this, new_data)), const_cast<Tensor&>(*this), new_data);
 #endif
 }
 inline Tensor Tensor::data() const {

--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -1,6 +1,8 @@
 # HEY! Trying to understand what this file does?  Read
 # "what has to be done to add a Operation ..." first!
 
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import re
 from code_template import CodeTemplate
 
@@ -887,7 +889,10 @@ def create_generic(top_env, declarations):
 
     def format_return_type(return_types):
         # type: (List[ReturnType]) -> str
-        if len(return_types) == 1:
+        len_return_types = len(return_types)
+        if len_return_types == 0:
+            return "void"
+        if len_return_types == 1:
             return return_types[0]['type']
         return "std::tuple<{}>".format(','.join(r['type'] for r in return_types))
 
@@ -1116,9 +1121,6 @@ def create_generic(top_env, declarations):
             if isinstance(t_raw, string_type):
                 t = t_raw
                 name = None
-            elif t_raw is None:
-                t = 'void'
-                name = None
             else:
                 t = t_raw['type']
                 name = t_raw['name']
@@ -1149,7 +1151,6 @@ def create_generic(top_env, declarations):
         assert option['python_module'] == '' or option['python_module'] == 'nn', \
             "Found python_module of {} for decl {}, but only \'\' string or \'nn\' are supported".format(
                 option['python_module'], option['name'])
-
         formals = native_get_formals(option)
         option['formals_list'] = formals
         option['formals'] = [format_formal(f) for f in formals]

--- a/aten/src/ATen/gen.py
+++ b/aten/src/ATen/gen.py
@@ -1,4 +1,6 @@
 
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import argparse
 import os
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -37,10 +37,11 @@
   use_c10_dispatcher: full
   variants: function
 
-- func: backward(Tensor self, Tensor? gradient=None, bool keep_graph=False, bool create_graph=False) -> void
+- func: backward(Tensor self, Tensor? gradient=None, bool keep_graph=False, bool create_graph=False) -> ()
   variants: method
 
-- func: set_data(Tensor(a!) self, Tensor new_data) -> void
+- func: set_data(Tensor(a!) self, Tensor new_data) -> Tensor(a!)
+  use_c10_dispatcher: unboxed_only
   variants: method
 
 - func: data(Tensor self) -> Tensor
@@ -1342,9 +1343,11 @@
 - func: _cufft_get_plan_cache_max_size(int device_index) -> int
   use_c10_dispatcher: full
 
-- func: _cufft_set_plan_cache_max_size(int device_index, int max_size) -> void
+- func: _cufft_set_plan_cache_max_size(int device_index, int max_size) -> ()
+  use_c10_dispatcher: unboxed_only
 
-- func: _cufft_clear_plan_cache(int device_index) -> void
+- func: _cufft_clear_plan_cache(int device_index) -> ()
+  use_c10_dispatcher: unboxed_only
 
 - func: index.Tensor(Tensor self, Tensor?[] indices) -> Tensor
   variants: function, method

--- a/aten/src/ATen/native_parse.py
+++ b/aten/src/ATen/native_parse.py
@@ -310,7 +310,7 @@ def parse_arguments(args, func_variants, declaration, func_return):
 
     # TODO: Explicit checking for void is a hack and should disappear after a more
     # functionally complete implementation of Tensor aliases.
-    if declaration['inplace'] and len(func_return) > 0 and func_return[0]['type'] != "void":
+    if declaration['inplace'] and len(func_return) > 0:
         found_self = False
         for arg_idx, argument in enumerate(arguments):
             if argument['name'] == "self":
@@ -331,12 +331,15 @@ def parse_arguments(args, func_variants, declaration, func_return):
 
 def parse_return_arguments(return_decl, inplace, func_decl):
     arguments = []
+    if return_decl == '()':
+        return arguments
+
     # TODO: Use a real parser here; this will get bamboozled
     # by signatures that contain things like std::array<bool, 2> (note the space)
     if return_decl[0] == '(' and return_decl[-1] == ')':
         return_decl = return_decl[1:-1]
-    multiple_args = len(return_decl.split(', ')) > 1
 
+    multiple_args = len(return_decl.split(', ')) > 1
     for arg_idx, arg in enumerate(return_decl.split(', ')):
         t, name, default, nullable, size, annotation = type_argument_translations(arg)
         # name of arguments and name of return sometimes have collision

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -509,7 +509,8 @@ def emit_body(declaration):
     inplace = declaration['inplace']
     is_out_fn = name.endswith('_out')
     modifies_arguments = inplace or is_out_fn
-    returns_void = len(returns) == 1 and returns[0]['type'] == 'void'
+    len_returns = len(returns)
+    returns_void = len_returns == 0
 
     base_name = name[:-1] if inplace else name[:-4] if is_out_fn else name
     view_info = VIEW_FUNCTIONS.get(base_name, None)

--- a/tools/jit/gen_jit_dispatch.py
+++ b/tools/jit/gen_jit_dispatch.py
@@ -12,6 +12,8 @@ generated.  In the full build system, OUTPUT_DIR is
 torch/csrc/jit/generated/
 """
 
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import argparse
 import copy
 import re
@@ -203,7 +205,8 @@ def is_jit_arg(i, arg):
 
 def is_jit_op(decl):
     # We currently don't support functions that return nothing
-    if all(r['type'] == 'void' for r in decl['returns']):
+    assert all(r['type'] != 'void' for r in decl['returns'])
+    if len(decl['returns']) == 0:
         return False
 
     arguments = decl['arguments']


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#27192 [ATEN->C10] Migrate return type void to () for native functions.**

Differential Revision: [D17565528](https://our.internmc.facebook.com/intern/diff/D17565528/)