### PR TITLE
[wip] Remove preallocation of type ids

### DIFF
--- a/c10/util/typeid.cpp
+++ b/c10/util/typeid.cpp
@@ -67,7 +67,24 @@ CAFFE_KNOWN_TYPE(bool*)
 CAFFE_KNOWN_TYPE(char*)
 CAFFE_KNOWN_TYPE(int*)
 
-// see typeid.h for details.
+// For some of the compilers, long is definied separately from int32_t and
+// int64_t. As a result we will need to actually define them separately.
+// It is recommended that one does NOT use long - use int32_t and int64_t
+// explicitly. Explicit long type annotation may go away in the future.
+// details: This hack works by defining a _guard_long_unique type, which is
+// long iff the compiler has a separate long type and is a dummy type otherwise.
+// we then allocate a type id to that _guard_long_unique. If the compiler has a
+// separate long type, this allocates a type id for long. Otherwise, it
+// allocates a type id for the dummy type, which doesn't matter.
+namespace detail {
+template <class T>
+class _guard_long_unique_dummy final {};
+template <class T>
+using _guard_long_unique = c10::guts::conditional_t<
+    std::is_same<long, int32_t>::value || std::is_same<long, int64_t>::value,
+    _guard_long_unique_dummy<T>,
+    T>;
+} // namespace detail
 CAFFE_KNOWN_TYPE(detail::_guard_long_unique<long>);
 CAFFE_KNOWN_TYPE(detail::_guard_long_unique<std::vector<long>>)
 

--- a/c10/util/typeid.h
+++ b/c10/util/typeid.h
@@ -80,8 +80,7 @@ class C10_API TypeIdentifier final
   }
 
   static constexpr TypeIdentifier uninitialized() {
-    return TypeIdentifier(
-        c10::util::type_index{11}); // 11 is Undefined from ScalarType
+    return TypeIdentifier(c10::util::type_index{0});
   }
 
  private:
@@ -538,73 +537,5 @@ inline std::ostream& operator<<(
   }
 #define CAFFE_KNOWN_TYPE(T) \
   _CAFFE_KNOWN_TYPE_DEFINE_TYPEMETADATA_INSTANCE(T, __COUNTER__)
-
-/**
- * CAFFE_DECLARE_PREALLOCATED_KNOWN_TYPE is used
- * to preallocate numbers so they line up exactly
- * with at::ScalarType's numbering.  All other numbers do not matter.
- * Please use CAFFE_KNOWN_TYPE instead for your own types.
- */
-#define CAFFE_DECLARE_PREALLOCATED_KNOWN_TYPE(PreallocatedId, T)      \
-  template <>                                                         \
-  constexpr inline TypeIdentifier TypeIdentifier::Get<T>() noexcept { \
-    return TypeIdentifier(c10::util::type_index{PreallocatedId});     \
-  }
-
-CAFFE_DECLARE_PREALLOCATED_KNOWN_TYPE(0, uint8_t)
-CAFFE_DECLARE_PREALLOCATED_KNOWN_TYPE(1, int8_t)
-CAFFE_DECLARE_PREALLOCATED_KNOWN_TYPE(2, int16_t)
-CAFFE_DECLARE_PREALLOCATED_KNOWN_TYPE(3, int)
-CAFFE_DECLARE_PREALLOCATED_KNOWN_TYPE(4, int64_t)
-CAFFE_DECLARE_PREALLOCATED_KNOWN_TYPE(5, at::Half)
-CAFFE_DECLARE_PREALLOCATED_KNOWN_TYPE(6, float)
-CAFFE_DECLARE_PREALLOCATED_KNOWN_TYPE(7, double)
-CAFFE_DECLARE_PREALLOCATED_KNOWN_TYPE(8, at::ComplexHalf)
-CAFFE_DECLARE_PREALLOCATED_KNOWN_TYPE(9, std::complex<float>)
-CAFFE_DECLARE_PREALLOCATED_KNOWN_TYPE(10, std::complex<double>)
-// 11 = undefined type id
-// 12 = Tensor (defined in tensor.h)
-CAFFE_DECLARE_PREALLOCATED_KNOWN_TYPE(13, std::string)
-CAFFE_DECLARE_PREALLOCATED_KNOWN_TYPE(14, bool)
-CAFFE_DECLARE_PREALLOCATED_KNOWN_TYPE(15, uint16_t)
-CAFFE_DECLARE_PREALLOCATED_KNOWN_TYPE(16, char)
-CAFFE_DECLARE_PREALLOCATED_KNOWN_TYPE(17, std::unique_ptr<std::mutex>)
-CAFFE_DECLARE_PREALLOCATED_KNOWN_TYPE(18, std::unique_ptr<std::atomic<bool>>)
-CAFFE_DECLARE_PREALLOCATED_KNOWN_TYPE(19, std::vector<int32_t>)
-CAFFE_DECLARE_PREALLOCATED_KNOWN_TYPE(20, std::vector<int64_t>)
-CAFFE_DECLARE_PREALLOCATED_KNOWN_TYPE(21, std::vector<unsigned long>)
-CAFFE_DECLARE_PREALLOCATED_KNOWN_TYPE(22, bool*)
-CAFFE_DECLARE_PREALLOCATED_KNOWN_TYPE(23, char*)
-CAFFE_DECLARE_PREALLOCATED_KNOWN_TYPE(24, int*)
-
-// For some of the compilers, long is definied separately from int32_t and
-// int64_t. As a result we will need to actually define them separately.
-// It is recommended that one does NOT use long - use int32_t and int64_t
-// explicitly. Explicit long type annotation may go away in the future.
-// details: This hack works by defining a _guard_long_unique type, which is
-// long iff the compiler has a separate long type and is a dummy type otherwise.
-// we then allocate a type id to that _guard_long_unique. If the compiler has a
-// separate long type, this allocates a type id for long. Otherwise, it
-// allocates a type id for the dummy type, which doesn't matter.
-namespace detail {
-template <class T>
-class _guard_long_unique_dummy final {};
-template <class T>
-using _guard_long_unique = c10::guts::conditional_t<
-    std::is_same<long, int32_t>::value || std::is_same<long, int64_t>::value,
-    _guard_long_unique_dummy<T>,
-    T>;
-} // namespace detail
-CAFFE_DECLARE_PREALLOCATED_KNOWN_TYPE(25, detail::_guard_long_unique<long>)
-CAFFE_DECLARE_PREALLOCATED_KNOWN_TYPE(
-    26,
-    detail::_guard_long_unique<std::vector<long>>)
-
-CAFFE_DECLARE_PREALLOCATED_KNOWN_TYPE(27, float*)
-CAFFE_DECLARE_PREALLOCATED_KNOWN_TYPE(28, at::Half*)
-CAFFE_DECLARE_PREALLOCATED_KNOWN_TYPE(29, c10::qint8)
-CAFFE_DECLARE_PREALLOCATED_KNOWN_TYPE(30, c10::quint8)
-CAFFE_DECLARE_PREALLOCATED_KNOWN_TYPE(31, c10::qint32)
-CAFFE_DECLARE_PREALLOCATED_KNOWN_TYPE(32, at::BFloat16)
 
 } // namespace caffe2

--- a/caffe2/core/tensor.h
+++ b/caffe2/core/tensor.h
@@ -611,8 +611,6 @@ CAFFE2_API void ReinitializeAndCopyFrom(
     const Tensor& src,
     bool async = false);
 
-CAFFE_DECLARE_PREALLOCATED_KNOWN_TYPE(12, Tensor)
-
 using TensorCPU = Tensor;
 
 constexpr int k_limit_default_ = 1000;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #26628 [wip] Remove CAFFE_KNOWN_TYPE
* #26619 [wip] caffe2::TypeMeta uses compile time type names
* #26618 [wip] Compile time type names
* #26616 c10::string_view
* **#28021 [wip] Remove preallocation of type ids**
* #28020 [wip] Constexpr type ids
* #28018 Update GCC for centos CI builds

We preallocated type ids to align them with ScalarType. At that point, the maximum type id was 10 and we used 11 to specify undefined type id.
However, since then, ScalarType got more additions, 11 isn't undefined anymore, and numbers 11-15 have meaning.
caffe2::TypeIdentifier also got its separate additions, 12 and upwards have meaning that differs from ScalarType.

I'm going with the (CI-tested) assumption that caffe2::TypeIdentifier and ScalarType actually don't need to be aligned
and remove the functionality for preallocated type ids. This simplifies our type ids.

Differential Revision: [D17935737](https://our.internmc.facebook.com/intern/diff/D17935737/)