### PR TITLE
[WIP] clone() changed to clone(at::MemoryFormat::Contiguous) at Sorting.cpp

### DIFF
--- a/aten/src/ATen/native/Sorting.cpp
+++ b/aten/src/ATen/native/Sorting.cpp
@@ -120,7 +120,7 @@ static std::tuple<Tensor&, Tensor&> kthvalue_out_impl_cpu(
     indices.zero_();
     return std::forward_as_tuple(values, indices);
   }
-  auto tmp_values = self.clone();
+  auto tmp_values = self.clone(at::MemoryFormat::Contiguous);
   auto tmp_indices = at::empty(self.sizes(), self.options().dtype(kLong));
   AT_DISPATCH_ALL_TYPES(self.scalar_type(), "kthvalue_cpu", [&] {
     dim_apply(
@@ -290,9 +290,9 @@ Tensor median_cpu(const Tensor& self) {
 #endif
   TORCH_CHECK(self.numel() > 0, "median cannot be called with empty tensor");
   if (self.dim() == 0 && self.numel() == 1) {
-    return self.clone();
+    return self.clone(at::MemoryFormat::Contiguous);
   }
-  auto tmp_values = self.clone().view(-1);
+  auto tmp_values = self.clone(at::MemoryFormat::Contiguous).view(-1);
   auto result = at::empty({1}, self.options());
   AT_DISPATCH_ALL_TYPES(self.scalar_type(), "median", [&] {
     // note, quick_select is 0 based while kthvalue is not


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #28008 clone() changed to clone(at::MemoryFormat::Contiguous) at check_alias_annotation.cpp
* #28007 clone() changed to clone(at::MemoryFormat::Contiguous) at cloneable.h
* #28006 clone() changed to clone(at::MemoryFormat::Contiguous) at tensor.cpp
* #28005 clone() changed to clone(at::MemoryFormat::Contiguous) at accumulate_grad.cpp
* #28004 clone() changed to clone(at::MemoryFormat::Contiguous) at autograd.cpp
* #28003 clone() changed to clone(at::MemoryFormat::Contiguous) at ProcessGroupGloo.cpp
* #28002 clone() changed to clone(at::MemoryFormat::Contiguous) at lbfgs.cpp
* #28001 clone() changed to clone(at::MemoryFormat::Contiguous) at Functions.cpp
* #28000 clone() changed to clone(at::MemoryFormat::Contiguous) at test_misc.cpp
* #27999 clone() changed to clone(at::MemoryFormat::Contiguous) at optim.cpp
* #27998 clone() changed to clone(at::MemoryFormat::Contiguous) at nn_utils.cpp
* #27997 clone() changed to clone(at::MemoryFormat::Contiguous) at functional.cpp
* #27996 clone() changed to clone(at::MemoryFormat::Contiguous) at pow_test.cpp
* #27995 clone() changed to clone(at::MemoryFormat::Contiguous) at broadcast_test.cpp
* #27994 clone() changed to clone(at::MemoryFormat::Contiguous) at TensorFactories.cpp
* #27993 clone() changed to clone(at::MemoryFormat::Contiguous) at TensorShape.cpp
* #27992 clone() changed to clone(at::MemoryFormat::Contiguous) at Unique.cu
* #27991 clone() changed to clone(at::MemoryFormat::Contiguous) at SpectralOps.cu
* #27990 clone() changed to clone(at::MemoryFormat::Contiguous) at SortingKthValue.cu
* #27989 clone() changed to clone(at::MemoryFormat::Contiguous) at TensorTransformations.cpp
* **#27988 clone() changed to clone(at::MemoryFormat::Contiguous) at Sorting.cpp**
* #27987 clone() changed to clone(at::MemoryFormat::Contiguous) at SobolEngineOps.cpp
* #27986 clone() changed to clone(at::MemoryFormat::Contiguous) at LinearAlgebraUtils.h
* #27985 clone() changed to clone(at::MemoryFormat::Contiguous) at LinearAlgebra.cpp
* #27984 clone() changed to clone(at::MemoryFormat::Contiguous) at Indexing.cpp

