### PR TITLE
[WIP] Stop promoting by copying for operator add

### DIFF
--- a/aten/src/ATen/Dispatch.h
+++ b/aten/src/ATen/Dispatch.h
@@ -12,6 +12,12 @@
     return __VA_ARGS__();                          \
   }
 
+#define AT_NAMED_PRIVATE_CASE_TYPE(enum_type, typename_, type, EXPRESSION) \
+  case enum_type: {                                                        \
+    using typename_ = type;                                                \
+    return EXPRESSION;                                                     \
+  }
+
 #define AT_QINT_PRIVATE_CASE_TYPE(enum_type, type, underlying_enum, underlying_type, ...) \
   case enum_type: {                                                     \
     const auto& UNDERLYING_TYPE C10_UNUSED = underlying_enum;           \
@@ -311,6 +317,24 @@ inline void deprecated_AT_DISPATCH_ALL_TYPES_AND_HALF_AND_COMPLEX() {}
       default:                                                                                                   \
         AT_ERROR(#NAME, " not implemented for '", toString(TYPE), "'");                                          \
     }                                                                                                            \
+  }()
+
+// Type of the macro below: expression -> expression
+#define AT_NAMED_DISPATCH_ALL_TYPES_AND2(SCALARTYPE1, SCALARTYPE2, TYPENAME, TYPE, NAME, EXPRESSION)                            \
+  [&] {                                                                                                                       \
+    switch (TYPE) {                                                                                                             \
+      AT_NAMED_PRIVATE_CASE_TYPE(at::ScalarType::Byte, TYPENAME, uint8_t, EXPRESSION)                                           \
+      AT_NAMED_PRIVATE_CASE_TYPE(at::ScalarType::Char, TYPENAME, int8_t, EXPRESSION)                                            \
+      AT_NAMED_PRIVATE_CASE_TYPE(at::ScalarType::Double, TYPENAME, double, EXPRESSION)                                          \
+      AT_NAMED_PRIVATE_CASE_TYPE(at::ScalarType::Float, TYPENAME, float, EXPRESSION)                                            \
+      AT_NAMED_PRIVATE_CASE_TYPE(at::ScalarType::Int, TYPENAME, int32_t, EXPRESSION)                                            \
+      AT_NAMED_PRIVATE_CASE_TYPE(at::ScalarType::Long, TYPENAME, int64_t, EXPRESSION)                                           \
+      AT_NAMED_PRIVATE_CASE_TYPE(at::ScalarType::Short, TYPENAME, int16_t, EXPRESSION)                                          \
+      AT_NAMED_PRIVATE_CASE_TYPE(SCALARTYPE1, TYPENAME, decltype(c10::impl::ScalarTypeToCPPType<SCALARTYPE1>::t), EXPRESSION)   \
+      AT_NAMED_PRIVATE_CASE_TYPE(SCALARTYPE2, TYPENAME, decltype(c10::impl::ScalarTypeToCPPType<SCALARTYPE2>::t), EXPRESSION)   \
+      default:                                                                                                                  \
+        AT_ERROR(#NAME, " not implemented for '", toString(TYPE), "'");                                                         \
+    }                                                                                                                           \
   }()
 
 #define AT_DISPATCH_ALL_TYPES_AND3(SCALARTYPE1, SCALARTYPE2, SCALARTYPE3, TYPE, NAME, ...)                       \

--- a/aten/src/ATen/native/BinaryOps.cpp
+++ b/aten/src/ATen/native/BinaryOps.cpp
@@ -27,7 +27,7 @@ static constexpr char alpha_mismatch_err[] =
 
 Tensor& add_out(Tensor& result, const Tensor& self, const Tensor& other, Scalar alpha) {
   auto iter = TensorIterator::binary_op(result, self, other,
-    /*check_mem_overlap=*/true);
+    /*check_mem_overlap=*/true, /*promote_by_copy=*/!self.device().is_cuda());
   TORCH_CHECK(! alpha.isBoolean() || iter.dtype() == ScalarType::Bool, "Boolean alpha only supported for boolean results");
   TORCH_CHECK(isFloatingType(iter.dtype()) || alpha.isIntegral(true), alpha_mismatch_err);
   add_stub(iter.device_type(), iter, alpha);
@@ -37,7 +37,8 @@ Tensor& add_out(Tensor& result, const Tensor& self, const Tensor& other, Scalar 
 
 Tensor add(const Tensor& self, const Tensor& other, Scalar alpha) {
   Tensor result;
-  auto iter = TensorIterator::binary_op(result, self, other);
+  auto iter = TensorIterator::binary_op(result, self, other,
+    /*check_mem_overlap=*/false, /*promote_by_copy=*/!self.device().is_cuda());
   TORCH_CHECK(! alpha.isBoolean() || iter.dtype() == ScalarType::Bool, "Boolean alpha only supported for boolean results");
   TORCH_CHECK(isFloatingType(iter.dtype()) || alpha.isIntegral(true), alpha_mismatch_err);
   add_stub(iter.device_type(), iter, alpha);

--- a/aten/src/ATen/native/BinaryOps.cpp
+++ b/aten/src/ATen/native/BinaryOps.cpp
@@ -27,7 +27,7 @@ static constexpr char alpha_mismatch_err[] =
 
 Tensor& add_out(Tensor& result, const Tensor& self, const Tensor& other, Scalar alpha) {
   auto iter = TensorIterator::binary_op(result, self, other,
-    /*check_mem_overlap=*/true, /*promote_by_copy=*/!self.device().is_cuda());
+    /*check_mem_overlap=*/true, /*promote=*/!self.device().is_cuda());
   TORCH_CHECK(! alpha.isBoolean() || iter.dtype() == ScalarType::Bool, "Boolean alpha only supported for boolean results");
   TORCH_CHECK(isFloatingType(iter.dtype()) || alpha.isIntegral(true), alpha_mismatch_err);
   add_stub(iter.device_type(), iter, alpha);
@@ -38,7 +38,7 @@ Tensor& add_out(Tensor& result, const Tensor& self, const Tensor& other, Scalar 
 Tensor add(const Tensor& self, const Tensor& other, Scalar alpha) {
   Tensor result;
   auto iter = TensorIterator::binary_op(result, self, other,
-    /*check_mem_overlap=*/false, /*promote_by_copy=*/!self.device().is_cuda());
+    /*check_mem_overlap=*/false, /*promote=*/!self.device().is_cuda());
   TORCH_CHECK(! alpha.isBoolean() || iter.dtype() == ScalarType::Bool, "Boolean alpha only supported for boolean results");
   TORCH_CHECK(isFloatingType(iter.dtype()) || alpha.isIntegral(true), alpha_mismatch_err);
   add_stub(iter.device_type(), iter, alpha);

--- a/aten/src/ATen/native/TensorIterator.cpp
+++ b/aten/src/ATen/native/TensorIterator.cpp
@@ -627,7 +627,7 @@ TensorIterator TensorIterator::binary_op(Tensor& out, const Tensor& a,
   auto iter = TensorIterator();
   iter.set_check_mem_overlap(check_mem_overlap);
   if (!promote) {
-    dont_compute_common_dtype();
+    iter.dont_compute_common_dtype();
   }
   iter.add_output(out);
   iter.add_input(a);

--- a/aten/src/ATen/native/TensorIterator.cpp
+++ b/aten/src/ATen/native/TensorIterator.cpp
@@ -229,7 +229,7 @@ void TensorIterator::compute_types() {
         if (!compute_common_dtype_only_for_inputs) {
           validate_dtype(op, common_dtype, ninputs());
         }
-        if (promote_by_copy_ && (!compute_common_dtype_only_for_inputs || !op.is_output)) {
+        if (!compute_common_dtype_only_for_inputs || !op.is_output) {
           maybe_promote_common_dtype(op, common_dtype);
         }
       }

--- a/aten/src/ATen/native/TensorIterator.cpp
+++ b/aten/src/ATen/native/TensorIterator.cpp
@@ -229,7 +229,7 @@ void TensorIterator::compute_types() {
         if (!compute_common_dtype_only_for_inputs) {
           validate_dtype(op, common_dtype, ninputs());
         }
-        if (!compute_common_dtype_only_for_inputs || !op.is_output) {
+        if (promote_by_copy_ && (!compute_common_dtype_only_for_inputs || !op.is_output)) {
           maybe_promote_common_dtype(op, common_dtype);
         }
       }
@@ -623,9 +623,10 @@ void TensorIterator::select_all_keeping_dim(int start_dim, IntArrayRef indices) 
 }
 
 TensorIterator TensorIterator::binary_op(Tensor& out, const Tensor& a,
-    const Tensor& b, bool check_mem_overlap) {
+    const Tensor& b, bool check_mem_overlap, bool promote_by_copy) {
   auto iter = TensorIterator();
   iter.set_check_mem_overlap(check_mem_overlap);
+  iter.set_promote_by_copy(promote_by_copy);
   iter.add_output(out);
   iter.add_input(a);
   iter.add_input(b);

--- a/aten/src/ATen/native/TensorIterator.cpp
+++ b/aten/src/ATen/native/TensorIterator.cpp
@@ -623,10 +623,12 @@ void TensorIterator::select_all_keeping_dim(int start_dim, IntArrayRef indices) 
 }
 
 TensorIterator TensorIterator::binary_op(Tensor& out, const Tensor& a,
-    const Tensor& b, bool check_mem_overlap, bool promote_by_copy) {
+    const Tensor& b, bool check_mem_overlap, bool promote) {
   auto iter = TensorIterator();
   iter.set_check_mem_overlap(check_mem_overlap);
-  iter.set_promote_by_copy(promote_by_copy);
+  if (!promote) {
+    dont_compute_common_dtype();
+  }
   iter.add_output(out);
   iter.add_input(a);
   iter.add_input(b);

--- a/aten/src/ATen/native/TensorIterator.h
+++ b/aten/src/ATen/native/TensorIterator.h
@@ -157,7 +157,7 @@ struct CAFFE2_API TensorIterator {
   void foreach_reduced_elt(loop_subiter_t loop, bool parallelize=true);
 
   static TensorIterator binary_op(Tensor& out, const Tensor& a, const Tensor& b,
-    bool check_mem_overlap = false);
+    bool check_mem_overlap = false, bool promote_by_copy=true);
   static TensorIterator comparison_op(Tensor& out, const Tensor& a, const Tensor& b,
     bool check_mem_overlap = false);
   static TensorIterator unary_op(Tensor& out, const Tensor& a,
@@ -289,6 +289,10 @@ struct CAFFE2_API TensorIterator {
     check_mem_overlap_ = check_mem_overlap;
   }
 
+  void set_promote_by_copy(bool promote_by_copy) {
+    promote_by_copy_ = promote_by_copy;
+  }
+
   /// Construction
   void add_output(const Tensor& output) {
     operands_.emplace_back(output);
@@ -355,6 +359,7 @@ protected:
   bool promote_gpu_output_dtypes_ = false;
   bool final_output_ = true;
   bool check_mem_overlap_ = false;
+  bool promote_by_copy_ = true;
 };
 /// A container-like struct that acts as if it contains splits of a
 /// TensorIterator that can use 32-bit indexing. Taken together the splits cover

--- a/aten/src/ATen/native/TensorIterator.h
+++ b/aten/src/ATen/native/TensorIterator.h
@@ -157,7 +157,7 @@ struct CAFFE2_API TensorIterator {
   void foreach_reduced_elt(loop_subiter_t loop, bool parallelize=true);
 
   static TensorIterator binary_op(Tensor& out, const Tensor& a, const Tensor& b,
-    bool check_mem_overlap = false, bool promote_by_copy=true);
+    bool check_mem_overlap = false, bool promote=true);
   static TensorIterator comparison_op(Tensor& out, const Tensor& a, const Tensor& b,
     bool check_mem_overlap = false);
   static TensorIterator unary_op(Tensor& out, const Tensor& a,
@@ -289,10 +289,6 @@ struct CAFFE2_API TensorIterator {
     check_mem_overlap_ = check_mem_overlap;
   }
 
-  void set_promote_by_copy(bool promote_by_copy) {
-    promote_by_copy_ = promote_by_copy;
-  }
-
   /// Construction
   void add_output(const Tensor& output) {
     operands_.emplace_back(output);
@@ -359,7 +355,6 @@ protected:
   bool promote_gpu_output_dtypes_ = false;
   bool final_output_ = true;
   bool check_mem_overlap_ = false;
-  bool promote_by_copy_ = true;
 };
 /// A container-like struct that acts as if it contains splits of a
 /// TensorIterator that can use 32-bit indexing. Taken together the splits cover

--- a/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
@@ -30,7 +30,7 @@ void add_kernel(TensorIterator& iter, Scalar alpha_scalar) {
         });
       });
   }
-} 
+}
 
 void atan2_kernel(TensorIterator& iter) {
   AT_DISPATCH_FLOATING_TYPES(iter.dtype(), "atan2_cpu", [&]() {

--- a/aten/src/ATen/native/cuda/BinaryOpsKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryOpsKernel.cu
@@ -21,7 +21,7 @@ void add_kernel_cuda(TensorIterator& iter, Scalar alpha_scalar) {
           using scalar_t = decltype(input0_t(0) + input1_t(0) + output_t(0));
           scalar_t alpha = alpha_scalar.to<scalar_t>();
           gpu_kernel_with_scalars(iter, [alpha]GPU_LAMBDA(input0_t a, input1_t b) -> output_t {
-            return output_t(a + alpha * b);
+            return output_t(scalar_t(a) + alpha * scalar_t(b));
           });
         }()
       )

--- a/aten/src/ATen/native/cuda/Loops.cuh
+++ b/aten/src/ATen/native/cuda/Loops.cuh
@@ -130,7 +130,6 @@ void gpu_kernel_impl(TensorIterator& iter, const func_t& f) {
     data[i] = (char*)iter.data_ptr(i);
   }
 
-
   int64_t numel = iter.numel();
   if (iter.is_trivial_1d()) {
     auto inner_strides = iter.get_inner_strides();
@@ -138,7 +137,6 @@ void gpu_kernel_impl(TensorIterator& iter, const func_t& f) {
     for (int i = 0; i < ntensors; i++) {
       strides[i] = inner_strides[i];
     }
-   
 
     launch_kernel<launch_size_1d, 1>(numel, [=]GPU_LAMBDA(int idx) {
       arg0_t* out = (arg0_t*)(data[0] + strides[0] * idx);


### PR DESCRIPTION
This is a partial fix of https://github.com/pytorch/pytorch/issues/26401.

I decide to keep the promote-by-copy support of `TensorIterator` because it allows us to easily implement type promotion with much less work, and allows us to intentionally implement type promotion of some operators by copy to keep the binary size small. It also allows us to improve the performance of type promotion for different operators incrementally.

In this PR, only GPU is fixed in this PR because the vectorized CPU code does not have support for operations of different types, which would require much more work to do.

This PR only changes add, other operators will be supported in future PR.

### nvprof result:
```python
import torch

_100M = 100 * 1024 ** 2
r = torch.randn(_100M, dtype=torch.float32, device='cuda')
d = torch.randn(_100M, dtype=torch.float64, device='cuda')
torch.cuda.synchronize()
torch.cuda.profiler.start()
r.add_(d)
torch.cuda.profiler.stop()
torch.cuda.synchronize()
```

### benchmark:
```python
import torch
print(torch.__version__)
print(torch.version.git_version)

_100M = 100 * 1024 ** 2
r = torch.randn(_100M, dtype=torch.float32, device='cuda')
d = torch.randn(_100M, dtype=torch.float64, device='cuda')
torch.cuda.synchronize()
%timeit r.add_(d); torch.cuda.synchronize()
```
original
```
1.4.0a0+7d277b0
7d277b0670eb1f9098a7e098e93b20453e8b5c9f
6.83 ms ± 1.12 ms per loop (mean ± std. dev. of 7 runs, 100 loops each)
```
new
```
```