### PR TITLE
Fix jit tracing namedtuple

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -447,6 +447,18 @@ class TestJit(JitTestCase):
         jit_f2 = torch.jit.trace(f2, x)
         assert f2(x) == jit_f2(x)  # fails
 
+    def test_trace_namedtuple(self):
+        Point = namedtuple('point', ['x', 'y'])
+
+        def f(p):
+            if type(p) is tuple:
+                p = Point(*p)
+            return p.x + p.y
+
+        p = Point(torch.randn(1), torch.randn(1))
+        traced = torch.jit.trace(f, (p,))
+        self.assertEqual(f(p), traced(p))
+
     @unittest.skipIf(not RUN_CUDA, "restore device requires CUDA")
     def test_restore_device_cuda(self):
         class MyModule(torch.jit.ScriptModule):

--- a/torch/autograd/function.py
+++ b/torch/autograd/function.py
@@ -254,7 +254,11 @@ def _nested_map(condition, fn, condition_msg=None):
         elif obj is None:
             return None
         elif isinstance(obj, (list, tuple)):
-            return type(obj)(_map(x) for x in obj)
+            mapped = (_map(x) for x in obj)
+            if hasattr(obj, '_fields'):
+                # obj is namedtuple
+                return type(obj)(*mapped)
+            return type(obj)(mapped)
         elif isinstance(obj, dict):
             return {x : _map(obj[x]) for x in obj}
         else:

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -363,6 +363,22 @@ class ONNXTracedModule(Module):
             return graph, outs[0]
 
 
+def _clone_inputs(args):
+    def clone_input(a):
+        if a is None:
+            return None
+        elif isinstance(a, torch.Tensor):
+            # TODO: figure out one liner to .clone() and set requires_grad
+            v = Variable(a.data.clone(memory_format=torch.preserve_format), requires_grad=a.requires_grad)
+            if a.grad is not None:
+                v.grad = clone_input(v.grad)
+            return v
+        else:
+            return a.clone(memory_format=torch.preserve_format)
+    return function._nested_map(lambda x: isinstance(x, torch.Tensor),
+                                clone_input, condition_msg="tensors")(args)
+
+
 # This is purely for developer debugging.  We are not going to advertise it.
 _JIT_DUMP = os.environ.get('PYTORCH_JIT_DUMP', False)
 _JIT_TIME = os.environ.get('PYTORCH_JIT_TIME', False)  # CUDA-only timing
@@ -442,7 +458,7 @@ def verify(model, args, loss_fn=torch.sum, devices=None):
     if not isinstance(args, tuple):
         args = (args,)
 
-    saved_args = copy.deepcopy(args)
+    saved_args = _clone_inputs(args)
     if is_module:
         saved_state = copy.deepcopy(model.state_dict())
 
@@ -522,7 +538,7 @@ def _check_trace(check_inputs, func, traced_func, check_tolerance,
         if is_trace_module:
             copied_dict = {}
             for name, data in inputs.items():
-                copied_dict[name] = copy.deepcopy(data)
+                copied_dict[name] = _clone_inputs(data)
             check_mod = torch.jit.trace_module(
                 func.__self__ if hasattr(func, '__self__') else func,
                 copied_dict,
@@ -538,7 +554,7 @@ def _check_trace(check_inputs, func, traced_func, check_tolerance,
         else:
             check_mod = torch.jit.trace(
                 func,
-                copy.deepcopy(inputs),
+                _clone_inputs(inputs),
                 check_trace=False,
                 _force_outplace=force_outplace,
                 _module_class=_module_class,
@@ -609,7 +625,7 @@ def _check_trace(check_inputs, func, traced_func, check_tolerance,
 
         def run_mod_and_filter_tensor_outputs(mod, inputs, running_what):
             try:
-                outs = wrap_retval(mod(*copy.deepcopy(inputs)))
+                outs = wrap_retval(mod(*_clone_inputs(inputs)))
                 outs = [out for out in outs if isinstance(out, torch.Tensor)]
                 return outs
             except Exception as e:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#29477 Use copy.deepcopy instead of a special implmentation to clone tracing inputs**

When passing in a namedtuple as trcing input, __clone_inputs will call into `torch.autograd.function._nested_map` and https://github.com/pytorch/pytorch/blob/593bb14/torch/autograd/function.py#L256 will run into error (because namedtuple doesn't support this style of constructor).

Differential Revision: [D18405504](https://our.internmc.facebook.com/intern/diff/D18405504/)