### PR TITLE
Install CUDA for clang-tidy

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -197,7 +197,7 @@ jobs:
           sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/7fa2af80.pub
           sudo add-apt-repository "deb http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/ /"
           sudo apt-get update
-          sudo apt-get -y install --no-optional cuda
+          sudo apt-get --no-install-recommends -y install cuda
           # Install dependencies
           pip install pyyaml
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -218,11 +218,8 @@ jobs:
           if [[ ! -d build ]]; then
             git submodule update --init --recursive
 
-            mkdir build
-            pushd build
             # We really only need compile_commands.json, so no need to build!
             time python setup.py --cmake-only
-            popd
 
             # Generate ATen files.
             time python aten/src/ATen/gen.py \

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -191,6 +191,13 @@ jobs:
       - name: Install dependencies
         run: |
           set -eux
+          # Install CUDA
+          wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/cuda-ubuntu1804.pin
+          sudo mv cuda-ubuntu1804.pin /etc/apt/preferences.d/cuda-repository-pin-600
+          sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/7fa2af80.pub
+          sudo add-apt-repository "deb http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/ /"
+          sudo apt-get update
+          sudo apt-get -y install cuda
           # Install dependencies
           pip install pyyaml
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -217,6 +217,7 @@ jobs:
 
           if [[ ! -d build ]]; then
             git submodule update --init --recursive
+
             mkdir build
             pushd build
             # We really only need compile_commands.json, so no need to build!

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -220,7 +220,7 @@ jobs:
             mkdir build
             pushd build
             # We really only need compile_commands.json, so no need to build!
-            time USE_NCCL=0 cmake ..
+            time python setup.py --cmake-only
             popd
 
             # Generate ATen files.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -217,7 +217,7 @@ jobs:
 
           if [[ ! -d build ]]; then
             git submodule update --init --recursive
-
+            export USE_NCCL=0
             mkdir build
             pushd build
             # We really only need compile_commands.json, so no need to build!

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -219,7 +219,7 @@ jobs:
             git submodule update --init --recursive
 
             # We really only need compile_commands.json, so no need to build!
-            time python setup.py --cmake-only
+            time python setup.py --cmake-only build
 
             # Generate ATen files.
             time python aten/src/ATen/gen.py \

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -218,6 +218,7 @@ jobs:
           if [[ ! -d build ]]; then
             git submodule update --init --recursive
 
+            export USE_NCCL=0
             # We really only need compile_commands.json, so no need to build!
             time python setup.py --cmake-only build
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -197,7 +197,7 @@ jobs:
           sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/7fa2af80.pub
           sudo add-apt-repository "deb http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/ /"
           sudo apt-get update
-          sudo apt-get -y install cuda
+          sudo apt-get --no-optional -y install cuda
           # Install dependencies
           pip install pyyaml
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -197,7 +197,7 @@ jobs:
           sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/7fa2af80.pub
           sudo add-apt-repository "deb http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/ /"
           sudo apt-get update
-          sudo apt-get -y install--no-optional cuda
+          sudo apt-get -y install --no-optional cuda
           # Install dependencies
           pip install pyyaml
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -197,7 +197,7 @@ jobs:
           sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/7fa2af80.pub
           sudo add-apt-repository "deb http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/ /"
           sudo apt-get update
-          sudo apt-get --no-optional -y install cuda
+          sudo apt-get -y install--no-optional cuda
           # Install dependencies
           pip install pyyaml
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -217,11 +217,10 @@ jobs:
 
           if [[ ! -d build ]]; then
             git submodule update --init --recursive
-            export USE_NCCL=0
             mkdir build
             pushd build
             # We really only need compile_commands.json, so no need to build!
-            time cmake ..
+            time USE_NCCL=0 cmake ..
             popd
 
             # Generate ATen files.

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -1,5 +1,3 @@
-#include <torch/csrc/python_headers.h>
-
 #include <array>
 #include <unordered_map>
 #include <thread>
@@ -19,11 +17,10 @@
 #include <torch/csrc/CudaIPCTypes.h>
 #include <torch/csrc/utils/pybind.h>
 #include <torch/csrc/utils/cuda_lazy_init.h>
-#include <torch/csrc/autograd/generated/VariableType.h>
 #include <torch/csrc/utils/python_strings.h>
 #include <torch/csrc/cuda/python_comm.h>
-#include <torch/csrc/autograd/generated/variable_factories.h>
 #include <torch/csrc/Generator.h>
+#include <torch/csrc/python_headers.h>
 
 using namespace torch;
 


### PR DESCRIPTION
fixes: https://github.com/pytorch/pytorch/issues/28009

clang-tidy is reporting `'cuda_runtime_api.h' file not found` when a PR modifying some file including this header.

Installation script take from official site:
https://developer.nvidia.com/cuda-downloads?target_os=Linux&target_arch=x86_64&target_distro=Ubuntu&target_version=1804&target_type=debnetwork