### PR TITLE
Add a missing document of conv_tbc

### DIFF
--- a/docs/source/nn.functional.rst
+++ b/docs/source/nn.functional.rst
@@ -39,6 +39,11 @@ Convolution functions
 
 .. autofunction:: conv_transpose3d
 
+:hidden:`conv_tbc`
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autofunction:: conv_tbc
+
 :hidden:`unfold`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Hi,

The `conv_tbc`  is an important function for language processing, but the document is missing. I just added it to the document.
B.t.w. I am a newbie here and please feel free to close this pull request, if this is not proper. :)