### PR TITLE
Remove unused argument "destId" in addSendRpcBackward

### DIFF
--- a/test/cpp/dist_autograd/test_dist_autograd.cpp
+++ b/test/cpp/dist_autograd/test_dist_autograd.cpp
@@ -35,7 +35,7 @@ TEST_F(DistAutogradTest, TestSendFunctionInvalidInputs) {
   std::vector<torch::Tensor> tensors = {in1, in2};
   rpc::worker_id_t worker_id = 1;
   addSendRpcBackward(
-      autogradContext, AutogradMetadata(1, 1), tensors, worker_id);
+      autogradContext, AutogradMetadata(1, 1), tensors);
   autogradContext->addKnownWorkerId(worker_id);
   auto send_function = autogradContext->sendFunctions()[1];
 
@@ -84,7 +84,7 @@ TEST_F(DistAutogradTest, TestInitializedContextCleanupSendFunction) {
   auto t = torch::ones({1}, options);
   auto tensors = std::vector<torch::Tensor>{t};
   addSendRpcBackward(
-      context, AutogradMetadata(context->contextId(), 0), tensors, 0);
+      context, AutogradMetadata(context->contextId(), 0), tensors);
 
   auto sendFunction = context->retrieveSendFunction(0);
   sendFunction->setGrads({t});

--- a/torch/csrc/distributed/autograd/utils.cpp
+++ b/torch/csrc/distributed/autograd/utils.cpp
@@ -21,8 +21,7 @@ using torch::distributed::rpc::WorkerInfo;
 void addSendRpcBackward(
     const ContextPtr& autogradContext,
     const AutogradMetadata& autogradMetadata,
-    std::vector<torch::Tensor>& tensors,
-    const rpc::worker_id_t dst) {
+    std::vector<torch::Tensor>& tensors) {
   // Attach autograd information only for tensors requiring grad.
   std::vector<torch::Tensor> tensors_with_grad;
   std::copy_if(
@@ -104,7 +103,7 @@ Message getMessageWithAutograd(
   if (tensorsRequireGrad) {
     // Record autograd information for 'send'.
     addSendRpcBackward(
-        autogradContext, autogradMetadata, rpcWithAutograd->tensors(), dstId);
+        autogradContext, autogradMetadata, rpcWithAutograd->tensors());
   }
   // Record the workerID
   autogradContext->addKnownWorkerId(dstId);

--- a/torch/csrc/distributed/autograd/utils.h
+++ b/torch/csrc/distributed/autograd/utils.h
@@ -16,8 +16,7 @@ namespace autograd {
 TORCH_API void addSendRpcBackward(
     const ContextPtr& autogradContext,
     const AutogradMetadata& autogradMetadata,
-    std::vector<torch::Tensor>& tensors,
-    const rpc::worker_id_t dst);
+    std::vector<torch::Tensor>& tensors);
 
 // This method is used to attach the 'recv' autograd function to the autograd
 // graph when we use RPC. This method creates a new 'recv' autograd function


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#31207 Remove unused argument "destId" in addSendRpcBackward**
* #31206 Remove the second copy on calling dist_autograd_context._known_worker_ids()

Cleanup after #30914.

In #30914, `autogradContext->addKnownWorkerId(dst);` was moved out of `addSendRpcBackward()`.

So `addSendRpcBackward()` does not need `dstId` as it's argument anymore.

Differential Revision: [D5742365](https://our.internmc.facebook.com/intern/diff/D5742365/)