### PR TITLE
Turn off scalar_checks for SpatialDepthwiseConvolution and SpatialConvolutionMM.

### DIFF
--- a/aten/src/ATen/nn.yaml
+++ b/aten/src/ATen/nn.yaml
@@ -121,7 +121,13 @@
   CPU:
     forward_scalar_types: ['Float', 'Double', 'Long', 'BFloat16']
     backward_scalar_types: ['Float', 'Double', 'BFloat16']
+  scalar_check:
+    output: 'false'
+    grad_input: 'false'
 
 - name: _thnn_conv_depthwise2d(Tensor self, Tensor weight, IntArrayRef[2] kernel_size, Tensor? bias, IntArrayRef[2] stride, IntArrayRef[2] padding, IntArrayRef[2] dilation)
   cname: SpatialDepthwiseConvolution
   buffers: []
+  scalar_check:
+    output: 'false'
+    grad_input: 'false'

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6297,6 +6297,12 @@ class TestTorchDeviceType(TestCase):
         # self.assertEqual((), torch.normal(zero_d, one_d).shape)
         # self.assertEqual((), torch.normal(1, one_d).shape)
 
+        # convolutions.  Yes, we are testing nn.functional here; seems justified
+        # given its similar to the other tests
+        w = torch.randn(2, 1, 3, 3, device=device).div_(2).requires_grad_()
+        self.assertRaises(RuntimeError, lambda: torch.nn.functional.conv2d(zero_d, w, groups=1))
+        self.assertRaises(RuntimeError, lambda: torch.nn.functional.conv2d(zero_d, w, groups=2))
+
         # nll_loss -- verify input can't be 0-dimensional.
         self.assertRaises(ValueError, lambda: torch.nn.functional.nll_loss(zero_d, zero_d, reduction='none'))
         self.assertRaises(ValueError, lambda: torch.nn.functional.nll_loss(zero_d, one_d, reduction='none'))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #30773 [BC-BREAKING] change index_select scalar_check to retain dimensionality of input.
* **#30772 Turn off scalar_checks for SpatialDepthwiseConvolution and SpatialConvolutionMM.**
* #30753 Move scalar_check from codegen to code in MultiLabelMarginCriterion.
* #30748 [BC-Breaking] Fix scalar check of MultiLabelMarginLoss.
* #30733 Fix a CUDA memory leak in MultiLabelMarginCriterion error checking.
* #30728 Turn off scalar_check for is_target for MultiLabelMarginCriterion, which is handled correctly in code.
* #30727 Support 0-d tensors in CUDA MultiLabelMarginCriterion.
* #30726 MultiMarginCriterion: move scalar_check to code instead of codegen.

The input(s) can't be 0-dimensional, so its irrelevant.

Restacked version ofd: https://github.com/pytorch/pytorch/pull/30438

Differential Revision: [D18821815](https://our.internmc.facebook.com/intern/diff/D18821815)