### PR TITLE
Export FBGEMM headers when installing PyTorch

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -543,8 +543,7 @@ if(USE_FBGEMM)
 
   if(USE_FBGEMM)
     list(APPEND Caffe2_DEPENDENCY_LIBS fbgemm)
-    set(fbgemm_INCLUDE_DIRS ${CMAKE_CURRENT_LIST_DIR}/../third_party/fbgemm/include)
-    message(STATUS "fcgemm include dirs: " "${fbgemm_INCLUDE_DIRS}" ", ${CMAKE_INSTALL_PREFIX}")
+    set(fbgemm_INCLUDE_DIRS ${FBGEMM_SOURCE_DIR}/include)
     install(DIRECTORY ${fbgemm_INCLUDE_DIRS}
       DESTINATION ${CMAKE_INSTALL_PREFIX}
       FILES_MATCHING PATTERN "*.h")

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -543,6 +543,11 @@ if(USE_FBGEMM)
 
   if(USE_FBGEMM)
     list(APPEND Caffe2_DEPENDENCY_LIBS fbgemm)
+    set(fbgemm_INCLUDE_DIRS ${CMAKE_CURRENT_LIST_DIR}/../third_party/fbgemm/include)
+    message(STATUS "fcgemm include dirs: " "${fbgemm_INCLUDE_DIRS}" ", ${CMAKE_INSTALL_PREFIX}")
+    install(DIRECTORY ${fbgemm_INCLUDE_DIRS}
+      DESTINATION ${CMAKE_INSTALL_PREFIX}
+      FILES_MATCHING PATTERN "*.h")
   endif()
 endif()
 

--- a/setup.py
+++ b/setup.py
@@ -245,7 +245,7 @@ if IS_WINDOWS:
     cmake_python_library = "{}/libs/python{}.lib".format(
         distutils.sysconfig.get_config_var("prefix"),
         distutils.sysconfig.get_config_var("VERSION"))
-    # Fix virtualenv builds 
+    # Fix virtualenv builds
     # TODO: Fix for python < 3.3
     if not os.path.exists(cmake_python_library):
         cmake_python_library = "{}/libs/python{}.lib".format(
@@ -846,6 +846,7 @@ if __name__ == '__main__':
                 'include/torch/csrc/jit/testing/*.h',
                 'include/torch/csrc/onnx/*.h',
                 'include/torch/csrc/utils/*.h',
+                'include/fbgemm/*.h',
                 'include/pybind11/*.h',
                 'include/pybind11/detail/*.h',
                 'include/TH/*.h*',


### PR DESCRIPTION
We export a few fbgemm related headers when installing PyTorch but the fbgemm headers themselves are not exported. This PR tries to fix it. 