### PR TITLE
Remove CollisionChecker from typeids

### DIFF
--- a/c10/util/typeid.cpp
+++ b/c10/util/typeid.cpp
@@ -27,11 +27,6 @@ const TypeMetaData _typeMetaDataInstance_uninitialized_ = detail::TypeMetaData(
     TypeIdentifier::uninitialized(),
     "nullptr (uninitialized)");
 
-C10_EXPORT CollisionChecker& collisionChecker_() {
-  static CollisionChecker singleton;
-  return singleton;
-}
-
 } // namespace detail
 
 // TODO Inlineable on non-MSVC like other preallocated ids?


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#29242 Remove CollisionChecker from typeids**

I don't really know why this is crashing, but it is crashing on ios with a EXC_BAD_ACCESS / KERN_INVALID_ADDRESS.
(see internal diff description for example link).

Removing it.

Differential Revision: [D18333464](https://our.internmc.facebook.com/intern/diff/D18333464/)