### PR TITLE
make the order btw div and mul in adagrad update consistent

### DIFF
--- a/caffe2/perfkernels/adagrad.h
+++ b/caffe2/perfkernels/adagrad.h
@@ -29,7 +29,7 @@ static inline void adagrad_update_base_inlined(
     float gi = g[i];
     float hi = decay * h[i] + gi * gi;
     nh[i] = hi;
-    nw[i] = w[i] + lr * gi / (std::sqrt(hi) + epsilon);
+    nw[i] = w[i] + lr / (std::sqrt(hi) + epsilon) * gi;
   }
 }
 
@@ -300,7 +300,7 @@ int sparse_adagrad(
       if (block_size == 1) {                                             \
         float gi = g[i];                                                 \
         float hi = nh[idx] = h[idx] + gi * gi;                           \
-        nw[idx] = w[idx] + lr * gi / (std::sqrt(hi) + epsilon);          \
+        nw[idx] = w[idx] + lr / (std::sqrt(hi) + epsilon) * gi;          \
       } else {                                                           \
         const int prefdist_T0 = 16;                                      \
         int i_pref = (i < num_rows - prefdist_T0) ? i + prefdist_T0 : i; \

--- a/caffe2/perfkernels/adagrad_avx.cc
+++ b/caffe2/perfkernels/adagrad_avx.cc
@@ -28,15 +28,15 @@ void adagrad_update__avx_f16c(
         _mm256_mul_ps(_mm256_set1_ps(decay), hi), _mm256_mul_ps(gi, gi));
     _mm256_storeu_ps(nh + i, nhi);
     __m256 vtmp = _mm256_div_ps(
-        gi, _mm256_add_ps(_mm256_sqrt_ps(nhi), _mm256_set1_ps(epsilon)));
-    _mm256_storeu_ps(
-        nw + i, _mm256_add_ps(wi, _mm256_mul_ps(_mm256_set1_ps(lr), vtmp)));
+        _mm256_set1_ps(lr),
+        _mm256_add_ps(_mm256_sqrt_ps(nhi), _mm256_set1_ps(epsilon)));
+    _mm256_storeu_ps(nw + i, _mm256_add_ps(wi, _mm256_mul_ps(gi, vtmp)));
   }
 
   for (; i < N; ++i) {
     float gi = g[i];
     float hi = nh[i] = decay * h[i] + gi * gi;
-    nw[i] = w[i] + lr * gi / (std::sqrt(hi) + epsilon);
+    nw[i] = w[i] + lr / (std::sqrt(hi) + epsilon) * gi;
   }
 }
 
@@ -96,8 +96,9 @@ void adagrad_fp16_update_prefetch__avx_f16c(
     _mm_storeu_si128(reinterpret_cast<__m128i*>(nh + i), nhhi);
 
     __m256 vtmp = _mm256_div_ps(
-        gi, _mm256_add_ps(_mm256_sqrt_ps(nhi), _mm256_set1_ps(epsilon)));
-    __m256 nwi = _mm256_add_ps(wi, _mm256_mul_ps(_mm256_set1_ps(lr), vtmp));
+        _mm256_set1_ps(lr),
+        _mm256_add_ps(_mm256_sqrt_ps(nhi), _mm256_set1_ps(epsilon)));
+    __m256 nwi = _mm256_add_ps(wi, _mm256_mul_ps(gi, vtmp));
     __m128i nhwi = _mm256_cvtps_ph(nwi, 0);
     _mm_storeu_si128(reinterpret_cast<__m128i*>(nw + i), nhwi);
   }
@@ -108,7 +109,7 @@ void adagrad_fp16_update_prefetch__avx_f16c(
         _cvtsh_ss(reinterpret_cast<const unsigned short*>(h)[i]) + gi * gi;
     reinterpret_cast<unsigned short*>(nh)[i] = _cvtss_sh(nhi, 0);
     float nwi = _cvtsh_ss(reinterpret_cast<const unsigned short*>(w)[i]) +
-        lr * gi / (std::sqrt(nhi) + epsilon);
+        lr / (std::sqrt(nhi) + epsilon) * gi;
     reinterpret_cast<unsigned short*>(nw)[i] = _cvtss_sh(nwi, 0);
   }
 }

--- a/caffe2/sgd/adagrad_op.h
+++ b/caffe2/sgd/adagrad_op.h
@@ -190,7 +190,7 @@ class SparseAdagradOp final : public Operator<Context> {
       if (block_size == 1) {
         float gi = gradIn[i];
         float hi = momentOut[idx] = momentIn[idx] + gi * gi;
-        paramOut[idx] = paramIn[idx] + lr[0] * gi / (std::sqrt(hi) + epsilon_);
+        paramOut[idx] = paramIn[idx] + lr[0] / (std::sqrt(hi) + epsilon_) * gi;
       } else {
         auto offsetI = i * block_size;
         auto offsetIdx = idx * block_size;
@@ -279,7 +279,7 @@ class RowWiseSparseAdagradOp final : public Operator<Context> {
       if (block_size == 1) {
         float gi = gradIn[i];
         float hi = momentOut[idx] = momentIn[idx] + gi * gi;
-        paramOut[idx] = paramIn[idx] + lr[0] * gi / (std::sqrt(hi) + epsilon_);
+        paramOut[idx] = paramIn[idx] + lr[0] / (std::sqrt(hi) + epsilon_) * gi;
       } else {
         auto offsetI = i * block_size;
         auto offsetIdx = idx * block_size;


### PR DESCRIPTION
Summary:
There was an inconsistency in the order of operation between scalar and SIMD code when we compute Adagrad.
In this diff we first compute effective_lr = lr / (sqrt(moment) + epsilon) and then multiply with gradient.

Test Plan: CI

Differential Revision: D18703416

