### PR TITLE
clone() changed to clone(at::MemoryFormat::Contiguous) at optim.cpp

### DIFF
--- a/test/cpp/api/optim.cpp
+++ b/test/cpp/api/optim.cpp
@@ -4,6 +4,7 @@
 
 #include <test/cpp/api/optim_baseline.h>
 #include <test/cpp/api/support.h>
+#include <ATen/MemoryFormatUtils.h>
 
 #include <cmath>
 #include <cstdlib>
@@ -298,7 +299,7 @@ TEST(OptimTest, ExternalVectorOfParameters) {
   std::vector<torch::Tensor> parameters = {
       torch::randn({2, 2}), torch::randn({3, 3}), torch::randn({4, 4})};
   std::vector<torch::Tensor> original_parameters = {
-      parameters[0].clone(), parameters[1].clone(), parameters[2].clone()};
+      clone_if_possible_with_memory_format(parameters[0]), clone_if_possible_with_memory_format(parameters[1]), clone_if_possible_with_memory_format(parameters[2])};
 
   // Set all gradients to one
   for (auto& parameter : parameters) {
@@ -318,7 +319,7 @@ TEST(OptimTest, AddParameter_LBFGS) {
   torch::manual_seed(0);
 
   std::vector<torch::Tensor> parameters = {torch::randn({5, 5})};
-  std::vector<torch::Tensor> original_parameters = {parameters[0].clone()};
+  std::vector<torch::Tensor> original_parameters = {clone_if_possible_with_memory_format(parameters[0])};
 
   // Set all gradients to one
   for (auto& parameter : parameters) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #27873 clone() changed to clone(at::MemoryFormat::Contiguous) at ProcessGroupGloo.cpp
* #27872 clone() changed to clone(at::MemoryFormat::Contiguous) at check_alias_annotation.cpp
* #27871 clone() changed to clone(at::MemoryFormat::Contiguous) at accumulate_grad.cpp
* #27870 clone() changed to clone(at::MemoryFormat::Contiguous) at lbfgs.cpp
* #27869 clone() changed to clone(at::MemoryFormat::Contiguous) at Functions.cpp
* #27868 clone() changed to clone(at::MemoryFormat::Contiguous) at test_misc.cpp
* **#27867 clone() changed to clone(at::MemoryFormat::Contiguous) at optim.cpp**
* #27866 clone() changed to clone(at::MemoryFormat::Contiguous) at nn_utils.cpp
* #27865 clone() changed to clone(at::MemoryFormat::Contiguous) at autograd.cpp
* #27863 clone() changed to clone(at::MemoryFormat::Contiguous) at pow_test.cpp
* #27862 clone() changed to clone(at::MemoryFormat::Contiguous) at broadcast_test.cpp
* #27861 clone() changed to clone(at::MemoryFormat::Contiguous) at Unique.cu
* #27860 clone() changed to clone(at::MemoryFormat::Contiguous) at SpectralOps.cu
* #27859 clone() changed to clone(at::MemoryFormat::Contiguous) at SortingKthValue.cu
* #27858 clone() changed to clone(at::MemoryFormat::Contiguous) at TensorTransformations.cpp
* #27857 clone() changed to clone(at::MemoryFormat::Contiguous) at Sorting.cpp
* #27856 clone() changed to clone(at::MemoryFormat::Contiguous) at SobolEngineOps.cpp
* #27855 clone() changed to clone(at::MemoryFormat::Contiguous) at LinearAlgebraUtils.h
* #27854 clone() changed to clone(at::MemoryFormat::Contiguous) at LinearAlgebra.cpp
* #27853 clone() changed to clone(at::MemoryFormat::Contiguous) at Indexing.cpp

