### PR TITLE
Add dill>=0.3.1 as testing dependency

### DIFF
--- a/.circleci/docker/common/install_travis_python.sh
+++ b/.circleci/docker/common/install_travis_python.sh
@@ -88,6 +88,9 @@ if [ -n "$TRAVIS_PYTHON_VERSION" ]; then
   # Install psutil for dataloader tests
   as_jenkins pip install psutil
 
+  # Install dill for serialization tests
+  as_jenkins pip install "dill>=0.3.1"
+
   # Cleanup package manager
   apt-get autoclean && apt-get clean
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#31120 Add dill>=0.3.1 as testing dependency**
* #31119 Speed up `Tensor::has_names` for unnamed tensors

For https://github.com/pytorch/pytorch/pull/30985 .

Test Plan:
- run `pip install "dill>=0.3.1"` locally, check that it actually
installs dill>=0.3.1.

Differential Revision: [D18934857](https://our.internmc.facebook.com/intern/diff/D18934857)