### PR TITLE
Fix compute_non_overlapping_and_dense()

### DIFF
--- a/aten/src/ATen/test/CMakeLists.txt
+++ b/aten/src/ATen/test/CMakeLists.txt
@@ -29,6 +29,7 @@ list(APPEND ATen_CPU_TEST_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/boxed_fallback_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/xla_tensor_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/tensor_iterator_test.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/memory_overlapping_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/cpu_generator_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/pow_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/variant_test.cpp)

--- a/aten/src/ATen/test/memory_overlapping_test.cpp
+++ b/aten/src/ATen/test/memory_overlapping_test.cpp
@@ -16,7 +16,7 @@ TEST(MemoryOverlapTest, TensorExpanded) {
 
 TEST(MemoryOverlapTest, ScalarExpanded) {
   for (auto size : sizes) {
-    Tensor t = at::ones({1}).expand(size);
+    Tensor t = at::tensor(1).expand(size);
     EXPECT_FALSE(t.is_contiguous());
     EXPECT_FALSE(t.is_non_overlapping_and_dense());
   }

--- a/aten/src/ATen/test/memory_overlapping_test.cpp
+++ b/aten/src/ATen/test/memory_overlapping_test.cpp
@@ -1,0 +1,73 @@
+#include <gtest/gtest.h>
+
+#include <ATen/ATen.h>
+
+using namespace at;
+
+std::vector<std::vector<int64_t>> sizes = {{1, 2, 3}, {1, 3, 2}, {2, 1, 3}, {3, 1, 2}, {3, 2, 1}, {2, 3, 1}};
+
+TEST(MemoryOverlapTest, TensorExpanded) {
+  for (auto size : sizes) {
+    Tensor t = at::ones({1}).expand(size);
+    EXPECT_FALSE(t.is_contiguous());
+    EXPECT_FALSE(t.is_non_overlapping_and_dense());
+  }
+}
+
+TEST(MemoryOverlapTest, ScalarExpanded) {
+  for (auto size : sizes) {
+    Tensor t = at::ones({1}).expand(size);
+    EXPECT_FALSE(t.is_contiguous());
+    EXPECT_FALSE(t.is_non_overlapping_and_dense());
+  }
+}
+
+TEST(MemoryOverlapTest, NonContiguousTensor) {
+  for (auto size : sizes) {
+    Tensor t = at::rand(size).transpose(1, 2).transpose(0, 2);
+    if (!t.is_contiguous()) {
+      EXPECT_TRUE(t.is_non_overlapping_and_dense());
+    }
+  }
+}
+
+TEST(MemoryOverlapTest, NonContiguousExpandedTensor) {
+  for (auto size : sizes) {
+    Tensor t = at::rand(size).transpose(1, 2).transpose(0, 2);
+    if (!t.is_contiguous()) {
+      for (auto size_to_add : {1, 2, 3, 4}) {
+        auto transpose_size = t.sizes().vec();
+        std::vector<int64_t> expanded_size(transpose_size);
+        expanded_size.insert(expanded_size.begin(), size_to_add);
+        auto expanded = t.expand(expanded_size);
+        EXPECT_FALSE(t.is_contiguous());
+        if (size_to_add == 1) {
+          EXPECT_TRUE(expanded.is_non_overlapping_and_dense());
+        } else {
+          EXPECT_FALSE(expanded.is_non_overlapping_and_dense());
+        }
+      }
+    }
+  }
+}
+
+TEST(MemoryOverlapTest, ContiguousTensor) {
+  for (auto size : sizes) {
+    Tensor t = at::rand(size);
+    EXPECT_TRUE(t.is_contiguous());
+    EXPECT_TRUE(t.is_non_overlapping_and_dense());
+  }
+}
+
+TEST(MemoryOverlapTest, ContiguousExpandedTensor) {
+  for (auto size : sizes) {
+    Tensor t = at::rand(size);
+    for (auto size_to_add : {1, 2, 3, 4}) {
+      std::vector<int64_t> expanded_size(size);
+      expanded_size.insert(expanded_size.begin(), size_to_add);
+      auto expanded = t.expand(expanded_size);
+      EXPECT_TRUE(t.is_contiguous());
+      EXPECT_TRUE(t.is_non_overlapping_and_dense());
+    }
+  }
+}

--- a/c10/core/TensorImpl.cpp
+++ b/c10/core/TensorImpl.cpp
@@ -143,6 +143,8 @@ bool TensorImpl::compute_non_overlapping_and_dense() const {
   std::sort(perm.begin(), perm.end(), [&](int64_t a, int64_t b) {
       if (sizes_[a] < 2) {
         return false;
+      } else if (sizes_[b] < 2) {
+        return true;
       }
       return strides_[a] < strides_[b];
   });


### PR DESCRIPTION
There are some cases when compute_non_overlapping_and_dense() doesn't work properly:
Example:
```
Tensor t = at::tensor(1).expand({1, 3, 2});
EXPECT_FALSE(t.is_contiguous());
EXPECT_FALSE(t.is_non_overlapping_and_dense()); //FAIL!!!
```