### PR TITLE
change conv, batchnorm input shapes

### DIFF
--- a/benchmarks/operator_benchmark/benchmark_core.py
+++ b/benchmarks/operator_benchmark/benchmark_core.py
@@ -164,7 +164,7 @@ class BenchmarkRunner(object):
     def __init__(self, args):
         # TODO: consider time-bound constraints as well.
         self.args = args
-        self.iters = 200
+        self.iters = 100
         self.has_explicit_iteration_count = False
         self.multiplier = 2
         self.predefined_minimum_secs = 1
@@ -249,7 +249,7 @@ class BenchmarkRunner(object):
     def _launch_forward(self, test_case, iters, print_per_iter):
         """ Use Python's timeit module to measure execution time (unit: second).
         """
-        cuda_sync = True if 'cuda' in test_case.test_config.test_name else False 
+        cuda_sync = True if 'cuda' in test_case.test_config.test_name else False
         func = test_case.run_forward
         if self.use_jit:
             func = test_case.run_jit_forward
@@ -336,7 +336,7 @@ class BenchmarkRunner(object):
                 (self.args.tag_filter == 'all' or
                     self._check_keep(op_test_config.tag, self.args.tag_filter)) and
                 (not self.args.forward_only or op_test_config.run_backward != self.args.forward_only) and
-                (self.args.device == 'None' or 'device' not in op_test_config.test_name or 
+                (self.args.device == 'None' or 'device' not in op_test_config.test_name or
                     self.args.device in op_test_config.test_name)):
             return True
 

--- a/benchmarks/operator_benchmark/pt/batchnorm_test.py
+++ b/benchmarks/operator_benchmark/pt/batchnorm_test.py
@@ -24,7 +24,7 @@ batchnorm_configs_short = op_bench.config_list(
 
 batchnorm_configs_long = op_bench.cross_product_configs(
     M=[1, 128],
-    N=[2 ** 16, 2048],
+    N=[8192, 2048],
     K=[1],
     device=['cpu', 'cuda'],
     tags=["long"]

--- a/benchmarks/operator_benchmark/pt/conv_test.py
+++ b/benchmarks/operator_benchmark/pt/conv_test.py
@@ -87,13 +87,13 @@ conv_2d_configs_short = op_bench.config_list(
 )
 
 conv_2d_configs_long = op_bench.cross_product_configs(
-    in_c=[128, 512],
-    out_c=[128, 512],
+    in_c=[128, 256],
+    out_c=[128, 256],
     kernel=[3],
     stride=[1, 2],
-    N=[8],
-    H=[64],
-    W=[64],
+    N=[4],
+    H=[32],
+    W=[32],
     device=['cpu', 'cuda'],
     tags=["long"]
 )


### PR DESCRIPTION
Summary: as title

Test Plan:
```
buck run mode/opt //caffe2/benchmarks/operator_benchmark/pt:conv_test
# ----------------------------------------
# PyTorch/Caffe2 Operator Micro-benchmarks
# ----------------------------------------
# Tag : None

# Benchmarking PyTorch: ConvTranspose2d
# Mode: Eager
# Name: ConvTranspose2d_in_c512_out_c512_kernel3_stride2_N8_H64_W64_cpu
# Input: in_c: 512, out_c: 512, kernel: 3, stride: 2, N: 8, H: 64, W: 64, device: cpu
Forward Execution Time (us) : 751635.354

Differential Revision: D18579767

