### PR TITLE
s/PackedTensorAccessor/PackedTensorAccessor64/

### DIFF
--- a/aten/src/ATen/native/cuda/FractionalMaxPool2d.cu
+++ b/aten/src/ATen/native/cuda/FractionalMaxPool2d.cu
@@ -35,10 +35,10 @@ __device__ inline int get_interval(accscalar_t sample,
 
 template <typename scalar_t>
 __global__ void fractional_max_pool2d_out_cuda_frame(
-  PackedTensorAccessor<scalar_t, 4> output,
-  PackedTensorAccessor<int64_t, 4> indices,
-  PackedTensorAccessor<scalar_t, 4> input,
-  PackedTensorAccessor<scalar_t, 3> samples,
+  PackedTensorAccessor64<scalar_t, 4> output,
+  PackedTensorAccessor64<int64_t, 4> indices,
+  PackedTensorAccessor64<scalar_t, 4> input,
+  PackedTensorAccessor64<scalar_t, 3> samples,
   int poolSizeH, int poolSizeW) {
 
   using accscalar_t = at::acc_type<scalar_t, /*is_cuda=*/true>;
@@ -95,9 +95,9 @@ __global__ void fractional_max_pool2d_out_cuda_frame(
 
 template <typename scalar_t>
 __global__ void fractional_max_pool2d_backward_out_cuda_frame(
-  PackedTensorAccessor<scalar_t, 4> gradInput,
-  PackedTensorAccessor<scalar_t, 4> gradOutput,
-  PackedTensorAccessor<int64_t, 4> indices) {
+  PackedTensorAccessor64<scalar_t, 4> gradInput,
+  PackedTensorAccessor64<scalar_t, 4> gradOutput,
+  PackedTensorAccessor64<int64_t, 4> indices) {
   // Output (h, w) point that this thread is responsible for
   int ourOutputPoint = threadIdx.x + blockIdx.x * blockDim.x;
   int plane = blockIdx.y;

--- a/aten/src/ATen/native/cuda/UpSampleBilinear2d.cu
+++ b/aten/src/ATen/native/cuda/UpSampleBilinear2d.cu
@@ -30,8 +30,8 @@ __global__ void upsample_bilinear2d_out_frame(
     const accscalar_t rheight,
     const accscalar_t rwidth,
     const bool align_corners,
-    const PackedTensorAccessor<scalar_t, 4> idata,
-    PackedTensorAccessor<scalar_t, 4> odata) {
+    const PackedTensorAccessor64<scalar_t, 4> idata,
+    PackedTensorAccessor64<scalar_t, 4> odata) {
   int index = threadIdx.x + blockIdx.x * blockDim.x;
 
   const int batchsize = idata.size(0);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #30272 Turn off Wattributes which is buggy on GCC versions we use
* #30271 Document VERBOSE env var; it is respected.
* #30270 Shut up unused parameter warning when parameter pack is empty.
* #30269 Delete some unnecessary is_variable tests after Variable-Tensor merge.
* #30268 Increase visibility of RRef and subclasses
* **#30265 s/PackedTensorAccessor/PackedTensorAccessor64/**
* #30254 Add an implicit conversion from c10::List to ArrayRef, then quash a warning
* #30252 Avoid deprecating get_contiguous_memory_format until call sites are fixed
* #30251 s/AT_CHECK/TORCH_CHECK/

Quash some more deprecated references.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>