### PR TITLE
add_hparams does not log hparam metric with spaces

### DIFF
--- a/torch/utils/tensorboard/summary.py
+++ b/torch/utils/tensorboard/summary.py
@@ -121,8 +121,8 @@ def hparams(hparam_dict=None, metric_dict=None):
         logging.warning('parameter: metric_dict should be a dictionary, nothing logged.')
         raise TypeError('parameter: metric_dict should be a dictionary, nothing logged.')
 
-    hps = [HParamInfo(name=k) for k in hparam_dict.keys()]
-    mts = [MetricInfo(name=MetricName(tag=k)) for k in metric_dict.keys()]
+    hps = [HParamInfo(name=k.replace(" ", "_")) for k in hparam_dict.keys()]
+    mts = [MetricInfo(name=MetricName(tag=k.replace(" ", "_"))) for k in metric_dict.keys()]
 
     exp = Experiment(hparam_infos=hps, metric_infos=mts)
 
@@ -137,21 +137,22 @@ def hparams(hparam_dict=None, metric_dict=None):
 
     ssi = SessionStartInfo()
     for k, v in hparam_dict.items():
+        key = k.replace(" ", "_")
         if isinstance(v, int) or isinstance(v, float):
-            ssi.hparams[k].number_value = v
+            ssi.hparams[key].number_value = v
             continue
 
         if isinstance(v, string_types):
-            ssi.hparams[k].string_value = v
+            ssi.hparams[key].string_value = v
             continue
 
         if isinstance(v, bool):
-            ssi.hparams[k].bool_value = v
+            ssi.hparams[key].bool_value = v
             continue
 
         if isinstance(v, torch.Tensor):
             v = make_np(v)[0]
-            ssi.hparams[k].number_value = v
+            ssi.hparams[key].number_value = v
             continue
         raise ValueError('value should be one of int, float, str, bool, or torch.Tensor')
 

--- a/torch/utils/tensorboard/writer.py
+++ b/torch/utils/tensorboard/writer.py
@@ -308,7 +308,7 @@ class SummaryWriter(object):
             w_hp.file_writer.add_summary(ssi)
             w_hp.file_writer.add_summary(sei)
             for k, v in metric_dict.items():
-                w_hp.add_scalar(k, v)
+                w_hp.add_scalar(k.replace(" ", "_"), v)
 
     def add_scalar(self, tag, scalar_value, global_step=None, walltime=None):
         """Add scalar data to summary.


### PR DESCRIPTION
Summary:
See GitHub issue:
https://github.com/pytorch/pytorch/issues/28765

Test Plan:
```
def test():
    writer = summary_writer()
    writer.add_hparams({"a 1": 0, "b": 0}, {"hparam/test accuracy": 0.5})
    writer.add_hparams({"a 1": 0, "b": 1}, {"hparam/test accuracy": 0.6})
    writer.add_hparams({"a 1": 1, "b": 0}, {"hparam/test accuracy": 0.61})
    writer.add_hparams({"a 1": 1, "b": 1}, {"hparam/test accuracy": 0.4})
    writer.add_hparams({"a 1": 2.0, "b": 1.5}, {"hparam/test accuracy": 0.7})
    writer.flush()
    writer.close()

test()
```

{F223164707}

Differential Revision: D18655030

