### PR TITLE
CPU-strided-complex support for ComplexFloat

### DIFF
--- a/aten/src/ATen/native/cpu/CopyKernel.cpp
+++ b/aten/src/ATen/native/cpu/CopyKernel.cpp
@@ -34,6 +34,38 @@ void copy_kernel_cast(TensorIterator& iter) {
     }
 }
 
+template <>
+void copy_kernel_cast<std::complex<float>>(TensorIterator& iter) {
+  // Specialization for inter-complex dtypes
+  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(
+    ScalarType::Half,
+    ScalarType::Bool,
+    ScalarType::BFloat16,
+    iter.dtype(1),
+    "copy_kernel_cast",
+    [&] {
+      cpu_kernel(iter, [=](scalar_t a) -> std::complex<float> {
+        return c10::static_cast_with_inter_type<std::complex<float>>(a);
+      });
+    });
+}
+
+template <>
+void copy_kernel_cast<std::complex<double>>(TensorIterator& iter) {
+  // Specialization for inter-complex dtypes
+  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(
+    ScalarType::Half,
+    ScalarType::Bool,
+    ScalarType::BFloat16,
+    iter.dtype(1),
+    "copy_kernel_cast",
+    [&] {
+      cpu_kernel(iter, [=](scalar_t a) -> std::complex<double> {
+        return c10::static_cast_with_inter_type<std::complex<double>>(a);
+      });
+    });
+}
+
 static void copy_kernel(TensorIterator& iter, bool non_blocking) {
   ScalarType dtype = iter.dtype(0);
   if (dtype == iter.dtype(1)) {


### PR DESCRIPTION
Re-submit of #29133

In-tree changes to pytorch to support complex numbers are being submitted here.
Out-of-tree support for complex numbers is here: [pytorch-cpu-strided-complex extension](https://gitlab.com/pytorch-complex/pytorch-cpu-strided-complex)

Changes
- [x]  Fixed Vec256 Permute operations for Complex Float
- [x]  Fixed copy_kernel_cast between complex data types
  -  copy_kernel_cast should not call std::real during inter-complex dtype conversion.