### PR TITLE
allow operator_range to take multiple ranges

### DIFF
--- a/benchmarks/operator_benchmark/benchmark_utils.py
+++ b/benchmarks/operator_benchmark/benchmark_utils.py
@@ -318,13 +318,15 @@ def get_operator_range(chars_range):
     if chars_range == 'None' or chars_range is None:
         return None
 
-    if '-' not in chars_range:
-        raise ValueError("Wrong format. The right input format is <start_char>-<end_char>")
-
-    start, end = chars_range.split("-")
     ops_start_chars_set = set()
-    for c in range(ord(start), ord(end) + 1):
-        ops_start_chars_set.add(chr(c).lower)
+    ranges = chars_range.split(',')
+    for item in ranges: 
+        if len(item) == 1: 
+            ops_start_chars_set.add(item.lower)
+            continue
+        start, end = item.split("-")
+        for c in range(ord(start), ord(end) + 1):
+            ops_start_chars_set.add(chr(c).lower)
     return ops_start_chars_set
 
 


### PR DESCRIPTION
Summary: as title

Test Plan:
```
buck run mode/opt //caffe2/benchmarks/operator_benchmark:benchmark_all_other_test -- --tag_filter all --iterations 1 --device cuda --operator_range a,b-c
# ----------------------------------------
# PyTorch/Caffe2 Operator Micro-benchmarks
# ----------------------------------------
# Tag : all

# Benchmarking PyTorch: add
# Mode: Eager
# Name: add_M8_N32_K256_cuda
# Input: M: 8, N: 32, K: 256, device: cuda
Forward Execution Time (us) : 71.683

# Benchmarking PyTorch: batchnorm
# Mode: Eager
# Name: batchnorm_M1_N256_K3136_cuda
# Input: M: 1, N: 256, K: 3136, device: cuda
Forward Execution Time (us) : 118.840

# Benchmarking PyTorch: batchnorm
# Mode: Eager
# Name: batchnorm_M1_N8192_K1_cuda
# Input: M: 1, N: 8192, K: 1, device: cuda
Forward Execution Time (us) : 134.274

# Benchmarking PyTorch: cat
# Mode: Eager
# Name: cat_M128_N128_K1_dim1_cuda
# Input: M: 128, N: 128, K: 1, dim: 1, device: cuda
Forward Execution Time (us) : 109.172
...

Differential Revision: D18605640

