### PR TITLE
Connect with clip range gather operator

### DIFF
--- a/caffe2/opt/custom/converter.cc
+++ b/caffe2/opt/custom/converter.cc
@@ -214,6 +214,10 @@ class ClipRangesGatherSigridHashConverter : public Converter {
     if (args.HasArgument("max_values")) {
       c->setMaxValues(args.GetRepeatedArgument<int64_t>("max_values"));
     }
+    if (args.HasArgument("hash_into_int32")) {
+      c->setHashIntoInt32(
+          args.GetSingleArgument<bool>("hash_into_int32", false));
+    }
     return nnOp;
   }
 
@@ -230,6 +234,8 @@ class ClipRangesGatherSigridHashConverter : public Converter {
         caffe2::MakeArgument<vector<int64_t>>("salts", fuse->getSalts()));
     op.add_arg()->CopyFrom(caffe2::MakeArgument<vector<int64_t>>(
         "max_values", fuse->getMaxValues()));
+    op.add_arg()->CopyFrom(caffe2::MakeArgument<bool>(
+        "hash_into_int32", fuse->getHashIntoInt32()));
     return op;
   }
 

--- a/caffe2/opt/custom/converter_test.cc
+++ b/caffe2/opt/custom/converter_test.cc
@@ -1,0 +1,33 @@
+#include "caffe2/core/common.h"
+#include "caffe2/core/test_utils.h"
+#include "caffe2/opt/converter.h"
+#include "caffe2/opt/custom/concat_elim.h"
+#include "caffe2/predictor/emulator/data_filler.h"
+#include "caffe2/utils/proto_utils.h"
+
+#include <gtest/gtest.h>
+
+using namespace caffe2::testing;
+using namespace caffe2::emulator;
+using caffe2::OperatorDef;
+using std::vector;
+
+TEST(Converter, ClipRangesGatherSigridHashConverter) {
+  OperatorDef op;
+  op.set_type("ClipRangesGatherSigridHash");
+  op.add_arg()->CopyFrom(caffe2::MakeArgument<bool>("hash_into_int32", true));
+  auto nnDef = convertToNeuralNetOperator(op);
+  auto* pNNDef =
+      static_cast<nom::repr::ClipRangesGatherSigridHash*>(nnDef.get());
+  EXPECT_TRUE(pNNDef);
+  EXPECT_TRUE(pNNDef->getHashIntoInt32());
+
+  OperatorDef op2;
+  op2.set_type("ClipRangesGatherSigridHash");
+  op2.add_arg()->CopyFrom(caffe2::MakeArgument<bool>("hash_into_int32", false));
+  auto nnDef2 = convertToNeuralNetOperator(op2);
+  auto* pNNDef2 =
+      static_cast<nom::repr::ClipRangesGatherSigridHash*>(nnDef2.get());
+  EXPECT_TRUE(pNNDef2);
+  EXPECT_FALSE(pNNDef2->getHashIntoInt32());
+}


### PR DESCRIPTION
Summary: When we are working on the fix for int32 instead of int64, we also need to take care of the ClipRangesGatherSigridHash since this is the operator that actually gets used during inference.

Test Plan: Added unittest to cover for the new case

Reviewed By: ipiszy

Differential Revision: D17147237

