### PR TITLE
Detect TorchScript archives in torch.load

### DIFF
--- a/caffe2/serialize/inline_container.cc
+++ b/caffe2/serialize/inline_container.cc
@@ -190,6 +190,17 @@ bool PyTorchStreamReader::hasRecord(const std::string& name) {
   return result;
 }
 
+std::vector<std::string> PyTorchStreamReader::getAllRecords() {
+  mz_uint num_files = mz_zip_reader_get_num_files(ar_.get());
+  std::vector<std::string> out;
+  char buf[MZ_ZIP_MAX_ARCHIVE_FILENAME_SIZE];
+  for (size_t i = 0; i < num_files; i++) {
+    mz_zip_reader_get_filename(ar_.get(), i, buf, MZ_ZIP_MAX_ARCHIVE_FILENAME_SIZE);
+    out.push_back(buf);
+  }
+  return out;
+}
+
 size_t PyTorchStreamReader::getRecordID(const std::string& name) {
   std::string ss = archive_name_plus_slash_ + name;
   size_t result = mz_zip_reader_locate_file(ar_.get(), ss.c_str(), nullptr, 0);

--- a/caffe2/serialize/inline_container.h
+++ b/caffe2/serialize/inline_container.h
@@ -106,6 +106,7 @@ class CAFFE2_API PyTorchStreamReader final {
   std::tuple<at::DataPtr, size_t> getRecord(const std::string& name);
   size_t getRecordOffset(const std::string& name);
   bool hasRecord(const std::string& name);
+  std::vector<std::string> getAllRecords();
 
   ~PyTorchStreamReader();
   uint64_t version() const {

--- a/torch/csrc/jit/init.cpp
+++ b/torch/csrc/jit/init.cpp
@@ -480,6 +480,9 @@ void initJITBindings(PyObject* module) {
         size_t size;
         std::tie(data, size) = self.getRecord(key);
         return py::bytes(reinterpret_cast<const char*>(data.get()), size);
+      })
+      .def("get_all_records", [](PyTorchStreamReader& self) {
+        return self.getAllRecords();
       });
 
   m.def(


### PR DESCRIPTION
This PR looks for a `constants.pkl` file at the top level in a zip file
in `torch.load`. If found, it calls `torch.jit.load` instead and issues
a warning to call `torch.jit.load` directly