### PR TITLE
convert_sync_batchnorm should not convert _InstanceNorm instances

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2050,7 +2050,7 @@ class TestNN(NNTestCase):
 
     def test_random_pruning_orig(self):
         r"""Test that original tensor is correctly stored in 'orig'
-        after pruning is applied. Important to make sure we don't 
+        after pruning is applied. Important to make sure we don't
         lose info about the original unpruned parameter.
         """
         # fixturize test
@@ -2083,12 +2083,12 @@ class TestNN(NNTestCase):
             for name in names:
                 with self._compatible_subtest(m=m, name=name):
                     # tensor prior to pruning
-                    original_tensor = getattr(m, name) 
+                    original_tensor = getattr(m, name)
                     prune.random_unstructured(m, name=name, amount=0.1)
                     # weight = weight_orig * weight_mask
                     self.assertEqual(
                         getattr(m, name),
-                        getattr(m, name + '_orig') 
+                        getattr(m, name + '_orig')
                         * getattr(m, name + '_mask').to(
                             dtype=original_tensor.dtype
                         ),
@@ -2187,7 +2187,7 @@ class TestNN(NNTestCase):
         y_postpruning = m(input_)
         y_postpruning.sum().backward()
         # weight_orig is the parameter, so it's the tensor that will accumulate the grad
-        self.assertEqual(m.weight_orig.grad, mask)  # all 1s, except for masked units 
+        self.assertEqual(m.weight_orig.grad, mask)  # all 1s, except for masked units
         self.assertEqual(m.bias.grad, torch.ones_like(m.bias))
 
         # make sure that weight_orig update doesn't modify [1, 0] and [0, 3]
@@ -2224,7 +2224,7 @@ class TestNN(NNTestCase):
 
     @unittest.skipIf(not PY3, "mock is not available in Python 2")
     def test_remove_pruning_forward(self):
-        r"""Remove pruning and check forward is unchanged from previous 
+        r"""Remove pruning and check forward is unchanged from previous
         pruned state.
         """
         input_ = torch.ones(1, 5)
@@ -2288,26 +2288,26 @@ class TestNN(NNTestCase):
             hook,
             torch.nn.utils.prune.PruningContainer
         )
-        # check that container._tensor_name is correctly set no matter how 
+        # check that container._tensor_name is correctly set no matter how
         # many pruning methods are in the container
         self.assertEqual(hook._tensor_name, 'weight')
 
-        # check that the pruning container has the right length 
+        # check that the pruning container has the right length
         # equal to the number of pruning iters
         self.assertEqual(len(hook), 2)  # m.weight has been pruned twice
 
-        # check that the entries of the pruning container are of the expected 
+        # check that the entries of the pruning container are of the expected
         # type and in the expected order
         self.assertIsInstance(hook[0], torch.nn.utils.prune.L1Unstructured)
         self.assertIsInstance(hook[1], torch.nn.utils.prune.LnStructured)
 
-        # check that all entries that are 0 in the 1st mask are 0 in the 
+        # check that all entries that are 0 in the 1st mask are 0 in the
         # 2nd mask too
         self.assertTrue(torch.all(m.weight_mask[weight_mask0 == 0] == 0))
 
         # prune again
         prune.ln_structured(m, name='weight', amount=0.1, n=float('inf'), dim=1)
-        # check that container._tensor_name is correctly set no matter how 
+        # check that container._tensor_name is correctly set no matter how
         # many pruning methods are in the container
         hook = next(iter(m._forward_pre_hooks.values()))
         self.assertEqual(hook._tensor_name, 'weight')
@@ -2338,8 +2338,8 @@ class TestNN(NNTestCase):
             container.add_pruning_method('ugh')
 
     def test_pruning_container_compute_mask(self):
-        r"""Test `compute_mask` of pruning container with a known `t` and 
-        `default_mask`. Indirectly checks that Ln structured pruning is 
+        r"""Test `compute_mask` of pruning container with a known `t` and
+        `default_mask`. Indirectly checks that Ln structured pruning is
         acting on the right axis.
         """
         # create an empty container
@@ -2357,7 +2357,7 @@ class TestNN(NNTestCase):
         t = torch.tensor([[1, 2, 3, 4], [5, 6, 7, 8]]).to(dtype=torch.float32)
         # create prior mask by hand
         default_mask = torch.tensor([[1, 1, 1, 0], [1, 1, 0, 1]])
-        # since we are pruning the two lowest magnitude units, the outcome of 
+        # since we are pruning the two lowest magnitude units, the outcome of
         # the calculation should be this:
         expected_mask = torch.tensor([[0, 0, 1, 0], [1, 1, 0, 1]])
         computed_mask = container.compute_mask(t, default_mask)
@@ -2367,7 +2367,7 @@ class TestNN(NNTestCase):
         q = prune.LnStructured(amount=1, n=2, dim=0)
         q._tensor_name = 'test'
         container.add_pruning_method(q)
-        # since we are pruning the lowest magnitude one of the two rows, the 
+        # since we are pruning the lowest magnitude one of the two rows, the
         # outcome of the calculation should be this:
         expected_mask = torch.tensor([[0, 0, 0, 0], [1, 1, 0, 1]])
         computed_mask = container.compute_mask(t, default_mask)
@@ -2377,7 +2377,7 @@ class TestNN(NNTestCase):
         r = prune.LnStructured(amount=1, n=2, dim=1)
         r._tensor_name = 'test'
         container.add_pruning_method(r)
-        # since we are pruning the lowest magnitude of the four columns, the 
+        # since we are pruning the lowest magnitude of the four columns, the
         # outcome of the calculation should be this:
         expected_mask = torch.tensor([[0, 1, 1, 0], [0, 1, 0, 1]])
         computed_mask = container.compute_mask(t, default_mask)
@@ -2385,8 +2385,8 @@ class TestNN(NNTestCase):
 
 
     def test_l1_unstructured_pruning(self):
-        r"""Test that l1 unstructured pruning actually removes the lowest 
-        entries by l1 norm (by hand). It also checks that applying l1 
+        r"""Test that l1 unstructured pruning actually removes the lowest
+        entries by l1 norm (by hand). It also checks that applying l1
         unstructured pruning more than once respects the previous mask.
         """
         m = nn.Linear(4, 2)
@@ -2446,7 +2446,7 @@ class TestNN(NNTestCase):
         """
         m = nn.Conv2d(3, 1, 2)
         m.weight.data = torch.Tensor(
-            [[[[1., 2.], [1., 2.5]], 
+            [[[[1., 2.], [1., 2.5]],
              [[0.5, 1.], [0.1, 0.1]],
              [[-3., -5.], [0.1, -1.]]]]
         )
@@ -2569,7 +2569,7 @@ class TestNN(NNTestCase):
     def test_pruning_rollback(self):
         r"""Test that if something fails when the we try to compute the mask,
         then the model isn't left in some intermediate half-pruned state.
-        The try/except statement in `apply` should handle rolling back 
+        The try/except statement in `apply` should handle rolling back
         to the previous state before pruning began.
         """
         modules = [nn.Linear(5, 7), nn.Conv3d(2, 2, 2)]
@@ -2583,7 +2583,7 @@ class TestNN(NNTestCase):
                         "torch.nn.utils.prune.L1Unstructured.compute_mask"
                     ) as compute_mask:
                         compute_mask.side_effect = Exception('HA!')
-                        with self.assertRaises(Exception): 
+                        with self.assertRaises(Exception):
                             prune.l1_unstructured(m, name=name, amount=0.9)
 
                         self.assertTrue(
@@ -2599,7 +2599,7 @@ class TestNN(NNTestCase):
     def test_pruning_serialization_model(self):
         # create a model
         model = torch.nn.Sequential(
-            torch.nn.Linear(10, 10), 
+            torch.nn.Linear(10, 10),
             torch.nn.ReLU(),
             torch.nn.Linear(10, 1),
         )
@@ -2635,7 +2635,7 @@ class TestNN(NNTestCase):
     def test_pruning_serialization_state_dict(self):
         # create a model
         model = torch.nn.Sequential(
-            torch.nn.Linear(10, 10), 
+            torch.nn.Linear(10, 10),
             torch.nn.ReLU(),
             torch.nn.Linear(10, 1),
         )
@@ -2655,7 +2655,7 @@ class TestNN(NNTestCase):
 
         pruned_weight = model[0].weight
 
-        # make pruning permanent and restore parameter names as in base 
+        # make pruning permanent and restore parameter names as in base
         # architecture
         prune.remove(module=model[0], name='weight')
 
@@ -2666,7 +2666,7 @@ class TestNN(NNTestCase):
 
         # save the state dict of model and reload it into new_model
         new_model = torch.nn.Sequential(
-            torch.nn.Linear(10, 10), 
+            torch.nn.Linear(10, 10),
             torch.nn.ReLU(),
             torch.nn.Linear(10, 1),
         )
@@ -2674,7 +2674,7 @@ class TestNN(NNTestCase):
             torch.save(model.state_dict(), fname)
             new_model.load_state_dict(torch.load(fname))
 
-        # check that the original weight and the new mask are not present in 
+        # check that the original weight and the new mask are not present in
         # new_model either.
         self.assertNotIn('0.weight_orig', new_model.state_dict())
         self.assertNotIn('0.weight_mask', new_model.state_dict())
@@ -2690,7 +2690,7 @@ class TestNN(NNTestCase):
         t = torch.tensor([[1, 2, 3, 4], [5, 6, 7, 8]]).to(dtype=torch.float32)
         # create prior mask by hand
         default_mask = torch.tensor([[1, 1, 1, 0], [1, 1, 0, 1]])
-        # since we are pruning the two lowest magnitude units, the outcome of 
+        # since we are pruning the two lowest magnitude units, the outcome of
         # the calculation should be this:
         expected_mask = torch.tensor([[0, 0, 1, 0], [1, 1, 0, 1]])
         pruned_tensor = p.prune(t, default_mask)
@@ -7876,6 +7876,17 @@ class TestNN(NNTestCase):
         out.backward()
         self.assertEqual(input.grad.dtype, dtype)
         self.assertEqual(input.grad, inputf.grad, prec=1e-1)
+
+    def test_convert_sync_batchnorm(self):
+        module = torch.nn.Sequential(
+            torch.nn.BatchNorm1d(100),
+            torch.nn.InstanceNorm1d(100)
+        ).cuda()
+        sync_bn_module = torch.nn.SyncBatchNorm.convert_sync_batchnorm(module)
+        children = list(sync_bn_module.children())
+        self.assertEqual(children[0].__class__, torch.nn.SyncBatchNorm)
+        self.assertEqual(children[1].__class__, torch.nn.InstanceNorm1d)
+
 
 class TestNNInit(TestCase):
     def setUp(self):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7877,6 +7877,7 @@ class TestNN(NNTestCase):
         self.assertEqual(input.grad.dtype, dtype)
         self.assertEqual(input.grad, inputf.grad, prec=1e-1)
 
+    @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
     def test_convert_sync_batchnorm(self):
         module = torch.nn.Sequential(
             torch.nn.BatchNorm1d(100),

--- a/torch/nn/modules/batchnorm.py
+++ b/torch/nn/modules/batchnorm.py
@@ -8,7 +8,8 @@ from .. import functional as F
 from .. import init
 
 
-class _BatchNorm(Module):
+class _NormBase(Module):
+    """Common base of _InstanceNorm and _BatchNorm"""
     _version = 2
     __constants__ = ['track_running_stats', 'momentum', 'eps', 'weight', 'bias',
                      'running_mean', 'running_var', 'num_batches_tracked',
@@ -16,7 +17,7 @@ class _BatchNorm(Module):
 
     def __init__(self, num_features, eps=1e-5, momentum=0.1, affine=True,
                  track_running_stats=True):
-        super(_BatchNorm, self).__init__()
+        super(_NormBase, self).__init__()
         self.num_features = num_features
         self.eps = eps
         self.momentum = momentum
@@ -53,10 +54,37 @@ class _BatchNorm(Module):
     def _check_input_dim(self, input):
         raise NotImplementedError
 
+    def extra_repr(self):
+        return '{num_features}, eps={eps}, momentum={momentum}, affine={affine}, ' \
+               'track_running_stats={track_running_stats}'.format(**self.__dict__)
+
+    def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict,
+                              missing_keys, unexpected_keys, error_msgs):
+        version = local_metadata.get('version', None)
+
+        if (version is None or version < 2) and self.track_running_stats:
+            # at version 2: added num_batches_tracked buffer
+            #               this should have a default value of 0
+            num_batches_tracked_key = prefix + 'num_batches_tracked'
+            if num_batches_tracked_key not in state_dict:
+                state_dict[num_batches_tracked_key] = torch.tensor(0, dtype=torch.long)
+
+        super(_NormBase, self)._load_from_state_dict(
+            state_dict, prefix, local_metadata, strict,
+            missing_keys, unexpected_keys, error_msgs)
+
+
+class _BatchNorm(_NormBase):
+
+    def __init__(self, num_features, eps=1e-5, momentum=0.1, affine=True,
+                 track_running_stats=True):
+        super(_BatchNorm, self).__init__(
+            num_features, eps, momentum, affine, track_running_stats)
+
     def forward(self, input):
         self._check_input_dim(input)
 
-        # exponential_average_factor is set to self.momentum 
+        # exponential_average_factor is set to self.momentum
         # (when it is available) only so that if gets updated
         # in ONNX graph when this node is exported to ONNX.
         if self.momentum is None:
@@ -77,25 +105,6 @@ class _BatchNorm(Module):
             input, self.running_mean, self.running_var, self.weight, self.bias,
             self.training or not self.track_running_stats,
             exponential_average_factor, self.eps)
-
-    def extra_repr(self):
-        return '{num_features}, eps={eps}, momentum={momentum}, affine={affine}, ' \
-               'track_running_stats={track_running_stats}'.format(**self.__dict__)
-
-    def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict,
-                              missing_keys, unexpected_keys, error_msgs):
-        version = local_metadata.get('version', None)
-
-        if (version is None or version < 2) and self.track_running_stats:
-            # at version 2: added num_batches_tracked buffer
-            #               this should have a default value of 0
-            num_batches_tracked_key = prefix + 'num_batches_tracked'
-            if num_batches_tracked_key not in state_dict:
-                state_dict[num_batches_tracked_key] = torch.tensor(0, dtype=torch.long)
-
-        super(_BatchNorm, self)._load_from_state_dict(
-            state_dict, prefix, local_metadata, strict,
-            missing_keys, unexpected_keys, error_msgs)
 
 
 class BatchNorm1d(_BatchNorm):
@@ -426,7 +435,7 @@ class SyncBatchNorm(_BatchNorm):
 
         self._check_input_dim(input)
 
-        # exponential_average_factor is set to self.momentum 
+        # exponential_average_factor is set to self.momentum
         # (when it is available) only so that if gets updated
         # in ONNX graph when this node is exported to ONNX.
         if self.momentum is None:
@@ -499,7 +508,7 @@ class SyncBatchNorm(_BatchNorm):
             if module.affine:
                 module_output.weight.data = module.weight.data.clone(memory_format=torch.preserve_format).detach()
                 module_output.bias.data = module.bias.data.clone(memory_format=torch.preserve_format).detach()
-                # keep reuqires_grad unchanged
+                # keep requires_grad unchanged
                 module_output.weight.requires_grad = module.weight.requires_grad
                 module_output.bias.requires_grad = module.bias.requires_grad
             module_output.running_mean = module.running_mean

--- a/torch/nn/modules/instancenorm.py
+++ b/torch/nn/modules/instancenorm.py
@@ -1,8 +1,8 @@
-from .batchnorm import _BatchNorm
+from .batchnorm import _NormBase
 from .. import functional as F
 
 
-class _InstanceNorm(_BatchNorm):
+class _InstanceNorm(_NormBase):
     def __init__(self, num_features, eps=1e-5, momentum=0.1, affine=False,
                  track_running_stats=False):
         super(_InstanceNorm, self).__init__(


### PR DESCRIPTION
Fixes #29187

This introduces a new class `_NormBase` that `_InstanceNorm` and `_BatchNorm` inherit from separately. This means the `isinstance(module, _BatchNorm)` check won't falsely pass for `_InstanceNorm`.

The suggested fix of adding `and not isinstance(module, _InstanceNorm)` works as well, but requires introducing a cyclic dependency between `instancenorm.py` and `batchnorm.py`.