### PR TITLE
Remove rpc.sync_rpc from the public API.

### DIFF
--- a/test/rpc_test.py
+++ b/test/rpc_test.py
@@ -494,25 +494,6 @@ class RpcTest(object):
             )
             self.assertEqual(ret, torch.ones(n, n) * 2)
 
-    @dist_init
-    def test_sync_rpc(self):
-        dst_rank = (self.rank + 1) % self.world_size
-        for i in range(20):
-            rpc.sync_rpc()
-            n = i + self.rank + 1
-            ret1 = rpc.rpc_sync(
-                "worker{}".format(dst_rank),
-                torch.add,
-                args=(torch.ones(n, n), torch.ones(n, n)),
-            )
-            rpc.sync_rpc()
-            ret2 = rpc.rpc_sync(
-                "worker{}".format(dst_rank), torch.add, args=(torch.ones(n, n), 2)
-            )
-            rpc.sync_rpc()
-            self.assertEqual(ret1, torch.ones(n, n) * 2)
-            self.assertEqual(ret2, torch.ones(n, n) * 3)
-
     @dist_init(setup_rpc=False)
     def test_join_rpc(self):
         # Initialize RPC.

--- a/torch/distributed/rpc/api.py
+++ b/torch/distributed/rpc/api.py
@@ -47,19 +47,6 @@ def join_rpc():
         _cleanup_python_rpc_handler()
 
 
-@_require_initialized
-def sync_rpc():
-    r"""
-    Block until all local and remote RPC processes reach this method and finish
-    sending all pending RPCs. As this method synchronizes at the process
-    level, if multiple threads are spawned, only one of them should call this
-    method at a time.
-    """
-
-    _agent.sync()
-
-
-
 # TODO: add a context manager to wrap _init_rpc_backend and join_rpc
 def _init_rpc_backend(
     backend=backend_registry.BackendType.PROCESS_GROUP,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#30033 Remove rpc.sync_rpc from the public API.**

Removing this API for now since we don't have a concrete use-case for
this yet and as a result exposing this as a public API might result in users
depending on this API.

We can always add some variant of this API back if needed later.

Differential Revision: [D18578056](https://our.internmc.facebook.com/intern/diff/D18578056/)