### PR TITLE
[pytorch] Minor followup on stringstream cleanups

### DIFF
--- a/aten/src/ATen/core/qualified_name.h
+++ b/aten/src/ATen/core/qualified_name.h
@@ -118,7 +118,7 @@ struct QualifiedName {
     out.reserve(reserve);
     for (size_t i = 0; i < v.size(); ++i) {
       if (i != 0) {
-        out.push_back(delimiter_);
+        out.push_back(delimiter);
       }
       out.append(v[i]);
     }

--- a/torch/csrc/jit/export.cpp
+++ b/torch/csrc/jit/export.cpp
@@ -630,13 +630,12 @@ class ScriptModuleSerializer {
           src.size() > kMinToCompress /*compress*/);
 
       // Write out the debug information
-      std::ostringstream debugFilename;
-      debugFilename << filename << ".debug_pkl";
+      std::string debugFilename = filename + ".debug_pkl";
       SourceRangePickler source_range_pickler;
       const auto& range_data =
           source_range_pickler.pickle(item.value().ranges());
       writer_.writeRecord(
-          debugFilename.str(),
+          debugFilename,
           range_data.data(),
           range_data.size(),
           range_data.size() > kMinToCompress /*compress*/);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#28300 [pytorch] Minor followup on stringstream cleanups**

- Remove trivial stringstream from ScriptModuleSerializer::writeCode;
    I didn't include this in earlier changes to avoid a merge conflict
    with an earlier change.
  - Remove underscore from QualifiedName var ref; no difference in
    current use, but more correct.

Differential Revision: [D18012511](https://our.internmc.facebook.com/intern/diff/D18012511/)