### PR TITLE
[ci][fix] Fix CircleCI behavior for non-leaf stack PRs

### DIFF
--- a/.circleci/scripts/should_run_job.sh
+++ b/.circleci/scripts/should_run_job.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -exu -o pipefail
 
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+#SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 # Check if we should actually run
 echo "BUILD_ENVIRONMENT: ${BUILD_ENVIRONMENT:-}"
@@ -17,7 +17,7 @@ if ! [ -e "$SCRIPT_DIR/COMMIT_MSG" ]; then
   echo "You should be running the copy in ~/workspace; SCRIPT_DIR=$SCRIPT_DIR"
   exit 1
 fi
-if [ -n "${CIRCLE_PULL_REQUEST:-}" ]; then
+if [ -n "${CIRCLE_PULL_REQUEST:-}" ] || [[ ${CIRCLE_BRANCH:-} =~ ^gh/.* ]]; then
   if [[ $CIRCLE_BRANCH != "ci-all/"* ]] && [[ $CIRCLE_BRANCH != "nightly" ]] &&  [[ $CIRCLE_BRANCH != "postnightly" ]] ; then
     # Don't swallow "script doesn't exist
     [ -e "$SCRIPT_DIR/should_run_job.py"  ]

--- a/.circleci/scripts/should_run_job.sh
+++ b/.circleci/scripts/should_run_job.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -exu -o pipefail
 
-#SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 # Check if we should actually run
 echo "BUILD_ENVIRONMENT: ${BUILD_ENVIRONMENT:-}"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #31090 [NFC] Dummy commit PR to make previous PR in stack not-leaf
* **#31088 [ci][fix] Fix CircleCI behavior for non-leaf stack PRs**


Original issue:
https://github.com/pytorch/pytorch/issues/31027

The problem is that for the stacks of PRs for non-leaf PRs circleCI does not set environment variable `CIRCLE_PULL_REQUEST` which is used to filter out some jobs that should run only on `master`.

(Android job for master includes alll 4 abis (x86, x86_64, armeabi-v7a, arm64-v8a)  and gradle build tries to get results from all 4 abis, for PRs we run only x86 build for resources economy. Thats why not filtered master android job fails as abis apart x86 were not scheduled)

env variable `CIRCLE_BRANCH ` is set fine and can be used as a workaround to distinguish that this is PR (published with ghstack).

Differential Revision: [D18966385](https://our.internmc.facebook.com/intern/diff/D18966385)