### PR TITLE
[WIP] switch defaults

### DIFF
--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -200,8 +200,13 @@ Tensor empty_like(
 
   if (self.is_quantized()) {
 
+
+    if (!optional_memory_format.has_value()) {
+      TORCH_CHECK(optional_memory_format.has_value(), " *_like temporary requires memory format")
+    }
+
     auto memory_format =
-        optional_memory_format.value_or(MemoryFormat::Contiguous);
+        optional_memory_format.value_or(MemoryFormat::Preserve);
 
     // TODO: To support all features of MemoryFormat::Preserve we need to add
     // _empty_affine_quantized_strided function and use it similarly to
@@ -239,8 +244,12 @@ Tensor empty_like(
 
   Tensor result;
 
+  if (!optional_memory_format.has_value()) {
+    TORCH_CHECK(optional_memory_format.has_value(), " *_like temporary requires memory format")
+  }
+
   auto memory_format =
-      optional_memory_format.value_or(MemoryFormat::Contiguous);
+      optional_memory_format.value_or(MemoryFormat::Preserve);
   if (memory_format == MemoryFormat::Preserve) {
     if (self.is_non_overlapping_and_dense()) {
       result = at::empty_strided(self.sizes(), self.strides(), options);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#29408 [WIP] switch defaults**
* #29392 explicitly provide memory format when calling to *_like operators
* #29391 explicitly provide memory format when calling to *_like operators
* #29390 explicitly provide memory format when calling to *_like operators
* #29389 explicitly provide memory format when calling to *_like operators
* #29388 explicitly provide memory format when calling to *_like operators
* #29387 explicitly provide memory format when calling to *_like operators
* #29386 explicitly provide memory format when calling to *_like operators

