### PR TITLE
Add examples to RRef doc

### DIFF
--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -72,6 +72,34 @@ PyObject* rpc_init(PyObject* /* unused */) {
           A class encapsulating a reference to a value of some type on a remote
           worker. This handle will keep the referenced remote value alive on the
           worker.
+
+          Example::
+
+              Following examples skip RPC initialization and shutdown code
+              for simplicity. Refer to RPC docs for those details.
+
+              1. Create an RRef using rpc.remote
+
+              >>> import torch.distributed.rpc as rpc
+              >>> rref = rpc.remote("worker1", torch.add, args=(torch.ones(2), 3))
+
+              2. Create an RRef from a local object
+
+              >>> from torch.distributed.rpc import RRef
+              >>> x = torch.zeros(2, 2)
+              >>> rref = RRef(x)
+
+              3. Share an RRef with other workers
+
+              On both worker0 and worker1:
+              >>> def f(rref):
+              >>>   return rref.to_here() + 1
+
+              On worker0:
+              >>> rref = RRef(torch.zeros(2, 2))
+              >>> # the following RPC shares the rref with worker1, reference
+              >>> # count is automatically updated.
+              >>> rpc.rpc_sync("worker1", f, args(rref,))
           )")
           .def(py::init<const py::object&>())
           .def(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#30516 Add examples to RRef doc**
* #30515 Make doc source format consistent in rpc/init.cpp
* #30491 Reorganize rpc API doc and add introduction

Differential Revision: [D18728183](https://our.internmc.facebook.com/intern/diff/D18728183)