### PR TITLE
reduce input shapes of long tag in op bench

### DIFF
--- a/benchmarks/operator_benchmark/benchmark_core.py
+++ b/benchmarks/operator_benchmark/benchmark_core.py
@@ -330,9 +330,10 @@ class BenchmarkRunner(object):
 
         # Filter framework, operator, test_name, tag, forward_only
         if (self._check_keep(op_test_config.test_name, self.args.test_name) and
-            self._check_keep(op_test_config.tag, self.args.tag_filter) and
             self._check_keep_list(test_case.op_bench.module_name(), operators) and
             self._check_keep_list(test_case.framework, frameworks) and
+                (self.args.tag_filter == 'all' or
+                    self._check_keep(op_test_config.tag, self.args.tag_filter)) and
                 (not self.args.forward_only or op_test_config.run_backward != self.args.forward_only) and
                 (self.args.device == 'None' or self.args.device in op_test_config.test_name)):
             return True

--- a/benchmarks/operator_benchmark/benchmark_runner.py
+++ b/benchmarks/operator_benchmark/benchmark_runner.py
@@ -25,7 +25,7 @@ def main():
 
     parser.add_argument(
         '--tag_filter',
-        help='tag_filter can be used to run the benchmarks which matches the tag',
+        help='tag_filter can be used to run the shapes which matches the tag. (all is used to run all the shapes)',
         default='short')
 
     # This option is used to filter test cases to run.

--- a/benchmarks/operator_benchmark/pt/add_test.py
+++ b/benchmarks/operator_benchmark/pt/add_test.py
@@ -10,9 +10,9 @@ import torch
 
 # Configs for PT add operator
 add_long_configs = op_bench.cross_product_configs(
-    M=[8, 64, 128],
-    N=range(2, 128, 64),
-    K=[8 ** x for x in range(0, 3)],
+    M=[8, 128],
+    N=[32, 64],
+    K=[256, 512],
     device=['cpu', 'cuda'],
     tags=["long"]
 )

--- a/benchmarks/operator_benchmark/pt/as_strided_test.py
+++ b/benchmarks/operator_benchmark/pt/as_strided_test.py
@@ -24,10 +24,10 @@ as_strided_configs_short = op_bench.config_list(
 )
 
 as_strided_configs_long = op_bench.cross_product_configs(
-    M=[128, 1024],
-    N=[128, 1024],
+    M=[512],
+    N=[1024],
     size=[(16, 16), (128, 128)],
-    stride=[(1, 1), (2, 2)],
+    stride=[(1, 1)],
     storage_offset=[0, 1],
     device=['cpu', 'cuda'],
     tags=['long']

--- a/benchmarks/operator_benchmark/pt/cat_test.py
+++ b/benchmarks/operator_benchmark/pt/cat_test.py
@@ -24,7 +24,7 @@ cat_configs_short = op_bench.config_list(
 )
 
 cat_configs_long = op_bench.cross_product_configs(
-    M=[128, 1024],
+    M=[128],
     N=[128, 1024],
     K=[1, 2],
     dim=[0, 1, 2],

--- a/benchmarks/operator_benchmark/pt/matmul_test.py
+++ b/benchmarks/operator_benchmark/pt/matmul_test.py
@@ -23,10 +23,10 @@ mm_short_configs = op_bench.config_list(
 
 
 mm_long_configs = op_bench.cross_product_configs(
-    M=[64, 128],
-    N=[64, 128],
-    K=[512],
-    trans_a=[True, False],
+    M=[32],
+    N=[512, 128],
+    K=[64],
+    trans_a=[False, True],
     trans_b=[True, False],
     device=['cpu', 'cuda'],
     tags=["long"]


### PR DESCRIPTION
Summary: For some operators, the number of tests (forward + backward) could easily go above 100. Many of them could be redundant so this diff tries to reduce the number of shapes.

Test Plan:
```
buck run //caffe2/benchmarks/operator_benchmark:benchmark_all_test -- --iterations 1
# ----------------------------------------
# PyTorch/Caffe2 Operator Micro-benchmarks
# ----------------------------------------
# Tag : short

# Benchmarking PyTorch: add
# Mode: Eager
# Name: add_M64_N64_K64_cpu
# Input: M: 64, N: 64, K: 64, device: cpu
Forward Execution Time (us) : 28418.926
...

Differential Revision: D18520946

