### PR TITLE
Fix for torch.save not saving source files

### DIFF
--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -287,7 +287,7 @@ def _save(obj, f, pickle_module, pickle_protocol):
             source_file = source = None
             try:
                 source_lines, _, source_file = get_source_lines_and_file(obj)
-                source = ''.join(obj)
+                source = ''.join(source_file)
             except Exception:  # saving the source is optional, so we can ignore any errors
                 warnings.warn("Couldn't retrieve source code for container of "
                               "type " + obj.__name__ + ". It won't be checked "


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#28642 Fix for torch.save not saving source files**

Summary: Fixed the reference to correct object

Test Plan:
Verified by running the sample test case to see file getting saved with no errors or warnings
import torch
m = torch.nn.Linear(500, 10)
torch.save(m, './test.pth')

Reviewers: vincentqb

Subscribers: gchauhan

Tasks:

Tags:

Fix for torch.save not saving file

Fix for torch.save not working