### PR TITLE
Re-enable python 2 builds

### DIFF
--- a/.circleci/cimodel/data/binary_build_data.py
+++ b/.circleci/cimodel/data/binary_build_data.py
@@ -34,13 +34,15 @@ def get_processor_arch_name(cuda_version):
 
 LINUX_PACKAGE_VARIANTS = OrderedDict(
     manywheel=[
+        "2.7m",
+        "2.7mu",
         "3.5m",
         "3.6m",
         "3.7m",
     ],
     conda=dimensions.STANDARD_PYTHON_VERSIONS,
     libtorch=[
-        "3.7m",
+        "2.7m",
     ],
 )
 
@@ -50,7 +52,7 @@ CONFIG_TREE_DATA = OrderedDict(
         wheel=dimensions.STANDARD_PYTHON_VERSIONS,
         conda=dimensions.STANDARD_PYTHON_VERSIONS,
         libtorch=[
-            "3.7",
+            "2.7",
         ],
     )),
 )

--- a/.circleci/cimodel/data/caffe2_build_data.py
+++ b/.circleci/cimodel/data/caffe2_build_data.py
@@ -4,7 +4,7 @@ from cimodel.lib.conf_tree import Ver
 
 CONFIG_TREE_DATA = [
     (Ver("ubuntu", "16.04"), [
-        # ([Ver("gcc", "5")], [X("onnx_py3.6")]),
+        ([Ver("gcc", "5")], [XImportant("onnx_py2")]),
         ([Ver("clang", "7")], [XImportant("onnx_py3.6")]),
     ]),
 ]

--- a/.circleci/cimodel/data/dimensions.py
+++ b/.circleci/cimodel/data/dimensions.py
@@ -8,6 +8,7 @@ CUDA_VERSIONS = [
 ]
 
 STANDARD_PYTHON_VERSIONS = [
+    "2.7",
     "3.5",
     "3.6",
     "3.7",

--- a/.circleci/cimodel/data/pytorch_build_data.py
+++ b/.circleci/cimodel/data/pytorch_build_data.py
@@ -4,6 +4,8 @@ from cimodel.lib.conf_tree import ConfigNode, X, XImportant
 CONFIG_TREE_DATA = [
     ("xenial", [
         (None, [
+            XImportant("2.7.9"),
+            X("2.7"),
             XImportant("3.5"),  # Not run on all PRs, but should be included on [test all]
             X("nightly"),
         ]),

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1657,6 +1657,44 @@ workflows:
             - pytorch_windows_build
       - setup
       - pytorch_linux_build:
+          name: pytorch_linux_xenial_py2_7_9_build
+          requires:
+            - setup
+          build_environment: "pytorch-linux-xenial-py2.7.9-build"
+          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py2.7.9:405"
+      - pytorch_linux_test:
+          name: pytorch_linux_xenial_py2_7_9_test
+          requires:
+            - setup
+            - pytorch_linux_xenial_py2_7_9_build
+          build_environment: "pytorch-linux-xenial-py2.7.9-test"
+          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py2.7.9:405"
+          resource_class: large
+      - pytorch_linux_build:
+          name: pytorch_linux_xenial_py2_7_build
+          requires:
+            - setup
+          filters:
+            branches:
+              only:
+                - master
+                - /ci-all\/.*/
+          build_environment: "pytorch-linux-xenial-py2.7-build"
+          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py2.7:405"
+      - pytorch_linux_test:
+          name: pytorch_linux_xenial_py2_7_test
+          requires:
+            - setup
+            - pytorch_linux_xenial_py2_7_build
+          filters:
+            branches:
+              only:
+                - master
+                - /ci-all\/.*/
+          build_environment: "pytorch-linux-xenial-py2.7-test"
+          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py2.7:405"
+          resource_class: large
+      - pytorch_linux_build:
           name: pytorch_linux_xenial_py3_5_build
           requires:
             - setup
@@ -2042,6 +2080,20 @@ workflows:
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3.6-gcc5.4:405"
           resource_class: large
       - caffe2_linux_build:
+          name: caffe2_onnx_py2_gcc5_ubuntu16_04_build
+          requires:
+            - setup
+          build_environment: "caffe2-onnx-py2-gcc5-ubuntu16.04-build"
+          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-gcc5-ubuntu16.04:345"
+      - caffe2_linux_test:
+          name: caffe2_onnx_py2_gcc5_ubuntu16_04_test
+          requires:
+            - setup
+            - caffe2_onnx_py2_gcc5_ubuntu16_04_build
+          build_environment: "caffe2-onnx-py2-gcc5-ubuntu16.04-test"
+          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-gcc5-ubuntu16.04:345"
+          resource_class: large
+      - caffe2_linux_build:
           name: caffe2_onnx_py3_6_clang7_ubuntu16_04_build
           requires:
             - setup
@@ -2063,8 +2115,8 @@ workflows:
       # at https://github.com/ezyang/pytorch-ci-hud/blob/master/src/BuildHistoryDisplay.js
 
       - binary_linux_build:
-          name: binary_linux_manywheel_3_7mu_cpu_devtoolset7_build
-          build_environment: "manywheel 3.7mu cpu devtoolset7"
+          name: binary_linux_manywheel_2_7mu_cpu_devtoolset7_build
+          build_environment: "manywheel 2.7mu cpu devtoolset7"
           requires:
             - setup
           docker_image: "pytorch/manylinux-cuda100"
@@ -2075,23 +2127,23 @@ workflows:
             - setup
           docker_image: "pytorch/manylinux-cuda100"
       - binary_linux_build:
-          name: binary_linux_conda_3_7_cpu_devtoolset7_build
-          build_environment: "conda 3.7 cpu devtoolset7"
+          name: binary_linux_conda_2_7_cpu_devtoolset7_build
+          build_environment: "conda 2.7 cpu devtoolset7"
           requires:
             - setup
           docker_image: "pytorch/conda-cuda"
       # This binary build is currently broken, see https://github_com/pytorch/pytorch/issues/16710
       # - binary_linux_conda_3_6_cu90_devtoolset7_build
       - binary_linux_build:
-          name: binary_linux_libtorch_3_7m_cpu_devtoolset7_shared-with-deps_build
-          build_environment: "libtorch 3.7m cpu devtoolset7"
+          name: binary_linux_libtorch_2_7m_cpu_devtoolset7_shared-with-deps_build
+          build_environment: "libtorch 2.7m cpu devtoolset7"
           requires:
             - setup
           libtorch_variant: "shared-with-deps"
           docker_image: "pytorch/manylinux-cuda100"
       - binary_linux_build:
-          name: binary_linux_libtorch_3_7m_cpu_gcc5_4_cxx11-abi_shared-with-deps_build
-          build_environment: "libtorch 3.7m cpu gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_shared-with-deps_build
+          build_environment: "libtorch 2.7m cpu gcc5.4_cxx11-abi"
           requires:
             - setup
           libtorch_variant: "shared-with-deps"
@@ -2104,22 +2156,22 @@ workflows:
           requires:
             - setup
       - binary_mac_build:
-          name: binary_macos_conda_3_7_cpu_build
-          build_environment: "conda 3.7 cpu"
+          name: binary_macos_conda_2_7_cpu_build
+          build_environment: "conda 2.7 cpu"
           requires:
             - setup
       - binary_mac_build:
-          name: binary_macos_libtorch_3_7_cpu_build
-          build_environment: "libtorch 3.7 cpu"
+          name: binary_macos_libtorch_2_7_cpu_build
+          build_environment: "libtorch 2.7 cpu"
           requires:
             - setup
 
       - binary_linux_test:
-          name: binary_linux_manywheel_3_7mu_cpu_devtoolset7_test
-          build_environment: "manywheel 3.7mu cpu devtoolset7"
+          name: binary_linux_manywheel_2_7mu_cpu_devtoolset7_test
+          build_environment: "manywheel 2.7mu cpu devtoolset7"
           requires:
             - setup
-            - binary_linux_manywheel_3_7mu_cpu_devtoolset7_build
+            - binary_linux_manywheel_2_7mu_cpu_devtoolset7_build
           docker_image: "pytorch/manylinux-cuda100"
       - binary_linux_test:
           name: binary_linux_manywheel_3_7m_cu100_devtoolset7_test
@@ -2131,31 +2183,53 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
-          name: binary_linux_conda_3_7_cpu_devtoolset7_test
-          build_environment: "conda 3.7 cpu devtoolset7"
+          name: binary_linux_conda_2_7_cpu_devtoolset7_test
+          build_environment: "conda 2.7 cpu devtoolset7"
           requires:
             - setup
-            - binary_linux_conda_3_7_cpu_devtoolset7_build
+            - binary_linux_conda_2_7_cpu_devtoolset7_build
           docker_image: "pytorch/conda-cuda"
       # This binary build is currently broken, see https://github_com/pytorch/pytorch/issues/16710
       # - binary_linux_conda_3_6_cu90_devtoolset7_test:
       - binary_linux_test:
-          name: binary_linux_libtorch_3_7m_cpu_devtoolset7_shared-with-deps_test
-          build_environment: "libtorch 3.7m cpu devtoolset7"
+          name: binary_linux_libtorch_2_7m_cpu_devtoolset7_shared-with-deps_test
+          build_environment: "libtorch 2.7m cpu devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_3_7m_cpu_devtoolset7_shared-with-deps_build
+            - binary_linux_libtorch_2_7m_cpu_devtoolset7_shared-with-deps_build
           libtorch_variant: "shared-with-deps"
           docker_image: "pytorch/manylinux-cuda100"
       - binary_linux_test:
-          name: binary_linux_libtorch_3_7m_cpu_gcc5_4_cxx11-abi_shared-with-deps_test
-          build_environment: "libtorch 3.7m cpu gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_shared-with-deps_test
+          build_environment: "libtorch 2.7m cpu gcc5.4_cxx11-abi"
           requires:
             - setup
-            - binary_linux_libtorch_3_7m_cpu_gcc5_4_cxx11-abi_shared-with-deps_build
+            - binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_shared-with-deps_build
           libtorch_variant: "shared-with-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
 
+      - smoke_linux_test:
+          name: smoke_linux_manywheel_2_7m_cpu_devtoolset7_nightly
+          build_environment: "manywheel 2.7m cpu devtoolset7"
+          requires:
+            - setup
+            - update_s3_htmls_for_nightlies
+            - update_s3_htmls_for_nightlies_devtoolset7
+          filters:
+            branches:
+              only: postnightly
+          docker_image: "pytorch/manylinux-cuda100"
+      - smoke_linux_test:
+          name: smoke_linux_manywheel_2_7mu_cpu_devtoolset7_nightly
+          build_environment: "manywheel 2.7mu cpu devtoolset7"
+          requires:
+            - setup
+            - update_s3_htmls_for_nightlies
+            - update_s3_htmls_for_nightlies_devtoolset7
+          filters:
+            branches:
+              only: postnightly
+          docker_image: "pytorch/manylinux-cuda100"
       - smoke_linux_test:
           name: smoke_linux_manywheel_3_5m_cpu_devtoolset7_nightly
           build_environment: "manywheel 3.5m cpu devtoolset7"
@@ -2189,6 +2263,32 @@ workflows:
             branches:
               only: postnightly
           docker_image: "pytorch/manylinux-cuda100"
+      - smoke_linux_test:
+          name: smoke_linux_manywheel_2_7m_cu92_devtoolset7_nightly
+          build_environment: "manywheel 2.7m cu92 devtoolset7"
+          requires:
+            - setup
+            - update_s3_htmls_for_nightlies
+            - update_s3_htmls_for_nightlies_devtoolset7
+          filters:
+            branches:
+              only: postnightly
+          docker_image: "pytorch/manylinux-cuda92"
+          use_cuda_docker_runtime: "1"
+          resource_class: gpu.medium
+      - smoke_linux_test:
+          name: smoke_linux_manywheel_2_7mu_cu92_devtoolset7_nightly
+          build_environment: "manywheel 2.7mu cu92 devtoolset7"
+          requires:
+            - setup
+            - update_s3_htmls_for_nightlies
+            - update_s3_htmls_for_nightlies_devtoolset7
+          filters:
+            branches:
+              only: postnightly
+          docker_image: "pytorch/manylinux-cuda92"
+          use_cuda_docker_runtime: "1"
+          resource_class: gpu.medium
       - smoke_linux_test:
           name: smoke_linux_manywheel_3_5m_cu92_devtoolset7_nightly
           build_environment: "manywheel 3.5m cu92 devtoolset7"
@@ -2226,6 +2326,32 @@ workflows:
             branches:
               only: postnightly
           docker_image: "pytorch/manylinux-cuda92"
+          use_cuda_docker_runtime: "1"
+          resource_class: gpu.medium
+      - smoke_linux_test:
+          name: smoke_linux_manywheel_2_7m_cu100_devtoolset7_nightly
+          build_environment: "manywheel 2.7m cu100 devtoolset7"
+          requires:
+            - setup
+            - update_s3_htmls_for_nightlies
+            - update_s3_htmls_for_nightlies_devtoolset7
+          filters:
+            branches:
+              only: postnightly
+          docker_image: "pytorch/manylinux-cuda100"
+          use_cuda_docker_runtime: "1"
+          resource_class: gpu.medium
+      - smoke_linux_test:
+          name: smoke_linux_manywheel_2_7mu_cu100_devtoolset7_nightly
+          build_environment: "manywheel 2.7mu cu100 devtoolset7"
+          requires:
+            - setup
+            - update_s3_htmls_for_nightlies
+            - update_s3_htmls_for_nightlies_devtoolset7
+          filters:
+            branches:
+              only: postnightly
+          docker_image: "pytorch/manylinux-cuda100"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
@@ -2268,6 +2394,32 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
+          name: smoke_linux_manywheel_2_7m_cu101_devtoolset7_nightly
+          build_environment: "manywheel 2.7m cu101 devtoolset7"
+          requires:
+            - setup
+            - update_s3_htmls_for_nightlies
+            - update_s3_htmls_for_nightlies_devtoolset7
+          filters:
+            branches:
+              only: postnightly
+          docker_image: "pytorch/manylinux-cuda101"
+          use_cuda_docker_runtime: "1"
+          resource_class: gpu.medium
+      - smoke_linux_test:
+          name: smoke_linux_manywheel_2_7mu_cu101_devtoolset7_nightly
+          build_environment: "manywheel 2.7mu cu101 devtoolset7"
+          requires:
+            - setup
+            - update_s3_htmls_for_nightlies
+            - update_s3_htmls_for_nightlies_devtoolset7
+          filters:
+            branches:
+              only: postnightly
+          docker_image: "pytorch/manylinux-cuda101"
+          use_cuda_docker_runtime: "1"
+          resource_class: gpu.medium
+      - smoke_linux_test:
           name: smoke_linux_manywheel_3_5m_cu101_devtoolset7_nightly
           build_environment: "manywheel 3.5m cu101 devtoolset7"
           requires:
@@ -2307,6 +2459,17 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
+          name: smoke_linux_conda_2_7_cpu_devtoolset7_nightly
+          build_environment: "conda 2.7 cpu devtoolset7"
+          requires:
+            - setup
+            - update_s3_htmls_for_nightlies
+            - update_s3_htmls_for_nightlies_devtoolset7
+          filters:
+            branches:
+              only: postnightly
+          docker_image: "pytorch/conda-cuda"
+      - smoke_linux_test:
           name: smoke_linux_conda_3_5_cpu_devtoolset7_nightly
           build_environment: "conda 3.5 cpu devtoolset7"
           requires:
@@ -2340,6 +2503,19 @@ workflows:
               only: postnightly
           docker_image: "pytorch/conda-cuda"
       - smoke_linux_test:
+          name: smoke_linux_conda_2_7_cu92_devtoolset7_nightly
+          build_environment: "conda 2.7 cu92 devtoolset7"
+          requires:
+            - setup
+            - update_s3_htmls_for_nightlies
+            - update_s3_htmls_for_nightlies_devtoolset7
+          filters:
+            branches:
+              only: postnightly
+          docker_image: "pytorch/conda-cuda"
+          use_cuda_docker_runtime: "1"
+          resource_class: gpu.medium
+      - smoke_linux_test:
           name: smoke_linux_conda_3_5_cu92_devtoolset7_nightly
           build_environment: "conda 3.5 cu92 devtoolset7"
           requires:
@@ -2368,6 +2544,19 @@ workflows:
       - smoke_linux_test:
           name: smoke_linux_conda_3_7_cu92_devtoolset7_nightly
           build_environment: "conda 3.7 cu92 devtoolset7"
+          requires:
+            - setup
+            - update_s3_htmls_for_nightlies
+            - update_s3_htmls_for_nightlies_devtoolset7
+          filters:
+            branches:
+              only: postnightly
+          docker_image: "pytorch/conda-cuda"
+          use_cuda_docker_runtime: "1"
+          resource_class: gpu.medium
+      - smoke_linux_test:
+          name: smoke_linux_conda_2_7_cu100_devtoolset7_nightly
+          build_environment: "conda 2.7 cu100 devtoolset7"
           requires:
             - setup
             - update_s3_htmls_for_nightlies
@@ -2418,6 +2607,19 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
+          name: smoke_linux_conda_2_7_cu101_devtoolset7_nightly
+          build_environment: "conda 2.7 cu101 devtoolset7"
+          requires:
+            - setup
+            - update_s3_htmls_for_nightlies
+            - update_s3_htmls_for_nightlies_devtoolset7
+          filters:
+            branches:
+              only: postnightly
+          docker_image: "pytorch/conda-cuda"
+          use_cuda_docker_runtime: "1"
+          resource_class: gpu.medium
+      - smoke_linux_test:
           name: smoke_linux_conda_3_5_cu101_devtoolset7_nightly
           build_environment: "conda 3.5 cu101 devtoolset7"
           requires:
@@ -2457,8 +2659,8 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
-          name: smoke_linux_libtorch_3_7m_cpu_devtoolset7_nightly_shared-with-deps
-          build_environment: "libtorch 3.7m cpu devtoolset7"
+          name: smoke_linux_libtorch_2_7m_cpu_devtoolset7_nightly_shared-with-deps
+          build_environment: "libtorch 2.7m cpu devtoolset7"
           requires:
             - setup
             - update_s3_htmls_for_nightlies
@@ -2469,8 +2671,8 @@ workflows:
           libtorch_variant: "shared-with-deps"
           docker_image: "pytorch/manylinux-cuda100"
       - smoke_linux_test:
-          name: smoke_linux_libtorch_3_7m_cpu_devtoolset7_nightly_shared-without-deps
-          build_environment: "libtorch 3.7m cpu devtoolset7"
+          name: smoke_linux_libtorch_2_7m_cpu_devtoolset7_nightly_shared-without-deps
+          build_environment: "libtorch 2.7m cpu devtoolset7"
           requires:
             - setup
             - update_s3_htmls_for_nightlies
@@ -2481,8 +2683,8 @@ workflows:
           libtorch_variant: "shared-without-deps"
           docker_image: "pytorch/manylinux-cuda100"
       - smoke_linux_test:
-          name: smoke_linux_libtorch_3_7m_cpu_devtoolset7_nightly_static-with-deps
-          build_environment: "libtorch 3.7m cpu devtoolset7"
+          name: smoke_linux_libtorch_2_7m_cpu_devtoolset7_nightly_static-with-deps
+          build_environment: "libtorch 2.7m cpu devtoolset7"
           requires:
             - setup
             - update_s3_htmls_for_nightlies
@@ -2493,8 +2695,8 @@ workflows:
           libtorch_variant: "static-with-deps"
           docker_image: "pytorch/manylinux-cuda100"
       - smoke_linux_test:
-          name: smoke_linux_libtorch_3_7m_cpu_devtoolset7_nightly_static-without-deps
-          build_environment: "libtorch 3.7m cpu devtoolset7"
+          name: smoke_linux_libtorch_2_7m_cpu_devtoolset7_nightly_static-without-deps
+          build_environment: "libtorch 2.7m cpu devtoolset7"
           requires:
             - setup
             - update_s3_htmls_for_nightlies
@@ -2505,8 +2707,8 @@ workflows:
           libtorch_variant: "static-without-deps"
           docker_image: "pytorch/manylinux-cuda100"
       - smoke_linux_test:
-          name: smoke_linux_libtorch_3_7m_cu92_devtoolset7_nightly_shared-with-deps
-          build_environment: "libtorch 3.7m cu92 devtoolset7"
+          name: smoke_linux_libtorch_2_7m_cu92_devtoolset7_nightly_shared-with-deps
+          build_environment: "libtorch 2.7m cu92 devtoolset7"
           requires:
             - setup
             - update_s3_htmls_for_nightlies
@@ -2519,8 +2721,8 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
-          name: smoke_linux_libtorch_3_7m_cu92_devtoolset7_nightly_shared-without-deps
-          build_environment: "libtorch 3.7m cu92 devtoolset7"
+          name: smoke_linux_libtorch_2_7m_cu92_devtoolset7_nightly_shared-without-deps
+          build_environment: "libtorch 2.7m cu92 devtoolset7"
           requires:
             - setup
             - update_s3_htmls_for_nightlies
@@ -2533,8 +2735,8 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
-          name: smoke_linux_libtorch_3_7m_cu92_devtoolset7_nightly_static-with-deps
-          build_environment: "libtorch 3.7m cu92 devtoolset7"
+          name: smoke_linux_libtorch_2_7m_cu92_devtoolset7_nightly_static-with-deps
+          build_environment: "libtorch 2.7m cu92 devtoolset7"
           requires:
             - setup
             - update_s3_htmls_for_nightlies
@@ -2547,8 +2749,8 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
-          name: smoke_linux_libtorch_3_7m_cu92_devtoolset7_nightly_static-without-deps
-          build_environment: "libtorch 3.7m cu92 devtoolset7"
+          name: smoke_linux_libtorch_2_7m_cu92_devtoolset7_nightly_static-without-deps
+          build_environment: "libtorch 2.7m cu92 devtoolset7"
           requires:
             - setup
             - update_s3_htmls_for_nightlies
@@ -2561,8 +2763,8 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
-          name: smoke_linux_libtorch_3_7m_cu100_devtoolset7_nightly_shared-with-deps
-          build_environment: "libtorch 3.7m cu100 devtoolset7"
+          name: smoke_linux_libtorch_2_7m_cu100_devtoolset7_nightly_shared-with-deps
+          build_environment: "libtorch 2.7m cu100 devtoolset7"
           requires:
             - setup
             - update_s3_htmls_for_nightlies
@@ -2575,8 +2777,8 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
-          name: smoke_linux_libtorch_3_7m_cu100_devtoolset7_nightly_shared-without-deps
-          build_environment: "libtorch 3.7m cu100 devtoolset7"
+          name: smoke_linux_libtorch_2_7m_cu100_devtoolset7_nightly_shared-without-deps
+          build_environment: "libtorch 2.7m cu100 devtoolset7"
           requires:
             - setup
             - update_s3_htmls_for_nightlies
@@ -2589,8 +2791,8 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
-          name: smoke_linux_libtorch_3_7m_cu100_devtoolset7_nightly_static-with-deps
-          build_environment: "libtorch 3.7m cu100 devtoolset7"
+          name: smoke_linux_libtorch_2_7m_cu100_devtoolset7_nightly_static-with-deps
+          build_environment: "libtorch 2.7m cu100 devtoolset7"
           requires:
             - setup
             - update_s3_htmls_for_nightlies
@@ -2603,8 +2805,8 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
-          name: smoke_linux_libtorch_3_7m_cu100_devtoolset7_nightly_static-without-deps
-          build_environment: "libtorch 3.7m cu100 devtoolset7"
+          name: smoke_linux_libtorch_2_7m_cu100_devtoolset7_nightly_static-without-deps
+          build_environment: "libtorch 2.7m cu100 devtoolset7"
           requires:
             - setup
             - update_s3_htmls_for_nightlies
@@ -2617,8 +2819,8 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
-          name: smoke_linux_libtorch_3_7m_cu101_devtoolset7_nightly_shared-with-deps
-          build_environment: "libtorch 3.7m cu101 devtoolset7"
+          name: smoke_linux_libtorch_2_7m_cu101_devtoolset7_nightly_shared-with-deps
+          build_environment: "libtorch 2.7m cu101 devtoolset7"
           requires:
             - setup
             - update_s3_htmls_for_nightlies
@@ -2631,8 +2833,8 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
-          name: smoke_linux_libtorch_3_7m_cu101_devtoolset7_nightly_shared-without-deps
-          build_environment: "libtorch 3.7m cu101 devtoolset7"
+          name: smoke_linux_libtorch_2_7m_cu101_devtoolset7_nightly_shared-without-deps
+          build_environment: "libtorch 2.7m cu101 devtoolset7"
           requires:
             - setup
             - update_s3_htmls_for_nightlies
@@ -2645,8 +2847,8 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
-          name: smoke_linux_libtorch_3_7m_cu101_devtoolset7_nightly_static-with-deps
-          build_environment: "libtorch 3.7m cu101 devtoolset7"
+          name: smoke_linux_libtorch_2_7m_cu101_devtoolset7_nightly_static-with-deps
+          build_environment: "libtorch 2.7m cu101 devtoolset7"
           requires:
             - setup
             - update_s3_htmls_for_nightlies
@@ -2659,8 +2861,8 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
-          name: smoke_linux_libtorch_3_7m_cu101_devtoolset7_nightly_static-without-deps
-          build_environment: "libtorch 3.7m cu101 devtoolset7"
+          name: smoke_linux_libtorch_2_7m_cu101_devtoolset7_nightly_static-without-deps
+          build_environment: "libtorch 2.7m cu101 devtoolset7"
           requires:
             - setup
             - update_s3_htmls_for_nightlies
@@ -2673,8 +2875,8 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
-          name: smoke_linux_libtorch_3_7m_cpu_gcc5_4_cxx11-abi_nightly_shared-with-deps
-          build_environment: "libtorch 3.7m cpu gcc5.4_cxx11-abi"
+          name: smoke_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_nightly_shared-with-deps
+          build_environment: "libtorch 2.7m cpu gcc5.4_cxx11-abi"
           requires:
             - setup
             - update_s3_htmls_for_nightlies
@@ -2685,8 +2887,8 @@ workflows:
           libtorch_variant: "shared-with-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
       - smoke_linux_test:
-          name: smoke_linux_libtorch_3_7m_cpu_gcc5_4_cxx11-abi_nightly_shared-without-deps
-          build_environment: "libtorch 3.7m cpu gcc5.4_cxx11-abi"
+          name: smoke_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_nightly_shared-without-deps
+          build_environment: "libtorch 2.7m cpu gcc5.4_cxx11-abi"
           requires:
             - setup
             - update_s3_htmls_for_nightlies
@@ -2697,8 +2899,8 @@ workflows:
           libtorch_variant: "shared-without-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
       - smoke_linux_test:
-          name: smoke_linux_libtorch_3_7m_cpu_gcc5_4_cxx11-abi_nightly_static-with-deps
-          build_environment: "libtorch 3.7m cpu gcc5.4_cxx11-abi"
+          name: smoke_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_nightly_static-with-deps
+          build_environment: "libtorch 2.7m cpu gcc5.4_cxx11-abi"
           requires:
             - setup
             - update_s3_htmls_for_nightlies
@@ -2709,8 +2911,8 @@ workflows:
           libtorch_variant: "static-with-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
       - smoke_linux_test:
-          name: smoke_linux_libtorch_3_7m_cpu_gcc5_4_cxx11-abi_nightly_static-without-deps
-          build_environment: "libtorch 3.7m cpu gcc5.4_cxx11-abi"
+          name: smoke_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_nightly_static-without-deps
+          build_environment: "libtorch 2.7m cpu gcc5.4_cxx11-abi"
           requires:
             - setup
             - update_s3_htmls_for_nightlies
@@ -2721,64 +2923,8 @@ workflows:
           libtorch_variant: "static-without-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
       - smoke_linux_test:
-          name: smoke_linux_libtorch_3_7m_cu92_gcc5_4_cxx11-abi_nightly_shared-with-deps
-          build_environment: "libtorch 3.7m cu92 gcc5.4_cxx11-abi"
-          requires:
-            - setup
-            - update_s3_htmls_for_nightlies
-            - update_s3_htmls_for_nightlies_devtoolset7
-          filters:
-            branches:
-              only: postnightly
-          libtorch_variant: "shared-with-deps"
-          docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
-          use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
-      - smoke_linux_test:
-          name: smoke_linux_libtorch_3_7m_cu92_gcc5_4_cxx11-abi_nightly_shared-without-deps
-          build_environment: "libtorch 3.7m cu92 gcc5.4_cxx11-abi"
-          requires:
-            - setup
-            - update_s3_htmls_for_nightlies
-            - update_s3_htmls_for_nightlies_devtoolset7
-          filters:
-            branches:
-              only: postnightly
-          libtorch_variant: "shared-without-deps"
-          docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
-          use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
-      - smoke_linux_test:
-          name: smoke_linux_libtorch_3_7m_cu92_gcc5_4_cxx11-abi_nightly_static-with-deps
-          build_environment: "libtorch 3.7m cu92 gcc5.4_cxx11-abi"
-          requires:
-            - setup
-            - update_s3_htmls_for_nightlies
-            - update_s3_htmls_for_nightlies_devtoolset7
-          filters:
-            branches:
-              only: postnightly
-          libtorch_variant: "static-with-deps"
-          docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
-          use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
-      - smoke_linux_test:
-          name: smoke_linux_libtorch_3_7m_cu92_gcc5_4_cxx11-abi_nightly_static-without-deps
-          build_environment: "libtorch 3.7m cu92 gcc5.4_cxx11-abi"
-          requires:
-            - setup
-            - update_s3_htmls_for_nightlies
-            - update_s3_htmls_for_nightlies_devtoolset7
-          filters:
-            branches:
-              only: postnightly
-          libtorch_variant: "static-without-deps"
-          docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
-          use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
-      - smoke_linux_test:
-          name: smoke_linux_libtorch_3_7m_cu100_gcc5_4_cxx11-abi_nightly_shared-with-deps
-          build_environment: "libtorch 3.7m cu100 gcc5.4_cxx11-abi"
+          name: smoke_linux_libtorch_2_7m_cu92_gcc5_4_cxx11-abi_nightly_shared-with-deps
+          build_environment: "libtorch 2.7m cu92 gcc5.4_cxx11-abi"
           requires:
             - setup
             - update_s3_htmls_for_nightlies
@@ -2791,8 +2937,8 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
-          name: smoke_linux_libtorch_3_7m_cu100_gcc5_4_cxx11-abi_nightly_shared-without-deps
-          build_environment: "libtorch 3.7m cu100 gcc5.4_cxx11-abi"
+          name: smoke_linux_libtorch_2_7m_cu92_gcc5_4_cxx11-abi_nightly_shared-without-deps
+          build_environment: "libtorch 2.7m cu92 gcc5.4_cxx11-abi"
           requires:
             - setup
             - update_s3_htmls_for_nightlies
@@ -2805,8 +2951,8 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
-          name: smoke_linux_libtorch_3_7m_cu100_gcc5_4_cxx11-abi_nightly_static-with-deps
-          build_environment: "libtorch 3.7m cu100 gcc5.4_cxx11-abi"
+          name: smoke_linux_libtorch_2_7m_cu92_gcc5_4_cxx11-abi_nightly_static-with-deps
+          build_environment: "libtorch 2.7m cu92 gcc5.4_cxx11-abi"
           requires:
             - setup
             - update_s3_htmls_for_nightlies
@@ -2819,8 +2965,8 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
-          name: smoke_linux_libtorch_3_7m_cu100_gcc5_4_cxx11-abi_nightly_static-without-deps
-          build_environment: "libtorch 3.7m cu100 gcc5.4_cxx11-abi"
+          name: smoke_linux_libtorch_2_7m_cu92_gcc5_4_cxx11-abi_nightly_static-without-deps
+          build_environment: "libtorch 2.7m cu92 gcc5.4_cxx11-abi"
           requires:
             - setup
             - update_s3_htmls_for_nightlies
@@ -2833,8 +2979,8 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
-          name: smoke_linux_libtorch_3_7m_cu101_gcc5_4_cxx11-abi_nightly_shared-with-deps
-          build_environment: "libtorch 3.7m cu101 gcc5.4_cxx11-abi"
+          name: smoke_linux_libtorch_2_7m_cu100_gcc5_4_cxx11-abi_nightly_shared-with-deps
+          build_environment: "libtorch 2.7m cu100 gcc5.4_cxx11-abi"
           requires:
             - setup
             - update_s3_htmls_for_nightlies
@@ -2847,8 +2993,8 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
-          name: smoke_linux_libtorch_3_7m_cu101_gcc5_4_cxx11-abi_nightly_shared-without-deps
-          build_environment: "libtorch 3.7m cu101 gcc5.4_cxx11-abi"
+          name: smoke_linux_libtorch_2_7m_cu100_gcc5_4_cxx11-abi_nightly_shared-without-deps
+          build_environment: "libtorch 2.7m cu100 gcc5.4_cxx11-abi"
           requires:
             - setup
             - update_s3_htmls_for_nightlies
@@ -2861,8 +3007,8 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
-          name: smoke_linux_libtorch_3_7m_cu101_gcc5_4_cxx11-abi_nightly_static-with-deps
-          build_environment: "libtorch 3.7m cu101 gcc5.4_cxx11-abi"
+          name: smoke_linux_libtorch_2_7m_cu100_gcc5_4_cxx11-abi_nightly_static-with-deps
+          build_environment: "libtorch 2.7m cu100 gcc5.4_cxx11-abi"
           requires:
             - setup
             - update_s3_htmls_for_nightlies
@@ -2875,8 +3021,8 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
-          name: smoke_linux_libtorch_3_7m_cu101_gcc5_4_cxx11-abi_nightly_static-without-deps
-          build_environment: "libtorch 3.7m cu101 gcc5.4_cxx11-abi"
+          name: smoke_linux_libtorch_2_7m_cu100_gcc5_4_cxx11-abi_nightly_static-without-deps
+          build_environment: "libtorch 2.7m cu100 gcc5.4_cxx11-abi"
           requires:
             - setup
             - update_s3_htmls_for_nightlies
@@ -2888,6 +3034,72 @@ workflows:
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
+      - smoke_linux_test:
+          name: smoke_linux_libtorch_2_7m_cu101_gcc5_4_cxx11-abi_nightly_shared-with-deps
+          build_environment: "libtorch 2.7m cu101 gcc5.4_cxx11-abi"
+          requires:
+            - setup
+            - update_s3_htmls_for_nightlies
+            - update_s3_htmls_for_nightlies_devtoolset7
+          filters:
+            branches:
+              only: postnightly
+          libtorch_variant: "shared-with-deps"
+          docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
+          use_cuda_docker_runtime: "1"
+          resource_class: gpu.medium
+      - smoke_linux_test:
+          name: smoke_linux_libtorch_2_7m_cu101_gcc5_4_cxx11-abi_nightly_shared-without-deps
+          build_environment: "libtorch 2.7m cu101 gcc5.4_cxx11-abi"
+          requires:
+            - setup
+            - update_s3_htmls_for_nightlies
+            - update_s3_htmls_for_nightlies_devtoolset7
+          filters:
+            branches:
+              only: postnightly
+          libtorch_variant: "shared-without-deps"
+          docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
+          use_cuda_docker_runtime: "1"
+          resource_class: gpu.medium
+      - smoke_linux_test:
+          name: smoke_linux_libtorch_2_7m_cu101_gcc5_4_cxx11-abi_nightly_static-with-deps
+          build_environment: "libtorch 2.7m cu101 gcc5.4_cxx11-abi"
+          requires:
+            - setup
+            - update_s3_htmls_for_nightlies
+            - update_s3_htmls_for_nightlies_devtoolset7
+          filters:
+            branches:
+              only: postnightly
+          libtorch_variant: "static-with-deps"
+          docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
+          use_cuda_docker_runtime: "1"
+          resource_class: gpu.medium
+      - smoke_linux_test:
+          name: smoke_linux_libtorch_2_7m_cu101_gcc5_4_cxx11-abi_nightly_static-without-deps
+          build_environment: "libtorch 2.7m cu101 gcc5.4_cxx11-abi"
+          requires:
+            - setup
+            - update_s3_htmls_for_nightlies
+            - update_s3_htmls_for_nightlies_devtoolset7
+          filters:
+            branches:
+              only: postnightly
+          libtorch_variant: "static-without-deps"
+          docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
+          use_cuda_docker_runtime: "1"
+          resource_class: gpu.medium
+      - smoke_mac_test:
+          name: smoke_macos_wheel_2_7_cpu_nightly
+          build_environment: "wheel 2.7 cpu"
+          requires:
+            - setup
+            - update_s3_htmls_for_nightlies
+            - update_s3_htmls_for_nightlies_devtoolset7
+          filters:
+            branches:
+              only: postnightly
       - smoke_mac_test:
           name: smoke_macos_wheel_3_5_cpu_nightly
           build_environment: "wheel 3.5 cpu"
@@ -2911,6 +3123,16 @@ workflows:
       - smoke_mac_test:
           name: smoke_macos_wheel_3_7_cpu_nightly
           build_environment: "wheel 3.7 cpu"
+          requires:
+            - setup
+            - update_s3_htmls_for_nightlies
+            - update_s3_htmls_for_nightlies_devtoolset7
+          filters:
+            branches:
+              only: postnightly
+      - smoke_mac_test:
+          name: smoke_macos_conda_2_7_cpu_nightly
+          build_environment: "conda 2.7 cpu"
           requires:
             - setup
             - update_s3_htmls_for_nightlies
@@ -2949,8 +3171,8 @@ workflows:
             branches:
               only: postnightly
       - smoke_mac_test:
-          name: smoke_macos_libtorch_3_7_cpu_nightly
-          build_environment: "libtorch 3.7 cpu"
+          name: smoke_macos_libtorch_2_7_cpu_nightly
+          build_environment: "libtorch 2.7 cpu"
           requires:
             - setup
             - update_s3_htmls_for_nightlies
@@ -2958,6 +3180,24 @@ workflows:
           filters:
             branches:
               only: postnightly
+      - binary_linux_build:
+          name: binary_linux_manywheel_2_7m_cpu_devtoolset7_nightly_build
+          build_environment: "manywheel 2.7m cpu devtoolset7"
+          requires:
+            - setup
+          filters:
+            branches:
+              only: nightly
+          docker_image: "pytorch/manylinux-cuda100"
+      - binary_linux_build:
+          name: binary_linux_manywheel_2_7mu_cpu_devtoolset7_nightly_build
+          build_environment: "manywheel 2.7mu cpu devtoolset7"
+          requires:
+            - setup
+          filters:
+            branches:
+              only: nightly
+          docker_image: "pytorch/manylinux-cuda100"
       - binary_linux_build:
           name: binary_linux_manywheel_3_5m_cpu_devtoolset7_nightly_build
           build_environment: "manywheel 3.5m cpu devtoolset7"
@@ -2986,6 +3226,24 @@ workflows:
               only: nightly
           docker_image: "pytorch/manylinux-cuda100"
       - binary_linux_build:
+          name: binary_linux_manywheel_2_7m_cu92_devtoolset7_nightly_build
+          build_environment: "manywheel 2.7m cu92 devtoolset7"
+          requires:
+            - setup
+          filters:
+            branches:
+              only: nightly
+          docker_image: "pytorch/manylinux-cuda92"
+      - binary_linux_build:
+          name: binary_linux_manywheel_2_7mu_cu92_devtoolset7_nightly_build
+          build_environment: "manywheel 2.7mu cu92 devtoolset7"
+          requires:
+            - setup
+          filters:
+            branches:
+              only: nightly
+          docker_image: "pytorch/manylinux-cuda92"
+      - binary_linux_build:
           name: binary_linux_manywheel_3_5m_cu92_devtoolset7_nightly_build
           build_environment: "manywheel 3.5m cu92 devtoolset7"
           requires:
@@ -3012,6 +3270,24 @@ workflows:
             branches:
               only: nightly
           docker_image: "pytorch/manylinux-cuda92"
+      - binary_linux_build:
+          name: binary_linux_manywheel_2_7m_cu100_devtoolset7_nightly_build
+          build_environment: "manywheel 2.7m cu100 devtoolset7"
+          requires:
+            - setup
+          filters:
+            branches:
+              only: nightly
+          docker_image: "pytorch/manylinux-cuda100"
+      - binary_linux_build:
+          name: binary_linux_manywheel_2_7mu_cu100_devtoolset7_nightly_build
+          build_environment: "manywheel 2.7mu cu100 devtoolset7"
+          requires:
+            - setup
+          filters:
+            branches:
+              only: nightly
+          docker_image: "pytorch/manylinux-cuda100"
       - binary_linux_build:
           name: binary_linux_manywheel_3_5m_cu100_devtoolset7_nightly_build
           build_environment: "manywheel 3.5m cu100 devtoolset7"
@@ -3040,6 +3316,24 @@ workflows:
               only: nightly
           docker_image: "pytorch/manylinux-cuda100"
       - binary_linux_build:
+          name: binary_linux_manywheel_2_7m_cu101_devtoolset7_nightly_build
+          build_environment: "manywheel 2.7m cu101 devtoolset7"
+          requires:
+            - setup
+          filters:
+            branches:
+              only: nightly
+          docker_image: "pytorch/manylinux-cuda101"
+      - binary_linux_build:
+          name: binary_linux_manywheel_2_7mu_cu101_devtoolset7_nightly_build
+          build_environment: "manywheel 2.7mu cu101 devtoolset7"
+          requires:
+            - setup
+          filters:
+            branches:
+              only: nightly
+          docker_image: "pytorch/manylinux-cuda101"
+      - binary_linux_build:
           name: binary_linux_manywheel_3_5m_cu101_devtoolset7_nightly_build
           build_environment: "manywheel 3.5m cu101 devtoolset7"
           requires:
@@ -3067,6 +3361,15 @@ workflows:
               only: nightly
           docker_image: "pytorch/manylinux-cuda101"
       - binary_linux_build:
+          name: binary_linux_conda_2_7_cpu_devtoolset7_nightly_build
+          build_environment: "conda 2.7 cpu devtoolset7"
+          requires:
+            - setup
+          filters:
+            branches:
+              only: nightly
+          docker_image: "pytorch/conda-cuda"
+      - binary_linux_build:
           name: binary_linux_conda_3_5_cpu_devtoolset7_nightly_build
           build_environment: "conda 3.5 cpu devtoolset7"
           requires:
@@ -3087,6 +3390,15 @@ workflows:
       - binary_linux_build:
           name: binary_linux_conda_3_7_cpu_devtoolset7_nightly_build
           build_environment: "conda 3.7 cpu devtoolset7"
+          requires:
+            - setup
+          filters:
+            branches:
+              only: nightly
+          docker_image: "pytorch/conda-cuda"
+      - binary_linux_build:
+          name: binary_linux_conda_2_7_cu92_devtoolset7_nightly_build
+          build_environment: "conda 2.7 cu92 devtoolset7"
           requires:
             - setup
           filters:
@@ -3121,6 +3433,15 @@ workflows:
               only: nightly
           docker_image: "pytorch/conda-cuda"
       - binary_linux_build:
+          name: binary_linux_conda_2_7_cu100_devtoolset7_nightly_build
+          build_environment: "conda 2.7 cu100 devtoolset7"
+          requires:
+            - setup
+          filters:
+            branches:
+              only: nightly
+          docker_image: "pytorch/conda-cuda"
+      - binary_linux_build:
           name: binary_linux_conda_3_5_cu100_devtoolset7_nightly_build
           build_environment: "conda 3.5 cu100 devtoolset7"
           requires:
@@ -3141,6 +3462,15 @@ workflows:
       - binary_linux_build:
           name: binary_linux_conda_3_7_cu100_devtoolset7_nightly_build
           build_environment: "conda 3.7 cu100 devtoolset7"
+          requires:
+            - setup
+          filters:
+            branches:
+              only: nightly
+          docker_image: "pytorch/conda-cuda"
+      - binary_linux_build:
+          name: binary_linux_conda_2_7_cu101_devtoolset7_nightly_build
+          build_environment: "conda 2.7 cu101 devtoolset7"
           requires:
             - setup
           filters:
@@ -3175,8 +3505,8 @@ workflows:
               only: nightly
           docker_image: "pytorch/conda-cuda"
       - binary_linux_build:
-          name: binary_linux_libtorch_3_7m_cpu_devtoolset7_nightly_shared-with-deps_build
-          build_environment: "libtorch 3.7m cpu devtoolset7"
+          name: binary_linux_libtorch_2_7m_cpu_devtoolset7_nightly_shared-with-deps_build
+          build_environment: "libtorch 2.7m cpu devtoolset7"
           requires:
             - setup
           filters:
@@ -3185,8 +3515,8 @@ workflows:
           libtorch_variant: "shared-with-deps"
           docker_image: "pytorch/manylinux-cuda100"
       - binary_linux_build:
-          name: binary_linux_libtorch_3_7m_cpu_devtoolset7_nightly_shared-without-deps_build
-          build_environment: "libtorch 3.7m cpu devtoolset7"
+          name: binary_linux_libtorch_2_7m_cpu_devtoolset7_nightly_shared-without-deps_build
+          build_environment: "libtorch 2.7m cpu devtoolset7"
           requires:
             - setup
           filters:
@@ -3195,8 +3525,8 @@ workflows:
           libtorch_variant: "shared-without-deps"
           docker_image: "pytorch/manylinux-cuda100"
       - binary_linux_build:
-          name: binary_linux_libtorch_3_7m_cpu_devtoolset7_nightly_static-with-deps_build
-          build_environment: "libtorch 3.7m cpu devtoolset7"
+          name: binary_linux_libtorch_2_7m_cpu_devtoolset7_nightly_static-with-deps_build
+          build_environment: "libtorch 2.7m cpu devtoolset7"
           requires:
             - setup
           filters:
@@ -3205,8 +3535,8 @@ workflows:
           libtorch_variant: "static-with-deps"
           docker_image: "pytorch/manylinux-cuda100"
       - binary_linux_build:
-          name: binary_linux_libtorch_3_7m_cpu_devtoolset7_nightly_static-without-deps_build
-          build_environment: "libtorch 3.7m cpu devtoolset7"
+          name: binary_linux_libtorch_2_7m_cpu_devtoolset7_nightly_static-without-deps_build
+          build_environment: "libtorch 2.7m cpu devtoolset7"
           requires:
             - setup
           filters:
@@ -3215,8 +3545,8 @@ workflows:
           libtorch_variant: "static-without-deps"
           docker_image: "pytorch/manylinux-cuda100"
       - binary_linux_build:
-          name: binary_linux_libtorch_3_7m_cu92_devtoolset7_nightly_shared-with-deps_build
-          build_environment: "libtorch 3.7m cu92 devtoolset7"
+          name: binary_linux_libtorch_2_7m_cu92_devtoolset7_nightly_shared-with-deps_build
+          build_environment: "libtorch 2.7m cu92 devtoolset7"
           requires:
             - setup
           filters:
@@ -3225,8 +3555,8 @@ workflows:
           libtorch_variant: "shared-with-deps"
           docker_image: "pytorch/manylinux-cuda92"
       - binary_linux_build:
-          name: binary_linux_libtorch_3_7m_cu92_devtoolset7_nightly_shared-without-deps_build
-          build_environment: "libtorch 3.7m cu92 devtoolset7"
+          name: binary_linux_libtorch_2_7m_cu92_devtoolset7_nightly_shared-without-deps_build
+          build_environment: "libtorch 2.7m cu92 devtoolset7"
           requires:
             - setup
           filters:
@@ -3235,8 +3565,8 @@ workflows:
           libtorch_variant: "shared-without-deps"
           docker_image: "pytorch/manylinux-cuda92"
       - binary_linux_build:
-          name: binary_linux_libtorch_3_7m_cu92_devtoolset7_nightly_static-with-deps_build
-          build_environment: "libtorch 3.7m cu92 devtoolset7"
+          name: binary_linux_libtorch_2_7m_cu92_devtoolset7_nightly_static-with-deps_build
+          build_environment: "libtorch 2.7m cu92 devtoolset7"
           requires:
             - setup
           filters:
@@ -3245,8 +3575,8 @@ workflows:
           libtorch_variant: "static-with-deps"
           docker_image: "pytorch/manylinux-cuda92"
       - binary_linux_build:
-          name: binary_linux_libtorch_3_7m_cu92_devtoolset7_nightly_static-without-deps_build
-          build_environment: "libtorch 3.7m cu92 devtoolset7"
+          name: binary_linux_libtorch_2_7m_cu92_devtoolset7_nightly_static-without-deps_build
+          build_environment: "libtorch 2.7m cu92 devtoolset7"
           requires:
             - setup
           filters:
@@ -3255,8 +3585,8 @@ workflows:
           libtorch_variant: "static-without-deps"
           docker_image: "pytorch/manylinux-cuda92"
       - binary_linux_build:
-          name: binary_linux_libtorch_3_7m_cu100_devtoolset7_nightly_shared-with-deps_build
-          build_environment: "libtorch 3.7m cu100 devtoolset7"
+          name: binary_linux_libtorch_2_7m_cu100_devtoolset7_nightly_shared-with-deps_build
+          build_environment: "libtorch 2.7m cu100 devtoolset7"
           requires:
             - setup
           filters:
@@ -3265,8 +3595,8 @@ workflows:
           libtorch_variant: "shared-with-deps"
           docker_image: "pytorch/manylinux-cuda100"
       - binary_linux_build:
-          name: binary_linux_libtorch_3_7m_cu100_devtoolset7_nightly_shared-without-deps_build
-          build_environment: "libtorch 3.7m cu100 devtoolset7"
+          name: binary_linux_libtorch_2_7m_cu100_devtoolset7_nightly_shared-without-deps_build
+          build_environment: "libtorch 2.7m cu100 devtoolset7"
           requires:
             - setup
           filters:
@@ -3275,8 +3605,8 @@ workflows:
           libtorch_variant: "shared-without-deps"
           docker_image: "pytorch/manylinux-cuda100"
       - binary_linux_build:
-          name: binary_linux_libtorch_3_7m_cu100_devtoolset7_nightly_static-with-deps_build
-          build_environment: "libtorch 3.7m cu100 devtoolset7"
+          name: binary_linux_libtorch_2_7m_cu100_devtoolset7_nightly_static-with-deps_build
+          build_environment: "libtorch 2.7m cu100 devtoolset7"
           requires:
             - setup
           filters:
@@ -3285,8 +3615,8 @@ workflows:
           libtorch_variant: "static-with-deps"
           docker_image: "pytorch/manylinux-cuda100"
       - binary_linux_build:
-          name: binary_linux_libtorch_3_7m_cu100_devtoolset7_nightly_static-without-deps_build
-          build_environment: "libtorch 3.7m cu100 devtoolset7"
+          name: binary_linux_libtorch_2_7m_cu100_devtoolset7_nightly_static-without-deps_build
+          build_environment: "libtorch 2.7m cu100 devtoolset7"
           requires:
             - setup
           filters:
@@ -3295,8 +3625,8 @@ workflows:
           libtorch_variant: "static-without-deps"
           docker_image: "pytorch/manylinux-cuda100"
       - binary_linux_build:
-          name: binary_linux_libtorch_3_7m_cu101_devtoolset7_nightly_shared-with-deps_build
-          build_environment: "libtorch 3.7m cu101 devtoolset7"
+          name: binary_linux_libtorch_2_7m_cu101_devtoolset7_nightly_shared-with-deps_build
+          build_environment: "libtorch 2.7m cu101 devtoolset7"
           requires:
             - setup
           filters:
@@ -3305,8 +3635,8 @@ workflows:
           libtorch_variant: "shared-with-deps"
           docker_image: "pytorch/manylinux-cuda101"
       - binary_linux_build:
-          name: binary_linux_libtorch_3_7m_cu101_devtoolset7_nightly_shared-without-deps_build
-          build_environment: "libtorch 3.7m cu101 devtoolset7"
+          name: binary_linux_libtorch_2_7m_cu101_devtoolset7_nightly_shared-without-deps_build
+          build_environment: "libtorch 2.7m cu101 devtoolset7"
           requires:
             - setup
           filters:
@@ -3315,8 +3645,8 @@ workflows:
           libtorch_variant: "shared-without-deps"
           docker_image: "pytorch/manylinux-cuda101"
       - binary_linux_build:
-          name: binary_linux_libtorch_3_7m_cu101_devtoolset7_nightly_static-with-deps_build
-          build_environment: "libtorch 3.7m cu101 devtoolset7"
+          name: binary_linux_libtorch_2_7m_cu101_devtoolset7_nightly_static-with-deps_build
+          build_environment: "libtorch 2.7m cu101 devtoolset7"
           requires:
             - setup
           filters:
@@ -3325,8 +3655,8 @@ workflows:
           libtorch_variant: "static-with-deps"
           docker_image: "pytorch/manylinux-cuda101"
       - binary_linux_build:
-          name: binary_linux_libtorch_3_7m_cu101_devtoolset7_nightly_static-without-deps_build
-          build_environment: "libtorch 3.7m cu101 devtoolset7"
+          name: binary_linux_libtorch_2_7m_cu101_devtoolset7_nightly_static-without-deps_build
+          build_environment: "libtorch 2.7m cu101 devtoolset7"
           requires:
             - setup
           filters:
@@ -3335,8 +3665,8 @@ workflows:
           libtorch_variant: "static-without-deps"
           docker_image: "pytorch/manylinux-cuda101"
       - binary_linux_build:
-          name: binary_linux_libtorch_3_7m_cpu_gcc5_4_cxx11-abi_nightly_shared-with-deps_build
-          build_environment: "libtorch 3.7m cpu gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_nightly_shared-with-deps_build
+          build_environment: "libtorch 2.7m cpu gcc5.4_cxx11-abi"
           requires:
             - setup
           filters:
@@ -3345,8 +3675,8 @@ workflows:
           libtorch_variant: "shared-with-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
       - binary_linux_build:
-          name: binary_linux_libtorch_3_7m_cpu_gcc5_4_cxx11-abi_nightly_shared-without-deps_build
-          build_environment: "libtorch 3.7m cpu gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_nightly_shared-without-deps_build
+          build_environment: "libtorch 2.7m cpu gcc5.4_cxx11-abi"
           requires:
             - setup
           filters:
@@ -3355,8 +3685,8 @@ workflows:
           libtorch_variant: "shared-without-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
       - binary_linux_build:
-          name: binary_linux_libtorch_3_7m_cpu_gcc5_4_cxx11-abi_nightly_static-with-deps_build
-          build_environment: "libtorch 3.7m cpu gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_nightly_static-with-deps_build
+          build_environment: "libtorch 2.7m cpu gcc5.4_cxx11-abi"
           requires:
             - setup
           filters:
@@ -3365,8 +3695,8 @@ workflows:
           libtorch_variant: "static-with-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
       - binary_linux_build:
-          name: binary_linux_libtorch_3_7m_cpu_gcc5_4_cxx11-abi_nightly_static-without-deps_build
-          build_environment: "libtorch 3.7m cpu gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_nightly_static-without-deps_build
+          build_environment: "libtorch 2.7m cpu gcc5.4_cxx11-abi"
           requires:
             - setup
           filters:
@@ -3375,8 +3705,8 @@ workflows:
           libtorch_variant: "static-without-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
       - binary_linux_build:
-          name: binary_linux_libtorch_3_7m_cu92_gcc5_4_cxx11-abi_nightly_shared-with-deps_build
-          build_environment: "libtorch 3.7m cu92 gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_2_7m_cu92_gcc5_4_cxx11-abi_nightly_shared-with-deps_build
+          build_environment: "libtorch 2.7m cu92 gcc5.4_cxx11-abi"
           requires:
             - setup
           filters:
@@ -3385,8 +3715,8 @@ workflows:
           libtorch_variant: "shared-with-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
       - binary_linux_build:
-          name: binary_linux_libtorch_3_7m_cu92_gcc5_4_cxx11-abi_nightly_shared-without-deps_build
-          build_environment: "libtorch 3.7m cu92 gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_2_7m_cu92_gcc5_4_cxx11-abi_nightly_shared-without-deps_build
+          build_environment: "libtorch 2.7m cu92 gcc5.4_cxx11-abi"
           requires:
             - setup
           filters:
@@ -3395,8 +3725,8 @@ workflows:
           libtorch_variant: "shared-without-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
       - binary_linux_build:
-          name: binary_linux_libtorch_3_7m_cu92_gcc5_4_cxx11-abi_nightly_static-with-deps_build
-          build_environment: "libtorch 3.7m cu92 gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_2_7m_cu92_gcc5_4_cxx11-abi_nightly_static-with-deps_build
+          build_environment: "libtorch 2.7m cu92 gcc5.4_cxx11-abi"
           requires:
             - setup
           filters:
@@ -3405,8 +3735,8 @@ workflows:
           libtorch_variant: "static-with-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
       - binary_linux_build:
-          name: binary_linux_libtorch_3_7m_cu92_gcc5_4_cxx11-abi_nightly_static-without-deps_build
-          build_environment: "libtorch 3.7m cu92 gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_2_7m_cu92_gcc5_4_cxx11-abi_nightly_static-without-deps_build
+          build_environment: "libtorch 2.7m cu92 gcc5.4_cxx11-abi"
           requires:
             - setup
           filters:
@@ -3415,8 +3745,8 @@ workflows:
           libtorch_variant: "static-without-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
       - binary_linux_build:
-          name: binary_linux_libtorch_3_7m_cu100_gcc5_4_cxx11-abi_nightly_shared-with-deps_build
-          build_environment: "libtorch 3.7m cu100 gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_2_7m_cu100_gcc5_4_cxx11-abi_nightly_shared-with-deps_build
+          build_environment: "libtorch 2.7m cu100 gcc5.4_cxx11-abi"
           requires:
             - setup
           filters:
@@ -3425,8 +3755,8 @@ workflows:
           libtorch_variant: "shared-with-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
       - binary_linux_build:
-          name: binary_linux_libtorch_3_7m_cu100_gcc5_4_cxx11-abi_nightly_shared-without-deps_build
-          build_environment: "libtorch 3.7m cu100 gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_2_7m_cu100_gcc5_4_cxx11-abi_nightly_shared-without-deps_build
+          build_environment: "libtorch 2.7m cu100 gcc5.4_cxx11-abi"
           requires:
             - setup
           filters:
@@ -3435,8 +3765,8 @@ workflows:
           libtorch_variant: "shared-without-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
       - binary_linux_build:
-          name: binary_linux_libtorch_3_7m_cu100_gcc5_4_cxx11-abi_nightly_static-with-deps_build
-          build_environment: "libtorch 3.7m cu100 gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_2_7m_cu100_gcc5_4_cxx11-abi_nightly_static-with-deps_build
+          build_environment: "libtorch 2.7m cu100 gcc5.4_cxx11-abi"
           requires:
             - setup
           filters:
@@ -3445,8 +3775,8 @@ workflows:
           libtorch_variant: "static-with-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
       - binary_linux_build:
-          name: binary_linux_libtorch_3_7m_cu100_gcc5_4_cxx11-abi_nightly_static-without-deps_build
-          build_environment: "libtorch 3.7m cu100 gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_2_7m_cu100_gcc5_4_cxx11-abi_nightly_static-without-deps_build
+          build_environment: "libtorch 2.7m cu100 gcc5.4_cxx11-abi"
           requires:
             - setup
           filters:
@@ -3455,8 +3785,8 @@ workflows:
           libtorch_variant: "static-without-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
       - binary_linux_build:
-          name: binary_linux_libtorch_3_7m_cu101_gcc5_4_cxx11-abi_nightly_shared-with-deps_build
-          build_environment: "libtorch 3.7m cu101 gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_2_7m_cu101_gcc5_4_cxx11-abi_nightly_shared-with-deps_build
+          build_environment: "libtorch 2.7m cu101 gcc5.4_cxx11-abi"
           requires:
             - setup
           filters:
@@ -3465,8 +3795,8 @@ workflows:
           libtorch_variant: "shared-with-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
       - binary_linux_build:
-          name: binary_linux_libtorch_3_7m_cu101_gcc5_4_cxx11-abi_nightly_shared-without-deps_build
-          build_environment: "libtorch 3.7m cu101 gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_2_7m_cu101_gcc5_4_cxx11-abi_nightly_shared-without-deps_build
+          build_environment: "libtorch 2.7m cu101 gcc5.4_cxx11-abi"
           requires:
             - setup
           filters:
@@ -3475,8 +3805,8 @@ workflows:
           libtorch_variant: "shared-without-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
       - binary_linux_build:
-          name: binary_linux_libtorch_3_7m_cu101_gcc5_4_cxx11-abi_nightly_static-with-deps_build
-          build_environment: "libtorch 3.7m cu101 gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_2_7m_cu101_gcc5_4_cxx11-abi_nightly_static-with-deps_build
+          build_environment: "libtorch 2.7m cu101 gcc5.4_cxx11-abi"
           requires:
             - setup
           filters:
@@ -3485,8 +3815,8 @@ workflows:
           libtorch_variant: "static-with-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
       - binary_linux_build:
-          name: binary_linux_libtorch_3_7m_cu101_gcc5_4_cxx11-abi_nightly_static-without-deps_build
-          build_environment: "libtorch 3.7m cu101 gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_2_7m_cu101_gcc5_4_cxx11-abi_nightly_static-without-deps_build
+          build_environment: "libtorch 2.7m cu101 gcc5.4_cxx11-abi"
           requires:
             - setup
           filters:
@@ -3494,6 +3824,14 @@ workflows:
               only: nightly
           libtorch_variant: "static-without-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
+      - binary_mac_build:
+          name: binary_macos_wheel_2_7_cpu_nightly_build
+          build_environment: "wheel 2.7 cpu"
+          requires:
+            - setup
+          filters:
+            branches:
+              only: nightly
       - binary_mac_build:
           name: binary_macos_wheel_3_5_cpu_nightly_build
           build_environment: "wheel 3.5 cpu"
@@ -3513,6 +3851,14 @@ workflows:
       - binary_mac_build:
           name: binary_macos_wheel_3_7_cpu_nightly_build
           build_environment: "wheel 3.7 cpu"
+          requires:
+            - setup
+          filters:
+            branches:
+              only: nightly
+      - binary_mac_build:
+          name: binary_macos_conda_2_7_cpu_nightly_build
+          build_environment: "conda 2.7 cpu"
           requires:
             - setup
           filters:
@@ -3543,8 +3889,8 @@ workflows:
             branches:
               only: nightly
       - binary_mac_build:
-          name: binary_macos_libtorch_3_7_cpu_nightly_build
-          build_environment: "libtorch 3.7 cpu"
+          name: binary_macos_libtorch_2_7_cpu_nightly_build
+          build_environment: "libtorch 2.7 cpu"
           requires:
             - setup
           filters:
@@ -3643,6 +3989,26 @@ workflows:
 # Nightly tests
 ##############################################################################
       - binary_linux_test:
+          name: binary_linux_manywheel_2_7m_cpu_devtoolset7_nightly_test
+          build_environment: "manywheel 2.7m cpu devtoolset7"
+          requires:
+            - setup
+            - binary_linux_manywheel_2_7m_cpu_devtoolset7_nightly_build
+          filters:
+            branches:
+              only: nightly
+          docker_image: "pytorch/manylinux-cuda100"
+      - binary_linux_test:
+          name: binary_linux_manywheel_2_7mu_cpu_devtoolset7_nightly_test
+          build_environment: "manywheel 2.7mu cpu devtoolset7"
+          requires:
+            - setup
+            - binary_linux_manywheel_2_7mu_cpu_devtoolset7_nightly_build
+          filters:
+            branches:
+              only: nightly
+          docker_image: "pytorch/manylinux-cuda100"
+      - binary_linux_test:
           name: binary_linux_manywheel_3_5m_cpu_devtoolset7_nightly_test
           build_environment: "manywheel 3.5m cpu devtoolset7"
           requires:
@@ -3672,6 +4038,30 @@ workflows:
             branches:
               only: nightly
           docker_image: "pytorch/manylinux-cuda100"
+      - binary_linux_test:
+          name: binary_linux_manywheel_2_7m_cu92_devtoolset7_nightly_test
+          build_environment: "manywheel 2.7m cu92 devtoolset7"
+          requires:
+            - setup
+            - binary_linux_manywheel_2_7m_cu92_devtoolset7_nightly_build
+          filters:
+            branches:
+              only: nightly
+          docker_image: "pytorch/manylinux-cuda92"
+          use_cuda_docker_runtime: "1"
+          resource_class: gpu.medium
+      - binary_linux_test:
+          name: binary_linux_manywheel_2_7mu_cu92_devtoolset7_nightly_test
+          build_environment: "manywheel 2.7mu cu92 devtoolset7"
+          requires:
+            - setup
+            - binary_linux_manywheel_2_7mu_cu92_devtoolset7_nightly_build
+          filters:
+            branches:
+              only: nightly
+          docker_image: "pytorch/manylinux-cuda92"
+          use_cuda_docker_runtime: "1"
+          resource_class: gpu.medium
       - binary_linux_test:
           name: binary_linux_manywheel_3_5m_cu92_devtoolset7_nightly_test
           build_environment: "manywheel 3.5m cu92 devtoolset7"
@@ -3706,6 +4096,30 @@ workflows:
             branches:
               only: nightly
           docker_image: "pytorch/manylinux-cuda92"
+          use_cuda_docker_runtime: "1"
+          resource_class: gpu.medium
+      - binary_linux_test:
+          name: binary_linux_manywheel_2_7m_cu100_devtoolset7_nightly_test
+          build_environment: "manywheel 2.7m cu100 devtoolset7"
+          requires:
+            - setup
+            - binary_linux_manywheel_2_7m_cu100_devtoolset7_nightly_build
+          filters:
+            branches:
+              only: nightly
+          docker_image: "pytorch/manylinux-cuda100"
+          use_cuda_docker_runtime: "1"
+          resource_class: gpu.medium
+      - binary_linux_test:
+          name: binary_linux_manywheel_2_7mu_cu100_devtoolset7_nightly_test
+          build_environment: "manywheel 2.7mu cu100 devtoolset7"
+          requires:
+            - setup
+            - binary_linux_manywheel_2_7mu_cu100_devtoolset7_nightly_build
+          filters:
+            branches:
+              only: nightly
+          docker_image: "pytorch/manylinux-cuda100"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
@@ -3745,6 +4159,30 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
+          name: binary_linux_manywheel_2_7m_cu101_devtoolset7_nightly_test
+          build_environment: "manywheel 2.7m cu101 devtoolset7"
+          requires:
+            - setup
+            - binary_linux_manywheel_2_7m_cu101_devtoolset7_nightly_build
+          filters:
+            branches:
+              only: nightly
+          docker_image: "pytorch/manylinux-cuda101"
+          use_cuda_docker_runtime: "1"
+          resource_class: gpu.medium
+      - binary_linux_test:
+          name: binary_linux_manywheel_2_7mu_cu101_devtoolset7_nightly_test
+          build_environment: "manywheel 2.7mu cu101 devtoolset7"
+          requires:
+            - setup
+            - binary_linux_manywheel_2_7mu_cu101_devtoolset7_nightly_build
+          filters:
+            branches:
+              only: nightly
+          docker_image: "pytorch/manylinux-cuda101"
+          use_cuda_docker_runtime: "1"
+          resource_class: gpu.medium
+      - binary_linux_test:
           name: binary_linux_manywheel_3_5m_cu101_devtoolset7_nightly_test
           build_environment: "manywheel 3.5m cu101 devtoolset7"
           requires:
@@ -3781,6 +4219,16 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
+          name: binary_linux_conda_2_7_cpu_devtoolset7_nightly_test
+          build_environment: "conda 2.7 cpu devtoolset7"
+          requires:
+            - setup
+            - binary_linux_conda_2_7_cpu_devtoolset7_nightly_build
+          filters:
+            branches:
+              only: nightly
+          docker_image: "pytorch/conda-cuda"
+      - binary_linux_test:
           name: binary_linux_conda_3_5_cpu_devtoolset7_nightly_test
           build_environment: "conda 3.5 cpu devtoolset7"
           requires:
@@ -3811,6 +4259,18 @@ workflows:
               only: nightly
           docker_image: "pytorch/conda-cuda"
       - binary_linux_test:
+          name: binary_linux_conda_2_7_cu92_devtoolset7_nightly_test
+          build_environment: "conda 2.7 cu92 devtoolset7"
+          requires:
+            - setup
+            - binary_linux_conda_2_7_cu92_devtoolset7_nightly_build
+          filters:
+            branches:
+              only: nightly
+          docker_image: "pytorch/conda-cuda"
+          use_cuda_docker_runtime: "1"
+          resource_class: gpu.medium
+      - binary_linux_test:
           name: binary_linux_conda_3_5_cu92_devtoolset7_nightly_test
           build_environment: "conda 3.5 cu92 devtoolset7"
           requires:
@@ -3840,6 +4300,18 @@ workflows:
           requires:
             - setup
             - binary_linux_conda_3_7_cu92_devtoolset7_nightly_build
+          filters:
+            branches:
+              only: nightly
+          docker_image: "pytorch/conda-cuda"
+          use_cuda_docker_runtime: "1"
+          resource_class: gpu.medium
+      - binary_linux_test:
+          name: binary_linux_conda_2_7_cu100_devtoolset7_nightly_test
+          build_environment: "conda 2.7 cu100 devtoolset7"
+          requires:
+            - setup
+            - binary_linux_conda_2_7_cu100_devtoolset7_nightly_build
           filters:
             branches:
               only: nightly
@@ -3883,6 +4355,18 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
+          name: binary_linux_conda_2_7_cu101_devtoolset7_nightly_test
+          build_environment: "conda 2.7 cu101 devtoolset7"
+          requires:
+            - setup
+            - binary_linux_conda_2_7_cu101_devtoolset7_nightly_build
+          filters:
+            branches:
+              only: nightly
+          docker_image: "pytorch/conda-cuda"
+          use_cuda_docker_runtime: "1"
+          resource_class: gpu.medium
+      - binary_linux_test:
           name: binary_linux_conda_3_5_cu101_devtoolset7_nightly_test
           build_environment: "conda 3.5 cu101 devtoolset7"
           requires:
@@ -3919,55 +4403,55 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
-          name: binary_linux_libtorch_3_7m_cpu_devtoolset7_nightly_shared-with-deps_test
-          build_environment: "libtorch 3.7m cpu devtoolset7"
+          name: binary_linux_libtorch_2_7m_cpu_devtoolset7_nightly_shared-with-deps_test
+          build_environment: "libtorch 2.7m cpu devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_3_7m_cpu_devtoolset7_nightly_shared-with-deps_build
+            - binary_linux_libtorch_2_7m_cpu_devtoolset7_nightly_shared-with-deps_build
           filters:
             branches:
               only: nightly
           libtorch_variant: "shared-with-deps"
           docker_image: "pytorch/manylinux-cuda100"
       - binary_linux_test:
-          name: binary_linux_libtorch_3_7m_cpu_devtoolset7_nightly_shared-without-deps_test
-          build_environment: "libtorch 3.7m cpu devtoolset7"
+          name: binary_linux_libtorch_2_7m_cpu_devtoolset7_nightly_shared-without-deps_test
+          build_environment: "libtorch 2.7m cpu devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_3_7m_cpu_devtoolset7_nightly_shared-without-deps_build
+            - binary_linux_libtorch_2_7m_cpu_devtoolset7_nightly_shared-without-deps_build
           filters:
             branches:
               only: nightly
           libtorch_variant: "shared-without-deps"
           docker_image: "pytorch/manylinux-cuda100"
       - binary_linux_test:
-          name: binary_linux_libtorch_3_7m_cpu_devtoolset7_nightly_static-with-deps_test
-          build_environment: "libtorch 3.7m cpu devtoolset7"
+          name: binary_linux_libtorch_2_7m_cpu_devtoolset7_nightly_static-with-deps_test
+          build_environment: "libtorch 2.7m cpu devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_3_7m_cpu_devtoolset7_nightly_static-with-deps_build
+            - binary_linux_libtorch_2_7m_cpu_devtoolset7_nightly_static-with-deps_build
           filters:
             branches:
               only: nightly
           libtorch_variant: "static-with-deps"
           docker_image: "pytorch/manylinux-cuda100"
       - binary_linux_test:
-          name: binary_linux_libtorch_3_7m_cpu_devtoolset7_nightly_static-without-deps_test
-          build_environment: "libtorch 3.7m cpu devtoolset7"
+          name: binary_linux_libtorch_2_7m_cpu_devtoolset7_nightly_static-without-deps_test
+          build_environment: "libtorch 2.7m cpu devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_3_7m_cpu_devtoolset7_nightly_static-without-deps_build
+            - binary_linux_libtorch_2_7m_cpu_devtoolset7_nightly_static-without-deps_build
           filters:
             branches:
               only: nightly
           libtorch_variant: "static-without-deps"
           docker_image: "pytorch/manylinux-cuda100"
       - binary_linux_test:
-          name: binary_linux_libtorch_3_7m_cu92_devtoolset7_nightly_shared-with-deps_test
-          build_environment: "libtorch 3.7m cu92 devtoolset7"
+          name: binary_linux_libtorch_2_7m_cu92_devtoolset7_nightly_shared-with-deps_test
+          build_environment: "libtorch 2.7m cu92 devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_3_7m_cu92_devtoolset7_nightly_shared-with-deps_build
+            - binary_linux_libtorch_2_7m_cu92_devtoolset7_nightly_shared-with-deps_build
           filters:
             branches:
               only: nightly
@@ -3976,11 +4460,11 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
-          name: binary_linux_libtorch_3_7m_cu92_devtoolset7_nightly_shared-without-deps_test
-          build_environment: "libtorch 3.7m cu92 devtoolset7"
+          name: binary_linux_libtorch_2_7m_cu92_devtoolset7_nightly_shared-without-deps_test
+          build_environment: "libtorch 2.7m cu92 devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_3_7m_cu92_devtoolset7_nightly_shared-without-deps_build
+            - binary_linux_libtorch_2_7m_cu92_devtoolset7_nightly_shared-without-deps_build
           filters:
             branches:
               only: nightly
@@ -3989,11 +4473,11 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
-          name: binary_linux_libtorch_3_7m_cu92_devtoolset7_nightly_static-with-deps_test
-          build_environment: "libtorch 3.7m cu92 devtoolset7"
+          name: binary_linux_libtorch_2_7m_cu92_devtoolset7_nightly_static-with-deps_test
+          build_environment: "libtorch 2.7m cu92 devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_3_7m_cu92_devtoolset7_nightly_static-with-deps_build
+            - binary_linux_libtorch_2_7m_cu92_devtoolset7_nightly_static-with-deps_build
           filters:
             branches:
               only: nightly
@@ -4002,11 +4486,11 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
-          name: binary_linux_libtorch_3_7m_cu92_devtoolset7_nightly_static-without-deps_test
-          build_environment: "libtorch 3.7m cu92 devtoolset7"
+          name: binary_linux_libtorch_2_7m_cu92_devtoolset7_nightly_static-without-deps_test
+          build_environment: "libtorch 2.7m cu92 devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_3_7m_cu92_devtoolset7_nightly_static-without-deps_build
+            - binary_linux_libtorch_2_7m_cu92_devtoolset7_nightly_static-without-deps_build
           filters:
             branches:
               only: nightly
@@ -4015,11 +4499,11 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
-          name: binary_linux_libtorch_3_7m_cu100_devtoolset7_nightly_shared-with-deps_test
-          build_environment: "libtorch 3.7m cu100 devtoolset7"
+          name: binary_linux_libtorch_2_7m_cu100_devtoolset7_nightly_shared-with-deps_test
+          build_environment: "libtorch 2.7m cu100 devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_3_7m_cu100_devtoolset7_nightly_shared-with-deps_build
+            - binary_linux_libtorch_2_7m_cu100_devtoolset7_nightly_shared-with-deps_build
           filters:
             branches:
               only: nightly
@@ -4028,11 +4512,11 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
-          name: binary_linux_libtorch_3_7m_cu100_devtoolset7_nightly_shared-without-deps_test
-          build_environment: "libtorch 3.7m cu100 devtoolset7"
+          name: binary_linux_libtorch_2_7m_cu100_devtoolset7_nightly_shared-without-deps_test
+          build_environment: "libtorch 2.7m cu100 devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_3_7m_cu100_devtoolset7_nightly_shared-without-deps_build
+            - binary_linux_libtorch_2_7m_cu100_devtoolset7_nightly_shared-without-deps_build
           filters:
             branches:
               only: nightly
@@ -4041,11 +4525,11 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
-          name: binary_linux_libtorch_3_7m_cu100_devtoolset7_nightly_static-with-deps_test
-          build_environment: "libtorch 3.7m cu100 devtoolset7"
+          name: binary_linux_libtorch_2_7m_cu100_devtoolset7_nightly_static-with-deps_test
+          build_environment: "libtorch 2.7m cu100 devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_3_7m_cu100_devtoolset7_nightly_static-with-deps_build
+            - binary_linux_libtorch_2_7m_cu100_devtoolset7_nightly_static-with-deps_build
           filters:
             branches:
               only: nightly
@@ -4054,11 +4538,11 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
-          name: binary_linux_libtorch_3_7m_cu100_devtoolset7_nightly_static-without-deps_test
-          build_environment: "libtorch 3.7m cu100 devtoolset7"
+          name: binary_linux_libtorch_2_7m_cu100_devtoolset7_nightly_static-without-deps_test
+          build_environment: "libtorch 2.7m cu100 devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_3_7m_cu100_devtoolset7_nightly_static-without-deps_build
+            - binary_linux_libtorch_2_7m_cu100_devtoolset7_nightly_static-without-deps_build
           filters:
             branches:
               only: nightly
@@ -4067,11 +4551,11 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
-          name: binary_linux_libtorch_3_7m_cu101_devtoolset7_nightly_shared-with-deps_test
-          build_environment: "libtorch 3.7m cu101 devtoolset7"
+          name: binary_linux_libtorch_2_7m_cu101_devtoolset7_nightly_shared-with-deps_test
+          build_environment: "libtorch 2.7m cu101 devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_3_7m_cu101_devtoolset7_nightly_shared-with-deps_build
+            - binary_linux_libtorch_2_7m_cu101_devtoolset7_nightly_shared-with-deps_build
           filters:
             branches:
               only: nightly
@@ -4080,11 +4564,11 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
-          name: binary_linux_libtorch_3_7m_cu101_devtoolset7_nightly_shared-without-deps_test
-          build_environment: "libtorch 3.7m cu101 devtoolset7"
+          name: binary_linux_libtorch_2_7m_cu101_devtoolset7_nightly_shared-without-deps_test
+          build_environment: "libtorch 2.7m cu101 devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_3_7m_cu101_devtoolset7_nightly_shared-without-deps_build
+            - binary_linux_libtorch_2_7m_cu101_devtoolset7_nightly_shared-without-deps_build
           filters:
             branches:
               only: nightly
@@ -4093,11 +4577,11 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
-          name: binary_linux_libtorch_3_7m_cu101_devtoolset7_nightly_static-with-deps_test
-          build_environment: "libtorch 3.7m cu101 devtoolset7"
+          name: binary_linux_libtorch_2_7m_cu101_devtoolset7_nightly_static-with-deps_test
+          build_environment: "libtorch 2.7m cu101 devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_3_7m_cu101_devtoolset7_nightly_static-with-deps_build
+            - binary_linux_libtorch_2_7m_cu101_devtoolset7_nightly_static-with-deps_build
           filters:
             branches:
               only: nightly
@@ -4106,11 +4590,11 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
-          name: binary_linux_libtorch_3_7m_cu101_devtoolset7_nightly_static-without-deps_test
-          build_environment: "libtorch 3.7m cu101 devtoolset7"
+          name: binary_linux_libtorch_2_7m_cu101_devtoolset7_nightly_static-without-deps_test
+          build_environment: "libtorch 2.7m cu101 devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_3_7m_cu101_devtoolset7_nightly_static-without-deps_build
+            - binary_linux_libtorch_2_7m_cu101_devtoolset7_nightly_static-without-deps_build
           filters:
             branches:
               only: nightly
@@ -4119,55 +4603,55 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
-          name: binary_linux_libtorch_3_7m_cpu_gcc5_4_cxx11-abi_nightly_shared-with-deps_test
-          build_environment: "libtorch 3.7m cpu gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_nightly_shared-with-deps_test
+          build_environment: "libtorch 2.7m cpu gcc5.4_cxx11-abi"
           requires:
             - setup
-            - binary_linux_libtorch_3_7m_cpu_gcc5_4_cxx11-abi_nightly_shared-with-deps_build
+            - binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_nightly_shared-with-deps_build
           filters:
             branches:
               only: nightly
           libtorch_variant: "shared-with-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
       - binary_linux_test:
-          name: binary_linux_libtorch_3_7m_cpu_gcc5_4_cxx11-abi_nightly_shared-without-deps_test
-          build_environment: "libtorch 3.7m cpu gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_nightly_shared-without-deps_test
+          build_environment: "libtorch 2.7m cpu gcc5.4_cxx11-abi"
           requires:
             - setup
-            - binary_linux_libtorch_3_7m_cpu_gcc5_4_cxx11-abi_nightly_shared-without-deps_build
+            - binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_nightly_shared-without-deps_build
           filters:
             branches:
               only: nightly
           libtorch_variant: "shared-without-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
       - binary_linux_test:
-          name: binary_linux_libtorch_3_7m_cpu_gcc5_4_cxx11-abi_nightly_static-with-deps_test
-          build_environment: "libtorch 3.7m cpu gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_nightly_static-with-deps_test
+          build_environment: "libtorch 2.7m cpu gcc5.4_cxx11-abi"
           requires:
             - setup
-            - binary_linux_libtorch_3_7m_cpu_gcc5_4_cxx11-abi_nightly_static-with-deps_build
+            - binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_nightly_static-with-deps_build
           filters:
             branches:
               only: nightly
           libtorch_variant: "static-with-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
       - binary_linux_test:
-          name: binary_linux_libtorch_3_7m_cpu_gcc5_4_cxx11-abi_nightly_static-without-deps_test
-          build_environment: "libtorch 3.7m cpu gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_nightly_static-without-deps_test
+          build_environment: "libtorch 2.7m cpu gcc5.4_cxx11-abi"
           requires:
             - setup
-            - binary_linux_libtorch_3_7m_cpu_gcc5_4_cxx11-abi_nightly_static-without-deps_build
+            - binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_nightly_static-without-deps_build
           filters:
             branches:
               only: nightly
           libtorch_variant: "static-without-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
       - binary_linux_test:
-          name: binary_linux_libtorch_3_7m_cu92_gcc5_4_cxx11-abi_nightly_shared-with-deps_test
-          build_environment: "libtorch 3.7m cu92 gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_2_7m_cu92_gcc5_4_cxx11-abi_nightly_shared-with-deps_test
+          build_environment: "libtorch 2.7m cu92 gcc5.4_cxx11-abi"
           requires:
             - setup
-            - binary_linux_libtorch_3_7m_cu92_gcc5_4_cxx11-abi_nightly_shared-with-deps_build
+            - binary_linux_libtorch_2_7m_cu92_gcc5_4_cxx11-abi_nightly_shared-with-deps_build
           filters:
             branches:
               only: nightly
@@ -4176,11 +4660,11 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
-          name: binary_linux_libtorch_3_7m_cu92_gcc5_4_cxx11-abi_nightly_shared-without-deps_test
-          build_environment: "libtorch 3.7m cu92 gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_2_7m_cu92_gcc5_4_cxx11-abi_nightly_shared-without-deps_test
+          build_environment: "libtorch 2.7m cu92 gcc5.4_cxx11-abi"
           requires:
             - setup
-            - binary_linux_libtorch_3_7m_cu92_gcc5_4_cxx11-abi_nightly_shared-without-deps_build
+            - binary_linux_libtorch_2_7m_cu92_gcc5_4_cxx11-abi_nightly_shared-without-deps_build
           filters:
             branches:
               only: nightly
@@ -4189,11 +4673,11 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
-          name: binary_linux_libtorch_3_7m_cu92_gcc5_4_cxx11-abi_nightly_static-with-deps_test
-          build_environment: "libtorch 3.7m cu92 gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_2_7m_cu92_gcc5_4_cxx11-abi_nightly_static-with-deps_test
+          build_environment: "libtorch 2.7m cu92 gcc5.4_cxx11-abi"
           requires:
             - setup
-            - binary_linux_libtorch_3_7m_cu92_gcc5_4_cxx11-abi_nightly_static-with-deps_build
+            - binary_linux_libtorch_2_7m_cu92_gcc5_4_cxx11-abi_nightly_static-with-deps_build
           filters:
             branches:
               only: nightly
@@ -4202,63 +4686,11 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
-          name: binary_linux_libtorch_3_7m_cu92_gcc5_4_cxx11-abi_nightly_static-without-deps_test
-          build_environment: "libtorch 3.7m cu92 gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_2_7m_cu92_gcc5_4_cxx11-abi_nightly_static-without-deps_test
+          build_environment: "libtorch 2.7m cu92 gcc5.4_cxx11-abi"
           requires:
             - setup
-            - binary_linux_libtorch_3_7m_cu92_gcc5_4_cxx11-abi_nightly_static-without-deps_build
-          filters:
-            branches:
-              only: nightly
-          libtorch_variant: "static-without-deps"
-          docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
-          use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
-      - binary_linux_test:
-          name: binary_linux_libtorch_3_7m_cu100_gcc5_4_cxx11-abi_nightly_shared-with-deps_test
-          build_environment: "libtorch 3.7m cu100 gcc5.4_cxx11-abi"
-          requires:
-            - setup
-            - binary_linux_libtorch_3_7m_cu100_gcc5_4_cxx11-abi_nightly_shared-with-deps_build
-          filters:
-            branches:
-              only: nightly
-          libtorch_variant: "shared-with-deps"
-          docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
-          use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
-      - binary_linux_test:
-          name: binary_linux_libtorch_3_7m_cu100_gcc5_4_cxx11-abi_nightly_shared-without-deps_test
-          build_environment: "libtorch 3.7m cu100 gcc5.4_cxx11-abi"
-          requires:
-            - setup
-            - binary_linux_libtorch_3_7m_cu100_gcc5_4_cxx11-abi_nightly_shared-without-deps_build
-          filters:
-            branches:
-              only: nightly
-          libtorch_variant: "shared-without-deps"
-          docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
-          use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
-      - binary_linux_test:
-          name: binary_linux_libtorch_3_7m_cu100_gcc5_4_cxx11-abi_nightly_static-with-deps_test
-          build_environment: "libtorch 3.7m cu100 gcc5.4_cxx11-abi"
-          requires:
-            - setup
-            - binary_linux_libtorch_3_7m_cu100_gcc5_4_cxx11-abi_nightly_static-with-deps_build
-          filters:
-            branches:
-              only: nightly
-          libtorch_variant: "static-with-deps"
-          docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
-          use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
-      - binary_linux_test:
-          name: binary_linux_libtorch_3_7m_cu100_gcc5_4_cxx11-abi_nightly_static-without-deps_test
-          build_environment: "libtorch 3.7m cu100 gcc5.4_cxx11-abi"
-          requires:
-            - setup
-            - binary_linux_libtorch_3_7m_cu100_gcc5_4_cxx11-abi_nightly_static-without-deps_build
+            - binary_linux_libtorch_2_7m_cu92_gcc5_4_cxx11-abi_nightly_static-without-deps_build
           filters:
             branches:
               only: nightly
@@ -4267,11 +4699,11 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
-          name: binary_linux_libtorch_3_7m_cu101_gcc5_4_cxx11-abi_nightly_shared-with-deps_test
-          build_environment: "libtorch 3.7m cu101 gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_2_7m_cu100_gcc5_4_cxx11-abi_nightly_shared-with-deps_test
+          build_environment: "libtorch 2.7m cu100 gcc5.4_cxx11-abi"
           requires:
             - setup
-            - binary_linux_libtorch_3_7m_cu101_gcc5_4_cxx11-abi_nightly_shared-with-deps_build
+            - binary_linux_libtorch_2_7m_cu100_gcc5_4_cxx11-abi_nightly_shared-with-deps_build
           filters:
             branches:
               only: nightly
@@ -4280,11 +4712,11 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
-          name: binary_linux_libtorch_3_7m_cu101_gcc5_4_cxx11-abi_nightly_shared-without-deps_test
-          build_environment: "libtorch 3.7m cu101 gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_2_7m_cu100_gcc5_4_cxx11-abi_nightly_shared-without-deps_test
+          build_environment: "libtorch 2.7m cu100 gcc5.4_cxx11-abi"
           requires:
             - setup
-            - binary_linux_libtorch_3_7m_cu101_gcc5_4_cxx11-abi_nightly_shared-without-deps_build
+            - binary_linux_libtorch_2_7m_cu100_gcc5_4_cxx11-abi_nightly_shared-without-deps_build
           filters:
             branches:
               only: nightly
@@ -4293,11 +4725,11 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
-          name: binary_linux_libtorch_3_7m_cu101_gcc5_4_cxx11-abi_nightly_static-with-deps_test
-          build_environment: "libtorch 3.7m cu101 gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_2_7m_cu100_gcc5_4_cxx11-abi_nightly_static-with-deps_test
+          build_environment: "libtorch 2.7m cu100 gcc5.4_cxx11-abi"
           requires:
             - setup
-            - binary_linux_libtorch_3_7m_cu101_gcc5_4_cxx11-abi_nightly_static-with-deps_build
+            - binary_linux_libtorch_2_7m_cu100_gcc5_4_cxx11-abi_nightly_static-with-deps_build
           filters:
             branches:
               only: nightly
@@ -4306,11 +4738,63 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
-          name: binary_linux_libtorch_3_7m_cu101_gcc5_4_cxx11-abi_nightly_static-without-deps_test
-          build_environment: "libtorch 3.7m cu101 gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_2_7m_cu100_gcc5_4_cxx11-abi_nightly_static-without-deps_test
+          build_environment: "libtorch 2.7m cu100 gcc5.4_cxx11-abi"
           requires:
             - setup
-            - binary_linux_libtorch_3_7m_cu101_gcc5_4_cxx11-abi_nightly_static-without-deps_build
+            - binary_linux_libtorch_2_7m_cu100_gcc5_4_cxx11-abi_nightly_static-without-deps_build
+          filters:
+            branches:
+              only: nightly
+          libtorch_variant: "static-without-deps"
+          docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
+          use_cuda_docker_runtime: "1"
+          resource_class: gpu.medium
+      - binary_linux_test:
+          name: binary_linux_libtorch_2_7m_cu101_gcc5_4_cxx11-abi_nightly_shared-with-deps_test
+          build_environment: "libtorch 2.7m cu101 gcc5.4_cxx11-abi"
+          requires:
+            - setup
+            - binary_linux_libtorch_2_7m_cu101_gcc5_4_cxx11-abi_nightly_shared-with-deps_build
+          filters:
+            branches:
+              only: nightly
+          libtorch_variant: "shared-with-deps"
+          docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
+          use_cuda_docker_runtime: "1"
+          resource_class: gpu.medium
+      - binary_linux_test:
+          name: binary_linux_libtorch_2_7m_cu101_gcc5_4_cxx11-abi_nightly_shared-without-deps_test
+          build_environment: "libtorch 2.7m cu101 gcc5.4_cxx11-abi"
+          requires:
+            - setup
+            - binary_linux_libtorch_2_7m_cu101_gcc5_4_cxx11-abi_nightly_shared-without-deps_build
+          filters:
+            branches:
+              only: nightly
+          libtorch_variant: "shared-without-deps"
+          docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
+          use_cuda_docker_runtime: "1"
+          resource_class: gpu.medium
+      - binary_linux_test:
+          name: binary_linux_libtorch_2_7m_cu101_gcc5_4_cxx11-abi_nightly_static-with-deps_test
+          build_environment: "libtorch 2.7m cu101 gcc5.4_cxx11-abi"
+          requires:
+            - setup
+            - binary_linux_libtorch_2_7m_cu101_gcc5_4_cxx11-abi_nightly_static-with-deps_build
+          filters:
+            branches:
+              only: nightly
+          libtorch_variant: "static-with-deps"
+          docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
+          use_cuda_docker_runtime: "1"
+          resource_class: gpu.medium
+      - binary_linux_test:
+          name: binary_linux_libtorch_2_7m_cu101_gcc5_4_cxx11-abi_nightly_static-without-deps_test
+          build_environment: "libtorch 2.7m cu101 gcc5.4_cxx11-abi"
+          requires:
+            - setup
+            - binary_linux_libtorch_2_7m_cu101_gcc5_4_cxx11-abi_nightly_static-without-deps_build
           filters:
             branches:
               only: nightly
@@ -4329,6 +4813,26 @@ workflows:
       #      - binary_linux_libtorch_2.7m_cu100_build
 
       # Nightly uploads
+      - binary_linux_upload:
+          name: binary_linux_manywheel_2_7m_cpu_devtoolset7_nightly_upload
+          build_environment: "manywheel 2.7m cpu devtoolset7"
+          requires:
+            - setup
+            - binary_linux_manywheel_2_7m_cpu_devtoolset7_nightly_test
+          filters:
+            branches:
+              only: nightly
+          context: org-member
+      - binary_linux_upload:
+          name: binary_linux_manywheel_2_7mu_cpu_devtoolset7_nightly_upload
+          build_environment: "manywheel 2.7mu cpu devtoolset7"
+          requires:
+            - setup
+            - binary_linux_manywheel_2_7mu_cpu_devtoolset7_nightly_test
+          filters:
+            branches:
+              only: nightly
+          context: org-member
       - binary_linux_upload:
           name: binary_linux_manywheel_3_5m_cpu_devtoolset7_nightly_upload
           build_environment: "manywheel 3.5m cpu devtoolset7"
@@ -4355,6 +4859,26 @@ workflows:
           requires:
             - setup
             - binary_linux_manywheel_3_7m_cpu_devtoolset7_nightly_test
+          filters:
+            branches:
+              only: nightly
+          context: org-member
+      - binary_linux_upload:
+          name: binary_linux_manywheel_2_7m_cu92_devtoolset7_nightly_upload
+          build_environment: "manywheel 2.7m cu92 devtoolset7"
+          requires:
+            - setup
+            - binary_linux_manywheel_2_7m_cu92_devtoolset7_nightly_test
+          filters:
+            branches:
+              only: nightly
+          context: org-member
+      - binary_linux_upload:
+          name: binary_linux_manywheel_2_7mu_cu92_devtoolset7_nightly_upload
+          build_environment: "manywheel 2.7mu cu92 devtoolset7"
+          requires:
+            - setup
+            - binary_linux_manywheel_2_7mu_cu92_devtoolset7_nightly_test
           filters:
             branches:
               only: nightly
@@ -4390,6 +4914,26 @@ workflows:
               only: nightly
           context: org-member
       - binary_linux_upload:
+          name: binary_linux_manywheel_2_7m_cu100_devtoolset7_nightly_upload
+          build_environment: "manywheel 2.7m cu100 devtoolset7"
+          requires:
+            - setup
+            - binary_linux_manywheel_2_7m_cu100_devtoolset7_nightly_test
+          filters:
+            branches:
+              only: nightly
+          context: org-member
+      - binary_linux_upload:
+          name: binary_linux_manywheel_2_7mu_cu100_devtoolset7_nightly_upload
+          build_environment: "manywheel 2.7mu cu100 devtoolset7"
+          requires:
+            - setup
+            - binary_linux_manywheel_2_7mu_cu100_devtoolset7_nightly_test
+          filters:
+            branches:
+              only: nightly
+          context: org-member
+      - binary_linux_upload:
           name: binary_linux_manywheel_3_5m_cu100_devtoolset7_nightly_upload
           build_environment: "manywheel 3.5m cu100 devtoolset7"
           requires:
@@ -4415,6 +4959,26 @@ workflows:
           requires:
             - setup
             - binary_linux_manywheel_3_7m_cu100_devtoolset7_nightly_test
+          filters:
+            branches:
+              only: nightly
+          context: org-member
+      - binary_linux_upload:
+          name: binary_linux_manywheel_2_7m_cu101_devtoolset7_nightly_upload
+          build_environment: "manywheel 2.7m cu101 devtoolset7"
+          requires:
+            - setup
+            - binary_linux_manywheel_2_7m_cu101_devtoolset7_nightly_test
+          filters:
+            branches:
+              only: nightly
+          context: org-member
+      - binary_linux_upload:
+          name: binary_linux_manywheel_2_7mu_cu101_devtoolset7_nightly_upload
+          build_environment: "manywheel 2.7mu cu101 devtoolset7"
+          requires:
+            - setup
+            - binary_linux_manywheel_2_7mu_cu101_devtoolset7_nightly_test
           filters:
             branches:
               only: nightly
@@ -4450,6 +5014,16 @@ workflows:
               only: nightly
           context: org-member
       - binary_linux_upload:
+          name: binary_linux_conda_2_7_cpu_devtoolset7_nightly_upload
+          build_environment: "conda 2.7 cpu devtoolset7"
+          requires:
+            - setup
+            - binary_linux_conda_2_7_cpu_devtoolset7_nightly_test
+          filters:
+            branches:
+              only: nightly
+          context: org-member
+      - binary_linux_upload:
           name: binary_linux_conda_3_5_cpu_devtoolset7_nightly_upload
           build_environment: "conda 3.5 cpu devtoolset7"
           requires:
@@ -4475,6 +5049,16 @@ workflows:
           requires:
             - setup
             - binary_linux_conda_3_7_cpu_devtoolset7_nightly_test
+          filters:
+            branches:
+              only: nightly
+          context: org-member
+      - binary_linux_upload:
+          name: binary_linux_conda_2_7_cu92_devtoolset7_nightly_upload
+          build_environment: "conda 2.7 cu92 devtoolset7"
+          requires:
+            - setup
+            - binary_linux_conda_2_7_cu92_devtoolset7_nightly_test
           filters:
             branches:
               only: nightly
@@ -4510,6 +5094,16 @@ workflows:
               only: nightly
           context: org-member
       - binary_linux_upload:
+          name: binary_linux_conda_2_7_cu100_devtoolset7_nightly_upload
+          build_environment: "conda 2.7 cu100 devtoolset7"
+          requires:
+            - setup
+            - binary_linux_conda_2_7_cu100_devtoolset7_nightly_test
+          filters:
+            branches:
+              only: nightly
+          context: org-member
+      - binary_linux_upload:
           name: binary_linux_conda_3_5_cu100_devtoolset7_nightly_upload
           build_environment: "conda 3.5 cu100 devtoolset7"
           requires:
@@ -4535,6 +5129,16 @@ workflows:
           requires:
             - setup
             - binary_linux_conda_3_7_cu100_devtoolset7_nightly_test
+          filters:
+            branches:
+              only: nightly
+          context: org-member
+      - binary_linux_upload:
+          name: binary_linux_conda_2_7_cu101_devtoolset7_nightly_upload
+          build_environment: "conda 2.7 cu101 devtoolset7"
+          requires:
+            - setup
+            - binary_linux_conda_2_7_cu101_devtoolset7_nightly_test
           filters:
             branches:
               only: nightly
@@ -4570,356 +5174,366 @@ workflows:
               only: nightly
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_libtorch_3_7m_cpu_devtoolset7_nightly_shared-with-deps_upload
-          build_environment: "libtorch 3.7m cpu devtoolset7"
+          name: binary_linux_libtorch_2_7m_cpu_devtoolset7_nightly_shared-with-deps_upload
+          build_environment: "libtorch 2.7m cpu devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_3_7m_cpu_devtoolset7_nightly_shared-with-deps_test
+            - binary_linux_libtorch_2_7m_cpu_devtoolset7_nightly_shared-with-deps_test
           filters:
             branches:
               only: nightly
           libtorch_variant: "shared-with-deps"
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_libtorch_3_7m_cpu_devtoolset7_nightly_shared-without-deps_upload
-          build_environment: "libtorch 3.7m cpu devtoolset7"
+          name: binary_linux_libtorch_2_7m_cpu_devtoolset7_nightly_shared-without-deps_upload
+          build_environment: "libtorch 2.7m cpu devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_3_7m_cpu_devtoolset7_nightly_shared-without-deps_test
+            - binary_linux_libtorch_2_7m_cpu_devtoolset7_nightly_shared-without-deps_test
           filters:
             branches:
               only: nightly
           libtorch_variant: "shared-without-deps"
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_libtorch_3_7m_cpu_devtoolset7_nightly_static-with-deps_upload
-          build_environment: "libtorch 3.7m cpu devtoolset7"
+          name: binary_linux_libtorch_2_7m_cpu_devtoolset7_nightly_static-with-deps_upload
+          build_environment: "libtorch 2.7m cpu devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_3_7m_cpu_devtoolset7_nightly_static-with-deps_test
+            - binary_linux_libtorch_2_7m_cpu_devtoolset7_nightly_static-with-deps_test
           filters:
             branches:
               only: nightly
           libtorch_variant: "static-with-deps"
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_libtorch_3_7m_cpu_devtoolset7_nightly_static-without-deps_upload
-          build_environment: "libtorch 3.7m cpu devtoolset7"
+          name: binary_linux_libtorch_2_7m_cpu_devtoolset7_nightly_static-without-deps_upload
+          build_environment: "libtorch 2.7m cpu devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_3_7m_cpu_devtoolset7_nightly_static-without-deps_test
+            - binary_linux_libtorch_2_7m_cpu_devtoolset7_nightly_static-without-deps_test
           filters:
             branches:
               only: nightly
           libtorch_variant: "static-without-deps"
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_libtorch_3_7m_cu92_devtoolset7_nightly_shared-with-deps_upload
-          build_environment: "libtorch 3.7m cu92 devtoolset7"
+          name: binary_linux_libtorch_2_7m_cu92_devtoolset7_nightly_shared-with-deps_upload
+          build_environment: "libtorch 2.7m cu92 devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_3_7m_cu92_devtoolset7_nightly_shared-with-deps_test
+            - binary_linux_libtorch_2_7m_cu92_devtoolset7_nightly_shared-with-deps_test
           filters:
             branches:
               only: nightly
           libtorch_variant: "shared-with-deps"
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_libtorch_3_7m_cu92_devtoolset7_nightly_shared-without-deps_upload
-          build_environment: "libtorch 3.7m cu92 devtoolset7"
+          name: binary_linux_libtorch_2_7m_cu92_devtoolset7_nightly_shared-without-deps_upload
+          build_environment: "libtorch 2.7m cu92 devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_3_7m_cu92_devtoolset7_nightly_shared-without-deps_test
+            - binary_linux_libtorch_2_7m_cu92_devtoolset7_nightly_shared-without-deps_test
           filters:
             branches:
               only: nightly
           libtorch_variant: "shared-without-deps"
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_libtorch_3_7m_cu92_devtoolset7_nightly_static-with-deps_upload
-          build_environment: "libtorch 3.7m cu92 devtoolset7"
+          name: binary_linux_libtorch_2_7m_cu92_devtoolset7_nightly_static-with-deps_upload
+          build_environment: "libtorch 2.7m cu92 devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_3_7m_cu92_devtoolset7_nightly_static-with-deps_test
+            - binary_linux_libtorch_2_7m_cu92_devtoolset7_nightly_static-with-deps_test
           filters:
             branches:
               only: nightly
           libtorch_variant: "static-with-deps"
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_libtorch_3_7m_cu92_devtoolset7_nightly_static-without-deps_upload
-          build_environment: "libtorch 3.7m cu92 devtoolset7"
+          name: binary_linux_libtorch_2_7m_cu92_devtoolset7_nightly_static-without-deps_upload
+          build_environment: "libtorch 2.7m cu92 devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_3_7m_cu92_devtoolset7_nightly_static-without-deps_test
+            - binary_linux_libtorch_2_7m_cu92_devtoolset7_nightly_static-without-deps_test
           filters:
             branches:
               only: nightly
           libtorch_variant: "static-without-deps"
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_libtorch_3_7m_cu100_devtoolset7_nightly_shared-with-deps_upload
-          build_environment: "libtorch 3.7m cu100 devtoolset7"
+          name: binary_linux_libtorch_2_7m_cu100_devtoolset7_nightly_shared-with-deps_upload
+          build_environment: "libtorch 2.7m cu100 devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_3_7m_cu100_devtoolset7_nightly_shared-with-deps_test
+            - binary_linux_libtorch_2_7m_cu100_devtoolset7_nightly_shared-with-deps_test
           filters:
             branches:
               only: nightly
           libtorch_variant: "shared-with-deps"
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_libtorch_3_7m_cu100_devtoolset7_nightly_shared-without-deps_upload
-          build_environment: "libtorch 3.7m cu100 devtoolset7"
+          name: binary_linux_libtorch_2_7m_cu100_devtoolset7_nightly_shared-without-deps_upload
+          build_environment: "libtorch 2.7m cu100 devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_3_7m_cu100_devtoolset7_nightly_shared-without-deps_test
+            - binary_linux_libtorch_2_7m_cu100_devtoolset7_nightly_shared-without-deps_test
           filters:
             branches:
               only: nightly
           libtorch_variant: "shared-without-deps"
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_libtorch_3_7m_cu100_devtoolset7_nightly_static-with-deps_upload
-          build_environment: "libtorch 3.7m cu100 devtoolset7"
+          name: binary_linux_libtorch_2_7m_cu100_devtoolset7_nightly_static-with-deps_upload
+          build_environment: "libtorch 2.7m cu100 devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_3_7m_cu100_devtoolset7_nightly_static-with-deps_test
+            - binary_linux_libtorch_2_7m_cu100_devtoolset7_nightly_static-with-deps_test
           filters:
             branches:
               only: nightly
           libtorch_variant: "static-with-deps"
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_libtorch_3_7m_cu100_devtoolset7_nightly_static-without-deps_upload
-          build_environment: "libtorch 3.7m cu100 devtoolset7"
+          name: binary_linux_libtorch_2_7m_cu100_devtoolset7_nightly_static-without-deps_upload
+          build_environment: "libtorch 2.7m cu100 devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_3_7m_cu100_devtoolset7_nightly_static-without-deps_test
+            - binary_linux_libtorch_2_7m_cu100_devtoolset7_nightly_static-without-deps_test
           filters:
             branches:
               only: nightly
           libtorch_variant: "static-without-deps"
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_libtorch_3_7m_cu101_devtoolset7_nightly_shared-with-deps_upload
-          build_environment: "libtorch 3.7m cu101 devtoolset7"
+          name: binary_linux_libtorch_2_7m_cu101_devtoolset7_nightly_shared-with-deps_upload
+          build_environment: "libtorch 2.7m cu101 devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_3_7m_cu101_devtoolset7_nightly_shared-with-deps_test
+            - binary_linux_libtorch_2_7m_cu101_devtoolset7_nightly_shared-with-deps_test
           filters:
             branches:
               only: nightly
           libtorch_variant: "shared-with-deps"
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_libtorch_3_7m_cu101_devtoolset7_nightly_shared-without-deps_upload
-          build_environment: "libtorch 3.7m cu101 devtoolset7"
+          name: binary_linux_libtorch_2_7m_cu101_devtoolset7_nightly_shared-without-deps_upload
+          build_environment: "libtorch 2.7m cu101 devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_3_7m_cu101_devtoolset7_nightly_shared-without-deps_test
+            - binary_linux_libtorch_2_7m_cu101_devtoolset7_nightly_shared-without-deps_test
           filters:
             branches:
               only: nightly
           libtorch_variant: "shared-without-deps"
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_libtorch_3_7m_cu101_devtoolset7_nightly_static-with-deps_upload
-          build_environment: "libtorch 3.7m cu101 devtoolset7"
+          name: binary_linux_libtorch_2_7m_cu101_devtoolset7_nightly_static-with-deps_upload
+          build_environment: "libtorch 2.7m cu101 devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_3_7m_cu101_devtoolset7_nightly_static-with-deps_test
+            - binary_linux_libtorch_2_7m_cu101_devtoolset7_nightly_static-with-deps_test
           filters:
             branches:
               only: nightly
           libtorch_variant: "static-with-deps"
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_libtorch_3_7m_cu101_devtoolset7_nightly_static-without-deps_upload
-          build_environment: "libtorch 3.7m cu101 devtoolset7"
+          name: binary_linux_libtorch_2_7m_cu101_devtoolset7_nightly_static-without-deps_upload
+          build_environment: "libtorch 2.7m cu101 devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_3_7m_cu101_devtoolset7_nightly_static-without-deps_test
+            - binary_linux_libtorch_2_7m_cu101_devtoolset7_nightly_static-without-deps_test
           filters:
             branches:
               only: nightly
           libtorch_variant: "static-without-deps"
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_libtorch_3_7m_cpu_gcc5_4_cxx11-abi_nightly_shared-with-deps_upload
-          build_environment: "libtorch 3.7m cpu gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_nightly_shared-with-deps_upload
+          build_environment: "libtorch 2.7m cpu gcc5.4_cxx11-abi"
           requires:
             - setup
-            - binary_linux_libtorch_3_7m_cpu_gcc5_4_cxx11-abi_nightly_shared-with-deps_test
+            - binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_nightly_shared-with-deps_test
           filters:
             branches:
               only: nightly
           libtorch_variant: "shared-with-deps"
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_libtorch_3_7m_cpu_gcc5_4_cxx11-abi_nightly_shared-without-deps_upload
-          build_environment: "libtorch 3.7m cpu gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_nightly_shared-without-deps_upload
+          build_environment: "libtorch 2.7m cpu gcc5.4_cxx11-abi"
           requires:
             - setup
-            - binary_linux_libtorch_3_7m_cpu_gcc5_4_cxx11-abi_nightly_shared-without-deps_test
+            - binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_nightly_shared-without-deps_test
           filters:
             branches:
               only: nightly
           libtorch_variant: "shared-without-deps"
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_libtorch_3_7m_cpu_gcc5_4_cxx11-abi_nightly_static-with-deps_upload
-          build_environment: "libtorch 3.7m cpu gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_nightly_static-with-deps_upload
+          build_environment: "libtorch 2.7m cpu gcc5.4_cxx11-abi"
           requires:
             - setup
-            - binary_linux_libtorch_3_7m_cpu_gcc5_4_cxx11-abi_nightly_static-with-deps_test
+            - binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_nightly_static-with-deps_test
           filters:
             branches:
               only: nightly
           libtorch_variant: "static-with-deps"
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_libtorch_3_7m_cpu_gcc5_4_cxx11-abi_nightly_static-without-deps_upload
-          build_environment: "libtorch 3.7m cpu gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_nightly_static-without-deps_upload
+          build_environment: "libtorch 2.7m cpu gcc5.4_cxx11-abi"
           requires:
             - setup
-            - binary_linux_libtorch_3_7m_cpu_gcc5_4_cxx11-abi_nightly_static-without-deps_test
+            - binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_nightly_static-without-deps_test
           filters:
             branches:
               only: nightly
           libtorch_variant: "static-without-deps"
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_libtorch_3_7m_cu92_gcc5_4_cxx11-abi_nightly_shared-with-deps_upload
-          build_environment: "libtorch 3.7m cu92 gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_2_7m_cu92_gcc5_4_cxx11-abi_nightly_shared-with-deps_upload
+          build_environment: "libtorch 2.7m cu92 gcc5.4_cxx11-abi"
           requires:
             - setup
-            - binary_linux_libtorch_3_7m_cu92_gcc5_4_cxx11-abi_nightly_shared-with-deps_test
+            - binary_linux_libtorch_2_7m_cu92_gcc5_4_cxx11-abi_nightly_shared-with-deps_test
           filters:
             branches:
               only: nightly
           libtorch_variant: "shared-with-deps"
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_libtorch_3_7m_cu92_gcc5_4_cxx11-abi_nightly_shared-without-deps_upload
-          build_environment: "libtorch 3.7m cu92 gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_2_7m_cu92_gcc5_4_cxx11-abi_nightly_shared-without-deps_upload
+          build_environment: "libtorch 2.7m cu92 gcc5.4_cxx11-abi"
           requires:
             - setup
-            - binary_linux_libtorch_3_7m_cu92_gcc5_4_cxx11-abi_nightly_shared-without-deps_test
+            - binary_linux_libtorch_2_7m_cu92_gcc5_4_cxx11-abi_nightly_shared-without-deps_test
           filters:
             branches:
               only: nightly
           libtorch_variant: "shared-without-deps"
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_libtorch_3_7m_cu92_gcc5_4_cxx11-abi_nightly_static-with-deps_upload
-          build_environment: "libtorch 3.7m cu92 gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_2_7m_cu92_gcc5_4_cxx11-abi_nightly_static-with-deps_upload
+          build_environment: "libtorch 2.7m cu92 gcc5.4_cxx11-abi"
           requires:
             - setup
-            - binary_linux_libtorch_3_7m_cu92_gcc5_4_cxx11-abi_nightly_static-with-deps_test
+            - binary_linux_libtorch_2_7m_cu92_gcc5_4_cxx11-abi_nightly_static-with-deps_test
           filters:
             branches:
               only: nightly
           libtorch_variant: "static-with-deps"
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_libtorch_3_7m_cu92_gcc5_4_cxx11-abi_nightly_static-without-deps_upload
-          build_environment: "libtorch 3.7m cu92 gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_2_7m_cu92_gcc5_4_cxx11-abi_nightly_static-without-deps_upload
+          build_environment: "libtorch 2.7m cu92 gcc5.4_cxx11-abi"
           requires:
             - setup
-            - binary_linux_libtorch_3_7m_cu92_gcc5_4_cxx11-abi_nightly_static-without-deps_test
+            - binary_linux_libtorch_2_7m_cu92_gcc5_4_cxx11-abi_nightly_static-without-deps_test
           filters:
             branches:
               only: nightly
           libtorch_variant: "static-without-deps"
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_libtorch_3_7m_cu100_gcc5_4_cxx11-abi_nightly_shared-with-deps_upload
-          build_environment: "libtorch 3.7m cu100 gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_2_7m_cu100_gcc5_4_cxx11-abi_nightly_shared-with-deps_upload
+          build_environment: "libtorch 2.7m cu100 gcc5.4_cxx11-abi"
           requires:
             - setup
-            - binary_linux_libtorch_3_7m_cu100_gcc5_4_cxx11-abi_nightly_shared-with-deps_test
+            - binary_linux_libtorch_2_7m_cu100_gcc5_4_cxx11-abi_nightly_shared-with-deps_test
           filters:
             branches:
               only: nightly
           libtorch_variant: "shared-with-deps"
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_libtorch_3_7m_cu100_gcc5_4_cxx11-abi_nightly_shared-without-deps_upload
-          build_environment: "libtorch 3.7m cu100 gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_2_7m_cu100_gcc5_4_cxx11-abi_nightly_shared-without-deps_upload
+          build_environment: "libtorch 2.7m cu100 gcc5.4_cxx11-abi"
           requires:
             - setup
-            - binary_linux_libtorch_3_7m_cu100_gcc5_4_cxx11-abi_nightly_shared-without-deps_test
+            - binary_linux_libtorch_2_7m_cu100_gcc5_4_cxx11-abi_nightly_shared-without-deps_test
           filters:
             branches:
               only: nightly
           libtorch_variant: "shared-without-deps"
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_libtorch_3_7m_cu100_gcc5_4_cxx11-abi_nightly_static-with-deps_upload
-          build_environment: "libtorch 3.7m cu100 gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_2_7m_cu100_gcc5_4_cxx11-abi_nightly_static-with-deps_upload
+          build_environment: "libtorch 2.7m cu100 gcc5.4_cxx11-abi"
           requires:
             - setup
-            - binary_linux_libtorch_3_7m_cu100_gcc5_4_cxx11-abi_nightly_static-with-deps_test
+            - binary_linux_libtorch_2_7m_cu100_gcc5_4_cxx11-abi_nightly_static-with-deps_test
           filters:
             branches:
               only: nightly
           libtorch_variant: "static-with-deps"
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_libtorch_3_7m_cu100_gcc5_4_cxx11-abi_nightly_static-without-deps_upload
-          build_environment: "libtorch 3.7m cu100 gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_2_7m_cu100_gcc5_4_cxx11-abi_nightly_static-without-deps_upload
+          build_environment: "libtorch 2.7m cu100 gcc5.4_cxx11-abi"
           requires:
             - setup
-            - binary_linux_libtorch_3_7m_cu100_gcc5_4_cxx11-abi_nightly_static-without-deps_test
+            - binary_linux_libtorch_2_7m_cu100_gcc5_4_cxx11-abi_nightly_static-without-deps_test
           filters:
             branches:
               only: nightly
           libtorch_variant: "static-without-deps"
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_libtorch_3_7m_cu101_gcc5_4_cxx11-abi_nightly_shared-with-deps_upload
-          build_environment: "libtorch 3.7m cu101 gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_2_7m_cu101_gcc5_4_cxx11-abi_nightly_shared-with-deps_upload
+          build_environment: "libtorch 2.7m cu101 gcc5.4_cxx11-abi"
           requires:
             - setup
-            - binary_linux_libtorch_3_7m_cu101_gcc5_4_cxx11-abi_nightly_shared-with-deps_test
+            - binary_linux_libtorch_2_7m_cu101_gcc5_4_cxx11-abi_nightly_shared-with-deps_test
           filters:
             branches:
               only: nightly
           libtorch_variant: "shared-with-deps"
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_libtorch_3_7m_cu101_gcc5_4_cxx11-abi_nightly_shared-without-deps_upload
-          build_environment: "libtorch 3.7m cu101 gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_2_7m_cu101_gcc5_4_cxx11-abi_nightly_shared-without-deps_upload
+          build_environment: "libtorch 2.7m cu101 gcc5.4_cxx11-abi"
           requires:
             - setup
-            - binary_linux_libtorch_3_7m_cu101_gcc5_4_cxx11-abi_nightly_shared-without-deps_test
+            - binary_linux_libtorch_2_7m_cu101_gcc5_4_cxx11-abi_nightly_shared-without-deps_test
           filters:
             branches:
               only: nightly
           libtorch_variant: "shared-without-deps"
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_libtorch_3_7m_cu101_gcc5_4_cxx11-abi_nightly_static-with-deps_upload
-          build_environment: "libtorch 3.7m cu101 gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_2_7m_cu101_gcc5_4_cxx11-abi_nightly_static-with-deps_upload
+          build_environment: "libtorch 2.7m cu101 gcc5.4_cxx11-abi"
           requires:
             - setup
-            - binary_linux_libtorch_3_7m_cu101_gcc5_4_cxx11-abi_nightly_static-with-deps_test
+            - binary_linux_libtorch_2_7m_cu101_gcc5_4_cxx11-abi_nightly_static-with-deps_test
           filters:
             branches:
               only: nightly
           libtorch_variant: "static-with-deps"
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_libtorch_3_7m_cu101_gcc5_4_cxx11-abi_nightly_static-without-deps_upload
-          build_environment: "libtorch 3.7m cu101 gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_2_7m_cu101_gcc5_4_cxx11-abi_nightly_static-without-deps_upload
+          build_environment: "libtorch 2.7m cu101 gcc5.4_cxx11-abi"
           requires:
             - setup
-            - binary_linux_libtorch_3_7m_cu101_gcc5_4_cxx11-abi_nightly_static-without-deps_test
+            - binary_linux_libtorch_2_7m_cu101_gcc5_4_cxx11-abi_nightly_static-without-deps_test
           filters:
             branches:
               only: nightly
           libtorch_variant: "static-without-deps"
+          context: org-member
+      - binary_mac_upload:
+          name: binary_macos_wheel_2_7_cpu_nightly_upload
+          build_environment: "wheel 2.7 cpu"
+          requires:
+            - setup
+            - binary_macos_wheel_2_7_cpu_nightly_build
+          filters:
+            branches:
+              only: nightly
           context: org-member
       - binary_mac_upload:
           name: binary_macos_wheel_3_5_cpu_nightly_upload
@@ -4947,6 +5561,16 @@ workflows:
           requires:
             - setup
             - binary_macos_wheel_3_7_cpu_nightly_build
+          filters:
+            branches:
+              only: nightly
+          context: org-member
+      - binary_mac_upload:
+          name: binary_macos_conda_2_7_cpu_nightly_upload
+          build_environment: "conda 2.7 cpu"
+          requires:
+            - setup
+            - binary_macos_conda_2_7_cpu_nightly_build
           filters:
             branches:
               only: nightly
@@ -4982,11 +5606,11 @@ workflows:
               only: nightly
           context: org-member
       - binary_mac_upload:
-          name: binary_macos_libtorch_3_7_cpu_nightly_upload
-          build_environment: "libtorch 3.7 cpu"
+          name: binary_macos_libtorch_2_7_cpu_nightly_upload
+          build_environment: "libtorch 2.7 cpu"
           requires:
             - setup
-            - binary_macos_libtorch_3_7_cpu_nightly_build
+            - binary_macos_libtorch_2_7_cpu_nightly_build
           filters:
             branches:
               only: nightly

--- a/.circleci/verbatim-sources/workflows-binary-builds-smoke-subset.yml
+++ b/.circleci/verbatim-sources/workflows-binary-builds-smoke-subset.yml
@@ -6,8 +6,8 @@
       # at https://github.com/ezyang/pytorch-ci-hud/blob/master/src/BuildHistoryDisplay.js
 
       - binary_linux_build:
-          name: binary_linux_manywheel_3_7mu_cpu_devtoolset7_build
-          build_environment: "manywheel 3.7mu cpu devtoolset7"
+          name: binary_linux_manywheel_2_7mu_cpu_devtoolset7_build
+          build_environment: "manywheel 2.7mu cpu devtoolset7"
           requires:
             - setup
           docker_image: "pytorch/manylinux-cuda100"
@@ -18,23 +18,23 @@
             - setup
           docker_image: "pytorch/manylinux-cuda100"
       - binary_linux_build:
-          name: binary_linux_conda_3_7_cpu_devtoolset7_build
-          build_environment: "conda 3.7 cpu devtoolset7"
+          name: binary_linux_conda_2_7_cpu_devtoolset7_build
+          build_environment: "conda 2.7 cpu devtoolset7"
           requires:
             - setup
           docker_image: "pytorch/conda-cuda"
       # This binary build is currently broken, see https://github_com/pytorch/pytorch/issues/16710
       # - binary_linux_conda_3_6_cu90_devtoolset7_build
       - binary_linux_build:
-          name: binary_linux_libtorch_3_7m_cpu_devtoolset7_shared-with-deps_build
-          build_environment: "libtorch 3.7m cpu devtoolset7"
+          name: binary_linux_libtorch_2_7m_cpu_devtoolset7_shared-with-deps_build
+          build_environment: "libtorch 2.7m cpu devtoolset7"
           requires:
             - setup
           libtorch_variant: "shared-with-deps"
           docker_image: "pytorch/manylinux-cuda100"
       - binary_linux_build:
-          name: binary_linux_libtorch_3_7m_cpu_gcc5_4_cxx11-abi_shared-with-deps_build
-          build_environment: "libtorch 3.7m cpu gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_shared-with-deps_build
+          build_environment: "libtorch 2.7m cpu gcc5.4_cxx11-abi"
           requires:
             - setup
           libtorch_variant: "shared-with-deps"
@@ -47,22 +47,22 @@
           requires:
             - setup
       - binary_mac_build:
-          name: binary_macos_conda_3_7_cpu_build
-          build_environment: "conda 3.7 cpu"
+          name: binary_macos_conda_2_7_cpu_build
+          build_environment: "conda 2.7 cpu"
           requires:
             - setup
       - binary_mac_build:
-          name: binary_macos_libtorch_3_7_cpu_build
-          build_environment: "libtorch 3.7 cpu"
+          name: binary_macos_libtorch_2_7_cpu_build
+          build_environment: "libtorch 2.7 cpu"
           requires:
             - setup
 
       - binary_linux_test:
-          name: binary_linux_manywheel_3_7mu_cpu_devtoolset7_test
-          build_environment: "manywheel 3.7mu cpu devtoolset7"
+          name: binary_linux_manywheel_2_7mu_cpu_devtoolset7_test
+          build_environment: "manywheel 2.7mu cpu devtoolset7"
           requires:
             - setup
-            - binary_linux_manywheel_3_7mu_cpu_devtoolset7_build
+            - binary_linux_manywheel_2_7mu_cpu_devtoolset7_build
           docker_image: "pytorch/manylinux-cuda100"
       - binary_linux_test:
           name: binary_linux_manywheel_3_7m_cu100_devtoolset7_test
@@ -74,28 +74,28 @@
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
-          name: binary_linux_conda_3_7_cpu_devtoolset7_test
-          build_environment: "conda 3.7 cpu devtoolset7"
+          name: binary_linux_conda_2_7_cpu_devtoolset7_test
+          build_environment: "conda 2.7 cpu devtoolset7"
           requires:
             - setup
-            - binary_linux_conda_3_7_cpu_devtoolset7_build
+            - binary_linux_conda_2_7_cpu_devtoolset7_build
           docker_image: "pytorch/conda-cuda"
       # This binary build is currently broken, see https://github_com/pytorch/pytorch/issues/16710
       # - binary_linux_conda_3_6_cu90_devtoolset7_test:
       - binary_linux_test:
-          name: binary_linux_libtorch_3_7m_cpu_devtoolset7_shared-with-deps_test
-          build_environment: "libtorch 3.7m cpu devtoolset7"
+          name: binary_linux_libtorch_2_7m_cpu_devtoolset7_shared-with-deps_test
+          build_environment: "libtorch 2.7m cpu devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_3_7m_cpu_devtoolset7_shared-with-deps_build
+            - binary_linux_libtorch_2_7m_cpu_devtoolset7_shared-with-deps_build
           libtorch_variant: "shared-with-deps"
           docker_image: "pytorch/manylinux-cuda100"
       - binary_linux_test:
-          name: binary_linux_libtorch_3_7m_cpu_gcc5_4_cxx11-abi_shared-with-deps_test
-          build_environment: "libtorch 3.7m cpu gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_shared-with-deps_test
+          build_environment: "libtorch 2.7m cpu gcc5.4_cxx11-abi"
           requires:
             - setup
-            - binary_linux_libtorch_3_7m_cpu_gcc5_4_cxx11-abi_shared-with-deps_build
+            - binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_shared-with-deps_build
           libtorch_variant: "shared-with-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -42,7 +42,7 @@ jobs:
           sudo apt-get install -y doxygen && pip install -r requirements.txt
           cd docs/cpp/source && ./check-doxygen.sh
 
-  flake8:
+  flake8-py3:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Python
@@ -72,12 +72,50 @@ jobs:
       - name: Add annotations
         uses: pytorch/add-annotations-github-action@master
         with:
-          check_name: 'flake8'
+          check_name: 'flake8-py3'
           linter_output_path: 'flake8-output.txt'
           commit_sha: ${{ steps.get_pr_tip.outputs.commit_sha }}
           regex: '^(?<filename>.*?):(?<lineNumber>\d+):(?<columnNumber>\d+): (?<errorCode>\w\d+) (?<errorDesc>.*)'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  flake8-py2:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 2.x
+          architecture: x64
+      - name: Fetch PyTorch
+        uses: actions/checkout@v1
+      - name: Checkout PR tip
+        run: |
+          set -eux
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            # We are on a PR, so actions/checkout leaves us on a merge commit.
+            # Check out the actual tip of the branch.
+            git checkout ${{ github.event.pull_request.head.sha }}
+          fi
+          echo ::set-output name=commit_sha::$(git rev-parse HEAD)
+        id: get_pr_tip
+      - name: Run flake8
+        run: |
+          set -eux
+          pip install flake8
+          rm -rf .circleci
+          flake8 --exit-zero > ${GITHUB_WORKSPACE}/flake8-output.txt
+          cat ${GITHUB_WORKSPACE}/flake8-output.txt
+      - name: Add annotations
+        uses: pytorch/add-annotations-github-action@master
+        with:
+          check_name: 'flake8-py2'
+          linter_output_path: 'flake8-output.txt'
+          commit_sha: ${{ steps.get_pr_tip.outputs.commit_sha }}
+          regex: '^(?<filename>.*?):(?<lineNumber>\d+):(?<columnNumber>\d+): (?<errorCode>\w\d+) (?<errorDesc>.*)'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 
   clang-tidy:
     if: github.event_name == 'pull_request'


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#31164 Re-enable python 2 builds**

We have a small number of internal projects that still are on Python 2.
Until we can figure out how to get rid of them, we need to continue
supporting Python 2 for PyTorch.

Differential Revision: [D18949698](https://our.internmc.facebook.com/intern/diff/D18949698)