### PR TITLE
[jit] fix tuple type co-variant rule

### DIFF
--- a/aten/src/ATen/core/type.cpp
+++ b/aten/src/ATen/core/type.cpp
@@ -511,7 +511,9 @@ bool TupleType::isSubtypeOfExt(const TypePtr rhs_, std::ostream* why_not) const 
   bool names_match = !rhs->schema() || test_names_match(schema(), rhs->schema());
   // co-variant rules for tuples
   return names_match && compare(*rhs, [&](const TypePtr a, const TypePtr b) {
-    return a->isSubtypeOfExt(b, why_not);
+    auto unshaped_a = unshapedType(a);
+    auto unshaped_b = unshapedType(b);
+    return unshaped_a->isSubtypeOfExt(unshaped_b, why_not);
   });
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #29751 [jit] Support named tuple in tracing
* **#30706 [jit] fix tuple type co-variant rule**

Summary:
Since tuple are immutable. For tuple type that are co-variant with each other, we should compare
the unshaped inner element types instead to allow the covariance.

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: