### PR TITLE
Fix confusing "does not have GPU support" warning message

### DIFF
--- a/caffe2/python/_import_c_extension.py
+++ b/caffe2/python/_import_c_extension.py
@@ -38,8 +38,9 @@ with extension_loader.DlopenGuard():
             logging.info('Failed to import AMD hip module: {}'.format(hip_e))
 
             logging.warning(
-                'This caffe2 python run does not have GPU support. '
-                'Will run in CPU only mode.')
+                'This caffe2 python run failed to load cuda module:{},'
+                'and AMD hip module:{}.'
+                'Will run in CPU only mode.'.format(gpu_e, hip_e))
             try:
                 from caffe2.python.caffe2_pybind11_state import *  # noqa
             except ImportError as cpu_e:


### PR DESCRIPTION
Many people who use caffe2 are confused about "does not have GPU support" warning message.
https://github.com/facebookresearch/video-nonlocal-net/issues/6
facebookarchive/caffe2#346
facebookarchive/caffe2#1634
facebookarchive/caffe2#197

Many none GPU reasons can cause this warning message. It is better to give the error info.
![image](https://user-images.githubusercontent.com/13826327/70129721-41175e00-16ba-11ea-85df-a4b1a1690149.png)
