### PR TITLE
[jit] don't copy ignored/unused methods to ScriptModule

### DIFF
--- a/torch/jit/_recursive.py
+++ b/torch/jit/_recursive.py
@@ -370,15 +370,6 @@ def create_script_module_impl(nn_module, concrete_type, cpp_module, stubs):
 
             script_module._modules[name] = scripted
 
-        # 3. Copy @ignored/@unused methods from the original `nn_module` to the new ScriptModule.
-        #    This ensures we can access these Python methods on the ScriptModule.
-        for name in dir(nn_module):
-            item = getattr(nn_module, name, None)
-            if not inspect.ismethod(item):
-                continue
-            if _jit_internal.is_ignored_fn(item):
-                setattr(script_module, name, item)
-
         # For convenience, attach the concrete type to the new ScriptModule
         script_module._concrete_type = concrete_type
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#29342 [jit] don't copy ignored/unused methods to ScriptModule**

This is not necessary, as we use `lazy_bind` to retrieve those methods
from the class anyway.

Differential Revision: [D18383381](https://our.internmc.facebook.com/intern/diff/D18383381)