### PR TITLE
Fix `.to` operator to preserve strides when `self` should be returned

### DIFF
--- a/aten/src/ATen/native/TensorConversions.cpp
+++ b/aten/src/ATen/native/TensorConversions.cpp
@@ -26,7 +26,8 @@ static inline Tensor to_impl(const Tensor& self, const TensorOptions& options, b
   if (self.dtype() == options.dtype() && self.layout() == options.layout() &&
       self.device() == options.device() && !copy &&
       (memory_format == MemoryFormat::Preserve ||
-       self.suggest_memory_format() == memory_format)) {
+       (!optional_memory_format.has_value() ||
+        self.is_contiguous(memory_format)))) {
     return self;
   }
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -5282,7 +5282,7 @@ tensor([[[1., 1., 1.,  ..., 1., 1., 1.],
             tensor[0] = np_val
             self.assertEqual(tensor[0], np_val)
 
-            # Original reported issue, np integral type parses to the correct 
+            # Original reported issue, np integral type parses to the correct
             # PyTorch integral type when passed for a `Scalar` parameter in
             # arithmetic operations:
             t = torch.from_numpy(np_arr)
@@ -12348,6 +12348,16 @@ class TestTorchDeviceType(TestCase):
         nhwc = x.contiguous(memory_format=torch.channels_last)
         y = nhwc.permute(0, 1, 3, 2).permute(0, 1, 3, 2)
         self.assertTrue(y.is_contiguous(memory_format=torch.channels_last))
+
+    def test_memory_format_to_operator(self, device):
+        x = torch.randn(4, 3, 8, 8, device=device).contiguous(memory_format=torch.channels_last)
+        z = x.to(device=device)
+        self.assertTrue(z.is_contiguous(memory_format=torch.channels_last))
+        self.assertEqual(x.data_ptr(), z.data_ptr())
+        z = x.to(memory_format=torch.contiguous_format)
+        self.assertTrue(z.is_contiguous(memory_format=torch.contiguous_format))
+        z = x.to(memory_format=torch.channels_last)
+        self.assertEqual(x.data_ptr(), z.data_ptr())
 
     def test_resize_as_preserves_strides(self, device):
         x = torch.empty(2, 3).t()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#31227 Fix `.to` operator to preserve strides when `self` should be returned**
* #31226 Revert "Switch default memory format of to (and similar) operators to Preserve"
* #31139 [WIP] Fix cudnn channels_last descriptio problem
* #31131 Add memory_format support to `zeros`, `ones`, `full` (still need tests)
* #30089 Switch default memory format of clone operator to Preserve
* #30088 Switch default memory format of to (and similar) operators to Preserve
* #30087 Switch default memory format of _like operators to Preserve

