### PR TITLE
Make nested RPCs always chianed by waiting on the future.

### DIFF
--- a/test/rpc_test.py
+++ b/test/rpc_test.py
@@ -166,7 +166,7 @@ def multi_layer_nested_sync_rpc(dst, world_size, ttl):
         next_dst = (dst + 1) % world_size
         return rpc.rpc_sync(
             current_dst,
-            multi_layer_nested_async_rpc,
+            multi_layer_nested_sync_rpc,
             args=(next_dst, world_size, ttl - 1),
         )
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#31140 Make nested RPCs always chianed by waiting on the future.**

Other RPC Agents don't have a way of detecting in-flight async calls. 

The only way to avoid in-flight async calls got disrupted for all RPC Agents is to only promise user that we only guarantee futures to be responded if users explicitly wait on those futures they care about.

Differential Revision: [D5708493](https://our.internmc.facebook.com/intern/diff/D5708493/)