### PR TITLE
[WIP] explicitly provide memory format when calling to *_like operators

### DIFF
--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -653,7 +653,7 @@ class TestCase(expecttest.TestCase):
         i.mul_(torch.tensor(size[:sparse_dim]).unsqueeze(1).to(i))
         i = i.to(torch.long)
         if is_uncoalesced:
-            v = torch.cat([v, torch.randn_like(v)], 0)
+            v = torch.cat([v, torch.randn_like(v, memory_format=torch.contiguous_format)], 0)
             i = torch.cat([i, i], 1)
 
         x = torch.sparse_coo_tensor(i, v, torch.Size(size))
@@ -1287,8 +1287,7 @@ def do_test_empty_full(self, dtypes, layout, device):
                 check_value(v.new_full(shape, fv + 3, dtype=int64_dtype, device=device, requires_grad=False),
                             int64_dtype, layout, device, fv + 3, False)
                 check_value(fake_full_like(v, fv + 4), dtype, layout, device, fv + 4, False)
-                check_value(fake_full_like(v, fv + 5,
-                                            dtype=int64_dtype, layout=layout, device=device, requires_grad=False),
+                check_value(fake_full_like(v, fv + 5, dtype=int64_dtype, layout=layout, device=device, requires_grad=False),
                             int64_dtype, layout, device, fv + 5, False)
 
 

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -15661,7 +15661,7 @@ a")
                   result = torch.to(torch.fill_(_1, 5), dtype=6, layout=0, device=torch.device("cpu"),
                                     non_blocking=False, copy=False)
                   result2 = torch.rand([10], dtype=6, layout=0, device=torch.device("cpu"))
-                  result3 = torch.rand_like(result2, dtype=6, layout=0, device=torch.device("cpu"))
+                  result3 = torch.rand_like(result2, dtype=6, layout=0, device=torch.device("cpu"), memory_format=torch.contiguous_format)
                   _2 = torch.add(torch.add(result, result2, alpha=1), result3, alpha=1)
                   return _2
                 ''',


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#30013 [WIP] explicitly provide memory format when calling to *_like operators**
* #30012 [WIP] switch defaults
* #30011 [WIP] fix more derivatives
* #30010 [WIP] fix derivatives
* #30009 explicitly provide memory format when calling to *_like operators
* #30008 explicitly provide memory format when calling to *_like operators
* #30007 explicitly provide memory format when calling to *_like operators
* #30006 explicitly provide memory format when calling to *_like operators (Redo of 81bf7364)
* #30005 explicitly provide memory format when calling to *_like operators (Redo of cc1c01)
* #30004 explicitly provide memory format when calling to *_like operators (Redo of e3e06549)
* #30003 explicitly provide memory format when calling to *_like operators (Redo of 4b4aa)
* #30002 explicitly provide memory format when calling to *_like operators (Redo of ce438f6967)
* #30001 explicitly provide memory format when calling to *_like operators (Redo of 631b22d)
* #30000 explicitly provide memory format when calling to *_like operators
* #29391 explicitly provide memory format when calling to *_like operators
* #29390 explicitly provide memory format when calling to *_like operators
* #29389 explicitly provide memory format when calling to *_like operators
* #29388 explicitly provide memory format when calling to *_like operators

