### PR TITLE
Regenerate aten_op.h when native_functions.yaml changes.

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -21,6 +21,7 @@ if (INTERN_BUILD_ATEN_OPS)
     --install_dir=${CMAKE_CURRENT_BINARY_DIR}/contrib/aten
   DEPENDS
   ATEN_CPU_FILES_GEN_TARGET
+  ${CMAKE_BINARY_DIR}/aten/src/ATen/Declarations.yaml
   ${CMAKE_CURRENT_SOURCE_DIR}/contrib/aten/gen_op.py
   ${CMAKE_CURRENT_SOURCE_DIR}/contrib/aten/aten_op_template.h)
 


### PR DESCRIPTION
Fixes #10127.

This ensures that aten_op.h is regenerated whenever a new native kernel
is removed. Previously it was only being regenerated when new native
kernels were added because this generated new source files, which this
cmake target depended on. However if a native kernel is removed then
there is no dependent target and the header is never regenerated.

Explicitly depending on native_functions.yaml ensures that the header
is regenerated even if a kernel is removed.

I'm no cmake expert so alternative approaches or reasons why this is 
obviously incorrect are very appreciated!

EDIT: reflecting comments below we now depend on `Dependencies.yaml` instead of `native_functions.yaml`.