### PR TITLE
[BC-BREAKING] MultiMarginCriterion: fix scalar_check in the case where reduction == None.

### DIFF
--- a/aten/src/ATen/native/LossMultiMargin.cpp
+++ b/aten/src/ATen/native/LossMultiMargin.cpp
@@ -116,7 +116,7 @@ void multi_margin_loss_out_cpu_template(
       target.sizes());
 
   // produce a scalar output for 1d input
-  if (reduction == Reduction::None && ndims > 1) {
+  if (reduction == Reduction::None && target.dim() > 0) {
     output.resize_({nframe});
   } else {
     output.resize_({});

--- a/aten/src/ATen/nn.yaml
+++ b/aten/src/ATen/nn.yaml
@@ -18,7 +18,7 @@
 - name: _thnn_multi_margin_loss(Tensor self, LongTensor target, Scalar p, Scalar margin, Tensor? weight, int64_t reduction)
   cname: MultiMarginCriterion
   scalar_check:
-    output: reduction != at::Reduction::None || self_->dim() == 0 || (reduction == at::Reduction::None && self_->dim() == 1)
+    output: reduction != at::Reduction::None || target_->dim() == 0
 
 - name: _thnn_multilabel_margin_loss(Tensor self, LongTensor target, int64_t reduction=at::Reduction::Mean)
   cname: MultiLabelMarginCriterion

--- a/test/common_nn.py
+++ b/test/common_nn.py
@@ -2702,20 +2702,19 @@ def multimarginloss_reference(input, target, p=1, margin=1, weight=None, reducti
     if target.dim() == 0:
         target = target.unsqueeze(0)
 
-    else:
-        n = input.size(0)
-        dim = input.size(1)
-        output = input.new(n)
-        for x in range(0, n):
-            output[x] = _multimarginloss_reference(input[x], target[x], p, margin, weight)
+    n = input.size(0)
+    dim = input.size(1)
+    output = input.new(n)
+    for x in range(0, n):
+        output[x] = _multimarginloss_reference(input[x], target[x], p, margin, weight)
 
-        if reduction == 'mean':
-            return output.mean() / dim
-        elif reduction == 'sum':
-            return output.sum() / dim
-        elif target_dim == 0:
-            return output.squeeze(0) / dim
-        return output / dim
+    if reduction == 'mean':
+        return output.mean() / dim
+    elif reduction == 'sum':
+        return output.sum() / dim
+    elif target_dim == 0:
+        return output.squeeze(0) / dim
+    return output / dim
 
 
 def cosineembeddingloss_reference(input1, input2, target, margin=0, reduction='mean'):

--- a/test/common_nn.py
+++ b/test/common_nn.py
@@ -807,6 +807,20 @@ def multimarginloss_1d_no_reduce_test():
         pickle=False)
 
 
+def multimarginloss_1d_input_0d_target_no_reduce_test():
+    t = torch.rand(()).mul(8).floor().long()
+    return dict(
+        fullname='multimarginloss_1d_input_0d_target_no_reduce',
+        constructor=wrap_functional(
+            lambda i: F.multi_margin_loss(i, t.type_as(i).long(), reduction='none')),
+        input_fn=lambda: torch.randn(10),
+        reference_fn=lambda i, *_:
+            loss_reference_fns['MultiMarginLoss'](i, t.data.type_as(i).long(), reduction='none'),
+        check_sum_reduction=True,
+        check_gradgrad=False,
+        pickle=False)
+
+
 def multimarginloss_p_no_reduce_test():
     t = torch.rand(5).mul(8).floor().long()
     return dict(
@@ -931,6 +945,7 @@ new_module_tests = [
     multilabelsoftmarginloss_weights_no_reduce_test(),
     multimarginloss_no_reduce_test(),
     multimarginloss_1d_no_reduce_test(),
+    multimarginloss_1d_input_0d_target_no_reduce_test(),
     multimarginloss_p_no_reduce_test(),
     multimarginloss_margin_no_reduce_test(),
     multimarginloss_weights_no_reduce_test(),
@@ -2680,10 +2695,13 @@ def _multimarginloss_reference(input, target_idx, p, margin, weight):
 
 
 def multimarginloss_reference(input, target, p=1, margin=1, weight=None, reduction='mean'):
-    if input.dim() == 1:
-        n = 1
-        dim = input.size(0)
-        return _multimarginloss_reference(input, target[0], p, margin, weight) / dim
+    if input.dim() < 2:
+        input = input.unsqueeze(0) if input.dim() == 1 else input.unsqueeze(0).unsqueeze(0)
+
+    target_dim = target.dim()
+    if target.dim() == 0:
+        target = target.unsqueeze(0)
+
     else:
         n = input.size(0)
         dim = input.size(1)
@@ -2695,6 +2713,8 @@ def multimarginloss_reference(input, target, p=1, margin=1, weight=None, reducti
             return output.mean() / dim
         elif reduction == 'sum':
             return output.sum() / dim
+        elif target_dim == 0:
+            return output.squeeze(0) / dim
         return output / dim
 
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6325,6 +6325,13 @@ class TestTorchDeviceType(TestCase):
                     self.assertRaises(RuntimeError, lambda: torch.nn.functional.multilabel_margin_loss(input, target, reduction='mean'))
                     self.assertRaises(RuntimeError, lambda: torch.nn.functional.multilabel_margin_loss(input, target, reduction='sum'))
 
+        # multi_margin_loss
+        for input in (zero_d, one_d, torch.randn(1, 1, device=device)):
+            for target in (torch.tensor(0, device=device), torch.tensor([0], device=device)):
+                self.assertEqual(target.shape, torch.nn.functional.multi_margin_loss(input, target, reduction='none').shape)
+                self.assertEqual((), torch.nn.functional.multi_margin_loss(input, target, reduction='mean').shape)
+                self.assertEqual((), torch.nn.functional.multi_margin_loss(input, target, reduction='sum').shape)
+
     @onlyCPU
     @dtypes(torch.float)
     def test_diag(self, device, dtype):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #30827 MultiMarginCriterion: move scalar_check from codegen to code.
* **#30826 [BC-BREAKING] MultiMarginCriterion: fix scalar_check in the case where reduction == None.**
* #30825 Fix error checking of CUDA multi_margin_loss.

Previously the scalar_check for the reduction None case was:
input.dim() <= 1, but it should be target based, i.e.:
target.dim() == 0.  This follows from the "correct cases", i.e.
(N, C) X (N,) -> (N,)
(C,) X () -> ()

Code example:

Previously:
```
>>> nn.MultiMarginLoss(reduction='none')(torch.tensor([1.]), torch.tensor([0]))
tensor(0.)
```
Now:
```
>>> nn.MultiMarginLoss(reduction='none')(torch.tensor([1.]), torch.tensor([0]))
tensor([0.])
```
Differential Revision: [D18833660](https://our.internmc.facebook.com/intern/diff/D18833660)