### PR TITLE
Enable test_py_built_in in rpc_test.py

### DIFF
--- a/test/rpc_test.py
+++ b/test/rpc_test.py
@@ -495,7 +495,6 @@ class RpcTest(object):
         value = VALUE_FUTURE.result()
         self.assertEqual(value, expected_src_rank)
 
-    @unittest.skip("Test is flaky, see https://github.com/pytorch/pytorch/issues/28932")
     @dist_init
     def test_py_built_in(self):
         n = self.rank + 1


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #29473 Enable test_stress_light_rpc in rpc_test.py
* #29472 Enable test_py_rref_args_user_share in rpc_test.py
* #29471 Enable test_multi_py_udf_remote in rpc_test.py
* **#29470 Enable test_py_built_in in rpc_test.py**

After landing #29069 and #29396, the flakiness in this test should disappear, hence re-enable it.

Differential Revision: [D18404822](https://our.internmc.facebook.com/intern/diff/D18404822)