### PR TITLE
[Mobile] Rename function parameters to avoid [-Werror,-Wshadow]

### DIFF
--- a/aten/src/ATen/core/dispatch/Dispatcher.h
+++ b/aten/src/ATen/core/dispatch/Dispatcher.h
@@ -181,9 +181,9 @@ inline Return Dispatcher::callUnboxed(const OperatorHandle& op, Args... args) co
 }
 
 template<class Return, class... Args>
-inline Return Dispatcher::doCallUnboxed(const DispatchTable& dispatchTable, const LeftRight<ska::flat_hash_map<TensorTypeId, KernelFunction>>& backendFallbackKernels_, Args... args) const {
+inline Return Dispatcher::doCallUnboxed(const DispatchTable& dispatchTable, const LeftRight<ska::flat_hash_map<TensorTypeId, KernelFunction>>& backendFallbackKernels, Args... args) const {
   detail::unused_arg_(args...);  // workaround for a false-positive warning about unused parameters in gcc 5
-  return backendFallbackKernels_.read([&] (const ska::flat_hash_map<TensorTypeId, KernelFunction>& backendFallbackKernels) -> Return {
+  return backendFallbackKernels.read([&] (const ska::flat_hash_map<TensorTypeId, KernelFunction>& backendFallbackKernels) -> Return {
     c10::optional<TensorTypeId> dispatchKey = dispatchTable.dispatchKeyExtractor().getDispatchKeyUnboxed(args...);
     const KernelFunction& kernel = dispatch_(dispatchTable, backendFallbackKernels, dispatchKey);
     return kernel.template callUnboxed<Return, Args...>(std::forward<Args>(args)...);
@@ -203,9 +203,9 @@ inline Return Dispatcher::callUnboxedOnly(const OperatorHandle& op, Args... args
 }
 
 template<class Return, class... Args>
-inline Return Dispatcher::doCallUnboxedOnly(const DispatchTable& dispatchTable, const LeftRight<ska::flat_hash_map<TensorTypeId, KernelFunction>>& backendFallbackKernels_, Args... args) const {
+inline Return Dispatcher::doCallUnboxedOnly(const DispatchTable& dispatchTable, const LeftRight<ska::flat_hash_map<TensorTypeId, KernelFunction>>& backendFallbackKernels, Args... args) const {
   detail::unused_arg_(args...);  // workaround for a false-positive warning about unused parameters in gcc 5
-  return backendFallbackKernels_.read([&] (const ska::flat_hash_map<TensorTypeId, KernelFunction>& backendFallbackKernels) -> Return {
+  return backendFallbackKernels.read([&] (const ska::flat_hash_map<TensorTypeId, KernelFunction>& backendFallbackKernels) -> Return {
     c10::optional<TensorTypeId> dispatchKey = dispatchTable.dispatchKeyExtractor().getDispatchKeyUnboxed<Args...>(args...);
     const KernelFunction& kernel = dispatch_(dispatchTable, backendFallbackKernels, dispatchKey);
     return kernel.template callUnboxedOnly<Return, Args...>(std::forward<Args>(args)...);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#30276 [Mobile] Rename function parameters to avoid [-Werror,-Wshadow]**

### Summary

When building PyTorch for iOS in BUCK, the compiler complains about the ivar shadowing 

```
/Users/taox/fbsource/xplat/caffe2/aten/src/ATen/core/dispatch/Dispatcher.h:184:144: error: declaration shadows a field of 'c10::Dispatcher' [-Werror,-Wshadow]
inline Return Dispatcher::doCallUnboxed(const DispatchTable& dispatchTable, const LeftRight<ska::flat_hash_map<TensorTypeId, KernelFunction>>& backendFallbackKernels_, Args... args) const {
                                                                                                                                               ^
/Users/taox/fbsource/xplat/caffe2/aten/src/ATen/core/dispatch/Dispatcher.h:134:63: note: previous declaration is here
  LeftRight<ska::flat_hash_map<TensorTypeId, KernelFunction>> backendFallbackKernels_;
```
This happens because the internal iOS compiler enforces the `[-Werror, -Wshadow]` on every source file when compiling. Say in `benchmark.mm` we import `<torch/script.h>`, then it'll  leads all the way to `Dispatcher.h`

```
 In file included from Apps/Internal/PyTorchPlayground/PyTorchPlayground/Application/Benchmark/Benchmark.mm:6:
In file included from /Users/taox/fbsource/xplat/caffe2/aten/src/ATen/ATen.h:5:
In file included from /Users/taox/fbsource/xplat/caffe2/aten/src/ATen/Context.h:4:
In file included from /Users/taox/fbsource/xplat/caffe2/aten/src/ATen/Tensor.h:12:
In file included from buck-out/cells/fbsource/gen/xplat/caffe2/TensorMethods.h/TensorMethods.h:10:
/Users/taox/fbsource/xplat/caffe2/aten/src/ATen/core/dispatch/Dispatcher.h
```
It'd be better to have a separate name for function parameters. 

cc @shoumikhin

Differential Revision: [D18649116](https://our.internmc.facebook.com/intern/diff/D18649116)