### PR TITLE
[C++ API] Fix clip_grad_norm_ / clip_grad_value_ to take input by value instead of by non-const ref

### DIFF
--- a/test/cpp/api/nn_utils.cpp
+++ b/test/cpp/api/nn_utils.cpp
@@ -10,18 +10,18 @@ using namespace torch::test;
 struct NNUtilsTest : torch::test::SeedingFixture {};
 
 TEST_F(NNUtilsTest, ClipGradNorm) {
-  auto linear_layer = Linear(10, 10);
+  auto l = Linear(10, 10);
   float max_norm = 2;
-  auto compute_norm = [linear_layer](float norm_type) -> float {
+  auto compute_norm = [&](float norm_type) -> float {
     float total_norm = 0.0;
     if (norm_type != std::numeric_limits<float>::infinity()) {
-      for (const auto& p : linear_layer->parameters()) {
+      for (const auto& p : l->parameters()) {
         total_norm +=
             p.grad().data().abs().pow(norm_type).sum().item().toFloat();
       }
       return std::pow(total_norm, 1.0 / norm_type);
     } else {
-      for (const auto& p : linear_layer->parameters()) {
+      for (const auto& p : l->parameters()) {
         auto param_max = p.grad().data().abs().max().item().toFloat();
         if (param_max > total_norm) {
           total_norm = param_max;
@@ -31,10 +31,10 @@ TEST_F(NNUtilsTest, ClipGradNorm) {
     }
   };
   auto compare_scaling =
-      [linear_layer](const std::vector<torch::Tensor>& grads) -> torch::Tensor {
+      [&](const std::vector<torch::Tensor>& grads) -> torch::Tensor {
     std::vector<torch::Tensor> p_scale;
     for (int i = 0; i < grads.size(); i++) {
-      auto param = linear_layer->parameters()[i];
+      auto param = l->parameters()[i];
       auto grad = grads[i];
       p_scale.push_back(param.grad().data().div(grad).view(-1));
     }
@@ -55,12 +55,11 @@ TEST_F(NNUtilsTest, ClipGradNorm) {
   };
   for (auto norm_type : norm_types) {
     for (int i = 0; i < grads.size(); i++) {
-      linear_layer->parameters()[i].grad() =
-          grads[i].clone().view_as(linear_layer->parameters()[i].data());
+      l->parameters()[i].grad() =
+          grads[i].clone().view_as(l->parameters()[i].data());
     }
     auto norm_before = compute_norm(norm_type);
-    auto layer_params = linear_layer->parameters();
-    auto norm = utils::clip_grad_norm_(layer_params, max_norm, norm_type);
+    auto norm = utils::clip_grad_norm_(l->parameters(), max_norm, norm_type);
     auto norm_after = compute_norm(norm_type);
     ASSERT_FLOAT_EQ(norm, norm_before);
     ASSERT_FLOAT_EQ(norm_after, max_norm);
@@ -75,11 +74,10 @@ TEST_F(NNUtilsTest, ClipGradNorm) {
   };
   for (auto norm_type : norm_types) {
     for (int i = 0; i < grads.size(); i++) {
-      linear_layer->parameters()[i].grad().data().copy_(grads[i]);
+      l->parameters()[i].grad().data().copy_(grads[i]);
     }
     auto norm_before = compute_norm(norm_type);
-    auto layer_params = linear_layer->parameters();
-    auto norm = utils::clip_grad_norm_(layer_params, max_norm, norm_type);
+    auto norm = utils::clip_grad_norm_(l->parameters(), max_norm, norm_type);
     auto norm_after = compute_norm(norm_type);
     ASSERT_FLOAT_EQ(norm, norm_before);
     ASSERT_FLOAT_EQ(norm_before, norm_after);
@@ -96,14 +94,13 @@ TEST_F(NNUtilsTest, ClipGradNorm) {
   p2.grad() = g.clone();
   for (const auto norm_type : norm_types) {
     utils::clip_grad_norm_(p1, max_norm, norm_type);
-    std::vector<torch::Tensor> params = {p2};
-    utils::clip_grad_norm_(params, max_norm, norm_type);
+    utils::clip_grad_norm_({p2}, max_norm, norm_type);
     ASSERT_TRUE(torch::allclose(p1.grad(), p2.grad()));
   }
 }
 
 TEST_F(NNUtilsTest, ClipGradValue) {
-  auto linear_layer = Linear(10, 10);
+  auto l = Linear(10, 10);
   float clip_value = 2.5;
 
   torch::Tensor grad_w = torch::arange(-50., 50).view({10, 10}).div_(5);
@@ -112,19 +109,18 @@ TEST_F(NNUtilsTest, ClipGradValue) {
       {grad_w, grad_b}, {grad_w, torch::Tensor()}};
   for (auto grad_list : grad_lists) {
     for (int i = 0; i < grad_list.size(); i++) {
-      auto p = linear_layer->parameters()[i];
+      auto p = l->parameters()[i];
       auto g = grad_list[i];
       p.grad() = g.defined() ? g.clone().view_as(p.data()) : g;
     }
 
-    auto layer_params = linear_layer->parameters();
-    utils::clip_grad_value_(layer_params, clip_value);
-    for (int i = 0; i < layer_params.size(); i++) {
-      if (layer_params[i].grad().defined()) {
+    utils::clip_grad_value_(l->parameters(), clip_value);
+    for (const auto& p : l->parameters()) {
+      if (p.grad().defined()) {
         ASSERT_LE(
-            layer_params[i].grad().data().max().item().toFloat(), clip_value);
+            p.grad().data().max().item().toFloat(), clip_value);
         ASSERT_GE(
-            layer_params[i].grad().data().min().item().toFloat(), -clip_value);
+            p.grad().data().min().item().toFloat(), -clip_value);
       }
     }
   }
@@ -136,7 +132,6 @@ TEST_F(NNUtilsTest, ClipGradValue) {
   p1.grad() = g.clone();
   p2.grad() = g.clone();
   utils::clip_grad_value_(p1, clip_value);
-  std::vector<torch::Tensor> params = {p2};
-  utils::clip_grad_value_(params, clip_value);
+  utils::clip_grad_value_({p2}, clip_value);
   ASSERT_TRUE(torch::allclose(p1.grad(), p2.grad()));
 }

--- a/torch/csrc/api/include/torch/nn/utils/clip_grad.h
+++ b/torch/csrc/api/include/torch/nn/utils/clip_grad.h
@@ -53,7 +53,7 @@ inline double clip_grad_norm_(
     std::initializer_list<Tensor> parameters,
     double max_norm,
     double norm_type = 2.0) {
-  return clip_grad_norm_(parameters, max_norm, norm_type);
+  return clip_grad_norm_(std::vector<Tensor>(parameters), max_norm, norm_type);
 }
 
 // A wrapper around clip_grad_norm_ that allows us to call the function with a
@@ -84,7 +84,7 @@ inline void clip_grad_value_(
 // A wrapper around clip_grad_value_ that allows us to call the function with a
 // braced-init list of Tensors.
 inline void clip_grad_value_(std::initializer_list<Tensor> parameters, double clip_value) {
-  clip_grad_value_(parameters, clip_value);
+  clip_grad_value_(std::vector<Tensor>(parameters), clip_value);
 }
 
 // A wrapper around clip_grad_value_ that allows us to call the function with a

--- a/torch/csrc/api/include/torch/nn/utils/clip_grad.h
+++ b/torch/csrc/api/include/torch/nn/utils/clip_grad.h
@@ -48,12 +48,21 @@ inline double clip_grad_norm_(
 }
 
 // A wrapper around clip_grad_norm_ that allows us to call the function with a
-// single Tensor.
+// braced-init list of Tensors.
 inline double clip_grad_norm_(
-    Tensor parameters,
+    std::initializer_list<Tensor> parameters,
     double max_norm,
     double norm_type = 2.0) {
-  std::vector<Tensor> params = {parameters};
+  return clip_grad_norm_(parameters, max_norm, norm_type);
+}
+
+// A wrapper around clip_grad_norm_ that allows us to call the function with a
+// single Tensor.
+inline double clip_grad_norm_(
+    Tensor parameter,
+    double max_norm,
+    double norm_type = 2.0) {
+  std::vector<Tensor> params = {parameter};
   return clip_grad_norm_(params, max_norm, norm_type);
 }
 
@@ -73,9 +82,15 @@ inline void clip_grad_value_(
 }
 
 // A wrapper around clip_grad_value_ that allows us to call the function with a
+// braced-init list of Tensors.
+inline void clip_grad_value_(std::initializer_list<Tensor> parameters, double clip_value) {
+  clip_grad_value_(parameters, clip_value);
+}
+
+// A wrapper around clip_grad_value_ that allows us to call the function with a
 // single Tensor.
-inline void clip_grad_value_(Tensor parameters, double clip_value) {
-  std::vector<Tensor> params = {parameters};
+inline void clip_grad_value_(Tensor parameter, double clip_value) {
+  std::vector<Tensor> params = {parameter};
   clip_grad_value_(params, clip_value);
 }
 

--- a/torch/csrc/api/include/torch/nn/utils/clip_grad.h
+++ b/torch/csrc/api/include/torch/nn/utils/clip_grad.h
@@ -11,7 +11,7 @@ namespace utils {
 // https://pytorch.org/docs/stable/nn.html?highlight=clip_grad_norm#torch.nn.utils.clip_grad_norm_
 // for more details about this module.
 inline double clip_grad_norm_(
-    std::vector<Tensor>& parameters,
+    std::vector<Tensor> parameters,
     double max_norm,
     double norm_type = 2.0) {
   std::vector<Tensor> params_with_grad;
@@ -50,7 +50,7 @@ inline double clip_grad_norm_(
 // A wrapper around clip_grad_norm_ that allows us to call the function with a
 // single Tensor.
 inline double clip_grad_norm_(
-    Tensor& parameters,
+    Tensor parameters,
     double max_norm,
     double norm_type = 2.0) {
   std::vector<Tensor> params = {parameters};
@@ -62,7 +62,7 @@ inline double clip_grad_norm_(
 // See https://pytorch.org/docs/stable/nn.html#clip-grad-value
 // for more details about this module.
 inline void clip_grad_value_(
-    std::vector<Tensor>& parameters,
+    std::vector<Tensor> parameters,
     double clip_value) {
 
   for (const auto& param : parameters) {
@@ -74,7 +74,7 @@ inline void clip_grad_value_(
 
 // A wrapper around clip_grad_value_ that allows us to call the function with a
 // single Tensor.
-inline void clip_grad_value_(Tensor& parameters, double clip_value) {
+inline void clip_grad_value_(Tensor parameters, double clip_value) {
   std::vector<Tensor> params = {parameters};
   clip_grad_value_(params, clip_value);
 }

--- a/torch/csrc/api/include/torch/nn/utils/clip_grad.h
+++ b/torch/csrc/api/include/torch/nn/utils/clip_grad.h
@@ -48,7 +48,7 @@ inline double clip_grad_norm_(
 }
 
 // A wrapper around clip_grad_norm_ that allows us to call the function with a
-// braced-init list of Tensors.
+// braced-init-list of Tensors.
 inline double clip_grad_norm_(
     std::initializer_list<Tensor> parameters,
     double max_norm,
@@ -82,7 +82,7 @@ inline void clip_grad_value_(
 }
 
 // A wrapper around clip_grad_value_ that allows us to call the function with a
-// braced-init list of Tensors.
+// braced-init-list of Tensors.
 inline void clip_grad_value_(std::initializer_list<Tensor> parameters, double clip_value) {
   clip_grad_value_(std::vector<Tensor>(parameters), clip_value);
 }


### PR DESCRIPTION
The original design of `torch::nn::utils::clip_grad_norm_` / `clip_grad_value_` takes input by non-const reference, which prevents users from passing rvalue reference as input into the functions. This PR changes the functions to take input by value, which 1.  fixes the problem, 2. matches the Python version's semantics, 3. adheres to the C++ API convention that if a function modifies its input in-place, it should take that input by value.