### PR TITLE
batch norm vecterization version

### DIFF
--- a/aten/src/ATen/native/Normalization.h
+++ b/aten/src/ATen/native/Normalization.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <ATen/ATen.h>
+#include <ATen/native/DispatchStub.h>
+#include <c10/core/Scalar.h>
+
+namespace at { namespace native {
+
+using batch_norm_cpu_inference_contiguous_fn = void (*)(Tensor&, const Tensor&, const Tensor&, const Tensor&);
+using batch_norm_cpu_inference_channels_last_fn = void (*)(Tensor&, const Tensor&, const Tensor&, const Tensor&);
+
+DECLARE_DISPATCH(batch_norm_cpu_inference_contiguous_fn, batch_norm_cpu_inference_contiguous_stub);
+DECLARE_DISPATCH(batch_norm_cpu_inference_channels_last_fn, batch_norm_cpu_inference_channels_last_stub);
+
+}} // namespace at::native

--- a/aten/src/ATen/native/cpu/Normalization.cpp
+++ b/aten/src/ATen/native/cpu/Normalization.cpp
@@ -1,0 +1,140 @@
+#include <ATen/ATen.h>
+#include <ATen/cpu/vec256/vec256.h>
+
+namespace at { namespace native {
+
+namespace {
+
+template <typename T>
+inline void apply(int64_t pos, const T& alpha, const T& beta, const T* input, T* output) {
+    using Vec = vec256::Vec256<T>;
+
+    Vec alpha_vec(alpha);
+    Vec beta_vec(beta);
+    Vec input_vec = Vec::loadu(&input[pos]);
+    Vec output_vec = vec256::fmadd<Vec>(input_vec, alpha_vec, beta_vec);
+
+    output_vec.store(&output[pos]);
+}
+
+static void batch_norm_cpu_inference_contiguous_kernel(
+    Tensor& output,
+    const Tensor& input, const Tensor& alpha, const Tensor& beta) {
+
+    AT_DISPATCH_ALL_TYPES(output.scalar_type(), "batch_norm_cpu_contiguous_kernel", [&] {
+
+        using Vec = vec256::Vec256<scalar_t>;
+
+        int64_t n_batch = input.size(0);
+        int64_t n_channel = input.size(1);
+        int64_t image_size = input.numel() / n_batch / n_channel;
+
+        const scalar_t* input_data = input.data_ptr<scalar_t>();
+        scalar_t* output_data = output.data_ptr<scalar_t>();
+
+        scalar_t* alpha_data = alpha.data_ptr<scalar_t>();
+        scalar_t* beta_data = beta.data_ptr<scalar_t>();
+
+        // Apply the linear terms to the input,
+        // output(n, c, h, w) = input(n, c, h, w) * alpha(c) + beta(c)
+        // No need to use parallel_for as this function is supposed to be memory-limited.
+        // Keep the loop struture simple to make sure compiler vetorization kicks in.
+        if (image_size != 1) {
+            for (int64_t n = 0; n < n_batch; ++n) {
+                for (int64_t c = 0; c < n_channel; ++c) {
+                    int64_t offset = n * n_channel * image_size + c * image_size;
+                    int64_t i = 0;
+                    for (; i < image_size - Vec::size(); i += Vec::size()) {
+                        apply<scalar_t>(offset+i, alpha_data[c], beta_data[c], input_data, output_data);
+                    }
+
+                    if (i < image_size) {
+                        for (; i < image_size; ++i) {
+                            output_data[offset+i] = input_data[offset+i] * alpha_data[c] + beta_data[c];
+                        }
+                    }
+                }
+            }
+        }
+        else {
+            for (int64_t n = 0; n < n_batch; ++n) {
+                int64_t offset = n * n_channel;
+                int64_t c = 0;
+                for (; c < n_channel - Vec::size(); c += Vec::size()) {
+                    apply<scalar_t>(offset+c, alpha_data[c], beta_data[c], input_data, output_data);
+                }
+
+                if (c < n_channel) {
+                    for (; c < n_channel; ++c) {
+                        output_data[offset+c] = input_data[offset+c] * alpha_data[c] + beta_data[c];
+                    }
+                }
+            }
+        }
+    });
+}
+
+static void batch_norm_cpu_inference_channels_last_kernel(
+    Tensor& output,
+    const Tensor& input, const Tensor& alpha, const Tensor& beta) {
+
+    AT_DISPATCH_ALL_TYPES(output.scalar_type(), "batch_norm_cpu_channels_last_kernel", [&] {
+
+        using Vec = vec256::Vec256<scalar_t>;
+
+        int64_t n_batch = input.size(0);
+        int64_t n_channel = input.size(1);
+        int64_t image_size = input.numel() / n_batch / n_channel;
+
+        const scalar_t* input_data = input.data_ptr<scalar_t>();
+        scalar_t* output_data = output.data_ptr<scalar_t>();
+
+        scalar_t* alpha_data = alpha.data_ptr<scalar_t>();
+        scalar_t* beta_data = beta.data_ptr<scalar_t>();
+
+        // Apply the linear terms to the input,
+        // output(n, c, h, w) = input(n, c, h, w) * alpha(c) + beta(c)
+        // No need to use parallel_for as this function is supposed to be memory-limited.
+        // Keep the loop struture simple to make sure compiler vetorization kicks in.
+        if (n_channel != 1) {
+            for (int64_t n = 0; n < n_batch; ++n) {
+                for (int64_t i = 0; i < image_size; ++i) {
+                    int64_t offset = n * image_size * n_channel + i * n_channel;
+                    int c = 0;
+                    for (; c < n_channel - Vec::size(); c += Vec::size()) {
+                        apply<scalar_t>(offset + c, alpha_data[c], beta_data[c], input_data, output_data);
+                    }
+
+                    if (c < n_channel) {
+                        for (; c < n_channel; ++c) {
+                            output_data[offset+c] = input_data[offset+c] * alpha_data[c] + beta_data[c];
+                        }
+                    }
+                }
+            }
+        }
+        else {
+            for (int64_t n = 0; n < n_batch; ++n) {
+                int64_t offset = n * image_size;
+                int64_t i = 0;
+                for (; i < image_size - Vec::size(); i += Vec::size()) {
+                    apply<scalar_t>(offset+i, alpha_data[0], beta_data[0], input_data, output_data);
+                }
+
+                if (i < image_size) {
+                    for (; i < image_size; ++i) {
+                        output_data[offset+i] = input_data[offset+i] * alpha_data[0] + beta_data[0];
+                    }
+                }
+            }
+        }
+    });
+}
+
+} // namespace
+
+REGISTER_DISPATCH(batch_norm_cpu_inference_contiguous_stub, &batch_norm_cpu_inference_contiguous_kernel)
+REGISTER_DISPATCH(batch_norm_cpu_inference_channels_last_stub, &batch_norm_cpu_inference_channels_last_kernel)
+
+} // namespace native
+} // namespace at


### PR DESCRIPTION
Here is a benchmark for explicit vectorization. It seems we got some performance gain for small channel number.

**Test program**
```
for c in [1,3,10,100,1000]:
    for hw in [1,4,16,64,256]:  
          print('Benchmark n=20 c={0} h={1} w={2}'.format(c, hw, hw))                  
          m = nn.BatchNorm2d(c, affine=False)                                                                                             
          m.eval()     
          input = torch.randn(20, c, hw, hw) 
          output = m(input) 
          %timeit m(input) 
          input = input.contiguous(memory_format=torch.channels_last)                                                                       
          output1 = m(input) 
          %timeit m(input)
```

**Benchmark Layout: No Explicit Vectorization | With Explicit Vectorization**
Benchmark n=20 c=1   h=1 w=1 |  
10.5 µs ± 289 ns per loop | 10.8 µs ± 259 ns per loop  -> contiguous format
11.4 µs ± 332 ns per loop | 10.8 µs ± 186 ns per loop   -> channels last format
Benchmark n=20 c=1 h=4 w=4 |  
10.6 µs ± 184 ns per loop | 10.9 µs ± 193 ns per loop
10.6 µs ± 246 ns per loop | 10.6 µs ± 66.2 ns per loop
Benchmark n=20 c=1 h=16 w=16 |  
11.2 µs ± 128 ns per loop | 11.4 µs ± 97.5 ns per loop
11.2 µs ± 210 ns per loop | 11.5 µs ± 149 ns per loop
Benchmark n=20 c=1 h=64 w=64 |  
25.6 µs ± 380 ns per loop | 23.8 µs ± 495 ns per loop
26.2 µs ± 1.19 µs per loop | 24.5 µs ± 521 ns per loop
Benchmark n=20 c=1 h=256 w=256 |  
623 µs ± 43.8 µs per loop | 570 µs ± 17.6 µs per loop
673 µs ± 49.2 µs per loop | 584 µs ± 19.7 µs per loop
Benchmark n=20 c=3 h=1 w=1 |  
10.4 µs ± 268 ns per loop | 10.6 µs ± 173 ns per loop
11 µs ± 331 ns per loop | 10.5 µs ± 172 ns per loop
Benchmark n=20 c=3 h=4 w=4 |  
10.8 µs ± 179 ns per loop | 11.2 µs ± 568 ns per loop
11.3 µs ± 232 ns per loop | 11.6 µs ± 91.1 ns per loop
Benchmark n=20 c=3 h=16 w=16 |  
14.4 µs ± 257 ns per loop | 13.9 µs ± 386 ns per loop
29.6 µs ± 2.09 µs per loop | 27.5 µs ± 461 ns per loop
Benchmark n=20 c=3 h=64 w=64 |  
52.4 µs ± 1.16 µs per loop | 47.5 µs ± 655 ns per loop
277 µs ± 17.3 µs per loop | 265 µs ± 5.11 µs per loop
Benchmark n=20 c=3 h=256 w=256 |  
1.55 ms ± 62.4 µs per loop | 1.38 ms ± 32.1 µs per loop
4.31 ms ± 102 µs per loop | 4.02 ms ± 44.1 µs per loop
Benchmark n=20 c=10 h=1 w=1 |  
11.5 µs ± 162 ns per loop | 10.5 µs ± 51.9 ns per loop
11.6 µs ± 662 ns per loop | 10.5 µs ± 251 ns per loop
Benchmark n=20 c=10 h=4 w=4 |  
13 µs ± 411 ns per loop | 12 µs ± 119 ns per loop
14.1 µs ± 690 ns per loop | 11.9 µs ± 77.4 ns per loop
Benchmark n=20 c=10 h=16 w=16 |  
20.2 µs ± 430 ns per loop | 19.9 µs ± 354 ns per loop
45.5 µs ± 1.31 µs per loop | 31.2 µs ± 539 ns per loop
Benchmark n=20 c=10 h=64 w=64 |  
357 µs ± 4.74 µs per loop | 334 µs ± 8.18 µs per loop
769 µs ± 32.3 µs per loop | 538 µs ± 23.6 µs per loop
Benchmark n=20 c=10 h=256 w=256 |  
10.1 ms ± 119 µs per loop | 9.98 ms ± 70.8 µs per loop
12.4 ms ± 154 µs per loop | 10.2 ms ± 227 µs per loop
Benchmark n=20 c=100 h=1 w=1 |  
10.5 µs ± 161 ns per loop | 11 µs ± 316 ns per loop
10.5 µs ± 85.7 ns per loop | 11 µs ± 213 ns per loop
Benchmark n=20 c=100 h=4 w=4 |  
22.9 µs ± 286 ns per loop | 26.4 µs ± 440 ns per loop
18.3 µs ± 228 ns per loop | 18 µs ± 1.05 µs per loop
Benchmark n=20 c=100 h=16 w=16 |  
164 µs ± 58.1 µs per loop | 225 µs ± 9.04 µs per loop
233 µs ± 14 µs per loop | 236 µs ± 7.29 µs per loop
Benchmark n=20 c=100 h=64 w=64 |  
6.57 ms ± 141 µs per loop | 6.49 ms ± 198 µs per loop
6.49 ms ± 53.3 µs per loop | 6.53 ms ± 86.8 µs per loop
Benchmark n=20 c=100 h=256 w=256 |  
106 ms ± 1.01 ms per loop | 110 ms ± 4.23 ms per loop
106 ms ± 932 µs per loop | 109 ms ± 2.95 ms per loop
Benchmark n=20 c=1000 h=1 w=1 |  
16 µs ± 361 ns per loop | 15.6 µs ± 356 ns per loop
16.4 µs ± 264 ns per loop | 15.6 µs ± 121 ns per loop
Benchmark n=20 c=1000 h=4 w=4 |  
126 µs ± 2.72 µs per loop | 149 µs ± 1.35 µs per loop
69.4 µs ± 3.5 µs per loop | 61.4 µs ± 1.04 µs per loop
Benchmark n=20 c=1000 h=16 w=16 |  
3.75 ms ± 99.4 µs per loop | 3.74 ms ± 137 µs per loop
3.82 ms ± 76.7 µs per loop | 3.64 ms ± 122 µs per loop
Benchmark n=20 c=1000 h=64 w=64 |  
75.8 ms ± 1.53 ms per loop | 76.8 ms ± 1.21 ms per loop
75 ms ± 1.11 ms per loop | 78.7 ms ± 744 µs per loop
Benchmark n=20 c=1000 h=256 w=256 |  
2.38 s ± 29.1 ms per loop | 2.45 s ± 22.6 ms per loop
2.85 s ± 371 ms per loop | 2.7 s ± 373 ms per loop

Verified that this code generated vectorization code:
0x00007fffddb2a904 <+6692>: vpmullw (%r12,%r9,1),%ymm2,%ymm0
0x00007fffddb2a90a <+6698>:	vpaddw %ymm1,%ymm0,%ymm0
0x00007fffddb2a90e <+6702>:	vmovdqu %ymm0,(%rbx,%r9,1)