### PR TITLE
DDP should not set grad for globally unused params

### DIFF
--- a/test/test_c10d.py
+++ b/test/test_c10d.py
@@ -2518,7 +2518,7 @@ class DistributedDataParallelTest(MultiProcessTestCase):
         except Exception as ex:
             self.fail("Unexpected exception: %s" % ex)
 
-    @requires_nccl()
+    @requires_gloo()
     @skip_if_lt_x_gpu(2)
     def test_global_local_unused_params_grad(self):
         """
@@ -2533,7 +2533,7 @@ class DistributedDataParallelTest(MultiProcessTestCase):
                     self.p = nn.Parameter(torch.ones(2, 2))
 
                 def forward(self, x):
-                    return self.p
+                    return self.p + x
 
             def __init__(self):
                 super().__init__()
@@ -2545,37 +2545,48 @@ class DistributedDataParallelTest(MultiProcessTestCase):
                 return (self.t0.p, self.t1.p, self.task_unused.p)
 
             def forward(self, x, rank):
-                return self.t0(x) + 2 if rank == 0 else self.t1(x) + 3
+                return self.t0(x) if rank == 0 else self.t1(x)
+
+        def run_and_verify_grad(model):
+            # Run forward
+            output = model(8, self.rank)
+
+            # The grads of all parameters should be None at this point.
+            t0_p, t1_p, task_unused_p = model.module.task_parameters()
+            self.assertIsNone(t0_p.grad)
+            self.assertIsNone(t1_p.grad)
+            self.assertIsNone(task_unused_p.grad)
+
+            # Run backward
+            output.mean().backward()
+
+            # Now locally unused parameter should have grad updated on all ranks.
+            # However the globally unused parameter should still have None grad.
+            self.assertIsNotNone(t0_p.grad)
+            self.assertIsNotNone(t1_p.grad)
+            self.assertIsNone(task_unused_p.grad)
+
 
         store = c10d.FileStore(self.file_name, self.world_size)
-        process_group = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
-        device_id = gpus_for_rank(self.world_size)[self.rank][0]
+        process_group = c10d.ProcessGroupGloo(store, self.rank, self.world_size)
 
-        model = DistributedDataParallel(
+        # Test on CPU
+        cpu_model = DistributedDataParallel(
+            GlobalLocalUnusedParamModule().cpu(),
+            process_group=process_group,
+            find_unused_parameters=True,
+        )
+        run_and_verify_grad(cpu_model)
+
+        # Test on GPU
+        device_id = gpus_for_rank(self.world_size)[self.rank][0]
+        gpu_model = DistributedDataParallel(
             GlobalLocalUnusedParamModule().to(device_id),
             device_ids=[device_id],
             process_group=process_group,
             find_unused_parameters=True,
         )
-
-        # Run forward
-        output = model(None, self.rank)
-
-        # The grads of all parameters should be None at this point.
-        t0_p, t1_p, task_unused_p = model.module.task_parameters()
-        self.assertIsNone(t0_p.grad)
-        self.assertIsNone(t1_p.grad)
-        self.assertIsNone(task_unused_p.grad)
-
-        # Run backward
-        loss = output.mean()
-        loss.backward()
-
-        # Now locally unused parameter should have grad updated on all ranks.
-        # However the globally unused parameter should still have None grad.
-        self.assertIsNotNone(t0_p.grad)
-        self.assertIsNotNone(t1_p.grad)
-        self.assertIsNone(task_unused_p.grad)
+        run_and_verify_grad(gpu_model)
 
     @requires_nccl()
     @skip_if_not_multigpu

--- a/test/test_c10d.py
+++ b/test/test_c10d.py
@@ -3095,9 +3095,9 @@ class ReducerTest(TestCase):
         output.backward()
 
         # The reducer will have marked the grad of fc3 as ready, because
-        # it doesn't show up in the autograd graph of `output`.
-        # This should result in its contents being equal to zero.
-        self.assertEqual(torch.zeros(model.fc3.weight.size()), model.fc3.weight.grad)
+        # it doesn't show up in the autograd graph of `output`. Since fc3.weight
+        # is considered being globally unused, it will be kept untouched as None.
+        self.assertEqual(None, model.fc3.weight.grad)
 
     def test_forward_backward_optimizer(self):
         batch_size = 10

--- a/test/test_c10d.py
+++ b/test/test_c10d.py
@@ -2519,6 +2519,65 @@ class DistributedDataParallelTest(MultiProcessTestCase):
             self.fail("Unexpected exception: %s" % ex)
 
     @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_global_local_unused_params_grad(self):
+        """
+        By simulating a multi-task training, this test is to make sure:
+        1) DDP does not touch the grad of globally unused parameters.
+        2) DDP does update the grad of locally unused parameters.
+        """
+        class GlobalLocalUnusedParamModule(nn.Module):
+            class Task(nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.p = nn.Parameter(torch.ones(2, 2))
+
+                def forward(self, x):
+                    return self.p
+
+            def __init__(self):
+                super().__init__()
+                self.t0 = self.Task()
+                self.t1 = self.Task()
+                self.task_unused = self.Task()
+
+            def task_parameters(self):
+                return (self.t0.p, self.t1.p, self.task_unused.p)
+
+            def forward(self, x, rank):
+                return self.t0(x) + 2 if rank == 0 else self.t1(x) + 3
+
+        store = c10d.FileStore(self.file_name, self.world_size)
+        process_group = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
+        device_id = gpus_for_rank(self.world_size)[self.rank][0]
+
+        model = DistributedDataParallel(
+            GlobalLocalUnusedParamModule().to(device_id),
+            device_ids=[device_id],
+            process_group=process_group,
+            find_unused_parameters=True,
+        )
+
+        # Run forward
+        output = model(None, self.rank)
+
+        # The grads of all parameters should be None at this point.
+        t0_p, t1_p, task_unused_p = model.module.task_parameters()
+        self.assertIsNone(t0_p.grad)
+        self.assertIsNone(t1_p.grad)
+        self.assertIsNone(task_unused_p.grad)
+
+        # Run backward
+        loss = output.mean()
+        loss.backward()
+
+        # Now locally unused parameter should have grad updated on all ranks.
+        # However the globally unused parameter should still have None grad.
+        self.assertIsNotNone(t0_p.grad)
+        self.assertIsNotNone(t1_p.grad)
+        self.assertIsNone(task_unused_p.grad)
+
+    @requires_nccl()
     @skip_if_not_multigpu
     @skip_if_rocm
     def test_multiple_outputs_multiple_backward(self):

--- a/test/test_c10d.py
+++ b/test/test_c10d.py
@@ -2529,14 +2529,14 @@ class DistributedDataParallelTest(MultiProcessTestCase):
         class GlobalLocalUnusedParamModule(nn.Module):
             class Task(nn.Module):
                 def __init__(self):
-                    super().__init__()
+                    super(GlobalLocalUnusedParamModule.Task, self).__init__()
                     self.p = nn.Parameter(torch.ones(2, 2))
 
                 def forward(self, x):
                     return self.p + x
 
             def __init__(self):
-                super().__init__()
+                super(GlobalLocalUnusedParamModule, self).__init__()
                 self.t0 = self.Task()
                 self.t1 = self.Task()
                 self.task_unused = self.Task()

--- a/torch/csrc/distributed/c10d/reducer.cpp
+++ b/torch/csrc/distributed/c10d/reducer.cpp
@@ -274,7 +274,6 @@ void Reducer::autograd_hook(VariableIndex index) {
   // function and their indexes stored in the `unused_parameters_` vector.
   if (!has_marked_unused_parameters_ && !unused_parameters_.empty()) {
     has_marked_unused_parameters_ = true;
-
     for (const auto& unused_index : unused_parameters_) {
       mark_variable_ready(unused_index);
     }

--- a/torch/csrc/distributed/c10d/reducer.cpp
+++ b/torch/csrc/distributed/c10d/reducer.cpp
@@ -169,10 +169,12 @@ Reducer::Reducer(
     local_used_maps_dev_.resize(replica_count);
 
     for (size_t i = 0; i < replica_count; i++) {
-      at::TensorOptions options;
+      at::TensorOptions options, options_host;
       options = options.dtype(at::kInt);
+      options_host =
+          replicas_[i][0].is_cuda() ? options.pinned_memory(true) : options;
       local_used_maps_[i] =
-          at::zeros({static_cast<long>(variable_count)}, options.pinned_memory(true));
+          at::zeros({static_cast<long>(variable_count)}, options_host);
       // This tensor needs to be on the same device as replica because backend
       // such as NCCL may not support CPU tensors, and hence it might not work
       // if we always put it on CPU.

--- a/torch/csrc/distributed/c10d/reducer.cpp
+++ b/torch/csrc/distributed/c10d/reducer.cpp
@@ -359,8 +359,7 @@ void Reducer::mark_variable_ready(VariableIndex index) {
   if (next_bucket_ == buckets_.size()) {
     // H2D from local_used_maps_ to local_used_maps_dev_
     for (size_t i = 0; i < local_used_maps_.size(); i++) {
-      local_used_maps_dev_[i] =
-          local_used_maps_[i].to(local_used_maps_dev_[i].device());
+      local_used_maps_dev_[i].copy_(local_used_maps_[i]);
     }
     local_used_work_ = process_group_->allreduce(local_used_maps_dev_);
 
@@ -670,7 +669,7 @@ void Reducer::finalize_backward() {
   local_used_work_->wait();
   // D2H from local_used_maps_dev_ to local_used_maps_
   for (size_t i = 0; i < local_used_maps_.size(); i++) {
-    local_used_maps_[i] = local_used_maps_dev_[i].to(at::kCPU);
+    local_used_maps_[i].copy_(local_used_maps_dev_[i]);
   }
 
   // Wait for asynchronous reduction to complete and unflatten contents.

--- a/torch/csrc/distributed/c10d/reducer.cpp
+++ b/torch/csrc/distributed/c10d/reducer.cpp
@@ -50,6 +50,7 @@ Reducer::Reducer(
       require_finalize_(false),
       next_bucket_(0),
       has_marked_unused_parameters_(false),
+      local_used_maps_reduced_(false),
       backward_stats_base_(0) {
   TORCH_CHECK(replicas_.size() >= 1, "Expected at least one model replica.");
   TORCH_CHECK(replicas_[0].size() >= 1, "Expected at least one parameter.");

--- a/torch/csrc/distributed/c10d/reducer.cpp
+++ b/torch/csrc/distributed/c10d/reducer.cpp
@@ -266,6 +266,10 @@ void Reducer::autograd_hook(VariableIndex index) {
   // function and their indexes stored in the `unused_parameters_` vector.
   if (!has_marked_unused_parameters_ && !unused_parameters_.empty()) {
     has_marked_unused_parameters_ = true;
+
+    // Allreduce locally used param maps to get the global consensus
+    local_used_work_ = process_group_->allreduce(local_used_maps_);
+
     for (const auto& unused_index : unused_parameters_) {
       mark_variable_ready(unused_index);
     }
@@ -592,9 +596,6 @@ void Reducer::prepare_for_backward(
     unused_parameters_.push_back(var_idx);
     local_used_maps_[var_idx.replica_index][var_idx.variable_index] = 0;
   }
-
-  // allreduce locally used param maps to get the global consensus
-  process_group_->allreduce(local_used_maps_);
 }
 
 // A bucket with one or more dense tensors needs to be unflattened.
@@ -653,6 +654,7 @@ void Reducer::finalize_backward() {
   TORCH_INTERNAL_ASSERT(next_bucket_ == buckets_.size());
 
   // Wait for asynchronous reduction to complete and unflatten contents.
+  local_used_work_->wait();
   for (auto& bucket : buckets_) {
     TORCH_INTERNAL_ASSERT(bucket.work);
     bucket.work->wait();

--- a/torch/csrc/distributed/c10d/reducer.cpp
+++ b/torch/csrc/distributed/c10d/reducer.cpp
@@ -172,7 +172,7 @@ Reducer::Reducer(
       at::TensorOptions options;
       options = options.dtype(at::kInt);
       local_used_maps_[i] =
-          at::zeros({static_cast<long>(variable_count)}, options);
+          at::zeros({static_cast<long>(variable_count)}, options.pinned_memory(true));
       // This tensor needs to be on the same device as replica because backend
       // such as NCCL may not support CPU tensors, and hence it might not work
       // if we always put it on CPU.
@@ -360,7 +360,9 @@ void Reducer::mark_variable_ready(VariableIndex index) {
   if (next_bucket_ == buckets_.size()) {
     // H2D from local_used_maps_ to local_used_maps_dev_
     for (size_t i = 0; i < local_used_maps_.size(); i++) {
-      local_used_maps_dev_[i].copy_(local_used_maps_[i]);
+      // We do async H2D to avoid the blocking overhead. The async copy and
+      // allreduce respect the current stream, so will be sequenced correctly.
+      local_used_maps_dev_[i].copy_(local_used_maps_[i], true);
     }
     local_used_work_ = process_group_->allreduce(local_used_maps_dev_);
 

--- a/torch/csrc/distributed/c10d/reducer.cpp
+++ b/torch/csrc/distributed/c10d/reducer.cpp
@@ -169,8 +169,8 @@ Reducer::Reducer(
       at::TensorOptions options;
       options = options.device(replicas_[i][0].device());
       options = options.dtype(at::kInt);
-      local_used_maps_[i] = torch::autograd::make_variable(
-            at::empty({variable_count}, options));
+      local_used_maps_[i] =
+          torch::autograd::make_variable(at::empty({variable_count}, options));
     }
   }
 }
@@ -542,7 +542,7 @@ void Reducer::prepare_for_backward(
     bucket.pending = bucket.replicas.size();
   }
 
-  for (auto& local_used: local_used_maps_) {
+  for (auto& local_used : local_used_maps_) {
     local_used.fill_(1);
   }
 
@@ -609,8 +609,8 @@ void Reducer::finalize_bucket_dense(Bucket& bucket) {
 
       const VariableIndex& var_idx = func_[variable.grad_accumulator().get()];
       bool global_unused =
-        local_used_maps_[var_idx.replica_index][var_idx.variable_index]
-          .item<int>() == 0;
+          local_used_maps_[var_idx.replica_index][var_idx.variable_index]
+              .item<int>() == 0;
 
       auto bucket_view =
           replica.contents.narrow(0, offset, length).view(variable.sizes());

--- a/torch/csrc/distributed/c10d/reducer.cpp
+++ b/torch/csrc/distributed/c10d/reducer.cpp
@@ -606,7 +606,8 @@ void Reducer::finalize_bucket_dense(Bucket& bucket) {
       const auto offset = replica.offsets[intra_bucket_index];
       const auto length = replica.lengths[intra_bucket_index];
 
-      const VariableIndex& var_idx = func_[variable.grad_accumulator().get()];
+      const VariableIndex& var_idx =
+          func_[torch::autograd::impl::grad_accumulator(variable).get()];
       bool global_unused =
           local_used_maps_[var_idx.replica_index][var_idx.variable_index]
               .item<int>() == 0;

--- a/torch/csrc/distributed/c10d/reducer.cpp
+++ b/torch/csrc/distributed/c10d/reducer.cpp
@@ -167,6 +167,9 @@ Reducer::Reducer(
     local_used_maps_.resize(replica_count);
     for (size_t i = 0; i < local_used_maps_.size(); i++) {
       at::TensorOptions options;
+      // This tensor needs to be on the same device as replica because backend
+      // such as NCCL may not support CPU tensors, and hence it might not work
+      // if we always put it on CPU.
       options = options.device(replicas_[i][0].device());
       options = options.dtype(at::kInt);
       local_used_maps_[i] =

--- a/torch/csrc/distributed/c10d/reducer.cpp
+++ b/torch/csrc/distributed/c10d/reducer.cpp
@@ -172,8 +172,7 @@ Reducer::Reducer(
       // if we always put it on CPU.
       options = options.device(replicas_[i][0].device());
       options = options.dtype(at::kInt);
-      local_used_maps_[i] =
-          torch::autograd::make_variable(at::empty({variable_count}, options));
+      local_used_maps_[i] = at::empty({variable_count}, options);
     }
   }
 }

--- a/torch/csrc/distributed/c10d/reducer.cpp
+++ b/torch/csrc/distributed/c10d/reducer.cpp
@@ -264,7 +264,7 @@ void Reducer::autograd_hook(VariableIndex index) {
   // output, they won't be part of the autograd graph, and won't receive
   // gradients. These parameters are discovered in the `prepare_for_backward`
   // function and their indexes stored in the `unused_parameters_` vector.
-  if (!has_marked_unused_parameters_ && !unused_parameters_.empty()) {
+  if (!has_marked_unused_parameters_) {
     has_marked_unused_parameters_ = true;
 
     // Allreduce locally used param maps to get the global consensus

--- a/torch/csrc/distributed/c10d/reducer.cpp
+++ b/torch/csrc/distributed/c10d/reducer.cpp
@@ -172,7 +172,8 @@ Reducer::Reducer(
       // if we always put it on CPU.
       options = options.device(replicas_[i][0].device());
       options = options.dtype(at::kInt);
-      local_used_maps_[i] = at::empty({variable_count}, options);
+      local_used_maps_[i] =
+          at::empty({static_cast<long>(variable_count)}, options);
     }
   }
 }

--- a/torch/csrc/distributed/c10d/reducer.h
+++ b/torch/csrc/distributed/c10d/reducer.h
@@ -74,6 +74,12 @@ class Reducer {
 
   bool has_marked_unused_parameters_;
   std::vector<VariableIndex> unused_parameters_;
+  // locally used parameter maps indicating if parameters are used locally
+  // during the current iteration. One tensor for each model replica and each
+  // tensor is one-dim int32 tensor of number of parameters. These tensors are
+  // marked and allreduced at the end of forward for figuring out the globally
+  // unused parameters.
+  std::vector<at::Tensor> local_used_maps_;
 
   void mark_variable_ready_dense(VariableIndex index);
 

--- a/torch/csrc/distributed/c10d/reducer.h
+++ b/torch/csrc/distributed/c10d/reducer.h
@@ -74,7 +74,7 @@ class Reducer {
 
   bool has_marked_unused_parameters_;
   std::vector<VariableIndex> unused_parameters_;
-  // locally used parameter maps indicating if parameters are used locally
+  // Locally used parameter maps indicating if parameters are used locally
   // during the current iteration. One tensor for each model replica and each
   // tensor is one-dim int32 tensor of number of parameters. These tensors are
   // marked and allreduced at the end of forward for figuring out the globally

--- a/torch/csrc/distributed/c10d/reducer.h
+++ b/torch/csrc/distributed/c10d/reducer.h
@@ -80,6 +80,8 @@ class Reducer {
   // marked and allreduced at the end of forward for figuring out the globally
   // unused parameters.
   std::vector<at::Tensor> local_used_maps_;
+  // Work handle for allreduce on local_used_maps_
+  std::shared_ptr<c10d::ProcessGroup::Work> local_used_work_;
 
   void mark_variable_ready_dense(VariableIndex index);
 

--- a/torch/csrc/distributed/c10d/reducer.h
+++ b/torch/csrc/distributed/c10d/reducer.h
@@ -144,6 +144,9 @@ class Reducer {
   struct Bucket {
     std::vector<BucketReplica> replicas;
 
+    // Global indice of participating variables in the bucket
+    std::vector<size_t> variable_indices;
+
     // Number of replicas to be marked done before this bucket is ready.
     size_t pending;
 

--- a/torch/csrc/distributed/c10d/reducer.h
+++ b/torch/csrc/distributed/c10d/reducer.h
@@ -86,6 +86,8 @@ class Reducer {
   // local_used_maps_dev_: dev tensors for reducing globally unused params
   std::vector<at::Tensor> local_used_maps_;
   std::vector<at::Tensor> local_used_maps_dev_;
+  // Indicate that reduction is done and D2H copy is done as well.
+  bool local_used_maps_reduced_;
 
   // Work handle for allreduce on local_used_maps_
   std::shared_ptr<c10d::ProcessGroup::Work> local_used_work_;

--- a/torch/csrc/distributed/c10d/reducer.h
+++ b/torch/csrc/distributed/c10d/reducer.h
@@ -151,7 +151,7 @@ class Reducer {
   struct Bucket {
     std::vector<BucketReplica> replicas;
 
-    // Global indice of participating variables in the bucket
+    // Global indices of participating variables in the bucket
     std::vector<size_t> variable_indices;
 
     // Number of replicas to be marked done before this bucket is ready.

--- a/torch/csrc/distributed/c10d/reducer.h
+++ b/torch/csrc/distributed/c10d/reducer.h
@@ -75,10 +75,12 @@ class Reducer {
   bool has_marked_unused_parameters_;
   std::vector<VariableIndex> unused_parameters_;
   // Locally used parameter maps indicating if parameters are used locally
-  // during the current iteration. One tensor for each model replica and each
-  // tensor is one-dim int32 tensor of number of parameters. These tensors are
-  // marked and allreduced at the end of forward for figuring out the globally
-  // unused parameters.
+  // during the current iteration or no_sync session if no_sync is on. One
+  // tensor for each model replica and each tensor is one-dim int32 tensor of
+  // number of parameters. These tensors are marked in autograd_hook to indicate
+  // the corresponding param has been used, and get allreduced in the end of
+  // backward of current iteration or no_sync session for figuring out the
+  // globally unused parameters.
   std::vector<at::Tensor> local_used_maps_;
   // Work handle for allreduce on local_used_maps_
   std::shared_ptr<c10d::ProcessGroup::Work> local_used_work_;

--- a/torch/csrc/distributed/c10d/reducer.h
+++ b/torch/csrc/distributed/c10d/reducer.h
@@ -81,7 +81,12 @@ class Reducer {
   // the corresponding param has been used, and get allreduced in the end of
   // backward of current iteration or no_sync session for figuring out the
   // globally unused parameters.
+  //
+  // local_used_maps_:     CPU tensors for bookkeeping locally used params
+  // local_used_maps_dev_: dev tensors for reducing globally unused params
   std::vector<at::Tensor> local_used_maps_;
+  std::vector<at::Tensor> local_used_maps_dev_;
+
   // Work handle for allreduce on local_used_maps_
   std::shared_ptr<c10d::ProcessGroup::Work> local_used_work_;
 


### PR DESCRIPTION
#28294 DDP should not set grad for globally unused parameters

DDP currently computes the param to bucket mapping upfront, and allreduce grads for all params in every iteration. Even if params are unused, it will just set grad to zero. With such behavior, optimizer cannot tell if a param indeed has a zero grad or it is not used in the current iteration. This could trigger convergence problems for optimizers with weight decay and momentum such as SGD. However, DDP cannot simply set grad to None for local unused parameters, as local unused parameters might be used in other processes, and hence we still need to allreduce its grad. Instead DDP should figure out the globally unused parameters and skip touching their grad in the end of backward.

Implementation summary:
* Add locally used parameter map for each model replica.
* Mark the locally unused parameters in the end of forward and then reduce to get the globally unused parameters.
* In the end of backward skip touching grad for those globally unused parameters.
* Add a unit test test_global_local_unused_params_grad
