### PR TITLE
Annotate CUDAGenerator.h with correct TORCH_CUDA_API

### DIFF
--- a/aten/src/ATen/CUDAGenerator.h
+++ b/aten/src/ATen/CUDAGenerator.h
@@ -2,9 +2,11 @@
 
 #include <ATen/core/Generator.h>
 
+// TODO: this file should be in ATen/cuda, not top level
+
 namespace at {
 
-struct CAFFE2_API CUDAGenerator : public Generator {
+struct TORCH_CUDA_API CUDAGenerator : public Generator {
   // Constructors
   CUDAGenerator(DeviceIndex device_index = -1);
   ~CUDAGenerator() = default;
@@ -28,8 +30,8 @@ private:
 namespace cuda {
 namespace detail {
 
-  CAFFE2_API CUDAGenerator* getDefaultCUDAGenerator(DeviceIndex device_index = -1);
-  CAFFE2_API std::shared_ptr<CUDAGenerator> createCUDAGenerator(DeviceIndex device_index = -1);
+  TORCH_CUDA_API CUDAGenerator* getDefaultCUDAGenerator(DeviceIndex device_index = -1);
+  TORCH_CUDA_API std::shared_ptr<CUDAGenerator> createCUDAGenerator(DeviceIndex device_index = -1);
 
 } // namespace detail
 } // namespace cuda


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #30309 Add missing TORCH_API to some sparse helpers
* #30308 DEFINE_DISPATCH in the correct namespace.
* #30307 Use normal dispatch to get to CUDA threshold kernels, instead of DispatchStub.
* #30306 Add missing CAFFE2_API annotations to NamedTensorUtils.h
* **#30305 Annotate CUDAGenerator.h with correct TORCH_CUDA_API**

This is actually CUDA related functionality with its implementation living
in the cuda/ folder.  For some reason it lives at the top level; it
should be moved (but that should be handled in another PR.)

Signed-off-by: Edward Z. Yang <ezyang@fb.com>