### PR TITLE
Lift rpc_timeout to RpcAgent, for other RpcAgents to reuse.

### DIFF
--- a/test/rpc_test.py
+++ b/test/rpc_test.py
@@ -261,7 +261,6 @@ class RpcTest(object):
             worker_name_to_id=self.worker_name_to_id,
         )
 
-    @requires_process_group_agent("PROCESS_GROUP rpc backend specific test, skip")
     @dist_init(setup_model_parallel=False)
     def test_duplicate_name(self):
         with self.assertRaisesRegex(RuntimeError, "is not unique"):
@@ -962,15 +961,13 @@ class RpcTest(object):
 
         self.assertEqual(result, sum(vals))
 
-    @requires_process_group_agent("PROCESS_GROUP rpc backend specific test, skip")
     @dist_init
-    def test_get_default_rpc_timeout(self):
-        timeout = rpc.get_rpc_timeout()
+    def test_get_global_process_timeout(self):
+        timeout = rpc.get_global_process_timeout()
         self.assertEqual(timeout, rpc.constants.DEFAULT_RPC_TIMEOUT)
 
-    @requires_process_group_agent("PROCESS_GROUP rpc backend specific test, skip")
     @dist_init(setup_model_parallel=False)
-    def test_set_rpc_timeout(self):
+    def test_set_global_process_timeout(self):
         timeout = timedelta(seconds=1)
         rpc.init_model_parallel(
             self_name="worker{}".format(self.rank),
@@ -978,12 +975,11 @@ class RpcTest(object):
             init_method=self.init_method,
             self_rank=self.rank,
             worker_name_to_id=self.worker_name_to_id,
-            rpc_timeout=timeout
+            global_process_timeout=timeout
         )
-        set_timeout = rpc.get_rpc_timeout()
+        set_timeout = rpc.get_global_process_timeout()
         self.assertEqual(timeout, set_timeout)
         rpc.join_rpc()
-
 
     def test_requires_process_group_agent_decorator(self):
         @requires_process_group_agent("test_func did not run")

--- a/test/rpc_test.py
+++ b/test/rpc_test.py
@@ -963,7 +963,7 @@ class RpcTest(object):
 
     @dist_init
     def test_get_global_rpc_server_processing_timeout(self):
-        timeout = rpc.get_global_process_timeout()
+        timeout = rpc.get_global_rpc_server_processing_timeout()
         self.assertEqual(timeout, rpc.constants.DEFAULT_RPC_TIMEOUT)
 
     @dist_init(setup_model_parallel=False)

--- a/test/rpc_test.py
+++ b/test/rpc_test.py
@@ -261,6 +261,7 @@ class RpcTest(object):
             worker_name_to_id=self.worker_name_to_id,
         )
 
+    @requires_process_group_agent("PROCESS_GROUP rpc backend specific test, skip")
     @dist_init(setup_model_parallel=False)
     def test_duplicate_name(self):
         with self.assertRaisesRegex(RuntimeError, "is not unique"):
@@ -962,12 +963,12 @@ class RpcTest(object):
         self.assertEqual(result, sum(vals))
 
     @dist_init
-    def test_get_global_rpc_server_processing_timeout(self):
-        timeout = rpc.get_global_rpc_server_processing_timeout()
+    def test_get_default_rpc_timeout(self):
+        timeout = rpc.get_rpc_timeout()
         self.assertEqual(timeout, rpc.constants.DEFAULT_RPC_TIMEOUT)
 
     @dist_init(setup_model_parallel=False)
-    def test_set_global_rpc_server_processing_timeout(self):
+    def test_set_rpc_timeout(self):
         timeout = timedelta(seconds=1)
         rpc.init_model_parallel(
             self_name="worker{}".format(self.rank),
@@ -975,11 +976,12 @@ class RpcTest(object):
             init_method=self.init_method,
             self_rank=self.rank,
             worker_name_to_id=self.worker_name_to_id,
-            global_rpc_server_processing_timeout=timeout
+            rpc_timeout=timeout
         )
-        set_timeout = rpc.get_global_rpc_server_processing_timeout()
+        set_timeout = rpc.get_rpc_timeout()
         self.assertEqual(timeout, set_timeout)
         rpc.join_rpc()
+
 
     def test_requires_process_group_agent_decorator(self):
         @requires_process_group_agent("test_func did not run")

--- a/test/rpc_test.py
+++ b/test/rpc_test.py
@@ -962,12 +962,12 @@ class RpcTest(object):
         self.assertEqual(result, sum(vals))
 
     @dist_init
-    def test_get_global_process_timeout(self):
+    def test_get_global_rpc_server_processing_timeout(self):
         timeout = rpc.get_global_process_timeout()
         self.assertEqual(timeout, rpc.constants.DEFAULT_RPC_TIMEOUT)
 
     @dist_init(setup_model_parallel=False)
-    def test_set_global_process_timeout(self):
+    def test_set_global_rpc_server_processing_timeout(self):
         timeout = timedelta(seconds=1)
         rpc.init_model_parallel(
             self_name="worker{}".format(self.rank),
@@ -975,9 +975,9 @@ class RpcTest(object):
             init_method=self.init_method,
             self_rank=self.rank,
             worker_name_to_id=self.worker_name_to_id,
-            global_process_timeout=timeout
+            global_rpc_server_processing_timeout=timeout
         )
-        set_timeout = rpc.get_global_process_timeout()
+        set_timeout = rpc.get_global_rpc_server_processing_timeout()
         self.assertEqual(timeout, set_timeout)
         rpc.join_rpc()
 

--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -42,8 +42,10 @@ PyObject* rpc_init(PyObject* /* unused */) {
           .def(
               "join", &RpcAgent::join, py::call_guard<py::gil_scoped_release>())
           .def(
-              "sync",
-              &RpcAgent::sync,
+              "sync", &RpcAgent::sync, py::call_guard<py::gil_scoped_release>())
+          .def(
+              "_get_global_process_timeout",
+              &RpcAgent::getGlobalProcessTimeout,
               py::call_guard<py::gil_scoped_release>());
 
   auto pyFuture = shared_ptr_class_<PyFuture>(module, "Future")
@@ -100,7 +102,7 @@ PyObject* rpc_init(PyObject* /* unused */) {
           py::arg("name"),
           py::arg("process_group"),
           py::arg("num_send_recv_threads"),
-          py::arg("rpc_timeout"))
+          py::arg("global_process_timeout"))
       .def(
           "get_worker_info",
           (const WorkerInfo& (ProcessGroupAgent::*)(void)const) &
@@ -120,8 +122,8 @@ PyObject* rpc_init(PyObject* /* unused */) {
           &ProcessGroupAgent::sync,
           py::call_guard<py::gil_scoped_release>())
       .def(
-          "_get_rpc_timeout",
-          &ProcessGroupAgent::getRpcTimeout,
+          "_get_global_process_timeout",
+          &ProcessGroupAgent::getGlobalProcessTimeout,
           py::call_guard<py::gil_scoped_release>());
 
   module.def("_start_rpc_agent", [](const std::shared_ptr<RpcAgent>& agent) {

--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -120,10 +120,6 @@ PyObject* rpc_init(PyObject* /* unused */) {
       .def(
           "sync",
           &ProcessGroupAgent::sync,
-          py::call_guard<py::gil_scoped_release>())
-      .def(
-          "_get_rpc_timeout",
-          &ProcessGroupAgent::getRpcTimeout,
           py::call_guard<py::gil_scoped_release>());
 
   module.def("_start_rpc_agent", [](const std::shared_ptr<RpcAgent>& agent) {

--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -44,8 +44,8 @@ PyObject* rpc_init(PyObject* /* unused */) {
           .def(
               "sync", &RpcAgent::sync, py::call_guard<py::gil_scoped_release>())
           .def(
-              "_get_global_process_timeout",
-              &RpcAgent::getGlobalProcessTimeout,
+              "_get_global_rpc_server_processiong_timeout",
+              &RpcAgent::getGlobalRpcServerProcessingTimeout,
               py::call_guard<py::gil_scoped_release>());
 
   auto pyFuture = shared_ptr_class_<PyFuture>(module, "Future")
@@ -102,7 +102,7 @@ PyObject* rpc_init(PyObject* /* unused */) {
           py::arg("name"),
           py::arg("process_group"),
           py::arg("num_send_recv_threads"),
-          py::arg("global_process_timeout"))
+          py::arg("global_rpc_server_processiong_timeout"))
       .def(
           "get_worker_info",
           (const WorkerInfo& (ProcessGroupAgent::*)(void)const) &
@@ -122,8 +122,8 @@ PyObject* rpc_init(PyObject* /* unused */) {
           &ProcessGroupAgent::sync,
           py::call_guard<py::gil_scoped_release>())
       .def(
-          "_get_global_process_timeout",
-          &ProcessGroupAgent::getGlobalProcessTimeout,
+          "_get_global_rpc_server_processiong_timeout",
+          &ProcessGroupAgent::getGlobalRpcServerProcessingTimeout,
           py::call_guard<py::gil_scoped_release>());
 
   module.def("_start_rpc_agent", [](const std::shared_ptr<RpcAgent>& agent) {

--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -44,8 +44,8 @@ PyObject* rpc_init(PyObject* /* unused */) {
           .def(
               "sync", &RpcAgent::sync, py::call_guard<py::gil_scoped_release>())
           .def(
-              "_get_global_rpc_server_processiong_timeout",
-              &RpcAgent::getGlobalRpcServerProcessingTimeout,
+              "_get_rpc_timeout",
+              &RpcAgent::getRpcTimeout,
               py::call_guard<py::gil_scoped_release>());
 
   auto pyFuture = shared_ptr_class_<PyFuture>(module, "Future")
@@ -102,7 +102,7 @@ PyObject* rpc_init(PyObject* /* unused */) {
           py::arg("name"),
           py::arg("process_group"),
           py::arg("num_send_recv_threads"),
-          py::arg("global_rpc_server_processiong_timeout"))
+          py::arg("rpc_timeout"))
       .def(
           "get_worker_info",
           (const WorkerInfo& (ProcessGroupAgent::*)(void)const) &
@@ -122,8 +122,8 @@ PyObject* rpc_init(PyObject* /* unused */) {
           &ProcessGroupAgent::sync,
           py::call_guard<py::gil_scoped_release>())
       .def(
-          "_get_global_rpc_server_processiong_timeout",
-          &ProcessGroupAgent::getGlobalRpcServerProcessingTimeout,
+          "_get_rpc_timeout",
+          &ProcessGroupAgent::getRpcTimeout,
           py::call_guard<py::gil_scoped_release>());
 
   module.def("_start_rpc_agent", [](const std::shared_ptr<RpcAgent>& agent) {

--- a/torch/csrc/distributed/rpc/process_group_agent.cpp
+++ b/torch/csrc/distributed/rpc/process_group_agent.cpp
@@ -119,11 +119,11 @@ ProcessGroupAgent::ProcessGroupAgent(
     std::string workerName,
     std::shared_ptr<c10d::ProcessGroup> pg,
     int numSendRecvThreads,
-    std::chrono::milliseconds globalProcessTimeout)
+    std::chrono::milliseconds globalRpcServerProcessingTimeout)
     : RpcAgent(
           WorkerInfo(std::move(workerName), pg->getRank()),
           c10::guts::make_unique<RequestCallbackImpl>(),
-          globalProcessTimeout),
+          globalRpcServerProcessingTimeout),
       pg_(std::move(pg)),
       sendCounts_(pg_->getSize()),
       recvCounts_(pg_->getSize()),

--- a/torch/csrc/distributed/rpc/process_group_agent.cpp
+++ b/torch/csrc/distributed/rpc/process_group_agent.cpp
@@ -119,11 +119,11 @@ ProcessGroupAgent::ProcessGroupAgent(
     std::string workerName,
     std::shared_ptr<c10d::ProcessGroup> pg,
     int numSendRecvThreads,
-    std::chrono::milliseconds globalRpcServerProcessingTimeout)
+    std::chrono::milliseconds rpcTimeout)
     : RpcAgent(
           WorkerInfo(std::move(workerName), pg->getRank()),
           c10::guts::make_unique<RequestCallbackImpl>(),
-          globalRpcServerProcessingTimeout),
+          rpcTimeout),
       pg_(std::move(pg)),
       sendCounts_(pg_->getSize()),
       recvCounts_(pg_->getSize()),

--- a/torch/csrc/distributed/rpc/process_group_agent.h
+++ b/torch/csrc/distributed/rpc/process_group_agent.h
@@ -39,7 +39,7 @@ class ProcessGroupAgent : public RpcAgent {
       std::string workerName,
       std::shared_ptr<c10d::ProcessGroup> pg,
       int numSendRecvThreads,
-      std::chrono::milliseconds rpcTimeout);
+      std::chrono::milliseconds globalProcessTimeouts);
 
   const WorkerInfo& getWorkerInfo(const std::string& workerName) const override;
 
@@ -50,9 +50,6 @@ class ProcessGroupAgent : public RpcAgent {
   void sync() override;
 
   void start() override;
-
-  // retrieves the timeout for all RPCs
-  const std::chrono::milliseconds& getRpcTimeout() const;
 
  protected:
   // This method wraps the destination information and the message into a
@@ -148,7 +145,6 @@ class ProcessGroupAgent : public RpcAgent {
   std::map<std::chrono::milliseconds, std::vector<int64_t>> futureTimeouts_;
   mutable std::mutex futureMutex_;
   mutable std::condition_variable futureCV_;
-  std::chrono::milliseconds rpcTimeout_;
 };
 
 } // namespace rpc

--- a/torch/csrc/distributed/rpc/process_group_agent.h
+++ b/torch/csrc/distributed/rpc/process_group_agent.h
@@ -39,7 +39,7 @@ class ProcessGroupAgent : public RpcAgent {
       std::string workerName,
       std::shared_ptr<c10d::ProcessGroup> pg,
       int numSendRecvThreads,
-      std::chrono::milliseconds globalProcessTimeouts);
+      std::chrono::milliseconds globalRpcServerProcessingTimeout);
 
   const WorkerInfo& getWorkerInfo(const std::string& workerName) const override;
 

--- a/torch/csrc/distributed/rpc/process_group_agent.h
+++ b/torch/csrc/distributed/rpc/process_group_agent.h
@@ -39,7 +39,7 @@ class ProcessGroupAgent : public RpcAgent {
       std::string workerName,
       std::shared_ptr<c10d::ProcessGroup> pg,
       int numSendRecvThreads,
-      std::chrono::milliseconds globalRpcServerProcessingTimeout);
+      std::chrono::milliseconds rpcTimeout);
 
   const WorkerInfo& getWorkerInfo(const std::string& workerName) const override;
 

--- a/torch/csrc/distributed/rpc/rpc_agent.cpp
+++ b/torch/csrc/distributed/rpc/rpc_agent.cpp
@@ -6,8 +6,13 @@ namespace rpc {
 
 constexpr size_t WorkerInfo::MAX_NAME_LEN;
 
-RpcAgent::RpcAgent(WorkerInfo workerId, std::unique_ptr<RequestCallback> cb)
-    : workerInfo_(std::move(workerId)), cb_(std::move(cb)) {}
+RpcAgent::RpcAgent(
+    WorkerInfo workerId,
+    std::unique_ptr<RequestCallback> cb,
+    std::chrono::milliseconds globalProcessTimeout)
+    : workerInfo_(std::move(workerId)),
+      cb_(std::move(cb)),
+      globalProcessTimeout_(globalProcessTimeout) {}
 
 RpcAgent::~RpcAgent() = default;
 

--- a/torch/csrc/distributed/rpc/rpc_agent.cpp
+++ b/torch/csrc/distributed/rpc/rpc_agent.cpp
@@ -9,10 +9,10 @@ constexpr size_t WorkerInfo::MAX_NAME_LEN;
 RpcAgent::RpcAgent(
     WorkerInfo workerId,
     std::unique_ptr<RequestCallback> cb,
-    std::chrono::milliseconds globalProcessTimeout)
+    std::chrono::milliseconds globalRpcServerProcessingTimeout)
     : workerInfo_(std::move(workerId)),
       cb_(std::move(cb)),
-      globalProcessTimeout_(globalProcessTimeout) {}
+      globalRpcServerProcessingTimeout_(globalRpcServerProcessingTimeout) {}
 
 RpcAgent::~RpcAgent() = default;
 

--- a/torch/csrc/distributed/rpc/rpc_agent.cpp
+++ b/torch/csrc/distributed/rpc/rpc_agent.cpp
@@ -9,10 +9,10 @@ constexpr size_t WorkerInfo::MAX_NAME_LEN;
 RpcAgent::RpcAgent(
     WorkerInfo workerId,
     std::unique_ptr<RequestCallback> cb,
-    std::chrono::milliseconds globalRpcServerProcessingTimeout)
+    std::chrono::milliseconds rpcTimeout)
     : workerInfo_(std::move(workerId)),
       cb_(std::move(cb)),
-      globalRpcServerProcessingTimeout_(globalRpcServerProcessingTimeout) {}
+      rpcTimeout_(rpcTimeout) {}
 
 RpcAgent::~RpcAgent() = default;
 

--- a/torch/csrc/distributed/rpc/rpc_agent.h
+++ b/torch/csrc/distributed/rpc/rpc_agent.h
@@ -66,7 +66,10 @@ class TORCH_API RpcAgent {
   // NB: RpcAgent implementations should not start serving requests until
   // ``start()`` is called, as there could be other contexts that have not been
   // initialized yet at this time.
-  RpcAgent(WorkerInfo id, std::unique_ptr<RequestCallback> cb);
+  RpcAgent(
+      WorkerInfo id,
+      std::unique_ptr<RequestCallback> cb,
+      std::chrono::milliseconds globalProcessTimeout_);
 
   virtual ~RpcAgent();
 
@@ -93,6 +96,11 @@ class TORCH_API RpcAgent {
 
   virtual const WorkerInfo& getWorkerInfo(worker_id_t id) const = 0;
 
+  // Retrieves the process timeout for all RPCs.
+  virtual const std::chrono::milliseconds& getGlobalProcessTimeout() const {
+    return globalProcessTimeout_;
+  }
+
   // Call sync and join all internal threads. This method should be called
   // before every RPC process exits.
   virtual void join() = 0;
@@ -114,6 +122,7 @@ class TORCH_API RpcAgent {
   const WorkerInfo workerInfo_;
   const std::string workerName_;
   const std::unique_ptr<RequestCallback> cb_;
+  const std::chrono::milliseconds globalProcessTimeout_;
 
  private:
   static std::shared_ptr<RpcAgent> defaultRpcAgent_;

--- a/torch/csrc/distributed/rpc/rpc_agent.h
+++ b/torch/csrc/distributed/rpc/rpc_agent.h
@@ -69,7 +69,7 @@ class TORCH_API RpcAgent {
   RpcAgent(
       WorkerInfo id,
       std::unique_ptr<RequestCallback> cb,
-      std::chrono::milliseconds globalProcessTimeout_);
+      std::chrono::milliseconds globalRpcServerProcessingTimeout);
 
   virtual ~RpcAgent();
 
@@ -97,8 +97,9 @@ class TORCH_API RpcAgent {
   virtual const WorkerInfo& getWorkerInfo(worker_id_t id) const = 0;
 
   // Retrieves the process timeout for all RPCs.
-  virtual const std::chrono::milliseconds& getGlobalProcessTimeout() const {
-    return globalProcessTimeout_;
+  virtual const std::chrono::milliseconds& getGlobalRpcServerProcessingTimeout()
+      const {
+    return globalRpcServerProcessingTimeout_;
   }
 
   // Call sync and join all internal threads. This method should be called
@@ -122,7 +123,7 @@ class TORCH_API RpcAgent {
   const WorkerInfo workerInfo_;
   const std::string workerName_;
   const std::unique_ptr<RequestCallback> cb_;
-  const std::chrono::milliseconds globalProcessTimeout_;
+  const std::chrono::milliseconds globalRpcServerProcessingTimeout_;
 
  private:
   static std::shared_ptr<RpcAgent> defaultRpcAgent_;

--- a/torch/csrc/distributed/rpc/rpc_agent.h
+++ b/torch/csrc/distributed/rpc/rpc_agent.h
@@ -97,7 +97,7 @@ class TORCH_API RpcAgent {
   virtual const WorkerInfo& getWorkerInfo(worker_id_t id) const = 0;
 
   // Retrieve the timeout for all RPCs.
-  virtual const std::chrono::milliseconds& getRpcTimeout() const {
+  inline const std::chrono::milliseconds& getRpcTimeout() const {
     return rpcTimeout_;
   }
 

--- a/torch/csrc/distributed/rpc/rpc_agent.h
+++ b/torch/csrc/distributed/rpc/rpc_agent.h
@@ -69,7 +69,7 @@ class TORCH_API RpcAgent {
   RpcAgent(
       WorkerInfo id,
       std::unique_ptr<RequestCallback> cb,
-      std::chrono::milliseconds globalRpcServerProcessingTimeout);
+      std::chrono::milliseconds rpcTimeout);
 
   virtual ~RpcAgent();
 
@@ -96,10 +96,9 @@ class TORCH_API RpcAgent {
 
   virtual const WorkerInfo& getWorkerInfo(worker_id_t id) const = 0;
 
-  // Retrieves the process timeout for all RPCs.
-  virtual const std::chrono::milliseconds& getGlobalRpcServerProcessingTimeout()
-      const {
-    return globalRpcServerProcessingTimeout_;
+  // Retrieve the timeout for all RPCs.
+  virtual const std::chrono::milliseconds& getRpcTimeout() const {
+    return rpcTimeout_;
   }
 
   // Call sync and join all internal threads. This method should be called
@@ -123,7 +122,7 @@ class TORCH_API RpcAgent {
   const WorkerInfo workerInfo_;
   const std::string workerName_;
   const std::unique_ptr<RequestCallback> cb_;
-  const std::chrono::milliseconds globalRpcServerProcessingTimeout_;
+  const std::chrono::milliseconds rpcTimeout_;
 
  private:
   static std::shared_ptr<RpcAgent> defaultRpcAgent_;

--- a/torch/distributed/rpc/__init__.py
+++ b/torch/distributed/rpc/__init__.py
@@ -28,7 +28,7 @@ if is_available():
         self_rank=-1,
         worker_name_to_id=None,
         num_send_recv_threads=DEFAULT_NUM_SEND_RECV_THREADS,
-        rpc_timeout=DEFAULT_RPC_TIMEOUT,
+        global_process_timeout=DEFAULT_RPC_TIMEOUT,
     ):
         r"""
         Initializes model parallel primitives such as the local rpc agent
@@ -53,7 +53,10 @@ if is_available():
             self_rank (int): a globally unique id/rank of this node.
             init_method(str): backend specific init arguments.
             num_send_recv_threads(int): Number of threads for send/recv work.
-            rpc_timeout (datetime.timedelta): Timeout for RPCs. Defaults to 10 seconds.
+            global_process_timeout (datetime.timedelta):
+                Fallback timeout for server to process an RPC request.
+                Defaults to 10 seconds.
+                0 means infinity.
         """
         # Rendezvous.
         world_size = len(worker_name_to_id)
@@ -70,7 +73,7 @@ if is_available():
             self_rank,
             worker_name_to_id,
             num_send_recv_threads,
-            rpc_timeout,
+            global_process_timeout,
         )
 
         # Initialize Autograd.

--- a/torch/distributed/rpc/__init__.py
+++ b/torch/distributed/rpc/__init__.py
@@ -28,7 +28,7 @@ if is_available():
         self_rank=-1,
         worker_name_to_id=None,
         num_send_recv_threads=DEFAULT_NUM_SEND_RECV_THREADS,
-        global_rpc_server_processing_timeout=DEFAULT_RPC_TIMEOUT,
+        rpc_timeout=DEFAULT_RPC_TIMEOUT,
     ):
         r"""
         Initializes model parallel primitives such as the local rpc agent
@@ -53,8 +53,8 @@ if is_available():
             self_rank (int): a globally unique id/rank of this node.
             init_method(str): backend specific init arguments.
             num_send_recv_threads(int): Number of threads for send/recv work.
-            global_rpc_server_processing_timeout (datetime.timedelta):
-                Fallback timeout for server to process an RPC request.
+            rpc_timeout (datetime.timedelta):
+                Global timeout for server to process an RPC request.
                 Defaults to 10 seconds.
                 0 means infinity.
         """
@@ -73,7 +73,7 @@ if is_available():
             self_rank,
             worker_name_to_id,
             num_send_recv_threads,
-            global_rpc_server_processing_timeout,
+            rpc_timeout,
         )
 
         # Initialize Autograd.

--- a/torch/distributed/rpc/__init__.py
+++ b/torch/distributed/rpc/__init__.py
@@ -53,9 +53,7 @@ if is_available():
             self_rank (int): a globally unique id/rank of this node.
             init_method(str): backend specific init arguments.
             num_send_recv_threads(int): Number of threads for send/recv work.
-            rpc_timeout (datetime.timedelta):
-                Global timeout for server to process an RPC request.
-                Defaults to 10 seconds.
+            rpc_timeout (datetime.timedelta): Timeout for RPCs. Defaults to 10 seconds.
                 0 means infinity.
         """
         # Rendezvous.

--- a/torch/distributed/rpc/__init__.py
+++ b/torch/distributed/rpc/__init__.py
@@ -28,7 +28,7 @@ if is_available():
         self_rank=-1,
         worker_name_to_id=None,
         num_send_recv_threads=DEFAULT_NUM_SEND_RECV_THREADS,
-        global_process_timeout=DEFAULT_RPC_TIMEOUT,
+        global_rpc_server_processing_timeout=DEFAULT_RPC_TIMEOUT,
     ):
         r"""
         Initializes model parallel primitives such as the local rpc agent
@@ -53,7 +53,7 @@ if is_available():
             self_rank (int): a globally unique id/rank of this node.
             init_method(str): backend specific init arguments.
             num_send_recv_threads(int): Number of threads for send/recv work.
-            global_process_timeout (datetime.timedelta):
+            global_rpc_server_processing_timeout (datetime.timedelta):
                 Fallback timeout for server to process an RPC request.
                 Defaults to 10 seconds.
                 0 means infinity.
@@ -73,7 +73,7 @@ if is_available():
             self_rank,
             worker_name_to_id,
             num_send_recv_threads,
-            global_process_timeout,
+            global_rpc_server_processing_timeout,
         )
 
         # Initialize Autograd.

--- a/torch/distributed/rpc/api.py
+++ b/torch/distributed/rpc/api.py
@@ -67,7 +67,7 @@ def _init_rpc(
     self_rank=-1,
     worker_name_to_id=None,
     num_send_recv_threads=DEFAULT_NUM_SEND_RECV_THREADS,
-    rpc_timeout=DEFAULT_RPC_TIMEOUT,
+    global_process_timeout=DEFAULT_RPC_TIMEOUT,
 ):
     if sys.version_info < (3, 0):
         raise RuntimeError("RPC package does not support Python2.")
@@ -85,7 +85,7 @@ def _init_rpc(
         self_rank=self_rank,
         worker_name_to_id=worker_name_to_id,
         num_send_recv_threads=num_send_recv_threads,
-        rpc_timeout=rpc_timeout,
+        global_process_timeout=global_process_timeout,
     )
     _start_rpc_agent(_agent)
 
@@ -111,14 +111,14 @@ def get_worker_info(worker_name=None):
         return _agent.get_worker_info()
 
 @_require_initialized
-def get_rpc_timeout():
+def get_global_process_timeout():
     """
     Retrieve the timeout for all RPCs that was set during RPC initialization.
 
     Returns:
         `datetime.timedelta` instance indicating the RPC timeout.
     """
-    return _agent._get_rpc_timeout()
+    return _agent._get_global_process_timeout()
 
 
 def _to_worker_info(name_or_info):

--- a/torch/distributed/rpc/api.py
+++ b/torch/distributed/rpc/api.py
@@ -1,16 +1,22 @@
-from . import invoke_rpc_builtin, invoke_rpc_python_udf
-from . import invoke_remote_builtin, invoke_remote_python_udf
-from . import _start_rpc_agent
-from . import _destroy_rref_context, _cleanup_python_rpc_handler
-from . import WorkerInfo
-from . import backend_registry
-from .constants import DEFAULT_RPC_TIMEOUT, DEFAULT_NUM_SEND_RECV_THREADS
-from .internal import _internal_rpc_pickler, PythonUDF
-
 import datetime
 import functools
 import sys
+
 import torch
+
+from . import (
+    WorkerInfo,
+    _cleanup_python_rpc_handler,
+    _destroy_rref_context,
+    _start_rpc_agent,
+    backend_registry,
+    invoke_remote_builtin,
+    invoke_remote_python_udf,
+    invoke_rpc_builtin,
+    invoke_rpc_python_udf,
+)
+from .constants import DEFAULT_NUM_SEND_RECV_THREADS, DEFAULT_RPC_TIMEOUT
+from .internal import PythonUDF, _internal_rpc_pickler
 
 
 _agent = None
@@ -25,6 +31,7 @@ def _require_initialized(func):
                 "torch.distributed.rpc.init_model_parallel first."
             )
         return func(*args, **kwargs)
+
     return wrapper
 
 
@@ -59,7 +66,6 @@ def sync_rpc():
     _agent.sync()
 
 
-
 # TODO: add a context manager to wrap _init_rpc and join_rpc
 def _init_rpc(
     backend=backend_registry.BackendType.PROCESS_GROUP,
@@ -68,7 +74,7 @@ def _init_rpc(
     self_rank=-1,
     worker_name_to_id=None,
     num_send_recv_threads=DEFAULT_NUM_SEND_RECV_THREADS,
-    global_process_timeout=DEFAULT_RPC_TIMEOUT,
+    global_rpc_server_processing_timeout=DEFAULT_RPC_TIMEOUT,
 ):
     if sys.version_info < (3, 0):
         raise RuntimeError("RPC package does not support Python2.")
@@ -79,8 +85,10 @@ def _init_rpc(
         raise RuntimeError("RPC is already initialized")
 
     # Initialize RPC.
-    if not isinstance(global_process_timeout, datetime.timedelta):
-        raise RuntimeError("`global_process_timeout` must be a `datetime.timedelta`.")
+    if not isinstance(global_rpc_server_processing_timeout, datetime.timedelta):
+        raise RuntimeError(
+            "`global_rpc_server_processing_timeout` must be a `datetime.timedelta`."
+        )
 
     _agent = backend_registry.init_backend(
         backend,
@@ -89,7 +97,7 @@ def _init_rpc(
         self_rank=self_rank,
         worker_name_to_id=worker_name_to_id,
         num_send_recv_threads=num_send_recv_threads,
-        global_process_timeout=global_process_timeout,
+        global_rpc_server_processing_timeout=global_rpc_server_processing_timeout,
     )
     _start_rpc_agent(_agent)
 
@@ -114,15 +122,16 @@ def get_worker_info(worker_name=None):
     else:
         return _agent.get_worker_info()
 
+
 @_require_initialized
-def get_global_process_timeout():
+def get_global_rpc_server_processing_timeout():
     """
     Retrieve the timeout for all RPCs that was set during RPC initialization.
 
     Returns:
         `datetime.timedelta` instance indicating the RPC timeout.
     """
-    return _agent._get_global_process_timeout()
+    return _agent._get_global_rpc_server_processing_timeout()
 
 
 def _to_worker_info(name_or_info):
@@ -180,13 +189,12 @@ def remote(to, func, args=None, kwargs=None):
 
     info = _to_worker_info(to)
     if qualified_name is not None:
-        return invoke_remote_builtin(
-            _agent, info, qualified_name, *args, **kwargs)
+        return invoke_remote_builtin(_agent, info, qualified_name, *args, **kwargs)
     else:
         (pickled_python_udf, tensors) = _internal_rpc_pickler.serialize(
-            PythonUDF(func, args, kwargs))
-        return invoke_remote_python_udf(
-            _agent, info, pickled_python_udf, tensors)
+            PythonUDF(func, args, kwargs)
+        )
+        return invoke_remote_python_udf(_agent, info, pickled_python_udf, tensors)
 
 
 def _invoke_rpc(to, func, args=None, kwargs=None):
@@ -200,14 +208,12 @@ def _invoke_rpc(to, func, args=None, kwargs=None):
 
     info = _to_worker_info(to)
     if qualified_name is not None:
-        fut = invoke_rpc_builtin(
-            _agent, info, qualified_name, *args, **kwargs
-        )
+        fut = invoke_rpc_builtin(_agent, info, qualified_name, *args, **kwargs)
     else:
         (pickled_python_udf, tensors) = _internal_rpc_pickler.serialize(
-            PythonUDF(func, args, kwargs))
-        fut = invoke_rpc_python_udf(
-            _agent, info, pickled_python_udf, tensors)
+            PythonUDF(func, args, kwargs)
+        )
+        fut = invoke_rpc_python_udf(_agent, info, pickled_python_udf, tensors)
     return fut
 
 

--- a/torch/distributed/rpc/api.py
+++ b/torch/distributed/rpc/api.py
@@ -7,6 +7,7 @@ from . import backend_registry
 from .constants import DEFAULT_RPC_TIMEOUT, DEFAULT_NUM_SEND_RECV_THREADS
 from .internal import _internal_rpc_pickler, PythonUDF
 
+import datetime
 import functools
 import sys
 import torch
@@ -78,6 +79,9 @@ def _init_rpc(
         raise RuntimeError("RPC is already initialized")
 
     # Initialize RPC.
+    if not isinstance(global_process_timeout, datetime.timedelta):
+        raise RuntimeError("`global_process_timeout` must be a `datetime.timedelta`.")
+
     _agent = backend_registry.init_backend(
         backend,
         store=store,

--- a/torch/distributed/rpc/backend_registry.py
+++ b/torch/distributed/rpc/backend_registry.py
@@ -45,6 +45,7 @@ def process_group_init_backend_handler(
     self_rank,
     worker_name_to_id,
     num_send_recv_threads,
+    global_process_timeout,
     *args,
     **kwargs
 ):
@@ -78,7 +79,7 @@ def process_group_init_backend_handler(
                 )
             )
         # TODO: add try-except and destroy _agent in all processes if any fails.
-        return ProcessGroupAgent(self_name, group, num_send_recv_threads, kwargs["rpc_timeout"])
+        return ProcessGroupAgent(self_name, group, num_send_recv_threads, global_process_timeout)
     except Exception as ex:
         dist.destroy_process_group()
         raise ex

--- a/torch/distributed/rpc/backend_registry.py
+++ b/torch/distributed/rpc/backend_registry.py
@@ -45,7 +45,7 @@ def process_group_init_backend_handler(
     self_rank,
     worker_name_to_id,
     num_send_recv_threads,
-    global_process_timeout,
+    global_rpc_server_processing_timeout,
     *args,
     **kwargs
 ):
@@ -79,11 +79,15 @@ def process_group_init_backend_handler(
                 )
             )
         # TODO: add try-except and destroy _agent in all processes if any fails.
-        return ProcessGroupAgent(self_name, group, num_send_recv_threads, global_process_timeout)
+        return ProcessGroupAgent(
+            self_name,
+            group,
+            num_send_recv_threads,
+            global_rpc_server_processing_timeout,
+        )
     except Exception as ex:
         dist.destroy_process_group()
         raise ex
-
 
 
 register_backend("PROCESS_GROUP", process_group_init_backend_handler)

--- a/torch/distributed/rpc/backend_registry.py
+++ b/torch/distributed/rpc/backend_registry.py
@@ -45,7 +45,7 @@ def process_group_init_backend_handler(
     self_rank,
     worker_name_to_id,
     num_send_recv_threads,
-    global_rpc_server_processing_timeout,
+    rpc_timeout,
     *args,
     **kwargs
 ):
@@ -83,11 +83,12 @@ def process_group_init_backend_handler(
             self_name,
             group,
             num_send_recv_threads,
-            global_rpc_server_processing_timeout,
+            rpc_timeout,
         )
     except Exception as ex:
         dist.destroy_process_group()
         raise ex
+
 
 
 register_backend("PROCESS_GROUP", process_group_init_backend_handler)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#29341 Lift rpc_timeout to RpcAgent, for other RpcAgents to reuse.**

https://github.com/pytorch/pytorch/pull/29336

So that other RpcAgent could use this timeout setting as well.

Differential Revision: [D5681951](https://our.internmc.facebook.com/intern/diff/D5681951/)