### PR TITLE
Fix the padding issue of quantized average pool operator

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
+++ b/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
@@ -524,18 +524,16 @@ void qavg_pool2d_nhwc_kernel(
         hend = std::min(hend, inputHeight);
         wend = std::min(wend, inputWidth);
 
-        int64_t size;
+        int64_t size = (hend - hstart) * (wend - wstart);
         int64_t divide_factor;
         if (divisor_override.has_value()) {
           divide_factor = divisor_override.value();
-          size = (hend - hstart) * (wend - wstart);
         } else {
           if (count_include_pad) {
             divide_factor = pool_size;
           } else {
             divide_factor = (hend - hstart) * (wend - wstart);
           }
-          size = divide_factor;
         }
 
         int64_t c = 0;

--- a/aten/src/ATen/native/quantized/cpu/q_avgpool.cpp
+++ b/aten/src/ATen/native/quantized/cpu/q_avgpool.cpp
@@ -96,7 +96,6 @@ static void avg_pool2d_out_frame(
                       std::nearbyint(sum * multiplier + output.q_zero_point()),
                       minimum),
                   maximum));
-          std::cout << "Value is " << sum * multiplier + output.q_zero_point() << std::endl;
           ptr_output++;
         }
       }

--- a/aten/src/ATen/native/quantized/cpu/q_avgpool.cpp
+++ b/aten/src/ATen/native/quantized/cpu/q_avgpool.cpp
@@ -69,18 +69,17 @@ static void avg_pool2d_out_frame(
           ptr_output->val_ = 0;
 
           int64_t divide_factor;
-          int64_t size;
+          int64_t size = (hend - hstart) * (wend - wstart);
           if (divisor_override.has_value()) {
             divide_factor = divisor_override.value();
-            size = (hend - hstart) * (wend - wstart);
           } else {
             if (count_include_pad) {
               divide_factor = pool_size;
             } else {
               divide_factor = (hend - hstart) * (wend - wstart);
             }
-            size = divide_factor;
           }
+
           int64_t kx, ky;
           for (ky = hstart; ky < hend; ky++) {
             for (kx = wstart; kx < wend; kx++)
@@ -97,6 +96,7 @@ static void avg_pool2d_out_frame(
                       std::nearbyint(sum * multiplier + output.q_zero_point()),
                       minimum),
                   maximum));
+          std::cout << "Value is " << sum * multiplier + output.q_zero_point() << std::endl;
           ptr_output++;
         }
       }

--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -443,7 +443,7 @@ try:
                 suppress_health_check=[hypothesis.HealthCheck.too_slow],
                 database=None,
                 max_examples=100,
-                verbosity=hypothesis.Verbosity.quiet))
+                verbosity=hypothesis.Verbosity.normal))
         hypothesis.settings.register_profile(
             "dev",
             hypothesis.settings(
@@ -467,7 +467,7 @@ try:
                 database=None,
                 max_examples=100,
                 min_satisfying_examples=1,
-                verbosity=hypothesis.Verbosity.quiet))
+                verbosity=hypothesis.Verbosity.normal))
         hypothesis.settings.register_profile(
             "dev",
             hypothesis.settings(

--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -443,7 +443,7 @@ try:
                 suppress_health_check=[hypothesis.HealthCheck.too_slow],
                 database=None,
                 max_examples=100,
-                verbosity=hypothesis.Verbosity.normal))
+                verbosity=hypothesis.Verbosity.quiet))
         hypothesis.settings.register_profile(
             "dev",
             hypothesis.settings(
@@ -467,7 +467,7 @@ try:
                 database=None,
                 max_examples=100,
                 min_satisfying_examples=1,
-                verbosity=hypothesis.Verbosity.normal))
+                verbosity=hypothesis.Verbosity.quiet))
         hypothesis.settings.register_profile(
             "dev",
             hypothesis.settings(

--- a/test/test_quantized.py
+++ b/test/test_quantized.py
@@ -542,7 +542,7 @@ class TestQuantizedOps(TestCase):
             qX_ref = torch.quantize_per_tensor(X_ref, scale=qX_hat.q_scale(), zero_point=qX_hat.q_zero_point(),
                                                dtype=torch_type)
 
-            self.assertEqual(qX_ref.int_repr(), qX_hat.int_repr(), prec=1.0,
+            self.assertEqual(qX_ref.int_repr().to(torch.double), qX_hat.int_repr().to(torch.double), prec=1.0,
                              message=error_message.format(name, qX_hat.int_repr(), qX_ref.int_repr()))
             self.assertEqual(scale, qX_hat.q_scale(),
                              message=error_message.format(name + '.scale', scale, qX_hat.q_scale()))

--- a/test/test_quantized.py
+++ b/test/test_quantized.py
@@ -541,13 +541,9 @@ class TestQuantizedOps(TestCase):
                         count_include_pad=count_include_pad, divisor_override=divisor_override)
             qX_ref = torch.quantize_per_tensor(X_ref, scale=qX_hat.q_scale(), zero_point=qX_hat.q_zero_point(),
                                                dtype=torch_type)
-            print(qX)
-            print(qX.int_repr())
-            print(qX_ref.int_repr())
-            print(qX_hat.int_repr())
-            print("======")
+
             self.assertEqual(qX_ref.int_repr(), qX_hat.int_repr(), prec=1.0,
-                             message="{} results are off".format(name, qX_hat.int_repr(), X_ref))
+                             message=error_message.format(name, qX_hat.int_repr(), qX_ref.int_repr()))
             self.assertEqual(scale, qX_hat.q_scale(),
                              message=error_message.format(name + '.scale', scale, qX_hat.q_scale()))
             self.assertEqual(zero_point, qX_hat.q_zero_point(),

--- a/test/test_quantized.py
+++ b/test/test_quantized.py
@@ -500,6 +500,7 @@ class TestQuantizedOps(TestCase):
         self.assertEqual(a_ref, a_hat.dequantize(),
                          message="ops.quantized.max_pool2d results are off")
 
+    @no_deadline
     @given(X=hu.tensor(shapes=hu.array_shapes(min_dims=3, max_dims=4,
                                               min_side=5, max_side=10),
                        qparams=hu.qparams(dtypes=torch.quint8)),
@@ -549,6 +550,7 @@ class TestQuantizedOps(TestCase):
                              message=error_message.format(name + '.zero_point', scale,
                                                           qX_hat.q_zero_point()))
 
+    @no_deadline
     @given(X=hu.tensor(shapes=hu.array_shapes(min_dims=4, max_dims=4,
                                               min_side=5, max_side=10),
                        qparams=hu.qparams(dtypes=torch.qint8)),

--- a/test/test_quantized.py
+++ b/test/test_quantized.py
@@ -502,7 +502,6 @@ class TestQuantizedOps(TestCase):
 
     @given(X=hu.tensor(shapes=hu.array_shapes(min_dims=3, max_dims=4,
                                               min_side=5, max_side=10),
-                       elements=st.floats(-100, 100, allow_nan=False),
                        qparams=hu.qparams(dtypes=torch.quint8)),
            kernel=st.sampled_from((3, 5)),
            stride=st.sampled_from((None, 1, 2)),
@@ -552,7 +551,6 @@ class TestQuantizedOps(TestCase):
 
     @given(X=hu.tensor(shapes=hu.array_shapes(min_dims=4, max_dims=4,
                                               min_side=5, max_side=10),
-                       elements=st.floats(-100, 100, allow_nan=False),
                        qparams=hu.qparams(dtypes=torch.qint8)),
            kernel=st.sampled_from((4, 5)),
            stride=st.sampled_from((None, 1, 2)),
@@ -597,8 +595,8 @@ class TestQuantizedOps(TestCase):
             qX_ref = torch.quantize_per_tensor(X_ref, scale=X_hat.q_scale(), zero_point=X_hat.q_zero_point(),
                                                dtype=torch_type)
 
-            self.assertEqual(qX_ref.int_repr(), X_hat.int_repr().to(torch.double), prec=1.0,
-                             message="{} results are off".format(name))
+            self.assertEqual(qX_ref.int_repr().to(torch.double), X_hat.int_repr().to(torch.double), prec=1.0,
+                             message=error_message.format(name, X_hat.int_repr(), qX_ref.int_repr()))
             self.assertEqual(scale, X_hat.q_scale(),
                              message=error_message.format(name + '.scale', scale, X_hat.q_scale()))
             self.assertEqual(zero_point, X_hat.q_zero_point(),

--- a/test/test_quantized.py
+++ b/test/test_quantized.py
@@ -541,7 +541,11 @@ class TestQuantizedOps(TestCase):
                         count_include_pad=count_include_pad, divisor_override=divisor_override)
             qX_ref = torch.quantize_per_tensor(X_ref, scale=qX_hat.q_scale(), zero_point=qX_hat.q_zero_point(),
                                                dtype=torch_type)
-
+            print(qX)
+            print(qX.int_repr())
+            print(qX_ref.int_repr())
+            print(qX_hat.int_repr())
+            print("======")
             self.assertEqual(qX_ref.int_repr(), qX_hat.int_repr(), prec=1.0,
                              message="{} results are off".format(name, qX_hat.int_repr(), X_ref))
             self.assertEqual(scale, qX_hat.q_scale(),

--- a/test/test_quantized.py
+++ b/test/test_quantized.py
@@ -527,7 +527,7 @@ class TestQuantizedOps(TestCase):
         qX = torch.quantize_per_tensor(X, scale=scale, zero_point=zero_point,
                                        dtype=torch_type)
         X = qX.dequantize()
-        # Run reference on int_repr + round to avoid double rounding error.
+        # Run reference on float tensor and then quantize the result for comparison
         X_ref = torch.nn.functional.avg_pool2d(
             X, kernel_size=kernel, stride=stride, padding=padding,
             ceil_mode=ceil_mode, count_include_pad=count_include_pad, divisor_override=divisor_override)

--- a/test/test_quantized.py
+++ b/test/test_quantized.py
@@ -540,7 +540,7 @@ class TestQuantizedOps(TestCase):
             qX_hat = op(qX, kernel_size=kernel, stride=stride, padding=padding, ceil_mode=ceil_mode,
                         count_include_pad=count_include_pad, divisor_override=divisor_override)
             qX_ref = torch.quantize_per_tensor(X_ref, scale=qX_hat.q_scale(), zero_point=qX_hat.q_zero_point(),
-                                       dtype=torch_type)
+                                               dtype=torch_type)
 
             self.assertEqual(qX_ref.int_repr(), qX_hat.int_repr(), prec=1.0,
                              message="{} results are off".format(name, qX_hat.int_repr(), X_ref))
@@ -595,7 +595,7 @@ class TestQuantizedOps(TestCase):
                        count_include_pad=count_include_pad, divisor_override=divisor_override)
             self.assertTrue(X_hat.stride() != sorted(X_hat.stride()))
             qX_ref = torch.quantize_per_tensor(X_ref, scale=X_hat.q_scale(), zero_point=X_hat.q_zero_point(),
-                                       dtype=torch_type)
+                                               dtype=torch_type)
 
             self.assertEqual(qX_ref.int_repr(), X_hat.int_repr().to(torch.double), prec=1.0,
                              message="{} results are off".format(name))

--- a/test/test_quantized.py
+++ b/test/test_quantized.py
@@ -516,7 +516,7 @@ class TestQuantizedOps(TestCase):
         within range. However, the float op will not.
         """
         X, (scale, zero_point, torch_type) = X
-        print(zero_point)
+
         assume(kernel // 2 >= padding)  # Kernel cannot be overhanging!
         iH, iW = X.shape[-2:]
         oH = pool_output_shape(iH, kernel, padding, stride, 0)


### PR DESCRIPTION
This is actually a bug in both testing and the average pool implementation. 
In testing, we used the quantized value as float input and failed to padding the value with zero_point. 
In op implementation, the size for averaging is not correct for padding case when count_include_pad is true.