### PR TITLE
[C++ API] Add functional overloads for fold, linear, loss, normalization, padding

### DIFF
--- a/torch/csrc/api/include/torch/nn/functional/fold.h
+++ b/torch/csrc/api/include/torch/nn/functional/fold.h
@@ -6,15 +6,21 @@ namespace torch {
 namespace nn {
 namespace functional {
 
-inline Tensor fold(const Tensor& input, const FoldOptions& options) {
+namespace detail {
+inline Tensor fold(const Tensor& input,
+                   ExpandingArray<2> output_size,
+                   ExpandingArray<2> kernel_size,
+                   ExpandingArray<2> dilation = 1,
+                   ExpandingArray<2> padding = 0,
+                   ExpandingArray<2> stride = 1) {
   if (input.dim() == 3) {
     return torch::col2im(
         input,
-        options.output_size(),
-        options.kernel_size(),
-        options.dilation(),
-        options.padding(),
-        options.stride());
+        output_size,
+        kernel_size,
+        dilation,
+        padding,
+        stride);
   } else {
     TORCH_CHECK(
         false,
@@ -22,21 +28,44 @@ inline Tensor fold(const Tensor& input, const FoldOptions& options) {
         "(got ", input.dim(), "D)");
   }
 }
+} // namespace detail
 
-inline Tensor unfold(const Tensor& input, const UnfoldOptions& options) {
+inline Tensor fold(const Tensor& input, const FoldOptions& options) {
+  return detail::fold(
+    input,
+    options.output_size(),
+    options.kernel_size(),
+    options.dilation(),
+    options.padding(),
+    options.stride());
+}
+
+// ============================================================================
+
+namespace detail {
+inline Tensor unfold(const Tensor& input,
+                     ExpandingArray<2> kernel_size,
+                     ExpandingArray<2> dilation = 1,
+                     ExpandingArray<2> padding = 0,
+                     ExpandingArray<2> stride = 1) {
   if (input.dim() == 4) {
     return torch::im2col(
         input,
-        options.kernel_size(),
-        options.dilation(),
-        options.padding(),
-        options.stride());
+        kernel_size,
+        dilation,
+        padding,
+        stride);
   } else {
     TORCH_CHECK(
         false,
         "Input Error: Only 4D input Tensors are supported "
         "(got ", input.dim(), "D)");
   }
+}
+} // namespace detail
+
+inline Tensor unfold(const Tensor& input, const UnfoldOptions& options) {
+  return detail::unfold(input, options.kernel_size(), options.dilation(), options.padding(), options.stride());
 }
 
 } // namespace functional

--- a/torch/csrc/api/include/torch/nn/functional/linear.h
+++ b/torch/csrc/api/include/torch/nn/functional/linear.h
@@ -10,6 +10,8 @@ inline Tensor bilinear(const Tensor& input1, const Tensor& input2, const Tensor&
     return torch::bilinear(input1, input2, weight, bias);
 }
 
+// ============================================================================
+
 inline Tensor linear(const Tensor& input, const Tensor& weight,
                      const Tensor& bias = {}) {
   if (input.dim() == 2 && bias.defined()) {

--- a/torch/csrc/api/include/torch/nn/functional/loss.h
+++ b/torch/csrc/api/include/torch/nn/functional/loss.h
@@ -7,48 +7,71 @@ namespace torch {
 namespace nn {
 namespace functional {
 
+namespace detail {
+inline Tensor l1_loss(
+    const Tensor& input,
+    const Tensor& target,
+    L1LossOptions::reduction_t reduction = torch::kMean) {
+  return torch::l1_loss(
+    input,
+    target,
+    enumtype::reduction_get_enum(reduction));
+}
+} // namespace detail
+
 inline Tensor l1_loss(
     const Tensor& input,
     const Tensor& target,
     const L1LossOptions& options = {}) {
-  return torch::l1_loss(
-    input,
-    target,
-    enumtype::reduction_get_enum(options.reduction()));
+  return detail::l1_loss(input, target, options.reduction());
 }
 
+// ============================================================================
+
+namespace detail {
 inline Tensor kl_div(
     const Tensor& input,
     const Tensor& target,
-    const KLDivLossOptions& options = {}) {
+    KLDivLossOptions::reduction_t reduction = torch::kMean) {
   torch::Reduction::Reduction reduction_enum;
 
-  if (c10::get_if<enumtype::kMean>(&options.reduction())) {
+  if (c10::get_if<enumtype::kMean>(&reduction)) {
     TORCH_WARN("reduction: 'mean' divides the total loss by both the batch size and the support size."
                "'batchmean' divides only by the batch size, and aligns with the KL div math definition."
                "'mean' will be changed to behave the same as 'batchmean' in the next major release.");
   }
 
   // special case for batchmean
-  if (c10::get_if<enumtype::kBatchMean>(&options.reduction())) {
+  if (c10::get_if<enumtype::kBatchMean>(&reduction)) {
     reduction_enum = torch::Reduction::Sum;
   } else {
-    reduction_enum = enumtype::reduction_get_enum(options.reduction());
+    reduction_enum = enumtype::reduction_get_enum(reduction);
   }
 
   auto reduced = torch::kl_div(input, target, reduction_enum);
 
-  if (c10::get_if<enumtype::kBatchMean>(&options.reduction()) && input.dim() != 0) {
+  if (c10::get_if<enumtype::kBatchMean>(&reduction) && input.dim() != 0) {
     reduced = reduced / input.sizes()[0];
   }
 
   return reduced;
 }
+} // namespace detail
 
+inline Tensor kl_div(
+    const Tensor& input,
+    const Tensor& target,
+    const KLDivLossOptions& options = {}) {
+  return detail::kl_div(input, target, options.reduction());
+}
+
+// ============================================================================
+
+namespace detail {
 inline Tensor mse_loss(
     const Tensor& input,
     const Tensor& target,
-    const MSELossOptions& options = {}) {
+    MSELossOptions::reduction_t reduction = torch::kMean) {
   if (!(target.sizes() == input.sizes())) {
     TORCH_WARN("Using a target size (", target.sizes(),
                ") that is different to the input size (", input.sizes(), "). ",
@@ -58,8 +81,8 @@ inline Tensor mse_loss(
   torch::Tensor ret;
   if (target.requires_grad()) {
     ret = torch::pow(input - target, 2);
-    if (!c10::get_if<enumtype::kNone>(&options.reduction())) {
-      ret = (c10::get_if<enumtype::kMean>(&options.reduction())) ? torch::mean(ret) : torch::sum(ret);
+    if (!c10::get_if<enumtype::kNone>(&reduction)) {
+      ret = c10::get_if<enumtype::kMean>(&reduction) ? torch::mean(ret) : torch::sum(ret);
     }
   } else {
     std::vector<torch::Tensor> broadcast_tensors = torch::broadcast_tensors({input, target});
@@ -68,16 +91,28 @@ inline Tensor mse_loss(
     ret = torch::mse_loss(
       expanded_input,
       expanded_target,
-      enumtype::reduction_get_enum(options.reduction()));
+      enumtype::reduction_get_enum(reduction));
   }
   return ret;
 }
+} // namespace detail
 
+inline Tensor mse_loss(
+    const Tensor& input,
+    const Tensor& target,
+    const MSELossOptions& options = {}) {
+  return detail::mse_loss(input, target, options.reduction());
+}
+
+// ============================================================================
+
+namespace detail {
 inline Tensor binary_cross_entropy(
     const Tensor& input,
     const Tensor& target,
-    const BCELossOptions& options = {}) {
-  auto reduction_enum = enumtype::reduction_get_enum(options.reduction());
+    Tensor weight = {},
+    BCELossOptions::reduction_t reduction = torch::kMean) {
+  auto reduction_enum = enumtype::reduction_get_enum(reduction);
 
   if (target.sizes() != input.sizes()) {
     TORCH_WARN("Using a target size (", target.sizes(), ") ",
@@ -91,7 +126,6 @@ inline Tensor binary_cross_entropy(
       "!= input nelement (", input.numel(), ")");
   }
 
-  auto weight = options.weight();
   if (weight.defined()) {
     auto new_size = at::infer_size(target.sizes(), weight.sizes());
     weight = weight.expand(new_size);
@@ -99,59 +133,109 @@ inline Tensor binary_cross_entropy(
 
   return torch::binary_cross_entropy(input, target, weight, reduction_enum);
 }
+} // namespace detail
+
+inline Tensor binary_cross_entropy(
+    const Tensor& input,
+    const Tensor& target,
+    const BCELossOptions& options = {}) {
+  return detail::binary_cross_entropy(input, target, options.weight(), options.reduction());
+}
+
+// ============================================================================
+
+namespace detail {
+inline Tensor hinge_embedding_loss(
+    const Tensor& input,
+    const Tensor& target,
+    double margin = 1.0,
+    HingeEmbeddingLossOptions::reduction_t reduction = torch::kMean) {
+  return torch::hinge_embedding_loss(
+      input,
+      target,
+      margin,
+      enumtype::reduction_get_enum(reduction));
+}
+} // namespace detail
 
 inline Tensor hinge_embedding_loss(
     const Tensor& input,
     const Tensor& target,
     const HingeEmbeddingLossOptions& options = {}) {
-  return torch::hinge_embedding_loss(
-      input,
-      target,
-      options.margin(),
-      enumtype::reduction_get_enum(options.reduction()));
+  return detail::hinge_embedding_loss(input, target, options.margin(), options.reduction());
 }
 
+// ============================================================================
+
+namespace detail {
 inline Tensor multi_margin_loss(
     const Tensor& input,
     const Tensor& target,
-    const MultiMarginLossOptions& options = {}) {
-  TORCH_CHECK(options.p() == 1 || options.p() == 2, "only p == 1 and p == 2 supported");
-  if (options.weight().defined()) {
-    TORCH_CHECK(options.weight().dim() == 1, "weight must be one-dimensional");
+    int64_t p = 1,
+    double margin = 1.0,
+    Tensor weight = Tensor(),
+    MultiMarginLossOptions::reduction_t reduction = torch::kMean) {
+  TORCH_CHECK(p == 1 || p == 2, "only p == 1 and p == 2 supported");
+  if (weight.defined()) {
+    TORCH_CHECK(weight.dim() == 1, "weight must be one-dimensional");
   }
 
   return torch::multi_margin_loss(
     input,
     target,
-    options.p(),
-    options.margin(),
-    options.weight(),
-    enumtype::reduction_get_enum(options.reduction())
+    p,
+    margin,
+    weight,
+    enumtype::reduction_get_enum(reduction)
   );
 }
+} // namespace detail
+
+inline Tensor multi_margin_loss(
+    const Tensor& input,
+    const Tensor& target,
+    const MultiMarginLossOptions& options = {}) {
+  return detail::multi_margin_loss(input, target, options.p(), options.margin(), options.weight(), options.reduction());
+}
+
+// ============================================================================
+
+namespace detail {
+inline Tensor cosine_embedding_loss(
+    const Tensor& input1,
+    const Tensor& input2,
+    const Tensor& target,
+    double margin = 0.0,
+    CosineEmbeddingLossOptions::reduction_t reduction = torch::kMean) {
+  return torch::cosine_embedding_loss(
+    input1,
+    input2,
+    target,
+    margin,
+    enumtype::reduction_get_enum(reduction));
+}
+} // namespace detail
 
 inline Tensor cosine_embedding_loss(
     const Tensor& input1,
     const Tensor& input2,
     const Tensor& target,
-    const CosineEmbeddingLossOptions& options) {
-  return torch::cosine_embedding_loss(
-    input1,
-    input2,
-    target,
-    options.margin(),
-    enumtype::reduction_get_enum(options.reduction()));
+    const CosineEmbeddingLossOptions& options = {}) {
+  return detail::cosine_embedding_loss(input1, input2, target, options.margin(), options.reduction());
 }
+
+// ============================================================================
 
 inline Tensor _smooth_l1_loss(const Tensor& input, const Tensor& target) {
     auto t = torch::abs(input - target);
     return torch::where(t < 1, 0.5 * torch::pow(t, 2), t - 0.5);
 }
 
+namespace detail {
 inline Tensor smooth_l1_loss(
     const Tensor& input,
     const Tensor& target,
-    const SmoothL1LossOptions& options = {}) {
+    torch::Reduction::Reduction reduction = torch::Reduction::Mean) {
   if (target.sizes() != input.sizes()) {
     TORCH_WARN("Using a target size (", target.sizes(), ") that is different to the input size (", input.sizes(), "). ",
                   "This will likely lead to incorrect results due to broadcasting. ",
@@ -162,105 +246,226 @@ inline Tensor smooth_l1_loss(
 
   if (target.requires_grad()) {
     ret = _smooth_l1_loss(input, target);
-    if (options.reduction() != torch::Reduction::None) {
-      ret = options.reduction() == torch::Reduction::Mean ? torch::mean(ret) : torch::sum(ret);
+    if (reduction != torch::Reduction::None) {
+      ret = reduction == torch::Reduction::Mean ? torch::mean(ret) : torch::sum(ret);
     }
   } else {
     std::vector<Tensor> expanded_tensors = torch::broadcast_tensors({input, target});
-    ret = torch::smooth_l1_loss(expanded_tensors[0], expanded_tensors[1], options.reduction());
+    ret = torch::smooth_l1_loss(expanded_tensors[0], expanded_tensors[1], reduction);
   }
   return ret;
 }
-  
+} // namespace detail
+
+inline Tensor smooth_l1_loss(
+    const Tensor& input,
+    const Tensor& target,
+    const SmoothL1LossOptions& options = {}) {
+  return detail::smooth_l1_loss(input, target, options.reduction());
+}
+
+// ============================================================================
+
+namespace detail {
+inline Tensor multilabel_margin_loss(
+    const Tensor& input,
+    const Tensor& target,
+    MultiLabelMarginLossOptions::reduction_t reduction = torch::kMean) {
+  return torch::multilabel_margin_loss(
+    input,
+    target,
+    enumtype::reduction_get_enum(reduction));
+}
+} // namespace detail
+
 inline Tensor multilabel_margin_loss(
     const Tensor& input,
     const Tensor& target,
     const MultiLabelMarginLossOptions& options = {}) {
-  return torch::multilabel_margin_loss(
+  return detail::multilabel_margin_loss(input, target, options.reduction());
+}
+
+// ============================================================================
+
+namespace detail {
+inline Tensor soft_margin_loss(
+    const Tensor& input,
+    const Tensor& target,
+    SoftMarginLossOptions::reduction_t reduction = torch::kMean) {
+  return torch::soft_margin_loss(
     input,
     target,
-    enumtype::reduction_get_enum(options.reduction()));
+    enumtype::reduction_get_enum(reduction));
 }
+} // namespace detail
 
 inline Tensor soft_margin_loss(
     const Tensor& input,
     const Tensor& target,
     const SoftMarginLossOptions& options = {}) {
-  return torch::soft_margin_loss(
-    input,
-    target,
-    enumtype::reduction_get_enum(options.reduction()));
+  return detail::soft_margin_loss(input, target, options.reduction());
 }
 
+// ============================================================================
+
+namespace detail {
 inline Tensor multilabel_soft_margin_loss(
     const Tensor& input,
     const Tensor& target,
-    const MultiLabelSoftMarginLossOptions& options = {}) {
+    Tensor weight = Tensor(),
+    MultiLabelSoftMarginLossOptions::reduction_t reduction = torch::kMean) {
   auto loss = -(target * torch::log_sigmoid(input) + (1 - target) * torch::log_sigmoid(-input));
-  if (options.weight().defined()) {
-    loss = loss * options.weight();
+  if (weight.defined()) {
+    loss = loss * weight;
   }
 
   loss = loss.sum(1) / input.size(1); // only return N loss values
 
   Tensor ret;
 
-  if (c10::get_if<enumtype::kNone>(&options.reduction())) {
+  if (c10::get_if<enumtype::kNone>(&reduction)) {
     ret = loss;
-  } else if (c10::get_if<enumtype::kMean>(&options.reduction())) {
+  } else if (c10::get_if<enumtype::kMean>(&reduction)) {
     ret = loss.mean();
-  } else if (c10::get_if<enumtype::kSum>(&options.reduction())) {
+  } else if (c10::get_if<enumtype::kSum>(&reduction)) {
     ret = loss.sum();
   } else {
     ret = input;
     TORCH_INTERNAL_ASSERT(
       false,
-      enumtype::get_enum_name(options.reduction()),
+      enumtype::get_enum_name(reduction),
       " is not valid");
   }
   return ret;
 }
+} // namespace detail
+
+inline Tensor multilabel_soft_margin_loss(
+    const Tensor& input,
+    const Tensor& target,
+    const MultiLabelSoftMarginLossOptions& options = {}) {
+  return detail::multilabel_soft_margin_loss(input, target, options.weight(), options.reduction());
+}
+
+// ============================================================================
+
+namespace detail {
+inline Tensor triplet_margin_loss(
+    const Tensor& anchor,
+    const Tensor& positive,
+    const Tensor& negative,
+    double margin = 1.0,
+    double p = 2.0,
+    double eps = 1e-6,
+    bool swap = false,
+    TripletMarginLossOptions::reduction_t reduction = torch::kMean) {
+  return torch::triplet_margin_loss(
+      anchor,
+      positive,
+      negative,
+      margin,
+      p,
+      eps,
+      swap,
+      enumtype::reduction_get_enum(reduction));
+}
+} // namespace detail
 
 inline Tensor triplet_margin_loss(
     const Tensor& anchor,
     const Tensor& positive,
     const Tensor& negative,
     const TripletMarginLossOptions& options = {}) {
-  return torch::triplet_margin_loss(
-      anchor,
-      positive,
-      negative,
-      options.margin(),
-      options.p(),
-      options.eps(),
-      options.swap(),
-      enumtype::reduction_get_enum(options.reduction()));
+  return detail::triplet_margin_loss(
+    anchor,
+    positive,
+    negative,
+    options.margin(),
+    options.p(),
+    options.eps(),
+    options.swap(),
+    options.reduction());
 }
 
-inline Tensor ctc_loss(const Tensor& log_probs, const Tensor& targets,
-  const Tensor& input_lengths, const Tensor& target_lengths,
-  const CTCLossOptions& options = {}) {
-  return torch::ctc_loss(log_probs, targets, input_lengths, target_lengths,
-    options.blank(), enumtype::reduction_get_enum(options.reduction()),
+// ============================================================================
+
+namespace detail {
+inline Tensor ctc_loss(const Tensor& log_probs,
+                       const Tensor& targets,
+                       const Tensor& input_lengths,
+                       const Tensor& target_lengths,
+                       int64_t blank = 0,
+                       CTCLossOptions::reduction_t reduction = torch::kMean,
+                       bool zero_infinity = false) {
+  return torch::ctc_loss(
+    log_probs,
+    targets,
+    input_lengths,
+    target_lengths,
+    blank,
+    enumtype::reduction_get_enum(reduction),
+    zero_infinity);
+}
+} // namespace detail
+
+inline Tensor ctc_loss(const Tensor& log_probs,
+                       const Tensor& targets,
+                       const Tensor& input_lengths,
+                       const Tensor& target_lengths,
+                       const CTCLossOptions& options = {}) {
+  return detail::ctc_loss(
+    log_probs,
+    targets,
+    input_lengths,
+    target_lengths,
+    options.blank(),
+    options.reduction(),
     options.zero_infinity());
 }
 
+// ============================================================================
+
+namespace detail {
+inline Tensor poisson_nll_loss(const Tensor& input,
+                               const Tensor& target,
+                               bool log_input = true,
+                               bool full = false,
+                               double eps = 1e-8,
+                               PoissonNLLLossOptions::reduction_t reduction = torch::kMean) {
+  return torch::poisson_nll_loss(
+    input, target,
+    log_input, full, eps, enumtype::reduction_get_enum(reduction));
+}
+} // namespace detail
+
 inline Tensor poisson_nll_loss(const Tensor& input, const Tensor& target,
                                const PoissonNLLLossOptions& options = {}) {
-  return torch::poisson_nll_loss(input, target, options.log_input(),
-    options.full(), options.eps(),
-    enumtype::reduction_get_enum(options.reduction()));
+  return detail::poisson_nll_loss(
+    input, target,
+    options.log_input(), options.full(), options.eps(), options.reduction());
 }
 
-inline Tensor margin_ranking_loss(const Tensor& input1, const Tensor& input2,
-  const Tensor& target, const MarginRankingLossOptions& options = {}) {
+// ============================================================================
+
+namespace detail {
+inline Tensor margin_ranking_loss(const Tensor& input1,
+                                  const Tensor& input2,
+                                  const Tensor& target,
+                                  double margin = 0,
+                                  MarginRankingLossOptions::reduction_t reduction = torch::kMean) {
   TORCH_CHECK(
     input1.dim() != 0 && input2.dim() != 0 && target.dim() != 0,
     "margin_ranking_loss does not support scalars, got sizes: "
     "input1: ", input1.sizes(), ", input2: ", input2.sizes(),
     ", target: ", target.sizes());
-  return torch::margin_ranking_loss(input1, input2, target, options.margin(),
-    enumtype::reduction_get_enum(options.reduction()));
+  return torch::margin_ranking_loss(input1, input2, target, margin,
+    enumtype::reduction_get_enum(reduction));
+}
+} // namespace detail
+
+inline Tensor margin_ranking_loss(const Tensor& input1, const Tensor& input2,
+  const Tensor& target, const MarginRankingLossOptions& options = {}) {
+  return detail::margin_ranking_loss(input1, input2, target, options.margin(), options.reduction());
 }
 
 } // namespace functional

--- a/torch/csrc/api/include/torch/nn/functional/loss.h
+++ b/torch/csrc/api/include/torch/nn/functional/loss.h
@@ -110,7 +110,7 @@ namespace detail {
 inline Tensor binary_cross_entropy(
     const Tensor& input,
     const Tensor& target,
-    Tensor weight,
+    const Tensor& weight,
     BCELossOptions::reduction_t reduction) {
   auto reduction_enum = enumtype::reduction_get_enum(reduction);
 
@@ -126,12 +126,13 @@ inline Tensor binary_cross_entropy(
       "!= input nelement (", input.numel(), ")");
   }
 
-  if (weight.defined()) {
-    auto new_size = at::infer_size(target.sizes(), weight.sizes());
-    weight = weight.expand(new_size);
+  auto weight_ = weight;
+  if (weight_.defined()) {
+    auto new_size = at::infer_size(target.sizes(), weight_.sizes());
+    weight_ = weight_.expand(new_size);
   }
 
-  return torch::binary_cross_entropy(input, target, weight, reduction_enum);
+  return torch::binary_cross_entropy(input, target, weight_, reduction_enum);
 }
 } // namespace detail
 
@@ -173,7 +174,7 @@ inline Tensor multi_margin_loss(
     const Tensor& target,
     int64_t p,
     double margin,
-    Tensor weight,
+    const Tensor& weight,
     MultiMarginLossOptions::reduction_t reduction) {
   TORCH_CHECK(p == 1 || p == 2, "only p == 1 and p == 2 supported");
   if (weight.defined()) {
@@ -312,7 +313,7 @@ namespace detail {
 inline Tensor multilabel_soft_margin_loss(
     const Tensor& input,
     const Tensor& target,
-    Tensor weight,
+    const Tensor& weight,
     MultiLabelSoftMarginLossOptions::reduction_t reduction) {
   auto loss = -(target * torch::log_sigmoid(input) + (1 - target) * torch::log_sigmoid(-input));
   if (weight.defined()) {

--- a/torch/csrc/api/include/torch/nn/functional/normalization.h
+++ b/torch/csrc/api/include/torch/nn/functional/normalization.h
@@ -9,45 +9,80 @@ namespace torch {
 namespace nn {
 namespace functional {
 
+namespace detail {
+inline Tensor normalize(
+    const Tensor& input,
+    double p = 2.0,
+    int64_t dim = 1,
+    double eps = 1e-12,
+    c10::optional<Tensor> out = c10::nullopt) {
+    if (out == c10::nullopt) {
+      auto denom = input.norm(p, dim, true).clamp_min(eps).expand_as(input);
+      return input / denom;
+    } else {
+      auto denom = input.norm(p, dim, true).clamp_min(eps).expand_as(input);
+      return torch::div_out(*out, input, denom);
+    }
+}
+} // namespace detail
+
 inline Tensor normalize(
     const Tensor& input,
     const NormalizeOptions& options = {},
     c10::optional<Tensor> out = c10::nullopt) {
-    if (out == c10::nullopt) {
-      auto denom = input.norm(options.p(), options.dim(), true).clamp_min(options.eps()).expand_as(input);
-      return input / denom;
-    } else {
-      auto denom = input.norm(options.p(), options.dim(), true).clamp_min(options.eps()).expand_as(input);
-      return torch::div_out(*out, input, denom);
-    }
+  return detail::normalize(input, options.p(), options.dim(), options.eps(), out);
 }
+
+// ============================================================================
+
+namespace detail {
+inline Tensor layer_norm(const Tensor& input,
+                         std::vector<int64_t> normalized_shape,
+                         const Tensor& weight = Tensor(),
+                         const Tensor& bias = Tensor(),
+                         double eps = 1e-5) {
+    return torch::layer_norm(input, normalized_shape, weight, bias, eps);
+}
+} // namespace detail
 
 inline Tensor layer_norm(const Tensor& input,
     const LayerNormOptions& options,
     const Tensor& weight = Tensor(),
     const Tensor& bias = Tensor()) {
-
-    return torch::layer_norm(input, options.normalized_shape(), weight, bias, options.eps());
+  return detail::layer_norm(input, options.normalized_shape(), weight, bias, options.eps());
 }
 
+// ============================================================================
+
+namespace detail {
 inline Tensor local_response_norm(
     const Tensor& input,
-    const LocalResponseNormOptions& options) {
+    int64_t size,
+    double alpha = 1e-4,
+    double beta = 0.75,
+    double k = 1.) {
     auto dim = input.dim();
     TORCH_CHECK(dim >=3, "Expected 3D or higher dimensionality input (got ", dim, " dimensions)");
     auto div = input.mul(input).unsqueeze(1);
     if (dim == 3) {
-      div = pad(div, PadOptions({0, 0, options.size() / 2, (options.size() - 1) / 2}));
-      div = avg_pool2d(div, AvgPool2dOptions({options.size(), 1}).stride(1)).squeeze(1);
+      div = detail::pad(div, /*pad=*/{0, 0, size / 2, (size - 1) / 2});
+      div = detail::avg_pool2d(div, /*kernel_size=*/{size, 1}, /*stride=*/1).squeeze(1);
     } else {
       auto sizes = input.sizes();
       div = div.view({sizes[0], 1, sizes[1], sizes[2], -1});
-      div = pad(div, PadOptions({0, 0, 0, 0, options.size() / 2, (options.size() - 1) / 2}));
-      div = avg_pool3d(div, AvgPool3dOptions({options.size(), 1, 1}).stride(1)).squeeze(1);
+      div = detail::pad(div, /*pad=*/{0, 0, 0, 0, size / 2, (size - 1) / 2});
+      div = detail::avg_pool3d(div, /*kernel_size=*/{size, 1, 1}, /*stride=*/1).squeeze(1);
       div = div.view(sizes);
     }
-    div = div.mul(options.alpha()).add(options.k()).pow(options.beta());
+    div = div.mul(alpha).add(k).pow(beta);
     return input / div;
+}
+} // namespace detail
+
+inline Tensor local_response_norm(
+    const Tensor& input,
+    const LocalResponseNormOptions& options) {
+  return detail::local_response_norm(input, options.size(), options.alpha(), options.beta(), options.k());
 }
 
 } // namespace functional

--- a/torch/csrc/api/include/torch/nn/functional/padding.h
+++ b/torch/csrc/api/include/torch/nn/functional/padding.h
@@ -27,47 +27,51 @@ inline Tensor _pad_circular(Tensor input, IntArrayRef padding) {
   return input;
 }
 
-inline Tensor pad(const Tensor& input, const PadOptions& options) {
-  TORCH_CHECK(options.pad().size() % 2 == 0, "Padding length must be divisible by 2");
-  TORCH_CHECK(((int64_t)(options.pad().size() / 2)) <= input.dim(), "Padding length too large");
-  if (c10::get_if<enumtype::kConstant>(&options.mode())) {
-    return torch::constant_pad_nd(input, options.pad(), options.value());
+namespace detail {
+inline Tensor pad(const Tensor& input,
+                  IntArrayRef pad,
+                  PadOptions::mode_t mode = torch::kConstant,
+                  double value = 0) {
+  TORCH_CHECK(pad.size() % 2 == 0, "Padding length must be divisible by 2");
+  TORCH_CHECK(((int64_t)(pad.size() / 2)) <= input.dim(), "Padding length too large");
+  if (c10::get_if<enumtype::kConstant>(&mode)) {
+    return torch::constant_pad_nd(input, pad, value);
   } else {
     TORCH_CHECK(
-      options.value() == 0,
+      value == 0,
       "Padding mode \"",
-      torch::enumtype::get_enum_name(options.mode()),
+      torch::enumtype::get_enum_name(mode),
       "\" doesn't take in value argument");
     if (input.dim() == 3) {
-      TORCH_CHECK(options.pad().size() == 2, "3D tensors expect 2 values for padding");
-      if (c10::get_if<enumtype::kReflect>(&options.mode())) {
-        return torch::reflection_pad1d(input, options.pad());
-      } else if (c10::get_if<enumtype::kReplicate>(&options.mode())) {
-        return torch::replication_pad1d(input, options.pad());
-      } else if (c10::get_if<enumtype::kCircular>(&options.mode())) {
-        return _pad_circular(input, options.pad());
+      TORCH_CHECK(pad.size() == 2, "3D tensors expect 2 values for padding");
+      if (c10::get_if<enumtype::kReflect>(&mode)) {
+        return torch::reflection_pad1d(input, pad);
+      } else if (c10::get_if<enumtype::kReplicate>(&mode)) {
+        return torch::replication_pad1d(input, pad);
+      } else if (c10::get_if<enumtype::kCircular>(&mode)) {
+        return _pad_circular(input, pad);
       } else {
         TORCH_CHECK(false, "NotImplementedError");
       }
     } else if (input.dim() == 4) {
-      TORCH_CHECK(options.pad().size() == 4, "4D tensors expect 4 values for padding");
-      if (c10::get_if<enumtype::kReflect>(&options.mode())) {
-        return torch::reflection_pad2d(input, options.pad());
-      } else if (c10::get_if<enumtype::kReplicate>(&options.mode())) {
-        return torch::replication_pad2d(input, options.pad());
-      } else if (c10::get_if<enumtype::kCircular>(&options.mode())) {
-        return _pad_circular(input, options.pad());
+      TORCH_CHECK(pad.size() == 4, "4D tensors expect 4 values for padding");
+      if (c10::get_if<enumtype::kReflect>(&mode)) {
+        return torch::reflection_pad2d(input, pad);
+      } else if (c10::get_if<enumtype::kReplicate>(&mode)) {
+        return torch::replication_pad2d(input, pad);
+      } else if (c10::get_if<enumtype::kCircular>(&mode)) {
+        return _pad_circular(input, pad);
       } else {
         TORCH_CHECK(false, "NotImplementedError");
       }
     } else if (input.dim() == 5) {
-      TORCH_CHECK(options.pad().size() == 6, "5D tensors expect 6 values for padding");
-      if (c10::get_if<enumtype::kReflect>(&options.mode())) {
+      TORCH_CHECK(pad.size() == 6, "5D tensors expect 6 values for padding");
+      if (c10::get_if<enumtype::kReflect>(&mode)) {
         TORCH_CHECK(false, "NotImplementedError");
-      } else if (c10::get_if<enumtype::kReplicate>(&options.mode())) {
-        return torch::replication_pad3d(input, options.pad());
-      } else if (c10::get_if<enumtype::kCircular>(&options.mode())) {
-        return _pad_circular(input, options.pad());
+      } else if (c10::get_if<enumtype::kReplicate>(&mode)) {
+        return torch::replication_pad3d(input, pad);
+      } else if (c10::get_if<enumtype::kCircular>(&mode)) {
+        return _pad_circular(input, pad);
       } else {
         TORCH_CHECK(false, "NotImplementedError");
       }
@@ -76,7 +80,13 @@ inline Tensor pad(const Tensor& input, const PadOptions& options) {
     }
   }
 }
+} // namespace detail
+
+inline Tensor pad(const Tensor& input, const PadOptions& options) {
+  return detail::pad(input, options.pad(), options.mode(), options.value());
+}
 
 } // namespace functional
 } // namespace nn
 } // namespace torch
+

--- a/torch/csrc/api/include/torch/nn/functional/padding.h
+++ b/torch/csrc/api/include/torch/nn/functional/padding.h
@@ -89,4 +89,3 @@ inline Tensor pad(const Tensor& input, const PadOptions& options) {
 } // namespace functional
 } // namespace nn
 } // namespace torch
-

--- a/torch/csrc/api/src/nn/modules/fold.cpp
+++ b/torch/csrc/api/src/nn/modules/fold.cpp
@@ -23,7 +23,13 @@ void FoldImpl::pretty_print(std::ostream& stream) const {
 }
 
 Tensor FoldImpl::forward(const Tensor& input) {
-  return F::fold(input, options);
+  return F::detail::fold(
+    input,
+    options.output_size(),
+    options.kernel_size(),
+    options.dilation(),
+    options.padding(),
+    options.stride());
 }
 
 // ============================================================================
@@ -41,7 +47,7 @@ void UnfoldImpl::pretty_print(std::ostream& stream) const {
 }
 
 Tensor UnfoldImpl::forward(const Tensor& input) {
-  return F::unfold(input, options);
+  return F::detail::unfold(input, options.kernel_size(), options.dilation(), options.padding(), options.stride());
 }
 
 } // namespace nn

--- a/torch/csrc/api/src/nn/modules/loss.cpp
+++ b/torch/csrc/api/src/nn/modules/loss.cpp
@@ -14,7 +14,7 @@ void L1LossImpl::pretty_print(std::ostream& stream) const {
 }
 
 Tensor L1LossImpl::forward(const Tensor& input, const Tensor& target) {
-  return F::l1_loss(input, target, options);
+  return F::detail::l1_loss(input, target, options.reduction());
 }
 
 // ============================================================================
@@ -29,7 +29,7 @@ void KLDivLossImpl::pretty_print(std::ostream& stream) const {
 }
 
 Tensor KLDivLossImpl::forward(const Tensor& input, const Tensor& target) {
-  return F::kl_div(input, target, options);
+  return F::detail::kl_div(input, target, options.reduction());
 }
 
 // ============================================================================
@@ -43,7 +43,7 @@ void MSELossImpl::pretty_print(std::ostream& stream) const {
 }
 
 Tensor MSELossImpl::forward(const Tensor& input, const Tensor& target) {
-  return F::mse_loss(input, target, options);
+  return F::detail::mse_loss(input, target, options.reduction());
 }
 
 // ============================================================================
@@ -61,7 +61,7 @@ void BCELossImpl::pretty_print(std::ostream& stream) const {
 }
 
 Tensor BCELossImpl::forward(const Tensor& input, const Tensor& target) {
-  return F::binary_cross_entropy(input, target, options);
+  return F::detail::binary_cross_entropy(input, target, options.weight(), options.reduction());
 }
 
 // ============================================================================
@@ -79,7 +79,7 @@ void HingeEmbeddingLossImpl::pretty_print(std::ostream& stream) const {
 Tensor HingeEmbeddingLossImpl::forward(
     const Tensor& input,
     const Tensor& target) {
-  return F::hinge_embedding_loss(input, target, options);
+  return F::detail::hinge_embedding_loss(input, target, options.margin(), options.reduction());
 }
 
 // ============================================================================
@@ -106,7 +106,7 @@ void MultiMarginLossImpl::pretty_print(std::ostream& stream) const {
 }
 
 Tensor MultiMarginLossImpl::forward(const Tensor& input, const Tensor& target) {
-  return F::multi_margin_loss(input, target, options);
+  return F::detail::multi_margin_loss(input, target, options.p(), options.margin(), options.weight(), options.reduction());
 }
 
 // ============================================================================
@@ -125,7 +125,7 @@ Tensor CosineEmbeddingLossImpl::forward(
     const Tensor& input1,
     const Tensor& input2,
     const Tensor& target) {
-  return F::cosine_embedding_loss(input1, input2, target, options);
+  return F::detail::cosine_embedding_loss(input1, input2, target, options.margin(), options.reduction());
 }
 // ============================================================================
 
@@ -146,7 +146,7 @@ void MultiLabelSoftMarginLossImpl::reset() {
 Tensor MultiLabelSoftMarginLossImpl::forward(
     const Tensor& input,
     const Tensor& target) {
-  return F::multilabel_soft_margin_loss(input, target, options);
+  return F::detail::multilabel_soft_margin_loss(input, target, options.weight(), options.reduction());
 }
 
 // ============================================================================
@@ -167,7 +167,15 @@ Tensor TripletMarginLossImpl::forward(
     const Tensor& anchor,
     const Tensor& positive,
     const Tensor& negative) {
-  return F::triplet_margin_loss(anchor, positive, negative, options);
+  return F::detail::triplet_margin_loss(
+    anchor,
+    positive,
+    negative,
+    options.margin(),
+    options.p(),
+    options.eps(),
+    options.swap(),
+    options.reduction());
 }
 
 // ============================================================================
@@ -183,7 +191,7 @@ void MultiLabelMarginLossImpl::pretty_print(std::ostream& stream) const {
 }
 
 Tensor MultiLabelMarginLossImpl::forward(const Tensor& input, const Tensor& target) {
-  return F::multilabel_margin_loss(input, target, options);
+  return F::detail::multilabel_margin_loss(input, target, options.reduction());
 }
 
 // ============================================================================
@@ -198,7 +206,7 @@ void SoftMarginLossImpl::pretty_print(std::ostream& stream) const {
 }
 
 Tensor SoftMarginLossImpl::forward(const Tensor& input, const Tensor& target) {
-  return F::soft_margin_loss(input, target, options);
+  return F::detail::soft_margin_loss(input, target, options.reduction());
 }
 
 // ============================================================================
@@ -213,7 +221,7 @@ void SmoothL1LossImpl::pretty_print(std::ostream& stream) const {
 }
 
 Tensor SmoothL1LossImpl::forward(const Tensor& input, const Tensor& target) {
-  return F::smooth_l1_loss(input, target, options);
+  return F::detail::smooth_l1_loss(input, target, options.reduction());
 }
   
 // ============================================================================
@@ -228,7 +236,14 @@ void CTCLossImpl::pretty_print(std::ostream& stream) const {
 
 Tensor CTCLossImpl::forward(const Tensor& log_probs, const Tensor& targets,
                  const Tensor& input_lengths, const Tensor& target_lengths) {
-  return F::ctc_loss(log_probs, targets, input_lengths, target_lengths, options);
+  return F::detail::ctc_loss(
+    log_probs,
+    targets,
+    input_lengths,
+    target_lengths,
+    options.blank(),
+    options.reduction(),
+    options.zero_infinity());
 }
 
 // ============================================================================
@@ -244,7 +259,9 @@ void PoissonNLLLossImpl::pretty_print(std::ostream& stream) const {
 
 Tensor PoissonNLLLossImpl::forward(
   const Tensor& log_input, const Tensor& target) {
-  return F::poisson_nll_loss(log_input, target, options);
+  return F::detail::poisson_nll_loss(
+    log_input, target,
+    options.log_input(), options.full(), options.eps(), options.reduction());
 }
 
 // ============================================================================
@@ -260,7 +277,7 @@ void MarginRankingLossImpl::pretty_print(std::ostream& stream) const {
 
 Tensor MarginRankingLossImpl::forward(const Tensor& input1,
     const Tensor& input2, const Tensor& target) {
-  return F::margin_ranking_loss(input1, input2, target, options);
+  return F::detail::margin_ranking_loss(input1, input2, target, options.margin(), options.reduction());
 }
 
 } // namespace nn

--- a/torch/csrc/api/src/nn/modules/normalization.cpp
+++ b/torch/csrc/api/src/nn/modules/normalization.cpp
@@ -39,7 +39,7 @@ void LayerNormImpl::pretty_print(std::ostream& stream) const {
 }
 
 torch::Tensor LayerNormImpl::forward(const Tensor& input) {
-  return F::layer_norm(input, options, weight, bias);
+  return F::detail::layer_norm(input, options.normalized_shape(), weight, bias, options.eps());
 }
 
 // ============================================================================
@@ -48,7 +48,7 @@ LocalResponseNormImpl::LocalResponseNormImpl(const LocalResponseNormOptions& opt
     : options(options_) {}
 
 Tensor LocalResponseNormImpl::forward(const Tensor& input) {
-  return F::local_response_norm(input, options);
+  return F::detail::local_response_norm(input, options.size(), options.alpha(), options.beta(), options.k());
 }
 
 void LocalResponseNormImpl::reset() {}

--- a/torch/csrc/api/src/nn/modules/padding.cpp
+++ b/torch/csrc/api/src/nn/modules/padding.cpp
@@ -16,7 +16,7 @@ void ReflectionPadImpl<D, Derived>::reset() {}
 
 template <size_t D, typename Derived>
 Tensor ReflectionPadImpl<D, Derived>::forward(const Tensor& input) {
-  return F::pad(input, PadOptions(at::ArrayRef<int64_t>(options.padding()).vec()).mode(torch::kReflect));
+  return F::detail::pad(input, options.padding(), torch::kReflect);
 }
 
 template <size_t D, typename Derived>
@@ -39,7 +39,7 @@ void ReplicationPadImpl<D, Derived>::reset() {}
 
 template <size_t D, typename Derived>
 Tensor ReplicationPadImpl<D, Derived>::forward(const Tensor& input) {
-  return F::pad(input, PadOptions(at::ArrayRef<int64_t>(options.padding()).vec()).mode(torch::kReplicate));
+  return F::detail::pad(input, options.padding(), torch::kReplicate);
 }
 
 template <size_t D, typename Derived>
@@ -65,7 +65,7 @@ void ZeroPad2dImpl::pretty_print(std::ostream& stream) const {
 }
 
 Tensor ZeroPad2dImpl::forward(const Tensor& input) {
-  return F::pad(input, PadOptions(at::ArrayRef<int64_t>(options.padding()).vec()).mode(torch::kConstant).value(0));
+  return F::detail::pad(input, options.padding(), torch::kConstant, 0);
 }
 
 // ============================================================================
@@ -79,7 +79,7 @@ void ConstantPadImpl<D, Derived>::reset() {}
 
 template <size_t D, typename Derived>
 Tensor ConstantPadImpl<D, Derived>::forward(const Tensor& input) {
-  return F::pad(input, PadOptions(at::ArrayRef<int64_t>(options.padding()).vec()).mode(torch::kConstant).value(options.value()));
+  return F::detail::pad(input, options.padding(), torch::kConstant, options.value());
 }
 
 template <size_t D, typename Derived>


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#29360 Add functional overloads for fold, linear, loss, normalization, padding**
* #29359 Add functional overloads for pixelshuffle, pooling, upsampling, vision
* #29358 Add functional overloads for activation, batchnorm, distance, embedding

This PR adds functional overloads that take the full set of arguments (instead of just Options) for the following functionals:
- fold
- linear
- loss
- normalization
- padding

These new functionals lives in the `torch::nn::functional::detail` namespace and they are only meant to be called from the module forward methods (i.e. they are not public API). This is in preparation for the future change where we make module Options and functional Options two different classes, because if the module forward method has to construct a new functional Options object every time it runs it will be pretty silly and bad performance.

Differential Revision: [D18376975](https://our.internmc.facebook.com/intern/diff/D18376975)