### PR TITLE
clone() changed to clone(at::MemoryFormat::Contiguous) at pow_test.cpp

### DIFF
--- a/aten/src/ATen/test/pow_test.cpp
+++ b/aten/src/ATen/test/pow_test.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <ATen/native/Pow.h>
+#include <ATen/MemoryFormatUtils.h>
 
 #include <torch/types.h>
 #include <torch/utils.h>
@@ -113,7 +114,7 @@ void tensor_pow_scalar(const Vals vals, const Pows pows) {
   for (const auto pow : pows) {
     auto actual_pow = tensor.pow(pow);
 
-    auto actual_pow_ = tensor.clone();
+    auto actual_pow_ = clone_if_possible_with_memory_format(tensor);
     actual_pow_.pow_(pow);
 
     auto actual_pow_out = torch::empty_like(tensor);
@@ -187,7 +188,7 @@ void tensor_pow_tensor(const Vals vals, Pows pows) {
 
     const auto actual_pow = vals_tensor.pow(pows_tensor);
 
-    auto actual_pow_ = vals_tensor.clone();
+    auto actual_pow_ = clone_if_possible_with_memory_format(vals_tensor);
     actual_pow_.pow_(pows_tensor);
 
     auto actual_pow_out = torch::empty_like(vals_tensor);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #27873 clone() changed to clone(at::MemoryFormat::Contiguous) at ProcessGroupGloo.cpp
* #27872 clone() changed to clone(at::MemoryFormat::Contiguous) at check_alias_annotation.cpp
* #27871 clone() changed to clone(at::MemoryFormat::Contiguous) at accumulate_grad.cpp
* #27870 clone() changed to clone(at::MemoryFormat::Contiguous) at lbfgs.cpp
* #27869 clone() changed to clone(at::MemoryFormat::Contiguous) at Functions.cpp
* #27868 clone() changed to clone(at::MemoryFormat::Contiguous) at test_misc.cpp
* #27867 clone() changed to clone(at::MemoryFormat::Contiguous) at optim.cpp
* #27866 clone() changed to clone(at::MemoryFormat::Contiguous) at nn_utils.cpp
* #27865 clone() changed to clone(at::MemoryFormat::Contiguous) at autograd.cpp
* **#27863 clone() changed to clone(at::MemoryFormat::Contiguous) at pow_test.cpp**
* #27862 clone() changed to clone(at::MemoryFormat::Contiguous) at broadcast_test.cpp
* #27861 clone() changed to clone(at::MemoryFormat::Contiguous) at Unique.cu
* #27860 clone() changed to clone(at::MemoryFormat::Contiguous) at SpectralOps.cu
* #27859 clone() changed to clone(at::MemoryFormat::Contiguous) at SortingKthValue.cu
* #27858 clone() changed to clone(at::MemoryFormat::Contiguous) at TensorTransformations.cpp
* #27857 clone() changed to clone(at::MemoryFormat::Contiguous) at Sorting.cpp
* #27856 clone() changed to clone(at::MemoryFormat::Contiguous) at SobolEngineOps.cpp
* #27855 clone() changed to clone(at::MemoryFormat::Contiguous) at LinearAlgebraUtils.h
* #27854 clone() changed to clone(at::MemoryFormat::Contiguous) at LinearAlgebra.cpp
* #27853 clone() changed to clone(at::MemoryFormat::Contiguous) at Indexing.cpp

