### PR TITLE
[distributed] improve error message on incorrect inputs into gather for
ProcessGroupGloo

### DIFF
--- a/test/test_c10d.py
+++ b/test/test_c10d.py
@@ -1092,15 +1092,19 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
             opts.rootRank = self.rank
             pg.gather([[t1] * self.world_size, [t1] * self.world_size], [t1], opts)
 
-        with self.assertRaisesRegex(ValueError, "requires a single-element output list"):
+        desired_list_size = self.world_size
+        incorrect_list_size = self.world_size - 1
+        err_str = "Incorrect output list size {}. Output list size should be {}"
+        with self.assertRaisesRegex(ValueError, err_str.format(incorrect_list_size, desired_list_size)):
             opts = c10d.GatherOptions()
             opts.rootRank = self.rank
-            pg.gather([[t1] * (self.world_size - 1)], [t1], opts)
+            pg.gather([[t1] * incorrect_list_size], [t1], opts)
 
-        with self.assertRaisesRegex(ValueError, "requires a single-element output list"):
+        incorrect_list_size = self.world_size + 1
+        with self.assertRaisesRegex(ValueError, err_str.format(incorrect_list_size, desired_list_size)):
             opts = c10d.GatherOptions()
             opts.rootRank = self.rank
-            pg.gather([[t1] * (self.world_size + 1)], [t1], opts)
+            pg.gather([[t1] * incorrect_list_size], [t1], opts)
 
         with self.assertRaisesRegex(ValueError, "invalid tensor type"):
             opts = c10d.GatherOptions()

--- a/torch/lib/c10d/ProcessGroupGloo.cpp
+++ b/torch/lib/c10d/ProcessGroupGloo.cpp
@@ -1896,11 +1896,17 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupGloo::gather(
   assertDense(invalidArgument, inputs);
 
   if (getRank() == opts.rootRank) {
-    if (outputs.size() != 1 ||
-        outputs[0].size() != static_cast<size_t>(getSize())) {
-      invalidArgument(
-          "requires a single-element output list "
-          "containing a list with <size> tensors");
+    if (outputs.size() != 1) {
+      std::stringstream ss;
+      ss << "requires a single-element output list containing a list with "
+         << getSize() << " tensors.";
+      invalidArgument(ss.str());
+    } else if (outputs[0].size() != static_cast<size_t>(getSize())) {
+      std::stringstream ss;
+      ss << "Incorrect output list size " << outputs[0].size()
+         << ". Output list size should be " << getSize()
+         << ", same as size of the process group.";
+      invalidArgument(ss.str());
     }
 
     const auto& type = inputs[0].type();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #27458 [distributed] improve error message for scatter in processGroupGloo
* **#27439 [distributed] improve error message on incorrect inputs into gather for
ProcessGroupGloo**
ProcessGroupGloo**

When users call dist.gather, they have to pass in a `gather_list` to
the function on the destination worker, and this list needs to have the same
size as the number of processes in the group. When the user initializes this
list incorrectly, the current error message is not very helpful (see https://github.com/pytorch/pytorch/issues/27440). This changes the error message so that the incorrect gather_list size is pointed out and the correct one is given.

Test plan: Modified the unit tests appropriately. Also tested by observing the new error message:

Prev: 
`ValueError: ProcessGroupGloo::gather: requires a single-element output list containing a list with <size> tensors`
New:
`ValueError: ProcessGroupGloo::gather: Incorrect output list size 1. Output list size should be 2, same as size of the process group.`

Differential Revision: [D17781370](https://our.internmc.facebook.com/intern/diff/D17781370/)