### PR TITLE
[jit] directly infer the module interface type from type annotation

### DIFF
--- a/test/test_jit_py3.py
+++ b/test/test_jit_py3.py
@@ -233,6 +233,26 @@ class TestScriptPy3(JitTestCase):
                 if True:
                     x : Optional[int] = 7
 
+    def test_module_annotation(self):
+        class Foo(nn.Module):
+            def __init__(self):
+                super(Foo, self).__init__()
+
+            def forward(self, x):
+                return x + 2
+
+        class Bar(nn.Module):
+            foo: Foo
+            def __init__(self):
+                super(Bar, self).__init__()
+                self.foo = Foo()
+
+            def forward(self, x):
+                return self.foo(x)
+
+        scripted_mod = torch.jit.script(Bar())
+        input = torch.randn(3, 4)
+        self.assertEqual(scripted_mod(input), input + 2)
 
     def test_any_in_class_fails(self):
         class MyCoolNamedTuple(NamedTuple):

--- a/test/test_jit_py3.py
+++ b/test/test_jit_py3.py
@@ -243,6 +243,7 @@ class TestScriptPy3(JitTestCase):
 
         class Bar(nn.Module):
             foo: Foo
+
             def __init__(self):
                 super(Bar, self).__init__()
                 self.foo = Foo()

--- a/torch/jit/_recursive.py
+++ b/torch/jit/_recursive.py
@@ -114,10 +114,11 @@ def infer_raw_concrete_type(nn_module):
         added_names.add(name)
 
     for name, item in nn_module._modules.items():
-        attr_type = infer_type(name, item)
-        if attr_type is not None:
-            # if the type can be inferred, it should be a module interface type
-            concrete_type.add_module_interface(name, attr_type)
+        module_ann = class_annotations.get(name)
+        if module_ann is not None and hasattr(module_ann, "__torch_script_interface__"):
+            # if we could infer module interface type from annotation, add it as module interface
+            module_interface_type = torch._C.InterfaceType(_jit_internal._qualified_name(module_ann))
+            concrete_type.add_module_interface(name, module_interface_type)
         else:
             # otherwise we get the concrete module type for item and add it to concrete_type
             sub_concrete_type = concrete_type_store.get_or_create_concrete_type(item)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#29298 [jit] directly infer the module interface type from type annotation**

Summary:
User sometimes could use their user-defined class or nn.Module as type
annotation instead of types from the typing module to annotate thier
modules, our `annotations.ann_to_type` only support JIT type
annotations, and raise error if it's not JIT supported type.

When we infer the module interface type, we should consider this use
case and do more explicitly type inference to only infer the interface
type from type annotation

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: