### PR TITLE
[wip] add fmt

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -118,3 +118,6 @@
     ignore = dirty
     path = android/libs/fbjni
     url = https://github.com/IvanKobzarev/fbjni.git
+[submodule "third_party/fmt"]
+	path = third_party/fmt
+	url = https://github.com/fmtlib/fmt

--- a/c10/util/Exception.h
+++ b/c10/util/Exception.h
@@ -11,6 +11,7 @@
 #include <sstream>
 #include <string>
 #include <vector>
+#include <fmt/format.h>
 
 #if defined(_MSC_VER) && _MSC_VER <= 1900
 #define __func__ __FUNCTION__
@@ -241,6 +242,13 @@ inline std::string if_empty_then(std::string x, std::string y) {
         __FILE__                              \
     );                                        \
   }
+#define TORCH_CHECK_FMT(cond, ...)                \
+  if (C10_UNLIKELY_OR_CONST(!(cond))) {       \
+    C10_THROW_ERROR(Error,                    \
+        #cond " CHECK FAILED at "             \
+        __FILE__                              \
+    );                                        \
+  }
 #else
 #define TORCH_CHECK(cond, ...)                              \
   if (C10_UNLIKELY_OR_CONST(!(cond))) {                     \
@@ -253,9 +261,17 @@ inline std::string if_empty_then(std::string x, std::string y) {
       )                                                     \
     );                                                      \
   }
+
+// Like TORCH_CHECK, but use Python-like format strings for the error message.
+// Usage:
+//    TORCH_CHECK(should_be_true, "{} had an error: {}", arg1, arg2);
+#define TORCH_CHECK_FMT(cond, fmt_str, ...)                 \
+  if (C10_UNLIKELY_OR_CONST(!(cond))) {                     \
+    C10_THROW_ERROR(Error,                                  \
+      fmt::format(fmt_str, __VA_ARGS__)                     \
+    );                                                      \
+  }
 #endif
-// TODO: We're going to get a lot of similar looking string literals
-// this way; check if this actually affects binary size.
 
 // Like TORCH_CHECK, but raises IndexErrors instead of Errors.
 #ifdef C10_MOBILE

--- a/c10/util/Exception.h
+++ b/c10/util/Exception.h
@@ -242,7 +242,7 @@ inline std::string if_empty_then(std::string x, std::string y) {
         __FILE__                              \
     );                                        \
   }
-#define TORCH_CHECK_FMT(cond, ...)                \
+#define TORCH_CHECK_FMT(cond, ...)            \
   if (C10_UNLIKELY_OR_CONST(!(cond))) {       \
     C10_THROW_ERROR(Error,                    \
         #cond " CHECK FAILED at "             \

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1443,3 +1443,5 @@ endif()
 #
 # End ATen checks
 #
+add_compile_options(-DFMT_HEADER_ONLY)
+include_directories(SYSTEM ${CMAKE_CURRENT_LIST_DIR}/../third_party/fmt/include)

--- a/torch/csrc/jit/import.cpp
+++ b/torch/csrc/jit/import.cpp
@@ -42,14 +42,12 @@ void postSetStateValidate(const IValue& v) {
     // Verify that all the non-optional attributes have been initialized
     // TODO: Issue #20497
     if (attrType->kind() != TypeKind::OptionalType) {
-      TORCH_CHECK(
+      TORCH_CHECK_FMT(
           !slot.isNone(),
-          "The field '",
+          "The field '{}' was left uninitialized after '__setstate__', "
+          "but expected a value of type '{}'",
           attrName,
-          "' was left unitialized after __setstate__, but expected a ",
-          "value of type '",
-          attrType->python_str(),
-          "'");
+          attrType->python_str());
     }
   }
 }

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -370,11 +370,12 @@ struct Environment {
       std::stringstream why_not;
       if (!as_simple_value->type()->isSubtypeOfExt(parent_type, &why_not)) {
         auto error = ErrorReport(loc);
-        error << "Variable '" << name << "' previously has type "
-              << simple_parent->type()->python_str()
-              << " but is now being assigned to a value of type "
-              << as_simple_value->type()->python_str();
-
+        error << fmt::format(
+            "Variable '{}' previously had type '{}', "
+            "but is now being assigned to a value of type '{}'",
+            name,
+            simple_parent->type()->python_str(),
+            as_simple_value->type()->python_str());
         // Special-cased error msg if we're trying to assign to a tensor list.
         if (simple_parent->type()->kind() == TypeKind::ListType &&
             as_simple_value->type()->kind() == TypeKind::ListType) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#28289 add fmt**

fmt is a formatting library for C++.

Motivation: We often write subpar compiler diagnostics because using 
iostreams is super annoying if you want to write a detailed message. This 
makes life a little bit easier.

fmt has several properties that make it nice for inclusion in PyTorch:
- Widely used
- Basically copies how Python does it
- Support for all the compilers and platforms we care about
- Standards track (C++20)
- Small code size
- Header only
- The author works at FB (hi @vitaut).

This PR includes it as a submodule and sets up the build (header-only,
because getting it to work as part of the `Caffe2Targets` export set was
beyond my cmake skills).

It also provides some example usage, including a `TORCH_CHECK_FMT` macro
in c10 that should test all the builds we care about.