### PR TITLE
qnnpack TanH

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qnnpack/CMakeLists.txt
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/CMakeLists.txt
@@ -147,6 +147,7 @@ SET(PYTORCH_QNNPACK_INIT_SRCS
   src/max-pooling.c
   src/sigmoid.c
   src/softargmax.c
+  src/tanh.c
   src/operator-delete.c)
 
 SET(PYTORCH_QNNPACK_EXEC_SRCS
@@ -446,6 +447,15 @@ IF(PYTORCH_QNNPACK_BUILD_TESTS)
   TARGET_LINK_LIBRARIES(softargmax-test PRIVATE pytorch_qnnpack cpuinfo gtest gtest_main)
   ADD_TEST(softargmax-test softargmax-test)
 
+  ADD_EXECUTABLE(tanh-test test/tanh.cc)
+  SET_TARGET_PROPERTIES(tanh-test PROPERTIES
+    CXX_STANDARD 14
+    CXX_STANDARD_REQUIRED YES
+    CXX_EXTENSIONS NO)
+  TARGET_INCLUDE_DIRECTORIES(tanh-test PRIVATE src test)
+  TARGET_LINK_LIBRARIES(tanh-test PRIVATE pytorch_qnnpack cpuinfo gtest gtest_main)
+  ADD_TEST(tanh-test tanh-test)
+
   ADD_EXECUTABLE(max-pooling-test test/max-pooling.cc)
   SET_TARGET_PROPERTIES(max-pooling-test PROPERTIES
     CXX_STANDARD 14
@@ -666,6 +676,13 @@ IF(PYTORCH_QNNPACK_BUILD_BENCHMARKS)
     CXX_STANDARD_REQUIRED YES
     CXX_EXTENSIONS NO)
   TARGET_LINK_LIBRARIES(softargmax-bench PRIVATE pytorch_qnnpack benchmark)
+
+  ADD_EXECUTABLE(tanh-bench bench/tanh.cc)
+  SET_TARGET_PROPERTIES(tanh-bench PROPERTIES
+    CXX_STANDARD 14
+    CXX_STANDARD_REQUIRED YES
+    CXX_EXTENSIONS NO)
+  TARGET_LINK_LIBRARIES(tanh-bench PRIVATE pytorch_qnnpack benchmark)
 
   ADD_EXECUTABLE(q8gemm-bench bench/q8gemm.cc)
   SET_TARGET_PROPERTIES(q8gemm-bench PROPERTIES

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/README.md
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/README.md
@@ -16,6 +16,7 @@ Currently implemented and planned for implementation operators are below:
 - [x] 2D Average Pooling
 - [x] Global Average Pooling
 - [x] Sigmoid
+- [x] TanH
 - [x] Leaky ReLU
 - [x] Clamp (can be used for ReLU, ReLU6 if it is not fused in another operator)
 - [x] SoftArgMax (aka SoftMax)

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/bench/tanh.cc
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/bench/tanh.cc
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <algorithm>
+#include <cmath>
+#include <functional>
+#include <random>
+#include <vector>
+
+#include <pytorch_qnnpack.h>
+
+#include <benchmark/benchmark.h>
+
+static void tanh_q8(benchmark::State& state) {
+  const size_t batchSize = static_cast<size_t>(state.range(0));
+  const size_t channels = static_cast<size_t>(state.range(1));
+
+  std::random_device randomDevice;
+  auto rng = std::mt19937(randomDevice());
+  auto u8rng = std::bind(std::uniform_int_distribution<uint8_t>(), rng);
+
+  std::vector<uint8_t> input(batchSize * channels);
+  std::vector<uint8_t> output(batchSize * channels);
+  std::generate(input.begin(), input.end(), std::ref(u8rng));
+  std::fill(output.begin(), output.end(), 0xA5);
+
+  pytorch_qnnp_status status = pytorch_qnnp_initialize();
+  if (status != pytorch_qnnp_status_success) {
+    state.SkipWithError("failed to initialize QNNPACK");
+  }
+
+  pytorch_qnnp_operator_t tanhOperator = nullptr;
+  status = pytorch_qnnp_create_tanh_nc_q8(
+      channels,
+      127 /* input zero point */,
+      1.0f /* input scale */,
+      0 /* output zero point */,
+      1.0f / 256.0f /* output scale */,
+      0 /* output min */,
+      255 /* output max */,
+      0 /* flags */,
+      &tanhOperator);
+  if (status != pytorch_qnnp_status_success || tanhOperator == nullptr) {
+    state.SkipWithError("failed to create TanH operator");
+  }
+
+  status = pytorch_qnnp_setup_tanh_nc_q8(
+      tanhOperator,
+      batchSize,
+      input.data(),
+      channels /* input:stride */,
+      output.data(),
+      channels /* output:stride */);
+  if (status != pytorch_qnnp_status_success) {
+    state.SkipWithError("failed to setup TanH operator");
+  }
+
+  for (auto _ : state) {
+    status =
+        pytorch_qnnp_run_operator(tanhOperator, nullptr /* thread pool */);
+    if (status != pytorch_qnnp_status_success) {
+      state.SkipWithError("failed to run TanH operator");
+    }
+  }
+
+  const size_t itemsPerIteration = batchSize * channels;
+  state.SetItemsProcessed(
+      int64_t(state.iterations()) * int64_t(itemsPerIteration));
+
+  const size_t bytesPerIteration = 2 * itemsPerIteration * sizeof(uint8_t);
+  state.SetBytesProcessed(
+      int64_t(state.iterations()) * int64_t(bytesPerIteration));
+
+  status = pytorch_qnnp_delete_operator(tanhOperator);
+  if (status != pytorch_qnnp_status_success) {
+    state.SkipWithError("failed to delete TanH operator");
+  }
+}
+
+static void CharacteristicArguments(benchmark::internal::Benchmark* b) {
+  b->ArgNames({"N", "C"});
+
+  int32_t c = 16;
+  for (int32_t n = 224; n >= 7; n /= 2) {
+    b->Args({n * n, c});
+    c *= 2;
+  }
+}
+
+BENCHMARK(tanh_q8)->Apply(CharacteristicArguments);
+
+#ifndef PYTORCH_QNNPACK_BENCHMARK_NO_MAIN
+BENCHMARK_MAIN();
+#endif

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/configure.py
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/configure.py
@@ -91,6 +91,7 @@ def main(args):
             build.cc("max-pooling.c"),
             build.cc("sigmoid.c"),
             build.cc("softargmax.c"),
+            build.cc("tanh.c"),
             # Scalar micro-kernels
             build.cc("u8lut32norm/scalar.c"),
             build.cc("x8lut/scalar.c"),
@@ -218,6 +219,7 @@ def main(args):
         build.unittest("max-pooling-test", build.cxx("max-pooling.cc"))
         build.unittest("sigmoid-test", build.cxx("sigmoid.cc"))
         build.unittest("softargmax-test", build.cxx("softargmax.cc"))
+        build.unittest("tanh-test", build.cxx("tanh.cc"))
         build.unittest(
             "requantization-test",
             [build.cxx("requantization.cc")] + requantization_objects,
@@ -255,6 +257,7 @@ def main(args):
         build.benchmark("max-pooling-bench", build.cxx("max-pooling.cc"))
         build.benchmark("sigmoid-bench", build.cxx("sigmoid.cc"))
         build.benchmark("softargmax-bench", build.cxx("softargmax.cc"))
+        build.benchmark("tanh-bench", build.cxx("tanh.cc"))
 
         build.benchmark("q8gemm-bench", build.cxx("q8gemm.cc"))
         build.benchmark("hgemm-bench", build.cxx("hgemm.cc"))

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/include/pytorch_qnnpack.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/include/pytorch_qnnpack.h
@@ -324,6 +324,25 @@ enum pytorch_qnnp_status pytorch_qnnp_setup_softargmax_nc_q8(
     uint8_t* output,
     size_t output_stride);
 
+enum pytorch_qnnp_status pytorch_qnnp_create_tanh_nc_q8(
+    size_t channels,
+    uint8_t input_zero_point,
+    float input_scale,
+    uint8_t output_zero_point,
+    float output_scale,
+    uint8_t output_min,
+    uint8_t output_max,
+    uint32_t flags,
+    pytorch_qnnp_operator_t* tanh);
+
+enum pytorch_qnnp_status pytorch_qnnp_setup_tanh_nc_q8(
+    pytorch_qnnp_operator_t tanh,
+    size_t batch_size,
+    const uint8_t* input,
+    size_t input_stride,
+    uint8_t* output,
+    size_t output_stride);
+
 enum pytorch_qnnp_status pytorch_qnnp_run_operator(
     pytorch_qnnp_operator_t op,
     pthreadpool_t threadpool);

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/tanh.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/tanh.c
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <assert.h>
+#include <math.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include <pytorch_qnnpack.h>
+#include <qnnpack/log.h>
+#include <qnnpack/operator.h>
+
+enum pytorch_qnnp_status pytorch_qnnp_create_tanh_nc_q8(
+    size_t channels,
+    uint8_t input_zero_point,
+    float input_scale,
+    uint8_t output_zero_point,
+    float output_scale,
+    uint8_t output_min,
+    uint8_t output_max,
+    uint32_t flags,
+    pytorch_qnnp_operator_t* tanh_out) {
+  pytorch_qnnp_operator_t tanh_op = NULL;
+  enum pytorch_qnnp_status status = pytorch_qnnp_status_uninitialized;
+
+  if (!pytorch_qnnp_params.initialized) {
+    pytorch_qnnp_log_error(
+        "pytorch_qnnp_create_tanh_nc_q8 failed because QNNPACK is not properly initialized");
+    goto error;
+  }
+
+  status = pytorch_qnnp_status_invalid_parameter;
+
+  if (channels == 0) {
+    pytorch_qnnp_log_error(
+        "failed to create TanH operator with %zu channels: number of channels must be non-zero",
+        channels);
+    goto error;
+  }
+
+  if (input_scale <= 0.0f || !isnormal(input_scale)) {
+    pytorch_qnnp_log_error(
+        "failed to create TanH operator with %.7g input scale: scale must be finite and positive",
+        input_scale);
+    goto error;
+  }
+
+  if (output_scale <= 0.0f || !isnormal(output_scale)) {
+    pytorch_qnnp_log_error(
+        "failed to create TanH operator with %.7g output scale: scale must be finite and positive",
+        output_scale);
+    goto error;
+  }
+
+  if (output_min >= output_max) {
+    pytorch_qnnp_log_error(
+        "failed to create TanH operator with [%" PRIu8 ", %" PRIu8
+        "] output range: range min must be below range max",
+        output_min,
+        output_max);
+    goto error;
+  }
+
+  status = pytorch_qnnp_status_unsupported_parameter;
+
+  if (output_scale != 0x1.0p-8f) {
+    pytorch_qnnp_log_error(
+        "failed to create TanH operator with %.7g output scale: only output scale of 1/256 is supported",
+        output_scale);
+    goto error;
+  }
+
+  if (output_zero_point != 0) {
+    pytorch_qnnp_log_error(
+        "failed to create TanH operator with %" PRIu8
+        " output zero point: only output zero point of 0 is supported",
+        output_zero_point);
+    goto error;
+  }
+
+  status = pytorch_qnnp_status_out_of_memory;
+
+  tanh_op = calloc(1, sizeof(struct pytorch_qnnp_operator));
+  if (tanh_op == NULL) {
+    pytorch_qnnp_log_error(
+        "failed to allocate %zu bytes for pytorch_qnnp_operator structure",
+        sizeof(struct pytorch_qnnp_operator));
+    goto error;
+  }
+
+  tanh_op->lookup_table = malloc(256 * sizeof(uint8_t));
+  if (tanh_op->lookup_table == NULL) {
+    pytorch_qnnp_log_error(
+        "failed to allocate 256 bytes for TanH lookup table");
+    goto error;
+  }
+
+  uint8_t* lookup_table = tanh_op->lookup_table;
+  const float scaled_min = (float)(int32_t)output_min;
+  const float scaled_max = (float)(int32_t)output_max;
+  for (int32_t i = 0; i < 256; i++) {
+    const float x =
+        input_scale * (float)(i - (int32_t)(uint32_t)input_zero_point);
+    /* Scale tanh(x) by 1 / output scale = 256.0 */
+    float expf_x = expf(x);
+    float expf_x_recipocal = expf(-x);
+    float tanh_x = (expf_x - expf_x_recipocal) / (expf_x - expf_x_recipocal);
+    float scaled_tanh_x = 256.0f * tanh_x;
+    if (scaled_tanh_x < scaled_min) {
+      scaled_tanh_x = scaled_min;
+    }
+    if (scaled_tanh_x > scaled_max) {
+      scaled_tanh_x = scaled_max;
+    }
+    lookup_table[(uint32_t)i] = (uint8_t)lrintf(scaled_tanh_x);
+  }
+
+  tanh_op->channels = channels;
+
+  tanh_op->ukernel_type = pytorch_qnnp_ukernel_type_lut;
+  tanh_op->format = pytorch_qnnp_format_quint8;
+
+  *tanh_out = tanh_op;
+  return pytorch_qnnp_status_success;
+
+error:
+  pytorch_qnnp_delete_operator(tanh_op);
+  return status;
+}
+
+enum pytorch_qnnp_status pytorch_qnnp_setup_tanh_nc_q8(
+    pytorch_qnnp_operator_t tanh,
+    size_t batch_size,
+    const uint8_t* input,
+    size_t input_stride,
+    uint8_t* output,
+    size_t output_stride) {
+  if (!pytorch_qnnp_params.initialized) {
+    pytorch_qnnp_log_error(
+        "pytorch_qnnp_setup_tanh_nc_q8 failed because QNNPACK is not properly initialized");
+    return pytorch_qnnp_status_uninitialized;
+  }
+
+  if (batch_size == 0) {
+    tanh->batch_size = 0;
+    return pytorch_qnnp_status_success;
+  }
+
+  tanh->batch_size = batch_size;
+  tanh->input = input;
+  tanh->input_pixel_stride = input_stride;
+  tanh->output = output;
+  tanh->output_pixel_stride = output_stride;
+
+  return pytorch_qnnp_status_success;
+}

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/test/tanh-operator-tester.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/test/tanh-operator-tester.h
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <cstddef>
+#include <cstdlib>
+#include <functional>
+#include <random>
+#include <vector>
+
+#include <pytorch_qnnpack.h>
+
+class TanHOperatorTester {
+ public:
+  inline TanHOperatorTester& channels(size_t channels) {
+    assert(channels != 0);
+    this->channels_ = channels;
+    return *this;
+  }
+
+  inline size_t channels() const {
+    return this->channels_;
+  }
+
+  inline TanHOperatorTester& inputStride(size_t inputStride) {
+    assert(inputStride != 0);
+    this->inputStride_ = inputStride;
+    return *this;
+  }
+
+  inline size_t inputStride() const {
+    if (this->inputStride_ == 0) {
+      return this->channels_;
+    } else {
+      assert(this->inputStride_ >= this->channels_);
+      return this->inputStride_;
+    }
+  }
+
+  inline TanHOperatorTester& outputStride(size_t outputStride) {
+    assert(outputStride != 0);
+    this->outputStride_ = outputStride;
+    return *this;
+  }
+
+  inline size_t outputStride() const {
+    if (this->outputStride_ == 0) {
+      return this->channels_;
+    } else {
+      assert(this->outputStride_ >= this->channels_);
+      return this->outputStride_;
+    }
+  }
+
+  inline TanHOperatorTester& batchSize(size_t batchSize) {
+    this->batchSize_ = batchSize;
+    return *this;
+  }
+
+  inline size_t batchSize() const {
+    return this->batchSize_;
+  }
+
+  inline TanHOperatorTester& inputScale(float inputScale) {
+    assert(inputScale > 0.0f);
+    assert(std::isnormal(inputScale));
+    this->inputScale_ = inputScale;
+    return *this;
+  }
+
+  inline float inputScale() const {
+    return this->inputScale_;
+  }
+
+  inline TanHOperatorTester& inputZeroPoint(uint8_t inputZeroPoint) {
+    this->inputZeroPoint_ = inputZeroPoint;
+    return *this;
+  }
+
+  inline uint8_t inputZeroPoint() const {
+    return this->inputZeroPoint_;
+  }
+
+  inline float outputScale() const {
+    return 1.0f / 256.0f;
+  }
+
+  inline uint8_t outputZeroPoint() const {
+    return 0;
+  }
+
+  inline TanHOperatorTester& qmin(uint8_t qmin) {
+    this->qmin_ = qmin;
+    return *this;
+  }
+
+  inline uint8_t qmin() const {
+    return this->qmin_;
+  }
+
+  inline TanHOperatorTester& qmax(uint8_t qmax) {
+    this->qmax_ = qmax;
+    return *this;
+  }
+
+  inline uint8_t qmax() const {
+    return this->qmax_;
+  }
+
+  inline TanHOperatorTester& iterations(size_t iterations) {
+    this->iterations_ = iterations;
+    return *this;
+  }
+
+  inline size_t iterations() const {
+    return this->iterations_;
+  }
+
+  void testQ8() const {
+    std::random_device randomDevice;
+    auto rng = std::mt19937(randomDevice());
+    auto u8rng = std::bind(std::uniform_int_distribution<uint8_t>(), rng);
+
+    std::vector<uint8_t> input((batchSize() - 1) * inputStride() + channels());
+    std::vector<uint8_t> output(
+        (batchSize() - 1) * outputStride() + channels());
+    std::vector<float> outputRef(batchSize() * channels());
+    for (size_t iteration = 0; iteration < iterations(); iteration++) {
+      std::generate(input.begin(), input.end(), std::ref(u8rng));
+      std::fill(output.begin(), output.end(), 0xA5);
+
+      /* Compute reference results */
+      for (size_t i = 0; i < batchSize(); i++) {
+        for (size_t c = 0; c < channels(); c++) {
+          const float x = inputScale() *
+              (int32_t(input[i * inputStride() + c]) -
+               int32_t(inputZeroPoint()));
+          const float exp_x = exp(x);
+          const float exp_x_r = exp(-x);
+          const float tanhX = (exp_x - exp_x_r) / (exp_x + exp_x_r);
+          const float scaledTanHX = tanhX / outputScale();
+          float y = scaledTanHX;
+          y = std::min<float>(y, int32_t(qmax()) - int32_t(outputZeroPoint()));
+          y = std::max<float>(y, int32_t(qmin()) - int32_t(outputZeroPoint()));
+          outputRef[i * channels() + c] = y + int32_t(outputZeroPoint());
+        }
+      }
+
+      /* Create, setup, run, and destroy TanH operator */
+      ASSERT_EQ(pytorch_qnnp_status_success, pytorch_qnnp_initialize());
+      pytorch_qnnp_operator_t tanhOp = nullptr;
+
+      ASSERT_EQ(
+          pytorch_qnnp_status_success,
+          pytorch_qnnp_create_tanh_nc_q8(
+              channels(),
+              inputZeroPoint(),
+              inputScale(),
+              outputZeroPoint(),
+              outputScale(),
+              qmin(),
+              qmax(),
+              0,
+              &tanhOp));
+      ASSERT_NE(nullptr, tanhOp);
+
+      ASSERT_EQ(
+          pytorch_qnnp_status_success,
+          pytorch_qnnp_setup_tanh_nc_q8(
+              tanhOp,
+              batchSize(),
+              input.data(),
+              inputStride(),
+              output.data(),
+              outputStride()));
+
+      ASSERT_EQ(
+          pytorch_qnnp_status_success,
+          pytorch_qnnp_run_operator(tanhOp, nullptr /* thread pool */));
+
+      ASSERT_EQ(
+          pytorch_qnnp_status_success, pytorch_qnnp_delete_operator(tanhOp));
+      tanhOp = nullptr;
+
+      /* Verify results */
+      for (size_t i = 0; i < batchSize(); i++) {
+        for (size_t c = 0; c < channels(); c++) {
+          ASSERT_NEAR(
+              float(int32_t(output[i * outputStride() + c])),
+              outputRef[i * channels() + c],
+              0.6f);
+        }
+      }
+    }
+  }
+
+ private:
+  size_t batchSize_{1};
+  size_t channels_{1};
+  size_t inputStride_{0};
+  size_t outputStride_{0};
+  float inputScale_{0.75f};
+  uint8_t inputZeroPoint_{121};
+  uint8_t qmin_{0};
+  uint8_t qmax_{255};
+  size_t iterations_{15};
+};

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/test/tanh.cc
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/test/tanh.cc
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+
+#include "tanh-operator-tester.h"
+
+#include <qnnpack/params.h>
+
+TEST(SIGMOID_OP, zero_batch) {
+  TanHOperatorTester().batchSize(0).channels(8).iterations(1).testQ8();
+}
+
+TEST(SIGMOID_OP, unit_batch) {
+  for (size_t channels = 1; channels < 100; channels += 15) {
+    TanHOperatorTester()
+        .batchSize(1)
+        .channels(channels)
+        .iterations(3)
+        .testQ8();
+  }
+}
+
+TEST(SIGMOID_OP, unit_batch_with_qmin) {
+  for (size_t channels = 1; channels < 100; channels += 15) {
+    TanHOperatorTester()
+        .batchSize(1)
+        .channels(channels)
+        .qmin(128)
+        .iterations(3)
+        .testQ8();
+  }
+}
+
+TEST(SIGMOID_OP, unit_batch_with_qmax) {
+  for (size_t channels = 1; channels < 100; channels += 15) {
+    TanHOperatorTester()
+        .batchSize(1)
+        .channels(channels)
+        .qmax(128)
+        .iterations(3)
+        .testQ8();
+  }
+}
+
+TEST(SIGMOID_OP, unit_batch_with_input_scale) {
+  for (size_t channels = 1; channels < 100; channels += 15) {
+    for (float inputScale = 1.0e-2f; inputScale < 1.0e+2f;
+         inputScale *= 10.0f) {
+      TanHOperatorTester()
+          .batchSize(1)
+          .channels(channels)
+          .inputScale(inputScale)
+          .iterations(1)
+          .testQ8();
+    }
+  }
+}
+
+TEST(SIGMOID_OP, unit_batch_with_input_zero_point) {
+  for (size_t channels = 1; channels < 100; channels += 15) {
+    for (int32_t inputZeroPoint = 0; inputZeroPoint <= 255;
+         inputZeroPoint += 51) {
+      TanHOperatorTester()
+          .batchSize(1)
+          .channels(channels)
+          .inputZeroPoint(uint8_t(inputZeroPoint))
+          .iterations(1)
+          .testQ8();
+    }
+  }
+}
+
+TEST(SIGMOID_OP, small_batch) {
+  for (size_t channels = 1; channels < 100; channels += 15) {
+    TanHOperatorTester()
+        .batchSize(3)
+        .channels(channels)
+        .iterations(3)
+        .testQ8();
+  }
+}
+
+TEST(SIGMOID_OP, small_batch_with_input_stride) {
+  for (size_t channels = 1; channels < 100; channels += 15) {
+    TanHOperatorTester()
+        .batchSize(3)
+        .channels(channels)
+        .inputStride(129)
+        .iterations(3)
+        .testQ8();
+  }
+}
+
+TEST(SIGMOID_OP, small_batch_with_output_stride) {
+  for (size_t channels = 1; channels < 100; channels += 15) {
+    TanHOperatorTester()
+        .batchSize(3)
+        .channels(channels)
+        .outputStride(117)
+        .iterations(3)
+        .testQ8();
+  }
+}
+
+TEST(SIGMOID_OP, small_batch_with_qmin) {
+  for (size_t channels = 1; channels < 100; channels += 15) {
+    TanHOperatorTester()
+        .batchSize(3)
+        .channels(channels)
+        .qmin(128)
+        .iterations(3)
+        .testQ8();
+  }
+}
+
+TEST(SIGMOID_OP, small_batch_with_qmax) {
+  for (size_t channels = 1; channels < 100; channels += 15) {
+    TanHOperatorTester()
+        .batchSize(3)
+        .channels(channels)
+        .qmax(128)
+        .iterations(3)
+        .testQ8();
+  }
+}
+
+TEST(SIGMOID_OP, small_batch_with_input_scale) {
+  for (size_t channels = 1; channels < 100; channels += 15) {
+    for (float inputScale = 1.0e-2f; inputScale < 1.0e+2f;
+         inputScale *= 10.0f) {
+      TanHOperatorTester()
+          .batchSize(3)
+          .channels(channels)
+          .inputScale(inputScale)
+          .iterations(1)
+          .testQ8();
+    }
+  }
+}
+
+TEST(SIGMOID_OP, small_batch_with_input_zero_point) {
+  for (size_t channels = 1; channels < 100; channels += 15) {
+    for (int32_t inputZeroPoint = 0; inputZeroPoint <= 255;
+         inputZeroPoint += 51) {
+      TanHOperatorTester()
+          .batchSize(3)
+          .channels(channels)
+          .inputZeroPoint(uint8_t(inputZeroPoint))
+          .iterations(1)
+          .testQ8();
+    }
+  }
+}
+
+TEST(SIGMOID_OP, strided_batch) {
+  for (size_t channels = 1; channels < 100; channels += 15) {
+    TanHOperatorTester()
+        .batchSize(3)
+        .channels(channels)
+        .inputStride(129)
+        .outputStride(117)
+        .iterations(3)
+        .testQ8();
+  }
+}
+
+TEST(SIGMOID_OP, strided_batch_with_qmin) {
+  for (size_t channels = 1; channels < 100; channels += 15) {
+    TanHOperatorTester()
+        .batchSize(3)
+        .channels(channels)
+        .inputStride(129)
+        .outputStride(117)
+        .qmin(128)
+        .iterations(3)
+        .testQ8();
+  }
+}
+
+TEST(SIGMOID_OP, strided_batch_with_qmax) {
+  for (size_t channels = 1; channels < 100; channels += 15) {
+    TanHOperatorTester()
+        .batchSize(3)
+        .channels(channels)
+        .inputStride(129)
+        .outputStride(117)
+        .qmax(128)
+        .iterations(3)
+        .testQ8();
+  }
+}
+
+TEST(SIGMOID_OP, strided_batch_with_input_scale) {
+  for (size_t channels = 1; channels < 100; channels += 15) {
+    for (float inputScale = 1.0e-2f; inputScale < 1.0e+2f;
+         inputScale *= 10.0f) {
+      TanHOperatorTester()
+          .batchSize(3)
+          .channels(channels)
+          .inputStride(129)
+          .outputStride(117)
+          .inputScale(inputScale)
+          .iterations(1)
+          .testQ8();
+    }
+  }
+}
+
+TEST(SIGMOID_OP, strided_batch_with_input_zero_point) {
+  for (size_t channels = 1; channels < 100; channels += 15) {
+    for (int32_t inputZeroPoint = 0; inputZeroPoint <= 255;
+         inputZeroPoint += 51) {
+      TanHOperatorTester()
+          .batchSize(3)
+          .channels(channels)
+          .inputStride(129)
+          .outputStride(117)
+          .inputZeroPoint(uint8_t(inputZeroPoint))
+          .iterations(1)
+          .testQ8();
+    }
+  }
+}


### PR DESCRIPTION

```console
./build/local/tanh-test
Running main() from gtest_main.cc
[==========] Running 18 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 18 tests from TANH_OP
[ RUN      ] TANH_OP.zero_batch
[       OK ] TANH_OP.zero_batch (0 ms)
[ RUN      ] TANH_OP.unit_batch
[       OK ] TANH_OP.unit_batch (0 ms)
[ RUN      ] TANH_OP.unit_batch_with_qmin
[       OK ] TANH_OP.unit_batch_with_qmin (1 ms)
[ RUN      ] TANH_OP.unit_batch_with_qmax
[       OK ] TANH_OP.unit_batch_with_qmax (0 ms)
[ RUN      ] TANH_OP.unit_batch_with_input_scale
[       OK ] TANH_OP.unit_batch_with_input_scale (1 ms)
[ RUN      ] TANH_OP.unit_batch_with_input_zero_point
[       OK ] TANH_OP.unit_batch_with_input_zero_point (1 ms)
[ RUN      ] TANH_OP.small_batch
[       OK ] TANH_OP.small_batch (0 ms)
[ RUN      ] TANH_OP.small_batch_with_input_stride
[       OK ] TANH_OP.small_batch_with_input_stride (1 ms)
[ RUN      ] TANH_OP.small_batch_with_output_stride
[       OK ] TANH_OP.small_batch_with_output_stride (0 ms)
[ RUN      ] TANH_OP.small_batch_with_qmin
[       OK ] TANH_OP.small_batch_with_qmin (0 ms)
[ RUN      ] TANH_OP.small_batch_with_qmax
[       OK ] TANH_OP.small_batch_with_qmax (1 ms)
[ RUN      ] TANH_OP.small_batch_with_input_scale
[       OK ] TANH_OP.small_batch_with_input_scale (1 ms)
[ RUN      ] TANH_OP.small_batch_with_input_zero_point
[       OK ] TANH_OP.small_batch_with_input_zero_point (1 ms)
[ RUN      ] TANH_OP.strided_batch
[       OK ] TANH_OP.strided_batch (0 ms)
[ RUN      ] TANH_OP.strided_batch_with_qmin
[       OK ] TANH_OP.strided_batch_with_qmin (1 ms)
[ RUN      ] TANH_OP.strided_batch_with_qmax
[       OK ] TANH_OP.strided_batch_with_qmax (0 ms)
[ RUN      ] TANH_OP.strided_batch_with_input_scale
[       OK ] TANH_OP.strided_batch_with_input_scale (1 ms)
[ RUN      ] TANH_OP.strided_batch_with_input_zero_point
[       OK ] TANH_OP.strided_batch_with_input_zero_point (2 ms)
[----------] 18 tests from TANH_OP (11 ms total)

[----------] Global test environment tear-down
[==========] 18 tests from 1 test case ran. (11 ms total)
[  PASSED  ] 18 tests.
```

Stack from [ghstack](https://github.com/ezyang/ghstack):
* #31031 [Draft] Quantized H Tangent function
* **#31013 qnnpack TanH**

Differential Revision: [D18898903](https://our.internmc.facebook.com/intern/diff/D18898903)