### PR TITLE
[JIT] Refactor iterables

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -11482,8 +11482,8 @@ a")
         self.checkModule(mod, (torch.tensor(3),))
 
         mod = M2(nn.ModuleList([]))
-        with self.assertRaisesRegex(Exception, "Must provide a type annotation"):
-            torch.jit.script(mod)
+        # defaults to List of Tensor for empty modulelist
+        self.assertEqual(torch.jit.script(mod)(torch.tensor(.5)), [])
 
         def bad_type_annotation():
             out = torch.jit.annotate(int, [x for x in [1, 2, 3]])

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -1088,8 +1088,7 @@ struct to_ir {
     const auto loc = lc.range();
     const auto targets_list = List<Expr>::create(lc.range(), {lc.target()});
     const auto itrs = List<Expr>::create(lc.range(), {lc.iter()});
-    auto placeholder_node =
-        graph->insertNode(create(prim::Uninitialized, loc, 1));
+    auto placeholder_node = graph->insertNode(create(prim::Print, loc, 0));
     Value* list_value = nullptr;
     if (type_hint) {
       if (!type_hint->cast<ListType>()) {
@@ -1105,11 +1104,10 @@ struct to_ir {
     }
     auto emit_body = [&]() {
       auto comprehension_out = emitExpr(lc.elt());
-      // if (*iter_pointer)
       if (list_value == nullptr) {
-        auto li_node = graph->createList(comprehension_out->type(), {})
-                           ->insertBefore(placeholder_node);
-        list_value = li_node->output();
+        auto list_node = graph->createList(comprehension_out->type(), {})
+                             ->insertBefore(placeholder_node);
+        list_value = list_node->output();
       }
       NamedValue self = NamedValue(loc, "self", list_value);
       NamedValue input = NamedValue(loc, "", comprehension_out);


### PR DESCRIPTION
Refactor list comprehensions so they go through the same path as other for loops, making List Comprehensions work with modulelists, also fixing #27255

Replacing https://github.com/pytorch/pytorch/pull/28296 which was gh-poisoned and previously accepted. 