### PR TITLE
Cleaning Up DistAutogradContext after set Timeout

### DIFF
--- a/test/common_distributed.py
+++ b/test/common_distributed.py
@@ -204,9 +204,6 @@ class MultiProcessTestCase(TestCase):
         start_time = time.time()
         for p in self.processes:
             p.join(timeout)
-        for i,p in enumerate(self.processes):
-            print('Process {} exited with exit code {} '.format(i,
-              p.exitcode))
         elapsed_time = time.time() - start_time
         if fn in self.skip_return_code_checks:
             self._check_no_test_errors(elapsed_time)

--- a/test/common_distributed.py
+++ b/test/common_distributed.py
@@ -204,6 +204,9 @@ class MultiProcessTestCase(TestCase):
         start_time = time.time()
         for p in self.processes:
             p.join(timeout)
+        for i,p in enumerate(self.processes):
+            print('Process {} exited with exit code {} '.format(i,
+              p.exitcode))
         elapsed_time = time.time() - start_time
         if fn in self.skip_return_code_checks:
             self._check_no_test_errors(elapsed_time)

--- a/test/dist_autograd_test.py
+++ b/test/dist_autograd_test.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import time
 import unittest
 import sys
+import datetime
 
 import torch
 import torch.distributed as dist
@@ -715,7 +716,8 @@ class DistAutogradTest(object):
     @dist_init(clean_shutdown=False)
     def test_context_cleanup_timeout(self):
         with dist_autograd.context() as context_id:
-            dist_autograd._setContextCleanupTimeout(2)
+            timeout = datetime.timedelta(seconds=2)
+            dist_autograd._setContextCleanupTimeout(timeout)
             t1 = torch.rand((3, 3), requires_grad=True)
             t2 = torch.rand((3, 3), requires_grad=True)
 

--- a/test/dist_autograd_test.py
+++ b/test/dist_autograd_test.py
@@ -725,15 +725,14 @@ class DistAutogradTest(object):
             #                        args=(t1, t2))
             #     rpc.rpc_sync("worker{}".format(dst_rank), _store_context_id,
             #         args=(context_id,))
-            time.sleep(20);
+            time.sleep(5);
             # if self.rank == 0:
             #     sys.exit(0)
 
             print(context_id)
             with self.assertRaises(RuntimeError):
                 dist_autograd._retrieve_context(context_id)
-            # success = _all_contexts_cleaned_up(num_contexts=len(dst_ranks))
-            # self.assertTrue(success)
+            print("worked")
 
     @dist_init(setup_model_parallel=True)
     def test_backward_without_context(self):

--- a/test/dist_autograd_test.py
+++ b/test/dist_autograd_test.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import time
 import unittest
-import sys
 
 import torch
 import torch.distributed as dist
@@ -462,7 +461,6 @@ class DistAutogradTest(object):
                 ret = rpc.rpc_sync("worker{}".format(dst_rank), torch.add, args=(t1, t2))
                 rpc.rpc_sync("worker{}".format(dst_rank), _set_rpc_done, args=(context_id, 1))
         # the thread's context id should be cleaned up
-        print(context_id)
         with self.assertRaises(RuntimeError):
             dist_autograd._retrieve_context(context_id)
         # check that all contexts have been cleaned up.

--- a/test/dist_autograd_test.py
+++ b/test/dist_autograd_test.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import time
 import unittest
+import sys
 
 import torch
 import torch.distributed as dist
@@ -712,7 +713,7 @@ class DistAutogradTest(object):
                 # Exit all other nodes.
                 pass
 
-    @dist_init
+    @dist_init(clean_shutdown=False)
     def test_context_cleanup_timeout(self):
         global known_context_ids
         dst_ranks = {rank for rank in range(self.world_size) if rank != self.rank}
@@ -720,19 +721,14 @@ class DistAutogradTest(object):
             t1 = torch.rand((3, 3), requires_grad=True)
             t2 = torch.rand((3, 3), requires_grad=True)
 
-            # for dst_rank in dst_ranks:
-            #     res = rpc.rpc_sync('worker{}'.format(self._next_rank()), torch.add,
-            #                        args=(t1, t2))
-            #     rpc.rpc_sync("worker{}".format(dst_rank), _store_context_id,
-            #         args=(context_id,))
-            time.sleep(5);
-            # if self.rank == 0:
-            #     sys.exit(0)
-
-            print(context_id)
-            with self.assertRaises(RuntimeError):
-                dist_autograd._retrieve_context(context_id)
-            print("worked")
+            time.sleep(10);
+            if self.rank == 2:
+                pass
+            else:
+                print(context_id)
+                with self.assertRaises(RuntimeError):
+                    dist_autograd._retrieve_context(context_id)
+                print("worked")
 
     @dist_init(setup_model_parallel=True)
     def test_backward_without_context(self):

--- a/test/dist_autograd_test.py
+++ b/test/dist_autograd_test.py
@@ -461,6 +461,7 @@ class DistAutogradTest(object):
                 ret = rpc.rpc_sync("worker{}".format(dst_rank), torch.add, args=(t1, t2))
                 rpc.rpc_sync("worker{}".format(dst_rank), _set_rpc_done, args=(context_id, 1))
         # the thread's context id should be cleaned up
+        print(context_id)
         with self.assertRaises(RuntimeError):
             dist_autograd._retrieve_context(context_id)
         # check that all contexts have been cleaned up.
@@ -719,17 +720,18 @@ class DistAutogradTest(object):
             t1 = torch.rand((3, 3), requires_grad=True)
             t2 = torch.rand((3, 3), requires_grad=True)
 
-            for dst_rank in dst_ranks:
-                res = rpc.rpc_sync('worker{}'.format(self._next_rank()), torch.add,
-                                   args=(t1, t2))
-                rpc.rpc_sync("worker{}".format(dst_rank), _store_context_id,
-                    args=(context_id,))
-            time.sleep(5);
+            # for dst_rank in dst_ranks:
+            #     res = rpc.rpc_sync('worker{}'.format(self._next_rank()), torch.add,
+            #                        args=(t1, t2))
+            #     rpc.rpc_sync("worker{}".format(dst_rank), _store_context_id,
+            #         args=(context_id,))
+            time.sleep(20);
             # if self.rank == 0:
             #     sys.exit(0)
 
-            # with self.assertRaises(RuntimeError):
-            dist_autograd._retrieve_context(context_id)
+            print(context_id)
+            with self.assertRaises(RuntimeError):
+                dist_autograd._retrieve_context(context_id)
             # success = _all_contexts_cleaned_up(num_contexts=len(dst_ranks))
             # self.assertTrue(success)
 

--- a/test/dist_autograd_test.py
+++ b/test/dist_autograd_test.py
@@ -721,7 +721,7 @@ class DistAutogradTest(object):
             t1 = torch.rand((3, 3), requires_grad=True)
             t2 = torch.rand((3, 3), requires_grad=True)
 
-            time.sleep(10)
+            time.sleep(15)
             # We let node 2 fail and ensure the contexts on the other nodes are
             # cleaned up after the timeout.
             if self.rank == 2:

--- a/test/dist_autograd_test.py
+++ b/test/dist_autograd_test.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import time
 import unittest
+import sys
 
 import torch
 import torch.distributed as dist
@@ -461,6 +462,7 @@ class DistAutogradTest(object):
                 ret = rpc.rpc_sync("worker{}".format(dst_rank), torch.add, args=(t1, t2))
                 rpc.rpc_sync("worker{}".format(dst_rank), _set_rpc_done, args=(context_id, 1))
         # the thread's context id should be cleaned up
+        print(context_id)
         with self.assertRaises(RuntimeError):
             dist_autograd._retrieve_context(context_id)
         # check that all contexts have been cleaned up.
@@ -719,12 +721,14 @@ class DistAutogradTest(object):
             t1 = torch.rand((3, 3), requires_grad=True)
             t2 = torch.rand((3, 3), requires_grad=True)
 
-            time.sleep(300);
+            time.sleep(390);
             if self.rank == 2:
                 pass
             else:
+                print(context_id)
                 with self.assertRaises(RuntimeError):
                     dist_autograd._retrieve_context(context_id)
+                print("worked")
 
     @dist_init(setup_model_parallel=True)
     def test_backward_without_context(self):

--- a/test/dist_autograd_test.py
+++ b/test/dist_autograd_test.py
@@ -721,7 +721,7 @@ class DistAutogradTest(object):
             t1 = torch.rand((3, 3), requires_grad=True)
             t2 = torch.rand((3, 3), requires_grad=True)
 
-            time.sleep(390);
+            time.sleep(10)
             if self.rank == 2:
                 pass
             else:

--- a/test/dist_autograd_test.py
+++ b/test/dist_autograd_test.py
@@ -718,6 +718,7 @@ class DistAutogradTest(object):
         global known_context_ids
         dst_ranks = {rank for rank in range(self.world_size) if rank != self.rank}
         with dist_autograd.context() as context_id:
+            dist_autograd._setContextCleanupTimeout(2)
             t1 = torch.rand((3, 3), requires_grad=True)
             t2 = torch.rand((3, 3), requires_grad=True)
 

--- a/test/dist_autograd_test.py
+++ b/test/dist_autograd_test.py
@@ -462,7 +462,6 @@ class DistAutogradTest(object):
                 ret = rpc.rpc_sync("worker{}".format(dst_rank), torch.add, args=(t1, t2))
                 rpc.rpc_sync("worker{}".format(dst_rank), _set_rpc_done, args=(context_id, 1))
         # the thread's context id should be cleaned up
-        print(context_id)
         with self.assertRaises(RuntimeError):
             dist_autograd._retrieve_context(context_id)
         # check that all contexts have been cleaned up.
@@ -724,10 +723,8 @@ class DistAutogradTest(object):
             # We let node 2 fail and ensure the contexts on the other nodes are
             # cleaned up after the timeout.
             if self.rank != 2:
-                print(context_id)
                 with self.assertRaisesRegex(RuntimeError, "Could not find autograd context with id: "):
                     dist_autograd._retrieve_context(context_id)
-                print("worked")
 
     @dist_init(setup_model_parallel=True)
     def test_backward_without_context(self):

--- a/test/dist_autograd_test.py
+++ b/test/dist_autograd_test.py
@@ -721,14 +721,12 @@ class DistAutogradTest(object):
             t1 = torch.rand((3, 3), requires_grad=True)
             t2 = torch.rand((3, 3), requires_grad=True)
 
-            time.sleep(390);
+            time.sleep(300);
             if self.rank == 2:
                 pass
             else:
-                print(context_id)
                 with self.assertRaises(RuntimeError):
                     dist_autograd._retrieve_context(context_id)
-                print("worked")
 
     @dist_init(setup_model_parallel=True)
     def test_backward_without_context(self):

--- a/test/dist_autograd_test.py
+++ b/test/dist_autograd_test.py
@@ -721,7 +721,7 @@ class DistAutogradTest(object):
             t1 = torch.rand((3, 3), requires_grad=True)
             t2 = torch.rand((3, 3), requires_grad=True)
 
-            time.sleep(10);
+            time.sleep(390);
             if self.rank == 2:
                 pass
             else:

--- a/test/dist_autograd_test.py
+++ b/test/dist_autograd_test.py
@@ -722,6 +722,8 @@ class DistAutogradTest(object):
             t2 = torch.rand((3, 3), requires_grad=True)
 
             time.sleep(10)
+            # We let node 2 fail and ensure the contexts on the other nodes are
+            # cleaned up after the timeout.
             if self.rank == 2:
                 pass
             else:

--- a/torch/csrc/distributed/autograd/context/dist_autograd_container.cpp
+++ b/torch/csrc/distributed/autograd/context/dist_autograd_container.cpp
@@ -27,7 +27,6 @@ DistAutogradContainer::DistAutogradContainer()
       max_id_(0) {
   terminateWatchdog_.store(false);
   cleanupWatchdogThread_ = std::thread(&DistAutogradContainer::cleanupContextWatchdog, this);
-  std::chrono::time_point<std::chrono::system_clock> creation_time = std::chrono::system_clock::now(); 
 }
 
 DistAutogradContainer::~DistAutogradContainer() {
@@ -92,7 +91,6 @@ DistAutogradContext& DistAutogradContainer::getOrCreateContext(
                           std::forward_as_tuple(context_id),
                           std::forward_as_tuple(context_id))
                       .first->second;
-  context_queue_.push(std::make_tuple(std::chrono::system_clock::now(), context_id));
   return context;
 }
 
@@ -115,7 +113,6 @@ const DistAutogradContext& DistAutogradContainer::newContext() {
                           std::forward_as_tuple(next_context_id_),
                           std::forward_as_tuple(next_context_id_))
                       .first->second;
-  context_queue_.push(std::make_tuple(std::chrono::system_clock::now(), next_context_id_));
   current_context_id_ = next_context_id_++;
   return context;
 }
@@ -135,8 +132,7 @@ DistAutogradContext& DistAutogradContainer::currentContext() {
   TORCH_CHECK(
       it != autograd_context_.end(),
       "Couldn't find autograd context "
-      "data for current autograd context id."
-      "Worker Id: ", getWorkerId());
+      "data for current autograd context id.");
   return it->second;
 }
 

--- a/torch/csrc/distributed/autograd/context/dist_autograd_container.cpp
+++ b/torch/csrc/distributed/autograd/context/dist_autograd_container.cpp
@@ -132,7 +132,7 @@ DistAutogradContext& DistAutogradContainer::currentContext() {
   TORCH_CHECK(
       it != autograd_context_.end(),
       "Couldn't find autograd context "
-      "data for current autograd context id.");
+      "data for current autograd context id");
   return it->second;
 }
 

--- a/torch/csrc/distributed/autograd/context/dist_autograd_container.cpp
+++ b/torch/csrc/distributed/autograd/context/dist_autograd_container.cpp
@@ -9,7 +9,7 @@ namespace autograd {
 constexpr int kAutoIncrementBits = 48;
 constexpr int64_t kAutoIncrementMask = (1LL << kAutoIncrementBits) - 1;
 constexpr int kMaxWorkerId = 65535;
-const std::chrono::duration<double> kContextTimeout = std::chrono::seconds(2);
+const std::chrono::duration<double> kContextTimeout = std::chrono::seconds(200);
 
 constexpr int64_t kInvalidContextId = -1;
 

--- a/torch/csrc/distributed/autograd/context/dist_autograd_container.cpp
+++ b/torch/csrc/distributed/autograd/context/dist_autograd_container.cpp
@@ -208,59 +208,6 @@ void DistAutogradContainer::cleanupContextWatchdog() {
   }
 }
 
-void DistAutogradContainer::testercleanupContextWatchdog() {
-  std::lock_guard<std::mutex> guard(autograd_context_lock_);
-  LOG(ERROR) << getWorkerId() << "- scheduled again!\n";
-  /* while (true) { */
-  std::this_thread::sleep_for(kContextTimeout);
-  while (!autograd_context_.empty()) {
-    LOG(ERROR) << getWorkerId() << "- entered the loop!\n";
-    LOG(ERROR) << getWorkerId() << "- queue size is " << autograd_context_.size() << "\n";
-    /* std::chrono::time_point<std::chrono::system_clock> now = std::chrono::system_clock::now(); */
-    /* auto diff = std::chrono::duration_cast<std::chrono::seconds>(now - std::get<0>(context_queue_.front())); */
-    /* auto diff = std::chrono::duration_cast<std::chrono::seconds>(now - creation_time); */
-    /* LOG(ERROR) << getWorkerId() << "- time since context creation: " << diff.count() << "\n"; */
-    /* LOG(ERROR) << kContextTimeout.count() << "\n"; */
-    /* while (std::chrono::system_clock::now() - std::get<0>(context_queue_.front()) >= kContextTimeout) { */
-    /* while (std::chrono::system_clock::now() - creation_time >= kContextTimeout) { */
-      LOG(ERROR) << getWorkerId() << "- cleared timeout!\n";
-      /* if (autograd_context_.find(std::get<1>(context_queue_.front())) == autograd_context_.end()) { */
-      /*   LOG(ERROR) << "messed up. " << std::get<1>(context_queue_.front()) << " not in map.\n"; */
-      /* } else { */
-      /*   LOG(ERROR) << "hello\n"; */
-      /* } */
-      /* for (auto& pair : autograd_context_) { */
-      /*   LOG(ERROR) << pair.first << "\n"; */
-      /* } */
-      for (auto& pair : autograd_context_) {
-        /* releaseContext(pair.second.contextId()); */
-        LOG(ERROR) << "just in case " << pair.first << "\n";
-        /* TORCH_CHECK( */
-        /*     autograd_context_.find(context_id) != autograd_context_.end(), */
-        /*     "Could not find autograd context with id: ", */
-        /*     context_id); */
-
-        if (autograd_context_.find(pair.first) != autograd_context_.end()) {
-          sendReleaseContextRpc(pair.first);
-          eraseContextIdAndReset(pair.first);
-        } else {
-          LOG(ERROR) << getWorkerId() << "- couldn't find context id: " << pair.first << "\n";
-        }
-        LOG(ERROR) << getWorkerId() << "- queue size post-deletion is " << autograd_context_.size() << "\n";
-        if (autograd_context_.size() == 0) {
-          LOG(ERROR) << getWorkerId() << " is exiting!!\n";
-          return;
-        }
-      }
-      /* releaseContext(std::get<1>(context_queue_.front())); */
-      /* context_queue_.pop(); */
-      /* if (context_queue_.empty()) { */
-      /*   return; */
-      /* } */
-    /* } */
-  }
-}
-
 DistAutogradContext& DistAutogradContainer::retrieveContext(
     int64_t context_id) {
   std::lock_guard<std::mutex> guard(autograd_context_lock_);

--- a/torch/csrc/distributed/autograd/context/dist_autograd_container.cpp
+++ b/torch/csrc/distributed/autograd/context/dist_autograd_container.cpp
@@ -196,24 +196,23 @@ void DistAutogradContainer::eraseContextIdAndReset(int64_t context_id) {
 }
 
 void DistAutogradContainer::cleanupContextWatchdog() {
-  LOG(ERROR) << getWorkerId() << "- scheduled again! watchdog: " << terminateWatchdog_.load() <<  "\n";
-  std::this_thread::sleep_for(kContextTimeout);
+  /* LOG(ERROR) << getWorkerId() << "- scheduled again! watchdog: " << terminateWatchdog_.load() <<  "\n"; */
+  /* std::this_thread::sleep_for(kContextTimeout); */
   while (!terminateWatchdog_.load()) {
     {
       std::lock_guard<std::mutex> guard(autograd_context_lock_);
-      LOG(ERROR) << getWorkerId() << "- got inside\n";
-      if (autograd_context_.empty()) {
-        LOG(ERROR) << getWorkerId() << "- nothing to loop thru\n";
-      }
+      /* LOG(ERROR) << getWorkerId() << "- got inside\n"; */
+      /* if (autograd_context_.empty()) { */
+      /*   LOG(ERROR) << getWorkerId() << "- nothing to loop thru\n"; */
+      /* } */
       for (auto it = autograd_context_.begin(); it != autograd_context_.end();) {
         auto now = std::chrono::high_resolution_clock::now();
-        LOG(ERROR) << getWorkerId() << "- candidate id " << it->first << "\n";
+        /* LOG(ERROR) << getWorkerId() << "- candidate id " << it->first << "\n"; */
         auto diff = std::chrono::duration_cast<std::chrono::seconds>(now - std::get<1>(it->second));
-        LOG(ERROR) << getWorkerId() << "- curr time: " << diff.count() << "\n";
-        /* LOG(ERROR) << getWorkerId() << "- " << kContextTimeout.count() << "\n"; */
+        /* LOG(ERROR) << getWorkerId() << "- curr time: " << diff.count() << "\n"; */
         if (diff >= kContextTimeout) { // && autograd_context_.find(pair.first) != autograd_context_.end()) {
           // TODO: see if you can just invoke destructor
-          LOG(ERROR) << getWorkerId() << "- cleared timeout!\n";
+          /* LOG(ERROR) << getWorkerId() << "- cleared timeout!\n"; */
           LOG(ERROR) << getWorkerId() << "- DELETING " << it->first << "\n";
           /* eraseContextIdAndReset(pair.first); */
           auto context_id = it->first;
@@ -227,13 +226,19 @@ void DistAutogradContainer::cleanupContextWatchdog() {
       }
     }
     // CV stuff
-    LOG(ERROR) << "Waiting for destruction\n";
-    std::unique_lock<std::mutex> guard(cleanupWatchdogCVMutex_);
-    cleanupWatchdogCV_.wait_for(
-        guard,
-        std::chrono::seconds(60),
-        [&]() -> bool { return terminateWatchdog_.load(); });
+    /* LOG(ERROR) << getWorkerId() << "- Waiting for destruction\n"; */
+    /* std::unique_lock<std::mutex> guard(cleanupWatchdogCVMutex_); */
+    /* cleanupWatchdogCV_.wait_for( */
+    /*     guard, */
+    /*     std::chrono::seconds(300), */
+    /*     [&]() -> bool { return terminateWatchdog_.load(); }); */
   }
+  LOG(ERROR) << getWorkerId() << "- Waiting for destruction\n";
+  std::unique_lock<std::mutex> guard(cleanupWatchdogCVMutex_);
+  cleanupWatchdogCV_.wait_for(
+      guard,
+      std::chrono::seconds(300),
+      [&]() -> bool { return terminateWatchdog_.load(); });
 }
 
 /* void DistAutogradContainer::cleanupContextWatchdog() { */

--- a/torch/csrc/distributed/autograd/context/dist_autograd_container.cpp
+++ b/torch/csrc/distributed/autograd/context/dist_autograd_container.cpp
@@ -9,7 +9,7 @@ namespace autograd {
 constexpr int kAutoIncrementBits = 48;
 constexpr int64_t kAutoIncrementMask = (1LL << kAutoIncrementBits) - 1;
 constexpr int kMaxWorkerId = 65535;
-const std::chrono::duration<double> kContextTimeout = std::chrono::seconds(60);
+const std::chrono::duration<double> kContextTimeout = std::chrono::seconds(200);
 
 constexpr int64_t kInvalidContextId = -1;
 
@@ -27,11 +27,15 @@ DistAutogradContainer::DistAutogradContainer()
       max_id_(0) {
   terminateWatchdog_.store(false);
   cleanupWatchdogThread_ = std::thread(&DistAutogradContainer::cleanupContextWatchdog, this);
+  LOG(ERROR) << getWorkerId() << "- watchdog thread created\n";
+  std::chrono::time_point<std::chrono::system_clock> creation_time = std::chrono::system_clock::now(); 
 }
 
 DistAutogradContainer::~DistAutogradContainer() {
+  LOG(ERROR) << getWorkerId() << "- destructor called\n";
   terminateWatchdog_.store(true);
   cleanupWatchdogThread_.join();
+  LOG(ERROR) << getWorkerId() << "- thread joined\n";
 }
 DistAutogradContainer& DistAutogradContainer::init(int64_t worker_id) {
   std::lock_guard<std::mutex> guard(dist_container_init_lock_);
@@ -91,6 +95,8 @@ DistAutogradContext& DistAutogradContainer::getOrCreateContext(
                           std::forward_as_tuple(context_id),
                           std::forward_as_tuple(context_id))
                       .first->second;
+  context_queue_.push(std::make_tuple(std::chrono::system_clock::now(), context_id));
+  LOG(ERROR) << getWorkerId() << "- insertion, new size: " << context_queue_.size() << " context_id: " << context_id << " getcreate\n";
   return context;
 }
 
@@ -113,6 +119,8 @@ const DistAutogradContext& DistAutogradContainer::newContext() {
                           std::forward_as_tuple(next_context_id_),
                           std::forward_as_tuple(next_context_id_))
                       .first->second;
+  context_queue_.push(std::make_tuple(std::chrono::system_clock::now(), next_context_id_));
+  LOG(ERROR) << getWorkerId() << "- insertion, new size: " << context_queue_.size() << " context_id: " << next_context_id_ << " insert\n";
   current_context_id_ = next_context_id_++;
   return context;
 }
@@ -132,7 +140,8 @@ DistAutogradContext& DistAutogradContainer::currentContext() {
   TORCH_CHECK(
       it != autograd_context_.end(),
       "Couldn't find autograd context "
-      "data for current autograd context id");
+      "data for current autograd context id."
+      "Worker Id: ", getWorkerId());
   return it->second;
 }
 
@@ -181,13 +190,16 @@ void DistAutogradContainer::eraseContextIdAndReset(int64_t context_id) {
 }
 
 void DistAutogradContainer::cleanupContextWatchdog() {
+  LOG(ERROR) << getWorkerId() << "- scheduled again!\n";
   std::this_thread::sleep_for(kContextTimeout);
   while(!terminateWatchdog_.load()) {
     std::lock_guard<std::mutex> guard(autograd_context_lock_);
     for (auto& pair : autograd_context_) {
       if (autograd_context_.find(pair.first) != autograd_context_.end()) { 
+        LOG(ERROR) << "just in case " << pair.first << "\n";
         sendReleaseContextRpc(pair.first);
         eraseContextIdAndReset(pair.first);
+        LOG(ERROR) << getWorkerId() << "- queue size post-deletion is " << autograd_context_.size() << "\n";
         if (autograd_context_.empty()) {
           return;
         }

--- a/torch/csrc/distributed/autograd/context/dist_autograd_container.cpp
+++ b/torch/csrc/distributed/autograd/context/dist_autograd_container.cpp
@@ -200,11 +200,12 @@ void DistAutogradContainer::cleanupContextWatchdog() {
       for (auto& pair : autograd_context_) {
         // TODO: see if you can just invoke destructor
         eraseContextIdAndReset(pair.first);
+        LOG(ERROR) << getWorkerId() << "- DELETING " << pair.first << "\n";
         /* std::chrono::time_point<std::chrono::system_clock> now = std::chrono::system_clock::now(); */ 
-        auto now = std::chrono::high_resolution_clock::now();
-        LOG(ERROR) << std::chrono::duration_cast<std::chrono::milliseconds>(now - creation_time).count() << "\n";
-        LOG(ERROR) << (now - creation_time).count() << "\n";
-        LOG(ERROR) << std::chrono::seconds(2).count() << "\n";
+        /* auto now = std::chrono::high_resolution_clock::now(); */
+        /* LOG(ERROR) << std::chrono::duration_cast<std::chrono::milliseconds>(now - creation_time).count() << "\n"; */
+        /* LOG(ERROR) << (now - creation_time).count() << "\n"; */
+        /* LOG(ERROR) << std::chrono::seconds(2).count() << "\n"; */
         LOG(ERROR) << getWorkerId() << "- queue size post-deletion is " << autograd_context_.size() << "\n";
       }
     }

--- a/torch/csrc/distributed/autograd/context/dist_autograd_container.cpp
+++ b/torch/csrc/distributed/autograd/context/dist_autograd_container.cpp
@@ -59,11 +59,11 @@ DistAutogradContainer& DistAutogradContainer::init(int64_t worker_id) {
   return container;
 }
 
-void DistAutogradContainer::setCleanupContextTimeout(int64_t newTimeout) {
+void DistAutogradContainer::setCleanupContextTimeout(std::chrono::seconds newTimeout) {
   TORCH_CHECK(
-      newTimeout >=0,
+      newTimeout >= std::chrono::seconds::zero(),
       "cleanupContextTimeout must be nonnegative");
-  cleanupContextTimeout = std::chrono::seconds(newTimeout);
+  cleanupContextTimeout = newTimeout;
 }
 
 DistAutogradContainer& DistAutogradContainer::getInstance() {

--- a/torch/csrc/distributed/autograd/context/dist_autograd_container.h
+++ b/torch/csrc/distributed/autograd/context/dist_autograd_container.h
@@ -2,6 +2,7 @@
 
 #include <mutex>
 #include <unordered_map>
+#include <chrono>
 
 #include <torch/csrc/distributed/autograd/context/dist_autograd_context.h>
 
@@ -96,6 +97,8 @@ class TORCH_API DistAutogradContainer {
   // function should be called with the lock.
   void eraseContextIdAndReset(int64_t context_id);
 
+  void cleanupContextWatchdog();
+
   // Auto incrementing context id used to identify unique autograd passes.
   // Initialized with the first 16 bits being the worker_id.
   int64_t next_context_id_;
@@ -105,6 +108,9 @@ class TORCH_API DistAutogradContainer {
 
   // Map from autograd_context_id to DistAutogradContext.
   std::unordered_map<int64_t, DistAutogradContext> autograd_context_;
+
+  // Queue to store DistAutogradContext pointers and their creation time.
+  std::queue<std::tuple<std::chrono::system_clock::time_point, int64_t>> context_queue_;
 
   // Whether or not the container has been initialized appropriately.
   bool initialized_;

--- a/torch/csrc/distributed/autograd/context/dist_autograd_container.h
+++ b/torch/csrc/distributed/autograd/context/dist_autograd_container.h
@@ -122,6 +122,11 @@ class TORCH_API DistAutogradContainer {
   // and worker_id_ are immutable.
   mutable std::mutex autograd_context_lock_;
 
+  void testercleanupContextWatchdog(); 
+
+  // Atomic var to control when the watchdog thread is killed.
+  std::atomic<bool> terminateWatchdog_;
+
   // Autograd message id to identify unique send/recv autograd function pairs.
   std::atomic<int64_t> next_autograd_message_id_;
 

--- a/torch/csrc/distributed/autograd/context/dist_autograd_container.h
+++ b/torch/csrc/distributed/autograd/context/dist_autograd_container.h
@@ -122,8 +122,6 @@ class TORCH_API DistAutogradContainer {
   // and worker_id_ are immutable.
   mutable std::mutex autograd_context_lock_;
 
-  void testercleanupContextWatchdog(); 
-
   // Atomic var to control when the watchdog thread is killed.
   std::atomic<bool> terminateWatchdog_;
 

--- a/torch/csrc/distributed/autograd/context/dist_autograd_container.h
+++ b/torch/csrc/distributed/autograd/context/dist_autograd_container.h
@@ -109,9 +109,6 @@ class TORCH_API DistAutogradContainer {
   // Map from autograd_context_id to DistAutogradContext.
   std::unordered_map<int64_t, DistAutogradContext> autograd_context_;
 
-  // Queue to store DistAutogradContext pointers and their creation time.
-  std::queue<std::tuple<std::chrono::time_point<std::chrono::system_clock>, int64_t>> context_queue_;
-
   // Thread running the cleanupContextWatchdog
   std::thread cleanupWatchdogThread_;
 
@@ -130,8 +127,6 @@ class TORCH_API DistAutogradContainer {
 
   // Maximum allowed value for autograd_context_id or autograd_message_id.
   int64_t max_id_;
-
-  std::chrono::time_point<std::chrono::system_clock> creation_time;
 };
 
 } // namespace autograd

--- a/torch/csrc/distributed/autograd/context/dist_autograd_container.h
+++ b/torch/csrc/distributed/autograd/context/dist_autograd_container.h
@@ -79,7 +79,7 @@ class TORCH_API DistAutogradContainer {
 
  private:
   DistAutogradContainer();
-  ~DistAutogradContainer() = default;
+  virtual ~DistAutogradContainer();
 
   DistAutogradContainer(const DistAutogradContainer&) = delete;
   DistAutogradContainer& operator=(const DistAutogradContainer&) = delete;
@@ -110,14 +110,17 @@ class TORCH_API DistAutogradContainer {
   std::unordered_map<int64_t, DistAutogradContext> autograd_context_;
 
   // Queue to store DistAutogradContext pointers and their creation time.
-  std::queue<std::tuple<std::chrono::system_clock::time_point, int64_t>> context_queue_;
+  std::queue<std::tuple<std::chrono::time_point<std::chrono::system_clock>, int64_t>> context_queue_;
+
+  // Thread running the cleanupContextWatchdog
+  std::thread cleanupWatchdogThread_;
 
   // Whether or not the container has been initialized appropriately.
   bool initialized_;
 
   // Lock to protect next_context_id_ and autograd_context map. initialized_
   // and worker_id_ are immutable.
-  mutable std::mutex autograd_context_lock_;
+  mutable std::recursive_mutex autograd_context_lock_;
 
   // Autograd message id to identify unique send/recv autograd function pairs.
   std::atomic<int64_t> next_autograd_message_id_;

--- a/torch/csrc/distributed/autograd/context/dist_autograd_container.h
+++ b/torch/csrc/distributed/autograd/context/dist_autograd_container.h
@@ -97,6 +97,7 @@ class TORCH_API DistAutogradContainer {
   // function should be called with the lock.
   void eraseContextIdAndReset(int64_t context_id);
 
+  // Sleeps for set timeout and then proceeds to release DistAutogradContexts
   void cleanupContextWatchdog();
 
   // Auto incrementing context id used to identify unique autograd passes.
@@ -119,7 +120,7 @@ class TORCH_API DistAutogradContainer {
   // and worker_id_ are immutable.
   mutable std::mutex autograd_context_lock_;
 
-  // Atomic var to control when the watchdog thread is killed.
+  // Atomic variable to control when the watchdog thread is killed.
   std::atomic<bool> terminateWatchdog_;
 
   // Autograd message id to identify unique send/recv autograd function pairs.

--- a/torch/csrc/distributed/autograd/context/dist_autograd_container.h
+++ b/torch/csrc/distributed/autograd/context/dist_autograd_container.h
@@ -120,13 +120,15 @@ class TORCH_API DistAutogradContainer {
 
   // Lock to protect next_context_id_ and autograd_context map. initialized_
   // and worker_id_ are immutable.
-  mutable std::recursive_mutex autograd_context_lock_;
+  mutable std::mutex autograd_context_lock_;
 
   // Autograd message id to identify unique send/recv autograd function pairs.
   std::atomic<int64_t> next_autograd_message_id_;
 
   // Maximum allowed value for autograd_context_id or autograd_message_id.
   int64_t max_id_;
+
+  std::chrono::time_point<std::chrono::system_clock> creation_time;
 };
 
 } // namespace autograd

--- a/torch/csrc/distributed/autograd/context/dist_autograd_container.h
+++ b/torch/csrc/distributed/autograd/context/dist_autograd_container.h
@@ -77,6 +77,7 @@ class TORCH_API DistAutogradContainer {
   // Clear current context id
   void clearCurrentContext();
 
+  // Sets the timeout after which DistAutogradContexts will be cleaned up
   void setCleanupContextTimeout(int64_t newTimeout);
 
  private:
@@ -118,10 +119,10 @@ class TORCH_API DistAutogradContainer {
   // Thread running the cleanupContextWatchdog
   std::thread cleanupWatchdogThread_;
 
-  // Condition Variable to control watchdog thread's wait time
+  // Condition Variable to control watchdog thread's wait time.
   std::condition_variable cleanupWatchdogCV_;
 
-  // CV Mutex
+  // Mutex for the cleanupWatchdog thread's condition variable.
   std::mutex cleanupWatchdogCVMutex_;
 
   // Whether or not the container has been initialized appropriately.
@@ -137,13 +138,12 @@ class TORCH_API DistAutogradContainer {
   // Autograd message id to identify unique send/recv autograd function pairs.
   std::atomic<int64_t> next_autograd_message_id_;
 
+  // Set Timeout after which watchdog thread will clean up
+  // DistAutogradContexts.
   std::chrono::duration<int64_t> cleanupContextTimeout;
 
   // Maximum allowed value for autograd_context_id or autograd_message_id.
   int64_t max_id_;
-
-  /* std::chrono::time_point<std::chrono::system_clock> creation_time; */
-  /* std::chrono::time_point<std::chrono::high_resolution_clock> creation_time; */
 };
 
 } // namespace autograd

--- a/torch/csrc/distributed/autograd/context/dist_autograd_container.h
+++ b/torch/csrc/distributed/autograd/context/dist_autograd_container.h
@@ -77,6 +77,8 @@ class TORCH_API DistAutogradContainer {
   // Clear current context id
   void clearCurrentContext();
 
+  void setCleanupContextTimeout(int64_t newTimeout);
+
  private:
   DistAutogradContainer();
   virtual ~DistAutogradContainer();
@@ -134,6 +136,8 @@ class TORCH_API DistAutogradContainer {
 
   // Autograd message id to identify unique send/recv autograd function pairs.
   std::atomic<int64_t> next_autograd_message_id_;
+
+  std::chrono::duration<int64_t> cleanupContextTimeout;
 
   // Maximum allowed value for autograd_context_id or autograd_message_id.
   int64_t max_id_;

--- a/torch/csrc/distributed/autograd/context/dist_autograd_container.h
+++ b/torch/csrc/distributed/autograd/context/dist_autograd_container.h
@@ -97,7 +97,6 @@ class TORCH_API DistAutogradContainer {
   // function should be called with the lock.
   void eraseContextIdAndReset(int64_t context_id);
 
-  // Sleeps for set timeout and then proceeds to release DistAutogradContexts
   void cleanupContextWatchdog();
 
   // Auto incrementing context id used to identify unique autograd passes.
@@ -110,6 +109,9 @@ class TORCH_API DistAutogradContainer {
   // Map from autograd_context_id to DistAutogradContext.
   std::unordered_map<int64_t, DistAutogradContext> autograd_context_;
 
+  // Queue to store DistAutogradContext pointers and their creation time.
+  std::queue<std::tuple<std::chrono::time_point<std::chrono::system_clock>, int64_t>> context_queue_;
+
   // Thread running the cleanupContextWatchdog
   std::thread cleanupWatchdogThread_;
 
@@ -120,7 +122,7 @@ class TORCH_API DistAutogradContainer {
   // and worker_id_ are immutable.
   mutable std::mutex autograd_context_lock_;
 
-  // Atomic variable to control when the watchdog thread is killed.
+  // Atomic var to control when the watchdog thread is killed.
   std::atomic<bool> terminateWatchdog_;
 
   // Autograd message id to identify unique send/recv autograd function pairs.
@@ -128,6 +130,8 @@ class TORCH_API DistAutogradContainer {
 
   // Maximum allowed value for autograd_context_id or autograd_message_id.
   int64_t max_id_;
+
+  std::chrono::time_point<std::chrono::system_clock> creation_time;
 };
 
 } // namespace autograd

--- a/torch/csrc/distributed/autograd/context/dist_autograd_container.h
+++ b/torch/csrc/distributed/autograd/context/dist_autograd_container.h
@@ -108,7 +108,7 @@ class TORCH_API DistAutogradContainer {
   int16_t worker_id_;
 
   // Map from autograd_context_id to DistAutogradContext.
-  std::unordered_map<int64_t, DistAutogradContext> autograd_context_;
+  std::unordered_map<int64_t, std::tuple<DistAutogradContext, std::chrono::time_point<std::chrono::high_resolution_clock>>> autograd_context_;
 
   // Queue to store DistAutogradContext pointers and their creation time.
   std::queue<std::tuple<std::chrono::time_point<std::chrono::system_clock>, int64_t>> context_queue_;
@@ -139,7 +139,7 @@ class TORCH_API DistAutogradContainer {
   int64_t max_id_;
 
   /* std::chrono::time_point<std::chrono::system_clock> creation_time; */
-  std::chrono::time_point<std::chrono::high_resolution_clock> creation_time;
+  /* std::chrono::time_point<std::chrono::high_resolution_clock> creation_time; */
 };
 
 } // namespace autograd

--- a/torch/csrc/distributed/autograd/context/dist_autograd_container.h
+++ b/torch/csrc/distributed/autograd/context/dist_autograd_container.h
@@ -78,7 +78,7 @@ class TORCH_API DistAutogradContainer {
   void clearCurrentContext();
 
   // Sets the timeout after which DistAutogradContexts will be cleaned up
-  void setCleanupContextTimeout(int64_t newTimeout);
+  void setCleanupContextTimeout(std::chrono::seconds newTimeout);
 
  private:
   DistAutogradContainer();

--- a/torch/csrc/distributed/autograd/context/dist_autograd_container.h
+++ b/torch/csrc/distributed/autograd/context/dist_autograd_container.h
@@ -97,6 +97,7 @@ class TORCH_API DistAutogradContainer {
   // function should be called with the lock.
   void eraseContextIdAndReset(int64_t context_id);
 
+  // Function that cleans up DistAutogradContexts when the timeout is up.
   void cleanupContextWatchdog();
 
   // Auto incrementing context id used to identify unique autograd passes.
@@ -115,6 +116,12 @@ class TORCH_API DistAutogradContainer {
   // Thread running the cleanupContextWatchdog
   std::thread cleanupWatchdogThread_;
 
+  // Condition Variable to control watchdog thread's wait time
+  std::condition_variable cleanupWatchdogCV_;
+
+  // CV Mutex
+  std::mutex cleanupWatchdogCVMutex_;
+
   // Whether or not the container has been initialized appropriately.
   bool initialized_;
 
@@ -131,7 +138,8 @@ class TORCH_API DistAutogradContainer {
   // Maximum allowed value for autograd_context_id or autograd_message_id.
   int64_t max_id_;
 
-  std::chrono::time_point<std::chrono::system_clock> creation_time;
+  /* std::chrono::time_point<std::chrono::system_clock> creation_time; */
+  std::chrono::time_point<std::chrono::high_resolution_clock> creation_time;
 };
 
 } // namespace autograd

--- a/torch/csrc/distributed/autograd/init.cpp
+++ b/torch/csrc/distributed/autograd/init.cpp
@@ -75,7 +75,7 @@ PyObject* dist_autograd_init(PyObject* /* unused */) {
   module.def(
       "_release_context",
       [](int64_t context_id) {
-        return DistAutogradContainer::getInstance().releaseContext(context_id);
+        return DistAutogradContainer::getInstance().releaseContextIfPresent(context_id);
       },
       py::call_guard<py::gil_scoped_release>());
 

--- a/torch/csrc/distributed/autograd/init.cpp
+++ b/torch/csrc/distributed/autograd/init.cpp
@@ -6,6 +6,7 @@
 #include <torch/csrc/utils/object_ptr.h>
 #include <torch/csrc/utils/pybind.h>
 #include <torch/types.h>
+#include <pybind11/chrono.h>
 
 namespace torch {
 namespace distributed {
@@ -85,7 +86,7 @@ PyObject* dist_autograd_init(PyObject* /* unused */) {
 
   module.def(
       "_setContextCleanupTimeout",
-      [](int64_t newTimeout) { DistAutogradContainer::getInstance().setCleanupContextTimeout(newTimeout); });
+      [](std::chrono::seconds newTimeout) { DistAutogradContainer::getInstance().setCleanupContextTimeout(newTimeout); });
 
   module.def(
       "_retrieve_context",

--- a/torch/csrc/distributed/autograd/init.cpp
+++ b/torch/csrc/distributed/autograd/init.cpp
@@ -84,6 +84,10 @@ PyObject* dist_autograd_init(PyObject* /* unused */) {
   });
 
   module.def(
+      "_setContextCleanupTimeout",
+      [](int64_t newTimeout) { DistAutogradContainer::getInstance().setCleanupContextTimeout(newTimeout); });
+
+  module.def(
       "_retrieve_context",
       [](int64_t context_id) -> const DistAutogradContext& {
         return DistAutogradContainer::getInstance().retrieveContext(context_id);


### PR DESCRIPTION
Addressing Issue #26379

Launches a background watchdog thread that sleeps for a set timeout and then releases all the `DistAutogradContext`s on each `DistAutogradContainer`. The test checks whether contexts are successfully cleaned up even if another node goes down. Borrows some code from #27940 to successfully complete tests even with node failures.

[bootcamp task]