### PR TITLE
Only set CCACHE_WRAPPER_PATH in the build scripts if it is not already passed in.

### DIFF
--- a/scripts/build_ios.sh
+++ b/scripts/build_ios.sh
@@ -26,7 +26,7 @@ if [ -n "${BUILD_PYTORCH_MOBILE:-}" ]; then
   if [ "${ENABLE_BITCODE:-}" == '1' ]; then
     CMAKE_ARGS+=("-DCMAKE_C_FLAGS=-fembed-bitcode")
     CMAKE_ARGS+=("-DCMAKE_CXX_FLAGS=-fembed-bitcode")
-  fi 
+  fi
 else
   # Build protobuf from third_party so we have a host protoc binary.
   echo "Building protoc"
@@ -45,7 +45,9 @@ fi
 # CMAKE_CXX_COMPILER to /usr/bin/g++. In order to use ccache (if it is available) we
 # must override these variables via CMake arguments.
 CMAKE_ARGS+=("-DCMAKE_TOOLCHAIN_FILE=$CAFFE2_ROOT/cmake/iOS.cmake")
-CCACHE_WRAPPER_PATH=/usr/local/opt/ccache/libexec
+if [ -n "${CCACHE_WRAPPER_PATH:-}"]; then
+  CCACHE_WRAPPER_PATH=/usr/local/opt/ccache/libexec
+fi
 if [ -d "$CCACHE_WRAPPER_PATH" ]; then
   CMAKE_ARGS+=("-DCMAKE_C_COMPILER=$CCACHE_WRAPPER_PATH/gcc")
   CMAKE_ARGS+=("-DCMAKE_CXX_COMPILER=$CCACHE_WRAPPER_PATH/g++")

--- a/scripts/build_local.sh
+++ b/scripts/build_local.sh
@@ -18,7 +18,9 @@ fi
 
 # Use ccache if available (this path is where Homebrew installs ccache symlinks)
 if [ "$(uname)" == 'Darwin' ]; then
-  CCACHE_WRAPPER_PATH=/usr/local/opt/ccache/libexec
+  if [ -n "${CCACHE_WRAPPER_PATH}" ]; then
+    CCACHE_WRAPPER_PATH=/usr/local/opt/ccache/libexec
+  fi
   if [ -d "$CCACHE_WRAPPER_PATH" ]; then
     CMAKE_ARGS+=("-DCMAKE_C_COMPILER=$CCACHE_WRAPPER_PATH/gcc")
     CMAKE_ARGS+=("-DCMAKE_CXX_COMPILER=$CCACHE_WRAPPER_PATH/g++")

--- a/scripts/build_local.sh
+++ b/scripts/build_local.sh
@@ -18,7 +18,7 @@ fi
 
 # Use ccache if available (this path is where Homebrew installs ccache symlinks)
 if [ "$(uname)" == 'Darwin' ]; then
-  if [ -n "${CCACHE_WRAPPER_PATH}" ]; then
+  if [ -n "${CCACHE_WRAPPER_PATH:-}"]; then
     CCACHE_WRAPPER_PATH=/usr/local/opt/ccache/libexec
   fi
   if [ -d "$CCACHE_WRAPPER_PATH" ]; then


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#29002 Only set CCACHE_WRAPPER_PATH in the build scripts if it is not already passed in.**

Differential Revision: [D18277225](https://our.internmc.facebook.com/intern/diff/D18277225)