### PR TITLE
enable the per channel dynamic quantization

### DIFF
--- a/test/test_quantization.py
+++ b/test/test_quantization.py
@@ -512,6 +512,7 @@ class PostTrainingDynamicQuantTest(QuantizationTestCase):
         prepare_dynamic(model, qconfig_dict)
         test_only_eval_fn(model, self.calib_data)
         convert_dynamic(model)
+
         def checkQuantized(model):
             self.checkDynamicQuantizedLinear(model.sub1.fc)
             self.checkDynamicQuantizedLinear(model.fc3)

--- a/torch/nn/quantized/dynamic/modules/linear.py
+++ b/torch/nn/quantized/dynamic/modules/linear.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import torch
 from ....modules.linear import Linear as NNLinear
 import torch.nn.quantized as nnq
+from torch.nn.quantized.modules.utils import _quantize_weight
 
 class Linear(nnq.Linear):
     r"""
@@ -68,8 +69,7 @@ class Linear(nnq.Linear):
             weight_observer = default_dynamic_qconfig.weight()
         assert weight_observer.dtype == torch.qint8, 'Weight observer must have dtype torch.qint8'
         weight_observer(mod.weight)
-        wt_scale, wt_zp = weight_observer.calculate_qparams()
-        qweight = torch.quantize_per_tensor(mod.weight.float(), float(wt_scale), int(wt_zp), torch.qint8)
+        qweight = _quantize_weight(mod.weight.float(), weight_observer)
         qlinear = Linear(mod.in_features, mod.out_features)
         qlinear.set_weight_bias(qweight, mod.bias)
         return qlinear

--- a/torch/quantization/qconfig.py
+++ b/torch/quantization/qconfig.py
@@ -63,6 +63,7 @@ class QConfigDynamic(namedtuple('QConfigDynamic', ['weight'])):
 
 default_dynamic_qconfig = QConfigDynamic(weight=default_weight_observer)
 float16_dynamic_qconfig = QConfigDynamic(weight=NoopObserver.with_args(dtype=torch.float16))
+per_channel_dynamic_qconfig = QConfigDynamic(weight=default_per_channel_weight_observer)
 
 default_qat_qconfig = QConfig(activation=default_fake_quant,
                               weight=default_weight_fake_quant)


### PR DESCRIPTION
The PR tried to enable the per-channel(row-wise) dynamic quantization for linear operator. Given we have seen some accuracy drop due to the per-tensor quantization, we expect the per-channel could help improve the accuracy.