### PR TITLE
NOT FOR COMMIT: Add previously broken build to PR workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1946,6 +1946,16 @@ workflows:
       # pytorch-ci-hud to adjust the list of whitelisted builds
       # at https://github.com/ezyang/pytorch-ci-hud/blob/master/src/BuildHistoryDisplay.js
 
+      # This job failed in the nightly run due to a bad docker image:
+      # https://circleci.com/gh/pytorch/pytorch/3620761
+      - binary_linux_build:
+          name: binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_nightly_shared-with-deps_build
+          build_environment: "libtorch 2.7m cpu gcc5.4_cxx11-abi"
+          requires:
+            - setup
+          libtorch_variant: "shared-with-deps"
+          docker_image: "pytorch/conda-cuda-cxx11-ubuntu1604:latest"
+
       - binary_linux_build:
           name: binary_linux_manywheel_2_7mu_cpu_devtoolset7_build
           build_environment: "manywheel 2.7mu cpu devtoolset7"

--- a/.circleci/verbatim-sources/workflows-binary-builds-smoke-subset.yml
+++ b/.circleci/verbatim-sources/workflows-binary-builds-smoke-subset.yml
@@ -5,6 +5,16 @@
       # pytorch-ci-hud to adjust the list of whitelisted builds
       # at https://github.com/ezyang/pytorch-ci-hud/blob/master/src/BuildHistoryDisplay.js
 
+      # This job failed in the nightly run due to a bad docker image:
+      # https://circleci.com/gh/pytorch/pytorch/3620761
+      - binary_linux_build:
+          name: binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_nightly_shared-with-deps_build
+          build_environment: "libtorch 2.7m cpu gcc5.4_cxx11-abi"
+          requires:
+            - setup
+          libtorch_variant: "shared-with-deps"
+          docker_image: "pytorch/conda-cuda-cxx11-ubuntu1604:latest"
+
       - binary_linux_build:
           name: binary_linux_manywheel_2_7mu_cpu_devtoolset7_build
           build_environment: "manywheel 2.7mu cpu devtoolset7"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #29943 Switch Docker image onda-cuda-cxx11-ubuntu1604 to new uniform name
* **#29941 NOT FOR COMMIT: Add previously broken build to PR workflow**

This was broken in my nightly run.  I'm temporarily adding to the PR job
list to make sure my upcoming docker rename doesn't break it.  This
change won't be landed.