### PR TITLE
[v1.4.0 cherrypick] Remove namespace F = torch::nn::functional from torch/nn/modules/batchnorm.h

### DIFF
--- a/torch/csrc/api/include/torch/nn/modules/batchnorm.h
+++ b/torch/csrc/api/include/torch/nn/modules/batchnorm.h
@@ -9,8 +9,6 @@
 
 #include <cstdint>
 
-namespace F = torch::nn::functional;
-
 namespace torch {
 namespace nn {
 
@@ -178,7 +176,7 @@ class BatchNormImplBase : public NormImplBase<D, Derived, BatchNormOptions> {
       }
     }
 
-    return F::detail::batch_norm(
+    return torch::nn::functional::detail::batch_norm(
         input,
         this->running_mean,
         this->running_var,

--- a/torch/csrc/api/include/torch/nn/modules/instancenorm.h
+++ b/torch/csrc/api/include/torch/nn/modules/instancenorm.h
@@ -14,7 +14,7 @@ class InstanceNormImpl : public torch::nn::NormImplBase<D, Derived, InstanceNorm
 
   Tensor forward(const Tensor& input) {
     this->_check_input_dim(input);
-    return F::detail::instance_norm(
+    return torch::nn::functional::detail::instance_norm(
       input, this->running_mean, this->running_var, this->weight, this->bias,
       this->is_training() || !this->options.track_running_stats(), this->options.momentum(), this->options.eps());
   }


### PR DESCRIPTION
This PR removes `namespace F = torch::nn::functional` from `torch/nn/modules/batchhnorm.h`, so that people don't have to define `torch::nn::functional` as `F` if they don't want to.

Fixes https://github.com/pytorch/pytorch/issues/30682.