### PR TITLE
Update hyperlink syntax for XLA, torchaudio, torchtext, and C++

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -16,7 +16,7 @@ PyTorch is an optimized tensor library for deep learning using GPUs and CPUs.
    :caption: Notes
 
    notes/*
-   * `PyTorch on XLA Devices <http://pytorch.org/xla/>`_
+   PyTorch on XLA Devices <http://pytorch.org/xla/>
 
 .. toctree::
   :glob:
@@ -65,26 +65,26 @@ PyTorch is an optimized tensor library for deep learning using GPUs and CPUs.
    :caption: torchvision Reference
 
    torchvision/index
-   
+
 .. toctree::
    :maxdepth: 1
    :caption: torchaudio Reference
-   
-   * `torchaudio <https://pytorch.org/audio>`_
+
+   torchaudio <https://pytorch.org/audio>
 
 .. toctree::
    :maxdepth: 1
    :caption: torchtext Reference
 
-   * `torchtext <https://pytorch.org/text>`_
+   torchtext <https://pytorch.org/text>
 
 .. toctree::
    :maxdepth: 1
    :caption: Other Languages
 
-   * `C++ API <https://pytorch.org/cppdocs/>`_
+   C++ API <https://pytorch.org/cppdocs/>
    packages
-   
+
 Indices and tables
 ==================
 


### PR DESCRIPTION
Tested locally. Should render as such: 
![image](https://user-images.githubusercontent.com/8042156/66861798-88982e00-ef44-11e9-9fcb-2b85506775d8.png)
