### PR TITLE
Print which output didn't have a dependence.

### DIFF
--- a/torch/csrc/jit/tracer.cpp
+++ b/torch/csrc/jit/tracer.cpp
@@ -181,7 +181,7 @@ bool TracingState::hasValue(const IValue& var) const {
 }
 
 
-Value* TracingState::getOutput(const IValue& iv) {
+Value* TracingState::getOutput(const IValue& iv, size_t i) {
    if (iv.isTensor()) {
      at::Tensor var = iv.toTensor();
      if (!var.defined()) {
@@ -193,7 +193,7 @@ Value* TracingState::getOutput(const IValue& iv) {
      auto it = value_map.find(iv);
      if (it == value_map.end()) {
        std::ostringstream os;
-       os << "output of traced region did not have observable "
+       os << "output " << i << " of traced region did not have observable "
           << "data dependence with trace inputs; this probably indicates your "
              "program "
           << "cannot be understood by the tracer.";
@@ -203,7 +203,7 @@ Value* TracingState::getOutput(const IValue& iv) {
   } else if (iv.isTuple()) {
     auto tuple = iv.toTuple()->elements();
     auto tuple_node = graph->createTuple(
-        fmap(tuple, [&](const IValue& ival) { return getOutput(ival); }));
+        fmap(tuple, [&](const IValue& ival) { return getOutput(ival, i); }));
     graph->insertNode(tuple_node);
     return tuple_node->output();
   } else {
@@ -344,7 +344,7 @@ std::pair<std::shared_ptr<TracingState>, Stack> trace(
     // invocations of the trace.
     size_t i = 0;
     for (auto& output : out_stack) {
-      state->graph->registerOutput(state->getOutput(output));
+      state->graph->registerOutput(state->getOutput(output, i));
       i++;
     }
     setTracingState(nullptr);

--- a/torch/csrc/jit/tracer.h
+++ b/torch/csrc/jit/tracer.h
@@ -63,7 +63,7 @@ struct TORCH_API TracingState
   void setValue(const IValue& v, Value* value);
   void delValue(const IValue& var);
   Value* getValue(const IValue& var);
-  Value* getOutput(const IValue& var);
+  Value* getOutput(const IValue& var, size_t i);
   bool hasValue(const IValue& var) const;
 
 private:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#29034 Print which output didn't have a dependence.**

When a tuple is returned, it is helpful to know specifically
which output was the culprit.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>