### PR TITLE
[TESTING] Test split libtorch binary builds on pr/link-torch-cpu

### DIFF
--- a/.circleci/scripts/binary_checkout.sh
+++ b/.circleci/scripts/binary_checkout.sh
@@ -39,7 +39,7 @@ git --no-pager log --max-count 1
 popd
 
 # Clone the Builder master repo
-git clone -q https://github.com/pytorch/builder.git "$BUILDER_ROOT"
+git clone -q https://github.com/pytorch/builder.git "$BUILDER_ROOT" -b pr/link-torch-cpu
 pushd "$BUILDER_ROOT"
 echo "Using builder from "
 git --no-pager log --max-count 1


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#29811 [TESTING] Test split libtorch binary builds on pr/link-torch-cpu**
* #29731 Split libtorch.so back into libtorch_{cpu,cuda,hip}
* #29730 Refactor target_compile_options into torch_compile_options
* #29729 Remove AT_LINK_STYLE entirely.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>