### PR TITLE
[ONNX] Modify ONNX constant folding test point in test_utility_funs.py for clarity

### DIFF
--- a/test/onnx/test_utility_funs.py
+++ b/test/onnx/test_utility_funs.py
@@ -140,7 +140,8 @@ class TestUtilityFuns(TestCase):
                 a = torch.tensor([[1., 2., 3.]])
                 b = torch.tensor([[4., 5., 6.]])
                 c = torch.cat((a, b), 0)
-                return b + c
+                d = b + c
+                return x + d
 
         _set_opset_version(self.opset_version)
         x = torch.ones(2, 3)
@@ -151,7 +152,7 @@ class TestUtilityFuns(TestCase):
             assert node.kind() != "onnx::Concat"
             assert node.kind() != "onnx::Cast"
             assert node.kind() != "onnx::Constant"
-        assert len(list(graph.nodes())) == 1
+        assert len(list(graph.nodes())) == 2
 
     def test_constant_fold_lstm(self):
         class GruNet(torch.nn.Module):


### PR DESCRIPTION
This is a minor update to the test point `TestUtilityFuns.test_constant_fold_concat` in `test/onnx/test_utility_fun.py` for clarity. Unlike before, the test model forward() method now uses the input `x`.
