### PR TITLE
clone() changed to clone(at::MemoryFormat::Contiguous) at test_misc.cpp

### DIFF
--- a/test/cpp/jit/test_misc.cpp
+++ b/test/cpp/jit/test_misc.cpp
@@ -3,6 +3,7 @@
 #include <ATen/core/ivalue.h>
 #include <ATen/Parallel.h>
 #include <ATen/ThreadLocalDebugInfo.h>
+#include <ATen/MemoryFormatUtils.h>
 
 #include "test/cpp/jit/test_base.h"
 #include "test/cpp/jit/test_utils.h"
@@ -243,10 +244,10 @@ void testATenNativeBatchNorm() {
   at::Tensor running_var = torch::randn({input_size[1]});
 
   // running_mean and running_var are changed in-place, so clone and send them
-  at::Tensor running_mean_eager = running_mean.clone();
-  at::Tensor running_var_eager = running_var.clone();
-  at::Tensor running_mean_jit = running_mean.clone();
-  at::Tensor running_var_jit = running_var.clone();
+  at::Tensor running_mean_eager = clone_if_possible_with_memory_format(running_mean);
+  at::Tensor running_var_eager = clone_if_possible_with_memory_format(running_var);
+  at::Tensor running_mean_jit = clone_if_possible_with_memory_format(running_mean);
+  at::Tensor running_var_jit = clone_if_possible_with_memory_format(running_var);
 
   // run forward eagerly
   at::Tensor output, savemean, saveinvstd;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #27873 clone() changed to clone(at::MemoryFormat::Contiguous) at ProcessGroupGloo.cpp
* #27872 clone() changed to clone(at::MemoryFormat::Contiguous) at check_alias_annotation.cpp
* #27871 clone() changed to clone(at::MemoryFormat::Contiguous) at accumulate_grad.cpp
* #27870 clone() changed to clone(at::MemoryFormat::Contiguous) at lbfgs.cpp
* #27869 clone() changed to clone(at::MemoryFormat::Contiguous) at Functions.cpp
* **#27868 clone() changed to clone(at::MemoryFormat::Contiguous) at test_misc.cpp**
* #27867 clone() changed to clone(at::MemoryFormat::Contiguous) at optim.cpp
* #27866 clone() changed to clone(at::MemoryFormat::Contiguous) at nn_utils.cpp
* #27865 clone() changed to clone(at::MemoryFormat::Contiguous) at autograd.cpp
* #27863 clone() changed to clone(at::MemoryFormat::Contiguous) at pow_test.cpp
* #27862 clone() changed to clone(at::MemoryFormat::Contiguous) at broadcast_test.cpp
* #27861 clone() changed to clone(at::MemoryFormat::Contiguous) at Unique.cu
* #27860 clone() changed to clone(at::MemoryFormat::Contiguous) at SpectralOps.cu
* #27859 clone() changed to clone(at::MemoryFormat::Contiguous) at SortingKthValue.cu
* #27858 clone() changed to clone(at::MemoryFormat::Contiguous) at TensorTransformations.cpp
* #27857 clone() changed to clone(at::MemoryFormat::Contiguous) at Sorting.cpp
* #27856 clone() changed to clone(at::MemoryFormat::Contiguous) at SobolEngineOps.cpp
* #27855 clone() changed to clone(at::MemoryFormat::Contiguous) at LinearAlgebraUtils.h
* #27854 clone() changed to clone(at::MemoryFormat::Contiguous) at LinearAlgebra.cpp
* #27853 clone() changed to clone(at::MemoryFormat::Contiguous) at Indexing.cpp

