### PR TITLE
[DO NOT MERGE] Simplify copy kernel

### DIFF
--- a/aten/src/ATen/Dispatch.h
+++ b/aten/src/ATen/Dispatch.h
@@ -221,11 +221,11 @@ inline void deprecated_AT_DISPATCH_ALL_TYPES_AND_HALF_AND_COMPLEX() {}
     const auto& SCALAR_TYPE C10_UNUSED = TYPE;                          \
     switch (TYPE) {                                                     \
       AT_QINT_PRIVATE_CASE_TYPE(                                        \
-          at::kQInt8, at::qint8, at::kChar, int8_t, __VA_ARGS__)                    \
+          at::kQInt8, at::qint8, at::kChar, int8_t, __VA_ARGS__)        \
       AT_QINT_PRIVATE_CASE_TYPE(                                        \
-          at::kQUInt8, at::quint8, at::kByte, uint8_t, __VA_ARGS__)                 \
+          at::kQUInt8, at::quint8, at::kByte, uint8_t, __VA_ARGS__)     \
       AT_QINT_PRIVATE_CASE_TYPE(                                        \
-          at::kQInt32, at::qint32, at::kInt, int, __VA_ARGS__)                      \
+          at::kQInt32, at::qint32, at::kInt, int, __VA_ARGS__)          \
       default:                                                          \
         AT_ERROR(#NAME, " not implemented for '", toString(TYPE), "'"); \
     }                                                                   \
@@ -343,6 +343,29 @@ inline void deprecated_AT_DISPATCH_ALL_TYPES_AND_HALF_AND_COMPLEX() {}
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Short, int16_t, __VA_ARGS__)                                          \
       AT_PRIVATE_CASE_TYPE(at::ScalarType::ComplexFloat, std::complex<float>, __VA_ARGS__)                       \
       AT_PRIVATE_CASE_TYPE(at::ScalarType::ComplexDouble, std::complex<double>, __VA_ARGS__)                     \
+      AT_PRIVATE_CASE_TYPE(SCALARTYPE1, decltype(c10::impl::ScalarTypeToCPPType<SCALARTYPE1>::t), __VA_ARGS__)   \
+      AT_PRIVATE_CASE_TYPE(SCALARTYPE2, decltype(c10::impl::ScalarTypeToCPPType<SCALARTYPE2>::t), __VA_ARGS__)   \
+      AT_PRIVATE_CASE_TYPE(SCALARTYPE3, decltype(c10::impl::ScalarTypeToCPPType<SCALARTYPE3>::t), __VA_ARGS__)   \
+      default:                                                                                                   \
+        AT_ERROR(#NAME, " not implemented for '", TYPE, "'");                                                    \
+    }                                                                                                            \
+  }()
+
+#define AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND_QINTS_AND3(SCALARTYPE1, SCALARTYPE2, SCALARTYPE3, TYPE, NAME, ...) \
+  [&] {                                                                                                          \
+    switch (TYPE) {                                                                                              \
+      AT_PRIVATE_CASE_TYPE(at::ScalarType::Byte, uint8_t, __VA_ARGS__)                                           \
+      AT_PRIVATE_CASE_TYPE(at::ScalarType::Char, int8_t, __VA_ARGS__)                                            \
+      AT_PRIVATE_CASE_TYPE(at::ScalarType::Double, double, __VA_ARGS__)                                          \
+      AT_PRIVATE_CASE_TYPE(at::ScalarType::Float, float, __VA_ARGS__)                                            \
+      AT_PRIVATE_CASE_TYPE(at::ScalarType::Int, int32_t, __VA_ARGS__)                                            \
+      AT_PRIVATE_CASE_TYPE(at::ScalarType::Long, int64_t, __VA_ARGS__)                                           \
+      AT_PRIVATE_CASE_TYPE(at::ScalarType::Short, int16_t, __VA_ARGS__)                                          \
+      AT_PRIVATE_CASE_TYPE(at::ScalarType::ComplexFloat, std::complex<float>, __VA_ARGS__)                       \
+      AT_PRIVATE_CASE_TYPE(at::ScalarType::ComplexDouble, std::complex<double>, __VA_ARGS__)                     \
+      AT_QINT_PRIVATE_CASE_TYPE(at::kQInt8, at::qint8, at::kChar, int8_t, __VA_ARGS__)                           \
+      AT_QINT_PRIVATE_CASE_TYPE(at::kQUInt8, at::quint8, at::kByte, uint8_t, __VA_ARGS__)                        \
+      AT_QINT_PRIVATE_CASE_TYPE(at::kQInt32, at::qint32, at::kInt, int, __VA_ARGS__)                             \
       AT_PRIVATE_CASE_TYPE(SCALARTYPE1, decltype(c10::impl::ScalarTypeToCPPType<SCALARTYPE1>::t), __VA_ARGS__)   \
       AT_PRIVATE_CASE_TYPE(SCALARTYPE2, decltype(c10::impl::ScalarTypeToCPPType<SCALARTYPE2>::t), __VA_ARGS__)   \
       AT_PRIVATE_CASE_TYPE(SCALARTYPE3, decltype(c10::impl::ScalarTypeToCPPType<SCALARTYPE3>::t), __VA_ARGS__)   \

--- a/aten/src/ATen/cpu/vec256/vec256_base.h
+++ b/aten/src/ATen/cpu/vec256/vec256_base.h
@@ -13,6 +13,7 @@
 #include <c10/util/C++17.h>
 #include <c10/util/BFloat16.h>
 #include <ATen/native/cpu/zmath.h>
+#include <c10/util/TypeCast.h>
 
 #if defined(__GNUC__)
 #define __at_align32__ __attribute__((aligned(32)))
@@ -681,8 +682,7 @@ inline void convert(const src_T *src, dst_T *dst, int64_t n) {
 # pragma unroll
 #endif
   for (int64_t i = 0; i < n; i++) {
-    *dst = static_cast<dst_T>(
-        static_cast<at::native::inter_copy_type_t<dst_T>>(*src));
+    *dst = c10::static_cast_with_inter_type<dst_T>(*src);
     src++;
     dst++;
   }

--- a/aten/src/ATen/native/Copy.cpp
+++ b/aten/src/ATen/native/Copy.cpp
@@ -124,10 +124,12 @@ static Tensor & copy_impl(Tensor & self, const Tensor & src, bool non_blocking) 
 
   auto iter = TensorIterator();
   iter.set_check_mem_overlap(true);
+  iter.dont_compute_common_dtype();
   iter.add_output(self);
   iter.add_input(src);
   iter.dont_resize_outputs();
   iter.build();
+  iter.set_common_dtype(iter.dtype());
 
   if (iter.numel() == 0) {
     return self;

--- a/aten/src/ATen/native/Copy.cpp
+++ b/aten/src/ATen/native/Copy.cpp
@@ -127,7 +127,6 @@ static Tensor & copy_impl(Tensor & self, const Tensor & src, bool non_blocking) 
   iter.add_output(self);
   iter.add_input(src);
   iter.dont_resize_outputs();
-  iter.dont_compute_common_dtype();
   iter.build();
 
   if (iter.numel() == 0) {

--- a/aten/src/ATen/native/Copy.h
+++ b/aten/src/ATen/native/Copy.h
@@ -9,44 +9,6 @@ struct TensorIterator;
 
 namespace native {
 
-// Note [Implicit conversion between signed and unsigned]
-// C and C++ have a lovely set of implicit conversion rules, where casting
-// signed integral values to unsigned integral values is always valid
-// (it basically treats the value as if using modulo arithmetic), however
-// converting negative floating point values to unsigned integral types
-// is UB! This means that: (double)-1 -> (int64_t)-1 -> (uint8_t)255 is
-// guaranteed to look like this, but we have (double)-1 -> (uint8_t)<ANYTHING>
-// because it's UB. This also makes UBSan really angry.
-//
-// I think those rules are stupid and we really shouldn't conform to them.
-// The structs below ensure that for all unsigned types we use (currently
-// only uint8_t), we will do an intermediate convertion via int64_t,
-// to ensure that any negative values are wrapped around correctly.
-//
-// Note that conversions from doubles to signed integral types that can't
-// represent a particular value after truncating the fracitonal part are UB as well,
-// but fixing them is not as simple as adding an int64_t intermediate, beacuse the
-// int64_t -> <smaller signed type> conversion is UB for those large values anyway.
-// I guess in that case we just have to live with that, but it's definitely less
-// surprising than the thing above.
-//
-// For the curious:
-//   https://en.cppreference.com/w/cpp/language/implicit_conversion
-//   The relevant paragraph is "Floating-integral conversions".
-
-template <typename T>
-struct inter_copy_type {
-  using type = T;
-};
-
-template <>
-struct inter_copy_type<uint8_t> {
-  using type = int64_t;
-};
-
-template <typename T>
-using inter_copy_type_t = typename inter_copy_type<T>::type;
-
 using copy_fn = void (*)(TensorIterator&, bool non_blocking);
 
 DECLARE_DISPATCH(copy_fn, copy_stub);

--- a/aten/src/ATen/native/TensorIterator.h
+++ b/aten/src/ATen/native/TensorIterator.h
@@ -318,6 +318,10 @@ struct CAFFE2_API TensorIterator {
     resize_outputs_ = false;
   }
 
+  void set_common_dtype(ScalarType dtype) {
+    common_dtype_ = dtype;
+  }
+
   void build();
 
 protected:

--- a/aten/src/ATen/native/TensorIterator.h
+++ b/aten/src/ATen/native/TensorIterator.h
@@ -93,10 +93,6 @@ struct CAFFE2_API OperandInfo {
   /// coalescing.
   Tensor tensor;
 
-  // Save the original tensor operand in cases when an output is modified
-  // (e.g. if dtype is changed)
-  Tensor original_tensor;
-
   /// The desired device and type for the operand. For inputs, this specifies that
   /// the input should be converted to this type if necessary. For outputs, this
   /// specifies which type to allocate. Note that there is very limited support
@@ -190,6 +186,7 @@ struct CAFFE2_API TensorIterator {
   IntArrayRef strides(int arg) const { return operands_[arg].stride_bytes; }
   void* data_ptr(int arg) const;
   ScalarType dtype(int arg=0) const { return operands_[arg].tensor.scalar_type(); }
+  ScalarType common_dtype() const { return common_dtype_; }
   ScalarType input_dtype(int arg=0) const { return operands_[num_outputs_ + arg].dtype; }
   Device device(int arg=0) const { return operands_[arg].device; }
   DeviceType device_type(int arg=0) const { return device(arg).type(); }
@@ -203,17 +200,6 @@ struct CAFFE2_API TensorIterator {
   Tensor output(int arg=0) const {
     AT_ASSERT(arg < num_outputs_);
     return operands_[arg].tensor;
-  }
-
-  void cast_outputs() {
-    if (compute_common_dtype_strategy_ == CommonDTypeStrategy::COMPUTE_ALL) {
-      for(int i=0; i < noutputs(); i++) {
-        if (operands_[i].original_tensor.defined() && dtype(i) != operands_[i].original_tensor.scalar_type()) {
-          operands_[i].original_tensor.copy_(operands_[i].tensor);
-          operands_[i].tensor = operands_[i].original_tensor;
-        }
-      }
-    }
   }
 
   Tensor input(int arg=0) const {
@@ -285,6 +271,18 @@ struct CAFFE2_API TensorIterator {
   /// CUDA reductions.
   bool is_final_output() const { return final_output_; }
 
+  bool has_promotion() const {
+    if (common_dtype_ == ScalarType::Undefined) {
+      return false;
+    }
+    for (auto& op : operands_) {
+      if (op.tensor.scalar_type() != common_dtype_) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   void set_check_mem_overlap(bool check_mem_overlap) {
     check_mem_overlap_ = check_mem_overlap;
   }
@@ -347,6 +345,7 @@ protected:
   SmallVector<OperandInfo, 4> operands_;
   int num_outputs_ = 0;
   CommonDTypeStrategy compute_common_dtype_strategy_ = CommonDTypeStrategy::COMPUTE_ALL;
+  ScalarType common_dtype_ = ScalarType::Undefined;
   bool has_coalesced_dimensions_ = false;
   bool accumulate_ = false;
   bool resize_outputs_ = true;

--- a/aten/src/ATen/native/cpu/CopyKernel.cpp
+++ b/aten/src/ATen/native/cpu/CopyKernel.cpp
@@ -4,6 +4,7 @@
 #include <ATen/native/Copy.h>
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/cpu/Loops.h>
+#include <c10/util/TypeCast.h>
 
 namespace at {
 namespace native {
@@ -14,8 +15,7 @@ void copy_kernel_cast(TensorIterator& iter) {
     if (isComplexType(iter.dtype(1))) {
       AT_DISPATCH_COMPLEX_TYPES(iter.dtype(1), "copy_kernel_cast", [&] {
         cpu_kernel(iter, [=](scalar_t a) -> self_T {
-            return static_cast<self_T>(
-                static_cast<at::native::inter_copy_type_t<self_T>>(std::real(a)));
+            return c10::static_cast_with_inter_type<self_T>(std::real(a));
           });
         });
     }
@@ -28,8 +28,7 @@ void copy_kernel_cast(TensorIterator& iter) {
         "copy_kernel_cast",
         [&] {
           cpu_kernel(iter, [=](scalar_t a) -> self_T {
-            return static_cast<self_T>(
-                static_cast<at::native::inter_copy_type_t<self_T>>(a));
+            return c10::static_cast_with_inter_type<self_T>(a);
           });
         });
     }

--- a/aten/src/ATen/native/cpu/CopyKernel.cpp
+++ b/aten/src/ATen/native/cpu/CopyKernel.cpp
@@ -4,67 +4,27 @@
 #include <ATen/native/Copy.h>
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/cpu/Loops.h>
-#include <c10/util/TypeCast.h>
 
 namespace at {
 namespace native {
 namespace {
 
-template <typename self_T>
-void copy_kernel_cast(TensorIterator& iter) {
-    if (isComplexType(iter.dtype(1))) {
-      AT_DISPATCH_COMPLEX_TYPES(iter.dtype(1), "copy_kernel_cast", [&] {
-        cpu_kernel(iter, [=](scalar_t a) -> self_T {
-            return c10::static_cast_with_inter_type<self_T>(std::real(a));
-          });
-        });
-    }
-    else {
-      AT_DISPATCH_ALL_TYPES_AND3(
-        ScalarType::Half,
-        ScalarType::Bool,
-        ScalarType::BFloat16,
-        iter.dtype(1),
-        "copy_kernel_cast",
-        [&] {
-          cpu_kernel(iter, [=](scalar_t a) -> self_T {
-            return c10::static_cast_with_inter_type<self_T>(a);
-          });
-        });
-    }
-}
-
 static void copy_kernel(TensorIterator& iter, bool non_blocking) {
   ScalarType dtype = iter.dtype(0);
-  if (dtype == iter.dtype(1)) {
-    if (dtype == ScalarType::Half) {
-      cpu_kernel(iter, [=](at::Half a) -> at::Half { return a; });
-    } else if (dtype == ScalarType::BFloat16) {
-      cpu_kernel(iter, [=](at::BFloat16 a) -> at::BFloat16 { return a; });
-    } else if (isQIntType(dtype)) {
-      AT_DISPATCH_QINT_TYPES(dtype, "copy_kernel", [&] {
-        cpu_kernel(
+  bool can_vectorize = (dtype == iter.dtype(1)) && (
+    dtype != ScalarType::Half && dtype != ScalarType::BFloat16 &&
+    !isQIntType(dtype) && !isComplexType(dtype));
+  if (can_vectorize) {
+    AT_DISPATCH_ALL_TYPES_AND(ScalarType::Bool, dtype, "copy_kernel",
+      [&] {
+        cpu_kernel_vec(
             iter,
-            [=](scalar_t a) -> scalar_t {return a; });
+            [=](scalar_t a) -> scalar_t { return a; },
+            [=](Vec256<scalar_t> a) { return a; });
       });
-    } else if (isComplexType(dtype)) {
-      AT_DISPATCH_COMPLEX_TYPES(dtype, "copy_kernel", [&] {
-          cpu_kernel(
-            iter,
-            [=](scalar_t a) -> scalar_t { return a; });
-        });
-    } else {
-      AT_DISPATCH_ALL_TYPES_AND(
-          ScalarType::Bool, dtype, "copy_kernel", [&] {
-            cpu_kernel_vec(
-                iter,
-                [=](scalar_t a) -> scalar_t { return a; },
-                [=](Vec256<scalar_t> a) { return a; });
-          });
-    }
   } else {
     AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(ScalarType::Half, ScalarType::Bool, ScalarType::BFloat16, dtype, "copy_", [&] {
-      copy_kernel_cast<scalar_t>(iter);
+      cpu_kernel(iter, [](scalar_t a) -> scalar_t { return a; });
     });
   }
 }

--- a/aten/src/ATen/native/cpu/CopyKernel.cpp
+++ b/aten/src/ATen/native/cpu/CopyKernel.cpp
@@ -10,23 +10,14 @@ namespace native {
 namespace {
 
 static void copy_kernel(TensorIterator& iter, bool non_blocking) {
-  ScalarType dtype = iter.dtype(0);
-  bool can_vectorize = (dtype == iter.dtype(1)) && (
-    dtype != ScalarType::Half && dtype != ScalarType::BFloat16 &&
-    !isQIntType(dtype) && !isComplexType(dtype));
-  if (can_vectorize) {
-    AT_DISPATCH_ALL_TYPES_AND(ScalarType::Bool, dtype, "copy_kernel",
-      [&] {
-        cpu_kernel_vec(
-            iter,
-            [=](scalar_t a) -> scalar_t { return a; },
-            [=](Vec256<scalar_t> a) { return a; });
-      });
-  } else {
-    AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(ScalarType::Half, ScalarType::Bool, ScalarType::BFloat16, dtype, "copy_", [&] {
-      cpu_kernel(iter, [](scalar_t a) -> scalar_t { return a; });
+  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND_QINTS_AND3(
+    ScalarType::Half, ScalarType::Bool, ScalarType::BFloat16, iter.common_dtype(), "copy_",
+    [&] {
+      cpu_kernel_vec(
+        iter,
+        [](scalar_t a) -> scalar_t { return a; },
+        [](Vec256<scalar_t> a) { return a; });
     });
-  }
 }
 
 } // anonymous namespace

--- a/aten/src/ATen/native/cpu/Loops.h
+++ b/aten/src/ATen/native/cpu/Loops.h
@@ -32,6 +32,7 @@
 #include <ATen/native/cpu/IsContiguous.h>
 #include <ATen/native/TensorIterator.h>
 #include <ATen/cpu/vec256/vec256.h>
+#include <c10/util/TypeCast.h>
 
 #ifndef _MSC_VER
 #pragma GCC diagnostic push
@@ -51,11 +52,27 @@ dereference_impl(char* C10_RESTRICT data[], const int64_t* strides, int64_t i,
         (data[INDEX] + i * strides[INDEX])...);
 }
 
+template <typename traits, std::size_t... INDEX>
+typename traits::ArgsTuple
+dereference_impl(char* C10_RESTRICT data[], const int64_t* strides, const ScalarType* dtypes, int64_t i,
+                 c10::guts::index_sequence<INDEX...>) {
+  return std::make_tuple(
+      fetch_and_cast<typename traits::template arg<INDEX>::type>(dtypes[INDEX],
+        data[INDEX] + i * strides[INDEX])...);
+}
+
 template <typename traits>
 typename traits::ArgsTuple
 dereference(char* C10_RESTRICT data[], const int64_t* strides, int64_t i) {
   using Indices = c10::guts::make_index_sequence<traits::arity>;
   return dereference_impl<traits>(data, strides, i, Indices{});
+}
+
+template <typename traits>
+typename traits::ArgsTuple
+dereference(char* C10_RESTRICT data[], const int64_t* strides, const ScalarType* dtypes, int64_t i) {
+  using Indices = c10::guts::make_index_sequence<traits::arity>;
+  return dereference_impl<traits>(data, strides, dtypes, i, Indices{});
 }
 
 template <typename traits, std::size_t... INDEX>
@@ -96,6 +113,23 @@ execute_op(char* C10_RESTRICT data[], const int64_t* strides, int64_t i, int64_t
 }
 
 template <typename func_t,
+    typename std::enable_if<!std::is_void<typename function_traits<func_t>::result_type>::value>::type* = nullptr>
+static inline void
+execute_op(char* C10_RESTRICT data[], const int64_t* strides, const ScalarType *dtypes, int64_t i, int64_t n, func_t op) {
+  using traits = function_traits<func_t>;
+  using result_type = typename traits::result_type;
+  for (; i < n; i++) {
+    void* out_ptr = data[0] + i * strides[0];
+    result_type result = c10::guts::apply(op, dereference<traits>(
+        &data[1],
+        &strides[1],
+        &dtypes[1],
+        i));
+    cast_and_store<result_type>(dtypes[0], out_ptr, result);
+  }
+}
+
+template <typename func_t,
     typename std::enable_if<std::is_void<typename function_traits<func_t>::result_type>::value>::type* = nullptr>
 static inline void
 execute_op(char* C10_RESTRICT data[], const int64_t* strides, int64_t i, int64_t n, func_t op) {
@@ -124,6 +158,22 @@ basic_loop(char* C10_RESTRICT data[], const int64_t* strides_, int64_t i, int64_
   }
 
   execute_op(data, strides, i, n, op);
+}
+
+template <typename func_t>
+static inline void
+basic_loop(char* C10_RESTRICT data[], const int64_t* strides_, const ScalarType *dtypes, int64_t i, int64_t n, func_t op) {
+  using traits = function_traits<func_t>;
+  constexpr int ntensors = traits::arity + 1;
+
+  // Copying strides to temporary array helps auto vectorization in older GCC
+  // versions.
+  int64_t strides[ntensors];
+  for (int arg = 0; arg < ntensors; arg++) {
+    strides[arg] = strides_[arg];
+  }
+
+  execute_op(data, strides, dtypes, i, n, op);
 }
 
 // Explicitly vectorized loop implementation. All inputs and outputs must be
@@ -186,25 +236,55 @@ static inline void unroll_contiguous_scalar_checks(
 template <typename func_t>
 void cpu_kernel(TensorIterator& iter, func_t op) {
   using traits = function_traits<func_t>;
-  TORCH_INTERNAL_ASSERT(iter.ntensors() >= traits::arity + 1);
+  constexpr int ntensors = traits::arity + 1;
+  TORCH_INTERNAL_ASSERT(iter.ntensors() >= ntensors);
 
-  iter.for_each([&](char** data, const int64_t* strides, int64_t n) {
-    if (is_contiguous<traits>(strides)) {
-      basic_loop(data, strides, 0, n, op);
-    } else {
-      using Indices = c10::guts::make_index_sequence<traits::arity>;
-      unroll_contiguous_scalar_checks<traits>(strides, Indices{}, [&](size_t _idx) {
-        basic_loop(data, strides, 0, n, op);
-      });
+  if (iter.has_promotion()) {
+    at::detail::Array<ScalarType, ntensors> dtypes;
+    for (int i = 0; i < ntensors; i++) {
+      dtypes[i] = iter.tensor(i).scalar_type();
     }
-  });
-  iter.cast_outputs();
+    iter.for_each([&](char** data, const int64_t* strides, int64_t n) {
+      if (is_contiguous<traits>(strides)) {
+        basic_loop(data, strides, dtypes.data, 0, n, op);
+      } else {
+        using Indices = c10::guts::make_index_sequence<traits::arity>;
+        unroll_contiguous_scalar_checks<traits>(strides, Indices{}, [&](size_t _idx) {
+          basic_loop(data, strides, dtypes.data, 0, n, op);
+        });
+      }
+    });
+  } else {
+    iter.for_each([&](char** data, const int64_t* strides, int64_t n) {
+      if (is_contiguous<traits>(strides)) {
+        basic_loop(data, strides, 0, n, op);
+      } else {
+        using Indices = c10::guts::make_index_sequence<traits::arity>;
+        unroll_contiguous_scalar_checks<traits>(strides, Indices{}, [&](size_t _idx) {
+          basic_loop(data, strides, 0, n, op);
+        });
+      }
+    });
+  }
 }
 
 template <typename func_t, typename vec_func_t>
 void cpu_kernel_vec(TensorIterator& iter, func_t op, vec_func_t vop) {
   using traits = function_traits<func_t>;
   TORCH_INTERNAL_ASSERT(iter.ntensors() >= traits::arity + 1);
+
+  // TODO(@zasdfgbnm): vectorized loop is not supported for now when
+  // there is type promotion. Supporting this will requires extending
+  // the loading and storing so that we do:
+  // Step 1: vector load original dtype
+  // Step 2: vector casting to common dtype
+  // Step 3: compute vop
+  // Step 3: vector casting to target dtype
+  // Step 5: vector store
+  if (iter.has_promotion()) {
+    cpu_kernel(iter, op);
+    return;
+  }
 
   iter.for_each([&](char** data, const int64_t* strides, int64_t n) {
     if (is_contiguous<traits>(strides)) {
@@ -220,7 +300,6 @@ void cpu_kernel_vec(TensorIterator& iter, func_t op, vec_func_t vop) {
       });
     }
   });
-  iter.cast_outputs();
 }
 
 template <typename func_t>
@@ -239,7 +318,6 @@ void cpu_serial_kernel(TensorIterator& iter, func_t op) {
       });
     }
   }, {0, iter.numel()});
-  iter.cast_outputs();
 }
 
 }}}  // namespace at::native::<anonymous>

--- a/aten/src/ATen/native/cuda/BinaryOpsKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryOpsKernel.cu
@@ -13,7 +13,7 @@
 namespace at { namespace native {
 
 void add_kernel_cuda(TensorIterator& iter, Scalar alpha_scalar) {
-  AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBool, iter.dtype(), "add_cuda/sub_cuda", [&]() {
+  AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBool, iter.common_dtype(), "add_cuda/sub_cuda", [&]() {
     auto alpha = alpha_scalar.to<scalar_t>();
     gpu_kernel_with_scalars(iter, [alpha]GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
       return a + alpha * b;
@@ -26,11 +26,11 @@ static void sub_kernel_cuda(TensorIterator& iter, Scalar alpha_scalar) {
 }
 
 void div_kernel_cuda(TensorIterator& iter) {
-  if (!isIntegralType(iter.dtype(), /*includeBool*/ false) && iter.is_cpu_scalar(2)) {
+  if (!isIntegralType(iter.common_dtype(), /*includeBool*/ false) && iter.is_cpu_scalar(2)) {
     // optimization for floating-point types: if the second operand is a CPU
     // scalar, compute a * reciprocal(b). Note that this may lose one bit of
     // precision compared to computing the division.
-    AT_DISPATCH_FLOATING_TYPES_AND_HALF(iter.dtype(), "div_cuda", [&]() {
+    AT_DISPATCH_FLOATING_TYPES_AND_HALF(iter.common_dtype(), "div_cuda", [&]() {
       auto inv_b = scalar_t(1.0 / iter.scalar_value<scalar_t>(2));
       iter.remove_operand(2);
       gpu_kernel(iter, [inv_b]GPU_LAMBDA(scalar_t a) -> scalar_t {
@@ -38,7 +38,7 @@ void div_kernel_cuda(TensorIterator& iter) {
       });
     });
   } else {
-    AT_DISPATCH_ALL_TYPES_AND(kHalf, iter.dtype(), "div_cuda", [&]() {
+    AT_DISPATCH_ALL_TYPES_AND(kHalf, iter.common_dtype(), "div_cuda", [&]() {
       gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
         return a / b;
       });
@@ -47,13 +47,13 @@ void div_kernel_cuda(TensorIterator& iter) {
 }
 
 void mul_kernel_cuda(TensorIterator& iter) {
-  if (iter.dtype() == ScalarType::Bool) {
+  if (iter.common_dtype() == ScalarType::Bool) {
     // Workaround for the error: '*' in boolean context, suggest '&&' instead [-Werror=int-in-bool-context]
     gpu_kernel_with_scalars(iter, []GPU_LAMBDA(bool a, bool b) -> bool {
       return a && b;
     });
   } else {
-    AT_DISPATCH_ALL_TYPES_AND(kHalf, iter.dtype(), "mul_cuda", [&]() {
+    AT_DISPATCH_ALL_TYPES_AND(kHalf, iter.common_dtype(), "mul_cuda", [&]() {
       gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
         return a * b;
       });
@@ -62,7 +62,7 @@ void mul_kernel_cuda(TensorIterator& iter) {
 }
 
 void atan2_kernel_cuda(TensorIterator& iter) {
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(iter.dtype(), "atan2_cuda", [&]() {
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(iter.common_dtype(), "atan2_cuda", [&]() {
     gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
       return ::atan2(a, b);
     });
@@ -70,14 +70,14 @@ void atan2_kernel_cuda(TensorIterator& iter) {
 }
 
 void logical_xor_kernel_cuda(TensorIterator& iter) {
-  if (iter.dtype() == ScalarType::Bool) {
+  if (iter.common_dtype() == ScalarType::Bool) {
     AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBool, iter.input_dtype(), "logical_xor_cuda", [&]() {
       gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> bool {
         return bool(a) != bool(b);
       });
     });
   } else {
-    AT_DISPATCH_ALL_TYPES_AND(kHalf, iter.dtype(), "logical_xor_cuda", [&]() {
+    AT_DISPATCH_ALL_TYPES_AND(kHalf, iter.common_dtype(), "logical_xor_cuda", [&]() {
       gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
         return static_cast<scalar_t>(bool(a) != bool(b));
       });
@@ -86,14 +86,14 @@ void logical_xor_kernel_cuda(TensorIterator& iter) {
 }
 
 void lt_kernel_cuda(TensorIterator& iter) {
-  if (iter.dtype() == ScalarType::Bool) {
+  if (iter.common_dtype() == ScalarType::Bool) {
     AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBool, iter.input_dtype(), "lt_cpu", [&]() {
       gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> bool {
         return a < b;
       });
     });
   } else {
-    AT_DISPATCH_ALL_TYPES_AND(kHalf, iter.dtype(), "lt_cpu", [&]() {
+    AT_DISPATCH_ALL_TYPES_AND(kHalf, iter.common_dtype(), "lt_cpu", [&]() {
       gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
         return a < b;
       });
@@ -102,14 +102,14 @@ void lt_kernel_cuda(TensorIterator& iter) {
 }
 
 void le_kernel_cuda(TensorIterator& iter) {
-  if (iter.dtype() == ScalarType::Bool) {
+  if (iter.common_dtype() == ScalarType::Bool) {
     AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBool, iter.input_dtype(), "le_cpu", [&]() {
       gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> bool {
         return a <= b;
       });
     });
   } else {
-    AT_DISPATCH_ALL_TYPES_AND(kHalf, iter.dtype(), "le_cpu", [&]() {
+    AT_DISPATCH_ALL_TYPES_AND(kHalf, iter.common_dtype(), "le_cpu", [&]() {
       gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
         return a <= b;
       });
@@ -118,14 +118,14 @@ void le_kernel_cuda(TensorIterator& iter) {
 }
 
 void gt_kernel_cuda(TensorIterator& iter) {
-  if (iter.dtype() == ScalarType::Bool) {
+  if (iter.common_dtype() == ScalarType::Bool) {
     AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBool, iter.input_dtype(), "gt_cpu", [&]() {
       gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> bool {
         return a > b;
       });
     });
   } else {
-    AT_DISPATCH_ALL_TYPES_AND(kHalf, iter.dtype(), "gt_cpu", [&]() {
+    AT_DISPATCH_ALL_TYPES_AND(kHalf, iter.common_dtype(), "gt_cpu", [&]() {
       gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
         return a > b;
       });
@@ -134,14 +134,14 @@ void gt_kernel_cuda(TensorIterator& iter) {
 }
 
 void ge_kernel_cuda(TensorIterator& iter) {
-  if (iter.dtype() == ScalarType::Bool) {
+  if (iter.common_dtype() == ScalarType::Bool) {
     AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBool, iter.input_dtype(), "ge_cpu", [&]() {
       gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> bool {
         return a >= b;
       });
     });
   } else {
-    AT_DISPATCH_ALL_TYPES_AND(kHalf, iter.dtype(), "ge_cpu", [&]() {
+    AT_DISPATCH_ALL_TYPES_AND(kHalf, iter.common_dtype(), "ge_cpu", [&]() {
       gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
         return a >= b;
       });
@@ -150,14 +150,14 @@ void ge_kernel_cuda(TensorIterator& iter) {
 }
 
 void eq_kernel_cuda(TensorIterator& iter) {
-  if (iter.dtype() == ScalarType::Bool) {
+  if (iter.common_dtype() == ScalarType::Bool) {
     AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBool, iter.input_dtype(), "eq_cpu", [&]() {
       gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> bool {
         return a == b;
       });
     });
   } else {
-    AT_DISPATCH_ALL_TYPES_AND(kHalf, iter.dtype(), "eq_cpu", [&]() {
+    AT_DISPATCH_ALL_TYPES_AND(kHalf, iter.common_dtype(), "eq_cpu", [&]() {
       gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
         return a == b;
       });
@@ -166,14 +166,14 @@ void eq_kernel_cuda(TensorIterator& iter) {
 }
 
 void ne_kernel_cuda(TensorIterator& iter) {
-  if (iter.dtype() == ScalarType::Bool) {
+  if (iter.common_dtype() == ScalarType::Bool) {
     AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBool, iter.input_dtype(), "ne_cpu", [&]() {
       gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> bool {
         return a != b;
       });
     });
   } else {
-    AT_DISPATCH_ALL_TYPES_AND(kHalf, iter.dtype(), "ne_cpu", [&]() {
+    AT_DISPATCH_ALL_TYPES_AND(kHalf, iter.common_dtype(), "ne_cpu", [&]() {
       gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
         return a != b;
       });

--- a/aten/src/ATen/native/cuda/Copy.cu
+++ b/aten/src/ATen/native/cuda/Copy.cu
@@ -8,6 +8,7 @@
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/cuda/Loops.cuh>
 #include <THC/THC.h>
+#include <c10/util/TypeCast.h>
 
 namespace at {
 namespace native {
@@ -17,7 +18,7 @@ using namespace at::cuda;
 template <typename dst_t, typename src_t>
 void copy_kernel_impl(TensorIterator& iter) {
   gpu_kernel(iter, []GPU_LAMBDA(src_t x) -> dst_t {
-    return static_cast<dst_t>(static_cast<native::inter_copy_type_t<dst_t>>(x));
+    return c10::static_cast_with_inter_type<dst_t>(x);
   });
 }
 

--- a/aten/src/ATen/native/cuda/Copy.cu
+++ b/aten/src/ATen/native/cuda/Copy.cu
@@ -8,19 +8,11 @@
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/cuda/Loops.cuh>
 #include <THC/THC.h>
-#include <c10/util/TypeCast.h>
 
 namespace at {
 namespace native {
 
 using namespace at::cuda;
-
-template <typename dst_t, typename src_t>
-void copy_kernel_impl(TensorIterator& iter) {
-  gpu_kernel(iter, []GPU_LAMBDA(src_t x) -> dst_t {
-    return c10::static_cast_with_inter_type<dst_t>(x);
-  });
-}
 
 // device-to-device copy, does type conversion
 static void copy_device_to_device(TensorIterator& iter, bool non_blocking) {
@@ -67,10 +59,7 @@ static void copy_device_to_device(TensorIterator& iter, bool non_blocking) {
         copy_stream));
   } else {
     AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBool, iter.dtype(0), "copy_", [&] {
-      using dst_t = scalar_t;
-      AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBool, iter.dtype(1), "copy_", [&] {
-        copy_kernel_impl<dst_t, scalar_t>(iter);
-      });
+      gpu_kernel(iter, []GPU_LAMBDA(scalar_t x) { return x; });
     });
   }
 

--- a/aten/src/ATen/native/cuda/Loops.cuh
+++ b/aten/src/ATen/native/cuda/Loops.cuh
@@ -35,6 +35,7 @@
 #include <ATen/detail/FunctionTraits.h>
 #include <ATen/native/TensorIterator.h>
 #include <c10/macros/Macros.h>
+#include <c10/util/TypeCast.h>
 
 // Marks a lambda as executable on both the host and device. The __host__
 // attribute is important so that we can access static type information from
@@ -116,6 +117,20 @@ invoke(const func_t &f, char *const C10_RESTRICT data[], const index_t strides[]
   return invoke_impl<traits>(f, data, strides, i, Indices{});
 }
 
+template <typename traits, typename func_t, typename index_t, size_t... I>
+C10_HOST_DEVICE typename traits::result_type
+invoke_impl(const func_t &f, char *const C10_RESTRICT data[], const index_t strides[], const ScalarType dtypes[], int i,
+            c10::guts::index_sequence<I...>) {
+  return f(c10::fetch_and_cast<typename traits::template arg<I>::type>(dtypes[I], data[I] + i * strides[I])...);
+}
+
+template <typename func_t, typename index_t, typename traits = function_traits<func_t>>
+C10_HOST_DEVICE typename traits::result_type
+invoke(const func_t &f, char *const C10_RESTRICT data[], const index_t strides[], const ScalarType dtypes[], int i) {
+  using Indices = c10::guts::make_index_sequence<traits::arity>;
+  return invoke_impl<traits>(f, data, strides, dtypes, i, Indices{});
+}
+
 template <typename func_t>
 void gpu_kernel_impl(TensorIterator& iter, const func_t& f) {
   using traits = function_traits<func_t>;
@@ -130,6 +145,10 @@ void gpu_kernel_impl(TensorIterator& iter, const func_t& f) {
     data[i] = (char*)iter.data_ptr(i);
   }
 
+  at::detail::Array<ScalarType, ntensors> dtypes;
+  for (int i = 0; i < ntensors; i++) {
+    dtypes[i] = iter.tensor(i).scalar_type();
+  }
 
   int64_t numel = iter.numel();
   if (iter.is_trivial_1d()) {
@@ -138,19 +157,35 @@ void gpu_kernel_impl(TensorIterator& iter, const func_t& f) {
     for (int i = 0; i < ntensors; i++) {
       strides[i] = inner_strides[i];
     }
-   
 
-    launch_kernel<launch_size_1d, 1>(numel, [=]GPU_LAMBDA(int idx) {
-      arg0_t* out = (arg0_t*)(data[0] + strides[0] * idx);
-      *out = invoke(f, &data.data[1], &strides.data[1], idx);
-    });
+    if (iter.has_promotion()) {
+      launch_kernel<launch_size_1d, 1>(numel, [=]GPU_LAMBDA(int idx) {
+        void* out = data[0] + strides[0] * idx;
+        arg0_t result = invoke(f, &data.data[1], &strides.data[1], &dtypes.data[1], idx);
+        c10::cast_and_store<arg0_t>(dtypes[0], out, result);
+      });
+    } else {
+      launch_kernel<launch_size_1d, 1>(numel, [=]GPU_LAMBDA(int idx) {
+        arg0_t* out = (arg0_t*)(data[0] + strides[0] * idx);
+        *out = invoke(f, &data.data[1], &strides.data[1], idx);
+      });
+    }
   } else {
     auto offset_calc = make_offset_calculator<traits::arity + 1>(iter);
-    launch_kernel<launch_size_nd, launch_bound2>(numel, [=]GPU_LAMBDA(int idx) {
-      auto offsets = offset_calc.get(idx);
-      arg0_t* out = (arg0_t*)(data[0] + offsets[0]);
-      *out = invoke(f, &data.data[1], &offsets.data[1], 1);
-    });
+    if (iter.has_promotion()) {
+      launch_kernel<launch_size_nd, launch_bound2>(numel, [=]GPU_LAMBDA(int idx) {
+        auto offsets = offset_calc.get(idx);
+        void* out = data[0] + offsets[0];
+        arg0_t result = invoke(f, &data.data[1], &offsets.data[1], &dtypes.data[1], 1);
+        c10::cast_and_store<arg0_t>(dtypes[0], out, result);
+      });
+    } else {
+      launch_kernel<launch_size_nd, launch_bound2>(numel, [=]GPU_LAMBDA(int idx) {
+        auto offsets = offset_calc.get(idx);
+        arg0_t* out = (arg0_t*)(data[0] + offsets[0]);
+        *out = invoke(f, &data.data[1], &offsets.data[1], 1);
+      });
+    }
   }
 }
 
@@ -174,7 +209,6 @@ void gpu_kernel(TensorIterator& iter, const func_t& f) {
   }
 
   gpu_kernel_impl(iter, f);
-  iter.cast_outputs();
 }
 
 template <typename func_t>

--- a/aten/src/ATen/test/tensor_iterator_test.cpp
+++ b/aten/src/ATen/test/tensor_iterator_test.cpp
@@ -188,8 +188,9 @@ TEST(TensorIteratorTest, ComputeCommonDTypeInputOnly) {
   iter.compute_common_dtype_only_for_inputs();
   iter.build();
   EXPECT_TRUE(iter.dtype(0) == at::kBool);
-  EXPECT_TRUE(iter.dtype(1) == at::kDouble);
+  EXPECT_TRUE(iter.dtype(1) == at::kFloat);
   EXPECT_TRUE(iter.dtype(2) == at::kDouble);
+  EXPECT_TRUE(iter.common_dtype() == at::kDouble);
 }
 
 TEST(TensorIteratorTest, DoNotComputeCommonDTypeInputOnly) {

--- a/c10/core/ScalarType.h
+++ b/c10/core/ScalarType.h
@@ -166,6 +166,10 @@ struct ScalarTypeToCPPType<c10::ScalarType::Long> {
   _(c10::quint8, QUInt8)         \
   _(c10::qint32, QInt32)
 
+#define AT_FORALL_COMPLEX_TYPES(_)             \
+  _(std::complex<float>, ComplexFloat)         \
+  _(std::complex<double>, ComplexDouble)
+
 static inline caffe2::TypeMeta scalarTypeToTypeMeta(ScalarType scalar_type) {
 #define DEFINE_CASE(ctype, name) \
   case ScalarType::name:         \

--- a/c10/util/TypeCast.h
+++ b/c10/util/TypeCast.h
@@ -1,0 +1,126 @@
+#pragma once
+
+#include <c10/core/ScalarType.h>
+#include <c10/util/Half.h>
+#include <c10/util/BFloat16.h>
+
+
+namespace c10 {
+
+// Note [Implicit conversion between signed and unsigned]
+// C and C++ have a lovely set of implicit conversion rules, where casting
+// signed integral values to unsigned integral values is always valid
+// (it basically treats the value as if using modulo arithmetic), however
+// converting negative floating point values to unsigned integral types
+// is UB! This means that: (double)-1 -> (int64_t)-1 -> (uint8_t)255 is
+// guaranteed to look like this, but we have (double)-1 -> (uint8_t)<ANYTHING>
+// because it's UB. This also makes UBSan really angry.
+//
+// I think those rules are stupid and we really shouldn't conform to them.
+// The structs below ensure that for all unsigned types we use (currently
+// only uint8_t), we will do an intermediate convertion via int64_t,
+// to ensure that any negative values are wrapped around correctly.
+//
+// Note that conversions from doubles to signed integral types that can't
+// represent a particular value after truncating the fracitonal part are UB as well,
+// but fixing them is not as simple as adding an int64_t intermediate, beacuse the
+// int64_t -> <smaller signed type> conversion is UB for those large values anyway.
+// I guess in that case we just have to live with that, but it's definitely less
+// surprising than the thing above.
+//
+// For the curious:
+//   https://en.cppreference.com/w/cpp/language/implicit_conversion
+//   The relevant paragraph is "Floating-integral conversions".
+
+template <typename T>
+struct inter_copy_type {
+  using type = T;
+};
+
+template <>
+struct inter_copy_type<uint8_t> {
+  using type = int64_t;
+};
+
+template <typename T>
+using inter_copy_type_t = typename inter_copy_type<T>::type;
+
+template <typename dest_t, typename src_t>
+C10_HOST_DEVICE inline dest_t static_cast_with_inter_type(src_t src) {
+  return static_cast<dest_t>(
+    static_cast<inter_copy_type_t<dest_t>>(src));
+}
+
+#ifdef C10_HOST_DEVICE
+#define ERROR_UNSUPPORTED_CAST assert(false);
+#else
+#define ERROR_UNSUPPORTED_CAST TORCH_CHECK(false, "Unexpected scalar type");
+#endif
+
+// Fetch a value with dynamic type src_type from ptr, and cast it to static type dest_t.
+#define FETCH_AND_CAST_CASE(type, scalartype) case ScalarType::scalartype: return static_cast_with_inter_type<dest_t>(*(const type *)ptr);
+#define FETCH_AND_CAST_COMPLEX_CASE(type, scalartype) case ScalarType::scalartype: return static_cast_with_inter_type<dest_t>(std::real(*(const type *)ptr));
+template<typename dest_t>
+C10_HOST_DEVICE inline dest_t fetch_and_cast(const ScalarType src_type, const void *ptr) {
+  switch (src_type) {
+    AT_FORALL_SCALAR_TYPES_AND3(Bool, Half, BFloat16, FETCH_AND_CAST_CASE)
+#ifndef C10_HOST_DEVICE
+    AT_FORALL_COMPLEX_TYPES(FETCH_AND_CAST_COMPLEX_CASE)
+#endif
+    default:;
+  }
+  ERROR_UNSUPPORTED_CAST
+  return dest_t(0); // just to avoid compiler warning
+}
+
+// Cast a value with static type src_t into dynamic dest_type, and store it to ptr.
+#define CAST_AND_STORE_CASE(type, scalartype) case ScalarType::scalartype: *(type *)ptr = static_cast_with_inter_type<type>(value); return;
+template<typename src_t>
+C10_HOST_DEVICE inline void cast_and_store(const ScalarType dest_type, void *ptr, src_t value) {
+  switch (dest_type) {
+    AT_FORALL_SCALAR_TYPES_AND3(Bool, Half, BFloat16, CAST_AND_STORE_CASE)
+    default:;
+  }
+  ERROR_UNSUPPORTED_CAST
+}
+
+template<>
+inline void cast_and_store<std::complex<float>>(const ScalarType dest_type, void *ptr, std::complex<float> value_) {
+  auto value = std::real(value_);
+  switch (dest_type) {
+    AT_FORALL_SCALAR_TYPES_AND3(Bool, Half, BFloat16, CAST_AND_STORE_CASE)
+    default:;
+  }
+  ERROR_UNSUPPORTED_CAST
+}
+template<>
+inline void cast_and_store<std::complex<double>>(const ScalarType dest_type, void *ptr, std::complex<double> value_) {
+  auto value = std::real(value_);
+  switch (dest_type) {
+    AT_FORALL_SCALAR_TYPES_AND3(Bool, Half, BFloat16, CAST_AND_STORE_CASE)
+    default:;
+  }
+  ERROR_UNSUPPORTED_CAST
+}
+
+#define DEFINE_UNCASTABLE(T, scalartype_)                                         \
+template<>                                                                        \
+inline T fetch_and_cast<T>(const ScalarType src_type, const void *ptr) {          \
+  assert(ScalarType::scalartype_ == src_type);                                    \
+  return *(const T *)ptr;                                                         \
+}                                                                                 \
+template<>                                                                        \
+inline void cast_and_store<T>(const ScalarType dest_type, void *ptr, T value) {   \
+  assert(ScalarType::scalartype_ == dest_type);                                   \
+  *(T *)ptr = value;                                                              \
+}
+
+AT_FORALL_QINT_TYPES(DEFINE_UNCASTABLE)
+
+#undef FETCH_AND_CAST_CASE
+#undef FETCH_AND_CAST_COMPLEX_CASE
+#undef CAST_AND_STORE_CASE
+#undef DEFINE_UNCASTABLE
+#undef ERROR_UNSUPPORTED_CAST
+
+}  // namespace c10


### PR DESCRIPTION
Using the new type promotion and dynamic casting added to `TensorIterator`, the copy kernels could be greatly simplified.

# Benchmark

**Script:**
```python
import torch
import timeit
import pandas
import itertools
from tqdm import tqdm
import math
print(torch.__version__)
print()

_10M = 10 * 1024 ** 2

d = {}

for from_, to in tqdm(itertools.product(torch.testing.get_all_dtypes(), repeat=2)):
    if from_ not in d:
        d[from_] = {}
    a = torch.zeros(_10M, dtype=from_)
    min_ = math.inf
    for i in range(100):
        start = timeit.default_timer()
        a.to(to)
        end = timeit.default_timer()
        elapsed = end - start
        if elapsed < min_:
            min_ = elapsed
    d[from_][to] = int(elapsed * 1000 * 1000)
    
pandas.DataFrame(d)
```

**Before:**
![image](https://user-images.githubusercontent.com/1032377/67171274-2e93d000-f36b-11e9-8fa0-91edd7dbc8ec.png)

**After:**
![image](https://user-images.githubusercontent.com/1032377/67171200-d361dd80-f36a-11e9-9b22-66292e395a09.png)
