### PR TITLE
Raise warning for schedulers following chainable shedulers

### DIFF
--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -19,6 +19,7 @@ EPOCH_DEPRECATION_WARNING = (
     "https://github.com/pytorch/pytorch/issues/new/choose."
 )
 
+SAVE_STATE_WARNING = "Please also save or load the state of the optimzer when saving or loading the scheduler."
 
 class _LRScheduler(object):
 
@@ -140,7 +141,7 @@ class _LRScheduler(object):
                 self.last_epoch += 1
                 values = self.get_lr()
             else:
-                warnings.warn(EPOCH_DEPRECATION_WARNING, DeprecationWarning)
+                warnings.warn(EPOCH_DEPRECATION_WARNING, UserWarning)
                 self.last_epoch = epoch
                 if hasattr(self, "_get_closed_form_lr"):
                     values = self._get_closed_form_lr()
@@ -196,6 +197,8 @@ class LambdaLR(_LRScheduler):
         The learning rate lambda functions will only be saved if they are callable objects
         and not if they are functions or lambdas.
         """
+
+        warnings.warn(SAVE_STATE_WARNING, UserWarning)
         state_dict = {key: value for key, value in self.__dict__.items() if key not in ('optimizer', 'lr_lambdas')}
         state_dict['lr_lambdas'] = [None] * len(self.lr_lambdas)
 
@@ -212,6 +215,8 @@ class LambdaLR(_LRScheduler):
             state_dict (dict): scheduler state. Should be an object returned
                 from a call to :meth:`state_dict`.
         """
+
+        warnings.warn(SAVE_STATE_WARNING, UserWarning)
         lr_lambdas = state_dict.pop('lr_lambdas')
         self.__dict__.update(state_dict)
 
@@ -296,7 +301,7 @@ class MultiplicativeLR(_LRScheduler):
     def get_lr(self):
         if not self._get_lr_called_within_step:
             warnings.warn("To get the last learning rate computed by the scheduler, "
-                          "please use `get_last_lr()`.", DeprecationWarning)
+                          "please use `get_last_lr()`.", UserWarning)
 
         if self.last_epoch > 0:
             return [group['lr'] * lmbda(self.last_epoch)
@@ -339,7 +344,7 @@ class StepLR(_LRScheduler):
     def get_lr(self):
         if not self._get_lr_called_within_step:
             warnings.warn("To get the last learning rate computed by the scheduler, "
-                          "please use `get_last_lr()`.", DeprecationWarning)
+                          "please use `get_last_lr()`.", UserWarning)
 
         if (self.last_epoch == 0) or (self.last_epoch % self.step_size != 0):
             return [group['lr'] for group in self.optimizer.param_groups]
@@ -384,7 +389,7 @@ class MultiStepLR(_LRScheduler):
     def get_lr(self):
         if not self._get_lr_called_within_step:
             warnings.warn("To get the last learning rate computed by the scheduler, "
-                          "please use `get_last_lr()`.", DeprecationWarning)
+                          "please use `get_last_lr()`.", UserWarning)
 
         if self.last_epoch not in self.milestones:
             return [group['lr'] for group in self.optimizer.param_groups]
@@ -413,7 +418,7 @@ class ExponentialLR(_LRScheduler):
     def get_lr(self):
         if not self._get_lr_called_within_step:
             warnings.warn("To get the last learning rate computed by the scheduler, "
-                          "please use `get_last_lr()`.", DeprecationWarning)
+                          "please use `get_last_lr()`.", UserWarning)
 
         if self.last_epoch == 0:
             return self.base_lrs
@@ -469,7 +474,7 @@ class CosineAnnealingLR(_LRScheduler):
     def get_lr(self):
         if not self._get_lr_called_within_step:
             warnings.warn("To get the last learning rate computed by the scheduler, "
-                          "please use `get_last_lr()`.", DeprecationWarning)
+                          "please use `get_last_lr()`.", UserWarning)
 
         if self.last_epoch == 0:
             return self.base_lrs
@@ -588,7 +593,7 @@ class ReduceLROnPlateau(object):
         if epoch is None:
             epoch = self.last_epoch + 1
         else:
-            warnings.warn(EPOCH_DEPRECATION_WARNING, DeprecationWarning)
+            warnings.warn(EPOCH_DEPRECATION_WARNING, UserWarning)
         self.last_epoch = epoch
 
         if self.is_better(current, self.best):
@@ -850,7 +855,7 @@ class CyclicLR(_LRScheduler):
 
         if not self._get_lr_called_within_step:
             warnings.warn("To get the last learning rate computed by the scheduler, "
-                          "please use `get_last_lr()`.", DeprecationWarning)
+                          "please use `get_last_lr()`.", UserWarning)
 
         cycle = math.floor(1 + self.last_epoch / self.total_size)
         x = 1. + self.last_epoch / self.total_size - cycle
@@ -927,7 +932,7 @@ class CosineAnnealingWarmRestarts(_LRScheduler):
     def get_lr(self):
         if not self._get_lr_called_within_step:
             warnings.warn("To get the last learning rate computed by the scheduler, "
-                          "please use `get_last_lr()`.", DeprecationWarning)
+                          "please use `get_last_lr()`.", UserWarning)
 
         return [self.eta_min + (base_lr - self.eta_min) * (1 + math.cos(math.pi * self.T_cur / self.T_i)) / 2
                 for base_lr in self.base_lrs]
@@ -1191,7 +1196,7 @@ class OneCycleLR(_LRScheduler):
     def get_lr(self):
         if not self._get_lr_called_within_step:
             warnings.warn("To get the last learning rate computed by the scheduler, "
-                          "please use `get_last_lr()`.", DeprecationWarning)
+                          "please use `get_last_lr()`.", UserWarning)
 
         lrs = []
         step_num = self.last_epoch


### PR DESCRIPTION
Fixes #29697. 

Raise warning for schedulers following chainable schedulers in #26423. See explanation for
* [new warning when load/save](https://github.com/pytorch/pytorch/issues/29697#issuecomment-564655802)
* [change from deprecation to user warning](https://github.com/pytorch/pytorch/issues/29697#issuecomment-564659775).

@gchanan -- This should go in the upcoming release following #26423. 

# Example

Version 1.3.1:
```python
import torch
from torch.nn import Parameter
from torch.optim import SGD
from torch.optim.lr_scheduler import StepLR

model = [Parameter(torch.randn(2, 2, requires_grad=True))]

print('Initial training')

optimizer = SGD(model, 0.1)
scheduler = StepLR(optimizer, 2)

for epoch in range(5):
    print(epoch, optimizer.param_groups[0]['lr'])
    optimizer.step()
    scheduler.step()

state_dict_lr = scheduler.state_dict()

print('Loading from checkpoint')

optimizer = SGD(model, 0.1)
scheduler = StepLR(optimizer, 2)

scheduler.load_state_dict(state_dict_lr)

for epoch in range(5, 10):
    print(epoch, optimizer.param_groups[0]['lr'])
    optimizer.step()
    scheduler.step()
```

```
Initial training
0 0.1
1 0.1
2 0.010000000000000002
3 0.010000000000000002
4 0.0010000000000000002
Loading from checkpoint
5 0.1
6 0.00010000000000000003
7 0.00010000000000000003
8 1.0000000000000003e-05
9 1.0000000000000003e-05
```
This is not correct, but no warnings are raised.

Version 1.3.1 and 1.4.0:
```python
import torch
from torch.nn import Parameter
from torch.optim import SGD
from torch.optim.lr_scheduler import StepLR

model = [Parameter(torch.randn(2, 2, requires_grad=True))]

print('Initial training')

optimizer = SGD(model, 0.1)
scheduler = StepLR(optimizer, 2)

for epoch in range(5):
    print(epoch, optimizer.param_groups[0]['lr'])
    optimizer.step()
    scheduler.step()

state_dict_lr = scheduler.state_dict()
state_dict_opt = optimizer.state_dict()

print('Loading from checkpoint')

optimizer = SGD(model, 0.1)
scheduler = StepLR(optimizer, 2)

scheduler.load_state_dict(state_dict_lr)
optimizer.load_state_dict(state_dict_opt)

for epoch in range(5, 10):
    print(epoch, optimizer.param_groups[0]['lr'])
    optimizer.step()
    scheduler.step()
```
```
Initial training
0 lr [0.1]
1 lr [0.1]
2 lr [0.010000000000000002]
3 lr [0.010000000000000002]
4 lr [0.0010000000000000002]
Loading from checkpoint
5 lr [0.0010000000000000002]
6 lr [0.00010000000000000003]
7 lr [0.00010000000000000003]
8 lr [1.0000000000000004e-05]
9 lr [1.0000000000000004e-05]
```