### PR TITLE
add flag to strip C10 error message

### DIFF
--- a/c10/util/Exception.h
+++ b/c10/util/Exception.h
@@ -196,7 +196,7 @@ inline std::string if_empty_then(std::string x, std::string y) {
 // simply raises an exception, it does NOT unceremoniously quit the process
 // (unlike assert()).
 //
-#ifdef C10_MOBILE
+#ifdef STRIP_ERROR_MESSAGES
 #define TORCH_INTERNAL_ASSERT(cond, ...)      \
   if (C10_UNLIKELY_OR_CONST(!(cond))) {       \
     C10_THROW_ERROR(Error,                    \
@@ -238,7 +238,7 @@ inline std::string if_empty_then(std::string x, std::string y) {
 // simply raises an exception, it does NOT unceremoniously quit the process
 // (unlike CHECK() from glog.)
 //
-#ifdef C10_MOBILE
+#ifdef STRIP_ERROR_MESSAGES
 #define TORCH_CHECK(cond, ...)                \
   if (C10_UNLIKELY_OR_CONST(!(cond))) {       \
     C10_THROW_ERROR(Error,                    \
@@ -263,7 +263,7 @@ inline std::string if_empty_then(std::string x, std::string y) {
 // this way; check if this actually affects binary size.
 
 // Like TORCH_CHECK, but raises IndexErrors instead of Errors.
-#ifdef C10_MOBILE
+#ifdef STRIP_ERROR_MESSAGES
 #define TORCH_CHECK_INDEX(cond, ...)          \
   if (C10_UNLIKELY_OR_CONST(!(cond))) {       \
     C10_THROW_ERROR(Error,                    \


### PR DESCRIPTION
Summary: Add flag to strip C10 error message. To ensure there's no size regression, add the same flag to existing caffe2 and pytorch build

Test Plan: size bot check

Reviewed By: dreiss

Differential Revision: D18577969

