### PR TITLE
add a new flag to select machine for op benchmark

### DIFF
--- a/benchmarks/operator_benchmark/benchmark_core.py
+++ b/benchmarks/operator_benchmark/benchmark_core.py
@@ -241,7 +241,8 @@ class BenchmarkRunner(object):
             self._check_keep(op_test_config.tag, self.args.tag_filter) and
             self._check_keep_list(test_case.op_bench.module_name(), operators) and
             self._check_keep_list(test_case.framework, frameworks) and
-                (not self.args.forward_only or op_test_config.run_backward != self.args.forward_only)):
+                (not self.args.forward_only or op_test_config.run_backward != self.args.forward_only) and
+                (self.args.device == 'None' or self.args.device in op_test_config.test_name)):
             return True
 
         return False

--- a/benchmarks/operator_benchmark/benchmark_runner.py
+++ b/benchmarks/operator_benchmark/benchmark_runner.py
@@ -123,6 +123,11 @@ def main():
         default="Caffe2,PyTorch")
 
     parser.add_argument(
+        '--device',
+        help='Run tests on the provided architecture (cpu, cuda)',
+        default='None')
+
+    parser.add_argument(
         '--wipe_cache',
         help='Wipe cache before benchmarking each operator',
         action='store_true',


### PR DESCRIPTION
Summary: This diff adds a new flag to pick cpu/gpu machines to run op benchmarks. The default is None which will try to run all support devices.

Test Plan:
```
buck run mode/opt caffe2/benchmarks/operator_benchmark/pt:add_test
# ----------------------------------------
# PyTorch/Caffe2 Operator Micro-benchmarks
# ----------------------------------------
# Tag : short

# Benchmarking PyTorch: add_
# Mode: Eager
# Name: add__M64_N64_K64_cpu
# Input: M: 64, N: 64, K: 64, device: cpu
Forward Execution Time (us) : 124.283
...
# Benchmarking PyTorch: add_
# Mode: Eager
# Name: add__M64_N64_K128_cuda_bwdall
# Input: M: 64, N: 64, K: 128, device: cuda
Backward Execution Time (us) : 176.592

buck run mode/opt caffe2/benchmarks/operator_benchmark/pt:add_test -- --device cpu
# ----------------------------------------
# PyTorch/Caffe2 Operator Micro-benchmarks
# ----------------------------------------
# Tag : short

# Benchmarking PyTorch: add_
# Mode: Eager
# Name: add__M64_N64_K64_cpu
# Input: M: 64, N: 64, K: 64, device: cpu
Forward Execution Time (us) : 121.884

buck run mode/opt caffe2/benchmarks/operator_benchmark/pt:add_test -- --device cuda
# ----------------------------------------
# PyTorch/Caffe2 Operator Micro-benchmarks
# ----------------------------------------
# Tag : short

# Benchmarking PyTorch: add_
# Mode: Eager
# Name: add__M64_N64_K64_cuda
# Input: M: 64, N: 64, K: 64, device: cuda
Forward Execution Time (us) : 26.002

Differential Revision: D18363942

