### PR TITLE
change softmax input shape

### DIFF
--- a/benchmarks/operator_benchmark/pt/softmax_test.py
+++ b/benchmarks/operator_benchmark/pt/softmax_test.py
@@ -17,8 +17,8 @@ Microbenchmarks for the softmax operators.
 # Configs for softmax ops
 softmax_configs_short = op_bench.config_list(
     attrs=[
-        [4, 3, 128, 128],
-        [8, 3, 256, 256],
+        [4, 3, 256, 256],
+        [8, 3, 512, 512],
     ],
     attr_names=[
         'N', 'C', 'H', 'W'


### PR DESCRIPTION
Summary: as title

Test Plan:
```
buck run mode/opt //caffe2/benchmarks/operator_benchmark/pt:softmax_test
Invalidating internal cached state: Buck configuration options changed between invocations. This may cause slower builds.
  Changed value project.buck_out='buck-out/opt' (was 'buck-out/dev')
  ... and 56 more. See logs for all changes
Parsing buck files: finished in 6.2 sec
Creating action graph: finished in 8.8 sec
Building: finished in 05:42.6 min (100%) 28336/28336 jobs, 23707 updated
  Total time: 05:57.7 min
# ----------------------------------------
# PyTorch/Caffe2 Operator Micro-benchmarks
# ----------------------------------------
# Tag : short

# Benchmarking PyTorch: Softmax
/proc/self/fd/4/softmax_test.py:57: UserWarning: Implicit dimension choice for softmax has been deprecated. Change the call to include dim=X as an argument.
  """
# Mode: Eager
# Name: Softmax_N4_C3_H256_W256
# Input: N: 4, C: 3, H: 256, W: 256
Forward Execution Time (us) : 18422.487

Reviewed By: hl475

Differential Revision: D18202335

