### PR TITLE
Back out "[bert/RoBERTa] Optimize LayerNorm with explicit vectorization using Vec256"

### DIFF
--- a/aten/src/ATen/native/cpu/layer_norm_kernel.cpp
+++ b/aten/src/ATen/native/cpu/layer_norm_kernel.cpp
@@ -5,8 +5,6 @@
 #include <ATen/ATen.h>
 #include <ATen/CPUApplyUtils.h>
 #include <ATen/Dispatch.h>
-#include <ATen/cpu/vec256/functional.h>
-#include <ATen/cpu/vec256/vec256.h>
 
 namespace at {
 namespace native {
@@ -24,11 +22,10 @@ void LayerNormKernelImplInternal(
     Tensor* Y,
     Tensor* mean,
     Tensor* rstd) {
-  using Vec = vec256::Vec256<T>;
   DCHECK_EQ(X.numel(), M * N);
   DCHECK(!gamma.defined() || gamma.numel() == N);
   DCHECK(!beta.defined() || beta.numel() == N);
-  T* X_data = X.data_ptr<T>();
+  const T* X_data = X.data_ptr<T>();
   const T* gamma_data = gamma.defined() ? gamma.data_ptr<T>() : nullptr;
   const T* beta_data = beta.defined() ? beta.data_ptr<T>() : nullptr;
   T* Y_data = Y->data_ptr<T>();
@@ -39,17 +36,14 @@ void LayerNormKernelImplInternal(
   const bool beta_null = beta_data == nullptr;
   at::parallel_for(0, M, 1, [&](int64_t start, int64_t end) {
     for (int64_t i = start; i < end; ++i) {
-      T* X_ptr = X_data + i * N;
+      const T* X_ptr = X_data + i * N;
       T* Y_ptr = Y_data + i * N;
-      T mean_val = vec256::reduce_all<T>(
-          [](Vec& x, Vec& y) { return x + y; },
-          X_ptr,
-          N);
-      T rstd_val = vec256::map_reduce_all<T>(
-          [](Vec x) { return x * x; },
-          [](Vec x, Vec y) { return x + y; },
-          X_ptr,
-          N);
+      T mean_val = T(0);
+      T rstd_val = T(0);
+      for (int64_t j = 0; j < N; ++j) {
+        mean_val += X_ptr[j];
+        rstd_val += X_ptr[j] * X_ptr[j];
+      }
       mean_val *= c;
       rstd_val = std::max(rstd_val * c - mean_val * mean_val, T(0));
       rstd_val = T(1) / std::sqrt(rstd_val + eps);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#31118 Back out "[bert/RoBERTa] Optimize LayerNorm with explicit vectorization using Vec256"**

Original commit changeset: f4cfed6e62ba

Differential Revision: [D18933897](https://our.internmc.facebook.com/intern/diff/D18933897/)