### PR TITLE
Change error message for torch.linspace().

### DIFF
--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -337,6 +337,7 @@ Tensor linspace(
     Scalar end,
     int64_t steps,
     const TensorOptions& options) {
+  TORCH_CHECK(steps >= 0, "number of steps must be non-negative");
   Tensor result = at::empty({steps}, options);
   return at::linspace_out(result, start, end, steps);
 }


### PR DESCRIPTION
Fix for https://github.com/pytorch/pytorch/issues/25810

Basically moves the error checking from the device-specific function to the native function.