### PR TITLE
[jit] clean up exported source format

### DIFF
--- a/caffe2/serialize/inline_container.cc
+++ b/caffe2/serialize/inline_container.cc
@@ -114,18 +114,18 @@ void PyTorchStreamReader::init() {
   size_t version_size;
   std::tie(version_ptr, version_size) = getRecord("version");
   std::string version(static_cast<const char*>(version_ptr.get()), version_size);
-  size_t version_number = caffe2::stoull(version);
+  version_ = caffe2::stoull(version);
   AT_ASSERTM(
-      version_number >= kMinSupportedFileFormatVersion,
+      version_ >= kMinSupportedFileFormatVersion,
       "Attempted to read a PyTorch file with version ",
-      c10::to_string(version_number),
+      c10::to_string(version_),
       ", but the minimum supported version for reading is ",
       c10::to_string(kMinSupportedFileFormatVersion),
       ". Your PyTorch script module file is too old. Please re-export it again.");
   AT_ASSERTM(
-      version_number <= kMaxSupportedFileFormatVersion,
+      version_ <= kMaxSupportedFileFormatVersion,
       "Attempted to read a PyTorch file with version ",
-      version_number,
+      version_,
       ", but the maximum supported version for reading is ",
       kMaxSupportedFileFormatVersion,
       ". Your PyTorch installation may be too old.");
@@ -286,7 +286,7 @@ void PyTorchStreamWriter::setup(const string& file_name) {
   valid("initializing archive ", file_name.c_str());
 
   std::stringstream version;
-  version << kMaxSupportedFileFormatVersion << "\n";
+  version << kProducedFileFormatVersion << "\n";
   writeRecord("version", version.str().c_str(), version.str().size());
 }
 

--- a/caffe2/serialize/inline_container.h
+++ b/caffe2/serialize/inline_container.h
@@ -90,7 +90,8 @@ namespace caffe2 {
 namespace serialize {
 
 constexpr uint64_t kMinSupportedFileFormatVersion = 0x1L;
-constexpr uint64_t kMaxSupportedFileFormatVersion = 0x1L;
+constexpr uint64_t kMaxSupportedFileFormatVersion = 0x2L;
+constexpr uint64_t kProducedFileFormatVersion = 0x1L;
 
 // Writer-specific constants
 constexpr uint64_t kFieldAlignment = 64;
@@ -107,7 +108,9 @@ class CAFFE2_API PyTorchStreamReader final {
   bool hasRecord(const std::string& name);
 
   ~PyTorchStreamReader();
-
+  uint64_t version() const {
+    return version_;
+  }
  private:
   void init();
   size_t read(uint64_t pos, char* buf, size_t n);
@@ -119,6 +122,7 @@ class CAFFE2_API PyTorchStreamReader final {
   std::unique_ptr<mz_zip_archive> ar_;
   std::string archive_name_;
   std::unique_ptr<ReadAdapterInterface> in_;
+  int64_t version_;
 };
 
 class CAFFE2_API PyTorchStreamWriter final {

--- a/test/cpp/jit/test_class_import.cpp
+++ b/test/cpp/jit/test_class_import.cpp
@@ -12,7 +12,6 @@ namespace jit {
 using namespace torch::jit::script;
 
 static const auto classSrcs1 = R"JIT(
-op_version_set = 1
 class FooNestedTest:
     def __init__(self, y):
         self.y = y
@@ -30,7 +29,6 @@ class FooTest:
 )JIT";
 
 static const auto classSrcs2 = R"JIT(
-op_version_set = 1
 class FooTest:
     def __init__(self, x):
       self.dx = x
@@ -46,7 +44,8 @@ static void import_libs(
       &tensor_table,
       [&](const std::string& name) -> std::shared_ptr<Source> {
         return src;
-      });
+      },
+      /*version=*/2);
   si.loadNamedType(QualifiedName(class_name));
 }
 

--- a/test/cpp/jit/test_save_load.cpp
+++ b/test/cpp/jit/test_save_load.cpp
@@ -57,21 +57,5 @@ void testSaveExtraFilesHook() {
   }
 }
 
-static const auto pretty_printed = R"JIT(
-op_version_set = 1000
-def foo(x: Tensor,
-    y: Tensor) -> Tensor:
-  _0 = torch.add(torch.mul(x, 2), y, alpha=1)
-  return _0
-)JIT";
-
-void testImportTooNew() {
-  Module m("__torch__.m");
-  const std::vector<at::Tensor> constant_table;
-  auto src = std::make_shared<Source>(pretty_printed);
-  SourceImporter si(m.class_compilation_unit(), &constant_table, nullptr);
-  ASSERT_ANY_THROW(si.LEGACY_import_methods(m, src));
-}
-
 } // namespace jit
 } // namespace torch

--- a/test/cpp/jit/tests.h
+++ b/test/cpp/jit/tests.h
@@ -62,7 +62,6 @@ namespace jit {
   _(SaveExtraFilesHook)                \
   _(DCE)                               \
   _(CustomFusionNestedBlocks)          \
-  _(ImportTooNew)                      \
   _(ClassDerive)                       \
   _(Inliner)                           \
   _(LiteInterpreterAdd)                \

--- a/torch/csrc/jit/export.cpp
+++ b/torch/csrc/jit/export.cpp
@@ -607,62 +607,28 @@ class ScriptModuleSerializer {
   }
 
   void writeCode(const at::NamedTypePtr& root_type) {
-    convertNamedType(root_type);
-    static const std::string opset_string =
-        c10::str("op_version_set = ", CURRENT_OP_VERSION_SET, "\n");
+    class_deps_.push_back(root_type);
+    for (size_t i = 0; i < class_deps_.size(); ++i) {
+      // note: convertNameType may extend class_deps_, so re-checking
+      // .size() is necessary
+      convertNamedType(class_deps_[i]);
+    }
 
     // Mapping of filename => src. We need this because multiple clases may go
     // in the same file (e.g. foo.bar.Baz and foo.bar.Qux)
+    for (auto& item : file_streams_) {
+      const std::string filename = qualifierToArchivePath(item.key(), "code/");
 
-    // Aggregate classes into files by their qualified names
-    std::unordered_map<std::string, std::ostringstream> fileToSrc;
-    std::unordered_map<std::string, SourceRangeRecords> fileToDebug;
-    for (auto& item : converted_types_) {
-      const auto& converted_type = item.key();
-      auto& type_info = item.value();
+      std::string src = item.value().str();
 
-      // For the type, foo.bar.Baz
-      const std::string filename =
-          qualifierToArchivePath(converted_type->name()->prefix(), "code/");
-      // End state: filename is "foo/bar.py", in which we will define a class
-      // named Baz
-      auto& stream = fileToSrc[filename];
-
-      // Adjust the SourceRange offsets since we are concatenating multiple
-      // classes to a single file.
-      // Need to add opset_string size as an offset because we will be
-      // prepending it to the file. (We should remove this opset_version string
-      // at some point and stash it in the model.json)
-      const auto offset =
-          static_cast<size_t>(stream.tellp()) + opset_string.size();
-      for (auto& sourceRange : type_info.debug_info) {
-        sourceRange.bytes += offset;
-      }
-
-      auto& debugInfo = fileToDebug[filename];
-      debugInfo.insert(
-          debugInfo.end(),
-          type_info.debug_info.begin(),
-          type_info.debug_info.end());
-      fileToSrc[filename] << type_info.source;
-    }
-
-    for (const auto& item : fileToSrc) {
-      const auto& filename = item.first;
-      const auto src = item.second.str();
-      const auto& debugInfo = fileToDebug.at(filename);
-
-      // Prepend the opset_version string
-      const auto lib_str = c10::str(opset_string, src);
-      writer_.writeRecord(
-          filename, lib_str.c_str(), lib_str.size(), /*compress=*/true);
+      writer_.writeRecord(filename, src.c_str(), src.size(), /*compress=*/true);
 
       // Write out the debug information
       std::stringstream debugFilename;
       debugFilename << filename << ".debug_pkl";
       SourceRangePickler source_range_pickler;
-      const auto& range_data = source_range_pickler.pickle(debugInfo);
-
+      const auto& range_data =
+          source_range_pickler.pickle(item.value().ranges());
       writer_.writeRecord(
           debugFilename.str(),
           range_data.data(),
@@ -742,46 +708,30 @@ class ScriptModuleSerializer {
   }
 
   void convertNamedType(const c10::NamedTypePtr& class_type) {
-    if (converted_types_.contains(class_type)) {
+    if (converted_types_.count(class_type)) {
       return;
     }
-
-    std::vector<c10::NamedTypePtr> class_deps;
-    std::ostringstream source_stream;
-    SourceRangeRecords source_ranges;
-    PythonPrint pp(
-        source_stream,
-        source_ranges,
-        constant_table_,
-        class_deps,
-        /*enforce_importable=*/true);
-    pp.printNamedType(class_type);
-    pp.finish();
-
-    for (const auto& c : class_deps) {
-      if (c == class_type) {
-        // Don't re-process this class and enter an infinite loop. We need this
-        // because we insert to converted_classes_ post-traversal, so the
-        // current class isn't in there yet.
-        continue;
-      }
-      convertNamedType(c);
+    converted_types_.insert(class_type);
+    std::string qualifier = class_type->name()->prefix();
+    PythonPrint* pp = file_streams_.find(qualifier);
+    if (!pp) {
+      pp = &file_streams_.insert(
+          qualifier,
+          PythonPrint(
+              constant_table_, class_deps_, /*enforce_importable=*/true));
+      pp->LEGACY_printOpVersion();
     }
-    // Insert *after* we've traversed the dependencies. This ensures that any
-    // given class will appear after its dependencies in the order.
-    TypeInfo info{source_stream.str(), std::move(source_ranges)};
-    converted_types_.insert(class_type, std::move(info));
+    pp->printNamedType(class_type);
   }
 
   caffe2::serialize::PyTorchStreamWriter writer_;
   std::vector<at::Tensor> constant_table_;
+  std::unordered_set<c10::NamedTypePtr> converted_types_;
+  std::vector<c10::NamedTypePtr> class_deps_;
 
-  // all deps used by this module hierarchy
-  struct TypeInfo {
-    std::string source;
-    SourceRangeRecords debug_info;
-  };
-  OrderedDict<c10::NamedTypePtr, TypeInfo> converted_types_;
+  // qualifier, e.g. '__torch__.Bar' -> PythonPrint for the file that will be
+  // created
+  OrderedDict<std::string, PythonPrint> file_streams_;
   bool bytecode_format_;
 };
 

--- a/torch/csrc/jit/export.h
+++ b/torch/csrc/jit/export.h
@@ -19,8 +19,6 @@ namespace jit {
 // file contents being the raw tensor data.
 using RawDataExportMap = std::unordered_map<std::string, at::Tensor>;
 
-constexpr size_t CURRENT_OP_VERSION_SET = 1;
-
 TORCH_API std::tuple<std::string, RawDataExportMap> export_onnx(
     const std::shared_ptr<Graph>& graph,
     const std::map<std::string, at::Tensor>& initializers,

--- a/torch/csrc/jit/import.cpp
+++ b/torch/csrc/jit/import.cpp
@@ -75,7 +75,8 @@ class ScriptModuleDeserializer final {
             [this](const std::string& qualifier) {
               return findSourceInArchiveFromQualifier(
                   *reader_, export_prefix_, qualifier);
-            }) {}
+            },
+            reader_->version()) {}
 
   script::Module deserialize(
       c10::optional<at::Device> device,

--- a/torch/csrc/jit/import_legacy.cpp
+++ b/torch/csrc/jit/import_legacy.cpp
@@ -51,7 +51,8 @@ class ScriptModuleDeserializer final {
             [this](const std::string& qualifier) {
               return findSourceInArchiveFromQualifier(
                   *reader_, export_prefix_, qualifier);
-            }) {}
+            },
+            reader_->version()) {}
 
   script::Module LEGACY_deserialize();
 

--- a/torch/csrc/jit/import_source.cpp
+++ b/torch/csrc/jit/import_source.cpp
@@ -103,9 +103,12 @@ struct SourceImporterImpl : public Resolver,
   SourceImporterImpl(
       const std::shared_ptr<CompilationUnit> cu,
       const std::vector<at::Tensor>* tensor_table,
-      SourceLoader source_loader)
+      SourceLoader source_loader,
+      size_t version)
       : cu_(cu), source_loader_(std::move(source_loader)) {
     env_ = {
+        {"torch", std::make_shared<BuiltinModule>("aten", version)},
+        {"ops", std::make_shared<OpsValue>(version)},
         // Constants present in the model. Used to resolve "CONSTANTS.n" to the
         // actual value
         {"CONSTANTS", std::make_shared<ConstantTableValue>(tensor_table)},
@@ -160,7 +163,7 @@ struct SourceImporterImpl : public Resolver,
       return;
     }
     Parser p(src);
-    parseAndCheckVersionNumber(p.lexer());
+    parsePossibleVersionNumber(p.lexer());
 
     auto& L = p.lexer();
 
@@ -193,7 +196,7 @@ struct SourceImporterImpl : public Resolver,
     c10::QualifiedName prefix = mod.name();
     Parser p(src);
 
-    parseAndCheckVersionNumber(p.lexer());
+    parsePossibleVersionNumber(p.lexer());
 
     parseImports(p.lexer());
 
@@ -395,39 +398,19 @@ struct SourceImporterImpl : public Resolver,
     cu_->register_type(tt);
   }
 
-  void parseAndCheckVersionNumber(Lexer& L) {
-    size_t version = parseVersionNumber(L);
-    // note: this cannot be called in the constructor because it may throw
-    if (version > CURRENT_OP_VERSION_SET) {
-      throw ErrorReport(L.cur().range)
-          << "Attempting to load a script generated from a newer version of "
-          << "PyTorch. Maximum supported TorchScript version is "
-          << CURRENT_OP_VERSION_SET
-          << " but the script being loaded is version " << version;
+  void parsePossibleVersionNumber(Lexer& L) {
+    // Older versions of serialization produced an op_version_set string
+    // per-file We now just use a single version which is handled by
+    // PyTorchStreamReader. We used to check if op_version_set was _newer_ for
+    // forward compatibility reasons but now that it doesn't exist there can't
+    // be a newer one, so we just discard this.
+    if (L.cur().kind == TK_IDENT && L.cur().text() == "op_version_set") {
+      auto range = L.cur().range;
+      L.next();
+      L.expect('=');
+      std::string version_text = L.expect(TK_NUMBER).text();
+      L.expect(TK_NEWLINE);
     }
-    // version numbers are specified per-file as a historic artifact.
-    // There really should be a version per entire source archive.
-    // We work around this by using the first version number in the components
-    // that need versions
-    if (env_.count("torch") == 0) {
-      env_["torch"] = std::make_shared<BuiltinModule>("aten", version);
-      env_["ops"] = std::make_shared<OpsValue>(version);
-    }
-  }
-
-  size_t parseVersionNumber(Lexer& L) {
-    auto range = L.cur().range;
-    auto name = L.expect(TK_IDENT).text();
-    L.expect('=');
-    std::string version_text = L.expect(TK_NUMBER).text();
-    L.expect(TK_NEWLINE);
-    auto version = Const::create(L.cur().range, version_text);
-    if (name != "op_version_set")
-      throw ErrorReport(range) << "expected an assignment to op_version_set";
-    if (!version.isIntegral())
-      throw ErrorReport(range)
-          << "expected an integral version but found " << version.text();
-    return size_t(version.asIntegral());
   }
 
   // older versions of serialization required import statements,
@@ -484,11 +467,13 @@ SourceImporter::SourceImporter(
     // The compilation unit that will own the imported source
     std::shared_ptr<CompilationUnit> cu,
     const std::vector<at::Tensor>* tensor_table,
-    SourceLoader loader)
+    SourceLoader loader,
+    size_t version)
     : pImpl(std::make_shared<SourceImporterImpl>(
           std::move(cu),
           tensor_table,
-          std::move(loader))) {}
+          std::move(loader),
+          version)) {}
 
 TypePtr SourceImporter::loadNamedType(const QualifiedName& name) const {
   TypePtr t = pImpl->findNamedType(name);

--- a/torch/csrc/jit/import_source.h
+++ b/torch/csrc/jit/import_source.h
@@ -24,7 +24,8 @@ struct TORCH_API SourceImporter {
       // The compilation unit that will own the imported source
       std::shared_ptr<CompilationUnit> cu,
       const std::vector<at::Tensor>* tensor_table,
-      SourceLoader loader);
+      SourceLoader loader,
+      size_t version);
 
   TypePtr loadNamedType(const QualifiedName& name) const;
 

--- a/torch/csrc/jit/jit_log.cpp
+++ b/torch/csrc/jit/jit_log.cpp
@@ -77,14 +77,11 @@ bool is_enabled(const char *cfname, JitLoggingLevels level) {
 // a dummy function to give to PythonPrint
 std::string log_function(const std::shared_ptr<torch::jit::Graph> &graph) {
   torch::jit::Function func("source_dump", graph, nullptr);
-  std::stringstream ss;
   std::vector<at::Tensor> tensors;
   std::vector<c10::NamedTypePtr> deps;
-  SourceRangeRecords source_ranges;
-  PythonPrint pp(ss, source_ranges, tensors, deps, false);
+  PythonPrint pp(tensors, deps, false);
   pp.printFunction(func);
-  pp.finish();
-  return ss.str();
+  return pp.str();
 }
 
 std::string jit_log_prefix(

--- a/torch/csrc/jit/passes/python_print.cpp
+++ b/torch/csrc/jit/passes/python_print.cpp
@@ -159,21 +159,6 @@ struct PythonPrintImpl {
       return ranges_;
     }
 
-    // Write out this TaggedStringStream's text and source ranges to
-    // os and source_ranges_out, respectively. stream_pos gives
-    // the byte offset into the current stream, so we can accurately
-    // record source ranges as byte offsets.
-    void print(
-        std::ostream& os,
-        SourceRangeRecords* source_ranges_out,
-        int64_t stream_pos) {
-      os << str();
-      for (const auto& x : ranges()) {
-        source_ranges_out->push_back(x);
-        source_ranges_out->back().bytes += stream_pos;
-      }
-    }
-
    private:
     std::ostringstream oss_;
     std::vector<TaggedRange> ranges_;
@@ -1206,34 +1191,14 @@ struct PythonPrintImpl {
     printFunction(func, /*print_first_argument_type=*/false);
   }
 
-  std::string getImports() {
-    std::ostringstream ret;
-    std::unordered_set<std::string> already_printed;
-    for (const auto& c : deps_table_) {
-      if (already_printed.count(c->name()->prefix())) {
-        continue;
-      }
-      // TODO we try to print a def for TestLinear in TestLinear.forward
-      ret << "import " << c->name()->prefix() << "\n";
-      already_printed.insert(c->name()->prefix());
-    }
-    return ret.str();
-  }
-
   PythonPrintImpl(
-      std::ostream& out,
-      SourceRangeRecords& source_ranges_out,
       std::vector<at::Tensor>& tensor_table,
       std::vector<c10::NamedTypePtr>& deps_table,
       bool enforce_importable)
-      : out_(out),
-        source_ranges_out_(source_ranges_out),
-        body_(&source_range_stack_),
+      : body_(&source_range_stack_),
         tensor_table_(tensor_table),
         deps_table_(deps_table),
-        enforce_importable_(enforce_importable) {
-    TORCH_INTERNAL_ASSERT(deps_table.empty());
-  }
+        enforce_importable_(enforce_importable) {}
 
   void printModuleMetadata(const ClassTypePtr& moduleType) {
     std::vector<std::string> params;
@@ -1341,23 +1306,11 @@ struct PythonPrintImpl {
     } else {
       TORCH_INTERNAL_ASSERT(false, "Unhandled NamedType");
     }
-    // remove `classType` from the list of deps
-    deps_table_.erase(
-        std::remove(deps_table_.begin(), deps_table_.end(), type),
-        deps_table_.end());
-  }
-
-  void finish() {
-    TORCH_INTERNAL_ASSERT(!finished_);
-    finished_ = true;
-    out_ << getImports();
-    int64_t source_offset = out_.tellp();
-    body_.print(out_, &source_ranges_out_, source_offset);
   }
 
   ~PythonPrintImpl() {}
 
- private:
+  TaggedStringStream body_;
   // When printing this node, is it safe to write it inline (i.e. without
   // assigning a temporary variable
   std::unordered_set<Node*> output_inline_;
@@ -1365,9 +1318,6 @@ struct PythonPrintImpl {
   // what valid identifiers are in use for the current function
   std::unordered_set<std::string> used_names_;
 
-  std::ostream& out_;
-  SourceRangeRecords& source_ranges_out_;
-  TaggedStringStream body_;
   // constants are written to this table, and given then named CONSTANTS.cN
   // where N is the index into this table.
   std::vector<at::Tensor>& tensor_table_;
@@ -1379,21 +1329,13 @@ struct PythonPrintImpl {
   // when we print this, should we error if the resulting output would
   // not be able to be reparsed?
   bool enforce_importable_;
-
-  // have we already printed to out_? We can't print more because we need
-  // to output imports before everything else
-  bool finished_ = false;
 };
 
 PythonPrint::PythonPrint(
-    std::ostream& out,
-    SourceRangeRecords& source_ranges_out,
     std::vector<at::Tensor>& tensor_table,
     std::vector<c10::NamedTypePtr>& deps_table,
     bool enforce_importable)
-    : pImpl(new PythonPrintImpl(
-          out,
-          source_ranges_out,
+    : pImpl(std::make_shared<PythonPrintImpl>(
           tensor_table,
           deps_table,
           enforce_importable)) {}
@@ -1410,8 +1352,16 @@ void PythonPrint::printMethod(const Function& func) {
   pImpl->printMethod(func);
 }
 
-void PythonPrint::finish() {
-  pImpl->finish();
+std::string PythonPrint::str() const {
+  return pImpl->body_.str();
+}
+
+const SourceRangeRecords& PythonPrint::ranges() const {
+  return pImpl->body_.ranges();
+}
+
+void PythonPrint::LEGACY_printOpVersion() {
+  pImpl->body_ << "op_version_set = 1\n";
 }
 
 PythonPrint::~PythonPrint() = default;

--- a/torch/csrc/jit/passes/python_print.h
+++ b/torch/csrc/jit/passes/python_print.h
@@ -16,8 +16,6 @@ struct PythonPrintImpl;
 
 struct TORCH_API PythonPrint {
   PythonPrint(
-      std::ostream& out,
-      SourceRangeRecords& source_ranges_out,
       std::vector<at::Tensor>& tensor_table,
       std::vector<c10::NamedTypePtr>& deps_table,
       bool enforce_importable = false);
@@ -25,12 +23,16 @@ struct TORCH_API PythonPrint {
   void printNamedType(const c10::NamedTypePtr& classType);
   void printFunction(const Function& callee);
   void printMethod(const Function& callee);
-  // must be called exactly once!
-  void finish();
+
+  std::string str() const;
+  const SourceRangeRecords& ranges() const;
+
   ~PythonPrint();
 
+  void LEGACY_printOpVersion();
+
  private:
-  std::unique_ptr<PythonPrintImpl> pImpl;
+  std::shared_ptr<PythonPrintImpl> pImpl;
 };
 
 TORCH_API bool printerHasSpecialCaseFor(c10::Symbol sym);

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -620,14 +620,11 @@ void initJitScriptBindings(PyObject* module) {
       .def_property_readonly(
           "code",
           [](Module& self) {
-            std::ostringstream ss;
             std::vector<at::Tensor> tensors;
             std::vector<c10::NamedTypePtr> deps;
-            SourceRangeRecords source_ranges;
-            PythonPrint pp(ss, source_ranges, tensors, deps, false);
+            PythonPrint pp(tensors, deps, false);
             pp.printNamedType(self.type());
-            pp.finish();
-            return ss.str();
+            return pp.str();
           })
       .def("apply", &Module::apply)
       .def("_clone", &Module::clone)
@@ -721,14 +718,11 @@ void initJitScriptBindings(PyObject* module) {
       .def_property_readonly(
           "code",
           [](const StrongFunctionPtr& self) {
-            std::ostringstream ss;
             std::vector<at::Tensor> tensors;
             std::vector<c10::NamedTypePtr> deps;
-            SourceRangeRecords source_ranges;
-            PythonPrint pp(ss, source_ranges, tensors, deps, false);
+            PythonPrint pp(tensors, deps, false);
             pp.printFunction(*self.function_);
-            pp.finish();
-            return ss.str();
+            return pp.str();
           })
       .def(
           "get_debug_state",
@@ -758,14 +752,11 @@ void initJitScriptBindings(PyObject* module) {
           "schema", [](Method& m) { return m.function().getSchema(); })
       .def_property_readonly("name", &Method::name)
       .def_property_readonly("code", [](Method& self) {
-        std::ostringstream ss;
         std::vector<at::Tensor> tensors;
         std::vector<c10::NamedTypePtr> deps;
-        SourceRangeRecords source_ranges;
-        PythonPrint pp(ss, source_ranges, tensors, deps, false);
+        PythonPrint pp(tensors, deps, false);
         pp.printMethod(self.function());
-        pp.finish();
-        return ss.str();
+        return pp.str();
       });
   m.def(
       "_jit_script_compile",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #28122 [jit] Stop producing op_version_set version numbers.
* **#28129 [jit] clean up exported source format**

The previous PR in the stack removed the need to order classes/functions
or have correct import statements. This resolved circular depedency issues
that can arise when class constructors like ModuleList put new instances
of themselves in a common namespace.

This PR changes our export format to no longer produce this information.
By doing so we can make the logic signficantly simpler, since we just
keep track of an individual PythonPrint object per file.

Notes:
* PythonPrint was changed to manage its own stream/list of ranges. It
was doing this anyway internally, this just makes the API more clear.
* Since we are changing the serialization format, I also removed op_version_set.
It is now replaced with the VERSION number that written in the zip archive.
This further simplifies the code emission process.
* A test of op_version_set was removed since there is no longer any behavior
to test.

Differential Revision: [D17961610](https://our.internmc.facebook.com/intern/diff/D17961610)