### PR TITLE
Update fbjni submodule to new upstream and latest version

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -117,4 +117,4 @@
 [submodule "android/libs/fbjni"]
     ignore = dirty
     path = android/libs/fbjni
-    url = https://github.com/IvanKobzarev/fbjni.git
+    url = https://github.com/facebookincubator/fbjni.git

--- a/android/libs/fbjni_local/build.gradle
+++ b/android/libs/fbjni_local/build.gradle
@@ -11,7 +11,7 @@ android {
 
         sourceSets {
             main {
-                manifest.srcFile '../fbjni/ApplicationManifest.xml'
+                manifest.srcFile '../fbjni/java/com/facebook/jni/AndroidManifest.xml'
                 java {
                     srcDir '../fbjni/java'
                 }
@@ -35,6 +35,7 @@ android {
 
 dependencies {
     compileOnly 'com.google.code.findbugs:jsr305:3.0.1'
+    implementation 'com.facebook.soloader:nativeloader:0.8.0'
 }
 
 apply from: rootProject.file('gradle/release.gradle')


### PR DESCRIPTION
Summary:
The central fbjni repository is now public, so point to it and
take the latest version, which includes support for host builds
and some condensed syntax.

Test Plan: CI

Differential Revision: D18217840

