### PR TITLE
add dim to the cat benchmark

### DIFF
--- a/benchmarks/operator_benchmark/pt/cat_test.py
+++ b/benchmarks/operator_benchmark/pt/cat_test.py
@@ -14,17 +14,20 @@ import torch
 cat_short_configs = op_bench.cross_product_configs(
     M=[256, 512],
     N=[512],
+    K=[1, 2],
+    dim=[0, 1, 2],
     tags=['short']
 )
 
 
 class CatBenchmark(op_bench.TorchBenchmarkBase):
-    def init(self, M, N):
-        self.input_one = torch.rand(M, N)
+    def init(self, M, N, K, dim):
+        self.input_one = torch.rand(M, N, K)
+        self.dim = dim
         self.set_module_name('cat')
 
     def forward(self):
-        return torch.cat((self.input_one, self.input_one))
+        return torch.cat((self.input_one, self.input_one), dim=self.dim)
 
 
 op_bench.generate_pt_test(cat_short_configs, CatBenchmark)


### PR DESCRIPTION
Summary: as title

Test Plan:
```
buck run caffe2/benchmarks/operator_benchmark/pt:cat_test -- --iterations 3

# ----------------------------------------
# PyTorch/Caffe2 Operator Micro-benchmarks
# ----------------------------------------
# Tag : short

# Benchmarking PyTorch: cat
# Mode: Eager
# Name: cat_M256_N512_K1_dim0
# Input: M: 256, N: 512, K: 1, dim: 0
Forward Execution Time (us) : 775.348

# Benchmarking PyTorch: cat
# Mode: Eager
# Name: cat_M256_N512_K1_dim1
# Input: M: 256, N: 512, K: 1, dim: 1
Forward Execution Time (us) : 3612.599

# Benchmarking PyTorch: cat
# Mode: Eager
# Name: cat_M256_N512_K1_dim2
# Input: M: 256, N: 512, K: 1, dim: 2
Forward Execution Time (us) : 91416.224
...
``

Differential Revision: D17835348

