### PR TITLE
Restructure comparison ops so as to better support XLA dispatch

### DIFF
--- a/aten/src/ATen/native/BinaryOps.cpp
+++ b/aten/src/ATen/native/BinaryOps.cpp
@@ -1,3 +1,4 @@
+#include <type_traits>
 #include <ATen/native/BinaryOps.h>
 
 #include <ATen/ATen.h>
@@ -203,17 +204,7 @@ Tensor rsub(const Tensor& self, Scalar other, Scalar alpha) {
 }
 
 template <typename Stub>
-static inline Tensor& comparison_op_impl_out(Tensor& result, const Tensor& self, const Tensor& other, Stub& stub) {
-  auto iter = TensorIterator::comparison_op(result, self, other,
-      /*check_mem_overlap=*/true);
-  stub(iter.device_type(), iter);
-  return result;
-}
-
-template <typename Stub>
 Tensor& comparison_op_out(Tensor& result, const Tensor& self, const Tensor& other, Stub& stub) {
-  TORCH_CHECK(result.scalar_type() == kBool,
-              "The output tensor of a comparison or logical op must be a bool, but was ", result.scalar_type());
   // Validate that is possible to convert zero-dim tensor's dtype to other dtype without overflow
   if (self.scalar_type() != other.scalar_type()) {
     if (self.dim() != 0 && other.dim() == 0) {
@@ -222,91 +213,96 @@ Tensor& comparison_op_out(Tensor& result, const Tensor& self, const Tensor& othe
       check_convert(self.item(), other.scalar_type());
     }
   }
-  return native::comparison_op_impl_out(result, self, other, stub);
+  auto iter = TensorIterator::comparison_op(result, self, other, /*check_mem_overlap=*/true);
+  stub(iter.device_type(), iter);
+  return result;
 }
 
-template <typename Stub>
-Tensor comparison_op(const Tensor& self, const Tensor& other, Stub& stub) {
+template <typename OutImpl>
+Tensor comparison_op(const Tensor& self, const Tensor& other, OutImpl& out_impl) {
   Tensor result = at::empty({0}, self.options().dtype(kBool));
-  return native::comparison_op_out(result, self, other, stub);
+  return out_impl(result, self, other);
 }
 
 // To avoid overflow during type promotion we will check that both dtypes of self and other are same
-template <typename Stub>
-Tensor& comparison_op_(Tensor& self, const Tensor& other, Stub& stub) {
+template <typename OutImpl>
+Tensor& comparison_op_(Tensor& self, const Tensor& other, OutImpl& out_impl) {
   TORCH_CHECK(self.dtype() == other.dtype(),
               "Expected object of scalar type ", self.dtype(), " but got scalar type ",
               other.dtype(), " for argument 'other'");
-  return native::comparison_op_impl_out(self, self, other, stub);
+  return out_impl(self, self, other);
 }
 
 // validates that is possible to convert Scalar other to self's dtype without overflow.
 // This behavior is unique to comparison ops; arithmetic operations don't do this.
 // In the future, we should reconsider this inconsistency and decide if we want to add the same check to arithmetic ops.
-template <typename Stub>
-Tensor& comparison_op_out(Tensor& result, const Tensor& self, Scalar other, Stub& stub) {
-  return native::comparison_op_out(result, self, wrapped_scalar_tensor_and_check_convert(other, self), stub);
+template <typename OutImpl>
+Tensor& comparison_op_out(Tensor& result, const Tensor& self, Scalar other, OutImpl& out_impl) {
+  return out_impl(result, self, wrapped_scalar_tensor_and_check_convert(other, self));
 }
 
-template <typename Stub>
-Tensor comparison_op(const Tensor& self, Scalar other, Stub& stub) {
-  Tensor result = at::empty({0}, self.options().dtype(kBool));
-  return native::comparison_op_out(result, self, other, stub);
+template <typename OutImpl>
+Tensor comparison_op(const Tensor& self, Scalar other, OutImpl& out_impl) {
+  return comparison_op(self, wrapped_scalar_tensor_and_check_convert(other, self), out_impl);
 }
 
-template <typename Stub>
-Tensor& comparison_op_(Tensor& self, Scalar other, Stub& stub) {
-  return native::comparison_op_impl_out(self, self, wrapped_scalar_tensor_and_check_convert(other, self), stub);
+template <typename OutImpl>
+Tensor& comparison_op_(Tensor& self, Scalar other, OutImpl& out_impl) {
+  return out_impl(self, self, wrapped_scalar_tensor_and_check_convert(other, self));
 }
+
+// We need explicit cast to OutFunc because each *_out func is overloaded twice. Without An explicit cast, merely
+// referring to *_out function is ambiguious.
+using OutFunc = std::add_const<Tensor&(&)(Tensor&, const Tensor&, const Tensor&)>::type;
 
 Tensor& lt_out(Tensor& result, const Tensor& self, const Tensor& other) { return comparison_op_out(result, self, other, lt_stub); }
-Tensor lt(const Tensor& self, const Tensor& other) { return comparison_op(self, other, lt_stub); }
-Tensor& lt_(Tensor& self, const Tensor& other) { return comparison_op_(self, other, lt_stub); }
-Tensor& lt_out(Tensor& result, const Tensor& self, Scalar other) { return comparison_op_out(result, self, other, lt_stub); }
-Tensor lt(const Tensor& self, Scalar other) { return comparison_op(self, other, lt_stub); }
-Tensor& lt_(Tensor& self, Scalar other) { return comparison_op_(self, other, lt_stub); }
+Tensor lt(const Tensor& self, const Tensor& other) { return comparison_op(self, other, static_cast<OutFunc>(at::lt_out)); }
+Tensor& lt_(Tensor& self, const Tensor& other) { return comparison_op_(self, other, static_cast<OutFunc>(at::lt_out)); }
+Tensor& lt_out(Tensor& result, const Tensor& self, Scalar other) { return comparison_op_out(result, self, other, static_cast<OutFunc>(at::lt_out)); }
+Tensor lt(const Tensor& self, Scalar other) { return comparison_op(self, other, static_cast<OutFunc>(at::lt_out)); }
+Tensor& lt_(Tensor& self, Scalar other) { return comparison_op_(self, other, static_cast<OutFunc>(at::lt_out)); }
 
 Tensor& le_out(Tensor& result, const Tensor& self, const Tensor& other) { return comparison_op_out(result, self, other, le_stub); }
-Tensor le(const Tensor& self, const Tensor& other) { return comparison_op(self, other, le_stub); }
-Tensor& le_(Tensor& self, const Tensor& other) { return comparison_op_(self, other, le_stub); }
-Tensor& le_out(Tensor& result, const Tensor& self, Scalar other) { return comparison_op_out(result, self, other, le_stub); }
-Tensor le(const Tensor& self, Scalar other) { return comparison_op(self, other, le_stub); }
-Tensor& le_(Tensor& self, Scalar other) { return comparison_op_(self, other, le_stub); }
+Tensor le(const Tensor& self, const Tensor& other) { return comparison_op(self, other, static_cast<OutFunc>(at::le_out)); }
+Tensor& le_(Tensor& self, const Tensor& other) { return comparison_op_(self, other, static_cast<OutFunc>(at::le_out)); }
+Tensor& le_out(Tensor& result, const Tensor& self, Scalar other) { return comparison_op_out(result, self, other, static_cast<OutFunc>(at::le_out)); }
+Tensor le(const Tensor& self, Scalar other) { return comparison_op(self, other, static_cast<OutFunc>(at::le_out)); }
+Tensor& le_(Tensor& self, Scalar other) { return comparison_op_(self, other, static_cast<OutFunc>(at::le_out)); }
 
 Tensor& gt_out(Tensor& result, const Tensor& self, const Tensor& other) { return comparison_op_out(result, self, other, gt_stub); }
-Tensor gt(const Tensor& self, const Tensor& other) { return comparison_op(self, other, gt_stub); }
-Tensor& gt_(Tensor& self, const Tensor& other) { return comparison_op_(self, other, gt_stub); }
-Tensor& gt_out(Tensor& result, const Tensor& self, Scalar other) { return comparison_op_out(result, self, other, gt_stub); }
-Tensor gt(const Tensor& self, Scalar other) { return comparison_op(self, other, gt_stub); }
-Tensor& gt_(Tensor& self, Scalar other) { return comparison_op_(self, other, gt_stub); }
+Tensor gt(const Tensor& self, const Tensor& other) { return comparison_op(self, other, static_cast<OutFunc>(at::gt_out)); }
+Tensor& gt_(Tensor& self, const Tensor& other) { return comparison_op_(self, other, static_cast<OutFunc>(at::gt_out)); }
+Tensor& gt_out(Tensor& result, const Tensor& self, Scalar other) { return comparison_op_out(result, self, other, static_cast<OutFunc>(at::gt_out)); }
+Tensor gt(const Tensor& self, Scalar other) { return comparison_op(self, other, static_cast<OutFunc>(at::gt_out)); }
+Tensor& gt_(Tensor& self, Scalar other) { return comparison_op_(self, other, static_cast<OutFunc>(at::gt_out)); }
 
 Tensor& ge_out(Tensor& result, const Tensor& self, const Tensor& other) { return comparison_op_out(result, self, other, ge_stub); }
-Tensor ge(const Tensor& self, const Tensor& other) { return comparison_op(self, other, ge_stub); }
-Tensor& ge_(Tensor& self, const Tensor& other) { return comparison_op_(self, other, ge_stub); }
-Tensor& ge_out(Tensor& result, const Tensor& self, Scalar other) { return comparison_op_out(result, self, other, ge_stub); }
-Tensor ge(const Tensor& self, Scalar other) { return comparison_op(self, other, ge_stub); }
-Tensor& ge_(Tensor& self, Scalar other) { return comparison_op_(self, other, ge_stub); }
+Tensor ge(const Tensor& self, const Tensor& other) { return comparison_op(self, other, static_cast<OutFunc>(at::ge_out)); }
+Tensor& ge_(Tensor& self, const Tensor& other) { return comparison_op_(self, other, static_cast<OutFunc>(at::ge_out)); }
+Tensor& ge_out(Tensor& result, const Tensor& self, Scalar other) { return comparison_op_out(result, self, other, static_cast<OutFunc>(at::ge_out)); }
+Tensor ge(const Tensor& self, Scalar other) { return comparison_op(self, other, static_cast<OutFunc>(at::ge_out)); }
+Tensor& ge_(Tensor& self, Scalar other) { return comparison_op_(self, other, static_cast<OutFunc>(at::ge_out)); }
 
 Tensor& eq_out(Tensor& result, const Tensor& self, const Tensor& other) { return comparison_op_out(result, self, other, eq_stub); }
-Tensor eq(const Tensor& self, const Tensor& other) { return comparison_op(self, other, eq_stub); }
-Tensor& eq_(Tensor& self, const Tensor& other) { return comparison_op_(self, other, eq_stub); }
-Tensor& eq_out(Tensor& result, const Tensor& self, Scalar other) { return comparison_op_out(result, self, other, eq_stub); }
-Tensor eq(const Tensor& self, Scalar other) { return comparison_op(self, other, eq_stub); }
-Tensor& eq_(Tensor& self, Scalar other) { return comparison_op_(self, other, eq_stub); }
+Tensor eq(const Tensor& self, const Tensor& other) { return comparison_op(self, other, static_cast<OutFunc>(at::eq_out)); }
+Tensor& eq_(Tensor& self, const Tensor& other) { return comparison_op_(self, other, static_cast<OutFunc>(at::eq_out)); }
+Tensor& eq_out(Tensor& result, const Tensor& self, Scalar other) { return comparison_op_out(result, self, other, static_cast<OutFunc>(at::eq_out)); }
+Tensor eq(const Tensor& self, Scalar other) { return comparison_op(self, other, static_cast<OutFunc>(at::eq_out)); }
+Tensor& eq_(Tensor& self, Scalar other) { return comparison_op_(self, other, static_cast<OutFunc>(at::eq_out)); }
 
 Tensor& ne_out(Tensor& result, const Tensor& self, const Tensor& other) { return comparison_op_out(result, self, other, ne_stub); }
-Tensor ne(const Tensor& self, const Tensor& other) { return comparison_op(self, other, ne_stub); }
-Tensor& ne_(Tensor& self, const Tensor& other) { return comparison_op_(self, other, ne_stub); }
-Tensor& ne_out(Tensor& result, const Tensor& self, Scalar other) { return comparison_op_out(result, self, other, ne_stub); }
-Tensor ne(const Tensor& self, Scalar other) { return comparison_op(self, other, ne_stub); }
-Tensor& ne_(Tensor& self, Scalar other) { return comparison_op_(self, other, ne_stub); }
+Tensor ne(const Tensor& self, const Tensor& other) { return comparison_op(self, other, static_cast<OutFunc>(at::ne_out)); }
+Tensor& ne_(Tensor& self, const Tensor& other) { return comparison_op_(self, other, static_cast<OutFunc>(at::ne_out)); }
+Tensor& ne_out(Tensor& result, const Tensor& self, Scalar other) { return comparison_op_out(result, self, other, static_cast<OutFunc>(at::ne_out)); }
+Tensor ne(const Tensor& self, Scalar other) { return comparison_op(self, other, static_cast<OutFunc>(at::ne_out)); }
+Tensor& ne_(Tensor& self, Scalar other) { return comparison_op_(self, other, static_cast<OutFunc>(at::ne_out)); }
 
 Tensor& logical_xor_out(Tensor& result, const Tensor& self, const Tensor& other) { return comparison_op_out(result, self, other, logical_xor_stub); }
-Tensor logical_xor(const Tensor& self, const Tensor& other) { return comparison_op(self, other, logical_xor_stub); }
-Tensor& logical_xor_(Tensor& self, const Tensor& other) { return comparison_op_(self, other, logical_xor_stub); }
-Tensor& logical_xor_out(Tensor& result, const Tensor& self, Scalar other) { return comparison_op_out(result, self, other, logical_xor_stub); }
-Tensor logical_xor(const Tensor& self, Scalar other) { return comparison_op(self, other, logical_xor_stub); }
-Tensor& logical_xor_(Tensor& self, Scalar other) { return comparison_op_(self, other, logical_xor_stub); }
+Tensor logical_xor(const Tensor& self, const Tensor& other) { return comparison_op(self, other, static_cast<OutFunc>(at::logical_xor_out)); }
+Tensor& logical_xor_(Tensor& self, const Tensor& other) { return comparison_op_(self, other, static_cast<OutFunc>(at::logical_xor_out)); }
+Tensor& logical_xor_out(Tensor& result, const Tensor& self, Scalar other) { return comparison_op_out(result, self, other, static_cast<OutFunc>(at::logical_xor_out)); }
+Tensor logical_xor(const Tensor& self, Scalar other) { return comparison_op(self, other, static_cast<OutFunc>(at::logical_xor_out)); }
+Tensor& logical_xor_(Tensor& self, Scalar other) { return comparison_op_(self, other, static_cast<OutFunc>(at::logical_xor_out)); }
 
 }
 }  // namespace at

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -5199,9 +5199,8 @@ tensor([[[1., 1., 1.,  ..., 1., 1., 1.],
             self.assertEqual(x[idx] >= y[idx], ge[idx] == 1)
 
     def test_comparison_ops_must_take_bool_output(self):
-        with self.assertRaisesRegex(RuntimeError, 'The output tensor of a comparison or logical op must be a bool'):
-            for op in [torch.lt, torch.le, torch.gt, torch.ge, torch.eq, torch.ne, torch.logical_xor]:
-                op(torch.tensor([True]), torch.tensor([False]), out=torch.empty(1, dtype=torch.uint8))
+        for op in [torch.lt, torch.le, torch.gt, torch.ge, torch.eq, torch.ne, torch.logical_xor]:
+            self.assertEqual(op(torch.tensor([True]), torch.tensor([False])).dtype, torch.bool)
 
     def test_inplace_comparison_ops_require_inputs_have_same_dtype(self):
         with self.assertRaisesRegex(RuntimeError, 'Expected object of scalar type'):


### PR DESCRIPTION
Per @ailzhang's suggestion in https://github.com/pytorch/pytorch/pull/28162#discussion_r344361926, this PR changes the implementation of binary comparison and logical ops
to those of unary ops in UnaryOps.cpp. The reason is that the call should eventually go through
at::op_out (e.g., at::logical_xor_out).

The check for Boolean output tensor is also removed, because:

- This check should only apply to _out functions but not on other variants. However, other variants
  must go through the _out variant eventually.
- It does not have a clear motivation and seems unnecessary.

