### PR TITLE
Fix BackendType repr in doc

### DIFF
--- a/torch/distributed/rpc/backend_registry.py
+++ b/torch/distributed/rpc/backend_registry.py
@@ -20,12 +20,8 @@ def _backend_type_repr(self):
 
 
 # Create an enum type, `BackendType`, with empty members.
-BackendType = enum.Enum(
-    value="BackendType",
-    names={},
-    __repr__=_backend_type_repr
-)
-
+BackendType = enum.Enum(value="BackendType", names={})
+BackendType.__repr__ = _backend_type_repr
 
 def register_backend(
     backend_name, construct_rpc_agent_options_handler, init_backend_handler
@@ -55,11 +51,8 @@ def register_backend(
         },
         **existing_enum_dict
     )
-    BackendType = enum.Enum(
-        value="BackendType",
-        names=extended_enum_dict,
-        __repr__=_backend_type_repr
-    )
+    BackendType = enum.Enum(value="BackendType", names=extended_enum_dict)
+    BackendType.__repr__ = _backend_type_repr
     return BackendType[backend_name]
 
 

--- a/torch/distributed/rpc/backend_registry.py
+++ b/torch/distributed/rpc/backend_registry.py
@@ -23,6 +23,7 @@ def _backend_type_repr(self):
 BackendType = enum.Enum(value="BackendType", names={})
 BackendType.__repr__ = _backend_type_repr
 
+
 def register_backend(
     backend_name, construct_rpc_agent_options_handler, init_backend_handler
 ):

--- a/torch/distributed/rpc/backend_registry.py
+++ b/torch/distributed/rpc/backend_registry.py
@@ -17,6 +17,10 @@ BackendValue = collections.namedtuple(
 # Create an enum type, `BackendType`, with empty members.
 BackendType = enum.Enum(value="BackendType", names={})
 
+def _backend_type_repr(self):
+    return "BackendType." + self.name
+
+BackendType.__repr__ = _backend_type_repr
 
 def register_backend(
     backend_name, construct_rpc_agent_options_handler, init_backend_handler
@@ -47,6 +51,7 @@ def register_backend(
         **existing_enum_dict
     )
     BackendType = enum.Enum(value="BackendType", names=extended_enum_dict)
+    BackendType.__repr__ = _backend_type_repr
     return BackendType[backend_name]
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #30259 Fix two links in RPC API doc
* **#30243 Fix BackendType repr in doc**
* #30240 Fix RRef design doc warning
* #30218 Add link to RRef protocol in RPC doc

Before this commit, rpc docs shows init_rpc as the following:

```python
torch.distributed.rpc.init_rpc(
   name,
   backend=<BackendType.PROCESS_GROUP: BackendValue(
     construct_rpc_agent_options_handler=<function _process_group_construct_rpc_agent_options_handler>,
     init_backend_handler=<function _process_group_init_backend_handler>)>,
   init_method=None,
   rank=-1,
   world_size=None,
   rpc_agent_options=None
)
```

It unnecessarily leaks implementation details. This commit adds a
__repr__ function to BackendType Enum class to address this problem.

closes #29905

Differential Revision: [D18641559](https://our.internmc.facebook.com/intern/diff/D18641559)