### PR TITLE
[iOS] Cocoapods 1.3.1 release

### DIFF
--- a/ios/LibTorch.podspec
+++ b/ios/LibTorch.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = 'LibTorch'
-    s.version          = '1.3.0'
+    s.version          = '1.3.1'
     s.authors          = 'PyTorch Team'
     s.license          = { :type => 'BSD' }
     s.homepage         = 'https://github.com/pytorch/pytorch'


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#29240 [iOS] Cocoapods 1.3.1 release**

### Summary

The 1.3.1 binary has been uploaded to AWS - https://ossci-ios.s3.amazonaws.com/libtorch_ios_1.3.1.zip. This PR updates the cocoapods version to 1.3.1

### Test Plan

- The 1.3.1 binary works well

Differential Revision: [D18333750](https://our.internmc.facebook.com/intern/diff/D18333750)