### PR TITLE
[jit/docs] move migration guide to appendix

### DIFF
--- a/docs/source/jit.rst
+++ b/docs/source/jit.rst
@@ -147,242 +147,6 @@ Example (using a traced module):
 
     my_script_module = torch.jit.script(MyScriptModule())
 
-Migrating to PyTorch 1.2 Recursive Scripting API
-------------------------------------------------
-This section details the changes to TorchScript in PyTorch 1.2. If you are new to TorchScript you can
-skip this section. There are two main changes to the TorchScript API with PyTorch 1.2.
-
-1. :func:`torch.jit.script <torch.jit.script>` will now attempt to recursively compile functions,
-methods, and classes that it encounters. Once you call ``torch.jit.script``,
-compilation is "opt-out", rather than "opt-in".
-
-2. ``torch.jit.script(nn_module_instance)`` is now the preferred way to create
-:class:`ScriptModule`\s, instead of inheriting from ``torch.jit.ScriptModule``.
-These changes combine to provide a simpler, easier-to-use API for converting
-your ``nn.Module``\s into :class:`ScriptModule`\s, ready to be optimized and executed in a
-non-Python environment.
-
-The new usage looks like this:
-
-.. testcode::
-
-    import torch
-    import torch.nn as nn
-    import torch.nn.functional as F
-
-    class Model(nn.Module):
-        def __init__(self):
-            super(Model, self).__init__()
-            self.conv1 = nn.Conv2d(1, 20, 5)
-            self.conv2 = nn.Conv2d(20, 20, 5)
-
-        def forward(self, x):
-            x = F.relu(self.conv1(x))
-            return F.relu(self.conv2(x))
-
-    my_model = Model()
-    my_scripted_model = torch.jit.script(my_model)
-
-
-* The module's ``forward`` is compiled by default. Methods called from ``forward`` are lazily compiled in the order they are used in ``forward``.
-* To compile a method other than ``forward`` that is not called from ``forward``, add ``@torch.jit.export``.
-* To stop the compiler from compiling a method, add :func:`@torch.jit.ignore <torch.jit.ignore>` or :func:`@torch.jit.unused <torch.jit.unused>`. ``@ignore`` leaves the
-* method as a call to python, and ``@unused`` replaces it with an exception. ``@ignored`` cannot be exported; ``@unused`` can.
-* Most attribute types can be inferred, so ``torch.jit.Attribute`` is not necessary. For empty container types, annotate their types using `PEP 526-style <https://www.python.org/dev/peps/pep-0526/#class-and-instance-variable-annotations>`_ class annotations.
-* Constants can be marked with a ``Final`` class annotation instead of adding the name of the member to ``__constants__``.
-* Python 3 type hints can be used in place of ``torch.jit.annotate``
-
-As a result of these changes, the following items are considered deprecated and should not appear in new code:
-  * The ``@torch.jit.script_method`` decorator
-  * Classes that inherit from ``torch.jit.ScriptModule``
-  * The ``torch.jit.Attribute`` wrapper class
-  * The ``__constants__`` array
-  * The ``torch.jit.annotate`` function
-
-Modules
-~~~~~~~
-.. warning::
-
-    The :func:`@torch.jit.ignore <torch.jit.ignore>` annotation's behavior changes in
-    PyTorch 1.2. Before PyTorch 1.2 the @ignore decorator was used to make a function
-    or method callable from code that is exported. To get this functionality back,
-    use ``@torch.jit.unused()``. ``@torch.jit.ignore`` is now equivalent
-    to ``@torch.jit.ignore(drop=False)``. See :func:`@torch.jit.ignore <torch.jit.ignore>`
-    and :func:`@torch.jit.unused<torch.jit.unused>` for details.
-
-When passed to the :func:`torch.jit.script <torch.jit.script>` function, a ``torch.nn.Module``\'s data is
-copied to a :class:`ScriptModule` and the TorchScript compiler compiles the module.
-The module's ``forward`` is compiled by default. Methods called from ``forward`` are
-lazily compiled in the order they are used in ``forward``, as well as any
-``@torch.jit.export`` methods.
-
-.. autofunction:: export
-
-Functions
-~~~~~~~~~
-Functions don't change much, they can be decorated with :func:`@torch.jit.ignore <torch.jit.ignore>` or :func:`torch.jit.unused <torch.jit.unused>` if needed.
-
-.. testcode::
-
-    # Same behavior as pre-PyTorch 1.2
-    @torch.jit.script
-    def some_fn():
-        return 2
-
-    # Marks a function as ignored, if nothing
-    # ever calls it then this has no effect
-    @torch.jit.ignore
-    def some_fn2():
-        return 2
-
-    # As with ignore, if nothing calls it then it has no effect.
-    # If it is called in script it is replaced with an exception.
-    @torch.jit.unused
-    def some_fn3():
-      import pdb; pdb.set_trace()
-      return 4
-
-    # Doesn't do anything, this function is already
-    # the main entry point
-    @torch.jit.export
-    def some_fn4():
-        return 2
-
-TorchScript Classes
-~~~~~~~~~~~~~~~~~~~
-Everything in a user defined `TorchScript Class`_ is exported by default, functions
-can be decorated with :func:`@torch.jit.ignore <torch.jit.ignore>` if needed.
-
-Attributes
-~~~~~~~~~~
-The TorchScript compiler needs to know the types of `module attributes`_. Most types
-can be inferred from the value of the member. Empty lists and dicts cannot have their
-types inferred and must have their types annotated with `PEP 526-style <https://www.python.org/dev/peps/pep-0526/#class-and-instance-variable-annotations>`_ class annotations.
-If a type cannot be inferred and is not explicilty annotated, it will not be added as an attribute
-to the resulting :class:`ScriptModule`
-
-
-Old API:
-
-.. testcode::
-
-    from typing import Dict
-    import torch
-
-    class MyModule(torch.jit.ScriptModule):
-        def __init__(self):
-            super(MyModule, self).__init__()
-            self.my_dict = torch.jit.Attribute({}, Dict[str, int])
-            self.my_int = torch.jit.Attribute(20, int)
-
-    m = MyModule()
-
-New API:
-
-.. testcode::
-
-    from typing import Dict
-
-    class MyModule(torch.nn.Module):
-        my_dict: Dict[str, int]
-
-        def __init__(self):
-            super(MyModule, self).__init__()
-            # This type cannot be inferred and must be specified
-            self.my_dict = {}
-
-            # The attribute type here is inferred to be `int`
-            self.my_int = 20
-
-        def forward(self):
-            pass
-
-    m = torch.jit.script(MyModule())
-
-Python 2
-^^^^^^^^
-If you are stuck on Python 2 and cannot use the class annotation syntax, you can use the ``__annotations__`` class member to directly apply type annotations.
-
-.. testcode::
-
-    from typing import Dict
-
-    class MyModule(torch.jit.ScriptModule):
-        __annotations__ = {'my_dict': Dict[str, int]}
-
-        def __init__(self):
-            super(MyModule, self).__init__()
-            self.my_dict = {}
-            self.my_int = 20
-
-Constants
-~~~~~~~~~
-The ``Final`` type constructor can be used to mark members as `constant`_. If members are not marked constant, they will be copied to the resulting :class:`ScriptModule` as an attribute. Using ``Final`` opens opportunities for optimization if the value is known to be fixed and gives additional type safety.
-
-Old API:
-
-.. testcode::
-
-    class MyModule(torch.jit.ScriptModule):
-        __constants__ = ['my_constant']
-
-        def __init__(self):
-            super(MyModule, self).__init__()
-            self.my_constant = 2
-
-        def forward(self):
-            pass
-    m = MyModule()
-
-New API:
-
-::
-
-    try:
-        from typing_extensions import Final
-    except:
-        # If you don't have `typing_extensions` installed, you can use a
-        # polyfill from `torch.jit`.
-        from torch.jit import Final
-
-    class MyModule(torch.nn.Module):
-
-        my_constant: Final[int]
-
-        def __init__(self):
-            super(MyModule, self).__init__()
-            self.my_constant = 2
-
-        def forward(self):
-            pass
-
-    m = torch.jit.script(MyModule())
-
-.. _Python 3 type hints:
-
-Variables
-~~~~~~~~~
-Containers are assumed to have type ``Tensor`` and be non-optional (see
-`Default Types`_ for more information). Previously, ``torch.jit.annotate`` was used to
-tell the TorchScript compiler what the type should be. Python 3 style type hints are
-now supported.
-
-.. testcode::
-
-    import torch
-    from typing import Dict, Optional
-
-    @torch.jit.script
-    def make_dict(flag: bool):
-        x: Dict[str, int] = {}
-        x['hi'] = 2
-        b: Optional[int] = None
-        if flag:
-            b = 2
-        return x, b
-
-
-
 TorchScript Language Reference
 -------------------------------
 
@@ -1753,3 +1517,242 @@ Q: I would like to trace module's method but I keep getting this error:
       - On the other hand, invoking ``trace`` with module's instance (e.g. ``my_module``) creates a new module and correctly copies parameters into the new module, so they can accumulate gradients if required.
 
     To trace a specific method on a module, see :func:`torch.jit.trace_module <torch.jit.trace_module>`
+
+Appendix
+--------
+
+Migrating to PyTorch 1.2 Recursive Scripting API
+================================================
+This section details the changes to TorchScript in PyTorch 1.2. If you are new to TorchScript you can
+skip this section. There are two main changes to the TorchScript API with PyTorch 1.2.
+
+1. :func:`torch.jit.script <torch.jit.script>` will now attempt to recursively compile functions,
+methods, and classes that it encounters. Once you call ``torch.jit.script``,
+compilation is "opt-out", rather than "opt-in".
+
+2. ``torch.jit.script(nn_module_instance)`` is now the preferred way to create
+:class:`ScriptModule`\s, instead of inheriting from ``torch.jit.ScriptModule``.
+These changes combine to provide a simpler, easier-to-use API for converting
+your ``nn.Module``\s into :class:`ScriptModule`\s, ready to be optimized and executed in a
+non-Python environment.
+
+The new usage looks like this:
+
+.. testcode::
+
+    import torch
+    import torch.nn as nn
+    import torch.nn.functional as F
+
+    class Model(nn.Module):
+        def __init__(self):
+            super(Model, self).__init__()
+            self.conv1 = nn.Conv2d(1, 20, 5)
+            self.conv2 = nn.Conv2d(20, 20, 5)
+
+        def forward(self, x):
+            x = F.relu(self.conv1(x))
+            return F.relu(self.conv2(x))
+
+    my_model = Model()
+    my_scripted_model = torch.jit.script(my_model)
+
+
+* The module's ``forward`` is compiled by default. Methods called from ``forward`` are lazily compiled in the order they are used in ``forward``.
+* To compile a method other than ``forward`` that is not called from ``forward``, add ``@torch.jit.export``.
+* To stop the compiler from compiling a method, add :func:`@torch.jit.ignore <torch.jit.ignore>` or :func:`@torch.jit.unused <torch.jit.unused>`. ``@ignore`` leaves the
+* method as a call to python, and ``@unused`` replaces it with an exception. ``@ignored`` cannot be exported; ``@unused`` can.
+* Most attribute types can be inferred, so ``torch.jit.Attribute`` is not necessary. For empty container types, annotate their types using `PEP 526-style <https://www.python.org/dev/peps/pep-0526/#class-and-instance-variable-annotations>`_ class annotations.
+* Constants can be marked with a ``Final`` class annotation instead of adding the name of the member to ``__constants__``.
+* Python 3 type hints can be used in place of ``torch.jit.annotate``
+
+As a result of these changes, the following items are considered deprecated and should not appear in new code:
+  * The ``@torch.jit.script_method`` decorator
+  * Classes that inherit from ``torch.jit.ScriptModule``
+  * The ``torch.jit.Attribute`` wrapper class
+  * The ``__constants__`` array
+  * The ``torch.jit.annotate`` function
+
+Modules
+~~~~~~~
+.. warning::
+
+    The :func:`@torch.jit.ignore <torch.jit.ignore>` annotation's behavior changes in
+    PyTorch 1.2. Before PyTorch 1.2 the @ignore decorator was used to make a function
+    or method callable from code that is exported. To get this functionality back,
+    use ``@torch.jit.unused()``. ``@torch.jit.ignore`` is now equivalent
+    to ``@torch.jit.ignore(drop=False)``. See :func:`@torch.jit.ignore <torch.jit.ignore>`
+    and :func:`@torch.jit.unused<torch.jit.unused>` for details.
+
+When passed to the :func:`torch.jit.script <torch.jit.script>` function, a ``torch.nn.Module``\'s data is
+copied to a :class:`ScriptModule` and the TorchScript compiler compiles the module.
+The module's ``forward`` is compiled by default. Methods called from ``forward`` are
+lazily compiled in the order they are used in ``forward``, as well as any
+``@torch.jit.export`` methods.
+
+.. autofunction:: export
+
+Functions
+~~~~~~~~~
+Functions don't change much, they can be decorated with :func:`@torch.jit.ignore <torch.jit.ignore>` or :func:`torch.jit.unused <torch.jit.unused>` if needed.
+
+.. testcode::
+
+    # Same behavior as pre-PyTorch 1.2
+    @torch.jit.script
+    def some_fn():
+        return 2
+
+    # Marks a function as ignored, if nothing
+    # ever calls it then this has no effect
+    @torch.jit.ignore
+    def some_fn2():
+        return 2
+
+    # As with ignore, if nothing calls it then it has no effect.
+    # If it is called in script it is replaced with an exception.
+    @torch.jit.unused
+    def some_fn3():
+      import pdb; pdb.set_trace()
+      return 4
+
+    # Doesn't do anything, this function is already
+    # the main entry point
+    @torch.jit.export
+    def some_fn4():
+        return 2
+
+TorchScript Classes
+~~~~~~~~~~~~~~~~~~~
+Everything in a user defined `TorchScript Class`_ is exported by default, functions
+can be decorated with :func:`@torch.jit.ignore <torch.jit.ignore>` if needed.
+
+Attributes
+~~~~~~~~~~
+The TorchScript compiler needs to know the types of `module attributes`_. Most types
+can be inferred from the value of the member. Empty lists and dicts cannot have their
+types inferred and must have their types annotated with `PEP 526-style <https://www.python.org/dev/peps/pep-0526/#class-and-instance-variable-annotations>`_ class annotations.
+If a type cannot be inferred and is not explicilty annotated, it will not be added as an attribute
+to the resulting :class:`ScriptModule`
+
+
+Old API:
+
+.. testcode::
+
+    from typing import Dict
+    import torch
+
+    class MyModule(torch.jit.ScriptModule):
+        def __init__(self):
+            super(MyModule, self).__init__()
+            self.my_dict = torch.jit.Attribute({}, Dict[str, int])
+            self.my_int = torch.jit.Attribute(20, int)
+
+    m = MyModule()
+
+New API:
+
+.. testcode::
+
+    from typing import Dict
+
+    class MyModule(torch.nn.Module):
+        my_dict: Dict[str, int]
+
+        def __init__(self):
+            super(MyModule, self).__init__()
+            # This type cannot be inferred and must be specified
+            self.my_dict = {}
+
+            # The attribute type here is inferred to be `int`
+            self.my_int = 20
+
+        def forward(self):
+            pass
+
+    m = torch.jit.script(MyModule())
+
+Python 2
+^^^^^^^^
+If you are stuck on Python 2 and cannot use the class annotation syntax, you can use the ``__annotations__`` class member to directly apply type annotations.
+
+.. testcode::
+
+    from typing import Dict
+
+    class MyModule(torch.jit.ScriptModule):
+        __annotations__ = {'my_dict': Dict[str, int]}
+
+        def __init__(self):
+            super(MyModule, self).__init__()
+            self.my_dict = {}
+            self.my_int = 20
+
+Constants
+~~~~~~~~~
+The ``Final`` type constructor can be used to mark members as `constant`_. If members are not marked constant, they will be copied to the resulting :class:`ScriptModule` as an attribute. Using ``Final`` opens opportunities for optimization if the value is known to be fixed and gives additional type safety.
+
+Old API:
+
+.. testcode::
+
+    class MyModule(torch.jit.ScriptModule):
+        __constants__ = ['my_constant']
+
+        def __init__(self):
+            super(MyModule, self).__init__()
+            self.my_constant = 2
+
+        def forward(self):
+            pass
+    m = MyModule()
+
+New API:
+
+::
+
+    try:
+        from typing_extensions import Final
+    except:
+        # If you don't have `typing_extensions` installed, you can use a
+        # polyfill from `torch.jit`.
+        from torch.jit import Final
+
+    class MyModule(torch.nn.Module):
+
+        my_constant: Final[int]
+
+        def __init__(self):
+            super(MyModule, self).__init__()
+            self.my_constant = 2
+
+        def forward(self):
+            pass
+
+    m = torch.jit.script(MyModule())
+
+.. _Python 3 type hints:
+
+Variables
+~~~~~~~~~
+Containers are assumed to have type ``Tensor`` and be non-optional (see
+`Default Types`_ for more information). Previously, ``torch.jit.annotate`` was used to
+tell the TorchScript compiler what the type should be. Python 3 style type hints are
+now supported.
+
+.. testcode::
+
+    import torch
+    from typing import Dict, Optional
+
+    @torch.jit.script
+    def make_dict(flag: bool):
+        x: Dict[str, int] = {}
+        x['hi'] = 2
+        b: Optional[int] = None
+        if flag:
+            b = 2
+        return x, b
+
+


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #31069 [jit/docs] add a warning for script classes
* **#31068 [jit/docs] move migration guide to appendix**

Let's get it out of the early parts now that the recursive API has been
around for a while

Differential Revision: [D18920498](https://our.internmc.facebook.com/intern/diff/D18920498)