### PR TITLE
Enable test_py_rref_args_user_share in rpc_test.py

### DIFF
--- a/test/rpc_test.py
+++ b/test/rpc_test.py
@@ -782,7 +782,6 @@ class RpcTest(object):
         )
         self.assertEqual(rref_c.to_here(), torch.ones(n, n) + 4)
 
-    @unittest.skip("Test is flaky, see https://github.com/pytorch/pytorch/issues/29212")
     @dist_init
     def test_py_rref_args_user_share(self):
         n = self.rank + 1


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #29473 Enable test_stress_light_rpc in rpc_test.py
* **#29472 Enable test_py_rref_args_user_share in rpc_test.py**
* #29471 Enable test_multi_py_udf_remote in rpc_test.py
* #29470 Enable test_py_built_in in rpc_test.py

After landing #29069 and #29396, the flakiness in this test should disappear, hence re-enable it.

Differential Revision: [D18404818](https://our.internmc.facebook.com/intern/diff/D18404818)