### PR TITLE
Fix a CUDA memory leak in MultiLabelMarginCriterion error checking.

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6306,6 +6306,17 @@ class TestTorchDeviceType(TestCase):
             self.assertEqual((), torch.nn.functional.nll_loss(input, target, reduction='mean').shape)
             self.assertEqual((), torch.nn.functional.nll_loss(input, target, reduction='sum').shape)
 
+        # multilabel_margin_loss
+        for input in (zero_d, one_d, torch.randn(1, 1, device=device)):
+            for target in (torch.tensor(0, device=device), torch.tensor([0], device=device), torch.tensor([[0]], device=device)):
+                if (input.dim() <= 1 and target.dim() <= 1) or (input.dim() == 2 and target.dim() == 2):
+                    pass
+                    # TODO: test
+                else:
+                    self.assertRaises(RuntimeError, lambda: torch.nn.functional.multilabel_margin_loss(input, target, reduction='none'))
+                    self.assertRaises(RuntimeError, lambda: torch.nn.functional.multilabel_margin_loss(input, target, reduction='mean'))
+                    self.assertRaises(RuntimeError, lambda: torch.nn.functional.multilabel_margin_loss(input, target, reduction='sum'))
+
     @onlyCPU
     @dtypes(torch.float)
     def test_diag(self, device, dtype):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #30790 [BC-BREAKING] change index_select scalar_check to retain dimensionality of input.
* #30789 Turn off scalar_checks for SpatialDepthwiseConvolution and SpatialConvolutionMM.
* #30770 Move scalar_check from codegen to code in MultiLabelMarginCriterion.
* #30768 [BC-Breaking] Fix scalar check of MultiLabelMarginLoss.
* **#30767 Fix a CUDA memory leak in MultiLabelMarginCriterion error checking.**
* #30766 Turn off scalar_check for is_target for MultiLabelMarginCriterion, which is handled correctly in code.
* #30765 Support 0-d tensors in CUDA MultiLabelMarginCriterion.

Restacked version of: https://github.com/pytorch/pytorch/pull/30733

Differential Revision: [D18821553](https://our.internmc.facebook.com/intern/diff/D18821553)