### PR TITLE
Restructure docs organization and naming

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -19,13 +19,6 @@ PyTorch is an optimized tensor library for deep learning using GPUs and CPUs.
    PyTorch on XLA Devices <http://pytorch.org/xla/>
 
 .. toctree::
-  :glob:
-  :maxdepth: 1
-  :caption: Community
-
-  community/*
-
-.. toctree::
    :maxdepth: 1
    :caption: Python API
 
@@ -81,10 +74,17 @@ PyTorch is an optimized tensor library for deep learning using GPUs and CPUs.
 
 .. toctree::
    :maxdepth: 1
-   :caption: Other Languages
+   :caption: Language Bindings
 
    C++ API <https://pytorch.org/cppdocs/>
    packages
+
+.. toctree::
+   :glob:
+   :maxdepth: 1
+   :caption: Community
+
+   community/*
 
 Indices and tables
 ==================

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -17,6 +17,13 @@ PyTorch is an optimized tensor library for deep learning using GPUs and CPUs.
 
    notes/*
    PyTorch on XLA Devices <http://pytorch.org/xla/>
+   
+.. toctree::
+   :maxdepth: 1
+   :caption: Language Bindings
+
+   C++ API <https://pytorch.org/cppdocs/>
+   packages
 
 .. toctree::
    :maxdepth: 1
@@ -71,13 +78,6 @@ PyTorch is an optimized tensor library for deep learning using GPUs and CPUs.
    :caption: torchtext Reference
 
    torchtext <https://pytorch.org/text>
-
-.. toctree::
-   :maxdepth: 1
-   :caption: Language Bindings
-
-   C++ API <https://pytorch.org/cppdocs/>
-   packages
 
 .. toctree::
    :glob:


### PR DESCRIPTION
* Rename “Other Languages” → “Language Bindings”
* Move the Community section to the bottom
* Move "Language Bindings" above "Python API"

