### PR TITLE
[Mobile] Fix deadlock issues in ThreadPool

### DIFF
--- a/aten/src/ATen/ParallelNative.cpp
+++ b/aten/src/ATen/ParallelNative.cpp
@@ -214,7 +214,7 @@ int get_num_threads() {
 #else
   caffe2::ThreadPool* pool = caffe2::mobile_threadpool();
   // caffe2::ThreadPool::getNumThreads() counts the current thread.
-  return !pool ? 1 /* current thread */ : pool->getNumThreads();
+  return !pool || in_parallel_region() ? 1 /* current thread */ : pool->getNumThreads();
 #endif // C10_MOBILE
 }
 

--- a/caffe2/utils/threadpool/ThreadPool.cc
+++ b/caffe2/utils/threadpool/ThreadPool.cc
@@ -84,7 +84,6 @@ ThreadPool::ThreadPool(int numThreads)
 ThreadPool::~ThreadPool() {}
 
 int ThreadPool::getNumThreads() const {
-  std::lock_guard<std::mutex> guard(executionMutex_);
   return numThreads_;
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#29885 [Mobile] Fix deadlock issues in ThreadPool**

### Summary

Currently, we have a deadlock issue on iOS when running Resnet50. The problem happens when the task being run in the ThreadPool wants to call `getNumThread()` who will try to acquire the same mutex. And thus cause the deadlock situation. The fix is just remove the guard for `_numThreads`, as it's not likely to change after initialization.

### Test Plan

1. Generate a Resnet50 model using trace_model.py
2. Run `ios/TestApp/bootstrap.sh` to do the benchmark

cc @shoumikhin @AshkanAliabadi

Differential Revision: [D18533505](https://our.internmc.facebook.com/intern/diff/D18533505)