### PR TITLE
[pytorch] Robustify rpc_agent handlers post-generic Future<T>

### DIFF
--- a/torch/csrc/distributed/rpc/process_group_agent.cpp
+++ b/torch/csrc/distributed/rpc/process_group_agent.cpp
@@ -382,16 +382,35 @@ void ProcessGroupAgent::enqueueRecv(RecvWork work) {
         if (message.isRequest()) {
           auto futureResponse = cb_->operator()(message);
           if (futureResponse->completed()) {
-            send(work.from_, std::move(*futureResponse).moveValue());
+            if (!futureResponse->hasError()) {
+              send(work.from_, std::move(*futureResponse).moveValue());
+            } else {
+              send(
+                  work.from_,
+                  createExceptionResponse(
+                      message, futureResponse->error()->what()));
+            }
           } else {
             auto fromId = work.from_.id_;
+            auto requestId = work.id_;
             futureResponse->addCallback(
-                [this, fromId, futureResponse](
+                [this, fromId, requestId, futureResponse](
                     const Message& /* unused */,
-                    const c10::optional<utils::FutureError>& /* unused */) {
-                  send(
-                      getWorkerInfo(fromId),
-                      std::move(*futureResponse).moveValue());
+                    const c10::optional<utils::FutureError>& err) {
+                  if (!err) {
+                    send(
+                        getWorkerInfo(fromId),
+                        std::move(*futureResponse).moveValue());
+                  } else {
+                    std::string errStr = err->what();
+                    std::vector<char> payload(errStr.begin(), errStr.end());
+                    Message m(
+                        std::move(payload),
+                        {},
+                        MessageType::EXCEPTION,
+                        requestId);
+                    send(getWorkerInfo(fromId), std::move(m));
+                  }
                 });
           }
         } else if (message.isResponse()) {

--- a/torch/csrc/utils/future.h
+++ b/torch/csrc/utils/future.h
@@ -108,6 +108,11 @@ class TORCH_API Future final {
     return error_ ? true : false;
   }
 
+  c10::optional<FutureError> error() const {
+    std::unique_lock<std::mutex> lock(mutex_);
+    return error_;
+  }
+
   // If completed() the callback will be invoked in-place.
   void addCallback(const Callback& callback) {
     std::unique_lock<std::mutex> lock(mutex_);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#31224 [pytorch] Robustify rpc_agent handlers with generic Future<T>**

If a future coming back to a rpc_agent server is satisfied with an
exception, ensure this information is propagated back over the wire.

Differential Revision: [D18979185](https://our.internmc.facebook.com/intern/diff/D18979185/)