### PR TITLE
Avoid keeping old histograms in the histogram observer to fix the OOM issue

### DIFF
--- a/caffe2/quantization/server/dynamic_histogram.h
+++ b/caffe2/quantization/server/dynamic_histogram.h
@@ -68,13 +68,13 @@ class DynamicHistogram {
 
  private:
   /// Dynamic histogram is implemented by the series of static histograms
-  /// histograms_[i+1] is a new histogram "expanded" from histograms_[i] when
+  /// and expands from the old histogram to new histogram when
   /// we see a new extremum.
   /// An invariant: the beginning of the first bin of histograms_[i] exactly
   /// matches with the beginning of a bin in histograms_[i+1]. The end of the
   /// last bin of histograms_[i] exactly matches with the end of a bin in
   /// histograms_[i+1].
-  std::vector<Histogram> histograms_;
+  std::unique_ptr<Histogram> histogram_;
   int nbins_;
   float min_, max_;
 


### PR DESCRIPTION
Summary: The previous histogram observer saves all histograms for new data and merge the histograms in the end. It could cause OOM issue when we want to collect histograms on large amount of data. In this diff, we assume running the histogram observer with a single thread and remap the histogram after seeing new data.

Test Plan:
```
buck test mode/opt caffe2/caffe2/quantization/server:dynamic_histogram_test
```

```
buck run mode/opt caffe2/caffe2/fb/fbgemm/numerical_debugger/workflows:int8_static_quantization_exporter -- --model-dir /mnt/public/summerdeng/ads/ --model-name downsized_ins_97293388_0.predictor --run --iter 10  --dataset-path /mnt/public/summerdeng/ads/ctr_instagram_story_int8/dataset/train/dataset_115764229_10 --hive-path="hive://ad_delivery/ig_ad_prefiltered_training_data_orc_injected/ds=2019-09-09/pipeline=ctr_instagram_story_click_only_model_opt_out_df" --collect-histogram --activation-histogram-file=/mnt/public/summerdeng/ads/ctr_instagram_story_int8/activation_histograms/dummy_debug_OOM.txt
```

Differential Revision: D18458764

