### PR TITLE
Bug fix: Handle missing keys in observer state dict during load

### DIFF
--- a/torch/quantization/fake_quantize.py
+++ b/torch/quantization/fake_quantize.py
@@ -108,9 +108,14 @@ class FakeQuantize(Module):
     def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict,
                               missing_keys, unexpected_keys, error_msgs):
 
-        self.scale = state_dict.pop(prefix + 'scale')
-        self.zero_point = state_dict.pop(prefix + 'zero_point')
-        super(FakeQuantize, self)._load_from_state_dict(state_dict, prefix, local_metadata, False,
+        local_state = ['scale', 'zero_point']
+        for name in local_state:
+            key = prefix + name
+            if key in state_dict:
+                setattr(self, name, state_dict.pop(key))
+            elif strict:
+                missing_keys.append(key)
+        super(FakeQuantize, self)._load_from_state_dict(state_dict, prefix, local_metadata, strict,
                                                         missing_keys, unexpected_keys, error_msgs)
 
 default_fake_quant = FakeQuantize.with_args(observer=MovingAverageMinMaxObserver, quant_min=0, quant_max=255,

--- a/torch/quantization/observer.py
+++ b/torch/quantization/observer.py
@@ -329,9 +329,14 @@ class MinMaxObserver(_ObserverBase):
     def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict,
                               missing_keys, unexpected_keys, error_msgs):
 
-        self.min_val = state_dict.pop(prefix + 'min_val')
-        self.max_val = state_dict.pop(prefix + 'max_val')
-        super(MinMaxObserver, self)._load_from_state_dict(state_dict, prefix, local_metadata, False,
+        local_state = ['min_val', 'max_val']
+        for name in local_state:
+            key = prefix + name
+            if key in state_dict:
+                setattr(self, name, state_dict.pop(key))
+            elif strict:
+                missing_keys.append(key)
+        super(MinMaxObserver, self)._load_from_state_dict(state_dict, prefix, local_metadata, strict,
                                                           missing_keys, unexpected_keys, error_msgs)
 
 
@@ -483,9 +488,14 @@ class PerChannelMinMaxObserver(_ObserverBase):
 
     def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict,
                               missing_keys, unexpected_keys, error_msgs):
-        self.min_vals = state_dict.pop(prefix + 'min_vals')
-        self.max_vals = state_dict.pop(prefix + 'max_vals')
-        super(PerChannelMinMaxObserver, self)._load_from_state_dict(state_dict, prefix, local_metadata, False,
+        local_state = ['min_vals', 'max_vals']
+        for name in local_state:
+            key = prefix + name
+            if key in state_dict:
+                setattr(self, name, state_dict.pop(key))
+            elif strict:
+                missing_keys.append(key)
+        super(PerChannelMinMaxObserver, self)._load_from_state_dict(state_dict, prefix, local_metadata, strict,
                                                                     missing_keys, unexpected_keys, error_msgs)
 
 class MovingAveragePerChannelMinMaxObserver(PerChannelMinMaxObserver):
@@ -819,9 +829,15 @@ class HistogramObserver(_ObserverBase):
 
     def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict,
                               missing_keys, unexpected_keys, error_msgs):
-        self.min_val = state_dict.pop(prefix + 'min_val')
-        self.max_val = state_dict.pop(prefix + 'max_val')
-        super(HistogramObserver, self)._load_from_state_dict(state_dict, prefix, local_metadata, False,
+
+        local_state = ['min_val', 'max_val']
+        for name in local_state:
+            key = prefix + name
+            if key in state_dict:
+                setattr(self, name, state_dict.pop(key))
+            elif strict:
+                missing_keys.append(key)
+        super(HistogramObserver, self)._load_from_state_dict(state_dict, prefix, local_metadata, strict,
                                                              missing_keys, unexpected_keys, error_msgs)
 
 class RecordingObserver(_ObserverBase):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#30357 Bug fix: Handle missing keys in observer state dict during load**

Fix issue https://github.com/pytorch/pytorch/issues/29032 in loading from state dict for observers and fake quant.

Differential Revision: [D18668517](https://our.internmc.facebook.com/intern/diff/D18668517/)