### PR TITLE
[C++ API] Exclude undefined tensors in the result of Module::parameters() / named_paramters() / buffers() / named_buffers()

### DIFF
--- a/test/cpp/api/module.cpp
+++ b/test/cpp/api/module.cpp
@@ -145,7 +145,7 @@ TEST_F(ModuleTest, RegisterParameterUndefinedTensor) {
   {
     TestModel model;
     model.register_parameter("undefined_tensor", torch::Tensor(), /*requires_grad=*/false);
-    ASSERT_FALSE(model.named_parameters()["undefined_tensor"].defined());
+    ASSERT_EQ(model.parameters().size(), 0);
   }
   {
     std::stringstream buffer;
@@ -153,7 +153,7 @@ TEST_F(ModuleTest, RegisterParameterUndefinedTensor) {
 
     TestModel model;
     model.register_parameter("undefined_tensor", torch::Tensor());
-    ASSERT_FALSE(model.named_parameters()["undefined_tensor"].defined());
+    ASSERT_EQ(model.parameters().size(), 0);
 
     ASSERT_EQ(
       count_substr_occurrences(
@@ -263,6 +263,43 @@ TEST_F(ModuleTest, DeviceOrDtypeConversionSkipsUndefinedTensor) {
 
 TEST_F(ModuleTest, DeviceOrDtypeConversionSkipsUndefinedTensor_CUDA) {
   test_DeviceOrDtypeConversionSkipsUndefinedTensor(torch::kCUDA, torch::kDouble);
+}
+
+TEST_F(ModuleTest, ParametersAndBuffersAccessorSkipsUndefinedTensor) {
+  {
+    Linear module(LinearOptions(10, 20).bias(false));
+
+    auto params = module->parameters();
+    ASSERT_EQ(params.size(), 1);
+    auto named_params = module->named_parameters();
+    ASSERT_EQ(named_params.size(), 1);
+
+    ASSERT_TRUE(pointer_equal(params[0], named_params["weight"]));
+    ASSERT_TRUE(pointer_equal(named_params["weight"], module->weight));
+  }
+  {
+    BatchNorm1d module(BatchNorm1dOptions(5).track_running_stats(false).affine(false));
+
+    auto buffers = module->buffers();
+    ASSERT_EQ(buffers.size(), 0);
+    auto named_buffers = module->named_buffers();
+    ASSERT_EQ(named_buffers.size(), 0);
+  }
+  {
+    BatchNorm1d module(BatchNorm1dOptions(5).track_running_stats(true).affine(false));
+
+    auto buffers = module->buffers();
+    ASSERT_EQ(buffers.size(), 3);
+    auto named_buffers = module->named_buffers();
+    ASSERT_EQ(named_buffers.size(), 3);
+
+    ASSERT_TRUE(pointer_equal(buffers[0], named_buffers["running_mean"]));
+    ASSERT_TRUE(pointer_equal(named_buffers["running_mean"], module->running_mean));
+    ASSERT_TRUE(pointer_equal(buffers[1], named_buffers["running_var"]));
+    ASSERT_TRUE(pointer_equal(named_buffers["running_var"], module->running_var));
+    ASSERT_TRUE(pointer_equal(buffers[2], named_buffers["num_batches_tracked"]));
+    ASSERT_TRUE(pointer_equal(named_buffers["num_batches_tracked"], module->num_batches_tracked));
+  }
 }
 
 TEST_F(ModuleTest, Conversion_MultiCUDA) {

--- a/test/cpp/api/support.h
+++ b/test/cpp/api/support.h
@@ -46,7 +46,7 @@ private:
 };
 
 inline bool pointer_equal(at::Tensor first, at::Tensor second) {
-  return first.data_ptr<float>() == second.data_ptr<float>();
+  return first.data_ptr() == second.data_ptr();
 }
 
 inline int count_substr_occurrences(const std::string& str, const std::string& substr) {

--- a/torch/csrc/api/include/torch/nn/cloneable.h
+++ b/torch/csrc/api/include/torch/nn/cloneable.h
@@ -47,7 +47,7 @@ class Cloneable : public virtual Module {
         "parameters as the original module after calling reset(). "
         "Are you sure you called register_parameter() inside reset() "
         "and not the constructor?");
-    for (const auto& parameter : parameters_) {
+    for (const auto& parameter : named_parameters(/*recurse=*/false)) {
       auto& tensor = *parameter;
       auto data = device && tensor.device() != *device ?
           tensor.to(*device) : autograd::Variable(tensor).clone();
@@ -59,7 +59,7 @@ class Cloneable : public virtual Module {
         "buffers as the original module after calling reset(). "
         "Are you sure you called register_buffer() inside reset() "
         "and not the constructor?");
-    for (const auto& buffer : buffers_) {
+    for (const auto& buffer : named_buffers(/*recurse=*/false)) {
       auto& tensor = *buffer;
       auto data = device && tensor.device() != *device ?
           tensor.to(*device) : autograd::Variable(tensor).clone();

--- a/torch/csrc/api/include/torch/nn/module.h
+++ b/torch/csrc/api/include/torch/nn/module.h
@@ -648,16 +648,12 @@ void Module::to_impl(Ts&&... ts) {
     child.value()->to(ts...);
   }
   // Then move every parameter to the new dtype/device.
-  for (auto& parameter : parameters_) {
-    if (parameter->defined()) {
-      parameter->set_data(autograd::Variable(*parameter).to(ts...));
-    }
+  for (auto& parameter : named_parameters(/*recurse=*/false)) {
+    parameter->set_data(autograd::Variable(*parameter).to(ts...));
   }
   // Then move every buffer to the new dtype/device.
-  for (auto& buffer : buffers_) {
-    if (buffer->defined()) {
-      buffer->set_data(autograd::Variable(*buffer).to(ts...));
-    }
+  for (auto& buffer : named_buffers(/*recurse=*/false)) {
+    buffer->set_data(autograd::Variable(*buffer).to(ts...));
   }
 }
 

--- a/torch/csrc/api/include/torch/nn/parallel/data_parallel.h
+++ b/torch/csrc/api/include/torch/nn/parallel/data_parallel.h
@@ -100,7 +100,7 @@ void replicate_grad_edges(
     const std::vector<std::shared_ptr<ModuleType>>& replicas,
     const std::vector<Device>& devices) {
 
-  for (auto& parameter : module->parameters_) {
+  for (auto& parameter : module->named_parameters(/*recurse=*/false)) {
     auto grad_fn = std::make_shared<ReduceAdd>((*parameter).device());
     grad_fn->set_next_edges(autograd::collect_next_edges(*parameter));
 
@@ -109,7 +109,7 @@ void replicate_grad_edges(
     }
   }
 
-  for (auto& buffer : module->buffers_) {
+  for (auto& buffer : module->named_buffers(/*recurse=*/false)) {
     if (buffer.value().requires_grad()){
       auto grad_fn = std::make_shared<ReduceAdd>((*buffer).device());
       grad_fn->set_next_edges(autograd::collect_next_edges(*buffer));

--- a/torch/csrc/api/src/nn/module.cpp
+++ b/torch/csrc/api/src/nn/module.cpp
@@ -32,15 +32,6 @@ std::string join_name(const std::string& name_prefix, const std::string& name) {
   full_name += name;
   return full_name;
 }
-
-void extend(
-    std::vector<Tensor>& vector,
-    const OrderedDict<std::string, Tensor>& dict) {
-  vector.reserve(vector.size() + dict.size());
-  for (const auto& item : dict) {
-    vector.push_back(item.value());
-  }
-}
 } // namespace
 
 Module::Module()
@@ -141,46 +132,48 @@ void Module::apply(
 }
 
 std::vector<Tensor> Module::parameters(bool recurse) const {
-  if (!recurse) {
-    return parameters_.values();
-  }
-  std::vector<Tensor> result;
-  apply(
-      [&result](const Module& module) { extend(result, module.parameters_); });
-  return result;
+  return named_parameters(recurse).values();
 }
 
 OrderedDict<std::string, Tensor> Module::named_parameters(bool recurse) const {
-  if (!recurse) {
-    return parameters_;
-  }
   OrderedDict<std::string, Tensor> result;
-  apply([&result](const std::string& name, const Module& module) {
-    for (const auto& parameter : module.parameters_) {
-      result.insert(join_name(name, parameter.key()), parameter.value());
+  if (!recurse) {
+    for (const auto& parameter : parameters_) {
+      if (parameter.value().defined()) {
+        result.insert(parameter.key(), parameter.value());
+      }
     }
-  });
+  } else {
+    apply([&result](const std::string& name, const Module& module) {
+      for (const auto& parameter : module.named_parameters(/*recurse=*/false)) {
+        TORCH_INTERNAL_ASSERT(parameter.value().defined());
+        result.insert(join_name(name, parameter.key()), parameter.value());
+      }
+    });
+  }
   return result;
 }
 
 std::vector<Tensor> Module::buffers(bool recurse) const {
-  if (!recurse) {
-    return buffers_.values();
-  }
-  std::vector<Tensor> result;
-  apply([&result](const Module& module) { extend(result, module.buffers_); });
-  return result;
+  return named_buffers(recurse).values();
 }
+
 OrderedDict<std::string, Tensor> Module::named_buffers(bool recurse) const {
-  if (!recurse) {
-    return buffers_;
-  }
   OrderedDict<std::string, Tensor> result;
-  apply([&result](const std::string& name, const Module& module) {
-    for (const auto& buffer : module.buffers_) {
-      result.insert(join_name(name, buffer.key()), buffer.value());
+  if (!recurse) {
+    for (const auto& buffer : buffers_) {
+      if (buffer.value().defined()) {
+        result.insert(buffer.key(), buffer.value());
+      }
     }
-  });
+  } else {
+    apply([&result](const std::string& name, const Module& module) {
+      for (const auto& buffer : module.named_buffers(/*recurse=*/false)) {
+        TORCH_INTERNAL_ASSERT(buffer.value().defined());
+        result.insert(join_name(name, buffer.key()), buffer.value());
+      }
+    });
+  }
   return result;
 }
 
@@ -261,7 +254,7 @@ void Module::zero_grad() {
   for (auto& child : children_) {
     child.value()->zero_grad();
   }
-  for (auto& parameter : parameters_) {
+  for (auto& parameter : named_parameters(/*recurse=*/false)) {
     auto& grad = parameter->grad();
     if (grad.defined()) {
       grad = grad.detach();
@@ -271,10 +264,10 @@ void Module::zero_grad() {
 }
 
 void Module::save(serialize::OutputArchive& archive) const {
-  for (const auto& parameter : parameters_) {
+  for (const auto& parameter : named_parameters(/*recurse=*/false)) {
     archive.write(parameter.key(), parameter.value());
   }
-  for (const auto& buffer : buffers_) {
+  for (const auto& buffer : named_buffers(/*recurse=*/false)) {
     archive.write(buffer.key(), buffer.value(), /*is_buffer=*/true);
   }
   for (const auto& child : children_) {
@@ -287,10 +280,10 @@ void Module::save(serialize::OutputArchive& archive) const {
 }
 
 void Module::load(serialize::InputArchive& archive) {
-  for (auto& parameter : parameters_) {
+  for (auto& parameter : named_parameters(/*recurse=*/false)) {
     archive.read(parameter.key(), parameter.value());
   }
-  for (auto& buffer : buffers_) {
+  for (auto& buffer : named_buffers(/*recurse=*/false)) {
     archive.read(buffer.key(), buffer.value(), /*is_buffer=*/true);
   }
   for (const auto& child : children_) {


### PR DESCRIPTION
PR https://github.com/pytorch/pytorch/pull/30523 attempted to fix https://github.com/pytorch/pytorch/issues/30508 and https://github.com/pytorch/pytorch/issues/30462, but the fix wasn't complete. This PR makes the following improvements:
1. Fixes https://github.com/pytorch/pytorch/issues/30508 and https://github.com/pytorch/pytorch/issues/30462 properly by excluding undefined tensors in the result of `Module::parameters()` / `named_parameters()` / `buffers()` / `named_buffers()`, which mirrors the Python API behavior.
2. Audits all use sites of `Module::parameters_` / `buffers_` and change them to `Module::named_parameters(/*recurse=*/false)` / `named_buffers(/*recurse=*/false)` when appropriate, so that use sites of module parameters / buffers never need to worry about undefined tensors.