### PR TITLE
Raise error if a block can not be found from a CUDA tensor

### DIFF
--- a/aten/src/ATen/hip/impl/HIPCachingAllocatorMasqueradingAsCUDA.cpp
+++ b/aten/src/ATen/hip/impl/HIPCachingAllocatorMasqueradingAsCUDA.cpp
@@ -10,7 +10,7 @@ Allocator* get() {
 }
 
 void recordStreamMasqueradingAsCUDA(const DataPtr& ptr, HIPStreamMasqueradingAsCUDA stream) {
-  HIPCachingAllocator::recordStream(ptr.get(), stream.hip_stream());
+  HIPCachingAllocator::recordStream(ptr, stream.hip_stream());
 }
 
 } // namespace HIPCachingAllocatorMasqueradingAsCUDA

--- a/aten/src/ATen/hip/impl/HIPCachingAllocatorMasqueradingAsCUDA.cpp
+++ b/aten/src/ATen/hip/impl/HIPCachingAllocatorMasqueradingAsCUDA.cpp
@@ -1,3 +1,4 @@
+#include <c10/core/Allocator.h>
 #include <ATen/hip/impl/HIPCachingAllocatorMasqueradingAsCUDA.h>
 
 namespace c10 { namespace hip {
@@ -8,8 +9,8 @@ Allocator* get() {
   return &allocator;
 }
 
-void recordStreamMasqueradingAsCUDA(void *ptr, HIPStreamMasqueradingAsCUDA stream) {
-  HIPCachingAllocator::recordStream(ptr, stream.hip_stream());
+void recordStreamMasqueradingAsCUDA(const DataPtr& ptr, HIPStreamMasqueradingAsCUDA stream) {
+  HIPCachingAllocator::recordStream(ptr.get(), stream.hip_stream());
 }
 
 } // namespace HIPCachingAllocatorMasqueradingAsCUDA

--- a/aten/src/ATen/hip/impl/HIPCachingAllocatorMasqueradingAsCUDA.h
+++ b/aten/src/ATen/hip/impl/HIPCachingAllocatorMasqueradingAsCUDA.h
@@ -4,11 +4,15 @@
 #include <ATen/hip/impl/HIPAllocatorMasqueradingAsCUDA.h>
 #include <ATen/hip/impl/HIPStreamMasqueradingAsCUDA.h>
 
-namespace c10 { namespace hip {
+namespace c10 {
+// forward declaration
+class DataPtr;
+namespace hip {
 namespace HIPCachingAllocatorMasqueradingAsCUDA {
 
 Allocator* get();
-C10_HIP_API void recordStreamMasqueradingAsCUDA(void *ptr, HIPStreamMasqueradingAsCUDA stream);
+C10_HIP_API void recordStreamMasqueradingAsCUDA(const DataPtr& ptr, HIPStreamMasqueradingAsCUDA stream);
 
 } // namespace HIPCachingAllocatorMasqueradingAsCUDA
-}} // namespace c10::hip
+} // namespace hip
+} // namespace c10

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -395,10 +395,6 @@ class THCCachingAllocator {
       return;
     }
 
-    // The ptr is not allocated by CUDA, most likely user error
-    TORCH_CHECK(
-        ptr.device().type() == kCUDA, "Tensor is not allocated in CUDA");
-
     // If a tensor is not allocated by this instance, simply skip
     // This usually happens when CUDA tensors are shared across processes,
     // we have implemented reference counting based sharing mechanism to
@@ -411,7 +407,7 @@ class THCCachingAllocator {
 
     Block* block = find_allocated_block(ptr.get());
     // block must not be null reaching here
-    TORCH_INTERNAL_ASSERT(block != NULL, "No allocated block can be found");
+    TORCH_INTERNAL_ASSERT(block != nullptr, "No allocated block can be found");
     if (stream.stream() == block->stream) {
       // ignore uses on the allocation stream, since those don't require any
       // special synchronization

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -388,25 +388,29 @@ class THCCachingAllocator {
     return basePtr;
   }
 
-  void recordStream(void* ptr, cuda::CUDAStream stream) {
+  void recordStream(const DataPtr& ptr, cuda::CUDAStream stream) {
     // Empty tensor's storage().data() might be a null ptr. As there is no
     // blocks associated with those tensors, it is fine to do nothing here.
-    if (!ptr) {
+    if (!ptr.get()) {
       return;
     }
 
+    // The ptr is not allocated by CUDA, most likely user error
+    TORCH_CHECK(ptr.device().type() == kCUDA, "Tensor is not allocated in CUDA");
+    // This could happen when a tensor is shared across processes, most likely user error
+    TORCH_CHECK(ptr.get_deleter() == &raw_delete, "Tensor is not allocated by the CUDACachingAllocator instance in current context");
+
     std::lock_guard<std::recursive_mutex> lock(mutex);
-    Block* block = find_allocated_block(ptr);
-    // block could be nullptr in some cases, e.g., tensor loaded from blob, or
-    // shared from another process, or not pointing to a CUDA tensor.
-    if (block) {
-      if (stream.stream() == block->stream) {
-        // ignore uses on the allocation stream, since those don't require any
-        // special synchronization
-        return;
-      }
-      block->stream_uses.insert(stream);
+
+    Block* block = find_allocated_block(ptr.get());
+    // block must not be null reaching here
+    TORCH_INTERNAL_ASSERT(block != NULL, "No allocated block can be found");
+    if (stream.stream() == block->stream) {
+      // ignore uses on the allocation stream, since those don't require any
+      // special synchronization
+      return;
     }
+    block->stream_uses.insert(stream);
   }
 
   /** returns cached blocks to the system allocator **/
@@ -819,10 +823,6 @@ class THCCachingAllocator {
 
 THCCachingAllocator caching_allocator;
 
-static void CudaCachingDeleter(void* ptr) {
-  caching_allocator.free(ptr);
-}
-
 // NB: I decided not to fold this into THCCachingAllocator, because the latter
 // has a lot more methods and it wasn't altogether clear that they should
 // actually be publicly exposed
@@ -834,10 +834,10 @@ struct CudaCachingAllocator : public Allocator {
     if (size != 0) {
       caching_allocator.malloc(&r, size, cuda::getCurrentCUDAStream(device));
     }
-    return {r, r, &CudaCachingDeleter, Device(DeviceType::CUDA, device)};
+    return {r, r, &raw_delete, Device(DeviceType::CUDA, device)};
   }
   DeleterFnPtr raw_deleter() const override {
-    return &CudaCachingDeleter;
+    return &raw_delete;
   }
 };
 
@@ -861,7 +861,7 @@ void* getBaseAllocation(void *ptr, size_t *size)
   return caching_allocator.getBaseAllocation(ptr, size);
 }
 
-void recordStream(void *ptr, cuda::CUDAStream stream)
+void recordStream(const DataPtr& ptr, cuda::CUDAStream stream)
 {
   caching_allocator.recordStream(ptr, stream);
 }

--- a/c10/cuda/CUDACachingAllocator.h
+++ b/c10/cuda/CUDACachingAllocator.h
@@ -108,7 +108,7 @@ C10_CUDA_API Allocator* get();
 C10_CUDA_API void emptyCache();
 C10_CUDA_API void cacheInfo(int dev_id, size_t* cachedAndFree, size_t* largestBlock);
 C10_CUDA_API void* getBaseAllocation(void *ptr, size_t *size);
-C10_CUDA_API void recordStream(void *ptr, CUDAStream stream);
+C10_CUDA_API void recordStream(const DataPtr&, CUDAStream stream);
 C10_CUDA_API DeviceStats getDeviceStats(int device);
 C10_CUDA_API void resetAccumulatedStats(int device);
 C10_CUDA_API void resetPeakStats(int device);
@@ -117,7 +117,6 @@ C10_CUDA_API std::vector<SegmentInfo> snapshot();
 C10_CUDA_API std::mutex* getFreeMutex();
 
 C10_CUDA_API std::shared_ptr<void> getIpcDevPtr(std::string handle);
-
 } // namespace CUDACachingAllocator
 
 }} // namespace c10::cuda

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -2076,13 +2076,5 @@ t2.start()
             for t in range(num_threads):
                 self.assertEqual(results[t].sum().item(), size * size)
 
-    def testCudaRecordStreamWithWrongDevice(self):
-        t = torch.randn(5, 5)
-        with self.assertRaisesRegex(RuntimeError, "Tensor is not allocated in CUDA"):
-            t.record_stream(torch.cuda.current_stream())
-        # Copy to CUDA
-        ct = t.to("cuda")
-        ct.record_stream(torch.cuda.current_stream())
-
 if __name__ == '__main__':
     run_tests()

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -2084,23 +2084,5 @@ t2.start()
         ct = t.to("cuda")
         ct.record_stream(torch.cuda.current_stream())
 
-    @classmethod
-    def _recordStreamFromADifferentProcess(cls, t):
-        inst = cls()
-        # This should throw exception as recrod_stream in a different process will not succeed
-        with inst.assertRaisesRegex(RuntimeError, "Tensor is not allocated by the CUDACachingAllocator instance in current context"):
-            t.record_stream(torch.cuda.current_stream())
-
-    def testCudaRecordStreamWithinWrongProcess(self):
-        SIZE = 5
-        t = torch.cuda.FloatTensor(SIZE)
-
-        ctx = mp.get_context('spawn')
-        p = ctx.Process(target=TestCuda._recordStreamFromADifferentProcess, args=(t,))
-        p.start()
-        p.join()
-        self.assertEqual(t.size()[0], SIZE)
-
-
 if __name__ == '__main__':
     run_tests()

--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -580,8 +580,7 @@ static PyObject * THPVariable_record_stream(PyObject* self, PyObject* arg)
   if (!THCPStream_Check(arg)) {
     return PyErr_Format(PyExc_TypeError, "expected Stream object");
   }
-  void* data = self_.storage().data_ptr().get();
-  c10::cuda::CUDACachingAllocator::recordStream(data, at::cuda::CUDAStream::unpack(((THCPStream*)arg)->cdata));
+  c10::cuda::CUDACachingAllocator::recordStream(self_.storage().data_ptr(), at::cuda::CUDAStream::unpack(((THCPStream*)arg)->cdata));
   Py_RETURN_NONE;
 #else
   throw std::runtime_error("PyTorch compiled without CUDA support");

--- a/torch/csrc/distributed/c10d/ddp.cpp
+++ b/torch/csrc/distributed/c10d/ddp.cpp
@@ -166,7 +166,7 @@ std::tuple<std::shared_ptr<ProcessGroup::Work>, at::Tensor> queueReduction(
     // freed before their worker stream ops finish.
     for (at::Tensor& grad : gradsBatch[devIdx]) {
       c10::cuda::CUDACachingAllocator::recordStream(
-          grad.storage().data(), workerStreams.back());
+          grad.storage().data_ptr(), workerStreams.back());
     }
   }
 
@@ -212,7 +212,7 @@ void syncReduction(
   // before their worker stream ops finish.
   for (at::Tensor& grad : gradsBatch) {
     c10::cuda::CUDACachingAllocator::recordStream(
-        grad.storage().data(), workerStream);
+        grad.storage().data_ptr(), workerStream);
   }
 
   at::cuda::CUDAStreamGuard cudaGuard(workerStream);

--- a/torch/lib/c10d/ProcessGroupGloo.cpp
+++ b/torch/lib/c10d/ProcessGroupGloo.cpp
@@ -259,9 +259,9 @@ void initializeStreamsEvents(
     if (tensors[i].is_sparse()) {
       if (tensors[i].is_coalesced()) {
         c10::cuda::CUDACachingAllocator::recordStream(
-            tensors[i].indices().storage().data(), streams[i]);
+            tensors[i].indices().storage().data_ptr(), streams[i]);
         c10::cuda::CUDACachingAllocator::recordStream(
-            tensors[i].values().storage().data(), streams[i]);
+            tensors[i].values().storage().data_ptr(), streams[i]);
       } else {
         // We will need to coalesce first, which means new tensors will
         // be allocated on the streams we just allocated, and there
@@ -269,7 +269,7 @@ void initializeStreamsEvents(
       }
     } else {
       c10::cuda::CUDACachingAllocator::recordStream(
-          tensors[i].storage().data(), streams[i]);
+          tensors[i].storage().data_ptr(), streams[i]);
     }
   }
 }
@@ -315,7 +315,7 @@ void initializeStreamsEvents(
       // new streams in this Work to prevent being freed before the Work
       // finishes.
       c10::cuda::CUDACachingAllocator::recordStream(
-          tensor.storage().data(), streams[i]);
+          tensor.storage().data_ptr(), streams[i]);
     }
   }
 }

--- a/torch/lib/c10d/ProcessGroupNCCL.cpp
+++ b/torch/lib/c10d/ProcessGroupNCCL.cpp
@@ -550,7 +550,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::collective(
     //
     // See [Sync Streams].
     c10::cuda::CUDACachingAllocator::recordStream(
-        inputs[i].storage().data(), ncclStream);
+        inputs[i].storage().data_ptr(), ncclStream);
   }
 
   {
@@ -686,7 +686,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::allgather(
           ncclComm_t comm,
           at::cuda::CUDAStream& stream) {
         c10::cuda::CUDACachingAllocator::recordStream(
-            output.storage().data(), stream);
+            output.storage().data_ptr(), stream);
         return ncclAllGather(
             input.data_ptr(),
             output.data_ptr(),
@@ -703,7 +703,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::allgather(
           for (size_t j = 0; j < outputTensors[0].size(); ++j) {
             // See [Sync Streams].
             c10::cuda::CUDACachingAllocator::recordStream(
-                outputTensors[i][j].storage().data(), ncclStreams[i]);
+                outputTensors[i][j].storage().data_ptr(), ncclStreams[i]);
 
             outputTensors[i][j].copy_(outputFlattened[i][j], true);
           }
@@ -737,7 +737,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::reduce_scatter(
           ncclComm_t comm,
           at::cuda::CUDAStream& stream) {
         c10::cuda::CUDACachingAllocator::recordStream(
-            output.storage().data(), stream);
+            output.storage().data_ptr(), stream);
         return ncclReduceScatter(
             input.data_ptr(),
             output.data_ptr(),
@@ -754,7 +754,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::reduce_scatter(
           for (size_t j = 0; j < inputTensors[0].size(); ++j) {
             // See [Sync Streams].
             c10::cuda::CUDACachingAllocator::recordStream(
-                inputTensors[i][j].storage().data(), ncclStreams[i]);
+                inputTensors[i][j].storage().data_ptr(), ncclStreams[i]);
 
             inputFlattened[i][j].copy_(inputTensors[i][j], true);
           }


### PR DESCRIPTION
After several discussions, we agreed not to put any extra safety check for recordStream as either the check will cause failures in certain scenarios or there is no need to throw for user errors. 

As a summary, it simply does what is described in https://github.com/pytorch/pytorch/issues/27405, check if a tensor is indeed allocated by a CUDACachingAllocator instance, if it is, then throw internal error if a block can not be retrieved.