### PR TITLE
[ci] kill pytorch_linux_xenial_cuda9_cudnn7_py2

### DIFF
--- a/.circleci/cimodel/data/pytorch_build_data.py
+++ b/.circleci/cimodel/data/pytorch_build_data.py
@@ -39,7 +39,6 @@ CONFIG_TREE_DATA = [
                 # and
                 # https://github.com/pytorch/pytorch/blob/master/.jenkins/pytorch/build.sh#L153
                 # (from https://github.com/pytorch/pytorch/pull/17323#discussion_r259453144)
-                X("2.7"),
                 XImportant("3.6"),
                 ("3.6", [
                     ("libtorch", [XImportant(True)])

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1674,31 +1674,6 @@ workflows:
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3.6-clang7:347"
           resource_class: large
       - pytorch_linux_build:
-          name: pytorch_linux_xenial_cuda9_cudnn7_py2_build
-          requires:
-            - setup
-          filters:
-            branches:
-              only:
-                - master
-                - /ci-all\/.*/
-          build_environment: "pytorch-linux-xenial-cuda9-cudnn7-py2-build"
-          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py2:347"
-      - pytorch_linux_test:
-          name: pytorch_linux_xenial_cuda9_cudnn7_py2_test
-          requires:
-            - setup
-            - pytorch_linux_xenial_cuda9_cudnn7_py2_build
-          filters:
-            branches:
-              only:
-                - master
-                - /ci-all\/.*/
-          build_environment: "pytorch-linux-xenial-cuda9-cudnn7-py2-test"
-          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py2:347"
-          use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
-      - pytorch_linux_build:
           name: pytorch_linux_xenial_cuda9_cudnn7_py3_build
           requires:
             - setup


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#29479 [ci] kill pytorch_linux_xenial_cuda9_cudnn7_py2**
* #29478 [ci] remove non-onnx caffe2 builds

Differential Revision: [D18406234](https://our.internmc.facebook.com/intern/diff/D18406234)