### PR TITLE
[REMOVED]

### DIFF
--- a/test/cpp/api/functional.cpp
+++ b/test/cpp/api/functional.cpp
@@ -12,7 +12,7 @@ struct FunctionalTest : torch::test::SeedingFixture {};
 
 TEST_F(FunctionalTest, MaxPool1d) {
   auto x = torch::ones({1, 1, 5});
-  auto y = F::max_pool1d(x, MaxPool1dOptions(3).stride(2));
+  auto y = F::max_pool1d(x, F::MaxPool1dFuncOptions(3).stride(2));
 
   ASSERT_EQ(y.ndimension(), 3);
   ASSERT_TRUE(torch::allclose(y, torch::ones({1, 1, 2})));
@@ -21,7 +21,7 @@ TEST_F(FunctionalTest, MaxPool1d) {
 
 TEST_F(FunctionalTest, MaxPool2d) {
   auto x = torch::ones({2, 5, 5});
-  auto y = F::max_pool2d(x, MaxPool2dOptions(3).stride(2));
+  auto y = F::max_pool2d(x, F::MaxPool2dFuncOptions(3).stride(2));
 
   ASSERT_EQ(y.ndimension(), 3);
   ASSERT_TRUE(torch::allclose(y, torch::ones({2, 2, 2})));
@@ -30,7 +30,7 @@ TEST_F(FunctionalTest, MaxPool2d) {
 
 TEST_F(FunctionalTest, MaxPool3d) {
   auto x = torch::ones({2, 5, 5, 5});
-  auto y = F::max_pool3d(x, MaxPool3dOptions(3).stride(2));
+  auto y = F::max_pool3d(x, F::MaxPool3dFuncOptions(3).stride(2));
 
   ASSERT_EQ(y.ndimension(), 4);
   ASSERT_TRUE(torch::allclose(y, torch::ones({2, 2, 2, 2})));
@@ -39,7 +39,7 @@ TEST_F(FunctionalTest, MaxPool3d) {
 
 TEST_F(FunctionalTest, AvgPool1d) {
   auto x = torch::ones({1, 1, 5});
-  auto y = F::avg_pool1d(x, AvgPool1dOptions(3).stride(2));
+  auto y = F::avg_pool1d(x, F::AvgPool1dFuncOptions(3).stride(2));
 
   ASSERT_EQ(y.ndimension(), 3);
   ASSERT_TRUE(torch::allclose(y, torch::ones({1, 1, 2})));
@@ -48,7 +48,7 @@ TEST_F(FunctionalTest, AvgPool1d) {
 
 TEST_F(FunctionalTest, AvgPool2d) {
   auto x = torch::ones({2, 5, 5});
-  auto y = F::avg_pool2d(x, AvgPool2dOptions(3).stride(2));
+  auto y = F::avg_pool2d(x, F::AvgPool2dFuncOptions(3).stride(2));
 
   ASSERT_EQ(y.ndimension(), 3);
   ASSERT_TRUE(torch::allclose(y, torch::ones({2, 2, 2})));
@@ -57,7 +57,7 @@ TEST_F(FunctionalTest, AvgPool2d) {
 
 TEST_F(FunctionalTest, AvgPool3d) {
   auto x = torch::ones({2, 5, 5, 5});
-  auto y = F::avg_pool3d(x, AvgPool3dOptions(3).stride(2));
+  auto y = F::avg_pool3d(x, F::AvgPool3dFuncOptions(3).stride(2));
 
   ASSERT_EQ(y.ndimension(), 4);
   ASSERT_TRUE(torch::allclose(y, torch::ones({2, 2, 2, 2})));
@@ -70,7 +70,7 @@ TEST_F(FunctionalTest, LPPool1d) {
   int kernel_size = 3;
 
   auto x = torch::ones({1, 1, 5});
-  auto y = F::lp_pool1d(x, LPPool1dOptions(norm_type, kernel_size).stride(stride));
+  auto y = F::lp_pool1d(x, F::LPPool1dFuncOptions(norm_type, kernel_size).stride(stride));
   auto expected = (torch::pow(torch::tensor({{{1, 1}}}, torch::kFloat), norm_type) * kernel_size).pow(1. / norm_type);
 
   ASSERT_EQ(y.ndimension(), 3);
@@ -84,7 +84,7 @@ TEST_F(FunctionalTest, LPPool2d) {
   std::vector<int64_t> kernel_size({2, 3});
 
   auto x = torch::ones({1, 2, 5});
-  auto y = F::lp_pool2d(x, LPPool2dOptions(norm_type, kernel_size).stride(stride));
+  auto y = F::lp_pool2d(x, F::LPPool2dFuncOptions(norm_type, kernel_size).stride(stride));
   auto expected = (torch::pow(torch::tensor({{{1, 1}}}, torch::kFloat), norm_type) * (kernel_size[0] * kernel_size[1])).pow(1. / norm_type);
 
   ASSERT_EQ(y.ndimension(), 3);
@@ -96,7 +96,7 @@ TEST_F(FunctionalTest, CosineSimilarity) {
   auto input1 = torch::tensor({{1, 2, 3}, {4, 5, 6}}, torch::kFloat);
   auto input2 = torch::tensor({{1, 8, 3}, {2, 1, 6}}, torch::kFloat);
   auto output =
-      F::cosine_similarity(input1, input2, CosineSimilarityOptions().dim(1));
+      F::cosine_similarity(input1, input2, F::CosineSimilarityFuncOptions().dim(1));
   auto expected = torch::tensor({0.8078, 0.8721}, torch::kFloat);
   ASSERT_TRUE(output.allclose(expected, 1e-04));
 }
@@ -168,7 +168,7 @@ TEST_F(FunctionalTest, MultiLabelSoftMarginLossWeightedNoReduction) {
   auto input = torch::tensor({{0., 2., 2., 0.}, {2., 1., 0., 1.}}, torch::dtype(torch::kFloat).requires_grad(true));
   auto target = torch::tensor({{0., 0., 1., 0.}, {1., 0., 1., 1.}}, torch::kFloat);
   auto weight = torch::tensor({0.1, 0.6, 0.4, 0.8}, torch::kFloat);
-  auto options = MultiLabelSoftMarginLossOptions().reduction(torch::kNone).weight(weight);
+  auto options = F::MultiLabelSoftMarginLossFuncOptions().reduction(torch::kNone).weight(weight);
   auto output =
       F::multilabel_soft_margin_loss(input, target, options);
   auto expected = torch::tensor({0.4876902, 0.3321295}, torch::kFloat);
@@ -183,7 +183,7 @@ TEST_F(FunctionalTest, PairwiseDistance) {
   auto input1 = torch::tensor({{1, 2, 3}, {4, 5, 6}}, torch::kFloat);
   auto input2 = torch::tensor({{1, 8, 3}, {2, 1, 6}}, torch::kFloat);
   auto output =
-      F::pairwise_distance(input1, input2, PairwiseDistanceOptions(1));
+      F::pairwise_distance(input1, input2, F::PairwiseDistanceFuncOptions().p(1));
   auto expected = torch::tensor({6, 6}, torch::kFloat);
   ASSERT_TRUE(output.allclose(expected));
 }
@@ -205,7 +205,7 @@ TEST_F(FunctionalTest, PDist) {
 
 TEST_F(FunctionalTest, AdaptiveMaxPool1d) {
   auto x = torch::ones({1, 1, 5});
-  auto y = F::adaptive_max_pool1d(x, AdaptiveMaxPool1dOptions(3));
+  auto y = F::adaptive_max_pool1d(x, F::AdaptiveMaxPool1dFuncOptions(3));
 
   ASSERT_EQ(y.ndimension(), 3);
   ASSERT_TRUE(torch::allclose(y, torch::ones({1, 1, 3})));
@@ -214,7 +214,7 @@ TEST_F(FunctionalTest, AdaptiveMaxPool1d) {
 
 TEST_F(FunctionalTest, AdaptiveMaxPool2d) {
   auto x = torch::ones({2, 5, 5});
-  auto y = F::adaptive_max_pool2d(x, AdaptiveMaxPool2dOptions(3));
+  auto y = F::adaptive_max_pool2d(x, F::AdaptiveMaxPool2dFuncOptions(3));
 
   ASSERT_EQ(y.ndimension(), 3);
   ASSERT_TRUE(torch::allclose(y, torch::ones({2, 3, 3})));
@@ -223,7 +223,7 @@ TEST_F(FunctionalTest, AdaptiveMaxPool2d) {
 
 TEST_F(FunctionalTest, AdaptiveMaxPool3d) {
   auto x = torch::ones({2, 5, 5, 5});
-  auto y = F::adaptive_max_pool3d(x, AdaptiveMaxPool3dOptions(3));
+  auto y = F::adaptive_max_pool3d(x, F::AdaptiveMaxPool3dFuncOptions(3));
 
   ASSERT_EQ(y.ndimension(), 4);
   ASSERT_TRUE(torch::allclose(y, torch::ones({2, 3, 3, 3})));
@@ -232,7 +232,7 @@ TEST_F(FunctionalTest, AdaptiveMaxPool3d) {
 
 TEST_F(FunctionalTest, AdaptiveAvgPool1d) {
   auto x = torch::ones({1, 1, 5});
-  auto y = F::adaptive_avg_pool1d(x, AdaptiveAvgPool1dOptions(3));
+  auto y = F::adaptive_avg_pool1d(x, F::AdaptiveAvgPool1dFuncOptions(3));
 
   ASSERT_EQ(y.ndimension(), 3);
   ASSERT_TRUE(torch::allclose(y, torch::ones({1, 1, 3})));
@@ -241,7 +241,7 @@ TEST_F(FunctionalTest, AdaptiveAvgPool1d) {
 
 TEST_F(FunctionalTest, AdaptiveAvgPool2d) {
   auto x = torch::ones({2, 5, 5});
-  auto y = F::adaptive_avg_pool2d(x, AdaptiveAvgPool2dOptions(3));
+  auto y = F::adaptive_avg_pool2d(x, F::AdaptiveAvgPool2dFuncOptions(3));
 
   ASSERT_EQ(y.ndimension(), 3);
   ASSERT_TRUE(torch::allclose(y, torch::ones({2, 3, 3})));
@@ -250,7 +250,7 @@ TEST_F(FunctionalTest, AdaptiveAvgPool2d) {
 
 TEST_F(FunctionalTest, AdaptiveAvgPool3d) {
   auto x = torch::ones({2, 5, 5, 5});
-  auto y = F::adaptive_avg_pool3d(x, AdaptiveAvgPool3dOptions(3));
+  auto y = F::adaptive_avg_pool3d(x, F::AdaptiveAvgPool3dFuncOptions(3));
 
   ASSERT_EQ(y.ndimension(), 4);
   ASSERT_TRUE(torch::allclose(y, torch::ones({2, 3, 3, 3})));
@@ -306,7 +306,7 @@ TEST_F(FunctionalTest, HingeEmbeddingLoss) {
   auto input = torch::tensor({{2, 22, 4}, {20, 10, 0}}, torch::kFloat);
   auto target = torch::tensor({{2, 6, 4}, {1, 10, 0}}, torch::kFloat);
   auto output = F::hinge_embedding_loss(
-      input, target, HingeEmbeddingLossOptions().margin(2));
+      input, target, F::HingeEmbeddingLossFuncOptions().margin(2));
   auto expected = torch::tensor({10}, torch::kFloat);
 
   ASSERT_TRUE(output.allclose(expected));
@@ -321,7 +321,7 @@ TEST_F(FunctionalTest, GridSample) {
   }}, torch::kFloat);
 
   // bilinear, zeros, true
-  auto options = GridSampleOptions()
+  auto options = F::GridSampleFuncOptions()
                     .mode("bilinear")
                     .padding_mode("zeros")
                     .align_corners(true);
@@ -331,7 +331,7 @@ TEST_F(FunctionalTest, GridSample) {
   ASSERT_TRUE(output.allclose(expected));
 
   // bilinear, zeros, false
-  options = GridSampleOptions()
+  options = F::GridSampleFuncOptions()
                 .mode("bilinear")
                 .padding_mode("zeros")
                 .align_corners(false);
@@ -346,7 +346,7 @@ TEST_F(FunctionalTest, GridSample) {
   ASSERT_TRUE(output.allclose(expected));
 
   // nearest, zeros, true
-  options = GridSampleOptions()
+  options = F::GridSampleFuncOptions()
                 .mode("nearest")
                 .padding_mode("zeros")
                 .align_corners(true);
@@ -356,7 +356,7 @@ TEST_F(FunctionalTest, GridSample) {
   ASSERT_TRUE(output.allclose(expected));
 
   // bilinear, border, true
-  options = GridSampleOptions()
+  options = F::GridSampleFuncOptions()
                 .mode("bilinear")
                 .padding_mode("border")
                 .align_corners(true);
@@ -366,7 +366,7 @@ TEST_F(FunctionalTest, GridSample) {
   ASSERT_TRUE(output.allclose(expected));
 
   // bilinear, reflection, true
-  options = GridSampleOptions()
+  options = F::GridSampleFuncOptions()
                 .mode("bilinear")
                 .padding_mode("reflection")
                 .align_corners(true);
@@ -484,7 +484,7 @@ TEST_F(FunctionalTest, MultiMarginLoss) {
     torch::dtype(torch::kFloat).requires_grad(true));
   auto target = torch::tensor({2, 1, 0}, torch::kLong);
   auto output = F::multi_margin_loss(
-    input, target, MultiMarginLossOptions().margin(2).weight(weight));
+    input, target, F::MultiMarginLossFuncOptions().margin(2).weight(weight));
   auto expected = torch::tensor({0.305556}, torch::kFloat);
 
   ASSERT_TRUE(output.allclose(expected, 1e-04));
@@ -495,7 +495,7 @@ TEST_F(FunctionalTest, CosineEmbeddingLoss) {
   auto input2 = torch::tensor({{2, 3, 5}, {9, 12, 0}});
   auto target = torch::tensor({1, -1});
   auto output = F::cosine_embedding_loss(
-      input1, input2, target, CosineEmbeddingLossOptions().margin(0.5));
+      input1, input2, target, F::CosineEmbeddingLossFuncOptions().margin(0.5));
   auto expected = torch::tensor({0.1004}, torch::kFloat);
 
   ASSERT_TRUE(output.allclose(expected, 1e-4));
@@ -531,7 +531,7 @@ TEST_F(FunctionalTest, TripletMarginLoss) {
   auto positive = torch::tensor({{2., 2.}}, torch::kFloat);
   auto negative = torch::tensor({{0., 0.}}, torch::kFloat);
   auto output = F::triplet_margin_loss(
-      anchor, positive, negative, TripletMarginLossOptions().margin(1.0));
+      anchor, positive, negative, F::TripletMarginLossFuncOptions().margin(1.0));
   auto expected = torch::tensor({0.}, torch::kFloat);
 
   ASSERT_TRUE(output.allclose(expected, 1e-04));
@@ -540,7 +540,7 @@ TEST_F(FunctionalTest, TripletMarginLoss) {
 TEST_F(FunctionalTest, MaxUnpool1d) {
   auto x = torch::tensor({{{2, 4, 5}}}, torch::dtype(torch::kFloat).requires_grad(true));
   auto indices = torch::tensor({{{1, 3, 4}}}, torch::kLong);
-  auto y = F::max_unpool1d(x, indices, MaxUnpool1dOptions(3));
+  auto y = F::max_unpool1d(x, indices, F::MaxUnpool1dFuncOptions(3));
 
   ASSERT_EQ(y.ndimension(), 3);
   ASSERT_TRUE(torch::allclose(
@@ -550,7 +550,7 @@ TEST_F(FunctionalTest, MaxUnpool1d) {
   x = torch::tensor({{{2, 4, 5}}}, torch::dtype(torch::kFloat).requires_grad(true));
   indices = torch::tensor({{{1, 3, 4}}}, torch::kLong);
   y = F::max_unpool1d(
-      x, indices, MaxUnpool1dOptions(3), std::vector<int64_t>({1, 1, 9}));
+      x, indices, F::MaxUnpool1dFuncOptions(3), std::vector<int64_t>({1, 1, 9}));
 
   ASSERT_EQ(y.ndimension(), 3);
   ASSERT_TRUE(torch::allclose(
@@ -559,7 +559,7 @@ TEST_F(FunctionalTest, MaxUnpool1d) {
 
   x = torch::tensor({{{2, 4, 5}}}, torch::dtype(torch::kFloat).requires_grad(true));
   indices = torch::tensor({{{1, 3, 4}}}, torch::kLong);
-  y = F::max_unpool1d(x, indices, MaxUnpool1dOptions(3).stride(2).padding(1));
+  y = F::max_unpool1d(x, indices, F::MaxUnpool1dFuncOptions(3).stride(2).padding(1));
 
   ASSERT_EQ(y.ndimension(), 3);
   ASSERT_TRUE(
@@ -582,7 +582,7 @@ TEST_F(FunctionalTest, MaxUnpool2d) {
   {{{31, 33, 34},
     {41, 43, 44},
     {46, 48, 49}}}}, torch::dtype(torch::kFloat).requires_grad(true));
-  auto y = F::max_unpool2d(x, indices, MaxUnpool2dOptions(3).stride(2).padding(1));
+  auto y = F::max_unpool2d(x, indices, F::MaxUnpool2dFuncOptions(3).stride(2).padding(1));
 
   ASSERT_EQ(y.dim(), 4);
   ASSERT_TRUE(torch::allclose(y, torch::tensor(
@@ -607,7 +607,7 @@ TEST_F(FunctionalTest, ELU) {
       x.resize_({size, size, size});
       auto y_exp = torch::max(torch::zeros_like(x), x) +
                 torch::min(torch::zeros_like(x), alpha * (torch::exp(x) - 1.0));
-      auto y = F::elu(x, ELUOptions().alpha(alpha).inplace(inplace));
+      auto y = F::elu(x, F::ELUFuncOptions().alpha(alpha).inplace(inplace));
 
       ASSERT_EQ(y.ndimension(), 3);
       ASSERT_EQ(y.sizes(), std::vector<int64_t>({size, size, size}));
@@ -658,7 +658,7 @@ TEST_F(FunctionalTest, Hardshrink) {
   for (const auto lambda : {-4.2, -1.0, -0.42, 0.0, 0.42, 1.0, 4.2, 42.42}) {
     auto x = torch::linspace(-10.0, 10.0, size * size * size);
     x.resize_({size, size, size}).set_requires_grad(true);
-    auto y = F::hardshrink(x, HardshrinkOptions().lambda(lambda));
+    auto y = F::hardshrink(x, F::HardshrinkFuncOptions().lambda(lambda));
     torch::Tensor s = y.sum();
 
     s.backward();
@@ -724,7 +724,7 @@ TEST_F(FunctionalTest, Hardtanh) {
         auto y_exp = (x < min_val) * min_val +
                      ((x >= min_val) * (x <= max_val)) * x +
                      (x > max_val) * max_val;
-        auto y = F::hardtanh(x,HardtanhOptions().min_val(min_val)
+        auto y = F::hardtanh(x, F::HardtanhFuncOptions().min_val(min_val)
           .max_val(max_val).inplace(inplace));
 
         ASSERT_EQ(y.ndimension(), 3);
@@ -745,7 +745,7 @@ TEST_F(FunctionalTest, LeakyReLU) {
       auto x = torch::linspace(-10.0, 10.0, size * size * size);
       x.resize_({size, size, size});
       auto y_exp = (x < 0) * x * negative_slope + (x >= 0) * x;
-      auto y = F::leaky_relu(x, LeakyReLUOptions()
+      auto y = F::leaky_relu(x, F::LeakyReLUFuncOptions()
         .negative_slope(negative_slope).inplace(inplace));
 
       ASSERT_EQ(y.ndimension(), 3);
@@ -790,7 +790,7 @@ TEST_F(FunctionalTest, GumbelSoftmax) {
   for(const auto dim: {0, -1}) {
     auto logits = torch::randn({5});
     int expected_count = 1;
-    auto y_draw = F::gumbel_softmax(logits, GumbelSoftmaxOptions().hard(true).dim(dim));
+    auto y_draw = F::gumbel_softmax(logits, F::GumbelSoftmaxFuncOptions().hard(true).dim(dim));
 
     // All values positive
     ASSERT_GE(y_draw.min().item<int>(), 0);
@@ -803,7 +803,7 @@ TEST_F(FunctionalTest, GumbelSoftmax) {
   { // Test 3: 2D shape, 1 dim
     auto logits = torch::randn({5, 4});
     int expected_count = 5;
-    auto y_draw = F::gumbel_softmax(logits, GumbelSoftmaxOptions().hard(true).dim(1));
+    auto y_draw = F::gumbel_softmax(logits, F::GumbelSoftmaxFuncOptions().hard(true).dim(1));
 
     // All values positive
     ASSERT_GE(y_draw.min().item<int>(), 0);
@@ -819,7 +819,7 @@ TEST_F(FunctionalTest, GumbelSoftmax) {
   for(auto i=0; i<2; i++) {
     auto logits = torch::randn({5, 4, 3});
     int expected_count = expected[i];
-    auto y_draw = F::gumbel_softmax(logits, GumbelSoftmaxOptions().hard(true).dim(dims[i]));
+    auto y_draw = F::gumbel_softmax(logits, F::GumbelSoftmaxFuncOptions().hard(true).dim(dims[i]));
 
     // All values positive
     ASSERT_GE(y_draw.min().item<int>(), 0);
@@ -839,7 +839,7 @@ TEST_F(FunctionalTest, GumbelSoftmax) {
     auto counts = torch::zeros_like(logits);
     torch::Tensor y_draw;
     for (auto i=0; i<num_draws; i++) {
-        y_draw = F::gumbel_softmax(logits, GumbelSoftmaxOptions().hard(true));
+        y_draw = F::gumbel_softmax(logits, F::GumbelSoftmaxFuncOptions().hard(true));
         counts += y_draw;
     }
 
@@ -902,14 +902,14 @@ TEST_F(FunctionalTest, PReLU) {
 
 TEST_F(FunctionalTest, LayerNorm) {
   const auto input = torch::randn({2, 2});
-  auto y = F::layer_norm(input, LayerNormOptions({2, 2}).eps(2e-5));
+  auto y = F::layer_norm(input, F::LayerNormFuncOptions({2, 2}).eps(2e-5));
   auto y_exp = torch::layer_norm(input, {2, 2}, torch::Tensor(), torch::Tensor(), 2e-5);
   ASSERT_TRUE(torch::allclose(y, y_exp));
 }
 
 TEST_F(FunctionalTest, LocalResponseNorm) {
   const auto x = torch::arange(100, 118).resize_({3, 3, 2});
-  const auto y = F::local_response_norm(x, LocalResponseNormOptions(2));
+  const auto y = F::local_response_norm(x, F::LocalResponseNormFuncOptions(2));
   ASSERT_EQ(y.ndimension(), 3);
   ASSERT_EQ(y.sizes(), torch::IntArrayRef({3, 3, 2}));
   const auto y_exp = torch::tensor(
@@ -996,7 +996,7 @@ TEST_F(FunctionalTest, Normalize) {
       {0.14285715, 0.17142858, 0.2000, 0.22857143, 0.25714287}}}, torch::requires_grad().dtype(torch::kFloat));
   { // Test #1
     auto input = torch::tensor({{{0, 1, 2, 3, 4}, {5, 6, 7, 8, 9}}}, torch::dtype(torch::kFloat).requires_grad(true));
-    auto norm = F::normalize(input, NormalizeOptions().p(1).dim(-1));
+    auto norm = F::normalize(input, F::NormalizeFuncOptions().p(1).dim(-1));
 
     // reduce to scalar to call .backward()
     torch::Tensor s = norm.sum();
@@ -1011,7 +1011,7 @@ TEST_F(FunctionalTest, Normalize) {
     auto input = torch::tensor({{{0, 1, 2, 3, 4}, {5, 6, 7, 8, 9}}}, torch::dtype(torch::kFloat));
     auto output = torch::randn({1,2,5}, torch::dtype(torch::kFloat));
     // non-null output argument
-    F::normalize(input, NormalizeOptions().p(1).dim(-1), output);
+    F::normalize(input, F::NormalizeFuncOptions().p(1).dim(-1), output);
     // default options
     F::normalize(input);
 
@@ -1020,7 +1020,7 @@ TEST_F(FunctionalTest, Normalize) {
 
   { // Test #3 Base case of scalar tensor
     auto input = torch::randn({}, torch::requires_grad());
-    torch::Tensor norm = F::normalize(input, NormalizeOptions().p(1).dim(-1));
+    torch::Tensor norm = F::normalize(input, F::NormalizeFuncOptions().p(1).dim(-1));
     norm.backward();
 
     ASSERT_EQ(input.grad().numel(), 1);
@@ -1033,7 +1033,7 @@ TEST_F(FunctionalTest, ReLU) {
     auto x = torch::linspace(-10.0, 10.0, size * size * size);
     x.resize_({size, size, size});
     auto y_exp = (x < 0) * 0 + (x >= 0) * x;
-    auto y = F::relu(x, ReLUOptions().inplace(inplace));
+    auto y = F::relu(x, F::ReLUFuncOptions().inplace(inplace));
 
     ASSERT_EQ(y.ndimension(), 3);
     ASSERT_EQ(y.sizes(), std::vector<int64_t>({size, size, size}));
@@ -1071,7 +1071,7 @@ TEST_F(FunctionalTest, ReLU6) {
     auto x = torch::linspace(-10.0, 10.0, size * size * size);
     x.resize_({size, size, size});
     auto y_exp = (x < 0) * 0 + ((x >= 0) * (x <= 6)) * x + (x > 6) * 6;
-    auto y = F::relu6(x, ReLU6Options().inplace(inplace));
+    auto y = F::relu6(x, F::ReLU6FuncOptions().inplace(inplace));
 
     ASSERT_EQ(y.ndimension(), 3);
     ASSERT_EQ(y.sizes(), std::vector<int64_t>({size, size, size}));
@@ -1111,7 +1111,7 @@ TEST_F(FunctionalTest, RReLU) {
         auto x = torch::linspace(-10.0, 10.0, size * size * size);
         x.resize_({size, size, size});
         auto x_copy = x.clone();
-        auto y = F::rrelu(x, RReLUOptions().lower(lower)
+        auto y = F::rrelu(x, F::RReLUFuncOptions().lower(lower)
           .upper(upper).inplace(inplace));
         auto z = ((x_copy >= 0) * (x_copy == y) +
           (x_copy < 0) * (y >= x_copy * upper) * (y <= lower * x_copy)) * 1.0;
@@ -1151,7 +1151,7 @@ TEST_F(FunctionalTest, CELU) {
       x.resize_({size, size, size});
       auto y_exp = torch::max(torch::zeros_like(x), x) +
         torch::min(torch::zeros_like(x), alpha * (torch::exp(x / alpha) - 1.0));
-      auto y = F::celu(x, CELUOptions().alpha(alpha).inplace(inplace));
+      auto y = F::celu(x, F::CELUFuncOptions().alpha(alpha).inplace(inplace));
 
       ASSERT_EQ(y.ndimension(), 3);
       ASSERT_EQ(y.sizes(), std::vector<int64_t>({size, size, size}));
@@ -1205,7 +1205,7 @@ TEST_F(FunctionalTest, Softplus) {
         (x <= threshold) * torch::log(1 + torch::exp(x * beta)) / beta +
         (x > threshold) * x;
       auto y = F::softplus(x,
-        SoftplusOptions().beta(beta).threshold(threshold));
+        F::SoftplusFuncOptions().beta(beta).threshold(threshold));
 
       ASSERT_EQ(y.ndimension(), 3);
       ASSERT_EQ(y.sizes(), std::vector<int64_t>({size, size, size}));
@@ -1232,7 +1232,7 @@ TEST_F(FunctionalTest, SoftplusDefaultOptions) {
 
 TEST_F(FunctionalTest, Fold) {
   auto input = torch::ones({1, 3 * 2 * 2, 2}, torch::kDouble);
-  auto output = F::fold(input, FoldOptions({3, 2}, {2, 2}));
+  auto output = F::fold(input, F::FoldFuncOptions({3, 2}, {2, 2}));
   auto expected = torch::tensor(
       {{{{1.0, 1.0}, {2.0, 2.0}, {1.0, 1.0}},
         {{1.0, 1.0}, {2.0, 2.0}, {1.0, 1.0}},
@@ -1245,7 +1245,7 @@ TEST_F(FunctionalTest, Fold) {
 
 TEST_F(FunctionalTest, Unfold) {
   auto input = torch::arange(0, 12, torch::kDouble).view({1, 2, 2, 3});
-  auto output = F::unfold(input, UnfoldOptions({2, 2}).padding(1).stride(2));
+  auto output = F::unfold(input, F::UnfoldFuncOptions({2, 2}).padding(1).stride(2));
   auto expected = torch::tensor(
       {{{0.0, 0.0, 0.0, 4.0},
         {0.0, 0.0, 3.0, 5.0},
@@ -1320,7 +1320,7 @@ TEST_F(FunctionalTest, Threshold) {
         x.resize_({size, size, size});
         auto y_exp = (x <= threshold) * value + (x > threshold) * x;
         auto y = F::threshold(x,
-          ThresholdOptions(threshold, value).inplace(inplace));
+          F::ThresholdFuncOptions(threshold, value).inplace(inplace));
 
         ASSERT_EQ(y.ndimension(), 3);
         ASSERT_EQ(y.sizes(), std::vector<int64_t>({size, size, size}));
@@ -1345,7 +1345,7 @@ TEST_F(FunctionalTest, BatchNorm1d) {
   auto bias = torch::zeros({num_features});
   auto output = F::batch_norm(
     input, mean, variance,
-    BatchNormOptions().weight(weight).bias(bias).momentum(momentum).eps(eps),
+    F::BatchNormFuncOptions().weight(weight).bias(bias).momentum(momentum).eps(eps),
     /*training=*/false);
   auto expected = (input - mean) / torch::sqrt(variance + eps);
   ASSERT_TRUE(output.allclose(expected));
@@ -1372,7 +1372,7 @@ TEST_F(FunctionalTest, BatchNorm2d) {
   auto bias = torch::zeros({num_features});
   auto output = F::batch_norm(
     input, mean, variance,
-    BatchNormOptions().weight(weight).bias(bias).momentum(momentum).eps(eps),
+    F::BatchNormFuncOptions().weight(weight).bias(bias).momentum(momentum).eps(eps),
     /*training=*/false);
   auto expected = torch::transpose((torch::transpose(input, 1, 3) - mean) / torch::sqrt(variance + eps), 1, 3);
   ASSERT_TRUE(output.allclose(expected));
@@ -1402,7 +1402,7 @@ TEST_F(FunctionalTest, BatchNorm3d) {
   auto bias = torch::zeros({num_features});
   auto output = F::batch_norm(
     input, mean, variance,
-    BatchNormOptions().weight(weight).bias(bias).momentum(momentum).eps(eps),
+    F::BatchNormFuncOptions().weight(weight).bias(bias).momentum(momentum).eps(eps),
     /*training=*/false);
   auto expected = torch::transpose((torch::transpose(input, 1, 4) - mean) / torch::sqrt(variance + eps), 1, 4);
   ASSERT_TRUE(output.allclose(expected));
@@ -1424,7 +1424,7 @@ TEST_F(FunctionalTest, Interpolate) {
   {
     // 1D interpolation
     auto input = torch::ones({1, 1, 2});
-    auto options = InterpolateOptions()
+    auto options = F::InterpolateFuncOptions()
                        .size({4})
                        .mode(torch::kNearest);
     auto output = F::interpolate(input, options);
@@ -1438,7 +1438,7 @@ TEST_F(FunctionalTest, Interpolate) {
       // test float scale factor up & down sampling
       for (const auto scale_factor : {0.5, 1.5, 2.0}) {
         auto input = torch::ones({1, 1, 2, 2});
-        auto options = InterpolateOptions()
+        auto options = F::InterpolateFuncOptions()
                            .scale_factor({scale_factor, scale_factor})
                            .mode(torch::kBilinear)
                            .align_corners(align_corners);
@@ -1457,7 +1457,7 @@ TEST_F(FunctionalTest, Interpolate) {
       for (const auto scale_factor : {0.5, 1.5, 2.0}) {
         auto input = torch::ones({1, 1, 2, 2, 2});
         auto options =
-            InterpolateOptions()
+            F::InterpolateFuncOptions()
                 .scale_factor({scale_factor, scale_factor, scale_factor})
                 .mode(torch::kTrilinear)
                 .align_corners(align_corners);
@@ -1474,31 +1474,31 @@ TEST_F(FunctionalTest, Interpolate) {
   {
     auto input = torch::randn({3, 2, 2});
     ASSERT_THROWS_WITH(
-        F::interpolate(input[0], InterpolateOptions().size({4, 4})),
+        F::interpolate(input[0], F::InterpolateFuncOptions().size({4, 4})),
         "Input Error: Only 3D, 4D and 5D input Tensors supported (got 2D) "
         "for the modes: nearest | linear | bilinear | bicubic | trilinear (got kNearest)");
     ASSERT_THROWS_WITH(
         F::interpolate(
             torch::reshape(input, {1, 1, 1, 3, 2, 2}),
-            InterpolateOptions().size({1, 1, 1, 3, 4, 4})),
+            F::InterpolateFuncOptions().size({1, 1, 1, 3, 4, 4})),
         "Input Error: Only 3D, 4D and 5D input Tensors supported (got 6D) "
         "for the modes: nearest | linear | bilinear | bicubic | trilinear (got kNearest)");
     ASSERT_THROWS_WITH(
-        F::interpolate(input, InterpolateOptions()),
+        F::interpolate(input, F::InterpolateFuncOptions()),
         "either size or scale_factor should be defined");
     ASSERT_THROWS_WITH(
         F::interpolate(
             input,
-            InterpolateOptions().size({3, 4, 4}).scale_factor({0.5})),
+            F::InterpolateFuncOptions().size({3, 4, 4}).scale_factor({0.5})),
         "only one of size or scale_factor should be defined");
     ASSERT_THROWS_WITH(
-        F::interpolate(input, InterpolateOptions().scale_factor({3, 2})),
+        F::interpolate(input, F::InterpolateFuncOptions().scale_factor({3, 2})),
         "scale_factor shape must match input shape. "
         "Input is 1D, scale_factor size is 2");
     ASSERT_THROWS_WITH(
         F::interpolate(
             input,
-            InterpolateOptions()
+            F::InterpolateFuncOptions()
                 .mode(torch::kNearest)
                 .align_corners(true)),
         "align_corners option can only be set with the "
@@ -1509,7 +1509,7 @@ TEST_F(FunctionalTest, Interpolate) {
 TEST_F(FunctionalTest, Pad) {
   {
     auto input = torch::arange(6, torch::kDouble).reshape({1, 2, 3});
-    auto output = F::pad(input, PadOptions({1, 2}).mode(torch::kCircular));
+    auto output = F::pad(input, F::PadFuncOptions({1, 2}).mode(torch::kCircular));
     auto expected = torch::tensor({{{2., 0., 1., 2., 0., 1.},
                                     {5., 3., 4., 5., 3., 4.}}}, torch::kDouble);
     ASSERT_EQ(output.sizes(), std::vector<int64_t>({1, 2, 6}));
@@ -1517,7 +1517,7 @@ TEST_F(FunctionalTest, Pad) {
   }
   {
     auto input = torch::arange(9, torch::kDouble).reshape({1, 1, 3, 3});
-    auto output = F::pad(input, PadOptions({3, 3, 3, 1}).mode(torch::kCircular));
+    auto output = F::pad(input, F::PadFuncOptions({3, 3, 3, 1}).mode(torch::kCircular));
     auto expected = torch::tensor(
        {{{{0., 1., 2., 0., 1., 2., 0., 1., 2.},
           {3., 4., 5., 3., 4., 5., 3., 4., 5.},
@@ -1531,7 +1531,7 @@ TEST_F(FunctionalTest, Pad) {
   }
   {
     auto input = torch::arange(12, torch::kDouble).reshape({1, 1, 2, 2, 3});
-    auto output = F::pad(input, PadOptions({3, 3, 2, 1, 2, 2}).mode(torch::kCircular));
+    auto output = F::pad(input, F::PadFuncOptions({3, 3, 2, 1, 2, 2}).mode(torch::kCircular));
     auto expected = torch::tensor(
        {{{{{ 0.,  1.,  2.,  0.,  1.,  2.,  0.,  1.,  2.},
            { 3.,  4.,  5.,  3.,  4.,  5.,  3.,  4.,  5.},
@@ -1573,7 +1573,7 @@ TEST_F(FunctionalTest, Pad) {
   }
   {
     auto input = torch::arange(16, torch::kDouble).reshape({2, 2, 2, 2});
-    auto output = F::pad(input, PadOptions({1, 1, 1, 1}).mode(torch::kReflect));
+    auto output = F::pad(input, F::PadFuncOptions({1, 1, 1, 1}).mode(torch::kReflect));
     auto expected = torch::tensor(
        {{{{ 3.,  2.,  3.,  2.},
           { 1.,  0.,  1.,  0.},
@@ -1599,7 +1599,7 @@ TEST_F(FunctionalTest, Pad) {
   }
   {
     auto input = torch::arange(12, torch::kDouble).reshape({1, 1, 2, 2, 3});
-    auto output = F::pad(input, PadOptions({1, 2, 2, 1, 1, 2}).mode(torch::kReplicate));
+    auto output = F::pad(input, F::PadFuncOptions({1, 2, 2, 1, 1, 2}).mode(torch::kReplicate));
     auto expected = torch::tensor(
        {{{{{ 0.,  0.,  1.,  2.,  2.,  2.},
            { 0.,  0.,  1.,  2.,  2.,  2.},
@@ -1635,13 +1635,13 @@ TEST_F(FunctionalTest, Pad) {
   }
   {
     auto input = torch::ones({1, 1, 1, 1}, torch::kDouble);
-    auto output = F::pad(input, PadOptions({1, 1}).mode(torch::kConstant).value(0));
+    auto output = F::pad(input, F::PadFuncOptions({1, 1}).mode(torch::kConstant).value(0));
     ASSERT_EQ(output.sizes(), std::vector<int64_t>({1, 1, 1, 3}));
     auto expected = torch::tensor({{{{0., 1., 0.}}}}, torch::kDouble);
   }
   {
     auto input = torch::ones({1, 1, 1, 1}, torch::kDouble);
-    auto output = F::pad(input, PadOptions({1, 1}));
+    auto output = F::pad(input, F::PadFuncOptions({1, 1}));
     ASSERT_EQ(output.sizes(), std::vector<int64_t>({1, 1, 1, 3}));
     auto expected = torch::tensor({{{{0., 1., 0.}}}}, torch::kDouble);
   }
@@ -1688,7 +1688,7 @@ TEST_F(FunctionalTest, CTCLoss) {
         torch::randn({50, 3, 15}, torch::kDouble).log_softmax(2);
       const auto loss = F::ctc_loss(
         log_probs, targets, input_lengths, target_lengths,
-        CTCLossOptions().reduction(torch::kNone));
+        F::CTCLossFuncOptions().reduction(torch::kNone));
       ASSERT_TRUE(loss.ge(0).all().item<bool>());
       ASSERT_TRUE(torch::allclose(
         -log_probs.sum(0).slice(1, 0, 1).view_as(loss), loss));
@@ -1701,7 +1701,7 @@ TEST_F(FunctionalTest, CTCLoss) {
         torch::randn({50, 3, 15}, torch::kDouble).log_softmax(2);
       const auto loss = F::ctc_loss(
         log_probs, targets, input_lengths, target_lengths,
-        CTCLossOptions().reduction(torch::kNone));
+        F::CTCLossFuncOptions().reduction(torch::kNone));
       ASSERT_TRUE(loss.ge(0).all().item<bool>());
       ASSERT_TRUE(torch::allclose(
           -log_probs.sum(0)
@@ -1721,13 +1721,13 @@ TEST_F(FunctionalTest, PoissonNLLLoss) {
     F::poisson_nll_loss(input, target)));
   ASSERT_TRUE(torch::allclose(component_wise_loss,
     F::poisson_nll_loss(input, target,
-    PoissonNLLLossOptions().reduction(torch::kNone))));
+    F::PoissonNLLLossFuncOptions().reduction(torch::kNone))));
   ASSERT_TRUE(torch::allclose(torch::sum(component_wise_loss),
     F::poisson_nll_loss(input, target,
-    PoissonNLLLossOptions().reduction(torch::kSum))));
+    F::PoissonNLLLossFuncOptions().reduction(torch::kSum))));
   ASSERT_TRUE(torch::allclose(torch::mean(component_wise_loss),
     F::poisson_nll_loss(input, target,
-    PoissonNLLLossOptions().reduction(torch::kMean))));
+    F::PoissonNLLLossFuncOptions().reduction(torch::kMean))));
 }
 
 TEST_F(FunctionalTest, MarginRankingLoss) {
@@ -1747,7 +1747,7 @@ TEST_F(FunctionalTest, MarginRankingLoss) {
     const auto margin = 0.5;
     ASSERT_TRUE(torch::allclose(
       F::margin_ranking_loss(input1, input2, target,
-        MarginRankingLossOptions().margin(0.5).reduction(torch::kSum)
+        F::MarginRankingLossFuncOptions().margin(0.5).reduction(torch::kSum)
       ),
       (-target * (input1 - input2) + margin).clamp(0).sum()
     ));
@@ -1759,7 +1759,7 @@ TEST_F(FunctionalTest, MarginRankingLoss) {
     const auto margin = 0.5;
     ASSERT_TRUE(torch::allclose(
       F::margin_ranking_loss(input1, input2, target,
-        MarginRankingLossOptions().margin(0.5).reduction(torch::kMean)
+        F::MarginRankingLossFuncOptions().margin(0.5).reduction(torch::kMean)
       ),
       (-target * (input1 - input2) + margin).clamp(0).mean()
     ));

--- a/test/cpp/api/modules.cpp
+++ b/test/cpp/api/modules.cpp
@@ -1565,7 +1565,7 @@ TEST_F(ModulesTest, MultiLabelSoftMarginLossWeightedNoReduction) {
 }
 
 TEST_F(ModulesTest, PairwiseDistance) {
-  PairwiseDistance dist(PairwiseDistanceOptions(1));
+  PairwiseDistance dist(PairwiseDistanceOptions().p(1));
   auto input1 = torch::tensor({{1, 2, 3}, {4, 5, 6}}, torch::dtype(torch::kFloat).requires_grad(true));
   auto input2 = torch::tensor({{1, 8, 3}, {2, 1, 6}}, torch::dtype(torch::kFloat).requires_grad(true));
   auto output = dist->forward(input1, input2);
@@ -2871,7 +2871,7 @@ TEST_F(ModulesTest, PrettyPrintPairwiseDistance) {
       c10::str(PairwiseDistance()),
       "torch::nn::PairwiseDistance(p=2, eps=1e-06, keepdim=false)");
   ASSERT_EQ(
-      c10::str(PairwiseDistance(PairwiseDistanceOptions(3).eps(0.5).keepdim(true))),
+      c10::str(PairwiseDistance(PairwiseDistanceOptions().p(3).eps(0.5).keepdim(true))),
       "torch::nn::PairwiseDistance(p=3, eps=0.5, keepdim=true)");
 }
 

--- a/torch/csrc/api/include/torch/nn/functional/activation.h
+++ b/torch/csrc/api/include/torch/nn/functional/activation.h
@@ -7,7 +7,7 @@ namespace torch {
 namespace nn{
 namespace functional {
 
-inline Tensor elu(Tensor& input, const ELUOptions& options = {}) {
+inline Tensor elu(Tensor& input, const ELUFuncOptions& options = {}) {
   if (options.inplace()) {
     return torch::elu_(input, options.alpha());
   } else {
@@ -15,7 +15,7 @@ inline Tensor elu(Tensor& input, const ELUOptions& options = {}) {
   }
 }
 
-inline Tensor selu(Tensor& input, const SELUOptions& options = {}) {
+inline Tensor selu(Tensor& input, const SELUFuncOptions& options = {}) {
   if (options.inplace()) {
     return torch::selu_(input);
   } else {
@@ -24,11 +24,11 @@ inline Tensor selu(Tensor& input, const SELUOptions& options = {}) {
 }
 
 inline Tensor hardshrink(const Tensor& input,
-                         const HardshrinkOptions& options = {}) {
+                         const HardshrinkFuncOptions& options = {}) {
   return torch::hardshrink(input, options.lambda());
 }
 
-inline Tensor hardtanh(Tensor& input, const HardtanhOptions& options = {}) {
+inline Tensor hardtanh(Tensor& input, const HardtanhFuncOptions& options = {}) {
   if (options.inplace()) {
     return torch::hardtanh_(input, options.min_val(), options.max_val());
   } else {
@@ -36,7 +36,7 @@ inline Tensor hardtanh(Tensor& input, const HardtanhOptions& options = {}) {
   }
 }
 
-inline Tensor leaky_relu(Tensor& input, const LeakyReLUOptions& options = {}) {
+inline Tensor leaky_relu(Tensor& input, const LeakyReLUFuncOptions& options = {}) {
   if (options.inplace()) {
     return torch::leaky_relu_(input, options.negative_slope());
   } else {
@@ -48,7 +48,7 @@ inline Tensor logsigmoid(const Tensor& input) {
   return torch::log_sigmoid(input);
 }
 
-inline Tensor gumbel_softmax(const Tensor& logits, const GumbelSoftmaxOptions& options = {}) {
+inline Tensor gumbel_softmax(const Tensor& logits, const GumbelSoftmaxFuncOptions& options = {}) {
   auto gumbels = -torch::empty_like(logits).exponential_().log();  // ~Gumbel(0,1)
   gumbels = (logits + gumbels) / options.tau();  // ~Gumbel(logits, tau)
   auto y_soft = gumbels.softmax(options.dim());
@@ -65,7 +65,7 @@ inline Tensor gumbel_softmax(const Tensor& logits, const GumbelSoftmaxOptions& o
   return ret;
 }
 
-inline Tensor softmax(const Tensor& input, const SoftmaxOptions& options,
+inline Tensor softmax(const Tensor& input, const SoftmaxFuncOptions& options,
                       c10::optional<torch::Dtype> dtype = c10::nullopt) {
   int64_t dim = options.dim();
   Tensor ret;
@@ -79,7 +79,7 @@ inline Tensor softmax(const Tensor& input, const SoftmaxOptions& options,
   return ret;
 }
 
-inline Tensor softmin(const Tensor& input, const SoftminOptions& options,
+inline Tensor softmin(const Tensor& input, const SoftminFuncOptions& options,
                       c10::optional<torch::Dtype> dtype = c10::nullopt) {
   int64_t dim = options.dim();
   Tensor ret;
@@ -93,7 +93,7 @@ inline Tensor softmin(const Tensor& input, const SoftminOptions& options,
   return ret;
 }
 
-inline Tensor log_softmax(const Tensor& input, const LogSoftmaxOptions& options,
+inline Tensor log_softmax(const Tensor& input, const LogSoftmaxFuncOptions& options,
                           c10::optional<torch::Dtype> dtype = c10::nullopt) {
   int64_t dim = options.dim();
   Tensor ret;
@@ -115,7 +115,7 @@ inline Tensor prelu(const Tensor& input, const Tensor& weight) {
   return torch::prelu(input, weight);
 }
 
-inline Tensor relu(Tensor& input, const ReLUOptions& options = {}) {
+inline Tensor relu(Tensor& input, const ReLUFuncOptions& options = {}) {
   if (options.inplace()) {
     return torch::relu_(input);
   } else {
@@ -123,12 +123,12 @@ inline Tensor relu(Tensor& input, const ReLUOptions& options = {}) {
   }
 }
 
-inline Tensor relu6(Tensor& input, const ReLU6Options& options = {}) {
+inline Tensor relu6(Tensor& input, const ReLU6FuncOptions& options = {}) {
   return hardtanh(input,
     HardtanhOptions().min_val(0).max_val(6).inplace(options.inplace()));
 }
 
-inline Tensor rrelu(Tensor& input, const RReLUOptions& options = {},
+inline Tensor rrelu(Tensor& input, const RReLUFuncOptions& options = {},
                     bool training = false) {
   if (options.inplace()) {
     return torch::rrelu_(input, options.lower(), options.upper(), training);
@@ -137,7 +137,7 @@ inline Tensor rrelu(Tensor& input, const RReLUOptions& options = {},
   }
 }
 
-inline Tensor celu(Tensor& input, const CELUOptions& options = {}) {
+inline Tensor celu(Tensor& input, const CELUFuncOptions& options = {}) {
   if (options.inplace()) {
     return torch::celu_(input, options.alpha());
   } else {
@@ -146,12 +146,12 @@ inline Tensor celu(Tensor& input, const CELUOptions& options = {}) {
 }
 
 inline Tensor softplus(const Tensor& input,
-                       const SoftplusOptions& options = {}) {
+                       const SoftplusFuncOptions& options = {}) {
   return torch::softplus(input, options.beta(), options.threshold());
 }
 
 inline Tensor softshrink(const Tensor& input,
-                         const SoftshrinkOptions& options = {}) {
+                         const SoftshrinkFuncOptions& options = {}) {
   return torch::softshrink(input, options.lambda());
 }
 
@@ -163,7 +163,7 @@ inline Tensor tanhshrink(const Tensor& input) {
   return input - input.tanh();
 }
 
-inline Tensor threshold(Tensor& input, const ThresholdOptions& options) {
+inline Tensor threshold(Tensor& input, const ThresholdFuncOptions& options) {
   if (options.inplace()) {
     return torch::threshold_(input, options.threshold(), options.value());
   } else {

--- a/torch/csrc/api/include/torch/nn/functional/batchnorm.h
+++ b/torch/csrc/api/include/torch/nn/functional/batchnorm.h
@@ -3,12 +3,14 @@
 #include <torch/nn/options/batchnorm.h>
 #include <torch/types.h>
 
+namespace F = torch::nn::functional;
+
 namespace torch {
 namespace nn {
 namespace functional {
 
 inline Tensor batch_norm(const Tensor& input, const Tensor& running_mean,
-                         const Tensor& running_var, const BatchNormOptions& options = {}, bool training = false) {
+                         const Tensor& running_var, const BatchNormFuncOptions& options = {}, bool training = false) {
   if (training) {
     auto size = input.sizes();
     int64_t size_prods = size[0];

--- a/torch/csrc/api/include/torch/nn/functional/distance.h
+++ b/torch/csrc/api/include/torch/nn/functional/distance.h
@@ -9,7 +9,7 @@ namespace functional {
 inline Tensor cosine_similarity(
     const Tensor& x1,
     const Tensor& x2,
-    const CosineSimilarityOptions& options) {
+    const CosineSimilarityFuncOptions& options) {
   return torch::cosine_similarity(
       x1,
       x2,
@@ -22,7 +22,7 @@ inline Tensor cosine_similarity(
 inline Tensor pairwise_distance(
     const Tensor& x1,
     const Tensor& x2,
-    const PairwiseDistanceOptions& options) {
+    const PairwiseDistanceFuncOptions& options) {
   return torch::pairwise_distance(
       x1,
       x2,

--- a/torch/csrc/api/include/torch/nn/functional/fold.h
+++ b/torch/csrc/api/include/torch/nn/functional/fold.h
@@ -6,7 +6,7 @@ namespace torch {
 namespace nn {
 namespace functional {
 
-inline Tensor fold(const Tensor& input, const FoldOptions& options) {
+inline Tensor fold(const Tensor& input, const FoldFuncOptions& options) {
   if (input.dim() == 3) {
     return torch::col2im(
         input,
@@ -23,7 +23,7 @@ inline Tensor fold(const Tensor& input, const FoldOptions& options) {
   }
 }
 
-inline Tensor unfold(const Tensor& input, const UnfoldOptions& options) {
+inline Tensor unfold(const Tensor& input, const UnfoldFuncOptions& options) {
   if (input.dim() == 4) {
     return torch::im2col(
         input,

--- a/torch/csrc/api/include/torch/nn/functional/loss.h
+++ b/torch/csrc/api/include/torch/nn/functional/loss.h
@@ -10,7 +10,7 @@ namespace functional {
 inline Tensor l1_loss(
     const Tensor& input,
     const Tensor& target,
-    const L1LossOptions& options = {}) {
+    const L1LossFuncOptions& options = {}) {
   return torch::l1_loss(
     input,
     target,
@@ -20,7 +20,7 @@ inline Tensor l1_loss(
 inline Tensor kl_div(
     const Tensor& input,
     const Tensor& target,
-    const KLDivLossOptions& options = {}) {
+    const KLDivLossFuncOptions& options = {}) {
   torch::Reduction::Reduction reduction_enum;
 
   if (c10::get_if<enumtype::kMean>(&options.reduction())) {
@@ -48,7 +48,7 @@ inline Tensor kl_div(
 inline Tensor mse_loss(
     const Tensor& input,
     const Tensor& target,
-    const MSELossOptions& options = {}) {
+    const MSELossFuncOptions& options = {}) {
   if (!(target.sizes() == input.sizes())) {
     TORCH_WARN("Using a target size (", target.sizes(),
                ") that is different to the input size (", input.sizes(), "). ",
@@ -76,7 +76,7 @@ inline Tensor mse_loss(
 inline Tensor binary_cross_entropy(
     const Tensor& input,
     const Tensor& target,
-    const BCELossOptions& options = {}) {
+    const BCELossFuncOptions& options = {}) {
   auto reduction_enum = enumtype::reduction_get_enum(options.reduction());
 
   if (target.sizes() != input.sizes()) {
@@ -103,7 +103,7 @@ inline Tensor binary_cross_entropy(
 inline Tensor hinge_embedding_loss(
     const Tensor& input,
     const Tensor& target,
-    const HingeEmbeddingLossOptions& options = {}) {
+    const HingeEmbeddingLossFuncOptions& options = {}) {
   return torch::hinge_embedding_loss(
       input,
       target,
@@ -114,7 +114,7 @@ inline Tensor hinge_embedding_loss(
 inline Tensor multi_margin_loss(
     const Tensor& input,
     const Tensor& target,
-    const MultiMarginLossOptions& options = {}) {
+    const MultiMarginLossFuncOptions& options = {}) {
   TORCH_CHECK(options.p() == 1 || options.p() == 2, "only p == 1 and p == 2 supported");
   if (options.weight().defined()) {
     TORCH_CHECK(options.weight().dim() == 1, "weight must be one-dimensional");
@@ -134,7 +134,7 @@ inline Tensor cosine_embedding_loss(
     const Tensor& input1,
     const Tensor& input2,
     const Tensor& target,
-    const CosineEmbeddingLossOptions& options) {
+    const CosineEmbeddingLossFuncOptions& options) {
   return torch::cosine_embedding_loss(
     input1,
     input2,
@@ -151,7 +151,7 @@ inline Tensor _smooth_l1_loss(const Tensor& input, const Tensor& target) {
 inline Tensor smooth_l1_loss(
     const Tensor& input,
     const Tensor& target,
-    const SmoothL1LossOptions& options = {}) {
+    const SmoothL1LossFuncOptions& options = {}) {
   if (target.sizes() != input.sizes()) {
     TORCH_WARN("Using a target size (", target.sizes(), ") that is different to the input size (", input.sizes(), "). ",
                   "This will likely lead to incorrect results due to broadcasting. ",
@@ -175,7 +175,7 @@ inline Tensor smooth_l1_loss(
 inline Tensor multilabel_margin_loss(
     const Tensor& input,
     const Tensor& target,
-    const MultiLabelMarginLossOptions& options = {}) {
+    const MultiLabelMarginLossFuncOptions& options = {}) {
   return torch::multilabel_margin_loss(
     input,
     target,
@@ -185,7 +185,7 @@ inline Tensor multilabel_margin_loss(
 inline Tensor soft_margin_loss(
     const Tensor& input,
     const Tensor& target,
-    const SoftMarginLossOptions& options = {}) {
+    const SoftMarginLossFuncOptions& options = {}) {
   return torch::soft_margin_loss(
     input,
     target,
@@ -195,7 +195,7 @@ inline Tensor soft_margin_loss(
 inline Tensor multilabel_soft_margin_loss(
     const Tensor& input,
     const Tensor& target,
-    const MultiLabelSoftMarginLossOptions& options = {}) {
+    const MultiLabelSoftMarginLossFuncOptions& options = {}) {
   auto loss = -(target * torch::log_sigmoid(input) + (1 - target) * torch::log_sigmoid(-input));
   if (options.weight().defined()) {
     loss = loss * options.weight();
@@ -225,7 +225,7 @@ inline Tensor triplet_margin_loss(
     const Tensor& anchor,
     const Tensor& positive,
     const Tensor& negative,
-    const TripletMarginLossOptions& options = {}) {
+    const TripletMarginLossFuncOptions& options = {}) {
   return torch::triplet_margin_loss(
       anchor,
       positive,
@@ -239,21 +239,21 @@ inline Tensor triplet_margin_loss(
 
 inline Tensor ctc_loss(const Tensor& log_probs, const Tensor& targets,
   const Tensor& input_lengths, const Tensor& target_lengths,
-  const CTCLossOptions& options = {}) {
+  const CTCLossFuncOptions& options = {}) {
   return torch::ctc_loss(log_probs, targets, input_lengths, target_lengths,
     options.blank(), enumtype::reduction_get_enum(options.reduction()),
     options.zero_infinity());
 }
 
 inline Tensor poisson_nll_loss(const Tensor& input, const Tensor& target,
-                               const PoissonNLLLossOptions& options = {}) {
+                               const PoissonNLLLossFuncOptions& options = {}) {
   return torch::poisson_nll_loss(input, target, options.log_input(),
     options.full(), options.eps(),
     enumtype::reduction_get_enum(options.reduction()));
 }
 
 inline Tensor margin_ranking_loss(const Tensor& input1, const Tensor& input2,
-  const Tensor& target, const MarginRankingLossOptions& options = {}) {
+  const Tensor& target, const MarginRankingLossFuncOptions& options = {}) {
   TORCH_CHECK(
     input1.dim() != 0 && input2.dim() != 0 && target.dim() != 0,
     "margin_ranking_loss does not support scalars, got sizes: "

--- a/torch/csrc/api/include/torch/nn/functional/normalization.h
+++ b/torch/csrc/api/include/torch/nn/functional/normalization.h
@@ -11,7 +11,7 @@ namespace functional {
 
 inline Tensor normalize(
     const Tensor& input,
-    const NormalizeOptions& options = {},
+    const NormalizeFuncOptions& options = {},
     c10::optional<Tensor> out = c10::nullopt) {
     if (out == c10::nullopt) {
       auto denom = input.norm(options.p(), options.dim(), true).clamp_min(options.eps()).expand_as(input);
@@ -23,7 +23,7 @@ inline Tensor normalize(
 }
 
 inline Tensor layer_norm(const Tensor& input,
-    const LayerNormOptions& options,
+    const LayerNormFuncOptions& options,
     const Tensor& weight = Tensor(),
     const Tensor& bias = Tensor()) {
 
@@ -32,18 +32,18 @@ inline Tensor layer_norm(const Tensor& input,
 
 inline Tensor local_response_norm(
     const Tensor& input,
-    const LocalResponseNormOptions& options) {
+    const LocalResponseNormFuncOptions& options) {
     auto dim = input.dim();
     TORCH_CHECK(dim >=3, "Expected 3D or higher dimensionality input (got ", dim, " dimensions)");
     auto div = input.mul(input).unsqueeze(1);
     if (dim == 3) {
-      div = pad(div, PadOptions({0, 0, options.size() / 2, (options.size() - 1) / 2}));
-      div = avg_pool2d(div, AvgPool2dOptions({options.size(), 1}).stride(1)).squeeze(1);
+      div = pad(div, PadFuncOptions({0, 0, options.size() / 2, (options.size() - 1) / 2}));
+      div = avg_pool2d(div, AvgPool2dFuncOptions({options.size(), 1}).stride(1)).squeeze(1);
     } else {
       auto sizes = input.sizes();
       div = div.view({sizes[0], 1, sizes[1], sizes[2], -1});
-      div = pad(div, PadOptions({0, 0, 0, 0, options.size() / 2, (options.size() - 1) / 2}));
-      div = avg_pool3d(div, AvgPool3dOptions({options.size(), 1, 1}).stride(1)).squeeze(1);
+      div = pad(div, PadFuncOptions({0, 0, 0, 0, options.size() / 2, (options.size() - 1) / 2}));
+      div = avg_pool3d(div, AvgPool3dFuncOptions({options.size(), 1, 1}).stride(1)).squeeze(1);
       div = div.view(sizes);
     }
     div = div.mul(options.alpha()).add(options.k()).pow(options.beta());

--- a/torch/csrc/api/include/torch/nn/functional/padding.h
+++ b/torch/csrc/api/include/torch/nn/functional/padding.h
@@ -27,7 +27,7 @@ inline Tensor _pad_circular(Tensor input, IntArrayRef padding) {
   return input;
 }
 
-inline Tensor pad(const Tensor& input, const PadOptions& options) {
+inline Tensor pad(const Tensor& input, const PadFuncOptions& options) {
   TORCH_CHECK(options.pad().size() % 2 == 0, "Padding length must be divisible by 2");
   TORCH_CHECK(((int64_t)(options.pad().size() / 2)) <= input.dim(), "Padding length too large");
   if (c10::get_if<enumtype::kConstant>(&options.mode())) {

--- a/torch/csrc/api/include/torch/nn/functional/pixelshuffle.h
+++ b/torch/csrc/api/include/torch/nn/functional/pixelshuffle.h
@@ -8,7 +8,7 @@ namespace functional {
 
 inline Tensor pixel_shuffle(
     const Tensor& input,
-    const PixelShuffleOptions& options) {
+    const PixelShuffleFuncOptions& options) {
   return torch::pixel_shuffle(
     input,
     options.upscale_factor()

--- a/torch/csrc/api/include/torch/nn/functional/pooling.h
+++ b/torch/csrc/api/include/torch/nn/functional/pooling.h
@@ -7,7 +7,7 @@ namespace torch {
 namespace nn{
 namespace functional {
 
-inline Tensor avg_pool1d(const Tensor& input, const AvgPool1dOptions& options) {
+inline Tensor avg_pool1d(const Tensor& input, const AvgPool1dFuncOptions& options) {
   return torch::avg_pool1d(
       input,
       options.kernel_size(),
@@ -17,7 +17,7 @@ inline Tensor avg_pool1d(const Tensor& input, const AvgPool1dOptions& options) {
       options.count_include_pad());
 }
 
-inline Tensor avg_pool2d(const Tensor& input, const AvgPool2dOptions& options) {
+inline Tensor avg_pool2d(const Tensor& input, const AvgPool2dFuncOptions& options) {
   return torch::avg_pool2d(
       input,
       options.kernel_size(),
@@ -28,7 +28,7 @@ inline Tensor avg_pool2d(const Tensor& input, const AvgPool2dOptions& options) {
       options.divisor_override());
 }
 
-inline Tensor avg_pool3d(const Tensor& input, const AvgPool3dOptions& options) {
+inline Tensor avg_pool3d(const Tensor& input, const AvgPool3dFuncOptions& options) {
   return torch::avg_pool3d(
       input,
       options.kernel_size(),
@@ -41,7 +41,7 @@ inline Tensor avg_pool3d(const Tensor& input, const AvgPool3dOptions& options) {
 
 // ============================================================================
 
-inline Tensor max_pool1d(const Tensor& input, const MaxPool1dOptions& options) {
+inline Tensor max_pool1d(const Tensor& input, const MaxPool1dFuncOptions& options) {
    return torch::max_pool1d(
       input,
       options.kernel_size(),
@@ -51,7 +51,7 @@ inline Tensor max_pool1d(const Tensor& input, const MaxPool1dOptions& options) {
       options.ceil_mode());
 }
 
-inline std::tuple<Tensor, Tensor> max_pool1d_with_indices(const Tensor& input, const MaxPool1dOptions& options) {
+inline std::tuple<Tensor, Tensor> max_pool1d_with_indices(const Tensor& input, const MaxPool1dFuncOptions& options) {
   return torch::max_pool1d_with_indices(
       input,
       options.kernel_size(),
@@ -61,7 +61,7 @@ inline std::tuple<Tensor, Tensor> max_pool1d_with_indices(const Tensor& input, c
       options.ceil_mode());
 }
 
-inline Tensor max_pool2d(const Tensor& input, const MaxPool2dOptions& options) {
+inline Tensor max_pool2d(const Tensor& input, const MaxPool2dFuncOptions& options) {
   return torch::max_pool2d(
       input,
       options.kernel_size(),
@@ -71,7 +71,7 @@ inline Tensor max_pool2d(const Tensor& input, const MaxPool2dOptions& options) {
       options.ceil_mode());
 }
 
-inline std::tuple<Tensor, Tensor> max_pool2d_with_indices(const Tensor& input, const MaxPool2dOptions& options) {
+inline std::tuple<Tensor, Tensor> max_pool2d_with_indices(const Tensor& input, const MaxPool2dFuncOptions& options) {
   return torch::max_pool2d_with_indices(
       input,
       options.kernel_size(),
@@ -81,7 +81,7 @@ inline std::tuple<Tensor, Tensor> max_pool2d_with_indices(const Tensor& input, c
       options.ceil_mode());
 }
 
-inline Tensor max_pool3d(const Tensor& input, const MaxPool3dOptions& options) {
+inline Tensor max_pool3d(const Tensor& input, const MaxPool3dFuncOptions& options) {
   return torch::max_pool3d(
       input,
       options.kernel_size(),
@@ -91,7 +91,7 @@ inline Tensor max_pool3d(const Tensor& input, const MaxPool3dOptions& options) {
       options.ceil_mode());
 }
 
-inline std::tuple<Tensor, Tensor> max_pool3d_with_indices(const Tensor& input, const MaxPool3dOptions& options) {
+inline std::tuple<Tensor, Tensor> max_pool3d_with_indices(const Tensor& input, const MaxPool3dFuncOptions& options) {
   return torch::max_pool3d_with_indices(
       input,
       options.kernel_size(),
@@ -104,49 +104,49 @@ inline std::tuple<Tensor, Tensor> max_pool3d_with_indices(const Tensor& input, c
 // ============================================================================
 
 inline Tensor adaptive_max_pool1d(const Tensor& input,
-  const AdaptiveMaxPool1dOptions& options) {
+  const AdaptiveMaxPool1dFuncOptions& options) {
    return std::get<0>(torch::adaptive_max_pool1d(input, options.output_size()));
 }
 
 inline std::tuple<Tensor, Tensor> adaptive_max_pool1d_with_indices(
-  const Tensor& input, const AdaptiveMaxPool1dOptions& options) {
+  const Tensor& input, const AdaptiveMaxPool1dFuncOptions& options) {
    return torch::adaptive_max_pool1d(input, options.output_size());
 }
 
 inline Tensor adaptive_max_pool2d(const Tensor& input,
-  const AdaptiveMaxPool2dOptions& options) {
+  const AdaptiveMaxPool2dFuncOptions& options) {
    return std::get<0>(torch::adaptive_max_pool2d(input, options.output_size()));
 }
 
 inline std::tuple<Tensor, Tensor> adaptive_max_pool2d_with_indices(
-  const Tensor& input, const AdaptiveMaxPool2dOptions& options) {
+  const Tensor& input, const AdaptiveMaxPool2dFuncOptions& options) {
    return torch::adaptive_max_pool2d(input, options.output_size());
 }
 
 inline Tensor adaptive_max_pool3d(const Tensor& input,
-  const AdaptiveMaxPool3dOptions& options) {
+  const AdaptiveMaxPool3dFuncOptions& options) {
    return std::get<0>(torch::adaptive_max_pool3d(input, options.output_size()));
 }
 
 inline std::tuple<Tensor, Tensor> adaptive_max_pool3d_with_indices(
-  const Tensor& input, const AdaptiveMaxPool3dOptions& options) {
+  const Tensor& input, const AdaptiveMaxPool3dFuncOptions& options) {
    return torch::adaptive_max_pool3d(input, options.output_size());
 }
 
 // ============================================================================
 
 inline Tensor adaptive_avg_pool1d(const Tensor& input,
-  const AdaptiveAvgPool1dOptions& options) {
+  const AdaptiveAvgPool1dFuncOptions& options) {
    return torch::adaptive_avg_pool1d(input, options.output_size());
 }
 
 inline Tensor adaptive_avg_pool2d(const Tensor& input,
-  const AdaptiveAvgPool2dOptions& options) {
+  const AdaptiveAvgPool2dFuncOptions& options) {
    return torch::adaptive_avg_pool2d(input, options.output_size());
 }
 
 inline Tensor adaptive_avg_pool3d(const Tensor& input,
-  const AdaptiveAvgPool3dOptions& options) {
+  const AdaptiveAvgPool3dFuncOptions& options) {
    return torch::adaptive_avg_pool3d(input, options.output_size());
 }
 
@@ -187,7 +187,7 @@ inline std::vector<int64_t> _unpool_output_size(const Tensor& input,
 }
 
 inline Tensor max_unpool1d(const Tensor& input, const Tensor& indices,
-    const MaxUnpool1dOptions& options,
+    const MaxUnpool1dFuncOptions& options,
     const c10::optional<IntArrayRef>& output_size = c10::nullopt) {
   auto output_size_ = _unpool_output_size(input, options.kernel_size(),
                                           options.stride(), options.padding(),
@@ -198,7 +198,7 @@ inline Tensor max_unpool1d(const Tensor& input, const Tensor& indices,
 }
 
 inline Tensor max_unpool2d(const Tensor& input, const Tensor& indices,
-  const MaxUnpool2dOptions& options,
+  const MaxUnpool2dFuncOptions& options,
   const c10::optional<IntArrayRef>& output_size = c10::nullopt) {
   auto output_size_ = _unpool_output_size(input, options.kernel_size(),
                                           options.stride(), options.padding(),
@@ -208,7 +208,7 @@ inline Tensor max_unpool2d(const Tensor& input, const Tensor& indices,
 }
 
 inline Tensor max_unpool3d(const Tensor& input, const Tensor& indices,
-  const MaxUnpool3dOptions& options,
+  const MaxUnpool3dFuncOptions& options,
   const c10::optional<IntArrayRef>& output_size = c10::nullopt) {
   auto output_size_ = _unpool_output_size(input, options.kernel_size(),
                                           options.stride(), options.padding(),
@@ -218,20 +218,20 @@ inline Tensor max_unpool3d(const Tensor& input, const Tensor& indices,
                              options.stride(), options.padding());
 }
 
-inline Tensor lp_pool1d(const Tensor& input, const LPPool1dOptions& options) {
+inline Tensor lp_pool1d(const Tensor& input, const LPPool1dFuncOptions& options) {
   Tensor out = avg_pool1d(
     input.pow(options.norm_type()),
-    AvgPool1dOptions(options.kernel_size()).stride(options.stride()).padding(0).ceil_mode(options.ceil_mode()));
+    AvgPool1dFuncOptions(options.kernel_size()).stride(options.stride()).padding(0).ceil_mode(options.ceil_mode()));
 
   return (torch::sign(out) * relu(torch::abs(out))).mul((*options.kernel_size())[0]).pow(1. / options.norm_type());
 }
 
-inline Tensor lp_pool2d(const Tensor& input, const LPPool2dOptions& options) {
+inline Tensor lp_pool2d(const Tensor& input, const LPPool2dFuncOptions& options) {
   int kw = (*options.kernel_size())[0];
   int kh = (*options.kernel_size())[1];
   Tensor out = avg_pool2d(
     input.pow(options.norm_type()),
-    AvgPool2dOptions(options.kernel_size()).stride(options.stride()).padding(0).ceil_mode(options.ceil_mode()));
+    AvgPool2dFuncOptions(options.kernel_size()).stride(options.stride()).padding(0).ceil_mode(options.ceil_mode()));
 
   return (torch::sign(out) * relu(torch::abs(out))).mul(kw * kh).pow(1. / options.norm_type());
 }

--- a/torch/csrc/api/include/torch/nn/functional/upsampling.h
+++ b/torch/csrc/api/include/torch/nn/functional/upsampling.h
@@ -9,7 +9,7 @@ namespace torch {
 namespace nn {
 namespace functional {
 
-inline Tensor interpolate(const Tensor& input, InterpolateOptions options) {
+inline Tensor interpolate(const Tensor& input, InterpolateFuncOptions options) {
   auto _check_size_scale_factor = [options](size_t dim) {
     if (options.size().empty() && options.scale_factor().empty()) {
       TORCH_CHECK(false, "either size or scale_factor should be defined");

--- a/torch/csrc/api/include/torch/nn/functional/vision.h
+++ b/torch/csrc/api/include/torch/nn/functional/vision.h
@@ -50,7 +50,7 @@ inline Tensor affine_grid(
 inline Tensor grid_sample(
     const Tensor& input,
     const Tensor& grid,
-    GridSampleOptions options = {}) {
+    GridSampleFuncOptions options = {}) {
 
   if ((options.mode().compare("bilinear") != 0) && (options.mode().compare("nearest") != 0)) {
     TORCH_CHECK(false, "nn::functional::grid_sample(): expected mode to be ",

--- a/torch/csrc/api/include/torch/nn/options.h
+++ b/torch/csrc/api/include/torch/nn/options.h
@@ -4,7 +4,6 @@
 #include <torch/nn/options/conv.h>
 #include <torch/nn/options/dropout.h>
 #include <torch/nn/options/fold.h>
-#include <torch/nn/options/linear.h>
 #include <torch/nn/options/loss.h>
 #include <torch/nn/options/normalization.h>
 #include <torch/nn/options/padding.h>

--- a/torch/csrc/api/include/torch/nn/options/activation.h
+++ b/torch/csrc/api/include/torch/nn/options/activation.h
@@ -2,6 +2,7 @@
 
 #include <torch/arg.h>
 #include <torch/csrc/WindowsTorchApiMacro.h>
+#include <torch/nn/options/common.h>
 #include <torch/types.h>
 
 namespace torch {
@@ -16,6 +17,8 @@ struct TORCH_API ELUOptions {
   TORCH_ARG(bool, inplace) = false;
 };
 
+TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(ELU, ELUFuncOptions)
+
 // ============================================================================
 
 /// Options for SELU functional and module.
@@ -26,6 +29,8 @@ struct TORCH_API SELUOptions {
   TORCH_ARG(bool, inplace);
 };
 
+TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(SELU, SELUFuncOptions)
+
 // ============================================================================
 
 /// Options for Hardshrink functional and module.
@@ -35,6 +40,8 @@ struct TORCH_API HardshrinkOptions {
   /// the `lambda` value for the Hardshrink formulation. Default: 0.5
   TORCH_ARG(double, lambda);
 };
+
+TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(Hardshrink, HardshrinkFuncOptions)
 
 // ============================================================================
 
@@ -50,6 +57,8 @@ struct TORCH_API HardtanhOptions {
   TORCH_ARG(bool, inplace) = false;
 };
 
+TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(Hardtanh, HardtanhFuncOptions)
+
 // ============================================================================
 
 /// Options for LeakyReLU functional and module.
@@ -61,20 +70,7 @@ struct TORCH_API LeakyReLUOptions {
   TORCH_ARG(bool, inplace) = false;
 };
 
-// ============================================================================
-
-/// Options for Gumbel Softmax functional and module.
-struct GumbelSoftmaxOptions {
-  /// non-negative scalar temperature
-  TORCH_ARG(double, tau) = 1.0;
-
-  /// returned samples will be discretized as one-hot vectors,
-  /// but will be differentiated as if it is the soft sample in autograd. Default: False
-  TORCH_ARG(bool, hard) = false;
-
-  /// dimension along which softmax will be computed. Default: -1
-  TORCH_ARG(int, dim) = -1;
-};
+TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(LeakyReLU, LeakyReLUFuncOptions)
 
 // ============================================================================
 
@@ -86,6 +82,8 @@ struct TORCH_API SoftmaxOptions {
   TORCH_ARG(int64_t, dim);
 };
 
+TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(Softmax, SoftmaxFuncOptions)
+
 // ============================================================================
 
 /// Options for the Softmin functional and module.
@@ -96,6 +94,8 @@ struct TORCH_API SoftminOptions {
   TORCH_ARG(int64_t, dim);
 };
 
+TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(Softmin, SoftminFuncOptions)
+
 // ============================================================================
 
 /// Options for the LogSoftmax functional and module.
@@ -105,6 +105,8 @@ struct TORCH_API LogSoftmaxOptions {
   /// Dimension along which LogSoftmax will be computed.
   TORCH_ARG(int64_t, dim);
 };
+
+TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(LogSoftmax, LogSoftmaxFuncOptions)
 
 // ============================================================================
 
@@ -118,6 +120,8 @@ struct TORCH_API PReLUOptions {
   TORCH_ARG(double, init) = 0.25;
 };
 
+TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(PReLU, PReLUFuncOptions)
+
 // ============================================================================
 
 /// Options for ReLU functional and module.
@@ -128,6 +132,8 @@ struct TORCH_API ReLUOptions {
   TORCH_ARG(bool, inplace);
 };
 
+TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(ReLU, ReLUFuncOptions)
+
 // ============================================================================
 
 /// Options for ReLU6 functional and module.
@@ -137,6 +143,8 @@ struct TORCH_API ReLU6Options {
   /// can optionally do the operation in-place. Default: False
   TORCH_ARG(bool, inplace);
 };
+
+TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(ReLU6, ReLU6FuncOptions)
 
 // ============================================================================
 
@@ -152,6 +160,8 @@ struct TORCH_API RReLUOptions {
   TORCH_ARG(bool, inplace) = false;
 };
 
+TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(RReLU, RReLUFuncOptions)
+
 // ============================================================================
 
 /// Options for CELU functional and module.
@@ -162,6 +172,8 @@ struct TORCH_API CELUOptions {
   /// can optionally do the operation in-place. Default: False
   TORCH_ARG(bool, inplace) = false;
 };
+
+TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(CELU, CELUFuncOptions)
 
 // ============================================================================
 
@@ -174,6 +186,8 @@ struct TORCH_API SoftplusOptions {
   TORCH_ARG(double, threshold) = 20.0;
 };
 
+TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(Softplus, SoftplusFuncOptions)
+
 // ============================================================================
 
 /// Options for Softshrink functional and module.
@@ -183,6 +197,8 @@ struct TORCH_API SoftshrinkOptions {
   /// the `lambda` value for the Softshrink formulation. Default: 0.5
   TORCH_ARG(double, lambda);
 };
+
+TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(Softshrink, SoftshrinkFuncOptions)
 
 // ============================================================================
 
@@ -200,6 +216,27 @@ struct ThresholdOptions {
   /// can optionally do the operation in-place. Default: False
   TORCH_ARG(bool, inplace) = false;
 };
+
+TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(Threshold, ThresholdFuncOptions)
+
+// ============================================================================
+
+namespace functional {
+
+/// Options for Gumbel Softmax functional.
+struct GumbelSoftmaxFuncOptions {
+  /// non-negative scalar temperature
+  TORCH_ARG(double, tau) = 1.0;
+
+  /// returned samples will be discretized as one-hot vectors,
+  /// but will be differentiated as if it is the soft sample in autograd. Default: False
+  TORCH_ARG(bool, hard) = false;
+
+  /// dimension along which softmax will be computed. Default: -1
+  TORCH_ARG(int, dim) = -1;
+};
+
+} // namespace functional
 
 } // namespace nn
 } // namespace torch

--- a/torch/csrc/api/include/torch/nn/options/batchnorm.h
+++ b/torch/csrc/api/include/torch/nn/options/batchnorm.h
@@ -2,6 +2,7 @@
 
 #include <torch/arg.h>
 #include <torch/csrc/WindowsTorchApiMacro.h>
+#include <torch/nn/options/common.h>
 #include <torch/types.h>
 
 namespace torch {
@@ -9,8 +10,6 @@ namespace nn {
 
 /// Options for the `BatchNorm` module.
 struct TORCH_API BatchNormOptions {
-  BatchNormOptions() {}
-
   /* implicit */ BatchNormOptions(int64_t num_features);
 
   /// The number of features of the input tensor.
@@ -34,17 +33,30 @@ struct TORCH_API BatchNormOptions {
   /// module.
   /// Changing this parameter after construction __has no effect__.
   TORCH_ARG(bool, track_running_stats) = true;
-
-  /// This parameter is only used in `F::batch_norm`.
-  TORCH_ARG(Tensor, weight) = Tensor();
-
-  /// This parameter is only used in `F::batch_norm`.
-  TORCH_ARG(Tensor, bias) = Tensor();
 };
 
 using BatchNorm1dOptions = BatchNormOptions;
 using BatchNorm2dOptions = BatchNormOptions;
 using BatchNorm3dOptions = BatchNormOptions;
+
+namespace functional {
+
+/// Options for the `BatchNorm` module.
+struct TORCH_API BatchNormFuncOptions {
+  TORCH_ARG(Tensor, weight) = Tensor();
+
+  TORCH_ARG(Tensor, bias) = Tensor();
+
+  /// A momentum multiplier for the mean and variance.
+  /// Changing this parameter after construction __is effective__.
+  TORCH_ARG(c10::optional<double>, momentum) = 0.1;
+
+  /// The epsilon value added for numerical stability.
+  /// Changing this parameter after construction __is effective__.
+  TORCH_ARG(double, eps) = 1e-5;
+};
+
+} // namespace functional
 
 } // namespace nn
 } // namespace torch

--- a/torch/csrc/api/include/torch/nn/options/common.h
+++ b/torch/csrc/api/include/torch/nn/options/common.h
@@ -1,0 +1,17 @@
+#pragma once
+
+// NOTE: You might ask: if we make `F::SomeFuncOptions` the same class as `torch::nn::SomeOptions`
+// for most functionals, what happens if the user erroneously passes `torch::nn::SomeOptions`
+// in their call to functionals, and we later on make `F::SomeFuncOptions` a different class from
+// `torch::nn::SomeOptions` which is going to break their code?
+//
+// Well, the answer is that they will get compile error at that time, which is enough motivation
+// for them to look at the documentation again and fix their usage error. Note that we choose not
+// to add mechanism to detect this misuse, because it is a valid and efficient use case for some
+// of our internal implementation (e.g. passing module options as functional options in a module's
+// `forward` method).
+
+#define TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(module_name, functional_options_name) \
+namespace functional { \
+using functional_options_name = module_name##Options; \
+}

--- a/torch/csrc/api/include/torch/nn/options/distance.h
+++ b/torch/csrc/api/include/torch/nn/options/distance.h
@@ -2,6 +2,7 @@
 
 #include <torch/arg.h>
 #include <torch/csrc/WindowsTorchApiMacro.h>
+#include <torch/nn/options/common.h>
 #include <torch/types.h>
 
 namespace torch {
@@ -15,19 +16,21 @@ struct TORCH_API CosineSimilarityOptions {
   TORCH_ARG(double, eps) = 1e-8;
 };
 
+TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(CosineSimilarity, CosineSimilarityFuncOptions)
+
 // ============================================================================
 
 /// Options for the `PairwiseDistance` module.
 struct TORCH_API PairwiseDistanceOptions {
-  PairwiseDistanceOptions(double p = 2.0)
-      : p_(p) {}
   /// The norm degree. Default: 2
-  TORCH_ARG(double, p);
+  TORCH_ARG(double, p) = 2.0;
   /// Small value to avoid division by zero. Default: 1e-6
   TORCH_ARG(double, eps) = 1e-6;
   /// Determines whether or not to keep the vector dimension. Default: false
   TORCH_ARG(bool, keepdim) = false;
 };
+
+TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(PairwiseDistance, PairwiseDistanceFuncOptions)
 
 } // namespace nn
 } // namespace torch

--- a/torch/csrc/api/include/torch/nn/options/fold.h
+++ b/torch/csrc/api/include/torch/nn/options/fold.h
@@ -3,6 +3,7 @@
 #include <torch/arg.h>
 #include <torch/csrc/WindowsTorchApiMacro.h>
 #include <torch/expanding_array.h>
+#include <torch/nn/options/common.h>
 #include <torch/types.h>
 
 namespace torch {
@@ -34,6 +35,10 @@ struct TORCH_API FoldOptions {
   TORCH_ARG(ExpandingArray<2>, stride) = 1;
 };
 
+TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(Fold, FoldFuncOptions)
+
+// ============================================================================
+
 /// Options for an Unfold functional and module.
 struct TORCH_API UnfoldOptions {
   UnfoldOptions(ExpandingArray<2> kernel_size)
@@ -53,6 +58,8 @@ struct TORCH_API UnfoldOptions {
   /// controls the stride for the sliding blocks.
   TORCH_ARG(ExpandingArray<2>, stride) = 1;
 };
+
+TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(Unfold, UnfoldFuncOptions)
 
 } // namespace nn
 } // namespace torch

--- a/torch/csrc/api/include/torch/nn/options/loss.h
+++ b/torch/csrc/api/include/torch/nn/options/loss.h
@@ -3,6 +3,7 @@
 #include <torch/arg.h>
 #include <torch/enum.h>
 #include <torch/csrc/WindowsTorchApiMacro.h>
+#include <torch/nn/options/common.h>
 #include <torch/types.h>
 
 namespace torch {
@@ -18,6 +19,8 @@ struct TORCH_API L1LossOptions {
   TORCH_ARG(reduction_t, reduction) = torch::kMean;
 };
 
+TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(L1Loss, L1LossFuncOptions)
+
 // ============================================================================
 
 /// Options for a KLDiv loss module.
@@ -30,6 +33,8 @@ struct TORCH_API KLDivLossOptions {
   /// ``'none'`` | ``'batchmean'`` | ``'sum'`` | ``'mean'``. Default: ``'mean'``
   TORCH_ARG(reduction_t, reduction) = torch::kMean;
 };
+
+TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(KLDivLoss, KLDivLossFuncOptions)
 
 // ============================================================================
 
@@ -44,6 +49,8 @@ struct TORCH_API MSELossOptions {
   TORCH_ARG(reduction_t, reduction) = torch::kMean;
 };
 
+TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(MSELoss, MSELossFuncOptions)
+
 // ============================================================================
 
 /// Options for a BCE loss module.
@@ -57,6 +64,8 @@ struct TORCH_API BCELossOptions {
   TORCH_ARG(reduction_t, reduction) = torch::kMean;
 };
 
+TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(BCELoss, BCELossFuncOptions)
+
 // ============================================================================
 
 /// Options for a Hinge Embedding loss functional and module.
@@ -69,6 +78,8 @@ struct TORCH_API HingeEmbeddingLossOptions {
   /// Specifies the reduction to apply to the output. Default: Mean
   TORCH_ARG(reduction_t, reduction) = torch::kMean;
 };
+
+TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(HingeEmbeddingLoss, HingeEmbeddingLossFuncOptions)
 
 // ============================================================================
 
@@ -92,6 +103,8 @@ struct TORCH_API MultiMarginLossOptions {
   TORCH_ARG(reduction_t, reduction) = torch::kMean;
 };
 
+TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(MultiMarginLoss, MultiMarginLossFuncOptions)
+
 // ============================================================================
 
 /// Options for a Hinge Embedding loss functional and module.
@@ -105,6 +118,8 @@ struct TORCH_API CosineEmbeddingLossOptions {
   /// Specifies the reduction to apply to the output. Default: Mean
   TORCH_ARG(reduction_t, reduction) = torch::kMean;
 };
+
+TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(CosineEmbeddingLoss, CosineEmbeddingLossFuncOptions)
 
 // ============================================================================
 
@@ -121,6 +136,8 @@ struct TORCH_API MultiLabelMarginLossOptions {
   TORCH_ARG(reduction_t, reduction) = torch::kMean;
 };
 
+TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(MultiLabelMarginLoss, MultiLabelMarginLossFuncOptions)
+
 // ============================================================================
 
 /// Options for a soft margin loss functional and module.
@@ -135,6 +152,8 @@ struct TORCH_API SoftMarginLossOptions {
   /// be summed. Default: 'mean'
   TORCH_ARG(reduction_t, reduction) = torch::kMean;
 };
+
+TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(SoftMarginLoss, SoftMarginLossFuncOptions)
 
 // ============================================================================
 
@@ -153,6 +172,8 @@ struct TORCH_API MultiLabelSoftMarginLossOptions {
   /// be summed. Default: 'mean'
   TORCH_ARG(reduction_t, reduction) = torch::kMean;
 };
+
+TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(MultiLabelSoftMarginLoss, MultiLabelSoftMarginLossFuncOptions)
 
 // ============================================================================
 
@@ -174,6 +195,8 @@ struct TORCH_API TripletMarginLossOptions {
   TORCH_ARG(reduction_t, reduction) = torch::kMean;
 };
 
+TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(TripletMarginLoss, TripletMarginLossFuncOptions)
+
 // ============================================================================
 
 /// Options for The Connectionist Temporal Classification loss functional and module.
@@ -190,6 +213,8 @@ struct TORCH_API CTCLossOptions {
   TORCH_ARG(bool, zero_infinity) = false;
 };
 
+TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(CTCLoss, CTCLossFuncOptions)
+
 // ============================================================================
 
 /// Options for a smooth L1 loss functional and module.
@@ -203,6 +228,8 @@ struct TORCH_API SmoothL1LossOptions {
   /// be summed. Default: 'mean'
   TORCH_ARG(torch::Reduction::Reduction, reduction);
 };
+
+TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(SmoothL1Loss, SmoothL1LossFuncOptions)
 
 // ============================================================================
 
@@ -223,6 +250,8 @@ struct TORCH_API PoissonNLLLossOptions {
   TORCH_ARG(reduction_t, reduction) = torch::kMean;
 };
 
+TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(PoissonNLLLoss, PoissonNLLLossFuncOptions)
+
 // ============================================================================
 
 /// Options for MarginRankingLoss functional and module.
@@ -234,6 +263,8 @@ struct TORCH_API MarginRankingLossOptions {
   /// Specifies the reduction to apply to the output. Default: Mean
   TORCH_ARG(reduction_t, reduction) = torch::kMean;
 };
+
+TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(MarginRankingLoss, MarginRankingLossFuncOptions)
 
 } // namespace nn
 } // namespace torch

--- a/torch/csrc/api/include/torch/nn/options/normalization.h
+++ b/torch/csrc/api/include/torch/nn/options/normalization.h
@@ -2,21 +2,12 @@
 
 #include <torch/arg.h>
 #include <torch/csrc/WindowsTorchApiMacro.h>
+#include <torch/nn/options/common.h>
 #include <torch/types.h>
 #include <vector>
 
 namespace torch {
 namespace nn {
-
-/// Options for the `normalize` module.
-struct TORCH_API NormalizeOptions {
-  /// The exponent value in the norm formulation. Default: 2.0
-  TORCH_ARG(double, p) = 2.0;
-  /// The dimension to reduce. Default: 1
-  TORCH_ARG(int64_t, dim) = 1;
-  /// Small value to avoid division by zero. Default: 1e-12
-  TORCH_ARG(double, eps) = 1e-12;
-};
 
 /// Options for the `LayerNorm` module.
 struct TORCH_API LayerNormOptions {
@@ -31,6 +22,8 @@ struct TORCH_API LayerNormOptions {
   TORCH_ARG(bool, elementwise_affine) = true;
 };
 
+TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(LayerNorm, LayerNormFuncOptions)
+
 // ============================================================================
 
 /// Options for LocalResponseNorm functional and module.
@@ -38,7 +31,7 @@ struct TORCH_API LocalResponseNormOptions {
   /* implicit */ LocalResponseNormOptions(int64_t size) : size_(size) {}
   /// amount of neighbouring channels used for normalization
   TORCH_ARG(int64_t, size);
-  
+
   /// multiplicative factor. Default: 1e-4
   TORCH_ARG(double, alpha) = 1e-4;
 
@@ -48,6 +41,10 @@ struct TORCH_API LocalResponseNormOptions {
   /// additive factor. Default: 1
   TORCH_ARG(double, k) = 1.;
 };
+
+TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(LocalResponseNorm, LocalResponseNormFuncOptions)
+
+// ============================================================================
 
 /// Options for the CrossMapLRN2d module.
 struct TORCH_API CrossMapLRN2dOptions {
@@ -62,6 +59,22 @@ struct TORCH_API CrossMapLRN2dOptions {
   TORCH_ARG(int64_t, k) = 1;
 
 };
+
+// ============================================================================
+
+namespace functional {
+
+/// Options for the `normalize` module.
+struct TORCH_API NormalizeFuncOptions {
+  /// The exponent value in the norm formulation. Default: 2.0
+  TORCH_ARG(double, p) = 2.0;
+  /// The dimension to reduce. Default: 1
+  TORCH_ARG(int64_t, dim) = 1;
+  /// Small value to avoid division by zero. Default: 1e-12
+  TORCH_ARG(double, eps) = 1e-12;
+};
+
+} // namespace functional
 
 } // namespace nn
 } // namespace torch

--- a/torch/csrc/api/include/torch/nn/options/padding.h
+++ b/torch/csrc/api/include/torch/nn/options/padding.h
@@ -10,28 +10,6 @@
 namespace torch {
 namespace nn {
 
-/// Options for a pad functional.
-struct TORCH_API PadOptions {
-  typedef c10::variant<
-    enumtype::kConstant,
-    enumtype::kReflect,
-    enumtype::kReplicate,
-    enumtype::kCircular> mode_t;
-
-  PadOptions(std::vector<int64_t> pad);
-
-  /// m-elements tuple, where m/2 <= input dimensions and m is even.
-  TORCH_ARG(std::vector<int64_t>, pad);
-
-  /// "constant", "reflect", "replicate" or "circular". Default: "constant"
-  TORCH_ARG(mode_t, mode) = torch::kConstant;
-
-  /// fill value for "constant" padding. Default: 0
-  TORCH_ARG(double, value) = 0;
-};
-
-// ============================================================================
-
 /// Options for a `D`-dimensional ReflectionPad module.
 template <size_t D>
 struct TORCH_API ReflectionPadOptions {
@@ -114,6 +92,32 @@ using ConstantPad2dOptions = ConstantPadOptions<2>;
 
 /// `ConstantPadOptions` specialized for 3-D ConstantPad.
 using ConstantPad3dOptions = ConstantPadOptions<3>;
+
+// ============================================================================
+
+namespace functional {
+
+/// Options for a pad functional.
+struct TORCH_API PadFuncOptions {
+  typedef c10::variant<
+    enumtype::kConstant,
+    enumtype::kReflect,
+    enumtype::kReplicate,
+    enumtype::kCircular> mode_t;
+
+  PadFuncOptions(std::vector<int64_t> pad);
+
+  /// m-elements tuple, where m/2 <= input dimensions and m is even.
+  TORCH_ARG(std::vector<int64_t>, pad);
+
+  /// "constant", "reflect", "replicate" or "circular". Default: "constant"
+  TORCH_ARG(mode_t, mode) = torch::kConstant;
+
+  /// fill value for "constant" padding. Default: 0
+  TORCH_ARG(double, value) = 0;
+};
+
+} // namespace functional
 
 } // namespace nn
 } // namespace torch

--- a/torch/csrc/api/include/torch/nn/options/pixelshuffle.h
+++ b/torch/csrc/api/include/torch/nn/options/pixelshuffle.h
@@ -2,6 +2,7 @@
 
 #include <torch/arg.h>
 #include <torch/csrc/WindowsTorchApiMacro.h>
+#include <torch/nn/options/common.h>
 #include <torch/types.h>
 
 namespace torch {
@@ -15,6 +16,8 @@ struct TORCH_API PixelShuffleOptions {
   /// Factor to increase spatial resolution by
   TORCH_ARG(int64_t, upscale_factor);
 };
+
+TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(PixelShuffle, PixelShuffleFuncOptions)
 
 } // namespace nn
 } // namespace torch

--- a/torch/csrc/api/include/torch/nn/options/pooling.h
+++ b/torch/csrc/api/include/torch/nn/options/pooling.h
@@ -3,6 +3,7 @@
 #include <torch/arg.h>
 #include <torch/csrc/WindowsTorchApiMacro.h>
 #include <torch/expanding_array.h>
+#include <torch/nn/options/common.h>
 #include <torch/types.h>
 
 namespace torch {
@@ -42,6 +43,10 @@ using AvgPool2dOptions = AvgPoolOptions<2>;
 /// `AvgPoolOptions` specialized for 3-D avgpool.
 using AvgPool3dOptions = AvgPoolOptions<3>;
 
+TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(AvgPool1d, AvgPool1dFuncOptions)
+TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(AvgPool2d, AvgPool2dFuncOptions)
+TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(AvgPool3d, AvgPool3dFuncOptions)
+
 // ============================================================================
 
 /// Options for a `D`-dimensional maxpool functional and module.
@@ -75,6 +80,10 @@ using MaxPool2dOptions = MaxPoolOptions<2>;
 /// `MaxPoolOptions` specialized for 3-D maxpool.
 using MaxPool3dOptions = MaxPoolOptions<3>;
 
+TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(MaxPool1d, MaxPool1dFuncOptions)
+TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(MaxPool2d, MaxPool2dFuncOptions)
+TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(MaxPool3d, MaxPool3dFuncOptions)
+
 // ============================================================================
 
 /// Options for a `D`-dimensional adaptive maxpool functional and module.
@@ -96,6 +105,10 @@ using AdaptiveMaxPool2dOptions = AdaptiveMaxPoolOptions<2>;
 /// `AdaptiveMaxPoolOptions` specialized for 3-D adaptive maxpool.
 using AdaptiveMaxPool3dOptions = AdaptiveMaxPoolOptions<3>;
 
+TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(AdaptiveMaxPool1d, AdaptiveMaxPool1dFuncOptions)
+TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(AdaptiveMaxPool2d, AdaptiveMaxPool2dFuncOptions)
+TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(AdaptiveMaxPool3d, AdaptiveMaxPool3dFuncOptions)
+
 // ============================================================================
 
 /// Options for a `D`-dimensional adaptive avgpool functional and module.
@@ -116,6 +129,10 @@ using AdaptiveAvgPool2dOptions = AdaptiveAvgPoolOptions<2>;
 
 /// `AdaptiveAvgPoolOptions` specialized for 3-D adaptive avgpool.
 using AdaptiveAvgPool3dOptions = AdaptiveAvgPoolOptions<3>;
+
+TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(AdaptiveAvgPool1d, AdaptiveAvgPool1dFuncOptions)
+TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(AdaptiveAvgPool2d, AdaptiveAvgPool2dFuncOptions)
+TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(AdaptiveAvgPool3d, AdaptiveAvgPool3dFuncOptions)
 
 // ============================================================================
 
@@ -144,6 +161,10 @@ using MaxUnpool2dOptions = MaxUnpoolOptions<2>;
 /// `MaxUnpoolOptions` specialized for 3-D maxunpool.
 using MaxUnpool3dOptions = MaxUnpoolOptions<3>;
 
+TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(MaxUnpool1d, MaxUnpool1dFuncOptions)
+TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(MaxUnpool2d, MaxUnpool2dFuncOptions)
+TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(MaxUnpool3d, MaxUnpool3dFuncOptions)
+
 // ============================================================================
 
 /// Options for a `D`-dimensional lppool functional and module.
@@ -169,6 +190,9 @@ using LPPool1dOptions = LPPoolOptions<1>;
 
 /// `LPPoolOptions` specialized for 2-D lppool.
 using LPPool2dOptions = LPPoolOptions<2>;
+
+TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(LPPool1d, LPPool1dFuncOptions)
+TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(LPPool2d, LPPool2dFuncOptions)
 
 } // namespace nn
 } // namespace torch

--- a/torch/csrc/api/include/torch/nn/options/upsampling.h
+++ b/torch/csrc/api/include/torch/nn/options/upsampling.h
@@ -12,8 +12,35 @@
 namespace torch {
 namespace nn {
 
+/// Options for a `D`-dimensional Upsample module.
+struct TORCH_API UpsampleOptions {
+  /// output spatial sizes.
+  TORCH_ARG(std::vector<int64_t>, size) = {};
+
+  /// multiplier for spatial size.
+  TORCH_ARG(std::vector<double>, scale_factor) = {};
+
+  /// the upsampling algorithm: one of "nearest", "linear", "bilinear",
+  /// "bicubic" and "trilinear". Default: "nearest"
+  typedef c10::variant<
+      enumtype::kNearest,
+      enumtype::kLinear,
+      enumtype::kBilinear,
+      enumtype::kBicubic,
+      enumtype::kTrilinear> mode_t;
+  TORCH_ARG(mode_t, mode) = torch::kNearest;
+
+  /// if "True", the corner pixels of the input and output tensors are
+  /// aligned, and thus preserving the values at those pixels. This only has
+  /// effect when :attr:`mode` is "linear", "bilinear", or
+  /// "trilinear". Default: "False"
+  TORCH_ARG(c10::optional<bool>, align_corners) = c10::nullopt;
+};
+
+namespace functional {
+
 /// Options for a `D`-dimensional interpolate functional.
-struct TORCH_API InterpolateOptions {
+struct TORCH_API InterpolateFuncOptions {
   typedef c10::variant<
       enumtype::kNearest,
       enumtype::kLinear,
@@ -44,30 +71,7 @@ struct TORCH_API InterpolateOptions {
   TORCH_ARG(c10::optional<bool>, align_corners) = c10::nullopt;
 };
 
-/// Options for a `D`-dimensional Upsample module.
-struct TORCH_API UpsampleOptions {
-  /// output spatial sizes.
-  TORCH_ARG(std::vector<int64_t>, size) = {};
-
-  /// multiplier for spatial size.
-  TORCH_ARG(std::vector<double>, scale_factor) = {};
-
-  /// the upsampling algorithm: one of "nearest", "linear", "bilinear",
-  /// "bicubic" and "trilinear". Default: "nearest"
-  typedef c10::variant<
-      enumtype::kNearest,
-      enumtype::kLinear,
-      enumtype::kBilinear,
-      enumtype::kBicubic,
-      enumtype::kTrilinear> mode_t;
-  TORCH_ARG(mode_t, mode) = torch::kNearest;
-
-  /// if "True", the corner pixels of the input and output tensors are
-  /// aligned, and thus preserving the values at those pixels. This only has
-  /// effect when :attr:`mode` is "linear", "bilinear", or
-  /// "trilinear". Default: "False"
-  TORCH_ARG(c10::optional<bool>, align_corners) = c10::nullopt;
-};
+} // namespace functional
 
 } // namespace nn
 } // namespace torch

--- a/torch/csrc/api/include/torch/nn/options/vision.h
+++ b/torch/csrc/api/include/torch/nn/options/vision.h
@@ -6,9 +6,10 @@
 
 namespace torch {
 namespace nn {
+namespace functional {
 
 /// Options for a Grid Sample module.
-struct TORCH_API GridSampleOptions {
+struct TORCH_API GridSampleFuncOptions {
   /// interpolation mode to calculate output values. Default: Bilinear
   TORCH_ARG(std::string, mode) = "bilinear";
   /// padding mode for outside grid values. Default: Zeros
@@ -17,5 +18,6 @@ struct TORCH_API GridSampleOptions {
   TORCH_ARG(c10::optional<bool>, align_corners) = c10::nullopt;
 };
 
+} // namespace functional
 } // namespace nn
 } // namespace torch

--- a/torch/csrc/api/src/nn/modules/batchnorm.cpp
+++ b/torch/csrc/api/src/nn/modules/batchnorm.cpp
@@ -156,7 +156,7 @@ Tensor BatchNormImplBase<D, Derived>::forward(const Tensor& input) {
       input,
       running_mean,
       running_var,
-      BatchNormOptions().weight(weight).bias(bias).momentum(exponential_average_factor).eps(options.eps()),
+      F::BatchNormFuncOptions().weight(weight).bias(bias).momentum(exponential_average_factor).eps(options.eps()),
       this->is_training() || !options.track_running_stats());
 }
 

--- a/torch/csrc/api/src/nn/modules/padding.cpp
+++ b/torch/csrc/api/src/nn/modules/padding.cpp
@@ -16,7 +16,7 @@ void ReflectionPadImpl<D, Derived>::reset() {}
 
 template <size_t D, typename Derived>
 Tensor ReflectionPadImpl<D, Derived>::forward(const Tensor& input) {
-  return F::pad(input, PadOptions(at::ArrayRef<int64_t>(options.padding()).vec()).mode(torch::kReflect));
+  return F::pad(input, F::PadFuncOptions(at::ArrayRef<int64_t>(options.padding()).vec()).mode(torch::kReflect));
 }
 
 template <size_t D, typename Derived>
@@ -39,7 +39,7 @@ void ReplicationPadImpl<D, Derived>::reset() {}
 
 template <size_t D, typename Derived>
 Tensor ReplicationPadImpl<D, Derived>::forward(const Tensor& input) {
-  return F::pad(input, PadOptions(at::ArrayRef<int64_t>(options.padding()).vec()).mode(torch::kReplicate));
+  return F::pad(input, F::PadFuncOptions(at::ArrayRef<int64_t>(options.padding()).vec()).mode(torch::kReplicate));
 }
 
 template <size_t D, typename Derived>
@@ -65,7 +65,7 @@ void ZeroPad2dImpl::pretty_print(std::ostream& stream) const {
 }
 
 Tensor ZeroPad2dImpl::forward(const Tensor& input) {
-  return F::pad(input, PadOptions(at::ArrayRef<int64_t>(options.padding()).vec()).mode(torch::kConstant).value(0));
+  return F::pad(input, F::PadFuncOptions(at::ArrayRef<int64_t>(options.padding()).vec()).mode(torch::kConstant).value(0));
 }
 
 // ============================================================================
@@ -79,7 +79,7 @@ void ConstantPadImpl<D, Derived>::reset() {}
 
 template <size_t D, typename Derived>
 Tensor ConstantPadImpl<D, Derived>::forward(const Tensor& input) {
-  return F::pad(input, PadOptions(at::ArrayRef<int64_t>(options.padding()).vec()).mode(torch::kConstant).value(options.value()));
+  return F::pad(input, F::PadFuncOptions(at::ArrayRef<int64_t>(options.padding()).vec()).mode(torch::kConstant).value(options.value()));
 }
 
 template <size_t D, typename Derived>

--- a/torch/csrc/api/src/nn/modules/upsampling.cpp
+++ b/torch/csrc/api/src/nn/modules/upsampling.cpp
@@ -23,7 +23,7 @@ void UpsampleImpl::pretty_print(std::ostream& stream) const {
 }
 
 Tensor UpsampleImpl::forward(const Tensor& input) {
-  InterpolateOptions::mode_t mode;
+  F::InterpolateFuncOptions::mode_t mode;
   if (c10::get_if<enumtype::kNearest>(&options.mode())) {
     mode = torch::kNearest;
   } else if (c10::get_if<enumtype::kLinear>(&options.mode())) {
@@ -38,7 +38,7 @@ Tensor UpsampleImpl::forward(const Tensor& input) {
 
   return F::interpolate(
       input,
-      InterpolateOptions()
+      F::InterpolateFuncOptions()
           .size(options.size())
           .scale_factor(options.scale_factor())
           .mode(mode)

--- a/torch/csrc/api/src/nn/options/padding.cpp
+++ b/torch/csrc/api/src/nn/options/padding.cpp
@@ -3,8 +3,6 @@
 namespace torch {
 namespace nn {
 
-PadOptions::PadOptions(std::vector<int64_t> pad) : pad_(std::move(pad)) {}
-
 template struct ReflectionPadOptions<1>;
 template struct ReflectionPadOptions<2>;
 
@@ -15,6 +13,12 @@ template struct ReplicationPadOptions<3>;
 template struct ConstantPadOptions<1>;
 template struct ConstantPadOptions<2>;
 template struct ConstantPadOptions<3>;
+
+namespace functional {
+
+PadFuncOptions::PadFuncOptions(std::vector<int64_t> pad) : pad_(std::move(pad)) {}
+
+} // namespace functional
 
 } // namespace nn
 } // namespace torch


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #29278 Make all non-input arguments to functionals part of its options
* ** #29277 Pass F::*FuncOptions instead of torch::nn::*Options to functionals **

Currently, we use `torch::nn::*Options` both as module options and functional options. However, this makes it very hard to manage the parameters in `torch::nn::*Options`, because a module's constructor can take a different set of arguments than the module's equivalent functional (e.g. `torch.nn.BatchNorm1d` takes `num_features, eps=1e-5, momentum=0.1, affine=True,
track_running_stats=True`, while `F::batch_norm` takes `running_mean, running_var, weight=None, bias=None, training=False, momentum=0.1, eps=1e-5`).

This PR resolves the above problem by making `F::*FuncOptions` a different class from `torch::nn::*Options` when necessary (i.e. when a module's constructor takes a different set of arguments than the module's equivalent functional). In the rest of the cases where the module constructor takes the same set of arguments as the module's equivalent functional, `F::*FuncOptions` is an alias of `torch::nn::*Options`.

Differential Revision: [D18350164](https://our.internmc.facebook.com/intern/diff/D18350164)