### PR TITLE
Add missing error messages for container modules

### DIFF
--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -199,6 +199,9 @@ class ModuleList(Module):
             self.add_module(str(offset + i), module)
         return self
 
+    def __call__(self, input):
+        raise RuntimeError('ModuleList should not be called directly.')
+
 
 class ModuleDict(Module):
     r"""Holds submodules in a dictionary.
@@ -432,6 +435,9 @@ class ParameterList(Module):
         tmpstr = '\n'.join(child_lines)
         return tmpstr
 
+    def __call__(self, input):
+        raise RuntimeError('ParameterList should not be called.')
+
 
 class ParameterDict(Module):
     r"""Holds parameters in a dictionary.
@@ -571,3 +577,6 @@ class ParameterDict(Module):
             child_lines.append('  (' + k + '): ' + parastr)
         tmpstr = '\n'.join(child_lines)
         return tmpstr
+
+    def __call__(self, input):
+        raise RuntimeError('ParameterDict should not be called.')

--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -199,8 +199,8 @@ class ModuleList(Module):
             self.add_module(str(offset + i), module)
         return self
 
-    def __call__(self, input):
-        raise RuntimeError('ModuleList should not be called directly.')
+    def forward(self):
+        raise NotImplementedError()
 
 
 class ModuleDict(Module):


### PR DESCRIPTION
Container `Module`s, including `ModuleList`, `ParameterList` and `ParameterDict`, should not be called like a regular `Module`.
This PR add error messages for these special modules.