### PR TITLE
getFuncName take func_value as argument (#29146)

### DIFF
--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -12,6 +12,7 @@ class CustomClassHolder : public c10::intrusive_ptr_target {};
 struct Function;
 namespace script {
 struct CompilationUnit;
+struct Module;
 }
 } // namespace jit
 } // namespace torch
@@ -325,6 +326,9 @@ struct CAFFE2_API IValue final {
   c10::intrusive_ptr<ivalue::Object> toObject() &&;
   c10::intrusive_ptr<ivalue::Object> toObject() const & ;
   const ivalue::Object& toObjectRef() const;
+
+  torch::jit::script::Module toModule() const;
+  bool isModule() const;
 
   // None
   bool isNone() const {

--- a/test/cpp/api/serialize.cpp
+++ b/test/cpp/api/serialize.cpp
@@ -416,7 +416,7 @@ TEST(SerializeTest, IValue) {
   input_archive.read("value", ivalue_out);
   ASSERT_EQ(ivalue_out.toInt(), 1);
 
-  ASSERT_THROWS_WITH(input_archive.read("bad_key", ivalue_out), "No such serialized IValue");
+  ASSERT_THROWS_WITH(input_archive.read("bad_key", ivalue_out), "does not have a field with the name");
 }
 
 // NOTE: if a `Module` contains unserializable submodules (e.g. `nn::Functional`),
@@ -492,5 +492,5 @@ TEST(SerializeTest, UnserializableSubmoduleIsIgnoredWhenLoadingModule) {
   const int output = in->named_buffers()["b.foo"].sum().item<int>();
   // `output` should equal to the sum of the values we manually assigned to "b.foo" before
   // serialization.
-  ASSERT_EQ(output, 5);  
+  ASSERT_EQ(output, 5);
 }

--- a/test/cpp/jit/test_interface.cpp
+++ b/test/cpp/jit/test_interface.cpp
@@ -67,11 +67,11 @@ void testModuleInterfaceSerialization() {
       subMod.module_object(),
       /*is_parameter=*/false);
   parentMod.define(parentForward, nativeResolver());
-  ASSERT_TRUE(parentMod.find_module("subMod").has_value());
+  ASSERT_TRUE(parentMod.hasattr("subMod"));
   std::stringstream ss;
   parentMod.save(ss);
   Module reloaded_mod = jit::load(ss);
-  ASSERT_TRUE(reloaded_mod.find_module("subMod").has_value());
+  ASSERT_TRUE(reloaded_mod.hasattr("subMod"));
   InterfaceTypePtr submodType =
       reloaded_mod.type()->getAttribute("subMod")->cast<InterfaceType>();
   ASSERT_TRUE(submodType->is_module());

--- a/test/cpp/jit/test_misc.cpp
+++ b/test/cpp/jit/test_misc.cpp
@@ -485,11 +485,11 @@ void testEvalModeForLoadedModule() {
     return; // The module file to load is not generated in Sandcastle
   std::string module_path = "dropout_model.pt";
   torch::jit::script::Module module = torch::jit::load(module_path);
-  AT_ASSERT(module.get_module("dropout").is_training());
+  AT_ASSERT(module.attr("dropout").toModule().is_training());
   module.eval();
-  AT_ASSERT(!module.get_module("dropout").is_training());
+  AT_ASSERT(!module.attr("dropout").toModule().is_training());
   module.train();
-  AT_ASSERT(module.get_module("dropout").is_training());
+  AT_ASSERT(module.attr("dropout").toModule().is_training());
 }
 
 // test a few features that are not directly used in schemas yet
@@ -964,8 +964,8 @@ void testModuleConversion() {
 
     m.to(at::kCUDA);
     m.to(at::kCPU);
-    AT_ASSERT(m.get_parameter("foo").device().is_cpu());
-    AT_ASSERT(m.get_buffer("bar").device().is_cpu());
+    AT_ASSERT(m.attr("foo").toTensor().device().is_cpu());
+    AT_ASSERT(m.attr("bar").toTensor().device().is_cpu());
   }
   {
     // test cpu to cuda for params and buffers
@@ -973,8 +973,8 @@ void testModuleConversion() {
     m.register_buffer("bar", torch::ones({}));
 
     m.to(at::kCUDA);
-    AT_ASSERT(m.get_parameter("foo").device().is_cuda());
-    AT_ASSERT(m.get_buffer("bar").device().is_cuda());
+    AT_ASSERT(m.attr("foo").toTensor().device().is_cuda());
+    AT_ASSERT(m.attr("bar").toTensor().device().is_cuda());
   }
 }
 

--- a/test/custom_operator/test_custom_ops.cpp
+++ b/test/custom_operator/test_custom_ops.cpp
@@ -14,12 +14,8 @@ template <typename Predicate>
 void check_all_parameters(
     const torch::jit::script::Module& module,
     Predicate predicate) {
-  for (const torch::jit::script::NameValue& parameter :
-       module.get_parameters()) {
-    AT_ASSERT(predicate(parameter.value.toTensor()));
-  }
-  for (const torch::jit::script::NameModule& child : module.get_modules()) {
-    check_all_parameters(child.module, predicate);
+  for (at::Tensor parameter : module.parameters()) {
+    AT_ASSERT(predicate(parameter));
   }
 }
 } // namespace helpers

--- a/torch/csrc/api/src/serialize/input-archive.cpp
+++ b/torch/csrc/api/src/serialize/input-archive.cpp
@@ -19,31 +19,21 @@ namespace serialize {
 InputArchive::InputArchive() {}
 
 void InputArchive::read(const std::string& key, c10::IValue& ivalue) {
-  if (auto named_attr = module_.find_attribute(key)) {
-    ivalue = *named_attr;
-  } else {
-    TORCH_CHECK(
-      false,
-      "No such serialized IValue '",
-      key,
-      "'");
-  }
+  ivalue = module_.attr(key);
 }
 
 bool InputArchive::try_read(
     const std::string& key,
     Tensor& tensor,
     bool is_buffer) {
-  auto param = module_.find_parameter(key);
-  auto buffer = module_.find_buffer(key);
-  if (!param && !buffer) return false;
-
-  // clang-format off
-  auto read_tensor = is_buffer ? *buffer : *param;
-  TORCH_CHECK(
-      bool(buffer) == is_buffer,
-      "Expected deserialized tensor for key '", key,
-      "' to ", is_buffer ? "not " : "", "be a buffer, but it was not");
+  if (!module_.hasattr(key)) {
+    return false;
+  }
+  auto iv = module_.attr(key);
+  if (!iv.isTensor()) {
+    return false;
+  }
+  auto read_tensor = iv.toTensor();
   // clang-format on
   if (tensor.defined()) {
     torch::NoGradGuard guard;
@@ -71,13 +61,16 @@ void InputArchive::read(
 }
 
 bool InputArchive::try_read(const std::string& key, InputArchive& archive) {
-  if (auto named_module = module_.find_module(key)) {
-    archive.module_ = std::move(*named_module);
-    archive.hierarchy_prefix_ = hierarchy_prefix_ + key + ".";
-    return true;
-  } else {
+  if (!module_.hasattr(key)) {
     return false;
   }
+  auto iv = module_.attr(key);
+  if (!iv.isModule()) {
+    return false;
+  }
+  archive.module_ = iv.toModule();
+  archive.hierarchy_prefix_ = hierarchy_prefix_ + key + ".";
+  return true;
 }
 
 void InputArchive::read(const std::string& key, InputArchive& archive) {

--- a/torch/csrc/jit/import_legacy.cpp
+++ b/torch/csrc/jit/import_legacy.cpp
@@ -298,11 +298,10 @@ script::Module ScriptModuleDeserializer::LEGACY_convertModule(
       std::make_shared<ClassResolver>(source_importer_));
   for (int i = 0; i < module_def.attributes_size(); ++i) {
     const torch::AttributeDef& attr_def = module_def.attributes(i);
-    if (module.find_buffer(attr_def.name())) {
-      // TODO: handle this above so this can be removed
+    if (module.hasattr(attr_def.name())) {
+      // this attribute was already registered as a buffer above.
       continue;
     }
-
     IValue ivalue;
     if (attr_def.id() >= 0) {
       // attribute has no value in the table, set it to None for now. After
@@ -349,17 +348,19 @@ script::Module ScriptModuleDeserializer::LEGACY_convertModule(
         LEGACY_pickled_ivalues_.at(module_def.get_state_attribute_id()));
   }
 
-  for (const script::NameValue& slot : module.get_attributes()) {
+  const ClassTypePtr& module_type = module.module_object()->type();
+  for (size_t i = 0, N = module_type->numAttributes(); i < N; ++i) {
     // Verify that all the non-optional attributes have been initialized
     // TODO: Issue #20497
-    if (slot.value.type()->kind() != TypeKind::OptionalType) {
+    const IValue& v = module.module_object()->getSlot(i);
+    if (module_type->getAttribute(i)->kind() != TypeKind::OptionalType) {
       TORCH_CHECK(
-          !slot.value.isNone(),
+          !v.isNone(),
           "The field '",
-          slot.name,
+          module_type->getAttributeName(i),
           "' was left unitialized after __setstate__, but expected a ",
           "value of type '",
-          slot.value.type()->python_str(),
+          v.type()->python_str(),
           "'");
     }
   }

--- a/torch/csrc/jit/passes/fixup_trace_scope_blocks.cpp
+++ b/torch/csrc/jit/passes/fixup_trace_scope_blocks.cpp
@@ -503,8 +503,8 @@ void runCleanupPasses(const std::shared_ptr<Graph>& g) {
 
 void runCleanupPasses(script::Module* m) {
   auto methods = m->get_methods();
-  for (auto module : m->get_modules()) {
-    runCleanupPasses(&module.module);
+  for (auto module : m->children()) {
+    runCleanupPasses(&module);
   }
   for (auto& method : methods) {
     runCleanupPasses(method.graph());

--- a/torch/csrc/jit/passes/quantization.cpp
+++ b/torch/csrc/jit/passes/quantization.cpp
@@ -32,7 +32,7 @@ void fillQConfigMap(
   }
   map[module.module_object()] = qconfig;
 
-  for (const script::NameModule& s : module.get_modules()) {
+  for (const script::NameModule& s : module.named_children()) {
     std::string child_key;
     if (key == "") {
       child_key = s.name;
@@ -40,11 +40,14 @@ void fillQConfigMap(
       child_key = key + "." + s.name;
     }
     fillQConfigMap(
-        s.module.module_object(), qconfig_dict, map, child_key, qconfig);
+        s.value.module_object(), qconfig_dict, map, child_key, qconfig);
   }
 }
 
-std::string getFuncName(const c10::QualifiedName& qname) {
+std::string getFuncName(Value* func_value) {
+  auto func_node = func_value->node();
+  auto func = func_node->output()->type()->expect<FunctionType>()->function();
+  const auto& qname = func->qualname();
   const auto& name = qname.qualifiedName();
   auto rdot_idx = name.rfind('.');
   if (rdot_idx != std::string::npos) {
@@ -71,9 +74,7 @@ bool nodeQuantizable(Node* n) {
       std::find(aten_funcs.begin(), aten_funcs.end(), n->kind()) !=
       aten_funcs.end();
   if (n->kind() == prim::CallFunction) {
-    auto func_node = n->inputs()[0]->node();
-    auto func = func_node->output()->type()->expect<FunctionType>()->function();
-    auto func_name = getFuncName(func->qualname());
+    auto func_name = getFuncName(n->inputs()[0]);
     is_quantizable |=
         std::find(call_funcs.begin(), call_funcs.end(), func_name) !=
         call_funcs.end();
@@ -172,7 +173,7 @@ Node* InsertObserversHelper::insertObserverFor(
   }
   script::Module observer = observer_module.clone();
   std::string observer_name = "_observer_" + c10::to_string(uid_++);
-  while (module.find_module(observer_name)) {
+  while (module.hasattr(observer_name)) {
     observer_name = "_observer_" + c10::to_string(uid_++);
   }
   module.register_module(observer_name, observer);
@@ -340,11 +341,7 @@ void InsertObserversHelper::insertObservers(
         script::Module callee_module;
         if (module_instance->node()->kind() == prim::GetAttr) {
           auto child_module_name = module_instance->node()->s(attr::name);
-          auto child_module = module.find_module(child_module_name);
-          TORCH_INTERNAL_ASSERT(
-              child_module,
-              "Child module " + child_module_name + " does not exist");
-          callee_module = child_module.value();
+          callee_module = module.attr(child_module_name).toModule();
         } else {
           TORCH_INTERNAL_ASSERT(
               module_instance == graph->inputs()[0],
@@ -513,17 +510,11 @@ std::tuple<IValue, IValue> QuantizeHelper::getQParams(Value* v) {
       "getQParams expects the corresponding observer for ",
       v->debugName(),
       " exists.");
-  auto observer_module = module_.find_module(observer_name.value());
-  TORCH_INTERNAL_ASSERT(
-      observer_module,
-      "getQParams expects the corresponding observer for ",
-      v->debugName(),
-      " exists.");
-  auto om = observer_module.value();
+  auto om = module_.attr(observer_name.value()).toModule();
   auto calculate_qparams = om.get_method("calculate_qparams");
   IValue qparams = calculate_qparams(std::vector<IValue>());
   checkCalculateQParamsResult(qparams);
-  auto scalar_type = om.get_attribute("dtype");
+  auto scalar_type = om.attr("dtype");
   return std::make_tuple(qparams, scalar_type);
 }
 
@@ -552,12 +543,7 @@ c10::optional<script::Module> QuantizeHelper::findChildModuleToQuantize(
       "Child instance should come from GetAttr.");
   auto child_module_name = child_instance->node()->s(attr::name);
   if (child_module_name.find("_observer_") == std::string::npos) {
-    auto child_module = module_.find_module(child_module_name);
-    TORCH_INTERNAL_ASSERT(
-        child_module,
-        "InsertQuantDeQuant - Child module " + child_module_name +
-            " does not exist");
-    return child_module;
+    return module_.attr(child_module_name).toModule();
   }
   return c10::nullopt;
 }
@@ -646,10 +632,8 @@ graph(%linear, %a_dequant, %w, %b, %w_scale, %w_zero_point, %w_dtype):
   auto filter = [](const Match& match,
                    const std::unordered_map<std::string, Value*>& vmap) {
     const auto& match_vmap = match.values_map;
-    auto linear_node = match_vmap.at(vmap.at("linear"))->node();
-    auto func =
-        linear_node->output()->type()->expect<FunctionType>()->function();
-    auto func_name = getFuncName(func->qualname());
+    auto linear_value = match_vmap.at(vmap.at("linear"));
+    auto func_name = getFuncName(linear_value);
     if (func_name == "linear") {
       return true;
     }
@@ -767,31 +751,31 @@ static std::tuple<at::Tensor, at::Tensor> computeUpdatedConvWeightAndBias(
   return std::make_tuple(new_w, new_b);
 }
 
+static bool hastensor(script::Module& m, const char* name) {
+  return m.hasattr(name) && m.attr(name).isTensor();
+}
+
 static bool tryExtractingConvBNParameters(
     script::Module& conv,
     script::Module& bn,
     ConvBNParameters& r) {
-  if (!conv.find_parameter("weight") || !bn.find_parameter("weight") ||
-      !bn.find_parameter("bias")) {
-    return false;
-  }
-  if (!bn.find_attribute("running_mean") || !bn.find_attribute("running_var") ||
-      !bn.get_attribute("running_mean").isTensor() ||
-      !bn.get_attribute("running_var").isTensor()) {
+  if (!hastensor(conv, "weight") || !hastensor(bn, "weight") ||
+      !hastensor(bn, "bias") || !hastensor(bn, "running_mean") ||
+      !hastensor(bn, "running_var")) {
     return false;
   }
 
-  r.bn_rm = bn.get_attribute("running_mean").toTensor();
-  r.bn_rv = bn.get_attribute("running_var").toTensor();
+  r.bn_rm = bn.attr("running_mean").toTensor();
+  r.bn_rv = bn.attr("running_var").toTensor();
   r.bn_eps = 1e-5; // TODO: allow access to the actual value. NOLINT
                    // Now we cannot do it because we inline all fields that are
                    // in __constants__ and lose all tracks of them.
-  r.bn_w = bn.get_parameter("weight");
-  r.bn_b = bn.get_parameter("bias");
+  r.bn_w = bn.attr("weight").toTensor();
+  r.bn_b = bn.attr("bias").toTensor();
 
-  r.conv_w = conv.get_parameter("weight");
-  if (conv.find_parameter("bias")) {
-    r.conv_b = conv.get_parameter("bias");
+  r.conv_w = conv.attr("weight").toTensor();
+  if (conv.hasattr("bias")) {
+    r.conv_b = conv.attr("bias").toTensor();
   } else {
     r.conv_b = at::zeros_like(r.bn_rm);
   }
@@ -826,8 +810,8 @@ graph(%self, %x):
     worklist.pop();
 
     // Queue submodules for processing
-    for (const script::NameModule& submodule : current.get_modules()) {
-      worklist.push(submodule.module);
+    for (const script::Module& submodule : current.children()) {
+      worklist.push(submodule);
     }
 
     // Process forward method of the current module
@@ -854,9 +838,11 @@ graph(%self, %x):
       TORCH_INTERNAL_ASSERT(matched_bn_submodule->kind() == prim::GetAttr);
 
       script::Module conv_submodule =
-          current.get_module(matched_conv_submodule->s(Symbol::attr("name")));
+          current.attr(matched_conv_submodule->s(Symbol::attr("name")))
+              .toModule();
       script::Module bn_submodule =
-          current.get_module(matched_bn_submodule->s(Symbol::attr("name")));
+          current.attr(matched_bn_submodule->s(Symbol::attr("name")))
+              .toModule();
 
       ConvBNParameters params;
       if (!tryExtractingConvBNParameters(
@@ -883,9 +869,9 @@ graph(%self, %x):
       GRAPH_UPDATE("Deleting ", *matched_bn);
 
       auto new_w_b = computeUpdatedConvWeightAndBias(params);
-      conv_submodule.set_parameter("weight", std::get<0>(new_w_b));
-      if (conv_submodule.find_parameter("bias")) {
-        conv_submodule.set_parameter("bias", std::get<1>(new_w_b));
+      conv_submodule.setattr("weight", std::get<0>(new_w_b));
+      if (conv_submodule.hasattr("bias")) {
+        conv_submodule.setattr("bias", std::get<1>(new_w_b));
       } else {
         conv_submodule.register_parameter("bias", std::get<1>(new_w_b), false);
       }
@@ -936,7 +922,7 @@ graph(%self, %scale, %zero_point, %dtype):
       continue;
     }
     auto match_vmap = match.values_map;
-    auto float_weight = module.get_parameter("weight").variable_data();
+    auto float_weight = module.attr("weight").toTensor().data();
     auto scale = toIValue(match_vmap.at(vmap.at("scale"))).value().toDouble();
     auto zero_point =
         toIValue(match_vmap.at(vmap.at("zero_point"))).value().toInt();
@@ -965,8 +951,8 @@ void InsertPrepackUnpack(script::Module& module) {
   for (auto& method : module.get_methods()) {
     auto graph = method.graph();
     InsertPrepackUnpack(graph);
-    for (script::NameModule m : module.get_modules()) {
-      InsertPrepackUnpack(m.module);
+    for (script::Module m : module.children()) {
+      InsertPrepackUnpack(m);
     }
   }
 }
@@ -1012,11 +998,11 @@ graph(%a_dequant, %w, %b, %w_scale, %w_zero_point, %w_dtype, %stride, %padding, 
           toIValue(match_vmap.at(vmap.at("w_zero_point"))).value().toInt();
       auto w_dtype =
           toIValue(match_vmap.at(vmap.at("w_dtype"))).value().toScalarType();
-      auto w = module.get_parameter("weight").variable_data();
+      auto w = module.attr("weight").toTensor().data();
       auto w_quant = at::quantize_per_tensor(w, w_scale, w_zero_point, w_dtype);
       c10::optional<at::Tensor> b = c10::nullopt;
-      if (module.find_parameter("bias")) {
-        b = module.get_parameter("bias").variable_data();
+      if (hastensor(module, "bias")) {
+        b = module.attr("bias").toTensor().data();
       }
       script::Module wrapper_module = packed_params_module.clone();
       auto set_weight_bias = wrapper_module.get_method("set_weight_bias");
@@ -1045,7 +1031,7 @@ graph(%a_dequant, %w, %b, %w_scale, %w_zero_point, %w_dtype, %stride, %padding, 
       // unique name for the module based on %w_quant
       int uid = 0;
       auto module_name = module_name_prefix + c10::to_string(uid++);
-      while (module.find_module(module_name)) {
+      while (module.hasattr(module_name)) {
         module_name_prefix + c10::to_string(uid++);
       }
       module.register_module(module_name, wrapper_module);
@@ -1084,9 +1070,9 @@ void FoldPrepackedWeightIntoModule(
   for (auto& method : module.get_methods()) {
     FoldPrepackedWeightIntoModule(
         module, method.name(), linear_params_module, conv_params_module);
-    for (script::NameModule m : module.get_modules()) {
+    for (script::Module m : module.children()) {
       FoldPrepackedWeightIntoModule(
-          m.module, linear_params_module, conv_params_module);
+          m, linear_params_module, conv_params_module);
     }
   }
 }

--- a/torch/csrc/jit/pybind_utils.h
+++ b/torch/csrc/jit/pybind_utils.h
@@ -625,7 +625,7 @@ inline c10::optional<py::object> tryToConvertToCustomClass(
   }
   return c10::nullopt;
 }
-inline py::object toPyObject(IValue&& ivalue) {
+inline py::object toPyObject(IValue ivalue) {
   if (ivalue.isNone()) {
     return py::none();
   } else if (ivalue.isTensor()) {

--- a/torch/csrc/jit/tracer.cpp
+++ b/torch/csrc/jit/tracer.cpp
@@ -293,7 +293,7 @@ static void gatherParametersAndBuffers(
   state->setValue(self.module_object(), self_value);
 
   auto self_ty = self.type();
-  for (const script::NameValue& s : self.get_slots()) {
+  for (const script::NameValue& s : self.named_attributes(/*recurse=*/false)) {
     auto qualname = prefix + "." + s.name;
     Value* trace_get_attr = g.insertNode(g.create(prim::TracedAttr))
                                 ->s_(attr::scope, qualname)

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1425,8 +1425,7 @@ class OrderedBufferDict(OrderedDictWrapper):
         super(OrderedBufferDict, self).__init__(module)
 
     def items(self):
-        return [(name, param) for name, _, param in
-                self.module._get_attributes() if isinstance(param, torch.Tensor)]
+        return [(name, param) for name, param in self.module._get_buffers()]
 
     def __setitem__(self, k, v):
         if not self.module._has_buffer(k):

--- a/torch/jit/_recursive.py
+++ b/torch/jit/_recursive.py
@@ -475,12 +475,10 @@ def infer_methods_to_compile(nn_module):
     check_module_initialized(nn_module)
 
     methods = []
-    if hasattr(nn_module, 'forward'):
-        if getattr(nn_module.forward, "__func__", None) == torch.nn.Module.forward:
-            # TODO, we deleted a check that forward is actually defined, instead skipping it
-            pass
-        elif not _jit_internal.is_ignored_fn(nn_module.forward):
-            methods = ['forward']
+    if hasattr(nn_module, 'forward') and \
+       getattr(type(nn_module), 'forward', None) != torch.nn.Module.forward and \
+       not _jit_internal.is_ignored_fn(nn_module.forward):
+        methods = ['forward']
 
     exported = []
     for name in dir(nn_module):

--- a/torch/nn/parallel/replicate.py
+++ b/torch/nn/parallel/replicate.py
@@ -123,16 +123,10 @@ def replicate(network, devices, detach=False):
             if _is_script_module(module):
                 # we have to initialize ScriptModule properly so that
                 # it works with pybind11
-                cpp_replica = torch._C.ScriptModule(torch._jit_internal._qualified_name(type(module)), torch.jit._python_cu, True)
-                for name, the_type, value in module._c._get_attributes():
-                    if name in module._buffers.keys():
-                        continue
-                    cpp_replica._register_attribute(name, the_type, value)
-
                 def init_fn(script_module):
                     # Don't do anything here, we'll initialize the ScriptModule below
                     return
-                replica = torch.jit.RecursiveScriptModule._construct(cpp_replica, init_fn)
+                replica = torch.jit.RecursiveScriptModule._construct(module._c._replicate_for_data_parallel(), init_fn)
             else:
                 replica = module._replicate_for_data_parallel()
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#29355 getFuncName take func_value as argument (#29146)**

Summary:
Pull Request resolved: https://github.com/pytorch/pytorch/pull/29146

getFuncName takes the Value that represents the function for argument
e.g.
for CallFunction(%1, %a, %b, %c), it takes %1 for argument

Test Plan:
test_jit.py

Imported from OSS

Differential Revision: D18362840

fbshipit-source-id: fc90ebe7db702aec9b50cec6db454d0eb8ee5612