### PR TITLE
Add error message if CUDA startup fails

### DIFF
--- a/caffe2/core/event_gpu.cc
+++ b/caffe2/core/event_gpu.cc
@@ -3,6 +3,7 @@
 #include "caffe2/core/operator.h"
 
 #include <atomic>
+#include <iostream>
 
 namespace caffe2 {
 
@@ -13,8 +14,15 @@ struct CudaEventWrapper {
         status_(EventStatus::EVENT_INITIALIZED) {
     CAFFE_ENFORCE(option.device_type(), PROTO_CUDA);
     CUDAGuard g(device_id_);
-    CUDA_ENFORCE(cudaEventCreateWithFlags(
-        &cuda_event_, cudaEventDefault | cudaEventDisableTiming));
+    try {
+      CUDA_ENFORCE(cudaEventCreateWithFlags(
+          &cuda_event_, cudaEventDefault | cudaEventDisableTiming));
+    } catch (const Error&) {
+      std::cerr << "ERROR: Failed to load CUDA.\n"
+                << "HINT: Check that this binary contains GPU code."
+                << std::endl;
+      throw;
+    }
   }
   ~CudaEventWrapper() {
     CUDAGuard g(device_id_);


### PR DESCRIPTION
Summary: This is the entry point to loading CUDA code, improve error message to prompt users to check that gpu code is included.

Test Plan: Build without gpu code.  Run the binary.  Check that the new error message exists.

Differential Revision: D18453798

