### PR TITLE
use earlier docker image to make sure generated binary size is small

### DIFF
--- a/.circleci/cimodel/data/binary_build_definitions.py
+++ b/.circleci/cimodel/data/binary_build_definitions.py
@@ -36,6 +36,8 @@ class Conf(object):
         # The cpu nightlies are built on the pytorch/manylinux-cuda100 docker image
         alt_docker_suffix = self.cuda_version or "100"
         docker_distro_suffix = "" if self.pydistro == "conda" else alt_docker_suffix
+        if self.cuda_version == "101":
+            return "soumith/manylinux-cuda101@sha256:5d62be90d5b7777121180e6137c7eed73d37aaf9f669c51b783611e37e0b4916"
         return miniutils.quote("pytorch/" + docker_distro_prefix + "-cuda" + docker_distro_suffix)
 
     def get_name_prefix(self):

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2277,7 +2277,7 @@ workflows:
           filters:
             branches:
               only: postnightly
-          docker_image: "pytorch/manylinux-cuda101"
+          docker_image: soumith/manylinux-cuda101@sha256:5d62be90d5b7777121180e6137c7eed73d37aaf9f669c51b783611e37e0b4916
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
@@ -2290,7 +2290,7 @@ workflows:
           filters:
             branches:
               only: postnightly
-          docker_image: "pytorch/manylinux-cuda101"
+          docker_image: soumith/manylinux-cuda101@sha256:5d62be90d5b7777121180e6137c7eed73d37aaf9f669c51b783611e37e0b4916
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
@@ -2303,7 +2303,7 @@ workflows:
           filters:
             branches:
               only: postnightly
-          docker_image: "pytorch/manylinux-cuda101"
+          docker_image: soumith/manylinux-cuda101@sha256:5d62be90d5b7777121180e6137c7eed73d37aaf9f669c51b783611e37e0b4916
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
@@ -2427,7 +2427,7 @@ workflows:
           filters:
             branches:
               only: postnightly
-          docker_image: "pytorch/conda-cuda"
+          docker_image: soumith/manylinux-cuda101@sha256:5d62be90d5b7777121180e6137c7eed73d37aaf9f669c51b783611e37e0b4916
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
@@ -2440,7 +2440,7 @@ workflows:
           filters:
             branches:
               only: postnightly
-          docker_image: "pytorch/conda-cuda"
+          docker_image: soumith/manylinux-cuda101@sha256:5d62be90d5b7777121180e6137c7eed73d37aaf9f669c51b783611e37e0b4916
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
@@ -2453,7 +2453,7 @@ workflows:
           filters:
             branches:
               only: postnightly
-          docker_image: "pytorch/conda-cuda"
+          docker_image: soumith/manylinux-cuda101@sha256:5d62be90d5b7777121180e6137c7eed73d37aaf9f669c51b783611e37e0b4916
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
@@ -2627,7 +2627,7 @@ workflows:
             branches:
               only: postnightly
           libtorch_variant: "shared-with-deps"
-          docker_image: "pytorch/manylinux-cuda101"
+          docker_image: soumith/manylinux-cuda101@sha256:5d62be90d5b7777121180e6137c7eed73d37aaf9f669c51b783611e37e0b4916
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
@@ -2641,7 +2641,7 @@ workflows:
             branches:
               only: postnightly
           libtorch_variant: "shared-without-deps"
-          docker_image: "pytorch/manylinux-cuda101"
+          docker_image: soumith/manylinux-cuda101@sha256:5d62be90d5b7777121180e6137c7eed73d37aaf9f669c51b783611e37e0b4916
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
@@ -2655,7 +2655,7 @@ workflows:
             branches:
               only: postnightly
           libtorch_variant: "static-with-deps"
-          docker_image: "pytorch/manylinux-cuda101"
+          docker_image: soumith/manylinux-cuda101@sha256:5d62be90d5b7777121180e6137c7eed73d37aaf9f669c51b783611e37e0b4916
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
@@ -2669,7 +2669,7 @@ workflows:
             branches:
               only: postnightly
           libtorch_variant: "static-without-deps"
-          docker_image: "pytorch/manylinux-cuda101"
+          docker_image: soumith/manylinux-cuda101@sha256:5d62be90d5b7777121180e6137c7eed73d37aaf9f669c51b783611e37e0b4916
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
@@ -3047,7 +3047,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "pytorch/manylinux-cuda101"
+          docker_image: soumith/manylinux-cuda101@sha256:5d62be90d5b7777121180e6137c7eed73d37aaf9f669c51b783611e37e0b4916
       - binary_linux_build:
           name: binary_linux_manywheel_3_6m_cu101_devtoolset7_nightly_build
           build_environment: "manywheel 3.6m cu101 devtoolset7"
@@ -3056,7 +3056,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "pytorch/manylinux-cuda101"
+          docker_image: soumith/manylinux-cuda101@sha256:5d62be90d5b7777121180e6137c7eed73d37aaf9f669c51b783611e37e0b4916
       - binary_linux_build:
           name: binary_linux_manywheel_3_7m_cu101_devtoolset7_nightly_build
           build_environment: "manywheel 3.7m cu101 devtoolset7"
@@ -3065,7 +3065,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "pytorch/manylinux-cuda101"
+          docker_image: soumith/manylinux-cuda101@sha256:5d62be90d5b7777121180e6137c7eed73d37aaf9f669c51b783611e37e0b4916
       - binary_linux_build:
           name: binary_linux_conda_3_5_cpu_devtoolset7_nightly_build
           build_environment: "conda 3.5 cpu devtoolset7"
@@ -3155,7 +3155,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "pytorch/conda-cuda"
+          docker_image: soumith/manylinux-cuda101@sha256:5d62be90d5b7777121180e6137c7eed73d37aaf9f669c51b783611e37e0b4916
       - binary_linux_build:
           name: binary_linux_conda_3_6_cu101_devtoolset7_nightly_build
           build_environment: "conda 3.6 cu101 devtoolset7"
@@ -3164,7 +3164,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "pytorch/conda-cuda"
+          docker_image: soumith/manylinux-cuda101@sha256:5d62be90d5b7777121180e6137c7eed73d37aaf9f669c51b783611e37e0b4916
       - binary_linux_build:
           name: binary_linux_conda_3_7_cu101_devtoolset7_nightly_build
           build_environment: "conda 3.7 cu101 devtoolset7"
@@ -3173,7 +3173,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "pytorch/conda-cuda"
+          docker_image: soumith/manylinux-cuda101@sha256:5d62be90d5b7777121180e6137c7eed73d37aaf9f669c51b783611e37e0b4916
       - binary_linux_build:
           name: binary_linux_libtorch_3_7m_cpu_devtoolset7_nightly_shared-with-deps_build
           build_environment: "libtorch 3.7m cpu devtoolset7"
@@ -3303,7 +3303,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "shared-with-deps"
-          docker_image: "pytorch/manylinux-cuda101"
+          docker_image: soumith/manylinux-cuda101@sha256:5d62be90d5b7777121180e6137c7eed73d37aaf9f669c51b783611e37e0b4916
       - binary_linux_build:
           name: binary_linux_libtorch_3_7m_cu101_devtoolset7_nightly_shared-without-deps_build
           build_environment: "libtorch 3.7m cu101 devtoolset7"
@@ -3313,7 +3313,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "shared-without-deps"
-          docker_image: "pytorch/manylinux-cuda101"
+          docker_image: soumith/manylinux-cuda101@sha256:5d62be90d5b7777121180e6137c7eed73d37aaf9f669c51b783611e37e0b4916
       - binary_linux_build:
           name: binary_linux_libtorch_3_7m_cu101_devtoolset7_nightly_static-with-deps_build
           build_environment: "libtorch 3.7m cu101 devtoolset7"
@@ -3323,7 +3323,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "static-with-deps"
-          docker_image: "pytorch/manylinux-cuda101"
+          docker_image: soumith/manylinux-cuda101@sha256:5d62be90d5b7777121180e6137c7eed73d37aaf9f669c51b783611e37e0b4916
       - binary_linux_build:
           name: binary_linux_libtorch_3_7m_cu101_devtoolset7_nightly_static-without-deps_build
           build_environment: "libtorch 3.7m cu101 devtoolset7"
@@ -3333,7 +3333,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "static-without-deps"
-          docker_image: "pytorch/manylinux-cuda101"
+          docker_image: soumith/manylinux-cuda101@sha256:5d62be90d5b7777121180e6137c7eed73d37aaf9f669c51b783611e37e0b4916
       - binary_linux_build:
           name: binary_linux_libtorch_3_7m_cpu_gcc5_4_cxx11-abi_nightly_shared-with-deps_build
           build_environment: "libtorch 3.7m cpu gcc5.4_cxx11-abi"
@@ -3753,7 +3753,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "pytorch/manylinux-cuda101"
+          docker_image: soumith/manylinux-cuda101@sha256:5d62be90d5b7777121180e6137c7eed73d37aaf9f669c51b783611e37e0b4916
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
@@ -3765,7 +3765,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "pytorch/manylinux-cuda101"
+          docker_image: soumith/manylinux-cuda101@sha256:5d62be90d5b7777121180e6137c7eed73d37aaf9f669c51b783611e37e0b4916
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
@@ -3777,7 +3777,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "pytorch/manylinux-cuda101"
+          docker_image: soumith/manylinux-cuda101@sha256:5d62be90d5b7777121180e6137c7eed73d37aaf9f669c51b783611e37e0b4916
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
@@ -3891,7 +3891,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "pytorch/conda-cuda"
+          docker_image: soumith/manylinux-cuda101@sha256:5d62be90d5b7777121180e6137c7eed73d37aaf9f669c51b783611e37e0b4916
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
@@ -3903,7 +3903,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "pytorch/conda-cuda"
+          docker_image: soumith/manylinux-cuda101@sha256:5d62be90d5b7777121180e6137c7eed73d37aaf9f669c51b783611e37e0b4916
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
@@ -3915,7 +3915,7 @@ workflows:
           filters:
             branches:
               only: nightly
-          docker_image: "pytorch/conda-cuda"
+          docker_image: soumith/manylinux-cuda101@sha256:5d62be90d5b7777121180e6137c7eed73d37aaf9f669c51b783611e37e0b4916
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
@@ -4076,7 +4076,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "shared-with-deps"
-          docker_image: "pytorch/manylinux-cuda101"
+          docker_image: soumith/manylinux-cuda101@sha256:5d62be90d5b7777121180e6137c7eed73d37aaf9f669c51b783611e37e0b4916
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
@@ -4089,7 +4089,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "shared-without-deps"
-          docker_image: "pytorch/manylinux-cuda101"
+          docker_image: soumith/manylinux-cuda101@sha256:5d62be90d5b7777121180e6137c7eed73d37aaf9f669c51b783611e37e0b4916
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
@@ -4102,7 +4102,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "static-with-deps"
-          docker_image: "pytorch/manylinux-cuda101"
+          docker_image: soumith/manylinux-cuda101@sha256:5d62be90d5b7777121180e6137c7eed73d37aaf9f669c51b783611e37e0b4916
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
@@ -4115,7 +4115,7 @@ workflows:
             branches:
               only: nightly
           libtorch_variant: "static-without-deps"
-          docker_image: "pytorch/manylinux-cuda101"
+          docker_image: soumith/manylinux-cuda101@sha256:5d62be90d5b7777121180e6137c7eed73d37aaf9f669c51b783611e37e0b4916
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:


### PR DESCRIPTION
Test shows using previous image, we can get much smaller binary size

 https://circleci.com/workflow-run/a46f2c7e-8545-4441-9c71-15c309f3c947 , check "Upload binary size" section, size of file is at the bottom of the log