### PR TITLE
Adds @precisionOverride decorator

### DIFF
--- a/test/common_device_type.py
+++ b/test/common_device_type.py
@@ -394,7 +394,7 @@ class deviceCountAtLeast(object):
 # Specifies per-dtype precision overrides.
 # Ex.
 #
-# @overridePrecision(torch.half : 1e-2, torch.float : 1e-4)
+# @precisionOverride(torch.half : 1e-2, torch.float : 1e-4)
 # @dtypes(torch.half, torch.float, torch.double)
 # def test_X(self, device, dtype):
 #   ...
@@ -403,12 +403,17 @@ class deviceCountAtLeast(object):
 # corresponding override, if it exists.
 # self.precision can be accessed directly, and it also controls the behavior of
 # functions like self.assertEqual().
-class overridePrecision(object):
+#
+# Note that self.precision is a scalar value, so if you require multiple
+# precisions (or are working with multiple dtypes) they should be specified
+# explicitly and computed using self.precision (e.g.
+# self.precision *2, max(1, self.precision)).
+class precisionOverride(object):
 
     def __init__(self, d):
-        assert isinstance(d, dict), "overridePrecision not given a dtype : precision dict!"
+        assert isinstance(d, dict), "precisionOverride not given a dtype : precision dict!"
         for dtype, prec in d.items():
-            assert isinstance(dtype, torch.dtype), "overridePrecision given unknown dtype {0}".format(dtype)
+            assert isinstance(dtype, torch.dtype), "precisionOverride given unknown dtype {0}".format(dtype)
 
         self.d = d
 

--- a/test/common_device_type.py
+++ b/test/common_device_type.py
@@ -1,4 +1,5 @@
 import inspect
+import threading
 from functools import wraps
 import unittest
 import torch
@@ -123,6 +124,18 @@ device_type_test_bases = []
 class DeviceTypeTestBase(TestCase):
     device_type = 'generic_device_type'
 
+    # Precision is a thread-local setting since it may be overriden per test
+    _tls = threading.local()
+    _tls.precision = TestCase.precision
+
+    @property
+    def precision(self):
+        return self._tls.precision
+
+    @precision.setter
+    def precision(self, prec):
+        self._tls.precision = prec
+
     # Returns a string representing the device that single device tests should use.
     # Note: single device tests use this device exclusively.
     @classmethod
@@ -145,6 +158,11 @@ class DeviceTypeTestBase(TestCase):
         if not hasattr(test, 'dtypes'):
             return None
         return test.dtypes.get(cls.device_type, test.dtypes.get('all', None))
+
+    def _get_precision_override(self, test, dtype):
+        if not hasattr(test, 'precision_overrides'):
+            return self.precision
+        return test.precision_overrides.get(dtype, self.precision)
 
     # Creates device-specific tests.
     @classmethod
@@ -170,7 +188,16 @@ class DeviceTypeTestBase(TestCase):
                 @wraps(test)
                 def instantiated_test(self, test=test, dtype=dtype):
                     device_arg = cls.get_primary_device() if not hasattr(test, 'num_required_devices') else cls.get_all_devices()
-                    return test(self, device_arg, dtype)
+                    # Sets precision and runs test
+                    # Note: precision is reset after the test is run
+                    guard_precision = self.precision
+                    try :
+                        self.precision = self._get_precision_override(test, dtype)
+                        result = test(self, device_arg, dtype)
+                    finally:
+                        self.precision = guard_precision
+
+                    return result
 
                 setattr(cls, dtype_test_name, instantiated_test)
 
@@ -362,6 +389,32 @@ class deviceCountAtLeast(object):
             return fn(slf, devices, *args, **kwargs)
 
         return multi_fn
+
+
+# Specifies per-dtype precision overrides.
+# Ex.
+#
+# @overridePrecision(torch.half : 1e-2, torch.float : 1e-4)
+# @dtypes(torch.half, torch.float, torch.double)
+# def test_X(self, device, dtype):
+#   ...
+#
+# When the test is instantiated its class's precision will be set to the
+# corresponding override, if it exists.
+# self.precision can be accessed directly, and it also controls the behavior of
+# functions like self.assertEqual().
+class overridePrecision(object):
+
+    def __init__(self, d):
+        assert isinstance(d, dict), "overridePrecision not given a dtype : precision dict!"
+        for dtype, prec in d.items():
+            assert isinstance(dtype, torch.dtype), "overridePrecision given unknown dtype {0}".format(dtype)
+
+        self.d = d
+
+    def __call__(self, fn):
+        fn.precision_overrides = self.d
+        return fn
 
 
 # Decorator that instantiates a variant of the test for each given dtype.

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -35,7 +35,7 @@ from common_utils import TestCase, iter_indices, TEST_NUMPY, TEST_SCIPY, TEST_MK
 from multiprocessing.reduction import ForkingPickler
 from common_device_type import instantiate_device_type_tests, \
     skipCPUIfNoLapack, skipCUDAIfNoMagma, skipCUDAIfRocm, onlyCUDA, onlyCPU, \
-    dtypes, dtypesIfCUDA, deviceCountAtLeast, skipCUDAIf
+    dtypes, dtypesIfCUDA, deviceCountAtLeast, skipCUDAIf, overridePrecision
 import torch.backends.quantized
 
 
@@ -12534,38 +12534,33 @@ class TestTorchDeviceType(TestCase):
             run_test(m, v2, v1, lambda x: x.transpose(0, 1))
 
     @onlyCPU
-    def test_addmv(self, device):
-        types = {
-            'torch.DoubleTensor': 1e-8,
-            'torch.FloatTensor': 1e-4,
-            'torch.BFloat16Tensor': 1e-0,
-        }
-        for tname, prec in types.items():
-            t = torch.randn(10, device=device).type(tname)
-            m = torch.randn(10, 100, device=device).type(tname)
-            v = torch.randn(100, device=device).type(tname)
-            res1 = torch.addmv(t, m, v)
-            res2 = torch.zeros(10, device=device).type(tname)
-            res2 += t
-            for i in range(10):
-                for j in range(100):
-                    res2[i] += m[i, j] * v[j]
+    @overridePrecision({torch.bfloat16: 1e-0, torch.float: 1e-4, torch.double: 1e-8})
+    @dtypes(torch.bfloat16, torch.float, torch.double)
+    def test_addmv(self, device, dtype):
+        t = torch.randn(10, device=device).to(dtype)
+        m = torch.randn(10, 100, device=device).to(dtype)
+        v = torch.randn(100, device=device).to(dtype)
+        res1 = torch.addmv(t, m, v)
+        res2 = torch.zeros(10, dtype=dtype, device=device)
+        res2 += t
+        for i in range(10):
+            for j in range(100):
+                res2[i] += m[i, j] * v[j]
 
-            self.assertEqual(res1, res2, prec)
+        self.assertEqual(res1, res2)
 
         # Test 0-strided
-        for tname, prec in types.items():
-            t = torch.randn(1, device=device).type(tname).expand(10)
-            m = torch.randn(10, 1, device=device).type(tname).expand(10, 100)
-            v = torch.randn(100, device=device).type(tname)
-            res1 = torch.addmv(t, m, v)
-            res2 = torch.zeros(10, device=device).type(tname)
-            res2 += t
-            for i in range(10):
-                for j in range(100):
-                    res2[i] += m[i, j] * v[j]
+        t = torch.randn(1, device=device).to(dtype).expand(10)
+        m = torch.randn(10, 1, device=device).to(dtype).expand(10, 100)
+        v = torch.randn(100, device=device).to(dtype)
+        res1 = torch.addmv(t, m, v)
+        res2 = torch.zeros(10, dtype=dtype, device=device)
+        res2 += t
+        for i in range(10):
+            for j in range(100):
+                res2[i] += m[i, j] * v[j]
 
-            self.assertEqual(res1, res2, prec)
+        self.assertEqual(res1, res2)
 
     @onlyCPU
     def test_addmm(self, device):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -35,7 +35,7 @@ from common_utils import TestCase, iter_indices, TEST_NUMPY, TEST_SCIPY, TEST_MK
 from multiprocessing.reduction import ForkingPickler
 from common_device_type import instantiate_device_type_tests, \
     skipCPUIfNoLapack, skipCUDAIfNoMagma, skipCUDAIfRocm, onlyCUDA, onlyCPU, \
-    dtypes, dtypesIfCUDA, deviceCountAtLeast, skipCUDAIf, overridePrecision
+    dtypes, dtypesIfCUDA, deviceCountAtLeast, skipCUDAIf, precisionOverride
 import torch.backends.quantized
 
 
@@ -12534,7 +12534,7 @@ class TestTorchDeviceType(TestCase):
             run_test(m, v2, v1, lambda x: x.transpose(0, 1))
 
     @onlyCPU
-    @overridePrecision({torch.bfloat16: 1e-0, torch.float: 1e-4, torch.double: 1e-8})
+    @precisionOverride({torch.bfloat16: 1e-0, torch.float: 1e-4, torch.double: 1e-8})
     @dtypes(torch.bfloat16, torch.float, torch.double)
     def test_addmv(self, device, dtype):
         t = torch.randn(10, device=device).to(dtype)


### PR DESCRIPTION
Adds the @overridePrecision decorator, which allows device generic tests to specify per-dtype precision overrides. 

Precision is overridden on the test class instance itself, and so is thread-local (so that running multiple tests in parallel will not conflict). It can be accessed directly from a test with self.precision, as before. 

