### PR TITLE
Fix memory leak in CUDA renorm, turn off scalar_check for renorm.

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -767,6 +767,7 @@
   variants:
     - function
   return: argument 0
+  scalar_check: false
   arguments:
     - arg: THTensor* result
       output: True

--- a/aten/src/THC/generic/THCTensorMathReduce.cu
+++ b/aten/src/THC/generic/THCTensorMathReduce.cu
@@ -117,14 +117,14 @@ void THCTensor_(prod)(THCState* state, THCTensor *self, THCTensor *src, int dime
 void THCTensor_(renorm)(THCState *state, THCTensor* self, THCTensor* src, scalar_t value, int dimension, scalar_t maxnorm)
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, self, src));
+  THArgCheck(dimension >= 0 && dimension < THCTensor_(nDimensionLegacyNoScalars)(state, src), 3, "invalid dimension");
+  THArgCheck(THCNumerics<scalar_t>::gt(value, scalar_cast<scalar_t>(0)), 2, "non-positive-norm not supported");
+  THArgCheck(THCTensor_(nDimensionLegacyNoScalars)(state, src) > 1, 1, "need at least 2 dimensions");
+
   THCTensor *self_;
   THCTensor *src_ = THCTensor_(newTranspose)(state, src, dimension, 0);
   THCTensor *data = THCTensor_(newClone)(state, src_);
   int64_t numel = THCTensor_(nElement)(state, data);
-
-  THArgCheck(dimension >= 0 && dimension < THCTensor_(nDimensionLegacyNoScalars)(state, src), 3, "invalid dimension");
-  THArgCheck(THCNumerics<scalar_t>::gt(value, scalar_cast<scalar_t>(0)), 2, "non-positive-norm not supported");
-  THArgCheck(THCTensor_(nDimensionLegacyNoScalars)(state, src) > 1, 1, "need at least 2 dimensions");
 
   if (numel > 0) {
     ptrdiff_t size = numel / THTensor_sizeLegacyNoScalars(data, 0);

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6041,6 +6041,9 @@ class TestTorchDeviceType(TestCase):
         self.assertEqual((), torch.cumsum(zero_d, 0).shape)
         self.assertEqual((), torch.cumprod(zero_d, 0).shape)
 
+        # renorm
+        self.assertRaises(RuntimeError, lambda: torch.renorm(zero_d, 0.5, 0, 1.0))
+
     @onlyCPU
     @dtypes(torch.float)
     def test_diag(self, device, dtype):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #29923 [BC-BREAKING] Turn off scalar_check for masked_select.
* #29880 Turn off scalar_checks for __and__ and clone.
* #29879 Turn off scalar_check for __or__
* #29878 Turn off scalar_check for lshift, rshift.
* #29877 Turn off scalar_check for diag.
* #29876 Turn off scalar_check for _th_max, _th_min.
* #29875 Turn off scalar_check for lstsq (gels), and test scalars for eig.
* #29874 Turn off scalar_check for sort.
* **#29873 Fix memory leak in CUDA renorm, turn off scalar_check for renorm.**
* #29872 Turn off scalar_checks for cumsum, cumprod.
* #29871 Turn off scalar_check for fmod.
* #29870 Turn off scalar_check for remainder.
* #29869 Turn off scalar_checks for multinomial_alias_setup_, which requires 1d tensors.
* #29868 Stop generating maybe_zero_dim calls for "scalar_check: false" with multiple outputs.
* #29867 Stop binding _th_resize_as_, which isn't used anymore.
* #29866 Skip outputting scalar_checks if they are false.

Renorm requires at least 2-dimensions, so scalar_check could never succeed.

Differential Revision: [D18521733](https://our.internmc.facebook.com/intern/diff/D18521733)