### PR TITLE
Add katex to pytorch-linux-xenial-py3.6-gcc5.4 docker image

### DIFF
--- a/.circleci/docker/build.sh
+++ b/.circleci/docker/build.sh
@@ -67,6 +67,7 @@ case "$image" in
     PROTOBUF=yes
     DB=yes
     VISION=yes
+    KATEX=yes
     ;;
   pytorch-linux-xenial-py3.6-gcc7.2)
     ANACONDA_PYTHON_VERSION=3.6


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #30487 Change python/cpp docs CI to use a CPU-only image
* **#30522 Add katex to pytorch-linux-xenial-py3.6-gcc5.4 docker image**

This is in preparation for moving the docs push CI jobs to depend on
`pytorch-linux-xenial-py3.6-gcc5.4` rather than
`pytorch-linux-xenial-cuda9-cudnn7-py3`.

Differential Revision: [D18731108](https://our.internmc.facebook.com/intern/diff/D18731108)