### PR TITLE
add as_strided operator to the benchmark

### DIFF
--- a/benchmarks/operator_benchmark/pt/as_strided_test.py
+++ b/benchmarks/operator_benchmark/pt/as_strided_test.py
@@ -1,0 +1,41 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import operator_benchmark as op_bench
+import torch
+
+
+"""Microbenchmarks for as_strided operator"""
+
+
+# Configs for PT as_strided operator
+split_short_configs = op_bench.cross_product_configs(
+    M=[256, 512],
+    N=[256, 512],
+    size=[(32, 32), (64, 64)],
+    stride=[(1, 1), (2, 2)],
+    storage_offset=[0, 1],
+    tags=['short']
+)
+
+
+class As_stridedBenchmark(op_bench.TorchBenchmarkBase):
+    def init(self, M, N, size, stride, storage_offset):
+        self.input_one = torch.rand(M, N)
+        self.size = size
+        self.stride = stride
+        self.storage_offset = storage_offset
+        self.set_module_name('as_strided')
+
+    def forward(self):
+        return torch.as_strided(
+            self.input_one, self.size, self.stride, self.storage_offset)
+
+
+op_bench.generate_pt_test(split_short_configs, As_stridedBenchmark)
+
+
+if __name__ == "__main__":
+    op_bench.benchmark_runner.main()


### PR DESCRIPTION
Summary: Support as_strided operator in the benchmark suite.

Test Plan:
buck run caffe2/benchmarks/operator_benchmark/pt:as_strided_test -- --iterations 3
```
# ----------------------------------------
# PyTorch/Caffe2 Operator Micro-benchmarks
# ----------------------------------------
# Tag : short

# Benchmarking PyTorch: as_strided
# Mode: Eager
# Name: as_strided_M256_N256_size(32,32)_stride(1,1)_storage_offset0
# Input: M: 256, N: 256, size: (32, 32), stride: (1, 1), storage_offset: 0
Forward Execution Time (us) : 92.008

# Benchmarking PyTorch: as_strided
# Mode: Eager
# Name: as_strided_M256_N256_size(32,32)_stride(1,1)_storage_offset1
# Input: M: 256, N: 256, size: (32, 32), stride: (1, 1), storage_offset: 1
Forward Execution Time (us) : 91.029
...

Reviewed By: hl475

Differential Revision: D17840076

