### PR TITLE
Devirtualize AutogradMeta.

### DIFF
--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -21,6 +21,9 @@
 
 namespace torch {
 namespace autograd {
+
+AutogradMeta::~AutogradMeta() = default;
+
 AutogradMeta::AutogradMeta(at::TensorImpl* self_impl, bool requires_grad, Edge gradient_edge) {
   grad_fn_ = std::move(gradient_edge.function);
   requires_grad_ = false;

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -87,7 +87,7 @@ using Variable = at::Tensor;
 /// Each `Variable` has one unique `AutogradMeta` struct, which stores autograd
 /// metadata fields that are necessary for tracking the Variable's autograd history.
 
-struct TORCH_API AutogradMeta : public c10::AutogradMetaInterface {
+struct TORCH_API AutogradMeta {
   std::string name_;
 
   Variable grad_;
@@ -116,23 +116,24 @@ struct TORCH_API AutogradMeta : public c10::AutogradMetaInterface {
   /// Sets the `requires_grad` property of `Variable`. This should be true for
   /// leaf variables that want to accumulate gradients, and false for all other
   /// variables.
-  void set_requires_grad(bool requires_grad, at::TensorImpl* self_impl) override {
+  void set_requires_grad(bool requires_grad, at::TensorImpl* self_impl) {
     TORCH_CHECK(
       !requires_grad || at::isFloatingType(at::typeMetaToScalarType(self_impl->dtype())),
       "Only Tensors of floating point dtype can require gradients");
     requires_grad_ = requires_grad;
   }
 
-  bool requires_grad() const override {
+  // TODO: devirtualize this guy
+  virtual bool requires_grad() const {
     return requires_grad_ || grad_fn_;
   }
 
   /// Accesses the gradient `Variable` of this `Variable`.
-  Variable& grad() override {
+  Variable& grad() {
     return grad_;
   }
 
-  const Variable& grad() const override {
+  const Variable& grad() const {
     return grad_;
   }
 

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -88,6 +88,8 @@ using Variable = at::Tensor;
 /// metadata fields that are necessary for tracking the Variable's autograd history.
 
 struct TORCH_API AutogradMeta {
+  virtual ~AutogradMeta();
+
   std::string name_;
 
   Variable grad_;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #28543 Test TensorTypeSet instead of autograd_meta_ for variable-ness.
* **#28526 Devirtualize AutogradMeta.**
* #28582 Merge libc10{,_cuda,_hip}.so libraries into libtorch.so
* #28554 [DO NOT MERGE] Test with companion builder patch
* #28287 Merge Tensor and Variable types.
* #28282 Unfriend Variable factory functions.
* #28581 Don't clobber pytorch image with libtorch build.

Now that torch/csrc/ and c10/ get linked into the same library, I can now
reference autograd code directly from TensorImpl.  That means I don't need
a virtual interface for AutogradMeta.  Delete it and replace it with direct
accesses from the C++ file (cannot put them inline, since AutogradMeta
is still an *incomplete* type at the time we are defining TensorImpl).

Note that this arrangement, where AutogradMeta is defined after Tensor,
is the ONLY arrangement that works, under the constraint that Tensor::grad()
returns a Tensor& reference.  To implement this interface, we must store
an honest-to-goodness copy of Tensor in AutogradMeta.

One subtlety when dealing with AutogradMeta as an incomplete type is that
the *destructor* must be defined out-of-line (since the destructor for
unique_ptr<AutogradMeta> requires a complete type!)  I was also surprised
to find that the move constructor for unique_ptr also requires complete types.

One thing I didn't touch, is that AutogradMeta::requires_grad() is still virtual.
This is because the implementation differs on its view subclass.  I'm not really
sure the class hierarchy here is buying us all that much, but that's for another
day.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>