### PR TITLE
Improve `ConcreteModuleType::dump()`

### DIFF
--- a/torch/csrc/jit/script/concrete_module_type.cpp
+++ b/torch/csrc/jit/script/concrete_module_type.cpp
@@ -187,6 +187,7 @@ c10::optional<py::object> ConcreteModuleType::findConstant(
 }
 
 void ConcreteModuleType::dump() const {
+  std::cout << "ConcreteModuleType for: " << py::getattr(pyClass_, "__name__") << "\n";
   std::cout << "Constants: \n";
   for (const auto& pr : constants_) {
     std::cout << "\t" << pr.first << ": " << pr.second.v_ << "\n";
@@ -199,11 +200,16 @@ void ConcreteModuleType::dump() const {
   std::cout << "\nSubmodules: \n";
   for (const auto& info : modules_) {
     std::cout << "\t" << info.name_ << ": "
-              << info.type_->python_str() << "\n";
+          << info.getJitType()->python_str() << "\n";
   }
   std::cout << "\nOverloads: \n";
   for (const auto& pr : overloads_) {
     std::cout << "\t" << pr.first << ": " << pr.second << "\n";
+  }
+  std::string isPoisoned = isPoisoned_ ? "true" : "false";
+  std::cout << "isPoisoned: " << isPoisoned << "\n";
+  if (jitType_) {
+    std::cout << "jit type: " << jitType_->python_str() << "\n";
   }
 }
 

--- a/torch/csrc/jit/script/concrete_module_type.h
+++ b/torch/csrc/jit/script/concrete_module_type.h
@@ -225,7 +225,7 @@ class VISIBILITY_HIDDEN ConcreteModuleType {
   // If true, this type will never compare equally to anything else. This is
   // used if we want to ensure that this type is not shared (for example, if it
   // came from a traced module)
-  bool isPoisoned_;
+  bool isPoisoned_ = false;
 
   // The value of any constants defined by the module.
   std::unordered_map<std::string, Constant> constants_;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #29583 [jit] correctly share types between traced modules
* **#29582 Improve `ConcreteModuleType::dump()`**

Give it more info, fix a segfault

Differential Revision: [D18435950](https://our.internmc.facebook.com/intern/diff/D18435950)