### PR TITLE
[iOS] Check device connection before running xcodebuild

### DIFF
--- a/ios/TestApp/.gitignore
+++ b/ios/TestApp/.gitignore
@@ -1,2 +1,3 @@
 model.pt
 .config
+Podfile.lock

--- a/ios/TestApp/README.md
+++ b/ios/TestApp/README.md
@@ -26,11 +26,11 @@ The benchmark folder contains two scripts that help you setup the benchmark proj
 4. Again, in the same directory, run `ruby setup.rb` to setup the XCode project.
 5. Open the `TestApp.xcodeproj`, you're ready to go.
 
-The benchmark code is written in C++, see `benchmark.mm` for more details.
+The benchmark code is written in C++, you can use `UI_LOG` to visualize the log. See `benchmark.mm` for more details. 
 
 ### `bootstrap.sh`
 
-For those who want to do perf testing but don't want touch XCode, `bootstrap.sh` is the right tool for you. It'll automatically build and install the app on your device. That being said, it does require you to have 
+For those who want to do perf testing but don't want to touch XCode, `bootstrap.sh` is the right tool for you. It'll automatically build and install the app on your device. That being said, it does require you to have 
 
 1. A valid iOS dev certificate installed on your local machine. 
 2. A valid provisioning profile for code signing

--- a/ios/TestApp/bootstrap.sh
+++ b/ios/TestApp/bootstrap.sh
@@ -17,6 +17,17 @@ help () {
 }
 bootstrap() {
     echo "starting"
+    echo "detecting devices..."
+    if ! [ -x "$(command -v ios-deploy)" ]; then
+        echo 'Error: ios-deploy is not installed.'
+        exit 1
+    fi 
+    ios-deploy -c -t 1
+    if [ "$?" -ne "0" ]; then
+        echo 'Error: No device connected. Please connect your device via USB then re-run the script'
+        exit 1
+    fi
+    echo "Done."
     PROJ_ROOT=$(pwd)
     BENCHMARK_DIR="${PROJ_ROOT}/benchmark"
     XCODE_PROJ_PATH="./TestApp.xcodeproj"
@@ -59,12 +70,8 @@ bootstrap() {
                             -configuration Debug \
                             PROVISIONING_PROFILE_SPECIFIER=${PROFILE}
     #install TestApp
-    if ! [ -x "$(command -v ios-deploy)" ]; then
-        echo 'Error: ios-deploy is not installed.'
-        exit 1
-    fi 
-    echo "installing, make sure your phone is unlocked"
-    ios-deploy --bundle "${XCODE_BUILD}/Debug-iphoneos/${XCODE_TARGET}.app"
+    echo "installing..."
+    ios-deploy -r --bundle "${XCODE_BUILD}/Debug-iphoneos/${XCODE_TARGET}.app"
     echo "Done."
 }
 while [[ $# -gt 1 ]]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#28996 [iOS] Check device connection**

### Summary 

It'd be frustrated to realize your phone is not connected after waiting so long for the build to finish. This PR checks the device connection status before running the xcodebuild command.

### Test Plan

- Don't break `bootstrap.sh`

Differential Revision: [D18258348](https://our.internmc.facebook.com/intern/diff/D18258348)