### PR TITLE
Restrict cosine_similarity max value to 1.0

### DIFF
--- a/aten/src/ATen/native/Distance.cpp
+++ b/aten/src/ATen/native/Distance.cpp
@@ -171,7 +171,7 @@ Tensor cosine_similarity(const Tensor& x1, const Tensor& x2, int64_t dim, double
   Tensor w1 = at::sum(x1 * x1, dim);
   Tensor w2 = at::sum(x2 * x2, dim);
   Tensor n12 = (w1 * w2).clamp_min_(eps * eps).sqrt_();
-  return w12.div_(n12);
+  return w12.div_(n12).clamp_max_(1.0);
 }
 
 }}  // namespace at::native

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -6329,6 +6329,12 @@ class TestNN(NNTestCase):
         self.assertEqual(input1.grad, torch.zeros_like(input1))
         self.assertEqual(input2.grad, input1 * 1e8)
 
+        # check if values are always between 0 and 1.
+        x = torch.tensor([[-0.8948,1.2475,3.9083,6.8356,1.6460,0.0952,-5.5912]])
+        y = torch.tensor([[-0.8950,1.2474,3.9082,6.8355,1.6460,0.0951,-5.5912]])
+        c = F.consine_similarity(x,y, dim=1)
+        self.assertEqual(c.max() - 1.0 == 0.0, prec=1e-7)
+
     def test_grid_sample_error_checking(self):
         input = torch.empty(1, 1, 2, 2)
         grid = torch.empty(1, 1, 1, 2)


### PR DESCRIPTION
This clamps the highest value achievable by `cosine_similarity` to `1.0`.

Fix for https://github.com/pytorch/pytorch/issues/29442

CC: @ezyang 