### PR TITLE
[WIP] clone() changed to clone(at::MemoryFormat::Contiguous) at optim.cpp

### DIFF
--- a/test/cpp/api/optim.cpp
+++ b/test/cpp/api/optim.cpp
@@ -298,7 +298,7 @@ TEST(OptimTest, ExternalVectorOfParameters) {
   std::vector<torch::Tensor> parameters = {
       torch::randn({2, 2}), torch::randn({3, 3}), torch::randn({4, 4})};
   std::vector<torch::Tensor> original_parameters = {
-      parameters[0].clone(), parameters[1].clone(), parameters[2].clone()};
+      parameters[0].clone(at::MemoryFormat::Contiguous), parameters[1].clone(at::MemoryFormat::Contiguous), parameters[2].clone(at::MemoryFormat::Contiguous)};
 
   // Set all gradients to one
   for (auto& parameter : parameters) {
@@ -318,7 +318,7 @@ TEST(OptimTest, AddParameter_LBFGS) {
   torch::manual_seed(0);
 
   std::vector<torch::Tensor> parameters = {torch::randn({5, 5})};
-  std::vector<torch::Tensor> original_parameters = {parameters[0].clone()};
+  std::vector<torch::Tensor> original_parameters = {parameters[0].clone(at::MemoryFormat::Contiguous)};
 
   // Set all gradients to one
   for (auto& parameter : parameters) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #28008 clone() changed to clone(at::MemoryFormat::Contiguous) at check_alias_annotation.cpp
* #28007 clone() changed to clone(at::MemoryFormat::Contiguous) at cloneable.h
* #28006 clone() changed to clone(at::MemoryFormat::Contiguous) at tensor.cpp
* #28005 clone() changed to clone(at::MemoryFormat::Contiguous) at accumulate_grad.cpp
* #28004 clone() changed to clone(at::MemoryFormat::Contiguous) at autograd.cpp
* #28003 clone() changed to clone(at::MemoryFormat::Contiguous) at ProcessGroupGloo.cpp
* #28002 clone() changed to clone(at::MemoryFormat::Contiguous) at lbfgs.cpp
* #28001 clone() changed to clone(at::MemoryFormat::Contiguous) at Functions.cpp
* #28000 clone() changed to clone(at::MemoryFormat::Contiguous) at test_misc.cpp
* **#27999 clone() changed to clone(at::MemoryFormat::Contiguous) at optim.cpp**
* #27998 clone() changed to clone(at::MemoryFormat::Contiguous) at nn_utils.cpp
* #27997 clone() changed to clone(at::MemoryFormat::Contiguous) at functional.cpp
* #27996 clone() changed to clone(at::MemoryFormat::Contiguous) at pow_test.cpp
* #27995 clone() changed to clone(at::MemoryFormat::Contiguous) at broadcast_test.cpp
* #27994 clone() changed to clone(at::MemoryFormat::Contiguous) at TensorFactories.cpp
* #27993 clone() changed to clone(at::MemoryFormat::Contiguous) at TensorShape.cpp
* #27992 clone() changed to clone(at::MemoryFormat::Contiguous) at Unique.cu
* #27991 clone() changed to clone(at::MemoryFormat::Contiguous) at SpectralOps.cu
* #27990 clone() changed to clone(at::MemoryFormat::Contiguous) at SortingKthValue.cu
* #27989 clone() changed to clone(at::MemoryFormat::Contiguous) at TensorTransformations.cpp
* #27988 clone() changed to clone(at::MemoryFormat::Contiguous) at Sorting.cpp
* #27987 clone() changed to clone(at::MemoryFormat::Contiguous) at SobolEngineOps.cpp
* #27986 clone() changed to clone(at::MemoryFormat::Contiguous) at LinearAlgebraUtils.h
* #27985 clone() changed to clone(at::MemoryFormat::Contiguous) at LinearAlgebra.cpp
* #27984 clone() changed to clone(at::MemoryFormat::Contiguous) at Indexing.cpp

