### PR TITLE
updated name_inference doc for cumsum and cumprod

### DIFF
--- a/docs/source/name_inference.rst
+++ b/docs/source/name_inference.rst
@@ -69,8 +69,8 @@ If you don't see an operation listed here, but it would help your use case, plea
    :meth:`Tensor.cosh_`,None
    :meth:`Tensor.cpu`,:ref:`keeps_input_names-doc`
    :meth:`Tensor.cuda`,:ref:`keeps_input_names-doc`
-   ":meth:`Tensor.cumprod`, :func:`torch.cumprod`",:ref:`removes_dimensions-doc`
-   ":meth:`Tensor.cumsum`, :func:`torch.cumsum`",:ref:`removes_dimensions-doc`
+   ":meth:`Tensor.cumprod`, :func:`torch.cumprod`",:ref:`keeps_input_names-doc`
+   ":meth:`Tensor.cumsum`, :func:`torch.cumsum`",:ref:`keeps_input_names-doc`
    :meth:`Tensor.data_ptr`,None
    ":meth:`Tensor.detach`, :func:`torch.detach`",:ref:`keeps_input_names-doc`
    :meth:`Tensor.detach_`,None
@@ -465,4 +465,3 @@ from name inference. For example,
     >>> x += y
     >>> x.names
     ('N', 'C')
-

--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -245,8 +245,6 @@ Reduction Ops
 ~~~~~~~~~~~~~~~~~~~~~~
 .. autofunction:: argmax
 .. autofunction:: argmin
-.. autofunction:: cumprod
-.. autofunction:: cumsum
 .. autofunction:: dist
 .. autofunction:: logsumexp
 .. autofunction:: mean
@@ -305,6 +303,8 @@ Other Operations
 .. autofunction:: cdist
 .. autofunction:: combinations
 .. autofunction:: cross
+.. autofunction:: cumprod
+.. autofunction:: cumsum
 .. autofunction:: diag
 .. autofunction:: diag_embed
 .. autofunction:: diagflat


### PR DESCRIPTION
cumsum/cumprod  perform their own respective operations over a desired dimension, but there is no reduction in dimensions in the process, i.e. they are not reduction operations and hence just keep the input names of the tensor on which the operation is performed