### PR TITLE
Make TripletMarginLossImpl subclass from Cloneable

### DIFF
--- a/torch/csrc/api/include/torch/nn/modules/loss.h
+++ b/torch/csrc/api/include/torch/nn/modules/loss.h
@@ -131,9 +131,11 @@ TORCH_MODULE(CosineEmbeddingLoss);
 /// samples. A triplet is composed by `a`, `p` and `n` (i.e., `anchor`, 
 /// `positive examples` and `negative examples` respectively). The
 /// shapes of all input tensors should be :math:`(N, D)`
-struct TORCH_API TripletMarginLossImpl : Module {
+struct TORCH_API TripletMarginLossImpl : public Cloneable<TripletMarginLossImpl> {
   explicit TripletMarginLossImpl(
       const TripletMarginLossOptions& options_ = {});
+
+  void reset() override;
 
   /// Pretty prints the `TripletMarginLoss` module into the given `stream`.
   void pretty_print(std::ostream& stream) const override;

--- a/torch/csrc/api/src/nn/modules/loss.cpp
+++ b/torch/csrc/api/src/nn/modules/loss.cpp
@@ -89,6 +89,8 @@ TripletMarginLossImpl::TripletMarginLossImpl(
     const TripletMarginLossOptions& options_)
     : options(options_) {}
 
+void TripletMarginLossImpl::reset() {}
+
 void TripletMarginLossImpl::pretty_print(std::ostream& stream) const {
   stream << "torch::nn::TripletMarginLoss(margin=" << options.margin() << 
             ", p=" << options.p() <<


### PR DESCRIPTION
Continuing from https://github.com/pytorch/pytorch/pull/27770 to make all `torch::nn` layers subclass from `torch::nn::Cloneable`.