### PR TITLE
Disables test_atomic_ops and testInputOrder

### DIFF
--- a/caffe2/python/data_workers_test.py
+++ b/caffe2/python/data_workers_test.py
@@ -112,6 +112,7 @@ class DataWorkersTest(unittest.TestCase):
         # Let's now shutdown and see it succeeds.
         self.assertTrue(coordinator.stop())
 
+    @unittest.skip("Test is flaky: https://github.com/pytorch/pytorch/issues/9064")
     def testInputOrder(self):
         #
         # Create two models (train and validation) with same input blobs

--- a/caffe2/python/operator_test/atomic_ops_test.py
+++ b/caffe2/python/operator_test/atomic_ops_test.py
@@ -7,6 +7,7 @@ from caffe2.python.test_util import TestCase
 
 
 class TestAtomicOps(TestCase):
+    @unittest.skip("Test is flaky: https://github.com/pytorch/pytorch/issues/28179")
     def test_atomic_ops(self):
         """
         Test that both countdown and checksum are update atomically by having

--- a/caffe2/python/operator_test/atomic_ops_test.py
+++ b/caffe2/python/operator_test/atomic_ops_test.py
@@ -5,6 +5,8 @@ from __future__ import unicode_literals
 from caffe2.python import core, workspace
 from caffe2.python.test_util import TestCase
 
+import unittest
+
 
 class TestAtomicOps(TestCase):
     @unittest.skip("Test is flaky: https://github.com/pytorch/pytorch/issues/28179")
@@ -47,5 +49,4 @@ class TestAtomicOps(TestCase):
         self.assertEquals(workspace.FetchBlob(checksum), 200010000)
 
 if __name__ == "__main__":
-    import unittest
     unittest.main()


### PR DESCRIPTION
These tests have been flaky for some time, see: 

- #28179 
- #9064 

This PR disables them. The actual tests were added/updated 2+ years ago. It's unclear who, if anyone, would own them now. 