### PR TITLE
[REMOVED]

### DIFF
--- a/torch/csrc/api/include/torch/detail/TensorDataContainer.h
+++ b/torch/csrc/api/include/torch/detail/TensorDataContainer.h
@@ -38,6 +38,13 @@ inline c10::ScalarType compute_desired_dtype(c10::ScalarType scalar_type) {
     // `torch::tensor(at::ArrayRef<T>)` and `torch::tensor(std::vector<T>)` as the specified
     // dtype `T` is always respected.
     return at::kLong;
+  } else if (scalar_type == at::kDouble) {
+    // yf225 TODO: add thorough tests for this
+    // When `scalar_type == at::kDouble`, we know that the user is passing in
+    // a floating-point literal without specifying its type (e.g. `1.0` instead of `1.0f`).
+    // In Python, the dtype of `torch.tensor(1.0)` depends on the value of
+    // `torch.get_default_dtype()`, and we should do the same for C++ `torch::tensor(1.0)`.
+    return at::typeMetaToScalarType(at::get_default_dtype());
   } else {
     return scalar_type;
   }
@@ -97,7 +104,7 @@ struct TensorDataContainer {
   // the innermost `TensorDataContainer`.
   TensorDataContainer() :
       sizes_({0}),
-      scalar_type_(at::kFloat),
+      scalar_type_(at::typeMetaToScalarType(at::get_default_dtype())), // yf225 TODO: comment here  // yf225 TODO: add thorough tests for this
       type_(TensorDataContainerType::InitList) {}
 #define TENSOR(T, S) \
   TensorDataContainer(T value) : \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #29097 [WIP] Support C++ tensor advanced indexing
* **#29072 Use default dtype for torch::tensor(floating_point_values) and torch::tensor(empty braced-init-list) when dtype is not specified**
* #29066 Use at::kLong for torch::tensor(integer_value) when dtype is not specified

