### PR TITLE
Fix handling of type comments in body

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -16482,24 +16482,24 @@ a")
 
     def test_type_comments_in_body(self):
         @torch.jit.script
-        def foo(a, # type: int
-                b, # type: int
-        ):
+        def foo(a,  # type: int
+                b,  # type: int
+                ):
             # type: (...) -> int
             # type: int
             return a + b
 
         class M(torch.nn.Module):
             def __init__(self,
-                         a, # type: int
-                         b  # type: int
-            ):
+                         a,  # type: int
+                         b   # type: int
+                         ):
                 # type: (...) -> None
-                super(Bar, self).__init__()
-                self.a = a # type: int
-                self.b = b # type: int
+                super(M, self).__init__()
+                self.a = a  # type: int
+                self.b = b  # type: int
 
-        torch.jit.script(Bar(2, 3))
+        torch.jit.script(M(2, 3))
 
 # known to be failing in tracer
 EXCLUDE_TRACED = {

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -16480,6 +16480,27 @@ a")
         with self.assertRaisesRegex(RuntimeError, "Inferred \'a\' to be of type \'Tensor"):
             foo(1)
 
+    def test_type_comments_in_body(self):
+        @torch.jit.script
+        def foo(a, # type: int
+                b, # type: int
+        ):
+            # type: (...) -> int
+            # type: int
+            return a + b
+
+        class M(torch.nn.Module):
+            def __init__(self,
+                         a, # type: int
+                         b  # type: int
+            ):
+                # type: (...) -> None
+                super(Bar, self).__init__()
+                self.a = a # type: int
+                self.b = b # type: int
+
+        torch.jit.script(Bar(2, 3))
+
 # known to be failing in tracer
 EXCLUDE_TRACED = {
     # The following fail due to #12024.

--- a/torch/jit/annotations.py
+++ b/torch/jit/annotations.py
@@ -159,7 +159,6 @@ def get_type_line(source):
     else:
         raise RuntimeError("Return type line '# type: (...) -> ...' not found on multiline "
                            "type annotation\n(See PEP 484 https://www.python.org/dev/peps/pep-0484/#suggested-syntax-for-python-2-7-and-straddling-code)")  # noqa
-        
 
     def get_parameter_type(line):
         item_type = line[line.find(type_comment) + len(type_comment):]

--- a/torch/jit/annotations.py
+++ b/torch/jit/annotations.py
@@ -156,7 +156,7 @@ def get_type_line(source):
             break
         elif type_comment in line:
             parameter_type_lines.append(line)
-    else:
+    if return_line is None:
         raise RuntimeError("Return type line '# type: (...) -> ...' not found on multiline "
                            "type annotation\n(See PEP 484 https://www.python.org/dev/peps/pep-0484/#suggested-syntax-for-python-2-7-and-straddling-code)")  # noqa
 

--- a/torch/jit/annotations.py
+++ b/torch/jit/annotations.py
@@ -150,15 +150,16 @@ def get_type_line(source):
     # https://www.python.org/dev/peps/pep-0484/#suggested-syntax-for-python-2-7-and-straddling-code
     return_line = None
     parameter_type_lines = []
-    for line_num, line in reversed(type_lines):
+    for line_num, line in type_lines:
         if '# type: (...) -> ' in line:
             return_line = (line_num, line)
+            break
         elif type_comment in line:
-            if return_line is None:
-                raise RuntimeError("Return type line '# type: (...) -> ...' not found on multiline "
-                                   "type annotation\n(See PEP 484 https://www.python.org/dev/peps/pep-0484/#suggested-syntax-for-python-2-7-and-straddling-code)")  # noqa
-            if line_num < return_line[0]:
-                parameter_type_lines.insert(0, line)
+            parameter_type_lines.append(line)
+    else:
+        raise RuntimeError("Return type line '# type: (...) -> ...' not found on multiline "
+                           "type annotation\n(See PEP 484 https://www.python.org/dev/peps/pep-0484/#suggested-syntax-for-python-2-7-and-straddling-code)")  # noqa
+        
 
     def get_parameter_type(line):
         item_type = line[line.find(type_comment) + len(type_comment):]


### PR DESCRIPTION
Fixes #30477. Any type comment after `# type: (...) -> ` is ignored.