### PR TITLE
[iOS] add benchmark code to iOS TestApp

### DIFF
--- a/ios/TestApp/.clang-format
+++ b/ios/TestApp/.clang-format
@@ -1,0 +1,8 @@
+BasedOnStyle: Google
+
+AlignOperands: false
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+BreakBeforeTernaryOperators: false
+ColumnLimit: 100
+PointerBindsToType: false

--- a/ios/TestApp/TestApp.xcodeproj/project.pbxproj
+++ b/ios/TestApp/TestApp.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
     objects = {
 
 /* Begin PBXBuildFile section */
+        A03C2960235EA3C1000B4408 /* Benchmark.mm in Sources */ = {isa = PBXBuildFile; fileRef = A03C295F235EA3C1000B4408 /* Benchmark.mm */; };
         A06D4CB5232F0DB200763E16 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = A06D4CB4232F0DB200763E16 /* AppDelegate.m */; };
         A06D4CB8232F0DB200763E16 /* ViewController.mm in Sources */ = {isa = PBXBuildFile; fileRef = A06D4CB7232F0DB200763E16 /* ViewController.mm */; };
         A06D4CBB232F0DB200763E16 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A06D4CB9232F0DB200763E16 /* Main.storyboard */; };
@@ -16,6 +17,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+        A03C295E235EA3C0000B4408 /* Benchmark.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Benchmark.h; sourceTree = "<group>"; };
+        A03C295F235EA3C1000B4408 /* Benchmark.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = Benchmark.mm; sourceTree = "<group>"; };
         A06D4CB0232F0DB200763E16 /* TestApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TestApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
         A06D4CB3232F0DB200763E16 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
         A06D4CB4232F0DB200763E16 /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
@@ -58,6 +61,8 @@
         A06D4CB2232F0DB200763E16 /* TestApp */ = {
             isa = PBXGroup;
             children = (
+                A03C295E235EA3C0000B4408 /* Benchmark.h */,
+                A03C295F235EA3C1000B4408 /* Benchmark.mm */,
                 A06D4CB3232F0DB200763E16 /* AppDelegate.h */,
                 A06D4CB4232F0DB200763E16 /* AppDelegate.m */,
                 A06D4CB6232F0DB200763E16 /* ViewController.h */,
@@ -143,6 +148,7 @@
                 A06D4CB8232F0DB200763E16 /* ViewController.mm in Sources */,
                 A06D4CC3232F0DB200763E16 /* main.m in Sources */,
                 A06D4CB5232F0DB200763E16 /* AppDelegate.m in Sources */,
+                A03C2960235EA3C1000B4408 /* Benchmark.mm in Sources */,
             );
             runOnlyForDeploymentPostprocessing = 0;
         };
@@ -286,6 +292,7 @@
                 ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
                 CODE_SIGN_STYLE = Manual;
                 DEVELOPMENT_TEAM = "";
+                ENABLE_BITCODE = NO;
                 INFOPLIST_FILE = TestApp/Info.plist;
                 LD_RUNPATH_SEARCH_PATHS = (
                     "$(inherited)",
@@ -304,6 +311,7 @@
                 ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
                 CODE_SIGN_STYLE = Manual;
                 DEVELOPMENT_TEAM = "";
+                ENABLE_BITCODE = NO;
                 INFOPLIST_FILE = TestApp/Info.plist;
                 LD_RUNPATH_SEARCH_PATHS = (
                     "$(inherited)",

--- a/ios/TestApp/TestApp/AppDelegate.h
+++ b/ios/TestApp/TestApp/AppDelegate.h
@@ -2,7 +2,6 @@
 
 @interface AppDelegate : UIResponder <UIApplicationDelegate>
 
-@property (strong, nonatomic) UIWindow *window;
+@property(strong, nonatomic) UIWindow *window;
 
 @end
-

--- a/ios/TestApp/TestApp/Base.lproj/Main.storyboard
+++ b/ios/TestApp/TestApp/Base.lproj/Main.storyboard
@@ -1,24 +1,46 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15400" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="zHv-VB-ug3">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15404"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--View Controller-->
+        <!--speed_benchmark_torch-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="ViewController" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                     </view>
+                    <navigationItem key="navigationItem" title="speed_benchmark_torch" id="zRt-2x-Qpi"/>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
+            <point key="canvasLocation" x="1042.0289855072465" y="137.94642857142856"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="wLe-Z7-hAV">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="zHv-VB-ug3" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="D6Q-SK-hgS">
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="BYZ-38-t0r" kind="relationship" relationship="rootViewController" id="771-m0-klC"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="BNl-FK-fMY" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="131.8840579710145" y="137.94642857142856"/>
         </scene>
     </scenes>
 </document>

--- a/ios/TestApp/TestApp/Benchmark.h
+++ b/ios/TestApp/TestApp/Benchmark.h
@@ -1,0 +1,11 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface Benchmark : NSObject
+
++ (void)benchmarkWithModel:(NSString* )modelPath;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/TestApp/TestApp/Benchmark.mm
+++ b/ios/TestApp/TestApp/Benchmark.mm
@@ -1,0 +1,86 @@
+#import "Benchmark.h"
+#include <string>
+#include <vector>
+
+#include "ATen/ATen.h"
+#include "caffe2/core/timer.h"
+#include "caffe2/utils/string_utils.h"
+#include "torch/csrc/autograd/grad_mode.h"
+#include "torch/csrc/jit/import.h"
+#include "torch/script.h"
+
+C10_DEFINE_string(model, "", "The given torch script model to benchmark.");
+C10_DEFINE_string(input_dims, "1,3,224,224",
+                  "Alternate to input_files, if all inputs are simple "
+                  "float TensorCPUs, specify the dimension using comma "
+                  "separated numbers. If multiple input needed, use "
+                  "semicolon to separate the dimension of different "
+                  "tensors.");
+C10_DEFINE_string(input_type, "float", "Input type (uint8_t/float)");
+C10_DEFINE_bool(print_output, false, "Whether to print output with all one input tensor.");
+C10_DEFINE_int(warmup, 0, "The number of iterations to warm up.");
+C10_DEFINE_int(iter, 10, "The number of iterations to run.");
+
+@implementation Benchmark
+
++ (void)benchmarkWithModel:(NSString*)modelPath {
+  FLAGS_model = std::string(modelPath.UTF8String);
+  CAFFE_ENFORCE_GE(FLAGS_input_dims.size(), 0, "Input dims must be specified.");
+  CAFFE_ENFORCE_GE(FLAGS_input_type.size(), 0, "Input type must be specified.");
+
+  std::vector<std::string> input_dims_list = caffe2::split(';', FLAGS_input_dims);
+  std::vector<std::string> input_type_list = caffe2::split(';', FLAGS_input_type);
+  CAFFE_ENFORCE_EQ(input_dims_list.size(), input_type_list.size(),
+                   "Input dims and type should have the same number of items.");
+
+  std::vector<c10::IValue> inputs;
+  for (size_t i = 0; i < input_dims_list.size(); ++i) {
+    auto input_dims_str = caffe2::split(',', input_dims_list[i]);
+    std::vector<int64_t> input_dims;
+    for (const auto& s : input_dims_str) {
+      input_dims.push_back(c10::stoi(s));
+    }
+    if (input_type_list[i] == "float") {
+      inputs.push_back(torch::ones(input_dims, at::ScalarType::Float));
+    } else if (input_type_list[i] == "uint8_t") {
+      inputs.push_back(torch::ones(input_dims, at::ScalarType::Byte));
+    } else {
+      CAFFE_THROW("Unsupported input type: ", input_type_list[i]);
+    }
+  }
+
+  auto qengines = at::globalContext().supportedQEngines();
+  if (std::find(qengines.begin(), qengines.end(), at::QEngine::QNNPACK) != qengines.end()) {
+    at::globalContext().setQEngine(at::QEngine::QNNPACK);
+  }
+  torch::autograd::AutoGradMode guard(false);
+  auto module = torch::jit::load(FLAGS_model);
+
+  at::AutoNonVariableTypeMode non_var_type_mode(true);
+  module.eval();
+  if (FLAGS_print_output) {
+    std::cout << module.forward(inputs) << std::endl;
+  }
+
+  std::cout << "Starting benchmark." << std::endl;
+  std::cout << "Running warmup runs." << std::endl;
+  CAFFE_ENFORCE(FLAGS_warmup >= 0, "Number of warm up runs should be non negative, provided ",
+                FLAGS_warmup, ".");
+  for (int i = 0; i < FLAGS_warmup; ++i) {
+    module.forward(inputs);
+  }
+
+  std::cout << "Main runs." << std::endl;
+  CAFFE_ENFORCE(FLAGS_iter >= 0, "Number of main runs should be non negative, provided ",
+                FLAGS_iter, ".");
+  caffe2::Timer timer;
+  auto millis = timer.MilliSeconds();
+  for (int i = 0; i < FLAGS_iter; ++i) {
+    module.forward(inputs);
+  }
+  millis = timer.MilliSeconds();
+  std::cout << "Main run finished. Milliseconds per iter: " << millis / FLAGS_iter
+            << ". Iters per second: " << 1000.0 * FLAGS_iter / millis << std::endl;
+}
+
+@end

--- a/ios/TestApp/TestApp/ViewController.h
+++ b/ios/TestApp/TestApp/ViewController.h
@@ -3,4 +3,3 @@
 @interface ViewController : UIViewController
 
 @end
-

--- a/ios/TestApp/TestApp/ViewController.mm
+++ b/ios/TestApp/TestApp/ViewController.mm
@@ -1,5 +1,6 @@
 #import "ViewController.h"
 #import <torch/script.h>
+#import "Benchmark.h"
 
 @interface ViewController ()
 
@@ -8,9 +9,16 @@
 @implementation ViewController
 
 - (void)viewDidLoad {
-    [super viewDidLoad];
-    // Do any additional setup after loading the view.
-}
+  [super viewDidLoad];
 
+  dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+    NSString* modelPath = [[NSBundle mainBundle] pathForResource:@"model" ofType:@"pt"];
+    if ([[NSFileManager defaultManager] fileExistsAtPath:modelPath]) {
+      [Benchmark benchmarkWithModel:modelPath];
+    } else {
+      NSLog(@"model doesn't exist!");
+    }
+  });
+}
 
 @end

--- a/scripts/xcode_build.rb
+++ b/scripts/xcode_build.rb
@@ -40,7 +40,7 @@ other_linker_flags      = ['$(inherited)', "-all_load"]
 target.build_configurations.each do |config|
     config.build_settings['HEADER_SEARCH_PATHS']    = header_search_path
     config.build_settings['LIBRARY_SEARCH_PATHS']   = libraries_search_path
-    config.build_settings['OTHER_LINKER_FLAGS']     = other_linker_flags
+    config.build_settings['OTHER_LDFLAGS']          = other_linker_flags
     config.build_settings['ENABLE_BITCODE']         = 'No'
     dev_team_id = options[:team_id]
     if not dev_team_id
@@ -51,11 +51,13 @@ end
 
 # link static libraries
 target.frameworks_build_phases.clear
-libs = ['libc10.a', 'libclog.a', 'libeigen_blas.a', 'libcpuinfo.a', 'libpytorch_qnnpack.a', 'libtorch.a']
+libs = ['libc10.a', 'libclog.a', 'libnnpack.a', 'libeigen_blas.a', 'libcpuinfo.a', 'libpytorch_qnnpack.a', 'libtorch.a']
 for lib in libs do 
     path = "#{install_path}/lib/#{lib}"
-    libref = project.frameworks_group.new_file(path)
-    target.frameworks_build_phases.add_file_reference(libref)
+    if File.exist?(path)
+        libref = project.frameworks_group.new_file(path)
+        target.frameworks_build_phases.add_file_reference(libref)
+    end
 end
 project.save
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#28405 [iOS] add benchmark code to iOS TestApp**

### Summary

As discussed with @AshkanAliabadi  and @ljk53, the iOS TestApp will share the same benchmark code with Android's speed_benchmark_torch.cpp. This PR is the first part which contains the Objective-C++ code. 

The second PR will include the scripts to setup and run the benchmark project. The third PR will include scripts that can automate the whole "build - test - install" process.

There are many ways to run the benchmark project. The easiest way is to use cocoapods. Simply run `pod install`. However, that will pull the 1.3 binary which is not what we want, but we can still use this approach to test the benchmark code. The second PR will contain scripts to run custom builds that we can tweak.

### Test Plan
- Don't break any existing CI jobs  (except for those flaky ones)

Differential Revision: [D18064187](https://our.internmc.facebook.com/intern/diff/D18064187)