### PR TITLE
Moving checks related to options.aliasAnalysis and schema.hasAliasInfo to read callsite

### DIFF
--- a/aten/src/ATen/core/op_registration/op_registration.cpp
+++ b/aten/src/ATen/core/op_registration/op_registration.cpp
@@ -42,12 +42,6 @@ void RegisterOperators::checkSchemaAndRegisterOp_(Options&& options) {
     // schema was explicitly specified. Check it matches the inferred one and register the op.
 
     const FunctionSchema& schema = options.schemaOrName_->right();
-    TORCH_CHECK(
-        options.aliasAnalysisKind_ == AliasAnalysisKind::FROM_SCHEMA ||
-            !schema.hasAnyAliasInfo(),
-        "In operator registration: Tried to register operator ",
-        options.schemaOrName_->right(),
-        " with aliasing information in the schema but without AliasAnalysisKind::FROM_SCHEMA.");
 
     for (auto& kernel : options.kernels) {
       if (nullptr != kernel.inferred_function_schema.get()) {

--- a/torch/csrc/jit/operator.h
+++ b/torch/csrc/jit/operator.h
@@ -150,6 +150,15 @@ struct TORCH_API Operator {
   }
 
   c10::AliasAnalysisKind aliasAnalysisKind() const {
+    if (isC10Op()) {
+      const FunctionSchema& schemaRef = schema();
+      TORCH_CHECK(
+          options_.aliasAnalysis() == AliasAnalysisKind::FROM_SCHEMA ||
+              !schemaRef.hasAnyAliasInfo(),
+          "In operator registration: Tried to register operator ",
+          schemaRef,
+          " with aliasing information in the schema but without AliasAnalysisKind::FROM_SCHEMA.");
+    }
     return options_.aliasAnalysis();
   }
 


### PR DESCRIPTION
Summary:
**Context:**
In D18530964, we allow not set aliasAnalysis at previous registration call, and then update it to the correct one in following registration call.

But its not working E2E due to those existing checks.

So we want to remove or delay those TORCH_CHECKs.

Here is the existing three callsites for operator.aliasAnalysisKind():
https://our.intern.facebook.com/intern/diffusion/FBS/browse/master/fbcode/caffe2/torch/csrc/jit/ir.cpp?lines=994%2C995%2C996%2C1001%2C1004

https://our.intern.facebook.com/intern/diffusion/FBS/browse/master/fbcode/caffe2/torch/csrc/jit/operator.cpp?lines=147%2C155

https://our.intern.facebook.com/intern/diffusion/FBS/browse/master/fbcode/caffe2/torch/csrc/jit/passes/alias_analysis.cpp?lines=260%2C277%2C380

**Things to check**
1. Those two checks are different. But since in original op_registration code, if options.schemaOrName_->is_right() is FALSE, we kind of convert it to FunctionSchema type, so in the read callsites, we only need to check the following: options.aliasAnalysisKind_ == AliasAnalysisKind::FROM_SCHEMA ||  !schema.hasAnyAliasInfo()

2. If the three callsites above are indeed needed for those checks.

3. Here we made assumptions that for reads from jit or other places, its always being called after all registrations calls are done. Trying to make sure its a valid assumption

Test Plan: Will update and refactor the tests soon.

Differential Revision: D18784623

