### PR TITLE
add copy_ operator the op bench

### DIFF
--- a/benchmarks/operator_benchmark/benchmark_all_other_test.py
+++ b/benchmarks/operator_benchmark/benchmark_all_other_test.py
@@ -8,7 +8,7 @@ from pt import ( # noqa
     add_test, batchnorm_test, cat_test, chunk_test, conv_test,  # noqa
     gather_test, linear_test, matmul_test, pool_test,  # noqa
     softmax_test, split_test, fill_test, as_strided_test,  # noqa
-    embeddingbag_test  # noqa
+    embeddingbag_test, binary_test  # noqa
 )
 
 if __name__ == "__main__":

--- a/benchmarks/operator_benchmark/pt/binary_test.py
+++ b/benchmarks/operator_benchmark/pt/binary_test.py
@@ -47,6 +47,7 @@ binary_ops_list = op_bench.op_list(
     attr_names=['op_name', 'op_func'],
     attrs=[
         ['add', torch.add],
+        ['copy_', lambda in1, in2: in1.copy_(in2)],
     ],
 )
 

--- a/benchmarks/operator_benchmark/pt/binary_test.py
+++ b/benchmarks/operator_benchmark/pt/binary_test.py
@@ -1,0 +1,95 @@
+import operator_benchmark as op_bench
+import torch
+
+
+"""Microbenchmarks for binary operators."""
+
+
+# Benchmark ops performance with broadcast
+binary_ops_bcast_list = op_bench.op_list(
+    attr_names=['op_name', 'op_func'],
+    attrs=[
+        ['add', torch.add],
+    ],
+)
+
+# Configs with broadcast
+binary_configs_broadcast = op_bench.config_list(
+    attr_names=['in_one', 'in_two'],
+    attrs=[
+        [[64, 1, 64], [1, 64, 1]],
+    ],
+    cross_product_configs={
+        'device': ['cpu'],
+        'dtype': [torch.float],
+    },
+    tags=["short"]
+)
+
+
+class BinaryOpBcastBenchmark(op_bench.TorchBenchmarkBase):
+    def init(self, in_one, in_two, dtype, device, op_func):
+        self.in_one = torch.randn(in_one, device=device).to(dtype=dtype)
+        self.in_two = torch.randn(in_two, device=device).to(dtype=dtype)
+        self.op_func = op_func
+
+    def forward(self):
+        return self.op_func(self.in_one, self.in_two)
+
+
+op_bench.generate_pt_tests_from_op_list(binary_ops_bcast_list,
+                                        binary_configs_broadcast,
+                                        BinaryOpBcastBenchmark)
+
+
+# Benchmark ops performance without broadcast
+binary_ops_list = op_bench.op_list(
+    attr_names=['op_name', 'op_func'],
+    attrs=[
+        ['add', torch.add],
+    ],
+)
+
+binary_short_configs = op_bench.config_list(
+    attr_names=['M', 'N', 'K'],
+    attrs=[
+        [1, 1, 1],
+        [64, 64, 64],
+        [64, 64, 128],
+    ],
+    cross_product_configs={
+        'device': ['cpu', 'cuda'],
+        'dtype_one' : [torch.int32],
+        'dtype_two' : [torch.int32],
+    },
+    tags=['short'],
+)
+
+binary_long_configs = op_bench.cross_product_configs(
+    M=[8, 128],
+    N=[32, 64],
+    K=[256, 512],
+    device=['cpu', 'cuda'],
+    dtype_one=[torch.int8, torch.int32],
+    dtype_two=[torch.int8, torch.int32],
+    tags=['long']
+)
+
+
+class BinaryOpBenchmark(op_bench.TorchBenchmarkBase):
+    def init(self, M, N, K, device, dtype_one, dtype_two, op_func):
+        self.input_one = torch.randn(M, N, K, device=device).to(dtype=dtype_one)
+        self.input_two = torch.randn(M, N, K, device=device).to(dtype=dtype_two)
+        self.op_func = op_func
+
+    def forward(self):
+        return self.op_func(self.input_one, self.input_two)
+
+
+op_bench.generate_pt_tests_from_op_list(binary_ops_list,
+                                        binary_short_configs + binary_long_configs,
+                                        BinaryOpBenchmark)
+
+
+if __name__ == "__main__":
+    op_bench.benchmark_runner.main()


### PR DESCRIPTION
Summary: Adds copy_ operator to the benchmark suite

Test Plan:
```
buck run caffe2/benchmarks/operator_benchmark/pt:binary_test -- --iterations 1 --operators copy_
# ----------------------------------------
# PyTorch/Caffe2 Operator Micro-benchmarks
# ----------------------------------------
# Tag : short

# Benchmarking PyTorch: copy_
# Mode: Eager
# Name: copy__M1_N1_K1_cpu_dtype_onetorch.int32_dtype_twotorch.int32
# Input: M: 1, N: 1, K: 1, device: cpu, dtype_one: torch.int32, dtype_two: torch.int32
Forward Execution Time (us) : 60.645

Reviewed By: hl475

Differential Revision: D19122910

