### PR TITLE
Fix Sphinx warning about '_images' not existing

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -158,7 +158,7 @@ if RELEASE:
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static', '_images']
+html_static_path = ['_static']
 
 
 # Called automatically by Sphinx, making this `conf.py` an "extension".


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#27927 Fix Sphinx warning about '_images' not existing**
* #27850 Bag of documentation fixes; fix more sphinx warnings

This fixes
`WARNING: html_static_path entry '_images' does not exist`
by removing '_images' from conf.py. As far as I can tell, '_images' in
`html_static_path` is only necessary if images already exist in the
`_images` folder; otherwise, sphinx is able to auto-generate _images
into the build directory and populate it correctly.

Test Plan:
- build and view the docs locally.

Differential Revision: [D17915109](https://our.internmc.facebook.com/intern/diff/D17915109)