### PR TITLE
bad tbb lambda capture, bad chunk size

### DIFF
--- a/aten/src/ATen/ParallelNativeTBB.h
+++ b/aten/src/ATen/ParallelNativeTBB.h
@@ -27,9 +27,15 @@ inline void parallel_for(
     f(begin, end);
     return;
   }
+
+  // Choose number of tasks based on grain size and number of threads.
+  int64_t chunk_size = divup((end - begin), get_num_threads());
+  // Make sure each task is at least grain_size size.
+  chunk_size = std::max(grain_size, chunk_size);
+
   std::atomic_flag err_flag = ATOMIC_FLAG_INIT;
   std::exception_ptr eptr;
-  tbb::parallel_for(tbb::blocked_range<int64_t>(begin, end, grain_size),
+  tbb::parallel_for(tbb::blocked_range<int64_t>(begin, end, chunk_size),
     [&eptr, &err_flag, f](const tbb::blocked_range<int64_t>& r) {
       try {
         f(r.begin(), r.end());
@@ -59,12 +65,18 @@ inline scalar_t parallel_reduce(
   if ((end - begin) < grain_size || get_num_threads() == 1) {
     return f(begin, end, ident);
   }
+
+  // Choose number of tasks based on grain size and number of threads.
+  int64_t chunk_size = divup((end - begin), get_num_threads());
+  // Make sure each task is at least grain_size size.
+  chunk_size = std::max(grain_size, chunk_size);
+
   scalar_t result;
   std::atomic_flag err_flag = ATOMIC_FLAG_INIT;
   std::exception_ptr eptr;
   result = tbb::parallel_reduce(
-    tbb::blocked_range<int64_t>(begin, end, grain_size), ident,
-    [&eptr, &err_flag, f, ident]
+    tbb::blocked_range<int64_t>(begin, end, chunk_size), ident,
+    [&eptr, &err_flag, f]
         (const tbb::blocked_range<int64_t>& r, scalar_t ident) {
       try {
         return f(r.begin(), r.end(), ident);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#30352 bad tbb lambda capture, bad chunk size**

1) tbb forwards us ident through parameter, we don't need to capture it.
2) tbb is being passed steps <= 0 which is bad.

Taken from TBB documentation:
```
The index type must be an integral type. The loop must not wrap around. The step value must be positive. If omitted, it is implicitly 1.
```

I have a build that uses `TBB_USE_DEBUG=1` and there are currently a lot of issues with PyTorch use.
Is TBB version not tested very much right now?

Differential Revision: [D18666029](https://our.internmc.facebook.com/intern/diff/D18666029/)