### PR TITLE
explicitly provide memory format when calling to *_like operators

### DIFF
--- a/aten/src/ATen/native/Distance.cpp
+++ b/aten/src/ATen/native/Distance.cpp
@@ -129,7 +129,7 @@ Tensor _cdist_backward(const Tensor& grad, const Tensor& x1, const Tensor& x2, c
   TORCH_CHECK(device2 == kCPU || device2 == kCUDA, "_cdist_backward only supports CPU and CUDA devices, X2 got: ", device2);
   IntArrayRef batch_tensor1(x1.sizes().data(), std::max<int64_t>(x1.dim() - 2, 0));
   int batch_product = std::accumulate(batch_tensor1.begin(), batch_tensor1.end(), 1, std::multiplies<int64_t>());
-  Tensor grad_x1 = at::empty_like(x1, x1.options()).view({batch_product, n, m});
+  Tensor grad_x1 = at::empty_like(x1, x1.options(), at::MemoryFormat::Contiguous).view({batch_product, n, m});
   cdist_backward_stub(device1, grad_x1, grad, x1, x2, p, cdist);
   return grad_x1;
 }

--- a/aten/src/ATen/native/TensorIterator.cpp
+++ b/aten/src/ATen/native/TensorIterator.cpp
@@ -157,7 +157,7 @@ static void maybe_copy_casting_to_common_dtype(OperandInfo& op, ScalarType commo
       op.tensor = op.tensor.to(common_dtype);
     } else {
       op.tensor =
-          at::empty_like(op.tensor, op.tensor.options().dtype(common_dtype));
+          at::empty_like(op.tensor, op.tensor.options().dtype(common_dtype), at::MemoryFormat::Contiguous);
     }
   }
 }

--- a/aten/src/ATen/native/cuda/Copy.cu
+++ b/aten/src/ATen/native/cuda/Copy.cu
@@ -136,7 +136,7 @@ static void copy_kernel_cuda(TensorIterator& iter, bool non_blocking) {
       src_contig = iter.tensor(1).to(iter.dtype(0)).expand_as(dst).contiguous();
     } else {
       bool same_type = iter.dtype(0) == iter.dtype(1);
-      dst_contig = (dst.is_contiguous() && same_type) ? dst : at::empty_like(dst, iter.dtype(1));
+      dst_contig = (dst.is_contiguous() && same_type) ? dst : at::empty_like(dst, iter.dtype(1), at::MemoryFormat::Contiguous);
       src_contig = iter.tensor(1).expand_as(dst).contiguous();
     }
 

--- a/aten/src/ATen/native/cuda/MultinomialKernel.cu
+++ b/aten/src/ATen/native/cuda/MultinomialKernel.cu
@@ -398,12 +398,12 @@ void multinomial_kernel_impl(Tensor& result, const Tensor& self, const int64_t n
 
       // For sampling without replacement, we modify the distribution
       // for subsequent samples in this space
-      Tensor origDist = native::empty_like(self_v);
+      Tensor origDist = native::empty_like(self_v, at::MemoryFormat::Contiguous);
       origDist.copy_(self_v);
 
-      Tensor normDist = native::empty_like(self_v);
+      Tensor normDist = native::empty_like(self_v, at::MemoryFormat::Contiguous);
 
-      Tensor prefixSum = native::empty_like(self_v);
+      Tensor prefixSum = native::empty_like(self_v, at::MemoryFormat::Contiguous);
 
       // Renorm along rows
       normDist.copy_(origDist);

--- a/aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp
@@ -100,7 +100,7 @@ class QLinearDynamicInt8 final : public torch::OperatorKernel {
     out_sizes.back() = N;
     // Allocate output Tensor and a buffer for fbgemmPacked to use
     auto output = at::empty(out_sizes, input.options().dtype(at::kFloat));
-    auto buffer = at::empty_like(output, output.options().dtype(at::kInt));
+    auto buffer = at::empty_like(output, output.options().dtype(at::kInt), at::MemoryFormat::Contiguous);
 
     int num_tasks = at::get_num_threads();
     at::parallel_for(0, num_tasks, 1, [&](int64_t begin, int64_t end) {

--- a/aten/src/ATen/native/sparse/cuda/SparseCUDATensorMath.cu
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDATensorMath.cu
@@ -629,7 +629,7 @@ Tensor _sparse_sum_backward_cuda(const Tensor& grad_, const SparseTensor& input_
       auto policy = thrust::cuda::par(allocator).on(stream);
       typedef thrust::device_ptr<int64_t> thrust_ptr;
 
-      grad_input_values = at::empty_like(input_values, grad_values.options());
+      grad_input_values = at::empty_like(input_values, grad_values.options(), at::MemoryFormat::Contiguous);
       AT_ASSERT(grad_input_values.is_cuda());
 
       // get 1D indices
@@ -642,7 +642,7 @@ Tensor _sparse_sum_backward_cuda(const Tensor& grad_, const SparseTensor& input_
       thrust_ptr input_indices_iter(input_indices_1D.data_ptr<int64_t>());
 
       // store lower_bound of input indices at grad indices
-      LongTensor input_indices_pos = at::empty_like(input_indices_1D);
+      LongTensor input_indices_pos = at::empty_like(input_indices_1D, at::MemoryFormat::Contiguous);
       thrust_ptr input_indices_pos_iter(input_indices_pos.data_ptr<int64_t>());
       thrust::lower_bound(policy,
                           grad_indices_iter, grad_indices_iter + grad_nnz,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #29313 [NOT TO LAND] Switch default of *_like
* #29312 [NOT TO LAND] Change tests to *_like ops
* #29311 explicitly provide memory format when calling to *_like operators
* #29310 explicitly provide memory format when calling to *_like operators
* #29309 explicitly provide memory format when calling to *_like operators
* **#29308 explicitly provide memory format when calling to *_like operators**

