### PR TITLE
Return None correctly from `Tensor.names` (#28659)

### DIFF
--- a/test/test_namedtensor.py
+++ b/test/test_namedtensor.py
@@ -154,6 +154,17 @@ class TestNamedTensor(TestCase):
             names65 = ['A' * i for i in range(1, 66)]
             x = factory([1] * 65, names=names64, device=device)
 
+    def test_none_names_refcount(self):
+        def scope():
+            unnamed = torch.empty(2, 3)
+            unnamed.names  # materialize [None, None]
+
+        prev_none_refcnt = sys.getrefcount(None)
+        scope()
+        self.assertEqual(sys.getrefcount(None), prev_none_refcnt,
+                         message='Using tensor.names should not change '
+                                 'the refcount of Py_None')
+
     def test_has_names(self):
         unnamed = torch.empty(2, 3)
         none_named = torch.empty(2, 3, names=(None, None))

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -335,8 +335,18 @@ PyObject *THPVariable_get_names(THPVariable *self, void *unused)
 
   const auto dimnames = self->cdata.names();
   for (size_t i = 0; i < size; ++i) {
-    PyObject* str = Py_None;
-    if (dimnames[i].type() != at::NameType::WILDCARD) {
+    PyObject* str;
+    if (dimnames[i].type() == at::NameType::WILDCARD) {
+      // PyTuple_SET_ITEM steals a reference to the object. When the tuple is
+      // deallocated, it'll decrement the refcount on Py_None, which is bad.
+      // To avoid this, we "create" a new reference to Py_None by increasing
+      // the refcount.
+      // Sources:
+      // - https://docs.python.org/3/c-api/tuple.html#c.PyTuple_SetItem
+      // - https://stackoverflow.com/questions/16400600/how-to-return-a-tuple-containing-a-none-value-from-the-c-api
+      Py_INCREF(Py_None);
+      str = Py_None;
+    } else {
       str = THPUtils_packString(dimnames[i].symbol().toUnqualString());
       if (!str) throw python_error();
     }


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/pytorch/pull/28659

Previously, we would return None from `Tensor.names` without bumping the
refcount. This is a bug; the Python API requires the developer to
increment the refcount on new references to None. This is because None
is a singleton object and does not automatically have its reference
count bumped when one uses Py_None (which is a pointer to the actual
None singleton object).

See the following for Python documentation on this:
- https://docs.python.org/3/c-api/none.html#c.Py_RETURN_NONE
- https://docs.python.org/3/extending/extending.html#back-to-the-example

Fixes https://github.com/pytorch/pytorch/issues/28646

Test Plan: - New test.

Differential Revision: D18140593

Pulled By: zou3519

fbshipit-source-id: 302a09021b68229e2e7b1b584b3549b30506bdab

