### PR TITLE
Move type casting to c10/util/TypeCast.h

### DIFF
--- a/aten/src/ATen/cpu/vec256/vec256_base.h
+++ b/aten/src/ATen/cpu/vec256/vec256_base.h
@@ -13,6 +13,7 @@
 #include <c10/util/C++17.h>
 #include <c10/util/BFloat16.h>
 #include <ATen/native/cpu/zmath.h>
+#include <c10/util/TypeCast.h>
 
 #if defined(__GNUC__)
 #define __at_align32__ __attribute__((aligned(32)))
@@ -681,8 +682,7 @@ inline void convert(const src_T *src, dst_T *dst, int64_t n) {
 # pragma unroll
 #endif
   for (int64_t i = 0; i < n; i++) {
-    *dst = static_cast<dst_T>(
-        static_cast<at::native::inter_copy_type_t<dst_T>>(*src));
+    *dst = c10::static_cast_with_inter_type<dst_T>(*src);
     src++;
     dst++;
   }

--- a/aten/src/ATen/native/Copy.h
+++ b/aten/src/ATen/native/Copy.h
@@ -9,44 +9,6 @@ struct TensorIterator;
 
 namespace native {
 
-// Note [Implicit conversion between signed and unsigned]
-// C and C++ have a lovely set of implicit conversion rules, where casting
-// signed integral values to unsigned integral values is always valid
-// (it basically treats the value as if using modulo arithmetic), however
-// converting negative floating point values to unsigned integral types
-// is UB! This means that: (double)-1 -> (int64_t)-1 -> (uint8_t)255 is
-// guaranteed to look like this, but we have (double)-1 -> (uint8_t)<ANYTHING>
-// because it's UB. This also makes UBSan really angry.
-//
-// I think those rules are stupid and we really shouldn't conform to them.
-// The structs below ensure that for all unsigned types we use (currently
-// only uint8_t), we will do an intermediate convertion via int64_t,
-// to ensure that any negative values are wrapped around correctly.
-//
-// Note that conversions from doubles to signed integral types that can't
-// represent a particular value after truncating the fracitonal part are UB as well,
-// but fixing them is not as simple as adding an int64_t intermediate, beacuse the
-// int64_t -> <smaller signed type> conversion is UB for those large values anyway.
-// I guess in that case we just have to live with that, but it's definitely less
-// surprising than the thing above.
-//
-// For the curious:
-//   https://en.cppreference.com/w/cpp/language/implicit_conversion
-//   The relevant paragraph is "Floating-integral conversions".
-
-template <typename T>
-struct inter_copy_type {
-  using type = T;
-};
-
-template <>
-struct inter_copy_type<uint8_t> {
-  using type = int64_t;
-};
-
-template <typename T>
-using inter_copy_type_t = typename inter_copy_type<T>::type;
-
 using copy_fn = void (*)(TensorIterator&, bool non_blocking);
 
 DECLARE_DISPATCH(copy_fn, copy_stub);

--- a/aten/src/ATen/native/cpu/CopyKernel.cpp
+++ b/aten/src/ATen/native/cpu/CopyKernel.cpp
@@ -4,6 +4,7 @@
 #include <ATen/native/Copy.h>
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/cpu/Loops.h>
+#include <c10/util/TypeCast.h>
 
 namespace at {
 namespace native {
@@ -14,8 +15,7 @@ void copy_kernel_cast(TensorIterator& iter) {
     if (isComplexType(iter.dtype(1))) {
       AT_DISPATCH_COMPLEX_TYPES(iter.dtype(1), "copy_kernel_cast", [&] {
         cpu_kernel(iter, [=](scalar_t a) -> self_T {
-            return static_cast<self_T>(
-                static_cast<at::native::inter_copy_type_t<self_T>>(std::real(a)));
+            return c10::static_cast_with_inter_type<self_T>(std::real(a));
           });
         });
     }
@@ -28,8 +28,7 @@ void copy_kernel_cast(TensorIterator& iter) {
         "copy_kernel_cast",
         [&] {
           cpu_kernel(iter, [=](scalar_t a) -> self_T {
-            return static_cast<self_T>(
-                static_cast<at::native::inter_copy_type_t<self_T>>(a));
+            return c10::static_cast_with_inter_type<self_T>(a);
           });
         });
     }

--- a/aten/src/ATen/native/cuda/Copy.cu
+++ b/aten/src/ATen/native/cuda/Copy.cu
@@ -8,6 +8,7 @@
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/cuda/Loops.cuh>
 #include <THC/THC.h>
+#include <c10/util/TypeCast.h>
 
 namespace at {
 namespace native {
@@ -17,7 +18,7 @@ using namespace at::cuda;
 template <typename dst_t, typename src_t>
 void copy_kernel_impl(TensorIterator& iter) {
   gpu_kernel(iter, []GPU_LAMBDA(src_t x) -> dst_t {
-    return static_cast<dst_t>(static_cast<native::inter_copy_type_t<dst_t>>(x));
+    return c10::static_cast_with_inter_type<dst_t>(x);
   });
 }
 

--- a/c10/core/ScalarType.h
+++ b/c10/core/ScalarType.h
@@ -166,6 +166,10 @@ struct ScalarTypeToCPPType<c10::ScalarType::Long> {
   _(c10::quint8, QUInt8)         \
   _(c10::qint32, QInt32)
 
+#define AT_FORALL_COMPLEX_TYPES(_)             \
+  _(std::complex<float>, ComplexFloat)         \
+  _(std::complex<double>, ComplexDouble)
+
 static inline caffe2::TypeMeta scalarTypeToTypeMeta(ScalarType scalar_type) {
 #define DEFINE_CASE(ctype, name) \
   case ScalarType::name:         \

--- a/c10/util/TypeCast.h
+++ b/c10/util/TypeCast.h
@@ -1,0 +1,126 @@
+#pragma once
+
+#include <c10/core/ScalarType.h>
+#include <c10/util/Half.h>
+#include <c10/util/BFloat16.h>
+
+
+namespace c10 {
+
+// Note [Implicit conversion between signed and unsigned]
+// C and C++ have a lovely set of implicit conversion rules, where casting
+// signed integral values to unsigned integral values is always valid
+// (it basically treats the value as if using modulo arithmetic), however
+// converting negative floating point values to unsigned integral types
+// is UB! This means that: (double)-1 -> (int64_t)-1 -> (uint8_t)255 is
+// guaranteed to look like this, but we have (double)-1 -> (uint8_t)<ANYTHING>
+// because it's UB. This also makes UBSan really angry.
+//
+// I think those rules are stupid and we really shouldn't conform to them.
+// The structs below ensure that for all unsigned types we use (currently
+// only uint8_t), we will do an intermediate convertion via int64_t,
+// to ensure that any negative values are wrapped around correctly.
+//
+// Note that conversions from doubles to signed integral types that can't
+// represent a particular value after truncating the fracitonal part are UB as well,
+// but fixing them is not as simple as adding an int64_t intermediate, beacuse the
+// int64_t -> <smaller signed type> conversion is UB for those large values anyway.
+// I guess in that case we just have to live with that, but it's definitely less
+// surprising than the thing above.
+//
+// For the curious:
+//   https://en.cppreference.com/w/cpp/language/implicit_conversion
+//   The relevant paragraph is "Floating-integral conversions".
+
+template <typename T>
+struct inter_copy_type {
+  using type = T;
+};
+
+template <>
+struct inter_copy_type<uint8_t> {
+  using type = int64_t;
+};
+
+template <typename T>
+using inter_copy_type_t = typename inter_copy_type<T>::type;
+
+template <typename dest_t, typename src_t>
+C10_HOST_DEVICE inline dest_t static_cast_with_inter_type(src_t src) {
+  return static_cast<dest_t>(
+    static_cast<inter_copy_type_t<dest_t>>(src));
+}
+
+#ifdef C10_HOST_DEVICE
+#define ERROR_UNSUPPORTED_CAST assert(false);
+#else
+#define ERROR_UNSUPPORTED_CAST TORCH_CHECK(false, "Unexpected scalar type");
+#endif
+
+// Fetch a value with dynamic type src_type from ptr, and cast it to static type dest_t.
+#define FETCH_AND_CAST_CASE(type, scalartype) case ScalarType::scalartype: return static_cast_with_inter_type<dest_t>(*(const type *)ptr);
+#define FETCH_AND_CAST_COMPLEX_CASE(type, scalartype) case ScalarType::scalartype: return static_cast_with_inter_type<dest_t>(std::real(*(const type *)ptr));
+template<typename dest_t>
+C10_HOST_DEVICE inline dest_t fetch_and_cast(const ScalarType src_type, const void *ptr) {
+  switch (src_type) {
+    AT_FORALL_SCALAR_TYPES_AND3(Bool, Half, BFloat16, FETCH_AND_CAST_CASE)
+#ifndef C10_HOST_DEVICE
+    AT_FORALL_COMPLEX_TYPES(FETCH_AND_CAST_COMPLEX_CASE)
+#endif
+    default:;
+  }
+  ERROR_UNSUPPORTED_CAST
+  return dest_t(0); // just to avoid compiler warning
+}
+
+// Cast a value with static type src_t into dynamic dest_type, and store it to ptr.
+#define CAST_AND_STORE_CASE(type, scalartype) case ScalarType::scalartype: *(type *)ptr = static_cast_with_inter_type<type>(value); return;
+template<typename src_t>
+C10_HOST_DEVICE inline void cast_and_store(const ScalarType dest_type, void *ptr, src_t value) {
+  switch (dest_type) {
+    AT_FORALL_SCALAR_TYPES_AND3(Bool, Half, BFloat16, CAST_AND_STORE_CASE)
+    default:;
+  }
+  ERROR_UNSUPPORTED_CAST
+}
+
+template<>
+inline void cast_and_store<std::complex<float>>(const ScalarType dest_type, void *ptr, std::complex<float> value_) {
+  auto value = std::real(value_);
+  switch (dest_type) {
+    AT_FORALL_SCALAR_TYPES_AND3(Bool, Half, BFloat16, CAST_AND_STORE_CASE)
+    default:;
+  }
+  ERROR_UNSUPPORTED_CAST
+}
+template<>
+inline void cast_and_store<std::complex<double>>(const ScalarType dest_type, void *ptr, std::complex<double> value_) {
+  auto value = std::real(value_);
+  switch (dest_type) {
+    AT_FORALL_SCALAR_TYPES_AND3(Bool, Half, BFloat16, CAST_AND_STORE_CASE)
+    default:;
+  }
+  ERROR_UNSUPPORTED_CAST
+}
+
+#define DEFINE_UNCASTABLE(T, scalartype_)                                         \
+template<>                                                                        \
+inline T fetch_and_cast<T>(const ScalarType src_type, const void *ptr) {          \
+  assert(ScalarType::scalartype_ == src_type);                                    \
+  return *(const T *)ptr;                                                         \
+}                                                                                 \
+template<>                                                                        \
+inline void cast_and_store<T>(const ScalarType dest_type, void *ptr, T value) {   \
+  assert(ScalarType::scalartype_ == dest_type);                                   \
+  *(T *)ptr = value;                                                              \
+}
+
+AT_FORALL_QINT_TYPES(DEFINE_UNCASTABLE)
+
+#undef FETCH_AND_CAST_CASE
+#undef FETCH_AND_CAST_COMPLEX_CASE
+#undef CAST_AND_STORE_CASE
+#undef DEFINE_UNCASTABLE
+#undef ERROR_UNSUPPORTED_CAST
+
+}  // namespace c10


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#28343 Move type casting to c10/util/TypeCast.h**
* #28352 Simplify copy kernel
* #28344 Make TensorIterator stop promoting types by copying
* #28343 Move type casting to c10/util/TypeCast.h

Type casting is used in copy, and will be used also in tensor iterator
in the next stacked diff. I move it to c10 to make it serve as an common
util for different things.

I also add two dynamic casting functions
- fetch_and_cast
- cast_and_store

fetch_and_cast fetch a value with dynamic type specified by a ScalarType
from a void pointer and cast it to a static type.

cast_and_store casts a static typed value into dynamic type specified
by a ScalarType, and store it into a void pointer.