### PR TITLE
TestCppExtension now removes /tmp/torch_extensions folder .

### DIFF
--- a/test/test_cpp_extensions.py
+++ b/test/test_cpp_extensions.py
@@ -59,6 +59,15 @@ class TestCppExtension(common.TestCase):
         if os.path.exists(default_build_root):
             shutil.rmtree(default_build_root)
 
+    @classmethod
+    def tearDownClass(cls):
+        if sys.platform == "win32":
+            print("Not wiping extensions build folder because Windows")
+            return
+        default_build_root = torch.utils.cpp_extension.get_default_build_root()
+        if os.path.exists(default_build_root):
+            shutil.rmtree(default_build_root)
+
     def test_extension_function(self):
         x = torch.randn(4, 4)
         y = torch.randn(4, 4)


### PR DESCRIPTION
TestCppExtension class from `/test/test_cpp_extensions.py` now removes the `/tmp/torch_extensions` folder, so that it could be created/deleted by other users.

