### PR TITLE
clone() changed to clone(at::MemoryFormat::Contiguous) at SobolEngineOps.cpp

### DIFF
--- a/aten/src/ATen/native/SobolEngineOps.cpp
+++ b/aten/src/ATen/native/SobolEngineOps.cpp
@@ -1,6 +1,7 @@
 #include <ATen/ATen.h>
 #include <ATen/Dispatch.h>
 #include <ATen/NativeFunctions.h>
+#include <ATen/MemoryFormatUtils.h>
 
 #include <ATen/native/SobolEngineOpsUtils.h>
 
@@ -21,7 +22,7 @@ std::tuple<Tensor, Tensor> _sobol_engine_draw(const Tensor& quasi, int64_t n, co
   TORCH_CHECK(quasi.dtype() == at::kLong,
            "quasi needs to be of type ", at::kLong);
 
-  Tensor wquasi = quasi.clone();
+  Tensor wquasi = clone_if_possible_with_memory_format(quasi);
   auto result_dtype = dtype.has_value() ? dtype.value() : at::kFloat;
   Tensor result = at::empty({n, dimension}, sobolstate.options().dtype(result_dtype));
 
@@ -93,7 +94,7 @@ Tensor& _sobol_engine_scramble_(Tensor& sobolstate, const Tensor& ltm, int64_t d
   /// Instead, we perform an element-wise product of all the matrices and sum over the last dimension.
   /// The required product of the m^{th} row in the d^{th} square matrix in `ltm` can be accessed
   /// using ltm_d_a[d][m] m and d are zero-indexed
-  Tensor diag_true = ltm.clone();
+  Tensor diag_true = clone_if_possible_with_memory_format(ltm);
   diag_true.diagonal(0, -2, -1).fill_(1);
   Tensor ltm_dots = cdot_pow2(diag_true);
   auto ltm_d_a = ltm_dots.accessor<int64_t, 2>();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #27873 clone() changed to clone(at::MemoryFormat::Contiguous) at ProcessGroupGloo.cpp
* #27912 clone() changed to clone(at::MemoryFormat::Contiguous) at ProcessGroupGloo.cpp
* #27911 clone() changed to clone(at::MemoryFormat::Contiguous) at check_alias_annotation.cpp
* #27910 clone() changed to clone(at::MemoryFormat::Contiguous) at accumulate_grad.cpp
* #27909 clone() changed to clone(at::MemoryFormat::Contiguous) at lbfgs.cpp
* #27908 clone() changed to clone(at::MemoryFormat::Contiguous) at Functions.cpp
* #27907 clone() changed to clone(at::MemoryFormat::Contiguous) at test_misc.cpp
* #27906 clone() changed to clone(at::MemoryFormat::Contiguous) at optim.cpp
* #27905 clone() changed to clone(at::MemoryFormat::Contiguous) at nn_utils.cpp
* #27904 clone() changed to clone(at::MemoryFormat::Contiguous) at autograd.cpp
* #27903 clone() changed to clone(at::MemoryFormat::Contiguous) at pow_test.cpp
* #27901 clone() changed to clone(at::MemoryFormat::Contiguous) at broadcast_test.cpp
* #27900 clone() changed to clone(at::MemoryFormat::Contiguous) at Unique.cu
* #27899 clone() changed to clone(at::MemoryFormat::Contiguous) at SpectralOps.cu
* #27898 clone() changed to clone(at::MemoryFormat::Contiguous) at SortingKthValue.cu
* #27897 clone() changed to clone(at::MemoryFormat::Contiguous) at TensorTransformations.cpp
* #27896 clone() changed to clone(at::MemoryFormat::Contiguous) at Sorting.cpp
* **#27895 clone() changed to clone(at::MemoryFormat::Contiguous) at SobolEngineOps.cpp**
* #27894 clone() changed to clone(at::MemoryFormat::Contiguous) at LinearAlgebraUtils.h
* #27893 clone() changed to clone(at::MemoryFormat::Contiguous) at LinearAlgebra.cpp
* #27892 clone() changed to clone(at::MemoryFormat::Contiguous) at Indexing.cpp

