### PR TITLE
Enable equality operator for bfloat16 CPU scalar types.

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -302,6 +302,7 @@
   name: _th_equal
   cname: equal
   cpu_bool: True
+  cpu_bfloat16: True
   cuda_bool: True
   variants:
     - function

--- a/aten/src/TH/generic/THTensorMath.h
+++ b/aten/src/TH/generic/THTensorMath.h
@@ -6,6 +6,7 @@
 #include <ATen/core/DistributionsHelper.h>
 
 TH_API void THTensor_(nonzero)(THLongTensor *subscript, THTensor *tensor);
+TH_API int THTensor_(equal)(THTensor *ta, THTensor *tb);
 
 #if !defined(TH_REAL_IS_HALF)
 
@@ -72,7 +73,6 @@ TH_API void THTensor_(div)(THTensor *r_, THTensor *t, scalar_t value);
 #if !defined(TH_REAL_IS_BFLOAT16)
 
 TH_API accreal THTensor_(sumall)(THTensor *t);
-TH_API int THTensor_(equal)(THTensor *ta, THTensor *tb);
 
 TH_API void THTensor_(bitand)(THTensor *r_, THTensor *t, scalar_t value);
 TH_API void THTensor_(cbitand)(THTensor *r_, THTensor *t, THTensor *src);

--- a/aten/src/TH/generic/THTensorMoreMath.cpp
+++ b/aten/src/TH/generic/THTensorMoreMath.cpp
@@ -13,8 +13,6 @@ ptrdiff_t THTensor_(numel)(THTensor *t)
   return THTensor_(nElement)(t);
 }
 
-#if !defined(TH_REAL_IS_BFLOAT16)
-
 static int THTensor_(equalImpl)(THTensor *ta, THTensor* tb)
 {
   std::atomic<int> equal{1};
@@ -61,6 +59,8 @@ int THTensor_(equal)(THTensor *ta, THTensor* tb) {
 #endif
   return THTensor_(equalImpl)(ta, tb);
 }
+
+#if !defined(TH_REAL_IS_BFLOAT16)
 
 // Helper function to be used in a reduction operation.
 // Due to resize semantics of outputs, if the specified output tensor r_ has


### PR DESCRIPTION
See https://github.com/pytorch/xla/issues/1330 for reference.

@mruberry @ailzhang FYI
