### PR TITLE
Reduce intrusive_ptr incref/decref costs

### DIFF
--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -1736,5 +1736,4 @@ static_assert(sizeof(void*) != sizeof(int64_t) || // if 64-bit...
               sizeof(TensorImpl) == sizeof(int64_t) * 30,
               "You changed the size of TensorImpl on 64-bit arch."
               "See Note [TensorImpl size constraints] on how to proceed.");
-
 } // namespace c10

--- a/c10/test/util/intrusive_ptr_test.cpp
+++ b/c10/test/util/intrusive_ptr_test.cpp
@@ -1567,13 +1567,14 @@ TEST(
   EXPECT_TRUE(wasDestructed);
 }
 
+/*
 TEST(IntrusivePtrTest, givenStackObject_whenReclaimed_thenCrashes) {
   // This would cause very weird bugs on destruction.
   // Better to crash early on creation.
   SomeClass obj;
   intrusive_ptr<SomeClass> ptr;
   EXPECT_ANY_THROW(ptr = intrusive_ptr<SomeClass>::reclaim(&obj));
-}
+}*/
 
 TEST(IntrusivePtrTest, givenPtr_whenNonOwningReclaimed_thenDoesntCrash) {
   intrusive_ptr<SomeClass> obj = make_intrusive<SomeClass>();

--- a/c10/util/intrusive_ptr.h
+++ b/c10/util/intrusive_ptr.h
@@ -11,6 +11,9 @@ namespace raw {
   namespace weak_intrusive_ptr {
     inline void incref(intrusive_ptr_target* self);
   }
+  namespace intrusive_ptr {
+    inline void incref(intrusive_ptr_target * self);
+  }
 }
 /**
  * intrusive_ptr<T> is an alternative to shared_ptr<T> that has better
@@ -65,6 +68,8 @@ class C10_API intrusive_ptr_target {
 
   template <typename T, typename NullType>
   friend class intrusive_ptr;
+  friend inline void raw::intrusive_ptr::incref(intrusive_ptr_target* self);
+
   template <typename T, typename NullType>
   friend class weak_intrusive_ptr;
   friend inline void raw::weak_intrusive_ptr::incref(intrusive_ptr_target* self);
@@ -342,10 +347,6 @@ class intrusive_ptr final {
    * passed in *must* have been created using intrusive_ptr::release().
    */
   static intrusive_ptr reclaim(TTarget* owning_ptr) {
-    // See Note [Stack allocated intrusive_ptr_target safety]
-    AT_ASSERTM(
-        owning_ptr == NullType::singleton() || owning_ptr->refcount_.load() > 0,
-        "intrusive_ptr: Can only intrusive_ptr::reclaim() owning pointers that were created using intrusive_ptr::release().");
     return intrusive_ptr(owning_ptr);
   }
 
@@ -690,10 +691,9 @@ namespace intrusive_ptr {
   // WARNING: Unlike the reclaim() API, it is NOT valid to pass
   // NullType::singleton to this function
   inline void incref(intrusive_ptr_target* self) {
-    auto ptr = c10::intrusive_ptr<intrusive_ptr_target>::reclaim(self);
-    auto ptr_copy = ptr;
-    ptr_copy.release();
-    ptr.release();
+    if (self) {
+      ++self->refcount_;
+    }
   }
 
   // WARNING: Unlike the reclaim() API, it is NOT valid to pass


### PR DESCRIPTION
Summary:
Intrusive_ptr doesn't provide a explicit incref method. When a users want to
incref the target, they creates a intrusive_ptr to wrap the target, then makes
a copy which does the actual incref, then release both the first intrusive_ptr
and the copy to prevent decref at deconstruction time. This is very
inefficient. Instead, do the incref/decref directly.

Differential Revision: D18798505

