### PR TITLE
Allow passing undefined Tensor to Module::register_parameter

### DIFF
--- a/test/cpp/api/module.cpp
+++ b/test/cpp/api/module.cpp
@@ -144,7 +144,7 @@ TEST_F(ModuleTest, RegisterParameterUndefinedTensor) {
   struct TestModel : public torch::nn::Module {};
   {
     TestModel model;
-    model.register_parameter("undefined_tensor", Tensor(), /*requires_grad=*/false);
+    model.register_parameter("undefined_tensor", torch::Tensor(), /*requires_grad=*/false);
     ASSERT_FALSE(model.named_parameters()["undefined_tensor"].defined());
   }
   {
@@ -152,7 +152,7 @@ TEST_F(ModuleTest, RegisterParameterUndefinedTensor) {
     CerrRedirect cerr_redirect(buffer.rdbuf());
 
     TestModel model;
-    model.register_parameter("undefined_tensor", Tensor());
+    model.register_parameter("undefined_tensor", torch::Tensor());
     ASSERT_FALSE(model.named_parameters()["undefined_tensor"].defined());
 
     ASSERT_EQ(

--- a/test/cpp/api/module.cpp
+++ b/test/cpp/api/module.cpp
@@ -140,6 +140,30 @@ TEST_F(ModuleTest, RegisterParameterThrowsForDuplicateModuleName) {
       "Parameter 'p' already defined");
 }
 
+TEST_F(ModuleTest, RegisterParameterUndefinedTensor) {
+  struct TestModel : public torch::nn::Module {};
+  {
+    TestModel model;
+    model.register_parameter("undefined_tensor", Tensor(), /*requires_grad=*/false);
+    ASSERT_FALSE(model->named_parameters()["undefined_tensor"].defined());
+  }
+  {
+    std::stringstream buffer;
+    CerrRedirect cerr_redirect(buffer.rdbuf());
+
+    TestModel model;
+    model.register_parameter("undefined_tensor", Tensor());
+    ASSERT_FALSE(model->named_parameters()["undefined_tensor"].defined());
+
+    ASSERT_EQ(
+      count_substr_occurrences(
+        buffer.str(),
+        "Ignoring the `requires_grad=true` function parameter"
+      ),
+    1);
+  }
+}
+
 TEST_F(ModuleTest, RegisterBufferThrowsForEmptyOrDottedName) {
   struct TestModel : public torch::nn::Module {};
   ASSERT_THROWS_WITH(

--- a/test/cpp/api/module.cpp
+++ b/test/cpp/api/module.cpp
@@ -145,7 +145,7 @@ TEST_F(ModuleTest, RegisterParameterUndefinedTensor) {
   {
     TestModel model;
     model.register_parameter("undefined_tensor", Tensor(), /*requires_grad=*/false);
-    ASSERT_FALSE(model->named_parameters()["undefined_tensor"].defined());
+    ASSERT_FALSE(model.named_parameters()["undefined_tensor"].defined());
   }
   {
     std::stringstream buffer;
@@ -153,7 +153,7 @@ TEST_F(ModuleTest, RegisterParameterUndefinedTensor) {
 
     TestModel model;
     model.register_parameter("undefined_tensor", Tensor());
-    ASSERT_FALSE(model->named_parameters()["undefined_tensor"].defined());
+    ASSERT_FALSE(model.named_parameters()["undefined_tensor"].defined());
 
     ASSERT_EQ(
       count_substr_occurrences(

--- a/torch/csrc/api/include/torch/nn/module.h
+++ b/torch/csrc/api/include/torch/nn/module.h
@@ -412,6 +412,9 @@ class TORCH_API Module : public std::enable_shared_from_this<Module> {
   /// implementation of your `Module`. Registering it makes it available to
   /// methods such as `parameters()`, `clone()` or `to().`
   ///
+  /// Note that registering an undefined Tensor (e.g. `module.register_parameter("param", Tensor())`)
+  /// is allowed, and is equivalent to `module.register_parameter("param", None)` in Python API.
+  ///
   /// \rst
   /// .. code-block:: cpp
   ///

--- a/torch/csrc/api/src/nn/module.cpp
+++ b/torch/csrc/api/src/nn/module.cpp
@@ -316,7 +316,15 @@ Tensor& Module::register_parameter(
       "Parameter name must not contain a dot (got '",
       name,
       "')");
-  tensor.set_requires_grad(requires_grad);
+  if (!tensor.defined()) {
+    if (requires_grad) {
+      TORCH_WARN(
+        "An undefined tensor cannot require grad. ",
+        "Ignoring the `requires_grad=true` function parameter.");
+    }
+  } else {
+    tensor.set_requires_grad(requires_grad);
+  }
   return parameters_.insert(std::move(name), std::move(tensor));
 }
 


### PR DESCRIPTION
C++ API `Module::register_parameter` should accept undefined Tensor as parameter, which is equivalent to `module.register_parameter("param", None)` in Python API.

This unblocks https://github.com/pytorch/pytorch/pull/26082 and https://github.com/pytorch/pytorch/pull/27156.