### PR TITLE
[pytorch] Buffer in Pickler to improve performance.

### DIFF
--- a/torch/csrc/jit/pickler.cpp
+++ b/torch/csrc/jit/pickler.cpp
@@ -14,6 +14,10 @@ using ::c10::IValue;
 // See https://docs.python.org/3/library/pickle.html#data-stream-format
 constexpr static uint8_t PROTOCOL_VERSION = 2;
 
+Pickler::~Pickler() {
+  flush();
+}
+
 const char* getClassName(PicklerClass cls) {
   switch (cls) {
     case PicklerClass::TENSOR:
@@ -48,6 +52,7 @@ void Pickler::endTuple() {
 
 void Pickler::stop() {
   push<PickleOpCode>(PickleOpCode::STOP);
+  flush();
 }
 
 // unmemoized version called by pushIValue
@@ -61,11 +66,7 @@ void Pickler::pushIValueImpl(const IValue& ivalue) {
   } else if (ivalue.isInt()) {
     pushInt(ivalue.toInt());
   } else if (ivalue.isBool()) {
-    if (ivalue.toBool()) {
-      push<PickleOpCode>(PickleOpCode::NEWTRUE);
-    } else {
-      push<PickleOpCode>(PickleOpCode::NEWFALSE);
-    }
+    pushBool(ivalue.toBool());
   } else if (ivalue.isString()) {
     pushString(ivalue.toStringRef());
   } else if (ivalue.isGenericList()) {
@@ -78,7 +79,7 @@ void Pickler::pushIValueImpl(const IValue& ivalue) {
     pushSpecializedList(
         ivalue, PicklerClass::INTLIST, [=](const IValue& ivalue) {
           for (const int64_t item : ivalue.toIntListRef()) {
-            pushIValue(item);
+            pushInt(item);
           }
         });
   } else if (ivalue.isTensorList()) {
@@ -92,14 +93,14 @@ void Pickler::pushIValueImpl(const IValue& ivalue) {
     pushSpecializedList(
         ivalue, PicklerClass::DOUBLELIST, [=](const IValue& ivalue) {
           for (double item : ivalue.toDoubleListRef()) {
-            pushIValue(item);
+            pushDouble(item);
           }
         });
   } else if (ivalue.isBoolList()) {
     pushSpecializedList(
         ivalue, PicklerClass::BOOLLIST, [=](const IValue& ivalue) {
           for (bool item : ivalue.toBoolList()) {
-            pushIValue(item);
+            pushBool(item);
           }
         });
   } else if (ivalue.isObject()) {
@@ -186,6 +187,10 @@ void Pickler::pushInt(int64_t n) {
   }
 }
 
+void Pickler::pushBool(bool value) {
+  push<PickleOpCode>(value ? PickleOpCode::NEWTRUE : PickleOpCode::NEWFALSE);
+}
+
 void Pickler::pushBinGet(uint32_t memo_id) {
   if (memo_id <= std::numeric_limits<uint8_t>::max()) {
     push<PickleOpCode>(PickleOpCode::BINGET);
@@ -250,7 +255,17 @@ void Pickler::pushStorageOfTensor(const at::Tensor& tensor) {
 }
 
 void Pickler::pushBytes(const std::string& string) {
-  writer_(string.data(), string.size());
+  static const size_t kSmallStr = 32;
+  if (string.size() <= kSmallStr &&
+      bufferPos_ + string.size() <= buffer_.size()) {
+    // Small string that fits: buffer the data.
+    memcpy(buffer_.data() + bufferPos_, string.data(), string.size());
+    bufferPos_ += string.size();
+  } else {
+    // Otherwise, first flush, then write directly.
+    flush();
+    writer_(string.data(), string.size());
+  }
 }
 
 void Pickler::pushGlobal(

--- a/torch/csrc/jit/pickler.h
+++ b/torch/csrc/jit/pickler.h
@@ -129,6 +129,7 @@ class Pickler {
       : writer_(writer),
         tensor_table_(tensor_table),
         memorized_class_types_(memorized_class_types) {}
+  ~Pickler();
 
   // Push protocol onto the stack
   void protocol();
@@ -152,6 +153,7 @@ class Pickler {
 
  private:
   void pushIValueImpl(const IValue& ivalue);
+  void pushBool(bool value);
   void pushDouble(double value);
   void pushGenericList(const IValue& ivalue);
   void pushIntList(const IValue& ivalue);
@@ -183,6 +185,19 @@ class Pickler {
 
   const void* getPointer(const IValue& ivalue);
 
+  // Caller checks that bufferPos_ > 0
+  void flushNonEmpty() {
+    writer_(buffer_.data(), bufferPos_);
+    bufferPos_ = 0;
+  }
+
+  void flush() {
+    if (bufferPos_ != 0) {
+      flushNonEmpty();
+    }
+  }
+
+  static constexpr size_t kBufSize = 256;
   // These convert values to bytes and add them to the stack (NB: since T is to
   // the left of a '::', its type cannot be deduced by the compiler so one must
   // explicitly instantiate the template, i.e. push<int>(int) works, push(int)
@@ -190,11 +205,21 @@ class Pickler {
   template <typename T>
   void push(typename std::common_type<T>::type value) {
     const char* begin = reinterpret_cast<const char*>(&value);
-    writer_(begin, sizeof(T));
+    if (bufferPos_ + sizeof(T) > buffer_.size()) {
+      flushNonEmpty();
+    }
+    static_assert(sizeof(T) < kBufSize, "Buffer overflow");
+    memcpy(buffer_.data() + bufferPos_, begin, sizeof(T));
+    bufferPos_ += sizeof(T);
   }
 
   // Stream to write binary data to
+  // Code shouldn't call writer_ directly without first flush()ing.
   std::function<void(const char*, size_t)> writer_;
+
+  // Buffer to avoid calling a writer_ on a per-byte basis.
+  std::array<char, kBufSize> buffer_;
+  size_t bufferPos_{0};
 
   // Stack of opcodes/data
   std::vector<char> stack_;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#28043 [pytorch] Double-buffer in Pickler to reduce #calls.**

This change adds a small fixed-size buffer to Pickler to
avoid calling writer_() and the associated downstream checks
on a per-opcode/per-byte basis.

We end up still doing a bounds check in the common case,
but the memcpy() is a fixed size. And we reduce the number
of backend calls.

In practice, this change speeds up the Pickle1MInts benchmark
for me locally from roughly 56msec to 22msec.

Additionally, in this change we convert a few pushIValue() on
typed lists, where we know the type to be double/int/boot to be
pushInt() to bypass a bit of logic.

We should additionally change the Unpickler, though keeping
this separate, since the std::function<> prototype needs to be
changed to do buffering (return value needs to change from bool
to size_t)

Differential Revision: [D17939311](https://our.internmc.facebook.com/intern/diff/D17939311/)