### PR TITLE
Fix error report highlight for unmatched type annotation 

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -3552,34 +3552,40 @@ def foo(x):
     def test_unmatched_type_annotation(self):
         message1 = re.escape("Number of type annotations (2) did not match the number of function parameters (1):")
         message2 = re.escape("""
-            def invalid(a):
-            ~~~~~~~~~~~~~ <--- HERE
+            def invalid2(a):
+            ~~~~~~~~~~~~~~ <--- HERE
+                # type: (Int, Int) -> Int
+                return a + 2
+        """.strip())
+        message3 = re.escape("""
+            def invalid4(a):
+            ~~~~~~~~~~~~~~ <--- HERE
                 # type: (Int, Int) -> Int
                 return a + 2
         """.strip())
         with self.assertRaisesRegex(RuntimeError, message1):
             @torch.jit.script
-            def invalid(a):
+            def invalid1(a):
                 # type: (Int, Int) -> Int
                 return a + 2
 
         with self.assertRaisesRegex(RuntimeError, message2):
             @torch.jit.script
-            def invalid(a):
+            def invalid2(a):
                 # type: (Int, Int) -> Int
                 return a + 2
 
         with self.assertRaisesRegex(RuntimeError, message1):
-            def invalid(a):
+            def invalid3(a):
                 # type: (Int, Int) -> Int
                 return a + 2
-            torch.jit.script(invalid)
+            torch.jit.script(invalid3)
 
-        with self.assertRaisesRegex(RuntimeError, message2):
-            def invalid(a):
+        with self.assertRaisesRegex(RuntimeError, message3):
+            def invalid4(a):
                 # type: (Int, Int) -> Int
                 return a + 2
-            torch.jit.script(invalid)
+            torch.jit.script(invalid4)
 
     def test_is_optional(self):
         ann = Union[List[int], List[float]]

--- a/torch/csrc/jit/script/parser.cpp
+++ b/torch/csrc/jit/script/parser.cpp
@@ -19,7 +19,7 @@ Decl mergeTypesFromTypeComment(
     expected_num_annotations -= 1;
   }
   if (expected_num_annotations != type_annotation_decl.params().size()) {
-    throw ErrorReport(type_annotation_decl.range())
+    throw ErrorReport(decl.range())
         << "Number of type annotations ("
         << type_annotation_decl.params().size()
         << ") did not match the number of "
@@ -650,7 +650,7 @@ struct ParserImpl {
         paramlist.range(), List<Param>(paramlist), return_annotation);
   }
 
-TreeRef parseClass() {
+  TreeRef parseClass() {
     L.expect(TK_CLASS_DEF);
     const auto name = parseIdent();
     Maybe<Expr> superclass = Maybe<Expr>::create(name.range());

--- a/torch/csrc/jit/script/parser.cpp
+++ b/torch/csrc/jit/script/parser.cpp
@@ -650,7 +650,7 @@ struct ParserImpl {
         paramlist.range(), List<Param>(paramlist), return_annotation);
   }
 
-  TreeRef parseClass() {
+TreeRef parseClass() {
     L.expect(TK_CLASS_DEF);
     const auto name = parseIdent();
     Maybe<Expr> superclass = Maybe<Expr>::create(name.range());

--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -193,7 +193,8 @@ def build_class_def(ctx, py_def, methods, self_name):
 
 def build_def(ctx, py_def, type_line, self_name=None):
     body = py_def.body
-    r = ctx.make_range(py_def.lineno, py_def.col_offset,
+    r = ctx.make_range(py_def.lineno + len(py_def.decorator_list),
+                       py_def.col_offset,
                        py_def.col_offset + len("def"))
     param_list = build_param_list(ctx, py_def.args, self_name)
     return_type = None


### PR DESCRIPTION
This PR fixes https://github.com/pytorch/pytorch/issues/25801 (see there for my verbose analysis).

As an example, for the following code:

```
import torch

@torch.jit.script
def f1(x):
    # type: (int, int) -> None
    pass
```

this PR will change error message from this:

```
RuntimeError:
Number of type annotations (2) did not match the number of function parameters (1):
# type: (int, int) -> None
```

to this:

```
RuntimeError:
Number of type annotations (2) did not match the number of function parameters (1):
at __scratch__/example.py:4:0
@torch.jit.script
def f1(x):
~~~~~~~~ <--- HERE
    # type: (int, int) -> None
    pass
```
