### PR TITLE
default caffe2_tvm_min_ops to 10

### DIFF
--- a/caffe2/opt/tvm_transformer.cc
+++ b/caffe2/opt/tvm_transformer.cc
@@ -8,7 +8,7 @@ C10_DEFINE_bool(
 
 C10_DEFINE_int32(
     caffe2_tvm_min_ops,
-    8,
+    10,
     "Minimal number of supported ops for the subgraph to be lowered to TVM");
 
 namespace caffe2 {


### PR DESCRIPTION
Summary: We've been running canaries with this setting for a while

Test Plan: build, sanity canary

Reviewed By: yinghai

Differential Revision: D17872108

