### PR TITLE
embedding_bag make_bag_size optimization

### DIFF
--- a/aten/src/ATen/native/EmbeddingBag.cpp
+++ b/aten/src/ATen/native/EmbeddingBag.cpp
@@ -197,9 +197,11 @@ void index_select_scale_add<float>(const Tensor &select_indices,
 
 }  // namespace
 
-static void make_bag_size(const Tensor &offsets, const Tensor &indices,
-                          const int64_t mode, Tensor &bag_size) {
+static at::Tensor make_bag_size(const Tensor &offsets, const Tensor &indices,
+                                const int64_t mode, const bool requires_grad) {
+  at::Tensor bag_size;
   if (mode == MODE_MEAN || mode == MODE_MAX) {
+    bag_size = at::zeros(offsets.sizes(), indices.options());
     // Compute this for MODE_MEAN and MODE_MAX (latter needed for backwards)
     if (offsets.size(0) != 1) {
       bag_size.slice(0, 0, bag_size.size(0) - 1, 1) =
@@ -207,7 +209,11 @@ static void make_bag_size(const Tensor &offsets, const Tensor &indices,
           offsets.slice(0, 0, offsets.size(0) - 1, 1);
     }
     bag_size[-1] = indices.size(0) - offsets[-1];
+  } else if (requires_grad) {
+    // in MODE_SUM, only initialize bag_size if we need gradients
+    bag_size = at::zeros(offsets.sizes(), indices.options());
   }
+  return bag_size;
 }
 
 static Tensor apply_bag_size(const Tensor &offsets, const Tensor &indices,
@@ -329,10 +335,10 @@ _embedding_bag_cpu(const Tensor &weight, const Tensor &indices,
     AT_ASSERT(per_sample_weights.numel() == indices.numel());
   }
 
-  auto bag_size = at::zeros(offsets.sizes(), indices.options());
-  make_bag_size(offsets, indices, mode, bag_size);
+  auto bag_size = make_bag_size(offsets, indices, mode, weight.requires_grad());
 
-  auto output = at::zeros({offsets.size(0), weight.size(1)}, weight.options());
+  // output tensor is not zero initialized
+  auto output = at::empty({offsets.size(0), weight.size(1)}, weight.options());
 
   // To save compute, if we are going to go down the fast path case for the 'sum'
   // mode, we skip calculating offset2bag, since it is not going to be used.


### PR DESCRIPTION
Summary:
From James' PR https://github.com/pytorch/pytorch/pull/19715.

embedding_bag microbenchmarks:
Baseline: P123020983
Only refactor make_bag_size, no changing at::zeros to at::empty: P123021393
Both (this diff): P123020983

Inference benchmark on T6_SKL - embedding bag self time only:
bs=40, baseline: .302 ms/iter
bs=40, with diff: .203 ms/iter
bs=1 baseline: .148 ms/iter
bs=1 with diff: .099 ms/iter

The bigger gap comes from fb::embedding_bag_byte_rowwise_offsets, I'm looking into that one too.

Test Plan:
MKL_NUM_THREADS=1 OMP_NUM_THREADS=1 numactl -m 0 -C 3 ./inference_benchmark_nolr_emb.par --pt-scripted-model=traced_model.pt --pt-inputs="batch_size_40/pt_inputs.pth" --iters=3000 --warmup-iters=100

buck run mode/opt //caffe2/benchmarks/operator_benchmark:benchmark_all_other_test -- --tag_filter all --iterations 3000 --operators embeddingbag

Reviewed By: yinghai, qizzzh

Differential Revision: D18714418

