### PR TITLE
[v1.4.0 patch] By default ignore RRef leaks during shutdown (#30217)

### DIFF
--- a/test/dist_utils.py
+++ b/test/dist_utils.py
@@ -72,6 +72,11 @@ def dist_init(old_test_method=None, setup_rpc=True, clean_shutdown=True):
 
     @wraps(old_test_method)
     def new_test_method(self, *arg, **kwargs):
+        # Setting _ignore_rref_leak to make sure OwnerRRefs are properly deleted
+        # in tests.
+        import torch.distributed.rpc.api as api
+        api._ignore_rref_leak = False
+
         self.worker_id = self.rank
 
         if setup_rpc:

--- a/test/rpc_test.py
+++ b/test/rpc_test.py
@@ -1086,6 +1086,49 @@ class RpcTest(RpcAgentTestFixture):
 
         self.assertEqual(result, sum(vals))
 
+    def _test_rref_leak(self, ignore_leak=False):
+        rpc.init_rpc(
+            name="worker{}".format(self.rank),
+            backend=self.rpc_backend,
+            rank=self.rank,
+            world_size=self.world_size,
+            rpc_backend_options=self.rpc_backend_options,
+        )
+
+        # This is for the below `dist.barrier`.
+        # For `RpcAgent` other than `ProcessGroupAgent`,
+        # no `_default_pg` is initialized.
+        if not dist.is_initialized():
+            dist.init_process_group(
+                backend="gloo",
+                init_method=self.init_method,
+                rank=self.rank,
+                world_size=self.world_size,
+            )
+        # Wait for all init to complete.
+        dist.barrier()
+
+        rref = rpc.remote(
+            "worker{}".format((self.rank + 1) % self.world_size),
+            torch.add,
+            args=(torch.ones(2, 2), 1)
+        )
+
+        if ignore_leak:
+            import torch.distributed.rpc.api as api
+            api._ignore_rref_leak = True
+
+        rpc.wait_all_workers()
+
+    @dist_init(setup_rpc=False)
+    def test_rref_leak(self):
+        with self.assertRaisesRegex(RuntimeError, "Leaking RRef"):
+            self._test_rref_leak()
+
+    @dist_init(setup_rpc=False)
+    def test_ignore_rref_leak(self):
+        self._test_rref_leak(ignore_leak=True)
+
     @dist_init(setup_rpc=False)
     def test_get_rpc_timeout(self):
         timeout = timedelta(seconds=1)

--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -165,8 +165,8 @@ Otherwise, throws an exception.
     agent->start();
   });
 
-  module.def("_destroy_rref_context", []() {
-    RRefContext::getInstance().destroyInstance();
+  module.def("_destroy_rref_context", [](bool ignoreRRefLeak) {
+    RRefContext::getInstance().destroyInstance(ignoreRRefLeak);
   });
 
   module.def("_cleanup_python_rpc_handler", []() {

--- a/torch/csrc/distributed/rpc/rref.cpp
+++ b/torch/csrc/distributed/rpc/rref.cpp
@@ -136,15 +136,16 @@ UserRRef<T>::UserRRef(
 
 template <typename T>
 UserRRef<T>::~UserRRef() {
-  // TODO: queue this in RRefContext instead of doing it here.
-  auto& ctx = RRefContext::getInstance();
-  if (ctx.getWorkerId() != ownerId_) {
-    auto fm = ctx.agent()->send(
-        ctx.agent()->getWorkerInfo(ownerId_),
-        RRefUserDelete(rrefId_, forkId_).toMessage());
-
-    fm->addCallback(
-        [](const Message& message) { RRefContext::handleException(message); });
+  try {
+    RRefContext::getInstance().delUser(ownerId_, rrefId_, forkId_);
+  } catch (const std::exception& ex) {
+    LOG(ERROR) << "Error occurred when deleting UserRRef instance, "
+               << "RRefId = " << rrefId_ << ", ForkId = " << forkId_ << " : "
+               << ex.what();
+  } catch (...) {
+    LOG(ERROR) << "Error occurred when deleting UserRRef instance, "
+               << "RRefId = " << rrefId_ << ", ForkId = " << forkId_ << " : "
+               << "unknown error";
   }
 }
 

--- a/torch/csrc/distributed/rpc/rref_context.cpp
+++ b/torch/csrc/distributed/rpc/rref_context.cpp
@@ -13,8 +13,13 @@ RRefContext& RRefContext::getInstance() {
   return *context;
 }
 
-void RRefContext::destroyInstance() {
-  RRefContext::getInstance().checkRRefLeaks();
+void RRefContext::destroyInstance(bool ignoreRRefLeak) {
+  auto& ctx = RRefContext::getInstance();
+  {
+    std::lock_guard<std::mutex> lock(ctx.destroyedMutex_);
+    ctx.destroyed_ = true;
+  }
+  ctx.checkRRefLeaks(ignoreRRefLeak);
 }
 
 void RRefContext::handleException(const Message& message) {
@@ -27,7 +32,7 @@ void RRefContext::handleException(const Message& message) {
 }
 
 RRefContext::RRefContext(std::shared_ptr<RpcAgent> agent)
-    : agent_(std::move(agent)) {}
+    : agent_(std::move(agent)), destroyed_(false) {}
 
 RRefContext::~RRefContext() {
   if (!owners_.empty()) {
@@ -36,7 +41,7 @@ RRefContext::~RRefContext() {
   }
 }
 
-void RRefContext::checkRRefLeaks() {
+void RRefContext::checkRRefLeaks(bool ignoreRRefLeak) {
   if (!forks_.empty()) {
     std::stringstream ss;
     for (auto& entry : forks_) {
@@ -46,7 +51,21 @@ void RRefContext::checkRRefLeaks() {
            << std::endl;
       }
     }
-    AT_ERROR(ss.str());
+
+    if (ignoreRRefLeak) {
+      LOG(WARNING)
+          << "Detected RRef Leaks during shutdown. This usually "
+          << "occurs when the application code still holds references to RRef "
+          << "instances when calling shutdown(). If the program has "
+          << "completed correctly and the process is exiting, it is OK to "
+          << "ignore these leaks. However, if you program will keep running "
+          << "after this, these leaks could result in memory leaks on RRef "
+          << "owners. Please make sure all RRefs are out of scope and Python "
+          << "GC has deleted them before calling shutdown(): \n"
+          << ss.str();
+    } else {
+      AT_ERROR(ss.str());
+    }
   }
 }
 
@@ -95,6 +114,21 @@ template std::shared_ptr<UserRRef<py::object>> RRefContext::createUserRRef<
     worker_id_t ownerId,
     const RRefId& rrefId,
     const ForkId& forkId);
+
+void RRefContext::delUser(
+    const worker_id_t owner,
+    const RRefId& rrefId,
+    const ForkId& forkId) {
+  std::lock_guard<std::mutex> lock(destroyedMutex_);
+  if (!destroyed_) {
+    auto fm = agent_->send(
+        agent_->getWorkerInfo(owner),
+        RRefUserDelete(rrefId, forkId).toMessage());
+
+    fm->addCallback(
+        [](const Message& message) { RRefContext::handleException(message); });
+  }
+}
 
 template <typename T>
 std::shared_ptr<RRef> RRefContext::getOrCreateRRef(const RRefForkData& rfd) {

--- a/torch/csrc/distributed/rpc/rref_context.h
+++ b/torch/csrc/distributed/rpc/rref_context.h
@@ -16,7 +16,7 @@ namespace rpc {
 class RRefContext {
  public:
   static RRefContext& getInstance();
-  static void destroyInstance();
+  static void destroyInstance(bool ignoreRRefLeak = true);
 
   static void handleException(const Message& message);
 
@@ -111,6 +111,11 @@ class RRefContext {
   void addPendingUser(const ForkId& forkId, const std::shared_ptr<RRef>& rref);
   void delPendingUser(const ForkId& forkId);
 
+  void delUser(
+      const worker_id_t owner,
+      const RRefId& rrefId,
+      const ForkId& forkId);
+
  private:
   RRefContext(std::shared_ptr<RpcAgent>);
 
@@ -123,7 +128,7 @@ class RRefContext {
   void finishForkRequest(const ForkId& forkId, worker_id_t parent);
 
   // If there is any leak on any RRef, this method will throw an error.
-  void checkRRefLeaks();
+  void checkRRefLeaks(bool ignoreRRefLeak);
 
   static std::atomic<local_id_t> nextLocalId_;
 
@@ -157,6 +162,9 @@ class RRefContext {
   //     owner learns about the forked child.
   std::unordered_map<ForkId, std::shared_ptr<RRef>, ForkId::Hash>
       pendingChildren_;
+
+  std::mutex destroyedMutex_;
+  bool destroyed_;
 };
 
 } // namespace rpc

--- a/torch/distributed/rpc/api.py
+++ b/torch/distributed/rpc/api.py
@@ -21,7 +21,16 @@ import torch.distributed as dist
 
 
 _agent = None
-
+# NB: Ignoring RRef leaks during shutdown. Without this, applications have to
+# make sure there is no references to any RRef in the application code and
+# Python GC has done its job to delete those RRefs. This is could result in bad
+# debugging experiences especially when for large applications. Therefore, by
+# default, we are going to ignore RRef leaks during shutdown. This is usually
+# fine as shutdown means applications have done training and no longer care
+# about states.
+#
+# To enable RRef leak checking, set this _ignore_rref_leak to False
+_ignore_rref_leak = True
 _default_pickler = _internal_rpc_pickler
 
 @contextlib.contextmanager
@@ -35,6 +44,7 @@ def _use_rpc_pickler(rpc_pickler):
         yield
     finally:
         _default_pickler = _internal_rpc_pickler
+
 
 def _require_initialized(func):
     @functools.wraps(func)
@@ -76,7 +86,7 @@ def wait_all_workers():
     if _agent:
         _agent.join()
         _agent = None
-        _destroy_rref_context()
+        _destroy_rref_context(_ignore_rref_leak)
         # clean up python rpc handler in wait_all_workers(), see comments in
         # PythonRpcHandler::cleanup(), call it in python API because the
         # cleanup() function has python dependency, it assumes python


### PR DESCRIPTION
Summary:
Note: This PR has been merged into master at efe1859 after the 1.4 branch cut (see original PR: #30217). This PR is to merge it into the 1.4 branch.

---- Original Commit Description Follows ---

Before this commit, RRefContext throws an error if it detects any
RRef leak during shutdown. However, this requires applications to
make sure that is has freed all references to RRefs in application
code, which can be a bad debugging experience when for large
applications. Besides, this also relies on Python GC to free things
up in time, which might not always be true. After this commit,
RRefContext would ignore leaking RRefs during shutdown, as shutdown
is called when the application has finished training and no longer
care about local states. Hence, it should be OK to just ignore
those leaks and destroy OwnerRRefs. If application would like to
enforce no leaks, just set torch.distributed.rpc.api._ignore_rref_leak
to False.