### PR TITLE
Improve CHECK_OP macro

### DIFF
--- a/c10/util/logging_is_not_google_glog.h
+++ b/c10/util/logging_is_not_google_glog.h
@@ -127,7 +127,7 @@ static_assert(
 #define CHECK_OP(val1, val2, op)                      \
   FATAL_IF(((val1) op (val2)))                        \
     << "Check failed: " #val1 " " #op " " #val2 " ("  \
-    << (val1) << " vs. " << (val2) << ")"
+    << (val1) << " vs. " << (val2) << ") "
 
 // Check_op macro definitions
 #define CHECK_EQ(val1, val2) CHECK_OP(val1, val2, ==)

--- a/c10/util/logging_is_not_google_glog.h
+++ b/c10/util/logging_is_not_google_glog.h
@@ -222,6 +222,12 @@ inline std::ostream& operator<<(
   out << '(' << p.first << ", " << p.second << ')';
   return out;
 }
+
+inline std::ostream& operator<<(
+    std::ostream& out, const std::nullptr_t&) {
+  out << "(null)";
+  return out;
+}
 } // namespace std
 
 namespace c10 {

--- a/c10/util/logging_is_not_google_glog.h
+++ b/c10/util/logging_is_not_google_glog.h
@@ -124,8 +124,10 @@ static_assert(
   CHECK(condition)
 #endif // NDEBUG
 
-#define CHECK_OP(val1, val2, op) \
-  FATAL_IF((val1 op val2)) << "Check failed: " #val1 " " #op " " #val2 " "
+#define CHECK_OP(val1, val2, op)                      \
+  FATAL_IF(((val1) op (val2)))                        \
+    << "Check failed: " #val1 " " #op " " #val2 " ("  \
+    << (val1) << " vs. " << (val2) << ")"
 
 // Check_op macro definitions
 #define CHECK_EQ(val1, val2) CHECK_OP(val1, val2, ==)


### PR DESCRIPTION
- Show values in question like glog.
- Handle expressions with logical operators properly by adding
  parentheses around expressions.
- Allow outputting nullptr (some build failed without this)
