### PR TITLE
[Mobile] Disable ProfilingGraphExecutorImpl for mobile

### DIFF
--- a/torch/csrc/jit/profiling_graph_executor_impl.cpp
+++ b/torch/csrc/jit/profiling_graph_executor_impl.cpp
@@ -24,7 +24,11 @@ static std::atomic<bool> executor_mode{false};
 static std::atomic<bool> profiling_mode{false};
 #else
 static std::atomic<bool> executor_mode{true};
+#ifdef C10_MOBILE
+static std::atomic<bool> profiling_mode{false};
+#else
 static std::atomic<bool> profiling_mode{true};
+#endif
 #endif
 
 

--- a/torch/csrc/jit/profiling_graph_executor_impl.cpp
+++ b/torch/csrc/jit/profiling_graph_executor_impl.cpp
@@ -19,16 +19,12 @@
 namespace torch {
 namespace jit {
 
-#ifdef FBCODE_CAFFE2
+#if defined (FBCODE_CAFFE2) || defined (C10_MOBILE)
 static std::atomic<bool> executor_mode{false};
 static std::atomic<bool> profiling_mode{false};
 #else
 static std::atomic<bool> executor_mode{true};
-#ifdef C10_MOBILE
-static std::atomic<bool> profiling_mode{false};
-#else
 static std::atomic<bool> profiling_mode{true};
-#endif
 #endif
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#30067 [Mobile] Disable profiling_model for mobile**

### Summary

The mobile build has been broken since last week due to a runtime error caused by a missing operator in JIT:

```shell
libc++abi.dylib: terminating with uncaught exception of type torch::jit::script::ErrorReport: 
Unknown builtin op: aten::_adaptive_avg_pool2d_backward.
Could not find any similar ops to aten::_adaptive_avg_pool2d_backward. This op may not exist or may not be currently supported in TorchScript.
:
at <string>:9:28
                grad_self = grad.expand(self.size()) / (self_size[-1] * self_size[-2])
            else:
                grad_self = torch._adaptive_avg_pool2d_backward(grad, self)
                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ <--- HERE

            return grad_self
```
### How this happens

Since we've disabled the autograd for the opensourced version, the `backward` ops won't get registered by JIT. 

When `forward` runs, a `GraphExecutor` will be created according to the value of  `executor_mode`.  In the mobile case , this one was set to true, which gives us the `ProfilingGraphExecutorImpl` object. Seems like this executor will eventually try to emit IR for autograd schemas? which causes the error.

### Fix

There are two ways to fix it. 

1. Add a macro to disable `profiling_mode` as well as `executor_mode` on mobile. Like what `FBCODE_CAFFE2` does [here](https://github.com/pytorch/pytorch/blob/master/torch/csrc/jit/profiling_graph_executor_impl.cpp#L22). 
2. Disable the two modes in runtime, by calling ` torch::jit::getExecutorMode() = false;` before calling forward.

(IMO, The second fix is sort of a workaround as it doesn't make sense from a user perspective (Why I need to do this).  But the up side is that we don't have to introduce yet another macro )

Feel free to drop comments, if there is a better way to fix it.

### How this was not detected by our mobile CI

We're working on adding runtime tests to our mobile build to prevent similar issues like this.

### Test Plan

- The error above disappears
- Don't break CI

cc @AshkanAliabadi

Differential Revision: [D18605998](https://our.internmc.facebook.com/intern/diff/D18605998)