### PR TITLE
Remove deprecated fromIvalue in RRefForkData

### DIFF
--- a/torch/csrc/distributed/rpc/rref.cpp
+++ b/torch/csrc/distributed/rpc/rref.cpp
@@ -82,32 +82,6 @@ RRefForkData RRefForkData::fromPyTuple(const py::tuple& t) {
   return RRefForkData(ownerId, rrefId, forkId, parent);
 }
 
-RRefForkData RRefForkData::fromIValue(const at::IValue& ivalue) {
-  auto ivalues = ivalue.toTuple()->elements();
-
-  TORCH_INTERNAL_ASSERT(
-      ivalues.size() == 4,
-      "Constructing RRefForkData from ivalue "
-      "expects a GenericList of 4 elements, but got ",
-      ivalues.size());
-
-  int64_t ownerId = ivalues[0].toInt();
-  TORCH_INTERNAL_ASSERT(
-      ownerId < std::numeric_limits<worker_id_t>::max(),
-      "RRefId createdOn out of range, got ",
-      ownerId);
-
-  RRefId rrefId = RRefId::fromIValue(ivalues[1]);
-  ForkId forkId = ForkId::fromIValue(ivalues[2]);
-
-  int64_t parent = ivalues[3].toInt();
-  TORCH_INTERNAL_ASSERT(
-      parent < std::numeric_limits<worker_id_t>::max(),
-      "RRefId createdOn out of range, got ",
-      parent);
-  return RRefForkData(ownerId, rrefId, forkId, parent);
-}
-
 //////////////////////////////  RRef  /////////////////////////////////////
 
 RRef::RRef(worker_id_t ownerId, const RRefId& rrefId)

--- a/torch/csrc/distributed/rpc/rref.h
+++ b/torch/csrc/distributed/rpc/rref.h
@@ -38,8 +38,6 @@ struct RRefForkData {
       const RRefId& rrefId_,
       const ForkId& forkId_,
       worker_id_t parent);
-
-  static RRefForkData fromIValue(const at::IValue&);
 };
 
 static_assert(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#30646 Remove deprecated fromIvalue in RRefForkData**

Differential Revision: [D18777610](https://our.internmc.facebook.com/intern/diff/D18777610)