### PR TITLE
[pytorch] remove AutoNonVariableTypeMode from jit-op-registry

### DIFF
--- a/tools/jit/gen_jit_dispatch.py
+++ b/tools/jit/gen_jit_dispatch.py
@@ -160,15 +160,9 @@ const auto options = TensorOptions()
 auto result_ = (${first}).${name}(${args_with_tensor_options});
 """)
 
-# Adding `AutoNonVariableTypeMode` guard for `USE_STATIC_DISPATCH` case is kinda
-# hack to address issue #26764. TODO: remove this hack after Variable/Tensor
-# unification (#23032) is done.
 CONSTRUCTOR = CodeTemplate("""\
 [](Stack & stack) {
     ${lvalues}
-#ifdef USE_STATIC_DISPATCH
-    at::AutoNonVariableTypeMode non_var_type_mode(true);
-#endif
     ${call}
     drop(stack, ${num_inputs});
     pack(stack, std::move(result_));


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#28402 [pytorch] remove AutoNonVariableTypeMode from jit-op-registry**
* #28400 [pytorch] change detach() & detach_() to no-op for USE_STATIC_DISPATCH mode
* #28399 [pytorch] remove AutoNonVariableTypeMode guard around forward() call
* #28398 [pytorch] Make static dispatch turn off variable before entering the kernel

Summary:
Revert PR #27274 as it's absorbed by PR #28398.

Test Plan:
- make sure all mobile models can load and run

Differential Revision: [D18055993](https://our.internmc.facebook.com/intern/diff/D18055993)