### PR TITLE
[BC-Breaking] Fix scalar check of MultiLabelMarginLoss.

### DIFF
--- a/aten/src/ATen/native/LossMultiLabelMargin.cpp
+++ b/aten/src/ATen/native/LossMultiLabelMargin.cpp
@@ -142,9 +142,9 @@ static void multilabel_margin_loss_forward_out_cpu_template(
   TORCH_CHECK(is_target.is_contiguous(), "is_target must be contiguous");
   is_target.zero_();
 
-  // special case ndims == 0: produce scalar output for scalar inputs
+  // special case target.dim() <= 1: produce scalar output for scalar inputs
   // even if reduction == Reduction::None
-  if (reduction != Reduction::None || ndims == 0) {
+  if (reduction != Reduction::None || target.dim() <= 1) {
     output.resize_({});
   } else {
     output.resize_({nframe});

--- a/aten/src/ATen/nn.yaml
+++ b/aten/src/ATen/nn.yaml
@@ -24,7 +24,7 @@
   cname: MultiLabelMarginCriterion
   buffers: [is_target]
   scalar_check:
-    output: reduction != at::Reduction::None || self_->dim() == 0
+    output: reduction != at::Reduction::None || target_->dim() <= 1
     is_target: 'false'
 
 - name: _thnn_nll_loss(Tensor self, LongTensor target, Tensor? weight, int64_t reduction, int64_t ignore_index)

--- a/test/common_nn.py
+++ b/test/common_nn.py
@@ -2606,9 +2606,6 @@ def smoothl1loss_reference(input, target, reduction='mean'):
 
 
 def _multilabelmarginloss_reference(input, target):
-    if input.dim() == 0:
-        return 0
-
     targets = []
     for target_index in target:
         if target_index < 0:
@@ -2625,27 +2622,29 @@ def _multilabelmarginloss_reference(input, target):
 
 
 def multilabelmarginloss_reference(input, target, reduction='mean'):
-    if input.dim() == 0:
-        dim = 1
-        output = torch.empty_like(input)
-        output.fill_(_multilabelmarginloss_reference(input, target))
-    elif input.dim() == 1:
-        n = 1
-        dim = input.size(0)
-        output = input.new(n).zero_()
-        output[0] = _multilabelmarginloss_reference(input, target)
-    else:
-        n = input.size(0)
-        dim = input.size(1)
-        output = input.new(n).zero_()
-        for i in range(0, n):
-            output[i] = _multilabelmarginloss_reference(input[i], target[i])
+    # make everything 2-dimensional
+    input_dim = input.dim()
+    if input.dim() < 2:
+        assert target.dim() < 2
+        input = input.unsqueeze(0) if input.dim() == 1 else input.unsqueeze(0).unsqueeze(0)
+        target = target.unsqueeze(0) if target.dim() == 1 else target.unsqueeze(0).unsqueeze(0)
+
+    n = input.size(0)
+    dim = input.size(1)
+    output = input.new(n).zero_()
+    for i in range(0, n):
+        output[i] = _multilabelmarginloss_reference(input[i], target[i])
 
     if reduction == 'mean':
         return output.mean() / dim
     elif reduction == 'sum':
         return output.sum() / dim
-    return output / dim
+    elif input_dim < 2:
+        # we know we have (1, C) X (1, C) -> (1,), so squeeze will get us
+        # back to correct dimensionality
+        return output.squeeze() / dim
+    else:
+        return output / dim
 
 
 def hingeembeddingloss_reference(input, target, margin=1.0, reduction='mean'):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6310,8 +6310,10 @@ class TestTorchDeviceType(TestCase):
         for input in (zero_d, one_d, torch.randn(1, 1, device=device)):
             for target in (torch.tensor(0, device=device), torch.tensor([0], device=device), torch.tensor([[0]], device=device)):
                 if (input.dim() <= 1 and target.dim() <= 1) or (input.dim() == 2 and target.dim() == 2):
-                    pass
-                    # TODO: test
+                    output_shape = (target.shape[0],) if target.dim() == 2 else ()
+                    self.assertEqual(output_shape, torch.nn.functional.multilabel_margin_loss(input, target, reduction='none').shape)
+                    self.assertEqual((), torch.nn.functional.multilabel_margin_loss(input, target, reduction='mean').shape)
+                    self.assertEqual((), torch.nn.functional.multilabel_margin_loss(input, target, reduction='sum').shape)
                 else:
                     self.assertRaises(RuntimeError, lambda: torch.nn.functional.multilabel_margin_loss(input, target, reduction='none'))
                     self.assertRaises(RuntimeError, lambda: torch.nn.functional.multilabel_margin_loss(input, target, reduction='mean'))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #30790 [BC-BREAKING] change index_select scalar_check to retain dimensionality of input.
* #30789 Turn off scalar_checks for SpatialDepthwiseConvolution and SpatialConvolutionMM.
* #30770 Move scalar_check from codegen to code in MultiLabelMarginCriterion.
* **#30768 [BC-Breaking] Fix scalar check of MultiLabelMarginLoss.**
* #30767 Fix a CUDA memory leak in MultiLabelMarginCriterion error checking.
* #30766 Turn off scalar_check for is_target for MultiLabelMarginCriterion, which is handled correctly in code.
* #30765 Support 0-d tensors in CUDA MultiLabelMarginCriterion.

The behavior didn't match the documentation, because the documentation (for 'none' reduction) reads:
input X target -> output
(N, C) X (N, C) -> (N,)
(C,) X (C,) -> ()

but the later case would output (1,).  This also changes the case to:
() X (C,) -> ()
from:
() X (C,) -> (C,)
which makes more sense with the above formulas.

Restacked version of: https://github.com/pytorch/pytorch/pull/30748

Code example of changes:
Previously:
```
>>> nn.MultiLabelMarginLoss(reduction='none')(torch.randn(3), torch.zeros(3, dtype=torch.long))
tensor([0.2959])
```

Now:
```
>>> nn.MultiLabelMarginLoss(reduction='none')(torch.randn(3), torch.zeros(3, dtype=torch.long))
tensor(0.2959)
```

Differential Revision: [D18821554](https://our.internmc.facebook.com/intern/diff/D18821554)