### PR TITLE
clone() changed to clone(at::MemoryFormat::Contiguous) at lbfgs.cpp

### DIFF
--- a/torch/csrc/api/src/optim/lbfgs.cpp
+++ b/torch/csrc/api/src/optim/lbfgs.cpp
@@ -6,6 +6,7 @@
 #include <torch/utils.h>
 
 #include <ATen/ATen.h>
+#include <ATen/MemoryFormatUtils.h>
 
 #include <cmath>
 #include <functional>
@@ -47,7 +48,7 @@ void LBFGS::add_grad(const torch::Tensor& step_size, const Tensor& update) {
 
 torch::Tensor LBFGS::step(LossClosure closure) {
   torch::Tensor orig_loss = closure();
-  torch::Tensor loss = orig_loss.clone();
+  torch::Tensor loss = clone_if_possible_with_memory_format(orig_loss);
   int64_t current_evals = 1;
   func_evals += 1;
 
@@ -68,7 +69,7 @@ torch::Tensor LBFGS::step(LossClosure closure) {
     if (state_n_iter == 1) {
       d = flat_grad.neg();
       H_diag = ONE;
-      prev_flat_grad = flat_grad.clone();
+      prev_flat_grad = clone_if_possible_with_memory_format(flat_grad);
     } else {
       Tensor y = flat_grad.sub(prev_flat_grad);
       Tensor s = d.mul(t);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #27873 clone() changed to clone(at::MemoryFormat::Contiguous) at ProcessGroupGloo.cpp
* #27872 clone() changed to clone(at::MemoryFormat::Contiguous) at check_alias_annotation.cpp
* #27871 clone() changed to clone(at::MemoryFormat::Contiguous) at accumulate_grad.cpp
* **#27870 clone() changed to clone(at::MemoryFormat::Contiguous) at lbfgs.cpp**
* #27869 clone() changed to clone(at::MemoryFormat::Contiguous) at Functions.cpp
* #27868 clone() changed to clone(at::MemoryFormat::Contiguous) at test_misc.cpp
* #27867 clone() changed to clone(at::MemoryFormat::Contiguous) at optim.cpp
* #27866 clone() changed to clone(at::MemoryFormat::Contiguous) at nn_utils.cpp
* #27865 clone() changed to clone(at::MemoryFormat::Contiguous) at autograd.cpp
* #27863 clone() changed to clone(at::MemoryFormat::Contiguous) at pow_test.cpp
* #27862 clone() changed to clone(at::MemoryFormat::Contiguous) at broadcast_test.cpp
* #27861 clone() changed to clone(at::MemoryFormat::Contiguous) at Unique.cu
* #27860 clone() changed to clone(at::MemoryFormat::Contiguous) at SpectralOps.cu
* #27859 clone() changed to clone(at::MemoryFormat::Contiguous) at SortingKthValue.cu
* #27858 clone() changed to clone(at::MemoryFormat::Contiguous) at TensorTransformations.cpp
* #27857 clone() changed to clone(at::MemoryFormat::Contiguous) at Sorting.cpp
* #27856 clone() changed to clone(at::MemoryFormat::Contiguous) at SobolEngineOps.cpp
* #27855 clone() changed to clone(at::MemoryFormat::Contiguous) at LinearAlgebraUtils.h
* #27854 clone() changed to clone(at::MemoryFormat::Contiguous) at LinearAlgebra.cpp
* #27853 clone() changed to clone(at::MemoryFormat::Contiguous) at Indexing.cpp

