### PR TITLE
Raise an error if torch.cat is given `out` as one of the input tensors

### DIFF
--- a/aten/src/ATen/MemoryOverlap.cpp
+++ b/aten/src/ATen/MemoryOverlap.cpp
@@ -40,6 +40,9 @@ MemOverlapStatus get_overlap_status(const Tensor& a, const Tensor& b) {
 
 MemOverlapStatus get_overlap_status(TensorImpl* a, TensorImpl* b) {
   if (a == b) return MemOverlapStatus::FULL;
+  if (a->numel() == 0 || b->numel() == 0) {
+    return MemOverlapStatus::NO;
+  }
   if (!a->is_contiguous() || !b->is_contiguous()) {
     return MemOverlapStatus::TOO_HARD;
   }

--- a/aten/src/ATen/MemoryOverlap.h
+++ b/aten/src/ATen/MemoryOverlap.h
@@ -21,8 +21,8 @@ CAFFE2_API MemOverlap has_internal_overlap(TensorImpl* t);
 CAFFE2_API void assert_no_internal_overlap(const Tensor& t);
 CAFFE2_API void assert_no_internal_overlap(TensorImpl* t);
 
-MemOverlapStatus get_overlap_status(const Tensor& a, const Tensor& b);
-MemOverlapStatus get_overlap_status(TensorImpl* a, TensorImpl* b);
+CAFFE2_API MemOverlapStatus get_overlap_status(const Tensor& a, const Tensor& b);
+CAFFE2_API MemOverlapStatus get_overlap_status(TensorImpl* a, TensorImpl* b);
 
 void assert_no_partial_overlap(const Tensor& a, const Tensor& b);
 void assert_no_partial_overlap(TensorImpl* a, TensorImpl* b);

--- a/aten/src/TH/generic/THTensor.cpp
+++ b/aten/src/TH/generic/THTensor.cpp
@@ -623,6 +623,13 @@ void THTensor_(catArray)(THTensor *result, THTensor **inputs, int numInputs, int
   bool allSkipped= true;
   int64_t nDims = 0;
   THTensor *notSkippedTensor;  // non-owning reference
+
+  // Inputs cannot alias the output tensor
+  for (int i = 0; i < numInputs; i++) {
+    THArgCheck(result != inputs[i], 0,
+        "Cannot output result into input tensor %d", i);
+  }
+
   auto should_skip = [](THTensor *t) { return t->is_empty() && t->dim() == 1; };
   for (int i = 0; i < numInputs; i++) {
     if (should_skip(inputs[i])) {

--- a/aten/src/THC/generic/THCTensorMath.cu
+++ b/aten/src/THC/generic/THCTensorMath.cu
@@ -87,6 +87,12 @@ void THCTensor_(catArray)(THCState *state, THCTensor *result,
   auto should_skip = [](THCTensor *t) { return t->is_empty() && t->dim() == 1; };
   int nDims = 0;
 
+  // Inputs cannot alias the output tensor
+  for (int i = 0; i < numInputs; i++) {
+    THArgCheck(result != inputs[i], 0,
+        "Cannot output result into input tensor %d", i);
+  }
+
   for (i = 0; i < numInputs; i++)
   {
     if (should_skip(inputs[i])) {

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6870,12 +6870,23 @@ class TestTorchDeviceType(TestCase):
         y = torch.randn((4, 6), device=device)
 
         with self.assertRaisesRegex(
-                RuntimeError, r"Cannot output result into input tensor 0"):
+                RuntimeError, r"unsupported operation:.* input tensor 0"):
             torch.cat([x, y], dim=0, out=x)
 
         with self.assertRaisesRegex(
-                RuntimeError, r"Cannot output result into input tensor 1"):
+                RuntimeError, r"unsupported operation:.* input tensor 1"):
             torch.cat([x, y], dim=0, out=y)
+
+        z = torch.zeros((4, 6), device=device)
+        with self.assertRaisesRegex(
+                RuntimeError, r"unsupported operation:.* input tensor 1"):
+            torch.cat([y, z], out=z[:2, :])
+
+        w = y.view(-1).clone()
+        a = torch.cat([w[:2], w[4:6]])
+        b = torch.cat([w[:2], w[4:6]], out=w[6:10])
+        self.assertEqual(a, b)
+        self.assertEqual(w[:6], y.view(-1)[:6])
 
     def test_is_set_to(self, device):
         t1 = torch.empty(3, 4, 9, 10, device=device)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6865,6 +6865,18 @@ class TestTorchDeviceType(TestCase):
         self.assertRaises(RuntimeError, lambda: torch.cat([x, empty], dim=1))
         self.assertRaises(RuntimeError, lambda: torch.cat([empty, x], dim=1))
 
+    def test_cat_out(self, device):
+        x = torch.zeros((0), device=device)
+        y = torch.randn((4, 6), device=device)
+
+        with self.assertRaisesRegex(
+                RuntimeError, r"Cannot output result into input tensor 0"):
+            torch.cat([x, y], dim=0, out=x)
+
+        with self.assertRaisesRegex(
+                RuntimeError, r"Cannot output result into input tensor 1"):
+            torch.cat([x, y], dim=0, out=y)
+
     def test_is_set_to(self, device):
         t1 = torch.empty(3, 4, 9, 10, device=device)
         t2 = torch.empty(3, 4, 9, 10, device=device)


### PR DESCRIPTION
Fixes #30562 for both cpu and cuda.