### PR TITLE
[Pytorch][Mobile] Add mobile operator observer for qpl logging.

### DIFF
--- a/torch/csrc/jit/mobile/module.h
+++ b/torch/csrc/jit/mobile/module.h
@@ -27,6 +27,7 @@ class TORCH_API Module {
     return run_method("forward", std::move(inputs));
   }
   Function* find_method(const std::string& basename) const;
+  std::string name() {return object_->name();}
  private:
   c10::intrusive_ptr<c10::ivalue::Object> object_;
   std::shared_ptr<CompilationUnit> cu_;

--- a/torch/csrc/jit/mobile/observer.h
+++ b/torch/csrc/jit/mobile/observer.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <string>
+#include <ATen/ThreadLocalDebugInfo.h>
+namespace torch {
+
+class MobileDebugInfo
+    : public at::ThreadLocalDebugInfoBase {
+public:
+  const std::string& getModelName() {
+    return model_name_;
+  }
+
+  void setModelName(const std::string& model_name) {
+    model_name_ = model_name;
+  }
+
+  const std::string& getMethodName() {
+    return method_name_;
+  }
+
+  void setMethodName(const std::string& method_name) {
+    method_name_ = method_name;
+  }
+
+  size_t getOpIdx() {
+    return op_idx_;
+  }
+
+  void setOpIdx(size_t op_idx) {
+    op_idx_ = op_idx;
+  }
+
+  virtual ~MobileDebugInfo() {}
+
+private:
+  std::string model_name_;
+  std::string method_name_;
+  size_t op_idx_ = 0;
+};
+
+} // namespace torch


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#30893 [Pytorch][Mobile] Add mobile operator observer for qpl logging.**

Add mobile operator observer to measure performance of each operator run.

Differential Revision: [D18131224](https://our.internmc.facebook.com/intern/diff/D18131224/)