### PR TITLE
Deprecate torch::nn::modules_ordered_dict API

### DIFF
--- a/original-doxygen-log.txt
+++ b/original-doxygen-log.txt
@@ -1,1 +1,0 @@
-error: Doxyfile not found and no input file specified!

--- a/original-doxygen-log.txt
+++ b/original-doxygen-log.txt
@@ -1,0 +1,1 @@
+error: Doxyfile not found and no input file specified!

--- a/test/cpp/api/sequential.cpp
+++ b/test/cpp/api/sequential.cpp
@@ -29,11 +29,11 @@ TEST_F(SequentialTest, ConstructsFromSharedPointer) {
       std::make_shared<M>(1), std::make_shared<M>(2), std::make_shared<M>(3));
   ASSERT_EQ(sequential->size(), 3);
 
-  Sequential sequential_named(modules_ordered_dict({
+  Sequential sequential_named({
     {"m1", std::make_shared<M>(1)},
     {std::string("m2"), std::make_shared<M>(2)},
     {"m3", std::make_shared<M>(3)}
-  }));
+  });
   ASSERT_EQ(sequential->size(), 3);
 }
 
@@ -60,11 +60,11 @@ TEST_F(SequentialTest, ConstructsFromConcreteType) {
   ASSERT_EQ(copy_count, 3);
 
   copy_count = 0;
-  Sequential sequential_named(modules_ordered_dict({
+  Sequential sequential_named({
     {"m1", M(1)},
     {std::string("m2"), M(2)},
     {"m3", M(3)}
-  }));
+  });
   ASSERT_EQ(sequential->size(), 3);
   ASSERT_EQ(copy_count, 3);
 }
@@ -86,12 +86,28 @@ TEST_F(SequentialTest, ConstructsFromModuleHolder) {
   Sequential sequential(M(1), M(2), M(3));
   ASSERT_EQ(sequential->size(), 3);
 
-  Sequential sequential_named(modules_ordered_dict({
+  Sequential sequential_named({
     {"m1", M(1)},
     {std::string("m2"), M(2)},
     {"m3", M(3)}
-  }));
+  });
   ASSERT_EQ(sequential->size(), 3);
+}
+
+TEST_F(SequentialTest, LegacyBuilderForOrderedDictOfNamedModules) {
+  std::stringstream buffer;
+  CerrRedirect cerr_redirect(buffer.rdbuf());
+
+  Sequential sequential_named(modules_ordered_dict({
+    {"m1", Linear(3, 4)},
+    {"m2", ReLU()},
+    {"m3", BatchNorm(3)}
+  }));
+  ASSERT_EQ(sequential_named->size(), 3);
+
+  ASSERT_EQ(
+    count_substr_occurrences(buffer.str(), "`torch::nn::modules_ordered_dict` is deprecated"),
+    1);
 }
 
 TEST_F(SequentialTest, PushBackAddsAnElement) {
@@ -401,14 +417,14 @@ TEST_F(SequentialTest, PrettyPrintSequential) {
       "  (5): torch::nn::LSTM(input_size=4, hidden_size=5, layers=1, dropout=0)\n"
       ")");
 
-  Sequential sequential_named(modules_ordered_dict({
+  Sequential sequential_named({
       {"linear", Linear(10, 3)},
       {"conv2d", Conv2d(1, 2, 3)},
       {"dropout", Dropout(0.5)},
       {"batchnorm", BatchNorm(5)},
       {"embedding", Embedding(4, 10)},
       {"lstm", LSTM(4, 5)}
-  }));
+  });
   ASSERT_EQ(
       c10::str(sequential_named),
       "torch::nn::Sequential(\n"

--- a/torch/csrc/api/include/torch/nn/modules/container/named_any.h
+++ b/torch/csrc/api/include/torch/nn/modules/container/named_any.h
@@ -91,11 +91,15 @@ class NamedAnyModule {
   AnyModule module_;
 };
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+
 C10_DEPRECATED_MESSAGE("`torch::nn::modules_ordered_dict` is deprecated. " \
                        "To construct a `Sequential` with named submodules, " \
                        "you can do `Sequential sequential({{\"m1\", MyModule(1)}, {\"m2\", MyModule(2)}})`")
 TORCH_API torch::OrderedDict<std::string, AnyModule> modules_ordered_dict(
   std::initializer_list<NamedAnyModule> named_modules);
+
+#endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 } // namespace nn
 } // namespace torch

--- a/torch/csrc/api/include/torch/nn/modules/container/named_any.h
+++ b/torch/csrc/api/include/torch/nn/modules/container/named_any.h
@@ -24,8 +24,8 @@ namespace nn {
 
 /// Stores a type erased `Module` with name.
 ///
-/// The `NamedAnyModule` class and the `modules_ordered_dict(...)` function enables
-/// the following API for constructing `nn::Sequential` with named submodules:
+/// The `NamedAnyModule` class enables the following API for constructing
+/// `nn::Sequential` with named submodules:
 /// \rst
 /// .. code-block:: cpp
 ///
@@ -37,49 +37,12 @@ namespace nn {
 ///     }
 ///   };
 ///
-///   Sequential sequential(modules_ordered_dict({
+///   Sequential sequential({
 ///     {"m1", std::make_shared<M>(1)},  // shared pointer to `Module` is supported
 ///     {std::string("m2"), M(2)},  // `Module` is supported
 ///     {"linear1", Linear(10, 3)}  // `ModuleHolder` is supported
-///   }));
+///   });
 /// \endrst
-///
-/// Specifically, we design the signature of `modules_ordered_dict(...)` to be
-/// `modules_ordered_dict(std::initializer_list<NamedAnyModule> named_modules)`, as
-/// a result of evaluating the following possible approaches:
-///
-/// Approach 1:
-/// `modules_ordered_dict(std::initializer_list<
-///   torch::OrderedDict<std::string, ModuleType>::Item> named_modules)`
-///
-/// Why it doens't work:
-/// When we pass in a braced-init list such as
-/// `modules_ordered_dict({{"m1", M(1)}, {"m2", M(2)}})`, at the template argument
-/// deduction step the compiler is not able to deduce the type of `ModuleType` to
-/// the type of `M(1)` or `M(2)`, since the compiler doesn't actually look into the
-/// braced-init list `{"m1", M(1)}` and figure out what the types of its elements are.
-///
-/// Approach 2:
-/// `modules_ordered_dict(std::initializer_list<
-///   std::pair<std::string, AnyModule> named_modules)`
-///
-/// Why it doens't work:
-/// When we pass in a braced-init list such as
-/// `modules_ordered_dict({{"m1", M(1)}, {"m2", M(2)}})`, the compiler is not able to
-/// match `std::initializer_list<std::pair<std::string, AnyModule>>` to the nested
-/// braced-init list `{{"m1", M(1)}, {"m2", M(2)}}`, and results in a "could not
-/// convert" error.
-///
-/// Approach 3:
-/// `modules_ordered_dict(std::initializer_list<NamedAnyModule> named_modules)`
-///
-/// Why it works:
-/// When we pass in a braced-init list such as
-/// `modules_ordered_dict({{"m1", M(1)}, {"m2", M(2)}})`, the compiler is passing the
-/// braced-init lists {"m1", M(1)} and {"m2", M(2)} to the `NamedAnyModule`
-/// constructors, and the constructors are able to figure out the types of the
-/// braced-init lists' elements and match to the correct module type.
-
 class NamedAnyModule {
  public:
   /// Creates a `NamedAnyModule` from a (boxed) `Module`.
@@ -114,6 +77,11 @@ class NamedAnyModule {
     return module_;
   }
 
+  /// Returns a const reference to the module.
+  const AnyModule& module() const noexcept {
+    return module_;
+  }
+
  private:
   /// Creates a `NamedAnyModule` from a type-erased `AnyModule`.
   NamedAnyModule(std::string name, AnyModule any_module)
@@ -123,6 +91,9 @@ class NamedAnyModule {
   AnyModule module_;
 };
 
+C10_DEPRECATED_MESSAGE("`torch::nn::modules_ordered_dict` is deprecated. " \
+                       "To construct a `Sequential` with named submodules, " \
+                       "you can do `Sequential sequential({{\"m1\", MyModule(1)}, {\"m2\", MyModule(2)}})`")
 TORCH_API torch::OrderedDict<std::string, AnyModule> modules_ordered_dict(
   std::initializer_list<NamedAnyModule> named_modules);
 

--- a/torch/csrc/api/src/nn/modules/container/named_any.cpp
+++ b/torch/csrc/api/src/nn/modules/container/named_any.cpp
@@ -5,6 +5,10 @@ namespace nn {
 
 torch::OrderedDict<std::string, AnyModule> modules_ordered_dict(
   std::initializer_list<NamedAnyModule> named_modules) {
+  TORCH_WARN(
+    "`torch::nn::modules_ordered_dict` is deprecated. "
+    "To construct a `Sequential` with named submodules, "
+    "you can do `Sequential sequential({{\"m1\", MyModule(1)}, {\"m2\", MyModule(2)}})`");
   torch::OrderedDict<std::string, AnyModule> dict;
   for (auto named_module : named_modules) {
     dict.insert(named_module.name(), std::move(named_module.module()));


### PR DESCRIPTION
I finally found a way to get the following API to work for constructing a list of named submodules for `Sequential`:
```cpp
Sequential sequential({
  {"m1", MyModule(1)},
  {"m2", MyModule(2)}
})`
```
which was actually our original proposed design and much simpler than our current API:
```cpp
Sequential sequential(modules_ordered_dict({
  {"m1", MyModule(1)},
  {"m2", MyModule(2)}
}));
```