### PR TITLE
Update 'einsum' docstring to conform to PEP-484

### DIFF
--- a/torch/functional.py
+++ b/torch/functional.py
@@ -146,7 +146,7 @@ Args:
            If an index appears several times for the same operand, a diagonal is taken.
            Ellipses `...` represent a fixed number of dimensions. If the right hand side is inferred,
            the ellipsis dimensions are at the beginning of the output.
-    operands (list of Tensors): The operands to compute the Einstein sum of.
+    operands (Tensor): The operands to compute the Einstein sum of.
 
 Examples::
 


### PR DESCRIPTION
[PEP-484](https://www.python.org/dev/peps/pep-0484/#arbitrary-argument-lists-and-default-argument-values) specifies that arbitrary argument lists, here `*operands`, should be annotated with the type of the single arguments, i.e. not indicating that the whole thing is wrapped into a `list` (which is a Python internal anyway). The previous docstring caused problems with type checkers for IDEs such as PyCharm ([see here](https://youtrack.jetbrains.com/issue/PY-38035)).

