### PR TITLE
Remove BUILD_NAMEDTENSOR from codegen and .cu files

### DIFF
--- a/aten/src/ATen/native/cuda/Distributions.cu
+++ b/aten/src/ATen/native/cuda/Distributions.cu
@@ -393,9 +393,7 @@ Tensor _dirichlet_grad_cuda(const Tensor& x, const Tensor& alpha, const Tensor& 
 }
 
 Tensor& bernoulli_tensor_cuda_(Tensor &self, const Tensor& p_, Generator* gen_) {
-#ifdef BUILD_NAMEDTENSOR
   NoNamesGuard guard;
-#endif
   auto gen = get_generator_or_default<CUDAGenerator>(gen_, cuda::detail::getDefaultCUDAGenerator());
   std::pair<uint64_t, uint64_t> rng_engine_inputs;
   {

--- a/aten/src/ATen/native/cuda/Resize.cu
+++ b/aten/src/ATen/native/cuda/Resize.cu
@@ -12,11 +12,9 @@ Tensor& resize_cuda_(
     Tensor& self,
     IntArrayRef size,
     c10::optional<MemoryFormat> optional_memory_format) {
-#ifdef BUILD_NAMEDTENSOR
   if (self.has_names()) {
     return resize_named_tensor_(self, size, optional_memory_format);
   }
-#endif
   auto* self_ = self.unsafeGetTensorImpl();
   resize_impl_cuda_(self_, size, /*strides=*/c10::nullopt);
   self_->maybe_zero_dim(size.size() == 0);

--- a/aten/src/ATen/native/cuda/SortingKthValue.cu
+++ b/aten/src/ATen/native/cuda/SortingKthValue.cu
@@ -247,22 +247,16 @@ std::tuple<Tensor&, Tensor&> kthvalue_out_cuda(
     int64_t dim,
     bool keepdim) {
   auto result = [&]() {
-#ifdef BUILD_NAMEDTENSOR
     NoNamesGuard guard;
-#endif
     return kthvalue_out_impl_cuda(values, indices, self, k, dim, keepdim);
   }();
-#ifdef BUILD_NAMEDTENSOR
   namedinference::propagate_names_for_reduction(values, self, dim, keepdim);
   namedinference::propagate_names_for_reduction(indices, self, dim, keepdim);
-#endif
   return result;
 }
 
 Tensor median_cuda(const Tensor& self) {
-#ifdef BUILD_NAMEDTENSOR
   NoNamesGuard guard;
-#endif
   return AT_DISPATCH_ALL_TYPES_AND(at::ScalarType::Half, self.scalar_type(), "median", [&] {
     return median_cuda_template<scalar_t>(self);
   });

--- a/aten/src/THC/generic/THCTensorIndex.cu
+++ b/aten/src/THC/generic/THCTensorIndex.cu
@@ -285,9 +285,7 @@ void THCTensor_(put)(THCState *state, THCTensor *dst, THCudaLongTensor *index, T
 
 void THCTensor_(indexFill)(THCState *state, THCTensor *dst, int dim, THCudaLongTensor *indices, scalar_t val)
 {
-#ifdef BUILD_NAMEDTENSOR
   at::NoNamesGuard guard;
-#endif
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 1, dst));
   THCAssertSameGPU(THCudaLongTensor_checkGPU(state, 1, indices));
   int dims = THCTensor_(nDimensionLegacyNoScalars)(state, dst);

--- a/aten/src/THC/generic/THCTensorMasked.cu
+++ b/aten/src/THC/generic/THCTensorMasked.cu
@@ -191,9 +191,7 @@ void THCTensor_(maskedCopyByte)(THCState* state,
 
 void THCTensor_(maskedSelect)(THCState* state,
                               THCTensor* tensor, THCTensor* src, THCudaByteTensor* mask) {
-#ifdef BUILD_NAMEDTENSOR
   at::NoNamesGuard guard;
-#endif
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 3, tensor, src, mask));
   THArgCheck(THCudaByteTensor_nElement(state, mask) ==
              THCTensor_(nElement)(state, src),
@@ -255,9 +253,7 @@ void THCTensor_(maskedSelect)(THCState* state,
 
 void THCTensor_(maskedSelectBool)(THCState* state,
                                    THCTensor* tensor, THCTensor* src, THCudaBoolTensor* mask) {
-#ifdef BUILD_NAMEDTENSOR
   at::NoNamesGuard guard;
-#endif
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 3, tensor, src, mask));
   THArgCheck(THCudaBoolTensor_nElement(state, mask) ==
              THCTensor_(nElement)(state, src),

--- a/aten/src/THC/generic/THCTensorMathBlas.cu
+++ b/aten/src/THC/generic/THCTensorMathBlas.cu
@@ -11,9 +11,7 @@
 
 accreal THCTensor_(dot)(THCState *state, THCTensor *self, THCTensor *src)
 {
-#ifdef BUILD_NAMEDTENSOR
   at::NoNamesGuard guard;
-#endif
   if ( (THTensor_nDimension(self) != 1) || (THTensor_nDimension(src) != 1) ) {
     THError("1D tensors expected, got %dD, %dD tensors",
        THTensor_nDimension(self), THTensor_nDimension(src));
@@ -163,14 +161,10 @@ static void THCTensor_(addmvImpl)(THCState *state, THCTensor *r_, THCTensor *t, 
 
 void THCTensor_(addmv)(THCState *state, THCTensor *r_, THCTensor *t, THCTensor *mat, THCTensor *vec, scalar_t beta, scalar_t alpha) {
   {
-#ifdef BUILD_NAMEDTENSOR
     at::NoNamesGuard guard;
-#endif
     THCTensor_(addmvImpl)(state, r_, t, mat, vec, beta, alpha);
   }
-#ifdef BUILD_NAMEDTENSOR
   at::namedinference::propagate_names_for_addmv(r_, mat, vec, t);
-#endif
 }
 
 void THCTensor_(addr)(THCState *state, THCTensor *r_, THCTensor *t, THCTensor *vec1, THCTensor *vec2, scalar_t beta, scalar_t alpha)
@@ -459,14 +453,10 @@ static void THCTensor_(addmmImpl)(THCState *state, THCTensor *r_, THCTensor *t, 
 
 void THCTensor_(addmm)(THCState *state, THCTensor *r_, THCTensor *t, THCTensor *m1, THCTensor *m2, scalar_t beta, scalar_t alpha) {
   {
-#ifdef BUILD_NAMEDTENSOR
     at::NoNamesGuard guard;
-#endif
     THCTensor_(addmmImpl)(state, r_, t, m1, m2, beta, alpha);
   }
-#ifdef BUILD_NAMEDTENSOR
   at::namedinference::propagate_names_for_addmm(r_, m1, m2, t);
-#endif
 }
 
 void THCTensor_(addbmm)(THCState *state, THCTensor *result, THCTensor *t,
@@ -545,11 +535,9 @@ void THCTensor_(baddbmm)(THCState *state, THCTensor *result, THCTensor *t,
              "equal number of batches expected");
   THArgCheck(THCTensor_(size)(state, t, 0) == THCTensor_(size)(state, batch2, 0), 7,
              "equal number of batches expected");
-#ifdef BUILD_NAMEDTENSOR
   auto maybe_outnames = at::namedinference::compute_baddbmm_outnames(result, batch1, batch2, t);
   {
     at::NoNamesGuard guard;
-#endif
   THArgCheck(THCTensor_(size)(state, t, 1) == THCTensor_(size)(state, batch1, 1), 6,
              "wrong matrix size");
   THArgCheck(THCTensor_(size)(state, t, 2) == THCTensor_(size)(state, batch2, 2), 7,
@@ -822,10 +810,8 @@ void THCTensor_(baddbmm)(THCState *state, THCTensor *result, THCTensor *t,
   if (result_ != result) {
     THCTensor_(freeCopyTo)(state, result_, result);
   }
-#ifdef BUILD_NAMEDTENSOR
   }
   at::namedinference::propagate_names_if_nonempty(result, maybe_outnames);
-#endif
 
 #else
   ERROR_ONLY_FP_TYPES("baddbmm");

--- a/aten/src/THC/generic/THCTensorMathPairwise.cu
+++ b/aten/src/THC/generic/THCTensorMathPairwise.cu
@@ -32,12 +32,10 @@ static int THCTensor_(equalImpl)(THCState *state, THCTensor *self_, THCTensor *s
 }
 
 int THCTensor_(equal)(THCState *state, THCTensor *self_, THCTensor *src_) {
-#ifdef BUILD_NAMEDTENSOR
   if (!at::namedinference::are_names_equal(self_, src_)) {
     return 0;
   }
   at::NoNamesGuard guard;
-#endif
   return THCTensor_(equalImpl)(state, self_, src_);
 }
 

--- a/aten/src/THC/generic/THCTensorMathPointwise.cu
+++ b/aten/src/THC/generic/THCTensorMathPointwise.cu
@@ -131,9 +131,7 @@ void THCTensor_(cminValue)(THCState *state, THCTensor *self, THCTensor *src, sca
 #if !defined(THC_REAL_IS_BOOL)
 
 static void propagate_names_if_named_tensor_enabled(THCTensor* result, THCTensor* src) {
-#ifdef BUILD_NAMEDTENSOR
   at::namedinference::propagate_names(result, src);
-#endif
 }
 
 #define IMPLEMENT_CUDA_TENSOR_BASIC_FUNC_(NAME, CFUNC, REAL)             \

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -21,8 +21,6 @@ from setuptools.command.build_ext import build_ext
 
 IS_WINDOWS = sys.platform == 'win32'
 
-BUILD_NAMEDTENSOR = os.getenv('BUILD_NAMEDTENSOR', '').upper() == '1'
-
 def _find_cuda_home():
     '''Finds the CUDA install path.'''
     # Guess #1
@@ -257,8 +255,6 @@ class BuildExtension(build_ext, object):
         self._check_abi()
         for extension in self.extensions:
             self._add_compile_flag(extension, '-DTORCH_API_INCLUDE_EXTENSION_H')
-            if BUILD_NAMEDTENSOR:
-                self._add_compile_flag(extension, '-DBUILD_NAMEDTENSOR')
             self._define_torch_extension_name(extension)
             self._add_gnu_cpp_abi_flag(extension)
 
@@ -1139,8 +1135,6 @@ def _write_ninja_file(path,
 
     common_cflags = ['-DTORCH_EXTENSION_NAME={}'.format(name)]
     common_cflags.append('-DTORCH_API_INCLUDE_EXTENSION_H')
-    if BUILD_NAMEDTENSOR:
-        common_cflags.append('-DBUILD_NAMEDTENSOR')
     common_cflags += ['-I{}'.format(include) for include in user_includes]
     common_cflags += ['-isystem {}'.format(include) for include in system_includes]
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #31117 Remove unnecessary ATen/core/EnableNamedTensor.h
* #31116 Remove all remaining usages of BUILD_NAMEDTENSOR
* **#31047 Remove BUILD_NAMEDTENSOR from codegen and .cu files**

Changelist:
- remove BUILD_NAMEDTENSOR from .cu files
- remove BUILD_NAMEDTENSOR special handling in function_wrapper.py,
gen.py
- remove BUILD_NAMEDTENSOR from cpp_extension.py. This code actually
did nothing because we always compile with BUILD_NAMEDTENSOR.

Future work:
- Remove torch._C.BUILD_NAMEDTENSOR. This is used in some python
functions.
- Remove aten/src/ATen/env.py, which defines BUILD_NAMEDTENSOR=True for
codegen. There should be no use cases of this left after this PR, but it
is future work to check that.
- Remove `aten/src/ATen/core/EnableNamedTensor.h`, which defines
the BUILD_NAMEDTENSOR C++ macro. There should be no uses of this left
after this PR, but it is future work to check that

Test Plan:
- run tests

Differential Revision: [D18908442](https://our.internmc.facebook.com/intern/diff/D18908442)