### PR TITLE
autograd/profiler: support merging FunctionEventAvg

### DIFF
--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -607,12 +607,12 @@ class FunctionEventAvg(FormattedTimesMixin):
             not group_by_input_shapes or
             other.input_shapes == self.input_shapes
         )
-        assert isinstance(other, FunctionEvent)
+        assert isinstance(other, (FunctionEvent, FunctionEventAvg))
         assert other.key == self.key
-        self.cpu_time_total += other.cpu_time
-        self.cuda_time_total += other.cuda_time
+        self.cpu_time_total += other.cpu_time_total
+        self.cuda_time_total += other.cuda_time_total
         self.self_cpu_time_total += other.self_cpu_time_total
-        self.count += 1
+        self.count += other.count
         return self
 
     def __iadd__(self, other):


### PR DESCRIPTION
Summary: Currently you can only add FunctionEvents to FunctionEventAvg. This makes it so you can add multiple FunctionEventAvg objects together. This is useful for merging multiple profiles together such as when dealing with distributed training.

Test Plan:
added unit test

  buck test //caffe2/test:autograd -- test_profiler

Differential Revision: D18785578

