### PR TITLE
[WIP] Updated codegen to remove TensorOptions from generated code

### DIFF
--- a/1.txt
+++ b/1.txt
@@ -1,0 +1,6023 @@
+-- The CXX compiler identification is GNU 7.4.0
+-- The C compiler identification is GNU 7.4.0
+-- Check for working CXX compiler: /usr/bin/c++
+-- Check for working CXX compiler: /usr/bin/c++ -- works
+-- Detecting CXX compiler ABI info
+-- Detecting CXX compiler ABI info - done
+-- Detecting CXX compile features
+-- Detecting CXX compile features - done
+-- Check for working C compiler: /usr/bin/cc
+-- Check for working C compiler: /usr/bin/cc -- works
+-- Detecting C compiler ABI info
+-- Detecting C compiler ABI info - done
+-- Detecting C compile features
+-- Detecting C compile features - done
+-- Not forcing any particular BLAS to be found
+-- Performing Test COMPILER_WORKS
+-- Performing Test COMPILER_WORKS - Success
+-- Performing Test SUPPORT_GLIBCXX_USE_C99
+-- Performing Test SUPPORT_GLIBCXX_USE_C99 - Success
+-- Performing Test CAFFE2_EXCEPTION_PTR_SUPPORTED
+-- Performing Test CAFFE2_EXCEPTION_PTR_SUPPORTED - Success
+-- std::exception_ptr is supported.
+-- Performing Test CAFFE2_IS_NUMA_AVAILABLE
+-- Performing Test CAFFE2_IS_NUMA_AVAILABLE - Success
+-- NUMA is available
+-- Performing Test CAFFE2_NEED_TO_TURN_OFF_DEPRECATION_WARNING
+-- Performing Test CAFFE2_NEED_TO_TURN_OFF_DEPRECATION_WARNING - Success
+-- Performing Test CAFFE2_COMPILER_SUPPORTS_AVX2_EXTENSIONS
+-- Performing Test CAFFE2_COMPILER_SUPPORTS_AVX2_EXTENSIONS - Success
+-- Current compiler supports avx2 extension. Will build perfkernels.
+-- Performing Test CAFFE2_COMPILER_SUPPORTS_AVX512_EXTENSIONS
+-- Performing Test CAFFE2_COMPILER_SUPPORTS_AVX512_EXTENSIONS - Success
+-- Current compiler supports avx512f extension. Will build fbgemm.
+-- Performing Test COMPILER_SUPPORTS_HIDDEN_VISIBILITY
+-- Performing Test COMPILER_SUPPORTS_HIDDEN_VISIBILITY - Success
+-- Performing Test COMPILER_SUPPORTS_HIDDEN_INLINE_VISIBILITY
+-- Performing Test COMPILER_SUPPORTS_HIDDEN_INLINE_VISIBILITY - Success
+-- Performing Test COMPILER_SUPPORTS_RDYNAMIC
+-- Performing Test COMPILER_SUPPORTS_RDYNAMIC - Success
+-- Building using own protobuf under third_party per request.
+-- Use custom protobuf build.
+-- Looking for pthread.h
+-- Looking for pthread.h - found
+-- Looking for pthread_create
+-- Looking for pthread_create - not found
+-- Looking for pthread_create in pthreads
+-- Looking for pthread_create in pthreads - not found
+-- Looking for pthread_create in pthread
+-- Looking for pthread_create in pthread - found
+-- Found Threads: TRUE  
+-- Caffe2 protobuf include directory: $<BUILD_INTERFACE:/scratch/iuriiz/repos/pytorch/third_party/protobuf/src>$<INSTALL_INTERFACE:include>
+-- Trying to find preferred BLAS backend of choice: MKL
+-- MKL_THREADING = OMP
+-- Looking for sys/types.h
+-- Looking for sys/types.h - found
+-- Looking for stdint.h
+-- Looking for stdint.h - found
+-- Looking for stddef.h
+-- Looking for stddef.h - found
+-- Check size of void*
+-- Check size of void* - done
+-- Looking for cblas_sgemm
+-- Looking for cblas_sgemm - found
+-- MKL libraries: /private/home/iuriiz/miniconda3/lib/libmkl_intel_lp64.so;/private/home/iuriiz/miniconda3/lib/libmkl_gnu_thread.so;/private/home/iuriiz/miniconda3/lib/libmkl_core.so;-fopenmp;/usr/lib/x86_64-linux-gnu/libpthread.so;/usr/lib/x86_64-linux-gnu/libm.so;/usr/lib/x86_64-linux-gnu/libdl.so
+-- MKL include directory: /private/home/iuriiz/miniconda3/include
+-- MKL OpenMP type: GNU
+-- MKL OpenMP library: -fopenmp
+-- The ASM compiler identification is GNU
+-- Found assembler: /usr/bin/cc
+-- Check if compiler accepts -pthread
+-- Check if compiler accepts -pthread - yes
+-- Brace yourself, we are building NNPACK
+-- Performing Test NNPACK_ARCH_IS_X86_32
+-- Performing Test NNPACK_ARCH_IS_X86_32 - Failed
+-- Found PythonInterp: /private/home/iuriiz/miniconda3/bin/python (found version "3.7.3") 
+-- NNPACK backend is x86-64
+-- Failed to find LLVM FileCheck
+-- Found Git: /usr/bin/git (found version "2.23.0") 
+-- Performing Test HAVE_CXX_FLAG_STD_CXX11
+-- Performing Test HAVE_CXX_FLAG_STD_CXX11 - Success
+-- Performing Test HAVE_CXX_FLAG_WALL
+-- Performing Test HAVE_CXX_FLAG_WALL - Success
+-- Performing Test HAVE_CXX_FLAG_WEXTRA
+-- Performing Test HAVE_CXX_FLAG_WEXTRA - Success
+-- Performing Test HAVE_CXX_FLAG_WSHADOW
+-- Performing Test HAVE_CXX_FLAG_WSHADOW - Success
+-- Performing Test HAVE_CXX_FLAG_WERROR
+-- Performing Test HAVE_CXX_FLAG_WERROR - Success
+-- Performing Test HAVE_CXX_FLAG_PEDANTIC
+-- Performing Test HAVE_CXX_FLAG_PEDANTIC - Success
+-- Performing Test HAVE_CXX_FLAG_PEDANTIC_ERRORS
+-- Performing Test HAVE_CXX_FLAG_PEDANTIC_ERRORS - Success
+-- Performing Test HAVE_CXX_FLAG_WSHORTEN_64_TO_32
+-- Performing Test HAVE_CXX_FLAG_WSHORTEN_64_TO_32 - Failed
+-- Performing Test HAVE_CXX_FLAG_WFLOAT_EQUAL
+-- Performing Test HAVE_CXX_FLAG_WFLOAT_EQUAL - Success
+-- Performing Test HAVE_CXX_FLAG_FSTRICT_ALIASING
+-- Performing Test HAVE_CXX_FLAG_FSTRICT_ALIASING - Success
+-- Performing Test HAVE_CXX_FLAG_WNO_DEPRECATED_DECLARATIONS
+-- Performing Test HAVE_CXX_FLAG_WNO_DEPRECATED_DECLARATIONS - Success
+-- Performing Test HAVE_CXX_FLAG_WSTRICT_ALIASING
+-- Performing Test HAVE_CXX_FLAG_WSTRICT_ALIASING - Success
+-- Performing Test HAVE_CXX_FLAG_WD654
+-- Performing Test HAVE_CXX_FLAG_WD654 - Failed
+-- Performing Test HAVE_CXX_FLAG_WTHREAD_SAFETY
+-- Performing Test HAVE_CXX_FLAG_WTHREAD_SAFETY - Failed
+-- Performing Test HAVE_CXX_FLAG_COVERAGE
+-- Performing Test HAVE_CXX_FLAG_COVERAGE - Success
+-- Performing Test COMPILER_SUPPORTS_AVX512
+-- Performing Test COMPILER_SUPPORTS_AVX512 - Success
+-- Found OpenMP_C: -fopenmp (found version "4.5") 
+-- Found OpenMP_CXX: -fopenmp (found version "4.5") 
+-- Found OpenMP: TRUE (found version "4.5")  
+-- Performing Test __CxxFlag__fmerge_all_constants
+-- Performing Test __CxxFlag__fmerge_all_constants - Success
+-- Found Numa: /usr/include  
+-- Found Numa  (include: /usr/include, library: /usr/lib/x86_64-linux-gnu/libnuma.so)
+-- Using third party subdirectory Eigen.
+Python 3.7.3
+-- Found PythonInterp: /private/home/iuriiz/miniconda3/bin/python (found suitable version "3.7.3", minimum required is "2.7") 
+-- Found PythonLibs: /private/home/iuriiz/miniconda3/lib/libpython3.7m.so.1.0 (found suitable version "3.7.3", minimum required is "2.7") 
+-- Could NOT find pybind11 (missing: pybind11_DIR)
+-- Could NOT find pybind11 (missing: pybind11_INCLUDE_DIR) 
+-- Using third_party/pybind11.
+-- pybind11 include dirs: /scratch/iuriiz/repos/pytorch/cmake/../third_party/pybind11/include
+-- Found MPI_C: /usr/lib/x86_64-linux-gnu/openmpi/lib/libmpi.so (found version "3.1") 
+-- Found MPI_CXX: /usr/lib/x86_64-linux-gnu/openmpi/lib/libmpi_cxx.so (found version "3.1") 
+-- Found MPI: TRUE (found version "3.1")  
+-- MPI support found
+-- MPI compile flags: 
+-- MPI include path: /usr/lib/x86_64-linux-gnu/openmpi/include/openmpi/usr/lib/x86_64-linux-gnu/openmpi/include/openmpi/opal/mca/event/libevent2022/libevent/usr/lib/x86_64-linux-gnu/openmpi/include/openmpi/opal/mca/event/libevent2022/libevent/include/usr/lib/x86_64-linux-gnu/openmpi/include
+-- MPI LINK flags path: -L/usr/lib -pthread
+-- MPI libraries: /usr/lib/x86_64-linux-gnu/openmpi/lib/libmpi_cxx.so/usr/lib/x86_64-linux-gnu/openmpi/lib/libmpi.so
+-- Adding OpenMP CXX_FLAGS: -fopenmp
+-- Will link against OpenMP libraries: /usr/lib/gcc/x86_64-linux-gnu/7/libgomp.so;/usr/lib/x86_64-linux-gnu/libpthread.so
+-- Could NOT find CUDA (missing: CUDA_TOOLKIT_ROOT_DIR CUDA_NVCC_EXECUTABLE CUDA_INCLUDE_DIRS CUDA_CUDART_LIBRARY) 
+-- MPI include path: /usr/lib/x86_64-linux-gnu/openmpi/include/openmpi/usr/lib/x86_64-linux-gnu/openmpi/include/openmpi/opal/mca/event/libevent2022/libevent/usr/lib/x86_64-linux-gnu/openmpi/include/openmpi/opal/mca/event/libevent2022/libevent/include/usr/lib/x86_64-linux-gnu/openmpi/include
+-- MPI libraries: /usr/lib/x86_64-linux-gnu/openmpi/lib/libmpi_cxx.so/usr/lib/x86_64-linux-gnu/openmpi/lib/libmpi.so
+-- 
+-- ******** Summary ********
+--   CMake version         : 3.14.0
+--   CMake command         : /private/home/iuriiz/miniconda3/bin/cmake
+--   System                : Linux
+--   C++ compiler          : /usr/bin/c++
+--   C++ compiler version  : 7.4.0
+--   CXX flags             :  -fvisibility-inlines-hidden -fopenmp -Wnon-virtual-dtor
+--   Build type            : Debug
+--   Compile definitions   : TH_BLAS_MKL;ONNX_ML=1
+--   CMAKE_PREFIX_PATH     : /private/home/iuriiz/miniconda3/lib/python3.7/site-packages
+--   CMAKE_INSTALL_PREFIX  : /scratch/iuriiz/repos/pytorch/torch
+--   CMAKE_MODULE_PATH     : /scratch/iuriiz/repos/pytorch/cmake/Modules;/scratch/iuriiz/repos/pytorch/cmake/public/../Modules_CUDA_fix
+-- 
+--   ONNX version          : 1.6.0
+--   ONNX NAMESPACE        : onnx_torch
+--   ONNX_BUILD_TESTS      : OFF
+--   ONNX_BUILD_BENCHMARKS : OFF
+--   ONNX_USE_LITE_PROTO   : OFF
+--   ONNXIFI_DUMMY_BACKEND : OFF
+--   ONNXIFI_ENABLE_EXT    : OFF
+-- 
+--   Protobuf compiler     : 
+--   Protobuf includes     : 
+--   Protobuf libraries    : 
+--   BUILD_ONNX_PYTHON     : OFF
+-- 
+-- ******** Summary ********
+--   CMake version         : 3.14.0
+--   CMake command         : /private/home/iuriiz/miniconda3/bin/cmake
+--   System                : Linux
+--   C++ compiler          : /usr/bin/c++
+--   C++ compiler version  : 7.4.0
+--   CXX flags             :  -fvisibility-inlines-hidden -fopenmp -Wnon-virtual-dtor
+--   Build type            : Debug
+--   Compile definitions   : TH_BLAS_MKL;ONNX_ML=1
+--   CMAKE_PREFIX_PATH     : /private/home/iuriiz/miniconda3/lib/python3.7/site-packages
+--   CMAKE_INSTALL_PREFIX  : /scratch/iuriiz/repos/pytorch/torch
+--   CMAKE_MODULE_PATH     : /scratch/iuriiz/repos/pytorch/cmake/Modules;/scratch/iuriiz/repos/pytorch/cmake/public/../Modules_CUDA_fix
+-- 
+--   ONNX version          : 1.4.1
+--   ONNX NAMESPACE        : onnx_torch
+--   ONNX_BUILD_TESTS      : OFF
+--   ONNX_BUILD_BENCHMARKS : OFF
+--   ONNX_USE_LITE_PROTO   : OFF
+--   ONNXIFI_DUMMY_BACKEND : OFF
+-- 
+--   Protobuf compiler     : 
+--   Protobuf includes     : 
+--   Protobuf libraries    : 
+--   BUILD_ONNX_PYTHON     : OFF
+-- Could not find CUDA with FP16 support, compiling without torch.CudaHalfTensor
+-- Removing -DNDEBUG from compile flags
+-- MAGMA not found. Compiling without MAGMA support
+-- Could not find hardware support for NEON on this machine.
+-- No OMAP3 processor on this machine.
+-- No OMAP4 processor on this machine.
+-- Looking for cpuid.h
+-- Looking for cpuid.h - found
+-- Performing Test HAVE_GCC_GET_CPUID
+-- Performing Test HAVE_GCC_GET_CPUID - Success
+-- Performing Test NO_GCC_EBX_FPIC_BUG
+-- Performing Test NO_GCC_EBX_FPIC_BUG - Success
+-- Performing Test C_HAS_AVX_1
+-- Performing Test C_HAS_AVX_1 - Failed
+-- Performing Test C_HAS_AVX_2
+-- Performing Test C_HAS_AVX_2 - Success
+-- Performing Test C_HAS_AVX2_1
+-- Performing Test C_HAS_AVX2_1 - Failed
+-- Performing Test C_HAS_AVX2_2
+-- Performing Test C_HAS_AVX2_2 - Success
+-- Performing Test CXX_HAS_AVX_1
+-- Performing Test CXX_HAS_AVX_1 - Failed
+-- Performing Test CXX_HAS_AVX_2
+-- Performing Test CXX_HAS_AVX_2 - Success
+-- Performing Test CXX_HAS_AVX2_1
+-- Performing Test CXX_HAS_AVX2_1 - Failed
+-- Performing Test CXX_HAS_AVX2_2
+-- Performing Test CXX_HAS_AVX2_2 - Success
+-- AVX compiler support found
+-- AVX2 compiler support found
+-- Performing Test BLAS_F2C_DOUBLE_WORKS
+-- Performing Test BLAS_F2C_DOUBLE_WORKS - Failed
+-- Performing Test BLAS_F2C_FLOAT_WORKS
+-- Performing Test BLAS_F2C_FLOAT_WORKS - Failed
+-- Performing Test BLAS_USE_CBLAS_DOT
+-- Performing Test BLAS_USE_CBLAS_DOT - Failed
+-- Found a library with BLAS API (mkl).
+-- Found a library with LAPACK API (mkl).
+-- USE_CUDNN is set to 0. Compiling without cuDNN support
+-- MIOpen not found. Compiling without MIOpen support
+-- MKLDNN_THREADING = OMP:COMP
+-- Found OpenMP_C: -fopenmp (found version "4.5") 
+-- Found OpenMP_CXX: -fopenmp (found version "4.5") 
+-- OpenMP lib: provided by compiler
+-- Found Doxygen: /usr/bin/doxygen (found version "1.8.13") found components:  doxygen dot 
+-- VTune profiling environment is unset
+-- Found MKL-DNN: TRUE
+-- Looking for clock_gettime in rt
+-- Looking for clock_gettime in rt - found
+-- Looking for mmap
+-- Looking for mmap - found
+-- Looking for shm_open
+-- Looking for shm_open - found
+-- Looking for shm_unlink
+-- Looking for shm_unlink - found
+-- Looking for malloc_usable_size
+-- Looking for malloc_usable_size - found
+-- Performing Test C_HAS_THREAD
+-- Performing Test C_HAS_THREAD - Success
+-- GCC 7.4.0: Adding gcc and gcc_s libs to link line
+-- NUMA paths:
+-- /usr/include
+-- /usr/lib/x86_64-linux-gnu/libnuma.so
+-- Performing Test COMPILER_SUPPORTS_NO_AVX256_SPLIT
+-- Performing Test COMPILER_SUPPORTS_NO_AVX256_SPLIT - Success
+-- Found OpenSSL: /usr/lib/x86_64-linux-gnu/libcrypto.so (found version "1.0.2n")  
+-- Check size of long double
+-- Check size of long double - done
+-- Performing Test COMPILER_SUPPORTS_LONG_DOUBLE
+-- Performing Test COMPILER_SUPPORTS_LONG_DOUBLE - Success
+-- Performing Test COMPILER_SUPPORTS_FLOAT128
+-- Performing Test COMPILER_SUPPORTS_FLOAT128 - Success
+-- Performing Test COMPILER_SUPPORTS_SSE2
+-- Performing Test COMPILER_SUPPORTS_SSE2 - Success
+-- Performing Test COMPILER_SUPPORTS_SSE4
+-- Performing Test COMPILER_SUPPORTS_SSE4 - Success
+-- Performing Test COMPILER_SUPPORTS_AVX
+-- Performing Test COMPILER_SUPPORTS_AVX - Success
+-- Performing Test COMPILER_SUPPORTS_FMA4
+-- Performing Test COMPILER_SUPPORTS_FMA4 - Success
+-- Performing Test COMPILER_SUPPORTS_AVX2
+-- Performing Test COMPILER_SUPPORTS_AVX2 - Success
+-- Performing Test COMPILER_SUPPORTS_AVX512F
+-- Performing Test COMPILER_SUPPORTS_AVX512F - Success
+-- Performing Test COMPILER_SUPPORTS_OPENMP
+-- Performing Test COMPILER_SUPPORTS_OPENMP - Success
+-- Performing Test COMPILER_SUPPORTS_WEAK_ALIASES
+-- Performing Test COMPILER_SUPPORTS_WEAK_ALIASES - Success
+-- Performing Test COMPILER_SUPPORTS_BUILTIN_MATH
+-- Performing Test COMPILER_SUPPORTS_BUILTIN_MATH - Success
+-- Performing Test COMPILER_SUPPORTS_SYS_GETRANDOM
+-- Performing Test COMPILER_SUPPORTS_SYS_GETRANDOM - Success
+-- Configuring build for SLEEF-v3.4.0
+-- Using option `-Wall -Wno-unused -Wno-attributes -Wno-unused-result -Wno-psabi -ffp-contract=off -fno-math-errno -fno-trapping-math` to compile libsleef
+-- Building shared libs : OFF
+-- MPFR : /usr/lib/x86_64-linux-gnu/libmpfr.so
+-- MPFR header file in /usr/include
+-- GMP : /usr/lib/x86_64-linux-gnu/libgmp.so
+-- RT : /usr/lib/x86_64-linux-gnu/librt.so
+-- FFTW3 : /usr/lib/x86_64-linux-gnu/libfftw3.so
+-- OPENSSL : 1.0.2n
+-- SDE : SDE_COMMAND-NOTFOUND
+-- RUNNING_ON_TRAVIS : 0
+-- COMPILER_SUPPORTS_OPENMP : 1
+-- NCCL operators skipped due to no CUDA support
+-- Excluding ideep operators as we are not using ideep
+-- Excluding image processing operators due to no opencv
+-- Excluding video processing operators due to no opencv
+-- Include Observer library
+-- /usr/bin/c++ /scratch/iuriiz/repos/pytorch/caffe2/../torch/abi-check.cpp -o /scratch/iuriiz/repos/pytorch/build/abi-check
+-- Determined _GLIBCXX_USE_CXX11_ABI=1
+-- Building c10d without CUDA/ROCm support
+-- MPI_INCLUDE_PATH: /usr/lib/x86_64-linux-gnu/openmpi/include/openmpi;/usr/lib/x86_64-linux-gnu/openmpi/include/openmpi/opal/mca/event/libevent2022/libevent;/usr/lib/x86_64-linux-gnu/openmpi/include/openmpi/opal/mca/event/libevent2022/libevent/include;/usr/lib/x86_64-linux-gnu/openmpi/include
+-- MPI_LIBRARIES: /usr/lib/x86_64-linux-gnu/openmpi/lib/libmpi_cxx.so;/usr/lib/x86_64-linux-gnu/openmpi/lib/libmpi.so
+-- MPIEXEC: /usr/bin/mpiexec
+-- pytorch is compiling with OpenMP. 
+OpenMP CXX_FLAGS: -fopenmp. 
+OpenMP libraries: /usr/lib/gcc/x86_64-linux-gnu/7/libgomp.so;/usr/lib/x86_64-linux-gnu/libpthread.so.
+-- Caffe2 is compiling with OpenMP. 
+OpenMP CXX_FLAGS: -fopenmp. 
+OpenMP libraries: /usr/lib/gcc/x86_64-linux-gnu/7/libgomp.so;/usr/lib/x86_64-linux-gnu/libpthread.so.
+-- Using ATen parallel backend: OMP
+-- Using lib/python3.7/site-packages as python relative installation path
+-- 
+-- ******** Summary ********
+-- General:
+--   CMake version         : 3.14.0
+--   CMake command         : /private/home/iuriiz/miniconda3/bin/cmake
+--   System                : Linux
+--   C++ compiler          : /usr/bin/c++
+--   C++ compiler id       : GNU
+--   C++ compiler version  : 7.4.0
+--   BLAS                  : MKL
+--   CXX flags             :  -fvisibility-inlines-hidden -fopenmp -DUSE_FBGEMM -DUSE_QNNPACK -DUSE_PYTORCH_QNNPACK -O2 -fPIC -Wno-narrowing -Wall -Wextra -Wno-missing-field-initializers -Wno-type-limits -Wno-array-bounds -Wno-unknown-pragmas -Wno-sign-compare -Wno-unused-parameter -Wno-unused-variable -Wno-unused-function -Wno-unused-result -Wno-strict-overflow -Wno-strict-aliasing -Wno-error=deprecated-declarations -Wno-stringop-overflow -Wno-error=pedantic -Wno-error=redundant-decls -Wno-error=old-style-cast -fdiagnostics-color=always -faligned-new -Wno-unused-but-set-variable -Wno-maybe-uninitialized -fno-math-errno -fno-trapping-math -Wno-stringop-overflow
+--   Build type            : Debug
+--   Compile definitions   : TH_BLAS_MKL;ONNX_ML=1;ONNX_NAMESPACE=onnx_torch;IDEEP_USE_MKL;HAVE_MMAP=1;_FILE_OFFSET_BITS=64;HAVE_SHM_OPEN=1;HAVE_SHM_UNLINK=1;HAVE_MALLOC_USABLE_SIZE=1
+--   CMAKE_PREFIX_PATH     : /private/home/iuriiz/miniconda3/lib/python3.7/site-packages
+--   CMAKE_INSTALL_PREFIX  : /scratch/iuriiz/repos/pytorch/torch
+-- 
+--   TORCH_VERSION         : 1.4.0
+--   CAFFE2_VERSION        : 1.4.0
+--   BUILD_CAFFE2_MOBILE   : ON
+--   USE_STATIC_DISPATCH   : OFF
+--   BUILD_BINARY          : OFF
+--   BUILD_CUSTOM_PROTOBUF : ON
+--     Link local protobuf : ON
+--   BUILD_DOCS            : OFF
+--   BUILD_PYTHON          : True
+--     Python version      : 3.7.3
+--     Python executable   : /private/home/iuriiz/miniconda3/bin/python
+--     Pythonlibs version  : 3.7.3
+--     Python library      : /private/home/iuriiz/miniconda3/lib/libpython3.7m.so.1.0
+--     Python includes     : /private/home/iuriiz/miniconda3/include/python3.7m
+--     Python site-packages: lib/python3.7/site-packages
+--   BUILD_CAFFE2_OPS      : 0
+--   BUILD_SHARED_LIBS     : ON
+--   BUILD_TEST            : True
+--   BUILD_JNI             : OFF
+--   INTERN_BUILD_MOBILE   : 
+--   USE_ASAN              : OFF
+--   USE_CUDA              : OFF
+--   USE_ROCM              : OFF
+--   USE_EIGEN_FOR_BLAS    : 
+--   USE_FBGEMM            : ON
+--   USE_FFMPEG            : OFF
+--   USE_GFLAGS            : OFF
+--   USE_GLOG              : OFF
+--   USE_LEVELDB           : OFF
+--   USE_LITE_PROTO        : OFF
+--   USE_LMDB              : OFF
+--   USE_METAL             : OFF
+--   USE_MKL               : ON
+--   USE_MKLDNN            : OFF
+--   USE_NCCL              : OFF
+--   USE_NNPACK            : ON
+--   USE_NUMPY             : ON
+--   USE_OBSERVERS         : ON
+--   USE_OPENCL            : OFF
+--   USE_OPENCV            : OFF
+--   USE_OPENMP            : ON
+--   USE_TBB               : OFF
+--   USE_PROF              : OFF
+--   USE_QNNPACK           : ON
+--   USE_REDIS             : OFF
+--   USE_ROCKSDB           : OFF
+--   USE_ZMQ               : OFF
+--   USE_DISTRIBUTED       : ON
+--     USE_MPI             : ON
+--     USE_GLOO            : ON
+--   BUILD_NAMEDTENSOR   : OFF
+--   Public Dependencies  : Threads::Threads;caffe2::mkl
+--   Private Dependencies : qnnpack;pytorch_qnnpack;nnpack;cpuinfo;fbgemm;/usr/lib/x86_64-linux-gnu/libnuma.so;fp16;/usr/lib/x86_64-linux-gnu/openmpi/lib/libmpi_cxx.so;/usr/lib/x86_64-linux-gnu/openmpi/lib/libmpi.so;gloo;foxi_loader;rt;gcc_s;gcc;dl
+-- Configuring done
+-- Generating done
+-- Build files have been written to: /scratch/iuriiz/repos/pytorch/build
+[1/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf-lite.dir/__/src/google/protobuf/stubs/io_win32.cc.o
+[2/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf-lite.dir/__/src/google/protobuf/io/zero_copy_stream.cc.o
+[3/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf-lite.dir/__/src/google/protobuf/stubs/stringprintf.cc.o
+[4/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf-lite.dir/__/src/google/protobuf/arenastring.cc.o
+[5/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf-lite.dir/__/src/google/protobuf/stubs/statusor.cc.o
+[6/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf-lite.dir/__/src/google/protobuf/stubs/structurally_valid.cc.o
+[7/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf-lite.dir/__/src/google/protobuf/stubs/status.cc.o
+[8/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf-lite.dir/__/src/google/protobuf/stubs/time.cc.o
+[9/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf-lite.dir/__/src/google/protobuf/io/zero_copy_stream_impl_lite.cc.o
+[10/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf-lite.dir/__/src/google/protobuf/stubs/bytestream.cc.o
+[11/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf-lite.dir/__/src/google/protobuf/arena.cc.o
+[12/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf-lite.dir/__/src/google/protobuf/stubs/stringpiece.cc.o
+[13/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/js/well_known_types_embed.cc.o
+[14/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf-lite.dir/__/src/google/protobuf/implicit_weak_message.cc.o
+[15/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/csharp/csharp_doc_comment.cc.o
+[16/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/java/java_doc_comment.cc.o
+[17/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf-lite.dir/__/src/google/protobuf/io/coded_stream.cc.o
+[18/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf-lite.dir/__/src/google/protobuf/stubs/int128.cc.o
+[19/2582] Building C object confu-deps/QNNPACK/CMakeFiles/qnnpack.dir/src/fully-connected.c.o
+[20/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf-lite.dir/__/src/google/protobuf/repeated_field.cc.o
+[21/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf-lite.dir/__/src/google/protobuf/stubs/common.cc.o
+[22/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf-lite.dir/__/src/google/protobuf/message_lite.cc.o
+[23/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf-lite.dir/__/src/google/protobuf/wire_format_lite.cc.o
+[24/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/csharp/csharp_repeated_primitive_field.cc.o
+[25/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/csharp/csharp_source_generator_base.cc.o
+[26/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf-lite.dir/__/src/google/protobuf/stubs/strutil.cc.o
+[27/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/csharp/csharp_repeated_enum_field.cc.o
+[28/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/csharp/csharp_enum_field.cc.o
+[29/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/code_generator.cc.o
+[30/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/csharp/csharp_helpers.cc.o
+[31/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/csharp/csharp_generator.cc.o
+[32/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/java/java_extension_lite.cc.o
+[33/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf-lite.dir/__/src/google/protobuf/generated_message_table_driven_lite.cc.o
+[34/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/java/java_generator_factory.cc.o
+[35/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/csharp/csharp_primitive_field.cc.o
+[36/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/java/java_extension.cc.o
+[37/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/java/java_lazy_message_field_lite.cc.o
+[38/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/cpp/cpp_map_field.cc.o
+[39/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/csharp/csharp_message_field.cc.o
+[40/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/csharp/csharp_reflection_class.cc.o
+[41/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/csharp/csharp_map_field.cc.o
+[42/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/csharp/csharp_repeated_message_field.cc.o
+[43/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/cpp/cpp_primitive_field.cc.o
+[44/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/cpp/cpp_service.cc.o
+[45/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/java/java_map_field.cc.o
+[46/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/java/java_message_builder_lite.cc.o
+[47/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/cpp/cpp_extension.cc.o
+[48/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/java/java_map_field_lite.cc.o
+[49/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/stubs/io_win32.cc.o
+[50/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/csharp/csharp_enum.cc.o
+[51/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf-lite.dir/__/src/google/protobuf/generated_message_util.cc.o
+[52/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/java/java_generator.cc.o
+[53/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/java/java_name_resolver.cc.o
+[54/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/cpp/cpp_message_field.cc.o
+[55/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/java/java_enum_field.cc.o
+[56/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/java/java_enum_field_lite.cc.o
+[57/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/java/java_enum_lite.cc.o
+[58/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/csharp/csharp_wrapper_field.cc.o
+[59/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/java/java_lazy_message_field.cc.o
+[60/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/java/java_message_builder.cc.o
+[61/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/cpp/cpp_field.cc.o
+[62/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/cpp/cpp_padding_optimizer.cc.o
+[63/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/java/java_enum.cc.o
+[64/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/java/java_helpers.cc.o
+[65/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/csharp/csharp_field_base.cc.o
+[66/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/cpp/cpp_generator.cc.o
+[67/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/cpp/cpp_enum.cc.o
+[68/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/java/java_context.cc.o
+[69/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/cpp/cpp_string_field.cc.o
+[70/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/java/java_field.cc.o
+[71/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/io/gzip_stream.cc.o
+[72/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/java/java_message_field_lite.cc.o
+[73/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/cpp/cpp_enum_field.cc.o
+[74/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/java/java_message_field.cc.o
+[75/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/csharp/csharp_message.cc.o
+[76/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/java/java_primitive_field_lite.cc.o
+[77/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/java/java_primitive_field.cc.o
+[78/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/arenastring.cc.o
+[79/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/arena.cc.o
+[80/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/io/zero_copy_stream.cc.o
+[81/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/java/java_message_lite.cc.o
+[82/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/zip_writer.cc.o
+[83/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/java/java_service.cc.o
+[84/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/protoc.dir/__/src/google/protobuf/compiler/main.cc.o
+[85/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/stubs/stringprintf.cc.o
+[86/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/subprocess.cc.o
+[87/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/objectivec/objectivec_enum.cc.o
+[88/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/cpp/cpp_helpers.cc.o
+[89/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/stubs/statusor.cc.o
+[90/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/stubs/status.cc.o
+[91/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/io/zero_copy_stream_impl_lite.cc.o
+[92/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/objectivec/objectivec_generator.cc.o
+[93/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/implicit_weak_message.cc.o
+[94/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/java/java_shared_code_generator.cc.o
+[95/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/stubs/structurally_valid.cc.o
+[96/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/java/java_message.cc.o
+[97/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/repeated_field.cc.o
+[98/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/stubs/bytestream.cc.o
+[99/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/java/java_file.cc.o
+[100/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/stubs/int128.cc.o
+[101/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/stubs/time.cc.o
+[102/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/java/java_string_field_lite.cc.o
+[103/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/io/coded_stream.cc.o
+[104/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/stubs/stringpiece.cc.o
+[105/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/objectivec/objectivec_extension.cc.o
+[106/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/io/strtod.cc.o
+[107/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/stubs/common.cc.o
+[108/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/objectivec/objectivec_oneof.cc.o
+[109/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/java/java_string_field.cc.o
+[110/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/objectivec/objectivec_enum_field.cc.o
+[111/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/objectivec/objectivec_message_field.cc.o
+[112/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf-lite.dir/__/src/google/protobuf/extension_set.cc.o
+[113/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/objectivec/objectivec_map_field.cc.o
+[114/2582] Building C object confu-deps/QNNPACK/CMakeFiles/qnnpack.dir/src/init.c.o
+[115/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/service.cc.o
+[116/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/message_lite.cc.o
+[117/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/io/zero_copy_stream_impl.cc.o
+[118/2582] Building C object confu-deps/QNNPACK/CMakeFiles/qnnpack.dir/src/add.c.o
+[119/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/any.cc.o
+[120/2582] Building C object confu-deps/QNNPACK/CMakeFiles/qnnpack.dir/src/channel-shuffle.c.o
+[121/2582] Linking CXX static library lib/libprotobuf-lited.a
+[122/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/objectivec/objectivec_field.cc.o
+[123/2582] Building C object confu-deps/QNNPACK/CMakeFiles/qnnpack.dir/src/clamp.c.o
+[124/2582] Building C object confu-deps/QNNPACK/CMakeFiles/qnnpack.dir/src/global-average-pooling.c.o
+[125/2582] Building C object confu-deps/QNNPACK/CMakeFiles/qnnpack.dir/src/leaky-relu.c.o
+[126/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/stubs/mathlimits.cc.o
+[127/2582] Building C object confu-deps/QNNPACK/CMakeFiles/qnnpack.dir/src/average-pooling.c.o
+[128/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/objectivec/objectivec_primitive_field.cc.o
+[129/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/wire_format_lite.cc.o
+[130/2582] Building C object confu-deps/QNNPACK/CMakeFiles/qnnpack.dir/src/operator-delete.c.o
+[131/2582] Building C object confu-deps/QNNPACK/CMakeFiles/qnnpack.dir/src/sigmoid.c.o
+[132/2582] Building C object confu-deps/QNNPACK/CMakeFiles/qnnpack.dir/src/x8lut/scalar.c.o
+[133/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/plugin.cc.o
+[134/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/stubs/strutil.cc.o
+[135/2582] Building C object confu-deps/QNNPACK/CMakeFiles/qnnpack.dir/src/deconvolution.c.o
+[136/2582] Building C object confu-deps/QNNPACK/CMakeFiles/qnnpack.dir/src/max-pooling.c.o
+[137/2582] Building C object confu-deps/QNNPACK/CMakeFiles/qnnpack.dir/src/softargmax.c.o
+[138/2582] Building C object confu-deps/QNNPACK/CMakeFiles/qnnpack.dir/src/indirection.c.o
+[139/2582] Building C object confu-deps/QNNPACK/CMakeFiles/qnnpack.dir/src/u8lut32norm/scalar.c.o
+[140/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/stubs/substitute.cc.o
+[141/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/ruby/ruby_generator.cc.o
+[142/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/io/tokenizer.cc.o
+[143/2582] Building C object confu-deps/QNNPACK/CMakeFiles/qnnpack.dir/src/sgemm/6x8-psimd.c.o
+[144/2582] Building C object confu-deps/QNNPACK/CMakeFiles/qnnpack.dir/src/q8avgpool/up8xm-sse2.c.o
+[145/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/cpp/cpp_file.cc.o
+[146/2582] Building C object confu-deps/QNNPACK/CMakeFiles/qnnpack.dir/src/operator-run.c.o
+[147/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/any.pb.cc.o
+[148/2582] Building C object confu-deps/QNNPACK/CMakeFiles/qnnpack.dir/src/q8avgpool/up8x9-sse2.c.o
+[149/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/util/internal/error_listener.cc.o
+[150/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/util/delimited_message_util.cc.o
+[151/2582] Building C object confu-deps/QNNPACK/CMakeFiles/qnnpack.dir/src/q8avgpool/mp8x9p8q-sse2.c.o
+[152/2582] Building C object confu-deps/QNNPACK/CMakeFiles/qnnpack.dir/src/q8gavgpool/up8xm-sse2.c.o
+[153/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/generated_message_util.cc.o
+[154/2582] Building C object confu-deps/QNNPACK/CMakeFiles/qnnpack.dir/src/u8maxpool/sub16-sse2.c.o
+[155/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/io/printer.cc.o
+[156/2582] Building C object confu-deps/QNNPACK/CMakeFiles/qnnpack.dir/src/q8gavgpool/up8x7-sse2.c.o
+[157/2582] Building C object confu-deps/QNNPACK/CMakeFiles/qnnpack.dir/src/u8clamp/sse2.c.o
+[158/2582] Building C object confu-deps/QNNPACK/CMakeFiles/qnnpack.dir/src/x8zip/x2-sse2.c.o
+[159/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/php/php_generator.cc.o
+[160/2582] Building C object confu-deps/QNNPACK/CMakeFiles/qnnpack.dir/src/u8maxpool/16x9p8q-sse2.c.o
+[161/2582] Building C object confu-deps/QNNPACK/CMakeFiles/qnnpack.dir/src/u8rmax/sse2.c.o
+[162/2582] Building C object confu-deps/QNNPACK/CMakeFiles/qnnpack.dir/src/x8zip/x3-sse2.c.o
+[163/2582] Building C object confu-deps/clog/CMakeFiles/clog.dir/src/clog.c.o
+[164/2582] Building C object confu-deps/cpuinfo/CMakeFiles/cpuinfo_internals.dir/src/init.c.o
+[165/2582] Building C object confu-deps/cpuinfo/CMakeFiles/cpuinfo_internals.dir/src/x86/info.c.o
+[166/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/duration.pb.cc.o
+[167/2582] Building C object confu-deps/QNNPACK/CMakeFiles/qnnpack.dir/src/x8zip/x4-sse2.c.o
+[168/2582] Building C object confu-deps/cpuinfo/CMakeFiles/cpuinfo_internals.dir/src/x86/init.c.o
+[169/2582] Building C object confu-deps/cpuinfo/CMakeFiles/cpuinfo_internals.dir/src/x86/vendor.c.o
+[170/2582] Building C object confu-deps/cpuinfo/CMakeFiles/cpuinfo_internals.dir/src/x86/uarch.c.o
+[171/2582] Building C object confu-deps/QNNPACK/CMakeFiles/qnnpack.dir/src/convolution.c.o
+[172/2582] Building C object confu-deps/cpuinfo/CMakeFiles/cpuinfo_internals.dir/src/api.c.o
+[173/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/util/internal/json_escaping.cc.o
+[174/2582] Building C object confu-deps/QNNPACK/CMakeFiles/qnnpack.dir/src/q8gavgpool/mp8x7p7q-sse2.c.o
+[175/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/field_mask.pb.cc.o
+[176/2582] Building C object confu-deps/cpuinfo/CMakeFiles/cpuinfo_internals.dir/src/x86/name.c.o
+[177/2582] Building C object confu-deps/cpuinfo/CMakeFiles/cpuinfo_internals.dir/src/linux/smallfile.c.o
+[178/2582] Linking C static library lib/libclog.a
+[179/2582] Building C object confu-deps/cpuinfo/CMakeFiles/cpuinfo_internals.dir/src/x86/topology.c.o
+[180/2582] Building C object confu-deps/cpuinfo/CMakeFiles/cpuinfo_internals.dir/src/x86/isa.c.o
+[181/2582] Building C object confu-deps/cpuinfo/CMakeFiles/cpuinfo_internals.dir/src/x86/cache/init.c.o
+[182/2582] Building C object confu-deps/cpuinfo/CMakeFiles/cpuinfo_internals.dir/src/x86/cache/descriptor.c.o
+[183/2582] Building C object confu-deps/cpuinfo/CMakeFiles/cpuinfo_internals.dir/src/x86/cache/deterministic.c.o
+[184/2582] Building C object confu-deps/cpuinfo/CMakeFiles/cpuinfo_internals.dir/src/linux/multiline.c.o
+[185/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/empty.pb.cc.o
+[186/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/util/internal/object_writer.cc.o
+[187/2582] Building C object confu-deps/QNNPACK/CMakeFiles/qnnpack.dir/src/x8zip/xm-sse2.c.o
+[188/2582] Building C object confu-deps/cpuinfo/CMakeFiles/cpuinfo_internals.dir/src/x86/linux/cpuinfo.c.o
+[189/2582] Building C object confu-deps/cpuinfo/CMakeFiles/cpuinfo_internals.dir/src/linux/current.c.o
+[190/2582] Building C object confu-deps/cpuinfo/CMakeFiles/cpuinfo.dir/src/x86/info.c.o
+[191/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/generated_message_table_driven_lite.cc.o
+[192/2582] Building C object confu-deps/cpuinfo/CMakeFiles/cpuinfo.dir/src/x86/init.c.o
+[193/2582] Building C object confu-deps/cpuinfo/CMakeFiles/cpuinfo_internals.dir/src/x86/linux/init.c.o
+[194/2582] Building C object confu-deps/cpuinfo/CMakeFiles/cpuinfo_internals.dir/src/linux/cpulist.c.o
+[195/2582] Building C object confu-deps/cpuinfo/CMakeFiles/cpuinfo.dir/src/init.c.o
+[196/2582] Building C object confu-deps/cpuinfo/CMakeFiles/cpuinfo.dir/src/api.c.o
+[197/2582] Building C object confu-deps/cpuinfo/CMakeFiles/cpuinfo.dir/src/x86/vendor.c.o
+[198/2582] Building C object confu-deps/cpuinfo/CMakeFiles/cpuinfo.dir/src/x86/uarch.c.o
+[199/2582] Building C object confu-deps/cpuinfo/CMakeFiles/cpuinfo.dir/src/x86/topology.c.o
+[200/2582] Building C object confu-deps/cpuinfo/CMakeFiles/cpuinfo.dir/src/x86/cache/init.c.o
+[201/2582] Building C object confu-deps/cpuinfo/CMakeFiles/cpuinfo.dir/src/x86/cache/deterministic.c.o
+[202/2582] Building C object confu-deps/cpuinfo/CMakeFiles/cpuinfo.dir/src/x86/isa.c.o
+[203/2582] Building C object confu-deps/cpuinfo/CMakeFiles/cpuinfo.dir/src/x86/name.c.o
+[204/2582] Building C object confu-deps/cpuinfo/CMakeFiles/cpuinfo.dir/src/x86/cache/descriptor.c.o
+[205/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/objectivec/objectivec_file.cc.o
+[206/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/plugin.pb.cc.o
+[207/2582] Building C object confu-deps/cpuinfo/CMakeFiles/cpuinfo_internals.dir/src/linux/processors.c.o
+[208/2582] Building C object confu-deps/cpuinfo/CMakeFiles/cpuinfo.dir/src/x86/linux/cpuinfo.c.o
+[209/2582] Building C object confu-deps/cpuinfo/CMakeFiles/cpuinfo.dir/src/linux/smallfile.c.o
+[210/2582] Building C object confu-deps/cpuinfo/CMakeFiles/cpuinfo.dir/src/linux/current.c.o
+[211/2582] Building C object confu-deps/QNNPACK/CMakeFiles/qnnpack.dir/src/q8vadd/sse2.c.o
+[212/2582] Building C object confu-deps/cpuinfo/CMakeFiles/cpuinfo.dir/src/x86/linux/init.c.o
+[213/2582] Building C object confu-deps/cpuinfo/CMakeFiles/cpuinfo.dir/src/linux/multiline.c.o
+[214/2582] Building C object confu-deps/cpuinfo/CMakeFiles/cpuinfo.dir/src/linux/cpulist.c.o
+[215/2582] Building C object confu-deps/pytorch_qnnpack/CMakeFiles/pytorch_qnnpack.dir/src/init.c.o
+[216/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/objectivec/objectivec_helpers.cc.o
+[217/2582] Building C object confu-deps/cpuinfo/CMakeFiles/cpuinfo.dir/src/linux/processors.c.o
+[218/2582] Building C object confu-deps/pytorch_qnnpack/CMakeFiles/pytorch_qnnpack.dir/src/channel-shuffle.c.o
+[219/2582] Building C object confu-deps/pytorch_qnnpack/CMakeFiles/pytorch_qnnpack.dir/src/clamp.c.o
+[220/2582] Building C object confu-deps/QNNPACK/CMakeFiles/qnnpack.dir/src/q8conv/4x4c2-sse2.c.o
+[221/2582] Linking C static library lib/libcpuinfo_internals.a
+[222/2582] Building C object confu-deps/pthreadpool/CMakeFiles/pthreadpool.dir/src/threadpool-pthreads.c.o
+[223/2582] Building C object confu-deps/QNNPACK/CMakeFiles/qnnpack.dir/src/q8gemm/2x4c8-sse2.c.o
+[224/2582] Building C object confu-deps/pytorch_qnnpack/CMakeFiles/pytorch_qnnpack.dir/src/add.c.o
+[225/2582] Building C object confu-deps/pytorch_qnnpack/CMakeFiles/pytorch_qnnpack.dir/src/leaky-relu.c.o
+[226/2582] Building C object confu-deps/pytorch_qnnpack/CMakeFiles/pytorch_qnnpack.dir/src/softargmax.c.o
+[227/2582] Building C object confu-deps/pytorch_qnnpack/CMakeFiles/pytorch_qnnpack.dir/src/operator-delete.c.o
+[228/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/source_context.pb.cc.o
+[229/2582] Building C object confu-deps/pytorch_qnnpack/CMakeFiles/pytorch_qnnpack.dir/src/global-average-pooling.c.o
+[230/2582] Building C object confu-deps/pytorch_qnnpack/CMakeFiles/pytorch_qnnpack.dir/src/max-pooling.c.o
+[231/2582] Building C object confu-deps/pytorch_qnnpack/CMakeFiles/pytorch_qnnpack.dir/src/sigmoid.c.o
+[232/2582] Building C object confu-deps/pytorch_qnnpack/CMakeFiles/pytorch_qnnpack.dir/src/u8lut32norm/scalar.c.o
+[233/2582] Building C object confu-deps/pytorch_qnnpack/CMakeFiles/pytorch_qnnpack.dir/src/x8lut/scalar.c.o
+[234/2582] Building C object confu-deps/pytorch_qnnpack/CMakeFiles/pytorch_qnnpack.dir/src/average-pooling.c.o
+[235/2582] Building C object confu-deps/pytorch_qnnpack/CMakeFiles/pytorch_qnnpack.dir/src/fully-connected.c.o
+[236/2582] Building C object confu-deps/pytorch_qnnpack/CMakeFiles/pytorch_qnnpack.dir/src/indirection.c.o
+[237/2582] Linking C static library lib/libcpuinfo.a
+[238/2582] Linking C static library lib/libpthreadpool.a
+[239/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/api.pb.cc.o
+[240/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/unknown_field_set.cc.o
+[241/2582] Building C object confu-deps/QNNPACK/CMakeFiles/qnnpack.dir/src/q8dwconv/up8x9-sse2.c.o
+[242/2582] Building C object confu-deps/QNNPACK/CMakeFiles/qnnpack.dir/src/q8gemm/4x4c2-sse2.c.o
+[243/2582] Building C object confu-deps/pytorch_qnnpack/CMakeFiles/pytorch_qnnpack.dir/src/q8avgpool/up8xm-sse2.c.o
+[244/2582] Building C object confu-deps/pytorch_qnnpack/CMakeFiles/pytorch_qnnpack.dir/src/operator-run.c.o
+[245/2582] Building C object confu-deps/NNPACK/CMakeFiles/nnpack_reference_layers.dir/src/ref/convolution-output.c.o
+[246/2582] Building C object confu-deps/NNPACK/CMakeFiles/nnpack_reference_layers.dir/src/ref/convolution-input-gradient.c.o
+[247/2582] Building C object confu-deps/pytorch_qnnpack/CMakeFiles/pytorch_qnnpack.dir/src/sgemm/6x8-psimd.c.o
+[248/2582] Building C object confu-deps/pytorch_qnnpack/CMakeFiles/pytorch_qnnpack.dir/src/q8avgpool/up8x9-sse2.c.o
+[249/2582] Building C object confu-deps/pytorch_qnnpack/CMakeFiles/pytorch_qnnpack.dir/src/q8gavgpool/up8xm-sse2.c.o
+[250/2582] Building C object confu-deps/pytorch_qnnpack/CMakeFiles/pytorch_qnnpack.dir/src/u8rmax/sse2.c.o
+[251/2582] Building C object confu-deps/pytorch_qnnpack/CMakeFiles/pytorch_qnnpack.dir/src/x8zip/x2-sse2.c.o
+[252/2582] Building C object confu-deps/NNPACK/CMakeFiles/nnpack_reference_layers.dir/src/ref/convolution-kernel.c.o
+[253/2582] Building C object confu-deps/NNPACK/CMakeFiles/nnpack_reference_layers.dir/src/ref/max-pooling-output.c.o
+[254/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/util/field_comparator.cc.o
+[255/2582] Building C object confu-deps/pytorch_qnnpack/CMakeFiles/pytorch_qnnpack.dir/src/deconvolution.c.o
+[256/2582] Building C object confu-deps/pytorch_qnnpack/CMakeFiles/pytorch_qnnpack.dir/src/u8clamp/sse2.c.o
+[257/2582] Building C object confu-deps/pytorch_qnnpack/CMakeFiles/pytorch_qnnpack.dir/src/u8maxpool/sub16-sse2.c.o
+[258/2582] Building C object confu-deps/NNPACK/CMakeFiles/nnpack_reference_layers.dir/src/ref/fully-connected-output.c.o
+[259/2582] Building C object confu-deps/pytorch_qnnpack/CMakeFiles/pytorch_qnnpack.dir/src/q8gavgpool/up8x7-sse2.c.o
+[260/2582] Building C object confu-deps/pytorch_qnnpack/CMakeFiles/pytorch_qnnpack.dir/src/x8zip/x4-sse2.c.o
+[261/2582] Building C object confu-deps/NNPACK/CMakeFiles/nnpack_reference_layers.dir/src/ref/softmax-output.c.o
+[262/2582] Building C object confu-deps/NNPACK/CMakeFiles/nnpack_reference_layers.dir/src/ref/relu-input-gradient.c.o
+[263/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/objectivec/objectivec_message.cc.o
+[264/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/timestamp.pb.cc.o
+[265/2582] Building C object confu-deps/pytorch_qnnpack/CMakeFiles/pytorch_qnnpack.dir/src/x8zip/x3-sse2.c.o
+[266/2582] Building C object confu-deps/NNPACK/CMakeFiles/nnpack_reference_layers.dir/src/ref/relu-output.c.o
+[267/2582] Building C object confu-deps/pytorch_qnnpack/CMakeFiles/pytorch_qnnpack.dir/src/u8maxpool/16x9p8q-sse2.c.o
+[268/2582] Building C object confu-deps/pytorch_qnnpack/CMakeFiles/pytorch_qnnpack.dir/src/x8zip/xm-sse2.c.o
+[269/2582] Building C object confu-deps/pytorch_qnnpack/CMakeFiles/pytorch_qnnpack.dir/src/q8gavgpool/mp8x7p7q-sse2.c.o
+[270/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/compiler/importer.cc.o
+[271/2582] Building C object confu-deps/pytorch_qnnpack/CMakeFiles/pytorch_qnnpack.dir/src/q8avgpool/mp8x9p8q-sse2.c.o
+[272/2582] Building C object confu-deps/QNNPACK/CMakeFiles/qnnpack.dir/src/q8dwconv/mp8x25-sse2.c.o
+[273/2582] Linking C static library lib/libnnpack_reference_layers.a
+[274/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/util/internal/json_stream_parser.cc.o
+[275/2582] Building C object confu-deps/pytorch_qnnpack/CMakeFiles/pytorch_qnnpack.dir/src/convolution.c.o
+[276/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/python/python_generator.cc.o
+[277/2582] Building CXX object third_party/fbgemm/CMakeFiles/fbgemm_avx2.dir/src/FbgemmFP16UKernelsAvx2.cc.o
+[278/2582] Building CXX object confu-deps/pytorch_qnnpack/CMakeFiles/pytorch_qnnpack.dir/src/fc-run.cc.o
+[279/2582] Linking C static library lib/libqnnpack.a
+[280/2582] Building CXX object confu-deps/pytorch_qnnpack/CMakeFiles/pytorch_qnnpack.dir/src/fc-prepack.cc.o
+[281/2582] Building C object confu-deps/pytorch_qnnpack/CMakeFiles/pytorch_qnnpack.dir/src/q8vadd/sse2.c.o
+[282/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/util/internal/field_mask_utility.cc.o
+[283/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/generated_message_table_driven.cc.o
+[284/2582] Building C object confu-deps/pytorch_qnnpack/CMakeFiles/pytorch_qnnpack.dir/src/q8gemm/2x4c8-sse2.c.o
+[285/2582] Building C object confu-deps/pytorch_qnnpack/CMakeFiles/pytorch_qnnpack.dir/src/q8conv/4x4c2-sse2.c.o
+[286/2582] Building C object confu-deps/pytorch_qnnpack/CMakeFiles/pytorch_qnnpack.dir/src/q8gemm/4x4c2-sse2.c.o
+[287/2582] Building C object confu-deps/pytorch_qnnpack/CMakeFiles/pytorch_qnnpack.dir/src/q8dwconv/up8x9-sse2.c.o
+[288/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/extension_set_heavy.cc.o
+[289/2582] Building CXX object confu-deps/pytorch_qnnpack/CMakeFiles/pytorch_qnnpack.dir/src/conv-prepack.cc.o
+[290/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/reflection_ops.cc.o
+[291/2582] Building CXX object confu-deps/pytorch_qnnpack/CMakeFiles/pytorch_qnnpack.dir/src/conv-run.cc.o
+[292/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/util/time_util.cc.o
+[293/2582] Building CXX object third_party/benchmark/src/CMakeFiles/benchmark.dir/commandlineflags.cc.o
+[294/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/util/internal/json_objectwriter.cc.o
+[295/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/map_field.cc.o
+[296/2582] Building CXX object third_party/benchmark/src/CMakeFiles/benchmark_main.dir/benchmark_main.cc.o
+[297/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/dynamic_message.cc.o
+[298/2582] Building C object confu-deps/pytorch_qnnpack/CMakeFiles/pytorch_qnnpack.dir/src/q8dwconv/mp8x25-sse2.c.o
+[299/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/js/js_generator.cc.o
+[300/2582] Linking CXX static library lib/libpytorch_qnnpack.a
+[301/2582] Building CXX object third_party/benchmark/src/CMakeFiles/benchmark.dir/sleep.cc.o
+[302/2582] Building CXX object third_party/fbgemm/CMakeFiles/fbgemm_avx2.dir/src/OptimizedKernelsAvx2.cc.o
+[303/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/util/field_mask_util.cc.o
+[304/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/util/internal/datapiece.cc.o
+[305/2582] Building CXX object third_party/benchmark/src/CMakeFiles/benchmark.dir/counter.cc.o
+[306/2582] Building CXX object third_party/fbgemm/CMakeFiles/fbgemm_avx2.dir/src/UtilsAvx2.cc.o
+[307/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/cpp/cpp_message.cc.o
+[308/2582] Building CXX object third_party/fbgemm/CMakeFiles/fbgemm_generic.dir/src/FbgemmBfloat16Convert.cc.o
+[309/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/util/internal/type_info_test_helper.cc.o
+[310/2582] Building CXX object third_party/fbgemm/CMakeFiles/fbgemm_avx2.dir/src/FbgemmBfloat16ConvertAvx2.cc.o
+[311/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/extension_set.cc.o
+[312/2582] Building CXX object third_party/fbgemm/CMakeFiles/fbgemm_avx2.dir/src/PackDepthwiseConvMatrixAvx2.cc.o
+[313/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/type.pb.cc.o
+[314/2582] Building CXX object third_party/benchmark/src/CMakeFiles/benchmark.dir/reporter.cc.o
+[315/2582] Building CXX object third_party/fbgemm/CMakeFiles/fbgemm_avx2.dir/src/FbgemmFloat16ConvertAvx2.cc.o
+[316/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/util/json_util.cc.o
+[317/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/util/type_resolver_util.cc.o
+[318/2582] Building CXX object third_party/fbgemm/CMakeFiles/fbgemm_generic.dir/src/FbgemmFloat16Convert.cc.o
+[319/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/util/internal/protostream_objectsource.cc.o
+[320/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/util/internal/utility.cc.o
+[321/2582] Building CXX object third_party/benchmark/src/CMakeFiles/benchmark.dir/colorprint.cc.o
+[322/2582] Building CXX object third_party/benchmark/src/CMakeFiles/benchmark.dir/json_reporter.cc.o
+[323/2582] Building CXX object third_party/benchmark/src/CMakeFiles/benchmark.dir/console_reporter.cc.o
+[324/2582] Building CXX object third_party/fbgemm/CMakeFiles/fbgemm_generic.dir/src/FbgemmI8Spmdm.cc.o
+[325/2582] Building CXX object third_party/benchmark/src/CMakeFiles/benchmark.dir/timers.cc.o
+[326/2582] Building CXX object third_party/fbgemm/CMakeFiles/fbgemm_avx512.dir/src/FbgemmFP16UKernelsAvx512.cc.o
+[327/2582] Building CXX object third_party/fbgemm/CMakeFiles/fbgemm_generic.dir/src/FbgemmFP16.cc.o
+[328/2582] Building CXX object third_party/benchmark/src/CMakeFiles/benchmark.dir/string_util.cc.o
+[329/2582] Building CXX object third_party/benchmark/src/CMakeFiles/benchmark.dir/csv_reporter.cc.o
+[330/2582] Building CXX object third_party/googletest/googlemock/gtest/CMakeFiles/gtest_main.dir/src/gtest_main.cc.o
+[331/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/util/internal/type_info.cc.o
+[332/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/wrappers.pb.cc.o
+[333/2582] Building CXX object third_party/benchmark/src/CMakeFiles/benchmark.dir/complexity.cc.o
+[334/2582] Building CXX object third_party/fbgemm/asmjit/CMakeFiles/asmjit.dir/src/asmjit/core/callconv.cpp.o
+[335/2582] Building CXX object third_party/fbgemm/asmjit/CMakeFiles/asmjit.dir/src/asmjit/core/globals.cpp.o
+[336/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/util/internal/proto_writer.cc.o
+[337/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/compiler/parser.cc.o
+[338/2582] Building CXX object third_party/fbgemm/asmjit/CMakeFiles/asmjit.dir/src/asmjit/core/cpuinfo.cpp.o
+[339/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/descriptor_database.cc.o
+[340/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/util/internal/default_value_objectwriter.cc.o
+[341/2582] Building CXX object third_party/benchmark/src/CMakeFiles/benchmark.dir/sysinfo.cc.o
+[342/2582] Building CXX object third_party/fbgemm/asmjit/CMakeFiles/asmjit.dir/src/asmjit/core/inst.cpp.o
+[343/2582] Building CXX object third_party/fbgemm/asmjit/CMakeFiles/asmjit.dir/src/asmjit/core/constpool.cpp.o
+[344/2582] Building CXX object third_party/fbgemm/asmjit/CMakeFiles/asmjit.dir/src/asmjit/core/arch.cpp.o
+[345/2582] Building CXX object third_party/fbgemm/asmjit/CMakeFiles/asmjit.dir/src/asmjit/core/osutils.cpp.o
+[346/2582] Building CXX object third_party/fbgemm/asmjit/CMakeFiles/asmjit.dir/src/asmjit/core/operand.cpp.o
+[347/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/util/internal/protostream_objectwriter.cc.o
+[348/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/generated_message_reflection.cc.o
+[349/2582] Building CXX object third_party/googletest/googlemock/CMakeFiles/gmock_main.dir/src/gmock_main.cc.o
+[350/2582] Building CXX object third_party/fbgemm/asmjit/CMakeFiles/asmjit.dir/src/asmjit/core/assembler.cpp.o
+[351/2582] Building CXX object third_party/fbgemm/asmjit/CMakeFiles/asmjit.dir/src/asmjit/core/support.cpp.o
+[352/2582] Building CXX object third_party/fbgemm/CMakeFiles/fbgemm_generic.dir/src/RefImplementations.cc.o
+[353/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotoc.dir/__/src/google/protobuf/compiler/command_line_interface.cc.o
+[354/2582] Building CXX object third_party/fbgemm/asmjit/CMakeFiles/asmjit.dir/src/asmjit/core/jitruntime.cpp.o
+[355/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/struct.pb.cc.o
+[356/2582] Building CXX object third_party/fbgemm/CMakeFiles/fbgemm_generic.dir/src/PackAMatrix.cc.o
+[357/2582] Building CXX object third_party/fbgemm/CMakeFiles/fbgemm_generic.dir/src/QuantUtils.cc.o
+[358/2582] Building CXX object third_party/fbgemm/asmjit/CMakeFiles/asmjit.dir/src/asmjit/core/string.cpp.o
+[359/2582] Building CXX object third_party/fbgemm/CMakeFiles/fbgemm_generic.dir/src/Utils.cc.o
+[360/2582] Building CXX object third_party/fbgemm/asmjit/CMakeFiles/asmjit.dir/src/asmjit/core/jitallocator.cpp.o
+[361/2582] Building CXX object third_party/fbgemm/asmjit/CMakeFiles/asmjit.dir/src/asmjit/core/target.cpp.o
+[362/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/wire_format.cc.o
+[363/2582] Building CXX object third_party/fbgemm/asmjit/CMakeFiles/asmjit.dir/src/asmjit/core/type.cpp.o
+[364/2582] Building CXX object third_party/fbgemm/CMakeFiles/fbgemm_generic.dir/src/PackAWithQuantRowOffset.cc.o
+[365/2582] Building CXX object third_party/benchmark/src/CMakeFiles/benchmark.dir/statistics.cc.o
+[366/2582] Building CXX object third_party/fbgemm/asmjit/CMakeFiles/asmjit.dir/src/asmjit/core/zonelist.cpp.o
+[367/2582] Building CXX object third_party/fbgemm/asmjit/CMakeFiles/asmjit.dir/src/asmjit/core/zonetree.cpp.o
+[368/2582] Building CXX object third_party/fbgemm/CMakeFiles/fbgemm_avx512.dir/src/FbgemmBfloat16ConvertAvx512.cc.o
+[369/2582] Building CXX object third_party/fbgemm/asmjit/CMakeFiles/asmjit.dir/src/asmjit/core/zone.cpp.o
+[370/2582] Building CXX object third_party/fbgemm/asmjit/CMakeFiles/asmjit.dir/src/asmjit/core/zonestack.cpp.o
+[371/2582] Building CXX object third_party/fbgemm/CMakeFiles/fbgemm_avx512.dir/src/FbgemmFloat16ConvertAvx512.cc.o
+[372/2582] Building CXX object third_party/fbgemm/CMakeFiles/fbgemm_generic.dir/src/PackWeightMatrixForGConv.cc.o
+[373/2582] Building CXX object third_party/fbgemm/CMakeFiles/fbgemm_generic.dir/src/PackBMatrix.cc.o
+[374/2582] Building CXX object third_party/fbgemm/CMakeFiles/fbgemm_generic.dir/src/PackAWithIm2Col.cc.o
+[375/2582] Building CXX object third_party/fbgemm/CMakeFiles/fbgemm_avx512.dir/src/UtilsAvx512.cc.o
+[376/2582] Building CXX object third_party/fbgemm/asmjit/CMakeFiles/asmjit.dir/src/asmjit/core/virtmem.cpp.o
+[377/2582] Building CXX object third_party/fbgemm/asmjit/CMakeFiles/asmjit.dir/src/asmjit/core/zonehash.cpp.o
+[378/2582] Building CXX object third_party/fbgemm/asmjit/CMakeFiles/asmjit.dir/src/asmjit/core/codeholder.cpp.o
+[379/2582] Building CXX object third_party/fbgemm/CMakeFiles/fbgemm_generic.dir/src/PackAWithRowOffset.cc.o
+[380/2582] Building CXX object third_party/fbgemm/asmjit/CMakeFiles/asmjit.dir/src/asmjit/core/builder.cpp.o
+[381/2582] Building CXX object third_party/gloo/gloo/CMakeFiles/gloo.dir/transport/buffer.cc.o
+[382/2582] Building CXX object third_party/fbgemm/asmjit/CMakeFiles/asmjit.dir/src/asmjit/core/zonevector.cpp.o
+[383/2582] Building CXX object third_party/fbgemm/asmjit/CMakeFiles/asmjit.dir/src/asmjit/core/compiler.cpp.o
+[384/2582] Building CXX object third_party/fbgemm/asmjit/CMakeFiles/asmjit.dir/src/asmjit/core/logging.cpp.o
+[385/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/message.cc.o
+[386/2582] Building CXX object third_party/fbgemm/asmjit/CMakeFiles/asmjit.dir/src/asmjit/core/rastack.cpp.o
+[387/2582] Building CXX object third_party/fbgemm/CMakeFiles/fbgemm_generic.dir/src/PackMatrix.cc.o
+[388/2582] Building CXX object third_party/fbgemm/asmjit/CMakeFiles/asmjit.dir/src/asmjit/x86/x86features.cpp.o
+[389/2582] Building CXX object third_party/gloo/gloo/CMakeFiles/gloo.dir/transport/unbound_buffer.cc.o
+[390/2582] Building CXX object third_party/fbgemm/asmjit/CMakeFiles/asmjit.dir/src/asmjit/x86/x86callconv.cpp.o
+[391/2582] Building CXX object third_party/fbgemm/asmjit/CMakeFiles/asmjit.dir/src/asmjit/x86/x86operand.cpp.o
+[392/2582] Building CXX object third_party/fbgemm/CMakeFiles/fbgemm_generic.dir/src/PackWeightsForConv.cc.o
+[393/2582] Building CXX object third_party/fbgemm/asmjit/CMakeFiles/asmjit.dir/src/asmjit/core/ralocal.cpp.o
+../third_party/fbgemm/third_party/asmjit/src/asmjit/core/ralocal.cpp: In member function ‘asmjit::Error asmjit::RALocalAllocator::allocBranch(asmjit::InstNode*, asmjit::RABlock*, asmjit::RABlock*)’:
+../third_party/fbgemm/third_party/asmjit/src/asmjit/core/ralocal.cpp:833:79: warning: unused parameter ‘cont’ [-Wunused-parameter]
+ Error RALocalAllocator::allocBranch(InstNode* node, RABlock* target, RABlock* cont) noexcept {
+                                                                               ^~~~
+[394/2582] Building CXX object third_party/gloo/gloo/CMakeFiles/gloo.dir/transport/address.cc.o
+[395/2582] Building C object third_party/foxi/CMakeFiles/foxi_loader.dir/foxi/onnxifi_loader.c.o
+[396/2582] Linking C static library lib/libfoxi_loader.a
+[397/2582] Building CXX object third_party/fbgemm/CMakeFiles/fbgemm_generic.dir/src/FbgemmConv.cc.o
+[398/2582] Building CXX object third_party/gloo/gloo/CMakeFiles/gloo.dir/types.cc.o
+[399/2582] Building CXX object third_party/gloo/gloo/CMakeFiles/gloo.dir/transport/pair.cc.o
+[400/2582] Building CXX object third_party/fbgemm/asmjit/CMakeFiles/asmjit.dir/src/asmjit/x86/x86instapi.cpp.o
+[401/2582] Building CXX object third_party/fbgemm/asmjit/CMakeFiles/asmjit.dir/src/asmjit/x86/x86logging.cpp.o
+../third_party/fbgemm/third_party/asmjit/src/asmjit/x86/x86logging.cpp: In function ‘asmjit::Error asmjit::x86::LoggingInternal::formatInstruction(asmjit::String&, uint32_t, const asmjit::BaseEmitter*, uint32_t, const asmjit::BaseInst&, const asmjit::Operand_*, uint32_t)’:
+../third_party/fbgemm/third_party/asmjit/src/asmjit/x86/x86logging.cpp:677:29: warning: unused variable ‘instInfo’ [-Wunused-variable]
+     const InstDB::InstInfo& instInfo = InstDB::infoById(instId);
+                             ^~~~~~~~
+[402/2582] Building CXX object third_party/gloo/gloo/CMakeFiles/gloo.dir/common/logging.cc.o
+[403/2582] Building CXX object third_party/gloo/gloo/CMakeFiles/gloo.dir/transport/device.cc.o
+[404/2582] Building CXX object third_party/gloo/gloo/CMakeFiles/gloo.dir/barrier.cc.o
+[405/2582] Building CXX object third_party/gloo/gloo/CMakeFiles/gloo.dir/transport/context.cc.o
+[406/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/text_format.cc.o
+[407/2582] Building CXX object third_party/gloo/gloo/CMakeFiles/gloo.dir/rendezvous/store.cc.o
+[408/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/common/mkldnn_debug.cpp.o
+[409/2582] Building CXX object third_party/fbgemm/asmjit/CMakeFiles/asmjit.dir/src/asmjit/x86/x86instdb.cpp.o
+[410/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/jit_sse42_1x1_convolution.cpp.o
+[411/2582] Building CXX object third_party/gloo/gloo/CMakeFiles/gloo.dir/gather.cc.o
+[412/2582] Building CXX object third_party/gloo/gloo/CMakeFiles/gloo.dir/algorithm.cc.o
+[413/2582] Building CXX object third_party/gloo/gloo/CMakeFiles/gloo.dir/rendezvous/prefix_store.cc.o
+[414/2582] Building CXX object third_party/gloo/gloo/CMakeFiles/gloo.dir/transport/tcp/address.cc.o
+[415/2582] Building CXX object third_party/gloo/gloo/CMakeFiles/gloo.dir/context.cc.o
+[416/2582] Building CXX object third_party/fbgemm/asmjit/CMakeFiles/asmjit.dir/src/asmjit/core/rapass.cpp.o
+[417/2582] Building CXX object third_party/gloo/gloo/CMakeFiles/gloo.dir/allgather.cc.o
+[418/2582] Building CXX object third_party/gloo/gloo/CMakeFiles/gloo.dir/broadcast.cc.o
+[419/2582] Building CXX object third_party/gloo/gloo/CMakeFiles/gloo.dir/scatter.cc.o
+[420/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/common/batch_normalization.cpp.o
+[421/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/common/utils.cpp.o
+[422/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/jit_sse42_1x1_conv_kernel_f32.cpp.o
+[423/2582] Building CXX object third_party/gloo/gloo/CMakeFiles/gloo.dir/allgatherv.cc.o
+[424/2582] Building CXX object third_party/gloo/gloo/CMakeFiles/gloo.dir/reduce.cc.o
+[425/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/common/scratchpad.cpp.o
+[426/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/common/deconvolution.cpp.o
+[427/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/util/message_differencer.cc.o
+[428/2582] Building CXX object third_party/gloo/gloo/CMakeFiles/gloo.dir/allreduce_local.cc.o
+[429/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/common/convolution.cpp.o
+[430/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/common/eltwise.cpp.o
+[431/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/common/inner_product.cpp.o
+[432/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/common/lrn.cpp.o
+[433/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/common/pooling.cpp.o
+[434/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/common/convolution_pd.cpp.o
+[435/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/common/engine.cpp.o
+[436/2582] Building CXX object third_party/gloo/gloo/CMakeFiles/gloo.dir/rendezvous/file_store.cc.o
+[437/2582] Building CXX object third_party/gloo/gloo/CMakeFiles/gloo.dir/rendezvous/hash_store.cc.o
+[438/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/gemm/f32/gemm_utils_f32.cpp.o
+[439/2582] Building CXX object third_party/benchmark/src/CMakeFiles/benchmark.dir/benchmark.cc.o
+[440/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/common/primitive_attr.cpp.o
+[441/2582] Building CXX object third_party/gloo/gloo/CMakeFiles/gloo.dir/common/linux.cc.o
+[442/2582] Building CXX object third_party/gloo/gloo/CMakeFiles/gloo.dir/allreduce.cc.o
+[443/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/common/primitive.cpp.o
+[444/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/common/primitive_desc.cpp.o
+[445/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/common/softmax.cpp.o
+[446/2582] Building CXX object third_party/gloo/gloo/CMakeFiles/gloo.dir/rendezvous/context.cc.o
+[447/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/common/shuffle.cpp.o
+[448/2582] Building CXX object third_party/googletest/googlemock/CMakeFiles/gmock.dir/src/gmock-all.cc.o
+[449/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/common/primitive_iterator.cpp.o
+[450/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/common/rnn.cpp.o
+[451/2582] Building CXX object third_party/fbgemm/asmjit/CMakeFiles/asmjit.dir/src/asmjit/core/emitter.cpp.o
+[452/2582] Building CXX object third_party/fbgemm/asmjit/CMakeFiles/asmjit.dir/src/asmjit/core/func.cpp.o
+[453/2582] Building CXX object third_party/gloo/gloo/CMakeFiles/gloo.dir/transport/tcp/buffer.cc.o
+[454/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/cpu_reducer.cpp.o
+[455/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/common/reorder.cpp.o
+[456/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/common/memory_desc_wrapper.cpp.o
+[457/2582] Building CXX object third_party/gloo/gloo/CMakeFiles/gloo.dir/transport/tcp/unbound_buffer.cc.o
+[458/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/common/query.cpp.o
+[459/2582] Building CXX object third_party/gloo/gloo/CMakeFiles/gloo.dir/mpi/context.cc.o
+In file included from ../third_party/gloo/gloo/mpi/context.cc:16:0:
+../third_party/gloo/gloo/mpi/context.cc: In destructor ‘gloo::mpi::MPIScope::~MPIScope()’:
+../third_party/gloo/gloo/common/logging.h:141:58: warning: throw will always call terminate() [-Wterminate]
+           r.get_message_and_free(MakeString(__VA_ARGS__))); \
+                                                          ^
+../third_party/gloo/gloo/common/logging.h:150:3: note: in expansion of macro ‘GLOO_ENFORCE_THAT_IMPL’
+   GLOO_ENFORCE_THAT_IMPL(Equals((x), (y)), #x " == " #y, __VA_ARGS__)
+   ^~~~~~~~~~~~~~~~~~~~~~
+../third_party/gloo/gloo/mpi/context.cc:43:3: note: in expansion of macro ‘GLOO_ENFORCE_EQ’
+   GLOO_ENFORCE_EQ(rv, MPI_SUCCESS);
+   ^~~~~~~~~~~~~~~
+../third_party/gloo/gloo/common/logging.h:141:58: note: in C++11 destructors default to noexcept
+           r.get_message_and_free(MakeString(__VA_ARGS__))); \
+                                                          ^
+../third_party/gloo/gloo/common/logging.h:150:3: note: in expansion of macro ‘GLOO_ENFORCE_THAT_IMPL’
+   GLOO_ENFORCE_THAT_IMPL(Equals((x), (y)), #x " == " #y, __VA_ARGS__)
+   ^~~~~~~~~~~~~~~~~~~~~~
+../third_party/gloo/gloo/mpi/context.cc:43:3: note: in expansion of macro ‘GLOO_ENFORCE_EQ’
+   GLOO_ENFORCE_EQ(rv, MPI_SUCCESS);
+   ^~~~~~~~~~~~~~~
+[460/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/descriptor.pb.cc.o
+[461/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/cpu_primitive.cpp.o
+[462/2582] Building CXX object third_party/gloo/gloo/CMakeFiles/gloo.dir/transport/tcp/device.cc.o
+[463/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/common/stream.cpp.o
+[464/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/common/memory.cpp.o
+[465/2582] Building CXX object third_party/fbgemm/asmjit/CMakeFiles/asmjit.dir/src/asmjit/x86/x86internal.cpp.o
+../third_party/fbgemm/third_party/asmjit/src/asmjit/x86/x86internal.cpp:1337:13: warning: ‘void asmjit::x86::dumpAssignment(asmjit::String&, const asmjit::x86::X86FuncArgsContext&)’ defined but not used [-Wunused-function]
+ static void dumpAssignment(String& sb, const X86FuncArgsContext& ctx) noexcept {
+             ^~~~~~~~~~~~~~
+[466/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/common/verbose.cpp.o
+[467/2582] Generating src/x86_64-fma/2d-fourier-8x8.py.o
+[468/2582] Building CXX object third_party/gloo/gloo/CMakeFiles/gloo.dir/transport/tcp/context.cc.o
+[469/2582] Building CXX object third_party/fbgemm/asmjit/CMakeFiles/asmjit.dir/src/asmjit/x86/x86compiler.cpp.o
+[470/2582] Building CXX object third_party/fbgemm/asmjit/CMakeFiles/asmjit.dir/src/asmjit/x86/x86builder.cpp.o
+[471/2582] Building CXX object third_party/gloo/gloo/CMakeFiles/gloo.dir/transport/tcp/pair.cc.o
+[472/2582] Building CXX object third_party/fbgemm/CMakeFiles/fbgemm_generic.dir/src/ExecuteKernel.cc.o
+[473/2582] Linking CXX static library lib/libgloo.a
+[474/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/cpu_batch_normalization_utils.cpp.o
+[475/2582] Building CXX object third_party/fbgemm/CMakeFiles/fbgemm_generic.dir/src/GenerateKernelU8S8S32ACC16Avx512VNNI.cc.o
+[476/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/jit_avx512_core_x8s8s32x_convolution.cpp.o
+[477/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/gemm/gemm.cpp.o
+[478/2582] Building CXX object third_party/fbgemm/asmjit/CMakeFiles/asmjit.dir/src/asmjit/x86/x86rapass.cpp.o
+[479/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/cpu_barrier.cpp.o
+[480/2582] Building CXX object third_party/benchmark/src/CMakeFiles/benchmark.dir/benchmark_register.cc.o
+[481/2582] Building CXX object third_party/googletest/googlemock/gtest/CMakeFiles/gtest.dir/src/gtest-all.cc.o
+[482/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/gemm/f32/ref_gemm_f32.cpp.o
+[483/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/gemm/s8x8s32/jit_avx512_core_gemv_s8u8s32.cpp.o
+[484/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/jit_avx512_core_x8s8s32x_deconvolution.cpp.o
+[485/2582] Linking CXX static library lib/libgtestd.a
+[486/2582] Linking CXX static library lib/libbenchmark.a
+[487/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/cpu_concat.cpp.o
+[488/2582] Linking CXX static library lib/libgtest_maind.a
+[489/2582] Linking CXX static library lib/libgmockd.a
+[490/2582] Building CXX object third_party/fbgemm/asmjit/CMakeFiles/asmjit.dir/src/asmjit/x86/x86assembler.cpp.o
+[491/2582] Linking CXX static library lib/libbenchmark_main.a
+[492/2582] Linking CXX static library lib/libgmock_maind.a
+[493/2582] Linking CXX static library lib/libasmjit.a
+[494/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/bfloat16_utils.cpp.o
+[495/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/gemm/s8x8s32/ref_gemm_s8x8s32.cpp.o
+[496/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/gemm/bf16/jit_avx512_core_s16_copy_bn_kern.cpp.o
+[497/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/gemm/bf16/jit_avx512_core_s16_copy_bt_kern.cpp.o
+[498/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/gemm/s8x8s32/jit_avx512_core_kernel_gemv_s8u8s32_kern.cpp.o
+[499/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/gemm/gemm_driver.cpp.o
+[500/2582] Building CXX object third_party/fbgemm/CMakeFiles/fbgemm_generic.dir/src/GenerateKernelU8S8S32ACC16Avx512.cc.o
+[501/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/gemm/bf16/jit_avx512_core_gemm_bf16bf16f32_kern.cpp.o
+[502/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/gemm/bf16/jit_avx512_core_s16_copy_an_kern.cpp.o
+[503/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/gemm/s8x8s32/simple_gemm_s8s8s32.cpp.o
+[504/2582] Building CXX object third_party/fbgemm/CMakeFiles/fbgemm_generic.dir/src/FbgemmSpConv.cc.o
+[505/2582] Building CXX object third_party/fbgemm/CMakeFiles/fbgemm_generic.dir/src/GenerateKernelU8S8S32ACC32.cc.o
+[506/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/gemm_convolution.cpp.o
+[507/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/gemm/s8x8s32/jit_avx512_core_gemm_s8u8s32_kern.cpp.o
+[508/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/gemm/f32/jit_avx2_f32_copy_bn_kern.cpp.o
+[509/2582] Building CXX object third_party/fbgemm/CMakeFiles/fbgemm_generic.dir/src/GenerateKernelU8S8S32ACC32Avx512VNNI.cc.o
+[510/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/gemm/gemm_info.cpp.o
+[511/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/gemm/f32/jit_avx2_f32_copy_bt_kern.cpp.o
+[512/2582] Building CXX object third_party/fbgemm/CMakeFiles/fbgemm_generic.dir/src/FbgemmI64.cc.o
+[513/2582] Building CXX object third_party/fbgemm/CMakeFiles/fbgemm_generic.dir/src/GenerateKernelU8S8S32ACC16.cc.o
+[514/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/gemm/s8x8s32/jit_avx512_core_u8_copy_bt_kern.cpp.o
+[515/2582] Building CXX object third_party/fbgemm/CMakeFiles/fbgemm_generic.dir/src/GenerateKernelU8S8S32ACC32Avx512.cc.o
+[516/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/gemm/s8x8s32/jit_avx512_core_u8_copy_an_kern.cpp.o
+[517/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/gemm/f32/jit_avx512_core_f32_copy_bn_kern.cpp.o
+[518/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/gemm/s8x8s32/jit_avx512_core_u8_copy_sum_bn_kern.cpp.o
+[519/2582] Building CXX object third_party/fbgemm/CMakeFiles/fbgemm_generic.dir/src/Fused8BitRowwiseEmbeddingLookup.cc.o
+[520/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/gemm/s8x8s32/jit_avx512_core_u8_copy_bn_kern.cpp.o
+[521/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/gemm/f32/jit_avx512_core_f32_copy_bt_kern.cpp.o
+[522/2582] Building CXX object third_party/fbgemm/CMakeFiles/fbgemm_generic.dir/src/FbgemmSpMM.cc.o
+[523/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/gemm/s8x8s32/jit_avx512_core_u8_copy_sum_bt_kern.cpp.o
+[524/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/gemm/f32/jit_avx512_common_gemm_f32.cpp.o
+[525/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/gemm/s8x8s32/jit_avx512_core_u8_copy_sum_an_kern.cpp.o
+[526/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/gemm/f32/jit_avx2_kernel_sgemm_kern.cpp.o
+[527/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/gemm/f32/jit_avx_gemm_f32.cpp.o
+[528/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/gemm/bf16/jit_avx512_core_s16_copy_at_kern.cpp.o
+[529/2582] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/descriptor.cc.o
+[530/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/gemm/f32/jit_avx2_f32_copy_an_kern.cpp.o
+[531/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/gemm/f32/jit_avx2_f32_copy_at_kern.cpp.o
+[532/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/jit_uni_reorder_utils.cpp.o
+[533/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/cpu_sum.cpp.o
+[534/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/gemm_inner_product.cpp.o
+[535/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/gemm_convolution_utils.cpp.o
+[536/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/gemm/f32/jit_avx512_core_f32_copy_an_kern.cpp.o
+[537/2582] Building CXX object third_party/fbgemm/CMakeFiles/fbgemm_generic.dir/src/Fbgemm.cc.o
+[538/2582] Building CXX object third_party/fbgemm/CMakeFiles/fbgemm_generic.dir/src/GroupwiseConvAcc32Avx2.cc.o
+[539/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/jit_avx2_convolution.cpp.o
+[540/2582] Linking CXX static library lib/libprotobufd.a
+[541/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/jit_avx2_1x1_conv_kernel_f32.cpp.o
+[542/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/gemm/s8x8s32/jit_avx512_core_u8_copy_at_kern.cpp.o
+[543/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/gemm_bf16_inner_product.cpp.o
+[544/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/jit_avx512_common_1x1_conv_kernel.cpp.o
+[545/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/gemm_inner_product_utils.cpp.o
+[546/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/jit_avx2_conv_kernel_f32.cpp.o
+[547/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/jit_avx512_common_conv_winograd_kernel_f32.cpp.o
+[548/2582] Linking CXX static library lib/libprotocd.a
+[549/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/gemm/s8x8s32/jit_avx512_core_u8_copy_sum_at_kern.cpp.o
+[550/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/gemm_x8s8s32x_inner_product.cpp.o
+[551/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/jit_avx2_1x1_convolution.cpp.o
+[552/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/jit_sse42_convolution.cpp.o
+[553/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/jit_avx512_core_bf16_1x1_conv_kernel.cpp.o
+[554/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/jit_avx512_core_bf16_dw_conv_kernel.cpp.o
+[555/2582] Linking CXX executable bin/protoc
+[556/2582] Running gen_proto.py on onnx/onnx.in.proto
+Processing /scratch/iuriiz/repos/pytorch/third_party/onnx/onnx/onnx.in.proto
+Writing /scratch/iuriiz/repos/pytorch/build/third_party/onnx/onnx/onnx_onnx_torch-ml.proto
+Writing /scratch/iuriiz/repos/pytorch/build/third_party/onnx/onnx/onnx_onnx_torch-ml.proto3
+Writing /scratch/iuriiz/repos/pytorch/build/third_party/onnx/onnx/onnx-ml.pb.h
+generating /scratch/iuriiz/repos/pytorch/build/third_party/onnx/onnx/onnx_pb.py
+[557/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/jit_avx512_common_convolution_winograd.cpp.o
+[558/2582] Building CXX object c10/CMakeFiles/c10.dir/core/Allocator.cpp.o
+[559/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/gemm_bf16_convolution.cpp.o
+[560/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/jit_sse42_conv_kernel_f32.cpp.o
+[561/2582] Building CXX object c10/CMakeFiles/c10.dir/core/DeviceType.cpp.o
+[562/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/gemm/f32/jit_avx512_core_f32_copy_at_kern.cpp.o
+[563/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/jit_avx512_core_bf16_conv_kernel.cpp.o
+[564/2582] Building CXX object c10/CMakeFiles/c10.dir/core/Device.cpp.o
+[565/2582] Building CXX object c10/CMakeFiles/c10.dir/core/CopyBytes.cpp.o
+[566/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/jit_avx512_core_x8s8s32x_1x1_conv_kernel.cpp.o
+[567/2582] Running C++ protocol buffer compiler on /scratch/iuriiz/repos/pytorch/build/third_party/onnx/onnx/onnx_onnx_torch-ml.proto
+[568/2582] Building CXX object c10/CMakeFiles/c10.dir/core/Stream.cpp.o
+[569/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/jit_avx512_core_fp32_wino_conv_4x3.cpp.o
+[570/2582] Building CXX object c10/CMakeFiles/c10.dir/core/DefaultDtype.cpp.o
+[571/2582] Running gen_proto.py on onnx/onnx-operators.in.proto
+Processing /scratch/iuriiz/repos/pytorch/third_party/onnx/onnx/onnx-operators.in.proto
+Writing /scratch/iuriiz/repos/pytorch/build/third_party/onnx/onnx/onnx-operators_onnx_torch-ml.proto
+Writing /scratch/iuriiz/repos/pytorch/build/third_party/onnx/onnx/onnx-operators_onnx_torch-ml.proto3
+Writing /scratch/iuriiz/repos/pytorch/build/third_party/onnx/onnx/onnx-operators-ml.pb.h
+generating /scratch/iuriiz/repos/pytorch/build/third_party/onnx/onnx/onnx_operators_pb.py
+[572/2582] Building CXX object c10/CMakeFiles/c10.dir/core/TensorTypeId.cpp.o
+[573/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/jit_transpose_src_utils.cpp.o
+[574/2582] Running C++ protocol buffer compiler on /scratch/iuriiz/repos/pytorch/build/third_party/onnx/onnx/onnx-operators_onnx_torch-ml.proto
+[575/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/ref_softmax.cpp.o
+[576/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/jit_avx512_core_fp32_wino_conv_2x3.cpp.o
+[577/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/ref_inner_product.cpp.o
+[578/2582] Building CXX object c10/CMakeFiles/c10.dir/core/TensorTypeSet.cpp.o
+[579/2582] Building CXX object c10/CMakeFiles/c10.dir/core/Scalar.cpp.o
+[580/2582] Building CXX object c10/CMakeFiles/c10.dir/util/C++17.cpp.o
+[581/2582] Building CXX object third_party/fbgemm/CMakeFiles/fbgemm_generic.dir/src/ExecuteKernelU8S8.cc.o
+[582/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/ref_deconvolution.cpp.o
+[583/2582] Building CXX object c10/CMakeFiles/c10.dir/util/Array.cpp.o
+[584/2582] Building CXX object c10/CMakeFiles/c10.dir/util/Optional.cpp.o
+[585/2582] Building CXX object c10/CMakeFiles/c10.dir/core/StorageImpl.cpp.o
+[586/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/jit_uni_lrn.cpp.o
+[587/2582] Building CXX object c10/CMakeFiles/c10.dir/core/Storage.cpp.o
+[588/2582] Building CXX object third_party/onnx/CMakeFiles/onnx.dir/onnx/common/assertions.cc.o
+[589/2582] Building CXX object c10/CMakeFiles/c10.dir/core/CPUAllocator.cpp.o
+[590/2582] Building CXX object c10/CMakeFiles/c10.dir/util/Half.cpp.o
+[591/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/ref_lrn.cpp.o
+[592/2582] Building CXX object c10/CMakeFiles/c10.dir/util/Metaprogramming.cpp.o
+[593/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/ref_convolution.cpp.o
+[594/2582] Building CXX object c10/CMakeFiles/c10.dir/core/impl/DeviceGuardImplInterface.cpp.o
+[595/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/jit_avx512_common_1x1_convolution.cpp.o
+[596/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/jit_uni_lrn_kernel_f32.cpp.o
+[597/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/jit_uni_dw_conv_kernel_f32.cpp.o
+[598/2582] Building CXX object c10/CMakeFiles/c10.dir/util/LeftRight.cpp.o
+[599/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/jit_avx512_core_x8s8s32x_conv_kernel.cpp.o
+[600/2582] Building CXX object c10/CMakeFiles/c10.dir/util/Backtrace.cpp.o
+[601/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/jit_avx512_common_conv_kernel.cpp.o
+[602/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/jit_avx512_common_lrn.cpp.o
+[603/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/jit_avx512_common_convolution.cpp.o
+[604/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/jit_uni_pool_kernel.cpp.o
+[605/2582] Building CXX object c10/CMakeFiles/c10.dir/core/TensorOptions.cpp.o
+[606/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/nchw_pooling.cpp.o
+[607/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/jit_avx512_core_bf16_sum.cpp.o
+[608/2582] Building CXX object c10/CMakeFiles/c10.dir/util/Exception.cpp.o
+[609/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/jit_uni_batch_normalization_s8.cpp.o
+[610/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/ncsp_batch_normalization.cpp.o
+[611/2582] Building CXX object third_party/onnx/CMakeFiles/onnx.dir/onnx/common/status.cc.o
+[612/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/nhwc_pooling.cpp.o
+[613/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/simple_concat.cpp.o
+[614/2582] Building CXX object c10/CMakeFiles/c10.dir/core/impl/LocalTensorTypeSet.cpp.o
+[615/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/nspc_batch_normalization.cpp.o
+[616/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/jit_avx512_core_bf16_convolution.cpp.o
+[617/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/jit_uni_reorder.cpp.o
+[618/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/ref_batch_normalization.cpp.o
+[619/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/gemm_x8s8s32x_convolution.cpp.o
+[620/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/jit_avx512_core_fp32_wino_conv_4x3_kernel.cpp.o
+[621/2582] Building CXX object c10/CMakeFiles/c10.dir/core/thread_pool.cpp.o
+[622/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/jit_uni_i8i8_pooling.cpp.o
+[623/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/ref_shuffle.cpp.o
+[624/2582] Building CXX object third_party/onnx/CMakeFiles/onnx.dir/onnx/common/interned_strings.cc.o
+[625/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/jit_avx512_core_bf16_1x1_convolution.cpp.o
+[626/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/jit_uni_softmax.cpp.o
+[627/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/jit_avx512_core_u8s8s32x_wino_convolution.cpp.o
+[628/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/ref_eltwise.cpp.o
+[629/2582] Building CXX object c10/CMakeFiles/c10.dir/util/Logging.cpp.o
+[630/2582] Building CXX object c10/CMakeFiles/c10.dir/core/UndefinedTensorImpl.cpp.o
+[631/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/jit_avx512_core_x8s8s32x_1x1_convolution.cpp.o
+[632/2582] Building CXX object c10/CMakeFiles/c10.dir/util/SmallVector.cpp.o
+[633/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/jit_uni_pooling.cpp.o
+[634/2582] Building CXX object third_party/onnx/CMakeFiles/onnx.dir/onnx/defs/attr_proto_util.cc.o
+[635/2582] Building CXX object c10/CMakeFiles/c10.dir/util/StringUtil.cpp.o
+[636/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/ref_pooling.cpp.o
+[637/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/jit_uni_dw_convolution.cpp.o
+[638/2582] Building CXX object c10/CMakeFiles/c10.dir/core/TensorImpl.cpp.o
+[639/2582] Building CXX object c10/CMakeFiles/c10.dir/util/thread_name.cpp.o
+[640/2582] Building CXX object c10/CMakeFiles/c10.dir/util/UniqueVoidPtr.cpp.o
+[641/2582] Building CXX object c10/CMakeFiles/c10.dir/util/Type.cpp.o
+[642/2582] Building CXX object c10/CMakeFiles/c10.dir/util/TypeTraits.cpp.o
+[643/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/rnn/ref_postgemm_gru.cpp.o
+[644/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/simple_sum.cpp.o
+[645/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/rnn/cell_gru.cpp.o
+[646/2582] Building CXX object c10/CMakeFiles/c10.dir/util/TypeList.cpp.o
+[647/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/rnn/ref_postgemm_gru_lbr.cpp.o
+[648/2582] Building CXX object c10/CMakeFiles/c10.dir/util/intrusive_ptr.cpp.o
+[649/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/rnn/cell_gru_lbr.cpp.o
+[650/2582] Building CXX object c10/CMakeFiles/c10.dir/util/flags_use_gflags.cpp.o
+[651/2582] Building CXX object third_party/onnx/CMakeFiles/onnx.dir/onnx/defs/function.cc.o
+[652/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/rnn/ref_postgemm_lstm.cpp.o
+[653/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/rnn/cell_common.cpp.o
+[654/2582] Building CXX object third_party/onnx/CMakeFiles/onnx.dir/__/__/caffe2/onnx/torch_ops/defs.cc.o
+[655/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/jit_uni_eltwise.cpp.o
+[656/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/jit_uni_batch_normalization.cpp.o
+[657/2582] Building CXX object third_party/onnx/CMakeFiles/onnx.dir/onnx/common/model_helpers.cc.o
+[658/2582] Building CXX object third_party/onnx/CMakeFiles/onnx.dir/onnx/defs/data_type_utils.cc.o
+[659/2582] Building CXX object third_party/onnx/CMakeFiles/onnx.dir/onnx/onnxifi_utils.cc.o
+[660/2582] Generating python/convnet_benchmarks.py
+[661/2582] Generating python/core.py
+[662/2582] Building CXX object third_party/onnx/CMakeFiles/onnx.dir/__/__/caffe2/onnx/torch_ops/schema.cc.o
+[663/2582] Generating python/core_gradients_test.py
+[664/2582] Generating python/core_test.py
+[665/2582] Generating python/crf.py
+[666/2582] Generating python/crf_predict.py
+[667/2582] Generating python/crf_viterbi_test.py
+[668/2582] Generating python/data_parallel_model.py
+[669/2582] Generating python/data_parallel_model_test.py
+[670/2582] Generating python/docs/__init__.py
+[671/2582] Generating python/convert_test.py
+[672/2582] Generating python/convnet_benchmarks_test.py
+[673/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/rnn/rnn_utils.cpp.o
+[674/2582] Generating python/dyndep.py
+[675/2582] Generating python/embedding_generation_benchmark.py
+[676/2582] Generating python/examples/__init__.py
+[677/2582] Generating python/examples/char_rnn.py
+[678/2582] Generating python/examples/imagenet_trainer.py
+[679/2582] Generating python/examples/lmdb_create_example.py
+[680/2582] Generating python/examples/resnet50_trainer.py
+[681/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/rnn/ref_postgemm_rnn.cpp.o
+[682/2582] Generating python/experiment_util.py
+[683/2582] Generating python/extension_loader.py
+[684/2582] Generating python/filler_test.py
+[685/2582] Building CXX object c10/test/CMakeFiles/c10_ConstexprCrc_test.dir/util/ConstexprCrc_test.cpp.o
+[686/2582] Building CXX object c10/test/CMakeFiles/c10_C++17_test.dir/util/C++17_test.cpp.o
+[687/2582] Generating python/functional.py
+[688/2582] Generating python/functional_test.py
+[689/2582] Generating python/fused_8bit_rowwise_conversion_ops_test.py
+[690/2582] Generating python/gradient_check_test.py
+[691/2582] Generating python/gradient_checker.py
+[692/2582] Generating python/dataset.py
+[693/2582] Generating __init__.py
+[694/2582] Generating python/db_file_reader.py
+[695/2582] Generating python/db_test.py
+[696/2582] Generating python/device_checker.py
+[697/2582] Generating python/data_workers.py
+[698/2582] Building CXX object c10/CMakeFiles/c10.dir/util/flags_use_no_gflags.cpp.o
+[699/2582] Building CXX object third_party/onnx/CMakeFiles/onnx.dir/onnx/defs/tensor_proto_util.cc.o
+[700/2582] Generating python/data_workers_test.py
+[701/2582] Generating python/docs/formatter.py
+[702/2582] Generating python/docs/parser.py
+[703/2582] Generating python/convert.py
+[704/2582] Generating python/dataio.py
+[705/2582] Generating python/dataio_test.py
+[706/2582] Generating python/docs/generator.py
+[707/2582] Generating python/docs/github.py
+[708/2582] Generating python/control_test.py
+[709/2582] Generating contrib/__init__.py
+[710/2582] Generating contrib/aten/__init__.py
+[711/2582] Generating contrib/aten/aten_test.py
+[712/2582] Generating contrib/aten/docs/__init__.py
+[713/2582] Generating contrib/aten/docs/sample.py
+[714/2582] Generating contrib/aten/gen_op.py
+[715/2582] Generating contrib/gloo/__init__.py
+[716/2582] Generating contrib/gloo/gloo_test.py
+[717/2582] Generating contrib/nccl/__init__.py
+[718/2582] Generating contrib/nccl/nccl_ops_test.py
+[719/2582] Generating contrib/nnpack/__init__.py
+[720/2582] Generating contrib/nnpack/nnpack_ops_test.py
+[721/2582] Building CXX object c10/test/CMakeFiles/c10_StreamGuard_test.dir/core/StreamGuard_test.cpp.o
+[722/2582] Generating contrib/playground/AnyExp.py
+[723/2582] Generating contrib/playground/AnyExpOnTerm.py
+[724/2582] Generating contrib/playground/ModuleRegister.py
+[725/2582] Generating contrib/playground/checkpoint.py
+[726/2582] Generating contrib/playground/compute_topk_accuracy.py
+[727/2582] Generating contrib/playground/__init__.py
+[728/2582] Generating contrib/playground/compute_loss.py
+[729/2582] Generating contrib/playground/meter.py
+[730/2582] Generating contrib/playground/module_map.py
+[731/2582] Generating contrib/playground/resnetdemo/IN1k_resnet.py
+[732/2582] Generating contrib/playground/output_generator.py
+[733/2582] Generating contrib/playground/resnetdemo/IN1k_resnet_no_test_model.py
+[734/2582] Generating contrib/playground/resnetdemo/__init__.py
+[735/2582] Generating contrib/playground/resnetdemo/caffe2_resnet50_default_forward.py
+[736/2582] Generating contrib/playground/resnetdemo/explicit_resnet_forward.py
+[737/2582] Generating contrib/playground/resnetdemo/caffe2_resnet50_default_param_update.py
+[738/2582] Generating contrib/playground/resnetdemo/explicit_resnet_param_update.py
+[739/2582] Generating contrib/playground/resnetdemo/gfs_IN1k.py
+[740/2582] Generating contrib/playground/resnetdemo/override_no_test_model_no_checkpoint.py
+[741/2582] Generating contrib/playground/resnetdemo/rendezvous_filestore.py
+[742/2582] Generating contrib/prof/__init__.py
+[743/2582] Generating contrib/prof/cuda_profile_ops_test.py
+[744/2582] Generating contrib/script/__init__.py
+[745/2582] Generating contrib/tensorboard/__init__.py
+[746/2582] Building CXX object c10/test/CMakeFiles/c10_TypeIndex_test.dir/util/TypeIndex_test.cpp.o
+[747/2582] Generating contrib/script/examples/__init__.py
+[748/2582] Generating contrib/tensorboard/tensorboard.py
+[749/2582] Generating contrib/tensorboard/tensorboard_exporter.py
+[750/2582] Generating contrib/tensorboard/tensorboard_exporter_test.py
+[751/2582] Generating contrib/tensorboard/tensorboard_test.py
+[752/2582] Generating contrib/warpctc/__init__.py
+[753/2582] Generating contrib/warpctc/ctc_ops_test.py
+[754/2582] Generating core/__init__.py
+[755/2582] Generating core/nomnigraph/__init__.py
+[756/2582] Generating core/nomnigraph/op_gen.py
+[757/2582] Generating distributed/__init__.py
+[758/2582] Generating distributed/file_store_handler_op_test.py
+[759/2582] Generating distributed/redis_store_handler_op_test.py
+[760/2582] Generating distributed/store_ops_test_util.py
+[761/2582] Building CXX object third_party/onnx/CMakeFiles/onnx.dir/onnx/defs/logical/old.cc.o
+[762/2582] Generating experiments/__init__.py
+[763/2582] Generating experiments/python/SparseTransformer.py
+[764/2582] Generating experiments/python/__init__.py
+[765/2582] Generating experiments/python/convnet_benchmarks.py
+[766/2582] Generating experiments/python/device_reduce_sum_bench.py
+[767/2582] Generating experiments/python/funhash_op_test.py
+[768/2582] Generating experiments/python/net_construct_bench.py
+[769/2582] Generating experiments/python/sparse_funhash_op_test.py
+[770/2582] Generating experiments/python/sparse_reshape_op_test.py
+[771/2582] Building CXX object third_party/onnx/CMakeFiles/onnx.dir/onnx/defs/object_detection/old.cc.o
+[772/2582] Generating experiments/python/tt_contraction_op_test.py
+[773/2582] Generating operators/experimental/optimizers/masked_adagrad_test.py
+[774/2582] Generating experiments/python/tt_pad_op_test.py
+[775/2582] Generating perfkernels/__init__.py
+[776/2582] Generating perfkernels/hp_emblookup_codegen.py
+[777/2582] Generating proto/__init__.py
+[778/2582] Generating python/__init__.py
+[779/2582] Generating python/allcompare_test.py
+[780/2582] Generating python/attention.py
+[781/2582] Building CXX object third_party/onnx/CMakeFiles/onnx.dir/onnx/defs/tensor_util.cc.o
+[782/2582] Generating python/_import_c_extension.py
+[783/2582] Generating python/benchmark_generator.py
+[784/2582] Generating python/binarysize.py
+[785/2582] Generating python/brew.py
+[786/2582] Generating python/brew_test.py
+[787/2582] Generating python/build.py
+[788/2582] Generating python/caffe_translator.py
+[789/2582] Generating python/cached_reader.py
+[790/2582] Generating python/caffe_translator_test.py
+[791/2582] Generating python/checkpoint.py
+[792/2582] Generating python/checkpoint_test.py
+[793/2582] Generating python/cnn.py
+[794/2582] Generating python/compatibility.py
+[795/2582] Generating python/context.py
+[796/2582] Generating python/control.py
+[797/2582] Building CXX object c10/test/CMakeFiles/c10_Array_test.dir/util/Array_test.cpp.o
+[798/2582] Generating python/context_test.py
+[799/2582] Generating python/control_ops_grad.py
+[800/2582] Generating python/control_ops_grad_test.py
+[801/2582] Generating python/control_ops_util.py
+[802/2582] Generating python/gru_cell.py
+[803/2582] Generating python/helpers/__init__.py
+[804/2582] Generating python/helpers/algebra.py
+[805/2582] Generating python/helpers/arg_scope.py
+[806/2582] Generating python/helpers/array_helpers.py
+[807/2582] Generating python/helpers/control_ops.py
+[808/2582] Generating python/helpers/conv.py
+[809/2582] Building CXX object c10/CMakeFiles/c10.dir/util/numa.cpp.o
+[810/2582] Generating python/helpers/db_input.py
+[811/2582] Generating python/helpers/dropout.py
+[812/2582] Generating python/helpers/elementwise_linear.py
+[813/2582] Generating python/helpers/fc.py
+[814/2582] Generating python/helpers/nonlinearity.py
+[815/2582] Generating python/helpers/normalization.py
+[816/2582] Generating python/helpers/pooling.py
+[817/2582] Generating python/helpers/train.py
+[818/2582] Generating python/hsm_util.py
+[819/2582] Generating python/helpers/tools.py
+[820/2582] Generating python/hip_test_util.py
+[821/2582] Generating python/hypothesis_test_util.py
+[822/2582] Generating python/ideep/__init__.py
+[823/2582] Generating python/hypothesis_test.py
+[824/2582] Generating python/ideep/LRN_op_test.py
+[825/2582] Generating python/ideep/adam_op_test.py
+[826/2582] Generating python/ideep/blobs_queue_db_test.py
+[827/2582] Generating python/ideep/channel_shuffle_op_test.py
+[828/2582] Generating python/ideep/conv_op_test.py
+[829/2582] Building CXX object third_party/onnx/CMakeFiles/onnx.dir/onnx/defs/tensor/utils.cc.o
+[830/2582] Generating python/ideep/concat_split_op_test.py
+[831/2582] Generating python/ideep/conv_transpose_test.py
+[832/2582] Generating python/ideep/copy_op_test.py
+[833/2582] Generating python/ideep/dropout_op_test.py
+[834/2582] Generating python/ideep/expanddims_squeeze_op_test.py
+[835/2582] Generating python/ideep/fc_op_test.py
+[836/2582] Generating python/ideep/leaky_relu_op_test.py
+[837/2582] Generating python/ideep/convfusion_op_test.py
+[838/2582] Generating python/ideep/elementwise_sum_op_test.py
+[839/2582] Generating python/ideep/moment_sgd_op_test.py
+[840/2582] Generating python/ideep/operator_fallback_op_test.py
+[841/2582] Generating python/ideep/order_switch_op_test.py
+[842/2582] Generating python/ideep/pool_op_test.py
+[843/2582] Generating python/ideep/pre_convert_test.py
+[844/2582] Generating python/ideep/relu_op_test.py
+[845/2582] Generating python/ideep/shape_op_test.py
+[846/2582] Generating python/ideep/sigmoid_op_test.py
+[847/2582] Generating python/ideep/softmax_op_test.py
+[848/2582] Generating python/ideep/spatial_bn_op_test.py
+[849/2582] Building CXX object third_party/onnx/CMakeFiles/onnx_proto.dir/onnx/onnx-operators_onnx_torch-ml.pb.cc.o
+[850/2582] Generating python/ideep/reshape_op_test.py
+[851/2582] Generating python/ideep/test_ideep_net.py
+[852/2582] Generating python/ideep/transform_ideep_net.py
+[853/2582] Generating python/ideep/transpose_op_test.py
+[854/2582] Generating python/ideep/weightedsum_op_test.py
+[855/2582] Generating python/ideep_test_util.py
+[856/2582] Generating python/layer_model_helper.py
+[857/2582] Generating python/layer_model_instantiator.py
+[858/2582] Generating python/layer_parameter_sharing_test.py
+[859/2582] Generating python/layer_test_util.py
+[860/2582] Generating python/layers/__init__.py
+[861/2582] Generating python/layers/adaptive_weight.py
+[862/2582] Generating python/layers/add_bias.py
+[863/2582] Generating python/layers/arc_cosine_feature_map.py
+[864/2582] Generating python/layers/batch_huber_loss.py
+[865/2582] Generating python/layers/batch_lr_loss.py
+[866/2582] Generating python/layers/batch_mse_loss.py
+[867/2582] Generating python/layers/batch_normalization.py
+[868/2582] Generating python/layers/batch_sigmoid_cross_entropy_loss.py
+[869/2582] Generating python/layers/blob_weighted_sum.py
+[870/2582] Generating python/layers/batch_softmax_loss.py
+[871/2582] Generating python/layers/conv.py
+[872/2582] Building CXX object third_party/onnx/CMakeFiles/onnx.dir/onnx/defs/generator/old.cc.o
+[873/2582] Building CXX object third_party/onnx/CMakeFiles/onnx.dir/onnx/defs/object_detection/defs.cc.o
+[874/2582] Generating python/layers/bpr_loss.py
+[875/2582] Generating python/layers/bucket_weighted.py
+[876/2582] Generating python/layers/build_index.py
+[877/2582] Generating python/layers/concat.py
+[878/2582] Generating python/layers/constant_weight.py
+[879/2582] Generating python/layers/dropout.py
+[880/2582] Generating python/layers/fc.py
+[881/2582] Generating python/layers/fc_with_bootstrap.py
+[882/2582] Generating python/layers/fc_without_bias.py
+[883/2582] Generating python/layers/feature_sparse_to_dense.py
+[884/2582] Generating python/layers/functional.py
+[885/2582] Generating python/layers/gather_record.py
+[886/2582] Generating python/layers/homotopy_weight.py
+[887/2582] Generating python/layers/label_smooth.py
+[888/2582] Generating python/layers/last_n_window_collector.py
+[889/2582] Generating python/layers/layer_normalization.py
+[890/2582] Generating python/layers/layers.py
+[891/2582] Generating python/layers/margin_rank_loss.py
+[892/2582] Generating python/layers/merge_id_lists.py
+[893/2582] Generating python/layers/pairwise_similarity.py
+[894/2582] Generating python/layers/position_weighted.py
+[895/2582] Generating python/layers/random_fourier_features.py
+[896/2582] Generating python/layers/reservoir_sampling.py
+[897/2582] Generating python/layers/sampling_train.py
+[898/2582] Generating python/layers/sampling_trainable_mixin.py
+[899/2582] Generating python/layers/select_record_by_context.py
+[900/2582] Generating python/layers/semi_random_features.py
+[901/2582] Generating python/layers/sparse_dropout_with_replacement.py
+[902/2582] Generating python/layers/sparse_feature_hash.py
+[903/2582] Generating python/layers/sparse_lookup.py
+[904/2582] Generating python/layers/split.py
+[905/2582] Generating python/layers/tags.py
+[906/2582] Generating python/layers/uniform_sampling.py
+[907/2582] Generating python/layers_test.py
+[908/2582] Generating python/lengths_reducer_rowwise_8bit_ops_test.py
+[909/2582] Generating python/lengths_reducer_fused_8bit_rowwise_ops_test.py
+[910/2582] Generating python/lstm_benchmark.py
+[911/2582] Generating python/memonger.py
+[912/2582] Generating python/memonger_test.py
+[913/2582] Generating python/mint/__init__.py
+[914/2582] Generating python/mint/app.py
+[915/2582] Generating python/mkl/__init__.py
+[916/2582] Generating python/mkl/mkl_LRN_op_test.py
+[917/2582] Generating python/mkl/mkl_LRN_speed_test.py
+[918/2582] Generating python/mkl/mkl_concat_op_test.py
+[919/2582] Generating python/mkl/mkl_conv_op_test.py
+[920/2582] Generating python/mkl/mkl_copy_op_test.py
+[921/2582] Generating python/mkl/mkl_elementwise_add_op_test.py
+[922/2582] Generating python/mkl/mkl_elementwise_sum_op_test.py
+[923/2582] Generating python/mkl/mkl_fc_op_test.py
+[924/2582] Generating python/mkl/mkl_fc_speed_test.py
+[925/2582] Generating python/mkl/mkl_fill_op_test.py
+[926/2582] Generating python/mkl/mkl_pool_op_test.py
+[927/2582] Generating python/mkl/mkl_pool_speed_test.py
+[928/2582] Generating python/mkl/mkl_relu_op_test.py
+[929/2582] Generating python/mkl/mkl_sbn_op_test.py
+[930/2582] Generating python/mkl/mkl_sbn_speed_test.py
+[931/2582] Generating python/mkl/mkl_sigmoid_op_test.py
+[932/2582] Building CXX object third_party/onnx/CMakeFiles/onnx.dir/onnx/defs/reduction/defs.cc.o
+[933/2582] Generating python/mkl/mkl_speed_test.py
+[934/2582] Generating python/mkl/mkl_squeeze_op_test.py
+[935/2582] Generating python/mkl/rewrite_graph.py
+[936/2582] Generating python/mkl/rewrite_graph_test.py
+[937/2582] Generating python/mkl_test_util.py
+[938/2582] Generating python/model_device_test.py
+[939/2582] Building CXX object third_party/onnx/CMakeFiles/onnx.dir/onnx/defs/logical/defs.cc.o
+[940/2582] Generating python/model_helper_test.py
+[941/2582] Generating python/model_helper.py
+[942/2582] Generating python/modeling/__init__.py
+[943/2582] Generating python/modeling/compute_histogram_for_blobs.py
+[944/2582] Generating python/modeling/compute_histogram_for_blobs_test.py
+[945/2582] Generating python/modeling/compute_norm_for_blobs.py
+[946/2582] Generating python/modeling/compute_norm_for_blobs_test.py
+[947/2582] Generating python/modeling/compute_statistics_for_blobs.py
+[948/2582] Generating python/modeling/compute_statistics_for_blobs_test.py
+[949/2582] Generating python/modeling/get_entry_from_blobs.py
+[950/2582] Generating python/modeling/get_entry_from_blobs_test.py
+[951/2582] Generating python/modeling/gradient_clipping.py
+[952/2582] Generating python/modeling/gradient_clipping_test.py
+[953/2582] Generating python/modeling/initializers.py
+[954/2582] Generating python/modeling/initializers_test.py
+[955/2582] Generating python/modeling/net_modifier.py
+[956/2582] Generating python/modeling/parameter_info.py
+[957/2582] Generating python/modeling/parameter_sharing.py
+[958/2582] Generating python/modeling/parameter_sharing_test.py
+[959/2582] Generating python/models/__init__.py
+[960/2582] Generating python/models/__sym_init__.py
+[961/2582] Generating python/models/download.py
+[962/2582] Generating python/models/imagenet_trainer_test_utils.py
+[963/2582] Generating python/models/resnet.py
+[964/2582] Generating python/models/resnet_test.py
+[965/2582] Generating python/models/seq2seq/__init__.py
+[966/2582] Generating python/models/seq2seq/beam_search.py
+[967/2582] Generating python/models/seq2seq/seq2seq_beam_search_test.py
+[968/2582] Generating python/models/seq2seq/seq2seq_model_helper.py
+[969/2582] Generating python/models/seq2seq/seq2seq_model_helper_test.py
+[970/2582] Generating python/models/seq2seq/train.py
+[971/2582] Generating python/models/shufflenet.py
+[972/2582] Building CXX object c10/test/CMakeFiles/c10_Half_test.dir/util/Half_test.cpp.o
+[973/2582] Generating python/models/seq2seq/seq2seq_util.py
+[974/2582] Generating python/models/seq2seq/translate.py
+[975/2582] Generating python/models/shufflenet_test.py
+[976/2582] Generating python/modifier_context.py
+[977/2582] Generating python/muji.py
+[978/2582] Generating python/muji_test.py
+[979/2582] Generating python/net_builder.py
+[980/2582] Generating python/net_builder_test.py
+[981/2582] Generating python/net_drawer.py
+[982/2582] Generating python/net_printer.py
+[983/2582] Generating python/net_printer_test.py
+[984/2582] Generating python/nomnigraph.py
+[985/2582] Generating python/nomnigraph_test.py
+[986/2582] Generating python/nomnigraph_transformations.py
+[987/2582] Generating python/nomnigraph_transformations_test.py
+[988/2582] Generating python/normalizer.py
+[989/2582] Generating python/normalizer_context.py
+[990/2582] Generating python/normalizer_test.py
+[991/2582] Generating python/numa_benchmark.py
+[992/2582] Generating python/numa_test.py
+[993/2582] Generating python/observer_test.py
+[994/2582] Generating python/onnx/__init__.py
+[995/2582] Generating python/onnx/backend.py
+[996/2582] Generating python/onnx/backend_cpp_rep.py
+[997/2582] Generating python/onnx/backend_rep.py
+[998/2582] Generating python/onnx/bin/__init__.py
+[999/2582] Generating python/onnx/bin/conversion.py
+[1000/2582] Generating python/onnx/error.py
+[1001/2582] Generating python/onnx/tests/__init__.py
+[1002/2582] Generating python/onnx/frontend.py
+[1003/2582] Generating python/onnx/test_onnxifi.py
+[1004/2582] Generating python/onnx/helper.py
+[1005/2582] Generating python/onnx/tests/c2_ref_test.py
+[1006/2582] Generating python/onnx/tests/helper_test.py
+[1007/2582] Generating python/onnx/tests/ssa_test.py
+[1008/2582] Generating python/onnx/onnxifi.py
+[1009/2582] Generating python/onnx/tests/conversion_test.py
+[1010/2582] Generating python/onnx/tests/onnx_backend_test.py
+[1011/2582] Generating python/onnx/tests/test_utils.py
+[1012/2582] Generating python/onnx/workspace.py
+[1013/2582] Generating python/operator_fp_exceptions_test.py
+[1014/2582] Generating python/operator_test/__init__.py
+[1015/2582] Generating python/operator_test/activation_ops_test.py
+[1016/2582] Generating python/operator_test/adadelta_test.py
+[1017/2582] Generating python/operator_test/adagrad_test.py
+[1018/2582] Generating python/operator_test/adagrad_test_helper.py
+[1019/2582] Generating python/operator_test/apmeter_test.py
+[1020/2582] Generating python/operator_test/arg_ops_test.py
+[1021/2582] Generating python/operator_test/assert_test.py
+[1022/2582] Generating python/operator_test/basic_rnn_test.py
+[1023/2582] Generating python/operator_test/batch_box_cox_test.py
+[1024/2582] Building CXX object c10/test/CMakeFiles/c10_TypeTraits_test.dir/util/TypeTraits_test.cpp.o
+[1025/2582] Generating python/operator_test/adam_test.py
+[1026/2582] Generating python/operator_test/affine_channel_op_test.py
+[1027/2582] Generating python/operator_test/atomic_ops_test.py
+[1028/2582] Generating python/operator_test/batch_bucketize_op_test.py
+[1029/2582] Generating python/operator_test/batch_moments_op_test.py
+[1030/2582] Generating python/operator_test/batch_sparse_to_dense_op_test.py
+[1031/2582] Generating python/operator_test/bbox_transform_test.py
+[1032/2582] Generating python/operator_test/bisect_percentile_op_test.py
+[1033/2582] Generating python/operator_test/blobs_queue_db_test.py
+[1034/2582] Generating python/operator_test/boolean_mask_test.py
+[1035/2582] Generating python/operator_test/boolean_unmask_test.py
+[1036/2582] Generating python/operator_test/box_with_nms_limit_op_test.py
+[1037/2582] Generating python/operator_test/bucketize_op_test.py
+[1038/2582] Generating python/operator_test/cast_op_test.py
+[1039/2582] Generating python/operator_test/ceil_op_test.py
+[1040/2582] Generating python/operator_test/channel_backprop_stats_op_test.py
+[1041/2582] Generating python/operator_test/channel_shuffle_test.py
+[1042/2582] Generating python/operator_test/channel_stats_op_test.py
+[1043/2582] Generating python/operator_test/checkpoint_test.py
+[1044/2582] Building CXX object third_party/onnx/CMakeFiles/onnx.dir/onnx/defs/reduction/old.cc.o
+[1045/2582] Building CXX object third_party/onnx/CMakeFiles/onnx.dir/onnx/defs/rnn/old.cc.o
+[1046/2582] Building CXX object third_party/onnx/CMakeFiles/onnx.dir/onnx/version_converter/helper.cc.o
+[1047/2582] Generating python/operator_test/clip_op_test.py
+[1048/2582] Generating python/operator_test/clip_tensor_op_test.py
+[1049/2582] Generating python/operator_test/collect_and_distribute_fpn_rpn_proposals_op_test.py
+[1050/2582] Generating python/operator_test/concat_split_op_test.py
+[1051/2582] Generating python/operator_test/conditional_test.py
+[1052/2582] Generating python/operator_test/conftest.py
+[1053/2582] Generating python/operator_test/conv_test.py
+[1054/2582] Generating python/operator_test/conv_transpose_test.py
+[1055/2582] Generating python/operator_test/copy_ops_test.py
+[1056/2582] Generating python/operator_test/copy_rows_to_tensor_op_test.py
+[1057/2582] Generating python/operator_test/cosine_embedding_criterion_op_test.py
+[1058/2582] Generating python/operator_test/counter_ops_test.py
+[1059/2582] Generating python/operator_test/crf_test.py
+[1060/2582] Generating python/operator_test/cross_entropy_ops_test.py
+[1061/2582] Generating python/operator_test/ctc_beam_search_decoder_op_test.py
+[1062/2582] Generating python/operator_test/ctc_greedy_decoder_op_test.py
+[1063/2582] Generating python/operator_test/cudnn_recurrent_test.py
+[1064/2582] Generating python/operator_test/data_couple_op_test.py
+[1065/2582] Generating python/operator_test/dense_vector_to_id_list_op_test.py
+[1066/2582] Generating python/operator_test/depthwise_3x3_conv_test.py
+[1067/2582] Generating python/operator_test/dataset_ops_test.py
+[1068/2582] Generating python/operator_test/deform_conv_test.py
+[1069/2582] Generating python/operator_test/detectron_keypoints.py
+[1070/2582] Generating python/operator_test/distance_op_test.py
+[1071/2582] Generating python/operator_test/dropout_op_test.py
+[1072/2582] Generating python/operator_test/duplicate_operands_test.py
+[1073/2582] Generating python/operator_test/elementwise_linear_op_test.py
+[1074/2582] Generating python/operator_test/elementwise_logical_ops_test.py
+[1075/2582] Generating python/operator_test/elementwise_op_broadcast_test.py
+[1076/2582] Generating python/operator_test/elementwise_ops_test.py
+[1077/2582] Generating python/operator_test/emptysample_ops_test.py
+[1078/2582] Generating python/operator_test/ensure_clipped_test.py
+[1079/2582] Generating python/operator_test/ensure_cpu_output_op_test.py
+[1080/2582] Generating python/operator_test/erf_op_test.py
+[1081/2582] Generating python/operator_test/expand_op_test.py
+[1082/2582] Generating python/operator_test/feature_maps_ops_test.py
+[1083/2582] Building CXX object third_party/onnx/CMakeFiles/onnx.dir/onnx/defs/quantization/defs.cc.o
+[1084/2582] Building CXX object third_party/onnx/CMakeFiles/onnx.dir/onnx/defs/rnn/defs.cc.o
+[1085/2582] Building CXX object third_party/onnx/CMakeFiles/onnx.dir/onnx/optimizer/pass_manager.cc.o
+[1086/2582] Generating python/operator_test/filler_ops_test.py
+[1087/2582] Generating python/operator_test/find_op_test.py
+[1088/2582] Generating python/operator_test/flexible_top_k_test.py
+[1089/2582] Generating python/operator_test/floor_op_test.py
+[1090/2582] Generating python/operator_test/flatten_op_test.py
+[1091/2582] Generating python/operator_test/gather_ops_test.py
+[1092/2582] Generating python/operator_test/gather_ranges_op_test.py
+[1093/2582] Generating python/operator_test/given_tensor_byte_string_to_uint8_fill_op_test.py
+[1094/2582] Generating python/operator_test/given_tensor_fill_op_test.py
+[1095/2582] Generating python/operator_test/glu_op_test.py
+[1096/2582] Generating python/operator_test/group_conv_test.py
+[1097/2582] Generating python/operator_test/group_norm_op_test.py
+[1098/2582] Generating python/operator_test/gru_test.py
+[1099/2582] Generating python/operator_test/heatmap_max_keypoint_op_test.py
+[1100/2582] Generating python/operator_test/hsm_test.py
+[1101/2582] Generating python/operator_test/hyperbolic_ops_test.py
+[1102/2582] Generating python/operator_test/im2col_col2im_test.py
+[1103/2582] Generating python/operator_test/image_input_op_test.py
+[1104/2582] Generating python/operator_test/index_hash_ops_test.py
+[1105/2582] Generating python/operator_test/index_ops_test.py
+[1106/2582] Generating python/operator_test/instance_norm_test.py
+[1107/2582] Generating python/operator_test/integral_image_ops_test.py
+[1108/2582] Generating python/operator_test/jsd_ops_test.py
+[1109/2582] Generating python/operator_test/key_split_ops_test.py
+[1110/2582] Generating python/operator_test/lars_test.py
+[1111/2582] Generating python/operator_test/layer_norm_op_test.py
+[1112/2582] Generating python/operator_test/leaky_relu_test.py
+[1113/2582] Generating python/operator_test/learning_rate_adaption_op_test.py
+[1114/2582] Generating python/operator_test/learning_rate_op_test.py
+[1115/2582] Generating python/operator_test/length_split_op_test.py
+[1116/2582] Generating python/operator_test/lengths_pad_op_test.py
+[1117/2582] Generating python/operator_test/lengths_tile_op_test.py
+[1118/2582] Generating python/operator_test/lengths_top_k_ops_test.py
+[1119/2582] Generating python/operator_test/listwise_l2r_operator_test.py
+[1120/2582] Generating python/operator_test/load_save_test.py
+[1121/2582] Generating python/operator_test/locally_connected_op_test.py
+[1122/2582] Generating python/operator_test/fc_operator_test.py
+[1123/2582] Generating python/operator_test/loss_ops_test.py
+[1124/2582] Generating python/operator_test/lpnorm_op_test.py
+[1125/2582] Generating python/operator_test/map_ops_test.py
+[1126/2582] Generating python/operator_test/margin_ranking_criterion_op_test.py
+[1127/2582] Generating python/operator_test/math_ops_test.py
+[1128/2582] Generating python/operator_test/matmul_op_test.py
+[1129/2582] Generating python/operator_test/mean_op_test.py
+[1130/2582] Generating python/operator_test/merge_id_lists_op_test.py
+[1131/2582] Generating python/operator_test/mkl_conv_op_test.py
+[1132/2582] Generating python/operator_test/mkl_packed_fc_op_test.py
+[1133/2582] Generating python/operator_test/mkl_speed_test.py
+[1134/2582] Generating python/operator_test/mod_op_test.py
+[1135/2582] Generating python/operator_test/moments_op_test.py
+[1136/2582] Generating python/operator_test/momentum_sgd_test.py
+[1137/2582] Generating python/operator_test/mpi_test.py
+[1138/2582] Generating python/operator_test/negate_gradient_op_test.py
+[1139/2582] Generating python/operator_test/ngram_ops_test.py
+[1140/2582] Generating python/operator_test/normalize_op_test.py
+[1141/2582] Generating python/operator_test/numpy_tile_op_test.py
+[1142/2582] Generating python/operator_test/one_hot_ops_test.py
+[1143/2582] Generating python/operator_test/onnx_while_test.py
+[1144/2582] Generating python/operator_test/order_switch_test.py
+[1145/2582] Generating python/operator_test/pack_ops_test.py
+[1146/2582] Generating python/operator_test/pack_rnn_sequence_op_test.py
+[1147/2582] Generating python/operator_test/enforce_finite_op_test.py
+[1148/2582] Generating python/operator_test/pad_test.py
+[1149/2582] Generating python/operator_test/partition_ops_test.py
+[1150/2582] Generating python/operator_test/percentile_op_test.py
+[1151/2582] Generating python/operator_test/piecewise_linear_transform_test.py
+[1152/2582] Generating python/operator_test/pooling_test.py
+[1153/2582] Generating python/operator_test/prepend_dim_test.py
+[1154/2582] Generating python/operator_test/python_op_test.py
+[1155/2582] Generating python/operator_test/rand_quantization_op_speed_test.py
+[1156/2582] Generating python/operator_test/rand_quantization_op_test.py
+[1157/2582] Generating python/operator_test/rank_loss_operator_test.py
+[1158/2582] Generating python/operator_test/rebatching_queue_test.py
+[1159/2582] Generating python/operator_test/record_queue_test.py
+[1160/2582] Generating python/operator_test/recurrent_net_executor_test.py
+[1161/2582] Generating python/operator_test/recurrent_network_test.py
+[1162/2582] Generating python/operator_test/reduce_ops_test.py
+[1163/2582] Generating python/operator_test/reduction_ops_test.py
+[1164/2582] Generating python/operator_test/reshape_ops_test.py
+[1165/2582] Generating python/operator_test/resize_op_test.py
+[1166/2582] Generating python/operator_test/rmac_regions_op_test.py
+[1167/2582] Generating python/operator_test/rnn_cell_test.py
+[1168/2582] Generating python/operator_test/roi_align_rotated_op_test.py
+[1169/2582] Generating python/operator_test/segment_ops_test.py
+[1170/2582] Generating python/operator_test/selu_op_test.py
+[1171/2582] Generating python/operator_test/sequence_ops_test.py
+[1172/2582] Generating python/operator_test/shape_inference_test.py
+[1173/2582] Generating python/operator_test/sinusoid_position_encoding_op_test.py
+[1174/2582] Generating python/operator_test/scale_op_test.py
+[1175/2582] Generating python/operator_test/softmax_ops_test.py
+[1176/2582] Generating python/operator_test/softplus_op_test.py
+[1177/2582] Generating python/operator_test/sparse_dropout_with_replacement_op_test.py
+[1178/2582] Generating python/operator_test/sparse_gradient_checker_test.py
+[1179/2582] Generating python/operator_test/sparse_lengths_sum_benchmark.py
+[1180/2582] Generating python/operator_test/sparse_normalize_test.py
+[1181/2582] Generating python/operator_test/sparse_ops_test.py
+[1182/2582] Generating python/operator_test/sparse_to_dense_mask_op_test.py
+[1183/2582] Generating python/operator_test/spatial_bn_op_test.py
+[1184/2582] Generating python/operator_test/specialized_segment_ops_test.py
+[1185/2582] Generating python/operator_test/square_root_divide_op_test.py
+[1186/2582] Generating python/operator_test/stats_ops_test.py
+[1187/2582] Generating python/operator_test/stats_put_ops_test.py
+[1188/2582] Generating python/operator_test/string_ops_test.py
+[1189/2582] Generating python/operator_test/text_file_reader_test.py
+[1190/2582] Generating python/operator_test/thresholded_relu_op_test.py
+[1191/2582] Generating python/operator_test/tile_op_test.py
+[1192/2582] Generating python/operator_test/top_k_test.py
+[1193/2582] Generating python/operator_test/transpose_op_test.py
+[1194/2582] Generating python/operator_test/torch_integration_test.py
+[1195/2582] Generating python/operator_test/trigonometric_op_test.py
+[1196/2582] Generating python/operator_test/unique_ops_test.py
+[1197/2582] Generating python/operator_test/unique_uniform_fill_op_test.py
+[1198/2582] Generating python/operator_test/upsample_op_test.py
+[1199/2582] Generating python/operator_test/utility_ops_test.py
+[1200/2582] Generating python/operator_test/video_input_op_test.py
+[1201/2582] Generating python/operator_test/weighted_multi_sample_test.py
+[1202/2582] Generating python/operator_test/weighted_sample_test.py
+[1203/2582] Generating python/operator_test/wngrad_test.py
+[1204/2582] Generating python/optimizer.py
+[1205/2582] Generating python/optimizer_context.py
+[1206/2582] Building CXX object c10/test/CMakeFiles/c10_tempfile_test.dir/util/tempfile_test.cpp.o
+[1207/2582] Generating python/operator_test/weighted_sum_test.py
+[1208/2582] Generating python/optimizer_test.py
+[1209/2582] Generating python/optimizer_test_util.py
+[1210/2582] Generating python/parallel_workers.py
+[1211/2582] Generating python/parallel_workers_test.py
+[1212/2582] Generating python/parallelize_bmuf_distributed_test.py
+[1213/2582] Generating python/pipeline.py
+[1214/2582] Generating python/pipeline_test.py
+[1215/2582] Generating python/predictor/__init__.py
+[1216/2582] Generating python/predictor/mobile_exporter.py
+[1217/2582] Generating python/predictor/mobile_exporter_test.py
+[1218/2582] Generating python/predictor/predictor_exporter.py
+[1219/2582] Generating python/predictor/predictor_exporter_test.py
+[1220/2582] Generating python/predictor/predictor_py_utils.py
+[1221/2582] Generating python/predictor/predictor_test.py
+[1222/2582] Generating python/predictor/serde.py
+[1223/2582] Generating python/predictor_constants.py
+[1224/2582] Generating python/python_op_test.py
+[1225/2582] Building CXX object c10/test/CMakeFiles/c10_TensorTypeSet_test.dir/core/TensorTypeSet_test.cpp.o
+[1226/2582] Generating python/queue_util.py
+[1227/2582] Generating python/record_queue.py
+[1228/2582] Generating python/recurrent.py
+[1229/2582] Generating python/regularizer.py
+[1230/2582] Generating python/regularizer_context.py
+[1231/2582] Generating python/regularizer_test.py
+[1232/2582] Generating python/rnn/__init__.py
+[1233/2582] Generating python/rnn/lstm_comparison.py
+[1234/2582] Generating python/rnn/rnn_cell_test_util.py
+[1235/2582] Generating python/rnn_cell.py
+[1236/2582] Generating python/schema.py
+[1237/2582] Generating python/schema_test.py
+[1238/2582] Generating python/scope.py
+[1239/2582] Generating python/scope_test.py
+[1240/2582] Generating python/serialized_test/__init__.py
+[1241/2582] Generating python/serialized_test/coverage.py
+[1242/2582] Generating python/serialized_test/serialized_test_util.py
+[1243/2582] Generating python/session.py
+[1244/2582] Generating python/session_test.py
+[1245/2582] Generating python/sparse_to_dense_mask_test.py
+[1246/2582] Generating python/sparse_to_dense_test.py
+[1247/2582] Generating python/task.py
+[1248/2582] Generating python/task_test.py
+[1249/2582] Generating python/test/__init__.py
+[1250/2582] Generating python/test/blob_deallocation_test.py
+[1251/2582] Generating python/test/do_op_test.py
+[1252/2582] Generating python/test/executor_test.py
+[1253/2582] Generating python/test/executor_test_util.py
+[1254/2582] Generating python/test/inference_lstm_op_test.py
+[1255/2582] Generating python/test/python_protobuf_test.py
+[1256/2582] Generating python/test_util.py
+[1257/2582] Generating python/text_file_reader.py
+[1258/2582] Generating python/timeout_guard.py
+[1259/2582] Generating python/toy_regression_test.py
+[1260/2582] Generating python/transformations.py
+[1261/2582] Generating python/transformations_test.py
+[1262/2582] Generating python/trt/__init__.py
+[1263/2582] Generating python/trt/test_pt_onnx_trt.py
+[1264/2582] Generating python/trt/test_trt.py
+[1265/2582] Generating python/trt/transform.py
+[1266/2582] Generating python/tt_core.py
+[1267/2582] Generating python/tt_core_test.py
+[1268/2582] Generating python/utils.py
+[1269/2582] Generating python/utils_test.py
+[1270/2582] Generating python/visualize.py
+[1271/2582] Generating python/workspace.py
+[1272/2582] Generating python/workspace_test.py
+[1273/2582] Generating quantization/__init__.py
+[1274/2582] Generating quantization/server/__init__.py
+[1275/2582] Generating quantization/server/batch_matmul_dnnlowp_op_test.py
+[1276/2582] Generating quantization/server/batch_permutation_dnnlowp_op_test.py
+[1277/2582] Generating quantization/server/channel_shuffle_dnnlowp_op_test.py
+[1278/2582] Generating quantization/server/concat_dnnlowp_op_test.py
+[1279/2582] Generating quantization/server/conv_depthwise_dnnlowp_op_test.py
+[1280/2582] Generating quantization/server/conv_dnnlowp_acc16_op_test.py
+[1281/2582] Generating quantization/server/conv_dnnlowp_op_test.py
+[1282/2582] Generating quantization/server/conv_groupwise_dnnlowp_acc16_op_test.py
+[1283/2582] Generating quantization/server/conv_groupwise_dnnlowp_op_test.py
+[1284/2582] Generating quantization/server/dequantize_dnnlowp_op_test.py
+[1285/2582] Generating quantization/server/dnnlowp_test_utils.py
+[1286/2582] Generating quantization/server/elementwise_add_dnnlowp_op_test.py
+[1287/2582] Generating quantization/server/elementwise_linear_dnnlowp_op_test.py
+[1288/2582] Generating quantization/server/elementwise_mul_dnnlowp_op_test.py
+[1289/2582] Generating quantization/server/elementwise_sum_dnnlowp_op_test.py
+[1290/2582] Generating quantization/server/fully_connected_dnnlowp_acc16_op_test.py
+[1291/2582] Generating quantization/server/fully_connected_dnnlowp_op_test.py
+[1292/2582] Generating quantization/server/fully_connected_fp16_test.py
+[1293/2582] Generating quantization/server/fully_connected_rowwise_dnnlowp_op_test.py
+[1294/2582] Generating quantization/server/gather_dnnlowp_op_test.py
+[1295/2582] Generating quantization/server/group_norm_dnnlowp_op_test.py
+[1296/2582] Generating quantization/server/lstm_unit_dnnlowp_op_test.py
+[1297/2582] Generating quantization/server/observer_test.py
+[1298/2582] Generating quantization/server/pool_dnnlowp_op_test.py
+[1299/2582] Generating quantization/server/quantize_dnnlowp_op_test.py
+[1300/2582] Generating quantization/server/relu_dnnlowp_op_test.py
+[1301/2582] Generating quantization/server/resize_nearest_3d_dnnlowp_op_test.py
+[1302/2582] Generating quantization/server/resize_nearest_dnnlowp_op_test.py
+[1303/2582] Generating quantization/server/sigmoid_dnnlowp_op_test.py
+[1304/2582] Generating quantization/server/spatial_batch_norm_dnnlowp_op_test.py
+[1305/2582] Generating quantization/server/utils.py
+[1306/2582] Generating quantization/server/tanh_dnnlowp_op_test.py
+[1307/2582] Building CXX object third_party/onnx/CMakeFiles/onnx.dir/onnx/defs/controlflow/defs.cc.o
+[1308/2582] Building CXX object third_party/onnx/CMakeFiles/onnx.dir/onnx/defs/controlflow/old.cc.o
+[1309/2582] Building CXX object third_party/onnx/CMakeFiles/onnx.dir/onnx/defs/traditionalml/old.cc.o
+[1310/2582] Running C++/Python protocol buffer compiler on /scratch/iuriiz/repos/pytorch/caffe2/proto/caffe2_legacy.proto
+[1311/2582] Running C++/Python protocol buffer compiler on /scratch/iuriiz/repos/pytorch/caffe2/proto/predictor_consts.proto
+[1312/2582] Running C++/Python protocol buffer compiler on /scratch/iuriiz/repos/pytorch/caffe2/proto/hsm.proto
+[1313/2582] Running C++/Python protocol buffer compiler on /scratch/iuriiz/repos/pytorch/caffe2/proto/prof_dag.proto
+[1314/2582] Running C++/Python protocol buffer compiler on /scratch/iuriiz/repos/pytorch/caffe2/proto/metanet.proto
+[1315/2582] Building CXX object third_party/onnx/CMakeFiles/onnx.dir/onnx/checker.cc.o
+[1316/2582] Building C object sleef/src/libm/CMakeFiles/mkalias.dir/mkalias.c.o
+[1317/2582] Building C object sleef/src/common/CMakeFiles/common.dir/common.c.o
+[1318/2582] Running C++/Python protocol buffer compiler on /scratch/iuriiz/repos/pytorch/caffe2/proto/torch.proto
+[1319/2582] Linking C executable sleef/bin/mkalias
+[1320/2582] Building C object sleef/src/libm/CMakeFiles/mkrename_gnuabi.dir/mkrename_gnuabi.c.o
+[1321/2582] Generating alias_avx512f.h
+[1322/2582] Building C object sleef/src/libm/CMakeFiles/mkdisp.dir/mkdisp.c.o
+[1323/2582] Running C++/Python protocol buffer compiler on /scratch/iuriiz/repos/pytorch/caffe2/proto/caffe2.proto
+[1324/2582] Building CXX object third_party/onnx/CMakeFiles/onnx.dir/onnx/defs/math/old.cc.o
+[1325/2582] Building C object sleef/src/libm/CMakeFiles/mkmasked_gnuabi.dir/mkmasked_gnuabi.c.o
+[1326/2582] Linking C executable sleef/bin/mkrename_gnuabi
+[1327/2582] Building CXX object third_party/onnx/CMakeFiles/onnx.dir/onnx/optimizer/pass.cc.o
+[1328/2582] Linking C executable sleef/bin/mkdisp
+[1329/2582] Building CXX object c10/CMakeFiles/c10.dir/util/typeid.cpp.o
+[1330/2582] Generating dispsse.c
+[1331/2582] Generating dispavx.c
+[1332/2582] Linking C executable sleef/bin/mkmasked_gnuabi
+[1333/2582] Building C object sleef/src/libm/CMakeFiles/mkrename.dir/mkrename.c.o
+[1334/2582] Linking CXX shared library lib/libc10.so
+[1335/2582] Linking C executable sleef/bin/mkrename
+[1336/2582] Generating include/renameavx2.h
+Generating renameavx2.h: mkrename finz_ 4 8 avx2
+[1337/2582] Generating include/renamesse2.h
+Generating renamesse2.h: mkrename cinz_ 2 4 sse2
+[1338/2582] Generating include/renameavx512fnofma.h
+Generating renameavx512fnofma.h: mkrename cinz_ 8 16 avx512fnofma
+[1339/2582] Generating include/renameavx.h
+Generating renameavx.h: mkrename cinz_ 4 8 avx
+[1340/2582] Generating include/renameavx512f.h
+Generating renameavx512f.h: mkrename finz_ 8 16 avx512f
+[1341/2582] Generating include/renameavx2128.h
+Generating renameavx2128.h: mkrename finz_ 2 4 avx2128
+[1342/2582] Generating include/renamepurec_scalar.h
+Generating renamepurec_scalar.h: mkrename cinz_ 1 1 purec
+[1343/2582] Generating include/renamefma4.h
+Generating renamefma4.h: mkrename finz_ 4 8 fma4
+[1344/2582] Generating include/renamesse4.h
+Generating renamesse4.h: mkrename cinz_ 2 4 sse4
+[1345/2582] Building CXX object third_party/onnx/CMakeFiles/onnx.dir/onnx/defs/generator/defs.cc.o
+[1346/2582] Generating include/renamepurecfma_scalar.h
+Generating renamepurecfma_scalar.h: mkrename finz_ 1 1 purecfma
+[1347/2582] Building C object sleef/src/common/CMakeFiles/arraymap.dir/arraymap.c.o
+[1348/2582] Building CXX object c10/test/CMakeFiles/c10_typeid_test.dir/util/typeid_test.cpp.o
+[1349/2582] Building CXX object c10/test/CMakeFiles/c10_Metaprogramming_test.dir/util/Metaprogramming_test.cpp.o
+[1350/2582] Linking CXX executable bin/c10_Half_test
+[1351/2582] Linking CXX executable bin/c10_Array_test
+[1352/2582] Linking CXX executable bin/c10_tempfile_test
+[1353/2582] Linking CXX executable bin/c10_TensorTypeSet_test
+[1354/2582] Building CXX object third_party/onnx/CMakeFiles/onnx.dir/onnx/defs/nn/old.cc.o
+[1355/2582] Building CXX object c10/test/CMakeFiles/c10_registry_test.dir/util/registry_test.cpp.o
+[1356/2582] Linking CXX executable bin/c10_StreamGuard_test
+[1357/2582] Linking CXX executable bin/c10_ConstexprCrc_test
+[1358/2582] Linking CXX executable bin/c10_C++17_test
+[1359/2582] Linking CXX executable bin/c10_TypeTraits_test
+[1360/2582] Linking CXX executable bin/c10_TypeIndex_test
+[1361/2582] Generating ../../../include/sleef.h
+Generating sleef.h: mkrename cinz_ 2 4 __m128d __m128 __m128i __m128i __SSE2__
+Generating sleef.h: mkrename cinz_ 2 4 __m128d __m128 __m128i __m128i __SSE2__ sse2
+Generating sleef.h: mkrename cinz_ 2 4 __m128d __m128 __m128i __m128i __SSE2__ sse4
+Generating sleef.h: mkrename cinz_ 4 8 __m256d __m256 __m128i struct\ {\ __m128i\ x,\ y;\ } __AVX__
+Generating sleef.h: mkrename cinz_ 4 8 __m256d __m256 __m128i struct\ {\ __m128i\ x,\ y;\ } __AVX__ avx
+Generating sleef.h: mkrename finz_ 4 8 __m256d __m256 __m128i struct\ {\ __m128i\ x,\ y;\ } __AVX__ fma4
+Generating sleef.h: mkrename finz_ 4 8 __m256d __m256 __m128i __m256i __AVX__ avx2
+Generating sleef.h: mkrename finz_ 2 4 __m128d __m128 __m128i __m128i __SSE2__ avx2128
+Generating sleef.h: mkrename finz_ 8 16 __m512d __m512 __m256i __m512i __AVX512F__
+Generating sleef.h: mkrename finz_ 8 16 __m512d __m512 __m256i __m512i __AVX512F__ avx512f
+Generating sleef.h: mkrename cinz_ 8 16 __m512d __m512 __m256i __m512i __AVX512F__ avx512fnofma
+Generating sleef.h: mkrename cinz_ 1 1 double float int32_t int32_t __STDC__ purec
+Generating sleef.h: mkrename finz_ 1 1 double float int32_t int32_t FP_FAST_FMA purecfma
+[1362/2582] Linking CXX executable bin/c10_typeid_test
+[1363/2582] Linking CXX executable bin/c10_Metaprogramming_test
+[1364/2582] Linking CXX executable bin/c10_registry_test
+[1365/2582] Building CXX object third_party/onnx/CMakeFiles/onnx.dir/onnx/defs/sequence/defs.cc.o
+[1366/2582] Building CXX object c10/test/CMakeFiles/c10_TypeList_test.dir/util/TypeList_test.cpp.o
+[1367/2582] Building CXX object third_party/onnx/CMakeFiles/onnx.dir/onnx/defs/traditionalml/defs.cc.o
+[1368/2582] Building CXX object c10/test/CMakeFiles/c10_DeviceGuard_test.dir/core/DeviceGuard_test.cpp.o
+[1369/2582] Building CXX object third_party/onnx/CMakeFiles/onnx.dir/onnx/defs/math/defs.cc.o
+[1370/2582] Generating renamedsp128.h
+[1371/2582] Linking CXX executable bin/c10_TypeList_test
+[1372/2582] Building CXX object caffe2/perfkernels/CMakeFiles/Caffe2_perfkernels_avx2.dir/math_cpu_avx2.cc.o
+[1373/2582] Building CXX object c10/test/CMakeFiles/c10_logging_test.dir/util/logging_test.cpp.o
+[1374/2582] Linking CXX executable bin/c10_DeviceGuard_test
+[1375/2582] Building CXX object c10/test/CMakeFiles/c10_flags_test.dir/util/flags_test.cpp.o
+[1376/2582] Building CXX object c10/test/CMakeFiles/c10_LeftRight_test.dir/util/LeftRight_test.cpp.o
+[1377/2582] Linking CXX executable bin/c10_logging_test
+[1378/2582] Building CXX object c10/test/CMakeFiles/c10_bfloat16_test.dir/util/bfloat16_test.cpp.o
+[1379/2582] Building CXX object c10/test/CMakeFiles/c10_InlineDeviceGuard_test.dir/core/impl/InlineDeviceGuard_test.cpp.o
+[1380/2582] Linking CXX executable bin/c10_LeftRight_test
+[1381/2582] Building CXX object c10/test/CMakeFiles/c10_InlineStreamGuard_test.dir/core/impl/InlineStreamGuard_test.cpp.o
+[1382/2582] Building CXX object caffe2/perfkernels/CMakeFiles/Caffe2_perfkernels_avx512.dir/common_avx512.cc.o
+[1383/2582] Linking CXX executable bin/c10_flags_test
+[1384/2582] Building CXX object caffe2/perfkernels/CMakeFiles/Caffe2_perfkernels_avx2.dir/common_avx2.cc.o
+[1385/2582] Building C object sleef/src/libm/CMakeFiles/sleefdetpurecfma_scalar.dir/sleefsimdsp.c.o
+[1386/2582] Building CXX object caffe2/perfkernels/CMakeFiles/Caffe2_perfkernels_avx.dir/common_avx.cc.o
+[1387/2582] Linking CXX executable bin/c10_bfloat16_test
+[1388/2582] Building CXX object c10/test/CMakeFiles/c10_string_view_test.dir/util/string_view_test.cpp.o
+[1389/2582] Building C object sleef/src/libm/CMakeFiles/sleefdetavx2.dir/sleefsimdsp.c.o
+[1390/2582] Building C object sleef/src/libm/CMakeFiles/sleefdetavx2128.dir/sleefsimdsp.c.o
+[1391/2582] Linking CXX executable bin/c10_InlineDeviceGuard_test
+[1392/2582] Linking CXX executable bin/c10_InlineStreamGuard_test
+[1393/2582] Building CXX object third_party/onnx/CMakeFiles/onnx.dir/onnx/defs/nn/defs.cc.o
+[1394/2582] Generating renamedsp256.h
+[1395/2582] Building C object sleef/src/libm/CMakeFiles/sleefdetsse4.dir/sleefsimdsp.c.o
+[1396/2582] Building C object sleef/src/libm/CMakeFiles/sleefdetpurecfma_scalar.dir/sleefsimddp.c.o
+[1397/2582] Building C object sleef/src/libm/CMakeFiles/sleefdetavx2.dir/sleefsimddp.c.o
+[1398/2582] Building C object sleef/src/libm/CMakeFiles/sleefdetavx512fnofma.dir/sleefsimdsp.c.o
+[1399/2582] Linking CXX executable bin/c10_string_view_test
+[1400/2582] Building C object sleef/src/libm/CMakeFiles/sleefdetavx2128.dir/sleefsimddp.c.o
+[1401/2582] Building C object sleef/src/libm/CMakeFiles/sleef.dir/rempitab.c.o
+[1402/2582] Building C object sleef/src/libm/CMakeFiles/sleef.dir/sleefld.c.o
+[1403/2582] Building CXX object caffe2/perfkernels/CMakeFiles/Caffe2_perfkernels_avx.dir/adagrad_avx.cc.o
+[1404/2582] Building CXX object third_party/onnx/CMakeFiles/onnx.dir/onnx/defs/tensor/old.cc.o
+[1405/2582] Building CXX object caffe2/perfkernels/CMakeFiles/Caffe2_perfkernels_avx2.dir/typed_axpy_avx2.cc.o
+[1406/2582] Building C object sleef/src/libm/CMakeFiles/sleef.dir/sleefqp.c.o
+[1407/2582] Building C object sleef/src/libm/CMakeFiles/sleefdetpurec_scalar.dir/sleefsimdsp.c.o
+[1408/2582] Building CXX object caffe2/perfkernels/CMakeFiles/Caffe2_perfkernels_avx.dir/typed_axpy_avx.cc.o
+[1409/2582] Building C object sleef/src/libm/CMakeFiles/sleefdetpurec_scalar.dir/sleefsimddp.c.o
+[1410/2582] Building CXX object third_party/onnx/CMakeFiles/onnx.dir/onnx/common/ir_pb_converter.cc.o
+[1411/2582] Building C object sleef/src/libm/CMakeFiles/sleefdetsse4.dir/sleefsimddp.c.o
+[1412/2582] Building CXX object third_party/onnx/CMakeFiles/onnx.dir/onnx/shape_inference/implementation.cc.o
+[1413/2582] Building CXX object third_party/onnx/CMakeFiles/onnx.dir/onnx/optimizer/pass_registry.cc.o
+[1414/2582] Building C object sleef/src/libm/CMakeFiles/sleefdetavx512fnofma.dir/sleefsimddp.c.o
+[1415/2582] Building C object sleef/src/libm/CMakeFiles/sleefdetavx.dir/sleefsimdsp.c.o
+[1416/2582] Building CXX object third_party/onnx/CMakeFiles/onnx.dir/onnx/defs/tensor/defs.cc.o
+[1417/2582] Building C object sleef/src/libm/CMakeFiles/sleefdetfma4.dir/sleefsimddp.c.o
+[1418/2582] Building C object sleef/src/libm/CMakeFiles/sleefdetavx.dir/sleefsimddp.c.o
+[1419/2582] Building C object sleef/src/libm/CMakeFiles/sleefdetfma4.dir/sleefsimdsp.c.o
+[1420/2582] Building C object sleef/src/libm/CMakeFiles/sleefavx2128.dir/sleefsimddp.c.o
+[1421/2582] Building C object sleef/src/libm/CMakeFiles/sleefavx2.dir/sleefsimdsp.c.o
+[1422/2582] Building C object sleef/src/libm/CMakeFiles/sleefavx2128.dir/sleefsimdsp.c.o
+[1423/2582] Building C object sleef/src/libm/CMakeFiles/sleefdetavx512f.dir/sleefsimdsp.c.o
+[1424/2582] Building CXX object third_party/onnx/CMakeFiles/onnx_proto.dir/onnx/onnx_onnx_torch-ml.pb.cc.o
+[1425/2582] Building C object sleef/src/libm/CMakeFiles/sleefavx2.dir/sleefsimddp.c.o
+[1426/2582] Building C object sleef/src/libm/CMakeFiles/sleefdetsse2.dir/sleefsimdsp.c.o
+[1427/2582] Linking CXX static library lib/libonnx_proto.a
+[1428/2582] Building CXX object third_party/onnx/CMakeFiles/onnx.dir/onnx/defs/schema.cc.o
+[1429/2582] Building CXX object caffe2/proto/CMakeFiles/Caffe2_PROTO.dir/predictor_consts.pb.cc.o
+[1430/2582] Building CXX object caffe2/proto/CMakeFiles/Caffe2_PROTO.dir/caffe2_legacy.pb.cc.o
+[1431/2582] Building C object sleef/src/libm/CMakeFiles/sleefdetavx512f.dir/sleefsimddp.c.o
+[1432/2582] Building CXX object caffe2/perfkernels/CMakeFiles/Caffe2_perfkernels_avx2.dir/embedding_lookup_fused_8bit_rowwise_avx2.cc.o
+[1433/2582] Building CXX object caffe2/perfkernels/CMakeFiles/Caffe2_perfkernels_avx2.dir/embedding_lookup_avx2.cc.o
+[1434/2582] Building C object sleef/src/libm/CMakeFiles/sleefpurecfma_scalar.dir/sleefsimdsp.c.o
+[1435/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/rnn/ref_rnn.cpp.o
+[1436/2582] Building CXX object caffe2/perfkernels/CMakeFiles/Caffe2_perfkernels_avx2.dir/embedding_lookup_fused_8bit_rowwise_idx_avx2.cc.o
+[1437/2582] Building C object sleef/src/libm/CMakeFiles/sleefavx512fnofma.dir/sleefsimdsp.c.o
+[1438/2582] Building C object sleef/src/libm/CMakeFiles/sleefsse4.dir/sleefsimddp.c.o
+[1439/2582] Building C object sleef/src/libm/CMakeFiles/sleeffma4.dir/sleefsimddp.c.o
+[1440/2582] Building C object sleef/src/libm/CMakeFiles/sleefdetsse2.dir/sleefsimddp.c.o
+[1441/2582] Building C object sleef/src/libm/CMakeFiles/sleefpurecfma_scalar.dir/sleefsimddp.c.o
+[1442/2582] Building C object sleef/src/libm/CMakeFiles/sleefsse4.dir/sleefsimdsp.c.o
+[1443/2582] Building C object sleef/src/libm/CMakeFiles/sleefavx512fnofma.dir/sleefsimddp.c.o
+[1444/2582] Building C object sleef/src/libm/CMakeFiles/sleeffma4.dir/sleefsimdsp.c.o
+[1445/2582] Building CXX object caffe2/perfkernels/CMakeFiles/Caffe2_perfkernels_avx2.dir/embedding_lookup_idx_avx2.cc.o
+[1446/2582] Building C object sleef/src/libm/CMakeFiles/dispsse_obj.dir/dispsse.c.o
+[1447/2582] Building CXX object caffe2/proto/CMakeFiles/Caffe2_PROTO.dir/prof_dag.pb.cc.o
+[1448/2582] Building CXX object caffe2/proto/CMakeFiles/Caffe2_PROTO.dir/hsm.pb.cc.o
+[1449/2582] Building C object sleef/src/libm/CMakeFiles/sleefavx512f.dir/sleefsimddp.c.o
+[1450/2582] Building C object sleef/src/libm/CMakeFiles/sleefavx512f.dir/sleefsimdsp.c.o
+[1451/2582] Building CXX object caffe2/proto/CMakeFiles/Caffe2_PROTO.dir/metanet.pb.cc.o
+[1452/2582] Building C object sleef/src/libm/CMakeFiles/sleefavx.dir/sleefsimddp.c.o
+[1453/2582] Building C object sleef/src/libm/CMakeFiles/dispavx_obj.dir/dispavx.c.o
+[1454/2582] Building C object sleef/src/libm/CMakeFiles/sleefavx.dir/sleefsimdsp.c.o
+[1455/2582] Building C object sleef/src/libm/CMakeFiles/sleefpurec_scalar.dir/sleefsimddp.c.o
+[1456/2582] Building C object sleef/src/libm/CMakeFiles/sleefpurec_scalar.dir/sleefsimdsp.c.o
+[1457/2582] Building C object sleef/src/libm/CMakeFiles/sleefsse2.dir/sleefsimdsp.c.o
+[1458/2582] Building C object sleef/src/libm/CMakeFiles/sleef.dir/sleefsp.c.o
+[1459/2582] Building CXX object caffe2/proto/CMakeFiles/Caffe2_PROTO.dir/torch.pb.cc.o
+[1460/2582] Building CXX object c10/test/CMakeFiles/c10_ordered_preserving_dict_test.dir/util/ordered_preserving_dict_test.cpp.o
+[1461/2582] Linking CXX executable bin/c10_ordered_preserving_dict_test
+[1462/2582] Building C object sleef/src/libm/CMakeFiles/sleefsse2.dir/sleefsimddp.c.o
+[1463/2582] Building C object sleef/src/libm/CMakeFiles/sleef.dir/sleefdp.c.o
+[1464/2582] Linking C static library sleef/lib/libsleef.a
+[1465/2582] Building CXX object caffe2/proto/CMakeFiles/Caffe2_PROTO.dir/caffe2.pb.cc.o
+[1466/2582] Linking CXX static library lib/libCaffe2_perfkernels_avx512.a
+[1467/2582] Linking CXX static library lib/libCaffe2_perfkernels_avx.a
+[1468/2582] Linking CXX static library lib/libCaffe2_perfkernels_avx2.a
+[1469/2582] Linking CXX static library lib/libcaffe2_protos.a
+[1470/2582] Building CXX object third_party/onnx/CMakeFiles/onnx.dir/onnx/optimizer/optimize.cc.o
+[1471/2582] Generating src/x86_64-fma/2d-fourier-16x16.py.o
+[1472/2582] Building CXX object third_party/fbgemm/CMakeFiles/fbgemm_avx2.dir/src/QuantUtilsAvx2.cc.o
+[1473/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/cpu_engine.cpp.o
+[1474/2582] Generating src/x86_64-fma/2d-winograd-8x8-3x3.py.o
+[1475/2582] Building CXX object third_party/onnx/CMakeFiles/onnx.dir/onnx/version_converter/convert.cc.o
+[1476/2582] Generating src/x86_64-fma/blas/s8gemm.py.o
+[1477/2582] Building CXX object c10/test/CMakeFiles/c10_intrusive_ptr_test.dir/util/intrusive_ptr_test.cpp.o
+[1478/2582] Linking CXX executable bin/c10_intrusive_ptr_test
+[1479/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/cpu_reorder.cpp.o
+[1480/2582] Linking CXX static library lib/libonnx.a
+[1481/2582] Generating ../aten/src/ATen/CPUType.cpp, ../aten/src/ATen/CPUType.h, ../aten/src/ATen/Declarations.yaml, ../aten/src/ATen/Functions.h, ../aten/src/ATen/LegacyTHFunctionsCPU.cpp, ../aten/src/ATen/LegacyTHFunctionsCPU.h, ../aten/src/ATen/MkldnnCPUType.cpp, ../aten/src/ATen/MkldnnCPUType.h, ../aten/src/ATen/NativeFunctions.h, ../aten/src/ATen/QuantizedCPUType.cpp, ../aten/src/ATen/QuantizedCPUType.h, ../aten/src/ATen/SparseCPUType.cpp, ../aten/src/ATen/SparseCPUType.h, ../aten/src/ATen/TypeDefault.cpp, ../aten/src/ATen/TypeDefault.h, ../aten/src/ATen/CUDAType.cpp, ../aten/src/ATen/CUDAType.h, ../aten/src/ATen/LegacyTHFunctionsCUDA.cpp, ../aten/src/ATen/LegacyTHFunctionsCUDA.h, ../aten/src/ATen/SparseCUDAType.cpp, ../aten/src/ATen/SparseCUDAType.h, ../aten/src/ATen/core/OpsAlreadyMovedToC10.cpp, ../aten/src/ATen/core/TensorBody.h, ../aten/src/ATen/core/TensorMethods.h
+[1482/2582] Generating src/x86_64-fma/blas/c8gemm.py.o
+[1483/2582] Building CXX object c10/test/CMakeFiles/c10_either_test.dir/util/either_test.cpp.o
+[1484/2582] Linking CXX executable bin/c10_either_test
+[1485/2582] Generating src/x86_64-fma/blas/s4c6gemm.py.o
+[1486/2582] Generating ../../../torch/__init__.pyi, ../../../torch/nn/functional.pyi
+Writing ./torch/__init__.pyi
+Writing ./torch/nn/functional.pyi
+[1487/2582] Generating src/x86_64-fma/blas/conv1x1.py.o
+[1488/2582] Generating src/x86_64-fma/blas/sgemm.py.o
+[1489/2582] Generating src/x86_64-fma/max-pooling.py.o
+[1490/2582] Generating src/x86_64-fma/relu.py.o
+[1491/2582] Generating src/x86_64-fma/softmax.py.o
+[1492/2582] Building CXX object third_party/ideep/mkl-dnn/src/CMakeFiles/mkldnn.dir/cpu/cpu_memory.cpp.o
+[1493/2582] Generating src/x86_64-fma/blas/sdotxf.py.o
+[1494/2582] Linking CXX static library lib/libmkldnn.a
+[1495/2582] Generating ../../torch/csrc/autograd/generated/Functions.cpp, ../../torch/csrc/jit/generated/register_aten_ops_0.cpp, ../../torch/csrc/jit/generated/register_aten_ops_1.cpp, ../../torch/csrc/jit/generated/register_aten_ops_2.cpp, ../../torch/csrc/autograd/generated/VariableType_0.cpp, ../../torch/csrc/autograd/generated/VariableType_1.cpp, ../../torch/csrc/autograd/generated/VariableType_2.cpp, ../../torch/csrc/autograd/generated/VariableType_3.cpp, ../../torch/csrc/autograd/generated/VariableType_4.cpp, ../../torch/csrc/autograd/generated/Functions.h, ../../torch/csrc/autograd/generated/variable_factories.h, ../../torch/csrc/autograd/generated/VariableType.h, ../../torch/csrc/autograd/generated/python_functions.cpp, ../../torch/csrc/autograd/generated/python_variable_methods.cpp, ../../torch/csrc/autograd/generated/python_torch_functions.cpp, ../../torch/csrc/autograd/generated/python_nn_functions.cpp, ../../torch/csrc/autograd/generated/python_functions.h, ../../torch/csrc/autograd/generated/python_variable_methods_dispatch.h, ../../torch/csrc/autograd/generated/python_torch_functions_dispatch.h, ../../torch/csrc/autograd/generated/python_nn_functions.h, ../../torch/csrc/autograd/generated/python_nn_functions_dispatch.h
+Writing torch/csrc/autograd/generated/python_functions.h
+Writing torch/csrc/autograd/generated/python_functions.cpp
+Writing torch/csrc/autograd/generated/python_variable_methods.cpp
+Writing torch/csrc/autograd/generated/python_variable_methods_dispatch.h
+Writing torch/csrc/autograd/generated/python_torch_functions.cpp
+Writing torch/csrc/autograd/generated/python_torch_functions_dispatch.h
+Writing torch/csrc/autograd/generated/python_nn_functions.cpp
+Writing torch/csrc/autograd/generated/python_nn_functions.h
+Writing torch/csrc/autograd/generated/python_nn_functions_dispatch.h
+Writing torch/csrc/autograd/generated/VariableType.h
+Writing torch/csrc/autograd/generated/VariableType_0.cpp
+Writing torch/csrc/autograd/generated/VariableType_1.cpp
+Writing torch/csrc/autograd/generated/VariableType_2.cpp
+Writing torch/csrc/autograd/generated/VariableType_3.cpp
+Writing torch/csrc/autograd/generated/VariableType_4.cpp
+Writing torch/csrc/autograd/generated/VariableTypeEverything.cpp
+Writing torch/csrc/autograd/generated/RegistrationDeclarations.h
+Writing torch/csrc/autograd/generated/Functions.h
+Writing torch/csrc/autograd/generated/Functions.cpp
+Writing torch/csrc/autograd/generated/variable_factories.h
+Writing torch/csrc/jit/generated/register_aten_ops_0.cpp
+Writing torch/csrc/jit/generated/register_aten_ops_1.cpp
+Writing torch/csrc/jit/generated/register_aten_ops_2.cpp
+[1496/2582] Generating src/x86_64-fma/blas/shdotxf.py.o
+[1497/2582] Building C object confu-deps/NNPACK/CMakeFiles/nnpack.dir/src/fully-connected-inference.c.o
+[1498/2582] Building C object confu-deps/NNPACK/CMakeFiles/nnpack.dir/src/softmax-output.c.o
+[1499/2582] Building C object confu-deps/NNPACK/CMakeFiles/nnpack.dir/src/x86_64-fma/softmax.c.o
+[1500/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/ParallelNative.cpp.o
+[1501/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/ParallelNativeTBB.cpp.o
+[1502/2582] Building C object confu-deps/NNPACK/CMakeFiles/nnpack.dir/src/pooling-output.c.o
+[1503/2582] Building C object confu-deps/NNPACK/CMakeFiles/nnpack.dir/src/relu-output.c.o
+[1504/2582] Building C object confu-deps/NNPACK/CMakeFiles/nnpack.dir/src/fully-connected-output.c.o
+[1505/2582] Building C object confu-deps/NNPACK/CMakeFiles/nnpack.dir/src/relu-input-gradient.c.o
+[1506/2582] Building C object confu-deps/NNPACK/CMakeFiles/nnpack.dir/src/init.c.o
+[1507/2582] Building C object confu-deps/NNPACK/CMakeFiles/nnpack.dir/src/convolution-kernel-gradient.c.o
+[1508/2582] Building C object confu-deps/NNPACK/CMakeFiles/nnpack.dir/src/convolution-output.c.o
+[1509/2582] Building C object confu-deps/NNPACK/CMakeFiles/nnpack.dir/src/convolution-input-gradient.c.o
+[1510/2582] Building C object confu-deps/NNPACK/CMakeFiles/nnpack.dir/src/convolution-inference.c.o
+[1511/2582] Linking C static library lib/libnnpack.a
+[1512/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/ThreadLocalDebugInfo.cpp.o
+[1513/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/cpu/FlushDenormal.cpp.o
+[1514/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/core/ATenGeneral.cpp.o
+[1515/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/core/Range.cpp.o
+[1516/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/detail/CPUGuardImpl.cpp.o
+[1517/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/CPUGenerator.cpp.o
+[1518/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/core/Generator.cpp.o
+[1519/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/core/Dimname.cpp.o
+[1520/2582] Building CXX object caffe2/CMakeFiles/common_test.dir/core/common_test.cc.o
+[1521/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/detail/HIPHooksInterface.cpp.o
+[1522/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/detail/CUDAHooksInterface.cpp.o
+[1523/2582] Building CXX object caffe2/CMakeFiles/fatal_signal_asan_no_sig_test.dir/utils/fatal_signal_asan_no_sig_test.cc.o
+[1524/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/core/grad_mode.cpp.o
+[1525/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/core/DeprecatedTypePropertiesRegistry.cpp.o
+[1526/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/core/LegacyDeviceTypeInit.cpp.o
+[1527/2582] Building CXX object caffe2/CMakeFiles/inline_container_test.dir/serialize/inline_container_test.cc.o
+[1528/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/core/blob.cpp.o
+[1529/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/torch/csrc/jit/script/strtod.cpp.o
+[1530/2582] Building CXX object caffe2/CMakeFiles/caffe2_pybind11_state.dir/python/pybind_state_registry.cc.o
+[1531/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/core/LegacyTypeDispatch.cpp.o
+[1532/2582] Building CXX object caffe2/CMakeFiles/mobile_test.dir/opt/mobile_test.cc.o
+[1533/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/core/register_symbols.cpp.o
+[1534/2582] Building CXX object caffe2/CMakeFiles/device_test.dir/opt/device_test.cc.o
+[1535/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/torch/csrc/jit/script/error_report.cpp.o
+[1536/2582] Building CXX object caffe2/CMakeFiles/NeuralNetTest.dir/core/nomnigraph/tests/NeuralNetTest.cc.o
+[1537/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/core/interned_strings.cpp.o
+[1538/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/torch/csrc/jit/source_range.cpp.o
+[1539/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/torch/csrc/jit/script/lexer.cpp.o
+[1540/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/core/op_registration/infer_schema.cpp.o
+[1541/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/core/VariableFallbackKernel.cpp.o
+[1542/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/Utils.cpp.o
+[1543/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/DynamicLibrary.cpp.o
+[1544/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/ExpandUtils.cpp.o
+[1545/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/TensorNames.cpp.o
+[1546/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/core/dispatch/OperatorEntry.cpp.o
+[1547/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/core/DeprecatedTypeProperties.cpp.o
+[1548/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/NamedTensorUtils.cpp.o
+[1549/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/core/dispatch/Dispatcher.cpp.o
+[1550/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/core/VariableHooksInterface.cpp.o
+[1551/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/core/Tensor.cpp.o
+[1552/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/core/NamedTensor.cpp.o
+[1553/2582] Building CXX object caffe2/CMakeFiles/smart_tensor_printer_test.dir/utils/smart_tensor_printer_test.cc.o
+[1554/2582] Building CXX object caffe2/CMakeFiles/List_test.dir/__/aten/src/ATen/core/List_test.cpp.o
+[1555/2582] Building CXX object caffe2/CMakeFiles/TensorImpl_test.dir/__/aten/src/ATen/core/TensorImpl_test.cpp.o
+[1556/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/core/Formatting.cpp.o
+[1557/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/core/op_registration/op_registration.cpp.o
+[1558/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/DispatchStub.cpp.o
+[1559/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/torch/csrc/jit/script/function_schema_parser.cpp.o
+[1560/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/torch/csrc/jit/script/schema_type_parser.cpp.o
+[1561/2582] Building CXX object caffe2/CMakeFiles/KernelFunction_test.dir/__/aten/src/ATen/core/boxing/KernelFunction_test.cpp.o
+[1562/2582] Building CXX object caffe2/CMakeFiles/caffe2_pybind11_state.dir/python/pybind_state_dlpack.cc.o
+[1563/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/core/ivalue.cpp.o
+[1564/2582] Building CXX object caffe2/CMakeFiles/math_test.dir/utils/math_test.cc.o
+[1565/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/MemoryOverlap.cpp.o
+[1566/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/LegacyBridge.cpp.o
+[1567/2582] Building CXX object caffe2/CMakeFiles/conv_to_nnpack_transform_test.dir/transforms/conv_to_nnpack_transform_test.cc.o
+[1568/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/TensorGeometry.cpp.o
+[1569/2582] Building CXX object caffe2/CMakeFiles/common_subexpression_elimination_test.dir/transforms/common_subexpression_elimination_test.cc.o
+[1570/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/Context.cpp.o
+[1571/2582] Building CXX object caffe2/CMakeFiles/depthwise3x3_conv_op_test.dir/share/contrib/depthwise/depthwise3x3_conv_op_test.cc.o
+[1572/2582] Building CXX object caffe2/CMakeFiles/net_async_tracing_test.dir/core/net_async_tracing_test.cc.o
+[1573/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/queue/rebatching_queue.cc.o
+[1574/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/ParallelOpenMP.cpp.o
+[1575/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/Version.cpp.o
+[1576/2582] Building CXX object caffe2/CMakeFiles/xla_tensor_test.dir/__/aten/src/ATen/test/xla_tensor_test.cpp.o
+[1577/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/ParallelCommon.cpp.o
+[1578/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/ParallelThreadPoolNative.cpp.o
+[1579/2582] Building CXX object caffe2/CMakeFiles/graph_test.dir/core/graph_test.cc.o
+[1580/2582] Building CXX object caffe2/CMakeFiles/weakref_test.dir/__/aten/src/ATen/test/weakref_test.cpp.o
+[1581/2582] Building CXX object caffe2/CMakeFiles/dlconvertor_test.dir/__/aten/src/ATen/test/dlconvertor_test.cpp.o
+[1582/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/DLConvertor.cpp.o
+[1583/2582] Building CXX object caffe2/CMakeFiles/wrapdim_test.dir/__/aten/src/ATen/test/wrapdim_test.cpp.o
+[1584/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/sgd/adam_op.cc.o
+[1585/2582] Building CXX object caffe2/CMakeFiles/pattern_net_transform_test.dir/transforms/pattern_net_transform_test.cc.o
+[1586/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/sgd/adadelta_op.cc.o
+[1587/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/queue/rebatching_queue_ops.cc.o
+[1588/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/sgd/adagrad_op.cc.o
+[1589/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/TensorUtils.cpp.o
+[1590/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/core/type.cpp.o
+[1591/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/SparseTensorImpl.cpp.o
+[1592/2582] Building CXX object caffe2/CMakeFiles/kernel_function_test.dir/__/aten/src/ATen/core/boxing/kernel_function_test.cpp.o
+[1593/2582] Building CXX object caffe2/CMakeFiles/caffe2_pybind11_state.dir/python/pybind_state_int8.cc.o
+[1594/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/queue/blobs_queue_db.cc.o
+[1595/2582] Building CXX object caffe2/CMakeFiles/NamedTensor_test.dir/__/aten/src/ATen/test/NamedTensor_test.cpp.o
+[1596/2582] Building CXX object caffe2/CMakeFiles/scalar_tensor_test.dir/__/aten/src/ATen/test/scalar_tensor_test.cpp.o
+[1597/2582] Building CXX object caffe2/CMakeFiles/scalar_test.dir/__/aten/src/ATen/test/scalar_test.cpp.o
+[1598/2582] Building CXX object caffe2/CMakeFiles/Dict_test.dir/__/aten/src/ATen/test/Dict_test.cpp.o
+[1599/2582] Building CXX object caffe2/CMakeFiles/thread_init_test.dir/__/aten/src/ATen/test/thread_init_test.cpp.o
+[1600/2582] Building CXX object caffe2/CMakeFiles/native_test.dir/__/aten/src/ATen/test/native_test.cpp.o
+[1601/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/AdaptiveAveragePooling3d.cpp.o
+In file included from aten/src/ATen/core/TensorBody.h:5:0,
+                 from ../aten/src/ATen/Tensor.h:11,
+                 from ../aten/src/ATen/Context.h:4,
+                 from ../aten/src/ATen/ATen.h:5,
+                 from ../aten/src/ATen/native/AdaptiveAveragePooling3d.cpp:1:
+../aten/src/ATen/native/AdaptiveAveragePooling3d.cpp: In function ‘at::Tensor at::native::adaptive_avg_pool3d_backward_cpu(const at::Tensor&, const at::Tensor&)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/AdaptiveAveragePooling3d.cpp:306:42: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto gradInput = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/AdaptiveAveragePooling3d.cpp:306:42: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto gradInput = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[1602/2582] Building CXX object caffe2/CMakeFiles/reduce_ops_test.dir/__/aten/src/ATen/test/reduce_ops_test.cpp.o
+[1603/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/AdaptiveAveragePooling.cpp.o
+In file included from aten/src/ATen/core/TensorBody.h:5:0,
+                 from ../aten/src/ATen/Tensor.h:11,
+                 from ../aten/src/ATen/Context.h:4,
+                 from ../aten/src/ATen/ATen.h:5,
+                 from ../aten/src/ATen/native/AdaptiveAveragePooling.cpp:1:
+../aten/src/ATen/native/AdaptiveAveragePooling.cpp: In function ‘at::Tensor at::native::adaptive_avg_pool2d_backward_cpu(const at::Tensor&, const at::Tensor&)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/AdaptiveAveragePooling.cpp:357:44: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     auto gradInput = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/AdaptiveAveragePooling.cpp:357:44: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     auto gradInput = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[1604/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/AdaptiveMaxPooling2d.cpp.o
+In file included from aten/src/ATen/core/TensorBody.h:5:0,
+                 from ../aten/src/ATen/Tensor.h:11,
+                 from ../aten/src/ATen/Context.h:4,
+                 from ../aten/src/ATen/ATen.h:5,
+                 from ../aten/src/ATen/native/AdaptiveMaxPooling2d.cpp:1:
+../aten/src/ATen/native/AdaptiveMaxPooling2d.cpp: In function ‘at::Tensor at::native::adaptive_max_pool2d_backward_cpu(const at::Tensor&, const at::Tensor&, const at::Tensor&)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/AdaptiveMaxPooling2d.cpp:397:42: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto gradInput = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/AdaptiveMaxPooling2d.cpp:397:42: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto gradInput = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[1605/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/torch/csrc/api/src/nn/modules/distance.cpp.o
+[1606/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/torch/csrc/api/src/nn/modules/dropout.cpp.o
+[1607/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/AdaptiveMaxPooling3d.cpp.o
+In file included from aten/src/ATen/core/TensorBody.h:5:0,
+                 from ../aten/src/ATen/Tensor.h:11,
+                 from ../aten/src/ATen/Context.h:4,
+                 from ../aten/src/ATen/ATen.h:5,
+                 from ../aten/src/ATen/native/AdaptiveMaxPooling3d.cpp:1:
+../aten/src/ATen/native/AdaptiveMaxPooling3d.cpp: In function ‘at::Tensor at::native::adaptive_max_pool3d_backward_cpu(const at::Tensor&, const at::Tensor&, const at::Tensor&)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/AdaptiveMaxPooling3d.cpp:443:42: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto gradInput = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/AdaptiveMaxPooling3d.cpp:443:42: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto gradInput = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[1608/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/AffineGridGenerator.cpp.o
+[1609/2582] Building CXX object caffe2/CMakeFiles/tensor_interop_test.dir/__/aten/src/ATen/test/tensor_interop_test.cpp.o
+[1610/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/Activation.cpp.o
+In file included from aten/src/ATen/core/TensorBody.h:5:0,
+                 from ../aten/src/ATen/Tensor.h:11,
+                 from ../aten/src/ATen/Context.h:4,
+                 from ../aten/src/ATen/ATen.h:5,
+                 from ../aten/src/ATen/native/Activation.h:3,
+                 from ../aten/src/ATen/native/Activation.cpp:1:
+../aten/src/ATen/native/Activation.cpp: In function ‘at::Tensor at::native::rrelu(const at::Tensor&, c10::Scalar, c10::Scalar, bool, at::Generator*)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/Activation.cpp:74:58: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   return at::rrelu_with_noise(self, at::empty_like(self, LEGACY_CONTIGUOUS_MEMORY_FORMAT), lower, upper, training, generator);
+                                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/Activation.cpp:74:58: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   return at::rrelu_with_noise(self, at::empty_like(self, LEGACY_CONTIGUOUS_MEMORY_FORMAT), lower, upper, training, generator);
+                                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/Activation.cpp: In function ‘at::Tensor& at::native::rrelu_(at::Tensor&, c10::Scalar, c10::Scalar, bool, at::Generator*)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/Activation.cpp:78:59: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   return at::rrelu_with_noise_(self, at::empty_like(self, LEGACY_CONTIGUOUS_MEMORY_FORMAT), lower, upper, training, generator);
+                                                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/Activation.cpp:78:59: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   return at::rrelu_with_noise_(self, at::empty_like(self, LEGACY_CONTIGUOUS_MEMORY_FORMAT), lower, upper, training, generator);
+                                                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/Activation.cpp: In function ‘at::Tensor at::native::prelu_cpu(const at::Tensor&, const at::Tensor&)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/Activation.cpp:182:41: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor result = at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/Activation.cpp:182:41: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor result = at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/Activation.cpp: In function ‘std::tuple<at::Tensor, at::Tensor> at::native::prelu_backward_cpu(const at::Tensor&, const at::Tensor&, const at::Tensor&)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/Activation.cpp:314:45: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor input_grad = at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/Activation.cpp:314:45: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor input_grad = at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/Activation.cpp:315:47: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor weight_grad = at::empty_like(weight, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/Activation.cpp:315:47: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor weight_grad = at::empty_like(weight, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/Activation.cpp:316:56: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor weight_grad_collector = at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/Activation.cpp:316:56: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor weight_grad_collector = at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/Activation.cpp: In function ‘at::Tensor at::native::hardshrink_cpu(const at::Tensor&, c10::Scalar)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/Activation.cpp:368:42: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto out_tensor = at::empty_like(self, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/Activation.cpp:368:42: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto out_tensor = at::empty_like(self, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/Activation.cpp: In function ‘at::Tensor at::native::hardshrink_backward_cpu(const at::Tensor&, const at::Tensor&, c10::Scalar)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/Activation.cpp:375:42: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto out_tensor = at::empty_like(self, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/Activation.cpp:375:42: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto out_tensor = at::empty_like(self, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/Activation.cpp: In function ‘at::Tensor at::native::gelu_cpu(const at::Tensor&)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/Activation.cpp:383:43: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor Y = at::native::empty_like(self, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/Activation.cpp:383:43: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor Y = at::native::empty_like(self, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/Activation.cpp: In function ‘at::Tensor at::native::gelu_backward_cpu(const at::Tensor&, const at::Tensor&)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/Activation.cpp:390:44: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor dX = at::native::empty_like(self, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/Activation.cpp:390:44: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor dX = at::native::empty_like(self, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[1611/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/AveragePool3d.cpp.o
+In file included from aten/src/ATen/core/TensorBody.h:5:0,
+                 from ../aten/src/ATen/Tensor.h:11,
+                 from ../aten/src/ATen/Context.h:4,
+                 from ../aten/src/ATen/ATen.h:5,
+                 from ../aten/src/ATen/native/AveragePool3d.cpp:1:
+../aten/src/ATen/native/AveragePool3d.cpp: In function ‘at::Tensor at::native::avg_pool3d_backward_cpu(const at::Tensor&, const at::Tensor&, c10::IntArrayRef, c10::IntArrayRef, c10::IntArrayRef, bool, bool, c10::optional<long int>)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/AveragePool3d.cpp:508:42: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto gradInput = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/AveragePool3d.cpp:508:42: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto gradInput = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[1612/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/torch/csrc/api/src/nn/modules/embedding.cpp.o
+[1613/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/AveragePool2d.cpp.o
+In file included from aten/src/ATen/core/TensorBody.h:5:0,
+                 from ../aten/src/ATen/Tensor.h:11,
+                 from ../aten/src/ATen/Context.h:4,
+                 from ../aten/src/ATen/ATen.h:5,
+                 from ../aten/src/ATen/native/AveragePool2d.cpp:1:
+../aten/src/ATen/native/AveragePool2d.cpp: In function ‘at::Tensor at::native::avg_pool2d_backward_cpu(const at::Tensor&, const at::Tensor&, c10::IntArrayRef, c10::IntArrayRef, c10::IntArrayRef, bool, bool, c10::optional<long int>)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/AveragePool2d.cpp:411:42: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto gradInput = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/AveragePool2d.cpp:411:42: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto gradInput = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[1614/2582] Building CXX object caffe2/CMakeFiles/tensor_iterator_test.dir/__/aten/src/ATen/test/tensor_iterator_test.cpp.o
+[1615/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/Col2Im.cpp.o
+In file included from aten/src/ATen/core/TensorBody.h:5:0,
+                 from ../aten/src/ATen/Tensor.h:11,
+                 from ../aten/src/ATen/Context.h:4,
+                 from ../aten/src/ATen/ATen.h:5,
+                 from ../aten/src/ATen/native/Col2Im.cpp:1:
+../aten/src/ATen/native/Col2Im.cpp: In function ‘at::Tensor at::native::col2im_cpu(const at::Tensor&, c10::IntArrayRef, c10::IntArrayRef, c10::IntArrayRef, c10::IntArrayRef, c10::IntArrayRef)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/Col2Im.cpp:216:41: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor output = at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/Col2Im.cpp:216:41: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor output = at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/Col2Im.cpp: In function ‘at::Tensor at::native::col2im_backward_cpu(const at::Tensor&, c10::IntArrayRef, c10::IntArrayRef, c10::IntArrayRef, c10::IntArrayRef)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/Col2Im.cpp:241:51: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor grad_input = at::empty_like(grad_output, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/Col2Im.cpp:241:51: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor grad_input = at::empty_like(grad_output, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[1616/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/TH/vector/AVX2.cpp.o
+[1617/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/Cross.cpp.o
+In file included from aten/src/ATen/core/TensorBody.h:5:0,
+                 from ../aten/src/ATen/Tensor.h:11,
+                 from ../aten/src/ATen/Context.h:4,
+                 from ../aten/src/ATen/ATen.h:5,
+                 from ../aten/src/ATen/native/Cross.cpp:1:
+../aten/src/ATen/native/Cross.cpp: In function ‘at::Tensor at::native::cross(const at::Tensor&, const at::Tensor&, c10::optional<long int>)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/Cross.cpp:12:38: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor out = at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/Cross.cpp:12:38: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor out = at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[1618/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/ConstantPadNd.cpp.o
+[1619/2582] Building CXX object caffe2/CMakeFiles/blob_test.dir/core/blob_test.cc.o
+[1620/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/ConvolutionTBC.cpp.o
+In file included from aten/src/ATen/core/TensorBody.h:5:0,
+                 from ../aten/src/ATen/Tensor.h:11,
+                 from ../aten/src/ATen/Context.h:4,
+                 from ../aten/src/ATen/ATen.h:5,
+                 from ../aten/src/ATen/native/ConvolutionTBC.cpp:1:
+../aten/src/ATen/native/ConvolutionTBC.cpp: In function ‘std::tuple<at::Tensor, at::Tensor, at::Tensor> at::native::conv_tbc_backward(const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, int64_t)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/ConvolutionTBC.cpp:72:41: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor dInput = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/ConvolutionTBC.cpp:72:41: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor dInput = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/ConvolutionTBC.cpp:85:43: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor dWeight = at::zeros_like(weight, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/ConvolutionTBC.cpp:85:43: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor dWeight = at::zeros_like(weight, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/ConvolutionTBC.cpp:99:39: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor dBias = at::zeros_like(bias, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/ConvolutionTBC.cpp:99:39: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor dBias = at::zeros_like(bias, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[1621/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/ConvolutionMM3d.cpp.o
+[1622/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/BinaryOps.cpp.o
+[1623/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/DilatedMaxPool2d.cpp.o
+In file included from aten/src/ATen/core/TensorBody.h:5:0,
+                 from ../aten/src/ATen/Tensor.h:11,
+                 from ../aten/src/ATen/Context.h:4,
+                 from ../aten/src/ATen/ATen.h:5,
+                 from ../aten/src/ATen/native/DilatedMaxPool2d.cpp:1:
+../aten/src/ATen/native/DilatedMaxPool2d.cpp: In function ‘at::Tensor at::native::max_pool2d_with_indices_backward_cpu(const at::Tensor&, const at::Tensor&, c10::IntArrayRef, c10::IntArrayRef, c10::IntArrayRef, c10::IntArrayRef, bool, const at::Tensor&)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/DilatedMaxPool2d.cpp:490:42: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto gradInput = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/DilatedMaxPool2d.cpp:490:42: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto gradInput = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[1624/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/Fill.cpp.o
+[1625/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/Convolution.cpp.o
+In file included from aten/src/ATen/core/TensorBody.h:5:0,
+                 from ../aten/src/ATen/Tensor.h:11,
+                 from ../aten/src/ATen/Context.h:4,
+                 from ../aten/src/ATen/ATen.h:5,
+                 from ../aten/src/ATen/native/Convolution.cpp:1:
+../aten/src/ATen/native/Convolution.cpp: In function ‘std::tuple<at::Tensor, at::Tensor, at::Tensor> at::native::convolution_backward_overrideable(const at::Tensor&, const at::Tensor&, const at::Tensor&, c10::IntArrayRef, c10::IntArrayRef, c10::IntArrayRef, bool, c10::IntArrayRef, int64_t, std::array<bool, 3>)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/Convolution.cpp:752:33: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+           at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT),
+                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/Convolution.cpp:752:33: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+           at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT),
+                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/Convolution.cpp:753:34: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+           at::empty_like(weight, LEGACY_CONTIGUOUS_MEMORY_FORMAT),
+                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/Convolution.cpp:753:34: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+           at::empty_like(weight, LEGACY_CONTIGUOUS_MEMORY_FORMAT),
+                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/Convolution.cpp: In function ‘std::tuple<at::Tensor, at::Tensor, at::Tensor> at::native::_convolution_double_backward(const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, c10::IntArrayRef, c10::IntArrayRef, c10::IntArrayRef, bool, c10::IntArrayRef, int64_t, bool, bool, bool, std::array<bool, 3>)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/Convolution.cpp:808:30: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     ggO = at::zeros_like(gO, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/Convolution.cpp:808:30: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     ggO = at::zeros_like(gO, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/Convolution.cpp:899:33: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     gW = at::zeros_like(weight, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/Convolution.cpp:899:33: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     gW = at::zeros_like(weight, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/Convolution.cpp:988:32: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     gI = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/Convolution.cpp:988:32: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     gI = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/Convolution.cpp:991:66: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   if (output_mask[0] && !ggO.defined()) ggO = at::zeros_like(gO, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/Convolution.cpp:991:66: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   if (output_mask[0] && !ggO.defined()) ggO = at::zeros_like(gO, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/Convolution.cpp:992:67: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   if (output_mask[1] && !gI.defined()) gI = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/Convolution.cpp:992:67: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   if (output_mask[1] && !gI.defined()) gI = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/Convolution.cpp:993:68: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   if (output_mask[2] && !gW.defined()) gW = at::zeros_like(weight, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/Convolution.cpp:993:68: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   if (output_mask[2] && !gW.defined()) gW = at::zeros_like(weight, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[1626/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/Embedding.cpp.o
+[1627/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/Dropout.cpp.o
+In file included from aten/src/ATen/core/TensorBody.h:5:0,
+                 from ../aten/src/ATen/Tensor.h:11,
+                 from ../aten/src/ATen/Context.h:4,
+                 from ../aten/src/ATen/ATen.h:5,
+                 from ../aten/src/ATen/native/Dropout.cpp:1:
+../aten/src/ATen/native/Dropout.cpp: In function ‘at::native::{anonymous}::Ctype<inplace> at::native::{anonymous}::_dropout_impl(T&, double, bool)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/Dropout.cpp:54:84: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto noise = feature_dropout ? make_feature_noise(input) : at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/Dropout.cpp: In instantiation of ‘at::native::{anonymous}::Ctype<inplace> at::native::{anonymous}::_dropout_impl(T&, double, bool) [with bool feature_dropout = false; bool alpha_dropout = false; bool inplace = false; T = const at::Tensor; at::native::{anonymous}::Ctype<inplace> = at::Tensor]’:
+../aten/src/ATen/native/Dropout.cpp:78:1:   required from ‘at::native::{anonymous}::Ctype<inplace> at::native::{anonymous}::_dropout(Args&& ...) [with bool inplace = false; Args = {const at::Tensor&, double&, bool&}; at::native::{anonymous}::Ctype<inplace> = at::Tensor]’
+../aten/src/ATen/native/Dropout.cpp:93:43:   required from here
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Dropout.cpp:54:84: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto noise = feature_dropout ? make_feature_noise(input) : at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Dropout.cpp:54:84: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto noise = feature_dropout ? make_feature_noise(input) : at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Dropout.cpp:54:84: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto noise = feature_dropout ? make_feature_noise(input) : at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/Dropout.cpp: In instantiation of ‘at::native::{anonymous}::Ctype<inplace> at::native::{anonymous}::_dropout_impl(T&, double, bool) [with bool feature_dropout = false; bool alpha_dropout = false; bool inplace = true; T = at::Tensor; at::native::{anonymous}::Ctype<inplace> = at::Tensor&]’:
+../aten/src/ATen/native/Dropout.cpp:78:1:   required from ‘at::native::{anonymous}::Ctype<inplace> at::native::{anonymous}::_dropout(Args&& ...) [with bool inplace = true; Args = {at::Tensor&, double&, bool&}; at::native::{anonymous}::Ctype<inplace> = at::Tensor&]’
+../aten/src/ATen/native/Dropout.cpp:102:40:   required from here
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Dropout.cpp:54:84: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto noise = feature_dropout ? make_feature_noise(input) : at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Dropout.cpp:54:84: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto noise = feature_dropout ? make_feature_noise(input) : at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Dropout.cpp:54:84: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto noise = feature_dropout ? make_feature_noise(input) : at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/Dropout.cpp: In instantiation of ‘at::native::{anonymous}::Ctype<inplace> at::native::{anonymous}::_dropout_impl(T&, double, bool) [with bool feature_dropout = true; bool alpha_dropout = false; bool inplace = false; T = const at::Tensor; at::native::{anonymous}::Ctype<inplace> = at::Tensor]’:
+../aten/src/ATen/native/Dropout.cpp:79:1:   required from ‘at::native::{anonymous}::Ctype<inplace> at::native::{anonymous}::_feature_dropout(Args&& ...) [with bool inplace = false; Args = {const at::Tensor&, double&, bool&}; at::native::{anonymous}::Ctype<inplace> = at::Tensor]’
+../aten/src/ATen/native/Dropout.cpp:106:49:   required from here
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Dropout.cpp:54:84: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto noise = feature_dropout ? make_feature_noise(input) : at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Dropout.cpp:54:84: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto noise = feature_dropout ? make_feature_noise(input) : at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Dropout.cpp:54:84: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto noise = feature_dropout ? make_feature_noise(input) : at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/Dropout.cpp: In instantiation of ‘at::native::{anonymous}::Ctype<inplace> at::native::{anonymous}::_dropout_impl(T&, double, bool) [with bool feature_dropout = true; bool alpha_dropout = false; bool inplace = true; T = at::Tensor; at::native::{anonymous}::Ctype<inplace> = at::Tensor&]’:
+../aten/src/ATen/native/Dropout.cpp:79:1:   required from ‘at::native::{anonymous}::Ctype<inplace> at::native::{anonymous}::_feature_dropout(Args&& ...) [with bool inplace = true; Args = {at::Tensor&, double&, bool&}; at::native::{anonymous}::Ctype<inplace> = at::Tensor&]’
+../aten/src/ATen/native/Dropout.cpp:110:48:   required from here
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Dropout.cpp:54:84: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto noise = feature_dropout ? make_feature_noise(input) : at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Dropout.cpp:54:84: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto noise = feature_dropout ? make_feature_noise(input) : at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Dropout.cpp:54:84: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto noise = feature_dropout ? make_feature_noise(input) : at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/Dropout.cpp: In instantiation of ‘at::native::{anonymous}::Ctype<inplace> at::native::{anonymous}::_dropout_impl(T&, double, bool) [with bool feature_dropout = false; bool alpha_dropout = true; bool inplace = false; T = const at::Tensor; at::native::{anonymous}::Ctype<inplace> = at::Tensor]’:
+../aten/src/ATen/native/Dropout.cpp:80:1:   required from ‘at::native::{anonymous}::Ctype<inplace> at::native::{anonymous}::_alpha_dropout(Args&& ...) [with bool inplace = false; Args = {const at::Tensor&, double&, bool&}; at::native::{anonymous}::Ctype<inplace> = at::Tensor]’
+../aten/src/ATen/native/Dropout.cpp:114:47:   required from here
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Dropout.cpp:54:84: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto noise = feature_dropout ? make_feature_noise(input) : at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Dropout.cpp:54:84: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto noise = feature_dropout ? make_feature_noise(input) : at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Dropout.cpp:54:84: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto noise = feature_dropout ? make_feature_noise(input) : at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/Dropout.cpp: In instantiation of ‘at::native::{anonymous}::Ctype<inplace> at::native::{anonymous}::_dropout_impl(T&, double, bool) [with bool feature_dropout = false; bool alpha_dropout = true; bool inplace = true; T = at::Tensor; at::native::{anonymous}::Ctype<inplace> = at::Tensor&]’:
+../aten/src/ATen/native/Dropout.cpp:80:1:   required from ‘at::native::{anonymous}::Ctype<inplace> at::native::{anonymous}::_alpha_dropout(Args&& ...) [with bool inplace = true; Args = {at::Tensor&, double&, bool&}; at::native::{anonymous}::Ctype<inplace> = at::Tensor&]’
+../aten/src/ATen/native/Dropout.cpp:118:46:   required from here
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Dropout.cpp:54:84: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto noise = feature_dropout ? make_feature_noise(input) : at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Dropout.cpp:54:84: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto noise = feature_dropout ? make_feature_noise(input) : at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Dropout.cpp:54:84: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto noise = feature_dropout ? make_feature_noise(input) : at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/Dropout.cpp: In instantiation of ‘at::native::{anonymous}::Ctype<inplace> at::native::{anonymous}::_dropout_impl(T&, double, bool) [with bool feature_dropout = true; bool alpha_dropout = true; bool inplace = false; T = const at::Tensor; at::native::{anonymous}::Ctype<inplace> = at::Tensor]’:
+../aten/src/ATen/native/Dropout.cpp:81:1:   required from ‘at::native::{anonymous}::Ctype<inplace> at::native::{anonymous}::_feature_alpha_dropout(Args&& ...) [with bool inplace = false; Args = {const at::Tensor&, double&, bool&}; at::native::{anonymous}::Ctype<inplace> = at::Tensor]’
+../aten/src/ATen/native/Dropout.cpp:122:55:   required from here
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Dropout.cpp:54:84: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto noise = feature_dropout ? make_feature_noise(input) : at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Dropout.cpp:54:84: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto noise = feature_dropout ? make_feature_noise(input) : at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Dropout.cpp:54:84: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto noise = feature_dropout ? make_feature_noise(input) : at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/Dropout.cpp: In instantiation of ‘at::native::{anonymous}::Ctype<inplace> at::native::{anonymous}::_dropout_impl(T&, double, bool) [with bool feature_dropout = true; bool alpha_dropout = true; bool inplace = true; T = at::Tensor; at::native::{anonymous}::Ctype<inplace> = at::Tensor&]’:
+../aten/src/ATen/native/Dropout.cpp:81:1:   required from ‘at::native::{anonymous}::Ctype<inplace> at::native::{anonymous}::_feature_alpha_dropout(Args&& ...) [with bool inplace = true; Args = {at::Tensor&, double&, bool&}; at::native::{anonymous}::Ctype<inplace> = at::Tensor&]’
+../aten/src/ATen/native/Dropout.cpp:126:54:   required from here
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Dropout.cpp:54:84: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto noise = feature_dropout ? make_feature_noise(input) : at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Dropout.cpp:54:84: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto noise = feature_dropout ? make_feature_noise(input) : at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Dropout.cpp:54:84: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto noise = feature_dropout ? make_feature_noise(input) : at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[1628/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/BatchLinearAlgebra.cpp.o
+In file included from aten/src/ATen/core/TensorBody.h:5:0,
+                 from ../aten/src/ATen/Tensor.h:11,
+                 from ../aten/src/ATen/Context.h:4,
+                 from ../aten/src/ATen/ATen.h:5,
+                 from ../aten/src/ATen/native/BatchLinearAlgebra.cpp:1:
+../aten/src/ATen/native/BatchLinearAlgebra.cpp: In function ‘at::Tensor at::native::inverse(const at::Tensor&)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/BatchLinearAlgebra.cpp:433:33: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     return at::empty_like(self, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/BatchLinearAlgebra.cpp:433:33: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     return at::empty_like(self, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/BatchLinearAlgebra.cpp: In function ‘at::Tensor at::native::cholesky(const at::Tensor&, bool)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/BatchLinearAlgebra.cpp:552:33: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     return at::empty_like(self, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/BatchLinearAlgebra.cpp:552:33: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     return at::empty_like(self, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/BatchLinearAlgebra.cpp: In function ‘std::tuple<at::Tensor, at::Tensor, at::Tensor> at::native::_lu_with_info_cpu(const at::Tensor&, bool, bool)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/BatchLinearAlgebra.cpp:613:46: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     self_working_copy = at::empty_like(self, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/BatchLinearAlgebra.cpp:613:46: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     self_working_copy = at::empty_like(self, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/BatchLinearAlgebra.cpp: In function ‘std::tuple<at::Tensor, at::Tensor> at::native::_symeig_helper_cpu(const at::Tensor&, bool, bool)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/BatchLinearAlgebra.cpp:895:69: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     return std::tuple<Tensor, Tensor>(eigvals, at::empty_like(self, LEGACY_CONTIGUOUS_MEMORY_FORMAT));
+                                                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/BatchLinearAlgebra.cpp:895:69: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     return std::tuple<Tensor, Tensor>(eigvals, at::empty_like(self, LEGACY_CONTIGUOUS_MEMORY_FORMAT));
+                                                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/BatchLinearAlgebra.cpp: In function ‘at::Tensor at::native::_lu_solve_helper_cpu(const at::Tensor&, const at::Tensor&, const at::Tensor&)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/BatchLinearAlgebra.cpp:1094:33: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     return at::zeros_like(self, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/BatchLinearAlgebra.cpp:1094:33: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     return at::zeros_like(self, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[1629/2582] Building CXX object third_party/fbgemm/CMakeFiles/fbgemm_avx2.dir/src/FbgemmI8Depthwise3DAvx2.cc.o
+[1630/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/ConvolutionMM2d.cpp.o
+[1631/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/Distance.cpp.o
+In file included from aten/src/ATen/core/TensorBody.h:5:0,
+                 from ../aten/src/ATen/Tensor.h:11,
+                 from ../aten/src/ATen/Context.h:4,
+                 from ../aten/src/ATen/ATen.h:5,
+                 from ../aten/src/ATen/native/Distance.cpp:1:
+../aten/src/ATen/native/Distance.cpp: In function ‘at::Tensor at::native::euclidean_dist_out(const at::Tensor&, const at::Tensor&)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/Distance.cpp:30:42: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor x1_pad = at::ones_like(x1_norm, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/Distance.cpp:30:42: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor x1_pad = at::ones_like(x1_norm, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/Distance.cpp:32:42: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor x2_pad = at::ones_like(x2_norm, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/Distance.cpp:32:42: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor x2_pad = at::ones_like(x2_norm, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/Distance.cpp: In function ‘at::Tensor at::native::_cdist_backward(const at::Tensor&, const at::Tensor&, const at::Tensor&, double, const at::Tensor&)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/Distance.cpp:132:53: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor grad_x1 = at::empty_like(x1, x1.options(), LEGACY_CONTIGUOUS_MEMORY_FORMAT).view({batch_product, n, m});
+                                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/Distance.cpp:132:53: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor grad_x1 = at::empty_like(x1, x1.options(), LEGACY_CONTIGUOUS_MEMORY_FORMAT).view({batch_product, n, m});
+                                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/Distance.cpp: In function ‘at::Tensor at::native::_pdist_forward(const at::Tensor&, double)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/Distance.cpp:141:50: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor result = at::empty({0}, self.options(), LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/Distance.cpp:141:50: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor result = at::empty({0}, self.options(), LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/Distance.cpp: In function ‘at::Tensor at::native::_pdist_backward(const at::Tensor&, const at::Tensor&, double, const at::Tensor&)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/Distance.cpp:162:40: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor result = at::empty_like(self, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/Distance.cpp:162:40: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor result = at::empty_like(self, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[1632/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/Copy.cpp.o
+[1633/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/Im2Col.cpp.o
+In file included from aten/src/ATen/core/TensorBody.h:5:0,
+                 from ../aten/src/ATen/Tensor.h:11,
+                 from ../aten/src/ATen/Context.h:4,
+                 from ../aten/src/ATen/ATen.h:5,
+                 from ../aten/src/ATen/native/Im2Col.cpp:1:
+../aten/src/ATen/native/Im2Col.cpp: In function ‘at::Tensor at::native::im2col_cpu(const at::Tensor&, c10::IntArrayRef, c10::IntArrayRef, c10::IntArrayRef, c10::IntArrayRef)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/Im2Col.cpp:166:41: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor output = at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/Im2Col.cpp:166:41: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor output = at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/Im2Col.cpp: In function ‘at::Tensor at::native::im2col_backward_cpu(const at::Tensor&, c10::IntArrayRef, c10::IntArrayRef, c10::IntArrayRef, c10::IntArrayRef, c10::IntArrayRef)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/Im2Col.cpp:199:51: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor grad_input = at::empty_like(grad_output, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/Im2Col.cpp:199:51: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor grad_input = at::empty_like(grad_output, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[1634/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/DilatedMaxPool3d.cpp.o
+In file included from aten/src/ATen/core/TensorBody.h:5:0,
+                 from ../aten/src/ATen/Tensor.h:11,
+                 from ../aten/src/ATen/Context.h:4,
+                 from ../aten/src/ATen/ATen.h:5,
+                 from ../aten/src/ATen/native/DilatedMaxPool3d.cpp:1:
+../aten/src/ATen/native/DilatedMaxPool3d.cpp: In function ‘at::Tensor at::native::max_pool3d_with_indices_backward_cpu(const at::Tensor&, const at::Tensor&, c10::IntArrayRef, c10::IntArrayRef, c10::IntArrayRef, c10::IntArrayRef, bool, const at::Tensor&)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/DilatedMaxPool3d.cpp:550:42: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto gradInput = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/DilatedMaxPool3d.cpp:550:42: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto gradInput = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[1635/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/LegacyDefinitions.cpp.o
+[1636/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/FractionalMaxPool2d.cpp.o
+[1637/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/FractionalMaxPool3d.cpp.o
+[1638/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/Itertools.cpp.o
+[1639/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/Lerp.cpp.o
+[1640/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/Integration.cpp.o
+[1641/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/LegacyNNDefinitions.cpp.o
+[1642/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/Memory.cpp.o
+[1643/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/GridSampler.cpp.o
+In file included from aten/src/ATen/core/TensorBody.h:5:0,
+                 from ../aten/src/ATen/Tensor.h:11,
+                 from ../aten/src/ATen/Context.h:4,
+                 from ../aten/src/ATen/ATen.h:5,
+                 from ../aten/src/ATen/native/GridSampler.h:3,
+                 from ../aten/src/ATen/native/GridSampler.cpp:1:
+../aten/src/ATen/native/GridSampler.cpp: In function ‘std::tuple<at::Tensor, at::Tensor> at::native::{anonymous}::grid_sampler_3d_backward_cpu_impl(const at::Tensor&, const at::Tensor&, const at::Tensor&, at::native::detail::GridSamplerInterpolation, at::native::detail::GridSamplerPadding, bool)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/GridSampler.cpp:179:45: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     auto grad_input = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                             ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/GridSampler.cpp:180:43: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     auto grad_grid = at::empty_like(grid, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                           ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/GridSampler.cpp: In instantiation of ‘std::tuple<at::Tensor, at::Tensor> at::native::{anonymous}::grid_sampler_3d_backward_cpu_impl(const at::Tensor&, const at::Tensor&, const at::Tensor&, at::native::detail::GridSamplerInterpolation, at::native::detail::GridSamplerPadding, bool) [with scalar_t = double]’:
+../aten/src/ATen/native/GridSampler.cpp:421:10:   required from here
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/GridSampler.cpp:179:45: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     auto grad_input = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                             ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/GridSampler.cpp:179:45: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     auto grad_input = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                             ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/GridSampler.cpp:179:45: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     auto grad_input = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                             ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/GridSampler.cpp:180:43: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     auto grad_grid = at::empty_like(grid, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                           ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/GridSampler.cpp:180:43: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     auto grad_grid = at::empty_like(grid, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                           ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/GridSampler.cpp:180:43: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     auto grad_grid = at::empty_like(grid, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                           ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/GridSampler.cpp: In instantiation of ‘std::tuple<at::Tensor, at::Tensor> at::native::{anonymous}::grid_sampler_3d_backward_cpu_impl(const at::Tensor&, const at::Tensor&, const at::Tensor&, at::native::detail::GridSamplerInterpolation, at::native::detail::GridSamplerPadding, bool) [with scalar_t = float]’:
+../aten/src/ATen/native/GridSampler.cpp:421:10:   required from here
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/GridSampler.cpp:179:45: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     auto grad_input = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                             ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/GridSampler.cpp:179:45: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     auto grad_input = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                             ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/GridSampler.cpp:179:45: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     auto grad_input = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                             ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/GridSampler.cpp:180:43: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     auto grad_grid = at::empty_like(grid, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                           ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/GridSampler.cpp:180:43: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     auto grad_grid = at::empty_like(grid, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                           ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/GridSampler.cpp:180:43: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     auto grad_grid = at::empty_like(grid, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                           ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[1644/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/Linear.cpp.o
+[1645/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/Distributions.cpp.o
+In file included from aten/src/ATen/core/TensorBody.h:5:0,
+                 from ../aten/src/ATen/Tensor.h:11,
+                 from ../aten/src/ATen/Context.h:4,
+                 from ../aten/src/ATen/ATen.h:5,
+                 from ../aten/src/ATen/native/Distributions.cpp:1:
+../aten/src/ATen/native/Distributions.cpp: In function ‘at::Tensor at::native::bernoulli(const at::Tensor&, at::Generator*)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/Distributions.cpp:115:31: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   return at::empty_like(self, LEGACY_CONTIGUOUS_MEMORY_FORMAT).bernoulli_(self, gen);
+                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/Distributions.cpp:115:31: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   return at::empty_like(self, LEGACY_CONTIGUOUS_MEMORY_FORMAT).bernoulli_(self, gen);
+                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/Distributions.cpp: In function ‘at::Tensor at::native::bernoulli(const at::Tensor&, double, at::Generator*)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/Distributions.cpp:119:31: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   return at::empty_like(self, LEGACY_CONTIGUOUS_MEMORY_FORMAT).bernoulli_(p, gen);
+                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/Distributions.cpp:119:31: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   return at::empty_like(self, LEGACY_CONTIGUOUS_MEMORY_FORMAT).bernoulli_(p, gen);
+                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[1646/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/PixelShuffle.cpp.o
+[1647/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/LossMultiMargin.cpp.o
+[1648/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/LossMultiLabelMargin.cpp.o
+In file included from aten/src/ATen/core/TensorBody.h:5:0,
+                 from ../aten/src/ATen/Tensor.h:11,
+                 from ../aten/src/ATen/Context.h:4,
+                 from ../aten/src/ATen/ATen.h:5,
+                 from ../aten/src/ATen/native/LossMultiLabelMargin.cpp:1:
+../aten/src/ATen/native/LossMultiLabelMargin.cpp: In function ‘at::Tensor at::native::multilabel_margin_loss_backward_cpu(const at::Tensor&, const at::Tensor&, const at::Tensor&, int64_t, const at::Tensor&)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/LossMultiLabelMargin.cpp:338:42: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto grad_input = at::zeros_like(self, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/LossMultiLabelMargin.cpp:338:42: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto grad_input = at::zeros_like(self, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[1649/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/LossNLL2d.cpp.o
+[1650/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/EmbeddingBag.cpp.o
+In file included from aten/src/ATen/core/TensorBody.h:5:0,
+                 from ../aten/src/ATen/Tensor.h:11,
+                 from ../aten/src/ATen/Context.h:4,
+                 from ../aten/src/ATen/ATen.h:5,
+                 from ../aten/src/ATen/native/EmbeddingBag.cpp:1:
+../aten/src/ATen/native/EmbeddingBag.cpp: In function ‘void at::native::make_offset2bag(const at::Tensor&, const at::Tensor&, at::Tensor&)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/EmbeddingBag.cpp:29:42: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+       0, offsets, at::ones_like(offsets, LEGACY_CONTIGUOUS_MEMORY_FORMAT)); // offset2bag = [1 0 1 0 1]
+                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/EmbeddingBag.cpp:29:42: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+       0, offsets, at::ones_like(offsets, LEGACY_CONTIGUOUS_MEMORY_FORMAT)); // offset2bag = [1 0 1 0 1]
+                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/EmbeddingBag.cpp: In function ‘at::Tensor at::native::apply_bag_size(const at::Tensor&, const at::Tensor&, int64_t, at::Tensor&, const at::Tensor&)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/EmbeddingBag.cpp:229:66: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+       auto bag_size_ = at::max(bag_size, at::ones_like(bag_size, LEGACY_CONTIGUOUS_MEMORY_FORMAT))
+                                                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/EmbeddingBag.cpp:229:66: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+       auto bag_size_ = at::max(bag_size, at::ones_like(bag_size, LEGACY_CONTIGUOUS_MEMORY_FORMAT))
+                                                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[1651/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/NNPACK.cpp.o
+[1652/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/LossNLL.cpp.o
+In file included from aten/src/ATen/core/TensorBody.h:5:0,
+                 from ../aten/src/ATen/Tensor.h:11,
+                 from ../aten/src/ATen/Context.h:4,
+                 from ../aten/src/ATen/ATen.h:5,
+                 from ../aten/src/ATen/native/LossNLL.cpp:1:
+../aten/src/ATen/native/LossNLL.cpp: In function ‘at::Tensor at::native::nll_loss_backward_cpu(const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, int64_t, int64_t, const at::Tensor&)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/LossNLL.cpp:383:42: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto grad_input = at::zeros_like(self, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/LossNLL.cpp:383:42: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto grad_input = at::zeros_like(self, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[1653/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/MaxUnpooling.cpp.o
+In file included from aten/src/ATen/core/TensorBody.h:5:0,
+                 from ../aten/src/ATen/Tensor.h:11,
+                 from ../aten/src/ATen/Context.h:4,
+                 from ../aten/src/ATen/ATen.h:5,
+                 from ../aten/src/ATen/native/MaxUnpooling.cpp:1:
+../aten/src/ATen/native/MaxUnpooling.cpp: In function ‘at::Tensor at::native::max_unpooling2d_backward_cpu(const at::Tensor&, const at::Tensor&, const at::Tensor&, c10::IntArrayRef)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/MaxUnpooling.cpp:469:42: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto grad_input = at::empty_like(self, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/MaxUnpooling.cpp:469:42: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto grad_input = at::empty_like(self, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/MaxUnpooling.cpp: In function ‘at::Tensor at::native::max_unpooling3d_backward_cpu(const at::Tensor&, const at::Tensor&, const at::Tensor&, c10::IntArrayRef, c10::IntArrayRef, c10::IntArrayRef)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/MaxUnpooling.cpp:603:42: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto grad_input = at::empty_like(self, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/MaxUnpooling.cpp:603:42: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto grad_input = at::empty_like(self, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[1654/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/NamedTensor.cpp.o
+[1655/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/NaiveConvolutionTranspose3d.cpp.o
+In file included from aten/src/ATen/core/TensorBody.h:5:0,
+                 from ../aten/src/ATen/Tensor.h:11,
+                 from ../aten/src/ATen/Context.h:4,
+                 from ../aten/src/ATen/ATen.h:5,
+                 from ../aten/src/ATen/native/NaiveConvolutionTranspose3d.cpp:1:
+../aten/src/ATen/native/NaiveConvolutionTranspose3d.cpp: In function ‘at::Tensor& at::native::slow_conv_transpose3d_out_cpu(at::Tensor&, const at::Tensor&, const at::Tensor&, c10::IntArrayRef, const at::Tensor&, c10::IntArrayRef, c10::IntArrayRef, c10::IntArrayRef, c10::IntArrayRef)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/NaiveConvolutionTranspose3d.cpp:851:41: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor finput = at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/NaiveConvolutionTranspose3d.cpp:851:41: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor finput = at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/NaiveConvolutionTranspose3d.cpp:852:40: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor fgrad = at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/NaiveConvolutionTranspose3d.cpp:852:40: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor fgrad = at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/NaiveConvolutionTranspose3d.cpp: In function ‘at::Tensor at::native::slow_conv_transpose3d_cpu(const at::Tensor&, const at::Tensor&, c10::IntArrayRef, const at::Tensor&, c10::IntArrayRef, c10::IntArrayRef, c10::IntArrayRef, c10::IntArrayRef)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/NaiveConvolutionTranspose3d.cpp:879:41: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor output = at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/NaiveConvolutionTranspose3d.cpp:879:41: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor output = at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/NaiveConvolutionTranspose3d.cpp:880:41: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor finput = at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/NaiveConvolutionTranspose3d.cpp:880:41: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor finput = at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/NaiveConvolutionTranspose3d.cpp:881:40: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor fgrad = at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/NaiveConvolutionTranspose3d.cpp:881:40: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor fgrad = at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[1656/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/NaiveConvolutionTranspose2d.cpp.o
+In file included from aten/src/ATen/core/TensorBody.h:5:0,
+                 from ../aten/src/ATen/Tensor.h:11,
+                 from ../aten/src/ATen/Context.h:4,
+                 from ../aten/src/ATen/ATen.h:5,
+                 from ../aten/src/ATen/native/NaiveConvolutionTranspose2d.cpp:1:
+../aten/src/ATen/native/NaiveConvolutionTranspose2d.cpp: In function ‘at::Tensor& at::native::slow_conv_transpose2d_out_cpu(at::Tensor&, const at::Tensor&, const at::Tensor&, c10::IntArrayRef, const at::Tensor&, c10::IntArrayRef, c10::IntArrayRef, c10::IntArrayRef, c10::IntArrayRef)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/NaiveConvolutionTranspose2d.cpp:730:42: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor columns = at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/NaiveConvolutionTranspose2d.cpp:730:42: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor columns = at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/NaiveConvolutionTranspose2d.cpp:731:39: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor ones = at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/NaiveConvolutionTranspose2d.cpp:731:39: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor ones = at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/NaiveConvolutionTranspose2d.cpp: In function ‘at::Tensor at::native::slow_conv_transpose2d_cpu(const at::Tensor&, const at::Tensor&, c10::IntArrayRef, const at::Tensor&, c10::IntArrayRef, c10::IntArrayRef, c10::IntArrayRef, c10::IntArrayRef)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/NaiveConvolutionTranspose2d.cpp:758:41: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor output = at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/NaiveConvolutionTranspose2d.cpp:758:41: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor output = at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/NaiveConvolutionTranspose2d.cpp:759:42: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor columns = at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/NaiveConvolutionTranspose2d.cpp:759:42: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor columns = at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/NaiveConvolutionTranspose2d.cpp:760:39: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor ones = at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/NaiveConvolutionTranspose2d.cpp:760:39: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor ones = at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[1657/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/Loss.cpp.o
+In file included from aten/src/ATen/core/TensorBody.h:5:0,
+                 from ../aten/src/ATen/Tensor.h:11,
+                 from ../aten/src/ATen/Context.h:4,
+                 from ../aten/src/ATen/ATen.h:5,
+                 from ../aten/src/ATen/native/Loss.cpp:6:
+../aten/src/ATen/native/Loss.cpp: In function ‘at::Tensor at::native::cosine_embedding_loss(const at::Tensor&, const at::Tensor&, const at::Tensor&, double, int64_t)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/Loss.cpp:44:36: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto zeros = at::zeros_like(cos, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/Loss.cpp:44:36: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto zeros = at::zeros_like(cos, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/Loss.cpp: In function ‘at::Tensor at::native::hinge_embedding_loss(const at::Tensor&, const at::Tensor&, double, int64_t)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/Loss.cpp:54:37: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto zeros = at::zeros_like(self, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/Loss.cpp:54:37: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto zeros = at::zeros_like(self, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/Loss.cpp: In function ‘at::Tensor at::native::kl_div(const at::Tensor&, const at::Tensor&, int64_t)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/Loss.cpp:81:43: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto zeros = at::zeros_like(output_pos, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/Loss.cpp:81:43: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto zeros = at::zeros_like(output_pos, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/Loss.cpp: In function ‘at::Tensor at::native::kl_div_backward_cpu(const at::Tensor&, const at::Tensor&, const at::Tensor&, int64_t)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/Loss.cpp:87:43: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto grad_input = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/Loss.cpp:87:43: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto grad_input = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/Loss.cpp: In function ‘at::Tensor at::native::smooth_l1_loss_backward(const at::Tensor&, const at::Tensor&, const at::Tensor&, int64_t)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/Loss.cpp:193:43: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto grad_input = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/Loss.cpp:193:43: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto grad_input = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/Loss.cpp: In function ‘at::Tensor at::native::mse_loss_backward(const at::Tensor&, const at::Tensor&, const at::Tensor&, int64_t)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/Loss.cpp:222:45: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor grad_input = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/Loss.cpp:222:45: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor grad_input = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/Loss.cpp: In function ‘at::Tensor at::native::l1_loss_backward(const at::Tensor&, const at::Tensor&, const at::Tensor&, int64_t)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/Loss.cpp:260:45: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor grad_input = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/Loss.cpp:260:45: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor grad_input = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[1658/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/PackedSequence.cpp.o
+[1659/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/Onehot.cpp.o
+[1660/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/Indexing.cpp.o
+In file included from ../aten/src/ATen/ATen.h:9:0,
+                 from ../aten/src/ATen/native/Indexing.h:5,
+                 from ../aten/src/ATen/native/Indexing.cpp:51:
+../aten/src/ATen/native/Indexing.cpp: In lambda function:
+../aten/src/ATen/native/Indexing.cpp:373:49: warning: ‘T* at::Tensor::data() const [with T = unsigned char]’ is deprecated: Tensor.data<T>() is deprecated. Please use Tensor.data_ptr<T>() instead. [-Wdeprecated-declarations]
+         scalar_t *self_ip = self.data<scalar_t>() + self_i * self_stride;
+                                                 ^
+../aten/src/ATen/Dispatch.h:12:12: note: in definition of macro ‘AT_PRIVATE_CASE_TYPE’
+     return __VA_ARGS__();                          \
+            ^~~~~~~~~~~
+../aten/src/ATen/native/Indexing.cpp:367:5: note: in expansion of macro ‘AT_DISPATCH_ALL_TYPES’
+     AT_DISPATCH_ALL_TYPES(self.scalar_type(), "index_add_", [&] {
+     ^~~~~~~~~~~~~~~~~~~~~
+In file included from ../aten/src/ATen/Tensor.h:11:0,
+                 from ../aten/src/ATen/Context.h:4,
+                 from ../aten/src/ATen/ATen.h:5,
+                 from ../aten/src/ATen/native/Indexing.h:5,
+                 from ../aten/src/ATen/native/Indexing.cpp:51:
+aten/src/ATen/core/TensorBody.h:323:7: note: declared here
+   T * data() const {
+       ^~~~
+In file included from ../aten/src/ATen/ATen.h:9:0,
+                 from ../aten/src/ATen/native/Indexing.h:5,
+                 from ../aten/src/ATen/native/Indexing.cpp:51:
+../aten/src/ATen/native/Indexing.cpp:374:45: warning: ‘T* at::Tensor::data() const [with T = unsigned char]’ is deprecated: Tensor.data<T>() is deprecated. Please use Tensor.data_ptr<T>() instead. [-Wdeprecated-declarations]
+         *self_ip += *(source.data<scalar_t>() + i * source_stride);
+                                             ^
+../aten/src/ATen/Dispatch.h:12:12: note: in definition of macro ‘AT_PRIVATE_CASE_TYPE’
+     return __VA_ARGS__();                          \
+            ^~~~~~~~~~~
+../aten/src/ATen/native/Indexing.cpp:367:5: note: in expansion of macro ‘AT_DISPATCH_ALL_TYPES’
+     AT_DISPATCH_ALL_TYPES(self.scalar_type(), "index_add_", [&] {
+     ^~~~~~~~~~~~~~~~~~~~~
+In file included from ../aten/src/ATen/Tensor.h:11:0,
+                 from ../aten/src/ATen/Context.h:4,
+                 from ../aten/src/ATen/ATen.h:5,
+                 from ../aten/src/ATen/native/Indexing.h:5,
+                 from ../aten/src/ATen/native/Indexing.cpp:51:
+aten/src/ATen/core/TensorBody.h:323:7: note: declared here
+   T * data() const {
+       ^~~~
+In file included from ../aten/src/ATen/ATen.h:9:0,
+                 from ../aten/src/ATen/native/Indexing.h:5,
+                 from ../aten/src/ATen/native/Indexing.cpp:51:
+../aten/src/ATen/native/Indexing.cpp: In lambda function:
+../aten/src/ATen/native/Indexing.cpp:373:49: warning: ‘T* at::Tensor::data() const [with T = signed char]’ is deprecated: Tensor.data<T>() is deprecated. Please use Tensor.data_ptr<T>() instead. [-Wdeprecated-declarations]
+         scalar_t *self_ip = self.data<scalar_t>() + self_i * self_stride;
+                                                 ^
+../aten/src/ATen/Dispatch.h:12:12: note: in definition of macro ‘AT_PRIVATE_CASE_TYPE’
+     return __VA_ARGS__();                          \
+            ^~~~~~~~~~~
+../aten/src/ATen/native/Indexing.cpp:367:5: note: in expansion of macro ‘AT_DISPATCH_ALL_TYPES’
+     AT_DISPATCH_ALL_TYPES(self.scalar_type(), "index_add_", [&] {
+     ^~~~~~~~~~~~~~~~~~~~~
+In file included from ../aten/src/ATen/Tensor.h:11:0,
+                 from ../aten/src/ATen/Context.h:4,
+                 from ../aten/src/ATen/ATen.h:5,
+                 from ../aten/src/ATen/native/Indexing.h:5,
+                 from ../aten/src/ATen/native/Indexing.cpp:51:
+aten/src/ATen/core/TensorBody.h:323:7: note: declared here
+   T * data() const {
+       ^~~~
+In file included from ../aten/src/ATen/ATen.h:9:0,
+                 from ../aten/src/ATen/native/Indexing.h:5,
+                 from ../aten/src/ATen/native/Indexing.cpp:51:
+../aten/src/ATen/native/Indexing.cpp:374:45: warning: ‘T* at::Tensor::data() const [with T = signed char]’ is deprecated: Tensor.data<T>() is deprecated. Please use Tensor.data_ptr<T>() instead. [-Wdeprecated-declarations]
+         *self_ip += *(source.data<scalar_t>() + i * source_stride);
+                                             ^
+../aten/src/ATen/Dispatch.h:12:12: note: in definition of macro ‘AT_PRIVATE_CASE_TYPE’
+     return __VA_ARGS__();                          \
+            ^~~~~~~~~~~
+../aten/src/ATen/native/Indexing.cpp:367:5: note: in expansion of macro ‘AT_DISPATCH_ALL_TYPES’
+     AT_DISPATCH_ALL_TYPES(self.scalar_type(), "index_add_", [&] {
+     ^~~~~~~~~~~~~~~~~~~~~
+In file included from ../aten/src/ATen/Tensor.h:11:0,
+                 from ../aten/src/ATen/Context.h:4,
+                 from ../aten/src/ATen/ATen.h:5,
+                 from ../aten/src/ATen/native/Indexing.h:5,
+                 from ../aten/src/ATen/native/Indexing.cpp:51:
+aten/src/ATen/core/TensorBody.h:323:7: note: declared here
+   T * data() const {
+       ^~~~
+In file included from ../aten/src/ATen/ATen.h:9:0,
+                 from ../aten/src/ATen/native/Indexing.h:5,
+                 from ../aten/src/ATen/native/Indexing.cpp:51:
+../aten/src/ATen/native/Indexing.cpp: In lambda function:
+../aten/src/ATen/native/Indexing.cpp:373:49: warning: ‘T* at::Tensor::data() const [with T = double]’ is deprecated: Tensor.data<T>() is deprecated. Please use Tensor.data_ptr<T>() instead. [-Wdeprecated-declarations]
+         scalar_t *self_ip = self.data<scalar_t>() + self_i * self_stride;
+                                                 ^
+../aten/src/ATen/Dispatch.h:12:12: note: in definition of macro ‘AT_PRIVATE_CASE_TYPE’
+     return __VA_ARGS__();                          \
+            ^~~~~~~~~~~
+../aten/src/ATen/native/Indexing.cpp:367:5: note: in expansion of macro ‘AT_DISPATCH_ALL_TYPES’
+     AT_DISPATCH_ALL_TYPES(self.scalar_type(), "index_add_", [&] {
+     ^~~~~~~~~~~~~~~~~~~~~
+In file included from ../aten/src/ATen/Tensor.h:11:0,
+                 from ../aten/src/ATen/Context.h:4,
+                 from ../aten/src/ATen/ATen.h:5,
+                 from ../aten/src/ATen/native/Indexing.h:5,
+                 from ../aten/src/ATen/native/Indexing.cpp:51:
+aten/src/ATen/core/TensorBody.h:323:7: note: declared here
+   T * data() const {
+       ^~~~
+In file included from ../aten/src/ATen/ATen.h:9:0,
+                 from ../aten/src/ATen/native/Indexing.h:5,
+                 from ../aten/src/ATen/native/Indexing.cpp:51:
+../aten/src/ATen/native/Indexing.cpp:374:45: warning: ‘T* at::Tensor::data() const [with T = double]’ is deprecated: Tensor.data<T>() is deprecated. Please use Tensor.data_ptr<T>() instead. [-Wdeprecated-declarations]
+         *self_ip += *(source.data<scalar_t>() + i * source_stride);
+                                             ^
+../aten/src/ATen/Dispatch.h:12:12: note: in definition of macro ‘AT_PRIVATE_CASE_TYPE’
+     return __VA_ARGS__();                          \
+            ^~~~~~~~~~~
+../aten/src/ATen/native/Indexing.cpp:367:5: note: in expansion of macro ‘AT_DISPATCH_ALL_TYPES’
+     AT_DISPATCH_ALL_TYPES(self.scalar_type(), "index_add_", [&] {
+     ^~~~~~~~~~~~~~~~~~~~~
+In file included from ../aten/src/ATen/Tensor.h:11:0,
+                 from ../aten/src/ATen/Context.h:4,
+                 from ../aten/src/ATen/ATen.h:5,
+                 from ../aten/src/ATen/native/Indexing.h:5,
+                 from ../aten/src/ATen/native/Indexing.cpp:51:
+aten/src/ATen/core/TensorBody.h:323:7: note: declared here
+   T * data() const {
+       ^~~~
+In file included from ../aten/src/ATen/ATen.h:9:0,
+                 from ../aten/src/ATen/native/Indexing.h:5,
+                 from ../aten/src/ATen/native/Indexing.cpp:51:
+../aten/src/ATen/native/Indexing.cpp: In lambda function:
+../aten/src/ATen/native/Indexing.cpp:373:49: warning: ‘T* at::Tensor::data() const [with T = float]’ is deprecated: Tensor.data<T>() is deprecated. Please use Tensor.data_ptr<T>() instead. [-Wdeprecated-declarations]
+         scalar_t *self_ip = self.data<scalar_t>() + self_i * self_stride;
+                                                 ^
+../aten/src/ATen/Dispatch.h:12:12: note: in definition of macro ‘AT_PRIVATE_CASE_TYPE’
+     return __VA_ARGS__();                          \
+            ^~~~~~~~~~~
+../aten/src/ATen/native/Indexing.cpp:367:5: note: in expansion of macro ‘AT_DISPATCH_ALL_TYPES’
+     AT_DISPATCH_ALL_TYPES(self.scalar_type(), "index_add_", [&] {
+     ^~~~~~~~~~~~~~~~~~~~~
+In file included from ../aten/src/ATen/Tensor.h:11:0,
+                 from ../aten/src/ATen/Context.h:4,
+                 from ../aten/src/ATen/ATen.h:5,
+                 from ../aten/src/ATen/native/Indexing.h:5,
+                 from ../aten/src/ATen/native/Indexing.cpp:51:
+aten/src/ATen/core/TensorBody.h:323:7: note: declared here
+   T * data() const {
+       ^~~~
+In file included from ../aten/src/ATen/ATen.h:9:0,
+                 from ../aten/src/ATen/native/Indexing.h:5,
+                 from ../aten/src/ATen/native/Indexing.cpp:51:
+../aten/src/ATen/native/Indexing.cpp:374:45: warning: ‘T* at::Tensor::data() const [with T = float]’ is deprecated: Tensor.data<T>() is deprecated. Please use Tensor.data_ptr<T>() instead. [-Wdeprecated-declarations]
+         *self_ip += *(source.data<scalar_t>() + i * source_stride);
+                                             ^
+../aten/src/ATen/Dispatch.h:12:12: note: in definition of macro ‘AT_PRIVATE_CASE_TYPE’
+     return __VA_ARGS__();                          \
+            ^~~~~~~~~~~
+../aten/src/ATen/native/Indexing.cpp:367:5: note: in expansion of macro ‘AT_DISPATCH_ALL_TYPES’
+     AT_DISPATCH_ALL_TYPES(self.scalar_type(), "index_add_", [&] {
+     ^~~~~~~~~~~~~~~~~~~~~
+In file included from ../aten/src/ATen/Tensor.h:11:0,
+                 from ../aten/src/ATen/Context.h:4,
+                 from ../aten/src/ATen/ATen.h:5,
+                 from ../aten/src/ATen/native/Indexing.h:5,
+                 from ../aten/src/ATen/native/Indexing.cpp:51:
+aten/src/ATen/core/TensorBody.h:323:7: note: declared here
+   T * data() const {
+       ^~~~
+In file included from ../aten/src/ATen/ATen.h:9:0,
+                 from ../aten/src/ATen/native/Indexing.h:5,
+                 from ../aten/src/ATen/native/Indexing.cpp:51:
+../aten/src/ATen/native/Indexing.cpp: In lambda function:
+../aten/src/ATen/native/Indexing.cpp:373:49: warning: ‘T* at::Tensor::data() const [with T = int]’ is deprecated: Tensor.data<T>() is deprecated. Please use Tensor.data_ptr<T>() instead. [-Wdeprecated-declarations]
+         scalar_t *self_ip = self.data<scalar_t>() + self_i * self_stride;
+                                                 ^
+../aten/src/ATen/Dispatch.h:12:12: note: in definition of macro ‘AT_PRIVATE_CASE_TYPE’
+     return __VA_ARGS__();                          \
+            ^~~~~~~~~~~
+../aten/src/ATen/native/Indexing.cpp:367:5: note: in expansion of macro ‘AT_DISPATCH_ALL_TYPES’
+     AT_DISPATCH_ALL_TYPES(self.scalar_type(), "index_add_", [&] {
+     ^~~~~~~~~~~~~~~~~~~~~
+In file included from ../aten/src/ATen/Tensor.h:11:0,
+                 from ../aten/src/ATen/Context.h:4,
+                 from ../aten/src/ATen/ATen.h:5,
+                 from ../aten/src/ATen/native/Indexing.h:5,
+                 from ../aten/src/ATen/native/Indexing.cpp:51:
+aten/src/ATen/core/TensorBody.h:323:7: note: declared here
+   T * data() const {
+       ^~~~
+In file included from ../aten/src/ATen/ATen.h:9:0,
+                 from ../aten/src/ATen/native/Indexing.h:5,
+                 from ../aten/src/ATen/native/Indexing.cpp:51:
+../aten/src/ATen/native/Indexing.cpp:374:45: warning: ‘T* at::Tensor::data() const [with T = int]’ is deprecated: Tensor.data<T>() is deprecated. Please use Tensor.data_ptr<T>() instead. [-Wdeprecated-declarations]
+         *self_ip += *(source.data<scalar_t>() + i * source_stride);
+                                             ^
+../aten/src/ATen/Dispatch.h:12:12: note: in definition of macro ‘AT_PRIVATE_CASE_TYPE’
+     return __VA_ARGS__();                          \
+            ^~~~~~~~~~~
+../aten/src/ATen/native/Indexing.cpp:367:5: note: in expansion of macro ‘AT_DISPATCH_ALL_TYPES’
+     AT_DISPATCH_ALL_TYPES(self.scalar_type(), "index_add_", [&] {
+     ^~~~~~~~~~~~~~~~~~~~~
+In file included from ../aten/src/ATen/Tensor.h:11:0,
+                 from ../aten/src/ATen/Context.h:4,
+                 from ../aten/src/ATen/ATen.h:5,
+                 from ../aten/src/ATen/native/Indexing.h:5,
+                 from ../aten/src/ATen/native/Indexing.cpp:51:
+aten/src/ATen/core/TensorBody.h:323:7: note: declared here
+   T * data() const {
+       ^~~~
+In file included from ../aten/src/ATen/ATen.h:9:0,
+                 from ../aten/src/ATen/native/Indexing.h:5,
+                 from ../aten/src/ATen/native/Indexing.cpp:51:
+../aten/src/ATen/native/Indexing.cpp: In lambda function:
+../aten/src/ATen/native/Indexing.cpp:373:49: warning: ‘T* at::Tensor::data() const [with T = long int]’ is deprecated: Tensor.data<T>() is deprecated. Please use Tensor.data_ptr<T>() instead. [-Wdeprecated-declarations]
+         scalar_t *self_ip = self.data<scalar_t>() + self_i * self_stride;
+                                                 ^
+../aten/src/ATen/Dispatch.h:12:12: note: in definition of macro ‘AT_PRIVATE_CASE_TYPE’
+     return __VA_ARGS__();                          \
+            ^~~~~~~~~~~
+../aten/src/ATen/native/Indexing.cpp:367:5: note: in expansion of macro ‘AT_DISPATCH_ALL_TYPES’
+     AT_DISPATCH_ALL_TYPES(self.scalar_type(), "index_add_", [&] {
+     ^~~~~~~~~~~~~~~~~~~~~
+In file included from ../aten/src/ATen/Tensor.h:11:0,
+                 from ../aten/src/ATen/Context.h:4,
+                 from ../aten/src/ATen/ATen.h:5,
+                 from ../aten/src/ATen/native/Indexing.h:5,
+                 from ../aten/src/ATen/native/Indexing.cpp:51:
+aten/src/ATen/core/TensorBody.h:323:7: note: declared here
+   T * data() const {
+       ^~~~
+In file included from ../aten/src/ATen/ATen.h:9:0,
+                 from ../aten/src/ATen/native/Indexing.h:5,
+                 from ../aten/src/ATen/native/Indexing.cpp:51:
+../aten/src/ATen/native/Indexing.cpp:374:45: warning: ‘T* at::Tensor::data() const [with T = long int]’ is deprecated: Tensor.data<T>() is deprecated. Please use Tensor.data_ptr<T>() instead. [-Wdeprecated-declarations]
+         *self_ip += *(source.data<scalar_t>() + i * source_stride);
+                                             ^
+../aten/src/ATen/Dispatch.h:12:12: note: in definition of macro ‘AT_PRIVATE_CASE_TYPE’
+     return __VA_ARGS__();                          \
+            ^~~~~~~~~~~
+../aten/src/ATen/native/Indexing.cpp:367:5: note: in expansion of macro ‘AT_DISPATCH_ALL_TYPES’
+     AT_DISPATCH_ALL_TYPES(self.scalar_type(), "index_add_", [&] {
+     ^~~~~~~~~~~~~~~~~~~~~
+In file included from ../aten/src/ATen/Tensor.h:11:0,
+                 from ../aten/src/ATen/Context.h:4,
+                 from ../aten/src/ATen/ATen.h:5,
+                 from ../aten/src/ATen/native/Indexing.h:5,
+                 from ../aten/src/ATen/native/Indexing.cpp:51:
+aten/src/ATen/core/TensorBody.h:323:7: note: declared here
+   T * data() const {
+       ^~~~
+In file included from ../aten/src/ATen/ATen.h:9:0,
+                 from ../aten/src/ATen/native/Indexing.h:5,
+                 from ../aten/src/ATen/native/Indexing.cpp:51:
+../aten/src/ATen/native/Indexing.cpp: In lambda function:
+../aten/src/ATen/native/Indexing.cpp:373:49: warning: ‘T* at::Tensor::data() const [with T = short int]’ is deprecated: Tensor.data<T>() is deprecated. Please use Tensor.data_ptr<T>() instead. [-Wdeprecated-declarations]
+         scalar_t *self_ip = self.data<scalar_t>() + self_i * self_stride;
+                                                 ^
+../aten/src/ATen/Dispatch.h:12:12: note: in definition of macro ‘AT_PRIVATE_CASE_TYPE’
+     return __VA_ARGS__();                          \
+            ^~~~~~~~~~~
+../aten/src/ATen/native/Indexing.cpp:367:5: note: in expansion of macro ‘AT_DISPATCH_ALL_TYPES’
+     AT_DISPATCH_ALL_TYPES(self.scalar_type(), "index_add_", [&] {
+     ^~~~~~~~~~~~~~~~~~~~~
+In file included from ../aten/src/ATen/Tensor.h:11:0,
+                 from ../aten/src/ATen/Context.h:4,
+                 from ../aten/src/ATen/ATen.h:5,
+                 from ../aten/src/ATen/native/Indexing.h:5,
+                 from ../aten/src/ATen/native/Indexing.cpp:51:
+aten/src/ATen/core/TensorBody.h:323:7: note: declared here
+   T * data() const {
+       ^~~~
+In file included from ../aten/src/ATen/ATen.h:9:0,
+                 from ../aten/src/ATen/native/Indexing.h:5,
+                 from ../aten/src/ATen/native/Indexing.cpp:51:
+../aten/src/ATen/native/Indexing.cpp:374:45: warning: ‘T* at::Tensor::data() const [with T = short int]’ is deprecated: Tensor.data<T>() is deprecated. Please use Tensor.data_ptr<T>() instead. [-Wdeprecated-declarations]
+         *self_ip += *(source.data<scalar_t>() + i * source_stride);
+                                             ^
+../aten/src/ATen/Dispatch.h:12:12: note: in definition of macro ‘AT_PRIVATE_CASE_TYPE’
+     return __VA_ARGS__();                          \
+            ^~~~~~~~~~~
+../aten/src/ATen/native/Indexing.cpp:367:5: note: in expansion of macro ‘AT_DISPATCH_ALL_TYPES’
+     AT_DISPATCH_ALL_TYPES(self.scalar_type(), "index_add_", [&] {
+     ^~~~~~~~~~~~~~~~~~~~~
+In file included from ../aten/src/ATen/Tensor.h:11:0,
+                 from ../aten/src/ATen/Context.h:4,
+                 from ../aten/src/ATen/ATen.h:5,
+                 from ../aten/src/ATen/native/Indexing.h:5,
+                 from ../aten/src/ATen/native/Indexing.cpp:51:
+aten/src/ATen/core/TensorBody.h:323:7: note: declared here
+   T * data() const {
+       ^~~~
+[1661/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/LossCTC.cpp.o
+In file included from aten/src/ATen/core/TensorBody.h:5:0,
+                 from ../aten/src/ATen/Tensor.h:11,
+                 from ../aten/src/ATen/Context.h:4,
+                 from ../aten/src/ATen/ATen.h:5,
+                 from ../aten/src/ATen/native/LossCTC.cpp:9:
+../aten/src/ATen/native/LossCTC.cpp: In function ‘at::Tensor at::native::{anonymous}::ctc_loss_backward_cpu_template(const at::Tensor&, const at::Tensor&, const at::Tensor&, c10::IntArrayRef, c10::IntArrayRef, const at::Tensor&, const at::Tensor&, int64_t, bool)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/LossCTC.cpp:178:50: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor grad = at::full_like(log_probs, neginf, LEGACY_CONTIGUOUS_MEMORY_FORMAT); // at this point, this is log of empty sum
+                                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/LossCTC.cpp:206:47: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor log_beta = at::empty_like(log_alpha, LEGACY_CONTIGUOUS_MEMORY_FORMAT);  // could be optimized to use only 2 rows
+                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/LossCTC.cpp: In instantiation of ‘at::Tensor at::native::{anonymous}::ctc_loss_backward_cpu_template(const at::Tensor&, const at::Tensor&, const at::Tensor&, c10::IntArrayRef, c10::IntArrayRef, const at::Tensor&, const at::Tensor&, int64_t, bool) [with scalar_t = double; c10::ScalarType target_scalar_type = (c10::ScalarType)4; c10::IntArrayRef = c10::ArrayRef<long int>; int64_t = long int]’:
+../aten/src/ATen/native/LossCTC.cpp:329:10:   required from here
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/LossCTC.cpp:178:50: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor grad = at::full_like(log_probs, neginf, LEGACY_CONTIGUOUS_MEMORY_FORMAT); // at this point, this is log of empty sum
+                                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/LossCTC.cpp:178:50: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor grad = at::full_like(log_probs, neginf, LEGACY_CONTIGUOUS_MEMORY_FORMAT); // at this point, this is log of empty sum
+                                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/LossCTC.cpp:178:50: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor grad = at::full_like(log_probs, neginf, LEGACY_CONTIGUOUS_MEMORY_FORMAT); // at this point, this is log of empty sum
+                                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/LossCTC.cpp:206:47: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor log_beta = at::empty_like(log_alpha, LEGACY_CONTIGUOUS_MEMORY_FORMAT);  // could be optimized to use only 2 rows
+                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/LossCTC.cpp:206:47: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor log_beta = at::empty_like(log_alpha, LEGACY_CONTIGUOUS_MEMORY_FORMAT);  // could be optimized to use only 2 rows
+                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/LossCTC.cpp:206:47: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor log_beta = at::empty_like(log_alpha, LEGACY_CONTIGUOUS_MEMORY_FORMAT);  // could be optimized to use only 2 rows
+                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/LossCTC.cpp: In instantiation of ‘at::Tensor at::native::{anonymous}::ctc_loss_backward_cpu_template(const at::Tensor&, const at::Tensor&, const at::Tensor&, c10::IntArrayRef, c10::IntArrayRef, const at::Tensor&, const at::Tensor&, int64_t, bool) [with scalar_t = double; c10::ScalarType target_scalar_type = (c10::ScalarType)3; c10::IntArrayRef = c10::ArrayRef<long int>; int64_t = long int]’:
+../aten/src/ATen/native/LossCTC.cpp:329:10:   required from here
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/LossCTC.cpp:178:50: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor grad = at::full_like(log_probs, neginf, LEGACY_CONTIGUOUS_MEMORY_FORMAT); // at this point, this is log of empty sum
+                                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/LossCTC.cpp:178:50: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor grad = at::full_like(log_probs, neginf, LEGACY_CONTIGUOUS_MEMORY_FORMAT); // at this point, this is log of empty sum
+                                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/LossCTC.cpp:178:50: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor grad = at::full_like(log_probs, neginf, LEGACY_CONTIGUOUS_MEMORY_FORMAT); // at this point, this is log of empty sum
+                                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/LossCTC.cpp:206:47: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor log_beta = at::empty_like(log_alpha, LEGACY_CONTIGUOUS_MEMORY_FORMAT);  // could be optimized to use only 2 rows
+                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/LossCTC.cpp:206:47: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor log_beta = at::empty_like(log_alpha, LEGACY_CONTIGUOUS_MEMORY_FORMAT);  // could be optimized to use only 2 rows
+                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/LossCTC.cpp:206:47: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor log_beta = at::empty_like(log_alpha, LEGACY_CONTIGUOUS_MEMORY_FORMAT);  // could be optimized to use only 2 rows
+                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/LossCTC.cpp: In instantiation of ‘at::Tensor at::native::{anonymous}::ctc_loss_backward_cpu_template(const at::Tensor&, const at::Tensor&, const at::Tensor&, c10::IntArrayRef, c10::IntArrayRef, const at::Tensor&, const at::Tensor&, int64_t, bool) [with scalar_t = float; c10::ScalarType target_scalar_type = (c10::ScalarType)4; c10::IntArrayRef = c10::ArrayRef<long int>; int64_t = long int]’:
+../aten/src/ATen/native/LossCTC.cpp:329:10:   required from here
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/LossCTC.cpp:178:50: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor grad = at::full_like(log_probs, neginf, LEGACY_CONTIGUOUS_MEMORY_FORMAT); // at this point, this is log of empty sum
+                                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/LossCTC.cpp:178:50: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor grad = at::full_like(log_probs, neginf, LEGACY_CONTIGUOUS_MEMORY_FORMAT); // at this point, this is log of empty sum
+                                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/LossCTC.cpp:178:50: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor grad = at::full_like(log_probs, neginf, LEGACY_CONTIGUOUS_MEMORY_FORMAT); // at this point, this is log of empty sum
+                                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/LossCTC.cpp:206:47: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor log_beta = at::empty_like(log_alpha, LEGACY_CONTIGUOUS_MEMORY_FORMAT);  // could be optimized to use only 2 rows
+                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/LossCTC.cpp:206:47: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor log_beta = at::empty_like(log_alpha, LEGACY_CONTIGUOUS_MEMORY_FORMAT);  // could be optimized to use only 2 rows
+                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/LossCTC.cpp:206:47: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor log_beta = at::empty_like(log_alpha, LEGACY_CONTIGUOUS_MEMORY_FORMAT);  // could be optimized to use only 2 rows
+                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/LossCTC.cpp: In instantiation of ‘at::Tensor at::native::{anonymous}::ctc_loss_backward_cpu_template(const at::Tensor&, const at::Tensor&, const at::Tensor&, c10::IntArrayRef, c10::IntArrayRef, const at::Tensor&, const at::Tensor&, int64_t, bool) [with scalar_t = float; c10::ScalarType target_scalar_type = (c10::ScalarType)3; c10::IntArrayRef = c10::ArrayRef<long int>; int64_t = long int]’:
+../aten/src/ATen/native/LossCTC.cpp:329:10:   required from here
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/LossCTC.cpp:178:50: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor grad = at::full_like(log_probs, neginf, LEGACY_CONTIGUOUS_MEMORY_FORMAT); // at this point, this is log of empty sum
+                                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/LossCTC.cpp:178:50: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor grad = at::full_like(log_probs, neginf, LEGACY_CONTIGUOUS_MEMORY_FORMAT); // at this point, this is log of empty sum
+                                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/LossCTC.cpp:178:50: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor grad = at::full_like(log_probs, neginf, LEGACY_CONTIGUOUS_MEMORY_FORMAT); // at this point, this is log of empty sum
+                                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/LossCTC.cpp:206:47: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor log_beta = at::empty_like(log_alpha, LEGACY_CONTIGUOUS_MEMORY_FORMAT);  // could be optimized to use only 2 rows
+                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/LossCTC.cpp:206:47: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor log_beta = at::empty_like(log_alpha, LEGACY_CONTIGUOUS_MEMORY_FORMAT);  // could be optimized to use only 2 rows
+                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/LossCTC.cpp:206:47: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor log_beta = at::empty_like(log_alpha, LEGACY_CONTIGUOUS_MEMORY_FORMAT);  // could be optimized to use only 2 rows
+                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[1662/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/Pooling.cpp.o
+[1663/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/PointwiseOps.cpp.o
+[1664/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/NaiveDilatedConvolution.cpp.o
+[1665/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/Scalar.cpp.o
+[1666/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/ReflectionPad.cpp.o
+In file included from aten/src/ATen/core/TensorBody.h:5:0,
+                 from ../aten/src/ATen/Tensor.h:11,
+                 from ../aten/src/ATen/Context.h:4,
+                 from ../aten/src/ATen/ATen.h:5,
+                 from ../aten/src/ATen/native/ReflectionPad.cpp:1:
+../aten/src/ATen/native/ReflectionPad.cpp: In function ‘at::Tensor at::native::reflection_pad1d_backward_cpu(const at::Tensor&, const at::Tensor&, c10::IntArrayRef)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/ReflectionPad.cpp:503:43: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto grad_input = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/ReflectionPad.cpp:503:43: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto grad_input = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/ReflectionPad.cpp: In function ‘at::Tensor at::native::reflection_pad2d_backward_cpu(const at::Tensor&, const at::Tensor&, c10::IntArrayRef)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/ReflectionPad.cpp:537:43: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto grad_input = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/ReflectionPad.cpp:537:43: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto grad_input = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[1667/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/ReplicationPadding.cpp.o
+In file included from aten/src/ATen/core/TensorBody.h:5:0,
+                 from ../aten/src/ATen/Tensor.h:11,
+                 from ../aten/src/ATen/Context.h:4,
+                 from ../aten/src/ATen/ATen.h:5,
+                 from ../aten/src/ATen/native/ReplicationPadding.cpp:1:
+../aten/src/ATen/native/ReplicationPadding.cpp: In function ‘at::Tensor at::native::replication_pad1d_backward_cpu(const at::Tensor&, const at::Tensor&, c10::IntArrayRef)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/ReplicationPadding.cpp:952:42: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto gradInput = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/ReplicationPadding.cpp:952:42: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto gradInput = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/ReplicationPadding.cpp: In function ‘at::Tensor at::native::replication_pad2d_backward_cpu(const at::Tensor&, const at::Tensor&, c10::IntArrayRef)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/ReplicationPadding.cpp:994:42: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto gradInput = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/ReplicationPadding.cpp:994:42: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto gradInput = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/ReplicationPadding.cpp: In function ‘at::Tensor at::native::replication_pad3d_backward_cpu(const at::Tensor&, const at::Tensor&, c10::IntArrayRef)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/ReplicationPadding.cpp:1036:42: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto gradInput = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/ReplicationPadding.cpp:1036:42: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   auto gradInput = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[1668/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/SobolEngineOps.cpp.o
+[1669/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/LinearAlgebra.cpp.o
+[1670/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/QuantizedLinear.cpp.o
+In file included from aten/src/ATen/core/TensorBody.h:5:0,
+                 from ../aten/src/ATen/Tensor.h:11,
+                 from ../aten/src/ATen/Context.h:4,
+                 from ../aten/src/ATen/ATen.h:5,
+                 from ../aten/src/ATen/native/QuantizedLinear.cpp:10:
+../aten/src/ATen/native/QuantizedLinear.cpp: In function ‘at::Tensor at::native::fbgemm_linear_int8_weight_fp32_activation(const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, c10::Scalar, c10::Scalar, const at::Tensor&)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/QuantizedLinear.cpp:100:77: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor output = at::empty(output_size, input.options().dtype(at::kFloat), LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/QuantizedLinear.cpp:100:77: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor output = at::empty(output_size, input.options().dtype(at::kFloat), LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/QuantizedLinear.cpp:101:75: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor buffer = at::empty(output_size, input.options().dtype(at::kInt), LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/QuantizedLinear.cpp:101:75: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor buffer = at::empty(output_size, input.options().dtype(at::kInt), LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/QuantizedLinear.cpp: In function ‘std::tuple<at::Tensor, at::Tensor, double, long int> at::native::fbgemm_linear_quantize_weight(const at::Tensor&)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/QuantizedLinear.cpp:241:7: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+       LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/QuantizedLinear.cpp:241:7: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+       LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/QuantizedLinear.cpp:253:73: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+       {weight_contig.size(0)}, weight_contig.options().dtype(at::kInt), LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/QuantizedLinear.cpp:253:73: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+       {weight_contig.size(0)}, weight_contig.options().dtype(at::kInt), LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[1671/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/RangeFactories.cpp.o
+[1672/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/Pow.cpp.o
+[1673/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/Resize.cpp.o
+[1674/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/TensorConversions.cpp.o
+FAILED: caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/TensorConversions.cpp.o 
+/usr/bin/c++  -DAT_PARALLEL_OPENMP=1 -DCPUINFO_SUPPORTED_PLATFORM=1 -DHAVE_MALLOC_USABLE_SIZE=1 -DHAVE_MMAP=1 -DHAVE_SHM_OPEN=1 -DHAVE_SHM_UNLINK=1 -DIDEEP_USE_MKL -DNNP_CONVOLUTION_ONLY=0 -DNNP_INFERENCE_ONLY=0 -DONNX_ML=1 -DONNX_NAMESPACE=onnx_torch -DTH_BLAS_MKL -D_FILE_OFFSET_BITS=64 -Dtorch_cpu_EXPORTS -Iaten/src -I../aten/src -I. -I../ -I../cmake/../third_party/benchmark/include -I../third_party/onnx -Ithird_party/onnx -I../third_party/foxi -Ithird_party/foxi -I../caffe2/../torch/csrc/api -I../caffe2/../torch/csrc/api/include -I../caffe2/aten/src/TH -Icaffe2/aten/src/TH -I../caffe2/../torch/../aten/src -Icaffe2/aten/src -Icaffe2/../aten/src -Icaffe2/../aten/src/ATen -I../caffe2/../torch/csrc -I../caffe2/../torch/../third_party/miniz-2.0.8 -I../aten/src/TH -I../aten/../third_party/catch/single_include -I../aten/src/ATen/.. -Icaffe2/aten/src/ATen -I../third_party/miniz-2.0.8 -I../caffe2/core/nomnigraph/include -I../c10/.. -I../third_party/QNNPACK/include -I../third_party/pthreadpool/include -I../aten/src/ATen/native/quantized/cpu/qnnpack/include -I../aten/src/ATen/native/quantized/cpu/qnnpack/src -I../third_party/QNNPACK/deps/clog/include -I../third_party/NNPACK/include -I../third_party/cpuinfo/include -I../third_party/fbgemm/include -I../third_party/fbgemm -I../third_party/fbgemm/third_party/asmjit/src -I../third_party/FP16/include -Ithird_party/ideep/mkl-dnn/include -I../third_party/ideep/mkl-dnn/src/../include -isystem third_party/gloo -isystem ../cmake/../third_party/gloo -isystem ../cmake/../third_party/googletest/googlemock/include -isystem ../cmake/../third_party/googletest/googletest/include -isystem ../third_party/protobuf/src -isystem /private/home/iuriiz/miniconda3/include -isystem ../third_party/gemmlowp -isystem ../third_party/neon2sse -isystem ../third_party -isystem ../cmake/../third_party/eigen -isystem /private/home/iuriiz/miniconda3/include/python3.7m -isystem /private/home/iuriiz/miniconda3/lib/python3.7/site-packages/numpy/core/include -isystem ../cmake/../third_party/pybind11/include -isystem /usr/lib/x86_64-linux-gnu/openmpi/include/openmpi -isystem /usr/lib/x86_64-linux-gnu/openmpi/include/openmpi/opal/mca/event/libevent2022/libevent -isystem /usr/lib/x86_64-linux-gnu/openmpi/include/openmpi/opal/mca/event/libevent2022/libevent/include -isystem /usr/lib/x86_64-linux-gnu/openmpi/include -isystem /opt/rocm/hip/include -isystem /include -isystem ../third_party/ideep/mkl-dnn/include -isystem ../third_party/ideep/include -isystem include -fvisibility-inlines-hidden -fopenmp -DUSE_FBGEMM -DUSE_QNNPACK -DUSE_PYTORCH_QNNPACK -O2 -fPIC -Wno-narrowing -Wall -Wextra -Wno-missing-field-initializers -Wno-type-limits -Wno-array-bounds -Wno-unknown-pragmas -Wno-sign-compare -Wno-unused-parameter -Wno-unused-variable -Wno-unused-function -Wno-unused-result -Wno-strict-overflow -Wno-strict-aliasing -Wno-error=deprecated-declarations -Wno-stringop-overflow -Wno-error=pedantic -Wno-error=redundant-decls -Wno-error=old-style-cast -fdiagnostics-color=always -faligned-new -Wno-unused-but-set-variable -Wno-maybe-uninitialized -fno-math-errno -fno-trapping-math -Wno-stringop-overflow -DHAVE_AVX_CPU_DEFINITION -DHAVE_AVX2_CPU_DEFINITION -g -fno-omit-frame-pointer -O0 -fPIC   -DCAFFE2_USE_GLOO -DHAVE_GCC_GET_CPUID -DUSE_AVX -DUSE_AVX2 -DTH_HAVE_THREAD -Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers -Wno-write-strings -Wno-unknown-pragmas -Wno-missing-braces -Wno-maybe-uninitialized -fvisibility=hidden -DCAFFE2_BUILD_MAIN_LIB -DASMJIT_STATIC -std=gnu++14 -MD -MT caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/TensorConversions.cpp.o -MF caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/TensorConversions.cpp.o.d -o caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/TensorConversions.cpp.o -c ../aten/src/ATen/native/TensorConversions.cpp
+../aten/src/ATen/native/TensorConversions.cpp: In function ‘at::Tensor at::native::to(const at::Tensor&, c10::optional<c10::ScalarType>, c10::optional<c10::Layout>, c10::optional<c10::Device>, c10::optional<bool>, bool, bool, c10::optional<c10::MemoryFormat>)’:
+../aten/src/ATen/native/TensorConversions.cpp:57:31: error: ‘options’ was not declared in this scope
+     const auto & layout_opt = options.layout_opt();
+                               ^~~~~~~
+../aten/src/ATen/native/TensorConversions.cpp:57:31: note: suggested alternative:
+In file included from ../aten/src/ATen/core/Dimname.h:5:0,
+                 from ../aten/src/ATen/core/NamedTensor.h:4,
+                 from aten/src/ATen/core/TensorBody.h:20,
+                 from ../aten/src/ATen/Tensor.h:11,
+                 from ../aten/src/ATen/Context.h:4,
+                 from ../aten/src/ATen/ATen.h:5,
+                 from ../aten/src/ATen/native/TensorConversions.cpp:1:
+../aten/src/ATen/core/aten_interned_strings.h:896:9: note:   ‘c10::attr::options’
+ _(attr, options) \
+         ^
+../aten/src/ATen/core/interned_strings.h:379:35: note: in definition of macro ‘DEFINE_SYMBOL’
+   namespace ns { constexpr Symbol s(static_cast<unique_t>(_keys::ns##_##s)); }
+                                   ^
+../aten/src/ATen/core/interned_strings.h:209:3: note: in expansion of macro ‘FORALL_ATTR_BASE_SYMBOLS’
+   FORALL_ATTR_BASE_SYMBOLS(_)        \
+   ^~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/core/interned_strings.h:380:1: note: in expansion of macro ‘FORALL_NS_SYMBOLS’
+ FORALL_NS_SYMBOLS(DEFINE_SYMBOL)
+ ^~~~~~~~~~~~~~~~~
+[1675/2582] Building CXX object caffe2/CMakeFiles/caffe2_pybind11_state.dir/python/pybind_state_nomni.cc.o
+[1676/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/Repeat.cpp.o
+In file included from aten/src/ATen/core/TensorBody.h:5:0,
+                 from ../aten/src/ATen/Tensor.h:11,
+                 from ../aten/src/ATen/Context.h:4,
+                 from ../aten/src/ATen/ATen.h:5,
+                 from ../aten/src/ATen/native/Repeat.cpp:1:
+../aten/src/ATen/native/Repeat.h: In function ‘at::Tensor at::native::repeat_interleave_common(const at::Tensor&)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/Repeat.h:13:40: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+         return at::empty_like(repeats, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/Repeat.h: In instantiation of ‘at::Tensor at::native::repeat_interleave_common(const at::Tensor&) [with void (* compute)(int64_t*, int64_t*, int64_t*, int64_t) = compute_cpu]’:
+../aten/src/ATen/native/Repeat.cpp:21:56:   required from here
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Repeat.h:13:40: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+         return at::empty_like(repeats, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Repeat.h:13:40: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+         return at::empty_like(repeats, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Repeat.h:13:40: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+         return at::empty_like(repeats, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[1677/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/SoftMax.cpp.o
+In file included from aten/src/ATen/core/TensorBody.h:5:0,
+                 from ../aten/src/ATen/Tensor.h:11,
+                 from ../aten/src/ATen/Context.h:4,
+                 from ../aten/src/ATen/ATen.h:5,
+                 from ../aten/src/ATen/native/SoftMax.cpp:1:
+../aten/src/ATen/native/SoftMax.cpp: In function ‘at::Tensor at::native::softmax_cpu(const at::Tensor&, int64_t, bool)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/SoftMax.cpp:124:49: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor output = at::native::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/SoftMax.cpp:124:49: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor output = at::native::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/SoftMax.cpp: In function ‘at::Tensor at::native::log_softmax_cpu(const at::Tensor&, int64_t, bool)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/SoftMax.cpp:148:49: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor output = at::native::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/SoftMax.cpp:148:49: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor output = at::native::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/SoftMax.cpp: In function ‘at::Tensor at::native::softmax_backward_cpu(const at::Tensor&, const at::Tensor&, int64_t, const at::Tensor&)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/SoftMax.cpp:179:52: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor grad_input = at::native::empty_like(grad, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/SoftMax.cpp:179:52: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor grad_input = at::native::empty_like(grad, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/SoftMax.cpp: In function ‘at::Tensor at::native::log_softmax_backward_cpu(const at::Tensor&, const at::Tensor&, int64_t, const at::Tensor&)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/SoftMax.cpp:211:52: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor grad_input = at::native::empty_like(grad, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/SoftMax.cpp:211:52: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor grad_input = at::native::empty_like(grad, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[1678/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/SummaryOps.cpp.o
+[1679/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/SpectralOps.cpp.o
+[1680/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/Normalization.cpp.o
+In file included from aten/src/ATen/core/TensorBody.h:5:0,
+                 from ../aten/src/ATen/Tensor.h:11,
+                 from ../aten/src/ATen/Context.h:4,
+                 from ../aten/src/ATen/ATen.h:5,
+                 from ../aten/src/ATen/native/Normalization.cpp:1:
+../aten/src/ATen/native/Normalization.cpp: In function ‘void at::native::batch_norm_cpu_inference_contiguous(at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, double)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/Normalization.cpp:106:39: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor alpha = at::empty_like(mean, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                       ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/Normalization.cpp:107:38: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor beta = at::empty_like(mean, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                      ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/Normalization.cpp: In function ‘void at::native::batch_norm_cpu_inference_channels_last(at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, double)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/Normalization.cpp:159:39: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor alpha = at::empty_like(mean, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                       ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/Normalization.cpp:160:38: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor beta = at::empty_like(mean, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                      ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/Normalization.cpp: In function ‘std::tuple<at::Tensor, at::Tensor, at::Tensor> at::native::batch_norm_cpu_transform_input_template(const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, bool, double)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/Normalization.cpp:209:43: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     Tensor output = at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                           ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/Normalization.cpp:228:41: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor output = at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                         ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/Normalization.cpp: In function ‘std::tuple<at::Tensor, at::Tensor, at::Tensor> at::native::batch_norm_backward_cpu_template(const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, bool, double, std::array<bool, 3>)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/Normalization.cpp:333:40: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     grad_input = at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                        ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/Normalization.cpp:336:42: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     grad_weight = at::empty_like(weight, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                          ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/Normalization.cpp:339:40: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     grad_bias = at::empty_like(weight, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                        ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/Normalization.cpp: In instantiation of ‘std::tuple<at::Tensor, at::Tensor, at::Tensor> at::native::batch_norm_cpu_transform_input_template(const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, bool, double) [with scalar_t = double]’:
+../aten/src/ATen/native/Normalization.cpp:630:10:   required from here
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Normalization.cpp:209:43: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     Tensor output = at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                           ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Normalization.cpp:209:43: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     Tensor output = at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                           ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Normalization.cpp:209:43: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     Tensor output = at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                           ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Normalization.cpp:228:41: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor output = at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                         ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Normalization.cpp:228:41: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor output = at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                         ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Normalization.cpp:228:41: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor output = at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                         ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/Normalization.cpp: In instantiation of ‘std::tuple<at::Tensor, at::Tensor, at::Tensor> at::native::batch_norm_cpu_transform_input_template(const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, bool, double) [with scalar_t = float]’:
+../aten/src/ATen/native/Normalization.cpp:630:10:   required from here
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Normalization.cpp:209:43: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     Tensor output = at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                           ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Normalization.cpp:209:43: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     Tensor output = at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                           ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Normalization.cpp:209:43: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     Tensor output = at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                           ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Normalization.cpp:228:41: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor output = at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                         ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Normalization.cpp:228:41: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor output = at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                         ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Normalization.cpp:228:41: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor output = at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                         ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/Normalization.cpp: In instantiation of ‘std::tuple<at::Tensor, at::Tensor, at::Tensor> at::native::batch_norm_backward_cpu_template(const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, bool, double, std::array<bool, 3>) [with scalar_t = double]’:
+../aten/src/ATen/native/Normalization.cpp:643:10:   required from here
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Normalization.cpp:333:40: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     grad_input = at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                        ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Normalization.cpp:333:40: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     grad_input = at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                        ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Normalization.cpp:333:40: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     grad_input = at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                        ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Normalization.cpp:336:42: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     grad_weight = at::empty_like(weight, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                          ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Normalization.cpp:336:42: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     grad_weight = at::empty_like(weight, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                          ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Normalization.cpp:336:42: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     grad_weight = at::empty_like(weight, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                          ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Normalization.cpp:339:40: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     grad_bias = at::empty_like(weight, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                        ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Normalization.cpp:339:40: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     grad_bias = at::empty_like(weight, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                        ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Normalization.cpp:339:40: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     grad_bias = at::empty_like(weight, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                        ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/Normalization.cpp: In instantiation of ‘std::tuple<at::Tensor, at::Tensor, at::Tensor> at::native::batch_norm_backward_cpu_template(const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, bool, double, std::array<bool, 3>) [with scalar_t = float]’:
+../aten/src/ATen/native/Normalization.cpp:643:10:   required from here
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Normalization.cpp:333:40: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     grad_input = at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                        ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Normalization.cpp:333:40: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     grad_input = at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                        ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Normalization.cpp:333:40: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     grad_input = at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                        ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Normalization.cpp:336:42: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     grad_weight = at::empty_like(weight, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                          ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Normalization.cpp:336:42: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     grad_weight = at::empty_like(weight, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                          ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Normalization.cpp:336:42: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     grad_weight = at::empty_like(weight, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                          ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Normalization.cpp:339:40: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     grad_bias = at::empty_like(weight, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                        ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Normalization.cpp:339:40: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     grad_bias = at::empty_like(weight, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                        ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Normalization.cpp:339:40: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     grad_bias = at::empty_like(weight, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                        ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/Normalization.cpp: In instantiation of ‘void at::native::batch_norm_cpu_inference_contiguous(at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, double) [with scalar_t = double]’:
+../aten/src/ATen/native/Normalization.cpp:210:50:   required from ‘std::tuple<at::Tensor, at::Tensor, at::Tensor> at::native::batch_norm_cpu_transform_input_template(const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, bool, double) [with scalar_t = double]’
+../aten/src/ATen/native/Normalization.cpp:630:10:   required from here
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Normalization.cpp:106:39: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor alpha = at::empty_like(mean, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                       ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Normalization.cpp:106:39: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor alpha = at::empty_like(mean, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                       ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Normalization.cpp:106:39: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor alpha = at::empty_like(mean, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                       ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Normalization.cpp:107:38: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor beta = at::empty_like(mean, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                      ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Normalization.cpp:107:38: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor beta = at::empty_like(mean, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                      ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Normalization.cpp:107:38: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor beta = at::empty_like(mean, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                      ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/Normalization.cpp: In instantiation of ‘void at::native::batch_norm_cpu_inference_channels_last(at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, double) [with scalar_t = double]’:
+../aten/src/ATen/native/Normalization.cpp:223:53:   required from ‘std::tuple<at::Tensor, at::Tensor, at::Tensor> at::native::batch_norm_cpu_transform_input_template(const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, bool, double) [with scalar_t = double]’
+../aten/src/ATen/native/Normalization.cpp:630:10:   required from here
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Normalization.cpp:159:39: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor alpha = at::empty_like(mean, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                       ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Normalization.cpp:159:39: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor alpha = at::empty_like(mean, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                       ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Normalization.cpp:159:39: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor alpha = at::empty_like(mean, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                       ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Normalization.cpp:160:38: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor beta = at::empty_like(mean, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                      ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Normalization.cpp:160:38: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor beta = at::empty_like(mean, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                      ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Normalization.cpp:160:38: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor beta = at::empty_like(mean, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                      ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/Normalization.cpp: In instantiation of ‘void at::native::batch_norm_cpu_inference_contiguous(at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, double) [with scalar_t = float]’:
+../aten/src/ATen/native/Normalization.cpp:210:50:   required from ‘std::tuple<at::Tensor, at::Tensor, at::Tensor> at::native::batch_norm_cpu_transform_input_template(const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, bool, double) [with scalar_t = float]’
+../aten/src/ATen/native/Normalization.cpp:630:10:   required from here
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Normalization.cpp:106:39: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor alpha = at::empty_like(mean, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                       ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Normalization.cpp:106:39: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor alpha = at::empty_like(mean, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                       ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Normalization.cpp:106:39: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor alpha = at::empty_like(mean, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                       ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Normalization.cpp:107:38: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor beta = at::empty_like(mean, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                      ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Normalization.cpp:107:38: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor beta = at::empty_like(mean, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                      ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Normalization.cpp:107:38: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor beta = at::empty_like(mean, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                      ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/Normalization.cpp: In instantiation of ‘void at::native::batch_norm_cpu_inference_channels_last(at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, double) [with scalar_t = float]’:
+../aten/src/ATen/native/Normalization.cpp:223:53:   required from ‘std::tuple<at::Tensor, at::Tensor, at::Tensor> at::native::batch_norm_cpu_transform_input_template(const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, bool, double) [with scalar_t = float]’
+../aten/src/ATen/native/Normalization.cpp:630:10:   required from here
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Normalization.cpp:159:39: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor alpha = at::empty_like(mean, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                       ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Normalization.cpp:159:39: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor alpha = at::empty_like(mean, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                       ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Normalization.cpp:159:39: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor alpha = at::empty_like(mean, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                       ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Normalization.cpp:160:38: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor beta = at::empty_like(mean, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                      ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Normalization.cpp:160:38: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor beta = at::empty_like(mean, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                      ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/Normalization.cpp:160:38: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor beta = at::empty_like(mean, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                      ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[1681/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/Unfold2d.cpp.o
+[1682/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/Sorting.cpp.o
+[1683/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/RNN.cpp.o
+In file included from aten/src/ATen/core/TensorBody.h:5:0,
+                 from ../aten/src/ATen/Tensor.h:11,
+                 from ../aten/src/ATen/Context.h:4,
+                 from ../aten/src/ATen/ATen.h:5,
+                 from ../aten/src/ATen/native/RNN.h:3,
+                 from ../aten/src/ATen/native/RNN.cpp:1:
+../aten/src/ATen/native/RNN.cpp: In function ‘std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor> at::native::_thnn_differentiable_lstm_cell_backward(const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/RNN.cpp:1071:30: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     gog = at::zeros_like(cx, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/RNN.cpp:1071:30: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     gog = at::zeros_like(cx, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[1684/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/ReduceOps.cpp.o
+[1685/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/TensorIteratorReduce.cpp.o
+[1686/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/TensorProperties.cpp.o
+[1687/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/TypeProperties.cpp.o
+[1688/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/mkldnn/IDeepRegistration.cpp.o
+[1689/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/TensorIterator.cpp.o
+In file included from aten/src/ATen/core/TensorBody.h:5:0,
+                 from ../aten/src/ATen/Tensor.h:11,
+                 from ../aten/src/ATen/Context.h:4,
+                 from ../aten/src/ATen/ATen.h:5,
+                 from ../aten/src/ATen/native/TensorIterator.h:3,
+                 from ../aten/src/ATen/native/TensorIterator.cpp:1:
+../aten/src/ATen/native/TensorIterator.cpp: In function ‘void at::maybe_copy_casting_to_common_dtype(at::OperandInfo&, c10::ScalarType)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/TensorIterator.cpp:162:78: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+           at::empty_like(op.tensor, op.tensor.options().dtype(common_dtype), LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/TensorIterator.cpp:162:78: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+           at::empty_like(op.tensor, op.tensor.options().dtype(common_dtype), LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[1690/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/Unfold3d.cpp.o
+[1691/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/TensorTransformations.cpp.o
+In file included from aten/src/ATen/core/TensorBody.h:5:0,
+                 from ../aten/src/ATen/Tensor.h:11,
+                 from ../aten/src/ATen/Context.h:4,
+                 from ../aten/src/ATen/ATen.h:5,
+                 from ../aten/src/ATen/native/TensorTransformations.h:1,
+                 from ../aten/src/ATen/native/TensorTransformations.cpp:1:
+../aten/src/ATen/native/TensorTransformations.cpp: In function ‘at::Tensor at::native::flip_cpu(const at::Tensor&, c10::IntArrayRef)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/TensorTransformations.cpp:52:49: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor out_tensor = at::empty_like(in_tensor, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/TensorTransformations.cpp:52:49: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor out_tensor = at::empty_like(in_tensor, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[1692/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/UpSampleBicubic2d.cpp.o
+[1693/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/UpSampleNearest1d.cpp.o
+[1694/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/UpSampleTrilinear3d.cpp.o
+[1695/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/TriangularOps.cpp.o
+In file included from aten/src/ATen/core/TensorBody.h:5:0,
+                 from ../aten/src/ATen/Tensor.h:11,
+                 from ../aten/src/ATen/Context.h:4,
+                 from ../aten/src/ATen/ATen.h:5,
+                 from ../aten/src/ATen/native/TriangularOps.cpp:1:
+../aten/src/ATen/native/TriangularOps.cpp: In function ‘at::Tensor& at::native::tril_cpu_(at::Tensor&, int64_t)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/TriangularOps.cpp:98:57: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor result = inplace ? self : at::empty_like(self, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/TriangularOps.cpp:98:57: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor result = inplace ? self : at::empty_like(self, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/TriangularOps.cpp: In function ‘at::Tensor& at::native::triu_cpu_(at::Tensor&, int64_t)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/TriangularOps.cpp:134:57: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor result = inplace ? self : at::empty_like(self, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/TriangularOps.cpp:134:57: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor result = inplace ? self : at::empty_like(self, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[1696/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/UpSampleLinear1d.cpp.o
+[1697/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/quantized/cpu/init_qnnpack.cpp.o
+[1698/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/VariableMethodStubs.cpp.o
+[1699/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/quantized/Copy.cpp.o
+[1700/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/UpSampleBilinear2d.cpp.o
+[1701/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/WeightNorm.cpp.o
+[1702/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/quantized/TensorFactories.cpp.o
+[1703/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/UnaryOps.cpp.o
+[1704/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/UpSampleNearest2d.cpp.o
+[1705/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/UpSampleNearest3d.cpp.o
+[1706/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/quantized/cpu/fbgemm_utils.cpp.o
+[1707/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/quantized/cpu/fake_quantize_per_channel_affine.cpp.o
+[1708/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/quantized/cpu/fake_quantize_core.cpp.o
+[1709/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/TensorFactories.cpp.o
+[1710/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/TensorCompare.cpp.o
+[1711/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/layer_norm.cpp.o
+In file included from aten/src/ATen/core/TensorBody.h:5:0,
+                 from ../aten/src/ATen/Tensor.h:11,
+                 from ../aten/src/ATen/Context.h:4,
+                 from ../aten/src/ATen/ATen.h:5,
+                 from ../aten/src/ATen/native/layer_norm.h:3,
+                 from ../aten/src/ATen/native/layer_norm.cpp:1:
+../aten/src/ATen/native/layer_norm.cpp: In function ‘std::tuple<at::Tensor, at::Tensor, at::Tensor> at::native::layer_norm_cpu(const at::Tensor&, const at::Tensor&, const at::Tensor&, int64_t, int64_t, double)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/layer_norm.cpp:26:40: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor Y = at::native::empty_like(X, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/layer_norm.cpp:26:40: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+   Tensor Y = at::native::empty_like(X, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/layer_norm.cpp: In function ‘std::tuple<at::Tensor, at::Tensor, at::Tensor> at::native::layer_norm_backward_cpu(const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&, int64_t, int64_t, std::array<bool, 3>)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/layer_norm.cpp:48:36: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     dX = at::native::empty_like(X, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/layer_norm.cpp:48:36: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     dX = at::native::empty_like(X, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/layer_norm.cpp:51:52: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     dgamma = M > 0 ? at::native::empty_like(gamma, LEGACY_CONTIGUOUS_MEMORY_FORMAT) : at::native::zeros_like(gamma, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/layer_norm.cpp:51:52: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     dgamma = M > 0 ? at::native::empty_like(gamma, LEGACY_CONTIGUOUS_MEMORY_FORMAT) : at::native::zeros_like(gamma, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/layer_norm.cpp:51:117: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     dgamma = M > 0 ? at::native::empty_like(gamma, LEGACY_CONTIGUOUS_MEMORY_FORMAT) : at::native::zeros_like(gamma, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                                                                                     ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/layer_norm.cpp:51:117: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     dgamma = M > 0 ? at::native::empty_like(gamma, LEGACY_CONTIGUOUS_MEMORY_FORMAT) : at::native::zeros_like(gamma, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                                                                                     ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/layer_norm.cpp:54:51: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     dbeta = M > 0 ? at::native::empty_like(gamma, LEGACY_CONTIGUOUS_MEMORY_FORMAT) : at::native::zeros_like(gamma, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/layer_norm.cpp:54:51: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     dbeta = M > 0 ? at::native::empty_like(gamma, LEGACY_CONTIGUOUS_MEMORY_FORMAT) : at::native::zeros_like(gamma, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/layer_norm.cpp:54:116: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     dbeta = M > 0 ? at::native::empty_like(gamma, LEGACY_CONTIGUOUS_MEMORY_FORMAT) : at::native::zeros_like(gamma, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                                                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/layer_norm.cpp:54:116: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     dbeta = M > 0 ? at::native::empty_like(gamma, LEGACY_CONTIGUOUS_MEMORY_FORMAT) : at::native::zeros_like(gamma, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                                                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[1712/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/TensorShape.cpp.o
+In file included from aten/src/ATen/core/TensorBody.h:5:0,
+                 from ../aten/src/ATen/Tensor.h:11,
+                 from ../aten/src/ATen/Context.h:4,
+                 from ../aten/src/ATen/ATen.h:5,
+                 from ../aten/src/ATen/native/TensorShape.cpp:3:
+../aten/src/ATen/native/TensorShape.cpp: In function ‘at::Tensor& at::native::sparse_transpose_(at::Tensor&, int64_t, int64_t)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/TensorShape.cpp:850:37: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     auto tmp = at::zeros_like(row0, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/TensorShape.cpp:850:37: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     auto tmp = at::zeros_like(row0, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[1713/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/quantized/cpu/fake_quantize_per_tensor_affine.cpp.o
+[1714/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/quantized/cpu/qupsample_bilinear2d.cpp.o
+[1715/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/quantized/cpu/qreduction.cpp.o
+[1716/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/quantized/cpu/q_avgpool.cpp.o
+[1717/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/quantized/QTensor.cpp.o
+[1718/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/quantized/cpu/q_adaavgpool.cpp.o
+[1719/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/sparse/SparseTensor.cpp.o
+[1720/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/quantized/TensorCompare.cpp.o
+[1721/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/sparse/SparseTensorMath.cpp.o
+In file included from aten/src/ATen/core/TensorBody.h:5:0,
+                 from ../aten/src/ATen/Tensor.h:11,
+                 from ../aten/src/ATen/Context.h:4,
+                 from ../aten/src/ATen/ATen.h:5,
+                 from ../aten/src/ATen/native/sparse/SparseTensorMath.h:3,
+                 from ../aten/src/ATen/native/sparse/SparseTensorMath.cpp:1:
+../aten/src/ATen/native/sparse/SparseTensorMath.cpp: In function ‘at::Tensor at::native::_sparse_sum_backward_cpu(const at::Tensor&, const SparseTensor&, c10::IntArrayRef)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/sparse/SparseTensorMath.cpp:1141:79: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+       grad_input_values = at::zeros_like(input_values, grad_values.options(), LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:75: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                                                           ^
+../aten/src/ATen/native/sparse/SparseTensorMath.cpp:1141:79: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+       grad_input_values = at::zeros_like(input_values, grad_values.options(), LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[1722/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/Unique.cpp.o
+[1723/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/quantized/cpu/qlinear.cpp.o
+[1724/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/quantized/cpu/qconv_unpack.cpp.o
+[1725/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/quantized/cpu/qsort.cpp.o
+[1726/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/quantized/cpu/qupsample_nearest2d.cpp.o
+[1727/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/mkl/SpectralOps.cpp.o
+[1728/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/quantized/cpu/qconcat.cpp.o
+[1729/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/quantized/cpu/qrelu.cpp.o
+[1730/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/mkl/LinearAlgebra.cpp.o
+[1731/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp.o
+In file included from aten/src/ATen/core/TensorBody.h:5:0,
+                 from ../aten/src/ATen/Tensor.h:11,
+                 from ../aten/src/ATen/Context.h:4,
+                 from ../aten/src/ATen/ATen.h:5,
+                 from ../aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp:1:
+../aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp: In member function ‘at::Tensor at::native::{anonymous}::QLinearDynamicInt8<ReluFused>::operator()(at::Tensor, at::Tensor)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp:103:76: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     auto buffer = at::empty_like(output, output.options().dtype(at::kInt), LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp: In instantiation of ‘at::Tensor at::native::{anonymous}::QLinearDynamicInt8<ReluFused>::operator()(at::Tensor, at::Tensor) [with bool ReluFused = false]’:
+../aten/src/ATen/core/boxing/kernel_functor.h:262:25:   required from ‘static ReturnType c10::detail::wrap_kernel_functor_unboxed_<KernelFunctor, ReturnType(ParameterTypes ...)>::call(c10::OperatorKernel*, ParameterTypes ...) [with KernelFunctor = at::native::{anonymous}::QLinearDynamicInt8<false>; ReturnType = at::Tensor; ParameterTypes = {at::Tensor, at::Tensor}]’
+../aten/src/ATen/core/boxing/KernelFunction_impl.h:101:33:   required from ‘static c10::KernelFunction c10::KernelFunction::makeFromUnboxedFunctorFactory(std::function<std::unique_ptr<c10::OperatorKernel>()>) [with KernelFunctor = at::native::{anonymous}::QLinearDynamicInt8<false>; bool AllowLegacyTypes = false]’
+../aten/src/ATen/core/op_registration/op_registration.h:150:69:   required from ‘c10::guts::enable_if_t<c10::guts::is_functor<LambdaType>::value, c10::RegisterOperators::Options&&> c10::RegisterOperators::Options::kernel(c10::TensorTypeId, ConstructorParameters&& ...) && [with KernelFunctor = at::native::{anonymous}::QLinearDynamicInt8<false>; ConstructorParameters = {}; c10::guts::enable_if_t<c10::guts::is_functor<LambdaType>::value, c10::RegisterOperators::Options&&> = c10::RegisterOperators::Options&&]’
+../aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp:224:77:   required from here
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp:103:76: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     auto buffer = at::empty_like(output, output.options().dtype(at::kInt), LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp:103:76: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     auto buffer = at::empty_like(output, output.options().dtype(at::kInt), LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp:103:76: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     auto buffer = at::empty_like(output, output.options().dtype(at::kInt), LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp: In instantiation of ‘at::Tensor at::native::{anonymous}::QLinearDynamicInt8<ReluFused>::operator()(at::Tensor, at::Tensor) [with bool ReluFused = true]’:
+../aten/src/ATen/core/boxing/kernel_functor.h:262:25:   required from ‘static ReturnType c10::detail::wrap_kernel_functor_unboxed_<KernelFunctor, ReturnType(ParameterTypes ...)>::call(c10::OperatorKernel*, ParameterTypes ...) [with KernelFunctor = at::native::{anonymous}::QLinearDynamicInt8<true>; ReturnType = at::Tensor; ParameterTypes = {at::Tensor, at::Tensor}]’
+../aten/src/ATen/core/boxing/KernelFunction_impl.h:101:33:   required from ‘static c10::KernelFunction c10::KernelFunction::makeFromUnboxedFunctorFactory(std::function<std::unique_ptr<c10::OperatorKernel>()>) [with KernelFunctor = at::native::{anonymous}::QLinearDynamicInt8<true>; bool AllowLegacyTypes = false]’
+../aten/src/ATen/core/op_registration/op_registration.h:150:69:   required from ‘c10::guts::enable_if_t<c10::guts::is_functor<LambdaType>::value, c10::RegisterOperators::Options&&> c10::RegisterOperators::Options::kernel(c10::TensorTypeId, ConstructorParameters&& ...) && [with KernelFunctor = at::native::{anonymous}::QLinearDynamicInt8<true>; ConstructorParameters = {}; c10::guts::enable_if_t<c10::guts::is_functor<LambdaType>::value, c10::RegisterOperators::Options&&> = c10::RegisterOperators::Options&&]’
+../aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp:227:76:   required from here
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp:103:76: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     auto buffer = at::empty_like(output, output.options().dtype(at::kInt), LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp:103:76: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     auto buffer = at::empty_like(output, output.options().dtype(at::kInt), LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp:103:76: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     auto buffer = at::empty_like(output, output.options().dtype(at::kInt), LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                                                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[1732/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/quantized/cpu/tensor_operators.cpp.o
+[1733/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/quantized/cpu/qpool.cpp.o
+[1734/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/quantized/cpu/qadd.cpp.o
+In file included from aten/src/ATen/core/TensorBody.h:5:0,
+                 from ../aten/src/ATen/Tensor.h:11,
+                 from ../aten/src/ATen/Context.h:4,
+                 from ../aten/src/ATen/ATen.h:5,
+                 from ../aten/src/ATen/native/quantized/cpu/qadd.cpp:1:
+../aten/src/ATen/native/quantized/cpu/qadd.cpp: In member function ‘at::Tensor at::native::{anonymous}::QAddScalar<ReLUFused>::operator()(at::Tensor, c10::Scalar)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/quantized/cpu/qadd.cpp:229:34: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     auto qc = at::empty_like(qa, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                  ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/quantized/cpu/qadd.cpp: In instantiation of ‘at::Tensor at::native::{anonymous}::QAddScalar<ReLUFused>::operator()(at::Tensor, c10::Scalar) [with bool ReLUFused = false]’:
+../aten/src/ATen/core/boxing/kernel_functor.h:262:25:   required from ‘static ReturnType c10::detail::wrap_kernel_functor_unboxed_<KernelFunctor, ReturnType(ParameterTypes ...)>::call(c10::OperatorKernel*, ParameterTypes ...) [with KernelFunctor = at::native::{anonymous}::QAddScalar<false>; ReturnType = at::Tensor; ParameterTypes = {at::Tensor, c10::Scalar}]’
+../aten/src/ATen/core/boxing/KernelFunction_impl.h:101:33:   required from ‘static c10::KernelFunction c10::KernelFunction::makeFromUnboxedFunctorFactory(std::function<std::unique_ptr<c10::OperatorKernel>()>) [with KernelFunctor = at::native::{anonymous}::QAddScalar<false>; bool AllowLegacyTypes = false]’
+../aten/src/ATen/core/op_registration/op_registration.h:150:69:   required from ‘c10::guts::enable_if_t<c10::guts::is_functor<LambdaType>::value, c10::RegisterOperators::Options&&> c10::RegisterOperators::Options::kernel(c10::TensorTypeId, ConstructorParameters&& ...) && [with KernelFunctor = at::native::{anonymous}::QAddScalar<false>; ConstructorParameters = {}; c10::guts::enable_if_t<c10::guts::is_functor<LambdaType>::value, c10::RegisterOperators::Options&&> = c10::RegisterOperators::Options&&]’
+../aten/src/ATen/native/quantized/cpu/qadd.cpp:262:82:   required from here
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/quantized/cpu/qadd.cpp:229:34: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     auto qc = at::empty_like(qa, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                  ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/quantized/cpu/qadd.cpp:229:34: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     auto qc = at::empty_like(qa, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                  ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/quantized/cpu/qadd.cpp:229:34: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     auto qc = at::empty_like(qa, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                  ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/quantized/cpu/qadd.cpp: In instantiation of ‘at::Tensor at::native::{anonymous}::QAddScalar<ReLUFused>::operator()(at::Tensor, c10::Scalar) [with bool ReLUFused = true]’:
+../aten/src/ATen/core/boxing/kernel_functor.h:262:25:   required from ‘static ReturnType c10::detail::wrap_kernel_functor_unboxed_<KernelFunctor, ReturnType(ParameterTypes ...)>::call(c10::OperatorKernel*, ParameterTypes ...) [with KernelFunctor = at::native::{anonymous}::QAddScalar<true>; ReturnType = at::Tensor; ParameterTypes = {at::Tensor, c10::Scalar}]’
+../aten/src/ATen/core/boxing/KernelFunction_impl.h:101:33:   required from ‘static c10::KernelFunction c10::KernelFunction::makeFromUnboxedFunctorFactory(std::function<std::unique_ptr<c10::OperatorKernel>()>) [with KernelFunctor = at::native::{anonymous}::QAddScalar<true>; bool AllowLegacyTypes = false]’
+../aten/src/ATen/core/op_registration/op_registration.h:150:69:   required from ‘c10::guts::enable_if_t<c10::guts::is_functor<LambdaType>::value, c10::RegisterOperators::Options&&> c10::RegisterOperators::Options::kernel(c10::TensorTypeId, ConstructorParameters&& ...) && [with KernelFunctor = at::native::{anonymous}::QAddScalar<true>; ConstructorParameters = {}; c10::guts::enable_if_t<c10::guts::is_functor<LambdaType>::value, c10::RegisterOperators::Options&&> = c10::RegisterOperators::Options&&]’
+../aten/src/ATen/native/quantized/cpu/qadd.cpp:265:81:   required from here
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/quantized/cpu/qadd.cpp:229:34: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     auto qc = at::empty_like(qa, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                  ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/quantized/cpu/qadd.cpp:229:34: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     auto qc = at::empty_like(qa, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                  ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/quantized/cpu/qadd.cpp:229:34: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     auto qc = at::empty_like(qa, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                  ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[1735/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/quantized/cpu/qlinear_prepack.cpp.o
+[1736/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/quantized/cpu/qmul.cpp.o
+In file included from aten/src/ATen/core/TensorBody.h:5:0,
+                 from ../aten/src/ATen/Tensor.h:11,
+                 from ../aten/src/ATen/Context.h:4,
+                 from ../aten/src/ATen/ATen.h:5,
+                 from ../aten/src/ATen/native/quantized/cpu/qmul.cpp:1:
+../aten/src/ATen/native/quantized/cpu/qmul.cpp: In member function ‘at::Tensor at::native::{anonymous}::QMulScalar<ReLUFused>::operator()(at::Tensor, c10::Scalar)’:
+../c10/core/MemoryFormat.h:32:46: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                              ^
+../aten/src/ATen/native/quantized/cpu/qmul.cpp:143:34: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     auto qc = at::empty_like(qa, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                  ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/quantized/cpu/qmul.cpp: In instantiation of ‘at::Tensor at::native::{anonymous}::QMulScalar<ReLUFused>::operator()(at::Tensor, c10::Scalar) [with bool ReLUFused = false]’:
+../aten/src/ATen/core/boxing/kernel_functor.h:262:25:   required from ‘static ReturnType c10::detail::wrap_kernel_functor_unboxed_<KernelFunctor, ReturnType(ParameterTypes ...)>::call(c10::OperatorKernel*, ParameterTypes ...) [with KernelFunctor = at::native::{anonymous}::QMulScalar<false>; ReturnType = at::Tensor; ParameterTypes = {at::Tensor, c10::Scalar}]’
+../aten/src/ATen/core/boxing/KernelFunction_impl.h:101:33:   required from ‘static c10::KernelFunction c10::KernelFunction::makeFromUnboxedFunctorFactory(std::function<std::unique_ptr<c10::OperatorKernel>()>) [with KernelFunctor = at::native::{anonymous}::QMulScalar<false>; bool AllowLegacyTypes = false]’
+../aten/src/ATen/core/op_registration/op_registration.h:150:69:   required from ‘c10::guts::enable_if_t<c10::guts::is_functor<LambdaType>::value, c10::RegisterOperators::Options&&> c10::RegisterOperators::Options::kernel(c10::TensorTypeId, ConstructorParameters&& ...) && [with KernelFunctor = at::native::{anonymous}::QMulScalar<false>; ConstructorParameters = {}; c10::guts::enable_if_t<c10::guts::is_functor<LambdaType>::value, c10::RegisterOperators::Options&&> = c10::RegisterOperators::Options&&]’
+../aten/src/ATen/native/quantized/cpu/qmul.cpp:182:55:   required from here
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/quantized/cpu/qmul.cpp:143:34: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     auto qc = at::empty_like(qa, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                  ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/quantized/cpu/qmul.cpp:143:34: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     auto qc = at::empty_like(qa, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                  ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/quantized/cpu/qmul.cpp:143:34: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     auto qc = at::empty_like(qa, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                  ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../aten/src/ATen/native/quantized/cpu/qmul.cpp: In instantiation of ‘at::Tensor at::native::{anonymous}::QMulScalar<ReLUFused>::operator()(at::Tensor, c10::Scalar) [with bool ReLUFused = true]’:
+../aten/src/ATen/core/boxing/kernel_functor.h:262:25:   required from ‘static ReturnType c10::detail::wrap_kernel_functor_unboxed_<KernelFunctor, ReturnType(ParameterTypes ...)>::call(c10::OperatorKernel*, ParameterTypes ...) [with KernelFunctor = at::native::{anonymous}::QMulScalar<true>; ReturnType = at::Tensor; ParameterTypes = {at::Tensor, c10::Scalar}]’
+../aten/src/ATen/core/boxing/KernelFunction_impl.h:101:33:   required from ‘static c10::KernelFunction c10::KernelFunction::makeFromUnboxedFunctorFactory(std::function<std::unique_ptr<c10::OperatorKernel>()>) [with KernelFunctor = at::native::{anonymous}::QMulScalar<true>; bool AllowLegacyTypes = false]’
+../aten/src/ATen/core/op_registration/op_registration.h:150:69:   required from ‘c10::guts::enable_if_t<c10::guts::is_functor<LambdaType>::value, c10::RegisterOperators::Options&&> c10::RegisterOperators::Options::kernel(c10::TensorTypeId, ConstructorParameters&& ...) && [with KernelFunctor = at::native::{anonymous}::QMulScalar<true>; ConstructorParameters = {}; c10::guts::enable_if_t<c10::guts::is_functor<LambdaType>::value, c10::RegisterOperators::Options&&> = c10::RegisterOperators::Options&&]’
+../aten/src/ATen/native/quantized/cpu/qmul.cpp:187:55:   required from here
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/quantized/cpu/qmul.cpp:143:34: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     auto qc = at::empty_like(qa, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                  ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/quantized/cpu/qmul.cpp:143:34: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     auto qc = at::empty_like(qa, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                  ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../c10/core/MemoryFormat.h:32:74: warning: ‘c10::MemoryFormat c10::get_contiguous_memory_format()’ is deprecated [-Wdeprecated-declarations]
+ #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+../aten/src/ATen/native/quantized/cpu/qmul.cpp:143:34: note: in expansion of macro ‘LEGACY_CONTIGUOUS_MEMORY_FORMAT’
+     auto qc = at::empty_like(qa, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+                                  ^
+../c10/core/MemoryFormat.h:34:36: note: declared here
+ C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[1737/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/quantized/cpu/qlinear_unpack.cpp.o
+[1738/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/mkldnn/MKLDNNCommon.cpp.o
+[1739/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/quantized/cpu/qconv_prepack.cpp.o
+[1740/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/quantized/cpu/qconv.cpp.o
+[1741/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/mkldnn/MkldnnTensorMath.cpp.o
+[1742/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/mkldnn/Linear.cpp.o
+[1743/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/mkldnn/MKLDNNConversions.cpp.o
+[1744/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/mkldnn/Relu.cpp.o
+[1745/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/mkldnn/Pooling.cpp.o
+[1746/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/mkldnn/Normalization.cpp.o
+[1747/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/mkldnn/BinaryOps.cpp.o
+[1748/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/mkldnn/SoftMax.cpp.o
+[1749/2582] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/mkldnn/Conv.cpp.o
+[1750/2582] Building CXX object third_party/fbgemm/CMakeFiles/fbgemm_avx2.dir/src/FbgemmI8DepthwisePerChannelQuantAvx2.cc.o
+[1751/2582] Building CXX object caffe2/CMakeFiles/caffe2_pybind11_state.dir/python/pybind_state.cc.o
+[1752/2582] Building CXX object third_party/fbgemm/CMakeFiles/fbgemm_avx2.dir/src/FbgemmI8DepthwiseAvx2.cc.o
+ninja: build stopped: interrupted by user.
+Building wheel torch-1.4.0a0+d2a3b6e
+-- Building version 1.4.0a0+d2a3b6e
+cmake -GNinja -DBUILD_CAFFE2_OPS=0 -DBUILD_PYTHON=True -DBUILD_TEST=True -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=/scratch/iuriiz/repos/pytorch/torch -DCMAKE_PREFIX_PATH=/private/home/iuriiz/miniconda3/lib/python3.7/site-packages -DNUMPY_INCLUDE_DIR=/private/home/iuriiz/miniconda3/lib/python3.7/site-packages/numpy/core/include -DPYTHON_EXECUTABLE=/private/home/iuriiz/miniconda3/bin/python -DPYTHON_INCLUDE_DIR=/private/home/iuriiz/miniconda3/include/python3.7m -DPYTHON_LIBRARY=/private/home/iuriiz/miniconda3/lib/libpython3.7m.so.1.0 -DTORCH_BUILD_VERSION=1.4.0a0+d2a3b6e -DUSE_CUDA=1 -DUSE_NUMPY=True /scratch/iuriiz/repos/pytorch
+cmake --build . --target install --config Debug -- -j 80

--- a/aten/src/ATen/ScalarOps.h
+++ b/aten/src/ATen/ScalarOps.h
@@ -13,14 +13,14 @@ inline at::Tensor scalar_to_tensor(Scalar s, const Device device = at::kCPU) {
   // This is the fast track we have for CPU scalar tensors.
   if (device == at::kCPU) {
     if (s.isFloatingPoint()) {
-      return at::native::scalar_tensor(s, at::device(at::kCPU).dtype(at::kDouble));
+      return at::native::scalar_tensor(s, at::kDouble, c10::nullopt, at::kCPU);
     } else if (s.isBoolean()) {
-      return at::native::scalar_tensor(s, at::device(at::kCPU).dtype(at::kBool));
+      return at::native::scalar_tensor(s, at::kBool, c10::nullopt, at::kCPU);
     } else if (s.isComplex()) {
-      return at::native::scalar_tensor(s, at::device(at::kCPU).dtype(at::kComplexDouble));
+      return at::native::scalar_tensor(s, at::kComplexDouble, c10::nullopt, at::kCPU);
     } else {
       AT_ASSERT(s.isIntegral(false));
-      return at::native::scalar_tensor(s, at::device(at::kCPU).dtype(at::kLong));
+      return at::native::scalar_tensor(s,  at::kLong, c10::nullopt, at::kCPU);
     }
   }
   if (s.isFloatingPoint()) {

--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -3,6 +3,7 @@
 
 import re
 from code_template import CodeTemplate
+from tensor_options_utils import *
 
 try:
     import typing  # noqa: F401
@@ -92,6 +93,10 @@ NATIVE_DISPATCH_DECLARATION = CodeTemplate("""\
 ${return_type} ${api_name}(${type_method_formals});
 """)
 
+NATIVE_DISPATCH_DECLARATION_CONST = CodeTemplate("""\
+${return_type} ${api_name}(${type_method_formals}) const;
+""")
+
 NATIVE_DISPATCH_DEFINITION_DEFAULT = CodeTemplate("""\
 ${return_type} ${api_name}(${type_method_formals}) {
 #ifdef BUILD_NAMEDTENSOR
@@ -146,7 +151,11 @@ BACKEND_FUNCTION_REGISTRATION = CodeTemplate("""\
 TENSOR_METHOD_DECLARATION = CodeTemplate("""\
 ${return_type} ${api_name}(${method_formals_with_defaults}) const;
 """)
+TENSOR_METHOD_DECLARATION_UNDERSCORE = CodeTemplate("""\
+${return_type} _${api_name}(${method_formals_with_defaults}) const;
+""")
 # add non-virtual declaration to Tensor.cpp
+
 C10_TENSOR_METHOD_DEFINITION = CodeTemplate("""\
 inline ${return_type} Tensor::${api_name}(${method_formals}) const {
 #ifdef USE_STATIC_DISPATCH
@@ -157,14 +166,36 @@ inline ${return_type} Tensor::${api_name}(${method_formals}) const {
 #endif
 }
 """)
+
+C10_TENSOR_METHOD_DEFINITION_UNDERSCORE = CodeTemplate("""\
+inline ${return_type} Tensor::_${api_name}(${method_formals}) const {
+#ifdef USE_STATIC_DISPATCH
+    ${static_dispatch_method_body}
+#else
+    static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::${operator_name}", "${overload_name}"}).value();
+    return op.callUnboxed<${formals_types_with_return}>(${method_actuals});
+#endif
+}
+""")
+
 # add a method declaration in Functions.h
 FUNCTION_DECLARATION = CodeTemplate("""\
 static inline ${return_type} ${api_name}(${formals_with_defaults});
+""")
+FUNCTION_DECLARATION_UNDERSCORE = CodeTemplate("""\
+static inline ${return_type} _${api_name}(${formals_with_defaults});
+""")
+COLLAPSED_FUNCTION_DECLARATION = CodeTemplate("""\
+static inline ${return_type} ${api_name}(${collapsed_formals_with_defaults});
 """)
 # add a method declaration in Functions.h
 DEPRECATED_FUNCTION_DECLARATION = CodeTemplate("""\
 C10_DEPRECATED static inline ${return_type} ${api_name}(${formals_with_defaults});
 """)
+DEPRECATED_COLLAPSED_FUNCTION_DECLARATION = CodeTemplate("""\
+C10_DEPRECATED static inline ${return_type} ${api_name}(${collapsed_formals_with_defaults});
+""")
+
 # add method definition in Functions.h
 C10_FUNCTION_DEFINITION = CodeTemplate("""\
 static inline ${return_type} ${api_name}(${formals}) {
@@ -209,8 +240,8 @@ CAFFE2_API ${return_type} ${native_type_method_dispatch}(${formals_with_defaults
 """)
 
 # special method definition for factory functions in Functions.h that initializes backends
-C10_FACTORY_DEFINITION = CodeTemplate("""\
-static inline ${return_type} ${api_name}(${formals}) {
+C10_FACTORY_DEFINITION_UNDERSCORE = CodeTemplate("""\
+static inline ${return_type} _${api_name}(${formals}) {
 #ifdef USE_STATIC_DISPATCH
     ${static_dispatch_function_body}
 #else
@@ -222,14 +253,75 @@ static inline ${return_type} ${api_name}(${formals}) {
 }
 """)
 
+COLLAPSED_FACTORY_DEFINITION = CodeTemplate("""\
+inline ${return_type} ${api_name}(${collapsed_formals}) { 
+    return _${api_name}(${expanded_native_actuals});
+}
+""")
+
+COLLAPSED_METHOD_DEFINITION = CodeTemplate("""\
+inline ${return_type} Tensor::${api_name}(${collapsed_formals}) const { 
+    c10::optional<ScalarType> dtype = c10::nullopt;
+    c10::optional<Layout> layout = c10::nullopt;
+    c10::optional<Device> device = c10::nullopt;
+    c10::optional<bool> pin_memory = c10::nullopt;
+
+    if (options.dtype_opt().has_value()) {
+        dtype = typeMetaToScalarType(options.dtype());
+    }
+
+    if (options.layout_opt().has_value()) {
+        layout = options.layout();
+    }
+    
+    if (options.device_opt().has_value()) {
+        device = options.device();
+    }
+
+    if (options.pinned_memory_opt().has_value()) {
+        pin_memory = options.pinned_memory();
+    }
+
+    return _${api_name}(${expanded_native_actuals});
+}
+""")
+
+# This is a special case for '.to' operator. It should be cleaned up
+# issue #30405
+COLLAPSED_METHOD_TO_DEFINITION = CodeTemplate("""\
+inline ${return_type} Tensor::${api_name}(${collapsed_formals}) const { 
+    TORCH_CHECK(options.requires_grad_opt() == c10::nullopt,
+         "to(options) expects unset requires_grad flag, but got "
+         "options.requires_grad set as ", options.requires_grad());
+
+    c10::optional<ScalarType> dtype = c10::nullopt;
+    c10::optional<Layout> layout = c10::nullopt;
+    c10::optional<Device> device = c10::nullopt;
+    c10::optional<bool> pin_memory = c10::nullopt;
+
+    if (options.dtype_opt().has_value()) {
+        dtype = typeMetaToScalarType(options.dtype());
+    }
+
+    if (options.layout_opt().has_value()) {
+        layout = options.layout();
+    }
+    
+    if (options.device_opt().has_value()) {
+        device = options.device();
+    }
+
+    if (options.pinned_memory_opt().has_value()) {
+        pin_memory = options.pinned_memory();
+    }
+
+    return _${api_name}(${expanded_native_actuals});
+}
+""")
+
 ZERO_DIM_CHECK = CodeTemplate("""\
 if (${check_name}.dim() == 0) {
     return ${api_name}(${zero_dim_actuals});
-}""")
-
-SPARSE_CHECK = CodeTemplate("""\
-if(${check_name}.is_sparse()) {
-    return static_cast<const TypeExtendedInterface*>(this)->${api_name}(${sparse_actuals});
 }""")
 
 CONDITIONAL_INITIALIZER = CodeTemplate("""\
@@ -561,7 +653,9 @@ FunctionOption = TypedDict('FunctionOption', {
     'field_name': str,
     'formals_list': List[AtFormal],
     'formals_with_defaults': List[str],
+    'collapsed_formals_with_defaults': List[str],
     'formals': List[str],
+    'collapsed_formals': List[str],
     'formals_types': List[str],
     'formals_types_with_return': List[str],
     'inferred_type_set': str,
@@ -570,6 +664,7 @@ FunctionOption = TypedDict('FunctionOption', {
     # This controls whether or not we generate the interface in Type or
     # TypeExtendedInterface
     'extended_method': bool,
+    'collapsed_method_actuals': List[str],
     'method_actuals': List[str],
     'method_formals_with_defaults': List[str],
     'method_formals': List[str],
@@ -581,6 +676,7 @@ FunctionOption = TypedDict('FunctionOption', {
     'operator_name': str,
     'overload_name': str,
     'native_actuals': List[str],
+    'collapsed_native_actuals': List[str],
     'native_type_method_dispatch': str,
     # options should be List[FunctionOption]
     'options': Any,
@@ -599,7 +695,6 @@ FunctionOption = TypedDict('FunctionOption', {
     'variants': str,
     'when_spares_dispatch': str,
     'when_sparse_dispatch': str,
-    'with_gil': bool,
     'zero_dim_dispatch_when_scalar': str,
 })
 
@@ -638,7 +733,10 @@ def device_guard(option, dispatch_options, dispatch_tensor):
     # For factory methods the `DeviceGuard` is already in the template.
     if option.get('device_guard', True):
         if dispatch_options:
-            return 'const DeviceGuard device_guard({}.device());'.format(dispatch_options['name'])
+            if any(arg['type'] == 'c10::optional<ScalarType>' for arg in option['arguments']):
+                return 'auto dev = device.has_value() ? device.value() : Device(kCPU);\nconst DeviceGuard device_guard(dev);'
+            else:    
+                return 'const DeviceGuard device_guard(device); '
         if dispatch_tensor:
             return 'const OptionalDeviceGuard device_guard(device_of({}));'.format(dispatch_tensor)
     return '// DeviceGuard omitted'
@@ -667,7 +765,7 @@ if ({named_conditions}) {{
 
 def dispatch_scalar_type(option, dispatch_options, dispatch_tensor):
     if dispatch_options:
-        return 'auto dispatch_scalar_type = typeMetaToScalarType({}.dtype());'.format(dispatch_options['name'])
+        return 'auto dispatch_scalar_type = typeMetaToScalarType(dtype.value());'
     if dispatch_tensor:
         return 'auto dispatch_scalar_type = infer_scalar_type({});'.format(dispatch_tensor)
     return '// dispatch_scalar_type omitted'
@@ -678,7 +776,6 @@ def is_real_argument_to_wrapper(argument):
     return not argument.get('output', False) and\
         argument['type'] != 'CONSTANT' and\
         argument['type'] != 'argument'
-
 
 def is_mutable_formal_argument(argument, option):
     # type: (THFormal, FunctionOption) -> bool
@@ -879,8 +976,11 @@ def create_generic(top_env, declarations):
         # and Tensor arguments, you MUST only ever register it generically.
         r = []
         for formal in formals:
-            if formal['dynamic_type'] in ['TensorOptions', 'TensorList'] or is_any_tensor_type(formal):
+            if formal['dynamic_type'] in ['TensorList'] or is_any_tensor_type(formal):
                 r.append(formal['name'])
+
+        if check_if_factory_method(formals):
+            r.append('dtype, device, layout, pin_memory')
         return r
 
     def format_formal(f):
@@ -956,10 +1056,8 @@ def create_generic(top_env, declarations):
         option['type_method_actuals'] = option['actuals']
 
         assert 'method' not in option['variants'], 'TH functions cannot be methods'
-        is_function = 'function' in option['variants']
         # NB: TH functions don't support multiple dispatch
         dispatch_tensor = find_dispatch_tensor(formals)
-        is_namespace_function = is_function and dispatch_tensor is not None
 
         broadcast_arg = get_broadcast_argument(option)
         # "s_" for "same size".
@@ -1087,6 +1185,11 @@ def create_generic(top_env, declarations):
         option['formals_list'] = formals
         option['formals'] = [format_formal(f) for f in formals]
         option['formals_with_defaults'] = [formal_with_default(f) for f in formals]
+
+        collapsed_formals = collapse_formals_list(formals)
+        option['collapsed_formals'] = [format_formal(f) for f in collapsed_formals]
+        option['collapsed_formals_with_defaults'] = [formal_with_default(f) for f in collapsed_formals]
+        
         option['returns'] = native_get_return_types(option)
         option['return_type'] = format_return_type(option['returns'])
         option['return_call'] = 'return ' if option['return_type'] != 'void' else ''
@@ -1107,6 +1210,8 @@ def create_generic(top_env, declarations):
         # be const_casted to be accepted as native function's non-const argument
         option['method_actuals'] = [
             f['name'] if f['name'] != 'self' else 'const_cast<Tensor&>(*this)' for f in formals]
+
+        option['collapsed_method_actuals'] = collapse_actuals(option['method_actuals'])
 
         def find_formal(formal_name, formals):
             for formal in formals:
@@ -1157,19 +1262,30 @@ def create_generic(top_env, declarations):
                 static_dispatch_method_body = STATIC_DISPATCH_FUNCTION_DEFAULT_BODY.substitute(
                     option, native_arguments=option['method_actuals'])
 
-            method_definition = C10_TENSOR_METHOD_DEFINITION
-            return FunctionCode(
+            if check_if_factory_method(option['arguments']):  
+                return FunctionCode(
+                declaration=TENSOR_METHOD_DECLARATION_UNDERSCORE.substitute(
+                    option, static_dispatch_method_body=static_dispatch_method_body),
+                definition=C10_TENSOR_METHOD_DEFINITION_UNDERSCORE.substitute( 
+                    option, static_dispatch_method_body=static_dispatch_method_body))
+            else:
+                return FunctionCode(
+
                 declaration=TENSOR_METHOD_DECLARATION.substitute(
                     option, static_dispatch_method_body=static_dispatch_method_body),
-                definition=method_definition.substitute(
+                definition=C10_TENSOR_METHOD_DEFINITION.substitute(
                     option, static_dispatch_method_body=static_dispatch_method_body))
 
         def gen_namespace_function(option, multidispatch_tensors):
             # type: (Any, List[str]) -> FunctionCode
+            
             option['inferred_type_set'] = (
                 'c10::detail::multi_dispatch_tensor_type_set({})'.format(', '.join(multidispatch_tensors)))
             declaration = DEPRECATED_FUNCTION_DECLARATION if option['deprecated'] else FUNCTION_DECLARATION
             fn_declaration = declaration.substitute(option)
+
+            if is_factory_method:
+                fn_declaration = FUNCTION_DECLARATION_UNDERSCORE.substitute(option)
 
             if isinstance(type_method_dispatch, dict):
                 static_dispatch_function_switches = []
@@ -1189,11 +1305,52 @@ def create_generic(top_env, declarations):
                     option, native_arguments=option['native_actuals'])
 
             if is_factory_method:
-                fn_definition = C10_FACTORY_DEFINITION.substitute(
+                fn_definition = C10_FACTORY_DEFINITION_UNDERSCORE.substitute(
                     option, static_dispatch_function_body=static_dispatch_function_body)
             else:
                 fn_definition = C10_FUNCTION_DEFINITION.substitute(
                     option, static_dispatch_function_body=static_dispatch_function_body)
+
+            return FunctionCode(definition=fn_definition, declaration=fn_declaration)
+
+        def gen_collapsed_function_declaration(option):
+            declaration = DEPRECATED_COLLAPSED_FUNCTION_DECLARATION if option['deprecated'] else COLLAPSED_FUNCTION_DECLARATION
+            fn_declaration = declaration.substitute(option)
+
+            expanded_native_actuals = option['collapsed_native_actuals'][:]
+            index = expanded_native_actuals.index('options')
+            expanded_native_actuals.remove('options')
+            expanded_native_actuals.insert(index, 'options.pinned_memory()')
+            expanded_native_actuals.insert(index, 'options.device()')
+            
+             # special case for 'sparse_coo_tensor' and '_sparse_coo_tensor_unsafe'
+             # issue #30405
+            if (option['name'] == 'sparse_coo_tensor' or option['name'] == '_sparse_coo_tensor_unsafe'):
+                expanded_native_actuals.insert(index, 'options.layout_opt()')
+            else:
+                expanded_native_actuals.insert(index, 'options.layout()')
+            expanded_native_actuals.insert(index, 'typeMetaToScalarType(options.dtype())')
+
+            fn_definition = COLLAPSED_FACTORY_DEFINITION.substitute(option, expanded_native_actuals=expanded_native_actuals)
+            return FunctionCode(definition=fn_definition, declaration=fn_declaration)
+
+        def gen_native_dispatch_declaration(option):
+            declaration = NATIVE_DISPATCH_DECLARATION_CONST
+            fn_declaration = declaration.substitute(option, type_method_formals= collapse_formals(option['method_formals_with_defaults']))
+
+            expanded_native_actuals = option['collapsed_method_actuals'][:]
+            expanded_native_actuals.remove('const_cast<Tensor&>(*this)')
+            index = expanded_native_actuals.index('options')
+            expanded_native_actuals.remove('options')
+            expanded_native_actuals.insert(index, 'pin_memory')
+            expanded_native_actuals.insert(index, 'device')
+            expanded_native_actuals.insert(index, 'layout')
+            expanded_native_actuals.insert(index, 'dtype')
+
+            if option['name'] == 'to':
+                fn_definition = COLLAPSED_METHOD_TO_DEFINITION.substitute(option, collapsed_formals = collapse_formals(option['method_formals']), expanded_native_actuals=expanded_native_actuals)
+            else:    
+                fn_definition = COLLAPSED_METHOD_DEFINITION.substitute(option, collapsed_formals = collapse_formals(option['method_formals']), expanded_native_actuals=expanded_native_actuals)
             return FunctionCode(definition=fn_definition, declaration=fn_declaration)
 
         # Emit #ifdef BUILD_NAMEDTENSOR macros for any code generated here
@@ -1218,20 +1375,17 @@ def create_generic(top_env, declarations):
                 option['name'], ", ".join(option['method_formals_with_defaults']))
 
         type_method_dispatch = option['type_method_definition_dispatch']
-
         multidispatch_tensors = find_multidispatch_tensors(formals)
-
         option['type_method_formals'] = [format_formal(f) for f in formals]
         option['type_method_actuals'] = [f['name'] for f in formals]
         option['native_actuals'] = [f['name'] for f in formals]
+        option['collapsed_native_actuals'] = [f['name'] for f in collapsed_formals]
 
         is_method = 'method' in option['variants']
         is_namespace_function = 'function' in option['variants']
         # For method-only entries, the first argument should be self
         if is_method and not is_namespace_function:
             assert formals[0]['name'] == 'self'
-        is_factory_method = find_formal('TensorOptions', formals) and 'method' not in option['variants']
-
         check_methods_do_not_start_with_underscore(option['name'], is_method)
 
         option['method_prefix_derived'] = ''
@@ -1239,7 +1393,7 @@ def create_generic(top_env, declarations):
         # first argument.  Scalar type test will be removed once TH is removed.
         # If you need more complex device guard behavior, you should disable
         # device guard and then manually add the guards you need.
-        dispatch_options = find_formal('TensorOptions', formals)
+        dispatch_options = check_tensor_options_in_formals(formals)
         guard_tensor = None if dispatch_options else find_dispatch_tensor(formals)
         option['device_guard_declaration'] = device_guard(option, dispatch_options, guard_tensor)
         option['named_guard_declaration'] = named_guard(option, find_tensors(formals),
@@ -1304,6 +1458,8 @@ def create_generic(top_env, declarations):
                 check_namedtensor_enabled(NATIVE_DECLARATION.substitute(option)))
 
         method_of = ['Type']
+        is_factory_method = check_if_factory_method(option['arguments'])
+
         if is_method:
             code = gen_tensor_method(option, multidispatch_tensors)
             if is_named_tensor_only:
@@ -1311,6 +1467,11 @@ def create_generic(top_env, declarations):
             top_env['tensor_method_declarations'].append(code.declaration)
             top_env['tensor_method_definitions'].append(code.definition)
             method_of.append('Tensor')
+            
+            if is_factory_method:
+                code = gen_native_dispatch_declaration(option)
+                top_env['tensor_method_declarations'].append(code.declaration)
+                top_env['tensor_method_definitions'].append(code.definition)
 
         if is_namespace_function:
             code = gen_namespace_function(option, multidispatch_tensors)
@@ -1319,6 +1480,17 @@ def create_generic(top_env, declarations):
             top_env['function_definitions'].append(code.definition)
             top_env['function_declarations'].append(code.declaration)
             method_of.append('namespace')
+
+            if is_factory_method:
+                # function_definitions and function_declarations are being used for constructing 
+                # Functions.h which is part of our C++ API. We have to preverse TensorOption here
+                collapsed_code = gen_collapsed_function_declaration(option)
+                
+                if is_named_tensor_only:
+                    collapsed_code = add_namedtensor_enabled_macro(collapsed_code)
+
+                top_env['function_definitions'].append(collapsed_code.definition)
+                top_env['function_declarations'].append(collapsed_code.declaration)
 
         if not BUILD_NAMEDTENSOR and is_named_tensor_only:
             return None
@@ -1367,7 +1539,6 @@ def create_generic(top_env, declarations):
         output_declarations.extend(output_options)
 
     return output_declarations
-
 
 def create_derived(backend_type_env, declarations):
     # type: (Environment, List[FunctionOption]) -> Tuple[List[str], List[str], List[str], List[str], List[str]]

--- a/aten/src/ATen/native/QuantizedLinear.cpp
+++ b/aten/src/ATen/native/QuantizedLinear.cpp
@@ -236,7 +236,9 @@ std::tuple<Tensor, Tensor, double, int64_t> fbgemm_linear_quantize_weight(
   q_params.precision = kPrecision;
 
   Tensor quantized = at::native::empty_like(
-      weight_contig, weight_contig.options().dtype(at::kChar), LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+      weight_contig, at::kChar, weight_contig.options().layout(), 
+      weight_contig.options().device(), weight_contig.options().pinned_memory(), 
+      LEGACY_CONTIGUOUS_MEMORY_FORMAT);
   // Tensor quantized = at::native::empty_cpu(
   //     weight_contig.sizes(), weight_contig.options().dtype(at::kChar));
   fbgemm::Quantize<int8_t>(

--- a/aten/src/ATen/native/SobolEngineOps.cpp
+++ b/aten/src/ATen/native/SobolEngineOps.cpp
@@ -150,7 +150,12 @@ Tensor& _sobol_engine_initialize_state_(Tensor& sobolstate, int64_t dimension) {
     }
   }
 
-  Tensor pow2s = at::pow(2, at::native::arange((MAXBIT - 1), -1, -1, sobolstate.options()));
+  Tensor pow2s = at::pow(2, at::native::arange(
+    (MAXBIT - 1), -1, -1, 
+    typeMetaToScalarType(sobolstate.options().dtype()), 
+                         sobolstate.options().layout(), 
+                         sobolstate.options().device(), 
+                         sobolstate.options().pinned_memory()));
   sobolstate.mul_(pow2s);
   return sobolstate;
 }

--- a/aten/src/ATen/native/SummaryOps.cpp
+++ b/aten/src/ATen/native/SummaryOps.cpp
@@ -36,7 +36,11 @@ Tensor _bincount_cpu_template(
 
   const input_t* self_p = self.data_ptr<input_t>();
   if (has_weights) {
-    output = native::zeros({nbins}, weights.options());
+    output = native::zeros({nbins},
+                            typeMetaToScalarType(weights.options().dtype()),
+                                                 weights.options().layout(),
+                                                 weights.options().device(),
+                                                 weights.options().pinned_memory());
     weights_t* output_p = output.data_ptr<weights_t>();
     const weights_t* weights_p = weights.data_ptr<weights_t>();
     for (int64_t i = 0; i < self.size(0); i++) {

--- a/aten/src/ATen/native/TensorConversions.cpp
+++ b/aten/src/ATen/native/TensorConversions.cpp
@@ -45,29 +45,23 @@ static inline Tensor to_impl(const Tensor& self, const TensorOptions& options, b
   return r;
 }
 
-Tensor to(const Tensor& self, const TensorOptions& options, bool non_blocking, bool copy, c10::optional<c10::MemoryFormat> optional_memory_format) {
-  TORCH_CHECK(options.requires_grad_opt() == c10::nullopt,
-           "to(options) expects unset requires_grad flag, but got "
-           "options.requires_grad set as ", options.requires_grad());
-
-  const auto & layout_opt = options.layout_opt();
-  TORCH_CHECK(!layout_opt || self.layout() == layout_opt.value(),
+Tensor to(const Tensor& self, c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory, bool non_blocking, bool copy, c10::optional<c10::MemoryFormat> optional_memory_format) {
+  TORCH_CHECK(!layout.has_value() || self.layout() == layout.value(),
            "to(options) doesn't support converting to a different layout, "
            "but got self.layout being ", self.layout(),
-           " and options.layout set as ", options.layout());
-
-  auto device_opt = options.device_opt();
-  if (device_opt) {
-    device_opt = ensure_has_index(device_opt.value());
+           " and options.layout set as ", layout.value());
+  
+  if (device.has_value()) {
+    device = ensure_has_index(device.value());
   }
-  const auto & dtype_opt = options.dtype_opt();
   auto specified_options = self.options();
-  if (device_opt) {
-    specified_options = specified_options.device(device_opt.value());
+  if (device.has_value()) {
+    specified_options = specified_options.device(device.value());
   }
-  if (dtype_opt) {
-    specified_options = specified_options.dtype(dtype_opt.value());
+  if (dtype.has_value()) {
+    specified_options = specified_options.dtype(dtype.value());
   }
+  
   return to_impl(self, specified_options, non_blocking, copy, optional_memory_format);
 }
 

--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -29,20 +29,22 @@
 namespace at {
 namespace native {
 namespace {
+
 void window_function_checks(
     const char* function_name,
-    const TensorOptions& options,
+    c10::optional<c10::ScalarType> dtype,
+    c10::optional<c10::Layout> layout,
     int64_t window_length) {
   TORCH_CHECK(
-      options.layout() != kSparse,
+      layout.has_value() && layout.value() != kSparse,
       function_name,
       " is not implemented for sparse types, got: ",
-      options);
+      layout.value());
   TORCH_CHECK(
-      at::isFloatingType(typeMetaToScalarType(options.dtype())) || at::isComplexType(typeMetaToScalarType(options.dtype())),
+      at::isFloatingType(dtype.value()) || at::isComplexType(dtype.value()),
       function_name,
       " expects floating point dtypes, got: ",
-      options);
+      dtype.value());
   TORCH_CHECK(
       window_length >= 0,
       function_name,
@@ -64,20 +66,24 @@ static inline bool allIntegral(std::initializer_list<std::reference_wrapper<Scal
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ arange ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Tensor arange(Scalar end, const TensorOptions& options) {
-  return native::arange(/*start=*/0, end, options);
+Tensor arange(Scalar end, c10::optional<c10::ScalarType> dtype, c10::optional<c10::Layout> layout, c10::optional<c10::Device> device, c10::optional<bool> pin_memory) {
+  return native::arange(/*start=*/0, end, dtype, layout, device, pin_memory);
 }
 
-Tensor arange(Scalar start, Scalar end, const TensorOptions& options) {
-  return native::arange(start, end, /*step=*/1, options);
+Tensor arange(Scalar start, Scalar end, c10::optional<c10::ScalarType> dtype, c10::optional<c10::Layout> layout, c10::optional<c10::Device> device, c10::optional<bool> pin_memory) {
+  return native::arange(start, end, /*step=*/1, dtype, layout, device, pin_memory);
 }
 
 Tensor arange(
     Scalar start,
     Scalar end,
     Scalar step,
-    const TensorOptions& options) {
-  bool set_to_integral_dtype = !options.has_dtype() && allIntegral({start, end, step});
+    c10::optional<c10::ScalarType> dtype, 
+    c10::optional<c10::Layout> layout, 
+    c10::optional<c10::Device> device, 
+    c10::optional<bool> pin_memory) {
+  TensorOptions options = TensorOptions().dtype(dtype).layout(layout).device(device).pinned_memory(pin_memory);
+  bool set_to_integral_dtype = !dtype.has_value() && allIntegral({start, end, step});
   Tensor result = set_to_integral_dtype
       ? at::empty({0}, options.dtype(at::ScalarType::Long))
       : at::empty({0}, options);
@@ -97,24 +103,24 @@ Tensor _dim_arange(const Tensor& like, int64_t dim) {
 }
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ empty ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Tensor empty_cpu(IntArrayRef size, const TensorOptions& options, c10::optional<c10::MemoryFormat> optional_memory_format) {
-  AT_ASSERT(options.device().type() == DeviceType::CPU);
+Tensor empty_cpu(IntArrayRef size, c10::optional<c10::ScalarType> dtype, c10::optional<c10::Layout> layout, c10::optional<c10::Device> device, c10::optional<bool> pin_memory, c10::optional<c10::MemoryFormat> optional_memory_format) {
+  AT_ASSERT(device.value().type() == DeviceType::CPU);
   TORCH_INTERNAL_ASSERT(impl::variable_excluded_from_dispatch());
   check_size_nonnegative(size);
 
   c10::Allocator* allocator;
-  if (options.pinned_memory()) {
+  if (pin_memory.has_value() && pin_memory.value()) {
     allocator = detail::getCUDAHooks().getPinnedMemoryAllocator();
   } else {
     allocator = at::getCPUAllocator();
   }
 
   int64_t nelements = prod_intlist(size);
-  auto dtype = options.dtype();
+  auto currDtype = dtype.has_value() ? scalarTypeToTypeMeta(dtype.value()) : at::get_default_dtype();
   auto storage_impl = c10::make_intrusive<StorageImpl>(
-    dtype,
+    currDtype,
     nelements,
-    allocator->allocate(nelements * dtype.itemsize()),
+    allocator->allocate(nelements * currDtype.itemsize()),
     allocator,
     /*resizeable=*/true);
 
@@ -133,24 +139,27 @@ Tensor empty_cpu(IntArrayRef size, const TensorOptions& options, c10::optional<c
 Tensor empty(
     IntArrayRef size,
     at::optional<DimnameList> names,
-    const TensorOptions& options,
+    c10::optional<c10::ScalarType> dtype, 
+    c10::optional<c10::Layout> layout, 
+    c10::optional<c10::Device> device, 
+    c10::optional<bool> pin_memory,
     optional<MemoryFormat> optional_memory_format) {
   if (!names.has_value()) {
-    return at::empty(size, options, optional_memory_format);
+    return at::_empty(size, dtype, layout, device, pin_memory, optional_memory_format);
   }
-  TORCH_CHECK(options.layout() == Layout::Strided,
+  TORCH_CHECK(layout.has_value() && layout.value() == Layout::Strided,
       "NYI: named tensors only support strided layout");
-  TORCH_CHECK(options.device().type() == DeviceType::CPU || options.device().type() == DeviceType::CUDA,
+  TORCH_CHECK((device.has_value() && device.value().type() == DeviceType::CPU) || device.value().type() == DeviceType::CUDA,
       "NYI: named tensors only support CPU and CUDA tensors");
-  auto result = at::empty(size, options, optional_memory_format);
+  auto result = at::_empty(size, dtype, layout, device, pin_memory, optional_memory_format);
   internal_set_names_inplace(result, names);
   return result;
 }
 #endif
 
-Tensor empty_strided_cpu(IntArrayRef size, IntArrayRef stride, const TensorOptions& options) {
+Tensor empty_strided_cpu(IntArrayRef size, IntArrayRef stride, c10::optional<c10::ScalarType> dtype, c10::optional<c10::Layout> layout, c10::optional<c10::Device> device, c10::optional<bool> pin_memory) {
   check_size_nonnegative(size);
-  auto t = at::native::empty_cpu({0}, options);
+  auto t = at::native::empty_cpu({0}, dtype, layout, device, pin_memory);
   at::native::resize_impl_cpu_(t.unsafeGetTensorImpl(), size, stride);
   return t;
 }
@@ -192,20 +201,22 @@ AT_FORALL_SCALAR_TYPES_AND3(Bool, Half, BFloat16, DEFINE_CAST_OP)
 Tensor empty_like(
     const Tensor& self,
     c10::optional<c10::MemoryFormat> optional_memory_format) {
-  return native::empty_like(self, self.options(), optional_memory_format);
+  return native::empty_like(self, typeMetaToScalarType(self.options().dtype()), self.options().layout(), self.options().device(), self.options().pinned_memory(), optional_memory_format);
 }
 
+// *_like functions should be consistent with the rest of ops and 
+// take optional dtype, layout, device and pin_memory
+// issue #30405 
 Tensor empty_like(
     const Tensor& self,
-    const TensorOptions& options,
+    ScalarType dtype, Layout layout, Device device, bool pin_memory,
     c10::optional<c10::MemoryFormat> optional_memory_format) {
-
   TORCH_CHECK(
-      !(options.layout() != kStrided &&
+      !(layout != kStrided &&
           optional_memory_format.has_value()),
       "memory format option is only supported by strided tensors");
-  if (options.layout() == kSparse && self.is_sparse()) {
-    auto result = at::empty({0}, options); // to be resized
+  if (layout == kSparse && self.is_sparse()) {
+    auto result = at::_empty({0}, dtype, layout, device, pin_memory); // to be resized
     result.sparse_resize_and_clear_(
         self.sizes(), self.sparse_dim(), self.dense_dim());
     return result;
@@ -226,24 +237,24 @@ Tensor empty_like(
 
     // We could check if dtype is still quantized?  But then should we shift/scale
     // the q_zero_point / q_scale or not?
-    TORCH_CHECK(!options.has_dtype() || options.dtype() == self.dtype(),
+    TORCH_CHECK(dtype != ScalarType::Undefined || dtype == self.dtype(),
                 "It is currently not supported to specify a dtype that doesn't match "
-                "the input tensor's dtype via empty_like.  Specified: ", options.dtype(),
+                "the input tensor's dtype via empty_like.  Specified: ", dtype,
                 " Input tensor's dtype: ", self.dtype());
     auto qscheme = self.qscheme();
     if (qscheme == kPerTensorAffine) {
-      return at::_empty_affine_quantized(self.sizes(), options,
+      return at::__empty_affine_quantized(self.sizes(), dtype, layout, device, pin_memory,
                                          self.q_scale(),
                                          self.q_zero_point(),
                                          memory_format);
     } else if (qscheme == kPerChannelAffine) {
       // Copy the tensors with channels to avoid accidental overrides
-      return at::_empty_per_channel_affine_quantized(
+      return at::__empty_per_channel_affine_quantized(
           self.sizes(),
           self.q_per_channel_scales().clone(at::MemoryFormat::Preserve),
           self.q_per_channel_zero_points().clone(at::MemoryFormat::Preserve),
           self.q_per_channel_axis(),
-          options,
+          dtype, layout, device, pin_memory,
           memory_format);
     } else {
       TORCH_CHECK(false, "Unsupported qscheme: ", toString(qscheme));
@@ -256,12 +267,12 @@ Tensor empty_like(
       optional_memory_format.value_or(MemoryFormat::Contiguous);
   if (memory_format == MemoryFormat::Preserve) {
     if (self.is_non_overlapping_and_dense()) {
-      result = at::empty_strided(self.sizes(), self.strides(), options);
+      result = at::_empty_strided(self.sizes(), self.strides(), dtype, layout, device, pin_memory);
     } else {
-      result = at::empty(self.sizes(), options, self.suggest_memory_format());
+      result = at::_empty(self.sizes(), dtype, layout, device, pin_memory, self.suggest_memory_format());
     }
   } else {
-    result = at::empty(self.sizes(), options, memory_format);
+    result = at::_empty(self.sizes(), dtype, layout, device, pin_memory, memory_format);
   }
 
 #ifdef BUILD_NAMEDTENSOR
@@ -276,19 +287,21 @@ Tensor empty_like(
 Tensor new_empty(
     const Tensor& self,
     IntArrayRef size,
-    const TensorOptions& options
+    c10::optional<c10::ScalarType> dtype, c10::optional<c10::Layout> layout, c10::optional<c10::Device> device, c10::optional<bool> pin_memory
     ) {
-  return at::empty(size, self.options().merge_in(options));
+  TensorOptions incomingTO = TensorOptions().dtype(dtype).layout(layout).device(device).pinned_memory(pin_memory);
+  TensorOptions mergedTO = self.options().merge_in(incomingTO);
+  return at::_empty(size, typeMetaToScalarType(mergedTO.dtype()), mergedTO.layout(), mergedTO.device(), mergedTO.pinned_memory());
 }
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ eye ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Tensor eye(int64_t n, const TensorOptions& options) {
-  return native::eye(n, -1, options);
+Tensor eye(int64_t n, c10::optional<c10::ScalarType> dtype, c10::optional<c10::Layout> layout, c10::optional<c10::Device> device, c10::optional<bool> pin_memory) {
+  return native::eye(n, -1, dtype, layout, device, pin_memory);
 }
 
-Tensor eye(int64_t n, int64_t m, const TensorOptions& options) {
-  auto tensor = at::empty({0}, options); // to be resized
+Tensor eye(int64_t n, int64_t m, c10::optional<c10::ScalarType> dtype, c10::optional<c10::Layout> layout, c10::optional<c10::Device> device, c10::optional<bool> pin_memory) {
+  auto tensor = at::_empty({0}, dtype, layout, device, pin_memory); // to be resized
   return at::eye_out(tensor, n, m);
 }
 
@@ -320,11 +333,11 @@ Tensor& eye_out_cpu(Tensor& result, int64_t n, int64_t m) {
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ full ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Tensor full(IntArrayRef size, Scalar fill_value, const TensorOptions& options) {
-  if (options.layout() == kSparse) {
+Tensor full(IntArrayRef size, Scalar fill_value, c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) {
+  if (layout.value() == kSparse) {
     AT_ERROR("full(...) is not implemented for sparse layout");
   }
-  auto result = at::empty(size, options);
+  auto result = at::_empty(size, dtype, layout, device, pin_memory);
   return result.fill_(fill_value);
 }
 
@@ -341,15 +354,18 @@ Tensor full_like(
     Scalar fill_value,
     c10::optional<c10::MemoryFormat> optional_memory_format) {
   return native::full_like(
-      self, fill_value, self.options(), optional_memory_format);
+      self, fill_value, typeMetaToScalarType(self.options().dtype()), self.options().layout(), self.options().device(), self.options().pinned_memory(), optional_memory_format);
 }
 
 Tensor full_like(
     const Tensor& self,
     Scalar fill_value,
-    const TensorOptions& options,
+    ScalarType dtype, 
+    Layout layout, 
+    Device device, 
+    bool pin_memory,
     c10::optional<c10::MemoryFormat> optional_memory_format) {
-  auto result = at::empty_like(self, options, optional_memory_format);
+  auto result = at::_empty_like(self, dtype, layout, device, pin_memory, optional_memory_format);
   return result.fill_(fill_value);
 }
 
@@ -357,8 +373,17 @@ Tensor new_full(
     const Tensor& self,
     IntArrayRef size,
     Scalar fill_value,
-    const TensorOptions& options
+    c10::optional<ScalarType> dtype, 
+    c10::optional<Layout> layout, 
+    c10::optional<Device> device, 
+    c10::optional<bool> pin_memory
     ) {
+  
+  const auto options = TensorOptions()
+        .dtype(dtype)
+        .layout(layout)
+        .device(device)
+        .pinned_memory(pin_memory);
   return at::full(size, fill_value, self.options().merge_in(options));
 }
 
@@ -369,9 +394,12 @@ Tensor linspace(
     Scalar start,
     Scalar end,
     int64_t steps,
-    const TensorOptions& options) {
+    c10::optional<ScalarType> dtype, 
+    c10::optional<Layout> layout, 
+    c10::optional<Device> device, 
+    c10::optional<bool> pin_memory) {
   TORCH_CHECK(steps >= 0, "number of steps must be non-negative");
-  Tensor result = at::empty({steps}, options);
+  Tensor result = at::_empty({steps}, dtype, layout, device, pin_memory);
   return at::linspace_out(result, start, end, steps);
 }
 
@@ -382,15 +410,18 @@ Tensor logspace(
     Scalar end,
     int64_t steps,
     double base,
-    const TensorOptions& options) {
-  Tensor result = at::empty({steps}, options);
+    c10::optional<ScalarType> dtype, 
+    c10::optional<Layout> layout, 
+    c10::optional<Device> device, 
+    c10::optional<bool> pin_memory) {
+  Tensor result = at::_empty({steps}, dtype, layout, device, pin_memory);
   return at::logspace_out(result, start, end, steps, base);
 }
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ones ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Tensor ones(IntArrayRef size, const TensorOptions& options) {
-  return native::full(size, /*fill_value=*/1, options);
+Tensor ones(IntArrayRef size, c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) {
+  return native::full(size, /*fill_value=*/1, dtype, layout, device, pin_memory);
 }
 
 Tensor& ones_out(Tensor& result, IntArrayRef size) {
@@ -399,9 +430,12 @@ Tensor& ones_out(Tensor& result, IntArrayRef size) {
 
 Tensor ones_like(
     const Tensor& self,
-    const TensorOptions& options,
+    ScalarType dtype, 
+    Layout layout, 
+    Device device, 
+    bool pin_memory,
     c10::optional<c10::MemoryFormat> optional_memory_format) {
-  auto result = at::empty_like(self, options, optional_memory_format);
+  auto result = at::_empty_like(self, dtype, layout, device, pin_memory, optional_memory_format);
   return result.fill_(1);
 }
 
@@ -409,13 +443,13 @@ Tensor ones_like(
     const Tensor& self,
     c10::optional<c10::MemoryFormat> optional_memory_format) {
   return native::ones_like(
-      self, self.options(), optional_memory_format);
+      self, typeMetaToScalarType(self.options().dtype()), self.options().layout(), self.options().device(), self.options().pinned_memory(), optional_memory_format);
 }
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ scalar_tensor ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Tensor scalar_tensor(Scalar s, const TensorOptions& options) {
-  if (options.device() == at::kCPU) {
+Tensor scalar_tensor(Scalar s, c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) {
+  if (device.has_value() && device.value() == at::kCPU) {
     // This is a fast track to skip device dispatch for making scalar tensor on CPU.
     // See https://github.com/pytorch/pytorch/pull/29915 for more detailed perf
     // difference.
@@ -423,21 +457,21 @@ Tensor scalar_tensor(Scalar s, const TensorOptions& options) {
     // revert this to following:
     //   auto result = at::empty({}, options);
     at::AutoNonVariableTypeMode non_var_type_mode(true);
-    auto result = empty_cpu({}, options);
+    auto result = empty_cpu({}, dtype, layout, device, pin_memory);
     at::native::fill_(result, s);
     return result;
   }
-  return at::empty({}, options).fill_(s);
+  return at::_empty({}, dtype, layout, device, pin_memory).fill_(s);
 }
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ rand ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Tensor rand(IntArrayRef size, const TensorOptions& options) {
-  return native::rand(size, nullptr, options);
+Tensor rand(IntArrayRef size, c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) {
+  return native::rand(size, nullptr, dtype, layout, device, pin_memory);
 }
 
-Tensor rand(IntArrayRef size, Generator* generator, const TensorOptions& options) {
-  auto result = at::empty(size, options);
+Tensor rand(IntArrayRef size, Generator* generator, c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) {
+  auto result = at::_empty(size, dtype, layout, device, pin_memory);
   return result.uniform_(0, 1, generator);
 }
 
@@ -453,37 +487,40 @@ Tensor& rand_out(Tensor& result, IntArrayRef size, Generator* generator) {
 Tensor rand_like(
     const Tensor& self,
     c10::optional<c10::MemoryFormat> optional_memory_format) {
-  return native::rand_like(self, self.options(), optional_memory_format);
+  return native::rand_like(self, typeMetaToScalarType(self.options().dtype()), self.options().layout(), self.options().device(), self.options().pinned_memory(), optional_memory_format);
 }
 
 Tensor rand_like(
     const Tensor& self,
-    const TensorOptions& options,
+    ScalarType dtype, 
+    Layout layout, 
+    Device device, 
+    bool pin_memory,
     c10::optional<c10::MemoryFormat> optional_memory_format) {
-  auto result = at::empty_like(self, options, optional_memory_format);
+  auto result = at::_empty_like(self, dtype, layout, device, pin_memory, optional_memory_format);
   return result.uniform_(0, 1, nullptr);
 }
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ randint ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Tensor randint(int64_t high, IntArrayRef size, const TensorOptions& options) {
-  return native::randint(high, size, nullptr, options);
+Tensor randint(int64_t high, IntArrayRef size, c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) {
+  return native::randint(high, size, nullptr, dtype, layout, device, pin_memory);
 }
 
 Tensor randint(
     int64_t high,
     IntArrayRef size,
     Generator* generator,
-    const TensorOptions& options) {
-  return native::randint(0, high, size, generator, options);
+    c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) {
+  return native::randint(0, high, size, generator, dtype, layout, device, pin_memory);
 }
 
 Tensor randint(
     int64_t low,
     int64_t high,
     IntArrayRef size,
-    const TensorOptions& options) {
-  return native::randint(low, high, size, nullptr, options);
+    c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) {
+  return native::randint(low, high, size, nullptr, dtype, layout, device, pin_memory);
 }
 
 Tensor randint(
@@ -491,8 +528,8 @@ Tensor randint(
     int64_t high,
     IntArrayRef size,
     Generator* generator,
-    const TensorOptions& options) {
-  auto result = at::empty(size, options);
+    c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) {
+  auto result = at::_empty(size, dtype, layout, device, pin_memory);
   return result.random_(low, high, generator);
 }
 
@@ -523,51 +560,47 @@ Tensor& randint_out(
   return result.random_(low, high, generator);
 }
 
+Tensor randint_like(const Tensor& self, int64_t high, c10::optional<c10::MemoryFormat> optional_memory_format) {
+  return native::randint_like(self, high, typeMetaToScalarType(self.options().dtype()), self.options().layout(), self.options().device(), self.options().pinned_memory(), optional_memory_format);
+}
+
+Tensor randint_like(const Tensor& self, int64_t low, int64_t high, c10::optional<c10::MemoryFormat> optional_memory_format) {
+  return native::randint_like(self, low, high, typeMetaToScalarType(self.options().dtype()), self.options().layout(), self.options().device(), self.options().pinned_memory(), optional_memory_format);
+}
+
 Tensor randint_like(
     const Tensor& self,
     int64_t high,
+    ScalarType dtype, 
+    Layout layout, 
+    Device device, 
+    bool pin_memory,
     c10::optional<c10::MemoryFormat> optional_memory_format) {
-  return native::randint_like(
-      self, high, self.options(), optional_memory_format);
+      auto result = at::_empty_like(self, dtype, layout, device, pin_memory, optional_memory_format);
+      return result.random_(0, high, nullptr);
 }
 
 Tensor randint_like(
     const Tensor& self,
     int64_t low,
     int64_t high,
+    ScalarType dtype, 
+    Layout layout, 
+    Device device, 
+    bool pin_memory,
     c10::optional<c10::MemoryFormat> optional_memory_format) {
-  return native::randint_like(
-      self, low, high, self.options(), optional_memory_format);
-}
-
-Tensor randint_like(
-    const Tensor& self,
-    int64_t high,
-    const TensorOptions& options,
-    c10::optional<c10::MemoryFormat> optional_memory_format) {
-  auto result = at::empty_like(self, options, optional_memory_format);
-  return result.random_(0, high, nullptr);
-  return native::randint(high, self.sizes(), nullptr, options);
-}
-
-Tensor randint_like(
-    const Tensor& self,
-    int64_t low,
-    int64_t high,
-    const TensorOptions& options,
-    c10::optional<c10::MemoryFormat> optional_memory_format) {
-  auto result = at::empty_like(self, options, optional_memory_format);
-  return result.random_(low, high, nullptr);
+      auto result = at::_empty_like(self, dtype, layout, device, pin_memory, optional_memory_format);
+      return result.random_(low, high, nullptr);
 }
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ randn ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Tensor randn(IntArrayRef size, const TensorOptions& options) {
-  return native::randn(size, nullptr, options);
+Tensor randn(IntArrayRef size, c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) {
+  return native::randn(size, nullptr, dtype, layout, device, pin_memory);
 }
 
-Tensor randn(IntArrayRef size, Generator* generator, const TensorOptions& options) {
-  auto result = at::empty(size, options);
+Tensor randn(IntArrayRef size, Generator* generator, c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) {
+  auto result = at::_empty(size, dtype, layout, device, pin_memory);
   return result.normal_(0, 1, generator);
 }
 
@@ -581,8 +614,8 @@ Tensor& randn_out(Tensor& result, IntArrayRef size, Generator* generator) {
 }
 
 Tensor normal(double mean, double std, IntArrayRef size,
-              Generator* generator, const TensorOptions& options) {
-  auto result = at::empty(size, options);
+              Generator* generator, c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) {
+  auto result = at::_empty(size, dtype, layout, device, pin_memory);
   return result.normal_(mean, std, generator);
 }
 
@@ -595,14 +628,17 @@ Tensor& normal_out(Tensor& result, double mean, double std,
 Tensor randn_like(
     const Tensor& self,
     c10::optional<c10::MemoryFormat> optional_memory_format) {
-  return native::randn_like(self, self.options(), optional_memory_format);
+  return native::randn_like(self, typeMetaToScalarType(self.options().dtype()), self.options().layout(), self.options().device(), self.options().pinned_memory(), optional_memory_format);
 }
 
 Tensor randn_like(
     const Tensor& self,
-    const TensorOptions& options,
+    ScalarType dtype, 
+    Layout layout, 
+    Device device, 
+    bool pin_memory,
     c10::optional<c10::MemoryFormat> optional_memory_format) {
-  auto result = at::empty_like(self, options, optional_memory_format);
+  auto result = at::_empty_like(self, dtype, layout, device, pin_memory, optional_memory_format);
   return result.normal_(0, 1, nullptr);
 }
 
@@ -632,12 +668,12 @@ void randperm_cpu(Tensor& result, int64_t n, CPUGenerator* generator) {
 }
 } // namespace
 
-Tensor randperm(int64_t n, const TensorOptions& options) {
-  return native::randperm(n, nullptr, options);
+Tensor randperm(int64_t n, c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) {
+  return native::randperm(n, nullptr, dtype, layout, device, pin_memory);
 }
 
-Tensor randperm(int64_t n, Generator* generator, const TensorOptions& options) {
-  auto tensor = at::empty(n, options);
+Tensor randperm(int64_t n, Generator* generator, c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) {
+  auto tensor = at::_empty(n, dtype, layout, device, pin_memory);
   return at::randperm_out(tensor, n, generator);
 }
 
@@ -665,28 +701,28 @@ Tensor range(
     Scalar start,
     Scalar end,
     Scalar step,
-    const TensorOptions& options) {
-  Tensor result = at::empty({0}, options);
+    c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) {
+  Tensor result = at::_empty({0}, dtype, layout, device, pin_memory);
   return at::range_out(result, start, end, step);
 }
 
 Tensor range(
     Scalar start,
     Scalar end,
-    const TensorOptions& options) {
-  return at::native::range(start, end, 1, options);
+    c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) {
+  return at::native::range(start, end, 1, dtype, layout, device, pin_memory);
 }
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ triangle ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Tensor tril_indices_cpu(
-    int64_t row, int64_t col, int64_t offset, const TensorOptions& options) {
-  check_args(row, col, options);
+    int64_t row, int64_t col, int64_t offset, c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) {
+  check_args(row, col, layout);
 
   auto tril_size = get_tril_size(row, col, offset);
 
   // create an empty Tensor with correct size
-  auto result = at::empty({2, tril_size}, options);
+  auto result = at::_empty({2, tril_size}, dtype, layout, device, pin_memory);
 
   // The following three approaches result in very little performance
   // differences. Hence, the 2nd option is taken for simpler code, and to return
@@ -725,13 +761,13 @@ Tensor tril_indices_cpu(
 }
 
 Tensor triu_indices_cpu(
-    int64_t row, int64_t col, int64_t offset, const TensorOptions& options) {
-  check_args(row, col, options);
+    int64_t row, int64_t col, int64_t offset, c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) {
+  check_args(row, col, layout);
 
   auto triu_size = row * col - get_tril_size(row, col, offset - 1);
 
   // create an empty Tensor with correct size
-  auto result = at::empty({2, triu_size}, options);
+  auto result = at::_empty({2, triu_size}, dtype, layout, device, pin_memory);
 
   AT_DISPATCH_ALL_TYPES(result.scalar_type(), "triu_indices", [&]() -> void {
     // fill the Tensor with correct values
@@ -762,7 +798,12 @@ Tensor triu_indices_cpu(
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ zeros ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Tensor zeros(IntArrayRef size, const TensorOptions& options) {
+Tensor zeros(IntArrayRef size, c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) {
+  const auto options = TensorOptions()
+        .dtype(dtype)
+        .layout(layout)
+        .device(device)
+        .pinned_memory(pin_memory);
   auto result = at::empty(size, options);
   return result.zero_();
 }
@@ -780,52 +821,64 @@ Tensor& zeros_out(Tensor& result, IntArrayRef size) {
 Tensor zeros_like(
     const Tensor& self,
     c10::optional<c10::MemoryFormat> optional_memory_format) {
-  return native::zeros_like(self, self.options(), optional_memory_format);
+  return native::zeros_like(self, typeMetaToScalarType(self.options().dtype()), self.options().layout(), self.options().device(), self.options().pinned_memory(), optional_memory_format);
 }
 
 Tensor zeros_like(
     const Tensor& self,
-    const TensorOptions& options,
+    ScalarType dtype, Layout layout,Device device, bool pin_memory,
     c10::optional<c10::MemoryFormat> optional_memory_format) {
-  if (options.layout() == kSparse && self.is_sparse()) {
-    auto res = at::empty({0}, options); // to be resized
+  if (layout == kSparse && self.is_sparse()) {
+    auto res = at::_empty({0}, dtype, layout, device, pin_memory); // to be resized
     res.sparse_resize_and_clear_(
         self.sizes(), self.sparse_dim(), self.dense_dim());
     return res;
   }
-  auto result = at::empty_like(self, options, optional_memory_format);
+  auto result = at::_empty_like(self, dtype, layout, device, pin_memory, optional_memory_format);
   return result.zero_();
 }
 
 Tensor new_zeros(
     const Tensor& self,
     IntArrayRef size,
-    const TensorOptions& options
+    c10::optional<ScalarType> dtype, 
+    c10::optional<Layout> layout, 
+    c10::optional<Device> device, 
+    c10::optional<bool> pin_memory
     ) {
+
+  // We shouldn't need to construct TensorOptions object
+  // issue 30405
+  const auto options = TensorOptions()
+        .dtype(dtype)
+        .layout(layout)
+        .device(device)
+        .pinned_memory(pin_memory);
+
   return at::zeros(size, self.options().merge_in(options));
 }
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~ bartlett_window ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Tensor bartlett_window(int64_t window_length, const TensorOptions& options) {
-  return native::bartlett_window(window_length, /*periodic=*/true, options);
+Tensor bartlett_window(int64_t window_length, c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) {
+  return native::bartlett_window(window_length, /*periodic=*/true, dtype, layout, device, pin_memory);
 }
 
 Tensor bartlett_window(
     int64_t window_length,
     bool periodic,
-    const TensorOptions& options) {
-  window_function_checks("bartlett_window", options, window_length);
+    c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) {
+  window_function_checks("bartlett_window", dtype, layout, window_length);
   if (window_length == 0) {
-    return at::empty({0}, options);
+    return at::_empty({0}, dtype, layout, device, pin_memory);
   }
   if (window_length == 1) {
-    return native::ones({1}, options);
+    return native::ones({1}, dtype, layout, device, pin_memory);
   }
   if (periodic) {
     window_length += 1;
   }
-  auto window = native::arange(window_length, options).mul_(2. / static_cast<double>(window_length - 1));
+  auto window = native::arange(window_length, dtype, layout, device, pin_memory).mul_(2. / static_cast<double>(window_length - 1));
   const int64_t first_half_size = ((window_length - 1) >> 1) + 1;
   window.narrow(0, first_half_size, window_length - first_half_size).mul_(-1).add_(2);
   return periodic ? window.narrow(0, 0, window_length - 1) : window;
@@ -833,48 +886,48 @@ Tensor bartlett_window(
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~ blackman_window ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Tensor blackman_window(int64_t window_length, const TensorOptions& options) {
-  return native::blackman_window(window_length, /*periodic=*/true, options);
+Tensor blackman_window(int64_t window_length, c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) {
+  return native::blackman_window(window_length, /*periodic=*/true, dtype, layout, device, pin_memory);
 }
 
 Tensor blackman_window(
     int64_t window_length,
     bool periodic,
-    const TensorOptions& options) {
-  window_function_checks("blackman_window", options, window_length);
+    c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) {
+  window_function_checks("blackman_window", dtype, layout, window_length);
   if (window_length == 1) {
-    return native::ones({1}, options);
+    return native::ones({1}, dtype, layout, device, pin_memory);
   }
   if (periodic) {
     window_length += 1;
   }
   // from https://en.wikipedia.org/wiki/Window_function#Blackman_window
-  auto window = native::arange(window_length, options).mul_(M_PI / static_cast<double>(window_length - 1));
+  auto window = native::arange(window_length, dtype, layout, device, pin_memory).mul_(M_PI / static_cast<double>(window_length - 1));
   window = window.mul(4).cos_().mul_(0.08) - window.mul(2).cos_().mul_(0.5) + 0.42;
   return periodic ? window.narrow(0, 0, window_length - 1) : window;
 }
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ hamming_window ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Tensor hamming_window(int64_t window_length, const TensorOptions& options) {
-  return native::hamming_window(window_length, /*periodic=*/true, options);
+Tensor hamming_window(int64_t window_length, c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) {
+  return native::hamming_window(window_length, /*periodic=*/true, dtype, layout, device, pin_memory);
 }
 
 Tensor hamming_window(
     int64_t window_length,
     bool periodic,
-    const TensorOptions& options) {
+    c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) {
   return native::hamming_window(
-      window_length, periodic, /*alpha=*/0.54, options);
+      window_length, periodic, /*alpha=*/0.54, dtype, layout, device, pin_memory);
 }
 
 Tensor hamming_window(
     int64_t window_length,
     bool periodic,
     double alpha,
-    const TensorOptions& options) {
+    c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) {
   return native::hamming_window(
-      window_length, periodic, alpha, /*beta=*/0.46, options);
+      window_length, periodic, alpha, /*beta=*/0.46, dtype, layout, device, pin_memory);
 }
 
 Tensor hamming_window(
@@ -882,42 +935,42 @@ Tensor hamming_window(
     bool periodic,
     double alpha,
     double beta,
-    const TensorOptions& options) {
-  window_function_checks("hamming_window", options, window_length);
+    c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) {
+   window_function_checks("hamming_window", dtype, layout, window_length);
   if (window_length == 0) {
-    return at::empty({0}, options);
+    return at::_empty({0}, dtype, layout, device, pin_memory);
   }
   if (window_length == 1) {
-    return native::ones({1}, options);
+    return native::ones({1}, dtype, layout, device, pin_memory);
   }
   if (periodic) {
     window_length += 1;
   }
-  auto window = native::arange(window_length, options);
+  auto window = native::arange(window_length, dtype, layout, device, pin_memory);
   window.mul_(M_PI * 2. / static_cast<double>(window_length - 1)).cos_().mul_(-beta).add_(alpha);
   return periodic ? window.narrow(0, 0, window_length - 1) : window;
 }
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ hann_window ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Tensor hann_window(int64_t window_length, const TensorOptions& options) {
-  return native::hann_window(window_length, /*periodic=*/true, options);
+Tensor hann_window(int64_t window_length, c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) {
+  return native::hann_window(window_length, /*periodic=*/true, dtype, layout, device, pin_memory);
 }
 
 Tensor hann_window(
     int64_t window_length,
     bool periodic,
-    const TensorOptions& options) {
-  window_function_checks("hann_window", options, window_length);
+    c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) {
+  window_function_checks("hann_window", dtype, layout, window_length);
   return native::hamming_window(
-      window_length, periodic, /*alpha=*/0.5, /*beta=*/0.5, options);
+      window_length, periodic, /*alpha=*/0.5, /*beta=*/0.5, dtype, layout, device, pin_memory);
 }
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ tensor ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 template <typename T>
-Tensor tensor_cpu(ArrayRef<T> values, const TensorOptions& options) {
-  auto result = at::empty(values.size(), options);
+Tensor tensor_cpu(ArrayRef<T> values, c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) {
+  auto result = at::_empty(values.size(), dtype, layout, device, pin_memory);
   AT_ASSERT(result.is_contiguous());
   AT_DISPATCH_ALL_TYPES_AND_COMPLEX(result.scalar_type(), "tensor_cpu", [&] {
     std::copy(values.begin(), values.end(), result.template data_ptr<scalar_t>());
@@ -926,32 +979,47 @@ Tensor tensor_cpu(ArrayRef<T> values, const TensorOptions& options) {
 }
 
 template <typename T>
-Tensor tensor_backend(ArrayRef<T> values, const TensorOptions& options) {
-  auto cpu_tensor = tensor_cpu(values, options.device(DeviceType::CPU));
+Tensor tensor_backend(ArrayRef<T> values, c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) {
+  const auto options = TensorOptions()
+        .dtype(dtype)
+        .layout(layout)
+        .device(device)
+        .pinned_memory(pin_memory);
+  auto cpu_tensor = tensor_cpu(values, dtype, layout, at::Device(DeviceType::CPU), pin_memory);
   return cpu_tensor.to(options.device());
 }
 
-#define TENSOR(T, _1)                                               \
-  Tensor tensor(ArrayRef<T> values, const TensorOptions& options) { \
-    if (options.device().type() != c10::DeviceType::CPU) {          \
-      return tensor_backend(values, options);                       \
-    } else {                                                        \
-      return tensor_cpu(values, options);                           \
-    }                                                               \
+#define TENSOR(T, _1)                                                                                                                      \
+  Tensor tensor(ArrayRef<T> values, const TensorOptions& options) {                                                                        \
+    if (options.device().type() != c10::DeviceType::CPU) {                                                                                 \
+      return tensor_backend(values, typeMetaToScalarType(options.dtype()), options.layout(), options.device(), options.pinned_memory());   \
+    } else {                                                                                                                               \
+      return tensor_cpu(values, typeMetaToScalarType(options.dtype()), options.layout(), options.device(), options.pinned_memory());       \
+    }                                                                                                                                      \
   }
 AT_FORALL_SCALAR_TYPES_AND3(Bool, Half, BFloat16, TENSOR)
 #undef TENSOR
 
-Tensor from_file(std::string filename, c10::optional<bool> shared, c10::optional<int64_t> size, const TensorOptions& options) {
-    TORCH_CHECK(!options.pinned_memory(), "tensors constructed from a file cannot be pinned");
+#define TENSOR(T, _1)                                                                                                                                              \
+  Tensor tensor(ArrayRef<T> values, c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) { \
+    if (device.value().type() != c10::DeviceType::CPU) {                        \
+      return tensor_backend(values, dtype, layout, device, pin_memory); \
+    } else {                                                            \
+      return tensor_cpu(values, dtype, layout, device, pin_memory);     \
+    }                                                                   \
+  }
+AT_FORALL_SCALAR_TYPES_AND3(Bool, Half, BFloat16, TENSOR)
+#undef TENSOR
+
+Tensor from_file(std::string filename, c10::optional<bool> shared, c10::optional<int64_t> size, c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) {
+    TORCH_CHECK(!pin_memory.value(), "tensors constructed from a file cannot be pinned");
     size_t my_size = size.value_or(0);
     int flags = shared.value_or(false) ? TH_ALLOCATOR_MAPPED_SHARED : 0;
-    auto dtype = options.dtype();
     auto storage_impl = c10::make_intrusive<at::StorageImpl>(
-      dtype,
+      scalarTypeToTypeMeta(dtype.value()),
       my_size,
       THMapAllocator::makeDataPtr(
-          filename.c_str(), flags, my_size * dtype.itemsize(), nullptr),
+          filename.c_str(), flags, my_size * scalarTypeToTypeMeta(dtype.value()).itemsize(), nullptr),
       /*allocator=*/nullptr,
       /*resizable=*/false);
     auto tensor = detail::make_tensor<at::TensorImpl>(storage_impl, at::TensorTypeId::CPUTensorId);
@@ -989,54 +1057,75 @@ Tensor full(
     IntArrayRef size,
     Scalar fill_value,
     optional<DimnameList> names,
-    const TensorOptions& options) {
-  auto result = at::empty(size, names, options);
+    c10::optional<ScalarType> dtype, 
+    c10::optional<Layout> layout, 
+    c10::optional<Device> device, 
+    c10::optional<bool> pin_memory) {
+  auto result = at::_empty(size, names, dtype, layout, device, pin_memory);
   return result.fill_(fill_value);
 }
 
 Tensor ones(
     IntArrayRef size,
     optional<DimnameList> names,
-    const TensorOptions& options) {
-  return native::full(size, /*fill_value=*/1, names, options);
+    c10::optional<ScalarType> dtype, 
+    c10::optional<Layout> layout, 
+    c10::optional<Device> device, 
+    c10::optional<bool> pin_memory) {
+  return native::full(size, /*fill_value=*/1, names, dtype, layout, device, pin_memory);
 }
 
 Tensor zeros(
     IntArrayRef size,
     optional<DimnameList> names,
-    const TensorOptions& options) {
-  return native::full(size, /*fill_value=*/0, names, options);
+    c10::optional<ScalarType> dtype, 
+    c10::optional<Layout> layout, 
+    c10::optional<Device> device, 
+    c10::optional<bool> pin_memory) {
+  return native::full(size, /*fill_value=*/0, names, dtype, layout, device, pin_memory);
 }
 
 Tensor randn(
     IntArrayRef size,
     optional<DimnameList> names,
-    const TensorOptions& options) {
-  return native::randn(size, nullptr, names, options);
+    c10::optional<ScalarType> dtype, 
+    c10::optional<Layout> layout, 
+    c10::optional<Device> device, 
+    c10::optional<bool> pin_memory) {
+  return native::randn(size, nullptr, names, dtype, layout, device, pin_memory);
 }
 
 Tensor randn(
     IntArrayRef size,
     Generator* generator,
     optional<DimnameList> names,
-    const TensorOptions& options) {
-  auto result = at::empty(size, names, options);
+    c10::optional<ScalarType> dtype, 
+    c10::optional<Layout> layout, 
+    c10::optional<Device> device, 
+    c10::optional<bool> pin_memory) {
+  auto result = at::_empty(size, names, dtype, layout, device, pin_memory);
   return result.normal_(0, 1, generator);
 }
 
 Tensor rand(
     IntArrayRef size,
     optional<DimnameList> names,
-    const TensorOptions& options) {
-  return native::rand(size, nullptr, names, options);
+    c10::optional<ScalarType> dtype, 
+    c10::optional<Layout> layout, 
+    c10::optional<Device> device, 
+    c10::optional<bool> pin_memory) {
+  return native::rand(size, nullptr, names, dtype, layout, device, pin_memory);
 }
 
 Tensor rand(
     IntArrayRef size,
     Generator* generator,
     optional<DimnameList> names,
-    const TensorOptions& options) {
-  auto result = at::empty(size, names, options);
+    c10::optional<ScalarType> dtype, 
+    c10::optional<Layout> layout, 
+    c10::optional<Device> device, 
+    c10::optional<bool> pin_memory) {
+  auto result = at::_empty(size, names, dtype, layout, device, pin_memory);
   return result.uniform_(0, 1, generator);
 }
 

--- a/aten/src/ATen/native/TensorFactories.h
+++ b/aten/src/ATen/native/TensorFactories.h
@@ -59,6 +59,18 @@ inline void check_args(
   }
 }
 
+inline void check_args(
+    int64_t row, int64_t col, c10::optional<c10::Layout> layout) {
+  TORCH_CHECK(row >= 0, "row must be non-negative, got", row);
+  TORCH_CHECK(col >= 0, "col must be non-negative, got", col);
+  if (layout.has_value()) {
+    TORCH_CHECK(
+      layout.value() == at::kStrided,
+      "only support layout=torch.strided, got",
+      layout.value())
+  }
+}
+
 inline void check_size_nonnegative(IntArrayRef size) {
   for (auto x: size) {
     TORCH_CHECK(x >= 0, "Trying to create tensor with negative dimension ", x, ": ", size);

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -155,7 +155,7 @@ static Tensor cat_sparse(TensorList tensors, int64_t dim) {
     }
     auto sizes_copy = sizes.vec();
     sizes_copy[wrapped] = cumulative_offset;
-    return native::sparse_coo_tensor(idxs, vals, sizes_copy, tensors[0].options());
+    return native::sparse_coo_tensor(idxs, vals, sizes_copy, typeMetaToScalarType(tensors[0].options().dtype()), tensors[0].options().layout(), tensors[0].options().device(), tensors[0].options().pinned_memory());
   }
   else {
     // Catting along a dense dimension requires us to create new values.
@@ -192,16 +192,16 @@ static Tensor cat_sparse(TensorList tensors, int64_t dim) {
       zeros_sizes[0] = t._values().size(0);
       zeros_sizes[values_dim] = cumulative_size;
       cumulative_size += t._values().size(values_dim);
-      auto z1 = native::zeros(zeros_sizes, t._values().options());
+      auto z1 = native::zeros(zeros_sizes, typeMetaToScalarType(t._values().options().dtype()), t._values().options().layout(), t._values().options().device(), t._values().options().pinned_memory());
       zeros_sizes[values_dim] = total_size - cumulative_size;
-      auto z2 = native::zeros(zeros_sizes, t._values().options());
+      auto z2 = native::zeros(zeros_sizes, typeMetaToScalarType(t._values().options().dtype()), t._values().options().layout(), t._values().options().device(), t._values().options().pinned_memory());
       vals_pieces.push_back(native::cat({z1, t._values(), z2}, values_dim));
       idxs_pieces.push_back(t._indices());
     }
     auto sizes_copy = sizes.vec();
     sizes_copy[wrapped] = total_size;
     // This can create an uncoalesced tensor
-    return native::sparse_coo_tensor(native::cat(idxs_pieces, 1), native::cat(vals_pieces), sizes_copy, tensors[0].options());
+    return native::sparse_coo_tensor(native::cat(idxs_pieces, 1), native::cat(vals_pieces), sizes_copy, typeMetaToScalarType(tensors[0].options().dtype()), tensors[0].options().layout(), tensors[0].options().device(), tensors[0].options().pinned_memory());
   }
 }
 
@@ -587,7 +587,7 @@ static Tensor select_sparse(const Tensor& self, int64_t dim, int64_t index) {
         return new_values.sum(0);
       }
     } else {
-      auto dimIndices = (arange(0, sparse_dim, self.device()) != dim).nonzero().view(-1);
+      auto dimIndices = (arange(0, sparse_dim, c10::nullopt, c10::nullopt, self.device()) != dim).nonzero().view(-1);
       auto new_indices = indices.index_select(1, nzIndices).index_select(0, dimIndices);
       return _sparse_coo_tensor_with_dims_and_tensors(
             sparse_dim - 1, dense_dim, new_sizes, new_indices, new_values, self.options());
@@ -1061,7 +1061,7 @@ static Tensor unsqueeze_sparse(Tensor const &self, int64_t dim /* should already
   if (dim <= sparse_dim) {
     auto new_indices = native::cat({
       indices.narrow(0, 0, dim),
-      native::zeros({1, indices.size(1)}, indices.options().dtype(kLong)),
+      native::zeros({1, indices.size(1)}, at::kLong, indices.options().layout_opt(), indices.options().device_opt(), indices.options().pinned_memory_opt()),
       indices.narrow(0, dim, indices.size(0) - dim)
     });
     return _sparse_coo_tensor_with_dims_and_tensors(

--- a/aten/src/ATen/native/UnaryOps.cpp
+++ b/aten/src/ATen/native/UnaryOps.cpp
@@ -271,7 +271,11 @@ Tensor mvlgamma(const Tensor& self, int64_t p) {
   TORCH_CHECK((self > 0.5 * (p - 1.)).all().item<uint8_t>(),
            "Condition for computing multivariate log-gamma not met");
   TORCH_CHECK(p >= 1, "p has to be greater than or equal to 1");
-  Tensor args = native::arange(-p / 2. + 0.5, 0.5, 0.5, self.options());
+  Tensor args = native::arange(-p / 2. + 0.5, 0.5, 0.5, 
+                              typeMetaToScalarType(self.options().dtype()), 
+                                                   self.options().layout(), 
+                                                   self.options().device(), 
+                                                   self.options().pinned_memory());
   args = args.add(self.unsqueeze(-1));
   return args.lgamma_().sum(-1).add_(p * (p - 1) * std::log(M_PI) / 4.);
 }
@@ -282,7 +286,11 @@ Tensor& mvlgamma_(Tensor& self, int64_t p) {
   TORCH_CHECK((self > 0.5 * (p - 1.)).all().item<uint8_t>(),
            "Condition for computing multivariate log-gamma not met");
   TORCH_CHECK(p >= 1, "p has to be greater than or equal to 1");
-  Tensor args = native::arange(-p / 2. + 0.5, 0.5, 0.5, self.options());
+  Tensor args = native::arange(-p / 2. + 0.5, 0.5, 0.5, 
+                               typeMetaToScalarType(self.options().dtype()), 
+                                                    self.options().layout(), 
+                                                    self.options().device(),
+                                                    self.options().pinned_memory());
   args = args.add(self.unsqueeze(-1));
   return self.copy_(args.lgamma_().sum(-1).add_(p * (p - 1) * std::log(M_PI) / 4.));
 }

--- a/aten/src/ATen/native/cuda/MultinomialKernel.cu
+++ b/aten/src/ATen/native/cuda/MultinomialKernel.cu
@@ -375,7 +375,11 @@ void multinomial_kernel_impl(Tensor& result, const Tensor& self, const int64_t n
       // To exploit greater parallelism for the sampling, generate the
       // Uniform random samples in a separate kernel launch, into
       // temporarily allocated memory. The device RNG is thread-limited
-      Tensor sampled = native::empty_cuda({numDist, n_sample}, self_v.options());
+      Tensor sampled = native::empty_cuda({numDist, n_sample}, 
+                                          typeMetaToScalarType(self_v.options().dtype()), 
+                                                               self_v.options().layout(), 
+                                                               self_v.options().device(), 
+                                                               self_v.options().pinned_memory());
       at::native::uniform_cuda_(sampled, 0.0, 1.0, gen);
 
       dim3 block(numCategories < maxThreads ? numCategories : maxThreads);

--- a/aten/src/ATen/native/cudnn/RNN.cpp
+++ b/aten/src/ATen/native/cudnn/RNN.cpp
@@ -1080,10 +1080,18 @@ std::tuple<Tensor, Tensor, Tensor, std::vector<Tensor>> _cudnn_rnn_backward(
 
 // TODO: I am not sure if we actually need the 'dropout' and 'train' parameters
 // to initialize just the state tensor
-Tensor _cudnn_init_dropout_state(double dropout, bool train, int64_t dropout_seed, const TensorOptions& options) {
+Tensor _cudnn_init_dropout_state(double dropout, bool train, int64_t dropout_seed, ScalarType dtype, Layout layout, Device device, bool pin_memory) {
   auto handle = getCudnnHandle();
   DropoutDescriptor dropout_desc;
   auto dropout_p = train ? dropout : 0;
+  
+  // Ideally we dont want to costruct this.
+  // Issue #30405
+  const auto options = TensorOptions()
+        .dtype(dtype)
+        .layout(layout)
+        .device(device)
+        .pinned_memory(pin_memory);
   dropout_desc.initialize_rng(handle, dropout_p, dropout_seed, options);
   return dropout_desc.state;
 }
@@ -1162,8 +1170,8 @@ DropoutState& get_dropout_state(double dropout_p, bool train, TensorOptions opti
   if (train && dropout_p > 0 && !state.buffer.defined()) {
     std::unique_lock<std::mutex> lock {state.mutex};
     int64_t seed = at::empty({}, at::kLong).random_().item<int64_t>();
-    state.buffer = at::_cudnn_init_dropout_state(
-      dropout_p, train, seed, options.dtype(at::kByte));
+    state.buffer = at::__cudnn_init_dropout_state(
+      dropout_p, train, seed, at::kByte, options.layout(), options.device(), options.pinned_memory());
     // NB: CUDA binds the event to a device at creation time, so we can initialize it
     // only now, when we know we're on the correct device.
     state.event.emplace();

--- a/aten/src/ATen/native/mkldnn/BinaryOps.cpp
+++ b/aten/src/ATen/native/mkldnn/BinaryOps.cpp
@@ -100,7 +100,11 @@ Tensor& mkldnn_mul_out(Tensor& result, const Tensor& self, const Tensor& other) 
 }
 
 Tensor mkldnn_mul(const Tensor& self, const Tensor& other) {
-  Tensor result = empty_mkldnn(self.sizes(), self.options());
+  Tensor result = empty_mkldnn(self.sizes(), 
+                               typeMetaToScalarType(self.options().dtype()), 
+                               self.options().layout(), 
+                               self.options().device(), 
+                               self.options().pinned_memory());
   return native::mkldnn_mul_out(result, self, other);
 }
 

--- a/aten/src/ATen/native/mkldnn/MKLDNNConversions.cpp
+++ b/aten/src/ATen/native/mkldnn/MKLDNNConversions.cpp
@@ -30,7 +30,11 @@ Tensor dense_to_mkldnn(const Tensor& cpu_tensor) {
              "Can't convert cpu tensor with the number of dimensions > 5");
   // TODO: consider to convert non-contiguous tensor to `ideep::tensor` directly.
   auto cpu_tensor_cont = cpu_tensor.contiguous();
-  Tensor mkldnn_tensor = empty_mkldnn(cpu_tensor_cont.sizes(), cpu_tensor_cont.options());
+  Tensor mkldnn_tensor = empty_mkldnn(cpu_tensor_cont.sizes(), 
+                                      typeMetaToScalarType(cpu_tensor_cont.options().dtype()), 
+                                      cpu_tensor_cont.options().layout(), 
+                                      cpu_tensor_cont.options().device(), 
+                                      cpu_tensor_cont.options().pinned_memory());
   ideep::tensor& dtensor = itensor_from_mkldnn(mkldnn_tensor);
   dtensor.feed_from(dtensor.get_dims(),
                     ideep::tensor::data_type::f32,

--- a/aten/src/ATen/native/mkldnn/TensorFactories.cpp
+++ b/aten/src/ATen/native/mkldnn/TensorFactories.cpp
@@ -4,22 +4,42 @@ namespace at { namespace native {
 
 #if AT_MKLDNN_ENABLED()
 
-Tensor empty_mkldnn(IntArrayRef sizes, const TensorOptions& options, c10::optional<c10::MemoryFormat> optional_memory_format) {
-  TORCH_CHECK(
-     !optional_memory_format.has_value(),
-     "'memory_format' argument is incompatible with mkldnn tensor");
-  // NOTE: int32_t dims from ideep::tensor but sizes needs int64_t
-  // TODO: support int64_t dims in ideep::tensor to avoid extra conversion
-  ideep::tensor::dims dst_dims (sizes.begin(), sizes.end());
-  ideep::tensor it;
-  it.resize<AllocForMKLDNN>(dst_dims, ideep::tensor::data_type::f32);
-  return new_with_itensor_mkldnn(std::move(it), options);
+Tensor empty_mkldnn(
+  IntArrayRef sizes, 
+  c10::optional<ScalarType> dtype, 
+  c10::optional<Layout> layout, 
+  c10::optional<Device> device, 
+  c10::optional<bool> pin_memory, 
+  c10::optional<c10::MemoryFormat> optional_memory_format) {
+    TORCH_CHECK(
+      !optional_memory_format.has_value(),
+      "'memory_format' argument is incompatible with mkldnn tensor");
+    // NOTE: int32_t dims from ideep::tensor but sizes needs int64_t
+    // TODO: support int64_t dims in ideep::tensor to avoid extra conversion
+    ideep::tensor::dims dst_dims (sizes.begin(), sizes.end());
+    ideep::tensor it;
+    it.resize<AllocForMKLDNN>(dst_dims, ideep::tensor::data_type::f32);
+    
+    // Ideally we dont want to costruct this.
+    // Issue #30405
+    const auto options = TensorOptions()
+      .dtype(dtype)
+      .layout(layout)
+      .device(device)
+      .pinned_memory(pin_memory);
+    return new_with_itensor_mkldnn(std::move(it), options);
 }
 
 #else
 
-Tensor empty_mkldnn(IntArrayRef sizes, const TensorOptions& options, c10::optional<c10::MemoryFormat> optional_memory_format) {
-  AT_ERROR("empty_mkldnn: MKL-DNN build is disabled");
+Tensor empty_mkldnn(
+  IntArrayRef sizes, 
+  c10::optional<ScalarType> dtype, 
+  c10::optional<Layout> layout, 
+  c10::optional<Device> device, 
+  c10::optional<bool> pin_memory, 
+  c10::optional<c10::MemoryFormat> optional_memory_format) {
+    AT_ERROR("empty_mkldnn: MKL-DNN build is disabled");
 }
 
 #endif // AT_MKLDNN_ENABLED()

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3247,7 +3247,7 @@
 
 # FIXME: would be nicer if TensorOptions was optional based; not adding default arguments for options given
 # the default would never make sense.
-- func: sparse_coo_tensor.size(int[] size, *, ScalarType dtype, Layout layout, Device device, bool pin_memory=False) -> Tensor
+- func: sparse_coo_tensor.size(int[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=False) -> Tensor
 
 - func: sparse_coo_tensor.indices(Tensor indices, Tensor values, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
 
@@ -3255,7 +3255,7 @@
 
 - func: _sparse_coo_tensor_unsafe(Tensor indices, Tensor values, int[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
 
-- func: _sparse_coo_tensor_with_dims(int sparse_dim, int dense_dim, int[] size, *, ScalarType dtype, Layout layout, Device device, bool pin_memory=False) -> Tensor
+- func: _sparse_coo_tensor_with_dims(int sparse_dim, int dense_dim, int[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=False) -> Tensor
   dispatch:
     SparseCPU: new_with_dims_sparse
     SparseCUDA: new_with_dims_sparse
@@ -3566,7 +3566,7 @@
 # to(Device) must not exist because all constructors of Device also works for
 # TensorOptions. Otherwise, an ambiguity error is thrown.
 # See NOTE [ TensorOptions Constructors ].
-- func: to.dtype_layout(Tensor self, *, ScalarType dtype, Layout layout, Device device, bool pin_memory=False, bool non_blocking=False, bool copy=False, MemoryFormat? memory_format=None) -> Tensor
+- func: to.dtype_layout(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=False, bool non_blocking=False, bool copy=False, MemoryFormat? memory_format=None) -> Tensor
   variants: method
   device_guard: False
   supports_named_tensor: True

--- a/aten/src/ATen/native/quantized/TensorFactories.cpp
+++ b/aten/src/ATen/native/quantized/TensorFactories.cpp
@@ -12,13 +12,20 @@ namespace native {
 // change to use quantizer
 Tensor empty_affine_quantized_cpu(
     IntArrayRef size,
-    const TensorOptions& options,
+    c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory,
     double scale,
     int64_t zero_point,
     c10::optional<c10::MemoryFormat> optional_memory_format) {
   TORCH_CHECK(
-      options.has_dtype(),
+      dtype.has_value(),
       "Must provide data type for Tensor creation functions.");
+ 
+ const auto options = TensorOptions()
+        .dtype(dtype)
+        .layout(layout)
+        .device(device)
+        .pinned_memory(pin_memory);
+
   return new_qtensor_cpu(
       size,
       options,
@@ -32,14 +39,21 @@ Tensor empty_per_channel_affine_quantized_cpu(
     const Tensor& scales,
     const Tensor& zero_points,
     int64_t axis,
-    const TensorOptions& options,
+    c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory,
     c10::optional<c10::MemoryFormat> optional_memory_format) {
   TORCH_CHECK(
-      options.has_dtype(),
+      dtype.has_value(),
       "Must provide data type for Tensor creation functions.");
   TORCH_CHECK(
-      options.dtype() == kQInt8 || options.dtype() == kQUInt8,
+      dtype.value() == kQInt8 || dtype.value() == kQUInt8,
       "Supported data type for tensor creation is int8 or uint8");
+
+    const auto options = TensorOptions()
+        .dtype(dtype)
+        .layout(layout)
+        .device(device)
+        .pinned_memory(pin_memory);
+
   return new_qtensor_cpu(
       size,
       options,
@@ -54,7 +68,7 @@ Tensor empty_per_channel_affine_quantized_cpu(
 // Provide better error message if dtype is wrong
 Tensor empty_affine_quantized_other_backends_stub(
     IntArrayRef,
-    const TensorOptions&,
+    c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory,
     double,
     int64_t,
     c10::optional<c10::MemoryFormat>) {
@@ -66,7 +80,7 @@ Tensor empty_per_channel_affine_quantized_other_backends_stub(
     const Tensor&,
     const Tensor&,
     int64_t,
-    const TensorOptions&,
+    c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory,
     c10::optional<c10::MemoryFormat>) {
   TORCH_CHECK(false, "Creation of quantized tensor requires quantized dtype like torch.quint8");
 }

--- a/aten/src/ATen/native/sparse/SparseTensorMath.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensorMath.cpp
@@ -846,7 +846,11 @@ SparseTensor& _sspaddmm_out_cpu(
   int64_t t_nnz = t._nnz();
   int64_t r_nnz = nnz * dim_k + t_nnz;
   LongTensor newi = at::empty({2, r_nnz}, kLong);
-  LongTensor newv = native::zeros({r_nnz}, values.options());
+  LongTensor newv = native::zeros({r_nnz}, 
+                                  typeMetaToScalarType(values.options().dtype()), 
+                                  values.options().layout(),
+                                  values.options().device(), 
+                                  values.options().pinned_memory());
 
   if (t_nnz != 0) {
     LongTensor narrowi = newi.narrow(1, 0, t_nnz);

--- a/aten/src/ATen/native_parse.py
+++ b/aten/src/ATen/native_parse.py
@@ -228,7 +228,7 @@ def parse_arguments(args, func_variants, declaration, func_return):
     supported_topt_arguments.append(
         [
             {'name': 'dtype', 'type': 'ScalarType', 'annotation': None, 'kwarg_only': True,
-             'default': 'long', 'is_nullable': True},
+             'default': 'at::kLong', 'is_nullable': True},
             {'name': 'layout', 'type': 'Layout', 'annotation': None, 'kwarg_only': True,
              'default': 'c10::nullopt', 'is_nullable': True},
             {'name': 'device', 'type': 'Device', 'annotation': None, 'kwarg_only': True,
@@ -259,33 +259,29 @@ def parse_arguments(args, func_variants, declaration, func_return):
     def is_tensor_option(argument):
         return argument['name'] in ['dtype', 'layout', 'device', 'pin_memory']
 
-    new_arguments = []
     idx = 0
+
+    # This is a hack around tril_indices/triu_indices as codegen doesn't handle default values well.
+    # issue #30405
     while idx < len(arguments):
         argument = arguments[idx]
-        number_of_arguments = len(supported_topt_arguments[0])
-        if is_tensor_option(argument) and len(arguments) - idx >= number_of_arguments:
-            topt_representation = []
-            for i in range(number_of_arguments):
-                argument = arguments[idx]
-                if not is_tensor_option(argument):
-                    break
-                topt_representation.append(argument)
-                idx += 1
-            if len(topt_representation) == number_of_arguments:
-                merged_argument = check_topt_representation(topt_representation)
-                assert merged_argument, \
-                    "Unsupported combination of TensorOptions {}, the only currently supported combinations are {}"\
-                    .format(str(topt_representation), str(supported_topt_arguments))
-                new_arguments.append(merged_argument)
-            else:
-                new_arguments += topt_representation
-        else:
-            new_arguments.append(argument)
-            idx += 1
-
-    arguments = new_arguments
-
+        if declaration['name'] == 'tril_indices' or declaration['name'] == 'triu_indices':
+            arguments = [
+                {'type': 'int64_t', 'name': 'row', 'is_nullable': False, 'annotation': None}, 
+                {'type': 'int64_t', 'name': 'col', 'is_nullable': False, 'annotation': None},
+                {'type': 'int64_t', 'name': 'offset', 'is_nullable': False, 'annotation': None, 'default': 0}, 
+                {'name': 'dtype', 'type': 'ScalarType', 'annotation': None, 'kwarg_only': True,
+                'default': 'at::kLong', 'is_nullable': True},
+                {'name': 'layout', 'type': 'Layout', 'annotation': None, 'kwarg_only': True,
+                'default': 'c10::nullopt', 'is_nullable': True},
+                {'name': 'device', 'type': 'Device', 'annotation': None, 'kwarg_only': True,
+                'default': 'c10::nullopt', 'is_nullable': True},
+                {'name': 'pin_memory', 'type': 'bool', 'annotation': None, 'kwarg_only': True,
+                'default': 'c10::nullopt', 'is_nullable': True},
+            ]
+    
+        idx += 1
+    
     # Sanity checks
 
     # TODO: convention is that the ith-argument correspond to the i-th return, but it would

--- a/aten/src/ATen/tensor_options_utils.py
+++ b/aten/src/ATen/tensor_options_utils.py
@@ -1,0 +1,133 @@
+tensor_options_optional_types_and_var = ['c10::optional<ScalarType> dtype', 'c10::optional<Layout> layout', 'c10::optional<Device> device', 'c10::optional<bool> pin_memory']
+tensor_options_types_and_var = ['ScalarType dtype', 'Layout layout', 'Device device', 'bool pin_memory']
+
+def check_if_factory_method(args):
+    for arg in args: 
+        if 'type' not in arg:
+            return False
+
+    a = any(arg['type'] == 'c10::optional<ScalarType>' for arg in args) and any(arg['type'] == 'c10::optional<Layout>' for arg in args) and any(arg['type'] == 'c10::optional<Device>' for arg in args) and any(arg['type'] == 'c10::optional<bool>' for arg in args)
+    c = any(arg['type'] == 'ScalarType' for arg in args) and any(arg['type'] == 'Layout' for arg in args) and any(arg['type'] == 'Device' for arg in args) and any(arg['type'] == 'bool' for arg in args)
+    b = any('TensorOptions' in arg['type'] for arg in args)
+
+    return a or b or c
+
+def collapse_actuals2(actuals):
+    collapsed = actuals[:]
+    index = actuals.index('dtype')
+    collapsed[index] = 'at::typeMetaToScalarType(options.dtype())'
+    collapsed[index + 1] = 'options.layout()'
+    collapsed[index + 2] = 'options.device()'
+    collapsed[index + 3] = 'options.pinned_memory()'
+    return collapsed
+
+
+def check_tensor_options_in_formals(formals):
+    return (any(formal['dynamic_type'] == 'ScalarType' for formal in formals) and
+            any(formal['dynamic_type'] == 'Layout' for formal in formals) and
+            any(formal['dynamic_type'] == 'Device' for formal in formals) and 
+            any(formal['dynamic_type'] == 'bool' for formal in formals))
+
+def collapse_actuals(actuals):
+        collapsed = actuals[:]
+        if (any(actual == 'dtype' for actual in actuals) and
+            any(actual == 'layout' for actual in actuals) and
+            any(actual == 'device' for actual in actuals) and 
+            any(actual == 'pin_memory' for actual in actuals)):
+            index = collapsed.index('dtype')
+
+            collapsed.pop(index)
+            collapsed.pop(index)
+            collapsed.pop(index)
+            collapsed.pop(index)
+            collapsed.insert(index, 'options')
+
+        return collapsed
+
+def collapse_formals(formals):
+    collapsed = formals[:]
+
+    hasTO = True
+    hasDefVal = False
+    for option in tensor_options_optional_types_and_var:
+        if not any(option in formal for formal in formals):
+            hasTO = False
+            break
+
+        if any((option in formal and '=' in formal) for formal in formals) :
+            hasDefVal = True
+
+        if hasTO:
+            index = [idx for idx, formal in enumerate(formals) if 'c10::optional<ScalarType> dtype' in formal][0]
+            collapsed.pop(index)
+            collapsed.pop(index)
+            collapsed.pop(index)
+            collapsed.pop(index)
+            if hasDefVal:
+                collapsed.insert(index, 'const at::TensorOptions & options={}')
+            else:
+                collapsed.insert(index, 'const at::TensorOptions & options')
+
+            return collapsed
+
+    hasTO = True
+    for option in tensor_options_types_and_var:
+        if not any(option in formal for formal in formals):
+            hasTO = False
+            break
+
+        if any((option in formal and '=' in formal) for formal in formals) :
+            hasDefVal = True
+
+        if hasTO:
+            index = [idx for idx, formal in enumerate(formals) if 'ScalarType dtype' in formal][0]
+            collapsed.pop(index)
+            collapsed.pop(index)
+            collapsed.pop(index)
+            collapsed.pop(index)
+            if hasDefVal:
+                collapsed.insert(index, 'const at::TensorOptions & options={}')
+            else:
+                collapsed.insert(index, 'const at::TensorOptions & options')
+
+            return collapsed
+
+    return collapsed
+
+def collapse_formals_list(formals):
+        collapsed = formals[:]
+        if (any(formal['type'] == 'c10::optional<ScalarType>' for formal in collapsed) and 
+            any(formal['type'] == 'c10::optional<Layout>' for formal in collapsed) and 
+            any(formal['type'] == 'c10::optional<Device>' for formal in collapsed) and 
+            any(formal['type'] == 'c10::optional<bool>' for formal in collapsed)):
+            index = 0
+            for i in range(len(collapsed)):
+                if collapsed[i]['type'] == 'c10::optional<ScalarType>':
+                    break
+                else:
+                    index += 1
+
+            collapsed.pop(index)
+            collapsed.pop(index)
+            collapsed.pop(index)
+            collapsed.pop(index)
+            collapsed.insert(index, {"annotation" : "None", "dynamic_type": "TensorOptions", "is_nullable": "False", "default": "{}", "kwarg_only": "True", "name": "options", "type": "const TensorOptions &", })
+
+        if (any(formal['type'] == 'ScalarType' for formal in collapsed) and 
+            any(formal['type'] == 'Layout' for formal in collapsed) and 
+            any(formal['type'] == 'Device' for formal in collapsed) and 
+            any(formal['type'] == 'bool' for formal in collapsed)):
+            index = 0
+            for i in range(len(collapsed)):
+                if collapsed[i]['type'] == 'ScalarType':
+                    break
+                else:
+                    index += 1
+
+            collapsed.pop(index)
+            collapsed.pop(index)
+            collapsed.pop(index)
+            collapsed.pop(index)
+            collapsed.insert(index, {"annotation" : "None", "dynamic_type": "TensorOptions", "is_nullable": "False", "kwarg_only": "True", "name": "options", "type": "const TensorOptions &", })
+
+        return collapsed

--- a/c10/core/Layout.h
+++ b/c10/core/Layout.h
@@ -6,7 +6,7 @@
 #include <iostream>
 
 namespace c10 {
-enum class Layout : int8_t { Strided, Sparse, Mkldnn };
+enum class Layout : int8_t { Strided, Sparse, Mkldnn, Unknown };
 
 constexpr auto kStrided = Layout::Strided;
 constexpr auto kSparse = Layout::Sparse;

--- a/caffe2/contrib/aten/gen_op.py
+++ b/caffe2/contrib/aten/gen_op.py
@@ -37,8 +37,10 @@ if args.aten_root:
             args.aten_root))
     sys.path.append(os.path.join(args.aten_root, 'src', 'ATen'))
     from code_template import CodeTemplate as CT
+    from tensor_options_utils import check_if_factory_method
 else:
     from src.ATen.code_template import CodeTemplate as CT
+    from src.ATen.tensor_options_utils import check_if_factory_method
 
 OP_TEMPLATE = CT.from_file(
     os.path.join(args.template_dir, 'aten_op_template.h'))
@@ -201,7 +203,7 @@ def get_num_inputs(o):
 def find_factory_methods(decls):
     factory_methods = {}
     for o in decls:
-        if any(arg['dynamic_type'] == 'TensorOptions' for arg in o['arguments']):
+        if check_if_factory_method(o['arguments']):
             factory_methods[o['name']] = 0
     return factory_methods
 

--- a/test/test_quantized_tensor.py
+++ b/test/test_quantized_tensor.py
@@ -112,9 +112,8 @@ class TestQuantizedTensor(TestCase):
         self.assertEqual(q.q_zero_point(), q_el.q_zero_point())
         self.assertEqual(q.dtype, q_el.dtype)
 
-        # create via empty_like but change the dtype (currently not supported)
-        with self.assertRaises(RuntimeError):
-            torch.empty_like(q, dtype=torch.qint8)
+        # create via empty_like but change the dtype
+        self.assertEqual(torch.qint8, torch.empty_like(q, dtype=torch.qint8).dtype)
 
     def test_qtensor_dtypes(self):
         r = torch.rand(3, 2, dtype=torch.float) * 4 - 2

--- a/tools/autograd/gen_variable_factories.py
+++ b/tools/autograd/gen_variable_factories.py
@@ -7,13 +7,52 @@ import re
 from .utils import CodeTemplate, write
 from .gen_variable_type import format_trace
 
+try:
+    from src.ATen.tensor_options_utils import *
+except ImportError:
+    from tools.shared.module_loader import import_module
+    TOUtils = import_module('tensor_options_utils', 'aten/src/ATen/tensor_options_utils.py')
+
+# This is a hack. 
+# issue #30405
+FUNCTION_TEMPLATE_ARANGE = CodeTemplate("""\
+inline at::Tensor ${name}(${collapsed_formals}) {
+  ${pre_record_trace}
+  at::Tensor tensor = ([&]() {
+    at::AutoNonVariableTypeMode non_var_type_mode(true);
+    auto currDtype = options.dtype_opt();
+    if (currDtype.has_value()) {
+      return at::_arange(${uncollapsed_actuals});
+    }
+    return at::_arange(${uncollapsed_actuals_nullptr});
+  })();
+  at::Tensor result =
+    autograd::make_variable(std::move(tensor), /*requires_grad=*/options.requires_grad());
+  ${post_record_trace}
+  return result;
+}
+""")
+
+FUNCTION_TEMPLATE_TENSOR_OPTIONS = CodeTemplate("""\
+inline at::Tensor ${name}(${collapsed_formals}) {
+  ${pre_record_trace}
+  at::Tensor tensor = ([&]() {
+    at::AutoNonVariableTypeMode non_var_type_mode(true);
+    return at::_${name}(${uncollapsed_actuals});
+  })();
+  at::Tensor result =
+    autograd::make_variable(std::move(tensor), /*requires_grad=*/options.requires_grad());
+  ${post_record_trace}
+  return result;
+}
+""")
 
 FUNCTION_TEMPLATE = CodeTemplate("""\
 inline at::Tensor ${name}(${formals}) {
   ${pre_record_trace}
   at::Tensor tensor = ([&]() {
     at::AutoNonVariableTypeMode non_var_type_mode(true);
-    return at::${name}(${actuals});
+    return at::_${name}(${actuals});
   })();
   at::Tensor result =
     autograd::make_variable(std::move(tensor), /*requires_grad=*/${requires_grad});
@@ -22,9 +61,7 @@ inline at::Tensor ${name}(${formals}) {
 }
 """)
 
-
 TYPE_PATTERN = re.compile(r"(?:const\s+)?([A-Z]\w+)")
-
 
 def fully_qualified_type(argument_type):
     match = TYPE_PATTERN.match(argument_type)
@@ -37,7 +74,7 @@ def fully_qualified_type(argument_type):
 def gen_variable_factories(out, declarations, template_path, disable_autograd=False):
     function_definitions = []
     for decl in declarations:
-        has_tensor_options = any(a["simple_type"] == "TensorOptions" for a in decl["arguments"])
+        has_tensor_options = TOUtils.check_if_factory_method(decl["arguments"])        
         is_namespace_fn = 'namespace' in decl['method_of']
         if (has_tensor_options or decl["name"].endswith("_like")) and is_namespace_fn:
             function_definitions.append(
@@ -47,29 +84,69 @@ def gen_variable_factories(out, declarations, template_path, disable_autograd=Fa
           CodeTemplate.from_file(template_path + "/variable_factories.h"),
           {"function_definitions": function_definitions})
 
-
+def replace_dtype_nullprt(actuals):
+    replaced = actuals[:]
+    index = actuals.index('at::typeMetaToScalarType(options.dtype())')
+    replaced[index] = 'c10::nullopt'
+    return replaced
+    
 def process_function(decl, has_tensor_options, disable_autograd):
     formals = []
     actuals = []
     for argument in decl["arguments"]:
         type = fully_qualified_type(argument["type"])
+        
         default = " = {}".format(argument["default"]) if "default" in argument else ""
+        if "default" in argument:
+            if argument["default"] == False or argument["default"] == True:
+                default = default.lower()
+
         formals.append("{} {}{}".format(type, argument["name"], default))
+
         actual = argument["name"]
         if argument["simple_type"] == "TensorOptions":
             actual = "at::TensorOptions({})".format(actual)
         actuals.append(actual)
-    requires_grad = "options.requires_grad()" if has_tensor_options else "false"
+
+    requires_grad = "false"
     if decl['name'].endswith('_like') and not has_tensor_options:
         # Insert TensorOptions before MemoryFormat
-        actuals.insert(-1, '{}.options()'.format(actuals[0]))
-
+        actuals.insert(-1, 'at::typeMetaToScalarType({}.options().dtype())'.format(actuals[0]))
+        actuals.insert(-1, '{}.options().layout()'.format(actuals[0]))
+        actuals.insert(-1, '{}.options().device()'.format(actuals[0]))
+        actuals.insert(-1, '{}.options().pinned_memory()'.format(actuals[0]))
+        
     if not disable_autograd:
         pre_record_trace, post_record_trace = format_trace(decl)
+        if has_tensor_options:
+            pre_record_trace = pre_record_trace.replace("jit::tracer::addInputs(node, \"dtype\", dtype);",
+                                                        "jit::tracer::addInputs(node, \"options\", options);")
+            pre_record_trace = pre_record_trace.replace("jit::tracer::addInputs(node, \"layout\", layout);",
+                                                        "")
+            pre_record_trace = pre_record_trace.replace("jit::tracer::addInputs(node, \"device\", device);",
+                                                        "")
+            pre_record_trace = pre_record_trace.replace("jit::tracer::addInputs(node, \"pin_memory\", pin_memory);",
+                                                        "")
     else:
         pre_record_trace, post_record_trace = '', ''
 
-    return FUNCTION_TEMPLATE.substitute(
-        name=decl["name"], formals=formals, actuals=actuals, requires_grad=requires_grad,
-        pre_record_trace=pre_record_trace, post_record_trace=post_record_trace
-    )
+    if not has_tensor_options:
+        return FUNCTION_TEMPLATE.substitute(
+            name=decl["name"], formals=formals, actuals=actuals, requires_grad=requires_grad,
+            pre_record_trace=pre_record_trace, post_record_trace=post_record_trace
+        )
+    else:
+        uncollapsed_actuals = TOUtils.collapse_actuals2(actuals)
+        collapsed_formals = TOUtils.collapse_formals(formals)
+        uncollapsed_actuals_nullptr = replace_dtype_nullprt(uncollapsed_actuals)
+
+        if decl['name'] == 'arange':
+            return FUNCTION_TEMPLATE_ARANGE.substitute(
+                name=decl["name"], collapsed_formals = collapsed_formals, actuals=actuals, uncollapsed_actuals=uncollapsed_actuals, uncollapsed_actuals_nullptr=uncollapsed_actuals_nullptr, requires_grad=requires_grad,
+                pre_record_trace=pre_record_trace, post_record_trace=post_record_trace
+            )
+        else:
+            return FUNCTION_TEMPLATE_TENSOR_OPTIONS.substitute(
+                name=decl["name"], collapsed_formals = collapsed_formals, actuals=actuals, uncollapsed_actuals=uncollapsed_actuals, requires_grad=requires_grad,
+                pre_record_trace=pre_record_trace, post_record_trace=post_record_trace
+            )

--- a/tools/pyi/gen_pyi.py
+++ b/tools/pyi/gen_pyi.py
@@ -39,7 +39,7 @@ read gen_pyi for the gory details.
 
 needed_modules = set()
 
-FACTORY_PARAMS = "dtype: Optional[_dtype]=None, device: Union[_device, str, None]=None, requires_grad: _bool=False"
+FACTORY_PARAMS = "dtype: Optional[_dtype]=None, layout: Optional[_layout]=None, device: Union[_device, str, None]=None, requires_grad: _bool=False"
 
 # this could be more precise w.r.t list contents etc. How to do Ellipsis?
 INDICES = "indices: Union[None, _int, slice, Tensor, List, Tuple]"
@@ -133,6 +133,7 @@ def type_to_python(typename, size=None):
         'Dimname': 'Union[str, None]',
         'DimnameList': 'List[Union[str, None]]',
         'QScheme': '_qscheme',
+        'Layout': '_layout'
     }[typename]
 
     return typename


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#30977 Updated codegen to remove TensorOptions from generated code**
* #30976 Prepare templates
* #30975 Updated DispatchKeyExtractor to expect TensorOptions
* #30974 Added C++ API test
* #30973 Add tracing support for optional Device and Layout

