### PR TITLE
[REMOVED]

### DIFF
--- a/torch/csrc/api/include/torch/nn/functional/activation.h
+++ b/torch/csrc/api/include/torch/nn/functional/activation.h
@@ -65,43 +65,40 @@ inline Tensor gumbel_softmax(const Tensor& logits, const GumbelSoftmaxFuncOption
   return ret;
 }
 
-inline Tensor softmax(const Tensor& input, const SoftmaxFuncOptions& options,
-                      c10::optional<torch::Dtype> dtype = c10::nullopt) {
+inline Tensor softmax(const Tensor& input, const SoftmaxFuncOptions& options) {
   int64_t dim = options.dim();
   Tensor ret;
 
-  if (dtype == c10::nullopt) {
+  if (options.dtype() == c10::nullopt) {
     ret = input.softmax(dim);
   } else {
-    ret = input.softmax(dim, dtype);
+    ret = input.softmax(dim, options.dtype());
   }
 
   return ret;
 }
 
-inline Tensor softmin(const Tensor& input, const SoftminFuncOptions& options,
-                      c10::optional<torch::Dtype> dtype = c10::nullopt) {
+inline Tensor softmin(const Tensor& input, const SoftminFuncOptions& options) {
   int64_t dim = options.dim();
   Tensor ret;
 
-  if (dtype == c10::nullopt) {
+  if (options.dtype() == c10::nullopt) {
     ret = (-input).softmax(dim);
   } else {
-    ret = (-input).softmax(dim, dtype);
+    ret = (-input).softmax(dim, options.dtype());
   }
 
   return ret;
 }
 
-inline Tensor log_softmax(const Tensor& input, const LogSoftmaxFuncOptions& options,
-                          c10::optional<torch::Dtype> dtype = c10::nullopt) {
+inline Tensor log_softmax(const Tensor& input, const LogSoftmaxFuncOptions& options) {
   int64_t dim = options.dim();
   Tensor ret;
 
-  if (dtype == c10::nullopt) {
+  if (options.dtype() == c10::nullopt) {
     ret = input.log_softmax(dim);
   } else {
-    ret = input.log_softmax(dim, dtype);
+    ret = input.log_softmax(dim, options.dtype());
   }
 
   return ret;
@@ -125,15 +122,14 @@ inline Tensor relu(Tensor& input, const ReLUFuncOptions& options = {}) {
 
 inline Tensor relu6(Tensor& input, const ReLU6FuncOptions& options = {}) {
   return hardtanh(input,
-    HardtanhOptions().min_val(0).max_val(6).inplace(options.inplace()));
+    HardtanhFuncOptions().min_val(0).max_val(6).inplace(options.inplace()));
 }
 
-inline Tensor rrelu(Tensor& input, const RReLUFuncOptions& options = {},
-                    bool training = false) {
+inline Tensor rrelu(Tensor& input, const RReLUFuncOptions& options = {}) {
   if (options.inplace()) {
-    return torch::rrelu_(input, options.lower(), options.upper(), training);
+    return torch::rrelu_(input, options.lower(), options.upper(), options.training());
   } else {
-    return torch::rrelu(input, options.lower(), options.upper(), training);
+    return torch::rrelu(input, options.lower(), options.upper(), options.training());
   }
 }
 

--- a/torch/csrc/api/include/torch/nn/functional/batchnorm.h
+++ b/torch/csrc/api/include/torch/nn/functional/batchnorm.h
@@ -10,8 +10,8 @@ namespace nn {
 namespace functional {
 
 inline Tensor batch_norm(const Tensor& input, const Tensor& running_mean,
-                         const Tensor& running_var, const BatchNormFuncOptions& options = {}, bool training = false) {
-  if (training) {
+                         const Tensor& running_var, const BatchNormFuncOptions& options = {}) {
+  if (options.training()) {
     auto size = input.sizes();
     int64_t size_prods = size[0];
     for (size_t i = 0; i < size.size() - 2; i++) {
@@ -27,7 +27,7 @@ inline Tensor batch_norm(const Tensor& input, const Tensor& running_mean,
     options.bias(),
     running_mean,
     running_var,
-    training,
+    options.training(),
     options.momentum().value(),
     options.eps(),
     at::globalContext().userEnabledCuDNN());

--- a/torch/csrc/api/include/torch/nn/functional/normalization.h
+++ b/torch/csrc/api/include/torch/nn/functional/normalization.h
@@ -11,23 +11,20 @@ namespace functional {
 
 inline Tensor normalize(
     const Tensor& input,
-    const NormalizeFuncOptions& options = {},
-    c10::optional<Tensor> out = c10::nullopt) {
-    if (out == c10::nullopt) {
+    const NormalizeFuncOptions& options = {}) {
+    if (options.out() == c10::nullopt) {
       auto denom = input.norm(options.p(), options.dim(), true).clamp_min(options.eps()).expand_as(input);
       return input / denom;
     } else {
       auto denom = input.norm(options.p(), options.dim(), true).clamp_min(options.eps()).expand_as(input);
-      return torch::div_out(*out, input, denom);
+      return torch::div_out(*options.out(), input, denom);
     }
 }
 
 inline Tensor layer_norm(const Tensor& input,
-    const LayerNormFuncOptions& options,
-    const Tensor& weight = Tensor(),
-    const Tensor& bias = Tensor()) {
+    const LayerNormFuncOptions& options) {
 
-    return torch::layer_norm(input, options.normalized_shape(), weight, bias, options.eps());
+    return torch::layer_norm(input, options.normalized_shape(), options.weight(), options.bias(), options.eps());
 }
 
 inline Tensor local_response_norm(

--- a/torch/csrc/api/include/torch/nn/functional/pooling.h
+++ b/torch/csrc/api/include/torch/nn/functional/pooling.h
@@ -187,32 +187,29 @@ inline std::vector<int64_t> _unpool_output_size(const Tensor& input,
 }
 
 inline Tensor max_unpool1d(const Tensor& input, const Tensor& indices,
-    const MaxUnpool1dFuncOptions& options,
-    const c10::optional<IntArrayRef>& output_size = c10::nullopt) {
+    const MaxUnpool1dFuncOptions& options) {
   auto output_size_ = _unpool_output_size(input, options.kernel_size(),
                                           options.stride(), options.padding(),
-                                          output_size);
+                                          options.output_size());
   output_size_.push_back(1);
   return torch::max_unpool2d(input.unsqueeze(3), indices.unsqueeze(3),
                              output_size_).squeeze(3);
 }
 
 inline Tensor max_unpool2d(const Tensor& input, const Tensor& indices,
-  const MaxUnpool2dFuncOptions& options,
-  const c10::optional<IntArrayRef>& output_size = c10::nullopt) {
+  const MaxUnpool2dFuncOptions& options) {
   auto output_size_ = _unpool_output_size(input, options.kernel_size(),
                                           options.stride(), options.padding(),
-                                          output_size);
+                                          options.output_size());
 
   return torch::max_unpool2d(input, indices, output_size_);
 }
 
 inline Tensor max_unpool3d(const Tensor& input, const Tensor& indices,
-  const MaxUnpool3dFuncOptions& options,
-  const c10::optional<IntArrayRef>& output_size = c10::nullopt) {
+  const MaxUnpool3dFuncOptions& options) {
   auto output_size_ = _unpool_output_size(input, options.kernel_size(),
                                           options.stride(), options.padding(),
-                                          output_size);
+                                          options.output_size());
 
   return torch::max_unpool3d(input, indices, output_size_,
                              options.stride(), options.padding());

--- a/torch/csrc/api/include/torch/nn/options/activation.h
+++ b/torch/csrc/api/include/torch/nn/options/activation.h
@@ -82,7 +82,23 @@ struct TORCH_API SoftmaxOptions {
   TORCH_ARG(int64_t, dim);
 };
 
-TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(Softmax, SoftmaxFuncOptions)
+// ============================================================================
+
+namespace functional {
+
+struct TORCH_API SoftmaxFuncOptions {
+  SoftmaxFuncOptions(int64_t dim);
+
+  /// Dimension along which Softmax will be computed.
+  TORCH_ARG(int64_t, dim);
+
+  /// the desired data type of returned tensor.
+  /// If specified, the input tensor is casted to `dtype` before the operation
+  /// is performed. This is useful for preventing data type overflows. Default: None.
+  TORCH_ARG(c10::optional<torch::Dtype>, dtype) = c10::nullopt;
+};
+
+} // namespace functional
 
 // ============================================================================
 
@@ -94,7 +110,23 @@ struct TORCH_API SoftminOptions {
   TORCH_ARG(int64_t, dim);
 };
 
-TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(Softmin, SoftminFuncOptions)
+// ============================================================================
+
+namespace functional {
+
+struct TORCH_API SoftminFuncOptions {
+  SoftminFuncOptions(int64_t dim);
+
+  /// Dimension along which Softmin will be computed.
+  TORCH_ARG(int64_t, dim);
+
+  /// the desired data type of returned tensor.
+  /// If specified, the input tensor is casted to `dtype` before the operation
+  /// is performed. This is useful for preventing data type overflows. Default: None.
+  TORCH_ARG(c10::optional<torch::Dtype>, dtype) = c10::nullopt;
+};
+
+} // namespace functional
 
 // ============================================================================
 
@@ -106,7 +138,23 @@ struct TORCH_API LogSoftmaxOptions {
   TORCH_ARG(int64_t, dim);
 };
 
-TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(LogSoftmax, LogSoftmaxFuncOptions)
+// ============================================================================
+
+namespace functional {
+
+struct TORCH_API LogSoftmaxFuncOptions {
+  LogSoftmaxFuncOptions(int64_t dim);
+
+  /// Dimension along which LogSoftmax will be computed.
+  TORCH_ARG(int64_t, dim);
+
+  /// the desired data type of returned tensor.
+  /// If specified, the input tensor is casted to `dtype` before the operation
+  /// is performed. This is useful for preventing data type overflows. Default: None.
+  TORCH_ARG(c10::optional<torch::Dtype>, dtype) = c10::nullopt;
+};
+
+} // namespace functional
 
 // ============================================================================
 
@@ -160,7 +208,24 @@ struct TORCH_API RReLUOptions {
   TORCH_ARG(bool, inplace) = false;
 };
 
-TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(RReLU, RReLUFuncOptions)
+// ============================================================================
+
+namespace functional {
+
+struct TORCH_API RReLUFuncOptions {
+  /// lower bound of the uniform distribution. Default: 1/8
+  TORCH_ARG(double, lower) = 1.0 / 8.0;
+
+  /// upper bound of the uniform distribution. Default: 1/3
+  TORCH_ARG(double, upper) = 1.0 / 3.0;
+
+  TORCH_ARG(bool, training) = false;
+
+  /// can optionally do the operation in-place. Default: False
+  TORCH_ARG(bool, inplace) = false;
+};
+
+} // namespace functional
 
 // ============================================================================
 
@@ -203,7 +268,7 @@ TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(Softshrink, SoftshrinkFuncOptions)
 // ============================================================================
 
 /// Options for Threshold functional and module.
-struct ThresholdOptions {
+struct TORCH_API ThresholdOptions {
   ThresholdOptions(double threshold, double value)
    : threshold_(threshold), value_(value) {}
 
@@ -224,7 +289,7 @@ TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(Threshold, ThresholdFuncOptions)
 namespace functional {
 
 /// Options for Gumbel Softmax functional.
-struct GumbelSoftmaxFuncOptions {
+struct TORCH_API GumbelSoftmaxFuncOptions {
   /// non-negative scalar temperature
   TORCH_ARG(double, tau) = 1.0;
 

--- a/torch/csrc/api/include/torch/nn/options/batchnorm.h
+++ b/torch/csrc/api/include/torch/nn/options/batchnorm.h
@@ -47,6 +47,8 @@ struct TORCH_API BatchNormFuncOptions {
 
   TORCH_ARG(Tensor, bias) = Tensor();
 
+  TORCH_ARG(bool, training) = false;
+
   /// A momentum multiplier for the mean and variance.
   /// Changing this parameter after construction __is effective__.
   TORCH_ARG(c10::optional<double>, momentum) = 0.1;

--- a/torch/csrc/api/include/torch/nn/options/normalization.h
+++ b/torch/csrc/api/include/torch/nn/options/normalization.h
@@ -22,7 +22,25 @@ struct TORCH_API LayerNormOptions {
   TORCH_ARG(bool, elementwise_affine) = true;
 };
 
-TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(LayerNorm, LayerNormFuncOptions)
+// ============================================================================
+
+namespace functional {
+
+/// Options for the `LayerNorm` module.
+struct TORCH_API LayerNormFuncOptions {
+  /* implicit */ LayerNormFuncOptions(std::vector<int64_t> normalized_shape);
+  /// input shape from an expected input.
+  TORCH_ARG(std::vector<int64_t>, normalized_shape);
+
+  TORCH_ARG(Tensor, weight) = {};
+
+  TORCH_ARG(Tensor, bias) = {};
+
+  /// a value added to the denominator for numerical stability. ``Default: 1e-5``.
+  TORCH_ARG(double, eps) = 1e-5;
+};
+
+} // namespace functional
 
 // ============================================================================
 
@@ -72,6 +90,9 @@ struct TORCH_API NormalizeFuncOptions {
   TORCH_ARG(int64_t, dim) = 1;
   /// Small value to avoid division by zero. Default: 1e-12
   TORCH_ARG(double, eps) = 1e-12;
+  /// the output tensor. If :attr:`out` is used, this
+  /// operation won't be differentiable.
+  TORCH_ARG(c10::optional<Tensor>, out) = c10::nullopt;
 };
 
 } // namespace functional

--- a/torch/csrc/api/include/torch/nn/options/pooling.h
+++ b/torch/csrc/api/include/torch/nn/options/pooling.h
@@ -136,7 +136,7 @@ TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(AdaptiveAvgPool3d, AdaptiveAvgPool3dFuncO
 
 // ============================================================================
 
-/// Options for a `D`-dimensional maxunpool functional and module.
+/// Options for a `D`-dimensional maxunpool module.
 template <size_t D>
 struct MaxUnpoolOptions {
   MaxUnpoolOptions(ExpandingArray<D> kernel_size)
@@ -161,9 +161,39 @@ using MaxUnpool2dOptions = MaxUnpoolOptions<2>;
 /// `MaxUnpoolOptions` specialized for 3-D maxunpool.
 using MaxUnpool3dOptions = MaxUnpoolOptions<3>;
 
-TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(MaxUnpool1d, MaxUnpool1dFuncOptions)
-TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(MaxUnpool2d, MaxUnpool2dFuncOptions)
-TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(MaxUnpool3d, MaxUnpool3dFuncOptions)
+// ============================================================================
+
+namespace functional {
+
+/// Options for a `D`-dimensional maxunpool functional.
+template <size_t D>
+struct MaxUnpoolFuncOptions {
+  MaxUnpoolFuncOptions(ExpandingArray<D> kernel_size)
+      : kernel_size_(kernel_size), stride_(kernel_size) {}
+
+  /// the size of the window to take a max over
+  TORCH_ARG(ExpandingArray<D>, kernel_size);
+
+  /// the stride of the window. Default value is `kernel_size
+  TORCH_ARG(ExpandingArray<D>, stride);
+
+  /// implicit zero padding to be added on both sides
+  TORCH_ARG(ExpandingArray<D>, padding) = 0;
+
+  /// the targeted output size
+  TORCH_ARG(c10::optional<std::vector<int64_t>>, output_size) = c10::nullopt;
+};
+
+/// `MaxUnpoolFuncOptions` specialized for 1-D maxunpool.
+using MaxUnpool1dFuncOptions = MaxUnpoolFuncOptions<1>;
+
+/// `MaxUnpoolFuncOptions` specialized for 2-D maxunpool.
+using MaxUnpool2dFuncOptions = MaxUnpoolFuncOptions<2>;
+
+/// `MaxUnpoolFuncOptions` specialized for 3-D maxunpool.
+using MaxUnpool3dFuncOptions = MaxUnpoolFuncOptions<3>;
+
+} // namespace functional
 
 // ============================================================================
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#29317 Make all non-input arguments to functionals part of its options**
* #29316 Pass F::*FuncOptions instead of torch::nn::*Options to functionals

ghstack-source-id: 35ad89c403b964018187ce293e5fbd2a5eb47f00
Pull Request resolved: https://github.com/pytorch/pytorch/pull/29278