### PR TITLE
fix torch square_ benchmark runtime error

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2566,7 +2566,7 @@
 
 - func: square_(Tensor(a!) self) -> Tensor(a!)
   supports_named_tensor: True
-  variants: method
+  variants: function, method
 
 - func: std(Tensor self, bool unbiased=True) -> Tensor
   use_c10_dispatcher: full


### PR DESCRIPTION
Summary: This is fixing the runtime error introduced in https://github.com/pytorch/pytorch/pull/30719 that added torch square_ operator to the benchmark suite.

Test Plan:
```
# ----------------------------------------
# PyTorch/Caffe2 Operator Micro-benchmarks
# ----------------------------------------
# Tag : short

# Benchmarking PyTorch: square_
# Mode: Eager
# Name: square__M512_N512_cpu
# Input: M: 512, N: 512, device: cpu
Forward Execution Time (us) : 66.291

Reviewed By: hl475

Differential Revision: D18987889

