### PR TITLE
[jit/docs] add a warning for script classes

### DIFF
--- a/docs/source/jit.rst
+++ b/docs/source/jit.rst
@@ -1624,6 +1624,12 @@ Functions don't change much, they can be decorated with :func:`@torch.jit.ignore
 
 TorchScript Classes
 ~~~~~~~~~~~~~~~~~~~
+.. warning::
+
+    TorchScript class support is experimental. Currently it is best suited
+    for simple record-like types (think a ``NamedTuple`` with methods
+    attached).
+
 Everything in a user defined `TorchScript Class`_ is exported by default, functions
 can be decorated with :func:`@torch.jit.ignore <torch.jit.ignore>` if needed.
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#31069 [jit/docs] add a warning for script classes**
* #31068 [jit/docs] move migration guide to appendix

Just to clarify that they are still experimental.

Differential Revision: [D18920496](https://our.internmc.facebook.com/intern/diff/D18920496)