### PR TITLE
Eliminate tensor copies from compute_common_type_ in TensorIterator.

### DIFF
--- a/aten/src/ATen/native/TypeProperties.h
+++ b/aten/src/ATen/native/TypeProperties.h
@@ -2,6 +2,14 @@
 
 namespace at { namespace native {
 
+struct ResultTypeState {
+  c10::ScalarType dimResult = ScalarType::Undefined;
+  c10::ScalarType wrappedResult = ScalarType::Undefined;
+  c10::ScalarType zeroResult = ScalarType::Undefined;
+};
+
+ResultTypeState update_result_type_state(const Tensor& tensor, const ResultTypeState& in_state);
+ScalarType result_type(const ResultTypeState& state);
 ScalarType result_type(TensorList tensors);
 
 }}


### PR DESCRIPTION
This requires refactoring at::native::result_type to operate as a
state machine, processing the input types one at a time.  There may
be other places in the code base that could benefit from adopting
this approach as well.

