### PR TITLE
MovingAverage Observer

### DIFF
--- a/test/test_quantization.py
+++ b/test/test_quantization.py
@@ -10,7 +10,9 @@ from torch.quantization import \
     QConfig, QConfigDynamic, default_observer, default_weight_observer, get_observer_dict,\
     quantize, prepare, convert, prepare_qat, quantize_qat, fuse_modules, \
     quantize_dynamic, default_qconfig, default_debug_qconfig, default_qat_qconfig, \
-    default_dynamic_qconfig, HistogramObserver, MinMaxObserver, PerChannelMinMaxObserver, RecordingObserver, QuantWrapper
+    default_dynamic_qconfig, HistogramObserver, MinMaxObserver, PerChannelMinMaxObserver,\
+    RecordingObserver, MovingAverageMinMaxObserver, MovingAveragePerChannelMinMaxObserver, \
+    QuantWrapper
 
 from torch.quantization._quantize_script import quantize_script
 
@@ -932,144 +934,173 @@ class ObserverTest(QuantizationTestCase):
     @given(qdtype=st.sampled_from((torch.qint8, torch.quint8)),
            qscheme=st.sampled_from((torch.per_tensor_affine, torch.per_tensor_symmetric)),
            reduce_range=st.booleans())
-    def test_minmax_observer(self, qdtype, qscheme, reduce_range):
+    def test_per_tensor_observers(self, qdtype, qscheme, reduce_range):
         # reduce_range cannot be true for symmetric quantization with uint8
         if qdtype == torch.quint8 and qscheme == torch.per_tensor_symmetric:
             reduce_range = False
-        myobs = MinMaxObserver(dtype=qdtype, qscheme=qscheme, reduce_range=reduce_range)
-        # Calculate Qparams should return with a warning for observers with no data
-        qparams = myobs.calculate_qparams()
-        x = torch.tensor([1.0, 2.0, 2.0, 3.0, 4.0, 5.0, 6.0])
-        y = torch.tensor([4.0, 5.0, 5.0, 6.0, 7.0, 8.0])
-        result = myobs(x)
-        result = myobs(y)
-        self.assertEqual(result, y)
-        self.assertEqual(myobs.min_val, 1.0)
-        self.assertEqual(myobs.max_val, 8.0)
-        qparams = myobs.calculate_qparams()
-        if reduce_range:
-            if qscheme == torch.per_tensor_symmetric:
-                ref_scale = 0.062745 * 255 / 127
-                ref_zero_point = 0 if qdtype is torch.qint8 else 128
+        ObserverList = [MinMaxObserver(dtype=qdtype, qscheme=qscheme, reduce_range=reduce_range),
+                        MovingAverageMinMaxObserver(averaging_constant=0.5,
+                                                    dtype=qdtype,
+                                                    qscheme=qscheme,
+                                                    reduce_range=reduce_range)]
+        for myobs in ObserverList:
+            # Calculate Qparams should return with a warning for observers with no data
+            qparams = myobs.calculate_qparams()
+            if type(myobs) == MinMaxObserver:
+                x = torch.tensor([1.0, 2.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+                y = torch.tensor([4.0, 5.0, 5.0, 6.0, 7.0, 8.0])
             else:
-                ref_scale = 0.0313725 * 255 / 127
-                ref_zero_point = -64 if qdtype is torch.qint8 else 0
-        else:
-            if qscheme == torch.per_tensor_symmetric:
-                ref_scale = 0.062745
-                ref_zero_point = 0 if qdtype is torch.qint8 else 128
-            else:
-                ref_scale = 0.0313725
-                ref_zero_point = -128 if qdtype is torch.qint8 else 0
-        self.assertEqual(qparams[1].item(), ref_zero_point)
-        self.assertAlmostEqual(qparams[0].item(), ref_scale, delta=1e-5)
+                # Moving average of min/max for x and y matches that of
+                # extreme values for x/y used for minmax observer
+                x = torch.tensor([0.0, 2.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+                y = torch.tensor([2.0, 5.0, 5.0, 6.0, 7.0, 10.0])
 
-        # Test for serializability
-        state_dict = myobs.state_dict()
-        b = io.BytesIO()
-        torch.save(state_dict, b)
-        b.seek(0)
-        loaded_dict = torch.load(b)
-        for key in state_dict:
-            self.assertEqual(state_dict[key], loaded_dict[key])
-        loaded_obs = MinMaxObserver(dtype=qdtype, qscheme=qscheme, reduce_range=reduce_range)
-        loaded_obs.load_state_dict(loaded_dict)
-        loaded_qparams = loaded_obs.calculate_qparams()
-        self.assertEqual(myobs.min_val, loaded_obs.min_val)
-        self.assertEqual(myobs.max_val, loaded_obs.max_val)
-        self.assertEqual(myobs.calculate_qparams(), loaded_obs.calculate_qparams())
+            result = myobs(x)
+            result = myobs(y)
+            self.assertEqual(result, y)
+            self.assertEqual(myobs.min_val, 1.0)
+            self.assertEqual(myobs.max_val, 8.0)
+            qparams = myobs.calculate_qparams()
+            if reduce_range:
+                if qscheme == torch.per_tensor_symmetric:
+                    ref_scale = 0.062745 * 255 / 127
+                    ref_zero_point = 0 if qdtype is torch.qint8 else 128
+                else:
+                    ref_scale = 0.0313725 * 255 / 127
+                    ref_zero_point = -64 if qdtype is torch.qint8 else 0
+            else:
+                if qscheme == torch.per_tensor_symmetric:
+                    ref_scale = 0.062745
+                    ref_zero_point = 0 if qdtype is torch.qint8 else 128
+                else:
+                    ref_scale = 0.0313725
+                    ref_zero_point = -128 if qdtype is torch.qint8 else 0
+            self.assertEqual(qparams[1].item(), ref_zero_point)
+            self.assertAlmostEqual(qparams[0].item(), ref_scale, delta=1e-5)
+            state_dict = myobs.state_dict()
+            b = io.BytesIO()
+            torch.save(state_dict, b)
+            b.seek(0)
+            loaded_dict = torch.load(b)
+            for key in state_dict:
+                self.assertEqual(state_dict[key], loaded_dict[key])
+            loaded_obs = MinMaxObserver(dtype=qdtype, qscheme=qscheme, reduce_range=reduce_range)
+            loaded_obs.load_state_dict(loaded_dict)
+            loaded_qparams = loaded_obs.calculate_qparams()
+            self.assertEqual(myobs.min_val, loaded_obs.min_val)
+            self.assertEqual(myobs.max_val, loaded_obs.max_val)
+            self.assertEqual(myobs.calculate_qparams(), loaded_obs.calculate_qparams())
 
     @given(qdtype=st.sampled_from((torch.qint8, torch.quint8)),
            qscheme=st.sampled_from((torch.per_channel_affine, torch.per_channel_symmetric)),
            ch_axis=st.sampled_from((0, 1, 2, 3)), reduce_range=st.booleans())
-    def test_per_channel_minmax_observer(self, qdtype, qscheme, ch_axis, reduce_range):
+    def test_per_channel_observers(self, qdtype, qscheme, ch_axis, reduce_range):
         # reduce_range cannot be true for symmetric quantization with uint8
         if qdtype == torch.quint8 and qscheme == torch.per_channel_symmetric:
             reduce_range = False
-        myobs = PerChannelMinMaxObserver(reduce_range=reduce_range, ch_axis=ch_axis, dtype=qdtype, qscheme=qscheme)
-        # Calculate qparams should work for empty observers
-        qparams = myobs.calculate_qparams()
-        x = torch.tensor(
-            [
-                [[[1.0, 2.0], [2.0, 2.5]], [[3.0, 4.0], [4.5, 6.0]]],
-                [[[-4.0, -3.0], [5.0, 5.0]], [[6.0, 3.0], [7.0, 8.0]]],
-            ]
-        )
-        result = myobs(x)
-        self.assertEqual(result, x)
-        qparams = myobs.calculate_qparams()
-        ref_min_vals = [[1.0, -4.0], [-4.0, 3.0], [-4.0, 2.0], [-4.0, -3.0]]
-        ref_max_vals = [[6.0, 8.0], [5.0, 8.0], [6.0, 8.0], [7.0, 8.0]]
-        per_channel_symmetric_ref_scales = [
-            [0.04705882, 0.06274509],
-            [0.03921569, 0.0627451],
-            [0.04705882, 0.0627451],
-            [0.05490196, 0.0627451],
-        ]
-        per_channel_affine_ref_scales = [
-            [0.02352941, 0.04705882],
-            [0.03529412, 0.03137255],
-            [0.03921569, 0.03137255],
-            [0.04313726, 0.04313726],
-        ]
-        per_channel_affine_qint8_zp = [
-            [-128, -43],
-            [-15, -128],
-            [-26, -128],
-            [-35, -58],
-        ]
-        per_channel_affine_quint8_zp = [[0, 85], [113, 0], [102, 0], [93, 70]]
+        ObserverList = [PerChannelMinMaxObserver(reduce_range=reduce_range,
+                                                 ch_axis=ch_axis,
+                                                 dtype=qdtype,
+                                                 qscheme=qscheme),
+                        MovingAveragePerChannelMinMaxObserver(averaging_constant=0.5,
+                                                              reduce_range=reduce_range,
+                                                              ch_axis=ch_axis,
+                                                              dtype=qdtype,
+                                                              qscheme=qscheme)]
 
-        self.assertEqual(myobs.min_vals, ref_min_vals[ch_axis])
-        self.assertEqual(myobs.max_vals, ref_max_vals[ch_axis])
-        if qscheme == torch.per_channel_symmetric:
-            ref_scales = per_channel_symmetric_ref_scales[ch_axis]
-            ref_zero_points = [0, 0] if qdtype is torch.qint8 else [128, 128]
-        else:
-            ref_scales = per_channel_affine_ref_scales[ch_axis]
-            ref_zero_points = (
-                per_channel_affine_qint8_zp[ch_axis]
-                if qdtype is torch.qint8
-                else per_channel_affine_quint8_zp[ch_axis]
+        for myobs in ObserverList:
+            # Calculate qparams should work for empty observers
+            qparams = myobs.calculate_qparams()
+            x = torch.tensor(
+                [
+                    [[[1.0, 2.0], [2.0, 2.5]], [[3.0, 4.0], [4.5, 6.0]]],
+                    [[[-4.0, -3.0], [5.0, 5.0]], [[6.0, 3.0], [7.0, 8.0]]],
+                ]
             )
+            if type(myobs) == MovingAveragePerChannelMinMaxObserver:
+                # Scaling the input tensor to model change in min/max values
+                # across batches
+                result = myobs(0.5 * x)
+                result = myobs(1.5 * x)
+                self.assertEqual(result, 1.5 * x)
+            else:
+                result = myobs(x)
+                self.assertEqual(result, x)
 
-        if reduce_range:
-            ref_scales = [s * 255 / 127 for s in ref_scales]
-            ref_zero_points = [math.floor(z / 2) for z in ref_zero_points]
+            qparams = myobs.calculate_qparams()
+            ref_min_vals = [[1.0, -4.0], [-4.0, 3.0], [-4.0, 2.0], [-4.0, -3.0]]
+            ref_max_vals = [[6.0, 8.0], [5.0, 8.0], [6.0, 8.0], [7.0, 8.0]]
+            per_channel_symmetric_ref_scales = [
+                [0.04705882, 0.06274509],
+                [0.03921569, 0.0627451],
+                [0.04705882, 0.0627451],
+                [0.05490196, 0.0627451],
+            ]
+            per_channel_affine_ref_scales = [
+                [0.02352941, 0.04705882],
+                [0.03529412, 0.03137255],
+                [0.03921569, 0.03137255],
+                [0.04313726, 0.04313726],
+            ]
+            per_channel_affine_qint8_zp = [
+                [-128, -43],
+                [-15, -128],
+                [-26, -128],
+                [-35, -58],
+            ]
+            per_channel_affine_quint8_zp = [[0, 85], [113, 0], [102, 0], [93, 70]]
 
-        self.assertTrue(torch.allclose(qparams[0], torch.tensor(ref_scales, dtype=qparams[0].dtype)))
-        self.assertTrue(torch.allclose(qparams[1], torch.tensor(ref_zero_points, dtype=qparams[1].dtype)))
+            self.assertEqual(myobs.min_vals, ref_min_vals[ch_axis])
+            self.assertEqual(myobs.max_vals, ref_max_vals[ch_axis])
+            if qscheme == torch.per_channel_symmetric:
+                ref_scales = per_channel_symmetric_ref_scales[ch_axis]
+                ref_zero_points = [0, 0] if qdtype is torch.qint8 else [128, 128]
+            else:
+                ref_scales = per_channel_affine_ref_scales[ch_axis]
+                ref_zero_points = (
+                    per_channel_affine_qint8_zp[ch_axis]
+                    if qdtype is torch.qint8
+                    else per_channel_affine_quint8_zp[ch_axis]
+                )
 
-        # Test for serializability
-        state_dict = myobs.state_dict()
-        b = io.BytesIO()
-        torch.save(state_dict, b)
-        b.seek(0)
-        loaded_dict = torch.load(b)
-        for key in state_dict:
-            self.assertEqual(state_dict[key], loaded_dict[key])
-        loaded_obs = PerChannelMinMaxObserver(reduce_range=reduce_range, ch_axis=ch_axis, dtype=qdtype, qscheme=qscheme)
-        loaded_obs.load_state_dict(loaded_dict)
-        loaded_qparams = loaded_obs.calculate_qparams()
-        self.assertEqual(myobs.min_vals, loaded_obs.min_vals)
-        self.assertEqual(myobs.max_vals, loaded_obs.max_vals)
-        self.assertEqual(myobs.calculate_qparams(), loaded_obs.calculate_qparams())
+            if reduce_range:
+                ref_scales = [s * 255 / 127 for s in ref_scales]
+                ref_zero_points = [math.floor(z / 2) for z in ref_zero_points]
+
+            self.assertTrue(torch.allclose(qparams[0], torch.tensor(ref_scales, dtype=qparams[0].dtype)))
+            self.assertTrue(torch.allclose(qparams[1], torch.tensor(ref_zero_points, dtype=qparams[1].dtype)))
+
+            # Test for serializability
+            state_dict = myobs.state_dict()
+            b = io.BytesIO()
+            torch.save(state_dict, b)
+            b.seek(0)
+            loaded_dict = torch.load(b)
+            for key in state_dict:
+                self.assertEqual(state_dict[key], loaded_dict[key])
+            loaded_obs = PerChannelMinMaxObserver(reduce_range=reduce_range, ch_axis=ch_axis, dtype=qdtype, qscheme=qscheme)
+            loaded_obs.load_state_dict(loaded_dict)
+            loaded_qparams = loaded_obs.calculate_qparams()
+            self.assertEqual(myobs.min_vals, loaded_obs.min_vals)
+            self.assertEqual(myobs.max_vals, loaded_obs.max_vals)
+            self.assertEqual(myobs.calculate_qparams(), loaded_obs.calculate_qparams())
 
     def test_observer_scriptable(self):
-        obs = torch.quantization.default_observer()
-        scripted = torch.jit.script(obs)
+        obs_list = [MinMaxObserver(), MovingAverageMinMaxObserver()]
+        for obs in obs_list:
+            scripted = torch.jit.script(obs)
 
-        x = torch.rand(3, 4)
-        obs(x)
-        scripted(x)
+            x = torch.rand(3, 4)
+            obs(x)
+            scripted(x)
 
-        self.assertEqual(obs.calculate_qparams(), scripted.calculate_qparams())
+            self.assertEqual(obs.calculate_qparams(), scripted.calculate_qparams())
 
-        buf = io.BytesIO()
-        torch.jit.save(scripted, buf)
-        buf.seek(0)
-        loaded = torch.jit.load(buf)
-        self.assertEqual(obs.calculate_qparams(), loaded.calculate_qparams())
+            buf = io.BytesIO()
+            torch.jit.save(scripted, buf)
+            buf.seek(0)
+            loaded = torch.jit.load(buf)
+            self.assertEqual(obs.calculate_qparams(), loaded.calculate_qparams())
 
     def test_no_qconfig_propagation(self):
         model = ModelWithNoQconfigPropagation()

--- a/torch/quantization/QConfig.py
+++ b/torch/quantization/QConfig.py
@@ -86,13 +86,13 @@ def get_default_qconfig(backend='fbgemm'):
 def get_default_qat_qconfig(backend='fbgemm'):
     # Histogram observer is too slow for quantization aware training
     if backend == 'fbgemm':
-        qconfig = QConfig(activation=FakeQuantize.with_args(observer=MinMaxObserver,
+        qconfig = QConfig(activation=FakeQuantize.with_args(observer=MovingAverageMinMaxObserver,
                                                             quant_min=0,
                                                             quant_max=255,
                                                             reduce_range=True),
                           weight=default_per_channel_weight_fake_quant)
     elif backend == 'qnnpack':
-        qconfig = QConfig(activation=FakeQuantize.with_args(observer=MinMaxObserver,
+        qconfig = QConfig(activation=FakeQuantize.with_args(observer=MovingAverageMinMaxObserver,
                                                             quant_min=0,
                                                             quant_max=255,
                                                             reduce_range=False),

--- a/torch/quantization/fake_quantize.py
+++ b/torch/quantization/fake_quantize.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import torch
 from torch.nn import Module
-from .observer import MinMaxObserver, HistogramObserver, PerChannelMinMaxObserver, _with_args
+from .observer import MovingAverageMinMaxObserver, HistogramObserver, MovingAveragePerChannelMinMaxObserver, _with_args
 
 class FakeQuantize(Module):
     ''' Simulate the quantize and dequantize operations in training time.
@@ -119,12 +119,12 @@ class FakeQuantize(Module):
         super(FakeQuantize, self)._load_from_state_dict(state_dict, prefix, local_metadata, False,
                                                         missing_keys, unexpected_keys, error_msgs)
 
-default_fake_quant = FakeQuantize.with_args(observer=MinMaxObserver, quant_min=0, quant_max=255,
+default_fake_quant = FakeQuantize.with_args(observer=MovingAverageMinMaxObserver, quant_min=0, quant_max=255,
                                             dtype=torch.quint8, qscheme=torch.per_tensor_affine, reduce_range=True)
-default_weight_fake_quant = FakeQuantize.with_args(observer=MinMaxObserver, quant_min=-128, quant_max=127,
+default_weight_fake_quant = FakeQuantize.with_args(observer=MovingAverageMinMaxObserver, quant_min=-128, quant_max=127,
                                                    dtype=torch.qint8, qscheme=torch.per_tensor_symmetric, reduce_range=False)
 
-default_per_channel_weight_fake_quant = FakeQuantize.with_args(observer=PerChannelMinMaxObserver,
+default_per_channel_weight_fake_quant = FakeQuantize.with_args(observer=MovingAveragePerChannelMinMaxObserver,
                                                                quant_min=-128,
                                                                quant_max=127,
                                                                dtype=torch.qint8,

--- a/torch/quantization/observer.py
+++ b/torch/quantization/observer.py
@@ -215,7 +215,7 @@ class MinMaxObserver(_ObserverBase):
             max_val = torch.max(torch.max(x), max_val)
         self.min_val = min_val
         self.max_val = max_val
-        return x
+        return x_orig
 
     @torch.jit.export
     def calculate_qparams(self):
@@ -237,6 +237,25 @@ class MinMaxObserver(_ObserverBase):
         self.max_val = state_dict.pop(prefix + 'max_val')
         super(MinMaxObserver, self)._load_from_state_dict(state_dict, prefix, local_metadata, False,
                                                           missing_keys, unexpected_keys, error_msgs)
+
+class MovingAverageMinMaxObserver(MinMaxObserver):
+    def __init__(self, averaging_constant=0.01, **kwargs):
+        self.averaging_constant = averaging_constant
+        super(MovingAverageMinMaxObserver, self).__init__(**kwargs)
+
+    def forward(self, x_orig):
+        x = x_orig.detach()  # avoid keeping autograd tape
+        min_val = self.min_val
+        max_val = self.max_val
+        if min_val is None or max_val is None:
+            min_val = torch.min(x)
+            max_val = torch.max(x)
+        else:
+            min_val = min_val + self.averaging_constant * (torch.min(x) - min_val)
+            max_val = max_val + self.averaging_constant * (torch.max(x) - max_val)
+        self.min_val = min_val
+        self.max_val = max_val
+        return x_orig
 
 
 class PerChannelMinMaxObserver(_ObserverBase):
@@ -260,26 +279,26 @@ class PerChannelMinMaxObserver(_ObserverBase):
                 "Cannot reduce range for symmetric quantization for quint8"
             )
 
-    def forward(self, x):
-        with torch.no_grad():
-            min_vals = self.min_vals
-            max_vals = self.max_vals
-            x_dim = x.size()
+    def forward(self, x_orig):
+        x = x_orig.detach()  # avoid keeping autograd tape
+        min_vals = self.min_vals
+        max_vals = self.max_vals
+        x_dim = x.size()
 
-            new_axis_list = list(range(len(x_dim)))
-            new_axis_list[self.ch_axis] = 0
-            new_axis_list[0] = self.ch_axis
-            y = x.permute(tuple(new_axis_list))
-            y = torch.flatten(y, start_dim=1)
-            if min_vals is None or max_vals is None:
-                min_vals = torch.min(y, 1)[0]
-                max_vals = torch.max(y, 1)[0]
-            else:
-                min_vals = torch.min(torch.min(y, 1)[0], min_vals)
-                max_vals = torch.max(torch.max(y, 1)[0], max_vals)
-            self.min_vals = min_vals
-            self.max_vals = max_vals
-        return x
+        new_axis_list = list(range(len(x_dim)))
+        new_axis_list[self.ch_axis] = 0
+        new_axis_list[0] = self.ch_axis
+        y = x.permute(tuple(new_axis_list))
+        y = torch.flatten(y, start_dim=1)
+        if min_vals is None or max_vals is None:
+            min_vals = torch.min(y, 1)[0]
+            max_vals = torch.max(y, 1)[0]
+        else:
+            min_vals = torch.min(torch.min(y, 1)[0], min_vals)
+            max_vals = torch.max(torch.max(y, 1)[0], max_vals)
+        self.min_vals = min_vals
+        self.max_vals = max_vals
+        return x_orig
 
     def calculate_qparams(self):
         return self._calculate_per_channel_qparams(self.min_vals, self.max_vals)
@@ -295,6 +314,38 @@ class PerChannelMinMaxObserver(_ObserverBase):
         self.max_vals = state_dict.pop(prefix + 'max_vals')
         super(PerChannelMinMaxObserver, self)._load_from_state_dict(state_dict, prefix, local_metadata, False,
                                                                     missing_keys, unexpected_keys, error_msgs)
+
+class MovingAveragePerChannelMinMaxObserver(PerChannelMinMaxObserver):
+    r"""Per Channel Observer Module
+    The module will record the running average of max and min value for each
+    channel of the observed Tensor and calculate_qparams will calculate
+    scales and zero_points for each channel
+    """
+
+    def __init__(self, averaging_constant=0.01, **kwargs):
+        self.averaging_constant = averaging_constant
+        super(MovingAveragePerChannelMinMaxObserver, self).__init__(**kwargs)
+
+    def forward(self, x_orig):
+        x = x_orig.detach()  # avoid keeping autograd tape
+        min_vals = self.min_vals
+        max_vals = self.max_vals
+        x_dim = x.size()
+
+        new_axis_list = list(range(len(x_dim)))
+        new_axis_list[self.ch_axis] = 0
+        new_axis_list[0] = self.ch_axis
+        y = x.permute(tuple(new_axis_list))
+        y = torch.flatten(y, start_dim=1)
+        if min_vals is None or max_vals is None:
+            min_vals = torch.min(y, 1)[0]
+            max_vals = torch.max(y, 1)[0]
+        else:
+            min_vals = min_vals + self.averaging_constant * (torch.min(y, 1)[0] - min_vals)
+            max_vals = max_vals + self.averaging_constant * (torch.max(y, 1)[0] - max_vals)
+        self.min_vals = min_vals
+        self.max_vals = max_vals
+        return x_orig
 
 class HistogramObserver(_ObserverBase):
     r"""


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#27393 MovingAverage Observer**

Observer that estimates moving averages of min and max values per batch,  more suited for quantization aware training instead of minmax observers that track extremal values across batches

Differential Revision: [D17727213](https://our.internmc.facebook.com/intern/diff/D17727213/)