### PR TITLE
Autogenerated contiguous memory format for old *_like calls

### DIFF
--- a/torch/csrc/autograd/functions/tensor.cpp
+++ b/torch/csrc/autograd/functions/tensor.cpp
@@ -19,7 +19,7 @@ auto CopyBackwards::apply(variable_list&& grads) -> variable_list {
   auto& grad = grads[0];
   variable_list grad_inputs(2);
   if (should_compute_output(0)) {
-    grad_inputs[0] = at::zeros_like(grad);
+    grad_inputs[0] = at::zeros_like(grad, at::MemoryFormat::Contiguous);
   }
   if (should_compute_output(1)) {
     at::DeviceGuard device_guard(src_device);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #29227 Autogenerated contiguous memory format for old *_like calls
* **#29226 Autogenerated contiguous memory format for old *_like calls**
* #29225 Autogenerated contiguous memory format for old *_like calls
* #29224 Autogenerated contiguous memory format for old *_like calls
* #29223 Autogenerated contiguous memory format for old *_like calls
* #29222 Autogenerated contiguous memory format for old *_like calls

Differential Revision: [D18330965](https://our.internmc.facebook.com/intern/diff/D18330965)