### PR TITLE
[pytorch][ci] add mobile build CI with host toolchain

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1925,6 +1925,13 @@ workflows:
           ios_platform: "OS"
           requires:
             - setup
+      # PyTorch Mobile PR builds (use linux host toolchain + mobile build options)
+      - pytorch_linux_build:
+          name: pytorch_linux_xenial_py3_clang5_mobile_build
+          requires:
+            - setup
+          build_environment: "pytorch-linux-xenial-py3-clang5-mobile-build"
+          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3-clang5-asan:405"
       - pytorch_linux_test:
           name: pytorch_linux_xenial_py3_6_gcc5_4_ge_config_legacy_test
           requires:

--- a/.circleci/generate_config_yml.py
+++ b/.circleci/generate_config_yml.py
@@ -94,6 +94,7 @@ YAML_SOURCES = [
     File("workflows-pytorch-macos-builds.yml"),
     File("workflows-pytorch-android-gradle-build.yml"),
     File("workflows-pytorch-ios-builds.yml"),
+    File("workflows-pytorch-mobile-builds.yml"),
     File("workflows-pytorch-ge-config-tests.yml"),
     Listgen(caffe2_build_definitions.get_workflow_jobs, 3),
     File("workflows-binary-builds-smoke-subset.yml"),

--- a/.circleci/scripts/should_run_job.py
+++ b/.circleci/scripts/should_run_job.py
@@ -58,6 +58,8 @@ default_set = set([
     # Pytorch iOS builds
     'pytorch-ios-10.2.1-x86_64_build',
     'pytorch-ios-10.2.1-arm64_build',
+    # PyTorch Mobile builds
+    'pytorch_linux_xenial_py3_clang5_mobile_build',
 
     # Pytorch backward compatibility check
     'pytorch-linux-backward-compatibility-check-test',

--- a/.circleci/scripts/should_run_job.py
+++ b/.circleci/scripts/should_run_job.py
@@ -59,7 +59,7 @@ default_set = set([
     'pytorch-ios-10.2.1-x86_64_build',
     'pytorch-ios-10.2.1-arm64_build',
     # PyTorch Mobile builds
-    'pytorch_linux_xenial_py3_clang5_mobile_build',
+    'pytorch-linux-xenial-py3-clang5-mobile-build',
 
     # Pytorch backward compatibility check
     'pytorch-linux-backward-compatibility-check-test',

--- a/.circleci/verbatim-sources/workflows-pytorch-mobile-builds.yml
+++ b/.circleci/verbatim-sources/workflows-pytorch-mobile-builds.yml
@@ -1,0 +1,7 @@
+      # PyTorch Mobile PR builds (use linux host toolchain + mobile build options)
+      - pytorch_linux_build:
+          name: pytorch_linux_xenial_py3_clang5_mobile_build
+          requires:
+            - setup
+          build_environment: "pytorch-linux-xenial-py3-clang5-mobile-build"
+          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3-clang5-asan:405"

--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -36,6 +36,12 @@ if [[ "$BUILD_ENVIRONMENT" == *-linux-xenial-py3-clang5-asan* ]]; then
   exec "$(dirname "${BASH_SOURCE[0]}")/build-asan.sh" "$@"
 fi
 
+if [[ "$BUILD_ENVIRONMENT" == *-linux-xenial-py3-clang5-mobile* ]]; then
+  # Use linux host toolchain + mobile build options in order to build & test
+  # mobile libtorch without having to setup Android/iOS toolchain/simulator.
+  exec ./scripts/build_mobile.sh -DBUILD_BINARY=ON "$@"
+fi
+
 echo "Python version:"
 python --version
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#30292 [pytorch][ci] add mobile build CI with host toolchain**

Summary:
We already have CI jobs to build Android/iOS libraries, but there are
two issues:
- It's no easy for people who are not regularly working on mobile to debug
these CI errors as they need setup Android/iOS build environment;
- It's hard to run cross-compiled mobile libraries as it requires
emulator. It happened a couple times recently that it can build but fail
to load and run a model with mobile build.

To address these problems, create this new CI job to build mobile
library with linux host toolchain so that we can build & test without
involving Android/iOS environment/simulator. Will add tests on top of it next.

Test Plan:
- check the new CI job

Differential Revision: [D18654074](https://our.internmc.facebook.com/intern/diff/D18654074)