### PR TITLE
[pytorch] remove AutoNonVariableTypeMode guard around forward() call

### DIFF
--- a/android/pytorch_android/src/main/cpp/pytorch_jni.cpp
+++ b/android/pytorch_android/src/main/cpp/pytorch_jni.cpp
@@ -615,7 +615,6 @@ class PytorchJni : public facebook::jni::HybridClass<PytorchJni> {
     }
     auto output = [&]() {
       torch::autograd::AutoGradMode guard(false);
-      at::AutoNonVariableTypeMode non_var_type_mode(true);
       return module_.forward(std::move(inputs));
     }();
     return JIValue::newJIValueFromAtIValue(output);
@@ -638,7 +637,6 @@ class PytorchJni : public facebook::jni::HybridClass<PytorchJni> {
     if (auto method = module_.find_method(methodName)) {
       auto output = [&]() {
         torch::autograd::AutoGradMode guard(false);
-        at::AutoNonVariableTypeMode non_var_type_mode(true);
         return (*method)(std::move(inputs));
       }();
       return JIValue::newJIValueFromAtIValue(output);

--- a/binaries/speed_benchmark_torch.cc
+++ b/binaries/speed_benchmark_torch.cc
@@ -89,7 +89,6 @@ int main(int argc, char** argv) {
   torch::autograd::AutoGradMode guard(false);
   auto module = torch::jit::load(FLAGS_model);
 
-  at::AutoNonVariableTypeMode non_var_type_mode(true);
   module.eval();
   if (FLAGS_print_output) {
     std::cout << module.forward(inputs) << std::endl;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #28402 [pytorch] remove AutoNonVariableTypeMode from jit-op-registry
* #28400 [pytorch] change detach() & detach_() to no-op for USE_STATIC_DISPATCH mode
* **#28399 [pytorch] remove AutoNonVariableTypeMode guard around forward() call**
* #28398 [pytorch] Make static dispatch turn off variable before entering the kernel

Summary:
This is also to address issue #26764

Turns out it's incorrect to wrap the entire forward() call with
NonVariableTypeMode guard as some JIT passes has is_variable() check and
can be triggered within forward() call, e.g.:
jit/passes/constant_propagation.cpp

Since now we are toggling NonVariableTypeMode per method/op call, we can
remove the guard around forward() now.

Test Plan:
- With stacked PRs, verified it can load and run previously failed models.

Differential Revision: [D18055850](https://our.internmc.facebook.com/intern/diff/D18055850)