### PR TITLE
LayerNorm: Handling if batch size is zero

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -310,6 +310,20 @@
         - THTensor* value
 ]]
 [[
+  name: _th_index_max_
+  cname: indexMax
+  types:
+    - Float
+  variants: function
+  return: argument 0
+  arguments:
+    - THTensor* self
+    - arg: long dim
+      wrap_dim: self
+    - THIndexTensor* index
+    - THTensor* source
+]]
+[[
   name: _th_unfold
   cname: unfold
   variants:

--- a/aten/src/ATen/core/aten_interned_strings.h
+++ b/aten/src/ATen/core/aten_interned_strings.h
@@ -368,6 +368,7 @@ _(aten, index) \
 _(aten, index_add) \
 _(aten, index_copy) \
 _(aten, index_fill) \
+_(aten, index_max) \
 _(aten, index_put) \
 _(aten, index_select) \
 _(aten, indices) \

--- a/aten/src/ATen/native/Indexing.cpp
+++ b/aten/src/ATen/native/Indexing.cpp
@@ -326,6 +326,10 @@ Tensor index_fill(const Tensor & self, int64_t dim, const Tensor & index, const 
   return self.clone().index_fill_(dim, index, source);
 }
 
+Tensor index_max(const Tensor & self, int64_t dim, const Tensor & index, const Tensor & source) {
+  return self.clone().index_max_(dim, index, source);
+}
+
 Tensor scatter(const Tensor & self, int64_t dim, const Tensor & index, const Tensor & source) {
   return self.clone().scatter_(dim, index, source);
 }

--- a/aten/src/ATen/native/NamedTensor.cpp
+++ b/aten/src/ATen/native/NamedTensor.cpp
@@ -372,6 +372,12 @@ Tensor index_fill(const Tensor& self, Dimname dim, const Tensor& index, const Te
 Tensor& index_fill_(Tensor& self, Dimname dim, const Tensor& index, const Tensor& source) {
   return self.index_fill_(dimname_to_position(self, dim), index, source);
 }
+Tensor index_max(const Tensor& self, Dimname dim, const Tensor& index, const Tensor& source) {
+  reportNYIDimnameOverload("index_max");
+}
+Tensor& index_max_(Tensor& self, Dimname dim, const Tensor& index, const Tensor& source) {
+  reportNYIDimnameOverload("index_max");
+}
 Tensor index_copy(const Tensor& self, Dimname dim, const Tensor& index, const Tensor& source) {
   reportNYIDimnameOverload("index_copy");
 }

--- a/aten/src/ATen/native/cuda/layer_norm_kernel.cu
+++ b/aten/src/ATen/native/cuda/layer_norm_kernel.cu
@@ -305,6 +305,7 @@ void LayerNormKernelImplInternal(
           N, eps, X_data, mean_data, rstd_data);
   LayerNormForwardCUDAKernel<T><<<M, kCUDANumThreads, 0, cuda_stream>>>(
       N, X_data, mean_data, rstd_data, gamma_data, beta_data, Y_data);
+  AT_CUDA_CHECK(cudaGetLastError());
 }
 
 void LayerNormKernelImpl(

--- a/aten/src/ATen/native/layer_norm.cpp
+++ b/aten/src/ATen/native/layer_norm.cpp
@@ -26,7 +26,9 @@ std::tuple<Tensor, Tensor, Tensor> layer_norm_cpu(
   Tensor Y = at::native::empty_like(X);
   Tensor mean = at::empty({M}, X.options());
   Tensor rstd = at::empty({M}, X.options());
-  LayerNormKernel(kCPU, X, gamma, beta, M, N, eps, &Y, &mean, &rstd);
+  if (M > 0) {
+    LayerNormKernel(kCPU, X, gamma, beta, M, N, eps, &Y, &mean, &rstd);
+  }
   return std::make_tuple(Y, mean, rstd);
 }
 
@@ -40,7 +42,9 @@ std::tuple<Tensor, Tensor, Tensor> layer_norm_cuda(
   Tensor Y = at::native::empty_like(X);
   Tensor mean = at::empty({M}, X.options());
   Tensor rstd = at::empty({M}, X.options());
-  LayerNormKernel(kCUDA, X, gamma, beta, M, N, eps, &Y, &mean, &rstd);
+  if (M > 0) {
+    LayerNormKernel(kCUDA, X, gamma, beta, M, N, eps, &Y, &mean, &rstd);
+  }
   return std::make_tuple(Y, mean, rstd);
 }
 
@@ -60,13 +64,15 @@ std::tuple<Tensor, Tensor, Tensor> layer_norm_backward_cpu(
     dX = at::native::empty_like(X);
   }
   if (grad_input_mask[1]) {
-    dgamma = at::native::empty_like(gamma);
+    dgamma = M > 0 ? at::native::empty_like(gamma) : at::native::zeros_like(gamma);
   }
   if (grad_input_mask[2]) {
-    dbeta = at::native::empty_like(gamma);
+    dbeta = M > 0 ? at::native::empty_like(gamma) : at::native::zeros_like(gamma);
   }
-  LayerNormBackwardKernel(
-      kCPU, dY, X, mean, rstd, gamma, M, N, &dX, &dgamma, &dbeta);
+  if (M > 0) {
+    LayerNormBackwardKernel(
+        kCPU, dY, X, mean, rstd, gamma, M, N, &dX, &dgamma, &dbeta);
+  }
   return std::make_tuple(dX, dgamma, dbeta);
 }
 
@@ -86,13 +92,15 @@ std::tuple<Tensor, Tensor, Tensor> layer_norm_backward_cuda(
     dX = at::native::empty_like(X);
   }
   if (grad_input_mask[1]) {
-    dgamma = at::native::empty_like(gamma);
+    dgamma = M > 0 ? at::native::empty_like(gamma) : at::native::zeros_like(gamma);
   }
   if (grad_input_mask[2]) {
-    dbeta = at::native::empty_like(gamma);
+    dbeta = M > 0 ? at::native::empty_like(gamma) : at::native::zeros_like(gamma);
   }
-  LayerNormBackwardKernel(
-      kCUDA, dY, X, mean, rstd, gamma, M, N, &dX, &dgamma, &dbeta);
+  if (M > 0) {
+    LayerNormBackwardKernel(
+        kCUDA, dY, X, mean, rstd, gamma, M, N, &dX, &dgamma, &dbeta);
+  }
   return std::make_tuple(dX, dgamma, dbeta);
 }
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -4049,6 +4049,20 @@
   variants: function, method
   supports_named_tensor: True
 
+- func: index_max_(Tensor(a!) self, int dim, Tensor index, Tensor source) -> Tensor(a!)
+  use_c10_dispatcher: unboxed_only
+  variants: method
+  dispatch:
+    CPU: legacy::cpu::_th_index_max_
+    CUDA: legacy::cuda::_th_index_max_
+
+- func: index_max(Tensor self, int dim, Tensor index, Tensor source) -> Tensor
+  use_c10_dispatcher: full
+  variants: function, method
+
+- func: index_max.dimname(Tensor self, Dimname dim, Tensor index, Tensor source) -> Tensor
+  variants: function, method
+
 - func: scatter_.src(Tensor(a!) self, int dim, Tensor index, Tensor src) -> Tensor(a!)
   use_c10_dispatcher: unboxed_only
   variants: method

--- a/aten/src/TH/generic/THTensorEvenMoreMath.cpp
+++ b/aten/src/TH/generic/THTensorEvenMoreMath.cpp
@@ -764,6 +764,53 @@ void THTensor_(indexAdd)(THTensor *tensor, int dim, THLongTensor *index, THTenso
   THLongTensor_free(index);
 }
 
+#if defined(TH_REAL_IS_FLOAT)
+static inline scalar_t max_scalar_t(scalar_t a, scalar_t b) {
+  return (b > a) ? b : a;
+}
+
+void THTensor_(indexMax)(THTensor *tensor, int dim, THLongTensor *index, THTensor *src)
+{
+  ptrdiff_t i, numel;
+  THTensor *tSlice, *sSlice;
+  int64_t *index_data;
+
+  numel = THLongTensor_nElement(index);
+  THArgCheck(THTensor_nDimensionLegacyNoScalars(index) == 1, 3, "Index is supposed to be a vector");
+  THArgCheck(dim < THTensor_nDimensionLegacyNoScalars(src), 4,"Indexing dim %d is out of bounds of tensor", dim);
+  THArgCheck(numel == THTensor_sizeLegacyNoScalars(src, dim),4,"Number of indices should be equal to source:size(dim)");
+
+  index = THLongTensor_newContiguous(index);
+  index_data = THLongTensor_data(index);
+
+  if (tensor->dim() > 1)
+  {
+    tSlice = THTensor_(new)();
+    sSlice = THTensor_(new)();
+
+    for (i=0; i<numel; i++)
+    {
+      THTensor_(select)(tSlice, tensor, dim, index_data[i]);
+      THTensor_(select)(sSlice, src, dim, i);
+      THTensor_(cmax)(tSlice, tSlice, sSlice);
+    }
+
+    c10::raw::intrusive_ptr::decref(tSlice);
+    c10::raw::intrusive_ptr::decref(sSlice);
+  }
+  else
+  {
+    for (i=0; i<numel; i++)
+    {
+      THTensor_(set1d)(tensor,
+              index_data[i],
+              max_scalar_t(THTensor_(get1d)(tensor,index_data[i]), THTensor_(get1d)(src,i)));
+    }
+  }
+  THLongTensor_free(index);
+}
+#endif
+
 accreal THTensor_(dot)(THTensor *tensor, THTensor *src)
 {
 #ifdef BUILD_NAMEDTENSOR

--- a/aten/src/TH/generic/THTensorMath.cpp
+++ b/aten/src/TH/generic/THTensorMath.cpp
@@ -217,6 +217,11 @@ static void THTensor_(addmmImpl)(THTensor *r_, THTensor *t, THTensor *m1, THTens
     }
   }
 
+  if((r_->size(0) == 0) || (r_->size(1) == 0))
+  {
+    return;
+  }
+
   // n == 1 || ldc >= max(1, m)
   #define LDC_COND(M, N, LDC) ((N) == 1 || (LDC) >= THMax(1, M))
 

--- a/aten/src/TH/generic/THTensorMath.h
+++ b/aten/src/TH/generic/THTensorMath.h
@@ -110,6 +110,9 @@ TH_API void THTensor_(cumprod)(THTensor *r_, THTensor *t, int dimension);
 #if !defined(TH_REAL_IS_BOOL) /* non bool only part */
 
 TH_API void THTensor_(indexAdd)(THTensor *tensor, int dim, THLongTensor *index, THTensor *src);
+#if defined(TH_REAL_IS_FLOAT)
+TH_API void THTensor_(indexMax)(THTensor *tensor, int dim, THLongTensor *index, THTensor *src);
+#endif
 
 TH_API accreal THTensor_(dot)(THTensor *t, THTensor *src);
 

--- a/aten/src/THC/THCAtomics.cuh
+++ b/aten/src/THC/THCAtomics.cuh
@@ -158,4 +158,21 @@ static inline  __device__  void atomicAdd(double *address, double val) {
 #endif
 #endif
 
+static inline  __device__  void atomicMax(float *address, float val) {
+  uint32_t* address_as_int = (uint32_t*)address;
+  uint32_t old = *address_as_int;
+  uint32_t assumed;
+
+  do {
+    assumed = old;
+    if (!(__int_as_float(assumed) < val)) {
+        return;
+    }
+    old = atomicCAS(address_as_int, assumed,
+                    __float_as_int(val));
+
+    // Note: uses integer comparison to avoid hang in case of NaN (since NaN != NaN)
+} while (assumed != old);
+}
+
 #endif // THC_ATOMICS_INC

--- a/aten/src/THC/generic/THCTensorIndex.cu
+++ b/aten/src/THC/generic/THCTensorIndex.cu
@@ -659,4 +659,132 @@ void THCTensor_(indexAdd)(THCState *state, THCTensor *dst, int dim, THCudaLongTe
 }
 
 #endif
+
+#if defined(THC_REAL_IS_FLOAT)
+void THCTensor_(indexMax)(THCState *state, THCTensor *dst, int dim, THCudaLongTensor *indices, THCTensor *src)
+{
+  THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, dst, src));
+  THCAssertSameGPU(THCudaLongTensor_checkGPU(state, 1, indices));
+
+  int dims = THCTensor_(nDimensionLegacyNoScalars)(state, dst);
+  THArgCheck(dims <= MAX_CUTORCH_DIMS, 2, CUTORCH_DIM_WARNING);
+  dims = THCTensor_(nDimensionLegacyNoScalars)(state, src);
+  THArgCheck(dims <= MAX_CUTORCH_DIMS, 5, CUTORCH_DIM_WARNING);
+  dims = THCudaLongTensor_nDimensionLegacyNoScalars(state, indices);
+  THArgCheck(dims <= MAX_CUTORCH_DIMS, 4, CUTORCH_DIM_WARNING);
+
+  // The `src` is partitioned into two parts:
+  // -the size of each slice we are indexing, which is the
+  // total size of the tensor ignoring dimension `dim`;
+  // -the number of indices we are choosing, which is the total size
+  // of the tensor `indices`.
+  ptrdiff_t sliceSize = THCTensor_(getSliceSize)(state, dst, dim, indices, src);
+  ptrdiff_t srcTotalSize = THCTensor_(nElement)(state, src);
+  int64_t dstMaxDimSize = THCTensor_(sizeLegacyNoScalars)(state, dst, dim);
+  ptrdiff_t numIndices = THCudaLongTensor_nElement(state, indices);
+
+  if (sliceSize == 0) {
+    return;
+  }
+  cudaStream_t stream = THCState_getCurrentStream(state);
+  int indContig = THCudaLongTensor_isContiguous(state, indices);
+
+  int mpc = at::cuda::getCurrentDeviceProperties()->multiProcessorCount;
+
+#define SMALL_INDEX(TENSOR_TYPE, TYPE, DST_DIM, SRC_DIM, IDX_DIM) \
+  indexMaxSmallIndex<TENSOR_TYPE, TYPE, DST_DIM, SRC_DIM, IDX_DIM> \
+    <<<smallIndexGrid, smallIndexBlock, 0, stream>>>(   \
+      dstInfo, srcInfo, indicesInfo,                    \
+      dstMaxDim, srcMaxDim, sliceSize, dstMaxDimSize);
+
+#define LARGE_INDEX(TENSOR_TYPE, TYPE,                        \
+                    DST_DIM, SRC_DIM, IDX_DIM, IDX_IS_MAJOR)  \
+  indexMaxLargeIndex<TENSOR_TYPE, TYPE,                       \
+                     DST_DIM, SRC_DIM, IDX_DIM, IDX_IS_MAJOR> \
+    <<<largeIndexGrid, largeIndexBlock, 0, stream>>>(         \
+      dstInfo, srcInfo, indicesInfo,                          \
+      dstMaxDim, srcMaxDim, srcTotalSize,                     \
+      (IDX_IS_MAJOR) ? sliceSize : numIndices,                \
+      dstMaxDimSize);
+
+  dim3 smallIndexGrid(std::min(THCCeilDiv(sliceSize, (ptrdiff_t)128), (ptrdiff_t)(mpc * 8)));
+  dim3 smallIndexBlock(std::min(sliceSize, (ptrdiff_t)128));
+
+  dim3 largeIndexGrid(std::min(THCCeilDiv(srcTotalSize, (ptrdiff_t)128), (ptrdiff_t)(mpc * 8)));
+  dim3 largeIndexBlock(std::min(srcTotalSize, (ptrdiff_t)128));
+
+  if (THCTensor_canUse32BitIndexMath(state, dst) &&
+      THCTensor_canUse32BitIndexMath(state, src) &&
+      THCTensor_canUse32BitIndexMath(state, indices)) {
+    TensorInfo<scalar_t, unsigned int> dstInfo =
+      getTensorInfo<scalar_t, THCTensor, unsigned int>(state, dst);
+    int dstMaxDim = dstInfo.collapseDims(dim);
+    dstInfo.reduceDim(dstMaxDim);
+
+    TensorInfo<scalar_t, unsigned int> srcInfo =
+      getTensorInfo<scalar_t, THCTensor, unsigned int>(state, src);
+    int srcMaxDim = srcInfo.collapseDims(dim);
+    srcInfo.reduceDim(srcMaxDim);
+
+    TensorInfo<int64_t, unsigned int> indicesInfo =
+      getTensorInfo<int64_t, THCudaLongTensor, unsigned int>(state, indices);
+    indicesInfo.collapseDims();
+
+    // A reasonable choice for when to have each thread iterate over
+    // indices to choose
+    if (numIndices <= 16) {
+      if (dstInfo.dims == 1 && srcInfo.dims == 1 && indContig) {
+        SMALL_INDEX(scalar_t, unsigned int, 1, 1, -2);
+      } else if (dstInfo.dims == 2 && srcInfo.dims == 2 && indContig) {
+        SMALL_INDEX(scalar_t, unsigned int, 2, 2, -2);
+      } else if (dstInfo.dims == 3 && srcInfo.dims == 3 && indContig) {
+        SMALL_INDEX(scalar_t, unsigned int, 3, 3, -2);
+      } else {
+        SMALL_INDEX(scalar_t, unsigned int, -1, -1, -1);
+      }
+    } else {
+      bool indexIsMajor = THCTensor_(indexShouldBeMajor)(dstInfo, dstMaxDim);
+
+      if (dstInfo.dims == 1 && srcInfo.dims == 1 && indContig) {
+        LARGE_INDEX(scalar_t, unsigned int, 1, 1, -2, true);
+      } else if (dstInfo.dims == 2 && srcInfo.dims == 2 && indContig) {
+        if (indexIsMajor) {
+          LARGE_INDEX(scalar_t, unsigned int, 2, 2, -2, true);
+        } else {
+          LARGE_INDEX(scalar_t, unsigned int, 2, 2, -2, false);
+        }
+      } else if (dstInfo.dims == 3 && srcInfo.dims == 3 && indContig) {
+        if (indexIsMajor) {
+          LARGE_INDEX(scalar_t, unsigned int, 3, 3, -2, true);
+        } else {
+          LARGE_INDEX(scalar_t, unsigned int, 3, 3, -2, false);
+        }
+      } else {
+        LARGE_INDEX(scalar_t, unsigned int, -1, -1, -1, true);
+      }
+    }
+  } else {
+    TensorInfo<scalar_t, uint64_t> dstInfo =
+      getTensorInfo<scalar_t, THCTensor, uint64_t>(state, dst);
+    int dstMaxDim = dstInfo.collapseDims(dim);
+    dstInfo.reduceDim(dstMaxDim);
+
+    TensorInfo<scalar_t, uint64_t> srcInfo =
+      getTensorInfo<scalar_t, THCTensor, uint64_t>(state, src);
+    int srcMaxDim = srcInfo.collapseDims(dim);
+    srcInfo.reduceDim(srcMaxDim);
+
+    TensorInfo<int64_t, uint64_t> indicesInfo =
+      getTensorInfo<int64_t, THCudaLongTensor, uint64_t>(state, indices);
+    indicesInfo.collapseDims();
+
+    LARGE_INDEX(scalar_t, uint64_t, -1, -1, -1, true);
+  }
+
+#undef SMALL_INDEX
+#undef LARGE_INDEX
+}
+#endif
+
+
 #endif

--- a/aten/src/THC/generic/THCTensorIndex.h
+++ b/aten/src/THC/generic/THCTensorIndex.h
@@ -12,4 +12,8 @@ THC_API void THCTensor_(put)(THCState *state, THCTensor *res_, THCudaLongTensor 
 THC_API void THCTensor_(indexAdd)(THCState *state, THCTensor *res_, int dim, THCudaLongTensor *indices, THCTensor *src);
 #endif
 
+#if defined(THC_REAL_IS_FLOAT)
+THC_API void THCTensor_(indexMax)(THCState *state, THCTensor *res_, int dim, THCudaLongTensor *indices, THCTensor *src);
+#endif
+
 #endif

--- a/aten/src/THC/generic/THCTensorMathBlas.cu
+++ b/aten/src/THC/generic/THCTensorMathBlas.cu
@@ -305,6 +305,11 @@ static void THCTensor_(addmmImpl)(THCState *state, THCTensor *r_, THCTensor *t, 
     }
   }
 
+  if((r_->size(0) == 0) || (r_->size(1) == 0))
+  {
+    return;
+  }
+
   /* r_ */
   if(r_->stride(0) == 1 &&
      r_->stride(1) != 0)

--- a/docs/source/tensors.rst
+++ b/docs/source/tensors.rst
@@ -289,6 +289,8 @@ view of a storage and defines numeric operations on it.
    .. automethod:: index_copy
    .. automethod:: index_fill_
    .. automethod:: index_fill
+   .. automethod:: index_max_
+   .. automethod:: index_max
    .. automethod:: index_put_
    .. automethod:: index_put
    .. automethod:: index_select

--- a/test/common_methods_invocations.py
+++ b/test/common_methods_invocations.py
@@ -625,6 +625,10 @@ def method_tests():
         ('index_fill', (S, S), (0, torch.tensor(0, dtype=torch.int64), 2), 'scalar_index_dim', (), [0]),
         ('index_fill', (), (0, torch.tensor([0], dtype=torch.int64), 2), 'scalar_input_dim', (), [0]),
         ('index_fill', (), (0, torch.tensor(0, dtype=torch.int64), 2), 'scalar_both_dim', (), [0]),
+        # @nocommit requires supporting non-floats
+        # ('index_max', (S, S), (0, index_variable(2, S), (2, S)), 'dim', (), [0]),
+        # ('index_max', (), (0, torch.tensor([0], dtype=torch.int64), (1,)), 'scalar_input_dim', (), [0]),
+        # ('index_max', (), (0, torch.tensor(0, dtype=torch.int64), ()), 'scalar_all_dim', (), [0]),
         ('inverse', lambda: random_fullrank_matrix_distinct_singular_value(S), NO_ARGS, '', (), NO_ARGS, [skipIfNoLapack]),
         ('inverse', lambda: random_fullrank_matrix_distinct_singular_value(S, 2, 3),
          NO_ARGS, 'batched', (), NO_ARGS, [skipIfNoLapack]),

--- a/test/common_nn.py
+++ b/test/common_nn.py
@@ -1128,6 +1128,14 @@ new_module_tests = [
         desc='3d_no_elementwise_affine',
     ),
     dict(
+        module_name='LayerNorm',
+        constructor_args=([5], 1e-3),
+        input_size=(0, 5),
+        cudnn=True,
+        check_eval=True,
+        desc='1d_empty_elementwise_affine',
+    ),
+    dict(
         module_name='GroupNorm',
         constructor_args=(3, 6, 1e-3),
         input_size=(4, 6, 5),

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -11267,6 +11267,7 @@ class TestTorchDeviceType(TestCase):
 
         self.assertEqual((0, 0), fn(torch.addmm, (0, 0), (0, 0), (0, 0)).shape)
         self.assertEqual((5, 6), fn(torch.addmm, (5, 6), (5, 0), (0, 6)).shape)
+        self.assertEqual((0, 1), fn(torch.addmm, (1, ), (0, 17), (17, 1)).shape)
 
         # mv, addmv
         self.assertEqual((0,), fn(torch.mv, (0, 0), (0,)).shape)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -397,6 +397,11 @@
   source: grad.index_select(dim, index)
   index: non_differentiable
 
+- name: index_max(Tensor self, int dim, Tensor index, Tensor source) -> Tensor
+  self: grad * (result == self)
+  source: grad.index_select(dim, index) * (result.index_select(dim, index) == source)
+  index: non_differentiable
+
 - name: index_copy_(Tensor(a!) self, int dim, Tensor index, Tensor source) -> Tensor(a!)
   self: grad.clone().index_fill_(dim, index, 0)
   source: grad.index_select(dim, index)

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -1353,6 +1353,13 @@ Args:
     accumulate (bool): whether to accumulate into self
 """)
 
+add_docstr_all('index_max_',
+               r"""
+index_max_(dim, index, tensor) -> Tensor
+
+@nocommit
+""")
+
 add_docstr_all('index_put',
                r"""
 index_put(indices, value, accumulate=False) -> Tensor
@@ -3339,6 +3346,13 @@ add_docstr_all('index_fill',
 index_fill(dim, index, value) -> Tensor
 
 Out-of-place version of :meth:`torch.Tensor.index_fill_`
+""")
+
+add_docstr_all('index_max',
+               r"""
+index_max(dim, index, tensor) -> Tensor
+
+Out-of-place version of :meth:`torch.Tensor.index_max_`
 """)
 
 add_docstr_all('scatter',


### PR DESCRIPTION
Summary:
Handling of empty example was giving a cuda error.
Adding getLastError check to make sure cuda errors are attributed to the
correct function (instead of currently it was attributing the error to the next
cuda operator).
Added special case for batch-size zero, also added to cpu to keep things
consistent.

Test Plan: test included

Differential Revision: D18085429

