### PR TITLE
addmm: Fix handling of case with empty tensor

### DIFF
--- a/aten/src/TH/generic/THTensorMath.cpp
+++ b/aten/src/TH/generic/THTensorMath.cpp
@@ -217,6 +217,11 @@ static void THTensor_(addmmImpl)(THTensor *r_, THTensor *t, THTensor *m1, THTens
     }
   }
 
+  if((r_->size(0) == 0) || (r_->size(1) == 0))
+  {
+    return;
+  }
+
   // n == 1 || ldc >= max(1, m)
   #define LDC_COND(M, N, LDC) ((N) == 1 || (LDC) >= THMax(1, M))
 

--- a/aten/src/THC/generic/THCTensorMathBlas.cu
+++ b/aten/src/THC/generic/THCTensorMathBlas.cu
@@ -305,6 +305,11 @@ static void THCTensor_(addmmImpl)(THCState *state, THCTensor *r_, THCTensor *t, 
     }
   }
 
+  if((r_->size(0) == 0) || (r_->size(1) == 0))
+  {
+    return;
+  }
+
   /* r_ */
   if(r_->stride(0) == 1 &&
      r_->stride(1) != 0)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -11283,6 +11283,7 @@ class TestTorchDeviceType(TestCase):
 
         self.assertEqual((0, 0), fn(torch.addmm, (0, 0), (0, 0), (0, 0)).shape)
         self.assertEqual((5, 6), fn(torch.addmm, (5, 6), (5, 0), (0, 6)).shape)
+        self.assertEqual((0, 1), fn(torch.addmm, (1, ), (0, 17), (17, 1)).shape)
 
         # mv, addmv
         self.assertEqual((0,), fn(torch.mv, (0, 0), (0,)).shape)


### PR DESCRIPTION
Summary:
addmm: Fix handling of case with empty tensor.
Currently these cause an error

Recreation of D18085389 without stacked diffs

Test Plan: test included

Differential Revision: D18122004

