### PR TITLE
[TSAN] Disable TSAN test for LiteInterpreterConv

### DIFF
--- a/test/cpp/jit/test_lite_interpreter.cpp
+++ b/test/cpp/jit/test_lite_interpreter.cpp
@@ -44,6 +44,10 @@ void testLiteInterpreterAdd() {
 }
 
 void testLiteInterpreterConv() {
+  auto s = std::getenv("PYTORCH_TEST_WITH_TSAN");
+  if (s && strcmp(s, "1") == 0)
+    return;
+
   std::vector<torch::jit::IValue> inputs;
 
   script::Module m("m");


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#27748 [TSAN] Disable TSAN test for LiteInterpreterConv**

There's TSAN test failure. From stack it's likely related to mkldnn (https://github.com/pytorch/pytorch/issues/27497). Before the issue is resolved, disable TSAN test.

Differential Revision: [D17880082](https://our.internmc.facebook.com/intern/diff/D17880082/)