### PR TITLE
Fix CUDA shared memory out of bound access in findPattern

### DIFF
--- a/aten/src/ATen/native/cuda/SortingRadixSelect.cuh
+++ b/aten/src/ATen/native/cuda/SortingRadixSelect.cuh
@@ -229,7 +229,7 @@ __device__ scalar_t findPattern(
     index_t withinSliceStride,
     bitwise_t desired,
     bitwise_t desiredMask) {
-  if (threadIdx.x < C10_WARP_SIZE) {
+  if (threadIdx.x < 2) {
     smem[threadIdx.x] = static_cast<scalar_t>(0);
   }
   __syncthreads();


### PR DESCRIPTION
This fixes https://github.com/pytorch/pytorch/issues/28789

Only the first two elements of `smem` are used in this function but at the beginning, it resets all the `C10_WARP_SIZE` to 0. When the `scalar_t` is 64bit, it goes out of the total shared memory size which is `sizeof(int) * C10_WARP_SIZE`, although this does not lead to any failure in CI.