### PR TITLE
[jit] static initialization order with mutex

### DIFF
--- a/torch/csrc/jit/fuser/compiler.cpp
+++ b/torch/csrc/jit/fuser/compiler.cpp
@@ -23,11 +23,17 @@
 #include <unordered_set>
 #include <utility>
 
+namespace {
+std::mutex& fusionBackendLock() {
+  static std::mutex fusion_backends_lock_{};
+  return fusion_backends_lock_;
+}
+}
+
 namespace torch {
 namespace jit {
 namespace fuser {
 
-std::mutex fusion_backends_lock_;
 static std::unordered_map<at::Device::Type, FusedKernelConstructor>&
 getFusionBackends() {
   static std::unordered_map<at::Device::Type, FusedKernelConstructor>
@@ -38,17 +44,17 @@ getFusionBackends() {
 void registerFusionBackend(
     at::Device::Type backend_type,
     FusedKernelConstructor ctor) {
-  std::lock_guard<std::mutex> guard(fusion_backends_lock_);
+  std::lock_guard<std::mutex> guard(fusionBackendLock());
   getFusionBackends()[backend_type] = std::move(ctor);
 }
 
 bool hasFusionBackend(at::Device::Type backend_type) {
-  std::lock_guard<std::mutex> guard(fusion_backends_lock_);
+  std::lock_guard<std::mutex> guard(fusionBackendLock());
   return getFusionBackends().count(backend_type);
 }
 
 const FusedKernelConstructor& getConstructor(at::Device::Type backend_type) {
-  std::lock_guard<std::mutex> guard(fusion_backends_lock_);
+  std::lock_guard<std::mutex> guard(fusionBackendLock());
   return getFusionBackends().at(backend_type);
 }
 


### PR DESCRIPTION
Summary: When building static libs version of pytorch 1.3 on windows (msvc v141), program crashes with bad memory reference because `fusion_backends_lock_` has not been initialized yet.

Test Plan:
sandcastle green,
tested locally on MSVC static builds that this fixes initialization.

Differential Revision: D17985919

