### PR TITLE
cache tensor scalar_type in OperandInfo

### DIFF
--- a/c10/core/TensorOptions.h
+++ b/c10/core/TensorOptions.h
@@ -335,14 +335,16 @@ struct C10_API TensorOptions {
     switch (layout()) {
       case Layout::Strided:
         switch (device().type()) {
-          case DeviceType::CPU:
-            if (isComplexType(typeMetaToScalarType(dtype()))) {
+          case DeviceType::CPU: {
+            auto dtype_tmp = typeMetaToScalarType(dtype());
+            if (isComplexType(dtype_tmp)) {
               return TensorTypeId::ComplexCPUTensorId;
             }
-            if (isQIntType(typeMetaToScalarType(dtype()))) {
+            if (isQIntType(dtype_tmp)) {
               return TensorTypeId::QuantizedCPUTensorId;
             }
             return TensorTypeId::CPUTensorId;
+            }
           case DeviceType::CUDA:
             if (isComplexType(typeMetaToScalarType(dtype()))) {
               return TensorTypeId::ComplexCUDATensorId;


### PR DESCRIPTION
Caches result of `scalar_type` call in TensorIterator and TensorOptions, because the call is expensive. 
This removes 120 - 150 ns of overhead (from 1.25 us to 1.12 us for out-of-place case, from 0.86 us to 0.73 us for inplace case)

Test plan: covered by existing tests
Differential Revision: D18576236

