### PR TITLE
Fix torch.eq doc string

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -1795,8 +1795,8 @@ Returns:
 Example::
 
     >>> torch.eq(torch.tensor([[1, 2], [3, 4]]), torch.tensor([[1, 1], [4, 4]]))
-    tensor([[ 1,  0],
-            [ 0,  1]], dtype=torch.uint8)
+    tensor([[ True, False],
+            [False,  True]])
 """.format(**common_args))
 
 add_docstr(torch.equal,


### PR DESCRIPTION
I just spotted incorrect doc string in `torch.eq`. I'm not sure these docstrings are managed manually, but I hope this change is okay. Thanks.

(FYI, other ops (lt, le, gt, ge, ne) seems already corrected.)