### PR TITLE
Disable c10d test_sync_params_with_buffers on ROCm

### DIFF
--- a/test/test_c10d.py
+++ b/test/test_c10d.py
@@ -2114,6 +2114,7 @@ class DistributedDataParallelTest(MultiProcessTestCase):
 
     @requires_gloo()
     @skip_if_not_multigpu
+    @skip_if_rocm
     def test_sync_params_with_buffers(self, dtype=torch.double):
         store = c10d.FileStore(self.file_name, self.world_size)
         options = c10d.ProcessGroupGloo.Options()


### PR DESCRIPTION
Failed runs on master:

https://ci.pytorch.org/jenkins/job/pytorch-builds/job/py3.6-clang7-rocmdeb-ubuntu16.04-test2/2097/
https://ci.pytorch.org/jenkins/job/pytorch-builds/job/py3.6-clang7-rocmdeb-ubuntu16.04-test2/2144/
https://ci.pytorch.org/jenkins/job/pytorch-builds/job/py3.6-clang7-rocmdeb-ubuntu16.04-test2/2154/
https://ci.pytorch.org/jenkins/job/pytorch-builds/job/py3.6-clang7-rocmdeb-ubuntu16.04-test2/2167/

```
19:59:03 ======================================================================
19:59:03 FAIL: test_sync_params_with_buffers (__main__.DistributedDataParallelTest)
19:59:03 ----------------------------------------------------------------------
19:59:03 Traceback (most recent call last):
19:59:03   File "/var/lib/jenkins/workspace/test/common_distributed.py", line 130, in wrapper
19:59:03     self._join_processes(fn)
19:59:03   File "/var/lib/jenkins/workspace/test/common_distributed.py", line 211, in _join_processes
19:59:03     self._check_return_codes(elapsed_time)
19:59:03   File "/var/lib/jenkins/workspace/test/common_distributed.py", line 235, in _check_return_codes
19:59:03     self.assertEqual(first_process.exitcode, 0)
19:59:03   File "/var/lib/jenkins/workspace/test/common_utils.py", line 748, in assertEqual
19:59:03     super(TestCase, self).assertLessEqual(abs(x - y), prec, message)
19:59:03 AssertionError: 10 not less than or equal to 1e-05 : 
19:59:03 
```