### PR TITLE
Disable broken test_cuda_kernel_loop_overflow_large test

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1811,6 +1811,8 @@ class TestCuda(TestCase):
         self.assertEqual(y[0, 0, 0, 2**30], expected)
 
     @unittest.skipIf(not TEST_LARGE_TENSOR, "not enough memory")
+    # See https://github.com/pytorch/pytorch/issues/26838
+    @unittest.expectedFailure()
     def test_cuda_kernel_loop_overflow_large(self):
         # Make sure input.numel() > INT_MAX is handled:
         x = torch.randn(1, 1, 1, 2**31, dtype=torch.float16, device="cuda")

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1812,7 +1812,7 @@ class TestCuda(TestCase):
 
     @unittest.skipIf(not TEST_LARGE_TENSOR, "not enough memory")
     # See https://github.com/pytorch/pytorch/issues/26838
-    @unittest.expectedFailure()
+    @unittest.expectedFailure
     def test_cuda_kernel_loop_overflow_large(self):
         # Make sure input.numel() > INT_MAX is handled:
         x = torch.randn(1, 1, 1, 2**31, dtype=torch.float16, device="cuda")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#29904 Disable broken test_cuda_kernel_loop_overflow_large test**

See https://github.com/pytorch/pytorch/issues/26838

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D18539740](https://our.internmc.facebook.com/intern/diff/D18539740)