### PR TITLE
[BC-breaking] Fix bugs in `torch::tensor` constructor

### DIFF
--- a/test/cpp/api/autograd.cpp
+++ b/test/cpp/api/autograd.cpp
@@ -471,14 +471,14 @@ TEST(CustomAutogradTest, DeepReentrant) {
       }
       {
         at::AutoGradMode enable_grad(true);
-        apply(ctx->saved_data["x"].toTensor()).sum().backward();
+        apply(ctx->saved_data["x"].toTensor())[0].sum().backward();
         return grad_output;
       }
     }
   };
 
   // This should not stack overflow
-  auto v = torch::tensor(8193, torch::requires_grad());
+  auto v = torch::tensor({8193}, torch::requires_grad());
   DeepReenter::apply(v).sum().backward();
 }
 
@@ -512,14 +512,14 @@ TEST(CustomAutogradTest, ReentrantPriority) {
       }
       {
         at::AutoGradMode enable_grad(true);
-        apply(ctx->saved_data["x"].toTensor()).sum().backward();
+        apply(ctx->saved_data["x"].toTensor())[0].sum().backward();
         return grad_output;
       }
     }
   };
 
-  auto a = MyFunction::apply(torch::tensor(6, torch::requires_grad()));
-  auto b = Reenter::apply(torch::tensor(9, torch::requires_grad()));
+  auto a = MyFunction::apply(torch::tensor({6}, torch::requires_grad()));
+  auto b = Reenter::apply(torch::tensor({9}, torch::requires_grad()));
   auto v = a*b;
   v.backward();
 

--- a/test/cpp/api/autograd.cpp
+++ b/test/cpp/api/autograd.cpp
@@ -471,7 +471,7 @@ TEST(CustomAutogradTest, DeepReentrant) {
       }
       {
         at::AutoGradMode enable_grad(true);
-        apply(ctx->saved_data["x"].toTensor())[0].sum().backward();
+        apply(ctx->saved_data["x"].toTensor()).sum().backward();
         return grad_output;
       }
     }
@@ -512,7 +512,7 @@ TEST(CustomAutogradTest, ReentrantPriority) {
       }
       {
         at::AutoGradMode enable_grad(true);
-        apply(ctx->saved_data["x"].toTensor())[0].sum().backward();
+        apply(ctx->saved_data["x"].toTensor()).sum().backward();
         return grad_output;
       }
     }

--- a/test/cpp/api/dataloader.cpp
+++ b/test/cpp/api/dataloader.cpp
@@ -636,7 +636,7 @@ TEST(DataTest, MapDoesNotCopy) {
 
   auto data = dataset.get_batch(1).at(0).data;
   ASSERT_EQ(data.numel(), 1);
-  ASSERT_EQ(data[0].item<float>(), 7);
+  ASSERT_EQ(data.item<float>(), 7);
 }
 
 TEST(DataTest, QueuePushAndPopFromSameThread) {

--- a/test/cpp/api/dataloader.cpp
+++ b/test/cpp/api/dataloader.cpp
@@ -616,8 +616,8 @@ struct UnCopyableDataset : public datasets::Dataset<UnCopyableDataset> {
   ~UnCopyableDataset() = default;
 
   Example<> get(size_t index) override {
-    return {torch::tensor(static_cast<int64_t>(index)),
-            torch::tensor(static_cast<int64_t>(index))};
+    return {torch::tensor({static_cast<int64_t>(index)}),
+            torch::tensor({static_cast<int64_t>(index)})};
   }
 
   torch::optional<size_t> size() const override {
@@ -636,7 +636,7 @@ TEST(DataTest, MapDoesNotCopy) {
 
   auto data = dataset.get_batch(1).at(0).data;
   ASSERT_EQ(data.numel(), 1);
-  ASSERT_EQ(data.item<float>(), 7);
+  ASSERT_EQ(data[0].item<float>(), 7);
 }
 
 TEST(DataTest, QueuePushAndPopFromSameThread) {

--- a/test/cpp/api/parallel.cpp
+++ b/test/cpp/api/parallel.cpp
@@ -212,7 +212,7 @@ TEST_F(ParallelTest, DataParallelUsesAllAvailableCUDADevices_CUDA) {
   struct M : torch::nn::Cloneable<M> {
     void reset() override {}
     torch::Tensor forward(torch::Tensor input) {
-      return torch::tensor(input.device().index());
+      return torch::tensor({input.device().index()});
     }
   };
 

--- a/test/cpp/api/tensor.cpp
+++ b/test/cpp/api/tensor.cpp
@@ -215,6 +215,18 @@ TEST(TensorTest, ContainsCorrectValueForSingleValueVariable) {
   ASSERT_EQ(tensor.sizes(), std::vector<int64_t>({1}));
   ASSERT_EQ(tensor.dtype(), at::kDouble);
   ASSERT_TRUE(almost_equal(tensor[0], 123.456));
+
+  tensor = torch::tensor(true);
+  ASSERT_EQ(tensor.numel(), 1);
+  ASSERT_EQ(tensor.sizes(), std::vector<int64_t>({}));
+  ASSERT_EQ(tensor.dtype(), at::kBool);
+  ASSERT_TRUE(almost_equal(tensor, true));
+
+  tensor = torch::tensor({true});
+  ASSERT_EQ(tensor.numel(), 1);
+  ASSERT_EQ(tensor.sizes(), std::vector<int64_t>({1}));
+  ASSERT_EQ(tensor.dtype(), at::kBool);
+  ASSERT_TRUE(almost_equal(tensor[0], true));
 }
 
 TEST(TensorTest, ContainsCorrectValuesForManyValuesVariable) {
@@ -253,6 +265,15 @@ TEST(TensorTest, ContainsCorrectValuesForManyValuesVariable) {
   ASSERT_TRUE(almost_equal(tensor[0], 1.5));
   ASSERT_TRUE(almost_equal(tensor[1], 2.25));
   ASSERT_TRUE(almost_equal(tensor[2], 3.125));
+
+  tensor = torch::tensor({true, false, true});
+  ASSERT_TRUE(tensor.is_variable());
+  ASSERT_EQ(tensor.numel(), 3);
+  ASSERT_EQ(tensor.sizes(), std::vector<int64_t>({3}));
+  ASSERT_EQ(tensor.dtype(), at::kBool);
+  ASSERT_TRUE(almost_equal(tensor[0], true));
+  ASSERT_TRUE(almost_equal(tensor[1], false));
+  ASSERT_TRUE(almost_equal(tensor[2], true));
 }
 
 TEST(TensorTest, MultidimTensorCtor) {

--- a/test/cpp/api/tensor.cpp
+++ b/test/cpp/api/tensor.cpp
@@ -345,10 +345,6 @@ TEST(TensorTest, MultidimTensorCtor) {
     ASSERT_FALSE(tensor.requires_grad());
   }
   {
-    ASSERT_THROWS_WITH(torch::tensor({1.1, {1.1}}),
-      "some message");
-  }
-  {
     ASSERT_THROWS_WITH(torch::tensor({{{2, 3, 4}, {{5, 6}, {7}}}}),
       "Expected all sub-lists to have sizes: 2 (e.g. {5, 6}), but got sub-list {7} with sizes: 1");
   }
@@ -418,11 +414,6 @@ TEST(TensorTest, PrettyPrintTensorDataContainer) {
     ASSERT_EQ(
       c10::str(torch::detail::TensorDataContainer<1>(1.1)),
       "1.1");
-  }
-  {
-    ASSERT_EQ(
-      c10::str(torch::detail::TensorDataContainer<1>({1.1})),
-      "{1.1}");
   }
   {
     ASSERT_EQ(

--- a/test/cpp/api/tensor.cpp
+++ b/test/cpp/api/tensor.cpp
@@ -277,6 +277,11 @@ TEST(TensorTest, MultidimTensorCtor) {
     ASSERT_FALSE(tensor.requires_grad());
   }
   {
+    auto tensor = torch::tensor({{{{{{{{}}}}, {{{{}}}}}}}});
+    ASSERT_EQ(tensor.sizes(), std::vector<int64_t>({1, 1, 1, 2, 1, 1, 1, 0}));
+    ASSERT_FALSE(tensor.requires_grad());
+  }
+  {
     auto tensor = torch::tensor({{1, 2}});
     ASSERT_EQ(tensor.dtype(), torch::kInt);
     ASSERT_EQ(tensor.sizes(), std::vector<int64_t>({1, 2}));
@@ -360,8 +365,32 @@ TEST(TensorTest, MultidimTensorCtor) {
       "Expected all elements of the tensor to have the same scalar type: Bool, but got element of scalar type: Int");
   }
   {
-    ASSERT_THROWS_WITH(torch::tensor({{{{{{{{{{{{{{{{{{{{{7}}}}}}}}}}}}}}}}}}}}}),
-      "yf225 TODO some err msg");
+    auto tensor = torch::tensor({{{{{{{{{{1}}}}}}}}}});
+    ASSERT_EQ(tensor.dtype(), torch::kInt);
+    ASSERT_EQ(tensor.sizes(), std::vector<int64_t>({1, 1, 1, 1, 1, 1, 1, 1, 1, 1}));
+    ASSERT_TRUE(torch::allclose(tensor, torch::full({1}, 1, torch::kInt).view(tensor.sizes())));
+    ASSERT_FALSE(tensor.requires_grad());
+  }
+  {
+    ASSERT_THROWS_WITH(torch::tensor({{{{{{{{{{{1}}}}}}}}}}}), "Tensor with more than 10 dimensions is not supported");
+  }
+  {
+    auto tensor = torch::tensor({{{{{{{{{{}}}}}}}}}});
+    ASSERT_EQ(tensor.sizes(), std::vector<int64_t>({1, 1, 1, 1, 1, 1, 1, 1, 1, 0}));
+    ASSERT_FALSE(tensor.requires_grad());
+  }
+  {
+    ASSERT_THROWS_WITH(torch::tensor({{{{{{{{{{{}}}}}}}}}}}), "Tensor with more than 10 dimensions is not supported");
+  }
+  {
+    auto tensor = torch::tensor({{{{{{{{{{1, 2}}}}}}}}}});
+    ASSERT_EQ(tensor.dtype(), torch::kInt);
+    ASSERT_EQ(tensor.sizes(), std::vector<int64_t>({1, 1, 1, 1, 1, 1, 1, 1, 1, 2}));
+    ASSERT_TRUE(torch::allclose(tensor, torch::arange(1, 3, torch::kInt).view(tensor.sizes())));
+    ASSERT_FALSE(tensor.requires_grad());
+  }
+  {
+    ASSERT_THROWS_WITH(torch::tensor({{{{{{{{{{{1, 2}}}}}}}}}}}), "Tensor with more than 10 dimensions is not supported");
   }
 }
 
@@ -388,6 +417,11 @@ TEST(TensorTest, PrettyPrintTensorDataContainer) {
   }
   {
     ASSERT_EQ(
+      c10::str(torch::detail::TensorDataContainer<1>({1.1})),
+      "{1.1}");
+  }
+  {
+    ASSERT_EQ(
       c10::str(torch::detail::TensorDataContainer<1>({1.1, 2.2})),
       "{1.1, 2.2}");
   }
@@ -400,6 +434,21 @@ TEST(TensorTest, PrettyPrintTensorDataContainer) {
     ASSERT_EQ(
       c10::str(torch::detail::TensorDataContainer<1>({{{{{{{{1.1, 2.2, 3.3}}}}}, {{{{{4.4, 5.5, 6.6}}}}}, {{{{{7.7, 8.8, 9.9}}}}}}}})),
       "{{{{{{{{1.1, 2.2, 3.3}}}}}, {{{{{4.4, 5.5, 6.6}}}}}, {{{{{7.7, 8.8, 9.9}}}}}}}}");
+  }
+  {
+    ASSERT_EQ(
+      c10::str(torch::detail::TensorDataContainer<1>({{{{{{{{{{1}}}}}}}}}})),
+      "{{{{{{{{{{1}}}}}}}}}}");
+  }
+  {
+    ASSERT_EQ(
+      c10::str(torch::detail::TensorDataContainer<1>({{{{{{{{{{}}}}}}}}}})),
+      "{{{{{{{{{{}}}}}}}}}}");
+  }
+  {
+    ASSERT_EQ(
+      c10::str(torch::detail::TensorDataContainer<1>({{{{{{{{{{1, 2}}}}}}}}}})),
+      "{{{{{{{{{{1, 2}}}}}}}}}}");
   }
 }
 

--- a/test/cpp/api/tensor.cpp
+++ b/test/cpp/api/tensor.cpp
@@ -191,10 +191,37 @@ TEST(TensorTest, ContainsCorrectValuesForManyValues) {
   ASSERT_TRUE(almost_equal(tensor[2], 3.125));
 }
 
+TEST(TensorTest, ContainsCorrectValueForSingleValueVariable) {
+  auto tensor = torch::tensor(123);
+  ASSERT_EQ(tensor.numel(), 1);
+  ASSERT_EQ(tensor.sizes(), std::vector<int64_t>({}));
+  ASSERT_EQ(tensor.dtype(), at::kInt);
+  ASSERT_EQ(tensor.item<int32_t>(), 123);
+
+  tensor = torch::tensor(123.456f);
+  ASSERT_EQ(tensor.numel(), 1);
+  ASSERT_EQ(tensor.sizes(), std::vector<int64_t>({}));
+  ASSERT_EQ(tensor.dtype(), at::kFloat);
+  ASSERT_TRUE(almost_equal(tensor, 123.456f));
+
+  tensor = torch::tensor(123.456);
+  ASSERT_EQ(tensor.numel(), 1);
+  ASSERT_EQ(tensor.sizes(), std::vector<int64_t>({}));
+  ASSERT_EQ(tensor.dtype(), at::kDouble);
+  ASSERT_TRUE(almost_equal(tensor, 123.456));
+
+  tensor = torch::tensor({123.456});
+  ASSERT_EQ(tensor.numel(), 1);
+  ASSERT_EQ(tensor.sizes(), std::vector<int64_t>({1}));
+  ASSERT_EQ(tensor.dtype(), at::kDouble);
+  ASSERT_TRUE(almost_equal(tensor[0], 123.456));
+}
+
 TEST(TensorTest, ContainsCorrectValuesForManyValuesVariable) {
   auto tensor = torch::tensor({1, 2, 3});
   ASSERT_TRUE(tensor.is_variable());
   ASSERT_EQ(tensor.numel(), 3);
+  ASSERT_EQ(tensor.sizes(), std::vector<int64_t>({3}));
   ASSERT_EQ(tensor.dtype(), at::kInt);
   ASSERT_TRUE(exactly_equal(tensor[0], 1));
   ASSERT_TRUE(exactly_equal(tensor[1], 2));
@@ -203,6 +230,7 @@ TEST(TensorTest, ContainsCorrectValuesForManyValuesVariable) {
   tensor = torch::tensor(std::vector<int>({1, 2, 3}));
   ASSERT_TRUE(tensor.is_variable());
   ASSERT_EQ(tensor.numel(), 3);
+  ASSERT_EQ(tensor.sizes(), std::vector<int64_t>({3}));
   ASSERT_EQ(tensor.dtype(), at::kInt);
   ASSERT_TRUE(exactly_equal(tensor[0], 1));
   ASSERT_TRUE(exactly_equal(tensor[1], 2));
@@ -211,6 +239,7 @@ TEST(TensorTest, ContainsCorrectValuesForManyValuesVariable) {
   tensor = torch::tensor({1.5, 2.25, 3.125});
   ASSERT_TRUE(tensor.is_variable());
   ASSERT_EQ(tensor.numel(), 3);
+  ASSERT_EQ(tensor.sizes(), std::vector<int64_t>({3}));
   ASSERT_EQ(tensor.dtype(), at::kDouble);
   ASSERT_TRUE(almost_equal(tensor[0], 1.5));
   ASSERT_TRUE(almost_equal(tensor[1], 2.25));
@@ -219,6 +248,7 @@ TEST(TensorTest, ContainsCorrectValuesForManyValuesVariable) {
   tensor = torch::tensor(std::vector<double>({1.5, 2.25, 3.125}));
   ASSERT_TRUE(tensor.is_variable());
   ASSERT_EQ(tensor.numel(), 3);
+  ASSERT_EQ(tensor.sizes(), std::vector<int64_t>({3}));
   ASSERT_EQ(tensor.dtype(), at::kDouble);
   ASSERT_TRUE(almost_equal(tensor[0], 1.5));
   ASSERT_TRUE(almost_equal(tensor[1], 2.25));
@@ -226,6 +256,26 @@ TEST(TensorTest, ContainsCorrectValuesForManyValuesVariable) {
 }
 
 TEST(TensorTest, MultidimTensorCtor) {
+  {
+    auto tensor = torch::tensor({{}, {}});
+    ASSERT_EQ(tensor.sizes(), std::vector<int64_t>({2, 0}));
+    ASSERT_FALSE(tensor.requires_grad());
+  }
+  {
+    auto tensor = torch::tensor({{{}, {}}});
+    ASSERT_EQ(tensor.sizes(), std::vector<int64_t>({1, 2, 0}));
+    ASSERT_FALSE(tensor.requires_grad());
+  }
+  {
+    auto tensor = torch::tensor({{{}}});
+    ASSERT_EQ(tensor.sizes(), std::vector<int64_t>({1, 1, 0}));
+    ASSERT_FALSE(tensor.requires_grad());
+  }
+  {
+    auto tensor = torch::tensor({{{{{{{{}}}}}}}});
+    ASSERT_EQ(tensor.sizes(), std::vector<int64_t>({1, 1, 1, 1, 1, 1, 1, 0}));
+    ASSERT_FALSE(tensor.requires_grad());
+  }
   {
     auto tensor = torch::tensor({{1, 2}});
     ASSERT_EQ(tensor.dtype(), torch::kInt);
@@ -262,6 +312,13 @@ TEST(TensorTest, MultidimTensorCtor) {
     ASSERT_FALSE(tensor.requires_grad());
   }
   {
+    auto tensor = torch::tensor({{{1}, {2}}});
+    ASSERT_EQ(tensor.dtype(), torch::kInt);
+    ASSERT_EQ(tensor.sizes(), std::vector<int64_t>({1, 2, 1}));
+    ASSERT_TRUE(torch::allclose(tensor, torch::arange(1, 3, torch::kInt).view(tensor.sizes())));
+    ASSERT_FALSE(tensor.requires_grad());
+  }
+  {
     auto tensor = torch::tensor({{1, 2}, {3, 4}});
     ASSERT_EQ(tensor.dtype(), torch::kInt);
     ASSERT_EQ(tensor.sizes(), std::vector<int64_t>({2, 2}));
@@ -294,9 +351,17 @@ TEST(TensorTest, MultidimTensorCtor) {
     ASSERT_THROWS_WITH(torch::tensor({{{true, 2.0, 3}, {true, 2.0, 3}}}),
       "Expected all elements of the tensor to have the same scalar type: Bool, but got element of scalar type: Double");
   }
+  {
+    ASSERT_THROWS_WITH(torch::tensor({{{true}, {2}}}),
+      "Expected all elements of the tensor to have the same scalar type: Bool, but got element of scalar type: Int");
+  }
+  {
+    ASSERT_THROWS_WITH(torch::tensor({{{true, 2}}}),
+      "Expected all elements of the tensor to have the same scalar type: Bool, but got element of scalar type: Int");
+  }
 }
 
-TEST(TensorTest, MultidimTensorCtor_CUDA) {
+TEST(TensorTest, MultidimTensrCtor_CUDA) {
   {
     auto tensor = torch::tensor(
       {{{{{{{{1.0, 2.0, 3.0}}}}}, {{{{{4.0, 5.0, 6.0}}}}}, {{{{{7.0, 8.0, 9.0}}}}}}}},
@@ -311,25 +376,25 @@ TEST(TensorTest, MultidimTensorCtor_CUDA) {
   }
 }
 
-TEST(TensorTest, PrettyPrintInitListTensor) {
+TEST(TensorTest, PrettyPrintTensorDataContainer) {
   {
     ASSERT_EQ(
-      c10::str(torch::detail::InitListTensor(1.1)),
+      c10::str(torch::detail::TensorDataContainer<1>(1.1)),
       "1.1");
   }
   {
     ASSERT_EQ(
-      c10::str(torch::detail::InitListTensor({1.1, 2.2})),
+      c10::str(torch::detail::TensorDataContainer<1>({1.1, 2.2})),
       "{1.1, 2.2}");
   }
   {
     ASSERT_EQ(
-      c10::str(torch::detail::InitListTensor({{1, 2}, {3, 4}})),
+      c10::str(torch::detail::TensorDataContainer<1>({{1, 2}, {3, 4}})),
       "{{1, 2}, {3, 4}}");
   }
   {
     ASSERT_EQ(
-      c10::str(torch::detail::InitListTensor({{{{{{{{1.1, 2.2, 3.3}}}}}, {{{{{4.4, 5.5, 6.6}}}}}, {{{{{7.7, 8.8, 9.9}}}}}}}})),
+      c10::str(torch::detail::TensorDataContainer<1>({{{{{{{{1.1, 2.2, 3.3}}}}}, {{{{{4.4, 5.5, 6.6}}}}}, {{{{{7.7, 8.8, 9.9}}}}}}}})),
       "{{{{{{{{1.1, 2.2, 3.3}}}}}, {{{{{4.4, 5.5, 6.6}}}}}, {{{{{7.7, 8.8, 9.9}}}}}}}}");
   }
 }

--- a/test/cpp/api/tensor.cpp
+++ b/test/cpp/api/tensor.cpp
@@ -359,6 +359,10 @@ TEST(TensorTest, MultidimTensorCtor) {
     ASSERT_THROWS_WITH(torch::tensor({{{true, 2}}}),
       "Expected all elements of the tensor to have the same scalar type: Bool, but got element of scalar type: Int");
   }
+  {
+    ASSERT_THROWS_WITH(torch::tensor({{{{{{{{{{{{{{{{{{{{{7}}}}}}}}}}}}}}}}}}}}}),
+      "yf225 TODO some err msg");
+  }
 }
 
 TEST(TensorTest, MultidimTensrCtor_CUDA) {

--- a/test/cpp/api/tensor.cpp
+++ b/test/cpp/api/tensor.cpp
@@ -257,27 +257,37 @@ TEST(TensorTest, ContainsCorrectValuesForManyValuesVariable) {
 
 TEST(TensorTest, MultidimTensorCtor) {
   {
+    auto tensor = torch::tensor({});
+    ASSERT_EQ(tensor.numel(), 0);
+    ASSERT_EQ(tensor.sizes(), std::vector<int64_t>({0}));
+  }
+  {
     auto tensor = torch::tensor({{}, {}});
+    ASSERT_EQ(tensor.numel(), 0);
     ASSERT_EQ(tensor.sizes(), std::vector<int64_t>({2, 0}));
     ASSERT_FALSE(tensor.requires_grad());
   }
   {
     auto tensor = torch::tensor({{{}, {}}});
+    ASSERT_EQ(tensor.numel(), 0);
     ASSERT_EQ(tensor.sizes(), std::vector<int64_t>({1, 2, 0}));
     ASSERT_FALSE(tensor.requires_grad());
   }
   {
     auto tensor = torch::tensor({{{}}});
+    ASSERT_EQ(tensor.numel(), 0);
     ASSERT_EQ(tensor.sizes(), std::vector<int64_t>({1, 1, 0}));
     ASSERT_FALSE(tensor.requires_grad());
   }
   {
     auto tensor = torch::tensor({{{{{{{{}}}}}}}});
+    ASSERT_EQ(tensor.numel(), 0);
     ASSERT_EQ(tensor.sizes(), std::vector<int64_t>({1, 1, 1, 1, 1, 1, 1, 0}));
     ASSERT_FALSE(tensor.requires_grad());
   }
   {
     auto tensor = torch::tensor({{{{{{{{}}}}, {{{{}}}}}}}});
+    ASSERT_EQ(tensor.numel(), 0);
     ASSERT_EQ(tensor.sizes(), std::vector<int64_t>({1, 1, 1, 2, 1, 1, 1, 0}));
     ASSERT_FALSE(tensor.requires_grad());
   }
@@ -376,6 +386,7 @@ TEST(TensorTest, MultidimTensorCtor) {
   }
   {
     auto tensor = torch::tensor({{{{{{{{{{}}}}}}}}}});
+    ASSERT_EQ(tensor.numel(), 0);
     ASSERT_EQ(tensor.sizes(), std::vector<int64_t>({1, 1, 1, 1, 1, 1, 1, 1, 1, 0}));
     ASSERT_FALSE(tensor.requires_grad());
   }

--- a/test/cpp/api/tensor.cpp
+++ b/test/cpp/api/tensor.cpp
@@ -345,6 +345,10 @@ TEST(TensorTest, MultidimTensorCtor) {
     ASSERT_FALSE(tensor.requires_grad());
   }
   {
+    ASSERT_THROWS_WITH(torch::tensor({1.1, {1.1}}),
+      "some message");
+  }
+  {
     ASSERT_THROWS_WITH(torch::tensor({{{2, 3, 4}, {{5, 6}, {7}}}}),
       "Expected all sub-lists to have sizes: 2 (e.g. {5, 6}), but got sub-list {7} with sizes: 1");
   }

--- a/test/cpp/api/tensor.cpp
+++ b/test/cpp/api/tensor.cpp
@@ -385,6 +385,9 @@ TEST(TensorTest, MultidimTensorCtor) {
     ASSERT_THROWS_WITH(torch::tensor({{{{{{{{{{{1}}}}}}}}}}}), "Tensor with more than 10 dimensions is not supported");
   }
   {
+    ASSERT_THROWS_WITH(torch::tensor({{{{{{{{{{{{1}}}}}}}}}}}}), "Tensor with more than 10 dimensions is not supported");
+  }
+  {
     auto tensor = torch::tensor({{{{{{{{{{}}}}}}}}}});
     ASSERT_EQ(tensor.numel(), 0);
     ASSERT_EQ(tensor.sizes(), std::vector<int64_t>({1, 1, 1, 1, 1, 1, 1, 1, 1, 0}));
@@ -392,6 +395,9 @@ TEST(TensorTest, MultidimTensorCtor) {
   }
   {
     ASSERT_THROWS_WITH(torch::tensor({{{{{{{{{{{}}}}}}}}}}}), "Tensor with more than 10 dimensions is not supported");
+  }
+  {
+    ASSERT_THROWS_WITH(torch::tensor({{{{{{{{{{{{}}}}}}}}}}}}), "Tensor with more than 10 dimensions is not supported");
   }
   {
     auto tensor = torch::tensor({{{{{{{{{{1, 2}}}}}}}}}});
@@ -402,6 +408,9 @@ TEST(TensorTest, MultidimTensorCtor) {
   }
   {
     ASSERT_THROWS_WITH(torch::tensor({{{{{{{{{{{1, 2}}}}}}}}}}}), "Tensor with more than 10 dimensions is not supported");
+  }
+  {
+    ASSERT_THROWS_WITH(torch::tensor({{{{{{{{{{{{1, 2}}}}}}}}}}}}), "Tensor with more than 10 dimensions is not supported");
   }
 }
 

--- a/test/cpp/api/tensor.cpp
+++ b/test/cpp/api/tensor.cpp
@@ -248,6 +248,13 @@ TEST(TensorTest, MultidimTensorCtor) {
     ASSERT_FALSE(tensor.requires_grad());
   }
   {
+    auto tensor = torch::tensor({{1}, {2}});
+    ASSERT_EQ(tensor.dtype(), torch::kInt);
+    ASSERT_EQ(tensor.sizes(), std::vector<int64_t>({2, 1}));
+    ASSERT_TRUE(torch::allclose(tensor, torch::arange(1, 3, torch::kInt).view(tensor.sizes())));
+    ASSERT_FALSE(tensor.requires_grad());
+  }
+  {
     auto tensor = torch::tensor({{{1, 2}}});
     ASSERT_EQ(tensor.dtype(), torch::kInt);
     ASSERT_EQ(tensor.sizes(), std::vector<int64_t>({1, 1, 2}));

--- a/tools/autograd/templates/variable_factories.h
+++ b/tools/autograd/templates/variable_factories.h
@@ -130,14 +130,14 @@ AT_FORALL_SCALAR_TYPES_AND3(Bool, Half, BFloat16, TENSOR)
   }
 
 #define TENSOR(T, S) \
-  TensorDataContainer(at::ArrayRef<T> values) { \
+  explicit TensorDataContainer(at::ArrayRef<T> values) { \
     at::AutoNonVariableTypeMode non_var_type_mode(true);  \
     type_ = TensorDataContainerType::Tensor; \
     sizes_ = {(int64_t)values.size()}; \
     scalar_type_ = at::k##S; \
     tensor_ = at::tensor(values, at::TensorOptions().device(at::kCPU).is_variable(false));       \
   } \
-  TensorDataContainer(std::vector<T> values) : TensorDataContainer(at::ArrayRef<T>(values)) {}
+  explicit TensorDataContainer(std::vector<T> values) : TensorDataContainer(at::ArrayRef<T>(values)) {}
 AT_FORALL_SCALAR_TYPES_AND3(Bool, Half, BFloat16, TENSOR)
 #undef TENSOR
 

--- a/tools/autograd/templates/variable_factories.h
+++ b/tools/autograd/templates/variable_factories.h
@@ -130,14 +130,14 @@ AT_FORALL_SCALAR_TYPES_AND3(Bool, Half, BFloat16, TENSOR)
   }
 
 #define TENSOR(T, S) \
-  explicit TensorDataContainer(at::ArrayRef<T> values) { \
+  TensorDataContainer(at::ArrayRef<T> values) { \
     at::AutoNonVariableTypeMode non_var_type_mode(true);  \
     type_ = TensorDataContainerType::Tensor; \
     sizes_ = {(int64_t)values.size()}; \
     scalar_type_ = at::k##S; \
     tensor_ = at::tensor(values, at::TensorOptions().device(at::kCPU).is_variable(false));       \
   } \
-  explicit TensorDataContainer(std::vector<T> values) : TensorDataContainer(at::ArrayRef<T>(values)) {}
+  TensorDataContainer(std::vector<T> values) : TensorDataContainer(at::ArrayRef<T>(values)) {}
 AT_FORALL_SCALAR_TYPES_AND3(Bool, Half, BFloat16, TENSOR)
 #undef TENSOR
 

--- a/tools/autograd/templates/variable_factories.h
+++ b/tools/autograd/templates/variable_factories.h
@@ -92,7 +92,7 @@ enum class TensorDataContainerType { Scalar, InitList, Tensor };
 // constructor, thus producing a tensor with the wrong sizes. If we templatize `TensorDataContainer` over
 // the # of tensor dimensions, such problem doesn't happen.
 template <size_t D>
-class TensorDataContainer {
+struct TensorDataContainer {
   // NOTE: For tensors with zero-size dimensions (e.g. `torch::tensor({{}, {}})`),
   // the innermost empty braced-init-list `{}` matches the default constructor of
   // the innermost `TensorDataContainer`.
@@ -236,7 +236,7 @@ AT_FORALL_SCALAR_TYPES_AND3(Bool, Half, BFloat16, TENSOR)
   TensorDataContainerType type_;
   at::Tensor tensor_;
 
-  friend class TensorDataContainer<(D > 1) ? D-1 : D>;
+  friend struct TensorDataContainer<(D > 1) ? D-1 : D>;
 };
 
 template <size_t D>
@@ -257,8 +257,7 @@ inline std::ostream& operator<<(std::ostream& stream, const TensorDataContainer<
 // Following the above reasoning, `TensorDataContainer<NESTED_INIT_LIST_MAX_DEPTH+1>` should only
 // accept scalars, and we throw "dimension exceeded" error in other constructors.
 template<>
-class TensorDataContainer<NESTED_INIT_LIST_MAX_DEPTH+1> {
- public:
+struct TensorDataContainer<NESTED_INIT_LIST_MAX_DEPTH+1> {
   TensorDataContainer() {
     TORCH_CHECK(
       false,
@@ -316,6 +315,7 @@ AT_FORALL_SCALAR_TYPES_AND3(Bool, Half, BFloat16, TENSOR)
       TORCH_INTERNAL_ASSERT(false, "Only scalar type is supported for this TensorDataContainer");
     }
   }
+
  private:
   std::vector<int64_t> sizes_;
   c10::Scalar scalar_;

--- a/tools/autograd/templates/variable_factories.h
+++ b/tools/autograd/templates/variable_factories.h
@@ -54,7 +54,7 @@ inline void fill_tensor(const TensorDataContainer<D>& init_list_tensor, at::Tens
 // otherwise `recursive template instantiation exceeded maximum depth`
 // error would be thrown.
 template <>
-inline void fill_tensor(const TensorDataContainer<TENSOR_CTOR_MAX_NUM_DIMS+1>& init_list_tensor, at::Tensor tensor) {
+inline void fill_tensor(const TensorDataContainer<TENSOR_CTOR_MAX_NUM_DIMS>& init_list_tensor, at::Tensor tensor) {
   TORCH_CHECK(
     false,
     "Tensor with more than ", TENSOR_CTOR_MAX_NUM_DIMS, " dimensions is not supported"); // yf225 TODO: add a test for this
@@ -95,7 +95,7 @@ inline std::ostream& operator<<(std::ostream& stream, const TensorDataContainer<
 template <>
 inline std::ostream& operator<<(
     std::ostream& stream,
-    const TensorDataContainer<TENSOR_CTOR_MAX_NUM_DIMS+1>& init_list_tensor) {
+    const TensorDataContainer<TENSOR_CTOR_MAX_NUM_DIMS>& init_list_tensor) {
   TORCH_CHECK(
     false,
     "Tensor with more than ", TENSOR_CTOR_MAX_NUM_DIMS, " dimensions is not supported"); // yf225 TODO: add a test for this

--- a/tools/autograd/templates/variable_factories.h
+++ b/tools/autograd/templates/variable_factories.h
@@ -31,10 +31,6 @@ template <size_t D> struct TensorDataContainer;
 
 template <size_t D>
 inline void fill_tensor(const TensorDataContainer<D>& init_list_tensor, at::Tensor tensor) {
-  static_assert(
-    D <= TENSOR_CTOR_MAX_NUM_DIMS,
-    "Tensor with more than 10 dimensions is not supported");
-
   size_t index = 0;
   for (const auto& elem : init_list_tensor.init_list()) {
     if (elem.type() == TensorDataContainerType::Scalar) {
@@ -53,20 +49,16 @@ inline void fill_tensor(const TensorDataContainer<D>& init_list_tensor, at::Tens
   }
 }
 
-// // NOTE: We add an explicit template specialization for `fill_tensor`
-// template <>
-// inline void fill_tensor(const TensorDataContainer<TENSOR_CTOR_MAX_NUM_DIMS+1>& init_list_tensor, at::Tensor tensor) {
-//   TORCH_CHECK(
-//     false,
-//     ); // yf225 TODO: add a test for this
-// }
+// NOTE: We add an explicit template specialization for `fill_tensor`
+template <>
+inline void fill_tensor(const TensorDataContainer<TENSOR_CTOR_MAX_NUM_DIMS+1>& init_list_tensor, at::Tensor tensor) {
+  TORCH_CHECK(
+    false,
+    "Tensor with more than ", TENSOR_CTOR_MAX_NUM_DIMS, " dimensions is not supported"); // yf225 TODO: add a test for this
+}
 
 template <size_t D>
 inline std::ostream& operator<<(std::ostream& stream, const TensorDataContainer<D>& init_list_tensor) {
-  static_assert(
-    D <= TENSOR_CTOR_MAX_NUM_DIMS,
-    "Tensor with more than 10 dimensions is not supported");
-
   if (init_list_tensor.type() == TensorDataContainerType::Scalar) {
     AT_DISPATCH_ALL_TYPES_AND3(at::kBool, at::kHalf, at::kBFloat16, init_list_tensor.scalar_type(), "TensorDataContainer_pretty_print_scalar", [&] {
       stream << init_list_tensor.scalar().template to<scalar_t>();
@@ -93,15 +85,15 @@ inline std::ostream& operator<<(std::ostream& stream, const TensorDataContainer<
   return stream;
 }
 
-// template <>
-// inline std::ostream& operator<<(
-//     std::ostream& stream,
-//     const TensorDataContainer<TENSOR_CTOR_MAX_NUM_DIMS+1>& init_list_tensor) {
-//   TORCH_CHECK(
-//     false,
-//     "Tensor with more than ", TENSOR_CTOR_MAX_NUM_DIMS, " dimensions is not supported"); // yf225 TODO: add a test for this
-//   return stream;
-// }
+template <>
+inline std::ostream& operator<<(
+    std::ostream& stream,
+    const TensorDataContainer<TENSOR_CTOR_MAX_NUM_DIMS+1>& init_list_tensor) {
+  TORCH_CHECK(
+    false,
+    "Tensor with more than ", TENSOR_CTOR_MAX_NUM_DIMS, " dimensions is not supported"); // yf225 TODO: add a test for this
+  return stream;
+}
 
 // We use `TensorDataContainer` to support converting the following data container types
 // into the equivalent Tensor:

--- a/tools/autograd/templates/variable_factories.h
+++ b/tools/autograd/templates/variable_factories.h
@@ -31,6 +31,10 @@ template <size_t D> struct TensorDataContainer;
 
 template <size_t D>
 inline void fill_tensor(const TensorDataContainer<D>& init_list_tensor, at::Tensor tensor) {
+  static_assert(
+    D <= TENSOR_CTOR_MAX_NUM_DIMS,
+    "Tensor with more than 10 dimensions is not supported");
+
   size_t index = 0;
   for (const auto& elem : init_list_tensor.init_list()) {
     if (elem.type() == TensorDataContainerType::Scalar) {
@@ -49,16 +53,20 @@ inline void fill_tensor(const TensorDataContainer<D>& init_list_tensor, at::Tens
   }
 }
 
-// NOTE: We add an explicit template specialization for `fill_tensor`
-template <>
-inline void fill_tensor(const TensorDataContainer<TENSOR_CTOR_MAX_NUM_DIMS+1>& init_list_tensor, at::Tensor tensor) {
-  TORCH_CHECK(
-    false,
-    "Tensor with more than ", TENSOR_CTOR_MAX_NUM_DIMS, " dimensions is not supported"); // yf225 TODO: add a test for this
-}
+// // NOTE: We add an explicit template specialization for `fill_tensor`
+// template <>
+// inline void fill_tensor(const TensorDataContainer<TENSOR_CTOR_MAX_NUM_DIMS+1>& init_list_tensor, at::Tensor tensor) {
+//   TORCH_CHECK(
+//     false,
+//     ); // yf225 TODO: add a test for this
+// }
 
 template <size_t D>
 inline std::ostream& operator<<(std::ostream& stream, const TensorDataContainer<D>& init_list_tensor) {
+  static_assert(
+    D <= TENSOR_CTOR_MAX_NUM_DIMS,
+    "Tensor with more than 10 dimensions is not supported");
+
   if (init_list_tensor.type() == TensorDataContainerType::Scalar) {
     AT_DISPATCH_ALL_TYPES_AND3(at::kBool, at::kHalf, at::kBFloat16, init_list_tensor.scalar_type(), "TensorDataContainer_pretty_print_scalar", [&] {
       stream << init_list_tensor.scalar().template to<scalar_t>();
@@ -85,15 +93,15 @@ inline std::ostream& operator<<(std::ostream& stream, const TensorDataContainer<
   return stream;
 }
 
-template <>
-inline std::ostream& operator<<(
-    std::ostream& stream,
-    const TensorDataContainer<TENSOR_CTOR_MAX_NUM_DIMS+1>& init_list_tensor) {
-  TORCH_CHECK(
-    false,
-    "Tensor with more than ", TENSOR_CTOR_MAX_NUM_DIMS, " dimensions is not supported"); // yf225 TODO: add a test for this
-  return stream;
-}
+// template <>
+// inline std::ostream& operator<<(
+//     std::ostream& stream,
+//     const TensorDataContainer<TENSOR_CTOR_MAX_NUM_DIMS+1>& init_list_tensor) {
+//   TORCH_CHECK(
+//     false,
+//     "Tensor with more than ", TENSOR_CTOR_MAX_NUM_DIMS, " dimensions is not supported"); // yf225 TODO: add a test for this
+//   return stream;
+// }
 
 // We use `TensorDataContainer` to support converting the following data container types
 // into the equivalent Tensor:

--- a/tools/autograd/templates/variable_factories.h
+++ b/tools/autograd/templates/variable_factories.h
@@ -22,80 +22,145 @@ using at::DimnameList;
 namespace torch {
 
 namespace detail {
-  enum class InitListTensorType { Scalar, InitList };
+enum class TensorDataContainerType { Scalar, InitList, Tensor };
 
-  // We use `InitListTensor` to support converting an arbitrarily nested braced-init-list
-  // (e.g. {{1, 2}, {3, 4}}) into the equivalent Tensor, taking advantage of the fact that
-  // the constructor will automatically be called recursively until it reaches all innermost
-  // scalar values.
-  //
-  // At any time, a `InitListTensor` object represents either of the following:
-  // 1. A scalar with value `scalar()` and type `scalar_type()`.
-  // 2. A Tensor represented in `std::initializer_list<InitListTensor>` form, with value
-  //    `init_list()`, Tensor scalar type `scalar_type()`, and Tensor sizes `sizes()`.
-  struct InitListTensor {
-#define TENSOR(T, S)                   \
-    InitListTensor(T scalar) :         \
-        scalar_(scalar), init_list_(), \
-        sizes_(),                      \
-        scalar_type_(at::k##S),        \
-        type_(InitListTensorType::Scalar) {}
+template <size_t D> struct TensorDataContainer;
+
+template <size_t D>
+inline void fill_tensor(const TensorDataContainer<D>& init_list_tensor, at::Tensor tensor) {
+  size_t index = 0;
+  for (const auto& elem : init_list_tensor.init_list()) {
+    if (elem.type() == TensorDataContainerType::Scalar) {
+      at::NoGradGuard guard;
+      tensor[index].fill_(elem.scalar());
+    } else if (elem.type() == TensorDataContainerType::InitList) {
+      fill_tensor(elem, tensor[index]);
+    } else if (elem.type() == TensorDataContainerType::Tensor) {
+      TORCH_INTERNAL_ASSERT(
+        false,
+        "TensorDataContainer is already a Tensor type, `fill_tensor` should not be called");
+    } else {
+      TORCH_INTERNAL_ASSERT(false, "Invalid TensorDataContainer type");
+    }
+    index++;
+  }
+}
+
+template <>
+inline void fill_tensor(const TensorDataContainer<11>& init_list_tensor, at::Tensor tensor) {
+  TORCH_CHECK(false, "Tensor has too many dimensions");  // yf225 TODO: improve error msg
+}
+
+template <size_t D>
+inline std::ostream& operator<<(std::ostream& stream, const TensorDataContainer<D>& init_list_tensor) {
+  if (init_list_tensor.type() == TensorDataContainerType::Scalar) {
+    AT_DISPATCH_ALL_TYPES_AND3(at::kBool, at::kHalf, at::kBFloat16, init_list_tensor.scalar_type(), "TensorDataContainer_pretty_print_scalar", [&] {
+      stream << init_list_tensor.scalar().template to<scalar_t>();
+    });
+  } else if (init_list_tensor.type() == TensorDataContainerType::InitList) {
+    stream << "{";
+    for (const TensorDataContainer<D+1>* it = init_list_tensor.init_list().begin(); it != init_list_tensor.init_list().end(); it++) {
+      stream << *it;
+      if (std::next(it) != init_list_tensor.init_list().end()) stream << ", ";
+    }
+    stream << "}";
+  } else if (init_list_tensor.type() == TensorDataContainerType::Tensor) {
+    auto tensor = init_list_tensor.to_tensor({});
+    stream << "{";
+    for (int64_t i = 0; i < tensor.sizes()[0]; i++) {
+      AT_DISPATCH_ALL_TYPES_AND3(at::kBool, at::kHalf, at::kBFloat16, init_list_tensor.scalar_type(), "TensorDataContainer_pretty_print_tensor_item", [&] {
+        stream << tensor[i].template item<scalar_t>();
+      });
+    }
+    stream << "}";
+  } else {
+    TORCH_INTERNAL_ASSERT(false, "Invalid TensorDataContainer type");
+  }
+  return stream;
+}
+
+template <>
+inline std::ostream& operator<<(std::ostream& stream, const TensorDataContainer<11>& init_list_tensor) {
+  TORCH_CHECK(false, "Tensor has too many dimensions");  // yf225 TODO: improve error msg
+  return stream;
+}
+
+template <size_t D>
+struct TensorDataContainer {
+  // NOTE: For tensors with zero-size dimensions (e.g. `torch::tensor({{}, {}})`),
+  // the innermost empty braced-init-list `{}` matches the default constructor of
+  // the innermost `TensorDataContainer`.
+  TensorDataContainer() : sizes_({0}), scalar_type_(at::ScalarType::Undefined), type_(TensorDataContainerType::InitList) {}
+#define TENSOR(T, S) \
+  TensorDataContainer(T value) : sizes_(), scalar_(value), scalar_type_(at::k##S), type_(TensorDataContainerType::Scalar) {}
 AT_FORALL_SCALAR_TYPES_AND3(Bool, Half, BFloat16, TENSOR)
 #undef TENSOR
-    InitListTensor(std::initializer_list<InitListTensor> init_list) :
-        scalar_(),
-        init_list_(init_list),
-        sizes_(),
-        scalar_type_(),
-        type_(InitListTensorType::InitList) {
-      TORCH_CHECK(
-        init_list.size() > 0,
-        "Empty init-list is not yet supported. We can create tensors with zero-size dimensions in the following way:\n",
-        "1-D: `torch::randn({0})`\n",
-        "N-D: `torch::randn({2, 3, 0})`");
-      scalar_type_ = init_list.begin()->scalar_type_;
-      const InitListTensor& first_elem = *(init_list.begin());
-      for (const auto& elem : init_list) {
-        TORCH_CHECK(elem.scalar_type_ == first_elem.scalar_type_,
-          "Expected all elements of the tensor to have the same scalar type: ",
-          first_elem.scalar_type_,
-          ", but got element of scalar type: ",
-          elem.scalar_type_);
-        TORCH_CHECK(elem.sizes_ == first_elem.sizes_,
-          "Expected all sub-lists to have sizes: ",
-          first_elem.sizes_,
-          " (e.g. ", first_elem, "), ",
-          "but got sub-list ",
-          elem,
-          " with sizes: ",
-          elem.sizes_);
-      }
-      sizes_.reserve(first_elem.sizes_.size() + 1);
-      sizes_.push_back(init_list.size());
-      sizes_.insert(sizes_.end(), first_elem.sizes_.begin(), first_elem.sizes_.end());
+  TensorDataContainer(std::initializer_list<TensorDataContainer<D+1>> init_list) :
+      sizes_(),
+      scalar_(),
+      scalar_type_(init_list.begin()->scalar_type()),
+      init_list_(init_list),
+      type_(TensorDataContainerType::InitList) {
+    const TensorDataContainer<D+1>& first_elem = *(init_list.begin());
+    for (const auto& elem : init_list) {
+      TORCH_CHECK(elem.sizes() == first_elem.sizes(),
+        "Expected all sub-lists to have sizes: ",
+        first_elem.sizes(),
+        " (e.g. ", first_elem, "), ",
+        "but got sub-list ",
+        elem,
+        " with sizes: ",
+        elem.sizes());
+      TORCH_CHECK(elem.scalar_type() == first_elem.scalar_type(),
+        "Expected all elements of the tensor to have the same scalar type: ",
+        first_elem.scalar_type(),
+        ", but got element of scalar type: ",
+        elem.scalar_type());
     }
+    sizes_.clear();
+    sizes_.reserve(first_elem.sizes().size() + 1);
+    sizes_.push_back(init_list.size());
+    sizes_.insert(sizes_.end(), first_elem.sizes().begin(), first_elem.sizes().end());
+  }
 
-    const c10::Scalar& scalar() const {
-      return scalar_;
-    }
+#define TENSOR(T, S) \
+  TensorDataContainer(at::ArrayRef<T> values) { \
+    type_ = TensorDataContainerType::Tensor; \
+    sizes_ = {(int64_t)values.size()}; \
+    scalar_type_ = at::k##S; \
+    at::AutoNonVariableTypeMode non_var_type_mode(true);  \
+    tensor_ = at::tensor(values, at::TensorOptions().device(at::kCPU).is_variable(false));       \
+  } \
+  TensorDataContainer(std::vector<T> values) : TensorDataContainer(at::ArrayRef<T>(values)) {}
+AT_FORALL_SCALAR_TYPES_AND3(Bool, Half, BFloat16, TENSOR)
+#undef TENSOR
 
-    const std::initializer_list<InitListTensor>& init_list() const {
-      return init_list_;
-    }
+  const c10::Scalar& scalar() const {
+    return scalar_;
+  }
 
-    const std::vector<int64_t>& sizes() const {
-      return sizes_;
-    }
+  const std::initializer_list<TensorDataContainer<D+1>>& init_list() const {
+    return init_list_;
+  }
 
-    const c10::ScalarType& scalar_type() const {
-      return scalar_type_;
-    }
+  const std::vector<int64_t>& sizes() const {
+    return sizes_;
+  }
 
-    const InitListTensorType& type() const {
-      return type_;
-    }
+  const c10::ScalarType& scalar_type() const {
+    return scalar_type_;
+  }
 
-    at::Tensor to_tensor(const at::TensorOptions& options) const {
+  const TensorDataContainerType& type() const {
+    return type_;
+  }
+
+  at::Tensor to_tensor(const at::TensorOptions& options) const {
+    if (type_ == TensorDataContainerType::Tensor) {
+      return tensor_.to(options);
+    } else if (type_ == TensorDataContainerType::Scalar) {
+      return at::scalar_tensor(scalar_, options);
+    } else if (type_ == TensorDataContainerType::InitList) {
       // NOTE: Here we explicitly choose to initialize the tensor on CPU first,
       // fill each element of the tensor, and then move the tensor to the desired
       // device. For CUDA device, this approach only involves 1 CUDA kernel launch,
@@ -106,113 +171,34 @@ AT_FORALL_SCALAR_TYPES_AND3(Bool, Half, BFloat16, TENSOR)
         at::AutoNonVariableTypeMode non_var_type_mode(true);
         return at::empty(sizes_, at::TensorOptions(options).device(at::kCPU).is_variable(false));
       })();
-      fill_tensor(tensor);
+      fill_tensor(*this, tensor);
       return tensor.to(options.device());
+    } else {
+      TORCH_INTERNAL_ASSERT(false, "Invalid TensorDataContainer type");
     }
-
-    void pretty_print_recursive(std::ostream& stream) const {
-      if (type_ == InitListTensorType::Scalar) {
-        AT_DISPATCH_ALL_TYPES_AND3(at::kBool, at::kHalf, at::kBFloat16, scalar_type_, "InitListTensor_pretty_print_scalar", [&] {
-          stream << scalar_.to<scalar_t>();
-        });
-      } else if (type_ == InitListTensorType::InitList) {
-        stream << "{";
-        for (const InitListTensor* it = init_list_.begin(); it != init_list_.end(); it++) {
-          it->pretty_print_recursive(stream);
-          if (std::next(it) != init_list_.end()) stream << ", ";
-        }
-        stream << "}";
-      }
-    }
-
-   private:
-    void fill_tensor(at::Tensor tensor) const {
-      size_t index = 0;
-      for (const auto& elem : init_list_) {
-        if (elem.type_ == InitListTensorType::Scalar) {
-          at::NoGradGuard guard;
-          tensor[index].fill_(elem.scalar());
-        } else if (elem.type_ == InitListTensorType::InitList) {
-          elem.fill_tensor(tensor[index]);
-        } else {
-          TORCH_INTERNAL_ASSERT(false, "Invalid InitListTensor");
-        }
-        index++;
-      }
-    }
-    c10::Scalar scalar_;
-    std::initializer_list<InitListTensor> init_list_;
-    std::vector<int64_t> sizes_;
-    c10::ScalarType scalar_type_;
-    InitListTensorType type_;
-  };
-
-  inline std::ostream& operator<<(std::ostream& stream, const InitListTensor& init_list_tensor) {
-    init_list_tensor.pretty_print_recursive(stream);
-    return stream;
   }
+ private:
+  std::vector<int64_t> sizes_;
+  c10::Scalar scalar_;
+  c10::ScalarType scalar_type_;
+  std::initializer_list<TensorDataContainer<D+1>> init_list_;
+  TensorDataContainerType type_;
+  at::Tensor tensor_;
+};
+
 } // namespace detail
 
-#define TENSOR(T, S)                                                       \
-  inline at::Tensor tensor(                                                \
-      at::ArrayRef<T> values, const at::TensorOptions& options) {          \
-    at::Tensor result = ([&]() {                                           \
-      at::AutoNonVariableTypeMode non_var_type_mode(true);                 \
-      return at::tensor(values, at::TensorOptions(options).is_variable(false)); \
-    })();                                                                  \
-    return autograd::make_variable(result, options.requires_grad());       \
-  }                                                                        \
-  inline at::Tensor tensor(                                                \
-      std::initializer_list<T> values, const at::TensorOptions& options) { \
-    return torch::tensor(at::ArrayRef<T>(values), options);                \
-  }                                                                        \
-  inline at::Tensor tensor(T value, const at::TensorOptions& options) {    \
-    return torch::tensor(at::ArrayRef<T>(value), options);                 \
-  }                                                                        \
-  inline at::Tensor tensor(at::ArrayRef<T> values) {                       \
-    return torch::tensor(std::move(values), at::dtype(at::k##S));          \
-  }                                                                        \
-  inline at::Tensor tensor(std::initializer_list<T> values) {              \
-    return torch::tensor(at::ArrayRef<T>(values));                         \
-  }                                                                        \
-  inline at::Tensor tensor(T value) {                                      \
-    return torch::tensor(at::ArrayRef<T>(value));                          \
-  }
-AT_FORALL_SCALAR_TYPES_AND3(Bool, Half, BFloat16, TENSOR)
-#undef TENSOR
-
-/// NOTE: `torch::tensor({})` doesn't work at the moment because we would need to solve the
-/// ambiguous overload problem (see https://github.com/pytorch/pytorch/pull/26210#discussion_r325336686).
-/// We can create tensors with zero-size dimensions in the following way instead:
-/// - 1-D tensor: `torch::randn({0})`
-/// - N-D tensor: `torch::randn({2, 3, 0})`
-///
 /// NOTE: Currently `torch::tensor(...)` doesn't support mixed data types
 /// (i.e. `torch::tensor({{bool, 2.0}})` doesn't work). We might be able to
 /// support it in the future by iterating over all sub-lists to find
 /// the largest data type that can represent all of the elements, or by using
 /// variadic templates.
-inline at::Tensor tensor(detail::InitListTensor init_list_tensor, const at::TensorOptions& options) {
+inline at::Tensor tensor(detail::TensorDataContainer<1> init_list_tensor, const at::TensorOptions& options) {
   return autograd::make_variable(init_list_tensor.to_tensor(options), options.requires_grad());
 }
 
-inline at::Tensor tensor(detail::InitListTensor init_list_tensor) {
+inline at::Tensor tensor(detail::TensorDataContainer<1> init_list_tensor) {
   return torch::tensor(init_list_tensor, at::dtype(init_list_tensor.scalar_type()));
-}
-
-/// NOTE: We add `torch::tensor(std::initializer_list<detail::InitListTensor>)` function overload (and its options variant),
-/// so that `torch::tensor({{1, 2}})` can take this overload instead of `torch::tensor(at::ArrayRef<T>)`.
-inline at::Tensor tensor(std::initializer_list<detail::InitListTensor> init_list, const at::TensorOptions& options) {
-  TORCH_INTERNAL_ASSERT(
-    init_list.begin()->type() != detail::InitListTensorType::Scalar,
-    "1D tensor construction such as `torch::tensor({1, 2, 3})` should never take the ",
-    "torch::tensor(std::initializer_list<detail::InitListTensor>) function overload. ",
-    "Please fix the code to avoid this regression.")
-  return torch::tensor(detail::InitListTensor(init_list), options);
-}
-
-inline at::Tensor tensor(std::initializer_list<detail::InitListTensor> init_list) {
-  return torch::tensor(init_list, at::dtype(init_list.begin()->scalar_type()));
 }
 
 /// A generic deleter function.

--- a/tools/autograd/templates/variable_factories.h
+++ b/tools/autograd/templates/variable_factories.h
@@ -23,7 +23,7 @@ namespace torch {
 
 namespace detail {
 
-const int NESTED_INIT_LIST_MAX_DEPTH = 10;
+#define NESTED_INIT_LIST_MAX_DEPTH 10
 
 enum class TensorDataContainerType { Scalar, InitList, Tensor };
 

--- a/tools/autograd/templates/variable_factories.h
+++ b/tools/autograd/templates/variable_factories.h
@@ -92,7 +92,7 @@ enum class TensorDataContainerType { Scalar, InitList, Tensor };
 // constructor, thus producing a tensor with the wrong sizes. If we templatize `TensorDataContainer` over
 // the # of tensor dimensions, such problem doesn't happen.
 template <size_t D>
-struct TensorDataContainer {
+class TensorDataContainer {
   // NOTE: For tensors with zero-size dimensions (e.g. `torch::tensor({{}, {}})`),
   // the innermost empty braced-init-list `{}` matches the default constructor of
   // the innermost `TensorDataContainer`.


### PR DESCRIPTION
1. Previously, `torch::tensor({{1}, {2}})` produces a tensor of sizes `{2}`. After this PR, it produces a tensor of sizes `{2, 1}`, matching the Python API behavior.
2. Fixed semantics of `torch::tensor(1.1)`: it now returns a 0-dim tensor instead of a 1-dim tensor, matching the Python API behavior.
3. Tensors with zero-size dimensions are now supported, e.g. `torch::tensor({{}, {}})` produces a tensor with sizes `{2, 0}`.
4. From now on, the behavior of `at::tensor(scalar_value)` (which produces a 1-dim tensor) would be different from `torch::tensor(scalar_value)` (which produces a 0-dim tensor). I will fix the behavior of `at::tensor(scalar_value)` in the next PR.