### PR TITLE
Fix when giving jit format warning about unsupported options, second attempt

### DIFF
--- a/torch/csrc/jit/register_special_ops.cpp
+++ b/torch/csrc/jit/register_special_ops.cpp
@@ -308,7 +308,7 @@ RegisterOperators reg({
         "aten::format(str self, ...) -> str",
         [](const Node* node) -> Operation {
           size_t num_inputs = node->inputs().size();
-          std::regex unsupported_options("\\{(.*?)\\}");
+          std::regex unsupported_options("\\{([^\\}]+)\\}");
           return [num_inputs, unsupported_options](Stack& stack) {
             auto format = peek(stack, 0, num_inputs).toStringRef();
 

--- a/torch/csrc/jit/register_special_ops.cpp
+++ b/torch/csrc/jit/register_special_ops.cpp
@@ -308,7 +308,7 @@ RegisterOperators reg({
         "aten::format(str self, ...) -> str",
         [](const Node* node) -> Operation {
           size_t num_inputs = node->inputs().size();
-          std::regex unsupported_options("\\{([^\\}]+)\\}");
+          std::regex unsupported_options(R"(\{([^\}]+)\})");
           return [num_inputs, unsupported_options](Stack& stack) {
             auto format = peek(stack, 0, num_inputs).toStringRef();
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#29193 Fix when giving jit format warning about unsupported options, second attempt**

Previous attempt in #28616 didn't work in clang8 and got reverted in #28916
This one escapes the } inside the brackets, maybe that works

Differential Revision: [D18324286](https://our.internmc.facebook.com/intern/diff/D18324286/)