### PR TITLE
Add cuda version for operators BatchSparseToDense and BatchDenseToSparse

### DIFF
--- a/caffe2/operators/batch_sparse_to_dense_op.cu
+++ b/caffe2/operators/batch_sparse_to_dense_op.cu
@@ -1,0 +1,146 @@
+#include "caffe2/operators/batch_sparse_to_dense_op.h"
+
+#include <cub/device/device_scan.cuh>
+
+#include "caffe2/core/context_gpu.h"
+
+namespace caffe2 {
+
+namespace {
+
+void array_prefix_sum_inclusive(
+    const int64_t* dev_array,
+    const int num_items,
+    Tensor& prefix_buffer,
+    Tensor& prefix_sum,
+    CUDAContext& context) {
+  // Retrieve buffer size
+  size_t temp_storage_bytes = 0;
+  prefix_sum.Resize(num_items);
+  cub::DeviceScan::InclusiveSum(
+      nullptr,
+      temp_storage_bytes,
+      dev_array,
+      prefix_sum.mutable_data<int64_t>(),
+      num_items,
+      context.cuda_stream());
+
+  // Allocate temporary storage
+  auto buffer_size = (temp_storage_bytes + sizeof(int64_t)) / sizeof(int64_t);
+  prefix_buffer.Resize(buffer_size);
+  void* dev_temp_storage =
+      static_cast<void*>(prefix_buffer.mutable_data<int64_t>());
+
+  // Inclusive sum
+  cub::DeviceScan::InclusiveSum(
+      dev_temp_storage,
+      temp_storage_bytes,
+      dev_array,
+      prefix_sum.mutable_data<int64_t>(),
+      num_items,
+      context.cuda_stream());
+}
+
+__global__ void FillInDenseValuesKernel(
+    const int64_t batch_size,
+    const int64_t dense_last_dim,
+    const int64_t* indices_data,
+    const float* values_data,
+    const int64_t* L_cum_sum_data,
+    float* output_data) {
+  CUDA_1D_KERNEL_LOOP(idx, batch_size) {
+    int offset_start = idx == 0 ? 0 : L_cum_sum_data[idx - 1];
+    int offset_end = L_cum_sum_data[idx];
+
+    for (int q = offset_start; q < offset_end; q++) {
+      int indice = indices_data[q];
+      float val = values_data[q];
+      output_data[idx * dense_last_dim + indice] = val;
+    }
+  }
+}
+
+__global__ void FillInSparseValuesKernel(
+    const int64_t batch_size,
+    const int64_t dense_last_dim,
+    const int64_t* indices_data,
+    const float* dense_data,
+    const int64_t* L_cum_sum_data,
+    float* output_data) {
+  CUDA_1D_KERNEL_LOOP(idx, batch_size) {
+    int offset_start = idx == 0 ? 0 : L_cum_sum_data[idx - 1];
+    int offset_end = L_cum_sum_data[idx];
+
+    for (int q = offset_start; q < offset_end; q++) {
+      int indice = indices_data[q];
+      output_data[q] = dense_data[idx * dense_last_dim + indice];
+    }
+  }
+}
+
+} // namespace
+
+template <>
+void BatchSparseToDenseOp<float, CUDAContext>::FillInDenseValues(
+    const int64_t batch_size,
+    const int64_t indice_lengths,
+    const int64_t* lengths_data,
+    const int64_t* indices_data,
+    const float* values_data,
+    float* output_data,
+    CUDAContext* context) {
+  // calculate the prefix sum of the length array
+  array_prefix_sum_inclusive(
+      lengths_data, batch_size, len_prefix_tmp_, len_prefix_sum_, context_);
+
+  // launch the gpu kernel for to fill in dense values
+  const int64_t min_size = 1;
+  FillInDenseValuesKernel<<<
+      CAFFE_GET_BLOCKS(std::max(batch_size, min_size)),
+      CAFFE_CUDA_NUM_THREADS,
+      0,
+      context->cuda_stream()>>>(
+      batch_size,
+      dense_last_dim_,
+      indices_data,
+      values_data,
+      len_prefix_sum_.data<int64_t>(),
+      output_data);
+}
+
+template <>
+void BatchDenseToSparseOp<float, CUDAContext>::FillInSparseValues(
+    const int64_t batch_size,
+    const int64_t indice_lengths,
+    const int64_t* lengths_data,
+    const int64_t* indices_data,
+    const float* dense_data,
+    float* output_data,
+    CUDAContext* context) {
+  // calculate the prefix sum of the length array
+  array_prefix_sum_inclusive(
+      lengths_data, batch_size, len_prefix_tmp_, len_prefix_sum_, context_);
+
+  // launch the gpu kernel for to fill in sparse values
+  const int64_t min_size = 1;
+  FillInSparseValuesKernel<<<
+      CAFFE_GET_BLOCKS(std::max(batch_size, min_size)),
+      CAFFE_CUDA_NUM_THREADS,
+      0,
+      context->cuda_stream()>>>(
+      batch_size,
+      dense_last_dim_,
+      indices_data,
+      dense_data,
+      len_prefix_sum_.data<int64_t>(),
+      output_data);
+}
+
+REGISTER_CUDA_OPERATOR(
+    BatchSparseToDense,
+    BatchSparseToDenseOp<float, CUDAContext>);
+
+REGISTER_CUDA_OPERATOR(
+    BatchDenseToSparse,
+    BatchDenseToSparseOp<float, CUDAContext>);
+} // namespace caffe2

--- a/caffe2/operators/batch_sparse_to_dense_op.h
+++ b/caffe2/operators/batch_sparse_to_dense_op.h
@@ -13,17 +13,79 @@ template <typename T, class Context>
 class BatchSparseToDenseOp : public Operator<Context> {
  public:
   USE_OPERATOR_CONTEXT_FUNCTIONS;
+
   template <class... Args>
   explicit BatchSparseToDenseOp(Args&&... args)
       : Operator<Context>(std::forward<Args>(args)...),
         OP_SINGLE_ARG(int64_t, "dense_last_dim", dense_last_dim_, -1),
         OP_SINGLE_ARG(T, "default_value", default_value_, static_cast<T>(0)) {}
-  bool RunOnDevice() override;
+  bool RunOnDevice() {
+    auto& lengths = Input(LENGTHS);
+    auto& indices = Input(INDICES);
+    auto& values = Input(VALUES);
+
+    CAFFE_ENFORCE_EQ(indices.numel(), values.numel());
+    CAFFE_ENFORCE_EQ(lengths.dim(), 1);
+    CAFFE_ENFORCE_EQ(indices.dim(), 1);
+
+    const int64_t* lengths_data = lengths.template data<int64_t>();
+    const int64_t* indices_data = indices.template data<int64_t>();
+    const T* values_data = values.template data<T>();
+    int64_t batch_size = lengths.numel();
+
+    vector<int64_t> output_shape = {batch_size};
+    if (InputSize() == 4) {
+      auto& shaper = Input(3);
+      CAFFE_ENFORCE_EQ(shaper.dim(), 2);
+      if (dense_last_dim_ == -1) {
+        dense_last_dim_ = shaper.size(1);
+      } else {
+        CAFFE_ENFORCE(
+            dense_last_dim_ == shaper.size(1),
+            "The last dim argument is not aligned with the shape input last dim");
+      }
+    } else {
+      CAFFE_ENFORCE(dense_last_dim_ >= 1, "The last dim of dense must be >= 1");
+    }
+    output_shape.push_back(dense_last_dim_);
+    auto* output = Output(0, output_shape, at::dtype<T>());
+    T* output_data = output->template mutable_data<T>();
+    math::Set(
+        output->numel(),
+        static_cast<T>(default_value_),
+        output_data,
+        &context_);
+
+    FillInDenseValues(
+        batch_size,
+        indices.numel(),
+        lengths_data,
+        indices_data,
+        values_data,
+        output_data,
+        &context_);
+
+    return true;
+  }
 
  private:
+  void FillInDenseValues(
+      const int64_t batch_size,
+      const int64_t indice_lengths,
+      const int64_t* lengths_data,
+      const int64_t* indices_data,
+      const T* values_data,
+      T* output_data,
+      Context* context);
+
   int64_t dense_last_dim_;
   T default_value_;
   INPUT_TAGS(LENGTHS, INDICES, VALUES);
+
+  // len_prefix_sum_ and len_prefix_tmp_ are buffers on the GPU. It is not used
+  // in the CPUContext implementation.
+  Tensor len_prefix_sum_{Context::GetDeviceType()};
+  Tensor len_prefix_tmp_{Context::GetDeviceType()};
 };
 
 template <typename T, class Context>
@@ -33,11 +95,55 @@ class BatchDenseToSparseOp : public Operator<Context> {
   template <class... Args>
   explicit BatchDenseToSparseOp(Args&&... args)
       : Operator<Context>(std::forward<Args>(args)...) {}
-  bool RunOnDevice() override;
+  bool RunOnDevice() {
+    auto& lengths = Input(LENGTHS);
+    auto& indices = Input(INDICES);
+    auto& dense = Input(DENSE);
+
+    CAFFE_ENFORCE_EQ(lengths.dim(), 1);
+    CAFFE_ENFORCE_EQ(indices.dim(), 1);
+    CAFFE_ENFORCE_EQ(dense.dim(), 2);
+    const int64_t* lengths_data = lengths.template data<int64_t>();
+    const int64_t* indices_data = indices.template data<int64_t>();
+    const T* dense_data = dense.template data<T>();
+
+    int64_t batch_size = lengths.numel();
+
+    CAFFE_ENFORCE_EQ(batch_size, dense.size(0));
+    dense_last_dim_ = dense.size(1);
+    vector<int64_t> output_shape = indices.sizes().vec();
+    auto* output = Output(0, output_shape, at::dtype<T>());
+    T* output_data = output->template mutable_data<T>();
+
+    FillInSparseValues(
+        batch_size,
+        indices.numel(),
+        lengths_data,
+        indices_data,
+        dense_data,
+        output_data,
+        &context_);
+
+    return true;
+  }
 
  private:
+  void FillInSparseValues(
+      const int64_t batch_size,
+      const int64_t indice_lengths,
+      const int64_t* lengths_data,
+      const int64_t* indices_data,
+      const T* dense_data,
+      T* output_data,
+      Context* context);
+
   int64_t dense_last_dim_;
   INPUT_TAGS(LENGTHS, INDICES, DENSE);
+
+  // len_prefix_sum_ and len_prefix_tmp_ are buffers on the GPU. It is not used
+  // in the CPUContext implementation.
+  Tensor len_prefix_sum_{Context::GetDeviceType()};
+  Tensor len_prefix_tmp_{Context::GetDeviceType()};
 };
 
 } // namespace caffe2

--- a/caffe2/python/operator_test/batch_sparse_to_dense_op_test.py
+++ b/caffe2/python/operator_test/batch_sparse_to_dense_op_test.py
@@ -17,7 +17,7 @@ class TestBatchSparseToDense(serial.SerializedTestCase):
         batch_size=st.integers(5, 10),
         dense_last_dim=st.integers(5, 10),
         default_value=st.floats(min_value=2.0, max_value=3.0),
-        **hu.gcs_cpu_only
+        **hu.gcs
     )
     def test_batch_sparse_to_dense(
         self, batch_size, dense_last_dim, default_value, gc, dc
@@ -72,7 +72,7 @@ class TestBatchSparseToDense(serial.SerializedTestCase):
     @given(
         batch_size=st.integers(5, 10),
         dense_last_dim=st.integers(5, 10),
-        **hu.gcs_cpu_only
+        **hu.gcs
     )
     def test_batch_dense_to_sparse(self, batch_size, dense_last_dim, gc, dc):
         L = np.random.randint(1, dense_last_dim + 1, size=(batch_size))


### PR DESCRIPTION
Summary: As titled

Test Plan:
unittest

 buck test  mode/dev-nosan  caffe2/caffe2/python/operator_test:batch_sparse_to_dense_op_test

Reviewed By: xianjiec

Differential Revision: D18197966

