### PR TITLE
only run embeddingbag op on cpu

### DIFF
--- a/benchmarks/operator_benchmark/pt/embeddingbag_test.py
+++ b/benchmarks/operator_benchmark/pt/embeddingbag_test.py
@@ -17,15 +17,15 @@ embeddingbag_short_configs = op_bench.cross_product_configs(
 
 
 class EmbeddingBagBenchmark(op_bench.TorchBenchmarkBase):
-    def init(self, embeddingbags, dim, mode, input_size, offset, sparse):
+    def init(self, embeddingbags, dim, mode, input_size, offset, sparse, device):
         self.embegging = torch.nn.EmbeddingBag(
             num_embeddings=embeddingbags,
             embedding_dim=dim,
             mode=mode,
-            sparse=sparse)
+            sparse=sparse).to(device=device)
         numpy.random.seed((1 << 32) - 1)
-        self.input = torch.tensor(numpy.random.randint(0, embeddingbags, input_size)).long()
-        self.offset = torch.LongTensor([offset])
+        self.input = torch.tensor(numpy.random.randint(0, embeddingbags, input_size), device=device).long()
+        self.offset = torch.LongTensor([offset], device=device)
 
         self.set_module_name('embeddingbag')
 


### PR DESCRIPTION
Summary: as title

Test Plan:
```
buck run mode/opt //caffe2/benchmarks/operator_benchmark:benchmark_all_other_test -- --tag_filter all --iterations 1 --device cuda --operators embeddingbag
# ----------------------------------------
# PyTorch/Caffe2 Operator Micro-benchmarks
# ----------------------------------------
# Tag : all
...

buck run mode/opt //caffe2/benchmarks/operator_benchmark:benchmark_all_other_test -- --tag_filter all --iterations 1 --device cuda --operators embeddingbag
# ----------------------------------------
# PyTorch/Caffe2 Operator Micro-benchmarks
# ----------------------------------------
# Tag : all

# Benchmarking PyTorch: embeddingbag
# Mode: Eager
# Name: embeddingbag_embeddingbags80_dim64_modesum_input_size8_offset0_sparseTrue_cpu
# Input: embeddingbags: 80, dim: 64, mode: sum, input_size: 8, offset: 0, sparse: True, device: cpu
Forward Execution Time (us) : 62.608
...

Reviewed By: hl475

Differential Revision: D18617540

