### PR TITLE
[android] Change nightly builds version to 1.4.0-SNAPSHOT

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,6 +1,6 @@
 ABI_FILTERS=armeabi-v7a,arm64-v8a,x86,x86_64
 
-VERSION_NAME=0.0.7-SNAPSHOT
+VERSION_NAME=1.4.0-SNAPSHOT
 GROUP=org.pytorch
 MAVEN_GROUP=org.pytorch
 POM_URL=https://github.com/pytorch/pytorch/tree/master/android


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#27381 [android] Change nightly builds version to 1.4.0-SNAPSHOT**

Changing android nightly builds from master to version 1.4.0-SNAPSHOT, as we also have 1.3.0-SNAPSHOT from the branch v1.3.0

Differential Revision: [D17773620](https://our.internmc.facebook.com/intern/diff/D17773620)