### PR TITLE
More checks on MSVC

### DIFF
--- a/test/cpp_extensions/setup.py
+++ b/test/cpp_extensions/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 from torch.utils.cpp_extension import BuildExtension, CppExtension, CUDAExtension
 from torch.utils.cpp_extension import CUDA_HOME
 
-CXX_FLAGS = [] if sys.platform == 'win32' else ['-g', '-Werror']
+CXX_FLAGS = ['/sdl', '/permissive-'] if sys.platform == 'win32' else ['-g', '-Werror']
 
 ext_modules = [
     CppExtension(


### PR DESCRIPTION
The flags `/sdl` and `/permissive-` are switched on automatically when using the VS GUI. Adding those checks will ensure that those annoying errors won't appear when users use the VS GUI to build their project.

More info:
https://docs.microsoft.com/en-us/cpp/build/reference/sdl-enable-additional-security-checks?view=vs-2017
https://docs.microsoft.com/en-us/cpp/build/reference/permissive-standards-conformance?view=vs-2017