### PR TITLE
[android] Expose setNumThreads to android api

### DIFF
--- a/android/pytorch_android/src/main/cpp/pytorch_jni_jit.cpp
+++ b/android/pytorch_android/src/main/cpp/pytorch_jni_jit.cpp
@@ -6,6 +6,8 @@
 #include <fbjni/ByteBuffer.h>
 #include <fbjni/fbjni.h>
 
+#include <caffe2/utils/threadpool/ThreadPool.h>
+#include <caffe2/utils/threadpool/ThreadPoolMobile.h>
 #include <torch/csrc/autograd/record_function.h>
 #include <torch/script.h>
 
@@ -73,6 +75,7 @@ class PytorchJni : public facebook::jni::HybridClass<PytorchJni> {
         makeNativeMethod("initHybrid", PytorchJni::initHybrid),
         makeNativeMethod("forward", PytorchJni::forward),
         makeNativeMethod("runMethod", PytorchJni::runMethod),
+        makeNativeMethod("setNumThreads", PytorchJni::setNumThreads),
     });
   }
 
@@ -121,6 +124,10 @@ class PytorchJni : public facebook::jni::HybridClass<PytorchJni> {
         facebook::jni::gJavaLangIllegalArgumentException,
         "Undefined method %s",
         methodName.c_str());
+  }
+
+  void setNumThreads(jint numThreads) {
+    caffe2::mobile_threadpool()->setNumThreads(numThreads);
   }
 };
 

--- a/android/pytorch_android/src/main/java/org/pytorch/INativePeer.java
+++ b/android/pytorch_android/src/main/java/org/pytorch/INativePeer.java
@@ -8,4 +8,6 @@ interface INativePeer {
   IValue forward(IValue... inputs);
 
   IValue runMethod(String methodName, IValue... inputs);
+
+  void setNumThreads(int numThreads);
 }

--- a/android/pytorch_android/src/main/java/org/pytorch/LiteNativePeer.java
+++ b/android/pytorch_android/src/main/java/org/pytorch/LiteNativePeer.java
@@ -25,4 +25,6 @@ class LiteNativePeer implements INativePeer {
   public native IValue forward(IValue... inputs);
 
   public native IValue runMethod(String methodName, IValue... inputs);
+
+  public native void setNumThreads(int numThreads);
 }

--- a/android/pytorch_android/src/main/java/org/pytorch/Module.java
+++ b/android/pytorch_android/src/main/java/org/pytorch/Module.java
@@ -48,6 +48,13 @@ public class Module {
     return mNativePeer.runMethod(methodName, inputs);
   }
 
+  public void setNumThreads(int numThreads) {
+    if (numThreads < 1) {
+        throw new IllegalArgumentException("Number of threads cannot be less than 1");
+    }
+    mNativePeer.setNumThreads(numThreads);
+  }
+
   /**
    * Explicitly destroys the native torch::jit::script::Module. Calling this method is not required,
    * as the native object will be destroyed when this object is garbage-collected. However, the

--- a/android/pytorch_android/src/main/java/org/pytorch/Module.java
+++ b/android/pytorch_android/src/main/java/org/pytorch/Module.java
@@ -48,6 +48,12 @@ public class Module {
     return mNativePeer.runMethod(methodName, inputs);
   }
 
+  /**
+   * Sets the number of threads used on native side.
+   * Has global effect for all loaded modules.
+   *
+   * @param numThreads number of threads, must be positive number.
+   */
   public void setNumThreads(int numThreads) {
     if (numThreads < 1) {
         throw new IllegalArgumentException("Number of threads cannot be less than 1");

--- a/android/pytorch_android/src/main/java/org/pytorch/Module.java
+++ b/android/pytorch_android/src/main/java/org/pytorch/Module.java
@@ -49,8 +49,8 @@ public class Module {
   }
 
   /**
-   * Sets the number of threads used on native side.
-   * Has global effect for all loaded modules.
+   * Globally sets the number of threads used on native side.
+   * Attention: Has global effect, all modules will use one thread pool with specified number of threads.
    *
    * @param numThreads number of threads, must be positive number.
    */

--- a/android/pytorch_android/src/main/java/org/pytorch/NativePeer.java
+++ b/android/pytorch_android/src/main/java/org/pytorch/NativePeer.java
@@ -25,4 +25,6 @@ class NativePeer implements INativePeer {
   public native IValue forward(IValue... inputs);
 
   public native IValue runMethod(String methodName, IValue... inputs);
+
+  public native void setNumThreads(int numThreads);
 }

--- a/caffe2/utils/threadpool/ThreadPool.cc
+++ b/caffe2/utils/threadpool/ThreadPool.cc
@@ -87,6 +87,11 @@ int ThreadPool::getNumThreads() const {
   return numThreads_;
 }
 
+void ThreadPool::setNumThreads(size_t numThreads) {
+  std::lock_guard<std::mutex> guard(executionMutex_);
+  numThreads_ = numThreads;
+}
+
 // Sets the minimum work size (range) for which to invoke the
 // threadpool; work sizes smaller than this will just be run on the
 // main (calling) thread

--- a/caffe2/utils/threadpool/ThreadPool.cc
+++ b/caffe2/utils/threadpool/ThreadPool.cc
@@ -88,7 +88,6 @@ int ThreadPool::getNumThreads() const {
 }
 
 void ThreadPool::setNumThreads(size_t numThreads) {
-  //std::lock_guard<std::mutex> guard(numThreadsMutex_);
   numThreads_ = numThreads;
 }
 
@@ -101,11 +100,7 @@ void ThreadPool::setMinWorkSize(size_t size) {
 }
 
 void ThreadPool::run(const std::function<void(int, size_t)>& fn, size_t range) {
-  const auto numThreads = numThreads_; 
-  //const auto numThreads = [&](){
-  //  std::lock_guard<std::mutex> g{numThreadsMutex_};
-  //  return numThreads_;
-  //}();
+  const auto numThreads = numThreads_.load(std::memory_order_relaxed); 
 
   std::lock_guard<std::mutex> guard(executionMutex_);
   // If there are no worker threads, or if the range is too small (too

--- a/caffe2/utils/threadpool/ThreadPool.cc
+++ b/caffe2/utils/threadpool/ThreadPool.cc
@@ -88,7 +88,7 @@ int ThreadPool::getNumThreads() const {
 }
 
 void ThreadPool::setNumThreads(size_t numThreads) {
-  std::lock_guard<std::mutex> guard(executionMutex_);
+  //std::lock_guard<std::mutex> guard(numThreadsMutex_);
   numThreads_ = numThreads;
 }
 
@@ -101,11 +101,17 @@ void ThreadPool::setMinWorkSize(size_t size) {
 }
 
 void ThreadPool::run(const std::function<void(int, size_t)>& fn, size_t range) {
+  const auto numThreads = numThreads_; 
+  //const auto numThreads = [&](){
+  //  std::lock_guard<std::mutex> g{numThreadsMutex_};
+  //  return numThreads_;
+  //}();
+
   std::lock_guard<std::mutex> guard(executionMutex_);
   // If there are no worker threads, or if the range is too small (too
   // little work), just run locally
   const bool runLocally = range < minWorkSize_ ||
-      FLAGS_caffe2_threadpool_force_inline || (numThreads_ == 0);
+      FLAGS_caffe2_threadpool_force_inline || (numThreads == 0);
   if (runLocally) {
     // Work is small enough to just run locally; multithread overhead
     // is too high
@@ -130,9 +136,9 @@ void ThreadPool::run(const std::function<void(int, size_t)>& fn, size_t range) {
   };
 
   CAFFE_ENFORCE_GE(numThreads_, 1);
-  const size_t unitsPerTask = (range + numThreads_ - 1) / numThreads_;
-  tasks_.resize(numThreads_);
-  for (size_t i = 0; i < numThreads_; ++i) {
+  const size_t unitsPerTask = (range + numThreads - 1) / numThreads;
+  tasks_.resize(numThreads);
+  for (size_t i = 0; i < numThreads; ++i) {
     if (!tasks_[i]) {
       tasks_[i].reset(new FnTask());
     }
@@ -148,7 +154,7 @@ void ThreadPool::run(const std::function<void(int, size_t)>& fn, size_t range) {
     CAFFE_ENFORCE_LE(task->start_, range);
     CAFFE_ENFORCE_LE(task->end_, range);
   }
-  CAFFE_ENFORCE_LE(tasks_.size(), numThreads_);
+  CAFFE_ENFORCE_LE(tasks_.size(), numThreads);
   CAFFE_ENFORCE_GE(tasks_.size(), 1);
   workersPool_->Execute(tasks_);
 }

--- a/caffe2/utils/threadpool/ThreadPool.h
+++ b/caffe2/utils/threadpool/ThreadPool.h
@@ -36,6 +36,7 @@ class CAFFE2_API /*alignas(kCacheLineSize)*/ ThreadPool {
   ~ThreadPool();
   // Returns the number of threads currently in use
   int getNumThreads() const;
+  void setNumThreads(size_t numThreads);
 
   // Sets the minimum work size (range) for which to invoke the
   // threadpool; work sizes smaller than this will just be run on the

--- a/caffe2/utils/threadpool/ThreadPool.h
+++ b/caffe2/utils/threadpool/ThreadPool.h
@@ -51,7 +51,7 @@ class CAFFE2_API /*alignas(kCacheLineSize)*/ ThreadPool {
   void withPool(const std::function<void(WorkersPool*)>& fn);
 
  private:
-  std::mutex executionMutex_;
+  mutable std::mutex executionMutex_;
   size_t minWorkSize_;
   std::atomic_size_t numThreads_;
   std::shared_ptr<WorkersPool> workersPool_;

--- a/caffe2/utils/threadpool/ThreadPool.h
+++ b/caffe2/utils/threadpool/ThreadPool.h
@@ -50,7 +50,8 @@ class CAFFE2_API /*alignas(kCacheLineSize)*/ ThreadPool {
   void withPool(const std::function<void(WorkersPool*)>& fn);
 
  private:
-  mutable std::mutex executionMutex_;
+  std::mutex executionMutex_;
+  //std::mutex numThreadsMutex_;
   size_t minWorkSize_;
   size_t numThreads_;
   std::shared_ptr<WorkersPool> workersPool_;

--- a/caffe2/utils/threadpool/ThreadPool.h
+++ b/caffe2/utils/threadpool/ThreadPool.h
@@ -7,6 +7,7 @@
 #include <memory>
 #include <mutex>
 #include <vector>
+#include <atomic>
 
 #include "caffe2/core/common.h"
 
@@ -51,9 +52,8 @@ class CAFFE2_API /*alignas(kCacheLineSize)*/ ThreadPool {
 
  private:
   std::mutex executionMutex_;
-  //std::mutex numThreadsMutex_;
   size_t minWorkSize_;
-  size_t numThreads_;
+  std::atomic_size_t numThreads_;
   std::shared_ptr<WorkersPool> workersPool_;
   std::vector<std::shared_ptr<Task>> tasks_;
 };


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#31033 [android] Expose setNumThreads to android api**

Intention:
There are requests from users to control number of threads from android side:
https://discuss.pytorch.org/t/android-pytorch-forward-method-running-in-a-separate-thread-slow-down-ui-thread/63516/2
https://discuss.pytorch.org/t/threading-of-model-pytorch-android/62490/2

At the moment `setNumThreads` is placed in `org.pytorch.Module`, but this method changes global threadPool size, in future we will move it to some separate class to repeat python binding structure, which has torch.set_num_threads()

Differential Revision: [D18923167](https://our.internmc.facebook.com/intern/diff/D18923167)