### PR TITLE
reorganize test binaries of op bench

### DIFF
--- a/benchmarks/operator_benchmark/benchmark_all_others.py
+++ b/benchmarks/operator_benchmark/benchmark_all_others.py
@@ -5,10 +5,11 @@ from __future__ import unicode_literals
 
 import operator_benchmark as op_bench
 from pt import ( # noqa
-    unary_test,  # noqa
+    add_test, batchnorm_test, cat_test, chunk_test, conv_test,  # noqa
+    gather_test, linear_test, matmul_test, pool_test,  # noqa
+    softmax_test, split_test, fill_test, as_strided_test,  # noqa
+    embeddingbag_test  # noqa
 )
-import benchmark_all_others  # noqa
-import benchmark_all_quantized_test  # noqa
 
 if __name__ == "__main__":
     op_bench.benchmark_runner.main()


### PR DESCRIPTION
Summary: This diff doesn't change how users run the benchmarks. But under the hood, we group all the tests into three groups: unary test, quantized test, and the rest ops (we name it others here).

Test Plan:
```
buck run //caffe2/benchmarks/operator_benchmark:benchmark_all_test -- --iterations 1
# ----------------------------------------
# PyTorch/Caffe2 Operator Micro-benchmarks
# ----------------------------------------
# Tag : short

# Benchmarking PyTorch: abs
# Mode: Eager
# Name: abs_M512_N512_cpu
# Input: M: 512, N: 512, device: cpu
Forward Execution Time (us) : 17914.301
...
# Benchmarking PyTorch: add
# Mode: Eager
# Name: add_M64_N64_K64_cpu_bwd2
# Input: M: 64, N: 64, K: 64, device: cpu
Backward Execution Time (us) : 66525.855
...
# Benchmarking PyTorch: mul
# Mode: Eager
# Name: mul_N2_dtypetorch.qint32_contigTrue
# Input: N: 2, dtype: torch.qint32, contig: True
Forward Execution Time (us) : 290.555
...

Reviewed By: hl475

Differential Revision: D18574719

