### PR TITLE
[WIP] clone() changed to clone(at::MemoryFormat::Contiguous) at accumulate_grad.cpp

### DIFF
--- a/torch/csrc/autograd/functions/accumulate_grad.cpp
+++ b/torch/csrc/autograd/functions/accumulate_grad.cpp
@@ -54,7 +54,7 @@ auto AccumulateGrad::apply(variable_list&& grads) -> variable_list {
       // addition of !post_hooks().empty().
       variable.grad() = new_grad.detach();
     } else {
-      variable.grad() = new_grad.clone();
+      variable.grad() = new_grad.clone(at::MemoryFormat::Contiguous);
     }
   } else if (!GradMode::is_enabled()) {
     // This case is not strictly necessary, but it makes the first-order only case


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #28008 clone() changed to clone(at::MemoryFormat::Contiguous) at check_alias_annotation.cpp
* #28007 clone() changed to clone(at::MemoryFormat::Contiguous) at cloneable.h
* #28006 clone() changed to clone(at::MemoryFormat::Contiguous) at tensor.cpp
* **#28005 clone() changed to clone(at::MemoryFormat::Contiguous) at accumulate_grad.cpp**
* #28004 clone() changed to clone(at::MemoryFormat::Contiguous) at autograd.cpp
* #28003 clone() changed to clone(at::MemoryFormat::Contiguous) at ProcessGroupGloo.cpp
* #28002 clone() changed to clone(at::MemoryFormat::Contiguous) at lbfgs.cpp
* #28001 clone() changed to clone(at::MemoryFormat::Contiguous) at Functions.cpp
* #28000 clone() changed to clone(at::MemoryFormat::Contiguous) at test_misc.cpp
* #27999 clone() changed to clone(at::MemoryFormat::Contiguous) at optim.cpp
* #27998 clone() changed to clone(at::MemoryFormat::Contiguous) at nn_utils.cpp
* #27997 clone() changed to clone(at::MemoryFormat::Contiguous) at functional.cpp
* #27996 clone() changed to clone(at::MemoryFormat::Contiguous) at pow_test.cpp
* #27995 clone() changed to clone(at::MemoryFormat::Contiguous) at broadcast_test.cpp
* #27994 clone() changed to clone(at::MemoryFormat::Contiguous) at TensorFactories.cpp
* #27993 clone() changed to clone(at::MemoryFormat::Contiguous) at TensorShape.cpp
* #27992 clone() changed to clone(at::MemoryFormat::Contiguous) at Unique.cu
* #27991 clone() changed to clone(at::MemoryFormat::Contiguous) at SpectralOps.cu
* #27990 clone() changed to clone(at::MemoryFormat::Contiguous) at SortingKthValue.cu
* #27989 clone() changed to clone(at::MemoryFormat::Contiguous) at TensorTransformations.cpp
* #27988 clone() changed to clone(at::MemoryFormat::Contiguous) at Sorting.cpp
* #27987 clone() changed to clone(at::MemoryFormat::Contiguous) at SobolEngineOps.cpp
* #27986 clone() changed to clone(at::MemoryFormat::Contiguous) at LinearAlgebraUtils.h
* #27985 clone() changed to clone(at::MemoryFormat::Contiguous) at LinearAlgebra.cpp
* #27984 clone() changed to clone(at::MemoryFormat::Contiguous) at Indexing.cpp

