### PR TITLE
[BC-BREAKING] change index_select scalar_check to retain dimensionality of input.

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -162,6 +162,7 @@
   variants:
     - function
   return: argument 0
+  scalar_check: self.dim() == 0
   arguments:
     - arg: THTensor* result
       output: True

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -403,12 +403,12 @@
 
 - name: index_add_(Tensor(a!) self, int dim, Tensor index, Tensor source) -> Tensor(a!)
   self: grad
-  source: grad.index_select(dim, index)
+  source: grad.index_select(dim, index).expand_as(source)
   index: non_differentiable
 
 - name: index_copy_(Tensor(a!) self, int dim, Tensor index, Tensor source) -> Tensor(a!)
   self: grad.clone().index_fill_(dim, index, 0)
-  source: grad.index_select(dim, index)
+  source: grad.index_select(dim, index).expand_as(source)
   index: non_differentiable
 
 - name: index_fill_.int_Scalar(Tensor(a!) self, int dim, Tensor index, Scalar value) -> Tensor(a!)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#30790 [BC-BREAKING] change index_select scalar_check to retain dimensionality of input.**
* #30789 Turn off scalar_checks for SpatialDepthwiseConvolution and SpatialConvolutionMM.
* #30770 Move scalar_check from codegen to code in MultiLabelMarginCriterion.
* #30768 [BC-Breaking] Fix scalar check of MultiLabelMarginLoss.
* #30767 Fix a CUDA memory leak in MultiLabelMarginCriterion error checking.
* #30766 Turn off scalar_check for is_target for MultiLabelMarginCriterion, which is handled correctly in code.
* #30765 Support 0-d tensors in CUDA MultiLabelMarginCriterion.

The index_select documentaiton reads:
"The returned tensor has the same number of dimensions as the original tensor (input)."

But the implementation would return a 0-dimensional tensor iff both the input and index were 0-dimensional.
This change makes it so we retuan a 0-dimensional tensor iff the input is 0-dimensional.

Restacked version of: https://github.com/pytorch/pytorch/pull/30502

Code example of change:
Previously:
```
>>> torch.index_select(torch.tensor(5), 0, torch.tensor([0]))
tensor([5])
```

Now:
```
>>> torch.index_select(torch.tensor(5), 0, torch.tensor([0]))
tensor(5)
```

Differential Revision: [D18825717](https://our.internmc.facebook.com/intern/diff/D18825717)