### PR TITLE
Fix for flaky caffe2 dataio test (test_time_limit_reader_with_short_limit)

### DIFF
--- a/caffe2/python/dataio_test.py
+++ b/caffe2/python/dataio_test.py
@@ -214,6 +214,7 @@ class TestReaderWithLimit(TestCase):
         return ws, session, src_ds, dst_ds
 
     def _test_limit_reader_shared(self, reader_class, size, expected_read_len,
+                                  expected_read_len_threshold,
                                   expected_finish, num_threads, read_delay,
                                   **limiter_args):
         ws, session, src_ds, dst_ds = \
@@ -232,10 +233,18 @@ class TestReaderWithLimit(TestCase):
             pipe(reader, dst_ds.writer(), num_runtime_threads=num_threads)
         session.run(tg)
         read_len = len(sorted(ws.blobs[str(dst_ds.content().label())].fetch()))
-        self.assertEqual(read_len, expected_read_len)
+
+        # Do a fuzzy match (expected_read_len +/- expected_read_len_threshold)
+        # to eliminate flakiness for time-limited tests
+        self.assertGreaterEqual(
+            read_len,
+            expected_read_len - expected_read_len_threshold)
+        self.assertLessEqual(
+            read_len,
+            expected_read_len + expected_read_len_threshold)
         self.assertEqual(
             sorted(ws.blobs[str(dst_ds.content().label())].fetch()),
-            list(range(expected_read_len))
+            list(range(read_len))
         )
         self.assertEqual(ws.blobs[str(reader.data_finished())].fetch(),
                          expected_finish)
@@ -245,6 +254,7 @@ class TestReaderWithLimit(TestCase):
         self._test_limit_reader_shared(ReaderWithLimit,
                                        size=100,
                                        expected_read_len=100,
+                                       expected_read_len_threshold=0,
                                        expected_finish=True,
                                        num_threads=8,
                                        read_delay=0,
@@ -255,6 +265,7 @@ class TestReaderWithLimit(TestCase):
         self._test_limit_reader_shared(ReaderWithLimit,
                                        size=100,
                                        expected_read_len=0,
+                                       expected_read_len_threshold=0,
                                        expected_finish=False,
                                        num_threads=8,
                                        read_delay=0,
@@ -265,6 +276,7 @@ class TestReaderWithLimit(TestCase):
         self._test_limit_reader_shared(ReaderWithLimit,
                                        size=100,
                                        expected_read_len=10,
+                                       expected_read_len_threshold=0,
                                        expected_finish=False,
                                        num_threads=8,
                                        read_delay=0,
@@ -275,6 +287,7 @@ class TestReaderWithLimit(TestCase):
         self._test_limit_reader_shared(ReaderWithLimit,
                                        size=100,
                                        expected_read_len=100,
+                                       expected_read_len_threshold=0,
                                        expected_finish=True,
                                        num_threads=8,
                                        read_delay=0,
@@ -285,6 +298,7 @@ class TestReaderWithLimit(TestCase):
         self._test_limit_reader_shared(ReaderWithTimeLimit,
                                        size=100,
                                        expected_read_len=100,
+                                       expected_read_len_threshold=0,
                                        expected_finish=True,
                                        num_threads=8,
                                        read_delay=0.1,
@@ -300,9 +314,16 @@ class TestReaderWithLimit(TestCase):
         # Because the time limit check happens before the delay + read op,
         # subtract a little bit of time to ensure we don't get in an extra read
         duration = duration - 0.25 * sleep_duration
+
+        # NOTE: `expected_read_len_threshold` was added because this test case
+        # has significant execution variation under stress. Under stress, we may
+        # read strictly less than the expected # of samples; anywhere from
+        # [0,N] where N = expected_read_len.
+        # Hence we set expected_read_len to N/2, plus or minus N/2.
         self._test_limit_reader_shared(ReaderWithTimeLimit,
                                        size=size,
-                                       expected_read_len=expected_read_len,
+                                       expected_read_len=expected_read_len / 2,
+                                       expected_read_len_threshold=expected_read_len / 2,
                                        expected_finish=False,
                                        num_threads=num_threads,
                                        read_delay=sleep_duration,
@@ -310,13 +331,16 @@ class TestReaderWithLimit(TestCase):
 
     def test_time_limit_reader_with_long_limit(self):
         # Read with ample time limit
+        # NOTE: we don't use `expected_read_len_threshold` because the duration,
+        # read_delay, and # threads should be more than sufficient
         self._test_limit_reader_shared(ReaderWithTimeLimit,
                                        size=50,
                                        expected_read_len=50,
+                                       expected_read_len_threshold=0,
                                        expected_finish=True,
                                        num_threads=4,
-                                       read_delay=0.25,
-                                       duration=6)
+                                       read_delay=0.2,
+                                       duration=10)
 
 
 class TestDBFileReader(TestCase):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#27592 Fix for flaky caffe2 dataio test (test_time_limit_reader_with_short_limit)**

The caffe2 data reader test `test_time_limit_reader_with_short_limit` is flaky as-written because it places an upper bound on how much can be read, but under stress it is possible for fewer records to be read. The fix is to make the assertion check a fuzzy/range check rather than exact equality, since there's not a straightforward way to precisely test a timer-based feature.

Differential Revision: [D17816775](https://our.internmc.facebook.com/intern/diff/D17816775/)