### PR TITLE
Attempt to use the _library targets recursively.

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -887,14 +887,6 @@ target_include_directories(torch_cpu SYSTEM PRIVATE "${Caffe2_DEPENDENCY_INCLUDE
 torch_set_target_props(torch_cpu)
 
 
-target_link_libraries(torch PUBLIC torch_cpu)
-if(USE_CUDA)
-  target_link_libraries(torch PUBLIC torch_cuda)
-elseif(USE_ROCM)
-  target_link_libraries(torch PUBLIC torch_hip)
-endif()
-
-
 target_compile_options(torch_cpu PRIVATE "-DCAFFE2_BUILD_MAIN_LIB")
 if(USE_CUDA)
   target_compile_options(torch_cuda PRIVATE "-DTORCH_CUDA_BUILD_MAIN_LIB")
@@ -1011,16 +1003,31 @@ if (MSVC AND BUILD_SHARED_LIBS)
   target_compile_options(torch_cpu PRIVATE "-DONNX_BUILD_MAIN_LIB")
 endif()
 
-install(TARGETS torch_cpu EXPORT Caffe2Targets DESTINATION "${TORCH_INSTALL_LIB_DIR}")
-if (USE_CUDA)
-  install(TARGETS torch_cuda EXPORT Caffe2Targets DESTINATION "${TORCH_INSTALL_LIB_DIR}")
-elseif (USE_ROCM)
-  install(TARGETS torch_hip EXPORT Caffe2Targets DESTINATION "${TORCH_INSTALL_LIB_DIR}")
-endif()
-install(TARGETS torch EXPORT Caffe2Targets DESTINATION "${TORCH_INSTALL_LIB_DIR}")
+caffe2_interface_library(torch_cpu torch_cpu_library)
 
+if (USE_CUDA)
+  caffe2_interface_library(torch_cuda torch_cuda_library)
+elseif (USE_ROCM)
+  caffe2_interface_library(torch_hip torch_hip_library)
+endif()
 
 caffe2_interface_library(torch torch_library)
+
+install(TARGETS torch_cpu torch_cpu_library EXPORT Caffe2Targets DESTINATION "${TORCH_INSTALL_LIB_DIR}")
+if (USE_CUDA)
+  install(TARGETS torch_cuda torch_cuda_library EXPORT Caffe2Targets DESTINATION "${TORCH_INSTALL_LIB_DIR}")
+elseif (USE_ROCM)
+  install(TARGETS torch_hip torch_hip_library EXPORT Caffe2Targets DESTINATION "${TORCH_INSTALL_LIB_DIR}")
+endif()
+install(TARGETS torch torch_library EXPORT Caffe2Targets DESTINATION "${TORCH_INSTALL_LIB_DIR}")
+
+target_link_libraries(torch PUBLIC torch_cpu_library)
+if(USE_CUDA)
+  target_link_libraries(torch PUBLIC torch_cuda_library)
+elseif(USE_ROCM)
+  target_link_libraries(torch PUBLIC torch_hip_library)
+endif()
+
 list(APPEND Caffe2_MAIN_LIBS torch_library)
 if (USE_TBB)
   list(APPEND Caffe2_MAIN_LIBS tbb)
@@ -1054,7 +1061,7 @@ if(USE_CUDA)
   # These public dependencies must go after the previous dependencies, as the
   # order of the libraries in the linker call matters here when statically
   # linking; libculibos and cublas must be last.
-  target_link_libraries(torch_cuda PUBLIC torch_cpu ${Caffe2_PUBLIC_CUDA_DEPENDENCY_LIBS})
+  target_link_libraries(torch_cuda PUBLIC torch_cpu_library ${Caffe2_PUBLIC_CUDA_DEPENDENCY_LIBS})
 
 
 endif()
@@ -1086,7 +1093,7 @@ if(USE_ROCM)
     # correct dependency from generated files.)
     target_link_libraries(torch_hip PRIVATE ATEN_CUDA_FILES_GEN_LIB)
   endif()
-  target_link_libraries(torch_hip PUBLIC torch_cpu ${Caffe2_HIP_DEPENDENCY_LIBS})
+  target_link_libraries(torch_hip PUBLIC torch_cpu_library ${Caffe2_HIP_DEPENDENCY_LIBS})
 
   # Since PyTorch files contain HIP headers, this is also needed to capture the includes.
   target_include_directories(torch_hip PRIVATE ${Caffe2_HIP_INCLUDE})


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#30607 Attempt to use the _library targets recursively.**
* #30315 Split libtorch.so back into libtorch_{cpu,cuda,hip}
* #30597 Disable test_backward_per_tensor
* #30314 Add missing trigramma_stub definition.
* #30313 Workaround hcc bug regarding extern "C" definitions
* #30312 Delete redundant THC_API on THCStorage_new
* #30311 Properly include declaration of dispatch in file that registers it.
* #30310 Add missing _API definitions.
* #30308 DEFINE_DISPATCH in the correct namespace.
* #30307 Use normal dispatch to get to CUDA threshold kernels, instead of DispatchStub.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>