### PR TITLE
Update ONNX Flatten to accept negative indices in opset 11

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -1413,7 +1413,7 @@ class TestONNXRuntime(unittest.TestCase):
     def test_flatten2d_neg(self):
         class FlattenModel(torch.nn.Module):
             def forward(self, x):
-                return torch.flatten(x, 1, -1), torch.flatten(x, 0, -2)#, torch.flatten(x, 1, -2)
+                return torch.flatten(x, 1, -1), torch.flatten(x, 0, -2), torch.flatten(x, 1, -2)
 
         x = torch.randint(10, (1, 2, 3, 4))
         self.run_test(FlattenModel(), x)

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -1394,7 +1394,6 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.randn(3, 4, 5, requires_grad=True)
         self.run_test(model, x)
 
-
     def test_flatten(self):
         class FlattenModel(torch.nn.Module):
             def forward(self, input):
@@ -1407,6 +1406,14 @@ class TestONNXRuntime(unittest.TestCase):
         class FlattenModel(torch.nn.Module):
             def forward(self, input):
                 return torch.flatten(input, 1)
+
+        x = torch.randint(10, (1, 2, 3, 4))
+        self.run_test(FlattenModel(), x)
+
+    def test_flatten2d_neg(self):
+        class FlattenModel(torch.nn.Module):
+            def forward(self, x):
+                return torch.flatten(x, 1, -1), torch.flatten(x, 0, -2)#, torch.flatten(x, 1, -2)
 
         x = torch.randint(10, (1, 2, 3, 4))
         self.run_test(FlattenModel(), x)

--- a/torch/onnx/symbolic_opset11.py
+++ b/torch/onnx/symbolic_opset11.py
@@ -421,3 +421,34 @@ def __lshift_(g, self, other):
 
     lshift = g.op('Mul', self, two_pow)
     return lshift
+
+
+@parse_args('v', 'i', 'i')
+def flatten(g, input, start_dim, end_dim):
+    dim = input.type().dim()
+    # use ONNX's Flatten operator for cases where the output shape is 2D
+    if start_dim == 1:
+        if (end_dim == -1 or (end_dim is not None and end_dim == dim - 1)):
+            return g.op("Flatten", input, axis_i=start_dim)
+    elif start_dim == 0:
+        if  (end_dim == -2 or (end_dim is not None and end_dim == dim - 2)):
+            return g.op("Flatten", input, axis_i=end_dim + 1)
+    # use Reshape for cases where the output shape is not 2D
+    if not input.isCompleteTensor():
+        return _unimplemented("flatten",
+                              "input size not accessible "
+                              "(consider using reshape op instead of flatten op to export to ONNX)")
+    # if end_dim is negative add dim
+    if end_dim < 0 :
+        end_dim = dim + end_dim
+    input_dims = input.type().sizes()
+    output_dims = []
+    for i in range(0, dim):
+        if start_dim < i and end_dim >= i:
+            output_dims[start_dim] = output_dims[start_dim] * input_dims[i]
+        else:
+            output_dims.append(input_dims[i])
+    shape = g.op("Constant", value_t=torch.LongTensor(output_dims))
+    from torch.onnx.symbolic_opset9 import _reshape_from_tensor
+    p = _reshape_from_tensor(g, input, shape)
+    return p

--- a/torch/onnx/symbolic_opset11.py
+++ b/torch/onnx/symbolic_opset11.py
@@ -431,7 +431,7 @@ def flatten(g, input, start_dim, end_dim):
         if (end_dim == -1 or (end_dim is not None and end_dim == dim - 1)):
             return g.op("Flatten", input, axis_i=start_dim)
     elif start_dim == 0:
-        if  (end_dim == -2 or (end_dim is not None and end_dim == dim - 2)):
+        if (end_dim == -2 or (end_dim is not None and end_dim == dim - 2)):
             return g.op("Flatten", input, axis_i=end_dim + 1)
     # use Reshape for cases where the output shape is not 2D
     if not input.isCompleteTensor():

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -1734,7 +1734,9 @@ def flatten(g, input, start_dim, end_dim):
         return g.op("Flatten", input, axis_i=end_dim + 1)
     # use Reshape for cases where the output shape is not 2D
     if not input.isCompleteTensor():
-        return _unimplemented("flatten", "input size not accessible")
+        return _unimplemented("flatten",
+                              "input size not accessible "
+                              "(consider using reshape op instead of flatten op to export to ONNX)")
     input_dims = input.type().sizes()
     output_dims = []
     for i in range(0, dim):


### PR DESCRIPTION
Update ONNX Flatten to accept negative indices in opset 11.
With this change, some cases of flatten do not rely on the input rank being available.
Fixes : https://github.com/pytorch/pytorch/issues/30512 .