### PR TITLE
Docs fix: torch.repeat -> torch.Tensor.repeat

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -7007,7 +7007,7 @@ Repeat elements of a tensor.
 
 .. warning::
 
-    This is different from :func:`torch.repeat` but similar to `numpy.repeat`.
+    This is different from :meth:`torch.Tensor.repeat` but similar to `numpy.repeat`.
 
 Args:
     {input}


### PR DESCRIPTION
Currently documentation for `torch.repeat_interleave` mentions `torch.repeat`, which does not exist. Instead, it should mention `torch.Tensor.repeat`

##### Why not make torch.repreat a function?
`torch.Tensor.repeat(*sizes)` has `*args` API, which warrants further discussion. `torch.repeat(tensor, iterable_of_sizes)` deviates from the `Tensor.repeat` (although is consistent with numpy.repeat / numpy.tile), while `torch.repeat(tensor, *sizes)` will be mixing arguments of different types.