### PR TITLE
Allow unrelated histories when rebasing to master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -323,7 +323,7 @@ jobs:
             echo "GIT_COMMIT: " ${GIT_COMMIT}
             git checkout -f ${GIT_COMMIT}
             git reset --hard ${GIT_COMMIT}
-            git merge --no-edit --no-ff ${GIT_MERGE_TARGET}
+            git merge --allow-unrelated-histories --no-edit --no-ff ${GIT_MERGE_TARGET}
             set +x
           else
             echo "Do NOT merge master branch into $CIRCLE_BRANCH in environment $BUILD_ENVIRONMENT"

--- a/.circleci/verbatim-sources/pytorch-job-specs.yml
+++ b/.circleci/verbatim-sources/pytorch-job-specs.yml
@@ -35,7 +35,7 @@ jobs:
             echo "GIT_COMMIT: " ${GIT_COMMIT}
             git checkout -f ${GIT_COMMIT}
             git reset --hard ${GIT_COMMIT}
-            git merge --no-edit --no-ff ${GIT_MERGE_TARGET}
+            git merge --allow-unrelated-histories --no-edit --no-ff ${GIT_MERGE_TARGET}
             set +x
           else
             echo "Do NOT merge master branch into $CIRCLE_BRANCH in environment $BUILD_ENVIRONMENT"


### PR DESCRIPTION
Some prs are refused to be merged.

For example, https://github.com/pytorch/pytorch/pull/29595