### PR TITLE
[jit] correctly share types between traced modules

### DIFF
--- a/test/jit/test_recursive_script.py
+++ b/test/jit/test_recursive_script.py
@@ -577,3 +577,24 @@ class TestRecursiveScript(JitTestCase):
 
         with self.assertRaisesRegex(RuntimeError, "property"):
             torch.jit.script(M())
+
+    def test_inner_traced_module(self):
+        class Dummy(nn.Module):
+            def forward(self, x):
+                return x
+
+        class Model(nn.Module):
+            def __init__(self, dummies: nn.ModuleList):
+                super().__init__()
+                self._dummies = dummies
+
+            def forward(self, x):
+                out = []
+                for dummy in self._dummies:
+                    out.append(dummy(x))
+                return out
+
+        dummy = torch.jit.trace(Dummy(), torch.randn(1, 2))
+        dummies = nn.ModuleList([dummy])
+        model = Model(dummies)
+        self.checkModule(model, (torch.rand(5, 5), ))

--- a/test/jit/test_recursive_script.py
+++ b/test/jit/test_recursive_script.py
@@ -584,7 +584,7 @@ class TestRecursiveScript(JitTestCase):
                 return x
 
         class Model(nn.Module):
-            def __init__(self, dummies: nn.ModuleList):
+            def __init__(self, dummies):
                 super().__init__()
                 self._dummies = dummies
 

--- a/torch/csrc/jit/script/concrete_module_type.h
+++ b/torch/csrc/jit/script/concrete_module_type.h
@@ -112,6 +112,12 @@ class VISIBILITY_HIDDEN ConcreteModuleType {
   friend bool operator==(
       const ConcreteModuleType& lhs,
       const ConcreteModuleType& rhs) {
+    if (lhs.jitType_ == rhs.jitType_) {
+      // If the computed types are the same, these modules can (obviously) share
+      // a type.
+      return true;
+    }
+
     if (lhs.isPoisoned_ || rhs.isPoisoned_) {
       return false;
     }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#29583 [jit] correctly share types between traced modules**
* #29582 Improve `ConcreteModuleType::dump()`

The normal flow for type sharing assumes that we will construct the
`ConcreteModuleType`, then use `operator==` to decide whether or not to
reuse an existing JIT type. In this case, `jitType_` is not populated,
so it doesn't make sense to compare it.

However, there is one exception to this flow: for traced modules, we
pre-compute the JIT type and poke it into the `ConcreteModuleType`
manually. To handle this case, we should compare the `jitType_`s in
`operator==` like everything else.

Differential Revision: [D18435949](https://our.internmc.facebook.com/intern/diff/D18435949)