### PR TITLE
Fix error checking of CUDA multi_margin_loss.

### DIFF
--- a/aten/src/THCUNN/generic/MultiMarginCriterion.cu
+++ b/aten/src/THCUNN/generic/MultiMarginCriterion.cu
@@ -20,6 +20,9 @@ void THNN_(MultiMarginCriterion_updateOutput)(
     weights = THCTensor_(newContiguous)(state, weights);
   if (THTensor_nDimensionLegacyNoScalars(input) == 1)
   {
+    int nframe = 1;
+    THArgCheck(!target->is_empty() && (THTensor_nDimensionLegacyNoScalars(target) == 1) && (THTensor_sizeLegacyNoScalars(target, 0) == nframe), 3,
+               "inconsistent target size");
     dim3 blocks(1);
     dim3 threads(MULTIMARGIN_THREADS);
     THCTensor_(resize1d)(state, output, 1);

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -10319,6 +10319,10 @@ class TestNNDeviceType(NNTestCase):
             with torch.backends.cudnn.flags(enabled=False):
                 self._test_batchnorm_update_stats(device)
 
+    def test_multi_margin_loss_errors(self, device):
+        self.assertRaises(RuntimeError,
+                          lambda: nn.functional.multi_margin_loss(torch.randn(5, device=device),
+                                                                  torch.zeros(3, device=device)))
 
 instantiate_device_type_tests(TestNNDeviceType, globals())
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

It didn't verify in the 1-d case that the targets were size 1..