### PR TITLE
Stop exporting TH/THC symbols as extern "C".

### DIFF
--- a/aten/src/ATen/test/basic.cpp
+++ b/aten/src/ATen/test/basic.cpp
@@ -3,11 +3,6 @@
 #include <ATen/ATen.h>
 #include <ATen/core/Reduction.h>
 
-// for TH compat test only...
-struct THFloatTensor;
-extern "C" THFloatTensor * THFloatTensor_newWithSize2d(size_t a, size_t b);
-extern "C" void THFloatTensor_fill(THFloatTensor *, float v);
-
 #include <iostream>
 #include <chrono>
 #include <string.h>
@@ -201,13 +196,6 @@ void TestZeroDim(DeprecatedTypeProperties& type) {
   f[2] = zeros({4}, type);
   f[1][0] = -1;
   ASSERT_EQ_RESOLVED(f[2][0].item<double>(), 0);
-}
-
-void TestTensorFromTH() {
-  int a = 4;
-  THFloatTensor* t = THFloatTensor_newWithSize2d(a, a);
-  THFloatTensor_fill(t, a);
-  ASSERT_NO_THROW(at::unsafeTensorFromTH(t, false));
 }
 
 void TestToCFloat() {

--- a/aten/src/TH/THGeneral.h.in
+++ b/aten/src/TH/THGeneral.h.in
@@ -28,32 +28,7 @@
 
 # define TH_EXTERNC extern "C"
 
-// Note(jiayq): copied from ATen/core/Macros.h. Because internal build of TH
-// and ATen are not unified yet, we need to duplicate code for now. Long term
-// we should merge macros.
-#ifdef _WIN32
-#if !defined(AT_CORE_STATIC_WINDOWS)
-// TODO: unfiy the controlling macros.
-#if defined(CAFFE2_BUILD_MAIN_LIBS) || defined(ATen_cpu_EXPORTS) || defined(caffe2_EXPORTS)
-#define TH_CPP_API __declspec(dllexport)
-#else // defined(CAFFE2_BUILD_MAIN_LIBS) || defined(ATen_cpu_EXPORTS) || defined(caffe2_EXPORTS)
-#define TH_CPP_API __declspec(dllimport)
-#endif // defined(CAFFE2_BUILD_MAIN_LIBS) || defined(ATen_cpu_EXPORTS) || defined(caffe2_EXPORTS)
-#else // !defined(AT_CORE_STATIC_WINDOWS)
-#define TH_CPP_API
-#endif // !defined(AT_CORE_STATIC_WINDOWS)
-#else  // _WIN32
-#if defined(__GNUC__)
-#define TH_CPP_API __attribute__((__visibility__("default")))
-#endif // defined(__GNUC__)
-#endif  // _WIN32
-
-#ifdef NO_EXPORT
-#undef TH_CPP_API
-#define TH_CPP_API
-#endif
-
-#define TH_API TH_EXTERNC TH_CPP_API
+#define TH_API TORCH_API
 
 #ifdef _WIN32
 # define TH_NO_RETURN __declspec(noreturn)

--- a/aten/src/TH/THGeneral.h.in
+++ b/aten/src/TH/THGeneral.h.in
@@ -30,7 +30,7 @@
 
 # define TH_EXTERNC extern "C"
 
-#define TH_API TORCH_API
+#define TH_API CAFFE2_API
 
 #ifdef _WIN32
 # define TH_NO_RETURN __declspec(noreturn)

--- a/aten/src/TH/THGeneral.h.in
+++ b/aten/src/TH/THGeneral.h.in
@@ -17,6 +17,8 @@
 #include <stddef.h>
 #include <inttypes.h>
 
+#include <c10/macros/Export.h>
+
 #ifdef TH_BLAS_MKL
 #include <mkl_vsl.h>
 #endif

--- a/aten/src/TH/THLogAdd.h
+++ b/aten/src/TH/THLogAdd.h
@@ -3,9 +3,9 @@
 
 #include <TH/THGeneral.h>
 
-TH_API const double THLog2Pi;
-TH_API const double THLogZero;
-TH_API const double THLogOne;
+extern "C" TH_API const double THLog2Pi;
+extern "C" TH_API const double THLogZero;
+extern "C" TH_API const double THLogOne;
 
 TH_API double THLogAdd(double log_a, double log_b);
 TH_API double THLogSub(double log_a, double log_b);

--- a/aten/src/TH/THStorageFunctions.hpp
+++ b/aten/src/TH/THStorageFunctions.hpp
@@ -31,7 +31,7 @@
 //    If it is not, you must report that the storage is dead.
 //
 
-TH_CPP_API THStorage* THStorage_new(caffe2::TypeMeta data_type);
+TH_API THStorage* THStorage_new(caffe2::TypeMeta data_type);
 TH_API ptrdiff_t THStorage_size(const THStorage *self);
 
 TH_API void THStorage_retain(THStorage *storage);

--- a/aten/src/TH/THTensor.hpp
+++ b/aten/src/TH/THTensor.hpp
@@ -118,9 +118,9 @@ TH_API void THTensor_free(THTensor *self);
 TH_API void THTensor_setStorageNd(THTensor *self, THStorage *storage, ptrdiff_t storageOffset, int nDimension, const int64_t *size, const int64_t *stride);
 TH_API void THTensor_resizeNd(THTensor *self, int nDimension, const int64_t *size, const int64_t *stride);
 
-TH_CPP_API void THTensor_resize(THTensor *self, at::IntArrayRef size, at::IntArrayRef stride);
-TH_CPP_API void THTensor_setStorage(THTensor *self, THStorage *storage_, ptrdiff_t storageOffset_, at::IntArrayRef size_, at::IntArrayRef stride_);
-TH_CPP_API c10::optional<std::vector<int64_t>> THTensor_compute_stride(
+TH_API void THTensor_resize(THTensor *self, at::IntArrayRef size, at::IntArrayRef stride);
+TH_API void THTensor_setStorage(THTensor *self, THStorage *storage_, ptrdiff_t storageOffset_, at::IntArrayRef size_, at::IntArrayRef stride_);
+TH_API c10::optional<std::vector<int64_t>> THTensor_compute_stride(
     at::IntArrayRef oldshape,
     at::IntArrayRef oldstride,
     at::IntArrayRef newshape);

--- a/aten/src/TH/generic/THTensor.hpp
+++ b/aten/src/TH/generic/THTensor.hpp
@@ -8,13 +8,13 @@
 // NOTE: functions exist here only to support dispatch via Declarations.cwrap.  You probably don't want to put
 // new functions in here, they should probably be un-genericized.
 
-TH_CPP_API void THTensor_(setStorage)(THTensor *self, THStorage *storage_, ptrdiff_t storageOffset_,
+TH_API void THTensor_(setStorage)(THTensor *self, THStorage *storage_, ptrdiff_t storageOffset_,
                                       at::IntArrayRef size_, at::IntArrayRef stride_);
 /* strides.data() might be NULL */
-TH_CPP_API THTensor *THTensor_(newWithStorage)(THStorage *storage, ptrdiff_t storageOffset,
+TH_API THTensor *THTensor_(newWithStorage)(THStorage *storage, ptrdiff_t storageOffset,
                                                at::IntArrayRef sizes, at::IntArrayRef strides);
 
-TH_CPP_API void THTensor_(resize)(THTensor *self, at::IntArrayRef size, at::IntArrayRef stride);
-TH_CPP_API THTensor *THTensor_(newWithSize)(at::IntArrayRef size, at::IntArrayRef stride);
+TH_API void THTensor_(resize)(THTensor *self, at::IntArrayRef size, at::IntArrayRef stride);
+TH_API THTensor *THTensor_(newWithSize)(at::IntArrayRef size, at::IntArrayRef stride);
 
 #endif

--- a/aten/src/THC/THCGeneral.h.in
+++ b/aten/src/THC/THCGeneral.h.in
@@ -18,7 +18,7 @@
 
 // TH & THC are now part of the same library as ATen and Caffe2
 // NB: However, we are planning to split it out to a torch_cuda library
-#define THC_API THC_EXTERNC TORCH_CUDA_API
+#define THC_API TORCH_CUDA_API
 #define THC_CLASS TORCH_CUDA_API
 
 #ifndef THAssert


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#29919 Stop exporting TH/THC symbols as extern "C".**

This is back from the old days when we had C clients, but we no
longer have this.  Switch off extern "C".

This makes us less likely to run into a ROCm bug where functions
declared __host__ do not respect extern "C" in the header forward
declaration (you have to explicitly respecify it on the implementation.)
Bug reference: https://github.com/RadeonOpenCompute/hcc/issues/839

Signed-off-by: Edward Z. Yang <ezyang@fb.com>