### PR TITLE
[pytorch] avoid Formatting::print() when STRIP_ERROR_MESSAGES is set

### DIFF
--- a/aten/src/ATen/core/dispatch/Dispatcher.cpp
+++ b/aten/src/ATen/core/dispatch/Dispatcher.cpp
@@ -56,9 +56,7 @@ OperatorHandle Dispatcher::findOrRegisterSchema_(FunctionSchema&& schema, Operat
   const auto found = findSchema(schema.operator_name());
   if (found != c10::nullopt) {
     if (found->schema() != schema) {
-      std::ostringstream str;
-      str << schema << " vs " << found->schema();
-      TORCH_CHECK(false, "Tried to register multiple operators with the same name and the same overload name but different schemas: ", str.str());
+      TORCH_CHECK(false, "Tried to register multiple operators with the same name and the same overload name but different schemas: ", schema, " vs ", found->schema());
     }
     if (options.isDefaultAliasAnalysisKind()) {
       // just do nothing and let it pass.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #29718 [pytorch][script] op dependency analysis bash driver
* #29550 [pytorch] add LLVM code analyzer in order to replace static dispatch
* **#30451 [pytorch] avoid Formatting::print() when STRIP_ERROR_MESSAGES is set**

Summary:
TORCH_CHECK takes __VA_ARGS__ so there is no need to concatenate strings
before calling it. This way it won't call Formatting::print() on the
tensor when STRIP_ERROR_MESSAGES macro is set. Formatting::print() calls
several specific tensor methods that brings in unnecessary inter-op
dependencies for static code analysis.

Test Plan:
- builds

Differential Revision: [D18703784](https://our.internmc.facebook.com/intern/diff/D18703784)