### PR TITLE
Raise an error if ROCm patch fails to apply.

### DIFF
--- a/tools/amd_build/build_amd.py
+++ b/tools/amd_build/build_amd.py
@@ -112,7 +112,7 @@ if not args.out_of_place_only:
     # Apply patch files in place (PyTorch only)
     patch_folder = os.path.join(amd_build_dir, "patches")
     for filename in os.listdir(os.path.join(amd_build_dir, "patches")):
-        subprocess.Popen(["git", "apply", os.path.join(patch_folder, filename)], cwd=proj_dir)
+        subprocess.check_call(["git", "apply", os.path.join(patch_folder, filename)], cwd=proj_dir)
 
 # Check if the compiler is hip-clang.
 def is_hip_clang():


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#29303 Raise an error if ROCm patch fails to apply.**

Signed-off-by: Edward Z. Yang <ezyang@fb.com>