### PR TITLE
change op bench input shape to reduce execution time

### DIFF
--- a/benchmarks/operator_benchmark/benchmark_core.py
+++ b/benchmarks/operator_benchmark/benchmark_core.py
@@ -174,7 +174,7 @@ class BenchmarkRunner(object):
         self.iters = 200
         self.has_explicit_iteration_count = False
         self.multiplier = 2
-        self.predefined_minimum_secs = 2
+        self.predefined_minimum_secs = 1
         self.max_iters = 1e6
         self.use_jit = args.use_jit
         self.num_runs = args.num_runs

--- a/benchmarks/operator_benchmark/pt/conv_test.py
+++ b/benchmarks/operator_benchmark/pt/conv_test.py
@@ -20,8 +20,8 @@ conv_1d_configs_short = op_bench.config_list(
         'in_c', 'out_c', 'kernel', 'stride', 'N', 'L'
     ],
     attrs=[
-        [256, 256, 3, 1, 1, 64],
-        [256, 256, 3, 2, 16, 128],
+        [128, 256, 3, 1, 1, 64],
+        [256, 256, 3, 2, 4, 64],
     ],
     cross_product_configs={
         'device': ['cpu', 'cuda'],

--- a/benchmarks/operator_benchmark/pt/linear_test.py
+++ b/benchmarks/operator_benchmark/pt/linear_test.py
@@ -15,7 +15,7 @@ linear_configs_short = op_bench.config_list(
     attr_names=["N", "IN", "OUT"],
     attrs=[
         [4, 256, 128],
-        [16, 1024, 256],
+        [16, 512, 256],
     ],
     cross_product_configs={
         'device': ['cpu', 'cuda'],

--- a/benchmarks/operator_benchmark/pt/softmax_test.py
+++ b/benchmarks/operator_benchmark/pt/softmax_test.py
@@ -20,8 +20,8 @@ softmax_configs_short = op_bench.config_list(
         'N', 'C', 'H', 'W'
     ],
     attrs=[
+        [1, 3, 256, 256],
         [4, 3, 256, 256],
-        [8, 3, 512, 512],
     ],
     cross_product_configs={
         'device': ['cpu', 'cuda'],
@@ -32,9 +32,9 @@ softmax_configs_short = op_bench.config_list(
 
 softmax_configs_long = op_bench.cross_product_configs(
     N=[8, 16],
-    C=[3, 64],
-    H=[64, 128],
-    W=[64, 128],
+    C=[3],
+    H=[256, 512],
+    W=[256, 512],
     device=['cpu', 'cuda'],
     tags=['long']
 )


### PR DESCRIPTION
Summary:
1. Reduce the predefined_min_time which is the minimum time each test needs to run. Based on the test result, the average time across different epoch are pretty stable before exiting. So we can safely reduce the predefined time here.
2. Chang the input shapes of several ops

Test Plan:
```
# ----------------------------------------
# PyTorch/Caffe2 Operator Micro-benchmarks
# ----------------------------------------
# Tag : short

# Benchmarking PyTorch: add
200 256.044864655
400 165.850520134
800 163.579881191
1600 162.871927023
3200 160.3128016
# Mode: Eager
# Name: add_cpu_M64_K64_bwd1_N64
# Input: device: cpu, K: 64, M: 64, N: 64
Backward Execution Time (us) : 164.715

# Benchmarking PyTorch: add
200 170.650482178
400 168.895125389
800 169.867575169
1600 163.400024176
3200 168.658420444
# Mode: Eager
# Name: add_cpu_M64_K64_bwd2_N64
# Input: device: cpu, K: 64, M: 64, N: 64
Backward Execution Time (us) : 168.777

Reviewed By: hl475

Differential Revision: D18438540

