### PR TITLE
explicitly provide memory format when calling to *_like operators

### DIFF
--- a/aten/src/ATen/native/Distance.cpp
+++ b/aten/src/ATen/native/Distance.cpp
@@ -129,7 +129,7 @@ Tensor _cdist_backward(const Tensor& grad, const Tensor& x1, const Tensor& x2, c
   TORCH_CHECK(device2 == kCPU || device2 == kCUDA, "_cdist_backward only supports CPU and CUDA devices, X2 got: ", device2);
   IntArrayRef batch_tensor1(x1.sizes().data(), std::max<int64_t>(x1.dim() - 2, 0));
   int batch_product = std::accumulate(batch_tensor1.begin(), batch_tensor1.end(), 1, std::multiplies<int64_t>());
-  Tensor grad_x1 = at::empty_like(x1, x1.options()).view({batch_product, n, m});
+  Tensor grad_x1 = at::empty_like(x1, x1.options(), LEGACY_CONTIGUOUS_MEMORY_FORMAT).view({batch_product, n, m});
   cdist_backward_stub(device1, grad_x1, grad, x1, x2, p, cdist);
   return grad_x1;
 }

--- a/aten/src/ATen/native/TensorIterator.cpp
+++ b/aten/src/ATen/native/TensorIterator.cpp
@@ -157,7 +157,7 @@ static void maybe_copy_casting_to_common_dtype(OperandInfo& op, ScalarType commo
       op.tensor = op.tensor.to(common_dtype);
     } else {
       op.tensor =
-          at::empty_like(op.tensor, op.tensor.options().dtype(common_dtype));
+          at::empty_like(op.tensor, op.tensor.options().dtype(common_dtype), LEGACY_CONTIGUOUS_MEMORY_FORMAT);
     }
   }
 }

--- a/aten/src/ATen/native/cuda/Copy.cu
+++ b/aten/src/ATen/native/cuda/Copy.cu
@@ -136,7 +136,7 @@ static void copy_kernel_cuda(TensorIterator& iter, bool non_blocking) {
       src_contig = iter.tensor(1).to(iter.dtype(0)).expand_as(dst).contiguous();
     } else {
       bool same_type = iter.dtype(0) == iter.dtype(1);
-      dst_contig = (dst.is_contiguous() && same_type) ? dst : at::empty_like(dst, iter.dtype(1));
+      dst_contig = (dst.is_contiguous() && same_type) ? dst : at::empty_like(dst, iter.dtype(1), LEGACY_CONTIGUOUS_MEMORY_FORMAT);
       src_contig = iter.tensor(1).expand_as(dst).contiguous();
     }
 

--- a/aten/src/ATen/native/cuda/MultinomialKernel.cu
+++ b/aten/src/ATen/native/cuda/MultinomialKernel.cu
@@ -398,12 +398,12 @@ void multinomial_kernel_impl(Tensor& result, const Tensor& self, const int64_t n
 
       // For sampling without replacement, we modify the distribution
       // for subsequent samples in this space
-      Tensor origDist = native::empty_like(self_v);
+      Tensor origDist = native::empty_like(self_v, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
       origDist.copy_(self_v);
 
-      Tensor normDist = native::empty_like(self_v);
+      Tensor normDist = native::empty_like(self_v, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
 
-      Tensor prefixSum = native::empty_like(self_v);
+      Tensor prefixSum = native::empty_like(self_v, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
 
       // Renorm along rows
       normDist.copy_(origDist);

--- a/aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp
@@ -100,7 +100,7 @@ class QLinearDynamicInt8 final : public torch::OperatorKernel {
     out_sizes.back() = N;
     // Allocate output Tensor and a buffer for fbgemmPacked to use
     auto output = at::empty(out_sizes, input.options().dtype(at::kFloat));
-    auto buffer = at::empty_like(output, output.options().dtype(at::kInt));
+    auto buffer = at::empty_like(output, output.options().dtype(at::kInt), LEGACY_CONTIGUOUS_MEMORY_FORMAT);
 
     int num_tasks = at::get_num_threads();
     at::parallel_for(0, num_tasks, 1, [&](int64_t begin, int64_t end) {

--- a/aten/src/ATen/native/sparse/cuda/SparseCUDATensorMath.cu
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDATensorMath.cu
@@ -629,7 +629,7 @@ Tensor _sparse_sum_backward_cuda(const Tensor& grad_, const SparseTensor& input_
       auto policy = thrust::cuda::par(allocator).on(stream);
       typedef thrust::device_ptr<int64_t> thrust_ptr;
 
-      grad_input_values = at::empty_like(input_values, grad_values.options());
+      grad_input_values = at::empty_like(input_values, grad_values.options(), LEGACY_CONTIGUOUS_MEMORY_FORMAT);
       AT_ASSERT(grad_input_values.is_cuda());
 
       // get 1D indices
@@ -642,7 +642,7 @@ Tensor _sparse_sum_backward_cuda(const Tensor& grad_, const SparseTensor& input_
       thrust_ptr input_indices_iter(input_indices_1D.data_ptr<int64_t>());
 
       // store lower_bound of input indices at grad indices
-      LongTensor input_indices_pos = at::empty_like(input_indices_1D);
+      LongTensor input_indices_pos = at::empty_like(input_indices_1D, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
       thrust_ptr input_indices_pos_iter(input_indices_pos.data_ptr<int64_t>());
       thrust::lower_bound(policy,
                           grad_indices_iter, grad_indices_iter + grad_nnz,

--- a/c10/core/MemoryFormat.h
+++ b/c10/core/MemoryFormat.h
@@ -26,6 +26,12 @@
 namespace c10 {
 enum class MemoryFormat : int8_t { Contiguous, Preserve, ChannelsLast };
 
+#define LEGACY_CONTIGUOUS_MEMORY_FORMAT get_contiguous_memory_format()
+
+inline MemoryFormat C10_DEPRECATED_MESSAGE('This call site was not checked, and was switched to old default behaviour') get_contiguous_memory_format() {
+  return MemoryFormat::Contiguous;
+}
+
 inline std::ostream& operator<<(
     std::ostream& stream,
     at::MemoryFormat memory_format) {

--- a/c10/core/MemoryFormat.h
+++ b/c10/core/MemoryFormat.h
@@ -31,7 +31,7 @@ enum class MemoryFormat : int8_t { Contiguous, Preserve, ChannelsLast };
 // behaviour of contiguous
 #define LEGACY_CONTIGUOUS_MEMORY_FORMAT get_contiguous_memory_format()
 
-C10_DEPRECATED_MESSAGE('This call site was not checked, and was switched to old default behaviour') inline MemoryFormat get_contiguous_memory_format() {
+C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
   return MemoryFormat::Contiguous;
 }
 

--- a/c10/core/MemoryFormat.h
+++ b/c10/core/MemoryFormat.h
@@ -31,7 +31,7 @@ enum class MemoryFormat : int8_t { Contiguous, Preserve, ChannelsLast };
 // behaviour of contiguous
 #define LEGACY_CONTIGUOUS_MEMORY_FORMAT get_contiguous_memory_format()
 
-inline MemoryFormat C10_DEPRECATED_MESSAGE('This call site was not checked, and was switched to old default behaviour') get_contiguous_memory_format() {
+C10_DEPRECATED_MESSAGE('This call site was not checked, and was switched to old default behaviour') inline MemoryFormat get_contiguous_memory_format() {
   return MemoryFormat::Contiguous;
 }
 

--- a/c10/core/MemoryFormat.h
+++ b/c10/core/MemoryFormat.h
@@ -26,6 +26,9 @@
 namespace c10 {
 enum class MemoryFormat : int8_t { Contiguous, Preserve, ChannelsLast };
 
+// If you are seeing this, it means that this call site was not checked if
+// the memory format could be preserved, and it was switched to old default
+// behaviour of contiguous
 #define LEGACY_CONTIGUOUS_MEMORY_FORMAT get_contiguous_memory_format()
 
 inline MemoryFormat C10_DEPRECATED_MESSAGE('This call site was not checked, and was switched to old default behaviour') get_contiguous_memory_format() {

--- a/c10/core/MemoryFormat.h
+++ b/c10/core/MemoryFormat.h
@@ -29,7 +29,7 @@ enum class MemoryFormat : int8_t { Contiguous, Preserve, ChannelsLast };
 // If you are seeing this, it means that this call site was not checked if
 // the memory format could be preserved, and it was switched to old default
 // behaviour of contiguous
-#define LEGACY_CONTIGUOUS_MEMORY_FORMAT get_contiguous_memory_format()
+#define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
 
 C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
   return MemoryFormat::Contiguous;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #29452 [WIP] switch defaults
* #29451 explicitly provide memory format when calling to *_like operators (Redo of 81bf73643b6552a63794fb889238aaf0c2a7baa6)
* #29450 explicitly provide memory format when calling to *_like operators (Redo of cc1c0120bc86b049bba36f2ff19a4f7b00e8e841)
* #29449 explicitly provide memory format when calling to *_like operators (Redo of e3e06549c196d4c6128d8cf3916037fdd386800e)
* #29448 explicitly provide memory format when calling to *_like operators (Redo of 4b4aa20399fb4c762fb6d2395b39f0f794f9f322)
* #29447 explicitly provide memory format when calling to *_like operators (Redo of ce438f6967)
* #29446 explicitly provide memory format when calling to *_like operators (Redo of 631b22dbed219dedecb66e483383bfdd43f486c4)
* #29392 explicitly provide memory format when calling to *_like operators
* #29391 explicitly provide memory format when calling to *_like operators
* #29390 explicitly provide memory format when calling to *_like operators
* #29389 explicitly provide memory format when calling to *_like operators
* #29388 explicitly provide memory format when calling to *_like operators
* #29387 explicitly provide memory format when calling to *_like operators
* **#29386 explicitly provide memory format when calling to *_like operators**

Differential Revision: [D18429727](https://our.internmc.facebook.com/intern/diff/D18429727)