### PR TITLE
FunctionEventAvg implements __iadd__ interface

### DIFF
--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -613,6 +613,9 @@ class FunctionEventAvg(FormattedTimesMixin):
         self.count += 1
         return self
 
+    def __iadd__(self, other):
+        return self.add(other)
+
     def __repr__(self):
         return (
             '<FunctionEventAvg key={} self_cpu_time={} cpu_time={} '


### PR DESCRIPTION
Resolving issue https://github.com/pytorch/pytorch/issues/26433 by making FunctionEventAvg implement the `__iadd__` interface again, like it used to.