### PR TITLE
Removed the observer from the benchmarks

### DIFF
--- a/benchmarks/operator_benchmark/pt/qactivation_test.py
+++ b/benchmarks/operator_benchmark/pt/qactivation_test.py
@@ -42,24 +42,9 @@ class _ActivationBenchmarkBase(op_bench.TorchBenchmarkBase):
     r"""Base class for all the activations."""
     def setup(self, dims, permute_dims, dtype):
         # Input dimensions
-        f_input = (torch.rand(*dims) - 0.5) * 1e6
-
-        # Get quantization paramerters and quantize
-        if dtype in (torch.qint8, torch.quint8):
-            observer = tq.MinMaxObserver(dtype=dtype,
-                                         qscheme=torch.per_tensor_affine,
-                                         reduce_range=False)
-            observer.forward(f_input)
-            scale, zero_point = observer.calculate_qparams()
-            scale, zero_point = scale.item(), zero_point.item()
-        else:
-            zero_point = 0
-            qinfo = torch.iinfo(dtype)
-            fmin, fmax = f_input.min().item(), f_input.max().item()
-            if fmax == fmin:
-                scale = 1.0
-            else:
-                scale = (fmax - fmin) / (qinfo.max - qinfo.min)
+        f_input = (torch.rand(*dims) - 0.5) * 256
+        scale = 1.0
+        zero_point = 0
 
         # Quantize the tensor
         self.q_input = torch.quantize_per_tensor(f_input, scale=scale,

--- a/benchmarks/operator_benchmark/pt/qpool_test.py
+++ b/benchmarks/operator_benchmark/pt/qpool_test.py
@@ -4,7 +4,6 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import torch
-import torch.quantization as tq
 
 import operator_benchmark as op_bench
 

--- a/benchmarks/operator_benchmark/pt/qpool_test.py
+++ b/benchmarks/operator_benchmark/pt/qpool_test.py
@@ -57,26 +57,13 @@ class QMaxPool2dBenchmark(op_bench.TorchBenchmarkBase):
 
         # Input dimensions
         if N == 0:
-            f_input = (torch.rand(C, H, W) - 0.5) * 1e6
+            f_input = (torch.rand(C, H, W) - 0.5) * 256
         else:
-            f_input = (torch.rand(N, C, H, W) - 0.5) * 1e6
+            f_input = (torch.rand(N, C, H, W) - 0.5) * 256
 
-        # Get quantization paramerters and quantize
-        if dtype in (torch.qint8, torch.quint8):
-            observer = tq.MinMaxObserver(dtype=dtype,
-                                         qscheme=torch.per_tensor_affine,
-                                         reduce_range=False)
-            observer.forward(f_input)
-            scale, zero_point = observer.calculate_qparams()
-            scale, zero_point = scale.item(), zero_point.item()
-        else:
-            zero_point = 0
-            qinfo = torch.iinfo(dtype)
-            fmin, fmax = f_input.min().item(), f_input.max().item()
-            if fmax == fmin:
-                scale = 1.0
-            else:
-                scale = (fmax - fmin) / (qinfo.max - qinfo.min)
+        scale = 1.0
+        zero_point = 0
+
         # Quantize the tensor
         self.q_input = torch.quantize_per_tensor(f_input, scale=scale,
                                                  zero_point=zero_point,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #29274 qadaptive_avgpool2d benchmarking
* #29268 qavgpool benchmarking
* #29259 Adding longer tests for relu
* **#29258 Removed the observer from the benchmarks**
* #29257 Adding short tests
* #29250 qpool benchmarking
* #29183 qrelu6 benchmarking
* #29182 Creating a base benchmarking class for activations.

Differential Revision: [D18341544](https://our.internmc.facebook.com/intern/diff/D18341544)