### PR TITLE
add shapes for fill benchmark

### DIFF
--- a/benchmarks/operator_benchmark/benchmark_all_test.py
+++ b/benchmarks/operator_benchmark/benchmark_all_test.py
@@ -7,7 +7,8 @@ import operator_benchmark as op_bench
 from pt import ( # noqa
     add_test, batchnorm_test, cat_test, chunk_test, conv_test, # noqa
     gather_test, linear_test, matmul_test, pool_test, # noqa
-    softmax_test, split_test, unary_test, qconv_test, qlinear_test # noqa
+    softmax_test, split_test, unary_test, qconv_test, qlinear_test, # noqa
+    fill_test, as_strided_test #noqa
 )
 
 

--- a/benchmarks/operator_benchmark/pt/fill_test.py
+++ b/benchmarks/operator_benchmark/pt/fill_test.py
@@ -3,13 +3,25 @@ import torch
 
 """Microbenchmark for Fill_ operator."""
 
+fill_short_configs = op_bench.config_list(
+    attr_names=["N"],
+    attrs=[
+        [1024],
+        [2048],
+    ],
+    cross_product_configs={
+        'device': ['cpu'],
+        'dtype':[torch.int32],
+    },
+    tags=["short"],
+)
 
-fill_short_configs = op_bench.cross_product_configs(
+fill_long_configs = op_bench.cross_product_configs(
     N=[10, 1000],
     device=torch.testing.get_all_device_types(),
     dtype=[torch.bool, torch.int8, torch.uint8, torch.int16, torch.int32,
            torch.int64, torch.half, torch.float, torch.double],
-    tags=["short"]
+    tags=["long"]
 )
 
 
@@ -22,7 +34,8 @@ class Fill_Benchmark(op_bench.TorchBenchmarkBase):
         return self.input_one.fill_(10)
 
 
-op_bench.generate_pt_test(fill_short_configs, Fill_Benchmark)
+op_bench.generate_pt_test(fill_short_configs + fill_long_configs, 
+                          Fill_Benchmark)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary: as title

Test Plan:
```
buck run mode/opt //caffe2/benchmarks/operator_benchmark/pt:fill_test
# ----------------------------------------
# PyTorch/Caffe2 Operator Micro-benchmarks
# ----------------------------------------
# Tag : short

# Benchmarking PyTorch: fill_
# Mode: Eager
# Name: fill__N1024_cpu_dtypetorch.int32
# Input: N: 1024, device: cpu, dtype: torch.int32
Forward Execution Time (us) : 2.008

Reviewed By: hl475

Differential Revision: D18241521

