### PR TITLE
[android] Module load with ReadAdapterInterface

### DIFF
--- a/android/pytorch_android/host/build.gradle
+++ b/android/pytorch_android/host/build.gradle
@@ -14,7 +14,10 @@ repositories {
 
 sourceSets {
     main {
-        java.srcDir '../src/main/java'
+        java {
+            srcDir '../src/main/java'
+            exclude 'org/pytorch/android/**'
+        }
     }
     test {
         java {

--- a/android/pytorch_android/src/main/cpp/pytorch_jni_jit.cpp
+++ b/android/pytorch_android/src/main/cpp/pytorch_jni_jit.cpp
@@ -8,10 +8,67 @@
 
 #include <torch/csrc/autograd/record_function.h>
 #include <torch/script.h>
+#include "caffe2/serialize/read_adapter_interface.h"
 
 #include "pytorch_jni_common.h"
 
 namespace pytorch_jni {
+
+class JReadAdapter : public facebook::jni::JavaClass<JReadAdapter> {
+ public:
+  static constexpr auto kJavaDescriptor = "Lorg/pytorch/ReadAdapter;";
+
+  jlong size() {
+    static const auto method =
+        JReadAdapter::javaClassStatic()->getMethod<jlong()>("size");
+    jlong result = method(self());
+    return result;
+  }
+};
+
+class ReadAdapter final : public caffe2::serialize::ReadAdapterInterface {
+ public:
+  explicit ReadAdapter(
+      facebook::jni::alias_ref<JReadAdapter::javaobject> jReadAdapter)
+      : jReadAdapter_(facebook::jni::make_global(jReadAdapter)),
+        size_(jReadAdapter_->size()),
+        jBuf_(nullptr),
+        jBufSize_(0){};
+
+  size_t size() const override {
+    return size_;
+  }
+
+  size_t read(uint64_t pos, void* buf, size_t n, const char* what = "")
+      const override {
+    if (pos >= size_) {
+      return 0;
+    }
+    uint8_t* ubuf = static_cast<uint8_t*>(buf);
+    if (jBufSize_ < n) {
+      facebook::jni::local_ref<facebook::jni::JByteBuffer> jBuf =
+          facebook::jni::JByteBuffer::wrapBytes(static_cast<uint8_t*>(buf), n);
+      jBuf_ = facebook::jni::make_global(jBuf);
+    }
+
+    static const auto method =
+        JReadAdapter::javaClassStatic()
+            ->getMethod<jint(
+                jlong,
+                facebook::jni::alias_ref<facebook::jni::JByteBuffer>,
+                jint)>("read");
+    jint result = method(jReadAdapter_, pos, jBuf_, n);
+    return result > 0 ? result : 0;
+  }
+
+  ~ReadAdapter() {}
+
+ private:
+  facebook::jni::global_ref<JReadAdapter::javaobject> jReadAdapter_;
+  size_t size_ = {};
+  mutable facebook::jni::global_ref<facebook::jni::JByteBuffer> jBuf_;
+  size_t jBufSize_ = {};
+};
 
 class PytorchJni : public facebook::jni::HybridClass<PytorchJni> {
  private:
@@ -21,10 +78,16 @@ class PytorchJni : public facebook::jni::HybridClass<PytorchJni> {
  public:
   constexpr static auto kJavaDescriptor = "Lorg/pytorch/NativePeer;";
 
-  static facebook::jni::local_ref<jhybriddata> initHybrid(
+  static facebook::jni::local_ref<jhybriddata> initHybridFilePath(
       facebook::jni::alias_ref<jclass>,
       facebook::jni::alias_ref<jstring> modelPath) {
     return makeCxxInstance(modelPath);
+  }
+
+  static facebook::jni::local_ref<jhybriddata> initHybridReadAdapter(
+      facebook::jni::alias_ref<jclass>,
+      facebook::jni::alias_ref<JReadAdapter::javaobject> jReadAdapter) {
+    return makeCxxInstance(jReadAdapter);
   }
 
 #ifdef TRACE_ENABLED
@@ -55,9 +118,28 @@ class PytorchJni : public facebook::jni::HybridClass<PytorchJni> {
     module_.eval();
   }
 
+  PytorchJni(facebook::jni::alias_ref<JReadAdapter::javaobject> jReadAdapter) {
+    auto qengines = at::globalContext().supportedQEngines();
+    if (std::find(qengines.begin(), qengines.end(), at::QEngine::QNNPACK) !=
+        qengines.end()) {
+      at::globalContext().setQEngine(at::QEngine::QNNPACK);
+    }
+#ifdef TRACE_ENABLED
+    torch::autograd::profiler::pushCallback(
+        &onFunctionEnter,
+        &onFunctionExit,
+        /* need_inputs */ false,
+        /* sampled */ false);
+#endif
+    module_ = torch::jit::load(torch::make_unique<ReadAdapter>(jReadAdapter));
+    module_.eval();
+  }
+
   static void registerNatives() {
     registerHybrid({
-        makeNativeMethod("initHybrid", PytorchJni::initHybrid),
+        makeNativeMethod("initHybridFilePath", PytorchJni::initHybridFilePath),
+        makeNativeMethod(
+            "initHybridReadAdapter", PytorchJni::initHybridReadAdapter),
         makeNativeMethod("forward", PytorchJni::forward),
         makeNativeMethod("runMethod", PytorchJni::runMethod),
     });

--- a/android/pytorch_android/src/main/java/org/pytorch/Module.java
+++ b/android/pytorch_android/src/main/java/org/pytorch/Module.java
@@ -23,6 +23,13 @@ public class Module {
     return new Module(new NativePeer(modelPath));
   }
 
+  public static Module load(final ReadAdapter readAdapter) {
+    if (!NativeLoader.isInitialized()) {
+      NativeLoader.init(new SystemDelegate());
+    }
+    return new Module(new NativePeer(readAdapter));
+  }
+
   Module(INativePeer nativePeer) {
     this.mNativePeer = nativePeer;
   }

--- a/android/pytorch_android/src/main/java/org/pytorch/NativePeer.java
+++ b/android/pytorch_android/src/main/java/org/pytorch/NativePeer.java
@@ -12,10 +12,16 @@ class NativePeer implements INativePeer {
 
   private final HybridData mHybridData;
 
-  private static native HybridData initHybrid(String moduleAbsolutePath);
+  private static native HybridData initHybridFilePath(String moduleAbsolutePath);
+
+  private static native HybridData initHybridReadAdapter(ReadAdapter readAdapter);
 
   NativePeer(String moduleAbsolutePath) {
-    mHybridData = initHybrid(moduleAbsolutePath);
+    mHybridData = initHybridFilePath(moduleAbsolutePath);
+  }
+
+  NativePeer(ReadAdapter readAdapter) {
+    mHybridData = initHybridReadAdapter(readAdapter);
   }
 
   public void resetNative() {

--- a/android/pytorch_android/src/main/java/org/pytorch/ReadAdapter.java
+++ b/android/pytorch_android/src/main/java/org/pytorch/ReadAdapter.java
@@ -1,0 +1,9 @@
+package org.pytorch;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+public interface ReadAdapter {
+    long size();
+    int read(long position, ByteBuffer buffer, int size) throws IOException;
+}

--- a/android/pytorch_android/src/main/java/org/pytorch/android/AssetReadAdapter.java
+++ b/android/pytorch_android/src/main/java/org/pytorch/android/AssetReadAdapter.java
@@ -1,0 +1,41 @@
+package org.pytorch.android;
+
+import org.pytorch.ReadAdapter;
+
+import java.io.Closeable;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import android.content.res.AssetManager;
+import android.content.res.AssetFileDescriptor;
+
+public class AssetReadAdapter implements ReadAdapter, Closeable {
+    private final long size;
+    private final long startOffset;
+    private final FileInputStream fileInputStream;
+    private final FileChannel fileChannel;
+
+    public AssetReadAdapter(AssetManager assetManager, String assetName) throws IOException {
+        AssetFileDescriptor fd = assetManager.openFd(assetName);
+        this.size = fd.getLength();
+        this.startOffset = fd.getStartOffset();
+        this.fileInputStream = fd.createInputStream();
+        this.fileChannel = fileInputStream.getChannel();
+    }
+
+    @Override
+    public long size() {
+        return size;
+    }
+
+    @Override
+    public int read(long position, ByteBuffer buffer, int size) throws IOException {
+        return fileChannel.read(buffer, startOffset + position);
+    }
+
+    @Override
+    public void close() throws IOException {
+        fileInputStream.close();
+    }
+}

--- a/android/test_app/app/build.gradle
+++ b/android/test_app/app/build.gradle
@@ -51,6 +51,9 @@ android {
         pickFirst '**/libfbjni.so'
         doNotStrip '**.so'
     }
+    aaptOptions {
+        noCompress 'pt'
+    }
 }
 
 dependencies {

--- a/android/test_app/app/src/main/java/org/pytorch/testapp/MainActivity.java
+++ b/android/test_app/app/src/main/java/org/pytorch/testapp/MainActivity.java
@@ -1,6 +1,5 @@
 package org.pytorch.testapp;
 
-import android.content.Context;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.HandlerThread;
@@ -11,12 +10,9 @@ import android.widget.TextView;
 import org.pytorch.IValue;
 import org.pytorch.Module;
 import org.pytorch.Tensor;
+import org.pytorch.android.AssetReadAdapter;
 
-import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.nio.FloatBuffer;
 
 import androidx.annotation.Nullable;
@@ -90,9 +86,11 @@ public class MainActivity extends AppCompatActivity {
   @Nullable
   protected Result doModuleForward() {
     if (mModule == null) {
-      final String moduleFileAbsoluteFilePath = new File(
-          assetFilePath(this, BuildConfig.MODULE_ASSET_NAME)).getAbsolutePath();
-      mModule = Module.load(moduleFileAbsoluteFilePath);
+      try {
+        mModule = Module.load(new AssetReadAdapter(getAssets(), BuildConfig.MODULE_ASSET_NAME));
+      } catch (IOException e) {
+        Log.e(TAG, "Error loading module from asset InputStream", e);
+      }
       mInputTensorBuffer = Tensor.allocateFloatBuffer(3 * 224 * 224);
       mInputTensor = Tensor.fromBlob(mInputTensorBuffer, new long[]{1, 3, 224, 224});
     }
@@ -105,28 +103,6 @@ public class MainActivity extends AppCompatActivity {
     final long analysisDuration = SystemClock.elapsedRealtime() - startTime;
 
     return new Result(scores, moduleForwardDuration, analysisDuration);
-  }
-
-  public static String assetFilePath(Context context, String assetName) {
-    File file = new File(context.getFilesDir(), assetName);
-    if (file.exists() && file.length() > 0) {
-      return file.getAbsolutePath();
-    }
-
-    try (InputStream is = context.getAssets().open(assetName)) {
-      try (OutputStream os = new FileOutputStream(file)) {
-        byte[] buffer = new byte[4 * 1024];
-        int read;
-        while ((read = is.read(buffer)) != -1) {
-          os.write(buffer, 0, read);
-        }
-        os.flush();
-      }
-      return file.getAbsolutePath();
-    } catch (IOException e) {
-      Log.e(TAG, "Error process asset " + assetName + " to file path");
-    }
-    return null;
   }
 
   static class Result {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#30109 [android] Module load with ReadAdapterInterface**

Exposing  `caffe2::serialize::ReadAdapterInterface` to java as a loading option of the Module (org.pytorch.ReadAdapter)
To load Module stream has to support `seek` (random access)

`java.io.InputStream` does not have `seek` so we can not use it as a Module loading source.

The main reason to have it was loading module from android assets, which are packed to one file and android exposes fileDescriptor of this file (with requirement that it was not compressed). 
Compression of the assets can be turned off by regexp in gradle as:
```
android {
    ...
    aaptOptions {
        noCompress 'pt'
    }
}
```
Using FileDescriptor we can have random access, so we can implement `org.pytorch.android.AssetReadAdapter implements org.pytorch.ReadAdapter` and it will be used as

```
Module module = Module.load(new AssetReadAdapter(getAssets(), assetName));
```

Folder `org.pytorch.android` is excluded from host build

Details of jni `ReadAdapter`:
As we do not know size of the buffer from the beginning - it's allocated lazily and reallocated when `read` requested reading of bigger chunk than it was before, but if read_size is smaller than current buffer size - we are reusing current buffer.

that's why it's mutable (as `caffe2::serialize::ReadAdapterInterface(...) const`):
```
mutable facebook::jni::global_ref<facebook::jni::JByteBuffer> jBuf_;
```

Testing:
test_app loading is changed to `ReadAdapter` approach:
```
cls && gradle test_app:installMobNet2QuantDebug -PABI_FILTERS=x86 && adb shell am start -n org.pytorch.testapp.mobNet2Quant/org.pytorch.testapp.MainActivity
```
Model runs ok.