### PR TITLE
[WIP][ONNX] Fix for opset11 arange dtype inference

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -4696,6 +4696,14 @@ a")
         b = torch.rand(1, requires_grad=True)
         self.checkScript(func, (a, b), optimize=True)
 
+    def test_trace_optioanl_dtype(self):
+        class Test(torch.nn.Module):
+            def forward(self):
+                return torch.arange(5)
+
+        traced = torch.jit.trace(Test(), ())
+        torch.allclose(traced(), Test()())
+
     def test_mul(self):
         def func(a, b):
             return a * b

--- a/tools/autograd/templates/python_torch_functions.cpp
+++ b/tools/autograd/templates/python_torch_functions.cpp
@@ -97,15 +97,6 @@ inline Tensor dispatch_arange(Scalar start, Scalar end, Scalar step, const Tenso
   return torch::arange(start, end, step, options);
 }
 
-static inline bool allIntegral(std::initializer_list<std::reference_wrapper<Scalar>> l) {
-  for (Scalar& s : l) {
-    if (!s.isIntegral(true)) {
-      return false;
-    }
-  }
-  return true;
-}
-
 static PyObject * THPVariable_arange(PyObject* self, PyObject* args, PyObject* kwargs)
 {
   HANDLE_TH_ERRORS
@@ -121,7 +112,7 @@ static PyObject * THPVariable_arange(PyObject* self, PyObject* args, PyObject* k
     if (r.isNone(1)) {
       auto end = r.scalar(0);
       // NOTE: r.scalartype(X) gives the default dtype if r.isNone(X)
-      auto scalarType = r.isNone(2) && allIntegral({end}) ? at::ScalarType::Long : r.scalartype(2);
+      c10::optional<ScalarType> scalarType = r.scalartypeOptional(2);
       const auto options = TensorOptions()
           .dtype(scalarType)
           .device(r.device(4))
@@ -141,7 +132,7 @@ static PyObject * THPVariable_arange(PyObject* self, PyObject* args, PyObject* k
       auto end = r.scalar(1);
       auto step = r.scalar(2);
       // NOTE: r.scalartype(X) gives the default dtype if r.isNone(X)
-      auto scalarType = r.isNone(4) && allIntegral({start, end, step}) ? at::ScalarType::Long : r.scalartype(4);
+      c10::optional<ScalarType> scalarType = r.scalartypeOptional(4);
       const auto options = TensorOptions()
           .dtype(scalarType)
           .device(r.device(6))

--- a/torch/csrc/jit/tracer.cpp
+++ b/torch/csrc/jit/tracer.cpp
@@ -489,6 +489,20 @@ void addInputs(Node* n, const char* name, at::Layout value) {
 void addInputs(Node* n, const char* name, at::ScalarType value) {
   detail::genericAddInput(n, static_cast<int64_t>(value));
 }
+
+void addInputs(
+    Node* n,
+    const char* name,
+    c10::optional<caffe2::TypeMeta> opt_dtype) {
+  if (opt_dtype.has_value()) {
+    return addInputs(n, name, at::typeMetaToScalarType(*opt_dtype));
+  } else {
+    Graph* g = n->owningGraph();
+    Value* none = g->insertNode(g->createNone())->output();
+    n->addInput(none);
+  }
+}
+
 void addInputs(Node* n, const char* name, at::MemoryFormat value) {
   detail::genericAddInput(n, static_cast<int64_t>(value));
 }
@@ -546,7 +560,7 @@ void addInputs(
 void addInputs(Node* n, const char* name, const at::TensorOptions& options) {
   // [TensorOptions in script] - update this when you change how we schematize
   // TensorOptions
-  addInputs(n, name, at::typeMetaToScalarType(options.dtype()));
+  addInputs(n, name, options.dtype_opt());
   addInputs(n, name, options.layout());
   addInputs(n, name, options.device());
   addInputs(n, name, options.pinned_memory());

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -332,7 +332,7 @@ def _arange_cast_helper(g, end, start=None, step=None, dtype=None):
             try:
                 if scalar.type().scalarType() != 'Long':
                     return False
-            except:
+            except Exception:
                 pass
         return True
 

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -327,12 +327,24 @@ def _scatter_helper(g, self, dim, index, src):
 
 
 def _arange_cast_helper(g, end, start=None, step=None, dtype=None):
+    def _is_all_integral(scalars):
+        for scalar in scalars:
+            try:
+                if scalar.type().scalarType() != 'Long':
+                    return False
+            except:
+                pass
+        return True
+
     # This logic is based on torch.arange docs. If 'dtype' is provided,
     # infer input types from dtype. If not, then check if any of start, stop,
     # or step are floating point, and infer the type from get_default.
     # Otherwise, the dtype is inferred to be torch.int64.
     if _is_value(dtype) and _is_none(dtype):
-        type = scalar_type_to_pytorch_type.index(torch.get_default_dtype())
+        if _is_all_integral([start, end, step]):
+            type = scalar_type_to_pytorch_type.index(torch.int64)
+        else:
+            type = scalar_type_to_pytorch_type.index(torch.get_default_dtype())
     else:
         type = dtype
 


### PR DESCRIPTION
- Fix on the ONNX export side associated with #27629. Tests exporting scripted arange on current master is likely to fail, since they do not have the jit changes yet.
- Code cleanup, remove duplicated arange dtype inference. It is moved to c++ in #27629.
- [ ] Rebase with master once #27629 is merged.