### PR TITLE
print last 50 runs when using ai_pep_format

### DIFF
--- a/benchmarks/operator_benchmark/benchmark_caffe2.py
+++ b/benchmarks/operator_benchmark/benchmark_caffe2.py
@@ -127,6 +127,9 @@ class Caffe2OperatorTestCase(object):
         if not workspace.RunOperatorMultiple(op, num_runs):
             raise ValueError("Unable to run operator gradient test case: {}".format(self.test_name))
 
+    def _print_per_iter(self):
+        pass
+
 
 def register_caffe2_op_test_case(op_bench, test_config):
     test_case = Caffe2OperatorTestCase(op_bench, test_config)

--- a/benchmarks/operator_benchmark/benchmark_core.py
+++ b/benchmarks/operator_benchmark/benchmark_core.py
@@ -197,6 +197,9 @@ class BenchmarkRunner(object):
                 iters, run_time_sec, curr_test_total_time, self.has_explicit_iteration_count)
 
             if results_are_significant:
+                # Print out the last 50 values when running with AI PEP
+                if self.args.ai_pep_format:
+                    test_case._print_per_iter()
                 break
 
             # Re-estimate the hopefully-sufficient

--- a/benchmarks/operator_benchmark/benchmark_pytorch.py
+++ b/benchmarks/operator_benchmark/benchmark_pytorch.py
@@ -126,6 +126,7 @@ class PyTorchOperatorTestCase(object):
         self.op_bench = op_bench
         self.place_holder_tensor = torch.ones(1)
         self.framework = "PyTorch"
+        self.time_series = []
 
     def run_jit_forward(self, num_runs, print_per_iter=False):
         """ Run the forward path of an op with JIT mode
@@ -134,26 +135,28 @@ class PyTorchOperatorTestCase(object):
             self.op_bench._jit_forward = self.op_bench._generate_jit_forward_graph()
         self.op_bench._jit_forward(num_runs, self.place_holder_tensor)
 
+    def _print_per_iter(self):
+        # print last 50 values
+        length = min(len(self.time_series), 50)
+        for i in range(length):
+            print("PyTorchObserver " + json.dumps(
+                {
+                    "type": self.test_config.test_name,
+                    "metric": "latency",
+                    "unit": "ms",
+                    "value": str(self.time_series[length - i - 1]),
+                }
+            ))
+
     def run_forward(self, num_runs, print_per_iter):
         """ Run the forward path of an op with eager mode
         """
         if print_per_iter:
-            time_series = []
             for _ in range(num_runs):
                 start_time = time.time()
                 self.output = self.op_bench.forward()
                 end_time = time.time()
-                time_series.append(end_time - start_time)
-
-            for iter_time in time_series:
-                print("PyTorchObserver " + json.dumps(
-                    {
-                        "type": self.test_config.test_name,
-                        "metric": "latency",
-                        "unit": "us",
-                        "value": str(iter_time),
-                    }
-                ))
+                self.time_series.append((end_time - start_time) * 1e3)
         else:
             for _ in range(num_runs):
                 self.output = self.op_bench.forward()


### PR DESCRIPTION
Summary: as title

Test Plan:
```
# ----------------------------------------
# PyTorch/Caffe2 Operator Micro-benchmarks
# ----------------------------------------
# Tag : short

# Benchmarking PyTorch: add
PyTorchObserver {"type": "add_M64_N64_K64_cpu", "metric": "latency", "unit": "ms", "value": "29.169559478759766"}
PyTorchObserver {"type": "add_M64_N64_K64_cpu", "metric": "latency", "unit": "ms", "value": "29.206514358520508"}
PyTorchObserver {"type": "add_M64_N64_K64_cpu", "metric": "latency", "unit": "ms", "value": "29.4950008392334"}
PyTorchObserver {"type": "add_M64_N64_K64_cpu", "metric": "latency", "unit": "ms", "value": "29.172897338867188"}
PyTorchObserver {"type": "add_M64_N64_K64_cpu", "metric": "latency", "unit": "ms", "value": "29.27255630493164"}
PyTorchObserver {"type": "add_M64_N64_K64_cpu", "metric": "latency", "unit": "ms", "value": "29.549837112426758"}
PyTorchObserver {"type": "add_M64_N64_K64_cpu", "metric": "latency", "unit": "ms", "value": "29.63113784790039"}
...

Reviewed By: hl475

Differential Revision: D17957611

