### PR TITLE
clone() changed to clone(at::MemoryFormat::Contiguous) at ProcessGroupGloo.cpp

### DIFF
--- a/aten/src/ATen/MemoryFormatUtils.h
+++ b/aten/src/ATen/MemoryFormatUtils.h
@@ -1,14 +1,18 @@
 #pragma once
 
 #include <ATen/ATen.h>
-#include <ATen/core/Tensor.h>
 
-static Tensor clone_if_possible_with_memory_format(const Tensor& src) {
+namespace at {
+
+static Tensor clone_if_possible_with_memory_format(const Tensor& self) {
   if (self.is_sparse()) {
     return self.clone();
-  } else if (input.is_mkldnn()) {
+  } else if (self.is_mkldnn()) {
     return self.clone();
   } else {
     return self.clone(at::MemoryFormat::Contiguous);
   }
 }
+
+}
+

--- a/aten/src/ATen/MemoryFormatUtils.h
+++ b/aten/src/ATen/MemoryFormatUtils.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ATen/ATen.h>
+#include <ATen/core/Tensor.h>
 
 static Tensor clone_if_possible_with_memory_format(const Tensor& src) {
   if (self.is_sparse()) {

--- a/torch/lib/c10d/ProcessGroupGloo.cpp
+++ b/torch/lib/c10d/ProcessGroupGloo.cpp
@@ -17,6 +17,7 @@
 #include <gloo/scatter.h>
 
 #include <ATen/SparseTensorUtils.h>
+#include <ATen/MemoryFormatUtils.h>
 
 #ifdef USE_CUDA
 #include <ATen/cuda/CUDAEvent.h>
@@ -1017,7 +1018,7 @@ class AsyncSparseAllreduceWork : public ProcessGroupGloo::AsyncWork {
     // Copy back to input tensors.
     outputs.reserve(inputs.size());
     for (size_t i = 0; i < inputs.size(); i++) {
-      outputs.push_back(output.clone());
+      outputs.push_back(clone_if_possible_with_memory_format(output));
     }
   }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#27873 clone() changed to clone(at::MemoryFormat::Contiguous) at ProcessGroupGloo.cpp**
* #27912 clone() changed to clone(at::MemoryFormat::Contiguous) at ProcessGroupGloo.cpp
* #27911 clone() changed to clone(at::MemoryFormat::Contiguous) at check_alias_annotation.cpp
* #27910 clone() changed to clone(at::MemoryFormat::Contiguous) at accumulate_grad.cpp
* #27909 clone() changed to clone(at::MemoryFormat::Contiguous) at lbfgs.cpp
* #27908 clone() changed to clone(at::MemoryFormat::Contiguous) at Functions.cpp
* #27907 clone() changed to clone(at::MemoryFormat::Contiguous) at test_misc.cpp
* #27906 clone() changed to clone(at::MemoryFormat::Contiguous) at optim.cpp
* #27905 clone() changed to clone(at::MemoryFormat::Contiguous) at nn_utils.cpp
* #27904 clone() changed to clone(at::MemoryFormat::Contiguous) at autograd.cpp
* #27903 clone() changed to clone(at::MemoryFormat::Contiguous) at pow_test.cpp
* #27901 clone() changed to clone(at::MemoryFormat::Contiguous) at broadcast_test.cpp
* #27900 clone() changed to clone(at::MemoryFormat::Contiguous) at Unique.cu
* #27899 clone() changed to clone(at::MemoryFormat::Contiguous) at SpectralOps.cu
* #27898 clone() changed to clone(at::MemoryFormat::Contiguous) at SortingKthValue.cu
* #27897 clone() changed to clone(at::MemoryFormat::Contiguous) at TensorTransformations.cpp
* #27896 clone() changed to clone(at::MemoryFormat::Contiguous) at Sorting.cpp
* #27895 clone() changed to clone(at::MemoryFormat::Contiguous) at SobolEngineOps.cpp
* #27894 clone() changed to clone(at::MemoryFormat::Contiguous) at LinearAlgebraUtils.h
* #27893 clone() changed to clone(at::MemoryFormat::Contiguous) at LinearAlgebra.cpp
* #27892 clone() changed to clone(at::MemoryFormat::Contiguous) at Indexing.cpp

