### PR TITLE
Add a variant of insertGraph that fills values map.

### DIFF
--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -1691,8 +1691,8 @@ std::vector<Value*> unpackOutputs(const std::vector<Value*>& outputs) {
 std::vector<Value*> insertGraph(
     Graph& g,
     Graph& callee,
-    ArrayRef<Value*> inputs) {
-  std::unordered_map<Value*, Value*> value_map;
+    ArrayRef<Value*> inputs,
+    std::unordered_map<Value*, Value*>& value_map) {
   auto value_map_func = [&](Value* v) { return value_map.at(v); };
   AT_ASSERT(callee.inputs().size() == inputs.size());
   for (size_t i = 0; i < inputs.size(); ++i) {
@@ -1711,6 +1711,14 @@ std::vector<Value*> insertGraph(
   }
 
   return outputs;
+}
+
+std::vector<Value*> insertGraph(
+    Graph& g,
+    Graph& callee,
+    ArrayRef<Value*> inputs) {
+  std::unordered_map<Value*, Value*> value_map;
+  return insertGraph(g, callee, inputs, value_map);
 }
 
 void ProfileOp::cloneFrom(Node* other_) {

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -1317,13 +1317,19 @@ TORCH_API void LintGraph(std::shared_ptr<Graph>& graph);
 TORCH_API at::ArrayRef<Value*> createTupleUnpack(Value* v);
 
 /** Insert graph \p CALLEE into graph \p G using \p INPUTS as input values.
- *
  * The insertion happens at the current insertion point.
+ * Optionally, one can also pass \p VALUE_MAP to get a map between \p CALLEE
+ * values and their cloned copies in \p G.
  */
 TORCH_API std::vector<Value*> insertGraph(
     Graph& g,
     Graph& callee,
     ArrayRef<Value*> inputs);
+TORCH_API std::vector<Value*> insertGraph(
+    Graph& g,
+    Graph& callee,
+    ArrayRef<Value*> inputs,
+    std::unordered_map<Value*, Value*>& value_map);
 
 /** Insert graph \p CALLEE after node \p TO_REPLACE, remove the node and
  * replace all its uses with corresponding outputs of the inserted graph. The


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #27915 Add logging to inliner.
* #21939 Add CallStack class.
* #27914 Make inlineCallTo to take Function instead of Graph as the callee argument.
* **#27913 Add a variant of insertGraph that fills values map.**

ghstack-source-id: db6bbfa9a9a4b5ceb61d1edde337ed45faf7640f
Pull Request resolved: https://github.com/pytorch/pytorch/pull/23619