### PR TITLE
Disable test_gpu_speed_mnist.sh perf test

### DIFF
--- a/.jenkins/pytorch/short-perf-test-cpu.sh
+++ b/.jenkins/pytorch/short-perf-test-cpu.sh
@@ -42,6 +42,10 @@ if [[ "$COMMIT_SOURCE" == master ]]; then
     python update_commit_hash.py new_cpu_runtime.json ${MASTER_COMMIT_ID}
 fi
 
+popd
+python setup.py install
+pushd .jenkins/pytorch/perf_test
+
 # Include tests
 . ./test_cpu_speed_mini_sequence_labeler.sh
 # test_gpu_speed_mnist.sh and test_cpu_speed_mnist.sh run

--- a/.jenkins/pytorch/short-perf-test-cpu.sh
+++ b/.jenkins/pytorch/short-perf-test-cpu.sh
@@ -44,7 +44,11 @@ fi
 
 # Include tests
 . ./test_cpu_speed_mini_sequence_labeler.sh
-. ./test_cpu_speed_mnist.sh
+# test_gpu_speed_mnist.sh and test_cpu_speed_mnist.sh run
+# "conda install -c pytorch torchvision", which would install pytorch-1.3 libs.
+# These tests then work on Python source files from master, which is
+# inconsistent with underlying libs.
+#. ./test_cpu_speed_mnist.sh
 . ./test_cpu_speed_torch.sh
 . ./test_cpu_speed_torch_tensor.sh
 

--- a/.jenkins/pytorch/short-perf-test-cpu.sh
+++ b/.jenkins/pytorch/short-perf-test-cpu.sh
@@ -64,7 +64,7 @@ run_test test_cpu_speed_torch_tensor ${TEST_MODE}
 
 # Sample model tests
 run_test test_cpu_speed_mini_sequence_labeler 20 ${TEST_MODE}
-run_test test_cpu_speed_mnist 20 ${TEST_MODE}
+#run_test test_cpu_speed_mnist 20 ${TEST_MODE}
 
 if [[ "$COMMIT_SOURCE" == master ]]; then
     # This could cause race condition if we are testing the same master commit twice,

--- a/.jenkins/pytorch/short-perf-test-gpu.sh
+++ b/.jenkins/pytorch/short-perf-test-gpu.sh
@@ -54,13 +54,13 @@ fi
 
 # Run tests
 if [[ "$COMMIT_SOURCE" == master ]]; then
-    run_test test_gpu_speed_mnist 20 compare_and_update
+    #run_test test_gpu_speed_mnist 20 compare_and_update
     run_test test_gpu_speed_word_language_model 20 compare_and_update
     run_test test_gpu_speed_cudnn_lstm 20 compare_and_update
     run_test test_gpu_speed_lstm 20 compare_and_update
     run_test test_gpu_speed_mlstm 20 compare_and_update
 else
-    run_test test_gpu_speed_mnist 20 compare_with_baseline
+    #run_test test_gpu_speed_mnist 20 compare_with_baseline
     run_test test_gpu_speed_word_language_model 20 compare_with_baseline
     run_test test_gpu_speed_cudnn_lstm 20 compare_with_baseline
     run_test test_gpu_speed_lstm 20 compare_with_baseline

--- a/.jenkins/pytorch/short-perf-test-gpu.sh
+++ b/.jenkins/pytorch/short-perf-test-gpu.sh
@@ -42,7 +42,11 @@ if [[ "$COMMIT_SOURCE" == master ]]; then
 fi
 
 # Include tests
-. ./test_gpu_speed_mnist.sh
+# test_gpu_speed_mnist.sh and test_cpu_speed_mnist.sh run
+# "conda install -c pytorch torchvision", which would install pytorch-1.3 libs.
+# These tests then work on Python source files from master, which is
+# inconsistent with underlying libs.
+#. ./test_gpu_speed_mnist.sh
 . ./test_gpu_speed_word_language_model.sh
 . ./test_gpu_speed_cudnn_lstm.sh
 . ./test_gpu_speed_lstm.sh

--- a/.jenkins/pytorch/short-perf-test-gpu.sh
+++ b/.jenkins/pytorch/short-perf-test-gpu.sh
@@ -41,6 +41,10 @@ if [[ "$COMMIT_SOURCE" == master ]]; then
     python update_commit_hash.py new_gpu_runtime.json ${MASTER_COMMIT_ID}
 fi
 
+popd
+python setup.py install
+pushd .jenkins/pytorch/perf_test
+
 # Include tests
 # test_gpu_speed_mnist.sh and test_cpu_speed_mnist.sh run
 # "conda install -c pytorch torchvision", which would install pytorch-1.3 libs.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#27816 Disable test_gpu_speed_mnist.sh perf test**

Files test_gpu_speed_mnist.sh and test_cpu_speed_mnist.sh run
"conda install -c pytorch torchvision", which would install
pytorch-1.3 libs. These tests then work on Python source files
from master, which is inconsistent with underlying libs.

pytorch_short_perf_test_gpu is failing on master, see: https://circleci.com/gh/pytorch/pytorch/3177578?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

The error is:

```
Oct 12 02:34:34 Traceback (most recent call last):
Oct 12 02:34:34   File "main.py", line 3, in <module>
Oct 12 02:34:34     import torch
Oct 12 02:34:34   File "/opt/conda/lib/python3.6/site-packages/torch/__init__.py", line 280, in <module>
Oct 12 02:34:34     from .functional import *
Oct 12 02:34:34   File "/opt/conda/lib/python3.6/site-packages/torch/functional.py", line 2, in <module>
Oct 12 02:34:34     import torch.nn.functional as F
Oct 12 02:34:34   File "/opt/conda/lib/python3.6/site-packages/torch/nn/__init__.py", line 3, in <module>
Oct 12 02:34:34     from .parallel import DataParallel  # noqa: F401
Oct 12 02:34:34   File "/opt/conda/lib/python3.6/site-packages/torch/nn/parallel/__init__.py", line 5, in <module>
Oct 12 02:34:34     from .distributed import DistributedDataParallel
Oct 12 02:34:34   File "/opt/conda/lib/python3.6/site-packages/torch/nn/parallel/distributed.py", line 8, in <module>
Oct 12 02:34:34     import torch.distributed as dist
Oct 12 02:34:34   File "/opt/conda/lib/python3.6/site-packages/torch/distributed/__init__.py", line 23, in <module>
Oct 12 02:34:34     from .rpc import _init_rpc
Oct 12 02:34:34   File "/opt/conda/lib/python3.6/site-packages/torch/distributed/rpc/__init__.py", line 9, in <module>
Oct 12 02:34:34     from .api import _init_rpc
Oct 12 02:34:34   File "/opt/conda/lib/python3.6/site-packages/torch/distributed/rpc/api.py", line 2, in <module>
Oct 12 02:34:34     from torch.distributed import invoke_remote_builtin, invoke_remote_python_udf
Oct 12 02:34:34 ImportError: cannot import name 'invoke_remote_python_udf'
```

Differential Revision: [D17896802](https://our.internmc.facebook.com/intern/diff/D17896802)