### PR TITLE
refactor tryMatchSchema (#26499)

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -11245,7 +11245,7 @@ a")
             ''')
 
     def test_invalid_call_arguments(self):
-        with self.assertRaisesRegex(RuntimeError, 'Arguments for call are not valid'):
+        with self.assertRaisesRegex(RuntimeError, 'but instead found type '):
             @torch.jit.script
             def invalid_call_arguments(x):
                 return torch.unsqueeze(3, 4, 5, 6, 7, 8)

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -1334,13 +1334,7 @@ Value* Graph::insert(
     at::ArrayRef<NamedValue> kwargs,
     const c10::optional<SourceRange>& range) {
   return script::emitBuiltinCall(
-      range.value_or(fakeRange()),
-      *this,
-      opname,
-      c10::nullopt,
-      args,
-      kwargs,
-      /*required=*/true);
+      range.value_or(fakeRange()), *this, opname, args, kwargs);
 }
 
 Node* Graph::create(NodeKind kind, size_t num_outputs) {

--- a/torch/csrc/jit/script/python_sugared_value.cpp
+++ b/torch/csrc/jit/script/python_sugared_value.cpp
@@ -96,18 +96,8 @@ std::shared_ptr<SugaredValue> PythonValue::call(
   auto inputs = toValues(*m.graph(), inputs_);
   auto schema = getSchema(inputs.size(), n_binders, loc);
 
-  std::stringstream failure_messages;
-  c10::optional<MatchedSchema> matched_schema = tryMatchSchema(
-      schema,
-      loc,
-      *m.graph(),
-      c10::nullopt,
-      inputs_,
-      attributes,
-      &failure_messages,
-      /*conv_tensor_to_num*/ true);
-  if (!matched_schema)
-    throw ErrorReport(loc) << failure_messages.str();
+  MatchedSchema matched_schema =
+      matchSchema(schema, loc, *m.graph(), inputs_, attributes);
 
   // If if a function is marked as dropped,
   // we throw an exception if it is invoked.
@@ -120,8 +110,7 @@ std::shared_ptr<SugaredValue> PythonValue::call(
             "This Python function is annotated to be ignored and cannot be run"));
     g->insert(prim::RaiseException, {err_msg}, {}, loc);
     return std::make_shared<SimpleValue>(
-        g->insertNode(
-             g->createUninitialized(matched_schema->return_types.at(0)))
+        g->insertNode(g->createUninitialized(matched_schema.return_types.at(0)))
             ->output());
   }
 
@@ -132,11 +121,11 @@ std::shared_ptr<SugaredValue> PythonValue::call(
       m.graph()->createPythonOp(THPObjectPtr(func.release().ptr()), cconv, {}));
 
   new_node->setSourceRange(loc);
-  for (auto& i : matched_schema->inputs)
+  for (auto& i : matched_schema.inputs)
     new_node->addInput(i);
 
   Value* output =
-      new_node->addOutput()->setType(matched_schema->return_types.at(0));
+      new_node->addOutput()->setType(matched_schema.return_types.at(0));
   return std::make_shared<SimpleValue>(output);
 }
 
@@ -220,70 +209,6 @@ Value* ConstantPythonTupleValue::asValue(const SourceRange& loc, Function& m) {
   return m.graph()->insertNode(node)->output();
 }
 
-std::shared_ptr<SugaredValue> OverloadedMethodValue::call(
-    const SourceRange& loc,
-    Function& caller,
-    at::ArrayRef<NamedValue> inputs,
-    at::ArrayRef<NamedValue> attributes,
-    size_t n_binders) {
-  std::vector<NamedValue> new_inputs = inputs.vec();
-  new_inputs.insert(new_inputs.begin(), module_);
-
-  std::stringstream failure_messages;
-  for (bool allow_conversions : {false, true}) {
-    // clear previous error messages
-    failure_messages.str("");
-    for (const std::string& method_name : method_names_) {
-      auto cls = module_->type()->expect<ClassType>();
-      const auto fn = cls->getMethod(method_name);
-      TORCH_INTERNAL_ASSERT(fn, "Expected class to have method ", method_name);
-      auto match = tryMatchSchema(
-          fn->getSchema(),
-          loc,
-          *caller.graph().get(),
-          c10::nullopt,
-          new_inputs,
-          attributes,
-          &failure_messages,
-          allow_conversions);
-      if (match) {
-        return MethodValue(module_, method_name)
-            .call(loc, caller, inputs, attributes, n_binders);
-      }
-    }
-  }
-  throw ErrorReport(loc) << failure_messages.str();
-}
-
-std::shared_ptr<SugaredValue> OverloadedFunctionValue::call(
-    const SourceRange& loc,
-    Function& caller,
-    at::ArrayRef<NamedValue> inputs_,
-    at::ArrayRef<NamedValue> attributes,
-    size_t n_binders) {
-  std::stringstream failure_messages;
-  for (bool allow_conversions : {false, true}) {
-    // clear previous error messages
-    failure_messages.str("");
-    for (const auto& compiled_overload : compiled_overloads_) {
-      const auto matched_schema = tryMatchSchema(
-          compiled_overload.function_->getSchema(),
-          loc,
-          *caller.graph(),
-          c10::nullopt,
-          inputs_,
-          attributes,
-          &failure_messages,
-          allow_conversions);
-      if (matched_schema) {
-        return FunctionValue(compiled_overload)
-            .call(loc, caller, inputs_, attributes, n_binders);
-      }
-    }
-  }
-  throw ErrorReport(loc) << failure_messages.str();
-}
-
 Value* ModuleValue::asValue(const SourceRange& loc, Function& m) {
   return self_;
 }
@@ -354,7 +279,7 @@ std::shared_ptr<SugaredValue> ModuleValue::attr(
   py::object overloads =
       py_module_.attr("_overloads").attr("get")(field, py::none());
   if (!overloads.is_none()) {
-    return std::make_shared<OverloadedMethodValue>(
+    return std::make_shared<MethodValue>(
         self_, py::cast<std::vector<std::string>>(overloads));
   }
   if (!py::hasattr(py_module_, field.c_str())) {
@@ -646,7 +571,7 @@ std::shared_ptr<SugaredValue> toSugaredValue(
         py::module::import("torch.jit").attr("_get_overloads")(obj);
     if (!overloads.is_none()) {
       auto compiled_fns = py::cast<std::vector<StrongFunctionPtr>>(overloads);
-      return std::make_shared<OverloadedFunctionValue>(std::move(compiled_fns));
+      return std::make_shared<FunctionValue>(std::move(compiled_fns));
     }
 
     auto compiled_fn =

--- a/torch/csrc/jit/script/python_sugared_value.h
+++ b/torch/csrc/jit/script/python_sugared_value.h
@@ -154,45 +154,6 @@ struct VISIBILITY_HIDDEN ConstantTupleMethod : public SugaredValue {
   const std::string name_;
 };
 
-struct VISIBILITY_HIDDEN OverloadedMethodValue : public SugaredValue {
-  OverloadedMethodValue(Value* module, std::vector<std::string> method_names)
-      : module_(module), method_names_(std::move(method_names)) {}
-
-  std::string kind() const override {
-    return "overloaded function";
-  }
-
-  std::shared_ptr<SugaredValue> call(
-      const SourceRange& loc,
-      Function& caller,
-      at::ArrayRef<NamedValue> inputs,
-      at::ArrayRef<NamedValue> attributes,
-      size_t n_binders) override;
-
- private:
-  Value* module_;
-  std::vector<std::string> method_names_;
-};
-
-struct VISIBILITY_HIDDEN OverloadedFunctionValue : public SugaredValue {
-  OverloadedFunctionValue(std::vector<StrongFunctionPtr> compiled_overloads)
-      : compiled_overloads_(std::move(compiled_overloads)) {}
-
-  std::string kind() const override {
-    return "overloaded function";
-  }
-
-  std::shared_ptr<SugaredValue> call(
-      const SourceRange& loc,
-      Function& caller,
-      at::ArrayRef<NamedValue> inputs,
-      at::ArrayRef<NamedValue> attributes,
-      size_t n_binders) override;
-
- private:
-  std::vector<StrongFunctionPtr> compiled_overloads_;
-};
-
 // defines how modules/methods behave inside the script subset.
 // for now this does not have any interaction with python.
 // in the future, we will add the ability to resolve `self.foo` to python

--- a/torch/csrc/jit/script/schema_matching.h
+++ b/torch/csrc/jit/script/schema_matching.h
@@ -21,22 +21,22 @@ struct MatchedSchema {
   c10::OptNameList return_field_names;
 };
 
-TORCH_API c10::optional<MatchedSchema> tryMatchSchema(
-    const ::c10::FunctionSchema& schema,
-    const SourceRange& loc,
-    Graph& graph,
-    c10::optional<NamedValue> self,
-    at::ArrayRef<NamedValue> args,
-    at::ArrayRef<NamedValue> kwargs,
-    std::ostream* failure_messages,
-    bool allow_conversions);
-
 TORCH_API MatchedSchema matchSchema(
     const ::c10::FunctionSchema& schema,
     const SourceRange& loc,
     Graph& graph,
     at::ArrayRef<NamedValue> args,
-    at::ArrayRef<NamedValue> kwarg);
+    at::ArrayRef<NamedValue> kwarg,
+    const c10::optional<NamedValue>& self = c10::nullopt);
+
+TORCH_API std::pair<size_t, MatchedSchema> matchSchemas(
+    const std::vector<const ::c10::FunctionSchema*>& schemas,
+    const SourceRange& loc,
+    Graph& graph,
+    at::ArrayRef<NamedValue> args,
+    at::ArrayRef<NamedValue> kwarg,
+    const c10::optional<NamedValue>& self = c10::nullopt,
+    bool render_errors = false);
 
 TORCH_API bool convertibleToList(
     const TypePtr& type,
@@ -46,14 +46,9 @@ TORCH_API Value* emitBuiltinCall(
     const SourceRange& loc,
     Graph& graph,
     Symbol name,
-    const c10::optional<NamedValue>& self,
     at::ArrayRef<NamedValue> inputs,
     at::ArrayRef<NamedValue> attributes,
-    // if true, emitBuiltinCall will throw an exception if this builtin does not
-    // exist, otherwise it will return nullptr if the builtin is not found.
-    bool required,
-    // should error strings be eager materialized?
-    bool render_errors = false);
+    const c10::optional<NamedValue>& self = c10::nullopt);
 
 TORCH_API c10::optional<size_t> findInputWithName(
     const std::string& name,

--- a/torch/csrc/jit/script/sugared_value.cpp
+++ b/torch/csrc/jit/script/sugared_value.cpp
@@ -50,7 +50,7 @@ std::shared_ptr<SugaredValue> BuiltinFunction::call(
     at::ArrayRef<NamedValue> attributes,
     size_t n_binders) {
   return std::make_shared<SimpleValue>(
-      emitBuiltinCall(loc, *m.graph(), symbol, self, inputs, attributes, true));
+      emitBuiltinCall(loc, *m.graph(), symbol, inputs, attributes, self));
 }
 
 // support syntax sugar for x.foo(y, z) by allowing x.foo to return a

--- a/torch/csrc/jit/script/sugared_value.h
+++ b/torch/csrc/jit/script/sugared_value.h
@@ -249,9 +249,16 @@ struct TORCH_API NamedTupleConstructor : public SugaredValue {
 };
 
 struct FunctionValue : public SugaredValue {
-  FunctionValue(Function* callee) : callee_(std::move(callee)) {}
+  FunctionValue(Function* callee) : callees_({std::move(callee)}) {}
   FunctionValue(const StrongFunctionPtr& p)
-      : callee_(p.function_), cu_(p.cu_) {}
+      : callees_({p.function_}), cu_(p.cu_) {}
+  FunctionValue(const std::vector<StrongFunctionPtr>& callees) {
+    for (const StrongFunctionPtr& callee : callees) {
+      cu_ = cu_ ? cu_ : callee.cu_;
+      TORCH_INTERNAL_ASSERT(callee.cu_ == cu_);
+      callees_.push_back(callee.function_);
+    }
+  }
 
   std::string kind() const override {
     return "function";
@@ -263,16 +270,20 @@ struct FunctionValue : public SugaredValue {
       at::ArrayRef<NamedValue> inputs,
       at::ArrayRef<NamedValue> attributes,
       size_t n_binders) override {
-    callee_->ensure_defined();
-    MatchedSchema match =
-        matchSchema(callee_->getSchema(), loc, *f.graph(), inputs, attributes);
-    Value* output = f.graph()->insertFunctionCall(callee_, match);
+    std::vector<const FunctionSchema*> schemas;
+    for (Function* callee : callees_) {
+      callee->ensure_defined();
+      schemas.push_back(&callee->getSchema());
+    }
+    auto match = matchSchemas(schemas, loc, *f.graph(), inputs, attributes);
+    Value* output =
+        f.graph()->insertFunctionCall(callees_[match.first], match.second);
     output->node()->setSourceRange(loc);
     return std::make_shared<SimpleValue>(output);
   }
 
  private:
-  Function* callee_;
+  std::vector<Function*> callees_;
   // TODO holding this thing is creepy
   std::shared_ptr<CompilationUnit> cu_;
 };
@@ -292,8 +303,10 @@ struct TORCH_API ClosureValue : public SugaredValue {
 
 // defines how a method obtained from a module/class/interface behaves in script
 struct MethodValue : public SugaredValue {
+  MethodValue(Value* self, std::vector<std::string> method_names)
+      : self_(std::move(self)), method_names_(std::move(method_names)) {}
   MethodValue(Value* self, std::string method_name)
-      : self_(std::move(self)), method_name_(std::move(method_name)) {}
+      : MethodValue(self, std::vector<std::string>({method_name})) {}
 
   std::string kind() const override {
     return "method";
@@ -307,28 +320,31 @@ struct MethodValue : public SugaredValue {
       size_t n_binders) override {
     std::vector<NamedValue> inputsWithSelf = {self_};
     inputsWithSelf.insert(inputsWithSelf.end(), inputs.begin(), inputs.end());
-    const FunctionSchema* schema = nullptr;
-    if (auto class_type = self_->type()->cast<ClassType>()) {
-      auto method = class_type->getMethod(method_name_);
-      TORCH_INTERNAL_ASSERT(method);
-      method->ensure_defined();
-      schema = &method->getSchema();
-    } else if (auto interface_type = self_->type()->cast<InterfaceType>()) {
-      schema = interface_type->getMethod(method_name_);
-    } else {
-      TORCH_INTERNAL_ASSERT(
-          false, "method constructed that is not a class or interface");
+    std::vector<const FunctionSchema*> schemas;
+    for (const std::string& method_name : method_names_) {
+      if (auto class_type = self_->type()->cast<ClassType>()) {
+        auto method = class_type->getMethod(method_name);
+        TORCH_INTERNAL_ASSERT(method);
+        method->ensure_defined();
+        schemas.push_back(&method->getSchema());
+      } else if (auto interface_type = self_->type()->cast<InterfaceType>()) {
+        schemas.push_back(interface_type->getMethod(method_name));
+      } else {
+        TORCH_INTERNAL_ASSERT(
+            false, "method constructed that is not a class or interface");
+      }
     }
-    MatchedSchema match =
-        matchSchema(*schema, loc, *f.graph(), inputsWithSelf, attributes);
-    Value* output = f.graph()->insertMethodCall(method_name_, match);
+    auto match =
+        matchSchemas(schemas, loc, *f.graph(), inputsWithSelf, attributes);
+    Value* output =
+        f.graph()->insertMethodCall(method_names_[match.first], match.second);
     output->node()->setSourceRange(loc);
     return std::make_shared<SimpleValue>(output);
   }
 
  private:
   Value* self_;
-  std::string method_name_;
+  std::vector<std::string> method_names_;
 };
 
 struct TORCH_API PrintValue : public SugaredValue {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#27725 refactor tryMatchSchema (#26499)**

We've changed how these functions are used over time, so I cleaned up
the header file API to match. In particular:

* tryMatchSchemas was added since the overload logic got copy/pasted
into three separate locations.
* With this change, tryMatchSchema is no longer public, as it is not needed
  outside of tryMatchSchemas
* emitBuiltinFunction no longer needs a requires argument (it was always true)

* Argument order for all the schema matching stuff now puts the 'self'
builtin override last. This is only rarely used and was inconsistent with
matchSchema