### PR TITLE
whitelist autogradanynonzero

### DIFF
--- a/test/backward_compatibility/check_backward_compatibility.py
+++ b/test/backward_compatibility/check_backward_compatibility.py
@@ -26,6 +26,7 @@ white_list = [
     ('rand_like', datetime.date(2019, 11, 11)),
     ('ones_like', datetime.date(2019, 11, 11)),
     ('full_like', datetime.date(2019, 11, 11)),
+    ('autogradanynonzero', datetime.date(2019, 11, 11)),
 ]
 
 

--- a/test/backward_compatibility/check_backward_compatibility.py
+++ b/test/backward_compatibility/check_backward_compatibility.py
@@ -26,7 +26,7 @@ white_list = [
     ('rand_like', datetime.date(2019, 11, 11)),
     ('ones_like', datetime.date(2019, 11, 11)),
     ('full_like', datetime.date(2019, 11, 11)),
-    ('autogradanynonzero', datetime.date(2019, 11, 11)),
+    ('AutogradAnyNonZero', datetime.date(2019, 11, 11)),
 ]
 
 


### PR DESCRIPTION
prim::AutogradAnyNonZero is optimized away under normal circumstances (a graph executor specializes tensor arguments and runs `specializeAutogradZero`), so the change should be backward compatible for as long as we are running the original executor.