### PR TITLE
Emergency disable sccache on OS X.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1032,10 +1032,10 @@ jobs:
             export IN_CIRCLECI=1
 
             # Install sccache
-            brew install openssl
-            sudo curl https://s3.amazonaws.com/ossci-macos/sccache --output /usr/local/bin/sccache
-            sudo chmod +x /usr/local/bin/sccache
-            export SCCACHE_BUCKET=ossci-compiler-cache-circleci-v2
+            # See https://github.com/pytorch/pytorch/issues/30321
+            # sudo curl https://s3.amazonaws.com/ossci-macos/sccache --output /usr/local/bin/sccache
+            # sudo chmod +x /usr/local/bin/sccache
+            # export SCCACHE_BUCKET=ossci-compiler-cache-circleci-v2
 
             # This IAM user allows write access to S3 bucket for sccache
             set +x
@@ -1115,10 +1115,10 @@ jobs:
             sudo chmod a+r /Developer/NVIDIA/CUDA-9.2/include/cudnn.h /Developer/NVIDIA/CUDA-9.2/lib/libcudnn*
 
             # Install sccache
-            brew install openssl
-            sudo curl https://s3.amazonaws.com/ossci-macos/sccache --output /usr/local/bin/sccache
-            sudo chmod +x /usr/local/bin/sccache
-            export SCCACHE_BUCKET=ossci-compiler-cache-circleci-v2
+            # See https://github.com/pytorch/pytorch/issues/30321
+            # sudo curl https://s3.amazonaws.com/ossci-macos/sccache --output /usr/local/bin/sccache
+            # sudo chmod +x /usr/local/bin/sccache
+            # export SCCACHE_BUCKET=ossci-compiler-cache-circleci-v2
             # This IAM user allows write access to S3 bucket for sccache
             set +x
             export AWS_ACCESS_KEY_ID=${CIRCLECI_AWS_ACCESS_KEY_FOR_SCCACHE_S3_BUCKET_V4}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1032,6 +1032,7 @@ jobs:
             export IN_CIRCLECI=1
 
             # Install sccache
+            brew install openssl
             sudo curl https://s3.amazonaws.com/ossci-macos/sccache --output /usr/local/bin/sccache
             sudo chmod +x /usr/local/bin/sccache
             export SCCACHE_BUCKET=ossci-compiler-cache-circleci-v2
@@ -1114,6 +1115,7 @@ jobs:
             sudo chmod a+r /Developer/NVIDIA/CUDA-9.2/include/cudnn.h /Developer/NVIDIA/CUDA-9.2/lib/libcudnn*
 
             # Install sccache
+            brew install openssl
             sudo curl https://s3.amazonaws.com/ossci-macos/sccache --output /usr/local/bin/sccache
             sudo chmod +x /usr/local/bin/sccache
             export SCCACHE_BUCKET=ossci-compiler-cache-circleci-v2

--- a/.circleci/verbatim-sources/job-specs-custom.yml
+++ b/.circleci/verbatim-sources/job-specs-custom.yml
@@ -107,10 +107,10 @@
             export IN_CIRCLECI=1
 
             # Install sccache
-            brew install openssl
-            sudo curl https://s3.amazonaws.com/ossci-macos/sccache --output /usr/local/bin/sccache
-            sudo chmod +x /usr/local/bin/sccache
-            export SCCACHE_BUCKET=ossci-compiler-cache-circleci-v2
+            # See https://github.com/pytorch/pytorch/issues/30321
+            # sudo curl https://s3.amazonaws.com/ossci-macos/sccache --output /usr/local/bin/sccache
+            # sudo chmod +x /usr/local/bin/sccache
+            # export SCCACHE_BUCKET=ossci-compiler-cache-circleci-v2
 
             # This IAM user allows write access to S3 bucket for sccache
             set +x
@@ -190,10 +190,10 @@
             sudo chmod a+r /Developer/NVIDIA/CUDA-9.2/include/cudnn.h /Developer/NVIDIA/CUDA-9.2/lib/libcudnn*
 
             # Install sccache
-            brew install openssl
-            sudo curl https://s3.amazonaws.com/ossci-macos/sccache --output /usr/local/bin/sccache
-            sudo chmod +x /usr/local/bin/sccache
-            export SCCACHE_BUCKET=ossci-compiler-cache-circleci-v2
+            # See https://github.com/pytorch/pytorch/issues/30321
+            # sudo curl https://s3.amazonaws.com/ossci-macos/sccache --output /usr/local/bin/sccache
+            # sudo chmod +x /usr/local/bin/sccache
+            # export SCCACHE_BUCKET=ossci-compiler-cache-circleci-v2
             # This IAM user allows write access to S3 bucket for sccache
             set +x
             export AWS_ACCESS_KEY_ID=${CIRCLECI_AWS_ACCESS_KEY_FOR_SCCACHE_S3_BUCKET_V4}

--- a/.circleci/verbatim-sources/job-specs-custom.yml
+++ b/.circleci/verbatim-sources/job-specs-custom.yml
@@ -107,6 +107,7 @@
             export IN_CIRCLECI=1
 
             # Install sccache
+            brew install openssl
             sudo curl https://s3.amazonaws.com/ossci-macos/sccache --output /usr/local/bin/sccache
             sudo chmod +x /usr/local/bin/sccache
             export SCCACHE_BUCKET=ossci-compiler-cache-circleci-v2
@@ -189,6 +190,7 @@
             sudo chmod a+r /Developer/NVIDIA/CUDA-9.2/include/cudnn.h /Developer/NVIDIA/CUDA-9.2/lib/libcudnn*
 
             # Install sccache
+            brew install openssl
             sudo curl https://s3.amazonaws.com/ossci-macos/sccache --output /usr/local/bin/sccache
             sudo chmod +x /usr/local/bin/sccache
             export SCCACHE_BUCKET=ossci-compiler-cache-circleci-v2

--- a/.jenkins/pytorch/macos-build.sh
+++ b/.jenkins/pytorch/macos-build.sh
@@ -27,21 +27,21 @@ else
   fi
 fi
 
-if which sccache > /dev/null; then
-  printf "#!/bin/sh\nexec sccache $(which clang++) \$*" > "${WORKSPACE_DIR}/clang++"
-  chmod a+x "${WORKSPACE_DIR}/clang++"
+# if which sccache > /dev/null; then
+#   printf "#!/bin/sh\nexec sccache $(which clang++) \$*" > "${WORKSPACE_DIR}/clang++"
+#   chmod a+x "${WORKSPACE_DIR}/clang++"
 
-  printf "#!/bin/sh\nexec sccache $(which clang) \$*" > "${WORKSPACE_DIR}/clang"
-  chmod a+x "${WORKSPACE_DIR}/clang"
+#   printf "#!/bin/sh\nexec sccache $(which clang) \$*" > "${WORKSPACE_DIR}/clang"
+#   chmod a+x "${WORKSPACE_DIR}/clang"
 
-  if [[ "${BUILD_ENVIRONMENT}" == *cuda* ]]; then
-    printf "#!/bin/sh\nexec sccache $(which nvcc) \$*" > "${WORKSPACE_DIR}/nvcc"
-    chmod a+x "${WORKSPACE_DIR}/nvcc"
-    export CUDA_NVCC_EXECUTABLE="${WORKSPACE_DIR}/nvcc"
-  fi
+#   if [[ "${BUILD_ENVIRONMENT}" == *cuda* ]]; then
+#     printf "#!/bin/sh\nexec sccache $(which nvcc) \$*" > "${WORKSPACE_DIR}/nvcc"
+#     chmod a+x "${WORKSPACE_DIR}/nvcc"
+#     export CUDA_NVCC_EXECUTABLE="${WORKSPACE_DIR}/nvcc"
+#   fi
 
-  export PATH="${WORKSPACE_DIR}:$PATH"
-fi
+#   export PATH="${WORKSPACE_DIR}:$PATH"
+# fi
 
 # If we run too many parallel jobs, we will OOM
 MAX_JOBS=2 USE_DISTRIBUTED=1 python setup.py install

--- a/.jenkins/pytorch/macos-build.sh
+++ b/.jenkins/pytorch/macos-build.sh
@@ -27,21 +27,21 @@ else
   fi
 fi
 
-# if which sccache > /dev/null; then
-#   printf "#!/bin/sh\nexec sccache $(which clang++) \$*" > "${WORKSPACE_DIR}/clang++"
-#   chmod a+x "${WORKSPACE_DIR}/clang++"
+if which sccache > /dev/null; then
+  printf "#!/bin/sh\nexec sccache $(which clang++) \$*" > "${WORKSPACE_DIR}/clang++"
+  chmod a+x "${WORKSPACE_DIR}/clang++"
 
-#   printf "#!/bin/sh\nexec sccache $(which clang) \$*" > "${WORKSPACE_DIR}/clang"
-#   chmod a+x "${WORKSPACE_DIR}/clang"
+  printf "#!/bin/sh\nexec sccache $(which clang) \$*" > "${WORKSPACE_DIR}/clang"
+  chmod a+x "${WORKSPACE_DIR}/clang"
 
-#   if [[ "${BUILD_ENVIRONMENT}" == *cuda* ]]; then
-#     printf "#!/bin/sh\nexec sccache $(which nvcc) \$*" > "${WORKSPACE_DIR}/nvcc"
-#     chmod a+x "${WORKSPACE_DIR}/nvcc"
-#     export CUDA_NVCC_EXECUTABLE="${WORKSPACE_DIR}/nvcc"
-#   fi
+  if [[ "${BUILD_ENVIRONMENT}" == *cuda* ]]; then
+    printf "#!/bin/sh\nexec sccache $(which nvcc) \$*" > "${WORKSPACE_DIR}/nvcc"
+    chmod a+x "${WORKSPACE_DIR}/nvcc"
+    export CUDA_NVCC_EXECUTABLE="${WORKSPACE_DIR}/nvcc"
+  fi
 
-#   export PATH="${WORKSPACE_DIR}:$PATH"
-# fi
+  export PATH="${WORKSPACE_DIR}:$PATH"
+fi
 
 # If we run too many parallel jobs, we will OOM
 MAX_JOBS=2 USE_DISTRIBUTED=1 python setup.py install


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#30319 Emergency disable sccache on OS X.**

Our current binaries do not appear to be compatible with
CircleCI's new OS X environment.

See https://github.com/pytorch/pytorch/issues/30321

Signed-off-by: Edward Z. Yang <ezyang@fb.com>