### PR TITLE
[WIP] C++ API parity: add Dropout, Dropout2D, Dropout3D

### DIFF
--- a/torch/csrc/api/include/torch/nn/functional/dropout.h
+++ b/torch/csrc/api/include/torch/nn/functional/dropout.h
@@ -9,25 +9,25 @@ namespace functional {
 
 inline Tensor dropout(Tensor input, const DropoutOptions& options) {
   if (options.inplace()) {
-    return torch::dropout_(input, options.p(), this->is_training());
+    return torch::dropout_(input, options.p(), input->is_training());
   } else {
-    return torch::dropout(input, options.p(), this->is_training()); 
+    return torch::dropout(input, options.p(), input->is_training()); 
   }
 }
 
 inline Tensor dropout2d(Tensor input, const Dropout2dOptions& options) {
   if (options.inplace()) {
-    return torch::feature_dropout_(input, options.p(), this->is_training());
+    return torch::feature_dropout_(input, options.p(), input->is_training());
   } else {
-    return torch::feature_dropout(input, options.p(), this->is_training()); 
+    return torch::feature_dropout(input, options.p(), input->is_training()); 
   }
 }
 
 inline Tensor dropout3d(Tensor input, const Dropout3dOptions& options) {
   if (options.inplace()) {
-    return torch::feature_dropout_(input, options.p(), this->is_training());
+    return torch::feature_dropout_(input, options.p(), input->is_training());
   } else {
-    return torch::feature_dropout(input, options.p(), this->is_training()); 
+    return torch::feature_dropout(input, options.p(), input->is_training()); 
   }
 }
 

--- a/torch/csrc/api/include/torch/nn/functional/dropout.h
+++ b/torch/csrc/api/include/torch/nn/functional/dropout.h
@@ -7,27 +7,27 @@ namespace torch {
 namespace nn {
 namespace functional {
 
-inline Tensor dropout(Tensor input, const DropoutOptions& options) {
+inline Tensor dropout(Tensor input, const DropoutOptions& options, bool training = false) {
   if (options.inplace()) {
-    return torch::dropout_(input, options.p(), input->is_training());
+    return torch::dropout_(input, options.p(), training);
   } else {
-    return torch::dropout(input, options.p(), input->is_training()); 
+    return torch::dropout(input, options.p(), training); 
   }
 }
 
-inline Tensor dropout2d(Tensor input, const Dropout2dOptions& options) {
+inline Tensor dropout2d(Tensor input, const Dropout2dOptions& options, bool training = false) {
   if (options.inplace()) {
-    return torch::feature_dropout_(input, options.p(), input->is_training());
+    return torch::feature_dropout_(input, options.p(), training);
   } else {
-    return torch::feature_dropout(input, options.p(), input->is_training()); 
+    return torch::feature_dropout(input, options.p(), training); 
   }
 }
 
-inline Tensor dropout3d(Tensor input, const Dropout3dOptions& options) {
+inline Tensor dropout3d(Tensor input, const Dropout3dOptions& options, bool training = false) {
   if (options.inplace()) {
-    return torch::feature_dropout_(input, options.p(), input->is_training());
+    return torch::feature_dropout_(input, options.p(), training);
   } else {
-    return torch::feature_dropout(input, options.p(), input->is_training()); 
+    return torch::feature_dropout(input, options.p(), training); 
   }
 }
 

--- a/torch/csrc/api/include/torch/nn/functional/dropout.h
+++ b/torch/csrc/api/include/torch/nn/functional/dropout.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <torch/nn/functional/activation.h>
+#include <torch/nn/options/dropout.h>
+
+namespace torch {
+namespace nn {
+namespace functional {
+
+inline Tensor dropout(Tensor input, const DropoutOptions& options) {
+  if (options.inplace()) {
+    return torch::dropout_(input, options.p(), this->is_training());
+  } else {
+    return torch::dropout(input, options.p(), this->is_training()); 
+  }
+}
+
+inline Tensor dropout2d(Tensor input, const Dropout2dOptions& options) {
+  if (options.inplace()) {
+    return torch::feature_dropout_(input, options.p(), this->is_training());
+  } else {
+    return torch::feature_dropout(input, options.p(), this->is_training()); 
+  }
+}
+
+inline Tensor dropout3d(Tensor input, const Dropout3dOptions& options) {
+  if (options.inplace()) {
+    return torch::feature_dropout_(input, options.p(), this->is_training());
+  } else {
+    return torch::feature_dropout(input, options.p(), this->is_training()); 
+  }
+}
+
+} // namespace functional
+} // namespace nn
+} // namespace torch

--- a/torch/csrc/api/include/torch/nn/modules/dropout.h
+++ b/torch/csrc/api/include/torch/nn/modules/dropout.h
@@ -2,6 +2,7 @@
 
 #include <torch/nn/cloneable.h>
 #include <torch/nn/options/dropout.h>
+#include <torch/nn/functional/dropout.h>
 #include <torch/nn/pimpl.h>
 #include <torch/types.h>
 
@@ -13,34 +14,73 @@
 namespace torch {
 namespace nn {
 
-namespace detail {
-template <typename Derived>
-class DropoutImplBase : public torch::nn::Cloneable<Derived> {
+template <size_t D, typename Derived>
+class TORCH_API DropoutImplBase : public torch::nn::Cloneable<Derived> {
  public:
-  explicit DropoutImplBase(const DropoutOptions& options_ = DropoutOptions());
+  explicit DropoutImplBase(const DropoutOptions<D>& options_ = DropoutOptions());
 
   void reset() override;
 
-  /// The options used to configure this `Dropout` module.
-  DropoutOptions options;
+  /// Pretty prints the `Dropout{1,2,3}d` module into the given `stream`.
+  void pretty_print(std::ostream& stream) const override;
+
+  /// The options with which this `Module` was constructed.
+  DropoutOptions<D> options;
 };
-} // namespace detail
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Dropout ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies [Dropout](https://arxiv.org/abs/1207.0580) during training.
 ///
 /// See https://pytorch.org/docs/stable/nn.html#torch.nn.Dropout to learn more
 /// about the exact semantics of this module.
-class TORCH_API DropoutImpl : public detail::DropoutImplBase<DropoutImpl> {
+class TORCH_API DropoutImpl : public DropoutImplBase<1, DropoutImpl> {
  public:
-  explicit DropoutImpl(const DropoutOptions& options_ = DropoutOptions());
-
-  /// During training, applies a noise mask to the input tensor.
-  /// During evaluation, applies an identity function.
+  using DropoutImplBase<1, DropoutImpl>::DropoutImplBase;
   Tensor forward(const Tensor& input);
-
-  /// Pretty prints the `Dropout` module into the given `stream`.
-  void pretty_print(std::ostream& stream) const override;
 };
+
+/// A `ModuleHolder` subclass for `DropoutImpl`.
+/// See the documentation for `DropoutImpl` class to learn what methods it
+/// provides, or the documentation for `ModuleHolder` to learn about PyTorch's
+/// module storage semantics.
+TORCH_MODULE(Dropout);
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Dropout2d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+/// Applies dropout over a 2-D input.
+/// See https://pytorch.org/docs/master/nn.html#torch.nn.Dropout2d to learn
+/// about the exact behavior of this module.
+class TORCH_API Dropout2dImpl : public DropoutImplBase<2, Dropout2dImpl> {
+ public:
+  using DropoutImplBase<2, Dropout2dImpl>::DropoutImplBase;
+  Tensor forward(const Tensor& input);
+};
+
+/// A `ModuleHolder` subclass for `Dropout2dImpl`.
+/// See the documentation for `Dropout2dImpl` class to learn what methods it
+/// provides, or the documentation for `ModuleHolder` to learn about PyTorch's
+/// module storage semantics.
+TORCH_MODULE(Dropout2d);
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Dropout3d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+/// Applies dropout over a 3-D input.
+/// See https://pytorch.org/docs/master/nn.html#torch.nn.Dropout3d to learn
+/// about the exact behavior of this module.
+class TORCH_API Dropout3dImpl : public DropoutImplBase<3, Dropout3dImpl> {
+ public:
+  using DropoutImplBase<3, Dropout3dImpl>::DropoutImplBase;
+  Tensor forward(const Tensor& input);
+};
+
+/// A `ModuleHolder` subclass for `Dropout3dImpl`.
+/// See the documentation for `Dropout3dImpl` class to learn what methods it
+/// provides, or the documentation for `ModuleHolder` to learn about PyTorch's
+/// module storage semantics.
+TORCH_MODULE(Dropout3d);
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ FeatureDropout ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies spatial [Dropout](https://arxiv.org/abs/1207.0580) to inputs with
 /// 2-D or 3-D features.
@@ -63,12 +103,6 @@ class TORCH_API FeatureDropoutImpl
   /// Pretty prints the `FeatureDropout` module into the given `stream`.
   void pretty_print(std::ostream& stream) const override;
 };
-
-/// A `ModuleHolder` subclass for `DropoutImpl`.
-/// See the documentation for `DropoutImpl` class to learn what methods it
-/// provides, or the documentation for `ModuleHolder` to learn about PyTorch's
-/// module storage semantics.
-TORCH_MODULE(Dropout);
 
 /// A `ModuleHolder` subclass for `FeatureDropoutImpl`.
 /// See the documentation for `FeatureDropoutImpl` class to learn what methods

--- a/torch/csrc/api/include/torch/nn/modules/dropout.h
+++ b/torch/csrc/api/include/torch/nn/modules/dropout.h
@@ -17,7 +17,9 @@ namespace nn {
 template <size_t D, typename Derived>
 class TORCH_API DropoutImplBase : public torch::nn::Cloneable<Derived> {
  public:
-  explicit DropoutImplBase(const DropoutOptions<D>& options_ = DropoutOptions());
+  DropoutImplBase(double p)
+      : DropoutImplBase((DropoutOptions<D>)(p)) {}
+  explicit DropoutImplBase(const DropoutOptionsBase<D>& options_);
 
   void reset() override;
 
@@ -25,7 +27,7 @@ class TORCH_API DropoutImplBase : public torch::nn::Cloneable<Derived> {
   void pretty_print(std::ostream& stream) const override;
 
   /// The options with which this `Module` was constructed.
-  DropoutOptions<D> options;
+  DropoutOptionsBase<D> options;
 };
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Dropout ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -92,9 +94,11 @@ TORCH_MODULE(Dropout3d);
 /// 3-D features. This `FeatureDropout` module can instead deal with both 2-D
 /// and 3-D features.
 class TORCH_API FeatureDropoutImpl
-    : public detail::DropoutImplBase<FeatureDropoutImpl> {
+    : public DropoutImplBase<2, FeatureDropoutImpl> {
  public:
-  explicit FeatureDropoutImpl(const DropoutOptions& options_ = DropoutOptions());
+  FeatureDropoutImpl(double p)
+      : FeatureDropoutImpl(FeatureDropoutOptions(p)) {}
+  explicit FeatureDropoutImpl(const FeatureDropoutOptions& options_);
 
   /// During training, applies a noise mask to the input tensor.
   /// During evaluation, applies an identity function.

--- a/torch/csrc/api/include/torch/nn/options/dropout.h
+++ b/torch/csrc/api/include/torch/nn/options/dropout.h
@@ -9,8 +9,10 @@ namespace nn {
 
 /// Options for `Dropout` and `FeatureDropout`.
 template <size_t D>
-struct DropoutOptions {
-  /* implicit */ DropoutOptions(double p = 0.5, bool inplace = false);
+struct DropoutOptionsBase {
+	  DropoutOptionsBase(double p)
+      : p_(p), inplace_(false) {}
+
   /// The probability with which a particular component of the input is set to
   /// zero.
   /// Changes to this parameter at runtime are effective.
@@ -21,14 +23,16 @@ struct DropoutOptions {
 };
 
 /// `DropoutOptions` specialized for 1-D Dropout.
-using DropoutOptions = DropoutOptions<1>;
+using DropoutOptions = DropoutOptionsBase<1>;
 
 /// `DropoutOptions` specialized for 2-D Dropout.
-using Dropout2dOptions = DropoutOptions<2>;
+using Dropout2dOptions = DropoutOptionsBase<2>;
 
 /// `DropoutOptions` specialized for 3-D Dropout.
-using Dropout3dOptions = DropoutOptions<3>;
+using Dropout3dOptions = DropoutOptionsBase<3>;
 
+/// `DropoutOptions` for old FeatureDropoutModule.
+using FeatureDropoutOptions = DropoutOptionsBase<2>;
 
 } // namespace nn
 } // namespace torch

--- a/torch/csrc/api/include/torch/nn/options/dropout.h
+++ b/torch/csrc/api/include/torch/nn/options/dropout.h
@@ -8,13 +8,27 @@ namespace torch {
 namespace nn {
 
 /// Options for `Dropout` and `FeatureDropout`.
-struct TORCH_API DropoutOptions {
-  /* implicit */ DropoutOptions(double rate = 0.5);
+template <size_t D>
+struct DropoutOptions {
+  /* implicit */ DropoutOptions(double p = 0.5, bool inplace = false);
   /// The probability with which a particular component of the input is set to
   /// zero.
   /// Changes to this parameter at runtime are effective.
-  TORCH_ARG(double, rate);
+  TORCH_ARG(double, p);
+
+  /// If set to True, will do this operation in-place
+  TORCH_ARG(bool, inplace);
 };
+
+/// `DropoutOptions` specialized for 1-D Dropout.
+using DropoutOptions = DropoutOptions<1>;
+
+/// `DropoutOptions` specialized for 2-D Dropout.
+using Dropout2dOptions = DropoutOptions<2>;
+
+/// `DropoutOptions` specialized for 3-D Dropout.
+using Dropout3dOptions = DropoutOptions<3>;
+
 
 } // namespace nn
 } // namespace torch

--- a/torch/csrc/api/src/nn/modules/dropout.cpp
+++ b/torch/csrc/api/src/nn/modules/dropout.cpp
@@ -14,7 +14,7 @@ namespace torch {
 namespace nn {
 
 template <size_t D, typename Derived>
-DropoutImplBase<D, Derived>::DropoutImplBase(const DropoutOptions<D>& options_)
+DropoutImplBase<D, Derived>::DropoutImplBase(const DropoutOptionsBase<D>& options_)
     : options(options_) {
   TORCH_CHECK(options.p() >= 0 && options.p() <= 1,
   	"dropout probability has to be between 0 and 1, but got ", options.p());
@@ -24,22 +24,23 @@ template <size_t D, typename Derived>
 void DropoutImplBase<D, Derived>::reset() {}
 
 template <size_t D, typename Derived>
-void AvgPoolImpl<D, Derived>::pretty_print(std::ostream& stream) const {
+void DropoutImplBase<D, Derived>::pretty_print(std::ostream& stream) const {
+
   stream << "torch::nn::Dropout" << D << "d"
          << "(p=" << options.p()
          << ", inplace=" << options.inplace() << ")";
 }
 
 Tensor DropoutImpl::forward(const Tensor& input) {
-  return F::dropout(input, options);
+  return F::dropout(input, options, this->is_training());
 }
 
 Tensor Dropout2dImpl::forward(const Tensor& input) {
-  return F::dropout2d(input, options);
+  return F::dropout2d(input, options, this->is_training());
 }
 
 Tensor Dropout3dImpl::forward(const Tensor& input) {
-  return F::dropout3d(input, options);
+  return F::dropout3d(input, options, this->is_training());
 }
 
 template class DropoutImplBase<1, DropoutImpl>;
@@ -48,7 +49,7 @@ template class DropoutImplBase<3, Dropout3dImpl>;
 
 template class DropoutImplBase<FeatureDropoutImpl>;
 
-FeatureDropoutImpl::FeatureDropoutImpl(const DropoutOptions& options_)
+FeatureDropoutImpl::FeatureDropoutImpl(const DropoutOptionsBase& options_)
     : DropoutImplBase(options_) {}
 
 Tensor FeatureDropoutImpl::forward(const Tensor& input) {

--- a/torch/csrc/api/src/nn/options/dropout.cpp
+++ b/torch/csrc/api/src/nn/options/dropout.cpp
@@ -3,7 +3,11 @@
 namespace torch {
 namespace nn {
 
-DropoutOptions::DropoutOptions(double rate) : rate_(rate) {}
+DropoutOptions::DropoutOptions(double p) : p_(p) {}
+
+template struct DropoutOptions<1>;
+template struct DropoutOptions<2>;
+template struct DropoutOptions<3>;
 
 } // namespace nn
 } // namespace torch

--- a/torch/csrc/api/src/nn/options/dropout.cpp
+++ b/torch/csrc/api/src/nn/options/dropout.cpp
@@ -3,11 +3,11 @@
 namespace torch {
 namespace nn {
 
-DropoutOptions::DropoutOptions(double p) : p_(p) {}
+DropoutOptionsBase::DropoutOptionsBase(double p) : p_(p) {}
 
-template struct DropoutOptions<1>;
-template struct DropoutOptions<2>;
-template struct DropoutOptions<3>;
+template struct DropoutOptionsBase<1>;
+template struct DropoutOptionsBase<2>;
+template struct DropoutOptionsBase<3>;
 
 } // namespace nn
 } // namespace torch


### PR DESCRIPTION
Todo:

1) Add tests for functional modules
2) Add deprecation warning for FeatureDropout
3) Check for traces of DropoutOptions(rate=) and replace with p