### PR TITLE
clone() changed to clone(at::MemoryFormat::Contiguous) at LinearAlgebraUtils.h

### DIFF
--- a/aten/src/ATen/native/LinearAlgebraUtils.h
+++ b/aten/src/ATen/native/LinearAlgebraUtils.h
@@ -1,6 +1,7 @@
 #include <ATen/ATen.h>
 #include <ATen/ExpandUtils.h>
 #include <ATen/TensorUtils.h>
+#include <ATen/MemoryFormatUtils.h>
 #include <limits>
 #include <sstream>
 #include <cstring>
@@ -22,7 +23,8 @@ static inline Tensor cloneBatchedColumnMajor(const Tensor& src) {
   // this will be efficient (no reordering of the data will occur)
   // because the first transpose will make the tensor contiguous,
   // and cloning a contiguous tensor is fast.
-  auto result = src.transpose(-2, -1).clone();
+  auto tr = src.transpose(-2, -1);
+  auto result = clone_if_possible_with_memory_format(tr);
   result.transpose_(-2, -1);
   return result;
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #27873 clone() changed to clone(at::MemoryFormat::Contiguous) at ProcessGroupGloo.cpp
* #27872 clone() changed to clone(at::MemoryFormat::Contiguous) at check_alias_annotation.cpp
* #27871 clone() changed to clone(at::MemoryFormat::Contiguous) at accumulate_grad.cpp
* #27870 clone() changed to clone(at::MemoryFormat::Contiguous) at lbfgs.cpp
* #27869 clone() changed to clone(at::MemoryFormat::Contiguous) at Functions.cpp
* #27868 clone() changed to clone(at::MemoryFormat::Contiguous) at test_misc.cpp
* #27867 clone() changed to clone(at::MemoryFormat::Contiguous) at optim.cpp
* #27866 clone() changed to clone(at::MemoryFormat::Contiguous) at nn_utils.cpp
* #27865 clone() changed to clone(at::MemoryFormat::Contiguous) at autograd.cpp
* #27863 clone() changed to clone(at::MemoryFormat::Contiguous) at pow_test.cpp
* #27862 clone() changed to clone(at::MemoryFormat::Contiguous) at broadcast_test.cpp
* #27861 clone() changed to clone(at::MemoryFormat::Contiguous) at Unique.cu
* #27860 clone() changed to clone(at::MemoryFormat::Contiguous) at SpectralOps.cu
* #27859 clone() changed to clone(at::MemoryFormat::Contiguous) at SortingKthValue.cu
* #27858 clone() changed to clone(at::MemoryFormat::Contiguous) at TensorTransformations.cpp
* #27857 clone() changed to clone(at::MemoryFormat::Contiguous) at Sorting.cpp
* #27856 clone() changed to clone(at::MemoryFormat::Contiguous) at SobolEngineOps.cpp
* **#27855 clone() changed to clone(at::MemoryFormat::Contiguous) at LinearAlgebraUtils.h**
* #27854 clone() changed to clone(at::MemoryFormat::Contiguous) at LinearAlgebra.cpp
* #27853 clone() changed to clone(at::MemoryFormat::Contiguous) at Indexing.cpp

