### PR TITLE
clone() changed to clone(at::MemoryFormat::Contiguous) at pow_test.cpp

### DIFF
--- a/aten/src/ATen/test/pow_test.cpp
+++ b/aten/src/ATen/test/pow_test.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <ATen/native/Pow.h>
+#include <ATen/MemoryFormatUtils.h>
 
 #include <torch/types.h>
 #include <torch/utils.h>
@@ -113,7 +114,7 @@ void tensor_pow_scalar(const Vals vals, const Pows pows) {
   for (const auto pow : pows) {
     auto actual_pow = tensor.pow(pow);
 
-    auto actual_pow_ = tensor.clone();
+    auto actual_pow_ = clone_if_possible_with_memory_format(tensor);
     actual_pow_.pow_(pow);
 
     auto actual_pow_out = torch::empty_like(tensor);
@@ -187,7 +188,7 @@ void tensor_pow_tensor(const Vals vals, Pows pows) {
 
     const auto actual_pow = vals_tensor.pow(pows_tensor);
 
-    auto actual_pow_ = vals_tensor.clone();
+    auto actual_pow_ = clone_if_possible_with_memory_format(vals_tensor);
     actual_pow_.pow_(pows_tensor);
 
     auto actual_pow_out = torch::empty_like(vals_tensor);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #27873 clone() changed to clone(at::MemoryFormat::Contiguous) at ProcessGroupGloo.cpp
* #27912 clone() changed to clone(at::MemoryFormat::Contiguous) at ProcessGroupGloo.cpp
* #27911 clone() changed to clone(at::MemoryFormat::Contiguous) at check_alias_annotation.cpp
* #27910 clone() changed to clone(at::MemoryFormat::Contiguous) at accumulate_grad.cpp
* #27909 clone() changed to clone(at::MemoryFormat::Contiguous) at lbfgs.cpp
* #27908 clone() changed to clone(at::MemoryFormat::Contiguous) at Functions.cpp
* #27907 clone() changed to clone(at::MemoryFormat::Contiguous) at test_misc.cpp
* #27906 clone() changed to clone(at::MemoryFormat::Contiguous) at optim.cpp
* #27905 clone() changed to clone(at::MemoryFormat::Contiguous) at nn_utils.cpp
* #27904 clone() changed to clone(at::MemoryFormat::Contiguous) at autograd.cpp
* **#27903 clone() changed to clone(at::MemoryFormat::Contiguous) at pow_test.cpp**
* #27901 clone() changed to clone(at::MemoryFormat::Contiguous) at broadcast_test.cpp
* #27900 clone() changed to clone(at::MemoryFormat::Contiguous) at Unique.cu
* #27899 clone() changed to clone(at::MemoryFormat::Contiguous) at SpectralOps.cu
* #27898 clone() changed to clone(at::MemoryFormat::Contiguous) at SortingKthValue.cu
* #27897 clone() changed to clone(at::MemoryFormat::Contiguous) at TensorTransformations.cpp
* #27896 clone() changed to clone(at::MemoryFormat::Contiguous) at Sorting.cpp
* #27895 clone() changed to clone(at::MemoryFormat::Contiguous) at SobolEngineOps.cpp
* #27894 clone() changed to clone(at::MemoryFormat::Contiguous) at LinearAlgebraUtils.h
* #27893 clone() changed to clone(at::MemoryFormat::Contiguous) at LinearAlgebra.cpp
* #27892 clone() changed to clone(at::MemoryFormat::Contiguous) at Indexing.cpp

