### PR TITLE
git: Ignore files that are generated by cmake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -250,3 +250,14 @@ GSYMS
 GPATH
 tags
 TAGS
+
+# Files generated my cmake
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+Makefile
+cmake_install.cmake
+install_manifest.txt
+CTestTestfile.cmake
+_deps


### PR DESCRIPTION
Saw some of the files that were generated by `cmake` were being included
whenver I ran a `git status` so I went about ignoring them.

Reference file that I pulled these from can be found here:
https://github.com/github/gitignore/blob/master/CMake.gitignore

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

