### PR TITLE
Change interface from map of TensorShape to shapeInfoMap

### DIFF
--- a/caffe2/opt/backend_transformer_base.h
+++ b/caffe2/opt/backend_transformer_base.h
@@ -49,7 +49,7 @@ class BackendTransformerBase {
       Workspace* ws,
       NetDef* pred_net,
       const std::vector<std::string>& weight_names,
-      const std::unordered_map<std::string, TensorShape>& shape_hints,
+      const ShapeInfoMap& shape_hints,
       const std::unordered_set<int>& blacklisted_ops) = 0;
 
   static void annotateOpIndex(NetDef* net);
@@ -68,10 +68,10 @@ class BackendTransformerBase {
       const std::string& fname) const;
 
   // SSA rewrite the net and return name mapping
-  std::unordered_map<std::string, TensorShape> ssaRewriteAndMapNames(
+  ShapeInfoMap ssaRewriteAndMapNames(
       Workspace* ws,
       NetDef* pred_net,
-      const std::unordered_map<std::string, TensorShape>& input_shape_hints);
+      const ShapeInfoMap& input_shape_hints);
 
   // Wrap TensorShape into TensorProto
   TensorProto wrapShapeInfoIntoTensorProto(
@@ -87,7 +87,7 @@ class BackendTransformerBase {
   ShapeInfoMap inferShapes(
       Workspace* ws,
       NetDef* pred_net,
-      const std::unordered_map<std::string, TensorShape>& shape_hints_mapped,
+      const ShapeInfoMap& shape_hints_mapped,
       const BoundShapeSpec& spec);
 
   // Input mapping of input name -> original input name

--- a/caffe2/opt/bound_shape_inferencer.cc
+++ b/caffe2/opt/bound_shape_inferencer.cc
@@ -52,6 +52,13 @@ void BoundShapeInferencer::EnsureShapeNames(
   }
 }
 
+void BoundShapeInferencer::Initialize(
+    const ShapeInfoMap& info,
+    bool extract_feature_len) {
+  shape_info_ = info;
+  extract_feature_len_ = extract_feature_len;
+}
+
 void BoundShapeInferencer::InferOps(
     const OperatorDef& op,
     caffe2::Workspace* /* ws */) {
@@ -85,12 +92,11 @@ void BoundShapeInferencer::InferOps(
 
 void BoundShapeInferencer::InferBoundShapeAndType(
     const NetDef& net,
-    const std::unordered_map<std::string, ShapeInfo>& info,
+    const ShapeInfoMap& info,
     caffe2::Workspace* ws,
     bool extract_feature_len) {
   const static std::unordered_set<std::string> unsupported{"Tile"};
-  shape_info_ = info;
-  extract_feature_len_ = extract_feature_len;
+  Initialize(info, extract_feature_len);
 
   bool inferFinished = false;
 

--- a/caffe2/opt/bound_shape_inferencer.h
+++ b/caffe2/opt/bound_shape_inferencer.h
@@ -36,9 +36,16 @@ class BoundShapeInferencerBase {
 
   virtual ~BoundShapeInferencerBase() {}
 
+  // Initializes BoundShapeInferencer and infers bound shape and type.
+  // info: shape information of some tensors,
+  // e.g. shape information of external input / output tensors;
+  // extract_feature_len:
+  // indicating whether to extract feature length from SigridTransform
+  // and other related operators. When enabled,
+  // extracted feature length information will be used to infer tensor shapes.
   virtual void InferBoundShapeAndType(
       const NetDef& net,
-      const std::unordered_map<std::string, ShapeInfo>& info,
+      const ShapeInfoMap& info,
       caffe2::Workspace* ws,
       bool extract_feature_len = false) = 0;
 
@@ -62,7 +69,7 @@ class BoundShapeInferencerBase {
 
  protected:
   const BoundShapeSpec spec_;
-  std::unordered_map<std::string, ShapeInfo> shape_info_;
+  ShapeInfoMap shape_info_;
   bool extract_feature_len_;
 };
 
@@ -74,7 +81,7 @@ class CAFFE2_API BoundShapeInferencer : public BoundShapeInferencerBase {
   virtual ~BoundShapeInferencer() override {}
   void InferBoundShapeAndType(
       const NetDef& net,
-      const std::unordered_map<std::string, ShapeInfo>& info,
+      const ShapeInfoMap& info,
       caffe2::Workspace* ws,
       bool extract_feature_len = false) override;
 
@@ -110,7 +117,11 @@ class CAFFE2_API BoundShapeInferencer : public BoundShapeInferencerBase {
   // function
   void InferCommonOp(const OperatorDef& op);
 
-  void EnsureShapeNames(std::unordered_map<std::string, ShapeInfo>* info) const;
+  // Initialize private parameters, such as shape_info, extract_feature_len_
+  // This is called at the beginning of InferBoundShapeAndType()
+  virtual void Initialize(const ShapeInfoMap& info, bool extract_feature_len);
+
+  void EnsureShapeNames(ShapeInfoMap* info) const;
 
   TensorBoundShape::DimType current_dim_type_{TensorBoundShape_DimType_BATCH};
   int64_t current_max_batch_size_{0};

--- a/caffe2/opt/custom/glow_net_transform.cc
+++ b/caffe2/opt/custom/glow_net_transform.cc
@@ -5,10 +5,7 @@
 
 #include <unordered_set>
 
-C10_DEFINE_bool(
-    onnxifi_debug_mode,
-    false,
-    "Enable onnxifi debug mode.");
+C10_DEFINE_bool(onnxifi_debug_mode, false, "Enable onnxifi debug mode.");
 
 C10_DEFINE_bool(
     onnxifi_adjust_batch,
@@ -91,7 +88,7 @@ void onnxifi(
     const std::vector<std::string>& output_names,
     const std::vector<std::string>& weight_names,
     const std::unordered_set<int>& blacklist,
-    const std::unordered_map<std::string, TensorShape>& shape_hints,
+    const ShapeInfoMap& shape_hints,
     bool use_onnx,
     size_t max_batch_size,
     size_t max_seq_size) {
@@ -134,13 +131,14 @@ void onnxifi(
         for (const auto& d : dims) {
           try {
             input.add_dims(std::stoi(d));
-          } catch (const std::exception &e) {
+          } catch (const std::exception& e) {
             valid = false;
             CAFFE_THROW("Cannot parse shape hint: ", hint);
           }
         }
         if (valid) {
-          more_shape_hints.emplace(kv.front(), input);
+          more_shape_hints.emplace(
+              kv.front(), constructShapeInfoWithDefaultDimType(input));
         }
       } else {
         CAFFE_THROW("Cannot parse shape hint: ", hint);

--- a/caffe2/opt/custom/glow_net_transform.h
+++ b/caffe2/opt/custom/glow_net_transform.h
@@ -6,6 +6,7 @@
 
 #include <caffe2/core/net.h>
 #include <caffe2/core/workspace.h>
+#include <caffe2/opt/shape_info.h>
 #include <caffe2/proto/caffe2_pb.h>
 
 C10_DECLARE_string(onnxifi_blacklist);
@@ -26,7 +27,7 @@ void onnxifi(
     const std::vector<std::string>& output_names,
     const std::vector<std::string>& weight_names,
     const std::unordered_set<int>& blacklist,
-    const std::unordered_map<std::string, TensorShape>& shape_hints,
+    const ShapeInfoMap& shape_hints,
     bool use_onnx,
     size_t max_batch_size = 0,
     size_t max_seq_size = 0);

--- a/caffe2/opt/onnxifi_transformer.cc
+++ b/caffe2/opt/onnxifi_transformer.cc
@@ -853,7 +853,7 @@ void OnnxifiTransformer::transform(
     Workspace* ws,
     NetDef* pred_net,
     const std::vector<std::string>& weight_names,
-    const std::unordered_map<std::string, TensorShape>& input_shape_hints,
+    const ShapeInfoMap& input_shape_hints,
     const std::unordered_set<int>& blacklisted_ops) {
   CAFFE_ENFORCE(ws);
   CAFFE_ENFORCE(pred_net, "Predict net cannot be nullptr");

--- a/caffe2/opt/onnxifi_transformer.h
+++ b/caffe2/opt/onnxifi_transformer.h
@@ -35,7 +35,7 @@ class CAFFE2_API OnnxifiTransformer final : public BackendTransformerBase {
       Workspace* ws,
       NetDef* pred_net,
       const std::vector<std::string>& weight_names,
-      const std::unordered_map<std::string, TensorShape>& shape_hints,
+      const ShapeInfoMap& shape_hints,
       const std::unordered_set<int>& blacklisted_ops) override;
 
  private:

--- a/caffe2/opt/shape_info.cc
+++ b/caffe2/opt/shape_info.cc
@@ -41,4 +41,15 @@ bool operator==(const ShapeInfo& lhs, const ShapeInfo& rhs) {
       lhs.shape.SerializeAsString() == rhs.shape.SerializeAsString();
 }
 
+ShapeInfo constructShapeInfoWithDefaultDimType(
+    TensorShape shape,
+    TensorBoundShape_DimType defaultFirstDimType) {
+  std::vector<TensorBoundShape_DimType> dimType(
+      shape.dims_size(), TensorBoundShape_DimType_CONSTANT);
+  if (dimType.size()) {
+    dimType[0] = defaultFirstDimType;
+  }
+  return ShapeInfo(dimType, shape);
+}
+
 } // namespace caffe2

--- a/caffe2/opt/shape_info.h
+++ b/caffe2/opt/shape_info.h
@@ -115,4 +115,16 @@ ShapeInfo getShapeInfoFromBlob(const Blob* blob);
 
 bool operator==(const ShapeInfo& lhs, const ShapeInfo& rhs);
 
+// Construct a ShapeInfo instance from TensorShape and constructed dimType.
+// Default first dimension of dimType is BATCH, reason:
+// We treat first dimension of hinted shapes as BATCH.
+// If there are shape hints on blobs in the workspace,
+// since they are already inserted as CONSTANT, it will take effect here.
+// For SEQ typed tensors, there are only a few of them and they will be
+// handled by BoundShapeInferencer.
+CAFFE2_API ShapeInfo constructShapeInfoWithDefaultDimType(
+    TensorShape shape,
+    TensorBoundShape_DimType defaultFirstDimType =
+        TensorBoundShape_DimType_BATCH);
+
 } // namespace caffe2

--- a/caffe2/opt/tvm_transformer.cc
+++ b/caffe2/opt/tvm_transformer.cc
@@ -148,7 +148,7 @@ void TvmTransformer::transform(
     Workspace* ws,
     NetDef* pred_net,
     const std::vector<std::string>& weight_names,
-    const std::unordered_map<std::string, TensorShape>& input_shape_hints,
+    const ShapeInfoMap& input_shape_hints,
     const std::unordered_set<int>& blacklisted_ops) {
   CAFFE_ENFORCE(ws);
   CAFFE_ENFORCE(pred_net, "Predict net cannot be nullptr");
@@ -263,7 +263,7 @@ void tvmTransform(
     const std::vector<std::string>& input_names,
     const std::vector<std::string>& output_names,
     const std::vector<std::string>& weight_names,
-    const std::unordered_map<std::string, TensorShape>& shape_hints,
+    const ShapeInfoMap& shape_hints,
     const std::unordered_set<int>& blacklisted_ops,
     size_t max_batch_size,
     size_t max_seq_size,

--- a/caffe2/opt/tvm_transformer.h
+++ b/caffe2/opt/tvm_transformer.h
@@ -36,7 +36,7 @@ class CAFFE2_API TvmTransformer final : public BackendTransformerBase {
       Workspace* ws,
       NetDef* pred_net,
       const std::vector<std::string>& weight_names,
-      const std::unordered_map<std::string, TensorShape>& shape_hints,
+      const ShapeInfoMap& shape_hints,
       const std::unordered_set<int>& blacklisted_ops) override;
 
  private:
@@ -70,7 +70,7 @@ CAFFE2_API void tvmTransform(
     const std::vector<std::string>& input_names,
     const std::vector<std::string>& output_names,
     const std::vector<std::string>& weight_names,
-    const std::unordered_map<std::string, TensorShape>& shape_hints,
+    const ShapeInfoMap& shape_hints,
     const std::unordered_set<int>& blacklisted_ops,
     size_t max_batch_size,
     size_t max_seq_size,

--- a/caffe2/python/pybind_state.cc
+++ b/caffe2/python/pybind_state.cc
@@ -26,6 +26,7 @@
 #include "caffe2/opt/onnxifi_transformer.h"
 #include "caffe2/opt/optimize_ideep.h"
 #include "caffe2/opt/passes.h"
+#include "caffe2/opt/shape_info.h"
 #include "caffe2/predictor/emulator/data_filler.h"
 #include "caffe2/predictor/predictor.h"
 #include "caffe2/python/pybind_state_registry.h"
@@ -247,7 +248,8 @@ bool feedBlob(
   }
 #ifdef FBCODE_CAFFE2
   if (auto module = torch::jit::script::as_module(arg)) {
-    blob->GetMutable<std::unique_ptr<torch::jit::script::Module>>()->reset(new torch::jit::script::Module(*module));
+    blob->GetMutable<std::unique_ptr<torch::jit::script::Module>>()->reset(
+        new torch::jit::script::Module(*module));
     return true;
   }
 #endif
@@ -1720,10 +1722,12 @@ void addGlobalMethods(py::module& m) {
             ParseProtoFromLargeString(
                 pred_net_str.cast<std::string>(), &pred_net),
             "broken pred_net protobuf");
-        std::unordered_map<std::string, TensorShape> tensor_shapes;
+        ShapeInfoMap shape_map;
         for (const auto& it : shapes) {
-          tensor_shapes.emplace(
-              it.first, CreateTensorShape(it.second, TensorProto::FLOAT));
+          shape_map.emplace(
+              it.first,
+              constructShapeInfoWithDefaultDimType(
+                  CreateTensorShape(it.second, TensorProto::FLOAT)));
         }
         OnnxifiTransformerOptions opts;
         opts.bound_shape_spec.max_batch_size = max_batch_size;
@@ -1745,7 +1749,7 @@ void addGlobalMethods(py::module& m) {
             curr_ws,
             &pred_net,
             weight_names_overwrite,
-            tensor_shapes,
+            shape_map,
             blacklist_set);
         std::string pred_net_str2;
         pred_net.SerializeToString(&pred_net_str2);


### PR DESCRIPTION
Summary: Change shape_hints from map<string, TensorShape> to ShapeInfoMap to catch dimType info from model file.

Differential Revision: D18821486

