### PR TITLE
Error instead of assertion failure for div by sparse

### DIFF
--- a/aten/src/ATen/native/sparse/SparseTensorMath.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensorMath.cpp
@@ -164,7 +164,7 @@ Tensor& div_sparse_(Tensor& self, const Tensor& value) {
 SparseTensor& div_out_sparse_zerodim(SparseTensor& r, const SparseTensor& t, const Tensor& value) {
   TORCH_CHECK(value.dim() == 0, "sparse division only supports division by a scalar (got shape ",
       value.sizes(), " for argument 'other')");
-  TORCH_CHECK(!value.is_sparse(), "Unsupported tensor layout");
+  TORCH_CHECK(!value.is_sparse(), "Unsupported tensor layout: Can't divide a sparse tensor by a sparse value");
 
   AT_ASSERT(r.is_sparse());
   AT_ASSERT(t.is_sparse());

--- a/aten/src/ATen/native/sparse/SparseTensorMath.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensorMath.cpp
@@ -164,7 +164,7 @@ Tensor& div_sparse_(Tensor& self, const Tensor& value) {
 SparseTensor& div_out_sparse_zerodim(SparseTensor& r, const SparseTensor& t, const Tensor& value) {
   TORCH_CHECK(value.dim() == 0, "sparse division only supports division by a scalar (got shape ",
       value.sizes(), " for argument 'other')");
-  TORCH_CHECK(!value.is_sparse(), "Unsupported tensor layout: Can't divide a sparse tensor by a sparse value");
+  TORCH_CHECK(!value.is_sparse(), "A Sparse Tensor can only be divided by a scalar or zero-dim dense tensor");
 
   AT_ASSERT(r.is_sparse());
   AT_ASSERT(t.is_sparse());

--- a/aten/src/ATen/native/sparse/SparseTensorMath.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensorMath.cpp
@@ -164,6 +164,7 @@ Tensor& div_sparse_(Tensor& self, const Tensor& value) {
 SparseTensor& div_out_sparse_zerodim(SparseTensor& r, const SparseTensor& t, const Tensor& value) {
   TORCH_CHECK(value.dim() == 0, "sparse division only supports division by a scalar (got shape ",
       value.sizes(), " for argument 'other')");
+  TORCH_CHECK(!value.is_sparse(), "Unsupported tensor layout");
 
   AT_ASSERT(r.is_sparse());
   AT_ASSERT(t.is_sparse());

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -2093,6 +2093,10 @@ class TestSparse(TestCase):
             sp_tensor_loaded = pickle.loads(serialized)
             self.assertEqual(sp_tensor, sp_tensor_loaded)
 
+    def test_div_by_sparse_error(self):
+
+        self.assertRaisesRegex(RuntimeError, 'Unsupported tensor layout', 
+                               lambda: torch.tensor(1., device=self.device) / torch.tensor(1., device=self.device).to_sparse())
 
 class TestUncoalescedSparse(TestSparse):
     def setUp(self):

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -2094,9 +2094,8 @@ class TestSparse(TestCase):
             self.assertEqual(sp_tensor, sp_tensor_loaded)
 
     def test_div_by_sparse_error(self):
-
-        self.assertRaisesRegex(RuntimeError, 'Unsupported tensor layout', 
-                               lambda: torch.tensor(1., device=self.device) / torch.tensor(1., device=self.device).to_sparse())
+        self.assertRaisesRegex(RuntimeError, 'A Sparse Tensor can only be divided',
+                               lambda: torch.tensor(1., device=self.device).to_sparse() / torch.tensor(1., device=self.device).to_sparse())
 
 class TestUncoalescedSparse(TestSparse):
     def setUp(self):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#30260 Error instead of assertion failure for div by sparse**

fixes: https://github.com/pytorch/pytorch/issues/30044

Summary:

Without this PR,

```
>>> torch.tensor(1.) / torch.tensor(1.).to_sparse()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
RuntimeError: r.is_sparse() INTERNAL ASSERT FAILED at /Users/distiller/project/conda/conda-bld/pytorch_1570710797334/work/aten/src/ATen/native/sparse/SparseTensorMath.cpp:168, please report a bug to PyTorch.
```

Test Plan:

Ran the same code with this change:

```
In [1]: import torch
In [2]: torch.tensor(1).to_sparse() / torch.tensor(1).to_sparse()
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
<ipython-input-2-7177f54f30bb> in <module>
----> 1 torch.tensor(1).to_sparse() / torch.tensor(1).to_sparse()

RuntimeError: Unsupported tensor layout
```

Differential Revision: [D18657387](https://our.internmc.facebook.com/intern/diff/D18657387)