### PR TITLE
Fixing data type in quantized pool benchmarking

### DIFF
--- a/benchmarks/operator_benchmark/pt/qpool_test.py
+++ b/benchmarks/operator_benchmark/pt/qpool_test.py
@@ -22,7 +22,7 @@ qpool2d_long_configs = op_bench.config_list(
     cross_product_configs={
         'N': (1, 4),
         'contig': (False, True),
-        'dtype': (torch.quint32,),
+        'dtype': (torch.quint8,),
     },
     tags=('long',)
 )
@@ -55,7 +55,7 @@ qadaptive_avgpool2d_long_configs = op_bench.cross_product_configs(
     N=(1, 4),
     C=(1, 3, 64, 128),
     contig=(False, True),
-    dtype=(torch.quint32,),
+    dtype=(torch.quint8,),
     tags=('long',)
 )
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#29663 Fixing data type in quantized pool benchmarking**

Differential Revision: [D18456671](https://our.internmc.facebook.com/intern/diff/D18456671)