### PR TITLE
[JIT] Sanitize module names on legacy import

### DIFF
--- a/torch/csrc/jit/import_legacy.cpp
+++ b/torch/csrc/jit/import_legacy.cpp
@@ -271,7 +271,11 @@ script::Module ScriptModuleDeserializer::LEGACY_convertModule(
   const auto atoms = c10::QualifiedName(module_def.name()).atoms();
   const size_t numPushed = atoms.size();
   for (const auto& atom : atoms) {
-    LEGACY_moduleStack_.emplace_back(atom);
+    auto is_digits = [](const std::string& str) {
+      return std::all_of(str.begin(), str.end(), ::isdigit);
+    };
+    auto sanitized = is_digits(atom) ? std::string("_") + atom : atom;
+    LEGACY_moduleStack_.emplace_back(sanitized);
   }
   auto module = script::Module(
       c10::QualifiedName(LEGACY_moduleStack_), compilation_unit_);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#27764 [JIT] Sanitize module names on legacy import**

Differential Revision: [D17882924](https://our.internmc.facebook.com/intern/diff/D17882924)