### PR TITLE
Check for mutable default parameters 

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -3364,6 +3364,20 @@ graph(%Ra, %Rb):
         t = Test()
         self.assertEqual(t(torch.ones(1)), torch.ones(1) + 4)
 
+    def test_mutable_default_values(self):
+        with self.assertRaisesRegex(Exception, "Mutable default parameters"):
+            @torch.jit.script
+            def foo(x=(1, [])):
+                # type: (Tuple[int, List[Tensor]])
+                return x
+
+        class Test(torch.nn.Module):
+            def forward(self, input=[]):
+                return input
+
+        with self.assertRaisesRegex(Exception, "Mutable default parameters"):
+            torch.jit.script(Test())
+
     def test_warnings(self):
         import warnings
 

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -216,9 +216,9 @@ void checkMutableFunctionDefault(
     const SourceRange& range,
     const Argument& arg,
     const py::object& def_arg) {
-  if (checkMutableFunctionDefault(def_arg)) {
+  if (checkMutableFunctionDefault(def_arg) || arg.type()->cast<ClassType>()) {
     throw ErrorReport(range)
-        << "Mutable default parameters are not supported because python bounds them to the function"
+        << "Mutable default parameters are not supported because Python binds them to the function"
         << " and they persist across function calls.\n As a workaround, make the default None and instantiate"
         << " the default parameter within the body of the function. Found "
         << def_arg.get_type() << " on parameter " << arg.name();

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -196,6 +196,35 @@ void checkOverloadDecl(const Decl& new_decl, const Decl& old_decl) {
 }
 } // namespace
 
+bool checkMutableFunctionDefault(const py::object& def_arg) {
+  if (py::isinstance<py::list>(def_arg) || py::isinstance<py::dict>(def_arg)) {
+    return true;
+  }
+  if (py::isinstance<py::tuple>(def_arg)) {
+    auto pytuple = def_arg.cast<py::tuple>();
+    for (py::handle t : pytuple) {
+      py::object obj = py::reinterpret_borrow<py::object>(t);
+      if (checkMutableFunctionDefault(obj)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+void checkMutableFunctionDefault(
+    const SourceRange& range,
+    const Argument& arg,
+    const py::object& def_arg) {
+  if (checkMutableFunctionDefault(def_arg)) {
+    throw ErrorReport(range)
+        << "Mutable default parameters are not supported because python bounds them to the function"
+        << " and they persist across function calls.\n As a workaround, make the default None and instantiate"
+        << " the default parameter within the body of the function. Found "
+        << def_arg.get_type() << " on parameter " << arg.name();
+  }
+}
+
 FunctionSchema getSchemaWithNameAndDefaults(
     const SourceRange& range,
     const FunctionSchema& schema,
@@ -205,6 +234,7 @@ FunctionSchema getSchemaWithNameAndDefaults(
   for (auto& arg : schema.arguments()) {
     auto it = default_args.find(arg.name());
     if (it != default_args.end()) {
+      checkMutableFunctionDefault(range, arg, it->second);
       try {
         IValue value;
         auto n = arg.N();


### PR DESCRIPTION
Fix for https://github.com/pytorch/pytorch/issues/21545

We we were silently giving wrong semantics previously:

Python behavior:
```
def test(x=[]):
   x.append(1)
   return len(x)

print(test()) # 1
print(test()) # 2
```

By checking at the python layer, we prevent any new models from serializing this behavior but do not break existing serialized models.