### PR TITLE
Additional autograd unit tests for Python UDFs.

### DIFF
--- a/docs/cpp/source/Doxyfile
+++ b/docs/cpp/source/Doxyfile
@@ -70,6 +70,8 @@ RECURSIVE              = YES
 # Blacklist certain file patterns from the INPUT section.
 EXCLUDE = ../../../torch/csrc/api/include/torch/nn/pimpl-inl.h \
           ../../../torch/csrc/api/include/torch/detail
+# Increase the max node size for our large files
+DOT_GRAPH_MAX_NODES    = 100
 ################################################################################
 # Output formats for Doxygen to create.                                        #
 ################################################################################

--- a/test/dist_autograd_test.py
+++ b/test/dist_autograd_test.py
@@ -22,7 +22,6 @@ ctx_ids = [-1, -1, -1, -1]
 
 known_context_ids = []
 
-
 # Send rpc done info and context_id to
 # dst_rank = (self.rank + rank_distance) % self.world_size
 # we don't need a lock here since the GIL is held while executing remote
@@ -82,7 +81,7 @@ def my_py_nested_call(t1, t2, dst, world_size, hops):
         return rpc.rpc_sync("worker{}".format(next_dst), my_py_nested_call,
                             args=(t1, t2, next_dst, world_size, hops - 1))
     else:
-        return rpc.rpc_sync("worker{}".format(next_dst), torch.add, args=(t1, t2))
+        return rpc.rpc_sync("worker{}".format(next_dst), my_py_add, args=(t1, t2))
 
 # after dist autograd context is cleaned up, it should be cleaned up on other
 # nodes. This helper allows timeout_seconds for those RPCs to be completed, and
@@ -102,6 +101,22 @@ def _all_contexts_cleaned_up(timeout_seconds=10):
     # all contexts have been cleaned up if trying to retrieve any context resulted in a RuntimeError.
     success = len(context_id_to_raised) == len(known_context_ids) and all(context_id_to_raised.values())
     return success
+
+def noop():
+    pass
+
+def wait_until_node_failure(rank):
+    '''
+    Loops until an RPC to the given rank fails. This is used to
+    indicate that the node has failed in unit tests.
+    '''
+    while True:
+        try:
+            rpc.rpc_sync("worker{}".format(rank), noop, args=())
+            time.sleep(0.1)
+        except Exception:
+            break
+
 
 
 # This function creates a dis atugorad context, run rpc_sync on the given ps,
@@ -135,11 +150,23 @@ class ExecMode(Enum):
     RPC_SYNC = 2  # Run the operation using rpc_sync
     REMOTE = 3  # Run the operation using remote.
 
-
 @unittest.skipIf(
     not torch._six.PY3, "Pytorch distributed autograd package " "does not support python2"
 )
 class DistAutogradTest(object):
+
+    def _initialize_pg(self):
+        # This is for tests using `dist.barrier`.
+        # For `RpcAgent` other than `ProcessGroupAgent`,
+        # no `_default_pg` is initialized.
+        if not dist.is_initialized():
+            dist.init_process_group(
+                backend="gloo",
+                init_method=self.init_method,
+                rank=self.rank,
+                world_size=self.world_size,
+            )
+
 
     def _exec_func(self, exec_mode, method, *args):
         if ExecMode.LOCAL == exec_mode:
@@ -310,16 +337,7 @@ class DistAutogradTest(object):
     def _test_graph(self, fn, exec_mode):
         dst_rank = (self.rank + 1) % self.world_size
 
-        # This is for the below `dist.barrier`.
-        # For `RpcAgent` other than `ProcessGroupAgent`,
-        # no `_default_pg` is initialized.
-        if not dist.is_initialized():
-            dist.init_process_group(
-                backend="gloo",
-                init_method=self.init_method,
-                rank=self.rank,
-                world_size=self.world_size,
-            )
+        self._initialize_pg()
 
         with dist_autograd.context() as context_id:
             t1 = torch.ones(3, 3, requires_grad=True)
@@ -389,16 +407,7 @@ class DistAutogradTest(object):
     def _test_graph_for_py_nested_call(self, exec_mode):
         dst_rank = (self.rank + 1) % self.world_size
 
-        # This is for the below `dist.barrier`.
-        # For `RpcAgent` other than `ProcessGroupAgent`,
-        # no `_default_pg` is initialized.
-        if not dist.is_initialized():
-            dist.init_process_group(
-                backend="gloo",
-                init_method=self.init_method,
-                rank=self.rank,
-                world_size=self.world_size,
-            )
+        self._initialize_pg()
 
         with dist_autograd.context() as context_id:
             t1 = torch.ones(3, 3, requires_grad=True)
@@ -476,16 +485,7 @@ class DistAutogradTest(object):
     def _test_graph_for_py_nested_call_itself(self, exec_mode):
         dst_rank = (self.rank + 1) % self.world_size
 
-        # This is for the below `dist.barrier`.
-        # For `RpcAgent` other than `ProcessGroupAgent`,
-        # no `_default_pg` is initialized.
-        if not dist.is_initialized():
-            dist.init_process_group(
-                backend="gloo",
-                init_method=self.init_method,
-                rank=self.rank,
-                world_size=self.world_size,
-            )
+        self._initialize_pg()
 
         with dist_autograd.context() as context_id:
             t1 = torch.ones(3, 3, requires_grad=True)
@@ -677,16 +677,7 @@ class DistAutogradTest(object):
 
     @dist_init
     def test_context_cleanup_nested_rpc(self):
-        # This is for the below `dist.barrier`.
-        # For `RpcAgent` other than `ProcessGroupAgent`,
-        # no `_default_pg` is initialized.
-        if not dist.is_initialized():
-            dist.init_process_group(
-                backend="gloo",
-                init_method=self.init_method,
-                rank=self.rank,
-                world_size=self.world_size,
-            )
+        self._initialize_pg()
 
         dst_rank = (self.rank + 1) % self.world_size
         nested_dst_rank = (dst_rank + 1) % self.world_size
@@ -1016,7 +1007,6 @@ class DistAutogradTest(object):
         with dist_autograd.context() as context_id:
             t1 = torch.rand((3, 3), requires_grad=True)
             t2 = torch.rand((3, 3), requires_grad=True)
-
             # Perform some ops before error simulation.
             tmp = (t1 + t2) * (t1 + t2)
             t3 = SimulateBackwardError.apply(tmp)
@@ -1032,25 +1022,15 @@ class DistAutogradTest(object):
             val = rpc.rpc_sync('worker{}'.format(self._next_rank()), torch.div,
                                args=(val, t2))
 
-            with self.assertRaises(RuntimeError):
+            with self.assertRaisesRegex(RuntimeError, 'Simulate error on backward pass'):
                 # Run backwards, and validate we receive an error.
                 dist_autograd.backward([val.sum()])
 
-    @unittest.skip("Using sleep to simulate syncronization is flaky")
     @unittest.skipIf(TEST_CONFIG.rpc_backend_name == "PROCESS_GROUP",
                      "Skipping this test temporarily since ProcessGroupAgent does not report errors on node failures")
     @dist_init(clean_shutdown=False)
     def test_backward_node_failure(self):
-        # This is for the below `dist.barrier`.
-        # For `RpcAgent` other than `ProcessGroupAgent`,
-        # no `_default_pg` is initialized.
-        if not dist.is_initialized():
-            dist.init_process_group(
-                backend="gloo",
-                init_method=self.init_method,
-                rank=self.rank,
-                world_size=self.world_size,
-            )
+        self._initialize_pg()
 
         with dist_autograd.context() as context_id:
             t1 = torch.rand((3, 3), requires_grad=True)
@@ -1064,8 +1044,11 @@ class DistAutogradTest(object):
 
             # Kill all odd rank nodes.
             if self.rank % 2 == 0:
-                # Wait a bit for all other nodes to die.
-                time.sleep(5)  # This is flaky.
+                # Wait for all other nodes to die.
+                for rank in range(self.world_size):
+                    if rank % 2 != 0:
+                        wait_until_node_failure(rank)
+
                 with self.assertRaisesRegex(RuntimeError, "Request aborted during client shutdown"):
                     # Run backwards, and validate we receive an error since all
                     # other nodes are dead.
@@ -1147,6 +1130,138 @@ class DistAutogradTest(object):
 
                 local_grads = self._verify_backwards(exec_mode, [loss], context_id, local_grads, t1, t2)
 
+    @dist_init
+    def test_backward_simple_python_udf(self):
+        # Run the same code locally and with dist autograd and verify gradients
+        # are same.
+        local_grads = None
+        t1 = torch.rand((3, 3), requires_grad=True)
+        t2 = torch.rand((3, 3), requires_grad=True)
+        for exec_mode in [ExecMode.LOCAL, ExecMode.REMOTE]:
+            with dist_autograd.context() as context_id:
+                ret = self._exec_func(exec_mode, my_py_add, t1, t2)
+                loss = ret.sum()
+                local_grads = self._verify_backwards(exec_mode, [loss], context_id, local_grads, t1, t2)
+
+    def _complex_python_udf(t1, t2):
+        t3 = torch.nn.functional.linear(t1, t2)
+        t4 = torch.nn.functional.linear(t2, t3)
+        t5 = torch.nn.functional.linear(t3, t4)
+        return torch.chain_matmul(t1, t2, t3, t4, t5)
+
+    @dist_init
+    def test_backward_complex_python_udf(self):
+        # Run the same code locally and with dist autograd and verify gradients
+        # are same.
+        local_grads = None
+        t1 = torch.rand((3, 3), requires_grad=True)
+        t2 = torch.rand((3, 3), requires_grad=True)
+        for exec_mode in [ExecMode.LOCAL, ExecMode.REMOTE]:
+            with dist_autograd.context() as context_id:
+                ret = self._exec_func(exec_mode, DistAutogradTest._complex_python_udf, t1, t2)
+                loss = ret.sum()
+                local_grads = self._verify_backwards(exec_mode, [loss], context_id, local_grads, t1, t2)
+
+    def _python_udf_with_backward_error(t1, t2):
+        t3 = t1 + t2
+        t4 = SimulateBackwardError.apply(t3)
+        return torch.chain_matmul(t1, t2, t3, t4)
+
+    def _nested_rpc_call_backward_error(t1, t2, dst):
+        t1 = t1 * t2
+        t2 = t1 + t2
+        res = rpc.rpc_sync('worker{}'.format(dst),
+                           DistAutogradTest._python_udf_with_backward_error,
+                           args=(t1, t2))
+        return torch.chain_matmul(t1, t2, res)
+
+
+    @dist_init
+    def test_backward_python_udf_error(self):
+        t1 = torch.rand((3, 3), requires_grad=True)
+        t2 = torch.rand((3, 3), requires_grad=True)
+        with dist_autograd.context() as context_id:
+            loss = rpc.rpc_sync('worker{}'.format(self._next_rank()),
+                                DistAutogradTest._nested_rpc_call_backward_error,
+                                args=(t1, t2, self._next_rank()))
+            with self.assertRaisesRegex(RuntimeError, 'Simulate error on backward pass'):
+                dist_autograd.backward([loss.sum()])
+
+
+    _backward_done = False
+
+    def _set_backward_done():
+        DistAutogradTest._backward_done = True
+
+    def _wait_backward_done():
+        while not DistAutogradTest._backward_done:
+            time.sleep(0.1)
+
+    @unittest.skipIf(TEST_CONFIG.rpc_backend_name == "PROCESS_GROUP",
+                     "Skipping this test temporarily since ProcessGroupAgent " +
+                     "does not report errors on node failures")
+    @dist_init(clean_shutdown=False)
+    def test_backward_node_failure_python_udf(self):
+        self._initialize_pg()
+
+        with dist_autograd.context() as context_id:
+            t1 = torch.rand((3, 3), requires_grad=True)
+            t2 = torch.rand((3, 3), requires_grad=True)
+
+            dst = self._next_rank()
+            res = rpc.rpc_sync('worker{}'.format(dst), my_py_nested_call,
+                               args=(t1, t2, dst, self.world_size, 1))
+
+            # Wait for all RPCs to be done.
+            dist.barrier()
+
+            # Kill rank 2 (last hop of nested rpc) and verify rank 0 receives an error.
+            if self.rank == 2:
+                return
+
+            if self.rank == 0:
+                # Wait for rank 2 to die.
+                wait_until_node_failure(2)
+
+                with self.assertRaisesRegex(RuntimeError, "Request aborted during client shutdown"):
+                    # Run backwards, and validate we receive an error since rank 2 is dead.
+                    dist_autograd.backward([res.sum()])
+
+                # Tell other nodes RPC is done.
+                for i in range(self.world_size):
+                    if i != self.rank and i != 2:
+                        rpc.rpc_sync('worker{}'.format(i), DistAutogradTest._set_backward_done, args=())
+            else:
+                # Wait for backward to finish on rank 0.
+                DistAutogradTest._wait_backward_done()
+
+    def _nested_python_udf(t1, t2, dst):
+        t3 = t1 * t2
+        t4 = t1 + t2
+        res = rpc.rpc_sync('worker{}'.format(dst), my_py_add, args=(t3, t4))
+        return torch.chain_matmul(t1, t2, t3, t4, res)
+
+    @dist_init
+    def test_backwards_nested_python_udf(self):
+        # Run equivalent of _nested_python_udf locally.
+        t1 = torch.rand((3, 3), requires_grad=True)
+        t2 = torch.rand((3, 3), requires_grad=True)
+        t3 = t1 * t2
+        t4 = t1 + t2
+        res = t3 + t4
+        loss = torch.chain_matmul(t1, t2, t3, t4, res).sum()
+        torch.autograd.backward([loss])
+
+        # Now run distributed autograd.
+        with dist_autograd.context() as context_id:
+            loss = rpc.rpc_sync('worker{}'.format(self._next_rank()),
+                                DistAutogradTest._nested_python_udf,
+                                args=(t1, t2, self._next_rank()))
+            dist_autograd.backward([loss.sum()])
+
+            grads = dist_autograd.get_gradients(context_id)
+            self.assertEqual(t1.grad, grads[t1])
+            self.assertEqual(t2.grad, grads[t2])
 
 if __name__ == '__main__':
     unittest.main()

--- a/torch/csrc/Exceptions.h
+++ b/torch/csrc/Exceptions.h
@@ -3,9 +3,10 @@
 #include <exception>
 #include <string>
 
+#include <c10/util/Exception.h>
 #include <torch/csrc/THP_export.h>
-#include <torch/csrc/utils/auto_gil.h>
 #include <torch/csrc/WindowsTorchApiMacro.h>
+#include <torch/csrc/utils/auto_gil.h>
 
 #define HANDLE_TH_ERRORS                                                       \
   try {
@@ -44,7 +45,11 @@ extern PyObject *THPException_FatalError;
 struct python_error : public std::exception {
   python_error() : type(nullptr), value(nullptr), traceback(nullptr) {}
 
-  python_error(const python_error &other) : type(other.type), value(other.value), traceback(other.traceback) {
+  python_error(const python_error& other)
+      : type(other.type),
+        value(other.value),
+        traceback(other.traceback),
+        message(other.message) {
     AutoGIL gil;
     Py_XINCREF(type);
     Py_XINCREF(value);
@@ -55,6 +60,7 @@ struct python_error : public std::exception {
     type = other.type;
     value = other.value;
     traceback = other.traceback;
+    message = std::move(other.message);
     other.type = nullptr;
     other.value = nullptr;
     other.traceback = nullptr;
@@ -69,6 +75,47 @@ struct python_error : public std::exception {
     }
   }
 
+  virtual const char* what() const noexcept override {
+    return message.c_str();
+  }
+
+  void build_message() {
+    // Ensure we have the GIL.
+    AutoGIL gil;
+
+    // No errors should be set when we enter the function since PyErr_Fetch
+    // clears the error indicator.
+    TORCH_INTERNAL_ASSERT(!PyErr_Occurred());
+
+    // Default message.
+    message = "python_error";
+
+    // Try to retrieve the error message from the value.
+    if (value != nullptr) {
+      // Reference count should not be zero.
+      TORCH_INTERNAL_ASSERT(value->ob_refcnt > 0);
+
+      PyObject* pyStr = PyObject_Str(value);
+      if (pyStr != nullptr) {
+        PyObject* encodedString =
+            PyUnicode_AsEncodedString(pyStr, "utf-8", "strict");
+        if (encodedString != nullptr) {
+          char* bytes = PyBytes_AS_STRING(encodedString);
+          if (bytes != nullptr) {
+            // Set the message.
+            message = std::string(bytes);
+          }
+          Py_XDECREF(encodedString);
+        }
+        Py_XDECREF(pyStr);
+      }
+    }
+
+    // Clear any errors since we don't want to propagate errors for functions
+    // that are trying to build a string for the error message.
+    PyErr_Clear();
+  }
+
   /** Saves the exception so that it can be re-thrown on a different thread */
   inline void persist() {
     if (type) return; // Don't overwrite exceptions
@@ -78,6 +125,7 @@ struct python_error : public std::exception {
     Py_XDECREF(value);
     Py_XDECREF(traceback);
     PyErr_Fetch(&type, &value, &traceback);
+    build_message();
   }
 
   /** Sets the current Python error from this exception */
@@ -94,6 +142,9 @@ struct python_error : public std::exception {
   PyObject* type;
   PyObject* value;
   PyObject* traceback;
+
+  // Message to return to the user when 'what()' is invoked.
+  std::string message;
 };
 
 #ifdef _THP_CORE

--- a/torch/csrc/autograd/engine.h
+++ b/torch/csrc/autograd/engine.h
@@ -165,7 +165,7 @@ struct TORCH_API Engine {
   // Given a pre-populated GraphTask and GraphRoot, computes the backward pass
   // for the graph. This API should only be used by internal autograd specific
   // machinery and shouldn't be exposed to users in anyway.
-  variable_list execute_with_graph_task(
+  virtual variable_list execute_with_graph_task(
       std::shared_ptr<GraphTask> graph_task,
       std::shared_ptr<Node> graph_root);
 

--- a/torch/csrc/autograd/python_engine.cpp
+++ b/torch/csrc/autograd/python_engine.cpp
@@ -70,6 +70,20 @@ variable_list PythonEngine::execute(
   }
 }
 
+variable_list PythonEngine::execute_with_graph_task(
+    std::shared_ptr<GraphTask> graph_task,
+    std::shared_ptr<Node> graph_root) {
+  try {
+    return Engine::execute_with_graph_task(graph_task, graph_root);
+  } catch (python_error& e) {
+    AutoGIL gil;
+    if (!PyErr_Occurred()) {
+      // Set the error indicator only if it is not set already.
+      e.restore();
+    }
+    throw;
+  }
+}
 }}} // namespace torch::autograd::python
 
 PyObject *THPEngineClass = nullptr;

--- a/torch/csrc/autograd/python_engine.h
+++ b/torch/csrc/autograd/python_engine.h
@@ -21,6 +21,10 @@ struct PythonEngine : public Engine {
       bool keep_graph,
       bool create_graph,
       const edge_list& outputs = {}) override;
+
+  variable_list execute_with_graph_task(
+      std::shared_ptr<GraphTask> graph_task,
+      std::shared_ptr<Node> graph_root) override;
   std::unique_ptr<AnomalyMetadata> make_anomaly_metadata() override;
 };
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #29069 Fix distributed autograd initialization.
* **#29041 Additional autograd unit tests for Python UDFs.**

1) Enhanced autograd unit tests to test the
torch.distributed.autograd.backward() API more thoroughly on Python UDFs.
2) Enhanced `python_error` to override `what` such that it returns an
appropriate error string if we call `what()` on this error. This ensures we can
propagate exceptions over the wire during RPCs (since we get the error string
by calling what() on the exception)

Differential Revision: [D18273041](https://our.internmc.facebook.com/intern/diff/D18273041/)