### PR TITLE
[BC-BREAKING] change index_select scalar_check to retain dimensionality of input.

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -162,6 +162,7 @@
   variants:
     - function
   return: argument 0
+  scalar_check: self.dim() == 0
   arguments:
     - arg: THTensor* result
       output: True


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#30773 [BC-BREAKING] change index_select scalar_check to retain dimensionality of input.**
* #30772 Turn off scalar_checks for SpatialDepthwiseConvolution and SpatialConvolutionMM.
* #30753 Move scalar_check from codegen to code in MultiLabelMarginCriterion.
* #30748 [BC-Breaking] Fix scalar check of MultiLabelMarginLoss.
* #30733 Fix a CUDA memory leak in MultiLabelMarginCriterion error checking.
* #30728 Turn off scalar_check for is_target for MultiLabelMarginCriterion, which is handled correctly in code.
* #30727 Support 0-d tensors in CUDA MultiLabelMarginCriterion.
* #30726 MultiMarginCriterion: move scalar_check to code instead of codegen.

The index_select documentaiton reads:
"The returned tensor has the same number of dimensions as the original tensor (input)."

But the implementation would return a 0-dimensional tensor iff both the input and index were 0-dimensional.
This change makes it so we retuan a 0-dimensional tensor iff the input is 0-dimensional.

Restacked version of: https://github.com/pytorch/pytorch/pull/30502

Differential Revision: [D18821814](https://our.internmc.facebook.com/intern/diff/D18821814)