### PR TITLE
Change keyword 'not' (unsupported in windows build) to '!'

### DIFF
--- a/aten/src/ATen/native/cpu/IsContiguous.h
+++ b/aten/src/ATen/native/cpu/IsContiguous.h
@@ -38,7 +38,7 @@ static inline bool is_contiguous(const int64_t* strides) {
 }
 
 template <typename traits,
-    typename std::enable_if<not std::is_void<typename traits::result_type>::value>::type* = nullptr>
+    typename std::enable_if<!std::is_void<typename traits::result_type>::value>::type* = nullptr>
 static inline bool is_contiguous(const int64_t* strides) {
   return IsContiguous<traits::arity, traits::arity, traits>::eval(strides);
 }
@@ -53,7 +53,7 @@ static inline bool is_contiguous_scalar(const int64_t* strides) {
 }
 
 template <typename traits, int s,
-    typename std::enable_if<not std::is_void<typename traits::result_type>::value>::type* = nullptr>
+    typename std::enable_if<!std::is_void<typename traits::result_type>::value>::type* = nullptr>
 static inline bool is_contiguous_scalar(const int64_t* strides) {
   static_assert(s > 0 && s <= traits::arity, "scalar argument index out of bounds");
   return IsContiguous<traits::arity, traits::arity, traits, s>::eval(strides);

--- a/aten/src/ATen/native/cpu/Loops.h
+++ b/aten/src/ATen/native/cpu/Loops.h
@@ -81,7 +81,7 @@ dereference_vec(char* C10_RESTRICT data[], const typename traits::result_type& o
 }
 
 template <typename func_t,
-    typename std::enable_if<not std::is_void<typename function_traits<func_t>::result_type>::value>::type* = nullptr>
+    typename std::enable_if<!std::is_void<typename function_traits<func_t>::result_type>::value>::type* = nullptr>
 static inline void
 execute_op(char* C10_RESTRICT data[], const int64_t* strides, int64_t i, int64_t n, func_t op) {
   using traits = function_traits<func_t>;


### PR DESCRIPTION
https://ci.pytorch.org/jenkins/job/caffe2-builds/job/py2-cuda9.0-cudnn7-windows-build/71076//console

```
00:25:49 C:\Jenkins\workspace\caffe2-builds\py2-cuda9.0-cudnn7-windows-build\aten\src\ATen/native/cpu/IsContiguous.h(41): error C2065: 'not': undeclared identifier
00:25:49 C:\Jenkins\workspace\caffe2-builds\py2-cuda9.0-cudnn7-windows-build\aten\src\ATen/native/cpu/IsContiguous.h(41): error C2059: syntax error: 'std::is_void<traits::result_type>::value'
00:25:49 C:\Jenkins\workspace\caffe2-builds\py2-cuda9.0-cudnn7-windows-build\aten\src\ATen/native/cpu/IsContiguous.h(41): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int
```

