### PR TITLE
Increase visibility of RRef and subclasses

### DIFF
--- a/torch/csrc/distributed/rpc/rref.h
+++ b/torch/csrc/distributed/rpc/rref.h
@@ -188,7 +188,7 @@ static_assert(
 //
 // ``RRef`` is the base type for both ``UserRRef`` and ``OwnerRRef``.
 // Each ``RRef`` has a globally unique ``RRefId``.
-class RRef {
+class TORCH_API RRef {
  public:
   // RRef is made NOT copyable NOT movable to prevent messing up reference
   // counting.
@@ -230,7 +230,7 @@ class RRef {
 // never owns the real value, the only way to get the value of the ``RRef`` is
 // to call ``to_here()`` and get a copy..
 template <typename T>
-class UserRRef final : public RRef {
+class UserRRef TORCH_API final : public RRef {
  public:
   UserRRef(const UserRRef& other) = delete;
   UserRRef(UserRRef&& other) = delete;
@@ -266,7 +266,7 @@ class UserRRef final : public RRef {
 // Keep the template only on the derived class because ``RRefContext`` needs to
 // erase the type on ``RRef`` and keep them in one map.
 template <typename T>
-class OwnerRRef final : public RRef {
+class OwnerRRef TORCH_API final : public RRef {
  public:
   OwnerRRef(const OwnerRRef& other) = delete;
   OwnerRRef(OwnerRRef&& other) = delete;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #30272 Turn off Wattributes which is buggy on GCC versions we use
* #30271 Document VERBOSE env var; it is respected.
* #30270 Shut up unused parameter warning when parameter pack is empty.
* #30269 Delete some unnecessary is_variable tests after Variable-Tensor merge.
* **#30268 Increase visibility of RRef and subclasses**
* #30265 s/PackedTensorAccessor/PackedTensorAccessor64/
* #30254 Add an implicit conversion from c10::List to ArrayRef, then quash a warning
* #30252 Avoid deprecating get_contiguous_memory_format until call sites are fixed
* #30251 s/AT_CHECK/TORCH_CHECK/

This quashes the warning:

```
../torch/csrc/distributed/rpc/rref.cpp:206:28: warning: ‘torch::distributed::rpc::OwnerRRef<T>::getValue()
 const [with T = pybind11::object]::<lambda()>’ declared with greater visibility than the type of its fiel
 d ‘torch::distributed::rpc::OwnerRRef<T>::getValue() const [with T = pybind11::object]::<lambda()>::<this capture>’ [-Wattributes]
    valueCV_.wait(lock, [this] { return value_.has_value(); });
```

Signed-off-by: Edward Z. Yang <ezyang@fb.com>