### PR TITLE
fix docs for lr

### DIFF
--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -595,13 +595,9 @@ class CyclicLR(_LRScheduler):
     `step` should be called after a batch has been used for training.
 
     This class has three built-in policies, as put forth in the paper:
-
-    "triangular":
-        A basic triangular cycle w/ no amplitude scaling.
-    "triangular2":
-        A basic triangular cycle that scales initial amplitude by half each cycle.
-    "exp_range":
-        A cycle that scales initial amplitude by gamma**(cycle iterations) at each
+    * "triangular": A basic triangular cycle w/ no amplitude scaling.
+    * "triangular2": A basic triangular cycle that scales initial amplitude by half each cycle.
+    * "exp_range": A cycle that scales initial amplitude by gamma**(cycle iterations) at each
         cycle iteration.
 
     This implementation was adapted from the github repo: `bckenstler/CLR`_
@@ -942,18 +938,10 @@ class OneCycleLR(_LRScheduler):
 
     This scheduler is not chainable.
 
-    This class has two built-in annealing strategies:
-
-    "cos":
-        Cosine annealing
-    "linear":
-        Linear annealing
-
     Note also that the total number of steps in the cycle can be determined in one
     of two ways (listed in order of precedence):
-
-    1) A value for total_steps is explicitly provided.
-    2) A number of epochs (epochs) and a number of steps per epoch
+    1. A value for total_steps is explicitly provided.
+    2. A number of epochs (epochs) and a number of steps per epoch
        (steps_per_epoch) are provided.
        In this case, the number of total steps is inferred by
        total_steps = epochs * steps_per_epoch
@@ -981,7 +969,8 @@ class OneCycleLR(_LRScheduler):
             increasing the learning rate.
             Default: 0.3
         anneal_strategy (str): {'cos', 'linear'}
-            Specifies the annealing strategy.
+            Specifies the annealing strategy: "cos" for cosine annealing, "linear" for
+            linear annealing.
             Default: 'cos'
         cycle_momentum (bool): If ``True``, momentum is cycled inversely
             to learning rate between 'base_momentum' and 'max_momentum'.

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -595,7 +595,8 @@ class CyclicLR(_LRScheduler):
     `step` should be called after a batch has been used for training.
 
     This class has three built-in policies, as put forth in the paper:
-    * "triangular": A basic triangular cycle w/ no amplitude scaling.
+
+    * "triangular": A basic triangular cycle without amplitude scaling.
     * "triangular2": A basic triangular cycle that scales initial amplitude by half each cycle.
     * "exp_range": A cycle that scales initial amplitude by gamma**(cycle iterations) at each
         cycle iteration.
@@ -940,6 +941,7 @@ class OneCycleLR(_LRScheduler):
 
     Note also that the total number of steps in the cycle can be determined in one
     of two ways (listed in order of precedence):
+
     1. A value for total_steps is explicitly provided.
     2. A number of epochs (epochs) and a number of steps per epoch
        (steps_per_epoch) are provided.

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -584,7 +584,7 @@ class ReduceLROnPlateau(object):
 
 
 class CyclicLR(_LRScheduler):
-    """Sets the learning rate of each parameter group according to
+    r"""Sets the learning rate of each parameter group according to
     cyclical learning rate policy (CLR). The policy cycles the learning
     rate between two boundaries with a constant frequency, as detailed in
     the paper `Cyclical Learning Rates for Training Neural Networks`_.
@@ -598,8 +598,8 @@ class CyclicLR(_LRScheduler):
 
     * "triangular": A basic triangular cycle without amplitude scaling.
     * "triangular2": A basic triangular cycle that scales initial amplitude by half each cycle.
-    * "exp_range": A cycle that scales initial amplitude by gamma**(cycle iterations) at each
-        cycle iteration.
+    * "exp_range": A cycle that scales initial amplitude by :math:`\text{gamma}^{\text{cycle iterations}}`
+      at each cycle iteration.
 
     This implementation was adapted from the github repo: `bckenstler/CLR`_
 
@@ -942,8 +942,8 @@ class OneCycleLR(_LRScheduler):
     Note also that the total number of steps in the cycle can be determined in one
     of two ways (listed in order of precedence):
 
-    1. A value for total_steps is explicitly provided.
-    2. A number of epochs (epochs) and a number of steps per epoch
+    #. A value for total_steps is explicitly provided.
+    #. A number of epochs (epochs) and a number of steps per epoch
        (steps_per_epoch) are provided.
        In this case, the number of total steps is inferred by
        total_steps = epochs * steps_per_epoch


### PR DESCRIPTION
Documentation for learning rate does not render well. Fixes #27730.

Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#28026 fix docs for lr**

Differential Revision: [D17953395](https://our.internmc.facebook.com/intern/diff/D17953395)