### PR TITLE
Return None correctly from `Tensor.names`

### DIFF
--- a/test/test_namedtensor.py
+++ b/test/test_namedtensor.py
@@ -143,6 +143,17 @@ class TestNamedTensor(TestCase):
             names65 = ['A' * i for i in range(1, 66)]
             x = factory([1] * 65, names=names64, device=device)
 
+    def test_none_names_refcount(self):
+        def scope():
+            unnamed = torch.empty(2, 3)
+            unnamed.names  # materialize [None, None]
+
+        none_refcnt = sys.getrefcount(None)
+        scope()
+        self.assertEqual(sys.getrefcount(None), none_refcnt,
+                         message='Calling tensor.names should not decrement '
+                                 'the refcount of Py_None')
+
     def test_has_names(self):
         unnamed = torch.empty(2, 3)
         none_named = torch.empty(2, 3, names=(None, None))

--- a/test/test_namedtensor.py
+++ b/test/test_namedtensor.py
@@ -148,10 +148,10 @@ class TestNamedTensor(TestCase):
             unnamed = torch.empty(2, 3)
             unnamed.names  # materialize [None, None]
 
-        none_refcnt = sys.getrefcount(None)
+        prev_none_refcnt = sys.getrefcount(None)
         scope()
-        self.assertEqual(sys.getrefcount(None), none_refcnt,
-                         message='Calling tensor.names should not decrement '
+        self.assertEqual(sys.getrefcount(None), prev_none_refcnt,
+                         message='Calling tensor.names should not change '
                                  'the refcount of Py_None')
 
     def test_has_names(self):

--- a/test/test_namedtensor.py
+++ b/test/test_namedtensor.py
@@ -151,7 +151,7 @@ class TestNamedTensor(TestCase):
         prev_none_refcnt = sys.getrefcount(None)
         scope()
         self.assertEqual(sys.getrefcount(None), prev_none_refcnt,
-                         message='Calling tensor.names should not change '
+                         message='Using tensor.names should not change '
                                  'the refcount of Py_None')
 
     def test_has_names(self):

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -337,7 +337,7 @@ PyObject *THPVariable_get_names(THPVariable *self, void *unused)
   for (size_t i = 0; i < size; ++i) {
     PyObject* str;
     if (dimnames[i].type() == at::NameType::WILDCARD) {
-      // Py_None is a special Python singleton; when we returning it as a dimname
+      // Py_None is a special Python singleton; when we return it as a dimname
       // we need to increment the refcount because this is a *new* reference.
       // See https://docs.python.org/3/extending/extending.html#back-to-the-example
       // and https://docs.python.org/3/c-api/none.html#c.Py_RETURN_NONE


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#28659 Return None correctly from `Tensor.names`**

Previously, we would return None from `Tensor.names` without bumping the
refcount. This is a bug: PyTuple_SET_ITEM steals a reference to the object.
When the tuple is deallocated, it'll decrement the refcount on Py_None.
The end result is that if Tensor.names is called a lot, Py_None's
refcount hits 0 and causes Python to throw an error.

To avoid this, we "create" a new reference to Py_None by increasing
the refcount and let PyTuple_SET_ITEM steal that reference.

See the following for Python documentation on this:
- https://docs.python.org/3/c-api/tuple.html#c.PyTuple_SetItem
- https://stackoverflow.com/questions/16400600/how-to-return-a-tuple-containing-a-none-value-from-the-c-api

Fixes https://github.com/pytorch/pytorch/issues/28646

Test Plan:
- New test.

Differential Revision: [D18140593](https://our.internmc.facebook.com/intern/diff/D18140593)