### PR TITLE
Revert "Mark protobuf include path as system include (#23012)"

### DIFF
--- a/cmake/ProtoBuf.cmake
+++ b/cmake/ProtoBuf.cmake
@@ -117,9 +117,12 @@ if ((NOT TARGET protobuf::libprotobuf) AND (NOT TARGET protobuf::libprotobuf-lit
   #     "Please set the proper paths so that I can find protobuf correctly.")
 endif()
 
+# Protobuf generated files use <> as inclusion path, so maybe we should use
+# SYSTEM inclusion path. But we need these include dirs to be found before
+# other protobuf include dirs in Anaconda
 get_target_property(__tmp protobuf::libprotobuf INTERFACE_INCLUDE_DIRECTORIES)
 message(STATUS "Caffe2 protobuf include directory: " ${__tmp})
-include_directories(BEFORE SYSTEM ${__tmp})
+include_directories(BEFORE ${__tmp})
 
 # If Protobuf_VERSION is known (true in most cases, false if we are building
 # local protobuf), then we will add a protobuf version check in


### PR DESCRIPTION
This reverts commit a2b3403962efce151d4c447e27106f9617c52595.

PR https://github.com/pytorch/pytorch/pull/23012 introduced issues for OSX builds, where user already has protobuf installed on system.

It is picking up user's installed protobuf in /usr/local/include, which should not happen.

Relevant filed issues are: https://github.com/pytorch/pytorch/issues/26945 and https://github.com/pytorch/pytorch/issues/25580

Fixes #26945
Fixes #25580

cc: @bddppq @xuhdev 