### PR TITLE
Increase verbosity of Hypothesis on CI.

### DIFF
--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -462,7 +462,7 @@ try:
                 suppress_health_check=[hypothesis.HealthCheck.too_slow],
                 database=None,
                 max_examples=100,
-                verbosity=hypothesis.Verbosity.quiet))
+                verbosity=hypothesis.Verbosity.normal))
         hypothesis.settings.register_profile(
             "dev",
             hypothesis.settings(
@@ -486,7 +486,7 @@ try:
                 database=None,
                 max_examples=100,
                 min_satisfying_examples=1,
-                verbosity=hypothesis.Verbosity.quiet))
+                verbosity=hypothesis.Verbosity.normal))
         hypothesis.settings.register_profile(
             "dev",
             hypothesis.settings(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#28799 Increase verbosity of Hypothesis on CI.**

When the verbosity is quiet, hypothesis no longer prints the real
error when it finds multiple falsifying examples: it just says
that there are two failures.  This is supremely unuseful. Make
it print more.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D18206936](https://our.internmc.facebook.com/intern/diff/D18206936)