### PR TITLE
fix device check in op bench

### DIFF
--- a/benchmarks/operator_benchmark/benchmark_core.py
+++ b/benchmarks/operator_benchmark/benchmark_core.py
@@ -343,7 +343,7 @@ class BenchmarkRunner(object):
                 (self.args.tag_filter == 'all' or
                     self._check_keep(op_test_config.tag, self.args.tag_filter)) and
                 (not self.args.forward_only or op_test_config.run_backward != self.args.forward_only) and
-                (self.args.device == 'None' or 'device' not in op_test_config.test_name or
+                (self.args.device == 'None' or 'device' not in test_case.test_config.input_config or
                     self.args.device in op_test_config.test_name)):
             return True
 


### PR DESCRIPTION
Summary: as title

Test Plan:
```
Before:
buck run mode/opt //caffe2/benchmarks/operator_benchmark/pt:unary_test -- --device cuda
# ----------------------------------------
# PyTorch/Caffe2 Operator Micro-benchmarks
# ----------------------------------------
# Tag : short

# Benchmarking PyTorch: abs
# Mode: Eager
# Name: abs_M512_N512_cpu
# Input: M: 512, N: 512, device: cpu
Forward Execution Time (us) : 91.190

# Benchmarking PyTorch: abs
# Mode: Eager
# Name: abs_M512_N512_cuda
# Input: M: 512, N: 512, device: cuda
Forward Execution Time (us) : 27.062

After:
# ----------------------------------------
# PyTorch/Caffe2 Operator Micro-benchmarks
# ----------------------------------------
# Tag : short

# Benchmarking PyTorch: abs
# Mode: Eager
# Name: abs_M512_N512_cuda
# Input: M: 512, N: 512, device: cuda
Forward Execution Time (us) : 28.154

# Benchmarking PyTorch: abs_
# Mode: Eager
# Name: abs__M512_N512_cuda
# Input: M: 512, N: 512, device: cuda
Forward Execution Time (us) : 15.959
...

Differential Revision: D18595176

