### PR TITLE
Also update the legacy API to support Packed Sequence support for quantized LSTM

### DIFF
--- a/torch/jit/quantized.py
+++ b/torch/jit/quantized.py
@@ -465,10 +465,15 @@ class QuantizedLSTM(QuantizedRNNBase):
             hx = self.permute_hidden(hx, sorted_indices)
 
         self.check_forward_args(input, hx, batch_sizes)
-        assert batch_sizes is None
-        result = _VF.quantized_lstm(input, hx, self.all_weights, self.bias, self.num_layers,
-                                    float(self.dropout), self.training, self.bidirectional,
-                                    self.batch_first, dtype=self.dtype, use_dynamic=False)
+
+        if batch_sizes is None:
+            result = _VF.quantized_lstm(input, hx, self.all_weights, self.bias, self.num_layers,
+                                        float(self.dropout), self.training, self.bidirectional,
+                                        self.batch_first, dtype=self.dtype, use_dynamic=False)
+        else:
+            result = _VF.quantized_lstm(input, batch_sizes, hx, self.all_weights, self.bias,
+                                        self.num_layers, float(self.dropout), self.training,
+                                        self.bidirectional, dtype=self.dtype, use_dynamic=False)
         output = result[0]
         hidden = result[1:]
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#29786 Also update the legacy API to support Packed Sequence support for quantized LSTM**

As Title says. This is a follow-up for https://github.com/pytorch/pytorch/pull/29585. Check https://github.com/pytorch/pytorch/issues/27963

Differential Revision: [D18497319](https://our.internmc.facebook.com/intern/diff/D18497319/)