### PR TITLE
Use c10::to_string in more places

### DIFF
--- a/torch/csrc/api/include/torch/nn/modules/container/modulelist.h
+++ b/torch/csrc/api/include/torch/nn/modules/container/modulelist.h
@@ -89,7 +89,7 @@ class ModuleListImpl : public Cloneable<ModuleListImpl> {
   void push_back(std::shared_ptr<Module> module) {
     modules_.push_back(std::move(module));
     const auto index = modules_.size() - 1;
-    register_module(std::to_string(index), modules_[index]);
+    register_module(c10::to_string(index), modules_[index]);
   }
 
   /// Adds a new `Module` to the `ModuleList` container, moving or copying
@@ -207,8 +207,8 @@ class ModuleListImpl : public Cloneable<ModuleListImpl> {
           std::move(module));
 
       for (size_t i = index; i < size() - 1; ++i)
-        replace_module(std::to_string(index), modules_[index]);
-      register_module(std::to_string(size() - 1), modules_.back());
+        replace_module(c10::to_string(index), modules_[index]);
+      register_module(c10::to_string(size() - 1), modules_.back());
     }
   }
 

--- a/torch/csrc/api/include/torch/nn/modules/container/sequential.h
+++ b/torch/csrc/api/include/torch/nn/modules/container/sequential.h
@@ -193,7 +193,7 @@ class SequentialImpl : public Cloneable<SequentialImpl> {
   /// Adds a new (boxed) `Module` to the `Sequential` container.
   template <typename ModuleType>
   void push_back(std::shared_ptr<ModuleType> module_ptr) {
-    push_back(std::to_string(modules_.size()), std::move(module_ptr));
+    push_back(c10::to_string(modules_.size()), std::move(module_ptr));
   }
 
   /// Adds a new named (boxed) `Module` to the `Sequential` container.
@@ -209,7 +209,7 @@ class SequentialImpl : public Cloneable<SequentialImpl> {
   /// `Sequential(std::make_shared<Module>(3, 4))`.
   template <typename M, typename = torch::detail::enable_if_module_t<M>>
   void push_back(M&& module) {
-    push_back(std::to_string(modules_.size()), std::forward<M>(module));
+    push_back(c10::to_string(modules_.size()), std::forward<M>(module));
   }
 
   /// Adds a new named `Module` to the `Sequential` container, moving or copying it
@@ -225,7 +225,7 @@ class SequentialImpl : public Cloneable<SequentialImpl> {
   /// `Sequential`.
   template <typename M>
   void push_back(const ModuleHolder<M>& module_holder) {
-    push_back(std::to_string(modules_.size()), module_holder);
+    push_back(c10::to_string(modules_.size()), module_holder);
   }
 
   /// Unwraps the contained named module of a `ModuleHolder` and adds it to the
@@ -343,7 +343,7 @@ class SequentialImpl : public Cloneable<SequentialImpl> {
 
   /// Adds a type-erased `AnyModule` to the `Sequential`.
   void push_back(AnyModule any_module) {
-    push_back(std::to_string(modules_.size()), std::move(any_module));
+    push_back(c10::to_string(modules_.size()), std::move(any_module));
   }
 
   void push_back(std::string name, AnyModule any_module) {

--- a/torch/csrc/api/include/torch/optim/serialize.h
+++ b/torch/csrc/api/include/torch/optim/serialize.h
@@ -50,7 +50,7 @@ void serialize(
       key + "/size", torch::tensor(static_cast<int64_t>(buffers.size())));
   for (size_t index = 0; index < buffers.size(); ++index) {
     archive.write(
-        key + "/" + std::to_string(index), buffers[index], /*is_buffer=*/true);
+        key + "/" + c10::to_string(index), buffers[index], /*is_buffer=*/true);
   }
 }
 
@@ -67,7 +67,7 @@ void serialize(
   for (size_t index = 0; index < size; ++index) {
     buffers.emplace_back();
     archive.read(
-        key + "/" + std::to_string(index), buffers.back(), /*is_buffer=*/true);
+        key + "/" + c10::to_string(index), buffers.back(), /*is_buffer=*/true);
   }
 }
 

--- a/torch/csrc/api/include/torch/serialize.h
+++ b/torch/csrc/api/include/torch/serialize.h
@@ -68,7 +68,7 @@ void save(const std::vector<torch::Tensor>& tensor_vec, SaveToArgs&&... args) {
       std::make_shared<jit::script::CompilationUnit>());
   for (size_t i = 0; i < tensor_vec.size(); i++) {
     auto& value = tensor_vec[i];
-    archive.write(std::to_string(i), value);
+    archive.write(c10::to_string(i), value);
   }
   archive.save_to(std::forward<SaveToArgs>(args)...);
 }
@@ -135,7 +135,7 @@ void load(std::vector<torch::Tensor>& tensor_vec, LoadFromArgs&&... args) {
   // the serialized `std::vector<torch::Tensor>`.
   size_t index = 0;
   torch::Tensor value;
-  while (archive.try_read(std::to_string(index), value)) {
+  while (archive.try_read(c10::to_string(index), value)) {
     tensor_vec.push_back(std::move(value));
     value = torch::Tensor();
     index++;


### PR DESCRIPTION
Summary:
std::to_string isn't reliably available on Android.  Use c10::to_string
instead in some more files that we want to add to some Android builds.

Test Plan: CI

Reviewed By: linbinyu

Differential Revision: D18509295

