### PR TITLE
[WIP] Add channels last tag

### DIFF
--- a/aten/src/ATen/native/TensorConversions.cpp
+++ b/aten/src/ATen/native/TensorConversions.cpp
@@ -35,6 +35,7 @@ static inline Tensor to_impl(const Tensor& self, const TensorOptions& options, b
       // Copy all strides
       auto r = at::empty_strided(self.sizes(), self.strides(), options);
       r.copy_(self);
+      r.unsafeGetTensorImpl()->set_channels_last_tag(self.unsafeGetTensorImpl()->is_channels_last_tag());
       return r;
     } else {
       memory_format = self.suggest_memory_format();

--- a/aten/src/ATen/native/TensorIterator.cpp
+++ b/aten/src/ATen/native/TensorIterator.cpp
@@ -301,6 +301,7 @@ void TensorIterator::allocate_outputs() {
         op.tensor = at::empty(tensor_shape, op.options());
         op.tensor.unsafeGetTensorImpl()->empty_tensor_restride(
             MemoryFormat::ChannelsLast);
+        op.tensor.unsafeGetTensorImpl()->set_channels_last_tag(true);
         // As we are allocating output after permutations is done, we need to
         // make sure that operand's strides are matching element size and
         // dimensions permutations which are stored in _perm

--- a/aten/src/ATen/native/cuda/AdaptiveAveragePooling.cu
+++ b/aten/src/ATen/native/cuda/AdaptiveAveragePooling.cu
@@ -463,7 +463,7 @@ namespace {
         // preserve channels_last stride on output tensor;
         if (!output.is_contiguous(at::MemoryFormat::ChannelsLast)) {
           // TODO: modify this after resize_ added `memory_format` tag
-          output.resize_({sizeB, sizeC, osizeH, osizeW}).as_strided_({sizeB, sizeC, osizeH, osizeW}, {sizeC*osizeH*osizeW, 1, osizeW*sizeC, sizeC});
+          output.resize_({sizeB, sizeC, osizeH, osizeW}, MemoryFormat::ChannelsLast);
         }
 
         const int max_threads = std::min<int>(
@@ -638,7 +638,7 @@ namespace {
         const dim3 block(block_x, block_y, block_z);
         int kernel_stride_C = cuda::ATenCeilDiv(sizeC, block_x * 4);
         int kernel_size_C = cuda::ATenCeilDiv(sizeC, block_x * kernel_stride_C);
-        
+
         // Do NOT clip grid_x, striding on Batch dimension is not in the kernel,
         // although it could be easily implemented given current kernel.
         int grid_x = sizeB*kernel_stride_C;

--- a/aten/src/ATen/native/cuda/DilatedMaxPool2d.cu
+++ b/aten/src/ATen/native/cuda/DilatedMaxPool2d.cu
@@ -333,11 +333,8 @@ void max_pool2d_with_indices_out_cuda_template(
   const int64_t in_stride_h = input.stride(-2);
   const int64_t in_stride_w = input.stride(-1);
 
-  output.resize_({nbatch, nInputPlane, outputHeight, outputWidth});
-  indices.resize_({nbatch, nInputPlane, outputHeight, outputWidth});
-
-  output.unsafeGetTensorImpl()->empty_tensor_restride(memory_format);
-  indices.unsafeGetTensorImpl()->empty_tensor_restride(memory_format);
+  output.resize_({nbatch, nInputPlane, outputHeight, outputWidth}, memory_format);
+  indices.resize_({nbatch, nInputPlane, outputHeight, outputWidth}, memory_format);
 
   const int count = safe_downcast<int, int64_t>(output.numel());
 

--- a/aten/src/ATen/native/cuda/TensorFactories.cu
+++ b/aten/src/ATen/native/cuda/TensorFactories.cu
@@ -67,6 +67,7 @@ Tensor empty_cuda(IntArrayRef size, const TensorOptions& options, c10::optional<
 
   auto memory_format = optional_memory_format.value_or(MemoryFormat::Contiguous);
   tensor.unsafeGetTensorImpl()->empty_tensor_restride(memory_format);
+  tensor.unsafeGetTensorImpl()->set_channels_last_tag(memory_format == MemoryFormat::ChannelsLast);
   return tensor;
 }
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -713,6 +713,10 @@
   variants: method
   supports_named_tensor: True
 
+- func: get_memory_format(Tensor self) -> MemoryFormat
+  variants: method
+  supports_named_tensor: True
+
 - func: convolution(Tensor input, Tensor weight, Tensor? bias, int[] stride, int[] padding, int[] dilation, bool transposed, int[] output_padding, int groups) -> Tensor
 
 - func: convolution_overrideable(Tensor input, Tensor weight, Tensor? bias, int[] stride, int[] padding, int[] dilation, bool transposed, int[] output_padding, int groups) -> Tensor

--- a/aten/src/ATen/templates/TensorBody.h
+++ b/aten/src/ATen/templates/TensorBody.h
@@ -208,7 +208,7 @@ class CAFFE2_API Tensor {
   }
 
   at::MemoryFormat suggest_memory_format() const {
-    if (!is_mkldnn() && !is_sparse() && !impl_->is_contiguous() && impl_->is_strides_like_channels_last()) {
+    if (!is_mkldnn() && !is_sparse() && impl_->is_channels_last_tag()) {
       return at::MemoryFormat::ChannelsLast;
     }
     return at::MemoryFormat::Contiguous;

--- a/c10/core/TensorImpl.cpp
+++ b/c10/core/TensorImpl.cpp
@@ -271,7 +271,7 @@ void TensorImpl::copy_tensor_metadata(
   dest_impl->type_set_ = src_impl->type_set_;
   dest_impl->is_contiguous_ = src_impl->is_contiguous_;
   dest_impl->is_channels_last_contiguous_ = src_impl->is_channels_last_contiguous_;
-  dest_impl->is_channels_last_ = src_impl->is_channels_last_;
+  dest_impl->is_channels_last_tag_ = src_impl->is_channels_last_tag_;
   dest_impl->is_non_overlapping_and_dense_ = src_impl->is_non_overlapping_and_dense_;
   dest_impl->is_wrapped_number_ = src_impl->is_wrapped_number_;
   dest_impl->reserved_ = src_impl->reserved_;

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -184,7 +184,8 @@ SUPPORTED_RETURN_TYPES = {
     'Scalar', 'bool', 'int64_t', 'void*', 'void',
     'QScheme', 'double',
     'IntArrayRef',
-    'ScalarType'
+    'ScalarType',
+    'MemoryFormat'
 }
 
 TENSOR_OPTIONS = CodeTemplate("""\

--- a/torch/csrc/MemoryFormat.cpp
+++ b/torch/csrc/MemoryFormat.cpp
@@ -22,6 +22,31 @@ PyObject *THPMemoryFormat_New(at::MemoryFormat memory_format, const std::string&
   return self.release();
 }
 
+PyObject* THPMemoryFormat_Get(at::MemoryFormat memory_format) {
+  switch (memory_format) {
+    case at::MemoryFormat::Preserve: {
+      static PyObject* py_memory_format =
+          THPMemoryFormat_New(memory_format, "torch.preserve_format");
+      Py_INCREF(py_memory_format);
+      return py_memory_format;
+    }
+    case at::MemoryFormat::Contiguous: {
+      static PyObject* py_memory_format =
+          THPMemoryFormat_New(memory_format, "torch.contiguous_format");
+      Py_INCREF(py_memory_format);
+      return py_memory_format;
+    }
+    case at::MemoryFormat::ChannelsLast: {
+      static PyObject* py_memory_format =
+          THPMemoryFormat_New(memory_format, "torch.channels_last");
+      Py_INCREF(py_memory_format);
+      return py_memory_format;
+    }
+    default:
+      AT_ERROR("Unknown memory format");
+  }
+}
+
 PyObject *THPMemoryFormat_repr(THPMemoryFormat *self)
 {
   return THPUtils_packString(self->name);

--- a/torch/csrc/MemoryFormat.h
+++ b/torch/csrc/MemoryFormat.h
@@ -23,3 +23,5 @@ inline bool THPMemoryFormat_Check(PyObject *obj) {
 PyObject * THPMemoryFormat_New(at::MemoryFormat memory_format, const std::string& name);
 
 void THPMemoryFormat_init(PyObject *module);
+
+PyObject* THPMemoryFormat_Get(at::MemoryFormat memory_format);

--- a/torch/csrc/autograd/utils/wrap_outputs.h
+++ b/torch/csrc/autograd/utils/wrap_outputs.h
@@ -8,6 +8,7 @@
 
 #include <torch/csrc/Dtype.h>
 #include <torch/csrc/Layout.h>
+#include <torch/csrc/MemoryFormat.h>
 #include <torch/csrc/QScheme.h>
 #include <torch/csrc/autograd/python_variable.h>
 #include <torch/csrc/autograd/variable.h>
@@ -63,6 +64,10 @@ inline PyObject* wrap(at::Tensor tensor) {
 
 inline PyObject* wrap(at::Scalar scalar) {
   return wrap(scalar_to_tensor(scalar));
+}
+
+inline PyObject* wrap(at::MemoryFormat memory_format) {
+  return THPMemoryFormat_Get(memory_format);
 }
 
 inline PyObject* wrap(at::QScheme qscheme) {

--- a/torch/csrc/utils/tensor_memoryformats.cpp
+++ b/torch/csrc/utils/tensor_memoryformats.cpp
@@ -14,9 +14,7 @@ namespace utils {
 
 #define _ADD_MEMORY_FORMAT(format, name)                                       \
   {                                                                            \
-    std::string module_name = "torch.";                                        \
-    PyObject* memory_format = THPMemoryFormat_New(format, module_name + name); \
-    Py_INCREF(memory_format);                                                  \
+    PyObject* memory_format = THPMemoryFormat_Get(format);                 \
     if (PyModule_AddObject(torch_module, name, memory_format) != 0) {          \
       throw python_error();                                                    \
     }                                                                          \

--- a/torch/csrc/utils/tensor_memoryformats.h
+++ b/torch/csrc/utils/tensor_memoryformats.h
@@ -1,7 +1,10 @@
 #pragma once
 
+
+
 namespace torch { namespace utils {
 
 void initializeMemoryFormats();
+
 
 }} // namespace torch::utils


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #31131 Add memory_format support to `zeros`, `ones`, `full` (still need tests)
* #30993 [WIP] Fixing resize_
* #30992 3d t support
* **#30743 [WIP] Add channels last tag**
* #30089 Switch default memory format of clone operator to Preserve
* #30088 Switch default memory format of to (and similar) operators to Preserve
* #30087 Switch default memory format of _like operators to Preserve
* #28991 Adding function to convert Module to channels last

