### PR TITLE
set the no_deadline for the adaptive_avg_pool_nhwc test

### DIFF
--- a/test/test_quantized.py
+++ b/test/test_quantized.py
@@ -656,6 +656,7 @@ class TestQuantizedOps(TestCase):
                                                           qX_hat.q_zero_point()))
 
     """Tests adaptive average pool operation on NHWC quantized tensors."""
+    @no_deadline
     @given(X=hu.tensor(shapes=hu.array_shapes(min_dims=4, max_dims=4,
                                               min_side=1, max_side=10),
                        qparams=hu.qparams(dtypes=torch.qint8)),


### PR DESCRIPTION
It is reported this test is flaky due to the time expiration. This pr flags it as no_deadline test.