### PR TITLE
[WIP] cache tensor scalar_type in OperandInfo

### DIFF
--- a/aten/src/ATen/native/TensorIterator.cpp
+++ b/aten/src/ATen/native/TensorIterator.cpp
@@ -96,7 +96,7 @@ static std::tuple<Device, ScalarType, bool> compute_common_type_(at::ArrayRef<Op
     if (!op.tensor.defined()) continue;
     //don't handle scalars
     if (op.tensor.dim() > 0){
-      ScalarType current = op.tensor.scalar_type();
+      ScalarType current = op.tensor_dtype;
       if (current == ScalarType::Undefined){
         all_same_type = false;
         break;
@@ -135,23 +135,23 @@ static void validate_dtype(OperandInfo& op, ScalarType common_dtype, CommonDType
     // For binary_ops, we follow casting rules. For unary/nullary types
     // we require the type to match.
     if (op.is_output && check_output) {
-      if (!canCast(common_dtype, op.tensor.scalar_type()))
+      if (!canCast(common_dtype, op.tensor_dtype))
       {
         AT_ERROR("result type ", common_dtype,
           " can't be cast to the desired output type ",
-          op.tensor.scalar_type());
+          op.tensor_dtype);
       }
     }
-    if (!promoting && op.dtype != op.tensor.scalar_type()) {
-      AT_ERROR("expected dtype ", op.dtype, " but got dtype ", op.tensor.scalar_type());
+    if (!promoting && op.target_dtype != op.tensor_dtype) {
+      AT_ERROR("expected dtype ", op.target_dtype, " but got dtype ", op.tensor_dtype);
     }
   }
 }
 
 static void maybe_copy_casting_to_common_dtype(OperandInfo& op, ScalarType common_dtype) {
-  if (op.tensor.defined() && op.tensor.scalar_type() != common_dtype)
+  if (op.tensor.defined() && op.tensor_dtype != common_dtype)
   {
-    op.dtype = common_dtype;
+    op.target_dtype = common_dtype;
     op.original_tensor = op.tensor;
     if (!op.is_output) {
       op.tensor = op.tensor.to(common_dtype);
@@ -159,6 +159,7 @@ static void maybe_copy_casting_to_common_dtype(OperandInfo& op, ScalarType commo
       op.tensor =
           at::empty_like(op.tensor, op.tensor.options().dtype(common_dtype), LEGACY_CONTIGUOUS_MEMORY_FORMAT);
     }
+    op.tensor_dtype = common_dtype;
   }
 }
 
@@ -196,30 +197,30 @@ void TensorIterator::compute_types() {
     for (auto& op : operands_) {
       if (!op.is_type_defined()) {
         op.device = common_device;
-        op.dtype = common_dtype_;
+        op.target_dtype = common_dtype_;
       } else if (compute_common_dtype &&
-                 (op.device != common_device || op.dtype != common_dtype_)) {
+                 (op.device != common_device || op.target_dtype != common_dtype_)) {
         if (allow_cpu_scalars_ && op.tensor.defined() && op.tensor.dim() == 0 &&
             common_device_is_cuda && op.tensor.device().is_cpu() &&
             !has_cpu_scalar) {
           // don't cast CPU scalars in CUDA ops that directly support them.
           op.device = op.tensor.device();
-          op.dtype = op.tensor.scalar_type();
+          op.target_dtype = op.tensor_dtype;
           has_cpu_scalar = true;
         } else if (promote_gpu_output_dtypes_ && op.tensor.defined() &&
             !op.is_output &&
-            op.tensor.scalar_type() == kHalf && common_dtype_ == kFloat &&
+            op.tensor_dtype == kHalf && common_dtype_ == kFloat &&
             op.tensor.device().is_cuda() && common_device_is_cuda) {
           // allow input tensor type upcasting for fp16 to fp32 in fused kernel
           // on GPU
           op.device = op.tensor.device();
-          op.dtype = op.tensor.scalar_type();
+          op.target_dtype = op.tensor_dtype;
         } else {
           op.device = common_device;
           if (compute_common_dtype_only_for_inputs && op.is_output) {
-            op.dtype = op.tensor.scalar_type();
+            op.target_dtype = op.tensor_dtype;
           } else {
-            op.dtype = common_dtype_;
+            op.target_dtype = common_dtype_;
           }
         }
       }
@@ -235,7 +236,7 @@ void TensorIterator::compute_types() {
       }
     }
 
-    if (op.tensor.defined() && op.tensor.scalar_type() != common_dtype_) {
+    if (op.tensor.defined() && op.tensor_dtype != common_dtype_) {
       have_differing_types_ = true;
     }
 
@@ -280,7 +281,7 @@ void TensorIterator::allocate_outputs() {
     auto& op = operands_[i];
     if (!op.tensor.defined()) {
       TORCH_INTERNAL_ASSERT(op.is_type_defined(), "no type for operand", i);
-      int element_size = elementSize(op.dtype);
+      int element_size = elementSize(op.target_dtype);
       op.stride_bytes = compatible_stride(element_size);
       //check if permutation is just an inverted order
       bool inverted = true;
@@ -303,6 +304,7 @@ void TensorIterator::allocate_outputs() {
         op.tensor =
             at::empty_strided(tensor_shape, tensor_stride, op.options());
       }
+      op.tensor_dtype = op.target_dtype;
     }
   }
 }
@@ -886,6 +888,7 @@ void TensorIterator::fast_set_up() {
         TORCH_INTERNAL_ASSERT(op.is_type_defined(), "no type for operand", i);
         op.tensor = at::empty(shape_, op.options());
       }
+      op.tensor_dtype = op.target_dtype;
   }
   //coalescing dimensions consists of collapsing dimensions to 1 (we are limited to contiguous no-broadcast cases here)
   if (ndim() > 1){


### PR DESCRIPTION
As `scalar_type` is an expensive call on tensors, cache its result in OperandInfo. This saves approx 140 ns per op in TensorIterator. 
Test plan: covered by current tests
Differential Revision: [D18576236](https://our.internmc.facebook.com/intern/diff/D18576236/)



