### PR TITLE
Better hashing for constant pool

### DIFF
--- a/torch/csrc/jit/node_hashing.cpp
+++ b/torch/csrc/jit/node_hashing.cpp
@@ -112,10 +112,22 @@ bool attributesEqualCSE(const Node* lhs, const Node* rhs) {
 
 size_t HashNode::operator()(const Node* k) const {
   AT_ASSERT(k != nullptr);
+  size_t constant_hash = 0;
+  if (k->kind() == prim::Constant) {
+    TypePtr type = k->output()->type();
+    if (type->isSubtypeOf(NumberType::get()) && k->kindOf(attr::value) == AttributeKind::i) {
+      constant_hash = std::hash<int64_t>{}(k->i(attr::value));
+    } else if (type->isSubtypeOf(NumberType::get()) && k->kindOf(attr::value) == AttributeKind::f) {
+      constant_hash = std::hash<float>{}(k->f(attr::value));
+    } else if (type->isSubtypeOf(BoolType::get())) {
+      constant_hash = std::hash<bool>{}(k->i(attr::value));
+    }
+  }
   return get_hash(
       k->kind(),
       fmap(k->outputs(), [](const Value* v) { return v->type()->kind(); }),
-      fmap(k->inputs(), [](const Value* v) { return v->unique(); }));
+      fmap(k->inputs(), [](const Value* v) { return v->unique(); }),
+      constant_hash);
 };
 
 bool EqualNode::operator()(const Node* lhs, const Node* rhs) const {


### PR DESCRIPTION
Some models many contain thousands constants (like list of ints) and Constant Pooling and CSE pass will move the constant around and update the constant pooling.

However our existing hash function only consider the node type + input type + output node (https://bddppq.github.io/codebrowser/pytorch/pytorch/torch/csrc/jit/node_hashing.cpp.html#_ZNK5torch3jit8HashNodeclEPKNS0_4NodeE), which will have a lot of conflicts... I have profiled, one insert may take as long as about 0.2 second...  And loading the model will take 200 second, which is insane.

So we should fix this performance issue by considering the constant value as well to avoid the conflict.