### PR TITLE
[DOC] Add note about when to install typing package

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ If you are building for NVIDIA's Jetson platforms (Jetson Nano, TX1, TX2, AGX Xa
 
 #### Install Dependencies
 
-Common
+Common (only install `typing` for Python <3.5)
 ```
 conda install numpy ninja pyyaml mkl mkl-include setuptools cmake cffi typing
 ```


### PR DESCRIPTION
Was just trying to build pytorch from source and had a small hiccup because the instructions say to `conda install typing`. Because `typing` is a built-in module in recent Python 3 versions, conda interpreted that to mean that I want Python 2. So I added a note to the docs.