### PR TITLE
Add documentation for torch.lgamma

### DIFF
--- a/docs/source/tensors.rst
+++ b/docs/source/tensors.rst
@@ -307,6 +307,8 @@ view of a storage and defines numeric operations on it.
    .. automethod:: le_
    .. automethod:: lerp
    .. automethod:: lerp_
+   .. automethod:: lgamma
+   .. automethod:: lgamma_
    .. automethod:: log
    .. automethod:: log_
    .. automethod:: logdet

--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -212,6 +212,7 @@ Pointwise Ops
 .. autofunction:: frac
 .. autofunction:: imag
 .. autofunction:: lerp
+.. autofunction:: lgamma
 .. autofunction:: log
 .. autofunction:: log10
 .. autofunction:: log1p

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -224,8 +224,6 @@ class _TestTorchMixin(object):
                        'is_nonzero',
                        'is_same_size',
                        'isclose',
-                       'lgamma',
-                       'lgamma_',
                        'log_softmax',
                        'map2_',
                        'new',

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -1497,6 +1497,19 @@ lerp_(end, weight) -> Tensor
 In-place version of :meth:`~Tensor.lerp`
 """)
 
+add_docstr_all('lgamma',
+               r"""
+lgamma() -> Tensor
+
+See :func:`torch.lgamma`
+""")
+
+add_docstr_all('lgamma_', r"""
+lgamma_() -> Tensor
+
+In-place version of :meth:`~Tensor.lgamma`
+""")
+
 add_docstr_all('log',
                r"""
 log() -> Tensor

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -2537,6 +2537,26 @@ Example::
     tensor([ 5.5000,  6.0000,  6.5000,  7.0000])
 """.format(**common_args))
 
+add_docstr(torch.lgamma,
+           r"""
+lgamma(input, out=None) -> Tensor
+
+Computes the logarithm of the gamma function on :attr:`input`.
+
+.. math::
+    \text{out}_{i} = \log \Gamma(\text{input}_{i})
+""" + """
+Args:
+    {input}
+    {out}
+
+Example::
+
+    >>> a = torch.arange(0.5, 2, 0.5)
+    >>> torch.lgamma(a)
+    tensor([ 0.5724,  0.0000, -0.1208])
+""".format(**common_args))
+
 add_docstr(torch.linspace,
            r"""
 linspace(start, end, steps=100, out=None, dtype=None, layout=torch.strided, device=None, requires_grad=False) -> Tensor


### PR DESCRIPTION
Changelog:
- Add doc string in _torch_docs.py, _tensor_docs.py
- Expose in docs/source/torch.rst, docs/source/tensors.rst

Test Plan:
- Remove `lgamma`, `lgamma_` from the blacklist

Fixes #27783 