### PR TITLE
Stop showing .api as an API path component in RPC docs

### DIFF
--- a/docs/source/rpc.rst
+++ b/docs/source/rpc.rst
@@ -51,8 +51,12 @@ RPC and RRef primitives
 This library provides primitives allowing users to create and modify references
 (RRefs) to remote data as well as remotely execute functions.
 
-.. automodule:: torch.distributed.rpc.api
-    :members:
+.. automodule:: torch.distributed.rpc
+.. autofunction:: rpc_sync
+.. autofunction:: rpc_async
+.. autofunction:: remote
+.. autofunction:: get_worker_info
+.. autofunction:: join_rpc
 
 Distributed Autograd Framework
 ------------------------------


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #30066 Design doc for Remote Reference
* **#30160 Stop showing .api as an API path component in RPC docs**

The path torch.distributed.rpc.api is an implementation detail, which
should not be used by applications to import RPC APIs. Instead, all
RPC APIs are exposed directly as torch.distributed.rpc.*. This
commit makes the API doc consistent with the above expectation.

closes #30014

Differential Revision: [D18616359](https://our.internmc.facebook.com/intern/diff/D18616359)