### PR TITLE
Fix a bug of C++ L-BFGS optimizer

### DIFF
--- a/torch/csrc/api/src/optim/lbfgs.cpp
+++ b/torch/csrc/api/src/optim/lbfgs.cpp
@@ -20,6 +20,10 @@ LBFGSOptions::LBFGSOptions(double learning_rate)
 Tensor LBFGS::gather_flat_grad() {
   std::vector<Tensor> views;
   for (auto& parameter : parameters_) {
+    if (!parameter.grad().defined()) {
+      continue;
+    }
+
     views.push_back(parameter.grad().view(-1));
   }
   return torch::cat(views);
@@ -29,6 +33,10 @@ void LBFGS::add_grad(const torch::Tensor& step_size, const Tensor& update) {
   NoGradGuard guard;
   int64_t offset = 0;
   for (auto& parameter : parameters_) {
+    if (!parameter.grad().defined()) {
+      continue;
+    }
+
     int64_t numel = parameter.numel();
     parameter.add_(
         update.slice(0, offset, offset + numel, 1).view_as(parameter),


### PR DESCRIPTION
Fixes #27605: The C++ L-BFGS Optimizer will not work properly if there are one or more registered tensors with no grad in the model:
```
terminate called after throwing an instance of 'c10::Error'
  what():  There were no tensor arguments to this function (e.g., you passed an empty list of Tensors), but no fallback function is registered for schema aten::view.  This usually means that this function requires a non-empty list of Tensors.  Available functions are [CUDATensorId, QuantizedCPUTensorId, VariableTensorId, CPUTensorId, MkldnnCPUTensorId] (lookup_ at /pytorch/aten/src/ATen/core/dispatch/DispatchTable.h:245)
```

Add some `if (!parameter.grad().defined()) {...}` in the ` torch/csrc/api/src/optim/lbfgs.cpp`
