### PR TITLE
[wip] record rpc functions to expose them in autograd profiler

### DIFF
--- a/test/rpc_test.py
+++ b/test/rpc_test.py
@@ -1240,3 +1240,13 @@ class RpcTest(RpcAgentTestFixture):
         with _use_rpc_pickler(test_pickler):
             self.assertTrue(torch.distributed.rpc.api._default_pickler is test_pickler)
         self.assertTrue(torch.distributed.rpc.api._default_pickler is _internal_rpc_pickler)
+
+    @dist_init(setup_rpc=True)
+    def test_profiler(self):
+        dst_rank = (self.rank + 1) % self.world_size
+        with torch.autograd.profiler.profile() as prof:
+            rpc.rpc_sync("worker{}".format(dst_rank), my_sleep_func, args=(7,))
+        averages = prof.key_averages()
+        print(averages.table(sort_by='self_cpu_time_total'))
+
+

--- a/torch/csrc/distributed/rpc/python_functions.cpp
+++ b/torch/csrc/distributed/rpc/python_functions.cpp
@@ -187,6 +187,8 @@ std::shared_ptr<FutureMessage> pyRpcPythonUdf(
     const WorkerInfo& dst,
     std::string& pickledPythonUDF,
     std::vector<torch::Tensor>& tensors) {
+  RECORD_FUNCTION("pyRpcPythonUdf", std::vector<c10::IValue>());
+
   auto pythonCall = c10::guts::make_unique<PythonCall>(
       std::vector<char>(pickledPythonUDF.begin(), pickledPythonUDF.end()),
       tensors);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#30700 [wip] record rpc functions to expose them in autograd profiler**
(Not yet ready for review)
Adds RECORD_FUNCTION macro calls to RPC code, so that the functions
can be recorded in the autograd profiler. This will allow users to see things
such as the CPU time spent in these functions when they use the profiler.

Differential Revision: [D18800095](https://our.internmc.facebook.com/intern/diff/D18800095/)