### PR TITLE
[WIP] switch defaults

### DIFF
--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -213,8 +213,13 @@ Tensor empty_like(
 
   if (self.is_quantized()) {
 
+
+    if (!optional_memory_format.has_value()) {
+      TORCH_CHECK(optional_memory_format.has_value(), " *_like temporary requires memory format")
+    }
+
     auto memory_format =
-        optional_memory_format.value_or(MemoryFormat::Contiguous);
+        optional_memory_format.value_or(MemoryFormat::Preserve);
 
     // TODO: To support all features of MemoryFormat::Preserve we need to add
     // _empty_affine_quantized_strided function and use it similarly to
@@ -252,8 +257,12 @@ Tensor empty_like(
 
   Tensor result;
 
+  if (!optional_memory_format.has_value()) {
+    TORCH_CHECK(optional_memory_format.has_value(), " *_like temporary requires memory format")
+  }
+
   auto memory_format =
-      optional_memory_format.value_or(MemoryFormat::Contiguous);
+      optional_memory_format.value_or(MemoryFormat::Preserve);
   if (memory_format == MemoryFormat::Preserve) {
     if (self.is_non_overlapping_and_dense()) {
       result = at::empty_strided(self.sizes(), self.strides(), options);

--- a/test/common_nn.py
+++ b/test/common_nn.py
@@ -21,6 +21,7 @@ from common_cuda import TEST_CUDA
 from torch.autograd.gradcheck import get_numerical_jacobian, iter_tensors
 from torch.autograd import Variable
 import torch.backends.cudnn
+from fake_operators import fake_empty_like, fake_rand_like, fake_randint_like, fake_randn_like, fake_ones_like, fake_zeros_like, fake_full_like
 
 
 # tarfile module tries to obtain a file object name in python 3.3
@@ -3366,9 +3367,9 @@ class NNTestCase(TestCase):
         for i in range(output_size):
             param, d_param = self._get_parameters(module)
             # make non grad zeros
-            d_param = [torch.zeros_like(p) if d is None else d for (p, d) in zip(param, d_param)]
+            d_param = [fake_zeros_like(p) if d is None else d for (p, d) in zip(param, d_param)]
 
-            d_out = torch.zeros_like(output)
+            d_out = fake_zeros_like(output)
             flat_d_out = d_out.view(-1)
             flat_d_out[i] = 1
 
@@ -3580,7 +3581,7 @@ class ModuleTest(TestBase):
             if tensor.size(d) > 1:
                 dim = d + 1
                 break
-        noncontig = torch.stack([torch.empty_like(tensor), tensor], dim).select(dim, 1).detach()
+        noncontig = torch.stack([fake_empty_like(tensor), tensor], dim).select(dim, 1).detach()
         assert noncontig.numel() == 1 or noncontig.numel() == 0 or not noncontig.is_contiguous()
         noncontig.requires_grad = tensor.requires_grad
         return noncontig
@@ -3656,7 +3657,7 @@ class ModuleTest(TestBase):
                 cpu_output = cpu_module(cpu_input)
                 gpu_output = gpu_module(gpu_input)
 
-                cpu_gradOutput = torch.randn_like(cpu_output, requires_grad=True)
+                cpu_gradOutput = fake_randn_like(cpu_output, requires_grad=True)
                 gpu_gradOutput = cpu_gradOutput.type_as(gpu_output).detach()
                 gpu_gradOutput.requires_grad = True
 

--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -140,6 +140,21 @@ ALL_TENSORTYPES = [torch.float,
                    torch.double,
                    torch.half]
 
+def fake_empty_like(*args, **kwargs):
+    if 'memory_format' not in kwargs:
+        kwargs['memory_format'] = torch.contiguous_format
+    return torch.empty_like(*args, **kwargs)
+
+def fake_rand_like(*args, **kwargs):
+    if 'memory_format' not in kwargs:
+        kwargs['memory_format'] = torch.contiguous_format
+    return torch.rand_like(*args, **kwargs)
+
+def fake_full_like(*args, **kwargs):
+    if 'memory_format' not in kwargs:
+        kwargs['memory_format'] = torch.contiguous_format
+    return torch.full_like(*args, **kwargs)
+
 # Used to run the same test with different tensor types
 def repeat_test_for_types(dtypes):
     def repeat_helper(f):
@@ -1257,8 +1272,8 @@ def do_test_empty_full(self, dtypes, layout, device):
             check_value(v.new_empty(shape), dtype, layout, device, None, False)
             check_value(v.new_empty(shape, dtype=int64_dtype, device=device, requires_grad=False),
                         int64_dtype, layout, device, None, False)
-            check_value(torch.empty_like(v), dtype, layout, device, None, False)
-            check_value(torch.empty_like(v, dtype=int64_dtype, layout=layout, device=device, requires_grad=False),
+            check_value(fake_empty_like(v), dtype, layout, device, None, False)
+            check_value(fake_empty_like(v, dtype=int64_dtype, layout=layout, device=device, requires_grad=False),
                         int64_dtype, layout, device, None, False)
 
             if dtype is not torch.float16 and layout != torch.sparse_coo:
@@ -1271,8 +1286,8 @@ def do_test_empty_full(self, dtypes, layout, device):
                             dtype, layout, device, fv + 2, rg)
                 check_value(v.new_full(shape, fv + 3, dtype=int64_dtype, device=device, requires_grad=False),
                             int64_dtype, layout, device, fv + 3, False)
-                check_value(torch.full_like(v, fv + 4), dtype, layout, device, fv + 4, False)
-                check_value(torch.full_like(v, fv + 5,
+                check_value(fake_full_like(v, fv + 4), dtype, layout, device, fv + 4, False)
+                check_value(fake_full_like(v, fv + 5,
                                             dtype=int64_dtype, layout=layout, device=device, requires_grad=False),
                             int64_dtype, layout, device, fv + 5, False)
 

--- a/test/fake_operators.py
+++ b/test/fake_operators.py
@@ -1,0 +1,36 @@
+import torch
+
+def fake_empty_like(*args, **kwargs):
+    if 'memory_format' not in kwargs:
+        kwargs['memory_format'] = torch.contiguous_format
+    return torch.empty_like(*args, **kwargs)
+
+def fake_rand_like(*args, **kwargs):
+    if 'memory_format' not in kwargs:
+        kwargs['memory_format'] = torch.contiguous_format
+    return torch.rand_like(*args, **kwargs)
+
+def fake_randint_like(*args, **kwargs):
+    if 'memory_format' not in kwargs:
+        kwargs['memory_format'] = torch.contiguous_format
+    return torch.randint_like(*args, **kwargs)
+
+def fake_randn_like(*args, **kwargs):
+    if 'memory_format' not in kwargs:
+        kwargs['memory_format'] = torch.contiguous_format
+    return torch.randn_like(*args, **kwargs)
+
+def fake_ones_like(*args, **kwargs):
+    if 'memory_format' not in kwargs:
+        kwargs['memory_format'] = torch.contiguous_format
+    return torch.ones_like(*args, **kwargs)
+
+def fake_zeros_like(*args, **kwargs):
+    if 'memory_format' not in kwargs:
+        kwargs['memory_format'] = torch.contiguous_format
+    return torch.zeros_like(*args, **kwargs)
+
+def fake_full_like(*args, **kwargs):
+    if 'memory_format' not in kwargs:
+        kwargs['memory_format'] = torch.contiguous_format
+    return torch.full_like(*args, **kwargs)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -38,6 +38,7 @@ from torch.autograd import gradcheck
 from torch.autograd.gradcheck import gradgradcheck
 from torch.nn import Parameter
 from torch.nn.parallel._functions import Broadcast
+from fake_operators import fake_empty_like, fake_rand_like, fake_randint_like, fake_randn_like, fake_ones_like, fake_zeros_like, fake_full_like
 from common_utils import freeze_rng_state, run_tests, TestCase, skipIfNoLapack, skipIfRocm, \
     TEST_NUMPY, TEST_SCIPY, download_file, PY3, to_gpu, \
     get_function_arglist, load_tests, repeat_test_for_types, ALL_TENSORTYPES, \
@@ -4013,7 +4014,7 @@ class TestNN(NNTestCase):
                 for size in sizes:
                     x = torch.randn(size, device="cuda", dtype=dtype)
                     out = conv(x.detach().clone().requires_grad_())
-                    out.backward(torch.ones_like(out))
+                    out.backward(fake_ones_like(out))
 
         run_test(benchmark=False)
         run_test(benchmark=True)
@@ -4364,7 +4365,7 @@ class TestNN(NNTestCase):
 
         res_cpu = torch.nn.functional.ctc_loss(log_probs, targets, input_lengths, target_lengths,
                                                reduction='sum', zero_infinity=True)
-        grad_out = torch.randn_like(res_cpu)
+        grad_out = fake_randn_like(res_cpu)
         grad_cpu, = torch.autograd.grad(res_cpu, log_probs, grad_out)
 
         with torch.backends.cudnn.flags(enabled=False):
@@ -6335,7 +6336,7 @@ class TestNN(NNTestCase):
         for N in range(1, 50, 10):
             input = torch.rand(N, 3, 1024, 1024)
             self.assertEqual(
-                torch.nn.L1Loss()(input, torch.zeros_like(input)),
+                torch.nn.L1Loss()(input, fake_zeros_like(input)),
                 input.abs().mean())
 
     def test_cosine_similarity(self):
@@ -6368,9 +6369,9 @@ class TestNN(NNTestCase):
 
         # Check dividing by 0.
         input1 = torch.randn(10).requires_grad_()
-        input2 = torch.zeros_like(input1).requires_grad_()
+        input2 = fake_zeros_like(input1).requires_grad_()
         torch.cosine_similarity(input1, input2, 0).sum().backward()
-        self.assertEqual(input1.grad, torch.zeros_like(input1))
+        self.assertEqual(input1.grad, fake_zeros_like(input1))
         self.assertEqual(input2.grad, input1 * 1e8)
 
     def test_grid_sample_error_checking(self):
@@ -6514,7 +6515,7 @@ class TestNN(NNTestCase):
                                             align_corners=align_corners)
                     self.assertTrue(out_cpu.size() == torch.Size([N, C, H, W]))
 
-                    gradients = torch.randn_like(out_cpu)
+                    gradients = fake_randn_like(out_cpu)
                     out_cpu.backward(gradients)
 
                     if TEST_CUDA:
@@ -6695,7 +6696,7 @@ class TestNN(NNTestCase):
                                         align_corners=align_corners)
                 self.assertTrue(out_cpu.size() == torch.Size([N, C, D, H, W]))
 
-                gradients = torch.randn_like(out_cpu)
+                gradients = fake_randn_like(out_cpu)
                 out_cpu.backward(gradients)
 
                 if TEST_CUDA:
@@ -7431,7 +7432,7 @@ class TestNN(NNTestCase):
             inputs = x, weight
 
         dummy_out = func(*inputs)
-        grad_y = torch.randn_like(dummy_out, device=device, dtype=dtype, requires_grad=True)
+        grad_y = fake_randn_like(dummy_out, device=device, dtype=dtype, requires_grad=True)
 
         # Issue #15353: test mkldnn double backward, don't run gradgradcheck due
         # to imprecision issues
@@ -8661,7 +8662,7 @@ class TestNNDeviceType(NNTestCase):
         self.assertAlmostEqual(torch.abs(var.data).mean(), 1, delta=1e-5)
 
         # check that eval mode doesn't change behavior
-        grad_out = torch.randn_like(output)
+        grad_out = fake_randn_like(output)
         res1 = output.data.clone()
         output.backward(grad_out)
         grad1 = input_var.grad.data.clone()
@@ -9206,7 +9207,7 @@ class TestNNDeviceType(NNTestCase):
         logits = logits.to(dtype).requires_grad_()
         probs = logits.softmax(dim=-1)
 
-        counts = torch.zeros_like(logits)
+        counts = fake_zeros_like(logits)
         for _ in range(num_draws):
             y_draw = F.gumbel_softmax(logits, hard=True)
             counts = counts + y_draw
@@ -9431,7 +9432,7 @@ class TestNNDeviceType(NNTestCase):
         outf = F.softmax(inputf, dim=-1)
         # should be bitwise equal
         self.assertEqual(out, outf, prec=0)
-        gO = torch.empty_like(outf).uniform_()
+        gO = fake_empty_like(outf).uniform_()
         out.backward(gO)
         outf.backward(gO)
         # should be bitwise equal
@@ -9480,17 +9481,17 @@ class TestNNDeviceType(NNTestCase):
             Embed.to(device)
 
             output = Embed(input=x, offsets=torch.tensor([0], device=device, dtype=torch.long))
-            self.assertEqual(output, torch.zeros_like(output))
+            self.assertEqual(output, fake_zeros_like(output))
 
             output = Embed(input=x, offsets=torch.tensor([0, 0], device=device, dtype=torch.long))
-            self.assertEqual(output, torch.zeros_like(output))
+            self.assertEqual(output, fake_zeros_like(output))
 
     def test_EmbeddingBag_per_sample_weights_failures(self, device):
         # Failure 1: mismatched embeddings / per_sample_weights dtype
         es = nn.EmbeddingBag(5, 2, mode='sum').to(dtype=torch.float, device=device)
         input = torch.tensor([3, 1, 1, 1, 4, 0], dtype=torch.long, device=device)
         offsets = torch.tensor([0, 0, 3, 3, 6], dtype=torch.long, device=device)
-        per_sample_weights = torch.randn_like(input, dtype=torch.double, device=device)
+        per_sample_weights = fake_randn_like(input, dtype=torch.double, device=device)
         if device == 'cpu':
             with self.assertRaisesRegex(RuntimeError, 'have the same type as'):
                 es(input, offsets, per_sample_weights)
@@ -9549,7 +9550,7 @@ class TestNNDeviceType(NNTestCase):
                 torch.arange(1, 11, device=device, dtype=dtype).view_as(es.weight))
             input = torch.tensor([3, 1, 1, 1, 4, 0], device=device, dtype=torch.long)
             offsets = torch.tensor([0, 0, 3, 3, 6], device=device, dtype=torch.long)
-            per_sample_weights = torch.randn_like(input, dtype=dtype) \
+            per_sample_weights = fake_randn_like(input, dtype=dtype) \
                                       .requires_grad_(trainable_scale)
             ref_per_sample_weights = \
                 per_sample_weights.detach().requires_grad_(trainable_scale)
@@ -9560,7 +9561,7 @@ class TestNNDeviceType(NNTestCase):
             result = es(input, offsets, per_sample_weights)
             self.assertEqual(result, expected, prec=dtype2prec[dtype])
 
-            grad = torch.randn_like(expected)
+            grad = fake_randn_like(expected)
             result.backward(grad)
             expected.backward(grad)
             self.assertEqual(es.weight.grad, reference_weights.grad,
@@ -9763,7 +9764,7 @@ class TestNNDeviceType(NNTestCase):
         dense_grad = es.weight.grad
         if dense_grad.is_sparse:
             dense_grad = dense_grad.to_dense()
-        self.assertEqual(dense_grad, torch.zeros_like(es.weight))
+        self.assertEqual(dense_grad, fake_zeros_like(es.weight))
 
         # now compare EmbeddingBag vs Embedding + Sum/Mean, for constant bag length
         N, D, B, L = random.randint(1, 100), random.randint(1, 100), random.randint(1, 50), random.randint(1, 50)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -38,6 +38,7 @@ from common_device_type import instantiate_device_type_tests, \
     skipCPUIfNoLapack, skipCUDAIfNoMagma, skipCUDAIfRocm, onlyCUDA, onlyCPU, \
     dtypes, dtypesIfCUDA, deviceCountAtLeast, skipCUDAIf, precisionOverride
 import torch.backends.quantized
+from fake_operators import fake_empty_like, fake_rand_like, fake_randint_like, fake_randn_like, fake_ones_like, fake_zeros_like, fake_full_like
 
 
 # load_tests from common_utils is used to automatically filter tests for
@@ -1015,12 +1016,12 @@ class _TestTorchMixin(object):
     def test_ones_like(self):
         expected = torch.ones(100, 100)
 
-        res1 = torch.ones_like(expected)
+        res1 = fake_ones_like(expected)
         self.assertEqual(res1, expected)
 
         # test boolean tensor
         expected = torch.tensor([True, True], dtype=torch.bool)
-        res1 = torch.ones_like(expected)
+        res1 = fake_ones_like(expected)
         self.assertEqual(res1, expected)
 
     def test_dtypes(self):
@@ -1136,10 +1137,10 @@ class _TestTorchMixin(object):
         def test_copy_behavior(t, non_blocking=False):
             self.assertIs(t, t.to(t, non_blocking=non_blocking))
             self.assertIs(t, t.to(t.dtype, non_blocking=non_blocking))
-            self.assertIs(t, t.to(torch.empty_like(t), non_blocking=non_blocking))
+            self.assertIs(t, t.to(fake_empty_like(t, memory_format=torch.contiguous_format), non_blocking=non_blocking))
             self.assertIsNot(t, t.to(t, non_blocking=non_blocking, copy=True))
             self.assertIsNot(t, t.to(t.dtype, non_blocking=non_blocking, copy=True))
-            self.assertIsNot(t, t.to(torch.empty_like(t), non_blocking=non_blocking, copy=True))
+            self.assertIsNot(t, t.to(fake_empty_like(t, memory_format=torch.contiguous_format), non_blocking=non_blocking, copy=True))
 
             devices = [t.device]
             if t.device.type == 'cuda':
@@ -1292,7 +1293,7 @@ class _TestTorchMixin(object):
         res2 = torch.tensor(expected)
         self.assertEqual(res2, expected)
         res2[1] = 2
-        self.assertEqual(expected, torch.ones_like(expected))
+        self.assertEqual(expected, fake_ones_like(expected))
 
         res2 = torch.tensor(expected, dtype=torch.int)
         self.assertEqual(res1, expected)
@@ -1388,7 +1389,7 @@ class _TestTorchMixin(object):
         res2 = expected.new_tensor(expected)
         self.assertEqual(res2, expected)
         res2[1] = 2
-        self.assertEqual(expected, torch.ones_like(expected))
+        self.assertEqual(expected, fake_ones_like(expected))
         res2 = expected.new_tensor(expected, dtype=torch.int)
         self.assertEqual(res2, expected)
         self.assertIs(torch.int, res2.dtype)
@@ -2157,7 +2158,7 @@ class _TestTorchMixin(object):
         mat2 = torch.randn(7, 7)
         q, r = torch.qr(mat1)
         m, tau = torch.geqrf(mat1)
-        out_holder = torch.empty_like(mat1)
+        out_holder = fake_empty_like(mat1, memory_format=torch.contiguous_format)
 
         res1 = torch.mm(q, mat2)
         res2 = torch.ormqr(m, tau, mat2, left=True, transpose=False)
@@ -2220,7 +2221,7 @@ class _TestTorchMixin(object):
                         for test_idx in test_idxs.tolist():
                             test_one_sample(flatten_batch_res[test_idx])
                     # compare with C2C
-                    xc = torch.stack([x, torch.zeros_like(x)], -1)
+                    xc = torch.stack([x, fake_zeros_like(x)], -1)
                     xc_res = xc.fft(signal_ndim, normalized=normalized)
                     self.assertEqual(res, xc_res)
                 test_input_signal_sizes = [signal_sizes]
@@ -3668,11 +3669,11 @@ class _TestTorchMixin(object):
         self.assertTrue(isBinary(p.bernoulli()))
 
         p = torch.rand(5, 5, dtype=p_dtype, device=device)
-        torch.bernoulli(torch.rand_like(p), out=p)
+        torch.bernoulli(fake_rand_like(p), out=p)
         self.assertTrue(isBinary(p))
 
         p = torch.rand(5, dtype=p_dtype, device=device).expand(5, 5)
-        torch.bernoulli(torch.rand_like(p), out=p)
+        torch.bernoulli(fake_rand_like(p), out=p)
         self.assertTrue(isBinary(p))
 
         t = torch.empty(10, 10, dtype=t_dtype, device=device)
@@ -3687,11 +3688,11 @@ class _TestTorchMixin(object):
         self.assertTrue(isBinary(t))
 
         t.fill_(2)
-        torch.bernoulli(torch.rand_like(t, dtype=p_dtype), out=t)
+        torch.bernoulli(fake_rand_like(t, dtype=p_dtype), out=t)
         self.assertTrue(isBinary(t))
 
         t.fill_(2)
-        t.bernoulli_(torch.rand_like(t, dtype=p_dtype))
+        t.bernoulli_(fake_rand_like(t, dtype=p_dtype))
         self.assertTrue(isBinary(t))
 
     def test_bernoulli(self):
@@ -4842,8 +4843,8 @@ tensor([[[1., 1., 1.,  ..., 1., 1., 1.],
         y = torch.autograd.Variable(torch.randn(4, 4))
         z = torch.autograd.Variable(torch.IntTensor([1, 2, 3]))
         for a in (x, y, z):
-            self.assertEqual(torch.empty_like(a).shape, a.shape)
-            self.assertEqual(torch.empty_like(a).type(), a.type())
+            self.assertEqual(fake_empty_like(a).shape, a.shape)
+            self.assertEqual(fake_empty_like(a).type(), a.type())
 
     def test_pin_memory(self):
         x = torch.randn(3, 5)
@@ -5889,7 +5890,7 @@ class TestTorchDeviceType(TestCase):
         if isinstance(inplace_op, str):
             inplace_op = getattr(torch.Tensor, inplace_op)
         input = torch.randn(1, dtype=dtype, device=device).expand(3, 3)
-        inputs = [input] + [torch.randn_like(input)
+        inputs = [input] + [fake_randn_like(input)
                             for i in range(num_inputs - 1)]
         if not expected_failure:
             with self.assertRaisesRegex(RuntimeError, 'single memory location'):
@@ -5903,7 +5904,7 @@ class TestTorchDeviceType(TestCase):
                                              expected_failure=False):
 
         def _test(op, output, input):
-            output_exp = torch.empty_like(output)
+            output_exp = fake_empty_like(output)
             op(input, out=output_exp)
             self.assertEqual(op(input, out=output), output_exp, op.__name__)
 
@@ -5968,7 +5969,7 @@ class TestTorchDeviceType(TestCase):
         except ValueError as e:
             err_msg = "Integers to negative integer powers are not allowed."
             self.assertEqual(str(e), err_msg)
-            out = torch.empty_like(base)
+            out = fake_empty_like(base)
             test_cases = [
                 lambda: base.pow(exponent),
                 lambda: base.pow_(exponent),
@@ -6792,7 +6793,7 @@ class TestTorchDeviceType(TestCase):
                     if scale > 0:
                         target = ref_M_sdet, ref_M_logabsdet + math.log(scale)
                     elif scale == 0:
-                        target = torch.zeros_like(ref_M_sdet), torch.full_like(ref_M_logabsdet, -inf)
+                        target = fake_zeros_like(ref_M_sdet), fake_full_like(ref_M_logabsdet, -inf)
                     else:
                         target = ref_M_sdet.neg(), ref_M_logabsdet + math.log(-scale)
 
@@ -6807,7 +6808,7 @@ class TestTorchDeviceType(TestCase):
 
             for x1, x2 in [(0, 3), (4, 1), (3, 2)]:
                 assert x1 != x2, 'x1 and x2 needs to be different for this test'
-                target = torch.zeros_like(ref_M_sdet), torch.full_like(ref_M_logabsdet, -inf)
+                target = fake_zeros_like(ref_M_sdet), fake_full_like(ref_M_logabsdet, -inf)
                 # dim 0
                 M_clone = M.clone()
                 M_clone[:, x2] = M_clone[:, x1]
@@ -6822,7 +6823,7 @@ class TestTorchDeviceType(TestCase):
                     if det_scale > 0:
                         target = ref_M_sdet, ref_M_logabsdet + math.log(det_scale)
                     elif det_scale == 0:
-                        target = torch.zeros_like(ref_M_sdet), torch.full_like(ref_M_logabsdet, -inf)
+                        target = fake_zeros_like(ref_M_sdet), fake_full_like(ref_M_logabsdet, -inf)
                     else:
                         target = ref_M_sdet.neg(), ref_M_logabsdet + math.log(-det_scale)
 
@@ -7631,7 +7632,7 @@ class TestTorchDeviceType(TestCase):
                             torch_result = maybe_squeeze_result(l, r, torch.matmul(l, r))
                             self.assertEqual(truth, torch_result)
                             # test torch.matmul with out
-                            out = torch.zeros_like(torch_result)
+                            out = fake_zeros_like(torch_result)
                             torch.matmul(l, r, out=out)
                             self.assertEqual(truth, maybe_squeeze_result(l, r, out))
 
@@ -8100,7 +8101,7 @@ class TestTorchDeviceType(TestCase):
             def assert_backward_eq(tensor, indexer):
                 cpu = tensor.float().clone().detach().requires_grad_(True)
                 outcpu = cpu[indexer]
-                gOcpu = torch.rand_like(outcpu)
+                gOcpu = fake_rand_like(outcpu)
                 outcpu.backward(gOcpu)
                 dev = cpu.to(device).detach().requires_grad_(True)
                 outdev = dev[indexer]
@@ -8371,7 +8372,7 @@ class TestTorchDeviceType(TestCase):
         b = torch.randn(*b_dims, dtype=dtype, device=device)
         A = random_fullrank_matrix_distinct_singular_value(*A_dims, dtype=dtype, device=device)
         LU_data, LU_pivots, info = torch.lu(A, get_infos=True, pivot=pivot)
-        self.assertEqual(info, torch.zeros_like(info))
+        self.assertEqual(info, fake_zeros_like(info))
         return b, A, LU_data, LU_pivots
 
     @skipCPUIfNoLapack
@@ -8410,7 +8411,7 @@ class TestTorchDeviceType(TestCase):
         b = torch.randn(3, 0, 3, dtype=dtype, device=device)
         A = torch.randn(3, 0, 0, dtype=dtype, device=device)
         LU_data, LU_pivots = torch.lu(A)
-        self.assertEqual(torch.empty_like(b), b.lu_solve(LU_data, LU_pivots))
+        self.assertEqual(fake_empty_like(b), b.lu_solve(LU_data, LU_pivots))
 
         sub_test(True)
         if self.device_type == 'cuda':
@@ -8668,8 +8669,8 @@ class TestTorchDeviceType(TestCase):
             else:
                 _, singvals, _ = torch.svd(x, compute_uv=True)
                 self.assertEqual(singvals, outs, 'Singular values mismatch')
-                self.assertEqual(outu, torch.zeros_like(outu), 'U not zero')
-                self.assertEqual(outv, torch.zeros_like(outv), 'V not zero')
+                self.assertEqual(outu, fake_zeros_like(outu), 'U not zero')
+                self.assertEqual(outv, fake_zeros_like(outv), 'V not zero')
 
             resu, ress, resv = torch.svd(x, some=some, compute_uv=compute_uv)
             self.assertEqual(resu, outu, 'outputs of svd and svd with out differ')
@@ -8695,8 +8696,8 @@ class TestTorchDeviceType(TestCase):
             else:
                 _, singvals, _ = torch.svd(x, compute_uv=True)
                 self.assertEqual(singvals, ress, 'Singular values mismatch')
-                self.assertEqual(resu, torch.zeros_like(resu), 'U not zero')
-                self.assertEqual(resv, torch.zeros_like(resv), 'V not zero')
+                self.assertEqual(resu, fake_zeros_like(resu), 'U not zero')
+                self.assertEqual(resv, fake_zeros_like(resv), 'V not zero')
 
         shapes = [(3, 3), (5, 3, 3), (7, 5, 3, 3),  # square matrices
                   (7, 3), (5, 7, 3), (7, 5, 7, 3),  # fat matrices
@@ -8895,7 +8896,7 @@ class TestTorchDeviceType(TestCase):
     def test_geqrf(self, device):
         a = torch.randn(5, 5, device=device)
         b, c = torch.geqrf(a)
-        b_placeholder, c_placeholder = torch.empty_like(b), torch.empty_like(c)
+        b_placeholder, c_placeholder = fake_empty_like(b), fake_empty_like(c)
         torch.geqrf(a, out=(b_placeholder, c_placeholder))
         self.assertEqual(b, b_placeholder)
         self.assertEqual(c, c_placeholder)
@@ -9349,7 +9350,7 @@ class TestTorchDeviceType(TestCase):
                       torch.tensor([0.8, 0.2], device=device),
                       torch.tensor([0.7, 0.2, 0.1], device=device)]:
             # Check how different the alias distribution and the original distribution are
-            alias_dist = torch.zeros_like(probs)
+            alias_dist = fake_zeros_like(probs)
             alias_table, prob_table = torch._multinomial_alias_setup(probs)
             alias_samples = torch._multinomial_alias_draw(prob_table, alias_table, MAX_SAMPLES)
             alias_dist = torch.unique(alias_samples, return_counts=True)[1].to(dtype=probs.dtype) / MAX_SAMPLES
@@ -9364,7 +9365,7 @@ class TestTorchDeviceType(TestCase):
             # Check the difference between the original probabilities and the reconstructed
             # probabilities from the alias and probability tables output by _multinomial_alias_setup
             alias_table, prob_table = torch._multinomial_alias_setup(probs)
-            actual = torch.zeros_like(probs)
+            actual = fake_zeros_like(probs)
             for i, vals in enumerate(zip(alias_table, prob_table)):
                 idx, p = vals
                 actual[i] += p
@@ -9588,7 +9589,7 @@ class TestTorchDeviceType(TestCase):
             self.assertEqual(a.sign(), a_target, 'sign device={} dtype={}'.format(device, dtype))
             self.assertEqual(torch.sign(a), a_target, 'sign device={} dtype={}'.format(device, dtype))
 
-            out = torch.empty_like(a)
+            out = fake_empty_like(a)
             torch.sign(a, out=out)
             self.assertEqual(out, a_target, 'sign_out device={} dtype={}'.format(device, dtype))
 
@@ -9601,7 +9602,7 @@ class TestTorchDeviceType(TestCase):
         self.assertEqual(a_bool.sign(), a_bool_target, 'sign device={} dtype=bool'.format(device))
         self.assertEqual(torch.sign(a_bool), a_bool_target, 'sign device={} dtype=bool'.format(device))
 
-        a_out = torch.empty_like(a_bool)
+        a_out = fake_empty_like(a_bool)
         torch.sign(a_bool, out=a_out)
         self.assertEqual(a_out, a_bool_target, 'sign_out device={} dtype=bool'.format(device))
 
@@ -10114,7 +10115,7 @@ class TestTorchDeviceType(TestCase):
     def test_zeros_like(self, device):
         expected = torch.zeros((100, 100,), device=device)
 
-        res1 = torch.zeros_like(expected)
+        res1 = fake_zeros_like(expected)
         self.assertEqual(res1, expected)
 
     def test_histc(self, device):
@@ -10353,21 +10354,21 @@ class TestTorchDeviceType(TestCase):
 
                 if (self.device_type == 'cuda' and dt == torch.bfloat16):
                     self.assertRaises(RuntimeError, lambda: torch.zeros(shape, device=device, dtype=dt).shape)
-                    self.assertRaises(RuntimeError, lambda: torch.zeros_like(torch.zeros(shape, device=device, dtype=dt)).shape)
+                    self.assertRaises(RuntimeError, lambda: fake_zeros_like(torch.zeros(shape, device=device, dtype=dt)).shape)
                     self.assertRaises(RuntimeError, lambda: torch.full(shape, 3, device=device, dtype=dt).shape)
-                    self.assertRaises(RuntimeError, lambda: torch.full_like(torch.zeros(shape, device=device, dtype=dt), 3))
+                    self.assertRaises(RuntimeError, lambda: fake_full_like(torch.zeros(shape, device=device, dtype=dt), 3))
                     self.assertRaises(RuntimeError, lambda: torch.ones(shape, device=device, dtype=dt).shape)
-                    self.assertRaises(RuntimeError, lambda: torch.ones_like(torch.zeros(shape, device=device, dtype=dt)).shape)
-                    self.assertRaises(RuntimeError, lambda: torch.empty_like(torch.zeros(shape, device=device, dtype=dt)).shape)
+                    self.assertRaises(RuntimeError, lambda: fake_ones_like(torch.zeros(shape, device=device, dtype=dt)).shape)
+                    self.assertRaises(RuntimeError, lambda: fake_empty_like(torch.zeros(shape, device=device, dtype=dt)).shape)
                 else:
                     self.assertEqual(shape, torch.zeros(shape, device=device, dtype=dt).shape)
-                    self.assertEqual(shape, torch.zeros_like(torch.zeros(shape, device=device, dtype=dt)).shape)
+                    self.assertEqual(shape, fake_zeros_like(torch.zeros(shape, device=device, dtype=dt)).shape)
                     self.assertEqual(shape, torch.full(shape, 3, device=device, dtype=dt).shape)
-                    self.assertEqual(shape, torch.full_like(torch.zeros(shape, device=device, dtype=dt), 3).shape)
+                    self.assertEqual(shape, fake_full_like(torch.zeros(shape, device=device, dtype=dt), 3).shape)
                     self.assertEqual(shape, torch.ones(shape, device=device, dtype=dt).shape)
-                    self.assertEqual(shape, torch.ones_like(torch.zeros(shape, device=device, dtype=dt)).shape)
+                    self.assertEqual(shape, fake_ones_like(torch.zeros(shape, device=device, dtype=dt)).shape)
                     self.assertEqual(shape, torch.empty(shape, device=device, dtype=dt).shape)
-                    self.assertEqual(shape, torch.empty_like(torch.zeros(shape, device=device, dtype=dt)).shape)
+                    self.assertEqual(shape, fake_empty_like(torch.zeros(shape, device=device, dtype=dt)).shape)
                     self.assertEqual(shape, torch.empty_strided(shape, (0,) * len(shape), device=device, dtype=dt).shape)
 
                 if dt == torch.half and device == "cpu":
@@ -10378,14 +10379,14 @@ class TestTorchDeviceType(TestCase):
                         self.assertRaises(RuntimeError, lambda: torch.randint(6, shape, device=device, dtype=dt))
                         continue  # Remove once random is supported for bfloat16 on cuda
                     self.assertEqual(shape, torch.randint(6, shape, device=device, dtype=dt).shape)
-                    self.assertEqual(shape, torch.randint_like(torch.zeros(shape, device=device, dtype=dt), 6).shape)
+                    self.assertEqual(shape, fake_randint_like(torch.zeros(shape, device=device, dtype=dt), 6).shape)
 
                 if dt != torch.double and dt != torch.float and dt != torch.half:
                     self.assertRaises(RuntimeError, lambda: torch.rand(shape, device=device, dtype=dt).shape)
 
                 if dt == torch.double or dt == torch.float:
                     self.assertEqual(shape, torch.randn(shape, device=device, dtype=dt).shape)
-                    self.assertEqual(shape, torch.randn_like(torch.zeros(shape, device=device, dtype=dt)).shape)
+                    self.assertEqual(shape, fake_randn_like(torch.zeros(shape, device=device, dtype=dt)).shape)
 
         self.assertEqual((0,), torch.arange(0, device=device).shape)
         self.assertEqual((0, 0), torch.eye(0, device=device).shape)
@@ -10695,7 +10696,7 @@ class TestTorchDeviceType(TestCase):
                             dst2 += [src[i]]
                     self.assertEqual(dst, torch.tensor(dst2), 0)
 
-                    dst3 = torch.empty_like(src, device=device)
+                    dst3 = fake_empty_like(src, device=device)
                     torch.masked_select(src, mask, out=dst3)
                     self.assertEqual(dst3, torch.Tensor(dst2), 0)
                     if maskType is torch.uint8:
@@ -10936,7 +10937,7 @@ class TestTorchDeviceType(TestCase):
                 k_ok = (k1 >= k0) | (j1 > j0) | (i1 > i0)
                 lex = torch.stack((i_ok, j_ok, k_ok), dim=1)
                 return lex
-            return torch.full_like(inds, 1)
+            return fake_full_like(inds, 1)
 
         def gen_nontrivial_input(num_src, dtype, device):
             while True:
@@ -10977,7 +10978,7 @@ class TestTorchDeviceType(TestCase):
                     for i in range(dst1.size(0)):
                         self.assertNotEqual(tensor[dst1[i, 0], dst1[i, 1], dst1[i, 2]].item(), 0)
                     lex = is_lexicographically_sorted(dst1)
-                    self.assertEqual(torch.ones_like(lex), lex)
+                    self.assertEqual(fake_ones_like(lex), lex)
                 if TEST_NUMPY:
                     tup1 = torch.nonzero(tensor, as_tuple=True)
                     tup2 = tensor.nonzero(as_tuple=True)
@@ -11942,8 +11943,8 @@ class TestTorchDeviceType(TestCase):
         torch.isnan(x)
 
         torch.empty((1, 3, 2), out=y)
-        torch.empty_like(x)
-        torch.empty_like(x, dtype=torch.int64)
+        fake_empty_like(x)
+        fake_empty_like(x, dtype=torch.int64)
 
         # to
         x.to(x)
@@ -12074,29 +12075,29 @@ class TestTorchDeviceType(TestCase):
         x = torch.randn(4, 3, 8, 8, device=device)
         nhwc = x.contiguous(memory_format=torch.channels_last)
 
-        like = torch.empty_like(nhwc, memory_format=torch.preserve_format)
+        like = fake_empty_like(nhwc, memory_format=torch.preserve_format)
         self.assertFalse(like.is_contiguous())
         self.assertTrue(like.is_contiguous(memory_format=torch.channels_last))
 
-        like_x = torch.empty_like(x, memory_format=torch.preserve_format)
+        like_x = fake_empty_like(x, memory_format=torch.preserve_format)
         self.assertTrue(like_x.is_contiguous())
         self.assertFalse(like_x.is_contiguous(memory_format=torch.channels_last))
 
-        like = torch.empty_like(x, memory_format=torch.channels_last)
+        like = fake_empty_like(x, memory_format=torch.channels_last)
         self.assertFalse(like.is_contiguous())
         self.assertTrue(like.is_contiguous(memory_format=torch.channels_last))
 
-        like = torch.empty_like(nhwc, memory_format=torch.contiguous_format)
+        like = fake_empty_like(nhwc, memory_format=torch.contiguous_format)
         self.assertTrue(like.is_contiguous())
         self.assertFalse(like.is_contiguous(memory_format=torch.channels_last))
 
-        like = torch.empty_like(nhwc)
+        like = fake_empty_like(nhwc)
         self.assertTrue(like.is_contiguous())
         self.assertFalse(like.is_contiguous(memory_format=torch.channels_last))
 
         sparse = x.to_sparse()
         with self.assertRaises(RuntimeError):
-            z = torch.empty_like(sparse, memory_format=torch.preserve_format)
+            z = fake_empty_like(sparse, memory_format=torch.preserve_format)
 
     def test_memory_format_consistency(self, device):
         x = torch.randn(10, 3, 1, 1, device=device)
@@ -12363,12 +12364,12 @@ class TestTorchDeviceType(TestCase):
     def test_pin_memory_from_constructor(self, device):
         def _get_like(t, **kwargs):
             return [
-                torch.rand_like(t, **kwargs),
-                torch.randn_like(t, **kwargs),
-                torch.empty_like(t, **kwargs),
-                torch.full_like(t, 4, **kwargs),
-                torch.zeros_like(t, **kwargs),
-                torch.ones_like(t, **kwargs),
+                fake_rand_like(t, **kwargs),
+                fake_randn_like(t, **kwargs),
+                fake_empty_like(t, **kwargs),
+                fake_full_like(t, 4, **kwargs),
+                fake_zeros_like(t, **kwargs),
+                fake_ones_like(t, **kwargs),
             ]
 
         def _get_tensors(**kwargs):
@@ -12726,7 +12727,7 @@ class TestTorchDeviceType(TestCase):
                 expected_tensor = torch.tensor([float(v) for v in expected],
                                                dtype=dtype, device=device)
                 self.assertEqual(expected_tensor == values_tensor.hardshrink(l),
-                                 torch.ones_like(values_tensor))
+                                 fake_ones_like(values_tensor))
 
         def test_helper(min, max):
             h([0.0, min, -min, 0.1, -0.1, 1.0, -1.0, max, -max, inf, -inf],
@@ -12910,14 +12911,14 @@ class TestTorchDeviceType(TestCase):
             return torch.randn((4, 3, 8, 8), device=device, dtype=torch.float32).contiguous(memory_format=torch.channels_last)
 
         transformation_fns = [
-            lambda t, **kwargs: torch.zeros_like(t, **kwargs),
-            lambda t, **kwargs: torch.ones_like(t, **kwargs),
-            lambda t, **kwargs: torch.randint_like(t, 10, 100, **kwargs),
-            lambda t, **kwargs: torch.randint_like(t, 100, **kwargs),
-            lambda t, **kwargs: torch.randn_like(t, **kwargs),
-            lambda t, **kwargs: torch.rand_like(t, **kwargs),
-            lambda t, **kwargs: torch.full_like(t, 7, **kwargs),
-            lambda t, **kwargs: torch.empty_like(t, **kwargs)]
+            lambda t, **kwargs: fake_zeros_like(t, **kwargs),
+            lambda t, **kwargs: fake_ones_like(t, **kwargs),
+            lambda t, **kwargs: fake_randint_like(t, 10, 100, **kwargs),
+            lambda t, **kwargs: fake_randint_like(t, 100, **kwargs),
+            lambda t, **kwargs: fake_randn_like(t, **kwargs),
+            lambda t, **kwargs: fake_rand_like(t, **kwargs),
+            lambda t, **kwargs: fake_full_like(t, 7, **kwargs),
+            lambda t, **kwargs: fake_empty_like(t, **kwargs)]
 
         for transformation_fn in transformation_fns:
             self._test_memory_format_transformations(device, input_generator_fn, transformation_fn, compare_data=False)
@@ -13952,20 +13953,20 @@ class TestDevicePrecision(TestCase):
     def test_zeros_like_multiple_device(self, devices):
         expected = torch.zeros(100, 100, device=devices[0])
         x = torch.randn(100, 100, device=devices[1], dtype=torch.float32)
-        output = torch.zeros_like(x)
+        output = fake_zeros_like(x)
         self.assertEqual(output, expected)
 
     def test_ones_like(self, device):
         expected = torch.ones(100, 100, device=device)
 
-        res1 = torch.ones_like(expected)
+        res1 = fake_ones_like(expected)
         self.assertEqual(res1, expected)
 
     @deviceCountAtLeast(2)
     def test_ones_like_multiple_device(self, devices):
         expected = torch.ones(100, 100, device=devices[0])
         x = torch.randn(100, 100, device=devices[1], dtype=torch.float32)
-        output = torch.ones_like(x)
+        output = fake_ones_like(x)
         self.assertEqual(output, expected)
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #30013 [WIP] explicitly provide memory format when calling to *_like operators
* **#30012 [WIP] switch defaults**
* #30011 [WIP] fix more derivatives
* #30010 [WIP] fix derivatives
* #30009 explicitly provide memory format when calling to *_like operators
* #30008 explicitly provide memory format when calling to *_like operators
* #30007 explicitly provide memory format when calling to *_like operators
* #30006 explicitly provide memory format when calling to *_like operators (Redo of 81bf7364)
* #30005 explicitly provide memory format when calling to *_like operators (Redo of cc1c01)
* #30004 explicitly provide memory format when calling to *_like operators (Redo of e3e06549)
* #30003 explicitly provide memory format when calling to *_like operators (Redo of 4b4aa)
* #30002 explicitly provide memory format when calling to *_like operators (Redo of ce438f6967)
* #30001 explicitly provide memory format when calling to *_like operators (Redo of 631b22d)
* #30000 explicitly provide memory format when calling to *_like operators
* #29391 explicitly provide memory format when calling to *_like operators
* #29390 explicitly provide memory format when calling to *_like operators
* #29389 explicitly provide memory format when calling to *_like operators
* #29388 explicitly provide memory format when calling to *_like operators

