### PR TITLE
explicitly provide memory format when calling to *_like operators

### DIFF
--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -182,14 +182,14 @@
   batch2: batch1.transpose(1, 2).bmm(grad) * alpha
 
 - name: bernoulli(Tensor self, *, Generator? generator=None) -> Tensor
-  self: zeros_like(grad)
+  self: zeros_like(grad, at::MemoryFormat::Preserve)
 
 - name: bernoulli_.Tensor(Tensor(a!) self, Tensor p, *, Generator? generator=None) -> Tensor(a!)
-  self: zeros_like(grad)
-  p: zeros_like(p)
+  self: zeros_like(grad, at::MemoryFormat::Preserve)
+  p: zeros_like(p, at::MemoryFormat::Preserve)
 
 - name: bernoulli_.float(Tensor(a!) self, float p=0.5, *, Generator? generator=None) -> Tensor(a!)
-  self: zeros_like(grad)
+  self: zeros_like(grad, at::MemoryFormat::Preserve)
 
 - name: bmm(Tensor self, Tensor mat2) -> Tensor
   self: grad.bmm(mat2.transpose(1, 2))
@@ -199,10 +199,10 @@
   tensors: cat_tensors_backward(grad, to_args_sizes(tensors), dim)
 
 - name: cauchy_(Tensor(a!) self, float median=0, float sigma=1, *, Generator? generator=None) -> Tensor(a!)
-  self: zeros_like(grad)
+  self: zeros_like(grad, at::MemoryFormat::Preserve)
 
 - name: ceil(Tensor self) -> Tensor
-  self: zeros_like(grad)
+  self: zeros_like(grad, at::MemoryFormat::Preserve)
 
 - name: cholesky(Tensor self, bool upper=False) -> Tensor
   self: cholesky_backward(grad, upper, result)
@@ -298,11 +298,11 @@
   self: not_implemented("eig")
 
 - name: eq_.Scalar(Tensor(a!) self, Scalar other) -> Tensor(a!)
-  self: zeros_like(self)
+  self: zeros_like(self, at::MemoryFormat::Preserve)
 
 - name: eq_.Tensor(Tensor(a!) self, Tensor other) -> Tensor(a!)
-  self: zeros_like(self)
-  other: zeros_like(other)
+  self: zeros_like(self, at::MemoryFormat::Preserve)
+  other: zeros_like(other, at::MemoryFormat::Preserve)
 
 - name: erf(Tensor self) -> Tensor
   self: 2.0 / sqrt(M_PI) * exp(-(self.pow(2))) * grad
@@ -323,7 +323,7 @@
   self: at::sum_to(grad, self.sizes())
 
 - name: exponential_(Tensor(a!) self, float lambd=1, *, Generator? generator=None) -> Tensor(a!)
-  self: zeros_like(grad)
+  self: zeros_like(grad, at::MemoryFormat::Preserve)
 
 - name: fake_quantize_per_tensor_affine(Tensor self, float scale, int zero_point, int quant_min, int quant_max) -> Tensor
   self: fake_quantize_per_tensor_affine_backward(grad, self, scale, zero_point, quant_min, quant_max)
@@ -332,14 +332,14 @@
   self: fake_quantize_per_channel_affine_backward(grad, self, scale, zero_point, axis, quant_min, quant_max)
 
 - name: fill_.Scalar(Tensor(a!) self, Scalar value) -> Tensor(a!)
-  self: zeros_like(grad)
+  self: zeros_like(grad, at::MemoryFormat::Preserve)
 
 - name: fill_.Tensor(Tensor(a!) self, Tensor value) -> Tensor(a!)
-  self: zeros_like(grad)
+  self: zeros_like(grad, at::MemoryFormat::Preserve)
   value: grad.sum()
 
 - name: floor(Tensor self) -> Tensor
-  self: zeros_like(grad)
+  self: zeros_like(grad, at::MemoryFormat::Preserve)
 
 - name: fmod.Scalar(Tensor self, Scalar other) -> Tensor
   self: grad
@@ -356,14 +356,14 @@
   index: non_differentiable
 
 - name: ge_.Scalar(Tensor(a!) self, Scalar other) -> Tensor(a!)
-  self: zeros_like(self)
+  self: zeros_like(self, at::MemoryFormat::Preserve)
 
 - name: ge_.Tensor(Tensor(a!) self, Tensor other) -> Tensor(a!)
-  self: zeros_like(self)
-  other: zeros_like(other)
+  self: zeros_like(self, at::MemoryFormat::Preserve)
+  other: zeros_like(other, at::MemoryFormat::Preserve)
 
 - name: geometric_(Tensor(a!) self, float p, *, Generator? generator=None) -> Tensor(a!)
-  self: zeros_like(grad)
+  self: zeros_like(grad, at::MemoryFormat::Preserve)
 
 - name: geqrf(Tensor self) -> (Tensor a, Tensor tau)
   self: not_implemented("geqrf")
@@ -385,11 +385,11 @@
   input, grid: grid_sampler_3d_backward(grad, input, grid, interpolation_mode, padding_mode, align_corners)
 
 - name: gt_.Scalar(Tensor(a!) self, Scalar other) -> Tensor(a!)
-  self: zeros_like(self)
+  self: zeros_like(self, at::MemoryFormat::Preserve)
 
 - name: gt_.Tensor(Tensor(a!) self, Tensor other) -> Tensor(a!)
-  self: zeros_like(self)
-  other: zeros_like(other)
+  self: zeros_like(self, at::MemoryFormat::Preserve)
+  other: zeros_like(other, at::MemoryFormat::Preserve)
 
 - name: histc(Tensor self, int bins=100, Scalar min=0, Scalar max=0) -> Tensor
   self: not_implemented("histc")
@@ -398,7 +398,7 @@
   self: Scalar(std::complex<double>{0.0, 1.0})*grad.to(self.scalar_type())
 
 - name: index.Tensor(Tensor self, Tensor?[] indices) -> Tensor
-  self: index_backward(zeros_like(self), indices, grad)
+  self: index_backward(zeros_like(self, at::MemoryFormat::Preserve), indices, grad)
   indices: TensorList()
 
 - name: index_add_(Tensor(a!) self, int dim, Tensor index, Tensor source) -> Tensor(a!)
@@ -421,11 +421,11 @@
   index: non_differentiable
 
 - name: index_put_(Tensor(a!) self, Tensor?[] indices, Tensor values, bool accumulate=False) -> Tensor(a!)
-  self: "accumulate ? grad : grad.clone().index_put_(indices, zeros_like(values), false)"
+  self: "accumulate ? grad : grad.clone().index_put_(indices, zeros_like(values, at::MemoryFormat::Preserve), false)"
   values: grad.index(indices)
 
 - name: _index_put_impl_(Tensor(a!) self, Tensor?[] indices, Tensor values, bool accumulate=False, bool unsafe=False) -> Tensor(a!)
-  self: "accumulate ? grad : grad.clone().index_put_(indices, zeros_like(values), false)"
+  self: "accumulate ? grad : grad.clone().index_put_(indices, zeros_like(values, at::MemoryFormat::Preserve), false)"
   values: grad.index(indices)
 
 - name: index_select(Tensor self, int dim, Tensor index) -> Tensor
@@ -439,11 +439,11 @@
   self: index_select_backward(grad, dim, indices, self.sizes(), keepdim)
 
 - name: le_.Scalar(Tensor(a!) self, Scalar other) -> Tensor(a!)
-  self: zeros_like(self)
+  self: zeros_like(self, at::MemoryFormat::Preserve)
 
 - name: le_.Tensor(Tensor(a!) self, Tensor other) -> Tensor(a!)
-  self: zeros_like(self)
-  other: zeros_like(other)
+  self: zeros_like(self, at::MemoryFormat::Preserve)
+  other: zeros_like(other, at::MemoryFormat::Preserve)
 
 - name: lerp.Scalar(Tensor self, Tensor end, Scalar weight) -> Tensor
   self: grad * (1 - weight.toDouble())
@@ -479,7 +479,7 @@
   self: logdet_backward(grad, self, result)
 
 - name: log_normal_(Tensor(a!) self, float mean=1, float std=2, *, Generator? generator=None) -> Tensor(a!)
-  self: zeros_like(grad)
+  self: zeros_like(grad, at::MemoryFormat::Preserve)
 
 - name: logsumexp(Tensor self, int[1] dim, bool keepdim=False) -> Tensor
   self: logsumexp_backward(grad, self, result, dim, keepdim)
@@ -489,11 +489,11 @@
   A: not_implemented("lstsq")
 
 - name: lt_.Scalar(Tensor(a!) self, Scalar other) -> Tensor(a!)
-  self: zeros_like(self)
+  self: zeros_like(self, at::MemoryFormat::Preserve)
 
 - name: lt_.Tensor(Tensor(a!) self, Tensor other) -> Tensor(a!)
-  self: zeros_like(self)
-  other: zeros_like(other)
+  self: zeros_like(self, at::MemoryFormat::Preserve)
+  other: zeros_like(other, at::MemoryFormat::Preserve)
 
 - name: _lu_with_info(Tensor self, bool pivot=True, bool check_errors=True) -> (Tensor, Tensor, Tensor)
   self: not_implemented("lu_with_info")
@@ -507,7 +507,7 @@
 
 - name: masked_fill_.Tensor(Tensor(a!) self, Tensor mask, Tensor value) -> Tensor(a!)
   self: grad.clone().masked_fill_(mask, 0)
-  value: at::where(mask, grad, zeros_like(grad)).sum()
+  value: at::where(mask, grad, zeros_like(grad, at::MemoryFormat::Preserve)).sum()
   mask: non_differentiable
 
 - name: masked_scatter_(Tensor(a!) self, Tensor mask, Tensor source) -> Tensor(a!)
@@ -601,11 +601,11 @@
   input, weight, bias: "GradMode::is_enabled() || grads[1].defined() || grads[2].defined() ? infinitely_differentiable_native_layer_norm_backward(grads[0], grads[1], grads[2], input, result1, result2, weight, M, N, eps, grad_input_mask) : native_layer_norm_backward(grads[0].is_contiguous() ? grads[0] : grads[0].contiguous(), input, result1, result2, weight, M, N, grad_input_mask)"
 
 - name: ne_.Scalar(Tensor(a!) self, Scalar other) -> Tensor(a!)
-  self: zeros_like(self)
+  self: zeros_like(self, at::MemoryFormat::Preserve)
 
 - name: ne_.Tensor(Tensor(a!) self, Tensor other) -> Tensor(a!)
-  self: zeros_like(self)
-  other: zeros_like(other)
+  self: zeros_like(self, at::MemoryFormat::Preserve)
+  other: zeros_like(other, at::MemoryFormat::Preserve)
 
 - name: neg(Tensor self) -> Tensor
   self: grad.neg()
@@ -641,7 +641,7 @@
   cdist: not_implemented("_cdist_backward")
 
 - name: normal_(Tensor(a!) self, float mean=0, float std=1, *, Generator? generator=None) -> Tensor(a!)
-  self: zeros_like(grad)
+  self: zeros_like(grad, at::MemoryFormat::Preserve)
 
 - name: normal.Tensor_float(Tensor mean, float std=1, *, Generator? generator=None) -> Tensor
   mean: at::zeros(mean.sizes(), grad.options())
@@ -666,7 +666,7 @@
   self: permute_backwards(grad, dims)
 
 - name: poisson(Tensor self, Generator? generator=None) -> Tensor
-  self: zeros_like(self)
+  self: zeros_like(self, at::MemoryFormat::Preserve)
 
 - name: pow.Tensor_Scalar(Tensor self, Scalar exponent) -> Tensor
   self: pow_backward(grad, self, exponent)
@@ -685,7 +685,7 @@
   self: prod_backward(grad, self.to(grad.scalar_type()), result, dim, keepdim)
 
 - name: put_(Tensor(a!) self, Tensor index, Tensor source, bool accumulate=False) -> Tensor(a!)
-  self: grad.clone().put_(index, zeros_like(source), accumulate)
+  self: grad.clone().put_(index, zeros_like(source, at::MemoryFormat::Preserve), accumulate)
   index: non_differentiable
   source: grad.take(index)
 
@@ -693,13 +693,13 @@
   self: qr_backward(grads, self, some, Q, R)
 
 - name: random_.from(Tensor(a!) self, int from, int to, *, Generator? generator=None) -> Tensor(a!)
-  self: zeros_like(grad)
+  self: zeros_like(grad, at::MemoryFormat::Preserve)
 
 - name: random_.to(Tensor(a!) self, int to, *, Generator? generator=None) -> Tensor(a!)
-  self: zeros_like(grad)
+  self: zeros_like(grad, at::MemoryFormat::Preserve)
 
 - name: random_(Tensor(a!) self, *, Generator? generator=None) -> Tensor(a!)
-  self: zeros_like(grad)
+  self: zeros_like(grad, at::MemoryFormat::Preserve)
 
 - name: real(Tensor self) -> Tensor
   self: grad.real()
@@ -727,7 +727,7 @@
 # - name: reshape(Tensor self, IntArrayRef shape)
 
 - name: round(Tensor self) -> Tensor
-  self: zeros_like(grad)
+  self: zeros_like(grad, at::MemoryFormat::Preserve)
 
 - name: rsqrt(Tensor self) -> Tensor
   self: -0.5 * grad * result.pow(3)
@@ -753,7 +753,7 @@
   self: sigmoid_backward(grad, result)
 
 - name: sign(Tensor self) -> Tensor
-  self: zeros_like(grad)
+  self: zeros_like(grad, at::MemoryFormat::Preserve)
 
 - name: sin(Tensor self) -> Tensor
   self: grad * self.cos()
@@ -845,7 +845,7 @@
   self: grad.rot90(-k, dims)
 
 - name: take(Tensor self, Tensor index) -> Tensor
-  self: zeros_like(self).put_(index, grad, true)
+  self: zeros_like(self, at::MemoryFormat::Preserve).put_(index, grad, true)
   index: non_differentiable
 
 - name: tan(Tensor self) -> Tensor
@@ -877,7 +877,7 @@
   self: grad.triu(diagonal)
 
 - name: trunc(Tensor self) -> Tensor
-  self: zeros_like(grad)
+  self: zeros_like(grad, at::MemoryFormat::Preserve)
 
 - name: to_dense(Tensor self) -> Tensor
   self: to_dense_backward(grad, self)
@@ -892,7 +892,7 @@
   self: unfold_backward(grad, self.sizes(), dimension, size, step)
 
 - name: uniform_(Tensor(a!) self, float from=0, float to=1, *, Generator? generator=None) -> Tensor(a!)
-  self: zeros_like(grad)
+  self: zeros_like(grad, at::MemoryFormat::Preserve)
 
 - name: _unique(Tensor self, bool sorted=True, bool return_inverse=False) -> (Tensor, Tensor)
   self: not_implemented("_unique")
@@ -917,8 +917,8 @@
 
 - name: _s_where(Tensor condition, Tensor self, Tensor other) -> Tensor
   condition: non_differentiable
-  self: where(condition, grad, zeros_like(grad))
-  other: where(condition, zeros_like(grad), grad)
+  self: where(condition, grad, zeros_like(grad, at::MemoryFormat::Preserve))
+  other: where(condition, zeros_like(grad, at::MemoryFormat::Preserve), grad)
 
 # weight_norm_cuda_interface_backward does not have an explicitly defined derivative, so if we do happen
 # to be running backward with create_graph=True, fall back to a backward function that uses
@@ -927,7 +927,7 @@
   v, g: "GradMode::is_enabled() ? _weight_norm_differentiable_backward(grad.contiguous(), v, g, result1, dim) : _weight_norm_cuda_interface_backward(grad.contiguous(), v, g, result1, dim)"
 
 - name: zero_(Tensor(a!) self) -> Tensor(a!)
-  self: zeros_like(grad)
+  self: zeros_like(grad, at::MemoryFormat::Preserve)
 
 - name: sparse_mask(Tensor self, Tensor mask) -> Tensor
   self: grad.to_dense().sparse_mask(mask).to_dense()
@@ -1049,7 +1049,7 @@
 
 - name: hardshrink_backward(Tensor grad_out, Tensor self, Scalar lambd) -> Tensor
   grad_out: hardshrink_backward(grad, self, lambd)
-  self: zeros_like(grad)
+  self: zeros_like(grad, at::MemoryFormat::Preserve)
 
 - name: hardtanh(Tensor self, Scalar min_val=-1, Scalar max_val=1) -> Tensor
   self: hardtanh_backward(grad, self, min_val, max_val)
@@ -1179,13 +1179,13 @@
   grad_output, input, weight: _convolution_double_backward(grads[0], grads[1], grads[2], grad_output, weight, input, stride, padding, dilation, false, output_padding, groups, false, false, false, grad_input_mask)
 
 - name: slow_conv_transpose2d(Tensor self, Tensor weight, int[2] kernel_size, Tensor? bias=None, int[2] stride=1, int[2] padding=0, int[2] output_padding=0, int[2] dilation=1) -> Tensor
-  self, weight, bias: slow_conv_transpose2d_backward(grad, self, weight, kernel_size, stride, padding, output_padding, dilation, empty_like(grad), empty_like(grad), grad_input_mask)
+  self, weight, bias: slow_conv_transpose2d_backward(grad, self, weight, kernel_size, stride, padding, output_padding, dilation, empty_like(grad, at::MemoryFormat::Preserve), empty_like(grad), grad_input_mask)
 
 - name: slow_conv_transpose2d_backward.output_mask(Tensor grad_output, Tensor self, Tensor weight, int[2] kernel_size, int[2] stride, int[2] padding, int[2] output_padding, int[2] dilation, Tensor columns, Tensor ones, bool[3] output_mask) -> (Tensor grad_input, Tensor grad_weight, Tensor grad_bias)
   grad_output, self, weight: _convolution_double_backward(grads[0], grads[1], grads[2], grad_output, weight, self, stride, padding, dilation, true, output_padding, 1, false, false, false, grad_input_mask)
 
 - name: slow_conv_transpose3d(Tensor self, Tensor weight, int[3] kernel_size, Tensor? bias=None, int[3] stride=1, int[3] padding=0, int[3] output_padding=0, int[3] dilation=1) -> Tensor
-  self, weight, bias: slow_conv_transpose3d_backward(grad, self, weight, kernel_size, stride, padding, output_padding, dilation, empty_like(grad), empty_like(grad), grad_input_mask)
+  self, weight, bias: slow_conv_transpose3d_backward(grad, self, weight, kernel_size, stride, padding, output_padding, dilation, empty_like(grad, at::MemoryFormat::Preserve), empty_like(grad), grad_input_mask)
 
 - name: slow_conv_transpose3d_backward.output_mask(Tensor grad_output, Tensor self, Tensor weight, int[3] kernel_size, int[3] stride, int[3] padding, int[3] output_padding, int[3] dilation, Tensor finput, Tensor fgrad_input, bool[3] output_mask) -> (Tensor grad_input, Tensor grad_weight, Tensor grad_bias)
   grad_output, self, weight: _convolution_double_backward(grads[0], grads[1], grads[2], grad_output, weight, self, stride, padding, dilation, true, output_padding, 1, false, false, false, grad_input_mask)
@@ -1231,27 +1231,27 @@
 
 - name: _adaptive_avg_pool2d_backward(Tensor grad_output, Tensor self) -> Tensor
   grad_output: _adaptive_avg_pool2d(grad, { grad_output.size(-2), grad_output.size(-1) })
-  self: zeros_like(self)
+  self: zeros_like(self, at::MemoryFormat::Preserve)
 
 - name: adaptive_avg_pool3d_backward(Tensor grad_output, Tensor self) -> Tensor
   grad_output: adaptive_avg_pool3d(grad, { grad_output.size(-3), grad_output.size(-2), grad_output.size(-1) })
-  self: zeros_like(self)
+  self: zeros_like(self, at::MemoryFormat::Preserve)
 
 - name: adaptive_max_pool2d_backward(Tensor grad_output, Tensor self, Tensor indices) -> Tensor
   grad_output: max_pool_double_backward(grad, indices, 2)
-  self: zeros_like(self)
+  self: zeros_like(self, at::MemoryFormat::Preserve)
 
 - name: adaptive_max_pool3d_backward(Tensor grad_output, Tensor self, Tensor indices) -> Tensor
   grad_output: max_pool_double_backward(grad, indices, 3)
-  self: zeros_like(self)
+  self: zeros_like(self, at::MemoryFormat::Preserve)
 
 - name: avg_pool2d_backward(Tensor grad_output, Tensor self, int[2] kernel_size, int[2] stride, int[2] padding, bool ceil_mode, bool count_include_pad, int? divisor_override) -> Tensor
   grad_output: avg_pool2d(grad, kernel_size, stride, padding, ceil_mode, count_include_pad, divisor_override)
-  self: zeros_like(self)
+  self: zeros_like(self, at::MemoryFormat::Preserve)
 
 - name: avg_pool3d_backward(Tensor grad_output, Tensor self, int[3] kernel_size, int[3] stride, int[3] padding, bool ceil_mode, bool count_include_pad, int? divisor_override) -> Tensor
   grad_output: avg_pool3d(grad, kernel_size, stride, padding, ceil_mode, count_include_pad, divisor_override)
-  self: zeros_like(self)
+  self: zeros_like(self, at::MemoryFormat::Preserve)
 
 - name: elu_backward(Tensor grad_output, Scalar alpha, Scalar scale, Scalar input_scale, Tensor output) -> Tensor
   grad_output: elu_backward(grad, alpha, scale, input_scale, output)
@@ -1259,11 +1259,11 @@
 
 - name: fractional_max_pool2d_backward(Tensor grad_output, Tensor self, int[2] kernel_size, int[2] output_size, Tensor indices) -> Tensor
   grad_output: max_pool_double_backward(grad, indices, 2)
-  self: zeros_like(self)
+  self: zeros_like(self, at::MemoryFormat::Preserve)
 
 - name: fractional_max_pool3d_backward(Tensor grad_output, Tensor self, int[3] kernel_size, int[3] output_size, Tensor indices) -> Tensor
   grad_output: max_pool_double_backward(grad, indices, 3)
-  self: zeros_like(self)
+  self: zeros_like(self, at::MemoryFormat::Preserve)
 
 - name: glu_backward(Tensor grad_output, Tensor self, int dim) -> Tensor
   grad_output: glu_double_backward_grad_output(grad, self, dim)
@@ -1271,16 +1271,16 @@
 
 - name: hardtanh_backward(Tensor grad_output, Tensor self, Scalar min_val, Scalar max_val) -> Tensor
   grad_output: hardtanh_backward(grad, self, min_val, max_val)
-  self: zeros_like(grad)
+  self: zeros_like(grad, at::MemoryFormat::Preserve)
 
 - name: kl_div_backward(Tensor grad_output, Tensor self, Tensor target, int reduction=Mean) -> Tensor
   grad_output: kl_div_double_backward_grad_output(grad, self, target, reduction)
-  self: zeros_like(grad)
-  target: zeros_like(grad)
+  self: zeros_like(grad, at::MemoryFormat::Preserve)
+  target: zeros_like(grad, at::MemoryFormat::Preserve)
 
 - name: l1_loss_backward(Tensor grad_output, Tensor self, Tensor target, int reduction) -> Tensor
   grad_output: l1_loss_double_backward_grad_output(grad, self, target, reduction)
-  self: zeros_like(grad)
+  self: zeros_like(grad, at::MemoryFormat::Preserve)
 
 - name: log_sigmoid_backward(Tensor grad_output, Tensor self, Tensor buffer) -> Tensor
   grad_output: log_sigmoid_backward(grad, self, buffer)
@@ -1292,21 +1292,21 @@
 
 - name: leaky_relu_backward(Tensor grad_output, Tensor self, Scalar negative_slope) -> Tensor
   grad_output: leaky_relu_backward(grad, self, negative_slope)
-  self: zeros_like(grad)
+  self: zeros_like(grad, at::MemoryFormat::Preserve)
 
 - name: max_pool2d_with_indices_backward(Tensor grad_output, Tensor self, int[2] kernel_size, int[2] stride, int[2] padding, int[2] dilation, bool ceil_mode, Tensor indices) -> Tensor
   grad_output: max_pool_double_backward(grad, indices, 2);
-  self: zeros_like(self)
+  self: zeros_like(self, at::MemoryFormat::Preserve)
   indices: non_differentiable
 
 - name: max_pool3d_with_indices_backward(Tensor grad_output, Tensor self, int[3] kernel_size, int[3] stride, int[3] padding, int[3] dilation, bool ceil_mode, Tensor indices) -> Tensor
   grad_output: max_pool_double_backward(grad, indices, 3);
-  self: zeros_like(self)
+  self: zeros_like(self, at::MemoryFormat::Preserve)
   indices: non_differentiable
 
 - name: max_unpool2d_backward(Tensor grad_output, Tensor self, Tensor indices, int[2] output_size) -> Tensor
   grad_output: max_unpool2d(grad, indices, output_size)
-  self: zeros_like(self)
+  self: zeros_like(self, at::MemoryFormat::Preserve)
   indices: non_differentiable
 
 - name: mse_loss_backward(Tensor grad_output, Tensor self, Tensor target, int reduction) -> Tensor
@@ -1315,37 +1315,37 @@
 
 - name: nll_loss_backward(Tensor grad_output, Tensor self, Tensor target, Tensor? weight, int reduction, int ignore_index, Tensor total_weight) -> Tensor
   grad_output: nll_loss(grad, target, weight, reduction, ignore_index)
-  self: zeros_like(grad)
+  self: zeros_like(grad, at::MemoryFormat::Preserve)
   target: non_differentiable
 
 - name: nll_loss2d_backward(Tensor grad_output, Tensor self, Tensor target, Tensor? weight, int reduction, int ignore_index, Tensor total_weight) -> Tensor
   grad_output: nll_loss2d(grad, target, weight, reduction, ignore_index)
-  self: zeros_like(grad)
+  self: zeros_like(grad, at::MemoryFormat::Preserve)
   target: non_differentiable
 
 - name: rrelu_with_noise_backward(Tensor grad_output, Tensor self, Tensor noise, Scalar lower, Scalar upper, bool training) -> Tensor
   grad_output: rrelu_with_noise_backward(grad, self, noise, lower, upper, training)
-  self: zeros_like(grad)
+  self: zeros_like(grad, at::MemoryFormat::Preserve)
 
 - name: reflection_pad1d_backward(Tensor grad_output, Tensor self, int[2] padding) -> Tensor
   grad_output: reflection_pad1d(grad, padding)
-  self: zeros_like(self)
+  self: zeros_like(self, at::MemoryFormat::Preserve)
 
 - name: reflection_pad2d_backward(Tensor grad_output, Tensor self, int[4] padding) -> Tensor
   grad_output: reflection_pad2d(grad, padding)
-  self: zeros_like(self)
+  self: zeros_like(self, at::MemoryFormat::Preserve)
 
 - name: replication_pad1d_backward(Tensor grad_output, Tensor self, int[2] padding) -> Tensor
   grad_output: replication_pad1d(grad, padding)
-  self: zeros_like(self)
+  self: zeros_like(self, at::MemoryFormat::Preserve)
 
 - name: replication_pad2d_backward(Tensor grad_output, Tensor self, int[4] padding) -> Tensor
   grad_output: replication_pad2d(grad, padding)
-  self: zeros_like(self)
+  self: zeros_like(self, at::MemoryFormat::Preserve)
 
 - name: replication_pad3d_backward(Tensor grad_output, Tensor self, int[6] padding) -> Tensor
   grad_output: replication_pad3d(grad, padding)
-  self: zeros_like(self)
+  self: zeros_like(self, at::MemoryFormat::Preserve)
 
 - name: smooth_l1_loss_backward(Tensor grad_output, Tensor self, Tensor target, int reduction) -> Tensor
   grad_output: smooth_l1_loss_double_backward_grad_output(grad, grad_output, self, target, reduction)
@@ -1365,11 +1365,11 @@
 
 - name: softshrink_backward(Tensor grad_output, Tensor self, Scalar lambd) -> Tensor
   grad_output: softshrink_backward(grad, self, lambd)
-  self: zeros_like(grad)
+  self: zeros_like(grad, at::MemoryFormat::Preserve)
 
 - name: threshold_backward(Tensor grad_output, Tensor self, Scalar threshold) -> Tensor
   grad_output: threshold_backward(grad, self, threshold)
-  self: zeros_like(grad)
+  self: zeros_like(grad, at::MemoryFormat::Preserve)
 
 - name: upsample_linear1d_backward(Tensor grad_output, int[1] output_size, int[3] input_size, bool align_corners) -> Tensor
   grad_output: upsample_linear1d(grad, output_size, align_corners)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #29313 [NOT TO LAND] Switch default of *_like
* #29312 [NOT TO LAND] Change tests to *_like ops
* #29311 explicitly provide memory format when calling to *_like operators
* **#29310 explicitly provide memory format when calling to *_like operators**
* #29309 explicitly provide memory format when calling to *_like operators
* #29308 explicitly provide memory format when calling to *_like operators

