### PR TITLE
msvc error C4805 fix

### DIFF
--- a/torch/csrc/jit/register_string_ops.cpp
+++ b/torch/csrc/jit/register_string_ops.cpp
@@ -170,7 +170,7 @@ auto reg_str_ops_2 =
                   bool is_upper = true;
                   for (size_t i = 0; i < string.size() && is_upper; ++i) {
                     char c = string[i];
-                    found_alpha |= ::isalpha(c);
+                    found_alpha |= static_cast<bool>(::isalpha(c));
                     is_upper &= (!::isalpha(c) || ::isupper(c));
                   }
                   return found_alpha && is_upper;
@@ -183,7 +183,7 @@ auto reg_str_ops_2 =
                   bool is_lower = true;
                   for (size_t i = 0; i < string.size() && is_lower; ++i) {
                     char c = string[i];
-                    found_alpha |= ::isalpha(c);
+                    found_alpha |= static_cast<bool>(::isalpha(c));
                     is_lower &= (!::isalpha(c) || ::islower(c));
                   }
                   return found_alpha && is_lower;


### PR DESCRIPTION
Fixes MSVC error message
```
15>d:\pytorch-scripts\caffe2_builders\v141\pytorch\torch\csrc\jit\register_string_ops.cpp(173): error C4805: '|=': unsafe mix of type 'bool' and type 'int' in operation
15>d:\pytorch-scripts\caffe2_builders\v141\pytorch\torch\csrc\jit\register_string_ops.cpp(173): error C4805: '|': unsafe mix of type 'bool' and type 'int' in operation
15>d:\pytorch-scripts\caffe2_builders\v141\pytorch\torch\csrc\jit\register_string_ops.cpp(186): error C4805: '|=': unsafe mix of type 'bool' and type 'int' in operation
15>d:\pytorch-scripts\caffe2_builders\v141\pytorch\torch\csrc\jit\register_string_ops.cpp(186): error C4805: '|': unsafe mix of type 'bool' and type 'int' in operation
```