### PR TITLE
fix a crash due in nested bailouts

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -3619,6 +3619,23 @@ class TestFrontend(JitTestCase):
 
 
 class TestScript(JitTestCase):
+    def test_nested_bailouts(self):
+        @torch.jit.ignore
+        def nomnom(x):
+            pass
+
+        @torch.jit.script
+        def fct_loop(x):
+            for i in range(3):
+                nomnom(i)
+                x = torch.cat((x, x), 0)
+            return x
+
+        x = torch.ones(2, 3, 4, dtype=torch.float32)
+        out = fct_loop(x)
+        jit_trace = torch.jit.trace(fct_loop, x)
+        out_trace = jit_trace(x)
+
     def test_set_attribute_through_optional(self):
         class A(torch.nn.Module):
             __annotations__ = {"x": Optional[torch.Tensor]}

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -3620,14 +3620,9 @@ class TestFrontend(JitTestCase):
 
 class TestScript(JitTestCase):
     def test_nested_bailouts(self):
-        @torch.jit.ignore
-        def nomnom(x):
-            pass
-
         @torch.jit.script
         def fct_loop(x):
             for i in range(3):
-                nomnom(i)
                 x = torch.cat((x, x), 0)
             return x
 

--- a/torch/csrc/jit/passes/bailout_graph.cpp
+++ b/torch/csrc/jit/passes/bailout_graph.cpp
@@ -20,6 +20,11 @@ static std::unordered_set<Value *> collectLoopCounts(Node *n) {
     if (outerNode->kind() == prim::Loop) {
       LoopView lv(outerNode);
       loopCounts.insert(lv.currentTripCount());
+      // if maxTripCount is a constant it will be memoized instead
+      // of being added as a graph input, so we can safely skip it
+      if (lv.maxTripCount()->node()->kind() != prim::Constant) {
+        loopCounts.insert(lv.maxTripCount());
+      }
     }
     it = outerNode->owningBlock();
   }


### PR DESCRIPTION
A prim::BailOut also needs to capture max trip counts as for some graphs they aren't constants and they are used in continuation graphs to figure out the remaining number of iterations to run.