### PR TITLE
Change dimType for shapeInfo

### DIFF
--- a/caffe2/opt/backend_transformer_base.cc
+++ b/caffe2/opt/backend_transformer_base.cc
@@ -52,7 +52,9 @@ TensorProto BackendTransformerBase::wrapShapeInfoIntoTensorProto(
   for (const auto i : shape_info.shape.dims()) {
     t.add_dims(i);
   }
-  t.add_int32_data(static_cast<int32_t>(shape_info.dim_type));
+  for (const auto& dimType : shape_info.getDimType()) {
+    t.add_int32_data(static_cast<int32_t>(dimType));
+  }
   return t;
 }
 
@@ -82,7 +84,9 @@ QTensorProto BackendTransformerBase::wrapShapeInfoIntoQTensorProto(
   for (const auto i : shape_info.shape.dims()) {
     t.add_dims(i);
   }
-  t.add_data(static_cast<int32_t>(shape_info.dim_type));
+  for (const auto& dimType : shape_info.getDimType()) {
+    t.add_data(static_cast<int32_t>(dimType));
+  }
   return t;
 }
 
@@ -126,16 +130,21 @@ ShapeInfoMap BackendTransformerBase::inferShapes(
   // here. For SEQ typed tensors, there are only a few of them and they will be
   // handled by BoundShapeInferencer.
   for (const auto& kv : shape_hints_mapped) {
+    std::vector<TensorBoundShape_DimType> dimType(
+        kv.second.dims_size(), TensorBoundShape_DimType_CONSTANT);
+    if (dimType.size()) {
+      dimType[0] = TensorBoundShape_DimType_BATCH;
+    }
     shape_map.emplace(
         std::piecewise_construct,
         std::forward_as_tuple(kv.first),
-        std::forward_as_tuple(ShapeInfo::DimType::BATCH, kv.second));
+        std::forward_as_tuple(dimType, kv.second));
   }
   // Populate shapes from workplace
   const std::vector<std::string> ws_blobs = ws->Blobs();
   for (const auto& s : ws_blobs) {
     auto shape_info = getShapeInfoFromBlob(ws->GetBlob(s));
-    if (shape_info.dim_type != ShapeInfo::DimType::UNKNOWN) {
+    if (shape_info.dimTypeIsSet()) {
       shape_map.emplace(s, shape_info);
     }
   }
@@ -148,7 +157,7 @@ ShapeInfoMap BackendTransformerBase::inferShapes(
         std::piecewise_construct,
         std::forward_as_tuple(kv.first),
         std::forward_as_tuple(
-            kv.second.dim_type,
+            kv.second.getDimType(),
             kv.second.shape,
             kv.second.is_quantized,
             kv.second.q_info));

--- a/caffe2/opt/bound_shape_inference_test.cc
+++ b/caffe2/opt/bound_shape_inference_test.cc
@@ -8,11 +8,11 @@ using namespace caffe2;
 namespace {
 
 ShapeInfo makeTensorInfo(
-    ShapeInfo::DimType t,
+    const std::vector<TensorBoundShape::DimType>& t,
     const std::vector<int64_t>& dims,
     TensorProto::DataType dtype = TensorProto_DataType_FLOAT) {
   ShapeInfo info;
-  info.dim_type = t;
+  info.setDimType(t);
   TensorShape& shape = info.shape;
   for (const auto d : dims) {
     shape.add_dims(d);
@@ -24,14 +24,14 @@ ShapeInfo makeTensorInfo(
 void verifyShapeInfo(
     const ShapeInfoMap& info,
     const std::string& name,
-    ShapeInfo::DimType t,
+    const std::vector<TensorBoundShape::DimType>& t,
     const std::vector<int64_t>& dims,
     TensorProto::DataType dtype = TensorProto_DataType_FLOAT) {
   LOG(INFO) << "Checking " << name;
   const auto it = info.find(name);
   ASSERT_TRUE(it != info.end());
   const auto& shape_info = it->second;
-  EXPECT_EQ(shape_info.dim_type, t);
+  EXPECT_EQ(shape_info.getDimType(), t);
   const auto& shape = shape_info.shape;
   ASSERT_EQ(shape.dims_size(), dims.size());
   for (int i = 0; i < dims.size(); ++i) {
@@ -48,27 +48,37 @@ TEST(BoundShapeInference, SparseLengthsSum) {
       "SparseLengthsSum", "", {"Weights", "Data", "Lengths"}, {"Out"}, {}));
   ShapeInfoMap shape_map;
   shape_map.emplace(
-      "Weights", makeTensorInfo(ShapeInfo::DimType::CONSTANT, {1000, 16}));
+      "Weights",
+      makeTensorInfo(
+          {TensorBoundShape_DimType_CONSTANT,
+           TensorBoundShape_DimType_CONSTANT},
+          {1000, 16}));
   BoundShapeSpec spec(20, 1000);
   BoundShapeInferencer eng(spec);
   eng.InferBoundShapeAndType(net, shape_map, nullptr);
   const auto& out_shape = eng.shape_info();
   verifyShapeInfo(
-      out_shape, "Weights", ShapeInfo::DimType::CONSTANT, {1000, 16});
+      out_shape,
+      "Weights",
+      {TensorBoundShape_DimType_CONSTANT, TensorBoundShape_DimType_CONSTANT},
+      {1000, 16});
   verifyShapeInfo(
       out_shape,
       "Data",
-      ShapeInfo::DimType::SEQ,
+      {TensorBoundShape_DimType_FEATURE_MAX_DEFAULT},
       {spec.max_seq_size},
       TensorProto_DataType_INT64);
   verifyShapeInfo(
       out_shape,
       "Lengths",
-      ShapeInfo::DimType::BATCH,
+      {TensorBoundShape_DimType_BATCH},
       {spec.max_batch_size},
       TensorProto_DataType_INT32);
   verifyShapeInfo(
-      out_shape, "Out", ShapeInfo::DimType::BATCH, {spec.max_batch_size, 16});
+      out_shape,
+      "Out",
+      {TensorBoundShape_DimType_BATCH, TensorBoundShape_DimType_CONSTANT},
+      {spec.max_batch_size, 16});
 }
 
 TEST(BoundShapeInference, SparseLengthsSumFused8BitRowwise) {
@@ -83,7 +93,10 @@ TEST(BoundShapeInference, SparseLengthsSumFused8BitRowwise) {
   shape_map.emplace(
       "Weights",
       makeTensorInfo(
-          ShapeInfo::DimType::CONSTANT, {1000, 58}, TensorProto_DataType_INT8));
+          {TensorBoundShape_DimType_CONSTANT,
+           TensorBoundShape_DimType_CONSTANT},
+          {1000, 58},
+          TensorProto_DataType_INT8));
   BoundShapeSpec spec(20, 1000);
   BoundShapeInferencer eng(spec);
   eng.InferBoundShapeAndType(net, shape_map, nullptr);
@@ -91,39 +104,33 @@ TEST(BoundShapeInference, SparseLengthsSumFused8BitRowwise) {
   verifyShapeInfo(
       out_shape,
       "Weights",
-      ShapeInfo::DimType::CONSTANT,
+      {TensorBoundShape_DimType_CONSTANT, TensorBoundShape_DimType_CONSTANT},
       {1000, 58},
       TensorProto_DataType_INT8);
   verifyShapeInfo(
       out_shape,
       "Data",
-      ShapeInfo::DimType::SEQ,
+      {TensorBoundShape_DimType_FEATURE_MAX_DEFAULT},
       {spec.max_seq_size},
       TensorProto_DataType_INT64);
   verifyShapeInfo(
       out_shape,
       "Lengths",
-      ShapeInfo::DimType::BATCH,
+      {TensorBoundShape_DimType_BATCH},
       {spec.max_batch_size},
       TensorProto_DataType_INT32);
   verifyShapeInfo(
-      out_shape, "Out", ShapeInfo::DimType::BATCH, {spec.max_batch_size, 50});
+      out_shape,
+      "Out",
+      {TensorBoundShape_DimType_BATCH, TensorBoundShape_DimType_CONSTANT},
+      {spec.max_batch_size, 50});
 }
 
 TEST(BoundShapeInference, LengthsRangeFill) {
   NetDef net;
-  net.add_op()->CopyFrom(CreateOperatorDef(
-    "LengthsRangeFill",
-    "",
-    {"X"},
-    {"Y"},
-    {}));
-  net.add_op()->CopyFrom(CreateOperatorDef(
-    "Copy",
-    "",
-    {"Y"},
-    {"Z"},
-    {}));
+  net.add_op()->CopyFrom(
+      CreateOperatorDef("LengthsRangeFill", "", {"X"}, {"Y"}, {}));
+  net.add_op()->CopyFrom(CreateOperatorDef("Copy", "", {"Y"}, {"Z"}, {}));
   ShapeInfoMap shape_map;
   BoundShapeSpec spec(20, 1000);
   BoundShapeInferencer eng(spec);
@@ -132,19 +139,19 @@ TEST(BoundShapeInference, LengthsRangeFill) {
   verifyShapeInfo(
       out_shape,
       "X",
-      ShapeInfo::DimType::BATCH,
+      {TensorBoundShape_DimType_BATCH},
       {spec.max_batch_size},
       TensorProto_DataType_INT32);
   verifyShapeInfo(
       out_shape,
       "Y",
-      ShapeInfo::DimType::SEQ,
+      {TensorBoundShape_DimType_FEATURE_MAX_DEFAULT},
       {spec.max_seq_size},
       TensorProto_DataType_INT32);
   verifyShapeInfo(
       out_shape,
       "Z",
-      ShapeInfo::DimType::SEQ,
+      {TensorBoundShape_DimType_FEATURE_MAX_DEFAULT},
       {spec.max_seq_size},
       TensorProto_DataType_INT32);
 }
@@ -171,20 +178,32 @@ TEST(BoundShapeInference, Reshape) {
       {MakeArgument<std::vector<int>>("shape", new_shape2)}));
   ShapeInfoMap shape_map;
   shape_map.emplace(
-      "W0", makeTensorInfo(ShapeInfo::DimType::CONSTANT, {16, 1024}));
-  shape_map.emplace("B0", makeTensorInfo(ShapeInfo::DimType::CONSTANT, {16}));
+      "W0",
+      makeTensorInfo(
+          {TensorBoundShape_DimType_CONSTANT,
+           TensorBoundShape_DimType_CONSTANT},
+          {16, 1024}));
+  shape_map.emplace(
+      "B0", makeTensorInfo({TensorBoundShape_DimType_CONSTANT}, {16}));
   BoundShapeSpec spec(20, 1000);
   BoundShapeInferencer eng(spec);
   eng.InferBoundShapeAndType(net, shape_map, nullptr);
   const auto& out_shape = eng.shape_info();
   verifyShapeInfo(
-      out_shape, "X0", ShapeInfo::DimType::BATCH, {spec.max_batch_size, 1024});
+      out_shape,
+      "X0",
+      {TensorBoundShape_DimType_BATCH, TensorBoundShape_DimType_CONSTANT},
+      {spec.max_batch_size, 1024});
   verifyShapeInfo(
-      out_shape, "X1", ShapeInfo::DimType::BATCH, {spec.max_batch_size, 16});
+      out_shape,
+      "X1",
+      {TensorBoundShape_DimType_BATCH, TensorBoundShape_DimType_CONSTANT},
+      {spec.max_batch_size, 16});
   verifyShapeInfo(
       out_shape,
       "Y1",
-      ShapeInfo::DimType::BATCH,
+      {TensorBoundShape_DimType_BATCH,
+       TensorBoundShape_DimType_CONSTANT}, // TODO
       {spec.max_batch_size * 16 / 8, 8});
   EXPECT_TRUE(out_shape.find("Y2") == out_shape.end());
 }
@@ -201,16 +220,23 @@ TEST(BoundShapeInference, ConcatMissingInput) {
   ShapeInfoMap shape_map;
   shape_map.emplace(
       "I0",
-      makeTensorInfo(ShapeInfo::DimType::BATCH, {spec.max_batch_size, 60}));
+      makeTensorInfo(
+          {TensorBoundShape_DimType_BATCH, TensorBoundShape_DimType_CONSTANT},
+          {spec.max_batch_size, 60}));
   BoundShapeInferencer eng(spec);
   eng.InferBoundShapeAndType(net, shape_map, nullptr);
   const auto& out_shape = eng.shape_info();
   verifyShapeInfo(
-      out_shape, "I0", ShapeInfo::DimType::BATCH, {spec.max_batch_size, 60});
+      out_shape,
+      "I0",
+      {TensorBoundShape_DimType_BATCH, TensorBoundShape_DimType_CONSTANT},
+      {spec.max_batch_size, 60});
   verifyShapeInfo(
       out_shape,
       "Cout",
-      ShapeInfo::DimType::BATCH,
+      {TensorBoundShape_DimType_BATCH,
+       TensorBoundShape_DimType_CONSTANT,
+       TensorBoundShape_DimType_CONSTANT},
       {spec.max_batch_size, 2, 60});
 }
 
@@ -228,23 +254,39 @@ TEST(BoundShapeInference, ConcatInferInputBackwards) {
   ShapeInfoMap shape_map;
   shape_map.emplace(
       "I0",
-      makeTensorInfo(ShapeInfo::DimType::BATCH, {spec.max_batch_size, 60}));
+      makeTensorInfo(
+          {TensorBoundShape_DimType_BATCH, TensorBoundShape_DimType_CONSTANT},
+          {spec.max_batch_size, 60}));
   shape_map.emplace(
-      "W0", makeTensorInfo(ShapeInfo::DimType::CONSTANT, {101, 16}));
-  shape_map.emplace("B0", makeTensorInfo(ShapeInfo::DimType::CONSTANT, {16}));
+      "W0",
+      makeTensorInfo(
+          {TensorBoundShape_DimType_CONSTANT,
+           TensorBoundShape_DimType_CONSTANT},
+          {101, 16}));
+  shape_map.emplace(
+      "B0", makeTensorInfo({TensorBoundShape_DimType_CONSTANT}, {16}));
   BoundShapeInferencer eng(spec);
   eng.InferBoundShapeAndType(net, shape_map, nullptr);
   const auto& out_shape = eng.shape_info();
   verifyShapeInfo(
-      out_shape, "I0", ShapeInfo::DimType::BATCH, {spec.max_batch_size, 60});
+      out_shape,
+      "I0",
+      {TensorBoundShape_DimType_BATCH, TensorBoundShape_DimType_CONSTANT},
+      {spec.max_batch_size, 60});
   verifyShapeInfo(
-      out_shape, "Cout", ShapeInfo::DimType::BATCH, {spec.max_batch_size, 101});
+      out_shape,
+      "Cout",
+      {TensorBoundShape_DimType_BATCH, TensorBoundShape_DimType_CONSTANT},
+      {spec.max_batch_size, 101});
   verifyShapeInfo(
-      out_shape, "Y", ShapeInfo::DimType::BATCH, {spec.max_batch_size, 16});
+      out_shape,
+      "Y",
+      {TensorBoundShape_DimType_BATCH, TensorBoundShape_DimType_CONSTANT},
+      {spec.max_batch_size, 16});
   verifyShapeInfo(
       out_shape,
       "I1",
-      ShapeInfo::DimType::BATCH,
+      {TensorBoundShape_DimType_BATCH, TensorBoundShape_DimType_CONSTANT},
       {spec.max_batch_size, 101 - 60});
 }
 
@@ -259,14 +301,17 @@ TEST(BoundShapeInference, Bucketize) {
   BoundShapeSpec spec(20, 1000);
   ShapeInfoMap shape_map;
   shape_map.emplace(
-      "In", makeTensorInfo(ShapeInfo::DimType::SEQ, {spec.max_batch_size, 60}));
+      "In",
+      makeTensorInfo(
+          {TensorBoundShape_DimType_BATCH, TensorBoundShape_DimType_CONSTANT},
+          {spec.max_batch_size, 60}));
   BoundShapeInferencer eng(spec);
   eng.InferBoundShapeAndType(net, shape_map, nullptr);
   const auto& out_shape = eng.shape_info();
   verifyShapeInfo(
       out_shape,
       "Out",
-      ShapeInfo::DimType::BATCH,
+      {TensorBoundShape_DimType_BATCH, TensorBoundShape_DimType_CONSTANT},
       {spec.max_batch_size, 60},
       TensorProto_DataType_INT32);
 }
@@ -292,37 +337,66 @@ TEST(BoundShapeInference, Split) {
   ShapeInfoMap shape_map;
   shape_map.emplace(
       "X",
-      makeTensorInfo(ShapeInfo::DimType::BATCH, {spec.max_batch_size, 48}));
+      makeTensorInfo(
+          {TensorBoundShape_DimType_BATCH, TensorBoundShape_DimType_CONSTANT},
+          {spec.max_batch_size, 48}));
   shape_map.emplace(
       "X1",
-      makeTensorInfo(ShapeInfo::DimType::BATCH, {spec.max_batch_size, 2, 48}));
+      makeTensorInfo(
+          {TensorBoundShape_DimType_BATCH,
+           TensorBoundShape_DimType_CONSTANT,
+           TensorBoundShape_DimType_CONSTANT},
+          {spec.max_batch_size, 2, 48}));
   BoundShapeInferencer eng(spec);
   eng.InferBoundShapeAndType(net, shape_map, nullptr);
   const auto& out_shape = eng.shape_info();
   verifyShapeInfo(
-      out_shape, "X", ShapeInfo::DimType::BATCH, {spec.max_batch_size, 48});
+      out_shape,
+      "X",
+      {TensorBoundShape_DimType_BATCH, TensorBoundShape_DimType_CONSTANT},
+      {spec.max_batch_size, 48});
   verifyShapeInfo(
-      out_shape, "X1", ShapeInfo::DimType::BATCH, {spec.max_batch_size, 2, 48});
+      out_shape,
+      "X1",
+      {TensorBoundShape_DimType_BATCH,
+       TensorBoundShape_DimType_CONSTANT,
+       TensorBoundShape_DimType_CONSTANT},
+      {spec.max_batch_size, 2, 48});
   verifyShapeInfo(
       out_shape,
       "Y0",
-      ShapeInfo::DimType::BATCH,
+      {TensorBoundShape_DimType_BATCH, TensorBoundShape_DimType_CONSTANT},
       {spec.max_batch_size, 48 / 2});
   verifyShapeInfo(
       out_shape,
       "Y1",
-      ShapeInfo::DimType::BATCH,
+      {TensorBoundShape_DimType_BATCH, TensorBoundShape_DimType_CONSTANT},
       {spec.max_batch_size, 48 / 2});
   verifyShapeInfo(
-      out_shape, "Y2", ShapeInfo::DimType::BATCH, {spec.max_batch_size, 4});
+      out_shape,
+      "Y2",
+      {TensorBoundShape_DimType_BATCH, TensorBoundShape_DimType_CONSTANT},
+      {spec.max_batch_size, 4});
   verifyShapeInfo(
-      out_shape, "Y3", ShapeInfo::DimType::BATCH, {spec.max_batch_size, 30});
+      out_shape,
+      "Y3",
+      {TensorBoundShape_DimType_BATCH, TensorBoundShape_DimType_CONSTANT},
+      {spec.max_batch_size, 30});
   verifyShapeInfo(
-      out_shape, "Y4", ShapeInfo::DimType::BATCH, {spec.max_batch_size, 14});
+      out_shape,
+      "Y4",
+      {TensorBoundShape_DimType_BATCH, TensorBoundShape_DimType_CONSTANT},
+      {spec.max_batch_size, 14});
   verifyShapeInfo(
-      out_shape, "Y5", ShapeInfo::DimType::BATCH, {spec.max_batch_size, 48});
+      out_shape,
+      "Y5",
+      {TensorBoundShape_DimType_BATCH, TensorBoundShape_DimType_CONSTANT},
+      {spec.max_batch_size, 48});
   verifyShapeInfo(
-      out_shape, "Y6", ShapeInfo::DimType::BATCH, {spec.max_batch_size, 48});
+      out_shape,
+      "Y6",
+      {TensorBoundShape_DimType_BATCH, TensorBoundShape_DimType_CONSTANT},
+      {spec.max_batch_size, 48});
 }
 
 TEST(BoundShapeInference, FC) {
@@ -333,25 +407,44 @@ TEST(BoundShapeInference, FC) {
       CreateOperatorDef("FCTransposed", "", {"X1", "W1", "B1"}, {"Out1"}, {}));
   ShapeInfoMap shape_map;
   shape_map.emplace(
-      "W0", makeTensorInfo(ShapeInfo::DimType::CONSTANT, {16, 1024}));
-  shape_map.emplace("B0", makeTensorInfo(ShapeInfo::DimType::CONSTANT, {16}));
+      "W0",
+      makeTensorInfo(
+          {TensorBoundShape_DimType_CONSTANT,
+           TensorBoundShape_DimType_CONSTANT},
+          {16, 1024}));
   shape_map.emplace(
-      "W1", makeTensorInfo(ShapeInfo::DimType::CONSTANT, {16, 1024}));
-  shape_map.emplace("B1", makeTensorInfo(ShapeInfo::DimType::CONSTANT, {1024}));
+      "B0", makeTensorInfo({TensorBoundShape_DimType_CONSTANT}, {16}));
+  shape_map.emplace(
+      "W1",
+      makeTensorInfo(
+          {TensorBoundShape_DimType_CONSTANT,
+           TensorBoundShape_DimType_CONSTANT},
+          {16, 1024}));
+  shape_map.emplace(
+      "B1", makeTensorInfo({TensorBoundShape_DimType_CONSTANT}, {1024}));
   BoundShapeSpec spec(20, 1000);
   BoundShapeInferencer eng(spec);
   eng.InferBoundShapeAndType(net, shape_map, nullptr);
   const auto& out_shape = eng.shape_info();
   verifyShapeInfo(
-      out_shape, "X0", ShapeInfo::DimType::BATCH, {spec.max_batch_size, 1024});
+      out_shape,
+      "X0",
+      {TensorBoundShape_DimType_BATCH, TensorBoundShape_DimType_CONSTANT},
+      {spec.max_batch_size, 1024});
   verifyShapeInfo(
-      out_shape, "Out0", ShapeInfo::DimType::BATCH, {spec.max_batch_size, 16});
+      out_shape,
+      "Out0",
+      {TensorBoundShape_DimType_BATCH, TensorBoundShape_DimType_CONSTANT},
+      {spec.max_batch_size, 16});
   verifyShapeInfo(
-      out_shape, "X1", ShapeInfo::DimType::BATCH, {spec.max_batch_size, 16});
+      out_shape,
+      "X1",
+      {TensorBoundShape_DimType_BATCH, TensorBoundShape_DimType_CONSTANT},
+      {spec.max_batch_size, 16});
   verifyShapeInfo(
       out_shape,
       "Out1",
-      ShapeInfo::DimType::BATCH,
+      {TensorBoundShape_DimType_BATCH, TensorBoundShape_DimType_CONSTANT},
       {spec.max_batch_size, 1024});
 }
 
@@ -361,16 +454,28 @@ TEST(BoundShapeInference, FC3D) {
       CreateOperatorDef("FC", "", {"X0", "W0", "B0"}, {"Out0"}, {}));
   ShapeInfoMap shape_map;
   shape_map.emplace(
-      "W0", makeTensorInfo(ShapeInfo::DimType::CONSTANT, {16, 1, 1024}));
-  shape_map.emplace("B0", makeTensorInfo(ShapeInfo::DimType::CONSTANT, {16}));
+      "W0",
+      makeTensorInfo(
+          {TensorBoundShape_DimType_CONSTANT,
+           TensorBoundShape_DimType_CONSTANT,
+           TensorBoundShape_DimType_CONSTANT},
+          {16, 1, 1024}));
+  shape_map.emplace(
+      "B0", makeTensorInfo({TensorBoundShape_DimType_CONSTANT}, {16}));
   BoundShapeSpec spec(20, 1000);
   BoundShapeInferencer eng(spec);
   eng.InferBoundShapeAndType(net, shape_map, nullptr);
   const auto& out_shape = eng.shape_info();
   verifyShapeInfo(
-      out_shape, "X0", ShapeInfo::DimType::BATCH, {spec.max_batch_size, 1024});
+      out_shape,
+      "X0",
+      {TensorBoundShape_DimType_BATCH, TensorBoundShape_DimType_CONSTANT},
+      {spec.max_batch_size, 1024});
   verifyShapeInfo(
-      out_shape, "Out0", ShapeInfo::DimType::BATCH, {spec.max_batch_size, 16});
+      out_shape,
+      "Out0",
+      {TensorBoundShape_DimType_BATCH, TensorBoundShape_DimType_CONSTANT},
+      {spec.max_batch_size, 16});
 }
 
 TEST(BoundShapeInference, Combo0) {
@@ -397,16 +502,27 @@ TEST(BoundShapeInference, Combo0) {
       CreateOperatorDef("BatchGather", "", {"Fout", "Indices"}, {"Gout"}, {}));
   ShapeInfoMap shape_map;
   shape_map.emplace(
-      "Weights0", makeTensorInfo(ShapeInfo::DimType::CONSTANT, {1000, 16}));
+      "Weights0",
+      makeTensorInfo(
+          {TensorBoundShape_DimType_CONSTANT,
+           TensorBoundShape_DimType_CONSTANT},
+          {1000, 16}));
   shape_map.emplace(
-      "Weights1", makeTensorInfo(ShapeInfo::DimType::CONSTANT, {20000, 16}));
+      "Weights1",
+      makeTensorInfo(
+          {TensorBoundShape_DimType_CONSTANT,
+           TensorBoundShape_DimType_CONSTANT},
+          {20000, 16}));
   shape_map.emplace(
-      "Indices", makeTensorInfo(ShapeInfo::DimType::CONSTANT, {2}));
+      "Indices", makeTensorInfo({TensorBoundShape_DimType_CONSTANT}, {2}));
   BoundShapeSpec spec(20, 1000);
   BoundShapeInferencer eng(spec);
   eng.InferBoundShapeAndType(net, shape_map, nullptr);
   const auto& out_shape = eng.shape_info();
   LOG(INFO) << eng.PrintShapeInfo();
   verifyShapeInfo(
-      out_shape, "Gout", ShapeInfo::DimType::BATCH, {spec.max_batch_size, 2});
+      out_shape,
+      "Gout",
+      {TensorBoundShape_DimType_BATCH, TensorBoundShape_DimType_CONSTANT},
+      {spec.max_batch_size, 2});
 }

--- a/caffe2/opt/bound_shape_inferencer.cc
+++ b/caffe2/opt/bound_shape_inferencer.cc
@@ -18,6 +18,15 @@ std::vector<int64_t> ConvertToVec(
   return out;
 }
 
+std::vector<TensorBoundShape::DimType> setDimTypeWithFirst(
+    TensorBoundShape::DimType firstDimType,
+    uint32_t n) {
+  std::vector<TensorBoundShape::DimType> dimTypes(
+      n, TensorBoundShape_DimType_CONSTANT);
+  dimTypes[0] = firstDimType;
+  return dimTypes;
+}
+
 int64_t SizeFromDim(const TensorShape& shape, int axis) {
   int64_t r = 1;
   for (int i = axis; i < shape.dims_size(); ++i) {
@@ -110,22 +119,22 @@ void BoundShapeInferencer::InferBoundShapeAndType(
   EnsureShapeNames(&shape_info_);
 }
 
-TensorShape& BoundShapeInferencer::SetTensorShapeAndTypeIfNotExist(
+TensorShape& BoundShapeInferencer::SetTensorBoundShapeIfNotExist(
     const std::string& name,
-    ShapeInfo::DimType t,
+    const std::vector<TensorBoundShape::DimType>& t,
     std::vector<int64_t> bound_dims,
     TensorProto::DataType type,
     bool is_quantized) {
-  return CheckAndSetTensorShapeAndType(
+  return CheckAndSetTensorBoundShape(
       name, t, bound_dims, type, is_quantized, true);
 }
 
 // if allow_existing_shape is true, we use existing shape directly
 // and not enforce shape to be equal to bound_dims
 // else we enforce them to be equal
-TensorShape& BoundShapeInferencer::CheckAndSetTensorShapeAndType(
+TensorShape& BoundShapeInferencer::CheckAndSetTensorBoundShape(
     const std::string& name,
-    ShapeInfo::DimType t,
+    const std::vector<TensorBoundShape::DimType>& t,
     std::vector<int64_t> bound_dims,
     TensorProto::DataType type,
     bool is_quantized,
@@ -146,10 +155,11 @@ TensorShape& BoundShapeInferencer::CheckAndSetTensorShapeAndType(
     CAFFE_ENFORCE_EQ(shape.dims_size(), bound_dims.size());
     // For shapes that was provided as a hint at the input of the net, fix the
     // batch size first.
-    if (shape.dims_size() > 0 &&
-        shape_info.dim_type == ShapeInfo::DimType::UNKNOWN &&
-        t > ShapeInfo::DimType::CONSTANT) {
-      shape_info.dim_type = t;
+    if ((!shape_info.dimTypeIsSet() ||
+         (shape.dims_size() &&
+          shape_info.getDimType(0) == TensorBoundShape_DimType_UNKNOWN)) &&
+        t.size() && t[0] > TensorBoundShape_DimType_CONSTANT) {
+      shape_info.setDimType(t);
       shape.set_dims(0, bound_dims.front());
     }
 
@@ -172,7 +182,7 @@ TensorShape& BoundShapeInferencer::CheckAndSetTensorShapeAndType(
     return shape;
   }
 
-  shape_info.dim_type = t;
+  shape_info.setDimType(t);
   shape.mutable_dims()->Clear();
   for (const auto d : bound_dims) {
     shape.add_dims(d);
@@ -194,7 +204,8 @@ void BoundShapeInferencer::InferGivenTensorFill(const OperatorDef& op) {
   InferCommonOp(op);
   auto it = shape_info_.find(op.output(0));
   if (it != shape_info_.end()) {
-    it->second.dim_type = ShapeInfo::DimType::CONSTANT;
+    it->second.setDimType(std::vector<TensorBoundShape::DimType>(
+        it->second.shape.dims_size(), TensorBoundShape_DimType_CONSTANT));
   }
 }
 
@@ -203,19 +214,19 @@ void BoundShapeInferencer::InferLengthsRangeFill(const OperatorDef& op) {
   CAFFE_ENFORCE_EQ(op.output_size(), 1, "LengthsRangeFill must have 1 output");
   // Both input and ouptut of LengthsRangeFill is int32:
   // https://fburl.com/fhwb5666
-  CheckAndSetTensorShapeAndType(
+  CheckAndSetTensorBoundShape(
       op.input(0),
-      ShapeInfo::DimType::BATCH,
+      {TensorBoundShape_DimType_BATCH},
       {spec_.max_batch_size},
       TensorProto_DataType_INT32,
       false);
-  CheckAndSetTensorShapeAndType(
+  CheckAndSetTensorBoundShape(
       op.output(0),
-      ShapeInfo::DimType::SEQ,
+      {TensorBoundShape_DimType_FEATURE_MAX_DEFAULT},
       {spec_.max_seq_size},
       TensorProto_DataType_INT32,
       false);
-  current_dim_type_ = ShapeInfo::DimType::SEQ;
+  current_dim_type_ = TensorBoundShape_DimType_FEATURE_MAX_DEFAULT;
 }
 
 void BoundShapeInferencer::InferSparseLengthsSum(const OperatorDef& op) {
@@ -242,31 +253,31 @@ void BoundShapeInferencer::InferSparseLengthsSum(const OperatorDef& op) {
   if (weight) {
     CAFFE_ENFORCE_EQ(
         op.input_size(), 4, "SparseLengthsWeightedSum must have 4 inputs");
-    SetTensorShapeAndTypeIfNotExist(
+    SetTensorBoundShapeIfNotExist(
         op.input(weight),
-        ShapeInfo::DimType::SEQ,
+        {TensorBoundShape_DimType_FEATURE_MAX_DEFAULT},
         {spec_.max_seq_size},
         TensorProto_DataType_FLOAT,
         false);
   }
 
   // Bound inputs
-  SetTensorShapeAndTypeIfNotExist(
+  SetTensorBoundShapeIfNotExist(
       op.input(1 + weight),
-      ShapeInfo::DimType::SEQ,
+      {TensorBoundShape_DimType_FEATURE_MAX_DEFAULT},
       {spec_.max_seq_size},
       TensorProto_DataType_INT64,
       false);
-  CheckAndSetTensorShapeAndType(
+  CheckAndSetTensorBoundShape(
       op.input(2 + weight),
-      ShapeInfo::DimType::BATCH,
+      {TensorBoundShape_DimType_BATCH},
       {spec_.max_batch_size},
       TensorProto_DataType_INT32,
       false);
 
   // Infer output
   CAFFE_ENFORCE_EQ(it->second.shape.dims_size(), 2);
-  current_dim_type_ = ShapeInfo::DimType::BATCH;
+  current_dim_type_ = TensorBoundShape_DimType_BATCH;
   current_max_batch_size_ = spec_.max_batch_size;
   auto output_dim1 = it->second.shape.dims(1);
   // If the op is SparseLengthsSumFused8BitRowwise, we need to extract 4 for
@@ -275,9 +286,11 @@ void BoundShapeInferencer::InferSparseLengthsSum(const OperatorDef& op) {
       op.type() == "SparseLengthsWeightedSumFused8BitRowwise") {
     output_dim1 -= 8;
   }
-  CheckAndSetTensorShapeAndType(
+  CAFFE_ENFORCE_GE(
+      it->second.getDimType().size(), 2, "input(0): ", op.input(0));
+  CheckAndSetTensorBoundShape(
       op.output(0),
-      ShapeInfo::DimType::BATCH,
+      {TensorBoundShape_DimType_BATCH, it->second.getDimType(1)},
       {spec_.max_batch_size, output_dim1},
       TensorProto_DataType_FLOAT,
       false);
@@ -287,7 +300,7 @@ void BoundShapeInferencer::InferShape(const OperatorDef& op) {
   InferCommonOp(op);
   // old_shape should be a constant
   if (op.output_size() > 0 && shape_info_.count(op.output(0))) {
-    shape_info_[op.output(0)].dim_type = ShapeInfo::DimType::CONSTANT;
+    shape_info_[op.output(0)].setDimType(0, TensorBoundShape_DimType_CONSTANT);
   }
 }
 
@@ -295,7 +308,7 @@ void BoundShapeInferencer::InferReshape(const OperatorDef& op) {
   InferCommonOp(op);
   // old_shape should be a constant
   if (op.output_size() > 1 && shape_info_.count(op.output(1))) {
-    shape_info_[op.output(1)].dim_type = ShapeInfo::DimType::CONSTANT;
+    shape_info_[op.output(1)].setDimType(0, TensorBoundShape_DimType_CONSTANT);
   }
 }
 
@@ -348,7 +361,8 @@ void BoundShapeInferencer::InferConcatInputs(const OperatorDef& op) {
     // Infer the shape of the second output of Concat
     InferCommonOp(op);
     if (op.output_size() > 1 && shape_info_.count(op.output(1))) {
-      shape_info_[op.output(1)].dim_type = ShapeInfo::DimType::CONSTANT;
+      shape_info_[op.output(1)].setDimType(
+          0, TensorBoundShape_DimType_CONSTANT);
     }
   }
 }
@@ -400,7 +414,7 @@ void BoundShapeInferencer::InferConcat(const OperatorDef& op) {
     }
 
     if (ref_input_shape) {
-      current_dim_type_ = ref_input_shape->dim_type;
+      current_dim_type_ = ref_input_shape->getDimType(0);
       for (const auto& i : missing_shape_inputs) {
         shape_info_.emplace(i, *ref_input_shape);
       }
@@ -409,7 +423,7 @@ void BoundShapeInferencer::InferConcat(const OperatorDef& op) {
   InferCommonOp(op);
   // split_info should be a constant
   if (op.output_size() > 1 && shape_info_.count(op.output(1))) {
-    shape_info_[op.output(1)].dim_type = ShapeInfo::DimType::CONSTANT;
+    shape_info_[op.output(1)].setDimType(0, TensorBoundShape_DimType_CONSTANT);
   }
 }
 
@@ -445,12 +459,16 @@ void BoundShapeInferencer::InferFC(const OperatorDef& op) {
     const int64_t K = transposed ? SizeToDim(w_shape, canonical_axis_w)
                                  : SizeFromDim(w_shape, canonical_axis_w);
     std::vector<int64_t> dims;
+    std::vector<TensorBoundShape::DimType> dimTypes;
     for (int i = 0; i < axis - 1; ++i) {
       dims.push_back(1);
+      dimTypes.push_back(TensorBoundShape_DimType_CONSTANT);
     }
     dims.push_back(spec_.max_batch_size);
+    dimTypes.push_back(TensorBoundShape_DimType_BATCH);
     dims.push_back(K);
-    current_dim_type_ = ShapeInfo::DimType::BATCH;
+    dimTypes.push_back(TensorBoundShape_DimType_CONSTANT);
+    current_dim_type_ = TensorBoundShape_DimType_BATCH;
     current_max_batch_size_ = spec_.max_batch_size;
     TensorProto::DataType w_data_type;
     if (fp16) {
@@ -461,18 +479,14 @@ void BoundShapeInferencer::InferFC(const OperatorDef& op) {
       w_data_type = w_shape.data_type();
     }
     // Note: for FbFCPacked, weight is fp16 but actications are in fp32
-    CheckAndSetTensorShapeAndType(
-        op.input(0),
-        ShapeInfo::DimType::BATCH,
-        dims,
-        w_data_type,
-        int8_fc ? true : false);
+    CheckAndSetTensorBoundShape(
+        op.input(0), dimTypes, dims, w_data_type, int8_fc ? true : false);
   } else {
     ShapeInfo& x_shape_info = x_it->second;
-    if (x_shape_info.dim_type != ShapeInfo::DimType::BATCH) {
+    if (x_shape_info.getDimType(0) != TensorBoundShape_DimType_BATCH) {
       CAFFE_ENFORCE_GE(x_shape_info.shape.dims_size(), 1);
       x_shape_info.shape.set_dims(0, spec_.max_batch_size);
-      x_shape_info.dim_type = ShapeInfo::DimType::BATCH;
+      x_shape_info.setDimType(0, TensorBoundShape_DimType_BATCH);
     }
   }
 
@@ -487,11 +501,12 @@ void BoundShapeInferencer::InferFC(const OperatorDef& op) {
   } else if (int8_fc) {
     output_data_type = TensorProto_DataType_UINT8;
   } else {
-    output_data_type = output_shapes[0].data_type();
+    output_data_type = output_shapes.front().data_type();
   }
-  CheckAndSetTensorShapeAndType(
+  CheckAndSetTensorBoundShape(
       op.output(0),
-      ShapeInfo::DimType::BATCH,
+      setDimTypeWithFirst(
+          TensorBoundShape_DimType_BATCH, output_shapes.front().dims().size()),
       ConvertToVec(output_shapes[0].dims()),
       output_data_type,
       int8_fc ? true : false);
@@ -552,9 +567,9 @@ void BoundShapeInferencer::InferCommonOp(const OperatorDef& op) {
         ++i;
         continue;
       }
-      CheckAndSetTensorShapeAndType(
+      CheckAndSetTensorBoundShape(
           op.output(i++),
-          current_dim_type_,
+          setDimTypeWithFirst(current_dim_type_, shape.dims().size()),
           ConvertToVec(shape.dims()),
           infered_data_type,
           is_quantized);

--- a/caffe2/opt/bound_shape_inferencer.h
+++ b/caffe2/opt/bound_shape_inferencer.h
@@ -50,7 +50,7 @@ class BoundShapeInferencerBase {
     std::stringstream ss;
     for (const auto& kv : shape_info_) {
       const auto& s = kv.second;
-      ss << s.shape.name() << ": dim_type: " << s.dim_type << ", dims: [";
+      ss << s.shape.name() << ": dim_type: " << s.getDimType() << ", dims: [";
       for (const auto d : s.shape.dims()) {
         ss << d << ", ";
       }
@@ -76,17 +76,17 @@ class CAFFE2_API BoundShapeInferencer : public BoundShapeInferencerBase {
       caffe2::Workspace* ws) override;
 
  protected:
-  TensorShape& CheckAndSetTensorShapeAndType(
+  TensorShape& CheckAndSetTensorBoundShape(
       const std::string& name,
-      ShapeInfo::DimType t,
+      const std::vector<TensorBoundShape::DimType>& t,
       std::vector<int64_t> bound_dims,
       TensorProto::DataType type,
       bool is_quantized,
       bool allow_existing_shape = false);
 
-  TensorShape& SetTensorShapeAndTypeIfNotExist(
+  TensorShape& SetTensorBoundShapeIfNotExist(
       const std::string& name,
-      ShapeInfo::DimType t,
+      const std::vector<TensorBoundShape::DimType>& t,
       std::vector<int64_t> bound_dims,
       TensorProto::DataType type,
       bool is_quantized);
@@ -109,7 +109,7 @@ class CAFFE2_API BoundShapeInferencer : public BoundShapeInferencerBase {
 
   void EnsureShapeNames(std::unordered_map<std::string, ShapeInfo>* info) const;
 
-  ShapeInfo::DimType current_dim_type_{ShapeInfo::DimType::BATCH};
+  TensorBoundShape::DimType current_dim_type_{TensorBoundShape_DimType_BATCH};
   int64_t current_max_batch_size_{0};
 };
 

--- a/caffe2/opt/onnxifi_op.cc
+++ b/caffe2/opt/onnxifi_op.cc
@@ -229,8 +229,12 @@ void OnnxifiOp<CPUContext>::extractOutputBatchSizes() {
     for (const auto d : dim0) {
       shape.add_dims(d);
     }
-    input_shape_info_[input_names_[i]] =
-        ShapeInfo(ShapeInfo::DimType::BATCH, std::move(shape));
+    std::vector<TensorBoundShape::DimType> dim_type(
+        shape.dims_size(), TensorBoundShape_DimType_CONSTANT);
+    if (dim_type.size()) {
+      dim_type[0] = TensorBoundShape_DimType_BATCH;
+    }
+    input_shape_info_[input_names_[i]] = ShapeInfo(dim_type, std::move(shape));
   }
   bound_shape_inferencer->InferBoundShapeAndType(
       netdef_, input_shape_info_, nullptr);

--- a/caffe2/opt/onnxifi_op.h
+++ b/caffe2/opt/onnxifi_op.h
@@ -236,8 +236,9 @@ class OnnxifiOp final : public Operator<Context> {
         for (const auto d : shape0) {
           shape.add_dims(d);
         }
-        weight_shape_info[weight_names[i]] =
-            ShapeInfo(ShapeInfo::DimType::CONSTANT, std::move(shape));
+        weight_shape_info[weight_names[i]] = ShapeInfo(
+            std::vector(shape0.size(), TensorBoundShape_DimType_CONSTANT),
+            std::move(shape));
       }
 
       Blob* defered_blob_reader = nullptr;

--- a/caffe2/opt/onnxifi_transformer.cc
+++ b/caffe2/opt/onnxifi_transformer.cc
@@ -276,7 +276,7 @@ OperatorDef OnnxifiTransformer::buildOnnxifiOp(
       CAFFE_ENFORCE(
           it != shape_hints.end(), "Input shape for ", input, " not found");
       const auto& info = it->second;
-      if (info.dim_type == ShapeInfo::DimType::BATCH &&
+      if (info.getDimType(0) == TensorBoundShape_DimType_BATCH &&
           getBlob1stDimSize(info) == max_batch_size) {
         nominal_batch_idx = idx;
         break;
@@ -458,13 +458,14 @@ NetDef OnnxifiTransformer::SubnetToOnnxifiOpViaOnnx(
           std::piecewise_construct,
           std::forward_as_tuple(ret.first->first),
           std::forward_as_tuple(
-              ShapeInfo::DimType::CONSTANT, ret.first->second));
+              std::vector(shape.dims_size(), TensorBoundShape_DimType_CONSTANT),
+              ret.first->second));
 
       // Feed into workspace as CPU Tensors
       auto* blob = ws->CreateBlob(t.name());
       auto* cpu_tensor = BlobGetMutableTensor(blob, CPU);
       std::vector<int64_t> dims;
-      for(const auto& d : t.dims()) {
+      for (const auto& d : t.dims()) {
         dims.push_back(d);
       }
       cpu_tensor->Resize(dims);

--- a/caffe2/opt/shape_info.cc
+++ b/caffe2/opt/shape_info.cc
@@ -8,9 +8,10 @@ namespace caffe2 {
 ShapeInfo getShapeInfoFromBlob(const Blob* blob) {
   ShapeInfo shape_info;
   shape_info.shape = GetTensorShapeOfBlob(blob);
-  shape_info.dim_type = shape_info.shape.unknown_shape()
-      ? ShapeInfo::DimType::UNKNOWN
-      : ShapeInfo::DimType::CONSTANT;
+  if (!shape_info.shape.unknown_shape()) {
+    shape_info.setDimType(std::vector<TensorBoundShape::DimType>(
+        shape_info.shape.dims_size(), TensorBoundShape_DimType_CONSTANT));
+  }
   if (blob->meta().id() == TypeMeta::Id<int8::Int8TensorCPU>()) {
     shape_info.is_quantized = true;
     LoadInt8TensorInfoOfBlob(
@@ -36,7 +37,7 @@ ShapeInfo getShapeInfoFromBlob(const Blob* blob) {
 }
 
 bool operator==(const ShapeInfo& lhs, const ShapeInfo& rhs) {
-  return lhs.dim_type == rhs.dim_type &&
+  return lhs.getDimType() == rhs.getDimType() &&
       lhs.shape.SerializeAsString() == rhs.shape.SerializeAsString();
 }
 

--- a/caffe2/opt/shape_info.h
+++ b/caffe2/opt/shape_info.h
@@ -19,26 +19,93 @@ struct CAFFE2_API QShapeInfo {
 };
 
 struct CAFFE2_API ShapeInfo {
-  enum DimType : int8_t { UNKNOWN = 0, CONSTANT = 1, BATCH = 2, SEQ = 3 };
   ShapeInfo(bool q = false) : is_quantized(q) {}
-  ShapeInfo(DimType t, TensorShape&& s, bool q = false)
-      : dim_type(t), shape(std::move(s)), is_quantized(q) {}
-  ShapeInfo(DimType t, const TensorShape& s, bool q = false)
-      : dim_type(t), shape(s), is_quantized(q) {}
+  ShapeInfo(
+      std::vector<TensorBoundShape_DimType>&& t,
+      TensorShape&& s,
+      bool q = false)
+      : shape(std::move(s)),
+        is_quantized(q),
+        dim_type(std::move(t)),
+        dim_type_is_set(true) {}
+  ShapeInfo(
+      const std::vector<TensorBoundShape_DimType>& t,
+      TensorShape&& s,
+      bool q = false)
+      : shape(std::move(s)),
+        is_quantized(q),
+        dim_type(t),
+        dim_type_is_set(true) {}
+  ShapeInfo(
+      const std::vector<TensorBoundShape_DimType>& t,
+      const TensorShape& s,
+      bool q = false)
+      : shape(s), is_quantized(q), dim_type(t), dim_type_is_set(true) {}
 
   ShapeInfo(bool q, const QShapeInfo& info) : is_quantized(q), q_info(info) {}
-  ShapeInfo(DimType t, TensorShape&& s, bool q, const QShapeInfo& info)
-      : dim_type(t), shape(std::move(s)), is_quantized(q), q_info(info) {}
-  ShapeInfo(DimType t, const TensorShape& s, bool q, const QShapeInfo& info)
-      : dim_type(t), shape(s), is_quantized(q), q_info(info) {}
+  ShapeInfo(
+      const std::vector<TensorBoundShape_DimType>& t,
+      TensorShape&& s,
+      bool q,
+      const QShapeInfo& info)
+      : shape(std::move(s)),
+        is_quantized(q),
+        q_info(info),
+        dim_type(t),
+        dim_type_is_set(true) {}
+  ShapeInfo(
+      const std::vector<TensorBoundShape_DimType>& t,
+      const TensorShape& s,
+      bool q,
+      const QShapeInfo& info)
+      : shape(s),
+        is_quantized(q),
+        q_info(info),
+        dim_type(t),
+        dim_type_is_set(true) {}
 
-  // type of the shape according its first dim
-  DimType dim_type{DimType::UNKNOWN};
+  void setDimType(const std::vector<TensorBoundShape_DimType>& dim_types) {
+    if (shape.dims_size()) {
+      CAFFE_ENFORCE_EQ(shape.dims_size(), dim_types.size());
+    }
+    dim_type = dim_types;
+    dim_type_is_set = true;
+  }
+
+  void setDimType(int idx, TensorBoundShape_DimType type) {
+    CAFFE_ENFORCE(
+        dim_type.size() > idx, dim_type.size(), "vs", dim_type.size());
+    dim_type[idx] = type;
+    dim_type_is_set = true;
+  }
+
+  bool dimTypeIsSet() {
+    return dim_type_is_set;
+  }
+
+  const std::vector<TensorBoundShape_DimType>& getDimType() const {
+    return dim_type;
+  }
+
+  TensorBoundShape_DimType getDimType(int idx) const {
+    if (dim_type.size() > idx) {
+      return dim_type[idx];
+    } else {
+      return TensorBoundShape_DimType_UNKNOWN;
+    }
+  }
+
   TensorShape shape;
 
   // quantization related information
   bool is_quantized;
   QShapeInfo q_info;
+
+ private:
+  // type of the shape for every dimension
+  // dim_type.size == shape.dims.size
+  std::vector<TensorBoundShape_DimType> dim_type;
+  bool dim_type_is_set = false;
 };
 
 using ShapeInfoMap = std::unordered_map<std::string, ShapeInfo>;


### PR DESCRIPTION
Summary: Previously, we use dimType to represent dimension type for a tensor. Now, change it to vector<DimType> to record dim type for every dimension of the tensor.

Differential Revision: D18579363

