### PR TITLE
Move mode_t declaration in PadOptions

### DIFF
--- a/torch/csrc/api/include/torch/nn/options/padding.h
+++ b/torch/csrc/api/include/torch/nn/options/padding.h
@@ -12,17 +12,18 @@ namespace nn {
 
 /// Options for a pad functional.
 struct TORCH_API PadOptions {
+  typedef c10::variant<
+    enumtype::kConstant,
+    enumtype::kReflect,
+    enumtype::kReplicate,
+    enumtype::kCircular> mode_t;
+
   PadOptions(std::vector<int64_t> pad);
 
   /// m-elements tuple, where m/2 <= input dimensions and m is even.
   TORCH_ARG(std::vector<int64_t>, pad);
 
   /// "constant", "reflect", "replicate" or "circular". Default: "constant"
-  typedef c10::variant<
-    enumtype::kConstant,
-    enumtype::kReflect,
-    enumtype::kReplicate,
-    enumtype::kCircular> mode_t;
   TORCH_ARG(mode_t, mode) = torch::kConstant;
 
   /// fill value for "constant" padding. Default: 0


### PR DESCRIPTION
Based on the discussion in https://github.com/pytorch/pytorch/pull/28413#discussion_r338839489, putting anything that's not tagged as `public:` under a `TORCH_ARG` line would hide it under `private:`. To get around this problem, we should move the `mode_t` declaration at the top of the PadOptions declaration.