### PR TITLE
Making torch/csrc/cuda nccl usage safe for nccl 2.5

### DIFF
--- a/torch/csrc/cuda/nccl.cpp
+++ b/torch/csrc/cuda/nccl.cpp
@@ -236,10 +236,10 @@ void broadcast(
   ncclDataType_t data_type = get_data_type(tensors[0]);
   int64_t numel = tensors[0].numel();
 
-  AutoNcclGroup nccl_group_guard;
   const auto comms = user_comms.empty() ? get_communicators(tensors)
                                         : ArrayRef<ncclComm_t>(user_comms);
 
+  AutoNcclGroup nccl_group_guard;
   at::cuda::OptionalCUDAGuard device_guard;
   for (size_t i = 0, num_tensors = tensors.size(); i < num_tensors; i++) {
     int device = tensors[i].get_device();
@@ -282,10 +282,10 @@ void reduce(
   ncclDataType_t data_type = get_data_type(inputs[0]);
 
   const auto count = inputs[0].numel();
-  AutoNcclGroup nccl_group_guard;
   auto comms_ref = user_comms.empty() ? get_communicators(inputs)
                                       : ArrayRef<ncclComm_t>(user_comms);
 
+  AutoNcclGroup nccl_group_guard;
   at::cuda::OptionalCUDAGuard device_guard;
   for (size_t i = 0; i < len; i++) {
     int device = inputs[i].device().index();

--- a/torch/csrc/cuda/python_nccl.cpp
+++ b/torch/csrc/cuda/python_nccl.cpp
@@ -191,9 +191,9 @@ PyObject* THCPModule_nccl_all_reduce(PyObject* self, PyObject* args) {
     ncclDataType_t data_type = get_data_type(inputs[0]);
 
     int64_t count = inputs[0].numel();
-    AutoNcclGroup nccl_group_guard;
     auto comms = user_comms.empty() ? get_communicators(inputs)
                                     : ArrayRef<ncclComm_t>(user_comms);
+    AutoNcclGroup nccl_group_guard;
     at::cuda::OptionalCUDAGuard device_guard;
     for (size_t i = 0; i < len; i++) {
       int device = inputs[i].get_device();
@@ -270,9 +270,9 @@ PyObject* THCPModule_nccl_all_gather(PyObject* self, PyObject* args) {
     ncclDataType_t data_type = get_data_type(inputs[0]);
 
     int64_t count = inputs[0].numel();
-    AutoNcclGroup nccl_group_guard;
     auto comms = user_comms.empty() ? get_communicators(inputs)
                                     : ArrayRef<ncclComm_t>(user_comms);
+    AutoNcclGroup nccl_group_guard;
     at::cuda::OptionalCUDAGuard device_guard;
     for (size_t i = 0; i < len; i++) {
       int device = inputs[i].get_device();
@@ -332,9 +332,9 @@ PyObject* THCPModule_nccl_reduce_scatter(PyObject* self, PyObject* args) {
     ncclDataType_t data_type = get_data_type(inputs[0]);
 
     int64_t count = inputs[0].numel() / len;
-    AutoNcclGroup nccl_group_guard;
     auto comms = user_comms.empty() ? get_communicators(inputs)
                                     : ArrayRef<ncclComm_t>(user_comms);
+    AutoNcclGroup nccl_group_guard;
     at::cuda::OptionalCUDAGuard device_guard;
     for (size_t i = 0; i < len; i++) {
       int device = inputs[i].get_device();


### PR DESCRIPTION
Thanks to @AddyLaddy @ptrblck for tracking this fix down.

In torch/csrc/cuda/nccl.cpp and torch/csrc/cuda/python_nccl.cpp, construction of the `AutoNcclGroup` guard (which calls `ncclGroupStart()`) [precedes](https://github.com/pytorch/pytorch/pull/29014/files#diff-3b6a42619dd44000cf58c0328b679a1cL239-L241) a possible call to `get_communicators`, which may call `ncclCommInitAll()`.  Calling `ncclCommInitAll()` within a `ncclGroupStart()/End()` is incorrect according to our Nccl people.

It seemed ok (relevant tests were silently passing) as long as Pytorch was compiled/linked against Nccl 2.4.x (which is currently what's locked into your third_party/nccl subrepo).  However, when we tried to compile and link against Nccl 2.5.x in internal builds, we began to see test hangs (TestAutogradDeviceTypeCUDA.test_unused_output_device_cuda was what initially brought it to our attention).

The present PR fixes those hangs, as far as we know, and will prevent a nasty future surprise when you start building against nccl 2.5.

The backend affected by this PR is exposed via https://github.com/pytorch/pytorch/blob/master/torch/cuda/nccl.py.  I'm not sure if the exposure is actually used anywhere (I think the distributed frontend is now backed by ProcessGroupNCCL in torch/lib/c10d).  So this PR may affect code that is already dead or dying, but still tested, it seems.

I skimmed ProcessGroupNCCL.cpp for potential similar vulnerabilities and didn't spot anything obvious.