### PR TITLE
remove extraneous type information from torch.matrix_rank documentation

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -2938,7 +2938,7 @@ Example::
 
 add_docstr(torch.matrix_rank,
            r"""
-matrix_rank(input, tol=None, bool symmetric=False) -> Tensor
+matrix_rank(input, tol=None, symmetric=False) -> Tensor
 
 Returns the numerical rank of a 2-D tensor. The method to compute the
 matrix rank is done using SVD by default. If :attr:`symmetric` is ``True``,


### PR DESCRIPTION
The types don't appear in the docstrings for other functions in the `torch` namespace so I think this was included here because of a copy/paste error.