### PR TITLE
[WIP] Fixing resize_

### DIFF
--- a/aten/src/ATen/native/Resize.cpp
+++ b/aten/src/ATen/native/Resize.cpp
@@ -25,6 +25,7 @@ Tensor& resize_cpu_(
         "Unsupported memory format",
         memory_format);
     self_->empty_tensor_restride(memory_format);
+    self_->set_channels_last_tag(memory_format == MemoryFormat::ChannelsLast);
   }
   return self;
 }

--- a/aten/src/ATen/native/TensorConversions.cpp
+++ b/aten/src/ATen/native/TensorConversions.cpp
@@ -30,6 +30,11 @@ static inline Tensor to_impl(const Tensor& self, const TensorOptions& options, b
     return self;
   }
 
+  if (self.dtype() == options.dtype() && self.layout() == options.layout() &&
+      self.device() == options.device() && !copy) {
+        std::cout << "Changing memory format during to_impl " << self.sizes() << " " << self.strides() << " " << memory_format << "\n";
+      }
+
   if (memory_format == MemoryFormat::Preserve) {
     if (self.is_non_overlapping_and_dense()) {
       // Copy all strides

--- a/aten/src/ATen/native/TensorProperties.cpp
+++ b/aten/src/ATen/native/TensorProperties.cpp
@@ -83,7 +83,7 @@ Tensor contiguous(const Tensor& self, MemoryFormat memory_format) {
   TORCH_CHECK(
       memory_format != MemoryFormat::Preserve,
       "preserve memory format is unsupported by the contiguous operator");
-
+  std::cout << "Doing restrides during contiguous call " << self.sizes() << " " << self.strides() << " " << memory_format << "\n";
   auto result = at::empty_like(self, self.options(), memory_format);
   return result.copy_(self);
 }

--- a/aten/src/ATen/native/cuda/Resize.cu
+++ b/aten/src/ATen/native/cuda/Resize.cu
@@ -27,6 +27,7 @@ Tensor& resize_cuda_(
         "Unsupported memory format",
         memory_format);
     self_->empty_tensor_restride(memory_format);
+    self_->set_channels_last_tag(memory_format == MemoryFormat::ChannelsLast);
   }
   return self;
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #31131 Add memory_format support to `zeros`, `ones`, `full` (still need tests)
* **#30993 [WIP] Fixing resize_**
* #30992 3d t support
* #30743 [WIP] Add channels last tag
* #30089 Switch default memory format of clone operator to Preserve
* #30088 Switch default memory format of to (and similar) operators to Preserve
* #30087 Switch default memory format of _like operators to Preserve
* #28991 Adding function to convert Module to channels last

