### PR TITLE
add addmm op to the benchmark suite

### DIFF
--- a/benchmarks/operator_benchmark/pt/add_test.py
+++ b/benchmarks/operator_benchmark/pt/add_test.py
@@ -52,5 +52,18 @@ op_bench.generate_pt_test(add_long_configs + add_short_configs, AddBenchmark)
 op_bench.generate_pt_gradient_test(add_long_configs + add_short_configs, AddBenchmark)
 
 
+"""Mircobenchmark for addmm operator."""
+class AddmmBenchmark(op_bench.TorchBenchmarkBase):
+    def init(self, M, N, K, device):
+        self.input_one = torch.rand(M, K, device=device)
+        self.mat1 = torch.rand(M, N, device=device)
+        self.mat2 = torch.rand(N, K, device=device)
+        self.set_module_name("addmm")
+
+    def forward(self):
+        return torch.addmm(self.input_one, self.mat1, self.mat2)
+
+op_bench.generate_pt_test(add_long_configs + add_short_configs, AddmmBenchmark)
+
 if __name__ == "__main__":
     op_bench.benchmark_runner.main()


### PR DESCRIPTION
Summary: Addes addmm operator which reuses existing input shapes for the add operator.

Test Plan:
```
buck run //caffe2/benchmarks/operator_benchmark/pt:add_test -- --iterations 1
# Benchmarking PyTorch: addmm
# Mode: Eager
# Name: addmm_M64_N64_K64_cpu
# Input: M: 64, N: 64, K: 64, device: cpu
Forward Execution Time (us) : 3936.071

# Benchmarking PyTorch: addmm
# Mode: Eager
# Name: addmm_M64_N64_K128_cpu
# Input: M: 64, N: 64, K: 128, device: cpu
Forward Execution Time (us) : 3238.556

Differential Revision: D18496476

