### PR TITLE
Add LiteModule java class for lite interpreter.

### DIFF
--- a/android/pytorch_android/build.gradle
+++ b/android/pytorch_android/build.gradle
@@ -27,6 +27,10 @@ android {
     }
     sourceSets {
         main {
+            java {
+                exclude 'org/pytorch/LiteModuleLoader.java'
+                exclude 'org/pytorch/LiteNativePeer.java'
+            }
             jniLibs.srcDirs = ['src/main/jniLibs']
         }
     }

--- a/android/pytorch_android/src/main/java/org/pytorch/INativePeer.java
+++ b/android/pytorch_android/src/main/java/org/pytorch/INativePeer.java
@@ -1,0 +1,11 @@
+// (c) Facebook, Inc. and its affiliates. Confidential and proprietary.
+
+package org.pytorch;
+
+interface INativePeer {
+  void resetNative();
+
+  IValue forward(IValue... inputs);
+
+  IValue runMethod(String methodName, IValue... inputs);
+}

--- a/android/pytorch_android/src/main/java/org/pytorch/LiteModuleLoader.java
+++ b/android/pytorch_android/src/main/java/org/pytorch/LiteModuleLoader.java
@@ -1,0 +1,10 @@
+// (c) Facebook, Inc. and its affiliates. Confidential and proprietary.
+
+package org.pytorch;
+
+public class LiteModuleLoader {
+
+  public static Module load(final String modelPath) {
+    return new Module(new LiteNativePeer(modelPath));
+  }
+}

--- a/android/pytorch_android/src/main/java/org/pytorch/LiteNativePeer.java
+++ b/android/pytorch_android/src/main/java/org/pytorch/LiteNativePeer.java
@@ -1,0 +1,28 @@
+// (c) Facebook, Inc. and its affiliates. Confidential and proprietary.
+
+package org.pytorch;
+
+import com.facebook.jni.HybridData;
+import com.facebook.soloader.nativeloader.NativeLoader;
+
+class LiteNativePeer implements INativePeer {
+  static {
+    NativeLoader.loadLibrary("pytorch_jni_lite");
+  }
+
+  private final HybridData mHybridData;
+
+  private static native HybridData initHybrid(String moduleAbsolutePath);
+
+  LiteNativePeer(String moduleAbsolutePath) {
+    mHybridData = initHybrid(moduleAbsolutePath);
+  }
+
+  void resetNative() {
+    mHybridData.resetNative();
+  }
+
+  native IValue forward(IValue... inputs);
+
+  native IValue runMethod(String methodName, IValue... inputs);
+}

--- a/android/pytorch_android/src/main/java/org/pytorch/Module.java
+++ b/android/pytorch_android/src/main/java/org/pytorch/Module.java
@@ -2,16 +2,13 @@
 
 package org.pytorch;
 
-import com.facebook.jni.HybridData;
 import com.facebook.soloader.nativeloader.NativeLoader;
 import com.facebook.soloader.nativeloader.SystemDelegate;
 
-/**
- * Java wrapper for torch::jit::script::Module.
- */
+/** Java wrapper for torch::jit::script::Module. */
 public class Module {
 
-  private NativePeer mNativePeer;
+  private INativePeer mNativePeer;
 
   /**
    * Loads a serialized TorchScript module from the specified path on the disk.
@@ -20,14 +17,14 @@ public class Module {
    * @return new {@link org.pytorch.Module} object which owns torch::jit::script::Module.
    */
   public static Module load(final String modelPath) {
-    return new Module(modelPath);
+    return new Module(new NativePeer(modelPath));
   }
 
-  private Module(final String moduleAbsolutePath) {
+  Module(INativePeer nativePeer) {
     if (!NativeLoader.isInitialized()) {
       NativeLoader.init(new SystemDelegate());
     }
-    this.mNativePeer = new NativePeer(moduleAbsolutePath);
+    this.mNativePeer = nativePeer;
   }
 
   /**
@@ -44,7 +41,7 @@ public class Module {
    * Runs the specified method of this module with the specified arguments.
    *
    * @param methodName name of the TorchScript method to run.
-   * @param inputs     arguments that will be passed to TorchScript method.
+   * @param inputs arguments that will be passed to TorchScript method.
    * @return return value from the method.
    */
   public IValue runMethod(String methodName, IValue... inputs) {
@@ -52,31 +49,12 @@ public class Module {
   }
 
   /**
-   * Explicitly destroys the native torch::jit::script::Module.
-   * Calling this method is not required, as the native object will be destroyed
-   * when this object is garbage-collected.  However, the timing of garbage collection
-   * is not guaranteed, so proactively calling {@code destroy} can free memory more quickly.
-   * See {@link com.facebook.jni.HybridData#resetNative}.
+   * Explicitly destroys the native torch::jit::script::Module. Calling this method is not required,
+   * as the native object will be destroyed when this object is garbage-collected. However, the
+   * timing of garbage collection is not guaranteed, so proactively calling {@code destroy} can free
+   * memory more quickly. See {@link com.facebook.jni.HybridData#resetNative}.
    */
   public void destroy() {
-    mNativePeer.mHybridData.resetNative();
-  }
-
-  private static class NativePeer {
-    static {
-      NativeLoader.loadLibrary("pytorch_jni");
-    }
-
-    private final HybridData mHybridData;
-
-    private static native HybridData initHybrid(String moduleAbsolutePath);
-
-    NativePeer(String moduleAbsolutePath) {
-      mHybridData = initHybrid(moduleAbsolutePath);
-    }
-
-    private native IValue forward(IValue... inputs);
-
-    private native IValue runMethod(String methodName, IValue... inputs);
+    mNativePeer.resetNative();
   }
 }

--- a/android/pytorch_android/src/main/java/org/pytorch/NativePeer.java
+++ b/android/pytorch_android/src/main/java/org/pytorch/NativePeer.java
@@ -1,0 +1,28 @@
+// (c) Facebook, Inc. and its affiliates. Confidential and proprietary.
+
+package org.pytorch;
+
+import com.facebook.jni.HybridData;
+import com.facebook.soloader.nativeloader.NativeLoader;
+
+class NativePeer implements INativePeer {
+  static {
+    NativeLoader.loadLibrary("pytorch_jni");
+  }
+
+  private final HybridData mHybridData;
+
+  private static native HybridData initHybrid(String moduleAbsolutePath);
+
+  NativePeer(String moduleAbsolutePath) {
+    mHybridData = initHybrid(moduleAbsolutePath);
+  }
+
+  void resetNative() {
+    mHybridData.resetNative();
+  }
+
+  native IValue forward(IValue... inputs);
+
+  native IValue runMethod(String methodName, IValue... inputs);
+}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#29956 Add LiteModule java class for lite interpreter.**

**As title: Add LiteModule java class for lite interpreter.**

1. Create LiteModule to handle pytorch_jni_lite binding separately to avoid one java file binding with two cpp files problem. This will also enable us to switch between full JIT and lite interpreter for production testing.
2. Change android buck file to have separate pytorch_jni_lite and pytorch_lite target.
3. Change APP_MODULE_CONFIGS to add pytorch_lite voltron module.

Differential Revision: [D18511688](https://our.internmc.facebook.com/intern/diff/D18511688/)