### PR TITLE
Stop generating maybe_zero_dim calls for "scalar_check: false" with multiple outputs.

### DIFF
--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -1690,7 +1690,7 @@ def create_derived(backend_type_env, declarations):
                     arguments_indices = ret['arguments']
                     arguments = [option['arguments'][argi]
                                  for argi in arguments_indices]
-                    if scalar_check is not None:
+                    if scalar_check is not None and scalar_check != 'false':
                         if not isinstance(scalar_check, dict):
                             if len(arguments) > 1:
                                 case_body.append("bool maybe_scalar = {};".format(scalar_check))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #29923 [BC-BREAKING] Turn off scalar_check for masked_select.
* #29880 Turn off scalar_checks for __and__ and clone.
* #29879 Turn off scalar_check for __or__
* #29878 Turn off scalar_check for lshift, rshift.
* #29877 Turn off scalar_check for diag.
* #29876 Turn off scalar_check for _th_max, _th_min.
* #29875 Turn off scalar_check for lstsq (gels), and test scalars for eig.
* #29874 Turn off scalar_check for sort.
* #29873 Fix memory leak in CUDA renorm, turn off scalar_check for renorm.
* #29872 Turn off scalar_checks for cumsum, cumprod.
* #29871 Turn off scalar_check for fmod.
* #29870 Turn off scalar_check for remainder.
* #29869 Turn off scalar_checks for multinomial_alias_setup_, which requires 1d tensors.
* **#29868 Stop generating maybe_zero_dim calls for "scalar_check: false" with multiple outputs.**
* #29867 Stop binding _th_resize_as_, which isn't used anymore.
* #29866 Skip outputting scalar_checks if they are false.

Codegen changes: https://gist.github.com/gchanan/b0db8ec1310d7e10435c75b951e7de83

Differential Revision: [D18521735](https://our.internmc.facebook.com/intern/diff/D18521735)