### PR TITLE
[pytorch][cmake] add static libraries to TorchConfig.cmake.in

### DIFF
--- a/cmake/TorchConfig.cmake.in
+++ b/cmake/TorchConfig.cmake.in
@@ -38,22 +38,40 @@ endif()
 # Library dependencies.
 if (@BUILD_SHARED_LIBS@)
   find_package(Caffe2 REQUIRED PATHS ${CMAKE_CURRENT_LIST_DIR}/../Caffe2)
-endif()
-
-if (NOT ANDROID)
-  find_library(TORCH_LIBRARY torch PATHS "${TORCH_INSTALL_PREFIX}/lib")
+  set(TORCH_LIBRARIES torch ${Caffe2_MAIN_LIBS})
 else()
-  find_library(TORCH_LIBRARY NO_CMAKE_FIND_ROOT_PATH torch PATHS "${TORCH_INSTALL_PREFIX}/lib")
+  add_library(torch STATIC IMPORTED) # set imported_location at the bottom
+  set(TORCH_LIBRARIES torch)
 endif()
 
-set(TORCH_LIBRARIES torch ${Caffe2_MAIN_LIBS})
-
-if (NOT ANDROID)
-  find_library(C10_LIBRARY c10 PATHS "${TORCH_INSTALL_PREFIX}/lib")
-else()
-  find_library(C10_LIBRARY c10 NO_CMAKE_FIND_ROOT_PATH PATHS "${TORCH_INSTALL_PREFIX}/lib")
-endif()
+find_library(C10_LIBRARY c10 PATHS "${TORCH_INSTALL_PREFIX}/lib")
 list(APPEND TORCH_LIBRARIES ${C10_LIBRARY})
+
+# We need manually add dependent libraries when they are not linked into the
+# shared library.
+# TODO: this list might be incomplete.
+if (NOT @BUILD_SHARED_LIBS@)
+  if (@USE_NNPACK@)
+    find_library(NNPACK_LIBRARY nnpack PATHS "${TORCH_INSTALL_PREFIX}/lib")
+    list(APPEND TORCH_LIBRARIES ${NNPACK_LIBRARY})
+  endif()
+
+  if (@USE_PYTORCH_QNNPACK@)
+    find_library(PYTORCH_QNNPACK_LIBRARY pytorch_qnnpack PATHS "${TORCH_INSTALL_PREFIX}/lib")
+    list(APPEND TORCH_LIBRARIES ${PYTORCH_QNNPACK_LIBRARY})
+  endif()
+
+  if (@INTERN_USE_EIGEN_BLAS@)
+    find_library(EIGEN_BLAS_LIBRARY eigen_blas PATHS "${TORCH_INSTALL_PREFIX}/lib")
+    list(APPEND TORCH_LIBRARIES ${EIGEN_BLAS_LIBRARY})
+  endif()
+
+  find_library(CPUINFO_LIBRARY cpuinfo PATHS "${TORCH_INSTALL_PREFIX}/lib")
+  list(APPEND TORCH_LIBRARIES ${CPUINFO_LIBRARY})
+
+  find_library(CLOG_LIBRARY clog PATHS "${TORCH_INSTALL_PREFIX}/lib")
+  list(APPEND TORCH_LIBRARIES ${CLOG_LIBRARY})
+endif()
 
 if (@USE_CUDA@)
   if(MSVC)
@@ -91,6 +109,7 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
   set(TORCH_CXX_FLAGS "-D_GLIBCXX_USE_CXX11_ABI=@GLIBCXX_USE_CXX11_ABI@")
 endif()
 
+find_library(TORCH_LIBRARY torch PATHS "${TORCH_INSTALL_PREFIX}/lib")
 set_target_properties(torch PROPERTIES
     IMPORTED_LOCATION "${TORCH_LIBRARY}"
     INTERFACE_INCLUDE_DIRECTORIES "${TORCH_INCLUDE_DIRS}"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #29718 [pytorch][script] op dependency analysis bash driver
* #29550 [pytorch] add LLVM code analyzer in order to replace static dispatch
* #29716 [pytorch] add test/mobile/op_deps project for dependency analysis test
* **#29837 [pytorch][cmake] add static libraries to TorchConfig.cmake.in**
* #29715 [pytorch] set USE_STATIC_DISPATCH outside cmake

Summary:
The current TorchConfig seems only handles shared libraries. When
building static libraries it doesn't provide the list of all needed
static libraries. This is especially a problem for mobile build as we
build static libraries first then link into shared library / binary to
do "gc-sections". Today we have to manually import these dependent
libraries on each callsite.

Test Plan:
- build_mobile.sh builds and runs;
- The baby test project in #29716 builds and runs;
- Will check CI for other platforms;

Differential Revision: [D18513404](https://our.internmc.facebook.com/intern/diff/D18513404)