### PR TITLE
Use correct API macro in VariableHooksInterface.

### DIFF
--- a/aten/src/ATen/core/VariableHooksInterface.h
+++ b/aten/src/ATen/core/VariableHooksInterface.h
@@ -50,10 +50,10 @@ struct CAFFE2_API VariableHooksInterface {
   virtual const std::string& name(const Tensor&) const = 0;
 };
 
-C10_API void SetVariableHooks(VariableHooksInterface* hooks);
-C10_API VariableHooksInterface* GetVariableHooks();
+CAFFE2_API void SetVariableHooks(VariableHooksInterface* hooks);
+CAFFE2_API VariableHooksInterface* GetVariableHooks();
 
-struct C10_API VariableHooksRegisterer {
+struct CAFFE2_API VariableHooksRegisterer {
   explicit VariableHooksRegisterer(VariableHooksInterface* hooks) {
     SetVariableHooks(hooks);
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#30320 Use correct API macro in VariableHooksInterface.**

Fixes #30296

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D18665704](https://our.internmc.facebook.com/intern/diff/D18665704)