### PR TITLE
[pt][quant] Add the warning message for  API with linear modules

### DIFF
--- a/torch/jit/quantized.py
+++ b/torch/jit/quantized.py
@@ -7,6 +7,8 @@ from torch.nn import _VF
 
 from torch.nn.utils.rnn import PackedSequence
 
+import warnings
+
 class QuantizedLinear(torch.jit.ScriptModule):
     __constants__ = ['scale', 'zero_point']
 
@@ -602,6 +604,9 @@ def quantize_rnn_cell_modules(module):
 
 
 def quantize_linear_modules(module, dtype=torch.int8):
+    warnings.warn("quantize_linear_modules function has been deprecated. "
+                  "Please use torch.quantization.quantize_dynamic API instead.")
+
     reassign = {}
     for name, mod in module.named_modules():
         if mod is module:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #28767 [pt][quant] Update the misleading comments for zero_points and scale in dynamic quant linear module
* **#28766 [pt][quant] Add the warning message for  API with linear modules**

Add the warning message to explicitly ask the users to upgrade the deprecated `torch.jit.quantized` API to the new `torch.quantization.quantize_dynamic` API.

Differential Revision: [D18164903](https://our.internmc.facebook.com/intern/diff/D18164903/)