### PR TITLE
clone() changed to clone(at::MemoryFormat::Contiguous) at TensorTransformations.cpp

### DIFF
--- a/aten/src/ATen/native/TensorTransformations.cpp
+++ b/aten/src/ATen/native/TensorTransformations.cpp
@@ -4,6 +4,7 @@
 #include <ATen/NativeFunctions.h>
 #include <ATen/Parallel.h>
 #include <c10/util/Exception.h>
+#include <ATen/MemoryFormatUtils.h>
 
 #include <algorithm>
 #include <vector>
@@ -80,7 +81,7 @@ Tensor roll_cpu(const Tensor& self, IntArrayRef shifts, IntArrayRef dims) {
   }
   // avoid a div zero error below.
   if (self.numel() == 0) {
-    return self.clone();
+    return clone_if_possible_with_memory_format(self);
   }
   int64_t dim = dims[0];
   int64_t size = self.size(dim);
@@ -135,7 +136,7 @@ Tensor rot90(const Tensor& self, int64_t k, IntArrayRef dims) {
     case 3:
       return self.flip({dims[0]}).transpose_(dims[0], dims[1]);
     default:
-      return self.clone();
+      return clone_if_possible_with_memory_format(self);
   }
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #27873 clone() changed to clone(at::MemoryFormat::Contiguous) at ProcessGroupGloo.cpp
* #27872 clone() changed to clone(at::MemoryFormat::Contiguous) at check_alias_annotation.cpp
* #27871 clone() changed to clone(at::MemoryFormat::Contiguous) at accumulate_grad.cpp
* #27870 clone() changed to clone(at::MemoryFormat::Contiguous) at lbfgs.cpp
* #27869 clone() changed to clone(at::MemoryFormat::Contiguous) at Functions.cpp
* #27868 clone() changed to clone(at::MemoryFormat::Contiguous) at test_misc.cpp
* #27867 clone() changed to clone(at::MemoryFormat::Contiguous) at optim.cpp
* #27866 clone() changed to clone(at::MemoryFormat::Contiguous) at nn_utils.cpp
* #27865 clone() changed to clone(at::MemoryFormat::Contiguous) at autograd.cpp
* #27863 clone() changed to clone(at::MemoryFormat::Contiguous) at pow_test.cpp
* #27862 clone() changed to clone(at::MemoryFormat::Contiguous) at broadcast_test.cpp
* #27861 clone() changed to clone(at::MemoryFormat::Contiguous) at Unique.cu
* #27860 clone() changed to clone(at::MemoryFormat::Contiguous) at SpectralOps.cu
* #27859 clone() changed to clone(at::MemoryFormat::Contiguous) at SortingKthValue.cu
* **#27858 clone() changed to clone(at::MemoryFormat::Contiguous) at TensorTransformations.cpp**
* #27857 clone() changed to clone(at::MemoryFormat::Contiguous) at Sorting.cpp
* #27856 clone() changed to clone(at::MemoryFormat::Contiguous) at SobolEngineOps.cpp
* #27855 clone() changed to clone(at::MemoryFormat::Contiguous) at LinearAlgebraUtils.h
* #27854 clone() changed to clone(at::MemoryFormat::Contiguous) at LinearAlgebra.cpp
* #27853 clone() changed to clone(at::MemoryFormat::Contiguous) at Indexing.cpp

