### PR TITLE
PRAGMA missing for clang

### DIFF
--- a/aten/src/TH/generic/THTensorApply.hpp
+++ b/aten/src/TH/generic/THTensorApply.hpp
@@ -61,7 +61,11 @@ if (std::isnan(val)) break;
 #define th_isnan_break(val)
 #endif
 
-#ifdef _MSC_VER
+#if defined(__clang__)
+#define PRAGMA(P) _Pragma(#P)
+#define PRAGMA_IVDEP      // Noop
+#define PRAGMA_SIMD       // Noop
+#elif defined(_MSC_VER)
 #define PRAGMA(P)         __pragma(P)
 # if _MSC_VER < 1920
 // MSVC < 2019 doesn't support loop pragmas.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#30351 PRAGMA missing for clang**

Not sure what proper fix is, clang is having trouble with the loop pragmas. This at least gets things compiling.

Differential Revision: [D18665812](https://our.internmc.facebook.com/intern/diff/D18665812/)