### PR TITLE
Simplify copy kernel with static_cast_with_inter_type

### DIFF
--- a/aten/src/ATen/native/cpu/CopyKernel.cpp
+++ b/aten/src/ATen/native/cpu/CopyKernel.cpp
@@ -10,62 +10,6 @@ namespace at {
 namespace native {
 namespace {
 
-template <typename self_T>
-void copy_kernel_cast(TensorIterator& iter) {
-    if (isComplexType(iter.dtype(1))) {
-      AT_DISPATCH_COMPLEX_TYPES(iter.dtype(1), "copy_kernel_cast", [&] {
-        cpu_kernel(iter, [=](scalar_t a) -> self_T {
-            return c10::static_cast_with_inter_type<self_T>(std::real(a));
-          });
-        });
-    }
-    else {
-      AT_DISPATCH_ALL_TYPES_AND3(
-        ScalarType::Half,
-        ScalarType::Bool,
-        ScalarType::BFloat16,
-        iter.dtype(1),
-        "copy_kernel_cast",
-        [&] {
-          cpu_kernel(iter, [=](scalar_t a) -> self_T {
-            return c10::static_cast_with_inter_type<self_T>(a);
-          });
-        });
-    }
-}
-
-template <>
-void copy_kernel_cast<std::complex<float>>(TensorIterator& iter) {
-  // Specialization for inter-complex dtypes
-  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(
-    ScalarType::Half,
-    ScalarType::Bool,
-    ScalarType::BFloat16,
-    iter.dtype(1),
-    "copy_kernel_cast",
-    [&] {
-      cpu_kernel(iter, [=](scalar_t a) -> std::complex<float> {
-        return c10::static_cast_with_inter_type<std::complex<float>>(a);
-      });
-    });
-}
-
-template <>
-void copy_kernel_cast<std::complex<double>>(TensorIterator& iter) {
-  // Specialization for inter-complex dtypes
-  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(
-    ScalarType::Half,
-    ScalarType::Bool,
-    ScalarType::BFloat16,
-    iter.dtype(1),
-    "copy_kernel_cast",
-    [&] {
-      cpu_kernel(iter, [=](scalar_t a) -> std::complex<double> {
-        return c10::static_cast_with_inter_type<std::complex<double>>(a);
-      });
-    });
-}
-
 static void copy_kernel(TensorIterator& iter, bool non_blocking) {
   ScalarType dtype = iter.dtype(0);
   if (dtype == iter.dtype(1)) {
@@ -96,7 +40,10 @@ static void copy_kernel(TensorIterator& iter, bool non_blocking) {
     }
   } else {
     AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(ScalarType::Half, ScalarType::Bool, ScalarType::BFloat16, dtype, "copy_", [&] {
-      copy_kernel_cast<scalar_t>(iter);
+      using dest_t = scalar_t;
+      AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(ScalarType::Half, ScalarType::Bool, ScalarType::BFloat16, iter.dtype(1), "copy_", [&] {
+        cpu_kernel(iter, c10::static_cast_with_inter_type<dest_t, scalar_t>);
+      });
     });
   }
 }


### PR DESCRIPTION
After https://github.com/pytorch/pytorch/pull/29612 get merged, `static_cast_with_inter_type` can now automatically convert complex types to its real values, therefore there is no need to do it inside copy kernel.

This should wait until https://github.com/pytorch/pytorch/pull/29612 get merged, otherwise it won't pass CI.