### PR TITLE
[rpc] Add get_metrics and get_debug_info to rpc agent

### DIFF
--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -69,6 +69,14 @@ PyObject* rpc_init(PyObject* /* unused */) {
           .def(
               "get_worker_infos",
               &RpcAgent::getWorkerInfos,
+              py::call_guard<py::gil_scoped_release>())
+          .def(
+              "get_debug_info",
+              &RpcAgent::getDebugInfo,
+              py::call_guard<py::gil_scoped_release>())
+          .def(
+              "get_metrics",
+              &RpcAgent::getMetrics,
               py::call_guard<py::gil_scoped_release>());
 
   auto pyRRef =

--- a/torch/csrc/distributed/rpc/process_group_agent.cpp
+++ b/torch/csrc/distributed/rpc/process_group_agent.cpp
@@ -553,6 +553,18 @@ const std::chrono::milliseconds ProcessGroupAgent::getRPCEndTime(
       : futureInfo.startTime_ + futureInfo.timeout_;
 }
 
+std::unordered_map<std::string, std::string> ProcessGroupAgent::getMetrics() {
+  std::unordered_map<std::string, std::string> metrics;
+  /* For now return an empty map, TODO add metrics like send/recv count etc */
+  return metrics;
+}
+
+std::unordered_map<std::string, std::string> ProcessGroupAgent::getDebugInfo() {
+  /* This would later include more info other than metrics for eg: may include
+     stack traces for the threads owned by the agent */
+  return getMetrics();
+}
+
 } // namespace rpc
 } // namespace distributed
 } // namespace torch

--- a/torch/csrc/distributed/rpc/process_group_agent.h
+++ b/torch/csrc/distributed/rpc/process_group_agent.h
@@ -66,6 +66,9 @@ class ProcessGroupAgent : public RpcAgent {
 
   void shutdown() override;
 
+  std::unordered_map<std::string, std::string> getMetrics() override;
+  std::unordered_map<std::string, std::string> getDebugInfo() override;
+
  protected:
   // This method wraps the destination information and the message into a
   // SendWork object, and put the SendWork into a queue. Another thread will

--- a/torch/csrc/distributed/rpc/rpc_agent.h
+++ b/torch/csrc/distributed/rpc/rpc_agent.h
@@ -139,6 +139,12 @@ class TORCH_API RpcAgent {
   // Retrieve the default rpc agent.
   static std::shared_ptr<RpcAgent> getDefaultRpcAgent();
 
+  // Retrive metrics as KV map
+  virtual std::unordered_map<std::string, std::string> getMetrics() = 0;
+
+  // Retrive debug info in addition to metrics as KV map
+  virtual std::unordered_map<std::string, std::string> getDebugInfo() = 0;
+
  protected:
   const WorkerInfo workerInfo_;
   const std::string workerName_;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#30782 [rpc] Add get_metrics and get_debug_info to rpc agent**

[rpc] Add get_metrics and get_debug_info to rpc agent

Differential Revision: [D18822789](https://our.internmc.facebook.com/intern/diff/D18822789/)