### PR TITLE
Exclude lite interpreter Java files from OSS host build

### DIFF
--- a/android/pytorch_android/host/build.gradle
+++ b/android/pytorch_android/host/build.gradle
@@ -14,7 +14,11 @@ repositories {
 
 sourceSets {
     main {
-        java.srcDir '../src/main/java'
+        java {
+            srcDir '../src/main/java'
+            exclude 'org/pytorch/LiteModuleLoader.java'
+            exclude 'org/pytorch/LiteNativePeer.java'
+        }
     }
     test {
         java {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#31204 Exclude lite interpreter Java files from OSS host build**

Differential Revision: [D19200610](https://our.internmc.facebook.com/intern/diff/D19200610)