### PR TITLE
[v1.4.0 cherrypick] Support exporting aten::copy_ and aten::index_put to ONNX opset 11

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -703,7 +703,7 @@ class TestONNXRuntime(unittest.TestCase):
                 return x
 
         x = torch.randn(3, 4, 5)
-        update = torch.arange(2*5).to(torch.float).view(2, 5)
+        update = torch.arange(2 * 5).to(torch.float).view(2, 5)
         self.run_test(IndexPutModel6(), (x, update))
 
     @skipIfUnsupportedMinOpsetVersion(11)

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -627,8 +627,6 @@ class TestONNXRuntime(unittest.TestCase):
     def test_tensor_index_advanced_indexing_consecutive(self):
         self._test_index_generic(lambda input: input[:, torch.tensor([0, 2]), torch.tensor([[1, 3], [4, 0]]), None])
 
-    # TODO: Enable the following tests after ScatterND is supported in ONNX Runtime.
-    @unittest.skip("Enable this once ScatterND is supported in ORT")
     @skipIfUnsupportedMinOpsetVersion(11)
     def test_index_put(self):
         class IndexPutModel(torch.nn.Module):
@@ -641,7 +639,6 @@ class TestONNXRuntime(unittest.TestCase):
         update = torch.ones(4)
         self.run_test(IndexPutModel(), (x, ind, update))
 
-    @unittest.skip("Enable this once ScatterND is supported in ORT")
     @skipIfUnsupportedMinOpsetVersion(11)
     def test_index_put_accumulate(self):
         class IndexPutModel(torch.nn.Module):
@@ -653,7 +650,6 @@ class TestONNXRuntime(unittest.TestCase):
         update = torch.ones(4)
         self.run_test(IndexPutModel(), (x, ind, update))
 
-    @unittest.skip("Enable this once ScatterND is supported in ORT")
     @skipIfUnsupportedMinOpsetVersion(11)
     def test_index_put_slice_index(self):
         class IndexPutModel(torch.nn.Module):
@@ -701,7 +697,6 @@ class TestONNXRuntime(unittest.TestCase):
         update = torch.tensor([10, 15]).view(2, 1)
         self.run_test(IndexPutModel5(), (x, update))
 
-    @unittest.skip("Enable this once ScatterND is supported in ORT")
     @skipIfUnsupportedMinOpsetVersion(11)
     def test_index_put_ellipsis(self):
         class IndexPutModel(torch.nn.Module):
@@ -720,9 +715,8 @@ class TestONNXRuntime(unittest.TestCase):
 
         x = torch.randn(3, 4, 5, 6, 7)
         update = torch.randn(4, 1, 3, 2)
-        # self.run_test(IndexPutModel2(), (x, update))
+        self.run_test(IndexPutModel2(), (x, update))
 
-    @unittest.skip("Enable this once ScatterND is supported in ORT")
     @skipIfUnsupportedMinOpsetVersion(11)
     def test_copy_(self):
         class CopyModel(torch.nn.Module):
@@ -768,7 +762,6 @@ class TestONNXRuntime(unittest.TestCase):
         update = torch.randn(1, 2)
         self.run_test(CopyModel3(), (x, update))
 
-    @unittest.skip("Enable this once ScatterND is supported in ORT")
     @skipIfUnsupportedMinOpsetVersion(11)
     def test_copy_ellipsis(self):
         class CopyModel(torch.nn.Module):

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -729,8 +729,8 @@ class TestONNXRuntime(unittest.TestCase):
     @skipIfUnsupportedMinOpsetVersion(11)
     def test_copy_(self):
         class CopyModel(torch.nn.Module):
-            def forward(self, x, update):
-                x[1:3] = update
+            def forward(self, x, data):
+                x[1:3] = data
                 return x
 
         x = torch.randn(3, 4)
@@ -739,8 +739,8 @@ class TestONNXRuntime(unittest.TestCase):
 
         # mixed slice and select
         class CopyModel2(torch.nn.Module):
-            def forward(self, x, update):
-                x[1:3, 0] = update
+            def forward(self, x, data):
+                x[1:3, 0] = data
                 return x
 
         x = torch.randn(3, 4)
@@ -754,8 +754,8 @@ class TestONNXRuntime(unittest.TestCase):
         self.run_test(CopyModel2(), (x, update))
 
         class CopyModel3(torch.nn.Module):
-            def forward(self, x, udpate):
-                x[1, 1:3] = update
+            def forward(self, x, data):
+                x[1, 1:3] = data
                 return x
 
         x = torch.randn(3, 4)

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -773,23 +773,18 @@ class TestONNXRuntime(unittest.TestCase):
         update = torch.ones(1)
         self.run_test(CopyModel(), (x, update))
 
-        class CopyModel2(torch.nn.Module):
-            def forward(self, x, update):
-                x[..., 1] = update
-                return x
-
         x = torch.randn(2, 3, 4, 5, 6)
         update = torch.ones(1)
-        self.run_test(CopyModel2(), (x, update))
+        self.run_test(CopyModel(), (x, update))
 
-        class CopyModel3(torch.nn.Module):
+        class CopyModel2(torch.nn.Module):
             def forward(self, x, update):
                 x[2, ..., 1:3] = update
                 return x
 
         x = torch.randn(3, 4, 5, 6)
         update = torch.ones(1)
-        self.run_test(CopyModel3(), (x, update))
+        self.run_test(CopyModel2(), (x, update))
 
     @skipIfUnsupportedMinOpsetVersion(10)
     def test_flip(self):

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -697,6 +697,15 @@ class TestONNXRuntime(unittest.TestCase):
         update = torch.tensor([10, 15]).view(2, 1)
         self.run_test(IndexPutModel5(), (x, update))
 
+        class IndexPutModel6(torch.nn.Module):
+            def forward(self, x, update):
+                x[1:3, 0] = update
+                return x
+
+        x = torch.randn(3, 4, 5)
+        update = torch.arange(2*5).to(torch.float).view(2, 5)
+        self.run_test(IndexPutModel6(), (x, update))
+
     @skipIfUnsupportedMinOpsetVersion(11)
     def test_index_put_ellipsis(self):
         class IndexPutModel(torch.nn.Module):

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -627,6 +627,177 @@ class TestONNXRuntime(unittest.TestCase):
     def test_tensor_index_advanced_indexing_consecutive(self):
         self._test_index_generic(lambda input: input[:, torch.tensor([0, 2]), torch.tensor([[1, 3], [4, 0]]), None])
 
+    # TODO: Enable the following tests after ScatterND is supported in ONNX Runtime.
+    @unittest.skip("Enable this once ScatterND is supported in ORT")
+    @skipIfUnsupportedMinOpsetVersion(11)
+    def test_index_put(self):
+        class IndexPutModel(torch.nn.Module):
+            def forward(self, x, ind, update):
+                x[ind] = update
+                return x
+
+        x = torch.randn(3, 4)
+        ind = torch.tensor([1], dtype=torch.long)
+        update = torch.ones(4)
+        self.run_test(IndexPutModel(), (x, ind, update))
+
+    @unittest.skip("Enable this once ScatterND is supported in ORT")
+    @skipIfUnsupportedMinOpsetVersion(11)
+    def test_index_put_accumulate(self):
+        class IndexPutModel(torch.nn.Module):
+            def forward(self, x, ind, update):
+                return x.index_put((ind, ), update, accumulate=True)
+
+        x = torch.randn(3, 4)
+        ind = torch.tensor([2], dtype=torch.long)
+        update = torch.ones(4)
+        self.run_test(IndexPutModel(), (x, ind, update))
+
+    @unittest.skip("Enable this once ScatterND is supported in ORT")
+    @skipIfUnsupportedMinOpsetVersion(11)
+    def test_index_put_slice_index(self):
+        class IndexPutModel(torch.nn.Module):
+            def forward(self, x, update):
+                x[1:2, 1:3, torch.tensor([1])] += update
+                return x
+
+        x = torch.randn(3, 4, 5)
+        update = torch.tensor([10, 15]).view(1, 2, 1)
+        self.run_test(IndexPutModel(), (x, update))
+
+        class IndexPutModel2(torch.nn.Module):
+            def forward(self, x, update):
+                x[torch.tensor([0, 2]), torch.tensor([1, 2])] += update
+                return x
+
+        x = torch.randn(3, 4, 5)
+        update = torch.randn(2, 5)
+        self.run_test(IndexPutModel2(), (x, update))
+
+        class IndexPutModel3(torch.nn.Module):
+            def forward(self, x, update):
+                x[torch.tensor([0, 2]), 1:2] += update
+                return x
+
+        x = torch.randn(3, 4, 5)
+        update = torch.tensor([10, 15]).view(2, 1, 1)
+        self.run_test(IndexPutModel3(), (x, update))
+
+        class IndexPutModel4(torch.nn.Module):
+            def forward(self, x, update):
+                x[torch.tensor([0, 2]), 2] += update
+                return x
+
+        x = torch.randn(3, 4, 5)
+        update = torch.tensor([10, 15]).view(2, 1)
+        self.run_test(IndexPutModel4(), (x, update))
+
+        class IndexPutModel5(torch.nn.Module):
+            def forward(self, x, update):
+                x[1:3, torch.tensor([0, 2]), 2] += update
+                return x
+
+        x = torch.randn(3, 4, 5)
+        update = torch.tensor([10, 15]).view(2, 1)
+        self.run_test(IndexPutModel5(), (x, update))
+
+    @unittest.skip("Enable this once ScatterND is supported in ORT")
+    @skipIfUnsupportedMinOpsetVersion(11)
+    def test_index_put_ellipsis(self):
+        class IndexPutModel(torch.nn.Module):
+            def forward(self, x, update):
+                x[..., torch.tensor([2, 1, 3]), 2:4] += update
+                return x
+
+        x = torch.randn(3, 4, 5, 6, 7)
+        update = torch.randn(3, 1, 1, 3, 2)
+        self.run_test(IndexPutModel(), (x, update))
+
+        class IndexPutModel2(torch.nn.Module):
+            def forward(self, x, update):
+                x[2, ..., torch.tensor([2, 1, 3]), 2:4] += update
+                return x
+
+        x = torch.randn(3, 4, 5, 6, 7)
+        update = torch.randn(4, 1, 3, 2)
+        # self.run_test(IndexPutModel2(), (x, update))
+
+    @unittest.skip("Enable this once ScatterND is supported in ORT")
+    @skipIfUnsupportedMinOpsetVersion(11)
+    def test_copy_(self):
+        class CopyModel(torch.nn.Module):
+            def forward(self, x, update):
+                x[1:3] = update
+                return x
+
+        x = torch.randn(3, 4)
+        update = torch.randn(2, 4)
+        self.run_test(CopyModel(), (x, update))
+
+        # mixed slice and select
+        class CopyModel2(torch.nn.Module):
+            def forward(self, x, update):
+                x[1:3, 0] = update
+                return x
+
+        x = torch.randn(3, 4)
+        update = torch.tensor([0], dtype=torch.float32)
+        self.run_test(CopyModel2(), (x, update))
+
+        update = torch.tensor([2, 3], dtype=torch.float32)
+        self.run_test(CopyModel2(), (x, update))
+
+        update = torch.randn(2)
+        self.run_test(CopyModel2(), (x, update))
+
+        class CopyModel3(torch.nn.Module):
+            def forward(self, x, udpate):
+                x[1, 1:3] = update
+                return x
+
+        x = torch.randn(3, 4)
+        update = torch.tensor([0], dtype=torch.float32)
+        self.run_test(CopyModel3(), (x, update))
+
+        update = torch.tensor([2, 3], dtype=torch.float32)
+        self.run_test(CopyModel3(), (x, update))
+
+        update = torch.randn(2)
+        self.run_test(CopyModel3(), (x, update))
+
+        update = torch.randn(1, 2)
+        self.run_test(CopyModel3(), (x, update))
+
+    @unittest.skip("Enable this once ScatterND is supported in ORT")
+    @skipIfUnsupportedMinOpsetVersion(11)
+    def test_copy_ellipsis(self):
+        class CopyModel(torch.nn.Module):
+            def forward(self, x, update):
+                x[..., 1] = update
+                return x
+
+        x = torch.randn(2, 3, 4)
+        update = torch.ones(1)
+        self.run_test(CopyModel(), (x, update))
+
+        class CopyModel2(torch.nn.Module):
+            def forward(self, x, update):
+                x[..., 1] = update
+                return x
+
+        x = torch.randn(2, 3, 4, 5, 6)
+        update = torch.ones(1)
+        self.run_test(CopyModel2(), (x, update))
+
+        class CopyModel3(torch.nn.Module):
+            def forward(self, x, update):
+                x[2, ..., 1:3] = update
+                return x
+
+        x = torch.randn(3, 4, 5, 6)
+        update = torch.ones(1)
+        self.run_test(CopyModel3(), (x, update))
+
     @skipIfUnsupportedMinOpsetVersion(10)
     def test_flip(self):
         class MyModule(torch.nn.Module):

--- a/tools/build_variables.py
+++ b/tools/build_variables.py
@@ -315,6 +315,7 @@ def add_torch_libs():
         "torch/csrc/jit/passes/onnx/prepare_division_for_onnx.cpp",
         "torch/csrc/jit/passes/onnx/scalar_type_analysis.cpp",
         "torch/csrc/jit/passes/onnx/unpack_quantized_weights.cpp",
+        "torch/csrc/jit/passes/onnx/prepare_inplace_ops_for_onnx.cpp",
         "torch/csrc/jit/passes/remove_inplace_ops.cpp",
         "torch/csrc/jit/passes/utils/check_alias_annotation.cpp",
         "torch/csrc/jit/python_arg_flatten.cpp",

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -78,6 +78,7 @@ set(TORCH_PYTHON_SRCS
     ${TORCH_SRC_DIR}/csrc/jit/passes/onnx/constant_fold.cpp
     ${TORCH_SRC_DIR}/csrc/jit/passes/onnx/scalar_type_analysis.cpp
     ${TORCH_SRC_DIR}/csrc/jit/passes/onnx/unpack_quantized_weights.cpp
+    ${TORCH_SRC_DIR}/csrc/jit/passes/onnx/prepare_inplace_ops_for_onnx.cpp
     ${TORCH_SRC_DIR}/csrc/jit/python_arg_flatten.cpp
     ${TORCH_SRC_DIR}/csrc/jit/python_interpreter.cpp
     ${TORCH_SRC_DIR}/csrc/jit/python_ir.cpp

--- a/torch/csrc/autograd/VariableTypeManual.cpp
+++ b/torch/csrc/autograd/VariableTypeManual.cpp
@@ -164,7 +164,6 @@ Tensor & copy_(Tensor & self, const Tensor & src, bool non_blocking) {
       jit::tracer::addInputs(node, "src", src);
       jit::tracer::addInputs(node, "self", self);
       graph->insertNode(node);
-      jit::tracer::ensureUniqueIfOutOfPlaced("copy_ (possibly due to an assignment)", self);
       output = node->output();
     } else {
       output = graph->insert(
@@ -172,6 +171,7 @@ Tensor & copy_(Tensor & self, const Tensor & src, bool non_blocking) {
           {jit::tracer::getValueTrace(self), jit::tracer::getValueTrace(src)});
       jit::tracer::recordSourceLocation(output->node());
     }
+    jit::tracer::ensureUniqueIfOutOfPlaced("copy_ (possibly due to an assignment)", self);
   }
   // TODO: once copy is exposed in Declarations.yaml we may be able to bind
   // it automatically

--- a/torch/csrc/autograd/VariableTypeManual.cpp
+++ b/torch/csrc/autograd/VariableTypeManual.cpp
@@ -157,7 +157,7 @@ Tensor & copy_(Tensor & self, const Tensor & src, bool non_blocking) {
   if(torch::jit::tracer::isTracing()) {
     const jit::tracer::TracingState& state = *jit::tracer::getTracingState();
     auto& graph = state.graph;
-    if (state.force_outplace) {
+    if (state.force_outplace && self.storage().use_count() <= 1) {
       // if you have no views of self, then an in place copy is equivalent to
       // making sure we expand src to the same size as self
       jit::Node* node = graph->create(jit::aten::expand_as, /*num_outputs=*/1);
@@ -170,6 +170,7 @@ Tensor & copy_(Tensor & self, const Tensor & src, bool non_blocking) {
       output = graph->insert(
           jit::aten::copy_,
           {jit::tracer::getValueTrace(self), jit::tracer::getValueTrace(src)});
+      jit::tracer::recordSourceLocation(output->node());
     }
   }
   // TODO: once copy is exposed in Declarations.yaml we may be able to bind

--- a/torch/csrc/jit/init.cpp
+++ b/torch/csrc/jit/init.cpp
@@ -34,6 +34,7 @@
 #include <torch/csrc/jit/passes/onnx/prepare_division_for_onnx.h>
 #include <torch/csrc/jit/passes/onnx/scalar_type_analysis.h>
 #include <torch/csrc/jit/passes/onnx/unpack_quantized_weights.h>
+#include <torch/csrc/jit/passes/onnx/prepare_inplace_ops_for_onnx.h>
 #include <torch/csrc/jit/passes/peephole.h>
 #include <torch/csrc/jit/passes/quantization.h>
 #include <torch/csrc/jit/passes/remove_expands.h>
@@ -134,6 +135,7 @@ void initJITBindings(PyObject* module) {
           },
           pybind11::return_value_policy::move)
       .def("_jit_pass_onnx_scalar_type_analysis", ScalarTypeAnalysisForONNX)
+      .def("_jit_pass_onnx_prepare_inplace_ops_for_onnx", PrepareInplaceOpsForONNX)
       .def("_jit_pass_fuse", FuseGraph)
       .def(
           "_jit_pass_dce",

--- a/torch/csrc/jit/passes/onnx/prepare_inplace_ops_for_onnx.cpp
+++ b/torch/csrc/jit/passes/onnx/prepare_inplace_ops_for_onnx.cpp
@@ -240,6 +240,23 @@ std::vector<Value*> ReshapeToAdvancedIndexingFormat(
 //    ...
 //    %16 : Float(2) = aten::index_put(%11, %13, %14, %15)
 // The aten::index_put node alone does not contain any indices (%13 : Tensor?[] = prim::ListConstruct()).
+//    ...
+//    # Below constructs index from slice node.
+//    %23 : Long() = aten::size(%0, %4)
+//    %28 : Tensor = aten::arange(%23, %24, %25, %26, %27)
+//    %33 : Tensor = aten::slice(%28, %4, %5, %6, %7)
+//    %39 : int[] = prim::Constant[value=[-1, 1]]()
+//    %40 : Tensor = aten::view(%33, %39)
+//    ...
+//    # Below constructs index from select node.
+//    %36 : int = prim::Constant[value=0]()
+//    %37 : Tensor = aten::unsqueeze(%10, %36)
+//    %42 : int[] = prim::Constant[value=[-1]]()
+//    %43 : Tensor = aten::view(%37, %42)
+//    ...
+//    # Adding the above two indices to index_put
+//    %44 : Tensor?[] = prim::ListConstruct(%40, %43)
+//    %45 : Float(2, 5) = aten::index_put(%0, %44, %14, %15)
 void SquashSliceAndSelect(Node* index_put_node) {
   auto graph = index_put_node->owningGraph();
 

--- a/torch/csrc/jit/passes/onnx/prepare_inplace_ops_for_onnx.cpp
+++ b/torch/csrc/jit/passes/onnx/prepare_inplace_ops_for_onnx.cpp
@@ -150,9 +150,7 @@ std::vector<Value*> ReshapeToAdvancedIndexingFormat(
       tensor_ind_count++;
     }
   }
-  printf("tensor ind count %zu\n", tensor_ind_count);
   size_t total_ind_count = tensor_ind_count + dim_index_map.size();
-  printf("total ind count %zu\n", total_ind_count);
 
   bool is_after_tensor_ind = false;
   size_t tensor_ind_offset = 0;

--- a/torch/csrc/jit/passes/onnx/prepare_inplace_ops_for_onnx.cpp
+++ b/torch/csrc/jit/passes/onnx/prepare_inplace_ops_for_onnx.cpp
@@ -79,6 +79,9 @@ std::vector<Node*> FetchSliceAndSelect(const Node* index_put_node) {
 }
 
 struct ConvertedIndex {
+  ConvertedIndex(Value* index, c10::Symbol orig_node_kind)
+      : index(index), orig_node_kind(orig_node_kind) {}
+
   Value* index;
   c10::Symbol orig_node_kind;
 };

--- a/torch/csrc/jit/passes/onnx/prepare_inplace_ops_for_onnx.cpp
+++ b/torch/csrc/jit/passes/onnx/prepare_inplace_ops_for_onnx.cpp
@@ -1,0 +1,265 @@
+#include <torch/csrc/jit/passes/onnx/prepare_inplace_ops_for_onnx.h>
+
+namespace torch {
+namespace jit {
+
+namespace {
+
+Value* CreateSizeOfDim(Value* input, int64_t dim, Node* insertBefore) {
+  auto graph = input->owningGraph();
+  WithInsertPoint guard(insertBefore);
+  auto size = graph->insert(aten::size, {input, dim});
+  return size;
+}
+
+Value* ConvertSelectToIndex(int64_t index, Node* insertBefore) {
+  // Create index tensor based on index attribute of aten::select node.
+  auto graph = insertBefore->owningGraph();
+  WithInsertPoint guard(insertBefore);
+  auto idx_tensor = graph->createNumToTensor(insertConstant(*graph, index));
+  graph->insertNode(idx_tensor);
+  return graph->insert(aten::unsqueeze, {idx_tensor->output(), 0});
+}
+
+Value* ConvertSliceToIndex(Node* slice, Value* size, Node* insertBefore) {
+  // Create index tensor based on aten::slice node.
+  auto graph = slice->owningGraph();
+  WithInsertPoint guard(insertBefore);
+  auto start = slice->get(attr::start);
+  auto end = slice->get(attr::end);
+  auto step = slice->get(attr::step);
+  auto index = graph->insert(aten::arange, {size});
+  auto sliced_index = graph->insert(aten::slice, {index, {0}, start, end, step});
+  return sliced_index;
+}
+
+Value* CreateCompleteIndexTensor(Value* size, Node* insertBefore) {
+  // Create index tensor of size.
+  // The result is torch.tensor([0, 1, 2, ..., size - 1])
+  auto graph = size->owningGraph();
+  WithInsertPoint guard(insertBefore);
+  auto index = graph->insert(aten::arange, {size});
+  return index;
+}
+
+bool IsSameSource(const Node* n, const Node* m) {
+  const auto& source_n = n->sourceRange().source();
+  const auto& source_m = m->sourceRange().source(); 
+  return ((source_n->text() == source_m->text()) &&
+      (source_n->starting_line_no() == source_m->starting_line_no()));
+}
+
+std::vector<Node*> FetchSliceAndSelect(const Node* index_put_node) {
+  // Trace back all the slice & select nodes associated with the index_put node.
+  // E.g. The IR for x[1:3, 0] = update
+  //    ...
+  //    %8 : Float(2, 4) = aten::slice(%0, %4, %5, %6, %7)
+  //    ...
+  //    %11 : Float(2) = aten::select(%8, %9, %10)
+  //    ...
+  //    %13 : Tensor?[] = prim::ListConstruct()
+  //    ...
+  //    %16 : Float(2) = aten::index_put(%11, %13, %14, %15)
+  //
+  // We collect %11 and %8, to construct the index tensors.
+  // The vector slice_and_select_node contains all the associated slice and
+  // select node, in the reversed order.
+  std::vector<Node*> slice_and_select_node;
+  auto src_node = index_put_node->input(0)->node();
+  while (src_node) {
+    if ((src_node->kind() == aten::slice || src_node->kind() == aten::select) &&
+        IsSameSource(src_node, index_put_node)) {
+      slice_and_select_node.emplace_back(src_node);
+      src_node = src_node->input(0)->node();
+    } else {
+      src_node = nullptr;
+    }
+  }
+  return slice_and_select_node;
+}
+
+std::unordered_map<int64_t, Value*> ConvertSliceAndSelectToIndex(
+    Graph* graph,
+    Node* index_put_node,
+    const std::vector<Node*>& slice_and_select_nodes,
+    Node* last_node,
+    Value* orig_data) {
+  std::unordered_map<int64_t, Value*> dim_index_map;
+  if (slice_and_select_nodes.size() == 0) {
+    return dim_index_map;
+  }
+
+  // Loop over fetched slice and select nodes and convert them to index tensors.
+  // keep track of which dimension the current slice/select node is applying to.
+  int64_t cur_dim = 0;
+  // select does not keep dims,
+  // this creates offset for latter slice and select nodes.
+  int64_t dim_offset = 0;
+  for (auto it = slice_and_select_nodes.rbegin(); it != slice_and_select_nodes.rend(); ++it) {
+    auto node = *it;
+    auto dim = node->get(attr::dim)->toInt() + dim_offset;
+
+    while (cur_dim < dim) {
+      // Handle skipped dims, these are created from ..., or tensor indices
+      // E.g.: x[torch.tensor([1, 0]), ..., 0] = update, where x has rank 3.
+      // Both torch.tensor([1, 0]) and ... are skipped, we only observe aten::select node
+      // with dim == 2.
+      // Tensor indices will be handled later. Ellipsis(...) are treated as a complete slice over
+      // the axes, thus we create index tensors here accordingly.
+      if (cur_dim - dim_offset >= index_put_node->input(1)->node()->inputs().size() ||
+          index_put_node->input(1)->node()->input(cur_dim - dim_offset)->node()->mustBeNone()) {
+        auto size = CreateSizeOfDim(orig_data, cur_dim, index_put_node);
+        WithInsertPoint guard(index_put_node);
+        auto index_tensor = graph->insert(aten::arange, {size});
+        dim_index_map[cur_dim] = index_tensor;
+      }
+      cur_dim++;
+    }
+
+    if (node->kind() == aten::slice) {
+      auto size = CreateSizeOfDim(orig_data, dim, index_put_node);
+      auto indexTensor = ConvertSliceToIndex(node, size, index_put_node);
+      dim_index_map[dim] = indexTensor;
+    } else if (node->kind() == aten::select) {
+      // aten::select
+      auto index = node->get(attr::index)->toInt();
+      auto indexTensor = ConvertSelectToIndex(index, index_put_node);
+      dim_index_map[dim] = indexTensor;
+      dim_offset++;
+    } else {
+      AT_ERROR("Unexpected node kind ", node->kind().toDisplayString(),
+          " Expected aten::slice or aten::select.");
+    }
+
+    cur_dim++;
+  }
+
+  return dim_index_map;
+}
+
+std::vector<Value*> ReshapeToAdvancedIndexingFormat(
+    Graph* graph,
+    Node* index_put_node,
+    std::unordered_map<int64_t, Value*> &dim_index_map) {
+  std::vector<Value*> indices;
+
+  auto old_indices_list = index_put_node->input(1)->node()->inputs();
+  size_t tensor_ind_count = 0;
+  for (size_t i = 0; i < old_indices_list.size(); ++i) {
+    if (!old_indices_list[i]->node()->mustBeNone()) {
+      tensor_ind_count++;
+    }
+  }
+  printf("tensor ind count %zu\n", tensor_ind_count);
+  size_t total_ind_count = tensor_ind_count + dim_index_map.size();
+  printf("total ind count %zu\n", total_ind_count);
+
+  bool is_after_tensor_ind = false;
+  size_t tensor_ind_offset = 0;
+  WithInsertPoint guard(index_put_node);
+  for (size_t i = 0; i < total_ind_count; ++i) {
+    size_t ind_size = 0;
+    Value *index = nullptr;
+    if (i < old_indices_list.size() && !old_indices_list[i]->node()->mustBeNone()) {
+      if (!is_after_tensor_ind) {
+        tensor_ind_offset = i;
+        is_after_tensor_ind = true;
+      }
+      AT_ASSERT(dim_index_map.size() + 1 > tensor_ind_offset);
+      ind_size = dim_index_map.size() + 1 - tensor_ind_offset;
+      index = old_indices_list[i];
+    } else {
+      if (is_after_tensor_ind) {
+        AT_ASSERT(total_ind_count > i);
+        ind_size = total_ind_count - i;
+      } else {
+        AT_ASSERT(dim_index_map.size() + 1 > i);
+        ind_size = dim_index_map.size() + 1 - i;
+      }
+      AT_ASSERT(dim_index_map.find(i) != dim_index_map.end());
+      index = dim_index_map[i];
+    }
+    std::vector<int64_t> view_shape(ind_size, 1);
+    view_shape[0] = -1;
+    auto unsqueezed_index = graph->insert(aten::view, {index, view_shape});
+    indices.emplace_back(unsqueezed_index);
+  }
+  return indices;
+}
+
+void SquashSliceAndSelect(Node* index_put_node) {
+  auto graph = index_put_node->owningGraph();
+
+  std::vector<Node*> slice_and_select_nodes = FetchSliceAndSelect(index_put_node);
+
+  Node* last_node = slice_and_select_nodes.size() > 0 ? slice_and_select_nodes.back() : index_put_node;
+  Value* orig_data = last_node->input(0);
+
+  std::unordered_map<int64_t, Value*> dim_index_map =
+      ConvertSliceAndSelectToIndex(graph, index_put_node, slice_and_select_nodes, last_node, orig_data);
+  std::vector<Value*> indices =
+      ReshapeToAdvancedIndexingFormat(graph, index_put_node, dim_index_map);
+
+  WithInsertPoint guard(index_put_node);
+  const auto list_indices = graph->insertNode(graph->createList(OptionalType::ofTensor(), indices))
+                                 ->output();
+  auto new_index_put =
+      graph->insert(aten::index_put, {orig_data, list_indices, index_put_node->input(2), index_put_node->input(3)});
+  new_index_put->copyMetadata(index_put_node->output());
+  index_put_node->output()->replaceAllUsesWith(new_index_put);
+
+  orig_data->replaceAllUsesAfterNodeWith(new_index_put->node(), new_index_put);
+}
+
+void PrepareCopyForONNX(Block* block) {
+  auto it = block->nodes().begin();
+  while (it != block->nodes().end()) {
+    auto node = *it;
+    ++it;
+    for (auto block : node->blocks()) {
+      PrepareCopyForONNX(block);
+    }
+
+    if (node->kind() == aten::copy_) {
+      // aten::copy_ can be viewed as a special case of index_put, where the
+      // tensor indices input is empty.
+      // Remove aten::copy_, and replace it with index_put.
+      // 1. create an empty listConstruct node as indices input for index_put.
+      // 2. create index_put node.
+      WithInsertPoint guard(node);
+      auto graph = node->owningGraph();
+      auto dummy_list = graph->insertNode(graph->createList(
+                                       OptionalType::ofTensor(), {}))
+                                   ->output();
+      auto index_put = graph->insert(aten::index_put, {node->input(0), dummy_list, node->input(1), node->input(2)});
+      index_put->node()->setSourceRange(node->sourceRange());
+      index_put->copyMetadata(node->output());
+      node->output()->replaceAllUsesWith(index_put);
+    }
+  }
+}
+
+void PrepareIndexPutForONNX(Block* block) {
+  auto it = block->nodes().begin();
+  while (it != block->nodes().end()) {
+    auto node = *it;
+    ++it;
+    for (auto block : node->blocks()) {
+      PrepareIndexPutForONNX(block);
+    }
+
+    if (node->kind() == aten::index_put || node->kind() == aten::index_put_) {
+      SquashSliceAndSelect(node);
+    }
+  }
+}
+
+} // namespace
+
+void PrepareInplaceOpsForONNX(const std::shared_ptr<Graph>& graph) {
+  PrepareCopyForONNX(graph->block());
+  PrepareIndexPutForONNX(graph->block());
+}
+
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/passes/onnx/prepare_inplace_ops_for_onnx.h
+++ b/torch/csrc/jit/passes/onnx/prepare_inplace_ops_for_onnx.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <torch/csrc/jit/ir.h>
+
+namespace torch{
+namespace jit{
+
+TORCH_API void PrepareInplaceOpsForONNX(const std::shared_ptr<Graph>& graph);
+
+} // namespace jit
+} // namespace torch

--- a/torch/onnx/symbolic_opset11.py
+++ b/torch/onnx/symbolic_opset11.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from sys import maxsize
+
 import torch
 import torch.onnx.symbolic_helper as sym_help
 import warnings
@@ -65,7 +67,7 @@ def index_put(g, self, indices_list_value, values, accumulate=False):
         broadcast_index_shape = g.op("Shape", index)
         index = g.op("Unsqueeze", index, axes_i=[-1])
     sub_data_shape = sym_help._slice_helper(
-        g, g.op("Shape", self), axes=[0], starts=[len(indices_list)], ends=[9223372036854775807])
+        g, g.op("Shape", self), axes=[0], starts=[len(indices_list)], ends=[maxsize])
     values_shape = g.op("Concat", broadcast_index_shape, sub_data_shape, axis_i=0)
     values = g.op("Reshape", values, values_shape)
 

--- a/torch/onnx/symbolic_opset11.py
+++ b/torch/onnx/symbolic_opset11.py
@@ -64,7 +64,8 @@ def index_put(g, self, indices_list_value, values, accumulate=False):
     else:
         broadcast_index_shape = g.op("Shape", index)
         index = g.op("Unsqueeze", index, axes_i=[-1])
-    sub_data_shape = sym_help._slice_helper(g, g.op("Shape", self), axes=[0], starts=[len(indices_list)], ends=[9223372036854775807])
+    sub_data_shape = sym_help._slice_helper(
+        g, g.op("Shape", self), axes=[0], starts=[len(indices_list)], ends=[9223372036854775807])
     values_shape = g.op("Concat", broadcast_index_shape, sub_data_shape, axis_i=0)
     values = g.op("Reshape", values, values_shape)
 
@@ -72,8 +73,7 @@ def index_put(g, self, indices_list_value, values, accumulate=False):
         dtype = self.type().scalarType()
         dtype = sym_help.scalar_type_to_onnx.index(sym_help.cast_pytorch_to_onnx[dtype])
         dtype = sym_help.scalar_type_to_pytorch_type[dtype]
-        zeros = g.op("ConstantOfShape",
-            g.op("Shape", self), value_t=torch.tensor([0], dtype=dtype))
+        zeros = g.op("ConstantOfShape", g.op("Shape", self), value_t=torch.tensor([0], dtype=dtype))
         result = g.op("ScatterND", zeros, index, values)
         result = add(g, self, result)
     else:

--- a/torch/onnx/symbolic_opset11.py
+++ b/torch/onnx/symbolic_opset11.py
@@ -42,6 +42,46 @@ def clamp(g, self, min, max):
     return g.op("Clip", self, min, max)
 
 
+def index_put(g, self, indices_list_value, values, accumulate=False):
+    indices_list = sym_help._unpack_list(indices_list_value)
+    if sym_help._operator_export_type == torch.onnx.OperatorExportTypes.ONNX_ATEN_FALLBACK:
+        args = [self] + indices_list + [values, accumulate]
+        return g.op("ATen", *args, operator_s='index_put')
+
+    from torch.onnx.symbolic_opset9 import add, expand
+    accumulate = sym_help._parse_arg(accumulate, 'b')
+
+    index = indices_list[0]
+
+    if len(indices_list) > 1:
+        for ind in indices_list[1:]:
+            index = add(g, index, ind)
+        broadcast_index_shape = g.op("Shape", index)
+        indices_list = [
+            g.op("Unsqueeze", expand(g, ind, broadcast_index_shape, None), axes_i=[-1]) for ind in indices_list
+        ]
+        index = g.op("Concat", *indices_list, axis_i=-1)
+    else:
+        broadcast_index_shape = g.op("Shape", index)
+        index = g.op("Unsqueeze", index, axes_i=[-1])
+    sub_data_shape = sym_help._slice_helper(g, g.op("Shape", self), axes=[0], starts=[len(indices_list)], ends=[9223372036854775807])
+    values_shape = g.op("Concat", broadcast_index_shape, sub_data_shape, axis_i=0)
+    values = g.op("Reshape", values, values_shape)
+
+    if accumulate:
+        dtype = self.type().scalarType()
+        dtype = sym_help.scalar_type_to_onnx.index(sym_help.cast_pytorch_to_onnx[dtype])
+        dtype = sym_help.scalar_type_to_pytorch_type[dtype]
+        zeros = g.op("ConstantOfShape",
+            g.op("Shape", self), value_t=torch.tensor([0], dtype=dtype))
+        result = g.op("ScatterND", zeros, index, values)
+        result = add(g, self, result)
+    else:
+        result = g.op("ScatterND", self, index, values)
+
+    return result
+
+
 @parse_args('v', 'i')
 def pixel_shuffle(g, self, upscale_factor):
     dims = self.type().sizes()

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -89,8 +89,6 @@ def _optimize_graph(graph, operator_export_type, _disable_torch_constant_prop=Fa
     # Inline everyting
     torch._C._jit_pass_inline(graph)
 
-    if operator_export_type != OperatorExportTypes.RAW:
-        torch._C._jit_pass_onnx_prepare_inplace_ops_for_onnx(graph)
     # Remove fork/wait nodes
     torch._C._jit_pass_inline_fork_wait(graph)
     torch._C._jit_pass_dce(graph)
@@ -116,6 +114,8 @@ def _optimize_graph(graph, operator_export_type, _disable_torch_constant_prop=Fa
     torch._C._jit_pass_lint(graph)
 
     if operator_export_type != OperatorExportTypes.RAW:
+        torch._C._jit_pass_onnx_prepare_inplace_ops_for_onnx(graph)
+
         # onnx does not support tuples, so try to remove them
         torch._C._jit_pass_lower_all_tuples(graph)
         torch._C._jit_pass_peephole(graph, True)

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -89,6 +89,8 @@ def _optimize_graph(graph, operator_export_type, _disable_torch_constant_prop=Fa
     # Inline everyting
     torch._C._jit_pass_inline(graph)
 
+    if operator_export_type != OperatorExportTypes.RAW:
+        torch._C._jit_pass_onnx_prepare_inplace_ops_for_onnx(graph)
     # Remove fork/wait nodes
     torch._C._jit_pass_inline_fork_wait(graph)
     torch._C._jit_pass_dce(graph)


### PR DESCRIPTION
The original PR is https://github.com/pytorch/pytorch/pull/26941

We hope we can cover torchvision models in PyTorch ONNX exporter with release 1.4. This PR is part of it.

cc: @spandantiwari @BowenBao 