### PR TITLE
Rename `BACKEND` to be `RPC_BACKEND` to be seperated from `COMMUNICATION_BACKEND` like gloo,nccl, in `rpc_test.py`

### DIFF
--- a/test/dist_utils.py
+++ b/test/dist_utils.py
@@ -40,7 +40,7 @@ def dist_init(test_method):
         dist.init_process_group(backend="gloo", init_method=self.init_method)
         rpc.init_model_parallel(
             self_name="worker%d" % self.rank,
-            backend=TEST_CONFIG.backend,
+            backend=TEST_CONFIG.rpc_backend,
             self_rank=self.rank,
             init_method=self.init_method,
         )

--- a/test/dist_utils.py
+++ b/test/dist_utils.py
@@ -22,7 +22,7 @@ class TestConfig:
             setattr(self, k, v)
 
 
-TEST_CONFIG = TestConfig(backend=getenv("RPC_BACKEND", RpcBackend.PROCESS_GROUP))
+TEST_CONFIG = TestConfig(rpc_backend=getenv("RPC_BACKEND", RpcBackend.PROCESS_GROUP))
 INIT_METHOD_TEMPLATE = "file://{file_name}?rank={rank}&world_size={world_size}"
 
 

--- a/test/dist_utils.py
+++ b/test/dist_utils.py
@@ -14,7 +14,7 @@ if not dist.is_available():
 
 
 class TestConfig:
-    __slots__ = ['backend']
+    __slots__ = ['rpc_backend']
 
     def __init__(self, *args, **kwargs):
         assert len(args) == 0, "TestConfig only takes kwargs."

--- a/test/rpc_test.py
+++ b/test/rpc_test.py
@@ -237,7 +237,7 @@ class RpcTest(object):
         rpc.init_model_parallel(self_name="worker1", backend=backend_name, self_rank=1)
 
     @unittest.skipIf(
-        TEST_CONFIG.backend != RpcBackend.PROCESS_GROUP,
+        TEST_CONFIG.rpc_backend != RpcBackend.PROCESS_GROUP,
         "PROCESS_GROUP rpc backend specific test, skip",
     )
     def test_duplicate_name(self):
@@ -245,7 +245,7 @@ class RpcTest(object):
         with self.assertRaisesRegex(RuntimeError, "is not unique"):
             rpc.init_model_parallel(
                 self_name="duplicate_name",
-                backend=TEST_CONFIG.backend,
+                backend=TEST_CONFIG.rpc_backend,
                 self_rank=self.rank,
                 init_method=self.init_method,
             )
@@ -255,14 +255,14 @@ class RpcTest(object):
         dist.init_process_group(backend="gloo", init_method=self.init_method)
         rpc.init_model_parallel(
             self_name="worker{}".format(self.rank),
-            backend=TEST_CONFIG.backend,
+            backend=TEST_CONFIG.rpc_backend,
             self_rank=self.rank,
             init_method=self.init_method,
         )
         with self.assertRaisesRegex(RuntimeError, "is already initialized"):
             rpc.init_model_parallel(
                 self_name="worker{}".format(self.rank),
-                backend=TEST_CONFIG.backend,
+                backend=TEST_CONFIG.rpc_backend,
                 self_rank=self.rank,
                 init_method=self.init_method,
             )
@@ -295,7 +295,7 @@ class RpcTest(object):
         with self.assertRaisesRegex(RuntimeError, "shorter than 128"):
             rpc.init_model_parallel(
                 self_name="".join(["a" for _ in range(500)]),
-                backend=TEST_CONFIG.backend,
+                backend=TEST_CONFIG.rpc_backend,
                 self_rank=self.rank,
                 init_method=self.init_method,
             )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#27792 Rename `BACKEND` to be `RPC_BACKEND` to be seperated from `COMMUNICATION_BACKEND` like gloo,nccl, in `rpc_test.py`**

Close https://github.com/pytorch/pytorch/issues/27232

Differential Revision: [D5474297](https://our.internmc.facebook.com/intern/diff/D5474297/)