### PR TITLE
clone() changed to clone(at::MemoryFormat::Contiguous) at accumulate_grad.cpp

### DIFF
--- a/torch/csrc/autograd/functions/accumulate_grad.cpp
+++ b/torch/csrc/autograd/functions/accumulate_grad.cpp
@@ -5,6 +5,7 @@
 #include <torch/csrc/autograd/functions/basic_ops.h>
 #include <torch/csrc/autograd/functions/tensor.h>
 #include <torch/csrc/autograd/functions/utils.h>
+#include <ATen/MemoryFormatUtils.h>
 
 #include <cstdint>
 #include <stdexcept>
@@ -54,7 +55,7 @@ auto AccumulateGrad::apply(variable_list&& grads) -> variable_list {
       // addition of !post_hooks().empty().
       variable.grad() = new_grad.detach();
     } else {
-      variable.grad() = new_grad.clone();
+      variable.grad() = clone_if_possible_with_memory_format(new_grad);
     }
   } else if (!GradMode::is_enabled()) {
     // This case is not strictly necessary, but it makes the first-order only case


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #27873 clone() changed to clone(at::MemoryFormat::Contiguous) at ProcessGroupGloo.cpp
* #27872 clone() changed to clone(at::MemoryFormat::Contiguous) at check_alias_annotation.cpp
* **#27871 clone() changed to clone(at::MemoryFormat::Contiguous) at accumulate_grad.cpp**
* #27870 clone() changed to clone(at::MemoryFormat::Contiguous) at lbfgs.cpp
* #27869 clone() changed to clone(at::MemoryFormat::Contiguous) at Functions.cpp
* #27868 clone() changed to clone(at::MemoryFormat::Contiguous) at test_misc.cpp
* #27867 clone() changed to clone(at::MemoryFormat::Contiguous) at optim.cpp
* #27866 clone() changed to clone(at::MemoryFormat::Contiguous) at nn_utils.cpp
* #27865 clone() changed to clone(at::MemoryFormat::Contiguous) at autograd.cpp
* #27863 clone() changed to clone(at::MemoryFormat::Contiguous) at pow_test.cpp
* #27862 clone() changed to clone(at::MemoryFormat::Contiguous) at broadcast_test.cpp
* #27861 clone() changed to clone(at::MemoryFormat::Contiguous) at Unique.cu
* #27860 clone() changed to clone(at::MemoryFormat::Contiguous) at SpectralOps.cu
* #27859 clone() changed to clone(at::MemoryFormat::Contiguous) at SortingKthValue.cu
* #27858 clone() changed to clone(at::MemoryFormat::Contiguous) at TensorTransformations.cpp
* #27857 clone() changed to clone(at::MemoryFormat::Contiguous) at Sorting.cpp
* #27856 clone() changed to clone(at::MemoryFormat::Contiguous) at SobolEngineOps.cpp
* #27855 clone() changed to clone(at::MemoryFormat::Contiguous) at LinearAlgebraUtils.h
* #27854 clone() changed to clone(at::MemoryFormat::Contiguous) at LinearAlgebra.cpp
* #27853 clone() changed to clone(at::MemoryFormat::Contiguous) at Indexing.cpp

