### PR TITLE
Enable nativeloader for pytorch jni and support mac x86-64.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,6 +29,7 @@ allprojects {
             classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:${GRADLE_BINTRAY_PLUGIN_VERSION}"
             classpath "com.github.dcendents:android-maven-gradle-plugin:${ANDROID_MAVEN_GRADLE_PLUGIN_VERSION}"
             classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.9.8"
+            implementation 'com.facebook.soloader:nativeloader:0.8.0'
         }
     }
 

--- a/android/pytorch_android/CMakeLists.txt
+++ b/android/pytorch_android/CMakeLists.txt
@@ -62,10 +62,9 @@ if (ANDROID_ABI)
     # Link most things statically on Android.
   target_link_libraries(pytorch
       fbjni
-      -Wl,--gc-sections
-      -Wl,--whole-archive
+      -Wl,-dead_strip
+      -Wl,-all_load
       libtorch
-      -Wl,--no-whole-archive
       libc10
       libnnpack
       libpytorch_qnnpack
@@ -79,10 +78,9 @@ else()
   # Prefer dynamic linking on the host
   target_link_libraries(pytorch
       fbjni
-      -Wl,--gc-sections
-      -Wl,--whole-archive
+      -Wl,-dead_strip
+      -Wl,-all_load
       torch
-      -Wl,--no-whole-archive
       c10
       nnpack
       pytorch_qnnpack

--- a/android/pytorch_android/src/main/cpp/pytorch_jni.cpp
+++ b/android/pytorch_android/src/main/cpp/pytorch_jni.cpp
@@ -143,7 +143,7 @@ class JTensor : public facebook::jni::JavaClass<JTensor> {
     }
 
     const auto& tensorShape = tensor.sizes();
-    std::vector<int64_t> tensorShapeVec;
+    std::vector<jlong> tensorShapeVec;
     for (const auto& s : tensorShape) {
       tensorShapeVec.push_back(s);
     }
@@ -418,7 +418,7 @@ class JIValue : public facebook::jni::JavaClass<JIValue> {
     } else if (JIValue::kTypeCodeLong == typeCode) {
       static const auto jMethodGetLong =
           JIValue::javaClassStatic()->getMethod<jlong()>("toLong");
-      return at::IValue{jMethodGetLong(jivalue)};
+      return at::IValue{(int64_t)jMethodGetLong(jivalue)};
     } else if (JIValue::kTypeCodeDouble == typeCode) {
       static const auto jMethodGetDouble =
           JIValue::javaClassStatic()->getMethod<jdouble()>("toDouble");
@@ -554,11 +554,11 @@ class JIValue : public facebook::jni::JavaClass<JIValue> {
       auto firstEntryValue = JIValue::JIValueToAtIValue(it->second);
       c10::TypePtr typePtr = firstEntryValue.type();
       c10::impl::GenericDict dict{c10::IntType::get(), typePtr};
-      dict.insert(it->first->longValue(), firstEntryValue);
+      dict.insert((int64_t)it->first->longValue(), firstEntryValue);
       it++;
       for (; it != jmap->end(); it++) {
         dict.insert(
-            it->first->longValue(), JIValue::JIValueToAtIValue(it->second));
+            (int64_t)it->first->longValue(), JIValue::JIValueToAtIValue(it->second));
       }
       return at::IValue{dict};
     }

--- a/android/pytorch_android/src/main/java/org/pytorch/Module.java
+++ b/android/pytorch_android/src/main/java/org/pytorch/Module.java
@@ -3,6 +3,8 @@
 package org.pytorch;
 
 import com.facebook.jni.HybridData;
+import com.facebook.soloader.nativeloader.NativeLoader;
+import com.facebook.soloader.nativeloader.SystemDelegate;
 
 /**
  * Java wrapper for torch::jit::script::Module.
@@ -22,6 +24,9 @@ public class Module {
   }
 
   private Module(final String moduleAbsolutePath) {
+    if (!NativeLoader.isInitialized()) {
+      NativeLoader.init(new SystemDelegate());
+    }
     this.mNativePeer = new NativePeer(moduleAbsolutePath);
   }
 
@@ -59,7 +64,7 @@ public class Module {
 
   private static class NativePeer {
     static {
-      System.loadLibrary("pytorch");
+      NativeLoader.loadLibrary("pytorch");
     }
 
     private final HybridData mHybridData;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#29338 Enable nativeloader for pytorch jni and support mac x86-64.**
* #29338 Enable nativeloader for pytorch jni and support mac x86-64.

