### PR TITLE
[jit] Fix hex literal parsing

### DIFF
--- a/c10/util/string_utils.h
+++ b/c10/util/string_utils.h
@@ -65,9 +65,6 @@ inline long long stoll(const std::string& str) {
 }
 
 inline long long stoll(const std::string& str, size_t pos, int base) {
-  // Anything other than 0 for both of these is unimplemented
-  AT_ASSERT(pos == 0);
-  AT_ASSERT(base == 0);
   // std::stoll doesn't exist in our Android environment, we need to implement
   // it ourselves.
   std::stringstream s;

--- a/c10/util/string_utils.h
+++ b/c10/util/string_utils.h
@@ -63,6 +63,28 @@ inline long long stoll(const std::string& str) {
   s >> result;
   return result;
 }
+
+inline long long stoll(const std::string& str, size_t pos, int base) {
+  // Anything other than 0 for both of these is unimplemented
+  AT_ASSERT(pos == 0);
+  AT_ASSERT(base == 0);
+  // std::stoll doesn't exist in our Android environment, we need to implement
+  // it ourselves.
+  std::stringstream s;
+  if (str.size() > 0 && str.at(0) == '0') {
+    if (str.size() > 1 && (str.at(1) == 'x' || str.at(1) == 'X')) {
+      s << std::hex << str;
+    } else {
+      s << std::oct << str;
+    }
+  } else {
+    s << str;
+  }
+  long long result = 0;
+  s >> result;
+  return result;
+}
+
 #else
 #define CAFFE2_TESTONLY_WE_ARE_USING_CUSTOM_STRING_FUNCTIONS 0
 using std::stod;

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -3975,6 +3975,40 @@ def foo(x):
         with self.assertRaisesRegex(RuntimeError, "out of range"):
             torch.jit.script(waytoobig)
 
+    def test_hex_literals(self):
+        def test1():
+            return 0xaaaaaa
+
+        def test2():
+            return 0xaaaaaa
+
+        def test3():
+            return -0xaaaaaa
+
+        self.checkScript(test1, [])
+        self.checkScript(test2, [])
+        self.checkScript(test3, [])
+
+        def ok():
+            a = 0x7FFFFFFFFFFFFFFF
+            return a
+
+        def toobig():
+            a = 0xFFFFFFFFFFFFFFFF
+            return a
+
+        def waytoobig():
+            a = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+            return a
+
+        self.checkScript(ok, [])
+
+        with self.assertRaisesRegex(RuntimeError, "out of range"):
+            torch.jit.script(toobig)
+
+        with self.assertRaisesRegex(RuntimeError, "out of range"):
+            torch.jit.script(waytoobig)
+
     def test_eval_python(self):
         def _test(m):
             self.assertTrue(m(torch.ones(2, 2)))

--- a/torch/csrc/jit/script/tree_views.h
+++ b/torch/csrc/jit/script/tree_views.h
@@ -801,7 +801,7 @@ struct Const : public Expr {
   }
   int64_t asIntegral() const {
     try {
-      return c10::stoll(subtree(0)->stringValue());
+      return c10::stoll(subtree(0)->stringValue(), /*pos=*/0, /*base=*/0);
     } catch (const std::out_of_range& e) {
       throw ErrorReport(range()) << "Integral constant out of range "
                                     "(must fit in a signed 64 bit integer)";


### PR DESCRIPTION
Stacked PRs
 * #29940 - [jit] Fix parsing of big float literals
 * **#29935 - [jit] Fix hex literal parsing**
 * #29931 - [jit] Throw a better error for int too big for int64_t

Previously these were all parsed as `0`

Differential Revision: [D19124944](https://our.internmc.facebook.com/intern/diff/19124944/)