### PR TITLE
[fixing cuda launch config failure on UpSampleNearest]

### DIFF
--- a/aten/src/ATen/native/cuda/UpSampleNearest1d.cu
+++ b/aten/src/ATen/native/cuda/UpSampleNearest1d.cu
@@ -108,7 +108,9 @@ static void upsample_nearest1d_out_cuda_template(
   unsigned int n = output.numel() / nbatch;
   dim3 bdim{std::min<unsigned int>(
       at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock, MAX_THREADS)};
-  dim3 gdim{cuda::ATenCeilDiv(n, bdim.x)};
+  dim3 gdim{std::min<int>(
+      at::cuda::getCurrentDeviceProperties()->maxGridSize[0],
+      cuda::ATenCeilDiv(n, bdim.x))};
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
       input.scalar_type(), "upsample_nearest1d_out_frame", [&] {
@@ -161,7 +163,9 @@ static void upsample_nearest1d_backward_out_cuda_template(
   unsigned int n = grad_input.numel() / nbatch;
   dim3 bdim{std::min<unsigned int>(
       at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock, MAX_THREADS)};
-  dim3 gdim{cuda::ATenCeilDiv(n, bdim.x)};
+  dim3 gdim{std::min<int>(
+      at::cuda::getCurrentDeviceProperties()->maxGridSize[0],
+      cuda::ATenCeilDiv(n, bdim.x))};
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
       grad_output.scalar_type(), "upsample_nearest1d_backward_out_frame", [&] {

--- a/aten/src/ATen/native/cuda/UpSampleNearest1d.cu
+++ b/aten/src/ATen/native/cuda/UpSampleNearest1d.cu
@@ -108,7 +108,7 @@ static void upsample_nearest1d_out_cuda_template(
   unsigned int n = output.numel() / nbatch;
   dim3 bdim{std::min<unsigned int>(
       at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock, MAX_THREADS)};
-  dim3 gdim{std::min<int>(
+  dim3 gdim{std::min<unsigned int>(
       at::cuda::getCurrentDeviceProperties()->maxGridSize[0],
       cuda::ATenCeilDiv(n, bdim.x))};
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
@@ -163,7 +163,7 @@ static void upsample_nearest1d_backward_out_cuda_template(
   unsigned int n = grad_input.numel() / nbatch;
   dim3 bdim{std::min<unsigned int>(
       at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock, MAX_THREADS)};
-  dim3 gdim{std::min<int>(
+  dim3 gdim{std::min<unsigned int>(
       at::cuda::getCurrentDeviceProperties()->maxGridSize[0],
       cuda::ATenCeilDiv(n, bdim.x))};
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();

--- a/aten/src/ATen/native/cuda/UpSampleNearest2d.cu
+++ b/aten/src/ATen/native/cuda/UpSampleNearest2d.cu
@@ -149,6 +149,7 @@ static void upsample_nearest2d_out_cuda_template(
       at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock, MAX_THREADS);
 
   int* maxThreadsDim = at::cuda::getCurrentDeviceProperties()->maxThreadsDim;
+  int* maxGridSize = at::cuda::getCurrentDeviceProperties()->maxGridSize;
 
   // upsample_2d_shape_check makes sure input/output tensor is not empty;
   int block_x = std::min<int>(
@@ -160,9 +161,12 @@ static void upsample_nearest2d_out_cuda_template(
       maxThreadsDim[2], std::min<int>(nc, max_threads / block_x / block_y));
   const dim3 block(block_x, block_y, block_z);
 
-  int grid_x = cuda::ATenCeilDiv(output_width, block_x);
-  int grid_y = cuda::ATenCeilDiv(output_height, block_y);
-  int grid_z = cuda::ATenCeilDiv(nc, block_z * 4);
+  int grid_x = std::min<int>(
+      maxGridSize[0], cuda::ATenCeilDiv(output_width, block_x));
+  int grid_y = std::min<int>(
+      maxGridSize[1], cuda::ATenCeilDiv(output_height, block_y));
+  int grid_z = std::min<int>(
+      maxGridSize[2], cuda::ATenCeilDiv(nc, block_z * 4));
   const dim3 grid(grid_x, grid_y, grid_z);
 
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
@@ -233,7 +237,9 @@ static void upsample_nearest2d_backward_out_cuda_template(
   unsigned int n = grad_input.numel() / nbatch;
   dim3 bdim{std::min<unsigned int>(
       at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock, MAX_THREADS)};
-  dim3 gdim{cuda::ATenCeilDiv(n, bdim.x)};
+  dim3 gdim{std::min<int>(
+      at::cuda::getCurrentDeviceProperties()->maxGridSize[0],
+      cuda::ATenCeilDiv(n, bdim.x))};
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
       grad_output.scalar_type(), "upsample_nearest2d_backward_out_frame", [&] {

--- a/aten/src/ATen/native/cuda/UpSampleNearest2d.cu
+++ b/aten/src/ATen/native/cuda/UpSampleNearest2d.cu
@@ -237,7 +237,7 @@ static void upsample_nearest2d_backward_out_cuda_template(
   unsigned int n = grad_input.numel() / nbatch;
   dim3 bdim{std::min<unsigned int>(
       at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock, MAX_THREADS)};
-  dim3 gdim{std::min<int>(
+  dim3 gdim{std::min<unsigned int>(
       at::cuda::getCurrentDeviceProperties()->maxGridSize[0],
       cuda::ATenCeilDiv(n, bdim.x))};
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();

--- a/aten/src/ATen/native/cuda/UpSampleNearest3d.cu
+++ b/aten/src/ATen/native/cuda/UpSampleNearest3d.cu
@@ -162,7 +162,9 @@ static void upsample_nearest3d_out_cuda_template(
   unsigned int n = output.numel() / nbatch;
   dim3 bdim{std::min<unsigned int>(
       at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock, MAX_THREADS)};
-  dim3 gdim{cuda::ATenCeilDiv(n, bdim.x)};
+  dim3 gdim{std::min<int>(
+      at::cuda::getCurrentDeviceProperties()->maxGridSize[0],
+      cuda::ATenCeilDiv(n, bdim.x))};
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
       input.scalar_type(), "upsample_nearest3d_out_frame", [&] {
@@ -238,7 +240,9 @@ static void upsample_nearest3d_backward_out_cuda_template(
   unsigned int n = grad_input.numel() / nbatch;
   dim3 bdim{std::min<unsigned int>(
       at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock, MAX_THREADS)};
-  dim3 gdim{cuda::ATenCeilDiv(n, bdim.x)};
+  dim3 gdim{std::min<int>(
+      at::cuda::getCurrentDeviceProperties()->maxGridSize[0],
+      cuda::ATenCeilDiv(n, bdim.x))};
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
       grad_output.scalar_type(), "upsample_nearest3d_backward_out_frame", [&] {

--- a/aten/src/ATen/native/cuda/UpSampleNearest3d.cu
+++ b/aten/src/ATen/native/cuda/UpSampleNearest3d.cu
@@ -162,7 +162,7 @@ static void upsample_nearest3d_out_cuda_template(
   unsigned int n = output.numel() / nbatch;
   dim3 bdim{std::min<unsigned int>(
       at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock, MAX_THREADS)};
-  dim3 gdim{std::min<int>(
+  dim3 gdim{std::min<unsigned int>(
       at::cuda::getCurrentDeviceProperties()->maxGridSize[0],
       cuda::ATenCeilDiv(n, bdim.x))};
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
@@ -240,7 +240,7 @@ static void upsample_nearest3d_backward_out_cuda_template(
   unsigned int n = grad_input.numel() / nbatch;
   dim3 bdim{std::min<unsigned int>(
       at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock, MAX_THREADS)};
-  dim3 gdim{std::min<int>(
+  dim3 gdim{std::min<unsigned int>(
       at::cuda::getCurrentDeviceProperties()->maxGridSize[0],
       cuda::ATenCeilDiv(n, bdim.x))};
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();

--- a/test/common_nn.py
+++ b/test/common_nn.py
@@ -1835,12 +1835,6 @@ new_module_tests = [
         pickle=False,
     ),
     dict(
-        constructor=wrap_functional(F.interpolate, size=None, scale_factor=2., mode='nearest'),
-        input_size=(2048, 256, 8, 8),
-        fullname='interpolate_nearest_2d_launch_configs_grid',
-        pickle=False,
-    ),
-    dict(
         constructor=wrap_functional(F.interpolate, size=2, scale_factor=None, mode='nearest'),
         input_size=(1, 128, 1, 1),
         fullname='interpolate_nearest_2d_launch_configs',

--- a/test/common_nn.py
+++ b/test/common_nn.py
@@ -1835,6 +1835,12 @@ new_module_tests = [
         pickle=False,
     ),
     dict(
+        constructor=wrap_functional(F.interpolate, size=None, scale_factor=2., mode='nearest'),
+        input_size=(2048, 256, 8, 8),
+        fullname='interpolate_nearest_2d_launch_configs_grid',
+        pickle=False,
+    ),
+    dict(
         constructor=wrap_functional(F.interpolate, size=2, scale_factor=None, mode='nearest'),
         input_size=(1, 128, 1, 1),
         fullname='interpolate_nearest_2d_launch_configs',

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -8392,6 +8392,13 @@ class TestNNDeviceType(NNTestCase):
                 self._test_rnn_retain_variables(device, dtype)
 
     @onlyCUDA
+    def test_upsamplingNearest2d_launch_config(self, device):
+        m = nn.Upsample(scale_factor=2)
+        x = torch.rand(2**24, 1, 1, 1).to(device=device)
+        o = m(x)
+
+
+    @onlyCUDA
     @skipCUDAIfCudnnVersionLessThan(7600)
     def test_CTCLoss_cudnn(self, device):
         target_lengths = [30, 25, 20]


### PR DESCRIPTION
This is to fix #22526 

Adding limitation on launch config for grid sizes as well, previous code is asking to launch blocks more than what's supported by the hardware;
Test added in test_cuda;