### PR TITLE
clone() changed to clone(at::MemoryFormat::Contiguous) at broadcast_test.cpp

### DIFF
--- a/aten/src/ATen/test/broadcast_test.cpp
+++ b/aten/src/ATen/test/broadcast_test.cpp
@@ -2,6 +2,7 @@
 #include <gtest/gtest.h>
 
 #include <ATen/ATen.h>
+#include <ATen/MemoryFormatUtils.h>
 
 using namespace at;
 
@@ -109,7 +110,7 @@ void TestIn3Basic(DeprecatedTypeProperties& T) {
   auto a = randn({3, 5, 2}, T);
   auto b = randn({3, 1, 2}, T);
   auto c = randn({1, 5, 1}, T);
-  auto aClone = a.clone();
+  auto aClone = clone_if_possible_with_memory_format(a);
   ASSERT_TRUE(a.addcmul_(b, c).equal(
       aClone.addcmul_(b.expand(a.sizes()), c.expand(a.sizes()))));
 }
@@ -119,7 +120,7 @@ void TestIn3WithScalar(DeprecatedTypeProperties& T) {
   auto a = randn({3, 5, 2}, T);
   auto b = randn({3, 1, 2}, T);
   auto c = randn({1, 5, 1}, T);
-  auto aClone = a.clone();
+  auto aClone = clone_if_possible_with_memory_format(a);
   auto bScalar = ones({1}, T);
   bScalar.unsafeGetTensorImpl()->maybe_zero_dim(true);
   ASSERT_TRUE(a.addcmul_(bScalar, c)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #27873 clone() changed to clone(at::MemoryFormat::Contiguous) at ProcessGroupGloo.cpp
* #27872 clone() changed to clone(at::MemoryFormat::Contiguous) at check_alias_annotation.cpp
* #27871 clone() changed to clone(at::MemoryFormat::Contiguous) at accumulate_grad.cpp
* #27870 clone() changed to clone(at::MemoryFormat::Contiguous) at lbfgs.cpp
* #27869 clone() changed to clone(at::MemoryFormat::Contiguous) at Functions.cpp
* #27868 clone() changed to clone(at::MemoryFormat::Contiguous) at test_misc.cpp
* #27867 clone() changed to clone(at::MemoryFormat::Contiguous) at optim.cpp
* #27866 clone() changed to clone(at::MemoryFormat::Contiguous) at nn_utils.cpp
* #27865 clone() changed to clone(at::MemoryFormat::Contiguous) at autograd.cpp
* #27863 clone() changed to clone(at::MemoryFormat::Contiguous) at pow_test.cpp
* **#27862 clone() changed to clone(at::MemoryFormat::Contiguous) at broadcast_test.cpp**
* #27861 clone() changed to clone(at::MemoryFormat::Contiguous) at Unique.cu
* #27860 clone() changed to clone(at::MemoryFormat::Contiguous) at SpectralOps.cu
* #27859 clone() changed to clone(at::MemoryFormat::Contiguous) at SortingKthValue.cu
* #27858 clone() changed to clone(at::MemoryFormat::Contiguous) at TensorTransformations.cpp
* #27857 clone() changed to clone(at::MemoryFormat::Contiguous) at Sorting.cpp
* #27856 clone() changed to clone(at::MemoryFormat::Contiguous) at SobolEngineOps.cpp
* #27855 clone() changed to clone(at::MemoryFormat::Contiguous) at LinearAlgebraUtils.h
* #27854 clone() changed to clone(at::MemoryFormat::Contiguous) at LinearAlgebra.cpp
* #27853 clone() changed to clone(at::MemoryFormat::Contiguous) at Indexing.cpp

