### PR TITLE
Adding elementwise kernel also operating on index

### DIFF
--- a/aten/src/ATen/native/cuda/Loops.cuh
+++ b/aten/src/ATen/native/cuda/Loops.cuh
@@ -129,73 +129,6 @@ C10_HOST_DEVICE typename traits::result_type
 invoke(const func_t &f, char *const C10_RESTRICT data[], const index_t strides[], const ScalarType dtypes[], int i) {
   using Indices = c10::guts::make_index_sequence<traits::arity>;
   return invoke_impl<traits>(f, data, strides, dtypes, i, Indices{});
-
-template <typename traits, typename index_t, std::size_t... I>
-C10_HOST_DEVICE typename traits::ArgsTuple
-invoke_with_index_impl(const func_t &f, char* const C10_RESTRICT data[], const index_t strides[], int i, int idx,
-                       c10::guts::index_sequence<I...>) {
-  return f(*(typename traits::template arg<I>::type*)(data[I] + i * strides[I])..., idx);
-}
-
-template <typename func_t, typename index_t, typename traits = function_traits<func_t>>
-C10_HOST_DEVICE typename traits::result_type
-invoke_with_index(const func_t &f, char* const C10_RESTRICT data[], const index_t strides[], int i, int idx) {
-  // index at last position
-  using Indices = c10::guts::make_index_sequence<traits::arity-1>;
-  return invoke_with_index_impl<traits>(f, data, strides, i, idx, Indices{});
-}
-
-template <typename func_t>
-void gpu_kernel_with_index_impl(TensorIterator& iter, const func_t& f) {
-  using traits = function_traits<func_t>;
-  using arg0_t = typename traits::result_type;
-  // need to +1(output) and -1(index)
-  constexpr int ntensors = traits::arity;
-  TORCH_INTERNAL_ASSERT(iter.ntensors() == traits::arity);
-
-  at::detail::Array<char*, ntensors> data;
-  for (int i = 0; i < ntensors; i++) {
-    data[i] = (char*)iter.data_ptr(i);
-  }
-
-  int64_t numel = iter.numel();
-  if (iter.is_trivial_1d()) {
-    auto inner_strides = iter.get_inner_strides();
-    at::detail::Array<int, ntensors> strides;
-    for (int i = 0; i < ntensors; i++) {
-      strides[i] = inner_strides[i];
-    }
-    launch_kernel<launch_size_1d, 1>(numel, [=]GPU_LAMBDA(int idx) {
-      arg0_t* out = (arg0_t*)(data[0] + strides[0] * idx);
-      *out = invoke_with_index(f, &data.data[1], &strides.data[1], idx, idx);
-    });
-  } else {
-      auto offset_calc = make_offset_calculator<traits::arity>(iter);
-    launch_kernel<launch_size_nd, launch_bound2>(numel, [=]GPU_LAMBDA(int idx) {
-      auto offsets = offset_calc.get(idx);
-      arg0_t* out = (arg0_t*)(data[0] + offsets[0]);
-      *out = invoke_with_index(f, &data.data[1], &offsets.data[1], 1, idx);
-    });
-  }
-}
-
-template <typename func_t>
-void gpu_kernel_with_index(TensorIterator& iter, const func_t& f) {
-  ASSERT_HOST_DEVICE_LAMBDA(func_t);
-
-  for (int arg = 0; arg < iter.ntensors(); arg++) {
-    TORCH_INTERNAL_ASSERT(iter.device(arg).is_cuda(), "gpu_kernel_with_index only support cuda tensor.");
-  }
-
-  if (iter.numel() == 0) {
-    return;
-  }
-
-  // Split will change index, thus is not supported
-  // The caller should handle the split and pass in different func
-  TORCH_INTERNAL_ASSERT(iter.can_use_32bit_indexing(), "gpu_kernel_with_index only support 32-bit indexing.");
-
-  gpu_kernel_with_index_impl(iter, f);
 }
 
 template <typename func_t>
@@ -307,6 +240,114 @@ void gpu_kernel_with_scalars(TensorIterator& iter, const func_t& f) {
   } else {
     gpu_kernel(iter, f);
   }
+}
+
+// similar to above code but work on lambda using index for calculation
+template <typename traits, typename func_t, typename index_t, size_t... INDEX>
+C10_HOST_DEVICE typename traits::result_type
+invoke_with_index_impl(const func_t &f, char* const C10_RESTRICT data[], const index_t strides[], int i, int idx,
+                       c10::guts::index_sequence<INDEX...>) {
+  return f(*(typename traits::template arg<INDEX>::type*)(data[INDEX] + i * strides[INDEX])..., idx);
+}
+
+template <typename func_t, typename index_t, typename traits = function_traits<func_t>>
+C10_HOST_DEVICE typename traits::result_type
+invoke_with_index(const func_t &f, char* const C10_RESTRICT data[], const index_t strides[], int i, int idx) {
+  // index at last position
+  using Indices = c10::guts::make_index_sequence<traits::arity-1>;
+  return invoke_with_index_impl<traits>(f, data, strides, i, idx, Indices{});
+}
+
+template <typename traits, typename func_t, typename index_t, size_t... I>
+C10_HOST_DEVICE typename traits::result_type
+invoke_with_index_impl(const func_t &f, char* const C10_RESTRICT data[], const index_t strides[], const ScalarType dtypes[],
+                       int i, int idx, c10::guts::index_sequence<I...>) {
+  return f(c10::fetch_and_cast<typename traits::template arg<I>::type>(dtypes[I], data[I] + i * strides[I])..., idx);
+}
+
+template <typename func_t, typename index_t, typename traits = function_traits<func_t>>
+C10_HOST_DEVICE typename traits::result_type
+invoke_with_index(const func_t &f, char* const C10_RESTRICT data[], const index_t strides[], const ScalarType dtypes[],
+                  int i, int idx) {
+  // index at last position
+  using Indices = c10::guts::make_index_sequence<traits::arity-1>;
+  return invoke_with_index_impl<traits>(f, data, strides, dtypes, i, idx, Indices{});
+}
+
+template <typename func_t>
+void gpu_kernel_with_index_impl(TensorIterator& iter, const func_t& f) {
+  using traits = function_traits<func_t>;
+  using arg0_t = typename traits::result_type;
+  // need to +1(output) and -1(index)
+  constexpr int ntensors = traits::arity;
+  TORCH_INTERNAL_ASSERT(iter.ntensors() == traits::arity);
+
+  at::detail::Array<char*, ntensors> data;
+  for (int i = 0; i < ntensors; i++) {
+    data[i] = (char*)iter.data_ptr(i);
+  }
+
+  at::detail::Array<ScalarType, ntensors> dtypes;
+  for (int i = 0; i < ntensors; i++) {
+    dtypes[i] = iter.tensor(i).scalar_type();
+  }
+
+  int64_t numel = iter.numel();
+  if (iter.is_trivial_1d()) {
+    auto inner_strides = iter.get_inner_strides();
+    at::detail::Array<int, ntensors> strides;
+    for (int i = 0; i < ntensors; i++) {
+      strides[i] = inner_strides[i];
+    }
+
+    if (iter.needs_dynamic_casting()) {
+      launch_kernel<launch_size_1d, 1>(numel, [=]GPU_LAMBDA(int idx) {
+        void* out = data[0] + strides[0] * idx;
+        arg0_t result = invoke_with_index(f, &data.data[1], &strides.data[1], &dtypes.data[1], idx, idx);
+        c10::cast_and_store<arg0_t>(dtypes[0], out, result);
+      });
+    } else {
+      launch_kernel<launch_size_1d, 1>(numel, [=]GPU_LAMBDA(int idx) {
+        arg0_t* out = (arg0_t*)(data[0] + strides[0] * idx);
+        *out = invoke_with_index(f, &data.data[1], &strides.data[1], idx, idx);
+      });
+    }
+  } else {
+    auto offset_calc = make_offset_calculator<traits::arity>(iter);
+    if (iter.needs_dynamic_casting()) {
+      launch_kernel<launch_size_nd, launch_bound2>(numel, [=]GPU_LAMBDA(int idx) {
+        auto offsets = offset_calc.get(idx);
+        void* out = data[0] + offsets[0];
+        arg0_t result = invoke_with_index(f, &data.data[1], &offsets.data[1], &dtypes.data[1], 1, idx);
+        c10::cast_and_store<arg0_t>(dtypes[0], out, result);
+      });
+    } else {
+      launch_kernel<launch_size_nd, launch_bound2>(numel, [=]GPU_LAMBDA(int idx) {
+        auto offsets = offset_calc.get(idx);
+        arg0_t* out = (arg0_t*)(data[0] + offsets[0]);
+        *out = invoke_with_index(f, &data.data[1], &offsets.data[1], 1, idx);
+      });
+    }
+  }
+}
+
+template <typename func_t>
+void gpu_kernel_with_index(TensorIterator& iter, const func_t& f) {
+  ASSERT_HOST_DEVICE_LAMBDA(func_t);
+
+  for (int arg = 0; arg < iter.ntensors(); arg++) {
+    TORCH_INTERNAL_ASSERT(iter.device(arg).is_cuda(), "gpu_kernel_with_index only support cuda tensor.");
+  }
+
+  if (iter.numel() == 0) {
+    return;
+  }
+
+  // Split will change index, thus is not supported
+  // The caller should handle the split and pass in different func
+  TORCH_INTERNAL_ASSERT(iter.can_use_32bit_indexing(), "gpu_kernel_with_index only support 32-bit indexing.");
+
+  gpu_kernel_with_index_impl(iter, f);
 }
 
 }} // namespace at::native

--- a/aten/src/ATen/native/cuda/RangeFactories.cu
+++ b/aten/src/ATen/native/cuda/RangeFactories.cu
@@ -6,38 +6,10 @@
 #include <cmath>
 #include <limits>
 
-#include <thrust/device_ptr.h>
-#include <thrust/sequence.h>
-#include <thrust/execution_policy.h>
+#include <ATen/native/cuda/Loops.cuh>
 
 namespace at {
 namespace native {
-
-template<typename T, typename accT = T>
-struct LinspaceOp {
-  __host__ __device__ LinspaceOp(accT start, accT step):
-    start_(start), step_(step) { }
-  __device__ __forceinline__ T operator()(ptrdiff_t index) {
-    accT increment = step_ * static_cast<accT>(index);
-    accT value = start_ + increment;
-    return static_cast<T>(value);
-  }
-
-  const accT start_, step_;
-};
-
-template<typename T, typename accT = T>
-struct LogspaceOp {
-  __host__ __device__ LogspaceOp(accT start, accT step, accT base):
-    start_(start), step_(step), base_(base) { }
-  __device__ __forceinline__ T operator()(ptrdiff_t index) {
-    accT increment = step_ * static_cast<accT>(index);
-    accT value = std::pow(base_, start_ + increment);
-    return static_cast<T>(value);
-  }
-
-  const accT start_, step_, base_;
-};
 
 Tensor& linspace_cuda_out(Tensor& result, Scalar start, Scalar end, int64_t steps) {
   TORCH_CHECK(steps >= 0, "number of steps must be non-negative");
@@ -45,28 +17,32 @@ Tensor& linspace_cuda_out(Tensor& result, Scalar start, Scalar end, int64_t step
   if (result.numel() != steps) {
     result.resize_({steps});
   }
-  Tensor r = result.is_contiguous() ? result : result.contiguous();
+  // Using TensorIter, output no longer need to be contiguous
+  // In the case of not doing resize_(), need to check whether output have internal overlap
+  TORCH_CHECK(has_internal_overlap(result) != MemOverlap::YES,
+              "unsupported operation: more than one element of the written-to tensor "
+              "refers to a single memory location. Please clone() the tensor before "
+              "performing the operation.");
 
   if (steps == 0) {
     // skip
   } else if (steps == 1) {
-    r.fill_(start);
+    result.fill_(start);
   } else {
-    AT_DISPATCH_FLOATING_TYPES(r.scalar_type(), "linspace_cuda", [&]() {
+    AT_DISPATCH_FLOATING_TYPES(result.scalar_type(), "linspace_cuda", [&]() {
       scalar_t scalar_start = start.to<scalar_t>();
       scalar_t scalar_end = end.to<scalar_t>();
       scalar_t step = (scalar_end - scalar_start) / static_cast<scalar_t>(steps - 1);
-      LinspaceOp<scalar_t> linspace_method(scalar_start, step);
-      thrust::device_ptr<scalar_t> data_(r.data_ptr<scalar_t>());
-      cudaStream_t stream = at::cuda::getCurrentCUDAStream();
-      auto policy = thrust::cuda::par.on(stream);
-      thrust::tabulate(policy, data_, data_ + steps, linspace_method);
+
+      auto iter = TensorIterator::nullary_op(result);
+      gpu_kernel_with_index(iter, [scalar_start, step]GPU_LAMBDA(int ind) -> scalar_t {
+          scalar_t inc = step * ind;
+          scalar_t val = scalar_start + inc;
+          return val;
+        });
     });
   }
 
-  if (!result.is_contiguous()) {
-    result.copy_(r);
-  }
   AT_CUDA_CHECK(cudaGetLastError());
   return result;
 }
@@ -77,29 +53,33 @@ Tensor& logspace_cuda_out(Tensor& result, Scalar start, Scalar end, int64_t step
   if (result.numel() != steps) {
     result.resize_({steps});
   }
-  Tensor r = result.is_contiguous() ? result : result.contiguous();
+  // Using TensorIter, output no longer need to be contiguous
+  // In the case of not doing resize_(), need to check whether output have internal overlap
+  TORCH_CHECK(has_internal_overlap(result) != MemOverlap::YES,
+              "unsupported operation: more than one element of the written-to tensor "
+              "refers to a single memory location. Please clone() the tensor before "
+              "performing the operation.");
 
   if (steps == 0) {
     // skip
   } else if (steps == 1) {
-    r.fill_(std::pow(base, start.to<double>()));
+    result.fill_(std::pow(base, start.to<double>()));
   } else {
-    AT_DISPATCH_FLOATING_TYPES(r.scalar_type(), "logspace_cuda", [&]() {
+    AT_DISPATCH_FLOATING_TYPES(result.scalar_type(), "logspace_cuda", [&]() {
       scalar_t scalar_base = static_cast<scalar_t>(base);
       scalar_t scalar_start = start.to<scalar_t>();
       scalar_t scalar_end = end.to<scalar_t>();
       scalar_t step = (scalar_end - scalar_start) / static_cast<scalar_t>(steps - 1);
-      LogspaceOp<scalar_t> logspace_method(scalar_start, step, scalar_base);
-      thrust::device_ptr<scalar_t> data_(r.data_ptr<scalar_t>());
-      cudaStream_t stream = at::cuda::getCurrentCUDAStream();
-      auto policy = thrust::cuda::par.on(stream);
-      thrust::tabulate(policy, data_, data_ + steps, logspace_method);
+
+      auto iter = TensorIterator::nullary_op(result);
+      gpu_kernel_with_index(iter, [scalar_start, step, scalar_base]GPU_LAMBDA(int ind) -> scalar_t {
+          scalar_t inc = step * ind;
+          scalar_t val = std::pow(scalar_base, scalar_start + inc);
+          return val;
+        });
     });
   }
 
-  if (!result.is_contiguous()) {
-    result.copy_(r);
-  }
   AT_CUDA_CHECK(cudaGetLastError());
   return result;
 }
@@ -118,19 +98,24 @@ Tensor& range_cuda_out(Tensor& result, Scalar start, Scalar end, Scalar step) {
     TORCH_CHECK(((xstep > 0) && (xend >= xstart)) || ((xstep < 0) && (xend <= xstart)),
              "upper bound and larger bound inconsistent with step sign");
     int64_t size = static_cast<int64_t>(((xend - xstart) / xstep) + 1);
+
     if (result.numel() != size) {
       result.resize_({size});
     }
-    Tensor r = result.is_contiguous() ? result : result.contiguous();
-    LinspaceOp<scalar_t, accscalar_t> linspace_method(xstart, xstep);
-    cudaStream_t stream = at::cuda::getCurrentCUDAStream();
-    auto policy = thrust::cuda::par.on(stream);
-    thrust::device_ptr<scalar_t> data_ptr(r.data_ptr<scalar_t>());
-    thrust::tabulate(policy, data_ptr, data_ptr + size, linspace_method);
+    // Using TensorIter, output no longer need to be contiguous
+    // In the case of not doing resize_(), need to check whether output have internal overlap
+    TORCH_CHECK(has_internal_overlap(result) != MemOverlap::YES,
+                "unsupported operation: more than one element of the written-to tensor "
+                "refers to a single memory location. Please clone() the tensor before "
+                "performing the operation.");
 
-    if (!result.is_contiguous()) {
-      result.copy_(r);
-    }
+    auto iter = TensorIterator::nullary_op(result);
+    gpu_kernel_with_index(iter, [xstart, xstep]GPU_LAMBDA(int ind) -> scalar_t {
+        accscalar_t inc = xstep * static_cast<accscalar_t>(ind);
+        accscalar_t val = xstart + inc;
+        return static_cast<scalar_t>(val);
+    });
+
   });
 
   AT_CUDA_CHECK(cudaGetLastError());
@@ -181,16 +166,20 @@ Tensor& arange_cuda_out(Tensor& result, Scalar start, Scalar end, Scalar step) {
       }
       result.resize_({size});
     }
-    Tensor r = result.is_contiguous() ? result : result.contiguous();
-    LinspaceOp<scalar_t, accscalar_t> linspace_method(xstart, xstep);
-    cudaStream_t stream = at::cuda::getCurrentCUDAStream();
-    auto policy = thrust::cuda::par.on(stream);
-    thrust::device_ptr<scalar_t> data_ptr(r.data_ptr<scalar_t>());
-    thrust::tabulate(policy, data_ptr, data_ptr + size, linspace_method);
+    // Using TensorIter, output no longer need to be contiguous
+    // In the case of not doing resize_(), need to check whether output have internal overlap
+    TORCH_CHECK(has_internal_overlap(result) != MemOverlap::YES,
+                "unsupported operation: more than one element of the written-to tensor "
+                "refers to a single memory location. Please clone() the tensor before "
+                "performing the operation.");
 
-    if (!result.is_contiguous()) {
-      result.copy_(r);
-    }
+    auto iter = TensorIterator::nullary_op(result);
+    gpu_kernel_with_index(iter, [xstart, xstep]GPU_LAMBDA(int ind) -> scalar_t {
+        accscalar_t inc = xstep * static_cast<accscalar_t>(ind);
+        accscalar_t val = xstart + inc;
+        return static_cast<scalar_t>(val);
+    });
+
   });
 
   AT_CUDA_CHECK(cudaGetLastError());

--- a/aten/src/ATen/native/cuda/RangeFactories.cu
+++ b/aten/src/ATen/native/cuda/RangeFactories.cu
@@ -32,7 +32,7 @@ Tensor& linspace_cuda_out(Tensor& result, Scalar start, Scalar end, int64_t step
   } else if (steps == 1) {
     r.fill_(start);
   } else {
-    AT_DISPATCH_FLOATING_TYPES(r.scalar_type(), "linspace_cuda", [&]() {
+    AT_DISPATCH_ALL_TYPES_AND(at::ScalarType::Half, r.scalar_type(), "linspace_cuda", [&]() {
       scalar_t scalar_start = start.to<scalar_t>();
       scalar_t scalar_end = end.to<scalar_t>();
       scalar_t step = (scalar_end - scalar_start) / static_cast<scalar_t>(steps - 1);
@@ -75,7 +75,7 @@ Tensor& logspace_cuda_out(Tensor& result, Scalar start, Scalar end, int64_t step
   } else if (steps == 1) {
     r.fill_(std::pow(base, start.to<double>()));
   } else {
-    AT_DISPATCH_FLOATING_TYPES(r.scalar_type(), "logspace_cuda", [&]() {
+    AT_DISPATCH_ALL_TYPES_AND(at::ScalarType::Half, r.scalar_type(), "logspace_cuda", [&]() {
       scalar_t scalar_base = static_cast<scalar_t>(base);
       scalar_t scalar_start = start.to<scalar_t>();
       scalar_t scalar_end = end.to<scalar_t>();


### PR DESCRIPTION
This PR add `gpu_kernel_with_index` as an addition to element-wise kernel template. It allows kernel to not only operate on input tensor value, but also each values index(view as 1d, so from 0 to numel) within the lambda.
Direct use case here is to replace thrust::tabulate used in range/arange/linspace. Benifits are:
- thrust::tabulate causes additional unneccessary synchronization on cpu.
- Now it works with tensor iterator, output no longer needs to be contiguous and a memcpy is saved
 
It can also potentially be reused to add new function to pytorch later, if we see use case both value and index is needed.(for example unify tril/triu into tensor iterator element-wise? add other pattern?)

Known issues:
https://github.com/pytorch/pytorch/pull/23586 is needed to enable non-contiguous case work properly, since overlapping needs to be checked. Currently non-contiguous tensor falls into TOO_HARD. I could write proper check in this file but I figured using exist method is better. @jjsjann123 
It does not work beyond 32bit indexing. But thrust was erroring on those case too. We could split tensor in caller to enable this. Index changes after split, so it is easier for caller to pass different lambda, and harder for the template to handle it in general.
