### PR TITLE
[WIP] Fix behavior of "dim=()" and "dim=None" in reduction methods to match numpy

### DIFF
--- a/aten/src/ATen/NamedTensorUtils.cpp
+++ b/aten/src/ATen/NamedTensorUtils.cpp
@@ -192,16 +192,17 @@ void propagate_names_except(Tensor& result, const Tensor& src, IntArrayRef exclu
   propagate_names(result, outnames);
 }
 
-void propagate_names_for_reduction(Tensor& result, const Tensor& src, IntArrayRef reduced_dims, bool keepdim) {
-  if (keepdim) {
+void propagate_names_for_reduction(Tensor& result, const Tensor& src, c10::optional<IntArrayRef> reduced_dims, bool keepdim) {
+  // This actually means "full reduction"
+  if (!reduced_dims.has_value()) {
+    return;
+  }
+  IntArrayRef reduced_dims_value = reduced_dims.value();
+  if (keepdim || reduced_dims_value.size() == 0) {
     propagate_names(result, src);
     return;
   }
-  // This actually means "full reduction"
-  if (reduced_dims.size() == 0) {
-    return;
-  }
-  propagate_names_except(result, src, reduced_dims);
+  propagate_names_except(result, src, reduced_dims_value);
 }
 
 void propagate_names(Tensor& result, const Tensor& src) {

--- a/aten/src/ATen/NamedTensorUtils.h
+++ b/aten/src/ATen/NamedTensorUtils.h
@@ -96,7 +96,7 @@ CAFFE2_API void propagate_names(Tensor& result, const Tensor& src);
 CAFFE2_API void propagate_names_except(Tensor& result, const Tensor& src, IntArrayRef excluded_idxs);
 
 // Used for reduction ops that have a `keepdim` arg.
-CAFFE2_API void propagate_names_for_reduction(Tensor& result, const Tensor& src, IntArrayRef excluded_idxs, bool keepdim);
+CAFFE2_API void propagate_names_for_reduction(Tensor& result, const Tensor& src, c10::optional<IntArrayRef> excluded_idxs, bool keepdim);
 
 CAFFE2_API void propagate_names_for_expand(Tensor& result, const Tensor& self);
 

--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -244,6 +244,7 @@ struct CAFFE2_API IValue final {
   c10::List<int64_t> toIntList() &&;
   c10::List<int64_t> toIntList() const &;
   c10::ArrayRef<int64_t> toIntListRef() const;
+  c10::optional<c10::ArrayRef<int64_t>> toOptionalIntListRef() const;
 
   // ConstantString
   IValue(c10::intrusive_ptr<ivalue::ConstantString> v);

--- a/aten/src/ATen/core/ivalue_inl.h
+++ b/aten/src/ATen/core/ivalue_inl.h
@@ -588,6 +588,12 @@ inline c10::ArrayRef<int64_t> IValue::toIntListRef() const {
   AT_ASSERT(isIntList(), "Expected IntList but got ", tagKind());
   return static_cast<const c10::detail::ListImpl<int64_t>*>(payload.as_intrusive_ptr)->list;
 }
+inline c10::optional<c10::ArrayRef<int64_t>> IValue::toOptionalIntListRef() const {
+  if (this->isNone()) {
+    return nullopt;
+  }
+  return this->toIntListRef();
+}
 inline c10::List<double> IValue::toDoubleList() && {
   AT_ASSERT(isDoubleList(), "Expected DoubleList but got ", tagKind());
   return c10::List<double>(moveToIntrusivePtr<c10::detail::ListImpl<double>>());

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -265,9 +265,9 @@ static Tensor& sum_out_impl(Tensor& result, const Tensor& self, c10::optional<In
   return result;
 }
 
-Tensor& sum_out(Tensor& result, const Tensor& self, IntArrayRef dim,
+Tensor& sum_out(Tensor& result, const Tensor& self, c10::optional<IntArrayRef> opt_dim,
                        bool keepdim, optional<ScalarType> opt_dtype) {
-  return sum_out_impl(result, self, dim, keepdim, opt_dtype);
+  return sum_out_impl(result, self, opt_dim, keepdim, opt_dtype);
 }
 
 Tensor& sum_out(Tensor& result, const Tensor& self, c10::optional<ScalarType> opt_dtype) {
@@ -278,9 +278,9 @@ Tensor sum(const Tensor &self, c10::optional<ScalarType> dtype) {
   Tensor result;
   return at::native::sum_out(result, self, dtype);
 }
-Tensor sum(const Tensor& self, IntArrayRef dim, bool keepdim, c10::optional<ScalarType> dtype) {
+Tensor sum(const Tensor& self, c10::optional<IntArrayRef> opt_dim, bool keepdim, c10::optional<ScalarType> dtype) {
   Tensor result;
-  return at::native::sum_out(result, self, dim, keepdim, dtype);
+  return at::native::sum_out(result, self, opt_dim, keepdim, dtype);
 }
 #ifdef BUILD_NAMEDTENSOR
 Tensor sum(const Tensor& self, DimnameList dim, bool keepdim, c10::optional<ScalarType> dtype) {

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -274,16 +274,6 @@ Tensor& sum_out(Tensor& result, const Tensor& self, c10::optional<ScalarType> op
   return sum_out_impl(result, self, c10::nullopt, false, opt_dtype);
 }
 
-IntArrayRef get_all_dims(const Tensor &tensor) {
-  size_t num_dims = tensor.dim();
-  long int dims_vector[num_dims];
-  for (size_t dim = 0; dim < num_dims; dim++) {
-    dims_vector[dim] = dim;
-  }
-  IntArrayRef dim(dims_vector, &dims_vector[num_dims]);
-  return dim;
-}
-
 Tensor sum(const Tensor &self, c10::optional<ScalarType> dtype) {
   Tensor result;
   return at::native::sum_out(result, self, dtype);
@@ -535,7 +525,6 @@ Tensor norm(const Tensor& self, optional<Scalar> p, IntArrayRef dim, bool keepdi
 }
 
 Tensor norm(const Tensor& self, optional<Scalar> p, ScalarType dtype) {
-  // return at::native::norm(self, p, IntArrayRef{}, false, optional<ScalarType>(dtype));
   Tensor result;
   return norm_out(result, self, p, dtype);
 }

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2514,7 +2514,7 @@
   variants: function, method
   supports_named_tensor: True
 
-- func: sum.dim_IntList(Tensor self, int[1] dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor
+- func: sum.dim_IntList(Tensor self, int[]? dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor
   variants: function, method
   supports_named_tensor: True
 
@@ -2522,7 +2522,7 @@
   variants: function, method
   supports_named_tensor: True
 
-- func: sum.IntList_out(Tensor self, int[1] dim, bool keepdim=False, *, ScalarType? dtype=None, Tensor(a!) out) -> Tensor(a!)
+- func: sum.IntList_out(Tensor self, int[]? dim, bool keepdim=False, *, ScalarType? dtype=None, Tensor(a!) out) -> Tensor(a!)
   supports_named_tensor: True
 
 - func: sum.DimnameList_out(Tensor self, Dimname[1] dim, bool keepdim=False, *, ScalarType? dtype=None, Tensor(a!) out) -> Tensor(a!)

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2514,7 +2514,7 @@
   variants: function, method
   supports_named_tensor: True
 
-- func: sum.dim_IntList(Tensor self, int[]? dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor
+- func: sum.dim_IntList(Tensor self, int[1]? dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor
   variants: function, method
   supports_named_tensor: True
 
@@ -2522,7 +2522,7 @@
   variants: function, method
   supports_named_tensor: True
 
-- func: sum.IntList_out(Tensor self, int[]? dim, bool keepdim=False, *, ScalarType? dtype=None, Tensor(a!) out) -> Tensor(a!)
+- func: sum.IntList_out(Tensor self, int[1]? dim, bool keepdim=False, *, ScalarType? dtype=None, Tensor(a!) out) -> Tensor(a!)
   supports_named_tensor: True
 
 - func: sum.DimnameList_out(Tensor self, Dimname[1] dim, bool keepdim=False, *, ScalarType? dtype=None, Tensor(a!) out) -> Tensor(a!)

--- a/aten/src/ATen/native_parse.py
+++ b/aten/src/ATen/native_parse.py
@@ -58,6 +58,9 @@ def type_argument_translations(arg):
     # Enables int[] by translating to legacy IntArrayRef.
     elif t == 'int[]':
         t = 'IntArrayRef'
+    # Enables int[]? by translating to legacy IntArrayRef.
+    elif t == 'int[]?':
+        t = 'IntArrayRef?'
     # Enables int by translating to legacy int64_t.
     elif t == 'int':
         t = 'int64_t'
@@ -87,6 +90,11 @@ def type_argument_translations(arg):
     elif re.match(r'int\[(\d+)\]', t):
         match = re.match(r'int\[(\d+)\]', t)
         t = 'IntArrayRef'
+        size = int(match.group(1))
+    # Enables int[x]? by translating to legacy IntArrayRef[x]. See [temp translations]
+    elif re.match(r'int\[(\d+)\]\?', t):
+        match = re.match(r'int\[(\d+)\]\?', t)
+        t = 'IntArrayRef?'
         size = int(match.group(1))
     # Enables bool[x] by translating to legacy std::array<bool,x>. See [temp translations]
     elif re.match(r'bool\[(\d+)\]', t):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -935,6 +935,16 @@ class _TestTorchMixin(object):
             lambda n, d: logsumexp(n, d),
             use_integral=False)
 
+    def test_mean_empty_dim(self):
+        x = torch.randn(25, 25)
+        x_mean = x.mean(dim=())
+        self.assertEqual(x, x_mean)
+
+    def test_sum_empty_dim(self):
+        x = torch.randn(25, 25)
+        x_sum = x.sum(dim=())
+        self.assertEqual(x, x_sum)
+
     def _test_reduce_integer_upcast(self, fn, has_out=True):
         shape = (3, 4, 5)
         reduced_shape = fn(torch.ones(shape)).shape
@@ -9048,6 +9058,11 @@ class TestTorchDeviceType(TestCase):
         # larger tensor sanity check
         self.assertEqual(2 * torch.norm(torch.ones(10000)), torch.norm(torch.ones(40000)))
 
+        # empty dimensions
+        x = torch.randn(25, 25, device=device)
+        res = x.norm(dim=())
+        self.assertEqual(x.abs(), res)
+
     @skipCUDAIfNoMagma
     @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
     def test_nuclear_norm_axes_small_brute_force(self, device):
@@ -10336,6 +10351,15 @@ class TestTorchDeviceType(TestCase):
             self.assertEqual(std1, std2)
             self.assertEqual(mean1, mean2)
 
+    def test_std_mean_empty_dims(self, device):
+        x = torch.rand(100, 50, 20, device=device)
+        for unbiased in [False, True]:
+            std1, mean1 = torch.std_mean(x, unbiased=unbiased, dim=())
+            std2 = x.std(unbiased=unbiased, dim=())
+            mean2 = x.mean(dim=())
+            self.assertEqual(std1, std2)
+            self.assertEqual(mean1, mean2)
+
     def test_var_mean(self, device):
         x = torch.rand(100, 300, 50, device=device)
         for dim in range(x.dim()):
@@ -10353,6 +10377,15 @@ class TestTorchDeviceType(TestCase):
             var1, mean1 = torch.var_mean(x, unbiased=unbiased)
             var2 = x.var(unbiased=unbiased)
             mean2 = x.mean()
+            self.assertEqual(var1, var2)
+            self.assertEqual(mean1, mean2)
+
+    def test_var_mean_empty_dims(self, device):
+        x = torch.rand(100, 50, 20, device=device)
+        for unbiased in [False, True]:
+            var1, mean1 = torch.var_mean(x, unbiased=unbiased, dim=())
+            var2 = x.var(unbiased=unbiased, dim=())
+            mean2 = x.mean(dim=())
             self.assertEqual(var1, var2)
             self.assertEqual(mean1, mean2)
 

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -823,7 +823,7 @@
 - name: sum(Tensor self, *, ScalarType? dtype=None) -> Tensor
   self: grad.expand(self.sizes())
 
-- name: sum.dim_IntList(Tensor self, int[]? dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor
+- name: sum.dim_IntList(Tensor self, int[1]? dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor
   self: sum_backward(grad, self.sizes(), dim, keepdim)
 
 - name: svd(Tensor self, bool some=True, bool compute_uv=True) -> (Tensor U, Tensor S, Tensor V)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -823,7 +823,7 @@
 - name: sum(Tensor self, *, ScalarType? dtype=None) -> Tensor
   self: grad.expand(self.sizes())
 
-- name: sum.dim_IntList(Tensor self, int[1] dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor
+- name: sum.dim_IntList(Tensor self, int[]? dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor
   self: sum_backward(grad, self.sizes(), dim, keepdim)
 
 - name: svd(Tensor self, bool some=True, bool compute_uv=True) -> (Tensor U, Tensor S, Tensor V)

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -931,13 +931,17 @@ def get_python_signature(declaration, include_out):
         typename = arg['simple_type']
         typename = typename if typename != 'Type' else 'ScalarType'
 
-        # TODO: remove this and make optional types in simple_type to be consistent across
-        # tensor and other types after make Tensor? be optional instead of undefined
-        if arg.get('is_nullable') and '?' not in typename:
-            typename = '{}?'.format(typename)
+        if arg.get('is_nullable') and '?' in typename and arg.get('size') is not None:
+            typename = typename.replace('?','')
+            typename = '{}[{}]?'.format(typename, arg['size'])
+        else:
+            # TODO: remove this and make optional types in simple_type to be consistent across
+            # tensor and other types after make Tensor? be optional instead of undefined
+            if arg.get('is_nullable') and '?' not in typename:
+                typename = '{}?'.format(typename)
+            if arg.get('size') is not None:
+                typename = '{}[{}]'.format(typename, arg['size'])
 
-        if arg.get('size') is not None:
-            typename = '{}[{}]'.format(typename, arg['size'])
         param = typename + ' ' + arg['name']
         default = None
         if arg.get('default') is not None:

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -181,8 +181,9 @@ Tensor unsqueeze_multiple(const Tensor & t, IntArrayRef dim, size_t n_dims) {
     return res;
 }
 
-Tensor sum_backward(const Tensor & grad, IntArrayRef sizes, IntArrayRef dims, bool keepdim) {
-  if (!keepdim && sizes.size() > 0) {
+Tensor sum_backward(const Tensor & grad, IntArrayRef sizes, c10::optional<IntArrayRef> opt_dims, bool keepdim) {
+  if (!keepdim && sizes.size() > 0 && opt_dims.has_value()) {
+    IntArrayRef& dims = opt_dims.value();
     if (dims.size()==1) {
       return grad.unsqueeze(dims[0]).expand(sizes);
     } else {

--- a/tools/jit/gen_jit_dispatch.py
+++ b/tools/jit/gen_jit_dispatch.py
@@ -54,6 +54,7 @@ TYPE_MAP = {
     # in returns
     'std::vector<Tensor>': 'Tensor[]',
     'IntArrayRef': 'int[]',
+    'IntArrayRef?': 'int[]?',
     'Layout': 'Layout',
     'Layout?': 'Layout?',
     'Device': 'Device',
@@ -88,6 +89,8 @@ def jit_type_of(arg):
     typ = TYPE_MAP[arg['simple_type']]
     if is_sized_intlist_arg(arg):
         typ = 'int[{}]'.format(arg['size'])
+    if is_sized_intlist_optional_arg(arg):
+        typ = 'int[{}]?'.format(arg['size'])
 
     typ = optional_type_of(arg, typ)
     return typ
@@ -99,6 +102,7 @@ FROM_IVALUE = {
     'Device': '{}.toDevice()',
     'Device?': '{}.toOptional<c10::Device>()',
     'IntArrayRef': '{}.toIntListRef()',
+    'IntArrayRef?': '{}.toOptionalIntListRef()',
     'Layout': '{}.toLayout()',
     'Layout?': '{}.toOptional<c10::Layout>()',
     'MemoryFormat': '{}.toMemoryFormat()',
@@ -227,6 +231,9 @@ def is_sized_intlist_arg(arg):
     """Returns True for arguments declared as IntArrayRef[k], but False for IntArrayRef."""
     return (arg['simple_type'] == 'IntArrayRef') and ('size' in arg)
 
+def is_sized_intlist_optional_arg(arg):
+    """Returns True for arguments declared as IntArrayRef[k]?, but False for IntArrayRef?."""
+    return (arg['simple_type'] == 'IntArrayRef?') and ('size' in arg)
 
 def base_name(decl):
     name = decl['name']

--- a/torch/csrc/jit/script/function_schema_parser.cpp
+++ b/torch/csrc/jit/script/function_schema_parser.cpp
@@ -137,6 +137,7 @@ struct SchemaParser {
         name = "";
       }
     } else {
+      L.nextIf('?');
       name = L.expect(TK_IDENT).text();
       if (L.nextIf('=')) {
         default_value = parseDefaultValue(type, N);

--- a/torch/csrc/jit/tracer.cpp
+++ b/torch/csrc/jit/tracer.cpp
@@ -589,6 +589,16 @@ void addInputs(Node* n, const char* name, at::IntArrayRef value) {
       g->insertNode(g->createList(jit::IntType::get(), info))->output());
 }
 
+void addInputs(Node* n, const char* name, c10::optional<at::IntArrayRef> value) {
+  if (value) {
+    detail::genericAddInput(n, *value);
+  } else {
+    Graph* g = n->owningGraph();
+    Value* none = g->insertNode(g->createNone())->output();
+    n->addInput(none);
+  }
+}
+
 void addInputs(Node* n, const char* name, const ArrayRef<double>& value) {
   AT_ERROR("Tracing float lists currently not supported!");
 }

--- a/torch/csrc/jit/tracer.h
+++ b/torch/csrc/jit/tracer.h
@@ -234,6 +234,7 @@ TORCH_API void addInputs(
     const c10::optional<at::Scalar>& value);
 TORCH_API void addInputs(Node* n, const char* name, const at::Tensor& value);
 TORCH_API void addInputs(Node* n, const char* name, at::IntArrayRef value);
+TORCH_API void addInputs(Node* n, const char* name, c10::optional<at::IntArrayRef> value);
 TORCH_API void addInputs(
     Node* n,
     const char* name,

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -133,6 +133,7 @@ struct PythonArgs {
   template<int N>
   inline std::array<at::Tensor, N> tensorlist_n(int i);
   inline std::vector<int64_t> intlist(int i);
+  inline c10::optional<std::vector<int64_t>> toIntListOptional(int i);
   inline std::vector<int64_t> intlistWithDefault(int i, std::vector<int64_t> default_intlist);
   inline at::Generator* generator(int i);
   inline at::Storage storage(int i);
@@ -298,6 +299,11 @@ inline std::array<at::Tensor, N> PythonArgs::tensorlist_n(int i) {
 }
 
 inline std::vector<int64_t> PythonArgs::intlist(int i) {
+  return intlistWithDefault(i, signature.params[i].default_intlist);
+}
+
+inline c10::optional<std::vector<int64_t>> PythonArgs::toIntListOptional(int i) {
+  if (!args[i]) return c10::nullopt;
   return intlistWithDefault(i, signature.params[i].default_intlist);
 }
 


### PR DESCRIPTION
dim=() means that no reduction should occur, as in numpy

Issue #29137

