### PR TITLE
Update CODEOWNERS for distributed rpc framework.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -19,3 +19,9 @@
 /torch/autograd/ @apaszke
 /torch/jit/ @apaszke
 /torch/utils/data/ @apaszke
+
+# Distributed RPC Framework.
+/torch/csrc/distributed/rpc @mrshenli @pritamdamania87
+/torch/csrc/distributed/autograd @mrshenli @pritamdamania87
+/torch/distributed/rpc @mrshenli @pritamdamania87
+/torch/distributed/autograd @mrshenli @pritamdamania87


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#29788 Update CODEOWNERS for distributed rpc framework.**

Differential Revision: [D18498997](https://our.internmc.facebook.com/intern/diff/D18498997/)