### PR TITLE
Fix race condition when creating build dir

### DIFF
--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -1052,11 +1052,13 @@ def _get_build_directory(name, verbose):
             root_extensions_directory))
 
     build_directory = os.path.join(root_extensions_directory, name)
-    if not os.path.exists(build_directory):
+    try:
+        os.makedirs(build_directory)
         if verbose:
             print('Creating extension directory {}...'.format(build_directory))
-        # This is like mkdir -p, i.e. will also create parent directories.
-        os.makedirs(build_directory)
+    except FileExistsError:
+        if verbose:
+            print('Using existing directory {}...'.format(build_directory))
 
     return build_directory
 


### PR DESCRIPTION
The original `check-and-act` style can raise `FileExistsError` when multiple processes are jit-compiling the extension on the same node.