### PR TITLE
Add host build for pytorch_android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,33 +1,37 @@
-buildscript {
-    ext {
-        minSdkVersion = 21
-        targetSdkVersion = 28
-        compileSdkVersion = 28
-        buildToolsVersion = '28.0.3'
-
-        coreVersion = "1.2.0"
-        extJUnitVersion = "1.1.1"
-        runnerVersion = "1.2.0"
-        rulesVersion = "1.2.0"
-        junitVersion = "4.12"
-    }
-
-    repositories {
-        google()
-        mavenLocal()
-        mavenCentral()
-        jcenter()
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.2'
-        classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:${GRADLE_BINTRAY_PLUGIN_VERSION}"
-        classpath "com.github.dcendents:android-maven-gradle-plugin:${ANDROID_MAVEN_GRADLE_PLUGIN_VERSION}"
-        classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.9.8"
-    }
-}
-
 allprojects {
+    if (name == "pytorch_host") {
+        return
+    }
+
+    buildscript {
+        ext {
+            minSdkVersion = 21
+            targetSdkVersion = 28
+            compileSdkVersion = 28
+            buildToolsVersion = '28.0.3'
+
+            coreVersion = "1.2.0"
+            extJUnitVersion = "1.1.1"
+            runnerVersion = "1.2.0"
+            rulesVersion = "1.2.0"
+            junitVersion = "4.12"
+        }
+
+        repositories {
+            google()
+            mavenLocal()
+            mavenCentral()
+            jcenter()
+        }
+
+        dependencies {
+            classpath 'com.android.tools.build:gradle:3.3.2'
+            classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:${GRADLE_BINTRAY_PLUGIN_VERSION}"
+            classpath "com.github.dcendents:android-maven-gradle-plugin:${ANDROID_MAVEN_GRADLE_PLUGIN_VERSION}"
+            classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.9.8"
+        }
+    }
+
     repositories {
         google()
         jcenter()

--- a/android/pytorch_android/host/build.gradle
+++ b/android/pytorch_android/host/build.gradle
@@ -1,0 +1,33 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the Apache-2 license found in the
+// LICENSE file in the root directory of this source tree.
+
+plugins {
+    id 'java-library'
+}
+
+repositories {
+    mavenLocal()
+    jcenter()
+}
+
+sourceSets {
+    main {
+        java.srcDir '../src/main/java'
+    }
+    test {
+        java {
+            srcDir '../src/androidTest/java'
+            exclude '**/PytorchInstrumented*'
+        }
+        resources.srcDirs = ["../src/androidTest/assets"]
+    }
+}
+
+dependencies {
+    compileOnly 'com.google.code.findbugs:jsr305:3.0.1'
+    implementation 'com.facebook.soloader:nativeloader:0.8.0'
+    implementation 'com.facebook.fbjni:fbjni:0.0.3-SNAPSHOT'
+    testImplementation 'junit:junit:4.12'
+}

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,4 +1,6 @@
-include ':app', ':pytorch_android', ':fbjni', ':pytorch_android_torchvision'
+include ':app', ':pytorch_android', ':fbjni', ':pytorch_android_torchvision', ':pytorch_host'
 
 project(':fbjni').projectDir = file('libs/fbjni_local')
 project(':pytorch_android_torchvision').projectDir = file('pytorch_android_torchvision')
+
+project(':pytorch_host').projectDir = file('pytorch_android/host')


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #28848 Add support for host build to pytorch_android native code
* #28847 Remove unnecessary BUILD_DIR variable in Android CMake build
* **#28846 Add host build for pytorch_android**

This adds a new gradle subproject at pytorch_android/host and tweaks
the top-level build.gradle to only run some Android bits on the other
projects.

Referencing Java sources from inside the host directory feels a bit
hacky, but getting host and Android Gradle builds to coexist in the same
directory hit several roadblocks.  We can try a bigger refactor to
separate the Android-specific and non-Android-specific parts of the
code, but that seems overkill at this point for 4 Java files.

This doesn't actually run without some local changes to fbjni, but I
want to get the files landed to avoid unnecessary merge conflicts.