### PR TITLE
Disable openmp in static and dynamic histograms

### DIFF
--- a/caffe2/quantization/server/dynamic_histogram.h
+++ b/caffe2/quantization/server/dynamic_histogram.h
@@ -11,8 +11,6 @@ namespace dnnlowp {
  * with an exception that (nbins - 1)th bin contains
  * [(nbins-1)*bin_width, nbins*bin_width]
  *
- * Make sure to call Finalize before GetHistogram to reduce per-thread
- * histogram.
  */
 class Histogram {
  public:
@@ -23,10 +21,7 @@ class Histogram {
 
   void Add(float f, uint64_t cnt = 1);
   /**
-   * This version collects histogram with multiple threads using per-thread
-   * histogram with privatization.
-   * We should call Finalize before GetHistogram to reduce per-thread
-   * histogram.
+   * This version collects histogram with single thread
    */
   void Add(const float* f, int len);
 
@@ -37,12 +32,6 @@ class Histogram {
     return max_;
   }
 
-  /**
-   * Reduce per-thread histogram. Need to call this before GetHistogram when
-   * the version of Add with multiple threads was used.
-   */
-  void Finalize();
-
   const std::vector<uint64_t>* GetHistogram() const {
     return &histogram_;
   }
@@ -50,7 +39,6 @@ class Histogram {
  private:
   float min_, max_;
   std::vector<uint64_t> histogram_;
-  std::vector<uint64_t> per_thread_histogram_;
 };
 
 /// An equi-width histogram where the spread of bins change over time when

--- a/caffe2/quantization/server/dynamic_histogram_test.cc
+++ b/caffe2/quantization/server/dynamic_histogram_test.cc
@@ -43,7 +43,6 @@ TEST(DynamicHistogram, HistSimilar) {
   }
 
   stringstream ss;
-  static_hist.Finalize();
   for (int i = 0; i < nbins; ++i) {
     ss << (*static_hist.GetHistogram())[i] << " ";
   }


### PR DESCRIPTION
Summary: Fix the test failure with mode/opt-lto by disabling openmp in both static and dynamic histograms. We will just use single thread in histogram processing as it's the common use case.

Test Plan:
```
buck run mode/opt caffe2/caffe2/fb/fbgemm/numerical_debugger/workflows:int8_static_quantization_exporter -- --model-dir /mnt/public/summerdeng/ads/ --model-name downsized_ins_97293388_0.predictor --run --iter 10  --dataset-path /mnt/public/summerdeng/ads/ctr_instagram_story_int8/dataset/train/dataset_115764229_10 --hive-path="hive://ad_delivery/ig_ad_prefiltered_training_data_orc_injected/ds=2019-09-09/pipeline=ctr_instagram_story_click_only_model_opt_out_df" --collect-histogram --activation-histogram-file=/mnt/public/summerdeng/ads/ctr_instagram_story_int8/activation_histograms/dummy_debug_OOM.txt
```
```
buck test mode/opt-lto caffe2/caffe2/quantization/server:dynamic_histogram_test -- --run-disabled
```

Reviewed By: hx89

Differential Revision: D18554614

