### PR TITLE
Fix `os.register_at_fork` not defined on Windows

### DIFF
--- a/torch/multiprocessing/_atfork.py
+++ b/torch/multiprocessing/_atfork.py
@@ -3,7 +3,7 @@ import sys
 
 __all__ = ['register_after_fork']
 
-if sys.version_info < (3, 7):
+if sys.platform == 'win32' or sys.version_info < (3, 7):
     import multiprocessing.util as _util
 
     def _register(func):


### PR DESCRIPTION
According to https://docs.python.org/3.8/library/os.html#os.register_at_fork, this function is only available in Unix platforms.