### PR TITLE
C++ tensor indexing: more indexing tests

### DIFF
--- a/test/cpp/api/tensor_indexing.cpp
+++ b/test/cpp/api/tensor_indexing.cpp
@@ -127,3 +127,76 @@ TEST(TensorIndexingTest, TestNone) {
   ASSERT_EQ(v.idx({{}, None, None}).sizes(), torch::IntArrayRef({5, 1, 1, 7, 3}));
   ASSERT_EQ(v.idx({"...", None}).sizes(), torch::IntArrayRef({5, 7, 3, 1}));
 }
+
+/*
+    def test_step(self):
+        v = torch.arange(10)
+        self.assertEqual(v[::1], v)
+        self.assertEqual(v[::2].tolist(), [0, 2, 4, 6, 8])
+        self.assertEqual(v[::3].tolist(), [0, 3, 6, 9])
+        self.assertEqual(v[::11].tolist(), [0])
+        self.assertEqual(v[1:6:2].tolist(), [1, 3, 5])
+*/
+TEST(TensorIndexingTest, TestStep) {
+  auto v = torch::arange(10);
+  assert_tensor_equal(v.idx({{None, None, 1}}), v);
+  assert_tensor_equal(v.idx({{None, None, 2}}), torch::tensor({0, 2, 4, 6, 8}));
+  assert_tensor_equal(v.idx({{None, None, 3}}), torch::tensor({0, 3, 6, 9}));
+  assert_tensor_equal(v.idx({{None, None, 11}}), torch::tensor({0}));
+  assert_tensor_equal(v.idx({{1, 6, 2}}), torch::tensor({1, 3, 5}));
+}
+
+/*
+    def test_step_assignment(self):
+        v = torch.zeros(4, 4)
+        v[0, 1::2] = torch.tensor([3., 4.])
+        self.assertEqual(v[0].tolist(), [0, 3, 0, 4])
+        self.assertEqual(v[1:].sum(), 0)
+*/
+TEST(TensorIndexingTest, TestStepAssignment) {
+  auto v = torch::zeros({4, 4});
+  v.idx_put_({0, {1, None, 2}}, torch::tensor({3., 4.}));
+  assert_tensor_equal(v.idx({0}), torch::tensor({0., 3., 0., 4.}));
+  assert_tensor_equal(v.idx({{1, None}}).sum(), 0);
+}
+
+/*
+    def test_bool_indices(self):
+        v = torch.randn(5, 7, 3)
+        boolIndices = torch.tensor([True, False, True, True, False], dtype=torch.bool)
+        self.assertEqual(v[boolIndices].shape, (3, 7, 3))
+        self.assertEqual(v[boolIndices], torch.stack([v[0], v[2], v[3]]))
+
+        v = torch.tensor([True, False, True], dtype=torch.bool)
+        boolIndices = torch.tensor([True, False, False], dtype=torch.bool)
+        uint8Indices = torch.tensor([1, 0, 0], dtype=torch.uint8)
+        with warnings.catch_warnings(record=True) as w:
+            self.assertEqual(v[boolIndices].shape, v[uint8Indices].shape)
+            self.assertEqual(v[boolIndices], v[uint8Indices])
+            self.assertEqual(v[boolIndices], tensor([True], dtype=torch.bool))
+            self.assertEquals(len(w), 2)
+*/
+TEST(TensorIndexingTest, TestBoolIndices) {
+  {
+    auto v = torch::randn({5, 7, 3});
+    auto boolIndices = torch::tensor({true, false, true, true, false}, torch::kBool);
+    ASSERT_EQ(v.idx({boolIndices}).sizes(), torch::IntArrayRef({3, 7, 3}));
+    assert_tensor_equal(v.idx({boolIndices}), torch::stack({v.idx({0}), v.idx({2}), v.idx({3})}));
+  }
+  {
+    auto v = torch::tensor({true, false, true}, torch::kBool);
+    auto boolIndices = torch::tensor({true, false, false}, torch::kBool);
+    auto uint8Indices = torch::tensor({1, 0, 0}, torch::kUInt8);
+
+    {
+      std::stringstream buffer;
+      CerrRedirect cerr_redirect(buffer.rdbuf());
+
+      ASSERT_EQ(v.idx({boolIndices}).sizes(), v.idx({uint8Indices}).sizes());
+      assert_tensor_equal(v.idx({boolIndices}), v.idx({uint8Indices}));
+      assert_tensor_equal(v.idx({boolIndices}), torch::tensor({true}, torch::kBool));
+
+      ASSERT_EQ(count_substr_occurrences(buffer.str(), "indexing with dtype torch.uint8 is now deprecated"), 2);
+    }
+  }
+}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#30423 C++ tensor indexing: more indexing tests**
* #29846 Add assert_tensor_equal and assert_tensor_not_equal to test/cpp/api/support.h
* #29847 C++ tensor indexing: add Tensor::idx() and Tensor::idx_put_(), and simple indexing tests
* #29845 C++ tensor advanced indexing: add Slice / TensorIndex

