### PR TITLE
ProcessGroupNCCL should respect timeout passed in to init_process_group.

### DIFF
--- a/test/test_c10d.py
+++ b/test/test_c10d.py
@@ -3109,15 +3109,13 @@ class CommTest(MultiProcessTestCase):
         c10d.distributed_c10d.init_process_group(
             backend=dist.Backend.NCCL, store=store, world_size=2, rank=self.rank,
             timeout=timedelta(seconds=timeout))
-        pg = c10d.distributed_c10d._get_default_group()
-        pg.allreduce(torch.rand(10).cuda(self.rank)).wait()
+        c10d.distributed_c10d.all_reduce(torch.rand(10).cuda(self.rank))
 
         if self.rank == 0:
             # This should timeout in about 1 second.
             start = time.time()
-            work = pg.allreduce(torch.rand(10).cuda(self.rank))
             with self.assertRaises(RuntimeError):
-                work.wait()
+                c10d.distributed_c10d.all_reduce(torch.rand(10).cuda(self.rank))
 
             total_time = time.time() - start
 

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -129,7 +129,8 @@ _default_pg = None
 _default_pg_init_method = None
 
 # Default process group wide timeout, if applicable.
-# This currently only applies to the gloo backend. To make an attempt at
+# This currently only to the gloo backend and nccl backend
+# (only if NCCL_BLOCKING_WAIT is set to 1). To make an attempt at
 # backwards compatibility with THD, we use an extraordinarily high default
 # timeout, given that THD did not have timeouts.
 _default_pg_timeout = timedelta(minutes=30)
@@ -348,7 +349,7 @@ def init_process_group(backend,
             the process group. Default value equals 30 minutes.
             This is applicable for the ``gloo`` backend. For ``nccl``, this is
             applicable only if the environment variable NCCL_BLOCKING_WAIT is
-            set to 1
+            set to 1.
         group_name (str, optional, deprecated): Group name.
 
     To enable ``backend == Backend.MPI``, PyTorch needs to built from source

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -346,7 +346,9 @@ def init_process_group(backend,
                                 Mutually exclusive with ``init_method``.
         timeout (timedelta, optional): Timeout for operations executed against
             the process group. Default value equals 30 minutes.
-            This is only applicable for the ``gloo`` backend.
+            This is applicable for the ``gloo`` backend. For ``nccl``, this is
+            applicable only if the environment variable NCCL_BLOCKING_WAIT is
+            set to 1
         group_name (str, optional, deprecated): Group name.
 
     To enable ``backend == Backend.MPI``, PyTorch needs to built from source
@@ -485,7 +487,8 @@ def _new_process_group_helper(world_size,
             pg = ProcessGroupNCCL(
                 prefix_store,
                 rank,
-                world_size)
+                world_size,
+                timeout)
             _pg_map[pg] = (Backend.NCCL, store)
             _pg_names[pg] = group_name
         else:

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -129,7 +129,7 @@ _default_pg = None
 _default_pg_init_method = None
 
 # Default process group wide timeout, if applicable.
-# This currently only to the gloo backend and nccl backend
+# This only applies to the gloo and nccl backends
 # (only if NCCL_BLOCKING_WAIT is set to 1). To make an attempt at
 # backwards compatibility with THD, we use an extraordinarily high default
 # timeout, given that THD did not have timeouts.
@@ -348,8 +348,8 @@ def init_process_group(backend,
         timeout (timedelta, optional): Timeout for operations executed against
             the process group. Default value equals 30 minutes.
             This is applicable for the ``gloo`` backend. For ``nccl``, this is
-            applicable only if the environment variable NCCL_BLOCKING_WAIT is
-            set to 1.
+            applicable only if the environment variable ``NCCL_BLOCKING_WAIT``
+            is set to 1.
         group_name (str, optional, deprecated): Group name.
 
     To enable ``backend == Backend.MPI``, PyTorch needs to built from source


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#27224 ProcessGroupNCCL should respect timeout passed in to init_process_group.**

As part of adding error handling to NCCL, we are now able to specify a
timeout for operations using ProcessGroupNCCL. Although, this timeout had a
default of 10 seconds and didn't respect the timeout specified in
init_process_group.

In this change, I've ensured we pass the appropriate timeout to
ProcessGroupNCCL.

Differential Revision: [D17717992](https://our.internmc.facebook.com/intern/diff/D17717992/)