### PR TITLE
don't set DEBUG=1 in py3.6-gcc5.4 CI build

### DIFF
--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -135,10 +135,6 @@ if [[ "$BUILD_ENVIRONMENT" == *ppc64le* ]]; then
   export TORCH_CUDA_ARCH_LIST="6.0"
 fi
 
-if [[ "$BUILD_ENVIRONMENT" == *xenial-py3.6-gcc5.4* ]]; then
-  export DEBUG=1
-fi
-
 # Patch required to build xla
 if [[ "${BUILD_ENVIRONMENT}" == *xla* ]]; then
   git clone --recursive https://github.com/pytorch/xla.git


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#29491 don't set DEBUG=1 in py3.6-gcc5.4 CI build**

Setting DEBUG=1 causes tests to run super slow. There are two reasons
why you might do it:
1. Testing `#NDEBUG` stuff. We don't really use this macro.
2. https://github.com/pytorch/pytorch/issues/4119. This is valid,
but I would prefer to allow internal contbuilds to test this, as the
infra is better there.

Differential Revision: [D18411635](https://our.internmc.facebook.com/intern/diff/D18411635)