### PR TITLE
3d t support

### DIFF
--- a/c10/core/MemoryFormat.h
+++ b/c10/core/MemoryFormat.h
@@ -51,13 +51,27 @@ inline std::ostream& operator<<(
 }
 
 inline std::vector<int64_t> get_channels_last_strides(IntArrayRef sizes) {
-  AT_ASSERT(sizes.size() == 4);
-  std::vector<int64_t> strides(sizes.size());
-  strides[1] = 1;
-  strides[3] = sizes[1];
-  strides[2] = strides[3] * sizes[3];
-  strides[0] = strides[2] * sizes[2];
-  return strides;
+  switch (sizes.size()) {
+    case 4: {
+    std::vector<int64_t> strides(sizes.size());
+    strides[1] = 1;
+    strides[3] = sizes[1];
+    strides[2] = strides[3] * sizes[3];
+    strides[0] = strides[2] * sizes[2];
+    return strides;
+  }
+    case 3: {
+    std::vector<int64_t> strides(sizes.size());
+    strides[0] = 1;
+    strides[2] = sizes[0];
+    strides[1] = strides[2] * sizes[2];
+    return strides;
+  }
+    default:
+    AT_ERROR("Unsupported tensor dimentiality for 2d images");
+  }
+
+
 }
 
 } // namespace c10

--- a/c10/core/TensorImpl.cpp
+++ b/c10/core/TensorImpl.cpp
@@ -126,6 +126,18 @@ bool TensorImpl::compute_strides_like_channels_last() const {
       }
     }
     return true;
+  } else if (sizes_.size() == 3) {
+    int64_t min = 0;
+    for (auto& d : {0, 2, 1}) {
+      if (sizes_[d] != 1) {
+        if (strides_[d] > min) {
+          min = strides_[d];
+        } else {
+          return false;
+        }
+      }
+    }
+    return true;
   }
   return false;
 }

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -1388,8 +1388,8 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
       }
       case MemoryFormat::ChannelsLast: {
         TORCH_CHECK(
-            dim() == 4,
-            "required rank 4 tensor to use channels_last format");
+            dim() == 4 || dim() == 3,
+            "required rank 4 or 3 tensor to use channels_last format");
         set_sizes_and_strides(sizes(), get_channels_last_strides(sizes()));
         set_channels_last_tag(true);
         break;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #31131 Add memory_format support to `zeros`, `ones`, `full` (still need tests)
* #30993 [WIP] Fixing resize_
* **#30992 3d t support**
* #30743 [WIP] Add channels last tag
* #30089 Switch default memory format of clone operator to Preserve
* #30088 Switch default memory format of to (and similar) operators to Preserve
* #30087 Switch default memory format of _like operators to Preserve
* #28991 Adding function to convert Module to channels last

