### PR TITLE
explicitly provide memory format when calling to to()

### DIFF
--- a/aten/src/ATen/SparseTensorUtils.h
+++ b/aten/src/ATen/SparseTensorUtils.h
@@ -35,8 +35,8 @@ inline void alias_into_sparse(const SparseTensor& self, const LongTensor& indice
 inline void copy_into_sparse(const SparseTensor& self, const LongTensor& indices, const Tensor& values, bool non_blocking) {
   alias_into_sparse(
       self,
-      indices.to(self._indices().options(), non_blocking, /*copy=*/true),
-      values.to(self._values().options(), non_blocking, /*copy=*/true));
+      indices.to(self._indices().options(), non_blocking, /*copy=*/true, at::MemoryFormat::Contiguous),
+      values.to(self._values().options(), non_blocking, /*copy=*/true, at::MemoryFormat::Contiguous));
 }
 
 // TODO: put this into the public API
@@ -93,7 +93,7 @@ inline LongTensor flatten_indices(const Tensor& indices, IntArrayRef full_size, 
         indices.options().device(kCPU));
     // NB: must be blocking because this blob may be freed after this closure,
     //     and non_blocking copy will see garbage.
-    auto indices_mult = indices_mult_cpu.to(indices.device(), /*non_blocking=*/false);
+    auto indices_mult = indices_mult_cpu.to(indices.device(), /*non_blocking=*/false, /*copy*/false, at::MemoryFormat::Contiguous);
     // Ideally we want matmul but matmul is slow on CPU Long and not implemented
     // on CUDA Long. So mul is faster.
     return indices.mul(indices_mult).sum(0);

--- a/aten/src/ATen/core/DeprecatedTypeProperties.cpp
+++ b/aten/src/ATen/core/DeprecatedTypeProperties.cpp
@@ -16,9 +16,9 @@ Storage DeprecatedTypeProperties::unsafeStorageFromTH(void * th_pointer, bool re
 
 Tensor DeprecatedTypeProperties::copy(const Tensor & src, bool non_blocking, c10::optional<Device> to_device) const {
   if (to_device) {
-    return src.to(src.options().dtype(scalarType()).device(to_device), non_blocking, /*copy=*/true);
+    return src.to(src.options().dtype(scalarType()).device(to_device), non_blocking, /*copy=*/true, at::MemoryFormat::Contiguous);
   }
-  return src.to(src.options().dtype(scalarType()), non_blocking, /*copy=*/true);
+  return src.to(src.options().dtype(scalarType()), non_blocking, /*copy=*/true, at::MemoryFormat::Contiguous);
 }
 
 } // namespace at

--- a/aten/src/ATen/native/Distributions.cpp
+++ b/aten/src/ATen/native/Distributions.cpp
@@ -142,7 +142,7 @@ Tensor& bernoulli_tensor_cpu_(Tensor& self, const Tensor& p_, Generator* gen) {
     std::lock_guard<std::mutex> lock(generator->mutex_);
     using self_t = scalar_t;
     if (p_.scalar_type() == kDouble) {
-      auto p = std::get<0>(expand_inplace(self, p_.to(kCPU)));
+      auto p = std::get<0>(expand_inplace(self, p_.to(kCPU, /*non-blocking*/true, /*copy*/false, at::MemoryFormat::Preserve)));
       CPU_tensor_apply2<self_t, double>(
         self, p, [generator](self_t& ret_val, double& p_val) {
           at::bernoulli_distribution<double> bernoulli(p_val);
@@ -150,7 +150,7 @@ Tensor& bernoulli_tensor_cpu_(Tensor& self, const Tensor& p_, Generator* gen) {
         });
     } else {
       AT_DISPATCH_FLOATING_TYPES(p_.scalar_type(), "bernoulli_tensor_cpu_p_", [&] {
-        auto p = std::get<0>(expand_inplace(self, p_.to(kCPU)));
+        auto p = std::get<0>(expand_inplace(self, p_.to(kCPU, /*non-blocking*/true, /*copy*/false, at::MemoryFormat::Preserve)));
         using p_t = scalar_t;
         CPU_tensor_apply2<self_t, p_t>(
           self, p, [generator](self_t& ret_val, p_t& p_val) {

--- a/aten/src/ATen/native/EmbeddingBag.cpp
+++ b/aten/src/ATen/native/EmbeddingBag.cpp
@@ -239,7 +239,7 @@ static Tensor apply_bag_size_backward(const Tensor &offsets,
       auto bag_size_ = indices.size(0);
       output /= bag_size_;
     } else {
-      auto inv_bag_size_ = (1 / bag_size.to(output.options()))
+      auto inv_bag_size_ = (1 / bag_size.to(output.options(), /*non-blocking*/true, /*copy*/false, at::MemoryFormat::Preserve))
                              .unsqueeze(1)
                              .index_select(0, offset2bag);
       output *= inv_bag_size_;

--- a/aten/src/ATen/native/Indexing.cpp
+++ b/aten/src/ATen/native/Indexing.cpp
@@ -196,7 +196,7 @@ static AdvancedIndex make_info(Tensor self, TensorList orig) {
   // Ensure indices are on the same device as self
   for (size_t i = 0; i < indices.size(); i++) {
     if (indices[i].defined() && indices[i].device() != self.device()) {
-      indices[i] = indices[i].to(self.device());
+      indices[i] = indices[i].to(self.device(), /*non-blocking*/true, /*copy*/false, at::MemoryFormat::Preserve);
     }
   }
   return AdvancedIndex(self, indices);

--- a/aten/src/ATen/native/LinearAlgebraUtils.h
+++ b/aten/src/ATen/native/LinearAlgebraUtils.h
@@ -109,7 +109,7 @@ static inline void batchCheckErrors(std::vector<int64_t>& infos, const char* nam
  */
 static inline void batchCheckErrors(const Tensor& infos, const char* name, bool allow_singular=false) {
   auto batch_size = infos.numel();
-  auto infos_cpu = infos.to(at::kCPU);
+  auto infos_cpu = infos.to(at::kCPU, /*non-blocking*/true, /*copy*/false, at::MemoryFormat::Preserve);
   auto infos_data = infos_cpu.data_ptr<int>();
   for (int64_t i = 0; i < batch_size; i++) {
     auto info = infos_data[i];

--- a/aten/src/ATen/native/LossCTC.cpp
+++ b/aten/src/ATen/native/LossCTC.cpp
@@ -354,7 +354,7 @@ Tensor ctc_loss(const Tensor& log_probs, const Tensor& targets, IntArrayRef inpu
     // GPU as a service for the user)
     res = std::get<0>(at::_ctc_loss(
         log_probs,
-        targets.to(log_probs.device(), kLong),
+        targets.to(log_probs.device(), kLong, /*non-blocking*/true, /*copy*/false, at::MemoryFormat::Preserve),
         input_lengths,
         target_lengths,
         BLANK,

--- a/aten/src/ATen/native/QuantizedLinear.cpp
+++ b/aten/src/ATen/native/QuantizedLinear.cpp
@@ -230,7 +230,7 @@ std::tuple<Tensor, Tensor, double, int64_t> fbgemm_linear_quantize_weight(
 
   q_params.precision = precision;
 
-  auto quantized = at::zeros_like(weight_contig, at::MemoryFormat::Contiguous).to(at::kChar).contiguous();
+  auto quantized = at::zeros_like(weight_contig, at::MemoryFormat::Contiguous).to(at::kChar, /*non-blocking*/true, /*copy*/false, at::MemoryFormat::Preserve);
   fbgemm::Quantize<int8_t>(
       /*src=*/weight_contig.data_ptr<float>(),
       /*dst=*/quantized.data_ptr<int8_t>(),
@@ -240,7 +240,7 @@ std::tuple<Tensor, Tensor, double, int64_t> fbgemm_linear_quantize_weight(
   // Calculate column offsets of the weight and store them away in a tensor.
   // Similarly to quantization, this can be done once and cached.
   auto col_offsets =
-      at::zeros_like(quantized, at::MemoryFormat::Contiguous).sum({1}).to(at::kInt).contiguous();
+      at::zeros_like(quantized, at::MemoryFormat::Contiguous).sum({1}).to(at::kInt, /*non-blocking*/true, /*copy*/false, at::MemoryFormat::Preserve);
   calc_col_offsets_transpose(
       /*K=*/quantized.size(1),
       /*N=*/quantized.size(0),

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -111,7 +111,7 @@ static TensorIterator make_reduction(
   if (self.scalar_type() == in_dtype) {
     return TensorIterator::reduce_op(viewed_result, self);
   }
-  return TensorIterator::reduce_op(viewed_result, self.to(in_dtype));
+  return TensorIterator::reduce_op(viewed_result, self.to(in_dtype, /*non-blocking*/true, /*copy*/false, at::MemoryFormat::Preserve));
 }
 
 static TensorIterator make_reduction(
@@ -165,7 +165,7 @@ static TensorIterator make_reduction(
       (self.is_cuda() && self.type().scalarType() == kHalf && dtype == kFloat)) {
     return TensorIterator::reduce_op(viewed_result1, viewed_result2, self);
   }
-  return TensorIterator::reduce_op(viewed_result1, viewed_result2, self.to(dtype));
+  return TensorIterator::reduce_op(viewed_result1, viewed_result2, self.to(dtype, /*non-blocking*/true, /*copy*/false, at::MemoryFormat::Preserve));
 }
 
 Tensor cumsum(const Tensor& self, int64_t dim, c10::optional<ScalarType> dtype) {
@@ -682,7 +682,7 @@ static Tensor &std_var_out(Tensor &result, const Tensor &self, IntArrayRef dim, 
 
   if (at::isComplexType(self.scalar_type())){
     ScalarType dtype = c10::toValueType(get_dtype(result, self, {}, true));
-    Tensor real_in = self.real().to(dtype);
+    Tensor real_in = self.real().to(dtype, /*non-blocking*/true, /*copy*/false, at::MemoryFormat::Preserve);
     Tensor real_out = at::empty({0}, self.options().dtype(dtype));
     auto iter = make_reduction("std or var", real_out, real_in, dim, keepdim, dtype);
     if (iter.numel() == 0) {
@@ -690,7 +690,7 @@ static Tensor &std_var_out(Tensor &result, const Tensor &self, IntArrayRef dim, 
     } else {
       std_var_stub(iter.device_type(), iter, unbiased, false);
     }
-    Tensor imag_in = self.imag().to(dtype);
+    Tensor imag_in = self.imag().to(dtype, /*non-blocking*/true, /*copy*/false, at::MemoryFormat::Preserve);
     Tensor imag_out = at::empty({0}, self.options().dtype(dtype));
     iter = make_reduction("std or var", imag_out, imag_in, dim, keepdim, dtype);
     if (iter.numel() == 0) {
@@ -726,7 +726,7 @@ static std::tuple<Tensor&,Tensor&> std_var_mean_out(const char* fname, Tensor &r
            ".");
   if (at::isComplexType(self.scalar_type())){
     ScalarType dtype = c10::toValueType(get_dtype(result1, self, {}, true));
-    Tensor real_in = self.real().to(dtype);
+    Tensor real_in = self.real().to(dtype, /*non-blocking*/true, /*copy*/false, at::MemoryFormat::Preserve);
     Tensor real_out_var = at::empty({0}, self.options().dtype(dtype));
     Tensor real_out_mean = at::empty({0}, self.options().dtype(dtype));
     auto iter = make_reduction(fname, real_out_var, real_out_mean, real_in, dim, keepdim, dtype);
@@ -736,7 +736,7 @@ static std::tuple<Tensor&,Tensor&> std_var_mean_out(const char* fname, Tensor &r
     } else {
       std_var_stub(iter.device_type(), iter, unbiased, false);
     }
-    Tensor imag_in = self.imag().to(dtype);
+    Tensor imag_in = self.imag().to(dtype, /*non-blocking*/true, /*copy*/false, at::MemoryFormat::Preserve);
     Tensor imag_out_var = at::empty({0}, self.options().dtype(dtype));
     Tensor imag_out_mean = at::empty({0}, self.options().dtype(dtype));
     iter = make_reduction(fname, imag_out_var, imag_out_mean, imag_in, dim, keepdim, dtype);

--- a/aten/src/ATen/native/SummaryOps.cpp
+++ b/aten/src/ATen/native/SummaryOps.cpp
@@ -60,7 +60,7 @@ _bincount_cpu(const Tensor& self, const Tensor& weights, int64_t minlength) {
     if (scalar == ScalarType::Undefined || scalar == ScalarType::Float)
       return _bincount_cpu_template<scalar_t, float>(self.contiguous(), weights.contiguous(), minlength);
     return _bincount_cpu_template<scalar_t, double>(
-        self.contiguous(), weights.contiguous().to(kDouble), minlength);
+        self.contiguous(), weights.contiguous().to(kDouble, /*non-blocking*/true, /*copy*/false, at::MemoryFormat::Preserve), minlength);
   });
 }
 

--- a/aten/src/ATen/native/TensorCompare.cpp
+++ b/aten/src/ATen/native/TensorCompare.cpp
@@ -65,7 +65,7 @@ Tensor isclose(const Tensor& self, const Tensor& other, double rtol, double atol
   // It is also possible for parameters to be 'wrapped_number's, in which case
   // max_error could be promoted to double when actual error is still a float.
   if (actual_error.scalar_type() != max_error.scalar_type()) {
-    actual_error = actual_error.to(max_error.scalar_type());
+    actual_error = actual_error.to(max_error.scalar_type(), /*non-blocking*/true, /*copy*/false, at::MemoryFormat::Preserve);
   }
 
   auto close = actual_error <= max_error;

--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -182,7 +182,7 @@ Tensor& empty_out(
   Tensor _cast_##n(const Tensor& self, bool non_blocking) {      \
     if (self.scalar_type() == ScalarType::n)                     \
       return self;                                               \
-    return self.to(ScalarType::n, non_blocking);                 \
+    return self.to(ScalarType::n, non_blocking, /*copy*/false, at::MemoryFormat::Preserve); \
   }
 
 AT_FORALL_SCALAR_TYPES_AND3(Bool, Half, BFloat16, DEFINE_CAST_OP)

--- a/aten/src/ATen/native/TensorIterator.cpp
+++ b/aten/src/ATen/native/TensorIterator.cpp
@@ -154,7 +154,7 @@ static void maybe_copy_casting_to_common_dtype(OperandInfo& op, ScalarType commo
     op.dtype = common_dtype;
     op.original_tensor = op.tensor;
     if (!op.is_output) {
-      op.tensor = op.tensor.to(common_dtype);
+      op.tensor = op.tensor.to(common_dtype, /*non-blocking*/true, /*copy*/false, at::MemoryFormat::Preserve);
     } else {
       op.tensor =
           at::empty_like(op.tensor, op.tensor.options().dtype(common_dtype), LEGACY_CONTIGUOUS_MEMORY_FORMAT);
@@ -244,7 +244,7 @@ void TensorIterator::compute_types() {
         AT_ERROR("output with device ", op.tensor.device(),
                   " doesn't match the desired device ", op.device);
       } else if (op.tensor.dim() == 0) {
-        op.tensor = op.tensor.to(op.options());
+        op.tensor = op.tensor.to(op.options(), /*non-blocking*/true, /*copy*/false, at::MemoryFormat::Preserve);
       } else {
         AT_ERROR("expected device ", op.device,
                   " but got device ", op.tensor.device());

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -651,9 +651,9 @@ Tensor index_select_sparse(const Tensor& self, int64_t dim, const Tensor& index)
         }
       }
     }
-    auto zIndices = at::from_blob(zindices.data(), {new_nnz}, at::kLong).to(indices.device());
+    auto zIndices = at::from_blob(zindices.data(), {new_nnz}, at::kLong).to(indices.device(), /*non-blocking*/true, /*copy*/false, at::MemoryFormat::Preserve);
     auto new_indices = indices.index_select(1, zIndices);
-    new_indices[dim] = at::from_blob(iindices.data(), {new_nnz}, at::kLong).to(indices.device());
+    new_indices[dim] = at::from_blob(iindices.data(), {new_nnz}, at::kLong).to(indices.device(), /*non-blocking*/true, /*copy*/false, at::MemoryFormat::Preserve);
     auto new_values = values.index_select(0, zIndices);
     return _sparse_coo_tensor_with_dims_and_tensors(
         sparse_dim, dense_dim, new_sizes, new_indices, new_values, self.options());

--- a/aten/src/ATen/native/TypeProperties.cpp
+++ b/aten/src/ATen/native/TypeProperties.cpp
@@ -41,7 +41,7 @@ bool _has_compatible_shallow_copy_type(const Tensor& self, const Tensor& from) {
 }
 
 Tensor type_as(const Tensor& self, const Tensor& other) {
-  return self.to(other.options());
+  return self.to(other.options(), /*non-blocking*/true, /*copy*/false, at::MemoryFormat::Preserve);
 }
 
 static inline ScalarType promote_skip_undefined(ScalarType a, ScalarType b) {

--- a/aten/src/ATen/native/WeightNorm.cpp
+++ b/aten/src/ATen/native/WeightNorm.cpp
@@ -89,7 +89,7 @@ std::tuple<Tensor, Tensor> _weight_norm_differentiable_backward
 
   // ...but saved_norms might be Float when saved_g and saved_v are half.
   // To consider:  saved_norms.to(..., True /*non_blocking*/);
-  auto norms = saved_norms.to(saved_g.scalar_type());
+  auto norms = saved_norms.to(saved_g.scalar_type(), /*non-blocking*/true, /*copy*/false, at::MemoryFormat::Preserve);
 
   std::vector<int64_t> bcast_size(saved_v.dim(), 1);
 

--- a/aten/src/ATen/native/cuda/BatchLinearAlgebra.cu
+++ b/aten/src/ATen/native/cuda/BatchLinearAlgebra.cu
@@ -973,7 +973,7 @@ std::tuple<Tensor, Tensor, Tensor> _lu_with_info_cuda(const Tensor& self, bool p
           */
           auto batch_size = infos_tensor.numel();
           auto infos_array = infos_tensor.view({batch_size});
-          auto infos_cpu = infos_array.to(at::kCPU);
+          auto infos_cpu = infos_array.to(at::kCPU, /*non-blocking*/true, /*copy*/false, at::MemoryFormat::Preserve);
           auto infos_data = infos_cpu.data_ptr<int>();
           auto input_array = self.view({batch_size, m, n});
           auto working_array = self_working_copy.view({batch_size, m, n});
@@ -1265,9 +1265,9 @@ std::tuple<Tensor, Tensor> _symeig_helper_cuda(const Tensor& self, bool eigenvec
     singleCheckErrors(infos[0], "symeig_cuda");
   }
   if (eigenvectors) {
-    return std::tuple<Tensor, Tensor>(eigvals_working_copy.to(self.device()), self_working_copy);
+    return std::tuple<Tensor, Tensor>(eigvals_working_copy.to(self.device(), /*non-blocking*/true, /*copy*/false, at::MemoryFormat::Preserve), self_working_copy, );
   } else {
-    return std::tuple<Tensor, Tensor>(eigvals_working_copy.to(self.device()), at::empty({0}, self.options()));
+    return std::tuple<Tensor, Tensor>(eigvals_working_copy.to(self.device(), /*non-blocking*/true, /*copy*/false, at::MemoryFormat::Preserve), at::empty({0}, self.options()));
   }
 }
 

--- a/aten/src/ATen/native/cuda/BatchLinearAlgebra.cu
+++ b/aten/src/ATen/native/cuda/BatchLinearAlgebra.cu
@@ -1265,7 +1265,7 @@ std::tuple<Tensor, Tensor> _symeig_helper_cuda(const Tensor& self, bool eigenvec
     singleCheckErrors(infos[0], "symeig_cuda");
   }
   if (eigenvectors) {
-    return std::tuple<Tensor, Tensor>(eigvals_working_copy.to(self.device(), /*non-blocking*/true, /*copy*/false, at::MemoryFormat::Preserve), self_working_copy, );
+    return std::tuple<Tensor, Tensor>(eigvals_working_copy.to(self.device(), /*non-blocking*/true, /*copy*/false, at::MemoryFormat::Preserve), self_working_copy);
   } else {
     return std::tuple<Tensor, Tensor>(eigvals_working_copy.to(self.device(), /*non-blocking*/true, /*copy*/false, at::MemoryFormat::Preserve), at::empty({0}, self.options()));
   }

--- a/aten/src/ATen/native/cuda/Copy.cu
+++ b/aten/src/ATen/native/cuda/Copy.cu
@@ -133,7 +133,7 @@ static void copy_kernel_cuda(TensorIterator& iter, bool non_blocking) {
     // the src device for GPU-GPU copies.
     if (iter.device_type(0) == kCUDA) {
       dst_contig = dst.is_contiguous() ? dst : at::empty_like(dst, at::MemoryFormat::Contiguous);
-      src_contig = iter.tensor(1).to(iter.dtype(0)).expand_as(dst).contiguous();
+      src_contig = iter.tensor(1).to(iter.dtype(0), /*non-blocking*/true, /*copy*/false, at::MemoryFormat::Preserve).expand_as(dst).contiguous();
     } else {
       bool same_type = iter.dtype(0) == iter.dtype(1);
       dst_contig = (dst.is_contiguous() && same_type) ? dst : at::empty_like(dst, iter.dtype(1), LEGACY_CONTIGUOUS_MEMORY_FORMAT);

--- a/aten/src/ATen/native/cuda/Distributions.cu
+++ b/aten/src/ATen/native/cuda/Distributions.cu
@@ -403,7 +403,7 @@ Tensor& bernoulli_tensor_cuda_(Tensor &self, const Tensor& p_, Generator* gen_) 
     std::lock_guard<std::mutex> lock(gen->mutex_);
     rng_engine_inputs = gen->philox_engine_inputs(10);
   }
-  auto p = std::get<0>(expand_inplace(self, p_.to(kCUDA)));
+  auto p = std::get<0>(expand_inplace(self, p_.to(kCUDA, /*non-blocking*/true, /*copy*/false, at::MemoryFormat::Preserve)));
   AT_DISPATCH_ALL_TYPES_AND2(
     at::ScalarType::Half, at::ScalarType::Bool, self.scalar_type(), "bernoulli_tensor_cuda_self_", [&] {
       using self_t = scalar_t;

--- a/aten/src/ATen/native/cuda/Normalization.cu
+++ b/aten/src/ATen/native/cuda/Normalization.cu
@@ -100,7 +100,7 @@ std::tuple<Tensor, Tensor> batch_norm_gather_stats_cuda(const Tensor& self, cons
 std::tuple<Tensor, Tensor> batch_norm_gather_stats_with_counts_cuda(const Tensor& self, const Tensor& mean, const Tensor& invstd, const Tensor& running_mean,
                                                         const Tensor& running_var, double momentum, double epsilon, IntArrayRef counts) {
   Tensor counts_ = at::from_blob((void*)counts.data(), {(int64_t)counts.size()}, self.options().dtype(at::kLong).device(at::kCPU));
-  counts_ = counts_.to(self.device()).to(running_mean.dtype());
+  counts_ = counts_.to(self.device(), /*non-blocking*/true, /*copy*/false, at::MemoryFormat::Preserve).to(running_mean.dtype(), /*non-blocking*/true, /*copy*/false, at::MemoryFormat::Preserve);
   return AT_DISPATCH_FLOATING_TYPES_AND_HALF(running_mean.scalar_type(), "batch_norm_update_stats_cuda", [&] {
       using accscalar_t = at::acc_type<scalar_t, true>;
       if (cuda::detail::canUse32BitIndexMath(self)) {

--- a/aten/src/ATen/native/cuda/SummaryOps.cu
+++ b/aten/src/ATen/native/cuda/SummaryOps.cu
@@ -364,7 +364,7 @@ Tensor _bincount_cuda(
     if (scalar == ScalarType::Undefined || scalar == ScalarType::Float)
       return _bincount_cuda_template<scalar_t, float>(self, weights, minlength);
     return _bincount_cuda_template<scalar_t, double>(
-        self, weights.to(kDouble), minlength);
+        self, weights.to(kDouble, /*non-blocking*/true, /*copy*/false, at::MemoryFormat::Preserve), minlength);
   });
 }
 

--- a/aten/src/ATen/native/sparse/SparseTensor.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensor.cpp
@@ -163,8 +163,8 @@ Tensor sparse_coo_tensor(const Tensor& indices, const Tensor& values_, const Ten
     LongTensor min_indices = std::get</* values */ 0>(indices.min(/* dim */ 1, /* keepdim */ false));
     LongTensor computed_indices_sizes = std::get</* values */ 0>(indices.max(/* dim */ 1, /* keepdim */ false));
     computed_indices_sizes.add_(1); // len = max_index + 1
-    LongTensor cpu_min_indices = min_indices.to(at::DeviceType::CPU);
-    LongTensor cpu_computed_indices_sizes = computed_indices_sizes.to(at::DeviceType::CPU);
+    LongTensor cpu_min_indices = min_indices.to(at::DeviceType::CPU, /*non-blocking*/true, /*copy*/false, at::MemoryFormat::Preserve);
+    LongTensor cpu_computed_indices_sizes = computed_indices_sizes.to(at::DeviceType::CPU, /*non-blocking*/true, /*copy*/false, at::MemoryFormat::Preserve);
     auto cpu_min_indices_accessor = cpu_min_indices.accessor<int64_t, 1>();
     auto cpu_computed_indices_sizes_accessor = cpu_computed_indices_sizes.accessor<int64_t, 1>();
     for (int64_t d = 0; d < sparse_dim; d++) {
@@ -210,8 +210,8 @@ Tensor sparse_coo_tensor(const Tensor& indices, const Tensor& values_, ArrayRef<
     LongTensor max_indices = std::get</* values */ 0>(indices.max(/* dim */ 1, /* keepdim */ false));
     LongTensor cpu_min_indices, cpu_max_indices;
     if (indices.is_cuda()) {
-      cpu_min_indices = min_indices.to(at::DeviceType::CPU);
-      cpu_max_indices = max_indices.to(at::DeviceType::CPU);
+      cpu_min_indices = min_indices.to(at::DeviceType::CPU, /*non-blocking*/true, /*copy*/false, at::MemoryFormat::Preserve);
+      cpu_max_indices = max_indices.to(at::DeviceType::CPU, /*non-blocking*/true, /*copy*/false, at::MemoryFormat::Preserve);
     } else {
       cpu_min_indices = min_indices;
       cpu_max_indices = max_indices;

--- a/aten/src/ATen/native/sparse/SparseTensorMath.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensorMath.cpp
@@ -947,10 +947,10 @@ Tensor _sparse_sum(const SparseTensor& input, ScalarType dtype) {
 }
 
 Tensor _sparse_sum(const SparseTensor& input, IntArrayRef dims_to_sum, ScalarType dtype) {
-  return at::_sparse_sum(input.to(dtype), dims_to_sum);
+  return at::_sparse_sum(input.to(dtype, /*non-blocking*/true, /*copy*/false, at::MemoryFormat::Preserve), dims_to_sum);
 }
 
-Tensor _sparse_sum(const SparseTensor& input, IntArrayRef dims_to_sum) {
+Tensor _sparse_sum(const SparseTensor& input, IntArrayRef dims_to_sum) {lkub
   TORCH_CHECK(input._nnz() > 0, "_sparse_sum: sparse tensor input._nnz() == 0, please call torch.sparse.sum(input) instead.")
 
   const int64_t input_dim = input.dim();

--- a/aten/src/ATen/native/sparse/SparseTensorMath.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensorMath.cpp
@@ -950,7 +950,7 @@ Tensor _sparse_sum(const SparseTensor& input, IntArrayRef dims_to_sum, ScalarTyp
   return at::_sparse_sum(input.to(dtype, /*non-blocking*/true, /*copy*/false, at::MemoryFormat::Preserve), dims_to_sum);
 }
 
-Tensor _sparse_sum(const SparseTensor& input, IntArrayRef dims_to_sum) {lkub
+Tensor _sparse_sum(const SparseTensor& input, IntArrayRef dims_to_sum) {
   TORCH_CHECK(input._nnz() > 0, "_sparse_sum: sparse tensor input._nnz() == 0, please call torch.sparse.sum(input) instead.")
 
   const int64_t input_dim = input.dim();

--- a/aten/src/ATen/quantized/Quantizer.cpp
+++ b/aten/src/ATen/quantized/Quantizer.cpp
@@ -460,8 +460,8 @@ QuantizerPtr make_per_channel_affine_quantizer(
   TORCH_CHECK(
       isIntegralType(zero_points.scalar_type(), false /*includeBool*/),
       "zero_points tensor must have integral type");
-  Tensor scales_double = scales.to(kDouble).contiguous();
-  Tensor zero_points_int64 = zero_points.to(kLong).contiguous();
+  Tensor scales_double = scales.to(kDouble, /*non-blocking*/true, /*copy*/false, at::MemoryFormat::Preserve).contiguous();
+  Tensor zero_points_int64 = zero_points.to(kLong, /*non-blocking*/true, /*copy*/false, at::MemoryFormat::Preserve).contiguous();
   double* scales_data = scales_double.data_ptr<double>();
   int64_t* zero_points_data = zero_points_int64.data_ptr<int64_t>();
   std::vector<double> scale_vals(scales_data, scales_data + scales.numel());

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -399,7 +399,7 @@ Tensor cumprod_backward(const Tensor &grad, const Tensor &input, int64_t dim) {
 }
 
 Tensor cumprod_backward(const Tensor &grad, const Tensor &input, int64_t dim, optional<ScalarType> dtype) {
-  return cumprod_backward(grad.to(input.scalar_type()), input, dim);
+  return cumprod_backward(grad.to(input.scalar_type(), /*non-blocking*/true, /*copy*/false, at::MemoryFormat::Preserve), input, dim);
 }
 
 Tensor solve_backward_self(const Tensor & grad, const Tensor & self, const Tensor & A) {
@@ -2240,10 +2240,10 @@ std::tuple<Tensor, Tensor, Tensor> batchnorm_double_backward(
   }
   // for half inputs, save_mean, save_invstd are float (ideally, we would cast
   // everything else, but not now)
-  auto mu = unsqueeze_dim1(training ? save_mean.to(input.scalar_type()) : running_mean, input);
+  auto mu = unsqueeze_dim1(training ? save_mean.to(input.scalar_type(), /*non-blocking*/true, /*copy*/false, at::MemoryFormat::Preserve) : running_mean, input);
   auto input_sub_mu = input - mu;
   auto sigma2_eps_neg_1_2 = unsqueeze_dim1(
-      training ? save_invstd.to(input.scalar_type())
+      training ? save_invstd.to(input.scalar_type(), /*non-blocking*/true, /*copy*/false, at::MemoryFormat::Preserve)
                : running_var.add(Scalar(eps)).pow(-0.5),
       input);
   auto sigma2_eps_neg_1 = sigma2_eps_neg_1_2.pow(2);


### PR DESCRIPTION
Currently to() has parameter memory_format with default value as Contiguous.
In the future it will be changed to different default memory format - Preserve.
To avoid any potencial issues, specify memory_format explicitly