### PR TITLE
[jit] split module interface tests

### DIFF
--- a/test/jit/test_module_interface.py
+++ b/test/jit/test_module_interface.py
@@ -1,6 +1,7 @@
 # flake8: noqa
 # TODO: enable linting check for this file
 
+from typing import List
 import torch
 import torch.nn as nn
 from jit_utils import JitTestCase
@@ -59,6 +60,148 @@ class TestModuleInterface(JitTestCase):
 
         with self.assertRaisesRegex(RuntimeError, "Tried to access nonexistent attribute"):
             torch.jit.script(TestNotModuleInterfaceCall())
+
+    def test_module_interface(self):
+        global OneTwoModule, OneTwoClass
+        @torch.jit.interface
+        class OneTwoModule(nn.Module):
+            def one(self, x, y):
+                # type: (Tensor, Tensor) -> Tensor
+                pass
+
+            def two(self, x):
+                # type: (Tensor) -> Tensor
+                pass
+
+            def forward(self, x):
+                # type: (Tensor) -> Tensor
+                pass
+
+        @torch.jit.interface
+        class OneTwoClass(object):
+            def one(self, x, y):
+                # type: (Tensor, Tensor) -> Tensor
+                pass
+
+            def two(self, x):
+                # type: (Tensor) -> Tensor
+                pass
+
+        class FooMod(nn.Module):
+            def one(self, x, y):
+                # type: (Tensor, Tensor) -> Tensor
+                return x + y
+
+            def two(self, x):
+                # type: (Tensor) -> Tensor
+                return 2 * x
+
+            def forward(self, x):
+                # type: (Tensor) -> Tensor
+                return self.one(self.two(x), x)
+
+        class BarMod(nn.Module):
+            def one(self, x, y):
+                # type: (Tensor, Tensor) -> Tensor
+                return x * y
+
+            def two(self, x):
+                # type: (Tensor) -> Tensor
+                return 2 / x
+
+            def forward(self, x):
+                # type: (Tensor) -> Tensor
+                return self.two(self.one(x, x))
+
+            @torch.jit.export
+            def forward2(self, x):
+                # type: (Tensor) -> Tensor
+                return self.two(self.one(x, x)) + 1
+
+        def use_module_interface(mod_list: List[OneTwoModule], x: torch.Tensor):
+            return mod_list[0].forward(x) + mod_list[1].forward(x)
+
+        def use_class_interface(mod_list, x):
+            # type: (List[OneTwoClass], Tensor) -> Tensor
+            return mod_list[0].two(x) + mod_list[1].one(x, x)
+
+        scripted_foo_mod = torch.jit.script(FooMod())
+        scripted_bar_mod = torch.jit.script(BarMod())
+        self.checkScript(use_module_interface,
+                         ([scripted_foo_mod, scripted_bar_mod], torch.rand(3, 4),))
+        self.checkScript(use_class_interface,
+                         ([scripted_foo_mod, scripted_bar_mod], torch.rand(3, 4),))
+
+        def call_module_interface_on_other_method(mod_interface, x):
+            # type: (OneTwoModule, Tensor) -> Tensor
+            return mod_interface.forward2(x)
+
+        # ensure error out when we call the module on the method other than the interface specified.
+        with self.assertRaisesRegex(RuntimeError, "Tried to access nonexistent attribute or method"):
+            self.checkScript(call_module_interface_on_other_method, (scripted_bar_mod, torch.rand(3, 4),))
+
+
+    def test_module_interface_subtype(self):
+        global OneTwoModule
+        @torch.jit.interface
+        class OneTwoModule(nn.Module):
+            def one(self, x, y):
+                # type: (Tensor, Tensor) -> Tensor
+                pass
+
+            def two(self, x):
+                # type: (Tensor) -> Tensor
+                pass
+
+            def forward(self, x):
+                # type: (Tensor) -> Tensor
+                pass
+
+        @torch.jit.script
+        def as_module_interface(x):
+            # type: (OneTwoModule) -> OneTwoModule
+            return x
+
+        @torch.jit.script
+        class Foo(object):
+            def one(self, x, y):
+                # type: (Tensor, Tensor) -> Tensor
+                return x + y
+
+            def two(self, x):
+                # type: (Tensor) -> Tensor
+                return 2 * x
+
+            def forward(self, x):
+                # type: (Tensor) -> Tensor
+                return self.one(self.two(x), x)
+
+        # check class object is not a subtype of module interface
+        with self.assertRaisesRegex(RuntimeError, "ScriptModule class can be subtype of module interface"):
+            as_module_interface(Foo())
+
+        class WrongMod(nn.Module):
+            def two(self, x):
+                # type: (int) -> int
+                return 2 * x
+
+            def forward(self, x):
+                # type: (Tensor) -> Tensor
+                return x + torch.randn(3, self.two(3))
+
+        scripted_wrong_mod = torch.jit.script(WrongMod())
+
+        # wrong module that is not compatible with module interface
+        with self.assertRaisesRegex(RuntimeError, "is not compatible with interface"):
+            as_module_interface(scripted_wrong_mod)
+
+    def test_module_interface_inheritance(self):
+        with self.assertRaisesRegex(RuntimeError, "does not support inheritance yet. Please directly"):
+            @torch.jit.interface
+            class InheritMod(nn.ReLU):
+                def three(self, x):
+                    # type: (Tensor) -> Tensor
+                    return 3 * x
 
     def test_module_swap(self):
         @torch.jit.interface

--- a/test/test_jit_py3.py
+++ b/test/test_jit_py3.py
@@ -6,10 +6,7 @@ from jit.test_module_interface import TestModuleInterface  # noqa: F401
 import unittest
 import sys
 import torch
-import torch.nn as nn
 import jit_utils
-
-from torch import Tensor
 
 class TestScriptPy3(JitTestCase):
     def test_joined_str(self):
@@ -233,7 +230,6 @@ class TestScriptPy3(JitTestCase):
                 if True:
                     x : Optional[int] = 7
 
-
     def test_any_in_class_fails(self):
         class MyCoolNamedTuple(NamedTuple):
             a : Any
@@ -244,136 +240,6 @@ class TestScriptPy3(JitTestCase):
             def foo():
                 return MyCoolNamedTuple(4, 5.5, [3])
             print(foo.graph)
-
-    def test_module_interface(self):
-        global OneTwo, OneTwoClass, Foo
-        @torch.jit.interface
-        class OneTwo(nn.Module):
-            def one(self, x, y):
-                # type: (Tensor, Tensor) -> Tensor
-                pass
-
-            def two(self, x):
-                # type: (Tensor) -> Tensor
-                pass
-
-            def forward(self, x):
-                # type: (Tensor) -> Tensor
-                pass
-
-        @torch.jit.interface
-        class OneTwoClass(object):
-            def one(self, x, y):
-                # type: (Tensor, Tensor) -> Tensor
-                pass
-
-            def two(self, x):
-                # type: (Tensor) -> Tensor
-                pass
-
-        class FooMod(nn.Module):
-            def one(self, x, y):
-                # type: (Tensor, Tensor) -> Tensor
-                return x + y
-
-            def two(self, x):
-                # type: (Tensor) -> Tensor
-                return 2 * x
-
-            def forward(self, x):
-                # type: (Tensor) -> Tensor
-                return self.one(self.two(x), x)
-
-        class BarMod(nn.Module):
-            def one(self, x, y):
-                # type: (Tensor, Tensor) -> Tensor
-                return x * y
-
-            def two(self, x):
-                # type: (Tensor) -> Tensor
-                return 2 / x
-
-            def forward(self, x):
-                # type: (Tensor) -> Tensor
-                return self.two(self.one(x, x))
-
-            @torch.jit.export
-            def forward2(self, x):
-                # type: (Tensor) -> Tensor
-                return self.two(self.one(x, x)) + 1
-
-        def use_module_interface(mod_list, x):
-            # type: (List[OneTwo], Tensor) -> Tensor
-            return mod_list[0].forward(x) + mod_list[1].forward(x)
-
-        def use_class_interface(mod_list, x):
-            # type: (List[OneTwoClass], Tensor) -> Tensor
-            return mod_list[0].two(x) + mod_list[1].one(x, x)
-
-        scripted_foo_mod = torch.jit.script(FooMod())
-        scripted_bar_mod = torch.jit.script(BarMod())
-        self.checkScript(use_module_interface,
-                         ([scripted_foo_mod, scripted_bar_mod], torch.rand(3, 4),))
-        self.checkScript(use_class_interface,
-                         ([scripted_foo_mod, scripted_bar_mod], torch.rand(3, 4),))
-
-        @torch.jit.script
-        def as_module_interface(x):
-            # type: (OneTwo) -> OneTwo
-            return x
-
-        @torch.jit.script
-        def as_class_interface(x):
-            # type: (OneTwoClass) -> OneTwoClass
-            return x
-
-        @torch.jit.script
-        class Foo(object):
-            def one(self, x, y):
-                # type: (Tensor, Tensor) -> Tensor
-                return x + y
-
-            def two(self, x):
-                # type: (Tensor) -> Tensor
-                return 2 * x
-
-            def forward(self, x):
-                # type: (Tensor) -> Tensor
-                return self.one(self.two(x), x)
-
-        # check class object is not a subtype of module interface
-        with self.assertRaisesRegex(RuntimeError, "ScriptModule class can be subtype of module interface"):
-            as_module_interface(Foo())
-
-        def call_module_interface_on_other_method(mod_interface, x):
-            # type: (OneTwo, Tensor) -> Tensor
-            return mod_interface.forward2(x)
-
-        # ensure error out when we call the module on the method other than the interface specified.
-        with self.assertRaisesRegex(RuntimeError, "Tried to access nonexistent attribute or method"):
-            self.checkScript(call_module_interface_on_other_method, (scripted_bar_mod, torch.rand(3, 4),))
-
-        class WrongMod(nn.Module):
-            def two(self, x):
-                # type: (int) -> int
-                return 2 * x
-
-            def forward(self, x):
-                # type: (Tensor) -> Tensor
-                return x + torch.randn(3, self.two(3))
-
-        scripted_wrong_mod = torch.jit.script(WrongMod())
-
-        # wrong module that is not compatible with module interface
-        with self.assertRaisesRegex(RuntimeError, "is not compatible with interface"):
-            as_module_interface(scripted_wrong_mod)
-
-        with self.assertRaisesRegex(RuntimeError, "does not support inheritance yet. Please directly"):
-            @torch.jit.interface
-            class InheritMod(FooMod):
-                def three(self, x):
-                    # type: (Tensor) -> Tensor
-                    return 3 * x
 
 if __name__ == '__main__':
     run_tests()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#29917 [jit] split module interface tests**

Summary:
move test_module_interface to its own file, no code logic change

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D18543235](https://our.internmc.facebook.com/intern/diff/D18543235)