### PR TITLE
Make set_grad_accumulator private (friend class SavedVariable)

### DIFF
--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -181,10 +181,15 @@ struct TORCH_API Variable : public at::Tensor {
   /// Gets the raw gradient function pointer, whatever it currently is.
   Node* grad_fn_unsafe() const;
 
+private:
   /// Set the gradient accumulator of the `Variable`. This is only applicable to
   /// leaf variables. Interior variables should call `set_gradient_edge()`.
   void set_grad_accumulator(std::weak_ptr<Node> grad_accumulator);
 
+  // Only user of set_grad_accumulator
+  friend class SavedVariable;
+
+public:
   /// Attempts to get a pointer to the gradient accumulator of the `Variable`,
   /// if it still exists. If the gradient accumulator function has been
   /// destroyed, returns a `nullptr`.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #27667 Devirtualize allow_tensor_metadata_change() getter/setter.
* **#27666 Make set_grad_accumulator private (friend class SavedVariable)**
* #27654 Make AutogradMeta a private struct in Variable.
* #27651 Add trailing underscore to member variable.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D17886544](https://our.internmc.facebook.com/intern/diff/D17886544)