### PR TITLE
print per block avg time when running on AI-PEP machines

### DIFF
--- a/benchmarks/operator_benchmark/benchmark_core.py
+++ b/benchmarks/operator_benchmark/benchmark_core.py
@@ -84,9 +84,6 @@ class BenchmarkRunner(object):
         if self.args.test_name is not None:
             self.args.tag_filter = None
 
-        if self.args.ai_pep_format:
-            self.print_per_iter = True
-
 
     def _print_header(self):
         DASH_LINE = '-' * 40
@@ -199,10 +196,18 @@ class BenchmarkRunner(object):
 
             report_run_time = 1e6 * run_time_sec / iters
             time_trace.append(report_run_time)
+            # Print out the time spent in each epoch in ms 
+            if self.args.ai_pep_format:
+                test_name = '_'.join([test_case.framework, test_case.test_config.test_name])
+                print("PyTorchObserver " + json.dumps(
+                    {
+                        "type": test_name,
+                        "metric": "latency",
+                        "unit": "ms",
+                        "value": str(report_run_time / 1e3),
+                    }
+                ))
             if results_are_significant:
-                # Print out the last 50 values when running with AI PEP
-                if self.args.ai_pep_format:
-                    test_case._print_per_iter()
                 break
 
             # Re-estimate the hopefully-sufficient


### PR DESCRIPTION
Summary: as title

Test Plan:
```
buck run mode/opt //caffe2/benchmarks/operator_benchmark/pt:softmax_test -- --ai_pep_format true
  Total time: 02:36.7 min
# ----------------------------------------
# PyTorch/Caffe2 Operator Micro-benchmarks
# ----------------------------------------
# Tag : short

# Benchmarking PyTorch: Softmax
/proc/self/fd/4/softmax_test.py:57: UserWarning: Implicit dimension choice for softmax has been deprecated. Change the call to include dim=X as an argument.
  """
PyTorchObserver {"type": "PyTorch_Softmax_N4_C3_H128_W128", "metric": "latency", "unit": "ms", "value": "4.83197245048359"}
PyTorchObserver {"type": "PyTorch_Softmax_N4_C3_H128_W128", "metric": "latency", "unit": "ms", "value": "4.839232977246866"}
PyTorchObserver {"type": "PyTorch_Softmax_N4_C3_H128_W128", "metric": "latency", "unit": "ms", "value": "4.7970924858236685"}
PyTorchObserver {"type": "PyTorch_Softmax_N4_C3_H128_W128", "metric": "latency", "unit": "ms", "value": "4.708389271399938"}
# Benchmarking PyTorch: Softmax
...

Reviewed By: hl475

Differential Revision: D18202504

