### PR TITLE
[pytorch] change detach() & detach_() to no-op for USE_STATIC_DISPATCH mode

### DIFF
--- a/aten/src/ATen/native/TensorProperties.cpp
+++ b/aten/src/ATen/native/TensorProperties.cpp
@@ -55,14 +55,20 @@ bool cudnn_is_acceptable(const Tensor& self) {
 }
 
 Tensor detach(const Tensor& self) {
+#ifndef USE_STATIC_DISPATCH
   // this just exists to give us a hook in VariableType and an entry in Declarations.yaml
   AT_ERROR("detach is not implemented for Tensor");
+#endif
+  // this is no-op for USE_STATIC_DISPATCH mode
   return self;
 }
 
 Tensor & detach_(Tensor & self) {
+#ifndef USE_STATIC_DISPATCH
   // this just exists to give us a hook in VariableType and an entry in Declarations.yaml
   AT_ERROR("detach_ is not implemented for Tensor");
+#endif
+  // this is no-op for USE_STATIC_DISPATCH mode
   return self;
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #28402 [pytorch] remove AutoNonVariableTypeMode from jit-op-registry
* **#28400 [pytorch] change detach() & detach_() to no-op for USE_STATIC_DISPATCH mode**
* #28399 [pytorch] remove AutoNonVariableTypeMode guard around forward() call
* #28398 [pytorch] Make static dispatch turn off variable before entering the kernel

Summary:
This is yet-another fix to issue #26764.

Some mobile models call tensor.detach() which won't work with
static-dispatch mode. We disable autograd for static-dispatch / mobile
build anyway so it seems fine to make these op-ops.

Test Plan:
- With stacked PRs, confirmed it can run failed models now.

Differential Revision: [D18055852](https://our.internmc.facebook.com/intern/diff/D18055852)