### PR TITLE
Defer pg agent listener thread until contexts are initialized

### DIFF
--- a/test/rpc_test.py
+++ b/test/rpc_test.py
@@ -27,7 +27,7 @@ def requires_process_group_agent(message=""):
 VALUE_FUTURE = concurrent.futures.Future()
 
 
-def stub_init_rpc_backend_handler(self_rank, self_name, init_method):
+def stub_start_rpc_backend_handler(self_rank, self_name, init_method):
     return mock.Mock()  # RpcAgent.
 
 
@@ -225,13 +225,13 @@ class RpcTest(object):
             rpc.rpc_sync(self_worker_name, torch.add, args=(torch.ones(2, 2), 1))
 
     @mock.patch.object(torch.distributed.autograd, "_init")
-    @mock.patch.object(torch.distributed.rpc.api, "_init_rpc_agent")
-    def test_register_rpc_backend_and_init_rpc_backend(
+    @mock.patch.object(torch.distributed.rpc.api, "_start_rpc_agent")
+    def test_register_rpc_backend_and_start_rpc_backend(
         self, mock_rpc_agent, mock_dist_autograd_init
     ):
         backend_name = "stub_backend"
         rpc.register_backend(
-            backend_name, stub_init_rpc_backend_handler
+            backend_name, stub_start_rpc_backend_handler
         )
         rpc.init_model_parallel(self_name="worker1", backend=backend_name, self_rank=1)
 

--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -103,7 +103,8 @@ PyObject* rpc_init(PyObject* /* unused */) {
           &ProcessGroupAgent::sync,
           py::call_guard<py::gil_scoped_release>());
 
-  module.def("_init_rpc_agent", [](std::shared_ptr<RpcAgent> agent) {
+  module.def("_start_rpc_agent", [](std::shared_ptr<RpcAgent> agent) {
+    agent->start();
     RpcAgent::setDefaultRpcAgent(std::move(agent));
   });
 

--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -104,8 +104,8 @@ PyObject* rpc_init(PyObject* /* unused */) {
           py::call_guard<py::gil_scoped_release>());
 
   module.def("_start_rpc_agent", [](std::shared_ptr<RpcAgent> agent) {
+    RpcAgent::setDefaultRpcAgent(agent);
     agent->start();
-    RpcAgent::setDefaultRpcAgent(std::move(agent));
   });
 
   module.def("_destroy_rref_context", []() {

--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -103,7 +103,7 @@ PyObject* rpc_init(PyObject* /* unused */) {
           &ProcessGroupAgent::sync,
           py::call_guard<py::gil_scoped_release>());
 
-  module.def("_start_rpc_agent", [](std::shared_ptr<RpcAgent> agent) {
+  module.def("_start_rpc_agent", [](const std::shared_ptr<RpcAgent>& agent) {
     RpcAgent::setDefaultRpcAgent(agent);
     agent->start();
   });

--- a/torch/csrc/distributed/rpc/process_group_agent.cpp
+++ b/torch/csrc/distributed/rpc/process_group_agent.cpp
@@ -150,7 +150,6 @@ ProcessGroupAgent::ProcessGroupAgent(
 
   // construct PythonRpcHandler singleton here
   PythonRpcHandler::getInstance();
-  listenerThread_ = std::thread(&ProcessGroupAgent::listenLoop, this);
 }
 
 const WorkerInfo& ProcessGroupAgent::getWorkerInfo(
@@ -245,6 +244,10 @@ void ProcessGroupAgent::sync() {
     // trigger more messages to be sent, we need to wait for the thread pool
     // again.
   } while (hasPendingMessage());
+}
+
+void ProcessGroupAgent::start() {
+  listenerThread_ = std::thread(&ProcessGroupAgent::listenLoop, this);
 }
 
 std::shared_ptr<FutureMessage> ProcessGroupAgent::send(

--- a/torch/csrc/distributed/rpc/process_group_agent.h
+++ b/torch/csrc/distributed/rpc/process_group_agent.h
@@ -48,6 +48,8 @@ class ProcessGroupAgent : public RpcAgent {
 
   void sync() override;
 
+  void start() override;
+
  protected:
   // This method wraps the destination information and the message into a
   // SendWork object, and put the SendWork into a queue. Another thread will

--- a/torch/csrc/distributed/rpc/rpc_agent.h
+++ b/torch/csrc/distributed/rpc/rpc_agent.h
@@ -63,6 +63,9 @@ class TORCH_API RpcAgent {
   // ``RpcAgent`` base class makes no assumption on the thread-safeness of the
   // ``RequestCallback``. ``RpcAgent`` implementations need to make sure that
   // its threading model conform to ``RequestCallback``'s requirement.
+  // NB: RpcAgent implementations should not start serving requests until
+  // ``start()`` is called, as there could be other contexts that have not been
+  // initialized yet at this time.
   RpcAgent(WorkerInfo id, std::unique_ptr<RequestCallback> cb);
 
   virtual ~RpcAgent();
@@ -97,6 +100,9 @@ class TORCH_API RpcAgent {
   // Synchronize the this process with other ``RpcAgent`` processes. Block until
   // all ``RpcAgent``s reach this method and send all pending messages.
   virtual void sync() = 0;
+
+  // start accepting requests
+  virtual void start() {}
 
   // Set the default rpc agent.
   static void setDefaultRpcAgent(std::shared_ptr<RpcAgent> defaultRpcAgent);

--- a/torch/distributed/rpc/api.py
+++ b/torch/distributed/rpc/api.py
@@ -1,6 +1,6 @@
 from torch.distributed import invoke_rpc_builtin, invoke_rpc_python_udf
 from torch.distributed import invoke_remote_builtin, invoke_remote_python_udf
-from torch.distributed import _init_rpc_agent
+from torch.distributed import _start_rpc_agent
 from torch.distributed import _destroy_rref_context
 from torch.distributed import ProcessGroupAgent
 from torch.distributed import WorkerInfo
@@ -87,7 +87,7 @@ def _init_rpc(backend=RpcBackend.PROCESS_GROUP,
         )
     else:
         raise RuntimeError("Unrecognized RPC backend ", backend)
-    _init_rpc_agent(_agent)
+    _start_rpc_agent(_agent)
 
 
 @_require_initialized


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #28030 Minor improvements in RPC api docs
* **#28013 Defer pg agent listener thread until contexts are initialized**

ProcessGroupAgent currently kicks off the listener thread in its
constructor. However, serving requests requires contexts to be
initialized, e.g., RRefContext and agent_ global var in api.py,
which might not be done yet when the first request arrives.
ProcessGroupAgent does not know what would be the appropriate time
to start the listener thread, hence exposing an API for higher
layer code to explicitly start listeners.

Differential Revision: [D17932271](https://our.internmc.facebook.com/intern/diff/D17932271)