### PR TITLE
[JIT] Check for unrolled loop in break & continue

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -7565,6 +7565,16 @@ a")
                         break
                 ''')
 
+        with self.assertRaisesRegex(RuntimeError, "do not support break or continue inside"):
+            @torch.jit.script
+            def foo(x):
+                i = 0
+                for a in (1, "2", 1.5):
+                    b = a
+                    if x:
+                        break
+                return b
+
     def test_python_call(self):
         def pyfunc(a):
             return a * 3.0

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -835,8 +835,7 @@ struct to_ir {
     // it is not a real thing yet, so just say the type is None
     closure_node->output()->setType(NoneType::get());
     Block* block = closure_node->addBlock();
-    auto prev_status = loop_status_;
-    WithLoopStatus guard(&loop_status_, LoopStatus::NOT_IN_LOOP);
+    WithLoopStatus loop_guard(&loop_status_, LoopStatus::NOT_IN_LOOP);
     {
       WithInsertPoint guard(block);
       pushFrame(block, /*starts_def=*/true);

--- a/torch/csrc/jit/script/parser.cpp
+++ b/torch/csrc/jit/script/parser.cpp
@@ -529,17 +529,11 @@ struct ParserImpl {
       }
       case TK_BREAK: {
         auto range = L.next().range;
-        if (cur_loop_count == 0) {
-          throw ErrorReport(range) << "SyntaxError: 'break' outside loop";
-        }
         L.expect(TK_NEWLINE);
         return Break::create(range);
       }
       case TK_CONTINUE: {
         auto range = L.next().range;
-        if (cur_loop_count == 0) {
-          throw ErrorReport(range) << "SyntaxError: 'continue' outside loop";
-        }
         L.expect(TK_NEWLINE);
         return Continue::create(range);
       }
@@ -588,9 +582,7 @@ struct ParserImpl {
     L.expect(TK_WHILE);
     auto cond = parseExp();
     L.expect(':');
-    cur_loop_count++;
     auto body = parseStatements(/*expect_indent=*/true);
-    cur_loop_count--;
     return While::create(r, Expr(cond), List<Stmt>(body));
   }
 
@@ -599,9 +591,7 @@ struct ParserImpl {
     L.expect(TK_FOR);
     auto targets = parseList(TK_NOTHING, ',', TK_IN, &ParserImpl::parseLHSExp);
     auto itrs = parseList(TK_NOTHING, ',', ':', &ParserImpl::parseExp);
-    cur_loop_count++;
     auto body = parseStatements(/*expect_indent=*/true);
-    cur_loop_count--;
     return For::create(r, targets, itrs, body);
   }
 
@@ -668,8 +658,6 @@ TreeRef parseClass() {
   }
 
   TreeRef parseFunction(bool is_method) {
-    size_t old_loop_count = cur_loop_count;
-    cur_loop_count = 0;
     L.expect(TK_DEF);
     auto name = parseIdent();
     auto decl = parseDecl();
@@ -684,7 +672,6 @@ TreeRef parseClass() {
     }
 
     auto stmts_list = parseStatements(false);
-    cur_loop_count = old_loop_count;
     return Def::create(
         name.range(), Ident(name), Decl(decl), List<Stmt>(stmts_list));
   }
@@ -703,7 +690,6 @@ TreeRef parseClass() {
   TreeRef makeList(const SourceRange& range, TreeList&& trees) {
     return create_compound(TK_LIST, range, std::move(trees));
   }
-  size_t cur_loop_count = 0;
   Lexer L;
   SharedParserData& shared;
 };


### PR DESCRIPTION
For the same reason we don't allow iteration over heterogenous types (modulelists/tuples) with types that don't have a static length, we also can't break/continue within them - we need to statically know all types.
