### PR TITLE
Speed up `Tensor::has_names` for unnamed tensors

### DIFF
--- a/aten/src/ATen/templates/TensorMethods.h
+++ b/aten/src/ATen/templates/TensorMethods.h
@@ -93,6 +93,11 @@ inline const NamedTensorMeta* Tensor::get_named_tensor_meta() const {
 }
 
 inline bool Tensor::has_names() const {
+  // If a user is using unnamed tensors, then we can short-circuit right here.
+  // Otherwise, impl::has_names attempts to retrieve names.
+  if (!impl_->has_named_tensor_meta()) {
+    return false;
+  }
   return impl::has_names(unsafeGetTensorImpl());
 }
 

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -843,6 +843,10 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
     return named_tensor_meta_.get();
   }
 
+  bool has_named_tensor_meta() {
+    return named_tensor_meta_ != nullptr;
+  }
+
 
   // NOTE [ TensorImpl Shallow-Copying ]
   //


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #31120 Add dill>=0.3.1 as testing dependency
* **#31119 Speed up `Tensor::has_names` for unnamed tensors**

Test Plan:
- run tests