### PR TITLE
C++ parity, grid_sample functional

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -573,6 +573,7 @@ if (NOT INTERN_BUILD_MOBILE OR NOT BUILD_CAFFE2_MOBILE)
       ${TORCH_SRC_DIR}/csrc/api/src/nn/options/linear.cpp
       ${TORCH_SRC_DIR}/csrc/api/src/nn/options/normalization.cpp
       ${TORCH_SRC_DIR}/csrc/api/src/nn/options/pooling.cpp
+      ${TORCH_SRC_DIR}/csrc/api/src/nn/options/vision.cpp
       ${TORCH_SRC_DIR}/csrc/api/src/nn/options/rnn.cpp
       ${TORCH_SRC_DIR}/csrc/api/src/optim/adagrad.cpp
       ${TORCH_SRC_DIR}/csrc/api/src/optim/adam.cpp

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -574,6 +574,7 @@ if (NOT INTERN_BUILD_MOBILE OR NOT BUILD_CAFFE2_MOBILE)
       ${TORCH_SRC_DIR}/csrc/api/src/nn/options/normalization.cpp
       ${TORCH_SRC_DIR}/csrc/api/src/nn/options/pooling.cpp
       ${TORCH_SRC_DIR}/csrc/api/src/nn/options/rnn.cpp
+      ${TORCH_SRC_DIR}/csrc/api/src/nn/options/vision.cpp
       ${TORCH_SRC_DIR}/csrc/api/src/optim/adagrad.cpp
       ${TORCH_SRC_DIR}/csrc/api/src/optim/adam.cpp
       ${TORCH_SRC_DIR}/csrc/api/src/optim/lbfgs.cpp

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -573,7 +573,6 @@ if (NOT INTERN_BUILD_MOBILE OR NOT BUILD_CAFFE2_MOBILE)
       ${TORCH_SRC_DIR}/csrc/api/src/nn/options/linear.cpp
       ${TORCH_SRC_DIR}/csrc/api/src/nn/options/normalization.cpp
       ${TORCH_SRC_DIR}/csrc/api/src/nn/options/pooling.cpp
-      ${TORCH_SRC_DIR}/csrc/api/src/nn/options/vision.cpp
       ${TORCH_SRC_DIR}/csrc/api/src/nn/options/rnn.cpp
       ${TORCH_SRC_DIR}/csrc/api/src/optim/adagrad.cpp
       ${TORCH_SRC_DIR}/csrc/api/src/optim/adam.cpp

--- a/setup.py
+++ b/setup.py
@@ -800,6 +800,7 @@ if __name__ == '__main__':
                 'include/ATen/cuda/detail/*.h',
                 'include/ATen/cudnn/*.h',
                 'include/ATen/detail/*.h',
+                'include/Aten/native/*.h',
                 'include/caffe2/utils/*.h',
                 'include/c10/*.h',
                 'include/c10/macros/*.h',

--- a/setup.py
+++ b/setup.py
@@ -800,7 +800,6 @@ if __name__ == '__main__':
                 'include/ATen/cuda/detail/*.h',
                 'include/ATen/cudnn/*.h',
                 'include/ATen/detail/*.h',
-                'include/Aten/native/*.h',
                 'include/caffe2/utils/*.h',
                 'include/c10/*.h',
                 'include/c10/macros/*.h',

--- a/test/cpp/api/functional.cpp
+++ b/test/cpp/api/functional.cpp
@@ -232,11 +232,6 @@ TEST_F(FunctionalTest, GridSample) {
   auto expected = torch::tensor({{{{0., 0., 1.}, {3., 4., 5.}, {7., 8., 0.}}}}, torch::kFloat);
 
   ASSERT_TRUE(output.allclose(expected));
-  
-  // default options (bilinear, zeros, true) same result as above
-  output = F::grid_sample(input, grid);
-
-  ASSERT_TRUE(output.allclose(expected));
 
   // bilinear, zeros, false
   options = GridSampleOptions()
@@ -245,6 +240,11 @@ TEST_F(FunctionalTest, GridSample) {
                 .align_corners(false);
   output = F::grid_sample(input, grid, options);
   expected = torch::tensor({{{{0., 0., 0.5}, {1.5, 4., 2.5}, {3.5, 2., 0.}}}}, torch::kFloat);
+
+  ASSERT_TRUE(output.allclose(expected));
+
+  // default options (bilinear, zeros, false) same result as above
+  output = F::grid_sample(input, grid);
 
   ASSERT_TRUE(output.allclose(expected));
 

--- a/test/cpp/api/functional.cpp
+++ b/test/cpp/api/functional.cpp
@@ -225,19 +225,24 @@ TEST_F(FunctionalTest, GridSample) {
 
   // bilinear, zeros, true
   auto options = GridSampleOptions()
-                  .mode(torch::GridSamplerInterpolation::Bilinear)
-                  .padding_mode(torch::GridSamplerPadding::Zeros)
-                  .align_corners(true);
+                    .mode("bilinear")
+                    .padding_mode("zeros")
+                    .align_corners(true);
   auto output = F::grid_sample(input, grid, options);
   auto expected = torch::tensor({{{{0., 0., 1.}, {3., 4., 5.}, {7., 8., 0.}}}}, torch::kFloat);
+
+  ASSERT_TRUE(output.allclose(expected));
+  
+  // default options (bilinear, zeros, true) same result as above
+  output = F::grid_sample(input, grid);
 
   ASSERT_TRUE(output.allclose(expected));
 
   // bilinear, zeros, false
   options = GridSampleOptions()
-                  .mode(torch::GridSamplerInterpolation::Bilinear)
-                  .padding_mode(torch::GridSamplerPadding::Zeros)
-                  .align_corners(false);
+                .mode("bilinear")
+                .padding_mode("zeros")
+                .align_corners(false);
   output = F::grid_sample(input, grid, options);
   expected = torch::tensor({{{{0., 0., 0.5}, {1.5, 4., 2.5}, {3.5, 2., 0.}}}}, torch::kFloat);
 
@@ -245,9 +250,9 @@ TEST_F(FunctionalTest, GridSample) {
 
   // nearest, zeros, true
   options = GridSampleOptions()
-                  .mode(torch::GridSamplerInterpolation::Nearest)
-                  .padding_mode(torch::GridSamplerPadding::Zeros)
-                  .align_corners(true);
+                .mode("nearest")
+                .padding_mode("zeros")
+                .align_corners(true);
   output = F::grid_sample(input, grid, options);
   expected = torch::tensor({{{{0., 0., 1.}, {3., 4., 5.}, {7., 8., 0.}}}}, torch::kFloat);
 
@@ -255,9 +260,9 @@ TEST_F(FunctionalTest, GridSample) {
 
   // bilinear, border, true
   options = GridSampleOptions()
-                  .mode(torch::GridSamplerInterpolation::Bilinear)
-                  .padding_mode(torch::GridSamplerPadding::Border)
-                  .align_corners(true);
+                .mode("bilinear")
+                .padding_mode("border")
+                .align_corners(true);
   output = F::grid_sample(input, grid, options);
   expected = torch::tensor({{{{0., 0., 1.}, {3., 4., 5.}, {7., 8., 8.}}}}, torch::kFloat);
 
@@ -265,9 +270,9 @@ TEST_F(FunctionalTest, GridSample) {
 
   // bilinear, reflection, true
   options = GridSampleOptions()
-                  .mode(torch::GridSamplerInterpolation::Bilinear)
-                  .padding_mode(torch::GridSamplerPadding::Reflection)
-                  .align_corners(true);
+                .mode("bilinear")
+                .padding_mode("reflection")
+                .align_corners(true);
   output = F::grid_sample(input, grid, options);
   expected = torch::tensor({{{{1., 0., 1.}, {3., 4., 5.}, {7., 8., 7.}}}}, torch::kFloat);
 

--- a/test/cpp/api/functional.cpp
+++ b/test/cpp/api/functional.cpp
@@ -215,6 +215,65 @@ TEST_F(FunctionalTest, HingeEmbeddingLoss) {
   ASSERT_TRUE(output.allclose(expected));
 }
 
+TEST_F(FunctionalTest, GridSample) {
+  auto input = torch::arange(9, torch::kFloat).view(std::vector<int64_t>({1, 1, 3, 3}));
+  auto grid = torch::tensor({{
+      {{-2., -1.}, {-1., -1.}, {0., -1.}},
+      {{-1., 0.}, {0., 0.}, {1., 0.}},
+      {{0., 1.}, {1., 1.}, {2., 1.}}
+  }}, torch::kFloat);
+
+  // bilinear, zeros, true
+  auto options = GridSampleOptions()
+                  .mode(torch::GridSamplerInterpolation::Bilinear)
+                  .padding_mode(torch::GridSamplerPadding::Zeros)
+                  .align_corners(true);
+  auto output = F::grid_sample(input, grid, options);
+  auto expected = torch::tensor({{{{0., 0., 1.}, {3., 4., 5.}, {7., 8., 0.}}}}, torch::kFloat);
+
+  ASSERT_TRUE(output.allclose(expected));
+
+  // bilinear, zeros, false
+  options = GridSampleOptions()
+                  .mode(torch::GridSamplerInterpolation::Bilinear)
+                  .padding_mode(torch::GridSamplerPadding::Zeros)
+                  .align_corners(false);
+  output = F::grid_sample(input, grid, options);
+  expected = torch::tensor({{{{0., 0., 0.5}, {1.5, 4., 2.5}, {3.5, 2., 0.}}}}, torch::kFloat);
+
+  ASSERT_TRUE(output.allclose(expected));
+
+  // nearest, zeros, true
+  options = GridSampleOptions()
+                  .mode(torch::GridSamplerInterpolation::Nearest)
+                  .padding_mode(torch::GridSamplerPadding::Zeros)
+                  .align_corners(true);
+  output = F::grid_sample(input, grid, options);
+  expected = torch::tensor({{{{0., 0., 1.}, {3., 4., 5.}, {7., 8., 0.}}}}, torch::kFloat);
+
+  ASSERT_TRUE(output.allclose(expected));
+
+  // bilinear, border, true
+  options = GridSampleOptions()
+                  .mode(torch::GridSamplerInterpolation::Bilinear)
+                  .padding_mode(torch::GridSamplerPadding::Border)
+                  .align_corners(true);
+  output = F::grid_sample(input, grid, options);
+  expected = torch::tensor({{{{0., 0., 1.}, {3., 4., 5.}, {7., 8., 8.}}}}, torch::kFloat);
+
+  ASSERT_TRUE(output.allclose(expected));
+
+  // bilinear, reflection, true
+  options = GridSampleOptions()
+                  .mode(torch::GridSamplerInterpolation::Bilinear)
+                  .padding_mode(torch::GridSamplerPadding::Reflection)
+                  .align_corners(true);
+  output = F::grid_sample(input, grid, options);
+  expected = torch::tensor({{{{1., 0., 1.}, {3., 4., 5.}, {7., 8., 7.}}}}, torch::kFloat);
+
+  ASSERT_TRUE(output.allclose(expected));
+}
+
 TEST_F(FunctionalTest, AffineGrid) {
   {
     // 2D affine.

--- a/tools/build_variables.py
+++ b/tools/build_variables.py
@@ -230,6 +230,7 @@ def add_torch_libs():
         "torch/csrc/api/src/nn/options/normalization.cpp",
         "torch/csrc/api/src/nn/options/pooling.cpp",
         "torch/csrc/api/src/nn/options/rnn.cpp",
+        "torch/csrc/api/src/nn/options/vision.cpp",
         "torch/csrc/api/src/optim/adagrad.cpp",
         "torch/csrc/api/src/optim/adam.cpp",
         "torch/csrc/api/src/optim/lbfgs.cpp",

--- a/tools/build_variables.py
+++ b/tools/build_variables.py
@@ -229,6 +229,7 @@ def add_torch_libs():
         "torch/csrc/api/src/nn/options/linear.cpp",
         "torch/csrc/api/src/nn/options/normalization.cpp",
         "torch/csrc/api/src/nn/options/pooling.cpp",
+        "torch/csrc/api/src/nn/options/vision.cpp",
         "torch/csrc/api/src/nn/options/rnn.cpp",
         "torch/csrc/api/src/optim/adagrad.cpp",
         "torch/csrc/api/src/optim/adam.cpp",

--- a/tools/build_variables.py
+++ b/tools/build_variables.py
@@ -229,7 +229,6 @@ def add_torch_libs():
         "torch/csrc/api/src/nn/options/linear.cpp",
         "torch/csrc/api/src/nn/options/normalization.cpp",
         "torch/csrc/api/src/nn/options/pooling.cpp",
-        "torch/csrc/api/src/nn/options/vision.cpp",
         "torch/csrc/api/src/nn/options/rnn.cpp",
         "torch/csrc/api/src/optim/adagrad.cpp",
         "torch/csrc/api/src/optim/adam.cpp",

--- a/torch/csrc/api/include/torch/nn/functional/vision.h
+++ b/torch/csrc/api/include/torch/nn/functional/vision.h
@@ -60,7 +60,7 @@ inline Tensor grid_sample(
   if ((options.padding_mode().compare("zeros") != 0) && 
       (options.padding_mode().compare("border") != 0) && 
       (options.padding_mode().compare("reflection") != 0)) {
-    TORCH_CHECK(false, "nn.functional.grid_sample(): expected padding_mode ",
+    TORCH_CHECK(false, "nn::functional::grid_sample(): expected padding_mode ",
                          "to be 'zeros', 'border', or 'reflection', ",
                          "but got: '", options.padding_mode(), "'");
   }
@@ -85,10 +85,11 @@ inline Tensor grid_sample(
   }
   
   if (!options.align_corners().has_value()) {
-    TORCH_WARN("Default grid_sample and affine_grid behavior will be changed ",
-                "to align_corners=False from 1.4.0. ",
-                "See the documentation of grid_sample for details.");
-    options.align_corners(true);
+    TORCH_WARN("Default grid_sample and affine_grid behavior has changed ",
+                   "to align_corners=False since 1.3.0. Please specify ",
+                   "align_corners=True if the old behavior is desired. ",
+                   "See the documentation of grid_sample for details.");
+    options.align_corners(false);
   }
   
   return torch::grid_sampler(input, grid, mode_enum, padding_mode_enum, options.align_corners().value());

--- a/torch/csrc/api/include/torch/nn/functional/vision.h
+++ b/torch/csrc/api/include/torch/nn/functional/vision.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <torch/nn/options/vision.h>
 #include <torch/types.h>
 
 namespace torch {
@@ -44,6 +45,21 @@ inline Tensor affine_grid(
   }
 
   return torch::affine_grid_generator(theta, size, align_corners);
+}
+
+inline Tensor grid_sample(
+    const Tensor& input,
+    const Tensor& grid,
+    GridSampleOptions options = {}) {
+  
+  if (!options.align_corners().has_value()) {
+    TORCH_WARN("Default grid_sample and affine_grid behavior will be changed ",
+                "to align_corners=False from 1.4.0. ",
+                "See the documentation of grid_sample for details.");
+    options.align_corners(true);
+  }
+  
+  return torch::grid_sampler(input, grid, static_cast<int64_t>(options.mode()), static_cast<int64_t>(options.padding_mode()), options.align_corners().value());
 }
 
 } // namespace functional

--- a/torch/csrc/api/include/torch/nn/functional/vision.h
+++ b/torch/csrc/api/include/torch/nn/functional/vision.h
@@ -51,6 +51,38 @@ inline Tensor grid_sample(
     const Tensor& input,
     const Tensor& grid,
     GridSampleOptions options = {}) {
+
+  if ((options.mode().compare("bilinear") != 0) && (options.mode().compare("nearest") != 0)) {
+    TORCH_CHECK(false, "nn::functional::grid_sample(): expected mode to be ",
+                         "'bilinear' or 'nearest', but got: '", options.mode(), "'");
+  }
+
+  if ((options.padding_mode().compare("zeros") != 0) && 
+      (options.padding_mode().compare("border") != 0) && 
+      (options.padding_mode().compare("reflection") != 0)) {
+    TORCH_CHECK(false, "nn.functional.grid_sample(): expected padding_mode ",
+                         "to be 'zeros', 'border', or 'reflection', ",
+                         "but got: '", options.padding_mode(), "'");
+  }
+
+  int64_t mode_enum, padding_mode_enum;
+
+  if (options.mode().compare("bilinear") == 0) {
+    mode_enum = 0;
+  }
+  else { /// mode == 'nearest'
+    mode_enum = 1;
+  }
+
+  if (options.padding_mode().compare("zeros") == 0) {
+    padding_mode_enum = 0;
+  }
+  else if (options.padding_mode().compare("border") == 0) {
+    padding_mode_enum = 1;
+  }
+  else { /// padding_mode == 'reflection'
+    padding_mode_enum = 2;
+  }
   
   if (!options.align_corners().has_value()) {
     TORCH_WARN("Default grid_sample and affine_grid behavior will be changed ",
@@ -59,7 +91,7 @@ inline Tensor grid_sample(
     options.align_corners(true);
   }
   
-  return torch::grid_sampler(input, grid, static_cast<int64_t>(options.mode()), static_cast<int64_t>(options.padding_mode()), options.align_corners().value());
+  return torch::grid_sampler(input, grid, mode_enum, padding_mode_enum, options.align_corners().value());
 }
 
 } // namespace functional

--- a/torch/csrc/api/include/torch/nn/options.h
+++ b/torch/csrc/api/include/torch/nn/options.h
@@ -8,4 +8,5 @@
 #include <torch/nn/options/loss.h>
 #include <torch/nn/options/normalization.h>
 #include <torch/nn/options/pooling.h>
+#include <torch/nn/options/vision.h>
 #include <torch/nn/options/rnn.h>

--- a/torch/csrc/api/include/torch/nn/options/vision.h
+++ b/torch/csrc/api/include/torch/nn/options/vision.h
@@ -13,7 +13,7 @@ struct TORCH_API GridSampleOptions {
   TORCH_ARG(std::string, mode) = "bilinear";
   /// padding mode for outside grid values. Default: Zeros
   TORCH_ARG(std::string, padding_mode) = "zeros";
-  /// Specifies perspective to pixel as point. Default: true
+  /// Specifies perspective to pixel as point. Default: false
   TORCH_ARG(c10::optional<bool>, align_corners) = c10::nullopt;
 };
 

--- a/torch/csrc/api/include/torch/nn/options/vision.h
+++ b/torch/csrc/api/include/torch/nn/options/vision.h
@@ -3,21 +3,16 @@
 #include <torch/arg.h>
 #include <torch/csrc/WindowsTorchApiMacro.h>
 #include <torch/types.h>
-#include <ATen/native/GridSampler.h>
 
 namespace torch {
-
-using torch::native::detail::GridSamplerInterpolation;
-using torch::native::detail::GridSamplerPadding;
-
 namespace nn {
 
 /// Options for a Grid Sample module.
 struct TORCH_API GridSampleOptions {
   /// interpolation mode to calculate output values. Default: Bilinear
-  TORCH_ARG(torch::GridSamplerInterpolation, mode) = torch::GridSamplerInterpolation::Bilinear;
+  TORCH_ARG(std::string, mode) = "bilinear";
   /// padding mode for outside grid values. Default: Zeros
-  TORCH_ARG(torch::GridSamplerPadding, padding_mode) = torch::GridSamplerPadding::Zeros;
+  TORCH_ARG(std::string, padding_mode) = "zeros";
   /// Specifies perspective to pixel as point. Default: true
   TORCH_ARG(c10::optional<bool>, align_corners) = c10::nullopt;
 };

--- a/torch/csrc/api/include/torch/nn/options/vision.h
+++ b/torch/csrc/api/include/torch/nn/options/vision.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <torch/arg.h>
+#include <torch/csrc/WindowsTorchApiMacro.h>
+#include <torch/types.h>
+#include <ATen/native/GridSampler.h>
+
+namespace torch {
+
+using torch::native::detail::GridSamplerInterpolation;
+using torch::native::detail::GridSamplerPadding;
+
+namespace nn {
+
+/// Options for a Grid Sample module.
+struct TORCH_API GridSampleOptions {
+  /// interpolation mode to calculate output values. Default: Bilinear
+  TORCH_ARG(torch::GridSamplerInterpolation, mode) = torch::GridSamplerInterpolation::Bilinear;
+  /// padding mode for outside grid values. Default: Zeros
+  TORCH_ARG(torch::GridSamplerPadding, padding_mode) = torch::GridSamplerPadding::Zeros;
+  /// Specifies perspective to pixel as point. Default: true
+  TORCH_ARG(c10::optional<bool>, align_corners) = c10::nullopt;
+};
+
+} // namespace nn
+} // namespace torch

--- a/torch/csrc/api/src/nn/options/vision.cpp
+++ b/torch/csrc/api/src/nn/options/vision.cpp
@@ -1,0 +1,1 @@
+#include <torch/nn/options/vision.h>

--- a/torch/csrc/api/src/nn/options/vision.cpp
+++ b/torch/csrc/api/src/nn/options/vision.cpp
@@ -1,1 +1,0 @@
-#include <torch/nn/options/vision.h>


### PR DESCRIPTION
#25883 
I put grid_sample in vision.h with affine grid.

I have a question in string argument(interpolation mode, padding mode)
I reuse torch::native::detail::GridSamplerInterpolation in GridSampler.h instead of using string.
It follows the way that uses reduction enum in loss functions.
I am not sure this is right.

@yf225 