### PR TITLE
Enable test_call_method_on_rref in rpc_test

### DIFF
--- a/test/rpc_test.py
+++ b/test/rpc_test.py
@@ -1062,7 +1062,6 @@ class RpcTest(RpcAgentTestFixture):
         )
         self.assertEqual(rref_c.to_here(), torch.ones(n, n) + 4)
 
-    @unittest.skip("Test is flaky on ASAN, see https://github.com/pytorch/pytorch/issues/29117")
     @dist_init(setup_rpc=True)
     def test_call_method_on_rref(self):
         """


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#30261 Enable test_call_method_on_rref in rpc_test**

With #29827, the flakiness should disappear for test_call_method_on_rref

Differential Revision: [D18645036](https://our.internmc.facebook.com/intern/diff/D18645036)