### PR TITLE
Update GCC for CentOS build

### DIFF
--- a/.jenkins/caffe2/build.sh
+++ b/.jenkins/caffe2/build.sh
@@ -4,12 +4,14 @@ set -ex
 
 source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 
-# TODO: Migrate all centos jobs to use proper devtoolset
-if [[ "$BUILD_ENVIRONMENT" == *py2-cuda9.0-cudnn7-centos7* ]]; then
-  # There is a bug in pango packge on Centos7 that causes undefined
-  # symbols, upgrading glib2 to >=2.56.1 solves the issue. See
-  # https://bugs.centos.org/view.php?id=15495
-  sudo yum install -y -q glib2-2.56.1
+if [[ "$BUILD_ENVIRONMENT" == *centos7* ]]; then
+  # CentOS has gcc 4 but we need a newer compiler. Upgrade it.
+  sudo yum install -y centos-release-scl
+  sudo yum install -y devtoolset-4\*
+  sudo yum install -y scl-utils
+
+  source scl_source enable devtoolset-4 || yes
+  gcc --version
 fi
 
 # CMAKE_ARGS are only passed to 'cmake' and the -Dfoo=bar does not work with


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #26628 [wip] Remove CAFFE_KNOWN_TYPE
* #26619 [wip] caffe2::TypeMeta uses compile time type names
* #26618 [wip] Compile time type names
* #26616 c10::string_view
* #28024 [wip] Remove preallocation of type ids
* #28023 [wip] Constexpr type ids
* **#28059 Update GCC for CentOS build**

Differential Revision: [D17945780](https://our.internmc.facebook.com/intern/diff/D17945780/)