### PR TITLE
[jit] kill _parameter_list

### DIFF
--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -382,18 +382,6 @@ def get_torchscript_modifier(fn):
     return getattr(fn, '_torchscript_modifier', FunctionModifiers.DEFAULT)
 
 
-def _parameter_list(parameter_names_fn):
-    """
-    Decorator to denote that a function returns a list of all the parameters
-    in a module
-    """
-    def decorator(fn):
-        fn._parameter_names_fn = parameter_names_fn
-        return fn
-
-    return decorator
-
-
 # overloading registration
 # overloads get registered in this file, and compiled in torch/jit/__init__.py
 # so that they can be imported in nn/functional.py without an import cycle

--- a/torch/jit/quantized.py
+++ b/torch/jit/quantized.py
@@ -5,7 +5,6 @@ from torch._jit_internal import Tuple, Optional, List  # noqa: F401
 from torch import Tensor  # noqa: F401
 from torch.nn import _VF
 
-from torch._jit_internal import _parameter_list
 from torch.nn.utils.rnn import PackedSequence
 
 class QuantizedLinear(torch.jit.ScriptModule):
@@ -243,10 +242,9 @@ def apply_permutation(tensor, permutation, dim=1):
 
 class QuantizedRNNBase(torch.jit.ScriptModule):
     __constants__ = ['mode', 'input_size', 'hidden_size', 'num_layers', 'bias',
-                     'batch_first', 'dropout', 'bidirectional', '_packed_weights',
-                     '_quantized_weights', 'dtype']
+                     'batch_first', 'dropout', 'bidirectional', 'dtype']
 
-    def __init__(self, other, dtype=torch.int8): 
+    def __init__(self, other, dtype=torch.int8):
         super(QuantizedRNNBase, self).__init__()
         self.mode = other.mode
         self.input_size = other.input_size
@@ -270,10 +268,10 @@ class QuantizedRNNBase(torch.jit.ScriptModule):
         if dtype != torch.int8 and dtype != torch.float16:
             raise RuntimeError('Unsupported dtype: {}'.format(dtype))
 
-        self._all_weights = []
-        packed_weights = []
-        quantized_weights = []
-        orig_weights = []
+        self._all_weights_names = []
+        self._packed_weights_names = []
+        self._quantized_weights_names = []
+        self._orig_weights_names = []
         for layer in range(self.num_layers):
             for direction in range(num_directions):
                 layer_input_size = self.input_size if layer == 0 else self.hidden_size * num_directions
@@ -285,7 +283,7 @@ class QuantizedRNNBase(torch.jit.ScriptModule):
                     weight = getattr(other, weight_name)
                     bias = getattr(other, bias_name)
 
-                    if dtype == torch.int8: 
+                    if dtype == torch.int8:
                         # for each layer, for each direction we need to quantize and pack
                         # weights and pack parameters in this order:
                         #
@@ -298,10 +296,10 @@ class QuantizedRNNBase(torch.jit.ScriptModule):
                         params = [qweight, bias, packed_weight, col_offsets, scale, zero_point]
                         pos_names = ['w', 'b', 'packed', 'col_offsets', 'scale', 'zero_point']
                         ret_name = ['{}_{}_l{}{}'.format(name, ihhh, layer, suffix) for name in pos_names]
-                        quantized_weights.append(ret_name[0])
-                        packed_weights.append(ret_name[2])
+                        self._quantized_weights_names.append(ret_name[0])
+                        self._packed_weights_names.append(ret_name[2])
                         return params, ret_name
-                    else: 
+                    else:
                         # for each layer, for each direction we need to quantize and pack
                         # weights and pack parameters in this order:
                         #
@@ -309,13 +307,13 @@ class QuantizedRNNBase(torch.jit.ScriptModule):
                         packed_weight = torch.fbgemm_pack_gemm_matrix_fp16(
                             weight.clone().float())
 
-                        orig_weights.append(weight_name)
+                        self._orig_weights_names.append(weight_name)
                         self.register_buffer(weight_name, weight)
                         params = [packed_weight, bias]
                         pos_names = ['packed', 'b']
                         ret_name = ['{}_{}_l{}{}'.format(name, ihhh, layer, suffix) for name in pos_names]
-                        packed_weights.append(ret_name[0])
-                        quantized_weights.append(ret_name[0])
+                        self._packed_weights_names.append(ret_name[0])
+                        self._quantized_weights_names.append(ret_name[0])
                         return params, ret_name
 
                 suffix = '_reverse' if direction == 1 else ''
@@ -325,17 +323,19 @@ class QuantizedRNNBase(torch.jit.ScriptModule):
                 for (ih, ih_name), (hh, hh_name) in zip(zip(ih_params, ih_param_names), zip(hh_params, hh_param_names)):
                     self.register_buffer(ih_name, torch.tensor(ih) if not isinstance(ih, torch.Tensor) else ih)
                     self.register_buffer(hh_name, torch.tensor(hh) if not isinstance(hh, torch.Tensor) else hh)
-                    self._all_weights.extend([ih_name, hh_name])
+                    self._all_weights_names.extend([ih_name, hh_name])
 
-        self._packed_weights = packed_weights
-        self._quantized_weights = quantized_weights
-        # For int8 quantization, _orig_weights is not needed in the quantization logic, 
-        # however there is a JIT compilation error without it. This is just used to 
-        # workaround that error. 
-        if dtype == torch.int8: 
-            self._orig_weights = self._packed_weights
-        else: 
-            self._orig_weights = orig_weights
+        # For int8 quantization, _orig_weights is not needed in the quantization logic,
+        # however there is a JIT compilation error without it. This is just used to
+        # workaround that error.
+        if dtype == torch.int8:
+            self._orig_weights_names = self._packed_weights_names
+
+        self._packed_weights = torch.jit.Attribute([getattr(self, weight) for weight in self._packed_weights_names], List[Tensor])
+        self._quantized_weights = torch.jit.Attribute([getattr(self, weight) for weight in self._quantized_weights_names], List[Tensor])
+        self._orig_weights = torch.jit.Attribute([getattr(self, weight) for weight in self._orig_weights_names], List[Tensor])
+        # this one is public
+        self.all_weights = torch.jit.Attribute([getattr(self, weight) for weight in self._all_weights_names], List[Tensor])
 
     @torch.jit.script_method
     def check_input(self, input, batch_sizes):
@@ -383,37 +383,23 @@ class QuantizedRNNBase(torch.jit.ScriptModule):
             return hx
         return apply_permutation(hx, permutation)
 
-    @property
-    def all_weights(self):
-        return [getattr(self, weight) for weight in self._all_weights]
+    def __setattr__(self, attr, value):
+        if hasattr(self, "_orig_weight_names"):
+            # keep weight attributes up to date if you do self.weight = ...
+            if attr in self._all_weights_names:
+                idx = self._all_weights_names.index(attr)
+                self.all_weights[idx] = value
+            elif attr in self._packed_weights_names:
+                idx = self._packed_weights_names.index(attr)
+                self._packed_weights[idx] = value
+            elif attr in self._orig_weights_names:
+                idx = self._orig_weights_names.index(attr)
+                self._orig_weights[idx] = value
+            elif attr in self._quantized_weights_names:
+                idx = self._quantized_weights_names.index(attr)
+                self._quantized_weights[idx] = value
 
-    def _get_all_weights_names(self):
-        return [weight for weight in self._all_weights]
-
-    @_parameter_list(_get_all_weights_names)
-    def _get_all_weights(self):
-        return self.all_weights
-
-    def _get_packed_weights_names(self):
-        return self._packed_weights
-
-    @_parameter_list(_get_packed_weights_names)
-    def _get_packed_weights(self):
-        return [getattr(self, name) for name in self._packed_weights]
-
-    def _get_quantized_weights_names(self):
-        return self._quantized_weights
-
-    @_parameter_list(_get_quantized_weights_names)
-    def _get_quantized_weights(self):
-        return [getattr(self, name) for name in self._quantized_weights]
-
-    def _get_orig_weights_names(self):
-        return self._orig_weights
-
-    @_parameter_list(_get_orig_weights_names)
-    def _get_orig_weights(self):
-        return [getattr(self, name) for name in self._get_orig_weights]
+        return super(QuantizedRNNBase, self).__setattr__(attr, value)
 
     # TODO: for some reason torch.jit.script_method causes a destruction of the
     # module to occur, which in turn frees the packed_ih object via its DataPtr
@@ -422,16 +408,16 @@ class QuantizedRNNBase(torch.jit.ScriptModule):
     @torch.jit.script_method
     def _unpack(self):
         if self.dtype == torch.int8:
-            packed_weights = self._get_packed_weights()
-            quantized_weights = self._get_quantized_weights()
+            packed_weights = self._packed_weights
+            quantized_weights = self._quantized_weights
             assert len(packed_weights) == len(quantized_weights)
             for i in range(len(packed_weights)):
                 packed = packed_weights[i]
                 quantized = quantized_weights[i]
                 packed.set_(torch.fbgemm_pack_quantized_matrix(quantized))
-        else: 
-            packed_weights = self._get_packed_weights()
-            orig_weights = self._get_orig_weights()
+        else:
+            packed_weights = self._packed_weights
+            orig_weights = self._orig_weights
             assert len(packed_weights) == len(orig_weights)
             for i in range(len(packed_weights)):
                 packed = packed_weights[i]
@@ -441,7 +427,7 @@ class QuantizedRNNBase(torch.jit.ScriptModule):
 
     @torch.jit.script_method
     def _pack(self):
-        for weight in self._get_packed_weights():
+        for weight in self._packed_weights:
             weight.set_(torch.zeros(torch.jit.annotate(List[int], []),
                         dtype=torch.uint8).detach())
 
@@ -449,7 +435,7 @@ class QuantizedRNNBase(torch.jit.ScriptModule):
 class QuantizedLSTM(QuantizedRNNBase):
     __overloads__ = {'forward': ['forward_packed', 'forward_tensor']}
 
-    def __init__(self, other, dtype): 
+    def __init__(self, other, dtype):
         super(QuantizedLSTM, self).__init__(other, dtype)
 
     @torch.jit.script_method
@@ -468,7 +454,7 @@ class QuantizedLSTM(QuantizedRNNBase):
 
         self.check_forward_args(input, hx, batch_sizes)
         assert batch_sizes is None
-        result = _VF.quantized_lstm(input, hx, self._get_all_weights(), self.bias, self.num_layers,
+        result = _VF.quantized_lstm(input, hx, self.all_weights, self.bias, self.num_layers,
                                     float(self.dropout), self.training, self.bidirectional,
                                     self.batch_first, dtype=self.dtype, use_dynamic=False)
         output = result[0]
@@ -544,11 +530,11 @@ class QuantizedGRU(QuantizedRNNBase):
 
         self.check_forward_args(input, hx, batch_sizes)
         if batch_sizes is None:
-            result = _VF.quantized_gru(input, hx, self._get_all_weights(), self.bias, self.num_layers,
+            result = _VF.quantized_gru(input, hx, self.all_weights, self.bias, self.num_layers,
                                        float(self.dropout), self.training, self.bidirectional,
                                        self.batch_first)
         else:
-            result = _VF.quantized_gru(input, batch_sizes, hx, self._get_all_weights(), self.bias, self.num_layers,
+            result = _VF.quantized_gru(input, batch_sizes, hx, self.all_weights, self.bias, self.num_layers,
                                        float(self.dropout), self.training, self.bidirectional)
 
         output = result[0]

--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -8,7 +8,6 @@ from ..parameter import Parameter
 from ..utils.rnn import PackedSequence
 from .. import init
 from .. import _VF
-from ..._jit_internal import _parameter_list
 
 _rnn_impls = {
     'RNN_TANH': _VF.rnn_tanh,
@@ -61,7 +60,7 @@ class RNNBase(Module):
         else:
             raise ValueError("Unrecognized RNN mode: " + mode)
 
-        self._all_weights = []
+        self._flat_weights_names = []
         for layer in range(num_layers):
             for direction in range(num_directions):
                 layer_input_size = input_size if layer == 0 else hidden_size * num_directions
@@ -82,10 +81,18 @@ class RNNBase(Module):
 
                 for name, param in zip(param_names, layer_params):
                     setattr(self, name, param)
-                self._all_weights.append(param_names)
+                self._flat_weights_names.extend(param_names)
 
+        self._flat_weights = [getattr(self, weight) for weight in self._flat_weights_names]
         self.flatten_parameters()
         self.reset_parameters()
+
+    def __setattr__(self, attr, value):
+        if hasattr(self, "_flat_weights_names") and attr in self._flat_weights_names:
+            # keep self._flat_weights up to date if you do self.weight = ...
+            idx = self._flat_weights_names.index(attr)
+            self._flat_weights[idx] = value
+        super(RNNBase, self).__setattr__(attr, value)
 
     def flatten_parameters(self):
         """Resets parameter data pointer so that they can use faster code paths.
@@ -128,13 +135,6 @@ class RNNBase(Module):
         stdv = 1.0 / math.sqrt(self.hidden_size)
         for weight in self.parameters():
             init.uniform_(weight, -stdv, stdv)
-
-    def _get_flat_weights_names(self):
-        return [weight for weights in self._all_weights for weight in weights]
-
-    @_parameter_list(_get_flat_weights_names)
-    def _get_flat_weights(self):
-        return self._flat_weights
 
     def check_input(self, input, batch_sizes):
         # type: (Tensor, Optional[Tensor]) -> None
@@ -203,10 +203,10 @@ class RNNBase(Module):
         self.check_forward_args(input, hx, batch_sizes)
         _impl = _rnn_impls[self.mode]
         if batch_sizes is None:
-            result = _impl(input, hx, self._get_flat_weights(), self.bias, self.num_layers,
+            result = _impl(input, hx, self._flat_weights, self.bias, self.num_layers,
                            self.dropout, self.training, self.bidirectional, self.batch_first)
         else:
-            result = _impl(input, batch_sizes, hx, self._get_flat_weights(), self.bias,
+            result = _impl(input, batch_sizes, hx, self._flat_weights, self.bias,
                            self.num_layers, self.dropout, self.training, self.bidirectional)
         output = result[0]
         hidden = result[1]
@@ -231,30 +231,24 @@ class RNNBase(Module):
 
     def __setstate__(self, d):
         super(RNNBase, self).__setstate__(d)
-        if 'all_weights' in d:
-            self._all_weights = d['all_weights']
-        if isinstance(self._all_weights[0][0], str):
+        if 'self._flat_weights' in d:
+            self._flat_weights = d['_flat_weights']
+            self._flat_weights_names = d['_flat_weights_names']
+        if isinstance(self._flat_weights_names[0][0], str):
             return
         num_layers = self.num_layers
         num_directions = 2 if self.bidirectional else 1
-        self._all_weights = []
+        self._flat_weights_names = []
         for layer in range(num_layers):
             for direction in range(num_directions):
                 suffix = '_reverse' if direction == 1 else ''
                 weights = ['weight_ih_l{}{}', 'weight_hh_l{}{}', 'bias_ih_l{}{}', 'bias_hh_l{}{}']
                 weights = [x.format(layer, suffix) for x in weights]
                 if self.bias:
-                    self._all_weights += [weights]
+                    self._flat_weights_names.extend(weights)
                 else:
-                    self._all_weights += [weights[:2]]
-
-    @property
-    def _flat_weights(self):
-        return [p for layerparams in self.all_weights for p in layerparams]
-
-    @property
-    def all_weights(self):
-        return [[getattr(self, weight) for weight in weights] for weights in self._all_weights]
+                    self._flat_weights_names.extend(weights[:2])
+        self._flat_weights = [getattr(self, weight) for weight in self._flat_weights_names]
 
 
 class RNN(RNNBase):
@@ -522,10 +516,10 @@ class LSTM(RNNBase):
 
         self.check_forward_args(input, hx, batch_sizes)
         if batch_sizes is None:
-            result = _VF.lstm(input, hx, self._get_flat_weights(), self.bias, self.num_layers,
+            result = _VF.lstm(input, hx, self._flat_weights, self.bias, self.num_layers,
                               self.dropout, self.training, self.bidirectional, self.batch_first)
         else:
-            result = _VF.lstm(input, batch_sizes, hx, self._get_flat_weights(), self.bias,
+            result = _VF.lstm(input, batch_sizes, hx, self._flat_weights, self.bias,
                               self.num_layers, self.dropout, self.training, self.bidirectional)
         output = result[0]
         hidden = result[1:]
@@ -676,10 +670,10 @@ class GRU(RNNBase):
     def run_impl(self, input, hx, batch_sizes):
         # type: (Tensor, Tensor, Optional[Tensor]) -> Tuple[Tensor, Tensor]
         if batch_sizes is None:
-            result = _VF.gru(input, hx, self._get_flat_weights(), self.bias, self.num_layers,
+            result = _VF.gru(input, hx, self._flat_weights, self.bias, self.num_layers,
                              self.dropout, self.training, self.bidirectional, self.batch_first)
         else:
-            result = _VF.gru(input, batch_sizes, hx, self._get_flat_weights(), self.bias,
+            result = _VF.gru(input, batch_sizes, hx, self._flat_weights, self.bias,
                              self.num_layers, self.dropout, self.training, self.bidirectional)
         return result
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#27397 [jit] kill _parameter_list**
* #26665 [jit Python None should have its type inferred as NoneType

This was devised in a time when we didn't have module attributes. They
are essentially just tensor lists, so represent them that way. This has
the additional benefit of making the RNN forward pass faster because we
effectively cache the flattened weights.

The only complication part is that someone may come along and do:
```
my_rnn_mod.w_ih_l0 = torch.nn.Parameter(...)
```

This means we need to override setattr to keep the flattened weights
cache up to date.