### PR TITLE
cleanup inlined call stack.

### DIFF
--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -320,8 +320,9 @@ struct TORCH_API Node {
   c10::optional<InlinedCallStackPtr> callstack() const {
     return callstack_;
   }
-  void setCallStack(InlinedCallStackPtr cs);
-  void insertCallStackEntry(Function* f, const SourceRange& sr);
+  void setCallStack(InlinedCallStackPtr cs) {
+    callstack_ = cs;
+  }
 
   // NB: This returns an ArrayRef; that means that it will
   // get invalidated if you resize inputs (e.g., using addInput)

--- a/torch/csrc/jit/scope.cpp
+++ b/torch/csrc/jit/scope.cpp
@@ -90,28 +90,15 @@ InlinedCallStack::InlinedCallStack(Function* fn, SourceRange source_range)
     : fn_(fn), source_range_(std::move(source_range)) {}
 
 InlinedCallStack::InlinedCallStack(
-    InlinedCallStackPtr caller,
+    InlinedCallStackPtr callee,
     Function* fn,
     SourceRange source_range)
-    : caller_(std::move(caller)),
+    : callee_(std::move(callee)),
       fn_(fn),
       source_range_(std::move(source_range)) {}
 
-InlinedCallStackPtr InlinedCallStack::insertCallStackEntry(
-    Function* fn,
-    const SourceRange& source_range) {
-  auto ent = std::make_pair(fn, source_range);
-  if (callees_.count(ent)) {
-    return callees_.at(ent);
-  }
-  auto subscope = c10::make_intrusive<InlinedCallStack>(
-      intrusive_from_this(), fn, source_range);
-  callees_[ent] = subscope;
-  return subscope;
-}
-
-c10::optional<InlinedCallStackPtr> InlinedCallStack::caller() const {
-  return caller_;
+c10::optional<InlinedCallStackPtr> InlinedCallStack::callee() const {
+  return callee_;
 }
 
 std::vector<InlinedCallStackEntry> InlinedCallStack::vec() {
@@ -119,7 +106,7 @@ std::vector<InlinedCallStackEntry> InlinedCallStack::vec() {
   c10::optional<InlinedCallStackPtr> current = intrusive_from_this();
   while (current) {
     r.emplace_back(std::make_pair((*current)->fn_, (*current)->source_range_));
-    current = (*current)->caller_;
+    current = (*current)->callee_;
   }
   return r;
 }

--- a/torch/csrc/jit/scope.h
+++ b/torch/csrc/jit/scope.h
@@ -72,47 +72,28 @@ struct InlinedCallStack;
  */
 using InlinedCallStackPtr = c10::intrusive_ptr<InlinedCallStack>;
 using InlinedCallStackEntry = std::pair<Function*, SourceRange>;
-struct InlinedCallStackHash {
-  std::size_t operator()(const InlinedCallStackEntry& cs) const {
-    return std::hash<void*>()(cs.first) ^
-        std::hash<void*>()(&*cs.second.source()) ^
-        std::hash<size_t>()(cs.second.start()) ^
-        std::hash<size_t>()(cs.second.end());
-  }
-};
 
 struct TORCH_API InlinedCallStack : public c10::intrusive_ptr_target {
  private:
-  c10::optional<InlinedCallStackPtr> caller_;
+  c10::optional<InlinedCallStackPtr> callee_;
 
-  std::unordered_map<
-      InlinedCallStackEntry,
-      InlinedCallStackPtr,
-      InlinedCallStackHash>
-      callees_;
   Function* fn_;
   SourceRange source_range_;
   InlinedCallStackPtr intrusive_from_this();
 
  public:
-  // Constructor for the root callstack node.
+  // Constructor for a leaf callstack node.
   InlinedCallStack(Function* fn, SourceRange source_range);
 
   // Constructor for an inner callstack node.
   InlinedCallStack(
-      InlinedCallStackPtr caller,
+      InlinedCallStackPtr callee,
       Function* fn,
       SourceRange source_range);
 
-  // Return callstack for the caller.
+  // Return callstack for the callee.
   // Essentially, move one level up in the trie.
-  c10::optional<InlinedCallStackPtr> caller() const;
-
-  // Insert new callee to the callstack.
-  // Essentially, find existing or insert new node into the trie.
-  InlinedCallStackPtr insertCallStackEntry(
-      Function* fn,
-      const SourceRange& source_range);
+  c10::optional<InlinedCallStackPtr> callee() const;
 
   // Flatten callstack to a vector of [Function, SourceRange] pairs.
   std::vector<InlinedCallStackEntry> vec();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #29884 update comment.
* **#29883 cleanup inlined call stack.**
* #27922 Add logging to inliner.
* #27921 Add InlinedCallStack class.
* #27920 Make inlineCallTo to take Function instead of Graph as the callee argument.
* #27919 Add a variant of insertGraph that fills values map.

