### PR TITLE
Turn off Wattributes which is buggy on GCC versions we use

### DIFF
--- a/cmake/public/utils.cmake
+++ b/cmake/public/utils.cmake
@@ -257,6 +257,9 @@ function(torch_compile_options libname)
         -Wno-missing-field-initializers
         -Wno-write-strings
         -Wno-unknown-pragmas
+        # Bug for visibility of lambdas
+        # https://stackoverflow.com/questions/44390898/gcc-6-x-warning-about-lambda-visibility
+        -Wno-attributes
         # Clang has an unfixed bug leading to spurious missing braces
         # warnings, see https://bugs.llvm.org/show_bug.cgi?id=21629
         -Wno-missing-braces


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#30272 Turn off Wattributes which is buggy on GCC versions we use**
* #30271 Document VERBOSE env var; it is respected.
* #30270 Shut up unused parameter warning when parameter pack is empty.
* #30269 Delete some unnecessary is_variable tests after Variable-Tensor merge.
* #30268 Increase visibility of RRef and subclasses
* #30265 s/PackedTensorAccessor/PackedTensorAccessor64/
* #30254 Add an implicit conversion from c10::List to ArrayRef, then quash a warning
* #30252 Avoid deprecating get_contiguous_memory_format until call sites are fixed
* #30251 s/AT_CHECK/TORCH_CHECK/

Signed-off-by: Edward Z. Yang <ezyang@fb.com>