### PR TITLE
[WIP] clone() changed to clone(at::MemoryFormat::Contiguous) at autograd.cpp

### DIFF
--- a/test/cpp/api/autograd.cpp
+++ b/test/cpp/api/autograd.cpp
@@ -236,7 +236,7 @@ TEST(CustomAutogradTest, MarkNonDifferentiableMixed) {
 TEST(CustomAutogradTest, MarkNonDifferentiableNone) {
   struct MyFunction : public Function<MyFunction> {
     static Variable forward(AutogradContext *ctx, Variable input) {
-      auto output = input.clone();
+      auto output = input.clone(at::MemoryFormat::Contiguous);
       ctx->mark_non_differentiable({output});
       return output;
     }
@@ -292,7 +292,7 @@ TEST(CustomAutogradTest, ReturnDuplicateInplace) {
   ASSERT_THROWS_WITH(DoubleInplace::apply(x), "leaf Variable that requires grad");
   // TODO ASSERT_THROWS_WITH(DoubleInplace::apply(x.clone()[0]), "only one output");
 
-  auto out = DoubleInplace::apply(x.clone());
+  auto out = DoubleInplace::apply(x.clone(at::MemoryFormat::Contiguous));
   ASSERT_TRUE(torch::equal(out[0],out[1]));
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #28008 clone() changed to clone(at::MemoryFormat::Contiguous) at check_alias_annotation.cpp
* #28007 clone() changed to clone(at::MemoryFormat::Contiguous) at cloneable.h
* #28006 clone() changed to clone(at::MemoryFormat::Contiguous) at tensor.cpp
* #28005 clone() changed to clone(at::MemoryFormat::Contiguous) at accumulate_grad.cpp
* **#28004 clone() changed to clone(at::MemoryFormat::Contiguous) at autograd.cpp**
* #28003 clone() changed to clone(at::MemoryFormat::Contiguous) at ProcessGroupGloo.cpp
* #28002 clone() changed to clone(at::MemoryFormat::Contiguous) at lbfgs.cpp
* #28001 clone() changed to clone(at::MemoryFormat::Contiguous) at Functions.cpp
* #28000 clone() changed to clone(at::MemoryFormat::Contiguous) at test_misc.cpp
* #27999 clone() changed to clone(at::MemoryFormat::Contiguous) at optim.cpp
* #27998 clone() changed to clone(at::MemoryFormat::Contiguous) at nn_utils.cpp
* #27997 clone() changed to clone(at::MemoryFormat::Contiguous) at functional.cpp
* #27996 clone() changed to clone(at::MemoryFormat::Contiguous) at pow_test.cpp
* #27995 clone() changed to clone(at::MemoryFormat::Contiguous) at broadcast_test.cpp
* #27994 clone() changed to clone(at::MemoryFormat::Contiguous) at TensorFactories.cpp
* #27993 clone() changed to clone(at::MemoryFormat::Contiguous) at TensorShape.cpp
* #27992 clone() changed to clone(at::MemoryFormat::Contiguous) at Unique.cu
* #27991 clone() changed to clone(at::MemoryFormat::Contiguous) at SpectralOps.cu
* #27990 clone() changed to clone(at::MemoryFormat::Contiguous) at SortingKthValue.cu
* #27989 clone() changed to clone(at::MemoryFormat::Contiguous) at TensorTransformations.cpp
* #27988 clone() changed to clone(at::MemoryFormat::Contiguous) at Sorting.cpp
* #27987 clone() changed to clone(at::MemoryFormat::Contiguous) at SobolEngineOps.cpp
* #27986 clone() changed to clone(at::MemoryFormat::Contiguous) at LinearAlgebraUtils.h
* #27985 clone() changed to clone(at::MemoryFormat::Contiguous) at LinearAlgebra.cpp
* #27984 clone() changed to clone(at::MemoryFormat::Contiguous) at Indexing.cpp

