### PR TITLE
Use dist.barrier() at the end of unit tests instead of join_rpc().

### DIFF
--- a/test/dist_utils.py
+++ b/test/dist_utils.py
@@ -43,8 +43,11 @@ def dist_init(test_method):
             backend=TEST_CONFIG.backend,
             self_rank=self.rank,
             init_method=self.init_method,
+            num_send_recv_threads=16,
         )
         test_method(self, *arg, **kwargs)
-        rpc.join_rpc()
+
+        # Synchronize all processes before shutting down.
+        dist.barrier()
 
     return wrapper


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#27799 Use dist.barrier() at the end of unit tests instead of join_rpc().**
* #27798 Test graceful termination with asymmetric load

dist.barrier() is sufficient to synchronize all processes before
shutting down for our unit tests. This change is on top of
https://github.com/pytorch/pytorch/pull/27761 to ensure the changes fix the
assymetric load issue.

Differential Revision: [D17893027](https://our.internmc.facebook.com/intern/diff/D17893027/)