### PR TITLE
Turn off scalar_check for sort.

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -562,6 +562,7 @@
   variants:
     - function
   return: argument 0,1
+  scalar_check: false
   arguments:
     - arg: THTensor* values
       output: True

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6044,6 +6044,10 @@ class TestTorchDeviceType(TestCase):
         # renorm
         self.assertRaises(RuntimeError, lambda: torch.renorm(zero_d, 0.5, 0, 1.0))
 
+        # sort
+        self.assertEqual([(), ()], [x.shape for x in torch.sort(zero_d, 0, False)])
+        self.assertEqual([(), ()], [x.shape for x in torch.sort(zero_d, 0, True)])
+
     @onlyCPU
     @dtypes(torch.float)
     def test_diag(self, device, dtype):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #29923 [BC-BREAKING] Turn off scalar_check for masked_select.
* #29880 Turn off scalar_checks for __and__ and clone.
* #29879 Turn off scalar_check for __or__
* #29878 Turn off scalar_check for lshift, rshift.
* #29877 Turn off scalar_check for diag.
* #29876 Turn off scalar_check for _th_max, _th_min.
* #29875 Turn off scalar_check for lstsq (gels), and test scalars for eig.
* **#29874 Turn off scalar_check for sort.**
* #29873 Fix memory leak in CUDA renorm, turn off scalar_check for renorm.
* #29872 Turn off scalar_checks for cumsum, cumprod.
* #29871 Turn off scalar_check for fmod.
* #29870 Turn off scalar_check for remainder.
* #29869 Turn off scalar_checks for multinomial_alias_setup_, which requires 1d tensors.
* #29868 Stop generating maybe_zero_dim calls for "scalar_check: false" with multiple outputs.
* #29867 Stop binding _th_resize_as_, which isn't used anymore.
* #29866 Skip outputting scalar_checks if they are false.

It's handled correctly by the op.

Differential Revision: [D18521744](https://our.internmc.facebook.com/intern/diff/D18521744)