### PR TITLE
Run clang-format for torch/distributed/rpc

### DIFF
--- a/torch/csrc/distributed/rpc/process_group_agent.cpp
+++ b/torch/csrc/distributed/rpc/process_group_agent.cpp
@@ -1,4 +1,5 @@
 #include <torch/csrc/distributed/rpc/process_group_agent.h>
+
 #include <c10/util/C++17.h>
 #include <c10d/ProcessGroup.hpp>
 #include <torch/csrc/distributed/rpc/request_callback_impl.h>

--- a/torch/csrc/distributed/rpc/python_functions.cpp
+++ b/torch/csrc/distributed/rpc/python_functions.cpp
@@ -1,13 +1,12 @@
 #include <torch/csrc/distributed/rpc/python_functions.h>
+
 #include <c10/util/C++17.h>
 #include <torch/csrc/distributed/autograd/context/dist_autograd_container.h>
 #include <torch/csrc/distributed/autograd/utils.h>
-#include <torch/csrc/distributed/rpc/python_call.h>
-#include <torch/csrc/distributed/rpc/python_resp.h>
-#include <torch/csrc/distributed/rpc/utils.h>
-
 #include <torch/csrc/distributed/rpc/message.h>
+#include <torch/csrc/distributed/rpc/python_call.h>
 #include <torch/csrc/distributed/rpc/python_remote_call.h>
+#include <torch/csrc/distributed/rpc/python_resp.h>
 #include <torch/csrc/distributed/rpc/python_rpc_handler.h>
 #include <torch/csrc/distributed/rpc/rref.h>
 #include <torch/csrc/distributed/rpc/rref_context.h>
@@ -15,7 +14,7 @@
 #include <torch/csrc/distributed/rpc/script_call.h>
 #include <torch/csrc/distributed/rpc/script_remote_call.h>
 #include <torch/csrc/distributed/rpc/script_resp.h>
-
+#include <torch/csrc/distributed/rpc/utils.h>
 #include <torch/csrc/jit/pybind_utils.h>
 
 namespace torch {

--- a/torch/csrc/distributed/rpc/request_callback.cpp
+++ b/torch/csrc/distributed/rpc/request_callback.cpp
@@ -1,4 +1,5 @@
 #include <torch/csrc/distributed/rpc/request_callback.h>
+
 #include <torch/csrc/distributed/autograd/context/dist_autograd_container.h>
 #include <torch/csrc/distributed/autograd/utils.h>
 

--- a/torch/csrc/distributed/rpc/request_callback_impl.cpp
+++ b/torch/csrc/distributed/rpc/request_callback_impl.cpp
@@ -1,4 +1,5 @@
 #include <torch/csrc/distributed/rpc/request_callback_impl.h>
+
 #include <c10/util/C++17.h>
 #include <torch/csrc/distributed/autograd/context/dist_autograd_container.h>
 #include <torch/csrc/distributed/autograd/context/dist_autograd_context.h>

--- a/torch/csrc/distributed/rpc/rpc_with_autograd.cpp
+++ b/torch/csrc/distributed/rpc/rpc_with_autograd.cpp
@@ -1,4 +1,5 @@
 #include <torch/csrc/distributed/rpc/rpc_with_autograd.h>
+
 #include <c10/util/C++17.h>
 #include <torch/csrc/distributed/rpc/utils.h>
 #include <torch/csrc/utils/byte_order.h>

--- a/torch/csrc/distributed/rpc/script_remote_call.cpp
+++ b/torch/csrc/distributed/rpc/script_remote_call.cpp
@@ -1,4 +1,5 @@
 #include <torch/csrc/distributed/rpc/script_remote_call.h>
+
 #include <c10/util/C++17.h>
 #include <torch/csrc/jit/pickle.h>
 

--- a/torch/csrc/distributed/rpc/script_resp.cpp
+++ b/torch/csrc/distributed/rpc/script_resp.cpp
@@ -1,4 +1,5 @@
 #include <torch/csrc/distributed/rpc/script_resp.h>
+
 #include <c10/util/C++17.h>
 #include <torch/csrc/jit/pickle.h>
 #include <torch/csrc/jit/unpickler.h>

--- a/torch/csrc/distributed/rpc/script_rref_proto.cpp
+++ b/torch/csrc/distributed/rpc/script_rref_proto.cpp
@@ -1,4 +1,5 @@
 #include <torch/csrc/distributed/rpc/script_rref_proto.h>
+
 #include <c10/util/C++17.h>
 #include <torch/csrc/jit/pickle.h>
 

--- a/torch/csrc/distributed/rpc/utils.cpp
+++ b/torch/csrc/distributed/rpc/utils.cpp
@@ -1,4 +1,5 @@
 #include <torch/csrc/distributed/rpc/utils.h>
+
 #include <torch/csrc/distributed/rpc/python_call.h>
 #include <torch/csrc/distributed/rpc/python_remote_call.h>
 #include <torch/csrc/distributed/rpc/python_resp.h>


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#27485 Run clang-format for torch/distributed/rpc**
* #27484 Rename PythonUDF{Call,Resp}
* #27483 Scope pybind11 functions to torch.distributed.{autograd,rpc}
* #27288 Move RPC backend registry to torch.distributed.rpc
* #27287 Remove torch.distributed.rpc function
* #27286 Rename variables and add comments
* #27285 Remove shebang from non-executable files in torch.distributed
* #27284 Fix pybind11 warnings in python_rpc_handler.cpp

