### PR TITLE
Skip outputting scalar_checks if they are false.

### DIFF
--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -1698,7 +1698,8 @@ def create_derived(backend_type_env, declarations):
                         for arg in arguments:
                             scalar_check_arg = (scalar_check if not isinstance(scalar_check, dict)
                                                 else scalar_check.get(arg['name']))  # type: ignore
-                            if scalar_check_arg is not None:
+                            # maybe_zero_dim(false) is a no-op
+                            if scalar_check_arg is not None and scalar_check_arg != 'false':
                                 stmt = "{}_->maybe_zero_dim({});".format(arg['name'], scalar_check_arg)
                                 if nullable_argument(arg):
                                     stmt = "if ({}_) {}".format(arg['name'], stmt)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#29772 Skip outputting scalar_checks if they are false.**
* #29759 Be explicit about scalar_checks in a few places.

This is a no-op anyway, so no reason to output.