### PR TITLE
[BC-BREAKING] change index_select scalar_check to retain dimensionality of input.

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -162,6 +162,7 @@
   variants:
     - function
   return: argument 0
+  scalar_check: self.dim() == 0
   arguments:
     - arg: THTensor* result
       output: True


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#30502 [BC-BREAKING] change index_select scalar_check to retain dimensionality of input.**
* #30438 Turn off scalar_checks for SpatialDepthwiseConvolution and SpatialConvolutionMM.
* #30437 [WIP] Remove scalar_check from topk, move it to the THC implementation.
* #30436 Turn off scalar_checks for _th_reciprocal.
* #30435 Turn off scalar_checks for torch.clamp.
* #30434 Turn off scalar_checks for exp, cos, cosh, tan, atan, tanh, erf, erfc.

The index_select documentaiton reads:
"The returned tensor has the same number of dimensions as the original tensor (input)."

But the implementation would return a 0-dimensional tensor iff both the input and index were 0-dimensional.
This change makes it so we retuan a 0-dimensional tensor iff the input is 0-dimensional.

Differential Revision: [D18730033](https://our.internmc.facebook.com/intern/diff/D18730033)