### PR TITLE
Support 0-batch size for nn.Linear.

### DIFF
--- a/aten/src/TH/generic/THTensorMath.cpp
+++ b/aten/src/TH/generic/THTensorMath.cpp
@@ -298,20 +298,29 @@ static void THTensor_(addmmImpl)(THTensor *r_, THTensor *t, THTensor *m1, THTens
   int64_t ldm1_ = (transpose_m1 == 'n' ? m1_->stride((transpose_r == 'n' ? 1 : 0)) : m1_->stride((transpose_r == 'n' ? 0 : 1)));
   int64_t ldm2_ = (transpose_m2 == 'n' ? m2_->stride((transpose_r == 'n' ? 1 : 0)) : m2_->stride((transpose_r == 'n' ? 0 : 1)));
 
-  /* do the operation */
-  THBlas_(gemm)(transpose_m1,
-                transpose_m2,
-                m,
-                n,
-                k,
-                alpha,
-                m1_->data<scalar_t>(),
-                ldm1_,
-                m2_->data<scalar_t>(),
-                ldm2_,
-                beta,
-                r__->data<scalar_t>(),
-                ldr__);
+  // Don't go through GEMM if result is empty matrix, since this is not
+  // supported by BLAS.
+  if (m != 0 && n != 0) {
+    if (k == 0) {
+      THTensor_(mul)(r__, r__, beta);
+    } else {
+      /* do the operation */
+      THBlas_(gemm)(transpose_m1,
+                    transpose_m2,
+                    m,
+                    n,
+                    k,
+                    alpha,
+                    m1_->data<scalar_t>(),
+                    ldm1_,
+                    m2_->data<scalar_t>(),
+                    ldm2_,
+                    beta,
+                    r__->data<scalar_t>(),
+                    ldr__);
+    }
+  }
+
 
   /* free intermediate variables */
   if(free_m1)

--- a/aten/src/THC/generic/THCTensorMathBlas.cu
+++ b/aten/src/THC/generic/THCTensorMathBlas.cu
@@ -305,6 +305,20 @@ static void THCTensor_(addmmImpl)(THCState *state, THCTensor *r_, THCTensor *t, 
     }
   }
 
+  // Special casing for empty matrices
+  if (r_->size(0) == 0 || r_->size(1) == 0) {
+    // No multiplication needed for case of empty result matrix.
+    return;
+  } else if (m1->size(1) == 0) {
+    // k == 0
+    if (ScalarConvert<scalar_t, double>::to(beta) != 0.0) {
+      THCTensor_(mul)(state, r_, r_, beta);
+    } else {
+      THCTensor_(zero)(state, r_);
+    }
+    return;
+  }
+
   /* r_ */
   if(r_->stride(0) == 1 &&
      r_->stride(1) != 0)

--- a/test/common_nn.py
+++ b/test/common_nn.py
@@ -57,6 +57,18 @@ module_tests = [
         reference_fn=lambda i, p, _: torch.mm(i, p[0].t())
     ),
     dict(
+        module_name='Linear',
+        constructor_args=(10, 8),
+        input_size=(0, 10),
+        desc='zero_batch',
+    ),
+    dict(
+        module_name='Linear',
+        constructor_args=(10, 8, False),
+        input_size=(0, 10),
+        desc='zero_batch_no_bias',
+    ),
+    dict(
         module_name='Threshold',
         constructor_args=(2., 1.),
         input_size=(2, 3, 4, 5),


### PR DESCRIPTION
Summary:
At the current moment of time nn.Linear (an it's interal functional code), will
fail in THBlas:

RuntimeError: invalid argument 8: lda should be at least max(1, 0), but have 0 at caffe2/aten/src/TH/generic/THBlas.cpp:363

This diff is trying to fix this bug.

As of now I was able to identify 2 possible places where changes needs to be done based on current dispatcher logic:
1. The file touched in this diff
2. caffe2/aten/src/THC/generic/THCTensorMathBlas.cu

At the moment I didn't find a better places comparing to injecting logic to those files:
the only non-generated function for forward pass, this + mm_mat2_backward function family on a backward pass.

Test Plan: New unit-tests are passing. Code that was failing earlier works. Need to test other backends.

Differential Revision: D17599915

