### PR TITLE
move MaskedAdagrad to caffe2/operators/experimental/optimizers

### DIFF
--- a/caffe2/operators/experimental/optimizers/masked_adagrad.cpp
+++ b/caffe2/operators/experimental/optimizers/masked_adagrad.cpp
@@ -1,0 +1,399 @@
+#include <shared_mutex>
+
+#include "caffe2/sgd/adagrad_op.h"
+#include "caffe2/utils/math.h"
+
+namespace caffe2 {
+namespace {
+
+class MaskedAdagradOp final : public Operator<CPUContext> {
+ public:
+  MaskedAdagradOp(const OperatorDef& operator_def, Workspace* ws)
+      : Operator<CPUContext>(operator_def, ws),
+        epsilon_(this->template GetSingleArgument<float>("epsilon", 1e-5)),
+        decay_(this->template GetSingleArgument<float>("decay", 1.0f)) {}
+
+  bool RunOnDevice() override {
+    Output(OUTPUT_PARAM)->ResizeLike(Input(PARAM));
+    Output(OUTPUT_MOMENT_1)->ResizeLike(Input(MOMENT_1));
+    int N = Input(GRAD).numel();
+    const float* w = Input(PARAM).template data<float>();
+    const float* g = Input(GRAD).template data<float>();
+    const float* h = Input(MOMENT_1).template data<float>();
+    const float* mask = Input(MASK).template data<float>();
+    float* nw = Output(OUTPUT_PARAM)->template mutable_data<float>();
+    float* nh = Output(OUTPUT_MOMENT_1)->template mutable_data<float>();
+    float lr = Input(LR).template data<float>()[0];
+    for (auto i = 0; i < N; ++i) {
+      float gi = g[i];
+      float hi = decay_ * h[i] + gi * gi;
+      nh[i] = mask[i] * hi;
+      nw[i] = mask[i] * (w[i] + lr / (std::sqrt(hi) + epsilon_) * gi);
+    }
+    return true;
+  }
+
+ protected:
+  float epsilon_;
+  float decay_;
+  INPUT_TAGS(PARAM, MOMENT_1, GRAD, LR, MASK);
+  OUTPUT_TAGS(OUTPUT_PARAM, OUTPUT_MOMENT_1);
+};
+
+class MaskedSparseAdagradOp final : public Operator<CPUContext> {
+ public:
+  MaskedSparseAdagradOp(const OperatorDef& operator_def, Workspace* ws)
+      : Operator<CPUContext>(operator_def, ws),
+        epsilon_(this->template GetSingleArgument<float>("epsilon", 1e-5)),
+        block_size_(this->template GetSingleArgument<int>("block_size", 1)),
+        delays_(this->template GetRepeatedArgument<int>("delays")),
+        prune_ratios_(
+            this->template GetRepeatedArgument<float>("prune_ratios")) {}
+
+  bool RunOnDevice() override {
+    return DispatchHelper<TensorTypes<int32_t, int64_t>>::call(
+        this, Input(INDICES));
+  }
+
+  template <typename SIndex>
+  bool DoRunWithType() {
+    const float* lr = Input(LR).template data<float>();
+    Output(OUTPUT_PARAM)->ResizeLike(Input(PARAM));
+    Output(OUTPUT_MOMENT_1)->ResizeLike(Input(MOMENT_1));
+
+    auto n = Input(INDICES).numel();
+
+    const SIndex* indices = Input(INDICES).template data<SIndex>();
+    const float* gradIn = Input(GRAD).template data<float>();
+    const float* paramIn = Input(PARAM).template data<float>();
+    const float* momentIn = Input(MOMENT_1).template data<float>();
+    float* paramOut = Output(OUTPUT_PARAM)->template mutable_data<float>();
+    float* momentOut = Output(OUTPUT_MOMENT_1)->template mutable_data<float>();
+
+    if (n == 0) {
+      return true;
+    }
+    auto row_size = Input(GRAD).numel() / n;
+
+    // Enforce:
+    // input(embedding/momentum) == outputs(embedding/momentum)
+    CAFFE_ENFORCE_EQ(
+        Input(PARAM).numel(),
+        Input(MOMENT_1).numel(),
+        "Input Param size: ",
+        Input(PARAM).numel(),
+        " Input Moment size: ",
+        Input(MOMENT_1).numel());
+
+    // input(grad) is compatible with size of indexes
+    CAFFE_ENFORCE_EQ(
+        Input(GRAD).numel() % n,
+        0,
+        "Incorrect gradient size:",
+        Input(GRAD).numel(),
+        " size of indexes:",
+        n);
+
+    bool mask_changed = false;
+    bool write_lock_acquired = false;
+    if (delays_.empty()) {
+      mask_changed = Input(MASK_CHANGED).data<bool>()[0];
+    } else {
+      // If delay is present, prune_rate also should be there
+      CAFFE_ENFORCE(!prune_ratios_.empty());
+      CAFFE_ENFORCE_EQ(delays_.size(), prune_ratios_.size());
+
+      std::int64_t iteration = Input(ITER).template data<std::int64_t>()[0];
+
+      auto delay_itr = std::find(delays_.begin(), delays_.end(), iteration);
+      if (delay_itr != delays_.end()) {
+        // If the current iteration matches with one of delays, we update mask
+        float prune_ratio = prune_ratios_.at(delay_itr - delays_.begin());
+
+        // Take an exclusive ownership of masks and weights
+        lock_.lock();
+        write_lock_acquired = true;
+        UpdateMask_(prune_ratio);
+        mask_changed = true;
+      }
+    }
+
+    int num_blocks_per_row = (row_size + block_size_ - 1) / block_size_;
+    int bitmask_bytes_per_row = (num_blocks_per_row + 7) / 8;
+
+    // Get mask
+    const uint8_t* bitmask = nullptr;
+    if (delays_.empty()) {
+      // If delays argument is empty, get from MASK input
+      bitmask = Input(MASK).data<uint8_t>();
+    } else if (OutputSize() > MASK_OUT) {
+      // If MASK_OUT is present, the blob stores bitmask
+      if (Output(MASK_OUT)->numel()) {
+        bitmask = Output(MASK_OUT)->data<uint8_t>();
+      }
+    } else {
+      // Otherwise, the operator keeps the mask internally.
+      bitmask = bitmask_.get();
+    }
+
+    if (mask_changed && bitmask) {
+      if (!write_lock_acquired) {
+        lock_.lock();
+        write_lock_acquired = true;
+      }
+      // If mask has changed, update the whole table using the new mask.
+      for (int i = 0; i < Input(PARAM).dim32(0); ++i) {
+        for (int j = 0; j < row_size; ++j) {
+          int j_block = j / block_size_;
+          int byte = j_block / 8;
+          int bit = j_block % 8;
+          bool mask = bitmask[i * bitmask_bytes_per_row + byte] & (1 << bit);
+          if (!mask) {
+            momentOut[i * row_size + j] = 0;
+            paramOut[i * row_size + j] = 0;
+          }
+        }
+      }
+    }
+    if (write_lock_acquired) {
+      lock_.unlock();
+    }
+
+    // Acquire read lock
+    lock_.lock_shared();
+
+    // The actual SparseAdagrad update
+    for (int i = 0; i < n; ++i) {
+      std::size_t idx = indices[i];
+      auto offsetI = i * row_size;
+      auto offsetIdx = idx * row_size;
+
+      // Enforce:
+      // access within range
+      // gradient access within range
+      CAFFE_ENFORCE_GE(
+          Input(PARAM).numel(),
+          row_size + offsetIdx,
+          this->debug_def().input(PARAM),
+          ", out of bound,  idx:",
+          idx,
+          " for input i:",
+          i,
+          " and block size:",
+          row_size,
+          " max size:",
+          Input(PARAM).numel());
+
+      // TODO: performance can be optimized using intrinsics later.
+      for (int j = 0; j < row_size; ++j) {
+        // Get mask
+        bool mask = true;
+        if (bitmask) {
+          int j_block = j / block_size_;
+          int byte = j_block / 8;
+          int bit = j_block % 8;
+          mask = bitmask[idx * bitmask_bytes_per_row + byte] & (1 << bit);
+        }
+
+        // Actual Adagrad update
+        float gi = gradIn[offsetI + j];
+        if (mask) {
+          float hi = momentOut[offsetIdx + j] =
+              momentIn[offsetIdx + j] + gi * gi;
+          paramOut[offsetIdx + j] =
+              paramIn[offsetIdx + j] + lr[0] / (std::sqrt(hi) + epsilon_) * gi;
+        } else {
+          momentOut[offsetIdx + j] = 0;
+          paramOut[offsetIdx + j] = 0;
+        }
+      }
+    }
+
+    // Release read lock
+    lock_.unlock_shared();
+
+    return true;
+  }
+
+ private:
+  void UpdateMask_(float prune_ratio) {
+    auto n = Input(INDICES).numel();
+    auto row_size = Input(GRAD).numel() / n;
+
+    // Create a temp buffer to store norm square of each block
+    int num_rows = Input(PARAM).numel() / row_size;
+    int num_blocks_per_row = (row_size + block_size_ - 1) / block_size_;
+    std::vector<float> norm_sq_buffer(num_rows * num_blocks_per_row);
+    const float* param = Input(PARAM).template data<float>();
+    for (int i = 0; i < num_rows; ++i) {
+      for (int j_block = 0; j_block < num_blocks_per_row; ++j_block) {
+        float norm_sq = 0;
+        for (int j = j_block * block_size_;
+             j < std::min<int>((j_block + 1) * block_size_, row_size);
+             ++j) {
+          norm_sq += param[i * row_size + j] * param[i * row_size + j];
+        }
+        norm_sq_buffer[i * num_blocks_per_row + j_block] = norm_sq;
+      }
+    }
+
+    // Create a temp buffer to store partially sorted results
+    int num_blocks_to_prune =
+        std::floor(num_rows * num_blocks_per_row * prune_ratio);
+    std::vector<float> norm_sq_partially_sorted(num_blocks_to_prune);
+    std::partial_sort_copy(
+        norm_sq_buffer.begin(),
+        norm_sq_buffer.end(),
+        norm_sq_partially_sorted.begin(),
+        norm_sq_partially_sorted.end());
+
+    // Determine threshold
+    float threshold =
+        norm_sq_partially_sorted.empty() ? 0 : norm_sq_partially_sorted.back();
+
+    // Create bitmask
+    uint8_t* bitmask = nullptr;
+    // For each row, we start a new byte in bitmask
+    int bitmask_bytes_per_row = (num_blocks_per_row + 7) / 8;
+
+    if (OutputSize() > MASK_OUT) {
+      Output(MASK_OUT)->Resize(num_rows, bitmask_bytes_per_row);
+      bitmask = Output(MASK_OUT)->mutable_data<uint8_t>();
+    } else {
+      if (!bitmask_) {
+        bitmask_.reset(new uint8_t[num_rows * bitmask_bytes_per_row]);
+      }
+      bitmask = bitmask_.get();
+    }
+
+    for (int i = 0; i < num_rows; ++i) {
+      for (int j_block = 0; j_block < num_blocks_per_row; ++j_block) {
+        int byte = j_block / 8;
+        int bit = j_block % 8;
+        if (bit == 0) {
+          bitmask[i * bitmask_bytes_per_row + byte] = 0;
+        }
+        int current_bitmask =
+            norm_sq_buffer[i * num_blocks_per_row + j_block] >= threshold;
+        bitmask[i * bitmask_bytes_per_row + byte] |= current_bitmask << bit;
+      }
+    }
+  } // UpdateMask_
+
+  float epsilon_;
+  int block_size_;
+  std::vector<int> delays_;
+  std::vector<float> prune_ratios_;
+
+  std::unique_ptr<uint8_t[]> bitmask_;
+
+  // A read-write lock to prevent access to weights while mask is being updated
+  // or weights are being pruned.
+  // Having a single global lock is overly protective but should be good for
+  // now for experimentations.
+  static std::shared_mutex lock_;
+
+  INPUT_TAGS(PARAM, MOMENT_1, INDICES, GRAD, LR, MASK, MASK_CHANGED, ITER);
+  OUTPUT_TAGS(OUTPUT_PARAM, OUTPUT_MOMENT_1, MASK_OUT);
+};
+
+std::shared_mutex MaskedSparseAdagradOp::lock_;
+
+REGISTER_CPU_OPERATOR(MaskedAdagrad, MaskedAdagradOp);
+OPERATOR_SCHEMA(MaskedAdagrad)
+    .NumInputs(5)
+    .NumOutputs(2)
+    .AllowInplace({{0, 0}, {1, 1}})
+    .SetDoc(R"DOC(
+
+Masked version of AdaGrad.
+Concretely, given inputs (param, grad, moment, learning_rate, mask),
+computes
+    new_moment = moment + square(grad) if mask == 1 else 0
+    effective_lr = learning_rate / (sqrt(new_moment) + epsilon)
+    update = learning_rate * grad / (sqrt(new_moment) + epsilon)
+    new_param = param + update if mask == 1 else 0
+and returns (new_param, new_moment).
+
+)DOC")
+    .Input(0, "param", "Parameters to be updated")
+    .Input(1, "moment", "Moment history")
+    .Input(2, "grad", "Gradient computed")
+    .Input(3, "lr", "learning rate")
+    .Input(
+        4,
+        "mask",
+        "masks (element type is float because it helps performance "
+        "and the size is not a big concern for dense parameters typically")
+    .Output(0, "output_param", "Updated parameters")
+    .Output(1, "output_moment", "Updated moment")
+
+    .Arg("epsilon", "Default 1e-5")
+    .Arg(
+        "decay",
+        "Default 1. If it is in (0, 1), the gradient square sum "
+        "is decayed by this factor.");
+
+REGISTER_CPU_OPERATOR(MaskedSparseAdagrad, MaskedSparseAdagradOp);
+OPERATOR_SCHEMA(MaskedSparseAdagrad)
+    .NumInputs(6, 8)
+    .NumOutputs(2, 3)
+    .EnforceInplace({{0, 0}, {1, 1}})
+    .SetDoc(R"DOC(
+
+Masked version of SparseAdagrad.
+There are two modes of using MaskedSparseAdagrad.
+
+The first mode is we feed mask and mask_changed inputs.
+When mask_changed is 1, we apply mask to the entire param and moment, instead
+of just the rows corresponding to indices. If we don't apply mask_changed when
+we input a new mask, we will have a problem that rows never touched will stay
+unpruned. This mode is more flexible because it allows providing arbitrary
+mask that could be generated by running sophisticated offline methods.
+
+The second mode is we provide delays and prune_ratios arguments, and let the
+operator generate masks internally. This allows a quick experimentation using
+simple (iterative) magnitude-based pruning. If delays and prune_ratios
+arguments are present, mask and mask_changed inputs will be ignored. delays and
+prune_ratios arguments should have the same lengths. For example, if delays =
+[1000, 2000, 3000] and prune_ratios = [0.5, 0.7, 0.9], the operator will create
+a mask for 50% sparsity at iteration 1000, a mask for 70% sparsity at iteration
+2000, and so on. Whenever we change the prune_ratios, we apply the updated mask
+to the entire param and moment. Otherwise, we apply the mask only the rows
+accessed via indices.
+
+)DOC")
+    .Input(0, "param", "Parameters to be updated")
+    .Input(1, "moment", "Moment history")
+    .Input(2, "indices", "Sparse indices")
+    .Input(3, "grad", "Gradient computed")
+    .Input(4, "lr", "learning rate")
+    .Input(5, "mask", "Bit mask in uint8_t. Ignored when delay is provided")
+    .Input(
+        6,
+        "mask_changed",
+        "1 boolean value to indicate whether mask has changed")
+    .Input(
+        7,
+        "iter",
+        "Optional input to feed iteration count in int32_t. "
+        "Only effective with delays and prune_ratios arguments are present")
+    .Output(0, "output_param", "Updated parameters")
+    .Output(1, "output_moment_1", "Updated moment")
+    .Output(
+        2,
+        "mask_out",
+        "Optional output to observe bit mask (in uint8_t) generated "
+        "internally. Only effective with delays and prune_ratios arguments "
+        "are present.")
+    .Arg("epsilon", "Default 1e-5")
+    .Arg("block_size", "Default 1")
+    .Arg(
+        "delays",
+        "Optional arg to internally generate mask and control when we change "
+        "prune ratios. Must be provided with prune_rates argument."
+        "If present mask and mask_changed inputs are ignored")
+    .Arg("prune_ratios", "Optional arg to control prune rates");
+
+} // anonymous namespace
+} // namespace caffe2

--- a/caffe2/operators/experimental/optimizers/masked_adagrad_test.py
+++ b/caffe2/operators/experimental/optimizers/masked_adagrad_test.py
@@ -1,0 +1,282 @@
+from __future__ import absolute_import, division, print_function
+
+import caffe2.python.hypothesis_test_util as hu
+import hypothesis.strategies as st
+import numpy as np
+from caffe2.python import core, dyndep, workspace
+from hypothesis import given
+
+
+dyndep.InitOpsLibrary(
+    "//caffe2/caffe2/operators/experimental/optimizers:sgd_masked_ops"
+)
+
+
+# Create a mask for magnitude-based block-structured pruning of param with
+# prune_ratio. Block sparsity structure is applied per row not across rows.
+def _get_mask(param, block_size, prune_ratio):
+    num_rows = param.shape[0]
+    row_size = int(np.prod(param.shape[1:]))
+    num_blocks_per_row = (row_size + block_size - 1) // block_size
+
+    # Pad and reshape to have block structure
+    row_size_padded = (row_size + block_size - 1) // block_size * block_size
+    param_padded = np.pad(
+        param.reshape(num_rows, -1),
+        ((0, 0), (0, row_size_padded - row_size)),
+        mode="constant",
+    )
+    param_padded_blocked = param_padded.reshape(
+        num_rows, row_size_padded // block_size, block_size
+    )
+
+    # Compute norm of each block and find threshold
+    norm_of_blocks = np.linalg.norm(param_padded_blocked, axis=2)
+    num_blocks_to_prune = int(np.floor(num_rows * num_blocks_per_row * prune_ratio))
+    threshold = (
+        0
+        if num_blocks_to_prune == 0
+        else np.partition(norm_of_blocks.flatten(), num_blocks_to_prune - 1)[
+            num_blocks_to_prune - 1
+        ]
+    )
+
+    # Create mask
+    mask = norm_of_blocks >= threshold
+    mask = np.broadcast_to(
+        mask.reshape(mask.shape + (1,)), mask.shape + (block_size,)
+    ).reshape(num_rows, row_size_padded)[:, :row_size]
+    return mask
+
+
+class TestMaskedAdagrad(hu.HypothesisTestCase):
+    @given(
+        inputs=hu.tensors(n=3),
+        lr=st.floats(
+            min_value=0.01, max_value=0.99, allow_nan=False, allow_infinity=False
+        ),
+        epsilon=st.floats(
+            min_value=0.01, max_value=0.99, allow_nan=False, allow_infinity=False
+        ),
+    )
+    def test_masked_adagrad(self, inputs, lr, epsilon):
+        param, moment, grad = inputs
+        moment = np.abs(moment)
+        lr = np.array([lr], dtype=np.float32)
+
+        mask = np.random.randint(2, size=param.shape).astype(np.float32)
+
+        workspace.FeedBlob("param", param)
+        workspace.FeedBlob("moment", moment)
+        workspace.FeedBlob("grad", grad)
+        workspace.FeedBlob("lr", lr)
+        workspace.FeedBlob("mask", mask)
+
+        ref_op = core.CreateOperator(
+            "Adagrad",
+            ["param", "moment", "grad", "lr"],
+            ["out_param_ref", "out_moment_ref"],
+            epsilon=epsilon,
+        )
+        op = core.CreateOperator(
+            "MaskedAdagrad",
+            ["param", "moment", "grad", "lr", "mask"],
+            ["out_param", "out_moment"],
+            epsilon=epsilon,
+        )
+
+        workspace.RunOperatorOnce(ref_op)
+        workspace.RunOperatorOnce(op)
+
+        out_param_ref = workspace.FetchBlob("out_param_ref")
+        out_moment_ref = workspace.FetchBlob("out_moment_ref")
+        out_param_ref = np.multiply(mask, out_param_ref)
+        out_moment_ref = np.multiply(mask, out_moment_ref)
+
+        out_param = workspace.FetchBlob("out_param")
+        out_moment = workspace.FetchBlob("out_moment")
+
+        np.testing.assert_array_equal(out_param_ref, out_param)
+        np.testing.assert_array_equal(out_moment_ref, out_moment)
+
+    @given(
+        inputs=hu.tensors(n=3),
+        lr=st.floats(
+            min_value=0.01, max_value=0.99, allow_nan=False, allow_infinity=False
+        ),
+        epsilon=st.floats(
+            min_value=0.01, max_value=0.99, allow_nan=False, allow_infinity=False
+        ),
+        has_mask_input=st.booleans(),
+        has_mask_out=st.booleans(),
+        block_size=st.integers(1, 4),
+    )
+    def test_masked_sparse_adagrad(
+        self, inputs, lr, epsilon, has_mask_input, has_mask_out, block_size
+    ):
+        param, moment, grad = inputs
+        moment = np.abs(moment)
+        lr = np.array([lr], dtype=np.float32)
+        param_ref = np.copy(param)
+        moment_ref = np.copy(moment)
+
+        num_rows = param.shape[0]
+        indices = np.random.randint(num_rows, size=grad.shape[0])
+
+        workspace.ResetWorkspace()
+
+        row_size = int(np.prod(param.shape[1:]))
+        num_blocks_per_row = (row_size + block_size - 1) // block_size
+        bitmask_bytes_per_row = (num_blocks_per_row + 7) // 8
+        if has_mask_input:
+            # Generate a random bit pattern
+            mask = np.random.randint(
+                np.iinfo(np.uint8).min,
+                np.iinfo(np.uint8).max + 1,
+                size=[num_rows, bitmask_bytes_per_row],
+                dtype=np.uint8,
+            )
+            workspace.FeedBlob("mask", mask)
+        else:
+            delays = np.array([1, 2, 3]).astype(np.int32)
+            # Make sure to use numbers that can be exactly represented in
+            # float32 to avoid potentially different ways of handling floats
+            # between Python and C++.
+            prune_ratios = np.array([0.5, 0.75, 0.875]).astype(np.float32)
+
+            # Feed empty mask
+            workspace.FeedBlob("mask", np.array([]).astype(np.uint8))
+
+        workspace.FeedBlob("param_ref", param_ref)
+        workspace.FeedBlob("moment_ref", moment_ref)
+        workspace.FeedBlob("param", param)
+        workspace.FeedBlob("moment", moment)
+        workspace.FeedBlob("indices", indices)
+        workspace.FeedBlob("grad", grad)
+        workspace.FeedBlob("lr", lr)
+
+        net = core.Net("test_net")
+
+        net.SparseAdagrad(
+            ["param_ref", "moment_ref", "indices", "grad", "lr"],
+            ["param_ref", "moment_ref"],
+            epsilon=epsilon,
+        )
+
+        inputs = ["param", "moment", "indices", "grad", "lr", "mask", "mask_changed"]
+        outputs = ["param", "moment"]
+        if not has_mask_input:
+            inputs += ["iter"]
+            if has_mask_out:
+                outputs += ["mask_out"]
+
+        net.MaskedSparseAdagrad(
+            inputs,
+            outputs,
+            epsilon=epsilon,
+            block_size=block_size,
+            delays=[] if has_mask_input else delays,
+            prune_ratios=[] if has_mask_input else prune_ratios,
+        )
+
+        workspace.FeedBlob("mask_changed", np.array([0]).astype(np.bool))
+        workspace.FeedBlob("iter", np.array([0]).astype(np.int64))
+        workspace.CreateNet(net)
+
+        if has_mask_input:
+            # Test1: if mask_changed == false, only the rows we're updating are masked
+            workspace.RunNet(net)
+
+            param_ref = workspace.FetchBlob("param_ref")
+            moment_ref = workspace.FetchBlob("moment_ref")
+            param = workspace.FetchBlob("param")
+            moment = workspace.FetchBlob("moment")
+
+            param_ref = param_ref.reshape(num_rows, -1)
+            moment_ref = moment_ref.reshape(num_rows, -1)
+
+            for i in range(grad.shape[0]):
+                row = indices[i]
+                for j in range(row_size):
+                    j_block = j // block_size
+                    byte = j_block // 8
+                    bit = j_block % 8
+                    m = mask[row][byte] & (1 << bit)
+                    if not m:
+                        param_ref[row, j] = 0
+                        moment_ref[row, j] = 0
+
+            np.testing.assert_array_equal(param_ref, param.reshape(num_rows, -1))
+            np.testing.assert_array_equal(moment_ref, moment.reshape(num_rows, -1))
+
+            # Test2: mask_changed == true
+            workspace.FeedBlob("param_ref", param_ref)
+            workspace.FeedBlob("moment_ref", moment_ref)
+            workspace.FeedBlob("mask_changed", np.array([1]).astype(np.bool))
+            workspace.RunNet(net)
+
+            param_ref = workspace.FetchBlob("param_ref")
+            moment_ref = workspace.FetchBlob("moment_ref")
+
+            for i in range(num_rows):
+                for j in range(row_size):
+                    j_block = j // block_size
+                    byte = j_block // 8
+                    bit = j_block % 8
+                    m = mask[i][byte] & (1 << bit)
+                    if not m:
+                        param_ref[i, j] = 0
+                        moment_ref[i, j] = 0
+
+            param = workspace.FetchBlob("param")
+            moment = workspace.FetchBlob("moment")
+
+            np.testing.assert_array_equal(param_ref, param.reshape(num_rows, -1))
+            np.testing.assert_array_equal(moment_ref, moment.reshape(num_rows, -1))
+        else:
+            # Test1: in the first iteration, there shouldn't be any masking
+            workspace.RunNet(net)
+
+            param_ref = workspace.FetchBlob("param_ref")
+            moment_ref = workspace.FetchBlob("moment_ref")
+
+            param = workspace.FetchBlob("param")
+            moment = workspace.FetchBlob("moment")
+
+            np.testing.assert_array_equal(param_ref, param)
+            np.testing.assert_array_equal(moment_ref, moment)
+
+            # Test2: for each pruning delay, masks should be updated accordingly
+            for i in range(len(delays)):
+                mask = _get_mask(param_ref, block_size, prune_ratios[i])
+
+                workspace.FeedBlob("iter", np.array([delays[i]]).astype(np.int64))
+                workspace.RunNet(net)
+
+                param_ref = workspace.FetchBlob("param_ref")
+                moment_ref = workspace.FetchBlob("moment_ref")
+
+                param = workspace.FetchBlob("param")
+                moment = workspace.FetchBlob("moment")
+
+                param_ref = mask * param_ref.reshape(num_rows, row_size)
+                moment_ref = mask * moment_ref.reshape(num_rows, row_size)
+
+                np.testing.assert_array_equal(param_ref.flatten(), param.flatten())
+                np.testing.assert_array_equal(moment_ref.flatten(), moment.flatten())
+
+            # Test3: after finishing delay, mask should be fixed
+            workspace.FeedBlob("iter", np.array([delays[-1] + 1]).astype(np.int64))
+            workspace.RunNet(net)
+
+            param_ref = workspace.FetchBlob("param_ref")
+            moment_ref = workspace.FetchBlob("moment_ref")
+
+            param = workspace.FetchBlob("param")
+            moment = workspace.FetchBlob("moment")
+
+            param_ref = mask * param_ref.reshape(num_rows, row_size)
+            moment_ref = mask * moment_ref.reshape(num_rows, row_size)
+
+            np.testing.assert_array_equal(param_ref.flatten(), param.flatten())
+            np.testing.assert_array_equal(moment_ref.flatten(), moment.flatten())


### PR DESCRIPTION
Summary: Move Masked*Adagrad operators so caffe2/python/optimizer.py can use them.

Test Plan: buck test caffe2/caffe2/operators/experimental/optimizers:masked_adagrad_test

Differential Revision: D18805532

