### PR TITLE
[WIP][quant][graphmode] Supporting different types of qscheme for modules that shares class types

### DIFF
--- a/torch/csrc/jit/passes/quantization.cpp
+++ b/torch/csrc/jit/passes/quantization.cpp
@@ -633,7 +633,10 @@ class InsertQuantDeQuantHelper {
   // TODO: we don't need to call this for each graph
   std::unordered_map<Graph*, std::vector<std::string>> observer_modules_to_remove_;
   std::unordered_map<Graph*, std::vector<Node*>> nodes_to_destroy_;
-  std::unordered_map<Graph*, std::unordered_map<Value*, QParamMap>> values_to_qparams_;
+  std::unordered_map<
+      Graph*,
+      std::unordered_map<QScheme, std::unordered_map<Value*, QParamMap>>>
+      values_to_qparams_;
 };
 
 void InsertQuantDeQuantHelper::collectObserverNodesAndValueToQuantize(
@@ -659,8 +662,9 @@ void InsertQuantDeQuantHelper::collectObserverNodesAndValueToQuantize(
   Value* new_value = observer->input(1);
   v->replaceAllUsesWith(new_value);
   auto tp = getQSchemeAndQParamMap(module, v);
+  auto qscheme = std::get<0>(tp);
   auto qparam_map = std::get<1>(tp);
-  values_to_qparams_[g].insert({new_value, qparam_map});
+  values_to_qparams_[g][qscheme].insert({new_value, qparam_map});
 }
 
 void InsertQuantDeQuantHelper::removeObservers(script::Module& module, Graph* g) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#31294 [WIP][quant][graphmode] Supporting different types of qscheme for modules that shares class types**
* #30553 [quant][graphmode] `insert_quant_dequant` pass support shared class types
* #31293 [quant][graphmode][refactor] Exposing qscheme from observer module
* #31292 [refactor] Remove redundant queries of qconfig in `insertObservers`

Summary:
Currently we don't support quantizating two modules shares same class type
but quantized by different types of quantization scheme(per channel vs. per tensor)
Although this case might be rare, we still want to add support for completeness

Test Plan:
tbd

Reviewers:
mvz

Subscribers:

Tasks:

Tags: