### PR TITLE
[ONNX] Export concat/stack with tensor[]

### DIFF
--- a/aten/src/ATen/core/interned_strings.h
+++ b/aten/src/ATen/core/interned_strings.h
@@ -197,6 +197,9 @@ namespace c10 {
   _(onnx, ConstantOfShape)           \
   _(onnx, Cast)                      \
   _(onnx, Mod)                       \
+  _(onnx, SplitToSequence)           \
+  _(onnx, SequenceConstruct)         \
+  _(onnx, SequenceEmpty)             \
   FORALL_ATTR_BASE_SYMBOLS(_)        \
   _(attr, Subgraph)                  \
   _(attr, ReverseSubgraph)           \
@@ -226,7 +229,8 @@ namespace c10 {
   _(attr, split)                     \
   _(attr, slot)                      \
   _(attr, kinds)                     \
-  _(attr, types)
+  _(attr, types)                     \
+  _(attr, keepdims)
 #else
 #define FORALL_NS_SYMBOLS(_) \
   _(namespaces, prim)              \

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -1136,6 +1136,21 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.randint(10, (1, 2, 3, 4))
         self.run_test(FlattenModel(), x)
 
+    @skipIfUnsupportedMinOpsetVersion(11)
+    def test_getitem(self):
+        class GetItemModel(torch.jit.ScriptModule):
+            @torch.jit.script_method
+            def forward(self, x, y, z, ind):
+                # this will create prim::ListConstruct(x, y, z) + aten::__getitem__
+                arr = [x, y, z]
+                return arr[ind]
+
+        x = torch.randn(3, 4, 5)
+        y = torch.randn(1, 4, 5)
+        z = torch.randn(2, 4, 5)
+        ind = torch.tensor(1, dtype=torch.long)
+        self.run_test(GetItemModel(), (x, y, z, ind))
+
     def test_unbind(self):
         class UnbindModel(torch.nn.Module):
             def forward(self, input):

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -1152,6 +1152,34 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.randn(3, 4, 5)
         self.run_test(UnbindModel2(), x)
 
+    @skipIfUnsupportedMinOpsetVersion(11)
+    def test_unbind_dynamic(self):
+        class UnbindModel(torch.jit.ScriptModule):
+            @torch.jit.script_method
+            def forward(self, input):
+                return input.unbind()[1]
+
+        x = torch.randn(3, 4, 5)
+        self.run_test(UnbindModel(), x)
+
+    def test_split(self):
+        class SplitModel(torch.nn.Module):
+            def forward(self, input):
+                return input.split([2, 1, 2])
+
+        x = torch.randn(5, 4, 3)
+        self.run_test(SplitModel(), x)
+
+    @skipIfUnsupportedMinOpsetVersion(11)
+    def test_split_dynamic(self):
+        class SplitModel(torch.jit.ScriptModule):
+            @torch.jit.script_method
+            def forward(self, input):
+                return input.split(2)[1]
+
+        x = torch.randn(5, 4, 3)
+        self.run_test(SplitModel(), x)
+
     @skipIfUnsupportedMinOpsetVersion(9)
     def test_tensor_factories(self):
         class TensorFactory(torch.nn.Module):

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -1195,6 +1195,46 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.randn(5, 4, 3)
         self.run_test(SplitModel(), x)
 
+    def test_concat(self):
+        class ConcatModel(torch.nn.Module):
+            def forward(self, x, y, z):
+                return torch.cat((x, y, z))
+
+        x = torch.randn(3, 4, 5)
+        y = torch.randn(1, 4, 5)
+        z = torch.randn(2, 4, 5)
+        self.run_test(ConcatModel(), (x, y, z))
+
+    @skipIfUnsupportedMinOpsetVersion(11)
+    def test_concat_dynamic(self):
+        class ConcatDynamicModel(torch.jit.ScriptModule):
+            @torch.jit.script_method
+            def forward(self, x):
+                return torch.cat(x.unbind())
+
+        x = torch.randn(4, 5, 6)
+        self.run_test(ConcatDynamicModel(), x)
+
+    def test_stack(self):
+        class StackModel(torch.nn.Module):
+            def forward(self, x, y, z):
+                return torch.stack((x, y, z), 1)
+
+        x = torch.randn(3, 4, 5)
+        y = torch.randn(3, 4, 5)
+        z = torch.randn(3, 4, 5)
+        self.run_test(StackModel(), (x, y, z))
+
+    @skipIfUnsupportedMinOpsetVersion(11)
+    def test_stack_dynamic(self):
+        class StackDynamicModel(torch.jit.ScriptModule):
+            @torch.jit.script_method
+            def forward(self, x):
+                return torch.stack(x.unbind(), 1)
+
+        x = torch.randn(4, 5, 6)
+        self.run_test(StackDynamicModel(), x)
+
     @skipIfUnsupportedMinOpsetVersion(9)
     def test_tensor_factories(self):
         class TensorFactory(torch.nn.Module):

--- a/torch/csrc/jit/passes/onnx/peephole.cpp
+++ b/torch/csrc/jit/passes/onnx/peephole.cpp
@@ -598,6 +598,7 @@ static void fuseSplitListUnpack(Block* b) {
       fuseSplitListUnpack(child_block);
     }
     if (it->kind() == prim::ListUnpack &&
+        it->inputs().size() == 1 &&
         it->input()->node()->kind() == onnx::Split) {
       auto origSplitNode = it->input()->node();
 
@@ -639,6 +640,7 @@ static void fuseUnbindListUnpack(Block *b) {
       fuseUnbindListUnpack(child_block);
     }
     if (it->kind() == prim::ListUnpack &&
+        it->inputs().size() == 1 &&
         it->input()->node()->kind() == aten::unbind) {
       Node* orig_unbind_node = it->input()->node();
       auto dim = orig_unbind_node->i(attr::axis);

--- a/torch/csrc/jit/passes/onnx/peephole.cpp
+++ b/torch/csrc/jit/passes/onnx/peephole.cpp
@@ -734,13 +734,11 @@ static void convertSplitToDynamic(Block *b, int opset_version) {
     }
 
     if (it->kind() == onnx::Split) {
-      // TODO: check output kind is tensor[]
       if (it->outputs().size() == 1 && it->output()->type()->kind() == TypeKind::ListType) {
         auto dim = it->i(attr::axis);
         auto split = it->is(attr::split);
         Node* split_const_node =
             b->owningGraph()->create(onnx::Constant, 1);
-        // at::from_blob(split.data(), {static_cast<int64_t>(split.size())}, at::kLong)
         auto tensor = at::empty(split.size(), c10::kLong);
         int64_t* data = tensor.data<int64_t>();
         for (size_t i = 0; i < split.size(); ++i) {

--- a/torch/csrc/jit/passes/onnx/peephole.cpp
+++ b/torch/csrc/jit/passes/onnx/peephole.cpp
@@ -518,7 +518,7 @@ static void replaceInputWithList(Node* node, size_t i, ArrayRef<Value*> to) {
   }
 }
 
-static void eraseListConstruct(Block* block) {
+static void eraseListConstruct(Block* block, int opset_version) {
   // TODO: Fix this pass/maybe get rid of this part.
   // Tensor lists might be used for meshgrid and such ops as well.
   for (auto it = block->nodes().begin(), end = block->nodes().end();
@@ -527,7 +527,7 @@ static void eraseListConstruct(Block* block) {
     ++it;
 
     for (auto b : n->blocks()) {
-      eraseListConstruct(b);
+      eraseListConstruct(b, opset_version);
     }
     std::vector<std::tuple<size_t, std::vector<Value*>>> replacements;
 
@@ -563,13 +563,21 @@ static void eraseListConstruct(Block* block) {
               i, std::vector<Value*>({concat_node->output()}));
 
         } else {
-          // Tensor lists are used mostly for inputs to cat/stack. They are
-          // already handled in those symbolics, and should become dead
-          // afterwards.
-          replacements.emplace_back(
-              i,
-              std::vector<Value*>(
-                  lc_node->inputs().begin(), lc_node->inputs().end()));
+          if (opset_version < 11) {
+            // Tensor lists are used mostly for inputs to cat/stack. They are
+            // already handled in those symbolics, and should become dead
+            // afterwards.
+            replacements.emplace_back(
+                i,
+                std::vector<Value*>(
+                    lc_node->inputs().begin(), lc_node->inputs().end()));
+          } else {
+            c10::Symbol seq_node_kind = lc_node->inputs().size() > 0 ? onnx::SequenceConstruct : onnx::SequenceEmpty;
+            Node* seq_node = block->owningGraph()->create(seq_node_kind, {lc_node->inputs()}, 1);
+            seq_node->insertBefore(lc_node);
+            seq_node->output()->copyMetadata(lc_node->output());
+            lc_node->replaceAllUsesWith(seq_node);
+          }
         }
       }
       i++;
@@ -608,7 +616,7 @@ static void fuseSplitListUnpack(Block* b) {
   }
 }
 
-// Unbind is being converted to ONNX as Split + Squeeze.
+// Traced Unbind is being converted to ONNX as Split + Squeeze.
 // Example IR
 // graph(%0 : Float(3, 4, 5)):
 //   %7 : Long() = prim::Constant[value={0}]()
@@ -669,6 +677,92 @@ static void fuseListConstructListUnpack(Block *b) {
   }
 }
 
+// Scripted Unbind is being converted to ONNX as SplitToSequence
+// Example IR
+// graph(%input.1 : Float(3, 4, 5)):
+//   %5 : Long() = prim::Constant[value={0}]()
+//   %6 : Long() = prim::Constant[value={1}]()
+//   %3 : Tensor[] = aten::unbind(%input.1, %5)
+//   %4 : Tensor = aten::__getitem__(%3, %6)
+//   return (%4)
+//
+// Translates to ONNX
+// graph(%input.1 : Float(3, 4, 5)):
+//   %1 : Long() = onnx::Constant[value={1}]()
+//   %2 : Tensor[] = onnx::SplitToSequence[axis=0, keepdims=0](%input.1)
+//   %3 : Tensor = onnx::SequenceAt(%2, %1)
+//   return (%3)
+static void convertDynamicUnbindToSplitToSequence(Block *b, int opset_version) {
+  for (auto it = b->nodes().begin(), end = b->nodes().end(); it != end; ++it) {
+    for (auto* child_block : it->blocks()) {
+      convertDynamicUnbindToSplitToSequence(child_block, opset_version);
+    }
+
+    if (it->kind() == aten::unbind) {
+      if (opset_version < 11) {
+        AT_ERROR("Dynamic unbind(dynamic number of outputs) is not exportable in opset version ", opset_version,
+            ". Please try exporting with opset version >= 11.");
+      }
+      auto dim = it->i(attr::axis);
+
+      Node* seq_split_node =
+          b->owningGraph()->create(onnx::SplitToSequence, {it->input()}, it->outputs().size());
+      seq_split_node->i_(attr::axis, dim);
+      seq_split_node->i_(attr::keepdims, 0);
+      seq_split_node->output()->copyMetadata(it->output());
+      seq_split_node->insertAfter(*it);
+      it->replaceAllUsesWith(seq_split_node);
+      it->removeAllInputs();
+      it.destroyCurrent();
+    }
+  }
+}
+
+static void convertUnbindToSplit(Block *b, int opset_version) {
+  fuseUnbindListUnpack(b);
+  convertDynamicUnbindToSplitToSequence(b, opset_version);
+}
+
+static void convertSplitToDynamic(Block *b, int opset_version) {
+  if (opset_version < 11) {
+    return;
+  }
+
+  for (auto it = b->nodes().begin(), end = b->nodes().end(); it != end; ++it) {
+    for (auto* child_block : it->blocks()) {
+      convertSplitToDynamic(child_block, opset_version);
+    }
+
+    if (it->kind() == onnx::Split) {
+      // TODO: check output kind is tensor[]
+      if (it->outputs().size() == 1 && it->output()->type()->kind() == TypeKind::ListType) {
+        auto dim = it->i(attr::axis);
+        auto split = it->is(attr::split);
+        Node* split_const_node =
+            b->owningGraph()->create(onnx::Constant, 1);
+        // at::from_blob(split.data(), {static_cast<int64_t>(split.size())}, at::kLong)
+        auto tensor = at::empty(split.size(), c10::kLong);
+        int64_t* data = tensor.data<int64_t>();
+        for (size_t i = 0; i < split.size(); ++i) {
+          *data++ = split[i];
+        }
+        split_const_node->t_(
+            attr::value,
+            autograd::make_variable(tensor));
+        split_const_node->insertBefore(*it);
+        Node* seq_split_node =
+            b->owningGraph()->create(onnx::SplitToSequence, {it->input(), split_const_node->output()});
+        seq_split_node->i_(attr::axis, dim);
+        seq_split_node->output()->copyMetadata(it->output());
+        seq_split_node->insertAfter(*it);
+        it->replaceAllUsesWith(seq_split_node);
+        it->removeAllInputs();
+        it.destroyCurrent();
+      }
+    }
+  }
+}
+
 void removeMaxPoolUnusedOutput(Block* b) {
   for (auto it = b->nodes().begin(), end = b->nodes().end(); it != end; ++it) {
     auto n = *it;
@@ -721,7 +815,9 @@ void PeepholeOptimizeONNX(std::shared_ptr<Graph>& graph, int opset_version, bool
   fuseListConstructListUnpack(graph->block());
   fuseSplitListUnpack(graph->block());
   fuseUnbindListUnpack(graph->block());
-  eraseListConstruct(graph->block());
+  eraseListConstruct(graph->block(), opset_version);
+  convertUnbindToSplit(graph->block(), opset_version);
+  convertSplitToDynamic(graph->block(), opset_version);
   removeMaxPoolUnusedOutput(graph->block());
 }
 

--- a/torch/onnx/symbolic_opset11.py
+++ b/torch/onnx/symbolic_opset11.py
@@ -171,6 +171,24 @@ def __getitem_(g, self, i):
     return g.op("SequenceAt", self, i)
 
 
+def cat(g, tensor_list, dim):
+    if sym_help._is_packed_list(tensor_list):
+        from torch.onnx.symbolic_opset9 import cat as cat_opset9
+        return cat_opset9(g, tensor_list, dim)
+    else:
+        dim = sym_help._get_const(dim, 'i', 'dim')
+        return g.op("ConcatFromSequence", tensor_list, axis_i=dim)
+
+
+def stack(g, tensor_list, dim):
+    if sym_help._is_packed_list(tensor_list):
+        from torch.onnx.symbolic_opset9 import stack as stack_opset9
+        return stack_opset9(g, tensor_list, dim)
+    else:
+        dim = sym_help._get_const(dim, 'i', 'dim')
+        return g.op("ConcatFromSequence", tensor_list, axis_i=dim, new_axis_i=1)
+
+
 @parse_args('v', 'i', 'i', 'i')
 def _unique2(g, self, sorted, return_inverse, return_counts):
     u, indices, inverse_indices, counts = g.op("Unique", self, sorted_i=sorted, outputs=4)

--- a/torch/onnx/symbolic_opset11.py
+++ b/torch/onnx/symbolic_opset11.py
@@ -167,6 +167,10 @@ def masked_scatter(g, self, mask, source):
     return g.op('ScatterND', self, index, source)
 
 
+def __getitem_(g, self, i):
+    return g.op("SequenceAt", self, i)
+
+
 @parse_args('v', 'i', 'i', 'i')
 def _unique2(g, self, sorted, return_inverse, return_counts):
     u, indices, inverse_indices, counts = g.op("Unique", self, sorted_i=sorted, outputs=4)

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -379,7 +379,7 @@ def prim_ConstantChunk(g, self, chunks, dim):
 def split(g, self, split_size_or_sizes, dim):
     if sym_help._is_value(split_size_or_sizes) and split_size_or_sizes.node().kind() != 'onnx::Constant':
         raise RuntimeError("ONNX symbolic expected a constant value of the {} argument, got `{}`"
-            .format('split_size_or_sizes', split_size_or_sizes))
+                           .format('split_size_or_sizes', split_size_or_sizes))
     split_val = split_size_or_sizes.node()['value']
     if split_val.dim() > 0:
         return split_with_sizes(g, self, split_size_or_sizes, dim)


### PR DESCRIPTION
For ONNX opset < 11, tensor list cannot be captured. Tensor lists of static length are unrolled into number of individual tensors.
Now with the introduced sequence structure in ONNX, tensor list can be represented.

This is the second PR related to sequence ops, following #29136