### PR TITLE
[pytorch] When pickling specialized lists, reduce prior to adding values.

### DIFF
--- a/test/cpp/api/jit.cpp
+++ b/test/cpp/api/jit.cpp
@@ -125,3 +125,16 @@ TEST(TorchScriptTest, TestPickle) {
   double eps = 0.0001;
   ASSERT_TRUE(diff < eps && diff > -eps);
 }
+
+TEST(TorchScriptTest, TestPickleIntList) {
+  std::vector<int64_t> orig = { 1, 2, 3, 4, 5};
+  std::vector<at::Tensor> tensor_table;
+  auto data = torch::jit::pickle(torch::IValue(orig), &tensor_table);
+  torch::IValue out = torch::jit::unpickle(data.data(), data.size());
+  EXPECT_TRUE(out.isIntList());
+  auto irr = out.toIntListRef();
+  EXPECT_EQ(irr.size(), orig.size());
+  for (size_t i = 0; i < irr.size(); ++i) {
+    EXPECT_EQ(irr[i], orig[i]);
+  }
+}

--- a/torch/csrc/jit/pickler.cpp
+++ b/torch/csrc/jit/pickler.cpp
@@ -386,6 +386,17 @@ void Pickler::pushSpecializedList(
   push<PickleOpCode>(PickleOpCode::MARK);
 
   push<PickleOpCode>(PickleOpCode::EMPTY_LIST);
+
+  // Finish tuple
+  push<PickleOpCode>(PickleOpCode::TUPLE);
+
+  // Call reduce.
+  // Since it's a specialized list, we want to reduce to the specialized
+  // type prior to adding the values. This way, unpickling can be more
+  // efficient, as it can read directly as int/double/etc. rather than
+  // constructing/destructing IValue for each entry.
+  push<PickleOpCode>(PickleOpCode::REDUCE);
+
   // Mark list
   push<PickleOpCode>(PickleOpCode::MARK);
 
@@ -394,12 +405,6 @@ void Pickler::pushSpecializedList(
 
   // Finish list
   push<PickleOpCode>(PickleOpCode::APPENDS);
-
-  // Finish tuple
-  push<PickleOpCode>(PickleOpCode::TUPLE);
-
-  // Call reduce
-  push<PickleOpCode>(PickleOpCode::REDUCE);
 }
 
 void Pickler::pushDouble(double value) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#28488 [pytorch] When pickling specialized lists, reduce prior to adding values.**

Previously, we weren't converting a generic list to specialized (int/double/etc)
until after we read all the values.

If we slightly change the order of the pickler opcodes, we can convert the
list to specialized before we read the values. And if the unpickler knows the
specialized type when reading, it can skip the per-entry IValue
constructor/destructor step.

This produces a 45% win for this specialized case - in my benchmark unpickling
a 1M random int list, the time goes from 65ms -> 36ms (both are still slow, but it's better).

Differential Revision: [D18078506](https://our.internmc.facebook.com/intern/diff/D18078506/)