### PR TITLE
Add sphinx class tag

### DIFF
--- a/torch/nn/intrinsic/qat/modules/conv_fused.py
+++ b/torch/nn/intrinsic/qat/modules/conv_fused.py
@@ -183,7 +183,7 @@ class ConvBnReLU2d(ConvBn2d):
 
     Implementation details: https://arxiv.org/pdf/1806.08342.pdf
 
-    Similar to `torch.nn.Conv2d`, with FakeQuantize modules initialized to
+    Similar to :class:`torch.nn.Conv2d`, with FakeQuantize modules initialized to
     default.
 
     Attributes:


### PR DESCRIPTION
Adding the sphinx class tag here so the docs will link out to the torch.nn.Conv2d class. Feel free to close if leaving it off was intentional.



cc @albanD @mruberry @jbschlosser @walterddr