### PR TITLE
add embeddingbag operator the the benchmark suite

### DIFF
--- a/benchmarks/operator_benchmark/pt/embeddingbag_test.py
+++ b/benchmarks/operator_benchmark/pt/embeddingbag_test.py
@@ -1,0 +1,40 @@
+import operator_benchmark as op_bench
+import torch
+import numpy
+
+"""EmbeddingBag Operator Benchmark"""
+
+embeddingbag_short_configs = op_bench.cross_product_configs(
+    embeddingbags=[80, 120, 1000, 2300],
+    dim=[64],
+    mode=['sum'],
+    input_size=[8, 16, 64],
+    offset=[0],
+    sparse=[True],
+    tags=['short']
+)
+
+
+class EmbeddingBagBenchmark(op_bench.TorchBenchmarkBase):
+    def init(self, embeddingbags, dim, mode, input_size, offset, sparse):
+        self.embegging = torch.nn.EmbeddingBag(
+            num_embeddings=embeddingbags,
+            embedding_dim=dim,
+            mode=mode,
+            sparse=sparse)
+        numpy.random.seed((1 << 32) - 1)
+        self.input = torch.tensor(numpy.random.randint(0, embeddingbags, input_size)).long()
+        self.offset = torch.LongTensor([offset])
+
+        self.set_module_name('embeddingbag')
+
+    def forward(self):
+        return self.embegging(self.input, self.offset)
+
+
+op_bench.generate_pt_test(embeddingbag_short_configs, EmbeddingBagBenchmark)
+op_bench.generate_pt_gradient_test(embeddingbag_short_configs, EmbeddingBagBenchmark)
+
+
+if __name__ == "__main__":
+    op_bench.benchmark_runner.main()


### PR DESCRIPTION
Summary: Add embeddingbag operator to the benchmark suite with different number of embeddings, dims, and inputs.

Test Plan:
```
buck run //caffe2/benchmarks/operator_benchmark/pt:embeddingbag_test -- --iterations 1
# ----------------------------------------
# PyTorch/Caffe2 Operator Micro-benchmarks
# ----------------------------------------
# Tag : short

# Benchmarking PyTorch: embeggingbag
# Mode: Eager
# Name: embeggingbag_embeddingbags80_dim64_modesum_input_size8_offset0_sparseTrue
# Input: embeddingbags: 80, dim: 64, mode: sum, input_size: 8, offset: 0, sparse: True
Forward Execution Time (us) : 658.912
...

Differential Revision: D18496340

