### PR TITLE
Fix two links in RPC API doc

### DIFF
--- a/docs/source/rpc.rst
+++ b/docs/source/rpc.rst
@@ -16,10 +16,11 @@ RPC and RRef Framework
 
 Before using RPC and distributed autograd primitives, initialization must take
 place. To initialize the RPC framework we need to use
-`init_rpc` which would initialize the RPC framework, RRef framework
-and distributed autograd. By default, this will also initialize the
-`ProcessGroup` (:func:`torch.distributed.Backend`) backend for RPC
-communication. The `ProcessGroup` backend internally uses gloo for communication.
+:meth:`~torch.distributed.rpc.init_rpc` which would initialize the RPC
+framework, RRef framework and distributed autograd. By default, this will also
+initialize the `ProcessGroup` (:meth:`~torch.distributed.init_process_group`)
+backend for RPC communication. The `ProcessGroup` backend internally uses gloo
+for communication.
 
 
 .. automodule:: torch.distributed.rpc


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#30259 Fix two links in RPC API doc**
* #30243 Fix BackendType repr in doc
* #30240 Fix RRef design doc warning
* #30218 Add link to RRef protocol in RPC doc

Differential Revision: [D18644749](https://our.internmc.facebook.com/intern/diff/D18644749)