### PR TITLE
[C++ API] Skip undefined tensors when moving torch::nn module to a different device

### DIFF
--- a/test/cpp/api/module.cpp
+++ b/test/cpp/api/module.cpp
@@ -257,11 +257,11 @@ void test_DeviceOrDtypeConversionSkipsUndefinedTensor(
   }
 }
 
-TEST_F(ModuleTest, DeviceConversionSkipsUndefinedTensor) {
+TEST_F(ModuleTest, DeviceOrDtypeConversionSkipsUndefinedTensor) {
   test_DeviceOrDtypeConversionSkipsUndefinedTensor(torch::kCPU, torch::kDouble);
 }
 
-TEST_F(ModuleTest, DeviceConversionSkipsUndefinedTensor_CUDA) {
+TEST_F(ModuleTest, DeviceOrDtypeConversionSkipsUndefinedTensor_CUDA) {
   test_DeviceOrDtypeConversionSkipsUndefinedTensor(torch::kCUDA, torch::kDouble);
 }
 

--- a/test/cpp/api/module.cpp
+++ b/test/cpp/api/module.cpp
@@ -225,7 +225,7 @@ void test_DeviceOrDtypeConversionSkipsUndefinedTensor(
   torch::Device to_device, torch::Dtype to_dtype) {
   {
     // Case 1: Undefined tensors as parameters
-    torch::nn::Linear module(torch::nn::LinearOptions(10, 20).bias(false));
+    Linear module(LinearOptions(10, 20).bias(false));
     ASSERT_TRUE(module->weight.defined());
     ASSERT_FALSE(module->bias.defined());
 

--- a/test/cpp/api/module.cpp
+++ b/test/cpp/api/module.cpp
@@ -241,7 +241,7 @@ void test_DeviceOrDtypeConversionSkipsUndefinedTensor(
   }
   {
     // Case 2: Undefined tensors as buffers
-    BatchNorm module(BatchNormOptions(5).track_running_stats(false).affine(true));
+    BatchNorm1d module(BatchNorm1dOptions(5).track_running_stats(false).affine(true));
     ASSERT_TRUE(module->weight.defined());
     ASSERT_FALSE(module->running_mean.defined());
 

--- a/test/cpp/api/module.cpp
+++ b/test/cpp/api/module.cpp
@@ -231,7 +231,7 @@ void test_DeviceOrDtypeConversionSkipsUndefinedTensor(
 
     module->to(to_device);
     ASSERT_TRUE(module->weight.defined());
-    ASSERT_EQ(module->weight.device(), to_device);
+    ASSERT_EQ(module->weight.device().type(), to_device.type());
     ASSERT_FALSE(module->bias.defined());
 
     module->to(to_dtype);
@@ -247,7 +247,7 @@ void test_DeviceOrDtypeConversionSkipsUndefinedTensor(
 
     module->to(to_device);
     ASSERT_TRUE(module->weight.defined());
-    ASSERT_EQ(module->weight.device(), to_device);
+    ASSERT_EQ(module->weight.device().type(), to_device.type());
     ASSERT_FALSE(module->running_mean.defined());
 
     module->to(to_dtype);

--- a/test/cpp/api/module.cpp
+++ b/test/cpp/api/module.cpp
@@ -221,6 +221,50 @@ TEST_F(ModuleTest, AsCastsModulesCorrectly) {
   ASSERT_EQ(unit.as<AGIUnit>(), &unit);
 }
 
+void test_DeviceOrDtypeConversionSkipsUndefinedTensor(
+  torch::Device to_device, torch::Dtype to_dtype) {
+  {
+    // Case 1: Undefined tensors as parameters
+    torch::nn::Linear module(torch::nn::LinearOptions(10, 20).bias(false));
+    ASSERT_TRUE(module->weight.defined());
+    ASSERT_FALSE(module->bias.defined());
+
+    module->to(to_device);
+    ASSERT_TRUE(module->weight.defined());
+    ASSERT_EQ(module->weight.device(), to_device);
+    ASSERT_FALSE(module->bias.defined());
+
+    module->to(to_dtype);
+    ASSERT_TRUE(module->weight.defined());
+    ASSERT_EQ(module->weight.dtype(), to_dtype);
+    ASSERT_FALSE(module->bias.defined());
+  }
+  {
+    // Case 2: Undefined tensors as buffers
+    BatchNorm module(BatchNormOptions(5).track_running_stats(false).affine(true));
+    ASSERT_TRUE(module->weight.defined());
+    ASSERT_FALSE(module->running_mean.defined());
+
+    module->to(to_device);
+    ASSERT_TRUE(module->weight.defined());
+    ASSERT_EQ(module->weight.device(), to_device);
+    ASSERT_FALSE(module->running_mean.defined());
+
+    module->to(to_dtype);
+    ASSERT_TRUE(module->weight.defined());
+    ASSERT_EQ(module->weight.dtype(), to_dtype);
+    ASSERT_FALSE(module->running_mean.defined());
+  }
+}
+
+TEST_F(ModuleTest, DeviceConversionSkipsUndefinedTensor) {
+  test_DeviceOrDtypeConversionSkipsUndefinedTensor(torch::kCPU, torch::kDouble);
+}
+
+TEST_F(ModuleTest, DeviceConversionSkipsUndefinedTensor_CUDA) {
+  test_DeviceOrDtypeConversionSkipsUndefinedTensor(torch::kCUDA, torch::kDouble);
+}
+
 TEST_F(ModuleTest, Conversion_MultiCUDA) {
   Linear module(128, 64);
   for (auto& parameter : module->parameters()) {

--- a/torch/csrc/api/include/torch/nn/module.h
+++ b/torch/csrc/api/include/torch/nn/module.h
@@ -649,11 +649,15 @@ void Module::to_impl(Ts&&... ts) {
   }
   // Then move every parameter to the new dtype/device.
   for (auto& parameter : parameters_) {
-    parameter->set_data(autograd::Variable(*parameter).to(ts...));
+    if (parameter->defined()) {
+      parameter->set_data(autograd::Variable(*parameter).to(ts...));
+    }
   }
   // Then move every buffer to the new dtype/device.
   for (auto& buffer : buffers_) {
-    buffer->set_data(autograd::Variable(*buffer).to(ts...));
+    if (buffer->defined()) {
+      buffer->set_data(autograd::Variable(*buffer).to(ts...));
+    }
   }
 }
 


### PR DESCRIPTION
This fixes high-pri issues such as https://github.com/pytorch/pytorch/issues/30508 and https://github.com/pytorch/pytorch/issues/30462.