### PR TITLE
Fixed bug in studentT logprob computation

### DIFF
--- a/torch/distributions/studentT.py
+++ b/torch/distributions/studentT.py
@@ -76,8 +76,7 @@ class StudentT(Distribution):
         if self._validate_args:
             self._validate_sample(value)
         y = (value - self.loc) / self.scale
-        Z = (self.scale.log() +
-             0.5 * self.df.log() +
+        Z = (0.5 * self.df.log() +
              0.5 * math.log(math.pi) +
              torch.lgamma(0.5 * self.df) -
              torch.lgamma(0.5 * (self.df + 1.)))


### PR DESCRIPTION
This PR is to fix the log_prob computation for the generalized student T distribution. The generalized student T is normalized in:
`y = (value - self.loc) / self.scale`
Thus, the scale term in the pdf should be removed from the pdf. It currently yields probabilities that are > 1.