### PR TITLE
Allow Tracing of convolution function #18776

### DIFF
--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -39,7 +39,7 @@ MANUAL_IMPLEMENTATIONS = {
 # on demand.  Only concrete ATen methods can be disabled this way; it will have
 # NO EFFECT otherwise.
 DONT_RECORD_TRACE = {
-    'convolution', 'conv1d', 'conv2d', 'conv3d', 'conv_transpose1d',
+    'conv1d', 'conv2d', 'conv3d', 'conv_transpose1d',
     'conv_transpose2d', 'conv_transpose3d', 'lstm_cell', 'gru_cell',
     'rnn_tanh_cell', 'rnn_relu_cell', 'linear',
     # FIXME: figure out a better way when we support sparse tensors in jit


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#28027 Allow Tracing of convolution function #18776**

Currently tracing convolution operations wraps to internal implementation
    _convolution function. As a result 'benchmark' and other flags are hard
    wired. Changes to these context flags at later stages are ignored.

    The proposed fix is to remove 'convolution' from DONT_RECORD_TRACE.
    Note all convolution operations end up calling convolution
    function so this fix applies to all convolution operations.

Differential Revision: [D17937072](https://our.internmc.facebook.com/intern/diff/D17937072)