### PR TITLE
unify as_strided benchmark

### DIFF
--- a/benchmarks/operator_benchmark/pt/add_test.py
+++ b/benchmarks/operator_benchmark/pt/add_test.py
@@ -12,14 +12,14 @@ import torch
 add_long_configs = op_bench.cross_product_configs(
     M=[8, 64, 128],
     N=range(2, 128, 64),
-    K=[8 ** x for x in range(0, 3)], 
+    K=[8 ** x for x in range(0, 3)],
     device=['cpu'],
     tags=["long"]
 )
 
 
 add_short_configs = op_bench.config_list(
-    attr_names=["M", "N", "K"], 
+    attr_names=["M", "N", "K"],
     attrs=[
         [64, 64, 64],
         [64, 64, 128],
@@ -27,12 +27,12 @@ add_short_configs = op_bench.config_list(
     cross_product_configs={
         'device': ['cpu'],
     },
-    tags=["short"], 
+    tags=["short"],
 )
 
 
 class AddBenchmark(op_bench.TorchBenchmarkBase):
-    def init(self, M, N, K, device): 
+    def init(self, M, N, K, device):
         self.input_one = torch.rand(M, N, K, device=device, requires_grad=self.auto_set())
         self.input_two = torch.rand(M, N, K, device=device, requires_grad=self.auto_set())
         self.set_module_name("add")
@@ -40,13 +40,13 @@ class AddBenchmark(op_bench.TorchBenchmarkBase):
     def forward(self):
         return torch.add(self.input_one, self.input_two)
 
-# The generated test names based on add_short_configs will be in the following pattern: 
+# The generated test names based on add_short_configs will be in the following pattern:
 # add_M8_N16_K32_devicecpu
 # add_M8_N16_K32_devicecpu_bwdall
 # add_M8_N16_K32_devicecpu_bwd1
 # add_M8_N16_K32_devicecpu_bwd2
 # ...
-# Those names can be used to filter tests. 
+# Those names can be used to filter tests.
 
 op_bench.generate_pt_test(add_long_configs + add_short_configs, AddBenchmark)
 op_bench.generate_pt_gradient_test(add_long_configs + add_short_configs, AddBenchmark)

--- a/benchmarks/operator_benchmark/pt/as_strided_test.py
+++ b/benchmarks/operator_benchmark/pt/as_strided_test.py
@@ -11,19 +11,32 @@ import torch
 
 
 # Configs for PT as_strided operator
-split_short_configs = op_bench.cross_product_configs(
-    M=[256, 512],
-    N=[256, 512],
-    size=[(32, 32), (64, 64)],
+as_strided_configs_short = op_bench.config_list(
+    attr_names=["M", "N", "size", "stride", "storage_offset"],
+    attrs=[
+        [256, 256, (32, 32), (1, 1), 0],
+        [512, 512, (64, 64), (2, 2), 1],
+    ],
+    cross_product_configs={
+        'device': ['cpu'],
+    },
+    tags=["short"],
+)
+
+as_strided_configs_long = op_bench.cross_product_configs(
+    M=[128, 1024],
+    N=[128, 1024],
+    size=[(16, 16), (128, 128)],
     stride=[(1, 1), (2, 2)],
     storage_offset=[0, 1],
-    tags=['short']
+    device=['cpu'],
+    tags=['long']
 )
 
 
 class As_stridedBenchmark(op_bench.TorchBenchmarkBase):
-    def init(self, M, N, size, stride, storage_offset):
-        self.input_one = torch.rand(M, N)
+    def init(self, M, N, size, stride, storage_offset, device):
+        self.input_one = torch.rand(M, N, device=device)
         self.size = size
         self.stride = stride
         self.storage_offset = storage_offset
@@ -34,7 +47,8 @@ class As_stridedBenchmark(op_bench.TorchBenchmarkBase):
             self.input_one, self.size, self.stride, self.storage_offset)
 
 
-op_bench.generate_pt_test(split_short_configs, As_stridedBenchmark)
+op_bench.generate_pt_test(as_strided_configs_short + as_strided_configs_long,
+                          As_stridedBenchmark)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary: as title

Test Plan:
```
buck run mode/opt //caffe2/benchmarks/operator_benchmark/pt:as_strided_test

# ----------------------------------------
# PyTorch/Caffe2 Operator Micro-benchmarks
# ----------------------------------------
# Tag : short

# Benchmarking PyTorch: as_strided
# Mode: Eager
# Name: as_strided_M256_N256_size(32,32)_stride(1,1)_storage_offset0_cpu
# Input: M: 256, N: 256, size: (32, 32), stride: (1, 1), storage_offset: 0, device: cpu
Forward Execution Time (us) : 2.792
...

Differential Revision: D18227052

