### PR TITLE
Add scripts to run cuda-memcheck on unittests manually

### DIFF
--- a/test/common_device_type.py
+++ b/test/common_device_type.py
@@ -3,7 +3,7 @@ from functools import wraps
 import unittest
 import torch
 from common_utils import TestCase, TEST_WITH_ROCM, TEST_MKL, \
-    skipCUDANonDefaultStreamIf
+    TEST_WITH_CUDA_MEMCHECK, skipCUDANonDefaultStreamIf
 
 # Note: Generic Device-Type Testing
 #
@@ -219,6 +219,8 @@ class CUDATestBase(DeviceTypeTestBase):
 device_type_test_bases.append(CPUTestBase)
 if torch.cuda.is_available():
     device_type_test_bases.append(CUDATestBase)
+if TEST_WITH_CUDA_MEMCHECK:
+    device_type_test_bases = [CUDATestBase]
 
 
 # Adds 'instantiated' device-specific test cases to the given scope.

--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -183,6 +183,7 @@ TEST_WITH_ASAN = os.getenv('PYTORCH_TEST_WITH_ASAN', '0') == '1'
 TEST_WITH_TSAN = os.getenv('PYTORCH_TEST_WITH_TSAN', '0') == '1'
 TEST_WITH_UBSAN = os.getenv('PYTORCH_TEST_WITH_UBSAN', '0') == '1'
 TEST_WITH_ROCM = os.getenv('PYTORCH_TEST_WITH_ROCM', '0') == '1'
+TEST_WITH_CUDA_MEMCHECK = os.getenv('PYTORCH_TEST_WITH_CUDA_MEMCHECK', '0') == '1'
 # Enables tests that are slow to run (disabled by default)
 TEST_WITH_SLOW = os.getenv('PYTORCH_TEST_WITH_SLOW', '0') == '1'
 

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -314,6 +314,10 @@ def parse_args():
         action='store_true',
         help='always run blacklisted windows tests')
     parser.add_argument(
+        '--cuda-memcheck',
+        action='store_true',
+        help='Run cuda-memcheck')
+    parser.add_argument(
         'additional_unittest_args',
         nargs='*',
         help='additional arguments passed through to unittest, e.g., '
@@ -324,6 +328,8 @@ def parse_args():
 def get_executable_command(options):
     if options.coverage:
         executable = ['coverage', 'run', '--parallel-mode', '--source torch']
+    elif options.cuda_memcheck:
+        executable = ['cuda-memcheck', '--error-exitcode', '1', sys.executable]
     else:
         executable = [sys.executable]
     if options.pytest:
@@ -427,6 +433,9 @@ def main():
 
     if options.jit:
         selected_tests = filter(lambda test_name: "jit" in test_name, TESTS)
+
+    if options.cuda_memcheck:
+        os.environ["PYTORCH_TEST_WITH_CUDA_MEMCHECK"] = "1"
 
     for test in selected_tests:
         test_name = 'test_{}'.format(test)


### PR DESCRIPTION
With this script we could run tests one by one using something like:
```
python test/run_test.py -i torch --cuda-memcheck --verbose TestTorch.test_empty_like
```
to see errors/hangs