### PR TITLE
Avoid MSVC _cvtsh_ss() workaround with clang-cl

### DIFF
--- a/caffe2/perfkernels/cvtsh_ss_bugfix.h
+++ b/caffe2/perfkernels/cvtsh_ss_bugfix.h
@@ -39,7 +39,7 @@ _cvtss_sh(float a, int imm8) {
 #undef __APPLE_NEED_FIX
 #undef __CLANG_NEED_FIX
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(__clang__)
 
 #include <c10/util/Half.h>
 #include <cstdint>


### PR DESCRIPTION
We (me @fnabulsi @bmcdb) have a handful of fixes used locally to build and run with clang-cl. I am aware of #8784 but it has not been touched in almost a year.

It may be more practical to upstream the non-controversial fixes piecewise. For example, this one.

Here, the dummy version of `_cvtsh_ss` for MSVC is not required (and hence causes conflicts) when using clang-cl so can be #ifdef'd out.