### PR TITLE
clone() changed to clone(at::MemoryFormat::Contiguous) at autograd.cpp

### DIFF
--- a/test/cpp/api/autograd.cpp
+++ b/test/cpp/api/autograd.cpp
@@ -3,6 +3,7 @@
 #include <torch/torch.h>
 
 #include <test/cpp/api/support.h>
+#include <ATen/MemoryFormatUtils.h>
 
 using namespace torch::autograd;
 
@@ -236,7 +237,7 @@ TEST(CustomAutogradTest, MarkNonDifferentiableMixed) {
 TEST(CustomAutogradTest, MarkNonDifferentiableNone) {
   struct MyFunction : public Function<MyFunction> {
     static Variable forward(AutogradContext *ctx, Variable input) {
-      auto output = input.clone();
+      auto output = clone_if_possible_with_memory_format(input);
       ctx->mark_non_differentiable({output});
       return output;
     }
@@ -292,7 +293,8 @@ TEST(CustomAutogradTest, ReturnDuplicateInplace) {
   ASSERT_THROWS_WITH(DoubleInplace::apply(x), "leaf Variable that requires grad");
   // TODO ASSERT_THROWS_WITH(DoubleInplace::apply(x.clone()[0]), "only one output");
 
-  auto out = DoubleInplace::apply(x.clone());
+  auto cloned = clone_if_possible_with_memory_format(x);
+  auto out = DoubleInplace::apply(cloned);
   ASSERT_TRUE(torch::equal(out[0],out[1]));
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #27873 clone() changed to clone(at::MemoryFormat::Contiguous) at ProcessGroupGloo.cpp
* #27872 clone() changed to clone(at::MemoryFormat::Contiguous) at check_alias_annotation.cpp
* #27871 clone() changed to clone(at::MemoryFormat::Contiguous) at accumulate_grad.cpp
* #27870 clone() changed to clone(at::MemoryFormat::Contiguous) at lbfgs.cpp
* #27869 clone() changed to clone(at::MemoryFormat::Contiguous) at Functions.cpp
* #27868 clone() changed to clone(at::MemoryFormat::Contiguous) at test_misc.cpp
* #27867 clone() changed to clone(at::MemoryFormat::Contiguous) at optim.cpp
* #27866 clone() changed to clone(at::MemoryFormat::Contiguous) at nn_utils.cpp
* **#27865 clone() changed to clone(at::MemoryFormat::Contiguous) at autograd.cpp**
* #27863 clone() changed to clone(at::MemoryFormat::Contiguous) at pow_test.cpp
* #27862 clone() changed to clone(at::MemoryFormat::Contiguous) at broadcast_test.cpp
* #27861 clone() changed to clone(at::MemoryFormat::Contiguous) at Unique.cu
* #27860 clone() changed to clone(at::MemoryFormat::Contiguous) at SpectralOps.cu
* #27859 clone() changed to clone(at::MemoryFormat::Contiguous) at SortingKthValue.cu
* #27858 clone() changed to clone(at::MemoryFormat::Contiguous) at TensorTransformations.cpp
* #27857 clone() changed to clone(at::MemoryFormat::Contiguous) at Sorting.cpp
* #27856 clone() changed to clone(at::MemoryFormat::Contiguous) at SobolEngineOps.cpp
* #27855 clone() changed to clone(at::MemoryFormat::Contiguous) at LinearAlgebraUtils.h
* #27854 clone() changed to clone(at::MemoryFormat::Contiguous) at LinearAlgebra.cpp
* #27853 clone() changed to clone(at::MemoryFormat::Contiguous) at Indexing.cpp

