### PR TITLE
Update API doc for wait_all_workers after rename

### DIFF
--- a/docs/source/rpc.rst
+++ b/docs/source/rpc.rst
@@ -56,7 +56,7 @@ This library provides primitives allowing users to create and modify references
 .. autofunction:: rpc_async
 .. autofunction:: remote
 .. autofunction:: get_worker_info
-.. autofunction:: join_rpc
+.. autofunction:: wait_all_workers
 
 Distributed Autograd Framework
 ------------------------------


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#30179 Update API doc for wait_all_workers after rename**

Differential Revision: [D18623092](https://our.internmc.facebook.com/intern/diff/D18623092)