### PR TITLE
[jit]C++ API parity: isinf

### DIFF
--- a/aten/src/ATen/native/TensorCompare.cpp
+++ b/aten/src/ATen/native/TensorCompare.cpp
@@ -87,6 +87,16 @@ Tensor isnan(const Tensor& self) {
   return self != self;
 }
 
+Tensor isinf(const Tensor &self) {
+  // Integral tensor types are always not inf
+  if (isIntegralType(self.scalar_type())) {
+    return at::zeros_like(self, at::kBool, at::MemoryFormat::Preserve);
+  }
+  return AT_DISPATCH_FLOATING_TYPES_AND_HALF(self.scalar_type(), "isinf", [&]() {
+    return self.abs() == std::numeric_limits<scalar_t>::infinity();
+  });
+}
+
 Tensor isfinite(const Tensor& self) {
   // Integral tensor types are finite
   if (!self.is_floating_point()) {

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -6521,3 +6521,9 @@
   variants: function
   device_guard: False
   supports_named_tensor: True
+
+- func: isinf(Tensor self) -> Tensor
+  use_c10_dispatcher: full
+  variants: function
+  device_guard: False
+  supports_named_tensor: True

--- a/test/cpp/api/functional.cpp
+++ b/test/cpp/api/functional.cpp
@@ -2470,6 +2470,76 @@ TEST_F(FunctionalTest, isfinite_CUDA) {
   test_isfinite<torch::kFloat16, c10::Half>(device);
 }
 
+template<c10::ScalarType S, typename T>
+void test_isinf(const at::Device& device) {
+  const std::vector<T> values = {
+    std::numeric_limits<T>::lowest(),
+    0, 1, 42,
+    std::numeric_limits<T>::min(),
+    std::numeric_limits<T>::max()
+  };
+  for (const auto value : values) {
+    const auto x = torch::full({3, 3}, value, torch::TensorOptions().dtype(S).device(device));
+    ASSERT_FALSE(torch::isinf(x).all().template item<bool>());
+  }
+  if (std::numeric_limits<T>::has_infinity) {
+    const auto inf = std::numeric_limits<T>::infinity();
+    const auto x = torch::tensor({
+      -inf,
+      std::numeric_limits<T>::lowest(),
+      static_cast<T>(0),
+      static_cast<T>(1),
+      static_cast<T>(42),
+      std::numeric_limits<T>::min(),
+      std::numeric_limits<T>::max(),
+      inf
+    }, torch::TensorOptions().dtype(S).device(device));
+    ASSERT_TRUE(torch::allclose(
+      // torch::allclose does not support comparing torch::kBool
+      torch::isinf(x).toType(torch::kInt),
+      torch::tensor(
+        {true, false, false, false, false, false, false, true},
+        torch::TensorOptions().device(device)
+      ).toType(torch::kInt)
+    ));
+  }
+  if (std::numeric_limits<T>::has_quiet_NaN) {
+    const auto x = torch::tensor({
+      std::numeric_limits<T>::quiet_NaN()
+    }, torch::TensorOptions().dtype(S).device(device));
+    ASSERT_FALSE(torch::isinf(x).all().template item<bool>());
+  }
+  if (std::numeric_limits<T>::has_signaling_NaN) {
+    const auto x = torch::tensor({
+      std::numeric_limits<T>::signaling_NaN()
+    }, torch::TensorOptions().dtype(S).device(device));
+    ASSERT_FALSE(torch::isinf(x).all().template item<bool>());
+  }
+}
+
+TEST_F(FunctionalTest, isinf) {
+  const at::Device device("cpu");
+  test_isinf<torch::kUInt8, uint8_t>(device);
+  test_isinf<torch::kInt8, int8_t>(device);
+  test_isinf<torch::kInt16, int16_t>(device);
+  test_isinf<torch::kInt32, int32_t>(device);
+  test_isinf<torch::kInt64, int64_t>(device);
+  test_isinf<torch::kFloat32, float>(device);
+  test_isinf<torch::kFloat64, double>(device);
+}
+
+TEST_F(FunctionalTest, isinf_CUDA) {
+  const at::Device device("cuda");
+  test_isinf<torch::kUInt8, uint8_t>(device);
+  test_isinf<torch::kInt8, int8_t>(device);
+  test_isinf<torch::kInt16, int16_t>(device);
+  test_isinf<torch::kInt32, int32_t>(device);
+  test_isinf<torch::kInt64, int64_t>(device);
+  test_isinf<torch::kFloat32, float>(device);
+  test_isinf<torch::kFloat64, double>(device);
+  test_isinf<torch::kFloat16, c10::Half>(device);
+}
+
 TEST_F(FunctionalTest, BCEWithLogitsLoss) {
   using namespace at::Reduction;
   { // test BCE with logits raises if target and input are different size

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -2437,6 +2437,22 @@ Example::
     tensor(1.9073e-06)
 """.format(**common_args))
 
+add_docstr(torch.isinf,
+           r"""
+Returns a new tensor with boolean elements representing if each element is `+/-INF` or not.
+
+    Arguments:
+        tensor (Tensor): A tensor to check
+
+    Returns:
+        Tensor: ``A torch.Tensor with dtype torch.bool`` containing a True at each location of `+/-INF` elements and False otherwise
+
+    Example::
+
+        >>> torch.isinf(torch.tensor([1, float('inf'), 2, float('-inf'), float('nan')]))
+        tensor([False,  True,  False,  True,  False])
+""")
+
 add_docstr(torch.isfinite,
            r"""
 Returns a new tensor with boolean elements representing if each element is `Finite` or not.

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -12,7 +12,6 @@ __all__ = [
     'cdist',
     'chain_matmul',
     'einsum',
-    'isinf',
     'lu',
     'lu_unpack',
     'norm',
@@ -256,32 +255,6 @@ Examples::
         # the old interface of passing the operands as one list argument
         operands = operands[0]
     return torch._C._VariableFunctions.einsum(equation, operands)
-
-
-def _isinf_dispatcher(tensor):
-    return (tensor,)
-
-
-@torch_function_dispatch(_isinf_dispatcher)
-def isinf(tensor):
-    r"""Returns a new tensor with boolean elements representing if each element is `+/-INF` or not.
-
-    Arguments:
-        tensor (Tensor): A tensor to check
-
-    Returns:
-        Tensor: ``A torch.Tensor with dtype torch.bool`` containing a True at each location of `+/-INF` elements and False otherwise
-
-    Example::
-
-        >>> torch.isinf(torch.tensor([1, float('inf'), 2, float('-inf'), float('nan')]))
-        tensor([False,  True,  False,  True,  False])
-    """
-    if not isinstance(tensor, torch.Tensor):
-        raise TypeError("The argument is not a tensor: {}".format(repr(tensor)))
-    if tensor.dtype in [torch.uint8, torch.int8, torch.int16, torch.int32, torch.int64]:
-        return torch.zeros_like(tensor, dtype=torch.bool, memory_format=torch.legacy_contiguous_format)
-    return tensor.abs() == inf
 
 
 def _meshgrid_dispatcher(*tensors, **kwargs):

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -1,6 +1,5 @@
 import torch
 import torch.nn.functional as F
-from torch._six import inf
 from itertools import product
 
 from ._overrides import torch_function_dispatch


### PR DESCRIPTION
fixes #31021, port the legacy binding method of `isinf` to C++ therefore support JIT