### PR TITLE
Back out "make the order btw div and mul in adagrad update consistent"

### DIFF
--- a/caffe2/perfkernels/adagrad.h
+++ b/caffe2/perfkernels/adagrad.h
@@ -29,7 +29,7 @@ static inline void adagrad_update_base_inlined(
     float gi = g[i];
     float hi = decay * h[i] + gi * gi;
     nh[i] = hi;
-    nw[i] = w[i] + lr / (std::sqrt(hi) + epsilon) * gi;
+    nw[i] = w[i] + lr * gi / (std::sqrt(hi) + epsilon);
   }
 }
 
@@ -300,7 +300,7 @@ int sparse_adagrad(
       if (block_size == 1) {                                             \
         float gi = g[i];                                                 \
         float hi = nh[idx] = h[idx] + gi * gi;                           \
-        nw[idx] = w[idx] + lr / (std::sqrt(hi) + epsilon) * gi;          \
+        nw[idx] = w[idx] + lr * gi / (std::sqrt(hi) + epsilon);          \
       } else {                                                           \
         const int prefdist_T0 = 16;                                      \
         int i_pref = (i < num_rows - prefdist_T0) ? i + prefdist_T0 : i; \

--- a/caffe2/sgd/adagrad_op.h
+++ b/caffe2/sgd/adagrad_op.h
@@ -190,7 +190,7 @@ class SparseAdagradOp final : public Operator<Context> {
       if (block_size == 1) {
         float gi = gradIn[i];
         float hi = momentOut[idx] = momentIn[idx] + gi * gi;
-        paramOut[idx] = paramIn[idx] + lr[0] / (std::sqrt(hi) + epsilon_) * gi;
+        paramOut[idx] = paramIn[idx] + lr[0] * gi / (std::sqrt(hi) + epsilon_);
       } else {
         auto offsetI = i * block_size;
         auto offsetIdx = idx * block_size;
@@ -279,7 +279,7 @@ class RowWiseSparseAdagradOp final : public Operator<Context> {
       if (block_size == 1) {
         float gi = gradIn[i];
         float hi = momentOut[idx] = momentIn[idx] + gi * gi;
-        paramOut[idx] = paramIn[idx] + lr[0] / (std::sqrt(hi) + epsilon_) * gi;
+        paramOut[idx] = paramIn[idx] + lr[0] * gi / (std::sqrt(hi) + epsilon_);
       } else {
         auto offsetI = i * block_size;
         auto offsetIdx = idx * block_size;


### PR DESCRIPTION
Summary:
Original commit changeset: 2a8b2a3f5401

Reverting this to be safe until we address test failures in T58528495

Test Plan: CI

Differential Revision: D18812384

