### PR TITLE
Use F::*FuncOptions for embedding/embeddingbag functionals

### DIFF
--- a/test/cpp/api/functional.cpp
+++ b/test/cpp/api/functional.cpp
@@ -985,7 +985,7 @@ TEST_F(FunctionalTest, EmbeddingBag) {
   auto offsets = torch::tensor({0,4}, torch::kLong);
   auto weight = torch::empty({10, 3});
   torch::nn::init::normal_(weight);
-  auto y = F::embedding_bag(input, weight, EmbeddingBagOptions().mode(torch::kSum), offsets);
+  auto y = F::embedding_bag(input, weight, F::EmbeddingBagFuncOptions().mode(torch::kSum).offsets(offsets));
   auto y_exp = std::get<0>(torch::embedding_bag(weight, input, offsets, false, 0, false, torch::Tensor()));
   ASSERT_TRUE(torch::allclose(y, y_exp));
 

--- a/torch/csrc/api/include/torch/nn/functional/embedding.h
+++ b/torch/csrc/api/include/torch/nn/functional/embedding.h
@@ -10,94 +10,135 @@ inline Tensor one_hot(const Tensor& tensor, int64_t num_classes = -1) {
   return torch::one_hot(tensor, num_classes);
 }
 
-inline void _no_grad_embedding_renorm_(Tensor weight, Tensor input, float max_norm, float norm_type) {
+namespace detail {
+inline void _no_grad_embedding_renorm_(Tensor weight, const Tensor& input, float max_norm, float norm_type) {
   torch::NoGradGuard no_grad;
   torch::embedding_renorm_(weight, input, max_norm, norm_type);
 }
 
-inline Tensor embedding(Tensor input, Tensor weight, EmbeddingOptions options = {}) {
-  if (options.padding_idx() != c10::nullopt) {
-    if (*options.padding_idx() > 0) {
-      TORCH_CHECK(*options.padding_idx() < weight.size(0), "Padding_idx must be within num_embeddings");
+inline Tensor embedding(const Tensor& input,
+                        const Tensor& weight,
+                        c10::optional<int64_t> padding_idx,
+                        c10::optional<double> max_norm,
+                        double norm_type,
+                        bool scale_grad_by_freq,
+                        bool sparse) {
+  auto input_ = input;
+
+  if (padding_idx != c10::nullopt) {
+    if (*padding_idx > 0) {
+      TORCH_CHECK(*padding_idx < weight.size(0), "Padding_idx must be within num_embeddings");
     }
-    else if (*options.padding_idx() < 0) {
-      TORCH_CHECK(*options.padding_idx() >= -weight.size(0), "Padding_idx must be within num_embedding");
-      options.padding_idx(weight.size(0) + *options.padding_idx());
+    else if (*padding_idx < 0) {
+      TORCH_CHECK(*padding_idx >= -weight.size(0), "Padding_idx must be within num_embedding");
+      padding_idx = weight.size(0) + *padding_idx;
     }
   } else {
-    options.padding_idx(-1);
+    padding_idx = -1;
   }
 
-  if (options.max_norm() != c10::nullopt) {
-    input = input.contiguous();
-    _no_grad_embedding_renorm_(weight, input, *options.max_norm(), options.norm_type());
+  if (max_norm != c10::nullopt) {
+    input_ = input_.contiguous();
+    _no_grad_embedding_renorm_(weight, input_, *max_norm, norm_type);
   }
-  return torch::embedding(weight, input, *options.padding_idx(), options.scale_grad_by_freq(), options.sparse());
+  return torch::embedding(weight, input_, *padding_idx, scale_grad_by_freq, sparse);
+}
+} // namespace detail
+
+inline Tensor embedding(const Tensor& input, const Tensor& weight, const EmbeddingFuncOptions& options = {}) {
+  return detail::embedding(
+    input,
+    weight,
+    options.padding_idx(),
+    options.max_norm(),
+    options.norm_type(),
+    options.scale_grad_by_freq(),
+    options.sparse());
 }
 
+namespace detail {
 inline Tensor embedding_bag(
-    Tensor input,
-    Tensor weight,
-    EmbeddingBagOptions options = {},
-    const Tensor& offsets = {},
-    const Tensor& per_sample_weights = {}) {
-
+    const Tensor& input,
+    const Tensor& weight,
+    const Tensor& offsets,
+    c10::optional<double> max_norm,
+    double norm_type,
+    bool scale_grad_by_freq,
+    EmbeddingBagMode mode,
+    bool sparse,
+    const Tensor& per_sample_weights) {
+  auto input_ = input;
   auto offsets_ = offsets;
   auto per_sample_weights_ = per_sample_weights;
-  TORCH_CHECK(!per_sample_weights_.defined() || input.sizes() == per_sample_weights_.sizes(),
-    "embedding_bag: If per_sample_weights (", per_sample_weights_.sizes(), ") is not null, then it must have the same shape as the input (", input.sizes(), ")");
-  if (input.dim() == 2) {
+  TORCH_CHECK(!per_sample_weights_.defined() || input_.sizes() == per_sample_weights_.sizes(),
+    "embedding_bag: If per_sample_weights (", per_sample_weights_.sizes(), ") is not null, then it must have the same shape as the input (", input_.sizes(), ")");
+  if (input_.dim() == 2) {
     TORCH_CHECK(!offsets_.defined(),
       "If input is 2D, then offsets has to be null, as input is treated is a mini-batch of fixed length sequences. However, found offsets of type Tensor");
-    offsets_ = torch::arange(0, input.numel(), input.size(1), torch::TensorOptions().dtype(torch::kLong).device(input.device()));
-    input = input.reshape(-1);
+    offsets_ = torch::arange(0, input_.numel(), input_.size(1), torch::TensorOptions().dtype(torch::kLong).device(input_.device()));
+    input_ = input_.reshape(-1);
     if (per_sample_weights_.defined()) {
       per_sample_weights_ = per_sample_weights_.reshape(-1);
     }
-  } else if (input.dim() == 1) {
+  } else if (input_.dim() == 1) {
     TORCH_CHECK(offsets_.defined(), "offsets has to be a 1D Tensor but got null");
     TORCH_CHECK(offsets_.dim() == 1, "offsets has to be a 1D Tensor");
     TORCH_CHECK(offsets_[0].item<int64_t>() == 0, "offsets[0] has to be 0, i.e., the first sequence in the mini-batch has to start from position 0. However, got ",
      offsets_[0].item<int64_t>());
-    TORCH_CHECK(offsets_[-1].item<int64_t>() <= input.size(0), "offsets[-1] can not be greater than input's length({",
-              input.size(0), "}), but got offsets[-1] of {", offsets_[-1].item<int64_t>(), "}");
+    TORCH_CHECK(offsets_[-1].item<int64_t>() <= input_.size(0), "offsets[-1] can not be greater than input's length({",
+              input_.size(0), "}), but got offsets[-1] of {", offsets_[-1].item<int64_t>(), "}");
   } else {
-    TORCH_CHECK(false, "input has to be 1D or 2D Tensor, but got Tensor of dimension ", input.dim());
+    TORCH_CHECK(false, "input has to be 1D or 2D Tensor, but got Tensor of dimension ", input_.dim());
   }
 
   int mode_enum;
-  if (c10::get_if<enumtype::kSum>(&options.mode())) {
+  if (c10::get_if<enumtype::kSum>(&mode)) {
     mode_enum = 0;
-  } else if (c10::get_if<enumtype::kMean>(&options.mode())) {
+  } else if (c10::get_if<enumtype::kMean>(&mode)) {
     mode_enum = 1;
-  } else if (c10::get_if<enumtype::kMax>(&options.mode())) {
+  } else if (c10::get_if<enumtype::kMax>(&mode)) {
     mode_enum = 2;
-    TORCH_CHECK(!options.scale_grad_by_freq(), "max mode does not support scaling the gradient by the frequency");
-    TORCH_CHECK(!options.sparse(), "max mode does not support sparse weights");
+    TORCH_CHECK(!scale_grad_by_freq, "max mode does not support scaling the gradient by the frequency");
+    TORCH_CHECK(!sparse, "max mode does not support sparse weights");
   } else {
     TORCH_CHECK(false, "mode has to be one of sum, mean or max");
   }
 
-  if (options.max_norm() != c10::nullopt) {
-    _no_grad_embedding_renorm_(weight, input, *options.max_norm(), options.norm_type());
+  if (max_norm != c10::nullopt) {
+    _no_grad_embedding_renorm_(weight, input_, *max_norm, norm_type);
   }
 
   TORCH_CHECK(
-    !per_sample_weights_.defined() || c10::get_if<enumtype::kSum>(&options.mode()),
+    !per_sample_weights_.defined() || c10::get_if<enumtype::kSum>(&mode),
     "embedding_bag: per_sample_weights was not null. ",
     "per_sample_weights is only supported for mode='kSum' (got mode='",
-    torch::enumtype::get_enum_name(options.mode()), "').Please open a feature request on GitHub.");
+    torch::enumtype::get_enum_name(mode), "').Please open a feature request on GitHub.");
 
   return std::get<0>(
     torch::embedding_bag(
       weight,
-      input,
+      input_,
       offsets_,
-      options.scale_grad_by_freq(),
+      scale_grad_by_freq,
       mode_enum,
-      options.sparse(),
+      sparse,
       per_sample_weights_));
 }
+} // namespace detail
+
+inline Tensor embedding_bag(const Tensor& input, const Tensor& weight, const EmbeddingBagFuncOptions& options = {}) {
+  return detail::embedding_bag(
+    input,
+    weight,
+    options.offsets(),
+    options.max_norm(),
+    options.norm_type(),
+    options.scale_grad_by_freq(),
+    options.mode(),
+    options.sparse(),
+    options.per_sample_weights());
+}
+
 } // namespace functional
 } // namespace nn
 } // namespace torch

--- a/torch/csrc/api/include/torch/nn/modules/embedding.h
+++ b/torch/csrc/api/include/torch/nn/modules/embedding.h
@@ -43,17 +43,22 @@ class Embedding : public torch::nn::ModuleHolder<EmbeddingImpl> {
  public:
   using torch::nn::ModuleHolder<EmbeddingImpl>::ModuleHolder;
 
-  static Embedding from_pretrained(const torch::Tensor& embeddings, EmbeddingOptions options = {}, bool freeze = true) {
+  static Embedding from_pretrained(const torch::Tensor& embeddings, EmbeddingFromPretrainedOptions options = {}) {
     TORCH_CHECK(embeddings.dim() == 2, "Embeddings parameter is expected to be 2-dimensional");
-    if (options.num_embeddings()) {
-      TORCH_WARN("`num_embeddings` options parameter is ignored in `torch::nn::Embedding::from_pretrained`.");
-    }
-    if (options.embedding_dim()) {
-      TORCH_WARN("`embedding_dim` options parameter is ignored in `torch::nn::Embedding::from_pretrained`.");
-    }
 
-    Embedding embedding(options.num_embeddings(embeddings.size(0)).embedding_dim(embeddings.size(1))._weight(embeddings));
-    embedding->weight.set_requires_grad(!freeze);
+    int64_t rows, cols;
+    rows = embeddings.size(0);
+    cols = embeddings.size(1);
+
+    Embedding embedding(
+      EmbeddingOptions(rows, cols)
+        ._weight(embeddings)
+        .padding_idx(options.padding_idx())
+        .max_norm(options.max_norm())
+        .norm_type(options.norm_type())
+        .scale_grad_by_freq(options.scale_grad_by_freq())
+        .sparse(options.sparse()));
+    embedding->weight.set_requires_grad(!options.freeze());
     return embedding;
   }
 };
@@ -85,16 +90,22 @@ class EmbeddingBag : public torch::nn::ModuleHolder<EmbeddingBagImpl> {
  public:
   using torch::nn::ModuleHolder<EmbeddingBagImpl>::ModuleHolder;
 
-  static EmbeddingBag from_pretrained(const torch::Tensor& embeddings, EmbeddingBagOptions options = {}, bool freeze = true) {
+  static EmbeddingBag from_pretrained(const torch::Tensor& embeddings, EmbeddingBagFromPretrainedOptions options = {}) {
     TORCH_CHECK(embeddings.dim() == 2, "Embeddings parameter is expected to be 2-dimensional");
-    if (options.num_embeddings()) {
-      TORCH_WARN("`num_embeddings` options parameter is ignored in `torch::nn::EmbeddingBag::from_pretrained`.");
-    }
-    if (options.embedding_dim()) {
-      TORCH_WARN("`embedding_dim` options parameter is ignored in `torch::nn::EmbeddingBag::from_pretrained`.");
-    }
-    EmbeddingBag embeddingbag(options.num_embeddings(embeddings.size(0)).embedding_dim(embeddings.size(1))._weight(embeddings));
-    embeddingbag->weight.set_requires_grad(!freeze);
+
+    int64_t rows, cols;
+    rows = embeddings.size(0);
+    cols = embeddings.size(1);
+
+    EmbeddingBag embeddingbag(
+      EmbeddingBagOptions(rows, cols)
+        ._weight(embeddings)
+        .max_norm(options.max_norm())
+        .norm_type(options.norm_type())
+        .scale_grad_by_freq(options.scale_grad_by_freq())
+        .mode(options.mode())
+        .sparse(options.sparse()));
+    embeddingbag->weight.set_requires_grad(!options.freeze());
     return embeddingbag;
   }
 };

--- a/torch/csrc/api/include/torch/nn/modules/embedding.h
+++ b/torch/csrc/api/include/torch/nn/modules/embedding.h
@@ -43,7 +43,7 @@ class Embedding : public torch::nn::ModuleHolder<EmbeddingImpl> {
  public:
   using torch::nn::ModuleHolder<EmbeddingImpl>::ModuleHolder;
 
-  static Embedding from_pretrained(const torch::Tensor& embeddings, EmbeddingFromPretrainedOptions options = {}) {
+  static Embedding from_pretrained(const torch::Tensor& embeddings, const EmbeddingFromPretrainedOptions& options = {}) {
     TORCH_CHECK(embeddings.dim() == 2, "Embeddings parameter is expected to be 2-dimensional");
 
     int64_t rows, cols;
@@ -90,7 +90,7 @@ class EmbeddingBag : public torch::nn::ModuleHolder<EmbeddingBagImpl> {
  public:
   using torch::nn::ModuleHolder<EmbeddingBagImpl>::ModuleHolder;
 
-  static EmbeddingBag from_pretrained(const torch::Tensor& embeddings, EmbeddingBagFromPretrainedOptions options = {}) {
+  static EmbeddingBag from_pretrained(const torch::Tensor& embeddings, const EmbeddingBagFromPretrainedOptions& options = {}) {
     TORCH_CHECK(embeddings.dim() == 2, "Embeddings parameter is expected to be 2-dimensional");
 
     int64_t rows, cols;

--- a/torch/csrc/api/include/torch/nn/options/embedding.h
+++ b/torch/csrc/api/include/torch/nn/options/embedding.h
@@ -7,52 +7,146 @@
 
 namespace torch {
 namespace nn {
-  /// Options for the `Embedding` module.
-  struct TORCH_API EmbeddingOptions {
-    EmbeddingOptions();
-    EmbeddingOptions(int64_t num_embeddings, int64_t embedding_dim);
-    /// The size of the dictionary of embeddings.
-    TORCH_ARG(c10::optional<int64_t>, num_embeddings) = c10::nullopt;
-    /// The size of each embedding vector.
-    TORCH_ARG(c10::optional<int64_t>, embedding_dim) = c10::nullopt;
-    /// If given, pads the output with the embedding vector at `padding_idx` (initialized to zeros) whenever it encounters the index.
-    TORCH_ARG(c10::optional<int64_t>, padding_idx) = c10::nullopt;
-    /// If given, each embedding vector with norm larger than `max_norm` is renormalized to have norm `max_norm`.
-    TORCH_ARG(c10::optional<double>, max_norm) = c10::nullopt;
-    /// The p of the p-norm to compute for the `max_norm` option. Default ``2``.
-    TORCH_ARG(double, norm_type) = 2.;
-    /// If given, this will scale gradients by the inverse of frequency of the words in the mini-batch. Default ``False``.
-    TORCH_ARG(bool, scale_grad_by_freq) = false;
-    /// If ``True``, gradient w.r.t. `weight` matrix will be a sparse tensor.
-    TORCH_ARG(bool, sparse) = false;
-    /// The learnable weights of the module of shape (num_embeddings, embedding_dim)
-    TORCH_ARG(torch::Tensor, _weight) = Tensor();
-  };
 
-  /// Options for the `EmbeddingBag` module.
-  struct TORCH_API EmbeddingBagOptions {
-    typedef c10::variant<enumtype::kSum, enumtype::kMean, enumtype::kMax> mode_t;
-    EmbeddingBagOptions();
-    EmbeddingBagOptions(int64_t num_embeddings, int64_t embedding_dim);
-    /// The size of the dictionary of embeddings.
-    TORCH_ARG(c10::optional<int64_t>, num_embeddings) = c10::nullopt;
-    /// The size of each embedding vector.
-    TORCH_ARG(c10::optional<int64_t>, embedding_dim) = c10::nullopt;
-    /// If given, each embedding vector with norm larger than `max_norm` is renormalized to have norm `max_norm`.
-    TORCH_ARG(c10::optional<double>, max_norm) = c10::nullopt;
-    /// The p of the p-norm to compute for the `max_norm` option. Default ``2``.
-    TORCH_ARG(double, norm_type) = 2.;
-    /// If given, this will scale gradients by the inverse of frequency of the words in the mini-batch. Default ``False``.
-    /// Note: this option is not supported when ``mode="kMax"``.
-    TORCH_ARG(bool, scale_grad_by_freq) = false;
-    /// ``"kSum"``, ``"kMean"`` or ``"kMax"``. Specifies the way to reduce the bag. ``"kSum"`` computes the weighted sum, taking `per_sample_weights`
-    /// into consideration. ``"kMean"`` computes the average of the values in the bag, ``"kMax"`` computes the max value over each bag.
-    TORCH_ARG(mode_t, mode) = torch::kMean;
-    /// If ``True``, gradient w.r.t. `weight` matrix will be a sparse tensor.
-    /// Note: this option is not supported when ``mode="kMax"``.
-    TORCH_ARG(bool, sparse) = false;
-    /// The learnable weights of the module of shape (num_embeddings, embedding_dim)
-    TORCH_ARG(torch::Tensor, _weight) = Tensor();
-  };
+/// Options for the `Embedding` module.
+struct TORCH_API EmbeddingOptions {
+  EmbeddingOptions(int64_t num_embeddings, int64_t embedding_dim);
+
+  /// The size of the dictionary of embeddings.
+  TORCH_ARG(int64_t, num_embeddings);
+  /// The size of each embedding vector.
+  TORCH_ARG(int64_t, embedding_dim);
+  /// If given, pads the output with the embedding vector at `padding_idx` (initialized to zeros) whenever it encounters the index.
+  TORCH_ARG(c10::optional<int64_t>, padding_idx) = c10::nullopt;
+  /// If given, each embedding vector with norm larger than `max_norm` is renormalized to have norm `max_norm`.
+  TORCH_ARG(c10::optional<double>, max_norm) = c10::nullopt;
+  /// The p of the p-norm to compute for the `max_norm` option. Default ``2``.
+  TORCH_ARG(double, norm_type) = 2.;
+  /// If given, this will scale gradients by the inverse of frequency of the words in the mini-batch. Default ``False``.
+  TORCH_ARG(bool, scale_grad_by_freq) = false;
+  /// If ``True``, gradient w.r.t. `weight` matrix will be a sparse tensor.
+  TORCH_ARG(bool, sparse) = false;
+  /// The learnable weights of the module of shape (num_embeddings, embedding_dim)
+  TORCH_ARG(torch::Tensor, _weight) = Tensor();
+};
+
+// ============================================================================
+
+/// Options for the `Embedding::from_pretrained` function.
+struct TORCH_API EmbeddingFromPretrainedOptions {
+  /// If ``true``, the tensor does not get updated in the learning process.
+  /// Equivalent to ``embedding.weight.requires_grad_(false)``. Default: ``true``
+  TORCH_ARG(bool, freeze) = true;
+  /// If given, pads the output with the embedding vector at `padding_idx` (initialized to zeros) whenever it encounters the index.
+  TORCH_ARG(c10::optional<int64_t>, padding_idx) = c10::nullopt;
+  /// If given, each embedding vector with norm larger than `max_norm` is renormalized to have norm `max_norm`.
+  TORCH_ARG(c10::optional<double>, max_norm) = c10::nullopt;
+  /// The p of the p-norm to compute for the `max_norm` option. Default ``2``.
+  TORCH_ARG(double, norm_type) = 2.;
+  /// If given, this will scale gradients by the inverse of frequency of the words in the mini-batch. Default ``False``.
+  TORCH_ARG(bool, scale_grad_by_freq) = false;
+  /// If ``True``, gradient w.r.t. `weight` matrix will be a sparse tensor.
+  TORCH_ARG(bool, sparse) = false;
+};
+
+// ============================================================================
+
+namespace functional {
+
+struct TORCH_API EmbeddingFuncOptions {
+  /// If given, pads the output with the embedding vector at `padding_idx` (initialized to zeros) whenever it encounters the index.
+  TORCH_ARG(c10::optional<int64_t>, padding_idx) = c10::nullopt;
+  /// If given, each embedding vector with norm larger than `max_norm` is renormalized to have norm `max_norm`.
+  TORCH_ARG(c10::optional<double>, max_norm) = c10::nullopt;
+  /// The p of the p-norm to compute for the `max_norm` option. Default ``2``.
+  TORCH_ARG(double, norm_type) = 2.;
+  /// If given, this will scale gradients by the inverse of frequency of the words in the mini-batch. Default ``False``.
+  TORCH_ARG(bool, scale_grad_by_freq) = false;
+  /// If ``True``, gradient w.r.t. `weight` matrix will be a sparse tensor.
+  TORCH_ARG(bool, sparse) = false;
+};
+
+} // namespace functional
+
+// ============================================================================
+
+typedef c10::variant<enumtype::kSum, enumtype::kMean, enumtype::kMax> EmbeddingBagMode;
+
+/// Options for the `EmbeddingBag` module.
+struct TORCH_API EmbeddingBagOptions {
+  EmbeddingBagOptions(int64_t num_embeddings, int64_t embedding_dim);
+
+  /// The size of the dictionary of embeddings.
+  TORCH_ARG(int64_t, num_embeddings);
+  /// The size of each embedding vector.
+  TORCH_ARG(int64_t, embedding_dim);
+  /// If given, each embedding vector with norm larger than `max_norm` is renormalized to have norm `max_norm`.
+  TORCH_ARG(c10::optional<double>, max_norm) = c10::nullopt;
+  /// The p of the p-norm to compute for the `max_norm` option. Default ``2``.
+  TORCH_ARG(double, norm_type) = 2.;
+  /// If given, this will scale gradients by the inverse of frequency of the words in the mini-batch. Default ``False``.
+  /// Note: this option is not supported when ``mode="kMax"``.
+  TORCH_ARG(bool, scale_grad_by_freq) = false;
+  /// ``"kSum"``, ``"kMean"`` or ``"kMax"``. Specifies the way to reduce the bag. ``"kSum"`` computes the weighted sum, taking `per_sample_weights`
+  /// into consideration. ``"kMean"`` computes the average of the values in the bag, ``"kMax"`` computes the max value over each bag.
+  TORCH_ARG(EmbeddingBagMode, mode) = torch::kMean;
+  /// If ``True``, gradient w.r.t. `weight` matrix will be a sparse tensor.
+  /// Note: this option is not supported when ``mode="kMax"``.
+  TORCH_ARG(bool, sparse) = false;
+  /// The learnable weights of the module of shape (num_embeddings, embedding_dim)
+  TORCH_ARG(torch::Tensor, _weight) = Tensor();
+};
+
+// ============================================================================
+
+/// Options for the `EmbeddingBag::from_pretrained` function.
+struct TORCH_API EmbeddingBagFromPretrainedOptions {
+  /// If ``true``, the tensor does not get updated in the learning process.
+  /// Equivalent to ``embeddingbag.weight.requires_grad_(false)``. Default: ``true``
+  TORCH_ARG(bool, freeze) = true;
+  /// If given, each embedding vector with norm larger than `max_norm` is renormalized to have norm `max_norm`.
+  TORCH_ARG(c10::optional<double>, max_norm) = c10::nullopt;
+  /// The p of the p-norm to compute for the `max_norm` option. Default ``2``.
+  TORCH_ARG(double, norm_type) = 2.;
+  /// If given, this will scale gradients by the inverse of frequency of the words in the mini-batch. Default ``False``.
+  /// Note: this option is not supported when ``mode="kMax"``.
+  TORCH_ARG(bool, scale_grad_by_freq) = false;
+  /// ``"kSum"``, ``"kMean"`` or ``"kMax"``. Specifies the way to reduce the bag. ``"kSum"`` computes the weighted sum, taking `per_sample_weights`
+  /// into consideration. ``"kMean"`` computes the average of the values in the bag, ``"kMax"`` computes the max value over each bag.
+  TORCH_ARG(EmbeddingBagMode, mode) = torch::kMean;
+  /// If ``True``, gradient w.r.t. `weight` matrix will be a sparse tensor.
+  /// Note: this option is not supported when ``mode="kMax"``.
+  TORCH_ARG(bool, sparse) = false;
+};
+
+// ============================================================================
+
+namespace functional {
+
+struct TORCH_API EmbeddingBagFuncOptions {
+  /// Only used when `input` is 1D. `offsets` determines
+  /// the starting index position of each bag (sequence) in `input`.
+  TORCH_ARG(torch::Tensor, offsets) = Tensor();
+  /// If given, each embedding vector with norm larger than `max_norm` is renormalized to have norm `max_norm`.
+  TORCH_ARG(c10::optional<double>, max_norm) = c10::nullopt;
+  /// The p of the p-norm to compute for the `max_norm` option. Default ``2``.
+  TORCH_ARG(double, norm_type) = 2.;
+  /// If given, this will scale gradients by the inverse of frequency of the words in the mini-batch. Default ``False``.
+  /// Note: this option is not supported when ``mode="kMax"``.
+  TORCH_ARG(bool, scale_grad_by_freq) = false;
+  /// ``"kSum"``, ``"kMean"`` or ``"kMax"``. Specifies the way to reduce the bag. ``"kSum"`` computes the weighted sum, taking `per_sample_weights`
+  /// into consideration. ``"kMean"`` computes the average of the values in the bag, ``"kMax"`` computes the max value over each bag.
+  TORCH_ARG(EmbeddingBagMode, mode) = torch::kMean;
+  /// If ``True``, gradient w.r.t. `weight` matrix will be a sparse tensor.
+  /// Note: this option is not supported when ``mode="kMax"``.
+  TORCH_ARG(bool, sparse) = false;
+  /// a tensor of float / double weights, or None to indicate all weights should be taken to be 1.
+  /// If specified, `per_sample_weights` must have exactly the same shape as input and is treated as
+  /// having the same `offsets`, if those are not None.
+  TORCH_ARG(torch::Tensor, per_sample_weights) = Tensor();
+};
+
+} // namespace functional
+
 } // namespace nn
 } // namespace torch

--- a/torch/csrc/api/src/nn/modules/embedding.cpp
+++ b/torch/csrc/api/src/nn/modules/embedding.cpp
@@ -18,35 +18,33 @@ EmbeddingImpl::EmbeddingImpl(const EmbeddingOptions& options_) : options(options
 }
 
 void EmbeddingImpl::reset() {
-  TORCH_CHECK(options.num_embeddings(), "num_embeddings needs to be specified in options");
-  TORCH_CHECK(options.embedding_dim(), "embedding_dim needs to be specified in options");
   if (options.padding_idx() != c10::nullopt) {
     if (*options.padding_idx() > 0) {
-      TORCH_CHECK(*options.padding_idx() < *options.num_embeddings(), "Padding_idx must be within num_embeddings");
+      TORCH_CHECK(*options.padding_idx() < options.num_embeddings(), "Padding_idx must be within num_embeddings");
     }
     else if (*options.padding_idx() < 0) {
-      TORCH_CHECK(*options.padding_idx() >= -(*options.num_embeddings()), "Padding_idx must be within num_embedding");
-      options.padding_idx(*options.num_embeddings() + *options.padding_idx());
+      TORCH_CHECK(*options.padding_idx() >= -options.num_embeddings(), "Padding_idx must be within num_embedding");
+      options.padding_idx(options.num_embeddings() + *options.padding_idx());
     }
   }
 
   if (!options._weight().defined()) {
     weight = register_parameter(
-        "weight", torch::empty({*options.num_embeddings(), *options.embedding_dim()}));
+        "weight", torch::empty({options.num_embeddings(), options.embedding_dim()}));
     torch::nn::init::normal_(weight);
     if (options.padding_idx() != c10::nullopt) {
       torch::NoGradGuard no_grad;
       weight[*options.padding_idx()].fill_(0);
     }
   } else {
-    TORCH_CHECK(options._weight().sizes() == torch::IntArrayRef({*options.num_embeddings(), *options.embedding_dim()}), "Shape of _weight does not match num_embeddings and embedding_dim");
+    TORCH_CHECK(options._weight().sizes() == torch::IntArrayRef({options.num_embeddings(), options.embedding_dim()}), "Shape of _weight does not match num_embeddings and embedding_dim");
     weight = register_parameter("weight", options._weight());
   }
 }
 
 void EmbeddingImpl::pretty_print(std::ostream& stream) const {
-  stream << "torch::nn::Embedding(num_embeddings=" << *options.num_embeddings()
-         << ", embedding_dim=" << *options.embedding_dim();
+  stream << "torch::nn::Embedding(num_embeddings=" << options.num_embeddings()
+         << ", embedding_dim=" << options.embedding_dim();
   if (options.padding_idx() != c10::nullopt) {
     stream << ", padding_idx=" << *options.padding_idx();
   }
@@ -66,7 +64,14 @@ void EmbeddingImpl::pretty_print(std::ostream& stream) const {
 }
 
 torch::Tensor EmbeddingImpl::forward(const Tensor& input) {
-  return F::embedding(input, weight, options);
+  return F::detail::embedding(
+    input,
+    weight,
+    options.padding_idx(),
+    options.max_norm(),
+    options.norm_type(),
+    options.scale_grad_by_freq(),
+    options.sparse());
 }
 
 EmbeddingBagImpl::EmbeddingBagImpl(const EmbeddingBagOptions& options_) : options(options_) { // NOLINT(modernize-pass-by-value)
@@ -74,27 +79,34 @@ EmbeddingBagImpl::EmbeddingBagImpl(const EmbeddingBagOptions& options_) : option
 }
 
 void EmbeddingBagImpl::reset() {
-  TORCH_CHECK(options.num_embeddings(), "num_embeddings needs to be specified in options");
-  TORCH_CHECK(options.embedding_dim(), "embedding_dim needs to be specified in options");
   if (!options._weight().defined()) {
     weight = register_parameter(
-        "weight", torch::empty({*options.num_embeddings(), *options.embedding_dim()}));
+        "weight", torch::empty({options.num_embeddings(), options.embedding_dim()}));
     torch::nn::init::normal_(weight);
   } else {
     TORCH_CHECK(
-      options._weight().sizes() == torch::IntArrayRef({*options.num_embeddings(), *options.embedding_dim()}),
+      options._weight().sizes() == torch::IntArrayRef({options.num_embeddings(), options.embedding_dim()}),
       "Shape of weight does not match num_embeddings and embedding_dim");
     weight = register_parameter("weight", options._weight());
   }
 }
 
 torch::Tensor EmbeddingBagImpl::forward(const Tensor& input, const Tensor& offsets, const Tensor& per_sample_weights) {
-  return F::embedding_bag(input, weight, EmbeddingBagOptions(options), offsets, per_sample_weights);
+  return F::detail::embedding_bag(
+    input,
+    weight,
+    offsets,
+    options.max_norm(),
+    options.norm_type(),
+    options.scale_grad_by_freq(),
+    options.mode(),
+    options.sparse(),
+    per_sample_weights);
 }
 
 void EmbeddingBagImpl::pretty_print(std::ostream& stream) const {
-  stream << "torch::nn::EmbeddingBag(num_embeddings=" << *options.num_embeddings()
-        << ", embedding_dim=" << *options.embedding_dim();
+  stream << "torch::nn::EmbeddingBag(num_embeddings=" << options.num_embeddings()
+        << ", embedding_dim=" << options.embedding_dim();
   if (options.max_norm() != c10::nullopt) {
     stream << ", max_norm=" << *options.max_norm();
   }

--- a/torch/csrc/api/src/nn/options/embedding.cpp
+++ b/torch/csrc/api/src/nn/options/embedding.cpp
@@ -2,11 +2,9 @@
 
 namespace torch {
 namespace nn {
-EmbeddingOptions::EmbeddingOptions() = default;
 EmbeddingOptions::EmbeddingOptions(int64_t num_embeddings, int64_t embedding_dim) :
  num_embeddings_(num_embeddings), embedding_dim_(embedding_dim) {}
 
-EmbeddingBagOptions::EmbeddingBagOptions() = default;
 EmbeddingBagOptions::EmbeddingBagOptions(int64_t num_embeddings, int64_t embedding_dim) :
  num_embeddings_(num_embeddings), embedding_dim_(embedding_dim) {}
 } // namespace nn


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#29673 Use F::*FuncOptions for embedding/embeddingbag functionals **
* #29584 Change arg dtype from float to double in LPPool and nn/utils/clip_grad.h
* #29536 Use c10::variant-based enums for SmoothL1Loss module and functional
* #29535 Use c10::variant-based enums for F::grid_sample
* #29404 Make all non-input arguments to functionals part of its options, and pass functional options by const-ref when possible

Following https://github.com/pytorch/pytorch/pull/29364 and https://github.com/pytorch/pytorch/pull/29404, this PR makes `F::EmbeddingFuncOptions` and `F::EmbeddingBagFuncOptions` separate classes from `torch::nn::EmbeddingOptions` and `torch::nn::EmbeddingBagOptions`, so that it's easier to enforce that arguments such as `num_embeddings` and `embedding_dim` are required for `torch::nn::EmbeddingOptions` and `torch::nn::EmbeddingBagOptions`.

Differential Revision: [D18462540](https://our.internmc.facebook.com/intern/diff/D18462540)