### PR TITLE
[v1.4.0] Fix reading `__cuda_array_interface__` without strides

### DIFF
--- a/test/test_numba_integration.py
+++ b/test/test_numba_integration.py
@@ -82,7 +82,7 @@ class TestNumbaIntegration(common.TestCase):
                     AttributeError, lambda: sparse_cuda_t.__cuda_array_interface__
                 )
 
-            # CUDA tensors have the attribute and v0 interface
+            # CUDA tensors have the attribute and v2 interface
             cudat = tp(10).cuda()
 
             self.assertTrue(hasattr(cudat, "__cuda_array_interface__"))
@@ -94,11 +94,11 @@ class TestNumbaIntegration(common.TestCase):
             )
 
             self.assertEqual(ar_dict["shape"], (10,))
-            self.assertEqual(ar_dict["strides"], (cudat.storage().element_size(),))
+            self.assertIs(ar_dict["strides"], None)
             # typestr from numpy, cuda-native little-endian
             self.assertEqual(ar_dict["typestr"], numpy.dtype(npt).newbyteorder("<").str)
             self.assertEqual(ar_dict["data"], (cudat.data_ptr(), False))
-            self.assertEqual(ar_dict["version"], 1)
+            self.assertEqual(ar_dict["version"], 2)
 
     @unittest.skipIf(not TEST_CUDA, "No cuda")
     @unittest.skipIf(not TEST_NUMBA_CUDA, "No numba.cuda")

--- a/torch/csrc/utils/tensor_numpy.cpp
+++ b/torch/csrc/utils/tensor_numpy.cpp
@@ -299,18 +299,18 @@ at::Tensor tensor_from_cuda_array_interface(PyObject* obj) {
         throw TypeError("strides must be a sequence of the same length as shape");
       }
       strides = seq_to_aten_shape(py_strides);
+
+      // __cuda_array_interface__ strides use bytes. Torch strides use element counts.
+      for (auto& stride : strides) {
+        if (stride%dtype_size_in_bytes != 0) {
+          throw ValueError(
+              "given array strides not a multiple of the element byte size. "
+              "Make a copy of the array to reallocate the memory.");
+          }
+        stride /= dtype_size_in_bytes;
+      }
     } else {
       strides = at::detail::defaultStrides(sizes);
-    }
-
-    // __cuda_array_interface__ strides use bytes. Torch strides use element counts.
-    for (auto& stride : strides) {
-      if (stride%dtype_size_in_bytes != 0) {
-        throw ValueError(
-            "given array strides not a multiple of the element byte size. "
-            "Make a copy of the array to reallocate the memory.");
-        }
-      stride /= dtype_size_in_bytes;
     }
   }
 

--- a/torch/tensor.py
+++ b/torch/tensor.py
@@ -557,10 +557,16 @@ class Tensor(torch._C._TensorBase):
         itemsize = self.storage().element_size()
 
         shape = tuple(self.shape)
-        strides = tuple(s * itemsize for s in self.stride())
-        data = (self.data_ptr(), False)  # read-only is false
+        if self.is_contiguous():
+            # __cuda_array_interface__ v2 requires the strides to be omitted
+            # (either not set or set to None) for C-contiguous arrays.
+            strides = None
+        else:
+            strides = tuple(s * itemsize for s in self.stride())
+        data_ptr = self.data_ptr() if self.numel() > 0 else 0
+        data = (data_ptr, False)  # read-only is false
 
-        return dict(typestr=typestr, shape=shape, strides=strides, data=data, version=1)
+        return dict(typestr=typestr, shape=shape, strides=strides, data=data, version=2)
 
     def refine_names(self, *names):
         r"""Refines the dimension names of :attr:`self` according to :attr:`names`.


### PR DESCRIPTION
Backport of #24947.