### PR TITLE
explicitly provide memory format when calling to *_like operators (derivatives)

### DIFF
--- a/test/common_nn.py
+++ b/test/common_nn.py
@@ -21,6 +21,7 @@ from common_cuda import TEST_CUDA
 from torch.autograd.gradcheck import get_numerical_jacobian, iter_tensors
 from torch.autograd import Variable
 import torch.backends.cudnn
+from fake_operators import fake_empty_like, fake_rand_like, fake_randint_like, fake_randn_like, fake_ones_like, fake_zeros_like, fake_full_like
 
 
 # tarfile module tries to obtain a file object name in python 3.3
@@ -3366,9 +3367,9 @@ class NNTestCase(TestCase):
         for i in range(output_size):
             param, d_param = self._get_parameters(module)
             # make non grad zeros
-            d_param = [torch.zeros_like(p) if d is None else d for (p, d) in zip(param, d_param)]
+            d_param = [fake_zeros_like(p) if d is None else d for (p, d) in zip(param, d_param)]
 
-            d_out = torch.zeros_like(output)
+            d_out = fake_zeros_like(output)
             flat_d_out = d_out.view(-1)
             flat_d_out[i] = 1
 
@@ -3580,7 +3581,7 @@ class ModuleTest(TestBase):
             if tensor.size(d) > 1:
                 dim = d + 1
                 break
-        noncontig = torch.stack([torch.empty_like(tensor), tensor], dim).select(dim, 1).detach()
+        noncontig = torch.stack([fake_empty_like(tensor), tensor], dim).select(dim, 1).detach()
         assert noncontig.numel() == 1 or noncontig.numel() == 0 or not noncontig.is_contiguous()
         noncontig.requires_grad = tensor.requires_grad
         return noncontig
@@ -3656,7 +3657,7 @@ class ModuleTest(TestBase):
                 cpu_output = cpu_module(cpu_input)
                 gpu_output = gpu_module(gpu_input)
 
-                cpu_gradOutput = torch.randn_like(cpu_output, requires_grad=True)
+                cpu_gradOutput = fake_randn_like(cpu_output, requires_grad=True)
                 gpu_gradOutput = cpu_gradOutput.type_as(gpu_output).detach()
                 gpu_gradOutput.requires_grad = True
 

--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -140,6 +140,21 @@ ALL_TENSORTYPES = [torch.float,
                    torch.double,
                    torch.half]
 
+def fake_empty_like(*args, **kwargs):
+    if 'memory_format' not in kwargs and not args[0].is_sparse:
+        kwargs['memory_format'] = torch.contiguous_format
+    return torch.empty_like(*args, **kwargs)
+
+def fake_rand_like(*args, **kwargs):
+    if 'memory_format' not in kwargs:
+        kwargs['memory_format'] = torch.contiguous_format
+    return torch.rand_like(*args, **kwargs)
+
+def fake_full_like(*args, **kwargs):
+    if 'memory_format' not in kwargs:
+        kwargs['memory_format'] = torch.contiguous_format
+    return torch.full_like(*args, **kwargs)
+
 # Used to run the same test with different tensor types
 def repeat_test_for_types(dtypes):
     def repeat_helper(f):
@@ -638,7 +653,7 @@ class TestCase(expecttest.TestCase):
         i.mul_(torch.tensor(size[:sparse_dim]).unsqueeze(1).to(i))
         i = i.to(torch.long)
         if is_uncoalesced:
-            v = torch.cat([v, torch.randn_like(v)], 0)
+            v = torch.cat([v, torch.randn_like(v, memory_format=torch.contiguous_format)], 0)
             i = torch.cat([i, i], 1)
 
         x = torch.sparse_coo_tensor(i, v, torch.Size(size))
@@ -1257,8 +1272,8 @@ def do_test_empty_full(self, dtypes, layout, device):
             check_value(v.new_empty(shape), dtype, layout, device, None, False)
             check_value(v.new_empty(shape, dtype=int64_dtype, device=device, requires_grad=False),
                         int64_dtype, layout, device, None, False)
-            check_value(torch.empty_like(v), dtype, layout, device, None, False)
-            check_value(torch.empty_like(v, dtype=int64_dtype, layout=layout, device=device, requires_grad=False),
+            check_value(fake_empty_like(v), dtype, layout, device, None, False)
+            check_value(fake_empty_like(v, dtype=int64_dtype, layout=layout, device=device, requires_grad=False),
                         int64_dtype, layout, device, None, False)
 
             if dtype is not torch.float16 and layout != torch.sparse_coo:
@@ -1271,9 +1286,8 @@ def do_test_empty_full(self, dtypes, layout, device):
                             dtype, layout, device, fv + 2, rg)
                 check_value(v.new_full(shape, fv + 3, dtype=int64_dtype, device=device, requires_grad=False),
                             int64_dtype, layout, device, fv + 3, False)
-                check_value(torch.full_like(v, fv + 4), dtype, layout, device, fv + 4, False)
-                check_value(torch.full_like(v, fv + 5,
-                                            dtype=int64_dtype, layout=layout, device=device, requires_grad=False),
+                check_value(fake_full_like(v, fv + 4), dtype, layout, device, fv + 4, False)
+                check_value(fake_full_like(v, fv + 5, dtype=int64_dtype, layout=layout, device=device, requires_grad=False),
                             int64_dtype, layout, device, fv + 5, False)
 
 

--- a/test/fake_operators.py
+++ b/test/fake_operators.py
@@ -1,0 +1,36 @@
+import torch
+
+def fake_empty_like(*args, **kwargs):
+    if 'memory_format' not in kwargs:
+        kwargs['memory_format'] = torch.contiguous_format
+    return torch.empty_like(*args, **kwargs)
+
+def fake_rand_like(*args, **kwargs):
+    if 'memory_format' not in kwargs:
+        kwargs['memory_format'] = torch.contiguous_format
+    return torch.rand_like(*args, **kwargs)
+
+def fake_randint_like(*args, **kwargs):
+    if 'memory_format' not in kwargs:
+        kwargs['memory_format'] = torch.contiguous_format
+    return torch.randint_like(*args, **kwargs)
+
+def fake_randn_like(*args, **kwargs):
+    if 'memory_format' not in kwargs:
+        kwargs['memory_format'] = torch.contiguous_format
+    return torch.randn_like(*args, **kwargs)
+
+def fake_ones_like(*args, **kwargs):
+    if 'memory_format' not in kwargs:
+        kwargs['memory_format'] = torch.contiguous_format
+    return torch.ones_like(*args, **kwargs)
+
+def fake_zeros_like(*args, **kwargs):
+    if 'memory_format' not in kwargs:
+        kwargs['memory_format'] = torch.contiguous_format
+    return torch.zeros_like(*args, **kwargs)
+
+def fake_full_like(*args, **kwargs):
+    if 'memory_format' not in kwargs:
+        kwargs['memory_format'] = torch.contiguous_format
+    return torch.full_like(*args, **kwargs)

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -12,6 +12,8 @@ from itertools import product
 from operator import mul
 from functools import reduce
 import torch
+from fake_operators import fake_empty_like, fake_rand_like, fake_randint_like, fake_randn_like, fake_ones_like, fake_zeros_like, fake_full_like
+
 
 # TODO: remove this global setting
 # Autograd tests use double as the default dtype
@@ -29,7 +31,6 @@ from common_utils import (TEST_MKL, TestCase, run_tests, skipIfNoLapack,
                           load_tests, random_symmetric_pd_matrix, random_symmetric_matrix, IS_WINDOWS, IS_MACOS)
 from torch.autograd import Variable, Function, detect_anomaly
 from torch.autograd.function import InplaceFunction
-from torch.testing import randn_like
 from common_methods_invocations import (method_tests,
                                         create_input, unpack_variables,
                                         EXCLUDE_FUNCTIONAL, EXCLUDE_GRADCHECK,
@@ -1028,7 +1029,7 @@ class TestAutograd(TestCase):
         b = torch.zeros(3, requires_grad=True)
         tensor = b + 0
         tensor[a != 0] = tensor[a != 0]
-        tensor.backward(torch.zeros_like(tensor))
+        tensor.backward(fake_zeros_like(tensor, memory_format=torch.preserve_format))
 
     def test_volatile_deprecated(self):
         v = torch.autograd.torch.randn(3, 3)
@@ -1162,7 +1163,7 @@ class TestAutograd(TestCase):
         b = torch.randn(5, 5, requires_grad=True)
 
         x = a * b
-        grad_output = torch.randn_like(x)
+        grad_output = fake_randn_like(x)
         torch.autograd.backward([x, x], [grad_output, grad_output])
 
         self.assertEqual(a.grad.data, b.data * grad_output * 2)
@@ -1404,7 +1405,7 @@ class TestAutograd(TestCase):
         expected_grad_input = torch.ones(*size)
         expected_grad_input[index] = 0
         self.assertEqual(x.grad, expected_grad_input)
-        self.assertEqual(value.grad, torch.ones_like(value))
+        self.assertEqual(value.grad, fake_ones_like(value))
 
         # case when x broadcasts to as y[1]
         x = torch.randn(4, requires_grad=True)
@@ -1478,7 +1479,7 @@ class TestAutograd(TestCase):
             outs = stacked.unbind()
             gi = grad.unbind()[i]
             g, = torch.autograd.grad(outs[i], stacked, gi)
-            g_expected = torch.stack([gi if j == i else torch.zeros_like(gi)
+            g_expected = torch.stack([gi if j == i else fake_zeros_like(gi)
                                       for j in range(3)], dim=0)
             self.assertEqual(g, g_expected)
 
@@ -1544,7 +1545,7 @@ class TestAutograd(TestCase):
         else:
             ind = torch.zeros(size_ind, dtype=torch.int64)
         out = torch.gather(x, dim, ind, sparse_grad=False)
-        grad = torch.rand_like(out)
+        grad = fake_rand_like(out)
         out.backward(grad)
         grad_dense = x.grad.clone()
         x.grad = None
@@ -1815,11 +1816,11 @@ class TestAutograd(TestCase):
     def _test_type_conversion_backward(self, t, ):
         fvar = Variable(t(torch.randn(5, 5).float()), requires_grad=True)
         fvar.double().sum().backward()
-        self.assertEqual(fvar.grad, torch.ones_like(fvar))
+        self.assertEqual(fvar.grad, fake_ones_like(fvar))
         self.assertEqual(type(fvar.grad.data), type(fvar.data))
         dvar = Variable(t(torch.randn(5, 5).double()), requires_grad=True)
         dvar.float().sum().backward()
-        self.assertEqual(dvar.grad, torch.ones_like(dvar))
+        self.assertEqual(dvar.grad, fake_ones_like(dvar))
         self.assertEqual(type(dvar.grad.data), type(dvar.data))
 
     def test_type_conversions(self):
@@ -2067,7 +2068,7 @@ class TestAutograd(TestCase):
         x = torch.randn(5, 5, requires_grad=True)
         y = MyFn.apply(x)
         y.sum().backward()
-        self.assertEqual(x.grad, torch.ones_like(x))
+        self.assertEqual(x.grad, fake_ones_like(x))
 
     def test_pickle(self):
         x = torch.randn(10, 10, requires_grad=True)
@@ -2990,7 +2991,7 @@ class TestAutograd(TestCase):
     def test_mul_out(self):
         a = torch.randn(2, 2, requires_grad=True)
         b = torch.randn(2, 2, requires_grad=True)
-        x = torch.zeros_like(a)
+        x = fake_zeros_like(a)
 
         # out=... functions don't support automatic differentiation currently
         self.assertRaisesRegex(RuntimeError, 'out=', lambda: torch.mul(a, b, out=x))
@@ -3063,14 +3064,14 @@ class TestAutograd(TestCase):
         A = torch.tensor([[1., 2.], [2., 4.]], dtype=torch.float32, requires_grad=True)
         w, v = torch.symeig(A, eigenvectors=False)
         with self.assertRaisesRegex(RuntimeError, 'cannot compute backward'):
-            torch.autograd.backward([w, v], [torch.ones_like(w), torch.ones_like(v)])
+            torch.autograd.backward([w, v], [fake_ones_like(w), fake_ones_like(v)])
 
     @skipIfNoLapack
     def test_svd_no_singularvectors(self):
         A = torch.randn(2, 2, dtype=torch.float32, requires_grad=True)
         u, s, v = torch.svd(A, compute_uv=False)
         with self.assertRaisesRegex(RuntimeError, 'cannot compute backward'):
-            torch.autograd.backward([u, s, v], [torch.ones_like(u), torch.ones_like(s), torch.ones_like(v)])
+            torch.autograd.backward([u, s, v], [fake_ones_like(u), fake_ones_like(s), fake_ones_like(v)])
 
     def test_no_grad_copy(self):
         # create autograd function that saves grad pointer as class static
@@ -3137,7 +3138,7 @@ class TestAutograd(TestCase):
 
             @staticmethod
             def backward(ctx, grad_out):
-                return NonDetFunc.apply(grad_out, ctx._jitter) * (1 + torch.rand_like(grad_out) * ctx._jitter), None
+                return NonDetFunc.apply(grad_out, ctx._jitter) * (1 + fake_rand_like(grad_out) * ctx._jitter), None
 
         inp = torch.randn(5, 5, requires_grad=True)
         gradcheck(lambda x: NonDetFunc.apply(x, 0.0), inp)
@@ -3383,7 +3384,7 @@ def run_functional_checks(test_case, test_name, name, apply_fn, run_grad_checks,
 
     self_variable = f_args_variable[0]
     if isinstance(output_variable, torch.Tensor) and output_variable.requires_grad and self_variable is not None:
-        output_variable.backward(randn_like(output_variable))
+        output_variable.backward(fake_randn_like(output_variable))
         test_case.assertEqual(self_variable.type(), self_variable.grad.type())
         test_case.assertEqual(self_variable.size(), self_variable.grad.size())
 
@@ -3464,9 +3465,9 @@ def add_test(
                         output_variable = getattr(torch, name)(*self_and_args_variable, **kwargs_variable)
                     if isinstance(output_variable, torch.autograd.Variable):
                         if output_variable.is_sparse:
-                            rand = randn_like(output_variable.to_dense()).to_sparse()
+                            rand = fake_randn_like(output_variable.to_dense()).to_sparse()
                         else:
-                            rand = randn_like(output_variable)
+                            rand = fake_randn_like(output_variable)
                         output_variable.backward(rand)
                         self.assertTrue(type(self_variable.data) == type(self_variable.grad.data))
                         self.assertTrue(self_variable.size() == self_variable.grad.size())
@@ -3504,7 +3505,7 @@ def add_test(
                             if i.grad is not None:
                                 i.grad.data.zero_()
                         for io, o in zip(inplace_output_variable, output_variable):
-                            grad = randn_like(io).double()
+                            grad = fake_randn_like(io).double()
                             io.backward(grad)
                             o.backward(grad)
                         for inp_i, i in zip((inplace_self_variable,) + inplace_args_variable,
@@ -3592,7 +3593,7 @@ class TestAutogradDeviceType(TestCase):
 
             # assert that _values is non-differentiable
             with self.assertRaisesRegex(RuntimeError, "does not have a grad_fn"):
-                other.detach().requires_grad_()._values().backward(torch.ones_like(other._values()))
+                other.detach().requires_grad_()._values().backward(fake_ones_like(other._values()))
 
         for empty_i, empty_v, empty_nnz in product([True, False], repeat=3):
             sparse_size = [] if empty_i else [2, 1]
@@ -3915,7 +3916,7 @@ class TestAutogradDeviceType(TestCase):
         # Tests half type on CUDA
         if self.device_type == 'cuda':
             x = x.to(dtype=torch.half, device=devices[0])
-            x.grad = torch.zeros_like(x)
+            x.grad = fake_zeros_like(x)
 
         # Tests cross-device assignment raises
         if len(devices) > 1:
@@ -3926,7 +3927,7 @@ class TestAutogradDeviceType(TestCase):
     @deviceCountAtLeast(1)
     @dtypes(torch.float, torch.double)
     def test_requires_grad_factory(self, devices, dtype):
-        fns = [torch.ones_like, torch.testing.randn_like]
+        fns = [fake_ones_like, fake_randn_like]
         x = torch.randn(2, 3, dtype=dtype, device=devices[0])
 
         for fn in fns:

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -760,10 +760,10 @@ class TestCuda(TestCase):
             torch.cuda.manual_seed(2)
             self.assertEqual(torch.cuda.initial_seed(), 2)
             x.uniform_()
-            a = torch.bernoulli(torch.full_like(x, 0.5))
+            a = torch.bernoulli(torch.full_like(x, 0.5, memory_format=torch.preserve_format))
             torch.cuda.manual_seed(2)
             y = x.clone().uniform_()
-            b = torch.bernoulli(torch.full_like(x, 0.5))
+            b = torch.bernoulli(torch.full_like(x, 0.5, memory_format=torch.preserve_format))
             self.assertEqual(x, y)
             self.assertEqual(a, b)
             self.assertEqual(torch.cuda.initial_seed(), 2)
@@ -1860,7 +1860,7 @@ class TestCuda(TestCase):
             output = MultiplyInStream.apply(x)
             output.sum().backward()
 
-        self.assertEqual(x.grad, torch.ones_like(x) * 2)
+        self.assertEqual(x.grad, torch.ones_like(x, memory_format=torch.preserve_format) * 2)
         self.assertEqual(torch.cuda.current_stream(), default_stream)
 
     def test_streaming_backwards_multiple_streams(self):
@@ -1895,7 +1895,7 @@ class TestCuda(TestCase):
             model = StreamModel().cuda()
             model(x).sum().backward()
 
-        self.assertEqual(x.grad, torch.ones_like(x) * 5)
+        self.assertEqual(x.grad, torch.ones_like(x, memory_format=torch.preserve_format) * 5)
 
     @unittest.skipIf(not TEST_MULTIGPU, "only one GPU detected")
     def test_cuda_init_race(self):

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -184,7 +184,7 @@ class TestIndexing(TestCase):
         for a in tensors:
             # prefix with a 1,1, to ensure we are compatible with numpy which cuts off prefix 1s
             # (some of these ops already prefix a 1 to the size)
-            neg_ones = torch.ones_like(a) * -1
+            neg_ones = torch.ones_like(a, memory_format=torch.preserve_format) * -1
             neg_ones_expanded = neg_ones.unsqueeze(0).unsqueeze(0)
             a[True] = neg_ones_expanded
             self.assertEqual(a, neg_ones)

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -40,6 +40,8 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch.quantization import QConfig
 from torch.quantization._quantize_script import ConvPackedParams, LinearPackedParams
+from fake_operators import fake_empty_like, fake_rand_like, fake_randint_like, fake_randn_like, fake_ones_like, fake_zeros_like, fake_full_like
+
 
 # Testing utils
 import jit_utils
@@ -395,7 +397,7 @@ class TestJit(JitTestCase):
                     if flag:
                         return x
                     else:
-                        return torch.zeros_like(x)
+                        return torch.zeros_like(x, memory_format=torch.contiguous_format)
                 x = torch.neg(x)
                 return make_decision(flag, x)
 
@@ -7145,10 +7147,10 @@ a")
         def test_copy_behavior(t, non_blocking=False):
             self.assertIs(t, s(t, 't.to(t, non_blocking=non_blocking)', non_blocking))
             self.assertIs(t, s(t, 't.to(t.dtype, non_blocking=non_blocking)', non_blocking))
-            self.assertIs(t, s(t, 't.to(torch.empty_like(t), non_blocking=non_blocking)', non_blocking))
+            self.assertIs(t, s(t, 't.to(torch.empty_like(t, memory_format=torch.contiguous_format), non_blocking=non_blocking)', non_blocking))
             self.assertIsNot(t, s(t, 't.to(t, non_blocking=non_blocking, copy=True)', non_blocking))
             self.assertIsNot(t, s(t, 't.to(t.dtype, non_blocking=non_blocking, copy=True)', non_blocking))
-            self.assertIsNot(t, s(t, 't.to(torch.empty_like(t), non_blocking=non_blocking, copy=True)', non_blocking))
+            self.assertIsNot(t, s(t, 't.to(torch.empty_like(t, memory_format=torch.contiguous_format), non_blocking=non_blocking, copy=True)', non_blocking))
 
             devices = [t.device]
             if t.device.type == 'cuda':
@@ -8073,9 +8075,9 @@ a")
             d = m2.sub2.a.mm(input)
             ref = a + b + m2.bias + m2.sub.weight + a + c + d
             self.assertEqual(ref, m2.forward(input))
-            m2.weight = nn.Parameter(torch.zeros_like(m2.weight))
-            m2.bias = nn.Parameter(torch.zeros_like(m2.bias))
-            m2.sub.weight = nn.Parameter(torch.zeros_like(m2.sub.weight))
+            m2.weight = nn.Parameter(fake_zeros_like(m2.weight))
+            m2.bias = nn.Parameter(fake_zeros_like(m2.bias))
+            m2.sub.weight = nn.Parameter(fake_zeros_like(m2.sub.weight))
             m2.sub2.a.data.zero_()
             self.assertEqual(torch.zeros(2, 2), m2.forward(torch.randn(3, 2)))
 
@@ -13225,7 +13227,7 @@ a")
             fb = FooBar()
             fb.linear1.weight = torch.nn.Parameter(
                 torch.tensor([[-150, 100], [100, -150]], dtype=torch.float), requires_grad=False)
-            fb.linear1.bias = torch.nn.Parameter(torch.zeros_like(fb.linear1.bias), requires_grad=False)
+            fb.linear1.bias = torch.nn.Parameter(fake_zeros_like(fb.linear1.bias), requires_grad=False)
 
             x = (torch.rand(1, K1).float() - 0.5) / 10.0
             value = torch.tensor([[100, -150]], dtype=torch.float)
@@ -15661,7 +15663,7 @@ a")
                   result = torch.to(torch.fill_(_1, 5), dtype=6, layout=0, device=torch.device("cpu"),
                                     non_blocking=False, copy=False)
                   result2 = torch.rand([10], dtype=6, layout=0, device=torch.device("cpu"))
-                  result3 = torch.rand_like(result2, dtype=6, layout=0, device=torch.device("cpu"))
+                  result3 = torch.rand_like(result2, dtype=6, layout=0, device=torch.device("cpu"), memory_format=1)
                   _2 = torch.add(torch.add(result, result2, alpha=1), result3, alpha=1)
                   return _2
                 ''',
@@ -17105,6 +17107,8 @@ for test in criterion_tests:
     add_nn_module_test(**test)
 
 if __name__ == '__main__':
+    # import os
+    # input(os.getpid())
     run_tests()
     if not PY2:
         import test_jit_py3

--- a/test/test_jit_fuser.py
+++ b/test/test_jit_fuser.py
@@ -781,7 +781,7 @@ class TestFuser(JitTestCase):
 
             @torch.jit.script_method
             def create(self, x):
-                return x * x + x + torch.rand_like(x)
+                return x * x + x + torch.rand_like(x, memory_format=torch.contiguous_format)
 
         x = torch.zeros([3, 4, 5], dtype=torch.float, device='cuda')
         m = M()
@@ -822,7 +822,7 @@ class TestFuser(JitTestCase):
     @unittest.skipIf(not RUN_CUDA, "fuser requires CUDA")
     def test_rand_broadcast_cuda(self):
         def fn_test_rand(x, y):
-            r = torch.rand_like(y)
+            r = torch.rand_like(y, memory_format=torch.contiguous_format)
             return r * x + x
 
         x = torch.randn(4, 4, dtype=torch.float, device='cuda')

--- a/test/test_namedtensor.py
+++ b/test/test_namedtensor.py
@@ -923,12 +923,12 @@ class TestNamedTensor(TestCase):
             method('narrow', 0, 0, 1),
 
             # creation functions
-            fn('empty_like'),
-            fn('zeros_like'),
-            fn('ones_like'),
-            fn('full_like', 3.14),
-            fn('rand_like'),
-            fn('randn_like'),
+            fn('empty_like', memory_format=torch.preserve_format),
+            fn('zeros_like', memory_format=torch.preserve_format),
+            fn('ones_like', memory_format=torch.preserve_format),
+            fn('full_like', 3.14, memory_format=torch.preserve_format),
+            fn('rand_like', memory_format=torch.preserve_format),
+            fn('randn_like', memory_format=torch.preserve_format),
 
             # bernoulli variants
             method('bernoulli_', 0.5),

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -38,6 +38,7 @@ from torch.autograd import gradcheck
 from torch.autograd.gradcheck import gradgradcheck
 from torch.nn import Parameter
 from torch.nn.parallel._functions import Broadcast
+from fake_operators import fake_empty_like, fake_rand_like, fake_randint_like, fake_randn_like, fake_ones_like, fake_zeros_like, fake_full_like
 from common_utils import freeze_rng_state, run_tests, TestCase, skipIfNoLapack, skipIfRocm, \
     TEST_NUMPY, TEST_SCIPY, download_file, PY3, to_gpu, \
     get_function_arglist, load_tests, repeat_test_for_types, ALL_TENSORTYPES, \
@@ -4013,7 +4014,7 @@ class TestNN(NNTestCase):
                 for size in sizes:
                     x = torch.randn(size, device="cuda", dtype=dtype)
                     out = conv(x.detach().clone().requires_grad_())
-                    out.backward(torch.ones_like(out))
+                    out.backward(fake_ones_like(out))
 
         run_test(benchmark=False)
         run_test(benchmark=True)
@@ -4364,7 +4365,7 @@ class TestNN(NNTestCase):
 
         res_cpu = torch.nn.functional.ctc_loss(log_probs, targets, input_lengths, target_lengths,
                                                reduction='sum', zero_infinity=True)
-        grad_out = torch.randn_like(res_cpu)
+        grad_out = fake_randn_like(res_cpu)
         grad_cpu, = torch.autograd.grad(res_cpu, log_probs, grad_out)
 
         with torch.backends.cudnn.flags(enabled=False):
@@ -6335,7 +6336,7 @@ class TestNN(NNTestCase):
         for N in range(1, 50, 10):
             input = torch.rand(N, 3, 1024, 1024)
             self.assertEqual(
-                torch.nn.L1Loss()(input, torch.zeros_like(input)),
+                torch.nn.L1Loss()(input, fake_zeros_like(input)),
                 input.abs().mean())
 
     def test_cosine_similarity(self):
@@ -6368,9 +6369,9 @@ class TestNN(NNTestCase):
 
         # Check dividing by 0.
         input1 = torch.randn(10).requires_grad_()
-        input2 = torch.zeros_like(input1).requires_grad_()
+        input2 = fake_zeros_like(input1).requires_grad_()
         torch.cosine_similarity(input1, input2, 0).sum().backward()
-        self.assertEqual(input1.grad, torch.zeros_like(input1))
+        self.assertEqual(input1.grad, fake_zeros_like(input1))
         self.assertEqual(input2.grad, input1 * 1e8)
 
     def test_grid_sample_error_checking(self):
@@ -6514,7 +6515,7 @@ class TestNN(NNTestCase):
                                             align_corners=align_corners)
                     self.assertTrue(out_cpu.size() == torch.Size([N, C, H, W]))
 
-                    gradients = torch.randn_like(out_cpu)
+                    gradients = fake_randn_like(out_cpu)
                     out_cpu.backward(gradients)
 
                     if TEST_CUDA:
@@ -6695,7 +6696,7 @@ class TestNN(NNTestCase):
                                         align_corners=align_corners)
                 self.assertTrue(out_cpu.size() == torch.Size([N, C, D, H, W]))
 
-                gradients = torch.randn_like(out_cpu)
+                gradients = fake_randn_like(out_cpu)
                 out_cpu.backward(gradients)
 
                 if TEST_CUDA:
@@ -7431,7 +7432,7 @@ class TestNN(NNTestCase):
             inputs = x, weight
 
         dummy_out = func(*inputs)
-        grad_y = torch.randn_like(dummy_out, device=device, dtype=dtype, requires_grad=True)
+        grad_y = fake_randn_like(dummy_out, device=device, dtype=dtype, requires_grad=True)
 
         # Issue #15353: test mkldnn double backward, don't run gradgradcheck due
         # to imprecision issues
@@ -8661,7 +8662,7 @@ class TestNNDeviceType(NNTestCase):
         self.assertAlmostEqual(torch.abs(var.data).mean(), 1, delta=1e-5)
 
         # check that eval mode doesn't change behavior
-        grad_out = torch.randn_like(output)
+        grad_out = fake_randn_like(output)
         res1 = output.data.clone()
         output.backward(grad_out)
         grad1 = input_var.grad.data.clone()
@@ -9224,7 +9225,7 @@ class TestNNDeviceType(NNTestCase):
         logits = logits.to(dtype).requires_grad_()
         probs = logits.softmax(dim=-1)
 
-        counts = torch.zeros_like(logits)
+        counts = fake_zeros_like(logits)
         for _ in range(num_draws):
             y_draw = F.gumbel_softmax(logits, hard=True)
             counts = counts + y_draw
@@ -9449,7 +9450,7 @@ class TestNNDeviceType(NNTestCase):
         outf = F.softmax(inputf, dim=-1)
         # should be bitwise equal
         self.assertEqual(out, outf, prec=0)
-        gO = torch.empty_like(outf).uniform_()
+        gO = fake_empty_like(outf).uniform_()
         out.backward(gO)
         outf.backward(gO)
         # should be bitwise equal
@@ -9498,17 +9499,17 @@ class TestNNDeviceType(NNTestCase):
             Embed.to(device)
 
             output = Embed(input=x, offsets=torch.tensor([0], device=device, dtype=torch.long))
-            self.assertEqual(output, torch.zeros_like(output))
+            self.assertEqual(output, fake_zeros_like(output))
 
             output = Embed(input=x, offsets=torch.tensor([0, 0], device=device, dtype=torch.long))
-            self.assertEqual(output, torch.zeros_like(output))
+            self.assertEqual(output, fake_zeros_like(output))
 
     def test_EmbeddingBag_per_sample_weights_failures(self, device):
         # Failure 1: mismatched embeddings / per_sample_weights dtype
         es = nn.EmbeddingBag(5, 2, mode='sum').to(dtype=torch.float, device=device)
         input = torch.tensor([3, 1, 1, 1, 4, 0], dtype=torch.long, device=device)
         offsets = torch.tensor([0, 0, 3, 3, 6], dtype=torch.long, device=device)
-        per_sample_weights = torch.randn_like(input, dtype=torch.double, device=device)
+        per_sample_weights = fake_randn_like(input, dtype=torch.double, device=device)
         if device == 'cpu':
             with self.assertRaisesRegex(RuntimeError, 'have the same type as'):
                 es(input, offsets, per_sample_weights)
@@ -9567,7 +9568,7 @@ class TestNNDeviceType(NNTestCase):
                 torch.arange(1, 11, device=device, dtype=dtype).view_as(es.weight))
             input = torch.tensor([3, 1, 1, 1, 4, 0], device=device, dtype=torch.long)
             offsets = torch.tensor([0, 0, 3, 3, 6], device=device, dtype=torch.long)
-            per_sample_weights = torch.randn_like(input, dtype=dtype) \
+            per_sample_weights = fake_randn_like(input, dtype=dtype) \
                                       .requires_grad_(trainable_scale)
             ref_per_sample_weights = \
                 per_sample_weights.detach().requires_grad_(trainable_scale)
@@ -9578,7 +9579,7 @@ class TestNNDeviceType(NNTestCase):
             result = es(input, offsets, per_sample_weights)
             self.assertEqual(result, expected, prec=dtype2prec[dtype])
 
-            grad = torch.randn_like(expected)
+            grad = fake_randn_like(expected)
             result.backward(grad)
             expected.backward(grad)
             self.assertEqual(es.weight.grad, reference_weights.grad,
@@ -9781,7 +9782,7 @@ class TestNNDeviceType(NNTestCase):
         dense_grad = es.weight.grad
         if dense_grad.is_sparse:
             dense_grad = dense_grad.to_dense()
-        self.assertEqual(dense_grad, torch.zeros_like(es.weight))
+        self.assertEqual(dense_grad, fake_zeros_like(es.weight))
 
         # now compare EmbeddingBag vs Embedding + Sum/Mean, for constant bag length
         N, D, B, L = random.randint(1, 100), random.randint(1, 100), random.randint(1, 50), random.randint(1, 50)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -38,6 +38,7 @@ from common_device_type import instantiate_device_type_tests, \
     skipCPUIfNoLapack, skipCUDAIfNoMagma, skipCUDAIfRocm, onlyCUDA, onlyCPU, \
     dtypes, dtypesIfCUDA, deviceCountAtLeast, skipCUDAIf, precisionOverride
 import torch.backends.quantized
+from fake_operators import fake_empty_like, fake_rand_like, fake_randint_like, fake_randn_like, fake_ones_like, fake_zeros_like, fake_full_like
 
 
 # load_tests from common_utils is used to automatically filter tests for
@@ -1015,12 +1016,12 @@ class _TestTorchMixin(object):
     def test_ones_like(self):
         expected = torch.ones(100, 100)
 
-        res1 = torch.ones_like(expected)
+        res1 = fake_ones_like(expected)
         self.assertEqual(res1, expected)
 
         # test boolean tensor
         expected = torch.tensor([True, True], dtype=torch.bool)
-        res1 = torch.ones_like(expected)
+        res1 = fake_ones_like(expected)
         self.assertEqual(res1, expected)
 
     def test_dtypes(self):
@@ -1136,10 +1137,10 @@ class _TestTorchMixin(object):
         def test_copy_behavior(t, non_blocking=False):
             self.assertIs(t, t.to(t, non_blocking=non_blocking))
             self.assertIs(t, t.to(t.dtype, non_blocking=non_blocking))
-            self.assertIs(t, t.to(torch.empty_like(t), non_blocking=non_blocking))
+            self.assertIs(t, t.to(fake_empty_like(t, memory_format=torch.contiguous_format), non_blocking=non_blocking))
             self.assertIsNot(t, t.to(t, non_blocking=non_blocking, copy=True))
             self.assertIsNot(t, t.to(t.dtype, non_blocking=non_blocking, copy=True))
-            self.assertIsNot(t, t.to(torch.empty_like(t), non_blocking=non_blocking, copy=True))
+            self.assertIsNot(t, t.to(fake_empty_like(t, memory_format=torch.contiguous_format), non_blocking=non_blocking, copy=True))
 
             devices = [t.device]
             if t.device.type == 'cuda':
@@ -1292,7 +1293,7 @@ class _TestTorchMixin(object):
         res2 = torch.tensor(expected)
         self.assertEqual(res2, expected)
         res2[1] = 2
-        self.assertEqual(expected, torch.ones_like(expected))
+        self.assertEqual(expected, fake_ones_like(expected))
 
         res2 = torch.tensor(expected, dtype=torch.int)
         self.assertEqual(res1, expected)
@@ -1388,7 +1389,7 @@ class _TestTorchMixin(object):
         res2 = expected.new_tensor(expected)
         self.assertEqual(res2, expected)
         res2[1] = 2
-        self.assertEqual(expected, torch.ones_like(expected))
+        self.assertEqual(expected, fake_ones_like(expected))
         res2 = expected.new_tensor(expected, dtype=torch.int)
         self.assertEqual(res2, expected)
         self.assertIs(torch.int, res2.dtype)
@@ -2161,7 +2162,7 @@ class _TestTorchMixin(object):
         mat2 = torch.randn(7, 7)
         q, r = torch.qr(mat1)
         m, tau = torch.geqrf(mat1)
-        out_holder = torch.empty_like(mat1)
+        out_holder = fake_empty_like(mat1, memory_format=torch.contiguous_format)
 
         res1 = torch.mm(q, mat2)
         res2 = torch.ormqr(m, tau, mat2, left=True, transpose=False)
@@ -2224,7 +2225,7 @@ class _TestTorchMixin(object):
                         for test_idx in test_idxs.tolist():
                             test_one_sample(flatten_batch_res[test_idx])
                     # compare with C2C
-                    xc = torch.stack([x, torch.zeros_like(x)], -1)
+                    xc = torch.stack([x, fake_zeros_like(x)], -1)
                     xc_res = xc.fft(signal_ndim, normalized=normalized)
                     self.assertEqual(res, xc_res)
                 test_input_signal_sizes = [signal_sizes]
@@ -3690,11 +3691,11 @@ class _TestTorchMixin(object):
         self.assertTrue(isBinary(p.bernoulli()))
 
         p = torch.rand(5, 5, dtype=p_dtype, device=device)
-        torch.bernoulli(torch.rand_like(p), out=p)
+        torch.bernoulli(fake_rand_like(p), out=p)
         self.assertTrue(isBinary(p))
 
         p = torch.rand(5, dtype=p_dtype, device=device).expand(5, 5)
-        torch.bernoulli(torch.rand_like(p), out=p)
+        torch.bernoulli(fake_rand_like(p), out=p)
         self.assertTrue(isBinary(p))
 
         t = torch.empty(10, 10, dtype=t_dtype, device=device)
@@ -3709,11 +3710,11 @@ class _TestTorchMixin(object):
         self.assertTrue(isBinary(t))
 
         t.fill_(2)
-        torch.bernoulli(torch.rand_like(t, dtype=p_dtype), out=t)
+        torch.bernoulli(fake_rand_like(t, dtype=p_dtype), out=t)
         self.assertTrue(isBinary(t))
 
         t.fill_(2)
-        t.bernoulli_(torch.rand_like(t, dtype=p_dtype))
+        t.bernoulli_(fake_rand_like(t, dtype=p_dtype))
         self.assertTrue(isBinary(t))
 
     def test_bernoulli(self):
@@ -4864,8 +4865,8 @@ tensor([[[1., 1., 1.,  ..., 1., 1., 1.],
         y = torch.autograd.Variable(torch.randn(4, 4))
         z = torch.autograd.Variable(torch.IntTensor([1, 2, 3]))
         for a in (x, y, z):
-            self.assertEqual(torch.empty_like(a).shape, a.shape)
-            self.assertEqual(torch.empty_like(a).type(), a.type())
+            self.assertEqual(fake_empty_like(a).shape, a.shape)
+            self.assertEqual(fake_empty_like(a).type(), a.type())
 
     def test_pin_memory(self):
         x = torch.randn(3, 5)
@@ -5911,7 +5912,7 @@ class TestTorchDeviceType(TestCase):
         if isinstance(inplace_op, str):
             inplace_op = getattr(torch.Tensor, inplace_op)
         input = torch.randn(1, dtype=dtype, device=device).expand(3, 3)
-        inputs = [input] + [torch.randn_like(input)
+        inputs = [input] + [fake_randn_like(input)
                             for i in range(num_inputs - 1)]
         if not expected_failure:
             with self.assertRaisesRegex(RuntimeError, 'single memory location'):
@@ -5925,7 +5926,7 @@ class TestTorchDeviceType(TestCase):
                                              expected_failure=False):
 
         def _test(op, output, input):
-            output_exp = torch.empty_like(output)
+            output_exp = fake_empty_like(output)
             op(input, out=output_exp)
             self.assertEqual(op(input, out=output), output_exp, op.__name__)
 
@@ -5990,7 +5991,7 @@ class TestTorchDeviceType(TestCase):
         except ValueError as e:
             err_msg = "Integers to negative integer powers are not allowed."
             self.assertEqual(str(e), err_msg)
-            out = torch.empty_like(base)
+            out = fake_empty_like(base)
             test_cases = [
                 lambda: base.pow(exponent),
                 lambda: base.pow_(exponent),
@@ -6814,7 +6815,7 @@ class TestTorchDeviceType(TestCase):
                     if scale > 0:
                         target = ref_M_sdet, ref_M_logabsdet + math.log(scale)
                     elif scale == 0:
-                        target = torch.zeros_like(ref_M_sdet), torch.full_like(ref_M_logabsdet, -inf)
+                        target = fake_zeros_like(ref_M_sdet), fake_full_like(ref_M_logabsdet, -inf)
                     else:
                         target = ref_M_sdet.neg(), ref_M_logabsdet + math.log(-scale)
 
@@ -6829,7 +6830,7 @@ class TestTorchDeviceType(TestCase):
 
             for x1, x2 in [(0, 3), (4, 1), (3, 2)]:
                 assert x1 != x2, 'x1 and x2 needs to be different for this test'
-                target = torch.zeros_like(ref_M_sdet), torch.full_like(ref_M_logabsdet, -inf)
+                target = fake_zeros_like(ref_M_sdet), fake_full_like(ref_M_logabsdet, -inf)
                 # dim 0
                 M_clone = M.clone()
                 M_clone[:, x2] = M_clone[:, x1]
@@ -6844,7 +6845,7 @@ class TestTorchDeviceType(TestCase):
                     if det_scale > 0:
                         target = ref_M_sdet, ref_M_logabsdet + math.log(det_scale)
                     elif det_scale == 0:
-                        target = torch.zeros_like(ref_M_sdet), torch.full_like(ref_M_logabsdet, -inf)
+                        target = fake_zeros_like(ref_M_sdet), fake_full_like(ref_M_logabsdet, -inf)
                     else:
                         target = ref_M_sdet.neg(), ref_M_logabsdet + math.log(-det_scale)
 
@@ -7653,7 +7654,7 @@ class TestTorchDeviceType(TestCase):
                             torch_result = maybe_squeeze_result(l, r, torch.matmul(l, r))
                             self.assertEqual(truth, torch_result)
                             # test torch.matmul with out
-                            out = torch.zeros_like(torch_result)
+                            out = fake_zeros_like(torch_result)
                             torch.matmul(l, r, out=out)
                             self.assertEqual(truth, maybe_squeeze_result(l, r, out))
 
@@ -8122,7 +8123,7 @@ class TestTorchDeviceType(TestCase):
             def assert_backward_eq(tensor, indexer):
                 cpu = tensor.float().clone().detach().requires_grad_(True)
                 outcpu = cpu[indexer]
-                gOcpu = torch.rand_like(outcpu)
+                gOcpu = fake_rand_like(outcpu)
                 outcpu.backward(gOcpu)
                 dev = cpu.to(device).detach().requires_grad_(True)
                 outdev = dev[indexer]
@@ -8393,7 +8394,7 @@ class TestTorchDeviceType(TestCase):
         b = torch.randn(*b_dims, dtype=dtype, device=device)
         A = random_fullrank_matrix_distinct_singular_value(*A_dims, dtype=dtype, device=device)
         LU_data, LU_pivots, info = torch.lu(A, get_infos=True, pivot=pivot)
-        self.assertEqual(info, torch.zeros_like(info))
+        self.assertEqual(info, fake_zeros_like(info))
         return b, A, LU_data, LU_pivots
 
     @skipCPUIfNoLapack
@@ -8432,7 +8433,7 @@ class TestTorchDeviceType(TestCase):
         b = torch.randn(3, 0, 3, dtype=dtype, device=device)
         A = torch.randn(3, 0, 0, dtype=dtype, device=device)
         LU_data, LU_pivots = torch.lu(A)
-        self.assertEqual(torch.empty_like(b), b.lu_solve(LU_data, LU_pivots))
+        self.assertEqual(fake_empty_like(b), b.lu_solve(LU_data, LU_pivots))
 
         sub_test(True)
         if self.device_type == 'cuda':
@@ -8690,8 +8691,8 @@ class TestTorchDeviceType(TestCase):
             else:
                 _, singvals, _ = torch.svd(x, compute_uv=True)
                 self.assertEqual(singvals, outs, 'Singular values mismatch')
-                self.assertEqual(outu, torch.zeros_like(outu), 'U not zero')
-                self.assertEqual(outv, torch.zeros_like(outv), 'V not zero')
+                self.assertEqual(outu, fake_zeros_like(outu), 'U not zero')
+                self.assertEqual(outv, fake_zeros_like(outv), 'V not zero')
 
             resu, ress, resv = torch.svd(x, some=some, compute_uv=compute_uv)
             self.assertEqual(resu, outu, 'outputs of svd and svd with out differ')
@@ -8717,8 +8718,8 @@ class TestTorchDeviceType(TestCase):
             else:
                 _, singvals, _ = torch.svd(x, compute_uv=True)
                 self.assertEqual(singvals, ress, 'Singular values mismatch')
-                self.assertEqual(resu, torch.zeros_like(resu), 'U not zero')
-                self.assertEqual(resv, torch.zeros_like(resv), 'V not zero')
+                self.assertEqual(resu, fake_zeros_like(resu), 'U not zero')
+                self.assertEqual(resv, fake_zeros_like(resv), 'V not zero')
 
         shapes = [(3, 3), (5, 3, 3), (7, 5, 3, 3),  # square matrices
                   (7, 3), (5, 7, 3), (7, 5, 7, 3),  # fat matrices
@@ -8917,7 +8918,7 @@ class TestTorchDeviceType(TestCase):
     def test_geqrf(self, device):
         a = torch.randn(5, 5, device=device)
         b, c = torch.geqrf(a)
-        b_placeholder, c_placeholder = torch.empty_like(b), torch.empty_like(c)
+        b_placeholder, c_placeholder = fake_empty_like(b), fake_empty_like(c)
         torch.geqrf(a, out=(b_placeholder, c_placeholder))
         self.assertEqual(b, b_placeholder)
         self.assertEqual(c, c_placeholder)
@@ -9371,7 +9372,7 @@ class TestTorchDeviceType(TestCase):
                       torch.tensor([0.8, 0.2], device=device),
                       torch.tensor([0.7, 0.2, 0.1], device=device)]:
             # Check how different the alias distribution and the original distribution are
-            alias_dist = torch.zeros_like(probs)
+            alias_dist = fake_zeros_like(probs)
             alias_table, prob_table = torch._multinomial_alias_setup(probs)
             alias_samples = torch._multinomial_alias_draw(prob_table, alias_table, MAX_SAMPLES)
             alias_dist = torch.unique(alias_samples, return_counts=True)[1].to(dtype=probs.dtype) / MAX_SAMPLES
@@ -9386,7 +9387,7 @@ class TestTorchDeviceType(TestCase):
             # Check the difference between the original probabilities and the reconstructed
             # probabilities from the alias and probability tables output by _multinomial_alias_setup
             alias_table, prob_table = torch._multinomial_alias_setup(probs)
-            actual = torch.zeros_like(probs)
+            actual = fake_zeros_like(probs)
             for i, vals in enumerate(zip(alias_table, prob_table)):
                 idx, p = vals
                 actual[i] += p
@@ -9610,7 +9611,7 @@ class TestTorchDeviceType(TestCase):
             self.assertEqual(a.sign(), a_target, 'sign device={} dtype={}'.format(device, dtype))
             self.assertEqual(torch.sign(a), a_target, 'sign device={} dtype={}'.format(device, dtype))
 
-            out = torch.empty_like(a)
+            out = fake_empty_like(a)
             torch.sign(a, out=out)
             self.assertEqual(out, a_target, 'sign_out device={} dtype={}'.format(device, dtype))
 
@@ -9623,7 +9624,7 @@ class TestTorchDeviceType(TestCase):
         self.assertEqual(a_bool.sign(), a_bool_target, 'sign device={} dtype=bool'.format(device))
         self.assertEqual(torch.sign(a_bool), a_bool_target, 'sign device={} dtype=bool'.format(device))
 
-        a_out = torch.empty_like(a_bool)
+        a_out = fake_empty_like(a_bool)
         torch.sign(a_bool, out=a_out)
         self.assertEqual(a_out, a_bool_target, 'sign_out device={} dtype=bool'.format(device))
 
@@ -10136,7 +10137,7 @@ class TestTorchDeviceType(TestCase):
     def test_zeros_like(self, device):
         expected = torch.zeros((100, 100,), device=device)
 
-        res1 = torch.zeros_like(expected)
+        res1 = fake_zeros_like(expected)
         self.assertEqual(res1, expected)
 
     def test_histc(self, device):
@@ -10375,21 +10376,21 @@ class TestTorchDeviceType(TestCase):
 
                 if (self.device_type == 'cuda' and dt == torch.bfloat16):
                     self.assertRaises(RuntimeError, lambda: torch.zeros(shape, device=device, dtype=dt).shape)
-                    self.assertRaises(RuntimeError, lambda: torch.zeros_like(torch.zeros(shape, device=device, dtype=dt)).shape)
+                    self.assertRaises(RuntimeError, lambda: fake_zeros_like(torch.zeros(shape, device=device, dtype=dt)).shape)
                     self.assertRaises(RuntimeError, lambda: torch.full(shape, 3, device=device, dtype=dt).shape)
-                    self.assertRaises(RuntimeError, lambda: torch.full_like(torch.zeros(shape, device=device, dtype=dt), 3))
+                    self.assertRaises(RuntimeError, lambda: fake_full_like(torch.zeros(shape, device=device, dtype=dt), 3))
                     self.assertRaises(RuntimeError, lambda: torch.ones(shape, device=device, dtype=dt).shape)
-                    self.assertRaises(RuntimeError, lambda: torch.ones_like(torch.zeros(shape, device=device, dtype=dt)).shape)
-                    self.assertRaises(RuntimeError, lambda: torch.empty_like(torch.zeros(shape, device=device, dtype=dt)).shape)
+                    self.assertRaises(RuntimeError, lambda: fake_ones_like(torch.zeros(shape, device=device, dtype=dt)).shape)
+                    self.assertRaises(RuntimeError, lambda: fake_empty_like(torch.zeros(shape, device=device, dtype=dt)).shape)
                 else:
                     self.assertEqual(shape, torch.zeros(shape, device=device, dtype=dt).shape)
-                    self.assertEqual(shape, torch.zeros_like(torch.zeros(shape, device=device, dtype=dt)).shape)
+                    self.assertEqual(shape, fake_zeros_like(torch.zeros(shape, device=device, dtype=dt)).shape)
                     self.assertEqual(shape, torch.full(shape, 3, device=device, dtype=dt).shape)
-                    self.assertEqual(shape, torch.full_like(torch.zeros(shape, device=device, dtype=dt), 3).shape)
+                    self.assertEqual(shape, fake_full_like(torch.zeros(shape, device=device, dtype=dt), 3).shape)
                     self.assertEqual(shape, torch.ones(shape, device=device, dtype=dt).shape)
-                    self.assertEqual(shape, torch.ones_like(torch.zeros(shape, device=device, dtype=dt)).shape)
+                    self.assertEqual(shape, fake_ones_like(torch.zeros(shape, device=device, dtype=dt)).shape)
                     self.assertEqual(shape, torch.empty(shape, device=device, dtype=dt).shape)
-                    self.assertEqual(shape, torch.empty_like(torch.zeros(shape, device=device, dtype=dt)).shape)
+                    self.assertEqual(shape, fake_empty_like(torch.zeros(shape, device=device, dtype=dt)).shape)
                     self.assertEqual(shape, torch.empty_strided(shape, (0,) * len(shape), device=device, dtype=dt).shape)
 
                 if dt == torch.half and device == "cpu":
@@ -10400,14 +10401,14 @@ class TestTorchDeviceType(TestCase):
                         self.assertRaises(RuntimeError, lambda: torch.randint(6, shape, device=device, dtype=dt))
                         continue  # Remove once random is supported for bfloat16 on cuda
                     self.assertEqual(shape, torch.randint(6, shape, device=device, dtype=dt).shape)
-                    self.assertEqual(shape, torch.randint_like(torch.zeros(shape, device=device, dtype=dt), 6).shape)
+                    self.assertEqual(shape, fake_randint_like(torch.zeros(shape, device=device, dtype=dt), 6).shape)
 
                 if dt != torch.double and dt != torch.float and dt != torch.half:
                     self.assertRaises(RuntimeError, lambda: torch.rand(shape, device=device, dtype=dt).shape)
 
                 if dt == torch.double or dt == torch.float:
                     self.assertEqual(shape, torch.randn(shape, device=device, dtype=dt).shape)
-                    self.assertEqual(shape, torch.randn_like(torch.zeros(shape, device=device, dtype=dt)).shape)
+                    self.assertEqual(shape, fake_randn_like(torch.zeros(shape, device=device, dtype=dt)).shape)
 
         self.assertEqual((0,), torch.arange(0, device=device).shape)
         self.assertEqual((0, 0), torch.eye(0, device=device).shape)
@@ -10717,7 +10718,7 @@ class TestTorchDeviceType(TestCase):
                             dst2 += [src[i]]
                     self.assertEqual(dst, torch.tensor(dst2), 0)
 
-                    dst3 = torch.empty_like(src, device=device)
+                    dst3 = fake_empty_like(src, device=device)
                     torch.masked_select(src, mask, out=dst3)
                     self.assertEqual(dst3, torch.Tensor(dst2), 0)
                     if maskType is torch.uint8:
@@ -10958,7 +10959,7 @@ class TestTorchDeviceType(TestCase):
                 k_ok = (k1 >= k0) | (j1 > j0) | (i1 > i0)
                 lex = torch.stack((i_ok, j_ok, k_ok), dim=1)
                 return lex
-            return torch.full_like(inds, 1)
+            return fake_full_like(inds, 1)
 
         def gen_nontrivial_input(num_src, dtype, device):
             while True:
@@ -10999,7 +11000,7 @@ class TestTorchDeviceType(TestCase):
                     for i in range(dst1.size(0)):
                         self.assertNotEqual(tensor[dst1[i, 0], dst1[i, 1], dst1[i, 2]].item(), 0)
                     lex = is_lexicographically_sorted(dst1)
-                    self.assertEqual(torch.ones_like(lex), lex)
+                    self.assertEqual(fake_ones_like(lex), lex)
                 if TEST_NUMPY:
                     tup1 = torch.nonzero(tensor, as_tuple=True)
                     tup2 = tensor.nonzero(as_tuple=True)
@@ -11964,8 +11965,8 @@ class TestTorchDeviceType(TestCase):
         torch.isnan(x)
 
         torch.empty((1, 3, 2), out=y)
-        torch.empty_like(x)
-        torch.empty_like(x, dtype=torch.int64)
+        fake_empty_like(x)
+        fake_empty_like(x, dtype=torch.int64)
 
         # to
         x.to(x)
@@ -12096,29 +12097,29 @@ class TestTorchDeviceType(TestCase):
         x = torch.randn(4, 3, 8, 8, device=device)
         nhwc = x.contiguous(memory_format=torch.channels_last)
 
-        like = torch.empty_like(nhwc, memory_format=torch.preserve_format)
+        like = fake_empty_like(nhwc, memory_format=torch.preserve_format)
         self.assertFalse(like.is_contiguous())
         self.assertTrue(like.is_contiguous(memory_format=torch.channels_last))
 
-        like_x = torch.empty_like(x, memory_format=torch.preserve_format)
+        like_x = fake_empty_like(x, memory_format=torch.preserve_format)
         self.assertTrue(like_x.is_contiguous())
         self.assertFalse(like_x.is_contiguous(memory_format=torch.channels_last))
 
-        like = torch.empty_like(x, memory_format=torch.channels_last)
+        like = fake_empty_like(x, memory_format=torch.channels_last)
         self.assertFalse(like.is_contiguous())
         self.assertTrue(like.is_contiguous(memory_format=torch.channels_last))
 
-        like = torch.empty_like(nhwc, memory_format=torch.contiguous_format)
+        like = fake_empty_like(nhwc, memory_format=torch.contiguous_format)
         self.assertTrue(like.is_contiguous())
         self.assertFalse(like.is_contiguous(memory_format=torch.channels_last))
 
-        like = torch.empty_like(nhwc)
+        like = fake_empty_like(nhwc)
         self.assertTrue(like.is_contiguous())
         self.assertFalse(like.is_contiguous(memory_format=torch.channels_last))
 
         sparse = x.to_sparse()
         with self.assertRaises(RuntimeError):
-            z = torch.empty_like(sparse, memory_format=torch.preserve_format)
+            z = fake_empty_like(sparse, memory_format=torch.preserve_format)
 
     def test_memory_format_consistency(self, device):
         x = torch.randn(10, 3, 1, 1, device=device)
@@ -12385,12 +12386,12 @@ class TestTorchDeviceType(TestCase):
     def test_pin_memory_from_constructor(self, device):
         def _get_like(t, **kwargs):
             return [
-                torch.rand_like(t, **kwargs),
-                torch.randn_like(t, **kwargs),
-                torch.empty_like(t, **kwargs),
-                torch.full_like(t, 4, **kwargs),
-                torch.zeros_like(t, **kwargs),
-                torch.ones_like(t, **kwargs),
+                fake_rand_like(t, **kwargs),
+                fake_randn_like(t, **kwargs),
+                fake_empty_like(t, **kwargs),
+                fake_full_like(t, 4, **kwargs),
+                fake_zeros_like(t, **kwargs),
+                fake_ones_like(t, **kwargs),
             ]
 
         def _get_tensors(**kwargs):
@@ -12748,7 +12749,7 @@ class TestTorchDeviceType(TestCase):
                 expected_tensor = torch.tensor([float(v) for v in expected],
                                                dtype=dtype, device=device)
                 self.assertEqual(expected_tensor == values_tensor.hardshrink(l),
-                                 torch.ones_like(values_tensor))
+                                 fake_ones_like(values_tensor))
 
         def test_helper(min, max):
             h([0.0, min, -min, 0.1, -0.1, 1.0, -1.0, max, -max, inf, -inf],
@@ -12932,14 +12933,14 @@ class TestTorchDeviceType(TestCase):
             return torch.randn((4, 3, 8, 8), device=device, dtype=torch.float32).contiguous(memory_format=torch.channels_last)
 
         transformation_fns = [
-            lambda t, **kwargs: torch.zeros_like(t, **kwargs),
-            lambda t, **kwargs: torch.ones_like(t, **kwargs),
-            lambda t, **kwargs: torch.randint_like(t, 10, 100, **kwargs),
-            lambda t, **kwargs: torch.randint_like(t, 100, **kwargs),
-            lambda t, **kwargs: torch.randn_like(t, **kwargs),
-            lambda t, **kwargs: torch.rand_like(t, **kwargs),
-            lambda t, **kwargs: torch.full_like(t, 7, **kwargs),
-            lambda t, **kwargs: torch.empty_like(t, **kwargs)]
+            lambda t, **kwargs: fake_zeros_like(t, **kwargs),
+            lambda t, **kwargs: fake_ones_like(t, **kwargs),
+            lambda t, **kwargs: fake_randint_like(t, 10, 100, **kwargs),
+            lambda t, **kwargs: fake_randint_like(t, 100, **kwargs),
+            lambda t, **kwargs: fake_randn_like(t, **kwargs),
+            lambda t, **kwargs: fake_rand_like(t, **kwargs),
+            lambda t, **kwargs: fake_full_like(t, 7, **kwargs),
+            lambda t, **kwargs: fake_empty_like(t, **kwargs)]
 
         for transformation_fn in transformation_fns:
             self._test_memory_format_transformations(device, input_generator_fn, transformation_fn, compare_data=False)
@@ -13973,20 +13974,20 @@ class TestDevicePrecision(TestCase):
     def test_zeros_like_multiple_device(self, devices):
         expected = torch.zeros(100, 100, device=devices[0])
         x = torch.randn(100, 100, device=devices[1], dtype=torch.float32)
-        output = torch.zeros_like(x)
+        output = fake_zeros_like(x)
         self.assertEqual(output, expected)
 
     def test_ones_like(self, device):
         expected = torch.ones(100, 100, device=device)
 
-        res1 = torch.ones_like(expected)
+        res1 = fake_ones_like(expected)
         self.assertEqual(res1, expected)
 
     @deviceCountAtLeast(2)
     def test_ones_like_multiple_device(self, devices):
         expected = torch.ones(100, 100, device=devices[0])
         x = torch.randn(100, 100, device=devices[1], dtype=torch.float32)
-        output = torch.ones_like(x)
+        output = fake_ones_like(x)
         self.assertEqual(output, expected)
 
 

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -182,14 +182,14 @@
   batch2: batch1.transpose(1, 2).bmm(grad) * alpha
 
 - name: bernoulli(Tensor self, *, Generator? generator=None) -> Tensor
-  self: zeros_like(grad)
+  self: zeros_like(grad, at::MemoryFormat::Preserve)
 
 - name: bernoulli_.Tensor(Tensor(a!) self, Tensor p, *, Generator? generator=None) -> Tensor(a!)
-  self: zeros_like(grad)
+  self: zeros_like(grad, at::MemoryFormat::Preserve)
   p: zeros_like(p)
 
 - name: bernoulli_.float(Tensor(a!) self, float p=0.5, *, Generator? generator=None) -> Tensor(a!)
-  self: zeros_like(grad)
+  self: zeros_like(grad, at::MemoryFormat::Preserve)
 
 - name: bmm(Tensor self, Tensor mat2) -> Tensor
   self: grad.bmm(mat2.transpose(1, 2))
@@ -199,10 +199,10 @@
   tensors: cat_tensors_backward(grad, to_args_sizes(tensors), dim)
 
 - name: cauchy_(Tensor(a!) self, float median=0, float sigma=1, *, Generator? generator=None) -> Tensor(a!)
-  self: zeros_like(grad)
+  self: zeros_like(grad, at::MemoryFormat::Preserve)
 
 - name: ceil(Tensor self) -> Tensor
-  self: zeros_like(grad)
+  self: zeros_like(grad, at::MemoryFormat::Preserve)
 
 - name: cholesky(Tensor self, bool upper=False) -> Tensor
   self: cholesky_backward(grad, upper, result)
@@ -323,7 +323,7 @@
   self: at::sum_to(grad, self.sizes())
 
 - name: exponential_(Tensor(a!) self, float lambd=1, *, Generator? generator=None) -> Tensor(a!)
-  self: zeros_like(grad)
+  self: zeros_like(grad, at::MemoryFormat::Preserve)
 
 - name: fake_quantize_per_tensor_affine(Tensor self, float scale, int zero_point, int quant_min, int quant_max) -> Tensor
   self: fake_quantize_per_tensor_affine_backward(grad, self, scale, zero_point, quant_min, quant_max)
@@ -332,14 +332,14 @@
   self: fake_quantize_per_channel_affine_backward(grad, self, scale, zero_point, axis, quant_min, quant_max)
 
 - name: fill_.Scalar(Tensor(a!) self, Scalar value) -> Tensor(a!)
-  self: zeros_like(grad)
+  self: zeros_like(grad, at::MemoryFormat::Preserve)
 
 - name: fill_.Tensor(Tensor(a!) self, Tensor value) -> Tensor(a!)
-  self: zeros_like(grad)
+  self: zeros_like(grad, at::MemoryFormat::Preserve)
   value: grad.sum()
 
 - name: floor(Tensor self) -> Tensor
-  self: zeros_like(grad)
+  self: zeros_like(grad, at::MemoryFormat::Preserve)
 
 - name: fmod.Scalar(Tensor self, Scalar other) -> Tensor
   self: grad
@@ -363,7 +363,7 @@
   other: zeros_like(other)
 
 - name: geometric_(Tensor(a!) self, float p, *, Generator? generator=None) -> Tensor(a!)
-  self: zeros_like(grad)
+  self: zeros_like(grad, at::MemoryFormat::Preserve)
 
 - name: geqrf(Tensor self) -> (Tensor a, Tensor tau)
   self: not_implemented("geqrf")
@@ -479,7 +479,7 @@
   self: logdet_backward(grad, self, result)
 
 - name: log_normal_(Tensor(a!) self, float mean=1, float std=2, *, Generator? generator=None) -> Tensor(a!)
-  self: zeros_like(grad)
+  self: zeros_like(grad, at::MemoryFormat::Preserve)
 
 - name: logsumexp(Tensor self, int[1] dim, bool keepdim=False) -> Tensor
   self: logsumexp_backward(grad, self, result, dim, keepdim)
@@ -507,7 +507,7 @@
 
 - name: masked_fill_.Tensor(Tensor(a!) self, Tensor mask, Tensor value) -> Tensor(a!)
   self: grad.clone().masked_fill_(mask, 0)
-  value: at::where(mask, grad, zeros_like(grad)).sum()
+  value: at::where(mask, grad, zeros_like(grad, at::MemoryFormat::Preserve)).sum()
   mask: non_differentiable
 
 - name: masked_scatter_(Tensor(a!) self, Tensor mask, Tensor source) -> Tensor(a!)
@@ -519,7 +519,7 @@
 # normally broadcasting is handled implicitly, but here, because we call an inplace
 # function as an optimization and the LHS doesn't broadcast for inplace functions,
 # we need to explicitly broadcast.
-  self: zeros_like(self.expand(at::infer_size(self.sizes(), mask.sizes()))).masked_scatter_(mask, grad)
+  self: zeros_like(self.expand(at::infer_size(self.sizes(), mask.sizes())), at::MemoryFormat::Preserve).masked_scatter_(mask, grad)
   mask: non_differentiable
 
 - name: max.dim(Tensor self, int dim, bool keepdim=False) -> (Tensor values, Tensor indices)
@@ -641,7 +641,7 @@
   cdist: not_implemented("_cdist_backward")
 
 - name: normal_(Tensor(a!) self, float mean=0, float std=1, *, Generator? generator=None) -> Tensor(a!)
-  self: zeros_like(grad)
+  self: zeros_like(grad, at::MemoryFormat::Preserve)
 
 - name: normal.Tensor_float(Tensor mean, float std=1, *, Generator? generator=None) -> Tensor
   mean: at::zeros(mean.sizes(), grad.options())
@@ -685,7 +685,7 @@
   self: prod_backward(grad, self.to(grad.scalar_type()), result, dim, keepdim)
 
 - name: put_(Tensor(a!) self, Tensor index, Tensor source, bool accumulate=False) -> Tensor(a!)
-  self: grad.clone().put_(index, zeros_like(source), accumulate)
+  self: grad.clone().put_(index, zeros_like(source, at::MemoryFormat::Preserve), accumulate)
   index: non_differentiable
   source: grad.take(index)
 
@@ -693,13 +693,13 @@
   self: qr_backward(grads, self, some, Q, R)
 
 - name: random_.from(Tensor(a!) self, int from, int to, *, Generator? generator=None) -> Tensor(a!)
-  self: zeros_like(grad)
+  self: zeros_like(grad, at::MemoryFormat::Preserve)
 
 - name: random_.to(Tensor(a!) self, int to, *, Generator? generator=None) -> Tensor(a!)
-  self: zeros_like(grad)
+  self: zeros_like(grad, at::MemoryFormat::Preserve)
 
 - name: random_(Tensor(a!) self, *, Generator? generator=None) -> Tensor(a!)
-  self: zeros_like(grad)
+  self: zeros_like(grad, at::MemoryFormat::Preserve)
 
 - name: real(Tensor self) -> Tensor
   self: grad.real()
@@ -727,7 +727,7 @@
 # - name: reshape(Tensor self, IntArrayRef shape)
 
 - name: round(Tensor self) -> Tensor
-  self: zeros_like(grad)
+  self: zeros_like(grad, at::MemoryFormat::Preserve)
 
 - name: rsqrt(Tensor self) -> Tensor
   self: -0.5 * grad * result.pow(3)
@@ -753,7 +753,7 @@
   self: sigmoid_backward(grad, result)
 
 - name: sign(Tensor self) -> Tensor
-  self: zeros_like(grad)
+  self: zeros_like(grad, at::MemoryFormat::Preserve)
 
 - name: sin(Tensor self) -> Tensor
   self: grad * self.cos()
@@ -877,7 +877,7 @@
   self: grad.triu(diagonal)
 
 - name: trunc(Tensor self) -> Tensor
-  self: zeros_like(grad)
+  self: zeros_like(grad, at::MemoryFormat::Preserve)
 
 - name: to_dense(Tensor self) -> Tensor
   self: to_dense_backward(grad, self)
@@ -892,7 +892,7 @@
   self: unfold_backward(grad, self.sizes(), dimension, size, step)
 
 - name: uniform_(Tensor(a!) self, float from=0, float to=1, *, Generator? generator=None) -> Tensor(a!)
-  self: zeros_like(grad)
+  self: zeros_like(grad, at::MemoryFormat::Preserve)
 
 - name: _unique(Tensor self, bool sorted=True, bool return_inverse=False) -> (Tensor, Tensor)
   self: not_implemented("_unique")
@@ -917,8 +917,8 @@
 
 - name: _s_where(Tensor condition, Tensor self, Tensor other) -> Tensor
   condition: non_differentiable
-  self: where(condition, grad, zeros_like(grad))
-  other: where(condition, zeros_like(grad), grad)
+  self: where(condition, grad, zeros_like(grad, at::MemoryFormat::Preserve))
+  other: where(condition, zeros_like(grad, at::MemoryFormat::Preserve), grad)
 
 # weight_norm_cuda_interface_backward does not have an explicitly defined derivative, so if we do happen
 # to be running backward with create_graph=True, fall back to a backward function that uses
@@ -927,7 +927,7 @@
   v, g: "GradMode::is_enabled() ? _weight_norm_differentiable_backward(grad.contiguous(), v, g, result1, dim) : _weight_norm_cuda_interface_backward(grad.contiguous(), v, g, result1, dim)"
 
 - name: zero_(Tensor(a!) self) -> Tensor(a!)
-  self: zeros_like(grad)
+  self: zeros_like(grad, at::MemoryFormat::Preserve)
 
 - name: sparse_mask(Tensor self, Tensor mask) -> Tensor
   self: grad.to_dense().sparse_mask(mask).to_dense()
@@ -1049,7 +1049,7 @@
 
 - name: hardshrink_backward(Tensor grad_out, Tensor self, Scalar lambd) -> Tensor
   grad_out: hardshrink_backward(grad, self, lambd)
-  self: zeros_like(grad)
+  self: zeros_like(grad, at::MemoryFormat::Preserve)
 
 - name: hardtanh(Tensor self, Scalar min_val=-1, Scalar max_val=1) -> Tensor
   self: hardtanh_backward(grad, self, min_val, max_val)
@@ -1271,16 +1271,16 @@
 
 - name: hardtanh_backward(Tensor grad_output, Tensor self, Scalar min_val, Scalar max_val) -> Tensor
   grad_output: hardtanh_backward(grad, self, min_val, max_val)
-  self: zeros_like(grad)
+  self: zeros_like(grad, at::MemoryFormat::Preserve)
 
 - name: kl_div_backward(Tensor grad_output, Tensor self, Tensor target, int reduction=Mean) -> Tensor
   grad_output: kl_div_double_backward_grad_output(grad, self, target, reduction)
-  self: zeros_like(grad)
-  target: zeros_like(grad)
+  self: zeros_like(grad, at::MemoryFormat::Preserve)
+  target: zeros_like(grad, at::MemoryFormat::Preserve)
 
 - name: l1_loss_backward(Tensor grad_output, Tensor self, Tensor target, int reduction) -> Tensor
   grad_output: l1_loss_double_backward_grad_output(grad, self, target, reduction)
-  self: zeros_like(grad)
+  self: zeros_like(grad, at::MemoryFormat::Preserve)
 
 - name: log_sigmoid_backward(Tensor grad_output, Tensor self, Tensor buffer) -> Tensor
   grad_output: log_sigmoid_backward(grad, self, buffer)
@@ -1292,7 +1292,7 @@
 
 - name: leaky_relu_backward(Tensor grad_output, Tensor self, Scalar negative_slope) -> Tensor
   grad_output: leaky_relu_backward(grad, self, negative_slope)
-  self: zeros_like(grad)
+  self: zeros_like(grad, at::MemoryFormat::Preserve)
 
 - name: max_pool2d_with_indices_backward(Tensor grad_output, Tensor self, int[2] kernel_size, int[2] stride, int[2] padding, int[2] dilation, bool ceil_mode, Tensor indices) -> Tensor
   grad_output: max_pool_double_backward(grad, indices, 2);
@@ -1315,17 +1315,17 @@
 
 - name: nll_loss_backward(Tensor grad_output, Tensor self, Tensor target, Tensor? weight, int reduction, int ignore_index, Tensor total_weight) -> Tensor
   grad_output: nll_loss(grad, target, weight, reduction, ignore_index)
-  self: zeros_like(grad)
+  self: zeros_like(grad, at::MemoryFormat::Preserve)
   target: non_differentiable
 
 - name: nll_loss2d_backward(Tensor grad_output, Tensor self, Tensor target, Tensor? weight, int reduction, int ignore_index, Tensor total_weight) -> Tensor
   grad_output: nll_loss2d(grad, target, weight, reduction, ignore_index)
-  self: zeros_like(grad)
+  self: zeros_like(grad, at::MemoryFormat::Preserve)
   target: non_differentiable
 
 - name: rrelu_with_noise_backward(Tensor grad_output, Tensor self, Tensor noise, Scalar lower, Scalar upper, bool training) -> Tensor
   grad_output: rrelu_with_noise_backward(grad, self, noise, lower, upper, training)
-  self: zeros_like(grad)
+  self: zeros_like(grad, at::MemoryFormat::Preserve)
 
 - name: reflection_pad1d_backward(Tensor grad_output, Tensor self, int[2] padding) -> Tensor
   grad_output: reflection_pad1d(grad, padding)
@@ -1365,11 +1365,11 @@
 
 - name: softshrink_backward(Tensor grad_output, Tensor self, Scalar lambd) -> Tensor
   grad_output: softshrink_backward(grad, self, lambd)
-  self: zeros_like(grad)
+  self: zeros_like(grad, at::MemoryFormat::Preserve)
 
 - name: threshold_backward(Tensor grad_output, Tensor self, Scalar threshold) -> Tensor
   grad_output: threshold_backward(grad, self, threshold)
-  self: zeros_like(grad)
+  self: zeros_like(grad, at::MemoryFormat::Preserve)
 
 - name: upsample_linear1d_backward(Tensor grad_output, int[1] output_size, int[3] input_size, bool align_corners) -> Tensor
   grad_output: upsample_linear1d(grad, output_size, align_corners)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #30081 [WIP] Modify default memory format
* **#30080 explicitly provide memory format when calling to *_like operators (derivatives)**
* #30008 explicitly provide memory format when calling to *_like operators
* #30007 explicitly provide memory format when calling to *_like operators
* #30006 explicitly provide memory format when calling to *_like operators (Redo of 81bf7364)
* #30005 explicitly provide memory format when calling to *_like operators (Redo of cc1c01)
* #30004 explicitly provide memory format when calling to *_like operators (Redo of e3e06549)
* #30003 explicitly provide memory format when calling to *_like operators (Redo of 4b4aa)
* #30002 explicitly provide memory format when calling to *_like operators (Redo of ce438f6967)
* #30001 explicitly provide memory format when calling to *_like operators (Redo of 631b22d)
* #30000 explicitly provide memory format when calling to *_like operators

