### PR TITLE
clone() changed to clone(at::MemoryFormat::Contiguous) at autograd.cpp

### DIFF
--- a/test/cpp/api/autograd.cpp
+++ b/test/cpp/api/autograd.cpp
@@ -3,6 +3,7 @@
 #include <torch/torch.h>
 
 #include <test/cpp/api/support.h>
+#include <ATen/MemoryFormatUtils.h>
 
 using namespace torch::autograd;
 
@@ -236,7 +237,7 @@ TEST(CustomAutogradTest, MarkNonDifferentiableMixed) {
 TEST(CustomAutogradTest, MarkNonDifferentiableNone) {
   struct MyFunction : public Function<MyFunction> {
     static Variable forward(AutogradContext *ctx, Variable input) {
-      auto output = input.clone();
+      auto output = clone_if_possible_with_memory_format(input);
       ctx->mark_non_differentiable({output});
       return output;
     }
@@ -292,7 +293,8 @@ TEST(CustomAutogradTest, ReturnDuplicateInplace) {
   ASSERT_THROWS_WITH(DoubleInplace::apply(x), "leaf Variable that requires grad");
   // TODO ASSERT_THROWS_WITH(DoubleInplace::apply(x.clone()[0]), "only one output");
 
-  auto out = DoubleInplace::apply(x.clone());
+  auto cloned = clone_if_possible_with_memory_format(x);
+  auto out = DoubleInplace::apply(cloned);
   ASSERT_TRUE(torch::equal(out[0],out[1]));
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #27873 clone() changed to clone(at::MemoryFormat::Contiguous) at ProcessGroupGloo.cpp
* #27912 clone() changed to clone(at::MemoryFormat::Contiguous) at ProcessGroupGloo.cpp
* #27911 clone() changed to clone(at::MemoryFormat::Contiguous) at check_alias_annotation.cpp
* #27910 clone() changed to clone(at::MemoryFormat::Contiguous) at accumulate_grad.cpp
* #27909 clone() changed to clone(at::MemoryFormat::Contiguous) at lbfgs.cpp
* #27908 clone() changed to clone(at::MemoryFormat::Contiguous) at Functions.cpp
* #27907 clone() changed to clone(at::MemoryFormat::Contiguous) at test_misc.cpp
* #27906 clone() changed to clone(at::MemoryFormat::Contiguous) at optim.cpp
* #27905 clone() changed to clone(at::MemoryFormat::Contiguous) at nn_utils.cpp
* **#27904 clone() changed to clone(at::MemoryFormat::Contiguous) at autograd.cpp**
* #27903 clone() changed to clone(at::MemoryFormat::Contiguous) at pow_test.cpp
* #27901 clone() changed to clone(at::MemoryFormat::Contiguous) at broadcast_test.cpp
* #27900 clone() changed to clone(at::MemoryFormat::Contiguous) at Unique.cu
* #27899 clone() changed to clone(at::MemoryFormat::Contiguous) at SpectralOps.cu
* #27898 clone() changed to clone(at::MemoryFormat::Contiguous) at SortingKthValue.cu
* #27897 clone() changed to clone(at::MemoryFormat::Contiguous) at TensorTransformations.cpp
* #27896 clone() changed to clone(at::MemoryFormat::Contiguous) at Sorting.cpp
* #27895 clone() changed to clone(at::MemoryFormat::Contiguous) at SobolEngineOps.cpp
* #27894 clone() changed to clone(at::MemoryFormat::Contiguous) at LinearAlgebraUtils.h
* #27893 clone() changed to clone(at::MemoryFormat::Contiguous) at LinearAlgebra.cpp
* #27892 clone() changed to clone(at::MemoryFormat::Contiguous) at Indexing.cpp

