### PR TITLE
fix: add some items into optim.__init__.pyi

### DIFF
--- a/torch/optim/__init__.pyi
+++ b/torch/optim/__init__.pyi
@@ -1,3 +1,13 @@
-from .sgd import SGD as SGD
-from .adam import Adam as Adam
-from . import lr_scheduler as lr_scheduler
+from .adadelta import Adadelta  
+from .adagrad import Adagrad  
+from .adam import Adam  
+from .adamw import AdamW  
+from .sparse_adam import SparseAdam  
+from .adamax import Adamax  
+from .asgd import ASGD  
+from .sgd import SGD  
+from .rprop import Rprop  
+from .rmsprop import RMSprop  
+from .optimizer import Optimizer  
+from .lbfgs import LBFGS  
+from . import lr_scheduler  


### PR DESCRIPTION
I found some declarations missing in `optim.__init__.pyi`, and add them into it.