### PR TITLE
Limit test_self_add test to ProcessGroupAgent only, since other RpcAgent could support sending to self

### DIFF
--- a/test/rpc_test.py
+++ b/test/rpc_test.py
@@ -208,6 +208,7 @@ class RpcTest(object):
         with self.assertRaisesRegex(RuntimeError, "Unknown destination worker"):
             unknown_worker_id = rpc.get_worker_info("WorkerUnknown")
 
+    @requires_process_group_agent
     @dist_init
     def test_self_add(self):
         self_worker_info = rpc.get_worker_info()
@@ -216,7 +217,7 @@ class RpcTest(object):
         with self.assertRaisesRegex(
             RuntimeError, "does not support making RPC calls to self"
         ):
-            rpc.rpc_sync(self_worker_info, torch.add, args=(torch.ones(2, 2), 1))
+            rpc.rpc_async(self_worker_info, torch.add, args=(torch.ones(2, 2), 1))
 
         with self.assertRaisesRegex(
             RuntimeError, "does not support making RPC calls to self"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#28999 Limit test_self_add test to ProcessGroupAgent only, since other RpcAgent could support sending to self**

Differential Revision: [D5550346](https://our.internmc.facebook.com/intern/diff/D5550346/)