### PR TITLE
Update docs for `new_group` to reflect all processes need to call it only for
MPI.

### DIFF
--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -428,9 +428,9 @@ def _new_process_group_helper(world_size,
     """
     Create a new distributed process group.
 
-    This function must be called by ALL processes in the global group, even if
-    the calling process is not part of the newly created group. In that case,
-    this function returns GroupMember.NON_GROUP_MEMBER.
+    For ``Backend.MPI``, this function must be called by ALL processes in the
+    global group, even if the calling process is not part of the newly created
+    group. In that case, this function returns GroupMember.NON_GROUP_MEMBER.
 
     This function is called with ``group_ranks == []`` for the default group.
     """
@@ -1440,10 +1440,10 @@ def new_group(ranks=None, timeout=_default_pg_timeout, backend=None):
     """
     Creates a new distributed group.
 
-    This function requires that all processes in the main group (i.e. all
-    processes that are part of the distributed job) enter this function, even
-    if they are not going to be members of the group. Additionally, groups
-    should be created in the same order in all processes.
+    For ``Backend.MPI``, this function requires that all processes in the main
+    group (i.e. all processes that are part of the distributed job) enter this
+    function, even if they are not going to be members of the group.
+    Additionally, groups should be created in the same order in all processes.
 
     Arguments:
         ranks (list[int]): List of ranks of group members.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#28247 Update docs for `new_group` to reflect all processes need to call it only for
MPI.**

MPI.

The documentation for `new_group` mentioned the following:

```
This function requires that all processes in the main group (i.e. all
processes that are part of the distributed job) enter this function, even
if they are not going to be members of the group
```

Although, this is only true for the MPI backend and not true for GLOO or NCCL.
As a result, in this change we're updating the docs to reflect this accurately.

Differential Revision: [D17988969](https://our.internmc.facebook.com/intern/diff/D17988969/)