### PR TITLE
Updates to Quantization documentation

### DIFF
--- a/docs/source/quantization.rst
+++ b/docs/source/quantization.rst
@@ -546,6 +546,13 @@ Functional interface
 .. autofunction:: conv2d
 .. autofunction:: conv3d
 .. autofunction:: max_pool2d
+.. autofunction:: adaptive_avg_pool2d
+.. autofunction:: avg_pool2d
+.. autofunction:: interpolate
+.. autofunction:: upsample
+.. autofunction:: upsample_bilinear
+.. autofunction:: upsample_nearest
+
 
 .. automodule:: torch.nn.quantized
 

--- a/docs/source/quantization.rst
+++ b/docs/source/quantization.rst
@@ -111,7 +111,7 @@ Operations that are available from the ``torch`` namespace or as methods on Tens
 
 * :func:`~torch.quantize_per_tensor` - Convert float tensor to quantized tensor with per-tensor scale and zero point
 * :func:`~torch.quantize_per_channel` - Convert float tensor to quantized tensor with per-channel scale and zero point
-* View-based operations like :meth:`~torch.Tensor.view`, :meth:`~torch.Tensor.as_strided`, :meth:`~torch.Tensor.expand`, :meth:`~torch.Tensor.flatten`, :meth:`~torch.Tensor.slice`, python-style indexing, etc - work as on regular tensor (if quantization is not per-channel)
+* View-based operations like :meth:`~torch.Tensor.view`, :meth:`~torch.Tensor.as_strided`, :meth:`~torch.Tensor.expand`, :meth:`~torch.Tensor.flatten`, :meth:`~torch.Tensor.select`, python-style indexing, etc - work as on regular tensor (if quantization is not per-channel)
 * Comparators
     * :meth:`~torch.Tensor.ne` — Not equal
     * :meth:`~torch.Tensor.eq` — Equal
@@ -132,12 +132,17 @@ Operations that are available from the ``torch`` namespace or as methods on Tens
 * :meth:`~torch.Tensor.q_per_channel_scales` — Returns the scales of the per-channel quantized tensor
 * :meth:`~torch.Tensor.q_per_channel_zero_points` — Returns the zero points of the per-channel quantized tensor
 * :meth:`~torch.Tensor.q_per_channel_axis` — Returns the channel axis of the per-channel quantized tensor
-* :meth:`~torch.Tensor.relu` — Rectified linear unit (copy)
-* :meth:`~torch.Tensor.relu_` — Rectified linear unit (inplace)
 * :meth:`~torch.Tensor.resize_` — In-place resize
 * :meth:`~torch.Tensor.sort` — Sorts the tensor
 * :meth:`~torch.Tensor.topk` — Returns k largest values of a tensor
 
+``torch.nn.functional``
+~~~~~~~~~~~~~~~~~~~~~~
+
+Basic activations are supported.
+
+* :meth:`~torch.nn.functional.relu` — Rectified linear unit (copy)
+* :meth:`~torch.nn.functional.relu_` — Rectified linear unit (inplace)
 
 ``torch.nn.intrinsic``
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/quantization.rst
+++ b/docs/source/quantization.rst
@@ -42,6 +42,15 @@ The corresponding implementation is chosen automatically based on the PyTorch bu
 
   Quantization-aware training (through :class:`~torch.quantization.FakeQuantize`) supports both CPU and CUDA.
 
+
+.. note::
+
+  When preparing a quantized model for use on the ARM to take advange of the `QNNPACK library <https://github.com/pytorch/QNNPACK>`_
+  you will probably want to override the default engine to use QNNPack so that you can validate the numerics. Do this by setting the
+  ``torch.backends.quantized.engine`` parameter as shown here.
+
+  ``torch.backends.quantized.engine = 'qnnpack'``
+
 Quantized Tensors
 ---------------------------------------
 

--- a/docs/source/quantization.rst
+++ b/docs/source/quantization.rst
@@ -45,11 +45,23 @@ The corresponding implementation is chosen automatically based on the PyTorch bu
 
 .. note::
 
-  When preparing a quantized model for use on the ARM to take advange of the `QNNPACK library <https://github.com/pytorch/QNNPACK>`_
-  you will probably want to override the default engine to use QNNPack so that you can validate the numerics. Do this by setting the
-  ``torch.backends.quantized.engine`` parameter as shown here.
+   When preparing a quantized model, it is necessary to ensure that qconfig and the engine used for quantized computations match 
+   the backend on which the model will be executed. Quantization currently supports two backends: fbgemm (for use on x86, 
+   `<https://github.com/pytorch/FBGEMM>`_) and qnnpack (for use on the ARM QNNPACK library `<https://github.com/pytorch/QNNPACK>`_). 
+   For example, if you are interested in quantizing a model to run on ARM, it is recommended to set the qconfig by calling:
 
-  ``torch.backends.quantized.engine = 'qnnpack'``
+   ``qconfig = torch.quantization.get_default_qconfig('qnnpack')``
+
+   for post training quantization and
+
+   ``qconfig = torch.quantization.get_default_qat_qconfig('qnnpack')``
+
+   for quantization aware training.
+
+   In addition, the torch.backends.quantized.engine parameter should be set to match the backend. For using qnnpack for inference, the 
+   backend is set to qnnpack as follows
+
+   ``torch.backends.quantized.engine = 'qnnpack'``
 
 Quantized Tensors
 ---------------------------------------
@@ -152,6 +164,13 @@ Basic activations are supported.
 
 * :meth:`~torch.nn.functional.relu` — Rectified linear unit (copy)
 * :meth:`~torch.nn.functional.relu_` — Rectified linear unit (inplace)
+* :meth:`~torch.nn.functional.max_pool2d` - Maximum pooling 
+* :meth:`~torch.nn.functional.adaptive_avg_pool2d` - Adaptive average pooling
+* :meth:`~torch.nn.functional.avg_pool2d` - Average pooling
+* :meth:`~torch.nn.functional.interpolate` - Interpolation
+* :meth:`~torch.nn.functional.upsample` - Upsampling
+* :meth:`~torch.nn.functional.upsample_bilinear` - Bilinear Upsampling 
+* :meth:`~torch.nn.functional.upsample_nearest` - Upsampling Nearest
 
 ``torch.nn.intrinsic``
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -446,7 +465,7 @@ Debugging utilities
 .. autofunction:: get_observer_dict
 .. autoclass:: RecordingObserver
 
-torch.nn.instrinsic
+torch.nn.intrinsic
 --------------------------------
 
 This module implements the combined (fused) modules conv + relu which can be then quantized.

--- a/torch/nn/intrinsic/modules/fused.py
+++ b/torch/nn/intrinsic/modules/fused.py
@@ -3,6 +3,8 @@ import torch
 from torch.nn import Conv2d, Conv3d, ReLU, Linear, BatchNorm2d
 
 class ConvReLU2d(torch.nn.Sequential):
+    r"""This is a sequential container which calls the Conv 2d and ReLU modules.
+    During quantization this will be replaced with the corresponding fused module."""
     def __init__(self, conv, relu):
         assert type(conv) == Conv2d and type(relu) == ReLU, \
             'Incorrect types for input modules{}{}'.format(
@@ -10,6 +12,8 @@ class ConvReLU2d(torch.nn.Sequential):
         super(ConvReLU2d, self).__init__(conv, relu)
 
 class ConvReLU3d(torch.nn.Sequential):
+    r"""This is a sequential container which calls the Conv 3d and ReLU modules.
+    During quantization this will be replaced with the corresponding fused module."""
     def __init__(self, conv, relu):
         assert type(conv) == Conv3d and type(relu) == ReLU, \
             'Incorrect types for input modules{}{}'.format(
@@ -17,6 +21,8 @@ class ConvReLU3d(torch.nn.Sequential):
         super(ConvReLU3d, self).__init__(conv, relu)
 
 class LinearReLU(torch.nn.Sequential):
+    r"""This is a sequential container which calls the Linear and ReLU modules.
+    During quantization this will be replaced with the corresponding fused module."""
     def __init__(self, linear, relu):
         assert type(linear) == Linear and type(relu) == ReLU, \
             'Incorrect types for input modules{}{}'.format(
@@ -24,6 +30,8 @@ class LinearReLU(torch.nn.Sequential):
         super(LinearReLU, self).__init__(linear, relu)
 
 class ConvBn2d(torch.nn.Sequential):
+    r"""This is a sequential container which calls the Conv 2d and Batch Norm 2d modules.
+    During quantization this will be replaced with the corresponding fused module."""
     def __init__(self, conv, bn):
         assert type(conv) == Conv2d and type(bn) == BatchNorm2d, \
             'Incorrect types for input modules{}{}'.format(
@@ -31,6 +39,8 @@ class ConvBn2d(torch.nn.Sequential):
         super(ConvBn2d, self).__init__(conv, bn)
 
 class ConvBnReLU2d(torch.nn.Sequential):
+    r"""This is a sequential container which calls the Conv 2d, Batch Norm 2d, and ReLU modules.
+    During quantization this will be replaced with the corresponding fused module."""
     def __init__(self, conv, bn, relu):
         assert type(conv) == Conv2d and type(bn) == BatchNorm2d and \
             type(relu) == ReLU, 'Incorrect types for input modules{}{}{}' \

--- a/torch/nn/intrinsic/quantized/modules/conv_relu.py
+++ b/torch/nn/intrinsic/quantized/modules/conv_relu.py
@@ -55,8 +55,8 @@ class ConvReLU3d(nnq.Conv3d):
 
     We adopt the same interface as :class:`torch.nn.quantized.Conv3d`.
 
-    Attributes:
-        Same as torch.nn.quantized.Conv3d
+    .. note::
+    Attributes: Same as torch.nn.quantized.Conv3d
 
     """
     _FLOAT_MODULE = torch.nn.intrinsic.ConvReLU3d

--- a/torch/quantization/fuse_modules.py
+++ b/torch/quantization/fuse_modules.py
@@ -121,10 +121,15 @@ def fuse_modules(model, modules_to_fuse, inplace=False, fuser_func=fuse_known_mo
     r"""Fuses a list of modules into a single module
 
     Fuses only the following sequence of modules:
-    conv, bn
-    conv, bn, relu
-    conv, relu
-    linear, relu
+
+    * conv, bn
+
+    * conv, bn, relu
+
+    * conv, relu
+
+    * linear, relu
+
     All other sequences are left unchanged.
     For these sequences, replaces the first item in the list
     with the fused module, replacing the rest of the modules

--- a/torch/quantization/qconfig.py
+++ b/torch/quantization/qconfig.py
@@ -18,8 +18,8 @@ class QConfig(namedtuple('QConfig', ['activation', 'weight'])):
     Observer classes have usually reasonable default arguments, but they can be overwritten with `with_args`
     method (that behaves like functools.partial):
 
-      my_qconfig = QConfig(activation=MinMaxObserver.with_args(dtype=torch.qint8),
-                           weight=default_observer.with_args(dtype=torch.qint8))
+      my_qconfig = QConfig(activation=MinMaxObserver.with_args(dtype=torch.qint8), 
+      weight=default_observer.with_args(dtype=torch.qint8))
     """
     def __new__(cls, activation, weight):
         # catch common mistakes


### PR DESCRIPTION
This pull request includes fixes for six quantization doc bugs.
https://github.com/pytorch/pytorch/issues/30283 - Rendering issue on QConfig
https://github.com/pytorch/pytorch/issues/26305 - Minor doc issue on fuse_modules()
https://github.com/pytorch/pytorch/issues/27451 - Issues with ConvReLU2d, ConvReLU3d, and LinearReLU doc issues
https://github.com/pytorch/pytorch/issues/26899 - Missing docstrings in torch.nn.intrinsic fused functions
https://github.com/pytorch/pytorch/issues/29735 - add discussion of QNNPack to quantization doc page
https://github.com/pytorch/pytorch/issues/27938 - some of the quantized functions lack documentation

Test Plan: This is a doc change. Run make html in the docs directory and look at the html in the browser. 