### PR TITLE
Fix conflicts in CMAKE_GENERATOR and generator

### DIFF
--- a/tools/setup_helpers/cmake.py
+++ b/tools/setup_helpers/cmake.py
@@ -168,6 +168,8 @@ class CMake:
 
         args = []
         if USE_NINJA:
+            # Avoid conflicts in '-G' and the `CMAKE_GENERATOR`
+            os.environ['CMAKE_GENERATOR'] = 'Ninja'
             args.append('-GNinja')
         elif IS_WINDOWS:
             generator = os.getenv('CMAKE_GENERATOR', 'Visual Studio 15 2017')


### PR DESCRIPTION
 ...specified in -G

https://cmake.org/cmake/help/latest/variable/CMAKE_GENERATOR.html
According to the document, the generator could be determined through two methods:
1. Specify in `-G`
2. Read from `CMAKE_GENERATOR`

We should avoid conflicts in these two methods. This fixes https://github.com/pytorch/pytorch/issues/30910.

