### PR TITLE
Make static dispatch turn off variable before entering the kernel. (#…

### DIFF
--- a/aten/src/ATen/core/TensorMethods.h
+++ b/aten/src/ATen/core/TensorMethods.h
@@ -11,6 +11,7 @@
 #include <ATen/core/dispatch/Dispatcher.h>
 #include <ATen/core/NamedTensor.h>
 #include <ATen/core/EnableNamedTensor.h>
+#include <ATen/core/LegacyTypeDispatch.h>
 
 #ifdef USE_STATIC_DISPATCH
 #include <ATen/TypeDefault.h>
@@ -59,6 +60,7 @@ inline TensorOptions Tensor::options() const {
 // all static inline to allow for inlining of the non-dynamic part of dispatch
 inline void Tensor::backward(const Tensor & gradient, bool keep_graph, bool create_graph) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
      TypeDefault::backward(const_cast<Tensor&>(*this), gradient, keep_graph, create_graph);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::backward(Tensor self, Tensor? gradient=None, bool keep_graph=False, bool create_graph=False) -> void");
@@ -67,6 +69,7 @@ inline void Tensor::backward(const Tensor & gradient, bool keep_graph, bool crea
 }
 inline void Tensor::set_data(const Tensor & new_data) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
      TypeDefault::set_data(const_cast<Tensor&>(*this), new_data);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::set_data(Tensor(a!) self, Tensor new_data) -> void");
@@ -75,6 +78,7 @@ inline void Tensor::set_data(const Tensor & new_data) const {
 }
 inline Tensor Tensor::data() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::data(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::data", ""}).value();
@@ -84,6 +88,7 @@ inline Tensor Tensor::data() const {
 }
 inline bool Tensor::is_leaf() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::is_leaf(const_cast<Tensor&>(*this));
 #else
     static auto table = globalATenDispatch().getOpTable("aten::is_leaf(Tensor self) -> bool");
@@ -92,6 +97,7 @@ inline bool Tensor::is_leaf() const {
 }
 inline int64_t Tensor::output_nr() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::output_nr(const_cast<Tensor&>(*this));
 #else
     static auto table = globalATenDispatch().getOpTable("aten::output_nr(Tensor self) -> int");
@@ -100,6 +106,7 @@ inline int64_t Tensor::output_nr() const {
 }
 inline int64_t Tensor::_version() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::_version(const_cast<Tensor&>(*this));
 #else
     static auto table = globalATenDispatch().getOpTable("aten::_version(Tensor self) -> int");
@@ -109,6 +116,7 @@ inline int64_t Tensor::_version() const {
 #ifdef BUILD_NAMEDTENSOR
 inline Tensor & Tensor::rename_(c10::optional<DimnameList> names) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::rename_(const_cast<Tensor&>(*this), names);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::rename_(Tensor(a!) self, Dimname[]? names) -> Tensor(a!)");
@@ -119,6 +127,7 @@ inline Tensor & Tensor::rename_(c10::optional<DimnameList> names) const {
 #ifdef BUILD_NAMEDTENSOR
 inline Tensor Tensor::rename(c10::optional<DimnameList> names) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::rename(const_cast<Tensor&>(*this), names);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::rename(Tensor(a) self, Dimname[]? names) -> Tensor(a)");
@@ -129,6 +138,7 @@ inline Tensor Tensor::rename(c10::optional<DimnameList> names) const {
 #ifdef BUILD_NAMEDTENSOR
 inline Tensor Tensor::align_to(DimnameList names) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::align_to(const_cast<Tensor&>(*this), names);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::align_to(Tensor(a) self, DimnameList names) -> Tensor(a)");
@@ -139,6 +149,7 @@ inline Tensor Tensor::align_to(DimnameList names) const {
 #ifdef BUILD_NAMEDTENSOR
 inline Tensor Tensor::align_as(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::align_as(const_cast<Tensor&>(*this), other);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::align_as", ""}).value();
@@ -150,6 +161,7 @@ inline Tensor Tensor::align_as(const Tensor & other) const {
 #ifdef BUILD_NAMEDTENSOR
 inline Tensor Tensor::refine_names(DimnameList names) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::refine_names(const_cast<Tensor&>(*this), names);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::refine_names(Tensor(a) self, DimnameList names) -> Tensor(a)");
@@ -160,6 +172,7 @@ inline Tensor Tensor::refine_names(DimnameList names) const {
 #ifdef BUILD_NAMEDTENSOR
 inline Tensor Tensor::unflatten(Dimname dim, IntArrayRef sizes, DimnameList names) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::unflatten(const_cast<Tensor&>(*this), dim, sizes, names);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::unflatten(Tensor self, Dimname dim, int[] sizes, DimnameList names) -> Tensor");
@@ -170,6 +183,7 @@ inline Tensor Tensor::unflatten(Dimname dim, IntArrayRef sizes, DimnameList name
 #ifdef BUILD_NAMEDTENSOR
 inline Tensor Tensor::unflatten(int64_t dim, IntArrayRef sizes, DimnameList names) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::unflatten(const_cast<Tensor&>(*this), dim, sizes, names);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::unflatten(Tensor self, int dim, int[] sizes, DimnameList names) -> Tensor");
@@ -179,6 +193,7 @@ inline Tensor Tensor::unflatten(int64_t dim, IntArrayRef sizes, DimnameList name
 #endif
 inline Tensor Tensor::abs() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::abs(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::abs", ""}).value();
@@ -188,6 +203,7 @@ inline Tensor Tensor::abs() const {
 }
 inline Tensor & Tensor::abs_() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::abs_(const_cast<Tensor&>(*this));
@@ -203,6 +219,7 @@ inline Tensor & Tensor::abs_() const {
 }
 inline Tensor Tensor::acos() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::acos(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::acos", ""}).value();
@@ -212,6 +229,7 @@ inline Tensor Tensor::acos() const {
 }
 inline Tensor & Tensor::acos_() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::acos_(const_cast<Tensor&>(*this));
@@ -227,6 +245,7 @@ inline Tensor & Tensor::acos_() const {
 }
 inline Tensor Tensor::add(const Tensor & other, Scalar alpha) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::add(const_cast<Tensor&>(*this), other, alpha);
@@ -245,6 +264,7 @@ inline Tensor Tensor::add(const Tensor & other, Scalar alpha) const {
 }
 inline Tensor & Tensor::add_(const Tensor & other, Scalar alpha) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::add_(const_cast<Tensor&>(*this), other, alpha);
@@ -263,6 +283,7 @@ inline Tensor & Tensor::add_(const Tensor & other, Scalar alpha) const {
 }
 inline Tensor Tensor::add(Scalar other, Scalar alpha) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::add(const_cast<Tensor&>(*this), other, alpha);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::add", "Scalar"}).value();
@@ -272,6 +293,7 @@ inline Tensor Tensor::add(Scalar other, Scalar alpha) const {
 }
 inline Tensor & Tensor::add_(Scalar other, Scalar alpha) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::add_(const_cast<Tensor&>(*this), other, alpha);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::add_", "Scalar"}).value();
@@ -281,6 +303,7 @@ inline Tensor & Tensor::add_(Scalar other, Scalar alpha) const {
 }
 inline Tensor Tensor::addmv(const Tensor & mat, const Tensor & vec, Scalar beta, Scalar alpha) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::addmv(const_cast<Tensor&>(*this), mat, vec, beta, alpha);
@@ -296,6 +319,7 @@ inline Tensor Tensor::addmv(const Tensor & mat, const Tensor & vec, Scalar beta,
 }
 inline Tensor & Tensor::addmv_(const Tensor & mat, const Tensor & vec, Scalar beta, Scalar alpha) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::addmv_(const_cast<Tensor&>(*this), mat, vec, beta, alpha);
@@ -311,6 +335,7 @@ inline Tensor & Tensor::addmv_(const Tensor & mat, const Tensor & vec, Scalar be
 }
 inline Tensor Tensor::addr(const Tensor & vec1, const Tensor & vec2, Scalar beta, Scalar alpha) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::addr(const_cast<Tensor&>(*this), vec1, vec2, beta, alpha);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::addr", ""}).value();
@@ -320,6 +345,7 @@ inline Tensor Tensor::addr(const Tensor & vec1, const Tensor & vec2, Scalar beta
 }
 inline Tensor & Tensor::addr_(const Tensor & vec1, const Tensor & vec2, Scalar beta, Scalar alpha) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::addr_(const_cast<Tensor&>(*this), vec1, vec2, beta, alpha);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::addr_", ""}).value();
@@ -329,6 +355,7 @@ inline Tensor & Tensor::addr_(const Tensor & vec1, const Tensor & vec2, Scalar b
 }
 inline Tensor Tensor::all(int64_t dim, bool keepdim) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::all(const_cast<Tensor&>(*this), dim, keepdim);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::all", "dim"}).value();
@@ -339,6 +366,7 @@ inline Tensor Tensor::all(int64_t dim, bool keepdim) const {
 #ifdef BUILD_NAMEDTENSOR
 inline Tensor Tensor::all(Dimname dim, bool keepdim) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::all(const_cast<Tensor&>(*this), dim, keepdim);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::all.dimname(Tensor self, Dimname dim, bool keepdim=False) -> Tensor");
@@ -348,6 +376,7 @@ inline Tensor Tensor::all(Dimname dim, bool keepdim) const {
 #endif
 inline bool Tensor::allclose(const Tensor & other, double rtol, double atol, bool equal_nan) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::allclose(const_cast<Tensor&>(*this), other, rtol, atol, equal_nan);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::allclose", ""}).value();
@@ -357,6 +386,7 @@ inline bool Tensor::allclose(const Tensor & other, double rtol, double atol, boo
 }
 inline Tensor Tensor::any(int64_t dim, bool keepdim) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::any(const_cast<Tensor&>(*this), dim, keepdim);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::any", "dim"}).value();
@@ -367,6 +397,7 @@ inline Tensor Tensor::any(int64_t dim, bool keepdim) const {
 #ifdef BUILD_NAMEDTENSOR
 inline Tensor Tensor::any(Dimname dim, bool keepdim) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::any(const_cast<Tensor&>(*this), dim, keepdim);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::any.dimname(Tensor self, Dimname dim, bool keepdim=False) -> Tensor");
@@ -376,6 +407,7 @@ inline Tensor Tensor::any(Dimname dim, bool keepdim) const {
 #endif
 inline Tensor Tensor::argmax(c10::optional<int64_t> dim, bool keepdim) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::argmax(const_cast<Tensor&>(*this), dim, keepdim);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::argmax", ""}).value();
@@ -385,6 +417,7 @@ inline Tensor Tensor::argmax(c10::optional<int64_t> dim, bool keepdim) const {
 }
 inline Tensor Tensor::argmin(c10::optional<int64_t> dim, bool keepdim) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::argmin(const_cast<Tensor&>(*this), dim, keepdim);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::argmin", ""}).value();
@@ -394,6 +427,7 @@ inline Tensor Tensor::argmin(c10::optional<int64_t> dim, bool keepdim) const {
 }
 inline Tensor Tensor::as_strided(IntArrayRef size, IntArrayRef stride, c10::optional<int64_t> storage_offset) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::as_strided(const_cast<Tensor&>(*this), size, stride, storage_offset);
@@ -412,6 +446,7 @@ inline Tensor Tensor::as_strided(IntArrayRef size, IntArrayRef stride, c10::opti
 }
 inline Tensor & Tensor::as_strided_(IntArrayRef size, IntArrayRef stride, c10::optional<int64_t> storage_offset) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::as_strided_(const_cast<Tensor&>(*this), size, stride, storage_offset);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::as_strided_", ""}).value();
@@ -421,6 +456,7 @@ inline Tensor & Tensor::as_strided_(IntArrayRef size, IntArrayRef stride, c10::o
 }
 inline Tensor Tensor::asin() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::asin(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::asin", ""}).value();
@@ -430,6 +466,7 @@ inline Tensor Tensor::asin() const {
 }
 inline Tensor & Tensor::asin_() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::asin_(const_cast<Tensor&>(*this));
@@ -445,6 +482,7 @@ inline Tensor & Tensor::asin_() const {
 }
 inline Tensor Tensor::atan() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::atan(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::atan", ""}).value();
@@ -454,6 +492,7 @@ inline Tensor Tensor::atan() const {
 }
 inline Tensor & Tensor::atan_() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::atan_(const_cast<Tensor&>(*this));
@@ -469,6 +508,7 @@ inline Tensor & Tensor::atan_() const {
 }
 inline Tensor Tensor::baddbmm(const Tensor & batch1, const Tensor & batch2, Scalar beta, Scalar alpha) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::baddbmm(const_cast<Tensor&>(*this), batch1, batch2, beta, alpha);
@@ -484,6 +524,7 @@ inline Tensor Tensor::baddbmm(const Tensor & batch1, const Tensor & batch2, Scal
 }
 inline Tensor & Tensor::baddbmm_(const Tensor & batch1, const Tensor & batch2, Scalar beta, Scalar alpha) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::baddbmm_(const_cast<Tensor&>(*this), batch1, batch2, beta, alpha);
@@ -499,6 +540,7 @@ inline Tensor & Tensor::baddbmm_(const Tensor & batch1, const Tensor & batch2, S
 }
 inline Tensor Tensor::bernoulli(Generator * generator) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::bernoulli(const_cast<Tensor&>(*this), generator);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::bernoulli", ""}).value();
@@ -508,6 +550,7 @@ inline Tensor Tensor::bernoulli(Generator * generator) const {
 }
 inline Tensor & Tensor::bernoulli_(const Tensor & p, Generator * generator) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::bernoulli_(const_cast<Tensor&>(*this), p, generator);
@@ -523,6 +566,7 @@ inline Tensor & Tensor::bernoulli_(const Tensor & p, Generator * generator) cons
 }
 inline Tensor & Tensor::bernoulli_(double p, Generator * generator) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::bernoulli_(const_cast<Tensor&>(*this), p, generator);
@@ -538,6 +582,7 @@ inline Tensor & Tensor::bernoulli_(double p, Generator * generator) const {
 }
 inline Tensor Tensor::bernoulli(double p, Generator * generator) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::bernoulli(const_cast<Tensor&>(*this), p, generator);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::bernoulli", "p"}).value();
@@ -547,6 +592,7 @@ inline Tensor Tensor::bernoulli(double p, Generator * generator) const {
 }
 inline Tensor Tensor::bincount(const Tensor & weights, int64_t minlength) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::bincount(const_cast<Tensor&>(*this), weights, minlength);
@@ -561,6 +607,7 @@ inline Tensor Tensor::bincount(const Tensor & weights, int64_t minlength) const 
 }
 inline Tensor Tensor::bitwise_not() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::bitwise_not(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::bitwise_not", ""}).value();
@@ -570,6 +617,7 @@ inline Tensor Tensor::bitwise_not() const {
 }
 inline Tensor & Tensor::bitwise_not_() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::bitwise_not_(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::bitwise_not_", ""}).value();
@@ -579,6 +627,7 @@ inline Tensor & Tensor::bitwise_not_() const {
 }
 inline Tensor Tensor::logical_not() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::logical_not(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::logical_not", ""}).value();
@@ -588,6 +637,7 @@ inline Tensor Tensor::logical_not() const {
 }
 inline Tensor & Tensor::logical_not_() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::logical_not_(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::logical_not_", ""}).value();
@@ -597,6 +647,7 @@ inline Tensor & Tensor::logical_not_() const {
 }
 inline Tensor Tensor::logical_xor(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::logical_xor(const_cast<Tensor&>(*this), other);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::logical_xor", ""}).value();
@@ -606,6 +657,7 @@ inline Tensor Tensor::logical_xor(const Tensor & other) const {
 }
 inline Tensor & Tensor::logical_xor_(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::logical_xor_(const_cast<Tensor&>(*this), other);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::logical_xor_", ""}).value();
@@ -615,6 +667,7 @@ inline Tensor & Tensor::logical_xor_(const Tensor & other) const {
 }
 inline Tensor Tensor::bmm(const Tensor & mat2) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::bmm(const_cast<Tensor&>(*this), mat2);
@@ -630,6 +683,7 @@ inline Tensor Tensor::bmm(const Tensor & mat2) const {
 }
 inline Tensor Tensor::ceil() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::ceil(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::ceil", ""}).value();
@@ -639,6 +693,7 @@ inline Tensor Tensor::ceil() const {
 }
 inline Tensor & Tensor::ceil_() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::ceil_(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::ceil_", ""}).value();
@@ -648,6 +703,7 @@ inline Tensor & Tensor::ceil_() const {
 }
 inline std::vector<Tensor> Tensor::chunk(int64_t chunks, int64_t dim) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::chunk(const_cast<Tensor&>(*this), chunks, dim);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::chunk", ""}).value();
@@ -657,6 +713,7 @@ inline std::vector<Tensor> Tensor::chunk(int64_t chunks, int64_t dim) const {
 }
 inline Tensor Tensor::clamp(c10::optional<Scalar> min, c10::optional<Scalar> max) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::clamp(const_cast<Tensor&>(*this), min, max);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::clamp", ""}).value();
@@ -666,6 +723,7 @@ inline Tensor Tensor::clamp(c10::optional<Scalar> min, c10::optional<Scalar> max
 }
 inline Tensor & Tensor::clamp_(c10::optional<Scalar> min, c10::optional<Scalar> max) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::clamp_(const_cast<Tensor&>(*this), min, max);
@@ -681,6 +739,7 @@ inline Tensor & Tensor::clamp_(c10::optional<Scalar> min, c10::optional<Scalar> 
 }
 inline Tensor Tensor::clamp_max(Scalar max) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::clamp_max(const_cast<Tensor&>(*this), max);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::clamp_max", ""}).value();
@@ -690,6 +749,7 @@ inline Tensor Tensor::clamp_max(Scalar max) const {
 }
 inline Tensor & Tensor::clamp_max_(Scalar max) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::clamp_max_(const_cast<Tensor&>(*this), max);
@@ -705,6 +765,7 @@ inline Tensor & Tensor::clamp_max_(Scalar max) const {
 }
 inline Tensor Tensor::clamp_min(Scalar min) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::clamp_min(const_cast<Tensor&>(*this), min);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::clamp_min", ""}).value();
@@ -714,6 +775,7 @@ inline Tensor Tensor::clamp_min(Scalar min) const {
 }
 inline Tensor & Tensor::clamp_min_(Scalar min) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::clamp_min_(const_cast<Tensor&>(*this), min);
@@ -729,6 +791,7 @@ inline Tensor & Tensor::clamp_min_(Scalar min) const {
 }
 inline Tensor Tensor::contiguous(MemoryFormat memory_format) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::contiguous(const_cast<Tensor&>(*this), memory_format);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::contiguous(Tensor self, *, MemoryFormat memory_format=contiguous_format) -> Tensor");
@@ -737,6 +800,7 @@ inline Tensor Tensor::contiguous(MemoryFormat memory_format) const {
 }
 inline Tensor & Tensor::copy_(const Tensor & src, bool non_blocking) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::copy_(const_cast<Tensor&>(*this), src, non_blocking);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::copy_", ""}).value();
@@ -746,6 +810,7 @@ inline Tensor & Tensor::copy_(const Tensor & src, bool non_blocking) const {
 }
 inline Tensor Tensor::cos() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::cos(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::cos", ""}).value();
@@ -755,6 +820,7 @@ inline Tensor Tensor::cos() const {
 }
 inline Tensor & Tensor::cos_() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::cos_(const_cast<Tensor&>(*this));
@@ -770,6 +836,7 @@ inline Tensor & Tensor::cos_() const {
 }
 inline Tensor Tensor::cosh() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::cosh(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::cosh", ""}).value();
@@ -779,6 +846,7 @@ inline Tensor Tensor::cosh() const {
 }
 inline Tensor & Tensor::cosh_() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::cosh_(const_cast<Tensor&>(*this));
@@ -794,6 +862,7 @@ inline Tensor & Tensor::cosh_() const {
 }
 inline Tensor Tensor::cumsum(int64_t dim, c10::optional<ScalarType> dtype) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::cumsum(const_cast<Tensor&>(*this), dim, dtype);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::cumsum(Tensor self, int dim, *, ScalarType? dtype=None) -> Tensor");
@@ -803,6 +872,7 @@ inline Tensor Tensor::cumsum(int64_t dim, c10::optional<ScalarType> dtype) const
 #ifdef BUILD_NAMEDTENSOR
 inline Tensor Tensor::cumsum(Dimname dim, c10::optional<ScalarType> dtype) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::cumsum(const_cast<Tensor&>(*this), dim, dtype);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::cumsum.dimname(Tensor self, Dimname dim, *, ScalarType? dtype=None) -> Tensor");
@@ -812,6 +882,7 @@ inline Tensor Tensor::cumsum(Dimname dim, c10::optional<ScalarType> dtype) const
 #endif
 inline Tensor Tensor::cumprod(int64_t dim, c10::optional<ScalarType> dtype) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::cumprod(const_cast<Tensor&>(*this), dim, dtype);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::cumprod(Tensor self, int dim, *, ScalarType? dtype=None) -> Tensor");
@@ -821,6 +892,7 @@ inline Tensor Tensor::cumprod(int64_t dim, c10::optional<ScalarType> dtype) cons
 #ifdef BUILD_NAMEDTENSOR
 inline Tensor Tensor::cumprod(Dimname dim, c10::optional<ScalarType> dtype) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::cumprod(const_cast<Tensor&>(*this), dim, dtype);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::cumprod.dimname(Tensor self, Dimname dim, *, ScalarType? dtype=None) -> Tensor");
@@ -830,6 +902,7 @@ inline Tensor Tensor::cumprod(Dimname dim, c10::optional<ScalarType> dtype) cons
 #endif
 inline Tensor Tensor::det() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::det(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::det", ""}).value();
@@ -839,6 +912,7 @@ inline Tensor Tensor::det() const {
 }
 inline Tensor Tensor::diag_embed(int64_t offset, int64_t dim1, int64_t dim2) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::diag_embed(const_cast<Tensor&>(*this), offset, dim1, dim2);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::diag_embed", ""}).value();
@@ -848,6 +922,7 @@ inline Tensor Tensor::diag_embed(int64_t offset, int64_t dim1, int64_t dim2) con
 }
 inline Tensor Tensor::diagflat(int64_t offset) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::diagflat(const_cast<Tensor&>(*this), offset);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::diagflat", ""}).value();
@@ -857,6 +932,7 @@ inline Tensor Tensor::diagflat(int64_t offset) const {
 }
 inline Tensor Tensor::diagonal(int64_t offset, int64_t dim1, int64_t dim2) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::diagonal(const_cast<Tensor&>(*this), offset, dim1, dim2);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::diagonal", ""}).value();
@@ -866,6 +942,7 @@ inline Tensor Tensor::diagonal(int64_t offset, int64_t dim1, int64_t dim2) const
 }
 inline Tensor & Tensor::fill_diagonal_(Scalar fill_value, bool wrap) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::fill_diagonal_(const_cast<Tensor&>(*this), fill_value, wrap);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::fill_diagonal_", ""}).value();
@@ -875,6 +952,7 @@ inline Tensor & Tensor::fill_diagonal_(Scalar fill_value, bool wrap) const {
 }
 inline Tensor Tensor::div(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::div(const_cast<Tensor&>(*this), other);
@@ -893,6 +971,7 @@ inline Tensor Tensor::div(const Tensor & other) const {
 }
 inline Tensor & Tensor::div_(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::div_(const_cast<Tensor&>(*this), other);
@@ -911,6 +990,7 @@ inline Tensor & Tensor::div_(const Tensor & other) const {
 }
 inline Tensor Tensor::div(Scalar other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::div(const_cast<Tensor&>(*this), other);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::div", "Scalar"}).value();
@@ -920,6 +1000,7 @@ inline Tensor Tensor::div(Scalar other) const {
 }
 inline Tensor & Tensor::div_(Scalar other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::div_(const_cast<Tensor&>(*this), other);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::div_", "Scalar"}).value();
@@ -929,6 +1010,7 @@ inline Tensor & Tensor::div_(Scalar other) const {
 }
 inline Tensor Tensor::dot(const Tensor & tensor) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::dot(const_cast<Tensor&>(*this), tensor);
@@ -944,6 +1026,7 @@ inline Tensor Tensor::dot(const Tensor & tensor) const {
 }
 inline Tensor Tensor::new_empty(IntArrayRef size, const TensorOptions & options) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::new_empty(const_cast<Tensor&>(*this), size, options);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::new_empty(Tensor self, int[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor");
@@ -952,6 +1035,7 @@ inline Tensor Tensor::new_empty(IntArrayRef size, const TensorOptions & options)
 }
 inline Tensor Tensor::new_full(IntArrayRef size, Scalar fill_value, const TensorOptions & options) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::new_full(const_cast<Tensor&>(*this), size, fill_value, options);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::new_full(Tensor self, int[] size, Scalar fill_value, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor");
@@ -960,6 +1044,7 @@ inline Tensor Tensor::new_full(IntArrayRef size, Scalar fill_value, const Tensor
 }
 inline Tensor & Tensor::resize_(IntArrayRef size) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::resize_(const_cast<Tensor&>(*this), size);
@@ -978,6 +1063,7 @@ inline Tensor & Tensor::resize_(IntArrayRef size) const {
 }
 inline Tensor Tensor::erf() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::erf(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::erf", ""}).value();
@@ -987,6 +1073,7 @@ inline Tensor Tensor::erf() const {
 }
 inline Tensor & Tensor::erf_() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::erf_(const_cast<Tensor&>(*this));
@@ -1002,6 +1089,7 @@ inline Tensor & Tensor::erf_() const {
 }
 inline Tensor Tensor::erfc() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::erfc(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::erfc", ""}).value();
@@ -1011,6 +1099,7 @@ inline Tensor Tensor::erfc() const {
 }
 inline Tensor & Tensor::erfc_() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::erfc_(const_cast<Tensor&>(*this));
@@ -1026,6 +1115,7 @@ inline Tensor & Tensor::erfc_() const {
 }
 inline Tensor Tensor::exp() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::exp(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::exp", ""}).value();
@@ -1035,6 +1125,7 @@ inline Tensor Tensor::exp() const {
 }
 inline Tensor & Tensor::exp_() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::exp_(const_cast<Tensor&>(*this));
@@ -1050,6 +1141,7 @@ inline Tensor & Tensor::exp_() const {
 }
 inline Tensor Tensor::expm1() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::expm1(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::expm1", ""}).value();
@@ -1059,6 +1151,7 @@ inline Tensor Tensor::expm1() const {
 }
 inline Tensor & Tensor::expm1_() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::expm1_(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::expm1_", ""}).value();
@@ -1068,6 +1161,7 @@ inline Tensor & Tensor::expm1_() const {
 }
 inline Tensor Tensor::expand(IntArrayRef size, bool implicit) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::expand(const_cast<Tensor&>(*this), size, implicit);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::expand", ""}).value();
@@ -1077,6 +1171,7 @@ inline Tensor Tensor::expand(IntArrayRef size, bool implicit) const {
 }
 inline Tensor Tensor::expand_as(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::expand_as(const_cast<Tensor&>(*this), other);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::expand_as", ""}).value();
@@ -1086,6 +1181,7 @@ inline Tensor Tensor::expand_as(const Tensor & other) const {
 }
 inline Tensor Tensor::flatten(int64_t start_dim, int64_t end_dim) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::flatten(const_cast<Tensor&>(*this), start_dim, end_dim);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::flatten", "using_ints"}).value();
@@ -1096,6 +1192,7 @@ inline Tensor Tensor::flatten(int64_t start_dim, int64_t end_dim) const {
 #ifdef BUILD_NAMEDTENSOR
 inline Tensor Tensor::flatten(int64_t start_dim, int64_t end_dim, Dimname out_dim) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::flatten(const_cast<Tensor&>(*this), start_dim, end_dim, out_dim);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::flatten.named_out_dim(Tensor self, int start_dim, int end_dim, Dimname out_dim) -> Tensor");
@@ -1106,6 +1203,7 @@ inline Tensor Tensor::flatten(int64_t start_dim, int64_t end_dim, Dimname out_di
 #ifdef BUILD_NAMEDTENSOR
 inline Tensor Tensor::flatten(Dimname start_dim, Dimname end_dim, Dimname out_dim) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::flatten(const_cast<Tensor&>(*this), start_dim, end_dim, out_dim);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::flatten.using_names(Tensor self, Dimname start_dim, Dimname end_dim, Dimname out_dim) -> Tensor");
@@ -1116,6 +1214,7 @@ inline Tensor Tensor::flatten(Dimname start_dim, Dimname end_dim, Dimname out_di
 #ifdef BUILD_NAMEDTENSOR
 inline Tensor Tensor::flatten(DimnameList dims, Dimname out_dim) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::flatten(const_cast<Tensor&>(*this), dims, out_dim);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::flatten.DimnameList(Tensor self, DimnameList dims, Dimname out_dim) -> Tensor");
@@ -1125,6 +1224,7 @@ inline Tensor Tensor::flatten(DimnameList dims, Dimname out_dim) const {
 #endif
 inline Tensor & Tensor::fill_(Scalar value) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::fill_(const_cast<Tensor&>(*this), value);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::fill_", "Scalar"}).value();
@@ -1134,6 +1234,7 @@ inline Tensor & Tensor::fill_(Scalar value) const {
 }
 inline Tensor & Tensor::fill_(const Tensor & value) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::fill_(const_cast<Tensor&>(*this), value);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::fill_", "Tensor"}).value();
@@ -1143,6 +1244,7 @@ inline Tensor & Tensor::fill_(const Tensor & value) const {
 }
 inline Tensor Tensor::floor() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::floor(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::floor", ""}).value();
@@ -1152,6 +1254,7 @@ inline Tensor Tensor::floor() const {
 }
 inline Tensor & Tensor::floor_() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::floor_(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::floor_", ""}).value();
@@ -1161,6 +1264,7 @@ inline Tensor & Tensor::floor_() const {
 }
 inline Tensor Tensor::frac() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::frac(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::frac", ""}).value();
@@ -1170,6 +1274,7 @@ inline Tensor Tensor::frac() const {
 }
 inline Tensor & Tensor::frac_() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::frac_(const_cast<Tensor&>(*this));
@@ -1185,6 +1290,7 @@ inline Tensor & Tensor::frac_() const {
 }
 inline Tensor Tensor::ger(const Tensor & vec2) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::ger(const_cast<Tensor&>(*this), vec2);
@@ -1200,6 +1306,7 @@ inline Tensor Tensor::ger(const Tensor & vec2) const {
 }
 inline Tensor Tensor::fft(int64_t signal_ndim, bool normalized) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::fft(const_cast<Tensor&>(*this), signal_ndim, normalized);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::fft", ""}).value();
@@ -1209,6 +1316,7 @@ inline Tensor Tensor::fft(int64_t signal_ndim, bool normalized) const {
 }
 inline Tensor Tensor::ifft(int64_t signal_ndim, bool normalized) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::ifft(const_cast<Tensor&>(*this), signal_ndim, normalized);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::ifft", ""}).value();
@@ -1218,6 +1326,7 @@ inline Tensor Tensor::ifft(int64_t signal_ndim, bool normalized) const {
 }
 inline Tensor Tensor::rfft(int64_t signal_ndim, bool normalized, bool onesided) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::rfft(const_cast<Tensor&>(*this), signal_ndim, normalized, onesided);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::rfft", ""}).value();
@@ -1227,6 +1336,7 @@ inline Tensor Tensor::rfft(int64_t signal_ndim, bool normalized, bool onesided) 
 }
 inline Tensor Tensor::irfft(int64_t signal_ndim, bool normalized, bool onesided, IntArrayRef signal_sizes) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::irfft(const_cast<Tensor&>(*this), signal_ndim, normalized, onesided, signal_sizes);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::irfft", ""}).value();
@@ -1236,6 +1346,7 @@ inline Tensor Tensor::irfft(int64_t signal_ndim, bool normalized, bool onesided,
 }
 inline Tensor Tensor::index(TensorList indices) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::index(const_cast<Tensor&>(*this), indices);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::index.Tensor(Tensor self, Tensor?[] indices) -> Tensor");
@@ -1244,6 +1355,7 @@ inline Tensor Tensor::index(TensorList indices) const {
 }
 inline Tensor & Tensor::index_copy_(int64_t dim, const Tensor & index, const Tensor & source) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::index_copy_(const_cast<Tensor&>(*this), dim, index, source);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::index_copy_", ""}).value();
@@ -1253,6 +1365,7 @@ inline Tensor & Tensor::index_copy_(int64_t dim, const Tensor & index, const Ten
 }
 inline Tensor Tensor::index_copy(int64_t dim, const Tensor & index, const Tensor & source) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::index_copy(const_cast<Tensor&>(*this), dim, index, source);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::index_copy", ""}).value();
@@ -1263,6 +1376,7 @@ inline Tensor Tensor::index_copy(int64_t dim, const Tensor & index, const Tensor
 #ifdef BUILD_NAMEDTENSOR
 inline Tensor & Tensor::index_copy_(Dimname dim, const Tensor & index, const Tensor & source) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::index_copy_(const_cast<Tensor&>(*this), dim, index, source);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::index_copy_.dimname(Tensor(a!) self, Dimname dim, Tensor index, Tensor source) -> Tensor(a!)");
@@ -1273,6 +1387,7 @@ inline Tensor & Tensor::index_copy_(Dimname dim, const Tensor & index, const Ten
 #ifdef BUILD_NAMEDTENSOR
 inline Tensor Tensor::index_copy(Dimname dim, const Tensor & index, const Tensor & source) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::index_copy(const_cast<Tensor&>(*this), dim, index, source);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::index_copy.dimname(Tensor self, Dimname dim, Tensor index, Tensor source) -> Tensor");
@@ -1282,6 +1397,7 @@ inline Tensor Tensor::index_copy(Dimname dim, const Tensor & index, const Tensor
 #endif
 inline Tensor & Tensor::index_put_(TensorList indices, const Tensor & values, bool accumulate) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::index_put_(const_cast<Tensor&>(*this), indices, values, accumulate);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::index_put_(Tensor(a!) self, Tensor?[] indices, Tensor values, bool accumulate=False) -> Tensor(a!)");
@@ -1290,6 +1406,7 @@ inline Tensor & Tensor::index_put_(TensorList indices, const Tensor & values, bo
 }
 inline Tensor Tensor::index_put(TensorList indices, const Tensor & values, bool accumulate) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::index_put(const_cast<Tensor&>(*this), indices, values, accumulate);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::index_put(Tensor self, Tensor?[] indices, Tensor values, bool accumulate=False) -> Tensor");
@@ -1298,6 +1415,7 @@ inline Tensor Tensor::index_put(TensorList indices, const Tensor & values, bool 
 }
 inline Tensor Tensor::inverse() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::inverse(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::inverse", ""}).value();
@@ -1307,6 +1425,7 @@ inline Tensor Tensor::inverse() const {
 }
 inline Tensor Tensor::isclose(const Tensor & other, double rtol, double atol, bool equal_nan) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::isclose(const_cast<Tensor&>(*this), other, rtol, atol, equal_nan);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::isclose", ""}).value();
@@ -1316,6 +1435,7 @@ inline Tensor Tensor::isclose(const Tensor & other, double rtol, double atol, bo
 }
 inline bool Tensor::is_distributed() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::is_distributed(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::is_distributed", ""}).value();
@@ -1325,6 +1445,7 @@ inline bool Tensor::is_distributed() const {
 }
 inline bool Tensor::is_floating_point() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::is_floating_point(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::is_floating_point", ""}).value();
@@ -1334,6 +1455,7 @@ inline bool Tensor::is_floating_point() const {
 }
 inline bool Tensor::is_complex() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::is_complex(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::is_complex", ""}).value();
@@ -1343,6 +1465,7 @@ inline bool Tensor::is_complex() const {
 }
 inline bool Tensor::is_nonzero() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::is_nonzero(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::is_nonzero", ""}).value();
@@ -1352,6 +1475,7 @@ inline bool Tensor::is_nonzero() const {
 }
 inline bool Tensor::is_same_size(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::is_same_size(const_cast<Tensor&>(*this), other);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::is_same_size", ""}).value();
@@ -1361,6 +1485,7 @@ inline bool Tensor::is_same_size(const Tensor & other) const {
 }
 inline bool Tensor::is_signed() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::is_signed(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::is_signed", ""}).value();
@@ -1370,6 +1495,7 @@ inline bool Tensor::is_signed() const {
 }
 inline std::tuple<Tensor,Tensor> Tensor::kthvalue(int64_t k, int64_t dim, bool keepdim) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::kthvalue(const_cast<Tensor&>(*this), k, dim, keepdim);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::kthvalue", ""}).value();
@@ -1380,6 +1506,7 @@ inline std::tuple<Tensor,Tensor> Tensor::kthvalue(int64_t k, int64_t dim, bool k
 #ifdef BUILD_NAMEDTENSOR
 inline std::tuple<Tensor,Tensor> Tensor::kthvalue(int64_t k, Dimname dim, bool keepdim) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::kthvalue(const_cast<Tensor&>(*this), k, dim, keepdim);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::kthvalue.dimname(Tensor self, int k, Dimname dim, bool keepdim=False) -> (Tensor values, Tensor indices)");
@@ -1389,6 +1516,7 @@ inline std::tuple<Tensor,Tensor> Tensor::kthvalue(int64_t k, Dimname dim, bool k
 #endif
 inline Tensor Tensor::log() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::log(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::log", ""}).value();
@@ -1398,6 +1526,7 @@ inline Tensor Tensor::log() const {
 }
 inline Tensor & Tensor::log_() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::log_(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::log_", ""}).value();
@@ -1407,6 +1536,7 @@ inline Tensor & Tensor::log_() const {
 }
 inline Tensor Tensor::log10() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::log10(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::log10", ""}).value();
@@ -1416,6 +1546,7 @@ inline Tensor Tensor::log10() const {
 }
 inline Tensor & Tensor::log10_() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::log10_(const_cast<Tensor&>(*this));
@@ -1431,6 +1562,7 @@ inline Tensor & Tensor::log10_() const {
 }
 inline Tensor Tensor::log1p() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::log1p(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::log1p", ""}).value();
@@ -1440,6 +1572,7 @@ inline Tensor Tensor::log1p() const {
 }
 inline Tensor & Tensor::log1p_() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::log1p_(const_cast<Tensor&>(*this));
@@ -1458,6 +1591,7 @@ inline Tensor & Tensor::log1p_() const {
 }
 inline Tensor Tensor::log2() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::log2(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::log2", ""}).value();
@@ -1467,6 +1601,7 @@ inline Tensor Tensor::log2() const {
 }
 inline Tensor & Tensor::log2_() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::log2_(const_cast<Tensor&>(*this));
@@ -1482,6 +1617,7 @@ inline Tensor & Tensor::log2_() const {
 }
 inline Tensor Tensor::logdet() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::logdet(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::logdet", ""}).value();
@@ -1491,6 +1627,7 @@ inline Tensor Tensor::logdet() const {
 }
 inline Tensor Tensor::log_softmax(int64_t dim, c10::optional<ScalarType> dtype) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::log_softmax(const_cast<Tensor&>(*this), dim, dtype);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::log_softmax(Tensor self, int dim, ScalarType? dtype=None) -> Tensor");
@@ -1500,6 +1637,7 @@ inline Tensor Tensor::log_softmax(int64_t dim, c10::optional<ScalarType> dtype) 
 #ifdef BUILD_NAMEDTENSOR
 inline Tensor Tensor::log_softmax(Dimname dim, c10::optional<ScalarType> dtype) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::log_softmax(const_cast<Tensor&>(*this), dim, dtype);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::log_softmax(Tensor self, Dimname dim, *, ScalarType? dtype=None) -> Tensor");
@@ -1509,6 +1647,7 @@ inline Tensor Tensor::log_softmax(Dimname dim, c10::optional<ScalarType> dtype) 
 #endif
 inline Tensor Tensor::logsumexp(IntArrayRef dim, bool keepdim) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::logsumexp(const_cast<Tensor&>(*this), dim, keepdim);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::logsumexp", ""}).value();
@@ -1519,6 +1658,7 @@ inline Tensor Tensor::logsumexp(IntArrayRef dim, bool keepdim) const {
 #ifdef BUILD_NAMEDTENSOR
 inline Tensor Tensor::logsumexp(DimnameList dim, bool keepdim) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::logsumexp(const_cast<Tensor&>(*this), dim, keepdim);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::logsumexp.names(Tensor self, Dimname[1] dim, bool keepdim=False) -> Tensor");
@@ -1528,6 +1668,7 @@ inline Tensor Tensor::logsumexp(DimnameList dim, bool keepdim) const {
 #endif
 inline Tensor Tensor::matmul(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::matmul(const_cast<Tensor&>(*this), other);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::matmul", ""}).value();
@@ -1537,6 +1678,7 @@ inline Tensor Tensor::matmul(const Tensor & other) const {
 }
 inline Tensor Tensor::matrix_power(int64_t n) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::matrix_power(const_cast<Tensor&>(*this), n);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::matrix_power", ""}).value();
@@ -1546,6 +1688,7 @@ inline Tensor Tensor::matrix_power(int64_t n) const {
 }
 inline std::tuple<Tensor,Tensor> Tensor::max(int64_t dim, bool keepdim) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::max(const_cast<Tensor&>(*this), dim, keepdim);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::max", "dim"}).value();
@@ -1555,6 +1698,7 @@ inline std::tuple<Tensor,Tensor> Tensor::max(int64_t dim, bool keepdim) const {
 }
 inline Tensor Tensor::max_values(IntArrayRef dim, bool keepdim) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::max_values(const_cast<Tensor&>(*this), dim, keepdim);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::max_values", ""}).value();
@@ -1565,6 +1709,7 @@ inline Tensor Tensor::max_values(IntArrayRef dim, bool keepdim) const {
 #ifdef BUILD_NAMEDTENSOR
 inline std::tuple<Tensor,Tensor> Tensor::max(Dimname dim, bool keepdim) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::max(const_cast<Tensor&>(*this), dim, keepdim);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::max.names_dim(Tensor self, Dimname dim, bool keepdim=False) -> (Tensor values, Tensor indices)");
@@ -1575,6 +1720,7 @@ inline std::tuple<Tensor,Tensor> Tensor::max(Dimname dim, bool keepdim) const {
 #ifdef BUILD_NAMEDTENSOR
 inline Tensor Tensor::max_values(DimnameList dim, bool keepdim) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::max_values(const_cast<Tensor&>(*this), dim, keepdim);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::max_values.names(Tensor self, Dimname[1] dim, bool keepdim=False) -> Tensor");
@@ -1584,6 +1730,7 @@ inline Tensor Tensor::max_values(DimnameList dim, bool keepdim) const {
 #endif
 inline Tensor Tensor::mean(c10::optional<ScalarType> dtype) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::mean(const_cast<Tensor&>(*this), dtype);
@@ -1601,6 +1748,7 @@ inline Tensor Tensor::mean(c10::optional<ScalarType> dtype) const {
 }
 inline Tensor Tensor::mean(IntArrayRef dim, bool keepdim, c10::optional<ScalarType> dtype) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::mean(const_cast<Tensor&>(*this), dim, keepdim, dtype);
@@ -1619,6 +1767,7 @@ inline Tensor Tensor::mean(IntArrayRef dim, bool keepdim, c10::optional<ScalarTy
 #ifdef BUILD_NAMEDTENSOR
 inline Tensor Tensor::mean(DimnameList dim, bool keepdim, c10::optional<ScalarType> dtype) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::mean(const_cast<Tensor&>(*this), dim, keepdim, dtype);
@@ -1634,6 +1783,7 @@ inline Tensor Tensor::mean(DimnameList dim, bool keepdim, c10::optional<ScalarTy
 #endif
 inline std::tuple<Tensor,Tensor> Tensor::median(int64_t dim, bool keepdim) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::median(const_cast<Tensor&>(*this), dim, keepdim);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::median", "dim"}).value();
@@ -1644,6 +1794,7 @@ inline std::tuple<Tensor,Tensor> Tensor::median(int64_t dim, bool keepdim) const
 #ifdef BUILD_NAMEDTENSOR
 inline std::tuple<Tensor,Tensor> Tensor::median(Dimname dim, bool keepdim) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::median(const_cast<Tensor&>(*this), dim, keepdim);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::median.names_dim(Tensor self, Dimname dim, bool keepdim=False) -> (Tensor values, Tensor indices)");
@@ -1653,6 +1804,7 @@ inline std::tuple<Tensor,Tensor> Tensor::median(Dimname dim, bool keepdim) const
 #endif
 inline std::tuple<Tensor,Tensor> Tensor::min(int64_t dim, bool keepdim) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::min(const_cast<Tensor&>(*this), dim, keepdim);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::min", "dim"}).value();
@@ -1662,6 +1814,7 @@ inline std::tuple<Tensor,Tensor> Tensor::min(int64_t dim, bool keepdim) const {
 }
 inline Tensor Tensor::min_values(IntArrayRef dim, bool keepdim) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::min_values(const_cast<Tensor&>(*this), dim, keepdim);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::min_values", ""}).value();
@@ -1672,6 +1825,7 @@ inline Tensor Tensor::min_values(IntArrayRef dim, bool keepdim) const {
 #ifdef BUILD_NAMEDTENSOR
 inline std::tuple<Tensor,Tensor> Tensor::min(Dimname dim, bool keepdim) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::min(const_cast<Tensor&>(*this), dim, keepdim);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::min.names_dim(Tensor self, Dimname dim, bool keepdim=False) -> (Tensor values, Tensor indices)");
@@ -1682,6 +1836,7 @@ inline std::tuple<Tensor,Tensor> Tensor::min(Dimname dim, bool keepdim) const {
 #ifdef BUILD_NAMEDTENSOR
 inline Tensor Tensor::min_values(DimnameList dim, bool keepdim) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::min_values(const_cast<Tensor&>(*this), dim, keepdim);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::min_values.names(Tensor self, Dimname[1] dim, bool keepdim=False) -> Tensor");
@@ -1691,6 +1846,7 @@ inline Tensor Tensor::min_values(DimnameList dim, bool keepdim) const {
 #endif
 inline Tensor Tensor::mm(const Tensor & mat2) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::mm(const_cast<Tensor&>(*this), mat2);
@@ -1709,6 +1865,7 @@ inline Tensor Tensor::mm(const Tensor & mat2) const {
 }
 inline std::tuple<Tensor,Tensor> Tensor::mode(int64_t dim, bool keepdim) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::mode(const_cast<Tensor&>(*this), dim, keepdim);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::mode", ""}).value();
@@ -1719,6 +1876,7 @@ inline std::tuple<Tensor,Tensor> Tensor::mode(int64_t dim, bool keepdim) const {
 #ifdef BUILD_NAMEDTENSOR
 inline std::tuple<Tensor,Tensor> Tensor::mode(Dimname dim, bool keepdim) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::mode(const_cast<Tensor&>(*this), dim, keepdim);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::mode.dimname(Tensor self, Dimname dim, bool keepdim=False) -> (Tensor values, Tensor indices)");
@@ -1728,6 +1886,7 @@ inline std::tuple<Tensor,Tensor> Tensor::mode(Dimname dim, bool keepdim) const {
 #endif
 inline Tensor Tensor::mul(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::mul(const_cast<Tensor&>(*this), other);
@@ -1746,6 +1905,7 @@ inline Tensor Tensor::mul(const Tensor & other) const {
 }
 inline Tensor & Tensor::mul_(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::mul_(const_cast<Tensor&>(*this), other);
@@ -1764,6 +1924,7 @@ inline Tensor & Tensor::mul_(const Tensor & other) const {
 }
 inline Tensor Tensor::mul(Scalar other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::mul(const_cast<Tensor&>(*this), other);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::mul", "Scalar"}).value();
@@ -1773,6 +1934,7 @@ inline Tensor Tensor::mul(Scalar other) const {
 }
 inline Tensor & Tensor::mul_(Scalar other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::mul_(const_cast<Tensor&>(*this), other);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::mul_", "Scalar"}).value();
@@ -1782,6 +1944,7 @@ inline Tensor & Tensor::mul_(Scalar other) const {
 }
 inline Tensor Tensor::mv(const Tensor & vec) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::mv(const_cast<Tensor&>(*this), vec);
@@ -1797,6 +1960,7 @@ inline Tensor Tensor::mv(const Tensor & vec) const {
 }
 inline Tensor Tensor::mvlgamma(int64_t p) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::mvlgamma(const_cast<Tensor&>(*this), p);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::mvlgamma", ""}).value();
@@ -1806,6 +1970,7 @@ inline Tensor Tensor::mvlgamma(int64_t p) const {
 }
 inline Tensor & Tensor::mvlgamma_(int64_t p) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::mvlgamma_(const_cast<Tensor&>(*this), p);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::mvlgamma_", ""}).value();
@@ -1815,6 +1980,7 @@ inline Tensor & Tensor::mvlgamma_(int64_t p) const {
 }
 inline Tensor Tensor::narrow_copy(int64_t dim, int64_t start, int64_t length) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::narrow_copy(const_cast<Tensor&>(*this), dim, start, length);
@@ -1833,6 +1999,7 @@ inline Tensor Tensor::narrow_copy(int64_t dim, int64_t start, int64_t length) co
 }
 inline Tensor Tensor::narrow(int64_t dim, int64_t start, int64_t length) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::narrow(const_cast<Tensor&>(*this), dim, start, length);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::narrow", ""}).value();
@@ -1842,6 +2009,7 @@ inline Tensor Tensor::narrow(int64_t dim, int64_t start, int64_t length) const {
 }
 inline Tensor Tensor::permute(IntArrayRef dims) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::permute(const_cast<Tensor&>(*this), dims);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::permute", ""}).value();
@@ -1851,6 +2019,7 @@ inline Tensor Tensor::permute(IntArrayRef dims) const {
 }
 inline Tensor Tensor::numpy_T() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::numpy_T(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::numpy_T", ""}).value();
@@ -1860,6 +2029,7 @@ inline Tensor Tensor::numpy_T() const {
 }
 inline bool Tensor::is_pinned() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::is_pinned(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::is_pinned", ""}).value();
@@ -1869,6 +2039,7 @@ inline bool Tensor::is_pinned() const {
 }
 inline Tensor Tensor::pin_memory() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::pin_memory(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::pin_memory", ""}).value();
@@ -1878,6 +2049,7 @@ inline Tensor Tensor::pin_memory() const {
 }
 inline Tensor Tensor::pinverse(double rcond) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::pinverse(const_cast<Tensor&>(*this), rcond);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::pinverse", ""}).value();
@@ -1887,6 +2059,7 @@ inline Tensor Tensor::pinverse(double rcond) const {
 }
 inline Tensor Tensor::reciprocal() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::reciprocal(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::reciprocal", ""}).value();
@@ -1896,6 +2069,7 @@ inline Tensor Tensor::reciprocal() const {
 }
 inline Tensor & Tensor::reciprocal_() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::reciprocal_(const_cast<Tensor&>(*this));
@@ -1911,6 +2085,7 @@ inline Tensor & Tensor::reciprocal_() const {
 }
 inline Tensor Tensor::neg() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::neg(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::neg", ""}).value();
@@ -1920,6 +2095,7 @@ inline Tensor Tensor::neg() const {
 }
 inline Tensor & Tensor::neg_() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::neg_(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::neg_", ""}).value();
@@ -1929,6 +2105,7 @@ inline Tensor & Tensor::neg_() const {
 }
 inline Tensor Tensor::repeat(IntArrayRef repeats) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::repeat(const_cast<Tensor&>(*this), repeats);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::repeat", ""}).value();
@@ -1938,6 +2115,7 @@ inline Tensor Tensor::repeat(IntArrayRef repeats) const {
 }
 inline Tensor Tensor::repeat_interleave(const Tensor & repeats, c10::optional<int64_t> dim) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::repeat_interleave(const_cast<Tensor&>(*this), repeats, dim);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::repeat_interleave", "self_Tensor"}).value();
@@ -1947,6 +2125,7 @@ inline Tensor Tensor::repeat_interleave(const Tensor & repeats, c10::optional<in
 }
 inline Tensor Tensor::repeat_interleave(int64_t repeats, c10::optional<int64_t> dim) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::repeat_interleave(const_cast<Tensor&>(*this), repeats, dim);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::repeat_interleave", "self_int"}).value();
@@ -1956,6 +2135,7 @@ inline Tensor Tensor::repeat_interleave(int64_t repeats, c10::optional<int64_t> 
 }
 inline Tensor Tensor::reshape(IntArrayRef shape) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::reshape(const_cast<Tensor&>(*this), shape);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::reshape", ""}).value();
@@ -1965,6 +2145,7 @@ inline Tensor Tensor::reshape(IntArrayRef shape) const {
 }
 inline Tensor Tensor::reshape_as(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::reshape_as(const_cast<Tensor&>(*this), other);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::reshape_as", ""}).value();
@@ -1974,6 +2155,7 @@ inline Tensor Tensor::reshape_as(const Tensor & other) const {
 }
 inline Tensor Tensor::round() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::round(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::round", ""}).value();
@@ -1983,6 +2165,7 @@ inline Tensor Tensor::round() const {
 }
 inline Tensor & Tensor::round_() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::round_(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::round_", ""}).value();
@@ -1992,6 +2175,7 @@ inline Tensor & Tensor::round_() const {
 }
 inline Tensor Tensor::relu() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::relu(const_cast<Tensor&>(*this));
@@ -2010,6 +2194,7 @@ inline Tensor Tensor::relu() const {
 }
 inline Tensor & Tensor::relu_() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::relu_(const_cast<Tensor&>(*this));
@@ -2028,6 +2213,7 @@ inline Tensor & Tensor::relu_() const {
 }
 inline Tensor Tensor::prelu(const Tensor & weight) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::prelu(const_cast<Tensor&>(*this), weight);
@@ -2043,6 +2229,7 @@ inline Tensor Tensor::prelu(const Tensor & weight) const {
 }
 inline std::tuple<Tensor,Tensor> Tensor::prelu_backward(const Tensor & grad_output, const Tensor & weight) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::prelu_backward(grad_output, const_cast<Tensor&>(*this), weight);
@@ -2058,6 +2245,7 @@ inline std::tuple<Tensor,Tensor> Tensor::prelu_backward(const Tensor & grad_outp
 }
 inline Tensor Tensor::hardshrink(Scalar lambd) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::hardshrink(const_cast<Tensor&>(*this), lambd);
@@ -2073,6 +2261,7 @@ inline Tensor Tensor::hardshrink(Scalar lambd) const {
 }
 inline Tensor Tensor::hardshrink_backward(const Tensor & grad_out, Scalar lambd) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::hardshrink_backward(grad_out, const_cast<Tensor&>(*this), lambd);
@@ -2088,6 +2277,7 @@ inline Tensor Tensor::hardshrink_backward(const Tensor & grad_out, Scalar lambd)
 }
 inline Tensor Tensor::rsqrt() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::rsqrt(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::rsqrt", ""}).value();
@@ -2097,6 +2287,7 @@ inline Tensor Tensor::rsqrt() const {
 }
 inline Tensor & Tensor::rsqrt_() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::rsqrt_(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::rsqrt_", ""}).value();
@@ -2107,6 +2298,7 @@ inline Tensor & Tensor::rsqrt_() const {
 #ifdef BUILD_NAMEDTENSOR
 inline Tensor Tensor::select(Dimname dim, int64_t index) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::select(const_cast<Tensor&>(*this), dim, index);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::select.Dimname(Tensor(a) self, Dimname dim, int index) -> Tensor(a)");
@@ -2116,6 +2308,7 @@ inline Tensor Tensor::select(Dimname dim, int64_t index) const {
 #endif
 inline Tensor Tensor::select(int64_t dim, int64_t index) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::select(const_cast<Tensor&>(*this), dim, index);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::select", "int"}).value();
@@ -2125,6 +2318,7 @@ inline Tensor Tensor::select(int64_t dim, int64_t index) const {
 }
 inline Tensor Tensor::sigmoid() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::sigmoid(const_cast<Tensor&>(*this));
@@ -2140,6 +2334,7 @@ inline Tensor Tensor::sigmoid() const {
 }
 inline Tensor & Tensor::sigmoid_() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::sigmoid_(const_cast<Tensor&>(*this));
@@ -2155,6 +2350,7 @@ inline Tensor & Tensor::sigmoid_() const {
 }
 inline Tensor Tensor::sin() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::sin(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::sin", ""}).value();
@@ -2164,6 +2360,7 @@ inline Tensor Tensor::sin() const {
 }
 inline Tensor & Tensor::sin_() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::sin_(const_cast<Tensor&>(*this));
@@ -2179,6 +2376,7 @@ inline Tensor & Tensor::sin_() const {
 }
 inline Tensor Tensor::sinh() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::sinh(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::sinh", ""}).value();
@@ -2188,6 +2386,7 @@ inline Tensor Tensor::sinh() const {
 }
 inline Tensor & Tensor::sinh_() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::sinh_(const_cast<Tensor&>(*this));
@@ -2203,6 +2402,7 @@ inline Tensor & Tensor::sinh_() const {
 }
 inline Tensor Tensor::detach() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::detach(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::detach", ""}).value();
@@ -2212,6 +2412,7 @@ inline Tensor Tensor::detach() const {
 }
 inline Tensor & Tensor::detach_() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::detach_(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::detach_", ""}).value();
@@ -2221,6 +2422,7 @@ inline Tensor & Tensor::detach_() const {
 }
 inline int64_t Tensor::size(int64_t dim) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::size(const_cast<Tensor&>(*this), dim);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::size", "int"}).value();
@@ -2231,6 +2433,7 @@ inline int64_t Tensor::size(int64_t dim) const {
 #ifdef BUILD_NAMEDTENSOR
 inline int64_t Tensor::size(Dimname dim) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::size(const_cast<Tensor&>(*this), dim);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::size.Dimname(Tensor self, Dimname dim) -> int");
@@ -2240,6 +2443,7 @@ inline int64_t Tensor::size(Dimname dim) const {
 #endif
 inline Tensor Tensor::slice(int64_t dim, int64_t start, int64_t end, int64_t step) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::slice(const_cast<Tensor&>(*this), dim, start, end, step);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::slice", "Tensor"}).value();
@@ -2249,6 +2453,7 @@ inline Tensor Tensor::slice(int64_t dim, int64_t start, int64_t end, int64_t ste
 }
 inline std::tuple<Tensor,Tensor> Tensor::slogdet() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::slogdet(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::slogdet", ""}).value();
@@ -2258,6 +2463,7 @@ inline std::tuple<Tensor,Tensor> Tensor::slogdet() const {
 }
 inline Tensor Tensor::smm(const Tensor & mat2) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::smm(const_cast<Tensor&>(*this), mat2);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::smm", ""}).value();
@@ -2267,6 +2473,7 @@ inline Tensor Tensor::smm(const Tensor & mat2) const {
 }
 inline Tensor Tensor::softmax(int64_t dim, c10::optional<ScalarType> dtype) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::softmax(const_cast<Tensor&>(*this), dim, dtype);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::softmax(Tensor self, int dim, ScalarType? dtype=None) -> Tensor");
@@ -2276,6 +2483,7 @@ inline Tensor Tensor::softmax(int64_t dim, c10::optional<ScalarType> dtype) cons
 #ifdef BUILD_NAMEDTENSOR
 inline Tensor Tensor::softmax(Dimname dim, c10::optional<ScalarType> dtype) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::softmax(const_cast<Tensor&>(*this), dim, dtype);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::softmax(Tensor self, Dimname dim, *, ScalarType? dtype=None) -> Tensor");
@@ -2285,6 +2493,7 @@ inline Tensor Tensor::softmax(Dimname dim, c10::optional<ScalarType> dtype) cons
 #endif
 inline std::vector<Tensor> Tensor::split(int64_t split_size, int64_t dim) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::split(const_cast<Tensor&>(*this), split_size, dim);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::split", "Tensor"}).value();
@@ -2294,6 +2503,7 @@ inline std::vector<Tensor> Tensor::split(int64_t split_size, int64_t dim) const 
 }
 inline std::vector<Tensor> Tensor::split_with_sizes(IntArrayRef split_sizes, int64_t dim) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::split_with_sizes(const_cast<Tensor&>(*this), split_sizes, dim);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::split_with_sizes", ""}).value();
@@ -2303,6 +2513,7 @@ inline std::vector<Tensor> Tensor::split_with_sizes(IntArrayRef split_sizes, int
 }
 inline Tensor Tensor::squeeze() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::squeeze(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::squeeze", ""}).value();
@@ -2312,6 +2523,7 @@ inline Tensor Tensor::squeeze() const {
 }
 inline Tensor Tensor::squeeze(int64_t dim) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::squeeze(const_cast<Tensor&>(*this), dim);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::squeeze", "dim"}).value();
@@ -2322,6 +2534,7 @@ inline Tensor Tensor::squeeze(int64_t dim) const {
 #ifdef BUILD_NAMEDTENSOR
 inline Tensor Tensor::squeeze(Dimname dim) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::squeeze(const_cast<Tensor&>(*this), dim);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::squeeze.dimname(Tensor(a) self, Dimname dim) -> Tensor(a)");
@@ -2331,6 +2544,7 @@ inline Tensor Tensor::squeeze(Dimname dim) const {
 #endif
 inline Tensor & Tensor::squeeze_() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::squeeze_(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::squeeze_", ""}).value();
@@ -2340,6 +2554,7 @@ inline Tensor & Tensor::squeeze_() const {
 }
 inline Tensor & Tensor::squeeze_(int64_t dim) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::squeeze_(const_cast<Tensor&>(*this), dim);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::squeeze_", "dim"}).value();
@@ -2350,6 +2565,7 @@ inline Tensor & Tensor::squeeze_(int64_t dim) const {
 #ifdef BUILD_NAMEDTENSOR
 inline Tensor & Tensor::squeeze_(Dimname dim) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::squeeze_(const_cast<Tensor&>(*this), dim);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::squeeze_.dimname(Tensor(a!) self, Dimname dim) -> Tensor(a!)");
@@ -2359,6 +2575,7 @@ inline Tensor & Tensor::squeeze_(Dimname dim) const {
 #endif
 inline Tensor Tensor::sspaddmm(const Tensor & mat1, const Tensor & mat2, Scalar beta, Scalar alpha) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::sspaddmm(const_cast<Tensor&>(*this), mat1, mat2, beta, alpha);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::sspaddmm", ""}).value();
@@ -2368,6 +2585,7 @@ inline Tensor Tensor::sspaddmm(const Tensor & mat1, const Tensor & mat2, Scalar 
 }
 inline Tensor Tensor::stft(int64_t n_fft, c10::optional<int64_t> hop_length, c10::optional<int64_t> win_length, const Tensor & window, bool normalized, bool onesided) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::stft(const_cast<Tensor&>(*this), n_fft, hop_length, win_length, window, normalized, onesided);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::stft(Tensor self, int n_fft, int? hop_length=None, int? win_length=None, Tensor? window=None, bool normalized=False, bool onesided=True) -> Tensor");
@@ -2376,6 +2594,7 @@ inline Tensor Tensor::stft(int64_t n_fft, c10::optional<int64_t> hop_length, c10
 }
 inline int64_t Tensor::stride(int64_t dim) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::stride(const_cast<Tensor&>(*this), dim);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::stride", "int"}).value();
@@ -2386,6 +2605,7 @@ inline int64_t Tensor::stride(int64_t dim) const {
 #ifdef BUILD_NAMEDTENSOR
 inline int64_t Tensor::stride(Dimname dim) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::stride(const_cast<Tensor&>(*this), dim);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::stride.Dimname(Tensor self, Dimname dim) -> int");
@@ -2395,6 +2615,7 @@ inline int64_t Tensor::stride(Dimname dim) const {
 #endif
 inline Tensor Tensor::sum(c10::optional<ScalarType> dtype) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::sum(const_cast<Tensor&>(*this), dtype);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::sum(Tensor self, *, ScalarType? dtype=None) -> Tensor");
@@ -2403,6 +2624,7 @@ inline Tensor Tensor::sum(c10::optional<ScalarType> dtype) const {
 }
 inline Tensor Tensor::sum(IntArrayRef dim, bool keepdim, c10::optional<ScalarType> dtype) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::sum(const_cast<Tensor&>(*this), dim, keepdim, dtype);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::sum.dim_IntList(Tensor self, int[1] dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor");
@@ -2412,6 +2634,7 @@ inline Tensor Tensor::sum(IntArrayRef dim, bool keepdim, c10::optional<ScalarTyp
 #ifdef BUILD_NAMEDTENSOR
 inline Tensor Tensor::sum(DimnameList dim, bool keepdim, c10::optional<ScalarType> dtype) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::sum(const_cast<Tensor&>(*this), dim, keepdim, dtype);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::sum.dim_DimnameList(Tensor self, Dimname[1] dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor");
@@ -2421,6 +2644,7 @@ inline Tensor Tensor::sum(DimnameList dim, bool keepdim, c10::optional<ScalarTyp
 #endif
 inline Tensor Tensor::sum_to_size(IntArrayRef size) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::sum_to_size(const_cast<Tensor&>(*this), size);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::sum_to_size", ""}).value();
@@ -2430,6 +2654,7 @@ inline Tensor Tensor::sum_to_size(IntArrayRef size) const {
 }
 inline Tensor Tensor::sqrt() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::sqrt(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::sqrt", ""}).value();
@@ -2439,6 +2664,7 @@ inline Tensor Tensor::sqrt() const {
 }
 inline Tensor & Tensor::sqrt_() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::sqrt_(const_cast<Tensor&>(*this));
@@ -2454,6 +2680,7 @@ inline Tensor & Tensor::sqrt_() const {
 }
 inline Tensor Tensor::std(bool unbiased) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::std(const_cast<Tensor&>(*this), unbiased);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::std", ""}).value();
@@ -2463,6 +2690,7 @@ inline Tensor Tensor::std(bool unbiased) const {
 }
 inline Tensor Tensor::std(IntArrayRef dim, bool unbiased, bool keepdim) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::std(const_cast<Tensor&>(*this), dim, unbiased, keepdim);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::std", "dim"}).value();
@@ -2473,6 +2701,7 @@ inline Tensor Tensor::std(IntArrayRef dim, bool unbiased, bool keepdim) const {
 #ifdef BUILD_NAMEDTENSOR
 inline Tensor Tensor::std(DimnameList dim, bool unbiased, bool keepdim) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::std(const_cast<Tensor&>(*this), dim, unbiased, keepdim);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::std.names_dim(Tensor self, Dimname[1] dim, bool unbiased=True, bool keepdim=False) -> Tensor");
@@ -2482,6 +2711,7 @@ inline Tensor Tensor::std(DimnameList dim, bool unbiased, bool keepdim) const {
 #endif
 inline Tensor Tensor::prod(c10::optional<ScalarType> dtype) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::prod(const_cast<Tensor&>(*this), dtype);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::prod(Tensor self, *, ScalarType? dtype=None) -> Tensor");
@@ -2490,6 +2720,7 @@ inline Tensor Tensor::prod(c10::optional<ScalarType> dtype) const {
 }
 inline Tensor Tensor::prod(int64_t dim, bool keepdim, c10::optional<ScalarType> dtype) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::prod(const_cast<Tensor&>(*this), dim, keepdim, dtype);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::prod.dim_int(Tensor self, int dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor");
@@ -2499,6 +2730,7 @@ inline Tensor Tensor::prod(int64_t dim, bool keepdim, c10::optional<ScalarType> 
 #ifdef BUILD_NAMEDTENSOR
 inline Tensor Tensor::prod(Dimname dim, bool keepdim, c10::optional<ScalarType> dtype) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::prod(const_cast<Tensor&>(*this), dim, keepdim, dtype);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::prod.dim_Dimname(Tensor self, Dimname dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor");
@@ -2508,6 +2740,7 @@ inline Tensor Tensor::prod(Dimname dim, bool keepdim, c10::optional<ScalarType> 
 #endif
 inline Tensor Tensor::t() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::t(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::t", ""}).value();
@@ -2517,6 +2750,7 @@ inline Tensor Tensor::t() const {
 }
 inline Tensor & Tensor::t_() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::t_(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::t_", ""}).value();
@@ -2526,6 +2760,7 @@ inline Tensor & Tensor::t_() const {
 }
 inline Tensor Tensor::tan() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::tan(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::tan", ""}).value();
@@ -2535,6 +2770,7 @@ inline Tensor Tensor::tan() const {
 }
 inline Tensor & Tensor::tan_() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::tan_(const_cast<Tensor&>(*this));
@@ -2550,6 +2786,7 @@ inline Tensor & Tensor::tan_() const {
 }
 inline Tensor Tensor::tanh() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::tanh(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::tanh", ""}).value();
@@ -2559,6 +2796,7 @@ inline Tensor Tensor::tanh() const {
 }
 inline Tensor & Tensor::tanh_() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::tanh_(const_cast<Tensor&>(*this));
@@ -2574,6 +2812,7 @@ inline Tensor & Tensor::tanh_() const {
 }
 inline Tensor Tensor::transpose(int64_t dim0, int64_t dim1) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::transpose(const_cast<Tensor&>(*this), dim0, dim1);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::transpose", "int"}).value();
@@ -2584,6 +2823,7 @@ inline Tensor Tensor::transpose(int64_t dim0, int64_t dim1) const {
 #ifdef BUILD_NAMEDTENSOR
 inline Tensor Tensor::transpose(Dimname dim0, Dimname dim1) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::transpose(const_cast<Tensor&>(*this), dim0, dim1);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::transpose.Dimname(Tensor(a) self, Dimname dim0, Dimname dim1) -> Tensor(a)");
@@ -2593,6 +2833,7 @@ inline Tensor Tensor::transpose(Dimname dim0, Dimname dim1) const {
 #endif
 inline Tensor & Tensor::transpose_(int64_t dim0, int64_t dim1) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::transpose_(const_cast<Tensor&>(*this), dim0, dim1);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::transpose_", ""}).value();
@@ -2602,6 +2843,7 @@ inline Tensor & Tensor::transpose_(int64_t dim0, int64_t dim1) const {
 }
 inline Tensor Tensor::flip(IntArrayRef dims) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::flip(const_cast<Tensor&>(*this), dims);
@@ -2617,6 +2859,7 @@ inline Tensor Tensor::flip(IntArrayRef dims) const {
 }
 inline Tensor Tensor::roll(IntArrayRef shifts, IntArrayRef dims) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::roll(const_cast<Tensor&>(*this), shifts, dims);
@@ -2632,6 +2875,7 @@ inline Tensor Tensor::roll(IntArrayRef shifts, IntArrayRef dims) const {
 }
 inline Tensor Tensor::rot90(int64_t k, IntArrayRef dims) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::rot90(const_cast<Tensor&>(*this), k, dims);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::rot90", ""}).value();
@@ -2641,6 +2885,7 @@ inline Tensor Tensor::rot90(int64_t k, IntArrayRef dims) const {
 }
 inline Tensor Tensor::trunc() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::trunc(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::trunc", ""}).value();
@@ -2650,6 +2895,7 @@ inline Tensor Tensor::trunc() const {
 }
 inline Tensor & Tensor::trunc_() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::trunc_(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::trunc_", ""}).value();
@@ -2659,6 +2905,7 @@ inline Tensor & Tensor::trunc_() const {
 }
 inline Tensor Tensor::type_as(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::type_as(const_cast<Tensor&>(*this), other);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::type_as", ""}).value();
@@ -2668,6 +2915,7 @@ inline Tensor Tensor::type_as(const Tensor & other) const {
 }
 inline Tensor Tensor::unsqueeze(int64_t dim) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::unsqueeze(const_cast<Tensor&>(*this), dim);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::unsqueeze", ""}).value();
@@ -2677,6 +2925,7 @@ inline Tensor Tensor::unsqueeze(int64_t dim) const {
 }
 inline Tensor & Tensor::unsqueeze_(int64_t dim) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::unsqueeze_(const_cast<Tensor&>(*this), dim);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::unsqueeze_", ""}).value();
@@ -2686,6 +2935,7 @@ inline Tensor & Tensor::unsqueeze_(int64_t dim) const {
 }
 inline Tensor Tensor::var(bool unbiased) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::var(const_cast<Tensor&>(*this), unbiased);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::var", ""}).value();
@@ -2695,6 +2945,7 @@ inline Tensor Tensor::var(bool unbiased) const {
 }
 inline Tensor Tensor::var(IntArrayRef dim, bool unbiased, bool keepdim) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::var(const_cast<Tensor&>(*this), dim, unbiased, keepdim);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::var", "dim"}).value();
@@ -2705,6 +2956,7 @@ inline Tensor Tensor::var(IntArrayRef dim, bool unbiased, bool keepdim) const {
 #ifdef BUILD_NAMEDTENSOR
 inline Tensor Tensor::var(DimnameList dim, bool unbiased, bool keepdim) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::var(const_cast<Tensor&>(*this), dim, unbiased, keepdim);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::var.names_dim(Tensor self, Dimname[1] dim, bool unbiased=True, bool keepdim=False) -> Tensor");
@@ -2714,6 +2966,7 @@ inline Tensor Tensor::var(DimnameList dim, bool unbiased, bool keepdim) const {
 #endif
 inline Tensor Tensor::view_as(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::view_as(const_cast<Tensor&>(*this), other);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::view_as", ""}).value();
@@ -2723,6 +2976,7 @@ inline Tensor Tensor::view_as(const Tensor & other) const {
 }
 inline Tensor Tensor::where(const Tensor & condition, const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::where(condition, const_cast<Tensor&>(*this), other);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::where", "self"}).value();
@@ -2732,6 +2986,7 @@ inline Tensor Tensor::where(const Tensor & condition, const Tensor & other) cons
 }
 inline Tensor Tensor::norm(c10::optional<Scalar> p, ScalarType dtype) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::norm(const_cast<Tensor&>(*this), p, dtype);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::norm.ScalarOpt_dtype(Tensor self, Scalar? p, *, ScalarType dtype) -> Tensor");
@@ -2740,6 +2995,7 @@ inline Tensor Tensor::norm(c10::optional<Scalar> p, ScalarType dtype) const {
 }
 inline Tensor Tensor::norm(Scalar p) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::norm(const_cast<Tensor&>(*this), p);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::norm", "Scalar"}).value();
@@ -2749,6 +3005,7 @@ inline Tensor Tensor::norm(Scalar p) const {
 }
 inline Tensor Tensor::norm(c10::optional<Scalar> p, IntArrayRef dim, bool keepdim, ScalarType dtype) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::norm(const_cast<Tensor&>(*this), p, dim, keepdim, dtype);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::norm.ScalarOpt_dim_dtype(Tensor self, Scalar? p, int[1] dim, bool keepdim, *, ScalarType dtype) -> Tensor");
@@ -2757,6 +3014,7 @@ inline Tensor Tensor::norm(c10::optional<Scalar> p, IntArrayRef dim, bool keepdi
 }
 inline Tensor Tensor::norm(c10::optional<Scalar> p, IntArrayRef dim, bool keepdim) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::norm(const_cast<Tensor&>(*this), p, dim, keepdim);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::norm", "ScalarOpt_dim"}).value();
@@ -2767,6 +3025,7 @@ inline Tensor Tensor::norm(c10::optional<Scalar> p, IntArrayRef dim, bool keepdi
 #ifdef BUILD_NAMEDTENSOR
 inline Tensor Tensor::norm(c10::optional<Scalar> p, DimnameList dim, bool keepdim, ScalarType dtype) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::norm(const_cast<Tensor&>(*this), p, dim, keepdim, dtype);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::norm.names_ScalarOpt_dim_dtype(Tensor self, Scalar? p, Dimname[1] dim, bool keepdim, *, ScalarType dtype) -> Tensor");
@@ -2777,6 +3036,7 @@ inline Tensor Tensor::norm(c10::optional<Scalar> p, DimnameList dim, bool keepdi
 #ifdef BUILD_NAMEDTENSOR
 inline Tensor Tensor::norm(c10::optional<Scalar> p, DimnameList dim, bool keepdim) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::norm(const_cast<Tensor&>(*this), p, dim, keepdim);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::norm.names_ScalarOpt_dim(Tensor self, Scalar? p, Dimname[1] dim, bool keepdim=False) -> Tensor");
@@ -2786,6 +3046,7 @@ inline Tensor Tensor::norm(c10::optional<Scalar> p, DimnameList dim, bool keepdi
 #endif
 inline Tensor Tensor::clone() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::clone(const_cast<Tensor&>(*this));
@@ -2807,6 +3068,7 @@ inline Tensor Tensor::clone() const {
 }
 inline Tensor & Tensor::resize_as_(const Tensor & the_template) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::resize_as_(const_cast<Tensor&>(*this), the_template);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::resize_as_", ""}).value();
@@ -2816,6 +3078,7 @@ inline Tensor & Tensor::resize_as_(const Tensor & the_template) const {
 }
 inline Tensor Tensor::pow(Scalar exponent) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::pow(const_cast<Tensor&>(*this), exponent);
@@ -2834,6 +3097,7 @@ inline Tensor Tensor::pow(Scalar exponent) const {
 }
 inline Tensor & Tensor::zero_() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::zero_(const_cast<Tensor&>(*this));
@@ -2852,6 +3116,7 @@ inline Tensor & Tensor::zero_() const {
 }
 inline Tensor Tensor::sub(const Tensor & other, Scalar alpha) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::sub(const_cast<Tensor&>(*this), other, alpha);
@@ -2870,6 +3135,7 @@ inline Tensor Tensor::sub(const Tensor & other, Scalar alpha) const {
 }
 inline Tensor & Tensor::sub_(const Tensor & other, Scalar alpha) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::sub_(const_cast<Tensor&>(*this), other, alpha);
@@ -2888,6 +3154,7 @@ inline Tensor & Tensor::sub_(const Tensor & other, Scalar alpha) const {
 }
 inline Tensor Tensor::sub(Scalar other, Scalar alpha) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::sub(const_cast<Tensor&>(*this), other, alpha);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::sub", "Scalar"}).value();
@@ -2897,6 +3164,7 @@ inline Tensor Tensor::sub(Scalar other, Scalar alpha) const {
 }
 inline Tensor & Tensor::sub_(Scalar other, Scalar alpha) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::sub_(const_cast<Tensor&>(*this), other, alpha);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::sub_", "Scalar"}).value();
@@ -2906,6 +3174,7 @@ inline Tensor & Tensor::sub_(Scalar other, Scalar alpha) const {
 }
 inline Tensor Tensor::addmm(const Tensor & mat1, const Tensor & mat2, Scalar beta, Scalar alpha) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::addmm(const_cast<Tensor&>(*this), mat1, mat2, beta, alpha);
@@ -2924,6 +3193,7 @@ inline Tensor Tensor::addmm(const Tensor & mat1, const Tensor & mat2, Scalar bet
 }
 inline Tensor & Tensor::addmm_(const Tensor & mat1, const Tensor & mat2, Scalar beta, Scalar alpha) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::addmm_(const_cast<Tensor&>(*this), mat1, mat2, beta, alpha);
@@ -2942,6 +3212,7 @@ inline Tensor & Tensor::addmm_(const Tensor & mat1, const Tensor & mat2, Scalar 
 }
 inline Tensor & Tensor::sparse_resize_(IntArrayRef size, int64_t sparse_dim, int64_t dense_dim) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::SparseCPU:
             return SparseCPUType::sparse_resize_(const_cast<Tensor&>(*this), size, sparse_dim, dense_dim);
@@ -2957,6 +3228,7 @@ inline Tensor & Tensor::sparse_resize_(IntArrayRef size, int64_t sparse_dim, int
 }
 inline Tensor & Tensor::sparse_resize_and_clear_(IntArrayRef size, int64_t sparse_dim, int64_t dense_dim) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::SparseCPU:
             return SparseCPUType::sparse_resize_and_clear_(const_cast<Tensor&>(*this), size, sparse_dim, dense_dim);
@@ -2972,6 +3244,7 @@ inline Tensor & Tensor::sparse_resize_and_clear_(IntArrayRef size, int64_t spars
 }
 inline Tensor Tensor::sparse_mask(const Tensor & mask) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::SparseCPU:
             return SparseCPUType::sparse_mask(const_cast<Tensor&>(*this), mask);
@@ -2987,6 +3260,7 @@ inline Tensor Tensor::sparse_mask(const Tensor & mask) const {
 }
 inline Tensor Tensor::to_dense() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::SparseCPU:
             return SparseCPUType::to_dense(const_cast<Tensor&>(*this));
@@ -3002,6 +3276,7 @@ inline Tensor Tensor::to_dense() const {
 }
 inline int64_t Tensor::sparse_dim() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::SparseCPU:
             return SparseCPUType::sparse_dim(const_cast<Tensor&>(*this));
@@ -3017,6 +3292,7 @@ inline int64_t Tensor::sparse_dim() const {
 }
 inline int64_t Tensor::_dimI() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::SparseCPU:
             return SparseCPUType::_dimI(const_cast<Tensor&>(*this));
@@ -3032,6 +3308,7 @@ inline int64_t Tensor::_dimI() const {
 }
 inline int64_t Tensor::dense_dim() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::SparseCPU:
             return SparseCPUType::dense_dim(const_cast<Tensor&>(*this));
@@ -3047,6 +3324,7 @@ inline int64_t Tensor::dense_dim() const {
 }
 inline int64_t Tensor::_dimV() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::SparseCPU:
             return SparseCPUType::_dimV(const_cast<Tensor&>(*this));
@@ -3062,6 +3340,7 @@ inline int64_t Tensor::_dimV() const {
 }
 inline int64_t Tensor::_nnz() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::SparseCPU:
             return SparseCPUType::_nnz(const_cast<Tensor&>(*this));
@@ -3077,6 +3356,7 @@ inline int64_t Tensor::_nnz() const {
 }
 inline Tensor Tensor::coalesce() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::SparseCPU:
             return SparseCPUType::coalesce(const_cast<Tensor&>(*this));
@@ -3092,6 +3372,7 @@ inline Tensor Tensor::coalesce() const {
 }
 inline bool Tensor::is_coalesced() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::SparseCPU:
             return SparseCPUType::is_coalesced(const_cast<Tensor&>(*this));
@@ -3107,6 +3388,7 @@ inline bool Tensor::is_coalesced() const {
 }
 inline Tensor Tensor::_indices() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::SparseCPU:
             return SparseCPUType::_indices(const_cast<Tensor&>(*this));
@@ -3122,6 +3404,7 @@ inline Tensor Tensor::_indices() const {
 }
 inline Tensor Tensor::_values() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::SparseCPU:
             return SparseCPUType::_values(const_cast<Tensor&>(*this));
@@ -3137,6 +3420,7 @@ inline Tensor Tensor::_values() const {
 }
 inline Tensor & Tensor::_coalesced_(bool coalesced) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::SparseCPU:
             return SparseCPUType::_coalesced_(const_cast<Tensor&>(*this), coalesced);
@@ -3152,6 +3436,7 @@ inline Tensor & Tensor::_coalesced_(bool coalesced) const {
 }
 inline Tensor Tensor::indices() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::SparseCPU:
             return SparseCPUType::indices(const_cast<Tensor&>(*this));
@@ -3167,6 +3452,7 @@ inline Tensor Tensor::indices() const {
 }
 inline Tensor Tensor::values() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::SparseCPU:
             return SparseCPUType::values(const_cast<Tensor&>(*this));
@@ -3182,6 +3468,7 @@ inline Tensor Tensor::values() const {
 }
 inline int64_t Tensor::numel() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::numel(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::numel", ""}).value();
@@ -3191,6 +3478,7 @@ inline int64_t Tensor::numel() const {
 }
 inline std::vector<Tensor> Tensor::unbind(int64_t dim) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::unbind(const_cast<Tensor&>(*this), dim);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::unbind", "int"}).value();
@@ -3201,6 +3489,7 @@ inline std::vector<Tensor> Tensor::unbind(int64_t dim) const {
 #ifdef BUILD_NAMEDTENSOR
 inline std::vector<Tensor> Tensor::unbind(Dimname dim) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::unbind(const_cast<Tensor&>(*this), dim);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::unbind.Dimname(Tensor(a) self, Dimname dim) -> Tensor(a)[]");
@@ -3210,6 +3499,7 @@ inline std::vector<Tensor> Tensor::unbind(Dimname dim) const {
 #endif
 inline Tensor Tensor::to_sparse(int64_t sparse_dim) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::to_sparse(const_cast<Tensor&>(*this), sparse_dim);
@@ -3225,6 +3515,7 @@ inline Tensor Tensor::to_sparse(int64_t sparse_dim) const {
 }
 inline Tensor Tensor::to_sparse() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::to_sparse(const_cast<Tensor&>(*this));
@@ -3240,6 +3531,7 @@ inline Tensor Tensor::to_sparse() const {
 }
 inline Tensor Tensor::to_mkldnn() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::to_mkldnn(const_cast<Tensor&>(*this));
@@ -3255,6 +3547,7 @@ inline Tensor Tensor::to_mkldnn() const {
 }
 inline Tensor Tensor::dequantize() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::QuantizedCPU:
             return QuantizedCPUType::dequantize(const_cast<Tensor&>(*this));
@@ -3270,6 +3563,7 @@ inline Tensor Tensor::dequantize() const {
 }
 inline double Tensor::q_scale() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::QuantizedCPU:
             return QuantizedCPUType::q_scale(const_cast<Tensor&>(*this));
@@ -3285,6 +3579,7 @@ inline double Tensor::q_scale() const {
 }
 inline int64_t Tensor::q_zero_point() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::QuantizedCPU:
             return QuantizedCPUType::q_zero_point(const_cast<Tensor&>(*this));
@@ -3300,6 +3595,7 @@ inline int64_t Tensor::q_zero_point() const {
 }
 inline Tensor Tensor::q_per_channel_scales() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::QuantizedCPU:
             return QuantizedCPUType::q_per_channel_scales(const_cast<Tensor&>(*this));
@@ -3315,6 +3611,7 @@ inline Tensor Tensor::q_per_channel_scales() const {
 }
 inline Tensor Tensor::q_per_channel_zero_points() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::QuantizedCPU:
             return QuantizedCPUType::q_per_channel_zero_points(const_cast<Tensor&>(*this));
@@ -3330,6 +3627,7 @@ inline Tensor Tensor::q_per_channel_zero_points() const {
 }
 inline int64_t Tensor::q_per_channel_axis() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::QuantizedCPU:
             return QuantizedCPUType::q_per_channel_axis(const_cast<Tensor&>(*this));
@@ -3344,6 +3642,7 @@ inline int64_t Tensor::q_per_channel_axis() const {
 }
 inline Tensor Tensor::int_repr() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::QuantizedCPU:
             return QuantizedCPUType::int_repr(const_cast<Tensor&>(*this));
@@ -3359,6 +3658,7 @@ inline Tensor Tensor::int_repr() const {
 }
 inline QScheme Tensor::qscheme() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::QuantizedCPU:
             return QuantizedCPUType::qscheme(const_cast<Tensor&>(*this));
@@ -3373,6 +3673,7 @@ inline QScheme Tensor::qscheme() const {
 }
 inline Tensor Tensor::to(const TensorOptions & options, bool non_blocking, bool copy) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::to(const_cast<Tensor&>(*this), options, non_blocking, copy);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::to.dtype_layout(Tensor self, *, ScalarType dtype, Layout layout, Device device, bool pin_memory=False, bool non_blocking=False, bool copy=False) -> Tensor");
@@ -3381,6 +3682,7 @@ inline Tensor Tensor::to(const TensorOptions & options, bool non_blocking, bool 
 }
 inline Tensor Tensor::to(Device device, ScalarType dtype, bool non_blocking, bool copy) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::to(const_cast<Tensor&>(*this), device, dtype, non_blocking, copy);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::to.device(Tensor self, Device device, ScalarType dtype, bool non_blocking=False, bool copy=False) -> Tensor");
@@ -3389,6 +3691,7 @@ inline Tensor Tensor::to(Device device, ScalarType dtype, bool non_blocking, boo
 }
 inline Tensor Tensor::to(ScalarType dtype, bool non_blocking, bool copy) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::to(const_cast<Tensor&>(*this), dtype, non_blocking, copy);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::to.dtype(Tensor self, ScalarType dtype, bool non_blocking=False, bool copy=False) -> Tensor");
@@ -3397,6 +3700,7 @@ inline Tensor Tensor::to(ScalarType dtype, bool non_blocking, bool copy) const {
 }
 inline Tensor Tensor::to(const Tensor & other, bool non_blocking, bool copy) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::to(const_cast<Tensor&>(*this), other, non_blocking, copy);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::to", "other"}).value();
@@ -3406,6 +3710,7 @@ inline Tensor Tensor::to(const Tensor & other, bool non_blocking, bool copy) con
 }
 inline Scalar Tensor::item() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::item(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::item", ""}).value();
@@ -3415,6 +3720,7 @@ inline Scalar Tensor::item() const {
 }
 inline Tensor & Tensor::set_(Storage source) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::set_(const_cast<Tensor&>(*this), source);
@@ -3429,6 +3735,7 @@ inline Tensor & Tensor::set_(Storage source) const {
 }
 inline Tensor & Tensor::set_(Storage source, int64_t storage_offset, IntArrayRef size, IntArrayRef stride) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::set_(const_cast<Tensor&>(*this), source, storage_offset, size, stride);
@@ -3446,6 +3753,7 @@ inline Tensor & Tensor::set_(Storage source, int64_t storage_offset, IntArrayRef
 }
 inline Tensor & Tensor::set_(const Tensor & source) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::set_(const_cast<Tensor&>(*this), source);
@@ -3461,6 +3769,7 @@ inline Tensor & Tensor::set_(const Tensor & source) const {
 }
 inline Tensor & Tensor::set_() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::set_(const_cast<Tensor&>(*this));
@@ -3476,6 +3785,7 @@ inline Tensor & Tensor::set_() const {
 }
 inline Tensor & Tensor::set_quantizer_(ConstQuantizerPtr quantizer) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::QuantizedCPU:
             return QuantizedCPUType::set_quantizer_(const_cast<Tensor&>(*this), quantizer);
@@ -3490,6 +3800,7 @@ inline Tensor & Tensor::set_quantizer_(ConstQuantizerPtr quantizer) const {
 }
 inline bool Tensor::is_set_to(const Tensor & tensor) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::is_set_to(const_cast<Tensor&>(*this), tensor);
@@ -3505,6 +3816,7 @@ inline bool Tensor::is_set_to(const Tensor & tensor) const {
 }
 inline Tensor & Tensor::masked_fill_(const Tensor & mask, Scalar value) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::masked_fill_(const_cast<Tensor&>(*this), mask, value);
@@ -3520,6 +3832,7 @@ inline Tensor & Tensor::masked_fill_(const Tensor & mask, Scalar value) const {
 }
 inline Tensor Tensor::masked_fill(const Tensor & mask, Scalar value) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::masked_fill(const_cast<Tensor&>(*this), mask, value);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::masked_fill", "Scalar"}).value();
@@ -3529,6 +3842,7 @@ inline Tensor Tensor::masked_fill(const Tensor & mask, Scalar value) const {
 }
 inline Tensor & Tensor::masked_fill_(const Tensor & mask, const Tensor & value) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::masked_fill_(const_cast<Tensor&>(*this), mask, value);
@@ -3544,6 +3858,7 @@ inline Tensor & Tensor::masked_fill_(const Tensor & mask, const Tensor & value) 
 }
 inline Tensor Tensor::masked_fill(const Tensor & mask, const Tensor & value) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::masked_fill(const_cast<Tensor&>(*this), mask, value);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::masked_fill", "Tensor"}).value();
@@ -3553,6 +3868,7 @@ inline Tensor Tensor::masked_fill(const Tensor & mask, const Tensor & value) con
 }
 inline Tensor & Tensor::masked_scatter_(const Tensor & mask, const Tensor & source) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::masked_scatter_(const_cast<Tensor&>(*this), mask, source);
@@ -3568,6 +3884,7 @@ inline Tensor & Tensor::masked_scatter_(const Tensor & mask, const Tensor & sour
 }
 inline Tensor Tensor::masked_scatter(const Tensor & mask, const Tensor & source) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::masked_scatter(const_cast<Tensor&>(*this), mask, source);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::masked_scatter", ""}).value();
@@ -3577,6 +3894,7 @@ inline Tensor Tensor::masked_scatter(const Tensor & mask, const Tensor & source)
 }
 inline Tensor Tensor::view(IntArrayRef size) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::view(const_cast<Tensor&>(*this), size);
@@ -3595,6 +3913,7 @@ inline Tensor Tensor::view(IntArrayRef size) const {
 }
 inline Tensor & Tensor::put_(const Tensor & index, const Tensor & source, bool accumulate) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::put_(const_cast<Tensor&>(*this), index, source, accumulate);
@@ -3610,6 +3929,7 @@ inline Tensor & Tensor::put_(const Tensor & index, const Tensor & source, bool a
 }
 inline Tensor & Tensor::index_add_(int64_t dim, const Tensor & index, const Tensor & source) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::index_add_(const_cast<Tensor&>(*this), dim, index, source);
@@ -3625,6 +3945,7 @@ inline Tensor & Tensor::index_add_(int64_t dim, const Tensor & index, const Tens
 }
 inline Tensor Tensor::index_add(int64_t dim, const Tensor & index, const Tensor & source) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::index_add(const_cast<Tensor&>(*this), dim, index, source);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::index_add", ""}).value();
@@ -3635,6 +3956,7 @@ inline Tensor Tensor::index_add(int64_t dim, const Tensor & index, const Tensor 
 #ifdef BUILD_NAMEDTENSOR
 inline Tensor Tensor::index_add(Dimname dim, const Tensor & index, const Tensor & source) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::index_add(const_cast<Tensor&>(*this), dim, index, source);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::index_add.dimname(Tensor self, Dimname dim, Tensor index, Tensor source) -> Tensor");
@@ -3644,6 +3966,7 @@ inline Tensor Tensor::index_add(Dimname dim, const Tensor & index, const Tensor 
 #endif
 inline Tensor & Tensor::index_fill_(int64_t dim, const Tensor & index, Scalar value) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::index_fill_(const_cast<Tensor&>(*this), dim, index, value);
@@ -3659,6 +3982,7 @@ inline Tensor & Tensor::index_fill_(int64_t dim, const Tensor & index, Scalar va
 }
 inline Tensor Tensor::index_fill(int64_t dim, const Tensor & index, Scalar value) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::index_fill(const_cast<Tensor&>(*this), dim, index, value);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::index_fill", "Scalar"}).value();
@@ -3668,6 +3992,7 @@ inline Tensor Tensor::index_fill(int64_t dim, const Tensor & index, Scalar value
 }
 inline Tensor & Tensor::index_fill_(int64_t dim, const Tensor & index, const Tensor & value) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::index_fill_(const_cast<Tensor&>(*this), dim, index, value);
@@ -3683,6 +4008,7 @@ inline Tensor & Tensor::index_fill_(int64_t dim, const Tensor & index, const Ten
 }
 inline Tensor Tensor::index_fill(int64_t dim, const Tensor & index, const Tensor & value) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::index_fill(const_cast<Tensor&>(*this), dim, index, value);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::index_fill", "Tensor"}).value();
@@ -3693,6 +4019,7 @@ inline Tensor Tensor::index_fill(int64_t dim, const Tensor & index, const Tensor
 #ifdef BUILD_NAMEDTENSOR
 inline Tensor & Tensor::index_fill_(Dimname dim, const Tensor & index, Scalar value) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::index_fill_(const_cast<Tensor&>(*this), dim, index, value);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::index_fill_.dimname_Scalar(Tensor(a!) self, Dimname dim, Tensor index, Scalar value) -> Tensor(a!)");
@@ -3703,6 +4030,7 @@ inline Tensor & Tensor::index_fill_(Dimname dim, const Tensor & index, Scalar va
 #ifdef BUILD_NAMEDTENSOR
 inline Tensor & Tensor::index_fill_(Dimname dim, const Tensor & index, const Tensor & value) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::index_fill_(const_cast<Tensor&>(*this), dim, index, value);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::index_fill_.dimname_Scalar(Tensor(a!) self, Dimname dim, Tensor index, Tensor value) -> Tensor(a!)");
@@ -3713,6 +4041,7 @@ inline Tensor & Tensor::index_fill_(Dimname dim, const Tensor & index, const Ten
 #ifdef BUILD_NAMEDTENSOR
 inline Tensor Tensor::index_fill(Dimname dim, const Tensor & index, Scalar value) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::index_fill(const_cast<Tensor&>(*this), dim, index, value);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::index_fill.dimname_Scalar(Tensor self, Dimname dim, Tensor index, Scalar value) -> Tensor");
@@ -3723,6 +4052,7 @@ inline Tensor Tensor::index_fill(Dimname dim, const Tensor & index, Scalar value
 #ifdef BUILD_NAMEDTENSOR
 inline Tensor Tensor::index_fill(Dimname dim, const Tensor & index, const Tensor & value) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::index_fill(const_cast<Tensor&>(*this), dim, index, value);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::index_fill.dimname_Tensor(Tensor self, Dimname dim, Tensor index, Tensor value) -> Tensor");
@@ -3732,6 +4062,7 @@ inline Tensor Tensor::index_fill(Dimname dim, const Tensor & index, const Tensor
 #endif
 inline Tensor & Tensor::scatter_(int64_t dim, const Tensor & index, const Tensor & src) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::scatter_(const_cast<Tensor&>(*this), dim, index, src);
@@ -3747,6 +4078,7 @@ inline Tensor & Tensor::scatter_(int64_t dim, const Tensor & index, const Tensor
 }
 inline Tensor Tensor::scatter(int64_t dim, const Tensor & index, const Tensor & src) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::scatter(const_cast<Tensor&>(*this), dim, index, src);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::scatter", "src"}).value();
@@ -3756,6 +4088,7 @@ inline Tensor Tensor::scatter(int64_t dim, const Tensor & index, const Tensor & 
 }
 inline Tensor & Tensor::scatter_(int64_t dim, const Tensor & index, Scalar value) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::scatter_(const_cast<Tensor&>(*this), dim, index, value);
@@ -3771,6 +4104,7 @@ inline Tensor & Tensor::scatter_(int64_t dim, const Tensor & index, Scalar value
 }
 inline Tensor Tensor::scatter(int64_t dim, const Tensor & index, Scalar value) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::scatter(const_cast<Tensor&>(*this), dim, index, value);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::scatter", "value"}).value();
@@ -3781,6 +4115,7 @@ inline Tensor Tensor::scatter(int64_t dim, const Tensor & index, Scalar value) c
 #ifdef BUILD_NAMEDTENSOR
 inline Tensor Tensor::scatter(Dimname dim, const Tensor & index, const Tensor & src) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::scatter(const_cast<Tensor&>(*this), dim, index, src);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::scatter.dimname_src(Tensor self, Dimname dim, Tensor index, Tensor src) -> Tensor");
@@ -3791,6 +4126,7 @@ inline Tensor Tensor::scatter(Dimname dim, const Tensor & index, const Tensor & 
 #ifdef BUILD_NAMEDTENSOR
 inline Tensor Tensor::scatter(Dimname dim, const Tensor & index, Scalar value) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::scatter(const_cast<Tensor&>(*this), dim, index, value);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::scatter.dimname_value(Tensor self, Dimname dim, Tensor index, Scalar value) -> Tensor");
@@ -3800,6 +4136,7 @@ inline Tensor Tensor::scatter(Dimname dim, const Tensor & index, Scalar value) c
 #endif
 inline Tensor & Tensor::scatter_add_(int64_t dim, const Tensor & index, const Tensor & src) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::scatter_add_(const_cast<Tensor&>(*this), dim, index, src);
@@ -3815,6 +4152,7 @@ inline Tensor & Tensor::scatter_add_(int64_t dim, const Tensor & index, const Te
 }
 inline Tensor Tensor::scatter_add(int64_t dim, const Tensor & index, const Tensor & src) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::scatter_add(const_cast<Tensor&>(*this), dim, index, src);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::scatter_add", ""}).value();
@@ -3825,6 +4163,7 @@ inline Tensor Tensor::scatter_add(int64_t dim, const Tensor & index, const Tenso
 #ifdef BUILD_NAMEDTENSOR
 inline Tensor Tensor::scatter_add(Dimname dim, const Tensor & index, const Tensor & src) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::scatter_add(const_cast<Tensor&>(*this), dim, index, src);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::scatter_add.dimname(Tensor self, Dimname dim, Tensor index, Tensor src) -> Tensor");
@@ -3834,6 +4173,7 @@ inline Tensor Tensor::scatter_add(Dimname dim, const Tensor & index, const Tenso
 #endif
 inline Tensor & Tensor::lt_(Scalar other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::lt_(const_cast<Tensor&>(*this), other);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::lt_", "Scalar"}).value();
@@ -3843,6 +4183,7 @@ inline Tensor & Tensor::lt_(Scalar other) const {
 }
 inline Tensor & Tensor::lt_(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::lt_(const_cast<Tensor&>(*this), other);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::lt_", "Tensor"}).value();
@@ -3852,6 +4193,7 @@ inline Tensor & Tensor::lt_(const Tensor & other) const {
 }
 inline Tensor & Tensor::gt_(Scalar other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::gt_(const_cast<Tensor&>(*this), other);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::gt_", "Scalar"}).value();
@@ -3861,6 +4203,7 @@ inline Tensor & Tensor::gt_(Scalar other) const {
 }
 inline Tensor & Tensor::gt_(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::gt_(const_cast<Tensor&>(*this), other);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::gt_", "Tensor"}).value();
@@ -3870,6 +4213,7 @@ inline Tensor & Tensor::gt_(const Tensor & other) const {
 }
 inline Tensor & Tensor::le_(Scalar other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::le_(const_cast<Tensor&>(*this), other);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::le_", "Scalar"}).value();
@@ -3879,6 +4223,7 @@ inline Tensor & Tensor::le_(Scalar other) const {
 }
 inline Tensor & Tensor::le_(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::le_(const_cast<Tensor&>(*this), other);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::le_", "Tensor"}).value();
@@ -3888,6 +4233,7 @@ inline Tensor & Tensor::le_(const Tensor & other) const {
 }
 inline Tensor & Tensor::ge_(Scalar other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::ge_(const_cast<Tensor&>(*this), other);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::ge_", "Scalar"}).value();
@@ -3897,6 +4243,7 @@ inline Tensor & Tensor::ge_(Scalar other) const {
 }
 inline Tensor & Tensor::ge_(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::ge_(const_cast<Tensor&>(*this), other);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::ge_", "Tensor"}).value();
@@ -3906,6 +4253,7 @@ inline Tensor & Tensor::ge_(const Tensor & other) const {
 }
 inline Tensor & Tensor::eq_(Scalar other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::eq_(const_cast<Tensor&>(*this), other);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::eq_", "Scalar"}).value();
@@ -3915,6 +4263,7 @@ inline Tensor & Tensor::eq_(Scalar other) const {
 }
 inline Tensor & Tensor::eq_(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::eq_(const_cast<Tensor&>(*this), other);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::eq_", "Tensor"}).value();
@@ -3924,6 +4273,7 @@ inline Tensor & Tensor::eq_(const Tensor & other) const {
 }
 inline Tensor & Tensor::ne_(Scalar other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::ne_(const_cast<Tensor&>(*this), other);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::ne_", "Scalar"}).value();
@@ -3933,6 +4283,7 @@ inline Tensor & Tensor::ne_(Scalar other) const {
 }
 inline Tensor & Tensor::ne_(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::ne_(const_cast<Tensor&>(*this), other);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::ne_", "Tensor"}).value();
@@ -3942,6 +4293,7 @@ inline Tensor & Tensor::ne_(const Tensor & other) const {
 }
 inline Tensor Tensor::__and__(Scalar other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::__and__(const_cast<Tensor&>(*this), other);
@@ -3957,6 +4309,7 @@ inline Tensor Tensor::__and__(Scalar other) const {
 }
 inline Tensor Tensor::__and__(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::__and__(const_cast<Tensor&>(*this), other);
@@ -3972,6 +4325,7 @@ inline Tensor Tensor::__and__(const Tensor & other) const {
 }
 inline Tensor & Tensor::__iand__(Scalar other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::__iand__(const_cast<Tensor&>(*this), other);
@@ -3987,6 +4341,7 @@ inline Tensor & Tensor::__iand__(Scalar other) const {
 }
 inline Tensor & Tensor::__iand__(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::__iand__(const_cast<Tensor&>(*this), other);
@@ -4002,6 +4357,7 @@ inline Tensor & Tensor::__iand__(const Tensor & other) const {
 }
 inline Tensor Tensor::__or__(Scalar other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::__or__(const_cast<Tensor&>(*this), other);
@@ -4017,6 +4373,7 @@ inline Tensor Tensor::__or__(Scalar other) const {
 }
 inline Tensor Tensor::__or__(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::__or__(const_cast<Tensor&>(*this), other);
@@ -4032,6 +4389,7 @@ inline Tensor Tensor::__or__(const Tensor & other) const {
 }
 inline Tensor & Tensor::__ior__(Scalar other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::__ior__(const_cast<Tensor&>(*this), other);
@@ -4047,6 +4405,7 @@ inline Tensor & Tensor::__ior__(Scalar other) const {
 }
 inline Tensor & Tensor::__ior__(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::__ior__(const_cast<Tensor&>(*this), other);
@@ -4062,6 +4421,7 @@ inline Tensor & Tensor::__ior__(const Tensor & other) const {
 }
 inline Tensor Tensor::__xor__(Scalar other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::__xor__(const_cast<Tensor&>(*this), other);
@@ -4077,6 +4437,7 @@ inline Tensor Tensor::__xor__(Scalar other) const {
 }
 inline Tensor Tensor::__xor__(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::__xor__(const_cast<Tensor&>(*this), other);
@@ -4092,6 +4453,7 @@ inline Tensor Tensor::__xor__(const Tensor & other) const {
 }
 inline Tensor & Tensor::__ixor__(Scalar other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::__ixor__(const_cast<Tensor&>(*this), other);
@@ -4107,6 +4469,7 @@ inline Tensor & Tensor::__ixor__(Scalar other) const {
 }
 inline Tensor & Tensor::__ixor__(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::__ixor__(const_cast<Tensor&>(*this), other);
@@ -4122,6 +4485,7 @@ inline Tensor & Tensor::__ixor__(const Tensor & other) const {
 }
 inline Tensor Tensor::__lshift__(Scalar other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::__lshift__(const_cast<Tensor&>(*this), other);
@@ -4137,6 +4501,7 @@ inline Tensor Tensor::__lshift__(Scalar other) const {
 }
 inline Tensor Tensor::__lshift__(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::__lshift__(const_cast<Tensor&>(*this), other);
@@ -4152,6 +4517,7 @@ inline Tensor Tensor::__lshift__(const Tensor & other) const {
 }
 inline Tensor & Tensor::__ilshift__(Scalar other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::__ilshift__(const_cast<Tensor&>(*this), other);
@@ -4167,6 +4533,7 @@ inline Tensor & Tensor::__ilshift__(Scalar other) const {
 }
 inline Tensor & Tensor::__ilshift__(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::__ilshift__(const_cast<Tensor&>(*this), other);
@@ -4182,6 +4549,7 @@ inline Tensor & Tensor::__ilshift__(const Tensor & other) const {
 }
 inline Tensor Tensor::__rshift__(Scalar other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::__rshift__(const_cast<Tensor&>(*this), other);
@@ -4197,6 +4565,7 @@ inline Tensor Tensor::__rshift__(Scalar other) const {
 }
 inline Tensor Tensor::__rshift__(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::__rshift__(const_cast<Tensor&>(*this), other);
@@ -4212,6 +4581,7 @@ inline Tensor Tensor::__rshift__(const Tensor & other) const {
 }
 inline Tensor & Tensor::__irshift__(Scalar other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::__irshift__(const_cast<Tensor&>(*this), other);
@@ -4227,6 +4597,7 @@ inline Tensor & Tensor::__irshift__(Scalar other) const {
 }
 inline Tensor & Tensor::__irshift__(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::__irshift__(const_cast<Tensor&>(*this), other);
@@ -4242,6 +4613,7 @@ inline Tensor & Tensor::__irshift__(const Tensor & other) const {
 }
 inline Tensor & Tensor::lgamma_() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::lgamma_(const_cast<Tensor&>(*this));
@@ -4257,6 +4629,7 @@ inline Tensor & Tensor::lgamma_() const {
 }
 inline Tensor & Tensor::atan2_(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::atan2_(const_cast<Tensor&>(*this), other);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::atan2_", ""}).value();
@@ -4266,6 +4639,7 @@ inline Tensor & Tensor::atan2_(const Tensor & other) const {
 }
 inline Tensor & Tensor::tril_(int64_t diagonal) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::tril_(const_cast<Tensor&>(*this), diagonal);
@@ -4281,6 +4655,7 @@ inline Tensor & Tensor::tril_(int64_t diagonal) const {
 }
 inline Tensor & Tensor::triu_(int64_t diagonal) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::triu_(const_cast<Tensor&>(*this), diagonal);
@@ -4296,6 +4671,7 @@ inline Tensor & Tensor::triu_(int64_t diagonal) const {
 }
 inline Tensor & Tensor::digamma_() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::digamma_(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::digamma_", ""}).value();
@@ -4305,6 +4681,7 @@ inline Tensor & Tensor::digamma_() const {
 }
 inline Tensor & Tensor::polygamma_(int64_t n) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::polygamma_(const_cast<Tensor&>(*this), n);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::polygamma_", ""}).value();
@@ -4314,6 +4691,7 @@ inline Tensor & Tensor::polygamma_(int64_t n) const {
 }
 inline Tensor & Tensor::renorm_(Scalar p, int64_t dim, Scalar maxnorm) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::renorm_(const_cast<Tensor&>(*this), p, dim, maxnorm);
@@ -4329,6 +4707,7 @@ inline Tensor & Tensor::renorm_(Scalar p, int64_t dim, Scalar maxnorm) const {
 }
 inline Tensor & Tensor::pow_(Scalar exponent) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::pow_(const_cast<Tensor&>(*this), exponent);
@@ -4344,6 +4723,7 @@ inline Tensor & Tensor::pow_(Scalar exponent) const {
 }
 inline Tensor & Tensor::pow_(const Tensor & exponent) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::pow_(const_cast<Tensor&>(*this), exponent);
@@ -4359,6 +4739,7 @@ inline Tensor & Tensor::pow_(const Tensor & exponent) const {
 }
 inline Tensor & Tensor::lerp_(const Tensor & end, Scalar weight) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::lerp_(const_cast<Tensor&>(*this), end, weight);
@@ -4374,6 +4755,7 @@ inline Tensor & Tensor::lerp_(const Tensor & end, Scalar weight) const {
 }
 inline Tensor & Tensor::lerp_(const Tensor & end, const Tensor & weight) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::lerp_(const_cast<Tensor&>(*this), end, weight);
@@ -4389,6 +4771,7 @@ inline Tensor & Tensor::lerp_(const Tensor & end, const Tensor & weight) const {
 }
 inline Tensor & Tensor::fmod_(Scalar other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::fmod_(const_cast<Tensor&>(*this), other);
@@ -4404,6 +4787,7 @@ inline Tensor & Tensor::fmod_(Scalar other) const {
 }
 inline Tensor & Tensor::fmod_(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::fmod_(const_cast<Tensor&>(*this), other);
@@ -4419,6 +4803,7 @@ inline Tensor & Tensor::fmod_(const Tensor & other) const {
 }
 inline Tensor & Tensor::remainder_(Scalar other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::remainder_(const_cast<Tensor&>(*this), other);
@@ -4434,6 +4819,7 @@ inline Tensor & Tensor::remainder_(Scalar other) const {
 }
 inline Tensor & Tensor::remainder_(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::remainder_(const_cast<Tensor&>(*this), other);
@@ -4449,6 +4835,7 @@ inline Tensor & Tensor::remainder_(const Tensor & other) const {
 }
 inline Tensor & Tensor::addbmm_(const Tensor & batch1, const Tensor & batch2, Scalar beta, Scalar alpha) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::addbmm_(const_cast<Tensor&>(*this), batch1, batch2, beta, alpha);
@@ -4464,6 +4851,7 @@ inline Tensor & Tensor::addbmm_(const Tensor & batch1, const Tensor & batch2, Sc
 }
 inline Tensor Tensor::addbmm(const Tensor & batch1, const Tensor & batch2, Scalar beta, Scalar alpha) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::addbmm(const_cast<Tensor&>(*this), batch1, batch2, beta, alpha);
@@ -4479,6 +4867,7 @@ inline Tensor Tensor::addbmm(const Tensor & batch1, const Tensor & batch2, Scala
 }
 inline Tensor & Tensor::addcdiv_(const Tensor & tensor1, const Tensor & tensor2, Scalar value) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::addcdiv_(const_cast<Tensor&>(*this), tensor1, tensor2, value);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::addcdiv_", ""}).value();
@@ -4488,6 +4877,7 @@ inline Tensor & Tensor::addcdiv_(const Tensor & tensor1, const Tensor & tensor2,
 }
 inline Tensor & Tensor::random_(int64_t from, int64_t to, Generator * generator) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::random_(const_cast<Tensor&>(*this), from, to, generator);
@@ -4503,6 +4893,7 @@ inline Tensor & Tensor::random_(int64_t from, int64_t to, Generator * generator)
 }
 inline Tensor & Tensor::random_(int64_t to, Generator * generator) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::random_(const_cast<Tensor&>(*this), to, generator);
@@ -4518,6 +4909,7 @@ inline Tensor & Tensor::random_(int64_t to, Generator * generator) const {
 }
 inline Tensor & Tensor::random_(Generator * generator) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::random_(const_cast<Tensor&>(*this), generator);
@@ -4533,6 +4925,7 @@ inline Tensor & Tensor::random_(Generator * generator) const {
 }
 inline Tensor & Tensor::uniform_(double from, double to, Generator * generator) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::uniform_(const_cast<Tensor&>(*this), from, to, generator);
@@ -4548,6 +4941,7 @@ inline Tensor & Tensor::uniform_(double from, double to, Generator * generator) 
 }
 inline Tensor & Tensor::normal_(double mean, double std, Generator * generator) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::normal_(const_cast<Tensor&>(*this), mean, std, generator);
@@ -4563,6 +4957,7 @@ inline Tensor & Tensor::normal_(double mean, double std, Generator * generator) 
 }
 inline Tensor & Tensor::cauchy_(double median, double sigma, Generator * generator) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::cauchy_(const_cast<Tensor&>(*this), median, sigma, generator);
@@ -4578,6 +4973,7 @@ inline Tensor & Tensor::cauchy_(double median, double sigma, Generator * generat
 }
 inline Tensor & Tensor::log_normal_(double mean, double std, Generator * generator) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::log_normal_(const_cast<Tensor&>(*this), mean, std, generator);
@@ -4593,6 +4989,7 @@ inline Tensor & Tensor::log_normal_(double mean, double std, Generator * generat
 }
 inline Tensor & Tensor::exponential_(double lambd, Generator * generator) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::exponential_(const_cast<Tensor&>(*this), lambd, generator);
@@ -4608,6 +5005,7 @@ inline Tensor & Tensor::exponential_(double lambd, Generator * generator) const 
 }
 inline Tensor & Tensor::geometric_(double p, Generator * generator) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::geometric_(const_cast<Tensor&>(*this), p, generator);
@@ -4623,6 +5021,7 @@ inline Tensor & Tensor::geometric_(double p, Generator * generator) const {
 }
 inline Tensor Tensor::diag(int64_t diagonal) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::diag(const_cast<Tensor&>(*this), diagonal);
@@ -4638,6 +5037,7 @@ inline Tensor Tensor::diag(int64_t diagonal) const {
 }
 inline Tensor Tensor::cross(const Tensor & other, c10::optional<int64_t> dim) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::cross(const_cast<Tensor&>(*this), other, dim);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::cross", ""}).value();
@@ -4647,6 +5047,7 @@ inline Tensor Tensor::cross(const Tensor & other, c10::optional<int64_t> dim) co
 }
 inline Tensor Tensor::triu(int64_t diagonal) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::triu(const_cast<Tensor&>(*this), diagonal);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::triu", ""}).value();
@@ -4656,6 +5057,7 @@ inline Tensor Tensor::triu(int64_t diagonal) const {
 }
 inline Tensor Tensor::tril(int64_t diagonal) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::tril(const_cast<Tensor&>(*this), diagonal);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::tril", ""}).value();
@@ -4665,6 +5067,7 @@ inline Tensor Tensor::tril(int64_t diagonal) const {
 }
 inline Tensor Tensor::trace() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::trace(const_cast<Tensor&>(*this));
@@ -4680,6 +5083,7 @@ inline Tensor Tensor::trace() const {
 }
 inline Tensor Tensor::ne(Scalar other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::ne(const_cast<Tensor&>(*this), other);
@@ -4698,6 +5102,7 @@ inline Tensor Tensor::ne(Scalar other) const {
 }
 inline Tensor Tensor::ne(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::ne(const_cast<Tensor&>(*this), other);
@@ -4716,6 +5121,7 @@ inline Tensor Tensor::ne(const Tensor & other) const {
 }
 inline Tensor Tensor::eq(Scalar other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::eq(const_cast<Tensor&>(*this), other);
@@ -4734,6 +5140,7 @@ inline Tensor Tensor::eq(Scalar other) const {
 }
 inline Tensor Tensor::eq(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::eq(const_cast<Tensor&>(*this), other);
@@ -4752,6 +5159,7 @@ inline Tensor Tensor::eq(const Tensor & other) const {
 }
 inline Tensor Tensor::ge(Scalar other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::ge(const_cast<Tensor&>(*this), other);
@@ -4770,6 +5178,7 @@ inline Tensor Tensor::ge(Scalar other) const {
 }
 inline Tensor Tensor::ge(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::ge(const_cast<Tensor&>(*this), other);
@@ -4788,6 +5197,7 @@ inline Tensor Tensor::ge(const Tensor & other) const {
 }
 inline Tensor Tensor::le(Scalar other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::le(const_cast<Tensor&>(*this), other);
@@ -4806,6 +5216,7 @@ inline Tensor Tensor::le(Scalar other) const {
 }
 inline Tensor Tensor::le(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::le(const_cast<Tensor&>(*this), other);
@@ -4824,6 +5235,7 @@ inline Tensor Tensor::le(const Tensor & other) const {
 }
 inline Tensor Tensor::gt(Scalar other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::gt(const_cast<Tensor&>(*this), other);
@@ -4842,6 +5254,7 @@ inline Tensor Tensor::gt(Scalar other) const {
 }
 inline Tensor Tensor::gt(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::gt(const_cast<Tensor&>(*this), other);
@@ -4860,6 +5273,7 @@ inline Tensor Tensor::gt(const Tensor & other) const {
 }
 inline Tensor Tensor::lt(Scalar other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::lt(const_cast<Tensor&>(*this), other);
@@ -4878,6 +5292,7 @@ inline Tensor Tensor::lt(Scalar other) const {
 }
 inline Tensor Tensor::lt(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::lt(const_cast<Tensor&>(*this), other);
@@ -4896,6 +5311,7 @@ inline Tensor Tensor::lt(const Tensor & other) const {
 }
 inline Tensor Tensor::take(const Tensor & index) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::take(const_cast<Tensor&>(*this), index);
@@ -4911,6 +5327,7 @@ inline Tensor Tensor::take(const Tensor & index) const {
 }
 inline Tensor Tensor::index_select(int64_t dim, const Tensor & index) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::index_select(const_cast<Tensor&>(*this), dim, index);
@@ -4930,6 +5347,7 @@ inline Tensor Tensor::index_select(int64_t dim, const Tensor & index) const {
 #ifdef BUILD_NAMEDTENSOR
 inline Tensor Tensor::index_select(Dimname dim, const Tensor & index) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::index_select(const_cast<Tensor&>(*this), dim, index);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::index_select.dimname(Tensor self, Dimname dim, Tensor index) -> Tensor");
@@ -4939,6 +5357,7 @@ inline Tensor Tensor::index_select(Dimname dim, const Tensor & index) const {
 #endif
 inline Tensor Tensor::masked_select(const Tensor & mask) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::masked_select(const_cast<Tensor&>(*this), mask);
@@ -4954,6 +5373,7 @@ inline Tensor Tensor::masked_select(const Tensor & mask) const {
 }
 inline Tensor Tensor::nonzero() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::nonzero(const_cast<Tensor&>(*this));
@@ -4969,6 +5389,7 @@ inline Tensor Tensor::nonzero() const {
 }
 inline std::vector<Tensor> Tensor::nonzero_numpy() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::nonzero_numpy(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::nonzero_numpy", ""}).value();
@@ -4978,6 +5399,7 @@ inline std::vector<Tensor> Tensor::nonzero_numpy() const {
 }
 inline Tensor Tensor::gather(int64_t dim, const Tensor & index, bool sparse_grad) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::gather(const_cast<Tensor&>(*this), dim, index, sparse_grad);
@@ -4994,6 +5416,7 @@ inline Tensor Tensor::gather(int64_t dim, const Tensor & index, bool sparse_grad
 #ifdef BUILD_NAMEDTENSOR
 inline Tensor Tensor::gather(Dimname dim, const Tensor & index, bool sparse_grad) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::gather(const_cast<Tensor&>(*this), dim, index, sparse_grad);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::gather.dimname(Tensor self, Dimname dim, Tensor index, *, bool sparse_grad=False) -> Tensor");
@@ -5003,6 +5426,7 @@ inline Tensor Tensor::gather(Dimname dim, const Tensor & index, bool sparse_grad
 #endif
 inline Tensor Tensor::addcmul(const Tensor & tensor1, const Tensor & tensor2, Scalar value) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::addcmul(const_cast<Tensor&>(*this), tensor1, tensor2, value);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::addcmul", ""}).value();
@@ -5012,6 +5436,7 @@ inline Tensor Tensor::addcmul(const Tensor & tensor1, const Tensor & tensor2, Sc
 }
 inline Tensor & Tensor::addcmul_(const Tensor & tensor1, const Tensor & tensor2, Scalar value) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::addcmul_(const_cast<Tensor&>(*this), tensor1, tensor2, value);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::addcmul_", ""}).value();
@@ -5021,6 +5446,7 @@ inline Tensor & Tensor::addcmul_(const Tensor & tensor1, const Tensor & tensor2,
 }
 inline Tensor Tensor::addcdiv(const Tensor & tensor1, const Tensor & tensor2, Scalar value) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::addcdiv(const_cast<Tensor&>(*this), tensor1, tensor2, value);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::addcdiv", ""}).value();
@@ -5030,6 +5456,7 @@ inline Tensor Tensor::addcdiv(const Tensor & tensor1, const Tensor & tensor2, Sc
 }
 inline std::tuple<Tensor,Tensor> Tensor::lstsq(const Tensor & A) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::lstsq(const_cast<Tensor&>(*this), A);
@@ -5045,6 +5472,7 @@ inline std::tuple<Tensor,Tensor> Tensor::lstsq(const Tensor & A) const {
 }
 inline std::tuple<Tensor,Tensor> Tensor::triangular_solve(const Tensor & A, bool upper, bool transpose, bool unitriangular) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::triangular_solve(const_cast<Tensor&>(*this), A, upper, transpose, unitriangular);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::triangular_solve", ""}).value();
@@ -5054,6 +5482,7 @@ inline std::tuple<Tensor,Tensor> Tensor::triangular_solve(const Tensor & A, bool
 }
 inline std::tuple<Tensor,Tensor> Tensor::symeig(bool eigenvectors, bool upper) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::symeig(const_cast<Tensor&>(*this), eigenvectors, upper);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::symeig", ""}).value();
@@ -5063,6 +5492,7 @@ inline std::tuple<Tensor,Tensor> Tensor::symeig(bool eigenvectors, bool upper) c
 }
 inline std::tuple<Tensor,Tensor> Tensor::eig(bool eigenvectors) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::eig(const_cast<Tensor&>(*this), eigenvectors);
@@ -5078,6 +5508,7 @@ inline std::tuple<Tensor,Tensor> Tensor::eig(bool eigenvectors) const {
 }
 inline std::tuple<Tensor,Tensor,Tensor> Tensor::svd(bool some, bool compute_uv) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::svd(const_cast<Tensor&>(*this), some, compute_uv);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::svd", ""}).value();
@@ -5087,6 +5518,7 @@ inline std::tuple<Tensor,Tensor,Tensor> Tensor::svd(bool some, bool compute_uv) 
 }
 inline Tensor Tensor::cholesky(bool upper) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::cholesky(const_cast<Tensor&>(*this), upper);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::cholesky", ""}).value();
@@ -5096,6 +5528,7 @@ inline Tensor Tensor::cholesky(bool upper) const {
 }
 inline Tensor Tensor::cholesky_solve(const Tensor & input2, bool upper) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::cholesky_solve(const_cast<Tensor&>(*this), input2, upper);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::cholesky_solve", ""}).value();
@@ -5105,6 +5538,7 @@ inline Tensor Tensor::cholesky_solve(const Tensor & input2, bool upper) const {
 }
 inline std::tuple<Tensor,Tensor> Tensor::solve(const Tensor & A) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::solve(const_cast<Tensor&>(*this), A);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::solve", ""}).value();
@@ -5114,6 +5548,7 @@ inline std::tuple<Tensor,Tensor> Tensor::solve(const Tensor & A) const {
 }
 inline Tensor Tensor::cholesky_inverse(bool upper) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::cholesky_inverse(const_cast<Tensor&>(*this), upper);
@@ -5129,6 +5564,7 @@ inline Tensor Tensor::cholesky_inverse(bool upper) const {
 }
 inline std::tuple<Tensor,Tensor> Tensor::qr(bool some) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::qr(const_cast<Tensor&>(*this), some);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::qr", ""}).value();
@@ -5138,6 +5574,7 @@ inline std::tuple<Tensor,Tensor> Tensor::qr(bool some) const {
 }
 inline std::tuple<Tensor,Tensor> Tensor::geqrf() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::geqrf(const_cast<Tensor&>(*this));
@@ -5153,6 +5590,7 @@ inline std::tuple<Tensor,Tensor> Tensor::geqrf() const {
 }
 inline Tensor Tensor::orgqr(const Tensor & input2) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::orgqr(const_cast<Tensor&>(*this), input2);
@@ -5168,6 +5606,7 @@ inline Tensor Tensor::orgqr(const Tensor & input2) const {
 }
 inline Tensor Tensor::ormqr(const Tensor & input2, const Tensor & input3, bool left, bool transpose) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::ormqr(const_cast<Tensor&>(*this), input2, input3, left, transpose);
@@ -5183,6 +5622,7 @@ inline Tensor Tensor::ormqr(const Tensor & input2, const Tensor & input3, bool l
 }
 inline Tensor Tensor::lu_solve(const Tensor & LU_data, const Tensor & LU_pivots) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::lu_solve(const_cast<Tensor&>(*this), LU_data, LU_pivots);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::lu_solve", ""}).value();
@@ -5192,6 +5632,7 @@ inline Tensor Tensor::lu_solve(const Tensor & LU_data, const Tensor & LU_pivots)
 }
 inline Tensor Tensor::multinomial(int64_t num_samples, bool replacement, Generator * generator) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::multinomial(const_cast<Tensor&>(*this), num_samples, replacement, generator);
@@ -5207,6 +5648,7 @@ inline Tensor Tensor::multinomial(int64_t num_samples, bool replacement, Generat
 }
 inline Tensor Tensor::lgamma() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::lgamma(const_cast<Tensor&>(*this));
@@ -5222,6 +5664,7 @@ inline Tensor Tensor::lgamma() const {
 }
 inline Tensor Tensor::digamma() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::digamma(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::digamma", ""}).value();
@@ -5231,6 +5674,7 @@ inline Tensor Tensor::digamma() const {
 }
 inline Tensor Tensor::polygamma(int64_t n) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::polygamma(n, const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::polygamma", ""}).value();
@@ -5240,6 +5684,7 @@ inline Tensor Tensor::polygamma(int64_t n) const {
 }
 inline Tensor Tensor::erfinv() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::erfinv(const_cast<Tensor&>(*this));
@@ -5255,6 +5700,7 @@ inline Tensor Tensor::erfinv() const {
 }
 inline Tensor & Tensor::erfinv_() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::erfinv_(const_cast<Tensor&>(*this));
@@ -5270,6 +5716,7 @@ inline Tensor & Tensor::erfinv_() const {
 }
 inline Tensor Tensor::sign() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::sign(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::sign", ""}).value();
@@ -5279,6 +5726,7 @@ inline Tensor Tensor::sign() const {
 }
 inline Tensor & Tensor::sign_() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::sign_(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::sign_", ""}).value();
@@ -5288,6 +5736,7 @@ inline Tensor & Tensor::sign_() const {
 }
 inline Tensor Tensor::dist(const Tensor & other, Scalar p) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::dist(const_cast<Tensor&>(*this), other, p);
@@ -5303,6 +5752,7 @@ inline Tensor Tensor::dist(const Tensor & other, Scalar p) const {
 }
 inline Tensor Tensor::atan2(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::atan2(const_cast<Tensor&>(*this), other);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::atan2", ""}).value();
@@ -5312,6 +5762,7 @@ inline Tensor Tensor::atan2(const Tensor & other) const {
 }
 inline Tensor Tensor::lerp(const Tensor & end, Scalar weight) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::lerp(const_cast<Tensor&>(*this), end, weight);
@@ -5327,6 +5778,7 @@ inline Tensor Tensor::lerp(const Tensor & end, Scalar weight) const {
 }
 inline Tensor Tensor::lerp(const Tensor & end, const Tensor & weight) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::lerp(const_cast<Tensor&>(*this), end, weight);
@@ -5342,6 +5794,7 @@ inline Tensor Tensor::lerp(const Tensor & end, const Tensor & weight) const {
 }
 inline Tensor Tensor::histc(int64_t bins, Scalar min, Scalar max) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::histc(const_cast<Tensor&>(*this), bins, min, max);
@@ -5357,6 +5810,7 @@ inline Tensor Tensor::histc(int64_t bins, Scalar min, Scalar max) const {
 }
 inline Tensor Tensor::fmod(Scalar other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::fmod(const_cast<Tensor&>(*this), other);
@@ -5372,6 +5826,7 @@ inline Tensor Tensor::fmod(Scalar other) const {
 }
 inline Tensor Tensor::fmod(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::fmod(const_cast<Tensor&>(*this), other);
@@ -5387,6 +5842,7 @@ inline Tensor Tensor::fmod(const Tensor & other) const {
 }
 inline Tensor Tensor::remainder(Scalar other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::remainder(const_cast<Tensor&>(*this), other);
@@ -5402,6 +5858,7 @@ inline Tensor Tensor::remainder(Scalar other) const {
 }
 inline Tensor Tensor::remainder(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::remainder(const_cast<Tensor&>(*this), other);
@@ -5417,6 +5874,7 @@ inline Tensor Tensor::remainder(const Tensor & other) const {
 }
 inline Tensor Tensor::min(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::min(const_cast<Tensor&>(*this), other);
@@ -5432,6 +5890,7 @@ inline Tensor Tensor::min(const Tensor & other) const {
 }
 inline Tensor Tensor::min() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::min(const_cast<Tensor&>(*this));
@@ -5450,6 +5909,7 @@ inline Tensor Tensor::min() const {
 }
 inline Tensor Tensor::max(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::max(const_cast<Tensor&>(*this), other);
@@ -5465,6 +5925,7 @@ inline Tensor Tensor::max(const Tensor & other) const {
 }
 inline Tensor Tensor::max() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::max(const_cast<Tensor&>(*this));
@@ -5483,6 +5944,7 @@ inline Tensor Tensor::max() const {
 }
 inline Tensor Tensor::median() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::median(const_cast<Tensor&>(*this));
@@ -5498,6 +5960,7 @@ inline Tensor Tensor::median() const {
 }
 inline std::tuple<Tensor,Tensor> Tensor::sort(int64_t dim, bool descending) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::sort(const_cast<Tensor&>(*this), dim, descending);
@@ -5517,6 +5980,7 @@ inline std::tuple<Tensor,Tensor> Tensor::sort(int64_t dim, bool descending) cons
 #ifdef BUILD_NAMEDTENSOR
 inline std::tuple<Tensor,Tensor> Tensor::sort(Dimname dim, bool descending) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::sort(const_cast<Tensor&>(*this), dim, descending);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::sort.dimname(Tensor self, Dimname dim, bool descending=False) -> (Tensor values, Tensor indices)");
@@ -5526,6 +5990,7 @@ inline std::tuple<Tensor,Tensor> Tensor::sort(Dimname dim, bool descending) cons
 #endif
 inline Tensor Tensor::argsort(int64_t dim, bool descending) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::argsort(const_cast<Tensor&>(*this), dim, descending);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::argsort", ""}).value();
@@ -5536,6 +6001,7 @@ inline Tensor Tensor::argsort(int64_t dim, bool descending) const {
 #ifdef BUILD_NAMEDTENSOR
 inline Tensor Tensor::argsort(Dimname dim, bool descending) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::argsort(const_cast<Tensor&>(*this), dim, descending);
 #else
     static auto table = globalATenDispatch().getOpTable("aten::argsort.dimname(Tensor self, Dimname dim, bool descending=False) -> Tensor");
@@ -5545,6 +6011,7 @@ inline Tensor Tensor::argsort(Dimname dim, bool descending) const {
 #endif
 inline std::tuple<Tensor,Tensor> Tensor::topk(int64_t k, int64_t dim, bool largest, bool sorted) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::topk(const_cast<Tensor&>(*this), k, dim, largest, sorted);
@@ -5563,6 +6030,7 @@ inline std::tuple<Tensor,Tensor> Tensor::topk(int64_t k, int64_t dim, bool large
 }
 inline Tensor Tensor::all() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::all(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::all", ""}).value();
@@ -5572,6 +6040,7 @@ inline Tensor Tensor::all() const {
 }
 inline Tensor Tensor::any() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::any(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::any", ""}).value();
@@ -5581,6 +6050,7 @@ inline Tensor Tensor::any() const {
 }
 inline Tensor Tensor::renorm(Scalar p, int64_t dim, Scalar maxnorm) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::renorm(const_cast<Tensor&>(*this), p, dim, maxnorm);
@@ -5596,6 +6066,7 @@ inline Tensor Tensor::renorm(Scalar p, int64_t dim, Scalar maxnorm) const {
 }
 inline Tensor Tensor::unfold(int64_t dimension, int64_t size, int64_t step) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::unfold(const_cast<Tensor&>(*this), dimension, size, step);
@@ -5611,6 +6082,7 @@ inline Tensor Tensor::unfold(int64_t dimension, int64_t size, int64_t step) cons
 }
 inline bool Tensor::equal(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::equal(const_cast<Tensor&>(*this), other);
@@ -5629,6 +6101,7 @@ inline bool Tensor::equal(const Tensor & other) const {
 }
 inline Tensor Tensor::pow(const Tensor & exponent) const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::pow(const_cast<Tensor&>(*this), exponent);
@@ -5644,6 +6117,7 @@ inline Tensor Tensor::pow(const Tensor & exponent) const {
 }
 inline Tensor Tensor::alias() const {
 #ifdef USE_STATIC_DISPATCH
+    at::AutoNonVariableTypeMode _var_guard(true);
     return TypeDefault::alias(const_cast<Tensor&>(*this));
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::alias", ""}).value();

--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -239,10 +239,17 @@ static inline ${return_type} ${api_name}(${formals}) {
 
 # In order to rely on the linker to strip unused ops, it requires us to dispatch statically
 # in Functions.h and TensorMethods.h.
+#
+# NB: The default body also needs to apply a variable guard, as in some
+# situations what we think is a default body actually does have an
+# explicit derivative, and thereby would have gotten unwrapped by
+# the time you get to the implementation.
 STATIC_DISPATCH_FUNCTION_DEFAULT_BODY = CodeTemplate("""\
+at::AutoNonVariableTypeMode _var_guard(true);
 ${return_call} TypeDefault::${native_type_method_dispatch}(${native_arguments});
 """)
 STATIC_DISPATCH_FUNCTION_SWITCH_BODY = CodeTemplate("""\
+at::AutoNonVariableTypeMode _var_guard(true);
 switch(tensorTypeIdToBackend(impl::dispatchTypeId(${type_set}))) {
     ${static_dispatch_function_switches}
     default:

--- a/aten/src/ATen/templates/TensorMethods.h
+++ b/aten/src/ATen/templates/TensorMethods.h
@@ -11,6 +11,7 @@
 #include <ATen/core/dispatch/Dispatcher.h>
 #include <ATen/core/NamedTensor.h>
 #include <ATen/core/EnableNamedTensor.h>
+#include <ATen/core/LegacyTypeDispatch.h>
 
 #ifdef USE_STATIC_DISPATCH
 #include <ATen/TypeDefault.h>


### PR DESCRIPTION
…26908)

Summary:
Pull Request resolved: https://github.com/pytorch/pytorch/pull/26908

This is because in static dispatch, variable is not supported.  But
you might still "have" a variable somehow (e.g., in JIT initialization
code), so we need to translate between the two worlds.

Attempt to fix #26764

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Test Plan: Imported from OSS

Differential Revision: D17607550

Pulled By: ezyang

fbshipit-source-id: ea2cb931215d749efd95259ad7a1a8ae96c38aed

