### PR TITLE
Fix CPU min_values/max_values initial value bug

### DIFF
--- a/aten/src/ATen/native/cpu/Reduce.h
+++ b/aten/src/ATen/native/cpu/Reduce.h
@@ -243,8 +243,8 @@ void binary_kernel_reduce(TensorIterator& iter, ops_t ops, init_t init) {
   });
 }
 
-template <typename func_t, typename vec_func_t>
-void binary_kernel_reduce_vec(TensorIterator& iter, func_t op, vec_func_t vop, double ident=0) {
+template <typename func_t, typename vec_func_t, typename ident_t = double>
+void binary_kernel_reduce_vec(TensorIterator& iter, func_t op, vec_func_t vop, ident_t ident=0) {
   using traits = binary_function_traits<func_t>;
   static_assert(
     all_same<

--- a/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
@@ -163,7 +163,7 @@ static void min_values_kernel_impl(TensorIterator& iter) {
       iter,
       [](scalar_t a, scalar_t b) -> scalar_t { return min_impl(a, b); },
       [](Vec256<scalar_t> a, Vec256<scalar_t> b) { return minimum(a, b); },
-      at::numeric_limits<scalar_t>::upper_bound());
+      std::numeric_limits<scalar_t>::max());
   });
 }
 
@@ -173,7 +173,7 @@ static void max_values_kernel_impl(TensorIterator& iter) {
       iter,
       [](scalar_t a, scalar_t b) -> scalar_t { return max_impl(a, b); },
       [](Vec256<scalar_t> a, Vec256<scalar_t> b) { return maximum(a, b); },
-      at::numeric_limits<scalar_t>::lower_bound());
+      std::numeric_limits<scalar_t>::min());
   });
 }
 

--- a/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
@@ -162,7 +162,8 @@ static void min_values_kernel_impl(TensorIterator& iter) {
     binary_kernel_reduce_vec(
       iter,
       [](scalar_t a, scalar_t b) -> scalar_t { return min_impl(a, b); },
-      [](Vec256<scalar_t> a, Vec256<scalar_t> b) { return minimum(a, b); });
+      [](Vec256<scalar_t> a, Vec256<scalar_t> b) { return minimum(a, b); },
+      at::numeric_limits<scalar_t>::upper_bound());
   });
 }
 
@@ -171,7 +172,8 @@ static void max_values_kernel_impl(TensorIterator& iter) {
     binary_kernel_reduce_vec(
       iter,
       [](scalar_t a, scalar_t b) -> scalar_t { return max_impl(a, b); },
-      [](Vec256<scalar_t> a, Vec256<scalar_t> b) { return maximum(a, b); });
+      [](Vec256<scalar_t> a, Vec256<scalar_t> b) { return maximum(a, b); },
+      at::numeric_limits<scalar_t>::lower_bound());
   });
 }
 

--- a/aten/src/ATen/test/reduce_ops_test.cpp
+++ b/aten/src/ATen/test/reduce_ops_test.cpp
@@ -20,11 +20,11 @@ TEST(ReduceOpsTest, MaxValuesAndMinValues) {
         a.min().item<double>()
       );
       ASSERT_FLOAT_EQ(
-        a.max_values(c10::IntArrayRef{-2, -1}).item<double>(),
+        a.neg().max_values(c10::IntArrayRef{0, 1}).item<double>(),
         a.max().item<double>()
       );
       ASSERT_FLOAT_EQ(
-        a.min_values(c10::IntArrayRef{-1, 1}).item<double>(),
+        a.neg().min_values(c10::IntArrayRef{0, 1}).item<double>(),
         a.min().item<double>()
       );
     }

--- a/aten/src/ATen/test/reduce_ops_test.cpp
+++ b/aten/src/ATen/test/reduce_ops_test.cpp
@@ -8,9 +8,18 @@ using namespace at;
 TEST(ReduceOpsTest, MaxValuesAndMinValues) {
   const int W = 10;
   const int H = 10;
-  if (hasCUDA()) {
-    for (const auto dtype : {kHalf, kFloat, kDouble, kShort, kInt, kLong}) {
-      auto a = at::rand({H, W}, TensorOptions(kCUDA).dtype(at::kHalf));
+
+  for (const auto dev : {kCPU, kCUDA}) {
+    std::vector<at::ScalarType> dtypes = {kFloat, kDouble, kShort, kInt, kLong};
+    if (hasCUDA()) {
+      dtypes.push_back(kHalf);
+    } else if (dev == kCUDA) {
+      // Skip CUDA test in non cuda env
+      continue;
+    }
+
+    for (const auto dtype : dtypes) {
+      auto a = at::rand({H, W}, TensorOptions(dev).dtype(dtype));
       ASSERT_FLOAT_EQ(
         a.max_values(c10::IntArrayRef{0, 1}).item<double>(),
         a.max().item<double>()

--- a/aten/src/ATen/test/reduce_ops_test.cpp
+++ b/aten/src/ATen/test/reduce_ops_test.cpp
@@ -10,18 +10,16 @@ TEST(ReduceOpsTest, MaxValuesAndMinValues) {
   const int H = 10;
 
   for (const auto dev : {kCPU, kCUDA}) {
-    std::vector<at::ScalarType> dtypes = {kFloat, kDouble, kLong};
+    std::vector<at::ScalarType> dtypes = {kFloat, kDouble, kShort, kInt, kLong};
     if (hasCUDA()) {
       dtypes.push_back(kHalf);
-      dtypes.push_back(kShort);
-      dtypes.push_back(kInt);
     } else if (dev == kCUDA) {
       // Skip CUDA test in non cuda env
       continue;
     }
 
     for (const auto dtype : dtypes) {
-      auto a = at::rand({H, W}, TensorOptions(dev).dtype(dtype));
+      auto a = (at::rand({H, W}, TensorOptions(dev).dtype(kFloat)) * 10).to(dtype);
       ASSERT_FLOAT_EQ(
         a.max_values(c10::IntArrayRef{0, 1}).item<double>(),
         a.max().item<double>()

--- a/aten/src/ATen/test/reduce_ops_test.cpp
+++ b/aten/src/ATen/test/reduce_ops_test.cpp
@@ -19,6 +19,14 @@ TEST(ReduceOpsTest, MaxValuesAndMinValues) {
         a.min_values(c10::IntArrayRef{0, 1}).item<double>(),
         a.min().item<double>()
       );
+      ASSERT_FLOAT_EQ(
+        a.max_values(c10::IntArrayRef{-2, -1}).item<double>(),
+        a.max().item<double>()
+      );
+      ASSERT_FLOAT_EQ(
+        a.min_values(c10::IntArrayRef{-1, 1}).item<double>(),
+        a.min().item<double>()
+      );
     }
   }
 }

--- a/aten/src/ATen/test/reduce_ops_test.cpp
+++ b/aten/src/ATen/test/reduce_ops_test.cpp
@@ -10,9 +10,11 @@ TEST(ReduceOpsTest, MaxValuesAndMinValues) {
   const int H = 10;
 
   for (const auto dev : {kCPU, kCUDA}) {
-    std::vector<at::ScalarType> dtypes = {kFloat, kDouble, kShort, kInt, kLong};
+    std::vector<at::ScalarType> dtypes = {kFloat, kDouble, kLong};
     if (hasCUDA()) {
       dtypes.push_back(kHalf);
+      dtypes.push_back(kShort);
+      dtypes.push_back(kInt);
     } else if (dev == kCUDA) {
       // Skip CUDA test in non cuda env
       continue;

--- a/aten/src/ATen/test/reduce_ops_test.cpp
+++ b/aten/src/ATen/test/reduce_ops_test.cpp
@@ -21,11 +21,11 @@ TEST(ReduceOpsTest, MaxValuesAndMinValues) {
       );
       ASSERT_FLOAT_EQ(
         a.neg().max_values(c10::IntArrayRef{0, 1}).item<double>(),
-        a.max().item<double>()
+        a.neg().max().item<double>()
       );
       ASSERT_FLOAT_EQ(
         a.neg().min_values(c10::IntArrayRef{0, 1}).item<double>(),
-        a.min().item<double>()
+        a.neg().min().item<double>()
       );
     }
   }

--- a/aten/src/ATen/test/reduce_ops_test.cpp
+++ b/aten/src/ATen/test/reduce_ops_test.cpp
@@ -11,15 +11,19 @@ TEST(ReduceOpsTest, MaxValuesAndMinValues) {
 
   for (const auto dev : {kCPU, kCUDA}) {
     std::vector<at::ScalarType> dtypes = {kFloat, kDouble, kShort, kInt, kLong};
-    if (hasCUDA()) {
-      dtypes.push_back(kHalf);
-    } else if (dev == kCUDA) {
-      // Skip CUDA test in non cuda env
+
+    // Skip CUDA test in non cuda env
+    if (!hasCUDA() && dev == kCUDA) {
       continue;
     }
 
+    // Enable half float test for CUDA
+    if (dev == kCUDA) {
+      dtypes.push_back(kHalf);
+    }
+
     for (const auto dtype : dtypes) {
-      auto a = (at::rand({H, W}, TensorOptions(dev).dtype(kFloat)) * 10).to(dtype);
+      auto a = at::randint(-10, 10, {H, W}, TensorOptions(dev).dtype(dtype));
       ASSERT_FLOAT_EQ(
         a.max_values(c10::IntArrayRef{0, 1}).item<double>(),
         a.max().item<double>()


### PR DESCRIPTION
Without specifying initial value in `binary_kernel_reduce_vec` it would be `0` which cause unexpected result in min_values/max_values.