### PR TITLE
Expose torch::jit::script::Module::dump_to_str to python as module._c.dump_to_str.

### DIFF
--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -474,6 +474,13 @@ void initJitScriptBindings(PyObject* module) {
           py::arg("attrs") = true,
           py::arg("params") = true)
       .def(
+          "dump_to_str",
+          &Module::dump_to_str,
+          py::arg("code") = true,
+          py::arg("attrs") = true,
+          py::arg("params") = true,
+          py::arg("indent") = 0)
+      .def(
           "_define",
           [](Module& m,
              py::object py_m,

--- a/torch/csrc/jit/script/module.cpp
+++ b/torch/csrc/jit/script/module.cpp
@@ -417,11 +417,11 @@ void Module::apply(const std::function<void(Module&)>& fn) {
   fn(*this);
 }
 
-std::string Module::_dump_to_string(
+std::string Module::dump_to_str(
     bool print_method_bodies,
     bool print_attr_values,
     bool print_param_values,
-    int level) const {
+    int level = 0) const {
   std::stringstream ss;
   std::stringstream parameters_ss;
   std::stringstream attributes_ss;
@@ -470,7 +470,7 @@ std::string Module::_dump_to_string(
   for (const Module& submodule : get_modules()) {
     // We do level + 2, because one level of indentation comes from 'submodules'
     // scope and the other one goes from a specific submodule we're printing.
-    ss << submodule._dump_to_string(
+    ss << submodule.dump_to_str(
         print_method_bodies, print_attr_values, print_param_values, level + 2);
   }
   ss << "  }" << std::endl;
@@ -484,11 +484,10 @@ void Module::dump(
     bool print_method_bodies = true,
     bool print_attr_values = true,
     bool print_param_values = true) const {
-  std::cout << _dump_to_string(
+  std::cout << dump_to_str(
                    print_method_bodies,
                    print_attr_values,
-                   print_param_values,
-                   0)
+                   print_param_values)
             << std::endl;
 }
 

--- a/torch/csrc/jit/script/module.h
+++ b/torch/csrc/jit/script/module.h
@@ -209,6 +209,12 @@ struct TORCH_API Module {
       bool print_attr_values,
       bool print_param_values) const;
 
+  std::string dump_to_str(
+      bool print_method_bodies,
+      bool print_attr_values,
+      bool print_param_values,
+      int level) const;
+
   const std::vector<Method> get_methods() const {
     return fmap(
         type()->methods(),
@@ -368,12 +374,6 @@ struct TORCH_API Module {
 
  private:
   Module clone_impl(std::unordered_map<TypePtr, TypePtr>& type_remap) const;
-
-  std::string _dump_to_string(
-      bool omit_method_bodies,
-      bool omit_attr_values,
-      bool omit_param_values,
-      int level) const;
 
   void clone_method(
       const Module& orig,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#27556 Expose torch::jit::script::Module::dump_to_str to python as module._c.dump_to_str.**
* #27555 Remove underscore from pybind of module._c.dump

Differential Revision: [D17814331](https://our.internmc.facebook.com/intern/diff/D17814331)