### PR TITLE
[v1.4.0 patch] add default arg for init_method (#30208)

### DIFF
--- a/docs/source/notes/distributed_autograd.rst
+++ b/docs/source/notes/distributed_autograd.rst
@@ -330,7 +330,7 @@ autograd and distributed optimizer is as follows:
   def random_tensor():
       return torch.rand((3, 3), requires_grad=True)
 
-  def _run_process(self_rank, dst_rank, file_name):
+  def _run_process(self_rank, dst_rank):
       self_name = "worker{}".format(self_rank)
       dst_name = "worker{}".format(dst_rank)
 
@@ -339,7 +339,6 @@ autograd and distributed optimizer is as follows:
           self_name=self_name,
           self_rank=self_rank,
           worker_name_to_id={"worker0": 0, "worker1": 1},
-          init_method="file://{}".format(file_name),
       )
 
       # Use a distributed autograd context.
@@ -362,16 +361,15 @@ autograd and distributed optimizer is as follows:
          # Run the distributed optimizer step.
          dist_optim.step()
 
-  def run_process(self_rank, dst_rank, file_name):
-      _run_process(self_rank, dst_rank, file_name)
+  def run_process(self_rank, dst_rank):
+      _run_process(self_rank, dst_rank)
       rpc.wait_all_workers()
 
-  file_name = NamedTemporaryFile().name
   processes = []
 
   # Run two workers.
   for i in range(2):
-      p = mp.Process(target=run_process, args=(i, (i + 1) % 2, file_name))
+      p = mp.Process(target=run_process, args=(i, (i + 1) % 2))
       p.start()
       processes.append(p)
 

--- a/test/dist_utils.py
+++ b/test/dist_utils.py
@@ -83,7 +83,6 @@ def dist_init(old_test_method=None, setup_rpc=True, clean_shutdown=True):
             rpc.init_rpc(
                 name="worker%d" % self.rank,
                 backend=self.rpc_backend,
-                init_method=self.init_method,
                 rank=self.rank,
                 world_size=self.world_size,
                 rpc_backend_options=self.rpc_backend_options,
@@ -134,6 +133,7 @@ def dist_init(old_test_method=None, setup_rpc=True, clean_shutdown=True):
 TEST_CONFIG.rpc_backend_name = "PROCESS_GROUP"
 TEST_CONFIG.build_rpc_backend_options = lambda test_object: rpc.backend_registry.construct_rpc_backend_options(
     test_object.rpc_backend,
+    init_method=test_object.init_method,
     # Use enough 'num_send_recv_threads' until we fix https://github.com/pytorch/pytorch/issues/26359
     num_send_recv_threads=16,
 )

--- a/test/rpc_test.py
+++ b/test/rpc_test.py
@@ -306,7 +306,6 @@ class RpcTest(RpcAgentTestFixture):
         rpc.init_rpc(
             name="worker1",
             backend=backend,
-            init_method=self.init_method,
             rank=self.rank,
             world_size=self.world_size,
             rpc_backend_options=self.rpc_backend_options,
@@ -334,7 +333,6 @@ class RpcTest(RpcAgentTestFixture):
         rpc.init_rpc(
             name="worker{}".format(self.rank),
             backend=self.rpc_backend,
-            init_method=self.init_method,
             rank=self.rank,
             world_size=self.world_size,
             rpc_backend_options=self.rpc_backend_options,
@@ -357,7 +355,6 @@ class RpcTest(RpcAgentTestFixture):
             rpc.init_rpc(
                 name="worker{}".format(self.rank),
                 backend=self.rpc_backend,
-                init_method=self.init_method,
                 rank=self.rank,
                 world_size=self.world_size,
                 rpc_backend_options=self.rpc_backend_options,
@@ -513,7 +510,6 @@ class RpcTest(RpcAgentTestFixture):
         rpc.init_rpc(
             name="worker%d" % self.rank,
             backend=self.rpc_backend,
-            init_method=self.init_method,
             rank=self.rank,
             world_size=self.world_size,
             rpc_backend_options=self.rpc_backend_options,
@@ -1102,7 +1098,6 @@ class RpcTest(RpcAgentTestFixture):
         rpc.init_rpc(
             name="worker{}".format(self.rank),
             backend=self.rpc_backend,
-            init_method=self.init_method,
             rank=self.rank,
             world_size=self.world_size,
             rpc_backend_options=rpc_backend_options,

--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -36,7 +36,8 @@ PyObject* rpc_init(PyObject* /* unused */) {
 
   auto rpcBackendOptions =
       shared_ptr_class_<RpcBackendOptions>(module, "RpcBackendOptions")
-          .def_readwrite("rpc_timeout", &RpcBackendOptions::rpcTimeout);
+          .def_readwrite("rpc_timeout", &RpcBackendOptions::rpcTimeout)
+          .def_readwrite("init_method", &RpcBackendOptions::initMethod);
 
   auto workerInfo =
       shared_ptr_class_<WorkerInfo>(

--- a/torch/csrc/distributed/rpc/process_group_agent.h
+++ b/torch/csrc/distributed/rpc/process_group_agent.h
@@ -14,7 +14,7 @@ namespace distributed {
 namespace rpc {
 
 struct ProcessGroupRpcBackendOptions : public RpcBackendOptions {
-  ProcessGroupRpcBackendOptions() noexcept = default;
+  ProcessGroupRpcBackendOptions() = default;
   int numSendRecvThreads;
 };
 

--- a/torch/csrc/distributed/rpc/rpc_agent.h
+++ b/torch/csrc/distributed/rpc/rpc_agent.h
@@ -13,8 +13,9 @@ namespace distributed {
 namespace rpc {
 
 struct RpcBackendOptions {
-  RpcBackendOptions() noexcept = default;
+  RpcBackendOptions() = default;
   std::chrono::milliseconds rpcTimeout;
+  std::string initMethod;
 };
 
 // A globally unique ID to identify an RpcAgent

--- a/torch/distributed/rpc/__init__.py
+++ b/torch/distributed/rpc/__init__.py
@@ -25,7 +25,6 @@ if is_available():
     def init_rpc(
         name,
         backend=backend_registry.BackendType.PROCESS_GROUP,
-        init_method=None,
         rank=-1,
         world_size=None,
         rpc_backend_options=None,
@@ -49,15 +48,21 @@ if is_available():
                         ``Worker1``) Name can only contain number, alphabet,
                         underscore, and/or dash, and must be shorter than
                         128 characters.
-            init_method(str): backend specific init arguments.
             rank (int): a globally unique id/rank of this node.
             world_size (int): The number of workers in the group.
             rpc_backend_options (RpcBackendOptions): The options passed to RpcAgent
                 consturctor.
         """
+
+        if not rpc_backend_options:
+            # default construct a set of RPC backend options.
+            rpc_backend_options = backend_registry.construct_rpc_backend_options(
+                backend
+            )
+
         # Rendezvous.
         rendezvous_iterator = torch.distributed.rendezvous(
-            init_method, rank=rank, world_size=world_size
+            rpc_backend_options.init_method, rank=rank, world_size=world_size
         )
         store, _, _ = next(rendezvous_iterator)
 

--- a/torch/distributed/rpc/api.py
+++ b/torch/distributed/rpc/api.py
@@ -96,12 +96,6 @@ def _init_rpc_backend(
     if sys.version_info < (3, 0):
         raise RuntimeError("RPC package does not support Python2.")
 
-    if not rpc_backend_options:
-        # default construct a set of RPC agent options.
-        rpc_backend_options = rpc.backend_registry.construct_rpc_backend_options(
-            backend
-        )
-
     _validate_rpc_args(backend, store, name, rank, world_size, rpc_backend_options)
 
     global _agent

--- a/torch/distributed/rpc/backend_registry.py
+++ b/torch/distributed/rpc/backend_registry.py
@@ -58,12 +58,17 @@ def register_backend(
 
 
 def construct_rpc_backend_options(
-    backend, rpc_timeout=rpc_constants.DEFAULT_RPC_TIMEOUT, **kwargs
+    backend,
+    rpc_timeout=rpc_constants.DEFAULT_RPC_TIMEOUT,
+    init_method=rpc_constants.DEFAULT_INIT_METHOD,
+    **kwargs
 ):
     if not isinstance(rpc_timeout, datetime.timedelta):
         raise RuntimeError("`rpc_timeout` must be a `datetime.timedelta`.")
 
-    return backend.value.construct_rpc_backend_options_handler(rpc_timeout, **kwargs)
+    return backend.value.construct_rpc_backend_options_handler(
+        rpc_timeout, init_method, **kwargs
+    )
 
 
 def init_backend(backend, *args, **kwargs):
@@ -71,12 +76,16 @@ def init_backend(backend, *args, **kwargs):
 
 
 def _process_group_construct_rpc_backend_options_handler(
-    rpc_timeout, num_send_recv_threads=rpc_constants.DEFAULT_NUM_SEND_RECV_THREADS, **kwargs
+    rpc_timeout,
+    init_method,
+    num_send_recv_threads=rpc_constants.DEFAULT_NUM_SEND_RECV_THREADS,
+    **kwargs
 ):
     from . import ProcessGroupRpcBackendOptions
 
     rpc_backend_options = ProcessGroupRpcBackendOptions()
     rpc_backend_options.rpc_timeout = rpc_timeout
+    rpc_backend_options.init_method = init_method
     rpc_backend_options.num_send_recv_threads = num_send_recv_threads
     return rpc_backend_options
 
@@ -102,9 +111,7 @@ def _process_group_init_backend_handler(
 
         if (rank != -1) and (rank != group.rank()):
             raise RuntimeError(
-                "rank argument {} doesn't match pg rank {}".format(
-                    rank, group.rank()
-                )
+                "rank argument {} doesn't match pg rank {}".format(rank, group.rank())
             )
         if (world_size != -1) and (world_size != group.size()):
             raise RuntimeError(

--- a/torch/distributed/rpc/constants.py
+++ b/torch/distributed/rpc/constants.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 
 # For any RpcAgent.
 DEFAULT_RPC_TIMEOUT = timedelta(seconds=60)
+DEFAULT_INIT_METHOD = "env://"
 
 
 # For ProcessGroupAgent.


### PR DESCRIPTION
Summary:
Note: This PR has been merged into master at 5c6705e after the 1.4 branch cut (see original PR: https://github.com/pytorch/pytorch/pull/30208). This PR is to merge it into the 1.4 branch.

---- Original Commit Description Follows ---

Pull Request resolved: https://github.com/pytorch/pytorch/pull/30208
Adds default arg for init_method so users don't have to pass this in,
and moves it to `RpcBackendOptions` struct. Removes `init_method` arg from rpc.init_rpc. Also fixes some docs.
ghstack-source-id: 94500475

Test Plan: Unit tests pass.

Reviewed By: mrshenli

Differential Revision: D18630074

fbshipit-source-id: 04b7dd7ec96f4c4da311b71d250233f1f262135a

