### PR TITLE
[pytorch] Improve float pickling/unpickling speed.

### DIFF
--- a/torch/csrc/jit/pickler.cpp
+++ b/torch/csrc/jit/pickler.cpp
@@ -403,13 +403,8 @@ void Pickler::pushSpecializedList(
 }
 
 void Pickler::pushDouble(double value) {
-  AT_ASSERT(sizeof(double) == 8);
-  char* bytes = reinterpret_cast<char*>(&value);
-
   push<PickleOpCode>(PickleOpCode::BINFLOAT);
-  for (size_t i = 0; i < 8; ++i) {
-    push<uint8_t>(bytes[8 - i - 1]);
-  }
+  push<double>(swapDoubleEndian(value));
 }
 
 void Pickler::pushLong(const std::string& data) {

--- a/torch/csrc/jit/pickler.h
+++ b/torch/csrc/jit/pickler.h
@@ -266,5 +266,17 @@ uint64_t getStorageKey(const at::Tensor& tensor);
 // otherwise return false
 bool checkHasValidSetGetState(const std::shared_ptr<c10::ClassType>& cls);
 
+// Python pickle format is big endian.
+namespace {
+double swapDoubleEndian(double value) {
+  static_assert(sizeof(double) == 8, "double length");
+  double d;
+  const char* const bytes = reinterpret_cast<char*>(&value);
+  char* const out = reinterpret_cast<char*>(&d);
+  std::reverse_copy(bytes, bytes + sizeof(double), out);
+  return *reinterpret_cast<double*>(out);
+}
+}
+
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/unpickler.cpp
+++ b/torch/csrc/jit/unpickler.cpp
@@ -170,18 +170,7 @@ IValue Unpickler::parse_ivalue() {
 }
 
 double Unpickler::readFloat() {
-  AT_ASSERT(sizeof(double) == 8);
-  double big_endian = read<double>();
-  double little_endian;
-
-  // Pickle floats are big endian, so reverse the bytes
-  auto big_endian_ptr = reinterpret_cast<const char*>(&big_endian);
-  std::reverse_copy(
-      big_endian_ptr,
-      big_endian_ptr + sizeof(big_endian),
-      reinterpret_cast<char*>(&little_endian));
-
-  return little_endian;
+  return swapDoubleEndian(read<double>());
 }
 
 void Unpickler::run() {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#28529 [pytorch] Improve float pickling/unpickling speed.**

This change improves double pickling/unpickling in 1M double list
microbenchmark by roughly 40% for pickling and 8% for unpickling.

- For pickling, the main benefit is avoiding per-byte bounds checks, so
  we only bounds-check 2 times rather than 9 times.

- Why is unpickling faster with this approach? Isn't it basically the same code?
  Yeah, it should be the same. But, it's not. Looking at the objdump, GCC produces
  better code, and microbenchmarks are consistently better, when the byte
  swapping code is pulled out to a separate inlined function. Sigh.

- This change gives the minor added benefit of de-duping code between pickler/unpickler.
  Note: it is not faster to put the implementation in one .cpp, since inlining
  is basically necessary to get the pref boost.

- I also did try std::reverse, as well as expanding on the unrolled
   'out[i] = bytes[8 - i - 1]' for loop approach.
  std::reverse_copy seems best, and is unrolled in practice.

Differential Revision: [D18089481](https://our.internmc.facebook.com/intern/diff/D18089481/)