### PR TITLE
Add pybind11 exception translator

### DIFF
--- a/test/test_cpp_extensions_jit.py
+++ b/test/test_cpp_extensions_jit.py
@@ -720,9 +720,34 @@ class TestCppExtensionJIT(common.TestCase):
         t = torch.rand(2).double()
         cpp_tensor_name = r"CPUDoubleType"
 
+        # Without error handling, the warnings cannot be catched
         warn_mod = torch.utils.cpp_extension.load_inline(name='warn_mod',
                                                          cpp_sources=[source],
-                                                         functions=['foo'])
+                                                         functions=['foo'],
+                                                         with_pytorch_error_handling=False)
+
+        with warnings.catch_warnings(record=True) as w:
+            warn_mod.foo(t, 0)
+            self.assertEqual(len(w), 0)
+
+            with self.assertRaisesRegex(TypeError, t.type()):
+                warn_mod.foo(t, 1)
+            self.assertEqual(len(w), 0)
+
+            with self.assertRaisesRegex(SystemError, "bad argument to internal function"):
+                warn_mod.foo(t, 2)
+            self.assertEqual(len(w), 0)
+
+            with self.assertRaisesRegex(KeyError, cpp_tensor_name):
+                warn_mod.foo(t, 3)
+            self.assertEqual(len(w), 0)
+
+
+        warn_mod = torch.utils.cpp_extension.load_inline(name='warn_mod',
+                                                         cpp_sources=[source],
+                                                         functions=['foo'],
+                                                         with_pytorch_error_handling=True)
+
 
         with warnings.catch_warnings(record=True) as w:
             # Catched with no error should be detected

--- a/test/test_cpp_extensions_jit.py
+++ b/test/test_cpp_extensions_jit.py
@@ -720,36 +720,9 @@ class TestCppExtensionJIT(common.TestCase):
         t = torch.rand(2).double()
         cpp_tensor_name = r"CPUDoubleType"
 
-        # Without error handling, the warnings cannot be catched
-        # and the Tensor type names are not cleaned
         warn_mod = torch.utils.cpp_extension.load_inline(name='warn_mod',
                                                          cpp_sources=[source],
-                                                         functions=['foo'],
-                                                         with_pytorch_error_handling=False)
-
-        with warnings.catch_warnings(record=True) as w:
-            warn_mod.foo(t, 0)
-            self.assertEqual(len(w), 0)
-
-            # pybind translate all our errors to RuntimeError
-            with self.assertRaisesRegex(RuntimeError, cpp_tensor_name):
-                warn_mod.foo(t, 1)
-            self.assertEqual(len(w), 0)
-
-            with self.assertRaisesRegex(RuntimeError, "bad argument to internal function|python_error"):
-                warn_mod.foo(t, 2)
-            self.assertEqual(len(w), 0)
-
-            with self.assertRaisesRegex(KeyError, cpp_tensor_name):
-                warn_mod.foo(t, 3)
-            self.assertEqual(len(w), 0)
-
-
-        warn_mod = torch.utils.cpp_extension.load_inline(name='warn_mod',
-                                                         cpp_sources=[source],
-                                                         functions=['foo'],
-                                                         with_pytorch_error_handling=True)
-
+                                                         functions=['foo'])
 
         with warnings.catch_warnings(record=True) as w:
             # Catched with no error should be detected

--- a/torch/csrc/Exceptions.h
+++ b/torch/csrc/Exceptions.h
@@ -40,8 +40,7 @@
 /// cpp warnings.
 #define HANDLE_TH_ERRORS                                             \
   try {                                                              \
-    torch::PyWarningHandler __enforce_warning_buffer;                \
-    try{
+    torch::PyWarningHandler __enforce_warning_buffer;
 
 #define CATCH_TH_ERRORS(retstmnt)                                    \
     catch (python_error & e) {                                       \
@@ -69,45 +68,10 @@
     }
 
 #define END_HANDLE_TH_ERRORS_PYBIND                                      \
-    }                                                                    \
-    catch (py::error_already_set & e) {                                  \
-      /* Unpack already stored error to be detectable by warning code */ \
-      e.restore();                                                       \
-      throw;                                                             \
-    }                                                                    \
-    catch (py::builtin_exception & e) {                                  \
-      /* Unpack already stored error to be detectable by warning code */ \
-      e.set_error();                                                     \
-      throw;                                                             \
-    }                                                                    \
-    catch (torch::jit::JITException & e) {                               \
-      /* Special case for JITException that are explicitly unpacked by */\
-      /* pybind. Set a temporary python error to be detectable by */     \
-      /* warning code */                                                 \
-      PyErr_SetString(PyExc_RuntimeError, "JITException");               \
-      throw;                                                             \
-    }                                                                    \
-    CATCH_TH_ERRORS(throw)                                               \
-  }                                                                      \
-  catch (py::error_already_set & e) {                                    \
-    /* Repack already stored error */                                    \
-    throw py::error_already_set();                                       \
-  }                                                                      \
-  catch (py::builtin_exception & e) {                                    \
-    /* Repack already stored error */                                    \
-    throw py::error_already_set();                                       \
-  }                                                                      \
-  catch (torch::jit::JITException & e) {                                 \
-    /* Special case for JITException that are explicitly unpacked by */  \
-    /* pybind. Clear the temporary error message we used */              \
-    PyErr_Clear();                                                       \
-    throw;                                                               \
   }                                                                      \
   CATCH_TH_ERRORS(throw py::error_already_set())
 
 #define END_HANDLE_TH_ERRORS_RET(retval)                             \
-    }                                                                \
-    CATCH_TH_ERRORS(return retval)                                   \
   }                                                                  \
   CATCH_TH_ERRORS(return retval)
 

--- a/torch/csrc/Exceptions.h
+++ b/torch/csrc/Exceptions.h
@@ -42,6 +42,7 @@
   try {                                                              \
     torch::PyWarningHandler __enforce_warning_buffer;
 
+// Only catch torch-specific exceptions
 #define CATCH_TH_ERRORS(retstmnt)                                    \
     catch (python_error & e) {                                       \
       retstmnt;                                                      \
@@ -60,7 +61,10 @@
       auto msg = torch::processErrorMsg(e.what());                   \
       PyErr_SetString(e.python_type(), msg.c_str());                 \
       retstmnt;                                                      \
-    }                                                                \
+    }
+
+#define CATCH_ALL_ERRORS(retstmnt)                                   \
+    CATCH_TH_ERRORS(retstmnt)                                        \
     catch (const std::exception& e) {                                \
       auto msg = torch::processErrorMsg(e.what());                   \
       PyErr_SetString(PyExc_RuntimeError, msg.c_str());              \
@@ -78,11 +82,11 @@
   catch (torch::jit::JITException & e) {                                 \
     throw;                                                               \
   }                                                                      \
-  CATCH_TH_ERRORS(throw py::error_already_set())
+  CATCH_ALL_ERRORS(throw py::error_already_set())
 
 #define END_HANDLE_TH_ERRORS_RET(retval)                             \
   }                                                                  \
-  CATCH_TH_ERRORS(return retval)
+  CATCH_ALL_ERRORS(return retval)
 
 #define END_HANDLE_TH_ERRORS END_HANDLE_TH_ERRORS_RET(nullptr)
 

--- a/torch/csrc/Exceptions.h
+++ b/torch/csrc/Exceptions.h
@@ -45,6 +45,7 @@
 // Only catch torch-specific exceptions
 #define CATCH_TH_ERRORS(retstmnt)                                    \
     catch (python_error & e) {                                       \
+      e.restore();                                                   \
       retstmnt;                                                      \
     }                                                                \
     catch (const c10::IndexError& e) {                               \

--- a/torch/csrc/Exceptions.h
+++ b/torch/csrc/Exceptions.h
@@ -69,6 +69,15 @@
 
 #define END_HANDLE_TH_ERRORS_PYBIND                                      \
   }                                                                      \
+  catch (py::error_already_set & e) {                                    \
+    throw;                                                               \
+  }                                                                      \
+  catch (py::builtin_exception & e) {                                    \
+    throw;                                                               \
+  }                                                                      \
+  catch (torch::jit::JITException & e) {                                 \
+    throw;                                                               \
+  }                                                                      \
   CATCH_TH_ERRORS(throw py::error_already_set())
 
 #define END_HANDLE_TH_ERRORS_RET(retval)                             \

--- a/torch/csrc/Exceptions.h
+++ b/torch/csrc/Exceptions.h
@@ -290,7 +290,8 @@ auto wrap_pybind_function_impl_(Func&& f, std::index_sequence<Is...>) {
   using traits = function_traits<Func>;
   namespace py = pybind11;
 
-  return [f](Arg<Func, Is> ...args) -> typename traits::result_type {
+  // f=f is needed to handle function references on older compilers
+  return [f=f](Arg<Func, Is> ...args) -> typename traits::result_type {
     HANDLE_TH_ERRORS
     return f(std::forward<Arg<Func, Is>>(args)...);
     END_HANDLE_TH_ERRORS_PYBIND

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -742,6 +742,15 @@ PyObject* initModule() {
   // setting up TH Errors so that they throw C++ exceptions
   at::init();
 
+  // Automatically translate errors thrown from pybind11 functions
+  py::register_exception_translator([](std::exception_ptr e) {
+    HANDLE_TH_ERRORS
+    if (e) {
+      std::rethrow_exception(e);
+    }
+    END_HANDLE_TH_ERRORS_RET()
+  });
+
   auto py_module = py::reinterpret_borrow<py::module>(module);
   py_module.def("_demangle", &c10::demangle);
   py_module.def("_log_api_usage_once", &LogAPIUsageOnceFromPython);

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -748,7 +748,7 @@ PyObject* initModule() {
     if (e) {
       std::rethrow_exception(e);
     }
-    END_HANDLE_TH_ERRORS_RET()
+    END_HANDLE_TH_ERRORS_PYBIND
   });
 
   auto py_module = py::reinterpret_borrow<py::module>(module);

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -744,11 +744,12 @@ PyObject* initModule() {
 
   // Automatically translate errors thrown from pybind11 functions
   py::register_exception_translator([](std::exception_ptr e) { // NOLINT
-    HANDLE_TH_ERRORS
-    if (e) {
-      std::rethrow_exception(e);
+    try {
+      if (e) {
+        std::rethrow_exception(e);
+      }
     }
-    END_HANDLE_TH_ERRORS_PYBIND
+    CATCH_TH_ERRORS()
   });
 
   auto py_module = py::reinterpret_borrow<py::module>(module);

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -743,7 +743,7 @@ PyObject* initModule() {
   at::init();
 
   // Automatically translate errors thrown from pybind11 functions
-  py::register_exception_translator([](std::exception_ptr e) {
+  py::register_exception_translator([](std::exception_ptr e) { // NOLINT
     HANDLE_TH_ERRORS
     if (e) {
       std::rethrow_exception(e);

--- a/torch/csrc/distributed/autograd/init.cpp
+++ b/torch/csrc/distributed/autograd/init.cpp
@@ -111,7 +111,12 @@ PyObject* dist_autograd_init(PyObject* /* unused */) {
         for (const auto& root : roots) {
           variables.emplace_back(root);
         }
-        DistEngine::getInstance().execute(variables, retainGraph);
+        try {
+          DistEngine::getInstance().execute(variables, retainGraph);
+        } catch (python_error & e) {
+          // FIXME: crashes if exception type is not RuntimeError
+          throw std::runtime_error(e.what());
+        }
       },
       R"(
 backward(roots: List[Tensor], retain_graph = False) -> None


### PR DESCRIPTION
Closes #30027

The idea here is that you can bind a function with `pybind11` in a single line and without modifying the function:
```cpp
m.def("foo", foo, py::call_guard<torch::PyWarningHandler>());
```
Where warnings are handled by the [`call_guard`](https://pybind11.readthedocs.io/en/stable/advanced/functions.html#call-guard) and exceptions are handled by the `pybind11` exception translator. To do this, I have added support for handling C++ exceptions in `torch::PyWarningHandler`'s destructor without setting the python error state before hand.