### PR TITLE
Port of multi_margin_loss from TH to ATen (CPU)

### DIFF
--- a/aten/src/ATen/native/LossMultiMargin.cpp
+++ b/aten/src/ATen/native/LossMultiMargin.cpp
@@ -1,5 +1,6 @@
 #include <ATen/ATen.h>
 #include <ATen/Dispatch.h>
+#include <ATen/AccumulateType.h>
 
 namespace at {
 namespace native {
@@ -55,6 +56,8 @@ static inline void multi_margin_loss_cpu_kernel(
     const int64_t nframe,
     const int64_t dim,
     const int64_t reduction) {
+  using accscalar_t = at::acc_type<scalar_t, false>;
+
   // dim() != 0 check is for 1d input which produces a scalar output (that
   // cannot be handeld by TensorAccessor)
   if (reduction == Reduction::None && output.dim() > 0) {
@@ -67,7 +70,7 @@ static inline void multi_margin_loss_cpu_kernel(
       input_data += dim;
     }
   } else {
-    scalar_t sum = 0;
+    accscalar_t sum = 0;
     auto output_acc = output.data_ptr<scalar_t>();
     for (int64_t t = 0; t < nframe; t++) {
       const auto idx = target_index_checked(target_data, t, dim);

--- a/aten/src/ATen/native/LossMultiMargin.cpp
+++ b/aten/src/ATen/native/LossMultiMargin.cpp
@@ -1,0 +1,328 @@
+#include <ATen/ATen.h>
+#include <ATen/Dispatch.h>
+
+namespace at {
+namespace native {
+
+namespace {
+
+template <typename scalar_t>
+inline scalar_t multi_margin_inner_sum_cpu(
+    const scalar_t* input_data,
+    const scalar_t* weight_data,
+    const int p,
+    const scalar_t margin,
+    const int64_t dim,
+    const int64_t target_idx) {
+  const scalar_t input_target = input_data[target_idx];
+  scalar_t sum = 0;
+  for (int64_t d = 0; d < dim; d++) {
+    if (d == target_idx) {
+      continue;
+    }
+
+    const scalar_t z = margin - input_target + input_data[d];
+    if (z > 0) {
+      scalar_t h = (p == 1) ? z : z * z;
+      if (weight_data != nullptr) {
+        h *= weight_data[target_idx];
+      }
+      sum += h;
+    }
+  }
+
+  sum /= dim;
+  return sum;
+}
+
+template <typename scalar_t>
+static inline void multi_margin_loss_cpu_kernel(
+    scalar_t* output_data,
+    scalar_t* input_data,
+    int64_t* target_data,
+    const int p,
+    scalar_t margin,
+    scalar_t* weight_data,
+    const int64_t nframe,
+    const int64_t dim,
+    const int64_t reduction) {
+  if (reduction == Reduction::None) {
+    for (int64_t t = 0; t < nframe; t++) {
+      auto sum = multi_margin_inner_sum_cpu(
+          input_data, weight_data, p, margin, dim, target_data[t]);
+      output_data[t] = sum;
+      input_data += dim;
+    }
+  } else {
+    scalar_t sum = 0;
+    for (int64_t t = 0; t < nframe; t++) {
+      sum += multi_margin_inner_sum_cpu(
+          input_data, weight_data, p, margin, dim, target_data[t]);
+      input_data += dim;
+    }
+    if (reduction == Reduction::Mean) {
+      sum /= nframe;
+    }
+    output_data[0] = sum;
+  }
+}
+
+void multi_margin_loss_out_cpu_template(
+    Tensor& output,
+    const Tensor& input,
+    const Tensor& target,
+    int p,
+    Scalar margin,
+    const Tensor& weight,
+    int64_t reduction) {
+  const auto ndims = input.dim();
+  TORCH_CHECK(
+      input.numel() > 0 && ndims <= 2,
+      "non-empty vector or matrix expected, got size: ",
+      input.sizes());
+
+  TORCH_CHECK(p == 1 || p == 2, "only p == 1 and p == 2 supported");
+
+  int64_t nframe, dim;
+  if (ndims <= 1) {
+    nframe = 1;
+    dim = ndims == 0 ? 1 : input.size(0);
+  } else {
+    nframe = input.size(0);
+    dim = input.size(1);
+  }
+
+  TORCH_CHECK(
+      target.numel() > 0 && target.dim() <= 1 && target.numel() == nframe,
+      "inconsistent target size, got: ",
+      target.sizes());
+
+  if (target.dim() > 0) {
+    for (int64_t i = 0; i < nframe; i++) {
+      int64_t idx = target[i].item().toLong();
+      TORCH_CHECK(idx >= 0 && idx < dim, "target out of range");
+    }
+  } else {
+    int64_t idx = target.item().toLong();
+    TORCH_CHECK(idx >= 0 && idx < dim, "target out of range");
+  }
+
+  if (reduction == Reduction::None) {
+    output.resize_({nframe});
+  } else {
+    output = at::tensor(0, input.options());
+  }
+
+  auto input_contiguous = input.contiguous();
+  auto target_contiguous = target.contiguous();
+
+  AT_DISPATCH_FLOATING_TYPES(
+      input.scalar_type(), "multi_margin_loss_cpu_kernel", [&] {
+        auto output_data = output.data_ptr<scalar_t>();
+        auto input_data = input_contiguous.data_ptr<scalar_t>();
+        auto target_data = target_contiguous.data_ptr<int64_t>();
+        auto weight_data =
+            weight.defined() ? weight.data_ptr<scalar_t>() : nullptr;
+        multi_margin_loss_cpu_kernel<scalar_t>(
+            output_data,
+            input_data,
+            target_data,
+            p,
+            margin.to<scalar_t>(),
+            weight_data,
+            nframe,
+            dim,
+            reduction);
+      });
+}
+
+template <typename scalar_t>
+static void multi_margin_loss_backward_cpu_kernel(
+    scalar_t* grad_input_data,
+    const Tensor& grad_output,
+    scalar_t* input_data,
+    int64_t* target_data,
+    int p,
+    scalar_t margin,
+    scalar_t g,
+    scalar_t* weight_data,
+    int64_t nframe,
+    int64_t dim,
+    int64_t reduction) {
+  for (int64_t t = 0; t < nframe; t++) {
+    int64_t target_idx = target_data[t];
+    scalar_t input_target = input_data[target_idx];
+    scalar_t grad_input_target = 0;
+    for (int64_t d = 0; d < dim; d++) {
+      scalar_t z = margin - input_target + input_data[d];
+      if (d == target_idx) {
+        continue;
+      }
+
+      if (z > 0) {
+        scalar_t h = (p == 1) ? g : 2 * g * z;
+        if (weight_data != nullptr) {
+          h *= weight_data[target_idx];
+        }
+        grad_input_target -= h;
+        grad_input_data[d] = h;
+      } else {
+        grad_input_data[d] = 0;
+      }
+    }
+    grad_input_data[target_idx] = grad_input_target;
+
+    input_data += dim;
+    grad_input_data += dim;
+  }
+
+  if (reduction != Reduction::None) {
+    const auto d = grad_output.item().to<scalar_t>();
+    for (int64_t t = 0; t < nframe * dim; t++) {
+      grad_input_data[t] *= d;
+    }
+  } else {
+    auto grad_output_acc = grad_output.accessor<scalar_t, 1>();
+    for (int64_t t = 0; t < nframe; t++) {
+      for (int64_t d = 0; d < dim; d++) {
+        grad_input_data[t * dim + d] *= grad_output_acc[t];
+      }
+    }
+  }
+}
+
+void multi_margin_loss_backward_out_cpu_template(
+    Tensor& grad_input,
+    const Tensor& grad_output,
+    const Tensor& input,
+    const Tensor& target,
+    int p,
+    Scalar margin,
+    const Tensor& weight,
+    int64_t reduction) {
+  const auto ndims = input.dim();
+  TORCH_CHECK(
+      input.numel() > 0 && ndims <= 2,
+      "non-empty vector or matrix expected, got size: ",
+      input.sizes());
+
+  TORCH_CHECK(p == 1 || p == 2, "only p == 1 and p == 2 supported");
+
+  int64_t nframe, dim;
+  if (ndims <= 1) {
+    nframe = 1;
+    dim = ndims == 0 ? 1 : input.size(0);
+  } else {
+    nframe = input.size(0);
+    dim = input.size(1);
+  }
+
+  TORCH_CHECK(
+      target.numel() > 0 && target.dim() <= 1 && target.numel() == nframe,
+      "inconsistent target size, got: ",
+      target.sizes());
+
+  grad_input.resize_as_(input);
+  TORCH_CHECK(grad_input.is_contiguous(), "grad_input must be contiguous");
+
+  auto input_contiguous = input.contiguous();
+  auto target_contiguous = target.contiguous();
+  auto weight_contiguous = weight.contiguous();
+  AT_DISPATCH_FLOATING_TYPES(
+      input.scalar_type(), "multi_margin_loss_backward_cpu_kernel", [&] {
+        auto grad_input_data = grad_input.data_ptr<scalar_t>();
+        auto input_data = input_contiguous.data_ptr<scalar_t>();
+        auto target_data = target_contiguous.data_ptr<int64_t>();
+        auto weight_data = weight_contiguous.defined()
+            ? weight_contiguous.data_ptr<scalar_t>()
+            : nullptr;
+        scalar_t g = reduction == Reduction::Mean
+            ? static_cast<scalar_t>(1. / (nframe * dim))
+            : static_cast<scalar_t>(1. / dim);
+        multi_margin_loss_backward_cpu_kernel<scalar_t>(
+            grad_input_data,
+            grad_output,
+            input_data,
+            target_data,
+            p,
+            margin.to<scalar_t>(),
+            g,
+            weight_data,
+            nframe,
+            dim,
+            reduction);
+      });
+}
+
+} // namespace
+
+Tensor multi_margin_loss_cpu(
+    const Tensor& input,
+    const Tensor& target,
+    Scalar p,
+    Scalar margin,
+    const Tensor& weight,
+    int64_t reduction) {
+  auto output = at::empty({0}, input.options());
+  multi_margin_loss_out_cpu_template(
+      output, input, target, p.toInt(), margin, weight, reduction);
+  return output;
+}
+
+Tensor& multi_margin_loss_cpu_out(
+    Tensor& output,
+    const Tensor& input,
+    const Tensor& target,
+    Scalar p,
+    Scalar margin,
+    const Tensor& weight,
+    int64_t reduction) {
+  multi_margin_loss_out_cpu_template(
+      output, input, target, p.toInt(), margin, weight, reduction);
+  return output;
+}
+
+Tensor multi_margin_loss_cpu_backward(
+    const Tensor& grad_output,
+    const Tensor& input,
+    const Tensor& target,
+    Scalar p,
+    Scalar margin,
+    const Tensor& weight,
+    int64_t reduction) {
+  auto grad_input = at::empty({0}, input.options());
+  multi_margin_loss_backward_out_cpu_template(
+      grad_input,
+      grad_output,
+      input,
+      target,
+      p.toInt(),
+      margin,
+      weight,
+      reduction);
+  return grad_input;
+}
+
+Tensor& multi_margin_loss_cpu_backward_out(
+    Tensor& grad_input,
+    const Tensor& grad_output,
+    const Tensor& input,
+    const Tensor& target,
+    Scalar p,
+    Scalar margin,
+    const Tensor& weight,
+    int64_t reduction) {
+  multi_margin_loss_backward_out_cpu_template(
+      grad_input,
+      grad_output,
+      input,
+      target,
+      p.toInt(),
+      margin,
+      weight,
+      reduction);
+  return grad_input;
+}
+
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -5572,25 +5572,25 @@
 - func: multi_margin_loss.out(Tensor self, Tensor target, Scalar p=1, Scalar margin=1, Tensor? weight=None, int reduction=Mean, *, Tensor(a!) out) -> Tensor(a!)
   python_module: nn
   dispatch:
-    CPU: legacy::cpu::_thnn_multi_margin_loss_forward_out
+    CPU: multi_margin_loss_cpu_out
     CUDA: legacy::cuda::_thnn_multi_margin_loss_forward_out
 
 - func: multi_margin_loss(Tensor self, Tensor target, Scalar p=1, Scalar margin=1, Tensor? weight=None, int reduction=Mean) -> Tensor
   python_module: nn
   dispatch:
-    CPU: legacy::cpu::_thnn_multi_margin_loss_forward
+    CPU: multi_margin_loss_cpu
     CUDA: legacy::cuda::_thnn_multi_margin_loss_forward
 
 - func: multi_margin_loss_backward.grad_input(Tensor grad_output, Tensor self, Tensor target, Scalar p, Scalar margin, Tensor? weight=None, int reduction=Mean, *, Tensor(a!) grad_input) -> Tensor(a!)
   python_module: nn
   dispatch:
-    CPU: legacy::cpu::_thnn_multi_margin_loss_backward_out
+    CPU: multi_margin_loss_cpu_backward_out
     CUDA: legacy::cuda::_thnn_multi_margin_loss_backward_out
 
 - func: multi_margin_loss_backward(Tensor grad_output, Tensor self, Tensor target, Scalar p, Scalar margin, Tensor? weight=None, int reduction=Mean) -> Tensor
   python_module: nn
   dispatch:
-    CPU: legacy::cpu::_thnn_multi_margin_loss_backward
+    CPU: multi_margin_loss_cpu_backward
     CUDA: legacy::cuda::_thnn_multi_margin_loss_backward
 
 - func: multilabel_margin_loss.out(Tensor self, Tensor target, int reduction=Mean, *, Tensor(a!) out) -> Tensor(a!)

--- a/aten/src/THNN/generic/THNN.h
+++ b/aten/src/THNN/generic/THNN.h
@@ -199,26 +199,6 @@ TH_API void THNN_(MultiLabelMarginCriterion_updateGradInput)(
           THTensor *isTarget,
           int64_t reduction);
 
-TH_API void THNN_(MultiMarginCriterion_updateOutput)(
-          THNNState *state,
-          THTensor *input,
-          THIndexTensor *target,
-          THTensor *output,
-          int64_t reduction,
-          int p,
-          THTensor* weights,      // [OPTIONAL]
-          accreal margin);
-TH_API void THNN_(MultiMarginCriterion_updateGradInput)(
-          THNNState *state,
-          THTensor *input,
-          THIndexTensor *target,
-          THTensor *gradOutput,
-          THTensor *gradInput,
-          int64_t reduction,
-          int p,
-          THTensor *weights,      // [OPTIONAL]
-          accreal margin);
-
 TH_API void THNN_(RReLU_updateOutput)(
           THNNState *state,
           THTensor *input,

--- a/aten/src/THNN/init.cpp
+++ b/aten/src/THNN/init.cpp
@@ -97,9 +97,6 @@
 #include <THNN/generic/MultiLabelMarginCriterion.c>
 #include <TH/THGenerateFloatTypes.h>
 
-#include <THNN/generic/MultiMarginCriterion.c>
-#include <TH/THGenerateFloatTypes.h>
-
 #include <THNN/generic/RReLU.c>
 #include <TH/THGenerateFloatTypes.h>
 


### PR DESCRIPTION
This is a port of the existing TH CPU C MultiMarginCriterion to function multi_margin_loss for ATen. ~~The ATen/C++ version is unfortunately significantly slower than the original. It is currently unclear to me what causes the performance degradation since the Tensor access is raw-pointer based similar to the original C implementation. (A first implementation I had created using TensorAccessor was even about 2x slower than the one in this PR).~~