### PR TITLE
support all with tag_filter to run all shapes

### DIFF
--- a/benchmarks/operator_benchmark/benchmark_core.py
+++ b/benchmarks/operator_benchmark/benchmark_core.py
@@ -330,9 +330,10 @@ class BenchmarkRunner(object):
 
         # Filter framework, operator, test_name, tag, forward_only
         if (self._check_keep(op_test_config.test_name, self.args.test_name) and
-            self._check_keep(op_test_config.tag, self.args.tag_filter) and
             self._check_keep_list(test_case.op_bench.module_name(), operators) and
             self._check_keep_list(test_case.framework, frameworks) and
+                (self.args.tag_filter == 'all' or
+                    self._check_keep(op_test_config.tag, self.args.tag_filter)) and
                 (not self.args.forward_only or op_test_config.run_backward != self.args.forward_only) and
                 (self.args.device == 'None' or self.args.device in op_test_config.test_name)):
             return True

--- a/benchmarks/operator_benchmark/benchmark_runner.py
+++ b/benchmarks/operator_benchmark/benchmark_runner.py
@@ -25,7 +25,7 @@ def main():
 
     parser.add_argument(
         '--tag_filter',
-        help='tag_filter can be used to run the benchmarks which matches the tag',
+        help='tag_filter can be used to run the shapes which matches the tag. (all is used to run all the shapes)',
         default='short')
 
     # This option is used to filter test cases to run.


### PR DESCRIPTION
Summary: This diff make `all` as a reserved keyword for tag_filter. When `all` is passed from user, it will run all the supported shapes.

Test Plan: buck run //caffe2/benchmarks/operator_benchmark/pt:add_test -- --iterations 1 --tag_filter all

Differential Revision: D18520249

