### PR TITLE
[pytorch] process_group_agent optimizations

### DIFF
--- a/torch/csrc/distributed/rpc/process_group_agent.h
+++ b/torch/csrc/distributed/rpc/process_group_agent.h
@@ -25,11 +25,22 @@ struct SendWork {
 // SendWork wraps a Message and RecvWork wraps a Tensor. The difference here is
 // to allow us to run serialization/deserialization in the worker threads.
 struct RecvWork {
-  RecvWork(const WorkerInfo& from, MessageType type, torch::Tensor&& payload)
-      : from_(from), type_(type), payload_(payload) {}
+  RecvWork(
+      const WorkerInfo& from,
+      MessageType type,
+      int64_t id,
+      int32_t serialization,
+      torch::Tensor&& payload)
+      : from_(from),
+        type_(type),
+        id_(id),
+        serialization_(serialization),
+        payload_(payload) {}
 
   const WorkerInfo& from_;
   const MessageType type_;
+  const int64_t id_;
+  const int32_t serialization_;
   torch::Tensor payload_;
 };
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#29296 [pytorch] process_group_agent optimizations**
* #29253 [pytorch] Support process_group_agent "sending to itself"

This change adds a few optimizations to process_group_agent:

 1) Don't add an extra tensor during serialization for the message id,
    but instead put that in the preamble tensor. This saves maybe 15%
    overhead for minimal-sized RPCs.

 2) Add a payload-only fastpath.
    a) For very tiny messages (e.g. acks, status updates), this reduces RPC overhead by roughly 50%, by removing zip file overhead and related setup/copying in torch::load()/torch::save().
    b) If we do end up with large non-tensor payloads, this saves us ~25% in benchmarks, from avoiding copying in torch::save/load.

Differential Revision: [D18352261](https://our.internmc.facebook.com/intern/diff/D18352261/)