### PR TITLE
Enabling intra-op parallelism for dynamic quantized Linear operator

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp
@@ -1,4 +1,5 @@
 #include <ATen/ATen.h>
+#include <ATen/Parallel.h>
 #include <ATen/core/op_registration/op_registration.h>
 #include <ATen/cpp_custom_type_hack.h>
 #include <ATen/native/quantized/cpu/fbgemm_utils.h>

--- a/aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp
@@ -14,9 +14,7 @@ template <bool ReluFused>
 class QLinearDynamicInt8 final : public torch::OperatorKernel {
  public:
 #ifdef USE_FBGEMM
-  at::Tensor operator()(
-      at::Tensor input,
-      at::Tensor packed_weight) {
+  at::Tensor operator()(at::Tensor input, at::Tensor packed_weight) {
     // fp32 * int8 -> fp32 (with quantization on activation, and dequantization
     // on the result).
 
@@ -75,38 +73,11 @@ class QLinearDynamicInt8 final : public torch::OperatorKernel {
 
     q_params.precision = precision;
 
-    // This operation does the following:
-    // 1) Quantizes the input matrix given the statistics we've calculated above
-    // 2) Creates a "row buffer" vector with offset values that must be added
-    //    to the integer matrix multiplication operation to ensure correctness.
-    //    This "row buffer" is also called the row offset, and it is needed when
-    //    we use affine quantization for weights.
-    // 3) Packs the resulting quantized matrix into vector-register and cache
-    //    friendly tiles.
-    //
-    //  Note this is not executed eagerly, but rather within the fbgemmPacked
-    //  call below.
-
-    fbgemm::PackAWithQuantRowOffset<uint8_t> packA(
-        /*trans=*/fbgemm::matrix_op_t::NoTranspose,
-        /*nRow=*/M,
-        /*nCol=*/K,
-        /*smat=*/input_ptr,
-        /*ld=*/K,
-        /*pmat=*/nullptr, // Currently, packA manages ownership of `pmat`.
-        /*scale=*/q_params.scale,
-        /*zero_pt=*/q_params.zero_point);
-    // TODO: Consider a way to pre-allocate and reuse
-    // pmat buffer.
-
     // ReQuantizeForFloat requires pointers to the zero point values,
     // since in the case of rowwise quantization these will be arrays rather
     // than scalars. But in this case, we're doing whole-tensor quantization so
     // we just pass a pointer to the scale values (and internally
     // ReQuantizeForFloat won't index past 0.
-
-    // This is the end of the pipeline, pass the resulting matrix through.
-    fbgemm::DoNothing<float, float> doNothingObj{};
 
     const float* bias_ptr = nullptr;
     at::Tensor bias_vec;
@@ -130,48 +101,47 @@ class QLinearDynamicInt8 final : public torch::OperatorKernel {
     auto output = at::empty(out_sizes, input.options().dtype(at::kFloat));
     auto buffer = at::empty_like(output, output.options().dtype(at::kInt));
 
-    if (pack_ptr.q_scheme == kPerTensorAffine) {
-      // Process the per tensor quantization.
+    int num_tasks = at::get_num_threads();
+    at::parallel_for(0, num_tasks, 1, [&](int64_t begin, int64_t end) {
+      // This operation does the following:
+      // 1) Quantizes the input matrix given the statistics we've calculated
+      // above 2) Creates a "row buffer" vector with offset values that must be
+      // added
+      //    to the integer matrix multiplication operation to ensure
+      //    correctness. This "row buffer" is also called the row offset, and it
+      //    is needed when we use affine quantization for weights.
+      // 3) Packs the resulting quantized matrix into vector-register and cache
+      //    friendly tiles.
       //
-      // After the uint8 * int8 matrix multiplication is performed, this
-      // operation does:
-      //  1) Add in row and column offsets to the rows and columns, respectively
-      //  2) Dequantize the results into floating point
-      //  3) Add in the bias term.
-      fbgemm::ReQuantizeForFloat<ReluFused> outputProcObj(
-          /*nextop=*/doNothingObj,
-          /*Aq_scale=*/q_params.scale,
-          /*Bq_scale=*/pack_ptr.w_scale.data(),
-          /*Aq_zero_point=*/q_params.zero_point,
-          /*Bq_zero_point=*/pack_ptr.w_zp.data(),
-          /*row_offsets=*/packA.getRowOffsetBuffer(),
-          /*col_offsets=*/col_offsets.data(),
-          /*bias=*/bias_ptr,
-          /*nCol=*/N);
+      //  Note this is not executed eagerly, but rather within the fbgemmPacked
+      //  call below.
 
-      // Do the GEMM
-      fbgemm::fbgemmPacked(
-          /*packA=*/packA,
-          /*packB=*/*packB,
-          /*C=*/output.data_ptr<float>(),
-          /*C_buffer=*/buffer.data_ptr<int32_t>(),
-          /*ldc=*/N,
-          /*outProcess=*/outputProcObj,
-          /*thread_id=*/0,
-          /*num_threads=*/1);
+      fbgemm::PackAWithQuantRowOffset<uint8_t> packA(
+          /*trans=*/fbgemm::matrix_op_t::NoTranspose,
+          /*nRow=*/M,
+          /*nCol=*/K,
+          /*smat=*/input_ptr,
+          /*ld=*/K,
+          /*pmat=*/nullptr, // Currently, packA manages ownership of `pmat`.
+          /*scale=*/q_params.scale,
+          /*zero_pt=*/q_params.zero_point);
+      // TODO: Consider a way to pre-allocate and reuse
+      // pmat buffer.
 
-    } else if (pack_ptr.q_scheme == kPerChannelAffine) {
-      // Process the per channel quantization.
-      //
-      // After the uint8 * int8 matrix multiplication is performed, this
-      // operation does:
-      //  1) Add in row and column offsets to the rows and columns, respectively
-      //  2) Dequantize the results into floating point
-      //  3) Add in the bias term.
-      fbgemm::ReQuantizeForFloat<
-          ReluFused,
-          fbgemm::QuantizationGranularity::OUT_CHANNEL>
-          outputProcObj(
+      // This is the end of the pipeline, pass the resulting matrix through.
+      fbgemm::DoNothing<float, float> doNothingObj{};
+
+      for (int task_id = begin; task_id < end; ++task_id) {
+        if (pack_ptr.q_scheme == kPerTensorAffine) {
+          // Process the per tensor quantization.
+          //
+          // After the uint8 * int8 matrix multiplication is performed, this
+          // operation does:
+          //  1) Add in row and column offsets to the rows and columns,
+          //  respectively.
+          //  2) Dequantize the results into floating point.
+          //  3) Add in the bias term.
+          fbgemm::ReQuantizeForFloat<ReluFused> outputProcObj(
               /*nextop=*/doNothingObj,
               /*Aq_scale=*/q_params.scale,
               /*Bq_scale=*/pack_ptr.w_scale.data(),
@@ -182,17 +152,53 @@ class QLinearDynamicInt8 final : public torch::OperatorKernel {
               /*bias=*/bias_ptr,
               /*nCol=*/N);
 
-      // Do the GEMM
-      fbgemm::fbgemmPacked(
-          /*packA=*/packA,
-          /*packB=*/*packB,
-          /*C=*/output.data_ptr<float>(),
-          /*C_buffer=*/buffer.data_ptr<int32_t>(),
-          /*ldc=*/N,
-          /*outProcess=*/outputProcObj,
-          /*thread_id=*/0,
-          /*num_threads=*/1);
-    }
+          // Do the GEMM
+          fbgemm::fbgemmPacked(
+              /*packA=*/packA,
+              /*packB=*/*packB,
+              /*C=*/output.data_ptr<float>(),
+              /*C_buffer=*/buffer.data_ptr<int32_t>(),
+              /*ldc=*/N,
+              /*outProcess=*/outputProcObj,
+              /*thread_id=*/task_id,
+              /*num_threads=*/num_tasks);
+
+        } else if (pack_ptr.q_scheme == kPerChannelAffine) {
+          // Process the per channel quantization.
+          //
+          // After the uint8 * int8 matrix multiplication is performed, this
+          // operation does:
+          //  1) Add in row and column offsets to the rows and columns,
+          //  respectively.
+          //  2) Dequantize the results into floating point.
+          //  3) Add in the bias term.
+          fbgemm::ReQuantizeForFloat<
+              ReluFused,
+              fbgemm::QuantizationGranularity::OUT_CHANNEL>
+              outputProcObj(
+                  /*nextop=*/doNothingObj,
+                  /*Aq_scale=*/q_params.scale,
+                  /*Bq_scale=*/pack_ptr.w_scale.data(),
+                  /*Aq_zero_point=*/q_params.zero_point,
+                  /*Bq_zero_point=*/pack_ptr.w_zp.data(),
+                  /*row_offsets=*/packA.getRowOffsetBuffer(),
+                  /*col_offsets=*/col_offsets.data(),
+                  /*bias=*/bias_ptr,
+                  /*nCol=*/N);
+
+          // Do the GEMM
+          fbgemm::fbgemmPacked(
+              /*packA=*/packA,
+              /*packB=*/*packB,
+              /*C=*/output.data_ptr<float>(),
+              /*C_buffer=*/buffer.data_ptr<int32_t>(),
+              /*ldc=*/N,
+              /*outProcess=*/outputProcObj,
+              /*thread_id=*/task_id,
+              /*num_threads=*/num_tasks);
+        }
+      }
+    });
 
     return output;
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#28477 Enabling intra-op parallelism for dynamic quantized Linear operator**

Similar to https://github.com/pytorch/pytorch/pull/26692, we would like to enable the intra-op parallelism for dynamic Linear op.


Test Benchmark:
```
import time
import torch

K, N = 1024, 1024

print('M', 'nthread=1', 'nthread=2', 'nthread=4', 'nthread=8', 'nthread=16', sep=', ')

for M in range(512, 2049, 512):
    print(M, sep=',', end=', ')
    for num_threads in (1, 2, 4, 8, 16,):

        torch.set_num_threads(num_threads)

        x = torch.rand(M, K)
        w = torch.rand(K, N)

        NITER = 20

        # Test dynamic quantized
        q_w = torch.quantize_per_tensor(w, 0.01, 0, dtype=torch.qint8)
        packed_w = torch.ops.quantized.linear_prepack(q_w, None)

        s = time.time()
        for i in range(NITER):
            torch.ops.quantized.linear_dynamic(x, packed_w)
        elapsed_per_iter_dyn_quant = (time.time() - s) / NITER

        print("{:0.2f}".format(2.0*M*N*K/elapsed_per_iter_dyn_quant/1E9), end=', ')
    print("\n", end='')
```
Before this Diff:
```
(base) [root@[test machine] ~/jhuang_test/dynamic_quant]# python benchmark_quantize_dynamic.py
M, nthread=1, nthread=2, nthread=4, nthread=8, nthread=16
512, 119.28, 139.50, 141.66, 141.58, 141.42,
1024, 122.42, 141.21, 123.09, 141.85, 123.03,
1536, 122.80, 122.18, 141.39, 123.25, 141.35,
2048, 123.41, 141.34, 123.62, 140.55, 123.76,
```

After this Diff:
```
(base) [root@[test machine] ~/jhuang_test/dynamic_quant]# python benchmark_quantize_dynamic.py
M, nthread=1, nthread=2, nthread=4, nthread=8, nthread=16
512, 123.29, 271.99, 508.66, 882.83, 1295.07,
1024, 126.05, 273.15, 515.42, 914.11, 877.63,
1536, 142.48, 236.85, 524.10, 481.32, 970.81,
2048, 124.76, 279.03, 433.73, 958.67, 1045.82,
```

Differential Revision: [D18074757](https://our.internmc.facebook.com/intern/diff/D18074757/)