### PR TITLE
[rpc][build] fix windows build

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -83,7 +83,9 @@ if PY36:
 
 WINDOWS_BLACKLIST = [
     'distributed',
+    'rpc_fork',
     'rpc_spawn',
+    'dist_autograd_fork',
     'dist_autograd_spawn',
     'dist_optimizer_spawn',
 ]
@@ -92,7 +94,9 @@ ROCM_BLACKLIST = [
     'cpp_extensions',
     'distributed',
     'multiprocessing',
+    'rpc_fork',
     'rpc_spawn',
+    'dist_autograd_fork',
     'dist_autograd_spawn',
     'dist_optimizer_spawn',
 ]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#30078 [rpc][build] fix windows build**

Windows tests are broken (https://ci.pytorch.org/jenkins/job/pytorch-builds/job/pytorch-win-ws2016-cuda9-cudnn7-py3-test2/56195/consoleFull). Fixes by skipping these tests on windows, since RPC is not supported on windows

Differential Revision: [D18591658](https://our.internmc.facebook.com/intern/diff/D18591658/)