### PR TITLE
[jit] Set existing attributes under recursive script

### DIFF
--- a/torch/jit/_recursive.py
+++ b/torch/jit/_recursive.py
@@ -60,7 +60,7 @@ def copy_to_script_module(original, stubs):
     for name in dir(original):
         if hasattr(script_module, name):
             # Only re-copy existing attributes
-            if script_module._c._has_attribute(name):
+            if script_module._c._has_attribute(name) and name not in constants_set:
                 item = getattr(original, name)
                 setattr(script_module, name, item)
                 script_module._c._set_attribute(name, item)

--- a/torch/jit/_recursive.py
+++ b/torch/jit/_recursive.py
@@ -59,7 +59,11 @@ def copy_to_script_module(original, stubs):
     class_annotations = getattr(original, '__annotations__', {})
     for name in dir(original):
         if hasattr(script_module, name):
-            # Don't re-copy properties
+            # Only re-copy existing attributes
+            if script_module._c._has_attribute(name):
+                item = getattr(original, name)
+                setattr(script_module, name, item)
+                script_module._c._set_attribute(name, item)
             continue
         item = getattr(original, name)
         if name in class_annotations:


### PR DESCRIPTION


This is related to #27109, `training` was being skipped since modules
have it as an attribute by default, but it should be copied anyways.

Differential Revision: [D17802544](https://our.internmc.facebook.com/intern/diff/17802544/)