### PR TITLE
Skip _batch_norm_impl_index and _batch_norm_impl_index_backward in BC check

### DIFF
--- a/test/backward_compatibility/check_backward_compatibility.py
+++ b/test/backward_compatibility/check_backward_compatibility.py
@@ -27,6 +27,8 @@ white_list = [
     ('ones_like', datetime.date(2019, 11, 11)),
     ('full_like', datetime.date(2019, 11, 11)),
     ('AutogradAnyNonZero', datetime.date(2019, 11, 11)),
+    ('_batch_norm_impl_index', datetime.date(2019, 11, 11)),
+    ('_batch_norm_impl_index_backward', datetime.date(2019, 11, 11)),
 ]
 
 


### PR DESCRIPTION
to unbreak the CI
