### PR TITLE
Add support for negative index to ArrayRef `operator[]` and `at()`

### DIFF
--- a/aten/src/ATen/test/basic.cpp
+++ b/aten/src/ATen/test/basic.cpp
@@ -301,6 +301,14 @@ void TestIntArrayRefExpansion(DeprecatedTypeProperties& type) {
   avg_pool3d(randn({3, 3, 3, 3, 3}, type.options()), 2, 1, 1);
 }
 
+void TestArrayRefNegativeIndex() {
+  ASSERT_TRUE(at::ArrayRef<int64_t>({1, 2})[-1] == 2);
+  ASSERT_TRUE(at::ArrayRef<int64_t>({1, 2})[-2] == 1);
+
+  ASSERT_TRUE(at::ArrayRef<int64_t>({1, 2}).at(-1) == 2);
+  ASSERT_TRUE(at::ArrayRef<int64_t>({1, 2}).at(-2) == 1);
+}
+
 void test(DeprecatedTypeProperties& type) {
   TestResize(type);
   TestOnesAndDot(type);
@@ -330,6 +338,7 @@ void test(DeprecatedTypeProperties& type) {
   TestNegativeDim(type);
   TestView(type);
   TestIntArrayRefExpansion(type);
+  TestArrayRefNegativeIndex();
 }
 
 TEST(BasicTest, BasicTestCPU) {

--- a/c10/util/ArrayRef.h
+++ b/c10/util/ArrayRef.h
@@ -184,6 +184,9 @@ class ArrayRef final {
   /// @name Operator Overloads
   /// @{
   constexpr const T& operator[](size_t Index) const {
+    if (Index < 0) {
+      Index += Length;
+    }
     return Data[Index];
   }
 
@@ -195,6 +198,9 @@ class ArrayRef final {
         Index,
         "; Length = ",
         Length);
+    if (Index < 0) {
+      Index += Length;
+    }
     return Data[Index];
   }
 


### PR DESCRIPTION
This PR adds support for negative index to ArrayRef `operator[]` and `at()`, so that we can write the following logic:
```cpp
input = torch::cat({input, input.narrow(2, 0, padding[-1])}, /*dim=*/2);
```
instead of
```cpp
input = torch::cat({input, input.narrow(2, 0, padding[(-1 + padding.size())])}, /*dim=*/2);
```