### PR TITLE
Enable using `torch.autograd.profiler.record_function` as decorator

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -2710,6 +2710,15 @@ class TestAutograd(TestCase):
             2,
         )
 
+        # We can also use record_function to decorate arbitrary function
+        @record_function('my_func')
+        def f(x, y):
+            return x + y
+
+        with profile() as p:
+            f(1, 2)
+
+        self.assertTrue('my_func' in str(p))
 
     def test_dir(self):
         x = torch.randn(10, 10)


### PR DESCRIPTION
```python
@record_function('my_func')
def f(x, y):
    return x + y

with profile() as p:
    f(1, 2)
print(prof.key_averages().table())
```

```
------------------------------------  ---------------  ---------------  ---------------  ---------------  ---------------  ---------------  
Name                                  Self CPU total %  Self CPU total   CPU total %      CPU total        CPU time avg     Number of Calls  
------------------------------------  ---------------  ---------------  ---------------  ---------------  ---------------  ---------------  
my_func                               85.42%           86.796us         87.27%           88.670us         88.670us         1                
------------------------------------  ---------------  ---------------  ---------------  ---------------  ---------------  ---------------  
Self CPU time total: 101.606us
```