### PR TITLE
Resubmit #29747. "Add `RpcAgentOptions` struct type, which bundles different required arguments for different `RpcAgent`s"

### DIFF
--- a/test/rpc_test.py
+++ b/test/rpc_test.py
@@ -30,8 +30,14 @@ def requires_process_group_agent(message=""):
 VALUE_FUTURE = concurrent.futures.Future()
 
 
-def stub_start_rpc_backend_handler(
-    store, self_name, self_rank, worker_name_to_id, *args, **kwargs
+def _stub_construct_rpc_agent_options_handler(
+    **kwargs
+):
+    return mock.Mock()  # RpcAgentOptions.
+
+
+def _stub_start_rpc_backend_handler(
+    store, name, rank, world_size, rpc_agent_options
 ):
     return mock.Mock()  # RpcAgent.
 
@@ -282,22 +288,27 @@ class RpcTest(RpcAgentTestFixture):
         backend_name = "stub_backend"
 
         backend = rpc.backend_registry.register_backend(
-            backend_name, stub_start_rpc_backend_handler
+            backend_name,
+            _stub_construct_rpc_agent_options_handler,
+            _stub_start_rpc_backend_handler,
         )
 
         with self.assertRaisesRegex(
             RuntimeError, "^RPC backend .+: already registered$"
         ):
-            rpc.backend_registry.register_backend(
-                backend_name, stub_start_rpc_backend_handler
+            backend = rpc.backend_registry.register_backend(
+                backend_name,
+                _stub_construct_rpc_agent_options_handler,
+                _stub_start_rpc_backend_handler,
             )
 
         rpc.init_rpc(
-            self_name="worker1",
+            name="worker1",
             backend=backend,
             init_method=self.init_method,
-            self_rank=self.rank,
-            worker_name_to_id=self.worker_name_to_id,
+            rank=self.rank,
+            world_size=self.world_size,
+            rpc_agent_options=self.rpc_agent_options,
         )
 
     @requires_process_group_agent("PROCESS_GROUP rpc backend specific test, skip")
@@ -310,20 +321,22 @@ class RpcTest(RpcAgentTestFixture):
             rpc._init_rpc_backend(
                 backend=self.rpc_backend,
                 store=store,
-                self_name="duplicate_name",
-                self_rank=self.rank,
-                worker_name_to_id=self.worker_name_to_id,
+                name="duplicate_name",
+                rank=self.rank,
+                world_size=self.world_size,
+                rpc_agent_options=self.rpc_agent_options,
             )
         rpc.join_rpc()
 
     @dist_init(setup_rpc=False)
     def test_reinit(self):
         rpc.init_rpc(
-            self_name="worker{}".format(self.rank),
+            name="worker{}".format(self.rank),
             backend=self.rpc_backend,
             init_method=self.init_method,
-            self_rank=self.rank,
-            worker_name_to_id=self.worker_name_to_id,
+            rank=self.rank,
+            world_size=self.world_size,
+            rpc_agent_options=self.rpc_agent_options,
         )
 
         # This is for the below `dist.barrier`.
@@ -341,11 +354,12 @@ class RpcTest(RpcAgentTestFixture):
 
         with self.assertRaisesRegex(RuntimeError, "is already initialized"):
             rpc.init_rpc(
-                self_name="worker{}".format(self.rank),
+                name="worker{}".format(self.rank),
                 backend=self.rpc_backend,
                 init_method=self.init_method,
-                self_rank=self.rank,
-                worker_name_to_id=self.worker_name_to_id,
+                rank=self.rank,
+                world_size=self.world_size,
+                rpc_agent_options=self.rpc_agent_options,
             )
         rpc.join_rpc()
 
@@ -358,10 +372,10 @@ class RpcTest(RpcAgentTestFixture):
             rpc._init_rpc_backend(
                 backend=self.rpc_backend,
                 store=store,
-                self_name="abc*",
-                self_rank=self.rank,
-                worker_name_to_id=self.worker_name_to_id,
-                num_send_recv_threads=16,
+                name="abc*",
+                rank=self.rank,
+                world_size=self.world_size,
+                rpc_agent_options=self.rpc_agent_options,
             )
 
         base_file_name = self.file_name
@@ -375,10 +389,10 @@ class RpcTest(RpcAgentTestFixture):
             rpc._init_rpc_backend(
                 backend=self.rpc_backend,
                 store=store,
-                self_name=" ",
-                self_rank=self.rank,
-                worker_name_to_id=self.worker_name_to_id,
-                num_send_recv_threads=16,
+                name=" ",
+                rank=self.rank,
+                world_size=self.world_size,
+                rpc_agent_options=self.rpc_agent_options,
             )
 
         # Use a different file path for FileStore to avoid rendezvous mismatch.
@@ -390,10 +404,10 @@ class RpcTest(RpcAgentTestFixture):
             rpc._init_rpc_backend(
                 backend=self.rpc_backend,
                 store=store,
-                self_name="",
-                self_rank=self.rank,
-                worker_name_to_id=self.worker_name_to_id,
-                num_send_recv_threads=16,
+                name="",
+                rank=self.rank,
+                world_size=self.world_size,
+                rpc_agent_options=self.rpc_agent_options,
             )
 
         # Use a different file path for FileStore to avoid rendezvous mismatch.
@@ -407,10 +421,10 @@ class RpcTest(RpcAgentTestFixture):
             rpc._init_rpc_backend(
                 backend=self.rpc_backend,
                 store=store,
-                self_name="".join(["a" for i in range(500)]),
-                self_rank=self.rank,
-                worker_name_to_id=self.worker_name_to_id,
-                num_send_recv_threads=16,
+                name="".join(["a" for i in range(500)]),
+                rank=self.rank,
+                world_size=self.world_size,
+                rpc_agent_options=self.rpc_agent_options,
             )
 
         from torch.distributed.rpc.api import _agent
@@ -496,11 +510,12 @@ class RpcTest(RpcAgentTestFixture):
     def test_join_rpc(self):
         # Initialize RPC.
         rpc.init_rpc(
-            self_name="worker%d" % self.rank,
+            name="worker%d" % self.rank,
             backend=self.rpc_backend,
             init_method=self.init_method,
-            self_rank=self.rank,
-            worker_name_to_id=self.worker_name_to_id,
+            rank=self.rank,
+            world_size=self.world_size,
+            rpc_agent_options=self.rpc_agent_options,
         )
 
         n = self.rank + 1
@@ -1076,13 +1091,19 @@ class RpcTest(RpcAgentTestFixture):
     @dist_init(setup_rpc=False)
     def test_get_rpc_timeout(self):
         timeout = timedelta(seconds=1)
+
+        # A new `RpcAgentOptions` is constructed
+        # when accessing `self.rpc_agent_options`.
+        rpc_agent_options = self.rpc_agent_options
+        rpc_agent_options.rpc_timeout = timeout
+
         rpc.init_rpc(
-            self_name="worker{}".format(self.rank),
+            name="worker{}".format(self.rank),
             backend=self.rpc_backend,
             init_method=self.init_method,
-            self_rank=self.rank,
-            worker_name_to_id=self.worker_name_to_id,
-            rpc_timeout=timeout
+            rank=self.rank,
+            world_size=self.world_size,
+            rpc_agent_options=rpc_agent_options,
         )
         set_timeout = rpc.get_rpc_timeout()
         self.assertEqual(timeout, set_timeout)

--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -34,6 +34,10 @@ PyObject* rpc_init(PyObject* /* unused */) {
 
   auto module = py::handle(rpc_module).cast<py::module>();
 
+  auto rpcAgentOptions =
+      shared_ptr_class_<RpcAgentOptions>(module, "RpcAgentOptions")
+          .def_readwrite("rpc_timeout", &RpcAgentOptions::rpcTimeout);
+
   auto workerInfo =
       shared_ptr_class_<WorkerInfo>(module, "WorkerInfo")
           .def_readonly("name", &WorkerInfo::name_)
@@ -97,6 +101,13 @@ PyObject* rpc_init(PyObject* /* unused */) {
               "wait",
               [&](FutureMessage& fut) { return toPyObj(fut.wait()); },
               py::call_guard<py::gil_scoped_release>());
+
+  shared_ptr_class_<ProcessGroupRpcAgentOptions>(
+      module, "ProcessGroupRpcAgentOptions", rpcAgentOptions)
+      .def(py::init<>())
+      .def_readwrite(
+          "num_send_recv_threads",
+          &ProcessGroupRpcAgentOptions::numSendRecvThreads);
 
   shared_ptr_class_<ProcessGroupAgent>(module, "ProcessGroupAgent", rpcAgent)
       .def(

--- a/torch/csrc/distributed/rpc/process_group_agent.h
+++ b/torch/csrc/distributed/rpc/process_group_agent.h
@@ -13,6 +13,11 @@ namespace torch {
 namespace distributed {
 namespace rpc {
 
+struct ProcessGroupRpcAgentOptions : public RpcAgentOptions {
+  ProcessGroupRpcAgentOptions() noexcept = default;
+  int numSendRecvThreads;
+};
+
 // SendWork and RecvWork will be put into a task queue, and later picked up by
 // worker threads from the same ThreadPool.
 struct SendWork {

--- a/torch/csrc/distributed/rpc/rpc_agent.h
+++ b/torch/csrc/distributed/rpc/rpc_agent.h
@@ -12,6 +12,11 @@ namespace torch {
 namespace distributed {
 namespace rpc {
 
+struct RpcAgentOptions {
+  RpcAgentOptions() noexcept = default;
+  std::chrono::milliseconds rpcTimeout;
+};
+
 // A globally unique ID to identify an RpcAgent
 struct TORCH_API WorkerInfo {
   WorkerInfo(std::string name, int id)

--- a/torch/distributed/rendezvous.py
+++ b/torch/distributed/rendezvous.py
@@ -3,6 +3,8 @@ try:
 except ImportError:
     from urlparse import urlparse
 
+import torch._six as six
+import numbers
 import os
 from . import FileStore, TCPStore
 
@@ -42,6 +44,15 @@ def register_rendezvous_handler(scheme, handler):
 
 
 def rendezvous(url, rank=-1, world_size=-1, **kwargs):
+    if not isinstance(url, six.string_classes):
+        raise RuntimeError("`url` must be a string. {}: {}".format(type(url), url))
+
+    if not isinstance(rank, numbers.Integral):
+        raise RuntimeError("`rank` must be an integer. {}".format(rank))
+
+    if not isinstance(world_size, numbers.Integral):
+        raise RuntimeError("`world_size` must be an integer. {}".format(world_size))
+
     # Append node-specific arguments.
     if rank != -1 or world_size != -1:
         assert (

--- a/torch/distributed/rpc/__init__.py
+++ b/torch/distributed/rpc/__init__.py
@@ -1,11 +1,12 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import numbers
 import sys
-import torch
 
+import torch
+import torch.distributed as dist
 
 from . import backend_registry
-from .constants import DEFAULT_RPC_TIMEOUT, DEFAULT_NUM_SEND_RECV_THREADS
 
 
 def is_available():
@@ -22,13 +23,12 @@ if is_available():
     import torch.distributed.autograd
 
     def init_rpc(
-        self_name,
+        name,
         backend=backend_registry.BackendType.PROCESS_GROUP,
         init_method=None,
-        self_rank=-1,
-        worker_name_to_id=None,
-        num_send_recv_threads=DEFAULT_NUM_SEND_RECV_THREADS,
-        rpc_timeout=DEFAULT_RPC_TIMEOUT,
+        rank=-1,
+        world_size=None,
+        rpc_agent_options=None,
     ):
         r"""
         Initializes RPC primitives such as the local RPC agent
@@ -45,21 +45,20 @@ if is_available():
                         Currently, process group backend is the only
                         available backend implementation. (default:
                         ``RpcBackend.PROCESS_GROUP``).
-            self_name (str): a globally unique name of this node. (e.g.,
+            name (str): a globally unique name of this node. (e.g.,
                         ``Trainer3``, ``ParameterServer2``, ``Master``,
                         ``Worker1``) Name can only contain number, alphabet,
                         underscore, and/or dash, and must be shorter than
                         128 characters.
-            self_rank (int): a globally unique id/rank of this node.
             init_method(str): backend specific init arguments.
-            num_send_recv_threads(int): Number of threads for send/recv work.
-            rpc_timeout (datetime.timedelta): Timeout for RPCs. Defaults to 60 seconds.
-                0 means infinity.
+            rank (int): a globally unique id/rank of this node.
+            world_size (int): The number of workers in the group.
+            rpc_agent_options (RpcAgentOptions): The options passed to RpcAgent
+                consturctor.
         """
         # Rendezvous.
-        world_size = len(worker_name_to_id)
         rendezvous_iterator = torch.distributed.rendezvous(
-            init_method, rank=self_rank, world_size=world_size
+            init_method, rank=rank, world_size=world_size
         )
         store, _, _ = next(rendezvous_iterator)
 
@@ -69,15 +68,7 @@ if is_available():
         # and others might not have. As a result, a node calling
         # torch.distributed.autograd.backward() would run into errors since
         # other nodes might not have been initialized.
-        torch.distributed.autograd._init(worker_name_to_id[self_name])
+        torch.distributed.autograd._init(rank)
 
         # Initialize RPC.
-        _init_rpc_backend(
-            backend,
-            store,
-            self_name,
-            self_rank,
-            worker_name_to_id,
-            num_send_recv_threads,
-            rpc_timeout,
-        )
+        _init_rpc_backend(backend, store, name, rank, world_size, rpc_agent_options)

--- a/torch/distributed/rpc/api.py
+++ b/torch/distributed/rpc/api.py
@@ -4,13 +4,13 @@ from . import _start_rpc_agent
 from . import _destroy_rref_context, _cleanup_python_rpc_handler
 from . import WorkerInfo
 from . import backend_registry
-from .constants import DEFAULT_RPC_TIMEOUT, DEFAULT_NUM_SEND_RECV_THREADS
 from .internal import _internal_rpc_pickler, PythonUDF
 
-import datetime
 import functools
+import numbers
 import sys
 import torch
+import torch.distributed as dist
 
 
 _agent = None
@@ -51,14 +51,37 @@ def join_rpc():
 def _init_rpc_backend(
     backend=backend_registry.BackendType.PROCESS_GROUP,
     store=None,
-    self_name=None,
-    self_rank=-1,
-    worker_name_to_id=None,
-    num_send_recv_threads=DEFAULT_NUM_SEND_RECV_THREADS,
-    rpc_timeout=DEFAULT_RPC_TIMEOUT,
+    name=None,
+    rank=-1,
+    world_size=-1,
+    rpc_agent_options=None,
 ):
+    from . import RpcAgentOptions
+
     if sys.version_info < (3, 0):
         raise RuntimeError("RPC package does not support Python2.")
+
+    if not isinstance(backend, backend_registry.BackendType):
+        raise RuntimeError("`backend` must be a `backend_registry.BackendType`.")
+
+    if not isinstance(store, dist.Store):
+        raise RuntimeError("`store` must be a `c10d::Store`. {}".format(store))
+
+    if not isinstance(name, str):
+        raise RuntimeError("`name` must be a string. {}".format(name))
+
+    if not isinstance(rank, numbers.Integral):
+        raise RuntimeError("`rank` must be an integer. {}".format(rank))
+
+    if not isinstance(world_size, numbers.Integral):
+        raise RuntimeError("`world_size` must be an integer. {}".format(world_size))
+
+    if not isinstance(rpc_agent_options, RpcAgentOptions):
+        raise RuntimeError(
+            "`rpc_agent_options` must be an `RpcAgentOptions`. {}".format(
+                rpc_agent_options
+            )
+        )
 
     global _agent
 
@@ -66,19 +89,13 @@ def _init_rpc_backend(
         raise RuntimeError("RPC is already initialized")
 
     # Initialize RPC.
-    if not isinstance(rpc_timeout, datetime.timedelta):
-        raise RuntimeError(
-            "`rpc_timeout` must be a `datetime.timedelta`."
-        )
-
     _agent = backend_registry.init_backend(
         backend,
         store=store,
-        self_name=self_name,
-        self_rank=self_rank,
-        worker_name_to_id=worker_name_to_id,
-        num_send_recv_threads=num_send_recv_threads,
-        rpc_timeout=rpc_timeout,
+        name=name,
+        rank=rank,
+        world_size=world_size,
+        rpc_agent_options=rpc_agent_options,
     )
     _start_rpc_agent(_agent)
 

--- a/torch/distributed/rpc/backend_registry.py
+++ b/torch/distributed/rpc/backend_registry.py
@@ -1,24 +1,34 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import collections
+import datetime
 import enum
 
 import torch.distributed as dist
 import torch.distributed.distributed_c10d as dc10d
 
+from . import constants as rpc_constants
 
-BackendValue = collections.namedtuple("BackendValue", ["init_backend_handler"])
+
+BackendValue = collections.namedtuple(
+    "BackendValue", ["construct_rpc_agent_options_handler", "init_backend_handler"]
+)
 
 # Create an enum type, `BackendType`, with empty members.
 BackendType = enum.Enum(value="BackendType", names={})
 
 
-def register_backend(backend_name, init_backend_handler):
+def register_backend(
+    backend_name, construct_rpc_agent_options_handler, init_backend_handler
+):
     """Registers a new RPC backend.
 
     Arguments:
-        backend (str): backend string to identify the handler.
-        handler (function): Handler that is invoked when the
+        backend_name (str): backend string to identify the handler.
+        construct_rpc_agent_options_handler (function):
+            Handler that is invoked when
+            rpc_backend.construct_rpc_agent_options(**dict) is called.
+        init_backend_handler (function): Handler that is invoked when the
             `_init_rpc_backend()` function is called with a backend.
              This returns the agent.
     """
@@ -28,26 +38,44 @@ def register_backend(backend_name, init_backend_handler):
     # Create a new enum type, `BackendType`, with extended members.
     existing_enum_dict = {member.name: member.value for member in BackendType}
     extended_enum_dict = dict(
-        {backend_name: BackendValue(init_backend_handler=init_backend_handler)},
+        {
+            backend_name: BackendValue(
+                construct_rpc_agent_options_handler=construct_rpc_agent_options_handler,
+                init_backend_handler=init_backend_handler,
+            )
+        },
         **existing_enum_dict
     )
     BackendType = enum.Enum(value="BackendType", names=extended_enum_dict)
     return BackendType[backend_name]
 
 
+def construct_rpc_agent_options(
+    backend, rpc_timeout=rpc_constants.DEFAULT_RPC_TIMEOUT, **kwargs
+):
+    if not isinstance(rpc_timeout, datetime.timedelta):
+        raise RuntimeError("`rpc_timeout` must be a `datetime.timedelta`.")
+
+    return backend.value.construct_rpc_agent_options_handler(rpc_timeout, **kwargs)
+
+
 def init_backend(backend, *args, **kwargs):
     return backend.value.init_backend_handler(*args, **kwargs)
 
 
+def _process_group_construct_rpc_agent_options_handler(
+    rpc_timeout, num_send_recv_threads=rpc_constants.DEFAULT_NUM_SEND_RECV_THREADS, **kwargs
+):
+    from . import ProcessGroupRpcAgentOptions
+
+    rpc_agent_options = ProcessGroupRpcAgentOptions()
+    rpc_agent_options.rpc_timeout = rpc_timeout
+    rpc_agent_options.num_send_recv_threads = num_send_recv_threads
+    return rpc_agent_options
+
+
 def _process_group_init_backend_handler(
-    store,
-    self_name,
-    self_rank,
-    worker_name_to_id,
-    num_send_recv_threads,
-    rpc_timeout,
-    *args,
-    **kwargs
+    store, name, rank, world_size, rpc_agent_options
 ):
     from . import ProcessGroupAgent
 
@@ -57,38 +85,40 @@ def _process_group_init_backend_handler(
             "Default process group must not be initialized before init_rpc."
         )
 
-    world_size = len(worker_name_to_id)
     dist.init_process_group(
-        backend="gloo", store=store, rank=self_rank, world_size=world_size
+        backend="gloo", store=store, rank=rank, world_size=world_size
     )
 
     try:
         group = dc10d._get_default_group()
         assert group is not None, "Failed to initialize default ProcessGroup."
 
-        if (self_rank != -1) and (self_rank != group.rank()):
+        if (rank != -1) and (rank != group.rank()):
             raise RuntimeError(
-                "self_rank argument {} doesn't match pg rank {}".format(
-                    self_rank, group.rank()
+                "rank argument {} doesn't match pg rank {}".format(
+                    rank, group.rank()
                 )
             )
-        if (worker_name_to_id is not None) and (len(worker_name_to_id) != group.size()):
+        if (world_size != -1) and (world_size != group.size()):
             raise RuntimeError(
-                "worker_name_to_id argument {} doesn't match pg size {}".format(
-                    worker_name_to_id, group.size()
+                "world_size argument {} doesn't match pg size {}".format(
+                    world_size, group.size()
                 )
             )
         # TODO: add try-except and destroy _agent in all processes if any fails.
         return ProcessGroupAgent(
-            self_name,
+            name,
             group,
-            num_send_recv_threads,
-            rpc_timeout,
+            rpc_agent_options.num_send_recv_threads,
+            rpc_agent_options.rpc_timeout,
         )
     except Exception as ex:
         dist.destroy_process_group()
         raise ex
 
 
-
-register_backend("PROCESS_GROUP", _process_group_init_backend_handler)
+register_backend(
+    "PROCESS_GROUP",
+    _process_group_construct_rpc_agent_options_handler,
+    _process_group_init_backend_handler,
+)

--- a/torch/distributed/rpc/constants.py
+++ b/torch/distributed/rpc/constants.py
@@ -1,5 +1,9 @@
 from datetime import timedelta
 
 
-DEFAULT_NUM_SEND_RECV_THREADS = 4
+# For any RpcAgent.
 DEFAULT_RPC_TIMEOUT = timedelta(seconds=60)
+
+
+# For ProcessGroupAgent.
+DEFAULT_NUM_SEND_RECV_THREADS = 4


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#30093 Resubmit "Add `RpcAgentOptions` struct type, which bundles different required arguments for different `RpcAgent`s"**
* #30092 Resubmit "Add RpcAgentTestFixture to extract duplicate code"

https://github.com/pytorch/pytorch/pull/28226 introduced `worker_to_id` arg to the `def init_rpc` function for other `RpcAgent`. While it's not really used by `ProcessGroupAgent`. Cleanup is wanted for this, as described in https://github.com/pytorch/pytorch/issues/29031.

To adapt to the difference of different `RpcAgent`, adding a `RpcAgentOptions` base classes, which allow leveraging inheritance to add extra fields.

Differential Revision: [D18595578](https://our.internmc.facebook.com/intern/diff/D18595578/)