### PR TITLE
link to documentation for RNNBase.flatten_parameters()

### DIFF
--- a/docs/source/nn.rst
+++ b/docs/source/nn.rst
@@ -496,6 +496,12 @@ Normalization layers
 Recurrent layers
 ----------------------------------
 
+:hidden:`RNNBase`
+~~~~~~~~~~~~~
+
+.. autoclass:: RNNBase
+    :members:
+
 :hidden:`RNN`
 ~~~~~~~~~~~~~
 


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/28658

I have added the link to the docs for `flatten_parameters`.

RNNBase is a superclass of RNN, LSTM and GRM classes. Should I add a link to `flatten_parameters()` in those sections as well ?