### PR TITLE
Turn off scalar_check for is_target for MultiLabelMarginCriterion, which is handled correctly in code.

### DIFF
--- a/aten/src/ATen/nn.yaml
+++ b/aten/src/ATen/nn.yaml
@@ -25,7 +25,7 @@
   buffers: [is_target]
   scalar_check:
     output: reduction != at::Reduction::None || self_->dim() == 0
-    is_target: target_->dim() == 0
+    is_target: 'false'
 
 - name: _thnn_nll_loss(Tensor self, LongTensor target, Tensor? weight, int64_t reduction, int64_t ignore_index)
   cname: ClassNLLCriterion


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #30790 [BC-BREAKING] change index_select scalar_check to retain dimensionality of input.
* #30789 Turn off scalar_checks for SpatialDepthwiseConvolution and SpatialConvolutionMM.
* #30770 Move scalar_check from codegen to code in MultiLabelMarginCriterion.
* #30768 [BC-Breaking] Fix scalar check of MultiLabelMarginLoss.
* #30767 Fix a CUDA memory leak in MultiLabelMarginCriterion error checking.
* **#30766 Turn off scalar_check for is_target for MultiLabelMarginCriterion, which is handled correctly in code.**
* #30765 Support 0-d tensors in CUDA MultiLabelMarginCriterion.

Restacked version of: https://github.com/pytorch/pytorch/pull/30728

Differential Revision: [D18821555](https://our.internmc.facebook.com/intern/diff/D18821555)