### PR TITLE
[distributed_launch] Add --no_python flag

### DIFF
--- a/torch/distributed/launch.py
+++ b/torch/distributed/launch.py
@@ -185,6 +185,9 @@ def parse_args():
                         help="Changes each process to interpret the launch script "
                              "as a python module, executing with the same behavior as"
                              "'python -m'.")
+    parser.add_argument("--no_python", default=False, action="store_true",
+                        help="Do not prepend the training script with \"python\" - just exec "
+                             "it directly. Useful when the script is not a Python script.")
 
     # positional
     parser.add_argument("training_script", type=str,
@@ -227,10 +230,16 @@ def main():
         current_env["LOCAL_RANK"] = str(local_rank)
 
         # spawn the processes
-        cmd = [sys.executable, "-u"]
-
-        if args.module:
-            cmd.append("-m")
+        cmd = []
+        if not args.no_python:
+            cmd = [sys.executable, "-u"]
+            if args.module:
+                cmd.append("-m")
+        else:
+            if not args.use_env:
+                raise ValueError("When using the '--no_python' flag, you must also set the '--use_env' flag.")
+            if args.module:
+                raise ValueError("Don't use both the '--no_python' flag and the '--module' flag at the same time.")
 
         cmd.append(args.training_script)
 

--- a/torch/distributed/launch.py
+++ b/torch/distributed/launch.py
@@ -230,8 +230,9 @@ def main():
         current_env["LOCAL_RANK"] = str(local_rank)
 
         # spawn the processes
+        with_python = not args.no_python
         cmd = []
-        if not args.no_python:
+        if with_python:
             cmd = [sys.executable, "-u"]
             if args.module:
                 cmd.append("-m")


### PR DESCRIPTION
Allows you to use a bash script wrapper in-between launch and your
training script. e.g.
```
python -m torch.distributed.launch --nproc_per_node=8 --no_python --use_env \
    bash -c 'exec numactl --cpunodebind=$(( LOCAL_RANK / 4 )) "$@"' -- \
    python train.py ...
```

