### PR TITLE
use avx2 and fma in adagrad

### DIFF
--- a/caffe2/perfkernels/adagrad.cc
+++ b/caffe2/perfkernels/adagrad.cc
@@ -72,6 +72,7 @@ void rowwise_adagrad_update__base(
 }
 
 // version without prefetching
+decltype(adagrad_update__base) adagrad_update__avx2_fma;
 decltype(adagrad_update__base) adagrad_update__avx_f16c;
 void adagrad_update(
     int N,
@@ -83,10 +84,12 @@ void adagrad_update(
     float epsilon,
     float decay,
     float lr) {
+  AVX2_FMA_DO(adagrad_update, N, w, g, h, nw, nh, epsilon, decay, lr);
   AVX_F16C_DO(adagrad_update, N, w, g, h, nw, nh, epsilon, decay, lr);
   BASE_DO(adagrad_update, N, w, g, h, nw, nh, epsilon, decay, lr);
 }
 
+decltype(adagrad_update_prefetch__base) adagrad_update_prefetch__avx2_fma;
 decltype(adagrad_update_prefetch__base) adagrad_update_prefetch__avx_f16c;
 void adagrad_update_prefetch(
     int N,
@@ -106,6 +109,20 @@ void adagrad_update_prefetch(
 
     float epsilon,
     float lr) {
+  AVX2_FMA_DO(
+      adagrad_update_prefetch,
+      N,
+      w,
+      w_n,
+      g,
+      h,
+      h_n,
+      nw,
+      nw_n,
+      nh,
+      nh_n,
+      epsilon,
+      lr);
   AVX_F16C_DO(
       adagrad_update_prefetch,
       N,
@@ -139,6 +156,8 @@ void adagrad_update_prefetch(
 // Version with prefetching for embeddings and
 // momentum using fp16
 decltype(
+    adagrad_fp16_update_prefetch__base) adagrad_fp16_update_prefetch__avx2_fma;
+decltype(
     adagrad_fp16_update_prefetch__base) adagrad_fp16_update_prefetch__avx_f16c;
 void adagrad_fp16_update_prefetch(
     int N,
@@ -153,6 +172,20 @@ void adagrad_fp16_update_prefetch(
     at::Half* nh_n, // prefetch ptr
     float epsilon,
     float lr) {
+  AVX2_FMA_DO(
+      adagrad_fp16_update_prefetch,
+      N,
+      w,
+      w_n,
+      g,
+      h,
+      h_n,
+      nw,
+      nw_n,
+      nh,
+      nh_n,
+      epsilon,
+      lr);
   AVX_F16C_DO(
       adagrad_fp16_update_prefetch,
       N,
@@ -183,6 +216,7 @@ void adagrad_fp16_update_prefetch(
       lr);
 }
 
+decltype(rowwise_adagrad_update__base) rowwise_adagrad_update__avx2_fma;
 decltype(rowwise_adagrad_update__base) rowwise_adagrad_update__avx_f16c;
 void rowwise_adagrad_update(
     int N,
@@ -196,12 +230,14 @@ void rowwise_adagrad_update(
 
     float epsilon,
     float lr) {
+  AVX2_FMA_DO(rowwise_adagrad_update, N, w, w_n, g, h, h_n, epsilon, lr);
   AVX_F16C_DO(rowwise_adagrad_update, N, w, w_n, g, h, h_n, epsilon, lr);
   BASE_DO(rowwise_adagrad_update, N, w, w_n, g, h, h_n, epsilon, lr);
 }
 
 SPARSE_ADAGRAD_SPECIALIZATION(int32_t, base);
 
+decltype(sparse_adagrad_int32_t__base) sparse_adagrad_int32_t__avx2_fma;
 decltype(sparse_adagrad_int32_t__base) sparse_adagrad_int32_t__avx_f16c;
 template <>
 int sparse_adagrad(
@@ -216,6 +252,19 @@ int sparse_adagrad(
     float* nh,
     float epsilon,
     float lr) {
+  AVX2_FMA_DO(
+      sparse_adagrad_int32_t,
+      num_rows,
+      block_size,
+      param_size,
+      w,
+      g,
+      h,
+      indices,
+      nw,
+      nh,
+      epsilon,
+      lr);
   AVX_F16C_DO(
       sparse_adagrad_int32_t,
       num_rows,
@@ -246,6 +295,7 @@ int sparse_adagrad(
 
 SPARSE_ADAGRAD_SPECIALIZATION(int64_t, base);
 
+decltype(sparse_adagrad_int64_t__base) sparse_adagrad_int64_t__avx2_fma;
 decltype(sparse_adagrad_int64_t__base) sparse_adagrad_int64_t__avx_f16c;
 template <>
 int sparse_adagrad(
@@ -260,6 +310,19 @@ int sparse_adagrad(
     float* nh,
     float epsilon,
     float lr) {
+  AVX2_FMA_DO(
+      sparse_adagrad_int64_t,
+      num_rows,
+      block_size,
+      param_size,
+      w,
+      g,
+      h,
+      indices,
+      nw,
+      nh,
+      epsilon,
+      lr);
   AVX_F16C_DO(
       sparse_adagrad_int64_t,
       num_rows,

--- a/caffe2/perfkernels/adagrad_avx2.cc
+++ b/caffe2/perfkernels/adagrad_avx2.cc
@@ -1,0 +1,135 @@
+#include "caffe2/perfkernels/adagrad.h"
+#include "caffe2/perfkernels/cvtsh_ss_bugfix.h"
+
+#include <emmintrin.h>
+#include <immintrin.h>
+
+namespace caffe2 {
+
+// version without prefetching
+void adagrad_update__avx2_fma(
+    int N,
+    const float* w,
+    const float* g,
+    const float* h,
+    float* nw,
+    float* nh,
+    float epsilon,
+    float decay,
+    float lr) {
+  constexpr size_t kSize = 8;
+  auto i = 0;
+  for (; i + kSize <= N; i += kSize) {
+    __m256 gi = _mm256_loadu_ps(g + i);
+    __m256 hi = _mm256_loadu_ps(h + i);
+    __m256 wi = _mm256_loadu_ps(w + i);
+
+    __m256 nhi =
+        _mm256_fmadd_ps(_mm256_set1_ps(decay), hi, _mm256_mul_ps(gi, gi));
+    _mm256_storeu_ps(nh + i, nhi);
+    __m256 vtmp = _mm256_div_ps(
+        gi, _mm256_add_ps(_mm256_sqrt_ps(nhi), _mm256_set1_ps(epsilon)));
+    _mm256_storeu_ps(nw + i, _mm256_fmadd_ps(_mm256_set1_ps(lr), vtmp, wi));
+  }
+
+  for (; i < N; ++i) {
+    float gi = g[i];
+    float hi = nh[i] = std::fma(decay, h[i], gi * gi);
+    nw[i] = std::fma(lr, gi / (std::sqrt(hi) + epsilon), w[i]);
+  }
+}
+
+void adagrad_update_prefetch__avx2_fma(
+    int N,
+    const float* w,
+    const float* w_n, // prefetch ptr
+
+    const float* g,
+
+    const float* h,
+    const float* h_n, // prefetch ptr
+
+    float* nw,
+    float* nw_n, // prefetch ptr
+
+    float* nh,
+    float* nh_n, // prefetch ptr
+
+    float epsilon,
+    float lr) {
+  internal::adagrad_update_prefetch_inlined(
+      N, w, w_n, g, h, h_n, nw, nw_n, nh, nh_n, epsilon, lr);
+}
+
+// Compute adagrad sparse, assumes embedding and momentum are at::Half
+void adagrad_fp16_update_prefetch__avx2_fma(
+    int N,
+    const at::Half* w,
+    const at::Half* w_n, // prefetch ptr
+    const float* g,
+    const at::Half* h,
+    const at::Half* h_n, // prefetch ptr
+    at::Half* nw,
+    at::Half* nw_n, // prefetch ptr
+    at::Half* nh,
+    at::Half* nh_n, // prefetch ptr
+    float epsilon,
+    float lr) {
+  constexpr int kSize = 8;
+  auto i = 0;
+  for (; i + kSize <= N; i += kSize) {
+    _mm_prefetch(reinterpret_cast<const char*>(&w_n[i]), _MM_HINT_T0);
+    _mm_prefetch(reinterpret_cast<const char*>(&h_n[i]), _MM_HINT_T0);
+    _mm_prefetch(reinterpret_cast<const char*>(&nw_n[i]), _MM_HINT_T0);
+    _mm_prefetch(reinterpret_cast<const char*>(&nh_n[i]), _MM_HINT_T0);
+
+    // only convert momentum and embedding, gradient is fp32
+    __m256 gi = _mm256_loadu_ps(g + i);
+    __m128i hhi = _mm_loadu_si128(reinterpret_cast<const __m128i*>(h + i));
+    __m256 hi = _mm256_cvtph_ps(hhi);
+    __m128i whi = _mm_loadu_si128(reinterpret_cast<const __m128i*>(w + i));
+    __m256 wi = _mm256_cvtph_ps(whi);
+
+    __m256 nhi = _mm256_fmadd_ps(gi, gi, hi);
+    __m128i nhhi = _mm256_cvtps_ph(nhi, 0);
+    _mm_storeu_si128(reinterpret_cast<__m128i*>(nh + i), nhhi);
+
+    __m256 vtmp = _mm256_div_ps(
+        gi, _mm256_add_ps(_mm256_sqrt_ps(nhi), _mm256_set1_ps(epsilon)));
+    __m256 nwi = _mm256_fmadd_ps(_mm256_set1_ps(lr), vtmp, wi);
+    __m128i nhwi = _mm256_cvtps_ph(nwi, 0);
+    _mm_storeu_si128(reinterpret_cast<__m128i*>(nw + i), nhwi);
+  }
+
+  for (; i < N; ++i) {
+    float gi = g[i];
+    float nhi = std::fma(
+        gi, gi, _cvtsh_ss(reinterpret_cast<const unsigned short*>(h)[i]));
+    reinterpret_cast<unsigned short*>(nh)[i] = _cvtss_sh(nhi, 0);
+    float nwi = std::fma(
+        lr,
+        gi / (std::sqrt(nhi) + epsilon),
+        _cvtsh_ss(reinterpret_cast<const unsigned short*>(w)[i]));
+    reinterpret_cast<unsigned short*>(nw)[i] = _cvtss_sh(nwi, 0);
+  }
+}
+
+void rowwise_adagrad_update__avx2_fma(
+    int N,
+    float* w,
+    float* w_n, // prefetch ptr
+
+    const float* g,
+
+    float* h,
+    float* h_n, // prefetch ptr
+
+    float epsilon,
+    float lr) {
+  internal::rowwise_adagrad_update_inlined(N, w, w_n, g, h, h_n, epsilon, lr);
+}
+
+SPARSE_ADAGRAD_SPECIALIZATION(int32_t, avx2_fma);
+SPARSE_ADAGRAD_SPECIALIZATION(int64_t, avx2_fma);
+
+} // namespace caffe2


### PR DESCRIPTION
Summary: Using FMA should be faster and provide (slight) accuracy benefits.

Test Plan:
buck test caffe2/caffe2/fb/dper/layer_models/tests/split_1:sparse_nn_test_4

gives the following errors and this may tell us that these tests are either numerically too sensitive or the tolerance range is too small. For test_beta_loss, I guess using fma actually improved the accuracy.

```
> ======================================================================
> FAIL: test_cat_cat_embedding_arch_with_transfter_on_last (caffe2.caffe2.fb.dper.layer_models.tests.split_1.sparse_nn_test_4.SparseNNTest4)
> ----------------------------------------------------------------------
> Traceback (most recent call last):
>   File "/data/users/jongsoo/fbsource/fbcode/buck-out/dev/gen/caffe2/caffe2/fb/dper/layer_models/tests/split_1/sparse_nn_test_4-3.7#binary,link-tree/caffe2/caffe2/fb/dper/layer_models/tests/split_1/sparse_nn_test_4.py", line 903, in test_cat_cat_embedding_arch_with_transfter_on_last
>     self.assertAlmostEqual(results["model_ne"], 0.1744275, delta=1e-5)
> AssertionError: 0.17446803612154085 != 0.1744275 within 1e-05 delta (4.053612154084063e-05 difference)

> ======================================================================
> FAIL: test_beta_loss (caffe2.caffe2.fb.dper.layer_models.tests.split_1.sparse_nn_test_4.SparseNNTest4)
> ----------------------------------------------------------------------
> Traceback (most recent call last):
>   File "/data/users/jongsoo/fbsource/fbcode/buck-out/dev/gen/caffe2/caffe2/fb/dper/layer_models/tests/split_1/sparse_nn_test_4-3.7#binary,link-tree/caffe2/caffe2/fb/dper/layer_models/tests/split_1/sparse_nn_test_4.py", line 681, in test_beta_loss
>     results["model_avg_lifetime_metric"], -1.958006, delta=1e-5
> AssertionError: -1.9943738633543253 != -1.958006 within 1e-05 delta (0.0363678633543254 difference)
```

Differential Revision: D18834383

