### PR TITLE
unify add benchmark format

### DIFF
--- a/benchmarks/operator_benchmark/pt/add_test.py
+++ b/benchmarks/operator_benchmark/pt/add_test.py
@@ -12,14 +12,14 @@ import torch
 add_long_configs = op_bench.cross_product_configs(
     M=[8, 64, 128],
     N=range(2, 128, 64),
-    K=[8 ** x for x in range(0, 3)], 
+    K=[8 ** x for x in range(0, 3)],
     device=['cpu'],
     tags=["long"]
 )
 
 
 add_short_configs = op_bench.config_list(
-    attr_names=["M", "N", "K"], 
+    attr_names=["M", "N", "K"],
     attrs=[
         [64, 64, 64],
         [64, 64, 128],
@@ -27,12 +27,12 @@ add_short_configs = op_bench.config_list(
     cross_product_configs={
         'device': ['cpu'],
     },
-    tags=["short"], 
+    tags=["short"],
 )
 
 
 class AddBenchmark(op_bench.TorchBenchmarkBase):
-    def init(self, M, N, K, device): 
+    def init(self, M, N, K, device):
         self.input_one = torch.rand(M, N, K, device=device, requires_grad=self.auto_set())
         self.input_two = torch.rand(M, N, K, device=device, requires_grad=self.auto_set())
         self.set_module_name("add")
@@ -40,13 +40,13 @@ class AddBenchmark(op_bench.TorchBenchmarkBase):
     def forward(self):
         return torch.add(self.input_one, self.input_two)
 
-# The generated test names based on add_short_configs will be in the following pattern: 
+# The generated test names based on add_short_configs will be in the following pattern:
 # add_M8_N16_K32_devicecpu
 # add_M8_N16_K32_devicecpu_bwdall
 # add_M8_N16_K32_devicecpu_bwd1
 # add_M8_N16_K32_devicecpu_bwd2
 # ...
-# Those names can be used to filter tests. 
+# Those names can be used to filter tests.
 
 op_bench.generate_pt_test(add_long_configs + add_short_configs, AddBenchmark)
 op_bench.generate_pt_gradient_test(add_long_configs + add_short_configs, AddBenchmark)


### PR DESCRIPTION
Summary: as title

Test Plan:
```
buck run mode/opt //caffe2/benchmarks/operator_benchmark/pt:add_test
# ----------------------------------------
# PyTorch/Caffe2 Operator Micro-benchmarks
# ----------------------------------------
# Tag : short

# Benchmarking PyTorch: add
# Mode: Eager
# Name: add_M64_N64_K64_cpu
# Input: M: 64, N: 64, K: 64, device: cpu
Forward Execution Time (us) : 125.279
...

Differential Revision: D18226789

