### PR TITLE
Add pybind11 trampoline class for c10d.Store

### DIFF
--- a/test/test_c10d.py
+++ b/test/test_c10d.py
@@ -343,7 +343,7 @@ class MyPythonStore(c10d.Store):
 
     def add(self, key, value):
         new = int(self.store.get(key, 0)) + value
-        self.set(key, bytes(str(new), "utf-8"))
+        self.set(key, bytes(str(new).encode("utf-8")))
         return new
 
 

--- a/test/test_c10d.py
+++ b/test/test_c10d.py
@@ -18,6 +18,7 @@ from functools import partial, reduce
 import operator
 
 import torch
+from torch._six import string_classes
 import common_utils as common
 from torch import nn
 import torch.nn.functional as F
@@ -329,7 +330,7 @@ class MyPythonStore(c10d.Store):
         self.store = dict()
 
     def set(self, key, value):
-        if type(key) is not str:
+        if not isinstance(key, string_classes):
             raise AssertionError("Expected set to be called with string key")
         if type(value) is not bytes:
             raise AssertionError("Expected set to be called with bytes value")

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -690,8 +690,8 @@ They are used in specifying strategies for reduction collectives, e.g.,
         set("key2", "value2");
         add("key3", 3);
         add("key3", 4);
-        add("key3", 5);
-        add("key3", 6);
+        add("key3", 3);
+        add("key3", 2);
         if (get("key") != "6") {
           throw std::runtime_error("assertion failed");
         }
@@ -704,7 +704,7 @@ They are used in specifying strategies for reduction collectives, e.g.,
         if (get("key2") != "value2") {
           throw std::runtime_error("assertion failed");
         }
-        if (get("key3") != "21") {
+        if (get("key3") != "15") {
           throw std::runtime_error("assertion failed");
         }
       },


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#30415 Add pybind11 trampoline class for c10d.Store**

This enables subclassing of c10d.Store and implementing its interface in Python.

Differential Revision: [D18693018](https://our.internmc.facebook.com/intern/diff/D18693018/)