### PR TITLE
Do not show cuda stats in autograd profiler when `use_cuda=False`

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -2594,6 +2594,18 @@ class TestAutograd(TestCase):
         print(prof.table())
         print(prof.key_averages(group_by_input_shape=True).table())
 
+    def test_profiler_no_cuda(self):
+        print("")
+        layer = torch.nn.Linear(20, 30)
+        x = torch.randn(128, 20)
+        with profile(use_cuda=False) as prof:
+            layer(x)
+
+        prof_str = str(prof)
+        print(prof_str)
+        self.assertTrue('cpu' in prof_str.lower())
+        self.assertTrue('cuda' not in prof_str.lower())
+
     def test_profiler_aggregation_lstm(self):
         print("")
         rnn = torch.nn.LSTM(10, 20, 2)


### PR DESCRIPTION
Example
```python
import torch
x = torch.randn(1)
with torch.autograd.profiler.profile(use_cuda=False) as prof:
    x + x
print(prof.key_averages().table(sort_by='cpu_time_total'))
```

Before:
```
-------  ---------------  ---------------  ---------------  ---------------  ---------------  ---------------  ---------------  ---------------  ---------------
Name     Self CPU total %  Self CPU total   CPU total %      CPU total        CPU time avg     CUDA total %     CUDA total       CUDA time avg    Number of Calls
-------  ---------------  ---------------  ---------------  ---------------  ---------------  ---------------  ---------------  ---------------  ---------------
add      100.00%          25.781ms         100.00%          25.781ms         25.781ms         NaN              0.000us          0.000us          1
-------  ---------------  ---------------  ---------------  ---------------  ---------------  ---------------  ---------------  ---------------  ---------------
Self CPU time total: 25.781ms
CUDA time total: 0.000us
```

After:
```
-------  ---------------  ---------------  ---------------  ---------------  ---------------  ---------------
Name     Self CPU total %  Self CPU total   CPU total %      CPU total        CPU time avg     Number of Calls
-------  ---------------  ---------------  ---------------  ---------------  ---------------  ---------------
add      100.00%          25.037ms         100.00%          25.037ms         25.037ms         1
-------  ---------------  ---------------  ---------------  ---------------  ---------------  ---------------
Self CPU time total: 25.037ms
```