### PR TITLE
Disable flaky test_process_group_debug_info

### DIFF
--- a/test/rpc_test.py
+++ b/test/rpc_test.py
@@ -1169,6 +1169,7 @@ class RpcTest(RpcAgentTestFixture):
         # checking debug info
         dist.barrier()
 
+    @unittest.skip("Test is flaky, see https://github.com/pytorch/pytorch/issues/31112")
     @dist_init
     @requires_process_group_agent("PROCESS_GROUP rpc backend specific test, skip")
     def test_process_group_debug_info(self):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #31114 Re-enable test_process_group_debug_info by adding barriers before and after every check
* **#31113 Disable flaky test_process_group_debug_info**

Differential Revision: [D18932365](https://our.internmc.facebook.com/intern/diff/D18932365)