### PR TITLE
Disable QNNPACK tests on MacOS

### DIFF
--- a/test/test_quantized.py
+++ b/test/test_quantized.py
@@ -1690,6 +1690,7 @@ class TestQuantizedConv(unittest.TestCase):
 @unittest.skipIf(TEST_WITH_UBSAN,
                  "QNNPACK does not play well with UBSAN at the moment,"
                  " so we skip the test if we are in a UBSAN environment.")
+@unittest.skipIf(IS_MACOS, "QNNPACK tests are flaky on MacOS currently - Issue #29326")
 class TestQNNPackOps(TestCase):
     """Tests the correctness of the quantized::qnnpack_relu op."""
     @given(X=hu.tensor(shapes=hu.array_shapes(1, 5, 1, 5),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#29328 Disable QNNPACK tests on MacOS**

Summary:
Tests are flaky as seen in issue #29326.
Disable until we fix the kernels.

Test Plan:
python test/test_quantized.py TestQNNPackOps

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D18358200](https://our.internmc.facebook.com/intern/diff/D18358200)