### PR TITLE
reduce op bench binary size

### DIFF
--- a/benchmarks/operator_benchmark/benchmark_caffe2.py
+++ b/benchmarks/operator_benchmark/benchmark_caffe2.py
@@ -6,7 +6,6 @@ from __future__ import unicode_literals
 from caffe2.python import workspace
 from caffe2.python import core
 from caffe2.proto import caffe2_pb2
-import benchmark_core
 import benchmark_utils
 from collections import namedtuple
 from benchmark_test_generator import _generate_test
@@ -133,9 +132,12 @@ class Caffe2OperatorTestCase(object):
         pass
 
 
-def register_caffe2_op_test_case(op_bench, test_config):
+def create_caffe2_op_test_case(op_bench, test_config):
     test_case = Caffe2OperatorTestCase(op_bench, test_config)
-    benchmark_core._register_test(test_case)
+    test_config = test_case.test_config
+    op = test_case.op_bench
+    func_name = "{}{}{}".format(op.module_name(), test_case.framework, str(test_config))
+    return (func_name, test_case)
 
 
 OpMeta = namedtuple("OpMeta", "op_type num_inputs input_dims input_types \
@@ -180,7 +182,7 @@ def generate_c2_test_from_ops(ops_metadata, bench_op, tags):
             str(op_metadata.args))
         test_config = TestConfig(test_name, input_config, tags, run_backward=False)
         if op is not None:
-            register_caffe2_op_test_case(
+            create_caffe2_op_test_case(
                 op,
                 test_config)
 
@@ -188,12 +190,12 @@ def generate_c2_test_from_ops(ops_metadata, bench_op, tags):
 def generate_c2_test(configs, c2_bench_op):
     """ This function creates Caffe2 op test based on the given operator
     """
-    _generate_test(configs, c2_bench_op, register_caffe2_op_test_case,
-                   run_backward=False)
+    return _generate_test(configs, c2_bench_op, create_caffe2_op_test_case,
+                          run_backward=False)
 
 
 def generate_c2_gradient_test(configs, c2_bench_op):
     """ This function creates Caffe2 op test based on the given operator
     """
-    _generate_test(configs, c2_bench_op, register_caffe2_op_test_case,
-                   run_backward=True)
+    return _generate_test(configs, c2_bench_op, create_caffe2_op_test_case,
+                          run_backward=True)

--- a/benchmarks/operator_benchmark/benchmark_core.py
+++ b/benchmarks/operator_benchmark/benchmark_core.py
@@ -8,6 +8,8 @@ import numpy as np
 import timeit
 import json
 import torch
+import copy
+import ast
 
 # needs to be imported after torch
 import cpp_extension # noqa
@@ -30,24 +32,128 @@ TestConfig(test_name='add_M8_N2_K1', input_config='M: 8, N: 2, K: 1',
 TestConfig = namedtuple("TestConfig", "test_name input_config tag run_backward")
 
 
-BENCHMARK_TESTER = {}
-
-
-def _register_test(test_case):
-    """ This method is used to register test. func_name is a global unique
-    string. For PyTorch add operator with M=8, N=2, K=1, tag = long, here
-    are the values for the members in test_case:
-    op.module_name: add
-    framework: PyTorch
-    test_config: TestConfig(test_name='add_M8_N2_K1', input_config='M: 8, N: 2, K: 1',
-        tag='long', run_backward=False)
-    func_name: addPyTorchTestConfig(test_name='add_M8_N2_K1', input_config='M: 8, N: 2, K: 1',
-                                    tag='long', run_backward=False)
+BENCHMARK_TESTER = []
+def _register_test(*test_metainfo):
+    """ save the metainfo needed to create a test. Currently test_metainfo
+        takes two different inputs:
+        1) This input when adds single op to the benchmark
+         _register_test(configs, pt_bench_op, create_pytorch_op_test_case,
+                          run_backward=True)
+        2) This input when addes a list of ops to the benchmark
+        _register_test(configs, pt_bench_op, create_pytorch_op_test_case,
+                          run_backward=False,
+                          op_name_function=op)
     """
-    test_config = test_case.test_config
-    op = test_case.op_bench
-    func_name = "{}{}{}".format(op.module_name(), test_case.framework, str(test_config))
-    BENCHMARK_TESTER[func_name] = test_case
+    BENCHMARK_TESTER.append(test_metainfo)
+
+
+def _create_test(bench_op_obj, orig_test_attrs, tags, OperatorTestCase, run_backward, bwd_input):
+    """ Create tests with the benchmark backend.
+        Args:
+            bench_op_obj: an object which instantiated from a subclass of
+                Caffe2BenchmarkBase/TorchBenchmarkBase which includes tensor
+                creation and operator execution.
+            test_attrs: a dictionary includes test configs.
+            tags: a attribute in test config to filter inputs
+            OperatorTestCase: a named tuple to save the metadata of an test
+            run_backward: a bool parameter indicating backward path
+    """
+    test_attrs = copy.deepcopy(orig_test_attrs)
+    test_attrs = {k: str(v) for k, v in test_attrs.items()}
+    ascii_test_attrs = ast.literal_eval(json.dumps(test_attrs))
+    input_config = str(ascii_test_attrs)[1:-1].replace('\'', '')
+    if bwd_input:
+        # When auto_set is used, the test name needs to include input.
+        test_attrs.update({'bwd': bwd_input})
+    test_name = bench_op_obj.test_name(**test_attrs)
+    test_config = TestConfig(test_name, input_config, tags, run_backward)
+    return OperatorTestCase(bench_op_obj, test_config)
+
+def _build_test(configs, bench_op, OperatorTestCase, run_backward, op_name_function=None):
+    """Generate PyTorch/Caffe2 tests of operators with different inputs.
+       Args:
+           configs: a dictionary that has the input shapes
+           bench_op: a subclass of Caffe2BenchmarkBase/TorchBenchmarkBase which includes tensor
+               creation and operator execution
+           OperatorTestCase: a named tuple to save the metadata of an test
+           run_backward: a bool parameter indicating backward path
+           op_name_function: a dictionary includes operator name and function
+    """
+    test_list = []
+    for config in configs:
+        test_attrs = {}
+        tags = None
+        keep_config = True
+        for attr in config:
+            # tags is only used in our benchmark backend to filter tests and
+            # it will be removed from config which is then passed to the init function
+            # an example of config and atrr is:
+            # config: [{'M': 16}, {'N': 16}, {'K': 64}, {'tags': 'short'}]
+            # attr: {'tags': 'short'}
+            if "tags" in attr:
+                tags = attr["tags"]
+                continue
+
+            # if 'cuda' is sepcified in input shape but the testing machines doesn't
+            # support, we will skip this input
+            if 'cuda' in attr.values():
+                if not torch.cuda.is_available():
+                    keep_config = False
+                    break
+
+            test_attrs.update(attr)
+
+        if not keep_config:
+            continue
+
+        if tags is None:
+            raise ValueError("Missing tags in configs")
+        input_config = str(test_attrs)[1:-1].replace('\'', '')
+        op = bench_op()
+        assert op is not None, "Can't create test"
+        tensor_error_info = None
+        # op_name_function is a dictionary which has op_name and op_function.
+        # an example of op_name_function is:
+        # {'op_name' : 'abs', 'op_function' : torch.abs}
+        # op_function is concatenated with the input dict then passed to the init function
+        # op_name is passed to the set_module_name function
+        init_dict = copy.deepcopy(test_attrs)
+        if op_name_function is not None:
+            op_name = op_name_function['op_name']
+            init_dict.update({'op_func' : op_name_function['op_func']})
+            op.set_module_name(op_name)
+
+        op._set_backward_test(run_backward)
+        try:
+            op.init(**init_dict)
+        except SkipInputShape:
+            print("Skipping: Config<{}> is not valid for op<{}>".format(input_config, op.module_name()))
+            continue
+
+        input_name = None
+
+        # _num_inputs_require_grads is used to track the number of tensors
+        # which use auto_set().
+        if op._num_inputs_require_grads > 0:
+            input_name = 'all'
+        test_list.append(_create_test(op, test_attrs, tags, OperatorTestCase, run_backward, input_name))
+
+        # This for loop is only used when auto_set is used.
+        # _pass_count counts how many times init has been called.
+        # _auto_set_counter is reset after init is called.
+        for i in range(op._num_inputs_require_grads):
+            op._pass_count += 1
+            op._auto_set_counter = 0
+
+            # TODO(mingzhe09088): remove this deepcopy when we encounter
+            # performance issue.
+            new_op = copy.deepcopy(op)
+            new_op.init(**init_dict)
+            # Input name index will start from input1
+            input_name = i + 1
+            test_list.append(_create_test(new_op, test_attrs, tags, OperatorTestCase, run_backward, input_name))
+
+    return test_list
 
 
 class BenchmarkRunner(object):
@@ -253,33 +359,38 @@ class BenchmarkRunner(object):
         if self.args.list_ops or self.args.list_tests:
             return
 
-        for full_test_id, test_case in BENCHMARK_TESTER.items():
-            op_test_config = test_case.test_config
+        for test_metainfo in BENCHMARK_TESTER:
+            # If auto_set is used, _build_test will return a list of tests including
+            # forward and backward ones
+            test_list = _build_test(*test_metainfo)
+            for test in test_list:
+                full_test_id, test_case = test
+                op_test_config = test_case.test_config
 
-            if not self._keep_test(test_case):
-                continue
+                if not self._keep_test(test_case):
+                    continue
 
-            # To reduce variance, fix a numpy randseed to the test case,
-            # so that the randomly generated input tensors remain the
-            # same for each test case.
-            # The random seed is limited to 32-bit because of numpy
-            # requirement.
-            np.random.seed(seed=hash(full_test_id) & ((1 << 32) - 1))
+                # To reduce variance, fix a numpy randseed to the test case,
+                # so that the randomly generated input tensors remain the
+                # same for each test case.
+                # The random seed is limited to 32-bit because of numpy
+                # requirement.
+                np.random.seed(seed=hash(full_test_id) & ((1 << 32) - 1))
 
-            print("# Benchmarking {}: {}".format(
-                test_case.framework,
-                test_case.op_bench.module_name()))
+                print("# Benchmarking {}: {}".format(
+                    test_case.framework,
+                    test_case.op_bench.module_name()))
 
-            if op_test_config.run_backward:
-                launch_func = self._launch_backward
-            else:
-                launch_func = self._launch_forward
+                if op_test_config.run_backward:
+                    launch_func = self._launch_backward
+                else:
+                    launch_func = self._launch_forward
 
-            # Warmup
-            launch_func(test_case, self.args.warmup_iterations, print_per_iter=False)
-            # Actual Execution
-            reported_time = [self._measure_time(launch_func, test_case,
-                                                self.iters, self.print_per_iter)
-                             for _ in range(self.num_runs)]
+                # Warmup
+                launch_func(test_case, self.args.warmup_iterations, print_per_iter=False)
+                # Actual Execution
+                reported_time = [self._measure_time(launch_func, test_case,
+                                                    self.iters, self.print_per_iter)
+                                 for _ in range(self.num_runs)]
 
-            self._print_perf_result(reported_time, test_case)
+                self._print_perf_result(reported_time, test_case)

--- a/benchmarks/operator_benchmark/benchmark_pytorch.py
+++ b/benchmarks/operator_benchmark/benchmark_pytorch.py
@@ -5,7 +5,6 @@ from __future__ import unicode_literals
 
 import time
 import json
-import benchmark_core
 import torch
 import cpp_extension # noqa
 
@@ -179,6 +178,19 @@ class PyTorchOperatorTestCase(object):
             self.mean.backward(retain_graph=True)
 
 
-def register_pytorch_op_test_case(op_bench, test_config):
+def create_pytorch_op_test_case(op_bench, test_config):
+    """ This method is used to generate est. func_name is a global unique
+    string. For PyTorch add operator with M=8, N=2, K=1, tag = long, here
+    are the values for the members in test_case:
+    op.module_name: add
+    framework: PyTorch
+    test_config: TestConfig(test_name='add_M8_N2_K1', input_config='M: 8, N: 2, K: 1',
+        tag='long', run_backward=False)
+    func_name: addPyTorchTestConfig(test_name='add_M8_N2_K1', input_config='M: 8, N: 2, K: 1',
+                                    tag='long', run_backward=False)
+    """
     test_case = PyTorchOperatorTestCase(op_bench, test_config)
-    benchmark_core._register_test(test_case)
+    test_config = test_case.test_config
+    op = test_case.op_bench
+    func_name = "{}{}{}".format(op.module_name(), test_case.framework, str(test_config))
+    return (func_name, test_case)

--- a/benchmarks/operator_benchmark/benchmark_test_generator.py
+++ b/benchmarks/operator_benchmark/benchmark_test_generator.py
@@ -3,133 +3,20 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import copy
-import ast
-import json
-import torch
-from benchmark_core import TestConfig
-from benchmark_pytorch import register_pytorch_op_test_case
-from benchmark_utils import SkipInputShape
-
-
-def _register_test(bench_op_obj, orig_test_attrs, tags, OperatorTestCase, run_backward, bwd_input):
-    """ Register tests with the benchmark backend.
-        Args:
-            bench_op_obj: an object which instantiated from a subclass of
-                Caffe2BenchmarkBase/TorchBenchmarkBase which includes tensor
-                creation and operator execution.
-            test_attrs: a dictionary includes test configs.
-            tags: a attribute in test config to filter inputs
-            OperatorTestCase: a named tuple to save the metadata of an test
-            run_backward: a bool parameter indicating backward path
-    """
-    test_attrs = copy.deepcopy(orig_test_attrs)
-    test_attrs = {k: str(v) for k, v in test_attrs.items()}
-    ascii_test_attrs = ast.literal_eval(json.dumps(test_attrs))
-    input_config = str(ascii_test_attrs)[1:-1].replace('\'', '')
-    if bwd_input:
-        # When auto_set is used, the test name needs to include input.
-        test_attrs.update({'bwd': bwd_input})
-    test_name = bench_op_obj.test_name(**test_attrs)
-    test_config = TestConfig(test_name, input_config, tags, run_backward)
-    OperatorTestCase(bench_op_obj, test_config)
-
-def _generate_test(configs, bench_op, OperatorTestCase, run_backward, op_name_function=None):
-    """Generate PyTorch/Caffe2 tests of operators with different inputs.
-       Args:
-           configs: a dictionary that has the input shapes
-           bench_op: a subclass of Caffe2BenchmarkBase/TorchBenchmarkBase which includes tensor
-               creation and operator execution
-           OperatorTestCase: a named tuple to save the metadata of an test
-           run_backward: a bool parameter indicating backward path
-           op_name_function: a dictionary includes operator name and function
-    """
-    for config in configs:
-        test_attrs = {}
-        tags = None
-        keep_config = True
-        for attr in config:
-            # tags is only used in our benchmark backend to filter tests and
-            # it will be removed from config which is then passed to the init function
-            # an example of config and atrr is:
-            # config: [{'M': 16}, {'N': 16}, {'K': 64}, {'tags': 'short'}]
-            # attr: {'tags': 'short'}
-            if "tags" in attr:
-                tags = attr["tags"]
-                continue
-
-            # if 'cuda' is sepcified in input shape but the testing machines doesn't
-            # support, we will skip this input
-            if 'cuda' in attr.values():
-                if not torch.cuda.is_available():
-                    keep_config = False
-                    break
-
-            test_attrs.update(attr)
-
-        if not keep_config:
-            continue
-
-        if tags is None:
-            raise ValueError("Missing tags in configs")
-        input_config = str(test_attrs)[1:-1].replace('\'', '')
-        op = bench_op()
-        assert op is not None, "Can't create test"
-        tensor_error_info = None
-        # op_name_function is a dictionary which has op_name and op_function.
-        # an example of op_name_function is:
-        # {'op_name' : 'abs', 'op_function' : torch.abs}
-        # op_function is concatenated with the input dict then passed to the init function
-        # op_name is passed to the set_module_name function
-        init_dict = copy.deepcopy(test_attrs)
-        if op_name_function is not None:
-            op_name = op_name_function['op_name']
-            init_dict.update({'op_func' : op_name_function['op_func']})
-            op.set_module_name(op_name)
-
-        op._set_backward_test(run_backward)
-        try:
-            op.init(**init_dict)
-        except SkipInputShape:
-            print("Skipping: Config<{}> is not valid for op<{}>".format(input_config, op.module_name()))
-            continue
-
-        input_name = None
-
-        # _num_inputs_require_grads is used to track the number of tensors
-        # which use auto_set().
-        if op._num_inputs_require_grads > 0:
-            input_name = 'all'
-        _register_test(op, test_attrs, tags, OperatorTestCase, run_backward, input_name)
-
-        # This for loop is only used when auto_set is used.
-        # _pass_count counts how many times init has been called.
-        # _auto_set_counter is reset after init is called.
-        for i in range(op._num_inputs_require_grads):
-            op._pass_count += 1
-            op._auto_set_counter = 0
-
-            # TODO(mingzhe09088): remove this deepcopy when we encounter
-            # performance issue.
-            new_op = copy.deepcopy(op)
-            new_op.init(**init_dict)
-            # Input name index will start from input1
-            input_name = i + 1
-            _register_test(new_op, test_attrs, tags, OperatorTestCase, run_backward, input_name)
+from benchmark_core import _register_test
+from benchmark_pytorch import create_pytorch_op_test_case
 
 
 def generate_pt_test(configs, pt_bench_op):
     """ This function creates PyTorch op test based on the given operator
     """
-    _generate_test(configs, pt_bench_op, register_pytorch_op_test_case,
-                   run_backward=False)
+    _register_test(configs, pt_bench_op, create_pytorch_op_test_case, False)
 
 
 def generate_pt_gradient_test(configs, pt_bench_op):
     """ This function creates PyTorch op test based on the given operator
     """
-    _generate_test(configs, pt_bench_op, register_pytorch_op_test_case,
-                   run_backward=True)
+    _register_test(configs, pt_bench_op, create_pytorch_op_test_case, True)
 
 
 def generate_pt_tests_from_op_list(ops_list, configs, pt_bench_op):
@@ -154,6 +41,4 @@ def generate_pt_tests_from_op_list(ops_list, configs, pt_bench_op):
         op_bench.generate_pt_tests_from_op_list(unary_ops_list, unary_ops_configs, UnaryOpBenchmark)
     """
     for op in ops_list:
-        _generate_test(configs, pt_bench_op, register_pytorch_op_test_case,
-                       run_backward=False,
-                       op_name_function=op)
+        _register_test(configs, pt_bench_op, create_pytorch_op_test_case, False, op)

--- a/benchmarks/operator_benchmark/pt/add_test.py
+++ b/benchmarks/operator_benchmark/pt/add_test.py
@@ -35,7 +35,7 @@ class AddBenchmark(op_bench.TorchBenchmarkBase):
     def init(self, M, N, K, device):
         self.input_one = torch.rand(M, N, K, device=device, requires_grad=self.auto_set())
         self.input_two = torch.rand(M, N, K, device=device, requires_grad=self.auto_set())
-        self.set_module_name("add_")
+        self.set_module_name("add")
 
     def forward(self):
         return torch.add(self.input_one, self.input_two)


### PR DESCRIPTION
Summary: This diff reduces the binary size of op benchmark by avoiding creating all tests at once.

Test Plan:
```
buck run //caffe2/benchmarks/operator_benchmark:benchmark_all_test

# ----------------------------------------
# PyTorch/Caffe2 Operator Micro-benchmarks
# ----------------------------------------
# Tag : long

# Benchmarking PyTorch: add
# Mode: Eager
# Name: add_M8_N2_K1_cpu
# Input: M: 8, N: 2, K: 1, device: cpu
Forward Execution Time (us) : 160.781

# Benchmarking PyTorch: add
# Mode: Eager
# Name: add_M8_N2_K8_cpu
# Input: M: 8, N: 2, K: 8, device: cpu
Forward Execution Time (us) : 158.941

Differential Revision: D18412342

