### PR TITLE
[quant][graphmode] Remove `fold_prepack` for now

### DIFF
--- a/torch/quantization/_quantize_script.py
+++ b/torch/quantization/_quantize_script.py
@@ -79,13 +79,6 @@ def convert_script(model, inplace=False):
     if not inplace:
         model = model.copy()
     torch._C._jit_pass_insert_quant_dequant(model._c, 'forward', True)
-    if 'fbgemm' in torch.backends.quantized.supported_engines:
-        torch._C._jit_pass_insert_prepack_unpack(model._c)
-        if linear_packed_params and conv_packed_params:
-            torch._C._jit_pass_fold_prepack(model._c,
-                                            linear_packed_params,
-                                            conv_packed_params)
-
     return model
 
 # TODO: non-scriptable QConfig will be supported later


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #30553 [quant][graphmode] `insert_quant_dequant` pass support shared class types
* **#30909 [quant][graphmode] Remove `fold_prepack` for now**
* #30860 [quant][graphmode][refactor] Factor out getInvokedMethod in `InsertQuantDeQuantHelper`
* #30859 [quant][graphmode][refactor] getQParams return a dictionary of qparams

Summary:
`fold_prepack` doesn't work anymore after we change `scale`, 'zero_point`
to be attributes, but since the freeze API is coming up, I don't want to
spend time to make this work since this will be thrown away later.

Test Plan:
.

Reviewers:
mvz

Subscribers:

Tasks:

Tags:

Differential Revision: [D18864537](https://our.internmc.facebook.com/intern/diff/D18864537)