### PR TITLE
Remove subgraphNode kind assert in unmergeSubgraph

### DIFF
--- a/torch/csrc/jit/passes/utils/subgraph_utils.cpp
+++ b/torch/csrc/jit/passes/utils/subgraph_utils.cpp
@@ -33,8 +33,6 @@ std::shared_ptr<Graph> getSubgraph(Node* n) {
 }
 
 void unmergeSubgraph(Node* subgraphNode) {
-  AT_ASSERT(subgraphNode->kind() == prim::DifferentiableGraph);
-
   // Inline the graph, replace uses of node outputs and destroy the node
   auto outerGraph = subgraphNode->owningGraph();
   WithInsertPoint guard(subgraphNode);


### PR DESCRIPTION
Summary: To be able to use this function more broadly.

Test Plan: unit tests

Reviewed By: jackm321

Differential Revision: D18978913

