### PR TITLE
add ZERO_COLLISION_HASH to caffe2 data type

### DIFF
--- a/caffe2/core/blob_serialization.cc
+++ b/caffe2/core/blob_serialization.cc
@@ -338,6 +338,11 @@ void TensorSerializer::Serialize(
         }
       }
     } break;
+    case TensorProto_DataType_ZERO_COLLISION_HASH: {
+      CAFFE_ENFORCE(
+          false,
+          "Serialization for zero collision hash type is supported by specialized serializer ZeroCollisionIdHashSerializer");
+    } break;
       // Note: we intentially do not provide "default:" so if any new data types
       // are added, the compiler should warn the user to add the case here.
   }
@@ -632,6 +637,11 @@ void TensorDeserializer::DeserializeToTensor(
                 (i + chunkBegin) * temp_blob.meta().itemsize(),
             1);
       }
+    } break;
+    case TensorProto_DataType_ZERO_COLLISION_HASH: {
+      CAFFE_ENFORCE(
+          false,
+          "Deserialization for zero collision hash type is supported by specialized deserializer ZeroCollisionIdHashDeserializer");
     } break;
       // Note: we intentially do not provide "default:" so if any new data types
   }

--- a/caffe2/proto/caffe2.proto
+++ b/caffe2/proto/caffe2.proto
@@ -62,6 +62,8 @@ message TensorProto {
     INT64 = 10;    // int64_t
     FLOAT16 = 12;  // at::Half
     DOUBLE = 13;   // double
+
+    ZERO_COLLISION_HASH = 14;  // zero-collision hash state
   }
   optional DataType data_type = 2 [default = FLOAT];
 


### PR DESCRIPTION
Summary: Add a new data type ZERO_COLLISION_HASH .

Test Plan: ci

Differential Revision: D18843626

