### PR TITLE
[WIP] add kernel size vs input size check for AvgPool2d

### DIFF
--- a/aten/src/ATen/native/Pool.h
+++ b/aten/src/ATen/native/Pool.h
@@ -79,6 +79,10 @@ pool2d_shape_check(
               "Calculated output size: (",
               nOutputPlane, "x", outputHeight, "x", outputWidth, "). ",
               "Output size is too small");
+  
+  TORCH_CHECK(inputHeight >= kH && inputWidth >= kW,
+              "input image ", "(H: ", inputHeight, " W: ", inputWidth, ") smaller than ",
+              "kernel size ", "(kH: ", kH, " kW: ", kW, ")");
 }
 
 // DilatedMaxPool2d (backward)

--- a/test/test_quantized.py
+++ b/test/test_quantized.py
@@ -402,6 +402,7 @@ class TestQuantizedOps(TestCase):
         # Check constraints
         assume(kernel // 2 >= padding)  # Kernel cannot be overhanging!
         iH, iW = X.shape[-2:]
+        assume(iH > kernel and iW > kernel) # Reject examples where image is smaller than kernel
         oH = pool_output_shape(iH, kernel, padding, stride, dilation)
         assume(oH > 0)
         oW = pool_output_shape(iW, kernel, padding, stride, dilation)
@@ -456,6 +457,7 @@ class TestQuantizedOps(TestCase):
         # Check constraints
         assume(kernel // 2 >= padding)  # Kernel cannot be overhanging!
         iH, iW = X.shape[-2:]
+        assume(iH > kernel and iW > kernel) # Reject examples where image is smaller than kernel
         oH = pool_output_shape(iH, kernel, padding, stride, dilation)
         assume(oH > 0)
         oW = pool_output_shape(iW, kernel, padding, stride, dilation)


### PR DESCRIPTION
add kernel size vs input size check similar to AvgPool3d (#15822) 

more details here:
https://github.com/pytorch/pytorch/issues/15822#issuecomment-539738235

