### PR TITLE
Make caffe2/fb folder compatible with AMD

### DIFF
--- a/caffe2/python/pybind_state_hip.cc
+++ b/caffe2/python/pybind_state_hip.cc
@@ -47,6 +47,7 @@ void addHIPGlobalMethods(py::module& m) {
     obj["name"] = py::cast(prop.name);
     obj["major"] = py::cast(prop.major);
     obj["minor"] = py::cast(prop.minor);
+    obj["totalGlobalMem"] = py::cast(prop.totalGlobalMem);
     return obj;
   });
 };


### PR DESCRIPTION
Summary:
caffe2_pb2.CUDA --> workspace.GpuDeviceType
workspace.NumCudaDevices() --> workspace.NumGpuDevices()

Also added the totalGlobalMem into get_device_properties(), which is needed by multi_gpu_utils.py

Test Plan:
sandcastle

f148921769

Reviewed By: bddppq

Differential Revision: D18290090

