### PR TITLE
[C++ API] Add functional overloads for activation, batchnorm, distance, embedding

### DIFF
--- a/torch/csrc/api/include/torch/nn/functional/activation.h
+++ b/torch/csrc/api/include/torch/nn/functional/activation.h
@@ -7,67 +7,126 @@ namespace torch {
 namespace nn{
 namespace functional {
 
-inline Tensor elu(Tensor& input, const ELUOptions& options = {}) {
-  if (options.inplace()) {
-    return torch::elu_(input, options.alpha());
+namespace detail {
+inline Tensor elu(Tensor& input, double alpha = 1.0, bool inplace = false) {
+  if (inplace) {
+    return torch::elu_(input, alpha);
   } else {
-    return torch::elu(input, options.alpha());
+    return torch::elu(input, alpha);
   }
 }
+} // namespace detail
 
-inline Tensor selu(Tensor& input, const SELUOptions& options = {}) {
-  if (options.inplace()) {
+inline Tensor elu(Tensor& input, const ELUOptions& options = {}) {
+  return detail::elu(input, options.alpha(), options.inplace());
+}
+
+// ============================================================================
+
+namespace detail {
+inline Tensor selu(Tensor& input, bool inplace = false) {
+  if (inplace) {
     return torch::selu_(input);
   } else {
     return torch::selu(input);
   }
 }
+} // namespace detail
+
+inline Tensor selu(Tensor& input, const SELUOptions& options = {}) {
+  return detail::selu(input, options.inplace());
+}
+
+// ============================================================================
+
+namespace detail {
+inline Tensor hardshrink(const Tensor& input,
+                         double lambda = 0.5) {
+  return torch::hardshrink(input, lambda);
+}
+} // namespace detail
 
 inline Tensor hardshrink(const Tensor& input,
                          const HardshrinkOptions& options = {}) {
-  return torch::hardshrink(input, options.lambda());
+  return detail::hardshrink(input, options.lambda());
 }
+
+// ============================================================================
+
+namespace detail {
+inline Tensor hardtanh(Tensor& input,
+                       double min_val = -1.0,
+                       double max_val = 1.0,
+                       bool inplace = false) {
+  if (inplace) {
+    return torch::hardtanh_(input, min_val, max_val);
+  } else {
+    return torch::hardtanh(input, min_val, max_val);
+  }
+}
+} // namespace detail
 
 inline Tensor hardtanh(Tensor& input, const HardtanhOptions& options = {}) {
-  if (options.inplace()) {
-    return torch::hardtanh_(input, options.min_val(), options.max_val());
-  } else {
-    return torch::hardtanh(input, options.min_val(), options.max_val());
-  }
+  return detail::hardtanh(input, options.min_val(), options.max_val(), options.inplace());
 }
 
-inline Tensor leaky_relu(Tensor& input, const LeakyReLUOptions& options = {}) {
-  if (options.inplace()) {
-    return torch::leaky_relu_(input, options.negative_slope());
+// ============================================================================
+
+namespace detail {
+inline Tensor leaky_relu(Tensor& input,
+                         double negative_slope = 1e-2,
+                         bool inplace = false) {
+  if (inplace) {
+    return torch::leaky_relu_(input, negative_slope);
   } else {
-    return torch::leaky_relu(input, options.negative_slope());
+    return torch::leaky_relu(input, negative_slope);
   }
 }
+} // namespace detail
+
+inline Tensor leaky_relu(Tensor& input, const LeakyReLUOptions& options = {}) {
+  return detail::leaky_relu(input, options.negative_slope(), options.inplace());
+}
+
+// ============================================================================
 
 inline Tensor logsigmoid(const Tensor& input) {
   return torch::log_sigmoid(input);
 }
 
-inline Tensor gumbel_softmax(const Tensor& logits, const GumbelSoftmaxOptions& options = {}) {
+// ============================================================================
+
+namespace detail {
+inline Tensor gumbel_softmax(const Tensor& logits,
+                             double tau = 1.0,
+                             bool hard = false,
+                             int dim = -1) {
   auto gumbels = -torch::empty_like(logits).exponential_().log();  // ~Gumbel(0,1)
-  gumbels = (logits + gumbels) / options.tau();  // ~Gumbel(logits, tau)
-  auto y_soft = gumbels.softmax(options.dim());
+  gumbels = (logits + gumbels) / tau;  // ~Gumbel(logits, tau)
+  auto y_soft = gumbels.softmax(dim);
 
   torch::Tensor ret;
-  if (options.hard()) {
+  if (hard) {
     // Straight through.
-    auto index = std::get<1>(y_soft.max(options.dim(), /*keepdim=*/true));
-    auto y_hard = torch::zeros_like(logits).scatter_(options.dim(), index, 1.0);
+    auto index = std::get<1>(y_soft.max(dim, /*keepdim=*/true));
+    auto y_hard = torch::zeros_like(logits).scatter_(dim, index, 1.0);
     ret = y_hard - y_soft.detach() + y_soft;
   } else {
     ret = y_soft;
   }
   return ret;
 }
+} // namespace detail
 
-inline Tensor softmax(const Tensor& input, const SoftmaxOptions& options,
+inline Tensor gumbel_softmax(const Tensor& logits, const GumbelSoftmaxOptions& options = {}) {
+  return detail::gumbel_softmax(logits, options.tau(), options.hard(), options.dim());
+}
+
+// ============================================================================
+
+namespace detail {
+inline Tensor softmax(const Tensor& input, int64_t dim,
                       c10::optional<torch::Dtype> dtype = c10::nullopt) {
-  int64_t dim = options.dim();
   Tensor ret;
 
   if (dtype == c10::nullopt) {
@@ -78,10 +137,18 @@ inline Tensor softmax(const Tensor& input, const SoftmaxOptions& options,
 
   return ret;
 }
+} // namespace detail
 
-inline Tensor softmin(const Tensor& input, const SoftminOptions& options,
+inline Tensor softmax(const Tensor& input, const SoftmaxOptions& options,
                       c10::optional<torch::Dtype> dtype = c10::nullopt) {
-  int64_t dim = options.dim();
+  return detail::softmax(input, options.dim(), dtype);
+}
+
+// ============================================================================
+
+namespace detail {
+inline Tensor softmin(const Tensor& input, int64_t dim,
+                      c10::optional<torch::Dtype> dtype = c10::nullopt) {
   Tensor ret;
 
   if (dtype == c10::nullopt) {
@@ -92,10 +159,18 @@ inline Tensor softmin(const Tensor& input, const SoftminOptions& options,
 
   return ret;
 }
+} // namespace detail
 
-inline Tensor log_softmax(const Tensor& input, const LogSoftmaxOptions& options,
+inline Tensor softmin(const Tensor& input, const SoftminOptions& options,
+                      c10::optional<torch::Dtype> dtype = c10::nullopt) {
+  return detail::softmin(input, options.dim(), dtype);
+}
+
+// ============================================================================
+
+namespace detail {
+inline Tensor log_softmax(const Tensor& input, int64_t dim,
                           c10::optional<torch::Dtype> dtype = c10::nullopt) {
-  int64_t dim = options.dim();
   Tensor ret;
 
   if (dtype == c10::nullopt) {
@@ -106,69 +181,151 @@ inline Tensor log_softmax(const Tensor& input, const LogSoftmaxOptions& options,
 
   return ret;
 }
+} // namespace detail
+
+inline Tensor log_softmax(const Tensor& input, const LogSoftmaxOptions& options,
+                          c10::optional<torch::Dtype> dtype = c10::nullopt) {
+  return detail::log_softmax(input, options.dim(), dtype);
+}
+
+// ============================================================================
 
 inline Tensor gelu(const Tensor& input) {
   return torch::gelu(input);
 }
 
+// ============================================================================
+
 inline Tensor prelu(const Tensor& input, const Tensor& weight) {
   return torch::prelu(input, weight);
 }
 
-inline Tensor relu(Tensor& input, const ReLUOptions& options = {}) {
-  if (options.inplace()) {
+// ============================================================================
+
+namespace detail {
+inline Tensor relu(Tensor& input, bool inplace = false) {
+  if (inplace) {
     return torch::relu_(input);
   } else {
     return torch::relu(input);
   }
 }
+} // namespace detail
+
+inline Tensor relu(Tensor& input, const ReLUOptions& options = {}) {
+  return detail::relu(input, options.inplace());
+}
+
+// ============================================================================
+
+namespace detail {
+inline Tensor relu6(Tensor& input, bool inplace = false) {
+  return detail::hardtanh(input, /*min_val=*/0, /*max_val=*/6, /*inplace=*/inplace);
+}
+} // namespace detail
 
 inline Tensor relu6(Tensor& input, const ReLU6Options& options = {}) {
-  return hardtanh(input,
-    HardtanhOptions().min_val(0).max_val(6).inplace(options.inplace()));
+  return detail::relu6(input, options.inplace());
 }
+
+// ============================================================================
+
+namespace detail {
+inline Tensor rrelu(Tensor& input,
+                    double lower = 1.0 / 8.0,
+                    double upper = 1.0 / 3.0,
+                    bool inplace = false,
+                    bool training = false) {
+  if (inplace) {
+    return torch::rrelu_(input, lower, upper, training);
+  } else {
+    return torch::rrelu(input, lower, upper, training);
+  }
+}
+} // namespace detail
 
 inline Tensor rrelu(Tensor& input, const RReLUOptions& options = {},
                     bool training = false) {
-  if (options.inplace()) {
-    return torch::rrelu_(input, options.lower(), options.upper(), training);
-  } else {
-    return torch::rrelu(input, options.lower(), options.upper(), training);
-  }
+  return detail::rrelu(input, options.lower(), options.upper(), options.inplace(), training);
 }
 
-inline Tensor celu(Tensor& input, const CELUOptions& options = {}) {
-  if (options.inplace()) {
-    return torch::celu_(input, options.alpha());
+// ============================================================================
+
+namespace detail {
+inline Tensor celu(Tensor& input,
+                   double alpha = 1.0,
+                   bool inplace = false) {
+  if (inplace) {
+    return torch::celu_(input, alpha);
   } else {
-    return torch::celu(input, options.alpha());
+    return torch::celu(input, alpha);
   }
 }
+} // namespace detail
+
+inline Tensor celu(Tensor& input, const CELUOptions& options = {}) {
+  return detail::celu(input, options.alpha(), options.inplace());
+}
+
+// ============================================================================
+
+namespace detail {
+inline Tensor softplus(const Tensor& input,
+                       double beta = 1.0,
+                       double threshold = 20.0) {
+  return torch::softplus(input, beta, threshold);
+}
+} // namespace detail
 
 inline Tensor softplus(const Tensor& input,
                        const SoftplusOptions& options = {}) {
-  return torch::softplus(input, options.beta(), options.threshold());
+  return detail::softplus(input, options.beta(), options.threshold());
 }
+
+
+// ============================================================================
+
+namespace detail {
+inline Tensor softshrink(const Tensor& input,
+                         double lambda = 0.5) {
+  return torch::softshrink(input, lambda);
+}
+} // namespace detail
 
 inline Tensor softshrink(const Tensor& input,
                          const SoftshrinkOptions& options = {}) {
-  return torch::softshrink(input, options.lambda());
+  return detail::softshrink(input, options.lambda());
 }
+
+// ============================================================================
 
 inline Tensor softsign(const Tensor& input) {
   return input / (input.abs() + 1);
 }
 
+// ============================================================================
+
 inline Tensor tanhshrink(const Tensor& input) {
   return input - input.tanh();
 }
 
-inline Tensor threshold(Tensor& input, const ThresholdOptions& options) {
-  if (options.inplace()) {
-    return torch::threshold_(input, options.threshold(), options.value());
+// ============================================================================
+
+namespace detail {
+inline Tensor threshold(Tensor& input,
+                        double threshold,
+                        double value,
+                        bool inplace = false) {
+  if (inplace) {
+    return torch::threshold_(input, threshold, value);
   } else {
-    return torch::threshold(input, options.threshold(), options.value());
+    return torch::threshold(input, threshold, value);
   }
+}
+} // namespace detail
+
+inline Tensor threshold(Tensor& input, const ThresholdOptions& options) {
+  return detail::threshold(input, options.threshold(), options.value(), options.inplace());
 }
 
 } // namespace functional

--- a/torch/csrc/api/include/torch/nn/functional/batchnorm.h
+++ b/torch/csrc/api/include/torch/nn/functional/batchnorm.h
@@ -7,8 +7,15 @@ namespace torch {
 namespace nn {
 namespace functional {
 
-inline Tensor batch_norm(const Tensor& input, const Tensor& running_mean,
-                         const Tensor& running_var, const BatchNormOptions& options = {}, bool training = false) {
+namespace detail {
+inline Tensor batch_norm(const Tensor& input,
+                         const Tensor& running_mean,
+                         const Tensor& running_var,
+                         Tensor weight = {},
+                         Tensor bias = {},
+                         bool training = false,
+                         c10::optional<double> momentum = 0.1,
+                         double eps = 1e-5) {
   if (training) {
     auto size = input.sizes();
     int64_t size_prods = size[0];
@@ -21,14 +28,28 @@ inline Tensor batch_norm(const Tensor& input, const Tensor& running_mean,
 
   return torch::batch_norm(
     input,
-    options.weight(),
-    options.bias(),
+    weight,
+    bias,
     running_mean,
     running_var,
     training,
-    options.momentum().value(),
-    options.eps(),
+    momentum.value(),
+    eps,
     at::globalContext().userEnabledCuDNN());
+}
+} // namespace detail
+
+inline Tensor batch_norm(const Tensor& input, const Tensor& running_mean,
+                         const Tensor& running_var, const BatchNormOptions& options = {}, bool training = false) {
+  return detail::batch_norm(
+    input,
+    running_mean,
+    running_var,
+    options.weight(),
+    options.bias(),
+    training,
+    options.momentum(),
+    options.eps());
 }
 
 } // namespace functional

--- a/torch/csrc/api/include/torch/nn/functional/distance.h
+++ b/torch/csrc/api/include/torch/nn/functional/distance.h
@@ -6,29 +6,50 @@ namespace torch {
 namespace nn {
 namespace functional {
 
+namespace detail {
 inline Tensor cosine_similarity(
     const Tensor& x1,
     const Tensor& x2,
-    const CosineSimilarityOptions& options) {
+    int64_t dim = 1,
+    double eps = 1e-8) {
   return torch::cosine_similarity(
       x1,
       x2,
-      options.dim(),
-      options.eps());
+      dim,
+      eps);
+}
+} // namespace detail
+
+inline Tensor cosine_similarity(
+    const Tensor& x1,
+    const Tensor& x2,
+    const CosineSimilarityOptions& options = {}) {
+  return detail::cosine_similarity(x1, x2, options.dim(), options.eps());
 }
 
 // ============================================================================
 
+namespace detail {
 inline Tensor pairwise_distance(
     const Tensor& x1,
     const Tensor& x2,
-    const PairwiseDistanceOptions& options) {
+    double p,
+    double eps = 1e-6,
+    bool keepdim = false) {
   return torch::pairwise_distance(
       x1,
       x2,
-      options.p(),
-      options.eps(),
-      options.keepdim());
+      p,
+      eps,
+      keepdim);
+}
+} // namespace detail
+
+inline Tensor pairwise_distance(
+    const Tensor& x1,
+    const Tensor& x2,
+    const PairwiseDistanceOptions& options = {}) {
+  return detail::pairwise_distance(x1, x2, options.p(), options.eps(), options.keepdim());
 }
 
 // ============================================================================
@@ -41,4 +62,4 @@ inline Tensor pdist(const Tensor& input, double p = 2.0) {
 
 } // namespace functional
 } // namespace nn
-} // namespace torch
+} // namesp

--- a/torch/csrc/api/include/torch/nn/functional/distance.h
+++ b/torch/csrc/api/include/torch/nn/functional/distance.h
@@ -62,4 +62,4 @@ inline Tensor pdist(const Tensor& input, double p = 2.0) {
 
 } // namespace functional
 } // namespace nn
-} // namesp
+} // namespace torch

--- a/torch/csrc/api/src/nn/modules/activation.cpp
+++ b/torch/csrc/api/src/nn/modules/activation.cpp
@@ -9,7 +9,7 @@ namespace nn {
 ELUImpl::ELUImpl(const ELUOptions& options_) : options(options_) {}
 
 Tensor ELUImpl::forward(Tensor input) {
-  return F::elu(input, options);
+  return F::detail::elu(input, options.alpha(), options.inplace());
 }
 
 void ELUImpl::reset() {}
@@ -27,7 +27,7 @@ void ELUImpl::pretty_print(std::ostream& stream) const {
 SELUImpl::SELUImpl(const SELUOptions& options_) : options(options_) {}
 
 Tensor SELUImpl::forward(Tensor input) {
-  return F::selu(input, options);
+  return F::detail::selu(input, options.inplace());
 }
 
 void SELUImpl::reset() {}
@@ -46,7 +46,7 @@ HardshrinkImpl::HardshrinkImpl(const HardshrinkOptions& options_)
     : options(options_) {}
 
 Tensor HardshrinkImpl::forward(const Tensor& input) {
-  return F::hardshrink(input, options);
+  return F::detail::hardshrink(input, options.lambda());
 }
 
 void HardshrinkImpl::reset() {}
@@ -64,7 +64,7 @@ HardtanhImpl::HardtanhImpl(const HardtanhOptions& options_)
 }
 
 Tensor HardtanhImpl::forward(Tensor input) {
-  return F::hardtanh(input, options);
+  return F::detail::hardtanh(input, options.min_val(), options.max_val(), options.inplace());
 }
 
 void HardtanhImpl::reset() {
@@ -88,7 +88,7 @@ LeakyReLUImpl::LeakyReLUImpl(const LeakyReLUOptions& options_)
     : options(options_) {}
 
 Tensor LeakyReLUImpl::forward(Tensor input) {
-  return F::leaky_relu(input, options);
+  return F::detail::leaky_relu(input, options.negative_slope(), options.inplace());
 }
 
 void LeakyReLUImpl::reset() {}
@@ -126,7 +126,7 @@ void SoftmaxImpl::pretty_print(std::ostream& stream) const {
 }
 
 Tensor SoftmaxImpl::forward(const Tensor& input) {
-  return F::softmax(input, options);
+  return F::detail::softmax(input, options.dim());
 }
 
 // ============================================================================
@@ -141,7 +141,7 @@ void SoftminImpl::pretty_print(std::ostream& stream) const {
 }
 
 Tensor SoftminImpl::forward(const Tensor& input) {
-  return F::softmin(input, options);
+  return F::detail::softmin(input, options.dim());
 }
 
 // ============================================================================
@@ -156,7 +156,7 @@ void LogSoftmaxImpl::pretty_print(std::ostream& stream) const {
 }
 
 Tensor LogSoftmaxImpl::forward(const Tensor& input) {
-  return F::log_softmax(input, options);
+  return F::detail::log_softmax(input, options.dim());
 }
 
 // ============================================================================
@@ -169,7 +169,7 @@ void Softmax2dImpl::pretty_print(std::ostream& stream) const {
 
 Tensor Softmax2dImpl::forward(const Tensor& input) {
   TORCH_CHECK(input.dim() == 4, "Softmax2d requires a 4D tensor as input");
-  return F::softmax(input, SoftmaxOptions(/*dim=*/1));
+  return F::detail::softmax(input, /*dim=*/1);
 }
 
 // ============================================================================
@@ -197,7 +197,7 @@ void PReLUImpl::pretty_print(std::ostream& stream) const {
 ReLUImpl::ReLUImpl(const ReLUOptions& options_) : options(options_) {}
 
 Tensor ReLUImpl::forward(Tensor input) {
-  return F::relu(input, options);
+  return F::detail::relu(input, options.inplace());
 }
 
 void ReLUImpl::reset() {}
@@ -215,7 +215,7 @@ void ReLUImpl::pretty_print(std::ostream& stream) const {
 ReLU6Impl::ReLU6Impl(const ReLU6Options& options_) : options(options_) {}
 
 Tensor ReLU6Impl::forward(Tensor input) {
-  return F::relu6(input, options);
+  return F::detail::relu6(input, options.inplace());
 }
 
 void ReLU6Impl::reset() {}
@@ -233,7 +233,7 @@ void ReLU6Impl::pretty_print(std::ostream& stream) const {
 RReLUImpl::RReLUImpl(const RReLUOptions& options_) : options(options_) {}
 
 Tensor RReLUImpl::forward(Tensor input) {
-  return F::rrelu(input, options, is_training());
+  return F::detail::rrelu(input, options.lower(), options.upper(), options.inplace(), is_training());
 }
 
 void RReLUImpl::reset() {}
@@ -252,7 +252,7 @@ void RReLUImpl::pretty_print(std::ostream& stream) const {
 CELUImpl::CELUImpl(const CELUOptions& options_) : options(options_) {}
 
 Tensor CELUImpl::forward(Tensor input) {
-  return F::celu(input, options);
+  return F::detail::celu(input, options.alpha(), options.inplace());
 }
 
 void CELUImpl::reset() {}
@@ -295,7 +295,7 @@ SoftplusImpl::SoftplusImpl(const SoftplusOptions& options_)
   : options(options_) {}
 
 Tensor SoftplusImpl::forward(const Tensor& input) {
-  return F::softplus(input, options);
+  return F::detail::softplus(input, options.beta(), options.threshold());
 }
 
 void SoftplusImpl::reset() {}
@@ -311,7 +311,7 @@ SoftshrinkImpl::SoftshrinkImpl(const SoftshrinkOptions& options_)
     : options(options_) {}
 
 Tensor SoftshrinkImpl::forward(const Tensor& input) {
-  return F::softshrink(input, options);
+  return F::detail::softshrink(input, options.lambda());
 }
 
 void SoftshrinkImpl::reset() {}
@@ -362,7 +362,7 @@ ThresholdImpl::ThresholdImpl(const ThresholdOptions& options_)
     : options(options_) {}
 
 Tensor ThresholdImpl::forward(Tensor input) {
-  return F::threshold(input, options);
+  return F::detail::threshold(input, options.threshold(), options.value(), options.inplace());
 }
 
 void ThresholdImpl::reset() {}

--- a/torch/csrc/api/src/nn/modules/batchnorm.cpp
+++ b/torch/csrc/api/src/nn/modules/batchnorm.cpp
@@ -152,12 +152,15 @@ Tensor BatchNormImplBase<D, Derived>::forward(const Tensor& input) {
     }
   }
 
-  return F::batch_norm(
+  return F::detail::batch_norm(
       input,
       running_mean,
       running_var,
-      BatchNormOptions().weight(weight).bias(bias).momentum(exponential_average_factor).eps(options.eps()),
-      this->is_training() || !options.track_running_stats());
+      weight,
+      bias,
+      this->is_training() || !options.track_running_stats(),
+      /*momentum=*/exponential_average_factor,
+      options.eps());
 }
 
 void BatchNorm1dImpl::_check_input_dim(const Tensor& input) {

--- a/torch/csrc/api/src/nn/modules/distance.cpp
+++ b/torch/csrc/api/src/nn/modules/distance.cpp
@@ -18,7 +18,7 @@ void CosineSimilarityImpl::pretty_print(std::ostream& stream) const {
 }
 
 Tensor CosineSimilarityImpl::forward(const Tensor& x1, const Tensor& x2) {
-  return F::cosine_similarity(x1, x2, options);
+  return F::detail::cosine_similarity(x1, x2, options.dim(), options.eps());
 }
 
 // ============================================================================
@@ -37,7 +37,7 @@ void PairwiseDistanceImpl::pretty_print(std::ostream& stream) const {
 }
 
 Tensor PairwiseDistanceImpl::forward(const Tensor& x1, const Tensor& x2) {
-  return F::pairwise_distance(x1, x2, options);
+  return F::detail::pairwise_distance(x1, x2, options.p(), options.eps(), options.keepdim());
 }
 
 } // namespace nn


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #29360 Add functional overloads for fold, linear, loss, normalization, padding
* #29359 Add functional overloads for pixelshuffle, pooling, upsampling, vision
* **#29358 Add functional overloads for activation, batchnorm, distance, embedding**

This PR adds functional overloads that take the full set of arguments (instead of just Options) for the following functionals:
- activation
- batchnorm
- distance
- embedding

These new functionals lives in the `torch::nn::functional::detail` namespace and they are only meant to be called from the module forward methods (i.e. they are not public API). This is in preparation for the future change where we make module Options and functional Options two different classes, because if the module forward method has to construct a new functional Options object every time it runs it will be pretty silly and bad performance.

Differential Revision: [D18376976](https://our.internmc.facebook.com/intern/diff/D18376976)