### PR TITLE
accept -1 in iterations and warmup iterations

### DIFF
--- a/benchmarks/operator_benchmark/benchmark_core.py
+++ b/benchmarks/operator_benchmark/benchmark_core.py
@@ -73,7 +73,10 @@ class BenchmarkRunner(object):
         self.use_jit = args.use_jit
         self.num_runs = args.num_runs
         self.print_per_iter = False
-        if self.args.iterations:
+        # 100 is the default warmup iterations 
+        if self.args.warmup_iterations == -1: 
+            self.args.warmup_iterations = 100
+        if self.args.iterations and self.args.iterations != -1:
             self.has_explicit_iteration_count = True
             self.iters = self.args.iterations
         # when a specific test is selected by a user, we don't need


### PR DESCRIPTION
Summary: as title

Test Plan:
```
buck run caffe2/benchmarks/operator_benchmark/pt:add_test -- --iterations -1 --warmup_iterations -1

# ----------------------------------------
# PyTorch/Caffe2 Operator Micro-benchmarks
# ----------------------------------------
# Tag : short

# Benchmarking PyTorch: add
# Mode: Eager
# Name: add_M64_N64_K64_cpu
# Input: M: 64, N: 64, K: 64, device: cpu
Forward Execution Time (us) : 30827.046
...

Reviewed By: hl475

Differential Revision: D17932071

