### PR TITLE
Autogenerated contiguous memory format for old *_like calls

### DIFF
--- a/aten/src/ATen/native/Activation.cpp
+++ b/aten/src/ATen/native/Activation.cpp
@@ -353,14 +353,14 @@ Tensor hardshrink_backward_cpu(const Tensor & grad, const Tensor & self, Scalar 
 
 
 Tensor gelu_cpu(const Tensor& self) {
-  Tensor Y = at::native::empty_like(self);
+  Tensor Y = at::native::empty_like(self, at::MemoryFormat::Contiguous);
   auto it = TensorIterator::unary_op(Y, self);
   GeluKernel(kCPU, it);
   return Y;
 }
 
 Tensor gelu_backward_cpu(const Tensor& grad, const Tensor& self) {
-  Tensor dX = at::native::empty_like(self);
+  Tensor dX = at::native::empty_like(self, at::MemoryFormat::Contiguous);
   auto it = TensorIterator::binary_op(dX, grad, self);
   GeluBackwardKernel(kCPU, it);
   return dX;

--- a/aten/src/ATen/native/SoftMax.cpp
+++ b/aten/src/ATen/native/SoftMax.cpp
@@ -121,7 +121,7 @@ void host_softmax_backward(
 Tensor softmax_cpu(const Tensor& input_, const int64_t dim_, const bool half_to_float) {
   AT_ASSERTM(!half_to_float, "softmax with half to float conversion is not supported on CPU");
   auto input = input_.contiguous();
-  Tensor output = at::native::empty_like(input);
+  Tensor output = at::native::empty_like(input, at::MemoryFormat::Contiguous);
   int64_t dim = maybe_wrap_dim(dim_, input.dim());
 
   if (input.numel() == 0) {
@@ -145,7 +145,7 @@ Tensor softmax_cpu(const Tensor& input_, const int64_t dim_, const bool half_to_
 Tensor log_softmax_cpu(const Tensor& input_, const int64_t dim_, const bool half_to_float) {
   AT_ASSERTM(!half_to_float, "softmax with half to float conversion is not supported on CPU");
   auto input = input_.contiguous();
-  Tensor output = at::native::empty_like(input);
+  Tensor output = at::native::empty_like(input, at::MemoryFormat::Contiguous);
   int64_t dim = maybe_wrap_dim(dim_, input.dim());
 
   if (input.numel() == 0) {
@@ -176,7 +176,7 @@ Tensor softmax_backward_cpu(
   int64_t dim = maybe_wrap_dim(dim_, grad_.dim());
   auto grad = grad_.contiguous();
   auto output = output_.contiguous();
-  Tensor grad_input = at::native::empty_like(grad);
+  Tensor grad_input = at::native::empty_like(grad, at::MemoryFormat::Contiguous);
 
   if (output.numel() == 0) {
     return grad_input;
@@ -208,7 +208,7 @@ Tensor log_softmax_backward_cpu(
   int64_t dim = maybe_wrap_dim(dim_, grad_.dim());
   auto grad = grad_.contiguous();
   auto output = output_.contiguous();
-  Tensor grad_input = at::native::empty_like(grad);
+  Tensor grad_input = at::native::empty_like(grad, at::MemoryFormat::Contiguous);
 
   if (output.numel() == 0) {
     return grad_input;

--- a/aten/src/ATen/native/cuda/Activation.cu
+++ b/aten/src/ATen/native/cuda/Activation.cu
@@ -329,14 +329,14 @@ void GeluBackwardCUDAKernelImpl(TensorIterator& it) {
 } // namespace
 
 Tensor gelu_cuda(const Tensor& self) {
-  Tensor Y = at::native::empty_like(self);
+  Tensor Y = at::native::empty_like(self, at::MemoryFormat::Contiguous);
   auto it = TensorIterator::unary_op(Y, self);
   GeluKernel(kCUDA, it);
   return Y;
 }
 
 Tensor gelu_backward_cuda(const Tensor& grad, const Tensor& self) {
-  Tensor dX = at::native::empty_like(self);
+  Tensor dX = at::native::empty_like(self, at::MemoryFormat::Contiguous);
   auto it = TensorIterator::binary_op(dX, grad, self);
   GeluBackwardKernel(kCUDA, it);
   return dX;

--- a/aten/src/ATen/native/cuda/layer_norm_kernel.cu
+++ b/aten/src/ATen/native/cuda/layer_norm_kernel.cu
@@ -448,7 +448,7 @@ std::tuple<Tensor, Tensor, Tensor> layer_norm_cuda(
     int64_t M,
     int64_t N,
     double eps) {
-  Tensor Y = at::native::empty_like(X);
+  Tensor Y = at::native::empty_like(X, at::MemoryFormat::Contiguous);
   Tensor mean = at::empty({M}, X.options());
   Tensor rstd = at::empty({M}, X.options());
   if (M > 0) {
@@ -470,13 +470,13 @@ std::tuple<Tensor, Tensor, Tensor> layer_norm_backward_cuda(
   Tensor dgamma;
   Tensor dbeta;
   if (grad_input_mask[0]) {
-    dX = at::native::empty_like(X);
+    dX = at::native::empty_like(X, at::MemoryFormat::Contiguous);
   }
   if (grad_input_mask[1]) {
-    dgamma = M > 0 ? at::native::empty_like(gamma) : at::native::zeros_like(gamma);
+    dgamma = M > 0 ? at::native::empty_like(gamma, at::MemoryFormat::Contiguous) : at::native::zeros_like(gamma);
   }
   if (grad_input_mask[2]) {
-    dbeta = M > 0 ? at::native::empty_like(gamma) : at::native::zeros_like(gamma);
+    dbeta = M > 0 ? at::native::empty_like(gamma, at::MemoryFormat::Contiguous) : at::native::zeros_like(gamma);
   }
   if (M > 0) {
     LayerNormBackwardKernelImpl(

--- a/aten/src/ATen/native/layer_norm.cpp
+++ b/aten/src/ATen/native/layer_norm.cpp
@@ -23,7 +23,7 @@ std::tuple<Tensor, Tensor, Tensor> layer_norm_cpu(
     int64_t M,
     int64_t N,
     double eps) {
-  Tensor Y = at::native::empty_like(X);
+  Tensor Y = at::native::empty_like(X, at::MemoryFormat::Contiguous);
   Tensor mean = at::empty({M}, X.options());
   Tensor rstd = at::empty({M}, X.options());
   if (M > 0) {
@@ -45,13 +45,13 @@ std::tuple<Tensor, Tensor, Tensor> layer_norm_backward_cpu(
   Tensor dgamma;
   Tensor dbeta;
   if (grad_input_mask[0]) {
-    dX = at::native::empty_like(X);
+    dX = at::native::empty_like(X, at::MemoryFormat::Contiguous);
   }
   if (grad_input_mask[1]) {
-    dgamma = M > 0 ? at::native::empty_like(gamma) : at::native::zeros_like(gamma);
+    dgamma = M > 0 ? at::native::empty_like(gamma, at::MemoryFormat::Contiguous) : at::native::zeros_like(gamma);
   }
   if (grad_input_mask[2]) {
-    dbeta = M > 0 ? at::native::empty_like(gamma) : at::native::zeros_like(gamma);
+    dbeta = M > 0 ? at::native::empty_like(gamma, at::MemoryFormat::Contiguous) : at::native::zeros_like(gamma);
   }
   if (M > 0) {
     LayerNormBackwardKernel(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #29227 Autogenerated contiguous memory format for old *_like calls
* #29226 Autogenerated contiguous memory format for old *_like calls
* #29225 Autogenerated contiguous memory format for old *_like calls
* #29224 Autogenerated contiguous memory format for old *_like calls
* **#29223 Autogenerated contiguous memory format for old *_like calls**
* #29222 Autogenerated contiguous memory format for old *_like calls

Differential Revision: [D18330967](https://our.internmc.facebook.com/intern/diff/D18330967)