### PR TITLE
change linear benchmark shapes

### DIFF
--- a/benchmarks/operator_benchmark/pt/linear_test.py
+++ b/benchmarks/operator_benchmark/pt/linear_test.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 
-import operator_benchmark as op_bench 
+import operator_benchmark as op_bench
 import torch
 import torch.nn as nn
 
@@ -13,8 +13,8 @@ import torch.nn as nn
 
 configs = op_bench.config_list(
     attrs=[
-        [4, 256, 100],
-        [16, 1024, 256],
+        [32, 1024, 256],
+        [64, 256, 100],
     ],
     attr_names=["N", "IN", "OUT"],
     tags=["short"]
@@ -24,7 +24,7 @@ configs = op_bench.config_list(
 class LinearBenchmark(op_bench.TorchBenchmarkBase):
     def init(self, N, IN, OUT):
         self.input_one = torch.rand(N, IN)
-        self.linear = nn.Linear(IN, OUT) 
+        self.linear = nn.Linear(IN, OUT)
         self.set_module_name("linear")
 
     def forward(self):


### PR DESCRIPTION
Summary: as title

Test Plan:
```
buck run //caffe2/benchmarks/operator_benchmark/pt:linear_test
# ----------------------------------------
# PyTorch/Caffe2 Operator Micro-benchmarks
# ----------------------------------------
# Tag : short

# Benchmarking PyTorch: linear
# Mode: Eager
# Name: linear_N32_IN1024_OUT256
# Input: N: 32, IN: 1024, OUT: 256
Forward Execution Time (us) : 1501.918

# Benchmarking PyTorch: linear
# Mode: Eager
# Name: linear_N64_IN256_OUT100
# Input: N: 64, IN: 256, OUT: 100
Forward Execution Time (us) : 1175.672

Reviewed By: hl475

Differential Revision: D17980463

