### PR TITLE
add torch.square

### DIFF
--- a/aten/src/ATen/core/aten_interned_strings.h
+++ b/aten/src/ATen/core/aten_interned_strings.h
@@ -126,6 +126,7 @@ _(aten, _sparse_mul_scalar) \
 _(aten, _sparse_mul_zerodim) \
 _(aten, _sparse_sum) \
 _(aten, _sqrt) \
+_(aten, _square) \
 _(aten, _standard_gamma) \
 _(aten, _standard_gamma_grad) \
 _(aten, _sum) \
@@ -619,6 +620,7 @@ _(aten, sparse_resize_and_clear) \
 _(aten, split) \
 _(aten, split_with_sizes) \
 _(aten, sqrt) \
+_(aten, square) \
 _(aten, squeeze) \
 _(aten, sspaddmm) \
 _(aten, stack) \

--- a/aten/src/ATen/native/UnaryOps.cpp
+++ b/aten/src/ATen/native/UnaryOps.cpp
@@ -149,6 +149,9 @@ Tensor& sqrt_out(Tensor& result, const Tensor& self) { return unary_op_impl_out(
 Tensor sqrt(const Tensor& self) { return unary_op_impl(self, at::sqrt_out); }
 Tensor& sqrt_(Tensor& self) { return unary_op_impl_(self, at::sqrt_out); }
 
+Tensor square(const Tensor& self) { return at::pow(self, 2); }
+Tensor& square_(Tensor& self) { return at::pow_out(self, self, 2); }
+
 Tensor& sigmoid_out(Tensor& result, const Tensor& self) { return unary_op_impl_out(result, self, sigmoid_stub);  }
 Tensor sigmoid(const Tensor& self) { return unary_op_impl(self, at::sigmoid_out);  }
 Tensor& sigmoid_(Tensor& self) { return unary_op_impl_(self, at::sigmoid_out);  }

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2549,6 +2549,15 @@
 - func: sqrt.out(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
   supports_named_tensor: True
 
+- func: square(Tensor self) -> Tensor
+  use_c10_dispatcher: full
+  supports_named_tensor: True
+  variants: function, method
+
+- func: square_(Tensor(a!) self) -> Tensor(a!)
+  supports_named_tensor: True
+  variants: method
+
 - func: std(Tensor self, bool unbiased=True) -> Tensor
   use_c10_dispatcher: full
   variants: function, method

--- a/benchmarks/operator_benchmark/pt/unary_test.py
+++ b/benchmarks/operator_benchmark/pt/unary_test.py
@@ -99,6 +99,8 @@ unary_ops_list = op_bench.op_list(
         ['sinh', torch.sinh],
         ['sqrt', torch.sqrt],
         ['sqrt_', torch.sqrt_],
+        ['square', torch.square],
+        ['square_', torch.square_],
         ['tan', torch.tan],
         ['tan_', torch.tan_],
         ['tanh', torch.tanh],

--- a/docs/source/tensors.rst
+++ b/docs/source/tensors.rst
@@ -446,6 +446,8 @@ view of a storage and defines numeric operations on it.
    .. automethod:: sparse_dim
    .. automethod:: sqrt
    .. automethod:: sqrt_
+   .. automethod:: square
+   .. automethod:: square_
    .. automethod:: squeeze
    .. automethod:: squeeze_
    .. automethod:: std

--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -239,6 +239,7 @@ Pointwise Ops
 .. autofunction:: sin
 .. autofunction:: sinh
 .. autofunction:: sqrt
+.. autofunction:: square
 .. autofunction:: tan
 .. autofunction:: tanh
 .. autofunction:: trunc

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -2577,6 +2577,20 @@ sqrt_() -> Tensor
 In-place version of :meth:`~Tensor.sqrt`
 """)
 
+add_docstr_all('square',
+               r"""
+square() -> Tensor
+
+See :func:`torch.square`
+""")
+
+add_docstr_all('square_',
+               r"""
+square_() -> Tensor
+
+In-place version of :meth:`~Tensor.square`
+""")
+
 add_docstr_all('squeeze',
                r"""
 squeeze(dim=None) -> Tensor

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -5053,6 +5053,25 @@ Example::
     tensor([    nan,  1.0112,  0.2883,  0.6933])
 """.format(**common_args))
 
+add_docstr(torch.square,
+           r"""
+square(input, out=None) -> Tensor
+
+Returns a new tensor with the square of the elements of :attr:`input`.
+
+Args:
+    {input}
+    {out}
+
+Example::
+
+    >>> a = torch.randn(4)
+    >>> a
+    tensor([-2.0755,  1.0226,  0.0831,  0.4806])
+    >>> torch.square(a)
+    tensor([ 4.3077,  1.0457,  0.0069,  0.2310])
+""".format(**common_args))
+
 add_docstr(torch.squeeze,
            r"""
 squeeze(input, dim=None, out=None) -> Tensor


### PR DESCRIPTION
Summary:

fixes #30524 
This adds an new operator `torch.square` to PyTorch

I think it is ready for the first-time review now @albanD 
