### PR TITLE
Buffer to speed Unpickler

### DIFF
--- a/torch/csrc/jit/import.cpp
+++ b/torch/csrc/jit/import.cpp
@@ -101,15 +101,16 @@ IValue ScriptModuleDeserializer::readArchive(const std::string& archive_name) {
 
   size_t bytes_read = 0;
   auto data = reinterpret_cast<const char*>(pickle_ptr.get());
-  auto reader = [&](char* buffer, size_t len) {
-    if (bytes_read + len > pickle_size) {
-      return false;
+  auto reader = [&](char* buffer, size_t len) -> size_t {
+    if (bytes_read >= pickle_size) {
+      return 0;
     }
+    len = std::min(pickle_size - bytes_read, len);
     // Copy len bytes into buffer
     const char* start = data + bytes_read;
     std::memcpy(buffer, start, len);
     bytes_read += len;
-    return true;
+    return len;
   };
 
   auto class_resolver = [&](const c10::QualifiedName& qn) {

--- a/torch/csrc/jit/mobile/import.cpp
+++ b/torch/csrc/jit/mobile/import.cpp
@@ -137,15 +137,16 @@ c10::IValue BytecodeDeserializer::readArchive(const std::string& archive_name) {
 
   size_t bytes_read = 0;
   auto data = reinterpret_cast<const char*>(pickle_ptr.get());
-  auto reader = [&](char* buffer, size_t len) {
-    if (bytes_read + len > pickle_size) {
-      return false;
+  auto reader = [&](char* buffer, size_t len) -> size_t {
+    if (bytes_read >= pickle_size) {
+      return 0;
     }
+    len = std::min(pickle_size - bytes_read, len);
     // Copy len bytes into buffer
     const char* start = data + bytes_read;
     std::memcpy(buffer, start, len);
     bytes_read += len;
-    return true;
+    return len;
   };
 
   auto class_resolver = [&](const c10::QualifiedName& qn) {

--- a/torch/csrc/jit/pickle.cpp
+++ b/torch/csrc/jit/pickle.cpp
@@ -91,7 +91,7 @@ std::vector<char> pickle_save(const at::IValue& ivalue) {
 }
 
 IValue unpickle(
-    std::function<bool(char*, size_t)> reader,
+    std::function<size_t(char*, size_t)> reader,
     ClassResolver class_resolver,
     const std::vector<at::Tensor>* tensor_table) {
   Unpickler unpickler(
@@ -106,15 +106,16 @@ IValue unpickle(
     const std::vector<at::Tensor>* tensor_table) {
   size_t bytes_read = 0;
   return unpickle(
-      [&](char* buffer, size_t len) {
-        if (bytes_read + len > size) {
-          return false;
+      [&](char* buffer, size_t len) -> size_t {
+        if (bytes_read >= size) {
+          return 0;
         }
+        len = std::min(size - bytes_read, len);
         // Copy len bytes into buffer
         const char* start = data + bytes_read;
         std::memcpy(buffer, start, len);
         bytes_read += len;
-        return true;
+        return len;
       },
       std::move(class_resolver),
       tensor_table);

--- a/torch/csrc/jit/pickle.h
+++ b/torch/csrc/jit/pickle.h
@@ -57,10 +57,10 @@ TORCH_API std::vector<char> pickle_save(const IValue& ivalue);
 
 /// `reader` is a function that takes in a size to read from some pickled
 /// binary. `reader` should remember where it last read, and return
-/// false if the read was not successful.
+/// the number of bytes read.
 /// See `torch::pickle` for details.
 TORCH_API IValue unpickle(
-    std::function<bool(char*, size_t)> reader,
+    std::function<size_t(char*, size_t)> reader,
     ClassResolver class_resolver,
     const std::vector<at::Tensor>* tensor_table);
 

--- a/torch/csrc/jit/unpickler.h
+++ b/torch/csrc/jit/unpickler.h
@@ -21,7 +21,7 @@ class Unpickler {
  public:
   // tensors inside the pickle are references to the tensor_table
   Unpickler(
-      std::function<bool(char*, size_t)> reader,
+      std::function<size_t(char*, size_t)> reader,
       ClassResolver class_resolver,
       const std::vector<at::Tensor>* tensor_table)
       : reader_(reader),
@@ -31,7 +31,7 @@ class Unpickler {
   // tensors inside the pickle contain meta-data, the raw tensor
   // dead is retrieved by calling `read_record`.
   Unpickler(
-      std::function<bool(char*, size_t)> reader,
+      std::function<size_t(char*, size_t)> reader,
       ClassResolver class_resolver,
       ObjLoader obj_loader,
       std::function<at::DataPtr(const std::string&)> read_record,
@@ -51,25 +51,37 @@ class Unpickler {
   template <typename T>
   T read() {
     T item;
-    if (!reader_(reinterpret_cast<char*>(&item), sizeof(item))) {
-      AT_ERROR("Unexpected end of pickler archive.");
+    if (sizeof(T) <= buffer_remaining_) {
+      // Fast path: entirely from buffer.
+      memcpy(&item, buffer_.data() + buffer_pos_, sizeof(T));
+      buffer_remaining_ -= sizeof(T);
+      buffer_pos_ += sizeof(T);
+    } else {
+      // Don't over-template the slow path, to avoid code size bloat.
+      readSlowWithBuffer(reinterpret_cast<char*>(&item), sizeof(T));
     }
     return item;
   }
-
+  void readSlowWithBuffer(char *dest, size_t sz);
   std::string readBytes(size_t num_bytes);
 
   double readFloat();
   PickleOpCode readInstruction();
-  PickleOpCode readOpCode();
+  PickleOpCode readOpCode() {
+    return static_cast<PickleOpCode>(read<uint8_t>());
+  }
   std::string readString();
   void readList(IValue list_ivalue);
   void setInput(size_t memo_id);
   void run();
 
-  // Returns a pointer to the number of bytes requested. This should state-fully
-  // remember how many bytes have been read
-  std::function<bool(char*, size_t)> reader_;
+  // Returns the number of bytes read. This should statefully
+  // remember the position. Don't call reader_ directly.
+  std::function<size_t(char*, size_t)> reader_;
+  // Small buffer to avoid calling reader_ on a per-byte basis.
+  std::array<char, 256> buffer_;
+  size_t buffer_pos_{0};
+  size_t buffer_remaining_{0};
 
   std::vector<IValue> stack_;
 


### PR DESCRIPTION
Summary:
This change uses a small buffer in the Unpickler to avoid
calling reader_() byte-by-byte. Particularly, the unpickler has a
tight loop reading 1-byte opcodes.

This can be more efficient because we avoid the variable-sized
memcpy (due to templating) and std::function indirection for the
common fast path.

This improves the unpickle-1m-ints benchmark by ~20%.

This change requires changing the std::function<> interface
to Unpickler to return size_t rather than bool, but there are
only a few uses of this api.

Differential Revision: D17869980

