### PR TITLE
Fix copy kernel regression for v1.4.0

### DIFF
--- a/aten/src/ATen/native/cpu/CopyKernel.cpp
+++ b/aten/src/ATen/native/cpu/CopyKernel.cpp
@@ -42,7 +42,22 @@ static void copy_kernel(TensorIterator& iter, bool non_blocking) {
     AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(ScalarType::Half, ScalarType::Bool, ScalarType::BFloat16, dtype, "copy_", [&] {
       using dest_t = scalar_t;
       AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(ScalarType::Half, ScalarType::Bool, ScalarType::BFloat16, iter.dtype(1), "copy_", [&] {
-        cpu_kernel(iter, c10::static_cast_with_inter_type<dest_t, scalar_t>);
+        // Note (@zasdfgbnm):
+        //
+        // The code below can not be simplified as
+        //    cpu_kernel(iter, c10::static_cast_with_inter_type<dest_t, scalar_t>::apply);
+        //
+        // because this would force the compiler to instantiate the inline function and generate a function call in the loop
+        // instead of inlining it, making all the optimizations like vectorization impossible.
+        // You can verify this by looking the the symbols of `libtorch_cpu.so`:
+        //
+        //    readelf -Ws libtorch_cpu.so | grep static_cast_with_inter_type
+        //
+        // If done correctly, the above command should have no output.
+        //
+        // See: https://github.com/pytorch/pytorch/issues/31271
+        cpu_kernel(iter, [](scalar_t src) -> dest_t {
+          return c10::static_cast_with_inter_type<dest_t, scalar_t>(src); });
       });
     });
   }


### PR DESCRIPTION
Are we still accepting PRs for 1.4.0? I see the issue unpinned.