### PR TITLE
[pytorch] Minor tweaks to rpc message api

### DIFF
--- a/torch/csrc/distributed/rpc/message.cpp
+++ b/torch/csrc/distributed/rpc/message.cpp
@@ -52,6 +52,10 @@ const std::vector<char>& Message::payload() const {
   return payload_;
 }
 
+std::vector<torch::Tensor>&& Message::moveTensors() && {
+  return std::move(tensors_);
+}
+
 std::vector<torch::Tensor>& Message::tensors() {
   return tensors_;
 }
@@ -60,7 +64,7 @@ const std::vector<torch::Tensor>& Message::tensors() const {
   return tensors_;
 }
 
-const MessageType& Message::type() const {
+MessageType Message::type() const {
   return type_;
 }
 

--- a/torch/csrc/distributed/rpc/message.h
+++ b/torch/csrc/distributed/rpc/message.h
@@ -86,11 +86,12 @@ class TORCH_API Message final {
 
   // Destructively retrieves the payload.
   std::vector<char>&& movePayload() &&;
+  std::vector<torch::Tensor>&& moveTensors() &&;
 
   const std::vector<char>& payload() const;
   std::vector<torch::Tensor>& tensors();
   const std::vector<torch::Tensor>& tensors() const;
-  const MessageType& type() const;
+  MessageType type() const;
 
   bool isRequest() const;
   bool isResponse() const;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#28326 [pytorch] Minor tweaks to rpc message api**

- Message::type() should return a MessageType, not const MessageType&,
   since MessageType is just an enum.
 - Add moveTensors() method for parallelism with movePayload().

Differential Revision: [D18021692](https://our.internmc.facebook.com/intern/diff/D18021692/)