### PR TITLE
[android][fbjni] fbjni gradle obey ABI_FILTERS parameter

### DIFF
--- a/android/libs/fbjni_local/build.gradle
+++ b/android/libs/fbjni_local/build.gradle
@@ -17,6 +17,9 @@ android {
                 }
             }
         }
+        ndk {
+            abiFilters ABI_FILTERS.split(",")
+        }
     }
     buildTypes {
         debug {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#30135 [android][fbjni] fbjni gradle obey ABI_FILTERS parameter**

Differential Revision: [D18610031](https://our.internmc.facebook.com/intern/diff/D18610031)

Obey the same gradle parameter as for pytorch_andrpod/build.gradle for `android.ndk.abiFilters` - `ABI_FILTERS`
To build and package only specified abis

To test:
```
gradle -p android -PABI_FILTERS=armeabi-v7a clean assembleDebug
```
```
└─ $ unzip -l ./android/pytorch_android/build/outputs/aar/pytorch_android-1.4.0-SNAPSHOT.aar
Archive:  ./android/pytorch_android/build/outputs/aar/pytorch_android-1.4.0-SNAPSHOT.aar
  Length      Date    Time    Name
---------  ---------- -----   ----
      269  02-01-1980 00:00   AndroidManifest.xml
    81895  02-01-1980 00:00   R.txt
    16368  02-01-1980 00:00   classes.jar
        0  02-01-1980 00:00   res/
        0  02-01-1980 00:00   res/values/
      116  02-01-1980 00:00   res/values/values.xml
        0  02-01-1980 00:00   jni/
        0  02-01-1980 00:00   jni/armeabi-v7a/
   579412  02-01-1980 00:00   jni/armeabi-v7a/libfbjni.so
 14854872  02-01-1980 00:00   jni/armeabi-v7a/libpytorch_jni.so
        0  02-01-1980 00:00   values/
        0  02-01-1980 00:00   armeabi-v7a/
---------                     -------
 15532932                     12 files
```