### PR TITLE
fix device check in op bench

### DIFF
--- a/benchmarks/operator_benchmark/benchmark_core.py
+++ b/benchmarks/operator_benchmark/benchmark_core.py
@@ -335,7 +335,8 @@ class BenchmarkRunner(object):
                 (self.args.tag_filter == 'all' or
                     self._check_keep(op_test_config.tag, self.args.tag_filter)) and
                 (not self.args.forward_only or op_test_config.run_backward != self.args.forward_only) and
-                (self.args.device == 'None' or self.args.device in op_test_config.test_name)):
+                (self.args.device == 'None' or 'device' not in op_test_config.test_name or 
+                    self.args.device in op_test_config.test_name)):
             return True
 
         return False


### PR DESCRIPTION
Summary: Some of the tests don't specify `device` in the input configs so filter by device won't work for them. This diff fixes that issue.

Test Plan:
```
buck run mode/opt //caffe2/benchmarks/operator_benchmark/pt:qpool_test -- --iterations 1 --device cpu
# ----------------------------------------
# PyTorch/Caffe2 Operator Micro-benchmarks
# ----------------------------------------
# Tag : short

# Benchmarking PyTorch: QAdaptiveAvgPool2dBenchmark
# Mode: Eager
# Name: QAdaptiveAvgPool2dBenchmark_N4_C3_input_size(224,224)_output_size(112,112)_contigTrue_dtypetorch.qint32
# Input: N: 4, C: 3, input_size: (224, 224), output_size: (112, 112), contig: True, dtype: torch.qint32
Forward Execution Time (us) : 2891.172

Differential Revision: D18535766

