### PR TITLE
[iOS] Fix the TestApp

### DIFF
--- a/ios/TestApp/README.md
+++ b/ios/TestApp/README.md
@@ -10,7 +10,7 @@ To quickly test our framework in Cocoapods, simply run
 pod install
 ```
 
-This will pull the latest version of `LibTorch` from Cocoapods.
+This will pull the latest version of `LibTorch` from Cocoapods. To run the app, you need to have your model copied to the project as well as a `config.json` file, which can be found in the benchmark folder.
 
 ### Circle CI and Fastlane
 

--- a/ios/TestApp/TestApp/ViewController.mm
+++ b/ios/TestApp/TestApp/ViewController.mm
@@ -16,6 +16,10 @@
   NSError* err;
   NSData* configData = [NSData
       dataWithContentsOfFile:[[NSBundle mainBundle] pathForResource:@"config" ofType:@"json"]];
+  if (!configData) {
+    NSLog(@"Config.json not found!");
+    return;
+  }
   NSDictionary* config = [NSJSONSerialization JSONObjectWithData:configData
                                                          options:NSJSONReadingAllowFragments
                                                            error:&err];


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#29247 [iOS] Fix TestApp**

### Summary

If you run the TestApp using Cocoapods, you'll likely run into an error due to the lack of `config.json` in the main bundle. This PR fixes this crash and updates the README as well.

### Test Plan

- Don't break CIs

Differential Revision: [D18339047](https://our.internmc.facebook.com/intern/diff/D18339047)