### PR TITLE
Fix torch.where to accept only tensors with same dtypes(CPU)

### DIFF
--- a/aten/src/ATen/native/Loss.cpp
+++ b/aten/src/ATen/native/Loss.cpp
@@ -31,7 +31,7 @@ Tensor cosine_embedding_loss(const Tensor& input1, const Tensor& input2, const T
   auto denom = (mag_square1 * mag_square2).sqrt_();
   auto cos = prod_sum / denom;
 
-  auto zeros = at::zeros_like(target);
+  auto zeros = at::zeros_like(cos);
   auto pos = 1 - cos;
   auto neg = (cos - margin).clamp_min_(0);
   auto output_pos = at::where(target == 1, pos, zeros);
@@ -67,8 +67,8 @@ Tensor margin_ranking_loss(const Tensor& input1, const Tensor& input2, const Ten
 }
 
 Tensor kl_div(const Tensor& input, const Tensor& target, int64_t reduction) {
-  auto zeros = at::zeros_like(target);
   auto output_pos = target * (at::log(target) - input);
+  auto zeros = at::zeros_like(output_pos);
   auto output = at::where(target > 0, output_pos, zeros);
   return apply_loss_reduction(output, reduction);
 }

--- a/aten/src/ATen/native/TensorCompare.cpp
+++ b/aten/src/ATen/native/TensorCompare.cpp
@@ -122,9 +122,7 @@ std::vector<Tensor> where(const Tensor& condition) {
 }
 
 Tensor _s_where_cpu(const Tensor& condition, const Tensor& self, const Tensor& other) {
-  if (self.dtype() != other.dtype()) {
-    TORCH_CHECK(false, "expected scalar type ", self.dtype(), " but found ", other.dtype());
-  }
+  TORCH_CHECK(self.dtype() == other.dtype(), "expected scalar type ", self.dtype(), " but found ", other.dtype());
   Tensor ret = at::empty(self.sizes(), self.options());
   AT_DISPATCH_ALL_TYPES(ret.scalar_type(), "where_cpu", [&] {
     where_cpu<scalar_t>(ret, condition, self, other);

--- a/aten/src/ATen/native/TensorCompare.cpp
+++ b/aten/src/ATen/native/TensorCompare.cpp
@@ -122,6 +122,9 @@ std::vector<Tensor> where(const Tensor& condition) {
 }
 
 Tensor _s_where_cpu(const Tensor& condition, const Tensor& self, const Tensor& other) {
+  if (self.dtype() != other.dtype()) {
+    TORCH_CHECK(false, "expected scalar type ", self.dtype(), " but found ", other.dtype());
+  }
   Tensor ret = at::empty(self.sizes(), self.options());
   AT_DISPATCH_ALL_TYPES(ret.scalar_type(), "where_cpu", [&] {
     where_cpu<scalar_t>(ret, condition, self, other);

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7230,9 +7230,9 @@ class TestNN(NNTestCase):
                     for dt3 in torch.testing.get_all_math_dtypes(device):
                         if dt3 == torch.uint8:
                             continue
-                        input1 = torch.tensor([[2, 3, 4], [6, 2, 4]], dtype=dt1)
-                        input2 = torch.tensor([[2, 3, 5], [3, 2, 1]], dtype=dt2)
-                        target = torch.tensor([1, -1], dtype=dt3)
+                        input1 = torch.tensor([[2, 3, 4], [6, 2, 4]], dtype=dt1, device=device)
+                        input2 = torch.tensor([[2, 3, 5], [3, 2, 1]], dtype=dt2, device=device)
+                        target = torch.tensor([1, -1], dtype=dt3, device=device)
                         result = torch.nn.functional.cosine_embedding_loss(input1, input2, target)
                         self.assertEqual(result.item(), 0.4672, 0.001)
 
@@ -7242,8 +7242,8 @@ class TestNN(NNTestCase):
                 for target_dtype in [torch.float32, torch.float64, torch.float16]:
                     if not device.startswith('cuda') and target_dtype == torch.float16:
                         continue
-                    input = torch.tensor([[2, 3, 5], [3, 2, 1]], dtype=input_dtype)
-                    target = torch.tensor([[1, 2, 3], [4, 5, 6]], dtype=target_dtype)
+                    input = torch.tensor([[2, 3, 5], [3, 2, 1]], dtype=input_dtype, device=device)
+                    target = torch.tensor([[1, 2, 3], [4, 5, 6]], dtype=target_dtype, device=device)
                     result = torch.nn.functional.kl_div(input, target)
                     self.assertEqual(result.item(), -3.6625, 0.001)
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7223,6 +7223,30 @@ class TestNN(NNTestCase):
                          loss_reference_fns['CosineEmbeddingLoss'](input1, input2, target,
                                                                    margin=0.5, reduction='none'))
 
+    def test_cosine_embedding_loss_with_diff_type(self):
+        for device in device_():
+            for dt1 in torch.testing.get_all_math_dtypes(device):
+                for dt2 in torch.testing.get_all_math_dtypes(device):
+                    for dt3 in torch.testing.get_all_math_dtypes(device):
+                        if dt3 == torch.uint8:
+                            continue
+                        input1 = torch.tensor([[2, 3, 4], [6, 2, 4]], dtype=dt1)
+                        input2 = torch.tensor([[2, 3, 5], [3, 2, 1]], dtype=dt2)
+                        target = torch.tensor([1, -1], dtype=dt3)
+                        result = torch.nn.functional.cosine_embedding_loss(input1, input2, target)
+                        self.assertEqual(result.item(), 0.4672, 0.001)
+
+    def test_kl_div_with_diff_type(self):
+        for device in device_():
+            for input_dtype in torch.testing.get_all_math_dtypes(device):
+                for target_dtype in [torch.float32, torch.float64, torch.float16]:
+                    if not device.startswith('cuda') and target_dtype == torch.float16:
+                        continue
+                    input = torch.tensor([[2, 3, 5], [3, 2, 1]],  dtype=input_dtype)
+                    target = torch.tensor([[1, 2, 3], [4, 5, 6]],  dtype=target_dtype)
+                    result = torch.nn.functional.kl_div(input, target)
+                    self.assertEqual(result.item(), -3.6625, 0.001)
+
     def test_margin_ranking_loss_no_reduce(self):
         input1 = torch.randn(15).mul_(10).requires_grad_()
         input2 = torch.randn(15).mul_(10).requires_grad_()

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7225,27 +7225,35 @@ class TestNN(NNTestCase):
 
     def test_cosine_embedding_loss_with_diff_type(self):
         for device in device_():
+            input1 = torch.tensor([[2, 3, 4], [6, 2, 4]], dtype=torch.double, device=device)
+            input2 = torch.tensor([[2, 3, 5], [3, 2, 1]], dtype=torch.double, device=device)
+            target = torch.tensor([1, -1], dtype=torch.int, device=device)
+            expected = torch.nn.functional.cosine_embedding_loss(input1, input2, target)
             for dt1 in torch.testing.get_all_math_dtypes(device):
                 for dt2 in torch.testing.get_all_math_dtypes(device):
                     for dt3 in torch.testing.get_all_math_dtypes(device):
+                        # dt3 is used as dtype for target = [1, -1], so let's skip unsigned type
                         if dt3 == torch.uint8:
                             continue
-                        input1 = torch.tensor([[2, 3, 4], [6, 2, 4]], dtype=dt1, device=device)
-                        input2 = torch.tensor([[2, 3, 5], [3, 2, 1]], dtype=dt2, device=device)
-                        target = torch.tensor([1, -1], dtype=dt3, device=device)
+                        input1 = input1.to(dt1)
+                        input2 = input2.to(dt2)
+                        target = target.to(dt3)
                         result = torch.nn.functional.cosine_embedding_loss(input1, input2, target)
-                        self.assertEqual(result.item(), 0.4672, 0.001)
+                        self.assertEqual(result.item(), expected.item(), 0.001)
 
     def test_kl_div_with_diff_type(self):
         for device in device_():
+            input = torch.tensor([[2, 3, 5], [3, 2, 1]], dtype=torch.double, device=device)
+            target = torch.tensor([[1, 2, 3], [4, 5, 6]], dtype=torch.double, device=device)
+            expected = torch.nn.functional.kl_div(input, target)
             for input_dtype in torch.testing.get_all_math_dtypes(device):
                 for target_dtype in [torch.float32, torch.float64, torch.float16]:
-                    if not device.startswith('cuda') and target_dtype == torch.float16:
+                    if (torch.device(device).type == 'cpu' and target_dtype == torch.float16):
                         continue
-                    input = torch.tensor([[2, 3, 5], [3, 2, 1]], dtype=input_dtype, device=device)
-                    target = torch.tensor([[1, 2, 3], [4, 5, 6]], dtype=target_dtype, device=device)
+                    input = input.to(input_dtype)
+                    target = target.to(target_dtype)
                     result = torch.nn.functional.kl_div(input, target)
-                    self.assertEqual(result.item(), -3.6625, 0.001)
+                    self.assertEqual(result.item(), expected.item(), 0.001)
 
     def test_margin_ranking_loss_no_reduce(self):
         input1 = torch.randn(15).mul_(10).requires_grad_()

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7242,8 +7242,8 @@ class TestNN(NNTestCase):
                 for target_dtype in [torch.float32, torch.float64, torch.float16]:
                     if not device.startswith('cuda') and target_dtype == torch.float16:
                         continue
-                    input = torch.tensor([[2, 3, 5], [3, 2, 1]],  dtype=input_dtype)
-                    target = torch.tensor([[1, 2, 3], [4, 5, 6]],  dtype=target_dtype)
+                    input = torch.tensor([[2, 3, 5], [3, 2, 1]], dtype=input_dtype)
+                    target = torch.tensor([[1, 2, 3], [4, 5, 6]], dtype=target_dtype)
                     result = torch.nn.functional.kl_div(input, target)
                     self.assertEqual(result.item(), -3.6625, 0.001)
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -983,16 +983,12 @@ class _TestTorchMixin(object):
                             self.assertRaisesRegex(RuntimeError, "expected scalar type", lambda: torch.where(x1 == 1, x1, x2))
                         else:
                             if x1.is_floating_point():
-                                res = torch.where(x1 < 0.5, x1, x2)
+                                condition = (x1 < 0.5)
                             else:
-                                res = torch.where(x1 == 1, x1, x2)
-                            for i in range(height):
-                                for j in range(width):
-                                    if (x1.is_floating_point() and x1[i][j] < 0.5) or \
-                                            (not x1.is_floating_point() and x1[i][j] == 1):
-                                        self.assertTrue(res[i][j].item() == x1[i][j].item())
-                                    else:
-                                        self.assertTrue(res[i][j].item() == x2[i][j].item())
+                                condition = (x1 == 1)
+                            expected = condition.to(x1.dtype) * x1 + (~condition).to(x2.dtype) * x2
+                            result = torch.where(condition, x1, x2)
+                            self.assertEqual(expected, result)
 
     def test_all_any_with_dim(self):
         def test(x):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -988,7 +988,8 @@ class _TestTorchMixin(object):
                                 res = torch.where(x1 == 1, x1, x2)
                             for i in range(height):
                                 for j in range(width):
-                                    if (x1.is_floating_point() and x1[i][j] < 0.5) or (not x1.is_floating_point() and x1[i][j] == 1):
+                                    if (x1.is_floating_point() and x1[i][j] < 0.5) or \
+                                            (not x1.is_floating_point() and x1[i][j] == 1):
                                         self.assertTrue(res[i][j].item() == x1[i][j].item())
                                     else:
                                         self.assertTrue(res[i][j].item() == x2[i][j].item())

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -951,8 +951,8 @@ class _TestTorchMixin(object):
             res = torch.where(a > 0)
             self.assertEqual(1, len(res))
 
-    def test_where_tensor_cpu(self):
-        def rand_tensor(size, dtype, device, cont):
+    def test_where_tensor(self):
+        def rand_tensor(size, dtype, device):
             if dtype.is_floating_point:
                 return torch.rand(size=size, dtype=dtype, device=device)
             elif dtype == torch.uint8:
@@ -962,11 +962,11 @@ class _TestTorchMixin(object):
             else:
                 return torch.randint(-5, 5, size=size, dtype=dtype, device=device)
 
-        def get_tensor(size, dtype, device, cont):
-            if not cont and len(size) < 2:
+        def get_tensor(size, dtype, device, contiguous):
+            if not contiguous and len(size) < 2:
                 raise RuntimeError("Unable to generate non contiguous tensor with size < 2")
-            t = rand_tensor(size, dtype, device, cont)
-            if cont:
+            t = rand_tensor(size, dtype, device)
+            if contiguous:
                 return t
             else:
                 return t.transpose(0, 1)
@@ -976,16 +976,19 @@ class _TestTorchMixin(object):
         for device in torch.testing.get_all_device_types():
             for dt1 in torch.testing.get_all_math_dtypes(device):
                 for dt2 in torch.testing.get_all_math_dtypes(device):
-                    for cont in [True, False]:
-                        x1 = get_tensor((height, width), dt1, device, cont)
-                        x2 = get_tensor((height, width), dt2, device, cont)
+                    for contiguous in [True, False]:
+                        x1 = get_tensor((height, width), dt1, device, contiguous)
+                        x2 = get_tensor((height, width), dt2, device, contiguous)
                         if dt1 != dt2:
                             self.assertRaisesRegex(RuntimeError, "expected scalar type", lambda: torch.where(x1 == 1, x1, x2))
                         else:
-                            res = torch.where(x1 == 1, x1, x2)
+                            if x1.is_floating_point():
+                                res = torch.where(x1 < 0.5, x1, x2)
+                            else:
+                                res = torch.where(x1 == 1, x1, x2)
                             for i in range(height):
                                 for j in range(width):
-                                    if x1[i][j] == 1:
+                                    if (x1.is_floating_point() and x1[i][j] < 0.5) or (not x1.is_floating_point() and x1[i][j] == 1):
                                         self.assertTrue(res[i][j].item() == x1[i][j].item())
                                     else:
                                         self.assertTrue(res[i][j].item() == x2[i][j].item())

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -951,6 +951,45 @@ class _TestTorchMixin(object):
             res = torch.where(a > 0)
             self.assertEqual(1, len(res))
 
+    def test_where_tensor_cpu(self):
+        def rand_tensor(size, dtype, device, cont):
+            if dtype.is_floating_point:
+                return torch.rand(size=size, dtype=dtype, device=device)
+            elif dtype == torch.uint8:
+                return torch.randint(1, 5, size=size, dtype=dtype, device=device)
+            elif dtype == torch.bool:
+                return torch.randint(0, 1, size=size, dtype=dtype, device=device).bool()
+            else:
+                return torch.randint(-5, 5, size=size, dtype=dtype, device=device)
+
+        def get_tensor(size, dtype, device, cont):
+            if not cont and len(size) < 2:
+                raise RuntimeError("Unable to generate non contiguous tensor with size < 2")
+            t = rand_tensor(size, dtype, device, cont)
+            if cont:
+                return t
+            else:
+                return t.transpose(0, 1)
+
+        height = 5
+        width = 5
+        for device in torch.testing.get_all_device_types():
+            for dt1 in torch.testing.get_all_math_dtypes(device):
+                for dt2 in torch.testing.get_all_math_dtypes(device):
+                    for cont in [True, False]:
+                        x1 = get_tensor((height, width), dt1, device, cont)
+                        x2 = get_tensor((height, width), dt2, device, cont)
+                        if dt1 != dt2:
+                            self.assertRaisesRegex(RuntimeError, "expected scalar type", lambda: torch.where(x1 == 1, x1, x2))
+                        else:
+                            res = torch.where(x1 == 1, x1, x2)
+                            for i in range(height):
+                                for j in range(width):
+                                    if x1[i][j] == 1:
+                                        self.assertTrue(res[i][j].item() == x1[i][j].item())
+                                    else:
+                                        self.assertTrue(res[i][j].item() == x2[i][j].item())
+
     def test_all_any_with_dim(self):
         def test(x):
             r1 = x.prod(dim=0, keepdim=False).byte()


### PR DESCRIPTION
Currently torch.where can be called with tensor arguments of different types, as an example: #28709

This fix should prohibit this and allow to call torch.where only with argument of same type. It's similar to CUDA behaviour.