### PR TITLE
C++ API parity: ELU, Hardshrink, Hardtanh, LeakyReLU, LogSigmoid minor fixes

### DIFF
--- a/torch/csrc/api/include/torch/nn/functional/activation.h
+++ b/torch/csrc/api/include/torch/nn/functional/activation.h
@@ -7,7 +7,7 @@ namespace torch {
 namespace nn{
 namespace functional {
 
-inline Tensor elu(Tensor& input, const ELUOptions& options) {
+inline Tensor elu(Tensor& input, const ELUOptions& options = {}) {
   if (options.inplace()) {
     return torch::elu_(input, options.alpha());
   } else {
@@ -16,11 +16,11 @@ inline Tensor elu(Tensor& input, const ELUOptions& options) {
 }
 
 inline Tensor hardshrink(const Tensor& input,
-                         const HardshrinkOptions& options) {
+                         const HardshrinkOptions& options = {}) {
   return torch::hardshrink(input, options.lambda());
 }
 
-inline Tensor hardtanh(Tensor& input, const HardtanhOptions& options) {
+inline Tensor hardtanh(Tensor& input, const HardtanhOptions& options = {}) {
   if (options.inplace()) {
     return torch::hardtanh_(input, options.min_val(), options.max_val());
   } else {
@@ -28,7 +28,7 @@ inline Tensor hardtanh(Tensor& input, const HardtanhOptions& options) {
   }
 }
 
-inline Tensor leaky_relu(Tensor& input, const LeakyReLUOptions& options) {
+inline Tensor leaky_relu(Tensor& input, const LeakyReLUOptions& options = {}) {
   if (options.inplace()) {
     return torch::leaky_relu_(input, options.negative_slope());
   } else {

--- a/torch/csrc/api/include/torch/nn/modules/activation.h
+++ b/torch/csrc/api/include/torch/nn/modules/activation.h
@@ -16,8 +16,7 @@ namespace nn {
 /// about the exact behavior of this module.
 class TORCH_API ELUImpl : public torch::nn::Cloneable<ELUImpl> {
  public:
-  ELUImpl() : ELUImpl(ELUOptions()) {}
-  explicit ELUImpl(const ELUOptions& options_);
+  explicit ELUImpl(const ELUOptions& options_ = {});
 
   Tensor forward(Tensor& input);
 
@@ -39,8 +38,7 @@ TORCH_MODULE(ELU);
 /// about the exact behavior of this module.
 class TORCH_API HardshrinkImpl : public torch::nn::Cloneable<HardshrinkImpl> {
  public:
-  HardshrinkImpl() : HardshrinkImpl(HardshrinkOptions()) {}
-  explicit HardshrinkImpl(const HardshrinkOptions& options_);
+  explicit HardshrinkImpl(const HardshrinkOptions& options_ = {});
 
   Tensor forward(const Tensor& input);
 
@@ -62,8 +60,7 @@ TORCH_MODULE(Hardshrink);
 /// about the exact behavior of this module.
 class TORCH_API HardtanhImpl : public torch::nn::Cloneable<HardtanhImpl> {
  public:
-  HardtanhImpl() : HardtanhImpl(HardtanhOptions()) {}
-  explicit HardtanhImpl(const HardtanhOptions& options_);
+  explicit HardtanhImpl(const HardtanhOptions& options_ = {});
 
   Tensor forward(Tensor& input);
 
@@ -85,8 +82,7 @@ TORCH_MODULE(Hardtanh);
 /// about the exact behavior of this module.
 class TORCH_API LeakyReLUImpl : public torch::nn::Cloneable<LeakyReLUImpl> {
  public:
-  LeakyReLUImpl() : LeakyReLUImpl(LeakyReLUOptions()) {}
-  explicit LeakyReLUImpl(const LeakyReLUOptions& options_);
+  explicit LeakyReLUImpl(const LeakyReLUOptions& options_ = {});
 
   Tensor forward(Tensor& input);
 
@@ -108,8 +104,6 @@ TORCH_MODULE(LeakyReLU);
 /// about the exact behavior of this module.
 class TORCH_API LogSigmoidImpl : public torch::nn::Cloneable<LogSigmoidImpl> {
  public:
-  LogSigmoidImpl() {}
-
   Tensor forward(const Tensor& input);
 
   void reset() override;

--- a/torch/csrc/api/include/torch/nn/options/activation.h
+++ b/torch/csrc/api/include/torch/nn/options/activation.h
@@ -7,10 +7,8 @@ namespace torch {
 namespace nn {
 
 /// Options for ELU functional and module.
-struct ELUOptions {
-  ELUOptions() {}
-
-  /// The alpha value for the ELU formulation. Default: 1.0
+struct TORCH_API ELUOptions {
+  /// The `alpha` value for the ELU formulation. Default: 1.0
   TORCH_ARG(double, alpha) = 1.0;
 
   /// can optionally do the operation in-place. Default: False
@@ -23,16 +21,14 @@ struct ELUOptions {
 struct TORCH_API HardshrinkOptions {
   /* implicit */ HardshrinkOptions(double lambda = 0.5);
 
-  /// the lambda value for the Hardshrink formulation. Default: 0.5
+  /// the `lambda` value for the Hardshrink formulation. Default: 0.5
   TORCH_ARG(double, lambda);
 };
 
 // ============================================================================
 
 /// Options for Hardtanh functional and module.
-struct HardtanhOptions {
-  HardtanhOptions() {}
-
+struct TORCH_API HardtanhOptions {
   /// minimum value of the linear region range. Default: -1
   TORCH_ARG(double, min_val) = -1.0;
 
@@ -46,9 +42,7 @@ struct HardtanhOptions {
 // ============================================================================
 
 /// Options for LeakyReLU functional and module.
-struct LeakyReLUOptions {
-  LeakyReLUOptions() {}
-
+struct TORCH_API LeakyReLUOptions {
   /// Controls the angle of the negative slope. Default: 1e-2
   TORCH_ARG(double, negative_slope) = 1e-2;
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #27309 C++ API parity: MultiheadAttention
* #27382 C++ API parity: Linear
* #27538 C++ API parity: Threshold
* #27537 C++ API parity: Tanhshrink
* #27536 C++ API parity: Tanh
* #27535 C++ API parity: Softsign
* #27534 C++ API parity: Softshrink
* #27489 C++ API parity: Softplus
* #27488 C++ API parity: Sigmoid
* #27487 C++ API parity: CELU
* #27437 C++ API parity: RReLU
* #27436 C++ API parity: ReLU6
* #27435 C++ API parity: ReLU
* #27429 C++ API parity: PReLU
* **#27565 C++ API parity: ELU, Hardshrink, Hardtanh, LeakyReLU, LogSigmoid minor fixes**

Differential Revision: [D17835416](https://our.internmc.facebook.com/intern/diff/D17835416)