### PR TITLE
[iOS][Benchmark] `bootstrap.sh` refactor 

### DIFF
--- a/ios/TestApp/.gitignore
+++ b/ios/TestApp/.gitignore
@@ -1,1 +1,2 @@
 model.pt
+.config

--- a/ios/TestApp/README.md
+++ b/ios/TestApp/README.md
@@ -21,9 +21,10 @@ The TestApp is currently being used as a dummy app by Circle CI for nightly jobs
 The benchmark folder contains two scripts that help you setup the benchmark project. The `setup.rb` does the heavy-lifting jobs of setting up the XCode project, whereas the `trace_model.py` is a Python script that you can tweak to generate your model for benchmarking. Simply follow the steps below to setup the project
 
 1. In the PyTorch root directory, run `BUILD_PYTORCH_MOBILE=1 IOS_ARCH=arm64 ./scripts/build_ios.sh` to generate the custom build from **Master** branch
-2. Navigate to the `benchmark` folder, run `python trace_model.py` to get your model generated.
-3. In the same directory, run `ruby setup.rb` to setup the XCode project.
-4. Open the `TestApp.xcodeproj`, you're ready to go.
+2. Navigate to the `benchmark` folder, run `python trace_model.py` to generate your model.
+3. In the same directory, open `config.json`. Those are the input parameters you can tweak.
+4. Again, in the same directory, run `ruby setup.rb` to setup the XCode project.
+5. Open the `TestApp.xcodeproj`, you're ready to go.
 
 The benchmark code is written in C++, see `benchmark.mm` for more details.
 
@@ -35,13 +36,13 @@ For those who want to do perf testing but don't want touch XCode, `bootstrap.sh`
 2. A valid provisioning profile for code signing
 3. A valid team identifier
 
-To run the script, simply type the command below and make sure your phone is unlocked and connected via USB. 
+To run the script, simply type the command below and make sure your phone is connected via USB. 
 
 ```shell
-./bootstrap -t ${TEAM_ID} -p ${PROVISIONING_PROFILE}
+./bootstrap
 ```
 
-The benchmark log will be displayed on the screen.
+Open the app on your device, the benchmark result will be displayed on the screen.
 
 > Note This requires ios-deploy to be installed. Please have a look at [ios-deploy](https://github.com/ios-control/ios-deploy). To quickly install it, use `npm -g i ios-deploy`
 

--- a/ios/TestApp/TestApp/Base.lproj/Main.storyboard
+++ b/ios/TestApp/TestApp/Base.lproj/Main.storyboard
@@ -33,7 +33,13 @@
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                     </view>
-                    <navigationItem key="navigationItem" title="speed_benchmark_torch" id="zRt-2x-Qpi"/>
+                    <navigationItem key="navigationItem" title="speed_benchmark_torch" id="zRt-2x-Qpi">
+                        <barButtonItem key="rightBarButtonItem" style="plain" systemItem="redo" id="J2L-mS-Fgq">
+                            <connections>
+                                <action selector="reRun:" destination="BYZ-38-t0r" id="OSo-SJ-K7N"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
                     <connections>
                         <outlet property="textView" destination="3QV-4Z-f2v" id="Z1X-Bu-UDB"/>
                     </connections>

--- a/ios/TestApp/TestApp/Benchmark.mm
+++ b/ios/TestApp/TestApp/Benchmark.mm
@@ -77,7 +77,6 @@ static int iter = 10;
   if (print_output) {
     std::cout << module.forward(inputs) << std::endl;
   }
-  UI_LOG(@"Start benchmarking...", nil);
   UI_LOG(@"Running warmup runs", nil);
   CAFFE_ENFORCE(warmup >= 0, "Number of warm up runs should be non negative, provided ", warmup,
                 ".");

--- a/ios/TestApp/TestApp/ViewController.mm
+++ b/ios/TestApp/TestApp/ViewController.mm
@@ -7,7 +7,8 @@
 
 @end
 
-@implementation ViewController
+@implementation ViewController {
+}
 
 - (void)viewDidLoad {
   [super viewDidLoad];
@@ -18,20 +19,29 @@
   NSDictionary* config = [NSJSONSerialization JSONObjectWithData:configData
                                                          options:NSJSONReadingAllowFragments
                                                            error:&err];
+
   if (err) {
     NSLog(@"Parse config.json failed!");
     return;
   }
+  [Benchmark setup:config];
+  [self runBenchmark];
+}
 
+- (void)runBenchmark {
+  self.textView.text = @"Start benchmarking...\n";
   dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-    if ([Benchmark setup:config]) {
-      NSString* text = [Benchmark run];
-      dispatch_async(dispatch_get_main_queue(), ^{
-        self.textView.text = text;
-      });
-    } else {
-      NSLog(@"Setup benchmark config failed!");
-    }
+    NSString* text = [Benchmark run];
+    dispatch_async(dispatch_get_main_queue(), ^{
+      self.textView.text = [self.textView.text stringByAppendingString:text];
+    });
+  });
+}
+
+- (IBAction)reRun:(id)sender {
+  self.textView.text = @"";
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [self runBenchmark];
   });
 }
 

--- a/ios/TestApp/bootstrap.sh
+++ b/ios/TestApp/bootstrap.sh
@@ -22,14 +22,30 @@ bootstrap() {
     XCODE_PROJ_PATH="./TestApp.xcodeproj"
     XCODE_TARGET="TestApp"
     XCODE_BUILD="./build"
-    if [ -d ${XCODE_BUILD} ]; then
+    if [ ! -f "./.config" ]; then 
+        touch .config
+        echo "" >> .config
+    else
+        source .config
+    fi
+    if [ -z "${TEAM_ID}" ]; then 
+        reply=$(bash -c 'read -r -p "Team Id:" tmp; echo $tmp')
+        TEAM_ID="${reply}"
+        echo "TEAM_ID=${TEAM_ID}" >> .config
+    fi
+    if [ -z "${PROFILE}" ]; then 
+        reply=$(bash -c 'read -r -p "Provisioning Profile:" tmp; echo $tmp')
+        PROFILE="${reply}"
+        echo "PROFILE=${PROFILE}" >> .config
+    fi
+    if [ -d "${XCODE_BUILD}" ]; then
         echo "found the old XCode build, remove it"
-        rm -rf ${XCODE_BUILD}
+        rm -rf "${XCODE_BUILD}"
     fi 
-    cd ${BENCHMARK_DIR}
+    cd "${BENCHMARK_DIR}"
     echo "Generating model"
     python trace_model.py
-    ruby setup.rb -t ${TEAM_ID}
+    ruby setup.rb -t "${TEAM_ID}"
     cd ..
     #run xcodebuild
     if ! [ -x "$(command -v xcodebuild)" ]; then
@@ -76,8 +92,5 @@ case $option in
 esac
 shift 
 done
-
-echo TEAM_ID = "${TEAM_ID}"
-echo PROFILE = "${PROFILE}"
 
 bootstrap


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#28809 [iOS][Automation] Refactor bootstrap.sh**

### Summary

This PR adds the interactive mode to `bootstrap.sh`. Instead of passing the credential information from command parameters(`-t`,`-p`), we're going to ask the user enter that information and save it to a config file, such that next time you don't have to enter again. So all you need now, is one line command 

```shell
./bootstrap
```

### Test Plan

- TestApp.ipa can be installed on any devices
- Don't break CI jobs

Differential Revision: [D18194032](https://our.internmc.facebook.com/intern/diff/D18194032)