### PR TITLE
inline to prevent duplicate obj when linking

### DIFF
--- a/test/cpp/jit/test_misc.cpp
+++ b/test/cpp/jit/test_misc.cpp
@@ -68,7 +68,7 @@
 
 namespace torch {
 namespace jit {
-c10::OperatorOptions aliasAnalysisFromSchema() {
+inline c10::OperatorOptions aliasAnalysisFromSchema() {
   c10::OperatorOptions result;
   result.setAliasAnalysis(c10::AliasAnalysisKind::FROM_SCHEMA);
   return result;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#30363 inline to prevent duplicate obj when linking**

getting duplicate definition errors when linking test.

Differential Revision: [D18669686](https://our.internmc.facebook.com/intern/diff/D18669686/)