### PR TITLE
Add RPC internal helper that overrides the default pickler

### DIFF
--- a/test/rpc_test.py
+++ b/test/rpc_test.py
@@ -13,6 +13,7 @@ import torch.distributed.rpc as rpc
 from torch.distributed.rpc import RRef
 from common_utils import load_tests
 from dist_utils import INIT_METHOD_TEMPLATE, TEST_CONFIG, dist_init
+from torch.distributed.rpc.api import _use_rpc_pickler
 from torch.distributed.rpc.internal import PythonUDF, _internal_rpc_pickler
 
 
@@ -1141,3 +1142,11 @@ class RpcTest(object):
             return "expected result"
 
         self.assertEqual(test_func(self), "expected result")
+
+    def test_use_rpc_pickler(self):
+        class TestPickler():
+            pass
+        test_pickler = TestPickler()
+        with _use_rpc_pickler(test_pickler):
+            self.assertTrue(torch.distributed.rpc.api._default_pickler is test_pickler)
+        self.assertTrue(torch.distributed.rpc.api._default_pickler is _internal_rpc_pickler)

--- a/torch/distributed/rpc/api.py
+++ b/torch/distributed/rpc/api.py
@@ -7,6 +7,7 @@ from . import backend_registry
 from .constants import DEFAULT_RPC_TIMEOUT, DEFAULT_NUM_SEND_RECV_THREADS
 from .internal import _internal_rpc_pickler, PythonUDF
 
+import contextlib
 import datetime
 import functools
 import sys
@@ -15,6 +16,19 @@ import torch
 
 _agent = None
 
+_default_pickler = _internal_rpc_pickler
+
+@contextlib.contextmanager
+def _use_rpc_pickler(rpc_pickler):
+    r"""
+    rpc_pickler: (.internal._InternalRPCPickler) Overrides the default RPC pickler
+    """
+    global _default_pickler
+    _default_pickler = rpc_pickler
+    try:
+        yield
+    finally:
+        _default_pickler = _internal_rpc_pickler
 
 def _require_initialized(func):
     @functools.wraps(func)
@@ -162,7 +176,7 @@ def remote(to, func, args=None, kwargs=None):
         return _invoke_remote_builtin(
             _agent, info, qualified_name, *args, **kwargs)
     else:
-        (pickled_python_udf, tensors) = _internal_rpc_pickler.serialize(
+        (pickled_python_udf, tensors) = _default_pickler.serialize(
             PythonUDF(func, args, kwargs))
         return _invoke_remote_python_udf(
             _agent, info, pickled_python_udf, tensors)
@@ -183,7 +197,7 @@ def _invoke_rpc(to, func, args=None, kwargs=None):
             _agent, info, qualified_name, *args, **kwargs
         )
     else:
-        (pickled_python_udf, tensors) = _internal_rpc_pickler.serialize(
+        (pickled_python_udf, tensors) = _default_pickler.serialize(
             PythonUDF(func, args, kwargs))
         fut = _invoke_rpc_python_udf(
             _agent, info, pickled_python_udf, tensors)


### PR DESCRIPTION
Summary: To enable share_memory over RPC, add an internal helper that overrides the default RPC pickler

Test Plan: ```python test/test_rpc_spawn RpcTestWithSpawn.test_use_rpc_pickler```

Differential Revision: D18598974

