### PR TITLE
improve .view() performance

### DIFF
--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -1202,8 +1202,8 @@ Tensor view(const Tensor& self, IntArrayRef size) {
     " spans across two contiguous subspaces). Use .reshape(...) instead.");
   auto stride_value = *stride;
   auto self_ = self.alias();
-  self_.set_(
-    self.storage(), self.storage_offset(), inferred_size, stride_value);
+  auto impl_ = self_.unsafeGetTensorImpl();
+  impl_->set_sizes_and_strides(inferred_size, stride_value);
   return self_;
 }
 

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -1,4 +1,3 @@
-#include <TH/THTensor.hpp>
 #include <algorithm>
 #include <vector>
 #include <ATen/ATen.h>
@@ -512,6 +511,32 @@ Tensor repeat(const Tensor& self, IntArrayRef repeats) {
   return result;
 }
 
+Tensor alias_with_sizes_and_strides(
+    const Tensor& self,
+    const c10::IntArrayRef sizes,
+    const c10::IntArrayRef strides) {
+  Tensor self_;
+  if (self.is_quantized()) {
+    auto impl = c10::make_intrusive<QTensorImpl>(
+        Storage(self.storage()),
+        self.type_set(),
+        get_qtensorimpl(self)->quantizer());
+    impl->set_storage_offset(self.storage_offset());
+    impl->set_sizes_and_strides(sizes, strides);
+    self_ = Tensor(std::move(impl));
+  } else {
+    auto impl = c10::make_intrusive<TensorImpl>(
+        Storage(self.storage()), self.type_set());
+    impl->set_storage_offset(self.storage_offset());
+    impl->set_sizes_and_strides(sizes, strides);
+    self_ = Tensor(std::move(impl));
+  }
+#ifdef BUILD_NAMEDTENSOR
+  namedinference::propagate_names(self_, self);
+#endif
+  return self_;
+}
+
 Tensor reshape(const Tensor& self, IntArrayRef proposed_shape) {
   if (self.is_sparse()) {
     AT_ERROR("reshape is not implemented for sparse tensors");
@@ -522,16 +547,17 @@ Tensor reshape(const Tensor& self, IntArrayRef proposed_shape) {
     return at::_mkldnn_reshape(self, shape);
   }
 
-  if (THTensor_compute_stride(self.sizes(), self.strides(), shape)) {
-    // `THTensor_compute_stride` returns the proper strides to use if this
+  auto stride =
+      at::detail::computeStride(self.sizes(), self.strides(), shape);
+    // `computeStride` returns the proper strides to use if this
     // `reshape` can be just a view.
     //
     // NB: Even though we have viewable geometry and the target strides here,
     //     we do not just call `as_strided` on `self` because the backward
     //     for `as_strided` is not as efficient as that of `view` (since the
-    //     former is meant to handle general cases). We will redo a
-    //     `THTensor_compute_stride` in `view` but that is quite cheap anyways.
-    return self.view(shape);
+    //     former is meant to handle general cases).
+  if (stride.has_value()) {
+    return alias_with_sizes_and_strides(self, shape, *stride);
   }
   return at::_unsafe_view(self.clone(at::MemoryFormat::Contiguous), shape);
 }
@@ -1201,33 +1227,11 @@ Tensor view(const Tensor& self, IntArrayRef size) {
     "not compatible with input tensor's size and stride (at least one dimension"
     " spans across two contiguous subspaces). Use .reshape(...) instead.");
   auto stride_value = *stride;
-  auto self_ = self.alias();
-  auto impl_ = self_.unsafeGetTensorImpl();
-  impl_->set_sizes_and_strides(inferred_size, stride_value);
-  return self_;
+  return alias_with_sizes_and_strides(self, inferred_size, stride_value);
 }
 
 Tensor alias(const Tensor& self) {
-  Tensor self_;
-  if (self.is_quantized()) {
-    auto impl = c10::make_intrusive<QTensorImpl>(
-                    Storage(self.storage()),
-                    self.type_set(),
-                    get_qtensorimpl(self)->quantizer());
-    impl->set_storage_offset(self.storage_offset());
-    impl->set_sizes_and_strides(self.sizes(), self.strides());
-    self_ = Tensor(std::move(impl));
-  } else {
-    auto impl = c10::make_intrusive<TensorImpl>(Storage(self.storage()),
-                                                self.type_set());
-    impl->set_storage_offset(self.storage_offset());
-    impl->set_sizes_and_strides(self.sizes(), self.strides());
-    self_ = Tensor(std::move(impl));
-  }
-#ifdef BUILD_NAMEDTENSOR
-  namedinference::propagate_names(self_, self);
-#endif
-  return self_;
+    return alias_with_sizes_and_strides(self, self.sizes(), self.strides());
 }
 
 Tensor unfold(const Tensor& self, int64_t dimension, int64_t size, int64_t step) {

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -557,7 +557,7 @@ Tensor reshape(const Tensor& self, IntArrayRef proposed_shape) {
     //     for `as_strided` is not as efficient as that of `view` (since the
     //     former is meant to handle general cases).
   if (stride.has_value()) {
-    return alias_with_sizes_and_strides(self, shape, *stride);
+    return self.view(shape);
   }
   return at::_unsafe_view(self.clone(at::MemoryFormat::Contiguous), shape);
 }

--- a/aten/src/TH/THTensor.cpp
+++ b/aten/src/TH/THTensor.cpp
@@ -92,14 +92,6 @@ void THTensor_resizeNd(THTensor *self, int nDimension, const int64_t *size, cons
   at::native::resize_impl_cpu_(self, sizes, strides);
 }
 
-// See ATen/TensorUtils.cpp
-c10::optional<std::vector<int64_t>> THTensor_compute_stride(
-    at::IntArrayRef oldshape,
-    at::IntArrayRef oldstride,
-    at::IntArrayRef newshape) {
-    return at::detail::computeStride(oldshape, oldstride, newshape);
-}
-
 // NB: Steals ownership of storage
 void THTensor_stealAndSetStoragePtr(THTensor* tensor, THStorage* storage) {
   // Caffe2 might have tensors whose storages are null, but we

--- a/aten/src/TH/THTensor.hpp
+++ b/aten/src/TH/THTensor.hpp
@@ -120,10 +120,6 @@ TH_API void THTensor_resizeNd(THTensor *self, int nDimension, const int64_t *siz
 
 TH_CPP_API void THTensor_resize(THTensor *self, at::IntArrayRef size, at::IntArrayRef stride);
 TH_CPP_API void THTensor_setStorage(THTensor *self, THStorage *storage_, ptrdiff_t storageOffset_, at::IntArrayRef size_, at::IntArrayRef stride_);
-TH_CPP_API c10::optional<std::vector<int64_t>> THTensor_compute_stride(
-    at::IntArrayRef oldshape,
-    at::IntArrayRef oldstride,
-    at::IntArrayRef newshape);
 
 #include <TH/generic/THTensor.hpp>
 #include <TH/THGenerateAllTypes.h>


### PR DESCRIPTION
Improve .view() performance by not calling set_ and instead restriding returned alias. This improves performance of .view() operation from ~500ns to ~360 ns

Test plan: covered by existing tests