### PR TITLE
Improve legacy QuantizedLinear functions to reduce overhead

### DIFF
--- a/aten/src/ATen/native/QuantizedLinear.cpp
+++ b/aten/src/ATen/native/QuantizedLinear.cpp
@@ -1,6 +1,15 @@
+#include <array>
+#include <cctype>
+#include <chrono>
+#include <cmath>
+#include <cstddef>
+#include <sstream>
+#include <string>
+#include <vector>
+
 #include "ATen/ATen.h"
-#include "ATen/Parallel.h"
 #include "ATen/NativeFunctions.h"
+#include "ATen/Parallel.h"
 #include "ATen/WrapDimUtilsMulti.h"
 #include "ATen/cpp_custom_type_hack.h"
 
@@ -10,23 +19,13 @@
 #include "fbgemm/QuantUtils.h"
 #endif // USE_FBGEMM
 
-#include <array>
-#include <cctype>
-#include <cmath>
-#include <cstddef>
-#include <sstream>
-#include <string>
-#include <vector>
-
-#include <chrono>
-
-namespace caffe2 {
 #ifdef USE_FBGEMM
+namespace caffe2 {
 // Required for cpp_custom_type_hack to work
 CAFFE_KNOWN_TYPE(fbgemm::PackBMatrix<int8_t>);
 CAFFE_KNOWN_TYPE(fbgemm::PackedGemmMatrixFP16);
-#endif // USE_FBGEMM
 } // namespace caffe2
+#endif // USE_FBGEMM
 
 namespace at {
 namespace native {
@@ -46,22 +45,23 @@ Tensor fbgemm_linear_int8_weight_fp32_activation(
   // fallback path and rather fail loudly if we cannot run FBGEMM.
   TORCH_CHECK(fbgemm::fbgemmSupportedCPU(), "Your CPU doesn't support FBGEMM.");
 
-  auto input_contig = input.contiguous();
-  auto* input_ptr = input_contig.data_ptr<float>();
+  const Tensor input_contig = input.contiguous();
+  const float* input_ptr = input_contig.data_ptr<float>();
 
   TORCH_CHECK(input.dim() >= 2);
-  int64_t M = size_to_dim_(input.dim() - 1, input.sizes());
-  int64_t K = input.size(input.dim() - 1);
+  const int64_t M = size_to_dim_(input.dim() - 1, input.sizes());
+  const int64_t K = input.size(input.dim() - 1);
   TORCH_CHECK(weight.dim() == 2);
   TORCH_CHECK(K == weight.size(1));
-  auto N = weight.size(0);
+  const int64_t N = weight.size(0);
   TORCH_CHECK(bias.dim() == 1);
   TORCH_CHECK(bias.size(0) == N);
   TORCH_CHECK(weight_scale.isFloatingPoint());
   TORCH_CHECK(weight_zero_point.isIntegral(false));
 
   // Calculate statistics for quantization of the input Tensor
-  float x_min, x_max;
+  float x_min;
+  float x_max;
   fbgemm::FindMinMax(
       /*m=*/input_ptr,
       /*min=*/&x_min,
@@ -69,102 +69,95 @@ Tensor fbgemm_linear_int8_weight_fp32_activation(
       /*len=*/input.numel());
 
   // Input tensor is quantized as 8-bit unsigned values
-  static constexpr int precision = 8;
-  static constexpr bool is_signed = false;
-  static constexpr int bound = (1 << (precision - 1));
+  constexpr int kPrecision = 8;
+  constexpr bool kIsSigned = false;
+  constexpr int kBound = (1 << (kPrecision - 1));
 
   // Calculate scale and zero point for quantization of input tensor
   auto q_params = fbgemm::ChooseQuantizationParams(
       /*min=*/x_min,
       /*max=*/x_max,
-      /*qmin=*/is_signed ? -bound : 0,
-      /*qmax=*/is_signed ? (bound - 1) : (1 << precision) - 1,
+      /*qmin=*/kIsSigned ? -kBound : 0,
+      /*qmax=*/kIsSigned ? (kBound - 1) : (1 << kPrecision) - 1,
       /*preserve_sparsity=*/false);
-
-  q_params.precision = precision;
+  q_params.precision = kPrecision;
 
   // ReQuantizeForFloat requires pointers to the scale and zero point values,
   // since in the case of rowwise quantization these will be arrays rather than
   // scalars. But in this case, we're doing whole-tensor quantization so we just
   // pass a pointer to the scale values (and internally ReQuantizeFor Float
   // won't index past 0
-  float weight_scale_float = static_cast<float>(weight_scale.to<double>());
-  int32_t weight_zero_point_int32 =
+  const float weight_scale_float =
+      static_cast<float>(weight_scale.to<double>());
+  const int32_t weight_zero_point_int32 =
       static_cast<int32_t>(weight_zero_point.to<int64_t>());
 
-  auto bias_contig = bias.contiguous();
+  const Tensor bias_contig = bias.contiguous();
 
-  // The resulting matrix here is 2-D, let's view it with the original
-  // left hand dimensions of the input.
-  // Here are two examples:
-  // 1. If the input tensor is {M, K}, the output tensor is {M, N}.
-  // 2. If the input tensor is {b, M, K}, the output tensor is {b, M, N}.
-  std::vector<int64_t> out_sizes = input.sizes().vec();
-  out_sizes.back() = N;
   // Allocate output Tensor and a buffer for fbgemmPacked to use
-  auto output = at::zeros(
-      out_sizes, bias.options().dtype(at::kFloat));
-  auto buffer = at::zeros_like(output, output.options().dtype(at::kInt));
+  std::vector<int64_t> output_size = input.sizes().vec();
+  output_size.back() = N;
+  Tensor output = at::empty(output_size, input.options().dtype(at::kFloat));
+  Tensor buffer = at::empty(output_size, input.options().dtype(at::kInt));
 
   // Pull out the PackBMatrix instance from the owning tensor
-  auto& packB = cpp_custom_type_hack::cast<fbgemm::PackBMatrix<int8_t>>(packed);
+  auto& pack_b =
+      cpp_custom_type_hack::cast<fbgemm::PackBMatrix<int8_t>>(packed);
 
-  int num_tasks = at::get_num_threads();
+  const int num_tasks = at::get_num_threads();
   at::parallel_for(0, num_tasks, 1, [&](int64_t begin, int64_t end) {
     // This operation does the following:
-    // 1) Quantizes the input matrix given the statistics we've calculated above
+    // 1) Quantizes the input matrix given the statistics we've calculated
+    //    above.
     // 2) Creates a "row buffer" vector with offset values that must be added
-    //    to the integer matrix multiplication operation to ensure correctness
+    //    to the integer matrix multiplication operation to ensure correctness.
     // 3) Packs the resulting quantized matrix into vector-register and cache
     //    friendly tiles.
     //
     //  Note this is not executed eagerly, but rather within the fbgemmPacked
     //  call below.
-    fbgemm::PackAWithQuantRowOffset<uint8_t> packA(
+    fbgemm::PackAWithQuantRowOffset<uint8_t> pack_a(
         /*trans=*/fbgemm::matrix_op_t::NoTranspose,
         /*nRow=*/M,
         /*nCol=*/K,
         /*smat=*/input_ptr,
         /*ld=*/K,
-        /*pmat=*/nullptr, // packA manages ownership of `pmat`
+        /*pmat=*/nullptr, // pack_a manages ownership of `pmat`
         /*scale=*/q_params.scale,
         /*zero_pt=*/q_params.zero_point);
 
     // This is the end of the pipeline, pass the resulting matrix through
-    fbgemm::DoNothing<float, float> doNothingObj{};
-
+    fbgemm::DoNothing<float, float> kDoNothingObj{};
     for (int task_id = begin; task_id < end; ++task_id) {
       // After the uint8 * int8 matrix multiplication is performed, this
       // operation does:
       //  1) Add in row and column offsets to the rows and columns, respectively
       //  2) Dequantize the results into floating point
       //  3) Add in the bias term
-      fbgemm::ReQuantizeForFloat</*FUSE_RELU*/ false> outputProcObj(
-          /*nextop=*/doNothingObj,
+      fbgemm::ReQuantizeForFloat</* FUSE_RELU */ false> output_proc_obj(
+          /*nextop=*/kDoNothingObj,
           /*Aq_scale=*/q_params.scale,
           /*Bq_scale=*/&weight_scale_float,
           /*Aq_zero_point=*/q_params.zero_point,
           /*Bq_zero_point=*/&weight_zero_point_int32,
-          /*row_offsets=*/packA.getRowOffsetBuffer(),
+          /*row_offsets=*/pack_a.getRowOffsetBuffer(),
           /*col_offsets=*/col_offsets.data_ptr<int32_t>(),
           /*bias=*/bias_contig.data_ptr<float>(),
           /*nCol=*/N);
-
       // Do the GEMM
       fbgemm::fbgemmPacked(
-          /*packA=*/packA,
-          /*packB=*/packB,
+          /*packA=*/pack_a,
+          /*packB=*/pack_b,
           /*C=*/output.data_ptr<float>(),
           /*C_buffer=*/buffer.data_ptr<int32_t>(),
           /*ldc=*/N,
-          /*outProcess=*/outputProcObj,
+          /*outProcess=*/output_proc_obj,
           /*thread_id=*/task_id,
           /*num_threads=*/num_tasks);
     }
   });
 
   return output;
-
 }
 
 Tensor fbgemm_linear_int8_weight(
@@ -191,24 +184,26 @@ Tensor fbgemm_linear_int8_weight(
 }
 
 namespace {
+
 // Calculate the column offsets
 // Note this includes the sum of the columns as well as the scalar term
 // B_zero_point * K, whereas the row_offsets created by
 // PackAWithQuantRowOffset is only the sum of the A rows.
-void calc_col_offsets_transpose(
+void CalcColOffsetsTranspose(
     int K,
     int N,
     const int8_t* Bint8,
     int32_t B_zero_point,
     int32_t* col_offsets) {
-  for (size_t i = 0; i < N; ++i) {
+  for (int i = 0; i < N; ++i) {
     int32_t sum = 0;
-    for (size_t j = 0; j < K; ++j) {
+    for (int j = 0; j < K; ++j) {
       sum += Bint8[i * K + j];
     }
     col_offsets[i] = sum - B_zero_point * K;
   }
 }
+
 } // namespace
 
 std::tuple<Tensor, Tensor, double, int64_t> fbgemm_linear_quantize_weight(
@@ -217,10 +212,11 @@ std::tuple<Tensor, Tensor, double, int64_t> fbgemm_linear_quantize_weight(
   // same numerics across different machines. Therefore, we do not provide a
   // fallback path and rather fail loudly if we cannot run FBGEMM.
   TORCH_CHECK(fbgemm::fbgemmSupportedCPU(), "Your CPU doesn't support FBGEMM.");
-  auto weight_contig = weight.contiguous();
+  const Tensor weight_contig = weight.contiguous();
 
   // Calculate weight statistics
-  float w_min, w_max;
+  float w_min;
+  float w_max;
   fbgemm::FindMinMax(
       /*m=*/weight_contig.data_ptr<float>(),
       /*min=*/&w_min,
@@ -228,19 +224,21 @@ std::tuple<Tensor, Tensor, double, int64_t> fbgemm_linear_quantize_weight(
       /*len=*/weight_contig.numel());
 
   // Choose parameters for quantizing the weight as 8-bit signed integer
-  static constexpr bool is_signed = true;
-  static constexpr int precision = 8;
-  static constexpr int bound = (1 << (precision - 1));
+  constexpr bool kIsSigned = true;
+  constexpr int kPrecision = 8;
+  constexpr int kBound = (1 << (kPrecision - 1));
   auto q_params = fbgemm::ChooseQuantizationParams(
       /*min=*/w_min,
       /*max=*/w_max,
-      /*qmin=*/is_signed ? -bound : 0,
-      /*qmax=*/is_signed ? (bound - 1) : (1 << precision) - 1,
+      /*qmin=*/kIsSigned ? -kBound : 0,
+      /*qmax=*/kIsSigned ? (kBound - 1) : (1 << kPrecision) - 1,
       /*preserve_sparsity=*/false);
+  q_params.precision = kPrecision;
 
-  q_params.precision = precision;
-
-  auto quantized = at::zeros_like(weight_contig, at::MemoryFormat::Contiguous).to(at::kChar).contiguous();
+  Tensor quantized = at::native::empty_like(
+      weight_contig, weight_contig.options().dtype(at::kChar));
+  // Tensor quantized = at::native::empty_cpu(
+  //     weight_contig.sizes(), weight_contig.options().dtype(at::kChar));
   fbgemm::Quantize<int8_t>(
       /*src=*/weight_contig.data_ptr<float>(),
       /*dst=*/quantized.data_ptr<int8_t>(),
@@ -249,9 +247,9 @@ std::tuple<Tensor, Tensor, double, int64_t> fbgemm_linear_quantize_weight(
 
   // Calculate column offsets of the weight and store them away in a tensor.
   // Similarly to quantization, this can be done once and cached.
-  auto col_offsets =
-      at::zeros_like(quantized, at::MemoryFormat::Contiguous).sum({1}).to(at::kInt).contiguous();
-  calc_col_offsets_transpose(
+  Tensor col_offsets = at::empty(
+      {weight_contig.size(0)}, weight_contig.options().dtype(at::kInt));
+  CalcColOffsetsTranspose(
       /*K=*/quantized.size(1),
       /*N=*/quantized.size(0),
       /*Bint8=*/quantized.data_ptr<int8_t>(),
@@ -267,15 +265,15 @@ Tensor fbgemm_pack_quantized_matrix(const Tensor& weight) {
   // same numerics across different machines. Therefore, we do not provide a
   // fallback path and rather fail loudly if we cannot run FBGEMM.
   TORCH_CHECK(fbgemm::fbgemmSupportedCPU(), "Your CPU doesn't support FBGEMM.");
-  int64_t K = weight.size(1);
-  int64_t N = weight.size(0);
-  auto weight_contig = weight.contiguous();
-  auto contiguous_ptr = weight_contig.data_ptr<int8_t>();
+  const int64_t K = weight.size(1);
+  const int64_t N = weight.size(0);
+  const Tensor weight_contig = weight.contiguous();
+  const int8_t* weight_ptr = weight_contig.data_ptr<int8_t>();
   auto ptr = guts::make_unique<fbgemm::PackBMatrix<int8_t>>(
       /*trans=*/fbgemm::matrix_op_t::Transpose,
       /*nRow=*/K,
       /*nCol=*/N,
-      /*smat=*/contiguous_ptr,
+      /*smat=*/weight_ptr,
       /*ld=*/K,
       /*pmat=*/nullptr, // PackBMatrix manages ownership of pmat
       /*groups=*/1);
@@ -290,32 +288,33 @@ Tensor fbgemm_pack_quantized_matrix(
   // TORCH_WARN(
   //     "fbgemm_pack_quantized_matrix(weight, K, N) will be deprecated soon."
   //     "Please use fbgemm_pack_quantized_matrix(weight) instead.");
-
   return at::native::fbgemm_pack_quantized_matrix(weight);
 }
 
-float raw_uint16_to_fp16(unsigned short value) {
+namespace {
+
+float RawUint16ToFp16(unsigned short value) {
   // Convert raw 16 bits half precision floating point number
   // to single precision floating point number.
-  unsigned short sign_bits = value >> 15;
-  unsigned short exponent_bits = value >> 10 & 0x1f;
-  unsigned short significand_bits = value & 0x3ff;
+  const unsigned short sign_bits = value >> 15;
+  const unsigned short exponent_bits = value >> 10 & 0x1f;
+  const unsigned short significand_bits = value & 0x3ff;
 
-  float sign = sign_bits ? -1 : 1;
-  float significand = 1 + significand_bits * 0x1p-10;
-  float exponent = exponent_bits - 0xf;
+  const float sign = sign_bits ? -1 : 1;
+  const float significand = 1 + significand_bits * 0x1p-10;
+  const float exponent = exponent_bits - 0xf;
 
   return sign * std::ldexp(significand, exponent);
 }
 
 template <typename T>
-bool check_and_saturate(T* element, T MAX) {
-  if (*element > MAX) {
-    *element = MAX;
+bool CheckAndSaturate(T max_val, T* element) {
+  if (*element > max_val) {
+    *element = max_val;
     return true;
   }
-  if (*element < -MAX) {
-    *element = -MAX;
+  if (*element < -max_val) {
+    *element = -max_val;
     return true;
   }
   return false;
@@ -324,20 +323,20 @@ bool check_and_saturate(T* element, T MAX) {
 // The range for using FP16 quantization of weights requires that the elements
 // should be in the range of [5.96e-8, 65504]. If it is out of range, then the
 // number will be saturated to max or min representable values by FP16.
-void handle_weights_saturation(float* weight, int64_t length) {
-  float FP16_MAX = raw_uint16_to_fp16(0x7BFF);
+void HandleWeightsSaturation(int64_t N, float* weight) {
+  const float kFp16Max = RawUint16ToFp16(0x7BFF);
   bool found_out_of_range = false;
-
-  for (int i = 0; i < length; ++i) {
-    if (check_and_saturate<float>(&weight[i], FP16_MAX)) {
+  for (int64_t i = 0; i < N; ++i) {
+    if (CheckAndSaturate<float>(kFp16Max, weight + i)) {
       found_out_of_range = true;
     }
   }
-
   if (found_out_of_range) {
     TORCH_WARN("FOUND weight out of range ");
   }
 }
+
+} // namespace
 
 Tensor fbgemm_pack_gemm_matrix_fp16(const Tensor& weight) {
   // We make a strong guarantee that models using these operators will have the
@@ -345,12 +344,11 @@ Tensor fbgemm_pack_gemm_matrix_fp16(const Tensor& weight) {
   // fallback path and rather fail loudly if we cannot run FBGEMM.
   TORCH_CHECK(fbgemm::fbgemmSupportedCPU(), "Your CPU doesn't support FBGEMM.");
 
-  int64_t K = weight.size(1);
-  int64_t N = weight.size(0);
+  const int64_t K = weight.size(1);
+  const int64_t N = weight.size(0);
   Tensor weight_contig = weight.contiguous();
-  auto weight_contig_ptr = weight_contig.data_ptr<float>();
-
-  handle_weights_saturation(weight_contig_ptr, K * N);
+  float* weight_contig_ptr = weight_contig.data_ptr<float>();
+  HandleWeightsSaturation(K * N, weight_contig_ptr);
 
   // TODO(mingzhe09088):
   // Consider using a functor here in PackedGemmMatrixFP16
@@ -373,8 +371,8 @@ Tensor fbgemm_linear_fp16_weight_fp32_activation(
   // fallback path and rather fail loudly if we cannot run FBGEMM.
   TORCH_CHECK(fbgemm::fbgemmSupportedCPU(), "Your CPU doesn't support FBGEMM.");
 
-  auto input_contig = input.contiguous();
-  auto* input_ptr = input_contig.data_ptr<float>();
+  const Tensor input_contig = input.contiguous();
+  const float* input_ptr = input_contig.data_ptr<float>();
 
   // Pull out the PackedGemmMatrixFP16 instance from the owning tensor
   const fbgemm::PackedGemmMatrixFP16& packed_weight_fp16 =
@@ -384,10 +382,11 @@ Tensor fbgemm_linear_fp16_weight_fp32_activation(
   TORCH_CHECK(input.dim() >= 2);
   TORCH_CHECK(bias.dim() == 1);
 
-  int64_t M = size_to_dim_(input.dim() - 1, input.sizes());
-  int64_t N = packed_weight_fp16.numCols();
-
-  auto output = at::empty({M, N}, bias.options().dtype(at::kFloat));
+  const int64_t M = size_to_dim_(input.dim() - 1, input.sizes());
+  const int64_t N = packed_weight_fp16.numCols();
+  std::vector<int64_t> output_size = input.sizes().vec();
+  output_size.back() = N;
+  Tensor output = at::empty(output_size, input.options().dtype(at::kFloat));
 
   // Call the fp16 gemm interface
   fbgemm::cblas_gemm_compute(
@@ -401,9 +400,7 @@ Tensor fbgemm_linear_fp16_weight_fp32_activation(
   // Add bias term
   output.add_(bias);
 
-  std::vector<int64_t> out_sizes = input.sizes().vec();
-  out_sizes.back() = N;
-  return output.view(out_sizes);
+  return output;
 }
 
 Tensor fbgemm_linear_fp16_weight(
@@ -414,7 +411,6 @@ Tensor fbgemm_linear_fp16_weight(
   // TORCH_WARN(
   //     "fbgemm_linear_fp16_weight will be deprecated soon."
   //     "Please use fbgemm_linear_fp16_weight_fp32_activation instead.");
-
   return at::native::fbgemm_linear_fp16_weight_fp32_activation(
       input, packed_weight, bias);
 }
@@ -529,5 +525,6 @@ bool fbgemm_is_cpu_supported() {
 }
 
 #endif // USE_FBGEMM
+
 } // namespace native
 } // namespace at


### PR DESCRIPTION
Summary:
Improve legacy QuantizedLinear functions to reduce overhead.

The legacy QuantizedLinear functions contains may unnecessary zeros and view ops which brings a large amount of overhead. This PR reduces them and improve the existing model performance. 

Differential Revision: D18494988

