### PR TITLE
clone() changed to clone(at::MemoryFormat::Contiguous) at LinearAlgebraUtils.h

### DIFF
--- a/aten/src/ATen/native/LinearAlgebraUtils.h
+++ b/aten/src/ATen/native/LinearAlgebraUtils.h
@@ -1,6 +1,7 @@
 #include <ATen/ATen.h>
 #include <ATen/ExpandUtils.h>
 #include <ATen/TensorUtils.h>
+#include <ATen/MemoryFormatUtils.h>
 #include <limits>
 #include <sstream>
 #include <cstring>
@@ -22,7 +23,8 @@ static inline Tensor cloneBatchedColumnMajor(const Tensor& src) {
   // this will be efficient (no reordering of the data will occur)
   // because the first transpose will make the tensor contiguous,
   // and cloning a contiguous tensor is fast.
-  auto result = src.transpose(-2, -1).clone();
+  auto tr = src.transpose(-2, -1);
+  auto result = clone_if_possible_with_memory_format(tr);
   result.transpose_(-2, -1);
   return result;
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #27873 clone() changed to clone(at::MemoryFormat::Contiguous) at ProcessGroupGloo.cpp
* #27912 clone() changed to clone(at::MemoryFormat::Contiguous) at ProcessGroupGloo.cpp
* #27911 clone() changed to clone(at::MemoryFormat::Contiguous) at check_alias_annotation.cpp
* #27910 clone() changed to clone(at::MemoryFormat::Contiguous) at accumulate_grad.cpp
* #27909 clone() changed to clone(at::MemoryFormat::Contiguous) at lbfgs.cpp
* #27908 clone() changed to clone(at::MemoryFormat::Contiguous) at Functions.cpp
* #27907 clone() changed to clone(at::MemoryFormat::Contiguous) at test_misc.cpp
* #27906 clone() changed to clone(at::MemoryFormat::Contiguous) at optim.cpp
* #27905 clone() changed to clone(at::MemoryFormat::Contiguous) at nn_utils.cpp
* #27904 clone() changed to clone(at::MemoryFormat::Contiguous) at autograd.cpp
* #27903 clone() changed to clone(at::MemoryFormat::Contiguous) at pow_test.cpp
* #27901 clone() changed to clone(at::MemoryFormat::Contiguous) at broadcast_test.cpp
* #27900 clone() changed to clone(at::MemoryFormat::Contiguous) at Unique.cu
* #27899 clone() changed to clone(at::MemoryFormat::Contiguous) at SpectralOps.cu
* #27898 clone() changed to clone(at::MemoryFormat::Contiguous) at SortingKthValue.cu
* #27897 clone() changed to clone(at::MemoryFormat::Contiguous) at TensorTransformations.cpp
* #27896 clone() changed to clone(at::MemoryFormat::Contiguous) at Sorting.cpp
* #27895 clone() changed to clone(at::MemoryFormat::Contiguous) at SobolEngineOps.cpp
* **#27894 clone() changed to clone(at::MemoryFormat::Contiguous) at LinearAlgebraUtils.h**
* #27893 clone() changed to clone(at::MemoryFormat::Contiguous) at LinearAlgebra.cpp
* #27892 clone() changed to clone(at::MemoryFormat::Contiguous) at Indexing.cpp

