### PR TITLE
Add an implicit conversion from c10::List to ArrayRef, then quash a warning

### DIFF
--- a/aten/src/ATen/core/List.h
+++ b/aten/src/ATen/core/List.h
@@ -428,6 +428,10 @@ public:
   // See [unsafe set type] for why this exists.
   void unsafeSetElementType(TypePtr t);
 
+  operator ArrayRef<T>() const {
+    return ArrayRef<T>(begin(), end());
+  }
+
 private:
   explicit List(c10::intrusive_ptr<detail::ListImpl<StorageT>>&& elements);
   friend struct IValue;

--- a/aten/src/ATen/core/List.h
+++ b/aten/src/ATen/core/List.h
@@ -428,8 +428,9 @@ public:
   // See [unsafe set type] for why this exists.
   void unsafeSetElementType(TypePtr t);
 
+  template <typename = typename std::enable_if<std::is_same<T, StorageT>::value, void>::type>
   operator ArrayRef<T>() const {
-    return ArrayRef<T>(begin(), end());
+    return ArrayRef<T>(impl_->list);
   }
 
 private:

--- a/aten/src/ATen/core/List.h
+++ b/aten/src/ATen/core/List.h
@@ -428,8 +428,8 @@ public:
   // See [unsafe set type] for why this exists.
   void unsafeSetElementType(TypePtr t);
 
-  template <typename = typename std::enable_if<std::is_same<T, StorageT>::value, void>::type>
-  operator ArrayRef<T>() const {
+  template <typename U = T>
+  operator typename std::enable_if<std::is_same<U, StorageT>::value, ArrayRef<U>>::type () const {
     return ArrayRef<T>(impl_->list);
   }
 

--- a/aten/src/ATen/native/quantized/cpu/qpool.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qpool.cpp
@@ -396,10 +396,10 @@ class QMaxPool2D_arr_args final : public torch::OperatorKernel {
    #endif
   Tensor operator()(
       Tensor qx,
-      std::vector<int64_t> kernel_size,
-      std::vector<int64_t> stride,
-      std::vector<int64_t> padding,
-      std::vector<int64_t> dilation,
+      c10::List<int64_t> kernel_size,
+      c10::List<int64_t> stride,
+      c10::List<int64_t> padding,
+      c10::List<int64_t> dilation,
       bool ceil_mode) {
     #ifdef USE_PYTORCH_QNNPACK
     if (at::globalContext().qEngine() == at::QEngine::QNNPACK && qx.scalar_type() == kQUInt8) {

--- a/torch/csrc/jit/register_c10_ops.cpp
+++ b/torch/csrc/jit/register_c10_ops.cpp
@@ -158,7 +158,8 @@ Operator createOperatorFromC10(const c10::OperatorHandle& op) {
                 reinterpret_cast<ListType*>(type.get())->getElementType();
             if (elem_type->isSubtypeOf(TensorType::get())) {
               AT_ASSERT(iter->isTensorList());
-              tracer::addOutput(node, stdd::vector<at::Tensor>(iter->toTensorList()));
+              // UGH, why are we converting this to a vector
+              tracer::addOutput(node, c10::impl::toVector(iter->toTensorList()));
             } else {
               throw std::runtime_error(
                   "unsupported ouptut list type: " + elem_type->str());

--- a/torch/csrc/jit/register_c10_ops.cpp
+++ b/torch/csrc/jit/register_c10_ops.cpp
@@ -158,7 +158,7 @@ Operator createOperatorFromC10(const c10::OperatorHandle& op) {
                 reinterpret_cast<ListType*>(type.get())->getElementType();
             if (elem_type->isSubtypeOf(TensorType::get())) {
               AT_ASSERT(iter->isTensorList());
-              tracer::addOutput(node, iter->toTensorList());
+              tracer::addOutput(node, stdd::vector<at::Tensor>(iter->toTensorList()));
             } else {
               throw std::runtime_error(
                   "unsupported ouptut list type: " + elem_type->str());


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #30272 Turn off Wattributes which is buggy on GCC versions we use
* #30271 Document VERBOSE env var; it is respected.
* #30270 Shut up unused parameter warning when parameter pack is empty.
* #30269 Delete some unnecessary is_variable tests after Variable-Tensor merge.
* #30268 Increase visibility of RRef and subclasses
* #30265 s/PackedTensorAccessor/PackedTensorAccessor64/
* **#30254 Add an implicit conversion from c10::List to ArrayRef, then quash a warning**
* #30252 Avoid deprecating get_contiguous_memory_format until call sites are fixed
* #30251 s/AT_CHECK/TORCH_CHECK/

Signed-off-by: Edward Z. Yang <ezyang@fb.com>