### PR TITLE
Revert RRef.to_here()/local_value() return type

### DIFF
--- a/test/rpc_test.py
+++ b/test/rpc_test.py
@@ -85,7 +85,7 @@ class MyClass:
 
 
 def _call_method_on_rref(method, rref, *args, **kwargs):
-    return method(rref.local_value().wait(), *args, **kwargs)
+    return method(rref.local_value(), *args, **kwargs)
 
 
 def run_nested_pickle(pickle_cls_instance, tensor):
@@ -120,7 +120,7 @@ def my_complex_tensor_function(list_input, tensor_class_input, dict_input):
 
 
 def my_rref_function(rref_a, rref_b):
-    return rref_a.to_here().wait() + rref_b.to_here().wait()
+    return rref_a.to_here() + rref_b.to_here()
 
 
 def no_result():
@@ -154,7 +154,7 @@ def nested_rref(dst):
 
 def nested_remote(dst):
     rref = rpc.remote(dst, torch.add, args=(torch.ones(2, 2), 3))
-    return rref.to_here().wait()
+    return rref.to_here()
 
 
 def rref_forward_chain(dst, world_size, rref, ttl):
@@ -166,7 +166,7 @@ def rref_forward_chain(dst, world_size, rref, ttl):
         )
         return [ret_rref]
     else:
-        return rref.to_here().wait()
+        return rref.to_here()
 
 
 def rpc_return_rref(dst):
@@ -687,7 +687,7 @@ class RpcTest(object):
             torch.add,
             args=(torch.ones(n, n), torch.ones(n, n)),
         )
-        self.assertEqual(rref.to_here().wait(), torch.ones(n, n) * 2)
+        self.assertEqual(rref.to_here(), torch.ones(n, n) * 2)
 
     @dist_init
     def test_asymmetric_load_with_join(self):
@@ -741,7 +741,7 @@ class RpcTest(object):
             expected.append(fn(*args_fn(n), **kwargs_fn(n)))
 
         for i in range(m):
-            self.assertEqual(rrefs[i].to_here().wait(), expected[i])
+            self.assertEqual(rrefs[i].to_here(), expected[i])
 
     @dist_init
     def test_multi_builtin_remote_ret(self):
@@ -759,7 +759,7 @@ class RpcTest(object):
             my_function,
             kwargs={"a": n, "b": n + 1, "c": n + 2},
         )
-        self.assertEqual(rref.to_here().wait(), my_function(n, n + 1, n + 2))
+        self.assertEqual(rref.to_here(), my_function(n, n + 1, n + 2))
 
     @unittest.skip("Test is flaky, see https://github.com/pytorch/pytorch/issues/29156")
     @dist_init
@@ -782,7 +782,7 @@ class RpcTest(object):
         rref_c = rpc.remote(
             "worker{}".format(dst_rank), my_rref_function, args=(rref_a, rref_b)
         )
-        self.assertEqual(rref_c.to_here().wait(), torch.ones(n, n) + 4)
+        self.assertEqual(rref_c.to_here(), torch.ones(n, n) + 4)
 
     @unittest.skip("Test is flaky, see https://github.com/pytorch/pytorch/issues/29212")
     @dist_init
@@ -799,7 +799,7 @@ class RpcTest(object):
         rref_c = rpc.remote(
             "worker{}".format(user_rank), my_rref_function, args=(rref_a, rref_b)
         )
-        self.assertEqual(rref_c.to_here().wait(), torch.ones(n, n) + 4)
+        self.assertEqual(rref_c.to_here(), torch.ones(n, n) + 4)
 
     @dist_init
     def test_py_rpc_rref_args(self):
@@ -829,7 +829,7 @@ class RpcTest(object):
             nested_remote,
             args=("worker{}".format(dst_rank2),),
         )
-        self.assertEqual(rref.to_here().wait(), torch.ones(2, 2) + 3)
+        self.assertEqual(rref.to_here(), torch.ones(2, 2) + 3)
 
     @dist_init
     def test_nested_rref(self):
@@ -841,10 +841,10 @@ class RpcTest(object):
             nested_rref,
             args=("worker{}".format(dst_rank2),),
         )
-        rrefs = rref_of_rrefs.to_here().wait()
+        rrefs = rref_of_rrefs.to_here()
         self.assertEqual(len(rrefs), 2)
-        self.assertEqual(rrefs[0].to_here().wait(), torch.ones(2, 2) + 1)
-        self.assertEqual(rrefs[1].to_here().wait(), torch.ones(2, 2) + 2)
+        self.assertEqual(rrefs[0].to_here(), torch.ones(2, 2) + 1)
+        self.assertEqual(rrefs[1].to_here(), torch.ones(2, 2) + 2)
 
     @dist_init
     def test_nested_rref_stress(self):
@@ -863,10 +863,10 @@ class RpcTest(object):
 
         for i in range(20):
             rref_of_rrefs = all_rrefs[i]
-            rrefs = rref_of_rrefs.to_here().wait()
+            rrefs = rref_of_rrefs.to_here()
             self.assertEqual(len(rrefs), 2)
-            self.assertEqual(rrefs[0].to_here().wait(), torch.ones(2, 2) + 1)
-            self.assertEqual(rrefs[1].to_here().wait(), torch.ones(2, 2) + 2)
+            self.assertEqual(rrefs[0].to_here(), torch.ones(2, 2) + 1)
+            self.assertEqual(rrefs[1].to_here(), torch.ones(2, 2) + 2)
 
     @dist_init
     def test_multi_layer_nested_async_rpc(self):
@@ -886,7 +886,7 @@ class RpcTest(object):
         dst_rank = n % self.world_size
         rref = rpc.remote("worker{}".format(dst_rank), raise_func)
         with self.assertRaisesRegex(Exception, "ValueError"):
-            rref.to_here().wait()
+            rref.to_here()
 
     @dist_init
     def test_rpc_return_rref(self):
@@ -898,7 +898,7 @@ class RpcTest(object):
             rpc_return_rref,
             args=("worker{}".format(dst_rank2),),
         )
-        self.assertEqual(rref.to_here().wait(), torch.ones(2, 2) + 1)
+        self.assertEqual(rref.to_here(), torch.ones(2, 2) + 1)
 
     @dist_init
     def test_rref_forward_chain(self):
@@ -914,7 +914,7 @@ class RpcTest(object):
 
         for i in range(ttl):
             self.assertEqual(len(ret_rref), 1)
-            ret_rref = ret_rref[0].to_here().wait()
+            ret_rref = ret_rref[0].to_here()
 
         ret = ret_rref
         self.assertEqual(ret, torch.add(torch.ones(n, n), 1))
@@ -932,7 +932,7 @@ class RpcTest(object):
         rref_c = rpc.remote(
             "worker{}".format(dst_rank), my_rref_function, args=(rref_a, rref_b)
         )
-        self.assertEqual(rref_c.to_here().wait(), torch.ones(n, n) + 4)
+        self.assertEqual(rref_c.to_here(), torch.ones(n, n) + 4)
 
     @unittest.skip("Test is flaky on ASAN, see https://github.com/pytorch/pytorch/issues/29117")
     @dist_init(setup_model_parallel=True)
@@ -954,7 +954,7 @@ class RpcTest(object):
         rpc.rpc_async(rref.owner(), _call_method_on_rref, args=(
             MyClass.increment_value, rref, vals[2])).wait()
         rpc.remote(rref.owner(), _call_method_on_rref, args=(
-            MyClass.increment_value, rref, vals[3])).to_here().wait()
+            MyClass.increment_value, rref, vals[3])).to_here()
 
         # queries state of the remote object
         result = rpc.rpc_sync(dst_worker, _call_method_on_rref, args=(

--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -46,12 +46,6 @@ PyObject* rpc_init(PyObject* /* unused */) {
               &RpcAgent::sync,
               py::call_guard<py::gil_scoped_release>());
 
-  auto pyFuture = shared_ptr_class_<PyFuture>(module, "Future")
-                      .def(
-                          "wait",
-                          &PyFuture::wait,
-                          py::call_guard<py::gil_scoped_release>());
-
   auto pyRRef =
       shared_ptr_class_<PyRRef>(module, "RRef")
           .def(

--- a/torch/csrc/distributed/rpc/py_rref.cpp
+++ b/torch/csrc/distributed/rpc/py_rref.cpp
@@ -23,65 +23,6 @@ constexpr int RREF_TUPLE_SIZE = 2;
 
 } // namespace
 
-//////////////////////////  PyFutureToHere  /////////////////////////////////
-
-template <typename T>
-PyFutureToHere<T>::PyFutureToHere(std::shared_ptr<ivalue::Future> future)
-    : future_(std::move(future)) {}
-
-template <>
-py::object PyFutureToHere<IValue>::wait() const {
-  future_->wait();
-  {
-    // acquiring GIL as torch::jit::toPyObject creates new py::object
-    // without grabbing the GIL.
-    AutoGIL ag;
-    return torch::jit::toPyObject(future_->value());
-  }
-}
-
-template <>
-py::object PyFutureToHere<py::object>::wait() const {
-  future_->wait();
-  // PythonRpcHandler acquires the GIL on creating the py::object
-  return PythonRpcHandler::getInstance().deserialize(
-      SerializedPyObj::fromIValues(future_->value().toTuple()->elements()));
-}
-
-template class PyFutureToHere<IValue>;
-template class PyFutureToHere<py::object>;
-
-//////////////////////////  PyFutureLocalValue  ////////////////////////////////
-
-template <typename T>
-PyFutureLocalValue<T>::PyFutureLocalValue(std::shared_ptr<OwnerRRef<T>> rref)
-    : rref_(std::move(rref)) {}
-
-template <>
-py::object PyFutureLocalValue<IValue>::wait() const {
-  auto value = rref_->getValue();
-  {
-    // acquiring GIL as torch::jit::toPyObject creates new py::object without
-    // grabbing the GIL.
-    AutoGIL ag;
-    return torch::jit::toPyObject(std::move(value));
-  }
-}
-
-template <>
-py::object PyFutureLocalValue<py::object>::wait() const {
-  const py::object& value = rref_->getValue();
-  {
-    // acquiring GIL as the return statement construct a new py::object from
-    // a const reference.
-    AutoGIL ag;
-    return value;
-  }
-}
-
-template class PyFutureLocalValue<IValue>;
-template class PyFutureLocalValue<py::object>;
-
 ///////////////////////////  PyRRef  //////////////////////////////////
 
 PyRRef::PyRRef(std::shared_ptr<RRef> rref) : rref_(std::move(rref)) {
@@ -96,32 +37,53 @@ WorkerInfo PyRRef::owner() const {
   return RRefContext::getInstance().agent()->getWorkerInfo(rref_->owner());
 }
 
-std::shared_ptr<PyFuture> PyRRef::toHere() {
+py::object PyRRef::toHere() {
   if (rref_->isOwner()) {
     return localValue();
   } else {
     if (rref_->isPyObj()) {
-      auto userRRef = std::static_pointer_cast<UserRRef<py::object>>(rref_);
-      return std::make_shared<PyFutureToHere<py::object>>(userRRef->toHere());
+      // UserRRef<py::object>::toHere() calls python_rpc_handler which acquires
+      // GIL.
+      return std::static_pointer_cast<UserRRef<py::object>>(rref_)->toHere();
     } else {
-      auto userRRef = std::static_pointer_cast<UserRRef<IValue>>(rref_);
-      return std::make_shared<PyFutureToHere<IValue>>(userRRef->toHere());
+      IValue value =
+          std::static_pointer_cast<UserRRef<IValue>>(rref_)->toHere();
+
+      {
+        // acquiring GIL as torch::jit::toPyObject creates new py::object
+        // without grabbing the GIL.
+        AutoGIL ag;
+        return torch::jit::toPyObject(std::move(value));
+      }
     }
   }
 }
 
-std::shared_ptr<PyFuture> PyRRef::localValue() {
+py::object PyRRef::localValue() {
   TORCH_CHECK(
       rref_->isOwner(),
       "Cannot call localValue() on a non-local reference. Call it on ",
       RRefContext::getInstance().getWorkerName());
 
   if (rref_->isPyObj()) {
-    return std::make_shared<PyFutureLocalValue<py::object>>(
-        std::dynamic_pointer_cast<OwnerRRef<py::object>>(rref_));
+    const py::object& value =
+        std::dynamic_pointer_cast<OwnerRRef<py::object>>(rref_)->getValue();
+
+    {
+      // acquiring GIL as the return statement construct a new py::object from
+      // a const reference.
+      AutoGIL ag;
+      return value;
+    }
   } else {
-    return std::make_shared<PyFutureLocalValue<IValue>>(
-        std::dynamic_pointer_cast<OwnerRRef<IValue>>(rref_));
+    auto value =
+        std::dynamic_pointer_cast<OwnerRRef<IValue>>(rref_)->getValue();
+    {
+      // acquiring GIL as torch::jit::toPyObject creates new py::object without
+      // grabbing the GIL.
+      AutoGIL ag;
+      return torch::jit::toPyObject(std::move(value));
+    }
   }
 }
 

--- a/torch/csrc/distributed/rpc/py_rref.h
+++ b/torch/csrc/distributed/rpc/py_rref.h
@@ -8,33 +8,6 @@ namespace torch {
 namespace distributed {
 namespace rpc {
 
-struct PyFuture {
-  virtual py::object wait() const = 0;
-  virtual ~PyFuture() = default;
-};
-
-template <typename T>
-class PyFutureToHere final : public PyFuture {
- public:
-  explicit PyFutureToHere(std::shared_ptr<ivalue::Future> future);
-  py::object wait() const override;
-  ~PyFutureToHere() override = default;
-
- private:
-  const std::shared_ptr<ivalue::Future> future_;
-};
-
-template <typename T>
-class PyFutureLocalValue final : public PyFuture {
- public:
-  explicit PyFutureLocalValue(std::shared_ptr<OwnerRRef<T>> rref);
-  py::object wait() const override;
-  ~PyFutureLocalValue() override = default;
-
- private:
-  const std::shared_ptr<OwnerRRef<T>> rref_;
-};
-
 // Python wrapper of an RRef shared_ptr that supports Python
 // pickle and unpickle.
 class PyRRef {
@@ -43,8 +16,8 @@ class PyRRef {
 
   bool isOwner() const;
   WorkerInfo owner() const;
-  std::shared_ptr<PyFuture> toHere();
-  std::shared_ptr<PyFuture> localValue();
+  py::object toHere();
+  py::object localValue();
   py::tuple pickle() const;
   static PyRRef unpickle(const py::tuple& t);
 

--- a/torch/csrc/distributed/rpc/rref.h
+++ b/torch/csrc/distributed/rpc/rref.h
@@ -248,16 +248,9 @@ class UserRRef final : public RRef {
   // Returns the globally unique ForkId of this RRef
   const ForkId& forkId() const;
 
-  // Get of copy of the value from the ``OwnerRRef``. Returns an ivalue::Future
-  // immediately. If this RRef wraps an IValue, the returned Future also wraps
-  // the same IValue. If this RRef wrap a py::object, the returned Future wraps
-  // an IValue representation of the py::object, which can be reconstructed
-  // using the following code:
-  //
-  // PythonRpcHandler::getInstance().deserialize(
-  //     SerializedPyObj::fromIValues(future->value().toTuple()->elements()));
-  //
-  std::shared_ptr<ivalue::Future> toHere();
+  // Get of copy of the value from the ``OwnerRRef``. If the value is not ready
+  // yet, this call will block.
+  T toHere();
 
   // Upon destruction, this ``UserRRef`` will tell the owner to deref.
   ~UserRRef() override;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#29396 Revert RRef.to_here()/local_value() return type**

The return types of RRef.to_here()/local_value() were recently
changed to Future, which triggers flakiness as the RRef could be
deleted before the future.wait() finishes. While we are still
discussing how we'd like to solve it, this commit reverts the
return type to stop bleeding in tests.

closes #28885

Differential Revision: [D18375571](https://our.internmc.facebook.com/intern/diff/D18375571)