### PR TITLE
C++ API parity: TensorTest.BackwardNonScalarOutputs

### DIFF
--- a/test/cpp/api/tensor.cpp
+++ b/test/cpp/api/tensor.cpp
@@ -474,6 +474,13 @@ TEST(TensorTest, BackwardCreatesOnesGrad) {
               torch::ones_like(x)));
 }
 
+TEST(TensorTest, GradCanBeImplicitlyCreatedOnlyForScalarOutputs) {
+  auto x = torch::randn({5, 5}, torch::requires_grad());
+  auto y = x * x;
+  ASSERT_THROWS_WITH(y.backward(),
+    "grad can be implicitly created only for scalar outputs");
+}
+
 TEST(TensorTest, IsLeaf) {
   auto x = torch::tensor({5}, at::TensorOptions().requires_grad(true));
   auto y = x * x;

--- a/test/cpp/api/tensor.cpp
+++ b/test/cpp/api/tensor.cpp
@@ -474,7 +474,7 @@ TEST(TensorTest, BackwardCreatesOnesGrad) {
               torch::ones_like(x)));
 }
 
-TEST(TensorTest, GradCanBeImplicitlyCreatedOnlyForScalarOutputs) {
+TEST(TensorTest, BackwardNonScalarOutputs) {
   auto x = torch::randn({5, 5}, torch::requires_grad());
   auto y = x * x;
   ASSERT_THROWS_WITH(y.backward(),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #26568 C++ API parity: at::Tensor::register_hook
* #26332 C++ API parity: at::Tensor::requires_grad_
* **#27314 C++ API parity: TensorTest.BackwardNonScalarOutputs**

Differential Revision: [D17746371](https://our.internmc.facebook.com/intern/diff/D17746371)