### PR TITLE
[java] host build gradle publishing

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,8 +1,4 @@
 allprojects {
-    if (name == "pytorch_host") {
-        return
-    }
-
     buildscript {
         ext {
             minSdkVersion = 21

--- a/android/pytorch_android/host/build.gradle
+++ b/android/pytorch_android/host/build.gradle
@@ -31,3 +31,6 @@ dependencies {
     implementation 'com.facebook.fbjni:fbjni-java-only:0.0.3'
     testImplementation 'junit:junit:4.12'
 }
+
+apply from: rootProject.file('gradle/release.gradle')
+

--- a/android/pytorch_android/host/gradle.properties
+++ b/android/pytorch_android/host/gradle.properties
@@ -1,0 +1,4 @@
+POM_NAME=pytorch_java_only pytorch java api
+POM_DESCRIPTION=pytorch_java_only pytorch java api
+POM_ARTIFACT_ID=pytorch_java_only
+POM_PACKAGING=jar


### PR DESCRIPTION
To publish snapshots:
`gradle -p android pytorch_host:uploadArchives`
(for test changed version to 0.0.1-SNAPSHOT)
Result:
https://oss.sonatype.org/#nexus-search;quick~pytorch_java_only

https://oss.sonatype.org/service/local/repositories/snapshots/content/org/pytorch/pytorch_java_only/0.0.1-SNAPSHOT/
jar:
https://oss.sonatype.org/service/local/repositories/snapshots/content/org/pytorch/pytorch_java_only/0.0.1-SNAPSHOT/pytorch_java_only-0.0.1-20191113.211446-1.jar

sources:
https://oss.sonatype.org/service/local/repositories/snapshots/content/org/pytorch/pytorch_java_only/0.0.1-SNAPSHOT/pytorch_java_only-0.0.1-20191113.211446-1-sources.jar
