### PR TITLE
add small input shapes to some ops

### DIFF
--- a/benchmarks/operator_benchmark/pt/add_test.py
+++ b/benchmarks/operator_benchmark/pt/add_test.py
@@ -21,6 +21,7 @@ add_long_configs = op_bench.cross_product_configs(
 add_short_configs = op_bench.config_list(
     attr_names=["M", "N", "K"],
     attrs=[
+        [1, 1, 1],
         [64, 64, 64],
         [64, 64, 128],
     ],

--- a/benchmarks/operator_benchmark/pt/as_strided_test.py
+++ b/benchmarks/operator_benchmark/pt/as_strided_test.py
@@ -14,6 +14,7 @@ import torch
 as_strided_configs_short = op_bench.config_list(
     attr_names=["M", "N", "size", "stride", "storage_offset"],
     attrs=[
+        [8, 8, (2, 2), (1, 1), 0],
         [256, 256, (32, 32), (1, 1), 0],
         [512, 512, (64, 64), (2, 2), 1],
     ],

--- a/benchmarks/operator_benchmark/pt/cat_test.py
+++ b/benchmarks/operator_benchmark/pt/cat_test.py
@@ -14,6 +14,7 @@ import torch
 cat_configs_short = op_bench.config_list(
     attr_names=['M', 'N', 'K', 'dim'],
     attrs=[
+        [1, 1, 1, 0],
         [256, 512, 1, 0],
         [512, 512, 2, 1],
     ],

--- a/benchmarks/operator_benchmark/pt/chunk_test.py
+++ b/benchmarks/operator_benchmark/pt/chunk_test.py
@@ -14,6 +14,7 @@ import torch
 chunk_short_configs = op_bench.config_list(
     attr_names=["M", "N", "chunks"],
     attrs=[
+        [8, 8, 2],
         [256, 512, 2],
         [512, 512, 2],
     ],

--- a/benchmarks/operator_benchmark/pt/fill_test.py
+++ b/benchmarks/operator_benchmark/pt/fill_test.py
@@ -6,6 +6,7 @@ import torch
 fill_short_configs = op_bench.config_list(
     attr_names=["N"],
     attrs=[
+        [1],
         [1024],
         [2048],
     ],
@@ -34,7 +35,7 @@ class Fill_Benchmark(op_bench.TorchBenchmarkBase):
         return self.input_one.fill_(10)
 
 
-op_bench.generate_pt_test(fill_short_configs + fill_long_configs, 
+op_bench.generate_pt_test(fill_short_configs + fill_long_configs,
                           Fill_Benchmark)
 
 

--- a/benchmarks/operator_benchmark/pt/linear_test.py
+++ b/benchmarks/operator_benchmark/pt/linear_test.py
@@ -14,6 +14,7 @@ import torch.nn as nn
 linear_configs_short = op_bench.config_list(
     attr_names=["N", "IN", "OUT"],
     attrs=[
+        [1, 1, 1],
         [4, 256, 128],
         [16, 512, 256],
     ],

--- a/benchmarks/operator_benchmark/pt/matmul_test.py
+++ b/benchmarks/operator_benchmark/pt/matmul_test.py
@@ -12,6 +12,7 @@ import torch
 mm_short_configs = op_bench.config_list(
     attr_names=["M", "N", "K", "trans_a", "trans_b"],
     attrs=[
+        [1, 1, 1, True, False],
         [128, 128, 128, True, False],
         [256, 256, 256, False, True],
     ],

--- a/benchmarks/operator_benchmark/pt/split_test.py
+++ b/benchmarks/operator_benchmark/pt/split_test.py
@@ -14,6 +14,7 @@ import torch
 split_configs_short = op_bench.config_list(
     attr_names=["M", "N", "parts"],
     attrs=[
+        [8, 8, 2],
         [256, 512, 2],
         [512, 512, 2],
     ],


### PR DESCRIPTION
Summary: as title

Test Plan: buck run //caffe2/benchmarks/operator_benchmark:benchmark_all_test -- --iterations 1 --operator add,as_strided,cat,chunk,fill,linear,matmul,split

Differential Revision: D18764248

