### PR TITLE
Add more defensive tests for undefined tensors.

### DIFF
--- a/aten/src/ATen/core/Tensor.cpp
+++ b/aten/src/ATen/core/Tensor.cpp
@@ -46,6 +46,7 @@ std::string Tensor::toString() const {
 }
 
 Tensor Tensor::variable_data() const noexcept {
+  TORCH_CHECK(defined(), "cannot call variable_data() on undefined tensor");
   auto self_impl_copy = unsafeGetTensorImpl()->shallow_copy_and_detach(
     /*version_counter=*/0,
     /*allow_tensor_metadata_change=*/false);
@@ -54,6 +55,7 @@ Tensor Tensor::variable_data() const noexcept {
 }
 
 Tensor Tensor::tensor_data() const noexcept {
+  TORCH_CHECK(defined(), "cannot call tensor_data() on undefined tensor");
   auto self_impl_copy = unsafeGetTensorImpl()->shallow_copy_and_detach(
     /*version_counter=*/unsafeGetTensorImpl()->version_counter(),
     /*allow_tensor_metadata_change=*/unsafeGetTensorImpl()->allow_tensor_metadata_change());
@@ -86,6 +88,7 @@ namespace {
 }
 
 const std::string& Tensor::name() const noexcept {
+  TORCH_CHECK(defined(), "cannot call variable_data() on undefined tensor");
   if (torch::autograd::impl::get_autograd_meta(*this)) {
     return torch::autograd::impl::get_autograd_meta(*this)->name_;
   } else {

--- a/aten/src/ATen/test/undefined_tensor_test.cpp
+++ b/aten/src/ATen/test/undefined_tensor_test.cpp
@@ -27,6 +27,7 @@ TEST(TestUndefined, UndefinedTest) {
   ASSERT_ANY_THROW(und.add(5));
   ASSERT_ANY_THROW(und.mm(und));
 
+  // public variable API
   ASSERT_ANY_THROW(und.variable_data());
   ASSERT_ANY_THROW(und.tensor_data());
   ASSERT_ANY_THROW(und.is_view());

--- a/aten/src/ATen/test/undefined_tensor_test.cpp
+++ b/aten/src/ATen/test/undefined_tensor_test.cpp
@@ -27,6 +27,15 @@ TEST(TestUndefined, UndefinedTest) {
   ASSERT_ANY_THROW(und.add(5));
   ASSERT_ANY_THROW(und.mm(und));
 
+  ASSERT_ANY_THROW(und.variable_data());
+  ASSERT_ANY_THROW(und.tensor_data());
+  ASSERT_ANY_THROW(und.is_view());
+  ASSERT_ANY_THROW(und.base());
+  ASSERT_ANY_THROW(und.name());
+  ASSERT_ANY_THROW(und.grad_fn());
+  ASSERT_ANY_THROW(und.remove_hook(0));
+  ASSERT_ANY_THROW(und.register_hook([](const Tensor& x) -> Tensor { return x; }));
+
   // copy_
   ASSERT_ANY_THROW(und.copy_(und));
   ASSERT_ANY_THROW(und.copy_(ft));

--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -61,6 +61,7 @@ static c10::impl::AutogradMetaFactoryRegisterer meta_factory_registerer(&meta_fa
 namespace impl {
 
   AutogradMeta* materialize_autograd_meta(const Variable& self) {
+    TORCH_CHECK(self.defined(), "cannot call materialize_autograd_meta() on undefined tensor");
     auto p = self.unsafeGetTensorImpl();
     if (!p->autograd_meta()) {
       p->set_autograd_meta(c10::guts::make_unique<AutogradMeta>());
@@ -173,14 +174,17 @@ namespace impl {
   void set_version_counter(
       const Variable& self,
       const c10::VariableVersion& version_counter) noexcept {
+    TORCH_CHECK(self.defined(), "cannot call set_version_counter() on undefined tensor");
     self.unsafeGetTensorImpl()->set_version_counter(version_counter);
   }
 
   void bump_version(const Variable& self) noexcept {
+    TORCH_CHECK(self.defined(), "cannot call bump_version() on undefined tensor");
     self.unsafeGetTensorImpl()->bump_version();
   }
 
   const c10::VariableVersion& version_counter(const Variable& self) noexcept {
+    TORCH_CHECK(self.defined(), "cannot call version_counter() on undefined tensor");
     return self.unsafeGetTensorImpl()->version_counter();
   }
 
@@ -219,15 +223,18 @@ namespace impl {
   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
   void set_pyobj(const Variable& self, PyObject* pyobj) noexcept {
+    TORCH_CHECK(self.defined(), "cannot call set_pyobj() on undefined tensor");
     self.unsafeGetTensorImpl()->set_pyobj(pyobj);
   }
 
   PyObject* pyobj(const Variable& self) noexcept {
+    TORCH_CHECK(self.defined(), "cannot call pyobj() on undefined tensor");
     return self.unsafeGetTensorImpl()->pyobj();
   }
 
   AutogradMeta* get_autograd_meta(const Variable& self) noexcept {
     // NB: could return null
+    TORCH_CHECK(self.defined(), "cannot call get_autograd_meta() on undefined tensor");
     return static_cast<AutogradMeta*>(self.unsafeGetTensorImpl()->autograd_meta());
   }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#29907 Add more defensive tests for undefined tensors.**
* #28287 Merge Tensor and Variable types.
* #29667 Delete redefinitions of methods in Variable already present on Tensor.
* #29665 Move most methods off Variable into torch::autograd::impl functions.
* #29653 Remove TensorImpl::is_variable, deprecate Tensor::is_variable

Signed-off-by: Edward Z. Yang <ezyang@fb.com>