### PR TITLE
[WIP] clone() changed to clone(at::MemoryFormat::Contiguous) at nn_utils.cpp

### DIFF
--- a/test/cpp/api/nn_utils.cpp
+++ b/test/cpp/api/nn_utils.cpp
@@ -56,7 +56,7 @@ TEST_F(NNUtilsTest, ClipGradNorm) {
   for (auto norm_type : norm_types) {
     for (int i = 0; i < grads.size(); i++) {
       linear_layer->parameters()[i].grad() =
-          grads[i].clone().view_as(linear_layer->parameters()[i].data());
+          grads[i].clone(at::MemoryFormat::Contiguous).view_as(linear_layer->parameters()[i].data());
     }
     auto norm_before = compute_norm(norm_type);
     auto layer_params = linear_layer->parameters();
@@ -92,8 +92,8 @@ TEST_F(NNUtilsTest, ClipGradNorm) {
   auto p1 = torch::randn({10, 10});
   auto p2 = torch::randn({10, 10});
   auto g = torch::arange(1., 101).view({10, 10});
-  p1.grad() = g.clone();
-  p2.grad() = g.clone();
+  p1.grad() = g.clone(at::MemoryFormat::Contiguous);
+  p2.grad() = g.clone(at::MemoryFormat::Contiguous);
   for (const auto norm_type : norm_types) {
     utils::clip_grad_norm_(p1, max_norm, norm_type);
     std::vector<torch::Tensor> params = {p2};


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #28008 clone() changed to clone(at::MemoryFormat::Contiguous) at check_alias_annotation.cpp
* #28007 clone() changed to clone(at::MemoryFormat::Contiguous) at cloneable.h
* #28006 clone() changed to clone(at::MemoryFormat::Contiguous) at tensor.cpp
* #28005 clone() changed to clone(at::MemoryFormat::Contiguous) at accumulate_grad.cpp
* #28004 clone() changed to clone(at::MemoryFormat::Contiguous) at autograd.cpp
* #28003 clone() changed to clone(at::MemoryFormat::Contiguous) at ProcessGroupGloo.cpp
* #28002 clone() changed to clone(at::MemoryFormat::Contiguous) at lbfgs.cpp
* #28001 clone() changed to clone(at::MemoryFormat::Contiguous) at Functions.cpp
* #28000 clone() changed to clone(at::MemoryFormat::Contiguous) at test_misc.cpp
* #27999 clone() changed to clone(at::MemoryFormat::Contiguous) at optim.cpp
* **#27998 clone() changed to clone(at::MemoryFormat::Contiguous) at nn_utils.cpp**
* #27997 clone() changed to clone(at::MemoryFormat::Contiguous) at functional.cpp
* #27996 clone() changed to clone(at::MemoryFormat::Contiguous) at pow_test.cpp
* #27995 clone() changed to clone(at::MemoryFormat::Contiguous) at broadcast_test.cpp
* #27994 clone() changed to clone(at::MemoryFormat::Contiguous) at TensorFactories.cpp
* #27993 clone() changed to clone(at::MemoryFormat::Contiguous) at TensorShape.cpp
* #27992 clone() changed to clone(at::MemoryFormat::Contiguous) at Unique.cu
* #27991 clone() changed to clone(at::MemoryFormat::Contiguous) at SpectralOps.cu
* #27990 clone() changed to clone(at::MemoryFormat::Contiguous) at SortingKthValue.cu
* #27989 clone() changed to clone(at::MemoryFormat::Contiguous) at TensorTransformations.cpp
* #27988 clone() changed to clone(at::MemoryFormat::Contiguous) at Sorting.cpp
* #27987 clone() changed to clone(at::MemoryFormat::Contiguous) at SobolEngineOps.cpp
* #27986 clone() changed to clone(at::MemoryFormat::Contiguous) at LinearAlgebraUtils.h
* #27985 clone() changed to clone(at::MemoryFormat::Contiguous) at LinearAlgebra.cpp
* #27984 clone() changed to clone(at::MemoryFormat::Contiguous) at Indexing.cpp

