### PR TITLE
Remove scalar_check from topk, move it to the THC implementation.

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -603,6 +603,7 @@
   variants:
     - function
   return: argument 0,1
+  scalar_check: false
   arguments:
     - arg: THTensor* values
       output: True

--- a/aten/src/THC/generic/THCTensorTopK.cu
+++ b/aten/src/THC/generic/THCTensorTopK.cu
@@ -11,9 +11,8 @@ void THCTensor_(topk)(THCState* state,
                       int64_t k, int dim, int dir, int sorted) {
   THAssert(topK != NULL && indices != NULL && input_ != NULL);
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 3, topK, indices, input_));
-  THArgCheck(THCTensor_(nDimensionLegacyNoScalars)(state, topK) <= MAX_CUTORCH_DIMS, 2, CUTORCH_DIM_WARNING);
-  int64_t dims = THCudaLongTensor_nDimensionLegacyNoScalars(state, indices);
-  THArgCheck(dims <= MAX_CUTORCH_DIMS, 3, CUTORCH_DIM_WARNING);
+  THArgCheck(THCTensor_(nDimension)(state, topK) <= MAX_CUTORCH_DIMS, 2, CUTORCH_DIM_WARNING);
+  THArgCheck(THCudaLongTensor_nDimension(state, indices) <= MAX_CUTORCH_DIMS, 3, CUTORCH_DIM_WARNING);
   int numDims = THCTensor_(nDimensionLegacyNoScalars)(state, input_);
   THArgCheck(numDims <= MAX_CUTORCH_DIMS, 4, CUTORCH_DIM_WARNING);
 
@@ -26,8 +25,10 @@ void THCTensor_(topk)(THCState* state,
 
   // Build the output size, which is the dim being selected set to
   // size k
-  std::vector<int64_t> topKSize = THTensor_sizesLegacyNoScalars(input);
-  topKSize[dim] = k;
+  std::vector<int64_t> topKSize = input->sizes().vec();
+  if (topKSize.size() > 0) {
+    topKSize[dim] = k;
+  }
   THCTensor_(resize)(state, topK, topKSize, {});
   THCudaLongTensor_resize(state, indices, topKSize, {});
 
@@ -114,6 +115,8 @@ void THCTensor_(topk)(THCState* state,
                                                                         \
   RUN_DIM(INDEX_T);
 
+  // the below is safe with 0-dimensional tensors because it is based on
+  // THCTensorInfo which implicitly expands to 1-dimensional.
   if (THCTensor_nElement(state, input) > 0) {
     // Based on required index size, run the algorithm with the
     // appropriate index type
@@ -132,7 +135,7 @@ void THCTensor_(topk)(THCState* state,
 
   // Sort the results if the user wants them sorted, since our
   // selection routine does not ensure sorting
-  if (sorted) {
+  if (sorted && THCTensor_(numel)(state, topK) > 1) {
     // FIXME: the k/v inplace sort along slice only works for size <=
     // 2048 at the moment
     // Workaround:

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6166,9 +6166,11 @@ class TestTorchDeviceType(TestCase):
         # renorm
         self.assertRaises(RuntimeError, lambda: torch.renorm(zero_d, 0.5, 0, 1.0))
 
-        # sort
+        # sort, topk
         self.assertEqual([(), ()], [x.shape for x in torch.sort(zero_d, 0, False)])
         self.assertEqual([(), ()], [x.shape for x in torch.sort(zero_d, 0, True)])
+        self.assertEqual([(), ()], [x.shape for x in torch.topk(zero_d, 1, 0, False)])
+        self.assertEqual([(), ()], [x.shape for x in torch.topk(zero_d, 1, 0, True)])
 
         # lstsq (gels)
         self.assertRaises(RuntimeError, lambda: torch.lstsq(zero_d, zero_d))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#30852 Remove scalar_check from topk, move it to the THC implementation.**

Differential Revision: [D18842662](https://our.internmc.facebook.com/intern/diff/D18842662)