### PR TITLE
[REMOVE]

### DIFF
--- a/torch/csrc/api/include/torch/utils/hooks.h
+++ b/torch/csrc/api/include/torch/utils/hooks.h
@@ -1,0 +1,47 @@
+/*
+from __future__ import absolute_import, division, print_function, unicode_literals
+import collections
+import weakref
+import warnings
+
+
+class RemovableHandle(object):
+    """A handle which provides the capability to remove a hook."""
+
+    next_id = 0
+
+    def __init__(self, hooks_dict):
+        self.hooks_dict_ref = weakref.ref(hooks_dict)
+        self.id = RemovableHandle.next_id
+        RemovableHandle.next_id += 1
+
+    def remove(self):
+        hooks_dict = self.hooks_dict_ref()
+        if hooks_dict is not None and self.id in hooks_dict:
+            del hooks_dict[self.id]
+
+    def __getstate__(self):
+        return (self.hooks_dict_ref(), self.id)
+
+    def __setstate__(self, state):
+        if state[0] is None:
+            # create a dead reference
+            self.hooks_dict_ref = weakref.ref(collections.OrderedDict())
+        else:
+            self.hooks_dict_ref = weakref.ref(state[0])
+        self.id = state[1]
+        RemovableHandle.next_id = max(RemovableHandle.next_id, self.id + 1)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, tb):
+        self.remove()
+*/
+
+#pragma once
+
+/// A handle which provides the capability to remove a hook.
+struct RemovableHandle {
+
+}

--- a/torch/csrc/api/src/utils/hooks.cpp
+++ b/torch/csrc/api/src/utils/hooks.cpp
@@ -1,0 +1,11 @@
+#include <torch/utils/hooks.h>
+
+namespace torch {
+namespace utils {
+namespace hooks {
+
+int64_t RemovableHandle::next_id = 0;
+
+} // namespace hooks
+} // namespace utils
+} // namespace torch


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#30280 [WIP] add RemovableHandle, and use it for Variable.register_hook, and remove Variable.remove_hook**
* #30279 Use torch::OrderedDict instead of std::vector to store hooks for Variable

