### PR TITLE
CPU-strided-complex support for ComplexFloat

### DIFF
--- a/aten/src/ATen/cpu/vec256/vec256_complex_float.h
+++ b/aten/src/ATen/cpu/vec256/vec256_complex_float.h
@@ -13,7 +13,7 @@ namespace {
 
 #if defined(__AVX__) && !defined(_MSC_VER)
 
-template <> class Vec256<std::complex<float>> {
+template <> class Vec256<std::complex<float>> { 
 private:
   __m256 values;
 public:

--- a/aten/src/ATen/native/cpu/CopyKernel.cpp
+++ b/aten/src/ATen/native/cpu/CopyKernel.cpp
@@ -35,6 +35,40 @@ void copy_kernel_cast(TensorIterator& iter) {
     }
 }
 
+template <>
+void copy_kernel_cast<std::complex<double>>(TensorIterator& iter) {
+  // Specialization for inter-complex dtypes
+  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(
+    ScalarType::Half,
+    ScalarType::Bool,
+    ScalarType::BFloat16,
+    iter.dtype(1),
+    "copy_kernel_cast",
+    [&] {
+      cpu_kernel(iter, [=](scalar_t a) -> std::complex<double> {
+        return static_cast<std::complex<double>>(
+            static_cast<at::native::inter_copy_type_t<std::complex<double>>>(a));
+      });
+    });
+}
+
+template <>
+void copy_kernel_cast<std::complex<float>>(TensorIterator& iter) {
+  // Specialization for inter-complex dtypes
+  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(
+    ScalarType::Half,
+    ScalarType::Bool,
+    ScalarType::BFloat16,
+    iter.dtype(1),
+    "copy_kernel_cast",
+    [&] {
+      cpu_kernel(iter, [=](scalar_t a) -> std::complex<float> {
+        return static_cast<std::complex<float>>(
+            static_cast<at::native::inter_copy_type_t<std::complex<float>>>(a));
+      });
+    });
+}
+
 static void copy_kernel(TensorIterator& iter, bool non_blocking) {
   ScalarType dtype = iter.dtype(0);
   if (dtype == iter.dtype(1)) {


### PR DESCRIPTION
In-tree changes to pytorch to support complex numbers are being submitted here.
Out-of-tree support for complex numbers is here: [pytorch-cpu-strided-complex extension](https://gitlab.com/pytorch-complex/pytorch-cpu-strided-complex)

Changes
- [x]  Fixed Vec256 Permute operations for Complex Float
- [x]  Fixed copy_kernel_cast between complex data types
  -  copy_kernel_cast should not call std::real during inter-complex dtype conversion.