### PR TITLE
[pytorch][cmake] call find_package(OpenMP) only when USE_OPENMP=ON

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -821,7 +821,9 @@ if (NOT NO_API)
 endif()
 
 
-find_package(OpenMP QUIET)
+if(USE_OPENMP)
+  find_package(OpenMP QUIET)
+endif()
 if(USE_OPENMP AND OPENMP_FOUND)
   message(STATUS "pytorch is compiling with OpenMP. \n"
     "OpenMP CXX_FLAGS: ${OpenMP_CXX_FLAGS}. \n"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#30223 [pytorch][cmake] call find_package(OpenMP) only when USE_OPENMP=ON**

Summary:
I ran into find_package(OpenMP) failure in some linux environment when
USE_OPENMP=OFF. Figured this workaround to unblock - not sure how hard
to find & fix the root cause of find_package() failure.

Test:
- works in my case;
- will check CI;

Differential Revision: [D18640309](https://our.internmc.facebook.com/intern/diff/D18640309)