### PR TITLE
[android][circleci] Print aars content detailed size info

### DIFF
--- a/.circleci/scripts/build_android_gradle.sh
+++ b/.circleci/scripts/build_android_gradle.sh
@@ -56,4 +56,16 @@ else
     $GRADLE_PATH -p ~/workspace/android/ assembleRelease
 fi
 
+
+find . -type f -name "*.a" -exec ls -lh {} \;
+
+while IFS= read -r -d '' file
+do
+  echo
+  echo "$file"
+  ls -lah "$file"
+  zipinfo -l "$file"
+done < <(find . -type f -name '*.aar' -print0)
+
 find . -type f -name *aar -print | xargs tar cfvz ~/workspace/android/artifacts.tgz
+


### PR DESCRIPTION
Output:
```
Oct 22 20:22:04 + find . -type f -name '*.a'
Oct 22 20:22:04 + xargs ls -lah
Oct 22 20:22:05 -rw-r--r-- 1 jenkins jenkins  12M Oct 22 20:21 ./android/pytorch_android/build/intermediates/jniLibs/release/x86/libc10.a
Oct 22 20:22:05 -rw-r--r-- 1 jenkins jenkins 5.9K Oct 22 20:21 ./android/pytorch_android/build/intermediates/jniLibs/release/x86/libclog.a
Oct 22 20:22:05 -rw-r--r-- 1 jenkins jenkins 282K Oct 22 20:21 ./android/pytorch_android/build/intermediates/jniLibs/release/x86/libcpuinfo.a
Oct 22 20:22:05 -rw-r--r-- 1 jenkins jenkins  67M Oct 22 20:21 ./android/pytorch_android/build/intermediates/jniLibs/release/x86/libeigen_blas.a
Oct 22 20:22:05 -rw-r--r-- 1 jenkins jenkins 1.4M Oct 22 20:21 ./android/pytorch_android/build/intermediates/jniLibs/release/x86/libnnpack.a
Oct 22 20:22:05 -rw-r--r-- 1 jenkins jenkins 966K Oct 22 20:21 ./android/pytorch_android/build/intermediates/jniLibs/release/x86/libpytorch_qnnpack.a
Oct 22 20:22:05 -rw-r--r-- 1 jenkins jenkins 644M Oct 22 20:21 ./android/pytorch_android/build/intermediates/jniLibs/release/x86/libtorch.a
Oct 22 20:22:05 -rw-r--r-- 1 jenkins jenkins  12M Oct 22 19:45 ./build_android/install/lib/libc10.a
Oct 22 20:22:05 -rw-r--r-- 1 jenkins jenkins 5.9K Oct 22 19:44 ./build_android/install/lib/libclog.a
Oct 22 20:22:05 -rw-r--r-- 1 jenkins jenkins 282K Oct 22 19:44 ./build_android/install/lib/libcpuinfo.a
Oct 22 20:22:05 -rw-r--r-- 1 jenkins jenkins  67M Oct 22 19:45 ./build_android/install/lib/libeigen_blas.a
Oct 22 20:22:05 -rw-r--r-- 1 jenkins jenkins 1.4M Oct 22 19:45 ./build_android/install/lib/libnnpack.a
Oct 22 20:22:05 -rw-r--r-- 1 jenkins jenkins 966K Oct 22 19:45 ./build_android/install/lib/libpytorch_qnnpack.a
Oct 22 20:22:05 -rw-r--r-- 1 jenkins jenkins 644M Oct 22 20:06 ./build_android/install/lib/libtorch.a
Oct 22 20:22:05 -rw-r--r-- 1 jenkins jenkins  12M Oct 22 19:45 ./build_android/lib/libc10.a
Oct 22 20:22:05 -rw-r--r-- 1 jenkins jenkins 5.9K Oct 22 19:44 ./build_android/lib/libclog.a
Oct 22 20:22:05 -rw-r--r-- 1 jenkins jenkins 282K Oct 22 19:44 ./build_android/lib/libcpuinfo.a
Oct 22 20:22:05 -rw-r--r-- 1 jenkins jenkins 274K Oct 22 19:44 ./build_android/lib/libcpuinfo_internals.a
Oct 22 20:22:05 -rw-r--r-- 1 jenkins jenkins  67M Oct 22 19:45 ./build_android/lib/libeigen_blas.a
Oct 22 20:22:05 -rw-r--r-- 1 jenkins jenkins 1.4M Oct 22 19:45 ./build_android/lib/libnnpack.a
Oct 22 20:22:05 -rw-r--r-- 1 jenkins jenkins  69K Oct 22 19:45 ./build_android/lib/libnnpack_reference_layers.a
Oct 22 20:22:05 -rw-r--r-- 1 jenkins jenkins  51K Oct 22 19:44 ./build_android/lib/libpthreadpool.a
Oct 22 20:22:05 -rw-r--r-- 1 jenkins jenkins 966K Oct 22 19:45 ./build_android/lib/libpytorch_qnnpack.a
Oct 22 20:22:05 -rw-r--r-- 1 jenkins jenkins 644M Oct 22 20:06 ./build_android/lib/libtorch.a
Oct 22 20:22:05 ++ find . -type f -name '*.aar'
Oct 22 20:22:05 
Oct 22 20:22:05 ./android/pytorch_android_torchvision/build/outputs/aar/pytorch_android_torchvision-release.aar
Oct 22 20:22:05 + for f in '`find . -type f -name "*.aar"`'
Oct 22 20:22:05 + echo
Oct 22 20:22:05 + echo ./android/pytorch_android_torchvision/build/outputs/aar/pytorch_android_torchvision-release.aar
Oct 22 20:22:05 + ls -lah ./android/pytorch_android_torchvision/build/outputs/aar/pytorch_android_torchvision-release.aar
Oct 22 20:22:05 -rw-r--r-- 1 jenkins jenkins 20K Oct 22 20:22 ./android/pytorch_android_torchvision/build/outputs/aar/pytorch_android_torchvision-release.aar
Oct 22 20:22:05 + zipinfo -l ./android/pytorch_android_torchvision/build/outputs/aar/pytorch_android_torchvision-release.aar
Oct 22 20:22:05 Archive:  ./android/pytorch_android_torchvision/build/outputs/aar/pytorch_android_torchvision-release.aar
Oct 22 20:22:05 Zip file size: 20260 bytes, number of entries: 7
Oct 22 20:22:05 -rw-r--r--  2.0 unx      281 b-      177 defN 80-Feb-01 00:00 AndroidManifest.xml
Oct 22 20:22:05 -rw-r--r--  2.0 unx    81895 b-    14629 defN 80-Feb-01 00:00 R.txt
Oct 22 20:22:05 -rw-r--r--  2.0 unx     4816 b-     4632 defN 80-Feb-01 00:00 classes.jar
Oct 22 20:22:05 drwxr-xr-x  2.0 unx        0 b-        2 defN 80-Feb-01 00:00 res/
Oct 22 20:22:05 drwxr-xr-x  2.0 unx        0 b-        2 defN 80-Feb-01 00:00 res/values/
Oct 22 20:22:05 -rw-r--r--  2.0 unx      128 b-      106 defN 80-Feb-01 00:00 res/values/values.xml
Oct 22 20:22:05 drwxr-xr-x  2.0 unx        0 b-        2 defN 80-Feb-01 00:00 values/
Oct 22 20:22:05 7 files, 87120 bytes uncompressed, 19550 bytes compressed:  77.6%
Oct 22 20:22:05 
Oct 22 20:22:05 ./android/pytorch_android/build/outputs/aar/pytorch_android-release.aar
Oct 22 20:22:05 + for f in '`find . -type f -name "*.aar"`'
Oct 22 20:22:05 + echo
Oct 22 20:22:05 + echo ./android/pytorch_android/build/outputs/aar/pytorch_android-release.aar
Oct 22 20:22:05 + ls -lah ./android/pytorch_android/build/outputs/aar/pytorch_android-release.aar
Oct 22 20:22:05 -rw-r--r-- 1 jenkins jenkins 6.6M Oct 22 20:21 ./android/pytorch_android/build/outputs/aar/pytorch_android-release.aar
Oct 22 20:22:05 + zipinfo -l ./android/pytorch_android/build/outputs/aar/pytorch_android-release.aar
Oct 22 20:22:05 Archive:  ./android/pytorch_android/build/outputs/aar/pytorch_android-release.aar
Oct 22 20:22:05 Zip file size: 6827798 bytes, number of entries: 12
Oct 22 20:22:05 -rw-r--r--  2.0 unx      269 b-      171 defN 80-Feb-01 00:00 AndroidManifest.xml
Oct 22 20:22:05 -rw-r--r--  2.0 unx    81895 b-    14629 defN 80-Feb-01 00:00 R.txt
Oct 22 20:22:05 -rw-r--r--  2.0 unx    16007 b-    14295 defN 80-Feb-01 00:00 classes.jar
Oct 22 20:22:05 drwxr-xr-x  2.0 unx        0 b-        2 defN 80-Feb-01 00:00 res/
Oct 22 20:22:05 drwxr-xr-x  2.0 unx        0 b-        2 defN 80-Feb-01 00:00 res/values/
Oct 22 20:22:05 -rw-r--r--  2.0 unx      116 b-      100 defN 80-Feb-01 00:00 res/values/values.xml
Oct 22 20:22:05 drwxr-xr-x  2.0 unx        0 b-        2 defN 80-Feb-01 00:00 jni/
Oct 22 20:22:05 drwxr-xr-x  2.0 unx        0 b-        2 defN 80-Feb-01 00:00 jni/x86/
Oct 22 20:22:05 -rw-r--r--  2.0 unx  1017704 b-   326504 defN 80-Feb-01 00:00 jni/x86/libfbjni.so
Oct 22 20:22:05 -rw-r--r--  2.0 unx 22309852 b-  6470885 defN 80-Feb-01 00:00 jni/x86/libpytorch.so
Oct 22 20:22:05 drwxr-xr-x  2.0 unx        0 b-        2 defN 80-Feb-01 00:00 values/
Oct 22 20:22:05 drwxr-xr-x  2.0 unx        0 b-        2 defN 80-Feb-01 00:00 x86/
Oct 22 20:22:05 12 files, 23425843 bytes uncompressed, 6826596 bytes compressed:  70.9%
Oct 22 20:22:05 + for f in '`find . -type f -name "*.aar"`'
Oct 22 20:22:05 + echo
Oct 22 20:22:05 + echo ./android/libs/fbjni_local/build/outputs/aar/pytorch_android_fbjni-release.aar
Oct 22 20:22:05 + ls -lah ./android/libs/fbjni_local/build/outputs/aar/pytorch_android_fbjni-release.aar
Oct 22 20:22:05 
Oct 22 20:22:05 ./android/libs/fbjni_local/build/outputs/aar/pytorch_android_fbjni-release.aar
Oct 22 20:22:05 -rw-r--r-- 1 jenkins jenkins 1.2M Oct 22 20:21 ./android/libs/fbjni_local/build/outputs/aar/pytorch_android_fbjni-release.aar
Oct 22 20:22:05 + zipinfo -l ./android/libs/fbjni_local/build/outputs/aar/pytorch_android_fbjni-release.aar
Oct 22 20:22:05 Archive:  ./android/libs/fbjni_local/build/outputs/aar/pytorch_android_fbjni-release.aar
Oct 22 20:22:05 Zip file size: 1172812 bytes, number of entries: 16
Oct 22 20:22:05 -rw-r--r--  2.0 unx      246 b-      162 defN 80-Feb-01 00:00 AndroidManifest.xml
Oct 22 20:22:05 -rw-r--r--  2.0 unx        0 b-        2 defN 80-Feb-01 00:00 R.txt
Oct 22 20:22:05 -rw-r--r--  2.0 unx    12582 b-     9896 defN 80-Feb-01 00:00 classes.jar
Oct 22 20:22:05 drwxr-xr-x  2.0 unx        0 b-        2 defN 80-Feb-01 00:00 jni/
Oct 22 20:22:05 drwxr-xr-x  2.0 unx        0 b-        2 defN 80-Feb-01 00:00 jni/arm64-v8a/
Oct 22 20:22:05 -rw-r--r--  2.0 unx   997768 b-   288617 defN 80-Feb-01 00:00 jni/arm64-v8a/libfbjni.so
Oct 22 20:22:05 drwxr-xr-x  2.0 unx        0 b-        2 defN 80-Feb-01 00:00 jni/armeabi-v7a/
Oct 22 20:22:05 -rw-r--r--  2.0 unx   599848 b-   219234 defN 80-Feb-01 00:00 jni/armeabi-v7a/libfbjni.so
Oct 22 20:22:05 drwxr-xr-x  2.0 unx        0 b-        2 defN 80-Feb-01 00:00 jni/x86/
Oct 22 20:22:05 -rw-r--r--  2.0 unx  1017704 b-   326504 defN 80-Feb-01 00:00 jni/x86/libfbjni.so
Oct 22 20:22:05 drwxr-xr-x  2.0 unx        0 b-        2 defN 80-Feb-01 00:00 jni/x86_64/
Oct 22 20:22:05 -rw-r--r--  2.0 unx  1055384 b-   326713 defN 80-Feb-01 00:00 jni/x86_64/libfbjni.so
Oct 22 20:22:05 drwxr-xr-x  2.0 unx        0 b-        2 defN 80-Feb-01 00:00 x86_64/
Oct 22 20:22:05 drwxr-xr-x  2.0 unx        0 b-        2 defN 80-Feb-01 00:00 x86/
Oct 22 20:22:05 drwxr-xr-x  2.0 unx        0 b-        2 defN 80-Feb-01 00:00 arm64-v8a/
Oct 22 20:22:05 drwxr-xr-x  2.0 unx        0 b-        2 defN 80-Feb-01 00:00 armeabi-v7a/
Oct 22 20:22:05 16 files, 3683532 bytes uncompressed, 1171146 bytes compressed:  68.2%
Oct 22 20:22:05 + xargs tar cfvz /var/lib/jenkins/workspace/android/artifacts.tgz
Oct 22 20:22:05 + find . -type f -name '*aar' -print
Oct 22 20:22:05 ./android/pytorch_android_torchvision/build/outputs/aar/pytorch_android_torchvision-release.aar
Oct 22 20:22:05 ./android/pytorch_android/build/outputs/aar/pytorch_android-release.aar
Oct 22 20:22:05 ./android/libs/fbjni_local/build/outputs/aar/pytorch_android_fbjni-release.aar
```