### PR TITLE
[pytorch] In FileStore, integrate activeOp locking with file locking.

### DIFF
--- a/torch/lib/c10d/FileStore.hpp
+++ b/torch/lib/c10d/FileStore.hpp
@@ -41,6 +41,10 @@ class FileStore : public Store {
 
   std::unordered_map<std::string, std::vector<uint8_t>> cache_;
 
+  // We employ a mutex to avoid multiple active file ops from a single
+  // instance of this class. We additionally employ file locking to
+  // protect against other accesses.
+  // This also protects cache_ and pos_.
   std::mutex activeFileOpLock_;
 };
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#28907 [pytorch] In FileStore, integrate activeOp locking with file locking.**

This reorgs FileStore slightly such that the active op locking
is integrated with File locking. They're effectively functionally
identical.

Differential Revision: [D18227510](https://our.internmc.facebook.com/intern/diff/D18227510/)