### PR TITLE
[jit] Proper print for one element tuple

### DIFF
--- a/aten/src/ATen/core/ivalue.cpp
+++ b/aten/src/ATen/core/ivalue.cpp
@@ -143,8 +143,11 @@ std::ostream& operator<<(std::ostream & out, const IValue & v) {
       return out << v.toInt();
     case IValue::Tag::Bool:
       return out << (v.toBool() ? "True" : "False");
-    case IValue::Tag::Tuple:
-      return printList(out, v.toTuple()->elements(), "(", ")");
+    case IValue::Tag::Tuple: {
+      const auto& elements = v.toTuple()->elements();
+      const auto& finish = elements.size() == 1 ? ",)" : ")";
+      return printList(out, elements, "(", finish);
+    }
     case IValue::Tag::IntList:
       return printList(out, v.toIntList(), "[", "]");
     case IValue::Tag::DoubleList:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #29220 [quant][graphmode] Enable foldbn tests
* #30787 [jit] Add unsafeRemoveConstant for ClassType
* #29219 [jit] Expose class constant through `attr` and `setattr` in object
* #29218 [jit] Preserve constant from ConcreteModuleType to ClassType
* **#30853 [jit] Proper print for one element tuple**

Summary:
Right now we print one element tuple as `(val)`, and it will
be interpreted as `val` in parsing, this PR changes it
to `(val,)` so we can recognize the one element tuple in parsing

Test Plan:
.

Reviewers:
.

Subscribers:

Tasks:

Tags:

Differential Revision: [D18846849](https://our.internmc.facebook.com/intern/diff/D18846849)