### PR TITLE
[lint] make sure clang-tidy is diffing against the right thing

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -209,7 +209,7 @@ jobs:
         run: |
           set -eux
           git remote add upstream https://github.com/pytorch/pytorch
-          git fetch upstream "${{ github.base_ref}}"
+          git fetch upstream "$GITHUB_BASE_REF"
 
           if [[ ! -d build ]]; then
             git submodule update --init --recursive
@@ -237,9 +237,11 @@ jobs:
           # Run Clang-Tidy
           # The negative filters below are to exclude files that include onnx_pb.h or
           # caffe2_pb.h, otherwise we'd have to build protos as part of this CI job.
+          MERGE_BASE=$(git merge-base $GITHUB_HEAD_REF $GITHUB_BASE_REF)
           python tools/clang_tidy.py                  \
+            --verbose                                 \
             --paths torch/csrc/                       \
-            --diff "${{ github.event.pull_request.base.sha}}" \
+            --diff "$MERGE_BASE"                      \
             -g"-torch/csrc/jit/export.cpp"            \
             -g"-torch/csrc/jit/import.cpp"            \
             -g"-torch/csrc/jit/netdef_converter.cpp"  \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #28798 Update on "[lint] make sure clang-tidy is diffing against the right thing"
* #28797 Update on "[lint] make sure clang-tidy is diffing against the right thing"
* **#28796 [lint] make sure clang-tidy is diffing against the right thing**

Okay, my last fix was wrong because it turns out that the base SHA is
computed at PR time using the actual repo's view of the base ref, not
the user's. So if the user doesn't rebase on top of the latest master
before putting up the PR, the diff thing is wrong anyway.

This PR fixes the issue by not relying on any of these API details and
just getting the merge-base of the base and head refs, which should
guarantee we are diffing against the right thing.