### PR TITLE
[pytorch] update code analyzer script to handle splitted torch libraries

### DIFF
--- a/tools/code_analyzer/build.sh
+++ b/tools/code_analyzer/build.sh
@@ -98,7 +98,7 @@ analyze_torch_mobile() {
     OBJECT_DIR="${WORK_DIR}/torch_objs"
     rm -rf "${OBJECT_DIR}" && mkdir -p "${OBJECT_DIR}" && pushd "${OBJECT_DIR}"
     for f in "${TORCH_INSTALL_PREFIX}/lib"/*.a; do
-      ar x ${f}
+      ar x "${f}"
     done
     popd
 
@@ -119,7 +119,7 @@ analyze_test_project() {
   OBJECT_DIR="${WORK_DIR}/test_objs"
   rm -rf "${OBJECT_DIR}" && mkdir -p "${OBJECT_DIR}" && pushd "${OBJECT_DIR}"
   for f in "${TEST_INSTALL_PREFIX}/lib"/*.a; do
-    ar x ${f}
+    ar x "${f}"
   done
   popd
 

--- a/tools/code_analyzer/build.sh
+++ b/tools/code_analyzer/build.sh
@@ -97,8 +97,9 @@ analyze_torch_mobile() {
     # Extract libtorch archive
     OBJECT_DIR="${WORK_DIR}/torch_objs"
     rm -rf "${OBJECT_DIR}" && mkdir -p "${OBJECT_DIR}" && pushd "${OBJECT_DIR}"
-    ar x "${TORCH_INSTALL_PREFIX}/lib/libc10.a"
-    ar x "${TORCH_INSTALL_PREFIX}/lib/libtorch.a"
+    for f in "${TORCH_INSTALL_PREFIX}/lib"/*.a; do
+      ar x ${f}
+    done
     popd
 
     # Link libtorch into a single module
@@ -117,8 +118,9 @@ analyze_test_project() {
   # Extract archive
   OBJECT_DIR="${WORK_DIR}/test_objs"
   rm -rf "${OBJECT_DIR}" && mkdir -p "${OBJECT_DIR}" && pushd "${OBJECT_DIR}"
-  ar x "${TEST_INSTALL_PREFIX}/lib/libc10.a"
-  ar x "${TEST_INSTALL_PREFIX}/lib/libOpLib.a"
+  for f in "${TEST_INSTALL_PREFIX}/lib"/*.a; do
+    ar x ${f}
+  done
   popd
 
   # Link into a single module


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #30866 [pytorch] generate op dependency graph as python code
* **#30864 [pytorch] update code analyzer script to handle splitted torch libraries**

Summary:
Change it to handle all archive files under install folder.

Test Plan:
```
ANALYZE_TEST=1 CHECK_RESULT=1 tools/code_analyzer/build.sh
ANALYZE_TORCH=1 tools/code_analyzer/build.sh
```

Differential Revision: [D18850317](https://our.internmc.facebook.com/intern/diff/D18850317)