### PR TITLE
use fbgemm's 3d group conv fast path

### DIFF
--- a/caffe2/quantization/server/conv_dnnlowp_op.h
+++ b/caffe2/quantization/server/conv_dnnlowp_op.h
@@ -110,6 +110,9 @@ class ConvDNNLowPOp : public ConvPoolDNNLowPOpBase<T, ConvFp32Op> {
 
   void ConvNHWCCore_(const T* col_buffer_data, vector<std::int32_t>* Y_int32);
 
+  fbgemm::conv_param_t<> GetConvParam_();
+  fbgemm::conv_param_t<3> GetConv3DParam_();
+
   std::vector<dnnlowp::RequantizationParams> requantization_params_;
 
   // used in fast path for T == uint8_t
@@ -120,6 +123,9 @@ class ConvDNNLowPOp : public ConvPoolDNNLowPOpBase<T, ConvFp32Op> {
   // For small gconv
   std::shared_ptr<fbgemm::PackWeightMatrixForGConv<std::int8_t>>
       Wq_gconv_packed_;
+  std::shared_ptr<
+      fbgemm::PackWeightMatrixForGConv<std::int8_t, std::int32_t, 3>>
+      Wq_gconv3d_packed_;
 
   // pre-computed biases and offsets
   std::shared_ptr<std::vector<std::int32_t>> b_quantized_;

--- a/caffe2/quantization/server/conv_dnnlowp_op_test.py
+++ b/caffe2/quantization/server/conv_dnnlowp_op_test.py
@@ -138,10 +138,14 @@ class DNNLowPOpConvTest(hu.HypothesisTestCase):
                     "Int8ConvPackWeight",
                     inputs,
                     ["W_packed"],
-                    group=group,
+                    stride=stride,
+                    kernel=kernel,
+                    dilation=dilation,
+                    pad=pad,
                     preserve_weight_sparsity=preserve_weight_sparsity,
-                    in_scale=x_q_param.scale,
                     engine=engine,
+                    group=group,
+                    in_scale=x_q_param.scale,
                 )
                 init_net.Proto().op.extend([pack])
 
@@ -382,9 +386,13 @@ class DNNLowPOpConvTest(hu.HypothesisTestCase):
                     "Int8ConvPackWeight",
                     inputs,
                     ["W_packed"],
+                    strides=[stride] * ndim,
+                    kernels=kernels,
+                    dilations=[dilation] * ndim,
+                    pads=[pad] * (ndim * 2),
+                    engine=engine,
                     group=group,
                     in_scale=x_q_param.scale,
-                    engine=engine,
                 )
                 init_net.Proto().op.extend([pack])
 

--- a/caffe2/quantization/server/fbgemm_pack_blob.h
+++ b/caffe2/quantization/server/fbgemm_pack_blob.h
@@ -38,6 +38,9 @@ struct Int8ConvDNNLowPPackedWeightBlob : public Int8FCDNNLowPPackedWeightBlob {
   // Only for 32-bit accumulation
   std::shared_ptr<fbgemm::PackedDepthWiseConvMatrix> W_depthwise;
   std::shared_ptr<fbgemm::PackWeightMatrixForGConv<std::int8_t>> W_gconv;
+  std::shared_ptr<
+      fbgemm::PackWeightMatrixForGConv<std::int8_t, std::int32_t, 3>>
+      W_gconv3d;
 };
 
 } // namespace caffe2

--- a/caffe2/quantization/server/fbgemm_pack_op.cc
+++ b/caffe2/quantization/server/fbgemm_pack_op.cc
@@ -380,25 +380,60 @@ bool ConvDNNLowPPackWeightOp::TakeDepthWise3x3x3FastPath_() {
   return ret;
 }
 
-bool ConvDNNLowPPackWeightOp::TakeGConvFastPath_() {
-  if (this->debug_def().engine() == "DNNLOWP_ACC16" ||
-      this->kernel_.size() != 2) {
-    return false;
-  }
+fbgemm::conv_param_t<> ConvDNNLowPPackWeightOp::GetConvParam_() {
+  CAFFE_ENFORCE_EQ(this->kernel_.size(), 2);
 
   auto& filter = InputTensorCPU_(FILTER);
   const int M = filter.dim32(0), C = filter.dim32(filter.dim() - 1) * group_;
-  fbgemm::conv_param_t<> conv_p(
-      1,
+
+  return fbgemm::conv_param_t<>(
+      1, // dummy
       C,
       M,
-      {1, 1},
+      {this->kernel_[0] * this->stride_[0],
+       this->kernel_[1] * this->stride_[1]}, // dummy
       group_,
       {this->kernel_[0], this->kernel_[1]},
       {this->stride_[0], this->stride_[1]},
       {this->pads_[0], this->pads_[1], this->pads_[2], this->pads_[3]});
+}
 
-  return fbgemm::fbgemmOptimizedGConv(conv_p);
+fbgemm::conv_param_t<3> ConvDNNLowPPackWeightOp::GetConv3DParam_() {
+  CAFFE_ENFORCE_EQ(this->kernel_.size(), 3);
+
+  auto& filter = InputTensorCPU_(FILTER);
+  const int M = filter.dim32(0), C = filter.dim32(filter.dim() - 1) * group_;
+
+  return fbgemm::conv_param_t<3>(
+      1, // dummy
+      C,
+      M,
+      {1,
+       this->kernel_[1] * this->stride_[1],
+       this->kernel_[2] * this->stride_[2]}, // dummy
+      group_,
+      {this->kernel_[0], this->kernel_[1], this->kernel_[2]},
+      {this->stride_[0], this->stride_[1], this->stride_[2]},
+      {this->pads_[0],
+       this->pads_[1],
+       this->pads_[2],
+       this->pads_[3],
+       this->pads_[4],
+       this->pads_[5]});
+}
+
+bool ConvDNNLowPPackWeightOp::TakeGConvFastPath_() {
+  if (this->debug_def().engine() == "DNNLOWP_ACC16" ||
+      (this->kernel_.size() != 2 && this->kernel_.size() != 3)) {
+    return false;
+  }
+
+  if (this->kernel_.size() == 2) {
+    return fbgemm::fbgemmOptimizedGConv(GetConvParam_());
+  } else {
+    CAFFE_ENFORCE_EQ(this->kernel_.size(), 3);
+    return fbgemm::fbgemmOptimizedGConv(GetConv3DParam_());
+  }
 }
 
 bool ConvDNNLowPPackWeightOp::RunOnDevice() {
@@ -543,18 +578,19 @@ bool ConvDNNLowPPackWeightOp::RunOnDevice() {
       Y->W_depthwise.reset(new fbgemm::PackedDepthWiseConvMatrix(
           group_, 3 * 3 * 3, W_quantized.data()));
     } else if (TakeGConvFastPath_()) {
-      fbgemm::conv_param_t<> conv_p(
-          1,
-          group_ * C_per_group,
-          M,
-          {1, 1},
-          group_,
-          {this->kernel_[0], this->kernel_[1]},
-          {this->stride_[0], this->stride_[1]},
-          {this->pads_[0], this->pads_[1], this->pads_[2], this->pads_[3]});
-
-      Y->W_gconv.reset(new fbgemm::PackWeightMatrixForGConv<int8_t>(
-          fbgemm::matrix_op_t::Transpose, conv_p, W_quantized.data()));
+      if (this->kernel_.size() == 2) {
+        Y->W_gconv.reset(new fbgemm::PackWeightMatrixForGConv<int8_t>(
+            fbgemm::matrix_op_t::Transpose,
+            GetConvParam_(),
+            W_quantized.data()));
+      } else {
+        CAFFE_ENFORCE_EQ(this->kernel_.size(), 3);
+        Y->W_gconv3d.reset(
+            new fbgemm::PackWeightMatrixForGConv<int8_t, int32_t, 3>(
+                fbgemm::matrix_op_t::Transpose,
+                GetConv3DParam_(),
+                W_quantized.data()));
+      }
     } else {
       Y->W.reset(new fbgemm::PackBMatrix<int8_t>(
           fbgemm::matrix_op_t::Transpose,

--- a/caffe2/quantization/server/fbgemm_pack_op.h
+++ b/caffe2/quantization/server/fbgemm_pack_op.h
@@ -57,6 +57,9 @@ class ConvDNNLowPPackWeightOp final
   bool TakeDepthWise3x3x3FastPath_();
   bool TakeGConvFastPath_();
 
+  fbgemm::conv_param_t<> GetConvParam_();
+  fbgemm::conv_param_t<3> GetConv3DParam_();
+
   // Save quantized weights right after quantization before layout packing for
   // performance purpose
   bool save_unpacked_weights_;


### PR DESCRIPTION
Summary:
Change DNNLOWP operators to use fbgemm's new 3D groupwise convolution (D18192339)

This diff also fixes an issue when column offsets are fused into bias.
In this case, we construct ReQuantizeOutput with col_offsets == 0 and A_zero_point == 0 even if real A_zero_point is 0.
In fbgemmGroupwiseConv, when we call dispatchOutputProcessing, we shouldn't pass the original A_zero_point .

Test Plan: CI

Differential Revision: D18282373

