### PR TITLE
Avoid deprecating get_contiguous_memory_format until call sites are fixed

### DIFF
--- a/c10/core/MemoryFormat.h
+++ b/c10/core/MemoryFormat.h
@@ -31,7 +31,10 @@ enum class MemoryFormat : int8_t { Contiguous, Preserve, ChannelsLast };
 // behaviour of contiguous
 #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
 
-C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+// This should be deprecated after we expunge all of the sites in our
+// codebase (not deprecated for now as we have a number of legacy sites
+// that need to be cleaned up first
+/* C10_DEPRECATED */ inline MemoryFormat get_contiguous_memory_format() {
   return MemoryFormat::Contiguous;
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #30272 Turn off Wattributes which is buggy on GCC versions we use
* #30271 Document VERBOSE env var; it is respected.
* #30270 Shut up unused parameter warning when parameter pack is empty.
* #30269 Delete some unnecessary is_variable tests after Variable-Tensor merge.
* #30268 Increase visibility of RRef and subclasses
* #30265 s/PackedTensorAccessor/PackedTensorAccessor64/
* #30254 Add an implicit conversion from c10::List to ArrayRef, then quash a warning
* **#30252 Avoid deprecating get_contiguous_memory_format until call sites are fixed**
* #30251 s/AT_CHECK/TORCH_CHECK/

Signed-off-by: Edward Z. Yang <ezyang@fb.com>