### PR TITLE
Make Conv{1,2,3}dOptions and ConvTranspose{1,2,3}dOptions different classes

### DIFF
--- a/torch/csrc/api/include/torch/nn/modules/conv.h
+++ b/torch/csrc/api/include/torch/nn/modules/conv.h
@@ -17,9 +17,9 @@ namespace nn {
 
 /// Base class for all (dimension-specialized) convolution modules.
 template <size_t D, typename Derived>
-class ConvImpl : public torch::nn::Cloneable<Derived> {
+class ConvNdImpl : public torch::nn::Cloneable<Derived> {
  public:
-  explicit ConvImpl(ConvOptions<D> options_) : options(std::move(options_)) {
+  explicit ConvNdImpl(detail::ConvNdOptions<D> options_) : options(std::move(options_)) {
     reset();
   }
 
@@ -98,7 +98,7 @@ class ConvImpl : public torch::nn::Cloneable<Derived> {
   }
 
   /// The options with which this `Module` was constructed.
-  ConvOptions<D> options;
+  detail::ConvNdOptions<D> options;
 
   /// The learned kernel (or "weight").
   Tensor weight;
@@ -112,15 +112,15 @@ class ConvImpl : public torch::nn::Cloneable<Derived> {
 /// Applies convolution over a 1-D input.
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.Conv1d to learn about
 /// the exact behavior of this module.
-class TORCH_API Conv1dImpl : public ConvImpl<1, Conv1dImpl> {
+class TORCH_API Conv1dImpl : public ConvNdImpl<1, Conv1dImpl> {
  public:
   Conv1dImpl(
       int64_t input_channels,
       int64_t output_channels,
       ExpandingArray<1> kernel_size)
-      : Conv1dImpl(ConvOptions<1>(input_channels, output_channels, kernel_size)) {
+      : Conv1dImpl(Conv1dOptions(input_channels, output_channels, kernel_size)) {
   }
-  explicit Conv1dImpl(ConvOptions<1> options_);
+  explicit Conv1dImpl(Conv1dOptions options_);
   Tensor forward(const Tensor& input);
 };
 
@@ -135,15 +135,15 @@ TORCH_MODULE(Conv1d);
 /// Applies convolution over a 2-D input.
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.Conv2d to learn about
 /// the exact behavior of this module.
-class TORCH_API Conv2dImpl : public ConvImpl<2, Conv2dImpl> {
+class TORCH_API Conv2dImpl : public ConvNdImpl<2, Conv2dImpl> {
  public:
   Conv2dImpl(
       int64_t input_channels,
       int64_t output_channels,
       ExpandingArray<2> kernel_size)
-      : Conv2dImpl(ConvOptions<2>(input_channels, output_channels, kernel_size)) {
+      : Conv2dImpl(Conv2dOptions(input_channels, output_channels, kernel_size)) {
   }
-  explicit Conv2dImpl(ConvOptions<2> options_);
+  explicit Conv2dImpl(Conv2dOptions options_);
   Tensor forward(const Tensor& input);
 };
 
@@ -158,15 +158,15 @@ TORCH_MODULE(Conv2d);
 /// Applies convolution over a 3-D input.
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.Conv3d to learn about
 /// the exact behavior of this module.
-class TORCH_API Conv3dImpl : public ConvImpl<3, Conv3dImpl> {
+class TORCH_API Conv3dImpl : public ConvNdImpl<3, Conv3dImpl> {
  public:
   Conv3dImpl(
       int64_t input_channels,
       int64_t output_channels,
       ExpandingArray<3> kernel_size)
-      : Conv3dImpl(ConvOptions<3>(input_channels, output_channels, kernel_size)) {
+      : Conv3dImpl(Conv3dOptions(input_channels, output_channels, kernel_size)) {
   }
-  explicit Conv3dImpl(ConvOptions<3> options_);
+  explicit Conv3dImpl(Conv3dOptions options_);
   Tensor forward(const Tensor& input);
 };
 
@@ -180,9 +180,9 @@ TORCH_MODULE(Conv3d);
 
 /// Base class for all (dimension-specialized) convolution transpose modules.
 template <size_t D, typename Derived>
-class ConvTransposeImpl : public ConvImpl<D, Derived> {
+class ConvTransposeNdImpl : public ConvNdImpl<D, Derived> {
  public:
-  using torch::nn::ConvImpl<D, Derived>::ConvImpl;
+  using torch::nn::ConvNdImpl<D, Derived>::ConvNdImpl;
 
   /// Pretty prints the `ConvTranspose{1,2,3}d` module into the given `stream`.
   void pretty_print(std::ostream& stream) const override {
@@ -224,15 +224,15 @@ class ConvTransposeImpl : public ConvImpl<D, Derived> {
 /// Applies the ConvTranspose1d function.
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.ConvTranspose1d to
 /// learn about the exact behavior of this module.
-class TORCH_API ConvTranspose1dImpl : public ConvTransposeImpl<1, ConvTranspose1dImpl> {
+class TORCH_API ConvTranspose1dImpl : public ConvTransposeNdImpl<1, ConvTranspose1dImpl> {
  public:
   ConvTranspose1dImpl(
       int64_t input_channels,
       int64_t output_channels,
       ExpandingArray<1> kernel_size)
-      : ConvTranspose1dImpl(ConvTransposeOptions<1>(input_channels, output_channels, kernel_size)) {
+      : ConvTranspose1dImpl(ConvTranspose1dOptions(input_channels, output_channels, kernel_size)) {
   }
-  explicit ConvTranspose1dImpl(ConvTransposeOptions<1> options_);
+  explicit ConvTranspose1dImpl(ConvTranspose1dOptions options_);
   Tensor forward(const Tensor& input,
                  const c10::optional<at::IntArrayRef>& output_size = c10::nullopt);
 };
@@ -244,15 +244,15 @@ TORCH_MODULE(ConvTranspose1d);
 /// Applies the ConvTranspose2d function.
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.ConvTranspose2d to
 /// learn about the exact behavior of this module.
-class TORCH_API ConvTranspose2dImpl : public ConvTransposeImpl<2, ConvTranspose2dImpl> {
+class TORCH_API ConvTranspose2dImpl : public ConvTransposeNdImpl<2, ConvTranspose2dImpl> {
  public:
   ConvTranspose2dImpl(
       int64_t input_channels,
       int64_t output_channels,
       ExpandingArray<2> kernel_size)
-      : ConvTranspose2dImpl(ConvTransposeOptions<2>(input_channels, output_channels, kernel_size)) {
+      : ConvTranspose2dImpl(ConvTranspose2dOptions(input_channels, output_channels, kernel_size)) {
   }
-  explicit ConvTranspose2dImpl(ConvTransposeOptions<2> options_);
+  explicit ConvTranspose2dImpl(ConvTranspose2dOptions options_);
   Tensor forward(const Tensor& input,
                  const c10::optional<at::IntArrayRef>& output_size = c10::nullopt);
 };
@@ -264,15 +264,15 @@ TORCH_MODULE(ConvTranspose2d);
 /// Applies the ConvTranspose3d function.
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.ConvTranspose3d to
 /// learn about the exact behavior of this module.
-class TORCH_API ConvTranspose3dImpl : public ConvTransposeImpl<3, ConvTranspose3dImpl> {
+class TORCH_API ConvTranspose3dImpl : public ConvTransposeNdImpl<3, ConvTranspose3dImpl> {
  public:
   ConvTranspose3dImpl(
       int64_t input_channels,
       int64_t output_channels,
       ExpandingArray<3> kernel_size)
-      : ConvTranspose3dImpl(ConvTransposeOptions<3>(input_channels, output_channels, kernel_size)) {
+      : ConvTranspose3dImpl(ConvTranspose3dOptions(input_channels, output_channels, kernel_size)) {
   }
-  explicit ConvTranspose3dImpl(ConvTransposeOptions<3> options_);
+  explicit ConvTranspose3dImpl(ConvTranspose3dOptions options_);
   Tensor forward(const Tensor& input,
                  const c10::optional<at::IntArrayRef>& output_size = c10::nullopt);
 };

--- a/torch/csrc/api/include/torch/nn/options/conv.h
+++ b/torch/csrc/api/include/torch/nn/options/conv.h
@@ -9,12 +9,14 @@
 namespace torch {
 namespace nn {
 
-/// Options for a `D`-dimensional convolution module.
-template <size_t D>
-struct ConvOptions {
-  typedef c10::variant<enumtype::kZeros, enumtype::kCircular> padding_mode_t;
+namespace detail {
 
-  ConvOptions(
+typedef c10::variant<enumtype::kZeros, enumtype::kCircular> conv_padding_mode_t;
+
+/// Options for a `D`-dimensional convolution or convolution transpose module.
+template <size_t D>
+struct ConvNdOptions {
+  ConvNdOptions(
       int64_t in_channels,
       int64_t out_channels,
       ExpandingArray<D> kernel_size) :
@@ -64,6 +66,67 @@ struct ConvOptions {
   /// numbers.
   /// This parameter __can__ be changed after construction.
   TORCH_ARG(ExpandingArray<D>, output_padding) = 0;
+
+  /// The number of convolution groups.
+  /// This parameter __can__ be changed after construction.
+  TORCH_ARG(int64_t, groups) = 1;
+
+  /// Whether to add a bias after individual applications of the kernel.
+  /// Changing this parameter after construction __has no effect__.
+  TORCH_ARG(bool, bias) = true;
+
+  /// Accepted values `zeros` and `circular` Default: `zeros`
+  TORCH_ARG(conv_padding_mode_t, padding_mode) = torch::kZeros;
+};
+
+} // namespace detail
+
+// ============================================================================
+
+/// Options for a `D`-dimensional convolution module.
+template <size_t D>
+struct ConvOptions {
+  using padding_mode_t = detail::conv_padding_mode_t;
+
+  ConvOptions(
+      int64_t in_channels,
+      int64_t out_channels,
+      ExpandingArray<D> kernel_size) :
+                in_channels_(in_channels),
+                out_channels_(out_channels),
+                kernel_size_(std::move(kernel_size)) {}
+
+  /// The number of channels the input volumes will have.
+  /// Changing this parameter after construction __has no effect__.
+  TORCH_ARG(int64_t, in_channels);
+
+  /// The number of output channels the convolution should produce.
+  /// Changing this parameter after construction __has no effect__.
+  TORCH_ARG(int64_t, out_channels);
+
+  /// The kernel size to use.
+  /// For a `D`-dim convolution, must be a single number or a list of `D`
+  /// numbers.
+  /// This parameter __can__ be changed after construction.
+  TORCH_ARG(ExpandingArray<D>, kernel_size);
+
+  /// The stride of the convolution.
+  /// For a `D`-dim convolution, must be a single number or a list of `D`
+  /// numbers.
+  /// This parameter __can__ be changed after construction.
+  TORCH_ARG(ExpandingArray<D>, stride) = 1;
+
+  /// The padding to add to the input volumes.
+  /// For a `D`-dim convolution, must be a single number or a list of `D`
+  /// numbers.
+  /// This parameter __can__ be changed after construction.
+  TORCH_ARG(ExpandingArray<D>, padding) = 0;
+
+  /// The kernel dilation.
+  /// For a `D`-dim convolution, must be a single number or a list of `D`
+  /// numbers.
+  /// This parameter __can__ be changed after construction.
+  TORCH_ARG(ExpandingArray<D>, dilation) = 1;
 
   /// The number of convolution groups.
   /// This parameter __can__ be changed after construction.
@@ -129,8 +192,67 @@ using Conv3dFuncOptions = ConvFuncOptions<3>;
 
 // ============================================================================
 
-template<size_t D>
-using ConvTransposeOptions = ConvOptions<D>;
+template <size_t D>
+struct ConvTransposeOptions {
+  using padding_mode_t = detail::conv_padding_mode_t;
+
+  ConvTransposeOptions(
+      int64_t in_channels,
+      int64_t out_channels,
+      ExpandingArray<D> kernel_size) :
+                in_channels_(in_channels),
+                out_channels_(out_channels),
+                kernel_size_(std::move(kernel_size)) {}
+
+  /// The number of channels the input volumes will have.
+  /// Changing this parameter after construction __has no effect__.
+  TORCH_ARG(int64_t, in_channels);
+
+  /// The number of output channels the convolution should produce.
+  /// Changing this parameter after construction __has no effect__.
+  TORCH_ARG(int64_t, out_channels);
+
+  /// The kernel size to use.
+  /// For a `D`-dim convolution, must be a single number or a list of `D`
+  /// numbers.
+  /// This parameter __can__ be changed after construction.
+  TORCH_ARG(ExpandingArray<D>, kernel_size);
+
+  /// The stride of the convolution.
+  /// For a `D`-dim convolution, must be a single number or a list of `D`
+  /// numbers.
+  /// This parameter __can__ be changed after construction.
+  TORCH_ARG(ExpandingArray<D>, stride) = 1;
+
+  /// The padding to add to the input volumes.
+  /// For a `D`-dim convolution, must be a single number or a list of `D`
+  /// numbers.
+  /// This parameter __can__ be changed after construction.
+  TORCH_ARG(ExpandingArray<D>, padding) = 0;
+
+  /// For transpose convolutions, the padding to add to output volumes.
+  /// For a `D`-dim convolution, must be a single number or a list of `D`
+  /// numbers.
+  /// This parameter __can__ be changed after construction.
+  TORCH_ARG(ExpandingArray<D>, output_padding) = 0;
+
+  /// The number of convolution groups.
+  /// This parameter __can__ be changed after construction.
+  TORCH_ARG(int64_t, groups) = 1;
+
+  /// Whether to add a bias after individual applications of the kernel.
+  /// Changing this parameter after construction __has no effect__.
+  TORCH_ARG(bool, bias) = true;
+
+  /// The kernel dilation.
+  /// For a `D`-dim convolution, must be a single number or a list of `D`
+  /// numbers.
+  /// This parameter __can__ be changed after construction.
+  TORCH_ARG(ExpandingArray<D>, dilation) = 1;
+
+  /// Accepted values `zeros` and `circular` Default: `zeros`
+  TORCH_ARG(padding_mode_t, padding_mode) = torch::kZeros;
+};
 
 /// `ConvTransposeOptions` specialized for 1-D convolution.
 using ConvTranspose1dOptions = ConvTransposeOptions<1>;

--- a/torch/csrc/api/src/nn/modules/conv.cpp
+++ b/torch/csrc/api/src/nn/modules/conv.cpp
@@ -19,8 +19,20 @@ namespace F = torch::nn::functional;
 namespace torch {
 namespace nn {
 Conv1dImpl::Conv1dImpl(
-    ConvOptions<1> options_)
-    : ConvImpl(options_.transposed(false).output_padding(0)) {}
+    Conv1dOptions options_)
+    : ConvNdImpl(
+        detail::ConvNdOptions<1>(
+          /*in_channels=*/options_.in_channels(),
+          /*out_channels=*/options_.out_channels(),
+          /*kernel_size=*/options_.kernel_size())
+          .stride(options_.stride())
+          .padding(options_.padding())
+          .dilation(options_.dilation())
+          .transposed(false)
+          .output_padding(0)
+          .groups(options_.groups())
+          .bias(options_.bias())
+          .padding_mode(options_.padding_mode())) {}
 
 Tensor Conv1dImpl::forward(const Tensor& input) {
   if (c10::get_if<enumtype::kCircular>(&options.padding_mode())) {
@@ -44,8 +56,20 @@ Tensor Conv1dImpl::forward(const Tensor& input) {
 }
 
 Conv2dImpl::Conv2dImpl(
-    ConvOptions<2> options_)
-    : ConvImpl(options_.transposed(false).output_padding(0)) {}
+    Conv2dOptions options_)
+    : ConvNdImpl(
+        detail::ConvNdOptions<2>(
+          /*in_channels=*/options_.in_channels(),
+          /*out_channels=*/options_.out_channels(),
+          /*kernel_size=*/options_.kernel_size())
+          .stride(options_.stride())
+          .padding(options_.padding())
+          .dilation(options_.dilation())
+          .transposed(false)
+          .output_padding(0)
+          .groups(options_.groups())
+          .bias(options_.bias())
+          .padding_mode(options_.padding_mode())) {}
 
 Tensor Conv2dImpl::forward(const Tensor& input) {
   if (c10::get_if<enumtype::kCircular>(&options.padding_mode())) {
@@ -71,8 +95,20 @@ Tensor Conv2dImpl::forward(const Tensor& input) {
 }
 
 Conv3dImpl::Conv3dImpl(
-    ConvOptions<3> options_)
-    : ConvImpl(options_.transposed(false).output_padding(0)) {}
+    Conv3dOptions options_)
+    : ConvNdImpl(
+        detail::ConvNdOptions<3>(
+          /*in_channels=*/options_.in_channels(),
+          /*out_channels=*/options_.out_channels(),
+          /*kernel_size=*/options_.kernel_size())
+          .stride(options_.stride())
+          .padding(options_.padding())
+          .dilation(options_.dilation())
+          .transposed(false)
+          .output_padding(0)
+          .groups(options_.groups())
+          .bias(options_.bias())
+          .padding_mode(options_.padding_mode())) {}
 
 Tensor Conv3dImpl::forward(const Tensor& input) {
   if (c10::get_if<enumtype::kCircular>(&options.padding_mode())) {
@@ -98,14 +134,14 @@ Tensor Conv3dImpl::forward(const Tensor& input) {
     options.groups());
 }
 
-template class ConvImpl<1, Conv1dImpl>;
-template class ConvImpl<2, Conv2dImpl>;
-template class ConvImpl<3, Conv3dImpl>;
+template class ConvNdImpl<1, Conv1dImpl>;
+template class ConvNdImpl<2, Conv2dImpl>;
+template class ConvNdImpl<3, Conv3dImpl>;
 
 // ============================================================================
 
 template <size_t D, typename Derived>
-std::vector<int64_t> ConvTransposeImpl<D, Derived>::_output_padding(
+std::vector<int64_t> ConvTransposeNdImpl<D, Derived>::_output_padding(
     const Tensor& input, const c10::optional<at::IntArrayRef>& output_size,
     const ExpandingArray<D>& stride, const ExpandingArray<D>& padding,
     const ExpandingArray<D>& kernel_size) {
@@ -151,7 +187,20 @@ std::vector<int64_t> ConvTransposeImpl<D, Derived>::_output_padding(
 }
 
 ConvTranspose1dImpl::ConvTranspose1dImpl(
-    ConvTransposeOptions<1> options_) : ConvTransposeImpl(options_.transposed(true)) {}
+    ConvTranspose1dOptions options_)
+    : ConvTransposeNdImpl(
+        detail::ConvNdOptions<1>(
+          /*in_channels=*/options_.in_channels(),
+          /*out_channels=*/options_.out_channels(),
+          /*kernel_size=*/options_.kernel_size())
+          .stride(options_.stride())
+          .padding(options_.padding())
+          .dilation(options_.dilation())
+          .transposed(true)
+          .output_padding(options_.output_padding())
+          .groups(options_.groups())
+          .bias(options_.bias())
+          .padding_mode(options_.padding_mode())) {}
 
 Tensor ConvTranspose1dImpl::forward(
     const Tensor& input, const c10::optional<at::IntArrayRef>& output_size) {
@@ -168,7 +217,19 @@ Tensor ConvTranspose1dImpl::forward(
 }
 
 ConvTranspose2dImpl::ConvTranspose2dImpl(
-    ConvTransposeOptions<2> options_) : ConvTransposeImpl(options_.transposed(true)) {}
+    ConvTranspose2dOptions options_)
+    : ConvTransposeNdImpl(detail::ConvNdOptions<2>(
+          /*in_channels=*/options_.in_channels(),
+          /*out_channels=*/options_.out_channels(),
+          /*kernel_size=*/options_.kernel_size())
+          .stride(options_.stride())
+          .padding(options_.padding())
+          .dilation(options_.dilation())
+          .transposed(true)
+          .output_padding(options_.output_padding())
+          .groups(options_.groups())
+          .bias(options_.bias())
+          .padding_mode(options_.padding_mode())) {}
 
 Tensor ConvTranspose2dImpl::forward(
     const Tensor& input, const c10::optional<at::IntArrayRef>& output_size) {
@@ -185,7 +246,19 @@ Tensor ConvTranspose2dImpl::forward(
 }
 
 ConvTranspose3dImpl::ConvTranspose3dImpl(
-    ConvTransposeOptions<3> options_) : ConvTransposeImpl(options_.transposed(true)) {}
+    ConvTranspose3dOptions options_)
+    : ConvTransposeNdImpl(detail::ConvNdOptions<3>(
+          /*in_channels=*/options_.in_channels(),
+          /*out_channels=*/options_.out_channels(),
+          /*kernel_size=*/options_.kernel_size())
+          .stride(options_.stride())
+          .padding(options_.padding())
+          .dilation(options_.dilation())
+          .transposed(true)
+          .output_padding(options_.output_padding())
+          .groups(options_.groups())
+          .bias(options_.bias())
+          .padding_mode(options_.padding_mode())) {}
 
 Tensor ConvTranspose3dImpl::forward(
     const Tensor& input, const c10::optional<at::IntArrayRef>& output_size) {
@@ -201,9 +274,9 @@ Tensor ConvTranspose3dImpl::forward(
     output_padding, options.groups(), options.dilation());
 }
 
-template class ConvTransposeImpl<1, ConvTranspose1dImpl>;
-template class ConvTransposeImpl<2, ConvTranspose2dImpl>;
-template class ConvTransposeImpl<3, ConvTranspose3dImpl>;
+template class ConvTransposeNdImpl<1, ConvTranspose1dImpl>;
+template class ConvTransposeNdImpl<2, ConvTranspose2dImpl>;
+template class ConvTransposeNdImpl<3, ConvTranspose3dImpl>;
 
 } // namespace nn
 } // namespace torch


### PR DESCRIPTION
Currently, both `Conv{1,2,3}dOptions` and `ConvTranspose{1,2,3}dOptions` are aliases of the `ConvOptions<{1,2,3}>` class, which causes confusion because the `ConvOptions` class has parameters such as `transposed` that shouldn't be exposed to the end user. (This has caused issues such as https://github.com/pytorch/pytorch/issues/30931.) This PR makes the following improvements:
1. Rename the original `torch::nn::ConvOptions<N>` class to `torch::nn::detail::ConvNdOptions<N>` class, to signify that it's an implementation detail and should not be used publicly.
2. Create new classes `torch::nn::ConvOptions<N>` and `torch::nn::ConvTransposeOptions<N>`, which have parameters that exactly match the constructor of `torch.nn.Conv{1,2,3}d` and `torch.nn.ConvTranspose{1,2,3}d` in Python API.

------

This PR is BC-breaking in the following way:
- `Conv{1,2,3}dOptions` no longer has the `transposed` argument. Users should migrate their code to use `ConvTranspose{1,2,3}d` layers instead, if they have `transposed` originally set to `true` in `Conv{1,2,3}dOptions`. Note that `ConvTranspose{1,2,3}d` cannot be used in a `Sequential` module because `Sequential` module doesn't support modules with forward method that can take optional arguments. Users should create their own wrapper for `ConvTranspose{1,2,3}d` and have its forward method just accept a tensor, if they want to use it in a `Sequential` module.
For example:
```cpp
struct ConvTranspose2dWrapperImpl : public torch::nn::ConvTranspose2dImpl {
  using torch::nn::ConvTranspose2dImpl::ConvTranspose2dImpl;

  torch::Tensor forward(const torch::Tensor& input) {
    return torch::nn::ConvTranspose2dImpl::forward(input, c10::nullopt);
  }
};

TORCH_MODULE(ConvTranspose2dWrapper);

torch::nn::Sequential sequential(
  ConvTranspose2dWrapper(torch::nn::ConvTranspose2dOptions(3, 3, 4));
```