### PR TITLE
Initial commit for L0 norm approx

### DIFF
--- a/caffe2/python/regularizer.py
+++ b/caffe2/python/regularizer.py
@@ -43,7 +43,20 @@ class Regularizer(object):
         return None
 
     def _feature_grouping(self, param, net):
-        return None
+        # Possible alternative grouping method via summing over absolute values
+        # Compute l2norm over feature weights
+        # pow( sum_i { pow(theda_i, 2) } ,  0.5)
+        param_mul = net.Mul([param, param], [net.NextScopedBlob("param_mul")])
+        param_reduced = net.ReduceFrontSum(
+            [param_mul], [net.NextScopedBlob("param_reduced")]
+        )
+        grouped_feature_weight_vec = net.Pow(
+            [param_reduced],
+            [net.NextScopedBlob("grouped_feature_weight_vec")],
+            exponent=0.5,
+        )
+
+        return grouped_feature_weight_vec
 
     def _ensure_clipped(
         self,
@@ -87,29 +100,21 @@ class L1Norm(Regularizer):
         net.Scale([output_blob], [output_blob], scale=self.reg_lambda)
         return output_blob
 
-class FCInputLpNorm(Regularizer):
+class LpNorm(Regularizer):
     def __init__(self, reg_lambda, p_value=0.5):
-        super(FCInputLpNorm, self).__init__()
-        assert reg_lambda >= 0, "factor ahead of regularization should be 0 or positive"
-        assert p_value >= 0, "p_value factor should be 0 or positive"
+        """
+        reg_lambda: parameter to scale regularization by
+
+        p_value:    determines what type of Lp norm to calculate. If p > 0,
+                    we will calculate Lp norm with the formula:
+                    pow( sum_i { pow(theda_i, p) } ,  1/p)
+        """
+        super(LpNorm, self).__init__()
+        assert reg_lambda > 0, "factor ahead of regularization should be greater than 0"
+        assert p_value > 0, "p_value factor should be greater than 0"
         self.p_value = p_value
         self.reg_lambda = reg_lambda
 
-    def _feature_grouping(self, param, net):
-        # Possible alternative grouping method via summing over absolute values
-        # Compute l2norm over feature weights
-        # pow( sum_i { pow(theda_i, 2) } ,  0.5)
-        param_mul = net.Mul([param, param], [net.NextScopedBlob("param_mul")])
-        param_reduced = net.ReduceFrontSum(
-            [param_mul], [net.NextScopedBlob("param_reduced")]
-        )
-        grouped_feature_weight_vec = net.Pow(
-            [param_reduced],
-            [net.NextScopedBlob("grouped_feature_weight_vec")],
-            exponent=0.5,
-        )
-
-        return grouped_feature_weight_vec
 
     def _run_on_loss(self, net, param_init_net, param, grad=None):
         # TODO: the second dim (num of input nodes) of param is after feature preproc,
@@ -120,18 +125,61 @@ class FCInputLpNorm(Regularizer):
         output_blob = net.NextScopedBlob(param + "_dense_feature_regularization")
         grouped_feature_weight_vec = self._feature_grouping(param, net)
 
-        # Compute Lpnorm over l2norm:
+        # Compute Lpnorm:
         # pow( sum_i { pow(theda_i, p) } ,  1/p)
         lp_vec_raised = net.Pow(
-            [grouped_feature_weight_vec], [net.NextScopedBlob("lp_vec_raised")], exponent=self.p_value
+            [grouped_feature_weight_vec],
+            [net.NextScopedBlob("lp_vec_raised")],
+            exponent=self.p_value,
         )
         lp_vec_summed = net.ReduceFrontSum(
             [lp_vec_raised], [net.NextScopedBlob("lp_vec_summed")]
         )
-        lp_vec = net.Pow(
-            [lp_vec_summed], [net.NextScopedBlob("lp_vec")], exponent=(1 / self.p_value)
+        lp_norm = net.Pow(
+            [lp_vec_summed],
+            [net.NextScopedBlob("lp_vec")],
+            exponent=(1 / self.p_value),
         )
-        net.Scale([lp_vec], [output_blob], scale=self.reg_lambda)
+        net.Scale([lp_norm], [output_blob], scale=self.reg_lambda)
+        return output_blob
+
+
+class L0ApproxNorm(Regularizer):
+    def __init__(self, reg_lambda, alpha=0.01):
+        """
+        reg_lambda: parameter to scale regularization by
+
+        alpha:      hyper parameter to tune that is only used in the calculation
+                    of approxiamte L0 norm.
+        """
+        super(L0ApproxNorm, self).__init__()
+        assert reg_lambda > 0, "factor ahead of regularization should be greater than 0"
+        assert alpha > 0, "alpha factor must be a positive value greater than 0"
+        self.reg_lambda = reg_lambda
+        self.alpha = alpha
+
+
+    def _run_on_loss(self, net, param_init_net, param, grad=None):
+        # TODO: the second dim (num of input nodes) of param is after feature preproc,
+        # and does not correspond to the original num of dense features.
+        # In the future, will want to create a util to reduce the input dim of param to
+        # match the num of dense features.
+
+        output_blob = net.NextScopedBlob(param + "_dense_feature_regularization")
+        grouped_feature_weight_vec = self._feature_grouping(param, net)
+
+        # compute approximate L0 norm
+        # sum_i ( min ( abs (theta_i), alpha))) / alpha
+        l0_abs = net.Abs(
+            [grouped_feature_weight_vec], [net.NextScopedBlob("l0_abs")]
+        )
+        l0_min = net.Clip([l0_abs], [net.NextScopedBlob("l0_min")], max=self.alpha)
+        l0_summed = net.ReduceFrontSum([l0_min], [net.NextScopedBlob("l0_summed")])
+        l0_norm = net.Scale(
+            [l0_summed], [net.NextScopedBlob("l0_norm")], scale=(1 / self.alpha)
+        )
+
+        net.Scale([l0_norm], [output_blob], scale=self.reg_lambda)
         return output_blob
 
 class L1NormTrimmed(Regularizer):


### PR DESCRIPTION
Summary:
Implement approximate L0 norm for use in the dense feature regularizer that will be used for feature importance. The formula is as follows:
{F212246801}

Reviewed By: wx1988

Differential Revision: D17432708

