### PR TITLE
add missing method annotations to torch.Tensor

### DIFF
--- a/tools/pyi/gen_pyi.py
+++ b/tools/pyi/gen_pyi.py
@@ -175,7 +175,7 @@ def arg_to_type_hint(arg):
 
 binary_ops = ('add', 'sub', 'mul', 'div', 'pow', 'lshift', 'rshift', 'mod', 'truediv',
               'matmul', 'floordiv',
-              'radd', 'rmul', 'rfloordiv',          # reverse arithmetic
+              'radd', 'rsub', 'rmul', 'rtruediv', 'rfloordiv', 'rpow',          # reverse arithmetic
               'and', 'or', 'xor',                   # logic
               'iadd', 'iand', 'idiv', 'ilshift', 'imul',
               'ior', 'irshift', 'isub', 'itruediv', 'ixor',  # inplace ops

--- a/tools/pyi/gen_pyi.py
+++ b/tools/pyi/gen_pyi.py
@@ -511,7 +511,7 @@ def gen_pyi(declarations_path, out):
         'cuda': ['def cuda(self, device: Optional[_device]=None, non_blocking: _bool=False) -> Tensor: ...'],
         'numpy': ['def numpy(self) -> Any: ...'],
         'apply_': ['def apply_(self, callable: Callable) -> Tensor: ...'],
-        'map_': ['def map_(tensor: Tensor, callable: Callable) -> Tensor: ...'],
+        'map_': ['def map_(self, tensor: Tensor, callable: Callable) -> Tensor: ...'],
         'storage': ['def storage(self) -> Storage: ...'],
         'type': ['def type(self, dtype: Union[None, str, _dtype]=None, non_blocking: _bool=False)'
                  ' -> Union[str, Tensor]: ...'],


### PR DESCRIPTION
Looks like some of the tensor methods defined in https://github.com/pytorch/pytorch/blob/master/torch/tensor.py#L393 were missing.

Also add missing self object to `map_`