### PR TITLE
explicitly provide memory format when calling to *_like operators

### DIFF
--- a/torch/autograd/gradcheck.py
+++ b/torch/autograd/gradcheck.py
@@ -142,7 +142,7 @@ def get_analytical_jacobian(input, output, nondet_tol=0.0):
     diff_input_list = list(iter_tensors(input, True))
     jacobian = make_jacobian(input, output.numel())
     jacobian_reentrant = make_jacobian(input, output.numel())
-    grad_output = torch.zeros_like(output)
+    grad_output = torch.zeros_like(output, memory_format=torch.contiguous_format)
     flat_grad_output = grad_output.view(-1)
     reentrant = True
     correct_grad_sizes = True
@@ -300,7 +300,7 @@ def gradcheck(func, inputs, eps=1e-6, atol=1e-5, rtol=1e-3, raise_exception=True
         diff_input_list = list(iter_tensors(tupled_inputs, True))
         if not diff_input_list:
             raise RuntimeError("no Tensors requiring grad found in input")
-        grads_input = torch.autograd.grad(output, diff_input_list, [torch.zeros_like(o) for o in output],
+        grads_input = torch.autograd.grad(output, diff_input_list, [torch.zeros_like(o, memory_format=torch.contiguous_format) for o in output],
                                           allow_unused=True)
         for gi, i in zip(grads_input, diff_input_list):
             if gi is None:
@@ -381,7 +381,7 @@ def gradgradcheck(func, inputs, grad_outputs=None, eps=1e-6, atol=1e-5, rtol=1e-
         # If grad_outputs is not specified, create random Tensors of the same
         # shape, type, and device as the outputs
         def randn_like(x):
-            y = torch.testing.randn_like(x if x.is_floating_point() else x.double())
+            y = torch.testing.randn_like(x if x.is_floating_point() else x.double(), memory_format=torch.contiguous_format)
             if gen_non_contig_grad_outputs:
                 y = torch.testing.make_non_contiguous(y)
             return y.requires_grad_()

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -264,7 +264,7 @@ def isfinite(tensor):
     # have a similar concept. It's safe to assume any created LongTensor doesn't
     # overflow and it's finite.
     if not tensor.is_floating_point():
-        return torch.ones_like(tensor, dtype=torch.bool)
+        return torch.ones_like(tensor, dtype=torch.bool, memory_format=torch.contiguous_format)
     return (tensor == tensor) & (tensor.abs() != inf)
 
 
@@ -285,7 +285,7 @@ def isinf(tensor):
     if not isinstance(tensor, torch.Tensor):
         raise TypeError("The argument is not a tensor: {}".format(repr(tensor)))
     if tensor.dtype in [torch.uint8, torch.int8, torch.int16, torch.int32, torch.int64]:
-        return torch.zeros_like(tensor, dtype=torch.bool)
+        return torch.zeros_like(tensor, dtype=torch.bool, memory_format=torch.contiguous_format)
     return tensor.abs() == inf
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #29313 [NOT TO LAND] Switch default of *_like
* #29312 [NOT TO LAND] Change tests to *_like ops
* #29311 explicitly provide memory format when calling to *_like operators
* #29310 explicitly provide memory format when calling to *_like operators
* **#29309 explicitly provide memory format when calling to *_like operators**
* #29308 explicitly provide memory format when calling to *_like operators

