### PR TITLE
Remove TensorImpl::maybe_zero_dim.

### DIFF
--- a/c10/core/TensorImpl.cpp
+++ b/c10/core/TensorImpl.cpp
@@ -182,11 +182,6 @@ int64_t TensorImpl::stride(int64_t d) const {
   return strides_[d];
 }
 
-TensorImpl* TensorImpl::maybe_zero_dim(bool condition_when_zero_dim) {
-  TORCH_INTERNAL_ASSERT(false, "maybe_zero_dim should not be called anymore");
-  return this;
-}
-
 bool TensorImpl::has_storage() const {
   return storage_;
 }

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -477,11 +477,6 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   }
 
   /**
-   *  DONT CALL THIS.  It will go away very soon.
-   */
-  virtual TensorImpl* maybe_zero_dim(bool condition_when_zero_dim);
-
-  /**
    * True if a tensor was auto-wrapped from a C++ or Python number.
    * For example, when you write 't + 2', 2 is auto-wrapped into a Tensor
    * with `is_wrapped_number_` set to true.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#30876 Remove TensorImpl::maybe_zero_dim.**
* #30875 Make maybe_zero_dim throw an exception, remove all calls.
* #30874 Remove scalar_check specification and codegen.
* #30827 MultiMarginCriterion: move scalar_check from codegen to code.
* #30826 [BC-BREAKING] MultiMarginCriterion: fix scalar_check in the case where reduction == None.

