### PR TITLE
Fix torch.where to accept tensors with different dtypes on CPU

### DIFF
--- a/aten/src/ATen/native/TensorCompare.cpp
+++ b/aten/src/ATen/native/TensorCompare.cpp
@@ -122,9 +122,10 @@ std::vector<Tensor> where(const Tensor& condition) {
 }
 
 Tensor _s_where_cpu(const Tensor& condition, const Tensor& self, const Tensor& other) {
-  Tensor ret = at::empty(self.sizes(), self.options());
+  auto common_type = at::promote_types(self.scalar_type(), other.scalar_type());
+  Tensor ret = at::empty(self.sizes(), self.options().dtype(common_type));
   AT_DISPATCH_ALL_TYPES(ret.scalar_type(), "where_cpu", [&] {
-    where_cpu<scalar_t>(ret, condition, self, other);
+    where_cpu<scalar_t>(ret, condition, self.to(common_type), other.to(common_type));
   });
   return ret;
 }

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -955,6 +955,36 @@ class _TestTorchMixin(object):
             res = torch.where(a > 0)
             self.assertEqual(1, len(res))
 
+    def test_where_tensor_cpu(self):
+        def rand_tensor(size, dtype, device):
+            if dtype.is_floating_point:
+                return torch.rand(size=size, dtype=dtype, device=device)
+            elif dtype == torch.uint8:
+                return torch.randint(1, 5, size=size, dtype=dtype, device=device)
+            elif dtype == torch.bool:
+                return torch.randint(0, 1, size=size, dtype=dtype, device=device).bool()
+            else:
+                return torch.randint(-5, 5, size=size, dtype=dtype, device=device)
+
+        device = "cpu"
+        for dt1 in torch.testing.get_all_math_dtypes(device):
+            for dt2 in torch.testing.get_all_math_dtypes(device):
+                x1 = rand_tensor((5, 5), dt1, device)
+                x2 = rand_tensor((5, 5), dt2, device)
+                res = torch.where(x1 < 1, x1, x2)
+                print(dt1)
+                print(dt2)
+                print(x1)
+                print(x2)
+                print(res)
+                for i in range(5):
+                    for j in range(5):
+                        if x1[i][j] < 1:
+                            self.assertTrue(res[i][j].item() == x1[i][j].item())
+                        else:
+                            self.assertTrue(res[i][j].item() == x2[i][j].item())
+
+
     def test_all_any_with_dim(self):
         def test(x):
             r1 = x.prod(dim=0, keepdim=False).byte()

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -972,11 +972,6 @@ class _TestTorchMixin(object):
                 x1 = rand_tensor((5, 5), dt1, device)
                 x2 = rand_tensor((5, 5), dt2, device)
                 res = torch.where(x1 < 1, x1, x2)
-                print(dt1)
-                print(dt2)
-                print(x1)
-                print(x2)
-                print(res)
                 for i in range(5):
                     for j in range(5):
                         if x1[i][j] < 1:


### PR DESCRIPTION
Fix torch.where when called with arguments of different tensor types, as an example: https://github.com/pytorch/pytorch/issues/28709

we will calculate common dtype, based on two argument of torch.where, and use it for dispatching.