### PR TITLE
[ROCm] [ROCm 2.10+] enable fast relu path for fp16 in the Caffe2 backend on ROCm

### DIFF
--- a/caffe2/operators/relu_op.cu
+++ b/caffe2/operators/relu_op.cu
@@ -33,7 +33,7 @@ __global__ void ReluCUDAKernel<half>(const int N, const half* X, half* Y) {
   const int i = blockIdx.x * CAFFE_CUDA_NUM_THREADS + threadIdx.x;
   if (i < N) {
     const half kZero = __float2half(0.0f);
-#if __CUDA_ARCH__ >= 530
+#if __CUDA_ARCH__ >= 530 || defined(__HIP_PLATFORM_HCC__)
     Y[i] = __hgt(__ldg(X + i), kZero) ? __ldg(X + i) : kZero;
 #else
     Y[i] = (__half2float(X[i]) > 0) ? X[i] : kZero;
@@ -46,7 +46,7 @@ __global__ void ReluCUDAKernel<half2>(const int N, const half2* X, half2* Y) {
   const int i = blockIdx.x * CAFFE_CUDA_NUM_THREADS + threadIdx.x;
   if (i < N) {
     const half2 kZero = __float2half2_rn(0.0f);
-#if __CUDA_ARCH__ >= 530
+#if __CUDA_ARCH__ >= 530 || defined(__HIP_PLATFORM_HCC__)
     Y[i] = __hmul2(__hgt2(__ldg(X + i), kZero), __ldg(X + i));
 #else
     const float2 xx = __half22float2(X[i]);
@@ -61,7 +61,7 @@ __global__ void
 ReluGradientCUDAKernel(const int N, const T* dY, const T* Y, T* dX) {
   const int i = blockIdx.x * CAFFE_CUDA_NUM_THREADS + threadIdx.x;
   if (i < N) {
-#if __CUDA_ARCH__ >= 350
+#if __CUDA_ARCH__ >= 350 || defined(__HIP_PLATFORM_HCC__)
     dX[i] = __ldg(Y + i) > T(0) ? __ldg(dY + i) : T(0);
 #else
     dX[i] = Y[i] > T(0) ? dY[i] : T(0);
@@ -78,7 +78,7 @@ __global__ void ReluGradientCUDAKernel<half>(
   const int i = blockIdx.x * CAFFE_CUDA_NUM_THREADS + threadIdx.x;
   if (i < N) {
     const half kZero = __float2half(0.0f);
-#if __CUDA_ARCH__ >= 530
+#if __CUDA_ARCH__ >= 530 || defined(__HIP_PLATFORM_HCC__)
     dX[i] = __hgt(__ldg(Y + i), kZero) ? __ldg(dY + i) : kZero;
 #else
     dX[i] = (__half2float(Y[i]) > 0) ? dY[i] : kZero;
@@ -95,7 +95,7 @@ __global__ void ReluGradientCUDAKernel<half2>(
   const int i = blockIdx.x * CAFFE_CUDA_NUM_THREADS + threadIdx.x;
   if (i < N) {
     const half2 kZero = __float2half2_rn(0.0f);
-#if __CUDA_ARCH__ >= 530
+#if __CUDA_ARCH__ >= 530 || defined(__HIP_PLATFORM_HCC__)
     dX[i] = __hmul2(__hgt2(__ldg(Y + i), kZero), __ldg(dY + i));
 #else
     const float2 dy = __half22float2(dY[i]);


### PR DESCRIPTION
With ROCm 2.10, the fast path in relu works.