### PR TITLE
Add Module::register_forward_pre_hook and run the hooks in module forward

### DIFF
--- a/aten/src/ATen/templates/TensorBody.h
+++ b/aten/src/ATen/templates/TensorBody.h
@@ -13,6 +13,7 @@
 #include <c10/util/Exception.h>
 #include <c10/util/Deprecated.h>
 #include <c10/util/Optional.h>
+#include <c10/util/any.h>
 #include <c10/util/intrusive_ptr.h>
 #include <c10/util/ordered_dict.h>
 #include <ATen/core/DeprecatedTypePropertiesRegistry.h>
@@ -37,7 +38,7 @@ namespace torch { namespace autograd {
 
 struct Node;
 
-using hooks_dict = c10::OrderedDict<unsigned, std::function<at::Tensor(const at::Tensor&)>>;
+using hooks_dict = c10::OrderedDict<unsigned, c10::any>;
 
 }} // namespace torch::autograd
 

--- a/torch/csrc/api/include/torch/nn/pimpl.h
+++ b/torch/csrc/api/include/torch/nn/pimpl.h
@@ -129,6 +129,7 @@ class ModuleHolder : torch::detail::ModuleHolderIndicator {
         auto hook = c10::any_cast<std::function<void(torch::nn::AnyModule, Args...)>>(any_hook);
         hook(torch::nn::AnyModule(impl_), std::forward<Args>(args)...);
       } catch (const c10::bad_any_cast& e) {
+        // yf225 TODO: add test for this err msg as well
         TORCH_CHECK(false, "yf225 TODO: some useful err msg about hook function input / output type being wrong");
       }
     }

--- a/torch/csrc/api/src/nn/module.cpp
+++ b/torch/csrc/api/src/nn/module.cpp
@@ -230,6 +230,10 @@ OrderedDict<std::string, std::shared_ptr<Module>> Module::named_children()
   return children_;
 }
 
+torch::autograd::hooks_dict Module::forward_pre_hooks() const {
+  return forward_pre_hooks_;
+}
+
 void Module::train(bool on) {
   for (auto& child : children_) {
     child.value()->train(on);

--- a/torch/csrc/autograd/cpp_hook.cpp
+++ b/torch/csrc/autograd/cpp_hook.cpp
@@ -23,7 +23,7 @@ variable_list CppFunctionPreHook::operator()(const variable_list& values) {
   auto value = values[value_idx_];
   for (const auto& item : *hooks_) {
     unsigned id = item.key();
-    const std::function<Variable(const Variable&)>& hook = item.value();
+    auto hook = c10::any_cast<std::function<Variable(const Variable&)>>(item.value());
     if (!hook) {
       // hook was removed
       continue;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#30484 Add Module::register_forward_pre_hook and run the hooks in module forward**
* #30483 Add std::any backport to c10
* #30339 Return RemovableHandle from Tensor::register_hook, and remove Tensor::remove_hook
* #30279 Use torch::OrderedDict instead of std::vector to store hooks for Variable

