### PR TITLE
Fix missing virtual destructor

### DIFF
--- a/torch/csrc/api/include/torch/data/datasets/chunk.h
+++ b/torch/csrc/api/include/torch/data/datasets/chunk.h
@@ -22,6 +22,8 @@ namespace datasets {
 template <typename ExampleType_, typename ChunkType_ = std::vector<ExampleType_>>
 class ChunkDataReader {
  public:
+  virtual ~ChunkDataReader() = default;
+
   using ChunkType = ChunkType_;
   using ExampleType = ExampleType_;
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#30927 Fix missing virtual destructor**
* #30519 Custom op autograd tests

Classes that are used virtually (e.g. have virtual methods) must have a virtual destructor or bad things happen

Differential Revision: [D18870351](https://our.internmc.facebook.com/intern/diff/D18870351/)