### PR TITLE
[reland] Remove observer module after insert_quant_dequant

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1117,7 +1117,7 @@ graph(%x : Tensor,
 
         get_forward(m._c)(data)
         torch._C._jit_pass_insert_quant_dequant(m._c, "forward", True)
-        assert len(m._c._get_modules()) == 1, \
+        assert len(m._modules._c.items()) == 1, \
             'Expected to have single submodule of conv'
 
         get_forward(m._c)(data)

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1116,9 +1116,9 @@ graph(%x : Tensor,
         data = torch.randn(1, 3, 10, 10, dtype=torch.float)
 
         get_forward(m._c)(data)
-        # right now the result will have extra observer modules
-        # will fix later when we figure out how to remove modules
         torch._C._jit_pass_insert_quant_dequant(m._c, "forward", True)
+        assert len(m._c._get_modules()) == 1, \
+            'Expected to have single submodule of conv'
 
         get_forward(m._c)(data)
         FileCheck().check_not("aten::quantize_per_tensor") \

--- a/torch/csrc/jit/passes/quantization.cpp
+++ b/torch/csrc/jit/passes/quantization.cpp
@@ -441,14 +441,23 @@ c10::optional<std::string> findObserverName(Value* v) {
 
 class QuantizeHelper {
  public:
-  QuantizeHelper(const script::Module& m) : module_(m) {}
+  QuantizeHelper(script::Module& m) : module_(m) {}
   // quantization parameters and scalar type
   std::tuple<IValue, IValue> getQParams(Value* v);
   c10::optional<script::Module> findChildModuleToQuantize(
       Value* child_instance);
   void quantizeTensor(Value* v, bool insert_after = true);
   void removeObserver(Value* v, const std::string& observer_name);
-  void destroyNodes() {
+  void removeModulesAndNodes() {
+    // Remove observer modules from last one to first one in order to
+    // reduce the time complexity, assuming all the observer modules
+    // are added after the existing modules, we'll have complexity of
+    // O(N) where N is number of observer moduels with this optimization
+    for (int64_t i = observer_modules_to_remove_.size() - 1; i >= 0; --i) {
+      auto observer_name = observer_modules_to_remove_[i];
+      module_.module_object()->unsafeRemoveAttr(observer_name);
+      module_.type()->unsafeRemoveAttribute(observer_name);
+    }
     // Destroy observer forward calls
     for (auto& n : nodes_to_destroy_) {
       n->destroy();
@@ -456,7 +465,7 @@ class QuantizeHelper {
   }
 
  private:
-  const script::Module& module_;
+  script::Module& module_;
   std::vector<std::string> observer_modules_to_remove_;
   std::vector<Node*> nodes_to_destroy_;
 };
@@ -604,7 +613,7 @@ void InsertQuantDeQuantImpl(
     qh.quantizeTensor(v, false);
   }
 
-  qh.destroyNodes();
+  qh.removeModulesAndNodes();
 }
 
 void insertPrepackUnpackForLinear(std::shared_ptr<Graph>& graph) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#29622 Remove observer module after insert_quant_dequant**

Summary:
Remove the observer module in the quantized model
original PR: https://github.com/pytorch/pytorch/pull/28985
Test Plan:
python test/test_jit.py 'TestJit.test_insert_quant_dequant'

Differential Revision: [D18442888](https://our.internmc.facebook.com/intern/diff/D18442888)