### PR TITLE
fix op bench runtime error when use_jit is enabled

### DIFF
--- a/benchmarks/operator_benchmark/benchmark_pytorch.py
+++ b/benchmarks/operator_benchmark/benchmark_pytorch.py
@@ -76,7 +76,7 @@ class TorchBenchmarkBase(object):
         @torch.jit.script
         def _jit_forward_graph(iters, place_holder):
             # type: (int, Tensor)
-            result = torch.jit.annotate(torch.Tensor, None)
+            result = torch.jit.annotate(torch.Tensor, place_holder)
             for _ in range(iters):
                 result = func(place_holder)
             return result


### PR DESCRIPTION
Summary: The JIT code used in op bench is not compatibility with latest JIT code path. This diff aims to resolve that issue.

Test Plan:
```buck run mode/opt //caffe2/benchmarks/operator_benchmark/pt:add_test -- --use_jit
Building: finished in 02:29.8 min (100%) 7055/7055 jobs, 1 updated
  Total time: 02:30.3 min
# ----------------------------------------
# PyTorch/Caffe2 Operator Micro-benchmarks
# ----------------------------------------
# Tag : short

# Benchmarking PyTorch: add
# Mode: JIT
# Name: add_M64_N64_K64_cpu
# Input: M: 64, N: 64, K: 64, device: cpu
Forward Execution Time (us) : 118.052

Reviewed By: hl475

Differential Revision: D18197057

