### PR TITLE
Add missing TORCH_API to some sparse helpers

### DIFF
--- a/aten/src/ATen/native/sparse/SparseTensorMath.h
+++ b/aten/src/ATen/native/sparse/SparseTensorMath.h
@@ -5,7 +5,7 @@
 
 namespace at { namespace native {
 
-sparse::SparseTensor& mul_out_sparse_scalar(sparse::SparseTensor& r, const sparse::SparseTensor& t, Scalar value);
-sparse::SparseTensor& mul_out_sparse_zerodim(sparse::SparseTensor& r, const sparse::SparseTensor& t, const Tensor& value);
+TORCH_API sparse::SparseTensor& mul_out_sparse_scalar(sparse::SparseTensor& r, const sparse::SparseTensor& t, Scalar value);
+TORCH_API sparse::SparseTensor& mul_out_sparse_zerodim(sparse::SparseTensor& r, const sparse::SparseTensor& t, const Tensor& value);
 
 }}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#30309 Add missing TORCH_API to some sparse helpers**
* #30308 DEFINE_DISPATCH in the correct namespace.
* #30307 Use normal dispatch to get to CUDA threshold kernels, instead of DispatchStub.
* #30306 Add missing CAFFE2_API annotations to NamedTensorUtils.h
* #30305 Annotate CUDAGenerator.h with correct TORCH_CUDA_API

These get used from CUDA code, so they need TORCH_API if we split
torch into torch_cpu and torch_cuda

Signed-off-by: Edward Z. Yang <ezyang@fb.com>