### PR TITLE
explicitly provide memory format when calling to *_like operators

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -342,3 +342,8 @@ from torch._classes import classes
 
 # Import the quasi random sampler
 import torch.quasirandom
+
+# If you are seeing this, it means that this call site was not checked if
+# the memory format could be preserved, and it was switched to old default
+# behaviour of contiguous
+legacy_contiguous_format = contiguous_format

--- a/torch/autograd/gradcheck.py
+++ b/torch/autograd/gradcheck.py
@@ -142,7 +142,7 @@ def get_analytical_jacobian(input, output, nondet_tol=0.0):
     diff_input_list = list(iter_tensors(input, True))
     jacobian = make_jacobian(input, output.numel())
     jacobian_reentrant = make_jacobian(input, output.numel())
-    grad_output = torch.zeros_like(output)
+    grad_output = torch.zeros_like(output, memory_format=torch.contiguous_format)
     flat_grad_output = grad_output.view(-1)
     reentrant = True
     correct_grad_sizes = True
@@ -300,7 +300,7 @@ def gradcheck(func, inputs, eps=1e-6, atol=1e-5, rtol=1e-3, raise_exception=True
         diff_input_list = list(iter_tensors(tupled_inputs, True))
         if not diff_input_list:
             raise RuntimeError("no Tensors requiring grad found in input")
-        grads_input = torch.autograd.grad(output, diff_input_list, [torch.zeros_like(o) for o in output],
+        grads_input = torch.autograd.grad(output, diff_input_list, [torch.zeros_like(o, memory_format=torch.contiguous_format) for o in output],
                                           allow_unused=True)
         for gi, i in zip(grads_input, diff_input_list):
             if gi is None:
@@ -381,7 +381,7 @@ def gradgradcheck(func, inputs, grad_outputs=None, eps=1e-6, atol=1e-5, rtol=1e-
         # If grad_outputs is not specified, create random Tensors of the same
         # shape, type, and device as the outputs
         def randn_like(x):
-            y = torch.testing.randn_like(x if x.is_floating_point() else x.double())
+            y = torch.testing.randn_like(x if x.is_floating_point() else x.double(), memory_format=torch.contiguous_format)
             if gen_non_contig_grad_outputs:
                 y = torch.testing.make_non_contiguous(y)
             return y.requires_grad_()

--- a/torch/autograd/gradcheck.py
+++ b/torch/autograd/gradcheck.py
@@ -142,7 +142,7 @@ def get_analytical_jacobian(input, output, nondet_tol=0.0):
     diff_input_list = list(iter_tensors(input, True))
     jacobian = make_jacobian(input, output.numel())
     jacobian_reentrant = make_jacobian(input, output.numel())
-    grad_output = torch.zeros_like(output, memory_format=torch.contiguous_format)
+    grad_output = torch.zeros_like(output, memory_format=torch.legacy_contiguous_format)
     flat_grad_output = grad_output.view(-1)
     reentrant = True
     correct_grad_sizes = True
@@ -300,7 +300,7 @@ def gradcheck(func, inputs, eps=1e-6, atol=1e-5, rtol=1e-3, raise_exception=True
         diff_input_list = list(iter_tensors(tupled_inputs, True))
         if not diff_input_list:
             raise RuntimeError("no Tensors requiring grad found in input")
-        grads_input = torch.autograd.grad(output, diff_input_list, [torch.zeros_like(o, memory_format=torch.contiguous_format) for o in output],
+        grads_input = torch.autograd.grad(output, diff_input_list, [torch.zeros_like(o, memory_format=torch.legacy_contiguous_format) for o in output],
                                           allow_unused=True)
         for gi, i in zip(grads_input, diff_input_list):
             if gi is None:
@@ -381,7 +381,7 @@ def gradgradcheck(func, inputs, grad_outputs=None, eps=1e-6, atol=1e-5, rtol=1e-
         # If grad_outputs is not specified, create random Tensors of the same
         # shape, type, and device as the outputs
         def randn_like(x):
-            y = torch.testing.randn_like(x if x.is_floating_point() else x.double(), memory_format=torch.contiguous_format)
+            y = torch.testing.randn_like(x if x.is_floating_point() else x.double(), memory_format=torch.legacy_contiguous_format)
             if gen_non_contig_grad_outputs:
                 y = torch.testing.make_non_contiguous(y)
             return y.requires_grad_()

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -264,7 +264,7 @@ def isfinite(tensor):
     # have a similar concept. It's safe to assume any created LongTensor doesn't
     # overflow and it's finite.
     if not tensor.is_floating_point():
-        return torch.ones_like(tensor, dtype=torch.bool)
+        return torch.ones_like(tensor, dtype=torch.bool, memory_format=torch.contiguous_format)
     return (tensor == tensor) & (tensor.abs() != inf)
 
 
@@ -285,7 +285,7 @@ def isinf(tensor):
     if not isinstance(tensor, torch.Tensor):
         raise TypeError("The argument is not a tensor: {}".format(repr(tensor)))
     if tensor.dtype in [torch.uint8, torch.int8, torch.int16, torch.int32, torch.int64]:
-        return torch.zeros_like(tensor, dtype=torch.bool)
+        return torch.zeros_like(tensor, dtype=torch.bool, memory_format=torch.contiguous_format)
     return tensor.abs() == inf
 
 

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -264,7 +264,7 @@ def isfinite(tensor):
     # have a similar concept. It's safe to assume any created LongTensor doesn't
     # overflow and it's finite.
     if not tensor.is_floating_point():
-        return torch.ones_like(tensor, dtype=torch.bool, memory_format=torch.contiguous_format)
+        return torch.ones_like(tensor, dtype=torch.bool, memory_format=torch.legacy_contiguous_format)
     return (tensor == tensor) & (tensor.abs() != inf)
 
 
@@ -285,7 +285,7 @@ def isinf(tensor):
     if not isinstance(tensor, torch.Tensor):
         raise TypeError("The argument is not a tensor: {}".format(repr(tensor)))
     if tensor.dtype in [torch.uint8, torch.int8, torch.int16, torch.int32, torch.int64]:
-        return torch.zeros_like(tensor, dtype=torch.bool, memory_format=torch.contiguous_format)
+        return torch.zeros_like(tensor, dtype=torch.bool, memory_format=torch.legacy_contiguous_format)
     return tensor.abs() == inf
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #29452 [WIP] switch defaults
* #29451 explicitly provide memory format when calling to *_like operators (Redo of 81bf73643b6552a63794fb889238aaf0c2a7baa6)
* #29450 explicitly provide memory format when calling to *_like operators (Redo of cc1c0120bc86b049bba36f2ff19a4f7b00e8e841)
* #29449 explicitly provide memory format when calling to *_like operators (Redo of e3e06549c196d4c6128d8cf3916037fdd386800e)
* #29448 explicitly provide memory format when calling to *_like operators (Redo of 4b4aa20399fb4c762fb6d2395b39f0f794f9f322)
* #29447 explicitly provide memory format when calling to *_like operators (Redo of ce438f6967)
* #29446 explicitly provide memory format when calling to *_like operators (Redo of 631b22dbed219dedecb66e483383bfdd43f486c4)
* #29392 explicitly provide memory format when calling to *_like operators
* #29391 explicitly provide memory format when calling to *_like operators
* #29390 explicitly provide memory format when calling to *_like operators
* #29389 explicitly provide memory format when calling to *_like operators
* #29388 explicitly provide memory format when calling to *_like operators
* **#29387 explicitly provide memory format when calling to *_like operators**
* #29386 explicitly provide memory format when calling to *_like operators

Differential Revision: [D18429729](https://our.internmc.facebook.com/intern/diff/D18429729)