### PR TITLE
[JIT] Use orig source range in Node::print

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -4034,6 +4034,20 @@ def foo(xyz):
         with self.assertRaisesRegex(RuntimeError, 'test_jit.py:{}'.format(lineno + 3)):
             loaded(torch.rand(3, 4), torch.rand(30, 40))
 
+    def test_serialized_source_ranges_graph(self):
+
+        class FooTest3(torch.jit.ScriptModule):
+            @torch.jit.script_method
+            def forward(self, x, w):
+                return torch.mm(x, w.t())
+
+        ft = FooTest3()
+        loaded = self.getExportImportCopy(ft)
+        _, lineno = inspect.getsourcelines(FooTest3)
+
+        fc = FileCheck().check('test_jit.py:{}'.format(lineno + 3))
+        fc.run(loaded.graph)
+
     def test_serialized_source_ranges2(self):
 
         class FooTest2(torch.jit.ScriptModule):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -3995,7 +3995,8 @@ def foo(x):
         bytesio = io.BytesIO(buffer)
         scripted = torch.jit.load(bytesio)
 
-        fc = FileCheck().check(':7:11')
+        _, lineno = inspect.getsourcelines(Scripted)
+        fc = FileCheck().check(':{}'.format(lineno + 3))
         fc.run(scripted.graph)
         fc.run(str(scripted.graph))
 

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -273,8 +273,10 @@ std::ostream &Node::print(std::ostream &out, size_t level,
   // In debug print, append file:line:col as a comment after each node
   if (print_source_locations) {
     SourceRange r = sourceRange();
-    if (auto orig = sourceRange().source()->findSourceRangeThatGenerated(r)) {
-      r = *orig;
+    if (sourceRange().source()) {
+      if (auto orig = sourceRange().source()->findSourceRangeThatGenerated(r)) {
+        r = *orig;
+      }
     }
     if (auto file_line_col = r.file_line_col()) {
       std::string filename;

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -272,7 +272,11 @@ std::ostream &Node::print(std::ostream &out, size_t level,
 
   // In debug print, append file:line:col as a comment after each node
   if (print_source_locations) {
-    if (auto file_line_col = sourceRange().file_line_col()) {
+    SourceRange r = sourceRange();
+    if (auto orig = sourceRange().source()->findSourceRangeThatGenerated(r)) {
+      r = *orig;
+    }
+    if (auto file_line_col = r.file_line_col()) {
       std::string filename;
       size_t line, col;
       std::tie(filename, line, col) = *file_line_col;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#27524 [JIT] Use orig source range in Node::print**

Differential Revision: [D17806454](https://our.internmc.facebook.com/intern/diff/D17806454)