### PR TITLE
Rename PyTorch JNI library to pytorch_jni

### DIFF
--- a/android/pytorch_android/CMakeLists.txt
+++ b/android/pytorch_android/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.4.1)
-project(pytorch CXX)
+project(pytorch_jni CXX)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_VERBOSE_MAKEFILE ON)
 
@@ -24,15 +24,15 @@ file(GLOB pytorch_android_SOURCES
   ${pytorch_android_DIR}/*.cpp
 )
 
-add_library(pytorch SHARED
+add_library(pytorch_jni SHARED
     ${pytorch_android_SOURCES}
 )
 
-target_compile_options(pytorch PRIVATE
+target_compile_options(pytorch_jni PRIVATE
   -fexceptions
 )
 
-target_include_directories(pytorch PUBLIC
+target_include_directories(pytorch_jni PUBLIC
     ${libtorch_include_DIR}
 )
 
@@ -60,7 +60,7 @@ if (ANDROID_ABI)
   import_static_lib(libclog)
 
     # Link most things statically on Android.
-  target_link_libraries(pytorch
+  target_link_libraries(pytorch_jni
       fbjni
       -Wl,--gc-sections
       -Wl,--whole-archive
@@ -77,7 +77,7 @@ if (ANDROID_ABI)
 else()
 
   # Prefer dynamic linking on the host
-  target_link_libraries(pytorch
+  target_link_libraries(pytorch_jni
       fbjni
       -Wl,--gc-sections
       -Wl,--whole-archive

--- a/android/pytorch_android/src/main/java/org/pytorch/Module.java
+++ b/android/pytorch_android/src/main/java/org/pytorch/Module.java
@@ -59,7 +59,7 @@ public class Module {
 
   private static class NativePeer {
     static {
-      System.loadLibrary("pytorch");
+      System.loadLibrary("pytorch_jni");
     }
 
     private final HybridData mHybridData;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #29413 Update fbjni and enable PyTorch JNI build
* **#29412 Rename PyTorch JNI library to pytorch_jni**
* #29455 Clean up pytorch_android_torchvision test

Summary:
Originally, this was going to be Android-only, so the name wasn't too
important.  But now that we're planning to distribute it with libtorch,
we should give it a more distinctive name.

Test Plan:
Ran tests according to
https://github.com/pytorch/pytorch/issues/6570#issuecomment-548537834