### PR TITLE
[android][fix] No debug symbols in release android buidls

### DIFF
--- a/android/pytorch_android/build.gradle
+++ b/android/pytorch_android/build.gradle
@@ -46,8 +46,9 @@ android {
         } else {
             pickFirst '**/libfbjni.so'
         }
-        if (nativeLibsDoNotStrip) {
+        if (nativeLibsDoNotStrip.toBoolean()) {
             doNotStrip "**/*.so"
+            logger.warn('WARNING: nativeLibsDoNotStrip==true; debug symbols included')
         }
     }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#30123 [android][fix] No debug symbols in release android buidls**

In groovy string `'false'` is resolved as boolean `true`

thats why even as in `gradle.properties`:
```
nativeLibsDoNotStrip=false
```
branch `if (nativeLibsDoNotStrip)` always passed

Differential Revision: [D18606907](https://our.internmc.facebook.com/intern/diff/D18606907)