### PR TITLE
[jit] Support MultiheadedAttention module

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -17042,6 +17042,13 @@ additional_module_tests = [
         'constructor_args': (S, S),
         'input_size': (S, S),
     },
+    {
+        'module_name': 'MultiheadAttention',
+        'constructor_args': (128, 8),
+        'input_size': (10, 8, 128),
+        'extra_args': (torch.randn(10, 8, 128), torch.randn(10, 8, 128)),
+        'slowTest': True
+    }
 ]
 
 

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -696,6 +696,7 @@ class MultiheadAttention(Module):
             self.q_proj_weight = Parameter(torch.Tensor(embed_dim, embed_dim))
             self.k_proj_weight = Parameter(torch.Tensor(embed_dim, self.kdim))
             self.v_proj_weight = Parameter(torch.Tensor(embed_dim, self.vdim))
+            self.register_parameter('in_proj_weight', None)
         else:
             self.in_proj_weight = Parameter(torch.empty(3 * embed_dim, embed_dim))
             self.register_parameter('q_proj_weight', None)

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -674,6 +674,11 @@ class MultiheadAttention(Module):
         >>> multihead_attn = nn.MultiheadAttention(embed_dim, num_heads)
         >>> attn_output, attn_output_weights = multihead_attn(query, key, value)
     """
+    __annotations__ = {
+        'bias_k': torch._jit_internal.Optional[torch.Tensor],
+        'bias_v': torch._jit_internal.Optional[torch.Tensor],
+    }
+    __constants__ = ['q_proj_weight', 'k_proj_weight', 'v_proj_weight']
 
     def __init__(self, embed_dim, num_heads, dropout=0., bias=True, add_bias_kv=False, add_zero_attn=False, kdim=None, vdim=None):
         super(MultiheadAttention, self).__init__()
@@ -693,6 +698,9 @@ class MultiheadAttention(Module):
             self.v_proj_weight = Parameter(torch.Tensor(embed_dim, self.vdim))
         else:
             self.in_proj_weight = Parameter(torch.empty(3 * embed_dim, embed_dim))
+            self.register_parameter('q_proj_weight', None)
+            self.register_parameter('k_proj_weight', None)
+            self.register_parameter('v_proj_weight', None)
 
         if bias:
             self.in_proj_bias = Parameter(torch.empty(3 * embed_dim))
@@ -709,6 +717,14 @@ class MultiheadAttention(Module):
         self.add_zero_attn = add_zero_attn
 
         self._reset_parameters()
+
+    def __setstate__(self, state):
+        if '_qkv_same_embed_dim' not in state:
+            state['_qkv_same_embed_dim'] = False
+            warnings.warn('A new version of MultiheadAttention module has been implemented. \
+                Please re-train your model with the new module',
+                            DeprecationWarning)
+        return super(MultiheadAttention, self).__setstate__(state)
 
     def _reset_parameters(self):
         if self._qkv_same_embed_dim:
@@ -728,6 +744,7 @@ class MultiheadAttention(Module):
 
     def forward(self, query, key, value, key_padding_mask=None,
                 need_weights=True, attn_mask=None):
+        # type: (Tensor, Tensor, Tensor, Optional[Tensor], bool, Optional[Tensor]) -> Tuple[Tensor, Optional[Tensor]]
         r"""
     Args:
         query, key, value: map a query and a set of key-value pairs to an output.
@@ -737,7 +754,7 @@ class MultiheadAttention(Module):
             the corresponding value on the attention layer will be filled with -inf.
         need_weights: output attn_output_weights.
         attn_mask: mask that prevents attention to certain positions. This is an additive mask
-            (i.e. the values will be added to the attention layer).  
+            (i.e. the values will be added to the attention layer).
 
     Shape:
         - Inputs:
@@ -756,30 +773,25 @@ class MultiheadAttention(Module):
         - attn_output_weights: :math:`(N, L, S)` where N is the batch size,
           L is the target sequence length, S is the source sequence length.
         """
-        if hasattr(self, '_qkv_same_embed_dim') and self._qkv_same_embed_dim is False:
-            return F.multi_head_attention_forward(
-                query, key, value, self.embed_dim, self.num_heads,
-                None, self.in_proj_bias,  # set self.in_proj_weight = None
-                self.bias_k, self.bias_v, self.add_zero_attn,
-                self.dropout, self.out_proj.weight, self.out_proj.bias, 
-                training=self.training,
-                key_padding_mask=key_padding_mask, need_weights=need_weights, 
-                attn_mask=attn_mask, use_separate_proj_weight=True,
-                q_proj_weight=self.q_proj_weight, k_proj_weight=self.k_proj_weight,
-                v_proj_weight=self.v_proj_weight)
-        else:
-            if not hasattr(self, '_qkv_same_embed_dim'):
-                warnings.warn('A new version of MultiheadAttention module has been implemented. \
-                    Please re-train your model with the new module',
-                              UserWarning)
-
+        if not self._qkv_same_embed_dim:
             return F.multi_head_attention_forward(
                 query, key, value, self.embed_dim, self.num_heads,
                 self.in_proj_weight, self.in_proj_bias,
                 self.bias_k, self.bias_v, self.add_zero_attn,
-                self.dropout, self.out_proj.weight, self.out_proj.bias, 
+                self.dropout, self.out_proj.weight, self.out_proj.bias,
                 training=self.training,
-                key_padding_mask=key_padding_mask, need_weights=need_weights, 
+                key_padding_mask=key_padding_mask, need_weights=need_weights,
+                attn_mask=attn_mask, use_separate_proj_weight=True,
+                q_proj_weight=self.q_proj_weight, k_proj_weight=self.k_proj_weight,
+                v_proj_weight=self.v_proj_weight)
+        else:
+            return F.multi_head_attention_forward(
+                query, key, value, self.embed_dim, self.num_heads,
+                self.in_proj_weight, self.in_proj_bias,
+                self.bias_k, self.bias_v, self.add_zero_attn,
+                self.dropout, self.out_proj.weight, self.out_proj.bias,
+                training=self.training,
+                key_padding_mask=key_padding_mask, need_weights=need_weights,
                 attn_mask=attn_mask)
 
 

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -722,8 +722,8 @@ class MultiheadAttention(Module):
         if '_qkv_same_embed_dim' not in state:
             state['_qkv_same_embed_dim'] = False
             warnings.warn('A new version of MultiheadAttention module has been implemented. \
-                Please re-train your model with the new module',
-                            DeprecationWarning)
+                          Please re-train your model with the new module',
+                          DeprecationWarning)
         return super(MultiheadAttention, self).__setstate__(state)
 
     def _reset_parameters(self):

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -719,14 +719,6 @@ class MultiheadAttention(Module):
 
         self._reset_parameters()
 
-    def __setstate__(self, state):
-        if '_qkv_same_embed_dim' not in state:
-            state['_qkv_same_embed_dim'] = False
-            warnings.warn('A new version of MultiheadAttention module has been implemented. \
-                          Please re-train your model with the new module',
-                          DeprecationWarning)
-        return super(MultiheadAttention, self).__setstate__(state)
-
     def _reset_parameters(self):
         if self._qkv_same_embed_dim:
             xavier_uniform_(self.in_proj_weight)

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -678,7 +678,7 @@ class MultiheadAttention(Module):
         'bias_k': torch._jit_internal.Optional[torch.Tensor],
         'bias_v': torch._jit_internal.Optional[torch.Tensor],
     }
-    __constants__ = ['q_proj_weight', 'k_proj_weight', 'v_proj_weight']
+    __constants__ = ['q_proj_weight', 'k_proj_weight', 'v_proj_weight', 'in_proj_weight']
 
     def __init__(self, embed_dim, num_heads, dropout=0., bias=True, add_bias_kv=False, add_zero_attn=False, kdim=None, vdim=None):
         super(MultiheadAttention, self).__init__()


### PR DESCRIPTION
Stacked PRs
 * #28561 - [jit] Make `nn.Transformer` TorchScript compatible
 * **#28555 - [jit] Support MultiheadedAttention module**

This makes MultiheadedAttention TorchScript compatible

It also breaks BC-compatibility for old models that do not have `_qkv_same_embed_dim` as an attribute.

Differential Revision: [D18124746](https://our.internmc.facebook.com/intern/diff/18124746/)