### PR TITLE
Shut up unused parameter warning when parameter pack is empty.

### DIFF
--- a/aten/src/ATen/native/cuda/Loops.cuh
+++ b/aten/src/ATen/native/cuda/Loops.cuh
@@ -107,6 +107,9 @@ template <typename traits, typename func_t, typename index_t, size_t... INDEX>
 C10_HOST_DEVICE typename traits::result_type
 invoke_impl(const func_t &f, char *const C10_RESTRICT data[], const index_t strides[], int i,
             c10::guts::index_sequence<INDEX...>) {
+  // Shut up unused parameter warning when parameter pack is empty
+  (void)strides;
+  (void)i;
   return f(*(typename traits::template arg<INDEX>::type*)(data[INDEX] + i * strides[INDEX])...);
 }
 
@@ -121,6 +124,9 @@ template <typename traits, typename func_t, typename index_t, size_t... I>
 C10_HOST_DEVICE typename traits::result_type
 invoke_impl(const func_t &f, char *const C10_RESTRICT data[], const index_t strides[], const ScalarType dtypes[], int i,
             c10::guts::index_sequence<I...>) {
+  // Shut up unused parameter warning when parameter pack is empty
+  (void)strides;
+  (void)i;
   return f(c10::fetch_and_cast<typename traits::template arg<I>::type>(dtypes[I], data[I] + i * strides[I])...);
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #30272 Turn off Wattributes which is buggy on GCC versions we use
* #30271 Document VERBOSE env var; it is respected.
* **#30270 Shut up unused parameter warning when parameter pack is empty.**
* #30269 Delete some unnecessary is_variable tests after Variable-Tensor merge.
* #30268 Increase visibility of RRef and subclasses
* #30265 s/PackedTensorAccessor/PackedTensorAccessor64/
* #30254 Add an implicit conversion from c10::List to ArrayRef, then quash a warning
* #30252 Avoid deprecating get_contiguous_memory_format until call sites are fixed
* #30251 s/AT_CHECK/TORCH_CHECK/

Signed-off-by: Edward Z. Yang <ezyang@fb.com>