### PR TITLE
[jit] Fix some return std::move warnings

### DIFF
--- a/torch/csrc/jit/import.cpp
+++ b/torch/csrc/jit/import.cpp
@@ -131,7 +131,7 @@ IValue ScriptModuleDeserializer::readArchive(const std::string& archive_name) {
       (*type.type_->getMethod("__setstate__"))({obj, input});
       setGraphExecutorOptimize(true);
       postSetStateValidate(obj);
-      return std::move(obj);
+      return obj;
     } else {
       auto dict = std::move(input).toGenericDict();
       auto obj = c10::ivalue::Object::create(type, n);

--- a/torch/csrc/jit/passes/bailout_graph.cpp
+++ b/torch/csrc/jit/passes/bailout_graph.cpp
@@ -23,7 +23,7 @@ static std::unordered_set<Value *> collectLoopCounts(Node *n) {
     it = outerNode->owningBlock();
   }
 
-  return std::move(loopCounts);
+  return loopCounts;
 }
 
 struct BailOutGraphBuilderForNode {


### PR DESCRIPTION


clang-tidy was complaining about these

Differential Revision: [D17767412](https://our.internmc.facebook.com/intern/diff/17767412/)