### PR TITLE
Scope pybind11 functions to torch.distributed.{autograd,rpc}

### DIFF
--- a/test/rpc_test.py
+++ b/test/rpc_test.py
@@ -12,8 +12,7 @@ import torch.distributed as dist
 import torch.distributed.rpc as rpc
 from common_utils import load_tests
 from dist_utils import INIT_METHOD_TEMPLATE, TEST_CONFIG, dist_init
-from torch.distributed import ProcessGroupAgent
-from torch.distributed.rpc import RpcBackend
+from torch.distributed.rpc import ProcessGroupAgent, RpcBackend
 from torch.distributed.rpc.internal import PythonUDF, _internal_rpc_pickler
 
 

--- a/torch/csrc/distributed/autograd/init.cpp
+++ b/torch/csrc/distributed/autograd/init.cpp
@@ -16,13 +16,13 @@ template <typename T>
 using shared_ptr_class_ = py::class_<T, std::shared_ptr<T>>;
 
 PyObject* dist_autograd_init(PyObject* /* unused */) {
-  auto dist_module =
+  auto autograd_module =
       THPObjectPtr(PyImport_ImportModule("torch.distributed.autograd"));
-  if (!dist_module) {
+  if (!autograd_module) {
     throw python_error();
   }
 
-  auto module = py::handle(dist_module).cast<py::module>();
+  auto module = py::handle(autograd_module).cast<py::module>();
 
   auto distAutogradContext =
       shared_ptr_class_<DistAutogradContext>(module, "DistAutogradContext")

--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -23,12 +23,13 @@ template <typename T>
 using shared_ptr_class_ = py::class_<T, std::shared_ptr<T>>;
 
 PyObject* rpc_init(PyObject* /* unused */) {
-  auto dist_module = THPObjectPtr(PyImport_ImportModule("torch.distributed"));
-  if (!dist_module) {
+  auto rpc_module =
+      THPObjectPtr(PyImport_ImportModule("torch.distributed.rpc"));
+  if (!rpc_module) {
     throw python_error();
   }
 
-  auto module = py::handle(dist_module).cast<py::module>();
+  auto module = py::handle(rpc_module).cast<py::module>();
 
   auto workerInfo = shared_ptr_class_<WorkerInfo>(module, "WorkerInfo")
                         .def_readonly("name", &WorkerInfo::name_)

--- a/torch/distributed/__init__.py
+++ b/torch/distributed/__init__.py
@@ -4,12 +4,11 @@ import torch
 
 
 def is_available():
-    return (hasattr(torch._C, "_c10d_init") and hasattr(torch._C, "_rpc_init")
-            and hasattr(torch._C, "_dist_autograd_init"))
+    return hasattr(torch._C, "_c10d_init")
 
 
-if is_available() and not (torch._C._c10d_init() and torch._C._rpc_init() and torch._C._dist_autograd_init()):
-    raise RuntimeError("Failed to initialize PyTorch distributed support")
+if is_available() and not torch._C._c10d_init():
+    raise RuntimeError("Failed to initialize torch.distributed")
 
 
 if is_available():

--- a/torch/distributed/autograd/__init__.py
+++ b/torch/distributed/autograd/__init__.py
@@ -1,5 +1,17 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import sys
+import torch
+
+
+def is_available():
+    return sys.version_info >= (3, 0) and hasattr(torch._C, "_dist_autograd_init")
+
+
+if is_available() and not torch._C._dist_autograd_init():
+    raise RuntimeError("Failed to initialize torch.distributed.autograd")
+
+
 class context(object):
     '''
     Autograd context object to wrap forward and backward passes when using

--- a/torch/distributed/rpc/__init__.py
+++ b/torch/distributed/rpc/__init__.py
@@ -1,11 +1,21 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import sys
+import torch
+
 
 from .backend_registry import *  # noqa: F401
 
 
-if sys.version_info >= (3, 0):
+def is_available():
+    return sys.version_info >= (3, 0) and hasattr(torch._C, "_rpc_init")
+
+
+if is_available() and not torch._C._rpc_init():
+    raise RuntimeError("Failed to initialize torch.distributed.rpc")
+
+
+if is_available():
     from .api import _init_rpc
     from .api import *  # noqa: F401
     import torch.distributed.autograd

--- a/torch/distributed/rpc/api.py
+++ b/torch/distributed/rpc/api.py
@@ -1,8 +1,8 @@
-from torch.distributed import invoke_rpc_builtin, invoke_rpc_python_udf
-from torch.distributed import invoke_remote_builtin, invoke_remote_python_udf
-from torch.distributed import _init_rref_context, _destroy_rref_context
-from torch.distributed import ProcessGroupAgent
-from torch.distributed import WorkerInfo
+from . import invoke_rpc_builtin, invoke_rpc_python_udf
+from . import invoke_remote_builtin, invoke_remote_python_udf
+from . import _init_rref_context, _destroy_rref_context
+from . import ProcessGroupAgent
+from . import WorkerInfo
 from .backend_registry import is_backend_registered, init_backend
 from .internal import _internal_rpc_pickler, PythonUDF
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #27485 Run clang-format for torch/distributed/rpc
* #27484 Rename PythonUDF{Call,Resp}
* **#27483 Scope pybind11 functions to torch.distributed.{autograd,rpc}**
* #27288 Move RPC backend registry to torch.distributed.rpc
* #27287 Remove torch.distributed.rpc function
* #27286 Rename variables and add comments
* #27285 Remove shebang from non-executable files in torch.distributed
* #27284 Fix pybind11 warnings in python_rpc_handler.cpp

