### PR TITLE
Remove unnecessary BUILD_DIR variable in Android CMake build

### DIFF
--- a/android/pytorch_android/CMakeLists.txt
+++ b/android/pytorch_android/CMakeLists.txt
@@ -24,11 +24,8 @@ target_include_directories(pytorch PUBLIC
     ${libtorch_include_DIR}
 )
 
-set(BUILD_DIR ${CMAKE_SOURCE_DIR}/build)
-file(MAKE_DIRECTORY ${BUILD_DIR})
-
 set(fbjni_DIR ${CMAKE_CURRENT_LIST_DIR}/../libs/fbjni/)
-set(fbjni_BUILD_DIR ${BUILD_DIR}/fbjni/${ANDROID_ABI})
+set(fbjni_BUILD_DIR ${CMAKE_BINARY_DIR}/fbjni/${ANDROID_ABI})
 
 add_subdirectory(${fbjni_DIR} ${fbjni_BUILD_DIR})
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #28848 Add support for host build to pytorch_android native code
* **#28847 Remove unnecessary BUILD_DIR variable in Android CMake build**
* #28846 Add host build for pytorch_android

CMake sets CMAKE_BINARY_DIR and creates it automatically.  Using this
allows us to use the -B command-line flag to CMake to specify an
alternate output directory.