### PR TITLE
Back out "Revert D17936166: [wip] Constexpr type ids"

### DIFF
--- a/c10/test/util/ConstexprCrc_test.cpp
+++ b/c10/test/util/ConstexprCrc_test.cpp
@@ -1,0 +1,23 @@
+#include <c10/util/ConstexprCrc.h>
+
+using c10::util::crc64_t;
+
+namespace {
+template <size_t N>
+constexpr crc64_t crc64(const char (&input)[N]) {
+  return c10::util::crc64(input, N - 1);
+}
+} // namespace
+
+// generic tests
+static_assert(
+    crc64("MyTestString") == crc64("MyTestString"),
+    "crc64 is deterministic");
+static_assert(
+    crc64("MyTestString1") != crc64("MyTestString2"),
+    "different strings, different result");
+
+// check concrete expected values (for CRC64 with Jones coefficients and an init
+// value of 0)
+static_assert(crc64_t{0} == crc64(""), "");
+static_assert(crc64_t{0xe9c6d914c4b8d9ca} == crc64("123456789"), "");

--- a/c10/test/util/TypeIndex_test.cpp
+++ b/c10/test/util/TypeIndex_test.cpp
@@ -1,0 +1,53 @@
+#include <c10/util/Metaprogramming.h>
+#include <c10/util/TypeIndex.h>
+
+using c10::util::get_type_index;
+
+namespace {
+
+static_assert(get_type_index<int>() == get_type_index<int>(), "");
+static_assert(get_type_index<float>() == get_type_index<float>(), "");
+static_assert(get_type_index<int>() != get_type_index<float>(), "");
+static_assert(
+    get_type_index<int(double, double)>() ==
+        get_type_index<int(double, double)>(),
+    "");
+static_assert(
+    get_type_index<int(double, double)>() != get_type_index<int(double)>(),
+    "");
+static_assert(
+    get_type_index<int(double, double)>() ==
+        get_type_index<int (*)(double, double)>(),
+    "");
+static_assert(
+    get_type_index<std::function<int(double, double)>>() ==
+        get_type_index<std::function<int(double, double)>>(),
+    "");
+static_assert(
+    get_type_index<std::function<int(double, double)>>() !=
+        get_type_index<std::function<int(double)>>(),
+    "");
+
+static_assert(get_type_index<int>() == get_type_index<int&>(), "");
+static_assert(get_type_index<int>() == get_type_index<int&&>(), "");
+static_assert(get_type_index<int>() == get_type_index<const int&>(), "");
+static_assert(get_type_index<int>() == get_type_index<const int>(), "");
+static_assert(get_type_index<const int>() == get_type_index<int&>(), "");
+static_assert(get_type_index<int>() != get_type_index<int*>(), "");
+static_assert(get_type_index<int*>() != get_type_index<int**>(), "");
+static_assert(
+    get_type_index<int(double&, double)>() !=
+        get_type_index<int(double, double)>(),
+    "");
+
+struct Dummy final {};
+struct Functor final {
+  int64_t operator()(uint32_t, Dummy&&, const Dummy&) const;
+};
+static_assert(
+    get_type_index<int64_t(uint32_t, Dummy&&, const Dummy&)>() ==
+        get_type_index<
+            c10::guts::infer_function_traits_t<Functor>::func_type>(),
+    "");
+
+} // namespace

--- a/c10/util/ConstexprCrc.h
+++ b/c10/util/ConstexprCrc.h
@@ -1,0 +1,137 @@
+#pragma once
+
+#include <c10/util/IdWrapper.h>
+#include <cstddef>
+#include <cstdint>
+
+namespace c10 {
+namespace util {
+
+namespace detail {
+constexpr uint64_t crc64_table[] = {
+    0x0000000000000000, 0x7ad870c830358979, 0xf5b0e190606b12f2,
+    0x8f689158505e9b8b, 0xc038e5739841b68f, 0xbae095bba8743ff6,
+    0x358804e3f82aa47d, 0x4f50742bc81f2d04, 0xab28ecb46814fe75,
+    0xd1f09c7c5821770c, 0x5e980d24087fec87, 0x24407dec384a65fe,
+    0x6b1009c7f05548fa, 0x11c8790fc060c183, 0x9ea0e857903e5a08,
+    0xe478989fa00bd371, 0x7d08ff3b88be6f81, 0x07d08ff3b88be6f8,
+    0x88b81eabe8d57d73, 0xf2606e63d8e0f40a, 0xbd301a4810ffd90e,
+    0xc7e86a8020ca5077, 0x4880fbd87094cbfc, 0x32588b1040a14285,
+    0xd620138fe0aa91f4, 0xacf86347d09f188d, 0x2390f21f80c18306,
+    0x594882d7b0f40a7f, 0x1618f6fc78eb277b, 0x6cc0863448deae02,
+    0xe3a8176c18803589, 0x997067a428b5bcf0, 0xfa11fe77117cdf02,
+    0x80c98ebf2149567b, 0x0fa11fe77117cdf0, 0x75796f2f41224489,
+    0x3a291b04893d698d, 0x40f16bccb908e0f4, 0xcf99fa94e9567b7f,
+    0xb5418a5cd963f206, 0x513912c379682177, 0x2be1620b495da80e,
+    0xa489f35319033385, 0xde51839b2936bafc, 0x9101f7b0e12997f8,
+    0xebd98778d11c1e81, 0x64b116208142850a, 0x1e6966e8b1770c73,
+    0x8719014c99c2b083, 0xfdc17184a9f739fa, 0x72a9e0dcf9a9a271,
+    0x08719014c99c2b08, 0x4721e43f0183060c, 0x3df994f731b68f75,
+    0xb29105af61e814fe, 0xc849756751dd9d87, 0x2c31edf8f1d64ef6,
+    0x56e99d30c1e3c78f, 0xd9810c6891bd5c04, 0xa3597ca0a188d57d,
+    0xec09088b6997f879, 0x96d1784359a27100, 0x19b9e91b09fcea8b,
+    0x636199d339c963f2, 0xdf7adabd7a6e2d6f, 0xa5a2aa754a5ba416,
+    0x2aca3b2d1a053f9d, 0x50124be52a30b6e4, 0x1f423fcee22f9be0,
+    0x659a4f06d21a1299, 0xeaf2de5e82448912, 0x902aae96b271006b,
+    0x74523609127ad31a, 0x0e8a46c1224f5a63, 0x81e2d7997211c1e8,
+    0xfb3aa75142244891, 0xb46ad37a8a3b6595, 0xceb2a3b2ba0eecec,
+    0x41da32eaea507767, 0x3b024222da65fe1e, 0xa2722586f2d042ee,
+    0xd8aa554ec2e5cb97, 0x57c2c41692bb501c, 0x2d1ab4dea28ed965,
+    0x624ac0f56a91f461, 0x1892b03d5aa47d18, 0x97fa21650afae693,
+    0xed2251ad3acf6fea, 0x095ac9329ac4bc9b, 0x7382b9faaaf135e2,
+    0xfcea28a2faafae69, 0x8632586aca9a2710, 0xc9622c4102850a14,
+    0xb3ba5c8932b0836d, 0x3cd2cdd162ee18e6, 0x460abd1952db919f,
+    0x256b24ca6b12f26d, 0x5fb354025b277b14, 0xd0dbc55a0b79e09f,
+    0xaa03b5923b4c69e6, 0xe553c1b9f35344e2, 0x9f8bb171c366cd9b,
+    0x10e3202993385610, 0x6a3b50e1a30ddf69, 0x8e43c87e03060c18,
+    0xf49bb8b633338561, 0x7bf329ee636d1eea, 0x012b592653589793,
+    0x4e7b2d0d9b47ba97, 0x34a35dc5ab7233ee, 0xbbcbcc9dfb2ca865,
+    0xc113bc55cb19211c, 0x5863dbf1e3ac9dec, 0x22bbab39d3991495,
+    0xadd33a6183c78f1e, 0xd70b4aa9b3f20667, 0x985b3e827bed2b63,
+    0xe2834e4a4bd8a21a, 0x6debdf121b863991, 0x1733afda2bb3b0e8,
+    0xf34b37458bb86399, 0x8993478dbb8deae0, 0x06fbd6d5ebd3716b,
+    0x7c23a61ddbe6f812, 0x3373d23613f9d516, 0x49aba2fe23cc5c6f,
+    0xc6c333a67392c7e4, 0xbc1b436e43a74e9d, 0x95ac9329ac4bc9b5,
+    0xef74e3e19c7e40cc, 0x601c72b9cc20db47, 0x1ac40271fc15523e,
+    0x5594765a340a7f3a, 0x2f4c0692043ff643, 0xa02497ca54616dc8,
+    0xdafce7026454e4b1, 0x3e847f9dc45f37c0, 0x445c0f55f46abeb9,
+    0xcb349e0da4342532, 0xb1eceec59401ac4b, 0xfebc9aee5c1e814f,
+    0x8464ea266c2b0836, 0x0b0c7b7e3c7593bd, 0x71d40bb60c401ac4,
+    0xe8a46c1224f5a634, 0x927c1cda14c02f4d, 0x1d148d82449eb4c6,
+    0x67ccfd4a74ab3dbf, 0x289c8961bcb410bb, 0x5244f9a98c8199c2,
+    0xdd2c68f1dcdf0249, 0xa7f41839ecea8b30, 0x438c80a64ce15841,
+    0x3954f06e7cd4d138, 0xb63c61362c8a4ab3, 0xcce411fe1cbfc3ca,
+    0x83b465d5d4a0eece, 0xf96c151de49567b7, 0x76048445b4cbfc3c,
+    0x0cdcf48d84fe7545, 0x6fbd6d5ebd3716b7, 0x15651d968d029fce,
+    0x9a0d8ccedd5c0445, 0xe0d5fc06ed698d3c, 0xaf85882d2576a038,
+    0xd55df8e515432941, 0x5a3569bd451db2ca, 0x20ed197575283bb3,
+    0xc49581ead523e8c2, 0xbe4df122e51661bb, 0x3125607ab548fa30,
+    0x4bfd10b2857d7349, 0x04ad64994d625e4d, 0x7e7514517d57d734,
+    0xf11d85092d094cbf, 0x8bc5f5c11d3cc5c6, 0x12b5926535897936,
+    0x686de2ad05bcf04f, 0xe70573f555e26bc4, 0x9ddd033d65d7e2bd,
+    0xd28d7716adc8cfb9, 0xa85507de9dfd46c0, 0x273d9686cda3dd4b,
+    0x5de5e64efd965432, 0xb99d7ed15d9d8743, 0xc3450e196da80e3a,
+    0x4c2d9f413df695b1, 0x36f5ef890dc31cc8, 0x79a59ba2c5dc31cc,
+    0x037deb6af5e9b8b5, 0x8c157a32a5b7233e, 0xf6cd0afa9582aa47,
+    0x4ad64994d625e4da, 0x300e395ce6106da3, 0xbf66a804b64ef628,
+    0xc5bed8cc867b7f51, 0x8aeeace74e645255, 0xf036dc2f7e51db2c,
+    0x7f5e4d772e0f40a7, 0x05863dbf1e3ac9de, 0xe1fea520be311aaf,
+    0x9b26d5e88e0493d6, 0x144e44b0de5a085d, 0x6e963478ee6f8124,
+    0x21c640532670ac20, 0x5b1e309b16452559, 0xd476a1c3461bbed2,
+    0xaeaed10b762e37ab, 0x37deb6af5e9b8b5b, 0x4d06c6676eae0222,
+    0xc26e573f3ef099a9, 0xb8b627f70ec510d0, 0xf7e653dcc6da3dd4,
+    0x8d3e2314f6efb4ad, 0x0256b24ca6b12f26, 0x788ec2849684a65f,
+    0x9cf65a1b368f752e, 0xe62e2ad306bafc57, 0x6946bb8b56e467dc,
+    0x139ecb4366d1eea5, 0x5ccebf68aecec3a1, 0x2616cfa09efb4ad8,
+    0xa97e5ef8cea5d153, 0xd3a62e30fe90582a, 0xb0c7b7e3c7593bd8,
+    0xca1fc72bf76cb2a1, 0x45775673a732292a, 0x3faf26bb9707a053,
+    0x70ff52905f188d57, 0x0a2722586f2d042e, 0x854fb3003f739fa5,
+    0xff97c3c80f4616dc, 0x1bef5b57af4dc5ad, 0x61372b9f9f784cd4,
+    0xee5fbac7cf26d75f, 0x9487ca0fff135e26, 0xdbd7be24370c7322,
+    0xa10fceec0739fa5b, 0x2e675fb4576761d0, 0x54bf2f7c6752e8a9,
+    0xcdcf48d84fe75459, 0xb71738107fd2dd20, 0x387fa9482f8c46ab,
+    0x42a7d9801fb9cfd2, 0x0df7adabd7a6e2d6, 0x772fdd63e7936baf,
+    0xf8474c3bb7cdf024, 0x829f3cf387f8795d, 0x66e7a46c27f3aa2c,
+    0x1c3fd4a417c62355, 0x935745fc4798b8de, 0xe98f353477ad31a7,
+    0xa6df411fbfb21ca3, 0xdc0731d78f8795da, 0x536fa08fdfd90e51,
+    0x29b7d047efec8728,
+};
+
+inline C10_HOST_CONSTEXPR uint64_t
+crc64impl(uint64_t accumulator, const char* data, size_t size) {
+#if __cpp_constexpr >= 201304
+  // if we are in C++14, just use a for loop. This compiles faster.
+  for (size_t i = 0; i < size; ++i) {
+    accumulator =
+        crc64_table[(accumulator ^ data[i]) & 0xFF] ^ (accumulator >> 8);
+  }
+  return accumulator;
+#else
+  // if we are in C++11, we need to do it recursively because of constexpr
+  // restrictions.
+  return (size == 0)
+      ? accumulator
+      : crc64impl(
+            crc64_table[(accumulator ^ *data) & 0xFF] ^ (accumulator >> 8),
+            data + 1,
+            size - 1);
+#endif
+}
+} // namespace detail
+
+struct crc64_t final : IdWrapper<crc64_t, uint64_t> {
+  constexpr crc64_t(uint64_t checksum) : IdWrapper(checksum) {}
+  constexpr uint64_t checksum() const {
+    return this->underlyingId();
+  }
+};
+
+// CRC64 with Jones coefficients and an init value of 0.
+inline C10_HOST_CONSTEXPR crc64_t crc64(const char* data, size_t size) {
+  return crc64_t{detail::crc64impl(0, data, size)};
+}
+} // namespace util
+} // namespace c10
+
+// Allow usage of crc64_t in std::unordered_set
+C10_DEFINE_HASH_FOR_IDWRAPPER(c10::util::crc64_t);

--- a/c10/util/IdWrapper.h
+++ b/c10/util/IdWrapper.h
@@ -48,7 +48,7 @@ class IdWrapper {
   //      Fix this once we don't need GCC 4.8 anymore.
   friend constexpr bool operator==(
       const concrete_type& lhs,
-      const concrete_type& rhs) {
+      const concrete_type& rhs) noexcept {
     return lhs.id_ == rhs.id_;
   }
 
@@ -57,7 +57,7 @@ class IdWrapper {
   //      Fix this once we don't need GCC 4.8 anymore.
   friend constexpr bool operator!=(
       const concrete_type& lhs,
-      const concrete_type& rhs) {
+      const concrete_type& rhs) noexcept {
     return !(lhs == rhs);
   }
 

--- a/c10/util/TypeIndex.h
+++ b/c10/util/TypeIndex.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <c10/util/C++17.h>
+#include <c10/util/ConstexprCrc.h>
+#include <c10/util/IdWrapper.h>
+#include <cinttypes>
+#include <functional>
+
+namespace c10 {
+namespace util {
+
+struct type_index final : IdWrapper<type_index, uint64_t> {
+  constexpr explicit type_index(uint64_t checksum) : IdWrapper(checksum) {}
+
+  // Allow usage in std::map / std::set
+  // TODO Disallow this and rather use std::unordered_map/set everywhere
+  friend constexpr bool operator<(type_index lhs, type_index rhs) noexcept {
+    return lhs.underlyingId() < rhs.underlyingId();
+  }
+
+  friend std::ostream& operator<<(std::ostream& stream, type_index typeId) {
+    return stream << typeId.underlyingId();
+  }
+};
+
+namespace detail {
+
+#if !defined(__clang__) && !defined(_MSC_VER) && defined(__GNUC__) && \
+    __GNUC__ < 5
+// Getting __PRETTY_FUNCTION__ at compile time only works with GCC >= 5
+#error "You're running a too old version of GCC. We need GCC 5 or later."
+#endif
+
+template <typename T>
+inline C10_HOST_CONSTEXPR uint64_t type_index_impl() noexcept {
+// Idea: __PRETTY_FUNCTION__ (or __FUNCSIG__ on msvc) contains a qualified name
+// of this function, including its template parameter, i.e. including the
+// type we want an id for. We use this name and run crc64 on it to get a type
+// id.
+#if defined(_MSC_VER)
+  return crc64(__FUNCSIG__, sizeof(__FUNCSIG__)).checksum();
+#else
+  return crc64(__PRETTY_FUNCTION__, sizeof(__PRETTY_FUNCTION__)).checksum();
+#endif
+}
+
+} // namespace detail
+
+template <typename T>
+inline C10_HOST_CONSTEXPR type_index get_type_index() noexcept {
+#if !defined(__CUDA_ARCH__)
+  // To enforce that this is really computed at compile time, we pass the crc
+  // checksum through std::integral_constant.
+  return type_index{std::integral_constant<
+      uint64_t,
+      detail::type_index_impl<guts::remove_cv_t<guts::decay_t<T>>>()>::value};
+#else
+  // nvcc unfortunately doesn't like this being constexpr in device code
+  return type_index{
+      detail::type_index_impl<guts::remove_cv_t<guts::decay_t<T>>>()};
+#endif
+}
+
+} // namespace util
+} // namespace c10
+
+C10_DEFINE_HASH_FOR_IDWRAPPER(c10::util::type_index);

--- a/c10/util/typeid.cpp
+++ b/c10/util/typeid.cpp
@@ -27,6 +27,11 @@ const TypeMetaData _typeMetaDataInstance_uninitialized_ = detail::TypeMetaData(
     TypeIdentifier::uninitialized(),
     "nullptr (uninitialized)");
 
+C10_EXPORT CollisionChecker& collisionChecker_() {
+  static CollisionChecker singleton;
+  return singleton;
+}
+
 } // namespace detail
 
 // TODO Inlineable on non-MSVC like other preallocated ids?
@@ -36,56 +41,41 @@ C10_EXPORT const detail::TypeMetaData* TypeMeta::_typeMetaDataInstance<
   return &detail::_typeMetaDataInstance_uninitialized_;
 }
 
-TypeIdentifier TypeIdentifier::createTypeId() {
-  static std::atomic<TypeIdentifier::underlying_type> counter(
-      TypeMeta::Id<_CaffeHighestPreallocatedTypeId>().underlyingId());
-  const TypeIdentifier::underlying_type new_value = ++counter;
-  if (new_value ==
-      std::numeric_limits<TypeIdentifier::underlying_type>::max()) {
-    throw std::logic_error(
-        "Ran out of available type ids. If you need more than 2^16 CAFFE_KNOWN_TYPEs, we need to increase TypeIdentifier to use more than 16 bit.");
-  }
-  return TypeIdentifier(new_value);
-}
-
-CAFFE_DEFINE_PREALLOCATED_KNOWN_TYPE(0, uint8_t)
-CAFFE_DEFINE_PREALLOCATED_KNOWN_TYPE(1, int8_t)
-CAFFE_DEFINE_PREALLOCATED_KNOWN_TYPE(2, int16_t)
-CAFFE_DEFINE_PREALLOCATED_KNOWN_TYPE(3, int)
-CAFFE_DEFINE_PREALLOCATED_KNOWN_TYPE(4, int64_t)
-CAFFE_DEFINE_PREALLOCATED_KNOWN_TYPE(5, at::Half)
-CAFFE_DEFINE_PREALLOCATED_KNOWN_TYPE(6, float)
-CAFFE_DEFINE_PREALLOCATED_KNOWN_TYPE(7, double)
-CAFFE_DEFINE_PREALLOCATED_KNOWN_TYPE(8, at::ComplexHalf)
-CAFFE_DEFINE_PREALLOCATED_KNOWN_TYPE(9, std::complex<float>)
-CAFFE_DEFINE_PREALLOCATED_KNOWN_TYPE(10, std::complex<double>)
+CAFFE_KNOWN_TYPE(uint8_t)
+CAFFE_KNOWN_TYPE(int8_t)
+CAFFE_KNOWN_TYPE(int16_t)
+CAFFE_KNOWN_TYPE(int)
+CAFFE_KNOWN_TYPE(int64_t)
+CAFFE_KNOWN_TYPE(at::Half)
+CAFFE_KNOWN_TYPE(float)
+CAFFE_KNOWN_TYPE(double)
+CAFFE_KNOWN_TYPE(at::ComplexHalf)
+CAFFE_KNOWN_TYPE(std::complex<float>)
+CAFFE_KNOWN_TYPE(std::complex<double>)
 // 11 = undefined type id
 // 12 = Tensor (defined in tensor.cc)
-CAFFE_DEFINE_PREALLOCATED_KNOWN_TYPE(13, std::string)
-CAFFE_DEFINE_PREALLOCATED_KNOWN_TYPE(14, bool)
-CAFFE_DEFINE_PREALLOCATED_KNOWN_TYPE(15, uint16_t)
-CAFFE_DEFINE_PREALLOCATED_KNOWN_TYPE(16, char)
-CAFFE_DEFINE_PREALLOCATED_KNOWN_TYPE(17, std::unique_ptr<std::mutex>)
-CAFFE_DEFINE_PREALLOCATED_KNOWN_TYPE(18, std::unique_ptr<std::atomic<bool>>)
-CAFFE_DEFINE_PREALLOCATED_KNOWN_TYPE(19, std::vector<int32_t>)
-CAFFE_DEFINE_PREALLOCATED_KNOWN_TYPE(20, std::vector<int64_t>)
-CAFFE_DEFINE_PREALLOCATED_KNOWN_TYPE(21, std::vector<unsigned long>)
-CAFFE_DEFINE_PREALLOCATED_KNOWN_TYPE(22, bool*)
-CAFFE_DEFINE_PREALLOCATED_KNOWN_TYPE(23, char*)
-CAFFE_DEFINE_PREALLOCATED_KNOWN_TYPE(24, int*)
+CAFFE_KNOWN_TYPE(std::string)
+CAFFE_KNOWN_TYPE(bool)
+CAFFE_KNOWN_TYPE(uint16_t)
+CAFFE_KNOWN_TYPE(char)
+CAFFE_KNOWN_TYPE(std::unique_ptr<std::mutex>)
+CAFFE_KNOWN_TYPE(std::unique_ptr<std::atomic<bool>>)
+CAFFE_KNOWN_TYPE(std::vector<int32_t>)
+CAFFE_KNOWN_TYPE(std::vector<int64_t>)
+CAFFE_KNOWN_TYPE(std::vector<unsigned long>)
+CAFFE_KNOWN_TYPE(bool*)
+CAFFE_KNOWN_TYPE(char*)
+CAFFE_KNOWN_TYPE(int*)
 
 // see typeid.h for details.
-CAFFE_DEFINE_PREALLOCATED_KNOWN_TYPE(25, detail::_guard_long_unique<long>);
-CAFFE_DEFINE_PREALLOCATED_KNOWN_TYPE(
-    26,
-    detail::_guard_long_unique<std::vector<long>>)
+CAFFE_KNOWN_TYPE(detail::_guard_long_unique<long>);
+CAFFE_KNOWN_TYPE(detail::_guard_long_unique<std::vector<long>>)
 
-CAFFE_DEFINE_PREALLOCATED_KNOWN_TYPE(27, float*)
-CAFFE_DEFINE_PREALLOCATED_KNOWN_TYPE(28, at::Half*)
-CAFFE_DEFINE_PREALLOCATED_KNOWN_TYPE(29, c10::qint8)
-CAFFE_DEFINE_PREALLOCATED_KNOWN_TYPE(30, c10::quint8)
-CAFFE_DEFINE_PREALLOCATED_KNOWN_TYPE(31, c10::qint32)
-CAFFE_DEFINE_PREALLOCATED_KNOWN_TYPE(32, at::BFloat16)
-CAFFE_DEFINE_PREALLOCATED_KNOWN_TYPE(33, _CaffeHighestPreallocatedTypeId)
+CAFFE_KNOWN_TYPE(float*)
+CAFFE_KNOWN_TYPE(at::Half*)
+CAFFE_KNOWN_TYPE(c10::qint8)
+CAFFE_KNOWN_TYPE(c10::quint8)
+CAFFE_KNOWN_TYPE(c10::qint32)
+CAFFE_KNOWN_TYPE(at::BFloat16)
 
 } // namespace caffe2

--- a/c10/util/typeid.h
+++ b/c10/util/typeid.h
@@ -24,10 +24,12 @@
 #include <c10/util/Half.h>
 #include <c10/util/IdWrapper.h>
 #include <c10/util/Type.h>
+#include <c10/util/TypeIndex.h>
 #include <c10/util/qint32.h>
 #include <c10/util/qint8.h>
 #include <c10/util/quint8.h>
 #include <c10/util/BFloat16.h>
+#include <c10/util/flat_hash_map.h>
 
 /*
  * TypeIdentifier is a small type containing an id.
@@ -60,17 +62,10 @@ namespace caffe2 {
  * dtype of tensors.
  */
 class C10_API TypeIdentifier final
-    : public at::IdWrapper<TypeIdentifier, uint16_t> {
+    : public at::IdWrapper<TypeIdentifier, c10::util::type_index> {
  public:
-  static TypeIdentifier createTypeId();
-
   friend std::ostream& operator<<(std::ostream& stream, TypeIdentifier typeId);
   friend bool operator<(TypeIdentifier lhs, TypeIdentifier rhs);
-
-  // 0 is uint8_t (due to ScalarType BC constraint)
-  static constexpr TypeIdentifier uninitialized() {
-    return TypeIdentifier(11);
-  }
 
   /**
    * Returns the unique id for the given type T. The id is unique for the type T
@@ -80,11 +75,18 @@ class C10_API TypeIdentifier final
    * is generated during run-time. Do NOT serialize the id for storage.
    */
   template <typename T>
-  C10_API static TypeIdentifier Get();
+  static C10_HOST_CONSTEXPR TypeIdentifier Get() noexcept {
+    return TypeIdentifier(c10::util::get_type_index<T>());
+  }
+
+  static constexpr TypeIdentifier uninitialized() {
+    return TypeIdentifier(
+        c10::util::type_index{11}); // 11 is Undefined from ScalarType
+  }
 
  private:
-  constexpr explicit TypeIdentifier(uint16_t id) : IdWrapper(id) {}
-  friend class TypeMeta;
+  constexpr explicit TypeIdentifier(c10::util::type_index id) : IdWrapper(id) {}
+  friend class TypeMeta; // TODO Is this friend an issue?
 };
 
 // Allow usage in std::map / std::set
@@ -303,15 +305,39 @@ constexpr const char* _typeName(const char* literalName) noexcept {
 }
 #endif
 
+// CollisionChecker is a safeguard to make sure none of our types generate
+// the same type id. Since we use crc64 of the string type name, there's a
+// (very) slight possibility of collisions and we want to be sure that doesn't
+// happen.
+class CollisionChecker final {
+public:
+  // Check that there is no type registered with this id and a different name
+  void check(TypeIdentifier id, const std::string& name) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto find = typeids_.find(id);
+    if (find != typeids_.end()) {
+      AT_ASSERT(find->second == name, "Typeid collision detected for ", find->second, " and ", name, ".");
+    } else {
+      typeids_.emplace(id, name);
+    }
+  }
+private:
+  std::mutex mutex_;
+  ska::flat_hash_map<TypeIdentifier, std::string> typeids_;
+};
+C10_API CollisionChecker& collisionChecker_();
+
 template <class T>
 inline TypeMetaData _makeTypeMetaDataInstance(const char* typeName) {
+  C10_HOST_CONSTEXPR_VAR auto typeId = TypeIdentifier::Get<T>();
+  collisionChecker_().check(typeId, typeName);
   return {sizeof(T),
           _PickNew<T>(),
           _PickPlacementNew<T>(),
           _PickCopy<T>(),
           _PickPlacementDelete<T>(),
           _PickDelete<T>(),
-          TypeIdentifier::Get<T>(),
+          typeId,
           typeName};
 }
 
@@ -325,7 +351,7 @@ class _Uninitialized final {};
  * stores some additional data such as the item size and the name of the type
  * for run-time inspection.
  */
-class C10_API TypeMeta {
+class C10_API TypeMeta final {
  public:
   using New = detail::TypeMetaData::New;
   using PlacementNew = detail::TypeMetaData::PlacementNew;
@@ -341,77 +367,77 @@ class C10_API TypeMeta {
   /**
    * Copy constructor.
    */
-  constexpr TypeMeta(const TypeMeta& src) noexcept = default;
+  TypeMeta(const TypeMeta& src) noexcept = default;
 
   /**
    * Assignment operator.
    */
-  AT_CPP14_CONSTEXPR TypeMeta& operator=(const TypeMeta& src) noexcept =
-      default;
+  TypeMeta& operator=(const TypeMeta& src) noexcept = default;
 
-  constexpr TypeMeta(TypeMeta&& rhs) noexcept = default;
+  TypeMeta(TypeMeta&& rhs) noexcept = default;
 
  private:
   // TypeMeta can only be created by Make, making sure that we do not
   // create incorrectly mixed up TypeMeta objects.
-  explicit constexpr TypeMeta(const detail::TypeMetaData* data) noexcept
-      : data_(data) {}
+  explicit TypeMeta(const detail::TypeMetaData* data) noexcept
+  : data_(data) {
+  }
 
  public:
   /**
    * Returns the type id.
    */
-  constexpr TypeIdentifier id() const noexcept {
+  TypeIdentifier id() const noexcept {
     return data_->id_;
   }
   /**
    * Returns the size of the item.
    */
-  constexpr size_t itemsize() const noexcept {
+  size_t itemsize() const noexcept {
     return data_->itemsize_;
   }
-  constexpr New* newFn() const noexcept {
+  New* newFn() const noexcept {
     return data_->new_;
   }
   /**
    * Returns the placement new function pointer for individual items.
    */
-  constexpr PlacementNew* placementNew() const noexcept {
+  PlacementNew* placementNew() const noexcept {
     return data_->placementNew_;
   }
   /**
    * Returns the typed copy function pointer for individual iterms.
    */
-  constexpr Copy* copy() const noexcept {
+  Copy* copy() const noexcept {
     return data_->copy_;
   }
   /**
    * Returns the destructor function pointer for individual items.
    */
-  constexpr PlacementDelete* placementDelete() const noexcept {
+  PlacementDelete* placementDelete() const noexcept {
     return data_->placementDelete_;
   }
-  constexpr Delete* deleteFn() const noexcept {
+  Delete* deleteFn() const noexcept {
     return data_->delete_;
   }
   /**
    * Returns a printable name for the type.
    */
-  constexpr const char* name() const noexcept {
+  const char* name() const noexcept {
     return data_->name_;
   }
 
   friend bool operator==(const TypeMeta& lhs, const TypeMeta& rhs) noexcept;
 
   template <typename T>
-  constexpr bool Match() const noexcept {
+  bool Match() const noexcept {
     return (*this == Make<T>());
   }
 
   // Below are static functions that can be called by passing a specific type.
 
   template <class T>
-  static TypeIdentifier Id() noexcept {
+  static C10_HOST_CONSTEXPR TypeIdentifier Id() noexcept {
     return TypeIdentifier::Get<T>();
   }
 
@@ -459,7 +485,8 @@ C10_EXPORT const detail::TypeMetaData* TypeMeta::_typeMetaDataInstance<
     detail::_Uninitialized>() noexcept;
 
 inline TypeMeta::TypeMeta() noexcept
-    : data_(_typeMetaDataInstance<detail::_Uninitialized>()) {}
+    : data_(_typeMetaDataInstance<detail::_Uninitialized>()) {
+}
 
 inline bool operator==(const TypeMeta& lhs, const TypeMeta& rhs) noexcept {
   return (lhs.data_ == rhs.data_);
@@ -509,73 +536,21 @@ inline std::ostream& operator<<(
   TypeMeta::_typeMetaDataInstance<T>() noexcept {                       \
     return &C10_CONCATENATE(detail::_typeMetaDataInstance_, Counter);   \
   }
-#define CAFFE_KNOWN_TYPE(T)                                               \
-  template <>                                                             \
-  EXPORT_IF_NOT_GCC TypeIdentifier TypeIdentifier::Get<T>() {             \
-    static const TypeIdentifier type_id = TypeIdentifier::createTypeId(); \
-    return type_id;                                                       \
-  }                                                                       \
+#define CAFFE_KNOWN_TYPE(T) \
   _CAFFE_KNOWN_TYPE_DEFINE_TYPEMETADATA_INSTANCE(T, __COUNTER__)
 
 /**
  * CAFFE_DECLARE_PREALLOCATED_KNOWN_TYPE is used
- * to preallocate ids for types that are queried very often so that they
- * can be resolved at compile time. Please use CAFFE_KNOWN_TYPE() instead
- * for your own types to allocate dynamic ids for them.
+ * to preallocate numbers so they line up exactly
+ * with at::ScalarType's numbering.  All other numbers do not matter.
+ * Please use CAFFE_KNOWN_TYPE instead for your own types.
  */
-#ifdef _MSC_VER
-#define CAFFE_DECLARE_PREALLOCATED_KNOWN_TYPE(PreallocatedId, T) \
-  template <>                                                    \
-  inline C10_EXPORT TypeIdentifier TypeIdentifier::Get<T>() {    \
-    return TypeIdentifier(PreallocatedId);                       \
-  }                                                              \
-  namespace detail {                                             \
-  C10_API extern const TypeMetaData C10_CONCATENATE(             \
-      _typeMetaDataInstance_preallocated_,                       \
-      PreallocatedId);                                           \
-  }
-#define CAFFE_DEFINE_PREALLOCATED_KNOWN_TYPE(PreallocatedId, T)         \
-  namespace detail {                                                    \
-  C10_EXPORT const TypeMetaData C10_CONCATENATE(                        \
-      _typeMetaDataInstance_preallocated_,                              \
-      PreallocatedId) = _makeTypeMetaDataInstance<T>(_typeName<T>(#T)); \
-  }                                                                     \
-  template <>                                                           \
-  C10_EXPORT const detail::TypeMetaData*                                \
-  TypeMeta::_typeMetaDataInstance<T>() noexcept {                       \
-    return &C10_CONCATENATE(                                            \
-        detail::_typeMetaDataInstance_preallocated_, PreallocatedId);   \
-  }
-#else // _MSC_VER
 #define CAFFE_DECLARE_PREALLOCATED_KNOWN_TYPE(PreallocatedId, T)      \
   template <>                                                         \
-  inline C10_EXPORT TypeIdentifier TypeIdentifier::Get<T>() {         \
-    return TypeIdentifier(PreallocatedId);                            \
-  }                                                                   \
-  namespace detail {                                                  \
-  C10_EXPORT extern const TypeMetaData C10_CONCATENATE(               \
-      _typeMetaDataInstance_preallocated_,                            \
-      PreallocatedId);                                                \
-  }                                                                   \
-  template <>                                                         \
-  inline const detail::TypeMetaData*                                  \
-  TypeMeta::_typeMetaDataInstance<T>() noexcept {                     \
-    return &C10_CONCATENATE(                                          \
-        detail::_typeMetaDataInstance_preallocated_, PreallocatedId); \
+  constexpr inline TypeIdentifier TypeIdentifier::Get<T>() noexcept { \
+    return TypeIdentifier(c10::util::type_index{PreallocatedId});     \
   }
-#define CAFFE_DEFINE_PREALLOCATED_KNOWN_TYPE(PreallocatedId, T)         \
-  namespace detail {                                                    \
-  const TypeMetaData C10_CONCATENATE(                                   \
-      _typeMetaDataInstance_preallocated_,                              \
-      PreallocatedId) = _makeTypeMetaDataInstance<T>(_typeName<T>(#T)); \
-  }
-#endif
 
-// Note: we have preallocated the numbers so they line up exactly
-// with at::ScalarType's numbering.  All other numbers do not matter.
-
-struct _CaffeHighestPreallocatedTypeId final {};
-// TODO static_assert number of declare/define align
 CAFFE_DECLARE_PREALLOCATED_KNOWN_TYPE(0, uint8_t)
 CAFFE_DECLARE_PREALLOCATED_KNOWN_TYPE(1, int8_t)
 CAFFE_DECLARE_PREALLOCATED_KNOWN_TYPE(2, int16_t)
@@ -631,6 +606,5 @@ CAFFE_DECLARE_PREALLOCATED_KNOWN_TYPE(29, c10::qint8)
 CAFFE_DECLARE_PREALLOCATED_KNOWN_TYPE(30, c10::quint8)
 CAFFE_DECLARE_PREALLOCATED_KNOWN_TYPE(31, c10::qint32)
 CAFFE_DECLARE_PREALLOCATED_KNOWN_TYPE(32, at::BFloat16)
-CAFFE_DECLARE_PREALLOCATED_KNOWN_TYPE(33, _CaffeHighestPreallocatedTypeId)
 
 } // namespace caffe2

--- a/caffe2/core/tensor.cc
+++ b/caffe2/core/tensor.cc
@@ -5,7 +5,7 @@
 
 namespace caffe2 {
 
-CAFFE_DEFINE_PREALLOCATED_KNOWN_TYPE(12, Tensor);
+CAFFE_KNOWN_TYPE(Tensor);
 
 TensorPrinter::TensorPrinter(
     const std::string& tensor_name,

--- a/caffe2/opt/optimize_ideep.cc
+++ b/caffe2/opt/optimize_ideep.cc
@@ -459,14 +459,14 @@ bool fuseConvSum(repr::NNModule* nn, caffe2::Workspace* ws) {
     auto newOutputName = repr::nn::get<repr::Tensor>(sumInputX)->getName() +
         "_fusion_fix_" + std::to_string(i);
 
-    auto newInputTensor = util::make_unique<repr::Tensor>(newOutputName);
+    auto newInputTensor = c10::guts::make_unique<repr::Tensor>(newOutputName);
     auto newInput = nn->dataFlow.createNode(
         unique_dyn_cast<repr::NeuralNetData>(newInputTensor));
 
     nn->dataFlow.replaceNode(sumInputX, newInput);
     nn->dataFlow.deleteNode(sumInputX);
 
-    auto newOutputTensor = util::make_unique<repr::Tensor>(newOutputName);
+    auto newOutputTensor = c10::guts::make_unique<repr::Tensor>(newOutputName);
     auto newOutput = nn->dataFlow.createNode(
         unique_dyn_cast<repr::NeuralNetData>(newOutputTensor));
 
@@ -627,7 +627,7 @@ bool enforceFusionInplace(repr::NNModule* nn, caffe2::Workspace* ws) {
       return false;
     }
 
-    auto newOutputTensor = util::make_unique<repr::Tensor>(inputName);
+    auto newOutputTensor = c10::guts::make_unique<repr::Tensor>(inputName);
     auto newOutput = nn->dataFlow.createNode(
         unique_dyn_cast<repr::NeuralNetData>(newOutputTensor));
     nn->dataFlow.replaceNode(convOutput, newOutput);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #26628 [wip] Remove CAFFE_KNOWN_TYPE
* #26619 [wip] caffe2::TypeMeta uses compile time type names
* #26618 [wip] Compile time type names
* #26616 c10::string_view
* #28024 [wip] Remove preallocation of type ids
* **#28155 Back out "Revert D17936166: [wip] Constexpr type ids"**

Original commit changeset: 92c63a96dedd

Differential Revision: [D17964410](https://our.internmc.facebook.com/intern/diff/D17964410/)