### PR TITLE
Clean up pytorch_android_torchvision test

### DIFF
--- a/android/pytorch_android_torchvision/src/androidTest/java/org/pytorch/torchvision/TorchVisionInstrumentedTests.java
+++ b/android/pytorch_android_torchvision/src/androidTest/java/org/pytorch/torchvision/TorchVisionInstrumentedTests.java
@@ -14,11 +14,6 @@ import static org.junit.Assert.assertArrayEquals;
 @RunWith(AndroidJUnit4.class)
 public class TorchVisionInstrumentedTests {
 
-  @Before
-  public void setUp() {
-    System.loadLibrary("pytorch");
-  }
-
   @Test
   public void smokeTest() {
     Bitmap bitmap = Bitmap.createBitmap(320, 240, Bitmap.Config.ARGB_8888);
@@ -27,6 +22,6 @@ public class TorchVisionInstrumentedTests {
             bitmap,
             TensorImageUtils.TORCHVISION_NORM_MEAN_RGB,
             TensorImageUtils.TORCHVISION_NORM_STD_RGB);
-    assertArrayEquals(new long[] {1l, 3l, 240l, 320l}, tensor.shape);
+    assertArrayEquals(new long[] {1l, 3l, 240l, 320l}, tensor.shape());
   }
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #29413 Update fbjni and enable PyTorch JNI build
* #29412 Rename PyTorch JNI library to pytorch_jni
* **#29455 Clean up pytorch_android_torchvision test**

Summary:
- Don't need to load native library.
- Shape is now private.