### PR TITLE
Autogenerated contiguous memory format for old *_like calls

### DIFF
--- a/aten/src/ATen/TensorOperators.h
+++ b/aten/src/ATen/TensorOperators.h
@@ -70,9 +70,9 @@ inline Tensor Tensor::operator[](int64_t index) const {
 #define AT_FORALL_BINARY_OPS(_) \
 _(+,x.add(y), y.add(x)) \
 _(*,x.mul(y), y.mul(x)) \
-_(-,x.sub(y), ::at::empty_like(y).fill_(x).sub_(y)) \
-_(/,x.div(y), ::at::empty_like(y).fill_(x).div_(y)) \
-_(%,x.remainder(y), ::at::empty_like(y).fill_(x).remainder_(y)) \
+_(-,x.sub(y), ::at::empty_like(y, at::MemoryFormat::Contiguous).fill_(x).sub_(y)) \
+_(/,x.div(y), ::at::empty_like(y, at::MemoryFormat::Contiguous).fill_(x).div_(y)) \
+_(%,x.remainder(y), ::at::empty_like(y, at::MemoryFormat::Contiguous).fill_(x).remainder_(y)) \
 _(<,x.lt(y), y.gt(x)) \
 _(<=,x.le(y), y.ge(x)) \
 _(>,x.gt(y),y.lt(x)) \

--- a/aten/src/ATen/native/Activation.cpp
+++ b/aten/src/ATen/native/Activation.cpp
@@ -44,11 +44,11 @@ Tensor & celu_(Tensor & self, Scalar alpha) {
 }
 
 Tensor rrelu(const Tensor & self, Scalar lower, Scalar upper, bool training, Generator* generator) {
-  return at::rrelu_with_noise(self, at::empty_like(self), lower, upper, training, generator);
+  return at::rrelu_with_noise(self, at::empty_like(self, at::MemoryFormat::Contiguous), lower, upper, training, generator);
 }
 
 Tensor & rrelu_(Tensor & self, Scalar lower, Scalar upper, bool training, Generator* generator) {
-  return at::rrelu_with_noise_(self, at::empty_like(self), lower, upper, training, generator);
+  return at::rrelu_with_noise_(self, at::empty_like(self, at::MemoryFormat::Contiguous), lower, upper, training, generator);
 }
 
 // computes `result = self <= threshold ? value : other`
@@ -152,7 +152,7 @@ Tensor prelu_cpu(const Tensor& self, const Tensor& weight_) {
   TORCH_CHECK(weight.is_contiguous());
 
   int64_t weight_num = weight.numel();
-  Tensor result = at::empty_like(input);
+  Tensor result = at::empty_like(input, at::MemoryFormat::Contiguous);
   auto strides = input.strides();
 
   // case1: shared weight for all channels
@@ -284,9 +284,9 @@ std::tuple<Tensor, Tensor> prelu_backward_cpu(const Tensor& grad_out_, const Ten
   auto strides = input.strides();
   auto dims = input.dim();
 
-  Tensor input_grad = at::empty_like(input);
-  Tensor weight_grad = at::empty_like(weight);
-  Tensor weight_grad_collector = at::empty_like(input);
+  Tensor input_grad = at::empty_like(input, at::MemoryFormat::Contiguous);
+  Tensor weight_grad = at::empty_like(weight, at::MemoryFormat::Contiguous);
+  Tensor weight_grad_collector = at::empty_like(input, at::MemoryFormat::Contiguous);
 
   // case1: shared parameter for all channels
   if (weight_num == 1) {
@@ -338,14 +338,14 @@ std::tuple<Tensor, Tensor> prelu_backward_cpu(const Tensor& grad_out_, const Ten
 // hardshrink
 // -----------------------------------
 Tensor hardshrink_cpu(const Tensor & self, Scalar lambd) {
-  auto out_tensor = at::empty_like(self);
+  auto out_tensor = at::empty_like(self, at::MemoryFormat::Contiguous);
   auto iter = TensorIterator::unary_op(out_tensor, self);
   hardshrink_cpu_stub(kCPU, iter, lambd);
   return out_tensor;
 }
 
 Tensor hardshrink_backward_cpu(const Tensor & grad, const Tensor & self, Scalar lambd) {
-  auto out_tensor = at::empty_like(self);
+  auto out_tensor = at::empty_like(self, at::MemoryFormat::Contiguous);
   auto iter = TensorIterator::binary_op(out_tensor, grad, self);
   hardshrink_backward_cpu_stub(kCPU, iter, lambd);
   return out_tensor;

--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -430,7 +430,7 @@ Tensor _inverse_helper_cpu(const Tensor& self) {
 
 Tensor inverse(const Tensor &self) {
   if (self.size(-1) == 0) {
-    return at::empty_like(self);
+    return at::empty_like(self, at::MemoryFormat::Contiguous);
   }
   squareCheckInputs(self);
   return at::_inverse_helper(self);
@@ -549,7 +549,7 @@ Tensor _cholesky_helper_cpu(const Tensor& self, bool upper) {
 
 Tensor cholesky(const Tensor &self, bool upper) {
   if (self.size(-1) == 0) {
-    return at::empty_like(self);
+    return at::empty_like(self, at::MemoryFormat::Contiguous);
   }
   squareCheckInputs(self);
 
@@ -607,7 +607,7 @@ std::tuple<Tensor, Tensor, Tensor> _lu_with_info_cpu(const Tensor& self, bool pi
 
   Tensor self_working_copy;
   if (self.numel() == 0) {
-    self_working_copy = at::empty_like(self);
+    self_working_copy = at::empty_like(self, at::MemoryFormat::Contiguous);
   } else {
     self_working_copy = cloneBatchedColumnMajor(self);
     AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(self.scalar_type(), "lu_cpu", [&]{
@@ -889,7 +889,7 @@ std::tuple<Tensor, Tensor> _symeig_helper_cpu(const Tensor& self, bool eigenvect
   auto eigvals = at::empty(self_sizes, self.options());
 
   if (self.numel() == 0) {
-    return std::tuple<Tensor, Tensor>(eigvals, at::empty_like(self));
+    return std::tuple<Tensor, Tensor>(eigvals, at::empty_like(self, at::MemoryFormat::Contiguous));
   }
 
   auto self_working_copy = cloneBatchedColumnMajor(self);

--- a/aten/src/ATen/native/Col2Im.cpp
+++ b/aten/src/ATen/native/Col2Im.cpp
@@ -213,7 +213,7 @@ Tensor col2im_cpu(
     IntArrayRef dilation,
     IntArrayRef padding,
     IntArrayRef stride) {
-  Tensor output = at::empty_like(input);
+  Tensor output = at::empty_like(input, at::MemoryFormat::Contiguous);
 
   col2im_out_cpu_template(
       output, input, output_size, kernel_size, dilation, padding, stride);
@@ -238,7 +238,7 @@ Tensor col2im_backward_cpu(
     IntArrayRef dilation,
     IntArrayRef padding,
     IntArrayRef stride) {
-  Tensor grad_input = at::empty_like(grad_output);
+  Tensor grad_input = at::empty_like(grad_output, at::MemoryFormat::Contiguous);
 
   col2im_backward_out_cpu_template(
       grad_input, grad_output, kernel_size, dilation, padding, stride);

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -746,8 +746,8 @@ std::tuple<Tensor, Tensor, Tensor> convolution_backward_overrideable(
         bool transposed, IntArrayRef output_padding, int64_t groups, std::array<bool, 3> output_mask) {
   AT_ERROR("You are likely triggering this with tensor backend other than CPU/CUDA/MKLDNN, if this is intended, please use torch::RegisterOperators() to override this function ");
   return std::tuple<Tensor, Tensor, Tensor>(
-          at::empty_like(input),
-          at::empty_like(weight),
+          at::empty_like(input, at::MemoryFormat::Contiguous),
+          at::empty_like(weight, at::MemoryFormat::Contiguous),
           at::empty({}));
 }
 

--- a/aten/src/ATen/native/Cross.cpp
+++ b/aten/src/ATen/native/Cross.cpp
@@ -9,7 +9,7 @@ namespace at { namespace native {
 DEFINE_DISPATCH(cross_stub);
 
 Tensor cross(const Tensor & input, const Tensor & other, const c10::optional<int64_t> dimension) {
-  Tensor out = at::empty_like(input);
+  Tensor out = at::empty_like(input, at::MemoryFormat::Contiguous);
   native::cross_out(out, input, other, dimension);
   return out;
 }

--- a/aten/src/ATen/native/Distance.cpp
+++ b/aten/src/ATen/native/Distance.cpp
@@ -159,7 +159,7 @@ Tensor _pdist_backward(const Tensor& grad, const Tensor& self, const double p, c
   TORCH_CHECK(pdist.is_contiguous(), "_pdist_backward requires pdist to be contiguous");
   auto device = self.type().device_type();
   TORCH_CHECK(device == kCPU || device == kCUDA, "_pdist_backward only supports CPU and CUDA devices, got: ", device);
-  Tensor result = at::empty_like(self);
+  Tensor result = at::empty_like(self, at::MemoryFormat::Contiguous);
   pdist_backward_stub(device, result, grad, self, p, pdist);
   return result;
 }

--- a/aten/src/ATen/native/Distributions.cpp
+++ b/aten/src/ATen/native/Distributions.cpp
@@ -114,11 +114,11 @@ namespace at {
 namespace native {
 
 Tensor bernoulli(const Tensor& self, Generator* gen) {
-  return at::empty_like(self).bernoulli_(self, gen);
+  return at::empty_like(self, at::MemoryFormat::Contiguous).bernoulli_(self, gen);
 }
 
 Tensor bernoulli(const Tensor& self, double p, Generator* gen) {
-  return at::empty_like(self).bernoulli_(p, gen);
+  return at::empty_like(self, at::MemoryFormat::Contiguous).bernoulli_(p, gen);
 }
 
 Tensor& bernoulli_out(Tensor& result, const Tensor& self, Generator* gen) {

--- a/aten/src/ATen/native/Dropout.cpp
+++ b/aten/src/ATen/native/Dropout.cpp
@@ -51,7 +51,7 @@ Ctype<inplace> _dropout_impl(T& input, double p, bool train) {
   }
 
   at::Tensor b; // used for alpha_dropout only
-  auto noise = feature_dropout ? make_feature_noise(input) : at::empty_like(input);
+  auto noise = feature_dropout ? make_feature_noise(input) : at::empty_like(input, at::MemoryFormat::Contiguous);
   noise.bernoulli_(1 - p);
   if (alpha_dropout) {
     constexpr double alpha = 1.7580993408473766;

--- a/aten/src/ATen/native/GridSampler.cpp
+++ b/aten/src/ATen/native/GridSampler.cpp
@@ -177,7 +177,7 @@ namespace {
                                     GridSamplerPadding padding_mode,
                                     bool align_corners) {
     auto grad_input = at::zeros_like(input);
-    auto grad_grid = at::empty_like(grid);
+    auto grad_grid = at::empty_like(grid, at::MemoryFormat::Contiguous);
     // If interpolation mode is Nearest, then grad_grid is not filled in the
     // loop below.
     if (interpolation_mode == GridSamplerInterpolation::Nearest) {

--- a/aten/src/ATen/native/Im2Col.cpp
+++ b/aten/src/ATen/native/Im2Col.cpp
@@ -163,7 +163,7 @@ Tensor im2col_cpu(
     IntArrayRef dilation,
     IntArrayRef padding,
     IntArrayRef stride) {
-  Tensor output = at::empty_like(input);
+  Tensor output = at::empty_like(input, at::MemoryFormat::Contiguous);
 
   im2col_out_cpu_template(
       output, input, kernel_size, dilation, padding, stride);
@@ -196,7 +196,7 @@ Tensor im2col_backward_cpu(
     IntArrayRef dilation,
     IntArrayRef padding,
     IntArrayRef stride) {
-  Tensor grad_input = at::empty_like(grad_output);
+  Tensor grad_input = at::empty_like(grad_output, at::MemoryFormat::Contiguous);
 
   im2col_backward_out_cpu_template(
       grad_input,

--- a/aten/src/ATen/native/LossCTC.cpp
+++ b/aten/src/ATen/native/LossCTC.cpp
@@ -203,7 +203,7 @@ Tensor ctc_loss_backward_cpu_template(const Tensor& grad_out, const Tensor& log_
     max_target_length = targets.size(1);
   }
 
-  Tensor log_beta = at::empty_like(log_alpha);  // could be optimized to use only 2 rows
+  Tensor log_beta = at::empty_like(log_alpha, at::MemoryFormat::Contiguous);  // could be optimized to use only 2 rows
   auto lpp  = log_probs.permute({1,0,2});
   auto log_probs_a_global = lpp.accessor<scalar_t, 3>();
   auto log_alpha_a_global = log_alpha.accessor<scalar_t, 3>();

--- a/aten/src/ATen/native/MaxUnpooling.cpp
+++ b/aten/src/ATen/native/MaxUnpooling.cpp
@@ -466,7 +466,7 @@ Tensor max_unpooling2d_backward_cpu(
     const Tensor& self,
     const Tensor& indices,
     IntArrayRef output_size) {
-  auto grad_input = at::empty_like(self);
+  auto grad_input = at::empty_like(self, at::MemoryFormat::Contiguous);
   max_unpooling2d_backward_out_cpu(
       grad_input, grad_output, self, indices, output_size);
   return grad_input;
@@ -600,7 +600,7 @@ Tensor max_unpooling3d_backward_cpu(
     IntArrayRef output_size,
     IntArrayRef stride,
     IntArrayRef padding) {
-  auto grad_input = at::empty_like(self);
+  auto grad_input = at::empty_like(self, at::MemoryFormat::Contiguous);
   max_unpooling3d_backward_out_cpu(
       grad_input, grad_output, self, indices, output_size, stride, padding);
   return grad_input;

--- a/aten/src/ATen/native/NaiveConvolutionTranspose2d.cpp
+++ b/aten/src/ATen/native/NaiveConvolutionTranspose2d.cpp
@@ -727,8 +727,8 @@ Tensor& slow_conv_transpose2d_out_cpu(
     IntArrayRef padding,
     IntArrayRef output_padding,
     IntArrayRef dilation) {
-  Tensor columns = at::empty_like(input);
-  Tensor ones = at::empty_like(input);
+  Tensor columns = at::empty_like(input, at::MemoryFormat::Contiguous);
+  Tensor ones = at::empty_like(input, at::MemoryFormat::Contiguous);
 
   slow_conv_transpose2d_out_cpu_template(
       output,
@@ -755,9 +755,9 @@ Tensor slow_conv_transpose2d_cpu(
     IntArrayRef padding,
     IntArrayRef output_padding,
     IntArrayRef dilation) {
-  Tensor output = at::empty_like(input);
-  Tensor columns = at::empty_like(input);
-  Tensor ones = at::empty_like(input);
+  Tensor output = at::empty_like(input, at::MemoryFormat::Contiguous);
+  Tensor columns = at::empty_like(input, at::MemoryFormat::Contiguous);
+  Tensor ones = at::empty_like(input, at::MemoryFormat::Contiguous);
 
   slow_conv_transpose2d_out_cpu_template(
       output,

--- a/aten/src/ATen/native/NaiveConvolutionTranspose3d.cpp
+++ b/aten/src/ATen/native/NaiveConvolutionTranspose3d.cpp
@@ -848,8 +848,8 @@ Tensor& slow_conv_transpose3d_out_cpu(
     IntArrayRef padding,
     IntArrayRef output_padding,
     IntArrayRef dilation) {
-  Tensor finput = at::empty_like(input);
-  Tensor fgrad = at::empty_like(input);
+  Tensor finput = at::empty_like(input, at::MemoryFormat::Contiguous);
+  Tensor fgrad = at::empty_like(input, at::MemoryFormat::Contiguous);
 
   slow_conv_transpose3d_out_cpu_template(
       output,
@@ -876,9 +876,9 @@ Tensor slow_conv_transpose3d_cpu(
     IntArrayRef padding,
     IntArrayRef output_padding,
     IntArrayRef dilation) {
-  Tensor output = at::empty_like(input);
-  Tensor finput = at::empty_like(input);
-  Tensor fgrad = at::empty_like(input);
+  Tensor output = at::empty_like(input, at::MemoryFormat::Contiguous);
+  Tensor finput = at::empty_like(input, at::MemoryFormat::Contiguous);
+  Tensor fgrad = at::empty_like(input, at::MemoryFormat::Contiguous);
 
   slow_conv_transpose3d_out_cpu_template(
       output,

--- a/aten/src/ATen/native/Normalization.cpp
+++ b/aten/src/ATen/native/Normalization.cpp
@@ -103,8 +103,8 @@ void batch_norm_cpu_inference_contiguous(Tensor& output, const Tensor& input,
   scalar_t* output_data = output.data_ptr<scalar_t>();
   const scalar_t* input_data = input.data_ptr<scalar_t>();
 
-  Tensor alpha = at::empty_like(mean);
-  Tensor beta = at::empty_like(mean);
+  Tensor alpha = at::empty_like(mean, at::MemoryFormat::Contiguous);
+  Tensor beta = at::empty_like(mean, at::MemoryFormat::Contiguous);
   scalar_t* alpha_data = alpha.data_ptr<scalar_t>();
   scalar_t* beta_data = beta.data_ptr<scalar_t>();
 
@@ -156,8 +156,8 @@ void batch_norm_cpu_inference_channels_last(Tensor& output, const Tensor& input,
   scalar_t* output_data = output.data_ptr<scalar_t>();
   const scalar_t* input_data = input.data_ptr<scalar_t>();
 
-  Tensor alpha = at::empty_like(mean);
-  Tensor beta = at::empty_like(mean);
+  Tensor alpha = at::empty_like(mean, at::MemoryFormat::Contiguous);
+  Tensor beta = at::empty_like(mean, at::MemoryFormat::Contiguous);
   scalar_t* alpha_data = alpha.data_ptr<scalar_t>();
   scalar_t* beta_data = beta.data_ptr<scalar_t>();
 
@@ -206,7 +206,7 @@ std::tuple<Tensor,Tensor,Tensor> batch_norm_cpu_transform_input_template(
       && running_mean.is_contiguous()
       && running_var.is_contiguous()) {
 
-    Tensor output = at::empty_like(input);
+    Tensor output = at::empty_like(input, at::MemoryFormat::Contiguous);
     batch_norm_cpu_inference_contiguous<scalar_t>(
       output, input, weight, bias, running_mean, running_var, eps);
     return std::make_tuple(output, save_mean, save_invstd);
@@ -225,7 +225,7 @@ std::tuple<Tensor,Tensor,Tensor> batch_norm_cpu_transform_input_template(
     return std::make_tuple(output, save_mean, save_invstd);
   }
 
-  Tensor output = at::empty_like(input);
+  Tensor output = at::empty_like(input, at::MemoryFormat::Contiguous);
 
   int64_t n_input = input.size(1);
 
@@ -330,13 +330,13 @@ std::tuple<Tensor, Tensor, Tensor> batch_norm_backward_cpu_template(const Tensor
   Tensor grad_weight;
   Tensor grad_bias;
   if (grad_input_mask[0]) {
-    grad_input = at::empty_like(input);
+    grad_input = at::empty_like(input, at::MemoryFormat::Contiguous);
   }
   if (grad_input_mask[1]) {
-    grad_weight = at::empty_like(weight);
+    grad_weight = at::empty_like(weight, at::MemoryFormat::Contiguous);
   }
   if (grad_input_mask[2]) {
-    grad_bias = at::empty_like(weight);
+    grad_bias = at::empty_like(weight, at::MemoryFormat::Contiguous);
   }
 
   auto weight_a = conditional_accessor_1d<scalar_t>(weight);

--- a/aten/src/ATen/native/Pow.cpp
+++ b/aten/src/ATen/native/Pow.cpp
@@ -57,12 +57,12 @@ Tensor pow(const Tensor& base, const Tensor& exp) {
 }
 
 Tensor pow(const Tensor& base, Scalar exp) {
-  Tensor result = at::empty_like(base);
+  Tensor result = at::empty_like(base, at::MemoryFormat::Contiguous);
   return native::pow_out(result, base, exp);
 }
 
 Tensor pow(Scalar base, const Tensor& exp) {
-  Tensor result = at::empty_like(exp);
+  Tensor result = at::empty_like(exp, at::MemoryFormat::Contiguous);
   return native::pow_out(result, base, exp);
 }
 

--- a/aten/src/ATen/native/Repeat.h
+++ b/aten/src/ATen/native/Repeat.h
@@ -10,7 +10,7 @@ static inline Tensor repeat_interleave_common(const Tensor &repeats) {
     TORCH_CHECK(repeats.scalar_type() == at::kLong, "repeats has to be Long tensor");
     TORCH_CHECK((repeats >= 0).all().item<uint8_t>(), "repeats can not be negative");
     if (repeats.size(0) == 0) {
-        return at::empty_like(repeats);
+        return at::empty_like(repeats, at::MemoryFormat::Contiguous);
     }
     Tensor repeats_ = repeats.contiguous();
     Tensor cumsum = repeats.cumsum(0);

--- a/aten/src/ATen/native/TensorTransformations.cpp
+++ b/aten/src/ATen/native/TensorTransformations.cpp
@@ -49,7 +49,7 @@ Tensor flip_cpu(const Tensor& self, IntArrayRef dims) {
   auto in_tensor = self;
   const int64_t total_dims = in_tensor.dim();
   auto flip_dims_b = at::dim_list_to_bitset(dims, total_dims);
-  Tensor out_tensor = at::empty_like(in_tensor);
+  Tensor out_tensor = at::empty_like(in_tensor, at::MemoryFormat::Contiguous);
 
   // create contiguous strides for input tensor
   auto stride_contiguous_v = std::vector<int64_t>(total_dims);

--- a/aten/src/ATen/native/TriangularOps.cpp
+++ b/aten/src/ATen/native/TriangularOps.cpp
@@ -95,7 +95,7 @@ Tensor& tril_cpu_(Tensor &self, int64_t k) {
   bool inplace;
   Tensor self_c;
   std::tie(inplace, self_c) = checkTrilTriuBatchContiguous(self, true);
-  Tensor result = inplace ? self : at::empty_like(self);
+  Tensor result = inplace ? self : at::empty_like(self, at::MemoryFormat::Contiguous);
   AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(at::ScalarType::Half, at::ScalarType::Bool, self.scalar_type(), "tril", [&]{
     apply_triu_tril<scalar_t, false>(result, self_c, inplace, k);
   });
@@ -131,7 +131,7 @@ Tensor& triu_cpu_(Tensor &self, int64_t k) {
   bool inplace;
   Tensor self_c;
   std::tie(inplace, self_c) = checkTrilTriuBatchContiguous(self, true);
-  Tensor result = inplace ? self : at::empty_like(self);
+  Tensor result = inplace ? self : at::empty_like(self, at::MemoryFormat::Contiguous);
   AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(at::ScalarType::Half, at::ScalarType::Bool, self.scalar_type(), "triu", [&]{
     apply_triu_tril<scalar_t, true>(result, self_c, inplace, k);
   });

--- a/aten/src/ATen/native/cpu/GridSamplerKernel.cpp
+++ b/aten/src/ATen/native/cpu/GridSamplerKernel.cpp
@@ -964,7 +964,7 @@ grid_sampler_2d_backward_cpu_kernel_impl(const Tensor& grad_output_,
   auto grad_output = grad_output_.contiguous();
 
   auto grad_input = at::zeros_like(input);
-  auto grad_grid = at::empty_like(grid);
+  auto grad_grid = at::empty_like(grid, at::MemoryFormat::Contiguous);
   auto N = input.size(0);
   auto spatial_size = grid.size(1) * grid.size(2);
   auto grain_size = spatial_size == 0 ? (N + 1)

--- a/aten/src/ATen/native/cuda/Activation.cu
+++ b/aten/src/ATen/native/cuda/Activation.cu
@@ -64,7 +64,7 @@ Tensor prelu_cuda(const Tensor& self, const Tensor& weight_) {
   TORCH_CHECK(weight.is_contiguous());
 
   int64_t weight_num = weight.numel();
-  Tensor result = at::empty_like(input);
+  Tensor result = at::empty_like(input, at::MemoryFormat::Contiguous);
   auto strides = input.strides();
 
   // case1: shared weight for all channels
@@ -177,9 +177,9 @@ std::tuple<Tensor, Tensor> prelu_backward_cuda(const Tensor& grad_out_, const Te
   int64_t weight_num = weight.numel();
   auto strides = input.strides();
   auto dims = input.dim();
-  Tensor input_grad = at::empty_like(input);
-  Tensor weight_grad = at::empty_like(weight);
-  Tensor weight_grad_collector = at::empty_like(input);
+  Tensor input_grad = at::empty_like(input, at::MemoryFormat::Contiguous);
+  Tensor weight_grad = at::empty_like(weight, at::MemoryFormat::Contiguous);
+  Tensor weight_grad_collector = at::empty_like(input, at::MemoryFormat::Contiguous);
   // case1: shared parameter for all channels
   if (weight_num == 1) {
     AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(), "prelu_backward_cuda", [&] {
@@ -270,7 +270,7 @@ void hardshrink_backward_cuda_kernel(const Tensor& self, Tensor& out_tensor, sca
 }
 
 Tensor hardshrink_cuda(const Tensor & self, Scalar lambd) {
-  auto out_tensor = at::empty_like(self);
+  auto out_tensor = at::empty_like(self, at::MemoryFormat::Contiguous);
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(self.scalar_type(), "hardshrink_cuda", [&] {
     hardshrink_cuda_kernel<scalar_t>(self, out_tensor, lambd.to<scalar_t>());
   });
@@ -278,7 +278,7 @@ Tensor hardshrink_cuda(const Tensor & self, Scalar lambd) {
 }
 
 Tensor hardshrink_backward_cuda(const Tensor & grad, const Tensor & self, Scalar lambd) {
-  auto out_tensor = at::empty_like(grad);
+  auto out_tensor = at::empty_like(grad, at::MemoryFormat::Contiguous);
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(self.scalar_type(), "hardshrink_backward_cuda", [&] {
     hardshrink_backward_cuda_kernel<scalar_t>(self, out_tensor, lambd.to<scalar_t>(), grad);
   });

--- a/aten/src/ATen/native/cuda/BatchLinearAlgebra.cu
+++ b/aten/src/ATen/native/cuda/BatchLinearAlgebra.cu
@@ -912,7 +912,7 @@ std::tuple<Tensor, Tensor, Tensor> _lu_with_info_cuda(const Tensor& self, bool p
 
   Tensor self_working_copy;
   if (self.numel() == 0) {
-    self_working_copy = at::empty_like(self);
+    self_working_copy = at::empty_like(self, at::MemoryFormat::Contiguous);
   } else {
     self_working_copy = cloneBatchedColumnMajor(self);
     AT_DISPATCH_FLOATING_TYPES(self.scalar_type(), "lu_cuda", [&]{
@@ -1174,7 +1174,7 @@ std::tuple<Tensor, Tensor> _symeig_helper_cuda(const Tensor& self, bool eigenvec
                               : at::empty(self_sizes, self.options().device(at::kCPU));
 
   if (self.numel() == 0) {
-    return std::tuple<Tensor, Tensor>(eigvals_working_copy, at::empty_like(self));
+    return std::tuple<Tensor, Tensor>(eigvals_working_copy, at::empty_like(self, at::MemoryFormat::Contiguous));
   }
 
   auto self_working_copy = cloneBatchedColumnMajor(self);

--- a/aten/src/ATen/native/cuda/Col2Im.cu
+++ b/aten/src/ATen/native/cuda/Col2Im.cu
@@ -171,7 +171,7 @@ Tensor col2im_cuda(
     IntArrayRef dilation,
     IntArrayRef padding,
     IntArrayRef stride) {
-  Tensor output = at::empty_like(input);
+  Tensor output = at::empty_like(input, at::MemoryFormat::Contiguous);
 
   col2im_out_cuda_template(
       output, input, output_size, kernel_size, dilation, padding, stride);
@@ -196,7 +196,7 @@ Tensor col2im_backward_cuda(
     IntArrayRef dilation,
     IntArrayRef padding,
     IntArrayRef stride) {
-  Tensor grad_input = at::empty_like(grad_output);
+  Tensor grad_input = at::empty_like(grad_output, at::MemoryFormat::Contiguous);
 
   col2im_backward_out_cuda_template(
       grad_input, grad_output, kernel_size, dilation, padding, stride);

--- a/aten/src/ATen/native/cuda/Copy.cu
+++ b/aten/src/ATen/native/cuda/Copy.cu
@@ -132,7 +132,7 @@ static void copy_kernel_cuda(TensorIterator& iter, bool non_blocking) {
     // Type conversions are performed on the CPU for CPU-GPU copies and on
     // the src device for GPU-GPU copies.
     if (iter.device_type(0) == kCUDA) {
-      dst_contig = dst.is_contiguous() ? dst : at::empty_like(dst);
+      dst_contig = dst.is_contiguous() ? dst : at::empty_like(dst, at::MemoryFormat::Contiguous);
       src_contig = iter.tensor(1).to(iter.dtype(0)).expand_as(dst).contiguous();
     } else {
       bool same_type = iter.dtype(0) == iter.dtype(1);

--- a/aten/src/ATen/native/cuda/Distributions.cu
+++ b/aten/src/ATen/native/cuda/Distributions.cu
@@ -736,19 +736,19 @@ Tensor& normal_out_cuda(Tensor& output, const Tensor& mean, const Tensor& std, G
 }
 
 Tensor normal_cuda(const Tensor& mean, double std, Generator* gen) {
-  Tensor ret = at::empty_like(mean);
+  Tensor ret = at::empty_like(mean, at::MemoryFormat::Contiguous);
   normal_out_cuda(ret, mean, std, gen);
   return ret;
 }
 
 Tensor normal_cuda(double mean, const Tensor& std, Generator* gen) {
-  Tensor ret = at::empty_like(std);
+  Tensor ret = at::empty_like(std, at::MemoryFormat::Contiguous);
   normal_out_cuda(ret, mean, std, gen);
   return ret;
 }
 
 Tensor normal_cuda(const Tensor& mean, const Tensor& std, Generator* gen) {
-  Tensor ret = at::empty_like(mean);
+  Tensor ret = at::empty_like(mean, at::MemoryFormat::Contiguous);
   normal_out_cuda(ret, mean, std, gen);
   return ret;
 }

--- a/aten/src/ATen/native/cuda/Dropout.cu
+++ b/aten/src/ATen/native/cuda/Dropout.cu
@@ -89,7 +89,7 @@ void masked_scale_kernel(at::Tensor& ret, const at::Tensor src, const at::Tensor
 std::tuple<Tensor,Tensor>
 fused_dropout_cuda(const Tensor& self, double p, Generator * gen_){
   auto gen = get_generator_or_default<CUDAGenerator>(gen_, cuda::detail::getDefaultCUDAGenerator());
-  Tensor ret = at::empty_like(self);
+  Tensor ret = at::empty_like(self, at::MemoryFormat::Contiguous);
   Tensor mask = at::empty(self.sizes(), self.options().dtype(kByte));
   const int64_t nelem = self.numel();
 //empty tensors should not get here, but just in case, avoid FPE
@@ -149,7 +149,7 @@ fused_dropout_cuda(const Tensor& self, double p, Generator * gen_){
 }
 
 Tensor masked_scale_cuda(const Tensor& self, const Tensor& mask, double scale){
-   Tensor ret = at::empty_like(self);
+   Tensor ret = at::empty_like(self, at::MemoryFormat::Contiguous);
    TORCH_CHECK(mask.scalar_type() == at::ScalarType::Byte, "mask should be torch.uint8 dtype");
    AT_DISPATCH_FLOATING_TYPES_AND_HALF(ret.scalar_type(), "masked_scale", [&] {
       using accscalar_t = acc_type<scalar_t, true>;

--- a/aten/src/ATen/native/cuda/Embedding.cu
+++ b/aten/src/ATen/native/cuda/Embedding.cu
@@ -265,8 +265,8 @@ Tensor embedding_dense_backward_cuda(const Tensor & grad_, const Tensor & indice
     return grad_weight;
   }
 
-  auto sorted_indices = at::empty_like(indices);
-  auto orig_indices = at::empty_like(indices);
+  auto sorted_indices = at::empty_like(indices, at::MemoryFormat::Contiguous);
+  auto orig_indices = at::empty_like(indices, at::MemoryFormat::Contiguous);
   using device_ptr = thrust::device_ptr<int64_t>;
 
   // Sort the inputs into sorted with the corresponding indices; we
@@ -291,7 +291,7 @@ Tensor embedding_dense_backward_cuda(const Tensor & grad_, const Tensor & indice
 
   Tensor count;
   if (scale_grad_by_freq) {
-    count = at::empty_like(indices);
+    count = at::empty_like(indices, at::MemoryFormat::Contiguous);
 
     auto allocator = THCThrustAllocator(globalContext().lazyInitCUDA());
     auto policy = thrust::cuda::par(allocator).on(stream);

--- a/aten/src/ATen/native/cuda/EmbeddingBackwardKernel.cu
+++ b/aten/src/ATen/native/cuda/EmbeddingBackwardKernel.cu
@@ -210,7 +210,7 @@ Tensor embedding_backward_cuda_kernel(
   int64_t num_of_segments;
   {
     auto sorted_indices_dev = thrust::device_ptr<int64_t>(sorted_indices.data_ptr<int64_t>());
-    auto dummy = at::empty_like(sorted_indices);
+    auto dummy = at::empty_like(sorted_indices, at::MemoryFormat::Contiguous);
     auto dummy_dev = thrust::device_ptr<int64_t>(dummy.data_ptr<int64_t>());
     auto ends = thrust::unique_by_key_copy(
             policy,

--- a/aten/src/ATen/native/cuda/EmbeddingBag.cu
+++ b/aten/src/ATen/native/cuda/EmbeddingBag.cu
@@ -133,8 +133,8 @@ Tensor embedding_bag_backward_cuda_sum_avg(
 
   int64_t stride = grad_weight.stride(0);
 
-  auto sorted_indices = at::empty_like(indices);
-  auto orig_indices = at::empty_like(indices);
+  auto sorted_indices = at::empty_like(indices, at::MemoryFormat::Contiguous);
+  auto orig_indices = at::empty_like(indices, at::MemoryFormat::Contiguous);
   using device_ptr = thrust::device_ptr<int64_t>;
 
   // Sort the inputs into sorted with the corresponding indices; we
@@ -159,7 +159,7 @@ Tensor embedding_bag_backward_cuda_sum_avg(
 
   Tensor count;
   if (scale_grad_by_freq) {
-    count = at::empty_like(indices);
+    count = at::empty_like(indices, at::MemoryFormat::Contiguous);
 
     auto allocator = THCThrustAllocator(globalContext().lazyInitCUDA());
     auto policy = thrust::cuda::par(allocator).on(stream);

--- a/aten/src/ATen/native/cuda/GridSampler.cu
+++ b/aten/src/ATen/native/cuda/GridSampler.cu
@@ -662,7 +662,7 @@ grid_sampler_2d_backward_cuda(const Tensor& grad_output, const Tensor& input,
   auto H = grid.size(1);
   auto W = grid.size(2);
   auto grad_input = at::zeros_like(input);
-  auto grad_grid = at::empty_like(grid);
+  auto grad_grid = at::empty_like(grid, at::MemoryFormat::Contiguous);
   int count = static_cast<int>(N * H * W);
   if (count > 0) {
     AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(), "grid_sampler_2d_backward_cuda", [&] {
@@ -692,7 +692,7 @@ grid_sampler_3d_backward_cuda(const Tensor& grad_output, const Tensor& input,
   auto H = grid.size(2);
   auto W = grid.size(3);
   auto grad_input = at::zeros_like(input);
-  auto grad_grid = at::empty_like(grid);
+  auto grad_grid = at::empty_like(grid, at::MemoryFormat::Contiguous);
   int count = static_cast<int>(N * D * H * W);
   if (count > 0) {
     AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(), "grid_sampler_3d_backward_cuda", [&] {

--- a/aten/src/ATen/native/cuda/Im2Col.cu
+++ b/aten/src/ATen/native/cuda/Im2Col.cu
@@ -172,7 +172,7 @@ Tensor im2col_cuda(
     IntArrayRef dilation,
     IntArrayRef padding,
     IntArrayRef stride) {
-  Tensor output = at::empty_like(input);
+  Tensor output = at::empty_like(input, at::MemoryFormat::Contiguous);
   im2col_out_cuda_template(
       output, input, kernel_size, dilation, padding, stride);
   return output;
@@ -204,7 +204,7 @@ Tensor im2col_backward_cuda(
     IntArrayRef dilation,
     IntArrayRef padding,
     IntArrayRef stride) {
-  Tensor grad_input = at::empty_like(grad_output);
+  Tensor grad_input = at::empty_like(grad_output, at::MemoryFormat::Contiguous);
   im2col_backward_out_cuda_template(
       grad_input,
       grad_output,

--- a/aten/src/ATen/native/cuda/Indexing.cu
+++ b/aten/src/ATen/native/cuda/Indexing.cu
@@ -191,8 +191,8 @@ void index_put_accum_kernel(Tensor & self, TensorList indices, const Tensor & va
       const bool permuted = !src.is_contiguous();
       auto src_ = permuted ? src.contiguous() : src;
       linearIndex = linearIndex.view(-1);
-      auto sorted_indices = at::empty_like(linearIndex);
-      auto orig_indices = at::empty_like(linearIndex);
+      auto sorted_indices = at::empty_like(linearIndex, at::MemoryFormat::Contiguous);
+      auto orig_indices = at::empty_like(linearIndex, at::MemoryFormat::Contiguous);
       using device_ptr = thrust::device_ptr<int64_t>;
       const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
     

--- a/aten/src/ATen/native/cuda/Lerp.cu
+++ b/aten/src/ATen/native/cuda/Lerp.cu
@@ -90,7 +90,7 @@ Tensor lerp_cuda_tensor(const Tensor& self, const Tensor& end, const Tensor& wei
   TORCH_CHECK(weight.dim() <= std::max(self.dim(), end.dim()),
            "weight should be of dimension max(self.dim(), end.dim()) or lesser");
   std::tie(b_self, b_end, b_weight) = expand_outplace(self, end, weight, "lerp_cuda");
-  Tensor result = at::empty_like(b_self);
+  Tensor result = at::empty_like(b_self, at::MemoryFormat::Contiguous);
   AT_DISPATCH_FLOATING_TYPES(self.scalar_type(), "lerp_cuda", [&]{
     lerp_cuda<scalar_t>(result, b_self, b_end, b_weight);
   });
@@ -100,7 +100,7 @@ Tensor lerp_cuda_tensor(const Tensor& self, const Tensor& end, const Tensor& wei
 Tensor lerp_cuda_scalar(const Tensor& self, const Tensor& end, Scalar weight) {
   Tensor b_self, b_end;
   std::tie(b_self, b_end) = expand_outplace(self, end, "lerp_cuda");
-  Tensor result = at::empty_like(b_self);
+  Tensor result = at::empty_like(b_self, at::MemoryFormat::Contiguous);
   AT_DISPATCH_FLOATING_TYPES(self.scalar_type(), "lerp_cuda", [&]{
     lerp_cuda<scalar_t>(result, b_self, b_end, weight.to<scalar_t>());
   });

--- a/aten/src/ATen/native/cuda/LossCTC.cu
+++ b/aten/src/ATen/native/cuda/LossCTC.cu
@@ -605,7 +605,7 @@ Tensor ctc_loss_backward_gpu_template(const Tensor& grad_out, const Tensor& log_
   auto input_lengths_t = at::tensor(input_lengths, targets.options().dtype(kLong));
   tg_batch_offsets = tg_batch_offsets.cuda();
 
-  Tensor log_beta = at::empty_like(log_alpha);
+  Tensor log_beta = at::empty_like(log_alpha, at::MemoryFormat::Contiguous);
   log_beta.fill_(neginf);
 
   Tensor grad = at::full_like(log_probs, neginf); // initialization for log(sum (alpha beta))

--- a/aten/src/ATen/native/cuda/MaxUnpooling.cu
+++ b/aten/src/ATen/native/cuda/MaxUnpooling.cu
@@ -466,7 +466,7 @@ at::Tensor max_unpooling2d_backward_cuda(
     const Tensor& self,
     const Tensor& indices,
     IntArrayRef output_size) {
-  auto grad_input = at::empty_like(self);
+  auto grad_input = at::empty_like(self, at::MemoryFormat::Contiguous);
   max_unpooling2d_backward_out_cuda(
       grad_input, grad_output, self, indices, output_size);
   return grad_input;
@@ -579,7 +579,7 @@ at::Tensor max_unpooling3d_backward_cuda(
     IntArrayRef output_size,
     IntArrayRef stride,
     IntArrayRef padding) {
-  auto grad_input = at::empty_like(self);
+  auto grad_input = at::empty_like(self, at::MemoryFormat::Contiguous);
   max_unpooling3d_backward_out_cuda(
       grad_input, grad_output, self, indices, output_size, stride, padding);
   return grad_input;

--- a/aten/src/ATen/native/cuda/NaiveConvolutionTranspose2d.cu
+++ b/aten/src/ATen/native/cuda/NaiveConvolutionTranspose2d.cu
@@ -772,8 +772,8 @@ Tensor& slow_conv_transpose2d_out_cuda(
     IntArrayRef padding,
     IntArrayRef output_padding,
     IntArrayRef dilation) {
-  Tensor columns = at::empty_like(input);
-  Tensor ones = at::empty_like(input);
+  Tensor columns = at::empty_like(input, at::MemoryFormat::Contiguous);
+  Tensor ones = at::empty_like(input, at::MemoryFormat::Contiguous);
 
   slow_conv_transpose2d_out_cuda_template(
       output,
@@ -800,9 +800,9 @@ Tensor slow_conv_transpose2d_cuda(
     IntArrayRef padding,
     IntArrayRef output_padding,
     IntArrayRef dilation) {
-  Tensor output = at::empty_like(input);
-  Tensor columns = at::empty_like(input);
-  Tensor ones = at::empty_like(input);
+  Tensor output = at::empty_like(input, at::MemoryFormat::Contiguous);
+  Tensor columns = at::empty_like(input, at::MemoryFormat::Contiguous);
+  Tensor ones = at::empty_like(input, at::MemoryFormat::Contiguous);
 
   slow_conv_transpose2d_out_cuda_template(
       output,

--- a/aten/src/ATen/native/cuda/NaiveConvolutionTranspose3d.cu
+++ b/aten/src/ATen/native/cuda/NaiveConvolutionTranspose3d.cu
@@ -881,8 +881,8 @@ Tensor& slow_conv_transpose3d_out_cuda(
     IntArrayRef padding,
     IntArrayRef output_padding,
     IntArrayRef dilation) {
-  Tensor finput = at::empty_like(input);
-  Tensor fgrad = at::empty_like(input);
+  Tensor finput = at::empty_like(input, at::MemoryFormat::Contiguous);
+  Tensor fgrad = at::empty_like(input, at::MemoryFormat::Contiguous);
 
   slow_conv_transpose3d_out_cuda_template(
       output,
@@ -909,9 +909,9 @@ Tensor slow_conv_transpose3d_cuda(
     IntArrayRef padding,
     IntArrayRef output_padding,
     IntArrayRef dilation) {
-  Tensor output = at::empty_like(input);
-  Tensor finput = at::empty_like(input);
-  Tensor fgrad = at::empty_like(input);
+  Tensor output = at::empty_like(input, at::MemoryFormat::Contiguous);
+  Tensor finput = at::empty_like(input, at::MemoryFormat::Contiguous);
+  Tensor fgrad = at::empty_like(input, at::MemoryFormat::Contiguous);
 
   slow_conv_transpose3d_out_cuda_template(
       output,

--- a/aten/src/ATen/native/cuda/Normalization.cu
+++ b/aten/src/ATen/native/cuda/Normalization.cu
@@ -60,7 +60,7 @@ std::tuple<Tensor, Tensor> batch_norm_stats_cuda(const Tensor& self, double epsi
 
 Tensor batch_norm_elemt_cuda(const Tensor& self, const Tensor& weight, const Tensor& bias,
                              const Tensor& mean, const Tensor& invstd, double epsilon) {
-  auto output = at::empty_like(self);
+  auto output = at::empty_like(self, at::MemoryFormat::Contiguous);
   batch_norm_elemt_cuda_out(output, self, weight, bias, mean, invstd, epsilon);
   return output;
 }

--- a/aten/src/ATen/native/cuda/Normalization.cuh
+++ b/aten/src/ATen/native/cuda/Normalization.cuh
@@ -528,7 +528,7 @@ std::tuple<Tensor, Tensor, Tensor> batch_norm_cuda_template(const Tensor& input_
   Tensor save_mean_;
   Tensor save_invstd_;
   auto input_reshaped = input_.reshape({input_.size(0), input_.size(1), -1}); // internally we merge the feature dimensions
-  auto output_reshaped = at::empty_like(input_reshaped);
+  auto output_reshaped = at::empty_like(input_reshaped, at::MemoryFormat::Contiguous);
 
   auto bs = input_reshaped.size(0);
   auto features = input_reshaped.size(2);
@@ -596,14 +596,14 @@ std::tuple<Tensor, Tensor, Tensor> batch_norm_backward_cuda_template(const Tenso
   auto grad_output_reshaped = grad_out_.reshape(input_reshaped.sizes());
 
   if (grad_input_mask[0]) {
-    grad_input_ = at::empty_like(input_);
+    grad_input_ = at::empty_like(input_, at::MemoryFormat::Contiguous);
     grad_input_reshaped = grad_input_.view(input_reshaped.sizes());
   }
   if (grad_input_mask[1]) {
-    grad_weight_ = at::empty_like(weight_);
+    grad_weight_ = at::empty_like(weight_, at::MemoryFormat::Contiguous);
   }
   if (grad_input_mask[2]) {
-    grad_bias_ = at::empty_like(weight_);
+    grad_bias_ = at::empty_like(weight_, at::MemoryFormat::Contiguous);
   }
 
   auto input = input_reshaped.generic_packed_accessor<input_scalar_t, 3, DefaultPtrTraits, index_t>();
@@ -756,8 +756,8 @@ std::tuple<Tensor, Tensor, Tensor, Tensor> batch_norm_backward_reduce_cuda_templ
   auto grad_output_reshaped = grad_out_.reshape(input_reshaped.sizes());
 
   if (input_g) {
-    mean_dy_ = at::empty_like(mean_);
-    mean_dy_xmu_ = at::empty_like(mean_);
+    mean_dy_ = at::empty_like(mean_, at::MemoryFormat::Contiguous);
+    mean_dy_xmu_ = at::empty_like(mean_, at::MemoryFormat::Contiguous);
   }
   if (weight_g) {
     grad_weight_ = at::empty({n_input}, weight_.options());
@@ -800,7 +800,7 @@ Tensor batch_norm_backward_elemt_cuda_template(const Tensor& grad_out_, const Te
   int64_t n_input = input_.size(1);
   auto input_reshaped = input_.reshape({input_.size(0), input_.size(1), -1}); // internally we merge the feature dimensions
   auto grad_output_reshaped = grad_out_.reshape(input_reshaped.sizes());
-  auto grad_input_reshaped = at::empty_like(input_reshaped);
+  auto grad_input_reshaped = at::empty_like(input_reshaped, at::MemoryFormat::Contiguous);
 
   auto bs = input_reshaped.size(0);
   auto features = input_reshaped.size(2);

--- a/aten/src/ATen/native/cuda/RNN.cu
+++ b/aten/src/ATen/native/cuda/RNN.cu
@@ -498,9 +498,9 @@ std::tuple<Tensor, Tensor, Tensor> _thnn_fused_lstm_cell_cuda(
              {input_bias, "input_bias", 3}, {hidden_bias, "hidden_bias", 4},
              /*factor=*/4, {cx, "prev_hidden", 5});
 
-  auto workspace = at::empty_like(input_gates);
-  auto hy = at::empty_like(cx);
-  auto cy = at::empty_like(cx);
+  auto workspace = at::empty_like(input_gates, at::MemoryFormat::Contiguous);
+  auto hy = at::empty_like(cx, at::MemoryFormat::Contiguous);
+  auto cy = at::empty_like(cx, at::MemoryFormat::Contiguous);
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(input_gates.scalar_type(), "_thnn_fused_lstm_cell_cuda", [&] {
     if (canUse32BitIndexMath(workspace)) { // See Note [64-bit index math check elision]
       lstm_forward_impl<scalar_t, int32_t>(input_gates, hidden_gates, input_bias, hidden_bias, cx, hy, cy, workspace);
@@ -538,8 +538,8 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor> _thnn_fused_lstm_cell_backwar
                          {cx, "cx", 3}, {cy, "cy", 4},
                          {workspace, "workspace", 5});
 
-  auto grad_gates = at::empty_like(workspace);
-  auto grad_cx = at::empty_like(cx);
+  auto grad_gates = at::empty_like(workspace, at::MemoryFormat::Contiguous);
+  auto grad_cx = at::empty_like(cx, at::MemoryFormat::Contiguous);
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(workspace.scalar_type(), "_thnn_fused_lstm_cell_cuda_backward", [&] {
     if (canUse32BitIndexMath(workspace)) { // See Note [64-bit index math check elision]
       lstm_backward_impl<scalar_t, int32_t>(grad_hy, grad_cy, cx, cy, workspace, grad_gates, grad_cx);
@@ -564,7 +564,7 @@ std::tuple<Tensor, Tensor> _thnn_fused_gru_cell_cuda(
              /*factor=*/3, {hx, "prev_hidden", 5});
 
   auto workspace = at::empty({hx.size(0), hx.size(1) * GRU_WORKSPACE_MULTIPLIER}, hx.options());
-  auto hy = at::empty_like(hx);
+  auto hy = at::empty_like(hx, at::MemoryFormat::Contiguous);
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(input_gates.scalar_type(), "_thnn_fused_gru_cell_cuda", [&] {
     if (canUse32BitIndexMath(workspace)) { // See Note [64-bit index math check elision]
       gru_forward_impl<scalar_t, int32_t>(input_gates, hidden_gates, input_bias, hidden_bias, hx, hy, workspace);
@@ -588,7 +588,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor> _thnn_fused_gru_cell_backward
   int64_t hidden_size = workspace.size(1) / GRU_WORKSPACE_MULTIPLIER;
   auto grad_input_gates = at::empty({workspace.size(0), hidden_size * 3}, workspace.options());
   auto grad_hidden_gates = at::empty({workspace.size(0), hidden_size * 3}, workspace.options());
-  auto grad_hx = at::empty_like(grad_hy);
+  auto grad_hx = at::empty_like(grad_hy, at::MemoryFormat::Contiguous);
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(grad_hy.scalar_type(), "_thnn_fused_gru_cell_cuda_backward", [&] {
     if (canUse32BitIndexMath(workspace)) { // See Note [64-bit index math check elision]
       gru_backward_impl<scalar_t, int32_t>(grad_hy, workspace, grad_input_gates, grad_hidden_gates, grad_hx);

--- a/aten/src/ATen/native/cuda/SoftMax.cu
+++ b/aten/src/ATen/native/cuda/SoftMax.cu
@@ -489,7 +489,7 @@ template<template<typename, typename, typename> class Epilogue, bool is_log_soft
 Tensor host_softmax(const Tensor & input_, const int64_t dim_, const bool half_to_float){
   if (half_to_float) AT_ASSERTM(input_.scalar_type() == ScalarType::Half,"conversion is supported for Half type only");
   auto input = input_.contiguous();
-  Tensor output = half_to_float ? at::empty_like(input, input.options().dtype(ScalarType::Float)) : at::empty_like(input);
+  Tensor output = half_to_float ? at::empty_like(input, input.options().dtype(ScalarType::Float)) : at::empty_like(input, at::MemoryFormat::Contiguous);
   static_assert(std::is_same<acc_type<at::Half, true>, float>::value, "accscalar_t for half should be float");
   if (input.dim() == 0) input = input.view(1);
   int64_t dim = maybe_wrap_dim(dim_, input.dim());
@@ -571,7 +571,7 @@ Tensor host_softmax(const Tensor & input_, const int64_t dim_, const bool half_t
 template<template<typename, typename, typename> class Epilogue, bool is_log_softmax>
 Tensor host_softmax_backward(const Tensor &grad_, const Tensor &output_, int64_t dim_, bool half_to_float){
   int64_t dim = maybe_wrap_dim(dim_, grad_.dim());
-  Tensor gI = half_to_float ? at::empty_like(grad_, grad_.options().dtype(ScalarType::Half)) : at::empty_like(grad_);
+  Tensor gI = half_to_float ? at::empty_like(grad_, grad_.options().dtype(ScalarType::Half)) : at::empty_like(grad_, at::MemoryFormat::Contiguous);
   if (grad_.numel() == 0) {
     return gI;
   }

--- a/aten/src/ATen/native/cuda/TensorTransformations.cu
+++ b/aten/src/ATen/native/cuda/TensorTransformations.cu
@@ -77,7 +77,7 @@ Tensor flip_cuda(const Tensor& self, IntArrayRef dims) {
   dim3 dim_block(block_size);
   dim3 dim_grid((N + block_size - 1) / block_size);
 
-  auto out_tensor = at::empty_like(in_tensor);
+  auto out_tensor = at::empty_like(in_tensor, at::MemoryFormat::Contiguous);
   if (out_tensor.numel() == 0) {
     return out_tensor;
   }
@@ -170,7 +170,7 @@ Tensor roll_cuda(const Tensor& self, IntArrayRef shifts, IntArrayRef dims) {
   if(!self.is_contiguous()) {
     in_tensor = self.contiguous();
   }
-  auto out_tensor = at::empty_like(in_tensor);
+  auto out_tensor = at::empty_like(in_tensor, at::MemoryFormat::Contiguous);
   if (out_tensor.numel() == 0) {
     return out_tensor;
   }

--- a/aten/src/ATen/native/cuda/UpSampleBicubic2d.cu
+++ b/aten/src/ATen/native/cuda/UpSampleBicubic2d.cu
@@ -320,7 +320,7 @@ Tensor upsample_bicubic2d_cuda(
     const Tensor& input,
     IntArrayRef output_size,
     bool align_corners) {
-  Tensor output = at::empty_like(input);
+  Tensor output = at::empty_like(input, at::MemoryFormat::Contiguous);
   upsample_bicubic2d_out_cuda_template(
       output, input, output_size, align_corners);
   return output;
@@ -342,7 +342,7 @@ Tensor upsample_bicubic2d_backward_cuda(
     IntArrayRef output_size,
     IntArrayRef input_size,
     bool align_corners) {
-  Tensor grad_input = at::empty_like(grad_output);
+  Tensor grad_input = at::empty_like(grad_output, at::MemoryFormat::Contiguous);
   upsample_bicubic2d_backward_out_cuda_template(
       grad_input, grad_output, output_size, input_size, align_corners);
   return grad_input;

--- a/aten/src/ATen/native/cuda/UpSampleBilinear2d.cu
+++ b/aten/src/ATen/native/cuda/UpSampleBilinear2d.cu
@@ -319,7 +319,7 @@ Tensor upsample_bilinear2d_cuda(
     const Tensor& input,
     IntArrayRef output_size,
     bool align_corners) {
-  Tensor output = at::empty_like(input);
+  Tensor output = at::empty_like(input, at::MemoryFormat::Contiguous);
   upsample_bilinear2d_out_cuda_template(
       output, input, output_size, align_corners);
   return output;
@@ -341,7 +341,7 @@ Tensor upsample_bilinear2d_backward_cuda(
     IntArrayRef output_size,
     IntArrayRef input_size,
     bool align_corners) {
-  Tensor grad_input = at::empty_like(grad_output);
+  Tensor grad_input = at::empty_like(grad_output, at::MemoryFormat::Contiguous);
   upsample_bilinear2d_backward_out_cuda_template(
       grad_input, grad_output, output_size, input_size, align_corners);
   return grad_input;

--- a/aten/src/ATen/native/cuda/UpSampleLinear1d.cu
+++ b/aten/src/ATen/native/cuda/UpSampleLinear1d.cu
@@ -239,7 +239,7 @@ Tensor upsample_linear1d_cuda(
     const Tensor& input,
     IntArrayRef output_size,
     bool align_corners) {
-  Tensor output = at::empty_like(input);
+  Tensor output = at::empty_like(input, at::MemoryFormat::Contiguous);
   upsample_linear1d_out_cuda_template(
       output, input, output_size, align_corners);
   return output;
@@ -261,7 +261,7 @@ Tensor upsample_linear1d_backward_cuda(
     IntArrayRef output_size,
     IntArrayRef input_size,
     bool align_corners) {
-  Tensor grad_input = at::empty_like(grad_output);
+  Tensor grad_input = at::empty_like(grad_output, at::MemoryFormat::Contiguous);
   upsample_linear1d_backward_out_cuda_template(
       grad_input, grad_output, output_size, input_size, align_corners);
   return grad_input;

--- a/aten/src/ATen/native/cuda/UpSampleNearest1d.cu
+++ b/aten/src/ATen/native/cuda/UpSampleNearest1d.cu
@@ -195,7 +195,7 @@ Tensor& upsample_nearest1d_out_cuda(
 }
 
 Tensor upsample_nearest1d_cuda(const Tensor& input, IntArrayRef output_size) {
-  Tensor output = at::empty_like(input);
+  Tensor output = at::empty_like(input, at::MemoryFormat::Contiguous);
   upsample_nearest1d_out_cuda_template(output, input, output_size);
   return output;
 }
@@ -214,7 +214,7 @@ Tensor upsample_nearest1d_backward_cuda(
     const Tensor& grad_output,
     IntArrayRef output_size,
     IntArrayRef input_size) {
-  Tensor grad_input = at::empty_like(grad_output);
+  Tensor grad_input = at::empty_like(grad_output, at::MemoryFormat::Contiguous);
   upsample_nearest1d_backward_out_cuda_template(
       grad_input, grad_output, output_size, input_size);
   return grad_input;

--- a/aten/src/ATen/native/cuda/UpSampleNearest2d.cu
+++ b/aten/src/ATen/native/cuda/UpSampleNearest2d.cu
@@ -280,7 +280,7 @@ Tensor& upsample_nearest2d_out_cuda(
 }
 
 Tensor upsample_nearest2d_cuda(const Tensor& input, IntArrayRef output_size) {
-  Tensor output = at::empty_like(input);
+  Tensor output = at::empty_like(input, at::MemoryFormat::Contiguous);
   upsample_nearest2d_out_cuda_template(output, input, output_size);
   return output;
 }
@@ -299,7 +299,7 @@ Tensor upsample_nearest2d_backward_cuda(
     const Tensor& grad_output,
     IntArrayRef output_size,
     IntArrayRef input_size) {
-  Tensor grad_input = at::empty_like(grad_output);
+  Tensor grad_input = at::empty_like(grad_output, at::MemoryFormat::Contiguous);
   upsample_nearest2d_backward_out_cuda_template(
       grad_input, grad_output, output_size, input_size);
   return grad_input;

--- a/aten/src/ATen/native/cuda/UpSampleNearest3d.cu
+++ b/aten/src/ATen/native/cuda/UpSampleNearest3d.cu
@@ -281,7 +281,7 @@ Tensor& upsample_nearest3d_out_cuda(
 }
 
 Tensor upsample_nearest3d_cuda(const Tensor& input, IntArrayRef output_size) {
-  Tensor output = at::empty_like(input);
+  Tensor output = at::empty_like(input, at::MemoryFormat::Contiguous);
   upsample_nearest3d_out_cuda_template(output, input, output_size);
   return output;
 }
@@ -300,7 +300,7 @@ Tensor upsample_nearest3d_backward_cuda(
     const Tensor& grad_output,
     IntArrayRef output_size,
     IntArrayRef input_size) {
-  Tensor grad_input = at::empty_like(grad_output);
+  Tensor grad_input = at::empty_like(grad_output, at::MemoryFormat::Contiguous);
   upsample_nearest3d_backward_out_cuda_template(
       grad_input, grad_output, output_size, input_size);
   return grad_input;

--- a/aten/src/ATen/native/cuda/UpSampleTrilinear3d.cu
+++ b/aten/src/ATen/native/cuda/UpSampleTrilinear3d.cu
@@ -375,7 +375,7 @@ Tensor upsample_trilinear3d_cuda(
     const Tensor& input,
     IntArrayRef output_size,
     bool align_corners) {
-  Tensor output = at::empty_like(input);
+  Tensor output = at::empty_like(input, at::MemoryFormat::Contiguous);
   upsample_trilinear3d_out_cuda_template(
       output, input, output_size, align_corners);
   return output;
@@ -397,7 +397,7 @@ Tensor upsample_trilinear3d_backward_cuda(
     IntArrayRef output_size,
     IntArrayRef input_size,
     bool align_corners) {
-  Tensor grad_input = at::empty_like(grad_output);
+  Tensor grad_input = at::empty_like(grad_output, at::MemoryFormat::Contiguous);
   upsample_trilinear3d_backward_out_cuda_template(
       grad_input, grad_output, output_size, input_size, align_corners);
   return grad_input;

--- a/aten/src/ATen/native/cuda/WeightNorm.cu
+++ b/aten/src/ATen/native/cuda/WeightNorm.cu
@@ -321,7 +321,7 @@ std::tuple<Tensor,Tensor> weight_norm_cuda
    const Tensor & g,
    int64_t dim)
 {
-  auto w = at::empty_like(v);
+  auto w = at::empty_like(v, at::MemoryFormat::Contiguous);
 
   // weight_norm_fused does have a derivative defined in derivatives.yaml, therefore, VariableType.cpp
   // sends the unpacked g.data() as the argument.  In other words, we expect "g" is a bare Tensor here.
@@ -420,8 +420,8 @@ std::tuple<Tensor, Tensor> weight_norm_cuda_backward
   TORCH_CHECK(saved_norms.is_contiguous(), "saved_norms must be contiguous");
   TORCH_CHECK(dim == 0 || dim == saved_v.dim() - 1, "fused kernels can only be applied for first or last dim")
 
-  auto grad_v = at::empty_like(saved_v);
-  auto grad_g = at::empty_like(saved_g);
+  auto grad_v = at::empty_like(saved_v, at::MemoryFormat::Contiguous);
+  auto grad_g = at::empty_like(saved_g, at::MemoryFormat::Contiguous);
 
   const int ndims = saved_v.dim();
 

--- a/aten/src/ATen/native/cudnn/Conv.cpp
+++ b/aten/src/ATen/native/cudnn/Conv.cpp
@@ -1096,7 +1096,7 @@ std::tuple<at::Tensor,at::Tensor,at::Tensor> cudnn_convolution_backward(
   Tensor grad_input, grad_weight, grad_bias;
   if (input.numel() == 0) {
     if (output_mask[0]) {
-      grad_input = at::empty_like(input);
+      grad_input = at::empty_like(input, at::MemoryFormat::Contiguous);
     }
     if (output_mask[1]) {
       grad_weight = at::zeros_like(weight);

--- a/aten/src/ATen/native/cudnn/LossCTC.cpp
+++ b/aten/src/ATen/native/cudnn/LossCTC.cpp
@@ -103,7 +103,7 @@ std::tuple<Tensor, Tensor> _cudnn_ctc_loss(const Tensor& log_probs_t, const Tens
   ctc_loss_desc.setEx(
       CUDNN_DATA_FLOAT, CUDNN_LOSS_NORMALIZATION_SOFTMAX, CUDNN_PROPAGATE_NAN);
   TensorDescriptor log_probs_desc{log_probs_t};
-  Tensor grad = at::empty_like(log_probs_t);
+  Tensor grad = at::empty_like(log_probs_t, at::MemoryFormat::Contiguous);
   TensorDescriptor grad_desc{grad};
 
   size_t workspace_size;

--- a/aten/src/ATen/native/quantized/cpu/qadd.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qadd.cpp
@@ -226,7 +226,7 @@ class QAddScalar final : public c10::OperatorKernel {
   TORCH_CHECK(qa.qscheme() == kPerTensorAffine ||
               qa.qscheme() == kPerTensorSymmetric,
               "Only per tensor quantization is suuported in Add.");
-    auto qc = at::empty_like(qa);
+    auto qc = at::empty_like(qa, at::MemoryFormat::Contiguous);
     return _add_scalar_out<ReLUFused>(qc, qa, b);
   }
 };

--- a/aten/src/ATen/native/quantized/cpu/qmul.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qmul.cpp
@@ -140,7 +140,7 @@ class QMulScalar final : public c10::OperatorKernel {
     TORCH_CHECK(qa.qscheme() == kPerTensorAffine ||
               qa.qscheme() == kPerTensorSymmetric,
               "Only per tensor quantization is suuported in Mul.");
-    auto qc = at::empty_like(qa);
+    auto qc = at::empty_like(qa, at::MemoryFormat::Contiguous);
     return _mul_scalar_out<ReLUFused>(qc, qa, b);
   }
 };

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -1894,7 +1894,7 @@ Tensor det_backward(const Tensor & grad, const Tensor& self, const Tensor& det) 
       return singular_case_backward(grad, self, det);
     }
 
-    Tensor grad_det = at::empty_like(self);
+    Tensor grad_det = at::empty_like(self, at::MemoryFormat::Contiguous);
 
     // invertible case
     grad_det.index_put_(/*indices=*/nonzero_det_indices,
@@ -1944,7 +1944,7 @@ Tensor logdet_backward(const Tensor & grad, const Tensor& self, const Tensor& lo
       return singular_case_backward(grad, self);
     }
 
-    Tensor grad_logdet = at::empty_like(self);
+    Tensor grad_logdet = at::empty_like(self, at::MemoryFormat::Contiguous);
 
     // invertible case
     grad_logdet.index_put_(/*indices=*/finite_logdet_indices,
@@ -1996,7 +1996,7 @@ Tensor slogdet_backward(const Tensor& grad_logabsdet,
       return singular_case_backward(grad_logabsdet, self);
     }
 
-    Tensor grad_slogdet = at::empty_like(self);
+    Tensor grad_slogdet = at::empty_like(self, at::MemoryFormat::Contiguous);
 
     // invertible case
     grad_slogdet.index_put_(/*indices=*/nonzero_signdet_indices,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #29227 Autogenerated contiguous memory format for old *_like calls
* #29226 Autogenerated contiguous memory format for old *_like calls
* #29225 Autogenerated contiguous memory format for old *_like calls
* #29224 Autogenerated contiguous memory format for old *_like calls
* #29223 Autogenerated contiguous memory format for old *_like calls
* **#29222 Autogenerated contiguous memory format for old *_like calls**

Differential Revision: [D18330966](https://our.internmc.facebook.com/intern/diff/D18330966)