### PR TITLE
[ci] don't overspecify required python version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7.4
+          python-version: 3.x
           architecture: x64
       - name: Checkout PyTorch
         uses: actions/checkout@master
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7.4
+          python-version: 3.x
           architecture: x64
       - name: Checkout PyTorch
         uses: actions/checkout@master
@@ -69,7 +69,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7.4
+          python-version: 3.x
           architecture: x64
       - name: Checkout PyTorch
         uses: actions/checkout@master
@@ -84,7 +84,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7.4
+          python-version: 3.x
           architecture: x64
       - name: Checkout PyTorch
         uses: actions/checkout@master
@@ -99,7 +99,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7.4
+          python-version: 3.x
           architecture: x64
       - name: Fetch PyTorch
         uses: actions/checkout@master
@@ -174,7 +174,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7.4
+          python-version: 3.x
           architecture: x64
       - name: Checkout PyTorch
         uses: actions/checkout@master


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#28842 [ci] don't overspecify required python version**

We don't care which python version, and github actions has changed the
versions available, breaking our CI. So just pin it to 3-something to
make it more future proof

Differential Revision: [D18205349](https://our.internmc.facebook.com/intern/diff/D18205349)