### PR TITLE
[pytorch] Fix serialization memory lifetime issue.

### DIFF
--- a/torch/csrc/distributed/rpc/utils.cpp
+++ b/torch/csrc/distributed/rpc/utils.cpp
@@ -203,7 +203,7 @@ std::string wireSerialize(
     pickler->pushIValue(tensors);
     pickler->stop();
     // Memory kept in scope for the function by pickler.
-    const auto& writeable_tensors = pickler->tensorData();
+    auto writeable_tensors = pickler->tensorData();
     entries.push_back({kMeta, metaEntry.data(), metaEntry.size()});
     for (size_t i = 0; i < writeable_tensors.size(); i++) {
       entries.push_back({c10::to_string(i),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#30603 [pytorch] Fix serialization memory lifetime issue.**

Pickler object needs to be kept in scope until data is written out to the
final serialized string. tensorData in particular is a reference to memory
owned by the descoped Pickle object.

Noticed this by inspection. In practice, this potential read-after-free here
is limited to non-cpu tensors, and any such use was very soon after free. 

Differential Revision: [D18760463](https://our.internmc.facebook.com/intern/diff/D18760463/)