### PR TITLE
avoid large vector copy when query per_channel q_params

### DIFF
--- a/aten/src/ATen/native/quantized/QTensor.cpp
+++ b/aten/src/ATen/native/quantized/QTensor.cpp
@@ -47,17 +47,13 @@ int64_t q_zero_point_quant(const Tensor& self) {
 Tensor q_per_channel_scales_quant(const Tensor& self) {
   auto quantizer = get_qtensorimpl(self)->quantizer();
   TORCH_CHECK(quantizer->qscheme() == kPerChannelAffine);
-  return at::tensor(
-      static_cast<PerChannelAffineQuantizer*>(quantizer.get())->scales(),
-      self.options().dtype(at::kDouble));
+  return static_cast<PerChannelAffineQuantizer*>(quantizer.get())->scales().to(kDouble);
 }
 
 Tensor q_per_channel_zero_points_quant(const Tensor& self) {
   auto quantizer = get_qtensorimpl(self)->quantizer();
   TORCH_CHECK(quantizer->qscheme() == kPerChannelAffine);
-  return at::tensor(
-      static_cast<PerChannelAffineQuantizer*>(quantizer.get())->zero_points(),
-      self.options().dtype(at::kLong));
+  return static_cast<PerChannelAffineQuantizer*>(quantizer.get())->zero_points().to(kLong);
 }
 
 int64_t q_per_channel_axis_quant(const Tensor& self) {

--- a/aten/src/ATen/quantized/Quantizer.cpp
+++ b/aten/src/ATen/quantized/Quantizer.cpp
@@ -66,14 +66,15 @@ void checkZeroPoint(std::string fn_name, int64_t zero_point) {
 }
 
 template <typename T>
-void checkZeroPoints(std::string fn_name, std::vector<int64_t> zero_points) {
-  for (size_t i = 0; i < zero_points.size(); ++i) {
-    TORCH_CHECK(zero_points[i] <= std::numeric_limits<T>::max(),
+void checkZeroPoints(std::string fn_name, Tensor zero_points) {
+  auto zero_points_data = zero_points.data_ptr<int64_t>();
+  for (size_t i = 0; i < zero_points.numel(); ++i) {
+    TORCH_CHECK(zero_points_data[i] <= std::numeric_limits<T>::max(),
                 fn_name,
                 "zero_point",
                 i,
                 "is out of range.");
-    TORCH_CHECK(zero_points[i] >= std::numeric_limits<T>::min(),
+    TORCH_CHECK(zero_points_data[i] >= std::numeric_limits<T>::min(),
                 fn_name,
                 "zero_point",
                 i,
@@ -365,8 +366,8 @@ template CAFFE2_API qint32 requantize_val<qint32, qint32>(double, int64_t, doubl
 template <typename T>
 Tensor quantize_tensor_per_channel_affine(Tensor rtensor,
                                           Tensor qtensor,
-                                          const std::vector<double>& scales,
-                                          const std::vector<int64_t>& zero_points,
+                                          Tensor scales,
+                                          Tensor zero_points,
                                           int64_t axis) {
   auto fn_name = "quantize_tensor_per_channel_affine";
   checkFloatCPUTensor(fn_name, rtensor);
@@ -376,9 +377,11 @@ Tensor quantize_tensor_per_channel_affine(Tensor rtensor,
   int64_t batches = size_to_dim_(axis, rtensor.sizes());
   int64_t elements_per_channel = size_from_dim_(axis + 1, rtensor.sizes());
   int64_t channel = rtensor.size(axis);
-  TORCH_CHECK(channel == int64_t(scales.size()),
+  auto scales_data = scales.data_ptr<double>();
+  auto zero_points_data = zero_points.data_ptr<int64_t>();
+  TORCH_CHECK(channel == int64_t(scales.numel()),
               "length of scales must equal to channel");
-  TORCH_CHECK(channel == int64_t(zero_points.size()),
+  TORCH_CHECK(channel == int64_t(zero_points.numel()),
               "length of zero_points must equal to channel");
   const float* rdata = rtensor.data_ptr<float>();
   auto qdata = qtensor.data_ptr<T>();
@@ -386,7 +389,7 @@ Tensor quantize_tensor_per_channel_affine(Tensor rtensor,
     for (auto c = 0; c < channel; ++c) {
       for (auto e = 0; e < elements_per_channel; ++e) {
         auto i = b * channel * elements_per_channel + c * elements_per_channel + e;
-        qdata[i] = quantize_val<T>(scales[c], zero_points[c], rdata[i]);
+        qdata[i] = quantize_val<T>(scales_data[c], zero_points_data[c], rdata[i]);
       }
     }
   }
@@ -396,8 +399,8 @@ Tensor quantize_tensor_per_channel_affine(Tensor rtensor,
 template <typename T>
 Tensor dequantize_tensor_per_channel_affine(Tensor qtensor,
                                             Tensor rtensor,
-                                            const std::vector<double>& scales,
-                                            const std::vector<int64_t>& zero_points,
+                                            Tensor scales,
+                                            Tensor zero_points,
                                             int64_t axis) {
   auto fn_name = "dequantize_tensor_per_channel_affine";
   checkFloatCPUTensor(fn_name, rtensor);
@@ -408,9 +411,11 @@ Tensor dequantize_tensor_per_channel_affine(Tensor qtensor,
   int64_t batches = size_to_dim_(axis, rtensor.sizes());
   int64_t elements_per_channel = size_from_dim_(axis + 1, rtensor.sizes());
   int64_t channel = rtensor.size(axis);
-  TORCH_CHECK(channel == int64_t(scales.size()),
+  auto scales_data = scales.data_ptr<double>();
+  auto zero_points_data = zero_points.data_ptr<int64_t>();
+  TORCH_CHECK(channel == int64_t(scales.numel()),
               "length of scales must equal to channel");
-  TORCH_CHECK(channel == int64_t(zero_points.size()),
+  TORCH_CHECK(channel == int64_t(zero_points.numel()),
               "length of zero_points must equal to channel");
   const auto* qd = qtensor.data_ptr<T>();
   float* rd = rtensor.data_ptr<float>();
@@ -420,7 +425,7 @@ Tensor dequantize_tensor_per_channel_affine(Tensor qtensor,
         auto i = b * channel * elements_per_channel + c * elements_per_channel + e;
         // We need to convert the qint8 value to float to ensure the subtraction
         // subexpression returns a float
-        rd[i] = (static_cast<float>(qd[i].val_) - zero_points[c]) * scales[c];
+        rd[i] = (static_cast<float>(qd[i].val_) - zero_points_data[c]) * scales_data[c];
       }
     }
   }
@@ -433,15 +438,6 @@ QuantizerPtr make_per_tensor_affine_quantizer(
     ScalarType scalar_type) {
   return c10::make_intrusive<PerTensorAffineQuantizer>(scalar_type,
       scale, zero_point);
-}
-
-QuantizerPtr make_per_channel_affine_quantizer(
-    const std::vector<double>& scales,
-    const std::vector<int64_t>& zero_points,
-    int64_t axis,
-    ScalarType scalar_type) {
-  return c10::make_intrusive<PerChannelAffineQuantizer>(scalar_type,
-                                                        scales, zero_points, axis);
 }
 
 QuantizerPtr make_per_channel_affine_quantizer(
@@ -463,13 +459,9 @@ QuantizerPtr make_per_channel_affine_quantizer(
       "zero_points tensor must have integral type");
   Tensor scales_double = scales.to(kDouble).contiguous();
   Tensor zero_points_int64 = zero_points.to(kLong).contiguous();
-  double* scales_data = scales_double.data_ptr<double>();
-  int64_t* zero_points_data = zero_points_int64.data_ptr<int64_t>();
-  std::vector<double> scale_vals(scales_data, scales_data + scales.numel());
-  std::vector<int64_t> zero_point_vals(
-      zero_points_data, zero_points_data + zero_points.numel());
-  return make_per_channel_affine_quantizer(
-      scale_vals, zero_point_vals, axis, scalar_type);
+  return c10::make_intrusive<PerChannelAffineQuantizer>(scalar_type,
+                                                        scales_double, zero_points_int64,
+                                                        axis);
 }
 
 QTensorImpl* get_qtensorimpl(const Tensor& self) {

--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -161,8 +161,6 @@ def _rebuild_qtensor(storage, storage_offset, size, stride, quantizer_params, re
         tensor = torch._empty_affine_quantized(size, scale=scale, zero_point=zero_point, dtype=storage.dtype)
     elif qscheme == torch.per_channel_affine:
         _, scales, zero_points, axis = quantizer_params
-        scales = torch.tensor(scales, dtype=torch.float64)
-        zero_points = torch.tensor(zero_points, dtype=torch.int64)
         tensor = torch._empty_per_channel_affine_quantized(
             size, scales=scales, zero_points=zero_points, axis=axis, dtype=storage.dtype)
     else:

--- a/torch/csrc/jit/pickler.cpp
+++ b/torch/csrc/jit/pickler.cpp
@@ -351,8 +351,8 @@ void Pickler::pushLiteralTensor(const IValue& ivalue) {
       case at::kPerChannelAffine: {
         const auto* quantizer = static_cast<at::PerChannelAffineQuantizer*>(
             tensor.quantizer().get());
-        pushIValue(c10::List<double>(quantizer->scales()));
-        pushIValue(c10::List<int64_t>(quantizer->zero_points()));
+        pushTensor(quantizer->scales());
+        pushTensor(quantizer->zero_points());
         pushInt(quantizer->axis());
       } break;
       default:

--- a/torch/csrc/jit/unpickler.cpp
+++ b/torch/csrc/jit/unpickler.cpp
@@ -571,13 +571,13 @@ void Unpickler::rebuildTensor(bool quantized) {
               {0}, storage_tensor.options(), q_scale, q_zero_point);
         } break;
         case at::kPerChannelAffine: {
-          std::vector<double> scales = convertList<double>(qparams.at(1));
-          std::vector<int64_t> zero_points = convertList<int64_t>(qparams.at(2));
+          const auto& scales = qparams.at(1).toTensor();
+          const auto& zero_points = qparams.at(2).toTensor();
           int64_t axis = qparams.at(3).toInt();
           result = _empty_per_channel_affine_quantized(
               {0},
-              at::tensor(scales),
-              at::tensor(zero_points),
+              scales,
+              zero_points,
               axis,
               storage_tensor.options());
         } break;

--- a/torch/tensor.py
+++ b/torch/tensor.py
@@ -105,8 +105,8 @@ class Tensor(torch._C._TensorBase):
                 # when/if we get multi-axis quantized tensors in the future, the shape
                 # is recoverable from the main tensor shape
                 quantizer_params = (torch.per_channel_affine,
-                                    [e.item() for e in self.q_per_channel_scales().reshape(-1)],
-                                    [e.item() for e in self.q_per_channel_zero_points().reshape(-1)],
+                                    self.q_per_channel_scales(),
+                                    self.q_per_channel_zero_points(),
                                     self.q_per_channel_axis())
             else:
                 raise RuntimeError("Serialization is not supported for tensors of type {}".format(self.qscheme()))


### PR DESCRIPTION
The quantizer use std::vector to save per_channel scales and zero_points, but when query scales(zero_points), it requires to return tensor. These lead to use std::vector to initialize tensors and it dose cost lots of time. So I change quantizer to save per_channel scales and zero_points by using tensor directly.