### PR TITLE
embedding_bag skip output zeroing for no grad

### DIFF
--- a/aten/src/ATen/native/EmbeddingBag.cpp
+++ b/aten/src/ATen/native/EmbeddingBag.cpp
@@ -337,7 +337,12 @@ _embedding_bag_cpu(const Tensor &weight, const Tensor &indices,
 
   auto bag_size = make_bag_size(offsets, indices, mode, weight.requires_grad());
 
-  auto output = at::zeros({offsets.size(0), weight.size(1)}, weight.options());
+  Tensor output;
+  if (weight.requires_grad()) {
+    output = at::zeros({offsets.size(0), weight.size(1)}, weight.options());
+  } else {
+    output = at::empty({offsets.size(0), weight.size(1)}, weight.options());
+  }
 
   // To save compute, if we are going to go down the fast path case for the 'sum'
   // mode, we skip calculating offset2bag, since it is not going to be used.


### PR DESCRIPTION
Summary:
Follow up to D18800166, use empty when we don't need gradients

Inference benchmark on T6_SKL - _embedding_bag self time only:
Baseline:
bs=40: P123764630 .244 ms/iter
bs=1: P123764996 .124 ms/iter

With diff:
bs=40: P123764511 .203 ms/iter
bs=1: P123764548 .98 ms/iter

Test Plan:
buck test caffe2/test:nn -- 'test_EmbeddingBag_*' --run-disabled
P123746024

buck test caffe2/test:jit -- 'test_nn_EmbeddingBag*'
P123746156

buck run mode/opt //caffe2/benchmarks/operator_benchmark:benchmark_all_other_test -- --tag_filter all --iterations 3000 --operators embeddingbag

MKL_NUM_THREADS=1 OMP_NUM_THREADS=1 numactl -m 0 -C 3 ./inference_benchmark_empty_make.par --pt-scripted-model=traced_model.pt --pt-inputs="batch_size_1/pt_inputs.pth" --iters=3000 --warmup-iters=100 --profiling-only

Differential Revision: D18938159

