### PR TITLE
[Quantization] Fix submodule traversal in insertPackUnpack pass.

### DIFF
--- a/torch/csrc/jit/passes/quantization.cpp
+++ b/torch/csrc/jit/passes/quantization.cpp
@@ -956,9 +956,9 @@ void InsertPrepackUnpack(script::Module& module) {
   for (auto& method : module.get_methods()) {
     auto graph = method.graph();
     InsertPrepackUnpack(graph);
-    for (script::Module m : module.children()) {
-      InsertPrepackUnpack(m);
-    }
+  }
+  for (script::Module m : module.children()) {
+    InsertPrepackUnpack(m);
   }
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#29914 [Quantization] Fix submodule traversal in insertPackUnpack pass.**

Summary:
Currently we're visiting all submodules every time we're visiting a
method of a module.

Differential Revision: [D18534602](https://our.internmc.facebook.com/intern/diff/D18534602)