### PR TITLE
Make maybe_zero_dim throw an exception, remove all calls.

### DIFF
--- a/aten/src/ATen/OpaqueTensorImpl.h
+++ b/aten/src/ATen/OpaqueTensorImpl.h
@@ -61,10 +61,6 @@ struct CAFFE2_API OpaqueTensorImpl : public TensorImpl {
     AT_ERROR("opaque tensors do not have set_storage_offset");
   }
 
-  TensorImpl* maybe_zero_dim(bool condition_when_zero_dim) override {
-      AT_ERROR("opaque tensors do not support maybe_zero_dim");
-  }
-
   bool has_storage() const override {
     return false;
     }

--- a/aten/src/ATen/SparseTensorImpl.cpp
+++ b/aten/src/ATen/SparseTensorImpl.cpp
@@ -73,13 +73,6 @@ void SparseTensorImpl::set_storage_offset(int64_t storage_offset) {
 int64_t SparseTensorImpl::dim() const {
   return sparse_dim_ + dense_dim_;
 }
-TensorImpl* SparseTensorImpl::maybe_zero_dim(bool condition_when_zero_dim) {
-  TORCH_CHECK(condition_when_zero_dim == (dim() == 0),
-           "Attempted to maybe_zero_dim on a SparseTensorImpl to ", condition_when_zero_dim,
-           " but the SparseTensor's dim() is ", dim(), " and SparseTensors do not support"
-           " changing dimensionality via maybe_zero_dim");
-  return this;
-}
 bool SparseTensorImpl::has_storage() const {
   return false;
 }

--- a/aten/src/ATen/SparseTensorImpl.h
+++ b/aten/src/ATen/SparseTensorImpl.h
@@ -49,7 +49,6 @@ public:
   void set_storage_offset(int64_t storage_offset) override;
 
   int64_t dim() const override;
-  TensorImpl* maybe_zero_dim(bool condition_when_zero_dim) override;
   bool has_storage() const override;
   const Storage& storage() const override;
   int64_t storage_offset() const override;

--- a/aten/src/ATen/native/Resize.cpp
+++ b/aten/src/ATen/native/Resize.cpp
@@ -16,7 +16,6 @@ Tensor& resize_cpu_(
 #endif
   auto* self_ = self.unsafeGetTensorImpl();
   resize_impl_cpu_(self_, size, /*strides=*/c10::nullopt);
-  self_->maybe_zero_dim(size.size() == 0);
   if (optional_memory_format.has_value()) {
     auto memory_format =
         optional_memory_format.value();

--- a/aten/src/ATen/native/cuda/Resize.cu
+++ b/aten/src/ATen/native/cuda/Resize.cu
@@ -18,7 +18,6 @@ Tensor& resize_cuda_(
 #endif
   auto* self_ = self.unsafeGetTensorImpl();
   resize_impl_cuda_(self_, size, /*strides=*/c10::nullopt);
-  self_->maybe_zero_dim(size.size() == 0);
   if (optional_memory_format.has_value()) {
     auto memory_format =
         optional_memory_format.value();

--- a/aten/src/ATen/native/quantized/cpu/tensor_operators.cpp
+++ b/aten/src/ATen/native/quantized/cpu/tensor_operators.cpp
@@ -74,7 +74,6 @@ Tensor& quantized_resize_cpu_(
       "Can only resize quantized tensors with per-tensor schemes!");
   auto* self_ = self.unsafeGetTensorImpl();
   resize_impl_cpu_(self_, size, /*strides=*/c10::nullopt);
-  self_->maybe_zero_dim(size.size() == 0);
   return self;
 }
 }}  // at::native

--- a/aten/src/ATen/test/broadcast_test.cpp
+++ b/aten/src/ATen/test/broadcast_test.cpp
@@ -22,8 +22,7 @@ void TestOut2Basic(DeprecatedTypeProperties& T) {
 
 // with scalar
 void TestOut2WithScalar(DeprecatedTypeProperties& T) {
-  auto aScalar = ones({1}, T);
-  aScalar.unsafeGetTensorImpl()->maybe_zero_dim(true);
+  auto aScalar = ones({}, T);
   auto b = randn({3, 5}, T);
   ASSERT_TRUE(
       (aScalar + b).equal(aScalar.expand(b.sizes()) + b.expand(b.sizes())));
@@ -56,8 +55,7 @@ void TestOut3Basic(DeprecatedTypeProperties& T) {
 
 // with scalar
 void TestOut3WithScalar(DeprecatedTypeProperties& T) {
-  auto aTensorScalar = ones({1}, T);
-  aTensorScalar.unsafeGetTensorImpl()->maybe_zero_dim(true);
+  auto aTensorScalar = ones({}, T);
   auto b = randn({3, 2, 1}, T);
   auto c = randn({1, 2, 5}, T);
   std::vector<int64_t> expanded_sizes = {3, 2, 5};
@@ -92,8 +90,7 @@ void TestIn2Basic(DeprecatedTypeProperties& T) {
 // with scalar
 void TestIn2WithScalar(DeprecatedTypeProperties& T) {
   auto a = randn({3, 5}, T);
-  auto bScalar = ones({1}, T);
-  bScalar.unsafeGetTensorImpl()->maybe_zero_dim(true);
+  auto bScalar = ones({}, T);
   ASSERT_TRUE((a + bScalar).equal(a + bScalar.expand(a.sizes())));
 }
 
@@ -120,8 +117,7 @@ void TestIn3WithScalar(DeprecatedTypeProperties& T) {
   auto b = randn({3, 1, 2}, T);
   auto c = randn({1, 5, 1}, T);
   auto aClone = a.clone();
-  auto bScalar = ones({1}, T);
-  bScalar.unsafeGetTensorImpl()->maybe_zero_dim(true);
+  auto bScalar = ones({}, T);
   ASSERT_TRUE(a.addcmul_(bScalar, c)
                   .equal(aClone.addcmul_(
                       bScalar.expand(a.sizes()), c.expand(a.sizes()))));
@@ -148,8 +144,7 @@ void TestExplicitDimWithScalar(DeprecatedTypeProperties& T) {
   auto a = randn({1}, T);
   auto b = randn({5, 3}, T);
   auto c = randn({3, 7}, T);
-  Tensor aScalar = ones({1}, T);
-  aScalar.unsafeGetTensorImpl()->maybe_zero_dim(true);
+  Tensor aScalar = ones({}, T);
   ASSERT_TRUE(aScalar.addmm(b, c).equal(aScalar.expand({5, 7}).addmm(b, c)));
 }
 

--- a/aten/src/ATen/test/wrapdim_test.cpp
+++ b/aten/src/ATen/test/wrapdim_test.cpp
@@ -15,8 +15,7 @@ void TestExpressionSpecification(DeprecatedTypeProperties& T) {
   ASSERT_TRUE(a.unsqueeze(4).equal(a.unsqueeze(-1)));
 
   // can unsqueeze scalar
-  auto b = randn(1, T);
-  b.unsafeGetTensorImpl()->maybe_zero_dim(true);
+  auto b = randn({}, T);
   ASSERT_TRUE(b.unsqueeze(0).equal(b.unsqueeze(-1)));
 }
 
@@ -28,7 +27,7 @@ void TestEmptyTensor(DeprecatedTypeProperties& T) {
 void TestScalarVs1Dim1Size(DeprecatedTypeProperties& T) {
   auto a = randn(1, T);
   ASSERT_TRUE(a.prod(0).equal(a.prod(-1)));
-  a.unsafeGetTensorImpl()->maybe_zero_dim(true);
+  a.resize_({});
   ASSERT_EQ(a.dim(), 0);
   ASSERT_TRUE(a.prod(0).equal(a.prod(-1)));
 }

--- a/aten/src/TH/THTensor.hpp
+++ b/aten/src/TH/THTensor.hpp
@@ -40,13 +40,6 @@ inline THStorage* THTensor_getStoragePtr(const THTensor* tensor) {
   return tensor->storage().unsafeGetStorageImpl();
 }
 
-inline void THTensor_maybe_zero_dim(THTensor *tensor, bool condition_when_zero_dim) {
-  bool set_zero_dim = condition_when_zero_dim && tensor->sizes().size() == 1 && tensor->size(0) == 1;
-  if (set_zero_dim) {
-    tensor->set_sizes_and_strides({}, {});
-  }
-}
-
 // [NOTE: nDimension vs nDimensionLegacyNoScalars vs nDimensionLegacyAll]
 // nDimension                 corresponds to the "true" ATen dimension.
 // nDimensionLegacyNoScalars  correpsonds to the ATen dimension, except scalars are viewed as 1-dimensional tensors.

--- a/c10/core/TensorImpl.cpp
+++ b/c10/core/TensorImpl.cpp
@@ -183,10 +183,7 @@ int64_t TensorImpl::stride(int64_t d) const {
 }
 
 TensorImpl* TensorImpl::maybe_zero_dim(bool condition_when_zero_dim) {
-  bool set_zero_dim = condition_when_zero_dim && this->sizes().size() == 1 && this->size(0) == 1;
-  if (set_zero_dim) {
-    resize_dim(0);
-  }
+  TORCH_INTERNAL_ASSERT(false, "maybe_zero_dim should not be called anymore");
   return this;
 }
 

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -477,21 +477,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   }
 
   /**
-   * If `condition_when_zero_dim` is true, and the tensor is a 1-dim, 1-size
-   * tensor, reshape the tensor into a 0-dim tensor (scalar).
-   *
-   * This helper function is called from generated wrapper code, to help
-   * "fix up" tensors that legacy code didn't generate in the correct shape.
-   * For example, suppose that we have a legacy function 'add' which produces
-   * a tensor which is the same shape as its inputs; however, if the inputs
-   * were zero-dimensional, it produced a 1-dim 1-size tensor (don't ask).
-   * result->maybe_zero_dim(lhs->dim() == 0 && rhs->dim() == 0) will be called,
-   * correctly resetting the dimension to 0 when when the inputs had 0-dim.
-   *
-   * As we teach more and more of TH to handle 0-dim correctly, this function
-   * will become less necessary.  At the moment, it is often called from functions
-   * that correctly handle the 0-dim case, and is just dead code in this case.
-   * In the glorious future, this function will be eliminated entirely.
+   *  DONT CALL THIS.  It will go away very soon.
    */
   virtual TensorImpl* maybe_zero_dim(bool condition_when_zero_dim);
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #30876 Remove TensorImpl::maybe_zero_dim.
* **#30875 Make maybe_zero_dim throw an exception, remove all calls.**
* #30874 Remove scalar_check specification and codegen.
* #30827 MultiMarginCriterion: move scalar_check from codegen to code.
* #30826 [BC-BREAKING] MultiMarginCriterion: fix scalar_check in the case where reduction == None.

That function isn't used anymore; doing this in a two step process because I think actually removing the function will break XLA.