### PR TITLE
[namedtensor] support addcmul, addcdiv

### DIFF
--- a/aten/src/ATen/native/PointwiseOps.cpp
+++ b/aten/src/ATen/native/PointwiseOps.cpp
@@ -44,9 +44,6 @@ Tensor& addcmul_out(
   iter.add_input(tensor2);
   iter.build();
   addcmul_stub(iter.device_type(), iter, value);
-#ifdef BUILD_NAMEDTENSOR
-  at::namedinference::propagate_names(result, self);
-#endif
   return result;
 }
 
@@ -82,9 +79,6 @@ Tensor& addcdiv_out(
   iter.add_input(tensor2);
   iter.build();
   addcdiv_stub(iter.device_type(), iter, value);
-#ifdef BUILD_NAMEDTENSOR
-  at::namedinference::propagate_names(result, self);
-#endif
   return result;
 }
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -4105,6 +4105,7 @@
 
 - func: addcdiv_(Tensor(a!) self, Tensor tensor1, Tensor tensor2, *, Scalar value=1) -> Tensor(a!)
   variants: method
+  supports_named_tensor: True
 
 - func: random_.from(Tensor(a!) self, int from, int to, *, Generator? generator=None) -> Tensor(a!)
   variants: method
@@ -4497,19 +4498,24 @@
   use_c10_dispatcher: full
 
 - func: addcmul.out(Tensor self, Tensor tensor1, Tensor tensor2, *, Scalar value=1, Tensor(a!) out) -> Tensor(a!)
+  supports_named_tensor: True
 
 - func: addcmul(Tensor self, Tensor tensor1, Tensor tensor2, *, Scalar value=1) -> Tensor
   use_c10_dispatcher: full
   variants: method, function
+  supports_named_tensor: True
 
 - func: addcmul_(Tensor(a!) self, Tensor tensor1, Tensor tensor2, *, Scalar value=1) -> Tensor(a!)
   variants: method
+  supports_named_tensor: True
 
 - func: addcdiv.out(Tensor self, Tensor tensor1, Tensor tensor2, *, Scalar value=1, Tensor(a!) out) -> Tensor(a!)
+  supports_named_tensor: True
 
 - func: addcdiv(Tensor self, Tensor tensor1, Tensor tensor2, *, Scalar value=1) -> Tensor
   use_c10_dispatcher: full
   variants: method, function
+  supports_named_tensor: True
 
 - func: lstsq.X(Tensor self, Tensor A, *, Tensor(a!) X, Tensor(b!) qr) -> (Tensor(a!) solution, Tensor(b!) QR)
   dispatch:

--- a/test/test_namedtensor.py
+++ b/test/test_namedtensor.py
@@ -605,6 +605,23 @@ class TestNamedTensor(TestCase):
             self.assertEqual(x.any().names, [])
             self.assertEqual(x.all().names, [])
 
+    def test_addcmul_addcdiv(self):
+        for device in torch.testing.get_all_device_types():
+            names = ['N']
+            a = torch.rand(3, device=device, names=names)
+            b = torch.rand(3, device=device, names=names)
+            # avoid division by 0
+            c = torch.rand(3, device=device, names=names).clamp_min_(0.1)
+            out = torch.randn(3, device=device, names=names)
+
+            self.assertEqual(torch.addcmul(a, b, c).names, names)
+            self.assertEqual(torch.addcmul(a, b, c, out=out).names, names)
+            self.assertEqual(a.addcmul_(b, c).names, names)
+
+            self.assertEqual(torch.addcdiv(a, b, c).names, names)
+            self.assertEqual(torch.addcdiv(a, b, c, out=out).names, names)
+            self.assertEqual(a.addcdiv_(b, c).names, names)
+
     def test_binary_ops(self):
         def test_basic(op):
             a = torch.empty(2, 3, names=('N', 'C'))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #28981 [namedtensor] add support for {ones,zeros,full,rand,randn}_like ops
* **#28975 [namedtensor] support addcmul, addcdiv**

TensorIterator supports propagating names so we just needed to enable
them with support_named_tensor: True

Test Plan:
- really basic tests to test that each variant (outplace, inplace, out=)
supports named tensors.

Differential Revision: [D18252421](https://our.internmc.facebook.com/intern/diff/D18252421)