### PR TITLE
[C++ API] Add functional overloads for pixelshuffle, pooling, upsampling, vision

### DIFF
--- a/torch/csrc/api/include/torch/nn/functional/pixelshuffle.h
+++ b/torch/csrc/api/include/torch/nn/functional/pixelshuffle.h
@@ -6,15 +6,23 @@ namespace torch {
 namespace nn {
 namespace functional {
 
+namespace detail {
+inline Tensor pixel_shuffle(
+    const Tensor& input,
+    int64_t upscale_factor) {
+  return ::torch::pixel_shuffle(
+    input,
+    upscale_factor
+  );
+}
+} // namespace detail
+
 inline Tensor pixel_shuffle(
     const Tensor& input,
     const PixelShuffleOptions& options) {
-  return torch::pixel_shuffle(
-    input,
-    options.upscale_factor()
-  );
+  return detail::pixel_shuffle(input, options.upscale_factor());
 }
 
 } // namespace functional
 } // namespace nn
-} // namespace torch
+} // namespace

--- a/torch/csrc/api/include/torch/nn/functional/pixelshuffle.h
+++ b/torch/csrc/api/include/torch/nn/functional/pixelshuffle.h
@@ -10,7 +10,7 @@ namespace detail {
 inline Tensor pixel_shuffle(
     const Tensor& input,
     int64_t upscale_factor) {
-  return ::torch::pixel_shuffle(
+  return torch::pixel_shuffle(
     input,
     upscale_factor
   );
@@ -25,4 +25,4 @@ inline Tensor pixel_shuffle(
 
 } // namespace functional
 } // namespace nn
-} // namespace
+} // namespace torch

--- a/torch/csrc/api/include/torch/nn/functional/pooling.h
+++ b/torch/csrc/api/include/torch/nn/functional/pooling.h
@@ -7,43 +7,115 @@ namespace torch {
 namespace nn{
 namespace functional {
 
-inline Tensor avg_pool1d(const Tensor& input, const AvgPool1dOptions& options) {
+namespace detail {
+inline Tensor avg_pool1d(const Tensor& input,
+                         ExpandingArray<1> kernel_size,
+                         ExpandingArray<1> stride,
+                         ExpandingArray<1> padding = 0,
+                         bool ceil_mode = false,
+                         bool count_include_pad = true) {
   return torch::avg_pool1d(
       input,
-      options.kernel_size(),
-      options.stride(),
-      options.padding(),
-      options.ceil_mode(),
-      options.count_include_pad());
+      kernel_size,
+      stride,
+      padding,
+      ceil_mode,
+      count_include_pad);
+}
+} // namespace detail
+
+inline Tensor avg_pool1d(const Tensor& input, const AvgPool1dOptions& options) {
+  return avg_pool1d(
+    input,
+    options.kernel_size(),
+    options.stride(),
+    options.padding(),
+    options.ceil_mode(),
+    options.count_include_pad());
 }
 
-inline Tensor avg_pool2d(const Tensor& input, const AvgPool2dOptions& options) {
+namespace detail {
+inline Tensor avg_pool2d(const Tensor& input,
+                         ExpandingArray<2> kernel_size,
+                         ExpandingArray<2> stride,
+                         ExpandingArray<2> padding = 0,
+                         bool ceil_mode = false,
+                         bool count_include_pad = true,
+                         c10::optional<int64_t> divisor_override = c10::nullopt) {
   return torch::avg_pool2d(
       input,
-      options.kernel_size(),
-      options.stride(),
-      options.padding(),
-      options.ceil_mode(),
-      options.count_include_pad(),
-      options.divisor_override());
+      kernel_size,
+      stride,
+      padding,
+      ceil_mode,
+      count_include_pad,
+      divisor_override);
+}
+} // namespace detail
+
+inline Tensor avg_pool2d(const Tensor& input, const AvgPool2dOptions& options) {
+  return detail::avg_pool2d(
+    input,
+    options.kernel_size(),
+    options.stride(),
+    options.padding(),
+    options.ceil_mode(),
+    options.count_include_pad(),
+    options.divisor_override());
 }
 
-inline Tensor avg_pool3d(const Tensor& input, const AvgPool3dOptions& options) {
+namespace detail {
+inline Tensor avg_pool3d(const Tensor& input,
+                         ExpandingArray<3> kernel_size,
+                         ExpandingArray<3> stride,
+                         ExpandingArray<3> padding = 0,
+                         bool ceil_mode = false,
+                         bool count_include_pad = true,
+                         c10::optional<int64_t> divisor_override = c10::nullopt) {
   return torch::avg_pool3d(
       input,
-      options.kernel_size(),
-      options.stride(),
-      options.padding(),
-      options.ceil_mode(),
-      options.count_include_pad(),
-      options.divisor_override());
+      kernel_size,
+      stride,
+      padding,
+      ceil_mode,
+      count_include_pad,
+      divisor_override);
+}
+} // namespace detail
+
+inline Tensor avg_pool3d(const Tensor& input, const AvgPool3dOptions& options) {
+  return detail::avg_pool3d(
+    input,
+    options.kernel_size(),
+    options.stride(),
+    options.padding(),
+    options.ceil_mode(),
+    options.count_include_pad(),
+    options.divisor_override());
 }
 
 // ============================================================================
 
-inline Tensor max_pool1d(const Tensor& input, const MaxPool1dOptions& options) {
+namespace detail {
+inline Tensor max_pool1d(const Tensor& input,
+                         ExpandingArray<1> kernel_size,
+                         ExpandingArray<1> stride,
+                         ExpandingArray<1> padding = 0,
+                         ExpandingArray<1> dilation = 1,
+                         bool ceil_mode = false) {
    return torch::max_pool1d(
       input,
+      kernel_size,
+      stride,
+      padding,
+      dilation,
+      ceil_mode);
+}
+} // namespace detail
+
+inline Tensor max_pool1d(const Tensor& input, const MaxPool1dOptions& options) {
+   return detail::max_pool1d(
+      input,
       options.kernel_size(),
       options.stride(),
       options.padding(),
@@ -51,9 +123,27 @@ inline Tensor max_pool1d(const Tensor& input, const MaxPool1dOptions& options) {
       options.ceil_mode());
 }
 
-inline std::tuple<Tensor, Tensor> max_pool1d_with_indices(const Tensor& input, const MaxPool1dOptions& options) {
+namespace detail {
+inline std::tuple<Tensor, Tensor> max_pool1d_with_indices(
+  const Tensor& input,
+  ExpandingArray<1> kernel_size,
+  ExpandingArray<1> stride,
+  ExpandingArray<1> padding = 0,
+  ExpandingArray<1> dilation = 1,
+  bool ceil_mode = false) {
   return torch::max_pool1d_with_indices(
       input,
+      kernel_size,
+      stride,
+      padding,
+      dilation,
+      ceil_mode);
+}
+} // namespace detail
+
+inline std::tuple<Tensor, Tensor> max_pool1d_with_indices(const Tensor& input, const MaxPool1dOptions& options) {
+  return detail::max_pool1d_with_indices(
+      input,
       options.kernel_size(),
       options.stride(),
       options.padding(),
@@ -61,9 +151,26 @@ inline std::tuple<Tensor, Tensor> max_pool1d_with_indices(const Tensor& input, c
       options.ceil_mode());
 }
 
-inline Tensor max_pool2d(const Tensor& input, const MaxPool2dOptions& options) {
+namespace detail {
+inline Tensor max_pool2d(const Tensor& input,
+                         ExpandingArray<2> kernel_size,
+                         ExpandingArray<2> stride,
+                         ExpandingArray<2> padding = 0,
+                         ExpandingArray<2> dilation = 1,
+                         bool ceil_mode = false) {
   return torch::max_pool2d(
       input,
+      kernel_size,
+      stride,
+      padding,
+      dilation,
+      ceil_mode);
+}
+} // namespace detail
+
+inline Tensor max_pool2d(const Tensor& input, const MaxPool2dOptions& options) {
+  return detail::max_pool2d(
+      input,
       options.kernel_size(),
       options.stride(),
       options.padding(),
@@ -71,18 +178,26 @@ inline Tensor max_pool2d(const Tensor& input, const MaxPool2dOptions& options) {
       options.ceil_mode());
 }
 
-inline std::tuple<Tensor, Tensor> max_pool2d_with_indices(const Tensor& input, const MaxPool2dOptions& options) {
+namespace detail {
+inline std::tuple<Tensor, Tensor> max_pool2d_with_indices(
+  const Tensor& input,
+  ExpandingArray<2> kernel_size,
+  ExpandingArray<2> stride,
+  ExpandingArray<2> padding = 0,
+  ExpandingArray<2> dilation = 1,
+  bool ceil_mode = false) {
   return torch::max_pool2d_with_indices(
       input,
-      options.kernel_size(),
-      options.stride(),
-      options.padding(),
-      options.dilation(),
-      options.ceil_mode());
+      kernel_size,
+      stride,
+      padding,
+      dilation,
+      ceil_mode);
 }
+} // namespace detail
 
-inline Tensor max_pool3d(const Tensor& input, const MaxPool3dOptions& options) {
-  return torch::max_pool3d(
+inline std::tuple<Tensor, Tensor> max_pool2d_with_indices(const Tensor& input, const MaxPool2dOptions& options) {
+  return detail::max_pool2d_with_indices(
       input,
       options.kernel_size(),
       options.stride(),
@@ -91,8 +206,53 @@ inline Tensor max_pool3d(const Tensor& input, const MaxPool3dOptions& options) {
       options.ceil_mode());
 }
 
-inline std::tuple<Tensor, Tensor> max_pool3d_with_indices(const Tensor& input, const MaxPool3dOptions& options) {
+namespace detail {
+inline Tensor max_pool3d(const Tensor& input,
+                         ExpandingArray<3> kernel_size,
+                         ExpandingArray<3> stride,
+                         ExpandingArray<3> padding = 0,
+                         ExpandingArray<3> dilation = 1,
+                         bool ceil_mode = false) {
+  return torch::max_pool3d(
+      input,
+      kernel_size,
+      stride,
+      padding,
+      dilation,
+      ceil_mode);
+}
+} // namespace detail
+
+inline Tensor max_pool3d(const Tensor& input, const MaxPool3dOptions& options) {
+  return detail::max_pool3d(
+      input,
+      options.kernel_size(),
+      options.stride(),
+      options.padding(),
+      options.dilation(),
+      options.ceil_mode());
+}
+
+namespace detail {
+inline std::tuple<Tensor, Tensor> max_pool3d_with_indices(
+  const Tensor& input,
+  ExpandingArray<3> kernel_size,
+  ExpandingArray<3> stride,
+  ExpandingArray<3> padding = 0,
+  ExpandingArray<3> dilation = 1,
+  bool ceil_mode = false) {
   return torch::max_pool3d_with_indices(
+      input,
+      kernel_size,
+      stride,
+      padding,
+      dilation,
+      ceil_mode);
+}
+} // namespace detail
+
+inline std::tuple<Tensor, Tensor> max_pool3d_with_indices(const Tensor& input, const MaxPool3dOptions& options) {
+  return detail::max_pool3d_with_indices(
       input,
       options.kernel_size(),
       options.stride(),
@@ -102,52 +262,115 @@ inline std::tuple<Tensor, Tensor> max_pool3d_with_indices(const Tensor& input, c
 }
 
 // ============================================================================
+
+namespace detail {
+inline Tensor adaptive_max_pool1d(const Tensor& input,
+  ExpandingArray<1> output_size) {
+   return std::get<0>(torch::adaptive_max_pool1d(input, output_size));
+}
+} // namespace detail
 
 inline Tensor adaptive_max_pool1d(const Tensor& input,
   const AdaptiveMaxPool1dOptions& options) {
-   return std::get<0>(torch::adaptive_max_pool1d(input, options.output_size()));
+   return detail::adaptive_max_pool1d(input, options.output_size());
 }
+
+namespace detail {
+inline std::tuple<Tensor, Tensor> adaptive_max_pool1d_with_indices(
+  const Tensor& input, ExpandingArray<1> output_size) {
+   return torch::adaptive_max_pool1d(input, output_size);
+}
+} // namespace detail
 
 inline std::tuple<Tensor, Tensor> adaptive_max_pool1d_with_indices(
   const Tensor& input, const AdaptiveMaxPool1dOptions& options) {
-   return torch::adaptive_max_pool1d(input, options.output_size());
+   return detail::adaptive_max_pool1d_with_indices(input, options.output_size());
 }
+
+namespace detail {
+inline Tensor adaptive_max_pool2d(const Tensor& input,
+  ExpandingArray<2> output_size) {
+   return std::get<0>(torch::adaptive_max_pool2d(input, output_size));
+}
+} // namespace detail
 
 inline Tensor adaptive_max_pool2d(const Tensor& input,
   const AdaptiveMaxPool2dOptions& options) {
-   return std::get<0>(torch::adaptive_max_pool2d(input, options.output_size()));
+   return detail::adaptive_max_pool2d(input, options.output_size());
 }
+
+namespace detail {
+inline std::tuple<Tensor, Tensor> adaptive_max_pool2d_with_indices(
+  const Tensor& input, ExpandingArray<2> output_size) {
+   return torch::adaptive_max_pool2d(input, output_size);
+}
+} // namespace detail
 
 inline std::tuple<Tensor, Tensor> adaptive_max_pool2d_with_indices(
   const Tensor& input, const AdaptiveMaxPool2dOptions& options) {
-   return torch::adaptive_max_pool2d(input, options.output_size());
+   return detail::adaptive_max_pool2d_with_indices(input, options.output_size());
 }
+
+namespace detail {
+inline Tensor adaptive_max_pool3d(const Tensor& input,
+  ExpandingArray<3> output_size) {
+   return std::get<0>(torch::adaptive_max_pool3d(input, output_size));
+}
+} // namespace detail
 
 inline Tensor adaptive_max_pool3d(const Tensor& input,
   const AdaptiveMaxPool3dOptions& options) {
-   return std::get<0>(torch::adaptive_max_pool3d(input, options.output_size()));
+   return detail::adaptive_max_pool3d(input, options.output_size());
 }
+
+namespace detail {
+inline std::tuple<Tensor, Tensor> adaptive_max_pool3d_with_indices(
+  const Tensor& input, ExpandingArray<3> output_size) {
+   return torch::adaptive_max_pool3d(input, output_size);
+}
+} // namespace detail
 
 inline std::tuple<Tensor, Tensor> adaptive_max_pool3d_with_indices(
   const Tensor& input, const AdaptiveMaxPool3dOptions& options) {
-   return torch::adaptive_max_pool3d(input, options.output_size());
+   return detail::adaptive_max_pool3d_with_indices(input, options.output_size());
 }
 
 // ============================================================================
 
+namespace detail {
+inline Tensor adaptive_avg_pool1d(const Tensor& input,
+  ExpandingArray<1> output_size) {
+   return torch::adaptive_avg_pool1d(input, output_size);
+}
+} // namespace detail
+
 inline Tensor adaptive_avg_pool1d(const Tensor& input,
   const AdaptiveAvgPool1dOptions& options) {
-   return torch::adaptive_avg_pool1d(input, options.output_size());
+   return detail::adaptive_avg_pool1d(input, options.output_size());
 }
+
+namespace detail {
+inline Tensor adaptive_avg_pool2d(const Tensor& input,
+  ExpandingArray<2> output_size) {
+   return torch::adaptive_avg_pool2d(input, output_size);
+}
+} // namespace detail
 
 inline Tensor adaptive_avg_pool2d(const Tensor& input,
   const AdaptiveAvgPool2dOptions& options) {
-   return torch::adaptive_avg_pool2d(input, options.output_size());
+   return detail::adaptive_avg_pool2d(input, options.output_size());
 }
+
+namespace detail {
+inline Tensor adaptive_avg_pool3d(const Tensor& input,
+  ExpandingArray<3> output_size) {
+   return torch::adaptive_avg_pool3d(input, output_size);
+}
+} // namespace detail
 
 inline Tensor adaptive_avg_pool3d(const Tensor& input,
   const AdaptiveAvgPool3dOptions& options) {
-   return torch::adaptive_avg_pool3d(input, options.output_size());
+   return detail::adaptive_avg_pool3d(input, options.output_size());
 }
 
 // ============================================================================
@@ -186,56 +409,151 @@ inline std::vector<int64_t> _unpool_output_size(const Tensor& input,
   }
 }
 
-inline Tensor max_unpool1d(const Tensor& input, const Tensor& indices,
-    const MaxUnpool1dOptions& options,
+namespace detail {
+inline Tensor max_unpool1d(
+    const Tensor& input,
+    const Tensor& indices,
+    ExpandingArray<1> kernel_size,
+    ExpandingArray<1> stride,
+    ExpandingArray<1> padding = 0,
     const c10::optional<IntArrayRef>& output_size = c10::nullopt) {
-  auto output_size_ = _unpool_output_size(input, options.kernel_size(),
-                                          options.stride(), options.padding(),
+  auto output_size_ = _unpool_output_size(input, kernel_size,
+                                          stride, padding,
                                           output_size);
   output_size_.push_back(1);
   return torch::max_unpool2d(input.unsqueeze(3), indices.unsqueeze(3),
                              output_size_).squeeze(3);
 }
+} // namespace detail
 
-inline Tensor max_unpool2d(const Tensor& input, const Tensor& indices,
-  const MaxUnpool2dOptions& options,
+inline Tensor max_unpool1d(const Tensor& input, const Tensor& indices,
+    const MaxUnpool1dOptions& options,
+    const c10::optional<IntArrayRef>& output_size = c10::nullopt) {
+  return detail::max_unpool1d(
+    input,
+    indices,
+    options.kernel_size(),
+    options.stride(),
+    options.padding(),
+    output_size);
+}
+
+namespace detail {
+inline Tensor max_unpool2d(
+  const Tensor& input,
+  const Tensor& indices,
+  ExpandingArray<2> kernel_size,
+  ExpandingArray<2> stride,
+  ExpandingArray<2> padding = 0,
   const c10::optional<IntArrayRef>& output_size = c10::nullopt) {
-  auto output_size_ = _unpool_output_size(input, options.kernel_size(),
-                                          options.stride(), options.padding(),
+  auto output_size_ = _unpool_output_size(input, kernel_size,
+                                          stride, padding,
                                           output_size);
 
   return torch::max_unpool2d(input, indices, output_size_);
 }
+} // namespace detail
+
+inline Tensor max_unpool2d(const Tensor& input, const Tensor& indices,
+  const MaxUnpool2dOptions& options,
+  const c10::optional<IntArrayRef>& output_size = c10::nullopt) {
+  return detail::max_unpool2d(
+    input,
+    indices,
+    options.kernel_size(),
+    options.stride(),
+    options.padding(),
+    output_size);
+}
+
+namespace detail {
+inline Tensor max_unpool3d(
+  const Tensor& input,
+  const Tensor& indices,
+  ExpandingArray<3> kernel_size,
+  ExpandingArray<3> stride,
+  ExpandingArray<3> padding = 0,
+  const c10::optional<IntArrayRef>& output_size = c10::nullopt) {
+  auto output_size_ = _unpool_output_size(input, kernel_size,
+                                          stride, padding,
+                                          output_size);
+
+  return torch::max_unpool3d(input, indices, output_size_,
+                             stride, padding);
+}
+} // namespace detail
 
 inline Tensor max_unpool3d(const Tensor& input, const Tensor& indices,
   const MaxUnpool3dOptions& options,
   const c10::optional<IntArrayRef>& output_size = c10::nullopt) {
-  auto output_size_ = _unpool_output_size(input, options.kernel_size(),
-                                          options.stride(), options.padding(),
-                                          output_size);
-
-  return torch::max_unpool3d(input, indices, output_size_,
-                             options.stride(), options.padding());
+  return detail::max_unpool3d(
+    input,
+    indices,
+    options.kernel_size(),
+    options.stride(),
+    options.padding(),
+    output_size);
 }
+
+// ============================================================================
+
+namespace detail {
+inline Tensor lp_pool1d(
+  const Tensor& input,
+  float norm_type,
+  ExpandingArray<1> kernel_size,
+  ExpandingArray<1> stride,
+  bool ceil_mode = false) {
+  Tensor out = detail::avg_pool1d(
+    input.pow(norm_type),
+    kernel_size,
+    stride,
+    /*padding=*/0,
+    ceil_mode);
+
+  return (torch::sign(out) * relu(torch::abs(out))).mul((*kernel_size)[0]).pow(1. / norm_type);
+}
+} // namespace detail
 
 inline Tensor lp_pool1d(const Tensor& input, const LPPool1dOptions& options) {
-  Tensor out = avg_pool1d(
-    input.pow(options.norm_type()),
-    AvgPool1dOptions(options.kernel_size()).stride(options.stride()).padding(0).ceil_mode(options.ceil_mode()));
-
-  return (torch::sign(out) * relu(torch::abs(out))).mul((*options.kernel_size())[0]).pow(1. / options.norm_type());
+  return detail::lp_pool1d(
+    input,
+    options.norm_type(),
+    options.kernel_size(),
+    options.stride(),
+    options.ceil_mode());
 }
 
-inline Tensor lp_pool2d(const Tensor& input, const LPPool2dOptions& options) {
-  int kw = (*options.kernel_size())[0];
-  int kh = (*options.kernel_size())[1];
-  Tensor out = avg_pool2d(
-    input.pow(options.norm_type()),
-    AvgPool2dOptions(options.kernel_size()).stride(options.stride()).padding(0).ceil_mode(options.ceil_mode()));
+namespace detail {
+inline Tensor lp_pool2d(
+  const Tensor& input,
+  float norm_type,
+  ExpandingArray<2> kernel_size,
+  ExpandingArray<2> stride,
+  bool ceil_mode = false) {
+  int kw = (*kernel_size)[0];
+  int kh = (*kernel_size)[1];
+  Tensor out = detail::avg_pool2d(
+    input.pow(norm_type),
+    kernel_size,
+    stride,
+    /*padding=*/0,
+    ceil_mode);
 
-  return (torch::sign(out) * relu(torch::abs(out))).mul(kw * kh).pow(1. / options.norm_type());
+  return (torch::sign(out) * relu(torch::abs(out))).mul(kw * kh).pow(1. / norm_type);
+}
+} // namespace detail
+
+inline Tensor lp_pool2d(const Tensor& input, const LPPool2dOptions& options) {
+  return detail::lp_pool2d(
+    input,
+    options.norm_type(),
+    options.kernel_size(),
+    options.stride(),
+    options.ceil_mode());
 }
 
 } // namespace functional
 } // namespace nn
 } // namespace torch
+

--- a/torch/csrc/api/include/torch/nn/functional/pooling.h
+++ b/torch/csrc/api/include/torch/nn/functional/pooling.h
@@ -556,4 +556,3 @@ inline Tensor lp_pool2d(const Tensor& input, const LPPool2dOptions& options) {
 } // namespace functional
 } // namespace nn
 } // namespace torch
-

--- a/torch/csrc/api/include/torch/nn/functional/pooling.h
+++ b/torch/csrc/api/include/torch/nn/functional/pooling.h
@@ -11,9 +11,9 @@ namespace detail {
 inline Tensor avg_pool1d(const Tensor& input,
                          ExpandingArray<1> kernel_size,
                          ExpandingArray<1> stride,
-                         ExpandingArray<1> padding = 0,
-                         bool ceil_mode = false,
-                         bool count_include_pad = true) {
+                         ExpandingArray<1> padding,
+                         bool ceil_mode,
+                         bool count_include_pad) {
   return torch::avg_pool1d(
       input,
       kernel_size,
@@ -38,10 +38,10 @@ namespace detail {
 inline Tensor avg_pool2d(const Tensor& input,
                          ExpandingArray<2> kernel_size,
                          ExpandingArray<2> stride,
-                         ExpandingArray<2> padding = 0,
-                         bool ceil_mode = false,
-                         bool count_include_pad = true,
-                         c10::optional<int64_t> divisor_override = c10::nullopt) {
+                         ExpandingArray<2> padding,
+                         bool ceil_mode,
+                         bool count_include_pad,
+                         c10::optional<int64_t> divisor_override) {
   return torch::avg_pool2d(
       input,
       kernel_size,
@@ -68,10 +68,10 @@ namespace detail {
 inline Tensor avg_pool3d(const Tensor& input,
                          ExpandingArray<3> kernel_size,
                          ExpandingArray<3> stride,
-                         ExpandingArray<3> padding = 0,
-                         bool ceil_mode = false,
-                         bool count_include_pad = true,
-                         c10::optional<int64_t> divisor_override = c10::nullopt) {
+                         ExpandingArray<3> padding,
+                         bool ceil_mode,
+                         bool count_include_pad,
+                         c10::optional<int64_t> divisor_override) {
   return torch::avg_pool3d(
       input,
       kernel_size,
@@ -100,9 +100,9 @@ namespace detail {
 inline Tensor max_pool1d(const Tensor& input,
                          ExpandingArray<1> kernel_size,
                          ExpandingArray<1> stride,
-                         ExpandingArray<1> padding = 0,
-                         ExpandingArray<1> dilation = 1,
-                         bool ceil_mode = false) {
+                         ExpandingArray<1> padding,
+                         ExpandingArray<1> dilation,
+                         bool ceil_mode) {
    return torch::max_pool1d(
       input,
       kernel_size,
@@ -128,9 +128,9 @@ inline std::tuple<Tensor, Tensor> max_pool1d_with_indices(
   const Tensor& input,
   ExpandingArray<1> kernel_size,
   ExpandingArray<1> stride,
-  ExpandingArray<1> padding = 0,
-  ExpandingArray<1> dilation = 1,
-  bool ceil_mode = false) {
+  ExpandingArray<1> padding,
+  ExpandingArray<1> dilation,
+  bool ceil_mode) {
   return torch::max_pool1d_with_indices(
       input,
       kernel_size,
@@ -155,9 +155,9 @@ namespace detail {
 inline Tensor max_pool2d(const Tensor& input,
                          ExpandingArray<2> kernel_size,
                          ExpandingArray<2> stride,
-                         ExpandingArray<2> padding = 0,
-                         ExpandingArray<2> dilation = 1,
-                         bool ceil_mode = false) {
+                         ExpandingArray<2> padding,
+                         ExpandingArray<2> dilation,
+                         bool ceil_mode) {
   return torch::max_pool2d(
       input,
       kernel_size,
@@ -183,9 +183,9 @@ inline std::tuple<Tensor, Tensor> max_pool2d_with_indices(
   const Tensor& input,
   ExpandingArray<2> kernel_size,
   ExpandingArray<2> stride,
-  ExpandingArray<2> padding = 0,
-  ExpandingArray<2> dilation = 1,
-  bool ceil_mode = false) {
+  ExpandingArray<2> padding,
+  ExpandingArray<2> dilation,
+  bool ceil_mode) {
   return torch::max_pool2d_with_indices(
       input,
       kernel_size,
@@ -210,9 +210,9 @@ namespace detail {
 inline Tensor max_pool3d(const Tensor& input,
                          ExpandingArray<3> kernel_size,
                          ExpandingArray<3> stride,
-                         ExpandingArray<3> padding = 0,
-                         ExpandingArray<3> dilation = 1,
-                         bool ceil_mode = false) {
+                         ExpandingArray<3> padding,
+                         ExpandingArray<3> dilation,
+                         bool ceil_mode) {
   return torch::max_pool3d(
       input,
       kernel_size,
@@ -238,9 +238,9 @@ inline std::tuple<Tensor, Tensor> max_pool3d_with_indices(
   const Tensor& input,
   ExpandingArray<3> kernel_size,
   ExpandingArray<3> stride,
-  ExpandingArray<3> padding = 0,
-  ExpandingArray<3> dilation = 1,
-  bool ceil_mode = false) {
+  ExpandingArray<3> padding,
+  ExpandingArray<3> dilation,
+  bool ceil_mode) {
   return torch::max_pool3d_with_indices(
       input,
       kernel_size,
@@ -415,8 +415,8 @@ inline Tensor max_unpool1d(
     const Tensor& indices,
     ExpandingArray<1> kernel_size,
     ExpandingArray<1> stride,
-    ExpandingArray<1> padding = 0,
-    const c10::optional<IntArrayRef>& output_size = c10::nullopt) {
+    ExpandingArray<1> padding,
+    const c10::optional<IntArrayRef>& output_size) {
   auto output_size_ = _unpool_output_size(input, kernel_size,
                                           stride, padding,
                                           output_size);
@@ -444,8 +444,8 @@ inline Tensor max_unpool2d(
   const Tensor& indices,
   ExpandingArray<2> kernel_size,
   ExpandingArray<2> stride,
-  ExpandingArray<2> padding = 0,
-  const c10::optional<IntArrayRef>& output_size = c10::nullopt) {
+  ExpandingArray<2> padding,
+  const c10::optional<IntArrayRef>& output_size) {
   auto output_size_ = _unpool_output_size(input, kernel_size,
                                           stride, padding,
                                           output_size);
@@ -472,8 +472,8 @@ inline Tensor max_unpool3d(
   const Tensor& indices,
   ExpandingArray<3> kernel_size,
   ExpandingArray<3> stride,
-  ExpandingArray<3> padding = 0,
-  const c10::optional<IntArrayRef>& output_size = c10::nullopt) {
+  ExpandingArray<3> padding,
+  const c10::optional<IntArrayRef>& output_size) {
   auto output_size_ = _unpool_output_size(input, kernel_size,
                                           stride, padding,
                                           output_size);
@@ -503,7 +503,7 @@ inline Tensor lp_pool1d(
   float norm_type,
   ExpandingArray<1> kernel_size,
   ExpandingArray<1> stride,
-  bool ceil_mode = false) {
+  bool ceil_mode) {
   Tensor out = detail::avg_pool1d(
     input.pow(norm_type),
     kernel_size,
@@ -530,7 +530,7 @@ inline Tensor lp_pool2d(
   float norm_type,
   ExpandingArray<2> kernel_size,
   ExpandingArray<2> stride,
-  bool ceil_mode = false) {
+  bool ceil_mode) {
   int kw = (*kernel_size)[0];
   int kh = (*kernel_size)[1];
   Tensor out = detail::avg_pool2d(

--- a/torch/csrc/api/include/torch/nn/functional/pooling.h
+++ b/torch/csrc/api/include/torch/nn/functional/pooling.h
@@ -509,7 +509,8 @@ inline Tensor lp_pool1d(
     kernel_size,
     stride,
     /*padding=*/0,
-    ceil_mode);
+    ceil_mode,
+    /*count_include_pad=*/true);
 
   return (torch::sign(out) * relu(torch::abs(out))).mul((*kernel_size)[0]).pow(1. / norm_type);
 }
@@ -538,7 +539,9 @@ inline Tensor lp_pool2d(
     kernel_size,
     stride,
     /*padding=*/0,
-    ceil_mode);
+    ceil_mode,
+    /*count_include_pad=*/true,
+    /*divisor_override=*/c10::nullopt);
 
   return (torch::sign(out) * relu(torch::abs(out))).mul(kw * kh).pow(1. / norm_type);
 }

--- a/torch/csrc/api/include/torch/nn/functional/upsampling.h
+++ b/torch/csrc/api/include/torch/nn/functional/upsampling.h
@@ -12,10 +12,10 @@ namespace functional {
 namespace detail {
 inline Tensor interpolate(
   const Tensor& input,
-  std::vector<int64_t> size = {},
-  std::vector<double> scale_factor = {},
-  InterpolateOptions::mode_t mode = torch::kNearest,
-  c10::optional<bool> align_corners = c10::nullopt) {
+  std::vector<int64_t> size,
+  std::vector<double> scale_factor,
+  InterpolateOptions::mode_t mode,
+  c10::optional<bool> align_corners) {
   auto _check_size_scale_factor = [&](size_t dim) {
     if (size.empty() && scale_factor.empty()) {
       TORCH_CHECK(false, "either size or scale_factor should be defined");

--- a/torch/csrc/api/include/torch/nn/functional/upsampling.h
+++ b/torch/csrc/api/include/torch/nn/functional/upsampling.h
@@ -120,4 +120,4 @@ inline Tensor interpolate(const Tensor& input, InterpolateOptions options = {}) 
 
 } // namespace functional
 } // namespace nn
-} // na
+} // namespace torch

--- a/torch/csrc/api/include/torch/nn/functional/upsampling.h
+++ b/torch/csrc/api/include/torch/nn/functional/upsampling.h
@@ -9,30 +9,36 @@ namespace torch {
 namespace nn {
 namespace functional {
 
-inline Tensor interpolate(const Tensor& input, InterpolateOptions options) {
-  auto _check_size_scale_factor = [options](size_t dim) {
-    if (options.size().empty() && options.scale_factor().empty()) {
+namespace detail {
+inline Tensor interpolate(
+  const Tensor& input,
+  std::vector<int64_t> size = {},
+  std::vector<double> scale_factor = {},
+  InterpolateOptions::mode_t mode = torch::kNearest,
+  c10::optional<bool> align_corners = c10::nullopt) {
+  auto _check_size_scale_factor = [&](size_t dim) {
+    if (size.empty() && scale_factor.empty()) {
       TORCH_CHECK(false, "either size or scale_factor should be defined");
     }
-    if (!options.size().empty() && !options.scale_factor().empty()) {
+    if (!size.empty() && !scale_factor.empty()) {
       TORCH_CHECK(false, "only one of size or scale_factor should be defined");
     }
-    if (!options.scale_factor().empty() &&
-        options.scale_factor().size() != dim) {
+    if (!scale_factor.empty() &&
+        scale_factor.size() != dim) {
       TORCH_CHECK(
           false,
           "scale_factor shape must match input shape. "
           "Input is ", dim, "D, scale_factor size is ",
-          options.scale_factor().size());
+          scale_factor.size());
     }
   };
 
-  auto _output_size = [input, options, _check_size_scale_factor](size_t dim) {
+  auto _output_size = [&](size_t dim) {
     _check_size_scale_factor(dim);
-    if (!options.size().empty()) {
-      return options.size();
+    if (!size.empty()) {
+      return size;
     }
-    auto scale_factors = options.scale_factor();
+    auto scale_factors = scale_factor;
 
     std::vector<int64_t> sizes;
     for (size_t i = 0; i < dim; ++i) {
@@ -42,66 +48,76 @@ inline Tensor interpolate(const Tensor& input, InterpolateOptions options) {
     return sizes;
   };
 
-  if (c10::get_if<enumtype::kNearest>(&options.mode()) ||
-      c10::get_if<enumtype::kArea>(&options.mode())) {
-    if (options.align_corners() != c10::nullopt) {
+  if (c10::get_if<enumtype::kNearest>(&mode) ||
+      c10::get_if<enumtype::kArea>(&mode)) {
+    if (align_corners != c10::nullopt) {
       TORCH_CHECK(
           false,
           "align_corners option can only be set with the "
           "interpolating modes: linear | bilinear | bicubic | trilinear");
     }
   } else {
-    if (options.align_corners() == c10::nullopt) {
+    if (align_corners == c10::nullopt) {
       TORCH_WARN(
           "Default upsampling behavior when mode is linear, bilinear, bicubic, "
           "or trilinear, has changed to align_corners=False since 0.4.0. "
           "Please specify align_corners=True if the old behavior is desired. "
           "See the documentation of nn.Upsample for details.");
-      options.align_corners(false);
+      align_corners = false;
     }
   }
 
-  if (input.dim() == 3 && c10::get_if<enumtype::kNearest>(&options.mode())) {
+  if (input.dim() == 3 && c10::get_if<enumtype::kNearest>(&mode)) {
     return torch::upsample_nearest1d(input, _output_size(1));
-  } else if (input.dim() == 4 && c10::get_if<enumtype::kNearest>(&options.mode())) {
+  } else if (input.dim() == 4 && c10::get_if<enumtype::kNearest>(&mode)) {
     return torch::upsample_nearest2d(input, _output_size(2));
-  } else if (input.dim() == 5 && c10::get_if<enumtype::kNearest>(&options.mode())) {
+  } else if (input.dim() == 5 && c10::get_if<enumtype::kNearest>(&mode)) {
     return torch::upsample_nearest3d(input, _output_size(3));
-  } else if (input.dim() == 3 && c10::get_if<enumtype::kArea>(&options.mode())) {
-    return adaptive_avg_pool1d(input, _output_size(1));
-  } else if (input.dim() == 4 && c10::get_if<enumtype::kArea>(&options.mode())) {
-    return adaptive_avg_pool2d(input, _output_size(2));
-  } else if (input.dim() == 5 && c10::get_if<enumtype::kArea>(&options.mode())) {
-    return adaptive_avg_pool3d(input, _output_size(3));
-  } else if (input.dim() == 3 && c10::get_if<enumtype::kLinear>(&options.mode())) {
-    return torch::upsample_linear1d(input, _output_size(1), *options.align_corners());
-  } else if (input.dim() == 3 && c10::get_if<enumtype::kBilinear>(&options.mode())) {
+  } else if (input.dim() == 3 && c10::get_if<enumtype::kArea>(&mode)) {
+    return detail::adaptive_avg_pool1d(input, _output_size(1));
+  } else if (input.dim() == 4 && c10::get_if<enumtype::kArea>(&mode)) {
+    return detail::adaptive_avg_pool2d(input, _output_size(2));
+  } else if (input.dim() == 5 && c10::get_if<enumtype::kArea>(&mode)) {
+    return detail::adaptive_avg_pool3d(input, _output_size(3));
+  } else if (input.dim() == 3 && c10::get_if<enumtype::kLinear>(&mode)) {
+    return torch::upsample_linear1d(input, _output_size(1), *align_corners);
+  } else if (input.dim() == 3 && c10::get_if<enumtype::kBilinear>(&mode)) {
     TORCH_CHECK(false, "Got 3D input, but bilinear mode needs 4D input");
-  } else if (input.dim() == 3 && c10::get_if<enumtype::kTrilinear>(&options.mode())) {
+  } else if (input.dim() == 3 && c10::get_if<enumtype::kTrilinear>(&mode)) {
     TORCH_CHECK(false, "Got 3D input, but trilinear mode needs 5D input");
-  } else if (input.dim() == 4 && c10::get_if<enumtype::kLinear>(&options.mode())) {
+  } else if (input.dim() == 4 && c10::get_if<enumtype::kLinear>(&mode)) {
     TORCH_CHECK(false, "Got 4D input, but linear mode needs 3D input");
-  } else if (input.dim() == 4 && c10::get_if<enumtype::kBilinear>(&options.mode())) {
-    return torch::upsample_bilinear2d(input, _output_size(2), *options.align_corners());
-  } else if (input.dim() == 4 && c10::get_if<enumtype::kTrilinear>(&options.mode())) {
+  } else if (input.dim() == 4 && c10::get_if<enumtype::kBilinear>(&mode)) {
+    return torch::upsample_bilinear2d(input, _output_size(2), *align_corners);
+  } else if (input.dim() == 4 && c10::get_if<enumtype::kTrilinear>(&mode)) {
     TORCH_CHECK(false, "Got 4D input, but trilinear mode needs 5D input");
-  } else if (input.dim() == 5 && c10::get_if<enumtype::kLinear>(&options.mode())) {
+  } else if (input.dim() == 5 && c10::get_if<enumtype::kLinear>(&mode)) {
     TORCH_CHECK(false, "Got 5D input, but linear mode needs 3D input");
-  } else if (input.dim() == 5 && c10::get_if<enumtype::kBilinear>(&options.mode())) {
+  } else if (input.dim() == 5 && c10::get_if<enumtype::kBilinear>(&mode)) {
     TORCH_CHECK(false, "Got 5D input, but bilinear mode needs 4D input");
-  } else if (input.dim() == 5 && c10::get_if<enumtype::kTrilinear>(&options.mode())) {
-    return torch::upsample_trilinear3d(input, _output_size(3), *options.align_corners());
-  } else if (input.dim() == 4 && c10::get_if<enumtype::kBicubic>(&options.mode())) {
-    return torch::upsample_bicubic2d(input, _output_size(2), *options.align_corners());
+  } else if (input.dim() == 5 && c10::get_if<enumtype::kTrilinear>(&mode)) {
+    return torch::upsample_trilinear3d(input, _output_size(3), *align_corners);
+  } else if (input.dim() == 4 && c10::get_if<enumtype::kBicubic>(&mode)) {
+    return torch::upsample_bicubic2d(input, _output_size(2), *align_corners);
   } else {
     TORCH_CHECK(
         false,
         "Input Error: Only 3D, 4D and 5D input Tensors supported "
         "(got ", input.dim(), "D) for the modes: nearest | linear | bilinear | bicubic | trilinear "
-        "(got ", enumtype::get_enum_name(options.mode()), ")");
+        "(got ", enumtype::get_enum_name(mode), ")");
   }
+}
+} // namespace detail
+
+inline Tensor interpolate(const Tensor& input, InterpolateOptions options = {}) {
+  return detail::interpolate(
+    input,
+    options.size(),
+    options.scale_factor(),
+    options.mode(),
+    options.align_corners());
 }
 
 } // namespace functional
 } // namespace nn
-} // namespace torch
+} // na

--- a/torch/csrc/api/include/torch/nn/functional/upsampling.h
+++ b/torch/csrc/api/include/torch/nn/functional/upsampling.h
@@ -12,8 +12,8 @@ namespace functional {
 namespace detail {
 inline Tensor interpolate(
   const Tensor& input,
-  std::vector<int64_t> size,
-  std::vector<double> scale_factor,
+  const std::vector<int64_t>& size,
+  const std::vector<double>& scale_factor,
   InterpolateOptions::mode_t mode,
   c10::optional<bool> align_corners) {
   auto _check_size_scale_factor = [&](size_t dim) {

--- a/torch/csrc/api/include/torch/nn/functional/vision.h
+++ b/torch/csrc/api/include/torch/nn/functional/vision.h
@@ -116,4 +116,3 @@ inline Tensor grid_sample(
 } // namespace functional
 } // namespace nn
 } // namespace torch
-

--- a/torch/csrc/api/include/torch/nn/functional/vision.h
+++ b/torch/csrc/api/include/torch/nn/functional/vision.h
@@ -47,54 +47,73 @@ inline Tensor affine_grid(
   return torch::affine_grid_generator(theta, size, align_corners);
 }
 
+// ============================================================================
+
+namespace detail {
 inline Tensor grid_sample(
     const Tensor& input,
     const Tensor& grid,
-    GridSampleOptions options = {}) {
+    std::string mode = "bilinear",
+    std::string padding_mode = "zeros",
+    c10::optional<bool> align_corners = c10::nullopt) {
 
-  if ((options.mode().compare("bilinear") != 0) && (options.mode().compare("nearest") != 0)) {
+  if ((mode.compare("bilinear") != 0) && (mode.compare("nearest") != 0)) {
     TORCH_CHECK(false, "nn::functional::grid_sample(): expected mode to be ",
-                         "'bilinear' or 'nearest', but got: '", options.mode(), "'");
+                         "'bilinear' or 'nearest', but got: '", mode, "'");
   }
 
-  if ((options.padding_mode().compare("zeros") != 0) && 
-      (options.padding_mode().compare("border") != 0) && 
-      (options.padding_mode().compare("reflection") != 0)) {
+  if ((padding_mode.compare("zeros") != 0) &&
+      (padding_mode.compare("border") != 0) &&
+      (padding_mode.compare("reflection") != 0)) {
     TORCH_CHECK(false, "nn::functional::grid_sample(): expected padding_mode ",
                          "to be 'zeros', 'border', or 'reflection', ",
-                         "but got: '", options.padding_mode(), "'");
+                         "but got: '", padding_mode, "'");
   }
 
   int64_t mode_enum, padding_mode_enum;
 
-  if (options.mode().compare("bilinear") == 0) {
+  if (mode.compare("bilinear") == 0) {
     mode_enum = 0;
   }
   else { /// mode == 'nearest'
     mode_enum = 1;
   }
 
-  if (options.padding_mode().compare("zeros") == 0) {
+  if (padding_mode.compare("zeros") == 0) {
     padding_mode_enum = 0;
   }
-  else if (options.padding_mode().compare("border") == 0) {
+  else if (padding_mode.compare("border") == 0) {
     padding_mode_enum = 1;
   }
   else { /// padding_mode == 'reflection'
     padding_mode_enum = 2;
   }
-  
-  if (!options.align_corners().has_value()) {
+
+  if (!align_corners.has_value()) {
     TORCH_WARN("Default grid_sample and affine_grid behavior has changed ",
                    "to align_corners=False since 1.3.0. Please specify ",
                    "align_corners=True if the old behavior is desired. ",
                    "See the documentation of grid_sample for details.");
-    options.align_corners(false);
+    align_corners = false;
   }
-  
-  return torch::grid_sampler(input, grid, mode_enum, padding_mode_enum, options.align_corners().value());
+
+  return torch::grid_sampler(input, grid, mode_enum, padding_mode_enum, align_corners.value());
+}
+} // namespace detail
+
+inline Tensor grid_sample(
+    const Tensor& input,
+    const Tensor& grid,
+    GridSampleOptions options = {}) {
+  return detail::grid_sample(
+    input,
+    grid,
+    options.mode(),
+    options.padding_mode(),
+    options.align_corners());
 }
 
 } // namespace functional
 } // namespace nn
 } // namespace torch
+

--- a/torch/csrc/api/include/torch/nn/functional/vision.h
+++ b/torch/csrc/api/include/torch/nn/functional/vision.h
@@ -53,9 +53,9 @@ namespace detail {
 inline Tensor grid_sample(
     const Tensor& input,
     const Tensor& grid,
-    std::string mode = "bilinear",
-    std::string padding_mode = "zeros",
-    c10::optional<bool> align_corners = c10::nullopt) {
+    std::string mode,
+    std::string padding_mode,
+    c10::optional<bool> align_corners) {
 
   if ((mode.compare("bilinear") != 0) && (mode.compare("nearest") != 0)) {
     TORCH_CHECK(false, "nn::functional::grid_sample(): expected mode to be ",

--- a/torch/csrc/api/src/nn/modules/pixelshuffle.cpp
+++ b/torch/csrc/api/src/nn/modules/pixelshuffle.cpp
@@ -18,7 +18,7 @@ void PixelShuffleImpl::reset() {}
 
 Tensor PixelShuffleImpl::forward(
     const Tensor& input) {
-  return F::pixel_shuffle(input, options);
+  return F::detail::pixel_shuffle(input, options.upscale_factor());
 }
 
 } // namespace nn

--- a/torch/csrc/api/src/nn/modules/pooling.cpp
+++ b/torch/csrc/api/src/nn/modules/pooling.cpp
@@ -23,15 +23,35 @@ void AvgPoolImpl<D, Derived>::pretty_print(std::ostream& stream) const {
 }
 
 Tensor AvgPool1dImpl::forward(const Tensor& input) {
-  return F::avg_pool1d(input, options);
+  return F::detail::avg_pool1d(
+    input,
+    options.kernel_size(),
+    options.stride(),
+    options.padding(),
+    options.ceil_mode(),
+    options.count_include_pad());
 }
 
 Tensor AvgPool2dImpl::forward(const Tensor& input) {
-  return F::avg_pool2d(input, options);
+  return F::detail::avg_pool2d(
+    input,
+    options.kernel_size(),
+    options.stride(),
+    options.padding(),
+    options.ceil_mode(),
+    options.count_include_pad(),
+    options.divisor_override());
 }
 
 Tensor AvgPool3dImpl::forward(const Tensor& input) {
-  return F::avg_pool3d(input, options);
+  return F::detail::avg_pool3d(
+    input,
+    options.kernel_size(),
+    options.stride(),
+    options.padding(),
+    options.ceil_mode(),
+    options.count_include_pad(),
+    options.divisor_override());
 }
 
 template class AvgPoolImpl<1, AvgPool1dImpl>;
@@ -59,27 +79,63 @@ void MaxPoolImpl<D, Derived>::pretty_print(std::ostream& stream) const {
 }
 
 Tensor MaxPool1dImpl::forward(const Tensor& input) {
-  return F::max_pool1d(input, options);
+  return F::detail::max_pool1d(
+    input,
+    options.kernel_size(),
+    options.stride(),
+    options.padding(),
+    options.dilation(),
+    options.ceil_mode());
 }
 
 std::tuple<Tensor, Tensor> MaxPool1dImpl::forward_with_indices(const Tensor& input) {
-  return F::max_pool1d_with_indices(input, options);
+  return F::detail::max_pool1d_with_indices(
+    input,
+    options.kernel_size(),
+    options.stride(),
+    options.padding(),
+    options.dilation(),
+    options.ceil_mode());
 }
 
 Tensor MaxPool2dImpl::forward(const Tensor& input) {
-  return F::max_pool2d(input, options);
+  return F::detail::max_pool2d(
+    input,
+    options.kernel_size(),
+    options.stride(),
+    options.padding(),
+    options.dilation(),
+    options.ceil_mode());
 }
 
 std::tuple<Tensor, Tensor> MaxPool2dImpl::forward_with_indices(const Tensor& input) {
-  return F::max_pool2d_with_indices(input, options);
+  return F::detail::max_pool2d_with_indices(
+    input,
+    options.kernel_size(),
+    options.stride(),
+    options.padding(),
+    options.dilation(),
+    options.ceil_mode());
 }
 
 Tensor MaxPool3dImpl::forward(const Tensor& input) {
-  return F::max_pool3d(input, options);
+  return F::detail::max_pool3d(
+    input,
+    options.kernel_size(),
+    options.stride(),
+    options.padding(),
+    options.dilation(),
+    options.ceil_mode());
 }
 
 std::tuple<Tensor, Tensor> MaxPool3dImpl::forward_with_indices(const Tensor& input) {
-  return F::max_pool3d_with_indices(input, options);
+  return F::detail::max_pool3d_with_indices(
+    input,
+    options.kernel_size(),
+    options.stride(),
+    options.padding(),
+    options.dilation(),
+    options.ceil_mode());
 }
 
 template class MaxPoolImpl<1, MaxPool1dImpl>;
@@ -102,27 +158,27 @@ void AdaptiveMaxPoolImpl<D, Derived>::pretty_print(std::ostream& stream) const {
 }
 
 Tensor AdaptiveMaxPool1dImpl::forward(const Tensor& input) {
-  return F::adaptive_max_pool1d(input, options);
+  return F::detail::adaptive_max_pool1d(input, options.output_size());
 }
 
 std::tuple<Tensor, Tensor> AdaptiveMaxPool1dImpl::forward_with_indices(const Tensor& input) {
-  return F::adaptive_max_pool1d_with_indices(input, options);
+  return F::detail::adaptive_max_pool1d_with_indices(input, options.output_size());
 }
 
 Tensor AdaptiveMaxPool2dImpl::forward(const Tensor& input) {
-  return F::adaptive_max_pool2d(input, options);
+  return F::detail::adaptive_max_pool2d(input, options.output_size());
 }
 
 std::tuple<Tensor, Tensor> AdaptiveMaxPool2dImpl::forward_with_indices(const Tensor& input) {
-  return F::adaptive_max_pool2d_with_indices(input, options);
+  return F::detail::adaptive_max_pool2d_with_indices(input, options.output_size());
 }
 
 Tensor AdaptiveMaxPool3dImpl::forward(const Tensor& input) {
-  return F::adaptive_max_pool3d(input, options);
+  return F::detail::adaptive_max_pool3d(input, options.output_size());
 }
 
 std::tuple<Tensor, Tensor> AdaptiveMaxPool3dImpl::forward_with_indices(const Tensor& input) {
-  return F::adaptive_max_pool3d_with_indices(input, options);
+  return F::detail::adaptive_max_pool3d_with_indices(input, options.output_size());
 }
 
 template class AdaptiveMaxPoolImpl<1, AdaptiveMaxPool1dImpl>;
@@ -145,15 +201,15 @@ void AdaptiveAvgPoolImpl<D, Derived>::pretty_print(std::ostream& stream) const {
 }
 
 Tensor AdaptiveAvgPool1dImpl::forward(const Tensor& input) {
-  return F::adaptive_avg_pool1d(input, options);
+  return F::detail::adaptive_avg_pool1d(input, options.output_size());
 }
 
 Tensor AdaptiveAvgPool2dImpl::forward(const Tensor& input) {
-  return F::adaptive_avg_pool2d(input, options);
+  return F::detail::adaptive_avg_pool2d(input, options.output_size());
 }
 
 Tensor AdaptiveAvgPool3dImpl::forward(const Tensor& input) {
-  return F::adaptive_avg_pool3d(input, options);
+  return F::detail::adaptive_avg_pool3d(input, options.output_size());
 }
 
 template class AdaptiveAvgPoolImpl<1, AdaptiveAvgPool1dImpl>;
@@ -180,17 +236,35 @@ void MaxUnpoolImpl<D, Derived>::pretty_print(std::ostream& stream) const {
 
 Tensor MaxUnpool1dImpl::forward(const Tensor& input, const Tensor& indices,
     const c10::optional<IntArrayRef>& output_size) {
-  return F::max_unpool1d(input, indices, options, output_size);
+  return F::detail::max_unpool1d(
+    input,
+    indices,
+    options.kernel_size(),
+    options.stride(),
+    options.padding(),
+    output_size);
 }
 
 Tensor MaxUnpool2dImpl::forward(const Tensor& input, const Tensor& indices,
     const c10::optional<IntArrayRef>& output_size) {
-  return F::max_unpool2d(input, indices, options, output_size);
+  return F::detail::max_unpool2d(
+    input,
+    indices,
+    options.kernel_size(),
+    options.stride(),
+    options.padding(),
+    output_size);
 }
 
 Tensor MaxUnpool3dImpl::forward(const Tensor& input, const Tensor& indices,
     const c10::optional<IntArrayRef>& output_size) {
-  return F::max_unpool3d(input, indices, options, output_size);
+  return F::detail::max_unpool3d(
+    input,
+    indices,
+    options.kernel_size(),
+    options.stride(),
+    options.padding(),
+    output_size);
 }
 
 template class MaxUnpoolImpl<1, MaxUnpool1dImpl>;
@@ -217,13 +291,23 @@ void LPPoolImpl<D, Derived>::pretty_print(std::ostream& stream) const {
 }
 
 Tensor LPPool1dImpl::forward(const Tensor& input) {
-  return F::lp_pool1d(input, options);
+  return F::detail::lp_pool1d(
+    input,
+    options.norm_type(),
+    options.kernel_size(),
+    options.stride(),
+    options.ceil_mode());
 }
 
 template class LPPoolImpl<1, LPPool1dImpl>;
 
 Tensor LPPool2dImpl::forward(const Tensor& input) {
-  return F::lp_pool2d(input, options);
+  return F::detail::lp_pool2d(
+    input,
+    options.norm_type(),
+    options.kernel_size(),
+    options.stride(),
+    options.ceil_mode());
 }
 
 template class LPPoolImpl<2, LPPool2dImpl>;

--- a/torch/csrc/api/src/nn/modules/upsampling.cpp
+++ b/torch/csrc/api/src/nn/modules/upsampling.cpp
@@ -36,13 +36,12 @@ Tensor UpsampleImpl::forward(const Tensor& input) {
     mode = torch::kTrilinear;
   }
 
-  return F::interpolate(
+  return F::detail::interpolate(
       input,
-      InterpolateOptions()
-          .size(options.size())
-          .scale_factor(options.scale_factor())
-          .mode(mode)
-          .align_corners(options.align_corners()));
+      options.size(),
+      options.scale_factor(),
+      mode,
+      options.align_corners());
 }
 
 } // namespace nn


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #29360 Add functional overloads for fold, linear, loss, normalization, padding
* **#29359 Add functional overloads for pixelshuffle, pooling, upsampling, vision**
* #29358 Add functional overloads for activation, batchnorm, distance, embedding

This PR adds functional overloads that take the full set of arguments (instead of just Options) for the following functionals:
- pixelshuffle
- pooling
- upsampling
- vision

These new functionals lives in the `torch::nn::functional::detail` namespace and they are only meant to be called from the module forward methods (i.e. they are not public API). This is in preparation for the future change where we make module Options and functional Options two different classes, because if the module forward method has to construct a new functional Options object every time it runs it will be pretty silly and bad performance.

Differential Revision: [D18376978](https://our.internmc.facebook.com/intern/diff/D18376978)