### PR TITLE
[tensorboard] Add method add_hparams to API doc

### DIFF
--- a/docs/source/tensorboard.rst
+++ b/docs/source/tensorboard.rst
@@ -91,5 +91,6 @@ Expected result:
    .. automethod:: add_pr_curve
    .. automethod:: add_custom_scalars
    .. automethod:: add_mesh
+   .. automethod:: add_hparams
    .. automethod:: flush
    .. automethod:: close


### PR DESCRIPTION
Adds the method `add_hparams` to `torch.utils.tensorboard` API docs for the PyTorch 1.3 release.

Picked version of https://github.com/pytorch/pytorch/pull/27344 for v1.3.0

cc @sanekmelnikov @lanpa @natalialunova @soumith @gchanan