### PR TITLE
Delete TEST_NAMEDTENSOR; run named tensor tests on all CIs

### DIFF
--- a/test/test_namedtensor.py
+++ b/test/test_namedtensor.py
@@ -11,7 +11,6 @@ import torch.nn.functional as F
 from multiprocessing.reduction import ForkingPickler
 import pickle
 import io
-import os
 import sys
 import warnings
 

--- a/test/test_namedtensor.py
+++ b/test/test_namedtensor.py
@@ -15,19 +15,9 @@ import os
 import sys
 import warnings
 
-
-def check_env_flag(name, default=''):
-    return os.getenv(name, default).upper() in ['ON', '1', 'YES', 'TRUE', 'Y']
-
-TEST_NAMEDTENSOR = check_env_flag('TEST_NAMEDTENSOR')
-
 skipIfNamedTensorDisabled = \
     unittest.skipIf(not torch._C._BUILD_NAMEDTENSOR,
                     'PyTorch not compiled with namedtensor support')
-
-skipIfNotTestingNamedTensor = \
-    unittest.skipIf(not TEST_NAMEDTENSOR,
-                    'TEST_NAMEDTENSOR=0; set it to 1 to enable named tensor tests')
 
 def pass_name_to_python_arg_parser(name):
     x = torch.empty(2, names=(name,))
@@ -1886,7 +1876,7 @@ class TestNamedTensor(TestCase):
 # Disable all tests if named tensor is not available.
 for attr in dir(TestNamedTensor):
     if attr.startswith('test_'):
-        new_test = skipIfNamedTensorDisabled(skipIfNotTestingNamedTensor(getattr(TestNamedTensor, attr)))
+        new_test = skipIfNamedTensorDisabled(getattr(TestNamedTensor, attr))
         setattr(TestNamedTensor, attr, new_test)
 
 if __name__ == '__main__':


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #27762 Remove named tensor builds from CI
* **#27760 Delete TEST_NAMEDTENSOR; run named tensor tests on all CIs**

There's nothing special about the named tensor tests that requires that
they be run in their own CI job. In this PR we delete the
TEST_NAMEDTENSOR flag that hides named tensor tests from regular jobs.
In the future, we'll delete the named tensor CI job so that we do not
duplicate signals.

Test Plan:
- wait for CI

Differential Revision: [D17882262](https://our.internmc.facebook.com/intern/diff/D17882262)