### PR TITLE
[Mobile] Use `gettimeofday` on iOS

### DIFF
--- a/torch/csrc/autograd/profiler.h
+++ b/torch/csrc/autograd/profiler.h
@@ -14,7 +14,9 @@
 #ifndef _WIN32
 #include <ctime>
 #endif
-
+#ifdef C10_IOS
+#include <sys/time.h>
+#endif
 #include <torch/csrc/autograd/record_function.h>
 
 typedef struct CUevent_st* CUDAEventStub;
@@ -76,7 +78,7 @@ inline int64_t getTime() {
   using namespace std::chrono;
   using clock = std::conditional<high_resolution_clock::is_steady, high_resolution_clock, steady_clock>::type;
   return duration_cast<nanoseconds>(clock::now().time_since_epoch()).count();
-#elif defined(__MACH__) && !defined(CLOCK_REALTIME)
+#elif (defined(__MACH__) && !defined(CLOCK_REALTIME)) || defined(C10_IOS)
   struct timeval now;
   gettimeofday(&now, NULL);
   return static_cast<int64_t>(now.tv_sec) * 1000000000 + static_cast<int64_t>(now.tv_usec) * 1000;

--- a/torch/csrc/autograd/profiler.h
+++ b/torch/csrc/autograd/profiler.h
@@ -14,6 +14,7 @@
 #ifndef _WIN32
 #include <ctime>
 #endif
+
 #include <torch/csrc/autograd/record_function.h>
 
 typedef struct CUevent_st* CUDAEventStub;
@@ -68,7 +69,7 @@ constexpr inline size_t ceilToMultiple(size_t a, size_t b) {
 #include <sys/time.h>
 // clock_gettime is not implemented on older versions of OS X (< 10.12).
 // If implemented, CLOCK_REALTIME will have already been defined.
-// For iOS, clock_gettime is only available on iOS 10.0 or newer. 
+// clock_gettime is only available on iOS 10.0 or newer. 
 #endif
 
 inline int64_t getTime() {

--- a/torch/csrc/autograd/profiler.h
+++ b/torch/csrc/autograd/profiler.h
@@ -14,9 +14,6 @@
 #ifndef _WIN32
 #include <ctime>
 #endif
-#ifdef C10_IOS
-#include <sys/time.h>
-#endif
 #include <torch/csrc/autograd/record_function.h>
 
 typedef struct CUevent_st* CUDAEventStub;
@@ -67,10 +64,11 @@ constexpr inline size_t ceilToMultiple(size_t a, size_t b) {
   return ((a + b - 1) / b) * b;
 }
 
-#if defined(__MACH__) && !defined(CLOCK_REALTIME)
+#if (defined(__MACH__) && !defined(CLOCK_REALTIME)) || defined(C10_IOS)
 #include <sys/time.h>
 // clock_gettime is not implemented on older versions of OS X (< 10.12).
 // If implemented, CLOCK_REALTIME will have already been defined.
+// For iOS, clock_gettime is only available on iOS 10.0 or newer. 
 #endif
 
 inline int64_t getTime() {

--- a/torch/csrc/autograd/profiler.h
+++ b/torch/csrc/autograd/profiler.h
@@ -69,7 +69,9 @@ constexpr inline size_t ceilToMultiple(size_t a, size_t b) {
 #include <sys/time.h>
 // clock_gettime is not implemented on older versions of OS X (< 10.12).
 // If implemented, CLOCK_REALTIME will have already been defined.
-// clock_gettime is only available on iOS 10.0 or newer. 
+
+// clock_gettime is only available on iOS 10.0 or newer. Unlike OS X, iOS can't rely on
+// CLOCK_REALTIME, as it is defined no matter if clock_gettime is implemented or not
 #endif
 
 inline int64_t getTime() {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#30361 [Mobile] Use `gettimeofday` on iOS**

### Summary

By default, the compiler will choose `clock_gettime` for the iOS build. However, that API is not available until iOS 10. Since the Facebook app still supports iOS 9.0,  we have to use `gettimeofday` instead.

```shell
xplat/caffe2/torch/csrc/autograd/profiler.h:86:3: error: 'clock_gettime' is only available on iOS 10.0 or newer [-Werror,-Wunguarded-availability]

xplat/caffe2/torch/csrc/autograd/profiler.h:86:17: error: '_CLOCK_MONOTONIC' is only available on iOS 10.0 or newer [-Werror,-Wunguarded-availability]
```

P.S. the open-sourced version is iOS 12.0 and above, so we don't have this problem.

### Test Plan

- buck build works
- Don't break CIs

Differential Revision: [D18730262](https://our.internmc.facebook.com/intern/diff/D18730262)