### PR TITLE
Add torch.nn.GELU for GELU activation

### DIFF
--- a/aten/src/ATen/core/aten_interned_strings.h
+++ b/aten/src/ATen/core/aten_interned_strings.h
@@ -337,6 +337,7 @@ _(aten, full) \
 _(aten, full_like) \
 _(aten, gather) \
 _(aten, ge) \
+_(aten, gelu) \
 _(aten, geometric) \
 _(aten, geqrf) \
 _(aten, ger) \

--- a/aten/src/ATen/native/Activation.cpp
+++ b/aten/src/ATen/native/Activation.cpp
@@ -353,16 +353,16 @@ Tensor hardshrink_backward_cpu(const Tensor & grad, const Tensor & self, Scalar 
 
 
 Tensor gelu_cpu(const Tensor& self) {
-  const auto X = self.contiguous();
-  Tensor Y = at::native::empty_like(X);
-  GeluKernel(kCPU, X, &Y);
+  Tensor Y = at::native::empty_like(self);
+  auto it = TensorIterator::unary_op(Y, self);
+  GeluKernel(kCPU, it);
   return Y;
 }
 
 Tensor gelu_backward_cpu(const Tensor& grad, const Tensor& self) {
-  const auto X = self.contiguous();
-  Tensor dX = at::native::empty_like(X);
-  GeluBackwardKernel(kCPU, grad.contiguous(), X, &dX);
+  Tensor dX = at::native::empty_like(self);
+  auto it = TensorIterator::binary_op(dX, grad, self);
+  GeluBackwardKernel(kCPU, it);
   return dX;
 }
 

--- a/aten/src/ATen/native/Activation.h
+++ b/aten/src/ATen/native/Activation.h
@@ -10,10 +10,9 @@ struct TensorIterator;
 
 namespace native {
 
+using activation_fn = void (*)(TensorIterator&);
+using activation_backward_fn = void (*)(TensorIterator&);
 using threshold_fn = void (*)(TensorIterator&, Scalar, Scalar);
-using activation_fn = void (*)(const Tensor& /* X */, Tensor* /* Y */);
-using activation_backward_fn =
-    void (*)(const Tensor& /* dY */, const Tensor& /* X */, Tensor* /* dX */);
 using hardshrink_cpu_fn = void (*)(TensorIterator&, Scalar);
 using hardshrink_backward_cpu_fn = void (*)(TensorIterator&, Scalar);
 

--- a/aten/src/ATen/native/cpu/Activation.cpp
+++ b/aten/src/ATen/native/cpu/Activation.cpp
@@ -42,166 +42,188 @@ static void threshold_kernel(
 
 #if AT_MKL_ENABLED()
 
-// TODO(yangxm): Consider to use TensorIterator here.
 template <typename T>
-void GeluKernelMKLImpl(const Tensor& X, Tensor* Y);
+void MKLCdfNorm(int64_t N, const T* X, T* Y);
 
-#define DELEGATE_GELU_KERNEL_MKL_IMPL(T, CdfNormFunc, MulFunc) \
-  template <>                                                  \
-  void GeluKernelMKLImpl<T>(const Tensor& X, Tensor* Y) {      \
-    const int64_t N = X.numel();                               \
-    const T* X_data = X.data_ptr<T>();                             \
-    T* Y_data = Y->data_ptr<T>();                                  \
-    CdfNormFunc(N, X_data, Y_data);                            \
-    MulFunc(N, X_data, Y_data, Y_data);                        \
+template <>
+void MKLCdfNorm<float>(int64_t N, const float* X, float* Y) {
+  vsCdfNorm(N, X, Y);
+}
+
+template <>
+void MKLCdfNorm<double>(int64_t N, const double* X, double* Y) {
+  vdCdfNorm(N, X, Y);
+}
+
+template <typename T>
+void MKLMul(int64_t N, const T* A, const T* B, T* Y);
+
+template <>
+void MKLMul<float>(int64_t N, const float* A, const float* B, float* Y) {
+  vsMul(N, A, B, Y);
+}
+
+template <>
+void MKLMul<double>(int64_t N, const double* A, const double* B, double* Y) {
+  vdMul(N, A, B, Y);
+}
+
+template <typename T>
+void MKLExp(int64_t N, const T* X, T* Y);
+
+template <>
+void MKLExp<float>(int64_t N, const float* X, float* Y) {
+  vsExp(N, X, Y);
+}
+
+template <>
+void MKLExp<double>(int64_t N, const double* X, double* Y) {
+  vdExp(N, X, Y);
+}
+
+template <typename T>
+void GeluMKLKernelImpl(TensorIterator* it) {
+  if (!it->can_use_32bit_indexing()) {
+    for (auto& sub_it : it->with_32bit_indexing()) {
+      GeluMKLKernelImpl<T>(&sub_it);
+    }
+    return;
   }
-DELEGATE_GELU_KERNEL_MKL_IMPL(float, vsCdfNorm, vsMul)
-DELEGATE_GELU_KERNEL_MKL_IMPL(double, vdCdfNorm, vdMul)
-#undef DELEGATE_GELU_KERNEL_MKL_IMPL
+  const int64_t N = it->numel();
+  const T* X_data = static_cast<T*>(it->data_ptr(1));
+  T* Y_data = static_cast<T*>(it->data_ptr(0));
+  MKLCdfNorm<T>(N, X_data, Y_data);
+  MKLMul<T>(N, X_data, Y_data, Y_data);
+}
+
+template <typename T>
+void GeluBackwardMKLKernelImpl(TensorIterator* it) {
+  if (!it->can_use_32bit_indexing()) {
+    for (auto& sub_it : it->with_32bit_indexing()) {
+      GeluBackwardMKLKernelImpl<T>(&sub_it);
+    }
+    return;
+  }
+  constexpr T kBeta = M_2_SQRTPI * M_SQRT1_2 * T(0.5);
+  const int64_t N = it->numel();
+  const T* dY_data = static_cast<T*>(it->data_ptr(1));
+  const T* X_data = static_cast<T*>(it->data_ptr(2));
+  T* dX_data = static_cast<T*>(it->data_ptr(0));
+  Tensor cdf = at::empty({N}, it->input(1).options());
+  T* cdf_data = cdf.template data_ptr<T>();
+  MKLCdfNorm<T>(N, X_data, cdf_data);
+  for (int64_t i = 0; i < N; ++i) {
+    dX_data[i] = T(-0.5) * X_data[i] * X_data[i];
+  }
+  MKLExp(N, dX_data, dX_data);
+  for (int64_t i = 0; i < N; ++i) {
+    dX_data[i] = dY_data[i] * (cdf_data[i] + kBeta * X_data[i] * dX_data[i]);
+  }
+}
 
 #else // AT_MKL_ENABLED()
 
 template <typename T>
-void GeluKernelMKLImpl(const Tensor& X, Tensor* Y) {
+void GeluMKLKernelImpl(TensorIterator* /* it */) {
+  AT_ASSERTM(false, "ATen not compiled with MKL");
+}
+
+template <typename T>
+void GeluBackwardMKLKernelImpl(TensorIterator* /* it */) {
   AT_ASSERTM(false, "ATen not compiled with MKL");
 }
 
 #endif // AT_MKL_ENABLED()
-
-template <typename T>
-void GeluKernelImplInternal(const Tensor& X, Tensor* Y) {
-  const int64_t N = X.numel();
-  const T* X_data = X.data_ptr<T>();
-  T* Y_data = Y->data_ptr<T>();
-  for (int64_t i = 0; i < N; ++i) {
-    Y_data[i] = X_data[i] * M_SQRT1_2;
-  }
-  Y->erf_();
-  for (int64_t i = 0; i < N; ++i) {
-    Y_data[i] = (Y_data[i] + T(1)) * X_data[i] * T(0.5);
-  }
-}
 
 // TODO(yangxm): Add another fast kernel using formula
 // y = 0.5x * (1 + tanh(sqrt(2/Pi) * (x + 0.044715x^3)))
 // and the fast tanh impl from Eigen.
-void GeluKernelImpl(const Tensor& X, Tensor* Y) {
-  if (at::hasMKL()) {
-    AT_DISPATCH_FLOATING_TYPES(X.scalar_type(), "GeluKernelImpl", [&]() {
-      GeluKernelMKLImpl<scalar_t>(X, Y);
+void GeluKernelImpl(TensorIterator& it) {
+  if (at::hasMKL() && it.is_contiguous()) {
+    AT_DISPATCH_FLOATING_TYPES(it.dtype(), "GeluKernelImpl", [&]() {
+      GeluMKLKernelImpl<scalar_t>(&it);
     });
   } else {
-    AT_DISPATCH_FLOATING_TYPES(X.scalar_type(), "GeluKernelImpl", [&]() {
-      GeluKernelImplInternal<scalar_t>(X, Y);
+    AT_DISPATCH_FLOATING_TYPES(it.dtype(), "GeluKernelImpl", [&]() {
+      using Vec = vec256::Vec256<scalar_t>;
+      const Vec kAlphaVec(M_SQRT1_2);
+      const Vec kOneVec(1);
+      const Vec kPointFiveVec(0.5);
+      cpu_kernel_vec(
+          it,
+          [](scalar_t x) {
+            constexpr scalar_t kAlpha = M_SQRT1_2;
+            return x * scalar_t(0.5) * (scalar_t(1) + std::erf(x * kAlpha));
+          },
+          [&](Vec x_vec) {
+            return x_vec * kPointFiveVec *
+                (kOneVec + (x_vec * kAlphaVec).erf());
+          });
     });
   }
 }
 
-#if AT_MKL_ENABLED()
-
-template <typename T>
-void GeluBackwardKernelMKLImpl(const Tensor& dY, const Tensor& X, Tensor* dX);
-
-// TODO(yangxm): Implement this by using template functions.
-#define DELEGATE_GELU_BACKWARD_KERNEL_MKL_IMPL(T, CdfNormFunc, ExpFunc)     \
-  template <>                                                               \
-  void GeluBackwardKernelMKLImpl<T>(                                        \
-      const Tensor& dY, const Tensor& X, Tensor* dX) {                      \
-    constexpr T kAlpha = M_2_SQRTPI * M_SQRT1_2 * T(0.5);                   \
-    Tensor scratch = at::native::empty_like(X);                             \
-    const int64_t N = X.numel();                                            \
-    const T* dY_data = dY.data_ptr<T>();                                        \
-    const T* X_data = X.data_ptr<T>();                                          \
-    T* dX_data = dX->data_ptr<T>();                                             \
-    T* scratch_data = scratch.data_ptr<T>();                                    \
-    CdfNormFunc(N, X_data, scratch_data);                                   \
-    for (int64_t i = 0; i < N; ++i) {                                       \
-      dX_data[i] = -T(0.5) * X_data[i] * X_data[i];                         \
-    }                                                                       \
-    ExpFunc(N, dX_data, dX_data);                                           \
-    for (int64_t i = 0; i < N; ++i) {                                       \
-      dX_data[i] =                                                          \
-          dY_data[i] * (scratch_data[i] + X_data[i] * dX_data[i] * kAlpha); \
-    }                                                                       \
-  }
-DELEGATE_GELU_BACKWARD_KERNEL_MKL_IMPL(float, vsCdfNorm, vsExp)
-DELEGATE_GELU_BACKWARD_KERNEL_MKL_IMPL(double, vdCdfNorm, vdExp)
-#undef DELEGATE_GELU_BACKWARD_KERNEL_MKL_IMPL
-
-#else // AT_MKL_ENABLED()
-
-template <typename T>
-void GeluBackwardKernelMKLImpl(const Tensor& dY, const Tensor& X, Tensor* dX) {
-  AT_ASSERTM(false, "ATen not compiled with MKL");
-}
-
-#endif // AT_MKL_ENABLED()
-
-template <typename T>
-void GeluBackwardKernelImplInternal(
-    const Tensor& dY,
-    const Tensor& X,
-    Tensor* dX) {
-  constexpr T kAlpha = M_2_SQRTPI * M_SQRT1_2 * T(0.5);
-  Tensor scratch = at::native::empty_like(X);
-  const int64_t N = X.numel();
-  const T* dY_data = dY.data_ptr<T>();
-  const T* X_data = X.data_ptr<T>();
-  T* dX_data = dX->data_ptr<T>();
-  T* scratch_data = scratch.data_ptr<T>();
-  for (int64_t i = 0; i < N; ++i) {
-    scratch_data[i] = X_data[i] * M_SQRT1_2;
-    dX_data[i] = -T(0.5) * X_data[i] * X_data[i];
-  }
-  // TODO(yangxm): Consider let forward pass preserve CdfNorm(X) in training
-  // pass to reduce this extra tensor.
-  scratch.erf_();
-  dX->exp_();
-  for (int64_t i = 0; i < N; ++i) {
-    dX_data[i] = dY_data[i] *
-        (T(0.5) * (T(1) + scratch_data[i]) + X_data[i] * dX_data[i] * kAlpha);
-  }
-}
-
-void GeluBackwardKernelImpl(const Tensor& dY, const Tensor& X, Tensor* dX) {
-  if (hasMKL()) {
-    AT_DISPATCH_FLOATING_TYPES(
-        X.scalar_type(), "GeluBackwardKernelImpl", [&]() {
-          GeluBackwardKernelMKLImpl<scalar_t>(dY, X, dX);
-        });
+void GeluBackwardKernelImpl(TensorIterator& it) {
+  if (hasMKL() && it.is_contiguous()) {
+    AT_DISPATCH_FLOATING_TYPES(it.dtype(), "GeluBackwardKernelImpl", [&]() {
+      GeluBackwardMKLKernelImpl<scalar_t>(&it);
+    });
   } else {
-    AT_DISPATCH_FLOATING_TYPES(
-        X.scalar_type(), "GeluBackwardKernelImpl", [&]() {
-          GeluBackwardKernelImplInternal<scalar_t>(dY, X, dX);
-        });
+    AT_DISPATCH_FLOATING_TYPES(it.dtype(), "GeluBackwardKernelImpl", [&]() {
+      using Vec = vec256::Vec256<scalar_t>;
+      const Vec kAlphaVec(M_SQRT1_2);
+      const Vec kBetaVec(M_2_SQRTPI * M_SQRT1_2 * 0.5);
+      const Vec kOneVec(1);
+      const Vec kPointFiveVec(0.5);
+      const Vec kMinusPointFiveVec(-0.5);
+      cpu_kernel_vec(
+          it,
+          [](scalar_t dy, scalar_t x) {
+            constexpr scalar_t kAlpha = M_SQRT1_2;
+            constexpr scalar_t kBeta = M_2_SQRTPI * M_SQRT1_2 * 0.5;
+            const scalar_t cdf =
+                scalar_t(0.5) * (scalar_t(1) + std::erf(x * kAlpha));
+            const scalar_t pdf = kBeta * std::exp(x * x * scalar_t(-0.5));
+            return dy * (cdf + x * pdf);
+          },
+          [&](Vec dy_vec, Vec x_vec) {
+            const Vec cdf_vec =
+                kPointFiveVec * (kOneVec + (x_vec * kAlphaVec).erf());
+            const Vec pdf_vec =
+                kBetaVec * (x_vec * x_vec * kMinusPointFiveVec).exp();
+            return dy_vec * (cdf_vec + x_vec * pdf_vec);
+          });
+    });
   }
 }
 
 void hardshrink_cpu_kernel(TensorIterator& iter, Scalar lambd) {
   AT_DISPATCH_FLOATING_TYPES(iter.dtype(), "hardshrink_cpu", [&] {
     auto lambd_val = lambd.to<scalar_t>();
-    cpu_kernel_vec(iter,
-      [=](scalar_t self_val) {
-        return (self_val >= -lambd_val && self_val <= lambd_val) ? scalar_t(0) : self_val;
-      },
-      [=](Vec256<scalar_t> self_val) {
-        return ((self_val < -lambd_val) | (self_val > lambd_val)) & self_val;
-      }
-    );
+    cpu_kernel_vec(
+        iter,
+        [=](scalar_t self_val) {
+          return (self_val >= -lambd_val && self_val <= lambd_val) ? scalar_t(0)
+                                                                   : self_val;
+        },
+        [=](Vec256<scalar_t> self_val) {
+          return ((self_val < -lambd_val) | (self_val > lambd_val)) & self_val;
+        });
   });
 }
 
 void hardshrink_backward_cpu_kernel(TensorIterator& iter, Scalar lambd) {
   AT_DISPATCH_FLOATING_TYPES(iter.dtype(), "hardshrink_backward_cpu", [&] {
     auto lambd_val = lambd.to<scalar_t>();
-    cpu_kernel_vec(iter,
-      [=](scalar_t grad_val, scalar_t self_val) {
-        return (self_val >= -lambd_val && self_val <= lambd_val) ? scalar_t(0) : grad_val;
-      },
-      [=](Vec256<scalar_t> grad_val, Vec256<scalar_t> self_val) {
-        return ((self_val < -lambd_val) | (self_val > lambd_val)) & grad_val;
-      }
-    );
+    cpu_kernel_vec(
+        iter,
+        [=](scalar_t grad_val, scalar_t self_val) {
+          return (self_val >= -lambd_val && self_val <= lambd_val) ? scalar_t(0)
+                                                                   : grad_val;
+        },
+        [=](Vec256<scalar_t> grad_val, Vec256<scalar_t> self_val) {
+          return ((self_val < -lambd_val) | (self_val > lambd_val)) & grad_val;
+        });
   });
 }
 
@@ -211,7 +233,9 @@ REGISTER_DISPATCH(threshold_stub, &threshold_kernel);
 REGISTER_DISPATCH(GeluKernel, &GeluKernelImpl);
 REGISTER_DISPATCH(GeluBackwardKernel, &GeluBackwardKernelImpl);
 REGISTER_DISPATCH(hardshrink_cpu_stub, &hardshrink_cpu_kernel);
-REGISTER_DISPATCH(hardshrink_backward_cpu_stub, &hardshrink_backward_cpu_kernel);
+REGISTER_DISPATCH(
+    hardshrink_backward_cpu_stub,
+    &hardshrink_backward_cpu_kernel);
 
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/native/cuda/Activation.cu
+++ b/aten/src/ATen/native/cuda/Activation.cu
@@ -5,8 +5,9 @@
 #include <math.h>
 
 #include <ATen/ATen.h>
-#include <ATen/NativeFunctions.h>
+#include <ATen/AccumulateType.h>
 #include <ATen/Dispatch.h>
+#include <ATen/NativeFunctions.h>
 #include <ATen/cuda/CUDAApplyUtils.cuh>
 #include <ATen/cuda/detail/IndexUtils.cuh>
 #include <ATen/native/cuda/Loops.cuh>
@@ -299,40 +300,29 @@ static void threshold_kernel(TensorIterator& iter, Scalar threshold, Scalar valu
 
 namespace {
 
-template <typename T>
-void GeluCUDAKernelImplInternal(const Tensor& X, Tensor* Y) {
-  at::cuda::CUDA_tensor_apply2<T, T>(X, *Y, [] __device__(const T& x, T& y) {
-    y = x * c10::cuda::compat::normcdf(x);
+void GeluCUDAKernelImpl(TensorIterator& it) {
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(it.dtype(), "GeluCUDAKernelImpl", [&]() {
+    using T_ACC = acc_type<scalar_t, true>;
+    gpu_kernel(it, [] GPU_LAMBDA(scalar_t x) -> scalar_t {
+      return static_cast<T_ACC>(x) *
+          c10::cuda::compat::normcdf(static_cast<T_ACC>(x));
+    });
   });
 }
 
-void GeluCUDAKernelImpl(const Tensor& X, Tensor* Y) {
-  AT_DISPATCH_FLOATING_TYPES(X.scalar_type(), "GeluCUDAKernelImpl", [&]() {
-    GeluCUDAKernelImplInternal<scalar_t>(X, Y);
-  });
-}
-
-template <typename T>
-void GeluBackwardCUDAKernelImplInternal(
-    const Tensor& dY,
-    const Tensor& X,
-    Tensor* dX) {
-  constexpr T kAlpha = M_2_SQRTPI * M_SQRT1_2 * T(0.5);
-  at::cuda::CUDA_tensor_apply3<T, T, T>(
-      dY, X, *dX, [] __device__(const T& dy, const T& x, T& dx) {
-        dx = dy *
-            (c10::cuda::compat::normcdf(x) +
-             x * kAlpha * c10::cuda::compat::exp(-T(0.5) * x * x));
-      });
-}
-
-void GeluBackwardCUDAKernelImpl(
-    const Tensor& dY,
-    const Tensor& X,
-    Tensor* dX) {
-  AT_DISPATCH_FLOATING_TYPES(
-      X.scalar_type(), "GeluBackwardCUDAKernelImpl", [&]() {
-        GeluBackwardCUDAKernelImplInternal<scalar_t>(dY, X, dX);
+void GeluBackwardCUDAKernelImpl(TensorIterator& it) {
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(
+      it.dtype(), "GeluBackwardCUDAKernelImpl", [&]() {
+        using T_ACC = acc_type<scalar_t, true>;
+        gpu_kernel(it, [] GPU_LAMBDA(scalar_t dy, scalar_t x) -> scalar_t {
+          constexpr T_ACC kBeta = M_2_SQRTPI * M_SQRT1_2 * T_ACC(0.5);
+          const T_ACC cdf = c10::cuda::compat::normcdf(static_cast<T_ACC>(x));
+          const T_ACC pdf =
+              c10::cuda::compat::exp(
+                  T_ACC(-0.5) * static_cast<T_ACC>(x) * static_cast<T_ACC>(x)) *
+              kBeta;
+          return static_cast<T_ACC>(dy) * (cdf + static_cast<T_ACC>(x) * pdf);
+        });
       });
 }
 
@@ -340,13 +330,15 @@ void GeluBackwardCUDAKernelImpl(
 
 Tensor gelu_cuda(const Tensor& self) {
   Tensor Y = at::native::empty_like(self);
-  GeluCUDAKernelImpl(self, &Y);
+  auto it = TensorIterator::unary_op(Y, self);
+  GeluKernel(kCUDA, it);
   return Y;
 }
 
 Tensor gelu_backward_cuda(const Tensor& grad, const Tensor& self) {
   Tensor dX = at::native::empty_like(self);
-  GeluBackwardCUDAKernelImpl(grad, self, &dX);
+  auto it = TensorIterator::binary_op(dX, grad, self);
+  GeluBackwardKernel(kCUDA, it);
   return dX;
 }
 

--- a/docs/source/nn.rst
+++ b/docs/source/nn.rst
@@ -349,6 +349,12 @@ Non-linear activations (weighted sum, nonlinearity)
 .. autoclass:: CELU
     :members:
 
+:hidden:`GELU`
+~~~~~~~~~~~~~~
+
+.. autoclass:: GELU
+    :members:
+
 :hidden:`Sigmoid`
 ~~~~~~~~~~~~~~~~~
 

--- a/docs/source/scripts/build_activation_images.py
+++ b/docs/source/scripts/build_activation_images.py
@@ -37,6 +37,7 @@ functions = [
     'RReLU',
     'SELU',
     'CELU',
+    'GELU',
     'Sigmoid',
     'Softplus',
     'Softshrink',

--- a/test/common_nn.py
+++ b/test/common_nn.py
@@ -1,9 +1,11 @@
+import math
 import sys
 import tempfile
 import unittest
+
 from copy import deepcopy
-from itertools import product
 from functools import reduce
+from itertools import product
 from operator import mul
 
 
@@ -2146,6 +2148,17 @@ new_module_tests = [
         constructor_args=(1,),
         input_size=(5, 6, 7),
         desc='dim',
+    ),
+    dict(
+        module_name='GELU',
+        input_size=(),
+        desc='scalar',
+        reference_fn=lambda x, *_: x * 0.5 * (1.0 + torch.erf(x / math.sqrt(2.0))),
+    ),
+    dict(
+        module_name='GELU',
+        input_size=(3, 2, 5),
+        reference_fn=lambda x, *_: x * 0.5 * (1.0 + torch.erf(x / math.sqrt(2.0))),
     ),
     dict(
         constructor=wrap_functional(F.softmax, dim=-1),

--- a/test/cpp/api/functional.cpp
+++ b/test/cpp/api/functional.cpp
@@ -645,6 +645,14 @@ TEST_F(FunctionalTest, SELU) {
   }
 }
 
+TEST_F(FunctionalTest, GELU) {
+  GELU model;
+  const auto x = torch::linspace(-3.0, 3.0, 100);
+  const auto y_exp = x * 0.5 * (1.0 + torch::erf(x / std::sqrt(2.0)));
+  const auto y = F::gelu(x);
+  ASSERT_TRUE(torch::allclose(y, y_exp));
+}
+
 TEST_F(FunctionalTest, Hardshrink) {
   const auto size = 3;
   for (const auto lambda : {-4.2, -1.0, -0.42, 0.0, 0.42, 1.0, 4.2, 42.42}) {
@@ -1017,16 +1025,6 @@ TEST_F(FunctionalTest, Normalize) {
 
     ASSERT_EQ(input.grad().numel(), 1);
   }
-}
-
-TEST_F(FunctionalTest, GeLU) {
-  auto x = torch::tensor({{2., 3.}, {4., 5.}});
-  auto y_exp = torch::tensor({{1.9545, 2.9960}, {3.9999, 5.0000}}) +
-        torch::tensor({{-2.3842e-07, -4.9829e-05}, {-2.6703e-05, -1.4305e-06}});
-  auto y = F::gelu(x);
-  ASSERT_EQ(y.ndimension(), 2);
-  ASSERT_EQ(y.sizes(), std::vector<int64_t>({2, 2}));
-  ASSERT_TRUE(torch::allclose(y, y_exp));
 }
 
 TEST_F(FunctionalTest, ReLU) {

--- a/test/cpp/api/modules.cpp
+++ b/test/cpp/api/modules.cpp
@@ -1858,6 +1858,14 @@ TEST_F(ModulesTest, CELU) {
   }
 }
 
+TEST_F(ModulesTest, GELU) {
+  GELU model;
+  const auto x = torch::linspace(-3.0, 3.0, 100);
+  const auto y_exp = x * 0.5 * (1.0 + torch::erf(x / std::sqrt(2.0)));
+  const auto y = model(x);
+  ASSERT_TRUE(torch::allclose(y, y_exp));
+}
+
 TEST_F(ModulesTest, Sigmoid) {
   Sigmoid model;
   auto x = torch::randn(100) * 10;

--- a/test/cpp_api_parity/parity-tracker.md
+++ b/test/cpp_api_parity/parity-tracker.md
@@ -56,6 +56,7 @@ torch.nn.ReLU6|Yes|No
 torch.nn.RReLU|Yes|No
 torch.nn.SELU|Yes|No
 torch.nn.CELU|Yes|No
+torch.nn.GELU|Yes|No
 torch.nn.Sigmoid|Yes|No
 torch.nn.Softplus|Yes|No
 torch.nn.Softshrink|Yes|No

--- a/test/cpp_api_parity/torch_nn_modules.py
+++ b/test/cpp_api_parity/torch_nn_modules.py
@@ -115,6 +115,7 @@ module_metadata_map = {
     'RReLU': TorchNNModuleMetadata(),
     'SELU': TorchNNModuleMetadata(),
     'CELU': TorchNNModuleMetadata(),
+    'GELU': TorchNNModuleMetadata(),
     'Sigmoid': TorchNNModuleMetadata(),
     'Softplus': TorchNNModuleMetadata(),
     'Softshrink': TorchNNModuleMetadata(),

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -1039,7 +1039,7 @@
   self: elu_backward(grad, alpha, scale, input_scale, result)
 
 - name: gelu(Tensor self) -> Tensor
-  self: gelu_backward(grad, self)
+  self: "GradMode::is_enabled() ? infinitely_differentiable_gelu_backward(grad, self) : gelu_backward(grad, self)"
 
 - name: glu(Tensor self, int dim=-1) -> Tensor
   self: glu_backward(grad, self, dim)

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -835,6 +835,15 @@ Tensor glu_double_backward_grad_output(const Tensor & grad, const Tensor & input
   return tmp.narrow(dim, 0, sizes[dim]) + tmp.narrow(dim, sizes[dim], sizes[dim]);
 }
 
+Tensor infinitely_differentiable_gelu_backward(
+    const Tensor& grad,
+    const Tensor& self) {
+  constexpr double kAlpha = M_2_SQRTPI * M_SQRT1_2 * 0.5;
+  Tensor cdf = (1.0 + (self * M_SQRT1_2).erf_()).mul_(0.5);
+  Tensor pdf = (-0.5 * self * self).exp_();
+  return cdf.addcmul_(self, pdf, kAlpha).mul_(grad);
+}
+
 Tensor kl_div_double_backward_grad_output(const Tensor & grad, const Tensor & input, const Tensor & target, int64_t reduction) {
   auto result = kl_div_backward(grad, input, target, at::Reduction::None);
   if (reduction == at::Reduction::Mean) {

--- a/torch/csrc/api/include/torch/nn/modules/activation.h
+++ b/torch/csrc/api/include/torch/nn/modules/activation.h
@@ -332,6 +332,23 @@ class TORCH_API CELUImpl : public torch::nn::Cloneable<CELUImpl> {
 
 TORCH_MODULE(CELU);
 
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ GELU ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+/// Applies gelu over a given input.
+/// See https://pytorch.org/docs/master/nn.html#torch.nn.GELU to learn
+/// about the exact behavior of this module.
+class TORCH_API GELUImpl : public torch::nn::Cloneable<GELUImpl> {
+ public:
+  Tensor forward(const Tensor& input);
+
+  void reset() override;
+
+  /// Pretty prints the `GELU` module into the given `stream`.
+  void pretty_print(std::ostream& stream) const override;
+};
+
+TORCH_MODULE(GELU);
+
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Sigmoid ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies sigmoid over a given input.

--- a/torch/csrc/api/src/nn/modules/activation.cpp
+++ b/torch/csrc/api/src/nn/modules/activation.cpp
@@ -267,6 +267,18 @@ void CELUImpl::pretty_print(std::ostream& stream) const {
 
 // ============================================================================
 
+Tensor GELUImpl::forward(const Tensor& input) {
+  return F::gelu(input);
+}
+
+void GELUImpl::reset() {}
+
+void GELUImpl::pretty_print(std::ostream& stream) const {
+  stream << "torch::nn::GELU()";
+}
+
+// ============================================================================
+
 Tensor SigmoidImpl::forward(const Tensor& input) {
   return torch::sigmoid(input);
 }

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -838,6 +838,7 @@ class ShapePropagator {
             "aten::rrelu(Tensor self, Scalar lower, Scalar upper, bool training, Generator? generator) -> Tensor",
             "aten::rsqrt(Tensor self) -> Tensor",
             "aten::selu(Tensor self) -> Tensor",
+            "aten::gelu(Tensor self) -> Tensor",
             "aten::sigmoid(Tensor self) -> Tensor",
             "aten::sign(Tensor self) -> Tensor",
             "aten::sin(Tensor self) -> Tensor",

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1117,7 +1117,7 @@ def gelu(input):
     r"""gelu(input) -> Tensor
 
     Applies element-wise the function
-    :math:`\text{GeLU}(x) = x * \Phi(x)`
+    :math:`\text{GELU}(x) = x * \Phi(x)`
 
     where :math:`\Phi(x)` is the Cumulative Distribution Function for Gaussian Distribution.
 

--- a/torch/nn/functional.pyi.in
+++ b/torch/nn/functional.pyi.in
@@ -137,6 +137,9 @@ def rrelu(input: Tensor, lower: float = ..., upper: float = ..., training: bool 
           inplace: bool = ...) -> Tensor: ...
 
 
+def gelu(input: Any): ...
+
+
 def hardshrink(input: Tensor, lambd: float = ...) -> Tensor: ...
 
 

--- a/torch/nn/modules/__init__.py
+++ b/torch/nn/modules/__init__.py
@@ -3,7 +3,7 @@ from .linear import Identity, Linear, Bilinear
 from .conv import Conv1d, Conv2d, Conv3d, \
     ConvTranspose1d, ConvTranspose2d, ConvTranspose3d
 from .activation import Threshold, ReLU, Hardtanh, ReLU6, Sigmoid, Tanh, \
-    Softmax, Softmax2d, LogSoftmax, ELU, SELU, CELU, Hardshrink, LeakyReLU, LogSigmoid, \
+    Softmax, Softmax2d, LogSoftmax, ELU, SELU, CELU, GELU, Hardshrink, LeakyReLU, LogSigmoid, \
     Softplus, Softshrink, MultiheadAttention, PReLU, Softsign, Softmin, Tanhshrink, RReLU, GLU
 from .loss import L1Loss, NLLLoss, KLDivLoss, MSELoss, BCELoss, BCEWithLogitsLoss, NLLLoss2d, \
     CosineEmbeddingLoss, CTCLoss, HingeEmbeddingLoss, MarginRankingLoss, \
@@ -34,7 +34,7 @@ from .flatten import Flatten
 __all__ = [
     'Module', 'Identity', 'Linear', 'Conv1d', 'Conv2d', 'Conv3d', 'ConvTranspose1d',
     'ConvTranspose2d', 'ConvTranspose3d', 'Threshold', 'ReLU', 'Hardtanh', 'ReLU6',
-    'Sigmoid', 'Tanh', 'Softmax', 'Softmax2d', 'LogSoftmax', 'ELU', 'SELU', 'CELU', 'GLU', 'Hardshrink',
+    'Sigmoid', 'Tanh', 'Softmax', 'Softmax2d', 'LogSoftmax', 'ELU', 'SELU', 'CELU', 'GLU', 'GELU', 'Hardshrink',
     'LeakyReLU', 'LogSigmoid', 'Softplus', 'Softshrink', 'MultiheadAttention', 'PReLU', 'Softsign', 'Softmin',
     'Tanhshrink', 'RReLU', 'L1Loss', 'NLLLoss', 'KLDivLoss', 'MSELoss', 'BCELoss', 'BCEWithLogitsLoss',
     'NLLLoss2d', 'PoissonNLLLoss', 'CosineEmbeddingLoss', 'CTCLoss', 'HingeEmbeddingLoss', 'MarginRankingLoss',

--- a/torch/nn/modules/__init__.pyi.in
+++ b/torch/nn/modules/__init__.pyi.in
@@ -1,9 +1,9 @@
 from .module import Module as Module
-from .activation import CELU as CELU, ELU as ELU, GLU as GLU, Hardshrink as Hardshrink, Hardtanh as Hardtanh, \
-    LeakyReLU as LeakyReLU, LogSigmoid as LogSigmoid, LogSoftmax as LogSoftmax, PReLU as PReLU, RReLU as RReLU, \
-    ReLU as ReLU, ReLU6 as ReLU6, SELU as SELU, Sigmoid as Sigmoid, Softmax as Softmax, Softmax2d as Softmax2d, \
-    Softmin as Softmin, Softplus as Softplus, Softshrink as Softshrink, Softsign as Softsign, Tanh as Tanh, \
-    Tanhshrink as Tanhshrink, Threshold as Threshold
+from .activation import CELU as CELU, ELU as ELU, GLU as GLU, GELU as GELU, Hardshrink as Hardshrink, \
+    Hardtanh as Hardtanh, LeakyReLU as LeakyReLU, LogSigmoid as LogSigmoid, LogSoftmax as LogSoftmax, PReLU as PReLU, \
+    RReLU as RReLU, ReLU as ReLU, ReLU6 as ReLU6, SELU as SELU, Sigmoid as Sigmoid, Softmax as Softmax, \
+    Softmax2d as Softmax2d, Softmin as Softmin, Softplus as Softplus, Softshrink as Softshrink, Softsign as Softsign, \
+    Tanh as Tanh, Tanhshrink as Tanhshrink, Threshold as Threshold
 from .adaptive import AdaptiveLogSoftmaxWithLoss as AdaptiveLogSoftmaxWithLoss
 from .batchnorm import BatchNorm1d as BatchNorm1d, BatchNorm2d as BatchNorm2d, BatchNorm3d as BatchNorm3d, \
     SyncBatchNorm as SyncBatchNorm

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -451,6 +451,30 @@ class GLU(Module):
         return 'dim={}'.format(self.dim)
 
 
+class GELU(Module):
+    r"""Applies the Gaussian Error Linear Units function:
+
+    .. math::
+        `\text{GELU}(x) = x * \Phi(x)`
+    where :math:`\Phi(x)` is the Cumulative Distribution Function for Gaussian Distribution.
+
+    Shape:
+        - Input: :math:`(N, *)` where `*` means, any number of additional
+          dimensions
+        - Output: :math:`(N, *)`, same shape as the input
+
+    .. image:: scripts/activation_images/GELU.png
+
+    Examples::
+
+        >>> m = nn.GELU()
+        >>> input = torch.randn(2)
+        >>> output = m(input)
+    """
+    def forward(self, input):
+        return F.gelu(input)
+
+
 class Hardshrink(Module):
     r"""Applies the hard shrinkage function element-wise:
 

--- a/torch/nn/modules/activation.pyi.in
+++ b/torch/nn/modules/activation.pyi.in
@@ -84,6 +84,10 @@ class GLU(Module):
     def forward(self, input: Tensor) -> Tensor: ...
 
 
+class GELU(Module):
+    def forward(self, input: Tensor) -> Tensor: ...
+
+
 class Hardshrink(Module):
     lambd: float = ...
 


### PR DESCRIPTION
Summary: 

1. Add torch.nn.GELU for GELU activation
2. Fix fp16 failures for torch.nn.functional.gelu on CUDA
3. Add infinitely differentiable backward implementation to support higher order gradient.
4. Change gelu_cpu kernel to use TensorIterator.

Differential Revision: D18240946

