### PR TITLE
Document VERBOSE env var; it is respected.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,10 @@
 #   DEBUG
 #     build with -O0 and -g (debug symbols)
 #
+#   VERBOSE
+#     run ninja/make verbosely, printing out each compile command as it
+#     compiles commands
+#
 #   REL_WITH_DEB_INFO
 #     build with optimizations and -g (debug symbols)
 #


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #30272 Turn off Wattributes which is buggy on GCC versions we use
* **#30271 Document VERBOSE env var; it is respected.**
* #30270 Shut up unused parameter warning when parameter pack is empty.
* #30269 Delete some unnecessary is_variable tests after Variable-Tensor merge.
* #30268 Increase visibility of RRef and subclasses
* #30265 s/PackedTensorAccessor/PackedTensorAccessor64/
* #30254 Add an implicit conversion from c10::List to ArrayRef, then quash a warning
* #30252 Avoid deprecating get_contiguous_memory_format until call sites are fixed
* #30251 s/AT_CHECK/TORCH_CHECK/

Signed-off-by: Edward Z. Yang <ezyang@fb.com>