### PR TITLE
Fix Type Errors in Examples about Named Tensor

### DIFF
--- a/docs/source/named_tensor.rst
+++ b/docs/source/named_tensor.rst
@@ -164,7 +164,7 @@ by name to a specified ordering. This is useful for performing "broadcasting by 
         return input * scale.align_as(input)
 
     >>> num_channels = 3
-    >>> scale = torch.randn(num_channels, names='C')
+    >>> scale = torch.randn(num_channels, names=('C',))
     >>> imgs = torch.rand(3, 3, 3, num_channels, names=('N', 'H', 'W', 'C'))
     >>> more_imgs = torch.rand(3, num_channels, 3, 3, names=('N', 'C', 'H', 'W'))
     >>> videos = torch.randn(3, num_channels, 3, 3, 3, names=('N', 'C', 'H', 'W', 'D')

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -314,7 +314,7 @@ Examples::
         return input * scale.align_as(input)
 
     >>> num_channels = 3
-    >>> scale = torch.randn(num_channels, names='C')
+    >>> scale = torch.randn(num_channels, names=('C',))
     >>> imgs = torch.rand(32, 128, 128, num_channels, names=('N', 'H', 'W', 'C'))
     >>> more_imgs = torch.rand(32, num_channels, 128, 128, names=('N', 'C', 'H', 'W'))
     >>> videos = torch.randn(3, num_channels, 128, 128, 128, names=('N', 'C', 'H', 'W', 'D'))


### PR DESCRIPTION
`names` should be `tuple`