### PR TITLE
Add CallStack class.

### DIFF
--- a/test/cpp/jit/tests.h
+++ b/test/cpp/jit/tests.h
@@ -12,6 +12,7 @@ namespace jit {
   _(ADFormulas)                        \
   _(Attributes)                        \
   _(Blocks)                            \
+  _(CallStack)                         \
   _(CodeTemplate)                      \
   _(ControlFlow)                       \
   _(CreateAutodiffSubgraphs)           \

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -1047,6 +1047,7 @@ Node::Node(Graph* graph_, NodeKind kind_)
       graph_(graph_),
       owning_block_(nullptr),
       scope_(graph_->current_scope_),
+      callstack_(c10::nullopt),
       op_(nullptr),
       topo_position_(0) {
   graph_->all_nodes.emplace(this);
@@ -1640,6 +1641,22 @@ void Graph::freeBlock(Block* b) {
   all_blocks.erase(it);
 }
 
+void Node::insertCallStackEntry(Function* f, SourceRange sr) {
+  if (!callstack_) {
+    callstack_ = c10::make_intrusive<CallStack>(f, sr);
+  } else {
+    callstack_ = (*callstack_)->insertCallStackEntry(f, sr);
+  }
+}
+
+void Node::appendCallStackOf(Node* other) {
+  if (other->callstack_) {
+    for (auto& e : (*other->callstack_)->asVector()) {
+      insertCallStackEntry(e.first, e.second);
+    }
+  }
+}
+
 at::ArrayRef<Value*> createTupleUnpack(Value* v) {
   // small peephole optimization to ensure IntArrayRef attributes can still turn
   // into constants e.g. in x.expand([3, 4])
@@ -1650,12 +1667,27 @@ at::ArrayRef<Value*> createTupleUnpack(Value* v) {
   return g.insertNode(g.createTupleUnpack(v))->outputs();
 }
 
-std::vector<Value*> inlineCallTo(
-    Node* to_replace,
-    Graph& callee) {
+std::vector<Value*> inlineCallTo(Node* to_replace, Function* callee) {
   WithInsertPoint guard(to_replace);
-  auto new_outputs =
-      insertGraph(*to_replace->owningGraph(), callee, to_replace->inputs());
+  std::unordered_map<Value*, Value*> value_map;
+  auto new_outputs = insertGraph(
+      *to_replace->owningGraph(),
+      *(callee->optimized_graph()),
+      to_replace->inputs(),
+      value_map);
+
+  // TODO: We might need to use nodes_map instead of value_map. Otherwise, we
+  // are missing nodes without outputs (e.g. prim::Print).
+  std::unordered_set<Node*> updated_nodes;
+  for (const auto& kv : value_map) {
+    Node* orig_node = kv.first->node();
+    Node* new_node = kv.second->node();
+    if (updated_nodes.insert(new_node).second) {
+      new_node->insertCallStackEntry(callee, to_replace->sourceRange());
+      new_node->appendCallStackOf(orig_node);
+    }
+  }
+
   const auto& old_outputs = to_replace->outputs();
 
   AT_ASSERT(new_outputs.size() == old_outputs.size());

--- a/torch/csrc/jit/passes/inliner.cpp
+++ b/torch/csrc/jit/passes/inliner.cpp
@@ -20,13 +20,13 @@ void inlineCalls(Block* block) {
         auto fun_type =
             function_constant->output()->type()->expect<FunctionType>();
         cur->removeInput(0);
-        inlineCallTo(cur, *fun_type->function()->optimized_graph());
+        inlineCallTo(cur, fun_type->function());
       } break;
       case prim::CallMethod: {
         const std::string& name = cur->s(attr::name);
         if (auto class_type = cur->input(0)->type()->cast<ClassType>()) {
           auto function = class_type->getMethod(name);
-          inlineCallTo(cur, *function->optimized_graph());
+          inlineCallTo(cur, function);
         }
       } break;
       default: {

--- a/torch/csrc/jit/scope.cpp
+++ b/torch/csrc/jit/scope.cpp
@@ -1,4 +1,5 @@
 #include <torch/csrc/jit/scope.h>
+#include <torch/csrc/jit/function.h>
 
 namespace torch {
 namespace jit {
@@ -77,5 +78,50 @@ std::string Scope::namesFromRoot(const std::string& separator) const {
   return out;
 }
 
+CallStackPtr CallStack::intrusive_from_this() {
+  c10::raw::intrusive_ptr::incref(this); // we are creating a new pointer
+                                         // from a raw `this` pointer
+                                         // so we need to bump the refcount
+                                         // to account for this ownership
+  return c10::intrusive_ptr<CallStack>::reclaim(this);
+}
+
+CallStack::CallStack(Function* fn, SourceRange source_range)
+    : fn_(fn), source_range_(source_range) {}
+
+CallStack::CallStack(
+    CallStackPtr caller,
+    Function* fn,
+    SourceRange source_range)
+    : fn_(fn), source_range_(source_range) {
+  caller_ = std::move(caller);
+}
+
+CallStackPtr CallStack::insertCallStackEntry(
+    Function* fn,
+    SourceRange source_range) {
+  auto ent = std::make_pair(fn, source_range);
+  if (callees_.count(ent)) {
+    return callees_.at(ent);
+  }
+  auto subscope =
+      c10::make_intrusive<CallStack>(intrusive_from_this(), fn, source_range);
+  callees_[ent] = subscope;
+  return subscope;
+}
+
+c10::optional<CallStackPtr> CallStack::caller() const {
+  return caller_;
+}
+
+std::vector<CallStackEntry> CallStack::asVector() {
+  std::vector<CallStackEntry> r;
+  c10::optional<CallStackPtr> current = intrusive_from_this();
+  while (current) {
+    r.push_back(std::make_pair((*current)->fn_, (*current)->source_range_));
+    current = (*current)->caller_;
+  }
+  return std::vector<CallStackEntry>(r.rbegin(), r.rend());
+}
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/scope.h
+++ b/torch/csrc/jit/scope.h
@@ -1,7 +1,10 @@
 #pragma once
 #include <ATen/core/interned_strings.h>
+#include <c10/util/Optional.h>
 #include <c10/util/intrusive_ptr.h>
 #include <torch/csrc/WindowsTorchApiMacro.h>
+#include <torch/csrc/jit/source_range.h>
+#include <unordered_map>
 
 namespace torch {
 namespace jit {
@@ -43,6 +46,56 @@ struct TORCH_API Scope : public c10::intrusive_ptr_target {
   Symbol name() const;
 
   std::string namesFromRoot(const std::string& separator = "/") const;
+};
+
+struct Function;
+struct CallStack;
+
+/**
+ * CallStack is a node of a trie that represents the callstack.
+ * Each node in the trie is a pair [Function, SourceRange].
+ * Each IR Node has a callstack field, which is basically a pointer to a trie
+ * node. Initially the field is null, but if the node is created during an
+ * inlining from a different function it gets filled with the function and
+ * source range info. As inlining continues, the trie can grow.
+ */
+using CallStackPtr = c10::intrusive_ptr<CallStack>;
+using CallStackEntry = std::pair<Function*, SourceRange>;
+struct CallStackHash {
+  std::size_t operator()(const CallStackEntry& cs) const {
+    return std::hash<void*>()(cs.first) ^
+        std::hash<void*>()(&*cs.second.source()) ^
+        std::hash<size_t>()(cs.second.start()) ^
+        std::hash<size_t>()(cs.second.end());
+  }
+};
+
+struct TORCH_API CallStack : public c10::intrusive_ptr_target {
+ private:
+  c10::optional<CallStackPtr> caller_;
+
+  std::unordered_map<CallStackEntry, CallStackPtr, CallStackHash> callees_;
+  Function* fn_;
+  SourceRange source_range_;
+  CallStackPtr intrusive_from_this();
+
+ public:
+  // Constructor for the root callstack node.
+  CallStack(Function* fn, SourceRange source_range);
+
+  // Constructor for an inner callstack node.
+  CallStack(CallStackPtr caller, Function* fn, SourceRange source_range);
+
+  // Return callstack for the caller.
+  // Essentially, move one level up in the trie.
+  c10::optional<CallStackPtr> caller() const;
+
+  // Insert new callee to the callstack.
+  // Essentially, find existing or insert new node into the trie.
+  CallStackPtr insertCallStackEntry(Function* fn, SourceRange source_range);
+
+  // Flatten callstack to a vector of [Function, SourceRange] pairs.
+  std::vector<CallStackEntry> asVector();
 };
 
 } // namespace jit


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #27918 Add logging to inliner.
* **#27917 Add CallStack class.**
* #27916 Add a variant of insertGraph that fills values map.

Callstack serves a similar purpose to Scope, but instead of storing
string names of the functions it stores pointer to Function objects
themselves. Currently, scopes are used in tracing and callstacks are
used in scripting - hopefully I would be able to merge them in future.

ghstack-source-id: 227b1b4ba6feaff45de0c541f8d4254aeb8be7e8