### PR TITLE
[JIT] Fix tracing of autograd functions

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -10380,6 +10380,33 @@ a")
             mte, (torch.zeros(1, 2, 3),), None, verbose=False,
             example_outputs=outputs)
 
+    def test_trace_autograd_function(self):
+        class TestFunc(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, input):
+                return torch.neg(input)
+
+            @staticmethod
+            def backward(ctx, grad_output):
+                return torch.neg(grad_output)
+
+
+
+        class TracedModule(torch.nn.Module):
+            def forward(self, x):
+                return torch.relu(TestFunc.apply(x))
+
+
+        class Wrapper(torch.nn.Module):
+            def __init__(self):
+                super(Wrapper, self).__init__()
+                self.tm = TracedModule()
+
+            def forward(self, x):
+                return self.tm(x)
+
+        traced = torch.jit.trace(Wrapper(), (torch.rand(3, 4),))
+
     def test_interpolate_trace(self):
         class test(nn.Module):
             def __init__(self):

--- a/torch/csrc/jit/python_tracer.cpp
+++ b/torch/csrc/jit/python_tracer.cpp
@@ -104,8 +104,7 @@ Node* preRecordPythonTrace(
     n->addInput(getValueTrace(input));
   }
 
-  // NB: Order matters. This must append after inputs but before outputs.
-  graph->appendNode(n);
+  graph->insertNode(n);
 
   return n;
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#29791 [JIT] Fix tracing of autograd functions**

These nodes were erroneously being put at the end of the graph, outside the proper TracedModuleForward Calls

cc @ilia-cher  

Differential Revision: [D18499142](https://our.internmc.facebook.com/intern/diff/D18499142)