### PR TITLE
[wip][jit] Unify Optional[T] and T

### DIFF
--- a/aten/src/ATen/core/type.cpp
+++ b/aten/src/ATen/core/type.cpp
@@ -171,6 +171,21 @@ c10::optional<TypePtr> unifyTypes(const TypePtr& t1, const TypePtr& t2) {
     return OptionalType::create(t1);
   }
 
+  // if t1 is Optional[T] and t2 is T, return Optional[T] and vice versa
+  if (t1->kind() == TypeKind::OptionalType && t2->kind() != TypeKind::OptionalType) {
+    auto unified = unifyTypes(t1->expect<OptionalType>()->getElementType(), t2);
+    if (!unified) {
+      return c10::nullopt;
+    }
+    return OptionalType::create(*unified);
+  } else if (t2->kind() == TypeKind::OptionalType && t1->kind() != TypeKind::OptionalType) {
+    auto unified = unifyTypes(t2->expect<OptionalType>()->getElementType(), t1);
+    if (!unified) {
+      return c10::nullopt;
+    }
+    return OptionalType::create(*unified);
+  }
+
   //types which contain other types
   if (t1->cast<ListType>() && t2->cast<ListType>()) {
     // because we have runtime specializations of lists, e.g. int[] = std::vector<int64_t>


### PR DESCRIPTION
~~Fixes #30015~~

This should already be covered by https://github.com/pytorch/pytorch/blob/d2674603a42eae9fdfb31f901160624fb02c888d/aten/src/ATen/core/type.cpp#L152-L154
but this
https://github.com/pytorch/pytorch/blob/d2674603a42eae9fdfb31f901160624fb02c888d/aten/src/ATen/core/type.cpp#L401-L404
isn't working for some reason even though both types are `Tensor`