### PR TITLE
Give a better error message when people accidentally use unsupported devices

### DIFF
--- a/c10/core/impl/DeviceGuardImplInterface.h
+++ b/c10/core/impl/DeviceGuardImplInterface.h
@@ -210,7 +210,10 @@ public:
 
 inline const DeviceGuardImplInterface* getDeviceGuardImpl(DeviceType type) {
   auto p = device_guard_impl_registry[static_cast<size_t>(type)].load();
-  AT_ASSERTM(p, "DeviceGuardImpl for ", type, " is not available");
+  // This seems to be the first place where you make use of a device
+  // when you pass devices to factory functions.  Give a nicer error
+  // message in this case.
+  TORCH_CHECK(p, "PyTorch is not linked with support for ", type, " devices");
   return p;
 }
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -424,6 +424,10 @@ class _TestTorchMixin(object):
         with self.assertRaisesRegex(RuntimeError, "Condition for computing multivariate log-gamma not met"):
             run_test(3)
 
+    def test_msnpu_error(self):
+        with self.assertRaisesRegex(RuntimeError, "support for msnpu"):
+            torch.zeros(1, device=torch.device('msnpu'))
+
     def _digamma_input(self, test_poles=True):
         input = []
         input.append((torch.randn(10).abs() + 1e-4).tolist())


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#29409 Give a better error message when people accidentally use unsupported devices**

Fixes #27875

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D18396828](https://our.internmc.facebook.com/intern/diff/D18396828)