### PR TITLE
add cuda to all op benchmark

### DIFF
--- a/benchmarks/operator_benchmark/pt/add_test.py
+++ b/benchmarks/operator_benchmark/pt/add_test.py
@@ -13,7 +13,7 @@ add_long_configs = op_bench.cross_product_configs(
     M=[8, 64, 128],
     N=range(2, 128, 64),
     K=[8 ** x for x in range(0, 3)],
-    device=['cpu'],
+    device=['cpu', 'cuda'],
     tags=["long"]
 )
 
@@ -25,7 +25,7 @@ add_short_configs = op_bench.config_list(
         [64, 64, 128],
     ],
     cross_product_configs={
-        'device': ['cpu'],
+        'device': ['cpu', 'cuda'],
     },
     tags=["short"],
 )

--- a/benchmarks/operator_benchmark/pt/as_strided_test.py
+++ b/benchmarks/operator_benchmark/pt/as_strided_test.py
@@ -18,7 +18,7 @@ as_strided_configs_short = op_bench.config_list(
         [512, 512, (64, 64), (2, 2), 1],
     ],
     cross_product_configs={
-        'device': ['cpu'],
+        'device': ['cpu', 'cuda'],
     },
     tags=["short"],
 )
@@ -29,7 +29,7 @@ as_strided_configs_long = op_bench.cross_product_configs(
     size=[(16, 16), (128, 128)],
     stride=[(1, 1), (2, 2)],
     storage_offset=[0, 1],
-    device=['cpu'],
+    device=['cpu', 'cuda'],
     tags=['long']
 )
 

--- a/benchmarks/operator_benchmark/pt/batchnorm_test.py
+++ b/benchmarks/operator_benchmark/pt/batchnorm_test.py
@@ -17,7 +17,7 @@ batchnorm_configs_short = op_bench.config_list(
         [1, 256, 3136],
     ],
     cross_product_configs={
-        'device': ['cpu'],
+        'device': ['cpu', 'cuda'],
     },
     tags=["short"]
 )
@@ -26,7 +26,7 @@ batchnorm_configs_long = op_bench.cross_product_configs(
     M=[1, 128],
     N=[2 ** 16, 2048],
     K=[1],
-    device=['cpu'],
+    device=['cpu', 'cuda'],
     tags=["long"]
 )
 

--- a/benchmarks/operator_benchmark/pt/cat_test.py
+++ b/benchmarks/operator_benchmark/pt/cat_test.py
@@ -18,7 +18,7 @@ cat_configs_short = op_bench.config_list(
         [512, 512, 2, 1],
     ],
     cross_product_configs={
-        'device': ['cpu'],
+        'device': ['cpu', 'cuda'],
     },
     tags=['short'],
 )
@@ -28,7 +28,7 @@ cat_configs_long = op_bench.cross_product_configs(
     N=[128, 1024],
     K=[1, 2],
     dim=[0, 1, 2],
-    device=['cpu'],
+    device=['cpu', 'cuda'],
     tags=['long']
 )
 

--- a/benchmarks/operator_benchmark/pt/chunk_test.py
+++ b/benchmarks/operator_benchmark/pt/chunk_test.py
@@ -18,7 +18,7 @@ chunk_short_configs = op_bench.config_list(
         [512, 512, 2],
     ],
     cross_product_configs={
-        'device': ['cpu'],
+        'device': ['cpu', 'cuda'],
     },
     tags=["short"],
 )
@@ -27,7 +27,7 @@ chunks_long_configs = op_bench.cross_product_configs(
     M=[128, 1024],
     N=[128, 1024],
     chunks=[2, 4],
-    device=['cpu'],
+    device=['cpu', 'cuda'],
     tags=['long']
 )
 

--- a/benchmarks/operator_benchmark/pt/conv_test.py
+++ b/benchmarks/operator_benchmark/pt/conv_test.py
@@ -24,7 +24,7 @@ conv_1d_configs_short = op_bench.config_list(
         [256, 256, 3, 2, 16, 128],
     ],
     cross_product_configs={
-        'device': ['cpu'],
+        'device': ['cpu', 'cuda'],
     },
     tags=['short']
 )
@@ -36,7 +36,7 @@ conv_1d_configs_long = op_bench.cross_product_configs(
     stride=[1, 2],
     N=[4, 8],
     L=[64, 128],
-    device=['cpu'],
+    device=['cpu', 'cuda'],
     tags=["long"]
 )
 
@@ -81,7 +81,7 @@ conv_2d_configs_short = op_bench.config_list(
         [256, 256, 3, 1, 1, 16, 16],
     ],
     cross_product_configs={
-        'device': ['cpu'],
+        'device': ['cpu', 'cuda'],
     },
     tags=['short']
 )
@@ -94,7 +94,7 @@ conv_2d_configs_long = op_bench.cross_product_configs(
     N=[4, 8],
     H=[32, 64],
     W=[32, 64],
-    device=['cpu'],
+    device=['cpu', 'cuda'],
     tags=["long"]
 )
 
@@ -138,7 +138,7 @@ conv_3d_configs_short = op_bench.config_list(
         [256, 256, 3, 1, 8, 4, 16, 16],
     ],
     cross_product_configs={
-        'device': ['cpu'],
+        'device': ['cpu', 'cuda'],
     },
     tags=['short']
 )
@@ -153,7 +153,7 @@ conv_3d_configs_long = op_bench.cross_product_configs(
     D=[4, 8],
     H=[32, 64],
     W=[32, 64],
-    device=['cpu'],
+    device=['cpu', 'cuda'],
     tags=["long"]
 )
 

--- a/benchmarks/operator_benchmark/pt/fill_test.py
+++ b/benchmarks/operator_benchmark/pt/fill_test.py
@@ -10,7 +10,7 @@ fill_short_configs = op_bench.config_list(
         [2048],
     ],
     cross_product_configs={
-        'device': ['cpu'],
+        'device': ['cpu', 'cuda'],
         'dtype': [torch.int32],
     },
     tags=["short"],

--- a/benchmarks/operator_benchmark/pt/gather_test.py
+++ b/benchmarks/operator_benchmark/pt/gather_test.py
@@ -18,7 +18,7 @@ gather_configs_short = op_bench.config_list(
         [512, 512, 1],
     ],
     cross_product_configs={
-        'device': ['cpu'],
+        'device': ['cpu', 'cuda'],
     },
     tags=["short"]
 )
@@ -28,7 +28,7 @@ gather_configs_long = op_bench.cross_product_configs(
     M=[128, 1024],
     N=[128, 1024],
     dim=[0, 1],
-    device=['cpu'],
+    device=['cpu', 'cuda'],
     tags=["long"]
 )
 

--- a/benchmarks/operator_benchmark/pt/linear_test.py
+++ b/benchmarks/operator_benchmark/pt/linear_test.py
@@ -18,7 +18,7 @@ linear_configs_short = op_bench.config_list(
         [16, 1024, 256],
     ],
     cross_product_configs={
-        'device': ['cpu'],
+        'device': ['cpu', 'cuda'],
     },
     tags=["short"]
 )
@@ -28,7 +28,7 @@ linear_configs_long = op_bench.cross_product_configs(
     N=[32, 64],
     IN=[128, 512],
     OUT=[64, 128],
-    device=['cpu'],
+    device=['cpu', 'cuda'],
     tags=["long"]
 )
 

--- a/benchmarks/operator_benchmark/pt/matmul_test.py
+++ b/benchmarks/operator_benchmark/pt/matmul_test.py
@@ -16,7 +16,7 @@ mm_short_configs = op_bench.config_list(
         [256, 256, 256, False, True],
     ],
     cross_product_configs={
-        'device': ['cpu'],
+        'device': ['cpu', 'cuda'],
     },
     tags=["short"],
 )
@@ -28,7 +28,7 @@ mm_long_configs = op_bench.cross_product_configs(
     K=[128, 512, 1024],
     trans_a=[True, False],
     trans_b=[True, False],
-    device=['cpu'],
+    device=['cpu', 'cuda'],
     tags=["long"]
 )
 

--- a/benchmarks/operator_benchmark/pt/pool_test.py
+++ b/benchmarks/operator_benchmark/pt/pool_test.py
@@ -20,7 +20,7 @@ pool_1d_configs_short = op_bench.config_list(
         [3, 1, 8, 256, 256],
     ],
     cross_product_configs={
-        'device': ['cpu'],
+        'device': ['cpu', 'cuda'],
     },
     tags=['short']
 )
@@ -31,7 +31,7 @@ pool_1d_configs_long = op_bench.cross_product_configs(
     N=[8, 16],
     C=[3],
     L=[128, 256],
-    device=['cpu'],
+    device=['cpu', 'cuda'],
     tags=['long']
 )
 

--- a/benchmarks/operator_benchmark/pt/softmax_test.py
+++ b/benchmarks/operator_benchmark/pt/softmax_test.py
@@ -24,7 +24,7 @@ softmax_configs_short = op_bench.config_list(
         [8, 3, 512, 512],
     ],
     cross_product_configs={
-        'device': ['cpu'],
+        'device': ['cpu', 'cuda'],
     },
     tags=['short']
 )
@@ -35,7 +35,7 @@ softmax_configs_long = op_bench.cross_product_configs(
     C=[3, 64],
     H=[64, 128],
     W=[64, 128],
-    device=['cpu'],
+    device=['cpu', 'cuda'],
     tags=['long']
 )
 

--- a/benchmarks/operator_benchmark/pt/split_test.py
+++ b/benchmarks/operator_benchmark/pt/split_test.py
@@ -18,7 +18,7 @@ split_configs_short = op_bench.config_list(
         [512, 512, 2],
     ],
     cross_product_configs={
-        'device': ['cpu'],
+        'device': ['cpu', 'cuda'],
     },
     tags=["short"],
 )
@@ -27,7 +27,7 @@ split_configs_long = op_bench.cross_product_configs(
     M=[128, 1024],
     N=[128, 1024],
     parts=[2, 4],
-    device=['cpu'],
+    device=['cpu', 'cuda'],
     tags=['long']
 )
 

--- a/benchmarks/operator_benchmark/pt/unary_test.py
+++ b/benchmarks/operator_benchmark/pt/unary_test.py
@@ -18,7 +18,7 @@ unary_ops_configs_short = op_bench.config_list(
         [512, 512],
     ],
     cross_product_configs={
-        'device': ['cpu'],
+        'device': ['cpu', 'cuda'],
     },
     tags=['short']
 )
@@ -26,7 +26,7 @@ unary_ops_configs_short = op_bench.config_list(
 unary_ops_configs_long = op_bench.cross_product_configs(
     M=[256, 1024],
     N=[256, 1024],
-    device=['cpu'],
+    device=['cpu', 'cuda'],
     tags=['long']
 )
 


### PR DESCRIPTION
Summary: as title

Test Plan:
```
buck run mode/dev-nosan //caffe2/benchmarks/operator_benchmark:benchmark_all_test -- --iterations 1

# ----------------------------------------
# PyTorch/Caffe2 Operator Micro-benchmarks
# ----------------------------------------
# Tag : short

# Benchmarking PyTorch: ConvTranspose2d
# Mode: Eager
# Name: ConvTranspose2d_kernel3_out_c256_H16_in_c256_N1_stride1_W16_cpu
# Input: kernel: 3, out_c: 256, H: 16, in_c: 256, N: 1, stride: 1, W: 16, device: cpu
Forward Execution Time (us) : 10434.151

Differential Revision: D18338258

