### PR TITLE
Remove underscore from pybind of module._c.dump

### DIFF
--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -468,7 +468,7 @@ void initJitScriptBindings(PyObject* module) {
           py::arg("_extra_files") = ExtraFilesMap())
       .def("_set_optimized", &Module::set_optimized)
       .def(
-          "_dump",
+          "dump",
           &Module::dump,
           py::arg("code") = true,
           py::arg("attrs") = true,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #27556 Expose torch::jit::script::Module::dump_to_str to python as module._c.dump_to_str.
* **#27555 Remove underscore from pybind of module._c.dump**

It is already under '_c' anyway.

Differential Revision: [D17814333](https://our.internmc.facebook.com/intern/diff/D17814333)