### PR TITLE
[jit] shut up clang-tidy on ir.h/cpp

### DIFF
--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -81,7 +81,9 @@ struct const_value_list_with_types {
       : values(values), delim(std::move(delim_)) {}
 };
 
-std::ostream& operator<<(std::ostream& out, const_value_list_with_types l) {
+std::ostream& operator<<(
+    std::ostream& out,
+    const const_value_list_with_types& l) {
   size_t i = 0;
   for (auto n : l.values) {
     if (i++ > 0) {
@@ -1591,10 +1593,10 @@ Node* Graph::createIsInstance(
   auto n = create(prim::isinstance, {v}, /*num_outputs*/ 1);
   std::vector<std::string> kinds;
   if (is_list) {
-    kinds.push_back("list");
+    kinds.emplace_back("list");
   }
   if (is_tuple) {
-    kinds.push_back("tuple");
+    kinds.emplace_back("tuple");
   }
   n->ss_(attr::kinds, std::move(kinds));
   n->tys_(attr::types, types.vec());
@@ -1614,7 +1616,7 @@ Value* Graph::insertFunctionCall(
   Value* fn_constant = insertNode(create(prim::Constant))
                            ->s_(attr::name, func_name)
                            ->output()
-                           ->setType(FunctionType::create(std::move(callee)));
+                           ->setType(FunctionType::create(callee));
   std::vector<Value*> inputs = {fn_constant};
   inputs.insert(inputs.end(), matched.inputs.begin(), matched.inputs.end());
   Value* result = insertNode(create(prim::CallFunction, inputs))
@@ -1655,11 +1657,10 @@ Node* Graph::createClone(
 }
 
 Value* Graph::insertConstant(
-    IValue val,
+    const IValue& val,
     c10::optional<SourceRange> loc,
     c10::optional<ScopePtr> scope) {
-  return jit::insertConstant(
-      *this, std::move(val), std::move(loc), std::move(scope));
+  return jit::insertConstant(*this, val, std::move(loc), std::move(scope));
 }
 
 std::string Graph::toString(bool print_source_locations) const {

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -1125,7 +1125,7 @@ struct Graph {
 
   // Insert constant IValue into the graph.
   TORCH_API Value* insertConstant(
-      IValue val,
+      const IValue& val,
       c10::optional<SourceRange> loc = c10::nullopt,
       c10::optional<ScopePtr> scope = c10::nullopt);
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#30118 [jit] shut up clang-tidy on ir.h/cpp**

Summary:

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D18620239](https://our.internmc.facebook.com/intern/diff/D18620239)