### PR TITLE
explicitly provide memory format when calling to clone() at SpectralOps.cu

### DIFF
--- a/aten/src/ATen/native/cuda/SpectralOps.cu
+++ b/aten/src/ATen/native/cuda/SpectralOps.cu
@@ -179,7 +179,7 @@ static inline Tensor _run_cufft(
     IntArrayRef output_sizes, bool input_was_cloned
 ) {
   if (config.should_clone_input() && !input_was_cloned) {
-    input = input.clone();
+    input = input.clone(at::MemoryFormat::Contiguous);
   }
 
   auto& plan = config.plan();
@@ -349,7 +349,7 @@ Tensor _fft_cufft(const Tensor& self, int64_t signal_ndim,
   // from a slicing.
   auto complex_size_bytes = 2 * input.element_size();
   if (reinterpret_cast<std::uintptr_t>(input.data_ptr()) % complex_size_bytes != 0) {
-    input = input.clone();
+    input = input.clone(at::MemoryFormat::Contiguous);
     input_was_cloned = true;
   }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #28702 explicitly provide memory format when calling to clone() at SparseCUDATensorMath.cu
* #28701 explicitly provide memory format when calling to clone() at SparseCUDATensor.cpp
* #28700 explicitly provide memory format when calling to clone() at SparseTensorMath.cpp
* #28699 explicitly provide memory format when calling to clone() at SparseTensor.cpp
* #28698 explicitly provide memory format when calling to clone() at TensorShape.cpp
* #28697 explicitly provide memory format when calling to clone() at SparseTensorUtils.h
* #28694 explicitly provide memory format when calling to clone() at observer.py
* #28693 explicitly provide memory format when calling to clone() at rprop.py
* #28692 explicitly provide memory format when calling to clone() at lbfgs.py
* #28691 explicitly provide memory format when calling to clone() at spectral_norm.py
* #28690 explicitly provide memory format when calling to clone() at parameter.py
* #28689 explicitly provide memory format when calling to clone() at batchnorm.py
* #28688 explicitly provide memory format when calling to clone() at ProcessGroupGloo.cpp
* #28687 explicitly provide memory format when calling to clone() at quantized.py
* #28686 explicitly provide memory format when calling to clone() at jit/__init__.py
* #28685 explicitly provide memory format when calling to clone() at studentT.py
* #28684 explicitly provide memory format when calling to clone() at pareto.py
* #28683 explicitly provide memory format when calling to clone() at multinomial.py
* #28682 explicitly provide memory format when calling to clone() at kl.py
* #28681 explicitly provide memory format when calling to clone() at geometric.py
* #28680 explicitly provide memory format when calling to clone() at fishersnedecor.py
* #28679 explicitly provide memory format when calling to clone() at exp_family.py
* #28678 explicitly provide memory format when calling to clone() at random.py
* #28676 explicitly provide memory format when calling to clone() at check_alias_annotation.cpp
* #28675 explicitly provide memory format when calling to clone() at tensor.cpp
* #28674 explicitly provide memory format when calling to clone() at lbfgs.cpp
* #28673 explicitly provide memory format when calling to clone() at tensor.py
* #28672 explicitly provide memory format when calling to clone() at quasirandom.py
* #28671 explicitly provide memory format when calling to clone() at functional.py
* #28670 explicitly provide memory format when calling to clone() at Functions.cpp
* #28668 explicitly provide memory format when calling to clone() at Unique.cu
* **#28667 explicitly provide memory format when calling to clone() at SpectralOps.cu**
* #28666 explicitly provide memory format when calling to clone() at SortingKthValue.cu
* #28665 explicitly provide memory format when calling to clone() at TensorFactories.cpp
* #28664 explicitly provide memory format when calling to clone() at TensorTransformations.cpp
* #28663 explicitly provide memory format when calling to clone() at Sorting.cpp
* #28662 explicitly provide memory format when calling to clone() at SobolEngineOps.cpp
* #28661 explicitly provide memory format when calling to clone() at LinearAlgebra.cpp
* #28660 explicitly provide memory format when calling to clone() at Indexing.cpp

Differential Revision: [D18333358](https://our.internmc.facebook.com/intern/diff/D18333358)