### PR TITLE
reduce predefined_min_secs for execution time

### DIFF
--- a/benchmarks/operator_benchmark/benchmark_core.py
+++ b/benchmarks/operator_benchmark/benchmark_core.py
@@ -68,7 +68,7 @@ class BenchmarkRunner(object):
         self.iters = 200
         self.has_explicit_iteration_count = False
         self.multiplier = 2
-        self.predefined_minimum_secs = 4
+        self.predefined_minimum_secs = 2
         self.max_iters = 1e6
         self.use_jit = args.use_jit
         self.num_runs = args.num_runs


### PR DESCRIPTION
Summary: as title

Test Plan:
```
Before this diff:
# ----------------------------------------
# PyTorch/Caffe2 Operator Micro-benchmarks
# ----------------------------------------
# Tag : short

# Benchmarking PyTorch: add_
# Mode: Eager
# Name: add__M64_N64_K64_cpu
# Input: M: 64, N: 64, K: 64, device: cpu
Forward Execution Time (us) : 122.965

# Benchmarking PyTorch: add_
# Mode: Eager
# Name: add__M64_N64_K128_cpu
# Input: M: 64, N: 64, K: 128, device: cpu
Forward Execution Time (us) : 229.735

# Benchmarking PyTorch: add_
# Mode: Eager
# Name: add__M64_N64_K64_cpu_bwdall
# Input: M: 64, N: 64, K: 64, device: cpu
Backward Execution Time (us) : 950.455

# Benchmarking PyTorch: add_
# Mode: Eager
# Name: add__M64_N64_K64_cpu_bwd1
# Input: M: 64, N: 64, K: 64, device: cpu
Backward Execution Time (us) : 826.893

After this diff:
buck run mode/opt //caffe2/benchmarks/operator_benchmark/pt:add_test;
Parsing buck files: finished in 0.7 sec
Building: finished in 02:35.7 min (100%) 7281/7281 jobs, 1 updated
  Total time: 02:36.4 min
# ----------------------------------------
# PyTorch/Caffe2 Operator Micro-benchmarks
# ----------------------------------------
# Tag : short

# Benchmarking PyTorch: add_
# Mode: Eager
# Name: add__M64_N64_K64_cpu
# Input: M: 64, N: 64, K: 64, device: cpu
Forward Execution Time (us) : 125.021

# Benchmarking PyTorch: add_
# Mode: Eager
# Name: add__M64_N64_K128_cpu
# Input: M: 64, N: 64, K: 128, device: cpu
Forward Execution Time (us) : 244.076

# Benchmarking PyTorch: add_
# Mode: Eager
# Name: add__M64_N64_K64_cpu_bwdall
# Input: M: 64, N: 64, K: 64, device: cpu
Backward Execution Time (us) : 946.280

# Benchmarking PyTorch: add_
# Mode: Eager
# Name: add__M64_N64_K64_cpu_bwd1
# Input: M: 64, N: 64, K: 64, device: cpu
Backward Execution Time (us) : 863.835

Differential Revision: D18305676

