### PR TITLE
[jit] remove FunctionType as an allowed constant

### DIFF
--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -26,7 +26,6 @@ import os
 import pickle
 import sys
 import textwrap
-import types
 import warnings
 
 from collections import OrderedDict

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1440,28 +1440,6 @@ class OrderedBufferDict(OrderedDictWrapper):
             raise KeyError(k)
         return self.module._get_buffer(k)
 
-# base types that can be constants
-# in addition, tuples and lists of these base types are also considered constants
-# If you edit this list, then you also need to edit the handlers in
-# ConstantValue in jit/script/init.cpp
-_constant_types = (bool, float, int, str, type(None), types.FunctionType, torch.device, torch.layout, torch.dtype)
-
-
-def _get_valid_constant(attr, v):
-    if isinstance(v, _constant_types):
-        return v
-    elif isinstance(v, tuple) or isinstance(v, list):
-        return tuple(_get_valid_constant(attr, x) for x in v)
-    constants = ", ".join(typ.__name__ for typ in _constant_types)
-    raise TypeError(textwrap.dedent("""
-        '{}' object for attribute '{}' is not a valid constant.
-        Valid constants are:
-          1. a nn.ModuleList
-          2. a value of type {{{}}}
-          3. a list or tuple of (2)
-        """.format(type(v).__name__, attr, constants)))
-
-
 # For each user-defined class that subclasses ScriptModule, this meta-class:
 # (1) finds all the methods annotated with @script_method in a ScriptModule and
 #     removes them from the class attributes

--- a/torch/jit/_recursive.py
+++ b/torch/jit/_recursive.py
@@ -1,7 +1,6 @@
 import inspect
 import torch
 import collections
-import types
 import textwrap
 import functools
 import warnings

--- a/torch/jit/_recursive.py
+++ b/torch/jit/_recursive.py
@@ -44,7 +44,7 @@ def make_stub_from_method(nn_module, method):
 # in addition, tuples and lists of these base types are also considered constants
 # If you edit this list, then you also need to edit the handlers in
 # ConstantValue in jit/script/init.cpp
-_constant_types = (bool, float, int, str, type(None), types.FunctionType, torch.device, torch.layout, torch.dtype)
+_constant_types = (bool, float, int, str, type(None), torch.device, torch.layout, torch.dtype)
 
 def _get_valid_constant(attr, v):
     if isinstance(v, _constant_types):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#29405 [jit] remove FunctionType as an allowed constant**

We never actually used this (function attributes are a separate pathway
in ConcreteModuleType).

Differential Revision: [D18378392](https://our.internmc.facebook.com/intern/diff/D18378392)