### PR TITLE
Migrate CPU_tensor_apply to TensorIterator for bernoulli_tensor_cpu_

### DIFF
--- a/aten/src/ATen/native/Distributions.cpp
+++ b/aten/src/ATen/native/Distributions.cpp
@@ -158,7 +158,7 @@ Tensor& bernoulli_tensor_cpu_(Tensor& self, const Tensor& p_, Generator* gen) {
         iter.add_input(p);
         iter.add_output(self);
         iter.build();
-        cpu_serial_kernel(iter, [&](const double p_val) -> scalar_t {
+        cpu_serial_kernel(iter, [&](const scalar_t p_val) -> scalar_t {
           at::bernoulli_distribution<float> bernoulli(p_val);
           return static_cast<scalar_t>(bernoulli(generator));
         });

--- a/aten/src/ATen/native/Distributions.cpp
+++ b/aten/src/ATen/native/Distributions.cpp
@@ -147,7 +147,7 @@ Tensor& bernoulli_tensor_cpu_(Tensor& self, const Tensor& p_, Generator* gen) {
       iter.add_input(p);
       iter.add_output(self);
       iter.build();
-      cpu_serial_kernel(iter, [&](const scalar_t p_val) -> scalar_t {
+      cpu_serial_kernel(iter, [&](const double p_val) -> scalar_t {
         at::bernoulli_distribution<double> bernoulli(p_val);
         return static_cast<scalar_t>(bernoulli(generator));
       });
@@ -158,7 +158,7 @@ Tensor& bernoulli_tensor_cpu_(Tensor& self, const Tensor& p_, Generator* gen) {
         iter.add_input(p);
         iter.add_output(self);
         iter.build();
-        cpu_serial_kernel(iter, [&](const scalar_t p_val) -> scalar_t {
+        cpu_serial_kernel(iter, [&](const double p_val) -> scalar_t {
           at::bernoulli_distribution<float> bernoulli(p_val);
           return static_cast<scalar_t>(bernoulli(generator));
         });


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #28590 Migrate CPU_tensor_apply to TensorIterator for _s_dirichlet_cpu
* #28589 Migrate CPU_tensor_apply to TensorIterator for _s_gamma_cpu
* #28588 Migrate CPU_tensor_apply to TensorIterator for _s_poisson_cpu
* #28587 Migrate CPU_tensor_apply to TensorIterator for _dirichlet_grad_cpu
* #28586 Migrate CPU_tensor_apply to TensorIterator for _standard_gamma_grad_cpu
* #28585 Migrate CPU_tensor_apply to TensorIterator for bernoulli_scalar_cpu_
* **#28584 Migrate CPU_tensor_apply to TensorIterator for bernoulli_tensor_cpu_**

