### PR TITLE
[lint] make sure clang-tidy is diffing against the right thing

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -209,7 +209,7 @@ jobs:
         run: |
           set -eux
           git remote add upstream https://github.com/pytorch/pytorch
-          git fetch upstream "${{ github.base_ref}}"
+          git fetch upstream "$GITHUB_BASE_REF"
 
           if [[ ! -d build ]]; then
             git submodule update --init --recursive
@@ -237,9 +237,11 @@ jobs:
           # Run Clang-Tidy
           # The negative filters below are to exclude files that include onnx_pb.h or
           # caffe2_pb.h, otherwise we'd have to build protos as part of this CI job.
+          MERGE_BASE=$(git merge-base $GITHUB_HEAD_REF $GITHUB_BASE_REF)
           python tools/clang_tidy.py                  \
+            --verbose                                 \
             --paths torch/csrc/                       \
-            --diff "${{ github.event.pull_request.base.sha}}" \
+            --diff "$MERGE_BASE"                      \
             -g"-torch/csrc/jit/export.cpp"            \
             -g"-torch/csrc/jit/import.cpp"            \
             -g"-torch/csrc/jit/netdef_converter.cpp"  \

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -254,6 +254,6 @@ jobs:
           check_name: 'clang-tidy'
           linter_output_path: 'clang-tidy-output.txt'
           commit_sha: ${{ steps.get_pr_tip.outputs.commit_sha }}
-          regex: '^(?<filename>.*?):(?<lineNumber>\d+):(?<columnNumber>\d+): (?<errorDesc>.*?) (?<errorCode>\[.*\])'
+          regex: '^(?<filename>.*?):(?<lineNumber>\d+):(?<columnNumber>\d+): (?<errorDesc>.*?) \[(?<errorCode>.*)\]'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -210,6 +210,8 @@ jobs:
           set -eux
           git remote add upstream https://github.com/pytorch/pytorch
           git fetch upstream "$GITHUB_BASE_REF"
+          git fetch upstream "$GITHUB_HEAD_REF"
+          MERGE_BASE=$(git merge-base $GITHUB_HEAD_REF $GITHUB_BASE_REF)
 
           if [[ ! -d build ]]; then
             git submodule update --init --recursive
@@ -237,7 +239,6 @@ jobs:
           # Run Clang-Tidy
           # The negative filters below are to exclude files that include onnx_pb.h or
           # caffe2_pb.h, otherwise we'd have to build protos as part of this CI job.
-          MERGE_BASE=$(git merge-base $GITHUB_HEAD_REF $GITHUB_BASE_REF)
           python tools/clang_tidy.py                  \
             --verbose                                 \
             --paths torch/csrc/                       \

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -210,8 +210,9 @@ jobs:
           set -eux
           git remote add upstream https://github.com/pytorch/pytorch
           git fetch upstream "$GITHUB_BASE_REF"
-          git fetch upstream "$GITHUB_HEAD_REF"
-          MERGE_BASE=$(git merge-base $GITHUB_HEAD_REF $GITHUB_BASE_REF)
+          BASE_SHA=${{ github.event.pull_request.base.sha }}
+          HEAD_SHA=${{ github.event.pull_request.head.sha }}
+          MERGE_BASE=$(git merge-base $BASE_SHA $HEAD_SHA)
 
           if [[ ! -d build ]]; then
             git submodule update --init --recursive


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#28788 [lint] make sure clang-tidy is diffing against the right thing**

Okay, my last fix was wrong because it turns out that the base SHA is
computed at PR time using the actual repo's view of the base ref, not
the user's. So if the user doesn't rebase on top of the latest master
before putting up the PR, the diff thing is wrong anyway.

This PR fixes the issue by not relying on any of these API details and
just getting the merge-base of the base and head refs, which should
guarantee we are diffing against the right thing.

This solution taken from https://github.com/github/VisualStudio/pull/1008

Differential Revision: [D18172391](https://our.internmc.facebook.com/intern/diff/D18172391)