### PR TITLE
fix benchmark_all_test when running on gpu

### DIFF
--- a/benchmarks/operator_benchmark/pt/conv_test.py
+++ b/benchmarks/operator_benchmark/pt/conv_test.py
@@ -45,6 +45,8 @@ class Conv1dBenchmark(op_bench.TorchBenchmarkBase):
     def init(self, in_c, out_c, kernel, stride, N, L, device):
         self.input = torch.rand(N, in_c, L, device=device)
         self.conv1d = nn.Conv1d(in_c, out_c, kernel, stride=stride)
+        if device == 'cuda': 
+            self.conv1d = self.conv1d.cuda() 
         self.set_module_name('Conv1d')
 
     def forward(self):
@@ -55,6 +57,8 @@ class ConvTranspose1dBenchmark(op_bench.TorchBenchmarkBase):
     def init(self, in_c, out_c, kernel, stride, N, L, device):
         self.input = torch.rand(N, in_c, L, device=device)
         self.convtranspose1d = nn.ConvTranspose1d(in_c, out_c, kernel, stride=stride)
+        if device == 'cuda':
+            self.convtranspose1d = self.convtranspose1d.cuda() 
         self.set_module_name('ConvTranspose1d')
 
     def forward(self):
@@ -103,6 +107,8 @@ class Conv2dBenchmark(op_bench.TorchBenchmarkBase):
     def init(self, in_c, out_c, kernel, stride, N, H, W, device):
         self.input = torch.rand(N, in_c, H, W, device=device)
         self.conv2d = nn.Conv2d(in_c, out_c, kernel, stride=stride)
+        if device == 'cuda':
+            self.conv2d = self.conv2d.cuda() 
         self.set_module_name('Conv2d')
 
     def forward(self):
@@ -113,6 +119,8 @@ class ConvTranspose2dBenchmark(op_bench.TorchBenchmarkBase):
     def init(self, in_c, out_c, kernel, stride, N, H, W, device):
         self.input = torch.rand(N, in_c, H, W, device=device)
         self.convtranspose2d = nn.ConvTranspose2d(in_c, out_c, kernel, stride=stride)
+        if device == 'cuda': 
+            self.convtranspose2d = self.convtranspose2d.cuda() 
         self.set_module_name('ConvTranspose2d')
 
     def forward(self):
@@ -148,6 +156,8 @@ class Conv3dBenchmark(op_bench.TorchBenchmarkBase):
     def init(self, in_c, out_c, kernel, stride, N, D, H, W, device):
         self.input = torch.rand(N, in_c, D, H, W, device=device)
         self.conv3d = nn.Conv3d(in_c, out_c, kernel, stride=stride)
+        if device == 'cuda': 
+            self.conv3d = self.conv3d.cuda() 
         self.set_module_name('Conv3d')
 
     def forward(self):
@@ -158,6 +168,8 @@ class ConvTranspose3dBenchmark(op_bench.TorchBenchmarkBase):
     def init(self, in_c, out_c, kernel, stride, N, D, H, W, device):
         self.input = torch.rand(N, in_c, D, H, W, device=device)
         self.convtranspose3d = nn.ConvTranspose3d(in_c, out_c, kernel, stride=stride)
+        if device == 'cuda': 
+            self.convtranspose3d = self.convtranspose3d.cuda() 
         self.set_module_name('ConvTranspose3d')
 
     def forward(self):

--- a/benchmarks/operator_benchmark/pt/linear_test.py
+++ b/benchmarks/operator_benchmark/pt/linear_test.py
@@ -37,6 +37,8 @@ class LinearBenchmark(op_bench.TorchBenchmarkBase):
     def init(self, N, IN, OUT, device):
         self.input_one = torch.rand(N, IN, device=device)
         self.linear = nn.Linear(IN, OUT)
+        if device == 'cuda': 
+            self.linear = self.linear.cuda()
         self.set_module_name("linear")
 
     def forward(self):


### PR DESCRIPTION
Summary: When some of the test running on cuda, there is a runtime error because of missing data transfer from cpu to cuda. This diff fixes that issue.

Test Plan:
```
buck run mode/opt //caffe2/benchmarks/operator_benchmark:benchmark_all_test -- --iterations 1
# ----------------------------------------
# PyTorch/Caffe2 Operator Micro-benchmarks
# ----------------------------------------
# Tag : short

# Benchmarking PyTorch: add
# Mode: Eager
# Name: add_M64_N64_K64_cpu
# Input: M: 64, N: 64, K: 64, device: cpu
Forward Execution Time (us) : 165.241

# Benchmarking PyTorch: add
# Mode: Eager
# Name: add_M64_N64_K64_cuda
# Input: M: 64, N: 64, K: 64, device: cuda
Forward Execution Time (us) : 56.546
...

Differential Revision: D18506269

