### PR TITLE
Implement backend-agnostic rpc._wait_all_workers() utility

### DIFF
--- a/test/dist_utils.py
+++ b/test/dist_utils.py
@@ -25,30 +25,6 @@ TEST_CONFIG = TestConfig()
 INIT_METHOD_TEMPLATE = "file://{file_name}"
 
 
-MASTER_RANK = 0
-_ALL_NODE_NAMES = set()
-_DONE_NODE_NAMES = set()
-_TERMINATION_SIGNAL = threading.Event()
-
-
-def on_master_follower_report_done(worker_name):
-    assert (
-        worker_name in _ALL_NODE_NAMES
-    ), "{worker_name} is not expected by master.".format(worker_name=worker_name)
-    assert (
-        worker_name not in _DONE_NODE_NAMES
-    ), "{worker_name} report done twice.".format(worker_name=worker_name)
-    _DONE_NODE_NAMES.add(worker_name)
-    if _ALL_NODE_NAMES != _DONE_NODE_NAMES:
-        return
-    set_termination_signal()
-
-
-def set_termination_signal():
-    assert not _TERMINATION_SIGNAL.is_set(), "Termination signal got set twice."
-    _TERMINATION_SIGNAL.set()
-
-
 def dist_init(old_test_method=None, setup_rpc=True, clean_shutdown=True):
     """
     We use this decorator for setting up and tearing down state since
@@ -96,38 +72,7 @@ def dist_init(old_test_method=None, setup_rpc=True, clean_shutdown=True):
         return_value = old_test_method(self, *arg, **kwargs)
 
         if setup_rpc:
-            if clean_shutdown:
-                # Follower reports done.
-                if self.rank == MASTER_RANK:
-                    on_master_follower_report_done("worker{}".format(MASTER_RANK))
-                else:
-                    rpc.rpc_async(
-                        "worker{}".format(MASTER_RANK),
-                        on_master_follower_report_done,
-                        args=("worker{}".format(self.rank),),
-                    )
-
-                # Master waits for followers to report done.
-                # Follower waits for master's termination command.
-                _TERMINATION_SIGNAL.wait()
-                if self.rank == MASTER_RANK:
-                    # Master sends termination command.
-                    futs = []
-                    for dst_rank in range(self.world_size):
-                        # torch.distributed.rpc module does not support sending to self.
-                        if dst_rank == MASTER_RANK:
-                            continue
-                        dst_name = "worker{}".format(dst_rank)
-                        fut = rpc.rpc_async(dst_name, set_termination_signal, args=())
-                        futs.append(fut)
-                    for fut in futs:
-                        assert fut.wait() is None, "Sending termination signal failed."
-
-            # Close RPC. Need to do this even if we don't have a clean shutdown
-            # since we need to shutdown the RPC agent. If we don't shutdown the
-            # RPC agent, tests would fail since RPC agent threads, locks and
-            # condition variables are not properly terminated.
-            rpc.shutdown()
+            rpc.shutdown(graceful=clean_shutdown)
 
         return return_value
 

--- a/test/rpc_test.py
+++ b/test/rpc_test.py
@@ -571,6 +571,44 @@ class RpcTest(RpcAgentTestFixture):
         # it's safe to call shutdown() multiple times
         rpc.shutdown()
 
+    @dist_init(clean_shutdown=False)
+    def test_wait_all_workers(self):
+        # worker0 drives and waits for worker1 and worker2
+        # throughout the test.
+        if self.rank == 0:
+            assert self.world_size >= 3
+
+            num_repeat = 30
+            futs = []
+
+            # Phase 1: Only worker1 has workload.
+            dst = "worker1"
+            for _ in range(num_repeat):
+                fut = rpc.rpc_async(dst, heavy_rpc, args=(torch.ones(100, 100),))
+                futs.append(fut)
+
+            for fut in futs:
+                fut.wait()
+                self.assertEqual(fut.wait(), 0)
+
+            # Phase 2: Only worker2 has workload.
+            # If join is not correctly implemented,
+            # worker2 should be closed by now.
+            dst = "worker2"
+            for _ in range(num_repeat):
+                fut = rpc.rpc_async(dst, heavy_rpc, args=(torch.ones(100, 100),))
+                futs.append(fut)
+
+            for fut in futs:
+                fut.wait()
+                self.assertEqual(fut.wait(), 0)
+
+        # worker0 calls this at the end after waiting for RPC responses.
+        # worker1/2 calls this immediately and has some works after it.
+        # worker3 calls this immediately and has no more work.
+        rpc.api._wait_all_workers()
+        rpc.shutdown(graceful=False)
+
     @dist_init
     def test_expected_src(self):
         dst_rank = (self.rank + 1) % self.world_size
@@ -1170,9 +1208,7 @@ class RpcTest(RpcAgentTestFixture):
         # without sending any messages.
         rpc.init_rpc(
             name="worker%d" % self.rank,
-            backend=rpc.backend_registry.BackendType[
-                dist_utils.TEST_CONFIG.rpc_backend_name
-            ],
+            backend=self.rpc_backend,
             rank=self.rank,
             world_size=self.world_size,
             rpc_backend_options=self.rpc_backend_options,
@@ -1186,9 +1222,7 @@ class RpcTest(RpcAgentTestFixture):
         # test that we can start RPC, send RPCs, and then run local shutdown.
         rpc.init_rpc(
             name="worker%d" % self.rank,
-            backend=rpc.backend_registry.BackendType[
-                dist_utils.TEST_CONFIG.rpc_backend_name
-            ],
+            backend=self.rpc_backend,
             rank=self.rank,
             world_size=self.world_size,
             rpc_backend_options=self.rpc_backend_options,
@@ -1215,7 +1249,7 @@ class RpcTest(RpcAgentTestFixture):
         # multiple times.
         rpc.init_rpc(
             name="worker%d" % self.rank,
-            backend=rpc.backend_registry.BackendType[dist_utils.TEST_CONFIG.rpc_backend_name],
+            backend=self.rpc_backend,
             rank=self.rank,
             world_size=self.world_size,
             rpc_backend_options=self.rpc_backend_options
@@ -1223,7 +1257,7 @@ class RpcTest(RpcAgentTestFixture):
         from torch.distributed.rpc.api import _wait_all_workers
         # intentional call to internal _wait_all_workers.
         _wait_all_workers()
-        rpc.shutdown()
+        rpc.shutdown(graceful=False)
 
     @dist_init(setup_rpc=False)
     def test_get_rpc_timeout(self):

--- a/torch/csrc/distributed/rpc/rpc_agent.h
+++ b/torch/csrc/distributed/rpc/rpc_agent.h
@@ -141,7 +141,6 @@ class TORCH_API RpcAgent {
 
  protected:
   const WorkerInfo workerInfo_;
-  const std::string workerName_;
   const std::unique_ptr<RequestCallback> cb_;
   std::atomic<std::chrono::milliseconds> rpcTimeout_;
 

--- a/torch/distributed/rpc/api.py
+++ b/torch/distributed/rpc/api.py
@@ -16,6 +16,7 @@ import contextlib
 import functools
 import numbers
 import sys
+import threading
 import torch
 import torch.distributed as dist
 
@@ -57,6 +58,28 @@ def _require_initialized(func):
         return func(*args, **kwargs)
     return wrapper
 
+# States used by `def _wait_all_workers():`.
+_ALL_WORKER_NAMES = None
+_DONE_WORKER_NAMES = set()
+_TERMINATION_SIGNAL = threading.Event()
+
+def _on_master_follower_report_done(worker_name):
+    assert (
+        worker_name in _ALL_WORKER_NAMES
+    ), "{worker_name} is not expected by master.".format(worker_name=worker_name)
+    assert (
+        worker_name not in _DONE_WORKER_NAMES
+    ), "{worker_name} reported done twice. ".format(worker_name=worker_name)
+    _DONE_WORKER_NAMES.add(worker_name)
+    if _ALL_WORKER_NAMES != _DONE_WORKER_NAMES:
+        return
+    _set_termination_signal()
+
+
+def _set_termination_signal():
+    assert not _TERMINATION_SIGNAL.is_set(), "Termination signal got set twice."
+    _TERMINATION_SIGNAL.set()
+
 
 def _wait_all_workers():
     r"""
@@ -66,10 +89,45 @@ def _wait_all_workers():
     terminate the RPC framework, and there is no guarantee that the RPC
     framework will work after this method returns.
     """
-    global _agent
+    if _agent is None:
+        return
 
-    if _agent:
-        _agent.join()
+    assert _ALL_WORKER_NAMES is not None, (
+        "`_ALL_WORKER_NAMES` is not initialized for `def wait_all_workers`."
+    )
+    master_worker_name = sorted(_ALL_WORKER_NAMES)[0]
+
+    self_worker_name = _agent.get_worker_info().name
+    assert self_worker_name not in _DONE_WORKER_NAMES, (
+        "Can not call wait_all_workers() twice."
+    )
+
+    is_master_worker = master_worker_name == self_worker_name
+
+    # All follower report done to the master.
+    if is_master_worker:
+        _on_master_follower_report_done(self_worker_name)
+    else:
+        rpc_async(
+            master_worker_name,
+            _on_master_follower_report_done,
+            args=(self_worker_name,),
+        )
+
+    _TERMINATION_SIGNAL.wait()
+
+    # Master's termination signal is the first to be unblocked,
+    # after receiving all followers' done reports.
+    if is_master_worker:
+        # The master sends out termination commands to all followers.
+        futs = []
+        for follower_worker_name in _ALL_WORKER_NAMES - {master_worker_name}:
+            fut = rpc_async(follower_worker_name, _set_termination_signal, args=())
+            futs.append(fut)
+        for fut in futs:
+            ret = fut.wait()
+            assert ret is None, "Sending termination signal failed. {ret}".format(ret=ret)
+
 
 def shutdown(graceful=True):
     r"""
@@ -103,18 +161,19 @@ def shutdown(graceful=True):
         >>> # wait for worker 0 to finish work, and then shutdown.
         >>> rpc.shutdown()
     """
-    global _agent
-    if _agent:
-        if graceful:
-            _wait_all_workers()
-        _destroy_rref_context(_ignore_rref_leak)
-        _agent.shutdown()
-        # clean up python rpc handler in shutdown(), see comments in
-        # PythonRpcHandler::cleanup(), call it in python API because the
-        # cleanup() function has python dependency, it assumes python
-        # interpreter exists
-        _cleanup_python_rpc_handler()
-        _agent = None
+    if _agent is None:
+        return
+
+    if graceful:
+        _wait_all_workers()
+    _destroy_rref_context(_ignore_rref_leak)
+    _agent.shutdown()
+    # clean up python rpc handler in shutdown(), see comments in
+    # PythonRpcHandler::cleanup(), call it in python API because the
+    # cleanup() function has python dependency, it assumes python
+    # interpreter exists
+    _cleanup_python_rpc_handler()
+
 
 # TODO: add a context manager to wrap _init_rpc_backend and shutdown
 def _init_rpc_backend(
@@ -146,6 +205,10 @@ def _init_rpc_backend(
         rpc_backend_options=rpc_backend_options,
     )
     _start_rpc_agent(_agent)
+
+    worker_infos = _agent.get_worker_infos()
+    global _ALL_WORKER_NAMES
+    _ALL_WORKER_NAMES = {worker_info.name for worker_info in worker_infos}
 
 
 @_require_initialized


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#30691 Implement backend-agnostic rpc._wait_all_workers() utility**

We need a backend-agnostic mechanism to do barrier-like operation before locally destroy RRef context and shutdown RPC Agent.

Differential Revision: [D18643137](https://our.internmc.facebook.com/intern/diff/D18643137/)