### PR TITLE
Remove unnecessary linker flags from JNI host build

### DIFF
--- a/android/pytorch_android/CMakeLists.txt
+++ b/android/pytorch_android/CMakeLists.txt
@@ -99,10 +99,7 @@ else()
   # Prefer dynamic linking on the host
   target_link_libraries(pytorch_jni
       fbjni
-      -Wl,--gc-sections
-      -Wl,--whole-archive
       torch
-      -Wl,--no-whole-archive
       c10
       nnpack
       pytorch_qnnpack


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #30207 Enable JNI build on Mac host
* **#30206 Remove unnecessary linker flags from JNI host build**

Summary:
- --whole-archive isn't needed because we link libtorch as a dynamic
  dependency, rather than static.
- --gc-sections isn't necessary because most (all?) of the code in our
  JNI library is used (and we're not staticly linking libtorch).
  Removing this one is useful because it's not supported by lld.

Test Plan:
Built on Linux.  Library size was unchanged.
Upcoming diff enables Mac JNI build.

Differential Revision: [D18653500](https://our.internmc.facebook.com/intern/diff/D18653500)