### PR TITLE
Remove confusing torch::jit::RegisterOperators for custom ops

### DIFF
--- a/benchmarks/operator_benchmark/pt_extension/extension.cpp
+++ b/benchmarks/operator_benchmark/pt_extension/extension.cpp
@@ -34,7 +34,7 @@ Tensor clear_cache() {
 // That caused an issue for our op benchmark which needs to run an op
 // in a loop and report the execution time. This diff resolves that issue by
 // registering this consume op with correct alias information which is DEFAULT.
-auto reg = torch::jit::RegisterOperators()
+auto reg = torch::RegisterOperators()
   .op("operator_benchmark::_consume", &consume)
   .op("operator_benchmark::_clear_cache", &clear_cache);
 

--- a/test/custom_operator/op.cpp
+++ b/test/custom_operator/op.cpp
@@ -23,7 +23,7 @@ int64_t custom_op2(std::string s1, std::string s2) {
 }
 
 static auto registry =
-    torch::jit::RegisterOperators()
+    torch::RegisterOperators()
         // We parse the schema for the user.
         .op("custom::op", &custom_op)
         .op("custom::op2", &custom_op2)

--- a/test/onnx/test_custom_ops.py
+++ b/test/onnx/test_custom_ops.py
@@ -20,7 +20,7 @@ class TestCustomOps(unittest.TestCase):
         }
 
         static auto registry =
-          torch::jit::RegisterOperators("custom_namespace::custom_add", &custom_add);
+          torch::RegisterOperators("custom_namespace::custom_add", &custom_add);
         """
 
         torch.utils.cpp_extension.load_inline(

--- a/test/test_cpp_extensions.py
+++ b/test/test_cpp_extensions.py
@@ -670,7 +670,7 @@ class TestCppExtension(common.TestCase):
         source = """
         #include <torch/script.h>
         torch::Tensor func(torch::Tensor x) { return x; }
-        static torch::jit::RegisterOperators r("test::func", &func);
+        static torch::RegisterOperators r("test::func", &func);
         """
         torch.utils.cpp_extension.load_inline(
             name="is_python_module",

--- a/torch/csrc/jit/custom_operator.h
+++ b/torch/csrc/jit/custom_operator.h
@@ -22,23 +22,6 @@ struct TORCH_API RegisterOperators {
     }
   }
 
-  /// Calls `op(...)` with the given operator name and implementation.
-  template <typename Implementation>
-  C10_DEPRECATED_MESSAGE("torch::jit::RegisterOperators is deprecated. Please use torch::RegisterOperators instead.")
-  RegisterOperators(const std::string& name, Implementation&& implementation) {
-    op_(name, std::forward<Implementation>(implementation));
-  }
-
-  template <typename Implementation>
-  C10_DEPRECATED_MESSAGE("torch::jit::RegisterOperators is deprecated. Please use torch::RegisterOperators instead.")
-  RegisterOperators& op(
-      const std::string& name,
-      Implementation&& implementation) {
-    op_(name, std::forward<Implementation>(implementation));
-
-    return *this;
-  }
-
 private:
 
   template <typename Implementation>

--- a/torch/csrc/jit/custom_operator.h
+++ b/torch/csrc/jit/custom_operator.h
@@ -2,7 +2,6 @@
 
 #include <torch/csrc/jit/operator.h>
 #include <ATen/core/stack.h>
-#include <ATen/core/op_registration/op_registration.h>
 
 namespace torch {
 namespace jit {
@@ -10,8 +9,7 @@ namespace jit {
 /// Registration class for new operators. Effectively calls
 /// `torch::jit::registerOperator` for every supplied operator, but allows doing
 /// so in the global scope when a `RegisterOperators` object is assigned to a
-/// static variable. Also handles registration of user-defined, "custom"
-/// operators.
+/// static variable.
 struct TORCH_API RegisterOperators {
   RegisterOperators() = default;
 
@@ -21,22 +19,7 @@ struct TORCH_API RegisterOperators {
       registerOperator(std::move(o));
     }
   }
-
-private:
-
-  template <typename Implementation>
-  void op_(const std::string& name, Implementation&& implementation) {
-    registrars_.emplace_back(std::make_shared<c10::RegisterOperators>(name, std::forward<Implementation>(implementation)));
-  }
-
-  // A c10::RegisterOperators instance is not copyable, so to make
-  // torch::jit::RegisterOperators copyable, we use shared_ptrs.
-  // We need to keep the c10::RegisterOperators instances around
-  // because this is an RAII pattern. In the destructor, the registered
-  // ops get de-registered.
-  std::vector<std::shared_ptr<c10::RegisterOperators>> registrars_;
 };
 
 } // namespace jit
-
 } // namespace torch

--- a/torch/csrc/jit/custom_operator.h
+++ b/torch/csrc/jit/custom_operator.h
@@ -2,6 +2,7 @@
 
 #include <torch/csrc/jit/operator.h>
 #include <ATen/core/stack.h>
+#include <ATen/core/op_registration/op_registration.h>
 
 namespace torch {
 namespace jit {
@@ -10,6 +11,8 @@ namespace jit {
 /// `torch::jit::registerOperator` for every supplied operator, but allows doing
 /// so in the global scope when a `RegisterOperators` object is assigned to a
 /// static variable.
+/// Note: This is *not* the custom operator API. If you want to register custom
+/// operators, take a look at torch::RegisterOperators.
 struct TORCH_API RegisterOperators {
   RegisterOperators() = default;
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#28229 Remove confusing torch::jit::RegisterOperators for custom ops**

We have `torch::RegisterOperators` for custom ops. `torch::jit::RegisterOperators` had a dual state of being able to register custom ops if called one way and being able to register pure JIT ops if called another way.
This is confusing because you end up in different operator libraries depending on which API exactly you're using.

This PR removes the ability for torch::jit::RegisterOperators to register custom ops and forces people to use the new torch::RegisterOperators.

This was already deprecated before but we now remove it.

Differential Revision: [D17981895](https://our.internmc.facebook.com/intern/diff/D17981895/)