### PR TITLE
Cleaned up func removed unused variable

### DIFF
--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -2115,7 +2115,6 @@ _compiled_overloaded_fns = {}
 
 def _compile_function_with_overload(qual_name, impl_fn, overload_decl, overload_defaults):
     impl_ast = torch.jit.get_jit_def(impl_fn)
-    _frames_up = 0
     _rcb = _jit_internal.createResolutionCallbackFromClosure(impl_fn)
     fn = torch._C._jit_script_compile_overload(qual_name, overload_decl, impl_ast, _rcb, overload_defaults)
     return fn


### PR DESCRIPTION
I don't see `_frames_up` being used anywhere. Just to clean up the code thought it should be removed.