### PR TITLE
DOC: torch.cuda.default_generators documentation referenced but don't exist. #27780

### DIFF
--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -94,12 +94,6 @@ Random sampling
 .. autoattribute:: torch.default_generator
    :annotation:  Returns the default CPU torch.Generator
 
-.. The following doesn't actually seem to exist.
-   https://github.com/pytorch/pytorch/issues/27780
-   .. autoattribute:: torch.cuda.default_generators
-      :annotation:  If cuda is available, returns a tuple of default CUDA torch.Generator-s.
-                    The number of CUDA torch.Generator-s returned is equal to the number of
-                    GPUs available in the system.
 .. autofunction:: bernoulli
 .. autofunction:: multinomial
 .. autofunction:: normal


### PR DESCRIPTION
Fixes issue - https://github.com/pytorch/pytorch/issues/27780

@ezyang @gchanan