### PR TITLE
Limit test_self_add test to ProcessGroupAgent only, since other RpcAgent could support sending to self

### DIFF
--- a/test/rpc_test.py
+++ b/test/rpc_test.py
@@ -226,7 +226,7 @@ class RpcTest(object):
         with self.assertRaisesRegex(
             RuntimeError, "does not support making RPC calls to self"
         ):
-            rpc.rpc_sync(self_worker_info, torch.add, args=(torch.ones(2, 2), 1))
+            rpc.rpc_async(self_worker_info, torch.add, args=(torch.ones(2, 2), 1))
 
         with self.assertRaisesRegex(
             RuntimeError, "does not support making RPC calls to self"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#29051 ThriftRpcAgent support sending to self**

https://github.com/pytorch/pytorch/pull/28999

`


Differential Revision: [D5550346](https://our.internmc.facebook.com/intern/diff/D5550346/)