### PR TITLE
Remove unused forward declaration

### DIFF
--- a/c10/core/thread_pool.h
+++ b/c10/core/thread_pool.h
@@ -14,10 +14,6 @@
 
 namespace c10 {
 
-namespace ivalue {
-struct Future;
-} // namespace ivalue
-
 // TODO: move this to C10 and make it C10_API
 class C10_API TaskThreadPoolBase {
  public:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#30154 Remove unused forward declaration**

This doesn't seem to be used in thread_pool.cpp.

Differential Revision: [D18614141](https://our.internmc.facebook.com/intern/diff/D18614141/)