### PR TITLE
Move scalar_check from codegen to code in MultiLabelMarginCriterion.

### DIFF
--- a/aten/src/ATen/nn.yaml
+++ b/aten/src/ATen/nn.yaml
@@ -24,8 +24,9 @@
   cname: MultiLabelMarginCriterion
   buffers: [is_target]
   scalar_check:
-    output: reduction != at::Reduction::None || target_->dim() <= 1
+    output: 'false'
     is_target: 'false'
+    grad_input: 'false'
 
 - name: _thnn_nll_loss(Tensor self, LongTensor target, Tensor? weight, int64_t reduction, int64_t ignore_index)
   cname: ClassNLLCriterion

--- a/aten/src/THCUNN/generic/MultiLabelMarginCriterion.cu
+++ b/aten/src/THCUNN/generic/MultiLabelMarginCriterion.cu
@@ -40,7 +40,7 @@ void THNN_(MultiLabelMarginCriterion_updateOutput)(
   {
     int dim = input->dim() == 0 ? 1 : input->size(0);
     int target_size = target->dim() == 0 ? 1 : target->size(0);
-    THCTensor_(resize1d)(state, output, 1);
+    THCTensor_(resize0d)(state, output);
 
     dim3 blocks(1);
     dim3 threads(MULTILABELMARGIN_THREADS);
@@ -66,7 +66,7 @@ void THNN_(MultiLabelMarginCriterion_updateOutput)(
     if (reduction != at::Reduction::None)
     {
       THCTensor *output_tmp = THCTensor_(newWithSize1d)(state, input->size(0));
-      THCTensor_(resize1d)(state, output, 1);
+      THCTensor_(resize0d)(state, output);
 
       cunn_MultiLabelMarginCriterion_updateOutput_kernel<scalar_t, accreal>
         <<<blocks, threads, 0, THCState_getCurrentStream(state)>>>(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #30790 [BC-BREAKING] change index_select scalar_check to retain dimensionality of input.
* #30789 Turn off scalar_checks for SpatialDepthwiseConvolution and SpatialConvolutionMM.
* **#30770 Move scalar_check from codegen to code in MultiLabelMarginCriterion.**
* #30768 [BC-Breaking] Fix scalar check of MultiLabelMarginLoss.
* #30767 Fix a CUDA memory leak in MultiLabelMarginCriterion error checking.
* #30766 Turn off scalar_check for is_target for MultiLabelMarginCriterion, which is handled correctly in code.
* #30765 Support 0-d tensors in CUDA MultiLabelMarginCriterion.

Restacked version of: https://github.com/pytorch/pytorch/pull/30753

Differential Revision: [D18821556](https://our.internmc.facebook.com/intern/diff/D18821556)