### PR TITLE
clone() changed to clone(at::MemoryFormat::Contiguous) at Functions.cpp

### DIFF
--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -7,6 +7,7 @@
 
 #include "Functions.h"
 #include <ATen/Utils.h>
+#include <ATen/MemoryFormatUtils.h>
 #include <c10/core/TensorOptions.h>
 #include <ATen/WrapDimUtils.h>
 #include <ATen/WrapDimUtilsMulti.h>
@@ -101,7 +102,7 @@ Tensor norm_backward(const Tensor & grad, const Tensor & self, const optional<Sc
     scale_v = grad / norm;
   } else if (std::isinf(p)) {
     self_scaled = self.sign() * (self.abs() == norm).type_as(self);
-    scale_v = grad.clone();
+    scale_v = clone_if_possible_with_memory_format(grad);
   } else if (p < 2.0) {
     self_scaled = self.sign() * self.abs().pow(p - 1);
     scale_v = grad / norm.pow(p - 1);
@@ -271,7 +272,8 @@ Tensor sum_scan_exclusive(const Tensor& x, int64_t dim) {
   Tensor ret = at::cumsum(-x, dim);
 
   int64_t end_idx = ret.size(dim) - 1;
-  Tensor ret_sum = ret.narrow(dim, end_idx, 1).clone();
+  auto narrowed = ret.narrow(dim, end_idx, 1);
+  Tensor ret_sum = clone_if_possible_with_memory_format(narrowed);
   ret -= ret_sum.expand_as(ret);
   ret += x;
   return ret;
@@ -419,7 +421,8 @@ Tensor cumsum_backward(const Tensor & x, int64_t dim) {
     return x;
   }
   auto ret = at::cumsum(-x, dim);
-  auto ret_sum = ret.narrow(dim, ret.size(dim) - 1, 1).clone();
+  auto narrowed = ret.narrow(dim, ret.size(dim) - 1, 1);
+  auto ret_sum = clone_if_possible_with_memory_format(narrowed);
   ret -= ret_sum.expand(ret.sizes());
   ret += x;
   return ret;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #27873 clone() changed to clone(at::MemoryFormat::Contiguous) at ProcessGroupGloo.cpp
* #27872 clone() changed to clone(at::MemoryFormat::Contiguous) at check_alias_annotation.cpp
* #27871 clone() changed to clone(at::MemoryFormat::Contiguous) at accumulate_grad.cpp
* #27870 clone() changed to clone(at::MemoryFormat::Contiguous) at lbfgs.cpp
* **#27869 clone() changed to clone(at::MemoryFormat::Contiguous) at Functions.cpp**
* #27868 clone() changed to clone(at::MemoryFormat::Contiguous) at test_misc.cpp
* #27867 clone() changed to clone(at::MemoryFormat::Contiguous) at optim.cpp
* #27866 clone() changed to clone(at::MemoryFormat::Contiguous) at nn_utils.cpp
* #27865 clone() changed to clone(at::MemoryFormat::Contiguous) at autograd.cpp
* #27863 clone() changed to clone(at::MemoryFormat::Contiguous) at pow_test.cpp
* #27862 clone() changed to clone(at::MemoryFormat::Contiguous) at broadcast_test.cpp
* #27861 clone() changed to clone(at::MemoryFormat::Contiguous) at Unique.cu
* #27860 clone() changed to clone(at::MemoryFormat::Contiguous) at SpectralOps.cu
* #27859 clone() changed to clone(at::MemoryFormat::Contiguous) at SortingKthValue.cu
* #27858 clone() changed to clone(at::MemoryFormat::Contiguous) at TensorTransformations.cpp
* #27857 clone() changed to clone(at::MemoryFormat::Contiguous) at Sorting.cpp
* #27856 clone() changed to clone(at::MemoryFormat::Contiguous) at SobolEngineOps.cpp
* #27855 clone() changed to clone(at::MemoryFormat::Contiguous) at LinearAlgebraUtils.h
* #27854 clone() changed to clone(at::MemoryFormat::Contiguous) at LinearAlgebra.cpp
* #27853 clone() changed to clone(at::MemoryFormat::Contiguous) at Indexing.cpp

