### PR TITLE
[experiment] Revert "always use the closure to resolve variable names (#27515)"

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -3400,7 +3400,6 @@ def foo(x):
                 cu.define(full)
 
     def test_namedtuple_python(self):
-        global MyTuple, MyMod  # see [local resolution in python]
         MyTuple = namedtuple('MyTuple', ['a'])
 
         @torch.jit.unused
@@ -15001,7 +15000,6 @@ a")
         self.checkScript(fn, ())
 
     def test_named_tuple_redefine(self):
-        global _1, _2
         _1 = namedtuple('GoogLeNetOutputs', ['logits', 'aux_logits2', 'aux_logits1'])
         _2 = namedtuple('GoogLeNetOutputs', ['different'])
 
@@ -15012,7 +15010,6 @@ a")
                 return x
 
     def test_named_tuple_py2(self):
-        global _GoogLeNetOutputs  # see [local resolution in python]
         _GoogLeNetOutputs = namedtuple('GoogLeNetOutputs', ['logits', 'aux_logits2', 'aux_logits1'])
 
         @torch.jit.script
@@ -15027,7 +15024,6 @@ a")
         self.assertEqual(out.aux_logits1, vals[2])
 
     def test_named_tuple_good_error(self):
-        global _GoogLeNetOutputs  # see [local resolution in python]
         _GoogLeNetOutputs = namedtuple('GoogLeNetOutputs', ['logits', 'aux_logits2', 'aux_logits1'])
 
         @torch.jit.script
@@ -19374,7 +19370,6 @@ class TestClassType(JitTestCase):
                         self.attr = x
 
     def test_class_type_as_param(self):
-        global FooTest  # see [local resolution in python]
         @torch.jit.script  # noqa: B903
         class FooTest(object):
             def __init__(self, x):
@@ -19517,7 +19512,6 @@ class TestClassType(JitTestCase):
         self.assertEqual(2 * input, output)
 
     def test_python_interop(self):
-        global Foo   # see [local resolution in python]
         @torch.jit.script  # noqa: B903
         class Foo(object):
             def __init__(self, x, y):
@@ -19544,7 +19538,6 @@ class TestClassType(JitTestCase):
         self.assertEqual(y, f2.y)
 
     def test_class_specialization(self):
-        global Foo  # see [local resolution in python]
         @torch.jit.script  # noqa: B903
         class Foo(object):
             def __init__(self, x, y):
@@ -19569,7 +19562,6 @@ class TestClassType(JitTestCase):
         FileCheck().check_count("Double(*, *) = prim::GetAttr", 4).run(graphstr)
 
     def test_class_sorting(self):
-        global Foo  # see [local resolution in python]
         @torch.jit.script  # noqa: B903
         class Foo(object):
             def __init__(self, x):
@@ -19683,7 +19675,6 @@ class TestClassType(JitTestCase):
         self.assertEqual(3 * input, output)
 
     def test_interface(self):
-        global Foo, Bar, OneTwo, OneTwoThree, OneTwoWrong, NotMember, NotMember2
         @torch.jit.script
         class Foo(object):
             def __init__(self):
@@ -19845,7 +19836,6 @@ class TestClassType(JitTestCase):
         # NamedTuple inheritance errors
 
     def test_overloaded_fn(self):
-        global Foo, MyClass  # see [local resolution in python]
         @torch.jit.script
         class Foo(object):
             def __init__(self, x):
@@ -20001,7 +19991,6 @@ class TestClassType(JitTestCase):
                 return Foo(torch.tensor(1)) + Foo(torch.tensor(1))
 
     def test_cast_overloads(self):
-        global Foo  # see [local resolution in python]
         @torch.jit.script
         class Foo(object):
             def __init__(self, val):

--- a/test/test_jit_py3.py
+++ b/test/test_jit_py3.py
@@ -110,8 +110,6 @@ class TestScriptPy3(JitTestCase):
         FileCheck().check_not('TupleConstruct').run(foo.graph)
 
     def test_named_tuple_type_annotation(self):
-        global MyCoolNamedTuple  # see [local resolution in python]
-
         class MyCoolNamedTuple(NamedTuple):
             a : int
             b : float

--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -16,25 +16,25 @@ from torch._utils_internal import get_source_lines_and_file
 boolean_dispatched = weakref.WeakKeyDictionary()  # noqa: T484
 
 
-def createResolutionCallbackFromFrame(frames_up=0):
+def createResolutionCallback(frames_up=0):
     """
     Creates a function which, given a string variable name,
     returns the value of the variable in the scope of the caller of
-    the function which called createResolutionCallbackFromFrame (by default).
+    the function which called createResolutionCallback (by default).
 
     This is used to enable access in-scope Python variables inside
     TorchScript fragments.
 
     frames_up is number of additional frames to go up on the stack.
     The default value is 0, which correspond to the frame of the caller
-    of createResolutionCallbackFromFrame. Also for example, if frames_up is set
-    to 1, then the frame of the caller's caller of createResolutionCallbackFromFrame
+    of createResolutionCallback. Also for example, if frames_up is set
+    to 1, then the frame of the caller's caller of createResolutionCallback
     will be taken.
 
     For example, the following program prints 2::
 
         def bar():
-            cb = createResolutionCallbackFromFrame(1)
+            cb = createResolutionCallback(1)
             print(cb("foo"))
 
         def baz():
@@ -74,48 +74,6 @@ def get_closure(fn):
         captures[captured_name] = fn.__closure__[index].cell_contents
 
     return captures
-
-# [local resolution in python]
-# Depending on where a variable is defined, and where it is used, we may
-# or may not be able to recover its value when recursively compiling a
-# script function. Remember in the general case, a module or function is
-# first defined and then later scripted. This means we do not have a
-# chance to capture the active frames when the function is defined. Hence any
-# name resolution has to happen later on the created closure. The way
-# python captures type annotations restricts what we can recover. The
-# follow example illustrates the different cases:
-#
-#         class MyGlobalClass:
-#         ...
-#         def my_local_scope():
-#             @torch.jit.script
-#             class MyClass:
-#                 ...
-#             @torch.jit.script
-#             class MyClassUsedAsVar:
-#                 ...
-#             def eg(x: MyClass, y: MyGlobalClass):
-#                 a_local_capture : Foo
-#                 return MyClassUsedAsVar(x)
-#
-# MyGlobalClass is defined in the __globals__ dictionary of function
-# 'eg', so it is always recoverable. my_local_scope introduces a new local
-# variable scope in the function. Classes defined here are only visible as
-# local variables. For the case of MyClassUsedAsVar, it is captured
-# because it is used as a variable inside the body of the function, and we
-# can resolve it using the captures returned from `get_closure`. However,
-# the type annotations are not captured by the closure. In Python
-# 3.0--3.9, the _value_ of MyClass and MyGlobalClass will be availiable as
-# annotations on `eg``, but starting in Python 4.0, they will represented as
-# strings and no longer present. Furthermore, since the body of `eg` does
-# not reference those names, they do not appear in the list of closed over
-# variables. In Python 2.x, type annotations are in comments, leading to a
-# similar situation where their definitions are not available. We anticipate
-# that most users will not run into this issue because their modules and
-# functions will be defined at a global scope like MyGlobalClass. In cases
-# where they are not, it is possible to work around issues by declaring the
-# values global in the function.
-
 
 
 def createResolutionCallbackFromClosure(fn):

--- a/torch/csrc/jit/script/python_sugared_value.cpp
+++ b/torch/csrc/jit/script/python_sugared_value.cpp
@@ -660,8 +660,7 @@ std::shared_ptr<SugaredValue> toSugaredValue(
   // methods here have been explicitly annotated to not be compiled,
   // so they do not have the same overload and compile checks as for functions
   if (isFunction || isMethod) {
-    auto rcb = py::module::import("torch._jit_internal")
-                   .attr("createResolutionCallbackFromClosure")(obj);
+    auto rcb = py::module::import("torch.jit").attr("_gen_rcb")(obj, 0);
     return std::make_shared<PythonValue>(obj, rcb);
   }
 

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1019,7 +1019,7 @@ class CompilationUnit(object):
 
     def define(self, lang, rcb=None, _frames_up=0):
         if not rcb:
-            rcb = _jit_internal.createResolutionCallbackFromFrame(_frames_up + 1)
+            rcb = _jit_internal.createResolutionCallback(_frames_up + 1)
         self._c.define(lang, rcb)
 
     def __getattr__(self, attr):
@@ -1217,18 +1217,36 @@ def script(obj, optimize=None, _frames_up=0, _rcb=None):
             raise RuntimeError("TorchScript classes must be new-style classes. "
                                "Please inherit from 'object'")
         if _rcb is None:
-            _rcb = _jit_internal.createResolutionCallbackFromFrame(_frames_up + 1)
+            _rcb = _jit_internal.createResolutionCallback(_frames_up + 1)
         _compile_and_register_class(obj, _rcb, qualified_name)
         return obj
     else:
         _check_directly_compile_overloaded(obj)
         ast = get_jit_def(obj)
         if _rcb is None:
-            _rcb = _jit_internal.createResolutionCallbackFromClosure(obj)
+            _rcb = _gen_rcb(obj, _frames_up)
         fn = torch._C._jit_script_compile(qualified_name, ast, _rcb, get_default_args(obj))
         # Forward docstrings
         fn.__doc__ = obj.__doc__
         return fn
+
+def _gen_rcb(obj, _frames_up):
+    _frames_up = _frames_up + 1  # for invoking _gen_rcb()
+
+    closure_rcb = _jit_internal.createResolutionCallbackFromClosure(obj)
+    stack_rcb = _jit_internal.createResolutionCallback(_frames_up + 1)
+
+    def _rcb(name):
+        # since type comments aren't captured in the function's closures,
+        # we still need to try to the rcb based on stack frames if the
+        # closure rcb fails
+        result = closure_rcb(name)
+        if result:
+            return result
+        return stack_rcb(name)
+
+    return _rcb
+
 
 def interface(obj):
     if not inspect.isclass(obj):
@@ -1237,7 +1255,7 @@ def interface(obj):
         raise RuntimeError("TorchScript interfaces must inherit from 'object'")
     qualified_name = _qualified_name(obj)
     ast = get_jit_class_def(obj, obj.__name__)
-    rcb = _jit_internal.createResolutionCallbackFromFrame(1)
+    rcb = _jit_internal.createResolutionCallback(1)
     torch._C._jit_script_interface_compile(qualified_name, ast, rcb)
     obj.__torch_script_interface__ = True
     return obj
@@ -1261,7 +1279,7 @@ def script_method(fn, _rcb=None):
     # createResolutionCallback internally adds 1 to get us to the scope of this
     # function (the calling function). Adding 2 gets us to the proper surrounding scope.
     if _rcb is None:
-        _rcb = _jit_internal.createResolutionCallbackFromFrame(frames_up=2)
+        _rcb = _jit_internal.createResolutionCallback(frames_up=2)
     ast = get_jit_def(fn, self_name="ScriptModule")
     return ScriptMethodStub(_rcb, ast, fn)
 
@@ -1622,7 +1640,7 @@ if _enabled:
             #
             # createResolutionCallback internally adds 1 to get us to our frame, then
             # we add 1 to get to the proper surrounding scope.
-            rcb = _jit_internal.createResolutionCallbackFromFrame(frames_up=1)
+            rcb = _jit_internal.createResolutionCallback(frames_up=1)
             self._c._define(self, lang, rcb)
 
         def copy(self):
@@ -1998,7 +2016,7 @@ _compiled_overloaded_fns = {}
 def _compile_function_with_overload(qual_name, impl_fn, overload_decl, overload_defaults):
     impl_ast = torch.jit.get_jit_def(impl_fn)
     _frames_up = 0
-    _rcb = _jit_internal.createResolutionCallbackFromClosure(impl_fn)
+    _rcb = _gen_rcb(impl_fn, _frames_up)
     fn = torch._C._jit_script_compile_overload(qual_name, overload_decl, impl_ast, _rcb, overload_defaults)
     return fn
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#27801 [experiment] Revert "always use the closure to resolve variable names (#27515)"**

I suspect the introduction of these globals is what is causing the py2
pybind errors on master. Let's see what happens with CI.