### PR TITLE
Add a check method for custom type tensor

### DIFF
--- a/aten/src/ATen/cpp_custom_type_hack.h
+++ b/aten/src/ATen/cpp_custom_type_hack.h
@@ -13,7 +13,7 @@ namespace at {
 namespace cpp_custom_type_hack {
 
 template <typename T>
-bool isa(const Tesnor& packed) {
+bool isa(const Tensor& packed) {
   return (packed.scalar_type() == kByte) &&
       (packed.storage().data_ptr().get_deleter() ==
        caffe2::TypeMeta::Make<T>().deleteFn());

--- a/aten/src/ATen/cpp_custom_type_hack.h
+++ b/aten/src/ATen/cpp_custom_type_hack.h
@@ -13,6 +13,13 @@ namespace at {
 namespace cpp_custom_type_hack {
 
 template <typename T>
+bool isa(const Tesnor& packed) {
+  return (packed.scalar_type() == kByte) &&
+      (packed.storage().data_ptr().get_deleter() ==
+       caffe2::TypeMeta::Make<T>().deleteFn());
+}
+
+template <typename T>
 T& cast(const Tensor& packed) {
   TORCH_CHECK(
       packed.scalar_type() == kByte, "Expected temporary cpp type wrapper");


### PR DESCRIPTION
For backend integration, backend (e.g. Glow) needs to check the content of the tensor to determine whether it is a legit byte tensor or some special packed format. This provides a convenient interface for that. 