### PR TITLE
Wraps assert statements in cuda kernels

### DIFF
--- a/aten/src/ATen/native/cuda/Distributions.cu
+++ b/aten/src/ATen/native/cuda/Distributions.cu
@@ -287,22 +287,22 @@ void bernoulli_tensor_cuda_kernel(
         float4 rand = curand_uniform4(&state);
         switch (n) {
           case 4: {
-            assert(0 <= p4 && p4 <= 1);
+            CUDA_KERNEL_ASSERT(0 <= p4 && p4 <= 1);
             v4 = static_cast<scalar_t>(rand.w <= p4);
             // fallthrough
           }
           case 3: {
-            assert(0 <= p3 && p3 <= 1);
+            CUDA_KERNEL_ASSERT(0 <= p3 && p3 <= 1);
             v3 = static_cast<scalar_t>(rand.z <= p3);
             // fallthrough
           }
           case 2: {
-            assert(0 <= p2 && p2 <= 1);
+            CUDA_KERNEL_ASSERT(0 <= p2 && p2 <= 1);
             v2 = static_cast<scalar_t>(rand.y <= p2);
             // fallthrough
           }
           case 1: {
-            assert(0 <= p1 && p1 <= 1);
+            CUDA_KERNEL_ASSERT(0 <= p1 && p1 <= 1);
             v1 = static_cast<scalar_t>(rand.x <= p1);
           }
         }

--- a/aten/src/ATen/native/cuda/IndexKernel.cu
+++ b/aten/src/ATen/native/cuda/IndexKernel.cu
@@ -57,7 +57,7 @@ void gpu_index_kernel(TensorIterator& iter, IntArrayRef index_size, IntArrayRef 
     #pragma unroll
     for (int i = 0; i < num_indices; i++) {
       int64_t index = *(int64_t*)(index_ptrs[i] + offsets[2]);
-      assert(index >= -sizes[i] && index < sizes[i] && "index out of bounds");
+      CUDA_KERNEL_ASSERT(index >= -sizes[i] && index < sizes[i] && "index out of bounds");
       if (index < 0) {
         index += sizes[i];
       }

--- a/aten/src/THC/THCTensorScatterGather.cu
+++ b/aten/src/THC/THCTensorScatterGather.cu
@@ -2,6 +2,7 @@
 #include <THC/THCGeneral.h>
 #include <THC/THCAtomics.cuh>
 #include <THC/THCApply.cuh>
+#include <c10/macros/Macros.h>
 
 // Compute the offsets into the given tensors for a linear index. For the 't2'
 // tensor, dimension 'dim' is skipped. The tensors are assumed to have the same
@@ -97,7 +98,7 @@ __global__ void THCudaTensor_gatherKernel(
                                                           src, &srcOffset);
 
     int64_t indexValue = index.data[indexOffset];
-    assert(indexValue >= 0 && indexValue < src.sizes[dim]);
+    CUDA_KERNEL_ASSERT(indexValue >= 0 && indexValue < src.sizes[dim]);
     srcOffset += indexValue * src.strides[dim];
 
     tensor.data[tensorOffset] = src.data[srcOffset];
@@ -127,7 +128,7 @@ __global__ void THCudaTensor_scatterKernel(
                                                           tensor, &tensorOffset);
 
     int64_t indexValue = index.data[indexOffset];
-    assert(indexValue >= 0 && indexValue < tensor.sizes[dim]);
+    CUDA_KERNEL_ASSERT(indexValue >= 0 && indexValue < tensor.sizes[dim]);
     tensorOffset += indexValue * tensor.strides[dim];
 
     tensor.data[tensorOffset] = src.data[srcOffset];
@@ -157,7 +158,7 @@ __global__ void THCudaTensor_scatterAddKernel(
                                                           tensor, &tensorOffset);
 
     int64_t indexValue = index.data[indexOffset];
-    assert(indexValue >= 0 && indexValue < tensor.sizes[dim]);
+    CUDA_KERNEL_ASSERT(indexValue >= 0 && indexValue < tensor.sizes[dim]);
     tensorOffset += indexValue * tensor.strides[dim];
 
     atomicAdd(&tensor.data[tensorOffset], src.data[srcOffset]);
@@ -185,7 +186,7 @@ __global__ void THCudaTensor_scatterFillKernel(
                                                           tensor, &tensorOffset);
 
     int64_t indexValue = index.data[indexOffset];
-    assert(indexValue >= 0 && indexValue < tensor.sizes[dim]);
+    CUDA_KERNEL_ASSERT(indexValue >= 0 && indexValue < tensor.sizes[dim]);
     tensorOffset += indexValue * tensor.strides[dim];
 
     tensor.data[tensorOffset] = value;

--- a/aten/src/THC/THCTensorTopK.cuh
+++ b/aten/src/THC/THCTensorTopK.cuh
@@ -2,7 +2,7 @@
 #define THC_TENSOR_TOPK_CUH
 
 #include <c10/macros/Macros.h>
-#include <aten/src/ATen/native/cuda/SortingRadixSelect.cuh>
+#include <ATen/native/cuda/SortingRadixSelect.cuh>
 
 using namespace at::native;
 
@@ -87,7 +87,7 @@ __global__ void gatherTopK(TensorInfo<T, IndexType> input,
 
     if (hasTopK) {
       int writeIndex = writeIndexStart + index;
-      assert(writeIndex < outputSliceSize);
+      CUDA_KERNEL_ASSERT(writeIndex < outputSliceSize);
 
       IndexType topKOffset = writeIndex * topKWithinSliceStride;
       IndexType indexOffset = writeIndex * indicesWithinSliceStride;
@@ -104,7 +104,7 @@ __global__ void gatherTopK(TensorInfo<T, IndexType> input,
   // writeIndexStart. There might be more than that number available,
   // in which case we have to choose the first seen set. We do this
   // via a prefix sum to calculate indices for writing results.
-  assert(outputSliceSize >= writeIndexStart);
+  CUDA_KERNEL_ASSERT(outputSliceSize >= writeIndexStart);
   IndexType topKRemaining = (outputSliceSize - writeIndexStart);
 
   for (IndexType i = threadIdx.x; i < numIterations; i += blockDim.x) {
@@ -119,7 +119,7 @@ __global__ void gatherTopK(TensorInfo<T, IndexType> input,
 
     if (hasTopK && index < topKRemaining) {
       int writeIndex = writeIndexStart + index;
-      assert(writeIndex < outputSliceSize);
+      CUDA_KERNEL_ASSERT(writeIndex < outputSliceSize);
 
       IndexType topKOffset = writeIndex * topKWithinSliceStride;
       IndexType indexOffset = writeIndex * indicesWithinSliceStride;

--- a/aten/src/THCUNN/BCECriterion.cu
+++ b/aten/src/THCUNN/BCECriterion.cu
@@ -11,6 +11,7 @@
 #include <thrust/transform.h>
 #include <thrust/transform_reduce.h>
 #include <thrust/system/cuda/execution_policy.h>
+#include <c10/macros/Macros.h>
 
 template <typename T>
 inline __host__ __device__ T eps();
@@ -39,7 +40,7 @@ struct bce_functor
   {
     Dtype input = thrust::get<0>(x);
     Dtype t = thrust::get<1>(x);
-    assert(input >= 0. && input <= 1.);
+    CUDA_KERNEL_ASSERT(input >= 0. && input <= 1.);
     return - (t * safe_log<Acctype>(ScalarConvert<Dtype, Acctype>::to(input))
         + (Acctype(1) - t) * safe_log<Acctype>(Acctype(1) - input));
   }
@@ -54,7 +55,7 @@ struct bce_updateOutput_no_reduce_functor
       const Dtype *target,
       Dtype *output)
   {
-    assert(*input >= 0. && *input <= 1.);
+    CUDA_KERNEL_ASSERT(*input >= 0. && *input <= 1.);
     *output = ScalarConvert<Acctype, Dtype>::to(
         -(*target * safe_log<Acctype>(ScalarConvert<Dtype, Acctype>::to(*input)) +
           (Acctype(1) - *target) * safe_log<Acctype>(Acctype(1) - *input)));
@@ -71,7 +72,7 @@ struct bce_functor_weights
     Dtype input = thrust::get<0>(x);
     Dtype t = thrust::get<1>(x);
     Dtype w = thrust::get<2>(x);
-    assert(input >= 0. && input <= 1.);
+    CUDA_KERNEL_ASSERT(input >= 0. && input <= 1.);
     return - w * (t * safe_log<Acctype>(ScalarConvert<Dtype, Acctype>::to(input)) +
         (Acctype(1) - t) * safe_log<Acctype>(Acctype(1) - input));
   }

--- a/aten/src/THCUNN/SpatialClassNLLCriterion.cu
+++ b/aten/src/THCUNN/SpatialClassNLLCriterion.cu
@@ -101,7 +101,7 @@ __global__ void cunn_SpatialClassNLLCriterion_updateOutput_kernel(
        i += step) {
     t = target[toffset + i];
     if (t != ignore_index) {
-      assert(t >= 0 && t < n_classes);
+      CUDA_KERNEL_ASSERT(t >= 0 && t < n_classes);
       cur_weight = weights ? weights[t] : ScalarConvert<int, T>::to(1);
       input_sum -= input[ioffset + i + map_nelem * t] * cur_weight;
       acc_weight += cur_weight;
@@ -156,7 +156,7 @@ __global__ void cunn_SpatialClassNLLCriterion_updateGradInput_kernel(
        i += step) {
     t = (int)target[toffset + i];
     if (t != ignore_index) {
-      assert(t >= 0 && t < n_classes);
+      CUDA_KERNEL_ASSERT(t >= 0 && t < n_classes);
       gradInput[ioffset + i + map_nelem * t] = -(weights ? weights[t] : ScalarConvert<int, T>::to(1)) * norm * gradOutput[0];
     }
   }

--- a/c10/macros/Macros.h
+++ b/c10/macros/Macros.h
@@ -199,6 +199,15 @@ constexpr uint32_t CUDA_THREADS_PER_BLOCK_FALLBACK = 256;
 #define C10_WARP_SIZE 32
 #endif
 
+// CUDA_KERNEL_ASSERT is a macro that wraps an assert() call inside cuda
+// kernels. This is not supported by Apple platforms so we special case it.
+// See http://docs.nvidia.com/cuda/cuda-c-programming-guide/#assertion
+#if defined(__APPLE__) || defined(__HIP_PLATFORM_HCC__)
+#define CUDA_KERNEL_ASSERT(...)
+#else // __APPLE__
+#define CUDA_KERNEL_ASSERT(...) assert(__VA_ARGS__)
+#endif // __APPLE__
+
 #ifdef __APPLE__
 #include <TargetConditionals.h>
 #endif

--- a/c10/util/TypeCast.h
+++ b/c10/util/TypeCast.h
@@ -2,6 +2,7 @@
 #include <c10/core/ScalarType.h>
 #include <c10/util/Half.h>
 #include <c10/util/BFloat16.h>
+#include <c10/macros/Macros.h>
 
 
 namespace c10 {
@@ -120,7 +121,7 @@ struct static_cast_with_inter_type {
 //
 
 #ifdef C10_HOST_DEVICE
-#define ERROR_UNSUPPORTED_CAST assert(false);
+#define ERROR_UNSUPPORTED_CAST CUDA_KERNEL_ASSERT(false);
 #else
 #define ERROR_UNSUPPORTED_CAST TORCH_CHECK(false, "Unexpected scalar type");
 #endif
@@ -151,12 +152,12 @@ C10_HOST_DEVICE inline void cast_and_store(const ScalarType dest_type, void *ptr
 #define DEFINE_UNCASTABLE(T, scalartype_)                                         \
 template<>                                                                        \
 C10_HOST_DEVICE inline T fetch_and_cast<T>(const ScalarType src_type, const void *ptr) {          \
-  assert(ScalarType::scalartype_ == src_type);                                    \
+  CUDA_KERNEL_ASSERT(ScalarType::scalartype_ == src_type);                                    \
   return *(const T *)ptr;                                                         \
 }                                                                                 \
 template<>                                                                        \
 C10_HOST_DEVICE inline void cast_and_store<T>(const ScalarType dest_type, void *ptr, T value) {   \
-  assert(ScalarType::scalartype_ == dest_type);                                   \
+  CUDA_KERNEL_ASSERT(ScalarType::scalartype_ == dest_type);                                   \
   *(T *)ptr = value;                                                              \
 }
 


### PR DESCRIPTION
Summary:
Change assert --> CUDA_ASSERT_KERNEL to avoid hip undefined __assert_fail()

This is similar to https://github.com/pytorch/pytorch/pull/13902 in caffe2 land.

Test Plan: wait for CI to clear

Differential Revision: D19047582

