### PR TITLE
Do not insert observers for empty sequential modules

### DIFF
--- a/test/common_quantization.py
+++ b/test/common_quantization.py
@@ -91,8 +91,8 @@ class QuantizationTestCase(TestCase):
         """
         if hasattr(module, 'qconfig') and module.qconfig is not None and \
            len(module._modules) == 0 and not isinstance(module, torch.nn.Sequential):
-                self.assertTrue(hasattr(module, 'activation_post_process'),
-                                'module: ' + str(type(module)) + ' do not have observer')
+            self.assertTrue(hasattr(module, 'activation_post_process'),
+                            'module: ' + str(type(module)) + ' do not have observer')
         for child in module.children():
             self.checkObservers(child)
 

--- a/test/common_quantization.py
+++ b/test/common_quantization.py
@@ -89,9 +89,10 @@ class QuantizationTestCase(TestCase):
         r"""Checks the module or module's leaf descendants
             have observers in preperation for quantization
         """
-        if hasattr(module, 'qconfig') and module.qconfig is not None and len(module._modules) == 0:
-            self.assertTrue(hasattr(module, 'activation_post_process'),
-                            'module: ' + str(type(module)) + ' do not have observer')
+        if hasattr(module, 'qconfig') and module.qconfig is not None and \
+           len(module._modules) == 0 and not isinstance(module, torch.nn.Sequential):
+                self.assertTrue(hasattr(module, 'activation_post_process'),
+                                'module: ' + str(type(module)) + ' do not have observer')
         for child in module.children():
             self.checkObservers(child)
 
@@ -464,6 +465,7 @@ class ModelWithSequentialFusion(nn.Module):
         self.features = nn.Sequential(*layers)
         head = [nn.Linear(300, 10), nn.ReLU(inplace=False)]
         self.classifier = nn.Sequential(*head)
+        self.seq = nn.Sequential()
         self.quant = QuantStub()
         self.dequant = DeQuantStub()
 
@@ -474,6 +476,7 @@ class ModelWithSequentialFusion(nn.Module):
         x = self.features(x)
         x = torch.reshape(x, (-1, 3 * 10 * 10))
         x = self.classifier(x)
+        x = self.seq(x)
         x = self.dequant(x)
         return x
 

--- a/torch/quantization/quantize.py
+++ b/torch/quantization/quantize.py
@@ -96,9 +96,9 @@ def add_observer_(module):
     # the output of the module, for input QuantStub will observe them
     if hasattr(module, 'qconfig') and module.qconfig is not None and \
        len(module._modules) == 0 and not isinstance(module, torch.nn.Sequential):
-            # observer and hook will be gone after we swap the module
-            module.add_module('activation_post_process', module.qconfig.activation())
-            module.register_forward_hook(_observer_forward_hook)
+        # observer and hook will be gone after we swap the module
+        module.add_module('activation_post_process', module.qconfig.activation())
+        module.register_forward_hook(_observer_forward_hook)
 
 def add_quant_dequant(module):
     r"""Wrap the leaf child module in QuantWrapper if it has a valid qconfig

--- a/torch/quantization/quantize.py
+++ b/torch/quantization/quantize.py
@@ -95,10 +95,10 @@ def add_observer_(module):
     # Insert observers only for leaf nodes, note that this observer is for
     # the output of the module, for input QuantStub will observe them
     if hasattr(module, 'qconfig') and module.qconfig is not None and \
-       len(module._modules) == 0:
-        # observer and hook will be gone after we swap the module
-        module.add_module('activation_post_process', module.qconfig.activation())
-        module.register_forward_hook(_observer_forward_hook)
+       len(module._modules) == 0 and not isinstance(module, torch.nn.Sequential):
+            # observer and hook will be gone after we swap the module
+            module.add_module('activation_post_process', module.qconfig.activation())
+            module.register_forward_hook(_observer_forward_hook)
 
 def add_quant_dequant(module):
     r"""Wrap the leaf child module in QuantWrapper if it has a valid qconfig


### PR DESCRIPTION
Fixes #28375 

Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#28384 Do not insert observers for empty sequential modules**

Differential Revision: [D18047293](https://our.internmc.facebook.com/intern/diff/D18047293/)