### PR TITLE
Change from int64_t to jlong for mac build

### DIFF
--- a/android/pytorch_android/src/main/cpp/pytorch_jni_common.cpp
+++ b/android/pytorch_android/src/main/cpp/pytorch_jni_common.cpp
@@ -162,7 +162,7 @@ public:
     }
 
     const auto& tensorShape = tensor.sizes();
-    std::vector<int64_t> tensorShapeVec;
+    std::vector<jlong> tensorShapeVec;
     for (const auto& s : tensorShape) {
       tensorShapeVec.push_back(s);
     }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#29861 Change from int64_t to jlong for mac build**

Follow https://github.com/pytorch/pytorch/issues/6570 to run ./run_host_tests.sh for Mac Build, we saw error below:

```error: cannot initialize a parameter of type 'const facebook::jni::JPrimitiveArray<_jlongArray *>::T *' (aka 'const long *') with an rvalue of type
      'std::__1::vector<long long, std::__1::allocator<long long> >::value_type *' (aka 'long long *')
    jTensorShape->setRegion(0, tensorShapeVec.size(), tensorShapeVec.data());```

Differential Revision: [D18519087](https://our.internmc.facebook.com/intern/diff/D18519087/)