### PR TITLE
Declare Dimname's kWildcard as extern instead of static

### DIFF
--- a/aten/src/ATen/core/Dimname.cpp
+++ b/aten/src/ATen/core/Dimname.cpp
@@ -6,6 +6,8 @@
 #ifdef BUILD_NAMEDTENSOR
 namespace at {
 
+Symbol kWildcard = Symbol::dimname("*");
+
 std::ostream& operator<<(std::ostream& out, const Dimname& dimname) {
   if (dimname.type() == NameType::WILDCARD) {
     out << "None";

--- a/aten/src/ATen/core/Dimname.cpp
+++ b/aten/src/ATen/core/Dimname.cpp
@@ -6,7 +6,7 @@
 #ifdef BUILD_NAMEDTENSOR
 namespace at {
 
-Symbol kWildcard = Symbol::dimname("*");
+static Symbol kWildcard = Symbol::dimname("*");
 
 std::ostream& operator<<(std::ostream& out, const Dimname& dimname) {
   if (dimname.type() == NameType::WILDCARD) {

--- a/aten/src/ATen/core/Dimname.h
+++ b/aten/src/ATen/core/Dimname.h
@@ -37,8 +37,6 @@ struct CAFFE2_API Dimname {
 
 using DimnameList = c10::ArrayRef<Dimname>;
 
-extern Symbol kWildcard;
-
 CAFFE2_API std::ostream& operator<<(std::ostream& out, const Dimname& dimname);
 
 inline bool operator==(const Dimname& lhs, const Dimname& rhs) {

--- a/aten/src/ATen/core/Dimname.h
+++ b/aten/src/ATen/core/Dimname.h
@@ -37,7 +37,7 @@ struct CAFFE2_API Dimname {
 
 using DimnameList = c10::ArrayRef<Dimname>;
 
-static Symbol kWildcard = Symbol::dimname("*");
+extern Symbol kWildcard;
 
 CAFFE2_API std::ostream& operator<<(std::ostream& out, const Dimname& dimname);
 


### PR DESCRIPTION
Fixes #27627

The variable being declared in a header as `static` meant that the global variable is initialized in every source file that includes it. This is particularly problematic when included in AVX source files as it generates SIGILL on older hardware.

