### PR TITLE
Add TORCH_DCHECK macro that checks only in debug builds

### DIFF
--- a/.jenkins/caffe2/test.sh
+++ b/.jenkins/caffe2/test.sh
@@ -40,6 +40,9 @@ for test in $(find "$cpp_test_dir" -executable -type f); do
         LD_LIBRARY_PATH="$ld_library_path" "$test"
       fi
       ;;
+    */*_benchmark)
+      LD_LIBRARY_PATH="$ld_library_path" "$test" --benchmark_color=false
+      ;;
     *)
       # Currently, we use a mixture of gtest (caffe2) and Catch2 (ATen). While
       # planning to migrate to gtest as the common PyTorch c++ test suite, we

--- a/c10/CMakeLists.txt
+++ b/c10/CMakeLists.txt
@@ -79,6 +79,7 @@ target_include_directories(
     $<INSTALL_INTERFACE:include>)
 
 add_subdirectory(test)
+add_subdirectory(benchmark)
 
 if(USE_CUDA)
   add_subdirectory(cuda)

--- a/c10/benchmark/CMakeLists.txt
+++ b/c10/benchmark/CMakeLists.txt
@@ -1,0 +1,14 @@
+# ---[ Benchmark binaries.
+
+file(GLOB_RECURSE C10_ALL_BENCH_FILES *.cpp)
+if (BUILD_TEST)
+  foreach(bench_src ${C10_ALL_BENCH_FILES})
+    get_filename_component(bench_file_name ${bench_src} NAME_WE)
+    set(bench_name "c10_${bench_file_name}")
+    add_executable(${bench_name} "${bench_src}")
+    target_link_libraries(${bench_name} c10 benchmark)
+    if (INSTALL_TEST)
+      install(TARGETS ${bench_name} DESTINATION test)
+    endif()
+  endforeach()
+endif()

--- a/c10/benchmark/intrusive_ptr_benchmark.cpp
+++ b/c10/benchmark/intrusive_ptr_benchmark.cpp
@@ -1,0 +1,75 @@
+#include <c10/util/intrusive_ptr.h>
+
+#include <benchmark/benchmark.h>
+#include <memory>
+
+using c10::intrusive_ptr;
+using c10::intrusive_ptr_target;
+using c10::make_intrusive;
+using c10::weak_intrusive_ptr;
+
+namespace {
+
+// Foo uses intrusive ptr
+class Foo : public intrusive_ptr_target {
+ public:
+  Foo(int param_) : param(param_) {}
+  int param;
+};
+
+
+class Bar : public std::enable_shared_from_this<Bar> {
+ public:
+  Bar(int param_) : param(param_) {}
+  int param;
+};
+
+static void BM_IntrusivePtrCtorDtor(benchmark::State& state) {
+  intrusive_ptr<Foo> var = make_intrusive<Foo>(0);
+  while (state.KeepRunning()) {
+    volatile intrusive_ptr<Foo> var2 = var;
+  }
+}
+BENCHMARK(BM_IntrusivePtrCtorDtor);
+
+static void BM_SharedPtrCtorDtor(benchmark::State& state) {
+  std::shared_ptr<Bar> var = std::make_shared<Bar>(0);
+  while (state.KeepRunning()) {
+    volatile std::shared_ptr<Bar> var2 = var;
+  }
+}
+BENCHMARK(BM_SharedPtrCtorDtor);
+
+static void BM_IntrusivePtrArray(benchmark::State& state) {
+  intrusive_ptr<Foo> var = make_intrusive<Foo>(0);
+  const size_t kLength = state.range(0);
+  std::vector<intrusive_ptr<Foo> > vararray(kLength);
+  while (state.KeepRunning()) {
+    for (int i = 0; i < kLength; ++i) {
+      vararray[i] = var;
+    }
+    for (int i = 0; i < kLength; ++i) {
+      vararray[i].reset();
+    }
+  }
+}
+BENCHMARK(BM_IntrusivePtrArray)->RangeMultiplier(2)->Range(16, 4096);
+
+static void BM_SharedPtrArray(benchmark::State& state) {
+  std::shared_ptr<Bar> var = std::make_shared<Bar>(0);
+  const size_t kLength = state.range(0);
+  std::vector<std::shared_ptr<Bar> > vararray(kLength);
+  while (state.KeepRunning()) {
+    for (int i = 0; i < kLength; ++i) {
+      vararray[i] = var;
+    }
+    for (int i = 0; i < kLength; ++i) {
+      vararray[i].reset();
+    }
+  }
+}
+BENCHMARK(BM_SharedPtrArray)->RangeMultiplier(2)->Range(16, 4096);
+} // namespace
+
+
+BENCHMARK_MAIN();

--- a/c10/test/util/exception_test.cpp
+++ b/c10/test/util/exception_test.cpp
@@ -1,0 +1,20 @@
+#include <c10/util/Exception.h>
+#include <gtest/gtest.h>
+#include <stdexcept>
+
+namespace {
+bool throw_func() {
+  throw std::runtime_error("I'm throwing...");
+}
+} // namespace
+
+TEST(ExceptionTest, TORCH_DCHECK) {
+#ifndef NDEBUG
+  ASSERT_THROW(TORCH_DCHECK(false), c10::Error);
+  ASSERT_NO_THROW(TORCH_DCHECK(true));
+#else
+  ASSERT_NO_THROW(TORCH_DCHECK(false));
+  // Does nothing - `throw_func()` should not be evaluated
+  ASSERT_NO_THROW(TORCH_DCHECK(throw_func()));
+#endif
+}

--- a/c10/util/Exception.h
+++ b/c10/util/Exception.h
@@ -259,6 +259,17 @@ inline std::string if_empty_then(std::string x, std::string y) {
     );                                                      \
   }
 #endif
+
+// Debug only version of TORCH_CHECK
+#ifndef NDEBUG
+#define TORCH_DCHECK(...) TORCH_CHECK(__VA_ARGS__)
+#else
+// Optimized version - generates no code.
+#define TORCH_DCHECK(...) \
+  while (false)           \
+  TORCH_CHECK(__VA_ARGS__)
+#endif
+
 // TODO: We're going to get a lot of similar looking string literals
 // this way; check if this actually affects binary size.
 

--- a/c10/util/intrusive_ptr.h
+++ b/c10/util/intrusive_ptr.h
@@ -93,10 +93,10 @@ class C10_API intrusive_ptr_target {
 #  pragma GCC diagnostic ignored "-Wterminate"
 #  pragma GCC diagnostic ignored "-Wexceptions"
 #endif
-    AT_ASSERTM(
+    TORCH_DCHECK(
         refcount_.load() == 0,
         "Tried to destruct an intrusive_ptr_target that still has intrusive_ptr to it");
-    AT_ASSERTM(
+    TORCH_DCHECK(
         weakcount_.load() == 0,
         "Tried to destruct an intrusive_ptr_target that still has weak_intrusive_ptr to it");
 #if defined(_MSC_VER) && !defined(__clang__)
@@ -185,7 +185,7 @@ class intrusive_ptr final {
   void retain_() {
     if (target_ != NullType::singleton()) {
       size_t new_refcount = ++target_->refcount_;
-      AT_ASSERTM(
+      TORCH_DCHECK(
           new_refcount != 1,
           "intrusive_ptr: Cannot increase refcount after it reached zero.");
     }
@@ -369,7 +369,7 @@ class intrusive_ptr final {
    */
   static intrusive_ptr unsafe_reclaim_from_nonowning(TTarget* raw_ptr) {
     // See Note [Stack allocated intrusive_ptr_target safety]
-    AT_ASSERTM(
+    TORCH_DCHECK(
         raw_ptr == NullType::singleton() || raw_ptr->refcount_.load() > 0,
         "intrusive_ptr: Can only reclaim pointers that are owned by someone");
     auto ptr = reclaim(raw_ptr); // doesn't increase refcount
@@ -442,7 +442,7 @@ class weak_intrusive_ptr final {
   void retain_() {
     if (target_ != NullType::singleton()) {
       size_t new_weakcount = ++target_->weakcount_;
-      AT_ASSERTM(
+      TORCH_DCHECK(
           new_weakcount != 1,
           "weak_intrusive_ptr: Cannot increase weakcount after it reached zero.");
     }
@@ -620,7 +620,7 @@ class weak_intrusive_ptr final {
     // if refcount > 0, weakcount must be >1 for weak references to exist.
     // see weak counting explanation at top of this file.
     // if refcount == 0, weakcount only must be >0.
-    AT_ASSERTM(
+    TORCH_DCHECK(
         owning_weak_ptr == NullType::singleton() ||
         owning_weak_ptr->weakcount_.load() > 1 ||
             (owning_weak_ptr->refcount_.load() == 0 &&


### PR DESCRIPTION
Summary:
Follow up on discoveries/discussions in https://github.com/pytorch/pytorch/pull/30810

Mimic the `DCHECK` macro from https://github.com/pytorch/pytorch/blob/e5eb871/c10/util/logging_is_not_google_glog.h#L117-L125

With this change the perf gap is eliminated:

```
================================================================================
Program Output:
================================================================================
Run on (36 X 1601 MHz CPU s)
2019-12-12 20:12:13
-----------------------------------------------------------------
Benchmark                          Time           CPU Iterations
-----------------------------------------------------------------
BM_IntrusivePtrCtorDtor           23 ns         23 ns   30914703
BM_SharedPtrCtorDtor              27 ns         27 ns   25895944
BM_IntrusivePtrArray/16          503 ns        503 ns    1392139
BM_IntrusivePtrArray/32         1006 ns       1006 ns     695749
BM_IntrusivePtrArray/64         2013 ns       2013 ns     347714
BM_IntrusivePtrArray/128        4024 ns       4024 ns     173964
BM_IntrusivePtrArray/256        8047 ns       8047 ns      86994
BM_IntrusivePtrArray/512       16106 ns      16106 ns      43461
BM_IntrusivePtrArray/1024      32208 ns      32207 ns      21731
BM_IntrusivePtrArray/2048      64431 ns      64430 ns      10865
BM_IntrusivePtrArray/4096     128940 ns     128938 ns       5429
BM_SharedPtrArray/16             503 ns        503 ns    1392128
BM_SharedPtrArray/32            1006 ns       1006 ns     695940
BM_SharedPtrArray/64            2012 ns       2012 ns     347817
BM_SharedPtrArray/128           4024 ns       4023 ns     173927
BM_SharedPtrArray/256           8069 ns       8069 ns      86741
BM_SharedPtrArray/512          16143 ns      16142 ns      43357
BM_SharedPtrArray/1024         32283 ns      32283 ns      21685
BM_SharedPtrArray/2048         64718 ns      64717 ns      10817
BM_SharedPtrArray/4096        129469 ns     129466 ns       5407
================================================================================
```

```
================================================================================
Program Output:
================================================================================
Run on (80 X 2001 MHz CPU s)
2019-12-12 20:12:23
-----------------------------------------------------------------
Benchmark                          Time           CPU Iterations
-----------------------------------------------------------------
BM_IntrusivePtrCtorDtor           18 ns         18 ns   38630411
BM_SharedPtrCtorDtor              22 ns         22 ns   32356114
BM_IntrusivePtrArray/16          402 ns        402 ns    1739637
BM_IntrusivePtrArray/32          805 ns        805 ns     869818
BM_IntrusivePtrArray/64         1610 ns       1609 ns     434881
BM_IntrusivePtrArray/128        3218 ns       3218 ns     217437
BM_IntrusivePtrArray/256        6436 ns       6436 ns     108739
BM_IntrusivePtrArray/512       12882 ns      12882 ns      54356
BM_IntrusivePtrArray/1024      25763 ns      25763 ns      27177
BM_IntrusivePtrArray/2048      51532 ns      51531 ns      13590
BM_IntrusivePtrArray/4096     103091 ns     103091 ns       6778
BM_SharedPtrArray/16             402 ns        402 ns    1740165
BM_SharedPtrArray/32             804 ns        804 ns     869035
BM_SharedPtrArray/64            1610 ns       1610 ns     434975
BM_SharedPtrArray/128           3218 ns       3218 ns     217505
BM_SharedPtrArray/256           6457 ns       6457 ns     108510
BM_SharedPtrArray/512          12909 ns      12909 ns      54249
BM_SharedPtrArray/1024         25810 ns      25810 ns      27127
BM_SharedPtrArray/2048         51763 ns      51763 ns      13531
BM_SharedPtrArray/4096        103506 ns     103505 ns       6759
================================================================================
```

Test Plan:
buck test caffe2/c10/... -- ExceptionTest.TORCH_DCHECK
buck test mode/opt caffe2/c10/... -- ExceptionTest.TORCH_DCHECK

Differential Revision: D18998243

