### PR TITLE
add operator-range argument to the op bench

### DIFF
--- a/benchmarks/operator_benchmark/benchmark_core.py
+++ b/benchmarks/operator_benchmark/benchmark_core.py
@@ -164,7 +164,7 @@ class BenchmarkRunner(object):
     def __init__(self, args):
         # TODO: consider time-bound constraints as well.
         self.args = args
-        self.iters = 200
+        self.iters = 100
         self.has_explicit_iteration_count = False
         self.multiplier = 2
         self.predefined_minimum_secs = 1
@@ -249,7 +249,7 @@ class BenchmarkRunner(object):
     def _launch_forward(self, test_case, iters, print_per_iter):
         """ Use Python's timeit module to measure execution time (unit: second).
         """
-        cuda_sync = True if 'cuda' in test_case.test_config.test_name else False 
+        cuda_sync = True if 'cuda' in test_case.test_config.test_name else False
         func = test_case.run_forward
         if self.use_jit:
             func = test_case.run_jit_forward
@@ -336,7 +336,7 @@ class BenchmarkRunner(object):
                 (self.args.tag_filter == 'all' or
                     self._check_keep(op_test_config.tag, self.args.tag_filter)) and
                 (not self.args.forward_only or op_test_config.run_backward != self.args.forward_only) and
-                (self.args.device == 'None' or 'device' not in op_test_config.test_name or 
+                (self.args.device == 'None' or 'device' not in op_test_config.test_name or
                     self.args.device in op_test_config.test_name)):
             return True
 

--- a/benchmarks/operator_benchmark/benchmark_core.py
+++ b/benchmarks/operator_benchmark/benchmark_core.py
@@ -172,6 +172,7 @@ class BenchmarkRunner(object):
         self.use_jit = args.use_jit
         self.num_runs = args.num_runs
         self.print_per_iter = False
+        self.operator_range = benchmark_utils.get_operator_range(args.operator_range)
         # 100 is the default warmup iterations
         if self.args.warmup_iterations == -1:
             self.args.warmup_iterations = 100
@@ -313,6 +314,11 @@ class BenchmarkRunner(object):
     def _check_keep(self, test_flag, cmd_flag):
         return (cmd_flag is None or test_flag == cmd_flag)
 
+    def _check_operator_first_char(self, test_flag, cmd_flag):
+        if cmd_flag is None or test_flag[:1] in cmd_falg:
+            return True
+        return False
+
     def _check_keep_list(self, test_flag, cmd_flag_list):
         if (cmd_flag_list is None or
                 any(test_flag == cmd_flag for cmd_flag in cmd_flag_list)):
@@ -333,6 +339,7 @@ class BenchmarkRunner(object):
         if (self._check_keep(op_test_config.test_name, self.args.test_name) and
             self._check_keep_list(test_case.op_bench.module_name(), operators) and
             self._check_keep_list(test_case.framework, frameworks) and
+            self._check_operator_first_char(test_case.op_bench.module_name(), self.operator_range) and
                 (self.args.tag_filter == 'all' or
                     self._check_keep(op_test_config.tag, self.args.tag_filter)) and
                 (not self.args.forward_only or op_test_config.run_backward != self.args.forward_only) and

--- a/benchmarks/operator_benchmark/benchmark_runner.py
+++ b/benchmarks/operator_benchmark/benchmark_runner.py
@@ -35,6 +35,11 @@ def main():
         default=None)
 
     parser.add_argument(
+        '--operator_range',
+        help='Filter tests based on operator_range(e.g. a-c)',
+        default=None)
+
+    parser.add_argument(
         '--test_name',
         help='Run tests that have the provided test_name',
         default=None)

--- a/benchmarks/operator_benchmark/benchmark_utils.py
+++ b/benchmarks/operator_benchmark/benchmark_utils.py
@@ -313,6 +313,21 @@ def is_pytorch_enabled(framework_arg):
     return 'PyTorch' in framework_arg
 
 
+def get_operator_range(chars_range):
+    """Generates the characters from chars_range inclusive."""
+    if chars_range == 'None' or chars_range is None:
+        return None
+
+    if '-' not in chars_range:
+        raise ValueError("Wrong format. The right input format is <start_char>-<end_char>")
+
+    start, end = chars_range.split("-")
+    ops_start_chars_set = set()
+    for c in range(ord(start), ord(end) + 1):
+        ops_start_chars_set.add(chr(c))
+    return ops_start_chars_set
+
+
 def process_arg_list(arg_list):
     if arg_list == 'None':
         return None

--- a/benchmarks/operator_benchmark/pt/batchnorm_test.py
+++ b/benchmarks/operator_benchmark/pt/batchnorm_test.py
@@ -24,7 +24,7 @@ batchnorm_configs_short = op_bench.config_list(
 
 batchnorm_configs_long = op_bench.cross_product_configs(
     M=[1, 128],
-    N=[2 ** 16, 2048],
+    N=[8192, 2048],
     K=[1],
     device=['cpu', 'cuda'],
     tags=["long"]

--- a/benchmarks/operator_benchmark/pt/conv_test.py
+++ b/benchmarks/operator_benchmark/pt/conv_test.py
@@ -87,13 +87,13 @@ conv_2d_configs_short = op_bench.config_list(
 )
 
 conv_2d_configs_long = op_bench.cross_product_configs(
-    in_c=[128, 512],
-    out_c=[128, 512],
+    in_c=[128, 256],
+    out_c=[128, 256],
     kernel=[3],
     stride=[1, 2],
-    N=[8],
-    H=[64],
-    W=[64],
+    N=[4],
+    H=[32],
+    W=[32],
     device=['cpu', 'cuda'],
     tags=["long"]
 )


### PR DESCRIPTION
Summary: This argument takes hyphen delimited start and end chars to filter operators. If the first character of an operator is in the start and end range, it will be tested. Otherwise skipped.

Test Plan: testing

Differential Revision: D18581910

