### PR TITLE
[mobile][quantization] Add quantized avg_pool2d for pytorch mobile

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/q_avgpool.cpp
+++ b/aten/src/ATen/native/quantized/cpu/q_avgpool.cpp
@@ -2,7 +2,10 @@
 #include <ATen/NativeFunctions.h>
 #include <ATen/Parallel.h>
 #include <ATen/native/Pool.h>
+#include <ATen/native/quantized/cpu/init_qnnpack.h>
+#include <ATen/native/quantized/cpu/qnnpack_utils.h>
 #include <ATen/native/quantized/cpu/quantized_ops.h>
+#include <caffe2/utils/threadpool/ThreadPoolMobile.h>
 
 #include <algorithm>
 #include <cmath>
@@ -282,7 +285,100 @@ Tensor q_avg_pool2d(
     return output;
   }
 }
+#ifdef USE_PYTORCH_QNNPACK
+Tensor qnnpack_avg_pool2d(
+    Tensor input,
+    IntArrayRef kernel_size,
+    IntArrayRef stride,
+    IntArrayRef padding,
+    bool ceil_mode,
+    bool count_include_pad,
+    c10::optional<int64_t> divisor_override) {
+  Tensor output;
+  int kW, kH, dW, dH, padW, padH;
+  std::tie(kW, kH) = get_kernel(kernel_size);
+  std::tie(dW, dH) = get_stride(stride, kW, kH);
+  std::tie(padW, padH) = get_padding(padding);
+  TORCH_CHECK(
+      input.ndimension() == 4,
+      "qnnpack_avg_pool2d(): Expected input to be 4-dimensional: got ",
+      input.ndimension());
 
+  int64_t batch_size = input.size(0);
+  int64_t inC = input.size(1);
+  int64_t inH = input.size(2);
+  int64_t inW = input.size(3);
+  auto output_shape =
+      get_output_shape(input, kW, kH, dW, dH, padW, padH, ceil_mode);
+  const int64_t oH = output_shape[output_shape.size() - 2];
+  const int64_t oW = output_shape[output_shape.size() - 1];
+  const auto outC = inC;
+
+  Tensor input_contig = input.permute({0, 2, 3, 1}).contiguous();
+
+  initQNNPACK();
+  const auto scale = input_contig.q_scale();
+  const auto zero_point = input_contig.q_zero_point();
+  TORCH_CHECK(
+      oH > 0 && oW > 0,
+      "qnnpack_avg_pool2d(): the resulting output Tensor size should be >= 0");
+  // NHWC output
+  output = at::_empty_affine_quantized(
+      {batch_size, oH, oW, outC},
+      at::device(kCPU).dtype(kQUInt8),
+      scale,
+      zero_point);
+
+  pytorch_qnnp_operator_t qnnpack_operator{nullptr};
+  const pytorch_qnnp_status createStatus =
+      pytorch_qnnp_create_average_pooling2d_nhwc_q8(
+          padH /* input_padding_top */,
+          padW /* input_padding_right */,
+          padH /* input_padding_bottom */,
+          padW /* input_padding_left */,
+          kH /* kernel height */,
+          kW /* kernel width */,
+          dH /* stride height */,
+          dW /* stride width */,
+          inC /* input channels */,
+          zero_point /* input zero_point */,
+          scale /* input scale */,
+          zero_point /* output zero_point */,
+          scale /* output scale */,
+          std::numeric_limits<uint8_t>::min() /* output min */,
+          std::numeric_limits<uint8_t>::max() /* output max */,
+          0 /* flags */,
+          &qnnpack_operator);
+  CAFFE_ENFORCE(
+      createStatus == pytorch_qnnp_status_success,
+      "failed to create QNNPACK Average Pooling operator");
+  std::unique_ptr<pytorch_qnnp_operator, QnnpackOperatorDeleter>
+      qnnpack_uniq_ptr(qnnpack_operator);
+
+  const pytorch_qnnp_status setupStatus =
+      pytorch_qnnp_setup_average_pooling2d_nhwc_q8(
+          qnnpack_operator,
+          batch_size,
+          inH,
+          inW,
+          (uint8_t*)input_contig.data_ptr<c10::quint8>() /* input data */,
+          inC,
+          (uint8_t*)output.data_ptr<c10::quint8>() /* output data */,
+          outC,
+          nullptr /* thread pool */);
+  CAFFE_ENFORCE(
+      setupStatus == pytorch_qnnp_status_success,
+      "failed to setup QNNPACK Average Pooling operator");
+  pthreadpool_t threadpool = caffe2::mobile_pthreadpool();
+  const pytorch_qnnp_status runStatus =
+      pytorch_qnnp_run_operator(qnnpack_operator, threadpool);
+  TORCH_INTERNAL_ASSERT(
+      runStatus == pytorch_qnnp_status_success,
+      "failed to run QNNPACK Average Pool operator");
+  // TODO: remove permute once MemoryLayout is added above
+  return output.permute({0, 3, 1, 2});
+#endif
+}
 } // namespace
 
 Tensor quantized_avg_pool2d(
@@ -294,6 +390,19 @@ Tensor quantized_avg_pool2d(
     bool count_include_pad,
     c10::optional<int64_t> divisor_override) {
   Tensor output;
+#ifdef USE_PYTORCH_QNNPACK
+  if (at::globalContext().qEngine() == at::QEngine::QNNPACK &&
+      input.scalar_type() == kQUInt8) {
+    return qnnpack_avg_pool2d(
+        input,
+        kernel_size,
+        stride,
+        padding,
+        ceil_mode,
+        count_include_pad,
+        divisor_override);
+  }
+#endif
   AT_DISPATCH_QINT_TYPES(input.scalar_type(), "quantized_avg_pool2d", [&]() {
     output = q_avg_pool2d<scalar_t>(
         input,

--- a/aten/src/ATen/native/quantized/cpu/q_avgpool.cpp
+++ b/aten/src/ATen/native/quantized/cpu/q_avgpool.cpp
@@ -377,8 +377,8 @@ Tensor qnnpack_avg_pool2d(
       "failed to run QNNPACK Average Pool operator");
   // TODO: remove permute once MemoryLayout is added above
   return output.permute({0, 3, 1, 2});
-#endif
 }
+#endif
 } // namespace
 
 Tensor quantized_avg_pool2d(

--- a/test/test_quantized.py
+++ b/test/test_quantized.py
@@ -557,9 +557,9 @@ class TestQuantizedOps(TestCase):
 
     @given(X=hu.tensor(shapes=hu.array_shapes(min_dims=4, max_dims=4,
                                               min_side=5, max_side=10),
-                       qparams=hu.qparams(dtypes=torch.quint8)),
+                       qparams=hu.qparams(dtypes=torch.qint8)),
            kernel=st.sampled_from((4, 5)),
-           stride=st.sampled_from((None, 1, 2)),
+           stride=st.sampled_from((1, 2)),
            padding=st.integers(0, 2),
            ceil_mode=st.sampled_from((True, False)),
            count_include_pad=st.sampled_from((True, False)),
@@ -578,6 +578,8 @@ class TestQuantizedOps(TestCase):
             if (qengine == 'qnnpack'):
                 ceil_mode = False
                 count_include_pad = True
+                torch_type = torch.quint8
+
             if X.shape[1] < 176:
                 X = np.repeat(X, 176 / X.shape[1], 1)
             X_nchw = np.ascontiguousarray(X.transpose([0, 2, 3, 1]))

--- a/test/test_quantized.py
+++ b/test/test_quantized.py
@@ -503,100 +503,108 @@ class TestQuantizedOps(TestCase):
     @given(X=hu.tensor(shapes=hu.array_shapes(min_dims=3, max_dims=4,
                                               min_side=5, max_side=10),
                        qparams=hu.qparams(dtypes=torch.quint8)),
-           kernel=st.sampled_from((3, 5)),
-           stride=st.sampled_from((None, 1, 2)),
+           kernel=st.sampled_from((2, 3, 5)),
+           stride=st.sampled_from((1, 2)),
            padding=st.integers(0, 2),
            ceil_mode=st.sampled_from((True, False)),
            count_include_pad=st.sampled_from((True, False)),
-           divisor_override=st.sampled_from((None, None)))
-    def test_avg_pool2d(self, X, kernel, stride, padding, ceil_mode, count_include_pad, divisor_override):
+           divisor_override=st.sampled_from((None, None)),
+           qengine=st.sampled_from(("qnnpack", "none")))
+    def test_avg_pool2d(self, X, kernel, stride, padding, ceil_mode, count_include_pad, divisor_override, qengine):
         """
         Note: we currently cannot test the divisor_override, because quantized op will clamp the result
         within range. However, the float op will not.
         """
-        X, (scale, zero_point, torch_type) = X
+        with override_quantized_engine(qengine):
+          X, (scale, zero_point, torch_type) = X
 
-        assume(kernel // 2 >= padding)  # Kernel cannot be overhanging!
-        iH, iW = X.shape[-2:]
-        oH = pool_output_shape(iH, kernel, padding, stride, 0)
-        assume(oH > 0)
-        oW = pool_output_shape(iW, kernel, padding, stride, 0)
-        assume(oW > 0)
+          if (qengine == 'qnnpack'):
+              ceil_mode = False
+              count_include_pad = True
+              divisor_override = None
+              assume(len(X.shape) == 4)
+          assume(kernel // 2 >= padding)  # Kernel cannot be overhanging!
+          iH, iW = X.shape[-2:]
+          oH = pool_output_shape(iH, kernel, padding, stride, 0)
+          assume(oH > 0)
+          oW = pool_output_shape(iW, kernel, padding, stride, 0)
+          assume(oW > 0)
 
-        X = torch.from_numpy(X)
-        qX = torch.quantize_per_tensor(X, scale=scale, zero_point=zero_point,
-                                       dtype=torch_type)
+          X = torch.from_numpy(X)
+          qX = torch.quantize_per_tensor(X, scale=scale, zero_point=zero_point,
+                                         dtype=torch_type)
 
-        # Run reference on int_repr + round to avoid double rounding error.
-        X_ref = torch.nn.functional.avg_pool2d(
-            qX.int_repr().to(torch.float), kernel_size=kernel, stride=stride, padding=padding,
-            ceil_mode=ceil_mode, count_include_pad=count_include_pad, divisor_override=divisor_override).round()
+          # Run reference on int_repr + round to avoid double rounding error.
+          X_ref = torch.nn.functional.avg_pool2d(
+              qX.int_repr().to(torch.float), kernel_size=kernel, stride=stride, padding=padding,
+              ceil_mode=ceil_mode, count_include_pad=count_include_pad, divisor_override=divisor_override).round()
 
-        ops_under_test = {
-            "nn.functional": torch.nn.functional.avg_pool2d,
-            "nn.quantized.functional": torch.nn.quantized.functional.avg_pool2d
-        }
-        error_message = r"Results are off for {}:\n\tExpected:\n{}\n\tGot:\n{}"
-        for name, op in ops_under_test.items():
-            qX_hat = op(qX, kernel_size=kernel, stride=stride, padding=padding, ceil_mode=ceil_mode,
-                        count_include_pad=count_include_pad, divisor_override=divisor_override)
-            self.assertEqual(X_ref, qX_hat.int_repr(), prec=1.0,
-                             message="{} results are off".format(name, qX_hat.int_repr(), X_ref))
-            self.assertEqual(scale, qX_hat.q_scale(),
-                             message=error_message.format(name + '.scale', scale, qX_hat.q_scale()))
-            self.assertEqual(zero_point, qX_hat.q_zero_point(),
-                             message=error_message.format(name + '.zero_point', scale,
-                                                          qX_hat.q_zero_point()))
+          ops_under_test = {
+              "nn.functional": torch.nn.functional.avg_pool2d,
+              "nn.quantized.functional": torch.nn.quantized.functional.avg_pool2d
+          }
+          error_message = r"Results are off for {}:\n\tExpected:\n{}\n\tGot:\n{}"
+          for name, op in ops_under_test.items():
+              qX_hat = op(qX, kernel_size=kernel, stride=stride, padding=padding, ceil_mode=ceil_mode,
+                          count_include_pad=count_include_pad, divisor_override=divisor_override)
+              self.assertEqual(X_ref, qX_hat.int_repr(), prec=1.0,
+                               message="{} results are off".format(name, qX_hat.int_repr(), X_ref))
+              self.assertEqual(scale, qX_hat.q_scale(),
+                               message=error_message.format(name + '.scale', scale, qX_hat.q_scale()))
+              self.assertEqual(zero_point, qX_hat.q_zero_point(),
+                               message=error_message.format(name + '.zero_point', scale,
+                                                            qX_hat.q_zero_point()))
 
     @given(X=hu.tensor(shapes=hu.array_shapes(min_dims=4, max_dims=4,
                                               min_side=5, max_side=10),
-                       qparams=hu.qparams(dtypes=torch.qint8)),
+                       qparams=hu.qparams(dtypes=torch.quint8)),
            kernel=st.sampled_from((4, 5)),
            stride=st.sampled_from((None, 1, 2)),
            padding=st.integers(0, 2),
            ceil_mode=st.sampled_from((True, False)),
            count_include_pad=st.sampled_from((True, False)),
-           divisor_override=st.sampled_from((None, None)))
-    def test_avg_pool2d_nhwc(self, X, kernel, stride, padding, ceil_mode, count_include_pad, divisor_override):
+           divisor_override=st.sampled_from((None, None)),
+           qengine=st.sampled_from(("qnnpack", "none")))
+    def test_avg_pool2d_nhwc(self, X, kernel, stride, padding, ceil_mode, count_include_pad, divisor_override, qengine):
         """
         Note: 1) we currently cannot test the divisor_override, because quantized op will clamp the result
         within range. However, the float op will not.
         2) we cannot test the qint32, since the float point precision is much lower than int32 for big number,
         which will make the test be very flaky.
         """
-        X, (scale, zero_point, torch_type) = X
-        H, W = X.shape[-2:]
+        with override_quantized_engine(qengine):
+          X, (scale, zero_point, torch_type) = X
+          H, W = X.shape[-2:]
+          if (qengine == 'qnnpack'):
+              ceil_mode = False
+              count_include_pad = True
+          if X.shape[1] < 176:
+              X = np.repeat(X, 176 / X.shape[1], 1)
+          X_nchw = np.ascontiguousarray(X.transpose([0, 2, 3, 1]))
+          qX = torch.quantize_per_tensor(torch.from_numpy(X_nchw), scale=scale,
+                                         zero_point=zero_point, dtype=torch_type).permute([0, 3, 1, 2])
+          # Run reference on int_repr + round to avoid double rounding error.
+          X_ref = torch.nn.functional.avg_pool2d(
+              qX.int_repr().to(torch.double), kernel_size=kernel, stride=stride, padding=padding,
+              ceil_mode=ceil_mode, count_include_pad=count_include_pad, divisor_override=divisor_override).round()
 
-        if X.shape[1] < 176:
-            X = np.repeat(X, 176 / X.shape[1], 1)
-
-        X_nchw = np.ascontiguousarray(X.transpose([0, 2, 3, 1]))
-        X = torch.from_numpy(X_nchw).permute([0, 3, 1, 2])
-        qX = torch.quantize_per_tensor(torch.from_numpy(X_nchw), scale=scale,
-                                       zero_point=zero_point, dtype=torch_type).permute([0, 3, 1, 2])
-
-        # Run reference on int_repr + round to avoid double rounding error.
-        X_ref = torch.nn.functional.avg_pool2d(
-            qX.int_repr().to(torch.double), kernel_size=kernel, stride=stride, padding=padding,
-            ceil_mode=ceil_mode, count_include_pad=count_include_pad, divisor_override=divisor_override).round()
-
-        self.assertTrue(qX.stride() != sorted(qX.stride()))
-        ops_under_test = {
-            "nn.functional": torch.nn.functional.avg_pool2d,
-            "nn.quantized.functional": torch.nn.quantized.functional.avg_pool2d
-        }
-        error_message = r"Results are off for {}:\n\tExpected:\n{}\n\tGot:\n{}"
-        for name, op in ops_under_test.items():
-            X_hat = op(qX, kernel_size=kernel, stride=stride, padding=padding, ceil_mode=ceil_mode,
-                       count_include_pad=count_include_pad, divisor_override=divisor_override)
-            self.assertTrue(X_hat.stride() != sorted(X_hat.stride()))
-            self.assertEqual(X_ref, X_hat.int_repr().to(torch.double), prec=1.0,
-                             message="{} results are off".format(name))
-            self.assertEqual(scale, X_hat.q_scale(),
-                             message=error_message.format(name + '.scale', scale, X_hat.q_scale()))
-            self.assertEqual(zero_point, X_hat.q_zero_point(),
-                             message=error_message.format(name + '.zero_point', scale,
-                             X_hat.q_zero_point()))
+          self.assertTrue(qX.stride() != sorted(qX.stride()))
+          ops_under_test = {
+              "nn.functional": torch.nn.functional.avg_pool2d,
+              "nn.quantized.functional": torch.nn.quantized.functional.avg_pool2d
+          }
+          error_message = r"Results are off for {}:\n\tExpected:\n{}\n\tGot:\n{}"
+          for name, op in ops_under_test.items():
+              X_hat = op(qX, kernel_size=kernel, stride=stride, padding=padding, ceil_mode=ceil_mode,
+                         count_include_pad=count_include_pad, divisor_override=divisor_override)
+              self.assertTrue(X_hat.stride() != sorted(X_hat.stride()))
+              self.assertEqual(X_ref, X_hat.int_repr().to(torch.double), prec=1.0,
+                               message="{} results are off".format(name))
+              self.assertEqual(scale, X_hat.q_scale(),
+                               message=error_message.format(name + '.scale', scale, X_hat.q_scale()))
+              self.assertEqual(zero_point, X_hat.q_zero_point(),
+                               message=error_message.format(name + '.zero_point', scale,
+                               X_hat.q_zero_point()))
 
     @no_deadline
     @given(X=hu.tensor(shapes=hu.array_shapes(min_dims=4, max_dims=4,

--- a/test/test_quantized.py
+++ b/test/test_quantized.py
@@ -516,44 +516,44 @@ class TestQuantizedOps(TestCase):
         within range. However, the float op will not.
         """
         with override_quantized_engine(qengine):
-          X, (scale, zero_point, torch_type) = X
+            X, (scale, zero_point, torch_type) = X
 
-          if (qengine == 'qnnpack'):
-              ceil_mode = False
-              count_include_pad = True
-              divisor_override = None
-              assume(len(X.shape) == 4)
-          assume(kernel // 2 >= padding)  # Kernel cannot be overhanging!
-          iH, iW = X.shape[-2:]
-          oH = pool_output_shape(iH, kernel, padding, stride, 0)
-          assume(oH > 0)
-          oW = pool_output_shape(iW, kernel, padding, stride, 0)
-          assume(oW > 0)
+            if (qengine == 'qnnpack'):
+                ceil_mode = False
+                count_include_pad = True
+                divisor_override = None
+                assume(len(X.shape) == 4)
+            assume(kernel // 2 >= padding)  # Kernel cannot be overhanging!
+            iH, iW = X.shape[-2:]
+            oH = pool_output_shape(iH, kernel, padding, stride, 0)
+            assume(oH > 0)
+            oW = pool_output_shape(iW, kernel, padding, stride, 0)
+            assume(oW > 0)
 
-          X = torch.from_numpy(X)
-          qX = torch.quantize_per_tensor(X, scale=scale, zero_point=zero_point,
-                                         dtype=torch_type)
+            X = torch.from_numpy(X)
+            qX = torch.quantize_per_tensor(X, scale=scale, zero_point=zero_point,
+                                           dtype=torch_type)
 
-          # Run reference on int_repr + round to avoid double rounding error.
-          X_ref = torch.nn.functional.avg_pool2d(
-              qX.int_repr().to(torch.float), kernel_size=kernel, stride=stride, padding=padding,
-              ceil_mode=ceil_mode, count_include_pad=count_include_pad, divisor_override=divisor_override).round()
+            # Run reference on int_repr + round to avoid double rounding error.
+            X_ref = torch.nn.functional.avg_pool2d(
+                qX.int_repr().to(torch.float), kernel_size=kernel, stride=stride, padding=padding,
+                ceil_mode=ceil_mode, count_include_pad=count_include_pad, divisor_override=divisor_override).round()
 
-          ops_under_test = {
-              "nn.functional": torch.nn.functional.avg_pool2d,
-              "nn.quantized.functional": torch.nn.quantized.functional.avg_pool2d
-          }
-          error_message = r"Results are off for {}:\n\tExpected:\n{}\n\tGot:\n{}"
-          for name, op in ops_under_test.items():
-              qX_hat = op(qX, kernel_size=kernel, stride=stride, padding=padding, ceil_mode=ceil_mode,
-                          count_include_pad=count_include_pad, divisor_override=divisor_override)
-              self.assertEqual(X_ref, qX_hat.int_repr(), prec=1.0,
-                               message="{} results are off".format(name, qX_hat.int_repr(), X_ref))
-              self.assertEqual(scale, qX_hat.q_scale(),
-                               message=error_message.format(name + '.scale', scale, qX_hat.q_scale()))
-              self.assertEqual(zero_point, qX_hat.q_zero_point(),
-                               message=error_message.format(name + '.zero_point', scale,
-                                                            qX_hat.q_zero_point()))
+            ops_under_test = {
+                "nn.functional": torch.nn.functional.avg_pool2d,
+                "nn.quantized.functional": torch.nn.quantized.functional.avg_pool2d
+            }
+            error_message = r"Results are off for {}:\n\tExpected:\n{}\n\tGot:\n{}"
+            for name, op in ops_under_test.items():
+                qX_hat = op(qX, kernel_size=kernel, stride=stride, padding=padding, ceil_mode=ceil_mode,
+                            count_include_pad=count_include_pad, divisor_override=divisor_override)
+                self.assertEqual(X_ref, qX_hat.int_repr(), prec=1.0,
+                                 message="{} results are off".format(name, qX_hat.int_repr(), X_ref))
+                self.assertEqual(scale, qX_hat.q_scale(),
+                                 message=error_message.format(name + '.scale', scale, qX_hat.q_scale()))
+                self.assertEqual(zero_point, qX_hat.q_zero_point(),
+                                 message=error_message.format(name + '.zero_point', scale,
+                                                              qX_hat.q_zero_point()))
 
     @given(X=hu.tensor(shapes=hu.array_shapes(min_dims=4, max_dims=4,
                                               min_side=5, max_side=10),
@@ -573,38 +573,38 @@ class TestQuantizedOps(TestCase):
         which will make the test be very flaky.
         """
         with override_quantized_engine(qengine):
-          X, (scale, zero_point, torch_type) = X
-          H, W = X.shape[-2:]
-          if (qengine == 'qnnpack'):
-              ceil_mode = False
-              count_include_pad = True
-          if X.shape[1] < 176:
-              X = np.repeat(X, 176 / X.shape[1], 1)
-          X_nchw = np.ascontiguousarray(X.transpose([0, 2, 3, 1]))
-          qX = torch.quantize_per_tensor(torch.from_numpy(X_nchw), scale=scale,
-                                         zero_point=zero_point, dtype=torch_type).permute([0, 3, 1, 2])
-          # Run reference on int_repr + round to avoid double rounding error.
-          X_ref = torch.nn.functional.avg_pool2d(
-              qX.int_repr().to(torch.double), kernel_size=kernel, stride=stride, padding=padding,
-              ceil_mode=ceil_mode, count_include_pad=count_include_pad, divisor_override=divisor_override).round()
+            X, (scale, zero_point, torch_type) = X
+            H, W = X.shape[-2:]
+            if (qengine == 'qnnpack'):
+                ceil_mode = False
+                count_include_pad = True
+            if X.shape[1] < 176:
+                X = np.repeat(X, 176 / X.shape[1], 1)
+            X_nchw = np.ascontiguousarray(X.transpose([0, 2, 3, 1]))
+            qX = torch.quantize_per_tensor(torch.from_numpy(X_nchw), scale=scale,
+                                           zero_point=zero_point, dtype=torch_type).permute([0, 3, 1, 2])
+            # Run reference on int_repr + round to avoid double rounding error.
+            X_ref = torch.nn.functional.avg_pool2d(
+                qX.int_repr().to(torch.double), kernel_size=kernel, stride=stride, padding=padding,
+                ceil_mode=ceil_mode, count_include_pad=count_include_pad, divisor_override=divisor_override).round()
 
-          self.assertTrue(qX.stride() != sorted(qX.stride()))
-          ops_under_test = {
-              "nn.functional": torch.nn.functional.avg_pool2d,
-              "nn.quantized.functional": torch.nn.quantized.functional.avg_pool2d
-          }
-          error_message = r"Results are off for {}:\n\tExpected:\n{}\n\tGot:\n{}"
-          for name, op in ops_under_test.items():
-              X_hat = op(qX, kernel_size=kernel, stride=stride, padding=padding, ceil_mode=ceil_mode,
-                         count_include_pad=count_include_pad, divisor_override=divisor_override)
-              self.assertTrue(X_hat.stride() != sorted(X_hat.stride()))
-              self.assertEqual(X_ref, X_hat.int_repr().to(torch.double), prec=1.0,
-                               message="{} results are off".format(name))
-              self.assertEqual(scale, X_hat.q_scale(),
-                               message=error_message.format(name + '.scale', scale, X_hat.q_scale()))
-              self.assertEqual(zero_point, X_hat.q_zero_point(),
-                               message=error_message.format(name + '.zero_point', scale,
-                               X_hat.q_zero_point()))
+            self.assertTrue(qX.stride() != sorted(qX.stride()))
+            ops_under_test = {
+                "nn.functional": torch.nn.functional.avg_pool2d,
+                "nn.quantized.functional": torch.nn.quantized.functional.avg_pool2d
+            }
+            error_message = r"Results are off for {}:\n\tExpected:\n{}\n\tGot:\n{}"
+            for name, op in ops_under_test.items():
+                X_hat = op(qX, kernel_size=kernel, stride=stride, padding=padding, ceil_mode=ceil_mode,
+                           count_include_pad=count_include_pad, divisor_override=divisor_override)
+                self.assertTrue(X_hat.stride() != sorted(X_hat.stride()))
+                self.assertEqual(X_ref, X_hat.int_repr().to(torch.double), prec=1.0,
+                                 message="{} results are off".format(name))
+                self.assertEqual(scale, X_hat.q_scale(),
+                                 message=error_message.format(name + '.scale', scale, X_hat.q_scale()))
+                self.assertEqual(zero_point, X_hat.q_zero_point(),
+                                 message=error_message.format(name + '.zero_point', scale,
+                                 X_hat.q_zero_point()))
 
     @no_deadline
     @given(X=hu.tensor(shapes=hu.array_shapes(min_dims=4, max_dims=4,

--- a/test/test_quantized.py
+++ b/test/test_quantized.py
@@ -563,50 +563,42 @@ class TestQuantizedOps(TestCase):
            padding=st.integers(0, 2),
            ceil_mode=st.sampled_from((True, False)),
            count_include_pad=st.sampled_from((True, False)),
-           divisor_override=st.sampled_from((None, None)),
-           qengine=st.sampled_from(("qnnpack", "none")))
-    def test_avg_pool2d_nhwc(self, X, kernel, stride, padding, ceil_mode, count_include_pad, divisor_override, qengine):
+           divisor_override=st.sampled_from((None, None)))
+    def test_avg_pool2d_nhwc(self, X, kernel, stride, padding, ceil_mode, count_include_pad, divisor_override):
         """
         Note: 1) we currently cannot test the divisor_override, because quantized op will clamp the result
         within range. However, the float op will not.
         2) we cannot test the qint32, since the float point precision is much lower than int32 for big number,
         which will make the test be very flaky.
         """
-        with override_quantized_engine(qengine):
-            X, (scale, zero_point, torch_type) = X
-            H, W = X.shape[-2:]
-            if (qengine == 'qnnpack'):
-                ceil_mode = False
-                count_include_pad = True
-                torch_type = torch.quint8
-
-            if X.shape[1] < 176:
-                X = np.repeat(X, 176 / X.shape[1], 1)
-            X_nchw = np.ascontiguousarray(X.transpose([0, 2, 3, 1]))
-            qX = torch.quantize_per_tensor(torch.from_numpy(X_nchw), scale=scale,
-                                           zero_point=zero_point, dtype=torch_type).permute([0, 3, 1, 2])
-            # Run reference on int_repr + round to avoid double rounding error.
-            X_ref = torch.nn.functional.avg_pool2d(
-                qX.int_repr().to(torch.double), kernel_size=kernel, stride=stride, padding=padding,
-                ceil_mode=ceil_mode, count_include_pad=count_include_pad, divisor_override=divisor_override).round()
-
-            self.assertTrue(qX.stride() != sorted(qX.stride()))
-            ops_under_test = {
-                "nn.functional": torch.nn.functional.avg_pool2d,
-                "nn.quantized.functional": torch.nn.quantized.functional.avg_pool2d
-            }
-            error_message = r"Results are off for {}:\n\tExpected:\n{}\n\tGot:\n{}"
-            for name, op in ops_under_test.items():
-                X_hat = op(qX, kernel_size=kernel, stride=stride, padding=padding, ceil_mode=ceil_mode,
-                           count_include_pad=count_include_pad, divisor_override=divisor_override)
-                self.assertTrue(X_hat.stride() != sorted(X_hat.stride()))
-                self.assertEqual(X_ref, X_hat.int_repr().to(torch.double), prec=1.0,
-                                 message="{} results are off".format(name))
-                self.assertEqual(scale, X_hat.q_scale(),
-                                 message=error_message.format(name + '.scale', scale, X_hat.q_scale()))
-                self.assertEqual(zero_point, X_hat.q_zero_point(),
-                                 message=error_message.format(name + '.zero_point', scale,
-                                 X_hat.q_zero_point()))
+        X, (scale, zero_point, torch_type) = X
+        H, W = X.shape[-2:]
+        if X.shape[1] < 176:
+            X = np.repeat(X, 176 / X.shape[1], 1)
+        X_nchw = np.ascontiguousarray(X.transpose([0, 2, 3, 1]))
+        qX = torch.quantize_per_tensor(torch.from_numpy(X_nchw), scale=scale,
+                                       zero_point=zero_point, dtype=torch_type).permute([0, 3, 1, 2])
+        # Run reference on int_repr + round to avoid double rounding error.
+        X_ref = torch.nn.functional.avg_pool2d(
+            qX.int_repr().to(torch.double), kernel_size=kernel, stride=stride, padding=padding,
+            ceil_mode=ceil_mode, count_include_pad=count_include_pad, divisor_override=divisor_override).round()
+        self.assertTrue(qX.stride() != sorted(qX.stride()))
+        ops_under_test = {
+            "nn.functional": torch.nn.functional.avg_pool2d,
+            "nn.quantized.functional": torch.nn.quantized.functional.avg_pool2d
+        }
+        error_message = r"Results are off for {}:\n\tExpected:\n{}\n\tGot:\n{}"
+        for name, op in ops_under_test.items():
+            X_hat = op(qX, kernel_size=kernel, stride=stride, padding=padding, ceil_mode=ceil_mode,
+                       count_include_pad=count_include_pad, divisor_override=divisor_override)
+            self.assertTrue(X_hat.stride() != sorted(X_hat.stride()))
+            self.assertEqual(X_ref, X_hat.int_repr().to(torch.double), prec=1.0,
+                             message="{} results are off".format(name))
+            self.assertEqual(scale, X_hat.q_scale(),
+                             message=error_message.format(name + '.scale', scale, X_hat.q_scale()))
+            self.assertEqual(zero_point, X_hat.q_zero_point(),
+                             message=error_message.format(name + '.zero_point', scale,
+                             X_hat.q_zero_point()))
 
     @no_deadline
     @given(X=hu.tensor(shapes=hu.array_shapes(min_dims=4, max_dims=4,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#27552 [mobile][quantization] Add quantized avg_pool2d for pytorch mobile**

Summary:
Add support to perform avg_pool2d on mobile. Tested using existing avg_pool2d python tests
Uses qnnpack backend, which currently only support 4 dim inputs.

Test Plan:
 python test/test_quantized.py TestQuantizedOps.test_avg_pool2d

Reviewers:

Subscribers:

Tasks:

Tags: