### PR TITLE
Disabling 'contig' in quantized arithmetic test

### DIFF
--- a/benchmarks/operator_benchmark/pt/qarithmetic_test.py
+++ b/benchmarks/operator_benchmark/pt/qarithmetic_test.py
@@ -10,7 +10,8 @@ import operator_benchmark as op_bench
 qarithmetic_binary_configs = op_bench.cross_product_configs(
     N=(2, 8, 64, 512),
     dtype=(torch.quint8, torch.qint8, torch.qint32),
-    contig=(False, True),
+    # contig=(False, True),  # TODO: Reenable this after #29435
+    contig=(True,),
     tags=('short',)
 )
 


### PR DESCRIPTION
Temporarily disabling the non-contiguous test. Should be reenabled once #29435 is resolved.

Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#29576 Disabling 'contig' in quantized arithmetic test**

Differential Revision: [D18433052](https://our.internmc.facebook.com/intern/diff/D18433052)