### PR TITLE
Change reorder_dimensions behavior to favor output writting sequence

### DIFF
--- a/aten/src/ATen/native/TensorIterator.cpp
+++ b/aten/src/ATen/native/TensorIterator.cpp
@@ -49,7 +49,7 @@ void TensorIterator::reorder_dimensions() {
       } else if (stride0 <= stride1) {
         return -1;
       } else {
-        ret = 1;
+        return 1;
       }
     }
     return ret;


### PR DESCRIPTION
reorder_dimensions() currently iterate all the operands when determining the dimension order in the TensorIterator. It tries to move a dimension to front if any operand has a dimension whose stride is bigger than this dimension.

reorder_dimensions() do respect the case that stride has zero value. I did not see a reason why reorder_dimensions() need to keep probing each operand under regular cases.

Changed behavior a little bit. 
Since operands is ordered by outputs tensor first followed by input tensor.  I would favor the writing of outputs is as sequential as possible. This could make the copy between tensors with different memory format faster.

Pls correct me if this change is wrong, thanks.

Fix #26812 

Benchmark on CPU
x = torch.randn(64, 2048, 7, 7).contiguous(memory_format = torch.contiguous_format) 
%timeit x.contiguous(memory_format = torch.channels_last) 
x = torch.randn(64, 2048, 7, 7).contiguous(memory_format = torch.channels_last) 
%timeit x.contiguous(memory_format = torch.contiguous_format) 
BEFORE:                                                                                        
20.7 ms ± 1.87 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
12.5 ms ± 49.4 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
AFTER:
9.26 ms ± 454 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
12.6 ms ± 53.9 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

Benchmark on GPU
x = torch.randn(64, 2048, 7, 7).contiguous(memory_format = torch.contiguous_format).cuda()  
%timeit x.contiguous(memory_format = torch.channels_last); torch.cuda.synchronize()  
x = torch.randn(64, 2048, 7, 7).contiguous(memory_format = torch.channels_last).cuda() 
%timeit x.contiguous(memory_format = torch.contiguous_format); torch.cuda.synchronize()
BEFORE:
622 µs ± 268 ns per loop (mean ± std. dev. of 7 runs, 1000 loops each)
5.2 µs ± 77.6 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
AFTER:
379 µs ± 316 ns per loop (mean ± std. dev. of 7 runs, 1000 loops each)
5.25 µs ± 76.3 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
