### PR TITLE
[quant] Skip copy_same_type_transpose_ for quantized tensor

### DIFF
--- a/aten/src/ATen/native/Copy.cpp
+++ b/aten/src/ATen/native/Copy.cpp
@@ -139,7 +139,8 @@ static Tensor & copy_impl(Tensor & self, const Tensor & src, bool non_blocking) 
     device_type = kCUDA;
   }
 
-  if (device_type == kCPU && copy_transpose_valid(self, src)) {
+  // TODO: if we need to, we can also enable this path for quantized tensor
+  if (device_type == kCPU && copy_transpose_valid(self, src) && !self.is_quantized()) {
     copy_same_type_transpose_(self, src);
     return self;
   }

--- a/aten/src/ATen/quantized/Quantizer.cpp
+++ b/aten/src/ATen/quantized/Quantizer.cpp
@@ -111,8 +111,6 @@ void quantize_vec(double scale, int64_t zero_point, const float *src, T *dst, si
   );
 }
 
-// TODO: dequantize_val?
-
 template <typename T>
 Tensor quantize_tensor(Tensor rtensor, Tensor qtensor, double scale, int64_t zero_point) {
   auto fn_name = "quantize_tensor";

--- a/test/test_quantized_tensor.py
+++ b/test/test_quantized_tensor.py
@@ -184,7 +184,8 @@ class TestQuantizedTensor(TestCase):
         # permuting larger tensors
         x = torch.randn(64, 64)
         qx = torch.quantize_per_tensor(x, 1.0, 0, torch.qint32)
-        print(qx.permute([1, 0]))
+        # should work
+        qx.permute([1, 0])
 
     def test_qtensor_per_channel_permute(self):
         r = torch.rand(20, 10, 2, 2, dtype=torch.float) * 4 - 2

--- a/test/test_quantized_tensor.py
+++ b/test/test_quantized_tensor.py
@@ -181,6 +181,11 @@ class TestQuantizedTensor(TestCase):
         self.assertEqual(qr.q_zero_point(), qlast.q_zero_point())
         self.assertEqual(qlast.dequantize(), qr.dequantize())
 
+        # permuting larger tensors
+        x = torch.randn(64, 64)
+        qx = torch.quantize_per_tensor(x, 1.0, 0, torch.qint32)
+        print(qx.permute([1, 0]))
+
     def test_qtensor_per_channel_permute(self):
         r = torch.rand(20, 10, 2, 2, dtype=torch.float) * 4 - 2
         scales = torch.rand(10) * 0.02 + 0.01


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #29660 [quant] Guard against copying from quantized Tensor to non-quantized Tensor
* **#29609 [quant] Skip copy_same_type_transpose_ for quantized tensor**

Summary:
We can enable this path later if there is a need.
trying to fix: https://github.com/pytorch/pytorch/issues/29435

Test Plan:
python test/test_quantized_tensor.py
Reviewers:
pt1quant

Subscribers:

Tasks:

Tags:

Differential Revision: [D18453723](https://our.internmc.facebook.com/intern/diff/D18453723)