### PR TITLE
Add nn.ResidualBlock and nn.ResidualBlockWithShortcut

### DIFF
--- a/docs/source/nn.rst
+++ b/docs/source/nn.rst
@@ -52,6 +52,21 @@ Containers
 .. autoclass:: ParameterDict
     :members:
 
+Residual blocks
+----------------------------------
+
+:hidden:`ResidualBlock`
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: ResidualBlock
+    :members:
+
+:hidden:`ResidualBlockWithShortcut`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: ResidualBlockWithShortcut
+    :members:
+
 Convolution layers
 ----------------------------------
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1592,6 +1592,22 @@ class TestNN(NNTestCase):
         parameters.clear()
         check()
 
+    def test_ResidualBlock(self):
+        net = nn.ResidualBlock(nn.ReLU(inplace=True))
+        input = torch.tensor([-2., -1., 0., 1., 2.])
+        expected = torch.tensor([-2., -1., 0., 2., 4.])
+        self.assertEqual(net(input), expected)
+
+    def test_ResidualBlockWithShortcut(self):
+        net = nn.ResidualBlockWithShortcut(
+            nn.ReLU(inplace=True),
+            nn.AvgPool1d(2),
+            shortcut=nn.AvgPool1d(2)
+        )
+        input = torch.tensor([[[-2., 0., 0., 2.]]])
+        expected = torch.tensor([[[-1., 2.]]])
+        self.assertEqual(net(input), expected)
+
     def test_add_module(self):
         l = nn.Linear(10, 20)
         net = nn.Module()

--- a/torch/nn/modules/__init__.py
+++ b/torch/nn/modules/__init__.py
@@ -10,6 +10,7 @@ from .loss import L1Loss, NLLLoss, KLDivLoss, MSELoss, BCELoss, BCEWithLogitsLos
     MultiLabelMarginLoss, MultiLabelSoftMarginLoss, MultiMarginLoss, \
     SmoothL1Loss, SoftMarginLoss, CrossEntropyLoss, TripletMarginLoss, PoissonNLLLoss
 from .container import Container, Sequential, ModuleList, ModuleDict, ParameterList, ParameterDict
+from .residual import ResidualBlock, ResidualBlockWithShortcut
 from .pooling import AvgPool1d, AvgPool2d, AvgPool3d, MaxPool1d, MaxPool2d, MaxPool3d, \
     MaxUnpool1d, MaxUnpool2d, MaxUnpool3d, FractionalMaxPool2d, FractionalMaxPool3d, LPPool1d, LPPool2d, \
     AdaptiveMaxPool1d, AdaptiveMaxPool2d, AdaptiveMaxPool3d, AdaptiveAvgPool1d, AdaptiveAvgPool2d, AdaptiveAvgPool3d
@@ -40,7 +41,8 @@ __all__ = [
     'NLLLoss2d', 'PoissonNLLLoss', 'CosineEmbeddingLoss', 'CTCLoss', 'HingeEmbeddingLoss', 'MarginRankingLoss',
     'MultiLabelMarginLoss', 'MultiLabelSoftMarginLoss', 'MultiMarginLoss', 'SmoothL1Loss',
     'SoftMarginLoss', 'CrossEntropyLoss', 'Container', 'Sequential', 'ModuleList', 'ModuleDict',
-    'ParameterList', 'ParameterDict', 'AvgPool1d', 'AvgPool2d', 'AvgPool3d', 'MaxPool1d', 'MaxPool2d',
+    'ParameterList', 'ParameterDict', 'ResidualBlock', 'ResidualBlockWithShortcut',
+    'AvgPool1d', 'AvgPool2d', 'AvgPool3d', 'MaxPool1d', 'MaxPool2d',
     'MaxPool3d', 'MaxUnpool1d', 'MaxUnpool2d', 'MaxUnpool3d', 'FractionalMaxPool2d', "FractionalMaxPool3d",
     'LPPool1d', 'LPPool2d', 'LocalResponseNorm', 'BatchNorm1d', 'BatchNorm2d', 'BatchNorm3d', 'InstanceNorm1d',
     'InstanceNorm2d', 'InstanceNorm3d', 'LayerNorm', 'GroupNorm', 'SyncBatchNorm',

--- a/torch/nn/modules/residual.py
+++ b/torch/nn/modules/residual.py
@@ -1,0 +1,49 @@
+from . import Identity, ModuleDict, Sequential
+
+
+class ResidualBlock(Sequential):
+    r"""A residual block with an identity shortcut connection.
+
+    Modules will be added to it in the order they are passed in the constructor.
+    Each module's output will be fed to the next module as input. Alternately,
+    an OrderedDict can be passed in. The final module's output will be added to
+    the original input and returned. The input and output must be the same
+    shape.
+
+    See: Kaiming He, Xiangyu Zhang, Shaoqing Ren, Jian Sun, "Deep Residual
+    Learning for Image Recognition" (https://arxiv.org/abs/1512.03385), and
+    "Identity Mappings in Deep Residual Networks"
+    (https://arxiv.org/abs/1603.05027).
+    """
+
+    def forward(self, input):
+        output = input.clone()
+        for module in self:
+            output = module(output)
+        return input + output
+
+
+class ResidualBlockWithShortcut(ModuleDict):
+    r"""A residual block with a non-identity shortcut connection.
+
+    Modules will be added to the 'main' branch in the order they are passed in
+    the constructor. Each module's output will be fed to the next module as
+    input. Alternately, an OrderedDict can be passed in. The final module's
+    output will be added to the output of the 'shortcut' branch. The two
+    branches' outputs must be the same shape.
+
+    See: Kaiming He, Xiangyu Zhang, Shaoqing Ren, Jian Sun, "Deep Residual
+    Learning for Image Recognition" (https://arxiv.org/abs/1512.03385), and
+    "Identity Mappings in Deep Residual Networks"
+    (https://arxiv.org/abs/1603.05027).
+    """
+
+    def __init__(self, *args, shortcut=Identity()):
+        super(ResidualBlockWithShortcut, self).__init__()
+        self['main'] = Sequential(*args)
+        self['shortcut'] = shortcut
+
+    def forward(self, input):
+        output_main = self['main'](input.clone())
+        output_shortcut = self['shortcut'](input)
+        return output_main + output_shortcut

--- a/torch/nn/modules/residual.py
+++ b/torch/nn/modules/residual.py
@@ -4,11 +4,34 @@ from . import Identity, ModuleDict, Sequential
 class ResidualBlock(Sequential):
     r"""A residual block with an identity shortcut connection.
 
-    Modules will be added to it in the order they are passed in the constructor.
-    Each module's output will be fed to the next module as input. Alternately,
-    an OrderedDict can be passed in. The final module's output will be added to
-    the original input and returned. The input and output must be the same
-    shape.
+    As in :class:`~torch.nn.Sequential`, modules will be added to it in the
+    order they are passed in the constructor, and an :class:`OrderedDict` can be
+    passed instead. The final module's output will be added to the original
+    input and returned. The input and output must be :ref:`broadcastable
+    <broadcasting-semantics>`.
+
+    Here is an example MNIST classifier::
+
+        model = nn.Sequential(
+            nn.Conv2d(1, 10, 1),
+            nn.ResidualBlock(
+                nn.ReLU(),
+                nn.Conv2d(10, 10, 3, padding=1),
+                nn.ReLU(),
+                nn.Conv2d(10, 10, 3, padding=1),
+            ),
+            nn.MaxPool2d(2),
+            nn.ResidualBlock(
+                nn.ReLU(),
+                nn.Conv2d(10, 10, 3, padding=1),
+                nn.ReLU(),
+                nn.Conv2d(10, 10, 3, padding=1),
+            ),
+            nn.MaxPool2d(2),
+            nn.Flatten(),
+            nn.Linear(7*7*10, 10),
+            nn.LogSoftmax(dim=-1),
+        )
 
     See: Kaiming He, Xiangyu Zhang, Shaoqing Ren, Jian Sun, "Deep Residual
     Learning for Image Recognition" (https://arxiv.org/abs/1512.03385), and
@@ -26,11 +49,37 @@ class ResidualBlock(Sequential):
 class ResidualBlockWithShortcut(ModuleDict):
     r"""A residual block with a non-identity shortcut connection.
 
-    Modules will be added to the 'main' branch in the order they are passed in
-    the constructor. Each module's output will be fed to the next module as
-    input. Alternately, an OrderedDict can be passed in. The final module's
-    output will be added to the output of the 'shortcut' branch. The two
-    branches' outputs must be the same shape.
+    As in :class:`~torch.nn.Sequential`, modules will be added to the 'main'
+    branch in the order they are passed in the constructor, and an
+    :class:`OrderedDict` can be passed instead. The :attr:`shortcut` keyword
+    argument specifies a module that performs the mapping for the shortcut
+    connection.  The output of the 'main' branch will be added to the output of
+    the 'shortcut' branch and returned. They must be :ref:`broadcastable
+    <broadcasting-semantics>`.
+
+    This module is useful where the 'main' branch has an output shape that is
+    different from its input shape, so :class:`~torch.nn.ResidualBlock` cannot
+    be used. The shortcut mapping may be used to adjust the shape of the input
+    to match. Here is an example MNIST classifier::
+
+        model = nn.Sequential(
+            nn.ResidualBlockWithShortcut(
+                nn.Conv2d(1, 10, 3, padding=1),
+                nn.ReLU(),
+                nn.Conv2d(10, 10, 3, stride=2, padding=1),
+                shortcut=nn.Conv2d(1, 10, 1, stride=2, bias=False),
+            ),
+            nn.ResidualBlockWithShortcut(
+                nn.ReLU(),
+                nn.Conv2d(10, 20, 3, padding=1),
+                nn.ReLU(),
+                nn.Conv2d(20, 20, 3, stride=2, padding=1),
+                shortcut=nn.Conv2d(10, 20, 1, stride=2, bias=False),
+            ),
+            nn.Flatten(),
+            nn.Linear(7*7*20, 10),
+            nn.LogSoftmax(dim=-1),
+        )
 
     See: Kaiming He, Xiangyu Zhang, Shaoqing Ren, Jian Sun, "Deep Residual
     Learning for Image Recognition" (https://arxiv.org/abs/1512.03385), and


### PR DESCRIPTION
Here are two modules that implement residual blocks in a nice object-oriented way. They subclass the container modules, and they accept modules as positional arguments similarly to `nn.Sequential`. They also pretty-print nicely, again due to subclassing the container modules.

The references for residual blocks are: Kaiming He, Xiangyu Zhang, Shaoqing Ren, Jian Sun, "Deep Residual Learning for Image Recognition" (https://arxiv.org/abs/1512.03385), and "Identity Mappings in Deep Residual Networks" (https://arxiv.org/abs/1603.05027).

Here's a complete example of a MNIST resnet model:

```python3
model = nn.Sequential(
    nn.Conv2d(1, 10, 1),
    nn.ResidualBlock(
        nn.ReLU(),
        nn.Conv2d(10, 10, 3, padding=1),
        nn.ReLU(),
        nn.Conv2d(10, 10, 3, padding=1),
    ),
    nn.MaxPool2d(2),
    nn.ResidualBlock(
        nn.ReLU(),
        nn.Conv2d(10, 10, 3, padding=1),
        nn.ReLU(),
        nn.Conv2d(10, 10, 3, padding=1),
    ),
    nn.MaxPool2d(2),
    nn.Flatten(),
    nn.Linear(7*7*10, 10),
    nn.LogSoftmax(dim=-1),
)
```

When it is printed, it looks like this:

```
Sequential(
  (0): Conv2d(1, 10, kernel_size=(1, 1), stride=(1, 1))
  (1): ResidualBlock(
    (0): ReLU()
    (1): Conv2d(10, 10, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))
    (2): ReLU()
    (3): Conv2d(10, 10, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))
  )
  (2): MaxPool2d(kernel_size=2, stride=2, padding=0, dilation=1, ceil_mode=False)
  (3): ResidualBlock(
    (0): ReLU()
    (1): Conv2d(10, 10, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))
    (2): ReLU()
    (3): Conv2d(10, 10, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))
  )
  (4): MaxPool2d(kernel_size=2, stride=2, padding=0, dilation=1, ceil_mode=False)
  (5): Flatten()
  (6): Linear(in_features=490, out_features=10, bias=True)
  (7): LogSoftmax()
)
```

The second proposed module, `nn.ResidualBlockWithShortcut`, is for the case where the output shape is different from the input shape. It allows you to specify a module on the "shortcut" branch, whose purpose is to reshape the input to match the main branch's output shape. In the original ResNet implementation this would be a 1x1 convolution with no bias, with different numbers of input and output channels. Here's another MNIST example:

```python3
model = nn.Sequential(
    nn.ResidualBlockWithShortcut(
        nn.Conv2d(1, 10, 3, padding=1),
        nn.ReLU(),
        nn.Conv2d(10, 10, 3, stride=2, padding=1),
        shortcut=nn.Conv2d(1, 10, 1, stride=2, bias=False)
    ),
    nn.ResidualBlockWithShortcut(
        nn.ReLU(),
        nn.Conv2d(10, 20, 3, padding=1),
        nn.ReLU(),
        nn.Conv2d(20, 20, 3, stride=2, padding=1),
        shortcut=nn.Conv2d(10, 20, 1, stride=2, bias=False)
    ),
    nn.Flatten(),
    nn.Linear(7*7*20, 10),
    nn.LogSoftmax(dim=-1),
)
```

When printed, it looks like:
```
Sequential(
  (0): ResidualBlockWithShortcut(
    (main): Sequential(
      (0): Conv2d(1, 10, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))
      (1): ReLU()
      (2): Conv2d(10, 10, kernel_size=(3, 3), stride=(2, 2), padding=(1, 1))
    )
    (shortcut): Conv2d(1, 10, kernel_size=(1, 1), stride=(2, 2), bias=False)
  )
  (1): ResidualBlockWithShortcut(
    (main): Sequential(
      (0): ReLU()
      (1): Conv2d(10, 20, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))
      (2): ReLU()
      (3): Conv2d(20, 20, kernel_size=(3, 3), stride=(2, 2), padding=(1, 1))
    )
    (shortcut): Conv2d(10, 20, kernel_size=(1, 1), stride=(2, 2), bias=False)
  )
  (2): Flatten()
  (3): Linear(in_features=980, out_features=10, bias=True)
  (4): LogSoftmax()
)
```