### PR TITLE
Update v1.3.0 Persons of Interest to match v1.2.0

### DIFF
--- a/docs/source/community/persons_of_interest.rst
+++ b/docs/source/community/persons_of_interest.rst
@@ -15,12 +15,74 @@ General Maintainers
 Module-level maintainers
 ------------------------
 
-torch.*
-~~~~~~~
+JIT
+~~~
 
--  Greg Chanan (`gchanan <https://github.com/gchanan>`__)
+-  Zach Devito (`zdevito <https://github.com/zdevito>`__)
+-  Michael Suo (`suo <https://github.com/suo>`__)
+
+Distributed
+~~~~~~~~~~~
+
+-  Pieter Noordhuis (`pietern <https://github.com/pietern>`__)
+-  Shen Li (`mrshenli <https://github.com/mrshenli>`__)
+-  (sunsetting) Teng Li (`teng-li <https://github.com/teng-li>`__)
+
+Autograd Engine
+~~~~~~~~~~~~~~~
+
+-  Alban Desmaison (`alband <https://github.com/alband>`__)
+-  Adam Paszke (`apaszke <https://github.com/apaszke>`__)
+
+Multiprocessing and DataLoaders
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+-  Simon Wang (`SsnL <https://github.com/SsnL>`__)
+-  Adam Paszke (`apaszke <https://github.com/apaszke>`__)
+-  (proposed) Vitaly Fedyunin
+   (`VitalyFedyunin <https://github.com/proposed>`__)
+
+CUDA
+~~~~
+
+-  Edward Yang (`ezyang <https://github.com/ezyang>`__)
+-  Natalia Gimelshein (`ngimel <https://github.com/ngimel>`__)
+
+C++
+~~~
+
+-  Will Feng (`yf225 <https://github.com/yf225>`__)
+-  (sunsetting) Peter Goldsborough
+   (`goldsborough <https://github.com/goldsborough>`__)
+
+Build + CI
+~~~~~~~~~~
+
+-  Will Feng (`yf225 <https://github.com/yf225>`__)
+-  Edward Yang (`ezyang <https://github.com/ezyang>`__)
+-  Jesse Hellemn (`pjh5 <https://github.com/pjh5>`__)
 -  Soumith Chintala (`soumith <https://github.com/soumith>`__)
--  [linear algebra] Vishwak Srinivasan (`vishwakftw <https://github.com/vishwakftw>`__)
+-  (sunsetting) Orion Reblitz-Richardson
+   (`orionr <https://github.com/orionr>`__)
+
+Distributions & RNG
+~~~~~~~~~~~~~~~~~~~
+
+-  Fritz Obermeyer (`fritzo <https://github.com/fritzo>`__)
+-  Neeraj Pradhan (`neerajprad <https://github.com/neerajprad>`__)
+-  Alican Bozkurt (`alicanb <https://github.com/alicanb>`__)
+-  Vishwak Srinivasan (`vishwakftw <https://github.com/vishwakftw>`__)
+
+C10
+~~~
+
+-  Sebastian Messmer (`smessmer <https://github.com/smessmer>`__)
+-  Edward Yang (`ezyang <https://github.com/ezyang>`__)
+
+ONNX <-> PyTorch
+~~~~~~~~~~~~~~~~
+
+-  Lu Fang (`houseroad <https://github.com/houseroad>`__)
 
 torch.nn
 ~~~~~~~~
@@ -31,69 +93,27 @@ torch.nn
 -  Soumith Chintala (`soumith <https://github.com/soumith>`__)
 -  Sam Gross (`colesbury <https://github.com/colesbury>`__)
 
-torch.optim
-~~~~~~~~~~~
-
--  Vincent Quenneville-Belair (`vincentqb <https://github.com/vincentqb>`__)
--  Soumith Chintala (`soumith <https://github.com/soumith>`__)
-
-Autograd Engine
-~~~~~~~~~~~~~~~
-
--  Edward Yang (`ezyang <https://github.com/ezyang>`__)
--  Alban Desmaison (`alband <https://github.com/alband>`__)
--  Adam Paszke (`apaszke <https://github.com/apaszke>`__)
-
-JIT
-~~~
-
--  Zach Devito (`zdevito <https://github.com/zdevito>`__)
--  Michael Suo (`suo <https://github.com/suo>`__)
-
-Distributions & RNG
-~~~~~~~~~~~~~~~~~~~
-
--  Fritz Obermeyer (`fritzo <https://github.com/fritzo>`__)
--  Neeraj Pradhan (`neerajprad <https://github.com/neerajprad>`__)
--  Alican Bozkurt (`alicanb <https://github.com/alicanb>`__)
--  Vishwak Srinivasan (`vishwakftw <https://github.com/vishwakftw>`__)
-
-Distributed
-~~~~~~~~~~~
-
--  Pieter Noordhuis (`pietern <https://github.com/pietern>`__)
--  Shen Li (`mrshenli <https://github.com/mrshenli>`__)
-..
- -  (proposed) Pritam Damania
-   (`pritamdamania87 <https://github.com/pritamdamania87>`__)
-
-Multiprocessing and DataLoaders
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
--  Vitaly Fedyunin (`VitalyFedyunin <https://github.com/VitalyFedyunin>`__)
--  Simon Wang (`SsnL <https://github.com/SsnL>`__)
--  Adam Paszke (`apaszke <https://github.com/apaszke>`__)
-
 CPU Performance / SIMD
 ~~~~~~~~~~~~~~~~~~~~~~
 
--  Xiaoqiang Zheng (`zheng-xq <https://github.com/zheng-xq>`__)
--  Vitaly Fedyunin (`VitalyFedyunin <https://github.com/VitalyFedyunin>`__)
+-  Christian Puhrsch (`cpuhrsch <https://github.com/cpuhrsch>`__)
 -  Sam Gross (`colesbury <https://github.com/colesbury>`__)
--  (sunsetting) Christian Puhrsch (`cpuhrsch <https://github.com/cpuhrsch>`__)
--  [threading] Ilia Cherniavskii (`ilia-cher <https://github.com/ilia-cher>`__)
+-  Richard Zou (`zou3519 <https://github.com/zou3519>`__)
 
-CUDA
-~~~~
+AMD/ROCm/HIP
+~~~~~~~~~~~~
 
--  Natalia Gimelshein (`ngimel <https://github.com/ngimel>`__)
--  Edward Yang (`ezyang <https://github.com/ezyang>`__)
--  Xiaoqiang Zheng (`zheng-xq <https://github.com/zheng-xq>`__)
+-  Junjie Bai (`bddppq <https://github.com/bddppq>`__)
+-  Johannes M. Dieterich (`iotamudelta <https://github.com/iotamudelta>`__)
+
+Windows
+~~~~~~~
+
+-  Peter Johnson (`peterjc123 <https://github.com/peterjc123>`__)
 
 MKLDNN
 ~~~~~~
 
--  Junjie Bai (`bddppq <https://github.com/bddppq>`__)
 -  Yinghai Lu (`yinghai <https://github.com/yinghai>`__)
 
 XLA
@@ -104,48 +124,7 @@ XLA
 -  Davide Libenzi (`dlibenzi <https://github.com/dlibenzi>`__)
 -  Alex Suhan (`asuhan <https://github.com/asuhan>`__)
 
-AMD/ROCm/HIP
-~~~~~~~~~~~~
-
--  Junjie Bai (`bddppq <https://github.com/bddppq>`__)
--  Johannes M. Dieterich (`iotamudelta <https://github.com/iotamudelta>`__)
-
-Build + CI
-~~~~~~~~~~
-
--  Will Feng (`yf225 <https://github.com/yf225>`__)
--  Edward Yang (`ezyang <https://github.com/ezyang>`__)
--  Soumith Chintala (`soumith <https://github.com/soumith>`__)
--  Karl Ostmo (`kostmo <https://github.com/kostmo>`__)
--  Hong Xu (`xuhdev <https://github.com/xuhdev>`__)
-
-Benchmarks
-~~~~~~~~~~
-
--  Mingzhe Li (`mingzhe09088 <https://github.com/mingzhe09088>`__)
-
-C++ API
-~~~~~~~
-
--  Will Feng (`yf225 <https://github.com/yf225>`__)
-
-C10 utils and operator dispatch
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
--  Sebastian Messmer (`smessmer <https://github.com/smessmer>`__)
--  Dmytro Dzhulgakov (`dzhulgakov <https://github.com/dzhulgakov>`__)
-
-ONNX <-> PyTorch
-~~~~~~~~~~~~~~~~
-
--  Lu Fang (`houseroad <https://github.com/houseroad>`__)
-
-Windows
-~~~~~~~
-
--  Peter Johnson (`peterjc123 <https://github.com/peterjc123>`__)
-
-PowerPC
-~~~~~~~
+PPC
+~~~
 
 -  Alfredo Mendoza (`avmgithub <https://github.com/avmgithub>`__)


### PR DESCRIPTION
Update v1.3.0 Persons of Interest to match that from v1.2.0
https://github.com/pytorch/pytorch/blob/v1.2.0/docs/source/community/persons_of_interest.rst

