### PR TITLE
Refactor qconv_prepack and qconv_unpack to support conv3d (#146)

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/fbgemm_utils.cpp
+++ b/aten/src/ATen/native/quantized/cpu/fbgemm_utils.cpp
@@ -1,0 +1,199 @@
+#ifdef USE_FBGEMM
+
+#include <ATen/native/quantized/cpu/fbgemm_utils.h>
+
+#include <ATen/ATen.h>
+#include <ATen/native/TensorFactories.h>
+#include <ATen/quantized/QTensorImpl.h>
+#include <ATen/quantized/Quantizer.h>
+
+#include <c10/core/QScheme.h>
+#include <c10/core/TensorOptions.h>
+
+namespace at {
+namespace native {
+namespace fbgemm_utils {
+
+namespace {
+
+bool IsChannelsLast3d(const Tensor& tensor) {
+  if (tensor.dim() != 5) {
+    return false;
+  }
+  const int64_t C = tensor.size(1);
+  const int64_t D = tensor.size(2);
+  const int64_t H = tensor.size(3);
+  const int64_t W = tensor.size(4);
+  return tensor.stride(0) == D * H * W * C && tensor.stride(1) == 1 &&
+      tensor.stride(2) == H * W * C && tensor.stride(3) == W * C &&
+      tensor.stride(4) == C;
+}
+
+template <typename T>
+void CopyToChannelsLast3dTensor(
+    int64_t N,
+    int64_t C,
+    int64_t D,
+    int64_t H,
+    int64_t W,
+    const T* src,
+    T* dst) {
+  const int64_t inner_size = D * H * W;
+  for (int64_t i = 0; i < N; ++i) {
+    for (int64_t j = 0; j < inner_size; ++j) {
+      for (int64_t k = 0; k < C; ++k) {
+        dst[(i * inner_size + j) * C + k] = src[(i * C + k) * inner_size + j];
+      }
+    }
+  }
+}
+
+} // namespace
+
+template <>
+fbgemm::conv_param_t<2> MakeFbgemmConvParam<2>(
+    int N,
+    int C,
+    int M,
+    const std::vector<int>& image_shape,
+    int groups,
+    const std::vector<int>& kernels,
+    const std::vector<int>& strides,
+    const std::vector<int>& pads,
+    const std::vector<int>& dilations) {
+  return fbgemm::conv_param_t<2>(
+      N, // batch size
+      C, // input channels
+      M, // output channels
+      {image_shape[0], image_shape[1]}, // feature map size
+      groups, // groups
+      {kernels[0], kernels[1]}, // kernels
+      {strides[0], strides[1]}, // strides
+      {pads[0], pads[1], pads[0], pads[1]}, // paddings
+      {dilations[0], dilations[1]}); // dilations
+}
+
+template <>
+fbgemm::conv_param_t<3> MakeFbgemmConvParam<3>(
+    int N,
+    int C,
+    int M,
+    const std::vector<int>& image_shape,
+    int groups,
+    const std::vector<int>& kernels,
+    const std::vector<int>& strides,
+    const std::vector<int>& pads,
+    const std::vector<int>& dilations) {
+  return fbgemm::conv_param_t<3>(
+      N, // batch size
+      C, // input channels
+      M, // output channels
+      {image_shape[0], image_shape[1], image_shape[2]}, // feature map size
+      groups, // groups
+      {kernels[0], kernels[1], kernels[2]}, // kernels
+      {strides[0], strides[1], strides[2]}, // strides
+      {pads[0], pads[1], pads[2], pads[0], pads[1], pads[2]}, // paddings
+      {dilations[0], dilations[1], dilations[2]}); // dilations
+}
+
+Tensor MakeStridedQTensorCPU(
+    const IntArrayRef& sizes,
+    const IntArrayRef& strides,
+    const TensorOptions& options,
+    QuantizerPtr quantizer) {
+  AT_ASSERT(options.device().is_cpu());
+  at::native::check_size_nonnegative(sizes);
+  auto* allocator = at::getCPUAllocator();
+  const int64_t nelements = at::prod_intlist(sizes);
+  auto dtype = options.dtype();
+  TORCH_CHECK(
+      isQIntType(typeMetaToScalarType(dtype)),
+      "ScalarType is not supported in new_qtensor_cpu.");
+  auto storage = c10::make_intrusive<StorageImpl>(
+      dtype,
+      nelements,
+      allocator->allocate(nelements * dtype.itemsize()),
+      allocator,
+      /* resizable = */ true);
+  auto tensor = detail::make_tensor<QTensorImpl>(
+      storage,
+      at::TensorTypeSet(at::TensorTypeId::QuantizedCPUTensorId),
+      quantizer);
+  get_qtensorimpl(tensor)->set_sizes_and_strides(sizes, strides);
+  return tensor;
+}
+
+Tensor MakeEmptyAffineQuantizedChannelsLast3dTensor(
+    int64_t N,
+    int64_t C,
+    int64_t D,
+    int64_t H,
+    int64_t W,
+    const TensorOptions& options,
+    double scale,
+    int64_t zero_point) {
+  return MakeStridedQTensorCPU(
+      {N, C, D, H, W},
+      {D * H * W * C, 1, H * W * C, W * C, C},
+      options,
+      make_per_tensor_affine_quantizer(
+          scale, zero_point, typeMetaToScalarType(options.dtype())));
+}
+
+Tensor MakeEmptyPerChannelAffineQuantizedChannelsLast3dTensor(
+    int64_t N,
+    int64_t C,
+    int64_t D,
+    int64_t H,
+    int64_t W,
+    const TensorOptions& options,
+    const Tensor& scales,
+    const Tensor& zero_points) {
+  return MakeStridedQTensorCPU(
+      {N, C, D, H, W},
+      {D * H * W * C, 1, H * W * C, W * C, C},
+      options,
+      make_per_channel_affine_quantizer(
+          scales,
+          zero_points,
+          0, // axis
+          typeMetaToScalarType(options.dtype())));
+}
+
+Tensor ConvertToChannelsLast3dTensor(const Tensor& src) {
+  TORCH_CHECK(src.dim() == 5);
+  Tensor dst;
+  if (IsChannelsLast3d(src)) {
+    dst = src;
+  } else {
+    const int64_t N = src.size(0);
+    const int64_t C = src.size(1);
+    const int64_t D = src.size(2);
+    const int64_t H = src.size(3);
+    const int64_t W = src.size(4);
+    dst = MakeStridedQTensorCPU(
+        {N, C, D, H, W},
+        {D * H * W * C, 1, H * W * C, W * C, C},
+        src.options(),
+        src.quantizer());
+    AT_DISPATCH_QINT_TYPES(
+        src.scalar_type(), "ConvertToChannelsLast3dTensor", [&]() {
+          const Tensor src_contig = src.contiguous();
+          CopyToChannelsLast3dTensor<scalar_t>(
+              N,
+              C,
+              D,
+              H,
+              W,
+              src_contig.data_ptr<scalar_t>(),
+              dst.data_ptr<scalar_t>());
+        });
+  }
+  return dst;
+}
+
+} // namespace fbgemm_utils
+} // namespace native
+} // namespace at
+
+#endif // USE_FBGEMM

--- a/aten/src/ATen/native/quantized/cpu/qconv.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv.cpp
@@ -121,8 +121,8 @@ class QConv2dInt8 final : public c10::OperatorKernel {
     const uint8_t* act_ptr =
         reinterpret_cast<uint8_t*>(act_contig.data_ptr<c10::quint8>());
 
-    PackedConvWeight& pack_ptr =
-        cpp_custom_type_hack::cast<PackedConvWeight>(packed_weight);
+    PackedConvWeight<2>& pack_ptr =
+        cpp_custom_type_hack::cast<PackedConvWeight<2>>(packed_weight);
     auto packB = pack_ptr.w.get();
     auto& col_offsets = pack_ptr.col_offsets;
     auto& kernel = pack_ptr.kernel;

--- a/aten/src/ATen/native/quantized/cpu/qconv_prepack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv_prepack.cpp
@@ -1,3 +1,6 @@
+#include <array>
+#include <vector>
+
 #include <ATen/ATen.h>
 #include <ATen/core/op_registration/op_registration.h>
 #include <ATen/cpp_custom_type_hack.h>
@@ -7,21 +10,60 @@
 #include <ATen/quantized/Quantizer.h>
 
 namespace caffe2 {
+
 #ifdef USE_FBGEMM
 // Required for cpp_custom_type_hack to work
-CAFFE_KNOWN_TYPE(PackedConvWeight);
+CAFFE_KNOWN_TYPE(PackedConvWeight<2>);
+CAFFE_KNOWN_TYPE(PackedConvWeight<3>);
 #endif
+
 #ifdef USE_PYTORCH_QNNPACK
 // Required for cpp_custom_type_hack to work
 CAFFE_KNOWN_TYPE(PackedConvWeightsQnnp);
 #endif // USE_PYTORCH_QNNPACK
+
 } // namespace caffe2
 
 namespace at {
 namespace native {
 namespace {
+
+template <int kSpatialDim = 2>
 class QConvPackWeightInt8 final : public c10::OperatorKernel {
  public:
+  Tensor operator()(
+      Tensor weight,
+      c10::optional<Tensor> bias,
+      torch::List<int64_t> stride,
+      torch::List<int64_t> padding,
+      torch::List<int64_t> dilation,
+      int64_t groups) {
+    auto& ctx = at::globalContext();
+#ifdef USE_FBGEMM
+    if (ctx.qEngine() == at::QEngine::FBGEMM) {
+      return fbgemm_conv_prepack(
+          weight, bias, stride, padding, dilation, groups);
+    }
+#endif
+
+#ifdef USE_PYTORCH_QNNPACK
+    if (ctx.qEngine() == at::QEngine::QNNPACK) {
+      TORCH_CHECK(
+          kSpatialDim == 2,
+          "quantized::conv_prepack (qnnpack): QNNPACK only supports Conv2d "
+          "now.");
+      return qnnpack_conv_prepack(
+          weight, bias, stride, padding, dilation, groups);
+    }
+#endif
+
+    TORCH_CHECK(
+        false,
+        "Didn't find engine for operation quantized::conv_prepack ",
+        toString(ctx.qEngine()));
+  }
+
+ private:
 #ifdef USE_FBGEMM
   Tensor fbgemm_conv_prepack(
       Tensor weight,
@@ -31,49 +73,63 @@ class QConvPackWeightInt8 final : public c10::OperatorKernel {
       torch::List<int64_t> dilation,
       int64_t groups) {
     TORCH_CHECK(
-        weight.ndimension() == 4, "Weights are expected to have 4 dimensions");
+        weight.ndimension() == kSpatialDim + 2,
+        "Weights are expected to have ",
+        kSpatialDim + 2,
+        " dimensions");
 
-    TORCH_CHECK(stride.size() == 2, "2D convolution only");
     TORCH_CHECK(
-        padding.size() == 2,
-        "Specify top/left padding only. \
-      bottom/right padding assumed to be equal to top/left");
-    TORCH_CHECK(dilation.size() == 2, "2D convolution only");
-    int output_channels = weight.size(0);
-    int input_channels_per_group = weight.size(1);
-    int kernel_h = weight.size(2);
-    int kernel_w = weight.size(3);
+        stride.size() == kSpatialDim,
+        "stride should contain ",
+        kSpatialDim,
+        " elements for ",
+        kSpatialDim,
+        "D convolution.");
+    TORCH_CHECK(
+        padding.size() == kSpatialDim,
+        "Specify front/top/left padding only. "
+        "end/bottom/right padding assumed to be equal to front/top/left");
+    TORCH_CHECK(
+        dilation.size() == kSpatialDim,
+        "dilation should contain ",
+        kSpatialDim,
+        " elements for ",
+        kSpatialDim,
+        "D convolution.");
+    const int output_channels = weight.size(0);
+    const int input_channels_per_group = weight.size(1);
+    const int kernel_d = kSpatialDim == 2 ? 1 : weight.size(2);
+    const int kernel_h = weight.size(kSpatialDim);
+    const int kernel_w = weight.size(kSpatialDim + 1);
 
     // mini-batch doesn't have any impact on how we pack weights
     // so we pass it as 1
     // Input image height/width also don't have any impact on how we pack
     // weights so we can pass any values
-    fbgemm::conv_param_t<2> conv_p(
-        1, // Mini-Batch
-        input_channels_per_group * groups, // input channels
-        output_channels,
-        {28, 28}, // Image height and width
-        groups,
-        {kernel_h, kernel_w},
-        {static_cast<int>(stride[0]), static_cast<int>(stride[1])},
-        {static_cast<int>(padding[0]),
-         static_cast<int>(padding[1]),
-         static_cast<int>(padding[0]),
-         static_cast<int>(padding[1])},
-        {static_cast<int>(dilation[0]), static_cast<int>(dilation[1])});
+    const fbgemm::conv_param_t<kSpatialDim> conv_p =
+        fbgemm_utils::MakeFbgemmConvParam<kSpatialDim>(
+            1, // dummy batch size
+            input_channels_per_group * groups, // input channels
+            output_channels,
+            kSpatialDim == 2 ? std::vector<int>{28, 28} // dummy image size
+                             : std::vector<int>{28, 28, 28},
+            groups,
+            kSpatialDim == 2 ? std::vector<int>{kernel_h, kernel_w}
+                             : std::vector<int>{kernel_d, kernel_h, kernel_w},
+            std::vector<int>(stride.begin(), stride.end()),
+            std::vector<int>(padding.begin(), padding.end()),
+            std::vector<int>(dilation.begin(), dilation.end()));
 
-    // FBGEMM expects weights to be in channels last
-    auto weight_contig = weight.contiguous(MemoryFormat::ChannelsLast);
     const auto qtype = weight.qscheme();
-    std::vector<int32_t> zero_points(1, 0);
+    std::vector<int32_t> zero_points;
     if (qtype == kPerTensorAffine) {
-      zero_points[0] = weight.q_zero_point();
+      zero_points = {static_cast<int32_t>(weight.q_zero_point())};
     } else if (qtype == kPerChannelAffine) {
       int64_t axis = weight.q_per_channel_axis();
       TORCH_CHECK(
           axis == 0,
           "Only per output channel quantization is supported for the weights");
-      zero_points.resize(output_channels, 0);
+      zero_points.resize(output_channels);
       for (int i = 0; i < output_channels; ++i) {
         zero_points[i] = weight.q_per_channel_zero_points()[i].item<int32_t>();
       }
@@ -81,40 +137,46 @@ class QConvPackWeightInt8 final : public c10::OperatorKernel {
       TORCH_CHECK(false, "Unsupported qscheme: ", toString(qtype));
     }
 
-    const int8_t* weight_ptr_int8 =
-        reinterpret_cast<int8_t*>(weight_contig.data_ptr<c10::qint8>());
-
+    // FBGEMM expects weights to be in channels last
+    // TODO: Change this when ChannelsLast3d is ready.
+    const Tensor weight_nhwc = kSpatialDim == 2
+        ? weight.contiguous(MemoryFormat::ChannelsLast)
+        : fbgemm_utils::ConvertToChannelsLast3dTensor(weight);
+    const int8_t* weight_data_int8 =
+        reinterpret_cast<int8_t*>(weight_nhwc.data_ptr<c10::qint8>());
     std::vector<int32_t> col_offsets(output_channels);
     // compute column offsets (Similar to
     // fbgemm::col_offsets_with_zero_pt_s8acc32_ref) please note that offsets
     // include the sum of columns as well as the scalar term weight_zero_point *
     // KDim
-    int NDim = output_channels / groups;
-    int KDim_per_group = kernel_h * kernel_w * input_channels_per_group;
+    const int output_channels_per_group = output_channels / groups;
+    const int inner_size =
+        kernel_d * kernel_h * kernel_w * input_channels_per_group;
     for (int g = 0; g < groups; ++g) {
-      for (int j = 0; j < NDim; ++j) {
+      for (int i = 0; i < output_channels_per_group; ++i) {
+        const int c = g * output_channels_per_group + i;
         int32_t sum = 0;
-        for (int k = 0; k < KDim_per_group; ++k) {
-          sum += weight_ptr_int8[(g * NDim + j) * KDim_per_group + k];
+        for (int j = 0; j < inner_size; ++j) {
+          sum += static_cast<int32_t>(weight_data_int8[c * inner_size + j]);
         }
         if (qtype == kPerTensorAffine) {
-          col_offsets[g * NDim + j] = sum - zero_points[0] * KDim_per_group;
+          col_offsets[c] = sum - zero_points[0] * inner_size;
         } else {
-          col_offsets[g * NDim + j] =
-              sum - zero_points[g * NDim + j] * KDim_per_group;
+          col_offsets[c] = sum - zero_points[c] * inner_size;
         }
       }
     }
 
-    std::vector<float> scales(1, 0.0);
+    std::vector<float> scales;
     if (qtype == kPerTensorAffine) {
-      scales[0] = weight.q_scale();
+      scales = {static_cast<float>(weight.q_scale())};
     } else if (qtype == kPerChannelAffine) {
-      scales.resize(output_channels, 0.0);
+      scales.resize(output_channels);
       for (int i = 0; i < output_channels; ++i) {
         scales[i] = weight.q_per_channel_scales()[i].item<float>();
       }
     }
+
     c10::optional<at::Tensor> bias_contig;
     if (bias.has_value()) {
       Tensor bias_vec = bias.value();
@@ -124,20 +186,26 @@ class QConvPackWeightInt8 final : public c10::OperatorKernel {
           "bias should have K elements: " + std::to_string(output_channels));
       bias_contig = bias->contiguous();
     }
-    auto ret_ptr = guts::make_unique<PackedConvWeight>(
-        PackedConvWeight{guts::make_unique<fbgemm::PackWeightsForConv<2>>(
-                             conv_p, weight_ptr_int8),
-                         bias_contig,
-                         col_offsets,
-                         {kernel_h, kernel_w},
-                         scales,
-                         zero_points,
-                         qtype});
+
+    auto ret_ptr = guts::make_unique<PackedConvWeight<kSpatialDim>>(
+        PackedConvWeight<kSpatialDim>{
+            guts::make_unique<fbgemm::PackWeightsForConv<kSpatialDim>>(
+                conv_p, weight_data_int8),
+            bias_contig,
+            col_offsets,
+            kSpatialDim == 2
+                ? std::vector<int64_t>{kernel_h, kernel_w}
+                : std::vector<int64_t>{kernel_d, kernel_h, kernel_w},
+            scales,
+            zero_points,
+            qtype});
+
     // TODO: we will need to replace this with torchscript classes at a later
     // point.
     return cpp_custom_type_hack::create(std::move(ret_ptr), weight.options());
   }
 #endif // USE_FBGEMM
+
 #ifdef USE_PYTORCH_QNNPACK
   at::Tensor qnnpack_conv_prepack(
       Tensor weight,
@@ -148,18 +216,20 @@ class QConvPackWeightInt8 final : public c10::OperatorKernel {
       int64_t groups) {
     TORCH_CHECK(
         weight.ndimension() == 4,
-        "quantized::conv_prepack (qnnpack): Weights are expected to have 4 dimensions");
+        "quantized::conv_prepack (qnnpack): Weights are expected to have 4 "
+        "dimensions");
     const auto qtype = weight.qscheme();
     TORCH_CHECK(
         weight.qscheme() == kPerTensorAffine,
-        "quantized::conv_prepack (qnnpack): only supports Per Tensor Quantization Scheme")
+        "quantized::conv_prepack (qnnpack): only supports Per Tensor "
+        "Quantization Scheme")
     TORCH_CHECK(
         stride.size() == 2,
         "quantized::conv_prepack (qnnpack): 2D convolution only");
     TORCH_CHECK(
         padding.size() == 2,
-        "quantized::conv_prepack (qnnpack): Specify top/left padding only. \
-       bottom/right padding assumed to be equal to top/left");
+        "quantized::conv_prepack (qnnpack): Specify top/left padding only. "
+        "bottom/right padding assumed to be equal to top/left");
     TORCH_CHECK(
         dilation.size() == 2,
         " quantized::conv_prepack (qnnpack): 2D convolution only");
@@ -180,8 +250,10 @@ class QConvPackWeightInt8 final : public c10::OperatorKernel {
       bias_fp32 = at::zeros(out_ch, weight.options().dtype(at::kFloat));
     }
     TORCH_CHECK(
-        !bias_fp32.defined() || (bias_fp32.ndimension() == 1 && bias_fp32.size(0) == out_ch),
-        "quantized::conv_prepack (qnnpack): expected bias to be 1-dimensional with ",
+        !bias_fp32.defined() ||
+            (bias_fp32.ndimension() == 1 && bias_fp32.size(0) == out_ch),
+        "quantized::conv_prepack (qnnpack): expected bias to be 1-dimensional "
+        "with ",
         out_ch,
         " elements",
         ", but got bias of size ",
@@ -238,37 +310,16 @@ class QConvPackWeightInt8 final : public c10::OperatorKernel {
     return cpp_custom_type_hack::create(std::move(wt_ptr), weight.options());
   }
 #endif // USE_PYTORCH_QNNPACK
-  Tensor operator()(
-      Tensor weight,
-      c10::optional<Tensor> bias,
-      torch::List<int64_t> stride,
-      torch::List<int64_t> padding,
-      torch::List<int64_t> dilation,
-      int64_t groups) {
-    auto& ctx = at::globalContext();
-#ifdef USE_FBGEMM
-    if (ctx.qEngine() == at::QEngine::FBGEMM) {
-      return fbgemm_conv_prepack(
-          weight, bias, stride, padding, dilation, groups);
-    }
-#endif
-#ifdef USE_PYTORCH_QNNPACK
-    if (ctx.qEngine() == at::QEngine::QNNPACK) {
-      return qnnpack_conv_prepack(
-          weight, bias, stride, padding, dilation, groups);
-    }
-#endif
-    TORCH_CHECK(
-        false,
-        "Didn't find engine for operation quantized::conv_prepack ",
-        toString(ctx.qEngine()));
-  }
 };
 
-static auto registry = c10::RegisterOperators().op(
-    "quantized::conv_prepack",
-    c10::RegisterOperators::options().kernel<QConvPackWeightInt8>(
-        TensorTypeId::QuantizedCPUTensorId));
+static auto registry =
+    c10::RegisterOperators()
+        .op("quantized::conv_prepack",
+            c10::RegisterOperators::options().kernel<QConvPackWeightInt8<2>>(
+                TensorTypeId::QuantizedCPUTensorId))
+        .op("quantized::conv3d_prepack",
+            c10::RegisterOperators::options().kernel<QConvPackWeightInt8<3>>(
+                TensorTypeId::QuantizedCPUTensorId));
 
 } // namespace
 } // namespace native

--- a/aten/src/ATen/native/quantized/cpu/qconv_unpack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv_unpack.cpp
@@ -1,3 +1,6 @@
+#include <tuple>
+#include <vector>
+
 #include <ATen/ATen.h>
 #include <ATen/core/op_registration/op_registration.h>
 #include <ATen/cpp_custom_type_hack.h>
@@ -14,74 +17,10 @@ namespace {
  * Therefore, the unpacking of packed weight tensor using QConvUnpackWeightsInt8
  * results in a tensor of the same shape.
  */
+
+template <int kSpatialDim = 2>
 class QConvUnpackWeightsInt8 final : public c10::OperatorKernel {
  public:
-#ifdef USE_FBGEMM
-  std::tuple<at::Tensor, c10::optional<Tensor>> fbgemm_conv_unpack(
-      at::Tensor packed_weights) {
-    // Pull out the packed weight instance from the owning tensor.
-    auto& pack_ptr =
-        cpp_custom_type_hack::cast<PackedConvWeight>(packed_weights);
-    auto packed_weights_p = pack_ptr.w.get();
-
-    // output channels
-    int output_channels = packed_weights_p->outputChannels();
-    int input_channels = packed_weights_p->inputChannels();
-    int groups = packed_weights_p->groups();
-    // R (kernel height)
-    int kernel_h = pack_ptr.kernel[0];
-    // S (kernel width)
-    int kernel_w = pack_ptr.kernel[1];
-
-    int C_per_G = input_channels / groups;
-
-    // Tensor for unpacked weights
-    // Unpacked format would be physical KRS(C/G) but logical KCRS (channels first)
-    // because that's how FBGEMM stores the weights
-    Tensor unpacked_weights;
-    if (pack_ptr.q_scheme == kPerTensorAffine) {
-      unpacked_weights = _empty_affine_quantized(
-          {output_channels, C_per_G, kernel_h, kernel_w},
-          device(kCPU).dtype(kQInt8),
-          pack_ptr.w_scale[0],
-          pack_ptr.w_zp[0],
-          MemoryFormat::ChannelsLast);
-    } else if (pack_ptr.q_scheme == kPerChannelAffine) {
-      auto scales = from_blob(
-          pack_ptr.w_scale.data(),
-          pack_ptr.w_scale.size(),
-          device(kCPU).dtype(kFloat));
-      auto zero_points = from_blob(
-          pack_ptr.w_zp.data(), pack_ptr.w_zp.size(), device(kCPU).dtype(kInt));
-
-      unpacked_weights = _empty_per_channel_affine_quantized(
-          {output_channels, C_per_G, kernel_h, kernel_w},
-          scales.toType(kDouble),
-          zero_points.toType(kLong),
-          0, /* The output channel axis is 0 */
-          device(kCPU).dtype(kQInt8),
-          MemoryFormat::ChannelsLast);
-    } else {
-      TORCH_CHECK(false, "Unsupported qscheme: ", toString(pack_ptr.q_scheme));
-    }
-    int8_t* unpacked_weights_p =
-        reinterpret_cast<int8_t*>(unpacked_weights.data_ptr<c10::qint8>());
-
-    packed_weights_p->unpack(unpacked_weights_p);
-
-    return std::tuple<at::Tensor, c10::optional<Tensor>>(
-        unpacked_weights, pack_ptr.bias);
-  }
-#endif
-#ifdef USE_PYTORCH_QNNPACK
-  std::tuple<at::Tensor, c10::optional<Tensor>> qnnpack_conv_unpack(
-      at::Tensor packed_weight) {
-    auto& pack_ptr =
-        cpp_custom_type_hack::cast<PackedConvWeightsQnnp>(packed_weight);
-    return std::tuple<at::Tensor, c10::optional<Tensor>>(
-        pack_ptr.orig_weight, pack_ptr.bias);
-  }
-#endif
   std::tuple<at::Tensor, c10::optional<at::Tensor>> operator()(
       Tensor packed_weights) {
     auto& ctx = at::globalContext();
@@ -91,23 +30,125 @@ class QConvUnpackWeightsInt8 final : public c10::OperatorKernel {
       return fbgemm_conv_unpack(packed_weights);
     }
 #endif
+
 #ifdef USE_PYTORCH_QNNPACK
     if (ctx.qEngine() == at::QEngine::QNNPACK) {
+      TORCH_CHECK(
+          kSpatialDim == 2,
+          "quantized::conv_unpack (qnnpack): QNNPACK only supports Conv2d "
+          "now.");
       return qnnpack_conv_unpack(packed_weights);
     }
 #endif
+
     TORCH_CHECK(
         false,
         "Didn't find engine for operation quantized::conv_unpack ",
         toString(ctx.qEngine()));
   }
+
+ private:
+#ifdef USE_FBGEMM
+  std::tuple<Tensor, c10::optional<Tensor>> fbgemm_conv_unpack(
+      Tensor packed_weights) {
+    // Pull out the packed weight instance from the owning tensor.
+    auto& pack_ptr = cpp_custom_type_hack::cast<PackedConvWeight<kSpatialDim>>(
+        packed_weights);
+    auto* packed_weights_p = pack_ptr.w.get();
+
+    // output channels
+    const int output_channels = packed_weights_p->outputChannels();
+    const int input_channels = packed_weights_p->inputChannels();
+    const int groups = packed_weights_p->groups();
+
+    const int kernel_d = kSpatialDim == 2 ? 1 : pack_ptr.kernel[0];
+    // R (kernel height)
+    const int kernel_h = pack_ptr.kernel[kSpatialDim - 2];
+    // S (kernel width)
+    const int kernel_w = pack_ptr.kernel[kSpatialDim - 1];
+
+    const int C_per_G = input_channels / groups;
+
+    // Tensor for unpacked weights
+    // Unpacked format would be physical KRS(C/G) but logical KCRS (channels
+    // first) because that's how
+    // ChannelsLast3d is not available now.FBGEMM stores the weights
+    // TODO: Unify 2d and 3d when ChannelsLast3d is ready.
+    Tensor unpacked_weights;
+    if (pack_ptr.q_scheme == kPerTensorAffine) {
+      unpacked_weights = kSpatialDim == 2
+          ? _empty_affine_quantized(
+                {output_channels, C_per_G, kernel_h, kernel_w},
+                device(kCPU).dtype(kQInt8),
+                pack_ptr.w_scale[0],
+                pack_ptr.w_zp[0],
+                MemoryFormat::ChannelsLast)
+          : fbgemm_utils::MakeEmptyAffineQuantizedChannelsLast3dTensor(
+                output_channels,
+                C_per_G,
+                kernel_d,
+                kernel_h,
+                kernel_w,
+                device(kCPU).dtype(kQInt8),
+                pack_ptr.w_scale[0],
+                pack_ptr.w_zp[0]);
+    } else if (pack_ptr.q_scheme == kPerChannelAffine) {
+      auto scales = from_blob(
+          pack_ptr.w_scale.data(),
+          pack_ptr.w_scale.size(),
+          device(kCPU).dtype(kFloat));
+      auto zero_points = from_blob(
+          pack_ptr.w_zp.data(), pack_ptr.w_zp.size(), device(kCPU).dtype(kInt));
+      unpacked_weights = kSpatialDim == 2
+          ? _empty_per_channel_affine_quantized(
+                {output_channels, C_per_G, kernel_h, kernel_w},
+                scales.toType(kDouble),
+                zero_points.toType(kLong),
+                0, /* The output channel axis is 0 */
+                device(kCPU).dtype(kQInt8),
+                MemoryFormat::ChannelsLast)
+          : fbgemm_utils::
+                MakeEmptyPerChannelAffineQuantizedChannelsLast3dTensor(
+                    output_channels,
+                    C_per_G,
+                    kernel_d,
+                    kernel_h,
+                    kernel_w,
+                    device(kCPU).dtype(kQInt8),
+                    scales.toType(kDouble),
+                    zero_points.toType(kLong));
+    } else {
+      TORCH_CHECK(false, "Unsupported qscheme: ", toString(pack_ptr.q_scheme));
+    }
+    int8_t* unpacked_weights_p =
+        reinterpret_cast<int8_t*>(unpacked_weights.data_ptr<c10::qint8>());
+    packed_weights_p->unpack(unpacked_weights_p);
+
+    return std::tuple<Tensor, c10::optional<Tensor>>(
+        unpacked_weights, pack_ptr.bias);
+  }
+#endif
+
+#ifdef USE_PYTORCH_QNNPACK
+  std::tuple<at::Tensor, c10::optional<Tensor>> qnnpack_conv_unpack(
+      at::Tensor packed_weight) {
+    auto& pack_ptr =
+        cpp_custom_type_hack::cast<PackedConvWeightsQnnp>(packed_weight);
+    return std::tuple<at::Tensor, c10::optional<Tensor>>(
+        pack_ptr.orig_weight, pack_ptr.bias);
+  }
+#endif
 };
 
-static auto registry = c10::RegisterOperators().op(
-    "quantized::conv_unpack(Tensor packed_weights)"
-    " -> (Tensor unpacked_weights, Tensor? B_origin)",
-    c10::RegisterOperators::options().kernel<QConvUnpackWeightsInt8>(
-        TensorTypeId::CPUTensorId));
+static auto registry =
+    c10::RegisterOperators()
+        .op("quantized::conv_unpack(Tensor packed_weights)"
+            " -> (Tensor unpacked_weights, Tensor? B_origin)",
+            c10::RegisterOperators::options().kernel<QConvUnpackWeightsInt8<2>>(
+                TensorTypeId::CPUTensorId))
+        .op("quantized::conv3d_unpack",
+            c10::RegisterOperators::options().kernel<QConvUnpackWeightsInt8<3>>(
+                TensorTypeId::CPUTensorId));
 
 } // namespace
 } // namespace native

--- a/test/test_quantized.py
+++ b/test/test_quantized.py
@@ -1276,6 +1276,49 @@ class TestQuantizedLinear(unittest.TestCase):
                     W_q.q_zero_point(), W_q_origin.q_zero_point())
 
 class TestQuantizedConv(unittest.TestCase):
+    def _test_qconv_unpack_impl(
+        self, qconv_prepack_fn, qconv_unpack_fn, inputs, strides, pads,
+        channelwise
+    ):
+        (X_data, W_data, bias_data, groups) = inputs
+        (X, (X_scale, X_zero_point, X_qtype)) = X_data
+        (W, (W_scale, W_zero_point, W_qtype)) = W_data
+        (bias, (bias_scale, bias_zero_point, bias_qtype)) = bias_data
+        if channelwise:
+            output_channels = W.shape[0]
+            W_scale = torch.tensor([W_scale] * output_channels)
+            W_zero_point = torch.tensor([W_zero_point] * output_channels)
+
+        W = torch.from_numpy(W).float()
+        bias = torch.from_numpy(bias).float()
+        if channelwise:
+            W_q = torch.quantize_per_channel(
+                W, scales=W_scale, zero_points=W_zero_point, axis=0,
+                dtype=W_qtype)
+        else:
+            W_q = torch.quantize_per_tensor(
+                W, scale=W_scale, zero_point=W_zero_point, dtype=W_qtype)
+
+        dilations = (1,) * len(strides)
+        W_packed = qconv_prepack_fn(W_q, bias, strides, pads, dilations, groups)
+        (W_unpacked, bias) = qconv_unpack_fn(W_packed)
+
+        # Assert equal
+        np.testing.assert_equal(W_q.int_repr().numpy(),
+                                W_unpacked.int_repr().numpy())
+        if channelwise:
+            np.testing.assert_array_almost_equal(
+                np.float32(W_q.q_per_channel_scales().numpy()),
+                np.float32(W_unpacked.q_per_channel_scales().numpy()),
+                decimal=4)
+            np.testing.assert_equal(W_q.q_per_channel_zero_points(
+            ).numpy(), W_unpacked.q_per_channel_zero_points().numpy())
+        else:
+            np.testing.assert_equal(np.float32(
+                W_q.q_scale()), np.float32(W_unpacked.q_scale()))
+            np.testing.assert_equal(
+                W_q.q_zero_point(), W_unpacked.q_zero_point())
+
     """Tests the correctness of quantized convolution op."""
     @given(batch_size=st.integers(1, 3),
            input_channels_per_group=st.sampled_from([2, 4, 5, 8, 16, 32]),
@@ -1435,71 +1478,78 @@ class TestQuantizedConv(unittest.TestCase):
             np.testing.assert_array_almost_equal(result_ref_q.int_repr().numpy(), Y_q.int_repr().numpy(), decimal=0)
 
     """Tests the correctness of the quantized::qconv_unpack op."""
-    @given(X=hu.tensor_conv2d(min_batch=1, max_batch=3,
-                              min_in_channels=1, max_in_channels=7,
-                              min_out_channels=1, max_out_channels=7,
-                              H_range=(6, 12), W_range=(6, 12),
-                              kH_range=(3, 5), kW_range=(3, 5),
-                              max_groups=4,
-                              qparams=[hu.qparams(dtypes=torch.quint8,
-                                                  zero_point_min=0,
-                                                  zero_point_max=0),
-                                       hu.qparams(dtypes=torch.qint8,
-                                                  zero_point_min=0,
-                                                  zero_point_max=0),
-                                       hu.qparams(dtypes=torch.qint32,
-                                                  zero_point_min=0,
-                                                  zero_point_max=0)]),
-           strideH=st.integers(1, 3), strideW=st.integers(1, 3),
-           padH=st.integers(1, 2), padW=st.integers(1, 2),
-           channelwise=st.booleans(),
-           qengine=st.sampled_from(("qnnpack", "fbgemm")))
-    def test_qconv_unpack(self, X, strideH, strideW, padH, padW, channelwise, qengine):
+    @given(
+        inputs=hu.tensor_conv(
+            spatial_dim=2, batch_size_range=(1, 3),
+            input_channels_per_group_range=(1, 4),
+            output_channels_per_group_range=(1, 4), feature_map_range=(4, 8),
+            kernel_range=(1, 4), max_groups=4,
+            qparams=[hu.qparams(dtypes=torch.quint8,
+                                zero_point_min=0,
+                                zero_point_max=0),
+                     hu.qparams(dtypes=torch.qint8,
+                                zero_point_min=0,
+                                zero_point_max=0),
+                     hu.qparams(dtypes=torch.qint32,
+                                zero_point_min=0,
+                                zero_point_max=0)]),
+        stride_h=st.integers(1, 3), stride_w=st.integers(1, 3),
+        pad_h=st.integers(1, 2), pad_w=st.integers(1, 2),
+        channelwise=st.booleans(),
+        qengine=st.sampled_from(("qnnpack", "fbgemm")))
+    def test_qconv_unpack(
+        self, inputs, stride_h, stride_w, pad_h, pad_w, channelwise, qengine
+    ):
         if qengine not in torch.backends.quantized.supported_engines:
             return
         if qengine == 'qnnpack':
             if IS_PPC or TEST_WITH_UBSAN:
                 return
             channelwise = False
+
         with override_quantized_engine(qengine):
-            (inputs, filters, bias, groups) = X
-            inputs, (inputs_scale, inputs_zero_point, inputs_qtype) = inputs
-            filters, (filters_scale, filters_zero_point, filters_qtype) = filters
-            bias, (bias_scale, bias_zero_point, bias_qtype) = bias
-            if channelwise:
-                output_channels = filters.shape[0]
-                filters_scale = torch.tensor([filters_scale] * output_channels)
-                filters_zero_point = torch.tensor([filters_zero_point] * output_channels)
             qconv_prepack = torch.ops.quantized.conv_prepack
             qconv_unpack = torch.ops.quantized.conv_unpack
-            W = torch.from_numpy(filters).to(torch.float)
-            if channelwise:
-                W_q = torch.quantize_per_channel(W,
-                                                 scales=filters_scale,
-                                                 zero_points=filters_zero_point,
-                                                 axis=0,
-                                                 dtype=filters_qtype)
-            else:
-                W_q = torch.quantize_per_tensor(W, scale=filters_scale, zero_point=filters_zero_point, dtype=filters_qtype)
-            # Pack weights using weight packing operator
-            strides = [strideH, strideW]
-            paddings = [padH, padW]
-            dilations = [1, 1]
-            bias = torch.from_numpy(bias).to(torch.float)
-            W_packed = qconv_prepack(W_q, bias, strides, paddings, dilations, groups)
-            # Unpack weights weight unpacking operator (Used for serialization)
-            W_unpacked = qconv_unpack(W_packed)[0]
-            bias = qconv_unpack(W_packed)[1]
-            # Assert equal
-            np.testing.assert_equal(W_q.int_repr().numpy(), W_unpacked.int_repr().numpy())
-            if channelwise:
-                np.testing.assert_array_almost_equal(np.float32(W_q.q_per_channel_scales().numpy()),
-                                                     np.float32(W_unpacked.q_per_channel_scales().numpy()),
-                                                     decimal=4)
-                np.testing.assert_equal(W_q.q_per_channel_zero_points().numpy(), W_unpacked.q_per_channel_zero_points().numpy())
-            else:
-                np.testing.assert_equal(np.float32(W_q.q_scale()), np.float32(W_unpacked.q_scale()))
-                np.testing.assert_equal(W_q.q_zero_point(), W_unpacked.q_zero_point())
+            self._test_qconv_unpack_impl(
+                qconv_prepack, qconv_unpack, inputs, (stride_h, stride_w),
+                (pad_h, pad_w), channelwise)
+
+    """Tests the correctness of the quantized::qconv3d_unpack op."""
+    @given(
+        inputs=hu.tensor_conv(
+            spatial_dim=3, batch_size_range=(1, 3),
+            input_channels_per_group_range=(1, 3),
+            output_channels_per_group_range=(1, 3), feature_map_range=(3, 6),
+            kernel_range=(1, 3), max_groups=3,
+            qparams=[hu.qparams(dtypes=torch.quint8,
+                                zero_point_min=0,
+                                zero_point_max=0),
+                     hu.qparams(dtypes=torch.qint8,
+                                zero_point_min=0,
+                                zero_point_max=0),
+                     hu.qparams(dtypes=torch.qint32,
+                                zero_point_min=0,
+                                zero_point_max=0)]),
+        stride_d=st.integers(1, 2), stride_h=st.integers(1, 2),
+        stride_w=st.integers(1, 2),
+        pad_d=st.integers(1, 2), pad_h=st.integers(1, 2),
+        pad_w=st.integers(1, 2),
+        channelwise=st.booleans(),
+        qengine=st.sampled_from(("fbgemm",)))
+    def test_qconv3d_unpack(
+        self, inputs, stride_d, stride_h, stride_w, pad_d, pad_h, pad_w,
+        channelwise, qengine
+    ):
+        if qengine not in torch.backends.quantized.supported_engines:
+            return
+
+        with override_quantized_engine(qengine):
+            qconv3d_prepack = torch.ops.quantized.conv3d_prepack
+            qconv3d_unpack = torch.ops.quantized.conv3d_unpack
+            self._test_qconv_unpack_impl(
+                qconv3d_prepack, qconv3d_unpack, inputs,
+                (stride_d, stride_h, stride_w), (pad_d, pad_h, pad_w),
+                channelwise)
 
 @unittest.skipUnless('qnnpack' in torch.backends.quantized.supported_engines,
                      "This Pytorch Build has not been built with QNNPACK")


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/FBGEMM/pull/146

Refactor qconv_prepack and qconv_unpack to support conv3d

Test Plan: buck test mode/dev-nosan caffe2/test:quantized -- "Conv"

Reviewed By: dskhudia

Differential Revision: D18023651

