### PR TITLE
Use libmkl_rt, or statically link against MKL

### DIFF
--- a/aten/tools/valgrind.sup
+++ b/aten/tools/valgrind.sup
@@ -9,3 +9,10 @@
    fun:handle_ld_preload
    ...
 }
+{
+   <Dynamically loaded MKL uninitialized jump>
+   Memcheck:Cond
+   fun:__intel_sse2_strrchr
+   fun:*_INTERNAL_45_______src_thirdparty_tbb_omp_dynamic_link_cpp*init_dl_data*
+   fun:__sti__$E
+}

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -842,7 +842,7 @@ if(USE_OPENMP AND OPENMP_FOUND)
     "OpenMP CXX_FLAGS: ${OpenMP_CXX_FLAGS}. \n"
     "OpenMP libraries: ${OpenMP_CXX_LIBRARIES}.")
   target_compile_options(torch_cpu INTERFACE ${OpenMP_CXX_FLAGS})
-  target_link_libraries(torch_cpu PRIVATE ${OpenMP_CXX_LIBRARIES})
+  target_link_libraries(torch_cpu INTERFACE ${OpenMP_CXX_LIBRARIES})
 endif()
 
 

--- a/cmake/Modules/FindMKL.cmake
+++ b/cmake/Modules/FindMKL.cmake
@@ -89,6 +89,7 @@ SET(mklseq)
 # Paths
 SET(saved_CMAKE_LIBRARY_PATH ${CMAKE_LIBRARY_PATH})
 SET(saved_CMAKE_INCLUDE_PATH ${CMAKE_INCLUDE_PATH})
+SET(saved_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES})
 IF(WIN32)
   # Set default MKLRoot for Windows
   IF($ENV{MKLProductDir})
@@ -197,7 +198,18 @@ MACRO(CHECK_ALL_LIBRARIES LIBRARIES OPENMP_TYPE OPENMP_LIBRARY _name _list _flag
         # Separately handling compiled TBB
         SET(_found_tbb TRUE)
       ELSE()
+        SET(MKL_SAVED_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES})
+        IF(${_library} MATCHES "mkl*")
+          # Unfortunately combinations of shared MKL libraries other than only libmkl_rt
+          # assume and _require_ loading them into the global symbol namespace, which
+          # generally causes a lot of pollution with common symbols like pthreads, etc.
+          # To avoid this we only allow either linking to libmkl_rt.so, or require all
+          # libraries to get statically linked.
+          # Relevant link: https://software.intel.com/en-us/forums/intel-math-kernel-library/topic/296094
+          SET(CMAKE_FIND_LIBRARY_SUFFIXES .a)
+        ENDIF()
         FIND_LIBRARY(${_prefix}_${_library}_LIBRARY NAMES ${_library})
+        SET(CMAKE_FIND_LIBRARY_SUFFIXES ${MKL_SAVED_LIBRARY_SUFFIXES})
       ENDIF()
       MARK_AS_ADVANCED(${_prefix}_${_library}_LIBRARY)
       IF(NOT (${_library} STREQUAL "tbb"))
@@ -250,12 +262,14 @@ ELSE(UNIX AND NOT APPLE)
   SET(mkl_dl "")
 ENDIF(UNIX AND NOT APPLE)
 
-# Check for version 10/11
-IF (NOT MKL_LIBRARIES)
-  SET(MKL_VERSION 1011)
-ENDIF (NOT MKL_LIBRARIES)
+SET(MKL_VERSION 1011)
 
-# First: search for parallelized ones with intel thread lib
+FIND_LIBRARY(MKL_LIBRARIES mkl_rt)
+IF (NOT MKL_LIBRARIES)
+  UNSET(MKL_LIBRARIES CACHE)
+ENDIF()
+
+# Search for parallelized ones with intel thread lib
 IF (NOT "${MKL_THREADING}" STREQUAL "SEQ")
   FOREACH(mklrtl ${mklrtls} "")
     FOREACH(mkliface ${mklifaces})
@@ -271,7 +285,19 @@ IF (NOT "${MKL_THREADING}" STREQUAL "SEQ")
   ENDFOREACH(mklrtl)
 ENDIF (NOT "${MKL_THREADING}" STREQUAL "SEQ")
 
-# Second: search for sequential ones
+# Search for parallelized ones with native pthread lib
+FOREACH(mklrtl ${mklrtls} "")
+  FOREACH(mkliface ${mklifaces})
+    FOREACH(mkl64 ${mkl64s} "")
+      IF (NOT MKL_LIBRARIES)
+        CHECK_ALL_LIBRARIES(MKL_LIBRARIES MKL_OPENMP_TYPE MKL_OPENMP_LIBRARY cblas_sgemm
+          "mkl_${mkliface}${mkl64};${mklthread};mkl_core;${mklrtl};pthread;${mkl_m};${mkl_dl}" "")
+      ENDIF (NOT MKL_LIBRARIES)
+    ENDFOREACH(mkl64)
+  ENDFOREACH(mkliface)
+ENDFOREACH(mklrtl)
+
+# Search for sequential ones
 FOREACH(mkliface ${mklifaces})
   FOREACH(mkl64 ${mkl64s} "")
     IF (NOT MKL_LIBRARIES)
@@ -283,18 +309,6 @@ FOREACH(mkliface ${mklifaces})
     ENDIF (NOT MKL_LIBRARIES)
   ENDFOREACH(mkl64)
 ENDFOREACH(mkliface)
-
-# First: search for parallelized ones with native pthread lib
-FOREACH(mklrtl ${mklrtls} "")
-  FOREACH(mkliface ${mklifaces})
-    FOREACH(mkl64 ${mkl64s} "")
-      IF (NOT MKL_LIBRARIES)
-        CHECK_ALL_LIBRARIES(MKL_LIBRARIES MKL_OPENMP_TYPE MKL_OPENMP_LIBRARY cblas_sgemm
-          "mkl_${mkliface}${mkl64};${mklthread};mkl_core;${mklrtl};pthread;${mkl_m};${mkl_dl}" "")
-      ENDIF (NOT MKL_LIBRARIES)
-    ENDFOREACH(mkl64)
-  ENDFOREACH(mkliface)
-ENDFOREACH(mklrtl)
 
 # Check for older versions
 IF (NOT MKL_LIBRARIES)
@@ -336,6 +350,7 @@ ENDIF (MKL_LIBRARIES)
 # Final
 SET(CMAKE_LIBRARY_PATH ${saved_CMAKE_LIBRARY_PATH})
 SET(CMAKE_INCLUDE_PATH ${saved_CMAKE_INCLUDE_PATH})
+SET(CMAKE_FIND_LIBRARY_SUFFIXES ${saved_CMAKE_FIND_LIBRARY_SUFFIXES})
 IF (MKL_LIBRARIES AND MKL_INCLUDE_DIR)
   SET(MKL_FOUND TRUE)
 ELSE (MKL_LIBRARIES AND MKL_INCLUDE_DIR)

--- a/cmake/Modules/FindMKL.cmake
+++ b/cmake/Modules/FindMKL.cmake
@@ -269,7 +269,7 @@ IF (NOT MKL_LIBRARIES)
   UNSET(MKL_LIBRARIES CACHE)
 ENDIF()
 
-# Search for parallelized ones with intel thread lib
+# First: search for parallelized ones with intel thread lib
 IF (NOT "${MKL_THREADING}" STREQUAL "SEQ")
   FOREACH(mklrtl ${mklrtls} "")
     FOREACH(mkliface ${mklifaces})
@@ -285,19 +285,7 @@ IF (NOT "${MKL_THREADING}" STREQUAL "SEQ")
   ENDFOREACH(mklrtl)
 ENDIF (NOT "${MKL_THREADING}" STREQUAL "SEQ")
 
-# Search for parallelized ones with native pthread lib
-FOREACH(mklrtl ${mklrtls} "")
-  FOREACH(mkliface ${mklifaces})
-    FOREACH(mkl64 ${mkl64s} "")
-      IF (NOT MKL_LIBRARIES)
-        CHECK_ALL_LIBRARIES(MKL_LIBRARIES MKL_OPENMP_TYPE MKL_OPENMP_LIBRARY cblas_sgemm
-          "mkl_${mkliface}${mkl64};${mklthread};mkl_core;${mklrtl};pthread;${mkl_m};${mkl_dl}" "")
-      ENDIF (NOT MKL_LIBRARIES)
-    ENDFOREACH(mkl64)
-  ENDFOREACH(mkliface)
-ENDFOREACH(mklrtl)
-
-# Search for sequential ones
+# Second: search for sequential ones
 FOREACH(mkliface ${mklifaces})
   FOREACH(mkl64 ${mkl64s} "")
     IF (NOT MKL_LIBRARIES)
@@ -309,6 +297,18 @@ FOREACH(mkliface ${mklifaces})
     ENDIF (NOT MKL_LIBRARIES)
   ENDFOREACH(mkl64)
 ENDFOREACH(mkliface)
+
+# First: search for parallelized ones with native pthread lib
+FOREACH(mklrtl ${mklrtls} "")
+  FOREACH(mkliface ${mklifaces})
+    FOREACH(mkl64 ${mkl64s} "")
+      IF (NOT MKL_LIBRARIES)
+        CHECK_ALL_LIBRARIES(MKL_LIBRARIES MKL_OPENMP_TYPE MKL_OPENMP_LIBRARY cblas_sgemm
+          "mkl_${mkliface}${mkl64};${mklthread};mkl_core;${mklrtl};pthread;${mkl_m};${mkl_dl}" "")
+      ENDIF (NOT MKL_LIBRARIES)
+    ENDFOREACH(mkl64)
+  ENDFOREACH(mkliface)
+ENDFOREACH(mklrtl)
 
 # Check for older versions
 IF (NOT MKL_LIBRARIES)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #31162 Don't use RTLD_GLOBAL to load _C.
* #31165 Pick parallel MKL implementation over sequential implementation.
* **#31159 Use libmkl_rt, or statically link against MKL**
* #31161 Actually get rid of Windows hacks in cpp_extensions.
* #31160 Stop using ctypes to interface with CUDA libraries.
* #31176 Move AutogradMeta and DeviceGuardImplInterface virtual methods out-of-line.
* #31157 Add missing TORCH_CUDA_API annotation to throw_nccl_error
* #31155 Remove dead CAFFE2_LIBS variable
* #31152 Remove LibIRC logic from cmake.

Part of removing RTLD_GLOBAL for _C.

MKL doesn't like being in a local scope, unless you use the libmkl_rt.so
variant, so I adapted our CMake configuration to either accept that or
only allow static linking.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>