### PR TITLE
Disable flaky test test_graph_for_py_nested_remote_call

### DIFF
--- a/test/dist_autograd_test.py
+++ b/test/dist_autograd_test.py
@@ -474,6 +474,7 @@ class DistAutogradTest(RpcAgentTestFixture):
     def test_graph_for_py_nested_call(self):
         self._test_graph_for_py_nested_call(ExecMode.RPC_SYNC)
 
+    @unittest.skip("Test is flaky, see https://github.com/pytorch/pytorch/issues/29938")
     @dist_init
     def test_graph_for_py_nested_remote_call(self):
         self._test_graph_for_py_nested_call(ExecMode.REMOTE)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#30132 Disable flaky test test_graph_for_py_nested_remote_call**

Differential Revision: [D18609560](https://our.internmc.facebook.com/intern/diff/D18609560)