### PR TITLE
add execution mode to the test name

### DIFF
--- a/benchmarks/operator_benchmark/benchmark_core.py
+++ b/benchmarks/operator_benchmark/benchmark_core.py
@@ -73,8 +73,8 @@ class BenchmarkRunner(object):
         self.use_jit = args.use_jit
         self.num_runs = args.num_runs
         self.print_per_iter = False
-        # 100 is the default warmup iterations 
-        if self.args.warmup_iterations == -1: 
+        # 100 is the default warmup iterations
+        if self.args.warmup_iterations == -1:
             self.args.warmup_iterations = 100
         if self.args.iterations and self.args.iterations != -1:
             self.has_explicit_iteration_count = True
@@ -196,9 +196,10 @@ class BenchmarkRunner(object):
 
             report_run_time = 1e6 * run_time_sec / iters
             time_trace.append(report_run_time)
-            # Print out the time spent in each epoch in ms 
+            # Print out the time spent in each epoch in ms
             if self.args.ai_pep_format:
-                test_name = '_'.join([test_case.framework, test_case.test_config.test_name])
+                mode = "JIT" if self.use_jit else "Eager"
+                test_name = '_'.join([test_case.framework, test_case.test_config.test_name, mode])
                 print("PyTorchObserver " + json.dumps(
                     {
                         "type": test_name,


### PR DESCRIPTION
Summary: as title

Test Plan:
```
buck run //caffe2/benchmarks/operator_benchmark/pt:add_test -- iterations 1 --ai_pep_format true
# ----------------------------------------
# PyTorch/Caffe2 Operator Micro-benchmarks
# ----------------------------------------
# Tag : short

# Benchmarking PyTorch: add
PyTorchObserver {"type": "PyTorch_add_M64_N64_K64_cpu_Eager", "metric": "latency", "unit": "ms", "value": "26.64516019518487"}

Reviewed By: hl475

Differential Revision: D18336980

