### PR TITLE
Make AutogradMeta a private struct in Variable.

### DIFF
--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -327,7 +327,10 @@ struct TORCH_API Variable : public at::Tensor {
   PyObject* pyobj() const noexcept;
   void set_pyobj(PyObject* pyobj) noexcept;
 
+ private:
   struct AutogradMeta;
+
+ public:
   Variable::AutogradMeta* get_autograd_meta() const noexcept;
 
  private:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #27667 Devirtualize allow_tensor_metadata_change() getter/setter.
* #27666 Make set_grad_accumulator private (friend class SavedVariable)
* **#27654 Make AutogradMeta a private struct in Variable.**
* #27651 Add trailing underscore to member variable.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D17886547](https://our.internmc.facebook.com/intern/diff/D17886547)