### PR TITLE
[distributed] improve error handling in getNCCLVersion in NCCLUtils

### DIFF
--- a/torch/lib/c10d/NCCLUtils.cpp
+++ b/torch/lib/c10d/NCCLUtils.cpp
@@ -10,14 +10,17 @@ std::string getNcclVersion() {
   std::call_once(ncclGetVersionFlag, []() {
     int version;
     ncclResult_t status = ncclGetVersion(&version);
-    if (status != ncclSuccess) {
+    // can't compute the version if call did not return successfully or version
+    // code < 100 (corresponding to 0.1.0)
+    if (status != ncclSuccess || version < 100) {
       versionString = "Unknown NCCL version";
+    } else {
+      auto ncclMajor = version / 1000;
+      auto ncclMinor = (version % 1000) / 100;
+      auto ncclPatch = version % (ncclMajor * 1000 + ncclMinor * 100);
+      versionString = std::to_string(ncclMajor) + "." +
+          std::to_string(ncclMinor) + "." + std::to_string(ncclPatch);
     }
-    auto ncclMajor = version / 1000;
-    auto ncclMinor = (version % 1000) / 100;
-    auto ncclPatch = version % (ncclMajor * 1000 + ncclMinor * 100);
-    versionString = std::to_string(ncclMajor) + "." +
-        std::to_string(ncclMinor) + "." + std::to_string(ncclPatch);
   });
 
   return versionString;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#27883 [distributed] improve error handling in getNCCLVersion in NCCLUtils**

Returns early if NCCL version code returned to us is < 100, to prevent
division errors. This shouldn't actually happen since the nvidia nccl version is way past 0.1.0 but nice to have this safeguard to not rely on assumptions.

Test plan: Follow same process as https://github.com/pytorch/pytorch/pull/27068. Also force version to be < 100 and ensure that "Unknown NCCL Version" is returned.

Differential Revision: [D17903234](https://our.internmc.facebook.com/intern/diff/D17903234/)