### PR TITLE
Add sphinx class tag

### DIFF
--- a/torch/nn/qat/modules/conv.py
+++ b/torch/nn/qat/modules/conv.py
@@ -11,7 +11,7 @@ class Conv2d(NNConv2d):
     https://pytorch.org/docs/stable/nn.html?highlight=conv2d#torch.nn.Conv2d
     for documentation.
 
-    Similar to `torch.nn.Conv2d`, with FakeQuantize modules initialized to
+    Similar to :class:`torch.nn.Conv2d`, with FakeQuantize modules initialized to
     default.
 
     Attributes:


### PR DESCRIPTION
Adding the sphinx class tag here so the docs will link out to the torch.nn.Conv2d class. Feel free to close if leaving it off was intentional.



cc @albanD @mruberry @jbschlosser @walterddr