### PR TITLE
[REMOVED]

### DIFF
--- a/test/cpp/api/tensor.cpp
+++ b/test/cpp/api/tensor.cpp
@@ -220,14 +220,16 @@ TEST(TensorTest, AtTensorCtorSingleDim) {
   }
 }
 
-TEST(TensorTest, TorchTensorCtorScalar) {
+TEST(TensorTest, TorchTensorCtorScalarIntegralType) {
   auto tensor = torch::tensor(123);
   ASSERT_EQ(tensor.numel(), 1);
   ASSERT_EQ(tensor.sizes(), std::vector<int64_t>({}));
-  ASSERT_EQ(tensor.dtype(), at::kInt);
+  ASSERT_EQ(tensor.dtype(), at::kLong);
   ASSERT_EQ(tensor.item<int32_t>(), 123);
+}
 
-  tensor = torch::tensor(123.456f);
+TEST(TensorTest, TorchTensorCtorScalarFloatingType) {
+  auto tensor = torch::tensor(123.456f);
   ASSERT_EQ(tensor.numel(), 1);
   ASSERT_EQ(tensor.sizes(), std::vector<int64_t>({}));
   ASSERT_EQ(tensor.dtype(), at::kFloat);
@@ -244,8 +246,10 @@ TEST(TensorTest, TorchTensorCtorScalar) {
   ASSERT_EQ(tensor.sizes(), std::vector<int64_t>({1}));
   ASSERT_EQ(tensor.dtype(), at::kDouble);
   ASSERT_TRUE(almost_equal(tensor[0], 123.456));
+}
 
-  tensor = torch::tensor(true);
+TEST(TensorTest, TorchTensorCtorScalarBoolType) {
+  auto tensor = torch::tensor(true);
   ASSERT_EQ(tensor.numel(), 1);
   ASSERT_EQ(tensor.sizes(), std::vector<int64_t>({}));
   ASSERT_EQ(tensor.dtype(), at::kBool);
@@ -258,12 +262,12 @@ TEST(TensorTest, TorchTensorCtorScalar) {
   ASSERT_TRUE(exactly_equal(tensor[0], true));
 }
 
-TEST(TensorTest, TorchTensorCtorSingleDim) {
+TEST(TensorTest, TorchTensorCtorSingleDimIntegralType) {
   auto tensor = torch::tensor({1, 2, 3});
   ASSERT_TRUE(tensor.is_variable());
   ASSERT_EQ(tensor.numel(), 3);
   ASSERT_EQ(tensor.sizes(), std::vector<int64_t>({3}));
-  ASSERT_EQ(tensor.dtype(), at::kInt);
+  ASSERT_EQ(tensor.dtype(), at::kLong);
   ASSERT_TRUE(exactly_equal(tensor[0], 1));
   ASSERT_TRUE(exactly_equal(tensor[1], 2));
   ASSERT_TRUE(exactly_equal(tensor[2], 3));
@@ -286,7 +290,27 @@ TEST(TensorTest, TorchTensorCtorSingleDim) {
   ASSERT_TRUE(exactly_equal(tensor[1], 2));
   ASSERT_TRUE(exactly_equal(tensor[2], 3));
 
-  tensor = torch::tensor({1.5, 2.25, 3.125});
+  tensor = torch::tensor(at::ArrayRef<int64_t>({1, 2, 3}));
+  ASSERT_TRUE(tensor.is_variable());
+  ASSERT_EQ(tensor.numel(), 3);
+  ASSERT_EQ(tensor.sizes(), std::vector<int64_t>({3}));
+  ASSERT_EQ(tensor.dtype(), at::kLong);
+  ASSERT_TRUE(exactly_equal(tensor[0], 1));
+  ASSERT_TRUE(exactly_equal(tensor[1], 2));
+  ASSERT_TRUE(exactly_equal(tensor[2], 3));
+
+  tensor = torch::tensor(std::vector<int64_t>({1, 2, 3}));
+  ASSERT_TRUE(tensor.is_variable());
+  ASSERT_EQ(tensor.numel(), 3);
+  ASSERT_EQ(tensor.sizes(), std::vector<int64_t>({3}));
+  ASSERT_EQ(tensor.dtype(), at::kLong);
+  ASSERT_TRUE(exactly_equal(tensor[0], 1));
+  ASSERT_TRUE(exactly_equal(tensor[1], 2));
+  ASSERT_TRUE(exactly_equal(tensor[2], 3));
+}
+
+TEST(TensorTest, TorchTensorCtorSingleDimFloatingType) {
+  auto tensor = torch::tensor({1.5, 2.25, 3.125});
   ASSERT_TRUE(tensor.is_variable());
   ASSERT_EQ(tensor.numel(), 3);
   ASSERT_EQ(tensor.sizes(), std::vector<int64_t>({3}));
@@ -311,8 +335,10 @@ TEST(TensorTest, TorchTensorCtorSingleDim) {
   ASSERT_TRUE(almost_equal(tensor[0], 1.5));
   ASSERT_TRUE(almost_equal(tensor[1], 2.25));
   ASSERT_TRUE(almost_equal(tensor[2], 3.125));
+}
 
-  tensor = torch::tensor({true, false, true});
+TEST(TensorTest, TorchTensorCtorSingleDimBoolType) {
+  auto tensor = torch::tensor({true, false, true});
   ASSERT_TRUE(tensor.is_variable());
   ASSERT_EQ(tensor.numel(), 3);
   ASSERT_EQ(tensor.sizes(), std::vector<int64_t>({3}));
@@ -331,24 +357,59 @@ TEST(TensorTest, TorchTensorCtorSingleDim) {
   ASSERT_TRUE(exactly_equal(tensor[2], true));
 }
 
-TEST(TensorTest, TorchTensorCtorMultiDim) {
+TEST(TensorTest, TorchTensorCtorMultiDimIntegralType) {
   {
     auto tensor = torch::tensor({{1, 2}});
-    ASSERT_EQ(tensor.dtype(), torch::kInt);
+    ASSERT_EQ(tensor.dtype(), torch::kLong);
     ASSERT_EQ(tensor.sizes(), std::vector<int64_t>({1, 2}));
-    ASSERT_TRUE(torch::allclose(tensor, torch::arange(1, 3, torch::kInt).view(tensor.sizes())));
+    ASSERT_TRUE(torch::allclose(tensor, torch::arange(1, 3, torch::kLong).view(tensor.sizes())));
     ASSERT_FALSE(tensor.requires_grad());
   }
   {
-    auto tensor = torch::tensor({{true, false}});
-    ASSERT_EQ(tensor.dtype(), torch::kBool);
-    ASSERT_EQ(tensor.sizes(), std::vector<int64_t>({1, 2}));
-    auto expected = torch::empty(tensor.sizes(), torch::kBool);
-    expected[0][0] = true;
-    expected[0][1] = false;
-    ASSERT_TRUE(torch::equal(tensor, expected));
+    auto tensor = torch::tensor({{1}, {2}});
+    ASSERT_EQ(tensor.dtype(), torch::kLong);
+    ASSERT_EQ(tensor.sizes(), std::vector<int64_t>({2, 1}));
+    ASSERT_TRUE(torch::allclose(tensor, torch::arange(1, 3, torch::kLong).view(tensor.sizes())));
     ASSERT_FALSE(tensor.requires_grad());
   }
+  {
+    auto tensor = torch::tensor({{{1, 2}}});
+    ASSERT_EQ(tensor.dtype(), torch::kLong);
+    ASSERT_EQ(tensor.sizes(), std::vector<int64_t>({1, 1, 2}));
+    ASSERT_TRUE(torch::allclose(tensor, torch::arange(1, 3, torch::kLong).view(tensor.sizes())));
+    ASSERT_FALSE(tensor.requires_grad());
+  }
+  {
+    auto tensor = torch::tensor({{{1}, {2}}});
+    ASSERT_EQ(tensor.dtype(), torch::kLong);
+    ASSERT_EQ(tensor.sizes(), std::vector<int64_t>({1, 2, 1}));
+    ASSERT_TRUE(torch::allclose(tensor, torch::arange(1, 3, torch::kLong).view(tensor.sizes())));
+    ASSERT_FALSE(tensor.requires_grad());
+  }
+  {
+    auto tensor = torch::tensor({{1, 2}, {3, 4}});
+    ASSERT_EQ(tensor.dtype(), torch::kLong);
+    ASSERT_EQ(tensor.sizes(), std::vector<int64_t>({2, 2}));
+    ASSERT_TRUE(torch::allclose(tensor, torch::arange(1, 5, torch::kLong).view(tensor.sizes())));
+    ASSERT_FALSE(tensor.requires_grad());
+  }
+  {
+    auto tensor = torch::tensor({{{{{{{{{{1}}}}}}}}}});
+    ASSERT_EQ(tensor.dtype(), torch::kLong);
+    ASSERT_EQ(tensor.sizes(), std::vector<int64_t>({1, 1, 1, 1, 1, 1, 1, 1, 1, 1}));
+    ASSERT_TRUE(torch::allclose(tensor, torch::full({1}, 1, torch::kLong).view(tensor.sizes())));
+    ASSERT_FALSE(tensor.requires_grad());
+  }
+  {
+    auto tensor = torch::tensor({{{{{{{{{{1, 2}}}}}}}}}});
+    ASSERT_EQ(tensor.dtype(), torch::kLong);
+    ASSERT_EQ(tensor.sizes(), std::vector<int64_t>({1, 1, 1, 1, 1, 1, 1, 1, 1, 2}));
+    ASSERT_TRUE(torch::allclose(tensor, torch::arange(1, 3, torch::kLong).view(tensor.sizes())));
+    ASSERT_FALSE(tensor.requires_grad());
+  }
+}
+
+TEST(TensorTest, TorchTensorCtorMultiDimFloatingType) {
   {
     auto tensor = torch::tensor({{1.0, 2.0}});
     ASSERT_EQ(tensor.dtype(), torch::kDouble);
@@ -357,17 +418,23 @@ TEST(TensorTest, TorchTensorCtorMultiDim) {
     ASSERT_FALSE(tensor.requires_grad());
   }
   {
-    auto tensor = torch::tensor({{1, 2}}, torch::dtype(torch::kInt));
-    ASSERT_EQ(tensor.dtype(), torch::kInt);
-    ASSERT_EQ(tensor.sizes(), std::vector<int64_t>({1, 2}));
-    ASSERT_TRUE(torch::allclose(tensor, torch::arange(1, 3, torch::kInt).view(tensor.sizes())));
+    auto tensor = torch::tensor({{{{{{{{1.0, 2.0, 3.0}}}}}, {{{{{4.0, 5.0, 6.0}}}}}, {{{{{7.0, 8.0, 9.0}}}}}}}});
+    ASSERT_EQ(tensor.dtype(), torch::kDouble);
+    ASSERT_EQ(tensor.sizes(), std::vector<int64_t>({1, 1, 3, 1, 1, 1, 1, 3}));
+    ASSERT_TRUE(torch::allclose(tensor, torch::arange(1, 10, torch::kDouble).view(tensor.sizes())));
     ASSERT_FALSE(tensor.requires_grad());
   }
+}
+
+TEST(TensorTest, TorchTensorCtorMultiDimBoolType) {
   {
-    auto tensor = torch::tensor({{1}, {2}});
-    ASSERT_EQ(tensor.dtype(), torch::kInt);
-    ASSERT_EQ(tensor.sizes(), std::vector<int64_t>({2, 1}));
-    ASSERT_TRUE(torch::allclose(tensor, torch::arange(1, 3, torch::kInt).view(tensor.sizes())));
+    auto tensor = torch::tensor({{true, false}});
+    ASSERT_EQ(tensor.dtype(), torch::kBool);
+    ASSERT_EQ(tensor.sizes(), std::vector<int64_t>({1, 2}));
+    auto expected = torch::empty(tensor.sizes(), torch::kBool);
+    expected[0][0] = true;
+    expected[0][1] = false;
+    ASSERT_TRUE(torch::equal(tensor, expected));
     ASSERT_FALSE(tensor.requires_grad());
   }
   {
@@ -380,25 +447,14 @@ TEST(TensorTest, TorchTensorCtorMultiDim) {
     ASSERT_TRUE(torch::equal(tensor, expected));
     ASSERT_FALSE(tensor.requires_grad());
   }
+}
+
+TEST(TensorTest, TorchTensorCtorMultiDimWithOptions) {
   {
-    auto tensor = torch::tensor({{{1, 2}}});
+    auto tensor = torch::tensor({{1, 2}}, torch::dtype(torch::kInt));
     ASSERT_EQ(tensor.dtype(), torch::kInt);
-    ASSERT_EQ(tensor.sizes(), std::vector<int64_t>({1, 1, 2}));
+    ASSERT_EQ(tensor.sizes(), std::vector<int64_t>({1, 2}));
     ASSERT_TRUE(torch::allclose(tensor, torch::arange(1, 3, torch::kInt).view(tensor.sizes())));
-    ASSERT_FALSE(tensor.requires_grad());
-  }
-  {
-    auto tensor = torch::tensor({{{1}, {2}}});
-    ASSERT_EQ(tensor.dtype(), torch::kInt);
-    ASSERT_EQ(tensor.sizes(), std::vector<int64_t>({1, 2, 1}));
-    ASSERT_TRUE(torch::allclose(tensor, torch::arange(1, 3, torch::kInt).view(tensor.sizes())));
-    ASSERT_FALSE(tensor.requires_grad());
-  }
-  {
-    auto tensor = torch::tensor({{1, 2}, {3, 4}});
-    ASSERT_EQ(tensor.dtype(), torch::kInt);
-    ASSERT_EQ(tensor.sizes(), std::vector<int64_t>({2, 2}));
-    ASSERT_TRUE(torch::allclose(tensor, torch::arange(1, 5, torch::kInt).view(tensor.sizes())));
     ASSERT_FALSE(tensor.requires_grad());
   }
   {
@@ -408,20 +464,16 @@ TEST(TensorTest, TorchTensorCtorMultiDim) {
     ASSERT_TRUE(torch::allclose(tensor, torch::arange(1, 5, torch::kFloat).view(tensor.sizes())));
     ASSERT_TRUE(tensor.requires_grad());
   }
-  {
-    auto tensor = torch::tensor({{{{{{{{1.0, 2.0, 3.0}}}}}, {{{{{4.0, 5.0, 6.0}}}}}, {{{{{7.0, 8.0, 9.0}}}}}}}});
-    ASSERT_EQ(tensor.dtype(), torch::kDouble);
-    ASSERT_EQ(tensor.sizes(), std::vector<int64_t>({1, 1, 3, 1, 1, 1, 1, 3}));
-    ASSERT_TRUE(torch::allclose(tensor, torch::arange(1, 10, torch::kDouble).view(tensor.sizes())));
-    ASSERT_FALSE(tensor.requires_grad());
-  }
+}
+
+TEST(TensorTest, TorchTensorCtorMultiDimErrorChecks) {
   {
     ASSERT_THROWS_WITH(torch::tensor({{{2, 3, 4}, {{5, 6}, {7}}}}),
       "Expected all sub-lists to have sizes: 2 (e.g. {5, 6}), but got sub-list {7} with sizes: 1");
   }
   {
     ASSERT_THROWS_WITH(torch::tensor({{{1, 2.0}, {1, 2.0}}}),
-      "Expected all elements of the tensor to have the same scalar type: Int, but got element of scalar type: Double");
+      "Expected all elements of the tensor to have the same scalar type: Long, but got element of scalar type: Double");
   }
   {
     ASSERT_THROWS_WITH(torch::tensor({{{true, 2.0, 3}, {true, 2.0, 3}}}),
@@ -429,25 +481,11 @@ TEST(TensorTest, TorchTensorCtorMultiDim) {
   }
   {
     ASSERT_THROWS_WITH(torch::tensor({{{true}, {2}}}),
-      "Expected all elements of the tensor to have the same scalar type: Bool, but got element of scalar type: Int");
+      "Expected all elements of the tensor to have the same scalar type: Bool, but got element of scalar type: Long");
   }
   {
     ASSERT_THROWS_WITH(torch::tensor({{{true, 2}}}),
-      "Expected all elements of the tensor to have the same scalar type: Bool, but got element of scalar type: Int");
-  }
-  {
-    auto tensor = torch::tensor({{{{{{{{{{1}}}}}}}}}});
-    ASSERT_EQ(tensor.dtype(), torch::kInt);
-    ASSERT_EQ(tensor.sizes(), std::vector<int64_t>({1, 1, 1, 1, 1, 1, 1, 1, 1, 1}));
-    ASSERT_TRUE(torch::allclose(tensor, torch::full({1}, 1, torch::kInt).view(tensor.sizes())));
-    ASSERT_FALSE(tensor.requires_grad());
-  }
-  {
-    auto tensor = torch::tensor({{{{{{{{{{1, 2}}}}}}}}}});
-    ASSERT_EQ(tensor.dtype(), torch::kInt);
-    ASSERT_EQ(tensor.sizes(), std::vector<int64_t>({1, 1, 1, 1, 1, 1, 1, 1, 1, 2}));
-    ASSERT_TRUE(torch::allclose(tensor, torch::arange(1, 3, torch::kInt).view(tensor.sizes())));
-    ASSERT_FALSE(tensor.requires_grad());
+      "Expected all elements of the tensor to have the same scalar type: Bool, but got element of scalar type: Long");
   }
 }
 
@@ -518,14 +556,14 @@ TEST(TensorTest, TorchTensorCtorZeroSizedDim) {
   }
 }
 
-TEST(TensorTest, TorchTensorCtorPreservesInitListDtype) {
-  ASSERT_EQ(torch::tensor({1, 2, 3}).dtype(), torch::kInt);
-  ASSERT_EQ(torch::tensor({{1, 2, 3}}).dtype(), torch::kInt);
+TEST(TensorTest, TorchTensorCtorWithoutSpecifyingDtype) {
+  ASSERT_EQ(torch::tensor({1, 2, 3}).dtype(), torch::kLong);
+  ASSERT_EQ(torch::tensor({{1, 2, 3}}).dtype(), torch::kLong);
   ASSERT_EQ(torch::tensor({1., 2., 3.}).dtype(), torch::kDouble);
   ASSERT_EQ(torch::tensor({{1., 2., 3.}}).dtype(), torch::kDouble);
 
-  ASSERT_EQ(torch::tensor({1, 2, 3}, torch::TensorOptions()).dtype(), torch::kInt);
-  ASSERT_EQ(torch::tensor({{1, 2, 3}}, torch::TensorOptions()).dtype(), torch::kInt);
+  ASSERT_EQ(torch::tensor({1, 2, 3}, torch::TensorOptions()).dtype(), torch::kLong);
+  ASSERT_EQ(torch::tensor({{1, 2, 3}}, torch::TensorOptions()).dtype(), torch::kLong);
   ASSERT_EQ(torch::tensor({1., 2., 3.}, torch::TensorOptions()).dtype(), torch::kDouble);
   ASSERT_EQ(torch::tensor({{1., 2., 3.}}, torch::TensorOptions()).dtype(), torch::kDouble);
 }

--- a/tools/autograd/templates/variable_factories.h
+++ b/tools/autograd/templates/variable_factories.h
@@ -33,6 +33,16 @@ namespace torch {
 /// We are going to fix this discrepancy by making `torch::tensor` give
 /// a float tensor by default.
 /// Tracking issue: https://github.com/pytorch/pytorch/issues/28902
+///
+/// NOTE: C++ `torch::tensor` with an integer literal or a braced-init-list of
+/// integer literals always produces a tensor of dtype `at::kLong` (aka. int64_t),
+/// matching Python `torch.tensor` behavior.
+///
+/// NOTE: The following dtypes are not supported by `torch::tensor` currently:
+/// - `unsigned int`
+/// - `unsigned long int`
+/// - `unsigned long long int`
+/// - `long long int`
 inline at::Tensor tensor(detail::TensorDataContainer tensor_data_container, const at::TensorOptions& options = {}) {
   return autograd::make_variable(
     tensor_data_container.convert_to_tensor(options),

--- a/torch/csrc/api/include/torch/detail/TensorDataContainer.h
+++ b/torch/csrc/api/include/torch/detail/TensorDataContainer.h
@@ -23,6 +23,23 @@ inline std::ostream& operator<<(std::ostream& stream, c10::BFloat16 value) {
   return stream;
 }
 
+inline c10::ScalarType compute_desired_dtype(c10::ScalarType scalar_type) {
+  if (scalar_type == at::kInt || scalar_type == at::kLong) {
+    // In C++, an integer literal without suffix (e.g. `1` instead of `1u`) can be one of
+    // `int` / `long int` / `long long int` types. When we find that `scalar_type` is one
+    // of those types, we always use `torch.int64` type, because In Python `torch.tensor(1)`
+    // always gives a tensor of `torch.int64` dtype.
+    //
+    // Note that this dtype computation only takes effect when the user passes an integer
+    // literal or a braced-init-list to `torch::tensor` constructor. It doesn't affect
+    // `torch::tensor(at::ArrayRef<T>)` and `torch::tensor(std::vector<T>)` as the specified
+    // dtype `T` is always respected.
+    return at::kLong;
+  } else {
+    return scalar_type;
+  }
+}
+
 // We use `TensorDataContainer` to support converting the following data container types
 // into the equivalent Tensor:
 //
@@ -82,7 +99,7 @@ struct TensorDataContainer {
 #define TENSOR(T, S) \
   TensorDataContainer(T value) : \
       sizes_(), \
-      scalar_type_(at::k##S), \
+      scalar_type_(compute_desired_dtype(at::k##S)), \
       type_(TensorDataContainerType::Scalar), \
       scalar_(value) {}
 AT_FORALL_SCALAR_TYPES_AND3(Bool, Half, BFloat16, TENSOR)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #29600 Support C++ tensor advanced indexing
* #29599 Use default dtype for torch::tensor(floating_point_values) and torch::tensor(empty braced-init-list) when dtype is not specified
* **#29598 Use at::kLong for torch::tensor(integer_value) when dtype is not specified**

ghstack-source-id: 6c866f98e35ad0378fecffe09a916c09d30d5224
Pull Request resolved: https://github.com/pytorch/pytorch/pull/29066