### PR TITLE
Move torch.cuda's atfork handler into C++

### DIFF
--- a/tools/amd_build/patches/a_torch_cuda___init__.py.patch
+++ b/tools/amd_build/patches/a_torch_cuda___init__.py.patch
@@ -1,8 +1,8 @@
 diff --git a/torch/cuda/__init__.py b/torch/cuda/__init__.py
-index 8450f27812..1de27a5b0d 100644
+index 21227ba9c0..994c778c74 100644
 --- a/torch/cuda/__init__.py
 +++ b/torch/cuda/__init__.py
-@@ -144,8 +144,6 @@ def _lazy_call(callable):
+@@ -148,8 +148,6 @@ def _lazy_call(callable):
          # Don't store the actual traceback to avoid memory cycle
          _queued_calls.append((callable, traceback.format_stack()))
  
@@ -11,13 +11,13 @@ index 8450f27812..1de27a5b0d 100644
  
  class DeferredCudaCallError(Exception):
      pass
-@@ -191,9 +189,6 @@ def _lazy_init():
+@@ -195,9 +193,6 @@ def _lazy_init():
                  "Cannot re-initialize CUDA in forked subprocess. " + msg)
          _check_driver()
          torch._C._cuda_init()
 -        _cudart = _load_cudart()
 -        _cudart.cudaGetErrorName.restype = ctypes.c_char_p
 -        _cudart.cudaGetErrorString.restype = ctypes.c_char_p
-         _original_pid = os.getpid()
          # Some of the queued calls may reentrantly call _lazy_init();
          # we need to just return without initializing in that case.
+         # However, we must not let any *other* threads in!

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -61,7 +61,7 @@ PyObject * THCPModule_getDevice_wrap(PyObject *self, PyObject *noargs)
 PyObject * THCPModule_getDeviceCount_wrap(PyObject *self, PyObject *noargs)
 {
   HANDLE_TH_ERRORS
-  //torch::utils::cuda_lazy_init();
+  torch::utils::cuda_lazy_init();
   return PyLong_FromLong(at::cuda::device_count());
   END_HANDLE_TH_ERRORS
 }

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -19,15 +19,12 @@ import warnings
 import threading
 from torch._six import raise_from
 from subprocess import Popen, PIPE
-from multiprocessing.util import register_after_fork as _register_after_fork
 from ._utils import _get_device_index
 
 _initialized = False
 _tls = threading.local()
 _initialization_lock = threading.Lock()
 _queued_calls = []  # don't invoke these until initialization occurs
-_in_bad_fork = False  # this global is also used in torch.manual_seed
-_original_pid = False
 _cudart = None
 
 
@@ -137,8 +134,13 @@ def _check_capability():
             warnings.warn(incorrect_binary_warn % (d, name, 10000, CUDA_VERSION))
 
 
+def is_initialized():
+    r"""Returns whether PyTorch's CUDA state has been initialized."""
+    return _initialized and not torch._C._cuda_isInBadFork()
+
+
 def _lazy_call(callable):
-    if _initialized:
+    if is_initialized():
         callable()
     else:
         # Don't store the actual traceback to avoid memory cycle
@@ -149,11 +151,6 @@ _lazy_call(_check_capability)
 
 class DeferredCudaCallError(Exception):
     pass
-
-
-def is_initialized():
-    r"""Returns whether PyTorch's CUDA state has been initialized."""
-    return _initialized
 
 
 def init():
@@ -170,8 +167,8 @@ def init():
 
 
 def _lazy_init():
-    global _initialized, _cudart, _original_pid, _queued_calls
-    if _initialized or hasattr(_tls, 'is_initializing'):
+    global _initialized, _cudart, _queued_calls
+    if is_initialized() or hasattr(_tls, 'is_initializing'):
         return
     with _initialization_lock:
         # We be double-checked locking, boys!  This is OK because
@@ -179,12 +176,12 @@ def _lazy_init():
         # is for when a thread blocked on some other thread which was
         # doing the initialization; when they get the lock, they will
         # find there is nothing left to do.
-        if _initialized:
+        if is_initialized():
             return
         # It is important to prevent other threads from entering _lazy_init
         # immediately, while we are still guaranteed to have the GIL, because some
         # of the C calls we make below will release the GIL
-        if _in_bad_fork:
+        if torch._C._cuda_isInBadFork():
             from sys import version_info
             if version_info < (3, 4):
                 msg = ("To use CUDA with multiprocessing, you must use Python "
@@ -199,7 +196,6 @@ def _lazy_init():
         _cudart = _load_cudart()
         _cudart.cudaGetErrorName.restype = ctypes.c_char_p
         _cudart.cudaGetErrorString.restype = ctypes.c_char_p
-        _original_pid = os.getpid()
         # Some of the queued calls may reentrantly call _lazy_init();
         # we need to just return without initializing in that case.
         # However, we must not let any *other* threads in!
@@ -215,17 +211,6 @@ def _lazy_init():
         finally:
             delattr(_tls, 'is_initializing')
         _initialized = True
-
-
-def _after_fork(arg):
-    global _initialized, _in_bad_fork
-    if _initialized and _original_pid != os.getpid():
-        _initialized = False
-        _in_bad_fork = True
-        _CudaBase.__new__ = _lazy_new
-        torch._C._cuda_set_run_yet_variable_to_false()
-
-_register_after_fork(_after_fork, _after_fork)
 
 
 def cudart():
@@ -335,8 +320,7 @@ def get_device_capability(device=None):
 
 
 def get_device_properties(device):
-    if not _initialized:
-        init()  # will define _get_device_properties and _CudaDeviceProperties
+    _lazy_init()  # will define _get_device_properties and _CudaDeviceProperties
     device = _get_device_index(device, optional=True)
     if device < 0 or device >= device_count():
         raise AssertionError("Invalid device id")
@@ -489,8 +473,8 @@ if not hasattr(torch._C, 'CudaDoubleStorageBase'):
 @staticmethod
 def _lazy_new(cls, *args, **kwargs):
     _lazy_init()
-    # We need this method only for lazy init, so we can remove it
-    del _CudaBase.__new__
+    # We may need to call lazy init again if we are a forked child
+    # del _CudaBase.__new__
     return super(_CudaBase, cls).__new__(cls, *args, **kwargs)
 
 

--- a/torch/random.py
+++ b/torch/random.py
@@ -1,7 +1,7 @@
 import contextlib
 import warnings
 
-from torch._C import default_generator
+from torch._C import default_generator, _cuda_isInBadFork
 
 
 def set_rng_state(new_state):
@@ -28,7 +28,7 @@ def manual_seed(seed):
     seed = int(seed)
     import torch.cuda
 
-    if not torch.cuda._in_bad_fork:
+    if not _cuda_isInBadFork():
         torch.cuda.manual_seed_all(seed)
 
     return default_generator.manual_seed(seed)
@@ -41,7 +41,7 @@ def seed():
     seed = default_generator.seed()
     import torch.cuda
 
-    if not torch.cuda._in_bad_fork:
+    if not _cuda_isInBadFork():
         torch.cuda.manual_seed_all(seed)
 
     return seed

--- a/torch/random.py
+++ b/torch/random.py
@@ -1,7 +1,7 @@
 import contextlib
 import warnings
 
-from torch._C import default_generator, _cuda_isInBadFork
+from torch._C import default_generator
 
 
 def set_rng_state(new_state):
@@ -28,7 +28,7 @@ def manual_seed(seed):
     seed = int(seed)
     import torch.cuda
 
-    if not _cuda_isInBadFork():
+    if not torch.cuda._is_in_bad_fork():
         torch.cuda.manual_seed_all(seed)
 
     return default_generator.manual_seed(seed)
@@ -41,7 +41,7 @@ def seed():
     seed = default_generator.seed()
     import torch.cuda
 
-    if not _cuda_isInBadFork():
+    if not torch.cuda._is_in_bad_fork():
         torch.cuda.manual_seed_all(seed)
 
     return seed


### PR DESCRIPTION
Fixes #23401 

We cannot rely on `multiprocessing.util.register_after_fork` since it is only
called for processes created by the `multiprocessing` module and not `os.fork()`.

Moving to `pthread_atfork` does always get called. However, I don't think it's safe to call python functions inside of the `atfork` handler so the python code has to be a bit more careful when checking `_initialized`.