### PR TITLE
Explain how to specify library location for MKL

### DIFF
--- a/cmake/Modules/FindMKL.cmake
+++ b/cmake/Modules/FindMKL.cmake
@@ -367,7 +367,8 @@ ENDIF (MKL_LIBRARIES AND MKL_INCLUDE_DIR)
 
 # Standard termination
 IF(NOT MKL_FOUND AND MKL_FIND_REQUIRED)
-  MESSAGE(FATAL_ERROR "MKL library not found. Please specify library location")
+  MESSAGE(FATAL_ERROR "MKL library not found. Please specify library location \
+    by setting CMAKE_PREFIX_PATH to the root directory of the MKL installation.")
 ENDIF(NOT MKL_FOUND AND MKL_FIND_REQUIRED)
 IF(NOT MKL_FIND_QUIETLY)
   IF(MKL_FOUND)

--- a/cmake/Modules/FindMKL.cmake
+++ b/cmake/Modules/FindMKL.cmake
@@ -368,7 +368,7 @@ ENDIF (MKL_LIBRARIES AND MKL_INCLUDE_DIR)
 # Standard termination
 IF(NOT MKL_FOUND AND MKL_FIND_REQUIRED)
   MESSAGE(FATAL_ERROR "MKL library not found. Please specify library location \
-    by setting CMAKE_PREFIX_PATH to the root directory of the MKL installation.")
+    by appending the root directory of the MKL installation to the environment variable CMAKE_PREFIX_PATH.")
 ENDIF(NOT MKL_FOUND AND MKL_FIND_REQUIRED)
 IF(NOT MKL_FIND_QUIETLY)
   IF(MKL_FOUND)


### PR DESCRIPTION
Fixes #24334.

I'm still kind of confused why `FindMKL.cmake` was unable to locate my MKL libraries. They are in the standard `/opt/intel/mkl` installation prefix on macOS. But at least with this more detailed error message, it will be easier for people to figure out how to fix the problem.

@zhangguanheng66 @xkszltl @soumith