### PR TITLE
Add types for the remaining optimizers.

### DIFF
--- a/torch/optim/__init__.pyi
+++ b/torch/optim/__init__.pyi
@@ -1,3 +1,13 @@
-from .sgd import SGD as SGD
-from .adam import Adam as Adam
 from . import lr_scheduler as lr_scheduler
+from .adadelta import Adadelta
+from .adagrad import Adagrad
+from .adam import Adam as Adam
+from .adamax import Adamax
+from .adamw import AdamW
+from .asgd import ASGD
+from .lbfgs import LBFGS
+from .optimizer import Optimizer
+from .rmsprop import RMSprop
+from .rprop import Rprop
+from .sgd import SGD as SGD
+from .sparse_adam import SparseAdam

--- a/torch/optim/adadelta.pyi
+++ b/torch/optim/adadelta.pyi
@@ -1,0 +1,5 @@
+from typing import Tuple
+from .optimizer import _params_t, Optimizer
+
+class Adadelta(Optimizer):
+    def __init__(self, params: _params_t, lr: float=..., rho: float=..., eps: float=..., weight_decay: float=...) -> None: ...

--- a/torch/optim/adagrad.pyi
+++ b/torch/optim/adagrad.pyi
@@ -1,0 +1,5 @@
+from typing import Tuple
+from .optimizer import _params_t, Optimizer
+
+class Adagrad(Optimizer):
+    def __init__(self, params: _params_t, lr: float=..., lr_decay: float=..., weight_decay: float=..., initial_accumulator_value: float=...,  eps: float=...) -> None: ...

--- a/torch/optim/adamax.pyi
+++ b/torch/optim/adamax.pyi
@@ -1,0 +1,5 @@
+from typing import Tuple
+from .optimizer import _params_t, Optimizer
+
+class Adamax(Optimizer):
+    def __init__(self, params: _params_t, lr: float=..., betas: Tuple[float, float]=..., eps: float=..., weight_decay: float=...) -> None: ...

--- a/torch/optim/adamw.pyi
+++ b/torch/optim/adamw.pyi
@@ -1,0 +1,5 @@
+from typing import Tuple
+from .optimizer import _params_t, Optimizer
+
+class AdamW(Optimizer):
+    def __init__(self, params: _params_t, lr: float=..., betas: Tuple[float, float]=..., eps: float=..., weight_decay: float=..., amsgrad: bool = ...) -> None: ...

--- a/torch/optim/asgd.pyi
+++ b/torch/optim/asgd.pyi
@@ -1,0 +1,5 @@
+from typing import Tuple
+from .optimizer import _params_t, Optimizer
+
+class ASGD(Optimizer):
+    def __init__(self, params: _params_t, lr: float=..., lambd: float=..., alpha: float=..., t0: float=..., weight_decay: float=...) -> None: ...

--- a/torch/optim/lbfgs.pyi
+++ b/torch/optim/lbfgs.pyi
@@ -1,0 +1,5 @@
+from typing import Tuple, Optional
+from .optimizer import _params_t, Optimizer
+
+class LBFGS(Optimizer):
+    def __init__(self, params: _params_t, lr: float=..., max_iter: int=..., max_eval: Optional[int]=..., tolerance_grad: float=..., tolerance_change: float=..., history_size: int=..., line_search_fn: Optional[str]=...) -> None: ...

--- a/torch/optim/rmsprop.pyi
+++ b/torch/optim/rmsprop.pyi
@@ -1,0 +1,5 @@
+from typing import Tuple
+from .optimizer import _params_t, Optimizer
+
+class RMSprop(Optimizer):
+    def __init__(self, params: _params_t, lr: float=..., alpha: float=..., eps: float=..., weight_decay: float=..., momentum: float=...,  centered: bool=...) -> None: ...

--- a/torch/optim/rprop.pyi
+++ b/torch/optim/rprop.pyi
@@ -1,0 +1,5 @@
+from typing import Tuple
+from .optimizer import _params_t, Optimizer
+
+class Rprop(Optimizer):
+    def __init__(self, params: _params_t, lr: float=..., etas: Tuple[float, float]=..., step_sizes: Tuple[float, float]=...) -> None: ...

--- a/torch/optim/sparse_adam.pyi
+++ b/torch/optim/sparse_adam.pyi
@@ -1,0 +1,6 @@
+
+from typing import Tuple
+from .optimizer import _params_t, Optimizer
+
+class SparseAdam(Optimizer):
+    def __init__(self, params: _params_t, lr: float=..., betas: Tuple[float, float]=..., eps: float=...) -> None: ...


### PR DESCRIPTION
**Patch Description**
Round out the rest of the optimizer types in torch.optim by creating the stubs for the rest of them.

**Testing**:
I ran mypy looking for just errors in that optim folder. There's no *new* mypy errors created.
```
$ mypy torch/optim | grep optim
$ git checkout master; mypy torch/optim | wc -l
968
$ git checkout typeoptims; mypy torch/optim | wc -l
968
```