### PR TITLE
[ci] merge some of the lint checks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 jobs:
-  consistent-circleci:
+  quick-checks:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Python
@@ -21,73 +21,22 @@ jobs:
         run: |
           pip install -r requirements.txt
           cd .circleci && ./ensure-consistency.py
-
-  validate-docker-version:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Setup Python
-        uses: actions/setup-python@v1
-        with:
-          python-version: 3.x
-          architecture: x64
-      - name: Checkout PyTorch
-        uses: actions/checkout@master
       - name: Ensure Docker version is correctly deployed
         run: .circleci/validate-docker-version.py
-
-  shellcheck-jenkins:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout PyTorch
-        uses: actions/checkout@master
       - name: Shellcheck Jenkins scripts
         run: |
           sudo apt-get install -y shellcheck
           .jenkins/run-shellcheck.sh
-
-  ensure-no-tabs:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout PyTorch
-        uses: actions/checkout@master
       - name: Ensure no tabs
         run: |
           (! git grep -I -l $'\t' -- . ':(exclude)*.svg' ':(exclude)**Makefile' ':(exclude)**/contrib/**' ':(exclude)third_party' ':(exclude).gitattributes' ':(exclude).gitmodules' || (echo "The above files have tabs; please convert them to spaces"; false))
-
-  ensure-not-executable:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout PyTorch
-        uses: actions/checkout@master
       - name: Ensure C++ source files are not executable
         run: |
           (! find . \( -path ./third_party -o -path ./.git -o -path ./torch/bin -o -path ./build \) -prune -o -type f -executable -regextype posix-egrep -not -regex '.+(\.(bash|sh|py|so)|git-pre-commit)$' -print | grep . || (echo 'The above files have executable permission; please remove their executable permission by using `chmod -x`'; false))
-
-  mypy-typecheck:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Setup Python
-        uses: actions/setup-python@v1
-        with:
-          python-version: 3.x
-          architecture: x64
-      - name: Checkout PyTorch
-        uses: actions/checkout@master
       - name: MyPy typecheck
         run: |
           pip install mypy mypy-extensions
           mypy @mypy-files.txt
-
-  cpp_doc_check:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Setup Python
-        uses: actions/setup-python@v1
-        with:
-          python-version: 3.x
-          architecture: x64
-      - name: Checkout PyTorch
-        uses: actions/checkout@master
       - name: C++ docs check
         run: |
           sudo apt-get install -y doxygen && pip install -r requirements.txt


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#28933 [ci] merge some of the lint checks**

Merge all the things that don't add annotations into a single
`quick-checks` job. This helps reduce concurrency and clutter
at the top of the status check page.

This doesn't touch the actually important items (flake8 + clang-tidy),
but those are a little trickier to handle because of how annotations are
added.

Differential Revision: [D18235396](https://our.internmc.facebook.com/intern/diff/D18235396)