### PR TITLE
Resubmit #29747. "Add RpcAgentTestFixture to extract duplicate code"

### DIFF
--- a/test/dist_autograd_test.py
+++ b/test/dist_autograd_test.py
@@ -7,7 +7,9 @@ import torch
 import torch.distributed as dist
 import torch.distributed.autograd as dist_autograd
 import torch.distributed.rpc as rpc
-from dist_utils import INIT_METHOD_TEMPLATE, dist_init, TEST_CONFIG
+import dist_utils
+from dist_utils import dist_init
+from rpc_agent_test_fixture import RpcAgentTestFixture
 
 import threading
 
@@ -159,7 +161,7 @@ class ExecMode(Enum):
 @unittest.skipIf(
     not torch._six.PY3, "Pytorch distributed autograd package " "does not support python2"
 )
-class DistAutogradTest(object):
+class DistAutogradTest(RpcAgentTestFixture):
 
     def _initialize_pg(self):
         # This is for tests using `dist.barrier`.
@@ -199,14 +201,6 @@ class DistAutogradTest(object):
 
     def _check_rpc_done(self, rank_distance):
         _check_rpc_done(rank_distance)
-
-    @property
-    def world_size(self):
-        return 4
-
-    @property
-    def init_method(self):
-        return INIT_METHOD_TEMPLATE.format(file_name=self.file_name)
 
     @dist_init
     def test_autograd_context(self):
@@ -1055,7 +1049,7 @@ class DistAutogradTest(object):
                 # Run backwards, and validate we receive an error.
                 dist_autograd.backward([val.sum()])
 
-    @unittest.skipIf(TEST_CONFIG.rpc_backend_name == "PROCESS_GROUP",
+    @unittest.skipIf(dist_utils.TEST_CONFIG.rpc_backend_name == "PROCESS_GROUP",
                      "Skipping this test temporarily since ProcessGroupAgent does not report errors on node failures")
     @dist_init(clean_shutdown=False)
     def test_backward_node_failure(self):
@@ -1226,7 +1220,7 @@ class DistAutogradTest(object):
         while not DistAutogradTest._backward_done:
             time.sleep(0.1)
 
-    @unittest.skipIf(TEST_CONFIG.rpc_backend_name == "PROCESS_GROUP",
+    @unittest.skipIf(dist_utils.TEST_CONFIG.rpc_backend_name == "PROCESS_GROUP",
                      "Skipping this test temporarily since ProcessGroupAgent " +
                      "does not report errors on node failures")
     @dist_init(clean_shutdown=False)

--- a/test/dist_optimizer_test.py
+++ b/test/dist_optimizer_test.py
@@ -2,13 +2,14 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import unittest
 
-from dist_utils import INIT_METHOD_TEMPLATE, dist_init
+from dist_utils import dist_init
 from torch import optim
 from torch.distributed.optim import DistributedOptimizer
 import torch
 import torch.distributed.autograd as dist_autograd
 import torch.distributed.rpc as rpc
 import threading
+from rpc_agent_test_fixture import RpcAgentTestFixture
 
 
 class MyModule:
@@ -83,17 +84,7 @@ def rpc_async_method(method, obj_rref, *args, **kwargs):
 @unittest.skipIf(
     not torch._six.PY3, "Pytorch distributed optim does not support python2"
 )
-class DistOptimizerTest(object):
-
-    @property
-    def world_size(self):
-        return 4
-
-    @property
-    def init_method(self):
-        return INIT_METHOD_TEMPLATE.format(
-            file_name=self.file_name, rank=self.rank, world_size=self.world_size
-        )
+class DistOptimizerTest(RpcAgentTestFixture):
 
     @dist_init()
     def test_dist_optim_exception(self):

--- a/test/dist_utils.py
+++ b/test/dist_utils.py
@@ -85,7 +85,7 @@ def dist_init(old_test_method=None, setup_rpc=True, clean_shutdown=True):
             # Use enough 'num_send_recv_threads' until we fix https://github.com/pytorch/pytorch/issues/26359
             rpc.init_rpc(
                 self_name="worker%d" % self.rank,
-                backend=rpc.backend_registry.BackendType[TEST_CONFIG.rpc_backend_name],
+                backend=self.rpc_backend,
                 init_method=self.init_method,
                 self_rank=self.rank,
                 worker_name_to_id=self.worker_name_to_id,

--- a/test/rpc_agent_test_fixture.py
+++ b/test/rpc_agent_test_fixture.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+
+import dist_utils
+import torch.distributed.rpc as rpc
+
+
+class RpcAgentTestFixture(object):
+    @property
+    def world_size(self):
+        return 4
+
+    @property
+    def init_method(self):
+        return dist_utils.INIT_METHOD_TEMPLATE.format(file_name=self.file_name)
+
+    @property
+    def rpc_backend(self):
+        return rpc.backend_registry.BackendType[dist_utils.TEST_CONFIG.rpc_backend_name]
+
+    @property
+    def rpc_agent_options(self):
+        return dist_utils.TEST_CONFIG.build_rpc_agent_options(self)

--- a/test/rpc_test.py
+++ b/test/rpc_test.py
@@ -12,14 +12,16 @@ import torch.distributed as dist
 import torch.distributed.rpc as rpc
 from torch.distributed.rpc import RRef
 from common_utils import load_tests
-from dist_utils import INIT_METHOD_TEMPLATE, TEST_CONFIG, dist_init
+import dist_utils
+from dist_utils import dist_init
 from torch.distributed.rpc.internal import PythonUDF, _internal_rpc_pickler
+from rpc_agent_test_fixture import RpcAgentTestFixture
 
 
 def requires_process_group_agent(message=""):
     def decorator(old_func):
         return unittest.skipUnless(
-            TEST_CONFIG.rpc_backend_name == "PROCESS_GROUP", message
+            dist_utils.TEST_CONFIG.rpc_backend_name == "PROCESS_GROUP", message
         )(old_func)
 
     return decorator
@@ -210,15 +212,7 @@ load_tests = load_tests
     sys.version_info < (3, 0),
     "Pytorch distributed rpc package " "does not support python2",
 )
-class RpcTest(object):
-    @property
-    def world_size(self):
-        return 4
-
-    @property
-    def init_method(self):
-        return INIT_METHOD_TEMPLATE.format(file_name=self.file_name)
-
+class RpcTest(RpcAgentTestFixture):
     @dist_init
     def test_worker_id(self):
         n = self.rank + 1
@@ -314,7 +308,7 @@ class RpcTest(object):
                 self.init_method, rank=self.rank, world_size=self.world_size
             ))
             rpc._init_rpc_backend(
-                backend=rpc.backend_registry.BackendType[TEST_CONFIG.rpc_backend_name],
+                backend=self.rpc_backend,
                 store=store,
                 self_name="duplicate_name",
                 self_rank=self.rank,
@@ -326,7 +320,7 @@ class RpcTest(object):
     def test_reinit(self):
         rpc.init_rpc(
             self_name="worker{}".format(self.rank),
-            backend=rpc.backend_registry.BackendType[TEST_CONFIG.rpc_backend_name],
+            backend=self.rpc_backend,
             init_method=self.init_method,
             self_rank=self.rank,
             worker_name_to_id=self.worker_name_to_id,
@@ -348,7 +342,7 @@ class RpcTest(object):
         with self.assertRaisesRegex(RuntimeError, "is already initialized"):
             rpc.init_rpc(
                 self_name="worker{}".format(self.rank),
-                backend=rpc.backend_registry.BackendType[TEST_CONFIG.rpc_backend_name],
+                backend=self.rpc_backend,
                 init_method=self.init_method,
                 self_rank=self.rank,
                 worker_name_to_id=self.worker_name_to_id,
@@ -362,7 +356,7 @@ class RpcTest(object):
                 self.init_method, rank=self.rank, world_size=self.world_size
             ))
             rpc._init_rpc_backend(
-                backend=rpc.backend_registry.BackendType[TEST_CONFIG.rpc_backend_name],
+                backend=self.rpc_backend,
                 store=store,
                 self_name="abc*",
                 self_rank=self.rank,
@@ -379,7 +373,7 @@ class RpcTest(object):
                 self.init_method, rank=self.rank, world_size=self.world_size
             ))
             rpc._init_rpc_backend(
-                backend=rpc.backend_registry.BackendType[TEST_CONFIG.rpc_backend_name],
+                backend=self.rpc_backend,
                 store=store,
                 self_name=" ",
                 self_rank=self.rank,
@@ -394,7 +388,7 @@ class RpcTest(object):
                 self.init_method, rank=self.rank, world_size=self.world_size
             ))
             rpc._init_rpc_backend(
-                backend=rpc.backend_registry.BackendType[TEST_CONFIG.rpc_backend_name],
+                backend=self.rpc_backend,
                 store=store,
                 self_name="",
                 self_rank=self.rank,
@@ -411,7 +405,7 @@ class RpcTest(object):
                 self.init_method, rank=self.rank, world_size=self.world_size
             ))
             rpc._init_rpc_backend(
-                backend=rpc.backend_registry.BackendType[TEST_CONFIG.rpc_backend_name],
+                backend=self.rpc_backend,
                 store=store,
                 self_name="".join(["a" for i in range(500)]),
                 self_rank=self.rank,
@@ -503,7 +497,7 @@ class RpcTest(object):
         # Initialize RPC.
         rpc.init_rpc(
             self_name="worker%d" % self.rank,
-            backend=rpc.backend_registry.BackendType[TEST_CONFIG.rpc_backend_name],
+            backend=self.rpc_backend,
             init_method=self.init_method,
             self_rank=self.rank,
             worker_name_to_id=self.worker_name_to_id,
@@ -1084,7 +1078,7 @@ class RpcTest(object):
         timeout = timedelta(seconds=1)
         rpc.init_rpc(
             self_name="worker{}".format(self.rank),
-            backend=rpc.backend_registry.BackendType[TEST_CONFIG.rpc_backend_name],
+            backend=self.rpc_backend,
             init_method=self.init_method,
             self_rank=self.rank,
             worker_name_to_id=self.worker_name_to_id,
@@ -1129,7 +1123,7 @@ class RpcTest(object):
         def test_func():
             return "expected result"
 
-        if TEST_CONFIG.rpc_backend_name == "PROCESS_GROUP":
+        if dist_utils.TEST_CONFIG.rpc_backend_name == "PROCESS_GROUP":
             self.assertEqual(test_func(), "expected result")
 
     def test_dist_init_decorator(self):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #30093 Resubmit "Add `RpcAgentOptions` struct type, which bundles different required arguments for different `RpcAgent`s"
* **#30092 Resubmit "Add RpcAgentTestFixture to extract duplicate code"**

There are duplicate code for component that rely on RpcAgent. Extract them into a re-usable test fixture class.

Differential Revision: [D18595408](https://our.internmc.facebook.com/intern/diff/D18595408/)