### PR TITLE
Update C++ torch::nn parity table for LayerNorm

### DIFF
--- a/test/cpp_api_parity/parity-tracker.md
+++ b/test/cpp_api_parity/parity-tracker.md
@@ -77,7 +77,7 @@ torch.nn.SyncBatchNorm|No|No
 torch.nn.InstanceNorm1d|No|No
 torch.nn.InstanceNorm2d|No|No
 torch.nn.InstanceNorm3d|No|No
-torch.nn.LayerNorm|No|No
+torch.nn.LayerNorm|Yes|No
 torch.nn.LocalResponseNorm|No|No
 torch.nn.RNN|No|No
 torch.nn.LSTM|No|No


### PR DESCRIPTION
Since now we have merged https://github.com/pytorch/pytorch/pull/28032 (thanks @anjali411!)