### PR TITLE
Enable PyTorch Probot as a GitHub Action.

### DIFF
--- a/.github/workflows/probot.yml
+++ b/.github/workflows/probot.yml
@@ -1,0 +1,17 @@
+name: PyTorch Probot
+on:
+  issues:
+    types: [opened, labeled, unlabeled]
+  issue_comment:
+    types: [created]
+  pull_request:
+    types: [opened, labeled, unlabeled]
+
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+    name: PyTorch Probot
+    steps:
+      - uses: pytorch/pytorch-probot@releases/v1
+        env:
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#28879 Enable PyTorch Probot as a GitHub Action.**

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D18231741](https://our.internmc.facebook.com/intern/diff/D18231741)