### PR TITLE
Fix memory leak due to circular dependency.

### DIFF
--- a/torch/csrc/distributed/autograd/functions/recvrpc_backward.cpp
+++ b/torch/csrc/distributed/autograd/functions/recvrpc_backward.cpp
@@ -40,7 +40,11 @@ variable_list RecvRpcBackward::apply(variable_list&& grads) {
       rpcAgent->getWorkerInfo(fromWorkerId_), std::move(gradCall).toMessage());
 
   // Record the future in the context.
-  autogradContext_->addOutstandingRpc(futureMessage);
+  if (auto sharedContext = autogradContext_.lock()) {
+    sharedContext->addOutstandingRpc(futureMessage);
+  } else {
+    C10_THROW_ERROR(Error, "Autograd context no longer valid");
+  }
 
   // 'recv' function sends the gradients over the wire using RPC, it doesn't
   // need to return anything for any downstream autograd function.

--- a/torch/csrc/distributed/autograd/functions/recvrpc_backward.h
+++ b/torch/csrc/distributed/autograd/functions/recvrpc_backward.h
@@ -30,8 +30,10 @@ class TORCH_API RecvRpcBackward : public torch::autograd::Node {
  private:
   const AutogradMetadata autogradMetadata_;
 
-  // Hold a reference to the autograd context.
-  std::shared_ptr<DistAutogradContext> autogradContext_;
+  // Hold a weak reference to the autograd context to avoid circular
+  // dependencies with the context (since it holds a reference to
+  // RecvRpcBackward).
+  std::weak_ptr<DistAutogradContext> autogradContext_;
 
   // The worker id from which the RPC was received. During the backward pass,
   // we need to propagate the gradients to this workerId.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#31030 Fix memory leak due to circular dependency.**

DistAutogradContext held a shared_ptr reference to RecvRpcBackward and
RecvRpcBackward held a shared_ptr reference to the context. This circular
dependency caused significant memory leaks. As a result, I'm changing the
reference in RecvRpcBackward to be a weak_ptr.

Differential Revision: [D18896389](https://our.internmc.facebook.com/intern/diff/D18896389/)