### PR TITLE
Add barriers to fix flaky test_graph_for_py_nested_call and
test_graph_for_py_nested_remote_call

### DIFF
--- a/test/dist_autograd_test.py
+++ b/test/dist_autograd_test.py
@@ -426,9 +426,15 @@ class DistAutogradTest(RpcAgentTestFixture):
             else:
                 raise ValueError("Unrecognized ExecMode {}".format(exec_mode))
 
+            # Barrier to ensure all RPCs are done.
+            dist.barrier()
+
             for rd in [1, 2, 3]:
                 rpc.rpc_sync("worker{}".format((self.rank + rd) % self.world_size),
                              _set_rpc_done, args=(context_id, rd))
+
+            # Barrier to ensure all set_rpc_done have completed.
+            dist.barrier()
 
             # For self.rank, it has 4 graphs to verify
             # One is for current context id when this rank send first rpc call.
@@ -451,17 +457,14 @@ class DistAutogradTest(RpcAgentTestFixture):
                                                   t1, t2, ret)
 
             # Verify second graph for 1st nested call.
-            self._check_rpc_done(1)
             ctx = dist_autograd._retrieve_context(ctx_ids[1])
             self._verify_graph_for_nested_rpc_call(ctx)
 
             # Verify third graph for 2nd nested call.
-            self._check_rpc_done(2)
             ctx = dist_autograd._retrieve_context(ctx_ids[2])
             self._verify_graph_for_nested_rpc_call(ctx)
 
             # verify last graph for rpc call execution.
-            self._check_rpc_done(3)
             ctx = dist_autograd._retrieve_context(ctx_ids[3])
             send_functions = ctx._send_functions()
             self.assertEqual(1, len(send_functions))
@@ -474,7 +477,7 @@ class DistAutogradTest(RpcAgentTestFixture):
     def test_graph_for_py_nested_call(self):
         self._test_graph_for_py_nested_call(ExecMode.RPC_SYNC)
 
-    @unittest.skip("Test is flaky, see https://github.com/pytorch/pytorch/issues/29938")
+    #@unittest.skip("Test is flaky, see https://github.com/pytorch/pytorch/issues/29938")
     @dist_init
     def test_graph_for_py_nested_remote_call(self):
         self._test_graph_for_py_nested_call(ExecMode.REMOTE)

--- a/test/dist_autograd_test.py
+++ b/test/dist_autograd_test.py
@@ -477,7 +477,6 @@ class DistAutogradTest(RpcAgentTestFixture):
     def test_graph_for_py_nested_call(self):
         self._test_graph_for_py_nested_call(ExecMode.RPC_SYNC)
 
-    #@unittest.skip("Test is flaky, see https://github.com/pytorch/pytorch/issues/29938")
     @dist_init
     def test_graph_for_py_nested_remote_call(self):
         self._test_graph_for_py_nested_call(ExecMode.REMOTE)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#30624 Add barriers to fix flaky test_graph_for_py_nested_call and
test_graph_for_py_nested_remote_call**
test_graph_for_py_nested_remote_call**
test_graph_for_py_nested_remote_call**

test_graph_for_py_nested_remote_call

These tests were flaky since we would end up calling the 'verify'
methods before some of the RPCs were done. The `check_rpc_done` function might
not guarantee this since set_rpc_done sets an appropriate flag in python which
causes `check_rpc_done` to pass. Although, there are a few steps after that
like attaching the send functions for the response of the RPC that might not
have executed by then.

Differential Revision: [D18768786](https://our.internmc.facebook.com/intern/diff/D18768786/)