### PR TITLE
[wip] Add memory_format torch.nn

### DIFF
--- a/torch/nn/intrinsic/qat/modules/conv_fused.py
+++ b/torch/nn/intrinsic/qat/modules/conv_fused.py
@@ -119,7 +119,7 @@ class ConvBn2d(nn.Conv2d):
             batch_var = torch.var(conv_orig, dim=[0, 2, 3], unbiased=False)
             n = float(conv_orig.numel() / conv_orig.size()[1])
             unbiased_batch_var = batch_var * (n / (n - 1))
-            batch_rstd = torch.ones_like(batch_var) / torch.sqrt(batch_var + self.eps)
+            batch_rstd = torch.ones_like(batch_var, memory_format=torch.contiguous_format) / torch.sqrt(batch_var + self.eps)
 
             rescale_factor = running_std * batch_rstd
             conv = conv * rescale_factor.reshape([1, -1, 1, 1])


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#30039 [wip] Add memory_format torch.nn**
* #30038 [wip] Add memory_format to quant
* #30036 Add memory format to optimizer
* #30034 [WIP] Update tests to avoid errors
* #30026 [WIP] Switch default and alternate tests
* #30008 explicitly provide memory format when calling to *_like operators
* #30007 explicitly provide memory format when calling to *_like operators
* #30006 explicitly provide memory format when calling to *_like operators (Redo of 81bf7364)
* #30005 explicitly provide memory format when calling to *_like operators (Redo of cc1c01)
* #30004 explicitly provide memory format when calling to *_like operators (Redo of e3e06549)
* #30003 explicitly provide memory format when calling to *_like operators (Redo of 4b4aa)
* #30002 explicitly provide memory format when calling to *_like operators (Redo of ce438f6967)
* #30001 explicitly provide memory format when calling to *_like operators (Redo of 631b22d)
* #30000 explicitly provide memory format when calling to *_like operators
* #29391 explicitly provide memory format when calling to *_like operators
* #29390 explicitly provide memory format when calling to *_like operators
* #29389 explicitly provide memory format when calling to *_like operators
* #29388 explicitly provide memory format when calling to *_like operators

