### PR TITLE
Revert "Switch default memory format of to (and similar) operators to Preserve"

### DIFF
--- a/aten/src/ATen/native/TensorConversions.cpp
+++ b/aten/src/ATen/native/TensorConversions.cpp
@@ -21,7 +21,7 @@ static inline Device ensure_has_index(Device device) {
 
 static inline Tensor to_impl(const Tensor& self, const TensorOptions& options, bool non_blocking, bool copy, c10::optional<c10::MemoryFormat> optional_memory_format) {
   auto memory_format =
-      optional_memory_format.value_or(MemoryFormat::Preserve);
+      optional_memory_format.value_or(MemoryFormat::Contiguous);
 
   if (self.dtype() == options.dtype() && self.layout() == options.layout() &&
       self.device() == options.device() && !copy &&

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -961,9 +961,9 @@ class TestCuda(TestCase):
         with torch.cuda.stream(user_stream):
             self.assertEqual(torch.cuda.current_stream(), user_stream)
         self.assertTrue(user_stream.query())
-        # Operate on 10 MB tensor which should take some time
+        # copy 10 MB tensor from CPU-GPU which should take some time
         tensor1 = torch.ByteTensor(10000000).pin_memory()
-        tensor2 = tensor1.cuda(non_blocking=True) + 1
+        tensor2 = tensor1.cuda(non_blocking=True)
         self.assertFalse(default_stream.query())
         default_stream.synchronize()
         self.assertTrue(default_stream.query())

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -13176,7 +13176,7 @@ class TestTorchDeviceType(TestCase):
         def transformation_fn(tensor, **kwargs):
             return tensor.to(dtype=torch.float64, **kwargs)
 
-        self._test_memory_format_transformations(device, input_generator_fn, transformation_fn, default_is_preserve=True)
+        self._test_memory_format_transformations(device, input_generator_fn, transformation_fn)
 
     def test_memory_format_type(self, device):
         def input_generator_fn(device):
@@ -13186,7 +13186,7 @@ class TestTorchDeviceType(TestCase):
         def transformation_fn(tensor, **kwargs):
             return tensor.type(torch.float64, **kwargs)
 
-        self._test_memory_format_transformations(device, input_generator_fn, transformation_fn, default_is_preserve=True)
+        self._test_memory_format_transformations(device, input_generator_fn, transformation_fn)
 
     def test_memory_format_clone(self, device):
         def input_generator_fn(device):
@@ -13246,14 +13246,14 @@ class TestTorchDeviceType(TestCase):
             shortcuts += ['bfloat16']
 
         for fn_name in shortcuts:
-            self._test_memory_format_transformations(device, input_generator_fn, get_fn(fn_name), default_is_preserve=True)
+            self._test_memory_format_transformations(device, input_generator_fn, get_fn(fn_name))
 
         # Test 'float' separately to avoid float->float no-op.
         def input_generator_fn_double(device):
             return torch.randn((4, 3, 8, 8), device=device, dtype=torch.float64).clamp(0, 1) \
                         .round().contiguous(memory_format=torch.channels_last)
 
-        self._test_memory_format_transformations(device, input_generator_fn_double, get_fn('float'), default_is_preserve=True)
+        self._test_memory_format_transformations(device, input_generator_fn_double, get_fn('float'))
 
     @onlyCUDA
     def test_memory_format_cpu_and_cuda_ops(self, device):
@@ -13266,8 +13266,8 @@ class TestTorchDeviceType(TestCase):
         def transformation_cuda_fn(tensor, **kwargs):
             return tensor.cuda(**kwargs)
 
-        self._test_memory_format_transformations('cuda', input_generator_fn, transformation_cpu_fn, default_is_preserve=True)
-        self._test_memory_format_transformations('cpu', input_generator_fn, transformation_cuda_fn, default_is_preserve=True)
+        self._test_memory_format_transformations('cuda', input_generator_fn, transformation_cpu_fn)
+        self._test_memory_format_transformations('cpu', input_generator_fn, transformation_cuda_fn)
 
     @onlyCPU
     @skipCPUIfNoLapack


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #31227 Fix `.to` operator to preserve strides when `self` should be returned
* **#31226 Revert "Switch default memory format of to (and similar) operators to Preserve"**
* #31139 [WIP] Fix cudnn channels_last descriptio problem
* #31131 Add memory_format support to `zeros`, `ones`, `full` (still need tests)
* #30089 Switch default memory format of clone operator to Preserve
* #30088 Switch default memory format of to (and similar) operators to Preserve
* #30087 Switch default memory format of _like operators to Preserve

This reverts commit 2f10e19dfeb7052ec03ee25d2d82b5854443bb10.