### PR TITLE
only run embeddingbag benchmark on cpu

### DIFF
--- a/benchmarks/operator_benchmark/pt/embeddingbag_test.py
+++ b/benchmarks/operator_benchmark/pt/embeddingbag_test.py
@@ -11,6 +11,7 @@ embeddingbag_short_configs = op_bench.cross_product_configs(
     input_size=[8, 16, 64],
     offset=[0],
     sparse=[True],
+    device=['cpu'],
     tags=['short']
 )
 


### PR DESCRIPTION
Summary: as title

Test Plan:
```
buck run mode/opt //caffe2/benchmarks/operator_benchmark:benchmark_all_other_test -- --tag_filter all --iterations 1 --device cuda --operators embeddingbag
# ----------------------------------------
# PyTorch/Caffe2 Operator Micro-benchmarks
# ----------------------------------------
# Tag : all

Differential Revision: D18598198

