### PR TITLE
[android] Expose setNumThreads to android api

### DIFF
--- a/android/pytorch_android/host/build.gradle
+++ b/android/pytorch_android/host/build.gradle
@@ -14,7 +14,10 @@ repositories {
 
 sourceSets {
     main {
-        java.srcDir '../src/main/java'
+        java {
+            srcDir '../src/main/java'
+            exclude 'org/pytorch/PyTorchAndroid.java'
+        }
     }
     test {
         java {

--- a/android/pytorch_android/src/main/cpp/pytorch_jni_common.cpp
+++ b/android/pytorch_android/src/main/cpp/pytorch_jni_common.cpp
@@ -7,6 +7,10 @@
 #include <fbjni/fbjni.h>
 
 #include "pytorch_jni_common.h"
+#if defined(__ANDROID__)
+#include <caffe2/utils/threadpool/ThreadPool.h>
+#include <caffe2/utils/threadpool/ThreadPoolMobile.h>
+#endif
 
 namespace pytorch_jni {
 
@@ -567,6 +571,33 @@ at::IValue JIValue::JIValueToAtIValue(
       facebook::jni::gJavaLangIllegalArgumentException,
       "Unknown IValue typeCode %d",
       typeCode);
+}
+
+#if defined(__ANDROID__)
+class PyTorchAndroidJni : public facebook::jni::JavaClass<PyTorchAndroidJni> {
+ public:
+  constexpr static auto kJavaDescriptor = "Lorg/pytorch/PyTorchAndroid;";
+
+  static void registerNatives() {
+    javaClassStatic()->registerNatives({
+        makeNativeMethod(
+            "nativeSetNumThreads", PyTorchAndroidJni::setNumThreads),
+    });
+  }
+
+  static void setNumThreads(facebook::jni::alias_ref<jclass>, jint numThreads) {
+    caffe2::mobile_threadpool()->setNumThreads(numThreads);
+  }
+};
+#endif
+
+void common_registerNatives() {
+  static const int once = []() {
+#if defined(__ANDROID__)
+    pytorch_jni::PyTorchAndroidJni::registerNatives();
+#endif
+    return 0;
+  }();
 }
 
 } // namespace pytorch_jni

--- a/android/pytorch_android/src/main/cpp/pytorch_jni_common.h
+++ b/android/pytorch_android/src/main/cpp/pytorch_jni_common.h
@@ -87,4 +87,6 @@ class JIValue : public facebook::jni::JavaClass<JIValue> {
   static at::IValue JIValueToAtIValue(
       facebook::jni::alias_ref<JIValue> jivalue);
 };
+
+void common_registerNatives();
 } // namespace pytorch_jni

--- a/android/pytorch_android/src/main/cpp/pytorch_jni_jit.cpp
+++ b/android/pytorch_android/src/main/cpp/pytorch_jni_jit.cpp
@@ -127,6 +127,8 @@ class PytorchJni : public facebook::jni::HybridClass<PytorchJni> {
 } // namespace pytorch_jni
 
 JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void*) {
-  return facebook::jni::initialize(
-      vm, [] { pytorch_jni::PytorchJni::registerNatives(); });
+  return facebook::jni::initialize(vm, [] {
+    pytorch_jni::PytorchJni::registerNatives();
+    pytorch_jni::common_registerNatives();
+  });
 }

--- a/android/pytorch_android/src/main/java/org/pytorch/PytorchAndroid.java
+++ b/android/pytorch_android/src/main/java/org/pytorch/PytorchAndroid.java
@@ -1,0 +1,29 @@
+package org.pytorch;
+
+import com.facebook.soloader.nativeloader.NativeLoader;
+import com.facebook.soloader.nativeloader.SystemDelegate;
+
+public final class PyTorchAndroid {
+  static {
+    if (!NativeLoader.isInitialized()) {
+      NativeLoader.init(new SystemDelegate());
+    }
+    NativeLoader.loadLibrary("pytorch_jni");
+  }
+
+  /**
+   * Globally sets the number of threads used on native side.
+   * Attention: Has global effect, all modules use one thread pool with specified number of threads.
+   *
+   * @param numThreads number of threads, must be positive number.
+   */
+  public static void setNumThreads(int numThreads) {
+    if (numThreads < 1) {
+      throw new IllegalArgumentException("Number of threads cannot be less than 1");
+    }
+
+    nativeSetNumThreads(numThreads);
+  }
+
+  private static native void nativeSetNumThreads(int numThreads);
+}

--- a/caffe2/utils/threadpool/ThreadPool.h
+++ b/caffe2/utils/threadpool/ThreadPool.h
@@ -7,6 +7,7 @@
 #include <memory>
 #include <mutex>
 #include <vector>
+#include <atomic>
 
 #include "caffe2/core/common.h"
 
@@ -36,6 +37,7 @@ class CAFFE2_API /*alignas(kCacheLineSize)*/ ThreadPool {
   ~ThreadPool();
   // Returns the number of threads currently in use
   int getNumThreads() const;
+  void setNumThreads(size_t numThreads);
 
   // Sets the minimum work size (range) for which to invoke the
   // threadpool; work sizes smaller than this will just be run on the
@@ -51,7 +53,7 @@ class CAFFE2_API /*alignas(kCacheLineSize)*/ ThreadPool {
  private:
   mutable std::mutex executionMutex_;
   size_t minWorkSize_;
-  size_t numThreads_;
+  std::atomic_size_t numThreads_;
   std::shared_ptr<WorkersPool> workersPool_;
   std::vector<std::shared_ptr<Task>> tasks_;
 };


### PR DESCRIPTION
PR https://github.com/pytorch/pytorch/pull/31033 was unlanded due to macos build failure:
https://app.circleci.com/jobs/github/pytorch/pytorch/3916388 

This PR has changes that `setNumThreads` is only for android and moved to separate class `org.pytorch.PytorchAndroid` as a static function which is better as it has global effect