### PR TITLE
Bag of documentation fixes; fix more sphinx warnings

### DIFF
--- a/docs/source/autograd.rst
+++ b/docs/source/autograd.rst
@@ -65,9 +65,8 @@ Variable (deprecated)
 Tensor autograd functions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. autoclass:: torch.Tensor
-   :members: grad, requires_grad, is_leaf, backward, detach, detach_, register_hook, retain_grad
-
    :noindex:
+   :members: grad, requires_grad, is_leaf, backward, detach, detach_, register_hook, retain_grad
 
 :hidden:`Function`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/autograd.rst
+++ b/docs/source/autograd.rst
@@ -66,7 +66,15 @@ Tensor autograd functions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. autoclass:: torch.Tensor
    :noindex:
-   :members: grad, requires_grad, is_leaf, backward, detach, detach_, register_hook, retain_grad
+
+   .. autoattribute:: grad
+   .. autoattribute:: requires_grad
+   .. autoattribute:: is_leaf
+   .. automethod:: backward
+   .. automethod:: detach
+   .. automethod:: detach_
+   .. automethod:: register_hook
+   .. automethod:: retain_grad
 
 :hidden:`Function`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/community/contribution_guide.rst
+++ b/docs/source/community/contribution_guide.rst
@@ -49,11 +49,13 @@ here is the basic process.
       operator/optimizer?” Giving evidence for its utility, e.g., usage
       in peer reviewed papers, or existence in other frameworks, helps a
       bit when making this case.
+
       - **Adding operators / algorithms from recently-released research**
         is generally not accepted, unless there is overwhelming evidence that
         this newly published work has ground-breaking results and will eventually
         become a standard in the field. If you are not sure where your method falls,
         open an issue first before implementing a PR.
+
    -  Core changes and refactors can be quite difficult to coordinate,
       as the pace of development on PyTorch master is quite fast.
       Definitely reach out about fundamental or cross-cutting changes;

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -56,6 +56,11 @@ extensions = [
     'javasphinx',
 ]
 
+# autosectionlabel throws warnings if section names are duplicated.
+# The following tells autosectionlabel to not throw a warning for
+# duplicated section names that are in different documents.
+autosectionlabel_prefix_document = True
+
 # katex options
 #
 #

--- a/docs/source/jit.rst
+++ b/docs/source/jit.rst
@@ -1625,6 +1625,7 @@ Frequently Asked Questions
 
 Q: I would like to train a model on GPU and do inference on CPU. What are the
 best practices?
+
    First convert your model from GPU to CPU and then save it, like so: ::
 
       cpu_model = gpu_model.cpu()
@@ -1696,6 +1697,7 @@ Q: I would like to trace module's method but I keep getting this error:
 
     This error usually means that the method you are tracing uses a module's parameters and
     you are passing the module's method instead of the module instance (e.g. ``my_module_instance.forward`` vs ``my_module_instance``).
+
       - Invoking ``trace`` with a module's method captures module parameters (which may require gradients) as **constants**.
       - On the other hand, invoking ``trace`` with module's instance (e.g. ``my_module``) creates a new module and correctly copies parameters into the new module, so they can accumulate gradients if required.
 

--- a/docs/source/jit.rst
+++ b/docs/source/jit.rst
@@ -245,7 +245,6 @@ Functions don't change much, they can be decorated with :func:`@torch.jit.ignore
     def some_fn4():
         return 2
 
-
 TorchScript Classes
 ~~~~~~~~~~~~~~~~~~~
 Everything in a user defined `TorchScript Class`_ is exported by default, functions

--- a/docs/source/multiprocessing.rst
+++ b/docs/source/multiprocessing.rst
@@ -1,4 +1,5 @@
 :orphan:
+
 .. _multiprocessing-doc:
 
 Multiprocessing package - torch.multiprocessing

--- a/docs/source/named_tensor.rst
+++ b/docs/source/named_tensor.rst
@@ -301,6 +301,7 @@ operators, see :ref:`name_inference_reference-doc`.
 
    .. automethod:: unflatten
    .. py:method:: flatten(dims, out_dim) -> Tensor
+      :noindex:
 
       Flattens :attr:`dims` into a single dimension with name :attr:`out_dim`.
 

--- a/docs/source/nn.init.rst
+++ b/docs/source/nn.init.rst
@@ -1,6 +1,8 @@
 .. role:: hidden
     :class: hidden-section
 
+.. _nn-init-doc:
+
 torch.nn.init
 =============
 

--- a/docs/source/nn.rst
+++ b/docs/source/nn.rst
@@ -883,4 +883,4 @@ Quantized Functions
 --------------------
 
 Quantization refers to techniques for performing computations and storing tensors at lower bitwidths than
-floating point precision. PyTorch supports both per tensor and per channel asymmetric linear quantization. To learn more how to use quantized functions in PyTorch, please refer to the :ref:`Quantization` documentation.
+floating point precision. PyTorch supports both per tensor and per channel asymmetric linear quantization. To learn more how to use quantized functions in PyTorch, please refer to the :ref:`quantization-doc` documentation.

--- a/docs/source/notes/cpu_threading_torchscript_inference.rst
+++ b/docs/source/notes/cpu_threading_torchscript_inference.rst
@@ -52,8 +52,10 @@ to speed up computations on CPU.
 
 ATen, MKL and MKL-DNN support intra-op parallelism and depend on the
 following parallelization libraries to implement it:
- * OpenMP_ - a standard (and a library, usually shipped with a compiler), widely used in external libraries;
- * TBB_ - a newer parallelization library optimized for task-based parallelism and concurrent environments.
+
+* OpenMP_ - a standard (and a library, usually shipped with a compiler), widely used in external libraries;
+* TBB_ - a newer parallelization library optimized for task-based parallelism and concurrent environments.
+
 OpenMP historically has been used by a large number of libraries. It is known
 for a relative ease of use and support for loop-based parallelism and other primitives.
 At the same time OpenMP is not known for a good interoperability with other threading

--- a/docs/source/notes/windows.rst
+++ b/docs/source/notes/windows.rst
@@ -157,7 +157,7 @@ be solved before we officially release it. You can build it by yourself.
 Import error
 ^^^^^^^^^^^^
 
-.. code-block:: py3tb
+.. code-block:: python
 
     from torch._C import *
 
@@ -188,7 +188,7 @@ uses MKL instead of OpenBLAS. You may type in the following command.
 Another possible cause may be you are using GPU version without NVIDIA
 graphics cards. Please replace your GPU package with the CPU one.
 
-.. code-block:: py3tb
+.. code-block:: python
 
     from torch._C import *
 
@@ -210,7 +210,7 @@ Usage (multiprocessing)
 Multiprocessing error without if-clause protection
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. code-block:: py3tb
+.. code-block:: python
 
     RuntimeError:
            An attempt has been made to start a new process before the
@@ -247,7 +247,7 @@ your code into the following structure.
 Multiprocessing error "Broken pipe"
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. code-block:: py3tb
+.. code-block:: python
 
     ForkingPickler(file, protocol).dump(obj)
 
@@ -261,7 +261,7 @@ can debug your code by reducing the ``num_worker`` of
 Multiprocessing error "driver shut down"
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. code-block:: py3tb
+.. code-block::
 
     Couldn’t open shared file mapping: <torch_14808_1591070686>, error code: <1455> at torch\lib\TH\THAllocator.c:154
 
@@ -275,7 +275,7 @@ update the TDR settings according to this `post
 CUDA IPC operations
 ^^^^^^^^^^^^^^^^^^^
 
-.. code-block:: py3tb
+.. code-block:: python
 
    THCudaCheck FAIL file=torch\csrc\generic\StorageSharing.cpp line=252 error=63 : OS call failed or operation not supported on this OS
 

--- a/docs/source/notes/windows.rst
+++ b/docs/source/notes/windows.rst
@@ -261,7 +261,7 @@ can debug your code by reducing the ``num_worker`` of
 Multiprocessing error "driver shut down"
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. code-block::
+::
 
     Couldn’t open shared file mapping: <torch_14808_1591070686>, error code: <1455> at torch\lib\TH\THAllocator.c:154
 

--- a/docs/source/quantization.rst
+++ b/docs/source/quantization.rst
@@ -188,7 +188,7 @@ Layers for the quantization-aware training
 Observers for computing the quantization parameters
 
 * :class:`~torch.quantization.MinMaxObserver` — Derives the quantization parameters from the running minimum and maximum of the observed tensor inputs (per tensor variant)
-* ``MovingAverageObserver`` — Derives the quantization parameters from the running averages of the minimums and maximums of the observed tensor inputs (per tensor variant)
+* :class:`~torch.quantization.MovingAverageMinMaxObserver` — Derives the quantization parameters from the running averages of the minimums and maximums of the observed tensor inputs (per tensor variant)
 * :class:`~torch.quantization.PerChannelMinMaxObserver`— Derives the quantization parameters from the running minimum and maximum of the observed tensor inputs (per channel variant)
 * :class:`~torch.quantization.MovingAveragePerChannelMinMaxObserver` — Derives the quantization parameters from the running averages of the minimums and maximums of the observed tensor inputs (per channel variant)
 * :class:`~torch.quantization.HistogramObserver` — Derives the quantization parameters by creating a histogram of running minimums and maximums.
@@ -400,8 +400,7 @@ Observers
 .. autoclass:: Observer
     :members:
 .. autoclass:: MinMaxObserver
-.. The following doesn't exist. https://github.com/pytorch/pytorch/issues/27849.
-   .. autoclass:: MovingAverageObserver
+.. autoclass:: MovingAverageMinMaxObserver
 .. autoclass:: PerChannelMinMaxObserver
 .. autoclass:: MovingAveragePerChannelMinMaxObserver
 .. autoclass:: HistogramObserver

--- a/docs/source/quantization.rst
+++ b/docs/source/quantization.rst
@@ -176,7 +176,7 @@ Layers for the quantization-aware training
     * :class:`~torch.quantization.Observer` — Abstract base class for observers
 * Quantization configurations
     * :class:`~torch.quantization.QConfig` — Quantization configuration class
-    * :attr:`~torch.quantization.default_qconfig` — Same as ``QConfig(activation=default_observer, weight=default_weight_observer)`` (See :class:`~torch.quantization.QConfig.QConfig`)
+    * ``default_qconfig`` — Same as ``QConfig(activation=default_observer, weight=default_weight_observer)`` (See :class:`~torch.quantization.QConfig.QConfig`)
     * :attr:`~torch.quantization.default_qat_qconfig` — Same as ``QConfig(activation=default_fake_quant, weight=default_weight_fake_quant)`` (See :class:`~torch.quantization.QConfig.QConfig`)
     * :attr:`~torch.quantization.default_dynamic_qconfig` — Same as ``QConfigDynamic(weight=default_weight_observer)`` (See :class:`~torch.quantization.QConfig.QConfigDynamic`)
     * :attr:`~torch.quantization.float16_dynamic_qconfig` — Same as ``QConfigDynamic(weight=NoopObserver.with_args(dtype=torch.float16))`` (See :class:`~torch.quantization.QConfig.QConfigDynamic`)
@@ -378,7 +378,9 @@ Top-level quantization APIs
 .. autofunction:: convert
 .. autoclass:: QConfig
 .. autoclass:: QConfigDynamic
-.. autoattribute:: default_qconfig
+
+.. FIXME: The following doesn't display correctly.
+   .. autoattribute:: default_qconfig
 
 Preparing model for quantization
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/quantization.rst
+++ b/docs/source/quantization.rst
@@ -1,3 +1,5 @@
+.. _quantization-doc:
+
 Quantization
 ===========================
 
@@ -186,7 +188,7 @@ Layers for the quantization-aware training
 Observers for computing the quantization parameters
 
 * :class:`~torch.quantization.MinMaxObserver` — Derives the quantization parameters from the running minimum and maximum of the observed tensor inputs (per tensor variant)
-* :class:`~torch.quantization.MovingAverageObserver` — Derives the quantization parameters from the running averages of the minimums and maximums of the observed tensor inputs (per tensor variant)
+* ``MovingAverageObserver`` — Derives the quantization parameters from the running averages of the minimums and maximums of the observed tensor inputs (per tensor variant)
 * :class:`~torch.quantization.PerChannelMinMaxObserver`— Derives the quantization parameters from the running minimum and maximum of the observed tensor inputs (per channel variant)
 * :class:`~torch.quantization.MovingAveragePerChannelMinMaxObserver` — Derives the quantization parameters from the running averages of the minimums and maximums of the observed tensor inputs (per channel variant)
 * :class:`~torch.quantization.HistogramObserver` — Derives the quantization parameters by creating a histogram of running minimums and maximums.
@@ -253,6 +255,9 @@ Quantization Workflows
 
 PyTorch provides three approaches to quantize models.
 
+.. _quantization tutorials:
+   https://pytorch.org/tutorials/#quantization-experimental
+
 1. Post Training Dynamic Quantization: This is the simplest to apply form of
    quantization where the weights are quantized ahead of time but the
    activations are dynamically quantized  during inference. This is used
@@ -261,7 +266,7 @@ PyTorch provides three approaches to quantize models.
    This is true for for LSTM and Transformer type models with small
    batch size. Applying dynamic quantization to a whole model can be
    done with a single call to :func:`torch.quantization.quantize_dynamic()`.
-   See the `quantization tutorials <https://pytorch.org/tutorials/#quantization-experimental>`_
+   See the `quantization tutorials`_
 2. Post Training Static Quantization: This is the most commonly used form of
    quantization where the weights are quantized ahead of time and the
    scale factor and bias for the activation tensors is pre-computed
@@ -291,7 +296,7 @@ PyTorch provides three approaches to quantize models.
       value to be used each activation tensor, and replaces key
       operators quantized implementations.
 
-   See the `quantization tutorials <https://pytorch.org/tutorials/#quantization_experimental>`_
+   See the `quantization tutorials`_
 
 
 3. Quantization Aware Training: In the rare cases where post training
@@ -312,7 +317,7 @@ PyTorch provides three approaches to quantize models.
    5. Train or fine tune the model.
    6. Identical to step (6) for post training quantization
 
-   See the `quantization tutorials <https://pytorch.org/tutorials/#quantization_experimental>`_
+   See the `quantization tutorials`_
 
 
 While default implementations of observers to select the scale factor and bias
@@ -395,7 +400,8 @@ Observers
 .. autoclass:: Observer
     :members:
 .. autoclass:: MinMaxObserver
-.. autoclass:: MovingAverageObserver
+.. The following doesn't exist. https://github.com/pytorch/pytorch/issues/27849.
+   .. autoclass:: MovingAverageObserver
 .. autoclass:: PerChannelMinMaxObserver
 .. autoclass:: MovingAveragePerChannelMinMaxObserver
 .. autoclass:: HistogramObserver

--- a/docs/source/sparse.rst
+++ b/docs/source/sparse.rst
@@ -64,6 +64,7 @@ SparseTensor has the following invariants:
   1. sparse_dim + dense_dim = len(SparseTensor.shape)
   2. SparseTensor._indices().shape = (sparse_dim, nnz)
   3. SparseTensor._values().shape = (nnz, SparseTensor.shape[sparse_dim:])
+
 Since SparseTensor._indices() is always a 2D tensor, the smallest sparse_dim = 1.
 Therefore, representation of a SparseTensor of sparse_dim = 0 is simply a dense tensor.
 

--- a/docs/source/tensors.rst
+++ b/docs/source/tensors.rst
@@ -396,6 +396,7 @@ view of a storage and defines numeric operations on it.
    .. automethod:: repeat
    .. automethod:: repeat_interleave
    .. autoattribute:: requires_grad
+      :noindex:
    .. automethod:: requires_grad_
    .. automethod:: reshape
    .. automethod:: reshape_as

--- a/torch/cuda/streams.py
+++ b/torch/cuda/streams.py
@@ -119,7 +119,7 @@ class Event(torch._C._CudaEventBase):
             (default: ``False``)
 
     .. _CUDA Event Documentation:
-    https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__EVENT.html
+       https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__EVENT.html
     """
 
     def __new__(cls, enable_timing=False, blocking=False, interprocess=False):

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -322,7 +322,8 @@ def init_process_group(backend,
         2. Specify ``init_method`` (a URL string) which indicates where/how
            to discover peers. Optionally specify ``rank`` and ``world_size``,
            or encode all required parameters in the URL and omit them.
-        If neither is specified, ``init_method`` is assumed to be "env://".
+
+    If neither is specified, ``init_method`` is assumed to be "env://".
 
 
     Arguments:

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -793,7 +793,7 @@ def trace(func,
                                  Tensor in which case it is automatically wrapped in a tuple
 
     Keyword arguments:
-        check_trace (bool, optional): check if the same inputs run through
+        check_trace (``bool``, optional): check if the same inputs run through
                                       traced code produce the same outputs. Default: ``True``. You might want
                                       to disable this if, for example, your network contains non-
                                       deterministic ops or if you are sure that the network is correct despite
@@ -934,7 +934,7 @@ def trace_module(mod,
                                          keys while tracing.
                                          ``{ 'forward' : example_forward_input, 'method2': example_method2_input}``
     Keyword arguments:
-        check_trace (bool, optional): check if the same inputs run through
+        check_trace (``bool``, optional): check if the same inputs run through
                                       traced code produce the same outputs. Default: ``True``. You might want
                                       to disable this if, for example, your network contains non-
                                       deterministic ops or if you are sure that the network is correct despite

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1938,6 +1938,9 @@ def kl_div(input, target, size_average=None, reduce=None, reduction='mean'):
         :attr:``reduction`` = ``'mean'`` doesn't return the true kl divergence value, please use
         :attr:``reduction`` = ``'batchmean'`` which aligns with KL math definition.
         In the next major release, ``'mean'`` will be changed to be the same as 'batchmean'.
+
+    .. _Kullback-Leibler divergence:
+        https://en.wikipedia.org/wiki/Kullback-Leibler_divergence
     """
     if size_average is not None or reduce is not None:
         reduction_enum = _Reduction.legacy_get_enum(size_average, reduce)

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -249,7 +249,7 @@ class Module(object):
     def apply(self, fn):
         r"""Applies ``fn`` recursively to every submodule (as returned by ``.children()``)
         as well as self. Typical use includes initializing the parameters of a model
-        (see also :ref:`torch-nn-init`).
+        (see also :ref:`nn-init-doc`).
 
         Args:
             fn (:class:`Module` -> None): function to be applied to each submodule

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -36,7 +36,7 @@ def export(model, args, f, export_params=True, verbose=False, training=False,
     Export a model into ONNX format.  This exporter runs your model
     once in order to get a trace of its execution to be exported;
     at the moment, it supports a limited set of dynamic models (e.g., RNNs.)
-    See also: :ref:`onnx-export`
+
     Arguments:
         model (torch.nn.Module): the model to be exported.
         args (tuple of arguments): the inputs to
@@ -72,8 +72,7 @@ def export(model, args, f, export_params=True, verbose=False, training=False,
         operator_export_type (enum, default OperatorExportTypes.ONNX):
             OperatorExportTypes.ONNX: all ops are exported as regular ONNX ops.
             OperatorExportTypes.ONNX_ATEN: all ops are exported as ATen ops.
-            OperatorExportTypes.ONNX_ATEN_FALLBACK: if symbolic is missing,
-                                                    fall back on ATen op.
+            OperatorExportTypes.ONNX_ATEN_FALLBACK: if symbolic is missing, fall back on ATen op.
             OperatorExportTypes.RAW: export raw ir.
         opset_version (int, default is 9): by default we export the model to the
             opset version of the onnx submodule. Since ONNX's latest opset may
@@ -103,7 +102,11 @@ def export(model, args, f, export_params=True, verbose=False, training=False,
             OR (2). An inner dictionary that specifies a mapping FROM the index of dynamic axis in
             corresponding input/output TO the name that is desired to be applied on such axis of
             such input/output during export.
+
             Example. if we have the following shape for inputs and outputs:
+
+            .. code-block:: none
+
                 shape(input_1) = ('b', 3, 'w', 'h')
                 and shape(input_2) = ('b', 4)
                 and shape(output)  = ('b', 'd', 5)

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -595,6 +595,7 @@ class CyclicLR(_LRScheduler):
     `step` should be called after a batch has been used for training.
 
     This class has three built-in policies, as put forth in the paper:
+
     "triangular":
         A basic triangular cycle w/ no amplitude scaling.
     "triangular2":
@@ -942,6 +943,7 @@ class OneCycleLR(_LRScheduler):
     This scheduler is not chainable.
 
     This class has two built-in annealing strategies:
+
     "cos":
         Cosine annealing
     "linear":
@@ -949,11 +951,13 @@ class OneCycleLR(_LRScheduler):
 
     Note also that the total number of steps in the cycle can be determined in one
     of two ways (listed in order of precedence):
+
     1) A value for total_steps is explicitly provided.
     2) A number of epochs (epochs) and a number of steps per epoch
        (steps_per_epoch) are provided.
        In this case, the number of total steps is inferred by
        total_steps = epochs * steps_per_epoch
+
     You must either provide a value for total_steps or provide a value for both
     epochs and steps_per_epoch.
 

--- a/torch/quantization/quantize.py
+++ b/torch/quantization/quantize.py
@@ -194,16 +194,20 @@ def quantize_dynamic(model, qconfig_spec=None, dtype=torch.qint8,
     Args:
         module: input model
         qconfig_spec: Either:
-            * A dictionary that maps from name or type of submodule to quantization
+
+            - A dictionary that maps from name or type of submodule to quantization
               configuration, qconfig applies to all submodules of a given
               module unless qconfig for the submodules are specified (when the
               submodule already has qconfig attribute). Entries in the dictionary
               need to be QConfigDynamic instances.
-            * A set of types and/or submodule names to apply dynamic quantization to,
+
+            - A set of types and/or submodule names to apply dynamic quantization to,
               in which case the `dtype` argument is used to specifiy the bit-width
+
         inplace: carry out model transformations in-place, the original module is mutated
         mapping: maps type of a submodule to a type of corresponding dynamically quantized version
             with which the submodule needs to be replaced
+
     """
     if qconfig_spec is None:
         if dtype == torch.qint8:
@@ -268,11 +272,13 @@ def quantize_qat(model, run_fn, run_args, inplace=False):
 def convert(module, mapping=None, inplace=False):
     r"""Converts the float module with observers (where we can get quantization
     parameters) to a quantized module.
+
     Args:
         module: calibrated module with observers
-        mapping: a dictionary that maps from float module type to quantized module type, can 
-                 be overwrritten to allow swapping user defined Modules
+        mapping: a dictionary that maps from float module type to quantized module type, can
+            be overwritten to allow swapping user defined Modules
         inplace: carry out model transformations in-place, the original module is mutated
+
     """
     if mapping is None:
         mapping = DEFAULT_MODULE_MAPPING


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #27927 Fix Sphinx warning about '_images' not existing
* **#27850 Bag of documentation fixes; fix more sphinx warnings**

Many of these are real problems in the documentation (i.e., link or
bullet point doesn't display correctly).

Test Plan:
- built and viewed the documentation for each change locally.

Differential Revision: [D17908123](https://our.internmc.facebook.com/intern/diff/D17908123)