### PR TITLE
Consolidate the places that find pybind11 include dirs

### DIFF
--- a/caffe2/core/nomnigraph/CMakeLists.txt
+++ b/caffe2/core/nomnigraph/CMakeLists.txt
@@ -8,7 +8,7 @@ list(APPEND Caffe2_CPU_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 list(APPEND Caffe2_CPU_TEST_SRCS ${NOMNI_TEST_SRCS})
 
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include
-        DESTINATION include
+        DESTINATION ${CMAKE_INSTALL_PREFIX}
         FILES_MATCHING PATTERN "*.h")
 
 # ---[ Send the lists to the parent scope.

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -795,12 +795,15 @@ endif()
 
 if(pybind11_FOUND)
     message(STATUS "System pybind11 found")
-    message(STATUS "pybind11 include dirs: " "${pybind11_INCLUDE_DIRS}")
-    include_directories(SYSTEM ${pybind11_INCLUDE_DIRS})
 else()
     message(STATUS "Using third_party/pybind11.")
-    include_directories(SYSTEM ${CMAKE_CURRENT_LIST_DIR}/../third_party/pybind11/include)
+    set(pybind11_INCLUDE_DIRS ${CMAKE_CURRENT_LIST_DIR}/../third_party/pybind11/include)
 endif()
+message(STATUS "pybind11 include dirs: " "${pybind11_INCLUDE_DIRS}")
+include_directories(SYSTEM ${pybind11_INCLUDE_DIRS})
+install(DIRECTORY ${pybind11_INCLUDE_DIRS}
+        DESTINATION ${CMAKE_INSTALL_PREFIX}
+        FILES_MATCHING PATTERN "*.h")
 
 # ---[ MPI
 if(USE_MPI)

--- a/setup.py
+++ b/setup.py
@@ -164,7 +164,7 @@
 from __future__ import print_function
 from setuptools import setup, Extension, distutils, find_packages
 from collections import defaultdict
-from distutils import core, dir_util
+from distutils import core
 from distutils.core import Distribution
 from distutils.errors import DistutilsArgError
 import setuptools.command.build_ext
@@ -345,9 +345,6 @@ def build_deps():
                 os.remove(sym_file)
         if not same:
             shutil.copyfile(orig_file, sym_file)
-
-    dir_util.copy_tree('third_party/pybind11/include/pybind11/',
-                       'torch/include/pybind11')
 
 ################################################################################
 # Building dependent libraries

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -125,7 +125,7 @@ set(TORCH_PYTHON_INCLUDE_DIRECTORIES
 
     ${TORCH_ROOT}/third_party/gloo
     ${TORCH_ROOT}/third_party/onnx
-    ${TORCH_ROOT}/third_party/pybind11/include
+    ${pybind11_INCLUDE_DIRS}
 
     ${TORCH_SRC_DIR}/csrc
     ${TORCH_SRC_DIR}/csrc/api/include


### PR DESCRIPTION
Also move the logic that installs the pybind11 headers from setup.py to cmake (to align with other headers).

