### PR TITLE
move uniform_ from TH to ATen and optimize with MKL VSL

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -1047,22 +1047,6 @@
     - Generator generator
 ]]
 [[
-  name: _th_uniform_
-  types:
-    - floating_point
-  backends:
-    - CPU
-  cname: uniform
-  variants: function
-  return: self
-  arguments:
-    - THTensor* self
-    - double from
-    - double to
-    - Generator generator
-]]
-
-[[
   name: _th_copy_ignoring_overlaps_
   cname: copyIgnoringOverlaps
   return: self

--- a/aten/src/ATen/native/Distributions.cpp
+++ b/aten/src/ATen/native/Distributions.cpp
@@ -115,7 +115,6 @@ namespace at {
 namespace native {
 
 DEFINE_DISPATCH(bernoulli_mkl_stub);
-DEFINE_DISPATCH(uniform_mkl_stub);
 DEFINE_DISPATCH(uniform_cpu_stub);
 DEFINE_DISPATCH(cauchy_stub);
 DEFINE_DISPATCH(exponential_stub);
@@ -195,12 +194,6 @@ Tensor& bernoulli_scalar_cpu_(Tensor& self, double p, Generator gen) {
 }
 
 Tensor& uniform_cpu_(Tensor& self, double from, double to, Generator* gen) {
-#if AT_MKL_ENABLED()
-  if (cpuinfo_initialize() && cpuinfo_vendor_intel == cpuinfo_get_processor(0)->core->vendor) {
-    uniform_mkl_stub(kCPU, self, from, to, gen);
-    return self;
-  }
-#endif
   auto iter = TensorIterator::nullary_op(self);
   uniform_cpu_stub(iter.device_type(), iter, from, to, gen);
   return self;

--- a/aten/src/ATen/native/Distributions.cpp
+++ b/aten/src/ATen/native/Distributions.cpp
@@ -193,7 +193,7 @@ Tensor& bernoulli_scalar_cpu_(Tensor& self, double p, Generator gen) {
   return self;
 }
 
-Tensor& uniform_cpu_(Tensor& self, double from, double to, Generator* gen) {
+Tensor& uniform_cpu_(Tensor& self, double from, double to, Generator gen) {
   auto iter = TensorIterator::nullary_op(self);
   uniform_cpu_stub(iter.device_type(), iter, from, to, gen);
   return self;

--- a/aten/src/ATen/native/UnaryOps.h
+++ b/aten/src/ATen/native/UnaryOps.h
@@ -56,6 +56,7 @@ DECLARE_DISPATCH(unary_fn, lgamma_stub);
 
 DECLARE_DISPATCH(void(*)(Tensor&, const double, Generator), bernoulli_mkl_stub);
 DECLARE_DISPATCH(void(*)(Tensor&, const double, const double, Generator *), uniform_mkl_stub);
+DECLARE_DISPATCH(void(*)(TensorIterator&, const double, const double, Generator *), uniform_cpu_stub);
 DECLARE_DISPATCH(void(*)(TensorIterator&, const double, const double, Generator), cauchy_stub);
 DECLARE_DISPATCH(void(*)(TensorIterator&, const double, Generator), exponential_stub);
 DECLARE_DISPATCH(void(*)(TensorIterator&, const double, Generator), geometric_stub);

--- a/aten/src/ATen/native/UnaryOps.h
+++ b/aten/src/ATen/native/UnaryOps.h
@@ -55,8 +55,7 @@ DECLARE_DISPATCH(unary_fn, trunc_stub);
 DECLARE_DISPATCH(unary_fn, lgamma_stub);
 
 DECLARE_DISPATCH(void(*)(Tensor&, const double, Generator), bernoulli_mkl_stub);
-DECLARE_DISPATCH(void(*)(Tensor&, const double, const double, Generator *), uniform_mkl_stub);
-DECLARE_DISPATCH(void(*)(TensorIterator&, const double, const double, Generator *), uniform_cpu_stub);
+DECLARE_DISPATCH(void(*)(TensorIterator&, const double, const double, Generator), uniform_cpu_stub);
 DECLARE_DISPATCH(void(*)(TensorIterator&, const double, const double, Generator), cauchy_stub);
 DECLARE_DISPATCH(void(*)(TensorIterator&, const double, Generator), exponential_stub);
 DECLARE_DISPATCH(void(*)(TensorIterator&, const double, Generator), geometric_stub);

--- a/aten/src/ATen/native/UnaryOps.h
+++ b/aten/src/ATen/native/UnaryOps.h
@@ -55,6 +55,7 @@ DECLARE_DISPATCH(unary_fn, trunc_stub);
 DECLARE_DISPATCH(unary_fn, lgamma_stub);
 
 DECLARE_DISPATCH(void(*)(Tensor&, const double, Generator), bernoulli_mkl_stub);
+DECLARE_DISPATCH(void(*)(Tensor&, const double, const double, Generator *), uniform_mkl_stub);
 DECLARE_DISPATCH(void(*)(TensorIterator&, const double, const double, Generator), cauchy_stub);
 DECLARE_DISPATCH(void(*)(TensorIterator&, const double, Generator), exponential_stub);
 DECLARE_DISPATCH(void(*)(TensorIterator&, const double, Generator), geometric_stub);

--- a/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
@@ -317,6 +317,68 @@ void bernoulli_mkl_kernel(Tensor &self, const double p, Generator gen) {
 }
 #endif
 
+#if !AT_MKL_ENABLED()
+void uniform_mkl_kernel(Tensor & self, const double from, const double to, Generator* gen) {
+  // Use AT_ASSERTM because this should never be reached, and AT_ASSERTM tells
+  // users to report this as a bug.
+  AT_ASSERTM(false, "ATen not compiled with MKL");
+}
+#else
+
+static inline void vslRngUniform(const int method, VSLStreamStatePtr stream,
+    const int n, float* r, const float a, const float b) {
+  vsRngUniform( method, stream, n, r, a, b );
+}
+
+static inline void vslRngUniform(const int method, VSLStreamStatePtr stream,
+    const int n, double* r, const double a, const double b) {
+  vdRngUniform( method, stream, n, r, a, b );
+}
+
+void uniform_mkl_kernel(Tensor & self, const double from, const double to, Generator* gen) {
+  CPUGenerator* generator = get_generator_or_default<CPUGenerator>(gen, detail::getDefaultCPUGenerator());
+  int64_t seed;
+  {
+    // See Note [Acquire lock when using random generators]
+    std::lock_guard<std::mutex> lock(generator->mutex_);
+    seed = generator->random();
+  }
+  int64_t n = self.numel();
+  bool contig = self.is_contiguous();
+
+  AT_DISPATCH_FLOATING_TYPES(self.scalar_type(), "uniform_cpu_", [&] {
+    Tensor tmp_tensor;
+    if (contig) {
+      tmp_tensor = self;
+    } else {
+      tmp_tensor = at::empty(self.sizes(), self.options());
+    }
+
+    scalar_t *self_ptr = self.data_ptr<scalar_t>();
+    scalar_t *sample_ptr = tmp_tensor.data_ptr<scalar_t>();
+
+    auto sample = [&](int64_t begin, int64_t end) {
+      int64_t len = end - begin;
+      if (len > 0) {
+        VSLStreamStatePtr stream;
+        vslNewStream(&stream, VSL_BRNG_MCG31, seed);
+        vslSkipAheadStream(stream, begin);
+        vslRngUniform(VSL_RNG_METHOD_UNIFORM_STD, stream, len,
+            sample_ptr + begin, static_cast<scalar_t>(from), static_cast<scalar_t>(to));
+        vslDeleteStream(&stream);
+      }
+    };
+
+    parallel_for(0, n, /* grain_size= */ 800, sample);
+
+    // copy_ if using buffer and non contiguous
+    if (!contig) {
+      self.copy_(tmp_tensor);
+    }
+  });
+}
+#endif
+
 static void exponential_kernel(TensorIterator& iter, double lambda, Generator gen) {
   AT_DISPATCH_FLOATING_TYPES(iter.dtype(), "exponential_cpu", [&]() {
     CPUGenerator* generator = get_generator_or_default<CPUGenerator>(gen, detail::getDefaultCPUGenerator());
@@ -453,6 +515,7 @@ static void rsqrt_kernel(TensorIterator& iter) {
 REGISTER_DISPATCH(rsqrt_stub, &rsqrt_kernel);
 REGISTER_DISPATCH(sigmoid_stub, &sigmoid_kernel);
 REGISTER_DISPATCH(bernoulli_mkl_stub, &bernoulli_mkl_kernel);
+REGISTER_DISPATCH(uniform_mkl_stub, &uniform_mkl_kernel);
 REGISTER_DISPATCH(cauchy_stub, &cauchy_kernel);
 REGISTER_DISPATCH(exponential_stub, &exponential_kernel);
 REGISTER_DISPATCH(geometric_stub, &geometric_kernel);

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -4363,7 +4363,7 @@
 - func: uniform_(Tensor(a!) self, float from=0, float to=1, *, Generator? generator=None) -> Tensor(a!)
   variants: method
   dispatch:
-    CPU: legacy::cpu::_th_uniform_
+    CPU: uniform_cpu_
     CUDA: uniform_cuda_
   supports_named_tensor: True
 

--- a/aten/src/TH/generic/THTensorRandom.cpp
+++ b/aten/src/TH/generic/THTensorRandom.cpp
@@ -20,21 +20,6 @@
 #define TH_REAL_MIN DBL_MIN
 #endif
 
-void THTensor_(uniform)(THTensor *self, double a, double b, at::Generator _generator)
-{
-  auto gen = at::get_generator_or_default<at::CPUGenerator>(_generator, at::detail::getDefaultCPUGenerator());
-  // See Note [Acquire lock when using random generators]
-  std::lock_guard<std::mutex> lock(gen->mutex_);
-
-  #if defined(TH_REAL_IS_FLOAT)
-  at::uniform_real_distribution<float> uniform((float)a, (float)b);
-  TH_TENSOR_APPLY(scalar_t, self, *self_data = (scalar_t)uniform(gen););
-  #else
-  at::uniform_real_distribution<double> uniform(a, b);
-  TH_TENSOR_APPLY(scalar_t, self, *self_data = (scalar_t)uniform(gen););
-  #endif
-}
-
 #undef TH_REAL_MIN
 
 void THTensor_(multinomialAliasSetup)(THTensor *probs, THLongTensor *J, THTensor *q)

--- a/aten/src/TH/generic/THTensorRandom.h
+++ b/aten/src/TH/generic/THTensorRandom.h
@@ -6,7 +6,6 @@
 #include <ATen/core/DistributionsHelper.h>
 
 #if defined(TH_REAL_IS_FLOAT) || defined(TH_REAL_IS_DOUBLE)
-TH_API void THTensor_(uniform)(THTensor *self, double a, double b, at::Generator _generator);
 TH_API void THTensor_(multinomialAliasSetup)(THTensor *prob_dist, THLongTensor *J, THTensor *q);
 TH_API void THTensor_(multinomialAliasDraw)(THLongTensor *self, THTensor *q, THLongTensor *J, int n_sample, at::Generator _generator);
 #endif


### PR DESCRIPTION
This PR moves `uniform_` CPU implementation from TH to ATen, e.g. `uniform_cpu_`.
When PyTorch is built with MKL support and CPU is deteced to be intel CPU, `uniform_cpu_` will finally call MKL VSL random generator which assures best performance on intel CPUs.
Otherwise (MKL is not built or AMD CPU), `uniform_cpu_` will end up in sequential random generator from ATen, this path is identical to old TH implementation.

Single socket run speedup: **2.4x~142x**
Single core run speedup: **3.2x~13x**