### PR TITLE
[pytorch] Temporarily disable test_numerical_consistency_per_tensor

### DIFF
--- a/test/test_fake_quant.py
+++ b/test/test_fake_quant.py
@@ -113,6 +113,7 @@ class TestFakeQuantizePerTensor(TestCase):
     @given(device=st.sampled_from(['cpu', 'cuda'] if torch.cuda.is_available() else ['cpu']),
            X=hu.tensor(shapes=hu.array_shapes(1, 5,),
                        qparams=hu.qparams(dtypes=torch.quint8)))
+    @unittest.skip("temporarily disable the test")
     def test_numerical_consistency_per_tensor(self, device, X):
         r"""Comparing numerical consistency between CPU quantize/dequantize op and the CPU fake quantize op
         """

--- a/test/test_fake_quant.py
+++ b/test/test_fake_quant.py
@@ -113,6 +113,7 @@ class TestFakeQuantizePerTensor(TestCase):
     @given(device=st.sampled_from(['cpu', 'cuda'] if torch.cuda.is_available() else ['cpu']),
            X=hu.tensor(shapes=hu.array_shapes(1, 5,),
                        qparams=hu.qparams(dtypes=torch.quint8)))
+    # https://github.com/pytorch/pytorch/issues/30604
     @unittest.skip("temporarily disable the test")
     def test_numerical_consistency_per_tensor(self, device, X):
         r"""Comparing numerical consistency between CPU quantize/dequantize op and the CPU fake quantize op


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#30600 [pytorch] Temporarily disable test_numerical_consistency_per_tensor**

test_numerical_consistency_per_tensor in test_fake_quant is failing on Windows.

Differential Revision: [D18760287](https://our.internmc.facebook.com/intern/diff/D18760287/)