### PR TITLE
Stop binding _th_resize_as_, which isn't used anymore.

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -142,21 +142,6 @@
     - THTensor* self
 ]]
 [[
-  name: _th_resize_as_
-  cname: resizeAs
-  cpu_half: True
-  cpu_bool: True
-  cuda_bool: True
-  cpu_bfloat16: True
-  variants:
-    - function
-  return: self
-  scalar_check: the_template_->dim() == 0
-  arguments:
-    - THTensor* self
-    - THTensor* the_template
-]]
-[[
   name: _th_index_select
   cpu_bool: True
   cuda_bool: True


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #29880 Turn off scalar_checks for __and__ and clone.
* #29879 Turn off scalar_check for __or__
* #29878 Turn off scalar_check for lshift, rshift.
* #29877 Turn off scalar_check for diag.
* #29876 Turn off scalar_check for _th_max, _th_min.
* #29875 Turn off scalar_check for lstsq (gels), and test scalars for eig.
* #29874 Turn off scalar_check for sort.
* #29873 Fix memory leak in CUDA renorm, turn off scalar_check for renorm.
* #29872 Turn off scalar_checks for cumsum, cumprod.
* #29871 Turn off scalar_check for fmod.
* #29870 Turn off scalar_check for remainder.
* #29869 Turn off scalar_checks for multinomial_alias_setup_, which requires 1d tensors.
* #29868 Stop generating maybe_zero_dim calls for "scalar_check: false" with multiple outputs.
* **#29867 Stop binding _th_resize_as_, which isn't used anymore.**
* #29866 Skip outputting scalar_checks if they are false.

Differential Revision: [D18521743](https://our.internmc.facebook.com/intern/diff/D18521743)