### PR TITLE
Turn off scalar_checks for multinomial_alias_setup_, which requires 1d tensors.

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -1414,6 +1414,7 @@
     - CPU
     - CUDA
   return: argument 1,2
+  scalar_check: false
   arguments:
     - arg: THTensor* probs
     - arg: THIndexTensor* J

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6016,6 +6016,12 @@ class TestTorchDeviceType(TestCase):
                 dims_small = [ds] + dims_small
         return (dims_small, dims_large, dims_full)
 
+    # collected tests of ops that used scalar_check in Declarations.cwrap for
+    # correctness
+    def test_scalar_check(self, device):
+        zero_d = torch.randn((), device=device)
+        self.assertRaises(RuntimeError, lambda: torch._multinomial_alias_setup(zero_d))
+
     @onlyCPU
     @dtypes(torch.float)
     def test_diag(self, device, dtype):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #29923 [BC-BREAKING] Turn off scalar_check for masked_select.
* #29880 Turn off scalar_checks for __and__ and clone.
* #29879 Turn off scalar_check for __or__
* #29878 Turn off scalar_check for lshift, rshift.
* #29877 Turn off scalar_check for diag.
* #29876 Turn off scalar_check for _th_max, _th_min.
* #29875 Turn off scalar_check for lstsq (gels), and test scalars for eig.
* #29874 Turn off scalar_check for sort.
* #29873 Fix memory leak in CUDA renorm, turn off scalar_check for renorm.
* #29872 Turn off scalar_checks for cumsum, cumprod.
* #29871 Turn off scalar_check for fmod.
* #29870 Turn off scalar_check for remainder.
* **#29869 Turn off scalar_checks for multinomial_alias_setup_, which requires 1d tensors.**
* #29868 Stop generating maybe_zero_dim calls for "scalar_check: false" with multiple outputs.
* #29867 Stop binding _th_resize_as_, which isn't used anymore.
* #29866 Skip outputting scalar_checks if they are false.

codegen changes: https://gist.github.com/gchanan/8e1b5184581fa37b27b6e856a75b470f

Differential Revision: [D18521741](https://our.internmc.facebook.com/intern/diff/D18521741)