### PR TITLE
C++ ModuleDict

### DIFF
--- a/test/cpp/api/CMakeLists.txt
+++ b/test/cpp/api/CMakeLists.txt
@@ -13,6 +13,7 @@ set(TORCH_API_TEST_SOURCES
   ${TORCH_API_TEST_DIR}/memory.cpp
   ${TORCH_API_TEST_DIR}/misc.cpp
   ${TORCH_API_TEST_DIR}/module.cpp
+  ${TORCH_API_TEST_DIR}/moduledict.cpp
   ${TORCH_API_TEST_DIR}/modulelist.cpp
   ${TORCH_API_TEST_DIR}/modules.cpp
   ${TORCH_API_TEST_DIR}/nn_utils.cpp

--- a/test/cpp/api/moduledict.cpp
+++ b/test/cpp/api/moduledict.cpp
@@ -1,0 +1,27 @@
+#include <gtest/gtest.h>
+
+#include <torch/torch.h>
+
+#include <algorithm>
+#include <memory>
+#include <vector>
+
+#include <test/cpp/api/support.h>
+
+using namespace torch::nn;
+using namespace torch::test;
+
+struct ModuleDictTest : torch::test::SeedingFixture {};
+
+TEST_F(ModuleDictTest, ConstructsFromSharedPointer) {
+  struct M : torch::nn::Module {
+    explicit M(int value_) : value(value_) {}
+    int value;
+  };
+
+  ModuleDict dict;
+  dict->insert("A", std::make_shared<M>(1));
+  dict->insert("B", std::make_shared<M>(2));
+  dict->insert("C", std::make_shared<M>(3));
+  ASSERT_EQ(dict->size(), 3);
+}

--- a/torch/csrc/api/include/torch/nn/module.h
+++ b/torch/csrc/api/include/torch/nn/module.h
@@ -514,6 +514,8 @@ class TORCH_API Module : public std::enable_shared_from_this<Module> {
  private:
   // Friend classes.
 
+  friend class ModuleDictImpl;
+
   template <typename Derived>
   friend class Cloneable;
 

--- a/torch/csrc/api/include/torch/nn/modules.h
+++ b/torch/csrc/api/include/torch/nn/modules.h
@@ -3,19 +3,20 @@
 // Containers
 #include <torch/nn/modules/container/any.h>
 #include <torch/nn/modules/container/functional.h>
+#include <torch/nn/modules/container/moduledict.h>
 #include <torch/nn/modules/container/modulelist.h>
 #include <torch/nn/modules/container/named_any.h>
 #include <torch/nn/modules/container/sequential.h>
 
 // Layers
+#include <torch/nn/modules/activation.h>
 #include <torch/nn/modules/batchnorm.h>
 #include <torch/nn/modules/conv.h>
-#include <torch/nn/modules/dropout.h>
 #include <torch/nn/modules/distance.h>
+#include <torch/nn/modules/dropout.h>
 #include <torch/nn/modules/embedding.h>
 #include <torch/nn/modules/fold.h>
 #include <torch/nn/modules/linear.h>
 #include <torch/nn/modules/loss.h>
 #include <torch/nn/modules/pooling.h>
 #include <torch/nn/modules/rnn.h>
-#include <torch/nn/modules/activation.h>

--- a/torch/csrc/api/include/torch/nn/modules/container/moduledict.h
+++ b/torch/csrc/api/include/torch/nn/modules/container/moduledict.h
@@ -1,0 +1,121 @@
+#pragma once
+
+#include <torch/nn/cloneable.h>
+#include <torch/nn/module.h>
+#include <torch/ordered_dict.h>
+
+#include <vector>
+
+namespace torch {
+namespace nn {
+
+class ModuleDictImpl : public Cloneable<ModuleDictImpl> {
+ public:
+  using Iterator = OrderedDict<std::string, std::shared_ptr<Module>>::Iterator;
+  using ConstIterator =
+      OrderedDict<std::string, std::shared_ptr<Module>>::ConstIterator;
+
+  ModuleDictImpl() = default;
+
+  std::shared_ptr<Module> clone(
+      const optional<Device>& device = nullopt) const override {
+    auto clone = std::make_shared<ModuleDictImpl>();
+    for (const auto& pair : children_) {
+      clone->insert(pair.key(), pair.value()->clone(device));
+    }
+    return clone;
+  }
+
+  /// `reset()` is empty for `ModuleList`, since it does not have parameters of
+  /// its own.
+  void reset() override {}
+
+  /// Pretty prints the `ModuleList` module into the given `stream`.
+  void pretty_print(std::ostream& stream) const override {
+    stream << "torch::nn::ModuleDict";
+  }
+
+  void erase(const std::string& name) {
+    children_.erase(name);
+  }
+
+  /// Returns the number of items currently stored in the `ModuleDict`.
+  size_t size() const noexcept {
+    return children_.size();
+  }
+
+  /// Returns true if the `ModuleDict` contains no elements.
+  bool is_empty() const noexcept {
+    return children_.is_empty();
+  }
+
+  /// Removes all items from this `ModuleDict`.
+  void clear();
+
+  std::shared_ptr<Module> pop(const std::string& name) {
+    auto value = children_[name];
+    children_.erase(name);
+    return value;
+  }
+
+  OrderedDict<std::string, std::shared_ptr<Module>> items() const noexcept {
+    return children_;
+  }
+
+  /// Inserts all items from `other` into this `ModuleDict`. If any key from
+  /// `other` is already present in this `ModuleDict`, an exception is thrown.
+  void update(ModuleDictImpl&& other) {
+    children_.update(std::move(other.children_));
+  }
+
+  /// Inserts all items from `other` into this `ModuleDict`. If any key from
+  /// `other` is already present in this `ModuleDict`, an exception is thrown.
+  void update(const ModuleDictImpl& other) {
+    children_.update(other.children_);
+  }
+
+  std::shared_ptr<Module>& insert(
+      const std::string& key,
+      std::shared_ptr<Module>&& value) {
+    return children_.insert(key, std::move(value));
+  }
+
+  std::shared_ptr<Module>& insert(
+      const std::string& key,
+      const std::shared_ptr<Module>& value) {
+    return children_.insert(key, value);
+  }
+
+  /// Returns an iterator to the start of the `ModuleDict`.
+  Iterator begin() {
+    return children_.begin();
+  }
+
+  /// Returns a const iterator to the start of the `ModuleDict`.
+  ConstIterator begin() const {
+    return children_.begin();
+  }
+
+  /// Returns an iterator to the end of the `ModuleDict`.
+  Iterator end() {
+    return children_.end();
+  }
+
+  /// Returns a const iterator to the end of the `ModuleDict`.
+  ConstIterator end() const {
+    return children_.end();
+  }
+
+  std::shared_ptr<Module>& operator[](const std::string& key) {
+    return children_[key];
+  }
+
+  const std::shared_ptr<Module>& operator[](const std::string& key) const {
+    return children_[key];
+  }
+};
+
+TORCH_MODULE(ModuleDict);
+
+} // namespace nn
+} // namespace torch


### PR DESCRIPTION
This is ```nn::ModuleDict``` for the C++ front-end.

@yf225 please take a look and tell me if the PR has problems. once you confirm the design I will add the documentations and the tests.
@yf225 is it possible to use  ```AnyModule``` here? It would require a secondary ```OrderedDict``` besides ```children_```.