### PR TITLE
Pin Linux image and modules version to 4.4.0-166

### DIFF
--- a/.circleci/scripts/setup_ci_environment.sh
+++ b/.circleci/scripts/setup_ci_environment.sh
@@ -29,7 +29,10 @@ sudo apt-get -y remove linux-image-generic linux-headers-generic linux-generic d
 # comes with Docker.
 sudo apt-get -y install \
   linux-headers-$(uname -r) \
-  linux-image-generic \
+  linux-image-4.4.0-166-generic \
+  linux-image-generic=4.4.0.166.174 \
+  linux-modules-4.4.0-166-generic \
+  linux-modules-extra-4.4.0-166-generic \
   moreutils \
   docker-ce=5:18.09.4~3-0~ubuntu-xenial \
   nvidia-container-runtime=2.0.0+docker18.09.4-1 \


### PR DESCRIPTION
When installing the 4.4.0-168 version, the following error is thrown (e.g. in https://app.circleci.com/jobs/github/pytorch/pytorch/3577840):
```
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 linux-image-generic : Depends: linux-image-4.4.0-168-generic but it is not going to be installed or
                                linux-image-unsigned-4.4.0-168-generic but it is not installable
                       Depends: linux-modules-extra-4.4.0-168-generic but it is not installable
                       Recommends: thermald but it is not going to be installed
E: Unable to correct problems, you have held broken packages.
```
The (temporary) solution is to pin the Linux image and modules version to 4.4.0-166.