### PR TITLE
Raise an error for is_signed on quantized types

### DIFF
--- a/c10/core/ScalarType.h
+++ b/c10/core/ScalarType.h
@@ -316,7 +316,7 @@ static inline bool isSignedType(ScalarType t) {
     case ScalarType::name:                       \
       return std::numeric_limits<ctype>::is_signed;
 
-  switch (toUnderlying(t)) {
+  switch (t) {
     AT_FORALL_SCALAR_TYPES_AND3(Half, Bool, BFloat16, CASE_SIGNED)
     default:
       AT_ERROR("Unknown ScalarType");

--- a/c10/core/ScalarType.h
+++ b/c10/core/ScalarType.h
@@ -312,9 +312,7 @@ static inline ScalarType toUnderlying(ScalarType t) {
 }
 
 static inline bool isSignedType(ScalarType t) {
-  if (isQIntType(t)) {
-    TORCH_CHECK(false, "isSignedType not supported for quantized types");
-  }
+  TORCH_CHECK(!isQIntType(t), "isSignedType not supported for quantized types");
   #define CASE_SIGNED(ctype, name) \
     case ScalarType::name:                       \
       return std::numeric_limits<ctype>::is_signed;

--- a/c10/core/ScalarType.h
+++ b/c10/core/ScalarType.h
@@ -312,6 +312,9 @@ static inline ScalarType toUnderlying(ScalarType t) {
 }
 
 static inline bool isSignedType(ScalarType t) {
+  if (isQIntType(t)) {
+    TORCH_CHECK(false, "isSignedType not supported for quantized types");
+  }
   #define CASE_SIGNED(ctype, name) \
     case ScalarType::name:                       \
       return std::numeric_limits<ctype>::is_signed;

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2443,9 +2443,9 @@ class _TestTorchMixin(object):
         for dtype in torch.testing.get_all_dtypes():
             self.assertEqual(dtype.is_signed, torch.is_signed(torch.tensor(0, dtype=dtype)))
 
-        self.assertFalse(torch.quint8.is_signed)
-        self.assertTrue(torch.qint8.is_signed)
-        self.assertTrue(torch.qint32.is_signed)
+        self.assertRaisesRegex(TypeError, 'support is_signed', lambda: torch.quint8.is_signed)
+        self.assertRaisesRegex(TypeError, 'support is_signed', lambda: torch.qint8.is_signed)
+        self.assertRaisesRegex(TypeError, 'support is_signed', lambda: torch.qint32.is_signed)
 
     def test_RNGState(self):
         state = torch.get_rng_state()

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2443,9 +2443,9 @@ class _TestTorchMixin(object):
         for dtype in torch.testing.get_all_dtypes():
             self.assertEqual(dtype.is_signed, torch.is_signed(torch.tensor(0, dtype=dtype)))
 
-        self.assertRaisesRegex(TypeError, 'support is_signed', lambda: torch.quint8.is_signed)
-        self.assertRaisesRegex(TypeError, 'support is_signed', lambda: torch.qint8.is_signed)
-        self.assertRaisesRegex(TypeError, 'support is_signed', lambda: torch.qint32.is_signed)
+        self.assertRaisesRegex(RuntimeError, 'not supported for quantized', lambda: torch.quint8.is_signed)
+        self.assertRaisesRegex(RuntimeError, 'not supported for quantized', lambda: torch.qint8.is_signed)
+        self.assertRaisesRegex(RuntimeError, 'not supported for quantized', lambda: torch.qint32.is_signed)
 
     def test_RNGState(self):
         state = torch.get_rng_state()

--- a/torch/csrc/Dtype.cpp
+++ b/torch/csrc/Dtype.cpp
@@ -8,6 +8,8 @@
 #include <torch/csrc/utils/tensor_dtypes.h>
 #include <torch/csrc/utils/tensor_types.h>
 
+#include <torch/csrc/Exceptions.h>
+
 PyObject * THPDtype_New(at::ScalarType scalar_type, const std::string& name)
 {
   AT_ASSERT(name.length() < DTYPE_NAME_LEN);
@@ -31,6 +33,10 @@ PyObject *THPDtype_is_floating_point(THPDtype *self, PyObject *noargs)
 
 PyObject *THPDtype_is_signed(THPDtype *self, PyObject *noargs)
 {
+  if (at::isQIntType(self->scalar_type)) {
+    PyErr_SetString(PyExc_TypeError, "Quantized types don't support is_signed");
+    return nullptr;
+  }
   if (at::isSignedType(self->scalar_type)) {
     Py_RETURN_TRUE;
   } else {

--- a/torch/csrc/Dtype.cpp
+++ b/torch/csrc/Dtype.cpp
@@ -33,15 +33,13 @@ PyObject *THPDtype_is_floating_point(THPDtype *self, PyObject *noargs)
 
 PyObject *THPDtype_is_signed(THPDtype *self, PyObject *noargs)
 {
-  if (at::isQIntType(self->scalar_type)) {
-    PyErr_SetString(PyExc_TypeError, "Quantized types don't support is_signed");
-    return nullptr;
-  }
+  HANDLE_TH_ERRORS
   if (at::isSignedType(self->scalar_type)) {
     Py_RETURN_TRUE;
   } else {
     Py_RETURN_FALSE;
   }
+  END_HANDLE_TH_ERRORS
 }
 
 PyObject *THPDtype_reduce(THPDtype *self, PyObject *noargs)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#30527 Raise an error for is_signed on quantized types**

Summary:

When we introduced dtype.is_signed we allowed for support of
quantized types, but we're not sure what the correct result should be.

See discussion at https://github.com/pytorch/pytorch/pull/29511

Differential Revision: [D18765410](https://our.internmc.facebook.com/intern/diff/D18765410)