### PR TITLE
change op benchmark forward_only flag

### DIFF
--- a/benchmarks/operator_benchmark/benchmark_all_test.py
+++ b/benchmarks/operator_benchmark/benchmark_all_test.py
@@ -7,7 +7,8 @@ import operator_benchmark as op_bench
 from pt import ( # noqa
     add_test, batchnorm_test, cat_test, chunk_test, conv_test, # noqa
     gather_test, linear_test, matmul_test, pool_test, # noqa
-    softmax_test, split_test, unary_test, qconv_test, qlinear_test # noqa
+    softmax_test, split_test, unary_test, qconv_test, qlinear_test, # noqa
+    fill_test, as_strided_test  # noqa
 )
 
 

--- a/benchmarks/operator_benchmark/benchmark_runner.py
+++ b/benchmarks/operator_benchmark/benchmark_runner.py
@@ -92,21 +92,29 @@ def main():
 
     parser.add_argument(
         "--ai_pep_format",
-        help="Print result when running on AI-PEP",
+        type=benchmark_utils.str2bool,
+        nargs='?',
+        const=True,
         default=False,
-        type=bool
+        help="Print result when running on AI-PEP"
     )
 
     parser.add_argument(
         "--use_jit",
-        help="Run operators with PyTorch JIT mode",
-        action='store_true'
+        type=benchmark_utils.str2bool,
+        nargs='?',
+        const=True,
+        default=False,
+        help="Run operators with PyTorch JIT mode"
     )
 
     parser.add_argument(
         "--forward_only",
-        help="Only run the forward path of operators",
-        action='store_true'
+        type=benchmark_utils.str2bool,
+        nargs='?',
+        const=True,
+        default=False,
+        help="Only run the forward path of operators"
     )
 
     parser.add_argument(

--- a/benchmarks/operator_benchmark/benchmark_utils.py
+++ b/benchmarks/operator_benchmark/benchmark_utils.py
@@ -21,6 +21,15 @@ _reserved_keywords = {"probs", "total_samples", "tags"}
 def shape_to_string(shape):
     return ', '.join([str(x) for x in shape])
 
+def str2bool(v):
+    if isinstance(v, bool):
+        return v
+    if v.lower() in ('yes', 'true', 't', 'y', '1'):
+        return True
+    elif v.lower() in ('no', 'false', 'f', 'n', '0'):
+        return False
+    else:
+        raise argparse.ArgumentTypeError('Boolean value expected.')
 
 def numpy_random(dtype, *shapes):
     """ Return a random numpy tensor of the provided dtype.

--- a/benchmarks/operator_benchmark/pt/fill_test.py
+++ b/benchmarks/operator_benchmark/pt/fill_test.py
@@ -3,13 +3,25 @@ import torch
 
 """Microbenchmark for Fill_ operator."""
 
+fill_short_configs = op_bench.config_list(
+    attr_names=["N"],
+    attrs=[
+        [1024],
+        [2048],
+    ],
+    cross_product_configs={
+        'device': ['cpu'],
+        'dtype':[torch.int32],
+    },
+    tags=["short"],
+)
 
-fill_short_configs = op_bench.cross_product_configs(
+fill_long_configs = op_bench.cross_product_configs(
     N=[10, 1000],
     device=torch.testing.get_all_device_types(),
     dtype=[torch.bool, torch.int8, torch.uint8, torch.int16, torch.int32,
            torch.int64, torch.half, torch.float, torch.double],
-    tags=["short"]
+    tags=["long"]
 )
 
 
@@ -22,7 +34,8 @@ class Fill_Benchmark(op_bench.TorchBenchmarkBase):
         return self.input_one.fill_(10)
 
 
-op_bench.generate_pt_test(fill_short_configs, Fill_Benchmark)
+op_bench.generate_pt_test(fill_short_configs + fill_long_configs, 
+                          Fill_Benchmark)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary: Change forward_only flag to take True or False so it should be integrated with PEP.

Test Plan:
```
buck run mode/opt //caffe2/benchmarks/operator_benchmark/pt:add_test -- --forward_only true

Reviewed By: hl475

Differential Revision: D18247416

