### PR TITLE
[quantization] Add missing commas in conv3d tests

### DIFF
--- a/test/test_quantized_nn_mods.py
+++ b/test/test_quantized_nn_mods.py
@@ -746,7 +746,7 @@ class ModuleAPITest(QuantizationTestCase):
            use_bias=st.booleans(),
            use_fused=st.booleans(),
            use_channelwise=st.booleans(),
-           qengine=st.sampled_from(("fbgemm")))
+           qengine=st.sampled_from(("fbgemm",)))
     def test_conv3d_api(
         self, batch_size, in_channels_per_group, D, H, W,
         out_channels_per_group, groups, kernel_d, kernel_h, kernel_w,

--- a/test/test_quantized_nn_mods.py
+++ b/test/test_quantized_nn_mods.py
@@ -207,7 +207,7 @@ class FunctionalAPITest(QuantizationTestCase):
            Y_zero_point=st.integers(0, 4),
            use_bias=st.booleans(),
            use_channelwise=st.booleans(),
-           qengine=st.sampled_from(("fbgemm")))
+           qengine=st.sampled_from(("fbgemm",)))
     def test_conv3d_api(
         self, batch_size, in_channels_per_group, D, H, W,
         out_channels_per_group, groups, kernel_d, kernel_h, kernel_w,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#30247 [quantization] Add missing commas in conv3d tests**

Differential Revision: [D18643017](https://our.internmc.facebook.com/intern/diff/D18643017)