### PR TITLE
[ci] remove consistency check from setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -889,10 +889,6 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Ensure config is up to date
-          command: ./ensure-consistency.py
-          working_directory: .circleci
-      - run:
           name: Save commit message
           command: git log --format='%B' -n 1 HEAD > .circleci/scripts/COMMIT_MSG
       # Note [Workspace for CircleCI scripts]

--- a/.circleci/verbatim-sources/job-specs-setup.yml
+++ b/.circleci/verbatim-sources/job-specs-setup.yml
@@ -5,10 +5,6 @@
     steps:
       - checkout
       - run:
-          name: Ensure config is up to date
-          command: ./ensure-consistency.py
-          working_directory: .circleci
-      - run:
           name: Save commit message
           command: git log --format='%B' -n 1 HEAD > .circleci/scripts/COMMIT_MSG
       # Note [Workspace for CircleCI scripts]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#30043 [ci] remove consistency check from setup**

This is already checked on in the GH actions linter, so this check is
redundant. And putting it in `setup` has the effect of blocking direct
changes to config.yml when I want to experiment, which is a bit
bothersome.

Differential Revision: [D18611674](https://our.internmc.facebook.com/intern/diff/D18611674)