### PR TITLE
unify split benchmark

### DIFF
--- a/benchmarks/operator_benchmark/pt/add_test.py
+++ b/benchmarks/operator_benchmark/pt/add_test.py
@@ -12,14 +12,14 @@ import torch
 add_long_configs = op_bench.cross_product_configs(
     M=[8, 64, 128],
     N=range(2, 128, 64),
-    K=[8 ** x for x in range(0, 3)], 
+    K=[8 ** x for x in range(0, 3)],
     device=['cpu'],
     tags=["long"]
 )
 
 
 add_short_configs = op_bench.config_list(
-    attr_names=["M", "N", "K"], 
+    attr_names=["M", "N", "K"],
     attrs=[
         [64, 64, 64],
         [64, 64, 128],
@@ -27,12 +27,12 @@ add_short_configs = op_bench.config_list(
     cross_product_configs={
         'device': ['cpu'],
     },
-    tags=["short"], 
+    tags=["short"],
 )
 
 
 class AddBenchmark(op_bench.TorchBenchmarkBase):
-    def init(self, M, N, K, device): 
+    def init(self, M, N, K, device):
         self.input_one = torch.rand(M, N, K, device=device, requires_grad=self.auto_set())
         self.input_two = torch.rand(M, N, K, device=device, requires_grad=self.auto_set())
         self.set_module_name("add")
@@ -40,13 +40,13 @@ class AddBenchmark(op_bench.TorchBenchmarkBase):
     def forward(self):
         return torch.add(self.input_one, self.input_two)
 
-# The generated test names based on add_short_configs will be in the following pattern: 
+# The generated test names based on add_short_configs will be in the following pattern:
 # add_M8_N16_K32_devicecpu
 # add_M8_N16_K32_devicecpu_bwdall
 # add_M8_N16_K32_devicecpu_bwd1
 # add_M8_N16_K32_devicecpu_bwd2
 # ...
-# Those names can be used to filter tests. 
+# Those names can be used to filter tests.
 
 op_bench.generate_pt_test(add_long_configs + add_short_configs, AddBenchmark)
 op_bench.generate_pt_gradient_test(add_long_configs + add_short_configs, AddBenchmark)

--- a/benchmarks/operator_benchmark/pt/as_strided_test.py
+++ b/benchmarks/operator_benchmark/pt/as_strided_test.py
@@ -11,19 +11,32 @@ import torch
 
 
 # Configs for PT as_strided operator
-split_short_configs = op_bench.cross_product_configs(
-    M=[256, 512],
-    N=[256, 512],
-    size=[(32, 32), (64, 64)],
+as_strided_configs_short = op_bench.config_list(
+    attr_names=["M", "N", "size", "stride", "storage_offset"],
+    attrs=[
+        [256, 256, (32, 32), (1, 1), 0],
+        [512, 512, (64, 64), (2, 2), 1],
+    ],
+    cross_product_configs={
+        'device': ['cpu'],
+    },
+    tags=["short"],
+)
+
+as_strided_configs_long = op_bench.cross_product_configs(
+    M=[128, 1024],
+    N=[128, 1024],
+    size=[(16, 16), (128, 128)],
     stride=[(1, 1), (2, 2)],
     storage_offset=[0, 1],
-    tags=['short']
+    device=['cpu'],
+    tags=['long']
 )
 
 
 class As_stridedBenchmark(op_bench.TorchBenchmarkBase):
-    def init(self, M, N, size, stride, storage_offset):
-        self.input_one = torch.rand(M, N)
+    def init(self, M, N, size, stride, storage_offset, device):
+        self.input_one = torch.rand(M, N, device=device)
         self.size = size
         self.stride = stride
         self.storage_offset = storage_offset
@@ -34,7 +47,8 @@ class As_stridedBenchmark(op_bench.TorchBenchmarkBase):
             self.input_one, self.size, self.stride, self.storage_offset)
 
 
-op_bench.generate_pt_test(split_short_configs, As_stridedBenchmark)
+op_bench.generate_pt_test(as_strided_configs_short + as_strided_configs_long,
+                          As_stridedBenchmark)
 
 
 if __name__ == "__main__":

--- a/benchmarks/operator_benchmark/pt/batchnorm_test.py
+++ b/benchmarks/operator_benchmark/pt/batchnorm_test.py
@@ -11,36 +11,41 @@ import torch.nn.functional as F
 
 """Microbenchmarks for batchnorm operator."""
 
-configs_short = op_bench.config_list(
+batchnorm_configs_short = op_bench.config_list(
+    attr_names=["M", "N", "K"],
     attrs=[
         [1, 256, 3136],
     ],
-    attr_names=["M", "N", "K"],
+    cross_product_configs={
+        'device': ['cpu'],
+    },
     tags=["short"]
 )
 
-configs_long = op_bench.cross_product_configs(
+batchnorm_configs_long = op_bench.cross_product_configs(
     M=[1, 128],
     N=[2 ** 16, 2048],
     K=[1],
+    device=['cpu'],
     tags=["long"]
 )
 
 
 class BatchNormBenchmark(op_bench.TorchBenchmarkBase):
-    def init(self, M, N, K):
-        self.input_one = torch.rand(M, N, K)
-        self.mean = torch.rand(N)
-        self.var = torch.rand(N)
-        self.weight = torch.rand(N)
-        self.bias = torch.rand(N)
+    def init(self, M, N, K, device):
+        self.input_one = torch.rand(M, N, K, device=device, requires_grad=self.auto_set())
+        self.mean = torch.rand(N, device=device)
+        self.var = torch.rand(N, device=device)
+        self.weight = torch.rand(N, device=device)
+        self.bias = torch.rand(N, device=device)
         self.set_module_name("batchnorm")
 
     def forward(self):
         return F.batch_norm(self.input_one, self.mean, self.var, self.weight, self.bias)
 
 
-op_bench.generate_pt_test(configs_short + configs_long, BatchNormBenchmark)
+op_bench.generate_pt_test(batchnorm_configs_short + batchnorm_configs_long, BatchNormBenchmark)
+op_bench.generate_pt_gradient_test(batchnorm_configs_short + batchnorm_configs_long, BatchNormBenchmark)
 
 
 if __name__ == "__main__":

--- a/benchmarks/operator_benchmark/pt/cat_test.py
+++ b/benchmarks/operator_benchmark/pt/cat_test.py
@@ -11,18 +11,31 @@ import torch
 
 
 # Configs for PT Cat operator
-cat_short_configs = op_bench.cross_product_configs(
-    M=[256, 512],
-    N=[512],
+cat_configs_short = op_bench.config_list(
+    attr_names=['M', 'N', 'K', 'dim'],
+    attrs=[
+        [256, 512, 1, 0],
+        [512, 512, 2, 1],
+    ],
+    cross_product_configs={
+        'device': ['cpu'],
+    },
+    tags=['short'],
+)
+
+cat_configs_long = op_bench.cross_product_configs(
+    M=[128, 1024],
+    N=[128, 1024],
     K=[1, 2],
     dim=[0, 1, 2],
-    tags=['short']
+    device=['cpu'],
+    tags=['long']
 )
 
 
 class CatBenchmark(op_bench.TorchBenchmarkBase):
-    def init(self, M, N, K, dim):
-        self.input_one = torch.rand(M, N, K)
+    def init(self, M, N, K, dim, device):
+        self.input_one = torch.rand(M, N, K, device=device)
         self.dim = dim
         self.set_module_name('cat')
 
@@ -30,7 +43,8 @@ class CatBenchmark(op_bench.TorchBenchmarkBase):
         return torch.cat((self.input_one, self.input_one), dim=self.dim)
 
 
-op_bench.generate_pt_test(cat_short_configs, CatBenchmark)
+op_bench.generate_pt_test(cat_configs_short + cat_configs_long,
+                          CatBenchmark)
 
 
 if __name__ == "__main__":

--- a/benchmarks/operator_benchmark/pt/chunk_test.py
+++ b/benchmarks/operator_benchmark/pt/chunk_test.py
@@ -11,17 +11,30 @@ import torch
 
 
 # Configs for PT Chunk operator
-chunks_short_configs = op_bench.cross_product_configs(
-    M=[256, 512],
-    N=[512],
-    chunks=[2],
-    tags=['short']
+chunk_short_configs = op_bench.config_list(
+    attr_names=["M", "N", "chunks"],
+    attrs=[
+        [256, 512, 2],
+        [512, 512, 2],
+    ],
+    cross_product_configs={
+        'device': ['cpu'],
+    },
+    tags=["short"],
+)
+
+chunks_long_configs = op_bench.cross_product_configs(
+    M=[128, 1024],
+    N=[128, 1024],
+    chunks=[2, 4],
+    device=['cpu'],
+    tags=['long']
 )
 
 
 class ChunkBenchmark(op_bench.TorchBenchmarkBase):
-    def init(self, M, N, chunks):
-        self.input_one = torch.rand(M, N)
+    def init(self, M, N, chunks, device):
+        self.input_one = torch.rand(M, N, device=device)
         self.chunks = chunks
         self.set_module_name('chunks')
 
@@ -29,7 +42,8 @@ class ChunkBenchmark(op_bench.TorchBenchmarkBase):
         return torch.chunk(self.input_one, self.chunks)
 
 
-op_bench.generate_pt_test(chunks_short_configs, ChunkBenchmark)
+op_bench.generate_pt_test(chunk_short_configs + chunks_long_configs,
+                          ChunkBenchmark)
 
 
 if __name__ == "__main__":

--- a/benchmarks/operator_benchmark/pt/conv_test.py
+++ b/benchmarks/operator_benchmark/pt/conv_test.py
@@ -15,21 +15,35 @@ Microbenchmarks for Conv1d and ConvTranspose1d operators.
 
 
 # Configs for conv-1d ops
-conv_1d_configs = op_bench.config_list(
+conv_1d_configs_short = op_bench.config_list(
+    attr_names=[
+        'in_c', 'out_c', 'kernel', 'stride', 'N', 'L'
+    ],
     attrs=[
         [256, 256, 3, 1, 1, 64],
         [256, 256, 3, 2, 16, 128],
     ],
-    attr_names=[
-        'in_c', 'out_c', 'kernel', 'stride', 'N', 'L'
-    ],
+    cross_product_configs={
+        'device': ['cpu'],
+    },
     tags=['short']
+)
+
+conv_1d_configs_long = op_bench.cross_product_configs(
+    in_c=[128, 512],
+    out_c=[128, 512],
+    kernel=[3],
+    stride=[1, 2],
+    N=[4, 8],
+    L=[64, 128],
+    device=['cpu'],
+    tags=["long"]
 )
 
 
 class Conv1dBenchmark(op_bench.TorchBenchmarkBase):
-    def init(self, in_c, out_c, kernel, stride, N, L):
-        self.input = torch.rand(N, in_c, L)
+    def init(self, in_c, out_c, kernel, stride, N, L, device):
+        self.input = torch.rand(N, in_c, L, device=device)
         self.conv1d = nn.Conv1d(in_c, out_c, kernel, stride=stride)
         self.set_module_name('Conv1d')
 
@@ -38,8 +52,8 @@ class Conv1dBenchmark(op_bench.TorchBenchmarkBase):
 
 
 class ConvTranspose1dBenchmark(op_bench.TorchBenchmarkBase):
-    def init(self, in_c, out_c, kernel, stride, N, L):
-        self.input = torch.rand(N, in_c, L)
+    def init(self, in_c, out_c, kernel, stride, N, L, device):
+        self.input = torch.rand(N, in_c, L, device=device)
         self.convtranspose1d = nn.ConvTranspose1d(in_c, out_c, kernel, stride=stride)
         self.set_module_name('ConvTranspose1d')
 
@@ -47,8 +61,10 @@ class ConvTranspose1dBenchmark(op_bench.TorchBenchmarkBase):
         return self.convtranspose1d(self.input)
 
 
-op_bench.generate_pt_test(conv_1d_configs, Conv1dBenchmark)
-op_bench.generate_pt_test(conv_1d_configs, ConvTranspose1dBenchmark)
+op_bench.generate_pt_test(conv_1d_configs_short + conv_1d_configs_long,
+                          Conv1dBenchmark)
+op_bench.generate_pt_test(conv_1d_configs_short + conv_1d_configs_long,
+                          ConvTranspose1dBenchmark)
 
 
 """
@@ -58,30 +74,34 @@ Microbenchmarks for Conv2d and ConvTranspose2d operators.
 
 # Configs for Conv2d and ConvTranspose1d
 conv_2d_configs_short = op_bench.config_list(
+    attr_names=[
+        'in_c', 'out_c', 'kernel', 'stride', 'N', 'H', 'W'
+    ],
     attrs=[
         [256, 256, 3, 1, 1, 16, 16],
     ],
-    attr_names=[
-        'in_c', 'out_c', 'kernel', 'stride', 'N', 'H', 'W'
-    ],
+    cross_product_configs={
+        'device': ['cpu'],
+    },
     tags=['short']
 )
 
-conv_2d_configs_long = op_bench.config_list(
-    attrs=[
-        [256, 256, 3, 1, 1, 32, 32],
-        [256, 256, 3, 2, 16, 64, 64],
-    ],
-    attr_names=[
-        'in_c', 'out_c', 'kernel', 'stride', 'N', 'H', 'W'
-    ],
-    tags=['long']
+conv_2d_configs_long = op_bench.cross_product_configs(
+    in_c=[128, 512],
+    out_c=[128, 512],
+    kernel=[3],
+    stride=[1, 2],
+    N=[4, 8],
+    H=[32, 64],
+    W=[32, 64],
+    device=['cpu'],
+    tags=["long"]
 )
 
 
 class Conv2dBenchmark(op_bench.TorchBenchmarkBase):
-    def init(self, in_c, out_c, kernel, stride, N, H, W):
-        self.input = torch.rand(N, in_c, H, W)
+    def init(self, in_c, out_c, kernel, stride, N, H, W, device):
+        self.input = torch.rand(N, in_c, H, W, device=device)
         self.conv2d = nn.Conv2d(in_c, out_c, kernel, stride=stride)
         self.set_module_name('Conv2d')
 
@@ -90,8 +110,8 @@ class Conv2dBenchmark(op_bench.TorchBenchmarkBase):
 
 
 class ConvTranspose2dBenchmark(op_bench.TorchBenchmarkBase):
-    def init(self, in_c, out_c, kernel, stride, N, H, W):
-        self.input = torch.rand(N, in_c, H, W)
+    def init(self, in_c, out_c, kernel, stride, N, H, W, device):
+        self.input = torch.rand(N, in_c, H, W, device=device)
         self.convtranspose2d = nn.ConvTranspose2d(in_c, out_c, kernel, stride=stride)
         self.set_module_name('ConvTranspose2d')
 
@@ -111,29 +131,36 @@ Microbenchmarks for Conv3d and ConvTranspose3d operators.
 
 # Configs for Conv3d and ConvTranspose3d
 conv_3d_configs_short = op_bench.config_list(
+    attr_names=[
+        'in_c', 'out_c', 'kernel', 'stride', 'N', 'D', 'H', 'W'
+    ],
     attrs=[
         [256, 256, 3, 1, 8, 4, 16, 16],
     ],
-    attr_names=[
-        'in_c', 'out_c', 'kernel', 'stride', 'N', 'D', 'H', 'W'
-    ],
+    cross_product_configs={
+        'device': ['cpu'],
+    },
     tags=['short']
 )
 
-conv_3d_configs_long = op_bench.config_list(
-    attrs=[
-        [256, 256, 3, 1, 8, 4, 32, 32],
-        [256, 256, 3, 2, 16, 8, 64, 64],
-    ],
-    attr_names=[
-        'in_c', 'out_c', 'kernel', 'stride', 'N', 'D', 'H', 'W'
-    ],
-    tags=['long']
+
+conv_3d_configs_long = op_bench.cross_product_configs(
+    in_c=[128, 512],
+    out_c=[128, 512],
+    kernel=[3],
+    stride=[1, 2],
+    N=[8, 16],
+    D=[4, 8],
+    H=[32, 64],
+    W=[32, 64],
+    device=['cpu'],
+    tags=["long"]
 )
 
+
 class Conv3dBenchmark(op_bench.TorchBenchmarkBase):
-    def init(self, in_c, out_c, kernel, stride, N, D, H, W):
-        self.input = torch.rand(N, in_c, D, H, W)
+    def init(self, in_c, out_c, kernel, stride, N, D, H, W, device):
+        self.input = torch.rand(N, in_c, D, H, W, device=device)
         self.conv3d = nn.Conv3d(in_c, out_c, kernel, stride=stride)
         self.set_module_name('Conv3d')
 
@@ -142,8 +169,8 @@ class Conv3dBenchmark(op_bench.TorchBenchmarkBase):
 
 
 class ConvTranspose3dBenchmark(op_bench.TorchBenchmarkBase):
-    def init(self, in_c, out_c, kernel, stride, N, D, H, W):
-        self.input = torch.rand(N, in_c, D, H, W)
+    def init(self, in_c, out_c, kernel, stride, N, D, H, W, device):
+        self.input = torch.rand(N, in_c, D, H, W, device=device)
         self.convtranspose3d = nn.ConvTranspose3d(in_c, out_c, kernel, stride=stride)
         self.set_module_name('ConvTranspose3d')
 

--- a/benchmarks/operator_benchmark/pt/gather_test.py
+++ b/benchmarks/operator_benchmark/pt/gather_test.py
@@ -11,31 +11,43 @@ import numpy
 """Microbenchmarks for gather operator."""
 
 # An example input from this configuration is M=4, N=4, dim=0.
-configs = op_bench.config_list(
+gather_configs_short = op_bench.config_list(
+    attr_names=["M", "N", "dim"],
     attrs=[
         [256, 512, 0],
         [512, 512, 1],
     ],
-    attr_names=["M", "N", "dim"],
+    cross_product_configs={
+        'device': ['cpu'],
+    },
     tags=["short"]
 )
 
 
+gather_configs_long = op_bench.cross_product_configs(
+    M=[128, 1024],
+    N=[128, 1024],
+    dim=[0, 1],
+    device=['cpu'],
+    tags=["long"]
+)
+
+
 class GatherBenchmark(op_bench.TorchBenchmarkBase):
-    # TODO (mingzhe0908): should we have a global seed for all ops?
-    def init(self, M, N, dim):
-        self.input_one = torch.rand(M, N)
+    def init(self, M, N, dim, device):
+        self.input_one = torch.rand(M, N, device=device)
         self.dim = dim
         min_val = M if dim == 0 else N
         numpy.random.seed((1 << 32) - 1)
-        self.index = torch.tensor(numpy.random.randint(0, min_val, (M, N)))
+        self.index = torch.tensor(numpy.random.randint(0, min_val, (M, N)), device=device)
         self.set_module_name("gather")
 
     def forward(self):
         return torch.gather(self.input_one, self.dim, self.index)
 
 
-op_bench.generate_pt_test(configs, GatherBenchmark)
+op_bench.generate_pt_test(gather_configs_short + gather_configs_long,
+                          GatherBenchmark)
 
 
 if __name__ == "__main__":

--- a/benchmarks/operator_benchmark/pt/linear_test.py
+++ b/benchmarks/operator_benchmark/pt/linear_test.py
@@ -11,19 +11,31 @@ import torch.nn as nn
 
 """Microbenchmarks for Linear operator."""
 
-configs = op_bench.config_list(
-    attrs=[
-        [32, 1024, 256],
-        [64, 256, 100],
-    ],
+linear_configs_short = op_bench.config_list(
     attr_names=["N", "IN", "OUT"],
+    attrs=[
+        [4, 256, 128],
+        [16, 1024, 256],
+    ],
+    cross_product_configs={
+        'device': ['cpu'],
+    },
     tags=["short"]
 )
 
 
+linear_configs_long = op_bench.cross_product_configs(
+    N=[32, 64],
+    IN=[128, 512],
+    OUT=[64, 128],
+    device=['cpu'],
+    tags=["long"]
+)
+
+
 class LinearBenchmark(op_bench.TorchBenchmarkBase):
-    def init(self, N, IN, OUT):
-        self.input_one = torch.rand(N, IN)
+    def init(self, N, IN, OUT, device):
+        self.input_one = torch.rand(N, IN, device=device)
         self.linear = nn.Linear(IN, OUT)
         self.set_module_name("linear")
 
@@ -31,7 +43,8 @@ class LinearBenchmark(op_bench.TorchBenchmarkBase):
         return self.linear(self.input_one)
 
 
-op_bench.generate_pt_test(configs, LinearBenchmark)
+op_bench.generate_pt_test(linear_configs_short + linear_configs_long,
+                          LinearBenchmark)
 
 
 if __name__ == "__main__":

--- a/benchmarks/operator_benchmark/pt/matmul_test.py
+++ b/benchmarks/operator_benchmark/pt/matmul_test.py
@@ -6,36 +6,39 @@ from __future__ import unicode_literals
 import operator_benchmark as op_bench
 import torch
 
-
 """Microbenchmarks for MatMul operator"""
 
-
 # Configs for PT Matmul operator
-mm_long_configs = op_bench.cross_product_configs(
-    M=[64, 128, 256],
-    N=range(2, 10, 3),
-    K=[128, 512, 1024], 
-    trans_a=[True, False],
-    trans_b=[True, False],
-    tags=["long"]
-)
-
-
 mm_short_configs = op_bench.config_list(
+    attr_names=["M", "N", "K", "trans_a", "trans_b"],
     attrs=[
         [128, 128, 128, True, False],
         [256, 256, 256, False, True],
     ],
-    attr_names=["M", "N", "K", "trans_a", "trans_b"], 
-    tags=["short"], 
+    cross_product_configs={
+        'device': ['cpu'],
+    },
+    tags=["short"],
+)
+
+
+mm_long_configs = op_bench.cross_product_configs(
+    M=[64, 128, 256],
+    N=range(2, 10, 3),
+    K=[128, 512, 1024],
+    trans_a=[True, False],
+    trans_b=[True, False],
+    device=['cpu'],
+    tags=["long"]
 )
 
 
 class MatMulBenchmark(op_bench.TorchBenchmarkBase):
-    def init(self, M, N, K, trans_a, trans_b): 
-        self.input_one = torch.rand(M, N) if trans_a \
-            else torch.rand(N, M).t()
-        self.input_two = torch.rand(N, K) if trans_b else torch.rand(K, N).t()
+    def init(self, M, N, K, trans_a, trans_b, device):
+        self.input_one = torch.rand(M, N, device=device) if trans_a \
+            else torch.rand(N, M, device=device).t()
+        self.input_two = torch.rand(N, K, device=device) if trans_b \
+            else torch.rand(K, N, device=device).t()
         self.set_module_name("matmul")
 
     def forward(self):

--- a/benchmarks/operator_benchmark/pt/pool_test.py
+++ b/benchmarks/operator_benchmark/pt/pool_test.py
@@ -3,16 +3,13 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-
 import operator_benchmark as op_bench
 import torch
 import torch.nn as nn
 
-
 """
 Microbenchmarks for MaxPool1d and AvgPool1d operators.
 """
-
 
 # Configs for pool-1d ops
 pool_1d_configs_short = op_bench.config_list(
@@ -22,17 +19,19 @@ pool_1d_configs_short = op_bench.config_list(
     attrs=[
         [3, 1, 8, 256, 256],
     ],
+    cross_product_configs={
+        'device': ['cpu'],
+    },
     tags=['short']
 )
 
-pool_1d_configs_long = op_bench.config_list(
-    attr_names=[
-        'kernel', 'stride', 'N', 'C', 'L'
-    ],
-    attrs=[
-        [3, 2, 8, 3, 128],
-        [3, 2, 16, 3, 256],
-    ],
+pool_1d_configs_long = op_bench.cross_product_configs(
+    kernel=[3],
+    stride=[1, 2],
+    N=[8, 16],
+    C=[3],
+    L=[128, 256],
+    device=['cpu'],
     tags=['long']
 )
 
@@ -46,8 +45,8 @@ pool_1d_ops_list = op_bench.op_list(
 
 
 class Pool1dBenchmark(op_bench.TorchBenchmarkBase):
-    def init(self, kernel, stride, N, C, L, op_func):
-        self.input = torch.rand(N, C, L)
+    def init(self, kernel, stride, N, C, L, device, op_func):
+        self.input = torch.rand(N, C, L, device=device)
         self.kernel = kernel
         self.stride = stride
         self.op_func = op_func(self.kernel, stride=self.stride)
@@ -74,17 +73,20 @@ pool_2d_configs_short = op_bench.config_list(
     attrs=[
         [[3, 1], [2, 1], 1, 16, 32, 32],
     ],
+    cross_product_configs={
+        'device': ['cpu'],
+    },
     tags=['short']
 )
 
-pool_2d_configs_long = op_bench.config_list(
-    attr_names=[
-        'kernel', 'stride', 'N', 'C', 'H', 'W'
-    ],
-    attrs=[
-        [[3, 2], [2, 2], 8, 32, 64, 64],
-        [[3, 3], [2, 2], 16, 32, 64, 64],
-    ],
+pool_2d_configs_long = op_bench.cross_product_configs(
+    kernel=[[3, 2], [3, 3]],
+    stride=[[2, 2]],
+    N=[8, 16],
+    C=[32],
+    H=[32, 64],
+    W=[32, 64],
+    device=['cpu'],
     tags=['long']
 )
 
@@ -98,8 +100,8 @@ pool_2d_ops_list = op_bench.op_list(
 
 
 class Pool2dBenchmark(op_bench.TorchBenchmarkBase):
-    def init(self, kernel, stride, N, C, H, W, op_func):
-        self.input = torch.rand(N, C, H, W)
+    def init(self, kernel, stride, N, C, H, W, device, op_func):
+        self.input = torch.rand(N, C, H, W, device=device)
         self.kernel = kernel
         self.stride = stride
         self.op_func = op_func(self.kernel, stride=self.stride)
@@ -126,17 +128,21 @@ pool_3d_configs_short = op_bench.config_list(
     attrs=[
         [[3, 1, 3], [2, 1, 2], 1, 16, 16, 32, 32],
     ],
+    cross_product_configs={
+        'device': ['cpu'],
+    },
     tags=['short']
 )
 
-pool_3d_configs_long = op_bench.config_list(
-    attr_names=[
-        'kernel', 'stride', 'N', 'C', 'D', 'H', 'W'
-    ],
-    attrs=[
-        [[3, 2, 3], [2, 2, 2], 8, 32, 32, 64, 64],
-        [[3, 3, 3], [2, 2, 2], 16, 32, 32, 64, 64],
-    ],
+pool_3d_configs_long = op_bench.cross_product_configs(
+    kernel=[[3, 2, 3], [3, 3, 3]],
+    stride=[[2, 2, 2]],
+    N=[8, 16],
+    C=[32],
+    D=[32],
+    H=[32, 64],
+    W=[32, 64],
+    device=['cpu'],
     tags=['long']
 )
 
@@ -151,8 +157,8 @@ pool_3d_ops_list = op_bench.op_list(
 
 
 class Pool3dBenchmark(op_bench.TorchBenchmarkBase):
-    def init(self, kernel, stride, N, C, D, H, W, op_func):
-        self.input = torch.rand(N, C, D, H, W)
+    def init(self, kernel, stride, N, C, D, H, W, device, op_func):
+        self.input = torch.rand(N, C, D, H, W, device=device)
         self.kernel = kernel
         self.stride = stride
         self.op_func = op_func(self.kernel, stride=self.stride)

--- a/benchmarks/operator_benchmark/pt/softmax_test.py
+++ b/benchmarks/operator_benchmark/pt/softmax_test.py
@@ -16,27 +16,29 @@ Microbenchmarks for the softmax operators.
 
 # Configs for softmax ops
 softmax_configs_short = op_bench.config_list(
+    attr_names=[
+        'N', 'C', 'H', 'W'
+    ],
     attrs=[
         [4, 3, 256, 256],
         [8, 3, 512, 512],
     ],
-    attr_names=[
-        'N', 'C', 'H', 'W'
-    ],
+    cross_product_configs={
+        'device': ['cpu'],
+    },
     tags=['short']
 )
 
-softmax_configs_long = op_bench.config_list(
-    attrs=[
-        [8, 3, 128, 128],
-        [16, 512, 14, 14],
-        [16, 256, 28, 28],
-    ],
-    attr_names=[
-        'N', 'C', 'H', 'W'
-    ],
-    tags=['long']
-)
+
+softmax_configs_long = op_bench.cross_product_configs(
+    N=[8, 16],
+    C=[3, 64],
+    H=[64, 128],
+    W=[64, 128],
+    device=['cpu'],
+     tags=['long']
+ )
+
 
 softmax_ops_list = op_bench.op_list(
     attr_names=['op_name', 'op_func'],
@@ -49,8 +51,8 @@ softmax_ops_list = op_bench.op_list(
 
 
 class SoftmaxBenchmark(op_bench.TorchBenchmarkBase):
-    def init(self, N, C, H, W, op_func):
-        self.input_one = torch.rand(N, C, H, W)
+    def init(self, N, C, H, W, device, op_func):
+        self.input_one = torch.rand(N, C, H, W, device=device)
         self.op_func = op_func()
 
     def forward(self):

--- a/benchmarks/operator_benchmark/pt/split_test.py
+++ b/benchmarks/operator_benchmark/pt/split_test.py
@@ -11,17 +11,30 @@ import torch
 
 
 # Configs for PT Split operator
-split_short_configs = op_bench.cross_product_configs(
-    M=[256, 512],
-    N=[512],
-    parts=[2],
-    tags=['short']
+split_configs_short = op_bench.config_list(
+    attr_names=["M", "N", "parts"],
+    attrs=[
+        [256, 512, 2],
+        [512, 512, 2],
+    ],
+    cross_product_configs={
+        'device': ['cpu'],
+    },
+    tags=["short"],
+)
+
+split_configs_long = op_bench.cross_product_configs(
+    M=[128, 1024],
+    N=[128, 1024],
+    parts=[2, 4],
+    device=['cpu'],
+    tags=['long']
 )
 
 
 class SplitBenchmark(op_bench.TorchBenchmarkBase):
-    def init(self, M, N, parts):
-        self.input_one = torch.rand(M, N)
+    def init(self, M, N, parts, device):
+        self.input_one = torch.rand(M, N, device=device)
         self.split_size = int(M * N / parts)
         self.set_module_name('split')
 
@@ -29,7 +42,8 @@ class SplitBenchmark(op_bench.TorchBenchmarkBase):
         return torch.split(self.input_one, self.split_size)
 
 
-op_bench.generate_pt_test(split_short_configs, SplitBenchmark)
+op_bench.generate_pt_test(split_configs_short + split_configs_long,
+                          SplitBenchmark)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary: as title

Test Plan:
```
buck run mode/opt //caffe2/benchmarks/operator_benchmark/pt:split_test

# ----------------------------------------
# PyTorch/Caffe2 Operator Micro-benchmarks
# ----------------------------------------
# Tag : short

# Benchmarking PyTorch: split
# Mode: Eager
# Name: split_M256_N512_parts2_cpu
# Input: M: 256, N: 512, parts: 2, device: cpu
Forward Execution Time (us) : 3.434

Differential Revision: D18231542

