### PR TITLE
[android][jni] GenericDict/List type use unshapedType()

### DIFF
--- a/android/pytorch_android/src/main/cpp/pytorch_jni_common.cpp
+++ b/android/pytorch_android/src/main/cpp/pytorch_jni_common.cpp
@@ -506,8 +506,7 @@ at::IValue JIValue::JIValueToAtIValue(
 
     auto jivalue_first_element = jarray->getElement(0);
     auto first_element = JIValue::JIValueToAtIValue(jivalue_first_element);
-    c10::TypePtr typePtr = first_element.type();
-    c10::impl::GenericList list{typePtr};
+    c10::impl::GenericList list{c10::unshapedType(first_element.type())};
     list.reserve(n);
     list.push_back(first_element);
     for (auto i = 1; i < n; ++i) {
@@ -529,8 +528,8 @@ at::IValue JIValue::JIValueToAtIValue(
     }
 
     auto firstEntryValue = JIValue::JIValueToAtIValue(it->second);
-    c10::TypePtr typePtr = firstEntryValue.type();
-    c10::impl::GenericDict dict{c10::StringType::get(), typePtr};
+    c10::impl::GenericDict dict{c10::StringType::get(),
+                                c10::unshapedType(firstEntryValue.type())};
     dict.insert(it->first->toStdString(), firstEntryValue);
     it++;
     for (; it != jmap->end(); it++) {
@@ -552,8 +551,8 @@ at::IValue JIValue::JIValueToAtIValue(
     }
 
     auto firstEntryValue = JIValue::JIValueToAtIValue(it->second);
-    c10::TypePtr typePtr = firstEntryValue.type();
-    c10::impl::GenericDict dict{c10::IntType::get(), typePtr};
+    c10::impl::GenericDict dict{c10::IntType::get(),
+                                c10::unshapedType(firstEntryValue.type())};
     dict.insert((int64_t)it->first->longValue(), firstEntryValue);
     it++;
     for (; it != jmap->end(); it++) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#30428 [android][jni] GenericDict/List type use unshapedType()**

Reported issue https://discuss.pytorch.org/t/incomprehensible-behaviour/61710 

Steps to reproduce:

```
class WrapRPN(nn.Module):
    def __init__(self):
        super().__init__()

    def forward(self, features):
        # type: (Dict[str, Tensor]) -> int
        return 0
```

```
#include <torch/script.h>

int main() {
  torch::jit::script::Module module = torch::jit::load("dict_str_tensor.pt");

  torch::Tensor tensor = torch::rand({2, 3});
  at::IValue ivalue{tensor};
  c10::impl::GenericDict dict{c10::StringType::get(),ivalue.type()};
  dict.insert("key", ivalue);
  module.forward({dict});
}
```

ValueType of `c10::impl::GenericDict` is from the first specified element as `ivalue.type()`
It fails on type check in` function_schema_inl.h` !value.type()->isSubtypeOf(argument.type())
as `DictType::isSubtypeOf` requires equal KeyType and ValueType, while `TensorType`s are different.

Fix:
Use c10::unshapedType for creating Generic List/Dict

Differential Revision: [D18717189](https://our.internmc.facebook.com/intern/diff/D18717189)