### PR TITLE
Fix install location for ATen_CORE_HEADERS by avoiding relative paths

### DIFF
--- a/aten/src/ATen/CMakeLists.txt
+++ b/aten/src/ATen/CMakeLists.txt
@@ -448,9 +448,10 @@ endif()
 
 # https://stackoverflow.com/questions/11096471/how-can-i-install-a-hierarchy-of-files-using-cmake
 FOREACH(HEADER  ${INSTALL_HEADERS})
-  string(REPLACE "${CMAKE_CURRENT_SOURCE_DIR}/" "" HEADER_SUB ${HEADER})
+  string(REPLACE "${CMAKE_CURRENT_SOURCE_DIR}/" "ATen/" HEADER_SUB ${HEADER})
+  string(REPLACE "${Caffe2_SOURCE_DIR}/" "" HEADER_SUB ${HEADER_SUB})
   GET_FILENAME_COMPONENT(DIR ${HEADER_SUB} DIRECTORY)
-  INSTALL(FILES ${HEADER} DESTINATION ${AT_INSTALL_INCLUDE_DIR}/ATen/${DIR})
+  INSTALL(FILES ${HEADER} DESTINATION "${AT_INSTALL_INCLUDE_DIR}/${DIR}")
 ENDFOREACH()
 
 # TODO: Install hip_generated_h when we have it

--- a/aten/src/ATen/core/CMakeLists.txt
+++ b/aten/src/ATen/core/CMakeLists.txt
@@ -8,22 +8,22 @@ EXCLUDE(ATen_CORE_SRCS "${ATen_CORE_SRCS}" ${ATen_CORE_TEST_SRCS})
 
 # Add files needed from jit folders
 LIST(APPEND ATen_CORE_HEADERS
-    ${CMAKE_CURRENT_SOURCE_DIR}/../../../../torch/csrc/jit/source_range.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/../../../../torch/csrc/jit/script/function_schema_parser.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/../../../../torch/csrc/jit/script/lexer.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/../../../../torch/csrc/jit/script/strtod.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/../../../../torch/csrc/jit/script/parse_string_literal.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/../../../../torch/csrc/jit/script/schema_type_parser.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/../../../../torch/csrc/jit/script/error_report.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/../../../../torch/csrc/jit/script/tree.h
+    ${Caffe2_SOURCE_DIR}/torch/csrc/jit/source_range.h
+    ${Caffe2_SOURCE_DIR}/torch/csrc/jit/script/function_schema_parser.h
+    ${Caffe2_SOURCE_DIR}/torch/csrc/jit/script/lexer.h
+    ${Caffe2_SOURCE_DIR}/torch/csrc/jit/script/strtod.h
+    ${Caffe2_SOURCE_DIR}/torch/csrc/jit/script/parse_string_literal.h
+    ${Caffe2_SOURCE_DIR}/torch/csrc/jit/script/schema_type_parser.h
+    ${Caffe2_SOURCE_DIR}/torch/csrc/jit/script/error_report.h
+    ${Caffe2_SOURCE_DIR}/torch/csrc/jit/script/tree.h
 )
 LIST(APPEND ATen_CORE_SRCS
-    ${CMAKE_CURRENT_SOURCE_DIR}/../../../../torch/csrc/jit/script/error_report.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/../../../../torch/csrc/jit/script/function_schema_parser.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/../../../../torch/csrc/jit/script/lexer.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/../../../../torch/csrc/jit/script/strtod.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/../../../../torch/csrc/jit/script/schema_type_parser.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/../../../../torch/csrc/jit/source_range.cpp
+    ${Caffe2_SOURCE_DIR}/torch/csrc/jit/script/error_report.cpp
+    ${Caffe2_SOURCE_DIR}/torch/csrc/jit/script/function_schema_parser.cpp
+    ${Caffe2_SOURCE_DIR}/torch/csrc/jit/script/lexer.cpp
+    ${Caffe2_SOURCE_DIR}/torch/csrc/jit/script/strtod.cpp
+    ${Caffe2_SOURCE_DIR}/torch/csrc/jit/script/schema_type_parser.cpp
+    ${Caffe2_SOURCE_DIR}/torch/csrc/jit/source_range.cpp
 )
 
 # Pass to parent


### PR DESCRIPTION
Fixes #20046

While installing, `aten/src/ATen` is shortened to just `ATen` so these relative paths become `/usr/local/include/ATen/core/../../../../torch` or simply `/usr/torch`.
Note that in cmake, `Caffe2` is the name for the root `pytorch` project so `Caffe2_SOURCE_DIR` gives the `pytorch` directory; *not* the `caffe2` directory.