### PR TITLE
[CI Testing] l1.large resource class on gcc5_4 testing and ASAN

### DIFF
--- a/.circleci/cimodel/data/pytorch_build_definitions.py
+++ b/.circleci/cimodel/data/pytorch_build_definitions.py
@@ -118,16 +118,16 @@ class Conf:
         job_def.update(self.gen_workflow_params(phase))
 
         if job_def['name'] == 'pytorch_linux_xenial_py3_6_gcc5_4_build':
-            job_def.update({'resource_class' : 'xlarge'})
+            job_def.update({'resource_class' : 'l1.large'})
 
         if job_def['name'] == 'pytorch_linux_xenial_py3_6_gcc5_4_test':
-            job_def.update({'resource_class' : 'xlarge'})
+            job_def.update({'resource_class' : 'l1.large'})
 
         if job_def['name'] == 'pytorch_linux_xenial_py3_clang5_asan_build':
-            job_def.update({'resource_class' : 'xlarge'})
+            job_def.update({'resource_class' : 'l1.large'})
 
         if job_def['name'] == 'pytorch_linux_xenial_py3_clang5_asan_test':
-            job_def.update({'resource_class' : 'xlarge'})
+            job_def.update({'resource_class' : 'l1.large'})
 
 
 

--- a/.circleci/cimodel/data/pytorch_build_definitions.py
+++ b/.circleci/cimodel/data/pytorch_build_definitions.py
@@ -117,6 +117,20 @@ class Conf:
             job_def["filters"] = {"branches": {"only": ["master", r"/ci-all\/.*/"]}}
         job_def.update(self.gen_workflow_params(phase))
 
+        if job_def['name'] == 'pytorch_linux_xenial_py3_6_gcc5_4_build':
+            job_def.update({'resource_class' : 'xlarge'})
+
+        if job_def['name'] == 'pytorch_linux_xenial_py3_6_gcc5_4_test':
+            job_def.update({'resource_class' : 'xlarge'})
+
+        if job_def['name'] == 'pytorch_linux_xenial_py3_clang5_asan_build':
+            job_def.update({'resource_class' : 'xlarge'})
+
+        if job_def['name'] == 'pytorch_linux_xenial_py3_clang5_asan_test':
+            job_def.update({'resource_class' : 'xlarge'})
+
+
+
         return {job_name : job_def}
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -852,8 +852,8 @@ jobs:
     - persist_to_workspace:
         root: /Users/distiller/workspace/
         paths: ios
-
-  binary_ios_upload:
+  
+  binary_ios_upload: 
     <<: *pytorch_ios_params
     macos:
       xcode: "10.2.1"
@@ -1287,7 +1287,7 @@ jobs:
           name: cert install
           no_output_timeout: "1h"
           command: |
-            set -e
+            set -e 
             PROJ_ROOT=/Users/distiller/project
             cd ${PROJ_ROOT}/ios/TestApp
             # install fastlane
@@ -1348,7 +1348,7 @@ jobs:
             if ! [ -x "$(command -v xcodebuild)" ]; then
               echo 'Error: xcodebuild is not installed.'
               exit 1
-            fi
+            fi 
             echo ${IOS_DEV_TEAM_ID}
             ruby ${PROJ_ROOT}/scripts/xcode_build.rb -i ${PROJ_ROOT}/build_ios/install -x ${PROJ_ROOT}/ios/TestApp/TestApp.xcodeproj -p ${IOS_PLATFORM} -c ${PROFILE} -t ${IOS_DEV_TEAM_ID}
             if ! [ "$?" -eq "0" ]; then
@@ -1565,6 +1565,7 @@ workflows:
             - setup
           build_environment: "pytorch-linux-xenial-py3.6-gcc5.4-build"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3.6-gcc5.4:347"
+          resource_class: xlarge
       - pytorch_linux_test:
           name: pytorch_linux_xenial_py3_6_gcc5_4_test
           requires:
@@ -3754,7 +3755,7 @@ workflows:
           context: org-member
           ios_platform: "SIMULATOR"
           ios_arch: "x86_64"
-          requires:
+          requires: 
             - setup
           filters:
             branches:
@@ -3765,7 +3766,7 @@ workflows:
           context: org-member
           ios_arch: "arm64"
           ios_platform: "OS"
-          requires:
+          requires: 
             - setup
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1496,6 +1496,7 @@ workflows:
             - pytorch_linux_xenial_py2_7_9_build
           build_environment: "pytorch-linux-xenial-py2.7.9-test"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py2.7.9:347"
+          resource_class: large
       - pytorch_linux_build:
           name: pytorch_linux_xenial_py2_7_build
           requires:
@@ -1519,6 +1520,7 @@ workflows:
                 - /ci-all\/.*/
           build_environment: "pytorch-linux-xenial-py2.7-test"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py2.7:347"
+          resource_class: large
       - pytorch_linux_build:
           name: pytorch_linux_xenial_py3_5_build
           requires:
@@ -1532,6 +1534,7 @@ workflows:
             - pytorch_linux_xenial_py3_5_build
           build_environment: "pytorch-linux-xenial-py3.5-test"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3.5:347"
+          resource_class: large
       - pytorch_linux_build:
           name: pytorch_linux_xenial_pynightly_build
           requires:
@@ -1555,6 +1558,7 @@ workflows:
                 - /ci-all\/.*/
           build_environment: "pytorch-linux-xenial-pynightly-test"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-pynightly:347"
+          resource_class: large
       - pytorch_linux_build:
           name: pytorch_linux_xenial_py3_6_gcc5_4_build
           requires:
@@ -1576,6 +1580,7 @@ workflows:
             - pytorch_linux_xenial_py3_6_gcc5_4_build
           build_environment: "pytorch-linux-backward-compatibility-check-test"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3.6-gcc5.4:347"
+          resource_class: large
       - pytorch_linux_build:
           name: pytorch_namedtensor_linux_xenial_py3_6_gcc5_4_build
           requires:
@@ -1589,6 +1594,7 @@ workflows:
             - pytorch_namedtensor_linux_xenial_py3_6_gcc5_4_build
           build_environment: "pytorch-namedtensor-linux-xenial-py3.6-gcc5.4-test"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3.6-gcc5.4:347"
+          resource_class: large
       - pytorch_linux_build:
           name: pytorch_linux_xenial_py3_6_gcc7_build
           requires:
@@ -1612,6 +1618,7 @@ workflows:
                 - /ci-all\/.*/
           build_environment: "pytorch-linux-xenial-py3.6-gcc7-test"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3.6-gcc7:347"
+          resource_class: large
       - pytorch_linux_build:
           name: pytorch_linux_xenial_py3_clang5_asan_build
           requires:
@@ -1640,6 +1647,7 @@ workflows:
             - pytorch_namedtensor_linux_xenial_py3_clang5_asan_build
           build_environment: "pytorch-namedtensor-linux-xenial-py3-clang5-asan-test"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3-clang5-asan:347"
+          resource_class: large
       - pytorch_linux_build:
           name: pytorch_xla_linux_xenial_py3_6_clang7_build
           requires:
@@ -1653,6 +1661,7 @@ workflows:
             - pytorch_xla_linux_xenial_py3_6_clang7_build
           build_environment: "pytorch-xla-linux-xenial-py3.6-clang7-test"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3.6-clang7:347"
+          resource_class: large
       - pytorch_linux_build:
           name: pytorch_linux_xenial_cuda9_cudnn7_py2_build
           requires:
@@ -1677,6 +1686,7 @@ workflows:
           build_environment: "pytorch-linux-xenial-cuda9-cudnn7-py2-test"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py2:347"
           use_cuda_docker_runtime: "1"
+          resource_class: gpu.medium
       - pytorch_linux_build:
           name: pytorch_linux_xenial_cuda9_cudnn7_py3_build
           requires:
@@ -1691,6 +1701,7 @@ workflows:
           build_environment: "pytorch-linux-xenial-cuda9-cudnn7-py3-test"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py3:347"
           use_cuda_docker_runtime: "1"
+          resource_class: gpu.medium
       - pytorch_linux_test:
           name: pytorch_linux_xenial_cuda9_cudnn7_py3_multigpu_test
           requires:
@@ -1699,6 +1710,7 @@ workflows:
           build_environment: "pytorch-linux-xenial-cuda9-cudnn7-py3-multigpu-test"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py3:347"
           use_cuda_docker_runtime: "1"
+          resource_class: gpu.large
       - pytorch_linux_test:
           name: pytorch_linux_xenial_cuda9_cudnn7_py3_NO_AVX2_test
           requires:
@@ -1707,6 +1719,7 @@ workflows:
           build_environment: "pytorch-linux-xenial-cuda9-cudnn7-py3-NO_AVX2-test"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py3:347"
           use_cuda_docker_runtime: "1"
+          resource_class: gpu.medium
       - pytorch_linux_test:
           name: pytorch_linux_xenial_cuda9_cudnn7_py3_NO_AVX_NO_AVX2_test
           requires:
@@ -1715,6 +1728,7 @@ workflows:
           build_environment: "pytorch-linux-xenial-cuda9-cudnn7-py3-NO_AVX-NO_AVX2-test"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py3:347"
           use_cuda_docker_runtime: "1"
+          resource_class: gpu.medium
       - pytorch_linux_test:
           name: pytorch_linux_xenial_cuda9_cudnn7_py3_slow_test
           requires:
@@ -1723,6 +1737,7 @@ workflows:
           build_environment: "pytorch-linux-xenial-cuda9-cudnn7-py3-slow-test"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py3:347"
           use_cuda_docker_runtime: "1"
+          resource_class: gpu.medium
       - pytorch_linux_test:
           name: pytorch_linux_xenial_cuda9_cudnn7_py3_nogpu_test
           requires:
@@ -1730,6 +1745,7 @@ workflows:
             - pytorch_linux_xenial_cuda9_cudnn7_py3_build
           build_environment: "pytorch-linux-xenial-cuda9-cudnn7-py3-nogpu-test"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py3:347"
+          resource_class: large
       - pytorch_python_doc_push:
           requires:
             - pytorch_linux_xenial_cuda9_cudnn7_py3_build
@@ -1750,6 +1766,7 @@ workflows:
           build_environment: "pytorch-libtorch-linux-xenial-cuda9-cudnn7-py3-test"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py3:347"
           use_cuda_docker_runtime: "1"
+          resource_class: gpu.medium
       - pytorch_linux_build:
           name: pytorch_namedtensor_linux_xenial_cuda9_cudnn7_py2_build
           requires:
@@ -1764,6 +1781,7 @@ workflows:
           build_environment: "pytorch-namedtensor-linux-xenial-cuda9-cudnn7-py2-test"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py2:347"
           use_cuda_docker_runtime: "1"
+          resource_class: gpu.medium
       - pytorch_linux_build:
           name: pytorch_linux_xenial_cuda9_2_cudnn7_py3_gcc7_build
           requires:
@@ -1788,6 +1806,7 @@ workflows:
           build_environment: "pytorch-linux-xenial-cuda9.2-cudnn7-py3-gcc7-test"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9.2-cudnn7-py3-gcc7:347"
           use_cuda_docker_runtime: "1"
+          resource_class: gpu.medium
       - pytorch_linux_build:
           name: pytorch_linux_xenial_cuda10_cudnn7_py3_gcc7_build
           requires:
@@ -1823,6 +1842,7 @@ workflows:
           build_environment: "pytorch-linux-xenial-cuda10.1-cudnn7-py3-gcc7-test"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda10.1-cudnn7-py3-gcc7:347"
           use_cuda_docker_runtime: "1"
+          resource_class: gpu.medium
       - pytorch_linux_build:
           name: pytorch_linux_xenial_py3_clang5_android_ndk_r19c_x86_32_build
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1565,7 +1565,7 @@ workflows:
             - setup
           build_environment: "pytorch-linux-xenial-py3.6-gcc5.4-build"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3.6-gcc5.4:347"
-          resource_class: xlarge
+          resource_class: l1.large
       - pytorch_linux_test:
           name: pytorch_linux_xenial_py3_6_gcc5_4_test
           requires:
@@ -1573,7 +1573,7 @@ workflows:
             - pytorch_linux_xenial_py3_6_gcc5_4_build
           build_environment: "pytorch-linux-xenial-py3.6-gcc5.4-test"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3.6-gcc5.4:347"
-          resource_class: xlarge
+          resource_class: l1.large
       - pytorch_linux_test:
           name: pytorch_linux_backward_compatibility_check_test
           requires:
@@ -1626,7 +1626,7 @@ workflows:
             - setup
           build_environment: "pytorch-linux-xenial-py3-clang5-asan-build"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3-clang5-asan:347"
-          resource_class: xlarge
+          resource_class: l1.large
       - pytorch_linux_test:
           name: pytorch_linux_xenial_py3_clang5_asan_test
           requires:
@@ -1634,7 +1634,7 @@ workflows:
             - pytorch_linux_xenial_py3_clang5_asan_build
           build_environment: "pytorch-linux-xenial-py3-clang5-asan-test"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3-clang5-asan:347"
-          resource_class: xlarge
+          resource_class: l1.large
       - pytorch_linux_build:
           name: pytorch_namedtensor_linux_xenial_py3_clang5_asan_build
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -852,8 +852,8 @@ jobs:
     - persist_to_workspace:
         root: /Users/distiller/workspace/
         paths: ios
-  
-  binary_ios_upload: 
+
+  binary_ios_upload:
     <<: *pytorch_ios_params
     macos:
       xcode: "10.2.1"
@@ -1287,7 +1287,7 @@ jobs:
           name: cert install
           no_output_timeout: "1h"
           command: |
-            set -e 
+            set -e
             PROJ_ROOT=/Users/distiller/project
             cd ${PROJ_ROOT}/ios/TestApp
             # install fastlane
@@ -1348,7 +1348,7 @@ jobs:
             if ! [ -x "$(command -v xcodebuild)" ]; then
               echo 'Error: xcodebuild is not installed.'
               exit 1
-            fi 
+            fi
             echo ${IOS_DEV_TEAM_ID}
             ruby ${PROJ_ROOT}/scripts/xcode_build.rb -i ${PROJ_ROOT}/build_ios/install -x ${PROJ_ROOT}/ios/TestApp/TestApp.xcodeproj -p ${IOS_PLATFORM} -c ${PROFILE} -t ${IOS_DEV_TEAM_ID}
             if ! [ "$?" -eq "0" ]; then
@@ -1496,7 +1496,6 @@ workflows:
             - pytorch_linux_xenial_py2_7_9_build
           build_environment: "pytorch-linux-xenial-py2.7.9-test"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py2.7.9:347"
-          resource_class: large
       - pytorch_linux_build:
           name: pytorch_linux_xenial_py2_7_build
           requires:
@@ -1520,7 +1519,6 @@ workflows:
                 - /ci-all\/.*/
           build_environment: "pytorch-linux-xenial-py2.7-test"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py2.7:347"
-          resource_class: large
       - pytorch_linux_build:
           name: pytorch_linux_xenial_py3_5_build
           requires:
@@ -1534,7 +1532,6 @@ workflows:
             - pytorch_linux_xenial_py3_5_build
           build_environment: "pytorch-linux-xenial-py3.5-test"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3.5:347"
-          resource_class: large
       - pytorch_linux_build:
           name: pytorch_linux_xenial_pynightly_build
           requires:
@@ -1558,7 +1555,6 @@ workflows:
                 - /ci-all\/.*/
           build_environment: "pytorch-linux-xenial-pynightly-test"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-pynightly:347"
-          resource_class: large
       - pytorch_linux_build:
           name: pytorch_linux_xenial_py3_6_gcc5_4_build
           requires:
@@ -1572,7 +1568,7 @@ workflows:
             - pytorch_linux_xenial_py3_6_gcc5_4_build
           build_environment: "pytorch-linux-xenial-py3.6-gcc5.4-test"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3.6-gcc5.4:347"
-          resource_class: large
+          resource_class: xlarge
       - pytorch_linux_test:
           name: pytorch_linux_backward_compatibility_check_test
           requires:
@@ -1580,7 +1576,6 @@ workflows:
             - pytorch_linux_xenial_py3_6_gcc5_4_build
           build_environment: "pytorch-linux-backward-compatibility-check-test"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3.6-gcc5.4:347"
-          resource_class: large
       - pytorch_linux_build:
           name: pytorch_namedtensor_linux_xenial_py3_6_gcc5_4_build
           requires:
@@ -1594,7 +1589,6 @@ workflows:
             - pytorch_namedtensor_linux_xenial_py3_6_gcc5_4_build
           build_environment: "pytorch-namedtensor-linux-xenial-py3.6-gcc5.4-test"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3.6-gcc5.4:347"
-          resource_class: large
       - pytorch_linux_build:
           name: pytorch_linux_xenial_py3_6_gcc7_build
           requires:
@@ -1618,13 +1612,13 @@ workflows:
                 - /ci-all\/.*/
           build_environment: "pytorch-linux-xenial-py3.6-gcc7-test"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3.6-gcc7:347"
-          resource_class: large
       - pytorch_linux_build:
           name: pytorch_linux_xenial_py3_clang5_asan_build
           requires:
             - setup
           build_environment: "pytorch-linux-xenial-py3-clang5-asan-build"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3-clang5-asan:347"
+          resource_class: xlarge
       - pytorch_linux_test:
           name: pytorch_linux_xenial_py3_clang5_asan_test
           requires:
@@ -1632,7 +1626,7 @@ workflows:
             - pytorch_linux_xenial_py3_clang5_asan_build
           build_environment: "pytorch-linux-xenial-py3-clang5-asan-test"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3-clang5-asan:347"
-          resource_class: large
+          resource_class: xlarge
       - pytorch_linux_build:
           name: pytorch_namedtensor_linux_xenial_py3_clang5_asan_build
           requires:
@@ -1646,7 +1640,6 @@ workflows:
             - pytorch_namedtensor_linux_xenial_py3_clang5_asan_build
           build_environment: "pytorch-namedtensor-linux-xenial-py3-clang5-asan-test"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3-clang5-asan:347"
-          resource_class: large
       - pytorch_linux_build:
           name: pytorch_xla_linux_xenial_py3_6_clang7_build
           requires:
@@ -1660,7 +1653,6 @@ workflows:
             - pytorch_xla_linux_xenial_py3_6_clang7_build
           build_environment: "pytorch-xla-linux-xenial-py3.6-clang7-test"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3.6-clang7:347"
-          resource_class: large
       - pytorch_linux_build:
           name: pytorch_linux_xenial_cuda9_cudnn7_py2_build
           requires:
@@ -1685,7 +1677,6 @@ workflows:
           build_environment: "pytorch-linux-xenial-cuda9-cudnn7-py2-test"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py2:347"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
       - pytorch_linux_build:
           name: pytorch_linux_xenial_cuda9_cudnn7_py3_build
           requires:
@@ -1700,7 +1691,6 @@ workflows:
           build_environment: "pytorch-linux-xenial-cuda9-cudnn7-py3-test"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py3:347"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
       - pytorch_linux_test:
           name: pytorch_linux_xenial_cuda9_cudnn7_py3_multigpu_test
           requires:
@@ -1709,7 +1699,6 @@ workflows:
           build_environment: "pytorch-linux-xenial-cuda9-cudnn7-py3-multigpu-test"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py3:347"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.large
       - pytorch_linux_test:
           name: pytorch_linux_xenial_cuda9_cudnn7_py3_NO_AVX2_test
           requires:
@@ -1718,7 +1707,6 @@ workflows:
           build_environment: "pytorch-linux-xenial-cuda9-cudnn7-py3-NO_AVX2-test"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py3:347"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
       - pytorch_linux_test:
           name: pytorch_linux_xenial_cuda9_cudnn7_py3_NO_AVX_NO_AVX2_test
           requires:
@@ -1727,7 +1715,6 @@ workflows:
           build_environment: "pytorch-linux-xenial-cuda9-cudnn7-py3-NO_AVX-NO_AVX2-test"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py3:347"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
       - pytorch_linux_test:
           name: pytorch_linux_xenial_cuda9_cudnn7_py3_slow_test
           requires:
@@ -1736,7 +1723,6 @@ workflows:
           build_environment: "pytorch-linux-xenial-cuda9-cudnn7-py3-slow-test"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py3:347"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
       - pytorch_linux_test:
           name: pytorch_linux_xenial_cuda9_cudnn7_py3_nogpu_test
           requires:
@@ -1744,7 +1730,6 @@ workflows:
             - pytorch_linux_xenial_cuda9_cudnn7_py3_build
           build_environment: "pytorch-linux-xenial-cuda9-cudnn7-py3-nogpu-test"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py3:347"
-          resource_class: large
       - pytorch_python_doc_push:
           requires:
             - pytorch_linux_xenial_cuda9_cudnn7_py3_build
@@ -1765,7 +1750,6 @@ workflows:
           build_environment: "pytorch-libtorch-linux-xenial-cuda9-cudnn7-py3-test"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py3:347"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
       - pytorch_linux_build:
           name: pytorch_namedtensor_linux_xenial_cuda9_cudnn7_py2_build
           requires:
@@ -1780,7 +1764,6 @@ workflows:
           build_environment: "pytorch-namedtensor-linux-xenial-cuda9-cudnn7-py2-test"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py2:347"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
       - pytorch_linux_build:
           name: pytorch_linux_xenial_cuda9_2_cudnn7_py3_gcc7_build
           requires:
@@ -1805,7 +1788,6 @@ workflows:
           build_environment: "pytorch-linux-xenial-cuda9.2-cudnn7-py3-gcc7-test"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9.2-cudnn7-py3-gcc7:347"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
       - pytorch_linux_build:
           name: pytorch_linux_xenial_cuda10_cudnn7_py3_gcc7_build
           requires:
@@ -1841,7 +1823,6 @@ workflows:
           build_environment: "pytorch-linux-xenial-cuda10.1-cudnn7-py3-gcc7-test"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda10.1-cudnn7-py3-gcc7:347"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
       - pytorch_linux_build:
           name: pytorch_linux_xenial_py3_clang5_android_ndk_r19c_x86_32_build
           requires:
@@ -3753,7 +3734,7 @@ workflows:
           context: org-member
           ios_platform: "SIMULATOR"
           ios_arch: "x86_64"
-          requires: 
+          requires:
             - setup
           filters:
             branches:
@@ -3764,7 +3745,7 @@ workflows:
           context: org-member
           ios_arch: "arm64"
           ios_platform: "OS"
-          requires: 
+          requires:
             - setup
           filters:
             branches:


### PR DESCRIPTION
Per title.

Reopening and trying "l1.large" instead of "xlarge" resource class. Seems like CircleCI docs are out of date. 