### PR TITLE
[wip] Add memory_format to quant

### DIFF
--- a/torch/quantization/observer.py
+++ b/torch/quantization/observer.py
@@ -772,7 +772,7 @@ class HistogramObserver(_ObserverBase):
             new_max = torch.max(x)
             new_histogram = torch.histc(x, self.bins, min=new_min, max=new_max)
             # combine the existing histogram and new histogram into 1 histogram
-            combined_histogram = torch.zeros_like(self.histogram)
+            combined_histogram = torch.zeros_like(self.histogram, memory_format=torch.contiguous_format)
             combined_min = torch.min(new_min, min_val)
             combined_max = torch.max(new_max, max_val)
             self._combine_histograms(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #30039 [wip] Add memory_format torch.nn
* **#30038 [wip] Add memory_format to quant**
* #30036 Add memory format to optimizer
* #30034 [WIP] Update tests to avoid errors
* #30026 [WIP] Switch default and alternate tests
* #30008 explicitly provide memory format when calling to *_like operators
* #30007 explicitly provide memory format when calling to *_like operators
* #30006 explicitly provide memory format when calling to *_like operators (Redo of 81bf7364)
* #30005 explicitly provide memory format when calling to *_like operators (Redo of cc1c01)
* #30004 explicitly provide memory format when calling to *_like operators (Redo of e3e06549)
* #30003 explicitly provide memory format when calling to *_like operators (Redo of 4b4aa)
* #30002 explicitly provide memory format when calling to *_like operators (Redo of ce438f6967)
* #30001 explicitly provide memory format when calling to *_like operators (Redo of 631b22d)
* #30000 explicitly provide memory format when calling to *_like operators
* #29391 explicitly provide memory format when calling to *_like operators
* #29390 explicitly provide memory format when calling to *_like operators
* #29389 explicitly provide memory format when calling to *_like operators
* #29388 explicitly provide memory format when calling to *_like operators

