### PR TITLE
axis -> dim for quantization interface

### DIFF
--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -242,7 +242,7 @@ Tensor empty_like(
           self.sizes(),
           self.q_per_channel_scales().clone(at::MemoryFormat::Preserve),
           self.q_per_channel_zero_points().clone(at::MemoryFormat::Preserve),
-          self.q_per_channel_axis(),
+          self.q_per_channel_dim(),
           options,
           memory_format);
     } else {

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1009,7 +1009,7 @@
 
 # it's a factory function receiving a tensor argument, thus overriding explicitly
 # other overrides are to provide a more helpful error message that dtype is required
-- func: _empty_per_channel_affine_quantized(int[] size, *, Tensor scales, Tensor zero_points, int axis, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=contiguous_format) -> Tensor
+- func: _empty_per_channel_affine_quantized(int[] size, *, Tensor scales, Tensor zero_points, int dim, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=contiguous_format) -> Tensor
   category_override: factory
   dispatch:
     CPU: empty_per_channel_affine_quantized_other_backends_stub
@@ -3402,7 +3402,7 @@
   dispatch:
     CPU: quantize_per_tensor_cpu
 
-- func: quantize_per_channel(Tensor self, Tensor scales, Tensor zero_points, int axis, ScalarType dtype) -> Tensor
+- func: quantize_per_channel(Tensor self, Tensor scales, Tensor zero_points, int dim, ScalarType dtype) -> Tensor
   variants: function
   dispatch:
     CPU: quantize_per_channel_cpu
@@ -3435,10 +3435,10 @@
   dispatch:
     QuantizedCPU: q_per_channel_zero_points_quant
 
-- func: q_per_channel_axis(Tensor self) -> int
+- func: q_per_channel_dim(Tensor self) -> int
   variants: function, method
   dispatch:
-    QuantizedCPU: q_per_channel_axis_quant
+    QuantizedCPU: q_per_channel_dim_quant
 
 - func: int_repr(Tensor self) -> Tensor
   use_c10_dispatcher: full
@@ -3451,7 +3451,7 @@
   dispatch:
     CPU: make_per_tensor_quantized_tensor_cpu
 
-- func: _make_per_channel_quantized_tensor(Tensor self, Tensor scale, Tensor zero_point, int axis) -> Tensor
+- func: _make_per_channel_quantized_tensor(Tensor self, Tensor scale, Tensor zero_point, int dim) -> Tensor
   dispatch:
     CPU: make_per_channel_quantized_tensor_cpu
 
@@ -3474,13 +3474,13 @@
     CPU: fake_quantize_per_tensor_affine_backward_cpu
     CUDA: fake_quantize_per_tensor_affine_backward_cuda
 
-- func: fake_quantize_per_channel_affine(Tensor self, Tensor scale, Tensor zero_point, int axis, int quant_min, int quant_max) -> Tensor
+- func: fake_quantize_per_channel_affine(Tensor self, Tensor scale, Tensor zero_point, int dim, int quant_min, int quant_max) -> Tensor
   variants: function
   dispatch:
     CPU: fake_quantize_per_channel_affine_cpu
     CUDA: fake_quantize_per_channel_affine_cuda
 
-- func: fake_quantize_per_channel_affine_backward(Tensor grad, Tensor self, Tensor scale, Tensor zero_point, int axis, int quant_min, int quant_max) -> Tensor
+- func: fake_quantize_per_channel_affine_backward(Tensor grad, Tensor self, Tensor scale, Tensor zero_point, int dim, int quant_min, int quant_max) -> Tensor
   variants: function
   dispatch:
     CPU: fake_quantize_per_channel_affine_backward_cpu

--- a/aten/src/ATen/native/quantized/QTensor.cpp
+++ b/aten/src/ATen/native/quantized/QTensor.cpp
@@ -21,10 +21,10 @@ Tensor quantize_per_channel_cpu(
     const Tensor& self,
     const Tensor& scales,
     const Tensor& zero_points,
-    int64_t axis,
+    int64_t dim,
     ScalarType dtype) {
   auto quantizer =
-      make_per_channel_affine_quantizer(scales, zero_points, axis, dtype);
+      make_per_channel_affine_quantizer(scales, zero_points, dim, dtype);
   return quantizer->quantize(self);
 }
 
@@ -60,10 +60,10 @@ Tensor q_per_channel_zero_points_quant(const Tensor& self) {
       self.options().dtype(at::kLong));
 }
 
-int64_t q_per_channel_axis_quant(const Tensor& self) {
+int64_t q_per_channel_dim_quant(const Tensor& self) {
   auto quantizer = get_qtensorimpl(self)->quantizer();
   TORCH_CHECK(quantizer->qscheme() == kPerChannelAffine);
-  return static_cast<PerChannelAffineQuantizer*>(quantizer.get())->axis();
+  return static_cast<PerChannelAffineQuantizer*>(quantizer.get())->dim();
 }
 
 // When input Tensor is non-dense, i.e. the allocated memory
@@ -112,12 +112,12 @@ Tensor make_per_channel_quantized_tensor_cpu(
     const Tensor& self,
     const Tensor& scales,
     const Tensor& zero_points,
-    int64_t axis) {
+    int64_t dim) {
   Tensor dst = at::_empty_per_channel_affine_quantized(
       self.sizes(),
       scales,
       zero_points,
-      axis,
+      dim,
       self.options().dtype(toQIntType(self.scalar_type())));
   Tensor self_contig = self.contiguous();
   AT_DISPATCH_QINT_TYPES(

--- a/aten/src/ATen/native/quantized/TensorFactories.cpp
+++ b/aten/src/ATen/native/quantized/TensorFactories.cpp
@@ -31,7 +31,7 @@ Tensor empty_per_channel_affine_quantized_cpu(
     IntArrayRef size,
     const Tensor& scales,
     const Tensor& zero_points,
-    int64_t axis,
+    int64_t dim,
     const TensorOptions& options,
     c10::optional<c10::MemoryFormat> optional_memory_format) {
   TORCH_CHECK(
@@ -46,7 +46,7 @@ Tensor empty_per_channel_affine_quantized_cpu(
       make_per_channel_affine_quantizer(
           scales,
           zero_points,
-          axis,
+          dim,
           typeMetaToScalarType(options.dtype())),
       optional_memory_format.value_or(MemoryFormat::Contiguous));
 }

--- a/aten/src/ATen/native/quantized/cpu/fake_quantize_per_channel_affine.cpp
+++ b/aten/src/ATen/native/quantized/cpu/fake_quantize_per_channel_affine.cpp
@@ -14,7 +14,7 @@ Args:
   dY: Backward input tensor (_backward op only).
   scale: scale of per channel affine quantization
   zero_point: zero_point of per channel affine quantization
-  axis: int specifying the axis to be quantized
+  dim: int specifying the dim to be quantized
   quant_min: minimum quantized value
   quant_max: maximum quantized value
 Returns:
@@ -26,7 +26,7 @@ Tensor fake_quantize_per_channel_affine_cpu(
     const Tensor& self,
     const Tensor& scale,
     const Tensor& zero_point,
-    int64_t axis,
+    int64_t dim,
     int64_t quant_min,
     int64_t quant_max) {
   // TODO: Use REGISTER_DISPATCH
@@ -39,7 +39,7 @@ Tensor fake_quantize_per_channel_affine_cpu(
       scale.numel() == zero_point.numel(),
       "scale and zero-point need to have the same dimensions");
   TORCH_CHECK(
-      scale.numel() == self.size(axis),
+      scale.numel() == self.size(dim),
       "dimensions of scale and zero-point are not consistent with input tensor")
 
   TORCH_CHECK(
@@ -53,13 +53,13 @@ Tensor fake_quantize_per_channel_affine_cpu(
       "`zero_point` must be between `quant_min` and `quant_max`.");
 
   TORCH_CHECK(
-      axis >= 0 && axis <= self.dim(),
-      "`axis` must be between 0 and number of dimensions of input");
+      dim >= 0 && dim <= self.dim(),
+      "`dim` must be between 0 and number of dimensions of input");
 
   auto Y = at::empty_like(self, self.options(), MemoryFormat::Preserve);
-  for (int i = 0; i < self.size(axis); i++) {
-    auto input_slice = self.slice(axis, i, i + 1);
-    auto output_slice = Y.slice(axis, i, i + 1);
+  for (int i = 0; i < self.size(dim); i++) {
+    auto input_slice = self.slice(dim, i, i + 1);
+    auto output_slice = Y.slice(dim, i, i + 1);
     float sc = scale[i].item().toFloat();
     int64_t z_point = zero_point[i].item().toLong();
     fake_quantize_slice(
@@ -76,7 +76,7 @@ Args:
   dY: Backward input tensor.
   scale: scale of per tensor affine quantization
   zero_point: zero_point of per tensor affine quantization
-  axis: int ,the axis over which quantization parameters vary
+  dim: int ,the dim over which quantization parameters vary
   quant_min: int, minimum quantized value
   quant_max: int, maximum quantized value
 
@@ -89,7 +89,7 @@ Tensor fake_quantize_per_channel_affine_backward_cpu(
     const Tensor& X,
     const Tensor& scale,
     const Tensor& zero_point,
-    int64_t axis,
+    int64_t dim,
     int64_t quant_min,
     int64_t quant_max) {
   TORCH_CHECK(dY.scalar_type() == ScalarType::Float);
@@ -108,7 +108,7 @@ Tensor fake_quantize_per_channel_affine_backward_cpu(
       scale.numel() == zero_point.numel(),
       "scale and zero-point need to have the same dimensions");
   TORCH_CHECK(
-      scale.numel() == X.size(axis),
+      scale.numel() == X.size(dim),
       "dimensions of scale and zero-point are not consistent with input tensor")
 
   TORCH_CHECK(
@@ -122,8 +122,8 @@ Tensor fake_quantize_per_channel_affine_backward_cpu(
       "`zero_point` must be between `quant_min` and `quant_max`.");
 
   TORCH_CHECK(
-      axis >= 0 && axis <= X.dim(),
-      "`axis` must be between 0 and number of dimensions of input");
+      dim >= 0 && dim <= X.dim(),
+      "`dim` must be between 0 and number of dimensions of input");
 
   if (X.numel() <= 0) {
     return X;
@@ -131,10 +131,10 @@ Tensor fake_quantize_per_channel_affine_backward_cpu(
 
   auto dX = at::empty_like(X, X.options(), MemoryFormat::Preserve);
 
-  for (int i = 0; i < X.size(axis); i++) {
-    auto X_slice = X.slice(axis, i, i + 1);
-    auto dY_slice = dY.slice(axis, i, i + 1);
-    auto dX_slice = dX.slice(axis, i, i + 1);
+  for (int i = 0; i < X.size(dim); i++) {
+    auto X_slice = X.slice(dim, i, i + 1);
+    auto dY_slice = dY.slice(dim, i, i + 1);
+    auto dX_slice = dX.slice(dim, i, i + 1);
     float sc = scale[i].item().toFloat();
     int64_t z_point = zero_point[i].item().toLong();
     fake_quantize_grad_slice(dX_slice, X_slice, dY_slice,

--- a/aten/src/ATen/native/quantized/cpu/fbgemm_utils.cpp
+++ b/aten/src/ATen/native/quantized/cpu/fbgemm_utils.cpp
@@ -156,7 +156,7 @@ Tensor MakeEmptyPerChannelAffineQuantizedChannelsLast3dTensor(
       make_per_channel_affine_quantizer(
           scales,
           zero_points,
-          0, // axis
+          0, // dim
           typeMetaToScalarType(options.dtype())));
 }
 

--- a/aten/src/ATen/native/quantized/cpu/qconv_prepack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv_prepack.cpp
@@ -125,9 +125,9 @@ class QConvPackWeightInt8 final : public c10::OperatorKernel {
     if (qtype == kPerTensorAffine) {
       zero_points = {static_cast<int32_t>(weight.q_zero_point())};
     } else if (qtype == kPerChannelAffine) {
-      int64_t axis = weight.q_per_channel_axis();
+      int64_t dim = weight.q_per_channel_dim();
       TORCH_CHECK(
-          axis == 0,
+          dim == 0,
           "Only per output channel quantization is supported for the weights");
       zero_points.resize(output_channels);
       for (int i = 0; i < output_channels; ++i) {

--- a/aten/src/ATen/native/quantized/cpu/qconv_unpack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv_unpack.cpp
@@ -104,7 +104,7 @@ class QConvUnpackWeightsInt8 final : public c10::OperatorKernel {
                 {output_channels, C_per_G, kernel_h, kernel_w},
                 scales.toType(kDouble),
                 zero_points.toType(kLong),
-                0, /* The output channel axis is 0 */
+                0, /* The output channel dim is 0 */
                 device(kCPU).dtype(kQInt8),
                 MemoryFormat::ChannelsLast)
           : fbgemm_utils::

--- a/aten/src/ATen/native/quantized/cpu/qlinear_unpack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear_unpack.cpp
@@ -40,7 +40,7 @@ class QLinearUnpackWeightInt8 final : public c10::OperatorKernel {
           {N, K},
           scales.toType(kDouble),
           zero_points.toType(kLong),
-          0, // The output channel axis is 0
+          0, // The output channel dim is 0
           device(kCPU).dtype(kQInt8));
     }
 

--- a/aten/src/ATen/native/quantized/cuda/fake_quantize_per_channel_affine.cu
+++ b/aten/src/ATen/native/quantized/cuda/fake_quantize_per_channel_affine.cu
@@ -13,7 +13,7 @@ Args:
   self: Forward input tensor.
   scale: scale of per channel affine quantization
   zero_point: zero_point of per channel affine quantization
-  axis: int specifying the axis to be quantized
+  dim: int specifying the dim to be quantized
   quant_min: minimum quantized value
   quant_max: maximum quantized value
 Returns:
@@ -24,7 +24,7 @@ Tensor fake_quantize_per_channel_affine_cuda(
     const Tensor& self,
     const Tensor& scale,
     const Tensor& zero_point,
-    int64_t axis,
+    int64_t dim,
     int64_t quant_min,
     int64_t quant_max) {
   TORCH_CHECK(self.is_cuda());
@@ -37,7 +37,7 @@ Tensor fake_quantize_per_channel_affine_cuda(
       scale.numel() == zero_point.numel(),
       "scale and zero-point need to have the same dimensions");
   TORCH_CHECK(
-      scale.numel() == self.size(axis),
+      scale.numel() == self.size(dim),
       "dimensions of scale and zero-point are not consistent with input tensor")
 
   TORCH_CHECK(
@@ -51,13 +51,13 @@ Tensor fake_quantize_per_channel_affine_cuda(
       "`zero_point` must be between `quant_min` and `quant_max`.");
 
   TORCH_CHECK(
-      axis >= 0 && axis <= self.dim(),
-      "`axis` must be between 0 and number of dimensions of input");
+      dim >= 0 && dim <= self.dim(),
+      "`dim` must be between 0 and number of dimensions of input");
 
   auto Y = at::empty_like(self, self.options(), MemoryFormat::Preserve);
-  for (int i = 0; i < self.size(axis); i++) {
-    auto X_slice = self.slice(axis, i, i + 1);
-    auto Y_slice = Y.slice(axis, i, i + 1);
+  for (int i = 0; i < self.size(dim); i++) {
+    auto X_slice = self.slice(dim, i, i + 1);
+    auto Y_slice = Y.slice(dim, i, i + 1);
     float sc = scale[i].item().toFloat();
     int64_t zp = zero_point[i].item().toLong();
     fake_quantize_slice_cuda(Y_slice, X_slice, sc, zp, quant_min, quant_max);
@@ -72,7 +72,7 @@ Args:
   X: Forward input tensor.
   scale: scale of per tensor affine quantization
   zero_point: zero_point of per tensor affine quantization
-  axis: int ,the axis over which quantization parameters vary
+  dim: int ,the dim over which quantization parameters vary
   quant_min: int, minimum quantized value
   quant_max: int, maximum quantized value
 
@@ -85,7 +85,7 @@ Tensor fake_quantize_per_channel_affine_backward_cuda(
     const Tensor& X,
     const Tensor& scale,
     const Tensor& zero_point,
-    int64_t axis,
+    int64_t dim,
     int64_t quant_min,
     int64_t quant_max) {
   TORCH_CHECK(dY.is_cuda());
@@ -105,7 +105,7 @@ Tensor fake_quantize_per_channel_affine_backward_cuda(
       scale.numel() == zero_point.numel(),
       "scale and zero-point need to have the same dimensions");
   TORCH_CHECK(
-      scale.numel() == X.size(axis),
+      scale.numel() == X.size(dim),
       "dimensions of scale and zero-point are not consistent with input tensor")
 
   TORCH_CHECK(
@@ -119,8 +119,8 @@ Tensor fake_quantize_per_channel_affine_backward_cuda(
       "`zero_point` must be between `quant_min` and `quant_max`.");
 
   TORCH_CHECK(
-      axis >= 0 && axis <= X.dim(),
-      "`axis` must be between 0 and number of dimensions of input");
+      dim >= 0 && dim <= X.dim(),
+      "`dim` must be between 0 and number of dimensions of input");
 
   if (X.numel() <= 0) {
     return X;
@@ -128,10 +128,10 @@ Tensor fake_quantize_per_channel_affine_backward_cuda(
 
   auto dX = at::empty_like(X, X.options(), MemoryFormat::Preserve);
 
-  for (int i = 0; i < X.size(axis); i++) {
-    auto dY_slice = dY.slice(axis, i, i + 1);
-    auto X_slice = X.slice(axis, i, i + 1);
-    auto dX_slice = dX.slice(axis, i, i + 1);
+  for (int i = 0; i < X.size(dim); i++) {
+    auto dY_slice = dY.slice(dim, i, i + 1);
+    auto X_slice = X.slice(dim, i, i + 1);
+    auto dX_slice = dX.slice(dim, i, i + 1);
     float sc = scale[i].item().toFloat();
     int64_t zp = zero_point[i].item().toLong();
     fake_quantize_grad_slice_cuda(

--- a/aten/src/ATen/quantized/Quantizer.h
+++ b/aten/src/ATen/quantized/Quantizer.h
@@ -179,11 +179,11 @@ struct CAFFE2_API PerChannelAffineQuantizer : public AffineQuantizer {
       ScalarType scalar_type,
       const std::vector<double>& scales,
       const std::vector<int64_t>& zero_points,
-      int64_t axis)
+      int64_t dim)
       : AffineQuantizer(scalar_type),
         scales_(scales),
         zero_points_(zero_points),
-        axis_(axis) {}
+        dim_(dim) {}
 
   QScheme qscheme() const override {
     return kPerChannelAffine;
@@ -197,8 +197,8 @@ struct CAFFE2_API PerChannelAffineQuantizer : public AffineQuantizer {
     return zero_points_;
   }
 
-  int64_t axis() const {
-    return axis_;
+  int64_t dim() const {
+    return dim_;
   }
 
   Tensor quantize(Tensor tensor) override;
@@ -213,13 +213,13 @@ struct CAFFE2_API PerChannelAffineQuantizer : public AffineQuantizer {
     return scalar_type() == other_per_channel_affine->scalar_type() &&
         scales() == other_per_channel_affine->scales() &&
         zero_points() == other_per_channel_affine->zero_points() &&
-        axis() == other_per_channel_affine->axis();
+        dim() == other_per_channel_affine->dim();
   }
 
  private:
   const std::vector<double> scales_;
   const std::vector<int64_t> zero_points_;
-  const int64_t axis_;
+  const int64_t dim_;
 };
 
 // This is an internal utility function for getting at the QTensorImpl,
@@ -254,12 +254,12 @@ make_per_tensor_affine_quantizer(
 CAFFE2_API QuantizerPtr
 make_per_channel_affine_quantizer(
     const std::vector<double>& scales, const std::vector<int64_t>& zero_points,
-    int64_t axis, ScalarType scalar_type);
+    int64_t dim, ScalarType scalar_type);
 // variant that unpacks scales and zero points from tensors
 CAFFE2_API QuantizerPtr make_per_channel_affine_quantizer(
     const Tensor& scales,
     const Tensor& zero_points,
-    int64_t axis,
+    int64_t dim,
     ScalarType scalar_type);
 
 // Create a Quantized Tensor given arguments for normal Tensor and a quantizer

--- a/aten/src/ATen/test/quantized_test.cpp
+++ b/aten/src/ATen/test/quantized_test.cpp
@@ -123,12 +123,12 @@ TEST(TestQTensor, EmptyPerchannelQuantized) {
   auto scales = rand({numel}).toType(kDouble);
   auto zero_points = randint(10, {10}).toType(kLong);
   int val = 100;
-  int ch_axis = 0;
+  int ch_dim = 0;
   Tensor q = at::_empty_per_channel_affine_quantized(
       {numel},
       scales,
       zero_points,
-      ch_axis,
+      ch_dim,
       at::device(at::kCPU).dtype(kQUInt8));
   // Assigning to QTensor
   auto* q_data = q.data_ptr<quint8>();

--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -774,7 +774,7 @@ class TestCase(expecttest.TestCase):
                     self.assertEqual(x.q_per_channel_zero_points(), y.q_per_channel_zero_points(),
                                      prec=prec, message=message,
                                      allow_inf=allow_inf)
-                    self.assertEqual(x.q_per_channel_axis(), y.q_per_channel_axis(),
+                    self.assertEqual(x.q_per_channel_dim(), y.q_per_channel_dim(),
                                      prec=prec, message=message)
                 self.assertEqual(x.dtype, y.dtype)
                 self.assertEqual(x.int_repr().to(torch.int32),

--- a/test/hypothesis_utils.py
+++ b/test/hypothesis_utils.py
@@ -205,14 +205,14 @@ def per_channel_tensor(draw, shapes=None, elements=None, qparams=None):
     enforced_zp = _ENFORCED_ZERO_POINT.get(qparams[2], None)
     if enforced_zp is not None:
         zp = enforced_zp
-    # Permute to model quantization along an axis
-    axis = int(np.random.randint(0, X.ndim, 1))
+    # Permute to model quantization along an dim
+    dim = int(np.random.randint(0, X.ndim, 1))
     permute_axes = np.arange(X.ndim)
-    permute_axes[0] = axis
-    permute_axes[axis] = 0
+    permute_axes[0] = dim
+    permute_axes[dim] = 0
     X = np.transpose(X, permute_axes)
 
-    return X, (scale, zp, axis, qparams[2])
+    return X, (scale, zp, dim, qparams[2])
 
 """Strategy for generating test cases for tensors used in Conv.
 The resulting tensors is in float32 format.

--- a/test/test_fake_quant.py
+++ b/test/test_fake_quant.py
@@ -25,33 +25,33 @@ def _fake_quantize_per_tensor_affine_grad_reference(dY, X, scale, zero_point, qu
     res[mask] = dY.cpu()[mask]
     return res
 
-# Helper function used to simulate per-channel fake-quant against any axis
-def _permute_to_axis_zero(X, axis):
-    new_axis_list = list(range(X.dim()))
-    new_axis_list[axis] = 0
-    new_axis_list[0] = axis
-    y = X.permute(tuple(new_axis_list))
-    return y, new_axis_list
+# Helper function used to simulate per-channel fake-quant against any dim
+def _permute_to_dim_zero(X, dim):
+    new_dim_list = list(range(X.dim()))
+    new_dim_list[dim] = 0
+    new_dim_list[0] = dim
+    y = X.permute(tuple(new_dim_list))
+    return y, new_dim_list
 
 # Reference method for fake quantize
-def _fake_quantize_per_channel_affine_reference(X, per_channel_scale, per_channel_zero_point, axis, quant_min, quant_max):
-    X, permute_axis_list = _permute_to_axis_zero(X, axis)
+def _fake_quantize_per_channel_affine_reference(X, per_channel_scale, per_channel_zero_point, dim, quant_min, quant_max):
+    X, permute_dim_list = _permute_to_dim_zero(X, dim)
     res = torch.zeros_like(X)
 
     for i in range(X.size()[0]):
         res[i] = (torch.clamp(torch.round(X[i] * (1.0 / per_channel_scale[i]) +
                   per_channel_zero_point[i]), quant_min, quant_max) - per_channel_zero_point[i]) * per_channel_scale[i]
 
-    out = res.permute(tuple(permute_axis_list))
+    out = res.permute(tuple(permute_dim_list))
     return out
 
 # Reference method for the gradient of the fake quantize operator
-def _fake_quantize_per_channel_affine_grad_reference(dY, X, per_channel_scale, per_channel_zero_point, axis, quant_min, quant_max):
-    X, permute_axis_list = _permute_to_axis_zero(X, axis)
+def _fake_quantize_per_channel_affine_grad_reference(dY, X, per_channel_scale, per_channel_zero_point, dim, quant_min, quant_max):
+    X, permute_dim_list = _permute_to_dim_zero(X, dim)
     Xq = torch.zeros_like(X)
     for i in range(X.size()[0]):
         Xq[i] = torch.round(X[i] * (1.0 / per_channel_scale[i]) + per_channel_zero_point[i])
-    Xq = Xq.permute(tuple(permute_axis_list))
+    Xq = Xq.permute(tuple(permute_dim_list))
     mask = (Xq >= quant_min) * (Xq <= quant_max)
     res = torch.zeros_like(dY)
     res[mask] = dY[mask]
@@ -217,16 +217,16 @@ class TestFakeQuantizePerChannel(TestCase):
         r"""Tests the forward path of the FakeQuantizePerTensorAffine op.
         """
         np.random.seed(NP_RANDOM_SEED)
-        X, (scale, zero_point, axis, torch_type) = X
+        X, (scale, zero_point, dim, torch_type) = X
         quant_min = torch.iinfo(torch_type).min
         quant_max = torch.iinfo(torch_type).max
 
         X = to_tensor(X, device)
         scale = to_tensor(scale, device)
         zero_point = torch.tensor(zero_point).to(dtype=torch.int64, device=device)
-        Y = _fake_quantize_per_channel_affine_reference(X.cpu(), scale.cpu(), zero_point.cpu(), axis, quant_min, quant_max)
+        Y = _fake_quantize_per_channel_affine_reference(X.cpu(), scale.cpu(), zero_point.cpu(), dim, quant_min, quant_max)
         Y_prime = torch.fake_quantize_per_channel_affine(
-            X, scale, zero_point, axis, quant_min, quant_max)
+            X, scale, zero_point, dim, quant_min, quant_max)
         np.testing.assert_allclose(Y, Y_prime.cpu(), rtol=tolerance, atol=tolerance)
 
     @no_deadline
@@ -237,7 +237,7 @@ class TestFakeQuantizePerChannel(TestCase):
         r"""Tests the backward method.
         """
         np.random.seed(NP_RANDOM_SEED)
-        X, (scale, zero_point, axis, torch_type) = X
+        X, (scale, zero_point, dim, torch_type) = X
         quant_min = torch.iinfo(torch_type).min
         quant_max = torch.iinfo(torch_type).max
 
@@ -246,10 +246,10 @@ class TestFakeQuantizePerChannel(TestCase):
         zero_point = torch.tensor(zero_point).to(dtype=torch.int64, device=device)
         X.requires_grad_()
         Y_prime = torch.fake_quantize_per_channel_affine(
-            X, scale, zero_point, axis, quant_min, quant_max)
+            X, scale, zero_point, dim, quant_min, quant_max)
         dout = torch.rand(X.shape, dtype=torch.float).to(device)
         dX = _fake_quantize_per_channel_affine_grad_reference(
-            dout, X, scale, zero_point, axis, quant_min, quant_max)
+            dout, X, scale, zero_point, dim, quant_min, quant_max)
         Y_prime.backward(dout)
         np.testing.assert_allclose(dX.cpu().detach().numpy(), X.grad.cpu().detach().numpy(), rtol=tolerance, atol=tolerance)
 
@@ -262,7 +262,7 @@ class TestFakeQuantizePerChannel(TestCase):
         r"""Comparing numerical consistency between CPU quantize/dequantize op and the CPU fake quantize op
         """
         np.random.seed(NP_RANDOM_SEED)
-        X, (scale, zero_point, axis, torch_type) = X
+        X, (scale, zero_point, dim, torch_type) = X
         quant_min = torch.iinfo(torch_type).min
         quant_max = torch.iinfo(torch_type).max
 
@@ -270,9 +270,9 @@ class TestFakeQuantizePerChannel(TestCase):
         scale = to_tensor(scale, device)
         zero_point = torch.tensor(zero_point).to(dtype=torch.int64, device=device)
         # quantize_linear and dequantize are only implemented in CPU
-        Y = torch.dequantize(torch.quantize_per_channel(X.cpu(), scale.cpu(), zero_point.cpu(), axis, torch_type))
+        Y = torch.dequantize(torch.quantize_per_channel(X.cpu(), scale.cpu(), zero_point.cpu(), dim, torch_type))
         Y_prime = torch.fake_quantize_per_channel_affine(
-            X, scale, zero_point, axis, quant_min, quant_max)
+            X, scale, zero_point, dim, quant_min, quant_max)
         np.testing.assert_allclose(Y, Y_prime.cpu(), rtol=tolerance, atol=tolerance)
 
     @no_deadline
@@ -281,25 +281,25 @@ class TestFakeQuantizePerChannel(TestCase):
            qparams=hu.qparams(dtypes=torch.qint8)))
     def test_fq_module(self, device, X):
         np.random.seed(NP_RANDOM_SEED)
-        X, (scale, zero_point, axis, torch_type) = X
+        X, (scale, zero_point, dim, torch_type) = X
         quant_min = torch.iinfo(torch_type).min
         quant_max = torch.iinfo(torch_type).max
 
         X = to_tensor(X, device)
         X.requires_grad_()
-        fq_module = FakeQuantize(default_per_channel_weight_observer, quant_min, quant_max, ch_axis=axis).to(device)
+        fq_module = FakeQuantize(default_per_channel_weight_observer, quant_min, quant_max, ch_dim=dim).to(device)
         Y_prime = fq_module(X)
         assert fq_module.scale is not None
         assert fq_module.zero_point is not None
         Y = _fake_quantize_per_channel_affine_reference(X, fq_module.scale,
-                                                        fq_module.zero_point, axis, quant_min, quant_max)
+                                                        fq_module.zero_point, dim, quant_min, quant_max)
         np.testing.assert_allclose(Y.cpu().detach().numpy(), Y_prime.cpu().detach().numpy(), rtol=tolerance, atol=tolerance)
 
         # Test backward
         dout = torch.rand(X.shape, dtype=torch.float, device=device)
         Y_prime.backward(dout)
         dX = _fake_quantize_per_channel_affine_grad_reference(dout, X, fq_module.scale,
-                                                              fq_module.zero_point, axis, quant_min, quant_max)
+                                                              fq_module.zero_point, dim, quant_min, quant_max)
         np.testing.assert_allclose(dX.cpu().numpy(), X.grad.cpu().detach().numpy(), rtol=tolerance, atol=tolerance)
 
     def test_fq_serializable(self):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -15944,7 +15944,7 @@ a")
                 torch.rand(2, 3, dtype=torch.float),
                 scales=torch.tensor([0.1, 0.5, 0.01]),
                 zero_points=torch.tensor([10, 0, 20]),
-                axis=1, dtype=torch.quint8).to(device)
+                dim=1, dtype=torch.quint8).to(device)
             m = M()
             m(q, qc)
             with open(fname, "rb") as handle:

--- a/test/test_quantized.py
+++ b/test/test_quantized.py
@@ -807,15 +807,15 @@ class TestQuantizedOps(TestCase):
         np.testing.assert_equal(cat_ref.numpy(), cat_q_out.numpy())
 
         # Test the cat on per-channel quantized tensor.
-        ch_axis = 1
-        scales = torch.from_numpy(np.array([1.0] * X.shape[ch_axis]))
+        ch_dim = 1
+        scales = torch.from_numpy(np.array([1.0] * X.shape[ch_dim]))
         scales = scales.to(torch.float64)
-        zero_points = torch.from_numpy(np.array([0] * X.shape[ch_axis]))
+        zero_points = torch.from_numpy(np.array([0] * X.shape[ch_dim]))
         zero_points = zero_points.to(torch.long)
         tensors_q[0] = torch.quantize_per_channel(
-            X, scales, zero_points, axis=ch_axis, dtype=torch_type)
+            X, scales, zero_points, dim=ch_dim, dtype=torch_type)
         with self.assertRaisesRegex(RuntimeError, "supported.*cat"):
-            cat_q = q_cat_op(tensors_q, dim=ch_axis, scale=scale,
+            cat_q = q_cat_op(tensors_q, dim=ch_dim, scale=scale,
                              zero_point=zero_point)
 
     @no_deadline
@@ -944,7 +944,7 @@ class TestQuantizedOps(TestCase):
                 scales=torch.tensor([scale] * channels),
                 zero_points=torch.tensor([zero_point] * channels),
                 dtype=torch_type,
-                axis=X.ndim - 1)
+                dim=X.ndim - 1)
         else:
             X_scheme = 'per_tensor'
             qX = torch.quantize_per_tensor(X, scale=scale, zero_point=zero_point,
@@ -958,7 +958,7 @@ class TestQuantizedOps(TestCase):
                 scales=torch.tensor([scale2] * channels),
                 zero_points=torch.tensor([zero_point2] * channels),
                 dtype=torch_type2,
-                axis=X2.ndim - 1)
+                dim=X2.ndim - 1)
         else:
             X2_scheme = 'per_tensor'
             qX2 = torch.quantize_per_tensor(X2, scale=scale2, zero_point=zero_point2,
@@ -1076,7 +1076,7 @@ class TestDynamicQuantizedLinear(TestCase):
             W_fp32 = torch.from_numpy(_dequantize(W_q0, W_scales.reshape(
                 (-1, 1)), W_zps.reshape((-1, 1)))).to(dtype=torch.float)
             W_q = torch.quantize_per_channel(W_fp32, scales=torch.from_numpy(W_scales),
-                                             zero_points=torch.from_numpy(W_zps), axis=0, dtype=torch.qint8)
+                                             zero_points=torch.from_numpy(W_zps), dim=0, dtype=torch.qint8)
             b_fp32 = torch.from_numpy(
                 _dequantize(b_q0, X_scale * W_scales, 0)
             ).to(dtype=torch.float) if use_bias else None
@@ -1190,12 +1190,12 @@ class TestQuantizedLinear(unittest.TestCase):
                 W = torch.from_numpy(_dequantize(W_q0, W_scales.reshape(
                     (-1, 1)), W_zps.reshape((-1, 1)))).to(dtype=torch.float)
                 W_q = torch.quantize_per_channel(W, scales=torch.from_numpy(W_scales),
-                                                 zero_points=torch.from_numpy(W_zps), axis=0, dtype=torch.qint8)
+                                                 zero_points=torch.from_numpy(W_zps), dim=0, dtype=torch.qint8)
                 b = torch.from_numpy(_dequantize(
                     b_q0, X_scale * W_scales, 0)).to(dtype=torch.float) if use_bias else None
                 b_q = torch.quantize_per_channel(b, scales=torch.from_numpy(X_scale * W_scales),
                                                  zero_points=torch.zeros(output_channels, dtype=torch.long),
-                                                 axis=0, dtype=torch.qint32) if use_bias else None
+                                                 dim=0, dtype=torch.qint32) if use_bias else None
             else:
                 W = torch.from_numpy(_dequantize(
                     W_q0, W_scales[0], W_zps[0])).to(dtype=torch.float)
@@ -1309,7 +1309,7 @@ class TestQuantizedConv(unittest.TestCase):
         bias = torch.from_numpy(bias).float()
         if channelwise:
             W_q = torch.quantize_per_channel(
-                W, scales=W_scale, zero_points=W_zero_point, axis=0,
+                W, scales=W_scale, zero_points=W_zero_point, dim=0,
                 dtype=W_qtype)
         else:
             W_q = torch.quantize_per_tensor(

--- a/test/test_quantized_nn_mods.py
+++ b/test/test_quantized_nn_mods.py
@@ -382,7 +382,7 @@ class ModuleAPITest(QuantizationTestCase):
                 zero_point_tensor = torch.zeros(out_features, dtype=torch.long)
                 for i in range(len(scale_tensor)):
                     scale_tensor[i] = (i + 1.0) / 255.0
-                W_q = torch.quantize_per_channel(W, scales=scale_tensor, zero_points=zero_point_tensor, axis=0, dtype=torch.qint8)
+                W_q = torch.quantize_per_channel(W, scales=scale_tensor, zero_points=zero_point_tensor, dim=0, dtype=torch.qint8)
             else:
                 W_q = torch.quantize_per_tensor(W, 0.1, 4, torch.qint8)
 

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -328,8 +328,8 @@
 - name: fake_quantize_per_tensor_affine(Tensor self, float scale, int zero_point, int quant_min, int quant_max) -> Tensor
   self: fake_quantize_per_tensor_affine_backward(grad, self, scale, zero_point, quant_min, quant_max)
 
-- name: fake_quantize_per_channel_affine(Tensor self, Tensor scale, Tensor zero_point, int axis, int quant_min, int quant_max) -> Tensor
-  self: fake_quantize_per_channel_affine_backward(grad, self, scale, zero_point, axis, quant_min, quant_max)
+- name: fake_quantize_per_channel_affine(Tensor self, Tensor scale, Tensor zero_point, int dim, int quant_min, int quant_max) -> Tensor
+  self: fake_quantize_per_channel_affine_backward(grad, self, scale, zero_point, dim, quant_min, quant_max)
 
 - name: fill_.Scalar(Tensor(a!) self, Scalar value) -> Tensor(a!)
   self: zeros_like(grad)

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -2026,7 +2026,7 @@ q_per_channel_scales() -> Tensor
 
 Given a Tensor quantized by linear (affine) per-channel quantization,
 returns a Tensor of scales of the underlying quantizer. It has the number of
-elements that matches the corresponding dimensions (from q_per_channel_axis) of
+elements that matches the corresponding dimensions (from q_per_channel_dim) of
 the tensor.
 """)
 
@@ -2036,13 +2036,13 @@ q_per_channel_zero_points() -> Tensor
 
 Given a Tensor quantized by linear (affine) per-channel quantization,
 returns a tensor of zero_points of the underlying quantizer. It has the number of
-elements that matches the corresponding dimensions (from q_per_channel_axis) of
+elements that matches the corresponding dimensions (from q_per_channel_dim) of
 the tensor.
 """)
 
-add_docstr_all('q_per_channel_axis',
+add_docstr_all('q_per_channel_dim',
                r"""
-q_per_channel_axis() -> int
+q_per_channel_dim() -> int
 
 Given a Tensor quantized by linear (affine) per-channel quantization,
 returns the index of dimension on which per-channel quantization is applied.

--- a/torch/csrc/jit/pickler.cpp
+++ b/torch/csrc/jit/pickler.cpp
@@ -342,7 +342,7 @@ void Pickler::pushLiteralTensor(const IValue& ivalue) {
             tensor.quantizer().get());
         pushIValue(c10::List<double>(quantizer->scales()));
         pushIValue(c10::List<int64_t>(quantizer->zero_points()));
-        pushInt(quantizer->axis());
+        pushInt(quantizer->dim());
       } break;
       default:
         TORCH_CHECK(

--- a/torch/quantization/fake_quantize.py
+++ b/torch/quantization/fake_quantize.py
@@ -56,7 +56,7 @@ class FakeQuantize(Module):
         self.zero_point = None
         self.dtype = self.activation_post_process.dtype
         self.qscheme = self.activation_post_process.qscheme
-        self.ch_axis = self.activation_post_process.ch_axis if hasattr(self.activation_post_process, 'ch_axis') else 0
+        self.ch_dim = self.activation_post_process.ch_dim if hasattr(self.activation_post_process, 'ch_dim') else 0
 
     def enable_fake_quant(self, enabled=True):
         self.fake_quant_enabled = enabled
@@ -82,7 +82,7 @@ class FakeQuantize(Module):
         if self.fake_quant_enabled:
             if self.qscheme == torch.per_channel_symmetric or self.qscheme == torch.per_channel_affine:
                 X = torch.fake_quantize_per_channel_affine(X, self.scale, self.zero_point,
-                                                           self.ch_axis, self.quant_min, self.quant_max)
+                                                           self.ch_dim, self.quant_min, self.quant_max)
             else:
                 X = torch.fake_quantize_per_tensor_affine(X, float(self.scale),
                                                           int(self.zero_point), self.quant_min,
@@ -123,7 +123,7 @@ default_per_channel_weight_fake_quant = FakeQuantize.with_args(observer=MovingAv
                                                                dtype=torch.qint8,
                                                                qscheme=torch.per_channel_symmetric,
                                                                reduce_range=False,
-                                                               ch_axis=0)
+                                                               ch_dim=0)
 default_histogram_fake_quant = FakeQuantize.with_args(observer=HistogramObserver,
                                                       quant_min=0,
                                                       quant_max=255,

--- a/torch/quantization/observer.py
+++ b/torch/quantization/observer.py
@@ -408,7 +408,7 @@ class PerChannelMinMaxObserver(_ObserverBase):
     parameters.
 
     Args:
-        ch_axis: Channel axis
+        ch_dim: Channel dim
         dtype: Quantized data type
         qscheme: Quantization scheme to be used
         reduce_range: Reduces the range of the quantized data type by 1 bit
@@ -422,12 +422,12 @@ class PerChannelMinMaxObserver(_ObserverBase):
               and zero_points are set to 1.0 and 0.
     """
 
-    def __init__(self, ch_axis=0, dtype=torch.quint8,
+    def __init__(self, ch_dim=0, dtype=torch.quint8,
                  qscheme=torch.per_channel_affine, reduce_range=False):
         super(PerChannelMinMaxObserver, self).__init__(dtype=dtype,
                                                        qscheme=qscheme,
                                                        reduce_range=reduce_range)
-        self.ch_axis = ch_axis
+        self.ch_dim = ch_dim
         self.register_buffer('min_vals', None)
         self.register_buffer('max_vals', None)
         if (
@@ -445,10 +445,10 @@ class PerChannelMinMaxObserver(_ObserverBase):
         max_vals = self.max_vals
         x_dim = x.size()
 
-        new_axis_list = list(range(len(x_dim)))
-        new_axis_list[self.ch_axis] = 0
-        new_axis_list[0] = self.ch_axis
-        y = x.permute(tuple(new_axis_list))
+        new_dim_list = list(range(len(x_dim)))
+        new_dim_list[self.ch_dim] = 0
+        new_dim_list[0] = self.ch_dim
+        y = x.permute(tuple(new_dim_list))
         y = torch.flatten(y, start_dim=1)
         if min_vals is None or max_vals is None:
             min_vals = torch.min(y, 1)[0]
@@ -486,7 +486,7 @@ class MovingAveragePerChannelMinMaxObserver(PerChannelMinMaxObserver):
 
     Args:
         averaging_constant: Averaging constant for min/max.
-        ch_axis: Channel axis
+        ch_dim: Channel dim
         dtype: Quantized data type
         qscheme: Quantization scheme to be used
         reduce_range: Reduces the range of the quantized data type by 1 bit
@@ -500,10 +500,10 @@ class MovingAveragePerChannelMinMaxObserver(PerChannelMinMaxObserver):
               and zero_points are set to 1.0 and 0.
     """
 
-    def __init__(self, averaging_constant=0.01, ch_axis=0, dtype=torch.quint8,
+    def __init__(self, averaging_constant=0.01, ch_dim=0, dtype=torch.quint8,
                  qscheme=torch.per_channel_affine, reduce_range=False):
         super(MovingAveragePerChannelMinMaxObserver, self).__init__(
-            ch_axis=ch_axis, dtype=dtype, qscheme=qscheme,
+            ch_dim=ch_dim, dtype=dtype, qscheme=qscheme,
             reduce_range=reduce_range)
         self.averaging_constant = averaging_constant
 
@@ -513,10 +513,10 @@ class MovingAveragePerChannelMinMaxObserver(PerChannelMinMaxObserver):
         max_vals = self.max_vals
         x_dim = x.size()
 
-        new_axis_list = list(range(len(x_dim)))
-        new_axis_list[self.ch_axis] = 0
-        new_axis_list[0] = self.ch_axis
-        y = x.permute(tuple(new_axis_list))
+        new_dim_list = list(range(len(x_dim)))
+        new_dim_list[self.ch_dim] = 0
+        new_dim_list[0] = self.ch_dim
+        y = x.permute(tuple(new_dim_list))
         y = torch.flatten(y, start_dim=1)
         if min_vals is None or max_vals is None:
             min_vals = torch.min(y, 1)[0]

--- a/torch/tensor.py
+++ b/torch/tensor.py
@@ -54,7 +54,7 @@ class Tensor(torch._C._TensorBase):
                     if self.qscheme() == torch.per_tensor_affine:
                         quantizer_params = self.qscheme(), self.q_scale(), self.q_zero_point()
                     elif self.qscheme() == torch.per_channel_affine:
-                        quantizer_params = self.qscheme(), self.q_per_channel_scales(), self.q_per_channel_zero_points(), self.q_per_channel_axis()
+                        quantizer_params = self.qscheme(), self.q_per_channel_scales(), self.q_per_channel_zero_points(), self.q_per_channel_dim()
                     else:
                         raise RuntimeError("Unsupported qscheme {} in deepcopy".format(self.qscheme()))
                     new_tensor = torch._utils._rebuild_qtensor(
@@ -104,7 +104,7 @@ class Tensor(torch._C._TensorBase):
                 quantizer_params = (torch.per_channel_affine,
                                     [e.item() for e in self.q_per_channel_scales().reshape(-1)],
                                     [e.item() for e in self.q_per_channel_zero_points().reshape(-1)],
-                                    self.q_per_channel_axis())
+                                    self.q_per_channel_dim())
             else:
                 raise RuntimeError("Serialization is not supported for tensors of type {}".format(self.qscheme()))
             args = (self.storage(),


### PR DESCRIPTION
This patch standardizes on the PyTorch usage of `dim` for index dimensions.
