### PR TITLE
fix fc fp16 quantization

### DIFF
--- a/caffe2/python/predictor/predictor_exporter_test.py
+++ b/caffe2/python/predictor/predictor_exporter_test.py
@@ -31,6 +31,24 @@ class MetaNetDefTest(unittest.TestCase):
         net_def = caffe2_pb2.NetDef()
         meta_net_def.nets.add(key="test_key", value=net_def)
 
+    def test_replace_blobs(self):
+        '''
+        Tests that NetDefs can be added to MetaNetDefs
+        '''
+        meta_net_def = metanet_pb2.MetaNetDef()
+        blob_name = "Test"
+        blob_def = ["AA"]
+        blob_def2 = ["BB"]
+        replaced_blob_def = ["CC"]
+        pred_utils.AddBlobs(meta_net_def, blob_name, blob_def)
+        self.assertEqual(blob_def, pred_utils.GetBlobs(meta_net_def, blob_name))
+        pred_utils.AddBlobs(meta_net_def, blob_name, blob_def2)
+        self.assertEqual(blob_def + blob_def2, pred_utils.GetBlobs(meta_net_def, blob_name))
+
+        pred_utils.ReplaceBlobs(meta_net_def, blob_name, replaced_blob_def)
+        self.assertEqual(replaced_blob_def, pred_utils.GetBlobs(meta_net_def, blob_name))
+
+
 class PredictorExporterTest(unittest.TestCase):
     def _create_model(self):
         m = cnn.CNNModelHelper()

--- a/caffe2/python/predictor/predictor_py_utils.py
+++ b/caffe2/python/predictor/predictor_py_utils.py
@@ -128,6 +128,12 @@ def AddBlobs(meta_net_def, blob_name, blob_def):
     for blob in blob_def:
         blobs.append(blob)
 
+def ReplaceBlobs(meta_net_def, blob_name, blob_def):
+    blobs = _ProtoMapGet(meta_net_def.blobs, blob_name)
+    assert blobs is not None, "The blob_name:{} does not exist".format(blob_name)
+    del blobs[:]
+    for blob in blob_def:
+        blobs.append(blob)
 
 def AddPlan(meta_net_def, plan_name, plan_def):
     meta_net_def.plans.add(key=plan_name, value=plan_def)


### PR DESCRIPTION
Summary:
The original approach is to save both fp16 and fp32 for all models, which increased the filesize and memory.

This diff is to save 'used' blobs into predictor file.

Test Plan:
fc clone workflow :
f149878151

ctr mbl feed test with fc fp16 quantization:
f149996395

Differential Revision: D18382503

