### PR TITLE
Add reset_parameters to torch::nn modules

### DIFF
--- a/torch/csrc/api/include/torch/nn/modules/batchnorm.h
+++ b/torch/csrc/api/include/torch/nn/modules/batchnorm.h
@@ -88,9 +88,11 @@ class TORCH_API BatchNormImplBase : public torch::nn::Cloneable<Derived> {
 
   Tensor forward(const Tensor& input);
 
+  void reset() override;
+
   void reset_running_stats();
 
-  void reset() override;
+  void reset_parameters();
 
   /// Pretty prints the `BatchNorm{1,2,3}d` module into the given `stream`.
   void pretty_print(std::ostream& stream) const override;

--- a/torch/csrc/api/include/torch/nn/modules/conv.h
+++ b/torch/csrc/api/include/torch/nn/modules/conv.h
@@ -22,6 +22,8 @@ class TORCH_API ConvImpl : public torch::nn::Cloneable<Derived> {
 
   void reset() override;
 
+  void reset_parameters();
+
   /// Pretty prints the `Conv{1,2,3}d` module into the given `stream`.
   void pretty_print(std::ostream& stream) const override;
 

--- a/torch/csrc/api/include/torch/nn/modules/embedding.h
+++ b/torch/csrc/api/include/torch/nn/modules/embedding.h
@@ -20,6 +20,8 @@ class TORCH_API EmbeddingImpl : public torch::nn::Cloneable<EmbeddingImpl> {
 
   void reset() override;
 
+  void reset_parameters();
+
   /// Pretty prints the `Embedding` module into the given `stream`.
   void pretty_print(std::ostream& stream) const override;
 
@@ -70,6 +72,8 @@ class TORCH_API EmbeddingBagImpl : public torch::nn::Cloneable<EmbeddingBagImpl>
   explicit EmbeddingBagImpl(const EmbeddingBagOptions& options_);
 
   void reset() override;
+
+  void reset_parameters();
 
   /// Pretty prints the `EmbeddingBag` module into the given `stream`.
   void pretty_print(std::ostream& stream) const override;

--- a/torch/csrc/api/include/torch/nn/modules/linear.h
+++ b/torch/csrc/api/include/torch/nn/modules/linear.h
@@ -41,6 +41,8 @@ class TORCH_API LinearImpl : public Cloneable<LinearImpl> {
 
   void reset() override;
 
+  void reset_parameters();
+
   /// Pretty prints the `Linear` module into the given `stream`.
   void pretty_print(std::ostream& stream) const override;
 
@@ -99,6 +101,8 @@ class TORCH_API BilinearImpl : public Cloneable<BilinearImpl> {
   explicit BilinearImpl(const BilinearOptions& options_);
 
   void reset() override;
+
+  void reset_parameters();
 
   /// Pretty prints the `Bilinear` module into the given `stream`.
   void pretty_print(std::ostream& stream) const override;

--- a/torch/csrc/api/include/torch/nn/modules/normalization.h
+++ b/torch/csrc/api/include/torch/nn/modules/normalization.h
@@ -21,6 +21,8 @@ class TORCH_API LayerNormImpl : public torch::nn::Cloneable<LayerNormImpl> {
 
   void reset() override;
 
+  void reset_parameters();
+
   /// Pretty prints the `LayerNorm` module into the given `stream`.
   void pretty_print(std::ostream& stream) const override;
 

--- a/torch/csrc/api/src/nn/modules/batchnorm.cpp
+++ b/torch/csrc/api/src/nn/modules/batchnorm.cpp
@@ -18,7 +18,7 @@ namespace torch {
 namespace nn {
 
 BatchNormImpl::BatchNormImpl(const BatchNormOptions& options_) : options(options_) {
-  TORCH_WARN("torch::nn::BatchNorm module is deprecated."
+  TORCH_WARN("torch::nn::BatchNorm module is deprecated and will be removed in 1.5. "
              "Use BatchNorm{1,2,3}d instead.");
   reset();
 }
@@ -85,15 +85,6 @@ BatchNormImplBase<D, Derived>::BatchNormImplBase(const BatchNormOptions& options
 }
 
 template <size_t D, typename Derived>
-void BatchNormImplBase<D, Derived>::reset_running_stats() {
-  if (options.track_running_stats()) {
-    running_mean.zero_();
-    running_var.fill_(1);
-    num_batches_tracked.zero_();
-  }
-}
-
-template <size_t D, typename Derived>
 void BatchNormImplBase<D, Derived>::reset() {
   if (options.affine()) {
     weight = this->register_parameter("weight", torch::empty({options.num_features()}));
@@ -111,7 +102,20 @@ void BatchNormImplBase<D, Derived>::reset() {
     running_var = this->register_buffer("running_var", Tensor());
     num_batches_tracked = this->register_buffer("num_batches_tracked", Tensor());
   }
+  reset_parameters();
+}
 
+template <size_t D, typename Derived>
+void BatchNormImplBase<D, Derived>::reset_running_stats() {
+  if (options.track_running_stats()) {
+    running_mean.zero_();
+    running_var.fill_(1);
+    num_batches_tracked.zero_();
+  }
+}
+
+template <size_t D, typename Derived>
+void BatchNormImplBase<D, Derived>::reset_parameters() {
   reset_running_stats();
   if (options.affine()) {
     torch::nn::init::ones_(weight);

--- a/torch/csrc/api/src/nn/modules/conv.cpp
+++ b/torch/csrc/api/src/nn/modules/conv.cpp
@@ -56,6 +56,11 @@ void ConvImpl<D, Derived>::reset() {
     this->register_parameter("bias", Tensor(), /*requires_grad=*/false);
   }
 
+  reset_parameters();
+}
+
+template <size_t D, typename Derived>
+void ConvImpl<D, Derived>::reset_parameters() {
   init::kaiming_uniform_(weight, /*a=*/std::sqrt(5));  // NOLINT(cppcoreguidelines-avoid-magic-numbers)
 
   if (bias.defined()) {

--- a/torch/csrc/api/src/nn/modules/embedding.cpp
+++ b/torch/csrc/api/src/nn/modules/embedding.cpp
@@ -31,14 +31,18 @@ void EmbeddingImpl::reset() {
   if (!options._weight().defined()) {
     weight = register_parameter(
         "weight", torch::empty({options.num_embeddings(), options.embedding_dim()}));
-    torch::nn::init::normal_(weight);
-    if (options.padding_idx() != c10::nullopt) {
-      torch::NoGradGuard no_grad;
-      weight[*options.padding_idx()].fill_(0);
-    }
+    reset_parameters();
   } else {
     TORCH_CHECK(options._weight().sizes() == torch::IntArrayRef({options.num_embeddings(), options.embedding_dim()}), "Shape of _weight does not match num_embeddings and embedding_dim");
     weight = register_parameter("weight", options._weight());
+  }
+}
+
+void EmbeddingImpl::reset_parameters() {
+  torch::nn::init::normal_(weight);
+  if (options.padding_idx() != c10::nullopt) {
+    torch::NoGradGuard no_grad;
+    weight[*options.padding_idx()].fill_(0);
   }
 }
 
@@ -82,13 +86,17 @@ void EmbeddingBagImpl::reset() {
   if (!options._weight().defined()) {
     weight = register_parameter(
         "weight", torch::empty({options.num_embeddings(), options.embedding_dim()}));
-    torch::nn::init::normal_(weight);
+    reset_parameters();
   } else {
     TORCH_CHECK(
       options._weight().sizes() == torch::IntArrayRef({options.num_embeddings(), options.embedding_dim()}),
       "Shape of weight does not match num_embeddings and embedding_dim");
     weight = register_parameter("weight", options._weight());
   }
+}
+
+void EmbeddingBagImpl::reset_parameters() {
+  torch::nn::init::normal_(weight);
 }
 
 torch::Tensor EmbeddingBagImpl::forward(const Tensor& input, const Tensor& offsets, const Tensor& per_sample_weights) {

--- a/torch/csrc/api/src/nn/modules/linear.cpp
+++ b/torch/csrc/api/src/nn/modules/linear.cpp
@@ -38,6 +38,10 @@ void LinearImpl::reset() {
     bias = register_parameter("bias", {}, /*requires_grad=*/false);
   }
 
+  reset_parameters();
+}
+
+void LinearImpl::reset_parameters() {
   torch::nn::init::kaiming_uniform_(weight, std::sqrt(5)); // NOLINT(cppcoreguidelines-avoid-magic-numbers)
   if (bias.defined()) {
     int64_t fan_in, fan_out;
@@ -88,6 +92,10 @@ void BilinearImpl::reset() {
     bias = register_parameter("bias", torch::Tensor(), /*requires_grad=*/false);
   }
 
+  reset_parameters();
+}
+
+void BilinearImpl::reset_parameters() {
   const auto bound = 1.0 / std::sqrt(weight.size(1));
   init::uniform_(weight, -bound, bound);
   if (bias.defined()) {

--- a/torch/csrc/api/src/nn/modules/normalization.cpp
+++ b/torch/csrc/api/src/nn/modules/normalization.cpp
@@ -24,6 +24,10 @@ void LayerNormImpl::reset() {
     weight = register_parameter("weight", torch::Tensor(), /*requires_grad=*/false);
     bias = register_parameter("bias", torch::Tensor(), /*requires_grad=*/false);
   }
+  reset_parameters();
+}
+
+void LayerNormImpl::reset_parameters() {
   if (options.elementwise_affine()) {
     torch::nn::init::ones_(weight);
     torch::nn::init::zeros_(bias);


### PR DESCRIPTION
This PR adds `reset_parameters` to the torch::nn modules whose Python version also has `reset_parameters` defined, so that there is better parity between Python and C++ version.