### PR TITLE
Change dper3 loss module to match dper2

### DIFF
--- a/caffe2/python/layers/batch_mse_loss.py
+++ b/caffe2/python/layers/batch_mse_loss.py
@@ -34,12 +34,7 @@ class BatchMSELoss(ModelLayer):
             self.get_next_blob_reference('output'))
 
     def add_ops(self, net):
-        prediction = net.Squeeze(
-            self.input_record.prediction(),
-            net.NextScopedBlob('squeezed_prediction'),
-            dims=[1]
-        )
-
+        prediction = self.input_record.prediction()
         label = self.input_record.label.field_blobs()
         if self.input_record.label.field_type().base != (
                 self.input_record.prediction.field_type().base):
@@ -51,6 +46,8 @@ class BatchMSELoss(ModelLayer):
                     self.input_record.prediction.field_type()
                 )
             )
+
+        label = net.ExpandDims(label, 1, dims=[1])
 
         label = net.StopGradient(
             label,


### PR DESCRIPTION
Summary: Fix the difference in dper3 and dper2 when regressionLoss is used.

Test Plan:
test using dper2 model id f134632386
Comparison tool output before change:
```
FOUND OP DIFFERENT WITH DPER2!!!
OP is of type ExpandDims
OP inputs ['supervision:label']
OP outputs ['sparse_nn/regression_loss/mean_squared_error_loss/ExpandDims:0']
===============================
Finished all dper3 ops, number of good ops 11, bad ops 1, skipped 26
run_comparison for dper2 / dper3 nets running time: 0.0020143985748291016
result type: <class 'NoneType'> result: None
```

After change:

```
FOUND OP DIFFERENT WITH DPER2!!!
OP is of type ExpandDims
OP inputs ['sparse_nn_2/regression_loss_2/mean_squared_error_loss_8/Squeeze:0_grad']
OP outputs ['sparse_nn_2/over_arch_2/linear_2/FC_grad']
===============================
Finished all dper3 ops, number of good ops 19, bad ops 1, skipped 16
run_comparison for dper2 / dper3 nets running time: 0.0017991065979003906
result type: <class 'NoneType'> result: None
```

dper2  label part of net P111794577
dper3  label part of net after change P116817194

Reviewed By: kennyhorror

Differential Revision: D17795740

