### PR TITLE
Autogenerated contiguous memory format for old *_like calls

### DIFF
--- a/aten/src/ATen/native/AdaptiveAveragePooling.cpp
+++ b/aten/src/ATen/native/AdaptiveAveragePooling.cpp
@@ -354,7 +354,7 @@ namespace {
     const Tensor& gradOutput,
     const Tensor& input)
   {
-    auto gradInput = at::zeros_like(input);
+    auto gradInput = at::zeros_like(input, at::MemoryFormat::Contiguous);
     adaptive_avg_pool2d_backward_out_cpu_template(
       gradInput, gradOutput, input);
     return gradInput;

--- a/aten/src/ATen/native/AdaptiveAveragePooling3d.cpp
+++ b/aten/src/ATen/native/AdaptiveAveragePooling3d.cpp
@@ -303,7 +303,7 @@ Tensor& adaptive_avg_pool3d_backward_out_cpu(
 Tensor adaptive_avg_pool3d_backward_cpu(
     const Tensor& gradOutput_,
     const Tensor& input) {
-  auto gradInput = at::zeros_like(input);
+  auto gradInput = at::zeros_like(input, at::MemoryFormat::Contiguous);
   adaptive_avg_pool3d_backward_out_cpu_template(gradInput, gradOutput_, input);
   return gradInput;
 }

--- a/aten/src/ATen/native/AdaptiveMaxPooling2d.cpp
+++ b/aten/src/ATen/native/AdaptiveMaxPooling2d.cpp
@@ -394,7 +394,7 @@ Tensor adaptive_max_pool2d_backward_cpu(
   const Tensor& input,
   const Tensor& indices)
 {
-  auto gradInput = at::zeros_like(input);
+  auto gradInput = at::zeros_like(input, at::MemoryFormat::Contiguous);
   adaptive_max_pool2d_backward_out_cpu_template(
     gradInput,
     gradOutput_,

--- a/aten/src/ATen/native/AdaptiveMaxPooling3d.cpp
+++ b/aten/src/ATen/native/AdaptiveMaxPooling3d.cpp
@@ -440,7 +440,7 @@ Tensor adaptive_max_pool3d_backward_cpu(
   const Tensor& input,
   const Tensor& indices)
 {
-  auto gradInput = at::zeros_like(input);
+  auto gradInput = at::zeros_like(input, at::MemoryFormat::Contiguous);
   adaptive_max_pool3d_backward_out_cpu_template(
     gradInput,
     gradOutput_,

--- a/aten/src/ATen/native/AveragePool2d.cpp
+++ b/aten/src/ATen/native/AveragePool2d.cpp
@@ -408,7 +408,7 @@ Tensor avg_pool2d_backward_cpu(
   bool count_include_pad,
   c10::optional<int64_t> divisor_override)
 {
-  auto gradInput = at::zeros_like(input);
+  auto gradInput = at::zeros_like(input, at::MemoryFormat::Contiguous);
   avg_pool2d_backward_out_cpu_template(
     gradInput,
     gradOutput_,

--- a/aten/src/ATen/native/AveragePool3d.cpp
+++ b/aten/src/ATen/native/AveragePool3d.cpp
@@ -505,7 +505,7 @@ Tensor avg_pool3d_backward_cpu(
   bool count_include_pad,
   c10::optional<int64_t> divisor_override)
 {
-  auto gradInput = at::zeros_like(input);
+  auto gradInput = at::zeros_like(input, at::MemoryFormat::Contiguous);
   avg_pool3d_backward_out_cpu_template(
     gradInput,
     gradOutput_,

--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -1088,7 +1088,7 @@ Tensor _lu_solve_helper_cpu(const Tensor& self, const Tensor& LU_data, const Ten
   std::vector<int64_t> infos(batchCount(self), 0);
 
   if (self.numel() == 0 || LU_data.numel() == 0) {
-    return at::zeros_like(self);
+    return at::zeros_like(self, at::MemoryFormat::Contiguous);
   }
   AT_DISPATCH_FLOATING_TYPES(self.scalar_type(), "lu_solve_cpu", [&]{
     apply_lu_solve<scalar_t>(self_working_copy, LU_data_working_copy, LU_pivots_working_copy, infos);

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -802,7 +802,7 @@ std::tuple<Tensor,Tensor,Tensor> _convolution_double_backward(
       }
     }
   } else {
-    ggO = at::zeros_like(gO);
+    ggO = at::zeros_like(gO, at::MemoryFormat::Contiguous);
   }
 
   if (ggb.defined()) {
@@ -893,7 +893,7 @@ std::tuple<Tensor,Tensor,Tensor> _convolution_double_backward(
       }
     }
   } else {
-    gW = at::zeros_like(weight);
+    gW = at::zeros_like(weight, at::MemoryFormat::Contiguous);
   }
 
   // Compute gI = convT(ggW, gO.t()) if !transposed
@@ -982,12 +982,12 @@ std::tuple<Tensor,Tensor,Tensor> _convolution_double_backward(
       }
     }
   } else {
-    gI = at::zeros_like(input);
+    gI = at::zeros_like(input, at::MemoryFormat::Contiguous);
   }
 
-  if (output_mask[0] && !ggO.defined()) ggO = at::zeros_like(gO);
-  if (output_mask[1] && !gI.defined()) gI = at::zeros_like(input);
-  if (output_mask[2] && !gW.defined()) gW = at::zeros_like(weight);
+  if (output_mask[0] && !ggO.defined()) ggO = at::zeros_like(gO, at::MemoryFormat::Contiguous);
+  if (output_mask[1] && !gI.defined()) gI = at::zeros_like(input, at::MemoryFormat::Contiguous);
+  if (output_mask[2] && !gW.defined()) gW = at::zeros_like(weight, at::MemoryFormat::Contiguous);
 
   return std::tuple<Tensor,Tensor,Tensor>{ggO, gI, gW};
 }

--- a/aten/src/ATen/native/ConvolutionTBC.cpp
+++ b/aten/src/ATen/native/ConvolutionTBC.cpp
@@ -69,7 +69,7 @@ std::tuple<Tensor, Tensor, Tensor> conv_tbc_backward(const Tensor& dOutput, cons
   auto olen = input_size[0] - kw + 1 + pad * 2;
   int real_pad = (olen - ilen + kw - 1) / 2;
 
-  Tensor dInput = at::zeros_like(input);
+  Tensor dInput = at::zeros_like(input, at::MemoryFormat::Contiguous);
   for (int k = 0; k < kw; k++) {
     int iShift = std::max(0, k - real_pad);
     int oShift = std::max(0, real_pad - k);
@@ -82,7 +82,7 @@ std::tuple<Tensor, Tensor, Tensor> conv_tbc_backward(const Tensor& dOutput, cons
     }
   }
 
-  Tensor dWeight = at::zeros_like(weight);
+  Tensor dWeight = at::zeros_like(weight, at::MemoryFormat::Contiguous);
   for (int k = 0; k < kw; k++) {
     int iShift = std::max(0, k - real_pad);
     int oShift = std::max(0, real_pad - k);
@@ -96,7 +96,7 @@ std::tuple<Tensor, Tensor, Tensor> conv_tbc_backward(const Tensor& dOutput, cons
     }
   }
 
-  Tensor dBias = at::zeros_like(bias);
+  Tensor dBias = at::zeros_like(bias, at::MemoryFormat::Contiguous);
   auto tmp = dOutput.sum(0, false);
   dBias.copy_(tmp.sum(0));
 

--- a/aten/src/ATen/native/DilatedMaxPool2d.cpp
+++ b/aten/src/ATen/native/DilatedMaxPool2d.cpp
@@ -487,7 +487,7 @@ Tensor max_pool2d_with_indices_backward_cpu(
   bool ceil_mode,
   const Tensor& indices)
 {
-  auto gradInput = at::zeros_like(input);
+  auto gradInput = at::zeros_like(input, at::MemoryFormat::Contiguous);
   max_pool2d_with_indices_backward_out_cpu_template(
     gradInput,
     gradOutput_,

--- a/aten/src/ATen/native/DilatedMaxPool3d.cpp
+++ b/aten/src/ATen/native/DilatedMaxPool3d.cpp
@@ -547,7 +547,7 @@ Tensor max_pool3d_with_indices_backward_cpu(
   bool ceil_mode,
   const Tensor& indices)
 {
-  auto gradInput = at::zeros_like(input);
+  auto gradInput = at::zeros_like(input, at::MemoryFormat::Contiguous);
   max_pool3d_with_indices_backward_out_cpu_template(
     gradInput,
     gradOutput_,

--- a/aten/src/ATen/native/GridSampler.cpp
+++ b/aten/src/ATen/native/GridSampler.cpp
@@ -176,7 +176,7 @@ namespace {
                                     GridSamplerInterpolation interpolation_mode,
                                     GridSamplerPadding padding_mode,
                                     bool align_corners) {
-    auto grad_input = at::zeros_like(input);
+    auto grad_input = at::zeros_like(input, at::MemoryFormat::Contiguous);
     auto grad_grid = at::empty_like(grid, at::MemoryFormat::Contiguous);
     // If interpolation mode is Nearest, then grad_grid is not filled in the
     // loop below.

--- a/aten/src/ATen/native/Loss.cpp
+++ b/aten/src/ATen/native/Loss.cpp
@@ -41,7 +41,7 @@ Tensor cosine_embedding_loss(const Tensor& input1, const Tensor& input2, const T
   auto denom = (mag_square1 * mag_square2).sqrt_();
   auto cos = prod_sum / denom;
 
-  auto zeros = at::zeros_like(target);
+  auto zeros = at::zeros_like(target, at::MemoryFormat::Contiguous);
   auto pos = 1 - cos;
   auto neg = (cos - margin).clamp_min_(0);
   auto output_pos = at::where(target == 1, pos, zeros);
@@ -51,7 +51,7 @@ Tensor cosine_embedding_loss(const Tensor& input1, const Tensor& input2, const T
 }
 
 Tensor hinge_embedding_loss(const Tensor& self, const Tensor& target, double margin, int64_t reduction) {
-  auto zeros = at::zeros_like(self);
+  auto zeros = at::zeros_like(self, at::MemoryFormat::Contiguous);
   auto margin_clamp = (margin - self).clamp_min_(0);
   auto output_margin = at::where(target != 1, margin_clamp, zeros);
   auto output_self = at::where(target != -1, self, zeros);
@@ -77,14 +77,14 @@ Tensor margin_ranking_loss(const Tensor& input1, const Tensor& input2, const Ten
 }
 
 Tensor kl_div(const Tensor& input, const Tensor& target, int64_t reduction) {
-  auto zeros = at::zeros_like(target);
+  auto zeros = at::zeros_like(target, at::MemoryFormat::Contiguous);
   auto output_pos = target * (at::log(target) - input);
   auto output = at::where(target > 0, output_pos, zeros);
   return apply_loss_reduction(output, reduction);
 }
 
 Tensor kl_div_backward_cpu(const Tensor& grad, const Tensor& input, const Tensor& target, int64_t reduction) {
-  auto grad_input = at::zeros_like(input);
+  auto grad_input = at::zeros_like(input, at::MemoryFormat::Contiguous);
   auto grad_expand = grad.expand_as(input);
   AT_DISPATCH_FLOATING_TYPES(input.scalar_type(), "kl_div_backward_cpu", [&]() {
     at::CPU_tensor_apply3<scalar_t, scalar_t, scalar_t>(
@@ -190,7 +190,7 @@ Tensor& smooth_l1_loss_backward_out(Tensor& grad_input, const Tensor& grad_outpu
 }
 
 Tensor smooth_l1_loss_backward(const Tensor& grad_output, const Tensor& input, const Tensor& target, int64_t reduction) {
-  auto grad_input = at::zeros_like(input);
+  auto grad_input = at::zeros_like(input, at::MemoryFormat::Contiguous);
   return at::smooth_l1_loss_backward_out(grad_input, grad_output, input, target, reduction);
 }
 
@@ -219,7 +219,7 @@ Tensor& mse_loss_out(Tensor&result, const Tensor& input, const Tensor& target, i
 }
 
 Tensor mse_loss_backward(const Tensor& grad_output, const Tensor& input, const Tensor& target, int64_t reduction) {
-  Tensor grad_input = at::zeros_like(input);
+  Tensor grad_input = at::zeros_like(input, at::MemoryFormat::Contiguous);
   return at::mse_loss_backward_out(grad_input, grad_output, input, target, reduction);
 }
 
@@ -257,7 +257,7 @@ Tensor& l1_loss_out(Tensor&result, const Tensor& input, const Tensor& target, in
 }
 
 Tensor l1_loss_backward(const Tensor& grad_output, const Tensor& input, const Tensor& target, int64_t reduction) {
-  Tensor grad_input = at::zeros_like(input);
+  Tensor grad_input = at::zeros_like(input, at::MemoryFormat::Contiguous);
   return at::l1_loss_backward_out(grad_input, grad_output, input, target, reduction);
 }
 

--- a/aten/src/ATen/native/LossMultiLabelMargin.cpp
+++ b/aten/src/ATen/native/LossMultiLabelMargin.cpp
@@ -335,7 +335,7 @@ Tensor multilabel_margin_loss_backward_cpu(
     const Tensor& target,
     int64_t reduction,
     const Tensor& is_target) {
-  auto grad_input = at::zeros_like(self);
+  auto grad_input = at::zeros_like(self, at::MemoryFormat::Contiguous);
   multilabel_margin_loss_backward_cpu_out(
       grad_input, grad_output, self, target, reduction, is_target);
   return grad_input;

--- a/aten/src/ATen/native/LossNLL.cpp
+++ b/aten/src/ATen/native/LossNLL.cpp
@@ -371,7 +371,7 @@ Tensor nll_loss_backward_cpu(
     int64_t reduction,
     int64_t ignore_index,
     const Tensor& total_weight) {
-  auto grad_input = at::zeros_like(self);
+  auto grad_input = at::zeros_like(self, at::MemoryFormat::Contiguous);
   nll_loss_backward_out_cpu(
       grad_input,
       grad_output,

--- a/aten/src/ATen/native/QuantizedLinear.cpp
+++ b/aten/src/ATen/native/QuantizedLinear.cpp
@@ -230,7 +230,7 @@ std::tuple<Tensor, Tensor, double, int64_t> fbgemm_linear_quantize_weight(
 
   q_params.precision = precision;
 
-  auto quantized = at::zeros_like(weight_contig).to(at::kChar).contiguous();
+  auto quantized = at::zeros_like(weight_contig, at::MemoryFormat::Contiguous).to(at::kChar).contiguous();
   fbgemm::Quantize<int8_t>(
       /*src=*/weight_contig.data_ptr<float>(),
       /*dst=*/quantized.data_ptr<int8_t>(),
@@ -240,7 +240,7 @@ std::tuple<Tensor, Tensor, double, int64_t> fbgemm_linear_quantize_weight(
   // Calculate column offsets of the weight and store them away in a tensor.
   // Similarly to quantization, this can be done once and cached.
   auto col_offsets =
-      at::zeros_like(quantized).sum({1}).to(at::kInt).contiguous();
+      at::zeros_like(quantized, at::MemoryFormat::Contiguous).sum({1}).to(at::kInt).contiguous();
   calc_col_offsets_transpose(
       /*K=*/quantized.size(1),
       /*N=*/quantized.size(0),

--- a/aten/src/ATen/native/RNN.cpp
+++ b/aten/src/ATen/native/RNN.cpp
@@ -1068,7 +1068,7 @@ _thnn_differentiable_lstm_cell_backward(
       gcx = gcx + grad_cy;
     }
   } else if (grad_cy.defined()) {
-    gog = at::zeros_like(cx);
+    gog = at::zeros_like(cx, at::MemoryFormat::Contiguous);
     gcx = grad_cy;
   }
   Tensor gig = gcx * c;

--- a/aten/src/ATen/native/ReflectionPad.cpp
+++ b/aten/src/ATen/native/ReflectionPad.cpp
@@ -500,7 +500,7 @@ Tensor reflection_pad1d_backward_cpu(
     const Tensor& grad_output,
     const Tensor& input,
     IntArrayRef padding) {
-  auto grad_input = at::zeros_like(input);
+  auto grad_input = at::zeros_like(input, at::MemoryFormat::Contiguous);
   reflection_pad1d_backward_out_template(
     grad_input, grad_output, input, padding);
   return grad_input;
@@ -534,7 +534,7 @@ Tensor reflection_pad2d_backward_cpu(
     const Tensor& grad_output,
     const Tensor& input,
     IntArrayRef padding) {
-  auto grad_input = at::zeros_like(input);
+  auto grad_input = at::zeros_like(input, at::MemoryFormat::Contiguous);
   reflection_pad2d_backward_out_template(
     grad_input, grad_output, input, padding);
   return grad_input;

--- a/aten/src/ATen/native/ReplicationPadding.cpp
+++ b/aten/src/ATen/native/ReplicationPadding.cpp
@@ -949,7 +949,7 @@ Tensor replication_pad1d_backward_cpu(
     const Tensor& input,
     IntArrayRef paddingSize)
 {
-  auto gradInput = at::zeros_like(input);
+  auto gradInput = at::zeros_like(input, at::MemoryFormat::Contiguous);
   replication_pad1d_backward_out_cpu_template(
       gradInput, gradOutput, input, paddingSize);
   return gradInput;
@@ -991,7 +991,7 @@ Tensor replication_pad2d_backward_cpu(
     const Tensor& input,
     IntArrayRef paddingSize)
 {
-  auto gradInput = at::zeros_like(input);
+  auto gradInput = at::zeros_like(input, at::MemoryFormat::Contiguous);
   replication_pad2d_backward_out_cpu_template(
       gradInput, gradOutput, input, paddingSize);
   return gradInput;
@@ -1033,7 +1033,7 @@ Tensor replication_pad3d_backward_cpu(
     const Tensor& input,
     IntArrayRef paddingSize)
 {
-  auto gradInput = at::zeros_like(input);
+  auto gradInput = at::zeros_like(input, at::MemoryFormat::Contiguous);
   replication_pad3d_backward_out_cpu_template(
       gradInput, gradOutput, input, paddingSize);
   return gradInput;

--- a/aten/src/ATen/native/cpu/GridSamplerKernel.cpp
+++ b/aten/src/ATen/native/cpu/GridSamplerKernel.cpp
@@ -963,7 +963,7 @@ grid_sampler_2d_backward_cpu_kernel_impl(const Tensor& grad_output_,
   // contiguous can greatly simplify this code.
   auto grad_output = grad_output_.contiguous();
 
-  auto grad_input = at::zeros_like(input);
+  auto grad_input = at::zeros_like(input, at::MemoryFormat::Contiguous);
   auto grad_grid = at::empty_like(grid, at::MemoryFormat::Contiguous);
   auto N = input.size(0);
   auto spatial_size = grid.size(1) * grid.size(2);

--- a/aten/src/ATen/native/cuda/AdaptiveAveragePooling.cu
+++ b/aten/src/ATen/native/cuda/AdaptiveAveragePooling.cu
@@ -735,7 +735,7 @@ namespace {
     const Tensor& gradOutput,
     const Tensor& input)
   {
-    auto gradInput = at::zeros_like(input);
+    auto gradInput = at::zeros_like(input, at::MemoryFormat::Contiguous);
     adaptive_avg_pool2d_backward_out_cuda_template(
       gradInput, gradOutput, input);
     return gradInput;

--- a/aten/src/ATen/native/cuda/AdaptiveAveragePooling3d.cu
+++ b/aten/src/ATen/native/cuda/AdaptiveAveragePooling3d.cu
@@ -508,7 +508,7 @@ Tensor& adaptive_avg_pool3d_backward_out_cuda(
 Tensor adaptive_avg_pool3d_backward_cuda(
     const Tensor& gradOutput_,
     const Tensor& input) {
-  auto gradInput = at::zeros_like(input);
+  auto gradInput = at::zeros_like(input, at::MemoryFormat::Contiguous);
   adaptive_avg_pool3d_backward_out_cuda_template(gradInput, gradOutput_, input);
   return gradInput;
 }

--- a/aten/src/ATen/native/cuda/AdaptiveMaxPooling2d.cu
+++ b/aten/src/ATen/native/cuda/AdaptiveMaxPooling2d.cu
@@ -455,7 +455,7 @@ Tensor adaptive_max_pool2d_backward_cuda(
   const Tensor& input,
   const Tensor& indices)
 {
-  auto gradInput = at::zeros_like(input);
+  auto gradInput = at::zeros_like(input, at::MemoryFormat::Contiguous);
   adaptive_max_pool2d_backward_out_cuda_template(
     gradInput,
     gradOutput_,

--- a/aten/src/ATen/native/cuda/AdaptiveMaxPooling3d.cu
+++ b/aten/src/ATen/native/cuda/AdaptiveMaxPooling3d.cu
@@ -508,7 +508,7 @@ Tensor adaptive_max_pool3d_backward_cuda(
   const Tensor& input,
   const Tensor& indices)
 {
-  auto gradInput = at::zeros_like(input);
+  auto gradInput = at::zeros_like(input, at::MemoryFormat::Contiguous);
   adaptive_max_pool3d_backward_out_cuda_template(
     gradInput,
     gradOutput_,

--- a/aten/src/ATen/native/cuda/AveragePool2d.cu
+++ b/aten/src/ATen/native/cuda/AveragePool2d.cu
@@ -487,7 +487,7 @@ Tensor avg_pool2d_backward_cuda(
   bool count_include_pad,
   c10::optional<int64_t> divisor_override)
 {
-  auto gradInput = at::zeros_like(input);
+  auto gradInput = at::zeros_like(input, at::MemoryFormat::Contiguous);
   avg_pool2d_backward_out_cuda_template(
     gradInput,
     gradOutput_,

--- a/aten/src/ATen/native/cuda/AveragePool3d.cu
+++ b/aten/src/ATen/native/cuda/AveragePool3d.cu
@@ -712,7 +712,7 @@ Tensor avg_pool3d_backward_cuda(
   bool count_include_pad,
   c10::optional<int64_t> divisor_override)
 {
-  auto gradInput = at::zeros_like(input);
+  auto gradInput = at::zeros_like(input, at::MemoryFormat::Contiguous);
   avg_pool3d_backward_out_cuda_template(
     gradInput,
     gradOutput_,

--- a/aten/src/ATen/native/cuda/BatchLinearAlgebra.cu
+++ b/aten/src/ATen/native/cuda/BatchLinearAlgebra.cu
@@ -1387,7 +1387,7 @@ Tensor _lu_solve_helper_cuda(const Tensor& self, const Tensor& LU_data, const Te
   auto LU_pivots_working_copy = LU_pivots.is_contiguous() ? LU_pivots : LU_pivots.contiguous();
 
   if (self.numel() == 0 || LU_data.numel() == 0) {
-    return at::zeros_like(self);
+    return at::zeros_like(self, at::MemoryFormat::Contiguous);
   }
   AT_DISPATCH_FLOATING_TYPES(self.scalar_type(), "lu_solve_cuda", [&]{
     apply_lu_solve<scalar_t>(self_working_copy, LU_data_working_copy, LU_pivots_working_copy, info);

--- a/aten/src/ATen/native/cuda/DilatedMaxPool2d.cu
+++ b/aten/src/ATen/native/cuda/DilatedMaxPool2d.cu
@@ -643,7 +643,7 @@ Tensor max_pool2d_with_indices_backward_cuda(
   bool ceil_mode,
   const Tensor& indices)
 {
-  auto gradInput = at::zeros_like(input);
+  auto gradInput = at::zeros_like(input, at::MemoryFormat::Contiguous);
   max_pool2d_with_indices_backward_out_cuda_template(
     gradInput,
     gradOutput_,

--- a/aten/src/ATen/native/cuda/DilatedMaxPool3d.cu
+++ b/aten/src/ATen/native/cuda/DilatedMaxPool3d.cu
@@ -566,7 +566,7 @@ Tensor max_pool3d_with_indices_backward_cuda(
   bool ceil_mode,
   const Tensor& indices)
 {
-  auto gradInput = at::zeros_like(input);
+  auto gradInput = at::zeros_like(input, at::MemoryFormat::Contiguous);
   max_pool3d_with_indices_backward_out_cuda_template(
     gradInput,
     gradOutput,

--- a/aten/src/ATen/native/cuda/GridSampler.cu
+++ b/aten/src/ATen/native/cuda/GridSampler.cu
@@ -661,7 +661,7 @@ grid_sampler_2d_backward_cuda(const Tensor& grad_output, const Tensor& input,
   auto N = input.size(0);
   auto H = grid.size(1);
   auto W = grid.size(2);
-  auto grad_input = at::zeros_like(input);
+  auto grad_input = at::zeros_like(input, at::MemoryFormat::Contiguous);
   auto grad_grid = at::empty_like(grid, at::MemoryFormat::Contiguous);
   int count = static_cast<int>(N * H * W);
   if (count > 0) {
@@ -691,7 +691,7 @@ grid_sampler_3d_backward_cuda(const Tensor& grad_output, const Tensor& input,
   auto D = grid.size(1);
   auto H = grid.size(2);
   auto W = grid.size(3);
-  auto grad_input = at::zeros_like(input);
+  auto grad_input = at::zeros_like(input, at::MemoryFormat::Contiguous);
   auto grad_grid = at::empty_like(grid, at::MemoryFormat::Contiguous);
   int count = static_cast<int>(N * D * H * W);
   if (count > 0) {

--- a/aten/src/ATen/native/cuda/Loss.cu
+++ b/aten/src/ATen/native/cuda/Loss.cu
@@ -26,7 +26,7 @@ void kl_div_backward_kernel(const Tensor& grad_input, const Tensor& target, cons
 namespace at { namespace native {
 
 Tensor kl_div_backward_cuda(const Tensor& grad, const Tensor& input, const Tensor& target, int64_t reduction) {
-  auto grad_input = at::zeros_like(input);
+  auto grad_input = at::zeros_like(input, at::MemoryFormat::Contiguous);
   Tensor grad_expand = grad.expand_as(input);
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(), "kl_div_backward_cuda", [&]() {
     kl_div_backward_kernel<scalar_t>(grad_input, target, grad_expand);

--- a/aten/src/ATen/native/cuda/ReflectionPad.cu
+++ b/aten/src/ATen/native/cuda/ReflectionPad.cu
@@ -410,7 +410,7 @@ Tensor reflection_pad1d_backward_cuda(
     const Tensor& grad_output,
     const Tensor& input,
     IntArrayRef padding) {
-  auto grad_input = at::zeros_like(input);
+  auto grad_input = at::zeros_like(input, at::MemoryFormat::Contiguous);
   reflection_pad1d_backward_out_template(
     grad_input, grad_output, input, padding);
   return grad_input;
@@ -443,7 +443,7 @@ Tensor reflection_pad2d_backward_cuda(
     const Tensor& grad_output,
     const Tensor& input,
     IntArrayRef padding) {
-  auto grad_input = at::zeros_like(input);
+  auto grad_input = at::zeros_like(input, at::MemoryFormat::Contiguous);
   reflection_pad2d_backward_out_template(
     grad_input, grad_output, input, padding);
   return grad_input;

--- a/aten/src/ATen/native/cuda/ReplicationPadding.cu
+++ b/aten/src/ATen/native/cuda/ReplicationPadding.cu
@@ -744,7 +744,7 @@ Tensor replication_pad1d_backward_cuda(
     const Tensor& input,
     IntArrayRef paddingSize)
 {
-  auto gradInput = at::zeros_like(input);
+  auto gradInput = at::zeros_like(input, at::MemoryFormat::Contiguous);
   replication_pad1d_backward_out_cuda_template(
       gradInput, gradOutput, input, paddingSize);
   return gradInput;
@@ -786,7 +786,7 @@ Tensor replication_pad2d_backward_cuda(
     const Tensor& input,
     IntArrayRef paddingSize)
 {
-  auto gradInput = at::zeros_like(input);
+  auto gradInput = at::zeros_like(input, at::MemoryFormat::Contiguous);
   replication_pad2d_backward_out_cuda_template(
       gradInput, gradOutput, input, paddingSize);
   return gradInput;
@@ -828,7 +828,7 @@ Tensor replication_pad3d_backward_cuda(
     const Tensor& input,
     IntArrayRef paddingSize)
 {
-  auto gradInput = at::zeros_like(input);
+  auto gradInput = at::zeros_like(input, at::MemoryFormat::Contiguous);
   replication_pad3d_backward_out_cuda_template(
       gradInput, gradOutput, input, paddingSize);
   return gradInput;

--- a/aten/src/ATen/native/cuda/layer_norm_kernel.cu
+++ b/aten/src/ATen/native/cuda/layer_norm_kernel.cu
@@ -473,10 +473,10 @@ std::tuple<Tensor, Tensor, Tensor> layer_norm_backward_cuda(
     dX = at::native::empty_like(X, at::MemoryFormat::Contiguous);
   }
   if (grad_input_mask[1]) {
-    dgamma = M > 0 ? at::native::empty_like(gamma, at::MemoryFormat::Contiguous) : at::native::zeros_like(gamma);
+    dgamma = M > 0 ? at::native::empty_like(gamma, at::MemoryFormat::Contiguous) : at::native::zeros_like(gamma, at::MemoryFormat::Contiguous);
   }
   if (grad_input_mask[2]) {
-    dbeta = M > 0 ? at::native::empty_like(gamma, at::MemoryFormat::Contiguous) : at::native::zeros_like(gamma);
+    dbeta = M > 0 ? at::native::empty_like(gamma, at::MemoryFormat::Contiguous) : at::native::zeros_like(gamma, at::MemoryFormat::Contiguous);
   }
   if (M > 0) {
     LayerNormBackwardKernelImpl(

--- a/aten/src/ATen/native/cudnn/Conv.cpp
+++ b/aten/src/ATen/native/cudnn/Conv.cpp
@@ -1099,7 +1099,7 @@ std::tuple<at::Tensor,at::Tensor,at::Tensor> cudnn_convolution_backward(
       grad_input = at::empty_like(input, at::MemoryFormat::Contiguous);
     }
     if (output_mask[1]) {
-      grad_weight = at::zeros_like(weight);
+      grad_weight = at::zeros_like(weight, at::MemoryFormat::Contiguous);
     }
     if (output_mask[2]) {
       grad_bias = at::zeros({grad_output.size(1)}, grad_output.options());

--- a/aten/src/ATen/native/cudnn/RNN.cpp
+++ b/aten/src/ATen/native/cudnn/RNN.cpp
@@ -1064,9 +1064,9 @@ std::tuple<Tensor, Tensor, Tensor, std::vector<Tensor>> _cudnn_rnn_backward(
     std::array<bool, 4> output_mask
     ) {
 
-  auto grad_output = grad_output_r.defined() ? grad_output_r : at::zeros_like(output);
-  auto grad_hy = grad_hy_r.defined() ? grad_hy_r : at::zeros_like(hx);
-  auto grad_cy = cx.defined() ? (grad_cy_r.defined() ? grad_cy_r : at::zeros_like(cx)) : grad_cy_r;
+  auto grad_output = grad_output_r.defined() ? grad_output_r : at::zeros_like(output, at::MemoryFormat::Contiguous);
+  auto grad_hy = grad_hy_r.defined() ? grad_hy_r : at::zeros_like(hx, at::MemoryFormat::Contiguous);
+  auto grad_cy = cx.defined() ? (grad_cy_r.defined() ? grad_cy_r : at::zeros_like(cx, at::MemoryFormat::Contiguous)) : grad_cy_r;
 
   Tensor dx, dhx, dcx;
   // NB: unconditionally compute this gradient, because it mutates reserve

--- a/aten/src/ATen/native/layer_norm.cpp
+++ b/aten/src/ATen/native/layer_norm.cpp
@@ -48,10 +48,10 @@ std::tuple<Tensor, Tensor, Tensor> layer_norm_backward_cpu(
     dX = at::native::empty_like(X, at::MemoryFormat::Contiguous);
   }
   if (grad_input_mask[1]) {
-    dgamma = M > 0 ? at::native::empty_like(gamma, at::MemoryFormat::Contiguous) : at::native::zeros_like(gamma);
+    dgamma = M > 0 ? at::native::empty_like(gamma, at::MemoryFormat::Contiguous) : at::native::zeros_like(gamma, at::MemoryFormat::Contiguous);
   }
   if (grad_input_mask[2]) {
-    dbeta = M > 0 ? at::native::empty_like(gamma, at::MemoryFormat::Contiguous) : at::native::zeros_like(gamma);
+    dbeta = M > 0 ? at::native::empty_like(gamma, at::MemoryFormat::Contiguous) : at::native::zeros_like(gamma, at::MemoryFormat::Contiguous);
   }
   if (M > 0) {
     LayerNormBackwardKernel(

--- a/aten/src/ATen/native/miopen/RNN_miopen.cpp
+++ b/aten/src/ATen/native/miopen/RNN_miopen.cpp
@@ -751,9 +751,9 @@ std::tuple<Tensor, Tensor, Tensor, std::vector<Tensor>> miopen_rnn_backward(
         double dropout, bool train, bool bidirectional, IntArrayRef batch_sizes, const Tensor& dropout_state, 
         const Tensor& reserve, std::array<bool, 4> output_mask
         ) {
-    auto grad_output = grad_output_r.defined() ? grad_output_r : at::zeros_like(output);
-    auto grad_hy = grad_hy_r.defined() ? grad_hy_r : at::zeros_like(hx);
-    auto grad_cy = cx.defined() ? (grad_cy_r.defined() ? grad_cy_r : at::zeros_like(cx)) : grad_cy_r;
+    auto grad_output = grad_output_r.defined() ? grad_output_r : at::zeros_like(output, at::MemoryFormat::Contiguous);
+    auto grad_hy = grad_hy_r.defined() ? grad_hy_r : at::zeros_like(hx, at::MemoryFormat::Contiguous);
+    auto grad_cy = cx.defined() ? (grad_cy_r.defined() ? grad_cy_r : at::zeros_like(cx, at::MemoryFormat::Contiguous)) : grad_cy_r;
 
     Tensor dx, dhx, dcx, ws;
     std::tie(dx, dhx, dcx, ws) = at::native::miopen_rnn_backward_input(input, weight_buf, hx, cx, output, grad_output, grad_hy, grad_cy, mode, hidden_size, num_layers, batch_first, dropout, train, bidirectional, batch_sizes, dropout_state, reserve, {output_mask[0], output_mask[1], output_mask[2]});


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #29227 Autogenerated contiguous memory format for old *_like calls
* #29226 Autogenerated contiguous memory format for old *_like calls
* #29225 Autogenerated contiguous memory format for old *_like calls
* **#29224 Autogenerated contiguous memory format for old *_like calls**
* #29223 Autogenerated contiguous memory format for old *_like calls
* #29222 Autogenerated contiguous memory format for old *_like calls

Differential Revision: [D18330968](https://our.internmc.facebook.com/intern/diff/D18330968)