### PR TITLE
Implementation of cosine learning rate training policy

### DIFF
--- a/caffe2/sgd/learning_rate_op.cc
+++ b/caffe2/sgd/learning_rate_op.cc
@@ -33,8 +33,10 @@ Required:
    `hill`: uses those in both `linearWarmup` and `inv`, plus `end_multiplier`
    `composite`: uses `sub_policy_num_iters` and additional args with format
    `cyclic`: uses `max_lr`, `stepsize`
+   `cosine`: uses `min_lr`, `max_lr`, `period`, `t_mult`, `lr_shrink`
    `constantThenLinearWarmup`: uses `start_warmup_multiplier`, `constant_warmup_num_iter`, `linear_warmup_num_iter`
    `compositeCyclical`: uses `start_warmup_multiplier`, `constant_warmup_num_iter`, `linear_warmup_num_iter`, `cyclical_max_lr`, `cyclical_step_size`, `cyclical_decay`
+   `compositeCosine`: uses `start_warmup_multiplier`, `constant_warmup_num_iter`, `linear_warmup_num_iter`, `cosine_max_lr`, `cosine_period`, `cosine_t_mult`, `cosine_lr_shrink`
    sub_policy_{sub_policy_index}_{sub_policy_arg}, for example:
    sub_policy_0_policy: "exp", sub_policy_0_gamma: 0.99,
    sub_policy_0_lr_scale: 1.2
@@ -58,10 +60,15 @@ Optional:
   `m3`: defaults to 0.5, the third piece lr of piece warmup
   `start_warmup_multiplier`: defaults to 0.1, part of constantThenLinearWarmup
   `constant_warmup_num_iter`: defaults to 10000000, part of constantThenLinearWarmup and constantThenLinearWarmup
-  `linear_warmup_num_iter`: defaults to 10000000, part of constantThenLinearWarmup and CompositeCyclicalLRPolicy
+  `linear_warmup_num_iter`: defaults to 10000000, part of constantThenLinearWarmup, CompositeCyclicalLRPolicy, CompositeCosineLRPolicy
   `cyclical_max_lr`: defaults to 0.05, part of CompositeCyclicalLRPolicy
   `cyclical_step_size`: defaults to 1000000, part of CompositeCyclicalLRPolicy
   `cyclical_decay`: defaults to 1.0, part of CompositeCyclicalLRPolicy
+  `cosine_min_lr`:defaults to 0.01, part of CompositeCosineLRPolicy
+  `cosine_max_lr`:defaults to 0.05, part of CompositeCosineLRPolicy
+  `cosine_period`:defaults to 50, part of CompositeCosineLRPolicy
+  `cosine_t_mult`:defaults to 1.0, part of CompositeCosineLRPolicy
+  `cosine_lr_shrink`:defaults to 0.99, part of CompositeCosineLRPolicy
 
 Usage:
   train_net.LearningRate(*iterations*, "*label*", base_lr=*float*,
@@ -120,6 +127,13 @@ Example usage:
     .Arg(
         "cyclical_decay",
         "defaults to 0.999, part of CompositeCyclicalLRPolicy")
+    .Arg("cosine_min_lr", "defaults to 0.01, part of CompositeCosineLRPolicy")
+    .Arg("cosine_max_lr", "defaults to 0.05, part of CompositeCosineLRPolicy")
+    .Arg("cosine_period", "defaults to 50, part of CompositeCosineLRPolicy")
+    .Arg("cosine_t_mult", "defaults to 1,0, part of CompositeCosineLRPolicy")
+    .Arg(
+        "cosine_lr_shrink",
+        "defaults to 0.99, part of CompositeCosineLRPolicy")
     .Input(0, "input", "description needed")
     .Output(0, "output", "description needed")
     .DeviceInferenceFunction([](const OperatorDef& def) {

--- a/caffe2/sgd/learning_rate_op.h
+++ b/caffe2/sgd/learning_rate_op.h
@@ -210,6 +210,48 @@ class LearningRateOp final : public Operator<Context> {
           cyclical_max_lr,
           cyclical_step_size,
           cyclical_decay);
+    } else if (policy == "cosine") {
+      T max_lr =
+          this->template GetSingleArgument<float>(arg_prefix + "max_lr", 0.5);
+      T min_lr =
+          this->template GetSingleArgument<float>(arg_prefix + "min_lr", 0.1);
+      int64_t period =
+          this->template GetSingleArgument<int>(arg_prefix + "period", 50);
+      T t_mult =
+          this->template GetSingleArgument<float>(arg_prefix + "t_mult", 1.0);
+      T lr_shrink = this->template GetSingleArgument<float>(
+          arg_prefix + "lr_shrink", 0.99);
+      DCHECK_GE(max_lr, min_lr);
+      return new CosineLearningRate<T>(
+          min_lr, max_lr, period, t_mult, lr_shrink);
+    } else if (policy == "compositeCosine") {
+      T start_warmup_multiplier = this->template GetSingleArgument<float>(
+          arg_prefix + "start_warmup_multiplier", 0.1);
+      int64_t constant_warmup_num_iter = this->template GetSingleArgument<int>(
+          arg_prefix + "constant_warmup_num_iter", 10000000);
+      int64_t linear_warmup_num_iter = this->template GetSingleArgument<int>(
+          arg_prefix + "linear_warmup_num_iter", 10000000);
+      T cosine_max_lr = this->template GetSingleArgument<float>(
+          arg_prefix + "cosine_max_lr", 0.5);
+      T cosine_min_lr = this->template GetSingleArgument<float>(
+          arg_prefix + "cosine_min_lr", 0.1);
+      int64_t cosine_period = this->template GetSingleArgument<int>(
+          arg_prefix + "cosine_period", 50);
+      T cosine_t_mult = this->template GetSingleArgument<float>(
+          arg_prefix + "cosine_t_mult", 1.0);
+      T cosine_lr_shrink = this->template GetSingleArgument<float>(
+          arg_prefix + "cosine_lr_shrink", 0.99);
+
+      DCHECK_GE(cosine_max_lr, cosine_min_lr);
+      return new CompositeCosineLearningRate<T>(
+          start_warmup_multiplier,
+          constant_warmup_num_iter,
+          linear_warmup_num_iter,
+          cosine_min_lr,
+          cosine_max_lr,
+          cosine_period,
+          cosine_t_mult,
+          cosine_lr_shrink);
     } else {
       CAFFE_THROW("Unknown learning rate policy: ", policy);
       return NULL;


### PR DESCRIPTION
Summary:
as titled. same as diff: D18195868.
We fix the windows compiling issue by changing the marco, inspired from: D15511736

Test Plan: buck test -v 2 caffe2/caffe2/fb/dper/layer_models/tests/split_1:sparse_nn_test  -- test_composite_cosine_lr_policy

Differential Revision: D18392276

