### PR TITLE
clone() changed to clone(at::MemoryFormat::Contiguous) at SortingKthValue.cu

### DIFF
--- a/aten/src/ATen/native/cuda/SortingKthValue.cu
+++ b/aten/src/ATen/native/cuda/SortingKthValue.cu
@@ -22,6 +22,7 @@
 #include <ATen/native/cuda/SortingCommon.cuh>
 #include <ATen/native/cuda/SortingRadixSelect.cuh>
 #include <ATen/NamedTensorUtils.h>
+#include <ATen/MemoryFormatUtils.h>
 
 namespace at {
 namespace native {
@@ -191,9 +192,9 @@ template <typename scalar_t>
 Tensor median_cuda_template(const Tensor& self) {
   TORCH_CHECK(self.numel() > 0, "median cannot be called with empty tensor");
   if (self.dim() == 0 && self.numel() == 1) {
-    return self.clone();
+    return clone_if_possible_with_memory_format(self);
   }
-  auto self_copy = self.clone().view(-1);
+  auto self_copy = clone_if_possible_with_memory_format(self).view(-1);
   auto values = at::empty({1}, self.options());
   auto indices = at::empty({1}, self.options().dtype(kLong));
   TORCH_CHECK(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #27873 clone() changed to clone(at::MemoryFormat::Contiguous) at ProcessGroupGloo.cpp
* #27912 clone() changed to clone(at::MemoryFormat::Contiguous) at ProcessGroupGloo.cpp
* #27911 clone() changed to clone(at::MemoryFormat::Contiguous) at check_alias_annotation.cpp
* #27910 clone() changed to clone(at::MemoryFormat::Contiguous) at accumulate_grad.cpp
* #27909 clone() changed to clone(at::MemoryFormat::Contiguous) at lbfgs.cpp
* #27908 clone() changed to clone(at::MemoryFormat::Contiguous) at Functions.cpp
* #27907 clone() changed to clone(at::MemoryFormat::Contiguous) at test_misc.cpp
* #27906 clone() changed to clone(at::MemoryFormat::Contiguous) at optim.cpp
* #27905 clone() changed to clone(at::MemoryFormat::Contiguous) at nn_utils.cpp
* #27904 clone() changed to clone(at::MemoryFormat::Contiguous) at autograd.cpp
* #27903 clone() changed to clone(at::MemoryFormat::Contiguous) at pow_test.cpp
* #27901 clone() changed to clone(at::MemoryFormat::Contiguous) at broadcast_test.cpp
* #27900 clone() changed to clone(at::MemoryFormat::Contiguous) at Unique.cu
* #27899 clone() changed to clone(at::MemoryFormat::Contiguous) at SpectralOps.cu
* **#27898 clone() changed to clone(at::MemoryFormat::Contiguous) at SortingKthValue.cu**
* #27897 clone() changed to clone(at::MemoryFormat::Contiguous) at TensorTransformations.cpp
* #27896 clone() changed to clone(at::MemoryFormat::Contiguous) at Sorting.cpp
* #27895 clone() changed to clone(at::MemoryFormat::Contiguous) at SobolEngineOps.cpp
* #27894 clone() changed to clone(at::MemoryFormat::Contiguous) at LinearAlgebraUtils.h
* #27893 clone() changed to clone(at::MemoryFormat::Contiguous) at LinearAlgebra.cpp
* #27892 clone() changed to clone(at::MemoryFormat::Contiguous) at Indexing.cpp

