### PR TITLE
Update on "[lint] make sure clang-tidy is diffing against the right thing"

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -210,6 +210,9 @@ jobs:
           set -eux
           git remote add upstream https://github.com/pytorch/pytorch
           git fetch upstream "$GITHUB_BASE_REF"
+          BASE_SHA=${{ github.event.pull_request.base.sha }}
+          HEAD_SHA=${{ github.event.pull_request.head.sha }}
+          MERGE_BASE=$(git merge-base $BASE_SHA $HEAD_SHA)
 
           if [[ ! -d build ]]; then
             git submodule update --init --recursive
@@ -237,7 +240,6 @@ jobs:
           # Run Clang-Tidy
           # The negative filters below are to exclude files that include onnx_pb.h or
           # caffe2_pb.h, otherwise we'd have to build protos as part of this CI job.
-          MERGE_BASE=$(git merge-base $GITHUB_HEAD_REF $GITHUB_BASE_REF)
           python tools/clang_tidy.py                  \
             --verbose                                 \
             --paths torch/csrc/                       \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#28798 Update on "[lint] make sure clang-tidy is diffing against the right thing"**
* #28797 Update on "[lint] make sure clang-tidy is diffing against the right thing"
* #28796 [lint] make sure clang-tidy is diffing against the right thing

Okay, my last fix was wrong because it turns out that the base SHA is
computed at PR time using the actual repo's view of the base ref, not
the user's. So if the user doesn't rebase on top of the latest master
before putting up the PR, the diff thing is wrong anyway.

This PR fixes the issue by not relying on any of these API details and
just getting the merge-base of the base and head refs, which should
guarantee we are diffing against the right thing.

This solution taken from https://github.com/github/VisualStudio/pull/1008

Differential Revision: [D18172391](https://our.internmc.facebook.com/intern/diff/D18172391)