### PR TITLE
Add overload name to JIT prim operators, version 2

### DIFF
--- a/test/backward_compatibility/check_backward_compatibility.py
+++ b/test/backward_compatibility/check_backward_compatibility.py
@@ -23,6 +23,7 @@ white_list = [
     ('cudnn_batch_norm', datetime.date(2019, 11, 15)),
     ('cudnn_batch_norm_backward', datetime.date(2019, 11, 15)),
     ('_nnpack_spatial_convolution', datetime.date(2019, 11, 12)),
+    ('append', datetime.date(2019, 11, 22)),
     ('thnn_conv3d', datetime.date(9999, 1, 1)),
     ('thnn_conv3d.out', datetime.date(9999, 1, 1)),
 ]

--- a/test/cpp/jit/test_lite_interpreter.cpp
+++ b/test/cpp/jit/test_lite_interpreter.cpp
@@ -112,5 +112,21 @@ void testLiteInterpreterTuple() {
   auto output = bc.run_method("forward", inputs);
   AT_ASSERT(output.toTuple()->elements()[1].toInt() == 2);
 }
+
+void testLiteInterpreterPrimOverload() {
+  script::Module m("m");
+  m.define(R"JIT(
+  def forward(self, x):
+      result = [1, 2]
+      result.append(3)
+      return result
+  )JIT");
+  std::stringstream ss;
+  m._save_for_mobile(ss);
+  mobile::Module bc = _load_for_mobile(ss);
+  std::vector<torch::jit::IValue> inputs({torch::ones({})});
+  auto output = bc.run_method("forward", inputs);
+  AT_ASSERT(output.toIntList()[2] == 3);
+}
 } // namespace torch
 } // namespace jit

--- a/test/cpp/jit/tests.h
+++ b/test/cpp/jit/tests.h
@@ -70,6 +70,7 @@ namespace jit {
   _(LiteInterpreterConv)               \
   _(LiteInterpreterInline)             \
   _(LiteInterpreterTuple)              \
+  _(LiteInterpreterPrimOverload)       \
   _(CommonAncestor)
 
 #define TH_FORALL_TESTS_CUDA(_) \

--- a/torch/csrc/jit/mobile/interpreter.cpp
+++ b/torch/csrc/jit/mobile/interpreter.cpp
@@ -25,7 +25,13 @@ void listConstruct(Stack& stack, int num_inputs) {
 bool InterpreterState::run(Stack& stack) {
   size_t pc = 0;
   while (true) {
+    Instruction inst = code_->instructions_[pc];
+
 //    std::cout << "RUNNING " << pc << " " << code_->instructions_[pc];
+//    if (inst.op == OP) {
+//      std::cout << ", " << code_->op_names_[inst.X].name << "." <<
+//        code_->op_names_[inst.X].overload_name;
+//    }
 //    std::cout << std::endl;
 //    for (auto val : stack) {
 //      if (val.isTensor()) {
@@ -34,7 +40,6 @@ bool InterpreterState::run(Stack& stack) {
 //        std::cout << val << std::endl;
 //      }
 //    }
-    Instruction inst = code_->instructions_[pc];
     switch (inst.op) {
       case OP: {
         c10::Dispatcher::singleton().callBoxed(*code_->operators_[inst.X], &stack);

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -2476,11 +2476,11 @@ RegisterOperators reg2({
           listSelect<value_type>,                                              \
           aliasAnalysisFromSchema()),                                          \
       Operator(                                                                \
-          "prim::min." decl_type "( " decl_type "[] l, " decl_type "[] r) -> " decl_type "[]",\
+          "prim::min.lr" decl_type "( " decl_type "[] l, " decl_type "[] r) -> " decl_type "[]",\
           minList<value_type>,                                                 \
           aliasAnalysisFromSchema()),                                          \
       Operator(                                                                \
-          "prim::max." decl_type "( " decl_type "[] l, " decl_type "[] r) -> " decl_type "[]",\
+          "prim::max.lr" decl_type "( " decl_type "[] l, " decl_type "[] r) -> " decl_type "[]",\
           maxList<value_type>,                                                 \
           aliasAnalysisFromSchema()),                                          \
       Operator(                                                                \

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -2400,36 +2400,36 @@ RegisterOperators reg2({
 // Mutable ops for lists containing mutable types.
 #define CREATE_MUTABLE_LIST_OPS(decl_type, value_type)                        \
   Operator(                                                                   \
-      "aten::select(" decl_type "[](a) list, int idx) -> " decl_type "(*)",   \
+      "aten::select." decl_type "( " decl_type "[](a) list, int idx) -> " decl_type "(*)",   \
       listSelect<value_type>,                                                 \
       aliasAnalysisFromSchema()),                                             \
       Operator(                                                               \
-          "aten::__getitem__(" decl_type "[](a) list, int idx) -> " decl_type \
+          "aten::__getitem__." decl_type "( " decl_type "[](a) list, int idx) -> " decl_type \
           "(*)",                                                              \
           listSelect<value_type>,                                             \
           aliasAnalysisFromSchema()),                                         \
       Operator(                                                               \
-          "aten::append( " decl_type "[](a!) self, " decl_type                \
+          "aten::append." decl_type "( " decl_type "[](a!) self, " decl_type                \
           "(c -> *) el) -> " decl_type "[](a!)",                              \
           listAppend<value_type>,                                             \
           aliasAnalysisFromSchema()),                                         \
       Operator(                                                               \
-          "aten::reverse( " decl_type "[](a!) self) -> ()",                   \
+          "aten::reverse." decl_type "( " decl_type "[](a!) self) -> ()",                   \
           listReverse<value_type>,                                            \
           aliasAnalysisFromSchema()),                                         \
       Operator(                                                               \
-          "aten::extend(" decl_type "[](a!) self, " decl_type                 \
+          "aten::extend." decl_type "( " decl_type "[](a!) self, " decl_type                 \
           " [] other) -> ()",                                                 \
           listExtend<value_type>,                                             \
           aliasAnalysisFromSchema()),                                         \
       Operator(                                                               \
-          "aten::copy(" decl_type                                             \
+          "aten::copy." decl_type "( " decl_type                                             \
           "[](a) self)"                                                       \
           " -> " decl_type "[]",                                              \
           listCopy<value_type>,                                               \
           aliasAnalysisFromSchema()),                                         \
       Operator(                                                               \
-          "aten::_set_item(" decl_type "[](a!) l, int idx, " decl_type        \
+          "aten::_set_item." decl_type "( " decl_type "[](a!) l, int idx, " decl_type        \
           "(b -> *) el) -> " decl_type "[](a!)",                              \
           listSetItem<value_type>,                                            \
           aliasAnalysisFromSchema()),                                         \
@@ -2444,7 +2444,7 @@ RegisterOperators reg2({
           listInsert<value_type>,                                             \
           aliasAnalysisFromSchema()),                                         \
       Operator(                                                               \
-          "aten::pop(" decl_type                                              \
+          "aten::pop." decl_type "( " decl_type                                              \
           "[](a!) self, int idx=-1)                                                 \
         -> " decl_type "(*)",                                                 \
           listPop<value_type>,                                                \
@@ -2468,51 +2468,51 @@ RegisterOperators reg2({
 // Mutable ops for lists containing immutable types.
 #define CREATE_IMMUTABLE_LIST_OPS(decl_type, value_type)                       \
   Operator(                                                                    \
-      "aten::select(" decl_type "[] a, int b) -> " decl_type,                  \
+      "aten::select." decl_type "( " decl_type "[] a, int b) -> " decl_type,                  \
       listSelect<value_type>,                                                  \
       aliasAnalysisFromSchema()),                                              \
       Operator(                                                                \
-          "aten::__getitem__(" decl_type "[](a) list, int idx) -> " decl_type, \
+          "aten::__getitem__." decl_type "( " decl_type "[](a) list, int idx) -> " decl_type, \
           listSelect<value_type>,                                              \
           aliasAnalysisFromSchema()),                                          \
       Operator(                                                                \
-          "prim::min(" decl_type "[] l, " decl_type "[] r) -> " decl_type "[]",\
+          "prim::min." decl_type "( " decl_type "[] l, " decl_type "[] r) -> " decl_type "[]",\
           minList<value_type>,                                                 \
           aliasAnalysisFromSchema()),                                          \
       Operator(                                                                \
-          "prim::max(" decl_type "[] l, " decl_type "[] r) -> " decl_type "[]",\
+          "prim::max." decl_type "( " decl_type "[] l, " decl_type "[] r) -> " decl_type "[]",\
           maxList<value_type>,                                                 \
           aliasAnalysisFromSchema()),                                          \
       Operator(                                                                \
-          "aten::append(" decl_type "[](a!) self, " decl_type                  \
+          "aten::append." decl_type "( " decl_type "[](a!) self, " decl_type                  \
           " el) -> " decl_type "[](a!)",                                       \
           listAppend<value_type>,                                              \
           aliasAnalysisFromSchema()),                                          \
       Operator(                                                                \
-          "aten::reverse(" decl_type "[](a!) self) -> ()",                     \
+          "aten::reverse." decl_type "( " decl_type "[](a!) self) -> ()",                     \
           listReverse<value_type>,                                             \
           aliasAnalysisFromSchema()),                                          \
       Operator(                                                                \
-          "prim::min(" decl_type "[] self) -> " decl_type,                     \
+          "prim::min." decl_type "( " decl_type "[] self) -> " decl_type,                     \
           listMin<value_type>,                                                 \
           aliasAnalysisFromSchema()),                                          \
       Operator(                                                                \
-          "prim::max(" decl_type "[] self) -> " decl_type,                     \
+          "prim::max." decl_type "( " decl_type "[] self) -> " decl_type,                     \
           listMax<value_type>,                                                 \
           aliasAnalysisFromSchema()),                                          \
       Operator(                                                                \
-          "aten::extend(" decl_type "[](a!) self, " decl_type                  \
+          "aten::extend." decl_type "( " decl_type "[](a!) self, " decl_type                  \
           " [] other) -> ()",                                                  \
           listExtend<value_type>,                                              \
           aliasAnalysisFromSchema()),                                          \
       Operator(                                                                \
-          "aten::copy(" decl_type                                              \
+          "aten::copy." decl_type "( " decl_type                                              \
           "[](a) self)"                                                        \
           " -> " decl_type "[]",                                               \
           listCopy<value_type>,                                                \
           aliasAnalysisFromSchema()),                                          \
       Operator(                                                                \
-          "aten::_set_item(" decl_type "[](a!) l, int idx, " decl_type         \
+          "aten::_set_item." decl_type "( " decl_type "[](a!) l, int idx, " decl_type         \
           " el) -> " decl_type "[](a!)",                                       \
           listSetItem<value_type>,                                             \
           aliasAnalysisFromSchema()),                                          \
@@ -2527,25 +2527,25 @@ RegisterOperators reg2({
           listInsert<value_type>,                                              \
           aliasAnalysisFromSchema()),                                          \
       Operator(                                                                \
-          "aten::remove(" decl_type                                            \
+          "aten::remove." decl_type "( " decl_type                                            \
           "[](a!) self,                                                           \
           " decl_type " el) -> ()",                                            \
           listRemove<value_type>,                                              \
           aliasAnalysisFromSchema()),                                          \
       Operator(                                                                \
-          "aten::index(" decl_type                                             \
+          "aten::index." decl_type "( " decl_type                                             \
           "[] self,                                                               \
           " decl_type " el) -> int",                                           \
           listIndex<value_type>,                                               \
           aliasAnalysisFromSchema()),                                          \
       Operator(                                                                \
-          "aten::count(" decl_type                                             \
+          "aten::count." decl_type "( " decl_type                                             \
           "[] self,                                                               \
           " decl_type " el) -> int",                                           \
           listCount<value_type>,                                               \
           aliasAnalysisFromSchema()),                                          \
       Operator(                                                                \
-          "aten::pop(" decl_type                                               \
+          "aten::pop." decl_type "( " decl_type                                               \
           "[](a!) self, int idx=-1)                                               \
           -> " decl_type,                                                      \
           listPop<value_type>,                                                 \
@@ -2572,31 +2572,31 @@ RegisterOperators reg2({
 
 #define CREATE_LIST_OPS(decl_type, c_type)                                          \
   Operator(                                                                         \
-      "aten::len(" decl_type "[] a) -> int",                                        \
+      "aten::len." decl_type "( " decl_type "[] a) -> int",                                        \
       listLen<c_type::value_type>,                                                  \
       aliasAnalysisFromSchema()),                                                   \
       Operator(                                                                     \
-          "aten::add(" decl_type "[] a, " decl_type "[] b) -> " decl_type           \
+          "aten::add." decl_type "( " decl_type "[] a, " decl_type "[] b) -> " decl_type           \
           "[]",                                                                     \
           listAdd<c_type::value_type>,                                              \
           aliasAnalysisFromSchema()),                                               \
       Operator(                                                                     \
-          "aten::add_(" decl_type "[](a!) self, " decl_type                         \
+          "aten::add_." decl_type "( " decl_type "[](a!) self, " decl_type                         \
           "[] b) -> " decl_type "[]",                                               \
           listInplaceAdd<c_type::value_type>,                                       \
           aliasAnalysisFromSchema()),                                               \
       Operator(                                                                     \
-          "aten::slice(" decl_type                                                  \
+          "aten::slice." decl_type "( " decl_type                                                  \
           "[] l, int start, int end=9223372036854775807, int step=1) -> " decl_type \
           "[]",                                                                     \
           listSlice<c_type::value_type>,                                            \
           aliasAnalysisFromSchema()),                                               \
       Operator(                                                                     \
-          "aten::list(" decl_type "[] l) -> " decl_type "[]",                       \
+          "aten::list." decl_type "( " decl_type "[] l) -> " decl_type "[]",                       \
           listList<c_type::value_type>,                                             \
           aliasAnalysisFromSchema()),                                               \
       Operator(                                                                     \
-          "aten::mul(" decl_type "[] l, int n) -> " decl_type "[]",                 \
+          "aten::mul." decl_type "( " decl_type "[] l, int n) -> " decl_type "[]",                 \
           listMulIntLeft<c_type::value_type>,                                       \
           aliasAnalysisFromSchema()),                                               \
       Operator(                                                                     \

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -2476,11 +2476,11 @@ RegisterOperators reg2({
           listSelect<value_type>,                                              \
           aliasAnalysisFromSchema()),                                          \
       Operator(                                                                \
-          "prim::min.lr" decl_type "( " decl_type "[] l, " decl_type "[] r) -> " decl_type "[]",\
+          "prim::min(" decl_type "[] l, " decl_type "[] r) -> " decl_type "[]",\
           minList<value_type>,                                                 \
           aliasAnalysisFromSchema()),                                          \
       Operator(                                                                \
-          "prim::max.lr" decl_type "( " decl_type "[] l, " decl_type "[] r) -> " decl_type "[]",\
+          "prim::max(" decl_type "[] l, " decl_type "[] r) -> " decl_type "[]",\
           maxList<value_type>,                                                 \
           aliasAnalysisFromSchema()),                                          \
       Operator(                                                                \

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -2400,36 +2400,36 @@ RegisterOperators reg2({
 // Mutable ops for lists containing mutable types.
 #define CREATE_MUTABLE_LIST_OPS(decl_type, value_type)                        \
   Operator(                                                                   \
-      "aten::select." decl_type "( " decl_type "[](a) list, int idx) -> " decl_type "(*)",   \
+      "aten::select(" decl_type "[](a) list, int idx) -> " decl_type "(*)",   \
       listSelect<value_type>,                                                 \
       aliasAnalysisFromSchema()),                                             \
       Operator(                                                               \
-          "aten::__getitem__." decl_type "( " decl_type "[](a) list, int idx) -> " decl_type \
+          "aten::__getitem__(" decl_type "[](a) list, int idx) -> " decl_type \
           "(*)",                                                              \
           listSelect<value_type>,                                             \
           aliasAnalysisFromSchema()),                                         \
       Operator(                                                               \
-          "aten::append." decl_type "( " decl_type "[](a!) self, " decl_type                \
+          "aten::append." decl_type "(" decl_type "[](a!) self, " decl_type                \
           "(c -> *) el) -> " decl_type "[](a!)",                              \
           listAppend<value_type>,                                             \
           aliasAnalysisFromSchema()),                                         \
       Operator(                                                               \
-          "aten::reverse." decl_type "( " decl_type "[](a!) self) -> ()",                   \
+          "aten::reverse(" decl_type "[](a!) self) -> ()",                   \
           listReverse<value_type>,                                            \
           aliasAnalysisFromSchema()),                                         \
       Operator(                                                               \
-          "aten::extend." decl_type "( " decl_type "[](a!) self, " decl_type                 \
+          "aten::extend(" decl_type "[](a!) self, " decl_type                 \
           " [] other) -> ()",                                                 \
           listExtend<value_type>,                                             \
           aliasAnalysisFromSchema()),                                         \
       Operator(                                                               \
-          "aten::copy." decl_type "( " decl_type                                             \
+          "aten::copy(" decl_type                                             \
           "[](a) self)"                                                       \
           " -> " decl_type "[]",                                              \
           listCopy<value_type>,                                               \
           aliasAnalysisFromSchema()),                                         \
       Operator(                                                               \
-          "aten::_set_item." decl_type "( " decl_type "[](a!) l, int idx, " decl_type        \
+          "aten::_set_item(" decl_type "[](a!) l, int idx, " decl_type        \
           "(b -> *) el) -> " decl_type "[](a!)",                              \
           listSetItem<value_type>,                                            \
           aliasAnalysisFromSchema()),                                         \
@@ -2444,7 +2444,7 @@ RegisterOperators reg2({
           listInsert<value_type>,                                             \
           aliasAnalysisFromSchema()),                                         \
       Operator(                                                               \
-          "aten::pop." decl_type "( " decl_type                                              \
+          "aten::pop(" decl_type                                              \
           "[](a!) self, int idx=-1)                                                 \
         -> " decl_type "(*)",                                                 \
           listPop<value_type>,                                                \
@@ -2468,11 +2468,11 @@ RegisterOperators reg2({
 // Mutable ops for lists containing immutable types.
 #define CREATE_IMMUTABLE_LIST_OPS(decl_type, value_type)                       \
   Operator(                                                                    \
-      "aten::select." decl_type "( " decl_type "[] a, int b) -> " decl_type,                  \
+      "aten::select(" decl_type "[] a, int b) -> " decl_type,                  \
       listSelect<value_type>,                                                  \
       aliasAnalysisFromSchema()),                                              \
       Operator(                                                                \
-          "aten::__getitem__." decl_type "( " decl_type "[](a) list, int idx) -> " decl_type, \
+          "aten::__getitem__(" decl_type "[](a) list, int idx) -> " decl_type, \
           listSelect<value_type>,                                              \
           aliasAnalysisFromSchema()),                                          \
       Operator(                                                                \
@@ -2484,35 +2484,35 @@ RegisterOperators reg2({
           maxList<value_type>,                                                 \
           aliasAnalysisFromSchema()),                                          \
       Operator(                                                                \
-          "aten::append." decl_type "( " decl_type "[](a!) self, " decl_type                  \
+          "aten::append." decl_type "(" decl_type "[](a!) self, " decl_type                  \
           " el) -> " decl_type "[](a!)",                                       \
           listAppend<value_type>,                                              \
           aliasAnalysisFromSchema()),                                          \
       Operator(                                                                \
-          "aten::reverse." decl_type "( " decl_type "[](a!) self) -> ()",                     \
+          "aten::reverse(" decl_type "[](a!) self) -> ()",                     \
           listReverse<value_type>,                                             \
           aliasAnalysisFromSchema()),                                          \
       Operator(                                                                \
-          "prim::min." decl_type "( " decl_type "[] self) -> " decl_type,                     \
+          "prim::min(" decl_type "[] self) -> " decl_type,                     \
           listMin<value_type>,                                                 \
           aliasAnalysisFromSchema()),                                          \
       Operator(                                                                \
-          "prim::max." decl_type "( " decl_type "[] self) -> " decl_type,                     \
+          "prim::max(" decl_type "[] self) -> " decl_type,                     \
           listMax<value_type>,                                                 \
           aliasAnalysisFromSchema()),                                          \
       Operator(                                                                \
-          "aten::extend." decl_type "( " decl_type "[](a!) self, " decl_type                  \
+          "aten::extend(" decl_type "[](a!) self, " decl_type                  \
           " [] other) -> ()",                                                  \
           listExtend<value_type>,                                              \
           aliasAnalysisFromSchema()),                                          \
       Operator(                                                                \
-          "aten::copy." decl_type "( " decl_type                                              \
+          "aten::copy(" decl_type                                              \
           "[](a) self)"                                                        \
           " -> " decl_type "[]",                                               \
           listCopy<value_type>,                                                \
           aliasAnalysisFromSchema()),                                          \
       Operator(                                                                \
-          "aten::_set_item." decl_type "( " decl_type "[](a!) l, int idx, " decl_type         \
+          "aten::_set_item(" decl_type "[](a!) l, int idx, " decl_type         \
           " el) -> " decl_type "[](a!)",                                       \
           listSetItem<value_type>,                                             \
           aliasAnalysisFromSchema()),                                          \
@@ -2527,25 +2527,25 @@ RegisterOperators reg2({
           listInsert<value_type>,                                              \
           aliasAnalysisFromSchema()),                                          \
       Operator(                                                                \
-          "aten::remove." decl_type "( " decl_type                                            \
+          "aten::remove(" decl_type                                            \
           "[](a!) self,                                                           \
           " decl_type " el) -> ()",                                            \
           listRemove<value_type>,                                              \
           aliasAnalysisFromSchema()),                                          \
       Operator(                                                                \
-          "aten::index." decl_type "( " decl_type                                             \
+          "aten::index(" decl_type                                             \
           "[] self,                                                               \
           " decl_type " el) -> int",                                           \
           listIndex<value_type>,                                               \
           aliasAnalysisFromSchema()),                                          \
       Operator(                                                                \
-          "aten::count." decl_type "( " decl_type                                             \
+          "aten::count(" decl_type                                             \
           "[] self,                                                               \
           " decl_type " el) -> int",                                           \
           listCount<value_type>,                                               \
           aliasAnalysisFromSchema()),                                          \
       Operator(                                                                \
-          "aten::pop." decl_type "( " decl_type                                               \
+          "aten::pop(" decl_type                                               \
           "[](a!) self, int idx=-1)                                               \
           -> " decl_type,                                                      \
           listPop<value_type>,                                                 \
@@ -2572,31 +2572,31 @@ RegisterOperators reg2({
 
 #define CREATE_LIST_OPS(decl_type, c_type)                                          \
   Operator(                                                                         \
-      "aten::len." decl_type "( " decl_type "[] a) -> int",                                        \
+      "aten::len(" decl_type "[] a) -> int",                                        \
       listLen<c_type::value_type>,                                                  \
       aliasAnalysisFromSchema()),                                                   \
       Operator(                                                                     \
-          "aten::add." decl_type "( " decl_type "[] a, " decl_type "[] b) -> " decl_type           \
+          "aten::add(" decl_type "[] a, " decl_type "[] b) -> " decl_type           \
           "[]",                                                                     \
           listAdd<c_type::value_type>,                                              \
           aliasAnalysisFromSchema()),                                               \
       Operator(                                                                     \
-          "aten::add_." decl_type "( " decl_type "[](a!) self, " decl_type                         \
+          "aten::add_(" decl_type "[](a!) self, " decl_type                         \
           "[] b) -> " decl_type "[]",                                               \
           listInplaceAdd<c_type::value_type>,                                       \
           aliasAnalysisFromSchema()),                                               \
       Operator(                                                                     \
-          "aten::slice." decl_type "( " decl_type                                                  \
+          "aten::slice(" decl_type                                                  \
           "[] l, int start, int end=9223372036854775807, int step=1) -> " decl_type \
           "[]",                                                                     \
           listSlice<c_type::value_type>,                                            \
           aliasAnalysisFromSchema()),                                               \
       Operator(                                                                     \
-          "aten::list." decl_type "( " decl_type "[] l) -> " decl_type "[]",                       \
+          "aten::list(" decl_type "[] l) -> " decl_type "[]",                       \
           listList<c_type::value_type>,                                             \
           aliasAnalysisFromSchema()),                                               \
       Operator(                                                                     \
-          "aten::mul." decl_type "( " decl_type "[] l, int n) -> " decl_type "[]",                 \
+          "aten::mul(" decl_type "[] l, int n) -> " decl_type "[]",                 \
           listMulIntLeft<c_type::value_type>,                                       \
           aliasAnalysisFromSchema()),                                               \
       Operator(                                                                     \

--- a/torch/csrc/jit/vararg_functions.h
+++ b/torch/csrc/jit/vararg_functions.h
@@ -22,7 +22,3 @@ void tupleUnpackFunc(int num_outputs, Stack& stack);
 void formatFunc(int num_inputs, Stack& stack);
 } // namespace jit
 } // namespace torch
-<<<<<<< HEAD
-=======
-
->>>>>>> OPN ops TupleConstruct/Unpack and format.

--- a/torch/csrc/jit/vararg_functions.h
+++ b/torch/csrc/jit/vararg_functions.h
@@ -22,3 +22,7 @@ void tupleUnpackFunc(int num_outputs, Stack& stack);
 void formatFunc(int num_inputs, Stack& stack);
 } // namespace jit
 } // namespace torch
+<<<<<<< HEAD
+=======
+
+>>>>>>> OPN ops TupleConstruct/Unpack and format.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #29970 Add missing operators for pytext, v2
* **#29960 Add overload name to JIT prim operators, version 2**

Overload name is required in mobile operators with the same name but different schema. Since it's not used in JIT, it's safe to add overload names for JIT operators.

Re-commit after a revert of #29656, because of backward compatibility failure. Adding overload name also triggers backward compatibility failures, so the overload names of append are added in this PR. Will contact the backward compatibility to add more overload names. 

Differential Revision: [D18555484](https://our.internmc.facebook.com/intern/diff/D18555484)