### PR TITLE
Updated codegen to remove TensorOptions from generated code

### DIFF
--- a/aten/src/ATen/ScalarOps.h
+++ b/aten/src/ATen/ScalarOps.h
@@ -13,14 +13,14 @@ inline at::Tensor scalar_to_tensor(Scalar s, const Device device = at::kCPU) {
   // This is the fast track we have for CPU scalar tensors.
   if (device == at::kCPU) {
     if (s.isFloatingPoint()) {
-      return at::native::scalar_tensor(s, at::device(at::kCPU).dtype(at::kDouble));
+      return at::native::scalar_tensor(s, at::kDouble, c10::nullopt, at::kCPU);
     } else if (s.isBoolean()) {
-      return at::native::scalar_tensor(s, at::device(at::kCPU).dtype(at::kBool));
+      return at::native::scalar_tensor(s, at::kBool, c10::nullopt, at::kCPU);
     } else if (s.isComplex()) {
-      return at::native::scalar_tensor(s, at::device(at::kCPU).dtype(at::kComplexDouble));
+      return at::native::scalar_tensor(s, at::kComplexDouble, c10::nullopt, at::kCPU);
     } else {
       AT_ASSERT(s.isIntegral(false));
-      return at::native::scalar_tensor(s, at::device(at::kCPU).dtype(at::kLong));
+      return at::native::scalar_tensor(s,  at::kLong, c10::nullopt, at::kCPU);
     }
   }
   if (s.isFloatingPoint()) {

--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -3,6 +3,7 @@
 
 import re
 from code_template import CodeTemplate
+from tensor_options_utils import *
 
 try:
     import typing  # noqa: F401
@@ -92,6 +93,10 @@ NATIVE_DISPATCH_DECLARATION = CodeTemplate("""\
 ${return_type} ${api_name}(${type_method_formals});
 """)
 
+NATIVE_DISPATCH_DECLARATION_CONST = CodeTemplate("""\
+${return_type} ${api_name}(${type_method_formals}) const;
+""")
+
 NATIVE_DISPATCH_DEFINITION_DEFAULT = CodeTemplate("""\
 ${return_type} ${api_name}(${type_method_formals}) {
 #ifdef BUILD_NAMEDTENSOR
@@ -146,7 +151,11 @@ BACKEND_FUNCTION_REGISTRATION = CodeTemplate("""\
 TENSOR_METHOD_DECLARATION = CodeTemplate("""\
 ${return_type} ${api_name}(${method_formals_with_defaults}) const;
 """)
+TENSOR_METHOD_DECLARATION_UNDERSCORE = CodeTemplate("""\
+${return_type} _${api_name}(${method_formals_with_defaults}) const;
+""")
 # add non-virtual declaration to Tensor.cpp
+
 C10_TENSOR_METHOD_DEFINITION = CodeTemplate("""\
 inline ${return_type} Tensor::${api_name}(${method_formals}) const {
 #ifdef USE_STATIC_DISPATCH
@@ -157,14 +166,36 @@ inline ${return_type} Tensor::${api_name}(${method_formals}) const {
 #endif
 }
 """)
+
+C10_TENSOR_METHOD_DEFINITION_UNDERSCORE = CodeTemplate("""\
+inline ${return_type} Tensor::_${api_name}(${method_formals}) const {
+#ifdef USE_STATIC_DISPATCH
+    ${static_dispatch_method_body}
+#else
+    static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::${operator_name}", "${overload_name}"}).value();
+    return op.callUnboxed<${formals_types_with_return}>(${method_actuals});
+#endif
+}
+""")
+
 # add a method declaration in Functions.h
 FUNCTION_DECLARATION = CodeTemplate("""\
 static inline ${return_type} ${api_name}(${formals_with_defaults});
+""")
+FUNCTION_DECLARATION_UNDERSCORE = CodeTemplate("""\
+static inline ${return_type} _${api_name}(${formals_with_defaults});
+""")
+COLLAPSED_FUNCTION_DECLARATION = CodeTemplate("""\
+static inline ${return_type} ${api_name}(${collapsed_formals_with_defaults});
 """)
 # add a method declaration in Functions.h
 DEPRECATED_FUNCTION_DECLARATION = CodeTemplate("""\
 C10_DEPRECATED static inline ${return_type} ${api_name}(${formals_with_defaults});
 """)
+DEPRECATED_COLLAPSED_FUNCTION_DECLARATION = CodeTemplate("""\
+C10_DEPRECATED static inline ${return_type} ${api_name}(${collapsed_formals_with_defaults});
+""")
+
 # add method definition in Functions.h
 C10_FUNCTION_DEFINITION = CodeTemplate("""\
 static inline ${return_type} ${api_name}(${formals}) {
@@ -209,8 +240,8 @@ CAFFE2_API ${return_type} ${native_type_method_dispatch}(${formals_with_defaults
 """)
 
 # special method definition for factory functions in Functions.h that initializes backends
-C10_FACTORY_DEFINITION = CodeTemplate("""\
-static inline ${return_type} ${api_name}(${formals}) {
+C10_FACTORY_DEFINITION_UNDERSCORE = CodeTemplate("""\
+static inline ${return_type} _${api_name}(${formals}) {
 #ifdef USE_STATIC_DISPATCH
     ${static_dispatch_function_body}
 #else
@@ -222,14 +253,75 @@ static inline ${return_type} ${api_name}(${formals}) {
 }
 """)
 
+COLLAPSED_FACTORY_DEFINITION = CodeTemplate("""\
+inline ${return_type} ${api_name}(${collapsed_formals}) { 
+    return _${api_name}(${expanded_native_actuals});
+}
+""")
+
+COLLAPSED_METHOD_DEFINITION = CodeTemplate("""\
+inline ${return_type} Tensor::${api_name}(${collapsed_formals}) const { 
+    c10::optional<ScalarType> dtype = c10::nullopt;
+    c10::optional<Layout> layout = c10::nullopt;
+    c10::optional<Device> device = c10::nullopt;
+    c10::optional<bool> pin_memory = c10::nullopt;
+
+    if (options.dtype_opt().has_value()) {
+        dtype = typeMetaToScalarType(options.dtype());
+    }
+
+    if (options.layout_opt().has_value()) {
+        layout = options.layout();
+    }
+    
+    if (options.device_opt().has_value()) {
+        device = options.device();
+    }
+
+    if (options.pinned_memory_opt().has_value()) {
+        pin_memory = options.pinned_memory();
+    }
+
+    return _${api_name}(${expanded_native_actuals});
+}
+""")
+
+# This is a special case for '.to' operator. It should be cleaned up
+# issue #30405
+COLLAPSED_METHOD_TO_DEFINITION = CodeTemplate("""\
+inline ${return_type} Tensor::${api_name}(${collapsed_formals}) const { 
+    TORCH_CHECK(options.requires_grad_opt() == c10::nullopt,
+         "to(options) expects unset requires_grad flag, but got "
+         "options.requires_grad set as ", options.requires_grad());
+
+    c10::optional<ScalarType> dtype = c10::nullopt;
+    c10::optional<Layout> layout = c10::nullopt;
+    c10::optional<Device> device = c10::nullopt;
+    c10::optional<bool> pin_memory = c10::nullopt;
+
+    if (options.dtype_opt().has_value()) {
+        dtype = typeMetaToScalarType(options.dtype());
+    }
+
+    if (options.layout_opt().has_value()) {
+        layout = options.layout();
+    }
+    
+    if (options.device_opt().has_value()) {
+        device = options.device();
+    }
+
+    if (options.pinned_memory_opt().has_value()) {
+        pin_memory = options.pinned_memory();
+    }
+
+    return _${api_name}(${expanded_native_actuals});
+}
+""")
+
 ZERO_DIM_CHECK = CodeTemplate("""\
 if (${check_name}.dim() == 0) {
     return ${api_name}(${zero_dim_actuals});
-}""")
-
-SPARSE_CHECK = CodeTemplate("""\
-if(${check_name}.is_sparse()) {
-    return static_cast<const TypeExtendedInterface*>(this)->${api_name}(${sparse_actuals});
 }""")
 
 CONDITIONAL_INITIALIZER = CodeTemplate("""\
@@ -561,7 +653,9 @@ FunctionOption = TypedDict('FunctionOption', {
     'field_name': str,
     'formals_list': List[AtFormal],
     'formals_with_defaults': List[str],
+    'collapsed_formals_with_defaults': List[str],
     'formals': List[str],
+    'collapsed_formals': List[str],
     'formals_types': List[str],
     'formals_types_with_return': List[str],
     'inferred_type_set': str,
@@ -570,6 +664,7 @@ FunctionOption = TypedDict('FunctionOption', {
     # This controls whether or not we generate the interface in Type or
     # TypeExtendedInterface
     'extended_method': bool,
+    'collapsed_method_actuals': List[str],
     'method_actuals': List[str],
     'method_formals_with_defaults': List[str],
     'method_formals': List[str],
@@ -581,6 +676,7 @@ FunctionOption = TypedDict('FunctionOption', {
     'operator_name': str,
     'overload_name': str,
     'native_actuals': List[str],
+    'collapsed_native_actuals': List[str],
     'native_type_method_dispatch': str,
     # options should be List[FunctionOption]
     'options': Any,
@@ -599,7 +695,6 @@ FunctionOption = TypedDict('FunctionOption', {
     'variants': str,
     'when_spares_dispatch': str,
     'when_sparse_dispatch': str,
-    'with_gil': bool,
     'zero_dim_dispatch_when_scalar': str,
 })
 
@@ -638,7 +733,10 @@ def device_guard(option, dispatch_options, dispatch_tensor):
     # For factory methods the `DeviceGuard` is already in the template.
     if option.get('device_guard', True):
         if dispatch_options:
-            return 'const DeviceGuard device_guard({}.device());'.format(dispatch_options['name'])
+            if any(arg['type'] == 'c10::optional<ScalarType>' for arg in option['arguments']):
+                return 'auto dev = device.has_value() ? device.value() : Device(kCPU);\nconst DeviceGuard device_guard(dev);'
+            else:    
+                return 'const DeviceGuard device_guard(device); '
         if dispatch_tensor:
             return 'const OptionalDeviceGuard device_guard(device_of({}));'.format(dispatch_tensor)
     return '// DeviceGuard omitted'
@@ -667,7 +765,7 @@ if ({named_conditions}) {{
 
 def dispatch_scalar_type(option, dispatch_options, dispatch_tensor):
     if dispatch_options:
-        return 'auto dispatch_scalar_type = typeMetaToScalarType({}.dtype());'.format(dispatch_options['name'])
+        return 'auto dispatch_scalar_type = typeMetaToScalarType(dtype.value());'
     if dispatch_tensor:
         return 'auto dispatch_scalar_type = infer_scalar_type({});'.format(dispatch_tensor)
     return '// dispatch_scalar_type omitted'
@@ -678,7 +776,6 @@ def is_real_argument_to_wrapper(argument):
     return not argument.get('output', False) and\
         argument['type'] != 'CONSTANT' and\
         argument['type'] != 'argument'
-
 
 def is_mutable_formal_argument(argument, option):
     # type: (THFormal, FunctionOption) -> bool
@@ -879,8 +976,11 @@ def create_generic(top_env, declarations):
         # and Tensor arguments, you MUST only ever register it generically.
         r = []
         for formal in formals:
-            if formal['dynamic_type'] in ['TensorOptions', 'TensorList'] or is_any_tensor_type(formal):
+            if formal['dynamic_type'] in ['TensorList'] or is_any_tensor_type(formal):
                 r.append(formal['name'])
+
+        if check_if_factory_method(formals):
+            r.append('dtype, device, layout, pin_memory')
         return r
 
     def format_formal(f):
@@ -956,10 +1056,8 @@ def create_generic(top_env, declarations):
         option['type_method_actuals'] = option['actuals']
 
         assert 'method' not in option['variants'], 'TH functions cannot be methods'
-        is_function = 'function' in option['variants']
         # NB: TH functions don't support multiple dispatch
         dispatch_tensor = find_dispatch_tensor(formals)
-        is_namespace_function = is_function and dispatch_tensor is not None
 
         broadcast_arg = get_broadcast_argument(option)
         # "s_" for "same size".
@@ -1087,6 +1185,11 @@ def create_generic(top_env, declarations):
         option['formals_list'] = formals
         option['formals'] = [format_formal(f) for f in formals]
         option['formals_with_defaults'] = [formal_with_default(f) for f in formals]
+
+        collapsed_formals = collapse_formals_list(formals)
+        option['collapsed_formals'] = [format_formal(f) for f in collapsed_formals]
+        option['collapsed_formals_with_defaults'] = [formal_with_default(f) for f in collapsed_formals]
+        
         option['returns'] = native_get_return_types(option)
         option['return_type'] = format_return_type(option['returns'])
         option['return_call'] = 'return ' if option['return_type'] != 'void' else ''
@@ -1107,6 +1210,8 @@ def create_generic(top_env, declarations):
         # be const_casted to be accepted as native function's non-const argument
         option['method_actuals'] = [
             f['name'] if f['name'] != 'self' else 'const_cast<Tensor&>(*this)' for f in formals]
+
+        option['collapsed_method_actuals'] = collapse_actuals(option['method_actuals'])
 
         def find_formal(formal_name, formals):
             for formal in formals:
@@ -1157,19 +1262,30 @@ def create_generic(top_env, declarations):
                 static_dispatch_method_body = STATIC_DISPATCH_FUNCTION_DEFAULT_BODY.substitute(
                     option, native_arguments=option['method_actuals'])
 
-            method_definition = C10_TENSOR_METHOD_DEFINITION
-            return FunctionCode(
+            if check_if_factory_method(option['arguments']):  
+                return FunctionCode(
+                declaration=TENSOR_METHOD_DECLARATION_UNDERSCORE.substitute(
+                    option, static_dispatch_method_body=static_dispatch_method_body),
+                definition=C10_TENSOR_METHOD_DEFINITION_UNDERSCORE.substitute( 
+                    option, static_dispatch_method_body=static_dispatch_method_body))
+            else:
+                return FunctionCode(
+
                 declaration=TENSOR_METHOD_DECLARATION.substitute(
                     option, static_dispatch_method_body=static_dispatch_method_body),
-                definition=method_definition.substitute(
+                definition=C10_TENSOR_METHOD_DEFINITION.substitute(
                     option, static_dispatch_method_body=static_dispatch_method_body))
 
         def gen_namespace_function(option, multidispatch_tensors):
             # type: (Any, List[str]) -> FunctionCode
+            
             option['inferred_type_set'] = (
                 'c10::detail::multi_dispatch_tensor_type_set({})'.format(', '.join(multidispatch_tensors)))
             declaration = DEPRECATED_FUNCTION_DECLARATION if option['deprecated'] else FUNCTION_DECLARATION
             fn_declaration = declaration.substitute(option)
+
+            if is_factory_method:
+                fn_declaration = FUNCTION_DECLARATION_UNDERSCORE.substitute(option)
 
             if isinstance(type_method_dispatch, dict):
                 static_dispatch_function_switches = []
@@ -1189,11 +1305,52 @@ def create_generic(top_env, declarations):
                     option, native_arguments=option['native_actuals'])
 
             if is_factory_method:
-                fn_definition = C10_FACTORY_DEFINITION.substitute(
+                fn_definition = C10_FACTORY_DEFINITION_UNDERSCORE.substitute(
                     option, static_dispatch_function_body=static_dispatch_function_body)
             else:
                 fn_definition = C10_FUNCTION_DEFINITION.substitute(
                     option, static_dispatch_function_body=static_dispatch_function_body)
+
+            return FunctionCode(definition=fn_definition, declaration=fn_declaration)
+
+        def gen_collapsed_function_declaration(option):
+            declaration = DEPRECATED_COLLAPSED_FUNCTION_DECLARATION if option['deprecated'] else COLLAPSED_FUNCTION_DECLARATION
+            fn_declaration = declaration.substitute(option)
+
+            expanded_native_actuals = option['collapsed_native_actuals'][:]
+            index = expanded_native_actuals.index('options')
+            expanded_native_actuals.remove('options')
+            expanded_native_actuals.insert(index, 'options.pinned_memory()')
+            expanded_native_actuals.insert(index, 'options.device()')
+            
+             # special case for 'sparse_coo_tensor' and '_sparse_coo_tensor_unsafe'
+             # issue #30405
+            if (option['name'] == 'sparse_coo_tensor' or option['name'] == '_sparse_coo_tensor_unsafe'):
+                expanded_native_actuals.insert(index, 'options.layout_opt()')
+            else:
+                expanded_native_actuals.insert(index, 'options.layout()')
+            expanded_native_actuals.insert(index, 'typeMetaToScalarType(options.dtype())')
+
+            fn_definition = COLLAPSED_FACTORY_DEFINITION.substitute(option, expanded_native_actuals=expanded_native_actuals)
+            return FunctionCode(definition=fn_definition, declaration=fn_declaration)
+
+        def gen_native_dispatch_declaration(option):
+            declaration = NATIVE_DISPATCH_DECLARATION_CONST
+            fn_declaration = declaration.substitute(option, type_method_formals= collapse_formals(option['method_formals_with_defaults']))
+
+            expanded_native_actuals = option['collapsed_method_actuals'][:]
+            expanded_native_actuals.remove('const_cast<Tensor&>(*this)')
+            index = expanded_native_actuals.index('options')
+            expanded_native_actuals.remove('options')
+            expanded_native_actuals.insert(index, 'pin_memory')
+            expanded_native_actuals.insert(index, 'device')
+            expanded_native_actuals.insert(index, 'layout')
+            expanded_native_actuals.insert(index, 'dtype')
+
+            if option['name'] == 'to':
+                fn_definition = COLLAPSED_METHOD_TO_DEFINITION.substitute(option, collapsed_formals = collapse_formals(option['method_formals']), expanded_native_actuals=expanded_native_actuals)
+            else:    
+                fn_definition = COLLAPSED_METHOD_DEFINITION.substitute(option, collapsed_formals = collapse_formals(option['method_formals']), expanded_native_actuals=expanded_native_actuals)
             return FunctionCode(definition=fn_definition, declaration=fn_declaration)
 
         # Emit #ifdef BUILD_NAMEDTENSOR macros for any code generated here
@@ -1218,20 +1375,17 @@ def create_generic(top_env, declarations):
                 option['name'], ", ".join(option['method_formals_with_defaults']))
 
         type_method_dispatch = option['type_method_definition_dispatch']
-
         multidispatch_tensors = find_multidispatch_tensors(formals)
-
         option['type_method_formals'] = [format_formal(f) for f in formals]
         option['type_method_actuals'] = [f['name'] for f in formals]
         option['native_actuals'] = [f['name'] for f in formals]
+        option['collapsed_native_actuals'] = [f['name'] for f in collapsed_formals]
 
         is_method = 'method' in option['variants']
         is_namespace_function = 'function' in option['variants']
         # For method-only entries, the first argument should be self
         if is_method and not is_namespace_function:
             assert formals[0]['name'] == 'self'
-        is_factory_method = find_formal('TensorOptions', formals) and 'method' not in option['variants']
-
         check_methods_do_not_start_with_underscore(option['name'], is_method)
 
         option['method_prefix_derived'] = ''
@@ -1239,7 +1393,7 @@ def create_generic(top_env, declarations):
         # first argument.  Scalar type test will be removed once TH is removed.
         # If you need more complex device guard behavior, you should disable
         # device guard and then manually add the guards you need.
-        dispatch_options = find_formal('TensorOptions', formals)
+        dispatch_options = check_tensor_options_in_formals(formals)
         guard_tensor = None if dispatch_options else find_dispatch_tensor(formals)
         option['device_guard_declaration'] = device_guard(option, dispatch_options, guard_tensor)
         option['named_guard_declaration'] = named_guard(option, find_tensors(formals),
@@ -1304,6 +1458,8 @@ def create_generic(top_env, declarations):
                 check_namedtensor_enabled(NATIVE_DECLARATION.substitute(option)))
 
         method_of = ['Type']
+        is_factory_method = check_if_factory_method(option['arguments'])
+
         if is_method:
             code = gen_tensor_method(option, multidispatch_tensors)
             if is_named_tensor_only:
@@ -1311,6 +1467,11 @@ def create_generic(top_env, declarations):
             top_env['tensor_method_declarations'].append(code.declaration)
             top_env['tensor_method_definitions'].append(code.definition)
             method_of.append('Tensor')
+            
+            if is_factory_method:
+                code = gen_native_dispatch_declaration(option)
+                top_env['tensor_method_declarations'].append(code.declaration)
+                top_env['tensor_method_definitions'].append(code.definition)
 
         if is_namespace_function:
             code = gen_namespace_function(option, multidispatch_tensors)
@@ -1319,6 +1480,17 @@ def create_generic(top_env, declarations):
             top_env['function_definitions'].append(code.definition)
             top_env['function_declarations'].append(code.declaration)
             method_of.append('namespace')
+
+            if is_factory_method:
+                # function_definitions and function_declarations are being used for constructing 
+                # Functions.h which is part of our C++ API. We have to preverse TensorOption here
+                collapsed_code = gen_collapsed_function_declaration(option)
+                
+                if is_named_tensor_only:
+                    collapsed_code = add_namedtensor_enabled_macro(collapsed_code)
+
+                top_env['function_definitions'].append(collapsed_code.definition)
+                top_env['function_declarations'].append(collapsed_code.declaration)
 
         if not BUILD_NAMEDTENSOR and is_named_tensor_only:
             return None
@@ -1367,7 +1539,6 @@ def create_generic(top_env, declarations):
         output_declarations.extend(output_options)
 
     return output_declarations
-
 
 def create_derived(backend_type_env, declarations):
     # type: (Environment, List[FunctionOption]) -> Tuple[List[str], List[str], List[str], List[str], List[str]]

--- a/aten/src/ATen/native/QuantizedLinear.cpp
+++ b/aten/src/ATen/native/QuantizedLinear.cpp
@@ -236,7 +236,9 @@ std::tuple<Tensor, Tensor, double, int64_t> fbgemm_linear_quantize_weight(
   q_params.precision = kPrecision;
 
   Tensor quantized = at::native::empty_like(
-      weight_contig, weight_contig.options().dtype(at::kChar), LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+      weight_contig, at::kChar, weight_contig.options().layout(), 
+      weight_contig.options().device(), weight_contig.options().pinned_memory(), 
+      LEGACY_CONTIGUOUS_MEMORY_FORMAT);
   // Tensor quantized = at::native::empty_cpu(
   //     weight_contig.sizes(), weight_contig.options().dtype(at::kChar));
   fbgemm::Quantize<int8_t>(

--- a/aten/src/ATen/native/SobolEngineOps.cpp
+++ b/aten/src/ATen/native/SobolEngineOps.cpp
@@ -150,7 +150,12 @@ Tensor& _sobol_engine_initialize_state_(Tensor& sobolstate, int64_t dimension) {
     }
   }
 
-  Tensor pow2s = at::pow(2, at::native::arange((MAXBIT - 1), -1, -1, sobolstate.options()));
+  Tensor pow2s = at::pow(2, at::native::arange(
+    (MAXBIT - 1), -1, -1, 
+    typeMetaToScalarType(sobolstate.options().dtype()), 
+                         sobolstate.options().layout(), 
+                         sobolstate.options().device(), 
+                         sobolstate.options().pinned_memory()));
   sobolstate.mul_(pow2s);
   return sobolstate;
 }

--- a/aten/src/ATen/native/SummaryOps.cpp
+++ b/aten/src/ATen/native/SummaryOps.cpp
@@ -36,7 +36,11 @@ Tensor _bincount_cpu_template(
 
   const input_t* self_p = self.data_ptr<input_t>();
   if (has_weights) {
-    output = native::zeros({nbins}, weights.options());
+    output = native::zeros({nbins},
+                            typeMetaToScalarType(weights.options().dtype()),
+                                                 weights.options().layout(),
+                                                 weights.options().device(),
+                                                 weights.options().pinned_memory());
     weights_t* output_p = output.data_ptr<weights_t>();
     const weights_t* weights_p = weights.data_ptr<weights_t>();
     for (int64_t i = 0; i < self.size(0); i++) {

--- a/aten/src/ATen/native/TensorConversions.cpp
+++ b/aten/src/ATen/native/TensorConversions.cpp
@@ -45,29 +45,23 @@ static inline Tensor to_impl(const Tensor& self, const TensorOptions& options, b
   return r;
 }
 
-Tensor to(const Tensor& self, const TensorOptions& options, bool non_blocking, bool copy, c10::optional<c10::MemoryFormat> optional_memory_format) {
-  TORCH_CHECK(options.requires_grad_opt() == c10::nullopt,
-           "to(options) expects unset requires_grad flag, but got "
-           "options.requires_grad set as ", options.requires_grad());
-
-  const auto & layout_opt = options.layout_opt();
-  TORCH_CHECK(!layout_opt || self.layout() == layout_opt.value(),
+Tensor to(const Tensor& self, c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory, bool non_blocking, bool copy, c10::optional<c10::MemoryFormat> optional_memory_format) {
+  TORCH_CHECK(!layout.has_value() || self.layout() == layout.value(),
            "to(options) doesn't support converting to a different layout, "
            "but got self.layout being ", self.layout(),
-           " and options.layout set as ", options.layout());
-
-  auto device_opt = options.device_opt();
-  if (device_opt) {
-    device_opt = ensure_has_index(device_opt.value());
+           " and options.layout set as ", layout.value());
+  
+  if (device.has_value()) {
+    device = ensure_has_index(device.value());
   }
-  const auto & dtype_opt = options.dtype_opt();
   auto specified_options = self.options();
-  if (device_opt) {
-    specified_options = specified_options.device(device_opt.value());
+  if (device.has_value()) {
+    specified_options = specified_options.device(device.value());
   }
-  if (dtype_opt) {
-    specified_options = specified_options.dtype(dtype_opt.value());
+  if (dtype.has_value()) {
+    specified_options = specified_options.dtype(dtype.value());
   }
+  
   return to_impl(self, specified_options, non_blocking, copy, optional_memory_format);
 }
 

--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -29,20 +29,22 @@
 namespace at {
 namespace native {
 namespace {
+
 void window_function_checks(
     const char* function_name,
-    const TensorOptions& options,
+    c10::optional<c10::ScalarType> dtype,
+    c10::optional<c10::Layout> layout,
     int64_t window_length) {
   TORCH_CHECK(
-      options.layout() != kSparse,
+      layout.has_value() && layout.value() != kSparse,
       function_name,
       " is not implemented for sparse types, got: ",
-      options);
+      layout.value());
   TORCH_CHECK(
-      at::isFloatingType(typeMetaToScalarType(options.dtype())) || at::isComplexType(typeMetaToScalarType(options.dtype())),
+      at::isFloatingType(dtype.value()) || at::isComplexType(dtype.value()),
       function_name,
       " expects floating point dtypes, got: ",
-      options);
+      dtype.value());
   TORCH_CHECK(
       window_length >= 0,
       function_name,
@@ -64,20 +66,24 @@ static inline bool allIntegral(std::initializer_list<std::reference_wrapper<Scal
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ arange ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Tensor arange(Scalar end, const TensorOptions& options) {
-  return native::arange(/*start=*/0, end, options);
+Tensor arange(Scalar end, c10::optional<c10::ScalarType> dtype, c10::optional<c10::Layout> layout, c10::optional<c10::Device> device, c10::optional<bool> pin_memory) {
+  return native::arange(/*start=*/0, end, dtype, layout, device, pin_memory);
 }
 
-Tensor arange(Scalar start, Scalar end, const TensorOptions& options) {
-  return native::arange(start, end, /*step=*/1, options);
+Tensor arange(Scalar start, Scalar end, c10::optional<c10::ScalarType> dtype, c10::optional<c10::Layout> layout, c10::optional<c10::Device> device, c10::optional<bool> pin_memory) {
+  return native::arange(start, end, /*step=*/1, dtype, layout, device, pin_memory);
 }
 
 Tensor arange(
     Scalar start,
     Scalar end,
     Scalar step,
-    const TensorOptions& options) {
-  bool set_to_integral_dtype = !options.has_dtype() && allIntegral({start, end, step});
+    c10::optional<c10::ScalarType> dtype, 
+    c10::optional<c10::Layout> layout, 
+    c10::optional<c10::Device> device, 
+    c10::optional<bool> pin_memory) {
+  TensorOptions options = TensorOptions().dtype(dtype).layout(layout).device(device).pinned_memory(pin_memory);
+  bool set_to_integral_dtype = !dtype.has_value() && allIntegral({start, end, step});
   Tensor result = set_to_integral_dtype
       ? at::empty({0}, options.dtype(at::ScalarType::Long))
       : at::empty({0}, options);
@@ -97,24 +103,24 @@ Tensor _dim_arange(const Tensor& like, int64_t dim) {
 }
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ empty ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Tensor empty_cpu(IntArrayRef size, const TensorOptions& options, c10::optional<c10::MemoryFormat> optional_memory_format) {
-  AT_ASSERT(options.device().type() == DeviceType::CPU);
+Tensor empty_cpu(IntArrayRef size, c10::optional<c10::ScalarType> dtype, c10::optional<c10::Layout> layout, c10::optional<c10::Device> device, c10::optional<bool> pin_memory, c10::optional<c10::MemoryFormat> optional_memory_format) {
+  AT_ASSERT(device.value().type() == DeviceType::CPU);
   TORCH_INTERNAL_ASSERT(impl::variable_excluded_from_dispatch());
   check_size_nonnegative(size);
 
   c10::Allocator* allocator;
-  if (options.pinned_memory()) {
+  if (pin_memory.has_value() && pin_memory.value()) {
     allocator = detail::getCUDAHooks().getPinnedMemoryAllocator();
   } else {
     allocator = at::getCPUAllocator();
   }
 
   int64_t nelements = prod_intlist(size);
-  auto dtype = options.dtype();
+  auto currDtype = dtype.has_value() ? scalarTypeToTypeMeta(dtype.value()) : at::get_default_dtype();
   auto storage_impl = c10::make_intrusive<StorageImpl>(
-    dtype,
+    currDtype,
     nelements,
-    allocator->allocate(nelements * dtype.itemsize()),
+    allocator->allocate(nelements * currDtype.itemsize()),
     allocator,
     /*resizeable=*/true);
 
@@ -133,24 +139,27 @@ Tensor empty_cpu(IntArrayRef size, const TensorOptions& options, c10::optional<c
 Tensor empty(
     IntArrayRef size,
     at::optional<DimnameList> names,
-    const TensorOptions& options,
+    c10::optional<c10::ScalarType> dtype, 
+    c10::optional<c10::Layout> layout, 
+    c10::optional<c10::Device> device, 
+    c10::optional<bool> pin_memory,
     optional<MemoryFormat> optional_memory_format) {
   if (!names.has_value()) {
-    return at::empty(size, options, optional_memory_format);
+    return at::_empty(size, dtype, layout, device, pin_memory, optional_memory_format);
   }
-  TORCH_CHECK(options.layout() == Layout::Strided,
+  TORCH_CHECK(layout.has_value() && layout.value() == Layout::Strided,
       "NYI: named tensors only support strided layout");
-  TORCH_CHECK(options.device().type() == DeviceType::CPU || options.device().type() == DeviceType::CUDA,
+  TORCH_CHECK((device.has_value() && device.value().type() == DeviceType::CPU) || device.value().type() == DeviceType::CUDA,
       "NYI: named tensors only support CPU and CUDA tensors");
-  auto result = at::empty(size, options, optional_memory_format);
+  auto result = at::_empty(size, dtype, layout, device, pin_memory, optional_memory_format);
   internal_set_names_inplace(result, names);
   return result;
 }
 #endif
 
-Tensor empty_strided_cpu(IntArrayRef size, IntArrayRef stride, const TensorOptions& options) {
+Tensor empty_strided_cpu(IntArrayRef size, IntArrayRef stride, c10::optional<c10::ScalarType> dtype, c10::optional<c10::Layout> layout, c10::optional<c10::Device> device, c10::optional<bool> pin_memory) {
   check_size_nonnegative(size);
-  auto t = at::native::empty_cpu({0}, options);
+  auto t = at::native::empty_cpu({0}, dtype, layout, device, pin_memory);
   at::native::resize_impl_cpu_(t.unsafeGetTensorImpl(), size, stride);
   return t;
 }
@@ -192,20 +201,22 @@ AT_FORALL_SCALAR_TYPES_AND3(Bool, Half, BFloat16, DEFINE_CAST_OP)
 Tensor empty_like(
     const Tensor& self,
     c10::optional<c10::MemoryFormat> optional_memory_format) {
-  return native::empty_like(self, self.options(), optional_memory_format);
+  return native::empty_like(self, typeMetaToScalarType(self.options().dtype()), self.options().layout(), self.options().device(), self.options().pinned_memory(), optional_memory_format);
 }
 
+// *_like functions should be consistent with the rest of ops and 
+// take optional dtype, layout, device and pin_memory
+// issue #30405 
 Tensor empty_like(
     const Tensor& self,
-    const TensorOptions& options,
+    ScalarType dtype, Layout layout, Device device, bool pin_memory,
     c10::optional<c10::MemoryFormat> optional_memory_format) {
-
   TORCH_CHECK(
-      !(options.layout() != kStrided &&
+      !(layout != kStrided &&
           optional_memory_format.has_value()),
       "memory format option is only supported by strided tensors");
-  if (options.layout() == kSparse && self.is_sparse()) {
-    auto result = at::empty({0}, options); // to be resized
+  if (layout == kSparse && self.is_sparse()) {
+    auto result = at::_empty({0}, dtype, layout, device, pin_memory); // to be resized
     result.sparse_resize_and_clear_(
         self.sizes(), self.sparse_dim(), self.dense_dim());
     return result;
@@ -226,24 +237,24 @@ Tensor empty_like(
 
     // We could check if dtype is still quantized?  But then should we shift/scale
     // the q_zero_point / q_scale or not?
-    TORCH_CHECK(!options.has_dtype() || options.dtype() == self.dtype(),
+    TORCH_CHECK(dtype != ScalarType::Undefined || dtype == self.dtype(),
                 "It is currently not supported to specify a dtype that doesn't match "
-                "the input tensor's dtype via empty_like.  Specified: ", options.dtype(),
+                "the input tensor's dtype via empty_like.  Specified: ", dtype,
                 " Input tensor's dtype: ", self.dtype());
     auto qscheme = self.qscheme();
     if (qscheme == kPerTensorAffine) {
-      return at::_empty_affine_quantized(self.sizes(), options,
+      return at::__empty_affine_quantized(self.sizes(), dtype, layout, device, pin_memory,
                                          self.q_scale(),
                                          self.q_zero_point(),
                                          memory_format);
     } else if (qscheme == kPerChannelAffine) {
       // Copy the tensors with channels to avoid accidental overrides
-      return at::_empty_per_channel_affine_quantized(
+      return at::__empty_per_channel_affine_quantized(
           self.sizes(),
           self.q_per_channel_scales().clone(at::MemoryFormat::Preserve),
           self.q_per_channel_zero_points().clone(at::MemoryFormat::Preserve),
           self.q_per_channel_axis(),
-          options,
+          dtype, layout, device, pin_memory,
           memory_format);
     } else {
       TORCH_CHECK(false, "Unsupported qscheme: ", toString(qscheme));
@@ -256,12 +267,12 @@ Tensor empty_like(
       optional_memory_format.value_or(MemoryFormat::Contiguous);
   if (memory_format == MemoryFormat::Preserve) {
     if (self.is_non_overlapping_and_dense()) {
-      result = at::empty_strided(self.sizes(), self.strides(), options);
+      result = at::_empty_strided(self.sizes(), self.strides(), dtype, layout, device, pin_memory);
     } else {
-      result = at::empty(self.sizes(), options, self.suggest_memory_format());
+      result = at::_empty(self.sizes(), dtype, layout, device, pin_memory, self.suggest_memory_format());
     }
   } else {
-    result = at::empty(self.sizes(), options, memory_format);
+    result = at::_empty(self.sizes(), dtype, layout, device, pin_memory, memory_format);
   }
 
 #ifdef BUILD_NAMEDTENSOR
@@ -276,19 +287,21 @@ Tensor empty_like(
 Tensor new_empty(
     const Tensor& self,
     IntArrayRef size,
-    const TensorOptions& options
+    c10::optional<c10::ScalarType> dtype, c10::optional<c10::Layout> layout, c10::optional<c10::Device> device, c10::optional<bool> pin_memory
     ) {
-  return at::empty(size, self.options().merge_in(options));
+  TensorOptions incomingTO = TensorOptions().dtype(dtype).layout(layout).device(device).pinned_memory(pin_memory);
+  TensorOptions mergedTO = self.options().merge_in(incomingTO);
+  return at::_empty(size, typeMetaToScalarType(mergedTO.dtype()), mergedTO.layout(), mergedTO.device(), mergedTO.pinned_memory());
 }
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ eye ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Tensor eye(int64_t n, const TensorOptions& options) {
-  return native::eye(n, -1, options);
+Tensor eye(int64_t n, c10::optional<c10::ScalarType> dtype, c10::optional<c10::Layout> layout, c10::optional<c10::Device> device, c10::optional<bool> pin_memory) {
+  return native::eye(n, -1, dtype, layout, device, pin_memory);
 }
 
-Tensor eye(int64_t n, int64_t m, const TensorOptions& options) {
-  auto tensor = at::empty({0}, options); // to be resized
+Tensor eye(int64_t n, int64_t m, c10::optional<c10::ScalarType> dtype, c10::optional<c10::Layout> layout, c10::optional<c10::Device> device, c10::optional<bool> pin_memory) {
+  auto tensor = at::_empty({0}, dtype, layout, device, pin_memory); // to be resized
   return at::eye_out(tensor, n, m);
 }
 
@@ -320,11 +333,11 @@ Tensor& eye_out_cpu(Tensor& result, int64_t n, int64_t m) {
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ full ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Tensor full(IntArrayRef size, Scalar fill_value, const TensorOptions& options) {
-  if (options.layout() == kSparse) {
+Tensor full(IntArrayRef size, Scalar fill_value, c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) {
+  if (layout.value() == kSparse) {
     AT_ERROR("full(...) is not implemented for sparse layout");
   }
-  auto result = at::empty(size, options);
+  auto result = at::_empty(size, dtype, layout, device, pin_memory);
   return result.fill_(fill_value);
 }
 
@@ -341,15 +354,18 @@ Tensor full_like(
     Scalar fill_value,
     c10::optional<c10::MemoryFormat> optional_memory_format) {
   return native::full_like(
-      self, fill_value, self.options(), optional_memory_format);
+      self, fill_value, typeMetaToScalarType(self.options().dtype()), self.options().layout(), self.options().device(), self.options().pinned_memory(), optional_memory_format);
 }
 
 Tensor full_like(
     const Tensor& self,
     Scalar fill_value,
-    const TensorOptions& options,
+    ScalarType dtype, 
+    Layout layout, 
+    Device device, 
+    bool pin_memory,
     c10::optional<c10::MemoryFormat> optional_memory_format) {
-  auto result = at::empty_like(self, options, optional_memory_format);
+  auto result = at::_empty_like(self, dtype, layout, device, pin_memory, optional_memory_format);
   return result.fill_(fill_value);
 }
 
@@ -357,8 +373,17 @@ Tensor new_full(
     const Tensor& self,
     IntArrayRef size,
     Scalar fill_value,
-    const TensorOptions& options
+    c10::optional<ScalarType> dtype, 
+    c10::optional<Layout> layout, 
+    c10::optional<Device> device, 
+    c10::optional<bool> pin_memory
     ) {
+  
+  const auto options = TensorOptions()
+        .dtype(dtype)
+        .layout(layout)
+        .device(device)
+        .pinned_memory(pin_memory);
   return at::full(size, fill_value, self.options().merge_in(options));
 }
 
@@ -369,9 +394,12 @@ Tensor linspace(
     Scalar start,
     Scalar end,
     int64_t steps,
-    const TensorOptions& options) {
+    c10::optional<ScalarType> dtype, 
+    c10::optional<Layout> layout, 
+    c10::optional<Device> device, 
+    c10::optional<bool> pin_memory) {
   TORCH_CHECK(steps >= 0, "number of steps must be non-negative");
-  Tensor result = at::empty({steps}, options);
+  Tensor result = at::_empty({steps}, dtype, layout, device, pin_memory);
   return at::linspace_out(result, start, end, steps);
 }
 
@@ -382,15 +410,18 @@ Tensor logspace(
     Scalar end,
     int64_t steps,
     double base,
-    const TensorOptions& options) {
-  Tensor result = at::empty({steps}, options);
+    c10::optional<ScalarType> dtype, 
+    c10::optional<Layout> layout, 
+    c10::optional<Device> device, 
+    c10::optional<bool> pin_memory) {
+  Tensor result = at::_empty({steps}, dtype, layout, device, pin_memory);
   return at::logspace_out(result, start, end, steps, base);
 }
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ones ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Tensor ones(IntArrayRef size, const TensorOptions& options) {
-  return native::full(size, /*fill_value=*/1, options);
+Tensor ones(IntArrayRef size, c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) {
+  return native::full(size, /*fill_value=*/1, dtype, layout, device, pin_memory);
 }
 
 Tensor& ones_out(Tensor& result, IntArrayRef size) {
@@ -399,9 +430,12 @@ Tensor& ones_out(Tensor& result, IntArrayRef size) {
 
 Tensor ones_like(
     const Tensor& self,
-    const TensorOptions& options,
+    ScalarType dtype, 
+    Layout layout, 
+    Device device, 
+    bool pin_memory,
     c10::optional<c10::MemoryFormat> optional_memory_format) {
-  auto result = at::empty_like(self, options, optional_memory_format);
+  auto result = at::_empty_like(self, dtype, layout, device, pin_memory, optional_memory_format);
   return result.fill_(1);
 }
 
@@ -409,13 +443,13 @@ Tensor ones_like(
     const Tensor& self,
     c10::optional<c10::MemoryFormat> optional_memory_format) {
   return native::ones_like(
-      self, self.options(), optional_memory_format);
+      self, typeMetaToScalarType(self.options().dtype()), self.options().layout(), self.options().device(), self.options().pinned_memory(), optional_memory_format);
 }
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ scalar_tensor ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Tensor scalar_tensor(Scalar s, const TensorOptions& options) {
-  if (options.device() == at::kCPU) {
+Tensor scalar_tensor(Scalar s, c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) {
+  if (device.has_value() && device.value() == at::kCPU) {
     // This is a fast track to skip device dispatch for making scalar tensor on CPU.
     // See https://github.com/pytorch/pytorch/pull/29915 for more detailed perf
     // difference.
@@ -423,21 +457,21 @@ Tensor scalar_tensor(Scalar s, const TensorOptions& options) {
     // revert this to following:
     //   auto result = at::empty({}, options);
     at::AutoNonVariableTypeMode non_var_type_mode(true);
-    auto result = empty_cpu({}, options);
+    auto result = empty_cpu({}, dtype, layout, device, pin_memory);
     at::native::fill_(result, s);
     return result;
   }
-  return at::empty({}, options).fill_(s);
+  return at::_empty({}, dtype, layout, device, pin_memory).fill_(s);
 }
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ rand ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Tensor rand(IntArrayRef size, const TensorOptions& options) {
-  return native::rand(size, nullptr, options);
+Tensor rand(IntArrayRef size, c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) {
+  return native::rand(size, nullptr, dtype, layout, device, pin_memory);
 }
 
-Tensor rand(IntArrayRef size, Generator* generator, const TensorOptions& options) {
-  auto result = at::empty(size, options);
+Tensor rand(IntArrayRef size, Generator* generator, c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) {
+  auto result = at::_empty(size, dtype, layout, device, pin_memory);
   return result.uniform_(0, 1, generator);
 }
 
@@ -453,37 +487,40 @@ Tensor& rand_out(Tensor& result, IntArrayRef size, Generator* generator) {
 Tensor rand_like(
     const Tensor& self,
     c10::optional<c10::MemoryFormat> optional_memory_format) {
-  return native::rand_like(self, self.options(), optional_memory_format);
+  return native::rand_like(self, typeMetaToScalarType(self.options().dtype()), self.options().layout(), self.options().device(), self.options().pinned_memory(), optional_memory_format);
 }
 
 Tensor rand_like(
     const Tensor& self,
-    const TensorOptions& options,
+    ScalarType dtype, 
+    Layout layout, 
+    Device device, 
+    bool pin_memory,
     c10::optional<c10::MemoryFormat> optional_memory_format) {
-  auto result = at::empty_like(self, options, optional_memory_format);
+  auto result = at::_empty_like(self, dtype, layout, device, pin_memory, optional_memory_format);
   return result.uniform_(0, 1, nullptr);
 }
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ randint ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Tensor randint(int64_t high, IntArrayRef size, const TensorOptions& options) {
-  return native::randint(high, size, nullptr, options);
+Tensor randint(int64_t high, IntArrayRef size, c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) {
+  return native::randint(high, size, nullptr, dtype, layout, device, pin_memory);
 }
 
 Tensor randint(
     int64_t high,
     IntArrayRef size,
     Generator* generator,
-    const TensorOptions& options) {
-  return native::randint(0, high, size, generator, options);
+    c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) {
+  return native::randint(0, high, size, generator, dtype, layout, device, pin_memory);
 }
 
 Tensor randint(
     int64_t low,
     int64_t high,
     IntArrayRef size,
-    const TensorOptions& options) {
-  return native::randint(low, high, size, nullptr, options);
+    c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) {
+  return native::randint(low, high, size, nullptr, dtype, layout, device, pin_memory);
 }
 
 Tensor randint(
@@ -491,8 +528,8 @@ Tensor randint(
     int64_t high,
     IntArrayRef size,
     Generator* generator,
-    const TensorOptions& options) {
-  auto result = at::empty(size, options);
+    c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) {
+  auto result = at::_empty(size, dtype, layout, device, pin_memory);
   return result.random_(low, high, generator);
 }
 
@@ -523,51 +560,47 @@ Tensor& randint_out(
   return result.random_(low, high, generator);
 }
 
+Tensor randint_like(const Tensor& self, int64_t high, c10::optional<c10::MemoryFormat> optional_memory_format) {
+  return native::randint_like(self, high, typeMetaToScalarType(self.options().dtype()), self.options().layout(), self.options().device(), self.options().pinned_memory(), optional_memory_format);
+}
+
+Tensor randint_like(const Tensor& self, int64_t low, int64_t high, c10::optional<c10::MemoryFormat> optional_memory_format) {
+  return native::randint_like(self, low, high, typeMetaToScalarType(self.options().dtype()), self.options().layout(), self.options().device(), self.options().pinned_memory(), optional_memory_format);
+}
+
 Tensor randint_like(
     const Tensor& self,
     int64_t high,
+    ScalarType dtype, 
+    Layout layout, 
+    Device device, 
+    bool pin_memory,
     c10::optional<c10::MemoryFormat> optional_memory_format) {
-  return native::randint_like(
-      self, high, self.options(), optional_memory_format);
+      auto result = at::_empty_like(self, dtype, layout, device, pin_memory, optional_memory_format);
+      return result.random_(0, high, nullptr);
 }
 
 Tensor randint_like(
     const Tensor& self,
     int64_t low,
     int64_t high,
+    ScalarType dtype, 
+    Layout layout, 
+    Device device, 
+    bool pin_memory,
     c10::optional<c10::MemoryFormat> optional_memory_format) {
-  return native::randint_like(
-      self, low, high, self.options(), optional_memory_format);
-}
-
-Tensor randint_like(
-    const Tensor& self,
-    int64_t high,
-    const TensorOptions& options,
-    c10::optional<c10::MemoryFormat> optional_memory_format) {
-  auto result = at::empty_like(self, options, optional_memory_format);
-  return result.random_(0, high, nullptr);
-  return native::randint(high, self.sizes(), nullptr, options);
-}
-
-Tensor randint_like(
-    const Tensor& self,
-    int64_t low,
-    int64_t high,
-    const TensorOptions& options,
-    c10::optional<c10::MemoryFormat> optional_memory_format) {
-  auto result = at::empty_like(self, options, optional_memory_format);
-  return result.random_(low, high, nullptr);
+      auto result = at::_empty_like(self, dtype, layout, device, pin_memory, optional_memory_format);
+      return result.random_(low, high, nullptr);
 }
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ randn ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Tensor randn(IntArrayRef size, const TensorOptions& options) {
-  return native::randn(size, nullptr, options);
+Tensor randn(IntArrayRef size, c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) {
+  return native::randn(size, nullptr, dtype, layout, device, pin_memory);
 }
 
-Tensor randn(IntArrayRef size, Generator* generator, const TensorOptions& options) {
-  auto result = at::empty(size, options);
+Tensor randn(IntArrayRef size, Generator* generator, c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) {
+  auto result = at::_empty(size, dtype, layout, device, pin_memory);
   return result.normal_(0, 1, generator);
 }
 
@@ -581,8 +614,8 @@ Tensor& randn_out(Tensor& result, IntArrayRef size, Generator* generator) {
 }
 
 Tensor normal(double mean, double std, IntArrayRef size,
-              Generator* generator, const TensorOptions& options) {
-  auto result = at::empty(size, options);
+              Generator* generator, c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) {
+  auto result = at::_empty(size, dtype, layout, device, pin_memory);
   return result.normal_(mean, std, generator);
 }
 
@@ -595,14 +628,17 @@ Tensor& normal_out(Tensor& result, double mean, double std,
 Tensor randn_like(
     const Tensor& self,
     c10::optional<c10::MemoryFormat> optional_memory_format) {
-  return native::randn_like(self, self.options(), optional_memory_format);
+  return native::randn_like(self, typeMetaToScalarType(self.options().dtype()), self.options().layout(), self.options().device(), self.options().pinned_memory(), optional_memory_format);
 }
 
 Tensor randn_like(
     const Tensor& self,
-    const TensorOptions& options,
+    ScalarType dtype, 
+    Layout layout, 
+    Device device, 
+    bool pin_memory,
     c10::optional<c10::MemoryFormat> optional_memory_format) {
-  auto result = at::empty_like(self, options, optional_memory_format);
+  auto result = at::_empty_like(self, dtype, layout, device, pin_memory, optional_memory_format);
   return result.normal_(0, 1, nullptr);
 }
 
@@ -632,12 +668,12 @@ void randperm_cpu(Tensor& result, int64_t n, CPUGenerator* generator) {
 }
 } // namespace
 
-Tensor randperm(int64_t n, const TensorOptions& options) {
-  return native::randperm(n, nullptr, options);
+Tensor randperm(int64_t n, c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) {
+  return native::randperm(n, nullptr, dtype, layout, device, pin_memory);
 }
 
-Tensor randperm(int64_t n, Generator* generator, const TensorOptions& options) {
-  auto tensor = at::empty(n, options);
+Tensor randperm(int64_t n, Generator* generator, c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) {
+  auto tensor = at::_empty(n, dtype, layout, device, pin_memory);
   return at::randperm_out(tensor, n, generator);
 }
 
@@ -665,28 +701,28 @@ Tensor range(
     Scalar start,
     Scalar end,
     Scalar step,
-    const TensorOptions& options) {
-  Tensor result = at::empty({0}, options);
+    c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) {
+  Tensor result = at::_empty({0}, dtype, layout, device, pin_memory);
   return at::range_out(result, start, end, step);
 }
 
 Tensor range(
     Scalar start,
     Scalar end,
-    const TensorOptions& options) {
-  return at::native::range(start, end, 1, options);
+    c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) {
+  return at::native::range(start, end, 1, dtype, layout, device, pin_memory);
 }
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ triangle ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Tensor tril_indices_cpu(
-    int64_t row, int64_t col, int64_t offset, const TensorOptions& options) {
-  check_args(row, col, options);
+    int64_t row, int64_t col, int64_t offset, c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) {
+  check_args(row, col, layout);
 
   auto tril_size = get_tril_size(row, col, offset);
 
   // create an empty Tensor with correct size
-  auto result = at::empty({2, tril_size}, options);
+  auto result = at::_empty({2, tril_size}, dtype, layout, device, pin_memory);
 
   // The following three approaches result in very little performance
   // differences. Hence, the 2nd option is taken for simpler code, and to return
@@ -725,13 +761,13 @@ Tensor tril_indices_cpu(
 }
 
 Tensor triu_indices_cpu(
-    int64_t row, int64_t col, int64_t offset, const TensorOptions& options) {
-  check_args(row, col, options);
+    int64_t row, int64_t col, int64_t offset, c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) {
+  check_args(row, col, layout);
 
   auto triu_size = row * col - get_tril_size(row, col, offset - 1);
 
   // create an empty Tensor with correct size
-  auto result = at::empty({2, triu_size}, options);
+  auto result = at::_empty({2, triu_size}, dtype, layout, device, pin_memory);
 
   AT_DISPATCH_ALL_TYPES(result.scalar_type(), "triu_indices", [&]() -> void {
     // fill the Tensor with correct values
@@ -762,7 +798,12 @@ Tensor triu_indices_cpu(
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ zeros ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Tensor zeros(IntArrayRef size, const TensorOptions& options) {
+Tensor zeros(IntArrayRef size, c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) {
+  const auto options = TensorOptions()
+        .dtype(dtype)
+        .layout(layout)
+        .device(device)
+        .pinned_memory(pin_memory);
   auto result = at::empty(size, options);
   return result.zero_();
 }
@@ -780,52 +821,64 @@ Tensor& zeros_out(Tensor& result, IntArrayRef size) {
 Tensor zeros_like(
     const Tensor& self,
     c10::optional<c10::MemoryFormat> optional_memory_format) {
-  return native::zeros_like(self, self.options(), optional_memory_format);
+  return native::zeros_like(self, typeMetaToScalarType(self.options().dtype()), self.options().layout(), self.options().device(), self.options().pinned_memory(), optional_memory_format);
 }
 
 Tensor zeros_like(
     const Tensor& self,
-    const TensorOptions& options,
+    ScalarType dtype, Layout layout,Device device, bool pin_memory,
     c10::optional<c10::MemoryFormat> optional_memory_format) {
-  if (options.layout() == kSparse && self.is_sparse()) {
-    auto res = at::empty({0}, options); // to be resized
+  if (layout == kSparse && self.is_sparse()) {
+    auto res = at::_empty({0}, dtype, layout, device, pin_memory); // to be resized
     res.sparse_resize_and_clear_(
         self.sizes(), self.sparse_dim(), self.dense_dim());
     return res;
   }
-  auto result = at::empty_like(self, options, optional_memory_format);
+  auto result = at::_empty_like(self, dtype, layout, device, pin_memory, optional_memory_format);
   return result.zero_();
 }
 
 Tensor new_zeros(
     const Tensor& self,
     IntArrayRef size,
-    const TensorOptions& options
+    c10::optional<ScalarType> dtype, 
+    c10::optional<Layout> layout, 
+    c10::optional<Device> device, 
+    c10::optional<bool> pin_memory
     ) {
+
+  // We shouldn't need to construct TensorOptions object
+  // issue 30405
+  const auto options = TensorOptions()
+        .dtype(dtype)
+        .layout(layout)
+        .device(device)
+        .pinned_memory(pin_memory);
+
   return at::zeros(size, self.options().merge_in(options));
 }
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~ bartlett_window ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Tensor bartlett_window(int64_t window_length, const TensorOptions& options) {
-  return native::bartlett_window(window_length, /*periodic=*/true, options);
+Tensor bartlett_window(int64_t window_length, c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) {
+  return native::bartlett_window(window_length, /*periodic=*/true, dtype, layout, device, pin_memory);
 }
 
 Tensor bartlett_window(
     int64_t window_length,
     bool periodic,
-    const TensorOptions& options) {
-  window_function_checks("bartlett_window", options, window_length);
+    c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) {
+  window_function_checks("bartlett_window", dtype, layout, window_length);
   if (window_length == 0) {
-    return at::empty({0}, options);
+    return at::_empty({0}, dtype, layout, device, pin_memory);
   }
   if (window_length == 1) {
-    return native::ones({1}, options);
+    return native::ones({1}, dtype, layout, device, pin_memory);
   }
   if (periodic) {
     window_length += 1;
   }
-  auto window = native::arange(window_length, options).mul_(2. / static_cast<double>(window_length - 1));
+  auto window = native::arange(window_length, dtype, layout, device, pin_memory).mul_(2. / static_cast<double>(window_length - 1));
   const int64_t first_half_size = ((window_length - 1) >> 1) + 1;
   window.narrow(0, first_half_size, window_length - first_half_size).mul_(-1).add_(2);
   return periodic ? window.narrow(0, 0, window_length - 1) : window;
@@ -833,48 +886,48 @@ Tensor bartlett_window(
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~ blackman_window ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Tensor blackman_window(int64_t window_length, const TensorOptions& options) {
-  return native::blackman_window(window_length, /*periodic=*/true, options);
+Tensor blackman_window(int64_t window_length, c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) {
+  return native::blackman_window(window_length, /*periodic=*/true, dtype, layout, device, pin_memory);
 }
 
 Tensor blackman_window(
     int64_t window_length,
     bool periodic,
-    const TensorOptions& options) {
-  window_function_checks("blackman_window", options, window_length);
+    c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) {
+  window_function_checks("blackman_window", dtype, layout, window_length);
   if (window_length == 1) {
-    return native::ones({1}, options);
+    return native::ones({1}, dtype, layout, device, pin_memory);
   }
   if (periodic) {
     window_length += 1;
   }
   // from https://en.wikipedia.org/wiki/Window_function#Blackman_window
-  auto window = native::arange(window_length, options).mul_(M_PI / static_cast<double>(window_length - 1));
+  auto window = native::arange(window_length, dtype, layout, device, pin_memory).mul_(M_PI / static_cast<double>(window_length - 1));
   window = window.mul(4).cos_().mul_(0.08) - window.mul(2).cos_().mul_(0.5) + 0.42;
   return periodic ? window.narrow(0, 0, window_length - 1) : window;
 }
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ hamming_window ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Tensor hamming_window(int64_t window_length, const TensorOptions& options) {
-  return native::hamming_window(window_length, /*periodic=*/true, options);
+Tensor hamming_window(int64_t window_length, c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) {
+  return native::hamming_window(window_length, /*periodic=*/true, dtype, layout, device, pin_memory);
 }
 
 Tensor hamming_window(
     int64_t window_length,
     bool periodic,
-    const TensorOptions& options) {
+    c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) {
   return native::hamming_window(
-      window_length, periodic, /*alpha=*/0.54, options);
+      window_length, periodic, /*alpha=*/0.54, dtype, layout, device, pin_memory);
 }
 
 Tensor hamming_window(
     int64_t window_length,
     bool periodic,
     double alpha,
-    const TensorOptions& options) {
+    c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) {
   return native::hamming_window(
-      window_length, periodic, alpha, /*beta=*/0.46, options);
+      window_length, periodic, alpha, /*beta=*/0.46, dtype, layout, device, pin_memory);
 }
 
 Tensor hamming_window(
@@ -882,42 +935,42 @@ Tensor hamming_window(
     bool periodic,
     double alpha,
     double beta,
-    const TensorOptions& options) {
-  window_function_checks("hamming_window", options, window_length);
+    c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) {
+   window_function_checks("hamming_window", dtype, layout, window_length);
   if (window_length == 0) {
-    return at::empty({0}, options);
+    return at::_empty({0}, dtype, layout, device, pin_memory);
   }
   if (window_length == 1) {
-    return native::ones({1}, options);
+    return native::ones({1}, dtype, layout, device, pin_memory);
   }
   if (periodic) {
     window_length += 1;
   }
-  auto window = native::arange(window_length, options);
+  auto window = native::arange(window_length, dtype, layout, device, pin_memory);
   window.mul_(M_PI * 2. / static_cast<double>(window_length - 1)).cos_().mul_(-beta).add_(alpha);
   return periodic ? window.narrow(0, 0, window_length - 1) : window;
 }
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ hann_window ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Tensor hann_window(int64_t window_length, const TensorOptions& options) {
-  return native::hann_window(window_length, /*periodic=*/true, options);
+Tensor hann_window(int64_t window_length, c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) {
+  return native::hann_window(window_length, /*periodic=*/true, dtype, layout, device, pin_memory);
 }
 
 Tensor hann_window(
     int64_t window_length,
     bool periodic,
-    const TensorOptions& options) {
-  window_function_checks("hann_window", options, window_length);
+    c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) {
+  window_function_checks("hann_window", dtype, layout, window_length);
   return native::hamming_window(
-      window_length, periodic, /*alpha=*/0.5, /*beta=*/0.5, options);
+      window_length, periodic, /*alpha=*/0.5, /*beta=*/0.5, dtype, layout, device, pin_memory);
 }
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ tensor ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 template <typename T>
-Tensor tensor_cpu(ArrayRef<T> values, const TensorOptions& options) {
-  auto result = at::empty(values.size(), options);
+Tensor tensor_cpu(ArrayRef<T> values, c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) {
+  auto result = at::_empty(values.size(), dtype, layout, device, pin_memory);
   AT_ASSERT(result.is_contiguous());
   AT_DISPATCH_ALL_TYPES_AND_COMPLEX(result.scalar_type(), "tensor_cpu", [&] {
     std::copy(values.begin(), values.end(), result.template data_ptr<scalar_t>());
@@ -926,32 +979,47 @@ Tensor tensor_cpu(ArrayRef<T> values, const TensorOptions& options) {
 }
 
 template <typename T>
-Tensor tensor_backend(ArrayRef<T> values, const TensorOptions& options) {
-  auto cpu_tensor = tensor_cpu(values, options.device(DeviceType::CPU));
+Tensor tensor_backend(ArrayRef<T> values, c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) {
+  const auto options = TensorOptions()
+        .dtype(dtype)
+        .layout(layout)
+        .device(device)
+        .pinned_memory(pin_memory);
+  auto cpu_tensor = tensor_cpu(values, dtype, layout, at::Device(DeviceType::CPU), pin_memory);
   return cpu_tensor.to(options.device());
 }
 
-#define TENSOR(T, _1)                                               \
-  Tensor tensor(ArrayRef<T> values, const TensorOptions& options) { \
-    if (options.device().type() != c10::DeviceType::CPU) {          \
-      return tensor_backend(values, options);                       \
-    } else {                                                        \
-      return tensor_cpu(values, options);                           \
-    }                                                               \
+#define TENSOR(T, _1)                                                                                                                      \
+  Tensor tensor(ArrayRef<T> values, const TensorOptions& options) {                                                                        \
+    if (options.device().type() != c10::DeviceType::CPU) {                                                                                 \
+      return tensor_backend(values, typeMetaToScalarType(options.dtype()), options.layout(), options.device(), options.pinned_memory());   \
+    } else {                                                                                                                               \
+      return tensor_cpu(values, typeMetaToScalarType(options.dtype()), options.layout(), options.device(), options.pinned_memory());       \
+    }                                                                                                                                      \
   }
 AT_FORALL_SCALAR_TYPES_AND3(Bool, Half, BFloat16, TENSOR)
 #undef TENSOR
 
-Tensor from_file(std::string filename, c10::optional<bool> shared, c10::optional<int64_t> size, const TensorOptions& options) {
-    TORCH_CHECK(!options.pinned_memory(), "tensors constructed from a file cannot be pinned");
+#define TENSOR(T, _1)                                                                                                                                              \
+  Tensor tensor(ArrayRef<T> values, c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) { \
+    if (device.value().type() != c10::DeviceType::CPU) {                        \
+      return tensor_backend(values, dtype, layout, device, pin_memory); \
+    } else {                                                            \
+      return tensor_cpu(values, dtype, layout, device, pin_memory);     \
+    }                                                                   \
+  }
+AT_FORALL_SCALAR_TYPES_AND3(Bool, Half, BFloat16, TENSOR)
+#undef TENSOR
+
+Tensor from_file(std::string filename, c10::optional<bool> shared, c10::optional<int64_t> size, c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory) {
+    TORCH_CHECK(!pin_memory.value(), "tensors constructed from a file cannot be pinned");
     size_t my_size = size.value_or(0);
     int flags = shared.value_or(false) ? TH_ALLOCATOR_MAPPED_SHARED : 0;
-    auto dtype = options.dtype();
     auto storage_impl = c10::make_intrusive<at::StorageImpl>(
-      dtype,
+      scalarTypeToTypeMeta(dtype.value()),
       my_size,
       THMapAllocator::makeDataPtr(
-          filename.c_str(), flags, my_size * dtype.itemsize(), nullptr),
+          filename.c_str(), flags, my_size * scalarTypeToTypeMeta(dtype.value()).itemsize(), nullptr),
       /*allocator=*/nullptr,
       /*resizable=*/false);
     auto tensor = detail::make_tensor<at::TensorImpl>(storage_impl, at::TensorTypeId::CPUTensorId);
@@ -989,54 +1057,75 @@ Tensor full(
     IntArrayRef size,
     Scalar fill_value,
     optional<DimnameList> names,
-    const TensorOptions& options) {
-  auto result = at::empty(size, names, options);
+    c10::optional<ScalarType> dtype, 
+    c10::optional<Layout> layout, 
+    c10::optional<Device> device, 
+    c10::optional<bool> pin_memory) {
+  auto result = at::_empty(size, names, dtype, layout, device, pin_memory);
   return result.fill_(fill_value);
 }
 
 Tensor ones(
     IntArrayRef size,
     optional<DimnameList> names,
-    const TensorOptions& options) {
-  return native::full(size, /*fill_value=*/1, names, options);
+    c10::optional<ScalarType> dtype, 
+    c10::optional<Layout> layout, 
+    c10::optional<Device> device, 
+    c10::optional<bool> pin_memory) {
+  return native::full(size, /*fill_value=*/1, names, dtype, layout, device, pin_memory);
 }
 
 Tensor zeros(
     IntArrayRef size,
     optional<DimnameList> names,
-    const TensorOptions& options) {
-  return native::full(size, /*fill_value=*/0, names, options);
+    c10::optional<ScalarType> dtype, 
+    c10::optional<Layout> layout, 
+    c10::optional<Device> device, 
+    c10::optional<bool> pin_memory) {
+  return native::full(size, /*fill_value=*/0, names, dtype, layout, device, pin_memory);
 }
 
 Tensor randn(
     IntArrayRef size,
     optional<DimnameList> names,
-    const TensorOptions& options) {
-  return native::randn(size, nullptr, names, options);
+    c10::optional<ScalarType> dtype, 
+    c10::optional<Layout> layout, 
+    c10::optional<Device> device, 
+    c10::optional<bool> pin_memory) {
+  return native::randn(size, nullptr, names, dtype, layout, device, pin_memory);
 }
 
 Tensor randn(
     IntArrayRef size,
     Generator* generator,
     optional<DimnameList> names,
-    const TensorOptions& options) {
-  auto result = at::empty(size, names, options);
+    c10::optional<ScalarType> dtype, 
+    c10::optional<Layout> layout, 
+    c10::optional<Device> device, 
+    c10::optional<bool> pin_memory) {
+  auto result = at::_empty(size, names, dtype, layout, device, pin_memory);
   return result.normal_(0, 1, generator);
 }
 
 Tensor rand(
     IntArrayRef size,
     optional<DimnameList> names,
-    const TensorOptions& options) {
-  return native::rand(size, nullptr, names, options);
+    c10::optional<ScalarType> dtype, 
+    c10::optional<Layout> layout, 
+    c10::optional<Device> device, 
+    c10::optional<bool> pin_memory) {
+  return native::rand(size, nullptr, names, dtype, layout, device, pin_memory);
 }
 
 Tensor rand(
     IntArrayRef size,
     Generator* generator,
     optional<DimnameList> names,
-    const TensorOptions& options) {
-  auto result = at::empty(size, names, options);
+    c10::optional<ScalarType> dtype, 
+    c10::optional<Layout> layout, 
+    c10::optional<Device> device, 
+    c10::optional<bool> pin_memory) {
+  auto result = at::_empty(size, names, dtype, layout, device, pin_memory);
   return result.uniform_(0, 1, generator);
 }
 

--- a/aten/src/ATen/native/TensorFactories.h
+++ b/aten/src/ATen/native/TensorFactories.h
@@ -59,6 +59,18 @@ inline void check_args(
   }
 }
 
+inline void check_args(
+    int64_t row, int64_t col, c10::optional<c10::Layout> layout) {
+  TORCH_CHECK(row >= 0, "row must be non-negative, got", row);
+  TORCH_CHECK(col >= 0, "col must be non-negative, got", col);
+  if (layout.has_value()) {
+    TORCH_CHECK(
+      layout.value() == at::kStrided,
+      "only support layout=torch.strided, got",
+      layout.value())
+  }
+}
+
 inline void check_size_nonnegative(IntArrayRef size) {
   for (auto x: size) {
     TORCH_CHECK(x >= 0, "Trying to create tensor with negative dimension ", x, ": ", size);

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -155,7 +155,7 @@ static Tensor cat_sparse(TensorList tensors, int64_t dim) {
     }
     auto sizes_copy = sizes.vec();
     sizes_copy[wrapped] = cumulative_offset;
-    return native::sparse_coo_tensor(idxs, vals, sizes_copy, tensors[0].options());
+    return native::sparse_coo_tensor(idxs, vals, sizes_copy, typeMetaToScalarType(tensors[0].options().dtype()), tensors[0].options().layout(), tensors[0].options().device(), tensors[0].options().pinned_memory());
   }
   else {
     // Catting along a dense dimension requires us to create new values.
@@ -192,16 +192,16 @@ static Tensor cat_sparse(TensorList tensors, int64_t dim) {
       zeros_sizes[0] = t._values().size(0);
       zeros_sizes[values_dim] = cumulative_size;
       cumulative_size += t._values().size(values_dim);
-      auto z1 = native::zeros(zeros_sizes, t._values().options());
+      auto z1 = native::zeros(zeros_sizes, typeMetaToScalarType(t._values().options().dtype()), t._values().options().layout(), t._values().options().device(), t._values().options().pinned_memory());
       zeros_sizes[values_dim] = total_size - cumulative_size;
-      auto z2 = native::zeros(zeros_sizes, t._values().options());
+      auto z2 = native::zeros(zeros_sizes, typeMetaToScalarType(t._values().options().dtype()), t._values().options().layout(), t._values().options().device(), t._values().options().pinned_memory());
       vals_pieces.push_back(native::cat({z1, t._values(), z2}, values_dim));
       idxs_pieces.push_back(t._indices());
     }
     auto sizes_copy = sizes.vec();
     sizes_copy[wrapped] = total_size;
     // This can create an uncoalesced tensor
-    return native::sparse_coo_tensor(native::cat(idxs_pieces, 1), native::cat(vals_pieces), sizes_copy, tensors[0].options());
+    return native::sparse_coo_tensor(native::cat(idxs_pieces, 1), native::cat(vals_pieces), sizes_copy, typeMetaToScalarType(tensors[0].options().dtype()), tensors[0].options().layout(), tensors[0].options().device(), tensors[0].options().pinned_memory());
   }
 }
 
@@ -587,7 +587,7 @@ static Tensor select_sparse(const Tensor& self, int64_t dim, int64_t index) {
         return new_values.sum(0);
       }
     } else {
-      auto dimIndices = (arange(0, sparse_dim, self.device()) != dim).nonzero().view(-1);
+      auto dimIndices = (arange(0, sparse_dim, c10::nullopt, c10::nullopt, self.device()) != dim).nonzero().view(-1);
       auto new_indices = indices.index_select(1, nzIndices).index_select(0, dimIndices);
       return _sparse_coo_tensor_with_dims_and_tensors(
             sparse_dim - 1, dense_dim, new_sizes, new_indices, new_values, self.options());
@@ -1061,7 +1061,7 @@ static Tensor unsqueeze_sparse(Tensor const &self, int64_t dim /* should already
   if (dim <= sparse_dim) {
     auto new_indices = native::cat({
       indices.narrow(0, 0, dim),
-      native::zeros({1, indices.size(1)}, indices.options().dtype(kLong)),
+      native::zeros({1, indices.size(1)}, at::kLong, indices.options().layout_opt(), indices.options().device_opt(), indices.options().pinned_memory_opt()),
       indices.narrow(0, dim, indices.size(0) - dim)
     });
     return _sparse_coo_tensor_with_dims_and_tensors(

--- a/aten/src/ATen/native/UnaryOps.cpp
+++ b/aten/src/ATen/native/UnaryOps.cpp
@@ -271,7 +271,11 @@ Tensor mvlgamma(const Tensor& self, int64_t p) {
   TORCH_CHECK((self > 0.5 * (p - 1.)).all().item<uint8_t>(),
            "Condition for computing multivariate log-gamma not met");
   TORCH_CHECK(p >= 1, "p has to be greater than or equal to 1");
-  Tensor args = native::arange(-p / 2. + 0.5, 0.5, 0.5, self.options());
+  Tensor args = native::arange(-p / 2. + 0.5, 0.5, 0.5, 
+                              typeMetaToScalarType(self.options().dtype()), 
+                                                   self.options().layout(), 
+                                                   self.options().device(), 
+                                                   self.options().pinned_memory());
   args = args.add(self.unsqueeze(-1));
   return args.lgamma_().sum(-1).add_(p * (p - 1) * std::log(M_PI) / 4.);
 }
@@ -282,7 +286,11 @@ Tensor& mvlgamma_(Tensor& self, int64_t p) {
   TORCH_CHECK((self > 0.5 * (p - 1.)).all().item<uint8_t>(),
            "Condition for computing multivariate log-gamma not met");
   TORCH_CHECK(p >= 1, "p has to be greater than or equal to 1");
-  Tensor args = native::arange(-p / 2. + 0.5, 0.5, 0.5, self.options());
+  Tensor args = native::arange(-p / 2. + 0.5, 0.5, 0.5, 
+                               typeMetaToScalarType(self.options().dtype()), 
+                                                    self.options().layout(), 
+                                                    self.options().device(),
+                                                    self.options().pinned_memory());
   args = args.add(self.unsqueeze(-1));
   return self.copy_(args.lgamma_().sum(-1).add_(p * (p - 1) * std::log(M_PI) / 4.));
 }

--- a/aten/src/ATen/native/cuda/MultinomialKernel.cu
+++ b/aten/src/ATen/native/cuda/MultinomialKernel.cu
@@ -375,7 +375,11 @@ void multinomial_kernel_impl(Tensor& result, const Tensor& self, const int64_t n
       // To exploit greater parallelism for the sampling, generate the
       // Uniform random samples in a separate kernel launch, into
       // temporarily allocated memory. The device RNG is thread-limited
-      Tensor sampled = native::empty_cuda({numDist, n_sample}, self_v.options());
+      Tensor sampled = native::empty_cuda({numDist, n_sample}, 
+                                          typeMetaToScalarType(self_v.options().dtype()), 
+                                                               self_v.options().layout(), 
+                                                               self_v.options().device(), 
+                                                               self_v.options().pinned_memory());
       at::native::uniform_cuda_(sampled, 0.0, 1.0, gen);
 
       dim3 block(numCategories < maxThreads ? numCategories : maxThreads);

--- a/aten/src/ATen/native/cudnn/RNN.cpp
+++ b/aten/src/ATen/native/cudnn/RNN.cpp
@@ -1080,10 +1080,18 @@ std::tuple<Tensor, Tensor, Tensor, std::vector<Tensor>> _cudnn_rnn_backward(
 
 // TODO: I am not sure if we actually need the 'dropout' and 'train' parameters
 // to initialize just the state tensor
-Tensor _cudnn_init_dropout_state(double dropout, bool train, int64_t dropout_seed, const TensorOptions& options) {
+Tensor _cudnn_init_dropout_state(double dropout, bool train, int64_t dropout_seed, ScalarType dtype, Layout layout, Device device, bool pin_memory) {
   auto handle = getCudnnHandle();
   DropoutDescriptor dropout_desc;
   auto dropout_p = train ? dropout : 0;
+  
+  // Ideally we dont want to costruct this.
+  // Issue #30405
+  const auto options = TensorOptions()
+        .dtype(dtype)
+        .layout(layout)
+        .device(device)
+        .pinned_memory(pin_memory);
   dropout_desc.initialize_rng(handle, dropout_p, dropout_seed, options);
   return dropout_desc.state;
 }
@@ -1162,8 +1170,8 @@ DropoutState& get_dropout_state(double dropout_p, bool train, TensorOptions opti
   if (train && dropout_p > 0 && !state.buffer.defined()) {
     std::unique_lock<std::mutex> lock {state.mutex};
     int64_t seed = at::empty({}, at::kLong).random_().item<int64_t>();
-    state.buffer = at::_cudnn_init_dropout_state(
-      dropout_p, train, seed, options.dtype(at::kByte));
+    state.buffer = at::__cudnn_init_dropout_state(
+      dropout_p, train, seed, at::kByte, options.layout(), options.device(), options.pinned_memory());
     // NB: CUDA binds the event to a device at creation time, so we can initialize it
     // only now, when we know we're on the correct device.
     state.event.emplace();

--- a/aten/src/ATen/native/mkldnn/BinaryOps.cpp
+++ b/aten/src/ATen/native/mkldnn/BinaryOps.cpp
@@ -100,7 +100,11 @@ Tensor& mkldnn_mul_out(Tensor& result, const Tensor& self, const Tensor& other) 
 }
 
 Tensor mkldnn_mul(const Tensor& self, const Tensor& other) {
-  Tensor result = empty_mkldnn(self.sizes(), self.options());
+  Tensor result = empty_mkldnn(self.sizes(), 
+                               typeMetaToScalarType(self.options().dtype()), 
+                               self.options().layout(), 
+                               self.options().device(), 
+                               self.options().pinned_memory());
   return native::mkldnn_mul_out(result, self, other);
 }
 

--- a/aten/src/ATen/native/mkldnn/MKLDNNConversions.cpp
+++ b/aten/src/ATen/native/mkldnn/MKLDNNConversions.cpp
@@ -30,7 +30,11 @@ Tensor dense_to_mkldnn(const Tensor& cpu_tensor) {
              "Can't convert cpu tensor with the number of dimensions > 5");
   // TODO: consider to convert non-contiguous tensor to `ideep::tensor` directly.
   auto cpu_tensor_cont = cpu_tensor.contiguous();
-  Tensor mkldnn_tensor = empty_mkldnn(cpu_tensor_cont.sizes(), cpu_tensor_cont.options());
+  Tensor mkldnn_tensor = empty_mkldnn(cpu_tensor_cont.sizes(), 
+                                      typeMetaToScalarType(cpu_tensor_cont.options().dtype()), 
+                                      cpu_tensor_cont.options().layout(), 
+                                      cpu_tensor_cont.options().device(), 
+                                      cpu_tensor_cont.options().pinned_memory());
   ideep::tensor& dtensor = itensor_from_mkldnn(mkldnn_tensor);
   dtensor.feed_from(dtensor.get_dims(),
                     ideep::tensor::data_type::f32,

--- a/aten/src/ATen/native/mkldnn/TensorFactories.cpp
+++ b/aten/src/ATen/native/mkldnn/TensorFactories.cpp
@@ -4,22 +4,42 @@ namespace at { namespace native {
 
 #if AT_MKLDNN_ENABLED()
 
-Tensor empty_mkldnn(IntArrayRef sizes, const TensorOptions& options, c10::optional<c10::MemoryFormat> optional_memory_format) {
-  TORCH_CHECK(
-     !optional_memory_format.has_value(),
-     "'memory_format' argument is incompatible with mkldnn tensor");
-  // NOTE: int32_t dims from ideep::tensor but sizes needs int64_t
-  // TODO: support int64_t dims in ideep::tensor to avoid extra conversion
-  ideep::tensor::dims dst_dims (sizes.begin(), sizes.end());
-  ideep::tensor it;
-  it.resize<AllocForMKLDNN>(dst_dims, ideep::tensor::data_type::f32);
-  return new_with_itensor_mkldnn(std::move(it), options);
+Tensor empty_mkldnn(
+  IntArrayRef sizes, 
+  c10::optional<ScalarType> dtype, 
+  c10::optional<Layout> layout, 
+  c10::optional<Device> device, 
+  c10::optional<bool> pin_memory, 
+  c10::optional<c10::MemoryFormat> optional_memory_format) {
+    TORCH_CHECK(
+      !optional_memory_format.has_value(),
+      "'memory_format' argument is incompatible with mkldnn tensor");
+    // NOTE: int32_t dims from ideep::tensor but sizes needs int64_t
+    // TODO: support int64_t dims in ideep::tensor to avoid extra conversion
+    ideep::tensor::dims dst_dims (sizes.begin(), sizes.end());
+    ideep::tensor it;
+    it.resize<AllocForMKLDNN>(dst_dims, ideep::tensor::data_type::f32);
+    
+    // Ideally we dont want to costruct this.
+    // Issue #30405
+    const auto options = TensorOptions()
+      .dtype(dtype)
+      .layout(layout)
+      .device(device)
+      .pinned_memory(pin_memory);
+    return new_with_itensor_mkldnn(std::move(it), options);
 }
 
 #else
 
-Tensor empty_mkldnn(IntArrayRef sizes, const TensorOptions& options, c10::optional<c10::MemoryFormat> optional_memory_format) {
-  AT_ERROR("empty_mkldnn: MKL-DNN build is disabled");
+Tensor empty_mkldnn(
+  IntArrayRef sizes, 
+  c10::optional<ScalarType> dtype, 
+  c10::optional<Layout> layout, 
+  c10::optional<Device> device, 
+  c10::optional<bool> pin_memory, 
+  c10::optional<c10::MemoryFormat> optional_memory_format) {
+    AT_ERROR("empty_mkldnn: MKL-DNN build is disabled");
 }
 
 #endif // AT_MKLDNN_ENABLED()

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3247,7 +3247,7 @@
 
 # FIXME: would be nicer if TensorOptions was optional based; not adding default arguments for options given
 # the default would never make sense.
-- func: sparse_coo_tensor.size(int[] size, *, ScalarType dtype, Layout layout, Device device, bool pin_memory=False) -> Tensor
+- func: sparse_coo_tensor.size(int[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=False) -> Tensor
 
 - func: sparse_coo_tensor.indices(Tensor indices, Tensor values, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
 
@@ -3255,7 +3255,7 @@
 
 - func: _sparse_coo_tensor_unsafe(Tensor indices, Tensor values, int[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
 
-- func: _sparse_coo_tensor_with_dims(int sparse_dim, int dense_dim, int[] size, *, ScalarType dtype, Layout layout, Device device, bool pin_memory=False) -> Tensor
+- func: _sparse_coo_tensor_with_dims(int sparse_dim, int dense_dim, int[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=False) -> Tensor
   dispatch:
     SparseCPU: new_with_dims_sparse
     SparseCUDA: new_with_dims_sparse
@@ -3566,7 +3566,7 @@
 # to(Device) must not exist because all constructors of Device also works for
 # TensorOptions. Otherwise, an ambiguity error is thrown.
 # See NOTE [ TensorOptions Constructors ].
-- func: to.dtype_layout(Tensor self, *, ScalarType dtype, Layout layout, Device device, bool pin_memory=False, bool non_blocking=False, bool copy=False, MemoryFormat? memory_format=None) -> Tensor
+- func: to.dtype_layout(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=False, bool non_blocking=False, bool copy=False, MemoryFormat? memory_format=None) -> Tensor
   variants: method
   device_guard: False
   supports_named_tensor: True

--- a/aten/src/ATen/native/quantized/TensorFactories.cpp
+++ b/aten/src/ATen/native/quantized/TensorFactories.cpp
@@ -12,13 +12,20 @@ namespace native {
 // change to use quantizer
 Tensor empty_affine_quantized_cpu(
     IntArrayRef size,
-    const TensorOptions& options,
+    c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory,
     double scale,
     int64_t zero_point,
     c10::optional<c10::MemoryFormat> optional_memory_format) {
   TORCH_CHECK(
-      options.has_dtype(),
+      dtype.has_value(),
       "Must provide data type for Tensor creation functions.");
+ 
+ const auto options = TensorOptions()
+        .dtype(dtype)
+        .layout(layout)
+        .device(device)
+        .pinned_memory(pin_memory);
+
   return new_qtensor_cpu(
       size,
       options,
@@ -32,14 +39,21 @@ Tensor empty_per_channel_affine_quantized_cpu(
     const Tensor& scales,
     const Tensor& zero_points,
     int64_t axis,
-    const TensorOptions& options,
+    c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory,
     c10::optional<c10::MemoryFormat> optional_memory_format) {
   TORCH_CHECK(
-      options.has_dtype(),
+      dtype.has_value(),
       "Must provide data type for Tensor creation functions.");
   TORCH_CHECK(
-      options.dtype() == kQInt8 || options.dtype() == kQUInt8,
+      dtype.value() == kQInt8 || dtype.value() == kQUInt8,
       "Supported data type for tensor creation is int8 or uint8");
+
+    const auto options = TensorOptions()
+        .dtype(dtype)
+        .layout(layout)
+        .device(device)
+        .pinned_memory(pin_memory);
+
   return new_qtensor_cpu(
       size,
       options,
@@ -54,7 +68,7 @@ Tensor empty_per_channel_affine_quantized_cpu(
 // Provide better error message if dtype is wrong
 Tensor empty_affine_quantized_other_backends_stub(
     IntArrayRef,
-    const TensorOptions&,
+    c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory,
     double,
     int64_t,
     c10::optional<c10::MemoryFormat>) {
@@ -66,7 +80,7 @@ Tensor empty_per_channel_affine_quantized_other_backends_stub(
     const Tensor&,
     const Tensor&,
     int64_t,
-    const TensorOptions&,
+    c10::optional<ScalarType> dtype, c10::optional<Layout> layout, c10::optional<Device> device, c10::optional<bool> pin_memory,
     c10::optional<c10::MemoryFormat>) {
   TORCH_CHECK(false, "Creation of quantized tensor requires quantized dtype like torch.quint8");
 }

--- a/aten/src/ATen/native/sparse/SparseTensorMath.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensorMath.cpp
@@ -846,7 +846,11 @@ SparseTensor& _sspaddmm_out_cpu(
   int64_t t_nnz = t._nnz();
   int64_t r_nnz = nnz * dim_k + t_nnz;
   LongTensor newi = at::empty({2, r_nnz}, kLong);
-  LongTensor newv = native::zeros({r_nnz}, values.options());
+  LongTensor newv = native::zeros({r_nnz}, 
+                                  typeMetaToScalarType(values.options().dtype()), 
+                                  values.options().layout(),
+                                  values.options().device(), 
+                                  values.options().pinned_memory());
 
   if (t_nnz != 0) {
     LongTensor narrowi = newi.narrow(1, 0, t_nnz);

--- a/aten/src/ATen/native_parse.py
+++ b/aten/src/ATen/native_parse.py
@@ -228,7 +228,7 @@ def parse_arguments(args, func_variants, declaration, func_return):
     supported_topt_arguments.append(
         [
             {'name': 'dtype', 'type': 'ScalarType', 'annotation': None, 'kwarg_only': True,
-             'default': 'long', 'is_nullable': True},
+             'default': 'at::kLong', 'is_nullable': True},
             {'name': 'layout', 'type': 'Layout', 'annotation': None, 'kwarg_only': True,
              'default': 'c10::nullopt', 'is_nullable': True},
             {'name': 'device', 'type': 'Device', 'annotation': None, 'kwarg_only': True,
@@ -259,33 +259,29 @@ def parse_arguments(args, func_variants, declaration, func_return):
     def is_tensor_option(argument):
         return argument['name'] in ['dtype', 'layout', 'device', 'pin_memory']
 
-    new_arguments = []
     idx = 0
+
+    # This is a hack around tril_indices/triu_indices as codegen doesn't handle default values well.
+    # issue #30405
     while idx < len(arguments):
         argument = arguments[idx]
-        number_of_arguments = len(supported_topt_arguments[0])
-        if is_tensor_option(argument) and len(arguments) - idx >= number_of_arguments:
-            topt_representation = []
-            for i in range(number_of_arguments):
-                argument = arguments[idx]
-                if not is_tensor_option(argument):
-                    break
-                topt_representation.append(argument)
-                idx += 1
-            if len(topt_representation) == number_of_arguments:
-                merged_argument = check_topt_representation(topt_representation)
-                assert merged_argument, \
-                    "Unsupported combination of TensorOptions {}, the only currently supported combinations are {}"\
-                    .format(str(topt_representation), str(supported_topt_arguments))
-                new_arguments.append(merged_argument)
-            else:
-                new_arguments += topt_representation
-        else:
-            new_arguments.append(argument)
-            idx += 1
-
-    arguments = new_arguments
-
+        if declaration['name'] == 'tril_indices' or declaration['name'] == 'triu_indices':
+            arguments = [
+                {'type': 'int64_t', 'name': 'row', 'is_nullable': False, 'annotation': None}, 
+                {'type': 'int64_t', 'name': 'col', 'is_nullable': False, 'annotation': None},
+                {'type': 'int64_t', 'name': 'offset', 'is_nullable': False, 'annotation': None, 'default': 0}, 
+                {'name': 'dtype', 'type': 'ScalarType', 'annotation': None, 'kwarg_only': True,
+                'default': 'at::kLong', 'is_nullable': True},
+                {'name': 'layout', 'type': 'Layout', 'annotation': None, 'kwarg_only': True,
+                'default': 'c10::nullopt', 'is_nullable': True},
+                {'name': 'device', 'type': 'Device', 'annotation': None, 'kwarg_only': True,
+                'default': 'c10::nullopt', 'is_nullable': True},
+                {'name': 'pin_memory', 'type': 'bool', 'annotation': None, 'kwarg_only': True,
+                'default': 'c10::nullopt', 'is_nullable': True},
+            ]
+    
+        idx += 1
+    
     # Sanity checks
 
     # TODO: convention is that the ith-argument correspond to the i-th return, but it would

--- a/aten/src/ATen/tensor_options_utils.py
+++ b/aten/src/ATen/tensor_options_utils.py
@@ -1,0 +1,133 @@
+tensor_options_optional_types_and_var = ['c10::optional<ScalarType> dtype', 'c10::optional<Layout> layout', 'c10::optional<Device> device', 'c10::optional<bool> pin_memory']
+tensor_options_types_and_var = ['ScalarType dtype', 'Layout layout', 'Device device', 'bool pin_memory']
+
+def check_if_factory_method(args):
+    for arg in args: 
+        if 'type' not in arg:
+            return False
+
+    a = any(arg['type'] == 'c10::optional<ScalarType>' for arg in args) and any(arg['type'] == 'c10::optional<Layout>' for arg in args) and any(arg['type'] == 'c10::optional<Device>' for arg in args) and any(arg['type'] == 'c10::optional<bool>' for arg in args)
+    c = any(arg['type'] == 'ScalarType' for arg in args) and any(arg['type'] == 'Layout' for arg in args) and any(arg['type'] == 'Device' for arg in args) and any(arg['type'] == 'bool' for arg in args)
+    b = any('TensorOptions' in arg['type'] for arg in args)
+
+    return a or b or c
+
+def collapse_actuals2(actuals):
+    collapsed = actuals[:]
+    index = actuals.index('dtype')
+    collapsed[index] = 'at::typeMetaToScalarType(options.dtype())'
+    collapsed[index + 1] = 'options.layout()'
+    collapsed[index + 2] = 'options.device()'
+    collapsed[index + 3] = 'options.pinned_memory()'
+    return collapsed
+
+
+def check_tensor_options_in_formals(formals):
+    return (any(formal['dynamic_type'] == 'ScalarType' for formal in formals) and
+            any(formal['dynamic_type'] == 'Layout' for formal in formals) and
+            any(formal['dynamic_type'] == 'Device' for formal in formals) and 
+            any(formal['dynamic_type'] == 'bool' for formal in formals))
+
+def collapse_actuals(actuals):
+        collapsed = actuals[:]
+        if (any(actual == 'dtype' for actual in actuals) and
+            any(actual == 'layout' for actual in actuals) and
+            any(actual == 'device' for actual in actuals) and 
+            any(actual == 'pin_memory' for actual in actuals)):
+            index = collapsed.index('dtype')
+
+            collapsed.pop(index)
+            collapsed.pop(index)
+            collapsed.pop(index)
+            collapsed.pop(index)
+            collapsed.insert(index, 'options')
+
+        return collapsed
+
+def collapse_formals(formals):
+    collapsed = formals[:]
+
+    hasTO = True
+    hasDefVal = False
+    for option in tensor_options_optional_types_and_var:
+        if not any(option in formal for formal in formals):
+            hasTO = False
+            break
+
+        if any((option in formal and '=' in formal) for formal in formals) :
+            hasDefVal = True
+
+        if hasTO:
+            index = [idx for idx, formal in enumerate(formals) if 'c10::optional<ScalarType> dtype' in formal][0]
+            collapsed.pop(index)
+            collapsed.pop(index)
+            collapsed.pop(index)
+            collapsed.pop(index)
+            if hasDefVal:
+                collapsed.insert(index, 'const at::TensorOptions & options={}')
+            else:
+                collapsed.insert(index, 'const at::TensorOptions & options')
+
+            return collapsed
+
+    hasTO = True
+    for option in tensor_options_types_and_var:
+        if not any(option in formal for formal in formals):
+            hasTO = False
+            break
+
+        if any((option in formal and '=' in formal) for formal in formals) :
+            hasDefVal = True
+
+        if hasTO:
+            index = [idx for idx, formal in enumerate(formals) if 'ScalarType dtype' in formal][0]
+            collapsed.pop(index)
+            collapsed.pop(index)
+            collapsed.pop(index)
+            collapsed.pop(index)
+            if hasDefVal:
+                collapsed.insert(index, 'const at::TensorOptions & options={}')
+            else:
+                collapsed.insert(index, 'const at::TensorOptions & options')
+
+            return collapsed
+
+    return collapsed
+
+def collapse_formals_list(formals):
+        collapsed = formals[:]
+        if (any(formal['type'] == 'c10::optional<ScalarType>' for formal in collapsed) and 
+            any(formal['type'] == 'c10::optional<Layout>' for formal in collapsed) and 
+            any(formal['type'] == 'c10::optional<Device>' for formal in collapsed) and 
+            any(formal['type'] == 'c10::optional<bool>' for formal in collapsed)):
+            index = 0
+            for i in range(len(collapsed)):
+                if collapsed[i]['type'] == 'c10::optional<ScalarType>':
+                    break
+                else:
+                    index += 1
+
+            collapsed.pop(index)
+            collapsed.pop(index)
+            collapsed.pop(index)
+            collapsed.pop(index)
+            collapsed.insert(index, {"annotation" : "None", "dynamic_type": "TensorOptions", "is_nullable": "False", "default": "{}", "kwarg_only": "True", "name": "options", "type": "const TensorOptions &", })
+
+        if (any(formal['type'] == 'ScalarType' for formal in collapsed) and 
+            any(formal['type'] == 'Layout' for formal in collapsed) and 
+            any(formal['type'] == 'Device' for formal in collapsed) and 
+            any(formal['type'] == 'bool' for formal in collapsed)):
+            index = 0
+            for i in range(len(collapsed)):
+                if collapsed[i]['type'] == 'ScalarType':
+                    break
+                else:
+                    index += 1
+
+            collapsed.pop(index)
+            collapsed.pop(index)
+            collapsed.pop(index)
+            collapsed.pop(index)
+            collapsed.insert(index, {"annotation" : "None", "dynamic_type": "TensorOptions", "is_nullable": "False", "kwarg_only": "True", "name": "options", "type": "const TensorOptions &", })
+
+        return collapsed

--- a/c10/core/Layout.h
+++ b/c10/core/Layout.h
@@ -6,7 +6,7 @@
 #include <iostream>
 
 namespace c10 {
-enum class Layout : int8_t { Strided, Sparse, Mkldnn };
+enum class Layout : int8_t { Strided, Sparse, Mkldnn, Unknown };
 
 constexpr auto kStrided = Layout::Strided;
 constexpr auto kSparse = Layout::Sparse;

--- a/caffe2/contrib/aten/gen_op.py
+++ b/caffe2/contrib/aten/gen_op.py
@@ -37,8 +37,10 @@ if args.aten_root:
             args.aten_root))
     sys.path.append(os.path.join(args.aten_root, 'src', 'ATen'))
     from code_template import CodeTemplate as CT
+    from tensor_options_utils import check_if_factory_method
 else:
     from src.ATen.code_template import CodeTemplate as CT
+    from src.ATen.tensor_options_utils import check_if_factory_method
 
 OP_TEMPLATE = CT.from_file(
     os.path.join(args.template_dir, 'aten_op_template.h'))
@@ -201,7 +203,7 @@ def get_num_inputs(o):
 def find_factory_methods(decls):
     factory_methods = {}
     for o in decls:
-        if any(arg['dynamic_type'] == 'TensorOptions' for arg in o['arguments']):
+        if check_if_factory_method(o['arguments']):
             factory_methods[o['name']] = 0
     return factory_methods
 

--- a/test/test_quantized_tensor.py
+++ b/test/test_quantized_tensor.py
@@ -112,9 +112,8 @@ class TestQuantizedTensor(TestCase):
         self.assertEqual(q.q_zero_point(), q_el.q_zero_point())
         self.assertEqual(q.dtype, q_el.dtype)
 
-        # create via empty_like but change the dtype (currently not supported)
-        with self.assertRaises(RuntimeError):
-            torch.empty_like(q, dtype=torch.qint8)
+        # create via empty_like but change the dtype
+        self.assertEqual(torch.qint8, torch.empty_like(q, dtype=torch.qint8).dtype)
 
     def test_qtensor_dtypes(self):
         r = torch.rand(3, 2, dtype=torch.float) * 4 - 2

--- a/tools/autograd/gen_variable_factories.py
+++ b/tools/autograd/gen_variable_factories.py
@@ -7,13 +7,52 @@ import re
 from .utils import CodeTemplate, write
 from .gen_variable_type import format_trace
 
+try:
+    from src.ATen.tensor_options_utils import *
+except ImportError:
+    from tools.shared.module_loader import import_module
+    TOUtils = import_module('tensor_options_utils', 'aten/src/ATen/tensor_options_utils.py')
+
+# This is a hack. 
+# issue #30405
+FUNCTION_TEMPLATE_ARANGE = CodeTemplate("""\
+inline at::Tensor ${name}(${collapsed_formals}) {
+  ${pre_record_trace}
+  at::Tensor tensor = ([&]() {
+    at::AutoNonVariableTypeMode non_var_type_mode(true);
+    auto currDtype = options.dtype_opt();
+    if (currDtype.has_value()) {
+      return at::_arange(${uncollapsed_actuals});
+    }
+    return at::_arange(${uncollapsed_actuals_nullptr});
+  })();
+  at::Tensor result =
+    autograd::make_variable(std::move(tensor), /*requires_grad=*/options.requires_grad());
+  ${post_record_trace}
+  return result;
+}
+""")
+
+FUNCTION_TEMPLATE_TENSOR_OPTIONS = CodeTemplate("""\
+inline at::Tensor ${name}(${collapsed_formals}) {
+  ${pre_record_trace}
+  at::Tensor tensor = ([&]() {
+    at::AutoNonVariableTypeMode non_var_type_mode(true);
+    return at::_${name}(${uncollapsed_actuals});
+  })();
+  at::Tensor result =
+    autograd::make_variable(std::move(tensor), /*requires_grad=*/options.requires_grad());
+  ${post_record_trace}
+  return result;
+}
+""")
 
 FUNCTION_TEMPLATE = CodeTemplate("""\
 inline at::Tensor ${name}(${formals}) {
   ${pre_record_trace}
   at::Tensor tensor = ([&]() {
     at::AutoNonVariableTypeMode non_var_type_mode(true);
-    return at::${name}(${actuals});
+    return at::_${name}(${actuals});
   })();
   at::Tensor result =
     autograd::make_variable(std::move(tensor), /*requires_grad=*/${requires_grad});
@@ -22,9 +61,7 @@ inline at::Tensor ${name}(${formals}) {
 }
 """)
 
-
 TYPE_PATTERN = re.compile(r"(?:const\s+)?([A-Z]\w+)")
-
 
 def fully_qualified_type(argument_type):
     match = TYPE_PATTERN.match(argument_type)
@@ -37,7 +74,7 @@ def fully_qualified_type(argument_type):
 def gen_variable_factories(out, declarations, template_path, disable_autograd=False):
     function_definitions = []
     for decl in declarations:
-        has_tensor_options = any(a["simple_type"] == "TensorOptions" for a in decl["arguments"])
+        has_tensor_options = TOUtils.check_if_factory_method(decl["arguments"])        
         is_namespace_fn = 'namespace' in decl['method_of']
         if (has_tensor_options or decl["name"].endswith("_like")) and is_namespace_fn:
             function_definitions.append(
@@ -47,29 +84,69 @@ def gen_variable_factories(out, declarations, template_path, disable_autograd=Fa
           CodeTemplate.from_file(template_path + "/variable_factories.h"),
           {"function_definitions": function_definitions})
 
-
+def replace_dtype_nullprt(actuals):
+    replaced = actuals[:]
+    index = actuals.index('at::typeMetaToScalarType(options.dtype())')
+    replaced[index] = 'c10::nullopt'
+    return replaced
+    
 def process_function(decl, has_tensor_options, disable_autograd):
     formals = []
     actuals = []
     for argument in decl["arguments"]:
         type = fully_qualified_type(argument["type"])
+        
         default = " = {}".format(argument["default"]) if "default" in argument else ""
+        if "default" in argument:
+            if argument["default"] == False or argument["default"] == True:
+                default = default.lower()
+
         formals.append("{} {}{}".format(type, argument["name"], default))
+
         actual = argument["name"]
         if argument["simple_type"] == "TensorOptions":
             actual = "at::TensorOptions({})".format(actual)
         actuals.append(actual)
-    requires_grad = "options.requires_grad()" if has_tensor_options else "false"
+
+    requires_grad = "false"
     if decl['name'].endswith('_like') and not has_tensor_options:
         # Insert TensorOptions before MemoryFormat
-        actuals.insert(-1, '{}.options()'.format(actuals[0]))
-
+        actuals.insert(-1, 'at::typeMetaToScalarType({}.options().dtype())'.format(actuals[0]))
+        actuals.insert(-1, '{}.options().layout()'.format(actuals[0]))
+        actuals.insert(-1, '{}.options().device()'.format(actuals[0]))
+        actuals.insert(-1, '{}.options().pinned_memory()'.format(actuals[0]))
+        
     if not disable_autograd:
         pre_record_trace, post_record_trace = format_trace(decl)
+        if has_tensor_options:
+            pre_record_trace = pre_record_trace.replace("jit::tracer::addInputs(node, \"dtype\", dtype);",
+                                                        "jit::tracer::addInputs(node, \"options\", options);")
+            pre_record_trace = pre_record_trace.replace("jit::tracer::addInputs(node, \"layout\", layout);",
+                                                        "")
+            pre_record_trace = pre_record_trace.replace("jit::tracer::addInputs(node, \"device\", device);",
+                                                        "")
+            pre_record_trace = pre_record_trace.replace("jit::tracer::addInputs(node, \"pin_memory\", pin_memory);",
+                                                        "")
     else:
         pre_record_trace, post_record_trace = '', ''
 
-    return FUNCTION_TEMPLATE.substitute(
-        name=decl["name"], formals=formals, actuals=actuals, requires_grad=requires_grad,
-        pre_record_trace=pre_record_trace, post_record_trace=post_record_trace
-    )
+    if not has_tensor_options:
+        return FUNCTION_TEMPLATE.substitute(
+            name=decl["name"], formals=formals, actuals=actuals, requires_grad=requires_grad,
+            pre_record_trace=pre_record_trace, post_record_trace=post_record_trace
+        )
+    else:
+        uncollapsed_actuals = TOUtils.collapse_actuals2(actuals)
+        collapsed_formals = TOUtils.collapse_formals(formals)
+        uncollapsed_actuals_nullptr = replace_dtype_nullprt(uncollapsed_actuals)
+
+        if decl['name'] == 'arange':
+            return FUNCTION_TEMPLATE_ARANGE.substitute(
+                name=decl["name"], collapsed_formals = collapsed_formals, actuals=actuals, uncollapsed_actuals=uncollapsed_actuals, uncollapsed_actuals_nullptr=uncollapsed_actuals_nullptr, requires_grad=requires_grad,
+                pre_record_trace=pre_record_trace, post_record_trace=post_record_trace
+            )
+        else:
+            return FUNCTION_TEMPLATE_TENSOR_OPTIONS.substitute(
+                name=decl["name"], collapsed_formals = collapsed_formals, actuals=actuals, uncollapsed_actuals=uncollapsed_actuals, requires_grad=requires_grad,
+                pre_record_trace=pre_record_trace, post_record_trace=post_record_trace
+            )

--- a/tools/pyi/gen_pyi.py
+++ b/tools/pyi/gen_pyi.py
@@ -39,7 +39,7 @@ read gen_pyi for the gory details.
 
 needed_modules = set()
 
-FACTORY_PARAMS = "dtype: Optional[_dtype]=None, device: Union[_device, str, None]=None, requires_grad: _bool=False"
+FACTORY_PARAMS = "dtype: Optional[_dtype]=None, layout: Optional[_layout]=None, device: Union[_device, str, None]=None, requires_grad: _bool=False"
 
 # this could be more precise w.r.t list contents etc. How to do Ellipsis?
 INDICES = "indices: Union[None, _int, slice, Tensor, List, Tuple]"
@@ -133,6 +133,7 @@ def type_to_python(typename, size=None):
         'Dimname': 'Union[str, None]',
         'DimnameList': 'List[Union[str, None]]',
         'QScheme': '_qscheme',
+        'Layout': '_layout'
     }[typename]
 
     return typename


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#31062 Updated codegen to remove TensorOptions from generated code**
* #31061 Prepare templates
* #31060 Updated DispatchKeyExtractor to expect TensorOptions
* #31059 Added C++ API test
* #31058 Add tracing support for optional Device and Layout

