### PR TITLE
[pytorch] Disable crc32 checks in torch::load().

### DIFF
--- a/third_party/miniz-2.0.8/miniz.c
+++ b/third_party/miniz-2.0.8/miniz.c
@@ -4522,7 +4522,9 @@ void *mz_zip_reader_extract_file_to_heap(mz_zip_archive *pZip, const char *pFile
 mz_bool mz_zip_reader_extract_to_callback(mz_zip_archive *pZip, mz_uint file_index, mz_file_write_func pCallback, void *pOpaque, mz_uint flags)
 {
     int status = TINFL_STATUS_DONE;
+#ifndef MINIZ_DISABLE_ZIP_READER_CRC32_CHECKS
     mz_uint file_crc32 = MZ_CRC32_INIT;
+#endif
     mz_uint64 read_buf_size, read_buf_ofs = 0, read_buf_avail, comp_remaining, out_buf_ofs = 0, cur_file_ofs;
     mz_zip_archive_file_stat file_stat;
     void *pRead_buf = NULL;

--- a/third_party/miniz-2.0.8/miniz.h
+++ b/third_party/miniz-2.0.8/miniz.h
@@ -145,6 +145,9 @@
    functions (such as tdefl_compress_mem_to_heap() and tinfl_decompress_mem_to_heap()) won't work. */
 /*#define MINIZ_NO_MALLOC */
 
+/* Define MINIZ_DISABLE_ZIP_READER_CRC32_CHECKS to skip crc32 integrity checks when unzipping */
+#define MINIZ_DISABLE_ZIP_READER_CRC32_CHECKS
+
 #if defined(__TINYC__) && (defined(__linux) || defined(__linux__))
 /* TODO: Work around "error: include file 'sys\utime.h' when compiling with tcc on Linux */
 #define MINIZ_NO_TIME


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#28858 [pytorch] Disable crc32 checks in torch::load().**

torch::load() probably would not be doing crc32 checks if we weren't
using zip format as a container, where crc32 is part of the format.

 - This change skips crc checks on the torch::load() side.
 - It currently leaves in changes on the torch::save() side, where
   there might yet be discussion about whether we want to retain
   compatibility with zip-based tools.

Instead, we rely on checksumming in any underlying transport layer,
along with the fact that some minor coefficient errors in tensors
aren't necessarily catastrophic.

Differential Revision: [D18214958](https://our.internmc.facebook.com/intern/diff/D18214958/)