### PR TITLE
Print which output didn't have dependence.

### DIFF
--- a/torch/csrc/jit/tracer.cpp
+++ b/torch/csrc/jit/tracer.cpp
@@ -181,7 +181,7 @@ bool TracingState::hasValue(const IValue& var) const {
 }
 
 
-Value* TracingState::getOutput(const IValue& iv) {
+Value* TracingState::getOutput(const IValue& iv, size_t i) {
    if (iv.isTensor()) {
      at::Tensor var = iv.toTensor();
      if (!var.defined()) {
@@ -193,7 +193,7 @@ Value* TracingState::getOutput(const IValue& iv) {
      auto it = value_map.find(iv);
      if (it == value_map.end()) {
        std::ostringstream os;
-       os << "output of traced region did not have observable "
+       os << "output " << i << " (" << var << ") of traced region did not have observable "
           << "data dependence with trace inputs; this probably indicates your "
              "program "
           << "cannot be understood by the tracer.";
@@ -203,7 +203,7 @@ Value* TracingState::getOutput(const IValue& iv) {
   } else if (iv.isTuple()) {
     auto tuple = iv.toTuple()->elements();
     auto tuple_node = graph->createTuple(
-        fmap(tuple, [&](const IValue& ival) { return getOutput(ival); }));
+        fmap(tuple, [&](const IValue& ival) { return getOutput(ival, i); }));
     graph->insertNode(tuple_node);
     return tuple_node->output();
   } else {
@@ -344,7 +344,9 @@ std::pair<std::shared_ptr<TracingState>, Stack> trace(
     // invocations of the trace.
     size_t i = 0;
     for (auto& output : out_stack) {
-      state->graph->registerOutput(state->getOutput(output));
+      // NB: The stack is in "reverse" order, so when we pass the diagnostic
+      // number we need to flip it based on size.
+      state->graph->registerOutput(state->getOutput(output, out_stack.size() - i));
       i++;
     }
     setTracingState(nullptr);

--- a/torch/csrc/jit/tracer.h
+++ b/torch/csrc/jit/tracer.h
@@ -63,7 +63,7 @@ struct TORCH_API TracingState
   void setValue(const IValue& v, Value* value);
   void delValue(const IValue& var);
   Value* getValue(const IValue& var);
-  Value* getOutput(const IValue& var);
+  Value* getOutput(const IValue& var, size_t i);
   bool hasValue(const IValue& var) const;
 
 private:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #28620 Merge Tensor and Variable.
* **#29047 Print which output didn't have dependence.**

When a tuple is returned, it is helpful to know specifically
which output was the culprit.

Actually, it was somewhat /more/ helpful to actually see the
contents of the tensor which didn't have dependence (or, e.g.,
the backtrace of the code that populated it), but that seemed
a step too far.

Differential Revision: [D18274323](https://our.internmc.facebook.com/intern/diff/D18274323/)