### PR TITLE
Remove autograd copy_ specific isFloatingPoint

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -3958,13 +3958,16 @@ class TestAutogradDeviceType(TestCase):
         output = input.to(device=devices[1]) + input.to(device=devices[1])
         output.backward()
 
-    def test_copy__bfloat16(self, device):
+    def test_copy_(self, device):
+        # At the time of writing this test, copy_ is not generated from native_functions.yaml
+        # there was a bug that bfloat16 was not recognized as floating.
         x = torch.randn(10, device=device, requires_grad=True)
-        y = torch.empty(10, device=device, dtype=torch.bfloat16)
-        y.copy_(x)
-        self.assertTrue(y.requires_grad)
-        z = x.to(torch.bfloat16)
-        self.assertTrue(z.requires_grad)
+        for dt in [torch.float, torch.double, torch.half, torch.bfloat16]:
+            y = torch.empty(10, device=device, dtype=dt)
+            y.copy_(x)
+            self.assertTrue(y.requires_grad)
+            z = x.to(torch.bfloat16)
+            self.assertTrue(z.requires_grad)
 
     @onlyCUDA
     def test_cross_device_reentrant_autograd(self, device):

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -3958,6 +3958,14 @@ class TestAutogradDeviceType(TestCase):
         output = input.to(device=devices[1]) + input.to(device=devices[1])
         output.backward()
 
+    def test_copy__bfloat16(self, device):
+        x = torch.randn(10, device=device, requires_grad=True)
+        y = torch.empty(10, device=device, dtype=torch.bfloat16)
+        y.copy_(x)
+        self.assertTrue(y.requires_grad)
+        z = x.to(torch.bfloat16)
+        self.assertTrue(z.requires_grad)
+
     @onlyCUDA
     def test_cross_device_reentrant_autograd(self, device):
         # Output on gpu so that this task will be associated with the gpu thread

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -39,7 +39,7 @@ from common_methods_invocations import (method_tests,
                                         mask_not_all_zeros,
                                         S)
 from common_device_type import (instantiate_device_type_tests, skipCUDAIfRocm,
-                                onlyCUDA, dtypes, dtypesIfCUDA,
+                                onlyCPU, onlyCUDA, dtypes, dtypesIfCUDA,
                                 deviceCountAtLeast, skipCUDAIfCudnnVersionLessThan)
 
 # load_tests from common_utils is used to automatically filter tests for
@@ -3958,6 +3958,7 @@ class TestAutogradDeviceType(TestCase):
         output = input.to(device=devices[1]) + input.to(device=devices[1])
         output.backward()
 
+    @onlyCPU
     def test_copy_(self, device):
         # At the time of writing this test, copy_ is not generated from native_functions.yaml
         # there was a bug that bfloat16 was not recognized as floating.

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -3962,7 +3962,8 @@ class TestAutogradDeviceType(TestCase):
         # At the time of writing this test, copy_ is not generated from native_functions.yaml
         # there was a bug that bfloat16 was not recognized as floating.
         x = torch.randn(10, device=device, requires_grad=True)
-        for dt in [torch.float, torch.double, torch.half, torch.bfloat16]:
+        floating_dt = [dt for dt in torch.testing.get_all_dtypes() if dt.is_floating_point]
+        for dt in floating_dt:
             y = torch.empty(10, device=device, dtype=dt)
             y.copy_(x)
             self.assertTrue(y.requires_grad)

--- a/torch/csrc/autograd/VariableTypeManual.cpp
+++ b/torch/csrc/autograd/VariableTypeManual.cpp
@@ -1,4 +1,5 @@
 #include <c10/util/Optional.h>
+#include <c10/core/ScalarType.h>
 #include <torch/csrc/autograd/VariableTypeUtils.h>
 #include <torch/csrc/utils/memory.h>
 #include <torch/csrc/autograd/utils/error_messages.h>
@@ -149,7 +150,7 @@ Tensor & copy_(Tensor & self, const Tensor & src, bool non_blocking) {
   check_inplace(self);
   std::shared_ptr<CopyBackwards> grad_fn;
   auto requires_grad = compute_requires_grad(self, src);
-  requires_grad &= isFloatingPoint(self.scalar_type());
+  requires_grad &= isFloatingType(self.scalar_type()) || isComplexType(self.scalar_type());
   if (requires_grad) {
     grad_fn = std::make_shared<CopyBackwards>();
     grad_fn->set_next_edges(collect_next_edges(self, src));

--- a/torch/csrc/autograd/VariableTypeManual.cpp
+++ b/torch/csrc/autograd/VariableTypeManual.cpp
@@ -150,7 +150,9 @@ Tensor & copy_(Tensor & self, const Tensor & src, bool non_blocking) {
   check_inplace(self);
   std::shared_ptr<CopyBackwards> grad_fn;
   auto requires_grad = compute_requires_grad(self, src);
-  requires_grad &= isFloatingType(self.scalar_type()) || isComplexType(self.scalar_type());
+  // currently, isFloatingType will return false for (floating) complex types,
+  // so this might have to be amended when they should be differentiable
+  requires_grad &= isFloatingType(self.scalar_type());
   if (requires_grad) {
     grad_fn = std::make_shared<CopyBackwards>();
     grad_fn->set_next_edges(collect_next_edges(self, src));

--- a/torch/csrc/autograd/VariableTypeUtils.h
+++ b/torch/csrc/autograd/VariableTypeUtils.h
@@ -80,10 +80,6 @@ inline void increment_version(Tensor & t) {
   as_variable_ref(t).bump_version();
 }
 
-inline bool isFloatingPoint(ScalarType s) {
-  return s == kFloat || s == kDouble || s == kHalf;
-}
-
 struct Flatten : IterArgs<Flatten> {
   Flatten(variable_list& out) : out(out) {}
   variable_list& out;


### PR DESCRIPTION
Remove autograd copy_ specific isFloatingPoint and use
c10's isFloatingType (and isComplexType).
Before this, .to or .copy_ would drop requires_grad for bfloat16
as the floating types were only considered to be double, float,
and half.

