### PR TITLE
Devirtualize allow_tensor_metadata_change() getter/setter.

### DIFF
--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -815,7 +815,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
    * Set whether a tensor allows changes to its metadata (e.g. sizes / strides / storage / storage_offset).
    * See NOTE [ Metadata Change for a Detached Tensor ] for details.
    */
-  virtual void set_allow_tensor_metadata_change(bool value) {
+  void set_allow_tensor_metadata_change(bool value) {
     allow_tensor_metadata_change_ = value;
   }
 
@@ -823,7 +823,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
    * True if a tensor allows changes to its metadata (e.g. sizes / strides / storage / storage_offset).
    * See NOTE [ Metadata Change for a Detached Tensor ] for details.
    */
-  virtual bool allow_tensor_metadata_change() const {
+  bool allow_tensor_metadata_change() const {
     return allow_tensor_metadata_change_;
   }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#27667 Devirtualize allow_tensor_metadata_change() getter/setter.**
* #27666 Make set_grad_accumulator private (friend class SavedVariable)
* #27654 Make AutogradMeta a private struct in Variable.
* #27651 Add trailing underscore to member variable.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D17886548](https://our.internmc.facebook.com/intern/diff/D17886548)