### PR TITLE
Update on "[lint] make sure clang-tidy is diffing against the right thing"

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -254,6 +254,6 @@ jobs:
           check_name: 'clang-tidy'
           linter_output_path: 'clang-tidy-output.txt'
           commit_sha: ${{ steps.get_pr_tip.outputs.commit_sha }}
-          regex: '^(?<filename>.*?):(?<lineNumber>\d+):(?<columnNumber>\d+): (?<errorDesc>.*?) (?<errorCode>\[.*\])'
+          regex: '^(?<filename>.*?):(?<lineNumber>\d+):(?<columnNumber>\d+): (?<errorDesc>.*?) \[(?<errorCode>.*)\]'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #28798 Update on "[lint] make sure clang-tidy is diffing against the right thing"
* **#28797 Update on "[lint] make sure clang-tidy is diffing against the right thing"**
* #28796 [lint] make sure clang-tidy is diffing against the right thing

Okay, my last fix was wrong because it turns out that the base SHA is
computed at PR time using the actual repo's view of the base ref, not
the user's. So if the user doesn't rebase on top of the latest master
before putting up the PR, the diff thing is wrong anyway.

This PR fixes the issue by not relying on any of these API details and
just getting the merge-base of the base and head refs, which should
guarantee we are diffing against the right thing.

This solution taken from https://github.com/github/VisualStudio/pull/1008

Differential Revision: [D18172391](https://our.internmc.facebook.com/intern/diff/D18172391)