### PR TITLE
[quantization] Dont use SubgraphRewriter in FoldQuantizeCallIntoBuffer

### DIFF
--- a/torch/csrc/jit/passes/quantization.cpp
+++ b/torch/csrc/jit/passes/quantization.cpp
@@ -948,8 +948,7 @@ graph(%self, %scale, %zero_point, %dtype):
         zero_point_node->kind() == prim::Constant &&
         dtype_node->kind() == prim::Constant;
   };
-  std::unordered_set<Node*> quantize_nodes_to_delete;
-  std::unordered_set<Node*> getattr_nodes_to_delete;
+  std::unordered_set<Node*> nodes_to_delete;
   for (const auto& match : matches) {
     if (!filter(match, vmap)) {
       continue;
@@ -968,28 +967,14 @@ graph(%self, %scale, %zero_point, %dtype):
     // Replace the GetAttr[weight]->quantize_per_tensor sequence
     // with a simple GetAttr[_quantized_weight] node.
     Value* orig_weight = match_vmap.at(vmap.at("weight"));
-    Value* orig_self = match_vmap.at(vmap.at("self"));
     Value* orig_weight_quant = match_vmap.at(vmap.at("weight_quant"));
 
-    WithInsertPoint insert_guard(orig_weight->node());
-    Value* new_weight_quant =
-        graph->insertGetAttr(orig_self, "_quantized_weight");
-    new_weight_quant->node()->setSourceRange(
-        orig_weight_quant->node()->sourceRange());
-    orig_weight_quant->replaceAllUsesWith(new_weight_quant);
-
-    quantize_nodes_to_delete.insert(orig_weight_quant->node());
-    getattr_nodes_to_delete.insert(orig_weight->node());
+    orig_weight->node()->s_(attr::name, "_quantized_weight");
+    orig_weight_quant->replaceAllUsesWith(orig_weight);
+    nodes_to_delete.insert(orig_weight_quant->node());
   }
 
-  // We need to delete the `quantize_per_tensor` nodes first,
-  // since they will have a Use of the corresponding `weight`
-  // value. Once we've deleted the quantize nodes, we can delete
-  // the original `GetAttr` nodes.
-  for (Node* n : quantize_nodes_to_delete) {
-    n->destroy();
-  }
-  for (Node* n : getattr_nodes_to_delete) {
+  for (Node* n : nodes_to_delete) {
     n->destroy();
   }
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #30199 [quantization] Use ConvPackedParams everywhere
* #30198 [quantization] Use LinearPackedParams everywhere
* #30188 [quantization] Memoize parseIR calls in graph mode quantization
* **#30264 [quantization] Dont use SubgraphRewriter in FoldQuantizeCallIntoBuffer**

Differential Revision: [D18645531](https://our.internmc.facebook.com/intern/diff/D18645531)