### PR TITLE
Delete move constructor from TaggedStringStream

### DIFF
--- a/aten/src/ATen/cpu/vec256/vec256_base.h
+++ b/aten/src/ATen/cpu/vec256/vec256_base.h
@@ -81,8 +81,8 @@ public:
   // Also, technically according to the C++ standard, we don't have to define
   // a constexpr variable if we never odr-use it.  But it seems that some
   // versions GCC/Clang have buggy determinations on whether or not an
-  // identifier is odr-used or not, and in any case it's hard to tel if
-  // a variabe is odr-used or not.  So best to just cut the probem at the root.
+  // identifier is odr-used or not, and in any case it's hard to tell if
+  // a variable is odr-used or not.  So best to just cut the probem at the root.
   static constexpr int size() {
     return 32 / sizeof(T);
   }

--- a/torch/csrc/jit/passes/python_print.cpp
+++ b/torch/csrc/jit/passes/python_print.cpp
@@ -106,7 +106,6 @@ struct PythonPrintImpl {
   class TaggedStringStream {
    public:
     TaggedStringStream(const SourceRangeStack* srs) : srs_(srs) {}
-    TaggedStringStream(TaggedStringStream&& rhs) = default;
 
     TaggedStringStream& operator<<(const std::string& s) {
       // This prevents having redundant entries at the same offset,


### PR DESCRIPTION
Summary:
This isn't used anywhere, and it doesn't work with older libstdc++
because std::ostringstream is not copyable or movable.

Test Plan: Internal android build.

Reviewed By: jamesr66a

Differential Revision: D18099511

