### PR TITLE
Disable JIT optimization passes for mobile build.

### DIFF
--- a/torch/csrc/jit/graph_executor.cpp
+++ b/torch/csrc/jit/graph_executor.cpp
@@ -477,7 +477,11 @@ void GraphExecutorImplBase::run(Stack& stack) {
   logging::getLogger()->addStatValue(
       logging::runtime_counters::GRAPH_EXECUTOR_INVOCATIONS, 1.0);
 
+#ifdef USE_STATIC_DISPATCH
+  ExecutionPlan plan(graph);
+#else
   ExecutionPlan plan = getPlanFor(stack);
+#endif
   InterpreterState(plan.code).run(stack);
   last_executed_optimized_graph = plan.graph;
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#30209 Disable JIT optimization passes for mobile build.**

For custom build we need a white list of operators prior to running the model. However the operators may be modified in the optimization passes. Disable the passes for mobile build and use the original graph, so that the ops at the runtime would be consistent to the ops white listed. 