### PR TITLE
CPU-Strided-Complex Fixes for real and imag ops

### DIFF
--- a/aten/src/ATen/NumericUtils.h
+++ b/aten/src/ATen/NumericUtils.h
@@ -34,9 +34,9 @@ inline C10_HOST_DEVICE bool _isnan(T val) {
 }
 
 template <typename T,
-          typename std::enable_if<std::is_complex_t<T>::value, int>::type = 0>
+          typename std::enable_if<c10::is_complex_t<T>::value, int>::type = 0>
 inline bool _isnan(T val) {
-  return std::isnan(std::real(val)) || std::isnan(std::imag(val));
+  return std::isnan(val.real()) || std::isnan(val.imag());
 }
 
 inline C10_HOST_DEVICE bool _isnan(at::BFloat16 val) {

--- a/aten/src/ATen/cpu/vec256/vec256_base.h
+++ b/aten/src/ATen/cpu/vec256/vec256_base.h
@@ -208,14 +208,13 @@ public:
   Vec256<T> angle() const {
     // other_t_angle is for SFINAE and clarity. Make sure it is not changed.
     static_assert(std::is_same<other_t_angle, T>::value, "other_t_angle must be T");
-    return *this;
+    return Vec256(0);
   }
   template <typename complex_t_angle = T,
             typename std::enable_if<c10::is_complex_t<complex_t_angle>::value, int>::type = 0>
   Vec256<T> angle() const {
     // complex_t_angle is for SFINAE and clarity. Make sure it is not changed.
     static_assert(std::is_same<complex_t_angle, T>::value, "complex_t_angle must be T");
-    // Specifically map() does not perform the type conversion needed by abs.
     return map([](T x) { return static_cast<T>(std::arg(x)); });
   }
   template <typename other_t_real = T,
@@ -230,7 +229,6 @@ public:
   Vec256<T> real() const {
     // complex_t_real is for SFINAE and clarity. Make sure it is not changed.
     static_assert(std::is_same<complex_t_real, T>::value, "complex_t_real must be T");
-    // Specifically map() does not perform the type conversion needed by abs.
     return map([](T x) { return static_cast<T>(x.real()); });
   }
   template <typename other_t_imag = T,
@@ -238,18 +236,28 @@ public:
   Vec256<T> imag() const {
     // other_t_imag is for SFINAE and clarity. Make sure it is not changed.
     static_assert(std::is_same<other_t_imag, T>::value, "other_t_imag must be T");
-    return *this;
+    return Vec256(0);
   }
   template <typename complex_t_imag = T,
             typename std::enable_if<c10::is_complex_t<complex_t_imag>::value, int>::type = 0>
   Vec256<T> imag() const {
     // complex_t_imag is for SFINAE and clarity. Make sure it is not changed.
     static_assert(std::is_same<complex_t_imag, T>::value, "complex_t_imag must be T");
-    // Specifically map() does not perform the type conversion needed by abs.
     return map([](T x) { return static_cast<T>(x.imag()); });
   }
+  template <typename other_t_conj = T,
+            typename std::enable_if<!c10::is_complex_t<other_t_conj>::value, int>::type = 0>
   Vec256<T> conj() const {
+    // other_t_conj is for SFINAE and clarity. Make sure it is not changed.
+    static_assert(std::is_same<other_t_conj, T>::value, "other_t_conj must be T");
     return *this;
+  }
+  template <typename complex_t_conj = T,
+            typename std::enable_if<c10::is_complex_t<complex_t_conj>::value, int>::type = 0>
+  Vec256<T> conj() const {
+    // complex_t_conj is for SFINAE and clarity. Make sure it is not changed.
+    static_assert(std::is_same<complex_t_conj, T>::value, "complex_t_conj must be T");
+    return map([](T x) { return static_cast<T>(std::conj(x)); });
   }
   Vec256<T> acos() const {
     return map(std::acos);

--- a/aten/src/ATen/cpu/vec256/vec256_base.h
+++ b/aten/src/ATen/cpu/vec256/vec256_base.h
@@ -179,38 +179,74 @@ public:
     }
     return ret;
   }
-  template <typename other_t = T,
-            typename std::enable_if<!std::is_floating_point<other_t>::value && !std::is_complex_t<other_t>::value, int>::type = 0>
+  template <typename other_t_abs = T,
+            typename std::enable_if<!std::is_floating_point<other_t_abs>::value && !c10::is_complex_t<other_t_abs>::value, int>::type = 0>
   Vec256<T> abs() const {
-    // other_t is for SFINAE and clarity. Make sure it is not changed.
-    static_assert(std::is_same<other_t, T>::value, "other_t must be T");
-    return map([](T x) -> T { return x < static_cast<other_t>(0) ? -x : x; });
+    // other_t_abs is for SFINAE and clarity. Make sure it is not changed.
+    static_assert(std::is_same<other_t_abs, T>::value, "other_t_abs must be T");
+    return map([](T x) -> T { return x < static_cast<T>(0) ? -x : x; });
   }
-  template <typename float_t = T,
-            typename std::enable_if<std::is_floating_point<float_t>::value, int>::type = 0>
+  template <typename float_t_abs = T,
+            typename std::enable_if<std::is_floating_point<float_t_abs>::value, int>::type = 0>
   Vec256<T> abs() const {
-    // float_t is for SFINAE and clarity. Make sure it is not changed.
-    static_assert(std::is_same<float_t, T>::value, "float_t must be T");
+    // float_t_abs is for SFINAE and clarity. Make sure it is not changed.
+    static_assert(std::is_same<float_t_abs, T>::value, "float_t_abs must be T");
     // Specifically deal with floating-point because the generic code above won't handle -0.0 (which should result in
     // 0.0) properly.
     return map(std::abs);
   }
-  template <typename complex_t = T,
-            typename std::enable_if<std::is_complex_t<complex_t>::value, int>::type = 0>
+  template <typename complex_t_abs = T,
+            typename std::enable_if<c10::is_complex_t<complex_t_abs>::value, int>::type = 0>
   Vec256<T> abs() const {
-    // complex_t is for SFINAE and clarity. Make sure it is not changed.
-    static_assert(std::is_same<complex_t, T>::value, "complex_t must be T");
+    // complex_t_abs is for SFINAE and clarity. Make sure it is not changed.
+    static_assert(std::is_same<complex_t_abs, T>::value, "complex_t_abs must be T");
     // Specifically map() does not perform the type conversion needed by abs.
-    return map([](T x) { return (T)std::abs(x); });
+    return map([](T x) { return static_cast<T>(std::abs(x)); });
   }
+  template <typename other_t_angle = T,
+            typename std::enable_if<!c10::is_complex_t<other_t_angle>::value, int>::type = 0>
   Vec256<T> angle() const {
+    // other_t_angle is for SFINAE and clarity. Make sure it is not changed.
+    static_assert(std::is_same<other_t_angle, T>::value, "other_t_angle must be T");
     return *this;
   }
+  template <typename complex_t_angle = T,
+            typename std::enable_if<c10::is_complex_t<complex_t_angle>::value, int>::type = 0>
+  Vec256<T> angle() const {
+    // complex_t_angle is for SFINAE and clarity. Make sure it is not changed.
+    static_assert(std::is_same<complex_t_angle, T>::value, "complex_t_angle must be T");
+    // Specifically map() does not perform the type conversion needed by abs.
+    return map([](T x) { return static_cast<T>(std::arg(x)); });
+  }
+  template <typename other_t_real = T,
+            typename std::enable_if<!c10::is_complex_t<other_t_real>::value, int>::type = 0>
   Vec256<T> real() const {
+    // other_t_real is for SFINAE and clarity. Make sure it is not changed.
+    static_assert(std::is_same<other_t_real, T>::value, "other_t_real must be T");
     return *this;
   }
+  template <typename complex_t_real = T,
+            typename std::enable_if<c10::is_complex_t<complex_t_real>::value, int>::type = 0>
+  Vec256<T> real() const {
+    // complex_t_real is for SFINAE and clarity. Make sure it is not changed.
+    static_assert(std::is_same<complex_t_real, T>::value, "complex_t_real must be T");
+    // Specifically map() does not perform the type conversion needed by abs.
+    return map([](T x) { return static_cast<T>(x.real()); });
+  }
+  template <typename other_t_imag = T,
+            typename std::enable_if<!c10::is_complex_t<other_t_imag>::value, int>::type = 0>
   Vec256<T> imag() const {
+    // other_t_imag is for SFINAE and clarity. Make sure it is not changed.
+    static_assert(std::is_same<other_t_imag, T>::value, "other_t_imag must be T");
     return *this;
+  }
+  template <typename complex_t_imag = T,
+            typename std::enable_if<c10::is_complex_t<complex_t_imag>::value, int>::type = 0>
+  Vec256<T> imag() const {
+    // complex_t_imag is for SFINAE and clarity. Make sure it is not changed.
+    static_assert(std::is_same<complex_t_imag, T>::value, "complex_t_imag must be T");
+    // Specifically map() does not perform the type conversion needed by abs.
+    return map([](T x) { return static_cast<T>(x.imag()); });
   }
   Vec256<T> conj() const {
     return *this;
@@ -259,14 +295,14 @@ public:
     return map(std::log1p);
   }
   template <typename other_t_log2 = T,
-            typename std::enable_if<!std::is_complex_t<other_t_log2>::value, int>::type = 0>
+            typename std::enable_if<!c10::is_complex_t<other_t_log2>::value, int>::type = 0>
   Vec256<T> log2() const {
     // other_t_log2 is for SFINAE and clarity. Make sure it is not changed.
     static_assert(std::is_same<other_t_log2, T>::value, "other_t_log2 must be T");
     return map(std::log2);
   }
   template <typename complex_t_log2 = T,
-            typename std::enable_if<std::is_complex_t<complex_t_log2>::value, int>::type = 0>
+            typename std::enable_if<c10::is_complex_t<complex_t_log2>::value, int>::type = 0>
   Vec256<T> log2() const {
     // complex_t_log2 is for SFINAE and clarity. Make sure it is not changed.
     static_assert(std::is_same<complex_t_log2, T>::value, "complex_t_log2 must be T");
@@ -395,7 +431,7 @@ template <class T> Vec256<T> inline operator||(
 // Implements the IEEE 754 201X `maximum` operation, which propagates NaN if
 // either input is a NaN.
 template <class T,
-          typename std::enable_if<!std::is_complex_t<T>::value, int>::type = 0>
+          typename std::enable_if<!c10::is_complex_t<T>::value, int>::type = 0>
 Vec256<T> inline maximum(const Vec256<T> &a, const Vec256<T> &b) {
   Vec256<T> c = Vec256<T>();
   for (int i = 0; i != Vec256<T>::size(); i++) {
@@ -411,7 +447,7 @@ Vec256<T> inline maximum(const Vec256<T> &a, const Vec256<T> &b) {
 }
 
 template <class T,
-          typename std::enable_if<std::is_complex_t<T>::value, int>::type = 0>
+          typename std::enable_if<c10::is_complex_t<T>::value, int>::type = 0>
 Vec256<T> inline maximum(const Vec256<T> &a, const Vec256<T> &b) {
   Vec256<T> c = Vec256<T>();
   for (int i = 0; i != Vec256<T>::size(); i++) {
@@ -438,7 +474,7 @@ inline T maximum(const T& a, const T& b) {
 // Implements the IEEE 754 201X `minimum` operation, which propagates NaN if
 // either input is a NaN.
 template <class T,
-          typename std::enable_if<!std::is_complex_t<T>::value, int>::type = 0>
+          typename std::enable_if<!c10::is_complex_t<T>::value, int>::type = 0>
 Vec256<T> inline minimum(const Vec256<T> &a, const Vec256<T> &b) {
   Vec256<T> c = Vec256<T>();
   for (int i = 0; i != Vec256<T>::size(); i++) {
@@ -454,7 +490,7 @@ Vec256<T> inline minimum(const Vec256<T> &a, const Vec256<T> &b) {
 }
 
 template <class T,
-          typename std::enable_if<std::is_complex_t<T>::value, int>::type = 0>
+          typename std::enable_if<c10::is_complex_t<T>::value, int>::type = 0>
 Vec256<T> inline minimum(const Vec256<T> &a, const Vec256<T> &b) {
   Vec256<T> c = Vec256<T>();
   for (int i = 0; i != Vec256<T>::size(); i++) {
@@ -480,7 +516,7 @@ inline T minimum(const T& a, const T& b) {
 
 // To save BC, it will not propagate NaN based on IEEE 754 201X
 template <class T,
-          typename std::enable_if<!std::is_complex_t<T>::value, int>::type = 0>
+          typename std::enable_if<!c10::is_complex_t<T>::value, int>::type = 0>
 Vec256<T> inline clamp(const Vec256<T> &a, const Vec256<T> &min_vec, const Vec256<T> &max_vec) {
   Vec256<T> c = Vec256<T>();
   for (int i = 0; i != Vec256<T>::size(); i++) {
@@ -490,7 +526,7 @@ Vec256<T> inline clamp(const Vec256<T> &a, const Vec256<T> &min_vec, const Vec25
 }
 
 template <class T,
-          typename std::enable_if<std::is_complex_t<T>::value, int>::type = 0>
+          typename std::enable_if<c10::is_complex_t<T>::value, int>::type = 0>
 Vec256<T> inline clamp(const Vec256<T> &a, const Vec256<T> &min_vec, const Vec256<T> &max_vec) {
   Vec256<T> c = Vec256<T>();
   for (int i = 0; i != Vec256<T>::size(); i++) {
@@ -500,7 +536,7 @@ Vec256<T> inline clamp(const Vec256<T> &a, const Vec256<T> &min_vec, const Vec25
 }
 
 template <class T,
-          typename std::enable_if<!std::is_complex_t<T>::value, int>::type = 0>
+          typename std::enable_if<!c10::is_complex_t<T>::value, int>::type = 0>
 Vec256<T> inline clamp_max(const Vec256<T> &a, const Vec256<T> &max_vec) {
   Vec256<T> c = Vec256<T>();
   for (int i = 0; i != Vec256<T>::size(); i++) {
@@ -510,7 +546,7 @@ Vec256<T> inline clamp_max(const Vec256<T> &a, const Vec256<T> &max_vec) {
 }
 
 template <class T,
-          typename std::enable_if<std::is_complex_t<T>::value, int>::type = 0>
+          typename std::enable_if<c10::is_complex_t<T>::value, int>::type = 0>
 Vec256<T> inline clamp_max(const Vec256<T> &a, const Vec256<T> &max_vec) {
   Vec256<T> c = Vec256<T>();
   for (int i = 0; i != Vec256<T>::size(); i++) {
@@ -520,7 +556,7 @@ Vec256<T> inline clamp_max(const Vec256<T> &a, const Vec256<T> &max_vec) {
 }
 
 template <class T,
-          typename std::enable_if<!std::is_complex_t<T>::value, int>::type = 0>
+          typename std::enable_if<!c10::is_complex_t<T>::value, int>::type = 0>
 Vec256<T> inline clamp_min(const Vec256<T> &a, const Vec256<T> &min_vec) {
   Vec256<T> c = Vec256<T>();
   for (int i = 0; i != Vec256<T>::size(); i++) {
@@ -530,7 +566,7 @@ Vec256<T> inline clamp_min(const Vec256<T> &a, const Vec256<T> &min_vec) {
 }
 
 template <class T,
-          typename std::enable_if<std::is_complex_t<T>::value, int>::type = 0>
+          typename std::enable_if<c10::is_complex_t<T>::value, int>::type = 0>
 Vec256<T> inline clamp_min(const Vec256<T> &a, const Vec256<T> &min_vec) {
   Vec256<T> c = Vec256<T>();
   for (int i = 0; i != Vec256<T>::size(); i++) {

--- a/aten/src/ATen/cpu/vec256/vec256_complex_double.h
+++ b/aten/src/ATen/cpu/vec256/vec256_complex_double.h
@@ -24,14 +24,14 @@ public:
   Vec256() {}
   Vec256(__m256d v) : values(v) {}
   Vec256(std::complex<double> val) {
-    double real_value = std::real(val);
-    double imag_value = std::imag(val);
+    double real_value = val.real();
+    double imag_value = val.imag();
     values = _mm256_setr_pd(real_value, imag_value,
                             real_value, imag_value);
   }
   Vec256(std::complex<double> val1, std::complex<double> val2) {
-    values = _mm256_setr_pd(std::real(val1), std::imag(val1),
-                            std::real(val2), std::imag(val2));
+    values = _mm256_setr_pd(val1.real(), val1.imag(),
+                            val2.real(), val2.imag());
   }
   operator __m256d() const {
     return values;

--- a/aten/src/ATen/cpu/vec256/vec256_complex_float.h
+++ b/aten/src/ATen/cpu/vec256/vec256_complex_float.h
@@ -24,8 +24,8 @@ public:
   Vec256() {}
   Vec256(__m256 v) : values(v) {}
   Vec256(std::complex<float> val) {
-    float real_value = std::real(val);
-    float imag_value = std::imag(val);
+    float real_value = val.real();
+    float imag_value = val.imag();
     values = _mm256_setr_ps(real_value, imag_value,
                             real_value, imag_value,
                             real_value, imag_value,
@@ -33,10 +33,10 @@ public:
                             );
   }
   Vec256(std::complex<float> val1, std::complex<float> val2, std::complex<float> val3, std::complex<float> val4) {
-    values = _mm256_setr_ps(std::real(val1), std::imag(val1),
-                            std::real(val2), std::imag(val2),
-                            std::real(val3), std::imag(val3),
-                            std::real(val4), std::imag(val4)
+    values = _mm256_setr_ps(val1.real(), val1.imag(),
+                            val2.real(), val2.imag(),
+                            val3.real(), val3.imag(),
+                            val4.real(), val4.imag()
                             );
   }
   operator __m256() const {

--- a/aten/src/ATen/native/cpu/zmath.h
+++ b/aten/src/ATen/native/cpu/zmath.h
@@ -73,53 +73,53 @@ inline double angle_impl <std::complex<double>, double> (std::complex<double> z)
 }
 
 template <typename SCALAR_TYPE, typename VALUE_TYPE=SCALAR_TYPE>
-inline VALUE_TYPE real_impl (SCALAR_TYPE z) {
+constexpr VALUE_TYPE real_impl (SCALAR_TYPE z) {
   return z; //No-Op
 }
 
 template<>
-inline std::complex<float> real_impl <std::complex<float>> (std::complex<float> z) {
-  return std::complex<float>(std::real(z), 0.0);
+constexpr std::complex<float> real_impl <std::complex<float>> (std::complex<float> z) {
+  return std::complex<float>(z.real(), 0.0);
 }
 
 template<>
-inline float real_impl <std::complex<float>, float> (std::complex<float> z) {
-  return std::real(z);
+constexpr float real_impl <std::complex<float>, float> (std::complex<float> z) {
+  return z.real();
 }
 
 template<>
-inline std::complex<double> real_impl <std::complex<double>> (std::complex<double> z) {
-  return std::complex<double>(std::real(z), 0.0);
+constexpr std::complex<double> real_impl <std::complex<double>> (std::complex<double> z) {
+  return std::complex<double>(z.real(), 0.0);
 }
 
 template<>
-inline double real_impl <std::complex<double>, double> (std::complex<double> z) {
-  return std::real(z);
+constexpr double real_impl <std::complex<double>, double> (std::complex<double> z) {
+  return z.real();
 }
 
 template <typename SCALAR_TYPE, typename VALUE_TYPE=SCALAR_TYPE>
-inline VALUE_TYPE imag_impl (SCALAR_TYPE z) {
+constexpr VALUE_TYPE imag_impl (SCALAR_TYPE z) {
   return 0;
 }
 
 template<>
-inline std::complex<float> imag_impl <std::complex<float>> (std::complex<float> z) {
-  return std::complex<float>(std::imag(z), 0.0);
+constexpr std::complex<float> imag_impl <std::complex<float>> (std::complex<float> z) {
+  return std::complex<float>(z.imag(), 0.0);
 }
 
 template<>
-inline float imag_impl <std::complex<float>, float> (std::complex<float> z) {
-  return std::imag(z);
+constexpr float imag_impl <std::complex<float>, float> (std::complex<float> z) {
+  return z.imag();
 }
 
 template<>
-inline std::complex<double> imag_impl <std::complex<double>> (std::complex<double> z) {
-  return std::complex<double>(std::imag(z), 0.0);
+constexpr std::complex<double> imag_impl <std::complex<double>> (std::complex<double> z) {
+  return std::complex<double>(z.imag(), 0.0);
 }
 
 template<>
-inline double imag_impl <std::complex<double>, double> (std::complex<double> z) {
-  return std::imag(z);
+constexpr double imag_impl <std::complex<double>, double> (std::complex<double> z) {
+  return z.imag();
 }
 
 template <typename TYPE>
@@ -129,12 +129,12 @@ inline TYPE conj_impl (TYPE z) {
 
 template<>
 inline std::complex<float> conj_impl <std::complex<float>> (std::complex<float> z) {
-  return std::complex<float>(std::real(z), -std::imag(z));
+  return std::complex<float>(z.real(), -z.imag());
 }
 
 template<>
 inline std::complex<double> conj_impl <std::complex<double>> (std::complex<double> z) {
-  return std::complex<double>(std::real(z), -std::imag(z));
+  return std::complex<double>(z.real(), -z.imag());
 }
 
 template <typename TYPE>
@@ -144,12 +144,12 @@ inline TYPE ceil_impl (TYPE z) {
 
 template <>
 inline std::complex<float> ceil_impl (std::complex<float> z) {
-  return std::complex<float>(std::ceil(std::real(z)), std::ceil(std::imag(z)));
+  return std::complex<float>(std::ceil(z.real()), std::ceil(z.imag()));
 }
 
 template <>
 inline std::complex<double> ceil_impl (std::complex<double> z) {
-  return std::complex<double>(std::ceil(std::real(z)), std::ceil(std::imag(z)));
+  return std::complex<double>(std::ceil(z.real()), std::ceil(z.imag()));
 }
 
 template <typename TYPE>
@@ -159,12 +159,12 @@ inline TYPE floor_impl (TYPE z) {
 
 template <>
 inline std::complex<float> floor_impl (std::complex<float> z) {
-  return std::complex<float>(std::floor(std::real(z)), std::floor(std::imag(z)));
+  return std::complex<float>(std::floor(z.real()), std::floor(z.imag()));
 }
 
 template <>
 inline std::complex<double> floor_impl (std::complex<double> z) {
-  return std::complex<double>(std::floor(std::real(z)), std::floor(std::imag(z)));
+  return std::complex<double>(std::floor(z.real()), std::floor(z.imag()));
 }
 
 template <typename TYPE>
@@ -174,12 +174,12 @@ inline TYPE round_impl (TYPE z) {
 
 template <>
 inline std::complex<float> round_impl (std::complex<float> z) {
-  return std::complex<float>(std::nearbyint(std::real(z)), std::nearbyint(std::imag(z)));
+  return std::complex<float>(std::nearbyint(z.real()), std::nearbyint(z.imag()));
 }
 
 template <>
 inline std::complex<double> round_impl (std::complex<double> z) {
-  return std::complex<double>(std::nearbyint(std::real(z)), std::nearbyint(std::imag(z)));
+  return std::complex<double>(std::nearbyint(z.real()), std::nearbyint(z.imag()));
 }
 
 template <typename TYPE>
@@ -189,12 +189,12 @@ inline TYPE trunc_impl (TYPE z) {
 
 template <>
 inline std::complex<float> trunc_impl (std::complex<float> z) {
-  return std::complex<float>(std::trunc(std::real(z)), std::trunc(std::imag(z)));
+  return std::complex<float>(std::trunc(z.real()), std::trunc(z.imag()));
 }
 
 template <>
 inline std::complex<double> trunc_impl (std::complex<double> z) {
-  return std::complex<double>(std::trunc(std::real(z)), std::trunc(std::imag(z)));
+  return std::complex<double>(std::trunc(z.real()), std::trunc(z.imag()));
 }
 
 template <typename TYPE>

--- a/c10/util/Complex.h
+++ b/c10/util/Complex.h
@@ -1,17 +1,17 @@
 #pragma once
 
-#include <complex>
+#include <c10/util/Half.h>
 
 
 namespace std {
-
-template <typename T> struct is_complex_t                  : public std::false_type {};
-template <typename T> struct is_complex_t<std::complex<T>> : public std::true_type {};
 
 template <>
 class numeric_limits<std::complex<float>> : public numeric_limits<float>  {};
 
 template <>
 class numeric_limits<std::complex<double>> : public numeric_limits<double>  {};
+
+template <>
+class numeric_limits<c10::ComplexHalf> : public numeric_limits<c10::Half>  {};
 
 } // namespace std


### PR DESCRIPTION
In-tree changes to pytorch to support complex numbers are being submitted here.
Out-of-tree support for complex numbers is here: [pytorch-cpu-strided-complex extension](https://gitlab.com/pytorch-complex/pytorch-cpu-strided-complex)

- [x]  Replaced std:real(a) with a.real() in kernel level code.
- [x]  Fixed Vec256_base implementation of complex ops so that it works correctly on Non-AVX devices. 
- [x]  Fix NumericUtils.h 

cc: @iotamudelta, @ezyang, @bddppq, @zasdfgbnm