### PR TITLE
Parallelize cpu index_put accumulate float path with cpu_atomic_add_float

### DIFF
--- a/aten/src/ATen/native/TensorIterator.cpp
+++ b/aten/src/ATen/native/TensorIterator.cpp
@@ -526,18 +526,18 @@ int TensorIterator::num_reduce_dims() const {
     }                                                                     \
   }
 
-void TensorIterator::for_each(loop_t loop) {
-  for_each(LOOP_WRAPPER(ntensors(), loop));
+void TensorIterator::for_each(loop_t loop, int64_t grain_size) {
+  for_each(LOOP_WRAPPER(ntensors(), loop), grain_size);
 }
 
-void TensorIterator::for_each(loop2d_t loop) {
+void TensorIterator::for_each(loop2d_t loop, int64_t grain_size) {
   int64_t numel = this->numel();
   if (numel == 0) {
     return;
   } else if (numel < internal::GRAIN_SIZE || at::get_num_threads() == 1) {
     return serial_for_each(loop, {0, numel});
   } else {
-    at::parallel_for(0, numel, internal::GRAIN_SIZE, [&](int64_t begin, int64_t end) {
+    at::parallel_for(0, numel, grain_size, [&](int64_t begin, int64_t end) {
       serial_for_each(loop, {begin, end});
     });
   }

--- a/aten/src/ATen/native/TensorIterator.h
+++ b/aten/src/ATen/native/TensorIterator.h
@@ -9,6 +9,7 @@
 #include <c10/util/Optional.h>
 #include <ATen/MemoryOverlap.h>
 #include <ATen/NamedTensorUtils.h>
+#include <ATen/Parallel.h>
 
 // TensorIterator is a helper class for element-wise operations, such as
 // arithmetic, comparisons, and trigonometric functions. It handles
@@ -263,8 +264,8 @@ struct CAFFE2_API TensorIterator {
     return c10::fetch_and_cast<T>(op.tensor.scalar_type(), op.data);
   }
 
-  void for_each(loop_t loop);
-  void for_each(loop2d_t loop);
+  void for_each(loop_t loop, int64_t grain_size = at::internal::GRAIN_SIZE);
+  void for_each(loop2d_t loop, int64_t grain_size = at::internal::GRAIN_SIZE);
 
   void parallel_reduce(loop2d_t loop);
 

--- a/aten/src/ATen/native/cpu/AtomicAddFloat.h
+++ b/aten/src/ATen/native/cpu/AtomicAddFloat.h
@@ -1,0 +1,33 @@
+#ifndef ATOMIC_ADD_FLOAT
+#define ATOMIC_ADD_FLOAT
+
+#if (defined(__x86_64__) || defined(__i386__))
+#include "ATen/native/cpu/Intrinsics.h"
+#else
+#define _mm_pause()
+#endif
+
+#include <atomic>
+
+static inline void cpu_atomic_add_float(float* dst, float fvalue)
+{
+  typedef union {
+    unsigned intV;
+    float floatV;
+  } uf32_t;
+
+  uf32_t new_value, old_value;
+  std::atomic<unsigned>* dst_intV = (std::atomic<unsigned>*)(dst);
+
+  old_value.floatV = *dst;
+  new_value.floatV = old_value.floatV + fvalue;
+
+  unsigned* old_intV = (unsigned*)(&old_value.intV);
+  while (!std::atomic_compare_exchange_strong(dst_intV, old_intV, new_value.intV)) {
+    _mm_pause();
+    old_value.floatV = *dst;
+    new_value.floatV = old_value.floatV + fvalue;
+  }
+}
+
+#endif


### PR DESCRIPTION
This is try to parallelize index_put accumulate path for float type on CPU. cpu_atomic_add_float is implemented by using atomic_compare_exchange_strong function.
for [DLRM](https://github.com/facebookresearch/dlrm) benchmark, _index_put_impl_ function time can be reduced from 827.741ms to 116.646ms for 1000 batches

Add a parameter "grain_size" to TensorIterator::for_each to fine tune the index_put performance 
The default value of grain_size is internal::GRAIN_SIZE. The index_put grain size is tuned to 3000 and cpu_kernel_vec grain size is tuned to 1024. The following is the grain size impact on the DLRM ops
( _index_put_impl_ based on index_put been parallellized with cpu_atomic_add_float):

|  Op Name               | without small grain_size      | with 1024 as grain_size in cpu_kernel_vec and 3000 in cpu_index_kernel    |
|-----------------|----------:|----------:|
|  add_  | 11.985s | 11.601s |
| mm            | 9.706s   |   9.518s |
| addmm         | 5.380s   | 5.247s |
| _embedding_bag         | 2.992s   | 2.663s |	
| _embedding_bag_backward         | 1.330s   | 1.354s |	
| threshold_backward         | 686.920ms   | 659.169ms |	
| _index_put_impl_         | 489.411ms   | 116.646ms |
| bmm         | 413.129ms   | 362.967ms |	
| zero_         | 379.659ms   | 310.623ms |	
| add         | 205.904ms   | 171.111ms |	
| cat         | 187.101ms   | 175.621ms |	
| Self CPU time total (s)         | 36.544   | 34.742 |	
| Average ms per iteration         | 38.25   | 36.44 |	

The more reason for grain size tuning, please further look at [PR#30803](https://github.com/pytorch/pytorch/issues/30803)
to get the DLRM performance here, please also have a look at 
[PR#23057](https://github.com/pytorch/pytorch/pull/23057), [PR#24385](https://github.com/pytorch/pytorch/pull/24385) and [PR#27804](https://github.com/pytorch/pytorch/pull/27804) 
and expose the env vars as below:
```
export LD_PRELOAD=$HOME/anaconda3/lib/libjemalloc.so  (conda install jemalloc)
export KMP_BLOCKTIME=1
export KMP_AFFINITY="granularity=fine,compact,1,0"
```
