### PR TITLE
[pytorch] String opts related to deserialization.

### DIFF
--- a/aten/src/ATen/core/qualified_name.h
+++ b/aten/src/ATen/core/qualified_name.h
@@ -105,14 +105,32 @@ struct QualifiedName {
   }
 
  private:
-  char delimiter_ = '.';
+  static constexpr char delimiter_ = '.';
+
+  // Helper for cacheAccessors() below.
+  template<typename T>
+  std::string join(char delimiter, const T& v) {
+    std::string out;
+    size_t reserve = 0;
+    for (const auto& e : v) {
+      reserve += e.size() + 1;
+    }
+    out.reserve(reserve);
+    for (size_t i = 0; i < v.size(); ++i) {
+      if (i != 0) {
+        out.push_back(delimiter_);
+      }
+      out.append(v[i]);
+    }
+    return out;
+  }
 
   void cacheAccessors() {
-    qualifiedName_ = Join(std::string(1, delimiter_), atoms_);
+    qualifiedName_ = join(delimiter_, atoms_);
     if (atoms_.size() > 1) {
       ArrayRef<std::string> view(atoms_);
       const auto prefixView = view.slice(0, view.size() - 1);
-      prefix_ = Join(".", prefixView);
+      prefix_ = join(delimiter_, prefixView);
     }
 
     if (atoms_.size() >= 1) {

--- a/caffe2/serialize/inline_container.cc
+++ b/caffe2/serialize/inline_container.cc
@@ -108,6 +108,7 @@ void PyTorchStreamReader::init() {
     CAFFE_THROW("file in archive is not in a subdirectory: ", buf);
   }
   archive_name_ = buf.substr(0, pos);
+  archive_name_plus_slash_ = archive_name_ + "/";
 
   // version check
   at::DataPtr version_ptr;
@@ -171,9 +172,8 @@ static std::string getPadding(size_t cursor, const std::string& filename, size_t
 }
 
 bool PyTorchStreamReader::hasRecord(const std::string& name) {
-  std::stringstream ss;
-  ss << archive_name_ << "/" << name;
-  mz_zip_reader_locate_file(ar_.get(), ss.str().c_str(), nullptr, 0);
+  std::string ss = archive_name_plus_slash_ + name;
+  mz_zip_reader_locate_file(ar_.get(), ss.c_str(), nullptr, 0);
   bool result = ar_->m_last_error != MZ_ZIP_FILE_NOT_FOUND;
   if (!result) {
     ar_->m_last_error = MZ_ZIP_NO_ERROR;
@@ -183,11 +183,10 @@ bool PyTorchStreamReader::hasRecord(const std::string& name) {
 }
 
 size_t PyTorchStreamReader::getRecordID(const std::string& name) {
-  std::stringstream ss;
-  ss << archive_name_ << "/" << name;
-  size_t result = mz_zip_reader_locate_file(ar_.get(), ss.str().c_str(), nullptr, 0);
+  std::string ss = archive_name_plus_slash_ + name;
+  size_t result = mz_zip_reader_locate_file(ar_.get(), ss.c_str(), nullptr, 0);
   if (ar_->m_last_error == MZ_ZIP_FILE_NOT_FOUND) {
-    CAFFE_THROW("file not found: ", ss.str());
+    CAFFE_THROW("file not found: ", ss);
   }
   valid("locating file ", name.c_str());
   return result;

--- a/caffe2/serialize/inline_container.h
+++ b/caffe2/serialize/inline_container.h
@@ -121,6 +121,7 @@ class CAFFE2_API PyTorchStreamReader final {
   istream_read_func(void* pOpaque, uint64_t file_ofs, void* pBuf, size_t n);
   std::unique_ptr<mz_zip_archive> ar_;
   std::string archive_name_;
+  std::string archive_name_plus_slash_;
   std::unique_ptr<ReadAdapterInterface> in_;
   int64_t version_;
 };

--- a/torch/csrc/jit/import.cpp
+++ b/torch/csrc/jit/import.cpp
@@ -94,8 +94,7 @@ class ScriptModuleDeserializer final {
 };
 
 IValue ScriptModuleDeserializer::readArchive(const std::string& archive_name) {
-  std::stringstream picklename;
-  picklename << archive_name << ".pkl";
+  std::string picklename = archive_name + ".pkl";
   at::DataPtr pickle_ptr;
   size_t pickle_size;
   std::tie(pickle_ptr, pickle_size) = reader_->getRecord(picklename.str());
@@ -153,10 +152,10 @@ IValue ScriptModuleDeserializer::readArchive(const std::string& archive_name) {
     }
   };
 
+  std::string archive_name_plus_slash = archive_name + "/";
   auto read_record = [&](const std::string& name) {
-    std::stringstream ss;
-    ss << archive_name << "/" << name;
-    return std::get<0>(reader_->getRecord(ss.str()));
+    std::string ss = archive_name_plus_slash + name;
+    return std::get<0>(reader_->getRecord(ss));
   };
 
   Unpickler unpickler(

--- a/torch/csrc/jit/import.cpp
+++ b/torch/csrc/jit/import.cpp
@@ -97,7 +97,7 @@ IValue ScriptModuleDeserializer::readArchive(const std::string& archive_name) {
   std::string picklename = archive_name + ".pkl";
   at::DataPtr pickle_ptr;
   size_t pickle_size;
-  std::tie(pickle_ptr, pickle_size) = reader_->getRecord(picklename.str());
+  std::tie(pickle_ptr, pickle_size) = reader_->getRecord(picklename);
 
   size_t bytes_read = 0;
   auto data = reinterpret_cast<const char*>(pickle_ptr.get());

--- a/torch/csrc/jit/script/parser.cpp
+++ b/torch/csrc/jit/script/parser.cpp
@@ -318,12 +318,12 @@ struct ParserImpl {
 
   StringLiteral parseConcatenatedStringLiterals() {
     auto range = L.cur().range;
-    std::stringstream ss;
+    std::string ss;
     while (L.cur().kind == TK_STRINGLITERAL) {
       auto literal_range = L.cur().range;
-      ss << parseStringLiteral(literal_range, L.next().text());
+      ss.append(parseStringLiteral(literal_range, L.next().text()));
     }
-    return StringLiteral::create(range, ss.str());
+    return StringLiteral::create(range, ss);
   }
 
   Expr parseAttributeValue() {

--- a/torch/csrc/jit/unpickler.cpp
+++ b/torch/csrc/jit/unpickler.cpp
@@ -705,14 +705,13 @@ inline bool is_valid_python_id_char(char c) {
 
 // Read a newline terminated string
 std::string Unpickler::readString() {
-  std::stringstream ss;
+  std::string ss;
   while (true) {
     char c = read<char>();
     if (c == '\n') {
       break;
     }
-
-    ss << c;
+    ss.push_back(c);
 
     // Simple check just in case there is no terminating '\n'
     TORCH_CHECK(
@@ -722,7 +721,7 @@ std::string Unpickler::readString() {
         "' in string, ",
         "strings must be qualified Python identifiers");
   }
-  return ss.str();
+  return ss;
 }
 
 } // namespace jit


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#28263 [pytorch] String opts related to deserialization.**

When looking at profiles of deserializing small data from torch::load(),
we found some straightforward string-related changes that in aggregate
improve the base time by 25%.

One of the main problems was over-use of std::stringstream - the
constructors alone were 18%+ of the time spent. This change improves
unpickling/deserializing by converting a handful of the hottest
usecases from the profiles:

 - unpickler's readString() goes from 10.3% of time to mostly out of the picture
 - QualifiedHame constructor (particularly Join call) was 8.9% of time,
   but afterwards disappears from the profiles.
 - getRecordID/hasRecord were ~5% each, but also get somewhat smaller.

Differential Revision: [D17997056](https://our.internmc.facebook.com/intern/diff/D17997056/)