### PR TITLE
Back out "Add memory format support to `ones_like` operator"

### DIFF
--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -384,20 +384,14 @@ Tensor& ones_out(Tensor& result, IntArrayRef size) {
   return native::full_out(result, size, /*fill_value=*/1);
 }
 
-Tensor ones_like(
-    const Tensor& self,
-    const TensorOptions& options,
-    c10::optional<c10::MemoryFormat> optional_memory_format) {
-  auto result = at::empty_like(self, options, optional_memory_format);
-  return result.fill_(1);
+Tensor ones_like(const Tensor& self) {
+  return native::ones(self.sizes(), self.options());
 }
 
-Tensor ones_like(
-    const Tensor& self,
-    c10::optional<c10::MemoryFormat> optional_memory_format) {
-  return native::ones_like(
-      self, self.options(), optional_memory_format);
+Tensor ones_like(const Tensor& self, const TensorOptions& options) {
+  return native::ones(self.sizes(), options);
 }
+
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ scalar_tensor ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Tensor scalar_tensor(Scalar s, const TensorOptions& options) {

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1988,9 +1988,10 @@
 
 - func: ones.out(int[] size, *, Tensor(a!) out) -> Tensor(a!)
 
-- func: ones_like(Tensor self, *, MemoryFormat? memory_format=None) -> Tensor
+- func: ones_like(Tensor self) -> Tensor
+  use_c10_dispatcher: full
 
-- func: ones_like.dtype(Tensor self, *, ScalarType dtype, Layout layout, Device device, bool pin_memory=False, MemoryFormat? memory_format=None) -> Tensor
+- func: ones_like.dtype(Tensor self, *, ScalarType dtype, Layout layout, Device device, bool pin_memory=False) -> Tensor
 
 - func: pairwise_distance(Tensor x1, Tensor x2, float p=2, float eps=1e-06, bool keepdim=False) -> Tensor
   use_c10_dispatcher: full

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -12591,15 +12591,6 @@ class TestTorchDeviceType(TestCase):
 
         self._test_memory_format_transformations(device, input_generator_fn, transformation_fn, compare_data=False)
 
-    def test_memory_format_ones_like_strides(self, device):
-        def input_generator_fn(device):
-            return torch.randn((10, 3, 32, 32), device=device, dtype=torch.float32).contiguous(memory_format=torch.channels_last)
-
-        def transformation_fn(tensor, **kwargs):
-            return torch.ones_like(tensor, **kwargs)
-
-        self._test_memory_format_transformations(device, input_generator_fn, transformation_fn, compare_data=False)
-
     def test_memory_format_type_shortcuts(self, device):
         def input_generator_fn(device):
             return torch.randn((10, 3, 32, 32), device=device, dtype=torch.float32).clamp(0, 1).round().contiguous(memory_format=torch.channels_last)

--- a/tools/autograd/gen_variable_factories.py
+++ b/tools/autograd/gen_variable_factories.py
@@ -63,8 +63,8 @@ def process_function(decl, has_tensor_options, disable_autograd):
         actuals.append(actual)
     requires_grad = "options.requires_grad()" if has_tensor_options else "false"
     if decl['name'].endswith('_like') and not has_tensor_options:
-        SUPPORT_MEMORY_FORMAT = ['empty_like', 'full_like', 'ones_like']
-        if decl['name'] in SUPPORT_MEMORY_FORMAT:
+        # it's a tensor
+        if decl['name'] == 'empty_like' or decl['name'] == 'full_like':
             actuals.insert(-1, '{}.options().is_variable(false)'.format(actuals[0]))
         else:
             actuals.append('{}.options().is_variable(false)'.format(actuals[0]))

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -858,7 +858,7 @@ class ShapePropagator {
             "aten::alias(Tensor self) -> Tensor",
             "aten::empty_like(Tensor self, *, MemoryFormat? memory_format=None) -> Tensor",
             "aten::full_like(Tensor self, Scalar fill_value, *, MemoryFormat? memory_format=None) -> Tensor",
-            "aten::ones_like(Tensor self, *, MemoryFormat? memory_format=None) -> Tensor",
+            "aten::ones_like(Tensor self) -> Tensor",
             "aten::rand_like(Tensor self) -> Tensor",
             "aten::randint_like(Tensor self, int high) -> Tensor",
             "aten::randint_like(Tensor self, int low, int high) -> Tensor",
@@ -1413,7 +1413,7 @@ class ShapePropagator {
         {
             "aten::empty_like(Tensor self, *, int dtype, int layout, Device device, bool pin_memory, MemoryFormat? memory_format=contiguous_format) -> Tensor",
             "aten::full_like(Tensor self, Scalar fill_value, *, int dtype, int layout, Device device, bool pin_memory, MemoryFormat? memory_format=contiguous_format) -> Tensor",
-            "aten::ones_like(Tensor self, *, int dtype, int layout, Device device, bool pin_memory, MemoryFormat? memory_format=contiguous_format) -> Tensor",
+            "aten::ones_like(Tensor self, *, int dtype, int layout, Device device, bool pin_memory) -> Tensor",
             "aten::rand_like(Tensor self, *, int dtype, int layout, Device device, bool pin_memory) -> Tensor",
             "aten::randint_like(Tensor self, int high, *, int dtype, int layout, Device device, bool pin_memory) -> Tensor",
             "aten::randint_like(Tensor self, int low, int high, *, int dtype, int layout, Device device, bool pin_memory) -> Tensor",

--- a/torch/onnx/symbolic_opset8.py
+++ b/torch/onnx/symbolic_opset8.py
@@ -256,8 +256,8 @@ def ones(g, sizes, dtype, layout, device, pin_memory=False):
     return _constant_fill(g, sizes, dtype, 1)
 
 
-@parse_args('v', 'i', 'v', 'v', 'v', 'v')
-def ones_like(g, input, dtype, layout, device, pin_memory=False, memory_format=None):
+@parse_args('v', 'i', 'v', 'v', 'v')
+def ones_like(g, input, dtype, layout, device, pin_memory=False):
     shape = g.op("Shape", input)
     return _constant_fill(g, shape, dtype, 1)
 

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -1229,8 +1229,8 @@ def ones(g, sizes, dtype, layout, device, pin_memory=False):
                 value_t=torch.tensor([1], dtype=sym_help.scalar_type_to_pytorch_type[dtype]))
 
 
-@parse_args('v', 'i', 'v', 'v', 'v', 'v')
-def ones_like(g, input, dtype, layout, device, pin_memory=False, memory_format=None):
+@parse_args('v', 'i', 'v', 'v', 'v')
+def ones_like(g, input, dtype, layout, device, pin_memory=False):
     shape = g.op("Shape", input)
     if dtype is None:
         dtype = 6  # float


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #28803 Back out "Add memory format support to `full_like` operator"
* **#28802 Back out "Add memory format support to `ones_like` operator"**
* #28801 Back out "Add memory format support to `rand_like` operator"

Original commit changeset: 5da9530f6b23

Differential Revision: [D18175303](https://our.internmc.facebook.com/intern/diff/D18175303/)