### PR TITLE
Adding cuda-memcheck to CI

### DIFF
--- a/.circleci/cimodel/data/pytorch_build_data.py
+++ b/.circleci/cimodel/data/pytorch_build_data.py
@@ -43,7 +43,10 @@ CONFIG_TREE_DATA = [
             ]),
             ("9.2", [X("3.6")]),
             ("10", [X("3.6")]),
-            ("10.1", [X("3.6")]),
+            ("10.1", [
+                X("3.6"),
+                ("3.6", [("cuda_memcheck", [XImportant(True)])]),
+            ]),
         ]),
     ]),
 ]
@@ -114,6 +117,7 @@ class ExperimentalFeatureConfigNode(TreeConfigNode):
             "libtorch": LibTorchConfigNode,
             "important": ImportantConfigNode,
             "android_abi": AndroidAbiConfigNode,
+            "cuda_memcheck": CudaMemcheckConfigNode,
         }
         return next_nodes[experimental_feature]
 
@@ -124,6 +128,17 @@ class XlaConfigNode(TreeConfigNode):
 
     def init2(self, node_name):
         self.props["is_xla"] = node_name
+
+    def child_constructor(self):
+        return ImportantConfigNode
+
+
+class CudaMemcheckConfigNode(TreeConfigNode):
+    def modify_label(self, label):
+        return "CUDA_MEMCHECK=" + str(label)
+
+    def init2(self, node_name):
+        self.props["cuda_memcheck"] = node_name
 
     def child_constructor(self):
         return ImportantConfigNode

--- a/.circleci/cimodel/data/pytorch_build_definitions.py
+++ b/.circleci/cimodel/data/pytorch_build_definitions.py
@@ -33,6 +33,7 @@ class Conf:
     parent_build: Optional['Conf'] = None
     is_libtorch: bool = False
     is_important: bool = False
+    is_cuda_memcheck: bool = False
 
     # TODO: Eliminate the special casing for docker paths
     # In the short term, we *will* need to support special casing as docker images are merged for caffe2 and pytorch
@@ -45,6 +46,8 @@ class Conf:
         leading.append("pytorch")
         if self.is_xla and not for_docker:
             leading.append("xla")
+        if self.is_cuda_memcheck and not for_docker:
+            leading.append("cuda-memcheck")
         if self.is_libtorch and not for_docker:
             leading.append("libtorch")
 
@@ -224,6 +227,7 @@ def instantiate_configs():
 
         is_libtorch = fc.find_prop("is_libtorch") or False
         is_important = fc.find_prop("is_important") or False
+        is_cuda_memcheck = fc.find_prop("cuda_memcheck") or False
 
         gpu_resource = None
         if cuda_version and cuda_version != "10":
@@ -240,6 +244,7 @@ def instantiate_configs():
             gpu_resource,
             is_libtorch=is_libtorch,
             is_important=is_important,
+            is_cuda_memcheck=is_cuda_memcheck,
         )
 
         if cuda_version == "9" and python_version == "3.6" and not is_libtorch:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1828,6 +1828,21 @@ workflows:
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda10.1-cudnn7-py3-gcc7:347"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
+      - pytorch_linux_build:
+          name: pytorch_cuda_memcheck_linux_xenial_cuda10_1_cudnn7_py3_gcc7_build
+          requires:
+            - setup
+          build_environment: "pytorch-cuda-memcheck-linux-xenial-cuda10.1-cudnn7-py3-gcc7-build"
+          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda10.1-cudnn7-py3-gcc7:347"
+      - pytorch_linux_test:
+          name: pytorch_cuda_memcheck_linux_xenial_cuda10_1_cudnn7_py3_gcc7_test
+          requires:
+            - setup
+            - pytorch_cuda_memcheck_linux_xenial_cuda10_1_cudnn7_py3_gcc7_build
+          build_environment: "pytorch-cuda-memcheck-linux-xenial-cuda10.1-cudnn7-py3-gcc7-test"
+          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda10.1-cudnn7-py3-gcc7:347"
+          use_cuda_docker_runtime: "1"
+          resource_class: gpu.medium
       # Warning: indentation here matters!
 
       # Pytorch MacOS builds

--- a/.circleci/scripts/should_run_job.py
+++ b/.circleci/scripts/should_run_job.py
@@ -14,6 +14,8 @@ default_set = set([
     'pytorch-linux-xenial-py2.7.9',
     # PyTorch CUDA
     'pytorch-linux-xenial-cuda9-cudnn7-py3',
+    # PyTorch CUDA Memcheck
+    'pytorch-cuda-memcheck-linux-xenial-cuda10.1-cudnn7-py3-gcc7',
     # PyTorch ASAN
     'pytorch-linux-xenial-py3-clang5-asan',
     # PyTorch DEBUG

--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -114,6 +114,12 @@ test_python_all_except_nn() {
   assert_git_not_dirty
 }
 
+test_python_cuda_memcheck() {
+  export PYTORCH_TEST_WITH_CUDA_MEMCHECK=1
+  time python test/run_test.py --cuda-memcheck --include torch --verbose
+  assert_git_not_dirty
+}
+
 test_aten() {
   # Test ATen
   # The following test(s) of ATen have already been skipped by caffe2 in rocm environment:
@@ -230,6 +236,8 @@ elif [[ "${BUILD_ENVIRONMENT}" == *-test2 || "${JOB_BASE_NAME}" == *-test2 ]]; t
   test_aten
   test_libtorch
   test_custom_script_ops
+elif [[ "$BUILD_ENVIRONMENT" == *cuda-memcheck* ]]; then
+  test_python_cuda_memcheck
 else
   test_torchvision
   test_python_nn

--- a/test/common_device_type.py
+++ b/test/common_device_type.py
@@ -3,7 +3,7 @@ from functools import wraps
 import unittest
 import torch
 from common_utils import TestCase, TEST_WITH_ROCM, TEST_MKL, \
-    skipCUDANonDefaultStreamIf
+    TEST_WITH_CUDA_MEMCHECK, skipCUDANonDefaultStreamIf
 
 # Note: Generic Device-Type Testing
 #
@@ -219,6 +219,8 @@ class CUDATestBase(DeviceTypeTestBase):
 device_type_test_bases.append(CPUTestBase)
 if torch.cuda.is_available():
     device_type_test_bases.append(CUDATestBase)
+if TEST_WITH_CUDA_MEMCHECK:
+    device_type_test_bases = [CUDATestBase]
 
 
 # Adds 'instantiated' device-specific test cases to the given scope.

--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -183,6 +183,7 @@ TEST_WITH_ASAN = os.getenv('PYTORCH_TEST_WITH_ASAN', '0') == '1'
 TEST_WITH_TSAN = os.getenv('PYTORCH_TEST_WITH_TSAN', '0') == '1'
 TEST_WITH_UBSAN = os.getenv('PYTORCH_TEST_WITH_UBSAN', '0') == '1'
 TEST_WITH_ROCM = os.getenv('PYTORCH_TEST_WITH_ROCM', '0') == '1'
+TEST_WITH_CUDA_MEMCHECK = os.getenv('PYTORCH_TEST_WITH_CUDA_MEMCHECK', '0') == '1'
 # Enables tests that are slow to run (disabled by default)
 TEST_WITH_SLOW = os.getenv('PYTORCH_TEST_WITH_SLOW', '0') == '1'
 

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -314,6 +314,10 @@ def parse_args():
         action='store_true',
         help='always run blacklisted windows tests')
     parser.add_argument(
+        '--cuda-memcheck',
+        action='store_true',
+        help='Run cuda-memcheck')
+    parser.add_argument(
         'additional_unittest_args',
         nargs='*',
         help='additional arguments passed through to unittest, e.g., '
@@ -324,6 +328,8 @@ def parse_args():
 def get_executable_command(options):
     if options.coverage:
         executable = ['coverage', 'run', '--parallel-mode', '--source torch']
+    elif options.cuda_memcheck:
+        executable = ['cuda-memcheck', '--error-exitcode', '1', sys.executable]
     else:
         executable = [sys.executable]
     if options.pytest:

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -434,6 +434,9 @@ def main():
     if options.jit:
         selected_tests = filter(lambda test_name: "jit" in test_name, TESTS)
 
+    if options.cuda_memcheck:
+        os.environ["PYTORCH_TEST_WITH_CUDA_MEMCHECK"] = "1"
+
     for test in selected_tests:
         test_name = 'test_{}'.format(test)
         test_module = parse_test_module(test)


### PR DESCRIPTION
This adds cuda-memcheck to our CI. This new test is "important" (triggered on PR). Currently it is only enabled on `test_torch.py` and we might need to disable some tests depending on the outcome of the test.