### PR TITLE
Adapt MKL-DNN operators for both imperative and future JIT environment

### DIFF
--- a/aten/src/ATen/native/mkldnn/Conv.cpp
+++ b/aten/src/ATen/native/mkldnn/Conv.cpp
@@ -290,7 +290,7 @@ Tensor mkldnn_convolution(
     IntArrayRef dilation,
     int64_t groups) {
   auto output = native::dnnl_conv2d(
-      input, weight, bias, padding, stride, dilation, groups);
+      input, weight, bias, stride, padding, dilation, groups);
 
   if (input.is_mkldnn()) {
     return output;

--- a/aten/src/ATen/native/mkldnn/MKLDNNCommon.h
+++ b/aten/src/ATen/native/mkldnn/MKLDNNCommon.h
@@ -30,6 +30,28 @@ ideep::tensor& itensor_from_mkldnn(const Tensor& mkldnn_tensor);
 // Construct an `ideep::tensor` "view" from dense tensor, note the
 // ideep::tensor will share the underlying buffer
 ideep::tensor itensor_view_from_dense(const Tensor& tensor);
+
+// Helper function for getting an ideep tensor out of an aten Tensor.
+// Note in case the aten Tensor is a dense tensor, the retured ideep
+// tensor is just a view of the storage of the aten dense tensor, so
+// caller needs to make sure the aten dense tensor's lifetime is
+// longer than the ideep tensor.
+inline ideep::tensor get_mkldnn_tensor(const Tensor& tensor) {
+  if (tensor.is_mkldnn()) {
+    return at::native::itensor_from_mkldnn(tensor);
+  } else {
+    return at::native::itensor_view_from_dense(tensor);
+  }
+}
+
+// Helper to create arbitrary DNNL Opaque tensor
+Tensor empty_dnnl(c10::IntArrayRef size, const c10::TensorOptions& options,
+    ideep::format format, int64_t groups);
+
+// This interface serve the purpose that created tensor actually 'like' the input
+// If it a Opaque, then returns an Opaque, otherwise call at::empty_like
+Tensor dnnl_empty_like(const Tensor& input);
+
 }}
 
 #endif // AT_MKLDNN_ENABLED

--- a/aten/src/ATen/native/mkldnn/MKLDNNConversions.cpp
+++ b/aten/src/ATen/native/mkldnn/MKLDNNConversions.cpp
@@ -144,7 +144,7 @@ Tensor mkldnn_reorder_conv2d_weight(
   AT_ERROR("mkldnn_reorder_conv2d_weight: MKL-DNN build is disabled");
 }
 
-Tensor _dnnl_reorder(
+Tensor dnnl_reorder(
     const Tensor& input, int64_t from, int64_t to, int64_t groups) {
   AT_ERROR("_dnnl_reorder: MKL-DNN build is disabled");
 }

--- a/aten/src/ATen/native/mkldnn/Pooling.cpp
+++ b/aten/src/ATen/native/mkldnn/Pooling.cpp
@@ -77,6 +77,29 @@ Tensor& mkldnn_adaptive_avg_pool2d_out(
       "mkldnn_adaptive_avg_pool2d_out: ATen not compiled with MKLDNN support");
 }
 
+Tensor dnnl_max_pool2d(
+    const Tensor& input,
+    IntArrayRef kernel_size,
+    IntArrayRef stride,
+    IntArrayRef padding,
+    IntArrayRef dilation,
+    bool ceil_mode) {
+  AT_ERROR(
+      "dnnl_max_pool2d: ATen not compiled with MKLDNN support");
+}
+
+Tensor dnnl_avg_pool2d(
+    const Tensor& input,
+    IntArrayRef kernel_size,
+    IntArrayRef stride,
+    IntArrayRef padding,
+    bool ceil_mode,
+    bool count_include_pad,
+    c10::optional<int64_t> divisor_override) {
+  AT_ERROR(
+      "dnnl_avg_pool2d: ATen not compiled with MKLDNN support");
+}
+
 } // namespace native
 } // namespace at
 

--- a/aten/src/ATen/native/mkldnn/Relu.cpp
+++ b/aten/src/ATen/native/mkldnn/Relu.cpp
@@ -15,6 +15,14 @@ Tensor& mkldnn_relu_(Tensor& input) {
   AT_ERROR("mkldnn_relu_: ATen not compiled with MKLDNN support");
 }
 
+Tensor dnnl_relu(const Tensor& input) {
+  AT_ERROR("dnnl_relu: ATen not compiled with MKLDNN support");
+}
+
+Tensor& dnnl_relu_(Tensor& input) {
+  AT_ERROR("dnnl_relu_: ATen not compiled with MKLDNN support");
+}
+
 }}
 
 #else // AT_MKLDNN_EBABLED
@@ -22,6 +30,32 @@ Tensor& mkldnn_relu_(Tensor& input) {
 #include <ATen/native/mkldnn/MKLDNNCommon.h>
 
 namespace at { namespace native {
+
+//
+// These two new interface have extended semantics,
+// if input is an Opaque tensor supported by this op, it will return an Opaque tensor.
+// if input is CPUTensor, it returns CPUTensor
+//
+Tensor dnnl_relu(const Tensor& input) {
+  const ideep::tensor x = get_mkldnn_tensor(input);
+
+  // Create CPU or Opaque result tensor
+  auto output = dnnl_empty_like(input);
+  auto y = get_mkldnn_tensor(output);
+
+  ideep::eltwise_forward::compute(
+      x, y, ideep::algorithm::eltwise_relu,
+      ideep::prop_kind::forward_inference, /*alpha*/ 0.0);
+  return output;
+}
+
+Tensor& dnnl_relu_(Tensor& input) {
+  ideep::tensor x = get_mkldnn_tensor(input);
+  ideep::eltwise_forward::compute(
+      x, x, ideep::algorithm::eltwise_relu,
+      ideep::prop_kind::forward_inference, /*alpha*/ 0.0);
+  return input;
+}
 
 Tensor mkldnn_relu(const Tensor& input) {
   const ideep::tensor& x = itensor_from_mkldnn(input);
@@ -32,10 +66,7 @@ Tensor mkldnn_relu(const Tensor& input) {
 }
 
 Tensor& mkldnn_relu_(Tensor& input) {
-  ideep::tensor& x = itensor_from_mkldnn(input);
-  ideep::eltwise_forward::compute<AllocForMKLDNN>(
-      x, x, ideep::algorithm::eltwise_relu, ideep::prop_kind::forward_training, /*alpha*/ 0.0);
-  return input;
+  return native::dnnl_relu_(input);
 }
 
 }}

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1747,6 +1747,11 @@
   dispatch:
     MkldnnCPU: mkldnn_max_pool2d
 
+- func: _dnnl_max_pool2d(Tensor self, int[2] kernel_size, int[2] stride=[], int[2] padding=0, int[2] dilation=1, bool ceil_mode=False) -> Tensor
+  dispatch:
+    CPU: dnnl_max_pool2d
+    MkldnnCPU: dnnl_max_pool2d
+
 - func: quantized_max_pool2d(Tensor self, int[2] kernel_size, int[2] stride=[], int[2] padding=0, int[2] dilation=1, bool ceil_mode=False) -> Tensor
   use_c10_dispatcher: unboxed_only
   requires_tensor: True
@@ -1832,6 +1837,25 @@
   variants: function, method
 
 - func: mkldnn_convolution(Tensor self, Tensor weight, Tensor? bias, int[] padding, int[] stride, int[] dilation, int groups) -> Tensor
+
+- func: _dnnl_conv2d(Tensor self, Tensor weight, Tensor? bias, int[] stride, int[] padding, int[] dilation, int groups) -> Tensor
+  dispatch:
+    CPU: dnnl_conv2d
+    MkldnnCPU: dnnl_conv2d
+
+- func: _dnnl_conv2d_relu(Tensor self, Tensor weight, Tensor? bias, int[] stride, int[] padding, int[] dilation, int groups) -> Tensor
+  dispatch:
+    CPU: dnnl_conv2d_relu
+    MkldnnCPU: dnnl_conv2d_relu
+
+# At this stage, should self must be a DNNL Opaque Tensor or there is no performance gain.
+- func: _dnnl_sum_conv2d_(Tensor(a!) self, Tensor input, Tensor weight, Tensor? bias, int[] stride, int[] padding, int[] dilation, int groups, Scalar alpha) -> Tensor(a!)
+  dispatch:
+    MkldnnCPU: dnnl_sum_conv2d_
+
+- func: _dnnl_sum_conv2d_then_relu_(Tensor(a!) self, Tensor input, Tensor weight, Tensor? bias, int[] stride, int[] padding, int[] dilation, int groups, Scalar alpha) -> Tensor(a!)
+  dispatch:
+    MkldnnCPU: dnnl_sum_conv2d_then_relu_
 
 - func: mkldnn_convolution_backward_input(int[] self_size, Tensor grad_output, Tensor weight, int[] padding, int[] stride, int[] dilation, int groups, bool bias_defined) -> Tensor
   use_c10_dispatcher: unboxed_only
@@ -2363,6 +2387,16 @@
     CUDA: relu_
     MkldnnCPU: mkldnn_relu_
     QuantizedCPU: quantized_relu_
+
+- func: _dnnl_relu(Tensor self) -> Tensor
+  dispatch:
+    CPU: dnnl_relu
+    MkldnnCPU: dnnl_relu
+
+- func: _dnnl_relu_(Tensor(a!) self) -> Tensor(a!)
+  dispatch:
+    CPU: dnnl_relu_
+    MkldnnCPU: dnnl_relu_
 
 - func: prelu(Tensor self, Tensor weight) -> Tensor
   use_c10_dispatcher: full
@@ -3641,6 +3675,11 @@
   python_module: nn
   dispatch:
     MkldnnCPU: mkldnn_reorder_conv2d_weight
+
+- func: _dnnl_reorder(Tensor self, int from, int to, int group=1) -> Tensor
+  dispatch:
+    CPU: dnnl_reorder
+    MkldnnCPU: dnnl_reorder
 
 - func: to_mkldnn_backward(Tensor grad, Tensor input) -> Tensor
   use_c10_dispatcher: full
@@ -6101,7 +6140,7 @@
   dispatch:
     CPU: avg_pool2d_cpu
     CUDA: avg_pool2d_cuda
-    MkldnnCPU: mkldnn_avg_pool2d
+    MkldnnCPU: dnnl_avg_pool2d
     QuantizedCPU: quantized_avg_pool2d
 
 - func: avg_pool2d_backward.grad_input(Tensor grad_output, Tensor self, int[2] kernel_size, int[2] stride, int[2] padding, bool ceil_mode, bool count_include_pad, int? divisor_override, *, Tensor(a!) grad_input) -> Tensor(a!)


### PR DESCRIPTION
First PR for https://github.com/pytorch/pytorch/issues/23657

Summary:
* Prepare MKL-DNN operators for JIT optimization pass, also promote brand DNNL instead of MKL-DNN
* DNNL operators semantics defined as:
  - All exposed DNNL ops accept both CPUTensor and Opaque Tensor, related standard ATen ops remain unchanged.
  - Computational intensive ops (convolution, etc.) which prefer specific data formats (DNNL’s term) will output Opaque Tensor
  - Memory intensive ops, whose performance doesn’t depend on formats, will output Tensor type the same as input
* Expose full DNNL functionality by adding interfaces with DNNL post ops

Signed-off-by: caozhong <zhong.z.cao@intel.com>

