### PR TITLE
[jit] Add support for `del`

### DIFF
--- a/aten/src/ATen/core/interned_strings.h
+++ b/aten/src/ATen/core/interned_strings.h
@@ -71,6 +71,7 @@ namespace c10 {
   _(aten, Int)                       \
   _(aten, Float)                     \
   _(aten, str)                       \
+  _(aten, Delete)                    \
   _(prim, device)                    \
   _(prim, dtype)                     \
   _(prim, shape)                     \

--- a/test/jit/test_list_dict.py
+++ b/test/jit/test_list_dict.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import unittest
+import inspect
 from typing import List, Dict
 from textwrap import dedent
 from collections import OrderedDict
@@ -96,6 +97,44 @@ class TestList(JitTestCase):
             return
         with self.assertRaisesRegex(RuntimeError, "previously has type"):
             self.checkScript(reassign_nested, (), optimize=False)
+
+    def test_del(self):
+        def inputs():
+            return [1, 2, 3, 4]
+
+        def fn(x):
+            # type: (List[int]) -> List[int]
+            del x[1]
+            return x
+
+        python_out = fn(inputs())
+        # checkScript reuses the same object, but here it's being mutated so do
+        # it manually
+        cu = torch.jit.CompilationUnit()
+        cu.define(dedent(inspect.getsource(fn)))
+        self.assertEqual(cu.fn(inputs()), python_out)
+        self.assertEqual(torch.jit.script(fn)(inputs()), python_out)
+
+        @torch.jit.script
+        def fn2(x):
+            # type: (List[int]) -> List[int]
+            del x[100]
+            return x
+
+        with self.assertRaisesRegex(RuntimeError, "out of range"):
+            fn2([])
+
+        with self.assertRaisesRegex(RuntimeError, "only supported for list and dict"):
+            @torch.jit.script
+            def fn(x):
+                del x
+
+        with self.assertRaisesRegex(RuntimeError, "deletion at a single index"):
+            @torch.jit.script
+            def fn(x):
+                # type: (List[int]) -> List[int]
+                del x[1:3]
+                return x
 
     def test_min_bool_list(self):
         def jit_min_list(a, b):
@@ -851,6 +890,25 @@ class TestDict(JitTestCase):
 
     def dict2(self):
         return {'x': torch.ones(1) + 100, 'y': torch.ones(1) + 101, 'z': torch.ones(1) + 102}
+
+    def test_del(self):
+        def inputs():
+            return {'hi': 2, 'bye': 3}
+
+        def fn(x):
+            # type: (Dict[str, int]) -> Dict[str, int]
+            del x['hi']
+            return x
+
+        python_out = fn(inputs())
+        # checkScript reuses the same object, but here it's being mutated so do
+        # it manually
+        cu = torch.jit.CompilationUnit()
+        cu.define(dedent(inspect.getsource(fn)))
+        self.assertEqual(cu.fn(inputs()), python_out)
+        self.assertEqual(torch.jit.script(fn)(inputs()), python_out)
+        with self.assertRaisesRegex(RuntimeError, "KeyError"):
+            self.checkScript(fn, [{}])
 
     def test_keys(self):
         @torch.jit.script

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -1637,7 +1637,7 @@ template <typename T> int maxList(Stack &stack) {
 }
 
 template <typename T>
-int listPop(Stack& stack) {
+int listPopImpl(Stack& stack, const char* empty_message) {
   int64_t idx = pop(stack).to<int64_t>();
   c10::List<T> list = pop(stack).to<c10::List<T>>();
 
@@ -1645,13 +1645,18 @@ int listPop(Stack& stack) {
   const int64_t normalized_idx = normalizeIndex(idx, list_size);
 
   if (list_size == 0) {
-    AT_ERROR("pop index out of range");
+    AT_ERROR(empty_message);
   }
 
   push(stack, getItem(list, idx));
   list.erase(list.begin() + normalized_idx);
 
   return 0;
+}
+
+template <typename T>
+int listPop(Stack& stack) {
+  return listPopImpl<T>(stack, "pop from empty list");
 }
 
 template <typename T>
@@ -1664,7 +1669,7 @@ int listClear(Stack& stack) {
 
 template <typename T>
 int listDelete(Stack& stack) {
-  listPop<T>(stack);
+  listPopImpl<T>(stack, "pop index out of range");
   pop(stack);
   return 0;
 }

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -890,6 +890,31 @@ struct to_ir {
     graph->insertNode(continue_node);
   }
 
+  void emitDelete(const Delete& stmt) {
+    if (stmt.expr().kind() != TK_SUBSCRIPT) {
+      throw ErrorReport(stmt.range())
+          << "del statements are only supported for list"
+             " and dict item deletion";
+    }
+    Subscript subscript(stmt.expr());
+    const List<Expr>& subscript_exprs = subscript.subscript_exprs();
+    if (subscript_exprs[0].kind() != TK_IDENT &&
+        subscript_exprs[0].kind() != TK_CONST &&
+        subscript_exprs[0].kind() != TK_VAR) {
+      throw ErrorReport(stmt.range())
+          << "del statements only support deletion at a single index, "
+             "slicing is not supported"
+             " (see https://github.com/pytorch/pytorch/issues/31430)";
+    }
+    const SugaredValuePtr sv = emitSugaredExpr(subscript.value(), 1);
+    const SourceRange& val_range = subscript.value().range();
+    Value* idx = emitExpr(subscript_exprs[0]);
+    Value* val = sv->asValue(val_range, method);
+    auto node = graph->create(aten::Delete, {val, idx}, 0)
+                    ->setSourceRange(stmt.range());
+    graph->insertNode(node);
+  }
+
   void emitReturn(const Return& stmt) {
     Value* result = emitExpr(stmt.expr());
     TypePtr result_type = def_stack_.back().declared_return_type_;
@@ -981,6 +1006,9 @@ struct to_ir {
           break;
         case TK_DEF:
           emitClosure(Def(stmt));
+          break;
+        case TK_DELETE:
+          emitDelete(Delete(stmt));
           break;
         default:
           throw ErrorReport(stmt)

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -898,9 +898,7 @@ struct to_ir {
     }
     Subscript subscript(stmt.expr());
     const List<Expr>& subscript_exprs = subscript.subscript_exprs();
-    if (subscript_exprs[0].kind() != TK_IDENT &&
-        subscript_exprs[0].kind() != TK_CONST &&
-        subscript_exprs[0].kind() != TK_VAR) {
+    if (subscript_exprs[0].kind() == TK_SLICE_EXPR) {
       throw ErrorReport(stmt.range())
           << "del statements only support deletion at a single index, "
              "slicing is not supported"

--- a/torch/csrc/jit/script/lexer.h
+++ b/torch/csrc/jit/script/lexer.h
@@ -102,6 +102,7 @@ namespace script {
   _(TK_LIST_COMP, "list comprehension", "")      \
   _(TK_BREAK, "break", "break")                  \
   _(TK_CONTINUE, "continue", "continue")         \
+  _(TK_DELETE, "del", "del")                     \
   _(TK_PASS, "pass", "pass")                     \
   _(TK_CLASS_DEF, "class", "class")              \
   _(TK_IMPORT, "import", "import")

--- a/torch/csrc/jit/script/parser.cpp
+++ b/torch/csrc/jit/script/parser.cpp
@@ -545,6 +545,12 @@ struct ParserImpl {
       case TK_DEF: {
         return parseFunction(/*is_method=*/in_class);
       }
+      case TK_DELETE: {
+        L.expect(TK_DELETE);
+        auto expr = parseExp();
+        L.expect(TK_NEWLINE);
+        return Delete::create(expr);
+      }
       default: {
         auto lhs = parseExpOrExpTuple();
         if (L.cur().kind != TK_NEWLINE) {

--- a/torch/csrc/jit/script/python_tree_views.cpp
+++ b/torch/csrc/jit/script/python_tree_views.cpp
@@ -170,6 +170,11 @@ void initTreeViewBindings(PyObject* module) {
             r, wrap_list(r, std::move(params)), wrap_maybe(r, return_type));
       }));
 
+  py::class_<Delete, Stmt>(m, "Delete")
+      .def(py::init([](Expr expr) {
+        return Delete::create(expr);
+      }));
+
   py::class_<Assign, Stmt>(m, "Assign")
       .def(py::init([](std::vector<Expr> lhs, const Expr& rhs) {
         auto li = wrap_list(rhs.range(), std::move(lhs));

--- a/torch/csrc/jit/script/tree_views.h
+++ b/torch/csrc/jit/script/tree_views.h
@@ -249,6 +249,7 @@ struct Stmt : public TreeView {
       case TK_ASSERT:
       case TK_PASS:
       case TK_BREAK:
+      case TK_DELETE:
       case TK_CONTINUE:
       case TK_DEF:
         return;
@@ -1020,6 +1021,18 @@ struct Starred : public Expr {
   }
   static Starred create(const SourceRange& range, const Expr& expr) {
     return Starred(Compound::create(TK_STARRED, range, {expr}));
+  }
+};
+
+struct Delete : public Stmt {
+  explicit Delete(const TreeRef& tree) : Stmt(tree) {
+    tree_->match(TK_DELETE);
+  }
+  Expr expr() const {
+    return Expr(subtree(0));
+  }
+  static Delete create(const Expr& value) {
+    return Delete(Compound::create(TK_DELETE, value.range(), {value}));
   }
 };
 

--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -298,6 +298,10 @@ class StmtBuilder(Builder):
         return Assign([lhs], rhs, the_type)
 
     @staticmethod
+    def build_Delete(ctx, stmt):
+        return Delete(build_expr(ctx, stmt.targets[0]))
+
+    @staticmethod
     def build_Return(ctx, stmt):
         r = ctx.make_range(stmt.lineno, stmt.col_offset, stmt.col_offset + len("return"))
         return Return(r, None if stmt.value is None else build_expr(ctx, stmt.value))


### PR DESCRIPTION
Adds the `del` keyword to the parser and corresponding `aten::Delete` op for lists and dicts

Fixes #20615

Differential Revision: [D19181473](https://our.internmc.facebook.com/intern/diff/19181473/)