### PR TITLE
Revert "Pin Linux image and modules version to 4.4.0-166 (#29690)"

### DIFF
--- a/.circleci/scripts/setup_ci_environment.sh
+++ b/.circleci/scripts/setup_ci_environment.sh
@@ -29,10 +29,7 @@ sudo apt-get -y remove linux-image-generic linux-headers-generic linux-generic d
 # comes with Docker.
 sudo apt-get -y install \
   linux-headers-$(uname -r) \
-  linux-image-4.4.0-166-generic \
-  linux-image-generic=4.4.0.166.174 \
-  linux-modules-4.4.0-166-generic \
-  linux-modules-extra-4.4.0-166-generic \
+  linux-image-generic \
   moreutils \
   docker-ce=5:18.09.4~3-0~ubuntu-xenial \
   nvidia-container-runtime=2.0.0+docker18.09.4-1 \


### PR DESCRIPTION
This reverts commit 907a29de70491bb1431b86d9a14829816965cdc0 because we don't need to pin the version anymore.

