### PR TITLE
add conversion functions to embedding tables

### DIFF
--- a/caffe2/operators/fused_rowwise_8bit_conversion_ops.cc
+++ b/caffe2/operators/fused_rowwise_8bit_conversion_ops.cc
@@ -21,8 +21,9 @@ REGISTER_CPU_OPERATOR(
     FloatToFused8BitRowwiseQuantized,
     FloatToFused8BitRowwiseQuantizedOp<
         float,
+        float,
         nullptr,
-        false, /* HAS_CONVERT */
+        false,
         CPUContext>);
 OPERATOR_SCHEMA(FloatToFused8BitRowwiseQuantized)
     .NumInputs(1)
@@ -41,21 +42,56 @@ Applies 8-bit row-wise quantization by determining the range
 (maximum - minimum) and offset (minimum value) of each row in the input
 matrix, and then scaling each element to an 8-bit number between 0 and
 255. To later de-quantize values, the scale (range / 255) and offset
-(bias) are stored alongside the data. More precisely, the first 4 bytes
-of each row in the output matrix are a 32-bit float storing the scale,
-the next 4 bytes store the bias as a 32-bit float, and all remaining
-bytes in the row encode single quantized values.)
+(bias) are stored alongside the data. More precisely, each row contains
+int8 elements for each quantized element, and the last 8 bytes
+of each row in the output matrix are a float storing the scale
+followed by another float containing the scale.)
 )DOC")
     .Input(0, "input", "Float32 input data")
     .Output(0, "output", "Fused scale, bias and quantized data");
 NO_GRADIENT(FloatToFused8BitRowwiseQuantized);
 
 REGISTER_CPU_OPERATOR(
+    FloatToFused8BitRowwiseQuantizedHalfScaleBias,
+    FloatToFused8BitRowwiseQuantizedOp<
+        float,
+        at::Half,
+        nullptr,
+        false,
+        CPUContext>);
+OPERATOR_SCHEMA(FloatToFused8BitRowwiseQuantizedHalfScaleBias)
+    .NumInputs(1)
+    .NumOutputs(1)
+    .TensorInferenceFunction([](const OperatorDef& /* def */,
+                                const vector<TensorShape>& in) {
+      vector<TensorShape> out;
+      TensorShape X = in[0];
+      X.set_dims(1, X.dims(1) + 4);
+      out.push_back(std::move(X));
+      out[0].set_data_type(TensorProto_DataType_UINT8);
+      return out;
+    })
+    .SetDoc(R"DOC(
+Applies 8-bit row-wise quantization by determining the range
+(maximum - minimum) and offset (minimum value) of each row in the input
+matrix, and then scaling each element to an 8-bit number between 0 and
+255. To later de-quantize values, the scale (range / 255) and offset
+(bias) are stored alongside the data. More precisely, each row contains
+int8 elements for each quantized element, and the last 4 bytes
+of each row in the output matrix are a half float storing the scale
+followed by another half float containing the scale.)
+)DOC")
+    .Input(0, "input", "Float32 input data")
+    .Output(0, "output", "Fused scale, bias and quantized data");
+NO_GRADIENT(FloatToFused8BitRowwiseQuantizedHalfScaleBias);
+
+REGISTER_CPU_OPERATOR(
     HalfFloatToFused8BitRowwiseQuantized,
     FloatToFused8BitRowwiseQuantizedOp<
         at::Half,
+        float,
         convertfp16fp32,
-        true, /* HAS_CONVERT*/
+        true,
         CPUContext>);
 OPERATOR_SCHEMA(HalfFloatToFused8BitRowwiseQuantized)
     .NumInputs(1)
@@ -74,21 +110,56 @@ Applies 8-bit row-wise quantization by determining the range
 (maximum - minimum) and offset (minimum value) of each row in the input
 matrix, and then scaling each element to an 8-bit number between 0 and
 255. To later de-quantize values, the scale (range / 255) and offset
-(bias) are stored alongside the data. More precisely, the first 4 bytes
-of each row in the output matrix are a 32-bit float storing the scale,
-the next 4 bytes store the bias as a 32-bit float, and all remaining
-bytes in the row encode single quantized values.)
+(bias) are stored alongside the data. More precisely, each row contains
+int8 elements for each quantized element, and the last 8 bytes
+of each row in the output matrix are a float storing the scale
+followed by another float containing the scale.)
 )DOC")
     .Input(0, "input", "Float16 input data")
     .Output(0, "output", "Fused scale, bias and quantized data");
 NO_GRADIENT(HalfFloatToFused8BitRowwiseQuantized);
 
 REGISTER_CPU_OPERATOR(
+    HalfFloatToFused8BitRowwiseQuantizedHalfScaleBias,
+    FloatToFused8BitRowwiseQuantizedOp<
+        at::Half,
+        at::Half,
+        convertfp16fp32,
+        true,
+        CPUContext>);
+OPERATOR_SCHEMA(HalfFloatToFused8BitRowwiseQuantizedHalfScaleBias)
+    .NumInputs(1)
+    .NumOutputs(1)
+    .TensorInferenceFunction([](const OperatorDef& /* def */,
+                                const vector<TensorShape>& in) {
+      vector<TensorShape> out;
+      TensorShape X = in[0];
+      X.set_dims(1, X.dims(1) + 4);
+      out.push_back(std::move(X));
+      out[0].set_data_type(TensorProto_DataType_UINT8);
+      return out;
+    })
+    .SetDoc(R"DOC(
+Applies 8-bit row-wise quantization by determining the range
+(maximum - minimum) and offset (minimum value) of each row in the input
+matrix, and then scaling each element to an 8-bit number between 0 and
+255. To later de-quantize values, the scale (range / 255) and offset
+(bias) are stored alongside the data. More precisely, each row contains
+int8 elements for each quantized element, and the last 4 bytes
+of each row in the output matrix are a float storing the scale
+followed by another float containing the scale.)
+)DOC")
+    .Input(0, "input", "Float16 input data")
+    .Output(0, "output", "Fused scale, bias and quantized data");
+NO_GRADIENT(HalfFloatToFused8BitRowwiseQuantizedHalfScaleBias);
+
+REGISTER_CPU_OPERATOR(
     Fused8BitRowwiseQuantizedToFloat,
     Fused8BitRowwiseQuantizedToFloatOp<
         float,
+        float,
         nullptr,
-        false, /* HAS_CONVERT */
+        false,
         CPUContext>);
 OPERATOR_SCHEMA(Fused8BitRowwiseQuantizedToFloat)
     .NumInputs(1)
@@ -121,11 +192,50 @@ the original, un-quantized floating point values.
 NO_GRADIENT(Fused8BitRowwiseQuantizedToFloat);
 
 REGISTER_CPU_OPERATOR(
+    Fused8BitRowwiseQuantizedHalfScaleBiasToFloat,
+    Fused8BitRowwiseQuantizedToFloatOp<
+        float,
+        at::Half,
+        nullptr,
+        false,
+        CPUContext>);
+OPERATOR_SCHEMA(Fused8BitRowwiseQuantizedHalfScaleBiasToFloat)
+    .NumInputs(1)
+    .NumOutputs(1)
+    .TensorInferenceFunction([](const OperatorDef& /* def */,
+                                const vector<TensorShape>& in) {
+      vector<TensorShape> out;
+      TensorShape X = in[0];
+      X.set_dims(1, X.dims(1) - 4);
+      out.push_back(std::move(X));
+      out[0].set_data_type(TensorProto_DataType_FLOAT);
+      return out;
+    })
+    .SetDoc(R"DOC(
+De-quantizes the result of the
+FloatToFused8BitRowwiseQuantized operator. The input is expected to
+encode the scale as a 16-bit float in the second to the last 2 bytes of each
+row, followed by the bias as a 16-bit float in the next 2 bytes, and the
+quantized values in the preceding bytes of the row. The output is a
+matrix containing only the values, but de-quantized. De-quantization is
+performed by multiplying each value by its row's scale and bias
+parameters. The de-quantized values will thus not be exactly equal to
+the original, un-quantized floating point values.
+)DOC")
+    .Input(
+        0,
+        "scale_bias_quantized_input",
+        "Fused scale, bias and quantized data")
+    .Output(0, "float_output", "Float32 data");
+NO_GRADIENT(Fused8BitRowwiseQuantizedHalfScaleBiasToFloat);
+
+REGISTER_CPU_OPERATOR(
     Fused8BitRowwiseQuantizedToHalfFloat,
     Fused8BitRowwiseQuantizedToFloatOp<
         at::Half,
+        float,
         convertfp32fp16,
-        true, /* HAS_CONVERT */
+        true,
         CPUContext>);
 OPERATOR_SCHEMA(Fused8BitRowwiseQuantizedToHalfFloat)
     .NumInputs(1)
@@ -157,6 +267,44 @@ the original, un-quantized floating point values.
     .Output(0, "float16_output", "Float16 data");
 NO_GRADIENT(Fused8BitRowwiseQuantizedToHalfFloat);
 
+REGISTER_CPU_OPERATOR(
+    Fused8BitRowwiseQuantizedHalfScaleBiasToHalfFloat,
+    Fused8BitRowwiseQuantizedToFloatOp<
+        float,
+        at::Half,
+        nullptr,
+        false,
+        CPUContext>);
+OPERATOR_SCHEMA(Fused8BitRowwiseQuantizedHalfScaleBiasToHalfFloat)
+    .NumInputs(1)
+    .NumOutputs(1)
+    .TensorInferenceFunction([](const OperatorDef& /* def */,
+                                const vector<TensorShape>& in) {
+      vector<TensorShape> out;
+      TensorShape X = in[0];
+      X.set_dims(1, X.dims(1) - 4);
+      out.push_back(std::move(X));
+      out[0].set_data_type(TensorProto_DataType_FLOAT);
+      return out;
+    })
+    .SetDoc(R"DOC(
+De-quantizes the result of the
+FloatToFused8BitRowwiseQuantized operator. The input is expected to
+encode the scale as a 16-bit float in the second to the last 2 bytes of each
+row, followed by the bias as a 16-bit float in the next 2 bytes, and the
+quantized values in the preceding bytes of the row. The output is a
+matrix containing only the values, but de-quantized. De-quantization is
+performed by multiplying each value by its row's scale and bias
+parameters. The de-quantized values will thus not be exactly equal to
+the original, un-quantized floating point values.
+)DOC")
+    .Input(
+        0,
+        "scale_bias_quantized_input",
+        "Fused scale, bias and quantized data")
+    .Output(0, "float_output", "Float32 data");
+NO_GRADIENT(Fused8BitRowwiseQuantizedHalfScaleBiasToHalfFloat);
+
 } // namespace caffe2
 
 // To workaround comma
@@ -164,8 +312,9 @@ NO_GRADIENT(Fused8BitRowwiseQuantizedToHalfFloat);
 using Fused8BitRowwiseQuantizedToFloatCPUOp =
     caffe2::Fused8BitRowwiseQuantizedToFloatOp<
         float,
+        float,
         nullptr,
-        false, /* HAS_CONVERT */
+        false,
         caffe2::CPUContext>;
 
 C10_EXPORT_CAFFE2_OP_TO_C10_CPU(

--- a/caffe2/perfkernels/fused_8bit_rowwise_conversion.cc
+++ b/caffe2/perfkernels/fused_8bit_rowwise_conversion.cc
@@ -1,5 +1,6 @@
 #include "fused_8bit_rowwise_conversion.h"
 
+#include <c10/util/Half.h>
 #include <algorithm>
 #include <cmath>
 
@@ -93,6 +94,94 @@ void Fused8BitRowwiseQuantizedToFloat(
       output);
   BASE_DO(
       Fused8BitRowwiseQuantizedToFloat,
+      input,
+      input_rows,
+      input_columns,
+      output);
+}
+
+void FloatToFused8BitRowwiseQuantizedSBHalf__base(
+    const float* input,
+    int input_rows,
+    int input_columns,
+    std::uint8_t* output) {
+  int output_columns = input_columns + 2 * sizeof(at::Half);
+  for (std::size_t row = 0; row < input_rows; ++row) {
+    const float* input_row = input + row * input_columns;
+    std::uint8_t* output_row = output + row * output_columns;
+    at::Half* output_row_scale_bias =
+        reinterpret_cast<at::Half*>(output_row + input_columns);
+
+    float Xmin = *std::min_element(input_row, input_row + input_columns);
+    float Xmax = *std::max_element(input_row, input_row + input_columns);
+
+    Xmin = static_cast<at::Half>(Xmin);
+    const float range = Xmax - Xmin;
+
+    at::Half scale = range == 0 ? 1.0f : range / 255.0;
+    if (scale == 0) {
+      // Corner case handling when Xmax == Xmin
+      // Any scale would work because X - Xmin will be 0 for all X
+      scale = 1.0f;
+    }
+
+    output_row_scale_bias[0] = scale;
+    output_row_scale_bias[1] = Xmin;
+    for (std::size_t col = 0; col < input_columns; ++col) {
+      float X = input_row[col];
+      std::uint8_t quantized =
+          std::max(0, std::min<int>(std::lrintf((X - Xmin) / scale), 255));
+      output_row[col] = quantized;
+    }
+  }
+}
+
+void Fused8BitRowwiseQuantizedSBHalfToFloat__base(
+    const std::uint8_t* input,
+    int input_rows,
+    int input_columns,
+    float* output) {
+  int output_columns = input_columns - 2 * sizeof(at::Half);
+
+  for (std::size_t row = 0; row < input_rows; ++row) {
+    const std::uint8_t* input_row = input + row * input_columns;
+    const at::Half* input_row_scale_bias =
+        reinterpret_cast<const at::Half*>(input_row + output_columns);
+    float* output_row = output + row * output_columns;
+
+    for (std::size_t col = 0; col < output_columns; ++col) {
+      output_row[col] = (int)input_row[col] * input_row_scale_bias[0] +
+          input_row_scale_bias[1];
+    }
+  }
+}
+
+decltype(FloatToFused8BitRowwiseQuantizedSBHalf__base)
+    FloatToFused8BitRowwiseQuantizedSBHalf__avx2_fma;
+void FloatToFused8BitRowwiseQuantizedSBHalf(
+    const float* input,
+    int input_rows,
+    int input_columns,
+    std::uint8_t* output) {
+  // TODO: Add AVX2 version
+  BASE_DO(
+      FloatToFused8BitRowwiseQuantizedSBHalf,
+      input,
+      input_rows,
+      input_columns,
+      output);
+}
+
+decltype(Fused8BitRowwiseQuantizedSBHalfToFloat__base)
+    Fused8BitRowwiseQuantizedSBHalfToFloat__avx2_fma;
+void Fused8BitRowwiseQuantizedSBHalfToFloat(
+    const std::uint8_t* input,
+    int input_rows,
+    int input_columns,
+    float* output) {
+  // TODO: Add AVX2 version
+  BASE_DO(
+      Fused8BitRowwiseQuantizedSBHalfToFloat,
       input,
       input_rows,
       input_columns,

--- a/caffe2/perfkernels/fused_8bit_rowwise_conversion.h
+++ b/caffe2/perfkernels/fused_8bit_rowwise_conversion.h
@@ -16,4 +16,16 @@ void Fused8BitRowwiseQuantizedToFloat(
     int input_columns,
     float* output);
 
+void FloatToFused8BitRowwiseQuantizedSBHalf(
+    const float* input,
+    int input_rows,
+    int input_columns,
+    std::uint8_t* output);
+
+void Fused8BitRowwiseQuantizedSBHalfToFloat(
+    const std::uint8_t* input,
+    int input_rows,
+    int input_columns,
+    float* output);
+
 } // namespace caffe2

--- a/caffe2/python/operator_test/shape_inference_test.py
+++ b/caffe2/python/operator_test/shape_inference_test.py
@@ -528,6 +528,17 @@ class TestShapeInference(test_util.TestCase):
         # TODO: find a tighter bound
         assert(np.allclose(x, x_recovered, atol=1e-2))
 
+        model = model_helper.ModelHelper(name="fp32_int8_conversion_test")
+        model.FloatToFused8BitRowwiseQuantizedHalfScaleBias('x', 'x_8bit')
+        model.Fused8BitRowwiseQuantizedHalfScaleBiasToFloat('x_8bit', 'x_recovered')
+        workspace.FeedBlob('x', np.random.rand(100, 150).astype(np.float32))
+        self.InferTensorRunAndCompare(model)
+        x = workspace.FetchBlob('x')
+        x_recovered = workspace.FetchBlob('x_recovered')
+        # TODO: find a tighter bound
+        assert(np.allclose(x, x_recovered, atol=1e-2))
+
+
     def testHalfInt8Conversion(self):
         model = model_helper.ModelHelper(name="fp16_int8_conversion_test")
         model.HalfFloatToFused8BitRowwiseQuantized('x', 'x_8bit')
@@ -538,6 +549,17 @@ class TestShapeInference(test_util.TestCase):
         x_recovered = workspace.FetchBlob('x_recovered')
         # TODO: find a tighter bound
         assert(np.allclose(x, x_recovered, atol=1e-2))
+
+        model = model_helper.ModelHelper(name="fp16_int8_conversion_test")
+        model.HalfFloatToFused8BitRowwiseQuantizedHalfScaleBias('x', 'x_8bit')
+        model.Fused8BitRowwiseQuantizedHalfScaleBiasToHalfFloat('x_8bit', 'x_recovered')
+        workspace.FeedBlob('x', np.random.rand(100, 150).astype(np.float16))
+        self.InferTensorRunAndCompare(model)
+        x = workspace.FetchBlob('x')
+        x_recovered = workspace.FetchBlob('x_recovered')
+        # TODO: find a tighter bound
+        assert(np.allclose(x, x_recovered, atol=1e-2))
+
 
     def testLearningRateOp(self):
         net = core.Net("lr_test")


### PR DESCRIPTION
Summary: add (fp32/fp16)<->(int8 rowwise quantized fp32/fp16 scale biases)

Test Plan:
added unit tests
enhanced shape inference tests

Differential Revision: D18920547

