### PR TITLE
[jit] change `drop_on_export` warning category

### DIFF
--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -382,12 +382,12 @@ def ignore(drop=False, **kwargs):
     drop_on_export = kwargs.pop("drop_on_export", None)
     if drop_on_export:
         warnings.warn("ignore(drop_on_export=True) has been deprecated. TorchScript will now drop the function "
-                      "call on compilation. Use torch.jit.unused now. {}", category=DeprecationWarning)
+                      "call on compilation. Use torch.jit.unused now. {}", category=FutureWarning)
 
         drop = drop_on_export
     elif drop:
         warnings.warn("ignore(True) has been deprecated. TorchScript will now drop the function "
-                      "call on compilation. Use torch.jit.unused now. {}", category=DeprecationWarning)
+                      "call on compilation. Use torch.jit.unused now. {}", category=FutureWarning)
 
     def decorator(fn):
         if drop:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #29611 [ci] test reporting
* **#29610 [jit] change `drop_on_export` warning category**

`DeprecationWarning` is intended for developers (and so is ignored in
certain circumstances). `FutureWarning` is the user-facing deprecation
warning. This fixes fbcode failures.

Differential Revision: [D18446393](https://our.internmc.facebook.com/intern/diff/D18446393)