### PR TITLE
[Don't Merge] Enable async copy_ in reducer

### DIFF
--- a/torch/csrc/distributed/c10d/reducer.cpp
+++ b/torch/csrc/distributed/c10d/reducer.cpp
@@ -364,7 +364,7 @@ void Reducer::mark_variable_ready(VariableIndex index) {
     for (size_t i = 0; i < local_used_maps_.size(); i++) {
       // We do async H2D to avoid the blocking overhead. The async copy and
       // allreduce respect the current stream, so will be sequenced correctly.
-      local_used_maps_dev_[i].copy_(local_used_maps_[i], false);
+      local_used_maps_dev_[i].copy_(local_used_maps_[i], true);
     }
     local_used_work_ = process_group_->allreduce(local_used_maps_dev_);
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #30951 [Don't Review][Don't Merge] Sync CUDA stream on local_used_maps_dev_ creation
* **#30950 [Don't Merge] Enable async copy_ in reducer**
* #30945 [Don't Review][Don't Merge] Debug DDP Hang with Global unused params detection

