### PR TITLE
Don't build test_cpp_rpc if torch is built without distributed support

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -745,7 +745,9 @@ ENDIF()
 
   if (BUILD_TEST AND NOT MSVC AND NOT USE_ROCM)
     add_subdirectory(${TORCH_ROOT}/test/cpp/jit ${CMAKE_BINARY_DIR}/test_jit)
-    add_subdirectory(${TORCH_ROOT}/test/cpp/rpc ${CMAKE_BINARY_DIR}/test_cpp_rpc)
+    if (USE_DISTRIBUTED)
+      add_subdirectory(${TORCH_ROOT}/test/cpp/rpc ${CMAKE_BINARY_DIR}/test_cpp_rpc)
+    endif()
   endif()
 
   if (BUILD_TEST AND NOT NO_API)


### PR DESCRIPTION
On the latest master, I get link errors when building one of the tests:

```sh
/home/pbell/git/pytorch/build/../test/cpp/rpc/test_wire_serialization.cpp:23: 
undefined reference to `torch::distributed::rpc::wireDeserialize(void const*, unsigned long)'
```

This seems to be caused by PR #29785 not working with `USE_DISTRIBUTED=0`.