### PR TITLE
Adds decorator to run a test only on CPU and CUDA

### DIFF
--- a/test/common_device_type.py
+++ b/test/common_device_type.py
@@ -367,6 +367,19 @@ class onlyOn(object):
         return only_fn
 
 
+# Only runs the test on the CPU and CUDA (the native device types)
+def onlyOnCPUAndCUDA(fn):
+    @wraps(fn)
+    def only_fn(self, device, *args, **kwargs):
+        if self.device_type != 'cpu' and self.device_type != 'cuda':
+            reason = "Doesn't run on {0}".format(self.device_type)
+            raise unittest.SkipTest(reason)
+
+        return fn(self, device, *args, **kwargs)
+
+    return only_fn
+
+
 # Decorator that provides all available devices of the device type to the test
 # as a list of strings instead of providing a single device string.
 # Skips the test if the number of available devices of the variant's device


### PR DESCRIPTION
Per title. Preemptively prevents tests from running on non-first party backends (like XLA). 