### PR TITLE
Add processTimeout for RPC Message

### DIFF
--- a/torch/csrc/distributed/rpc/message.cpp
+++ b/torch/csrc/distributed/rpc/message.cpp
@@ -19,6 +19,28 @@ Message::Message(
     int64_t id)
     : payload_(payload), tensors_(tensors), type_(type), id_(id) {}
 
+Message::Message(
+    std::vector<char>&& payload,
+    std::vector<torch::Tensor>&& tensors,
+    MessageType type,
+    std::chrono::milliseconds processTimeout)
+    : payload_(payload),
+      tensors_(tensors),
+      type_(type),
+      processTimeout_(processTimeout) {}
+
+Message::Message(
+    std::vector<char>&& payload,
+    std::vector<torch::Tensor>&& tensors,
+    MessageType type,
+    std::chrono::milliseconds processTimeout,
+    int64_t id)
+    : payload_(payload),
+      tensors_(tensors),
+      type_(type),
+      processTimeout_(processTimeout),
+      id_(id) {}
+
 Message::Message(const Message& other) = default;
 
 Message::Message(Message&& other) noexcept = default;
@@ -66,6 +88,10 @@ const std::vector<torch::Tensor>& Message::tensors() const {
 
 MessageType Message::type() const {
   return type_;
+}
+
+c10::optional<std::chrono::milliseconds> Message::processTimeout() const {
+  return processTimeout_;
 }
 
 bool Message::isRequest() const {

--- a/torch/csrc/distributed/rpc/message.h
+++ b/torch/csrc/distributed/rpc/message.h
@@ -83,6 +83,19 @@ class TORCH_API Message final {
       MessageType type,
       int64_t id);
 
+  Message(
+      std::vector<char>&& payload,
+      std::vector<torch::Tensor>&& tensors,
+      MessageType type,
+      std::chrono::milliseconds processTimeout);
+
+  Message(
+      std::vector<char>&& payload,
+      std::vector<torch::Tensor>&& tensors,
+      MessageType type,
+      std::chrono::milliseconds processTimeout,
+      int64_t id);
+
   Message(const Message& other);
   Message(Message&& other) noexcept;
   Message& operator=(Message const& rhs) &;
@@ -97,6 +110,7 @@ class TORCH_API Message final {
   std::vector<torch::Tensor>& tensors();
   const std::vector<torch::Tensor>& tensors() const;
   MessageType type() const;
+  c10::optional<std::chrono::milliseconds> processTimeout() const;
 
   bool isRequest() const;
   bool isResponse() const;
@@ -112,6 +126,9 @@ class TORCH_API Message final {
   std::vector<char> payload_;
   std::vector<torch::Tensor> tensors_;
   MessageType type_ = MessageType::UNKNOWN;
+  /* For client side to dictate the timeout constraint on server side.
+         Only useful when the Message is a request. */
+  c10::optional<std::chrono::milliseconds> processTimeout_;
   int64_t id_ = -1;
 };
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#29347 Add processTimeout for RPC Message**
* #29341 Pass global_process_timeout to RpcAgent

This is for enabling per-RPC timeout.

Both client side and server side need to know the user specified timeout.

Client side dictates server side the timeout through `rpc::Message`.


# Future work

Make server side consume this timeout. See the change point in D18109586.

Differential Revision: [D5591068](https://our.internmc.facebook.com/intern/diff/D5591068/)