### PR TITLE
Don't run dist_autograd_fork on Python 2

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -27,7 +27,6 @@ TESTS = [
     'cuda',
     'cuda_primary_ctx',
     'dataloader',
-    'dist_autograd_fork',
     'distributed',
     'distributions',
     'docs_coverage',
@@ -75,6 +74,7 @@ if PY36:
         'jit_py3',
         'rpc_fork',
         'rpc_spawn',
+        'dist_autograd_fork',
         'dist_autograd_spawn',
     ])
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #27531 Run clang-format for torch/distributed/rpc
* #27530 Rename PythonUDF{Call,Resp}
* #27529 Scope pybind11 functions to torch.distributed.{autograd,rpc}
* **#27612 Don't run dist_autograd_fork on Python 2**

The file imports from torch.distributed.rpc, which won't be
initialized when running on Python 2.

Differential Revision: [D17855033](https://our.internmc.facebook.com/intern/diff/D17855033)