### PR TITLE
[tensorboard] Add method add_hparams to API doc

### DIFF
--- a/docs/source/tensorboard.rst
+++ b/docs/source/tensorboard.rst
@@ -91,5 +91,6 @@ Expected result:
    .. automethod:: add_pr_curve
    .. automethod:: add_custom_scalars
    .. automethod:: add_mesh
+   .. automethod:: add_hparams
    .. automethod:: flush
    .. automethod:: close


### PR DESCRIPTION
Adds the method `add_hparams` to `torch.utils.tensorboard` API docs. Will want to have this in PyTorch 1.3 release.

cc @sanekmelnikov @lanpa @natalialunova