### PR TITLE
Change activation modules in C++ from using Tensor& to Tensor

### DIFF
--- a/test/cpp/api/sequential.cpp
+++ b/test/cpp/api/sequential.cpp
@@ -13,6 +13,10 @@ using namespace torch::test;
 
 struct SequentialTest : torch::test::SeedingFixture {};
 
+TEST_F(SequentialTest, CanContainThings) {
+  Sequential sequential(Linear(3, 4), Functional(torch::relu), BatchNorm(3));
+}
+
 TEST_F(SequentialTest, ConstructsFromSharedPointer) {
   struct M : torch::nn::Module {
     explicit M(int value_) : value(value_) {}

--- a/test/cpp/api/sequential.cpp
+++ b/test/cpp/api/sequential.cpp
@@ -14,7 +14,7 @@ using namespace torch::test;
 struct SequentialTest : torch::test::SeedingFixture {};
 
 TEST_F(SequentialTest, CanContainThings) {
-  Sequential sequential(Linear(3, 4), Functional(torch::relu), BatchNorm(3));
+  Sequential sequential(Linear(3, 4), ReLU(), BatchNorm(3));
 }
 
 TEST_F(SequentialTest, ConstructsFromSharedPointer) {

--- a/torch/csrc/api/include/torch/nn/modules/activation.h
+++ b/torch/csrc/api/include/torch/nn/modules/activation.h
@@ -18,7 +18,7 @@ class TORCH_API ELUImpl : public torch::nn::Cloneable<ELUImpl> {
  public:
   explicit ELUImpl(const ELUOptions& options_ = {});
 
-  Tensor forward(Tensor& input);
+  Tensor forward(Tensor input);
 
   void reset() override;
 
@@ -40,7 +40,7 @@ class TORCH_API SELUImpl : public torch::nn::Cloneable<SELUImpl> {
  public:
   explicit SELUImpl(const SELUOptions& options_ = {});
 
-  Tensor forward(Tensor& input);
+  Tensor forward(Tensor input);
 
   void reset() override;
 
@@ -84,7 +84,7 @@ class TORCH_API HardtanhImpl : public torch::nn::Cloneable<HardtanhImpl> {
  public:
   explicit HardtanhImpl(const HardtanhOptions& options_ = {});
 
-  Tensor forward(Tensor& input);
+  Tensor forward(Tensor input);
 
   void reset() override;
 
@@ -106,7 +106,7 @@ class TORCH_API LeakyReLUImpl : public torch::nn::Cloneable<LeakyReLUImpl> {
  public:
   explicit LeakyReLUImpl(const LeakyReLUOptions& options_ = {});
 
-  Tensor forward(Tensor& input);
+  Tensor forward(Tensor input);
 
   void reset() override;
 
@@ -253,7 +253,7 @@ class TORCH_API ReLUImpl : public torch::nn::Cloneable<ReLUImpl> {
  public:
   explicit ReLUImpl(const ReLUOptions& options_ = {});
 
-  Tensor forward(Tensor& input);
+  Tensor forward(Tensor input);
 
   void reset() override;
 
@@ -275,7 +275,7 @@ class TORCH_API ReLU6Impl : public torch::nn::Cloneable<ReLU6Impl> {
  public:
   explicit ReLU6Impl(const ReLU6Options& options_ = {});
 
-  Tensor forward(Tensor& input);
+  Tensor forward(Tensor input);
 
   void reset() override;
 
@@ -297,7 +297,7 @@ class TORCH_API RReLUImpl : public torch::nn::Cloneable<RReLUImpl> {
  public:
   explicit RReLUImpl(const RReLUOptions& options_ = {});
 
-  Tensor forward(Tensor& input);
+  Tensor forward(Tensor input);
 
   void reset() override;
 
@@ -319,7 +319,7 @@ class TORCH_API CELUImpl : public torch::nn::Cloneable<CELUImpl> {
  public:
   explicit CELUImpl(const CELUOptions& options_ = {});
 
-  Tensor forward(Tensor& input);
+  Tensor forward(Tensor input);
 
   void reset() override;
 
@@ -455,7 +455,7 @@ class TORCH_API ThresholdImpl : public torch::nn::Cloneable<ThresholdImpl> {
     : ThresholdImpl(ThresholdOptions(threshold, value)) {}
   explicit ThresholdImpl(const ThresholdOptions& options_);
 
-  Tensor forward(Tensor& input);
+  Tensor forward(Tensor input);
 
   void reset() override;
 

--- a/torch/csrc/api/src/nn/modules/activation.cpp
+++ b/torch/csrc/api/src/nn/modules/activation.cpp
@@ -8,7 +8,7 @@ namespace nn {
 
 ELUImpl::ELUImpl(const ELUOptions& options_) : options(options_) {}
 
-Tensor ELUImpl::forward(Tensor& input) {
+Tensor ELUImpl::forward(Tensor input) {
   return F::elu(input, options);
 }
 
@@ -26,7 +26,7 @@ void ELUImpl::pretty_print(std::ostream& stream) const {
 
 SELUImpl::SELUImpl(const SELUOptions& options_) : options(options_) {}
 
-Tensor SELUImpl::forward(Tensor& input) {
+Tensor SELUImpl::forward(Tensor input) {
   return F::selu(input, options);
 }
 
@@ -63,7 +63,7 @@ HardtanhImpl::HardtanhImpl(const HardtanhOptions& options_)
   reset();
 }
 
-Tensor HardtanhImpl::forward(Tensor& input) {
+Tensor HardtanhImpl::forward(Tensor input) {
   return F::hardtanh(input, options);
 }
 
@@ -87,7 +87,7 @@ void HardtanhImpl::pretty_print(std::ostream& stream) const {
 LeakyReLUImpl::LeakyReLUImpl(const LeakyReLUOptions& options_)
     : options(options_) {}
 
-Tensor LeakyReLUImpl::forward(Tensor& input) {
+Tensor LeakyReLUImpl::forward(Tensor input) {
   return F::leaky_relu(input, options);
 }
 
@@ -196,7 +196,7 @@ void PReLUImpl::pretty_print(std::ostream& stream) const {
 
 ReLUImpl::ReLUImpl(const ReLUOptions& options_) : options(options_) {}
 
-Tensor ReLUImpl::forward(Tensor& input) {
+Tensor ReLUImpl::forward(Tensor input) {
   return F::relu(input, options);
 }
 
@@ -214,7 +214,7 @@ void ReLUImpl::pretty_print(std::ostream& stream) const {
 
 ReLU6Impl::ReLU6Impl(const ReLU6Options& options_) : options(options_) {}
 
-Tensor ReLU6Impl::forward(Tensor& input) {
+Tensor ReLU6Impl::forward(Tensor input) {
   return F::relu6(input, options);
 }
 
@@ -232,7 +232,7 @@ void ReLU6Impl::pretty_print(std::ostream& stream) const {
 
 RReLUImpl::RReLUImpl(const RReLUOptions& options_) : options(options_) {}
 
-Tensor RReLUImpl::forward(Tensor& input) {
+Tensor RReLUImpl::forward(Tensor input) {
   return F::rrelu(input, options, is_training());
 }
 
@@ -251,7 +251,7 @@ void RReLUImpl::pretty_print(std::ostream& stream) const {
 
 CELUImpl::CELUImpl(const CELUOptions& options_) : options(options_) {}
 
-Tensor CELUImpl::forward(Tensor& input) {
+Tensor CELUImpl::forward(Tensor input) {
   return F::celu(input, options);
 }
 
@@ -349,7 +349,7 @@ void TanhshrinkImpl::pretty_print(std::ostream& stream) const {
 ThresholdImpl::ThresholdImpl(const ThresholdOptions& options_)
     : options(options_) {}
 
-Tensor ThresholdImpl::forward(Tensor& input) {
+Tensor ThresholdImpl::forward(Tensor input) {
   return F::threshold(input, options);
 }
 


### PR DESCRIPTION
Sequential does not like modules added to it to take Tensor&
(const Tensor& and Tensor are both OK).
Functional and others use Tensor when they want to potentially
change things in-place.
This changes ReLU and friends to also do that.

Unfortunately, this seems to be BC breaking on the ABI level.
On the other hand, use of the module ReLU seems rare enough outside
Sequential (in particular in C++ models, the standard seems to be
to use torch::relu instead).

is the BC breaking OK here? (@yf225 or anyone else)