### PR TITLE
[WIP] Add stop api to rpc agent

### DIFF
--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -37,6 +37,12 @@ PyObject* rpc_init(PyObject* /* unused */) {
   auto rpcAgent =
       shared_ptr_class_<RpcAgent>(module, "RpcAgent")
           .def(
+              "start",
+              &RpcAgent::start,
+              py::call_guard<py::gil_scoped_release>())
+          .def(
+              "stop", &RpcAgent::stop, py::call_guard<py::gil_scoped_release>())
+          .def(
               "join", &RpcAgent::join, py::call_guard<py::gil_scoped_release>())
           .def(
               "sync",
@@ -87,6 +93,14 @@ PyObject* rpc_init(PyObject* /* unused */) {
           py::arg("name"),
           py::arg("process_group"),
           py::arg("num_send_recv_threads") = 4)
+      .def(
+          "start",
+          &ProcessGroupAgent::start,
+          py::call_guard<py::gil_scoped_release>())
+      .def(
+          "stop",
+          &ProcessGroupAgent::stop,
+          py::call_guard<py::gil_scoped_release>())
       .def(
           "get_worker_info",
           (const WorkerInfo& (ProcessGroupAgent::*)(void)const) &

--- a/torch/csrc/distributed/rpc/process_group_agent.h
+++ b/torch/csrc/distributed/rpc/process_group_agent.h
@@ -50,6 +50,8 @@ class ProcessGroupAgent : public RpcAgent {
 
   void start() override;
 
+  void stop() override;
+
  protected:
   // This method wraps the destination information and the message into a
   // SendWork object, and put the SendWork into a queue. Another thread will
@@ -133,6 +135,8 @@ class ProcessGroupAgent : public RpcAgent {
   std::unordered_map<int64_t, std::shared_ptr<FutureMessage>> futures_;
   mutable std::mutex futureMutex_;
   mutable std::condition_variable futureCV_;
+
+  std::atomic<bool> start_{false};
 };
 
 } // namespace rpc

--- a/torch/csrc/distributed/rpc/rpc_agent.h
+++ b/torch/csrc/distributed/rpc/rpc_agent.h
@@ -104,6 +104,9 @@ class TORCH_API RpcAgent {
   // start accepting requests
   virtual void start() {}
 
+  // stop accepting requests
+  virtual void stop() {}
+
   // Set the default rpc agent.
   static void setDefaultRpcAgent(std::shared_ptr<RpcAgent> defaultRpcAgent);
 

--- a/torch/distributed/rpc/api.py
+++ b/torch/distributed/rpc/api.py
@@ -58,6 +58,7 @@ def sync_rpc():
 
     _agent.sync()
 
+
 class RpcBackend(Enum):
     PROCESS_GROUP = 1
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#28238 [WIP] Add stop api to rpc agent**

This is a followup for https://github.com/pytorch/pytorch/pull/27776, especially the comment, https://github.com/pytorch/pytorch/pull/27776#discussion_r335246151.

The plan is as follow.
- Add local stop API to RpcAgent.
- Change unit tests to use stop rather than join.

Differential Revision: [D5516149](https://our.internmc.facebook.com/intern/diff/D5516149/)