### PR TITLE
[JIT] Fix aten::format regex for clang8

### DIFF
--- a/torch/csrc/jit/register_special_ops.cpp
+++ b/torch/csrc/jit/register_special_ops.cpp
@@ -308,7 +308,7 @@ RegisterOperators reg({
         "aten::format(str self, ...) -> str",
         [](const Node* node) -> Operation {
           size_t num_inputs = node->inputs().size();
-          std::regex unsupported_options("\\{([^}]+)\\}");
+          std::regex unsupported_options("\\{(.*?)\\}");
           return [num_inputs, unsupported_options](Stack& stack) {
             auto format = peek(stack, 0, num_inputs).toStringRef();
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #28474 [JIT] Trace module calls
* #28864 [JIT] API for finding a common ancestor block for a pair of nodes
* **#28916 [JIT] Fix aten::format regex for clang8**

The previous regex caused a `std::regex_error` under clang8 complaining about `error_brack`, which is strange because the square brackets are balanced. Seems like a stdlib bug to me. So to workaround this, I've switched to the older regex with a non-greedy match in the inner atom

Differential Revision: [D18232654](https://our.internmc.facebook.com/intern/diff/D18232654)