### PR TITLE
[JIT] Make _ConstModuleList submodule identifiers legal

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -4334,6 +4334,25 @@ a")
                 return a
             ''')
 
+    @_tmp_donotuse_dont_inline_everything
+    def test_sequential_indices_are_legal(self):
+        class FooBar(torch.nn.Module):
+            def forward(self, x):
+                return torch.neg(x)
+
+        class Baz(torch.nn.Module):
+            def __init__(self):
+                super(Baz, self).__init__()
+                self.l = torch.nn.ModuleList([FooBar() for _ in range(3)])
+
+            def forward(self, x):
+                for layer in self.l:
+                    x = layer(x)
+                return x
+
+        b = torch.jit.script(Baz())
+        FileCheck().check('name="_0"').check('name="_1"').run(b.graph)
+
     def test_string_single_escape(self):
         with self.assertRaisesRegex(RuntimeError, "expected a valid token*"):
             torch.jit.CompilationUnit('''

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1747,12 +1747,14 @@ class _ConstModuleList(ScriptModule):
             for key, module in modules.items():
                 if isinstance(module, torch.nn.Module):
                     module = torch.jit._recursive.recursive_script(module)
+                # Make a valid Python name
+                key = key if not key.isdigit() else '_' + key
                 self.add_module(key, module)
         else:
             for i, module in enumerate(modules):
                 if isinstance(module, torch.nn.Module):
                     module = torch.jit._recursive.recursive_script(module)
-                self.add_module(str(i), module)
+                self.add_module("_" + str(i), module)
 
     def __getitem__(self, idx):
         if isinstance(idx, slice):


### PR DESCRIPTION
This broke loading because we would have stuff like `layer.0` which is illegal