### PR TITLE
Fix typo: Caffe2_MAIN_LIB to Caffe2_MAIN_LIBS

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -1055,7 +1055,7 @@ install(TARGETS torch EXPORT Caffe2Targets DESTINATION "${TORCH_INSTALL_LIB_DIR}
 caffe2_interface_library(torch torch_library)
 list(APPEND Caffe2_MAIN_LIBS torch_library)
 if (USE_TBB)
-  list(APPEND Caffe2_MAIN_LIB tbb)
+  list(APPEND Caffe2_MAIN_LIBS tbb)
 endif()
 
 # Install PDB files for MSVC builds


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#29746 Fix typo: Caffe2_MAIN_LIB to Caffe2_MAIN_LIBS**

I don't know if this actually broke anything because I just discovered
the typo while reading the cmake.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D18504546](https://our.internmc.facebook.com/intern/diff/D18504546)