### PR TITLE
LayerNorm: Handling if batch size is zero

### DIFF
--- a/aten/src/ATen/native/cuda/layer_norm_kernel.cu
+++ b/aten/src/ATen/native/cuda/layer_norm_kernel.cu
@@ -305,6 +305,7 @@ void LayerNormKernelImplInternal(
           N, eps, X_data, mean_data, rstd_data);
   LayerNormForwardCUDAKernel<T><<<M, kCUDANumThreads, 0, cuda_stream>>>(
       N, X_data, mean_data, rstd_data, gamma_data, beta_data, Y_data);
+  AT_CUDA_CHECK(cudaGetLastError());
 }
 
 void LayerNormKernelImpl(
@@ -450,7 +451,9 @@ std::tuple<Tensor, Tensor, Tensor> layer_norm_cuda(
   Tensor Y = at::native::empty_like(X);
   Tensor mean = at::empty({M}, X.options());
   Tensor rstd = at::empty({M}, X.options());
-  LayerNormKernelImpl(X, gamma, beta, M, N, eps, &Y, &mean, &rstd);
+  if (M > 0) {
+    LayerNormKernelImpl(X, gamma, beta, M, N, eps, &Y, &mean, &rstd);
+  }
   return std::make_tuple(std::move(Y), std::move(mean), std::move(rstd));
 }
 
@@ -470,13 +473,15 @@ std::tuple<Tensor, Tensor, Tensor> layer_norm_backward_cuda(
     dX = at::native::empty_like(X);
   }
   if (grad_input_mask[1]) {
-    dgamma = at::native::empty_like(gamma);
+    dgamma = M > 0 ? at::native::empty_like(gamma) : at::native::zeros_like(gamma);
   }
   if (grad_input_mask[2]) {
-    dbeta = at::native::empty_like(gamma);
+    dbeta = M > 0 ? at::native::empty_like(gamma) : at::native::zeros_like(gamma);
   }
-  LayerNormBackwardKernelImpl(
-      dY, X, mean, rstd, gamma, M, N, &dX, &dgamma, &dbeta);
+  if (M > 0) {
+    LayerNormBackwardKernelImpl(
+        dY, X, mean, rstd, gamma, M, N, &dX, &dgamma, &dbeta);
+  }
   return std::make_tuple(std::move(dX), std::move(dgamma), std::move(dbeta));
 }
 

--- a/test/common_nn.py
+++ b/test/common_nn.py
@@ -1130,6 +1130,14 @@ new_module_tests = [
         desc='3d_no_elementwise_affine',
     ),
     dict(
+        module_name='LayerNorm',
+        constructor_args=([5], 1e-3),
+        input_size=(0, 5),
+        cudnn=True,
+        check_eval=True,
+        desc='1d_empty_elementwise_affine',
+    ),
+    dict(
         module_name='GroupNorm',
         constructor_args=(3, 6, 1e-3),
         input_size=(4, 6, 5),


### PR DESCRIPTION
Summary:
Handling of empty example was giving a cuda error.
Adding getLastError check to make sure cuda errors are attributed to the
correct function (instead of currently it was attributing the error to the next
cuda operator).
Added special case for batch-size zero, also added to cpu to keep things
consistent.

Resubmit of D18085429 without stacked commits

Test Plan: test included

Differential Revision: D18122212

