### PR TITLE
Disable tsan for test_c10d multiprocess test cases.

### DIFF
--- a/test/test_c10d.py
+++ b/test/test_c10d.py
@@ -28,7 +28,7 @@ from torch.nn.parallel import DistributedDataParallel
 from common_distributed import MultiProcessTestCase, \
     requires_gloo, requires_nccl, requires_nccl_version, \
     skip_if_not_multigpu, skip_if_lt_x_gpu, skip_for_known_issues, get_timeout, skip_if_rocm
-from common_utils import TestCase, load_tests, run_tests, retry_on_address_already_in_use_error
+from common_utils import TestCase, load_tests, run_tests, retry_on_address_already_in_use_error, TEST_WITH_TSAN
 
 # load_tests from common_utils is used to automatically filter tests for
 # sharding on sandcastle. This line silences flake warnings
@@ -559,6 +559,7 @@ class TimeoutTest(TestCase):
 
 
 @requires_gloo()
+@unittest.skipIf(TEST_WITH_TSAN, "TSAN is not fork-safe since we're forking in a multi-threaded environment")
 class ProcessGroupGlooTest(MultiProcessTestCase):
     def setUp(self):
         super(ProcessGroupGlooTest, self).setUp()
@@ -1798,6 +1799,7 @@ class QuadraGpuNet(nn.Module):
         return F.softmax(x, dim=1).to(dev0)
 
 
+@unittest.skipIf(TEST_WITH_TSAN, "TSAN is not fork-safe since we're forking in a multi-threaded environment")
 class DistributedDataParallelTest(MultiProcessTestCase):
     def setUp(self):
         super(DistributedDataParallelTest, self).setUp()
@@ -2978,6 +2980,7 @@ class ComputeBucketAssignmentTest(TestCase):
         result = dist._compute_bucket_assignment_by_size(tensors, [200, 400])
         self.assertEqual([[0], [1], [2, 4], [3, 5]], result)
 
+@unittest.skipIf(TEST_WITH_TSAN, "TSAN is not fork-safe since we're forking in a multi-threaded environment")
 class NcclErrorHandlingTest(MultiProcessTestCase):
     def setUp(self):
         super(NcclErrorHandlingTest, self).setUp()
@@ -3130,6 +3133,7 @@ class NcclErrorHandlingTest(MultiProcessTestCase):
             time.sleep(2 * timeout)
 
 
+@unittest.skipIf(TEST_WITH_TSAN, "TSAN is not fork-safe since we're forking in a multi-threaded environment")
 class CommTest(MultiProcessTestCase):
     def setUp(self):
         super(CommTest, self).setUp()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#28385 Disable tsan for test_c10d multiprocess test cases.**

TSAN doesn't work with multiprocessing with fork() since we end up
forking in a multithreaded environment which is dangerous. As a result, I'm
disabling TSAN in this change.

Similar to https://github.com/pytorch/pytorch/pull/27410 and
https://github.com/pytorch/pytorch/pull/25005

Differential Revision: [D18047778](https://our.internmc.facebook.com/intern/diff/D18047778/)