### PR TITLE
clone() changed to clone(at::MemoryFormat::Contiguous) at accumulate_grad.cpp

### DIFF
--- a/torch/csrc/autograd/functions/accumulate_grad.cpp
+++ b/torch/csrc/autograd/functions/accumulate_grad.cpp
@@ -5,6 +5,7 @@
 #include <torch/csrc/autograd/functions/basic_ops.h>
 #include <torch/csrc/autograd/functions/tensor.h>
 #include <torch/csrc/autograd/functions/utils.h>
+#include <ATen/MemoryFormatUtils.h>
 
 #include <cstdint>
 #include <stdexcept>
@@ -54,7 +55,7 @@ auto AccumulateGrad::apply(variable_list&& grads) -> variable_list {
       // addition of !post_hooks().empty().
       variable.grad() = new_grad.detach();
     } else {
-      variable.grad() = new_grad.clone();
+      variable.grad() = clone_if_possible_with_memory_format(new_grad);
     }
   } else if (!GradMode::is_enabled()) {
     // This case is not strictly necessary, but it makes the first-order only case


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #27873 clone() changed to clone(at::MemoryFormat::Contiguous) at ProcessGroupGloo.cpp
* #27912 clone() changed to clone(at::MemoryFormat::Contiguous) at ProcessGroupGloo.cpp
* #27911 clone() changed to clone(at::MemoryFormat::Contiguous) at check_alias_annotation.cpp
* **#27910 clone() changed to clone(at::MemoryFormat::Contiguous) at accumulate_grad.cpp**
* #27909 clone() changed to clone(at::MemoryFormat::Contiguous) at lbfgs.cpp
* #27908 clone() changed to clone(at::MemoryFormat::Contiguous) at Functions.cpp
* #27907 clone() changed to clone(at::MemoryFormat::Contiguous) at test_misc.cpp
* #27906 clone() changed to clone(at::MemoryFormat::Contiguous) at optim.cpp
* #27905 clone() changed to clone(at::MemoryFormat::Contiguous) at nn_utils.cpp
* #27904 clone() changed to clone(at::MemoryFormat::Contiguous) at autograd.cpp
* #27903 clone() changed to clone(at::MemoryFormat::Contiguous) at pow_test.cpp
* #27901 clone() changed to clone(at::MemoryFormat::Contiguous) at broadcast_test.cpp
* #27900 clone() changed to clone(at::MemoryFormat::Contiguous) at Unique.cu
* #27899 clone() changed to clone(at::MemoryFormat::Contiguous) at SpectralOps.cu
* #27898 clone() changed to clone(at::MemoryFormat::Contiguous) at SortingKthValue.cu
* #27897 clone() changed to clone(at::MemoryFormat::Contiguous) at TensorTransformations.cpp
* #27896 clone() changed to clone(at::MemoryFormat::Contiguous) at Sorting.cpp
* #27895 clone() changed to clone(at::MemoryFormat::Contiguous) at SobolEngineOps.cpp
* #27894 clone() changed to clone(at::MemoryFormat::Contiguous) at LinearAlgebraUtils.h
* #27893 clone() changed to clone(at::MemoryFormat::Contiguous) at LinearAlgebra.cpp
* #27892 clone() changed to clone(at::MemoryFormat::Contiguous) at Indexing.cpp

