### PR TITLE
Update distributed autograd design doc with appropriate links.

### DIFF
--- a/docs/source/notes/autograd.rst
+++ b/docs/source/notes/autograd.rst
@@ -1,3 +1,5 @@
+.. _autograd-mechanics:
+
 Autograd mechanics
 ==================
 
@@ -55,6 +57,8 @@ will also require them.
 
     # Optimize only the classifier
     optimizer = optim.SGD(model.fc.parameters(), lr=1e-2, momentum=0.9)
+
+.. _how-autograd-encodes-history:
 
 How autograd encodes the history
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/notes/distributed_autograd.rst
+++ b/docs/source/notes/distributed_autograd.rst
@@ -1,3 +1,6 @@
+.. warning::
+  The :ref:`distributed-rpc-framework` is experimental and subject to change.
+
 Distributed Autograd Design
 ===========================
 

--- a/docs/source/rpc.rst
+++ b/docs/source/rpc.rst
@@ -1,5 +1,4 @@
-.. role:: hidden
-    :class: hidden-section
+.. _distributed-rpc-framework:
 
 Distributed RPC Framework
 =========================
@@ -25,6 +24,8 @@ and distributed autograd.
 
 .. automodule:: torch.distributed.rpc
 .. autofunction:: init_model_parallel
+
+.. _rref:
 
 RRef
 ----


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#29927 Update distributed autograd design doc with appropriate links.**

With the docs page now up, we can update the links in the design doc
to point to the docs page.

Differential Revision: [D18541878](https://our.internmc.facebook.com/intern/diff/D18541878/)