### PR TITLE
clone() changed to clone(at::MemoryFormat::Contiguous) at Unique.cu

### DIFF
--- a/aten/src/ATen/native/cuda/Unique.cu
+++ b/aten/src/ATen/native/cuda/Unique.cu
@@ -2,6 +2,7 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <THC/THCGeneral.h>
 #include <THC/THCThrustAllocator.cuh>
+#include <ATen/MemoryFormatUtils.h>
 #include <thrust/execution_policy.h>
 
 #include <tuple>
@@ -84,7 +85,7 @@ std::tuple<Tensor, Tensor, Tensor> unique_cuda_template(
   auto policy = thrust::cuda::par(allocator).on(stream);
 
   auto options = self.options().dtype(kLong);
-  Tensor output = self.clone().reshape(-1);
+  Tensor output = clone_if_possible_with_memory_format(self).reshape(-1);
   int64_t num_inp = output.numel();
   scalar_t* output_data = output.data_ptr<scalar_t>();
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #27873 clone() changed to clone(at::MemoryFormat::Contiguous) at ProcessGroupGloo.cpp
* #27912 clone() changed to clone(at::MemoryFormat::Contiguous) at ProcessGroupGloo.cpp
* #27911 clone() changed to clone(at::MemoryFormat::Contiguous) at check_alias_annotation.cpp
* #27910 clone() changed to clone(at::MemoryFormat::Contiguous) at accumulate_grad.cpp
* #27909 clone() changed to clone(at::MemoryFormat::Contiguous) at lbfgs.cpp
* #27908 clone() changed to clone(at::MemoryFormat::Contiguous) at Functions.cpp
* #27907 clone() changed to clone(at::MemoryFormat::Contiguous) at test_misc.cpp
* #27906 clone() changed to clone(at::MemoryFormat::Contiguous) at optim.cpp
* #27905 clone() changed to clone(at::MemoryFormat::Contiguous) at nn_utils.cpp
* #27904 clone() changed to clone(at::MemoryFormat::Contiguous) at autograd.cpp
* #27903 clone() changed to clone(at::MemoryFormat::Contiguous) at pow_test.cpp
* #27901 clone() changed to clone(at::MemoryFormat::Contiguous) at broadcast_test.cpp
* **#27900 clone() changed to clone(at::MemoryFormat::Contiguous) at Unique.cu**
* #27899 clone() changed to clone(at::MemoryFormat::Contiguous) at SpectralOps.cu
* #27898 clone() changed to clone(at::MemoryFormat::Contiguous) at SortingKthValue.cu
* #27897 clone() changed to clone(at::MemoryFormat::Contiguous) at TensorTransformations.cpp
* #27896 clone() changed to clone(at::MemoryFormat::Contiguous) at Sorting.cpp
* #27895 clone() changed to clone(at::MemoryFormat::Contiguous) at SobolEngineOps.cpp
* #27894 clone() changed to clone(at::MemoryFormat::Contiguous) at LinearAlgebraUtils.h
* #27893 clone() changed to clone(at::MemoryFormat::Contiguous) at LinearAlgebra.cpp
* #27892 clone() changed to clone(at::MemoryFormat::Contiguous) at Indexing.cpp

