### PR TITLE
[pytorch] Minor: add static_assert to Pickler buffering.

### DIFF
--- a/torch/csrc/jit/pickler.h
+++ b/torch/csrc/jit/pickler.h
@@ -201,12 +201,14 @@ class Pickler {
   // the left of a '::', its type cannot be deduced by the compiler so one must
   // explicitly instantiate the template, i.e. push<int>(int) works, push(int)
   // does not)
+  static constexpr size_t kBufferSize = 256;
   template <typename T>
   void push(typename std::common_type<T>::type value) {
     const char* begin = reinterpret_cast<const char*>(&value);
     if (bufferPos_ + sizeof(T) > buffer_.size()) {
       flushNonEmpty();
     }
+    static_assert(sizeof(T) <= kBufferSize, "Buffer size assumption");
     memcpy(buffer_.data() + bufferPos_, begin, sizeof(T));
     bufferPos_ += sizeof(T);
   }
@@ -216,7 +218,7 @@ class Pickler {
   std::function<void(const char*, size_t)> writer_;
 
   // Buffer to avoid calling a writer_ on a per-byte basis.
-  std::array<char, 256> buffer_;
+  std::array<char, kBufferSize> buffer_;
   size_t bufferPos_{0};
 
   // Stack of opcodes/data


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#28114 [pytorch] Minor: add static_assert to Pickler buffering.**

This is followup on the pickler buffering change.

Differential Revision: [D17955006](https://our.internmc.facebook.com/intern/diff/D17955006/)