### PR TITLE
[WIP] Move quantized::add_scalar and quantized::add_scalar_relu to ATen

### DIFF
--- a/aten/src/ATen/core/op_registration/op_registration.h
+++ b/aten/src/ATen/core/op_registration/op_registration.h
@@ -372,7 +372,11 @@ public:
       static_assert(!std::is_same<FuncType, KernelFunction::BoxedKernelFunction>::value, "Tried to register a stackbased (i.e. internal) kernel function using the public kernel<...>() API. Please either use the internal kernel(...) API or also implement the kernel function as defined by the public API.");
       static_assert(kernel_func != nullptr, "Kernel function cannot be nullptr");
 
-      at::globalATenDispatch().registerOp<FuncType>(dispatch_key, legacyATenSchema_->c_str(), kernel_func);
+      if (legacyATenSchema_.has_value()) {
+        at::globalATenDispatch().registerOp<FuncType>(dispatch_key, legacyATenSchema_->c_str(), kernel_func);
+      } else {
+        at::globalATenDispatch().registerOp<FuncType>(dispatch_key, c10::toString(schemaOrName_->right()).c_str(), kernel_func);          
+      }
       return std::move(*this);
     }
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -286,6 +286,7 @@
     SparseCPU: add_sparse
     SparseCUDA: add_sparse
     MkldnnCPU: mkldnn_add
+    QuantizedCPU: quantized_add
   supports_named_tensor: True
 
 - func: add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)
@@ -306,6 +307,7 @@
     SparseCPU: add_out_sparse_cpu
     SparseCUDA: add_out_sparse_cuda
     MkldnnCPU: mkldnn_add_out
+    QuantizedCPU: quantized_add_out
   supports_named_tensor: True
 
 # For C++ only, until we have conversion from C++ numbers to Tensor
@@ -314,10 +316,44 @@
   variants: function, method
   supports_named_tensor: True
 
+- func: quantized::add_scalar(Tensor self, Scalar other) -> Tensor
+  matches_jit_signature: False
+  use_c10_dispatcher: unboxed_only
+  dispatch:
+    QuantizedCPU: quantized_add_scalar
+
+- func: quantized::add_scalar_(Tensor(a!) self, Scalar other) -> Tensor(a!)
+  matches_jit_signature: False
+  use_c10_dispatcher: unboxed_only
+  dispatch:
+    QuantizedCPU: quantized_add_scalar_
+
+- func: quantized::add_scalar.out(Tensor self, Scalar other, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: False
+  dispatch:
+    QuantizedCPU: quantized_add_scalar_out
+
 - func: add_.Scalar(Tensor(a!) self, Scalar other, Scalar alpha=1) -> Tensor(a!)
   use_c10_dispatcher: unboxed_only
   variants: method
   supports_named_tensor: True
+
+- func: quantized::add_scalar_relu(Tensor self, Scalar other) -> Tensor
+  matches_jit_signature: False
+  use_c10_dispatcher: unboxed_only
+  dispatch:
+    QuantizedCPU: quantized_add_scalar_relu
+
+- func: quantized::add_scalar_relu_(Tensor(a!) self, Scalar other) -> Tensor(a!)
+  matches_jit_signature: False
+  use_c10_dispatcher: unboxed_only
+  dispatch:
+    QuantizedCPU: quantized_add_scalar_relu_
+
+- func: quantized::add_scalar_relu.out(Tensor self, Scalar other, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: False
+  dispatch:
+    QuantizedCPU: quantized_add_scalar_relu_out
 
 - func: addmv(Tensor self, Tensor mat, Tensor vec, *, Scalar beta=1, Scalar alpha=1) -> Tensor
   use_c10_dispatcher: full

--- a/aten/src/ATen/native/quantized/cpu/quantized_ops.h
+++ b/aten/src/ATen/native/quantized/cpu/quantized_ops.h
@@ -8,6 +8,8 @@ namespace native {
 using qrelu_fn = void (*)(const at::Tensor& /*qx*/, at::Tensor& /*qy*/);
 using qadd_fn =
     void (*)(Tensor& /*out*/, const Tensor& /*self*/, const Tensor& /*other*/);
+using qadd_scalar_fn =
+    void (*)(Tensor& /*out*/, const Tensor& /*self*/, Scalar /*other*/);
 using qmaxpool_2d_fn = void (*)(
     const Tensor& qx,
     int64_t iC, // input/output channels
@@ -79,6 +81,8 @@ DECLARE_DISPATCH(qrelu_fn, qrelu_stub);
 DECLARE_DISPATCH(qrelu_fn, qrelu6_stub);
 DECLARE_DISPATCH(qadd_fn, qadd_stub);
 DECLARE_DISPATCH(qadd_fn, qadd_relu_stub);
+DECLARE_DISPATCH(qadd_scalar_fn, qadd_scalar_stub);
+DECLARE_DISPATCH(qadd_scalar_fn, qadd_scalar_relu_stub);
 DECLARE_DISPATCH(qmaxpool_2d_fn, qmaxpool_2d_nhwc_stub);
 DECLARE_DISPATCH(qadaptive_avg_pool2d_fn, qadaptive_avg_pool2d_nhwc_stub);
 DECLARE_DISPATCH(qavg_pool2d_fn, qavg_pool2d_nhwc_stub);

--- a/aten/src/ATen/native_parse.py
+++ b/aten/src/ATen/native_parse.py
@@ -382,9 +382,15 @@ def run(paths):
         for func in parse_native_yaml(path):
             declaration = {'mode': 'native'}
             try:
-                declaration['schema_string'] = "aten::" + func['func']
-                if '->' in func['func']:
-                    func_decl, return_decl = [x.strip() for x in func['func'].split('->')]
+                schema = func['func']
+                if '::' not in schema:
+                    schema_string = "aten::" + schema
+                else:
+                    schema_string = schema
+                    schema = schema.replace('::', '_')
+                declaration['schema_string'] = schema_string
+                if '->' in schema_string:
+                    func_decl, return_decl = [x.strip() for x in schema.split('->')]
                 else:
                     raise Exception('Expected return declaration')
                 fn_name, arguments = func_decl.split('(', 1)
@@ -392,7 +398,7 @@ def run(paths):
                     fn_name, overload_name = fn_name.split('.', 1)
                 else:
                     overload_name = ''
-                assert arguments[-1] == ")", "Expecting closing ) for {}".format(func['func'])
+                assert arguments[-1] == ")", "Expecting closing ) for {}".format(schema)
                 arguments = arguments[:-1]  # Expect closing )
                 declaration['name'] = func.get('name', fn_name)
                 declaration['operator_name'] = func.get('name', fn_name)


### PR DESCRIPTION
This is a WIP attempt to fix #27097.

This compiles and I'm able to do `import torch` but when I access `pytorch.ops.quantized.add_scalar`, I get an error:

```
In [3]: torch.ops.quantized.add_scalar
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
<ipython-input-3-4f39065448d7> in <module>
----> 1 torch.ops.quantized.add_scalar

~/pytorch/torch/_ops.py in __getattr__(self, op_name)
     59         # for overloads and raise an exception if there are more than one.
     60         qualified_op_name = '{}::{}'.format(self.name, op_name)
---> 61         op = torch._C._jit_get_operation(qualified_op_name)
     62         # let the script frontend know that op is identical to the builtin op
     63         # with qualified_op_name

RuntimeError: Found 2 overloads for operator quantized::add_scalar! Overloads are not supported from Python.
```

