### PR TITLE
 Test graceful termination of RPCAgent with asymmetric load

### DIFF
--- a/test/rpc_test.py
+++ b/test/rpc_test.py
@@ -634,12 +634,10 @@ class RpcTest(object):
                 fut.wait()
                 self.assertEqual(fut.wait(), 0)
 
-            # Phase 1: Only worker2 has workload.
+            # Phase 2: Only worker2 has workload.
             # If join is not correctly implemented,
             # worker2 should be closed by now.
             dst = "worker2"
-            num_repeat = 200
-            futs = []
             for _ in range(num_repeat):
                 fut = rpc.rpc_async(dst, heavy_rpc, args=(torch.ones(100, 100),))
                 futs.append(fut)

--- a/test/rpc_test.py
+++ b/test/rpc_test.py
@@ -605,6 +605,52 @@ class RpcTest(object):
         )
         self.assertEqual(rref.to_here(), torch.ones(n, n) * 2)
 
+    def test_asymmetric_load_with_join(self):
+        """Test graceful termination."""
+        # Initialize RPC.
+        dist.init_process_group(backend="gloo", init_method=self.init_method)
+        rpc.init_model_parallel(
+            self_name="worker%d" % self.rank,
+            backend=TEST_CONFIG.backend,
+            self_rank=self.rank,
+            init_method=self.init_method,
+        )
+
+        # worker0 drives and waits for worker1 and worker2
+        # throughout the test.
+        if self.rank == 0:
+            assert self.world_size >= 3
+
+            num_repeat = 200
+            futs = []
+
+            # Phase 1: Only worker1 has workload.
+            dst = "worker1"
+            for _ in range(num_repeat):
+                fut = rpc.rpc_async(dst, heavy_rpc, args=(torch.ones(100, 100),))
+                futs.append(fut)
+
+            for fut in futs:
+                fut.wait()
+                self.assertEqual(fut.wait(), 0)
+
+            # Phase 1: Only worker2 has workload.
+            # If join is not correctly implemented,
+            # worker2 should be closed by now.
+            dst = "worker2"
+            num_repeat = 200
+            futs = []
+            for _ in range(num_repeat):
+                fut = rpc.rpc_async(dst, heavy_rpc, args=(torch.ones(100, 100),))
+                futs.append(fut)
+
+            for fut in futs:
+                fut.wait()
+                self.assertEqual(fut.wait(), 0)
+
+        # Close RPC.
+        rpc.join_rpc()
+
     def _test_multi_remote_call(self, fn, args_fn=lambda x: (), kwargs_fn=lambda x: {}):
         m = 10
         n = self.rank + 1

--- a/test/rpc_test.py
+++ b/test/rpc_test.py
@@ -605,17 +605,9 @@ class RpcTest(object):
         )
         self.assertEqual(rref.to_here(), torch.ones(n, n) * 2)
 
+    @dist_init
     def test_asymmetric_load_with_join(self):
         """Test graceful termination."""
-        # Initialize RPC.
-        dist.init_process_group(backend="gloo", init_method=self.init_method)
-        rpc.init_model_parallel(
-            self_name="worker%d" % self.rank,
-            backend=TEST_CONFIG.backend,
-            self_rank=self.rank,
-            init_method=self.init_method,
-        )
-
         # worker0 drives and waits for worker1 and worker2
         # throughout the test.
         if self.rank == 0:
@@ -645,9 +637,6 @@ class RpcTest(object):
             for fut in futs:
                 fut.wait()
                 self.assertEqual(fut.wait(), 0)
-
-        # Close RPC.
-        rpc.join_rpc()
 
     def _test_multi_remote_call(self, fn, args_fn=lambda x: (), kwargs_fn=lambda x: {}):
         m = 10


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #27776 Add master to RPC test
* **#27761 Test graceful termination of RPCAgent with asymmetric load**

# Problem

`rpc_test` currently only has test cases that put equal amount of work on every worker node. 
The problem is that even if the `RpcAgent::sync` is implemented as an empty method. There is no termination misbehavior detected.

# Solution

At least add one imbalanced-loaded test.

Differential Revision: [D5361435](https://our.internmc.facebook.com/intern/diff/D5361435/)