### PR TITLE
Add RPC internal helper that overrides the default pickler.

### DIFF
--- a/test/rpc_test.py
+++ b/test/rpc_test.py
@@ -14,6 +14,7 @@ from torch.distributed.rpc import RRef
 from common_utils import load_tests
 import dist_utils
 from dist_utils import dist_init
+from torch.distributed.rpc.api import _use_rpc_pickler
 from torch.distributed.rpc.internal import PythonUDF, _internal_rpc_pickler
 from rpc_agent_test_fixture import RpcAgentTestFixture
 
@@ -1161,3 +1162,11 @@ class RpcTest(RpcAgentTestFixture):
             return "expected result"
 
         self.assertEqual(test_func(self), "expected result")
+
+    def test_use_rpc_pickler(self):
+        class TestPickler():
+            pass
+        test_pickler = TestPickler()
+        with _use_rpc_pickler(test_pickler):
+            self.assertTrue(torch.distributed.rpc.api._default_pickler is test_pickler)
+        self.assertTrue(torch.distributed.rpc.api._default_pickler is _internal_rpc_pickler)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#30185 Add RPC internal helper that overrides the default pickler.**

To enable share_memory over RPC, add an internal helper that overrides the default RPC pickler.
Replace D18598974

Differential Revision: [D18621372](https://our.internmc.facebook.com/intern/diff/D18621372/)