### PR TITLE
don't use size()/stride() functions in TensorImpl, use size_[d]/stride_[d] instead

### DIFF
--- a/c10/core/TensorImpl.cpp
+++ b/c10/core/TensorImpl.cpp
@@ -84,9 +84,9 @@ bool TensorImpl::compute_contiguous() const {
     return is_contiguous;
   int64_t z = 1;
   for (int64_t d = dim() - 1; d >= 0; d--) {
-    if (size(d) != 1) {
-      if (stride(d) == z) {
-        z *= size(d);
+    if (sizes_[d] != 1) {
+      if (strides_[d] == z) {
+        z *= sizes_[d];
       } else {
         is_contiguous = false;
         break;
@@ -97,12 +97,12 @@ bool TensorImpl::compute_contiguous() const {
 }
 
 bool TensorImpl::compute_channels_last_contiguous() const {
-  if (dim() == 4) {
+  if (sizes_.size() == 4) {
     int64_t expected = 1;
     for (auto& d : {1, 3, 2, 0}) {
-      if (size(d) != 1) {
-        if (stride(d) == expected) {
-          expected *= size(d);
+      if (sizes_[d] != 1) {
+        if (strides_[d] == expected) {
+          expected *= sizes_[d];
         } else {
           return false;
         }
@@ -114,12 +114,12 @@ bool TensorImpl::compute_channels_last_contiguous() const {
 }
 
 bool TensorImpl::compute_strides_like_channels_last() const {
-  if (dim() == 4) {
+  if (sizes_.size() == 4) {
     int64_t min = 0;
     for (auto& d : {1, 3, 2, 0}) {
-      if (size(d) != 1) {
-        if (stride(d) > min) {
-          min = stride(d);
+      if (sizes_[d] != 1) {
+        if (strides_[d] > min) {
+          min = strides_[d];
         } else {
           return false;
         }
@@ -132,7 +132,7 @@ bool TensorImpl::compute_strides_like_channels_last() const {
 
 bool TensorImpl::compute_non_overlapping_and_dense() const {
   if (dim() == 1) {
-    return size(0) < 2 || stride(0) == 1;
+    return sizes_[0] < 2 || strides_[0] == 1;
   }
   SmallVector<int64_t,5> perm;
   perm.resize(dim());

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -1372,9 +1372,11 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
     #endif
     switch (memory_format) {
       case MemoryFormat::Contiguous: {
-        strides_.resize(sizes_.size(), 0);
-        if (dim() > 0) {
-          int last_idx = dim() - 1;
+        // dim_ is a virtual call, don't repeat it
+        auto dim_ = dim();
+        strides_.resize(dim_);
+        if (dim_ > 0) {
+          int last_idx = dim_ - 1;
           strides_[last_idx] = 1;
           for (auto i = last_idx - 1; i >= 0; --i) {
             strides_[i] = strides_[i + 1] * std::max<int64_t>(sizes_[i + 1], 1);


### PR DESCRIPTION
Summary: This improved multi-d microbenchmark by ~100 ns, empty_tensor_restride used to be 13% of iteration time, now about 5%

Test Plan: Covered by existing tests

Differential Revision: D18704233

