### PR TITLE
fix op benchmark OOM issue

### DIFF
--- a/benchmarks/operator_benchmark/benchmark_core.py
+++ b/benchmarks/operator_benchmark/benchmark_core.py
@@ -79,7 +79,6 @@ def _build_test(configs, bench_op, OperatorTestCase, run_backward, op_name_funct
            run_backward: a bool parameter indicating backward path
            op_name_function: a dictionary includes operator name and function
     """
-    test_list = []
     for config in configs:
         test_attrs = {}
         tags = None
@@ -132,7 +131,7 @@ def _build_test(configs, bench_op, OperatorTestCase, run_backward, op_name_funct
         # which use auto_set().
         if op._num_inputs_require_grads > 0:
             input_name = 'all'
-        test_list.append(_create_test(op, test_attrs, tags, OperatorTestCase, run_backward, input_name))
+        yield _create_test(op, test_attrs, tags, OperatorTestCase, run_backward, input_name)
 
         # This for loop is only used when auto_set is used.
         # _pass_count counts how many times init has been called.
@@ -147,9 +146,7 @@ def _build_test(configs, bench_op, OperatorTestCase, run_backward, op_name_funct
             new_op.init(**init_dict)
             # Input name index will start from input1
             input_name = i + 1
-            test_list.append(_create_test(new_op, test_attrs, tags, OperatorTestCase, run_backward, input_name))
-
-    return test_list
+            yield _create_test(new_op, test_attrs, tags, OperatorTestCase, run_backward, input_name)
 
 
 class BenchmarkRunner(object):
@@ -362,10 +359,7 @@ class BenchmarkRunner(object):
         self._print_header()
 
         for test_metainfo in BENCHMARK_TESTER:
-            # If auto_set is used, _build_test will return a list of tests including
-            # forward and backward ones
-            test_list = _build_test(*test_metainfo)
-            for test in test_list:
+            for test in _build_test(*test_metainfo):
                 full_test_id, test_case = test
                 op_test_config = test_case.test_config
 


### PR DESCRIPTION
Summary: Before this diff, all tests of an operator are created at once before testing. Once an operator is benchmark, the same process will move to the next operator and so on. The issue is that the number of tests of a single operator could be > 100 which can cause OOM issues. This diff avoids creating all the tests of an operator at once by using generators which creates/runs test one by one.

Test Plan:
```
buck run //caffe2/benchmarks/operator_benchmark:benchmark_all_quantized_test -- --iterations 1
# ----------------------------------------
# PyTorch/Caffe2 Operator Micro-benchmarks
# ----------------------------------------
# Tag : short

# Benchmarking PyTorch: relu
# Mode: Eager
# Name: relu_dims(3,4,5)_contigFalse_inplaceFalse_dtypetorch.quint8
# Input: dims: (3, 4, 5), contig: False, inplace: False, dtype: torch.quint8
Forward Execution Time (us) : 52.493

# Benchmarking PyTorch: relu
# Mode: Eager
# Name: relu_dims(3,4,5)_contigFalse_inplaceFalse_dtypetorch.qint8
# Input: dims: (3, 4, 5), contig: False, inplace: False, dtype: torch.qint8
Forward Execution Time (us) : 44.945
...

Differential Revision: D18500103

