### PR TITLE
Add possibility for miniz to use an external crc definition.

### DIFF
--- a/third_party/miniz-2.0.8/miniz.c
+++ b/third_party/miniz-2.0.8/miniz.c
@@ -82,6 +82,12 @@ mz_ulong mz_adler32(mz_ulong adler, const unsigned char *ptr, size_t buf_len)
         }
         return ~crcu32;
     }
+#elif defined(USE_EXTERNAL_MZCRC)
+/* If USE_EXTERNAL_CRC is defined, an external module will export the
+ * mz_crc32() symbol for us to use, e.g. an SSE-accelerated version.
+ * Depending on the impl, it may be necessary to ~ the input/output crc values.
+ */
+mz_ulong mz_crc32(mz_ulong crc, const mz_uint8 *ptr, size_t buf_len);
 #else
 /* Faster, but larger CPU cache footprint.
  */


### PR DESCRIPTION
Summary:
We add an #ifdef check for USE_EXTERNAL_MZCRC, in which case miniz
will look for an external mz_crc32 definition. The default behavior
is unchanged.

Test Plan: Unchanged default behavior, but buck test caffe2/test/...

Differential Revision: D17814440

