### PR TITLE
[NHWC SUPPORT] cuDNN conv channels_last behavior update.

### DIFF
--- a/aten/src/ATen/native/cudnn/Conv.cpp
+++ b/aten/src/ATen/native/cudnn/Conv.cpp
@@ -965,7 +965,11 @@ std::tuple<at::Tensor,at::Tensor,at::Tensor> cudnn_convolution_transpose_backwar
     IntArrayRef padding, IntArrayRef output_padding, IntArrayRef stride, IntArrayRef dilation, int64_t groups,
     bool benchmark, bool deterministic, std::array<bool,3> output_mask) {
 
-  Tensor grad_output = grad_output_t.contiguous(input.suggest_memory_format());
+  auto convolution_memory_format =
+      input.suggest_memory_format() == at::MemoryFormat::ChannelsLast ||
+      weight.suggest_memory_format() == at::MemoryFormat::ChannelsLast ?
+      at::MemoryFormat::ChannelsLast : at::MemoryFormat::Contiguous;
+  Tensor grad_output = grad_output_t.contiguous(convolution_memory_format);
 
   Tensor grad_input, grad_weight, grad_bias;
   if (output_mask[0]) {
@@ -1090,8 +1094,11 @@ std::tuple<at::Tensor,at::Tensor,at::Tensor> cudnn_convolution_backward(
     const at::Tensor& input, const at::Tensor& grad_output_t, const at::Tensor& weight,
     IntArrayRef padding, IntArrayRef stride, IntArrayRef dilation, int64_t groups,
     bool benchmark, bool deterministic, std::array<bool,3> output_mask) {
-
-  Tensor grad_output = grad_output_t.contiguous(input.suggest_memory_format());
+  auto convolution_memory_format =
+      input.suggest_memory_format() == at::MemoryFormat::ChannelsLast ||
+      weight.suggest_memory_format() == at::MemoryFormat::ChannelsLast ?
+      at::MemoryFormat::ChannelsLast : at::MemoryFormat::Contiguous;
+  Tensor grad_output = grad_output_t.contiguous(convolution_memory_format);
 
   Tensor grad_input, grad_weight, grad_bias;
   if (input.numel() == 0) {

--- a/torch/nn/utils/__init__.py
+++ b/torch/nn/utils/__init__.py
@@ -4,3 +4,4 @@ from .weight_norm import weight_norm, remove_weight_norm
 from .convert_parameters import parameters_to_vector, vector_to_parameters
 from .spectral_norm import spectral_norm, remove_spectral_norm
 from .fusion import fuse_conv_bn_eval, fuse_conv_bn_weights
+from .layout import convert_conv2d_weight_memory_layout

--- a/torch/nn/utils/layout.py
+++ b/torch/nn/utils/layout.py
@@ -1,0 +1,36 @@
+import torch
+
+def convert_conv2d_weight_memory_layout(module, layout):
+    r"""Convert ``memory_format`` of ``nn.Conv2d.weight`` to ``layout``
+
+    The conversion recursively applies to nested ``nn.Module``, including ``module``.
+    Note that it only changes the memory_format, but not the semantics of each dimensions.
+
+    This function is used to facilitate the computation to adopt NHWC kernels, which
+    provides considerable speed up for fp16 data on CUDA devices with compute capability >= 7.0
+
+    Example:
+        >>>  input = torch.randint(1, 10, (2, 8, 4, 4), dtype=torch.float16, device="cuda")
+        >>>  model = nn.Sequential(
+        >>>      nn.Conv2d(8, 4, 3)).cuda().half()
+        >>>  # This is identical to:
+        >>>  # nn.utils.convert_conv2d_weight_memory_layout(model, torch.channels_last)
+        >>>  model = nn.utils.convert_conv2d_weight_memory_layout(model, torch.channels_last)
+        >>>  out = model(input)
+
+    Arguments:
+        module (nn.Module): ``nn.Conv2d`` or container ``nn.Module``
+        layout: user specified ``memory_layout``,
+            e.g. ``torch.channels_last`` or ``torch.contiguous_format``
+
+    Returns:
+        The original module with updated ``nn.Conv2d``
+    """
+
+    # TODO: expand this to `_ConvNd` when channels_last support is extended
+    # beyond only 4d tensors.
+    if isinstance(module, torch.nn.Conv2d):
+        module.weight.data = module.weight.contiguous(memory_format=layout)
+    for child in module.children():
+        convert_conv2d_weight_memory_layout(child, layout)
+    return module


### PR DESCRIPTION
1. Updated channels_last propagation rule on cuDNN convolution:
If input or weight is in channels_last memory_format, we'll compute the layer
using channels_last memory_format and propagate the format to the output as well

This is to allow user to easily specify the desired memory_format for
convolution layers, which could potentially offer considerable speed up when
using proper memory_format.

2. Provided util function to recursively convert memory format of
``nn.Conv2d.weight`` to specified memory_format:

    >>> convert_conv2d_weight_memory_layout(module, torch.channels_last)

