### PR TITLE
[iOS][CI] Disable automatically code signing for TestApp

### DIFF
--- a/ios/TestApp/TestApp.xcodeproj/project.pbxproj
+++ b/ios/TestApp/TestApp.xcodeproj/project.pbxproj
@@ -284,15 +284,16 @@
             isa = XCBuildConfiguration;
             buildSettings = {
                 ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-                CODE_SIGN_STYLE = Automatic;
-                DEVELOPMENT_TEAM = GW8XWHWQR7;
+                CODE_SIGN_STYLE = Manual;
+                DEVELOPMENT_TEAM = "";
                 INFOPLIST_FILE = TestApp/Info.plist;
                 LD_RUNPATH_SEARCH_PATHS = (
                     "$(inherited)",
                     "@executable_path/Frameworks",
                 );
-                PRODUCT_BUNDLE_IDENTIFIER = com.pytorch.testApp.TestApp;
+                PRODUCT_BUNDLE_IDENTIFIER = com.pytorch.ios.TestApp;
                 PRODUCT_NAME = "$(TARGET_NAME)";
+                PROVISIONING_PROFILE_SPECIFIER = "";
                 TARGETED_DEVICE_FAMILY = "1,2";
             };
             name = Debug;
@@ -301,15 +302,16 @@
             isa = XCBuildConfiguration;
             buildSettings = {
                 ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-                CODE_SIGN_STYLE = Automatic;
-                DEVELOPMENT_TEAM = GW8XWHWQR7;
+                CODE_SIGN_STYLE = Manual;
+                DEVELOPMENT_TEAM = "";
                 INFOPLIST_FILE = TestApp/Info.plist;
                 LD_RUNPATH_SEARCH_PATHS = (
                     "$(inherited)",
                     "@executable_path/Frameworks",
                 );
-                PRODUCT_BUNDLE_IDENTIFIER = com.pytorch.testApp.TestApp;
+                PRODUCT_BUNDLE_IDENTIFIER = com.pytorch.ios.TestApp;
                 PRODUCT_NAME = "$(TARGET_NAME)";
+                PROVISIONING_PROFILE_SPECIFIER = "";
                 TARGETED_DEVICE_FAMILY = "1,2";
             };
             name = Release;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #27594 [iOS][CI] add testing code to PR jobs
* #27593 [iOS][CI] Install developer certificate for code signing
* **#27591 [iOS][CI]Disable automatically code signing for TestApp**

## Summary

Since the nightly jobs are lack of  testing phases, we don't really have a way to test the binary before uploading it to AWS. To make the work more solid, we need to figure out a way to verify the binary. 

Fortunately, the XCode tool chain offers a way to build your app without XCode app, which is the [xcodebuild](https://developer.apple.com/library/archive/technotes/tn2339/_index.html) command. Now we can link our binary to a testing app and run `xcodebuild` to to see if there is any linking error. The PRs below have already done some of the preparation jobs

- [#26261](https://github.com/pytorch/pytorch/pull/26261)
- [#26632](https://github.com/pytorch/pytorch/pull/26632)

The challenge comes when testing the arm64 build as we don't have a way to code-sign our TestApp. Circle CI has a  [tutorial](https://circleci.com/docs/2.0/ios-codesigning/)  but is too complicated to implement. Anyway, I figured out an easier way to do it 

1. Disable automatically code sign in XCode
2. Export the encoded developer certificate and provisioning profile to org-context in Circle CI (done)
3. Install the developer certificate to the key chain store on CI machines via Fastlane.
4. Add the testing code to PR jobs and verify the result.
5. Add the testing code to nightly jobs and verify the result.

## Test Plan

- Both PR jobs and nightly jobs can finish successfully.
- `xcodebuild` can finish successfully

Differential Revision: [D17844036](https://our.internmc.facebook.com/intern/diff/D17844036)