### PR TITLE
Update CircleCI config to use Docker images from "pytorch" account

### DIFF
--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -340,12 +340,12 @@ Libtorch packages are built in the wheel build scripts: manywheel/build_*.sh for
 
 All linux builds occur in docker images. The docker images are
 
-* soumith/conda-cuda
+* pytorch/conda-cuda
     * Has ALL CUDA versions installed. The script pytorch/builder/conda/switch_cuda_version.sh sets /usr/local/cuda to a symlink to e.g. /usr/local/cuda-10.0 to enable different CUDA builds
     * Also used for cpu builds
-* soumith/manylinux-cuda90
-* soumith/manylinux-cuda92
-* soumith/manylinux-cuda100
+* pytorch/manylinux-cuda90
+* pytorch/manylinux-cuda92
+* pytorch/manylinux-cuda100
     * Also used for cpu builds
 
 The Dockerfiles are available in pytorch/builder, but there is no circleci job or script to build these docker images, and they cannot be run locally (unless you have the correct local packages/paths). Only Soumith can build them right now.
@@ -411,7 +411,7 @@ You can build Linux binaries locally easily using docker.
 
 ```
 # Run the docker
-# Use the correct docker image, soumith/conda-cuda used here as an example
+# Use the correct docker image, pytorch/conda-cuda used here as an example
 #
 # -v path/to/foo:path/to/bar makes path/to/foo on your local machine (the
 #    machine that you're running the command on) accessible to the docker
@@ -426,7 +426,7 @@ docker run \
     -v your/pytorch/repo:/pytorch \
     -v your/builder/repo:/builder \
     -v where/you/want/packages/to/appear:/final_pkgs \
-    -it soumith/conda-cuda /bin/bash
+    -it pytorch/conda-cuda /bin/bash
 
 # Export whatever variables are important to you. All variables that you'd
 # possibly need are in .circleci/scripts/binary_populate_env.sh

--- a/.circleci/cimodel/data/binary_build_definitions.py
+++ b/.circleci/cimodel/data/binary_build_definitions.py
@@ -24,7 +24,7 @@ class Conf(object):
 
     def gen_docker_image(self):
         if self.gcc_config_variant == 'gcc5.4_cxx11-abi':
-            return miniutils.quote("soumith/conda-cuda-cxx11-ubuntu1604:latest")
+            return miniutils.quote("pytorch/conda-cuda-cxx11-ubuntu1604:latest")
 
         docker_word_substitution = {
             "manywheel": "manylinux",
@@ -33,10 +33,10 @@ class Conf(object):
 
         docker_distro_prefix = miniutils.override(self.pydistro, docker_word_substitution)
 
-        # The cpu nightlies are built on the soumith/manylinux-cuda100 docker image
+        # The cpu nightlies are built on the pytorch/manylinux-cuda100 docker image
         alt_docker_suffix = self.cuda_version or "100"
         docker_distro_suffix = "" if self.pydistro == "conda" else alt_docker_suffix
-        return miniutils.quote("soumith/" + docker_distro_prefix + "-cuda" + docker_distro_suffix)
+        return miniutils.quote("pytorch/" + docker_distro_prefix + "-cuda" + docker_distro_suffix)
 
     def get_name_prefix(self):
         return "smoke" if self.smoke else "binary"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1951,19 +1951,19 @@ workflows:
           build_environment: "manywheel 2.7mu cpu devtoolset7"
           requires:
             - setup
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
       - binary_linux_build:
           name: binary_linux_manywheel_3_7m_cu100_devtoolset7_build
           build_environment: "manywheel 3.7m cu100 devtoolset7"
           requires:
             - setup
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
       - binary_linux_build:
           name: binary_linux_conda_2_7_cpu_devtoolset7_build
           build_environment: "conda 2.7 cpu devtoolset7"
           requires:
             - setup
-          docker_image: "soumith/conda-cuda"
+          docker_image: "pytorch/conda-cuda"
       # This binary build is currently broken, see https://github_com/pytorch/pytorch/issues/16710
       # - binary_linux_conda_3_6_cu90_devtoolset7_build
       - binary_linux_build:
@@ -1972,14 +1972,14 @@ workflows:
           requires:
             - setup
           libtorch_variant: "shared-with-deps"
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
       - binary_linux_build:
           name: binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_shared-with-deps_build
           build_environment: "libtorch 2.7m cpu gcc5.4_cxx11-abi"
           requires:
             - setup
           libtorch_variant: "shared-with-deps"
-          docker_image: "yf225/pytorch-binary-docker-image-ubuntu16.04:latest"
+          docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
       # TODO we should test a libtorch cuda build, but they take too long
       # - binary_linux_libtorch_2_7m_cu90_devtoolset7_static-without-deps_build
       - binary_mac_build:
@@ -2004,14 +2004,14 @@ workflows:
           requires:
             - setup
             - binary_linux_manywheel_2_7mu_cpu_devtoolset7_build
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
       - binary_linux_test:
           name: binary_linux_manywheel_3_7m_cu100_devtoolset7_test
           build_environment: "manywheel 3.7m cu100 devtoolset7"
           requires:
             - setup
             - binary_linux_manywheel_3_7m_cu100_devtoolset7_build
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
@@ -2020,7 +2020,7 @@ workflows:
           requires:
             - setup
             - binary_linux_conda_2_7_cpu_devtoolset7_build
-          docker_image: "soumith/conda-cuda"
+          docker_image: "pytorch/conda-cuda"
       # This binary build is currently broken, see https://github_com/pytorch/pytorch/issues/16710
       # - binary_linux_conda_3_6_cu90_devtoolset7_test:
       - binary_linux_test:
@@ -2030,7 +2030,7 @@ workflows:
             - setup
             - binary_linux_libtorch_2_7m_cpu_devtoolset7_shared-with-deps_build
           libtorch_variant: "shared-with-deps"
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
       - binary_linux_test:
           name: binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_shared-with-deps_test
           build_environment: "libtorch 2.7m cpu gcc5.4_cxx11-abi"
@@ -2038,7 +2038,7 @@ workflows:
             - setup
             - binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_shared-with-deps_build
           libtorch_variant: "shared-with-deps"
-          docker_image: "yf225/pytorch-binary-docker-image-ubuntu16.04:latest"
+          docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
 
       - smoke_linux_test:
           name: smoke_linux_manywheel_2_7m_cpu_devtoolset7_nightly
@@ -2050,7 +2050,7 @@ workflows:
           filters:
             branches:
               only: postnightly
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
       - smoke_linux_test:
           name: smoke_linux_manywheel_2_7mu_cpu_devtoolset7_nightly
           build_environment: "manywheel 2.7mu cpu devtoolset7"
@@ -2061,7 +2061,7 @@ workflows:
           filters:
             branches:
               only: postnightly
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
       - smoke_linux_test:
           name: smoke_linux_manywheel_3_5m_cpu_devtoolset7_nightly
           build_environment: "manywheel 3.5m cpu devtoolset7"
@@ -2072,7 +2072,7 @@ workflows:
           filters:
             branches:
               only: postnightly
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
       - smoke_linux_test:
           name: smoke_linux_manywheel_3_6m_cpu_devtoolset7_nightly
           build_environment: "manywheel 3.6m cpu devtoolset7"
@@ -2083,7 +2083,7 @@ workflows:
           filters:
             branches:
               only: postnightly
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
       - smoke_linux_test:
           name: smoke_linux_manywheel_3_7m_cpu_devtoolset7_nightly
           build_environment: "manywheel 3.7m cpu devtoolset7"
@@ -2094,7 +2094,7 @@ workflows:
           filters:
             branches:
               only: postnightly
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
       - smoke_linux_test:
           name: smoke_linux_manywheel_2_7m_cu92_devtoolset7_nightly
           build_environment: "manywheel 2.7m cu92 devtoolset7"
@@ -2105,7 +2105,7 @@ workflows:
           filters:
             branches:
               only: postnightly
-          docker_image: "soumith/manylinux-cuda92"
+          docker_image: "pytorch/manylinux-cuda92"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
@@ -2118,7 +2118,7 @@ workflows:
           filters:
             branches:
               only: postnightly
-          docker_image: "soumith/manylinux-cuda92"
+          docker_image: "pytorch/manylinux-cuda92"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
@@ -2131,7 +2131,7 @@ workflows:
           filters:
             branches:
               only: postnightly
-          docker_image: "soumith/manylinux-cuda92"
+          docker_image: "pytorch/manylinux-cuda92"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
@@ -2144,7 +2144,7 @@ workflows:
           filters:
             branches:
               only: postnightly
-          docker_image: "soumith/manylinux-cuda92"
+          docker_image: "pytorch/manylinux-cuda92"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
@@ -2157,7 +2157,7 @@ workflows:
           filters:
             branches:
               only: postnightly
-          docker_image: "soumith/manylinux-cuda92"
+          docker_image: "pytorch/manylinux-cuda92"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
@@ -2170,7 +2170,7 @@ workflows:
           filters:
             branches:
               only: postnightly
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
@@ -2183,7 +2183,7 @@ workflows:
           filters:
             branches:
               only: postnightly
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
@@ -2196,7 +2196,7 @@ workflows:
           filters:
             branches:
               only: postnightly
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
@@ -2209,7 +2209,7 @@ workflows:
           filters:
             branches:
               only: postnightly
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
@@ -2222,7 +2222,7 @@ workflows:
           filters:
             branches:
               only: postnightly
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
@@ -2235,7 +2235,7 @@ workflows:
           filters:
             branches:
               only: postnightly
-          docker_image: "soumith/manylinux-cuda101"
+          docker_image: "pytorch/manylinux-cuda101"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
@@ -2248,7 +2248,7 @@ workflows:
           filters:
             branches:
               only: postnightly
-          docker_image: "soumith/manylinux-cuda101"
+          docker_image: "pytorch/manylinux-cuda101"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
@@ -2261,7 +2261,7 @@ workflows:
           filters:
             branches:
               only: postnightly
-          docker_image: "soumith/manylinux-cuda101"
+          docker_image: "pytorch/manylinux-cuda101"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
@@ -2274,7 +2274,7 @@ workflows:
           filters:
             branches:
               only: postnightly
-          docker_image: "soumith/manylinux-cuda101"
+          docker_image: "pytorch/manylinux-cuda101"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
@@ -2287,7 +2287,7 @@ workflows:
           filters:
             branches:
               only: postnightly
-          docker_image: "soumith/manylinux-cuda101"
+          docker_image: "pytorch/manylinux-cuda101"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
@@ -2300,7 +2300,7 @@ workflows:
           filters:
             branches:
               only: postnightly
-          docker_image: "soumith/conda-cuda"
+          docker_image: "pytorch/conda-cuda"
       - smoke_linux_test:
           name: smoke_linux_conda_3_5_cpu_devtoolset7_nightly
           build_environment: "conda 3.5 cpu devtoolset7"
@@ -2311,7 +2311,7 @@ workflows:
           filters:
             branches:
               only: postnightly
-          docker_image: "soumith/conda-cuda"
+          docker_image: "pytorch/conda-cuda"
       - smoke_linux_test:
           name: smoke_linux_conda_3_6_cpu_devtoolset7_nightly
           build_environment: "conda 3.6 cpu devtoolset7"
@@ -2322,7 +2322,7 @@ workflows:
           filters:
             branches:
               only: postnightly
-          docker_image: "soumith/conda-cuda"
+          docker_image: "pytorch/conda-cuda"
       - smoke_linux_test:
           name: smoke_linux_conda_3_7_cpu_devtoolset7_nightly
           build_environment: "conda 3.7 cpu devtoolset7"
@@ -2333,7 +2333,7 @@ workflows:
           filters:
             branches:
               only: postnightly
-          docker_image: "soumith/conda-cuda"
+          docker_image: "pytorch/conda-cuda"
       - smoke_linux_test:
           name: smoke_linux_conda_2_7_cu92_devtoolset7_nightly
           build_environment: "conda 2.7 cu92 devtoolset7"
@@ -2344,7 +2344,7 @@ workflows:
           filters:
             branches:
               only: postnightly
-          docker_image: "soumith/conda-cuda"
+          docker_image: "pytorch/conda-cuda"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
@@ -2357,7 +2357,7 @@ workflows:
           filters:
             branches:
               only: postnightly
-          docker_image: "soumith/conda-cuda"
+          docker_image: "pytorch/conda-cuda"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
@@ -2370,7 +2370,7 @@ workflows:
           filters:
             branches:
               only: postnightly
-          docker_image: "soumith/conda-cuda"
+          docker_image: "pytorch/conda-cuda"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
@@ -2383,7 +2383,7 @@ workflows:
           filters:
             branches:
               only: postnightly
-          docker_image: "soumith/conda-cuda"
+          docker_image: "pytorch/conda-cuda"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
@@ -2396,7 +2396,7 @@ workflows:
           filters:
             branches:
               only: postnightly
-          docker_image: "soumith/conda-cuda"
+          docker_image: "pytorch/conda-cuda"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
@@ -2409,7 +2409,7 @@ workflows:
           filters:
             branches:
               only: postnightly
-          docker_image: "soumith/conda-cuda"
+          docker_image: "pytorch/conda-cuda"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
@@ -2422,7 +2422,7 @@ workflows:
           filters:
             branches:
               only: postnightly
-          docker_image: "soumith/conda-cuda"
+          docker_image: "pytorch/conda-cuda"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
@@ -2435,7 +2435,7 @@ workflows:
           filters:
             branches:
               only: postnightly
-          docker_image: "soumith/conda-cuda"
+          docker_image: "pytorch/conda-cuda"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
@@ -2448,7 +2448,7 @@ workflows:
           filters:
             branches:
               only: postnightly
-          docker_image: "soumith/conda-cuda"
+          docker_image: "pytorch/conda-cuda"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
@@ -2461,7 +2461,7 @@ workflows:
           filters:
             branches:
               only: postnightly
-          docker_image: "soumith/conda-cuda"
+          docker_image: "pytorch/conda-cuda"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
@@ -2474,7 +2474,7 @@ workflows:
           filters:
             branches:
               only: postnightly
-          docker_image: "soumith/conda-cuda"
+          docker_image: "pytorch/conda-cuda"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
@@ -2487,7 +2487,7 @@ workflows:
           filters:
             branches:
               only: postnightly
-          docker_image: "soumith/conda-cuda"
+          docker_image: "pytorch/conda-cuda"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
@@ -2501,7 +2501,7 @@ workflows:
             branches:
               only: postnightly
           libtorch_variant: "shared-with-deps"
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
       - smoke_linux_test:
           name: smoke_linux_libtorch_2_7m_cpu_devtoolset7_nightly_shared-without-deps
           build_environment: "libtorch 2.7m cpu devtoolset7"
@@ -2513,7 +2513,7 @@ workflows:
             branches:
               only: postnightly
           libtorch_variant: "shared-without-deps"
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
       - smoke_linux_test:
           name: smoke_linux_libtorch_2_7m_cpu_devtoolset7_nightly_static-with-deps
           build_environment: "libtorch 2.7m cpu devtoolset7"
@@ -2525,7 +2525,7 @@ workflows:
             branches:
               only: postnightly
           libtorch_variant: "static-with-deps"
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
       - smoke_linux_test:
           name: smoke_linux_libtorch_2_7m_cpu_devtoolset7_nightly_static-without-deps
           build_environment: "libtorch 2.7m cpu devtoolset7"
@@ -2537,7 +2537,7 @@ workflows:
             branches:
               only: postnightly
           libtorch_variant: "static-without-deps"
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
       - smoke_linux_test:
           name: smoke_linux_libtorch_2_7m_cu92_devtoolset7_nightly_shared-with-deps
           build_environment: "libtorch 2.7m cu92 devtoolset7"
@@ -2549,7 +2549,7 @@ workflows:
             branches:
               only: postnightly
           libtorch_variant: "shared-with-deps"
-          docker_image: "soumith/manylinux-cuda92"
+          docker_image: "pytorch/manylinux-cuda92"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
@@ -2563,7 +2563,7 @@ workflows:
             branches:
               only: postnightly
           libtorch_variant: "shared-without-deps"
-          docker_image: "soumith/manylinux-cuda92"
+          docker_image: "pytorch/manylinux-cuda92"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
@@ -2577,7 +2577,7 @@ workflows:
             branches:
               only: postnightly
           libtorch_variant: "static-with-deps"
-          docker_image: "soumith/manylinux-cuda92"
+          docker_image: "pytorch/manylinux-cuda92"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
@@ -2591,7 +2591,7 @@ workflows:
             branches:
               only: postnightly
           libtorch_variant: "static-without-deps"
-          docker_image: "soumith/manylinux-cuda92"
+          docker_image: "pytorch/manylinux-cuda92"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
@@ -2605,7 +2605,7 @@ workflows:
             branches:
               only: postnightly
           libtorch_variant: "shared-with-deps"
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
@@ -2619,7 +2619,7 @@ workflows:
             branches:
               only: postnightly
           libtorch_variant: "shared-without-deps"
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
@@ -2633,7 +2633,7 @@ workflows:
             branches:
               only: postnightly
           libtorch_variant: "static-with-deps"
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
@@ -2647,7 +2647,7 @@ workflows:
             branches:
               only: postnightly
           libtorch_variant: "static-without-deps"
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
@@ -2661,7 +2661,7 @@ workflows:
             branches:
               only: postnightly
           libtorch_variant: "shared-with-deps"
-          docker_image: "soumith/manylinux-cuda101"
+          docker_image: "pytorch/manylinux-cuda101"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
@@ -2675,7 +2675,7 @@ workflows:
             branches:
               only: postnightly
           libtorch_variant: "shared-without-deps"
-          docker_image: "soumith/manylinux-cuda101"
+          docker_image: "pytorch/manylinux-cuda101"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
@@ -2689,7 +2689,7 @@ workflows:
             branches:
               only: postnightly
           libtorch_variant: "static-with-deps"
-          docker_image: "soumith/manylinux-cuda101"
+          docker_image: "pytorch/manylinux-cuda101"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
@@ -2703,7 +2703,7 @@ workflows:
             branches:
               only: postnightly
           libtorch_variant: "static-without-deps"
-          docker_image: "soumith/manylinux-cuda101"
+          docker_image: "pytorch/manylinux-cuda101"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
@@ -2717,7 +2717,7 @@ workflows:
             branches:
               only: postnightly
           libtorch_variant: "shared-with-deps"
-          docker_image: "soumith/conda-cuda-cxx11-ubuntu1604:latest"
+          docker_image: "pytorch/conda-cuda-cxx11-ubuntu1604:latest"
       - smoke_linux_test:
           name: smoke_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_nightly_shared-without-deps
           build_environment: "libtorch 2.7m cpu gcc5.4_cxx11-abi"
@@ -2729,7 +2729,7 @@ workflows:
             branches:
               only: postnightly
           libtorch_variant: "shared-without-deps"
-          docker_image: "soumith/conda-cuda-cxx11-ubuntu1604:latest"
+          docker_image: "pytorch/conda-cuda-cxx11-ubuntu1604:latest"
       - smoke_linux_test:
           name: smoke_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_nightly_static-with-deps
           build_environment: "libtorch 2.7m cpu gcc5.4_cxx11-abi"
@@ -2741,7 +2741,7 @@ workflows:
             branches:
               only: postnightly
           libtorch_variant: "static-with-deps"
-          docker_image: "soumith/conda-cuda-cxx11-ubuntu1604:latest"
+          docker_image: "pytorch/conda-cuda-cxx11-ubuntu1604:latest"
       - smoke_linux_test:
           name: smoke_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_nightly_static-without-deps
           build_environment: "libtorch 2.7m cpu gcc5.4_cxx11-abi"
@@ -2753,7 +2753,7 @@ workflows:
             branches:
               only: postnightly
           libtorch_variant: "static-without-deps"
-          docker_image: "soumith/conda-cuda-cxx11-ubuntu1604:latest"
+          docker_image: "pytorch/conda-cuda-cxx11-ubuntu1604:latest"
       - smoke_linux_test:
           name: smoke_linux_libtorch_2_7m_cu92_gcc5_4_cxx11-abi_nightly_shared-with-deps
           build_environment: "libtorch 2.7m cu92 gcc5.4_cxx11-abi"
@@ -2765,7 +2765,7 @@ workflows:
             branches:
               only: postnightly
           libtorch_variant: "shared-with-deps"
-          docker_image: "soumith/conda-cuda-cxx11-ubuntu1604:latest"
+          docker_image: "pytorch/conda-cuda-cxx11-ubuntu1604:latest"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
@@ -2779,7 +2779,7 @@ workflows:
             branches:
               only: postnightly
           libtorch_variant: "shared-without-deps"
-          docker_image: "soumith/conda-cuda-cxx11-ubuntu1604:latest"
+          docker_image: "pytorch/conda-cuda-cxx11-ubuntu1604:latest"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
@@ -2793,7 +2793,7 @@ workflows:
             branches:
               only: postnightly
           libtorch_variant: "static-with-deps"
-          docker_image: "soumith/conda-cuda-cxx11-ubuntu1604:latest"
+          docker_image: "pytorch/conda-cuda-cxx11-ubuntu1604:latest"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
@@ -2807,7 +2807,7 @@ workflows:
             branches:
               only: postnightly
           libtorch_variant: "static-without-deps"
-          docker_image: "soumith/conda-cuda-cxx11-ubuntu1604:latest"
+          docker_image: "pytorch/conda-cuda-cxx11-ubuntu1604:latest"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
@@ -2821,7 +2821,7 @@ workflows:
             branches:
               only: postnightly
           libtorch_variant: "shared-with-deps"
-          docker_image: "soumith/conda-cuda-cxx11-ubuntu1604:latest"
+          docker_image: "pytorch/conda-cuda-cxx11-ubuntu1604:latest"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
@@ -2835,7 +2835,7 @@ workflows:
             branches:
               only: postnightly
           libtorch_variant: "shared-without-deps"
-          docker_image: "soumith/conda-cuda-cxx11-ubuntu1604:latest"
+          docker_image: "pytorch/conda-cuda-cxx11-ubuntu1604:latest"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
@@ -2849,7 +2849,7 @@ workflows:
             branches:
               only: postnightly
           libtorch_variant: "static-with-deps"
-          docker_image: "soumith/conda-cuda-cxx11-ubuntu1604:latest"
+          docker_image: "pytorch/conda-cuda-cxx11-ubuntu1604:latest"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
@@ -2863,7 +2863,7 @@ workflows:
             branches:
               only: postnightly
           libtorch_variant: "static-without-deps"
-          docker_image: "soumith/conda-cuda-cxx11-ubuntu1604:latest"
+          docker_image: "pytorch/conda-cuda-cxx11-ubuntu1604:latest"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
@@ -2877,7 +2877,7 @@ workflows:
             branches:
               only: postnightly
           libtorch_variant: "shared-with-deps"
-          docker_image: "soumith/conda-cuda-cxx11-ubuntu1604:latest"
+          docker_image: "pytorch/conda-cuda-cxx11-ubuntu1604:latest"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
@@ -2891,7 +2891,7 @@ workflows:
             branches:
               only: postnightly
           libtorch_variant: "shared-without-deps"
-          docker_image: "soumith/conda-cuda-cxx11-ubuntu1604:latest"
+          docker_image: "pytorch/conda-cuda-cxx11-ubuntu1604:latest"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
@@ -2905,7 +2905,7 @@ workflows:
             branches:
               only: postnightly
           libtorch_variant: "static-with-deps"
-          docker_image: "soumith/conda-cuda-cxx11-ubuntu1604:latest"
+          docker_image: "pytorch/conda-cuda-cxx11-ubuntu1604:latest"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
@@ -2919,7 +2919,7 @@ workflows:
             branches:
               only: postnightly
           libtorch_variant: "static-without-deps"
-          docker_image: "soumith/conda-cuda-cxx11-ubuntu1604:latest"
+          docker_image: "pytorch/conda-cuda-cxx11-ubuntu1604:latest"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_mac_test:
@@ -3020,7 +3020,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
       - binary_linux_build:
           name: binary_linux_manywheel_2_7mu_cpu_devtoolset7_nightly_build
           build_environment: "manywheel 2.7mu cpu devtoolset7"
@@ -3029,7 +3029,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
       - binary_linux_build:
           name: binary_linux_manywheel_3_5m_cpu_devtoolset7_nightly_build
           build_environment: "manywheel 3.5m cpu devtoolset7"
@@ -3038,7 +3038,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
       - binary_linux_build:
           name: binary_linux_manywheel_3_6m_cpu_devtoolset7_nightly_build
           build_environment: "manywheel 3.6m cpu devtoolset7"
@@ -3047,7 +3047,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
       - binary_linux_build:
           name: binary_linux_manywheel_3_7m_cpu_devtoolset7_nightly_build
           build_environment: "manywheel 3.7m cpu devtoolset7"
@@ -3056,7 +3056,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
       - binary_linux_build:
           name: binary_linux_manywheel_2_7m_cu92_devtoolset7_nightly_build
           build_environment: "manywheel 2.7m cu92 devtoolset7"
@@ -3065,7 +3065,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/manylinux-cuda92"
+          docker_image: "pytorch/manylinux-cuda92"
       - binary_linux_build:
           name: binary_linux_manywheel_2_7mu_cu92_devtoolset7_nightly_build
           build_environment: "manywheel 2.7mu cu92 devtoolset7"
@@ -3074,7 +3074,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/manylinux-cuda92"
+          docker_image: "pytorch/manylinux-cuda92"
       - binary_linux_build:
           name: binary_linux_manywheel_3_5m_cu92_devtoolset7_nightly_build
           build_environment: "manywheel 3.5m cu92 devtoolset7"
@@ -3083,7 +3083,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/manylinux-cuda92"
+          docker_image: "pytorch/manylinux-cuda92"
       - binary_linux_build:
           name: binary_linux_manywheel_3_6m_cu92_devtoolset7_nightly_build
           build_environment: "manywheel 3.6m cu92 devtoolset7"
@@ -3092,7 +3092,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/manylinux-cuda92"
+          docker_image: "pytorch/manylinux-cuda92"
       - binary_linux_build:
           name: binary_linux_manywheel_3_7m_cu92_devtoolset7_nightly_build
           build_environment: "manywheel 3.7m cu92 devtoolset7"
@@ -3101,7 +3101,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/manylinux-cuda92"
+          docker_image: "pytorch/manylinux-cuda92"
       - binary_linux_build:
           name: binary_linux_manywheel_2_7m_cu100_devtoolset7_nightly_build
           build_environment: "manywheel 2.7m cu100 devtoolset7"
@@ -3110,7 +3110,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
       - binary_linux_build:
           name: binary_linux_manywheel_2_7mu_cu100_devtoolset7_nightly_build
           build_environment: "manywheel 2.7mu cu100 devtoolset7"
@@ -3119,7 +3119,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
       - binary_linux_build:
           name: binary_linux_manywheel_3_5m_cu100_devtoolset7_nightly_build
           build_environment: "manywheel 3.5m cu100 devtoolset7"
@@ -3128,7 +3128,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
       - binary_linux_build:
           name: binary_linux_manywheel_3_6m_cu100_devtoolset7_nightly_build
           build_environment: "manywheel 3.6m cu100 devtoolset7"
@@ -3137,7 +3137,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
       - binary_linux_build:
           name: binary_linux_manywheel_3_7m_cu100_devtoolset7_nightly_build
           build_environment: "manywheel 3.7m cu100 devtoolset7"
@@ -3146,7 +3146,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
       - binary_linux_build:
           name: binary_linux_manywheel_2_7m_cu101_devtoolset7_nightly_build
           build_environment: "manywheel 2.7m cu101 devtoolset7"
@@ -3155,7 +3155,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/manylinux-cuda101"
+          docker_image: "pytorch/manylinux-cuda101"
       - binary_linux_build:
           name: binary_linux_manywheel_2_7mu_cu101_devtoolset7_nightly_build
           build_environment: "manywheel 2.7mu cu101 devtoolset7"
@@ -3164,7 +3164,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/manylinux-cuda101"
+          docker_image: "pytorch/manylinux-cuda101"
       - binary_linux_build:
           name: binary_linux_manywheel_3_5m_cu101_devtoolset7_nightly_build
           build_environment: "manywheel 3.5m cu101 devtoolset7"
@@ -3173,7 +3173,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/manylinux-cuda101"
+          docker_image: "pytorch/manylinux-cuda101"
       - binary_linux_build:
           name: binary_linux_manywheel_3_6m_cu101_devtoolset7_nightly_build
           build_environment: "manywheel 3.6m cu101 devtoolset7"
@@ -3182,7 +3182,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/manylinux-cuda101"
+          docker_image: "pytorch/manylinux-cuda101"
       - binary_linux_build:
           name: binary_linux_manywheel_3_7m_cu101_devtoolset7_nightly_build
           build_environment: "manywheel 3.7m cu101 devtoolset7"
@@ -3191,7 +3191,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/manylinux-cuda101"
+          docker_image: "pytorch/manylinux-cuda101"
       - binary_linux_build:
           name: binary_linux_conda_2_7_cpu_devtoolset7_nightly_build
           build_environment: "conda 2.7 cpu devtoolset7"
@@ -3200,7 +3200,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/conda-cuda"
+          docker_image: "pytorch/conda-cuda"
       - binary_linux_build:
           name: binary_linux_conda_3_5_cpu_devtoolset7_nightly_build
           build_environment: "conda 3.5 cpu devtoolset7"
@@ -3209,7 +3209,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/conda-cuda"
+          docker_image: "pytorch/conda-cuda"
       - binary_linux_build:
           name: binary_linux_conda_3_6_cpu_devtoolset7_nightly_build
           build_environment: "conda 3.6 cpu devtoolset7"
@@ -3218,7 +3218,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/conda-cuda"
+          docker_image: "pytorch/conda-cuda"
       - binary_linux_build:
           name: binary_linux_conda_3_7_cpu_devtoolset7_nightly_build
           build_environment: "conda 3.7 cpu devtoolset7"
@@ -3227,7 +3227,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/conda-cuda"
+          docker_image: "pytorch/conda-cuda"
       - binary_linux_build:
           name: binary_linux_conda_2_7_cu92_devtoolset7_nightly_build
           build_environment: "conda 2.7 cu92 devtoolset7"
@@ -3236,7 +3236,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/conda-cuda"
+          docker_image: "pytorch/conda-cuda"
       - binary_linux_build:
           name: binary_linux_conda_3_5_cu92_devtoolset7_nightly_build
           build_environment: "conda 3.5 cu92 devtoolset7"
@@ -3245,7 +3245,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/conda-cuda"
+          docker_image: "pytorch/conda-cuda"
       - binary_linux_build:
           name: binary_linux_conda_3_6_cu92_devtoolset7_nightly_build
           build_environment: "conda 3.6 cu92 devtoolset7"
@@ -3254,7 +3254,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/conda-cuda"
+          docker_image: "pytorch/conda-cuda"
       - binary_linux_build:
           name: binary_linux_conda_3_7_cu92_devtoolset7_nightly_build
           build_environment: "conda 3.7 cu92 devtoolset7"
@@ -3263,7 +3263,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/conda-cuda"
+          docker_image: "pytorch/conda-cuda"
       - binary_linux_build:
           name: binary_linux_conda_2_7_cu100_devtoolset7_nightly_build
           build_environment: "conda 2.7 cu100 devtoolset7"
@@ -3272,7 +3272,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/conda-cuda"
+          docker_image: "pytorch/conda-cuda"
       - binary_linux_build:
           name: binary_linux_conda_3_5_cu100_devtoolset7_nightly_build
           build_environment: "conda 3.5 cu100 devtoolset7"
@@ -3281,7 +3281,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/conda-cuda"
+          docker_image: "pytorch/conda-cuda"
       - binary_linux_build:
           name: binary_linux_conda_3_6_cu100_devtoolset7_nightly_build
           build_environment: "conda 3.6 cu100 devtoolset7"
@@ -3290,7 +3290,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/conda-cuda"
+          docker_image: "pytorch/conda-cuda"
       - binary_linux_build:
           name: binary_linux_conda_3_7_cu100_devtoolset7_nightly_build
           build_environment: "conda 3.7 cu100 devtoolset7"
@@ -3299,7 +3299,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/conda-cuda"
+          docker_image: "pytorch/conda-cuda"
       - binary_linux_build:
           name: binary_linux_conda_2_7_cu101_devtoolset7_nightly_build
           build_environment: "conda 2.7 cu101 devtoolset7"
@@ -3308,7 +3308,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/conda-cuda"
+          docker_image: "pytorch/conda-cuda"
       - binary_linux_build:
           name: binary_linux_conda_3_5_cu101_devtoolset7_nightly_build
           build_environment: "conda 3.5 cu101 devtoolset7"
@@ -3317,7 +3317,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/conda-cuda"
+          docker_image: "pytorch/conda-cuda"
       - binary_linux_build:
           name: binary_linux_conda_3_6_cu101_devtoolset7_nightly_build
           build_environment: "conda 3.6 cu101 devtoolset7"
@@ -3326,7 +3326,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/conda-cuda"
+          docker_image: "pytorch/conda-cuda"
       - binary_linux_build:
           name: binary_linux_conda_3_7_cu101_devtoolset7_nightly_build
           build_environment: "conda 3.7 cu101 devtoolset7"
@@ -3335,7 +3335,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/conda-cuda"
+          docker_image: "pytorch/conda-cuda"
       - binary_linux_build:
           name: binary_linux_libtorch_2_7m_cpu_devtoolset7_nightly_shared-with-deps_build
           build_environment: "libtorch 2.7m cpu devtoolset7"
@@ -3345,7 +3345,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "shared-with-deps"
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
       - binary_linux_build:
           name: binary_linux_libtorch_2_7m_cpu_devtoolset7_nightly_shared-without-deps_build
           build_environment: "libtorch 2.7m cpu devtoolset7"
@@ -3355,7 +3355,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "shared-without-deps"
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
       - binary_linux_build:
           name: binary_linux_libtorch_2_7m_cpu_devtoolset7_nightly_static-with-deps_build
           build_environment: "libtorch 2.7m cpu devtoolset7"
@@ -3365,7 +3365,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "static-with-deps"
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
       - binary_linux_build:
           name: binary_linux_libtorch_2_7m_cpu_devtoolset7_nightly_static-without-deps_build
           build_environment: "libtorch 2.7m cpu devtoolset7"
@@ -3375,7 +3375,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "static-without-deps"
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
       - binary_linux_build:
           name: binary_linux_libtorch_2_7m_cu92_devtoolset7_nightly_shared-with-deps_build
           build_environment: "libtorch 2.7m cu92 devtoolset7"
@@ -3385,7 +3385,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "shared-with-deps"
-          docker_image: "soumith/manylinux-cuda92"
+          docker_image: "pytorch/manylinux-cuda92"
       - binary_linux_build:
           name: binary_linux_libtorch_2_7m_cu92_devtoolset7_nightly_shared-without-deps_build
           build_environment: "libtorch 2.7m cu92 devtoolset7"
@@ -3395,7 +3395,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "shared-without-deps"
-          docker_image: "soumith/manylinux-cuda92"
+          docker_image: "pytorch/manylinux-cuda92"
       - binary_linux_build:
           name: binary_linux_libtorch_2_7m_cu92_devtoolset7_nightly_static-with-deps_build
           build_environment: "libtorch 2.7m cu92 devtoolset7"
@@ -3405,7 +3405,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "static-with-deps"
-          docker_image: "soumith/manylinux-cuda92"
+          docker_image: "pytorch/manylinux-cuda92"
       - binary_linux_build:
           name: binary_linux_libtorch_2_7m_cu92_devtoolset7_nightly_static-without-deps_build
           build_environment: "libtorch 2.7m cu92 devtoolset7"
@@ -3415,7 +3415,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "static-without-deps"
-          docker_image: "soumith/manylinux-cuda92"
+          docker_image: "pytorch/manylinux-cuda92"
       - binary_linux_build:
           name: binary_linux_libtorch_2_7m_cu100_devtoolset7_nightly_shared-with-deps_build
           build_environment: "libtorch 2.7m cu100 devtoolset7"
@@ -3425,7 +3425,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "shared-with-deps"
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
       - binary_linux_build:
           name: binary_linux_libtorch_2_7m_cu100_devtoolset7_nightly_shared-without-deps_build
           build_environment: "libtorch 2.7m cu100 devtoolset7"
@@ -3435,7 +3435,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "shared-without-deps"
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
       - binary_linux_build:
           name: binary_linux_libtorch_2_7m_cu100_devtoolset7_nightly_static-with-deps_build
           build_environment: "libtorch 2.7m cu100 devtoolset7"
@@ -3445,7 +3445,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "static-with-deps"
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
       - binary_linux_build:
           name: binary_linux_libtorch_2_7m_cu100_devtoolset7_nightly_static-without-deps_build
           build_environment: "libtorch 2.7m cu100 devtoolset7"
@@ -3455,7 +3455,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "static-without-deps"
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
       - binary_linux_build:
           name: binary_linux_libtorch_2_7m_cu101_devtoolset7_nightly_shared-with-deps_build
           build_environment: "libtorch 2.7m cu101 devtoolset7"
@@ -3465,7 +3465,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "shared-with-deps"
-          docker_image: "soumith/manylinux-cuda101"
+          docker_image: "pytorch/manylinux-cuda101"
       - binary_linux_build:
           name: binary_linux_libtorch_2_7m_cu101_devtoolset7_nightly_shared-without-deps_build
           build_environment: "libtorch 2.7m cu101 devtoolset7"
@@ -3475,7 +3475,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "shared-without-deps"
-          docker_image: "soumith/manylinux-cuda101"
+          docker_image: "pytorch/manylinux-cuda101"
       - binary_linux_build:
           name: binary_linux_libtorch_2_7m_cu101_devtoolset7_nightly_static-with-deps_build
           build_environment: "libtorch 2.7m cu101 devtoolset7"
@@ -3485,7 +3485,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "static-with-deps"
-          docker_image: "soumith/manylinux-cuda101"
+          docker_image: "pytorch/manylinux-cuda101"
       - binary_linux_build:
           name: binary_linux_libtorch_2_7m_cu101_devtoolset7_nightly_static-without-deps_build
           build_environment: "libtorch 2.7m cu101 devtoolset7"
@@ -3495,7 +3495,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "static-without-deps"
-          docker_image: "soumith/manylinux-cuda101"
+          docker_image: "pytorch/manylinux-cuda101"
       - binary_linux_build:
           name: binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_nightly_shared-with-deps_build
           build_environment: "libtorch 2.7m cpu gcc5.4_cxx11-abi"
@@ -3505,7 +3505,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "shared-with-deps"
-          docker_image: "soumith/conda-cuda-cxx11-ubuntu1604:latest"
+          docker_image: "pytorch/conda-cuda-cxx11-ubuntu1604:latest"
       - binary_linux_build:
           name: binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_nightly_shared-without-deps_build
           build_environment: "libtorch 2.7m cpu gcc5.4_cxx11-abi"
@@ -3515,7 +3515,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "shared-without-deps"
-          docker_image: "soumith/conda-cuda-cxx11-ubuntu1604:latest"
+          docker_image: "pytorch/conda-cuda-cxx11-ubuntu1604:latest"
       - binary_linux_build:
           name: binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_nightly_static-with-deps_build
           build_environment: "libtorch 2.7m cpu gcc5.4_cxx11-abi"
@@ -3525,7 +3525,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "static-with-deps"
-          docker_image: "soumith/conda-cuda-cxx11-ubuntu1604:latest"
+          docker_image: "pytorch/conda-cuda-cxx11-ubuntu1604:latest"
       - binary_linux_build:
           name: binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_nightly_static-without-deps_build
           build_environment: "libtorch 2.7m cpu gcc5.4_cxx11-abi"
@@ -3535,7 +3535,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "static-without-deps"
-          docker_image: "soumith/conda-cuda-cxx11-ubuntu1604:latest"
+          docker_image: "pytorch/conda-cuda-cxx11-ubuntu1604:latest"
       - binary_linux_build:
           name: binary_linux_libtorch_2_7m_cu92_gcc5_4_cxx11-abi_nightly_shared-with-deps_build
           build_environment: "libtorch 2.7m cu92 gcc5.4_cxx11-abi"
@@ -3545,7 +3545,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "shared-with-deps"
-          docker_image: "soumith/conda-cuda-cxx11-ubuntu1604:latest"
+          docker_image: "pytorch/conda-cuda-cxx11-ubuntu1604:latest"
       - binary_linux_build:
           name: binary_linux_libtorch_2_7m_cu92_gcc5_4_cxx11-abi_nightly_shared-without-deps_build
           build_environment: "libtorch 2.7m cu92 gcc5.4_cxx11-abi"
@@ -3555,7 +3555,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "shared-without-deps"
-          docker_image: "soumith/conda-cuda-cxx11-ubuntu1604:latest"
+          docker_image: "pytorch/conda-cuda-cxx11-ubuntu1604:latest"
       - binary_linux_build:
           name: binary_linux_libtorch_2_7m_cu92_gcc5_4_cxx11-abi_nightly_static-with-deps_build
           build_environment: "libtorch 2.7m cu92 gcc5.4_cxx11-abi"
@@ -3565,7 +3565,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "static-with-deps"
-          docker_image: "soumith/conda-cuda-cxx11-ubuntu1604:latest"
+          docker_image: "pytorch/conda-cuda-cxx11-ubuntu1604:latest"
       - binary_linux_build:
           name: binary_linux_libtorch_2_7m_cu92_gcc5_4_cxx11-abi_nightly_static-without-deps_build
           build_environment: "libtorch 2.7m cu92 gcc5.4_cxx11-abi"
@@ -3575,7 +3575,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "static-without-deps"
-          docker_image: "soumith/conda-cuda-cxx11-ubuntu1604:latest"
+          docker_image: "pytorch/conda-cuda-cxx11-ubuntu1604:latest"
       - binary_linux_build:
           name: binary_linux_libtorch_2_7m_cu100_gcc5_4_cxx11-abi_nightly_shared-with-deps_build
           build_environment: "libtorch 2.7m cu100 gcc5.4_cxx11-abi"
@@ -3585,7 +3585,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "shared-with-deps"
-          docker_image: "soumith/conda-cuda-cxx11-ubuntu1604:latest"
+          docker_image: "pytorch/conda-cuda-cxx11-ubuntu1604:latest"
       - binary_linux_build:
           name: binary_linux_libtorch_2_7m_cu100_gcc5_4_cxx11-abi_nightly_shared-without-deps_build
           build_environment: "libtorch 2.7m cu100 gcc5.4_cxx11-abi"
@@ -3595,7 +3595,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "shared-without-deps"
-          docker_image: "soumith/conda-cuda-cxx11-ubuntu1604:latest"
+          docker_image: "pytorch/conda-cuda-cxx11-ubuntu1604:latest"
       - binary_linux_build:
           name: binary_linux_libtorch_2_7m_cu100_gcc5_4_cxx11-abi_nightly_static-with-deps_build
           build_environment: "libtorch 2.7m cu100 gcc5.4_cxx11-abi"
@@ -3605,7 +3605,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "static-with-deps"
-          docker_image: "soumith/conda-cuda-cxx11-ubuntu1604:latest"
+          docker_image: "pytorch/conda-cuda-cxx11-ubuntu1604:latest"
       - binary_linux_build:
           name: binary_linux_libtorch_2_7m_cu100_gcc5_4_cxx11-abi_nightly_static-without-deps_build
           build_environment: "libtorch 2.7m cu100 gcc5.4_cxx11-abi"
@@ -3615,7 +3615,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "static-without-deps"
-          docker_image: "soumith/conda-cuda-cxx11-ubuntu1604:latest"
+          docker_image: "pytorch/conda-cuda-cxx11-ubuntu1604:latest"
       - binary_linux_build:
           name: binary_linux_libtorch_2_7m_cu101_gcc5_4_cxx11-abi_nightly_shared-with-deps_build
           build_environment: "libtorch 2.7m cu101 gcc5.4_cxx11-abi"
@@ -3625,7 +3625,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "shared-with-deps"
-          docker_image: "soumith/conda-cuda-cxx11-ubuntu1604:latest"
+          docker_image: "pytorch/conda-cuda-cxx11-ubuntu1604:latest"
       - binary_linux_build:
           name: binary_linux_libtorch_2_7m_cu101_gcc5_4_cxx11-abi_nightly_shared-without-deps_build
           build_environment: "libtorch 2.7m cu101 gcc5.4_cxx11-abi"
@@ -3635,7 +3635,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "shared-without-deps"
-          docker_image: "soumith/conda-cuda-cxx11-ubuntu1604:latest"
+          docker_image: "pytorch/conda-cuda-cxx11-ubuntu1604:latest"
       - binary_linux_build:
           name: binary_linux_libtorch_2_7m_cu101_gcc5_4_cxx11-abi_nightly_static-with-deps_build
           build_environment: "libtorch 2.7m cu101 gcc5.4_cxx11-abi"
@@ -3645,7 +3645,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "static-with-deps"
-          docker_image: "soumith/conda-cuda-cxx11-ubuntu1604:latest"
+          docker_image: "pytorch/conda-cuda-cxx11-ubuntu1604:latest"
       - binary_linux_build:
           name: binary_linux_libtorch_2_7m_cu101_gcc5_4_cxx11-abi_nightly_static-without-deps_build
           build_environment: "libtorch 2.7m cu101 gcc5.4_cxx11-abi"
@@ -3655,7 +3655,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "static-without-deps"
-          docker_image: "soumith/conda-cuda-cxx11-ubuntu1604:latest"
+          docker_image: "pytorch/conda-cuda-cxx11-ubuntu1604:latest"
       - binary_mac_build:
           name: binary_macos_wheel_2_7_cpu_nightly_build
           build_environment: "wheel 2.7 cpu"
@@ -3829,7 +3829,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
       - binary_linux_test:
           name: binary_linux_manywheel_2_7mu_cpu_devtoolset7_nightly_test
           build_environment: "manywheel 2.7mu cpu devtoolset7"
@@ -3839,7 +3839,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
       - binary_linux_test:
           name: binary_linux_manywheel_3_5m_cpu_devtoolset7_nightly_test
           build_environment: "manywheel 3.5m cpu devtoolset7"
@@ -3849,7 +3849,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
       - binary_linux_test:
           name: binary_linux_manywheel_3_6m_cpu_devtoolset7_nightly_test
           build_environment: "manywheel 3.6m cpu devtoolset7"
@@ -3859,7 +3859,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
       - binary_linux_test:
           name: binary_linux_manywheel_3_7m_cpu_devtoolset7_nightly_test
           build_environment: "manywheel 3.7m cpu devtoolset7"
@@ -3869,7 +3869,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
       - binary_linux_test:
           name: binary_linux_manywheel_2_7m_cu92_devtoolset7_nightly_test
           build_environment: "manywheel 2.7m cu92 devtoolset7"
@@ -3879,7 +3879,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/manylinux-cuda92"
+          docker_image: "pytorch/manylinux-cuda92"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
@@ -3891,7 +3891,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/manylinux-cuda92"
+          docker_image: "pytorch/manylinux-cuda92"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
@@ -3903,7 +3903,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/manylinux-cuda92"
+          docker_image: "pytorch/manylinux-cuda92"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
@@ -3915,7 +3915,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/manylinux-cuda92"
+          docker_image: "pytorch/manylinux-cuda92"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
@@ -3927,7 +3927,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/manylinux-cuda92"
+          docker_image: "pytorch/manylinux-cuda92"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
@@ -3939,7 +3939,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
@@ -3951,7 +3951,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
@@ -3963,7 +3963,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
@@ -3975,7 +3975,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
@@ -3987,7 +3987,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
@@ -3999,7 +3999,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/manylinux-cuda101"
+          docker_image: "pytorch/manylinux-cuda101"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
@@ -4011,7 +4011,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/manylinux-cuda101"
+          docker_image: "pytorch/manylinux-cuda101"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
@@ -4023,7 +4023,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/manylinux-cuda101"
+          docker_image: "pytorch/manylinux-cuda101"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
@@ -4035,7 +4035,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/manylinux-cuda101"
+          docker_image: "pytorch/manylinux-cuda101"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
@@ -4047,7 +4047,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/manylinux-cuda101"
+          docker_image: "pytorch/manylinux-cuda101"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
@@ -4059,7 +4059,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/conda-cuda"
+          docker_image: "pytorch/conda-cuda"
       - binary_linux_test:
           name: binary_linux_conda_3_5_cpu_devtoolset7_nightly_test
           build_environment: "conda 3.5 cpu devtoolset7"
@@ -4069,7 +4069,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/conda-cuda"
+          docker_image: "pytorch/conda-cuda"
       - binary_linux_test:
           name: binary_linux_conda_3_6_cpu_devtoolset7_nightly_test
           build_environment: "conda 3.6 cpu devtoolset7"
@@ -4079,7 +4079,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/conda-cuda"
+          docker_image: "pytorch/conda-cuda"
       - binary_linux_test:
           name: binary_linux_conda_3_7_cpu_devtoolset7_nightly_test
           build_environment: "conda 3.7 cpu devtoolset7"
@@ -4089,7 +4089,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/conda-cuda"
+          docker_image: "pytorch/conda-cuda"
       - binary_linux_test:
           name: binary_linux_conda_2_7_cu92_devtoolset7_nightly_test
           build_environment: "conda 2.7 cu92 devtoolset7"
@@ -4099,7 +4099,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/conda-cuda"
+          docker_image: "pytorch/conda-cuda"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
@@ -4111,7 +4111,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/conda-cuda"
+          docker_image: "pytorch/conda-cuda"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
@@ -4123,7 +4123,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/conda-cuda"
+          docker_image: "pytorch/conda-cuda"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
@@ -4135,7 +4135,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/conda-cuda"
+          docker_image: "pytorch/conda-cuda"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
@@ -4147,7 +4147,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/conda-cuda"
+          docker_image: "pytorch/conda-cuda"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
@@ -4159,7 +4159,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/conda-cuda"
+          docker_image: "pytorch/conda-cuda"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
@@ -4171,7 +4171,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/conda-cuda"
+          docker_image: "pytorch/conda-cuda"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
@@ -4183,7 +4183,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/conda-cuda"
+          docker_image: "pytorch/conda-cuda"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
@@ -4195,7 +4195,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/conda-cuda"
+          docker_image: "pytorch/conda-cuda"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
@@ -4207,7 +4207,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/conda-cuda"
+          docker_image: "pytorch/conda-cuda"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
@@ -4219,7 +4219,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/conda-cuda"
+          docker_image: "pytorch/conda-cuda"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
@@ -4231,7 +4231,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "soumith/conda-cuda"
+          docker_image: "pytorch/conda-cuda"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
@@ -4244,7 +4244,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "shared-with-deps"
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
       - binary_linux_test:
           name: binary_linux_libtorch_2_7m_cpu_devtoolset7_nightly_shared-without-deps_test
           build_environment: "libtorch 2.7m cpu devtoolset7"
@@ -4255,7 +4255,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "shared-without-deps"
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
       - binary_linux_test:
           name: binary_linux_libtorch_2_7m_cpu_devtoolset7_nightly_static-with-deps_test
           build_environment: "libtorch 2.7m cpu devtoolset7"
@@ -4266,7 +4266,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "static-with-deps"
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
       - binary_linux_test:
           name: binary_linux_libtorch_2_7m_cpu_devtoolset7_nightly_static-without-deps_test
           build_environment: "libtorch 2.7m cpu devtoolset7"
@@ -4277,7 +4277,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "static-without-deps"
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
       - binary_linux_test:
           name: binary_linux_libtorch_2_7m_cu92_devtoolset7_nightly_shared-with-deps_test
           build_environment: "libtorch 2.7m cu92 devtoolset7"
@@ -4288,7 +4288,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "shared-with-deps"
-          docker_image: "soumith/manylinux-cuda92"
+          docker_image: "pytorch/manylinux-cuda92"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
@@ -4301,7 +4301,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "shared-without-deps"
-          docker_image: "soumith/manylinux-cuda92"
+          docker_image: "pytorch/manylinux-cuda92"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
@@ -4314,7 +4314,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "static-with-deps"
-          docker_image: "soumith/manylinux-cuda92"
+          docker_image: "pytorch/manylinux-cuda92"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
@@ -4327,7 +4327,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "static-without-deps"
-          docker_image: "soumith/manylinux-cuda92"
+          docker_image: "pytorch/manylinux-cuda92"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
@@ -4340,7 +4340,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "shared-with-deps"
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
@@ -4353,7 +4353,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "shared-without-deps"
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
@@ -4366,7 +4366,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "static-with-deps"
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
@@ -4379,7 +4379,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "static-without-deps"
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
@@ -4392,7 +4392,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "shared-with-deps"
-          docker_image: "soumith/manylinux-cuda101"
+          docker_image: "pytorch/manylinux-cuda101"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
@@ -4405,7 +4405,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "shared-without-deps"
-          docker_image: "soumith/manylinux-cuda101"
+          docker_image: "pytorch/manylinux-cuda101"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
@@ -4418,7 +4418,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "static-with-deps"
-          docker_image: "soumith/manylinux-cuda101"
+          docker_image: "pytorch/manylinux-cuda101"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
@@ -4431,7 +4431,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "static-without-deps"
-          docker_image: "soumith/manylinux-cuda101"
+          docker_image: "pytorch/manylinux-cuda101"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
@@ -4444,7 +4444,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "shared-with-deps"
-          docker_image: "soumith/conda-cuda-cxx11-ubuntu1604:latest"
+          docker_image: "pytorch/conda-cuda-cxx11-ubuntu1604:latest"
       - binary_linux_test:
           name: binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_nightly_shared-without-deps_test
           build_environment: "libtorch 2.7m cpu gcc5.4_cxx11-abi"
@@ -4455,7 +4455,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "shared-without-deps"
-          docker_image: "soumith/conda-cuda-cxx11-ubuntu1604:latest"
+          docker_image: "pytorch/conda-cuda-cxx11-ubuntu1604:latest"
       - binary_linux_test:
           name: binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_nightly_static-with-deps_test
           build_environment: "libtorch 2.7m cpu gcc5.4_cxx11-abi"
@@ -4466,7 +4466,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "static-with-deps"
-          docker_image: "soumith/conda-cuda-cxx11-ubuntu1604:latest"
+          docker_image: "pytorch/conda-cuda-cxx11-ubuntu1604:latest"
       - binary_linux_test:
           name: binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_nightly_static-without-deps_test
           build_environment: "libtorch 2.7m cpu gcc5.4_cxx11-abi"
@@ -4477,7 +4477,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "static-without-deps"
-          docker_image: "soumith/conda-cuda-cxx11-ubuntu1604:latest"
+          docker_image: "pytorch/conda-cuda-cxx11-ubuntu1604:latest"
       - binary_linux_test:
           name: binary_linux_libtorch_2_7m_cu92_gcc5_4_cxx11-abi_nightly_shared-with-deps_test
           build_environment: "libtorch 2.7m cu92 gcc5.4_cxx11-abi"
@@ -4488,7 +4488,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "shared-with-deps"
-          docker_image: "soumith/conda-cuda-cxx11-ubuntu1604:latest"
+          docker_image: "pytorch/conda-cuda-cxx11-ubuntu1604:latest"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
@@ -4501,7 +4501,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "shared-without-deps"
-          docker_image: "soumith/conda-cuda-cxx11-ubuntu1604:latest"
+          docker_image: "pytorch/conda-cuda-cxx11-ubuntu1604:latest"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
@@ -4514,7 +4514,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "static-with-deps"
-          docker_image: "soumith/conda-cuda-cxx11-ubuntu1604:latest"
+          docker_image: "pytorch/conda-cuda-cxx11-ubuntu1604:latest"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
@@ -4527,7 +4527,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "static-without-deps"
-          docker_image: "soumith/conda-cuda-cxx11-ubuntu1604:latest"
+          docker_image: "pytorch/conda-cuda-cxx11-ubuntu1604:latest"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
@@ -4540,7 +4540,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "shared-with-deps"
-          docker_image: "soumith/conda-cuda-cxx11-ubuntu1604:latest"
+          docker_image: "pytorch/conda-cuda-cxx11-ubuntu1604:latest"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
@@ -4553,7 +4553,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "shared-without-deps"
-          docker_image: "soumith/conda-cuda-cxx11-ubuntu1604:latest"
+          docker_image: "pytorch/conda-cuda-cxx11-ubuntu1604:latest"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
@@ -4566,7 +4566,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "static-with-deps"
-          docker_image: "soumith/conda-cuda-cxx11-ubuntu1604:latest"
+          docker_image: "pytorch/conda-cuda-cxx11-ubuntu1604:latest"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
@@ -4579,7 +4579,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "static-without-deps"
-          docker_image: "soumith/conda-cuda-cxx11-ubuntu1604:latest"
+          docker_image: "pytorch/conda-cuda-cxx11-ubuntu1604:latest"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
@@ -4592,7 +4592,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "shared-with-deps"
-          docker_image: "soumith/conda-cuda-cxx11-ubuntu1604:latest"
+          docker_image: "pytorch/conda-cuda-cxx11-ubuntu1604:latest"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
@@ -4605,7 +4605,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "shared-without-deps"
-          docker_image: "soumith/conda-cuda-cxx11-ubuntu1604:latest"
+          docker_image: "pytorch/conda-cuda-cxx11-ubuntu1604:latest"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
@@ -4618,7 +4618,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "static-with-deps"
-          docker_image: "soumith/conda-cuda-cxx11-ubuntu1604:latest"
+          docker_image: "pytorch/conda-cuda-cxx11-ubuntu1604:latest"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
@@ -4631,7 +4631,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "static-without-deps"
-          docker_image: "soumith/conda-cuda-cxx11-ubuntu1604:latest"
+          docker_image: "pytorch/conda-cuda-cxx11-ubuntu1604:latest"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       #- binary_linux_libtorch_2.7m_cpu_test:

--- a/.circleci/scripts/binary_populate_env.sh
+++ b/.circleci/scripts/binary_populate_env.sh
@@ -32,11 +32,11 @@ fi
 export DOCKER_IMAGE=${DOCKER_IMAGE:-}
 if [[ -z "$DOCKER_IMAGE" ]]; then
   if [[ "$PACKAGE_TYPE" == conda ]]; then
-    export DOCKER_IMAGE="soumith/conda-cuda"
+    export DOCKER_IMAGE="pytorch/conda-cuda"
   elif [[ "$DESIRED_CUDA" == cpu ]]; then
-    export DOCKER_IMAGE="soumith/manylinux-cuda100"
+    export DOCKER_IMAGE="pytorch/manylinux-cuda100"
   else
-    export DOCKER_IMAGE="soumith/manylinux-cuda${DESIRED_CUDA:2}"
+    export DOCKER_IMAGE="pytorch/manylinux-cuda${DESIRED_CUDA:2}"
   fi
 fi
 

--- a/.circleci/verbatim-sources/workflows-binary-builds-smoke-subset.yml
+++ b/.circleci/verbatim-sources/workflows-binary-builds-smoke-subset.yml
@@ -10,19 +10,19 @@
           build_environment: "manywheel 2.7mu cpu devtoolset7"
           requires:
             - setup
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
       - binary_linux_build:
           name: binary_linux_manywheel_3_7m_cu100_devtoolset7_build
           build_environment: "manywheel 3.7m cu100 devtoolset7"
           requires:
             - setup
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
       - binary_linux_build:
           name: binary_linux_conda_2_7_cpu_devtoolset7_build
           build_environment: "conda 2.7 cpu devtoolset7"
           requires:
             - setup
-          docker_image: "soumith/conda-cuda"
+          docker_image: "pytorch/conda-cuda"
       # This binary build is currently broken, see https://github_com/pytorch/pytorch/issues/16710
       # - binary_linux_conda_3_6_cu90_devtoolset7_build
       - binary_linux_build:
@@ -31,14 +31,14 @@
           requires:
             - setup
           libtorch_variant: "shared-with-deps"
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
       - binary_linux_build:
           name: binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_shared-with-deps_build
           build_environment: "libtorch 2.7m cpu gcc5.4_cxx11-abi"
           requires:
             - setup
           libtorch_variant: "shared-with-deps"
-          docker_image: "yf225/pytorch-binary-docker-image-ubuntu16.04:latest"
+          docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
       # TODO we should test a libtorch cuda build, but they take too long
       # - binary_linux_libtorch_2_7m_cu90_devtoolset7_static-without-deps_build
       - binary_mac_build:
@@ -63,14 +63,14 @@
           requires:
             - setup
             - binary_linux_manywheel_2_7mu_cpu_devtoolset7_build
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
       - binary_linux_test:
           name: binary_linux_manywheel_3_7m_cu100_devtoolset7_test
           build_environment: "manywheel 3.7m cu100 devtoolset7"
           requires:
             - setup
             - binary_linux_manywheel_3_7m_cu100_devtoolset7_build
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
@@ -79,7 +79,7 @@
           requires:
             - setup
             - binary_linux_conda_2_7_cpu_devtoolset7_build
-          docker_image: "soumith/conda-cuda"
+          docker_image: "pytorch/conda-cuda"
       # This binary build is currently broken, see https://github_com/pytorch/pytorch/issues/16710
       # - binary_linux_conda_3_6_cu90_devtoolset7_test:
       - binary_linux_test:
@@ -89,7 +89,7 @@
             - setup
             - binary_linux_libtorch_2_7m_cpu_devtoolset7_shared-with-deps_build
           libtorch_variant: "shared-with-deps"
-          docker_image: "soumith/manylinux-cuda100"
+          docker_image: "pytorch/manylinux-cuda100"
       - binary_linux_test:
           name: binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_shared-with-deps_test
           build_environment: "libtorch 2.7m cpu gcc5.4_cxx11-abi"
@@ -97,5 +97,5 @@
             - setup
             - binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_shared-with-deps_build
           libtorch_variant: "shared-with-deps"
-          docker_image: "yf225/pytorch-binary-docker-image-ubuntu16.04:latest"
+          docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
 


### PR DESCRIPTION
Summary:
Using images from personal accounts restricts our ability to push
updates in a timely manner.

Test Plan:
CI

ghstack-source-id: 00bdb8d41bbf70bdef53547d02d9f57605395205
Pull Request resolved: https://github.com/pytorch/pytorch/pull/29835

