### PR TITLE
[quantization] Fix tracing for dynamic quantized LSTM

### DIFF
--- a/torch/nn/quantized/dynamic/modules/rnn.py
+++ b/torch/nn/quantized/dynamic/modules/rnn.py
@@ -27,6 +27,12 @@ class PackedParameter(torch.nn.Module):
         self.param = torch.ops.quantized.linear_prepack(*state[0])
         self.training = state[1]
 
+    # This only exists because there's a bug in recursive scripting
+    # that arises only in Python 2 where a recursively scripted
+    # module does not have a forward(). We can delete this once we
+    # drop python 2 support
+    def forward(self):
+        raise RuntimeError('PackedParameter cannot be called')
 
 class RNNBase(torch.nn.Module):
 

--- a/torch/nn/quantized/dynamic/modules/rnn.py
+++ b/torch/nn/quantized/dynamic/modules/rnn.py
@@ -13,6 +13,20 @@ def apply_permutation(tensor, permutation, dim=1):
     # type: (Tensor, Tensor, int) -> Tensor
     return tensor.index_select(dim, permutation)
 
+class PackedParameter(torch.nn.Module):
+    def __init__(self, param):
+        super(PackedParameter, self).__init__()
+        self.param = param
+
+    @torch.jit.export
+    def __getstate__(self):
+        return (torch.ops.quantized.linear_unpack(self.param), self.training)
+
+    @torch.jit.export
+    def __setstate__(self, state):
+        self.param = torch.ops.quantized.linear_prepack(*state[0])
+        self.training = state[1]
+
 
 class RNNBase(torch.nn.Module):
 
@@ -51,7 +65,7 @@ class RNNBase(torch.nn.Module):
             raise ValueError("Unrecognized RNN mode: " + mode)
 
         self._all_weight_names = []
-        self._all_weight_values = []
+        _all_weight_values = []
         for layer in range(num_layers):
             for direction in range(num_directions):
                 layer_input_size = input_size if layer == 0 else hidden_size * num_directions
@@ -111,7 +125,9 @@ class RNNBase(torch.nn.Module):
 
                 for (ih, ih_name), (hh, hh_name) in zip(zip(ih_params, ih_param_names), zip(hh_params, hh_param_names)):
                     self._all_weight_names.extend([ih_name, hh_name])
-                    self._all_weight_values.extend([ih, hh])
+                    _all_weight_values.extend([PackedParameter(p) for p in [ih, hh]])
+
+            self._all_weight_values = torch.nn.ModuleList(_all_weight_values)
 
     def _get_name(self):
         return 'DynamicQuantizedRNN'
@@ -173,48 +189,6 @@ class RNNBase(torch.nn.Module):
             return hx
         return apply_permutation(hx, permutation)
 
-    @torch.jit.export
-    def __getstate__(self):
-        vals = (
-            self.mode,
-            self.input_size,
-            self.hidden_size,
-            self.num_layers,
-            self.bias,
-            self.batch_first,
-            self.dropout,
-            self.bidirectional,
-            self._all_weight_names,
-            self.training,
-            self.dtype,
-        )
-
-        dynamic_vals = torch.jit.annotate(List[Tuple[torch.Tensor, Optional[torch.Tensor]]],
-                                          [])
-
-        for i in range(len(self._all_weight_names)):
-            dynamic_vals.append(torch.ops.quantized.linear_unpack(self._all_weight_values[i]))
-        return vals, dynamic_vals
-
-    @torch.jit.export
-    def __setstate__(self, state):
-        vals, dynamic_vals = state
-        self.mode = vals[0]
-        self.input_size = vals[1]
-        self.hidden_size = vals[2]
-        self.num_layers = vals[3]
-        self.bias = vals[4]
-        self.batch_first = vals[5]
-        self.dropout = vals[6]
-        self.bidirectional = vals[7]
-        self._all_weight_names = vals[8]
-        self.training = vals[9]
-        self.dtype = vals[10]
-
-        self._all_weight_values = []
-        for i in range(len(self._all_weight_names)):
-            self._all_weight_values.append(torch.ops.quantized.linear_prepack(*dynamic_vals[i]))
-
     @classmethod
     def from_float(cls, mod):
         assert type(mod) == torch.nn.LSTM, 'nn.quantized.dynamic.RNNBase.from_float only works for nn.LSTM'
@@ -246,7 +220,7 @@ class RNNBase(torch.nn.Module):
         assert mod.bias
 
         qRNNBase._all_weight_names = []
-        qRNNBase._all_weight_values = []
+        _all_weight_values = []
         for layer in range(qRNNBase.num_layers):
             for direction in range(num_directions):
                 layer_input_size = qRNNBase.input_size if layer == 0 else qRNNBase.hidden_size * num_directions
@@ -294,7 +268,8 @@ class RNNBase(torch.nn.Module):
 
                 for (ih, ih_name), (hh, hh_name) in zip(zip(ih_params, ih_param_names), zip(hh_params, hh_param_names)):
                     qRNNBase._all_weight_names.extend([ih_name, hh_name])
-                    qRNNBase._all_weight_values.extend([ih, hh])
+                    _all_weight_values.extend([PackedParameter(p) for p in [ih, hh]])
+        qRNNBase._all_weight_values = torch.nn.ModuleList(_all_weight_values)
 
         return qRNNBase
 
@@ -327,7 +302,11 @@ class LSTM(RNNBase):
         self.check_forward_args(input, hx, batch_sizes)
         assert batch_sizes is None
 
-        result = _VF.quantized_lstm(input, hx, self._all_weight_values, self.bias, self.num_layers,
+        weight_values = []
+        for mod in self._all_weight_values:
+            weight_values.append(mod.param)
+
+        result = _VF.quantized_lstm(input, hx, weight_values, self.bias, self.num_layers,
                                     float(self.dropout), self.training, self.bidirectional,
                                     self.batch_first, dtype=self.dtype, use_dynamic=True)
         output = result[0]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#29331 [quantization] Fix tracing for dynamic quantized LSTM**

Closes #27954 

This fixes the hard-coding of packed parameter values for the dynamic quantized LSTM by orchestrating the following dance:

1) Each variadic parameter on the module has its own Module. That Module defines the `__getstate__` and __setstate__` method s.t. packed weights are properly re-done on model load.
2) Each of these modules is wrapped into a `torch.nn.ModuleList`, s.t. the parameters appear as attributes in the hierarchy. Then, `gatherParametersAndBuffers` (https://github.com/pytorch/pytorch/blob/9c43b16df9dad3dfb4da1efab68d8c88e6437e8f/torch/csrc/jit/tracer.cpp#L285) can see these parameters and create a `Value*` for them in the traced graph.
3) In forward, we need to convert from ModuleList -> Module -> Parameter to a simple TensorList of the parameters. We just use a loop here. In tracing, we simply record a `ListConstruct` with each of the proper parameter values. In scripting, the `ModuleList` is const, so it can be unrolled into the graph and a subsequent `ListConstruct` does its business.

The `forward` of the traced LSTM before and after this change are as follows:

Before
```
def forward(self,
    input: Tensor,
    argument_2: Tuple[Tensor, Tensor]) -> Tuple[Tensor, Tuple[Tensor, Tensor]]:
  hx, hx0, = argument_2
  _0, _1, _2 = torch.quantized_lstm(input, [hx, hx0], [CONSTANTS.c0, CONSTANTS.c1], True, 1, 0., True, False, False, dtype=12, use_dynamic=True)
  return (_0, (_1, _2))
```

After

```
def forward(self,
    input: Tensor,
    argument_2: Tuple[Tensor, Tensor]) -> Tuple[Tensor, Tuple[Tensor, Tensor]]:
  _0 = self.cell._all_weight_values
  _1 = getattr(_0, "0").param
  _2 = getattr(_0, "1").param
  hx, hx0, = argument_2
  _3, _4, _5 = torch.quantized_lstm(input, [hx, hx0], [_1, _2], True, 1, 0., True, False, False, dtype=12, use_dynamic=True)
  return (_3, (_4, _5))

```

Differential Revision: [D18374904](https://our.internmc.facebook.com/intern/diff/D18374904)