### PR TITLE
Fix test_memory_format_clone in test_torch.py

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -12654,7 +12654,6 @@ class TestTorchDeviceType(TestCase):
         clone = transformation_fn(nhwc)
 
         if default_is_preserve:
-            self.assertFalse(clone.is_contiguous())
             self.assertTrue(clone.is_contiguous(memory_format=torch.channels_last))
         else:
             self.assertTrue(clone.is_contiguous())

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -12694,7 +12694,7 @@ class TestTorchDeviceType(TestCase):
         def transformation_fn(tensor, **kwargs):
             return tensor.clone(**kwargs)
 
-        self._test_memory_format_transformations(device, input_generator_fn, transformation_fn, True)
+        self._test_memory_format_transformations(device, input_generator_fn, transformation_fn, default_is_preserve=True)
 
     @onlyCPU
     @dtypes(torch.double)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -12653,9 +12653,7 @@ class TestTorchDeviceType(TestCase):
         nhwc = input_generator_fn(device)
         clone = transformation_fn(nhwc)
 
-        if default_is_preserve:
-            self.assertTrue(clone.is_contiguous(memory_format=torch.channels_last))
-        else:
+        if not default_is_preserve:
             self.assertTrue(clone.is_contiguous())
             self.assertFalse(clone.is_contiguous(memory_format=torch.channels_last))
         if compare_data:


### PR DESCRIPTION
After the merge, _test_memory_format_transformations has two boolean arguments: compare_data and default_is_preserve. To make it obvious, we should use arguments' names calling this  function.

If default memory format for clone() is preserved we should not expect that it will be contiguous 