### PR TITLE
Revert "Revert D18171156: Merge Tensor and Variable."

### DIFF
--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -142,22 +142,22 @@ CAFFE2_API Allocator* getCPUAllocator();
 
 static inline DeprecatedTypeProperties& getNonVariableDeprecatedTypeProperties(Backend p, ScalarType s) {
   return globalDeprecatedTypePropertiesRegistry().getDeprecatedTypeProperties(
-      p, s, /*is_variable*/false);
+      p, s);
 }
 
 static inline DeprecatedTypeProperties& CPU(ScalarType s) {
   return globalDeprecatedTypePropertiesRegistry().getDeprecatedTypeProperties(
-      Backend::CPU, s, /*is_variable*/false);
+      Backend::CPU, s);
 }
 
 static inline DeprecatedTypeProperties& CUDA(ScalarType s) {
   return globalDeprecatedTypePropertiesRegistry().getDeprecatedTypeProperties(
-      Backend::CUDA, s, /*is_variable*/false);
+      Backend::CUDA, s);
 }
 
 static inline DeprecatedTypeProperties& HIP(ScalarType s) {
   return globalDeprecatedTypePropertiesRegistry().getDeprecatedTypeProperties(
-      Backend::HIP, s, /*is_variable*/false);
+      Backend::HIP, s);
 }
 
 static inline bool hasCUDA() {

--- a/aten/src/ATen/InitialTensorOptions.h
+++ b/aten/src/ATen/InitialTensorOptions.h
@@ -9,7 +9,7 @@ namespace at {
 // NOTE: this is not a stable API.
 inline TensorOptions initialTensorOptions() {
   return TensorOptions(kCPU).dtype(kFloat).layout(kStrided)
-                            .requires_grad(false).is_variable(false);
+                            .requires_grad(false);
 }
 
 }

--- a/aten/src/ATen/core/DeprecatedTypeProperties.h
+++ b/aten/src/ATen/core/DeprecatedTypeProperties.h
@@ -19,8 +19,8 @@ class Tensor;
 // dtype-specific.
 class CAFFE2_API DeprecatedTypeProperties {
  public:
-  DeprecatedTypeProperties(Backend backend, ScalarType scalar_type, bool is_variable)
-    : backend_(backend), scalar_type_(scalar_type), is_variable_(is_variable) {}
+  DeprecatedTypeProperties(Backend backend, ScalarType scalar_type)
+    : backend_(backend), scalar_type_(scalar_type) {}
 
   Backend backend() const {
     return backend_;
@@ -50,10 +50,6 @@ class CAFFE2_API DeprecatedTypeProperties {
     return scalarTypeToTypeMeta(scalar_type_);
   }
 
-  bool is_variable() const {
-    return is_variable_;
-  }
-
   bool operator==(const DeprecatedTypeProperties& other) const {
     return backend_ == other.backend() && scalar_type_ == other.scalarType();
   }
@@ -69,20 +65,17 @@ class CAFFE2_API DeprecatedTypeProperties {
     } else {
       base_str = std::string(at::toString(backend_)) + at::toString(scalar_type_) + "Type";
     }
-    if (is_variable_) {
-      return "Variable[" + base_str + "]";
-    }
     return base_str;
   }
 
   DeprecatedTypeProperties & toBackend(Backend b) const {
     return globalDeprecatedTypePropertiesRegistry().getDeprecatedTypeProperties(
-        b, scalar_type_, is_variable_);
+        b, scalar_type_);
   }
 
   DeprecatedTypeProperties & toScalarType(ScalarType s) const {
     return globalDeprecatedTypePropertiesRegistry().getDeprecatedTypeProperties(
-        backend_, s, is_variable_);
+        backend_, s);
   }
 
   DeprecatedTypeProperties & cpu() const {
@@ -101,8 +94,7 @@ class CAFFE2_API DeprecatedTypeProperties {
   TensorOptions options(int16_t device_index = -1) const {
     return TensorOptions().dtype(typeMeta())
                           .device(device_type(), device_index)
-                          .layout(layout())
-                          .is_variable(is_variable());
+                          .layout(layout());
   }
 
   /// Constructs the `TensorOptions` from a type and a Device.  Asserts that
@@ -134,7 +126,6 @@ class CAFFE2_API DeprecatedTypeProperties {
  private:
   Backend backend_;
   ScalarType scalar_type_;
-  bool is_variable_;
 };
 
 }  // namespace at

--- a/aten/src/ATen/core/DeprecatedTypePropertiesRegistry.cpp
+++ b/aten/src/ATen/core/DeprecatedTypePropertiesRegistry.cpp
@@ -11,19 +11,16 @@ void DeprecatedTypePropertiesDeleter::operator()(DeprecatedTypeProperties * ptr)
 DeprecatedTypePropertiesRegistry::DeprecatedTypePropertiesRegistry() {
   for (int b = 0; b < static_cast<int>(Backend::NumOptions); ++b) {
     for (int s = 0; s < static_cast<int>(ScalarType::NumOptions); ++s) {
-      for (int v = 0; v < 2; ++ v) {
-        registry[b][s][v] = c10::guts::make_unique<DeprecatedTypeProperties>(
-                static_cast<Backend>(b),
-                static_cast<ScalarType>(s),
-                v);
-      }
+      registry[b][s] = c10::guts::make_unique<DeprecatedTypeProperties>(
+              static_cast<Backend>(b),
+              static_cast<ScalarType>(s));
     }
   }
 }
 
 DeprecatedTypeProperties& DeprecatedTypePropertiesRegistry::getDeprecatedTypeProperties(
-    Backend p, ScalarType s, bool is_variable) const {
-  return *registry[static_cast<int>(p)][static_cast<int>(s)][is_variable];
+    Backend p, ScalarType s) const {
+  return *registry[static_cast<int>(p)][static_cast<int>(s)];
 }
 
 // TODO: This could be bad juju if someone calls globalContext() in the

--- a/aten/src/ATen/core/DeprecatedTypePropertiesRegistry.h
+++ b/aten/src/ATen/core/DeprecatedTypePropertiesRegistry.h
@@ -18,13 +18,12 @@ class CAFFE2_API DeprecatedTypePropertiesRegistry {
  public:
   DeprecatedTypePropertiesRegistry();
 
-  DeprecatedTypeProperties& getDeprecatedTypeProperties(Backend p, ScalarType s, bool is_variable) const;
+  DeprecatedTypeProperties& getDeprecatedTypeProperties(Backend p, ScalarType s) const;
 
 private:
   std::unique_ptr<DeprecatedTypeProperties> registry
     [static_cast<int>(Backend::NumOptions)]
-    [static_cast<int>(ScalarType::NumOptions)]
-    [2];  // is_variable
+    [static_cast<int>(ScalarType::NumOptions)];
 };
 
 CAFFE2_API DeprecatedTypePropertiesRegistry& globalDeprecatedTypePropertiesRegistry();

--- a/aten/src/ATen/core/LegacyTypeDispatch.h
+++ b/aten/src/ATen/core/LegacyTypeDispatch.h
@@ -50,7 +50,34 @@ CAFFE2_API LegacyTypeDispatch& globalLegacyTypeDispatch();
 // A RAII, thread local (!) guard that will disable dispatch to variable
 // handler.
 //
-// See NOTE [ Treating Variables as non-Variables in type dispatch ] for details.
+// NOTE [ Treating Variables as non-Variables in type dispatch ]
+//
+// What exactly does AutoNonVariableType do?  The short answer is, it causes
+// dispatches on ATen functions to go to the non-variable implementation,
+// bypassing autograd handling (and also profiling and tracing).
+//
+// To understand why this guard exists, it's helpful to understand the history
+// behind how Variable was implemented.  Previously, Variables were implemented
+// as a wrapper on Tensors; so the act of processing a Variable involved
+// unwrapping the underlying Tensor, and then calling the underlying base
+// operation on /that/ operation
+//
+// However, after the Variable/Tensor merge, there is no concept of unwrapping
+// a tensor anymore.  If you just call the operation on the same variable
+// again inside your VariableType handler, you'll dispatch back to
+// VariableType, which is not what we want.
+//
+// The solution to the above problem is to add `at::NonVariableTypeMode`, which
+// when enabled will cause `legacyTensorType()` and `getType()` to always return
+// non-Variable type, even if the tensor being called on is a variable.
+//
+// TODO: Since `torch::NoGradGuard` serves the same purpose in libtorch, we should
+// merge these two thread-local guards.  However, NoGradGuard does something
+// subtly different: it turns of gradient recording, but DOES NOT skip
+// VariableType implementation (as we still might need to profile or trace).
+// To unify the two, we would first have to move profiling and tracing out of
+// VariableType.
+
 struct CAFFE2_API AutoNonVariableTypeMode {
   // NB: The enabled parameter must ALWAYS be black, as Henry Ford used to say.
   // TODO: Eliminate this parameter entirely
@@ -61,5 +88,11 @@ struct CAFFE2_API AutoNonVariableTypeMode {
   }
   c10::impl::ExcludeTensorTypeIdGuard guard_;
 };
+
+namespace impl {
+inline bool variable_is_excluded() {
+  return c10::impl::tls_local_tensor_type_set().excluded_.has(TensorTypeId::VariableTensorId);
+}
+}
 
 } // namespace at

--- a/aten/src/ATen/core/Tensor.cpp
+++ b/aten/src/ATen/core/Tensor.cpp
@@ -13,18 +13,15 @@ void Tensor::enforce_invariants() {
   // supported by ATen
   scalar_type();
   if (defined()) {
-    // If it's a variable - we definitely not in C2 land
-    if (!is_variable()) {
-      AT_ASSERTM(
-          impl_->dtype_initialized(),
-          "Partially-initialized tensor not supported by at::Tensor");
-      AT_ASSERTM(
-          !impl_->is_sparse(),
-          "Sparse Tensors are supported by at::Tensor, but invariant checking isn't implemented.  Please file a bug.");
-      AT_ASSERTM(
-          impl_->storage_initialized(),
-          "Partially-initialized tensor not supported by at::Tensor");
-    }
+    AT_ASSERTM(
+        impl_->dtype_initialized(),
+        "Partially-initialized tensor not supported by at::Tensor");
+    AT_ASSERTM(
+        !impl_->is_sparse(),
+        "Sparse Tensors are supported by at::Tensor, but invariant checking isn't implemented.  Please file a bug.");
+    AT_ASSERTM(
+        impl_->storage_initialized(),
+        "Partially-initialized tensor not supported by at::Tensor");
   }
 }
 

--- a/aten/src/ATen/cpp_custom_type_hack.h
+++ b/aten/src/ATen/cpp_custom_type_hack.h
@@ -26,6 +26,9 @@ T& cast(const Tensor& packed) {
 
 template <typename T>
 Tensor create(std::unique_ptr<T> ptr, TensorOptions options) {
+  // None of this should trace, so turn off Variable handling
+  at::AutoNonVariableTypeMode guard;
+
   // We store this instance away in a Tensor and register a deleter function
   // so that we do not leak memory. On the other side, we pull out the storage's
   // data_ptr and get the right typed pointer.

--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -86,7 +86,7 @@ Tensor _dim_arange(const Tensor& like, int64_t dim) {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ empty ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Tensor empty_cpu(IntArrayRef size, const TensorOptions& options, c10::optional<c10::MemoryFormat> optional_memory_format) {
   AT_ASSERT(options.device().type() == DeviceType::CPU);
-  AT_ASSERT(!options.is_variable());  // is_variable should have been 'unpacked'  // TODO: remove this when Variable and Tensor are merged
+  TORCH_INTERNAL_ASSERT(impl::variable_is_excluded());
   check_size_nonnegative(size);
 
   c10::Allocator* allocator;

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -30,7 +30,7 @@ Tensor _reshape_from_tensor(const Tensor& self, const Tensor& shape_tensor) {
 }
 
 Tensor _shape_as_tensor(const Tensor& self) {
-  auto options = TensorOptions(at::kLong).is_variable(self.options().is_variable());
+  auto options = TensorOptions(at::kLong);
   return at::tensor(self.sizes(), options);
 }
 

--- a/aten/src/ATen/native/cuda/TensorFactories.cu
+++ b/aten/src/ATen/native/cuda/TensorFactories.cu
@@ -45,7 +45,7 @@ Tensor& eye_out_cuda(Tensor& result, int64_t n, int64_t m) {
 
 Tensor empty_cuda(IntArrayRef size, const TensorOptions& options, c10::optional<MemoryFormat> optional_memory_format) {
   AT_ASSERT(options.backend() == at::Backend::CUDA);
-  AT_ASSERT(!options.is_variable());  // is_variable should have been 'unpacked'  // TODO: remove this when Variable and Tensor are merged
+  TORCH_INTERNAL_ASSERT(impl::variable_is_excluded());
   TORCH_CHECK(!options.pinned_memory(), "Only dense CPU tensors can be pinned");
   check_size_nonnegative(size);
 

--- a/aten/src/ATen/native/cudnn/RNN.cpp
+++ b/aten/src/ATen/native/cudnn/RNN.cpp
@@ -1153,14 +1153,12 @@ struct DropoutState {
 
 DropoutState& get_dropout_state(double dropout_p, bool train, TensorOptions options) {
   // Each state is slightly over 2MB and initialized lazily, so it's fine to cache them.
-  static std::vector<DropoutState> ten_dropout_state_cache { static_cast<size_t>(cuda::getNumGPUs()) };
-  static std::vector<DropoutState> var_dropout_state_cache { static_cast<size_t>(cuda::getNumGPUs()) };
+  static std::vector<DropoutState> dropout_state_cache { static_cast<size_t>(cuda::getNumGPUs()) };
   static std::mutex state_cache_mut;
 
   int device = cuda::current_device();
   std::unique_lock<std::mutex> lock {state_cache_mut};
-  auto& state = options.is_variable() ? var_dropout_state_cache.at(device)
-                                      : ten_dropout_state_cache.at(device);
+  auto& state = dropout_state_cache.at(device);
   if (train && dropout_p > 0 && !state.buffer.defined()) {
     std::unique_lock<std::mutex> lock {state.mutex};
     int64_t seed = at::empty({}, at::kLong).random_().item<int64_t>();

--- a/aten/src/ATen/native/sparse/SparseTensor.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensor.cpp
@@ -71,7 +71,7 @@ Tensor values_sparse(const Tensor& self) {
 /*** Helper methods ***/
 
 SparseTensor new_sparse(const TensorOptions& options) {
-  AT_ASSERT(!options.is_variable());  // TODO: remove this when Variable and Tensor are merged
+  TORCH_INTERNAL_ASSERT(impl::variable_is_excluded());
   AT_ASSERT(options.layout() == kSparse);
   TensorTypeId type_id;
   if (options.device().is_cuda()) {

--- a/aten/src/ATen/quantized/Quantizer.cpp
+++ b/aten/src/ATen/quantized/Quantizer.cpp
@@ -474,10 +474,9 @@ QuantizerPtr make_per_channel_affine_quantizer(
 }
 
 QTensorImpl* get_qtensorimpl(const Tensor& self) {
-  // TODO: remove this when Variable and Tensor are merged
-  TORCH_INTERNAL_ASSERT(
-      !self.is_variable(),
-      "_internal_get_QTensorImpl: should not be a variable");
+  TORCH_CHECK(
+      !self.requires_grad(),
+      "quantized tensors do not support autograd");
   TORCH_INTERNAL_ASSERT(self.is_quantized(), "get_qtensorimpl: not a quantized tensor");
   return static_cast<QTensorImpl*>(self.unsafeGetTensorImpl());
 }

--- a/aten/src/ATen/templates/Functions.h
+++ b/aten/src/ATen/templates/Functions.h
@@ -28,6 +28,7 @@ inline Tensor from_blob(
     IntArrayRef strides,
     const std::function<void(void*)>& deleter,
     const TensorOptions& options = {}) {
+  AutoNonVariableTypeMode guard;
   auto device = globalContext().getDeviceFromPtr(data, options.device().type());
   if (options.device().has_index()) {
     TORCH_CHECK(

--- a/aten/src/ATen/templates/LegacyTHFunctions.cpp
+++ b/aten/src/ATen/templates/LegacyTHFunctions.cpp
@@ -28,8 +28,7 @@ namespace {
   TensorOptions options(ScalarType s) {
     return TensorOptions().dtype(s)
                           .device(DeviceType::${DeviceType})
-                          .layout(kStrided)
-                          .is_variable(false);
+                          .layout(kStrided);
   }
 
   Allocator* allocator() {

--- a/aten/src/ATen/templates/TensorBody.h
+++ b/aten/src/ATen/templates/TensorBody.h
@@ -229,8 +229,7 @@ class CAFFE2_API Tensor {
   DeprecatedTypeProperties & type() const {
     return globalDeprecatedTypePropertiesRegistry().getDeprecatedTypeProperties(
         tensorTypeIdToBackend(legacyExtractTypeId(type_set())),
-        scalar_type(),
-        is_variable());
+        scalar_type());
   }
   TensorTypeSet type_set() const {
     return impl_->type_set();

--- a/aten/src/ATen/templates/TensorMethods.h
+++ b/aten/src/ATen/templates/TensorMethods.h
@@ -52,8 +52,7 @@ inline Tensor Tensor::toBackend(Backend b) const {
 inline TensorOptions Tensor::options() const {
   return TensorOptions().dtype(dtype())
                         .device(device())
-                        .layout(layout())
-                        .is_variable(is_variable());
+                        .layout(layout());
 }
 
 // all static inline to allow for inlining of the non-dynamic part of dispatch

--- a/c10/core/TensorOptions.h
+++ b/c10/core/TensorOptions.h
@@ -56,7 +56,7 @@ namespace c10 {
 /// NOTE [ TensorOptions Constructors ]
 ///
 /// TensorOptions is like a dictionary with entries from the set:
-/// {requires_grad, is_variable, device, dtype, layout}, where each entry may be
+/// {requires_grad, device, dtype, layout}, where each entry may be
 /// unspecified (i.e., is optional). It is used to specify the properties of
 /// tensors in many places both in C++ internal and API, e.g., tensor factory
 /// methods like `at::empty({10}, options)`, tensor conversions like
@@ -100,13 +100,11 @@ namespace c10 {
 struct C10_API TensorOptions {
   TensorOptions()
     : requires_grad_(false)
-    , is_variable_(false)
     , pinned_memory_(false)
     , has_device_(false)
     , has_dtype_(false)
     , has_layout_(false)
     , has_requires_grad_(false)
-    , has_is_variable_(false)
     , has_pinned_memory_(false)
     {}
 
@@ -153,12 +151,10 @@ struct C10_API TensorOptions {
         has_layout_ == other.has_layout_ &&
         has_device_ == other.has_device_ &&
         has_requires_grad_ == other.has_requires_grad_ &&
-        has_is_variable_ == other.has_is_variable_ &&
         (!has_dtype_ || dtype_ == other.dtype_) &&
         (!has_layout_ || layout_ == other.layout_) &&
         (!has_device_ || device_ == other.device_) &&
-        (!requires_grad_ || requires_grad_ == other.requires_grad_) &&
-        (!is_variable_ || is_variable_ == other.is_variable_);
+        (!requires_grad_ || requires_grad_ == other.requires_grad_);
   }
 
   /// True if any of the elements of this `TensorOptions` do not match that of
@@ -227,14 +223,6 @@ struct C10_API TensorOptions {
     r.set_requires_grad(requires_grad);
     return r;
   }
-
-  /// Sets the `is_variable` property on the `TensorOptions`.
-  C10_NODISCARD TensorOptions is_variable(c10::optional<bool> is_variable) const noexcept {
-    TensorOptions r = *this;
-    r.set_is_variable(is_variable);
-    return r;
-  }
-
 
   /// Sets the `pinned_memory` property on the `TensorOptions`.
   C10_NODISCARD TensorOptions pinned_memory(c10::optional<bool> pinned_memory) const noexcept {
@@ -313,17 +301,6 @@ struct C10_API TensorOptions {
                               : c10::nullopt;
   }
 
-  /// Returns the `is_variable` property of the `TensorOptions`.
-  bool is_variable() const noexcept {
-    return has_is_variable_ ? is_variable_ : false;
-  }
-
-  /// Returns whether the `is_variable` is specified.
-  bool has_is_variable() const noexcept {
-    return has_is_variable_;
-  }
-
-
   /// Returns the `pinned_memory` property of the `TensorOptions`.
   bool pinned_memory() const noexcept {
     return has_pinned_memory_ ? pinned_memory_ : false;
@@ -332,13 +309,6 @@ struct C10_API TensorOptions {
   /// Returns whether the `pinned_memory` is specified.
   bool has_pinned_memory() const noexcept {
     return has_pinned_memory_;
-  }
-
-
-  /// Returns the `is_variable` property of the `TensorOptions`, or
-  /// `c10::nullopt` if `is_variable` is not specified.
-  c10::optional<bool> is_variable_opt() const noexcept {
-    return has_is_variable_ ? c10::make_optional(is_variable_) : c10::nullopt;
   }
 
 
@@ -371,16 +341,13 @@ struct C10_API TensorOptions {
     if (!r.has_layout()) r.set_layout(layout());
     // NB: requires grad is right biased; not a logical AND/OR!
     if (!r.has_requires_grad()) r.set_requires_grad(requires_grad());
-    if (!r.has_is_variable()) r.set_is_variable(is_variable());
     if (!r.has_pinned_memory()) r.set_pinned_memory(pinned_memory());
     return r;
   }
 
   // Resolves the tensor type set specified by the current construction axes.
   TensorTypeSet type_set() const noexcept {
-    auto r = TensorTypeSet(computeTensorTypeId());
-    if (is_variable()) r = r.add(TensorTypeId::VariableTensorId);
-    return r;
+    return TensorTypeSet(computeTensorTypeId()).add(TensorTypeId::VariableTensorId);
   }
 
   inline TensorTypeId computeTensorTypeId() const {
@@ -504,16 +471,6 @@ struct C10_API TensorOptions {
     }
   }
 
-  /// Mutably set the `is_variable` property of `TensorOptions`.
-  void set_is_variable(c10::optional<bool> is_variable) & noexcept {
-    if (is_variable) {
-      is_variable_ = *is_variable;
-      has_is_variable_ = true;
-    } else {
-      has_is_variable_ = false;
-    }
-  }
-
   /// Mutably set the `pinned_memory` property of `TensorOptions`.
   void set_pinned_memory(c10::optional<bool> pinned_memory) & noexcept {
     if (pinned_memory) {
@@ -538,7 +495,6 @@ struct C10_API TensorOptions {
   // for that matter)
 
   bool requires_grad_     : 1;
-  bool is_variable_       : 1;
   bool pinned_memory_     : 1;
 
 
@@ -546,7 +502,6 @@ struct C10_API TensorOptions {
   bool has_dtype_         : 1;
   bool has_layout_        : 1;
   bool has_requires_grad_ : 1;
-  bool has_is_variable_   : 1;
   bool has_pinned_memory_ : 1;
 };
 

--- a/caffe2/contrib/aten/gen_op.py
+++ b/caffe2/contrib/aten/gen_op.py
@@ -154,6 +154,7 @@ OPTION_TEMPLATE = CT("""\
 case ${key}: { // ${name}
     ${initialization}
     run_op = [=] {
+        at::AutoNonVariableTypeMode guard;
         ${statements}
         auto the_result = ${invocation};
         ${assignments}

--- a/caffe2/python/workspace_test.py
+++ b/caffe2/python/workspace_test.py
@@ -299,10 +299,8 @@ class TestWorkspace(unittest.TestCase):
         t.resize_(5)
         t[4] = t[2] = 777
         np.testing.assert_array_equal(t.numpy(), np.array([2,2,777,2,777]))
-        # this doesn't work because of variable / tensor confusion
-        # the underlying data tensor is not properly reshaped :(
         np.testing.assert_array_equal(
-            workspace.FetchBlob("foo"), np.array([2,2,777,2]))
+            workspace.FetchBlob("foo"), np.array([2,2,777,2,777]))
 
         z = torch.ones((4,), dtype=torch.int64)
         workspace.FeedBlob('bar', z)
@@ -388,10 +386,8 @@ class TestWorkspaceGPU(test_util.TestCase):
         t[4] = t[2] = 777
         np.testing.assert_array_equal(
             t.cpu().numpy(), np.array([2,2,777,2,777]))
-        # this doesn't work because of variable / tensor confusion
-        # the underlying data tensor is not properly reshaped :(
         np.testing.assert_array_equal(
-            workspace.FetchBlob("foo"), np.array([2,2,777,2]))
+            workspace.FetchBlob("foo"), np.array([2,2,777,2,777]))
 
         z = torch.ones((4,), dtype=torch.int64, device="cuda")
         workspace.FeedBlob('bar', z)

--- a/test/cpp/api/tensor.cpp
+++ b/test/cpp/api/tensor.cpp
@@ -731,9 +731,6 @@ TEST(TensorTest, DataPtr) {
 TEST(TensorTest, Data) {
   const auto tensor = torch::rand({3, 3});
   ASSERT_TRUE(torch::equal(tensor, tensor.data()));
-
-  const auto tensor2 = at::rand({3, 3});
-  ASSERT_THROW(tensor2.data(), c10::Error);
 }
 
 TEST(TensorTest, BackwardAndGrad) {
@@ -741,11 +738,6 @@ TEST(TensorTest, BackwardAndGrad) {
   auto y = x * x;
   y.backward();
   ASSERT_EQ(x.grad().item<float>(), 10.0);
-
-  x = at::tensor({5});
-  y = x * x;
-  ASSERT_THROWS_WITH(y.backward(), "backward is not implemented for Tensor");
-  ASSERT_THROWS_WITH(x.grad(), "grad is not implemented for Tensor");
 }
 
 TEST(TensorTest, BackwardCreatesOnesGrad) {
@@ -767,12 +759,6 @@ TEST(TensorTest, IsLeaf) {
   auto y = x * x;
   ASSERT_TRUE(x.is_leaf());
   ASSERT_FALSE(y.is_leaf());
-
-  x = at::tensor({5});
-  y = x * x;
-  const auto message = "is_leaf is not implemented for Tensor";
-  ASSERT_THROWS_WITH(y.is_leaf(), message);
-  ASSERT_THROWS_WITH(x.is_leaf(), message);
 }
 
 TEST(TensorTest, OutputNr) {
@@ -780,12 +766,6 @@ TEST(TensorTest, OutputNr) {
   auto y = x * x;
   ASSERT_EQ(x.output_nr(), 0);
   ASSERT_EQ(y.output_nr(), 0);
-
-  x = at::tensor({5});
-  y = x * x;
-  const auto message = "output_nr is not implemented for Tensor";
-  ASSERT_THROWS_WITH(y.output_nr(), message);
-  ASSERT_THROWS_WITH(x.output_nr(), message);
 }
 
 TEST(TensorTest, Version) {
@@ -795,14 +775,6 @@ TEST(TensorTest, Version) {
   ASSERT_EQ(x._version(), 1);
   x.add_(1);
   ASSERT_EQ(x._version(), 2);
-
-  x = at::ones(3);
-  const auto message = "version is not implemented for Tensor";
-  ASSERT_THROWS_WITH(x._version(), message);
-  x.mul_(2);
-  ASSERT_THROWS_WITH(x._version(), message);
-  x.add_(1);
-  ASSERT_THROWS_WITH(x._version(), message);
 }
 
 TEST(TensorTest, Detach) {
@@ -812,12 +784,6 @@ TEST(TensorTest, Detach) {
   ASSERT_FALSE(y.is_leaf());
   ASSERT_TRUE(y_detached.is_leaf());
   ASSERT_FALSE(y_detached.requires_grad());
-
-  x = at::tensor({5}, at::TensorOptions().requires_grad(false));
-  y = x * x;
-  const auto message = "detach is not implemented for Tensor";
-  ASSERT_THROWS_WITH(x.detach(), message);
-  ASSERT_THROWS_WITH(y.detach(), message);
 }
 
 TEST(TensorTest, DetachInplace) {
@@ -828,12 +794,6 @@ TEST(TensorTest, DetachInplace) {
   ASSERT_FALSE(y.requires_grad());
   ASSERT_TRUE(y_detached.is_leaf());
   ASSERT_FALSE(y_detached.requires_grad());
-
-  x = at::tensor({5}, at::TensorOptions().requires_grad(false));
-  y = x * x;
-  const auto message = "detach_ is not implemented for Tensor";
-  ASSERT_THROWS_WITH(x.detach_(), message);
-  ASSERT_THROWS_WITH(y.detach_(), message);
 }
 
 TEST(TensorTest, SetData) {
@@ -845,10 +805,6 @@ TEST(TensorTest, SetData) {
   x.set_data(y);
   ASSERT_TRUE(torch::equal(x, y));
   ASSERT_EQ(x.data_ptr<float>(), y.data_ptr<float>());
-
-  x = at::tensor({5});
-  y = at::tensor({5});
-  ASSERT_THROWS_WITH(x.set_data(y), "set_data is not implemented for Tensor");
 }
 
 TEST(TensorTest, RequiresGradInplace) {
@@ -866,11 +822,4 @@ TEST(TensorTest, RequiresGradInplace) {
   const auto int_tensor = torch::tensor({5}, at::TensorOptions().dtype(torch::kInt));
   ASSERT_THROWS_WITH(int_tensor.requires_grad_(true),
     "Only Tensors of floating point dtype can require gradients");
-
-  x = at::tensor({5}, at::TensorOptions().requires_grad(false));
-  y = x * x;
-  ASSERT_THROWS_WITH(x.requires_grad_(false),
-    "requires_grad_ is not implemented for Tensor");
-  ASSERT_THROWS_WITH(y.requires_grad_(false),
-    "requires_grad_ is not implemented for Tensor");
 }

--- a/test/expect/TestScript.test_print-stdout.expect
+++ b/test/expect/TestScript.test_print-stdout.expect
@@ -2,4 +2,4 @@
  0.9526
  0.9975
  0.9999
-[ Variable[CPUDoubleType]{4} ] 1 2 [1, 2] [1., 2.]
+[ CPUDoubleType{4} ] 1 2 [1, 2] [1., 2.]

--- a/test/expect/TestScript.test_string_print-stdout.expect
+++ b/test/expect/TestScript.test_string_print-stdout.expect
@@ -1,2 +1,2 @@
 1
-[ Variable[CPULongType]{} ] abcd 2 1.5
+[ CPULongType{} ] abcd 2 1.5

--- a/test/onnx/test_utility_funs.py
+++ b/test/onnx/test_utility_funs.py
@@ -137,8 +137,23 @@ class TestUtilityFuns(TestCase):
     def test_constant_fold_concat(self):
         class ConcatModule(torch.nn.Module):
             def forward(self, x):
-                a = torch.tensor([[1., 2., 3.]])
-                b = torch.tensor([[4., 5., 6.]])
+                # Why did I insert a Cast here?  There appears to be intentional
+                # behavior in ONNX constant folding where constant tensors which
+                # are not attached to any known to be foldable onnx
+                # operations don't get extracted into the initializer graph.  So
+                # without these casts, we will actually fail to pull out one of
+                # the constants, thus failing constant folding.  I think the
+                # test is wrong but I don't have time to write a more correct
+                # test (I think the right way to go about the test is to setup
+                # a predicate for what invariant graphs should hold after
+                # constant folding, and then verify this predicate holds.
+                # I think the asserts below are an attempt at this predicate,
+                # but it is not right!)
+                #
+                # More commentary at
+                # https://github.com/pytorch/pytorch/pull/18698/files#r340107552
+                a = torch.tensor([[1., 2., 3.]]).to(torch.float)
+                b = torch.tensor([[4., 5., 6.]]).to(torch.float)
                 c = torch.cat((a, b), 0)
                 d = b + c
                 return x + d

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -358,6 +358,13 @@ class TestJit(JitTestCase):
 
         traced_rec = torch.jit.trace(rec, (input))
 
+    def test_trace_legacy_ctor(self):
+        class MyModule(nn.Module):
+            def forward(self, x):
+                return (x + 1, torch.FloatTensor([0]))
+
+        traced_rec = torch.jit.trace(MyModule(), torch.randn(2, 2))
+
     @unittest.skip("Requires a lot of RAM")
     def test_big(self):
         m = torch.jit.ScriptModule()

--- a/tools/autograd/gen_variable_factories.py
+++ b/tools/autograd/gen_variable_factories.py
@@ -57,14 +57,12 @@ def process_function(decl, has_tensor_options, disable_autograd):
         formals.append("{} {}{}".format(type, argument["name"], default))
         actual = argument["name"]
         if argument["simple_type"] == "TensorOptions":
-            # We want to make `at::{name}` always return a
-            # tensor and not a variable, since we create a variable right after.
-            actual = "at::TensorOptions({}).is_variable(false)".format(actual)
+            actual = "at::TensorOptions({})".format(actual)
         actuals.append(actual)
     requires_grad = "options.requires_grad()" if has_tensor_options else "false"
     if decl['name'].endswith('_like') and not has_tensor_options:
         # Insert TensorOptions before MemoryFormat
-        actuals.insert(-1, '{}.options().is_variable(false)'.format(actuals[0]))
+        actuals.insert(-1, '{}.options()'.format(actuals[0]))
 
     if not disable_autograd:
         pre_record_trace, post_record_trace = format_trace(decl)

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -204,7 +204,7 @@ UNPACK_TENSOR = CodeTemplate("""\
 auto${ref} ${arg_name}_ = unpack${suffix}(${arg_name}, "${arg_name}", ${arg_pos});""")
 
 UNPACK_OPTIONS = CodeTemplate("""\
-auto ${arg_name}_ = TensorOptions(${arg_name}).is_variable(false);""")
+auto ${arg_name}_ = TensorOptions(${arg_name});""")
 
 DECLARE_GRAD_FN = CodeTemplate("""\
 std::shared_ptr<${op}> grad_fn;

--- a/tools/autograd/templates/variable_factories.h
+++ b/tools/autograd/templates/variable_factories.h
@@ -68,7 +68,7 @@ inline at::Tensor from_blob(
     const at::TensorOptions& options = at::TensorOptions()) {
   at::Tensor tensor = ([&]() {
     at::AutoNonVariableTypeMode non_var_type_mode(true);
-    return at::from_blob(data, sizes, strides, deleter, options.is_variable(false));
+    return at::from_blob(data, sizes, strides, deleter, options);
   })();
   return autograd::make_variable(tensor, options.requires_grad());
 }
@@ -104,7 +104,7 @@ inline at::Tensor from_blob(
     const at::TensorOptions& options = at::TensorOptions()) {
   at::Tensor tensor = ([&]() {
     at::AutoNonVariableTypeMode non_var_type_mode(true);
-    return at::from_blob(data, sizes, deleter, options.is_variable(false));
+    return at::from_blob(data, sizes, deleter, options);
   })();
   return autograd::make_variable(tensor, options.requires_grad());
 }

--- a/torch/csrc/api/include/torch/detail/TensorDataContainer.h
+++ b/torch/csrc/api/include/torch/detail/TensorDataContainer.h
@@ -136,19 +136,10 @@ AT_FORALL_SCALAR_TYPES_AND3(Bool, Half, BFloat16, TENSOR)
       scalar_type_(at::k##S), \
       type_(TensorDataContainerType::Tensor) { \
     at::AutoNonVariableTypeMode non_var_type_mode(true); \
-    /* NOTE: if I only use
-       `tensor_ = at::tensor(values, at::dtype(scalar_type_).device(at::kCPU).is_variable(false));` here,
-       a call such as
-       `torch::tensor(at::ArrayRef<bool>({true, false, true}))` would throw the following runtime error:
-       ```
-       C++ exception with description ""tensor_cpu" not implemented for 'Bool'
-       (operator() at ../aten/src/ATen/native/TensorFactories.cpp:850)
-       ```
-    */ \
     if (scalar_type_ == at::kBool) { \
-      tensor_ = at::tensor(values, at::TensorOptions().device(at::kCPU).is_variable(false)); \
+      tensor_ = at::tensor(values, at::TensorOptions().device(at::kCPU)); \
     } else { \
-      tensor_ = at::tensor(values, at::dtype(scalar_type_).device(at::kCPU).is_variable(false)); \
+      tensor_ = at::tensor(values, at::dtype(scalar_type_).device(at::kCPU)); \
     } \
   }
 AT_FORALL_SCALAR_TYPES_AND3(Bool, Half, BFloat16, TENSOR)
@@ -218,7 +209,7 @@ AT_FORALL_SCALAR_TYPES_AND2(Half, BFloat16, TENSOR)
 
     if (is_scalar()) {
       at::AutoNonVariableTypeMode non_var_type_mode(true);
-      return at::scalar_tensor(scalar_, options.is_variable(false));
+      return at::scalar_tensor(scalar_, options);
     } else if (is_init_list()) {
       // NOTE: Here we explicitly choose to initialize the tensor on CPU first,
       // fill each element of the tensor, and then move the tensor to the desired
@@ -228,7 +219,7 @@ AT_FORALL_SCALAR_TYPES_AND2(Half, BFloat16, TENSOR)
       // `N` is the number of the elements in the tensor).
       at::Tensor tensor = ([&]() {
         at::AutoNonVariableTypeMode non_var_type_mode(true);
-        return at::empty(sizes_, options.device(at::kCPU).is_variable(false));
+        return at::empty(sizes_, options.device(at::kCPU));
       })();
       fill_tensor(tensor);
       return tensor.to(options.device());

--- a/torch/csrc/autograd/custom_function.cpp
+++ b/torch/csrc/autograd/custom_function.cpp
@@ -13,7 +13,7 @@ VariableInfo::VariableInfo(const Variable& var)
 
 Variable VariableInfo::zeros(at::OptionalDeviceGuard& device_guard) const {
   return at::zeros(size,
-    at::TensorOptions(scalar_type).device(device).layout(layout).is_variable(true));
+    at::TensorOptions(scalar_type).device(device).layout(layout));
 }
 
 variable_list _wrap_outputs(const variable_list &input_vars,

--- a/torch/csrc/autograd/python_legacy_variable.cpp
+++ b/torch/csrc/autograd/python_legacy_variable.cpp
@@ -50,8 +50,7 @@ static PyObject *THPVariable_pynew(PyTypeObject* type, PyObject *args, PyObject 
     auto scalar_type = torch::tensors::get_default_scalar_type();
     auto options = TensorOptions(scalar_type)
         .device(computeDeviceType(type_id))
-        .layout(layout_from_backend(tensorTypeIdToBackend(type_id)))
-        .is_variable(true);
+        .layout(layout_from_backend(tensorTypeIdToBackend(type_id)));
     var = at::empty({0}, options);
   } else if (THPVariable_Check(data)) {
     var = ((THPVariable*)data)->cdata.detach();

--- a/torch/csrc/autograd/python_variable_indexing.cpp
+++ b/torch/csrc/autograd/python_variable_indexing.cpp
@@ -139,7 +139,7 @@ static Variable valueToTensor(c10::TensorOptions options, PyObject* value) {
   if (THPVariable_Check(value)) {
     return reinterpret_cast<THPVariable*>(value)->cdata;
   }
-  options = options.is_variable(true);
+  at::AutoNonVariableTypeMode guard;
   if (THPUtils_checkLong(value) || PyBool_Check(value)) {
     return at::scalar_tensor(Scalar(THPUtils_unpackLong(value)), options);
   }

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -33,6 +33,11 @@ struct Node;
 /// `Variable` called its `grad` (gradient). If the variable is a leaf, its
 /// gradient will be accumulated into this variable.
 ///
+/// Every Tensor is a Variable, but sometimes we colloquially refer to Variables
+/// that don't require gradients as Tensors (since none of the autograd
+/// machinery for Variables applies).  Historically, Variables and Tensors
+/// were separate concepts, but we've merged them together.
+///
 ///                              Gradient Edges
 ///~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 /// Furthermore, `Variable`s have the notion of a `gradient_edge`, which is the
@@ -74,12 +79,10 @@ struct Node;
 /// operations you can perform on `Tensor`s also on `Variable`s. Furthermore,
 /// `Variable` and `Tensor` actually convert implicitly between each other. You
 /// can thus call functions defined on `Tensor`s also with `Variable`s. For
-/// this, the `Variable` class allows implicit construction from `Tensor`. It is
-/// the responsibility of calling code to ensure that this constructor is
-/// invoked only when the `Tensor` contains autograd metadata. Most notably, it
-/// is *not* correct to construct a brand new `Variable` from a `Tensor` using
-/// this constructor. To do so, you must use the `make_variable` free function
-/// instead. To create a view variable, use `make_variable_view`.
+/// this, the `Variable` class allows implicit construction from `Tensor`.
+///
+/// Our intention is to eliminate the Variable class in the near future, or make
+/// it so that only internal code uses it to do internal operations.
 ///~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 struct AutogradMeta;
@@ -93,19 +96,12 @@ struct TORCH_API Variable : public at::Tensor {
   // Tensor Conversions
   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-  // "Downcasts" a `Tensor` into a `Variable`. Only call this on tensors you
-  // know are Variables.
+  // "Downcasts" a `Tensor` into a `Variable`.
   /*implicit*/ Variable(at::Tensor const& rhs) : at::Tensor(rhs) {
-    TORCH_CHECK(
-        is_variable() || !defined(),
-        "Tensor that was converted to Variable was not actually a Variable");
   }
 
   /*implicit*/ Variable(at::Tensor&& rhs)
       : at::Tensor(std::move(rhs)) {
-    TORCH_CHECK(
-        is_variable() || !defined(),
-        "Tensor that was converted to Variable was not actually a Variable");
   }
 
   // NOTE: Assignment operators to Tensor come for free from the constructors.
@@ -322,6 +318,8 @@ public:
 
 /// Each `Variable` has one unique `AutogradMeta` struct, which stores autograd
 /// metadata fields that are necessary for tracking the Variable's autograd history.
+/// As an optimization, a Variable may store a nullptr, in lieu of a default
+/// constructed AutogradMeta.
 
 struct TORCH_API AutogradMeta : public c10::AutogradMetaInterface {
   std::string name_;
@@ -520,13 +518,14 @@ inline Variable make_variable_view(
 /// set only for leaves, and determines whether the `Variable` will accumulate
 /// gradients. NOTE: `data` must *not* be a `Variable` already. Its dynamic
 /// type *must* be `Tensor`.
+///
+/// TODO: Eliminate this function as much as possible, as it can be expressed
+/// more clearly as detach() or a no-op in most call sites (especially when
+/// there is only one use of the variable).
 inline Variable make_variable(
     at::Tensor data,
     bool requires_grad = false,
     bool allow_tensor_metadata_change = true) {
-  TORCH_CHECK(
-      !data.is_variable(),
-      "Must not create a new variable from a variable, use its .tensor_data()");
   if (data.defined()) {
     if (data.getIntrusivePtr().use_count() == 1 && data.getIntrusivePtr()->unique_version()) {
       auto data_impl = data.getIntrusivePtr();
@@ -561,9 +560,6 @@ inline Variable make_variable(
     at::Tensor data,
     Edge gradient_edge,
     bool allow_tensor_metadata_change = true) {
-  TORCH_CHECK(
-      !data.is_variable(),
-      "Must not create a new variable from a variable, use its .tensor_data()");
   if (data.defined()) {
     auto data_impl_copy = data.getIntrusivePtr()->shallow_copy_and_detach(
       /*version_counter=*/0,
@@ -578,22 +574,13 @@ inline Variable make_variable(
 // Tensor Conversion
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-/// Downcasts the `Tensor` reference to a `Variable` reference. If compiling
-/// in DEBUG mode and the tensor's dynamic type is not in fact `Variable`,
-/// throws a `std::invalid_argument` exception.
+// In the old days, these casts were checked, but now that every Tensor
+// is a Variable this cast is always valid
 inline Variable& as_variable_ref(at::Tensor& tensor) {
-  TORCH_CHECK(
-      tensor.is_variable(),
-      "Attempted to cast a Tensor to a Variable, but "
-      "the dynamic type of the value is not Variable.");
   return static_cast<Variable&>(tensor);
 }
 
 inline const Variable& as_variable_ref(const at::Tensor& tensor) {
-  TORCH_CHECK(
-      tensor.is_variable(),
-      "Attempted to cast a Tensor to a Variable, but "
-      "the dynamic type of the value is not Variable.");
   return static_cast<const Variable&>(tensor);
 }
 

--- a/torch/csrc/jit/passes/onnx/constant_fold.cpp
+++ b/torch/csrc/jit/passes/onnx/constant_fold.cpp
@@ -322,6 +322,12 @@ std::vector<Node*> getOnnxConstParentsToRemove(Node* node) {
 
 // This method updates the block in-place to fold all the one-time
 // constant-based computations/ops into an initializer node.
+//
+// NB: This is not constant folding in the traditional sense, as we
+// don't try particularly hard to evaluate operations on constant nodes.
+// This is more of a partial evaluation  analysis, where operations on constant
+// nodes can be lifted so we run them earlier, before the usual parameters are
+// known.
 void ConstantFoldONNX(Block* b, ParamMap& paramsDict, int opset_version) {
   if (opset_version != ONNX_OPSET_9 && opset_version != ONNX_OPSET_10 &&
       opset_version != ONNX_OPSET_11) {

--- a/torch/csrc/jit/tracer.cpp
+++ b/torch/csrc/jit/tracer.cpp
@@ -620,8 +620,13 @@ autograd::Variable getSizeOf(const autograd::Variable& var, int64_t dim) {
   auto& tracing_state = getTracingState();
   auto& graph = tracing_state->graph;
 
-  auto size_var =
-      autograd::make_variable(scalar_to_tensor(at::Scalar(var.size(dim))));
+  Variable size_var;
+  {
+    // Make sure this scalar to tensor isn't traced!
+    at::AutoNonVariableTypeMode guard;
+    size_var =
+        autograd::make_variable(scalar_to_tensor(at::Scalar(var.size(dim))));
+  }
   auto* value = getValueTrace(var);
   auto dim_val = graph->insertConstant(dim);
   recordSourceLocation(dim_val->node());

--- a/torch/csrc/utils/python_arg_parser.cpp
+++ b/torch/csrc/utils/python_arg_parser.cpp
@@ -667,8 +667,12 @@ at::Tensor PythonArgs::tensor_slow(int i) {
     throw TypeError("expected Tensor as argument %d, but got %s", i,
         Py_TYPE(obj)->tp_name);
   }
-  auto tensor = scalar_to_tensor(scalar);
-  tensor.unsafeGetTensorImpl()->set_wrapped_number(true);
+  at::Tensor tensor;
+  {
+    at::AutoNonVariableTypeMode guard;
+    tensor = scalar_to_tensor(scalar);
+    tensor.unsafeGetTensorImpl()->set_wrapped_number(true);
+  }
   return autograd::make_variable(tensor);
 }
 

--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -66,8 +66,7 @@ Backend backendToBackendOfDeviceType(Backend b, DeviceType d) {
 TensorOptions options(c10::TensorTypeId type_id, at::ScalarType scalar_type, const c10::optional<Device>& device=c10::nullopt) {
   auto options = TensorOptions(scalar_type)
       .device(computeDeviceType(type_id))
-      .layout(layout_from_backend(tensorTypeIdToBackend(type_id)))
-      .is_variable(true);
+      .layout(layout_from_backend(tensorTypeIdToBackend(type_id)));
   if (device.has_value()) {
     return options.device(device);
   }
@@ -277,13 +276,28 @@ Tensor internal_new_from_data(
 
   auto sizes = compute_sizes(data);
   ScalarType inferred_scalar_type = type_inference ? infer_scalar_type(data) : scalar_type;
-  auto tensor = autograd::make_variable(at::empty(sizes, at::initialTensorOptions().dtype(inferred_scalar_type).pinned_memory(pin_memory)), /*requires_grad=*/false);
-  recursive_store(
-      (char*)tensor.data_ptr(), tensor.sizes(), tensor.strides(), 0,
-      inferred_scalar_type, tensor.dtype().itemsize(), data);
+  // This exists to prevent us from tracing the call to empty().  The actual
+  // autograd code doesn't really matter, because requires_grad is always false
+  // here.
+  Tensor tensor;
+  {
+    at::AutoNonVariableTypeMode guard;
+    tensor = at::empty(sizes, at::initialTensorOptions().dtype(inferred_scalar_type).pinned_memory(pin_memory));
+    recursive_store(
+        (char*)tensor.data_ptr(), tensor.sizes(), tensor.strides(), 0,
+        inferred_scalar_type, tensor.dtype().itemsize(), data);
+  }
   auto device = device_opt.has_value() ? *device_opt : at::Device(computeDeviceType(type_id));
   AutoNoGIL no_gil;
   maybe_initialize_cuda(device);
+  // However, it is VERY important that we trace the to() call here (even
+  // though the reason this is important is a hack).  Without *some* factory
+  // function call that is traced at construction time, we will consider
+  // a tensor constant as originating from "outside" the trace, and if you
+  // try to return it directly we will fail with the error saying no
+  // "no observable data dependence".  In an ideal world, we wouldn't trace
+  // a to() call but I need to think harder about what exactly we should trace
+  // in this case.
   return tensor.to(device, inferred_scalar_type, /*non_blocking=*/false, /*copy=*/false);
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #29213 Delete all trivial uses of make_variable.
* #29204 Miscellaneous follow up for code review comments
* #29203 Rename getNonVariableDeprecatedTypeProperties to getDeprecatedTypeProperties
* **#29299 Revert "Revert D18171156: Merge Tensor and Variable."**

This reverts commit 9c43b16df9dad3dfb4da1efab68d8c88e6437e8f.

Differential Revision: [D18353504](https://our.internmc.facebook.com/intern/diff/D18353504)