### PR TITLE
Include hierarchy information in C++ API loading error messages

### DIFF
--- a/test/cpp/api/serialize.cpp
+++ b/test/cpp/api/serialize.cpp
@@ -127,6 +127,39 @@ TEST(SerializeTest, NonContiguous) {
   ASSERT_TRUE(x.allclose(y));
 }
 
+TEST(SerializeTest, ErrorOnMissingKey) {
+  struct B : torch::nn::Module {
+    B(const std::string& name_c) {
+      register_buffer(name_c, torch::ones(5, torch::kFloat));
+    }
+  };
+  struct A : torch::nn::Module {
+    A(const std::string& name_b, const std::string& name_c) {
+      register_module(name_b, std::make_shared<B>(name_c));
+    }
+  };
+  struct M : torch::nn::Module {
+    M(const std::string& name_a,
+      const std::string& name_b,
+      const std::string& name_c) {
+      register_module(name_a, std::make_shared<A>(name_b, name_c));
+    }
+  };
+
+  // create a hierarchy of models with names differing below the top level
+  auto model1 = std::make_shared<M>("a", "b", "c");
+  auto model2 = std::make_shared<M>("a", "b", "x");
+  auto model3 = std::make_shared<M>("a", "x", "c");
+
+  std::stringstream stream;
+  torch::save(model1, stream);
+  // We want the errors to contain hierarchy information, too.
+  ASSERT_THROWS_WITH(
+      torch::load(model2, stream), "No such serialized tensor 'a.b.x'");
+  ASSERT_THROWS_WITH(
+      torch::load(model3, stream), "No such serialized submodule: 'a.x'");
+}
+
 TEST(SerializeTest, XOR) {
   // We better be able to save and load an XOR model!
   auto getLoss = [](Sequential model, uint32_t batch_size) {

--- a/torch/csrc/api/include/torch/serialize/input-archive.h
+++ b/torch/csrc/api/include/torch/serialize/input-archive.h
@@ -102,6 +102,7 @@ class TORCH_API InputArchive final {
 
  private:
   jit::script::Module module_;
+  std::string hierarchy_prefix;
 };
 } // namespace serialize
 } // namespace torch

--- a/torch/csrc/api/include/torch/serialize/input-archive.h
+++ b/torch/csrc/api/include/torch/serialize/input-archive.h
@@ -102,7 +102,7 @@ class TORCH_API InputArchive final {
 
  private:
   jit::script::Module module_;
-  std::string hierarchy_prefix;
+  std::string hierarchy_prefix_;
 };
 } // namespace serialize
 } // namespace torch

--- a/torch/csrc/api/src/serialize/input-archive.cpp
+++ b/torch/csrc/api/src/serialize/input-archive.cpp
@@ -65,7 +65,7 @@ void InputArchive::read(
   TORCH_CHECK(
       try_read(key, tensor, is_buffer),
       "No such serialized tensor '",
-      hierarchy_prefix,
+      hierarchy_prefix_,
       key,
       "'");
 }
@@ -73,7 +73,7 @@ void InputArchive::read(
 bool InputArchive::try_read(const std::string& key, InputArchive& archive) {
   if (auto named_module = module_.find_module(key)) {
     archive.module_ = std::move(*named_module);
-    archive.hierarchy_prefix = hierarchy_prefix + key + ".";
+    archive.hierarchy_prefix_ = hierarchy_prefix_ + key + ".";
     return true;
   } else {
     return false;
@@ -84,7 +84,7 @@ void InputArchive::read(const std::string& key, InputArchive& archive) {
   TORCH_CHECK(
       try_read(key, archive),
       "No such serialized submodule: '",
-      hierarchy_prefix,
+      hierarchy_prefix_,
       key,
       "'");
 }

--- a/torch/csrc/api/src/serialize/input-archive.cpp
+++ b/torch/csrc/api/src/serialize/input-archive.cpp
@@ -63,15 +63,17 @@ void InputArchive::read(
     Tensor& tensor,
     bool is_buffer) {
   TORCH_CHECK(
-    try_read(key, tensor, is_buffer),
-    "No such serialized tensor '",
-    key,
-    "'");
+      try_read(key, tensor, is_buffer),
+      "No such serialized tensor '",
+      hierarchy_prefix,
+      key,
+      "'");
 }
 
 bool InputArchive::try_read(const std::string& key, InputArchive& archive) {
   if (auto named_module = module_.find_module(key)) {
     archive.module_ = std::move(*named_module);
+    archive.hierarchy_prefix = hierarchy_prefix + key + ".";
     return true;
   } else {
     return false;
@@ -80,8 +82,11 @@ bool InputArchive::try_read(const std::string& key, InputArchive& archive) {
 
 void InputArchive::read(const std::string& key, InputArchive& archive) {
   TORCH_CHECK(
-    try_read(key, archive),
-    "No such serialized submodule: '", key, "'");
+      try_read(key, archive),
+      "No such serialized submodule: '",
+      hierarchy_prefix,
+      key,
+      "'");
 }
 
 void InputArchive::load_from(const std::string& filename,


### PR DESCRIPTION
Before, we would only give the key we are looking for (i.e. typically
just "No such serialized tensor 'weight'", no matter for which submodule
we were looking for a weight.
Now we error with "No such serialized tensor '0.conv1.weight'" or
similar.
The analogous information is added to missing module error messages.

I threw in a test, and it saved me already...

