### PR TITLE
[iOS]Update Cocoapods to 1.4.0

### DIFF
--- a/ios/LibTorch.podspec
+++ b/ios/LibTorch.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = 'LibTorch'
-    s.version          = '1.3.1'
+    s.version          = '1.4.0'
     s.authors          = 'PyTorch Team'
     s.license          = { :type => 'BSD' }
     s.homepage         = 'https://github.com/pytorch/pytorch'


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#30326 [iOS]Update Cocoapods to 1.4.0**

Note that this PR won't trigger the cocoapods build. We'll push the binary and release the cocoapods after the branch cut.

Differential Revision: [D18660308](https://our.internmc.facebook.com/intern/diff/D18660308)