### PR TITLE
[rpc] fix default rpc backend options when no options are passed in

### DIFF
--- a/test/rpc_test.py
+++ b/test/rpc_test.py
@@ -1189,3 +1189,25 @@ class RpcTest(RpcAgentTestFixture):
         with _use_rpc_pickler(test_pickler):
             self.assertTrue(torch.distributed.rpc.api._default_pickler is test_pickler)
         self.assertTrue(torch.distributed.rpc.api._default_pickler is _internal_rpc_pickler)
+
+    def test_default_rpc_backend_options_init(self):
+        # tests that if rpc_backend_options are not passed in, a default set
+        # is constructed.
+        rpc.init_rpc(
+            name="worker{}".format(self.rank),
+            backend=self.rpc_backend,
+            init_method=self.init_method,
+            rank=self.rank,
+            world_size=self.world_size,
+            rpc_backend_options=None,
+        )
+        default_options = rpc.backend_registry.construct_rpc_backend_options(
+            self.rpc_backend
+        )
+        # We should have the default timeout that is present in the default opts.
+        self.assertEqual(default_options.rpc_timeout, rpc.get_rpc_timeout())
+        rpc.wait_all_workers()
+
+
+
+

--- a/test/rpc_test.py
+++ b/test/rpc_test.py
@@ -1207,7 +1207,3 @@ class RpcTest(RpcAgentTestFixture):
         # We should have the default timeout that is present in the default opts.
         self.assertEqual(default_options.rpc_timeout, rpc.get_rpc_timeout())
         rpc.wait_all_workers()
-
-
-
-

--- a/torch/distributed/rpc/api.py
+++ b/torch/distributed/rpc/api.py
@@ -97,8 +97,8 @@ def _init_rpc_backend(
         raise RuntimeError("RPC package does not support Python2.")
 
     if not rpc_backend_options:
-        # default construct a set of RPC agent options.
-        rpc_backend_options = rpc.backend_registry.construct_rpc_backend_options(
+        # default construct a set of RPC backend options.
+        rpc_backend_options = backend_registry.construct_rpc_backend_options(
             backend
         )
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#30397 [rpc] fix default rpc backend options when no options are passed in**

If rpc_backend_options are not passed in and defaulted to `None`, this currently results in a NameError since the name `rpc` is not defined here. We need to just use `backend_registry`. This was not caught before since all the tests pass in these options, so this code path was never executed. A test for these default options is thus also added.

(I would prefer to merge https://github.com/pytorch/pytorch/pull/30208/ where it is also fixed over this, but that PR is currently blocked by broken/flaky tests, so putting this fix up as well.)

Differential Revision: [D18682606](https://our.internmc.facebook.com/intern/diff/D18682606/)