### PR TITLE
Disable flaky test_rref_context_debug_info

### DIFF
--- a/test/rpc_test.py
+++ b/test/rpc_test.py
@@ -1109,6 +1109,7 @@ class RpcTest(RpcAgentTestFixture):
             "UserRRef(RRefId = {0}({1}, 1), ForkId = {0}({1}, 2))".format(id_class, self.rank)
         )
 
+    @unittest.skip("Test is flaky, see https://github.com/pytorch/pytorch/issues/30988")
     @dist_init
     def test_rref_context_debug_info(self):
         if not dist.is_initialized():


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #30994 Re-enable test_rref_context_debug_info after enforcing proper synchronization
* **#30990 Disable flaky test_rref_context_debug_info**

Differential Revision: [D18893023](https://our.internmc.facebook.com/intern/diff/D18893023)