### PR TITLE
Force building with GCC 5

### DIFF
--- a/c10/util/C++17.h
+++ b/c10/util/C++17.h
@@ -11,6 +11,12 @@
 #include <functional>
 #include <c10/macros/Macros.h>
 
+
+#if !defined(__clang__) && !defined(_MSC_VER) && defined(__GNUC__) && \
+  __GNUC__ < 5
+#error "You're trying to build PyTorch with a too old version of GCC. We need GCC 5 or later."
+#endif
+
 /*
  * This header adds some polyfills with C++14 and C++17 functionality
  */


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#28098 Force building with GCC 5**

Make sure that we're building with GCC 5 everywhere

Differential Revision: [D17953640](https://our.internmc.facebook.com/intern/diff/D17953640/)