### PR TITLE
missed one place to workaround vs2019 bug on preprocessing

### DIFF
--- a/torch/csrc/jit/passes/quantization.cpp
+++ b/torch/csrc/jit/passes/quantization.cpp
@@ -974,7 +974,7 @@ graph(%a_dequant, %w, %b, %w_scale, %w_zero_point, %w_dtype):
 graph(%a_dequant, %w, %b, %w_scale, %w_zero_point, %w_dtype, %stride, %padding, %dilation, %groups):
         %w_quant = aten::quantize_per_tensor(%w, %w_scale, %w_zero_point, %w_dtype)
         %packed_params = quantized::conv_prepack(%w_quant, %b, %stride, %padding, %dilation, %groups)
-        return (%packed_params))";
+        return (%packed_params) )";
 
   // (is_conv, pattern, packed_params_module)
   auto pattern_and_modules = {


### PR DESCRIPTION
original pull request is https://github.com/pytorch/pytorch/pull/28349  , it's a workaround for visual studio 2019 preprocessing bug: https://developercommunity.visualstudio.com/content/problem/674096/when-using-p-raw-litteral-preprocessing-fails-and.html 