### PR TITLE
Pow() : Use lightweight operations for predefined scalar exponent values

### DIFF
--- a/caffe2/operators/pow_op.cc
+++ b/caffe2/operators/pow_op.cc
@@ -18,8 +18,22 @@ struct EigenPowFunctor {
           EIGEN_POW((ConstEigenVectorArrayMap<T1>(a, n)), (e));
     } else {
       if (b_is_scalar) {
-        EigenVectorArrayMap<R>(out, n) =
-            EIGEN_POW((ConstEigenVectorArrayMap<T1>(a, n)), (b[0]));
+        if (b[0] == -1.) {
+          EigenVectorArrayMap<R>(out, n) =
+              ConstEigenVectorArrayMap<T1>(a, n).inverse();
+        } else if (b[0] == 0.5) {
+          EigenVectorArrayMap<R>(out, n) =
+              ConstEigenVectorArrayMap<T1>(a, n).sqrt();
+        } else if (b[0] == -0.5) {
+          EigenVectorArrayMap<R>(out, n) =
+              ConstEigenVectorArrayMap<T1>(a, n).rsqrt();
+        } else if (b[0] == 2.) {
+          EigenVectorArrayMap<R>(out, n) =
+              ConstEigenVectorArrayMap<T1>(a, n).square();
+        } else {
+          EigenVectorArrayMap<R>(out, n) =
+              EIGEN_POW((ConstEigenVectorArrayMap<T1>(a, n)), (b[0]));
+        }
       } else {
         EigenVectorArrayMap<R>(out, n) = EIGEN_POW(
             (ConstEigenVectorArrayMap<T1>(a, n)),


### PR DESCRIPTION
Summary: Use of predefined and less compute intensive functions instead of pow() for predefined scalar exponent values.

Test Plan: automated tests

Differential Revision: D18227280

