### PR TITLE
Add more tests for torch::arange

### DIFF
--- a/test/cpp/api/tensor.cpp
+++ b/test/cpp/api/tensor.cpp
@@ -634,11 +634,19 @@ TEST(TensorTest, TorchTensorCtorWithoutSpecifyingDtype) {
   test_TorchTensorCtorWithoutSpecifyingDtype_expected_dtype(/*default_dtype=*/torch::kDouble);
 }
 
+void test_Arange_expected_dtype(c10::ScalarType default_dtype) {
+  AutoDefaultDtypeMode dtype_mode(default_dtype);
+
+  ASSERT_EQ(torch::arange(0., 5).dtype(), default_dtype);
+}
+
 TEST(TensorTest, Arange) {
-  { // Test #1
+  {
     auto x = torch::arange(0, 5);
-    TORCH_INTERNAL_ASSERT(x.dtype() == at::ScalarType::Long);
+    ASSERT_EQ(x.dtype() == torch::kLong);
   }
+  test_Arange_expected_dtype(torch::kFloat);
+  test_Arange_expected_dtype(torch::kDouble);
 }
 
 TEST(TensorTest, PrettyPrintTensorDataContainer) {

--- a/test/cpp/api/tensor.cpp
+++ b/test/cpp/api/tensor.cpp
@@ -643,7 +643,7 @@ void test_Arange_expected_dtype(c10::ScalarType default_dtype) {
 TEST(TensorTest, Arange) {
   {
     auto x = torch::arange(0, 5);
-    ASSERT_EQ(x.dtype() == torch::kLong);
+    ASSERT_EQ(x.dtype(), torch::kLong);
   }
   test_Arange_expected_dtype(torch::kFloat);
   test_Arange_expected_dtype(torch::kDouble);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #29633 Support C++ tensor advanced indexing
* **#29689 Add more tests for torch::arange**
* #29632 Use default dtype for torch::tensor(floating_point_values) and torch::tensor(empty braced-init-list) when dtype is not specified

Differential Revision: [D18465818](https://our.internmc.facebook.com/intern/diff/D18465818)