### PR TITLE
Do not call cpuinfo_initialize() on other than x86 arch. (#26265)

### DIFF
--- a/aten/src/ATen/native/DispatchStub.cpp
+++ b/aten/src/ATen/native/DispatchStub.cpp
@@ -23,7 +23,7 @@ static CPUCapability compute_cpu_capability() {
     AT_WARN("ignoring invalid value for ATEN_CPU_CAPABILITY: ", envar);
   }
 
-#ifndef __powerpc__
+#if !defined(__powerpc__) && !defined(__s390x__)
   if (cpuinfo_initialize()) {
     if (cpuinfo_has_x86_avx2() && cpuinfo_has_x86_fma3()) {
       return CPUCapability::AVX2;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

Summary:
cpuinfo_initialize() was not implemented for s390 arch.
cpuinfo calls are x86 specific to determine vector extensions AVX, AVX512 etc.
Without this patch an unnecessary error log is printed in s390 arch:
Error in cpuinfo: processor architecture is not supported in cpuinfo

Differential Revision: D17452301

Pulled By: izdeby

fbshipit-source-id: 9ca485550385c26dec18aac5953c887f1ffbfb7a