### PR TITLE
make_subclass is public API, per comments from FastAI

### DIFF
--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -145,6 +145,9 @@ static PyObject *THPVariable_pynew(PyTypeObject *type, PyObject *args, PyObject 
 }
 
 // Instantiates a subclass of torch.Tensor. Used by nn.Parameter()
+//
+// WARNING: Apparently this is now semi-public, as fastai v2 is using it, see
+// https://github.com/pytorch/pytorch/issues/22402#issuecomment-541340831
 static PyObject* THPVariable_make_subclass(PyObject* _ignored, PyObject* args, PyObject* kwargs) {
   HANDLE_TH_ERRORS
   static PythonArgParser parser({


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#31148 make_subclass is public API, per comments from FastAI**

Signed-off-by: Edward Z. Yang <ezyang@fb.com>