### PR TITLE
Revert "Use -isystem for system includes in C++ extensions (#11459)"

### DIFF
--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -1117,24 +1117,18 @@ def _write_ninja_file(path,
     # Turn into absolute paths so we can emit them into the ninja build
     # file wherever it is.
     sources = [os.path.abspath(file) for file in sources]
-    user_includes = [os.path.abspath(file) for file in extra_include_paths]
+    includes = [os.path.abspath(file) for file in extra_include_paths]
 
     # include_paths() gives us the location of torch/extension.h
-    system_includes = include_paths(with_cuda)
+    includes += include_paths(with_cuda)
     # sysconfig.get_paths()['include'] gives us the location of Python.h
-    system_includes.append(sysconfig.get_paths()['include'])
-
-    # Windows does not understand `-isystem`.
-    if IS_WINDOWS:
-        user_includes += system_includes
-        system_includes.clear()
+    includes.append(sysconfig.get_paths()['include'])
 
     common_cflags = ['-DTORCH_EXTENSION_NAME={}'.format(name)]
     common_cflags.append('-DTORCH_API_INCLUDE_EXTENSION_H')
     if BUILD_NAMEDTENSOR:
         common_cflags.append('-DBUILD_NAMEDTENSOR')
-    common_cflags += ['-I{}'.format(include) for include in user_includes]
-    common_cflags += ['-isystem {}'.format(include) for include in system_includes]
+    common_cflags += ['-I{}'.format(include) for include in includes]
 
     common_cflags += ['-D_GLIBCXX_USE_CXX11_ABI=' + str(int(torch._C._GLIBCXX_USE_CXX11_ABI))]
 


### PR DESCRIPTION
This reverts commit 01c7542f43a0c27215bfadf3cde43797f700982d.

 * The use of -isystem is incorrect here. It changes the search order
   and breaks build on gcc6 and later. Concretely, GCC uses the
   `#include_next` directive in `cstdlib` to fix system `stdlib.h` and
   `-isystem /usr/include` breaks the procedure.

Check [GCC documentation](https://gcc.gnu.org/onlinedocs/gcc/Directory-Options.html) for details.
FYI, I found bug reports on other C++ projects for reference:
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=70129
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=70936
https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/thread/Q5SWCUUMWQ4EMS7CU2CBOZHV3WZYOOTT/
https://forums.opensuse.org/showthread.php/518941-stdlib-h-No-such-file-or-directory
https://bugreports.qt.io/browse/QTBUG-53367

