### PR TITLE
Fix when giving jit format warning about unsupported options

### DIFF
--- a/torch/csrc/jit/register_special_ops.cpp
+++ b/torch/csrc/jit/register_special_ops.cpp
@@ -308,7 +308,7 @@ RegisterOperators reg({
         "aten::format(str self, ...) -> str",
         [](const Node* node) -> Operation {
           size_t num_inputs = node->inputs().size();
-          std::regex unsupported_options("\\{(.*)\\}");
+          std::regex unsupported_options("\\{([^}]+)\\}");
           return [num_inputs, unsupported_options](Stack& stack) {
             auto format = peek(stack, 0, num_inputs).toStringRef();
 


### PR DESCRIPTION
Summary: Current reges also matches strings with '{}' so warning is always given.

Test Plan: Previous code was giving a warning about unspported options, these disappeared. When adding something inside '{}' the warning came back.

Differential Revision: D18039443

