### PR TITLE
change operator_range to work with lower and upper in op bench

### DIFF
--- a/benchmarks/operator_benchmark/benchmark_core.py
+++ b/benchmarks/operator_benchmark/benchmark_core.py
@@ -315,7 +315,7 @@ class BenchmarkRunner(object):
         return (cmd_flag is None or test_flag == cmd_flag)
 
     def _check_operator_first_char(self, test_flag, cmd_flag):
-        if cmd_flag is None or test_flag[:1] in cmd_falg:
+        if cmd_flag is None or test_flag[:1].lower in cmd_flag:
             return True
         return False
 

--- a/benchmarks/operator_benchmark/benchmark_utils.py
+++ b/benchmarks/operator_benchmark/benchmark_utils.py
@@ -324,7 +324,7 @@ def get_operator_range(chars_range):
     start, end = chars_range.split("-")
     ops_start_chars_set = set()
     for c in range(ord(start), ord(end) + 1):
-        ops_start_chars_set.add(chr(c))
+        ops_start_chars_set.add(chr(c).lower)
     return ops_start_chars_set
 
 


### PR DESCRIPTION
Summary: as title

Test Plan:
```
buck run mode/opt caffe2/benchmarks/operator_benchmark:benchmark_all_quantized_test  -- --iterations 1 --operator_range a-a
# ----------------------------------------
# PyTorch/Caffe2 Operator Micro-benchmarks
# ----------------------------------------
# Tag : short

# Benchmarking PyTorch: add
# Mode: Eager
# Name: add_N2_dtypetorch.quint8_contigTrue
# Input: N: 2, dtype: torch.quint8, contig: True
Forward Execution Time (us) : 22.251

# Benchmarking PyTorch: add
# Mode: Eager
# Name: add_N2_dtypetorch.qint8_contigTrue
# Input: N: 2, dtype: torch.qint8, contig: True
Forward Execution Time (us) : 17.247

# Benchmarking PyTorch: add
# Mode: Eager
# Name: add_N2_dtypetorch.qint32_contigTrue
# Input: N: 2, dtype: torch.qint32, contig: True
Forward Execution Time (us) : 29.653
...

Differential Revision: D18596447

