### PR TITLE
Fix torch.where to accept tensors with different types

### DIFF
--- a/aten/src/ATen/native/TensorCompare.cpp
+++ b/aten/src/ATen/native/TensorCompare.cpp
@@ -122,6 +122,9 @@ std::vector<Tensor> where(const Tensor& condition) {
 }
 
 Tensor _s_where_cpu(const Tensor& condition, const Tensor& self, const Tensor& other) {
+  if (self.dtype() != other.dtype()) {
+    TORCH_CHECK(false, "expected scalar type ", self.dtype(), " but found ", other.dtype());
+  }
   Tensor ret = at::empty(self.sizes(), self.options());
   AT_DISPATCH_ALL_TYPES(ret.scalar_type(), "where_cpu", [&] {
     where_cpu<scalar_t>(ret, condition, self, other);

--- a/aten/src/ATen/native/TensorCompare.cpp
+++ b/aten/src/ATen/native/TensorCompare.cpp
@@ -122,12 +122,10 @@ std::vector<Tensor> where(const Tensor& condition) {
 }
 
 Tensor _s_where_cpu(const Tensor& condition, const Tensor& self, const Tensor& other) {
-  if (self.dtype() != other.dtype()) {
-    TORCH_CHECK(false, "expected scalar type ", self.dtype(), " but found ", other.dtype());
-  }
-  Tensor ret = at::empty(self.sizes(), self.options());
+  auto common_type = at::promote_types(self.scalar_type(), other.scalar_type());
+  Tensor ret = at::empty(self.sizes(), self.options().dtype(common_type));
   AT_DISPATCH_ALL_TYPES(ret.scalar_type(), "where_cpu", [&] {
-    where_cpu<scalar_t>(ret, condition, self, other);
+    where_cpu<scalar_t>(ret, condition, self.to(common_type), other.to(common_type));
   });
   return ret;
 }

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -774,16 +774,14 @@ class _TestTorchMixin(object):
                 for dt2 in torch.testing.get_all_math_dtypes(device):
                     x1 = rand_tensor((5, 5), dt1, device)
                     x2 = rand_tensor((5, 5), dt2, device)
-                    if (dt1 != dt2):
-                        self.assertRaisesRegex(RuntimeError, "expected scalar type", lambda: torch.where(x1 < 1, x1, x2))
-                    else:
-                        res = torch.where(x1 < 1, x1, x2)
-                        for i in range(5):
-                            for j in range(5):
-                                if x1[i][j] < 1:
-                                    self.assertTrue(res[i][j] == x1[i][j])
-                                else:
-                                    self.assertTrue(res[i][j] == x2[i][j])
+                    res = torch.where(x1 < 1, x1, x2)
+                    for i in range(5):
+                        for j in range(5):
+                            if x1[i][j] < 1:
+                                self.assertTrue(res[i][j] == x1[i][j])
+                            else:
+                                self.assertTrue(res[i][j] == x2[i][j])
+
 
     def test_all_any_with_dim(self):
         def test(x):


### PR DESCRIPTION
Fix for the issue (https://github.com/pytorch/pytorch/issues/28709) when torch.where is called with different Tensor types.