### PR TITLE
Rename catchAll to compound for clarity

### DIFF
--- a/aten/src/ATen/core/boxing/kernel_function_test.cpp
+++ b/aten/src/ATen/core/boxing/kernel_function_test.cpp
@@ -433,7 +433,7 @@ void kernelWithDictInputWithoutOutput(Dict<string, Tensor> input1) {
 
 TEST(OperatorRegistrationTest_FunctionBasedKernel, givenKernelWithDictInput_withoutOutput_whenRegistered_thenCanBeCalled) {
   auto registrar = RegisterOperators()
-      .op("_test::dict_input(Dict(str, Tensor) input) -> ()", RegisterOperators::options().catchAllKernel<decltype(kernelWithDictInputWithoutOutput), &kernelWithDictInputWithoutOutput>());
+      .op("_test::dict_input(Dict(str, Tensor) input) -> ()", RegisterOperators::options().compoundKernel<decltype(kernelWithDictInputWithoutOutput), &kernelWithDictInputWithoutOutput>());
 
   auto op = c10::Dispatcher::singleton().findSchema({"_test::dict_input", ""});
   ASSERT_TRUE(op.has_value());
@@ -453,7 +453,7 @@ string kernelWithDictInputWithOutput(Dict<string, string> input1) {
 
 TEST(OperatorRegistrationTest_FunctionBasedKernel, givenKernelWithDictInput_withOutput_whenRegistered_thenCanBeCalled) {
   auto registrar = RegisterOperators()
-      .op("_test::dict_input(Dict(str, str) input) -> str", RegisterOperators::options().catchAllKernel<decltype(kernelWithDictInputWithOutput), &kernelWithDictInputWithOutput>());
+      .op("_test::dict_input(Dict(str, str) input) -> str", RegisterOperators::options().compoundKernel<decltype(kernelWithDictInputWithOutput), &kernelWithDictInputWithOutput>());
 
   auto op = c10::Dispatcher::singleton().findSchema({"_test::dict_input", ""});
   ASSERT_TRUE(op.has_value());
@@ -472,7 +472,7 @@ Dict<string, string> kernelWithDictOutput(Dict<string, string> input) {
 
 TEST(OperatorRegistrationTest_FunctionBasedKernel, givenKernelWithDictOutput_whenRegistered_thenCanBeCalled) {
   auto registrar = RegisterOperators()
-      .op("_test::dict_output(Dict(str, str) input) -> Dict(str, str)", RegisterOperators::options().catchAllKernel<decltype(kernelWithDictOutput), &kernelWithDictOutput>());
+      .op("_test::dict_output(Dict(str, str) input) -> Dict(str, str)", RegisterOperators::options().compoundKernel<decltype(kernelWithDictOutput), &kernelWithDictOutput>());
 
   auto op = c10::Dispatcher::singleton().findSchema({"_test::dict_output", ""});
   ASSERT_TRUE(op.has_value());
@@ -500,7 +500,7 @@ TEST(OperatorRegistrationTest_FunctionBasedKernel, givenFallbackKernelWithoutAny
   // is no way to get the dispatch key. For operators that only have a fallback
   // kernel, this must work for backwards compatibility.
   auto registrar = RegisterOperators()
-      .op("_test::no_tensor_args() -> ()", RegisterOperators::options().catchAllKernel<decltype(kernelWithoutInputs), &kernelWithoutInputs>());
+      .op("_test::no_tensor_args() -> ()", RegisterOperators::options().compoundKernel<decltype(kernelWithoutInputs), &kernelWithoutInputs>());
 
   auto op = c10::Dispatcher::singleton().findSchema({"_test::no_tensor_args", ""});
   ASSERT_TRUE(op.has_value());
@@ -519,7 +519,7 @@ TEST(OperatorRegistrationTest_FunctionBasedKernel, givenFallbackKernelWithoutTen
   // is no way to get the dispatch key. For operators that only have a fallback
   // kernel, this must work for backwards compatibility.
   auto registrar = RegisterOperators()
-      .op("_test::no_tensor_args(int arg) -> int", RegisterOperators::options().catchAllKernel<decltype(kernelWithoutTensorInputs), &kernelWithoutTensorInputs>());
+      .op("_test::no_tensor_args(int arg) -> int", RegisterOperators::options().compoundKernel<decltype(kernelWithoutTensorInputs), &kernelWithoutTensorInputs>());
 
   auto op = c10::Dispatcher::singleton().findSchema({"_test::no_tensor_args", ""});
   ASSERT_TRUE(op.has_value());
@@ -674,7 +674,7 @@ std::tuple<int64_t, Tensor> kernelForSchemaInference(Tensor arg1, int64_t arg2, 
 
 TEST(OperatorRegistrationTest_FunctionBasedKernel, givenKernel_whenRegisteredWithoutSpecifyingSchema_thenInfersSchema) {
   auto registrar = RegisterOperators()
-      .op("_test::no_schema_specified", RegisterOperators::options().catchAllKernel<decltype(kernelForSchemaInference), &kernelForSchemaInference>());
+      .op("_test::no_schema_specified", RegisterOperators::options().compoundKernel<decltype(kernelForSchemaInference), &kernelForSchemaInference>());
 
   auto op = c10::Dispatcher::singleton().findSchema({"_test::no_schema_specified", ""});
   ASSERT_TRUE(op.has_value());

--- a/aten/src/ATen/core/boxing/kernel_functor_test.cpp
+++ b/aten/src/ATen/core/boxing/kernel_functor_test.cpp
@@ -476,7 +476,7 @@ struct KernelWithDictInputWithoutOutput final : OperatorKernel {
 
 TEST(OperatorRegistrationTest_FunctorBasedKernel, givenKernelWithDictInput_withoutOutput_whenRegistered_thenCanBeCalled) {
   auto registrar = RegisterOperators()
-      .op("_test::dict_input(Dict(str, Tensor) input) -> ()", RegisterOperators::options().catchAllKernel<KernelWithDictInputWithoutOutput>());
+      .op("_test::dict_input(Dict(str, Tensor) input) -> ()", RegisterOperators::options().compoundKernel<KernelWithDictInputWithoutOutput>());
 
   auto op = c10::Dispatcher::singleton().findSchema({"_test::dict_input", ""});
   ASSERT_TRUE(op.has_value());
@@ -498,7 +498,7 @@ struct KernelWithDictInputWithOutput final : OperatorKernel {
 
 TEST(OperatorRegistrationTest_FunctorBasedKernel, givenKernelWithDictInput_withOutput_whenRegistered_thenCanBeCalled) {
   auto registrar = RegisterOperators()
-      .op("_test::dict_input(Dict(str, str) input) -> str", RegisterOperators::options().catchAllKernel<KernelWithDictInputWithOutput>());
+      .op("_test::dict_input(Dict(str, str) input) -> str", RegisterOperators::options().compoundKernel<KernelWithDictInputWithOutput>());
 
   auto op = c10::Dispatcher::singleton().findSchema({"_test::dict_input", ""});
   ASSERT_TRUE(op.has_value());
@@ -519,7 +519,7 @@ struct KernelWithDictOutput final : OperatorKernel {
 
 TEST(OperatorRegistrationTest_FunctorBasedKernel, givenKernelWithDictOutput_whenRegistered_thenCanBeCalled) {
   auto registrar = RegisterOperators()
-      .op("_test::dict_output(Dict(str, str) input) -> Dict(str, str)", RegisterOperators::options().catchAllKernel<KernelWithDictOutput>());
+      .op("_test::dict_output(Dict(str, str) input) -> Dict(str, str)", RegisterOperators::options().compoundKernel<KernelWithDictOutput>());
 
   auto op = c10::Dispatcher::singleton().findSchema({"_test::dict_output", ""});
   ASSERT_TRUE(op.has_value());
@@ -646,7 +646,7 @@ TEST(OperatorRegistrationTest_FunctorBasedKernel, givenFallbackKernelWithoutAnyA
   // is no way to get the dispatch key. For operators that only have a fallback
   // kernel, this must work for backwards compatibility.
   auto registrar = RegisterOperators()
-      .op("_test::no_tensor_args() -> ()", RegisterOperators::options().catchAllKernel<KernelWithoutInputs>());
+      .op("_test::no_tensor_args() -> ()", RegisterOperators::options().compoundKernel<KernelWithoutInputs>());
 
   auto op = c10::Dispatcher::singleton().findSchema({"_test::no_tensor_args", ""});
   ASSERT_TRUE(op.has_value());
@@ -667,7 +667,7 @@ TEST(OperatorRegistrationTest_FunctorBasedKernel, givenFallbackKernelWithoutTens
   // is no way to get the dispatch key. For operators that only have a fallback
   // kernel, this must work for backwards compatibility.
   auto registrar = RegisterOperators()
-      .op("_test::no_tensor_args(int arg) -> int", RegisterOperators::options().catchAllKernel<KernelWithoutTensorInputs>());
+      .op("_test::no_tensor_args(int arg) -> int", RegisterOperators::options().compoundKernel<KernelWithoutTensorInputs>());
 
   auto op = c10::Dispatcher::singleton().findSchema({"_test::no_tensor_args", ""});
   ASSERT_TRUE(op.has_value());
@@ -825,7 +825,7 @@ TEST(OperatorRegistrationTest_FunctorBasedKernel, givenKernel_whenRegisteredWith
 
 TEST(OperatorRegistrationTest_FunctorBasedKernel, givenKernel_whenRegisteredCatchAllWithoutSpecifyingSchema_thenInfersSchema) {
   auto registrar = RegisterOperators()
-      .op("_test::no_schema_specified", RegisterOperators::options().catchAllKernel<KernelForSchemaInference>());
+      .op("_test::no_schema_specified", RegisterOperators::options().compoundKernel<KernelForSchemaInference>());
 
   auto op = c10::Dispatcher::singleton().findSchema({"_test::no_schema_specified", ""});
   ASSERT_TRUE(op.has_value());

--- a/aten/src/ATen/core/boxing/kernel_lambda_test.cpp
+++ b/aten/src/ATen/core/boxing/kernel_lambda_test.cpp
@@ -378,7 +378,7 @@ int captured_dict_size = 0;
 
 TEST(OperatorRegistrationTest_LambdaBasedKernel, givenKernelWithDictInput_withoutOutput_whenRegistered_thenCanBeCalled) {
   auto registrar = RegisterOperators()
-      .op("_test::dict_input(Dict(str, Tensor) input) -> ()", RegisterOperators::options().catchAllKernel([] (Dict<string, Tensor> input1) {
+      .op("_test::dict_input(Dict(str, Tensor) input) -> ()", RegisterOperators::options().compoundKernel([] (Dict<string, Tensor> input1) {
         captured_dict_size = input1.size();
       }));
 
@@ -396,7 +396,7 @@ TEST(OperatorRegistrationTest_LambdaBasedKernel, givenKernelWithDictInput_withou
 
 TEST(OperatorRegistrationTest_LambdaBasedKernel, givenKernelWithDictInput_withOutput_whenRegistered_thenCanBeCalled) {
   auto registrar = RegisterOperators()
-      .op("_test::dict_input(Dict(str, str) input) -> str", RegisterOperators::options().catchAllKernel([] (Dict<string, string> input1) {
+      .op("_test::dict_input(Dict(str, str) input) -> str", RegisterOperators::options().compoundKernel([] (Dict<string, string> input1) {
         return input1.at("key2");
       }));
 
@@ -413,7 +413,7 @@ TEST(OperatorRegistrationTest_LambdaBasedKernel, givenKernelWithDictInput_withOu
 
 TEST(OperatorRegistrationTest_LambdaBasedKernel, givenKernelWithDictOutput_whenRegistered_thenCanBeCalled) {
   auto registrar = RegisterOperators()
-    .op("_test::dict_output(Dict(str, str) input) -> Dict(str, str)", RegisterOperators::options().catchAllKernel([] (Dict<string, string> input) {
+    .op("_test::dict_output(Dict(str, str) input) -> Dict(str, str)", RegisterOperators::options().compoundKernel([] (Dict<string, string> input) {
       return input;
     }));
 
@@ -439,7 +439,7 @@ TEST(OperatorRegistrationTest_LambdaBasedKernel, givenFallbackKernelWithoutAnyAr
   // is no way to get the dispatch key. For operators that only have a fallback
   // kernel, this must work for backwards compatibility.
   auto registrar = RegisterOperators()
-      .op("_test::no_tensor_args() -> ()", RegisterOperators::options().catchAllKernel([] () {called = true;}));
+      .op("_test::no_tensor_args() -> ()", RegisterOperators::options().compoundKernel([] () {called = true;}));
 
   auto op = c10::Dispatcher::singleton().findSchema({"_test::no_tensor_args", ""});
   ASSERT_TRUE(op.has_value());
@@ -454,7 +454,7 @@ TEST(OperatorRegistrationTest_LambdaBasedKernel, givenFallbackKernelWithoutTenso
   // is no way to get the dispatch key. For operators that only have a fallback
   // kernel, this must work for backwards compatibility.
   auto registrar = RegisterOperators()
-      .op("_test::no_tensor_args(int arg) -> int", RegisterOperators::options().catchAllKernel([] (int64_t arg) {return arg + 1;}));
+      .op("_test::no_tensor_args(int arg) -> int", RegisterOperators::options().compoundKernel([] (int64_t arg) {return arg + 1;}));
 
   auto op = c10::Dispatcher::singleton().findSchema({"_test::no_tensor_args", ""});
   ASSERT_TRUE(op.has_value());
@@ -581,7 +581,7 @@ TEST(OperatorRegistrationTest_LambdaBasedKernel, givenKernel_whenRegistered_then
 
 TEST(OperatorRegistrationTest_LambdaBasedKernel, givenKernel_whenRegisteredWithoutSpecifyingSchema_thenInfersSchema) {
   auto registrar = RegisterOperators()
-      .op("_test::no_schema_specified", RegisterOperators::options().catchAllKernel([] (Tensor arg1, int64_t arg2, const c10::List<Tensor>& arg3) -> std::tuple<int64_t, Tensor> {return {};}));
+      .op("_test::no_schema_specified", RegisterOperators::options().compoundKernel([] (Tensor arg1, int64_t arg2, const c10::List<Tensor>& arg3) -> std::tuple<int64_t, Tensor> {return {};}));
 
   auto op = c10::Dispatcher::singleton().findSchema({"_test::no_schema_specified", ""});
   ASSERT_TRUE(op.has_value());

--- a/aten/src/ATen/core/boxing/kernel_stackbased_test.cpp
+++ b/aten/src/ATen/core/boxing/kernel_stackbased_test.cpp
@@ -116,7 +116,7 @@ TEST(OperatorRegistrationTest_StackBasedKernel, givenFallbackKernelWithoutAnyArg
   // is no way to get the dispatch key. For operators that only have a fallback
   // kernel, this must work for backwards compatibility.
   auto registrar = RegisterOperators()
-      .op("_test::no_tensor_args() -> ()", RegisterOperators::options().catchAllKernel<&kernelWithoutInputs>());
+      .op("_test::no_tensor_args() -> ()", RegisterOperators::options().compoundKernel<&kernelWithoutInputs>());
 
   auto op = c10::Dispatcher::singleton().findSchema({"_test::no_tensor_args", ""});
   ASSERT_TRUE(op.has_value());
@@ -135,7 +135,7 @@ TEST(OperatorRegistrationTest_StackBasedKernel, givenFallbackKernelWithoutTensor
   // is no way to get the dispatch key. For operators that only have a fallback
   // kernel, this must work for backwards compatibility.
   auto registrar = RegisterOperators()
-      .op("_test::no_tensor_args(int arg) -> int", RegisterOperators::options().catchAllKernel<&kernelWithoutTensorInputs>());
+      .op("_test::no_tensor_args(int arg) -> int", RegisterOperators::options().compoundKernel<&kernelWithoutTensorInputs>());
 
   auto op = c10::Dispatcher::singleton().findSchema({"_test::no_tensor_args", ""});
   ASSERT_TRUE(op.has_value());
@@ -150,7 +150,7 @@ void kernelForSchemaInference(const OperatorHandle&, Stack* stack) {
 
 TEST(OperatorRegistrationTest_StackBasedKernel, givenKernel_whenRegisteredWithoutSpecifyingSchema_thenFailsBecauseItCannotInferFromStackBasedKernel) {
   expectThrows<c10::Error>([] {
-      RegisterOperators().op("_test::no_schema_specified", RegisterOperators::options().catchAllKernel<&kernelForSchemaInference>());
+      RegisterOperators().op("_test::no_schema_specified", RegisterOperators::options().compoundKernel<&kernelForSchemaInference>());
   }, "Cannot infer operator schema for this kind of kernel in registration of operator _test::no_schema_specified");
 }
 

--- a/aten/src/ATen/core/dispatch/OperatorEntry.h
+++ b/aten/src/ATen/core/dispatch/OperatorEntry.h
@@ -54,7 +54,7 @@ private:
   DispatchTable dispatchTable_;
 
   // kernels_ stores all registered kernels for the corresponding dispatch key
-  // and catchAllKernels_ stores the catch-all kernels.
+  // and compoundKernels_ stores the catch-all kernels.
   // If an operator library gets loaded that overwrites an already existing kernel,
   // both kernels will be in that list but only the newer one will be in
   // dispatchTable. If any of the kernels go away (say the library gets
@@ -72,7 +72,7 @@ private:
   //    kernels_[dispatch_key] does not exist
   //  - If kernels_[dispatch_key] exists, then it has elements.
   //    It is never an empty list.
-  // Analogous invariants for catchAllKernels_.
+  // Analogous invariants for compoundKernels_.
   //
   // Why do we do that?
   // -----
@@ -86,7 +86,7 @@ private:
   // is already registered, but that's a lot of effort to implement and
   // currently not high-pri.
   ska::flat_hash_map<TensorTypeId, std::list<KernelFunction>> kernels_;
-  std::list<KernelFunction> catchAllKernels_;
+  std::list<KernelFunction> compoundKernels_;
 
   // Some metadata about the operator
   OperatorOptions options_;

--- a/aten/src/ATen/core/op_registration/README.md
+++ b/aten/src/ATen/core/op_registration/README.md
@@ -67,10 +67,10 @@ namespace { Tensor my_kernel_fallback(Tensor a, Tensor b) {...} }
 
 static auto registry = torch::RegisterOperators()
    .op("my_namespace::my_op", torch::RegisterOperators::options()
-       .catchAllKernel<decltype(my_kernel_fallback), &my_kernel_fallback>());
+       .compoundKernel<decltype(my_kernel_fallback), &my_kernel_fallback>());
 ```
 
-The other ways of specifying kernels mentioned above (as functions, functors or lambdas) also work with `catchAllKernel()`.
+The other ways of specifying kernels mentioned above (as functions, functors or lambdas) also work with `compoundKernel()`.
 
 ### Syntactic Sugar
 

--- a/aten/src/ATen/core/op_registration/op_registration_test.cpp
+++ b/aten/src/ATen/core/op_registration/op_registration_test.cpp
@@ -86,7 +86,7 @@ TEST(OperatorRegistrationTest, whenRegisteringSameSchemaWithDifferentAliasAnalys
 
 TEST(OperatorRegistrationTest, whenRegisteringWithSchemaBeforeKernelInOptionsObject_thenCanBeCalled) {
   bool called = false;
-  auto registrar = c10::RegisterOperators().op(c10::RegisterOperators::options().schema("_test::dummy(Tensor dummy) -> ()").catchAllKernel<MockKernel>(&called));
+  auto registrar = c10::RegisterOperators().op(c10::RegisterOperators::options().schema("_test::dummy(Tensor dummy) -> ()").compoundKernel<MockKernel>(&called));
 
   auto op = Dispatcher::singleton().findSchema({"_test::dummy", ""});
   ASSERT_TRUE(op.has_value());
@@ -97,7 +97,7 @@ TEST(OperatorRegistrationTest, whenRegisteringWithSchemaBeforeKernelInOptionsObj
 
 TEST(OperatorRegistrationTest, whenRegisteringWithSchemaAfterKernelInOptionsObject_thenCanBeCalled) {
   bool called = false;
-  auto registrar = c10::RegisterOperators().op(c10::RegisterOperators::options().catchAllKernel<MockKernel>(&called).schema("_test::dummy(Tensor dummy) -> ()"));
+  auto registrar = c10::RegisterOperators().op(c10::RegisterOperators::options().compoundKernel<MockKernel>(&called).schema("_test::dummy(Tensor dummy) -> ()"));
 
   auto op = Dispatcher::singleton().findSchema({"_test::dummy", ""});
   ASSERT_TRUE(op.has_value());
@@ -108,7 +108,7 @@ TEST(OperatorRegistrationTest, whenRegisteringWithSchemaAfterKernelInOptionsObje
 
 TEST(OperatorRegistrationTest, whenRegisteringWithNameBeforeKernelInOptionsObject_thenCanBeCalled) {
   bool called = false;
-  auto registrar = c10::RegisterOperators().op(c10::RegisterOperators::options().schema("_test::dummy").catchAllKernel<MockKernel>(&called));
+  auto registrar = c10::RegisterOperators().op(c10::RegisterOperators::options().schema("_test::dummy").compoundKernel<MockKernel>(&called));
 
   auto op = Dispatcher::singleton().findSchema({"_test::dummy", ""});
   ASSERT_TRUE(op.has_value());
@@ -119,7 +119,7 @@ TEST(OperatorRegistrationTest, whenRegisteringWithNameBeforeKernelInOptionsObjec
 
 TEST(OperatorRegistrationTest, whenRegisteringWithNameAfterKernelInOptionsObject_thenCanBeCalled) {
   bool called = false;
-  auto registrar = c10::RegisterOperators().op(c10::RegisterOperators::options().catchAllKernel<MockKernel>(&called).schema("_test::dummy"));
+  auto registrar = c10::RegisterOperators().op(c10::RegisterOperators::options().compoundKernel<MockKernel>(&called).schema("_test::dummy"));
 
   auto op = Dispatcher::singleton().findSchema({"_test::dummy", ""});
   ASSERT_TRUE(op.has_value());
@@ -130,7 +130,7 @@ TEST(OperatorRegistrationTest, whenRegisteringWithNameAfterKernelInOptionsObject
 
 TEST(OperatorRegistrationTest, whenRegisteringWithoutSchema_thenFails) {
   expectThrows<c10::Error>([] {
-    c10::RegisterOperators().op(c10::RegisterOperators::options().catchAllKernel<DummyKernel>());
+    c10::RegisterOperators().op(c10::RegisterOperators::options().compoundKernel<DummyKernel>());
   }, "In operator registration: Tried to register an operator without specifying a schema or operator name.");
 }
 
@@ -148,7 +148,7 @@ TEST(OperatorRegistrationTest, whenCallingOpWithWrongDispatchKey_thenFails) {
 
 TEST(OperatorRegistrationTest, givenOpWithCatchallKernel_whenCallingOp_thenCallsCatchallKernel) {
   bool called = false;
-  auto registrar = c10::RegisterOperators().op("_test::dummy(Tensor dummy) -> ()", c10::RegisterOperators::options().catchAllKernel<MockKernel>(&called));
+  auto registrar = c10::RegisterOperators().op("_test::dummy(Tensor dummy) -> ()", c10::RegisterOperators::options().compoundKernel<MockKernel>(&called));
 
   auto op = Dispatcher::singleton().findSchema({"_test::dummy", ""});
   ASSERT_TRUE(op.has_value());
@@ -160,7 +160,7 @@ TEST(OperatorRegistrationTest, givenOpWithCatchallKernel_whenCallingOp_thenCalls
 // TODO Rewrite (since this is now allowed) and reenable
 // TEST(OperatorRegistrationTest, givenOpWithCatchallKernel_whenRegisteringDispatchedKernel_thenFails) {
 //   bool called = false;
-//   auto registrar = c10::RegisterOperators().op("_test::dummy(Tensor dummy) -> ()", c10::RegisterOperators::options().catchAllKernel<MockKernel>(&called));
+//   auto registrar = c10::RegisterOperators().op("_test::dummy(Tensor dummy) -> ()", c10::RegisterOperators::options().compoundKernel<MockKernel>(&called));
 //   expectThrows<c10::Error>([&] {
 //     c10::RegisterOperators().op("_test::dummy(Tensor dummy) -> ()", c10::RegisterOperators::options().kernel<MockKernel>(c10::TensorTypeId::CPUTensorId, &called));
 //   }, "for an operator which already has a catch-all kernel registered");
@@ -170,7 +170,7 @@ TEST(OperatorRegistrationTest, givenOpWithCatchallKernel_whenCallingOp_thenCalls
 //   bool called = false;
 //   expectThrows<c10::Error>([&] {
 //     auto registrar = c10::RegisterOperators().op("_test::dummy(Tensor dummy) -> ()", c10::RegisterOperators::options()
-//       .catchAllKernel<MockKernel>(&called)
+//       .compoundKernel<MockKernel>(&called)
 //       .kernel<MockKernel>(c10::TensorTypeId::CPUTensorId, &called));
 //   }, "for an operator which already has a catch-all kernel registered");
 // }
@@ -181,7 +181,7 @@ TEST(OperatorRegistrationTest, givenOpWithDispatchedKernelOutOfScope_whenRegiste
     auto registrar = c10::RegisterOperators().op("_test::dummy(Tensor dummy) -> ()", c10::RegisterOperators::options().kernel<MockKernel>(c10::TensorTypeId::CPUTensorId, &called));
   }
 
-  auto registrar = c10::RegisterOperators().op("_test::dummy(Tensor dummy) -> ()", c10::RegisterOperators::options().catchAllKernel<MockKernel>(&called));
+  auto registrar = c10::RegisterOperators().op("_test::dummy(Tensor dummy) -> ()", c10::RegisterOperators::options().compoundKernel<MockKernel>(&called));
 
   auto op = Dispatcher::singleton().findSchema({"_test::dummy", ""});
   ASSERT_TRUE(op.has_value());
@@ -195,7 +195,7 @@ TEST(OperatorRegistrationTest, givenOpWithDispatchedKernelOutOfScope_whenRegiste
 //   bool called = false;
 //   auto registrar = c10::RegisterOperators().op("_test::dummy(Tensor dummy) -> ()", c10::RegisterOperators::options().kernel<MockKernel>(c10::TensorTypeId::CPUTensorId, &called));
 //   expectThrows<c10::Error>([&] {
-//     c10::RegisterOperators().op("_test::dummy(Tensor dummy) -> ()", c10::RegisterOperators::options().catchAllKernel<MockKernel>(&called));
+//     c10::RegisterOperators().op("_test::dummy(Tensor dummy) -> ()", c10::RegisterOperators::options().compoundKernel<MockKernel>(&called));
 //   }, "Tried to register a catch-all kernel for an operator which already has kernels for dispatch keys CPUTensorId. An operator can only have either a catch-all kernel or kernels with dispatch keys. The operator schema is _test::dummy");
 // }
 //
@@ -204,14 +204,14 @@ TEST(OperatorRegistrationTest, givenOpWithDispatchedKernelOutOfScope_whenRegiste
 //   expectThrows<c10::Error>([&] {
 //     auto registrar = c10::RegisterOperators().op("_test::dummy(Tensor dummy) -> ()", c10::RegisterOperators::options()
 //       .kernel<MockKernel>(c10::TensorTypeId::CPUTensorId, &called)
-//       .catchAllKernel<MockKernel>(&called));
+//       .compoundKernel<MockKernel>(&called));
 //   }, "Tried to register a catch-all kernel for an operator which already has kernels for dispatch keys CPUTensorId. An operator can only have either a catch-all kernel or kernels with dispatch keys. The operator schema is _test::dummy");
 // }
 
 TEST(OperatorRegistrationTest, givenOpWithCatchallKernelOutOfScope_whenRegisteringDispatchedKernelAndCallingOp_thenCallsCatchallKernel) {
   bool called = false;
   {
-    auto registrar = c10::RegisterOperators().op("_test::dummy(Tensor dummy) -> ()", c10::RegisterOperators::options().catchAllKernel<MockKernel>(&called));
+    auto registrar = c10::RegisterOperators().op("_test::dummy(Tensor dummy) -> ()", c10::RegisterOperators::options().compoundKernel<MockKernel>(&called));
   }
 
   auto registrar = c10::RegisterOperators().op("_test::dummy(Tensor dummy) -> ()", c10::RegisterOperators::options().kernel<MockKernel>(c10::TensorTypeId::CPUTensorId, &called));
@@ -331,13 +331,13 @@ TEST(OperatorRegistrationTest, givenMultipleKernelsWithSameDispatchKey_whenCalle
 
 TEST(OperatorRegistrationTest, givenMultipleCatchallKernels_whenRegistering_thenShowsWarning) {
   auto registrar = c10::RegisterOperators()
-      .op("_test::dummy(Tensor dummy) -> ()", c10::RegisterOperators::options().catchAllKernel<DummyKernel>());
+      .op("_test::dummy(Tensor dummy) -> ()", c10::RegisterOperators::options().compoundKernel<DummyKernel>());
 
   auto op = Dispatcher::singleton().findSchema({"_test::dummy", ""});
   ASSERT_TRUE(op.has_value()); // assert schema is registered
 
   testing::internal::CaptureStderr();
-  c10::RegisterOperators().op("_test::dummy(Tensor dummy) -> ()", c10::RegisterOperators::options().catchAllKernel<DummyKernel>());
+  c10::RegisterOperators().op("_test::dummy(Tensor dummy) -> ()", c10::RegisterOperators::options().compoundKernel<DummyKernel>());
   std::string output = testing::internal::GetCapturedStderr();
   EXPECT_THAT(output, testing::HasSubstr("Warning: Registered a catch-all kernel for operator _test::dummy that overwrote a previously registered catch-all kernel for the same operator."));
 }
@@ -346,16 +346,16 @@ TEST(OperatorRegistrationTest, givenMultipleCatchallKernels_whenRegisteringInSam
   expectThrows<c10::Error>([&] {
     auto registrar = c10::RegisterOperators()
         .op("_test::dummy(Tensor dummy) -> ()", c10::RegisterOperators::options()
-            .catchAllKernel<DummyKernel>()
-            .catchAllKernel<DummyKernel>());
+            .compoundKernel<DummyKernel>()
+            .compoundKernel<DummyKernel>());
   }, "Tried to register multiple catch-all kernels for operator schema _test::dummy");
 }
 
 TEST(OperatorRegistrationTest, givenMultipleCatchallKernels_whenCalled_thenCallsNewerKernel) {
   bool called_kernel1 = false;
   bool called_kernel2 = false;
-  auto registrar1 = c10::RegisterOperators().op("_test::dummy(Tensor dummy) -> ()", c10::RegisterOperators::options().catchAllKernel<MockKernel>(&called_kernel1));
-  auto registrar2 = c10::RegisterOperators().op("_test::dummy(Tensor dummy) -> ()", c10::RegisterOperators::options().catchAllKernel<MockKernel>(&called_kernel2));
+  auto registrar1 = c10::RegisterOperators().op("_test::dummy(Tensor dummy) -> ()", c10::RegisterOperators::options().compoundKernel<MockKernel>(&called_kernel1));
+  auto registrar2 = c10::RegisterOperators().op("_test::dummy(Tensor dummy) -> ()", c10::RegisterOperators::options().compoundKernel<MockKernel>(&called_kernel2));
 
   auto op = Dispatcher::singleton().findSchema({"_test::dummy", ""});
   ASSERT_TRUE(op.has_value()); // assert schema is registered
@@ -384,8 +384,8 @@ TEST(OperatorRegistrationTest, givenMultipleKernelsWithSameDispatchKey_whenNewer
 TEST(OperatorRegistrationTest, givenMultipleCatchallKernels_whenNewerKernelDeletedAndOpCalled_thenCallsOlderKernel) {
   bool called_kernel1 = false;
   bool called_kernel2 = false;
-  auto registrar1 = c10::RegisterOperators().op("_test::dummy(Tensor dummy) -> ()", c10::RegisterOperators::options().catchAllKernel<MockKernel>(&called_kernel1));
-  auto registrar2 = c10::RegisterOperators().op("_test::dummy(Tensor dummy) -> ()", c10::RegisterOperators::options().catchAllKernel<MockKernel>(&called_kernel2));
+  auto registrar1 = c10::RegisterOperators().op("_test::dummy(Tensor dummy) -> ()", c10::RegisterOperators::options().compoundKernel<MockKernel>(&called_kernel1));
+  auto registrar2 = c10::RegisterOperators().op("_test::dummy(Tensor dummy) -> ()", c10::RegisterOperators::options().compoundKernel<MockKernel>(&called_kernel2));
 
   registrar2 = c10::RegisterOperators(); // destruct the registrar
 
@@ -416,8 +416,8 @@ TEST(OperatorRegistrationTest, givenMultipleKernelsWithSameDispatchKey_whenOlder
 TEST(OperatorRegistrationTest, givenMultipleCatchallKernels_whenOlderKernelDeletedAndOpCalled_thenCallsNewerKernel) {
   bool called_kernel1 = false;
   bool called_kernel2 = false;
-  auto registrar1 = c10::RegisterOperators().op("_test::dummy(Tensor dummy) -> ()", c10::RegisterOperators::options().catchAllKernel<MockKernel>(&called_kernel1));
-  auto registrar2 = c10::RegisterOperators().op("_test::dummy(Tensor dummy) -> ()", c10::RegisterOperators::options().catchAllKernel<MockKernel>(&called_kernel2));
+  auto registrar1 = c10::RegisterOperators().op("_test::dummy(Tensor dummy) -> ()", c10::RegisterOperators::options().compoundKernel<MockKernel>(&called_kernel1));
+  auto registrar2 = c10::RegisterOperators().op("_test::dummy(Tensor dummy) -> ()", c10::RegisterOperators::options().compoundKernel<MockKernel>(&called_kernel2));
 
   registrar1 = c10::RegisterOperators(); // destruct the registrar
 
@@ -452,8 +452,8 @@ TEST(OperatorRegistrationTest, givenMultipleCatchallKernels_whenOlderAndThenNewe
   bool called_kernel1 = false;
   bool called_kernel2 = false;
   auto registrar0 = c10::RegisterOperators().op("_test::dummy(Tensor dummy) -> ()");
-  auto registrar1 = c10::RegisterOperators().op("_test::dummy(Tensor dummy) -> ()", c10::RegisterOperators::options().catchAllKernel<MockKernel>(&called_kernel1));
-  auto registrar2 = c10::RegisterOperators().op("_test::dummy(Tensor dummy) -> ()", c10::RegisterOperators::options().catchAllKernel<MockKernel>(&called_kernel2));
+  auto registrar1 = c10::RegisterOperators().op("_test::dummy(Tensor dummy) -> ()", c10::RegisterOperators::options().compoundKernel<MockKernel>(&called_kernel1));
+  auto registrar2 = c10::RegisterOperators().op("_test::dummy(Tensor dummy) -> ()", c10::RegisterOperators::options().compoundKernel<MockKernel>(&called_kernel2));
 
   registrar1 = c10::RegisterOperators(); // destruct the registrar
   registrar2 = c10::RegisterOperators(); // destruct the registrar
@@ -490,8 +490,8 @@ TEST(OperatorRegistrationTest, givenMultipleCatchallKernels_whenNewerAndThenOlde
   bool called_kernel1 = false;
   bool called_kernel2 = false;
   auto registrar0 = c10::RegisterOperators().op("_test::dummy(Tensor dummy) -> ()");
-  auto registrar1 = c10::RegisterOperators().op("_test::dummy(Tensor dummy) -> ()", c10::RegisterOperators::options().catchAllKernel<MockKernel>(&called_kernel1));
-  auto registrar2 = c10::RegisterOperators().op("_test::dummy(Tensor dummy) -> ()", c10::RegisterOperators::options().catchAllKernel<MockKernel>(&called_kernel2));
+  auto registrar1 = c10::RegisterOperators().op("_test::dummy(Tensor dummy) -> ()", c10::RegisterOperators::options().compoundKernel<MockKernel>(&called_kernel1));
+  auto registrar2 = c10::RegisterOperators().op("_test::dummy(Tensor dummy) -> ()", c10::RegisterOperators::options().compoundKernel<MockKernel>(&called_kernel2));
 
   registrar2 = c10::RegisterOperators(); // destruct the registrar
   registrar1 = c10::RegisterOperators(); // destruct the registrar
@@ -751,7 +751,7 @@ TEST(OperatorRegistrationTest, whenRegisteringBackendFallbackKernelAndCatchallKe
   auto registrar = c10::Dispatcher::singleton().registerBackendFallbackKernel(c10::TensorTypeId::CPUTensorId, c10::KernelFunction::makeFromBoxedFunction<&backend_fallback_kernel>());
 
   auto registrar1 = c10::RegisterOperators().op("_test::dummy(Tensor dummy, str input) -> ()", c10::RegisterOperators::options()
-      .catchAllKernel([] (Tensor, std::string) {
+      .compoundKernel([] (Tensor, std::string) {
         called = true;
       }));
   auto op = Dispatcher::singleton().findSchema({"_test::dummy", ""});
@@ -839,7 +839,7 @@ struct ArgTypeTestKernel final : OperatorKernel {
 
   static void test(TestModernAPI, InputType input, std::function<void(const InputType&)> inputExpectation, OutputType output, std::function<void(const c10::Stack&)> outputExpectation, const std::string& schema) {
     return test_([&] {
-      return c10::RegisterOperators().op("_test::my_op" + schema, c10::RegisterOperators::options().catchAllKernel<ArgTypeTestKernel>(input, inputExpectation, output));
+      return c10::RegisterOperators().op("_test::my_op" + schema, c10::RegisterOperators::options().compoundKernel<ArgTypeTestKernel>(input, inputExpectation, output));
     }, input, inputExpectation, output, outputExpectation, schema);
   }
 

--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -127,7 +127,7 @@ BACKEND_UNBOXEDONLY_FUNCTION_REGISTRATION = CodeTemplate("""\
 DEFAULT_FUNCTION_REGISTRATION = CodeTemplate("""\
 .op(torch::RegisterOperators::options()
   .schema("${schema_string}")
-  .catchAllKernel<${return_type} (${formals_types})>(&TypeDefault::${api_name})
+  .compoundKernel<${return_type} (${formals_types})>(&TypeDefault::${api_name})
   .aliasAnalysis(c10::AliasAnalysisKind::FROM_SCHEMA))
 """)
 BACKEND_FUNCTION_REGISTRATION = CodeTemplate("""\

--- a/test/cpp/jit/test_alias_analysis.cpp
+++ b/test/cpp/jit/test_alias_analysis.cpp
@@ -739,7 +739,7 @@ graph():
     auto ops = torch::RegisterOperators().op(
         "uses::list",
         torch::RegisterOperators::options()
-            .catchAllKernel([](torch::List<at::Tensor> in) {
+            .compoundKernel([](torch::List<at::Tensor> in) {
               return torch::rand({2, 3});
             })
             .aliasAnalysis(AliasAnalysisKind::PURE_FUNCTION));
@@ -781,7 +781,7 @@ graph():
     auto ops = torch::RegisterOperators().op(
         "uses::list",
         torch::RegisterOperators::options()
-            .catchAllKernel([](torch::List<at::Tensor> in) {
+            .compoundKernel([](torch::List<at::Tensor> in) {
               return torch::rand({2, 3});
             })
             .aliasAnalysis(AliasAnalysisKind::PURE_FUNCTION));
@@ -992,7 +992,7 @@ void testAliasRegistration() {
     auto registry = torch::RegisterOperators().op(
         "foo::rand1",
         torch::RegisterOperators::options()
-            .catchAllKernel([](at::Tensor) -> at::Tensor {
+            .compoundKernel([](at::Tensor) -> at::Tensor {
               return at::rand({2, 2});
             })
             .aliasAnalysis(AliasAnalysisKind::CONSERVATIVE));
@@ -1008,7 +1008,7 @@ void testAliasRegistration() {
     auto registry = torch::RegisterOperators().op(
         "foo::rand2(Tensor arg1) -> Tensor",
         torch::RegisterOperators::options()
-            .catchAllKernel([](at::Tensor) -> at::Tensor {
+            .compoundKernel([](at::Tensor) -> at::Tensor {
               return at::rand({2, 2});
             })
             .aliasAnalysis(AliasAnalysisKind::CONSERVATIVE));
@@ -1026,7 +1026,7 @@ void testAliasRegistration() {
           torch::RegisterOperators().op(
               "foo::rand3(Tensor(a) arg1) -> Tensor(b)",
               torch::RegisterOperators::options()
-                  .catchAllKernel([](at::Tensor) -> at::Tensor {
+                  .compoundKernel([](at::Tensor) -> at::Tensor {
                     return at::rand({2, 2});
                   })
                   .aliasAnalysis(AliasAnalysisKind::CONSERVATIVE));
@@ -1039,7 +1039,7 @@ void testAliasRegistration() {
           torch::RegisterOperators().op(
               "foo::rand4(Tensor(a) arg1) -> Tensor(a)",
               torch::RegisterOperators::options()
-                  .catchAllKernel([](at::Tensor) -> at::Tensor {
+                  .compoundKernel([](at::Tensor) -> at::Tensor {
                     return at::rand({2, 2});
                   })
                   .aliasAnalysis(AliasAnalysisKind::CONSERVATIVE));
@@ -1052,7 +1052,7 @@ void testAliasRegistration() {
           torch::RegisterOperators().op(
               "foo::rand5",
               torch::RegisterOperators::options()
-                  .catchAllKernel([](at::Tensor) -> at::Tensor {
+                  .compoundKernel([](at::Tensor) -> at::Tensor {
                     return at::rand({2, 2});
                   })
                   .aliasAnalysis(AliasAnalysisKind::FROM_SCHEMA));
@@ -1063,7 +1063,7 @@ void testAliasRegistration() {
     auto registry = torch::RegisterOperators().op(
         "foo::rand6(Tensor arg1) -> Tensor",
         torch::RegisterOperators::options()
-            .catchAllKernel([](at::Tensor) -> at::Tensor {
+            .compoundKernel([](at::Tensor) -> at::Tensor {
               return at::rand({2, 2});
             })
             .aliasAnalysis(AliasAnalysisKind::FROM_SCHEMA));
@@ -1080,7 +1080,7 @@ void testAliasRegistration() {
     auto registry = torch::RegisterOperators().op(
         "foo::rand7(Tensor(a) arg1) -> Tensor(a)",
         torch::RegisterOperators::options()
-            .catchAllKernel([](at::Tensor t) -> at::Tensor { return t * 2; })
+            .compoundKernel([](at::Tensor t) -> at::Tensor { return t * 2; })
             .aliasAnalysis(AliasAnalysisKind::FROM_SCHEMA));
     const auto rand_op = Symbol::fromQualString("foo::rand7");
 
@@ -1095,7 +1095,7 @@ void testAliasRegistration() {
     auto registry = torch::RegisterOperators().op(
         "foo::rand8(Tensor(a) arg1) -> Tensor(b)",
         torch::RegisterOperators::options()
-            .catchAllKernel([](at::Tensor t) -> at::Tensor { return t * 2; })
+            .compoundKernel([](at::Tensor t) -> at::Tensor { return t * 2; })
             .aliasAnalysis(AliasAnalysisKind::FROM_SCHEMA));
     const auto rand_op = Symbol::fromQualString("foo::rand8");
     auto graph = std::make_shared<Graph>();
@@ -1109,7 +1109,7 @@ void testAliasRegistration() {
     auto registry = torch::RegisterOperators().op(
         "foo::rand9",
         torch::RegisterOperators::options()
-            .catchAllKernel([](at::Tensor) -> at::Tensor {
+            .compoundKernel([](at::Tensor) -> at::Tensor {
               return at::rand({2, 2});
             })
             .aliasAnalysis(AliasAnalysisKind::PURE_FUNCTION));
@@ -1125,7 +1125,7 @@ void testAliasRegistration() {
     auto registry = torch::RegisterOperators().op(
         "foo::rand10(Tensor arg1) -> Tensor",
         torch::RegisterOperators::options()
-            .catchAllKernel([](at::Tensor) -> at::Tensor {
+            .compoundKernel([](at::Tensor) -> at::Tensor {
               return at::rand({2, 2});
             })
             .aliasAnalysis(AliasAnalysisKind::PURE_FUNCTION));
@@ -1143,7 +1143,7 @@ void testAliasRegistration() {
           torch::RegisterOperators().op(
               "foo::rand11(Tensor(a) arg1) -> Tensor(a)",
               torch::RegisterOperators::options()
-                  .catchAllKernel(
+                  .compoundKernel(
                       [](at::Tensor t) -> at::Tensor { return t * 2; })
                   .aliasAnalysis(AliasAnalysisKind::PURE_FUNCTION));
         },
@@ -1155,7 +1155,7 @@ void testAliasRegistration() {
           torch::RegisterOperators().op(
               "foo::rand12(Tensor(a) arg1) -> Tensor(b)",
               torch::RegisterOperators::options()
-                  .catchAllKernel(
+                  .compoundKernel(
                       [](at::Tensor t) -> at::Tensor { return t * 2; })
                   .aliasAnalysis(AliasAnalysisKind::PURE_FUNCTION));
         },

--- a/test/mobile/op_deps/simple_ops.cpp
+++ b/test/mobile/op_deps/simple_ops.cpp
@@ -69,7 +69,7 @@ auto registerer = torch::RegisterOperators()
     .aliasAnalysis(c10::AliasAnalysisKind::FROM_SCHEMA))
   .op(torch::RegisterOperators::options()
     .schema("aten::BB(Tensor self) -> Tensor")
-    .catchAllKernel<decltype(BB_op), &BB_op>()
+    .compoundKernel<decltype(BB_op), &BB_op>()
     .aliasAnalysis(c10::AliasAnalysisKind::FROM_SCHEMA))
   .op(torch::RegisterOperators::options()
     .schema("aten::CC(Tensor self) -> Tensor")
@@ -77,7 +77,7 @@ auto registerer = torch::RegisterOperators()
     .aliasAnalysis(c10::AliasAnalysisKind::FROM_SCHEMA))
   .op(torch::RegisterOperators::options()
     .schema("aten::DD(Tensor self) -> Tensor")
-    .catchAllKernel(&DD_op)
+    .compoundKernel(&DD_op)
     .aliasAnalysis(c10::AliasAnalysisKind::FROM_SCHEMA))
   .op(torch::RegisterOperators::options()
     .schema("aten::EE(Tensor self) -> Tensor")
@@ -94,7 +94,7 @@ auto registerer = torch::RegisterOperators()
     }))
   .op(torch::RegisterOperators::options()
     .schema("aten::HH(Tensor self) -> Tensor")
-    .catchAllKernel([] (Tensor a) -> Tensor {
+    .compoundKernel([] (Tensor a) -> Tensor {
       return a;
     }));
 

--- a/torch/csrc/jit/mobile/register_mobile_ops.cpp
+++ b/torch/csrc/jit/mobile/register_mobile_ops.cpp
@@ -261,7 +261,7 @@ static auto registry = torch::RegisterOperators().op(
   })
 ).op(
   "_aten::eq",
-  torch::RegisterOperators::options().catchAllKernel(
+  torch::RegisterOperators::options().compoundKernel(
     [](int64_t a, int64_t b) -> bool {
       return a == b;
     })
@@ -292,34 +292,34 @@ static auto registry = torch::RegisterOperators().op(
   })
 ).op(
   "_prim::NumToTensor",
-  torch::RegisterOperators::options().catchAllKernel(
+  torch::RegisterOperators::options().compoundKernel(
   [](at::Scalar s) -> at::Tensor {
       return at::scalar_to_tensor(s);
   })
 ).op(
   // Dummy operator that does nothing. Used to reserve a location of an operator table.
   "_prim::ListConstruct.int",
-  torch::RegisterOperators::options().catchAllKernel(
+  torch::RegisterOperators::options().compoundKernel(
   []() {
   })
 ).op(
   "_prim::ListConstruct.float",
-  torch::RegisterOperators::options().catchAllKernel(
+  torch::RegisterOperators::options().compoundKernel(
   []() {
   })
 ).op(
   "_prim::ListConstruct.bool",
-  torch::RegisterOperators::options().catchAllKernel(
+  torch::RegisterOperators::options().compoundKernel(
   []() {
   })
 ).op(
   "_prim::ListConstruct.Tensor",
-  torch::RegisterOperators::options().catchAllKernel(
+  torch::RegisterOperators::options().compoundKernel(
   []() {
   })
 ).op(
   "_prim::ListConstruct.generic",
-  torch::RegisterOperators::options().catchAllKernel(
+  torch::RegisterOperators::options().compoundKernel(
   []() {
   })
 
@@ -370,7 +370,7 @@ static auto registry = torch::RegisterOperators().op(
   torch::RegisterOperators::options().kernel<&cat_kernel>(c10::TensorTypeId::CPUTensorId)
 ).op(
   "_aten::__is__(t1 self, t2 obj) -> bool",
-  torch::RegisterOperators::options().catchAllKernel<&__is__kernel>()
+  torch::RegisterOperators::options().compoundKernel<&__is__kernel>()
 ).op(
   "_aten::log_softmax.int(Tensor self, int dim, ScalarType? dtype=None) -> Tensor",
   torch::RegisterOperators::options().kernel<&log_softmax_kernel>(c10::TensorTypeId::CPUTensorId)
@@ -379,25 +379,25 @@ static auto registry = torch::RegisterOperators().op(
   torch::RegisterOperators::options().kernel<&softmax_kernel>(c10::TensorTypeId::CPUTensorId)
 ).op(
   "_aten::warn() -> void",
-  torch::RegisterOperators::options().catchAllKernel<&warn_kernel>()
+  torch::RegisterOperators::options().compoundKernel<&warn_kernel>()
 ).op(
   "_prim::unchecked_cast",
-  torch::RegisterOperators::options().catchAllKernel(
+  torch::RegisterOperators::options().compoundKernel(
   []() {
   })
 ).op(
   "_prim::TupleConstruct",
-  torch::RegisterOperators::options().catchAllKernel(
+  torch::RegisterOperators::options().compoundKernel(
   []() {
   })
 ).op(
   "_prim::TupleUnpack",
-  torch::RegisterOperators::options().catchAllKernel(
+  torch::RegisterOperators::options().compoundKernel(
   []() {
   })
 ).op(
   "_aten::format",
-  torch::RegisterOperators::options().catchAllKernel(
+  torch::RegisterOperators::options().compoundKernel(
   []() {
   })
 ).op(
@@ -405,7 +405,7 @@ static auto registry = torch::RegisterOperators().op(
   torch::RegisterOperators::options().kernel<&listAppend<at::Tensor>>(c10::TensorTypeId::CPUTensorId)
 ).op(
   "_aten::append.int(int self) -> void",
-  torch::RegisterOperators::options().catchAllKernel<&listAppend<int64_t>>()
+  torch::RegisterOperators::options().compoundKernel<&listAppend<int64_t>>()
 );
 
 }

--- a/torch/csrc/jit/register_string_ops.cpp
+++ b/torch/csrc/jit/register_string_ops.cpp
@@ -131,7 +131,7 @@ auto reg_str_ops_2 =
         .op("aten::splitlines(str self, bool keepends=False) -> str[]",
             torch::RegisterOperators::options()
                 .aliasAnalysis(AliasAnalysisKind::FROM_SCHEMA)
-                .catchAllKernel([](std::string string, bool keepends) {
+                .compoundKernel([](std::string string, bool keepends) {
                   std::string delimiters =
                       "\n\r\r\n\v\x0b\f\x0c\x1c\x1d\x1e\x85\u2028\u2029";
                   c10::List<std::string> splits;
@@ -158,14 +158,14 @@ auto reg_str_ops_2 =
         .op("aten::slice.str(str string, int start, int end=9223372036854775807, int step=1) -> str",
             torch::RegisterOperators::options()
                 .aliasAnalysis(AliasAnalysisKind::FROM_SCHEMA)
-                .catchAllKernel<decltype(stringSlice), &stringSlice>())
+                .compoundKernel<decltype(stringSlice), &stringSlice>())
 
         // upper and lower require there to be at least one alpha character,
         // and ignore all other characters
         .op("aten::isupper(str self) -> bool",
             torch::RegisterOperators::options()
                 .aliasAnalysis(AliasAnalysisKind::FROM_SCHEMA)
-                .catchAllKernel([](std::string string) {
+                .compoundKernel([](std::string string) {
                   bool found_alpha = false;
                   bool is_upper = true;
                   for (size_t i = 0; i < string.size() && is_upper; ++i) {
@@ -178,7 +178,7 @@ auto reg_str_ops_2 =
         .op("aten::islower(str self) -> bool",
             torch::RegisterOperators::options()
                 .aliasAnalysis(AliasAnalysisKind::FROM_SCHEMA)
-                .catchAllKernel([](std::string string) {
+                .compoundKernel([](std::string string) {
                   bool found_alpha = false;
                   bool is_lower = true;
                   for (size_t i = 0; i < string.size() && is_lower; ++i) {
@@ -192,7 +192,7 @@ auto reg_str_ops_2 =
         .op("aten::capitalize(str self) -> str",
             torch::RegisterOperators::options()
                 .aliasAnalysis(AliasAnalysisKind::FROM_SCHEMA)
-                .catchAllKernel([](std::string string) {
+                .compoundKernel([](std::string string) {
                   std::stringstream ss;
                   auto first_char = true;
                   for (char c : string) {
@@ -209,7 +209,7 @@ auto reg_str_ops_2 =
         .op("aten::title(str self) -> str",
             torch::RegisterOperators::options()
                 .aliasAnalysis(AliasAnalysisKind::FROM_SCHEMA)
-                .catchAllKernel([](std::string string) {
+                .compoundKernel([](std::string string) {
                   std::stringstream ss;
                   bool prev_is_nonalpha = true;
                   for (char c : string) {
@@ -230,7 +230,7 @@ auto reg_str_ops_2 =
         .op("aten::center(str self, int width, str fillchar=' ') -> str",
             torch::RegisterOperators::options()
                 .aliasAnalysis(AliasAnalysisKind::FROM_SCHEMA)
-                .catchAllKernel([](std::string string,
+                .compoundKernel([](std::string string,
                                    int64_t width,
                                    std::string fillchar) {
                   if (fillchar.size() != 1) {
@@ -266,7 +266,7 @@ auto reg_str_ops_2 =
         .op("aten::count(str self, str substr, int start=0, int end=-1) -> int",
             torch::RegisterOperators::options()
                 .aliasAnalysis(AliasAnalysisKind::FROM_SCHEMA)
-                .catchAllKernel([](std::string string,
+                .compoundKernel([](std::string string,
                                    std::string substr,
                                    int64_t start,
                                    int64_t end) {
@@ -298,7 +298,7 @@ auto reg_str_ops_2 =
         .op("aten::endswith(str self, str substr, int start=0, int end=-1) -> bool",
             torch::RegisterOperators::options()
                 .aliasAnalysis(AliasAnalysisKind::FROM_SCHEMA)
-                .catchAllKernel([](std::string string,
+                .compoundKernel([](std::string string,
                                    std::string substr,
                                    int64_t start,
                                    int64_t end) {
@@ -325,7 +325,7 @@ auto reg_str_ops_2 =
         .op("aten::startswith(str self, str substr, int start=0, int end=-1) -> bool",
             torch::RegisterOperators::options()
                 .aliasAnalysis(AliasAnalysisKind::FROM_SCHEMA)
-                .catchAllKernel([](std::string string,
+                .compoundKernel([](std::string string,
                                    std::string substr,
                                    int64_t start,
                                    int64_t end) {
@@ -349,7 +349,7 @@ auto reg_str_ops_2 =
         .op("aten::expandtabs(str self, int tabsize=8) -> str",
             torch::RegisterOperators::options()
                 .aliasAnalysis(AliasAnalysisKind::FROM_SCHEMA)
-                .catchAllKernel([](std::string string, int64_t tabsize) {
+                .compoundKernel([](std::string string, int64_t tabsize) {
                   std::stringstream ss;
                   size_t index = 0;
                   for (const auto& c : string) {
@@ -372,7 +372,7 @@ auto reg_str_ops_2 =
         .op("aten::find(str self, str substr, int start=0, int end=-1) -> int",
             torch::RegisterOperators::options()
                 .aliasAnalysis(AliasAnalysisKind::FROM_SCHEMA)
-                .catchAllKernel([](std::string string,
+                .compoundKernel([](std::string string,
                                    std::string substr,
                                    int64_t start,
                                    int64_t end) {
@@ -382,7 +382,7 @@ auto reg_str_ops_2 =
         .op("aten::rfind(str self, str substr, int start=0, int end=-1) -> int",
             torch::RegisterOperators::options()
                 .aliasAnalysis(AliasAnalysisKind::FROM_SCHEMA)
-                .catchAllKernel([](std::string string,
+                .compoundKernel([](std::string string,
                                    std::string substr,
                                    int64_t start,
                                    int64_t end) {
@@ -392,7 +392,7 @@ auto reg_str_ops_2 =
         .op("aten::index.str(str self, str substr, int start=0, int end=-1) -> int",
             torch::RegisterOperators::options()
                 .aliasAnalysis(AliasAnalysisKind::FROM_SCHEMA)
-                .catchAllKernel([](std::string string,
+                .compoundKernel([](std::string string,
                                    std::string substr,
                                    int64_t start,
                                    int64_t end) {
@@ -406,7 +406,7 @@ auto reg_str_ops_2 =
         .op("aten::rindex(str self, str substr, int start=0, int end=-1) -> int",
             torch::RegisterOperators::options()
                 .aliasAnalysis(AliasAnalysisKind::FROM_SCHEMA)
-                .catchAllKernel([](std::string string,
+                .compoundKernel([](std::string string,
                                    std::string substr,
                                    int64_t start,
                                    int64_t end) {
@@ -421,7 +421,7 @@ auto reg_str_ops_2 =
         .op("aten::isidentifier(str self) -> bool",
             torch::RegisterOperators::options()
                 .aliasAnalysis(AliasAnalysisKind::FROM_SCHEMA)
-                .catchAllKernel([](std::string string) {
+                .compoundKernel([](std::string string) {
                   LOG(WARNING)
                       << "The isidentifier() implementation being used is from Python 2\n";
                   if (string.size() < 1) {
@@ -440,7 +440,7 @@ auto reg_str_ops_2 =
         .op("aten::istitle(str self) -> bool",
             torch::RegisterOperators::options()
                 .aliasAnalysis(AliasAnalysisKind::FROM_SCHEMA)
-                .catchAllKernel([](std::string string) {
+                .compoundKernel([](std::string string) {
                   auto result = false;
 
                   bool prev_is_alpha = false;
@@ -473,7 +473,7 @@ auto reg_str_ops_2 =
         .op("aten::isprintable(str self) -> bool",
             torch::RegisterOperators::options()
                 .aliasAnalysis(AliasAnalysisKind::FROM_SCHEMA)
-                .catchAllKernel([](std::string string) {
+                .compoundKernel([](std::string string) {
                   auto result =
                       std::all_of(string.begin(), string.end(), [](char c) {
                         return ::isalnum(c) || ::ispunct(c) || c == ' ';
@@ -484,7 +484,7 @@ auto reg_str_ops_2 =
         .op("aten::ljust(str self, int width, str fillchar=' ') -> str",
             torch::RegisterOperators::options()
                 .aliasAnalysis(AliasAnalysisKind::FROM_SCHEMA)
-                .catchAllKernel([](std::string string,
+                .compoundKernel([](std::string string,
                                    int64_t width,
                                    std::string fillchar) {
                   if (fillchar.size() != 1) {
@@ -507,7 +507,7 @@ auto reg_str_ops_2 =
         .op("aten::rjust(str self, int width, str fillchar=' ') -> str",
             torch::RegisterOperators::options()
                 .aliasAnalysis(AliasAnalysisKind::FROM_SCHEMA)
-                .catchAllKernel([](std::string string,
+                .compoundKernel([](std::string string,
                                    int64_t width,
                                    std::string fillchar) {
                   if (fillchar.size() != 1) {
@@ -529,7 +529,7 @@ auto reg_str_ops_2 =
         .op("aten::zfill(str self, int width) -> str",
             torch::RegisterOperators::options()
                 .aliasAnalysis(AliasAnalysisKind::FROM_SCHEMA)
-                .catchAllKernel([](std::string string, int64_t width) {
+                .compoundKernel([](std::string string, int64_t width) {
                   auto to_append = std::max(
                       int64_t(0), width - static_cast<int64_t>(string.size()));
 
@@ -545,7 +545,7 @@ auto reg_str_ops_2 =
         .op("aten::lstrip(str self, str chars=' \\n\\t\\f\\v') -> str",
             torch::RegisterOperators::options()
                 .aliasAnalysis(AliasAnalysisKind::FROM_SCHEMA)
-                .catchAllKernel([](std::string string, std::string chars) {
+                .compoundKernel([](std::string string, std::string chars) {
                   auto index = string.find_first_not_of(chars);
                   if (index != std::string::npos) {
                     string = string.substr(index, string.size());
@@ -558,7 +558,7 @@ auto reg_str_ops_2 =
         .op("aten::rstrip(str self, str chars=' \\n\\t\\f\\v') -> str",
             torch::RegisterOperators::options()
                 .aliasAnalysis(AliasAnalysisKind::FROM_SCHEMA)
-                .catchAllKernel([](std::string string, std::string chars) {
+                .compoundKernel([](std::string string, std::string chars) {
                   auto index = string.find_last_not_of(chars);
                   if (index != std::string::npos) {
                     string = string.substr(0, index + 1);
@@ -571,7 +571,7 @@ auto reg_str_ops_2 =
         .op("aten::strip(str self, str chars=' \\n\\t\\f\\v') -> str",
             torch::RegisterOperators::options()
                 .aliasAnalysis(AliasAnalysisKind::FROM_SCHEMA)
-                .catchAllKernel([](std::string string, std::string chars) {
+                .compoundKernel([](std::string string, std::string chars) {
                   auto rindex = string.find_last_not_of(chars);
                   if (rindex != std::string::npos) {
                     string = string.substr(0, rindex + 1);
@@ -590,7 +590,7 @@ auto reg_str_ops_2 =
         .op("aten::replace(str self, str old, str new, int max=-1) -> str",
             torch::RegisterOperators::options()
                 .aliasAnalysis(AliasAnalysisKind::FROM_SCHEMA)
-                .catchAllKernel([](std::string string,
+                .compoundKernel([](std::string string,
                                    std::string old_str,
                                    std::string new_str,
                                    int64_t max) {
@@ -611,7 +611,7 @@ auto reg_str_ops_2 =
         .op("aten::partition(str self, str separator) -> (str, str, str)",
             torch::RegisterOperators::options()
                 .aliasAnalysis(AliasAnalysisKind::FROM_SCHEMA)
-                .catchAllKernel([](std::string string, std::string separator) {
+                .compoundKernel([](std::string string, std::string separator) {
                   auto pos = string.find(separator, 0);
                   if (pos == std::string::npos) {
                     pos = string.size();
@@ -628,7 +628,7 @@ auto reg_str_ops_2 =
         .op("aten::rpartition(str self, str separator) -> (str, str, str)",
             torch::RegisterOperators::options()
                 .aliasAnalysis(AliasAnalysisKind::FROM_SCHEMA)
-                .catchAllKernel([](std::string string, std::string separator) {
+                .compoundKernel([](std::string string, std::string separator) {
                   auto pos = string.find(separator, 0);
                   auto rpos = pos;
                   do {
@@ -652,7 +652,7 @@ auto reg_str_ops_2 =
         .op("aten::split.str(str self, str separator=' ', int max=-1) -> str[]",
             torch::RegisterOperators::options()
                 .aliasAnalysis(AliasAnalysisKind::FROM_SCHEMA)
-                .catchAllKernel(
+                .compoundKernel(
                     [](std::string string, std::string separator, int64_t max) {
                       std::string::size_type prev_pos = 0;
                       std::string::size_type pos = 0;
@@ -678,7 +678,7 @@ auto reg_str_ops_2 =
         .op("aten::rsplit(str self, str separator=' ', int max=-1) -> str[]",
             torch::RegisterOperators::options()
                 .aliasAnalysis(AliasAnalysisKind::FROM_SCHEMA)
-                .catchAllKernel(
+                .compoundKernel(
                     [](std::string string, std::string separator, int64_t max) {
                       std::reverse(separator.begin(), separator.end());
                       std::reverse(string.begin(), string.end());


### PR DESCRIPTION
Summary: Replacing functions like catchAllKernel with a name more clearly describing what they are used for

Test Plan: run all tests

Differential Revision: D18767891

