### PR TITLE
Fix int-float conversion warning

### DIFF
--- a/c10/util/Half.h
+++ b/c10/util/Half.h
@@ -450,7 +450,7 @@ typename std::enable_if<std::is_integral<From>::value && !std::is_same<From, boo
     return f > limit::max() ||
         (f < 0 && -static_cast<uint64_t>(f) > limit::max());
   } else {
-    return f < limit::lowest() || f > limit::max();
+    return f < static_cast<From>(limit::lowest()) || f >= static_cast<From>(limit::max());
   }
 }
 


### PR DESCRIPTION
Summary:
We started to see build failures with top-of-trunk LLVM compiler. The failures point to a warning that was treated as error for implicit conversion from long to double. This change added explicit cast to suppress the warning, and also tweaked the comparison to account for precision loss after long->double conversion. Note that for other conversions, this tweak may leads to slightly conservative overflow check.

```
caffe2/c10/util/Half.h:467:37: error: implicit conversion from 'long' to 'double' changes value from 9223372036854775807 to 9223372036854775808 [-Werror,-Wimplicit-int-float-conversion]
[CONTEXT]   return f < limit::lowest() || f > limit::max();
[CONTEXT]                                   ~ ^~~~~~~~~~~~
```

Test Plan:
local build clean

Differential Revision: D18642524

