### PR TITLE
Fix RRef design doc warning

### DIFF
--- a/docs/source/notes/rref.rst
+++ b/docs/source/notes/rref.rst
@@ -182,6 +182,7 @@ User Share RRef with Owner as Return Value
 
 
 .. code::
+
   import torch
   import torch.distributed.rpc as rpc
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #30259 Fix two links in RPC API doc
* #30243 Fix BackendType repr in doc
* **#30240 Fix RRef design doc warning**
* #30218 Add link to RRef protocol in RPC doc

Get rid of the following warning when build docs:

```
/Users/shenli/Project/pytorch/docs/source/notes/rref.rst:184: WARNING: Error in "code" directive:
maximum 1 argument(s) allowed, 6 supplied.

.. code::
  import torch
  import torch.distributed.rpc as rpc

  # on worker A
  rref = rpc.remote('B', torch.add, args=(torch.ones(2), 1))
  # say the rref has RRefId 100 and ForkId 1
  rref.to_here()
```

Differential Revision: [D18640016](https://our.internmc.facebook.com/intern/diff/D18640016)