### PR TITLE
[quant][graphmode] Remove `values_to_quantize_`

### DIFF
--- a/torch/csrc/jit/passes/quantization.cpp
+++ b/torch/csrc/jit/passes/quantization.cpp
@@ -591,7 +591,6 @@ class InsertQuantDeQuantHelper {
   // TODO: we don't need to call this for each graph
   std::unordered_map<Graph*, std::vector<std::string>> observer_modules_to_remove_;
   std::unordered_map<Graph*, std::vector<Node*>> nodes_to_destroy_;
-  std::unordered_map<Graph*, std::vector<Value*>> values_to_quantize_;
   std::unordered_map<Graph*, std::unordered_map<Value*, std::tuple<IValue, IValue>>> values_to_qparams_;
 };
 
@@ -617,7 +616,6 @@ void InsertQuantDeQuantHelper::collectObserverNodesAndValueToQuantize(
   nodes_to_destroy_[g].push_back(observer->inputs()[0]->node());
   Value* new_value = observer->input(1);
   v->replaceAllUsesWith(new_value);
-  values_to_quantize_[g].push_back(new_value);
   values_to_qparams_[g].insert({new_value, getQParams(module, v)});
 }
 
@@ -671,11 +669,12 @@ bool InsertQuantDeQuantHelper::registerQParams(
 }
 
 void InsertQuantDeQuantHelper::quantizeTensors(script::Module& module, Graph* g, Value* self) {
-  if (!values_to_quantize_.count(g)) {
+  if (!values_to_qparams_.count(g)) {
     return;
   }
-  for (auto& v : values_to_quantize_.at(g)) {
-    auto qparams_and_scalar_type = values_to_qparams_.at(g).at(v);
+  for (auto& pr : values_to_qparams_.at(g)) {
+    auto* v = pr.first;
+    auto qparams_and_scalar_type = pr.second;
     auto is_per_channel = registerQParams(module, qparams_and_scalar_type, v->debugName());
     insertQuantDeQuantCall(self, v, is_per_channel);
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #30553 [quant][graphmode] `insert_quant_dequant` pass support shared class types
* #30860 [quant][graphmode][refactor] Factor out getInvokedMethod in `InsertQuantDeQuantHelper`
* #30859 [quant][graphmode][refactor] getQParams return a dictionary of qparams
* **#30858 [quant][graphmode] Remove `values_to_quantize_`**
* #30552 [quant][graphmode][refactor] Add registerQParams function

Summary:
This is not needed since we have `values_to_qparams_`

Test Plan:
.

Reviewers:
mvz

Subscribers:

Tasks:

Tags:

Differential Revision: [D18848992](https://our.internmc.facebook.com/intern/diff/D18848992)