### PR TITLE
WIP_FIXING_FUSER

### DIFF
--- a/test/test_jit_fuser.py
+++ b/test/test_jit_fuser.py
@@ -20,8 +20,10 @@ from test_jit import JitTestCase, enable_cpu_fuser, RUN_CUDA, RUN_CUDA_HALF, RUN
 
 class TestFuser(JitTestCase):
     def assertAllFused(self, graph, except_for=()):
+        print("Input GRAPH\n", graph, "\nEND OF GRAPH\n\n")
         if [n.kind() for n in graph.nodes()] == ['prim::DifferentiableGraph']:
             graph = next(graph.nodes()).g('Subgraph')
+        print("Checking GRAPH\n", graph, "\nEND OF GRAPH\n\n")
         allowed_nodes = {'prim::Constant', 'prim::FusionGroup', 'prim::TupleConstruct'} | set(except_for)
         self.assertTrue(all(node.kind() in allowed_nodes for node in graph.nodes()),
                         'got {}'.format(graph))
@@ -772,6 +774,8 @@ class TestFuser(JitTestCase):
         script_f = torch.jit.script(fn_test_rand, (x, y))
         out = script_f(x, y)
         self.assertAllFused(script_f.graph_for(x, y))
+        print("Goog one", script_f.graph_for(x, y), "\n\n\n")
+
         x.requires_grad_(True)
         out = script_f(x, y)
         self.assertAllFused(script_f.graph_for(x, y), except_for=("aten::size", "prim::BroadcastSizes",

--- a/torch/csrc/jit/passes/graph_fuser.cpp
+++ b/torch/csrc/jit/passes/graph_fuser.cpp
@@ -170,6 +170,8 @@ struct GraphFuser {
   }
 
   bool isFusable(Node* node) {
+    std::cout << "Checking isFusable " << node->kind().toDisplayString()
+              << "\n";
     return callback_(node);
   }
 

--- a/torch/csrc/jit/symbolic_script.cpp
+++ b/torch/csrc/jit/symbolic_script.cpp
@@ -923,11 +923,11 @@ const std::vector<std::string> functions = {
 
             return torch.log2(self), backward
 
-        def rand_like(self):
+        def rand_like(self, *, memory_format: int=0):
             def backward(grad_output):
                 return None
 
-            return torch.rand_like(self), backward
+            return torch.rand_like(self, memory_format=memory_format), backward
 
         def reciprocal(self):
             result = torch.reciprocal(self)
@@ -1309,7 +1309,7 @@ const std::vector<std::string> functions = {
 
             return torch.__interpolate(input, size, scale_factor, mode, align_corners), backward
       )",
-      R"(
+    R"(
         def AD_sizes_if_not_equal_multi_1(t1, t2, res):
             return torch._size_if_not_equal(t1.size(), res.size()), torch._size_if_not_equal(t2.size(), res.size())
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#28591 WIP_FIXING_FUSER**
* #28544 Add torch.memory_format support to the TorchScript
* #28292 Add memory format support to the `resize_` op.
* #28291 TensroIterator preserve format for binary, ternary operators.
* #28077 Add channels last support to cuda.comm.scatter and gather
* #28076 Kill `operator==` of TensorOptions as confusing one
* #27979 Add memory format support to `resize_as_` operator
* #27891 Cleanup testing of _like operators
* #27890 Add memory format support to `randn_like` operator
* #27889 Add memory format support to `randint_like` operator
* #27562 Add memory format support to `zeros_like` operator
* #27561 Add memory format support to `rand_like` operator
* #27270 Add memory format support to `ones_like` operator
* #27262 Add memory format support to `full_like` operator
* #27244 Add memory format support to `empty_like` operator

Differential Revision: [D18115953](https://our.internmc.facebook.com/intern/diff/D18115953)