### PR TITLE
[REMOVED]

### DIFF
--- a/torch/csrc/api/include/torch/utils/hooks.h
+++ b/torch/csrc/api/include/torch/utils/hooks.h
@@ -41,7 +41,19 @@ class RemovableHandle(object):
 
 #pragma once
 
-/// A handle which provides the capability to remove a hook.
-struct RemovableHandle {
+namespace torch {
+namespace utils {
+namespace hooks {
 
-}
+/// A handle which provides the capability to remove a hook.
+class RemovableHandle {
+ public:
+  // yf225 TODO: let's use a std::weak_ptr to mimick Python version behavior
+  explicit RemovableHandle() {}
+ private:
+  static int64_t next_id;
+};
+
+} // namespace hooks
+} // namespace utils
+} // namespace torch

--- a/torch/csrc/api/src/utils/hooks.cpp
+++ b/torch/csrc/api/src/utils/hooks.cpp
@@ -1,0 +1,11 @@
+#include <torch/utils/hooks.h>
+
+namespace torch {
+namespace utils {
+namespace hooks {
+
+int64_t RemovableHandle::next_id = 0;
+
+} // namespace hooks
+} // namespace utils
+} // namespace torch


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#30278 [WIP] add RemovableHandle, and use it for Variable.register_hook, and remove Variable.remove_hook**
* #30277 Use torch::OrderedDict instead of std::vector to store hooks for Variable

