### PR TITLE
[quant] Refactor QAT Conv module for better extensibility

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -993,7 +993,7 @@ graph(%x : Tensor,
                    .check('Tensor = aten::conv2d') \
                    .check('Observer = prim::GetAttr[name="_observer_') \
                    .check_next('prim::CallMethod[name="forward"](%_observer_') \
-                   .run(str(m._c.getattr("conv")._get_method('conv2d_forward').graph))
+                   .run(str(m._c.getattr("conv")._get_method('_conv_forward').graph))
 
     @_tmp_donotuse_dont_inline_everything
     def test_insert_observers_child_qconfig(self):
@@ -1046,8 +1046,8 @@ graph(%x : Tensor,
         check_not_observed(get_forward_graph(m._c))
         # check conv.forward is observed
         check_not_observed(get_forward_graph(m._c.getattr('conv')))
-        # check conv.conv2d_forward is observed
-        check_observed(get_module_method(m, 'conv', 'conv2d_forward').graph)
+        # check conv._conv_forward is observed
+        check_observed(get_module_method(m, 'conv', '_conv_forward').graph)
         # check sub is not observed
         check_not_observed(get_module_method(m, 'sub', 'forward'))
         # check forward of sub.linear is observed
@@ -1168,7 +1168,7 @@ graph(%x : Tensor,
                        .check(quant_func) \
                        .check_next("aten::dequantize") \
                        .check("return") \
-                       .run(str(get_module_method(m, 'conv', 'conv2d_forward').graph))
+                       .run(str(get_module_method(m, 'conv', '_conv_forward').graph))
 
     def test_insert_prepack_unpack(self):
         # Module with linear and per tensor/channel quantized weight

--- a/torch/nn/intrinsic/qat/modules/conv_fused.py
+++ b/torch/nn/intrinsic/qat/modules/conv_fused.py
@@ -5,37 +5,18 @@ import torch.nn.intrinsic
 import torch.nn.qat as nnqat
 import torch.nn.functional as F
 from torch.nn import init
+from torch.nn.modules.utils import _pair
 
 
-class ConvBn2d(nn.Conv2d):
-    r"""
-    A ConvBn2d module is a module fused from Conv2d and BatchNorm2d,
-    attached with FakeQuantize modules for both output activation and weight,
-    used in quantization aware training.
-
-    We combined the interface of :class:`torch.nn.Conv2d` and
-    :class:`torch.nn.BatchNorm2d`.
-
-    Implementation details: https://arxiv.org/pdf/1806.08342.pdf section 3.2.2
-
-    Similar to :class:`torch.nn.Conv2d`, with FakeQuantize modules initialized
-    to default.
-
-    Attributes:
-        freeze_bn:
-        activation_post_process: fake quant module for output activation
-        weight_fake_quant: fake quant module for weight
-
-    """
-    _FLOAT_MODULE = torch.nn.intrinsic.ConvBn2d
-
+class _ConvBnNd(nn.modules.conv._ConvNd):
     def __init__(self,
-                 # Conv2d args
-                 in_channels, out_channels, kernel_size, stride=1,
-                 padding=0, dilation=1, groups=1,
+                 # ConvNd args
+                 in_channels, out_channels, kernel_size, stride,
+                 padding, dilation, transposed, output_padding,
+                 groups,
                  # bias: None, only support Conv with no bias
-                 padding_mode='zeros',
-                 # BatchNorm2d args
+                 padding_mode,
+                 # BatchNormNd args
                  # num_features: out_channels
                  eps=1e-05, momentum=0.1,
                  # affine: True
@@ -43,8 +24,9 @@ class ConvBn2d(nn.Conv2d):
                  # Args for this module
                  freeze_bn=False,
                  qconfig=None):
-        super(ConvBn2d, self).__init__(in_channels, out_channels, kernel_size,
-                                       stride, padding, dilation, groups, False, padding_mode)
+        nn.modules.conv._ConvNd.__init__(self, in_channels, out_channels, kernel_size,
+                                        stride, padding, dilation, transposed,
+                                        output_padding, groups, False, padding_mode)
         assert qconfig, 'qconfig must be provided for QAT module'
         self.qconfig = qconfig
         self.eps = eps
@@ -73,7 +55,7 @@ class ConvBn2d(nn.Conv2d):
         init.zeros_(self.beta)
 
     def reset_parameters(self):
-        super(ConvBn2d, self).reset_parameters()
+        super(_ConvBnNd, self).reset_parameters()
         # A hack to avoid resetting on undefined parameters
         if hasattr(self, 'gamma'):
             self.reset_bn_parameters()
@@ -110,7 +92,7 @@ class ConvBn2d(nn.Conv2d):
         running_std = torch.sqrt(self.running_var + self.eps)
         scale_factor = self.gamma / running_std
         scaled_weight = self.weight * scale_factor.reshape([-1, 1, 1, 1])
-        conv = self.conv2d_forward(input, self.weight_fake_quant(scaled_weight))
+        conv = self._conv_forward(input, self.weight_fake_quant(scaled_weight))
 
         if self.training and not self.freeze_bn:
             # recovering original conv to get original batch_mean and batch_var
@@ -136,7 +118,7 @@ class ConvBn2d(nn.Conv2d):
 
     def extra_repr(self):
         # TODO(jerryzh): extend
-        return super(ConvBn2d, self).extra_repr()
+        return super(_ConvBnNd, self).extra_repr()
 
     def forward(self, input):
         return self.activation_post_process(self._forward(input))
@@ -170,6 +152,51 @@ class ConvBn2d(nn.Conv2d):
         qat_convbn.running_var = bn.running_var
         qat_convbn.num_batches_tracked = bn.num_batches_tracked
         return qat_convbn
+
+class ConvBn2d(_ConvBnNd, nn.Conv2d):
+    r"""
+    A ConvBn2d module is a module fused from Conv2d and BatchNorm2d,
+    attached with FakeQuantize modules for both output activation and weight,
+    used in quantization aware training.
+
+    We combined the interface of :class:`torch.nn.Conv2d` and
+    :class:`torch.nn.BatchNorm2d`.
+
+    Implementation details: https://arxiv.org/pdf/1806.08342.pdf section 3.2.2
+
+    Similar to :class:`torch.nn.Conv2d`, with FakeQuantize modules initialized
+    to default.
+
+    Attributes:
+        freeze_bn:
+        activation_post_process: fake quant module for output activation
+        weight_fake_quant: fake quant module for weight
+
+    """
+    _FLOAT_MODULE = torch.nn.intrinsic.ConvBn2d
+
+    def __init__(self,
+                 # ConvNd args
+                 in_channels, out_channels, kernel_size, stride=1,
+                 padding=0, dilation=1, groups=1,
+                 # bias: None, only support Conv with no bias
+                 padding_mode='zeros',
+                 # BatchNorm2d args
+                 # num_features: out_channels
+                 eps=1e-05, momentum=0.1,
+                 # affine: True
+                 # track_running_stats: True
+                 # Args for this module
+                 freeze_bn=False,
+                 qconfig=None):
+        kernel_size = _pair(kernel_size)
+        stride = _pair(stride)
+        padding = _pair(padding)
+        dilation = _pair(dilation)
+        _ConvBnNd.__init__(self,
+            in_channels, out_channels, kernel_size, stride, padding, dilation,
+            False, _pair(0), groups, padding_mode,
+            eps, momentum, freeze_bn, qconfig)
 
 class ConvBnReLU2d(ConvBn2d):
     r"""
@@ -214,8 +241,7 @@ class ConvBnReLU2d(ConvBn2d):
                                            qconfig)
 
     def forward(self, input):
-        return self.activation_post_process(
-            F.relu(super(ConvBnReLU2d, self)._forward(input)))
+        return self.activation_post_process(F.relu(self._forward(input)))
 
     @classmethod
     def from_float(cls, mod, qconfig=None):
@@ -252,7 +278,7 @@ class ConvReLU2d(nnqat.Conv2d):
 
     def forward(self, input):
         return self.activation_post_process(F.relu(
-            super(ConvReLU2d, self).conv2d_forward(input, self.weight_fake_quant(self.weight))))
+            self._conv_forward(input, self.weight_fake_quant(self.weight))))
 
     @classmethod
     def from_float(cls, mod, qconfig=None):

--- a/torch/nn/intrinsic/qat/modules/conv_fused.py
+++ b/torch/nn/intrinsic/qat/modules/conv_fused.py
@@ -25,8 +25,8 @@ class _ConvBnNd(nn.modules.conv._ConvNd):
                  freeze_bn=False,
                  qconfig=None):
         nn.modules.conv._ConvNd.__init__(self, in_channels, out_channels, kernel_size,
-                                        stride, padding, dilation, transposed,
-                                        output_padding, groups, False, padding_mode)
+                                         stride, padding, dilation, transposed,
+                                         output_padding, groups, False, padding_mode)
         assert qconfig, 'qconfig must be provided for QAT module'
         self.qconfig = qconfig
         self.eps = eps
@@ -193,10 +193,9 @@ class ConvBn2d(_ConvBnNd, nn.Conv2d):
         stride = _pair(stride)
         padding = _pair(padding)
         dilation = _pair(dilation)
-        _ConvBnNd.__init__(self,
-            in_channels, out_channels, kernel_size, stride, padding, dilation,
-            False, _pair(0), groups, padding_mode,
-            eps, momentum, freeze_bn, qconfig)
+        _ConvBnNd.__init__(self, in_channels, out_channels, kernel_size, stride,
+                           padding, dilation, False, _pair(0), groups, padding_mode,
+                           eps, momentum, freeze_bn, qconfig)
 
 class ConvBnReLU2d(ConvBn2d):
     r"""

--- a/torch/nn/intrinsic/qat/modules/conv_fused.py
+++ b/torch/nn/intrinsic/qat/modules/conv_fused.py
@@ -240,7 +240,7 @@ class ConvBnReLU2d(ConvBn2d):
                                            qconfig)
 
     def forward(self, input):
-        return self.activation_post_process(F.relu(self._forward(input)))
+        return self.activation_post_process(F.relu(ConvBn2d._forward(self, input)))
 
     @classmethod
     def from_float(cls, mod, qconfig=None):

--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -331,7 +331,7 @@ class Conv2d(_ConvNd):
             in_channels, out_channels, kernel_size, stride, padding, dilation,
             False, _pair(0), groups, bias, padding_mode)
 
-    def conv2d_forward(self, input, weight):
+    def _conv_forward(self, input, weight):
         if self.padding_mode == 'circular':
             expanded_padding = ((self.padding[1] + 1) // 2, self.padding[1] // 2,
                                 (self.padding[0] + 1) // 2, self.padding[0] // 2)
@@ -342,7 +342,7 @@ class Conv2d(_ConvNd):
                         self.padding, self.dilation, self.groups)
 
     def forward(self, input):
-        return self.conv2d_forward(input, self.weight)
+        return self._conv_forward(input, self.weight)
 
 class Conv3d(_ConvNd):
     r"""Applies a 3D convolution over an input signal composed of several input

--- a/torch/nn/qat/modules/conv.py
+++ b/torch/nn/qat/modules/conv.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
-from torch.nn import Conv2d as NNConv2d
+import torch.nn as nn
 from torch.nn.intrinsic import ConvReLU2d
 
-class Conv2d(NNConv2d):
+class Conv2d(nn.Conv2d):
     r"""
     A Conv2d module attached with FakeQuantize modules for both output
     activation and weight, used for quantization aware training.
@@ -18,7 +18,7 @@ class Conv2d(NNConv2d):
         activation_post_process: fake quant module for output activation
         weight_fake_quant: fake quant module for weight
     """
-    _FLOAT_MODULE = NNConv2d
+    _FLOAT_MODULE = nn.Conv2d
 
     def __init__(self, in_channels, out_channels, kernel_size, stride=1,
                  padding=0, dilation=1, groups=1,
@@ -33,7 +33,7 @@ class Conv2d(NNConv2d):
 
     def forward(self, input):
         return self.activation_post_process(
-            self.conv2d_forward(input, self.weight_fake_quant(self.weight)))
+            self._conv_forward(input, self.weight_fake_quant(self.weight)))
 
     @classmethod
     def from_float(cls, mod, qconfig=None):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#30362 [quant] Refactor QAT Conv module for better extensibility**

Summary:
Right now the qat modules(qat.ConvBn2d, qat.ConvBnReLU2d, qat.Conv2d)
are not convinent to support other dimensions of Conv, this PR refactors
these modules so that we can support Conv1d/Conv3d better

Test Plan:
python test/test_quantization.py

Reviewers:
pt1quant

Subscribers:

Tasks:

Tags:

Differential Revision: [D18691152](https://our.internmc.facebook.com/intern/diff/D18691152)