### PR TITLE
[C++ API] Pass Tensor instead of Tensor& to torch::nn functionals that can change input in place

### DIFF
--- a/test/cpp/api/functional.cpp
+++ b/test/cpp/api/functional.cpp
@@ -724,6 +724,7 @@ TEST_F(FunctionalTest, ELU) {
       }
     }
   }
+  ASSERT_TRUE(F::elu(torch::tensor(1)).defined());
 }
 
 TEST_F(FunctionalTest, SELU) {
@@ -750,6 +751,7 @@ TEST_F(FunctionalTest, SELU) {
     auto expected = F::selu(input, false);
     ASSERT_TRUE(output.allclose(expected));
   }
+  ASSERT_TRUE(F::selu(torch::tensor(1)).defined());
 }
 
 TEST_F(FunctionalTest, GLU) {
@@ -856,6 +858,7 @@ TEST_F(FunctionalTest, Hardtanh) {
       }
     }
   }
+  ASSERT_TRUE(F::hardtanh(torch::tensor(1)).defined());
 }
 
 TEST_F(FunctionalTest, LeakyReLU) {
@@ -876,6 +879,7 @@ TEST_F(FunctionalTest, LeakyReLU) {
       }
     }
   }
+  ASSERT_TRUE(F::leaky_relu(torch::tensor(1)).defined());
 }
 
 TEST_F(FunctionalTest, LogSigmoid) {
@@ -1204,6 +1208,7 @@ TEST_F(FunctionalTest, ReLU) {
       ASSERT_TRUE(torch::allclose(x, y_exp));
     }
   }
+  ASSERT_TRUE(F::relu(torch::tensor(1)).defined());
 }
 
 TEST_F(FunctionalTest, ReLUDefaultOptions) {
@@ -1242,6 +1247,7 @@ TEST_F(FunctionalTest, ReLU6) {
       ASSERT_TRUE(torch::allclose(x, y_exp));
     }
   }
+  ASSERT_TRUE(F::relu6(torch::tensor(1)).defined());
 }
 
 TEST_F(FunctionalTest, ReLU6DefaultOptions) {
@@ -1278,6 +1284,7 @@ TEST_F(FunctionalTest, RReLU) {
       }
     }
   }
+  ASSERT_TRUE(F::rrelu(torch::tensor(1)).defined());
 }
 
 TEST_F(FunctionalTest, RReLUDefaultOptions) {
@@ -1314,6 +1321,7 @@ TEST_F(FunctionalTest, CELU) {
       }
     }
   }
+  ASSERT_TRUE(F::celu(torch::tensor(1)).defined());
 }
 
 TEST_F(FunctionalTest, CELUDefaultOptions) {
@@ -1484,6 +1492,7 @@ TEST_F(FunctionalTest, Threshold) {
       }
     }
   }
+  ASSERT_TRUE(F::threshold(torch::tensor(1)).defined());
 }
 
 TEST_F(FunctionalTest, BatchNorm1d) {
@@ -1929,6 +1938,7 @@ TEST_F(FunctionalTest, Dropout) {
   auto output = F::dropout(input);
   ASSERT_TRUE(torch::allclose(input_mean, output.mean(), 0.01, 0.05));
   ASSERT_TRUE((input_std <= output.std()).all().item<bool>());
+  ASSERT_TRUE(F::dropout(torch::tensor(1)).defined());
 }
 
 TEST_F(FunctionalTest, Dropout2d) {
@@ -1944,6 +1954,7 @@ TEST_F(FunctionalTest, Dropout2d) {
   auto output = F::dropout2d(input);
   ASSERT_TRUE(torch::allclose(input_mean, output.mean(), 0.01, 0.05));
   ASSERT_TRUE((input_std <= output.std()).all().item<bool>());
+  ASSERT_TRUE(F::dropout2d(torch::tensor(1)).defined());
 }
 
 TEST_F(FunctionalTest, Dropout3d) {
@@ -1959,4 +1970,5 @@ TEST_F(FunctionalTest, Dropout3d) {
   auto output = F::dropout3d(input);
   ASSERT_TRUE(torch::allclose(input_mean, output.mean(), 0.01, 0.05));
   ASSERT_TRUE((input_std <= output.std()).all().item<bool>());
+  ASSERT_TRUE(F::dropout3d(torch::tensor(1)).defined());
 }

--- a/test/cpp/api/functional.cpp
+++ b/test/cpp/api/functional.cpp
@@ -625,7 +625,7 @@ TEST_F(FunctionalTest, NLLLoss) {
                               {-3.7038, -0.1038, -2.6038},
                               {-2.3422, -1.3422, -0.4422}},
                              torch::kFloat);
-  auto target = torch::tensor({1, 0, 2}, torch::kLong); 
+  auto target = torch::tensor({1, 0, 2}, torch::kLong);
   auto output = F::nll_loss(
       input, target, F::NLLLossFuncOptions().ignore_index(-100).reduction(torch::kMean));
   auto expected = torch::tensor(2.4258, torch::kFloat);
@@ -724,7 +724,7 @@ TEST_F(FunctionalTest, ELU) {
       }
     }
   }
-  ASSERT_TRUE(F::elu(torch::tensor(1)).defined());
+  ASSERT_TRUE(F::elu(torch::tensor(1.)).defined());
 }
 
 TEST_F(FunctionalTest, SELU) {
@@ -751,7 +751,7 @@ TEST_F(FunctionalTest, SELU) {
     auto expected = F::selu(input, false);
     ASSERT_TRUE(output.allclose(expected));
   }
-  ASSERT_TRUE(F::selu(torch::tensor(1)).defined());
+  ASSERT_TRUE(F::selu(torch::tensor(1.)).defined());
 }
 
 TEST_F(FunctionalTest, GLU) {
@@ -858,7 +858,7 @@ TEST_F(FunctionalTest, Hardtanh) {
       }
     }
   }
-  ASSERT_TRUE(F::hardtanh(torch::tensor(1)).defined());
+  ASSERT_TRUE(F::hardtanh(torch::tensor(1.)).defined());
 }
 
 TEST_F(FunctionalTest, LeakyReLU) {
@@ -879,7 +879,7 @@ TEST_F(FunctionalTest, LeakyReLU) {
       }
     }
   }
-  ASSERT_TRUE(F::leaky_relu(torch::tensor(1)).defined());
+  ASSERT_TRUE(F::leaky_relu(torch::tensor(1.)).defined());
 }
 
 TEST_F(FunctionalTest, LogSigmoid) {
@@ -1208,7 +1208,7 @@ TEST_F(FunctionalTest, ReLU) {
       ASSERT_TRUE(torch::allclose(x, y_exp));
     }
   }
-  ASSERT_TRUE(F::relu(torch::tensor(1)).defined());
+  ASSERT_TRUE(F::relu(torch::tensor(1.)).defined());
 }
 
 TEST_F(FunctionalTest, ReLUDefaultOptions) {
@@ -1247,7 +1247,7 @@ TEST_F(FunctionalTest, ReLU6) {
       ASSERT_TRUE(torch::allclose(x, y_exp));
     }
   }
-  ASSERT_TRUE(F::relu6(torch::tensor(1)).defined());
+  ASSERT_TRUE(F::relu6(torch::tensor(1.)).defined());
 }
 
 TEST_F(FunctionalTest, ReLU6DefaultOptions) {
@@ -1284,7 +1284,7 @@ TEST_F(FunctionalTest, RReLU) {
       }
     }
   }
-  ASSERT_TRUE(F::rrelu(torch::tensor(1)).defined());
+  ASSERT_TRUE(F::rrelu(torch::tensor(1.)).defined());
 }
 
 TEST_F(FunctionalTest, RReLUDefaultOptions) {
@@ -1321,7 +1321,7 @@ TEST_F(FunctionalTest, CELU) {
       }
     }
   }
-  ASSERT_TRUE(F::celu(torch::tensor(1)).defined());
+  ASSERT_TRUE(F::celu(torch::tensor(1.)).defined());
 }
 
 TEST_F(FunctionalTest, CELUDefaultOptions) {
@@ -1492,7 +1492,7 @@ TEST_F(FunctionalTest, Threshold) {
       }
     }
   }
-  ASSERT_TRUE(F::threshold(torch::tensor(1)).defined());
+  ASSERT_TRUE(F::threshold(torch::tensor(1.), F::ThresholdFuncOptions(0.5, 0.5)).defined());
 }
 
 TEST_F(FunctionalTest, BatchNorm1d) {
@@ -1938,7 +1938,7 @@ TEST_F(FunctionalTest, Dropout) {
   auto output = F::dropout(input);
   ASSERT_TRUE(torch::allclose(input_mean, output.mean(), 0.01, 0.05));
   ASSERT_TRUE((input_std <= output.std()).all().item<bool>());
-  ASSERT_TRUE(F::dropout(torch::tensor(1)).defined());
+  ASSERT_TRUE(F::dropout(torch::tensor(1.)).defined());
 }
 
 TEST_F(FunctionalTest, Dropout2d) {
@@ -1954,7 +1954,7 @@ TEST_F(FunctionalTest, Dropout2d) {
   auto output = F::dropout2d(input);
   ASSERT_TRUE(torch::allclose(input_mean, output.mean(), 0.01, 0.05));
   ASSERT_TRUE((input_std <= output.std()).all().item<bool>());
-  ASSERT_TRUE(F::dropout2d(torch::tensor(1)).defined());
+  ASSERT_TRUE(F::dropout2d(torch::randn({50, 100})).defined());
 }
 
 TEST_F(FunctionalTest, Dropout3d) {
@@ -1970,5 +1970,5 @@ TEST_F(FunctionalTest, Dropout3d) {
   auto output = F::dropout3d(input);
   ASSERT_TRUE(torch::allclose(input_mean, output.mean(), 0.01, 0.05));
   ASSERT_TRUE((input_std <= output.std()).all().item<bool>());
-  ASSERT_TRUE(F::dropout3d(torch::tensor(1)).defined());
+  ASSERT_TRUE(F::dropout3d(torch::randn({50, 100})).defined());
 }

--- a/torch/csrc/api/include/torch/nn/functional/activation.h
+++ b/torch/csrc/api/include/torch/nn/functional/activation.h
@@ -17,7 +17,7 @@ inline Tensor elu(Tensor& input, double alpha, bool inplace) {
 }
 } // namespace detail
 
-inline Tensor elu(Tensor& input, const ELUFuncOptions& options = {}) {
+inline Tensor elu(Tensor input, const ELUFuncOptions& options = {}) {
   return detail::elu(input, options.alpha(), options.inplace());
 }
 
@@ -33,7 +33,7 @@ inline Tensor selu(Tensor& input, bool inplace) {
 }
 } // namespace detail
 
-inline Tensor selu(Tensor& input, const SELUFuncOptions& options = {}) {
+inline Tensor selu(Tensor input, const SELUFuncOptions& options = {}) {
   return detail::selu(input, options.inplace());
 }
 
@@ -66,7 +66,7 @@ inline Tensor hardtanh(Tensor& input,
 }
 } // namespace detail
 
-inline Tensor hardtanh(Tensor& input, const HardtanhFuncOptions& options = {}) {
+inline Tensor hardtanh(Tensor input, const HardtanhFuncOptions& options = {}) {
   return detail::hardtanh(input, options.min_val(), options.max_val(), options.inplace());
 }
 
@@ -84,7 +84,7 @@ inline Tensor leaky_relu(Tensor& input,
 }
 } // namespace detail
 
-inline Tensor leaky_relu(Tensor& input, const LeakyReLUFuncOptions& options = {}) {
+inline Tensor leaky_relu(Tensor input, const LeakyReLUFuncOptions& options = {}) {
   return detail::leaky_relu(input, options.negative_slope(), options.inplace());
 }
 
@@ -222,7 +222,7 @@ inline Tensor relu(Tensor& input, bool inplace) {
 }
 } // namespace detail
 
-inline Tensor relu(Tensor& input, const ReLUFuncOptions& options = {}) {
+inline Tensor relu(Tensor input, const ReLUFuncOptions& options = {}) {
   return detail::relu(input, options.inplace());
 }
 
@@ -234,14 +234,13 @@ inline Tensor relu6(Tensor& input, bool inplace) {
 }
 } // namespace detail
 
-inline Tensor relu6(Tensor& input, const ReLU6FuncOptions& options = {}) {
+inline Tensor relu6(Tensor input, const ReLU6FuncOptions& options = {}) {
   return detail::relu6(input, options.inplace());
 }
 
 // ============================================================================
 
 namespace detail {
-
 inline Tensor rrelu(Tensor& input,
                     double lower,
                     double upper,
@@ -255,7 +254,7 @@ inline Tensor rrelu(Tensor& input,
 }
 } // namespace detail
 
-inline Tensor rrelu(Tensor& input, const RReLUFuncOptions& options = {}) {
+inline Tensor rrelu(Tensor input, const RReLUFuncOptions& options = {}) {
   return detail::rrelu(input, options.lower(), options.upper(), options.training(), options.inplace());
 }
 
@@ -273,7 +272,7 @@ inline Tensor celu(Tensor& input,
 }
 } // namespace detail
 
-inline Tensor celu(Tensor& input, const CELUFuncOptions& options = {}) {
+inline Tensor celu(Tensor input, const CELUFuncOptions& options = {}) {
   return detail::celu(input, options.alpha(), options.inplace());
 }
 
@@ -334,7 +333,7 @@ inline Tensor threshold(Tensor& input,
 }
 } // namespace detail
 
-inline Tensor threshold(Tensor& input, const ThresholdFuncOptions& options) {
+inline Tensor threshold(Tensor input, const ThresholdFuncOptions& options) {
   return detail::threshold(input, options.threshold(), options.value(), options.inplace());
 }
 

--- a/torch/csrc/api/include/torch/nn/functional/dropout.h
+++ b/torch/csrc/api/include/torch/nn/functional/dropout.h
@@ -22,7 +22,7 @@ inline Tensor dropout(Tensor& input, double p, bool training, bool inplace) {
 
 } // namespace detail
 
-inline Tensor dropout(Tensor& input,
+inline Tensor dropout(Tensor input,
     const DropoutFuncOptions& options = {}) {
   return detail::dropout(
       input, options.p(), options.training(), options.inplace());
@@ -46,7 +46,7 @@ inline Tensor dropout2d(Tensor& input, double p, bool training, bool inplace) {
 
 } // namespace detail
 
-inline Tensor dropout2d(Tensor& input,
+inline Tensor dropout2d(Tensor input,
     const Dropout2dFuncOptions& options = {}) {
   return detail::dropout2d(
       input, options.p(), options.training(), options.inplace());
@@ -70,7 +70,7 @@ inline Tensor dropout3d(Tensor& input, double p, bool training, bool inplace) {
 
 } // namespace detail
 
-inline Tensor dropout3d(Tensor& input,
+inline Tensor dropout3d(Tensor input,
     const Dropout3dFuncOptions& options = {}) {
   return detail::dropout3d(
       input, options.p(), options.training(), options.inplace());


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#30112 [C++ API] Pass Tensor instead of Tensor& to torch::nn functionals that can change input in place**

Currently, we have torch::nn functionals that takes `input` as `Tensor&` in order to be able to in-place change `input`'s value. We likely shouldn't do this because it will prevent the following use case:
```cpp
F::elu(torch::tensor(1), F::ELUFuncOptions().inplace(true))
```
The solution is to change the type of `input` to `Tensor`, so that we can pass an rvalue into the functional.

Differential Revision: [D18601580](https://our.internmc.facebook.com/intern/diff/D18601580)