### PR TITLE
Wrap warning handler in a function to avoid siof

### DIFF
--- a/c10/util/Exception.cpp
+++ b/c10/util/Exception.cpp
@@ -66,8 +66,12 @@ void Error::AppendMessage(const std::string& new_msg) {
 namespace Warning {
 
 namespace {
-  static WarningHandler base_warning_handler_ = WarningHandler();
-  static thread_local WarningHandler* warning_handler_ = &base_warning_handler_;
+  WarningHandler* getHandler() {
+    static WarningHandler base_warning_handler_ = WarningHandler();
+    return &base_warning_handler_;
+  };
+  static thread_local WarningHandler* warning_handler_ = getHandler();
+
 }
 
 void warn(SourceLocation source_location, const std::string& msg) {


### PR DESCRIPTION
Summary:
SparseNN benchmark crashed due to this.
Wrap warning handler in a function to avoid siof.

Test Plan: Tested locally, SparseNN benchmark no longer crashes.

Differential Revision: D18826731

