### PR TITLE
Add `torch.version.hip` from cmake

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -325,6 +325,7 @@ def build_deps():
         cmake_cache_vars = defaultdict(lambda: None, cmake.get_cmake_cache_variables())
         f.write("cuda = {}\n".format(repr(cmake_cache_vars['CUDA_VERSION'])))
         f.write("git_version = {}\n".format(repr(sha)))
+        f.write("hip_version = {}\n".format(repr(cmake_cache_vars['HIP_VERSION'])))
 
     if CMAKE_ONLY:
         report('Finished running cmake. Run "ccmake build" or '

--- a/setup.py
+++ b/setup.py
@@ -325,7 +325,7 @@ def build_deps():
         cmake_cache_vars = defaultdict(lambda: None, cmake.get_cmake_cache_variables())
         f.write("cuda = {}\n".format(repr(cmake_cache_vars['CUDA_VERSION'])))
         f.write("git_version = {}\n".format(repr(sha)))
-        f.write("hip_version = {}\n".format(repr(cmake_cache_vars['HIP_VERSION'])))
+        f.write("hip = {}\n".format(repr(cmake_cache_vars['HIP_VERSION'])))
 
     if CMAKE_ONLY:
         report('Finished running cmake. Run "ccmake build" or '


### PR DESCRIPTION
This adds the HIP_VERSION cmake variable as hip_version.
This should help detecting ROCm, e.g. in #22091.

To parallel CUDA, hip_version is a string.
An alternative variant might be to split by '.' and only take the first two parts. 
The method suffers a bit from ROCm not being as monolithic as CUDA.