### PR TITLE
Pass global_process_timeout to RpcAgent

### DIFF
--- a/test/rpc_test.py
+++ b/test/rpc_test.py
@@ -261,7 +261,6 @@ class RpcTest(object):
             worker_name_to_id=self.worker_name_to_id,
         )
 
-    @requires_process_group_agent("PROCESS_GROUP rpc backend specific test, skip")
     @dist_init(setup_model_parallel=False)
     def test_duplicate_name(self):
         with self.assertRaisesRegex(RuntimeError, "is not unique"):
@@ -962,15 +961,13 @@ class RpcTest(object):
 
         self.assertEqual(result, sum(vals))
 
-    @requires_process_group_agent("PROCESS_GROUP rpc backend specific test, skip")
     @dist_init
-    def test_get_default_rpc_timeout(self):
-        timeout = rpc.get_rpc_timeout()
+    def test_get_global_process_timeout(self):
+        timeout = rpc.get_global_process_timeout()
         self.assertEqual(timeout, rpc.constants.DEFAULT_RPC_TIMEOUT)
 
-    @requires_process_group_agent("PROCESS_GROUP rpc backend specific test, skip")
     @dist_init(setup_model_parallel=False)
-    def test_set_rpc_timeout(self):
+    def test_set_global_process_timeout(self):
         timeout = timedelta(seconds=1)
         rpc.init_model_parallel(
             self_name="worker{}".format(self.rank),
@@ -978,9 +975,9 @@ class RpcTest(object):
             init_method=self.init_method,
             self_rank=self.rank,
             worker_name_to_id=self.worker_name_to_id,
-            rpc_timeout=timeout
+            global_process_timeout=timeout
         )
-        set_timeout = rpc.get_rpc_timeout()
+        set_timeout = rpc.get_global_process_timeout()
         self.assertEqual(timeout, set_timeout)
         rpc.join_rpc()
 

--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -42,8 +42,10 @@ PyObject* rpc_init(PyObject* /* unused */) {
           .def(
               "join", &RpcAgent::join, py::call_guard<py::gil_scoped_release>())
           .def(
-              "sync",
-              &RpcAgent::sync,
+              "sync", &RpcAgent::sync, py::call_guard<py::gil_scoped_release>())
+          .def(
+              "_get_global_process_timeout",
+              &RpcAgent::getGlobalProcessTimeout,
               py::call_guard<py::gil_scoped_release>());
 
   auto pyFuture = shared_ptr_class_<PyFuture>(module, "Future")
@@ -100,7 +102,7 @@ PyObject* rpc_init(PyObject* /* unused */) {
           py::arg("name"),
           py::arg("process_group"),
           py::arg("num_send_recv_threads"),
-          py::arg("rpc_timeout"))
+          py::arg("global_process_timeout"))
       .def(
           "get_worker_info",
           (const WorkerInfo& (ProcessGroupAgent::*)(void)const) &
@@ -120,8 +122,8 @@ PyObject* rpc_init(PyObject* /* unused */) {
           &ProcessGroupAgent::sync,
           py::call_guard<py::gil_scoped_release>())
       .def(
-          "_get_rpc_timeout",
-          &ProcessGroupAgent::getRpcTimeout,
+          "_get_global_process_timeout",
+          &ProcessGroupAgent::getGlobalProcessTimeout,
           py::call_guard<py::gil_scoped_release>());
 
   module.def("_start_rpc_agent", [](const std::shared_ptr<RpcAgent>& agent) {

--- a/torch/csrc/distributed/rpc/process_group_agent.h
+++ b/torch/csrc/distributed/rpc/process_group_agent.h
@@ -39,7 +39,7 @@ class ProcessGroupAgent : public RpcAgent {
       std::string workerName,
       std::shared_ptr<c10d::ProcessGroup> pg,
       int numSendRecvThreads,
-      std::chrono::milliseconds rpcTimeout);
+      std::chrono::milliseconds globalProcessTimeouts);
 
   const WorkerInfo& getWorkerInfo(const std::string& workerName) const override;
 
@@ -50,9 +50,6 @@ class ProcessGroupAgent : public RpcAgent {
   void sync() override;
 
   void start() override;
-
-  // retrieves the timeout for all RPCs
-  const std::chrono::milliseconds& getRpcTimeout() const;
 
  protected:
   // This method wraps the destination information and the message into a
@@ -148,7 +145,6 @@ class ProcessGroupAgent : public RpcAgent {
   std::map<std::chrono::milliseconds, std::vector<int64_t>> futureTimeouts_;
   mutable std::mutex futureMutex_;
   mutable std::condition_variable futureCV_;
-  std::chrono::milliseconds rpcTimeout_;
 };
 
 } // namespace rpc

--- a/torch/csrc/distributed/rpc/rpc_agent.cpp
+++ b/torch/csrc/distributed/rpc/rpc_agent.cpp
@@ -6,8 +6,13 @@ namespace rpc {
 
 constexpr size_t WorkerInfo::MAX_NAME_LEN;
 
-RpcAgent::RpcAgent(WorkerInfo workerId, std::unique_ptr<RequestCallback> cb)
-    : workerInfo_(std::move(workerId)), cb_(std::move(cb)) {}
+RpcAgent::RpcAgent(
+    WorkerInfo workerId,
+    std::unique_ptr<RequestCallback> cb,
+    std::chrono::milliseconds globalProcessTimeout)
+    : workerInfo_(std::move(workerId)),
+      cb_(std::move(cb)),
+      globalProcessTimeout_(globalProcessTimeout) {}
 
 RpcAgent::~RpcAgent() = default;
 

--- a/torch/csrc/distributed/rpc/rpc_agent.h
+++ b/torch/csrc/distributed/rpc/rpc_agent.h
@@ -66,7 +66,10 @@ class TORCH_API RpcAgent {
   // NB: RpcAgent implementations should not start serving requests until
   // ``start()`` is called, as there could be other contexts that have not been
   // initialized yet at this time.
-  RpcAgent(WorkerInfo id, std::unique_ptr<RequestCallback> cb);
+  RpcAgent(
+      WorkerInfo id,
+      std::unique_ptr<RequestCallback> cb,
+      std::chrono::milliseconds globalProcessTimeout_);
 
   virtual ~RpcAgent();
 
@@ -93,6 +96,11 @@ class TORCH_API RpcAgent {
 
   virtual const WorkerInfo& getWorkerInfo(worker_id_t id) const = 0;
 
+  // Retrieves the process timeout for all RPCs.
+  virtual const std::chrono::milliseconds& getGlobalProcessTimeout() const {
+    return globalProcessTimeout_;
+  };
+
   // Call sync and join all internal threads. This method should be called
   // before every RPC process exits.
   virtual void join() = 0;
@@ -114,6 +122,7 @@ class TORCH_API RpcAgent {
   const WorkerInfo workerInfo_;
   const std::string workerName_;
   const std::unique_ptr<RequestCallback> cb_;
+  const std::chrono::milliseconds globalProcessTimeout_;
 
  private:
   static std::shared_ptr<RpcAgent> defaultRpcAgent_;

--- a/torch/distributed/rpc/__init__.py
+++ b/torch/distributed/rpc/__init__.py
@@ -28,7 +28,7 @@ if is_available():
         self_rank=-1,
         worker_name_to_id=None,
         num_send_recv_threads=DEFAULT_NUM_SEND_RECV_THREADS,
-        rpc_timeout=DEFAULT_RPC_TIMEOUT,
+        global_process_timeout=DEFAULT_RPC_TIMEOUT,
     ):
         r"""
         Initializes model parallel primitives such as the local rpc agent
@@ -53,7 +53,9 @@ if is_available():
             self_rank (int): a globally unique id/rank of this node.
             init_method(str): backend specific init arguments.
             num_send_recv_threads(int): Number of threads for send/recv work.
-            rpc_timeout (datetime.timedelta): Timeout for RPCs. Defaults to 10 seconds.
+            global_process_timeout (datetime.timedelta):
+                Fallback timeout for server to process an RPC request.
+                Defaults to 10 seconds.
         """
         # Rendezvous.
         world_size = len(worker_name_to_id)
@@ -70,7 +72,7 @@ if is_available():
             self_rank,
             worker_name_to_id,
             num_send_recv_threads,
-            rpc_timeout,
+            global_process_timeout,
         )
 
         # Initialize Autograd.

--- a/torch/distributed/rpc/api.py
+++ b/torch/distributed/rpc/api.py
@@ -67,7 +67,7 @@ def _init_rpc(
     self_rank=-1,
     worker_name_to_id=None,
     num_send_recv_threads=DEFAULT_NUM_SEND_RECV_THREADS,
-    rpc_timeout=DEFAULT_RPC_TIMEOUT,
+    global_process_timeout=DEFAULT_RPC_TIMEOUT,
 ):
     if sys.version_info < (3, 0):
         raise RuntimeError("RPC package does not support Python2.")
@@ -85,7 +85,7 @@ def _init_rpc(
         self_rank=self_rank,
         worker_name_to_id=worker_name_to_id,
         num_send_recv_threads=num_send_recv_threads,
-        rpc_timeout=rpc_timeout,
+        global_process_timeout=global_process_timeout,
     )
     _start_rpc_agent(_agent)
 
@@ -111,14 +111,14 @@ def get_worker_info(worker_name=None):
         return _agent.get_worker_info()
 
 @_require_initialized
-def get_rpc_timeout():
+def get_global_process_timeout():
     """
     Retrieve the timeout for all RPCs that was set during RPC initialization.
 
     Returns:
         `datetime.timedelta` instance indicating the RPC timeout.
     """
-    return _agent._get_rpc_timeout()
+    return _agent._get_global_process_timeout()
 
 
 def _to_worker_info(name_or_info):

--- a/torch/distributed/rpc/backend_registry.py
+++ b/torch/distributed/rpc/backend_registry.py
@@ -45,6 +45,7 @@ def process_group_init_backend_handler(
     self_rank,
     worker_name_to_id,
     num_send_recv_threads,
+    global_process_timeout,
     *args,
     **kwargs
 ):
@@ -78,7 +79,7 @@ def process_group_init_backend_handler(
                 )
             )
         # TODO: add try-except and destroy _agent in all processes if any fails.
-        return ProcessGroupAgent(self_name, group, num_send_recv_threads, kwargs["rpc_timeout"])
+        return ProcessGroupAgent(self_name, group, num_send_recv_threads, global_process_timeout)
     except Exception as ex:
         dist.destroy_process_group()
         raise ex


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#29336 Pass global_process_timeout to RpcAgent**

- Rename the concept from "rpcTimeout" to "globalProcessTimeout", because 1) this timeout is used to limit the server-side request processing time. 2) This timeout is a global setting in contract to per-RPC setting.

Differential Revision: [D5681951](https://our.internmc.facebook.com/intern/diff/D5681951/)