### PR TITLE
Create byte-aware word lstm benchmark

### DIFF
--- a/caffe2/python/utils.py
+++ b/caffe2/python/utils.py
@@ -62,6 +62,9 @@ def Caffe2TensorToNumpyArray(tensor):
     elif tensor.data_type == caffe2_pb2.TensorProto.DOUBLE:
         return np.asarray(
             tensor.double_data, dtype=np.float64).reshape(tensor.dims)
+    elif tensor.data_type == caffe2_pb2.TensorProto.INT64:
+        return np.asarray(
+            tensor.int64_data, dtype=np.int64).reshape(tensor.dims)
     elif tensor.data_type == caffe2_pb2.TensorProto.INT32:
         return np.asarray(
             tensor.int32_data, dtype=np.int).reshape(tensor.dims)   # pb.INT32=>np.int use int32_data
@@ -94,6 +97,9 @@ def NumpyArrayToCaffe2Tensor(arr, name=None):
     elif arr.dtype == np.float64:
         tensor.data_type = caffe2_pb2.TensorProto.DOUBLE
         tensor.double_data.extend(list(arr.flatten().astype(np.float64)))
+    elif arr.dtype == np.int64:
+        tensor.data_type = caffe2_pb2.TensorProto.INT64
+        tensor.int64_data.extend(list(arr.flatten().astype(np.int64)))
     elif arr.dtype == np.int or arr.dtype == np.int32:
         tensor.data_type = caffe2_pb2.TensorProto.INT32
         tensor.int32_data.extend(arr.flatten().astype(np.int).tolist())
@@ -110,7 +116,7 @@ def NumpyArrayToCaffe2Tensor(arr, name=None):
         tensor.data_type = caffe2_pb2.TensorProto.UINT8
         tensor.int32_data.extend(list(arr.flatten().astype(np.uint8)))   # np.uint8=>pb.UNIT8 use int32_data
     else:
-        # TODO: complete the data type: bool, float16, byte, int64, string
+        # TODO: complete the data type: bool, float16, byte, string
         raise RuntimeError(
             "Numpy data type not supported yet: " + str(arr.dtype))
     return tensor


### PR DESCRIPTION
Summary:
1. Update the LiteLM dataset conversion script (fbcode/pytext/fb/tools/lite_lm_dataset_to_tensorproto.py)
2. Created a benchmark json file for byte-aware lstm word model (xplat/aibench/specifications/models/caffe2/assistant/lite_lm_len5.json)
3. In order to run the model -- created an int64 Tensor for the model, added batch gather ops to the BUCK file

Test Plan:
```
1. Create tensorproto of the model input
buck run mode/opt //pytext/fb/tools:byte_lm_dataset_to_tensorproto -- --in-path /mnt/vol/pytext/smart_keyboard/aibench/test_5.txt --out-path /mnt/vol/pytext/smart_keyboard/aibench/byteAwareWordLM/ --hidden_dim 203 --layers_num 2 --max_seq_len 64 --max_byte_len 15

2. Run the aibench command
buck run fbsource//xplat/aibench:run_bench -- -b aibench/specifications/models/caffe2/assistant/lm_byte_lstm_len5.json --remote --devices SM-G960U-8.0.0-26
```

Differential Revision: D17785682

