### PR TITLE
explicitly provide memory format when calling to *_like operators

### DIFF
--- a/aten/src/ATen/native/Distance.cpp
+++ b/aten/src/ATen/native/Distance.cpp
@@ -27,9 +27,9 @@ Tensor pdist(const Tensor& self, const double p) {
 
 Tensor euclidean_dist_out(const Tensor& x1, const Tensor& x2) {
   Tensor x1_norm = x1.pow(2).sum(-1, true);
-  Tensor x1_pad = at::ones_like(x1_norm);
+  Tensor x1_pad = at::ones_like(x1_norm, at::MemoryFormat::Contiguous);
   Tensor x2_norm = x2.pow(2).sum(-1, true);
-  Tensor x2_pad = at::ones_like(x2_norm);
+  Tensor x2_pad = at::ones_like(x2_norm, at::MemoryFormat::Contiguous);
   Tensor x1_ = at::cat({x1.mul(-2), x1_norm, x1_pad}, -1);
   Tensor x2_ = at::cat({x2, x2_pad, x2_norm}, -1);
   Tensor result = x1_.matmul(x2_.transpose(-2, -1));
@@ -138,7 +138,7 @@ Tensor _pdist_forward(const Tensor& self, const double p) {
   TORCH_CHECK(self.is_contiguous(), "_pdist_forward requires contiguous input");
   auto device = self.type().device_type();
   TORCH_CHECK(device == kCPU || device == kCUDA, "_pdist_forward only supports CPU and CUDA devices, got: ", device);
-  Tensor result = at::empty({0}, self.options());
+  Tensor result = at::empty({0}, self.options(), at::MemoryFormat::Contiguous);
   if (self.size(0) <= 1) {
     result.resize_({0});
   } else {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #29313 [NOT TO LAND] Switch default of *_like
* #29312 [NOT TO LAND] Change tests to *_like ops
* **#29311 explicitly provide memory format when calling to *_like operators**
* #29310 explicitly provide memory format when calling to *_like operators
* #29309 explicitly provide memory format when calling to *_like operators
* #29308 explicitly provide memory format when calling to *_like operators

