### PR TITLE
Support in-place update in IndexHashOp

### DIFF
--- a/caffe2/operators/index_hash_ops.cc
+++ b/caffe2/operators/index_hash_ops.cc
@@ -16,6 +16,7 @@ specified number. All input and output indices are enforced to be positive.
 )DOC")
     .Input(0, "Indices", "Input feature indices.")
     .Output(0, "HashedIndices", "Hashed feature indices.")
+    .AllowOneToOneInplace()
     .Arg("seed", "seed for the hash function")
     .Arg("modulo", "must be > 0, hashed ids will be modulo this number")
     .TensorInferenceFunction([](const OperatorDef& /* unused */,


### PR DESCRIPTION
Summary: `IndexHash` did not support in-place update.

Differential Revision: D18612231

