### PR TITLE
Skip registry warning

### DIFF
--- a/torch/lib/c10d/GlooDeviceFactory.cpp
+++ b/torch/lib/c10d/GlooDeviceFactory.cpp
@@ -28,7 +28,7 @@
 
 namespace c10d {
 
-C10_DEFINE_SHARED_REGISTRY(
+C10_DEFINE_SHARED_REGISTRY_WITHOUT_WARNING(
     GlooDeviceRegistry,
     ::gloo::transport::Device,
     const std::string& /* interface */,


### PR DESCRIPTION
Gloo device creator registry is throwing warning that confuses users.
Create C10_DEFINE_SHARED_REGISTRY_WITHOUT_WARNING API to skip such warning

Tested both `C10_DEFINE_SHARED_REGISTRY` and `C10_DEFINE_SHARED_REGISTRY_WITHOUT_WARNING`.
Make sure nothing breaks

