### PR TITLE
[ONNX] Partially support tensor lists in loop/concat/stack

### DIFF
--- a/aten/src/ATen/core/interned_strings.h
+++ b/aten/src/ATen/core/interned_strings.h
@@ -165,6 +165,8 @@ namespace c10 {
   _(aten, clear)                     \
   _(aten, setdefault)                \
   _(aten, bin)                       \
+  _(aten, pop)                       \
+  _(aten, insert)                    \
   _(prim, unchecked_unwrap_optional) \
   _(aten, __contains__)              \
   _(prim, BailoutTemplate)           \
@@ -206,6 +208,8 @@ namespace c10 {
   _(onnx, SplitToSequence)           \
   _(onnx, SequenceConstruct)         \
   _(onnx, SequenceEmpty)             \
+  _(onnx, SequenceInsert)            \
+  _(onnx, ConcatFromSequence)        \
   FORALL_ATTR_BASE_SYMBOLS(_)        \
   _(attr, Subgraph)                  \
   _(attr, ReverseSubgraph)           \
@@ -237,7 +241,9 @@ namespace c10 {
   _(attr, kinds)                     \
   _(attr, types)                     \
   _(attr, scope)                     \
-  _(attr, keepdims)
+  _(attr, keepdims)                  \
+  _(attr, new_axis)
+>>>>>>> Export dynamic unbind/split and __getitem__
 #else
 #define FORALL_NS_SYMBOLS(_) \
   _(namespaces, prim)              \

--- a/aten/src/ATen/core/interned_strings.h
+++ b/aten/src/ATen/core/interned_strings.h
@@ -243,7 +243,6 @@ namespace c10 {
   _(attr, scope)                     \
   _(attr, keepdims)                  \
   _(attr, new_axis)
->>>>>>> Export dynamic unbind/split and __getitem__
 #else
 #define FORALL_NS_SYMBOLS(_) \
   _(namespaces, prim)              \

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -1679,6 +1679,17 @@ class TestONNXRuntime(unittest.TestCase):
         self.run_test(UnbindModel3(), x)
 
     @skipIfUnsupportedMinOpsetVersion(11)
+    def test_len(self):
+        class LenModel(torch.jit.ScriptModule):
+            @torch.jit.script_method
+            def forward(self, input):
+                return len(input.unbind()) + input
+
+        x = torch.randn(4, 5)
+        self.run_test(LenModel(), x, input_names=['input'], dynamic_axes={'input': {0: 'seq'}},
+                      test_with_inputs=(torch.randn(5, 5),))
+
+    @skipIfUnsupportedMinOpsetVersion(11)
     def test_unbind_dynamic(self):
         class UnbindModel(torch.jit.ScriptModule):
             @torch.jit.script_method
@@ -1728,6 +1739,112 @@ class TestONNXRuntime(unittest.TestCase):
 
         x = torch.randn(5, 4, 3)
         self.run_test(SplitModel2(), x)
+
+    def test_concat(self):
+        class ConcatModel(torch.nn.Module):
+            def forward(self, x, y, z):
+                return torch.cat((x, y, z))
+
+        x = torch.randn(3, 4, 5)
+        y = torch.randn(1, 4, 5)
+        z = torch.randn(2, 4, 5)
+        self.run_test(ConcatModel(), (x, y, z))
+
+    @skipIfUnsupportedMinOpsetVersion(11)
+    def test_concat_dynamic(self):
+        class ConcatDynamicModel(torch.jit.ScriptModule):
+            @torch.jit.script_method
+            def forward(self, x):
+                return torch.cat(x.unbind())
+
+        x = torch.randn(4, 5, 6)
+        self.run_test(ConcatDynamicModel(), x)
+
+    def test_stack(self):
+        class StackModel(torch.nn.Module):
+            def forward(self, x, y, z):
+                return torch.stack((x, y, z), 1)
+
+        x = torch.randn(3, 4, 5)
+        y = torch.randn(3, 4, 5)
+        z = torch.randn(3, 4, 5)
+        self.run_test(StackModel(), (x, y, z))
+
+    @skipIfUnsupportedMinOpsetVersion(11)
+    def test_stack_dynamic(self):
+        class StackDynamicModel(torch.jit.ScriptModule):
+            @torch.jit.script_method
+            def forward(self, x):
+                return torch.stack(x.unbind(), 1)
+
+        x = torch.randn(4, 5, 6)
+        self.run_test(StackDynamicModel(), x)
+
+    def test_loop_dynamic(self):
+        class LoopModel(torch.jit.ScriptModule):
+            @torch.jit.script_method
+            def forward(self, x):
+                for i in range(x.size(2)):
+                    x = x + i
+                return x
+
+        model = LoopModel()
+        inputs = torch.zeros(1, 2, 3, dtype=torch.long)
+        self.run_test(model, inputs)
+
+    @skipIfUnsupportedMinOpsetVersion(9)
+    def test_loop_nested(self):
+        class NestedLoopsModel(torch.jit.ScriptModule):
+            @torch.jit.script_method
+            def forward(self, x):
+                for i in range(5):
+                    a = 0
+                    while a < 4:
+                        a += 1
+                    x = x + a
+                return x
+
+        model = NestedLoopsModel()
+        inputs = torch.zeros(1, 2, 3, dtype=torch.long)
+        self.run_test(model, inputs)
+
+    @skipIfUnsupportedMinOpsetVersion(11)
+    def test_loop_with_list(self):
+        class ListLoopModel(torch.jit.ScriptModule):
+            @torch.jit.script_method
+            def forward(self, x):
+                res = []
+                res1 = []
+                arr = x.split([3, 4, 1, 1, 2, 3, 2], 0)
+                res2 = torch.zeros(3, 4, dtype=torch.long)
+                for i in range(len(arr)):
+                    res = res.append(arr[i].sum(0, False))
+                    res1 = res1.append(arr[-1-i].sum(0, False))
+                    res2 += 1
+                return torch.stack(res), torch.stack(res1), res2
+
+        model = ListLoopModel()
+        inputs = torch.randn(16)
+        self.run_test(model, inputs)
+
+    @skipIfUnsupportedMinOpsetVersion(11)
+    def test_list(self):
+        class ListModel(torch.jit.ScriptModule):
+            @torch.jit.script_method
+            def forward(self, x):
+                tensors = x.unbind()
+                res = []
+                res = res.append(tensors[0])
+                res = res.append(tensors[1])
+                res.pop(1)
+
+                res.insert(0, tensors[1])
+                res.append(tensors[2])
+                return torch.ones(len(res))
+
+        model = ListModel()
+        inputs = torch.randn(16, 1)
+        self.run_test(model, inputs)
 
     @skipIfUnsupportedMinOpsetVersion(9)
     def test_tensor_factories(self):

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -1819,7 +1819,7 @@ class TestONNXRuntime(unittest.TestCase):
                 res2 = torch.zeros(3, 4, dtype=torch.long)
                 for i in range(len(arr)):
                     res = res.append(arr[i].sum(0, False))
-                    res1 = res1.append(arr[-1-i].sum(0, False))
+                    res1 = res1.append(arr[-1 - i].sum(0, False))
                     res2 += 1
                 return torch.stack(res), torch.stack(res1), res2
 

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -1834,8 +1834,8 @@ class TestONNXRuntime(unittest.TestCase):
             def forward(self, x):
                 tensors = x.unbind()
                 res = []
-                res = res.append(tensors[0])
-                res = res.append(tensors[1])
+                res.append(tensors[0])
+                res.append(tensors[1])
                 res.pop(1)
 
                 res.insert(0, tensors[1])

--- a/torch/csrc/jit/passes/dead_code_elimination.cpp
+++ b/torch/csrc/jit/passes/dead_code_elimination.cpp
@@ -111,6 +111,13 @@ class DeadCodeEliminator {
       // Special handling to deal with loop carried dependencies.
       auto loop = LoopView(outerNode);
       for (size_t i = 0; i < loop.carriedOutputs().size(); i++) {
+        if (outerNode->kind() == c10::onnx::Loop) {
+          // Special handling for onnx loop.
+          // The number of body carried inputs and outputs are different.
+          // They cannot be mapped to each other easily by the same index.
+          liveValues_.insert(loop.bodyCarriedOutputs().at(i));
+          continue;
+        }
         auto innerInput = loop.bodyCarriedInputs().at(i);
         auto innerOutput = loop.bodyCarriedOutputs().at(i);
         auto outerOutput = loop.carriedOutputs().at(i);

--- a/torch/csrc/jit/passes/onnx/fixup_onnx_loop.cpp
+++ b/torch/csrc/jit/passes/onnx/fixup_onnx_loop.cpp
@@ -194,10 +194,10 @@ void ConvertSequenceDependencies(Block* block) {
   }
 }
 
-static void fuseSequenceSplitConcat(Block *b) {
+static void FuseSequenceSplitConcat(Block *b) {
   for (auto it = b->nodes().begin(), end = b->nodes().end(); it != end; ++it) {
     for (auto* child_block : it->blocks()) {
-      fuseSequenceSplitConcat(child_block);
+      FuseSequenceSplitConcat(child_block);
     }
     if (it->kind() == onnx::ConcatFromSequence &&
         it->input()->node()->kind() == onnx::SplitToSequence) {
@@ -234,7 +234,7 @@ static void fuseSequenceSplitConcat(Block *b) {
 void FixupONNXLoops(std::shared_ptr<Graph>& graph) {
   FixupONNXLoops(graph->block());
   ConvertSequenceDependencies(graph->block());
-  fuseSequenceSplitConcat(graph->block());
+  FuseSequenceSplitConcat(graph->block());
   EliminateDeadCode(graph->block(), true, DCESideEffectPolicy::ALLOW_DELETING_NODES_WITH_SIDE_EFFECTS);
 }
 

--- a/torch/csrc/jit/passes/onnx/fixup_onnx_loop.cpp
+++ b/torch/csrc/jit/passes/onnx/fixup_onnx_loop.cpp
@@ -1,4 +1,6 @@
 #include <torch/csrc/jit/passes/onnx/fixup_onnx_loop.h>
+#include <torch/csrc/jit/passes/dead_code_elimination.h>
+#include <torch/csrc/jit/passes/onnx/peephole.h>
 
 namespace torch {
 namespace jit {
@@ -68,8 +70,172 @@ void FixupONNXLoops(Block* block) {
   }
 }
 
+namespace {
+bool IsErasableSequence(const Node* loop_node, size_t i) {
+  AT_ASSERT(loop_node->blocks().size() == 1);
+  auto* sub_block = loop_node->blocks()[0];
+  auto* out_node = sub_block->outputs()[i-1]->node();
+  auto* in_val = sub_block->inputs()[i];
+
+  if (out_node->kind() != ::c10::onnx::SequenceInsert) {
+    return false;
+  }
+
+  if (out_node->inputs().size() == 3) {
+    // Non-default insert position is not supported.
+    return false;
+  }
+
+  if (out_node->input(0) != in_val) {
+    // Only SequenceInsert that applies on loop-carried sequence is supported.
+    return false;
+  }
+
+  const auto seq_node_kind = loop_node->inputs()[i]->node()->kind();
+  if (seq_node_kind != ::c10::onnx::SequenceEmpty) {
+    // Initial sequence must be empty.
+    return false;
+  }
+
+  if (out_node->output()->uses().size() != 1) {
+    // The sequence is not supported to be used elsewhere.
+    return false;
+  }
+
+  return true;
+}
+} // anonymous namespace
+
+// ONNX::Loop does not support Sequence type as loop-carried dependencies. Only tensors are supported.
+// This pass converts Sequence loop-carried dependencies to scan_outputs.
+// In opset 11, only the below pattern is supported.
+//
+// PTIR graph:
+//  ...
+//  %res.1 : Tensor[] = prim::ListConstruct()
+//  %res : Tensor[] = prim::Loop(%11, %22, %res.1)
+//    block0(%i.1 : Tensor, %res.6 : Tensor[]):
+//      ...
+//      %res.3 : Tensor[] = aten::append(%res.6, %17)
+//      -> (%22, %res.3)
+//  return (%res.3)
+//
+// ONNX graph:
+//  ...
+//  %res : Tensor = onnx::Loop(%11, %22)
+//    block0(%i.1 : Tensor):
+//      ...
+//      -> (%22, %17)
+//  %res_seq : Tensor[] = onnx::SplitToSequence[keepdims=0](%res)
+//  return (%res_seq)
+void ConvertSequenceDependencies(Block* block) {
+  for (auto* node : block->nodes()) {
+    for (Block* block : node->blocks()) {
+      ConvertSequenceDependencies(block);
+    }
+
+    if (node->kind() == ::c10::onnx::Loop) {
+      auto* loop_node = node;
+      auto* graph = loop_node->owningGraph();
+
+      AT_ASSERT(loop_node->blocks().size() == 1);
+      auto* sub_block = loop_node->blocks()[0];
+
+      std::vector<size_t> idx_to_remove;
+      // loop sub-block inputs are  (iter, cond, loop-carried dependencies)
+      // loop sub-block outputs are (      cond, loop-carried dependencies, scan outputs)
+      // loop inputs are            (iter, cond, loop-carried dependencies)
+      // loop outputs are           (            loop-carried dependencies, scan outputs)
+      for (size_t i = 2; i < sub_block->inputs().size(); ++i) {
+        if (IsErasableSequence(loop_node, i)) {
+          auto* seq_node = sub_block->outputs()[i-1]->node();
+          // Replace sequence output with the inserted element.
+          auto inserted_value = seq_node->input(1);
+          sub_block->return_node()->replaceInputWith(seq_node->output(), inserted_value);
+
+          // Split the added scan_output back to expected tensor sequence.
+          auto loop_output = loop_node->output(i-2);
+          Node* split_node = loop_node->owningGraph()->create(onnx::SplitToSequence);
+          loop_output->replaceAllUsesWith(split_node->output());
+          split_node->i_(attr::keepdims, 0);
+          split_node->addInput(loop_output);
+          split_node->insertAfter(loop_node);
+          split_node->output()->copyMetadata(loop_output);
+
+          // Update loop output metadata.
+          loop_output->copyMetadata(inserted_value);
+          loop_output->setType(c10::unshapedType(loop_output->type()));
+
+          // The node that produces sequence should be safe to remove now.
+          seq_node->destroy();
+
+          idx_to_remove.push_back(i);
+        }
+      }
+
+      for (size_t i = 0; i < idx_to_remove.size(); ++i) {
+        size_t idx = idx_to_remove[i] - i;
+
+        sub_block->eraseInput(idx);
+        loop_node->removeInput(idx);
+
+        // Swap output order. Move all scan outputs to the back.
+        sub_block->return_node()->addInput(sub_block->return_node()->inputs().at(idx - 1));
+        sub_block->return_node()->removeInput(idx - 1);
+
+        auto loop_out = loop_node->addOutput();
+        loop_out->copyMetadata(loop_node->outputs().at(idx - 2));
+        loop_node->outputs().at(idx - 2)->replaceAllUsesWith(loop_out);
+        loop_node->eraseOutput(idx - 2);
+      }
+
+    }
+
+  }
+}
+
+static void fuseSequenceSplitConcat(Block *b) {
+  for (auto it = b->nodes().begin(), end = b->nodes().end(); it != end; ++it) {
+    for (auto* child_block : it->blocks()) {
+      fuseSequenceSplitConcat(child_block);
+    }
+    if (it->kind() == onnx::ConcatFromSequence &&
+        it->input()->node()->kind() == onnx::SplitToSequence) {
+      if (it->input()->uses().size() > 1) {
+        continue;
+      }
+
+      auto split_node = it->input()->node();
+      auto concat_node = *it;
+
+      const auto split_axis = split_node->hasAttribute(attr::axis) ? split_node->i(attr::axis) : 0;
+      const auto split_keepdims = split_node->hasAttribute(attr::keepdims) ? split_node->i(attr::keepdims) : 1;
+      const auto concat_axis = concat_node->i(attr::axis);
+      const auto concat_new_axis = concat_node->hasAttribute(attr::new_axis) ? concat_node->i(attr::new_axis) : 0;
+      const bool has_input_split = split_node->inputs().size() == 2;
+
+      if (has_input_split) {
+        continue;
+      }
+
+      if (split_keepdims == concat_new_axis) {
+        continue;
+      }
+
+      if (split_axis != concat_axis) {
+        continue;
+      }
+
+      concat_node->output()->replaceAllUsesWith(split_node->input());
+    }
+  }
+}
+
 void FixupONNXLoops(std::shared_ptr<Graph>& graph) {
   FixupONNXLoops(graph->block());
+  ConvertSequenceDependencies(graph->block());
+  fuseSequenceSplitConcat(graph->block());
+  EliminateDeadCode(graph->block(), true, DCESideEffectPolicy::ALLOW_DELETING_NODES_WITH_SIDE_EFFECTS);
 }
 
 } // namespace jit

--- a/torch/csrc/jit/passes/onnx/peephole.cpp
+++ b/torch/csrc/jit/passes/onnx/peephole.cpp
@@ -742,7 +742,7 @@ static void convertSplitToDynamic(Block *b, int opset_version) {
         Node* split_const_node =
             b->owningGraph()->create(onnx::Constant, 1);
         auto tensor = at::empty(split.size(), c10::kLong);
-        int64_t* data = tensor.data<int64_t>();
+        int64_t* data = tensor.data_ptr<int64_t>();
         for (auto split_size : split) {
           *data++ = split_size;
         }

--- a/torch/csrc/jit/passes/onnx/prepare_inplace_ops_for_onnx.cpp
+++ b/torch/csrc/jit/passes/onnx/prepare_inplace_ops_for_onnx.cpp
@@ -356,7 +356,7 @@ static void PrepareListPopForONNX(Block* b) {
   }
 }
 
-static void PrepareListAppendInsertForONNX(Block *b) {
+static void PrepareListAppendAndInsertForONNX(Block *b) {
   for (auto it = b->nodes().begin(), end = b->nodes().end(); it != end; ++it) {
     for (auto* child_block : it->blocks()) {
       PrepareListPopForONNX(child_block);
@@ -378,7 +378,7 @@ void PrepareInplaceOpsForONNX(const std::shared_ptr<Graph>& graph) {
   PrepareCopyForONNX(graph->block());
   PrepareIndexPutForONNX(graph->block());
   PrepareListPopForONNX(graph->block());
-  PrepareListAppendInsertForONNX(graph->block());
+  PrepareListAppendAndInsertForONNX(graph->block());
 }
 
 } // namespace jit

--- a/torch/csrc/jit/passes/onnx/prepare_inplace_ops_for_onnx.cpp
+++ b/torch/csrc/jit/passes/onnx/prepare_inplace_ops_for_onnx.cpp
@@ -328,11 +328,57 @@ void PrepareIndexPutForONNX(Block* block) {
   }
 }
 
+// aten::pop is inplace. The tensor list input is updated.
+// This pass creates an aten::__getitem__ op to return the original output from aten::pop.
+// Then it makes the original aten::pop operator return the updated tensor list,
+// and replaces all later uses of that tensor list with this new output.
+static void PrepareListPopForONNX(Block* b) {
+  for (auto it = b->nodes().begin(), end = b->nodes().end(); it != end; ++it) {
+    for (auto* child_block : it->blocks()) {
+      PrepareListPopForONNX(child_block);
+    }
+
+    if (it->kind() == aten::pop) {
+      //   %ten : Tensor = aten::pop(%seq, %pos)
+      // Convert to
+      //   %ten : Tensor = aten::__getitem__(%seq, %pos)
+      //   %new_seq : Tensor[] = aten::pop(%seq, %pos)
+      // And replace all uses of %seq afterwards with %new_seq
+      Node* getitem_node =
+          b->owningGraph()->create(aten::__getitem__, {it->inputs()});
+      getitem_node->output()->copyMetadata(it->output());
+      getitem_node->insertBefore(*it);
+      it->output()->replaceAllUsesWith(getitem_node->output());
+
+      it->output()->copyMetadata(it->inputs()[0]);
+      it->inputs()[0]->replaceAllUsesAfterNodeWith(*it, it->output());
+    }
+  }
+}
+
+static void PrepareListAppendInsertForONNX(Block *b) {
+  for (auto it = b->nodes().begin(), end = b->nodes().end(); it != end; ++it) {
+    for (auto* child_block : it->blocks()) {
+      PrepareListPopForONNX(child_block);
+    }
+
+    if (it->kind() == aten::insert || it->kind() == aten::append) {
+      if (it->outputs().size() == 0) {
+        it->addOutput();
+        it->output()->copyMetadata(it->inputs()[0]);
+      }
+      it->inputs()[0]->replaceAllUsesAfterNodeWith(*it, it->output());
+    }
+  }
+}
+
 } // namespace
 
 void PrepareInplaceOpsForONNX(const std::shared_ptr<Graph>& graph) {
   PrepareCopyForONNX(graph->block());
   PrepareIndexPutForONNX(graph->block());
+  PrepareListPopForONNX(graph->block());
+  PrepareListAppendInsertForONNX(graph->block());
 }
 
 } // namespace jit

--- a/torch/onnx/symbolic_opset11.py
+++ b/torch/onnx/symbolic_opset11.py
@@ -230,8 +230,42 @@ def masked_scatter(g, self, mask, source):
     return g.op('ScatterND', self, index, source)
 
 
+def len(g, self):
+    return g.op("SequenceLength", self)
+
+
 def __getitem_(g, self, i):
     return g.op("SequenceAt", self, i)
+
+
+def append(g, self, tensor):
+    return g.op("SequenceInsert", self, tensor)
+
+
+def insert(g, self, pos, tensor):
+    return g.op("SequenceInsert", self, tensor, pos)
+
+
+def pop(g, tensor_list, dim):
+    return g.op("SequenceErase", tensor_list, dim)
+
+
+def cat(g, tensor_list, dim):
+    if sym_help._is_packed_list(tensor_list):
+        from torch.onnx.symbolic_opset9 import cat as cat_opset9
+        return cat_opset9(g, tensor_list, dim)
+    else:
+        dim = sym_help._get_const(dim, 'i', 'dim')
+        return g.op("ConcatFromSequence", tensor_list, axis_i=dim)
+
+
+def stack(g, tensor_list, dim):
+    if sym_help._is_packed_list(tensor_list):
+        from torch.onnx.symbolic_opset9 import stack as stack_opset9
+        return stack_opset9(g, tensor_list, dim)
+    else:
+        dim = sym_help._get_const(dim, 'i', 'dim')
+        return g.op("ConcatFromSequence", tensor_list, axis_i=dim, new_axis_i=1)
 
 
 @parse_args('v', 'i', 'i', 'i')

--- a/torch/onnx/symbolic_opset11.py
+++ b/torch/onnx/symbolic_opset11.py
@@ -230,7 +230,7 @@ def masked_scatter(g, self, mask, source):
     return g.op('ScatterND', self, index, source)
 
 
-def len(g, self):
+def _len(g, self):
     return g.op("SequenceLength", self)
 
 

--- a/torch/onnx/symbolic_registry.py
+++ b/torch/onnx/symbolic_registry.py
@@ -27,6 +27,8 @@ def register_version(domain, version):
 def register_ops_helper(domain, version, iter_version):
     version_ops = get_ops_in_version(iter_version)
     for op in version_ops:
+        if op[0] == '_len':
+            op = ('len', op[1])
         if isfunction(op[1]) and not is_registered_op(op[0], domain, version):
             register_op(op[0], op[1], domain, version)
 


### PR DESCRIPTION
This is a follow-up PR after https://github.com/pytorch/pytorch/pull/29136 ~~and https://github.com/pytorch/pytorch/pull/29171~~

ONNX::Loop does not support Sequence type as loop-carried dependencies. Only tensors are supported.
This PR adds a pass that converts Sequence loop-carried dependencies to scan_outputs.
In opset 11, only the below pattern is supported.
```
PTIR graph:
 ...
 %res.1 : Tensor[] = prim::ListConstruct()
 %res : Tensor[] = prim::Loop(%11, %22, %res.1)
   block0(%i.1 : Tensor, %res.6 : Tensor[]):
     ...
     %res.3 : Tensor[] = aten::append(%res.6, %17)
     -> (%22, %res.3)
 return (%res.3)

ONNX graph:
 ...
 %res : Tensor = onnx::Loop(%11, %22)
   block0(%i.1 : Tensor):
     ...
     -> (%22, %17)
 %res_seq : Tensor[] = onnx::SplitToSequence[keepdims=0](%res)
 return (%res_seq)
```