### PR TITLE
Add docs for how we expose declarations in at:: to torch::

### DIFF
--- a/torch/csrc/api/include/torch/types.h
+++ b/torch/csrc/api/include/torch/types.h
@@ -8,6 +8,26 @@
 #include <torch/csrc/autograd/variable.h>
 
 namespace torch {
+
+// NOTE [ Exposing names in `at::` to `torch::` ]
+//
+// The following line `using namespace at;` is responsible for exposing all names declared in
+// `at::` namespace` to `torch::` namespace.
+//
+// According to the rules laid out in
+// https://en.cppreference.com/w/cpp/language/qualified_lookup, section "Namespace members":
+// ```
+// Qualified lookup within the scope of a namespace N first considers all declarations that are
+// located in N and all declarations that are located in the inline namespace members of N
+// (and, transitively, in their inline namespace members). If there are no declarations in that set
+// then it considers declarations in all namespaces named by using-directives found in N and
+// in all transitive inline namespace members of N.
+// ```
+//
+// This means that if both `at::` and `torch::` namespaces have a function with the same signature
+// (e.g. both `at::func()` and `torch::func()` exist), after `namespace torch { using namespace at; }`,
+// when we call `torch::func()`, the `func()` function defined in `torch::` namespace will always
+// be called, and the `func()` function defined in `at::` namespace is always hidden.
 using namespace at; // NOLINT
 
 using c10::optional;

--- a/torch/csrc/api/include/torch/types.h
+++ b/torch/csrc/api/include/torch/types.h
@@ -9,10 +9,10 @@
 
 namespace torch {
 
-// NOTE [ Exposing names in `at::` to `torch::` ]
+// NOTE [ Exposing declarations in `at::` to `torch::` ]
 //
-// The following line `using namespace at;` is responsible for exposing all names declared in
-// `at::` namespace` to `torch::` namespace.
+// The following line `using namespace at;` is responsible for exposing all declarations in
+// `at::` namespace to `torch::` namespace.
 //
 // According to the rules laid out in
 // https://en.cppreference.com/w/cpp/language/qualified_lookup, section "Namespace members":


### PR DESCRIPTION
This PR adds docs for how we expose declarations in `at::` to `torch::`, to make the semantics more clear.
