### PR TITLE
Enable test_stress_light_rpc in rpc_test.py

### DIFF
--- a/test/rpc_test.py
+++ b/test/rpc_test.py
@@ -668,7 +668,6 @@ class RpcTest(object):
             )
         )
 
-    @unittest.skip("Test is flaky, see https://github.com/pytorch/pytorch/issues/29150")
     @dist_init
     def test_stress_light_rpc(self):
         self._stress_test_rpc(light_rpc)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#29473 Enable test_stress_light_rpc in rpc_test.py**
* #29472 Enable test_py_rref_args_user_share in rpc_test.py
* #29471 Enable test_multi_py_udf_remote in rpc_test.py
* #29470 Enable test_py_built_in in rpc_test.py

After landing #29069 and #29396, the flakiness in this test should disappear, hence re-enable it.

Differential Revision: [D18404820](https://our.internmc.facebook.com/intern/diff/D18404820)