### PR TITLE
minir edit to fix benchmark_all_test cuda error

### DIFF
--- a/benchmarks/operator_benchmark/pt/conv_test.py
+++ b/benchmarks/operator_benchmark/pt/conv_test.py
@@ -44,9 +44,7 @@ conv_1d_configs_long = op_bench.cross_product_configs(
 class Conv1dBenchmark(op_bench.TorchBenchmarkBase):
     def init(self, in_c, out_c, kernel, stride, N, L, device):
         self.input = torch.rand(N, in_c, L, device=device)
-        self.conv1d = nn.Conv1d(in_c, out_c, kernel, stride=stride)
-        if device == 'cuda': 
-            self.conv1d = self.conv1d.cuda() 
+        self.conv1d = nn.Conv1d(in_c, out_c, kernel, stride=stride).to(device=device)
         self.set_module_name('Conv1d')
 
     def forward(self):
@@ -56,9 +54,7 @@ class Conv1dBenchmark(op_bench.TorchBenchmarkBase):
 class ConvTranspose1dBenchmark(op_bench.TorchBenchmarkBase):
     def init(self, in_c, out_c, kernel, stride, N, L, device):
         self.input = torch.rand(N, in_c, L, device=device)
-        self.convtranspose1d = nn.ConvTranspose1d(in_c, out_c, kernel, stride=stride)
-        if device == 'cuda':
-            self.convtranspose1d = self.convtranspose1d.cuda() 
+        self.convtranspose1d = nn.ConvTranspose1d(in_c, out_c, kernel, stride=stride).to(device=device)
         self.set_module_name('ConvTranspose1d')
 
     def forward(self):
@@ -106,9 +102,7 @@ conv_2d_configs_long = op_bench.cross_product_configs(
 class Conv2dBenchmark(op_bench.TorchBenchmarkBase):
     def init(self, in_c, out_c, kernel, stride, N, H, W, device):
         self.input = torch.rand(N, in_c, H, W, device=device)
-        self.conv2d = nn.Conv2d(in_c, out_c, kernel, stride=stride)
-        if device == 'cuda':
-            self.conv2d = self.conv2d.cuda() 
+        self.conv2d = nn.Conv2d(in_c, out_c, kernel, stride=stride).to(device=device)
         self.set_module_name('Conv2d')
 
     def forward(self):
@@ -118,9 +112,7 @@ class Conv2dBenchmark(op_bench.TorchBenchmarkBase):
 class ConvTranspose2dBenchmark(op_bench.TorchBenchmarkBase):
     def init(self, in_c, out_c, kernel, stride, N, H, W, device):
         self.input = torch.rand(N, in_c, H, W, device=device)
-        self.convtranspose2d = nn.ConvTranspose2d(in_c, out_c, kernel, stride=stride)
-        if device == 'cuda': 
-            self.convtranspose2d = self.convtranspose2d.cuda() 
+        self.convtranspose2d = nn.ConvTranspose2d(in_c, out_c, kernel, stride=stride).to(device=device)
         self.set_module_name('ConvTranspose2d')
 
     def forward(self):
@@ -155,9 +147,7 @@ conv_3d_configs_short = op_bench.config_list(
 class Conv3dBenchmark(op_bench.TorchBenchmarkBase):
     def init(self, in_c, out_c, kernel, stride, N, D, H, W, device):
         self.input = torch.rand(N, in_c, D, H, W, device=device)
-        self.conv3d = nn.Conv3d(in_c, out_c, kernel, stride=stride)
-        if device == 'cuda': 
-            self.conv3d = self.conv3d.cuda() 
+        self.conv3d = nn.Conv3d(in_c, out_c, kernel, stride=stride).to(device=device)
         self.set_module_name('Conv3d')
 
     def forward(self):
@@ -167,9 +157,7 @@ class Conv3dBenchmark(op_bench.TorchBenchmarkBase):
 class ConvTranspose3dBenchmark(op_bench.TorchBenchmarkBase):
     def init(self, in_c, out_c, kernel, stride, N, D, H, W, device):
         self.input = torch.rand(N, in_c, D, H, W, device=device)
-        self.convtranspose3d = nn.ConvTranspose3d(in_c, out_c, kernel, stride=stride)
-        if device == 'cuda': 
-            self.convtranspose3d = self.convtranspose3d.cuda() 
+        self.convtranspose3d = nn.ConvTranspose3d(in_c, out_c, kernel, stride=stride).to(device=device)
         self.set_module_name('ConvTranspose3d')
 
     def forward(self):

--- a/benchmarks/operator_benchmark/pt/linear_test.py
+++ b/benchmarks/operator_benchmark/pt/linear_test.py
@@ -36,9 +36,7 @@ linear_configs_long = op_bench.cross_product_configs(
 class LinearBenchmark(op_bench.TorchBenchmarkBase):
     def init(self, N, IN, OUT, device):
         self.input_one = torch.rand(N, IN, device=device)
-        self.linear = nn.Linear(IN, OUT)
-        if device == 'cuda': 
-            self.linear = self.linear.cuda()
+        self.linear = nn.Linear(IN, OUT).to(device=device)
         self.set_module_name("linear")
 
     def forward(self):


### PR DESCRIPTION
Summary: This diff replaces the if check cuda with to(device...) which is a much cleaner interface.

Test Plan:
```
buck run mode/opt //caffe2/benchmarks/operator_benchmark:benchmark_all_test -- --iterations 1
# ----------------------------------------
# PyTorch/Caffe2 Operator Micro-benchmarks
# ----------------------------------------
# Tag : short

# Benchmarking PyTorch: add
# Mode: Eager
# Name: add_M64_N64_K64_cpu
# Input: M: 64, N: 64, K: 64, device: cpu
Forward Execution Time (us) : 129.548

# Benchmarking PyTorch: add
# Mode: Eager
# Name: add_M64_N64_K64_cuda
# Input: M: 64, N: 64, K: 64, device: cuda
Forward Execution Time (us) : 48.313
...

Reviewed By: bddppq

Differential Revision: D18507568

