### PR TITLE
Check the error return of nvrtcGetProgramLogSize and nvrtcGetProgramLog

### DIFF
--- a/torch/csrc/jit/fuser/cuda/fused_kernel.cpp
+++ b/torch/csrc/jit/fuser/cuda/fused_kernel.cpp
@@ -120,9 +120,9 @@ FusedKernelCUDA::FusedKernelCUDA(
       nvrtc().nvrtcCompileProgram(program, args.size(), args.data());
   if (result != NVRTC_SUCCESS) {
     size_t logsize;
-    nvrtc().nvrtcGetProgramLogSize(program, &logsize);
+    AT_CUDA_NVRTC_CHECK(nvrtc().nvrtcGetProgramLogSize(program, &logsize));
     std::vector<char> log(logsize);
-    nvrtc().nvrtcGetProgramLog(program, log.data());
+    AT_CUDA_NVRTC_CHECK(nvrtc().nvrtcGetProgramLog(program, log.data()));
     std::stringstream cu;
     cu << log.data();
     throw std::runtime_error(cu.str());


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#30663 Check the error return of nvrtcGetProgramLogSize and nvrtcGetProgramLog**

Yes they can fail.  See https://github.com/ROCm-Developer-Tools/HIP/issues/1706

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D18810088](https://our.internmc.facebook.com/intern/diff/D18810088)