### PR TITLE
Temporarily disable test_numerical_consistency_per_channel due to failure

### DIFF
--- a/test/test_fake_quant.py
+++ b/test/test_fake_quant.py
@@ -256,7 +256,7 @@ class TestFakeQuantizePerChannel(TestCase):
     @given(device=st.sampled_from(['cpu', 'cuda'] if torch.cuda.is_available() else ['cpu']),
            X=hu.per_channel_tensor(shapes=hu.array_shapes(1, 5,),
            qparams=hu.qparams(dtypes=torch.quint8)))
-    @unittest.skip("temoprarily disable the test")
+    @unittest.skip("temporarily disable the test")
     def test_numerical_consistency_per_channel(self, device, X):
         r"""Comparing numerical consistency between CPU quantize/dequantize op and the CPU fake quantize op
         """

--- a/test/test_fake_quant.py
+++ b/test/test_fake_quant.py
@@ -256,6 +256,7 @@ class TestFakeQuantizePerChannel(TestCase):
     @given(device=st.sampled_from(['cpu', 'cuda'] if torch.cuda.is_available() else ['cpu']),
            X=hu.per_channel_tensor(shapes=hu.array_shapes(1, 5,),
            qparams=hu.qparams(dtypes=torch.quint8)))
+    @unittest.skip("temoprarily disable the test")
     def test_numerical_consistency_per_channel(self, device, X):
         r"""Comparing numerical consistency between CPU quantize/dequantize op and the CPU fake quantize op
         """

--- a/test/test_quantizer.py
+++ b/test/test_quantizer.py
@@ -39,7 +39,7 @@ class WeightObserver(Observer):
 @unittest.skipUnless('fbgemm' in torch.backends.quantized.supported_engines,
                      " Quantized operations require FBGEMM. FBGEMM is only optimized for CPUs"
                      " with instruction set support avx2 or newer.")
-@unittest.skip("temoprarily disable the test")
+@unittest.skip("temporarily disable the test")
 class QuantizerTestCase(TestCase):
     @_tmp_donotuse_dont_inline_everything
     def test_default(self):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#28807 Temporarily disable test_numerical_consistency_per_channel due to failure**

`FAIL: test_numerical_consistency_per_channel (_main_.TestFakeQuantizePerChannel)`

This test is failing consistently on master, we can't find a clean blame.

Differential Revision: [D18181496](https://our.internmc.facebook.com/intern/diff/D18181496/)