### PR TITLE
Intrusive_ptr implementation slower than shared_ptr

### DIFF
--- a/.jenkins/caffe2/test.sh
+++ b/.jenkins/caffe2/test.sh
@@ -40,6 +40,9 @@ for test in $(find "$cpp_test_dir" -executable -type f); do
         LD_LIBRARY_PATH="$ld_library_path" "$test"
       fi
       ;;
+    */*_benchmark)
+      LD_LIBRARY_PATH="$ld_library_path" "$test" --benchmark_color=false
+      ;;
     *)
       # Currently, we use a mixture of gtest (caffe2) and Catch2 (ATen). While
       # planning to migrate to gtest as the common PyTorch c++ test suite, we

--- a/c10/CMakeLists.txt
+++ b/c10/CMakeLists.txt
@@ -79,6 +79,7 @@ target_include_directories(
     $<INSTALL_INTERFACE:include>)
 
 add_subdirectory(test)
+add_subdirectory(benchmark)
 
 if(USE_CUDA)
   add_subdirectory(cuda)

--- a/c10/benchmark/CMakeLists.txt
+++ b/c10/benchmark/CMakeLists.txt
@@ -1,0 +1,14 @@
+# ---[ Benchmark binaries.
+
+file(GLOB_RECURSE C10_ALL_BENCH_FILES *.cpp)
+if (BUILD_TEST)
+  foreach(bench_src ${C10_ALL_BENCH_FILES})
+    get_filename_component(bench_file_name ${bench_src} NAME_WE)
+    set(bench_name "c10_${bench_file_name}")
+    add_executable(${bench_name} "${bench_src}")
+    target_link_libraries(${bench_name} c10 benchmark)
+    if (INSTALL_TEST)
+      install(TARGETS ${bench_name} DESTINATION test)
+    endif()
+  endforeach()
+endif()

--- a/c10/benchmark/intrusive_ptr_benchmark.cpp
+++ b/c10/benchmark/intrusive_ptr_benchmark.cpp
@@ -1,0 +1,81 @@
+#include <c10/util/intrusive_ptr.h>
+
+#include "benchmark/benchmark.h"
+
+#include <map>
+#include <memory>
+#include <set>
+#include <unordered_map>
+#include <unordered_set>
+
+using c10::intrusive_ptr;
+using c10::intrusive_ptr_target;
+using c10::make_intrusive;
+using c10::weak_intrusive_ptr;
+
+namespace {
+
+// Foo uses intrusive ptr
+class Foo : public intrusive_ptr_target {
+ public:
+  Foo(int param_) : param(param_) {}
+  int param;
+};
+
+
+class Bar : public std::enable_shared_from_this<Bar> {
+ public:
+  Bar(int param_) : param(param_) {}
+  int param;
+};
+
+static void BM_IntrusivePtrCtorDtor(benchmark::State& state) {
+  intrusive_ptr<Foo> var = make_intrusive<Foo>(0);
+  while (state.KeepRunning()) {
+    volatile intrusive_ptr<Foo> var2 = var;
+  }
+}
+BENCHMARK(BM_IntrusivePtrCtorDtor);
+
+static void BM_SharedPtrCtorDtor(benchmark::State& state) {
+  std::shared_ptr<Bar> var = std::make_shared<Bar>(0);
+  while (state.KeepRunning()) {
+    volatile std::shared_ptr<Bar> var2 = var;
+  }
+}
+BENCHMARK(BM_SharedPtrCtorDtor);
+
+// todo: parameterize the array length
+static const int kLength = 1000;
+
+static void BM_IntrusivePtrArray(benchmark::State& state) {
+  intrusive_ptr<Foo> var = make_intrusive<Foo>(0);
+  std::vector<intrusive_ptr<Foo> > vararray(kLength);
+  while (state.KeepRunning()) {
+    for (int i = 0; i < kLength; ++i) {
+      vararray[i] = var;
+    }
+    for (int i = 0; i < kLength; ++i) {
+      vararray[i].reset();
+    }
+  }
+}
+BENCHMARK(BM_IntrusivePtrArray);
+
+static void BM_SharedPtrArray(benchmark::State& state) {
+  std::shared_ptr<Bar> var = std::make_shared<Bar>(0);
+  std::vector<std::shared_ptr<Bar> > vararray(kLength);
+  while (state.KeepRunning()) {
+    for (int i = 0; i < kLength; ++i) {
+      vararray[i] = var;
+    }
+    for (int i = 0; i < kLength; ++i) {
+      vararray[i].reset();
+    }
+  }
+}
+BENCHMARK(BM_SharedPtrArray);
+} // namespace
+
+
+BENCHMARK_MAIN();

--- a/c10/benchmark/intrusive_ptr_benchmark.cpp
+++ b/c10/benchmark/intrusive_ptr_benchmark.cpp
@@ -1,7 +1,6 @@
 #include <c10/util/intrusive_ptr.h>
 
 #include "benchmark/benchmark.h"
-
 #include <map>
 #include <memory>
 #include <set>
@@ -45,11 +44,9 @@ static void BM_SharedPtrCtorDtor(benchmark::State& state) {
 }
 BENCHMARK(BM_SharedPtrCtorDtor);
 
-// todo: parameterize the array length
-static const int kLength = 1000;
-
 static void BM_IntrusivePtrArray(benchmark::State& state) {
   intrusive_ptr<Foo> var = make_intrusive<Foo>(0);
+  const size_t kLength = state.range(0);
   std::vector<intrusive_ptr<Foo> > vararray(kLength);
   while (state.KeepRunning()) {
     for (int i = 0; i < kLength; ++i) {
@@ -60,10 +57,11 @@ static void BM_IntrusivePtrArray(benchmark::State& state) {
     }
   }
 }
-BENCHMARK(BM_IntrusivePtrArray);
+BENCHMARK(BM_IntrusivePtrArray)->RangeMultiplier(2)->Range(16, 4096);
 
 static void BM_SharedPtrArray(benchmark::State& state) {
   std::shared_ptr<Bar> var = std::make_shared<Bar>(0);
+  const size_t kLength = state.range(0);
   std::vector<std::shared_ptr<Bar> > vararray(kLength);
   while (state.KeepRunning()) {
     for (int i = 0; i < kLength; ++i) {
@@ -74,7 +72,7 @@ static void BM_SharedPtrArray(benchmark::State& state) {
     }
   }
 }
-BENCHMARK(BM_SharedPtrArray);
+BENCHMARK(BM_SharedPtrArray)->RangeMultiplier(2)->Range(16, 4096);
 } // namespace
 
 


### PR DESCRIPTION
It was a random coding exercise so I wasn't putting much effort into it; but, I was like "hey is the current intrusive_ptr implementation optimized enough?" so I compared it with shared_ptr (using std::shared_from_this).

My benchmark result shows that intrusive_ptr is actually slower. On my macbook the speed is:

```
---------------------------------------------------------------
Benchmark                        Time           CPU Iterations
---------------------------------------------------------------
BM_IntrusivePtrCtorDtor         14 ns         14 ns   52541902
BM_SharedPtrCtorDtor            10 ns         10 ns   71898849
BM_IntrusivePtrArray         14285 ns      14112 ns      49775
BM_SharedPtrArray            13821 ns      13384 ns      51602
```

Wanted to share the results so someone could probably take a look if interested.
