### PR TITLE
make python remote exception to rethrow when using remote reference to itself

### DIFF
--- a/test/rpc_test.py
+++ b/test/rpc_test.py
@@ -940,8 +940,13 @@ class RpcTest(object):
     def test_remote_with_exception(self):
         n = self.rank + 1
         dst_rank = n % self.world_size
+        # check ref to other workers
         rref = rpc.remote("worker{}".format(dst_rank), raise_func)
         with self.assertRaisesRegex(Exception, "ValueError"):
+            rref.to_here()
+        # check ref to itself
+        rref = rpc.remote("worker{}".format(self.rank), no_result, args=(10,))
+        with self.assertRaisesRegex(Exception, "TypeError"):
             rref.to_here()
 
     @dist_init

--- a/torch/csrc/distributed/rpc/python_rpc_handler.cpp
+++ b/torch/csrc/distributed/rpc/python_rpc_handler.cpp
@@ -24,6 +24,7 @@ PythonRpcHandler::PythonRpcHandler() {
   pyRunFunction_ = getFunction(module, "_run_function");
   pyLoadReturnValue_ = getFunction(module, "_load_return_value");
   pySerialize_ = getFunction(module, "serialize");
+  pyHandleException_ = getFunction(module, "_handle_exception");
 }
 
 void PythonRpcHandler::cleanup() {
@@ -31,6 +32,7 @@ void PythonRpcHandler::cleanup() {
   pyRunFunction_ = py::none();
   pyLoadReturnValue_ = py::none();
   pySerialize_ = py::none();
+  pyHandleException_ = py::none();
 }
 
 PythonRpcHandler& PythonRpcHandler::getInstance() {
@@ -77,6 +79,11 @@ py::object PythonRpcHandler::deserialize(const SerializedPyObj& serializedObj) {
   AutoGIL ag;
   return pyLoadReturnValue_(
       py::bytes(serializedObj.payload_), serializedObj.tensors_);
+}
+
+void PythonRpcHandler::handleException(const py::object& obj) {
+  AutoGIL ag;
+  pyHandleException_(obj);
 }
 
 } // namespace rpc

--- a/torch/csrc/distributed/rpc/python_rpc_handler.h
+++ b/torch/csrc/distributed/rpc/python_rpc_handler.h
@@ -39,6 +39,9 @@ class PYBIND11_EXPORT PythonRpcHandler {
   // Deserialize a string into a py::object
   py::object deserialize(const SerializedPyObj& serializedObj);
 
+  // Check if obj is RemoteException, then throw it
+  void handleException(const py::object& obj);
+
   // Explicitly clean up py::objects to avoid segment faults when
   // py::objects with CPython are cleaned up later at program exit
   // See similar issues reported https://github.com/pybind/pybind11/issues/1598
@@ -71,6 +74,9 @@ class PYBIND11_EXPORT PythonRpcHandler {
 
   // Ref to `torch.distributed.rpc.internal.serialize`.
   py::object pySerialize_;
+
+  // Ref to 'torch.distributed.rpc.internal._handle_exception'
+  py::object pyHandleException_;
 };
 
 } // namespace rpc

--- a/torch/csrc/distributed/rpc/rref.cpp
+++ b/torch/csrc/distributed/rpc/rref.cpp
@@ -199,11 +199,20 @@ template class UserRRef<py::object>;
 
 //////////////////////////  OwnerRRef  /////////////////////////////////////
 
-template <typename T>
-const T& OwnerRRef<T>::getValue() const {
+template <>
+const IValue& OwnerRRef<IValue>::getValue() const {
   // TODO: use callback to make this non-blocking
   std::unique_lock<std::mutex> lock(mutex_);
   valueCV_.wait(lock, [this] { return value_.has_value(); });
+  return value_.value();
+}
+
+template <>
+const py::object& OwnerRRef<py::object>::getValue() const {
+  // TODO: use callback to make this non-blocking
+  std::unique_lock<std::mutex> lock(mutex_);
+  valueCV_.wait(lock, [this] { return value_.has_value(); });
+  PythonRpcHandler::getInstance().handleException(value_.value());
   return value_.value();
 }
 

--- a/torch/distributed/rpc/internal.py
+++ b/torch/distributed/rpc/internal.py
@@ -119,6 +119,9 @@ def _run_function(binary_data, tensor_table):
         result = RemoteException(except_str)
     return result
 
+def _handle_exception(result):
+    if isinstance(result, RemoteException):
+        raise Exception(result.msg)
 
 def _load_return_value(binary_data, tensor_table):
     r"""
@@ -129,8 +132,7 @@ def _load_return_value(binary_data, tensor_table):
     Raises exception if the return value is a wrapped exception.
     """
     result = _internal_rpc_pickler.deserialize(binary_data, tensor_table)
-    if isinstance(result, RemoteException):
-        raise Exception(result.msg)
+    _handle_exception(result)
     return result
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#29929 make python remote exception to rethrow when using remote reference to itself**

Right now, python call remote exception rethrown is coupled with deserializtiaon.
For owner ref, the setValue() and getValue() do not use serialization and deserialization, so when users create a ref to itself, and call ownerRef.to_here(), python call remote exception will not be rethrown.

This diff is to move remote exception rethrown out of deserialization, and exception can be handled for owner ref getValue()

Differential Revision: [D18541916](https://our.internmc.facebook.com/intern/diff/D18541916/)