### PR TITLE
Make model building faster by not using deepcopy in OpAlmostEqual

### DIFF
--- a/caffe2/python/layer_model_helper.py
+++ b/caffe2/python/layer_model_helper.py
@@ -201,10 +201,9 @@ class LayerModelHelper(model_helper.ModelHelper):
                 )
             # check if the original initializer is the same as the one intended
             # now
-            assert utils.OpAlmostEqual(
+            assert utils.OpEqualExceptDebugInfo(
                 initializer_op,
                 self.global_constant_initializers[blob_name],
-                'debug_info'
             ), \
                 "conflict initializers for global constant %s, " \
                 "previous %s, now %s" % (

--- a/caffe2/python/layers/layers.py
+++ b/caffe2/python/layers/layers.py
@@ -244,8 +244,8 @@ def is_request_only_scalar(scalar):
     return True
 
 # Contains features accessed in a model layer of a given type
-# type: A string representing the kind of feature, consistent with FeatureSpec
-# ids: A set of feature IDs that are accessed in the model layer
+# `type`: A string representing the kind of feature, consistent with FeatureSpec
+# `ids`: A set of feature IDs that are accessed in the model layer
 AccessedFeatures = namedtuple("AccessedFeatures", ["type", "ids"])
 
 class ModelLayer(object):
@@ -391,8 +391,7 @@ class ModelLayer(object):
 
             # do not add duplicated init ops
             if any(
-                utils.OpAlmostEqual(op, init_op, "debug_info")
-                for op in init_net._net.op
+                utils.OpEqualExceptDebugInfo(op, init_op) for op in init_net._net.op
             ):
                 continue
 

--- a/caffe2/python/utils.py
+++ b/caffe2/python/utils.py
@@ -21,27 +21,19 @@ OPTIMIZER_ITERATION_NAME = "optimizer_iteration"
 ITERATION_MUTEX_NAME = "iteration_mutex"
 
 
-def OpAlmostEqual(op_a, op_b, ignore_fields=None):
+def OpEqualExceptDebugInfo(op_a, op_b):
     '''
-    Two ops are identical except for each field in the `ignore_fields`.
+    Two ops are identical except `debug_info`.
+    This is a faster version of `OpAlmostEqual`.
     '''
-    ignore_fields = ignore_fields or []
-    if not isinstance(ignore_fields, list):
-        ignore_fields = [ignore_fields]
-
-    assert all(isinstance(f, text_type) for f in ignore_fields), (
-        'Expect each field is text type, but got {}'.format(ignore_fields))
-
-    def clean_op(op):
-        op = copy.deepcopy(op)
-        for field in ignore_fields:
-            if op.HasField(field):
-                op.ClearField(field)
-        return op
-
-    op_a = clean_op(op_a)
-    op_b = clean_op(op_b)
-    return op_a == op_b
+    debug_info_a = op_a.debug_info
+    debug_info_b = op_b.debug_info
+    op_a.debug_info = ''
+    op_b.debug_info = ''
+    ret_val = (op_a == op_b)
+    op_a.debug_info = debug_info_a
+    op_b.debug_info = debug_info_b
+    return ret_val
 
 
 def CaffeBlobToNumpyArray(blob):

--- a/caffe2/python/utils_test.py
+++ b/caffe2/python/utils_test.py
@@ -1,27 +1,49 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
-from caffe2.python import utils, test_util
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import numpy as np
+from caffe2.python import core, test_util, utils
 
 
 class TestUtils(test_util.TestCase):
     def testArgsToDict(self):
-        args = [utils.MakeArgument("int1", 3),
-                utils.MakeArgument("float1", 4.0),
-                utils.MakeArgument("string1", "foo"),
-                utils.MakeArgument("intlist1", np.array([3, 4])),
-                utils.MakeArgument("floatlist1", np.array([5.0, 6.0])),
-                utils.MakeArgument("stringlist1", np.array(["foo", "bar"]))]
+        args = [
+            utils.MakeArgument("int1", 3),
+            utils.MakeArgument("float1", 4.0),
+            utils.MakeArgument("string1", "foo"),
+            utils.MakeArgument("intlist1", np.array([3, 4])),
+            utils.MakeArgument("floatlist1", np.array([5.0, 6.0])),
+            utils.MakeArgument("stringlist1", np.array(["foo", "bar"])),
+        ]
         dict_ = utils.ArgsToDict(args)
-        expected = {"int1" : 3,
-                    "float1" : 4.0,
-                    "string1" : b"foo",
-                    "intlist1" : [3, 4],
-                    "floatlist1" : [5.0, 6.0],
-                    "stringlist1" : [b"foo", b"bar"]}
-        self.assertEqual(dict_, expected, "dictionary version of arguments "
-                         "doesn't match original")
+        expected = {
+            "int1": 3,
+            "float1": 4.0,
+            "string1": b"foo",
+            "intlist1": [3, 4],
+            "floatlist1": [5.0, 6.0],
+            "stringlist1": [b"foo", b"bar"],
+        }
+        self.assertEqual(
+            dict_, expected, "dictionary version of arguments " "doesn't match original"
+        )
+
+    def testOpEqualExceptDebugInfo(self):
+        def create_two_ops(op_name_1, op_name_2):
+            input = core.BlobReference("input_blob_name")
+            output = core.BlobReference("output_blob_name")
+            return (
+                core.CreateOperator("Cast", input, output, name=op_name_1),
+                core.CreateOperator(
+                    "Cast", input, output, name=op_name_2, debug_info="second op"
+                ),
+            )
+
+        op1, op2 = create_two_ops("op_name", "op_name")
+        self.assertTrue(utils.OpEqualExceptDebugInfo(op1, op2))
+        # debug info doesn't change after OpEqualExceptDebugInfo. op1 has
+        # empty debug info by default.
+        self.assertEqual(op1.debug_info, "")
+        self.assertEqual(op2.debug_info, "second op")
+
+        op3, op4 = create_two_ops("name_1", "name_2")
+        self.assertFalse(utils.OpEqualExceptDebugInfo(op3, op4))


### PR DESCRIPTION
Summary:
OpAlmostEqual could be executed millions of times in model construction. Using deepcopy in it makes model construction really slow.

`add_init_params` uses `OpAlmostEqual` to check whether a newly added op is the same as an existing op in the net. In f152692759, `add_init_params` is executed ~4000 times and `OpAlmostEqual` is executed 15362348 times. Here is a profiling of model building time of it. Removing deepcopy can save half of the time.

```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
      3/1    0.000    0.000  495.596  495.596 {built-in method builtins.exec}
        1    0.007    0.007  495.596  495.596 <string>:1(<module>)
        1    0.001    0.001  495.589  495.589 assemble.py:85(assemble_model)
     3942    0.092    0.000  438.322    0.111 layers.py:424(add_operators)
     3942    0.119    0.000  365.790    0.093 layers.py:369(add_init_params)
     7910    3.749    0.000  365.595    0.046 {built-in method builtins.any}
 15370164   31.220    0.000  361.845    0.000 layers.py:394(<genexpr>)
 15362348   60.270    0.000  330.625    0.000 utils.py:24(OpAlmostEqual)
     1964    0.015    0.000  257.163    0.131 layer_model_helper.py:571(wrapper)
 30724696   28.876    0.000  247.575    0.000 utils.py:35(clean_op)
     1971    0.050    0.000  220.158    0.112 layer_model_helper.py:365(add_layer)
        1    0.000    0.000  218.866  218.866 layer_model_instantiator.py:93(generate_training_nets_forward_only)
        1    0.010    0.010  218.866  218.866 layer_model_instantiator.py:76(_generate_training_net_only)
30775522/30729583   60.460    0.000  203.321    0.000 copy.py:132(deepcopy)
        1    0.002    0.002  200.983  200.983 sparse_nn.py:545(build_model)
        1    0.013    0.013  200.656  200.656 sparse_nn.py:866(_build_model_impl)
        1    0.008    0.008  200.433  200.433 sparse_nn_lib.py:996(build_sparse_nn)
      3/1    0.000    0.000  200.285  200.285 sparse_nn_lib.py:246(_add_nested_model)
        2    0.020    0.010  200.197  100.098 sparse_nn_lib.py:102(_fuse_dense_sparse)
        1    0.022    0.022  146.817  146.817 unary_processor.py:85(unary_processor)
```

Test Plan:
In the old workflow f152692759, it takes 19 minutes before it enters the function `run_dist_job_with_estimation` (model building ran 2 times, each time takes ~7 minutes)
```
I1122 160521.922 font_manager.py:1458] generated new fontManager
...
...
...
I1122 162413.914 logger.py:70] Logging load_python_args_latency:20.3841958046
```

In the cloned workflow f154919607, it takes only 5 minutes before it enters `run_dist_job_with_estimation` (model building ran 1 time, takes less than 3 minutes.)

```
I1204 100409.531 font_manager.py:1458] generated new fontManager
...
...
...
I1204 100910.834 logger.py:70] Logging load_python_args_latency:4.157371520996094
```

Differential Revision: D18811864

