### PR TITLE
Support softmax with D == 0

### DIFF
--- a/caffe2/operators/softmax_op.cc
+++ b/caffe2/operators/softmax_op.cc
@@ -14,7 +14,7 @@ bool SoftmaxOp<float, CPUContext>::RunOnDevice() {
   auto* Y = Output(0, X.sizes(), at::dtype<float>());
   const float* X_data = X.data<float>();
   float* Y_data = Y->mutable_data<float>();
-  if (N == 0) {
+  if (N == 0 || D == 0) {
     return true;
   }
   if (!scale_.defined()) {
@@ -57,7 +57,7 @@ bool SoftmaxGradientOp<float, CPUContext>::RunOnDevice() {
   const float* Ydata = Y.data<float>();
   const float* dYdata = dY.data<float>();
   float* dXdata = dX->mutable_data<float>();
-  if (N == 0) {
+  if (N == 0 || D == 0) {
     return true;
   }
   context_.CopySameDevice<float>(Y.numel(), dYdata, dXdata);

--- a/caffe2/operators/softmax_op_cudnn.cc
+++ b/caffe2/operators/softmax_op_cudnn.cc
@@ -11,7 +11,7 @@ constexpr int GRADIENT_NUM_DESCRIPTORS = 3;
 constexpr int BOTTOM_DESC_ID = 0;
 constexpr int TOP_DESC_ID = 1;
 constexpr int TOP_GRADIENT_DESC_ID = 2;
-}  // namespace
+} // namespace
 
 class CuDNNSoftmaxOp final : public Operator<CUDAContext> {
  public:
@@ -37,7 +37,7 @@ class CuDNNSoftmaxOp final : public Operator<CUDAContext> {
 
     auto* Y = Output(0, X.sizes(), at::dtype<T>());
     auto* Y_data = Y->template mutable_data<T>();
-    if (N == 0) {
+    if (N == 0 || D == 0) {
       return true;
     }
     if (dims_ != X.sizes()) {
@@ -75,7 +75,6 @@ class CuDNNSoftmaxOp final : public Operator<CUDAContext> {
   vector<int64_t> dims_;
 };
 
-
 class CuDNNSoftmaxGradientOp final : public Operator<CUDAContext> {
  public:
   template <class... Args>
@@ -102,7 +101,7 @@ class CuDNNSoftmaxGradientOp final : public Operator<CUDAContext> {
     CHECK_EQ(Y.sizes(), dY.sizes());
     auto* dX = Output(0, Y.sizes(), at::dtype<T>());
     auto* dX_data = dX->template mutable_data<T>();
-    if (N == 0) {
+    if (N == 0 || D == 0) {
       return true;
     }
     if (dims_ != Y.sizes()) {
@@ -145,5 +144,5 @@ class CuDNNSoftmaxGradientOp final : public Operator<CUDAContext> {
 namespace {
 REGISTER_CUDNN_OPERATOR(Softmax, CuDNNSoftmaxOp);
 REGISTER_CUDNN_OPERATOR(SoftmaxGradient, CuDNNSoftmaxGradientOp);
-}  // namespace
-}  // namespace caffe2
+} // namespace
+} // namespace caffe2


### PR DESCRIPTION
Summary:
As titled.

This fix is crucial as multi_channel splitting would create history that has no items (i.e., D == 0), which leads to flow failure.

Test Plan:
Unittest

flow test:

before fix: f148783160

after fix: f149082299

Differential Revision: D18296081

