### PR TITLE
Fixes PackedSequence.to (and unifies PackedSequence conversions)

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -187,6 +187,7 @@ class PackedSequenceTest(TestCase):
                 padded, lengths, enforce_sorted=enforce_sorted).cpu()
 
             self.assertIs(a, a.to('cpu'))
+            self.assertIs(a, a.cpu())
             self.assertIs(a, a.to('cpu', dtype=torch.int32))
             self.assertEqual(a.long(), a.to(torch.int64))
 
@@ -194,6 +195,7 @@ class PackedSequenceTest(TestCase):
                 for cuda in ['cuda', 'cuda:0' if torch.cuda.device_count() == 1 else 'cuda:1']:
                     b = a.cuda(device=cuda)
                     self.assertIs(b, b.to(cuda))
+                    self.assertIs(b, b.cuda())
                     self.assertEqual(a, b.to('cpu'))
                     self.assertEqual(b, a.to(cuda))
                     self.assertEqual(a, b.to('cpu', dtype=torch.int32))

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -8987,7 +8987,7 @@ class TestNNDeviceType(NNTestCase):
             packed = rnn_utils.pack_padded_sequence(
                 padded, lengths, enforce_sorted=enforce_sorted)
             self.assertFalse(packed.is_cuda)
-            packed = packed.to(device=device)
+            packed = packed.to(device)
             self.assertTrue(packed.is_cuda)
             unpacked, _ = rnn_utils.pad_packed_sequence(packed)
             self.assertEqual(unpacked.type(), cuda_type_str)

--- a/torch/nn/utils/rnn.py
+++ b/torch/nn/utils/rnn.py
@@ -103,31 +103,31 @@ class PackedSequence(PackedSequence_):
         return self.to(*args, device='cuda', **kwargs)
 
     def cpu(self, *args, **kwargs):
-        return self.to(*args, device='cuda', **kwargs)
+        return self.to(*args, device='cpu', **kwargs)
 
     def double(self):
-        return self.to(*args, dtype=torch.double, **kwargs)
+        return self.to(dtype=torch.double)
 
     def float(self):
-        return self.to(*args, dtype=torch.float, **kwargs)
+        return self.to(dtype=torch.float)
 
     def half(self):
-        return self.to(*args, dtype=torch.half, **kwargs)
+        return self.to(dtype=torch.half)
 
     def long(self):
-        return self.to(*args, dtype=torch.long, **kwargs)
+        return self.to(dtype=torch.long)
 
     def int(self):
-        return self.to(*args, dtype=torch.int, **kwargs)
+        return self.to(dtype=torch.int)
 
     def short(self):
-        return self.to(*args, dtype=torch.short, **kwargs)
+        return self.to(dtype=torch.short)
 
     def char(self):
-        return self.to(*args, dtype=torch.int8, **kwargs)
+        return self.to(dtype=torch.int8)
 
     def byte(self):
-        return self.to(*args, dtype=torch.uint8, **kwargs)
+        return self.to(dtype=torch.uint8)
 
     def to(self, *args, **kwargs):
         r"""Performs dtype and/or device conversion on `self.data`.

--- a/torch/nn/utils/rnn.py
+++ b/torch/nn/utils/rnn.py
@@ -156,7 +156,7 @@ class PackedSequence(PackedSequence_):
             return self
         else:
             # Only forwards device arg/kwarg and non_blocking and copy kwargs
-            kwargs = {k : v for k, v in filter(lambda t: t[0] == 'non_blocking' or t[0] == 'copy', d.iteritems())}
+            kwargs = {k : v for k, v in filter(lambda t: t[0] == 'non_blocking' or t[0] == 'copy', kwargs.iteritems())}
             sorted_indices = bind(self.sorted_indices, lambda t: t.to(data.device, **kwargs))
             unsorted_indices = bind(self.unsorted_indices, lambda t: t.to(data.device, **kwargs))
             return type(self)(data, self.batch_sizes, sorted_indices, unsorted_indices)

--- a/torch/nn/utils/rnn.py
+++ b/torch/nn/utils/rnn.py
@@ -150,7 +150,7 @@ class PackedSequence(PackedSequence_):
             # Indices are always long tensors, so don't forward requests
             # to change the dtype
             args = [arg for arg in args if not isinstance(arg, torch.dtype)]
-            del kwargs['dtype']
+            kwargs.pop('dtype', None)
 
             sorted_indices = bind(self.sorted_indices, lambda t: t.to(*args, **kwargs))
             unsorted_indices = bind(self.unsorted_indices, lambda t: t.to(*args, **kwargs))

--- a/torch/nn/utils/rnn.py
+++ b/torch/nn/utils/rnn.py
@@ -100,90 +100,34 @@ class PackedSequence(PackedSequence_):
                           bind(self.unsorted_indices, lambda t: t.pin_memory()))
 
     def cuda(self, *args, **kwargs):
-        """Returns a GPU copy if `self.data` not already on the GPU"""
-        if self.is_cuda:
-            return self
-        else:
-            # Why not convert `batch_sizes`?
-            # See NOTE [ device and dtype of a PackedSequence ]
-            return type(self)(self.data.cuda(*args, **kwargs), self.batch_sizes,
-                              bind(self.sorted_indices, lambda t: t.cuda(*args, **kwargs)),
-                              bind(self.unsorted_indices, lambda t: t.cuda(*args, **kwargs)))
+        return self.to(*args, device='cuda', **kwargs)
 
-    def cpu(self):
-        """Returns a CPU copy if `self.data` not already on the CPU"""
-        if self.is_cuda:
-            # Why not convert `batch_sizes`?
-            # See NOTE [ device and dtype of a PackedSequence ]
-            return type(self)(self.data.cpu(), self.batch_sizes,
-                              bind(self.sorted_indices, lambda t: t.cpu()),
-                              bind(self.unsorted_indices, lambda t: t.cpu()))
-        else:
-            return self
+    def cpu(self, *args, **kwargs):
+        return self.to(*args, device='cuda', **kwargs)
 
     def double(self):
-        r"""Returns copy with `self.data` cast to double type"""
-
-        # Why not convert `batch_sizes`?
-        # See NOTE [ device and dtype of a PackedSequence ]
-        return type(self)(self.data.double(), self.batch_sizes,
-                          self.sorted_indices, self.unsorted_indices)
+        return self.to(*args, dtype=torch.double, **kwargs)
 
     def float(self):
-        r"""Returns copy with `self.data` cast to float type"""
-
-        # Why not convert `batch_sizes`?
-        # See NOTE [ device and dtype of a PackedSequence ]
-        return type(self)(self.data.float(), self.batch_sizes,
-                          self.sorted_indices, self.unsorted_indices)
+        return self.to(*args, dtype=torch.float, **kwargs)
 
     def half(self):
-        r"""Returns copy with `self.data` cast to half type"""
-
-        # Why not convert `batch_sizes`?
-        # See NOTE [ device and dtype of a PackedSequence ]
-        return type(self)(self.data.half(), self.batch_sizes,
-                          self.sorted_indices, self.unsorted_indices)
+        return self.to(*args, dtype=torch.half, **kwargs)
 
     def long(self):
-        r"""Returns copy with `self.data` cast to long type"""
-
-        # Why not convert `batch_sizes`?
-        # See NOTE [ device and dtype of a PackedSequence ]
-        return type(self)(self.data.long(), self.batch_sizes,
-                          self.sorted_indices, self.unsorted_indices)
+        return self.to(*args, dtype=torch.long, **kwargs)
 
     def int(self):
-        r"""Returns copy with `self.data` cast to int type"""
-
-        # Why not convert `batch_sizes`?
-        # See NOTE [ device and dtype of a PackedSequence ]
-        return type(self)(self.data.int(), self.batch_sizes,
-                          self.sorted_indices, self.unsorted_indices)
+        return self.to(*args, dtype=torch.int, **kwargs)
 
     def short(self):
-        r"""Returns copy with `self.data` cast to short type"""
-
-        # Why not convert `batch_sizes`?
-        # See NOTE [ device and dtype of a PackedSequence ]
-        return type(self)(self.data.short(), self.batch_sizes,
-                          self.sorted_indices, self.unsorted_indices)
+        return self.to(*args, dtype=torch.short, **kwargs)
 
     def char(self):
-        r"""Returns copy with `self.data` cast to char type"""
-
-        # Why not convert `batch_sizes`?
-        # See NOTE [ device and dtype of a PackedSequence ]
-        return type(self)(self.data.char(), self.batch_sizes,
-                          self.sorted_indices, self.unsorted_indices)
+        return self.to(*args, dtype=torch.int8, **kwargs)
 
     def byte(self):
-        r"""Returns copy with `self.data` cast to byte type"""
-
-        # Why not convert `batch_sizes`?
-        # See NOTE [ device and dtype of a PackedSequence ]
-        return type(self)(self.data.byte(), self.batch_sizes,
-                          self.sorted_indices, self.unsorted_indices)
+        return self.to(*args, dtype=torch.uint8, **kwargs)
 
     def to(self, *args, **kwargs):
         r"""Performs dtype and/or device conversion on `self.data`.

--- a/torch/nn/utils/rnn.py
+++ b/torch/nn/utils/rnn.py
@@ -200,17 +200,13 @@ class PackedSequence(PackedSequence_):
         # Why not convert `batch_sizes`?
         # See NOTE [ device and dtype of a PackedSequence ]
         data = self.data.to(*args, **kwargs)
-        sorted_indices = self.sorted_indices
-        unsorted_indices = self.unsorted_indices
-        device_kw = 'device'
-        if device_kw in kwargs:
-            sorted_indices = bind(sorted_indices, lambda t: t.to(kwargs[device_kw]))
-            unsorted_indices = bind(unsorted_indices, lambda t: t.to(kwargs[device_kw]))
+        sorted_indices = bind(self.sorted_indices, lambda t: t.to(*args, **kwargs))
+        unsorted_indices = bind(self.unsorted_indices, lambda t: t.to(*args, **kwargs))
+
         if data is self.data:
             return self
         else:
-            return type(self)(data, self.batch_sizes,
-                              sorted_indices, unsorted_indices)
+            return type(self)(data, self.batch_sizes, sorted_indices, unsorted_indices)
 
     @property
     def is_cuda(self):

--- a/torch/nn/utils/rnn.py
+++ b/torch/nn/utils/rnn.py
@@ -101,15 +101,15 @@ class PackedSequence(PackedSequence_):
 
     def cuda(self, *args, **kwargs):
         # Adds device 'cuda' to kwargs if needed
-        ex = torch.FloatTensor().to(*args, **kwargs)
+        ex = torch.tensor((), dtype=self.data.dtype, device=self.data.device).to(*args, **kwargs)
         if ex.is_cuda:
             return self.to(*args, **kwargs)
         return self.to(*args, device='cuda', **kwargs)
 
     def cpu(self, *args, **kwargs):
         # Adds device 'cpu' to kwargs if needed
-        ex = torch.FloatTensor().to(*args, **kwargs)
-        if ex.is_cpu:
+        ex = torch.tensor((), dtype=self.data.dtype, device=self.data.device).to(*args, **kwargs)
+        if ex.device == 'cpu':
             return self.to(*args, **kwargs)
         return self.to(*args, device='cpu', **kwargs)
 
@@ -156,7 +156,7 @@ class PackedSequence(PackedSequence_):
             return self
         else:
             # Only forwards device arg/kwarg and non_blocking and copy kwargs
-            kwargs = {k : v for k, v in filter(lambda t: t[0] == 'non_blocking' or t[0] == 'copy', kwargs.iteritems())}
+            kwargs = {k : v for k, v in filter(lambda t: t[0] == 'non_blocking' or t[0] == 'copy', kwargs.items())}
             sorted_indices = bind(self.sorted_indices, lambda t: t.to(data.device, **kwargs))
             unsorted_indices = bind(self.unsorted_indices, lambda t: t.to(data.device, **kwargs))
             return type(self)(data, self.batch_sizes, sorted_indices, unsorted_indices)


### PR DESCRIPTION
PackedSequence.to(device) incorrectly places one of three tensors on the device and leaves the other two tensors where they are. If these devices are distinct then further operations on PackedSequence will fail. This behavior is inconsistent with Tensor.to and PackedSequence's behavior when .cuda() is called.

Additionally, PackedSequence defines multiple other conversion functions that were independently and inconsistently implemented.

This PR unifies all implementations and makes the PackedSequence.to behavior more consistent with Tensor.to. It is not completely consistent per comments. test_device_mask in test_nn.py is updated to validate the new functionality.

