### PR TITLE
Fix compilation error when buildng with FFMPEG

### DIFF
--- a/caffe2/video/video_decoder.cc
+++ b/caffe2/video/video_decoder.cc
@@ -3,6 +3,7 @@
 #include <caffe2/core/logging.h>
 #include <mutex>
 #include <random>
+#include <array>
 
 namespace caffe2 {
 

--- a/caffe2/video/video_input_op.h
+++ b/caffe2/video/video_input_op.h
@@ -574,7 +574,7 @@ bool VideoInputOp<Context>::GetImageAndLabelsFromDBValue(
             CV_8UC1,
             const_cast<char*>(encoded_image_str.data())),
         cv::IMREAD_COLOR);
-    if (src.rows == 0 or src.cols == 0) {
+    if (src.rows == 0 || src.cols == 0) {
       throw std::runtime_error("Both rows and cols are 0 for image");
     }
   } else if (image_proto.data_type() == TensorProto::BYTE) {

--- a/cmake/Modules/FindFFmpeg.cmake
+++ b/cmake/Modules/FindFFmpeg.cmake
@@ -39,6 +39,11 @@ else (FFMPEG_LIBRARIES AND FFMPEG_INCLUDE_DIR)
     PATHS ${_FFMPEG_SWSCALE_LIBRARY_DIRS} /usr/lib /usr/local/lib /opt/local/lib /sw/lib
   )
 
+  find_library(FFMPEG_LIBSWRESAMPLE
+    NAMES swresample
+    PATHS ${_FFMPEG_SWSCALE_LIBRARY_DIRS} /usr/lib /usr/local/lib /opt/local/lib /sw/lib
+  )
+
   if (FFMPEG_LIBAVCODEC AND FFMPEG_LIBAVFORMAT)
     set(FFMPEG_FOUND TRUE)
   endif()
@@ -51,6 +56,7 @@ else (FFMPEG_LIBRARIES AND FFMPEG_INCLUDE_DIR)
       ${FFMPEG_LIBAVFORMAT}
       ${FFMPEG_LIBAVUTIL}
       ${FFMPEG_LIBSWSCALE}
+      ${FFMPEG_LIBSWRESAMPLE}
     )
 
     if (NOT FFMPEG_FIND_QUIETLY)


### PR DESCRIPTION
When building with FFMPEG, I encountered compilation error due to missing include/library.
I also find the change in video_input_op.h will improve build on Windows.