### PR TITLE
Migrate dist from TH to ATen(CPU, CUDA)

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -566,23 +566,6 @@
     - real maxnorm
 ]]
 [[
-  name: _th_dist
-  types:
-    - floating_point
-  backends:
-    - CUDA
-  variants:
-    - function
-  options:
-    - cname: dist
-      return: accreal
-      arguments:
-        - arg: THTensor* self
-          broadcast: other fallback
-        - THTensor* other
-        - real p
-]]
-[[
   name: _th_histc
   cname: histc
   types:

--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -570,7 +570,6 @@
   types:
     - floating_point
   backends:
-    - CPU
     - CUDA
   variants:
     - function

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -974,4 +974,12 @@ std::tuple<Tensor, Tensor> cummin(const Tensor& self, Dimname dim) {
 std::tuple<Tensor&, Tensor&> cummin_out(Tensor& values, Tensor& indices, const Tensor& self, Dimname dim) {
   return at::cummin_out(values, indices, self, dimname_to_position(self, dim));
 }
+
+Tensor dist(const Tensor &self, const Tensor& other, Scalar p){
+  Tensor result = at::empty_like(self, at::MemoryFormat::Contiguous);
+  result = at::abs(self - other);
+  result = at::pow_out(result, result, p);
+  result = at::pow_out(result, at::sum(result), 1.0 / p.toDouble());
+  return result;
+
 }} // namespace at::native

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -976,10 +976,18 @@ std::tuple<Tensor&, Tensor&> cummin_out(Tensor& values, Tensor& indices, const T
 }
 
 Tensor dist(const Tensor &self, const Tensor& other, Scalar p){
+
+  if (at::isfinite(self).logical_not().any().item<uint8_t>() || at::isfinite(other).logical_not().any().item<uint8_t>()){
+    Tensor result = at::empty({1}, self.options());
+    result[0] = std::numeric_limits<double>::infinity();
+    return result[0];
+  }
+
   Tensor result = at::empty_like(self, at::MemoryFormat::Contiguous);
   result = at::abs(self - other);
   result = at::pow_out(result, result, p);
   result = at::pow_out(result, at::sum(result), 1.0 / p.toDouble());
   return result;
+}
 
 }} // namespace at::native

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -976,18 +976,7 @@ std::tuple<Tensor&, Tensor&> cummin_out(Tensor& values, Tensor& indices, const T
 }
 
 Tensor dist(const Tensor &self, const Tensor& other, Scalar p){
-
-  if (at::isfinite(self).logical_not().any().item<uint8_t>() || at::isfinite(other).logical_not().any().item<uint8_t>()){
-    Tensor result = at::empty({1}, self.options());
-    result[0] = std::numeric_limits<double>::infinity();
-    return result[0];
-  }
-
-  Tensor result = at::empty_like(self, at::MemoryFormat::Contiguous);
-  result = at::abs(self - other);
-  result = at::pow_out(result, result, p);
-  result = at::pow_out(result, at::sum(result), 1.0 / p.toDouble());
-  return result;
+  return at::norm(self - other, p);
 }
 
 }} // namespace at::native

--- a/aten/src/ATen/native/cuda/Reduce.cu
+++ b/aten/src/ATen/native/cuda/Reduce.cu
@@ -47,4 +47,8 @@ std::ostream& operator<<(std::ostream& out, const ReduceConfig& config) {
   return out;
 }
 
+Tensor dist_cuda(const Tensor &self, const Tensor& other, Scalar p){
+    return at::norm(self - other, p);
+}
+
 }}  // namespace at::native

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -4937,7 +4937,7 @@
   variants: method, function
   dispatch:
     CPU: dist
-    CUDA: legacy::cuda::_th_dist
+    CUDA: dist_cuda
 
 - func: atan2.out(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
   supports_named_tensor: True

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -4936,7 +4936,7 @@
   use_c10_dispatcher: full
   variants: method, function
   dispatch:
-    CPU: legacy::cpu::_th_dist
+    CPU: dist
     CUDA: legacy::cuda::_th_dist
 
 - func: atan2.out(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)

--- a/aten/src/TH/generic/THTensorMoreMath.cpp
+++ b/aten/src/TH/generic/THTensorMoreMath.cpp
@@ -1068,33 +1068,6 @@ void THTensor_(renorm)(THTensor *res, THTensor *src, scalar_t value, int dimensi
   c10::raw::intrusive_ptr::decref(rowS);
 }
 
-accreal THTensor_(dist)(THTensor *tensor, THTensor *src, scalar_t value)
-{
-  scalar_t sum;
-  if (value == INFINITY) {
-    sum = -1.0;
-    TH_TENSOR_APPLY2(scalar_t, tensor, scalar_t, src,
-                     sum = THMax(sum, TH_MATH_NAME(fabs)(*tensor_data - *src_data)););
-    return sum;
-  } else if (value == -INFINITY) {
-    sum = INFINITY;
-    TH_TENSOR_APPLY2(scalar_t, tensor, scalar_t, src,
-                     sum = THMin(sum, TH_MATH_NAME(fabs)(*tensor_data - *src_data)););
-    return sum;
-  } else if (value == 0.0) {
-    sum = 0.0;
-    TH_TENSOR_APPLY2(scalar_t, tensor, scalar_t, src,
-                     sum += (*tensor_data - *src_data != 0.0););
-    return sum;
-  } else {
-    sum = 0.0;
-    TH_TENSOR_APPLY2(scalar_t, tensor, scalar_t, src,
-                     sum += TH_MATH_NAME(pow)(
-                       TH_MATH_NAME(fabs)(*tensor_data - *src_data), value););
-    return TH_MATH_NAME(pow)(sum, 1.0/value);
-  }
-}
-
 accreal THTensor_(meanall)(THTensor *tensor)
 {
   return THTensor_(sumall)(tensor)/THTensor_(nElement)(tensor);


### PR DESCRIPTION
[#24691](https://github.com/pytorch/pytorch/issues/24691)
[#24551](https://github.com/pytorch/pytorch/issues/24551)

Benchmark:

**Speed**
```python
import time, sys
import torch
import math

inf = math.inf

torch.manual_seed(0)
devices = ["cpu", "cuda"]
ps = [0, 1, 2, 3, 4, inf, -inf]

# Warm up
for device in devices:
    for n in [1, 10, 100, 1000]:
        x = torch.randn(100, n, requires_grad=False, device=device)
        y = torch.randn(100, n, requires_grad=False, device=device)
        for i in range(1000):
            for p in ps:
                dist_xy = torch.dist(x, y, p)

for device in devices:
    print('On {}'.format(device))
    for n in [1, 10, 100, 1000]:
        total_time = 0
        x = torch.randn(100, n, requires_grad=False, device=device)
        y = torch.randn(100, n, requires_grad=False, device=device)
        for i in range(10000):
            for p in ps:
                t1 = time.time()
                dist_xy = torch.dist(x, y, p)
                t2 = time.time()
                total_time += (t2 - t1)
        average_time = total_time / 10000 / len(ps) * 1000
        print("input size(100, %d) average time is %.8f (ms)." % (n, average_time))
```

Output
Before:
```shel
On cpu
input size(100, 1) average time is 0.0079491 (ms).
input size(100, 10) average time is 0.0364167 (ms).
input size(100, 100) average time is 0.3120752 (ms).
input size(100, 1000) average time is 3.0605820 (ms).
On cuda
input size(100, 1) average time is 0.04745627 (ms).
input size(100, 10) average time is 0.04919453 (ms).
input size(100, 100) average time is 0.06601572 (ms).
input size(100, 1000) average time is 0.07849015 (ms).
```

After:
```shell
On cpu
input size(100, 1) average time is 0.0099936 (ms).
input size(100, 10) average time is 0.0340414 (ms).
input size(100, 100) average time is 0.2793379 (ms).
input size(100, 1000) average time is 0.7858076 (ms).
On cuda
input size(100, 1) average time is 0.04410237 (ms).
input size(100, 10) average time is 0.03326339 (ms).
input size(100, 100) average time is 0.03314828 (ms).
input size(100, 1000) average time is 0.03990038 (ms).
```

**Precision**

```python
for device in devices:
    torch.manual_seed(0)
    print('On {}'.format(device))
    for n in [1, 10, 100, 1000]:
        x = torch.randn(100, n, requires_grad=False).to(device)
        y = torch.randn(100, n, requires_grad=False).to(device)
        for p in ps:
            dist_xy_float = torch.dist(x, y, p)
            dist_xy_double = torch.dist(x.double(), y.double(), p)
            difference = torch.abs(dist_xy_double - dist_xy_float)
            print('input size (100, {}), p: {}, float: {}, double: {}, difference: {}'.format(n, p, dist_xy_float, dist_xy_double, difference))
```

Part of [output](https://gist.github.com/rivergold/dd95014dc7f163b22f72699d1134cdd2) 
Before:
```shell
On cpu
input size (100, 100), p: 0, float: 10000.0, double: 10000.0, difference: 0.0
input size (100, 100), p: 1, float: 11474.1806640625, double: 11474.185433543797, difference: 0.00476948129653465
input size (100, 100), p: 2, float: 143.50729370117188, double: 143.5073391487937, difference: 4.5447621829453055e-05
input size (100, 100), p: 3, float: 36.045475006103516, double: 36.04550275212738, difference: 2.774602386779179e-05
input size (100, 100), p: 4, float: 18.796083450317383, double: 18.79609807865317, difference: 1.4628335787136848e-05
input size (100, 100), p: inf, float: 5.540258407592773, double: 5.5402586460113525, difference: 2.384185791015625e-07
input size (100, 100), p: -inf, float: 3.4868717193603516e-06, double: 3.4868717193603516e-06, difference: 0.0
On cuda
input size (100, 100), p: 0, float: 10000.0, double: 10000.0, difference: 0.0
input size (100, 100), p: 1, float: 11474.1865234375, double: 11474.185433543797, difference: 0.00108989370346535
input size (100, 100), p: 2, float: 143.50733947753906, double: 143.5073391487933, difference: 3.2874575595087663e-07
input size (100, 100), p: 3, float: 36.04550552368164, double: 36.045502752127405, difference: 2.7715542358919265e-06
input size (100, 100), p: 4, float: 18.796098709106445, double: 18.796098078653177, difference: 6.304532682577246e-07
input size (100, 100), p: inf, float: 5.540258407592773, double: 5.5402586460113525, difference: 2.384185791015625e-07
input size (100, 100), p: -inf, float: 3.4868717193603516e-06, double: 3.4868717193603516e-06, difference: 0.0
```

After
```shell
On cpu
input size (100, 100), p: 0, float: 10000.0, double: 10000.0, difference: 0.0
input size (100, 100), p: 1, float: 11474.1806640625, double: 11474.185433543797, difference: 0.00476948129653465
input size (100, 100), p: 2, float: 143.50729370117188, double: 143.5073391487937, difference: 4.5447621829453055e-05
input size (100, 100), p: 3, float: 36.045475006103516, double: 36.04550275212738, difference: 2.774602386779179e-05
input size (100, 100), p: 4, float: 18.796083450317383, double: 18.79609807865317, difference: 1.4628335787136848e-05
input size (100, 100), p: inf, float: 5.540258407592773, double: 5.5402586460113525, difference: 2.384185791015625e-07
input size (100, 100), p: -inf, float: 3.4868717193603516e-06, double: 3.4868717193603516e-06, difference: 0.0
On cuda
input size (100, 100), p: 0, float: 10000.0, double: 10000.0, difference: 0.0
input size (100, 100), p: 1, float: 11474.185546875, double: 11474.185433543797, difference: 0.00011333120346534997
input size (100, 100), p: 2, float: 143.50733947753906, double: 143.5073391487933, difference: 3.2874575595087663e-07
input size (100, 100), p: 3, float: 36.04550552368164, double: 36.045502752127405, difference: 2.7715542358919265e-06
input size (100, 100), p: 4, float: 18.796096801757812, double: 18.796098078653177, difference: 1.2768953645547754e-06
input size (100, 100), p: inf, float: 5.540258407592773, double: 5.5402586460113525, difference: 2.384185791015625e-07
input size (100, 100), p: -inf, float: 3.4868717193603516e-06, double: 3.4868717193603516e-06, difference: 0.0
```