### PR TITLE
Add support for host build to pytorch_android native code

### DIFF
--- a/android/pytorch_android/CMakeLists.txt
+++ b/android/pytorch_android/CMakeLists.txt
@@ -4,7 +4,19 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_VERBOSE_MAKEFILE ON)
 
 set(pytorch_android_DIR ${CMAKE_CURRENT_LIST_DIR}/src/main/cpp)
-set(libtorch_include_DIR ${pytorch_android_DIR}/libtorch_include/${ANDROID_ABI})
+
+if (ANDROID_ABI)
+  set(libtorch_include_DIR ${pytorch_android_DIR}/libtorch_include/${ANDROID_ABI})
+  set(BUILD_SUBDIR ${ANDROID_ABI})
+else()
+  if (NOT LIBTORCH_HOME)
+    message(FATAL_ERROR
+      "pytorch_android requires LIBTORCH_HOME to be defined for non-Android builds.")
+  endif()
+  set(libtorch_include_DIR ${LIBTORCH_HOME}/include)
+  link_directories(${LIBTORCH_HOME}/lib)
+  set(BUILD_SUBDIR host)
+endif()
 
 message(STATUS "libtorch dir:${libtorch_DIR}")
 
@@ -25,36 +37,57 @@ target_include_directories(pytorch PUBLIC
 )
 
 set(fbjni_DIR ${CMAKE_CURRENT_LIST_DIR}/../libs/fbjni/)
-set(fbjni_BUILD_DIR ${CMAKE_BINARY_DIR}/fbjni/${ANDROID_ABI})
+set(fbjni_BUILD_DIR ${CMAKE_BINARY_DIR}/fbjni/${BUILD_SUBDIR})
 
 add_subdirectory(${fbjni_DIR} ${fbjni_BUILD_DIR})
 
-function(import_static_lib name)
-  add_library(${name} STATIC IMPORTED)
-  set_property(
-      TARGET ${name}
-      PROPERTY IMPORTED_LOCATION
-      ${CMAKE_CURRENT_LIST_DIR}/src/main/jniLibs/${ANDROID_ABI}/${name}.a)
-endfunction(import_static_lib)
+if (ANDROID_ABI)
 
-import_static_lib(libtorch)
-import_static_lib(libc10)
-import_static_lib(libnnpack)
-import_static_lib(libpytorch_qnnpack)
-import_static_lib(libeigen_blas)
-import_static_lib(libcpuinfo)
-import_static_lib(libclog)
+  function(import_static_lib name)
+    add_library(${name} STATIC IMPORTED)
+    set_property(
+        TARGET ${name}
+        PROPERTY IMPORTED_LOCATION
+        ${CMAKE_CURRENT_LIST_DIR}/src/main/jniLibs/${ANDROID_ABI}/${name}.a)
+  endfunction(import_static_lib)
 
-target_link_libraries(pytorch
-    fbjni
-    -Wl,--gc-sections
-    -Wl,--whole-archive
-    libtorch
-    -Wl,--no-whole-archive
-    libc10
-    libnnpack
-    libpytorch_qnnpack
-    libeigen_blas
-    libcpuinfo
-    libclog
-)
+  import_static_lib(libtorch)
+  import_static_lib(libc10)
+  import_static_lib(libnnpack)
+  import_static_lib(libpytorch_qnnpack)
+  import_static_lib(libeigen_blas)
+  import_static_lib(libcpuinfo)
+  import_static_lib(libclog)
+
+    # Link most things statically on Android.
+  target_link_libraries(pytorch
+      fbjni
+      -Wl,--gc-sections
+      -Wl,--whole-archive
+      libtorch
+      -Wl,--no-whole-archive
+      libc10
+      libnnpack
+      libpytorch_qnnpack
+      libeigen_blas
+      libcpuinfo
+      libclog
+  )
+
+else()
+
+  # Prefer dynamic linking on the host
+  target_link_libraries(pytorch
+      fbjni
+      -Wl,--gc-sections
+      -Wl,--whole-archive
+      torch
+      -Wl,--no-whole-archive
+      c10
+      nnpack
+      pytorch_qnnpack
+      cpuinfo
+      clog
+  )
+
+endif()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#28848 Add support for host build to pytorch_android native code**
* #28847 Remove unnecessary BUILD_DIR variable in Android CMake build
* #28846 Add host build for pytorch_android

When ANDROID_ABI is not set, find libtorch headers and libraries from
the LIBTORCH_HOME build variable (which must be set by hand), place
output under a "host" directory, and use dynamic linking instead of
static.

This doesn't actually work without some local changes to fbjni, but I
want to get the changes landed to avoid unnecessary merge conflicts.