### PR TITLE
separate PT and C2 to reduce build time

### DIFF
--- a/benchmarks/operator_benchmark/benchmark_runner.py
+++ b/benchmarks/operator_benchmark/benchmark_runner.py
@@ -5,7 +5,6 @@ from __future__ import unicode_literals
 
 import argparse
 
-from caffe2.python import workspace
 import torch
 
 import benchmark_core
@@ -124,9 +123,6 @@ def main():
 
     args, _ = parser.parse_known_args()
 
-    if benchmark_utils.is_caffe2_enabled(args.framework):
-        workspace.GlobalInit(['caffe2', '--caffe2_log_level=0'])
-        workspace.ClearGlobalNetObserver()
     if args.omp_num_threads:
         # benchmark_utils.set_omp_threads sets the env variable OMP_NUM_THREADS
         # which doesn't have any impact as C2 init logic has already been called

--- a/benchmarks/operator_benchmark/benchmark_test_generator.py
+++ b/benchmarks/operator_benchmark/benchmark_test_generator.py
@@ -3,12 +3,10 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from collections import namedtuple
 import copy 
 import ast
 import json
 from benchmark_core import TestConfig
-from benchmark_caffe2 import register_caffe2_op_test_case
 from benchmark_pytorch import register_pytorch_op_test_case
 from benchmark_utils import SkipInputShape
 
@@ -106,53 +104,6 @@ def _generate_test(configs, bench_op, OperatorTestCase, run_backward, op_name_fu
             _register_test(new_op, test_attrs, tags, OperatorTestCase, run_backward, input_name)
 
 
-OpMeta = namedtuple("OpMeta", "op_type num_inputs input_dims input_types \
-                    output_dims num_outputs args device")
-
-def generate_c2_test_from_ops(ops_metadata, bench_op, tags):
-    """
-    This function is used to generate Caffe2 tests based on the meatdata
-    of operators. The metadata includes seven fields which are 1) op_type:
-    the name of the operator. 2) num_inputs: the number of input blobs.
-    3) input_dims: a dictionary which includes the shapes of the input blobs.
-    4) input_types: a list which includes the types of input blobs. 5)
-    output_dims: a dictionary which includes the shapes of output blobs.
-    6) num_oupts: the number of output blobs. 7) args: a dictionary which
-    includes the args for th operator.
-    Here is an example to show the metadata for the WeighedSum operator
-    op_type : WeightedSum
-    num_inputs: 4
-    input_dims: {'0': [256], '1': [1], '2': [256], '3': [1]}
-    input_types: ['float', 'float', 'float', 'float']
-    output_dims:  {'0': [256]}
-    num_outputs: 4
-    args: {}
-    TODO(mingzhe0908): introduce device and add it to the benchmark name
-    """
-    for op_metadata in ops_metadata:
-        tmp_attrs = OpMeta(op_metadata.op_type,
-                           op_metadata.num_inputs,
-                           op_metadata.input_dims,
-                           op_metadata.input_types,
-                           op_metadata.output_dims,
-                           op_metadata.num_outputs,
-                           op_metadata.args,
-                           op_metadata.device)
-        test_attrs = tmp_attrs._asdict()
-        op = bench_op()
-        op.init(**test_attrs)
-        test_name = op.test_name("short")
-        input_config = "Shapes: {}, Type: {}, Args: {}".format(
-            op_metadata.input_dims,
-            op_metadata.input_types,
-            str(op_metadata.args))
-        test_config = TestConfig(test_name, input_config, tags, run_backward=False)
-        if op is not None:
-            register_caffe2_op_test_case(
-                op,
-                test_config)
-
-
 def generate_pt_test(configs, pt_bench_op):
     """ This function creates PyTorch op test based on the given operator
     """
@@ -160,24 +111,10 @@ def generate_pt_test(configs, pt_bench_op):
                    run_backward=False)
 
 
-def generate_c2_test(configs, c2_bench_op):
-    """ This function creates Caffe2 op test based on the given operator
-    """
-    _generate_test(configs, c2_bench_op, register_caffe2_op_test_case,
-                   run_backward=False)
-
-
 def generate_pt_gradient_test(configs, pt_bench_op):
     """ This function creates PyTorch op test based on the given operator
     """
     _generate_test(configs, pt_bench_op, register_pytorch_op_test_case,
-                   run_backward=True)
-
-
-def generate_c2_gradient_test(configs, c2_bench_op):
-    """ This function creates Caffe2 op test based on the given operator
-    """
-    _generate_test(configs, c2_bench_op, register_caffe2_op_test_case,
                    run_backward=True)
 
 

--- a/benchmarks/operator_benchmark/c2/add_test.py
+++ b/benchmarks/operator_benchmark/c2/add_test.py
@@ -4,6 +4,8 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import operator_benchmark as op_bench
+import benchmark_caffe2 as op_bench_c2
+from benchmark_caffe2 import Caffe2BenchmarkBase # noqa
 from caffe2.python import core 
 
 
@@ -29,7 +31,7 @@ add_short_configs = op_bench.config_list(
     tags=["short"], 
 )
 
-class AddBenchmark(op_bench.Caffe2BenchmarkBase):
+class AddBenchmark(op_bench_c2.Caffe2BenchmarkBase):
     def init(self, M, N, K, dtype): 
         self.input_one = self.tensor([M, N, K], dtype) 
         self.input_two = self.tensor([M, N, K], dtype) 
@@ -43,7 +45,7 @@ class AddBenchmark(op_bench.Caffe2BenchmarkBase):
         return op
 
 
-op_bench.generate_c2_test(add_long_configs + add_short_configs, AddBenchmark)
+op_bench_c2.generate_c2_test(add_long_configs + add_short_configs, AddBenchmark)
 
 
 if __name__ == "__main__":

--- a/benchmarks/operator_benchmark/c2/matmul_test.py
+++ b/benchmarks/operator_benchmark/c2/matmul_test.py
@@ -5,6 +5,8 @@ from __future__ import unicode_literals
 
 
 import operator_benchmark as op_bench
+import benchmark_caffe2 as op_bench_c2
+from benchmark_caffe2 import Caffe2BenchmarkBase # noqa
 from caffe2.python import core 
 
 """Microbenchmarks for MatMul operator"""
@@ -31,7 +33,7 @@ mm_short_configs = op_bench.config_list(
 )
 
 
-class MatMulBenchmark(op_bench.Caffe2BenchmarkBase):
+class MatMulBenchmark(op_bench_c2.Caffe2BenchmarkBase):
     def init(self, M, N, K, trans_a, trans_b): 
         self.input_one = self.tensor([N, M]) if trans_a else self.tensor([M, N])
         self.input_two = self.tensor([K, N]) if trans_b else self.tensor([N, K])
@@ -46,7 +48,7 @@ class MatMulBenchmark(op_bench.Caffe2BenchmarkBase):
         return op
 
 
-op_bench.generate_c2_test(mm_long_configs + mm_short_configs, MatMulBenchmark)
+op_bench_c2.generate_c2_test(mm_long_configs + mm_short_configs, MatMulBenchmark)
 
 
 if __name__ == "__main__":

--- a/benchmarks/operator_benchmark/operator_benchmark.py
+++ b/benchmarks/operator_benchmark/operator_benchmark.py
@@ -2,6 +2,5 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 # TODO (mingzhe09088): get rid of noqa
 import benchmark_runner # noqa
 from benchmark_pytorch import TorchBenchmarkBase # noqa
-from benchmark_caffe2 import Caffe2BenchmarkBase # noqa
 from benchmark_test_generator import * # noqa
 from benchmark_utils import * # noqa


### PR DESCRIPTION
Summary: as title

Test Plan:
```
Before:
buck run mode/opt caffe2/benchmarks/operator_benchmark:benchmark_all_test -- --operator sigmoid
Action graph will be rebuilt because files have been added or removed.
Building: finished in 02:19.5 min (100%) 7032/7032 jobs, 1 updated
  Total time: 02:20.0 min
# ----------------------------------------
# PyTorch/Caffe2 Operator Micro-benchmarks
# ----------------------------------------
# Tag : short

# Benchmarking PyTorch: sigmoid
# Mode: Eager
# Name: sigmoid_M512_N512
# Input: M: 512, N: 512
Forward Execution Time (us) : 371.808

With this diff
buck run mode/opt caffe2/benchmarks/operator_benchmark:benchmark_all_test -- --operator sigmoid
Parsing buck files: finished in 0.9 sec
Creating action graph: finished in 9.3 sec
Building: finished in 7.1 sec (100%) 5287/5287 jobs, 4 updated
  Total time: 17.3 sec
# ----------------------------------------
# PyTorch/Caffe2 Operator Micro-benchmarks
# ----------------------------------------
# Tag : short

# Benchmarking PyTorch: sigmoid
# Mode: Eager
# Name: sigmoid_M512_N512
# Input: M: 512, N: 512
Forward Execution Time (us) : 377.108

Reviewed By: hl475

Differential Revision: D18152071

