### PR TITLE
Document WorkerInfo and RpcBackendOptions structures in RPC docs.

### DIFF
--- a/docs/source/rpc.rst
+++ b/docs/source/rpc.rst
@@ -96,6 +96,8 @@ functions as well as create (RRefs) to remote data objects.
 .. autofunction:: shutdown
 .. autoclass:: WorkerInfo
     :members:
+.. autoclass:: RpcBackendOptions
+    :members:
 
 
 .. _rref:

--- a/docs/source/rpc.rst
+++ b/docs/source/rpc.rst
@@ -94,6 +94,8 @@ functions as well as create (RRefs) to remote data objects.
 .. autofunction:: remote
 .. autofunction:: get_worker_info
 .. autofunction:: shutdown
+.. autoclass:: WorkerInfo
+    :members:
 
 
 .. _rref:

--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -35,9 +35,20 @@ PyObject* rpc_init(PyObject* /* unused */) {
   auto module = py::handle(rpc_module).cast<py::module>();
 
   auto rpcBackendOptions =
-      shared_ptr_class_<RpcBackendOptions>(module, "RpcBackendOptions")
-          .def_readwrite("rpc_timeout", &RpcBackendOptions::rpcTimeout)
-          .def_readwrite("init_method", &RpcBackendOptions::initMethod);
+      shared_ptr_class_<RpcBackendOptions>(
+          module,
+          "RpcBackendOptions",
+          R"(A structure encapsulating the options passed into the RPC backend.
+            An instance of this class can be passed in to :meth:`~torch.distributed.rpc.init_rpc` in order to
+            initialize RPC with specific configurations, such as the RPC timeout
+            and init_method to be used. )")
+          .def_readwrite("rpc_timeout", &RpcBackendOptions::rpcTimeout,
+            R"(A `datetime.timedelta` indicating the timeout to use for all RPCs.
+                If an RPC does not complete in this timeframe, it will complete
+                with an exception indicating that it has timed out.)")
+          .def_readwrite("init_method", &RpcBackendOptions::initMethod,
+            R"(URL specifying how to initialize the process group.
+                Default is “env://”)");
 
   auto workerInfo =
       shared_ptr_class_<WorkerInfo>(
@@ -46,16 +57,20 @@ PyObject* rpc_init(PyObject* /* unused */) {
           R"(A structure that encapsulates information of a worker in the system.
             Contains the name and ID of the worker. This class is not meant to
             be constructed directly, rather, an instance can be retrieved
-            through :class:`~torch.distributed.rpc.get_worker_info` and the
-            result can be passed in to functions such as rpc_async, rpc_sync,
-            remote to avoid copying a string on every invocation.)")
+            through :meth:`~torch.distributed.rpc.get_worker_info` and the
+            result can be passed in to functions such as
+            :meth:`~torch.distributed.rpc.rpc_sync`, :class:`~torch.distributed.rpc.rpc_async`,
+            :meth:`~torch.distributed.rpc.remote` to avoid copying a string on every invocation.)")
           .def(
               py::init<std::string, worker_id_t>(),
               py::arg("name"),
               py::arg("id"))
-          .def_readonly("name", &WorkerInfo::name_, R"(The name of the worker.)")
           .def_readonly(
-              "id", &WorkerInfo::id_, R"(Globally unique id to identify the worker.)")
+              "name", &WorkerInfo::name_, R"(The name of the worker.)")
+          .def_readonly(
+              "id",
+              &WorkerInfo::id_,
+              R"(Globally unique id to identify the worker.)")
           .def("__eq__", &WorkerInfo::operator==, py::is_operator())
           // pybind11 suggests the syntax  .def(hash(py::self)), with the
           // unqualified "hash" function call. However the

--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -53,9 +53,9 @@ PyObject* rpc_init(PyObject* /* unused */) {
               py::init<std::string, worker_id_t>(),
               py::arg("name"),
               py::arg("id"))
-          .def_readonly("name", &WorkerInfo::name_, R"(Name fouhvoufdhohouhouhou the worker.)")
+          .def_readonly("name", &WorkerInfo::name_, R"(The name of the worker.)")
           .def_readonly(
-              "id", &WorkerInfo::id_, R"(Globally unique id of the worker.)")
+              "id", &WorkerInfo::id_, R"(Globally unique id to identify the worker.)")
           .def("__eq__", &WorkerInfo::operator==, py::is_operator())
           // pybind11 suggests the syntax  .def(hash(py::self)), with the
           // unqualified "hash" function call. However the

--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -39,9 +39,9 @@ PyObject* rpc_init(PyObject* /* unused */) {
           module,
           "RpcBackendOptions",
           R"(A structure encapsulating the options passed into the RPC backend.
-            An instance of this class can be passed in to :meth:`~torch.distributed.rpc.init_rpc` in order to
-            initialize RPC with specific configurations, such as the RPC timeout
-            and init_method to be used. )")
+            An instance of this class can be passed in to :meth:`~torch.distributed.rpc.init_rpc`
+            in order to initialize RPC with specific configurations, such as the
+             RPC timeout and init_method to be used. )")
           .def_readwrite("rpc_timeout", &RpcBackendOptions::rpcTimeout,
             R"(A `datetime.timedelta` indicating the timeout to use for all RPCs.
                 If an RPC does not complete in this timeframe, it will complete
@@ -60,7 +60,8 @@ PyObject* rpc_init(PyObject* /* unused */) {
             through :meth:`~torch.distributed.rpc.get_worker_info` and the
             result can be passed in to functions such as
             :meth:`~torch.distributed.rpc.rpc_sync`, :class:`~torch.distributed.rpc.rpc_async`,
-            :meth:`~torch.distributed.rpc.remote` to avoid copying a string on every invocation.)")
+            :meth:`~torch.distributed.rpc.remote` to avoid copying a string on
+            every invocation.)")
           .def(
               py::init<std::string, worker_id_t>(),
               py::arg("name"),

--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -43,12 +43,17 @@ PyObject* rpc_init(PyObject* /* unused */) {
       shared_ptr_class_<WorkerInfo>(
           module,
           "WorkerInfo",
-          R"(Encapsulates information of a worker in the system.)")
+          R"(A structure that encapsulates information of a worker in the system.
+            Contains the name and ID of the worker. This class is not meant to
+            be constructed directly, rather, an instance can be retrieved
+            through :class:`~torch.distributed.rpc.get_worker_info` and the
+            result can be passed in to functions such as rpc_async, rpc_sync,
+            remote to avoid copying a string on every invocation.)")
           .def(
               py::init<std::string, worker_id_t>(),
               py::arg("name"),
               py::arg("id"))
-          .def_readonly("name", &WorkerInfo::name_, R"(Name of the worker.)")
+          .def_readonly("name", &WorkerInfo::name_, R"(Name fouhvoufdhohouhouhou the worker.)")
           .def_readonly(
               "id", &WorkerInfo::id_, R"(Globally unique id of the worker.)")
           .def("__eq__", &WorkerInfo::operator==, py::is_operator())

--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -42,13 +42,17 @@ PyObject* rpc_init(PyObject* /* unused */) {
             An instance of this class can be passed in to :meth:`~torch.distributed.rpc.init_rpc`
             in order to initialize RPC with specific configurations, such as the
              RPC timeout and init_method to be used. )")
-          .def_readwrite("rpc_timeout", &RpcBackendOptions::rpcTimeout,
-            R"(A `datetime.timedelta` indicating the timeout to use for all RPCs.
+          .def_readwrite(
+              "rpc_timeout",
+              &RpcBackendOptions::rpcTimeout,
+              R"(A `datetime.timedelta` indicating the timeout to use for all RPCs.
                 If an RPC does not complete in this timeframe, it will complete
                 with an exception indicating that it has timed out.)")
-          .def_readwrite("init_method", &RpcBackendOptions::initMethod,
-            R"(URL specifying how to initialize the process group.
-                Default is “env://”)");
+          .def_readwrite(
+              "init_method",
+              &RpcBackendOptions::initMethod,
+              R"(URL specifying how to initialize the process group.
+                Default is env://)");
 
   auto workerInfo =
       shared_ptr_class_<WorkerInfo>(


### PR DESCRIPTION
We mention `WorkerInfo` and `RpcBackendOptions` in a couple of different locations in our docs, and these are public classes that the user may use, so we should add the class to the documentation. 
<img width="978" alt="Screen Shot 2019-12-10 at 1 42 22 PM" src="https://user-images.githubusercontent.com/8039770/70571759-47db2080-1b53-11ea-9d61-c83985a29dd9.png">
