### PR TITLE
Improve reshape backward when the op is a view

### DIFF
--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -501,9 +501,9 @@ Tensor reshape(const Tensor& self, IntArrayRef proposed_shape) {
     //
     // NB: Even though we have viewable geometry and the target strides here,
     //     we do not just call `as_strided` on `self` because the backward
-    //     for `as_strided` is not as efficient as `view` (since the former
-    //     is meant to handle general cases). We will redo `THTensor_compute_stride`
-    //     in `view` but that is quite cheap anyways.
+    //     for `as_strided` is not as efficient as that of `view` (since the
+    //     former is meant to handle general cases). We will redo a
+    //     `THTensor_compute_stride` in `view` but that is quite cheap anyways.
     return at::view(self, shape);
   }
   return at::_unsafe_view(self.clone(at::MemoryFormat::Contiguous), shape);

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -496,12 +496,15 @@ Tensor reshape(const Tensor& self, IntArrayRef proposed_shape) {
   }
 
   if (THTensor_compute_stride(self.sizes(), self.strides(), shape)) {
-    // `THTensor_compute_stride` returns the proper strides to use if viewable.
-    // NB: Even though we have stride here, we do not just call `as_strided`
-    //     on `self` because the backward for `as_strided` is not as efficient
-    //     as `view` (since it is meant to handle general cases), and 
-    //     `THTensor_compute_stride` is quite cheap anyways.
-    return at::_unsafe_view(self, shape);
+    // `THTensor_compute_stride` returns the proper strides to use if this 
+    // `reshape` can be just a view.
+    //
+    // NB: Even though we have viewable geometry and the target strides here,
+    //     we do not just call `as_strided` on `self` because the backward
+    //     for `as_strided` is not as efficient as `view` (since the former
+    //     is meant to handle general cases). We will redo `THTensor_compute_stride`
+    //     in `view` but that is quite cheap anyways.
+    return at::view(self, shape);
   }
   return at::_unsafe_view(self.clone(at::MemoryFormat::Contiguous), shape);
 }

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -504,7 +504,7 @@ Tensor reshape(const Tensor& self, IntArrayRef proposed_shape) {
     //     for `as_strided` is not as efficient as that of `view` (since the
     //     former is meant to handle general cases). We will redo a
     //     `THTensor_compute_stride` in `view` but that is quite cheap anyways.
-    return at::view(self, shape);
+    return self.view(shape);
   }
   return at::_unsafe_view(self.clone(at::MemoryFormat::Contiguous), shape);
 }

--- a/test/common_nn.py
+++ b/test/common_nn.py
@@ -3560,7 +3560,9 @@ class ModuleTest(TestBase):
         nc_grad_output = self.noncontiguize(grad_output)
         for contig_i, contig_g in product((True, False), repeat=2):
             i = input if contig_i else nc_input
-            go = grad_output if contig_g else nc_grad_output
+            # Some ops, e.g., nn.Flatten, returns gradient that shares
+            # storage with the grad_output. Hence we copy here.
+            go = deepcopy(grad_output if contig_g else nc_grad_output)
             test_case._zero_grad_parameters(module)
             test_case._zero_grad_input(i)
             with freeze_rng_state():

--- a/test/common_nn.py
+++ b/test/common_nn.py
@@ -3560,7 +3560,7 @@ class ModuleTest(TestBase):
         nc_grad_output = self.noncontiguize(grad_output)
         for contig_i, contig_g in product((True, False), repeat=2):
             i = input if contig_i else nc_input
-            # Some ops, e.g., nn.Flatten, returns gradient that shares
+            # Some ops, e.g., nn.Flatten, return gradient that shares
             # storage with the grad_output. Hence we copy here.
             go = deepcopy(grad_output if contig_g else nc_grad_output)
             test_case._zero_grad_parameters(module)


### PR DESCRIPTION
Currently, `reshape` does an `as_strided` when the geometry is viewable. However, `as_strided` backward is not very optimized, and can not always detect such cases. Improvements are planned at https://github.com/pytorch/pytorch/pull/8965, and I will finish it some day. But the current situation is that in these cases backward through `reshape` will copy gradient while a simple `view` will not. This is unnecessary.

Notably this affects `flatten` and a whole bunch of other ops implemented on top of `reshape`.

```py
In [15]: x = torch.randn(3, 4, requires_grad=True)

In [16]: y = x.reshape(x.shape)

In [17]: assert y._base is not None

In [18]: gy = torch.randn_like(y)

In [20]: gx = torch.autograd.grad(y, x, gy)[0]

In [21]: gx
Out[21]:
tensor([[ 0.2189,  0.3396, -0.1108,  1.7703],
        [ 1.0737, -0.1222,  1.0765, -1.3363],
        [-1.3798, -0.2950,  0.0800,  0.2501]])

In [22]: gx._base  # not gy
Out[22]:
tensor([ 0.2189,  0.3396, -0.1108,  1.7703,  1.0737, -0.1222,  1.0765, -1.3363,
        -1.3798, -0.2950,  0.0800,  0.2501])

In [23]: gy.zero_()
Out[23]:
tensor([[0., 0., 0., 0.],
        [0., 0., 0., 0.],
        [0., 0., 0., 0.]])

In [24]: gx  # not sharing storage with gy
Out[24]:
tensor([[ 0.2189,  0.3396, -0.1108,  1.7703],
        [ 1.0737, -0.1222,  1.0765, -1.3363],
        [-1.3798, -0.2950,  0.0800,  0.2501]])

# but everything is optimized with view, which should be equivalent with reshape in this case
In [25]: y = x.view(x.shape)  

In [26]: assert y._base is not None

In [27]: gy = torch.randn_like(y)

In [28]: gx = torch.autograd.grad(y, x, gy)[0]

In [29]: gx
Out[29]:
tensor([[-2.4463,  1.1446,  0.1501,  0.1212],
        [-1.1125,  1.4661,  0.9092, -0.2153],
        [-0.1937, -0.3381, -1.3883, -0.7329]])

In [30]: gy.zero_()
Out[30]:
tensor([[0., 0., 0., 0.],
        [0., 0., 0., 0.],
        [0., 0., 0., 0.]])

In [31]: gx  # sharing storage with gy
Out[31]:
tensor([[0., 0., 0., 0.],
        [0., 0., 0., 0.],
        [0., 0., 0., 0.]])

```