### PR TITLE
[REMOVED]

### DIFF
--- a/torch/csrc/api/include/torch/nn/functional/activation.h
+++ b/torch/csrc/api/include/torch/nn/functional/activation.h
@@ -65,8 +65,7 @@ inline Tensor gumbel_softmax(const Tensor& logits, const GumbelSoftmaxFuncOption
   return ret;
 }
 
-inline Tensor softmax(const Tensor& input, const SoftmaxFuncOptions& options,
-                      c10::optional<torch::Dtype> dtype = c10::nullopt) {
+inline Tensor softmax(const Tensor& input, const SoftmaxFuncOptions& options) {
   int64_t dim = options.dim();
   Tensor ret;
 
@@ -79,8 +78,7 @@ inline Tensor softmax(const Tensor& input, const SoftmaxFuncOptions& options,
   return ret;
 }
 
-inline Tensor softmin(const Tensor& input, const SoftminFuncOptions& options,
-                      c10::optional<torch::Dtype> dtype = c10::nullopt) {
+inline Tensor softmin(const Tensor& input, const SoftminFuncOptions& options) {
   int64_t dim = options.dim();
   Tensor ret;
 
@@ -93,8 +91,7 @@ inline Tensor softmin(const Tensor& input, const SoftminFuncOptions& options,
   return ret;
 }
 
-inline Tensor log_softmax(const Tensor& input, const LogSoftmaxFuncOptions& options,
-                          c10::optional<torch::Dtype> dtype = c10::nullopt) {
+inline Tensor log_softmax(const Tensor& input, const LogSoftmaxFuncOptions& options) {
   int64_t dim = options.dim();
   Tensor ret;
 
@@ -128,8 +125,7 @@ inline Tensor relu6(Tensor& input, const ReLU6FuncOptions& options = {}) {
     HardtanhOptions().min_val(0).max_val(6).inplace(options.inplace()));
 }
 
-inline Tensor rrelu(Tensor& input, const RReLUFuncOptions& options = {},
-                    bool training = false) {
+inline Tensor rrelu(Tensor& input, const RReLUFuncOptions& options = {}) {
   if (options.inplace()) {
     return torch::rrelu_(input, options.lower(), options.upper(), training);
   } else {

--- a/torch/csrc/api/include/torch/nn/options/activation.h
+++ b/torch/csrc/api/include/torch/nn/options/activation.h
@@ -82,7 +82,23 @@ struct TORCH_API SoftmaxOptions {
   TORCH_ARG(int64_t, dim);
 };
 
-TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(Softmax, SoftmaxFuncOptions)
+// ============================================================================
+
+namespace functional {
+
+struct TORCH_API SoftmaxFuncOptions {
+  SoftmaxFuncOptions(int64_t dim);
+
+  /// Dimension along which Softmax will be computed.
+  TORCH_ARG(int64_t, dim);
+
+  /// the desired data type of returned tensor.
+  /// If specified, the input tensor is casted to `dtype` before the operation
+  /// is performed. This is useful for preventing data type overflows. Default: None.
+  TORCH_ARG(c10::optional<torch::Dtype>, dtype) = c10::nullopt;
+};
+
+} // namespace functional
 
 // ============================================================================
 
@@ -94,7 +110,23 @@ struct TORCH_API SoftminOptions {
   TORCH_ARG(int64_t, dim);
 };
 
-TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(Softmin, SoftminFuncOptions)
+// ============================================================================
+
+namespace functional {
+
+struct TORCH_API SoftminFuncOptions {
+  SoftminFuncOptions(int64_t dim);
+
+  /// Dimension along which Softmin will be computed.
+  TORCH_ARG(int64_t, dim);
+
+  /// the desired data type of returned tensor.
+  /// If specified, the input tensor is casted to `dtype` before the operation
+  /// is performed. This is useful for preventing data type overflows. Default: None.
+  TORCH_ARG(c10::optional<torch::Dtype>, dtype) = c10::nullopt;
+};
+
+} // namespace functional
 
 // ============================================================================
 
@@ -106,7 +138,23 @@ struct TORCH_API LogSoftmaxOptions {
   TORCH_ARG(int64_t, dim);
 };
 
-TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(LogSoftmax, LogSoftmaxFuncOptions)
+// ============================================================================
+
+namespace functional {
+
+struct TORCH_API LogSoftmaxFuncOptions {
+  LogSoftmaxFuncOptions(int64_t dim);
+
+  /// Dimension along which LogSoftmax will be computed.
+  TORCH_ARG(int64_t, dim);
+
+  /// the desired data type of returned tensor.
+  /// If specified, the input tensor is casted to `dtype` before the operation
+  /// is performed. This is useful for preventing data type overflows. Default: None.
+  TORCH_ARG(c10::optional<torch::Dtype>, dtype) = c10::nullopt;
+};
+
+} // namespace functional
 
 // ============================================================================
 
@@ -160,7 +208,24 @@ struct TORCH_API RReLUOptions {
   TORCH_ARG(bool, inplace) = false;
 };
 
-TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(RReLU, RReLUFuncOptions)
+// ============================================================================
+
+namespace functional {
+
+struct TORCH_API RReLUFuncOptions {
+  /// lower bound of the uniform distribution. Default: 1/8
+  TORCH_ARG(double, lower) = 1.0 / 8.0;
+
+  /// upper bound of the uniform distribution. Default: 1/3
+  TORCH_ARG(double, upper) = 1.0 / 3.0;
+
+  TORCH_ARG(bool, training) = false;
+
+  /// can optionally do the operation in-place. Default: False
+  TORCH_ARG(bool, inplace) = false;
+};
+
+} // namespace functional
 
 // ============================================================================
 
@@ -203,7 +268,7 @@ TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(Softshrink, SoftshrinkFuncOptions)
 // ============================================================================
 
 /// Options for Threshold functional and module.
-struct ThresholdOptions {
+struct TORCH_API ThresholdOptions {
   ThresholdOptions(double threshold, double value)
    : threshold_(threshold), value_(value) {}
 
@@ -224,7 +289,7 @@ TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(Threshold, ThresholdFuncOptions)
 namespace functional {
 
 /// Options for Gumbel Softmax functional.
-struct GumbelSoftmaxFuncOptions {
+struct TORCH_API GumbelSoftmaxFuncOptions {
   /// non-negative scalar temperature
   TORCH_ARG(double, tau) = 1.0;
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#29278 Make all non-input arguments to functionals part of its options**
* #29277 Pass F::*FuncOptions instead of torch::nn::*Options to functionals

