### PR TITLE
[iOS] add an unit test target to TestApp

### DIFF
--- a/ios/TestApp/TestApp.xcodeproj/project.pbxproj
+++ b/ios/TestApp/TestApp.xcodeproj/project.pbxproj
@@ -14,7 +14,18 @@
         A06D4CBD232F0DB200763E16 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A06D4CBC232F0DB200763E16 /* Assets.xcassets */; };
         A06D4CC0232F0DB200763E16 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A06D4CBE232F0DB200763E16 /* LaunchScreen.storyboard */; };
         A06D4CC3232F0DB200763E16 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = A06D4CC2232F0DB200763E16 /* main.m */; };
+        A0EA3B0A237FCB72007CEA34 /* TestAppTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = A0EA3B09237FCB72007CEA34 /* TestAppTests.mm */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+        A0EA3B04237FCB08007CEA34 /* PBXContainerItemProxy */ = {
+            isa = PBXContainerItemProxy;
+            containerPortal = A06D4CA8232F0DB200763E16 /* Project object */;
+            proxyType = 1;
+            remoteGlobalIDString = A06D4CAF232F0DB200763E16;
+            remoteInfo = TestApp;
+        };
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
         A03C295E235EA3C0000B4408 /* Benchmark.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Benchmark.h; sourceTree = "<group>"; };
@@ -29,10 +40,20 @@
         A06D4CBF232F0DB200763E16 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
         A06D4CC1232F0DB200763E16 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
         A06D4CC2232F0DB200763E16 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+        A0EA3AFF237FCB08007CEA34 /* TestAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TestAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+        A0EA3B03237FCB08007CEA34 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+        A0EA3B09237FCB72007CEA34 /* TestAppTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = TestAppTests.mm; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
         A06D4CAD232F0DB200763E16 /* Frameworks */ = {
+            isa = PBXFrameworksBuildPhase;
+            buildActionMask = 2147483647;
+            files = (
+            );
+            runOnlyForDeploymentPostprocessing = 0;
+        };
+        A0EA3AFC237FCB08007CEA34 /* Frameworks */ = {
             isa = PBXFrameworksBuildPhase;
             buildActionMask = 2147483647;
             files = (
@@ -46,6 +67,7 @@
             isa = PBXGroup;
             children = (
                 A06D4CB2232F0DB200763E16 /* TestApp */,
+                A0EA3B00237FCB08007CEA34 /* TestAppTests */,
                 A06D4CB1232F0DB200763E16 /* Products */,
             );
             sourceTree = "<group>";
@@ -54,6 +76,7 @@
             isa = PBXGroup;
             children = (
                 A06D4CB0232F0DB200763E16 /* TestApp.app */,
+                A0EA3AFF237FCB08007CEA34 /* TestAppTests.xctest */,
             );
             name = Products;
             sourceTree = "<group>";
@@ -76,6 +99,15 @@
             path = TestApp;
             sourceTree = "<group>";
         };
+        A0EA3B00237FCB08007CEA34 /* TestAppTests */ = {
+            isa = PBXGroup;
+            children = (
+                A0EA3B09237FCB72007CEA34 /* TestAppTests.mm */,
+                A0EA3B03237FCB08007CEA34 /* Info.plist */,
+            );
+            path = TestAppTests;
+            sourceTree = "<group>";
+        };
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -96,6 +128,24 @@
             productReference = A06D4CB0232F0DB200763E16 /* TestApp.app */;
             productType = "com.apple.product-type.application";
         };
+        A0EA3AFE237FCB08007CEA34 /* TestAppTests */ = {
+            isa = PBXNativeTarget;
+            buildConfigurationList = A0EA3B08237FCB08007CEA34 /* Build configuration list for PBXNativeTarget "TestAppTests" */;
+            buildPhases = (
+                A0EA3AFB237FCB08007CEA34 /* Sources */,
+                A0EA3AFC237FCB08007CEA34 /* Frameworks */,
+                A0EA3AFD237FCB08007CEA34 /* Resources */,
+            );
+            buildRules = (
+            );
+            dependencies = (
+                A0EA3B05237FCB08007CEA34 /* PBXTargetDependency */,
+            );
+            name = TestAppTests;
+            productName = TestAppTests;
+            productReference = A0EA3AFF237FCB08007CEA34 /* TestAppTests.xctest */;
+            productType = "com.apple.product-type.bundle.unit-test";
+        };
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -106,6 +156,9 @@
                 TargetAttributes = {
                     A06D4CAF232F0DB200763E16 = {
                         CreatedOnToolsVersion = 10.3;
+                    };
+                    A0EA3AFE237FCB08007CEA34 = {
+                        CreatedOnToolsVersion = 11.2.1;
                     };
                 };
             };
@@ -123,6 +176,7 @@
             projectRoot = "";
             targets = (
                 A06D4CAF232F0DB200763E16 /* TestApp */,
+                A0EA3AFE237FCB08007CEA34 /* TestAppTests */,
             );
         };
 /* End PBXProject section */
@@ -135,6 +189,13 @@
                 A06D4CC0232F0DB200763E16 /* LaunchScreen.storyboard in Resources */,
                 A06D4CBD232F0DB200763E16 /* Assets.xcassets in Resources */,
                 A06D4CBB232F0DB200763E16 /* Main.storyboard in Resources */,
+            );
+            runOnlyForDeploymentPostprocessing = 0;
+        };
+        A0EA3AFD237FCB08007CEA34 /* Resources */ = {
+            isa = PBXResourcesBuildPhase;
+            buildActionMask = 2147483647;
+            files = (
             );
             runOnlyForDeploymentPostprocessing = 0;
         };
@@ -152,7 +213,23 @@
             );
             runOnlyForDeploymentPostprocessing = 0;
         };
+        A0EA3AFB237FCB08007CEA34 /* Sources */ = {
+            isa = PBXSourcesBuildPhase;
+            buildActionMask = 2147483647;
+            files = (
+                A0EA3B0A237FCB72007CEA34 /* TestAppTests.mm in Sources */,
+            );
+            runOnlyForDeploymentPostprocessing = 0;
+        };
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+        A0EA3B05237FCB08007CEA34 /* PBXTargetDependency */ = {
+            isa = PBXTargetDependency;
+            target = A06D4CAF232F0DB200763E16 /* TestApp */;
+            targetProxy = A0EA3B04237FCB08007CEA34 /* PBXContainerItemProxy */;
+        };
+/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
         A06D4CB9232F0DB200763E16 /* Main.storyboard */ = {
@@ -324,6 +401,40 @@
             };
             name = Release;
         };
+        A0EA3B06237FCB08007CEA34 /* Debug */ = {
+            isa = XCBuildConfiguration;
+            buildSettings = {
+                CODE_SIGN_STYLE = Automatic;
+                INFOPLIST_FILE = TestAppTests/Info.plist;
+                IPHONEOS_DEPLOYMENT_TARGET = 12.4;
+                LD_RUNPATH_SEARCH_PATHS = (
+                    "$(inherited)",
+                    "@executable_path/Frameworks",
+                    "@loader_path/Frameworks",
+                );
+                PRODUCT_BUNDLE_IDENTIFIER = com.pytorch.ios.TestAppTests;
+                PRODUCT_NAME = "$(TARGET_NAME)";
+                TARGETED_DEVICE_FAMILY = "1,2";
+            };
+            name = Debug;
+        };
+        A0EA3B07237FCB08007CEA34 /* Release */ = {
+            isa = XCBuildConfiguration;
+            buildSettings = {
+                CODE_SIGN_STYLE = Automatic;
+                INFOPLIST_FILE = TestAppTests/Info.plist;
+                IPHONEOS_DEPLOYMENT_TARGET = 12.4;
+                LD_RUNPATH_SEARCH_PATHS = (
+                    "$(inherited)",
+                    "@executable_path/Frameworks",
+                    "@loader_path/Frameworks",
+                );
+                PRODUCT_BUNDLE_IDENTIFIER = com.pytorch.ios.TestAppTests;
+                PRODUCT_NAME = "$(TARGET_NAME)";
+                TARGETED_DEVICE_FAMILY = "1,2";
+            };
+            name = Release;
+        };
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -341,6 +452,15 @@
             buildConfigurations = (
                 A06D4CC7232F0DB200763E16 /* Debug */,
                 A06D4CC8232F0DB200763E16 /* Release */,
+            );
+            defaultConfigurationIsVisible = 0;
+            defaultConfigurationName = Release;
+        };
+        A0EA3B08237FCB08007CEA34 /* Build configuration list for PBXNativeTarget "TestAppTests" */ = {
+            isa = XCConfigurationList;
+            buildConfigurations = (
+                A0EA3B06237FCB08007CEA34 /* Debug */,
+                A0EA3B07237FCB08007CEA34 /* Release */,
             );
             defaultConfigurationIsVisible = 0;
             defaultConfigurationName = Release;

--- a/ios/TestApp/TestApp.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
+++ b/ios/TestApp/TestApp.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1120"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A06D4CAF232F0DB200763E16"
+               BuildableName = "TestApp.app"
+               BlueprintName = "TestApp"
+               ReferencedContainer = "container:TestApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A06D4CAF232F0DB200763E16"
+            BuildableName = "TestApp.app"
+            BlueprintName = "TestApp"
+            ReferencedContainer = "container:TestApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A06D4CAF232F0DB200763E16"
+            BuildableName = "TestApp.app"
+            BlueprintName = "TestApp"
+            ReferencedContainer = "container:TestApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ios/TestApp/TestApp.xcodeproj/xcshareddata/xcschemes/TestAppTests.xcscheme
+++ b/ios/TestApp/TestApp.xcodeproj/xcshareddata/xcschemes/TestAppTests.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1120"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A0EA3AFE237FCB08007CEA34"
+               BuildableName = "TestAppTests.xctest"
+               BlueprintName = "TestAppTests"
+               ReferencedContainer = "container:TestApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A0EA3AFE237FCB08007CEA34"
+               BuildableName = "TestAppTests.xctest"
+               BlueprintName = "TestAppTests"
+               ReferencedContainer = "container:TestApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A0EA3AFE237FCB08007CEA34"
+            BuildableName = "TestAppTests.xctest"
+            BlueprintName = "TestAppTests"
+            ReferencedContainer = "container:TestApp.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ios/TestApp/TestAppTests/Info.plist
+++ b/ios/TestApp/TestAppTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>$(DEVELOPMENT_LANGUAGE)</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleIdentifier</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>$(PRODUCT_NAME)</string>
+    <key>CFBundlePackageType</key>
+    <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+</dict>
+</plist>

--- a/ios/TestApp/TestAppTests/TestAppTests.mm
+++ b/ios/TestApp/TestAppTests/TestAppTests.mm
@@ -1,5 +1,6 @@
 #import <XCTest/XCTest.h>
-#import <torch/script.h>
+
+#include <torch/script.h>
 
 @interface TestAppTests : XCTestCase
 
@@ -9,30 +10,31 @@
   torch::jit::script::Module _module;
 }
 
-- (void)setUp {
++ (void)setUp {
   [super setUp];
-  NSString* modelPath = [[NSBundle bundleForClass:[self class]] pathForResource:@"model"
-                                                                         ofType:@"pt"];
-  XCTAssertTrue([[NSFileManager defaultManager] fileExistsAtPath:modelPath],
-                @"model.pt doesn't exist!");
   auto qengines = at::globalContext().supportedQEngines();
   if (std::find(qengines.begin(), qengines.end(), at::QEngine::QNNPACK) != qengines.end()) {
     at::globalContext().setQEngine(at::QEngine::QNNPACK);
   }
   torch::autograd::AutoGradMode guard(false);
-  _module = torch::jit::load(std::string(modelPath.UTF8String));
-  _module.eval();
 }
 
-- (void)tearDown {
-  [super tearDown];
+- (void)setUp {
+  [super setUp];
+  NSString* modelPath = [[NSBundle bundleForClass:[self class]] pathForResource:@"model"
+                                                                         ofType:@"pt"];
+  XCTAssertTrue([NSFileManager.defaultManager fileExistsAtPath:modelPath],
+                @"model.pt doesn't exist!");
+  _module = torch::jit::load(modelPath.UTF8String);
 }
 
 - (void)testForward {
+  _module.eval();
   std::vector<c10::IValue> inputs;
   inputs.push_back(torch::ones({1, 3, 224, 224}, at::ScalarType::Float));
-  auto outputTensor = _module.forward(inputs).toTensor().view(-1);
-  XCTAssertEqual(outputTensor.numel(), 1000);
+  auto outputTensor = _module.forward(inputs).toTensor();
+  float* outputBuffer = outputTensor.data_ptr<float>();
+  XCTAssertTrue(outputBuffer != nullptr, @"");
 }
 
 @end

--- a/ios/TestApp/TestAppTests/TestAppTests.mm
+++ b/ios/TestApp/TestAppTests/TestAppTests.mm
@@ -1,0 +1,38 @@
+#import <XCTest/XCTest.h>
+#import <torch/script.h>
+
+@interface TestAppTests : XCTestCase
+
+@end
+
+@implementation TestAppTests {
+  torch::jit::script::Module _module;
+}
+
+- (void)setUp {
+  [super setUp];
+  NSString* modelPath = [[NSBundle bundleForClass:[self class]] pathForResource:@"model"
+                                                                         ofType:@"pt"];
+  XCTAssertTrue([[NSFileManager defaultManager] fileExistsAtPath:modelPath],
+                @"model.pt doesn't exist!");
+  auto qengines = at::globalContext().supportedQEngines();
+  if (std::find(qengines.begin(), qengines.end(), at::QEngine::QNNPACK) != qengines.end()) {
+    at::globalContext().setQEngine(at::QEngine::QNNPACK);
+  }
+  torch::autograd::AutoGradMode guard(false);
+  _module = torch::jit::load(std::string(modelPath.UTF8String));
+  _module.eval();
+}
+
+- (void)tearDown {
+  [super tearDown];
+}
+
+- (void)testForward {
+  std::vector<c10::IValue> inputs;
+  inputs.push_back(torch::ones({1, 3, 224, 224}, at::ScalarType::Float));
+  auto outputTensor = _module.forward(inputs).toTensor().view(-1);
+  XCTAssertEqual(outputTensor.numel(), 1000);
+}
+
+@end


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #29963 [iOS] update fastlane to use Scanfile
* **#29962 [iOS] add an unit test target to TestApp**

### Summary

Recently we've found that the master branch was constantly broken due to some unwanted change being landed on mobile. The problem is that our CI was not able to detect the runtime errors. Starting from this PR, we'll add some unit tests to the iOS Simulator build. As follows:

1. Add an unit test target to XCode (this PR)
2. Use Fastlane to run the tests on CI
3. Modify the CI scripts to trigger tests

### Test Plan

- Don't break the existing CI jobs unless they are flaky.

Differential Revision: [D18582908](https://our.internmc.facebook.com/intern/diff/D18582908)