### PR TITLE
Fix index out of bound error in Engine::ready_queue_size when called before start_threads

### DIFF
--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -837,6 +837,12 @@ bool Engine::is_checkpoint_valid() {
 }
 
 size_t Engine::ready_queue_size(at::Device device) {
+  if (ready_queues_.empty()) {
+    // The vector ready_queues_ is initialized in start_threads, but this method
+    // can be called before start_threads. Adding this check to avoid index
+    // out of bound error.
+    return 0;
+  }
   return ready_queue(device).size();
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #30888 Add glue code to collect debug info from all components
* **#30967 Fix index out of bound error in Engine::ready_queue_size when called before start_threads**
* #30884 Adding debugging metrics to process group agent

Differential Revision: [D18887178](https://our.internmc.facebook.com/intern/diff/D18887178)