### PR TITLE
autograd/profiler: make python record_function use JIT methods

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -354,6 +354,7 @@ if (NOT INTERN_BUILD_MOBILE OR NOT BUILD_CAFFE2_MOBILE)
     ${TORCH_SRC_DIR}/csrc/autograd/input_buffer.cpp
     ${TORCH_SRC_DIR}/csrc/autograd/profiler.cpp
     ${TORCH_SRC_DIR}/csrc/autograd/record_function.cpp
+    ${TORCH_SRC_DIR}/csrc/autograd/record_function_ops.cpp
     ${TORCH_SRC_DIR}/csrc/autograd/saved_variable.cpp
     ${TORCH_SRC_DIR}/csrc/autograd/variable.cpp
     ${TORCH_SRC_DIR}/csrc/jit/autodiff.cpp

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -2631,18 +2631,55 @@ class TestAutograd(TestCase):
     def test_record_function(self):
         x = torch.randn(10, 10)
 
-        with profile() as p:
-            with record_function("label"):
+        def forward(x):
+            with record_function("outer"):
                 y = x * 2 + 4
+                with record_function("inner"):
+                    y = y - 1
+            y = y / 1
 
-        last_end = 0
-        names = ['mul', 'add']
-        labels = ['label']
-        self.assertEqual(len(p.function_events), len(names) + len(labels))
-        for info, expected_name in zip(p.function_events, labels):
-            self.assertGreater(info.cpu_interval.start, last_end)
+        forward(x)
+
+        with profile() as p:
+            forward(x)
+
+        events = p.function_events
+        start_order = [
+            'profiler::_record_function_enter',
+            'outer',
+            'mul',
+            'add',
+            'profiler::_record_function_enter',
+            'inner',
+            'sub',
+            'profiler::_record_function_exit',
+            'profiler::_record_function_exit',
+            'div',
+        ]
+        self.assertEqual(len(events), len(start_order))
+        for info, expected_name in zip(events, start_order):
             self.assertEqual(info.name, expected_name)
-            last_end = info.cpu_interval.end
+
+        def count_events_before(before, target):
+            matches = [e for e in events if e.name == before]
+            self.assertEqual(len(matches), 1)
+            match = matches[0]
+
+            count = 0
+            for e in events:
+                if e.name == target and e.cpu_interval.end <= match.cpu_interval.end:
+                    count += 1
+            return count
+
+        self.assertEqual(
+            count_events_before("inner", "profiler::_record_function_exit"),
+            1,
+        )
+        self.assertEqual(
+            count_events_before("outer", "profiler::_record_function_exit"),
+            2,
+        )
+
 
     def test_dir(self):
         x = torch.randn(10, 10)

--- a/tools/build_variables.py
+++ b/tools/build_variables.py
@@ -47,6 +47,7 @@ libtorch_sources = [
     "torch/csrc/autograd/input_buffer.cpp",
     "torch/csrc/autograd/profiler.cpp",
     "torch/csrc/autograd/record_function.cpp",
+    "torch/csrc/autograd/record_function_ops.cpp",
     "torch/csrc/autograd/saved_variable.cpp",
     "torch/csrc/autograd/variable.cpp",
     "torch/csrc/distributed/autograd/utils.cpp",

--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -342,10 +342,10 @@ class record_function(object):
         self.name = name
 
     def __enter__(self):
-        torch.autograd._push_range(self.name)
+        self.handle = torch.ops.profiler._record_function_enter(self.name)
 
     def __exit__(self, *args):
-        torch.autograd._pop_range()
+        torch.ops.profiler._record_function_exit(self.handle)
         return False
 
 

--- a/torch/csrc/autograd/record_function.h
+++ b/torch/csrc/autograd/record_function.h
@@ -21,6 +21,20 @@ struct TORCH_API StringView {
   inline const char* str() const {
     return str_ptr_;
   }
+
+  friend std::ostream& operator<<(std::ostream& os, const StringView& dt) {
+    os << dt.str();
+    return os;
+  }
+
+  friend bool operator==(const StringView& lhs, const StringView& rhs) {
+    return strcmp(lhs.str(), rhs.str()) == 0;
+  }
+
+  friend bool operator!=(const StringView& lhs, const StringView& rhs) {
+    return !(lhs == rhs);
+  }
+
  private:
   std::shared_ptr<std::string> owned_str_ptr_;
   const char* str_ptr_;
@@ -29,6 +43,12 @@ struct TORCH_API StringView {
 struct TORCH_API RecordFunction {
   // Default constructor is used with before function called afterwards
   RecordFunction() {}
+
+  RecordFunction(const RecordFunction&) = delete;
+  RecordFunction& operator=(const RecordFunction&) = delete;
+
+  // current returns the currently active RecordFunction in this thread.
+  static RecordFunction* current();
 
   // before function initializes RecordFunction members and calls
   // start callbacks
@@ -81,6 +101,8 @@ struct TORCH_API RecordFunction {
     run_sampled_ = run_sampled;
   }
 
+  void end();
+
  private:
   void processCallbacks();
 
@@ -88,6 +110,7 @@ struct TORCH_API RecordFunction {
   StringView name_;
   int64_t sequence_nr_ = -1;
   std::vector<c10::IValue> inputs_;
+  // parent_ points to the parent RecordFunction and must out live this.
   RecordFunction* parent_ = nullptr;
 
   bool initialized_ = false;

--- a/torch/csrc/autograd/record_function_ops.cpp
+++ b/torch/csrc/autograd/record_function_ops.cpp
@@ -1,0 +1,50 @@
+#include <ATen/cpp_custom_type_hack.h>
+#include <torch/csrc/autograd/record_function.h>
+#include <torch/csrc/jit/custom_operator.h>
+
+namespace caffe2 {
+// Required for cpp_custom_type_hack to work
+CAFFE_KNOWN_TYPE(torch::autograd::profiler::RecordFunction);
+} // namespace caffe2
+
+namespace torch {
+namespace autograd {
+namespace profiler {
+
+at::Tensor record_function_enter(const std::string& name) {
+  auto rec = at::guts::make_unique<RecordFunction>();
+  // Only add new scope if profiling is enabled.
+  if (auto* current = RecordFunction::current()) {
+    AT_ASSERT(
+        current->name() == StringView("profiler::_record_function_enter"));
+    // RecordFunction requires parent_ to be alive for it's entire lifetime.
+    // Since the currently active RecordFunction will only live for the lifetime
+    // of this op we need to end it early so the new RecordFunction we create is
+    // a direct child of the parent RecordFunction.
+    current->end();
+
+    rec->before(name);
+  }
+  return at::cpp_custom_type_hack::create(std::move(rec), at::TensorOptions());
+}
+
+void record_function_exit(const at::Tensor& handle) {
+  // We don't actually need to do anything with handle just need to persist the
+  // lifetime until now.
+  auto& rec = at::cpp_custom_type_hack::cast<RecordFunction>(handle);
+  if (auto* current = RecordFunction::current()) {
+    AT_ASSERT(current->parent() == &rec, "rec must be parent");
+    AT_ASSERT(current->name() == StringView("profiler::_record_function_exit"));
+    current->end();
+    rec.end();
+  }
+}
+
+static auto registry =
+    RegisterOperators()
+        .op("profiler::_record_function_enter", &record_function_enter)
+        .op("profiler::_record_function_exit", &record_function_exit);
+
+} // namespace profiler
+} // namespace autograd
+} // namespace torch


### PR DESCRIPTION
This makes the python autograd.profiler.record_function use two new jit methods. This allows for using record_function in TorchScript modules.

See #28249 for discussion.

Differential Revision: D17997612

