### PR TITLE
[ONNX] Try exporting ONNX with force_outplace=False

### DIFF
--- a/aten/src/ATen/core/interned_strings.h
+++ b/aten/src/ATen/core/interned_strings.h
@@ -168,6 +168,8 @@ namespace c10 {
   _(prim, unchecked_unwrap_optional) \
   _(aten, __contains__)              \
   _(prim, BailoutTemplate)           \
+  _(aten, zero_)                     \
+  _(aten, fill_)                     \
   FORALL_ATEN_BASE_SYMBOLS(_)        \
   _(onnx, Add)                       \
   _(onnx, Concat)                    \

--- a/test/onnx/test_pytorch_onnx_caffe2.py
+++ b/test/onnx/test_pytorch_onnx_caffe2.py
@@ -1411,7 +1411,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
 
         x = torch.ones(2, 3, 4)
         y = torch.ones(2, 3, 4) * 2
-        self.run_model_test(Arithmetic(), train=False, input=(), batch_size=BATCH_SIZE, use_gpu=False, example_outputs=(x+3, y*(x+3)))
+        self.run_model_test(Arithmetic(), train=False, input=(), batch_size=BATCH_SIZE, use_gpu=False, example_outputs=(x + 3, y * (x + 3)))
 
     def test_tensor_factories(self):
         class TensorFactory(torch.nn.Module):

--- a/test/onnx/test_pytorch_onnx_caffe2.py
+++ b/test/onnx/test_pytorch_onnx_caffe2.py
@@ -1383,6 +1383,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
         x = torch.randn(3, 4, 5)
         self.run_model_test(UnbindModel2(), train=False, input=(x,), batch_size=BATCH_SIZE, use_gpu=False)
 
+    @skipIfUnsupportedMinOpsetVersion(9)
     def test_inplace_zero(self):
         class Zero_(torch.nn.Module):
             def forward(self, x):
@@ -1391,6 +1392,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
         x = torch.randn(2, 3, 4)
         self.run_model_test(Zero_(), train=False, input=(x,), batch_size=BATCH_SIZE, use_gpu=False)
 
+    @skipIfUnsupportedMinOpsetVersion(9)
     def test_inplace_fill(self):
         class Fill_(torch.nn.Module):
             def forward(self, x):

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -1324,6 +1324,7 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.randn(2, 3, 4)
         self.run_test(TensorFactory(), x)
 
+    @skipIfUnsupportedMinOpsetVersion(9)
     def test_inplace_zero(self):
         class Zero_(torch.nn.Module):
             def forward(self, x):
@@ -1332,6 +1333,7 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.randn(2, 3, 4)
         self.run_test(Zero_(), x)
 
+    @skipIfUnsupportedMinOpsetVersion(9)
     def test_inplace_fill(self):
         class Fill_(torch.nn.Module):
             def forward(self, x):

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -1324,6 +1324,34 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.randn(2, 3, 4)
         self.run_test(TensorFactory(), x)
 
+    def test_inplace_zero(self):
+        class Zero_(torch.nn.Module):
+            def forward(self, x):
+                return x.zero_(), x
+
+        x = torch.randn(2, 3, 4)
+        self.run_test(Zero_(), x)
+
+    def test_inplace_fill(self):
+        class Fill_(torch.nn.Module):
+            def forward(self, x):
+                return x.fill_(3), x
+
+        x = torch.randn(2, 3, 4)
+        self.run_test(Fill_(), x)
+
+    def test_inplace_arithmetic(self):
+        class Arithmetic(torch.jit.ScriptModule):
+            @torch.jit.script_method
+            def forward(self, x, y):
+                x.add_(3)
+                y.mul_(x)
+                return x, y
+
+        x = torch.randn(2, 3, 4)
+        y = torch.randn(2, 3, 4)
+        self.run_test(Arithmetic(), (x, y))
+
     def test_sort(self):
         class SortModel(torch.nn.Module):
             def __init__(self, dim):

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -818,6 +818,19 @@ void Value::replaceAllUsesWith(Value* newValue) {
   }
 }
 
+void Value::replaceAllUsesAfterNodeWith(const Node* node, Value* newValue) {
+  std::for_each(uses_.begin(), uses_.end(), [&node, newValue](Use &u) {
+    if (u.user->isAfter(node)) {
+      u.user->inputs_[u.offset] = newValue;
+      newValue->uses_.push_back(u);
+    }
+  });
+
+  uses_.erase(std::remove_if(uses_.begin(), uses_.end(), [&node](const Use& u){
+    return u.user->isAfter(node);
+  }), uses_.end());
+}
+
 size_t findArgument(const FunctionSchema& the_schema, Symbol name) {
   auto name_str = name.toUnqualString();
   for (size_t i = 0; i < the_schema.arguments().size(); ++i) {

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -227,6 +227,8 @@ struct Value {
   //          %5 = h(%6, %6)
   TORCH_API void replaceAllUsesWith(Value* newValue);
 
+  TORCH_API void replaceAllUsesAfterNodeWith(const Node* node, Value* newValue);
+
   TORCH_API Value* copyMetadata(Value* from);
 };
 

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -227,6 +227,16 @@ struct Value {
   //          %5 = h(%6, %6)
   TORCH_API void replaceAllUsesWith(Value* newValue);
 
+  // Replaces all uses of this value with 'newValue' after 'node'.
+  // Given:   %3 = f(%1, %2)
+  //          %4 = g(%3)
+  //          %5 = inplace_(%3)
+  //          %6 = h(%3, %3)
+  // Execute: %3.replaceAllUsesAfterNodeWith(%5.node(), %5)
+  // Result:  %3 = f(%1, %2)
+  //          %4 = g(%3)
+  //          %5 = inplace_(%3)
+  //          %6 = h(%5, %5)
   TORCH_API void replaceAllUsesAfterNodeWith(const Node* node, Value* newValue);
 
   TORCH_API Value* copyMetadata(Value* from);

--- a/torch/csrc/jit/passes/remove_inplace_ops.cpp
+++ b/torch/csrc/jit/passes/remove_inplace_ops.cpp
@@ -50,7 +50,7 @@ void RemoveInplaceOps(Block* block) {
 
       int additionalInputCount = 0;
       if (expectedInputCount.find(node->kind()) != expectedInputCount.end()) {
-        additionalInputCount = static_cast<int>(expectedInputCount.at(node->kind())) - newNode->inputs().size();
+        additionalInputCount = expectedInputCount.at(node->kind()) - static_cast<int>(newNode->inputs().size());
       }
 
       for (int i = 0; i < additionalInputCount; ++i) {

--- a/torch/csrc/jit/passes/remove_inplace_ops.cpp
+++ b/torch/csrc/jit/passes/remove_inplace_ops.cpp
@@ -11,9 +11,9 @@ static const std::unordered_map<NodeKind, NodeKind> inPlaceToOutOfPlace = {
     {aten::zero_, aten::zeros_like},
     {aten::fill_, aten::full_like}};
 
-static const std::unordered_map<NodeKind, size_t> additionalNoneArgumentCount = {
-    {aten::zero_, 1},
-    {aten::fill_, 1}};
+static const std::unordered_map<NodeKind, int> expectedInputCount = {
+    {aten::zero_, 2},
+    {aten::fill_, 3}};
 
 bool isInplaceOp(const Node* node) {
   return inPlaceToOutOfPlace.count(node->kind()) != 0;
@@ -48,12 +48,12 @@ void RemoveInplaceOps(Block* block) {
         newNode->addInput(input);
       }
 
-      size_t additionalInputCount = 0;
-      if (additionalNoneArgumentCount.find(node->kind()) != additionalNoneArgumentCount.end()) {
-        additionalInputCount = additionalNoneArgumentCount.at(node->kind());
+      int additionalInputCount = 0;
+      if (expectedInputCount.find(node->kind()) != expectedInputCount.end()) {
+        additionalInputCount = static_cast<int>(expectedInputCount.at(node->kind())) - newNode->inputs().size();
       }
 
-      for (size_t i = 0; i < additionalInputCount; ++i) {
+      for (int i = 0; i < additionalInputCount; ++i) {
         auto noneNode = graph->createNone();
         noneNode->insertBefore(newNode);
         newNode->addInput(noneNode->output());

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -1232,7 +1232,7 @@ def empty(g, sizes, dtype, layout, device, pin_memory=False, memory_format=None)
 
 
 @parse_args('v', 'i', 'v', 'v', 'v', 'v')
-def empty_like(g, input, dtype, layout, device, pin_memory=False, memory_format=None):
+def empty_like(g, input, dtype=None, layout=None, device=None, pin_memory=False, memory_format=None):
     return zeros_like(g, input, dtype, layout, device, pin_memory)
 
 
@@ -1271,7 +1271,7 @@ def ones(g, sizes, dtype, layout, device, pin_memory=False):
 
 
 @parse_args('v', 'i', 'v', 'v', 'v', 'v')
-def ones_like(g, input, dtype, layout, device, pin_memory=False, memory_format=None):
+def ones_like(g, input, dtype=None, layout=None, device=None, pin_memory=False, memory_format=None):
     shape = g.op("Shape", input)
     if dtype is None:
         dtype = 6  # float

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -1254,7 +1254,7 @@ def zeros(g, sizes, dtype, layout, device, pin_memory=False):
 
 
 @parse_args('v', 'i', 'v', 'v', 'v', 'v')
-def zeros_like(g, input, dtype, layout, device, pin_memory=False, memory_format=None):
+def zeros_like(g, input, dtype=None, layout=None, device=None, pin_memory=False, memory_format=None):
     shape = g.op("Shape", input)
     if dtype is None:
         dtype = 6  # float
@@ -1293,7 +1293,7 @@ def full(g, sizes, value, dtype, layout, device, pin_memory=False):
 
 
 @parse_args('v', 'f', 'i', 'v', 'v', 'v', 'v')
-def full_like(g, input, fill_value, dtype, layout, device, pin_memory=False, memory_format=None):
+def full_like(g, input, fill_value, dtype=None, layout=None, device=None, pin_memory=False, memory_format=None):
     shape = g.op("Shape", input)
     if dtype is None:
         dtype = 6  # float

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -212,7 +212,7 @@ def _trace(func, args, operator_export_type, return_outs=False):
     if isinstance(args, torch.Tensor):
         args = (args, )
 
-    trace_graph, torch_out, inputs_states = torch.jit._get_trace_graph(func, args, _force_outplace=True, _return_inputs_states=True)
+    trace_graph, torch_out, inputs_states = torch.jit._get_trace_graph(func, args, _force_outplace=False, _return_inputs_states=True)
     warn_on_static_input_change(inputs_states)
 
     trace_graph = _optimize_graph(trace_graph, operator_export_type)
@@ -233,7 +233,7 @@ def _trace_and_get_graph_from_model(model, args, training):
     # can turn training=True (or None, to preserve whatever the original
     # training mode was.)
     with set_training(model, training):
-        trace_graph, torch_out, inputs_states = torch.jit._get_trace_graph(model, args, _force_outplace=True, _return_inputs_states=True)
+        trace_graph, torch_out, inputs_states = torch.jit._get_trace_graph(model, args, _force_outplace=False, _return_inputs_states=True)
         warn_on_static_input_change(inputs_states)
 
     if orig_state_dict_keys != _unique_state_dict(model).keys():


### PR DESCRIPTION
This should resolve #29008. This flag has two effects on the tracer.
- Remove the underscroll for inplace operators. E.g.: index_put_ ==> index_put. This is handled in utils.py separately as well.
- Add out as input for backward computation.