### PR TITLE
Test type hints using tutorials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ test/data/*.pt
 test/backward_compatibility/new_schemas.txt
 dropout_model.pt
 test/generated_type_hints_smoketest.py
+test/generated_tutorial_type_hints_smoketest.py
 test/htmlcov
 test/cpp_extensions/install/
 third_party/build/

--- a/.gitmodules
+++ b/.gitmodules
@@ -111,9 +111,13 @@
     path = third_party/foxi
     url = https://github.com/houseroad/foxi.git
 [submodule "third_party/tbb"]
-	path = third_party/tbb
-	url = https://github.com/01org/tbb
-	branch = tbb_2018
+    path = third_party/tbb
+    url = https://github.com/01org/tbb
+    branch = tbb_2018
+[submodule "third_party/tutorials"]
+    ignore = dirty
+	path = third_party/tutorials
+	url = git@github.com:pytorch/tutorials
 [submodule "android/libs/fbjni"]
     ignore = dirty
     path = android/libs/fbjni


### PR DESCRIPTION
Incremental progress towards #16574.

Create a unit test in `test_type_hints.py` which runs `mypy` over all Python files found in `tutorials/beginner_source`, `tutorials/intermediate_source`, and `tutorials/advanced_source`, skipping a blacklist comprised of any such files which were found not to successfully pass at the time of this PR's writing.

Of the files not specified in this test's blacklist, there are exactly eight from `beginner_source` which mypy currently successfully runs over! So this adds a marginal amount of coverage.

Uses a git submodule in order to get access to https://github.com/pytorch/tutorials. How sketchy is this approach? The submodule approach seems to allow us to pin to a specific commit (https://github.com/pytorch/tutorials/commit/8081dd7b67cd01180cb1b2033cfeda34a51ff6a3, in particular) so that new tutorials don't suddenly cause test failures here.

In future work, we could remove individual files off of this blacklist, see what their deal is, and fix them.

Tested using `pytest test/test_type_hints.py`.