### PR TITLE
remove wipe cache from op bench

### DIFF
--- a/benchmarks/operator_benchmark/benchmark_core.py
+++ b/benchmarks/operator_benchmark/benchmark_core.py
@@ -278,10 +278,6 @@ class BenchmarkRunner(object):
         curr_test_total_time = 0
         time_trace = []
         while True:
-            # Wipe cache
-            if self.args.wipe_cache:
-                torch.ops.operator_benchmark._clear_cache()
-
             run_time_sec = launch_test(test_case, iters, print_per_iter)
             curr_test_total_time += run_time_sec
             # Analyze time after each run to decide if the result is stable

--- a/benchmarks/operator_benchmark/benchmark_runner.py
+++ b/benchmarks/operator_benchmark/benchmark_runner.py
@@ -132,13 +132,6 @@ def main():
         help='Run tests on the provided architecture (cpu, cuda)',
         default='None')
 
-    parser.add_argument(
-        '--wipe_cache',
-        help='Wipe cache before benchmarking each operator',
-        action='store_true',
-        default=False
-    )
-
     args, _ = parser.parse_known_args()
 
     if args.omp_num_threads:

--- a/benchmarks/operator_benchmark/pt_extension/extension.cpp
+++ b/benchmarks/operator_benchmark/pt_extension/extension.cpp
@@ -1,4 +1,3 @@
-#include <cpuinfo.h>
 #include <torch/extension.h>
 #include <torch/script.h>
 
@@ -8,37 +7,14 @@ Tensor consume(Tensor a) {
   return a;
 }
 
-Tensor clear_cache() {
-  static uint32_t* wipe_buffer = nullptr;
-  static size_t wipe_size = 0;
-
-  if (wipe_buffer == nullptr) {
-    TORCH_CHECK(cpuinfo_initialize(), "failed to initialize cpuinfo");
-    const cpuinfo_processor* processor = cpuinfo_get_processor(0);
-    wipe_size = processor->cache.l3->size;
-    wipe_buffer = static_cast<uint32_t*>(malloc(wipe_size));
-    TORCH_CHECK(wipe_buffer != nullptr);
-  }
-  int64_t hash = 0;
-  for (uint32_t i = 0; i * sizeof(uint32_t) < wipe_size; i += 8) {
-    hash ^= wipe_buffer[i];
-    wipe_buffer[i] = hash;
-  }
-  /* Make sure compiler doesn't optimize the loop away */
-  Tensor ret = torch::from_blob(&hash, {1,});
-  return ret;
-}
-
 // When JIT tracing is used on function with constant for loop,
 // the for loop is optimized away because of dead code elimination.
 // That caused an issue for our op benchmark which needs to run an op
 // in a loop and report the execution time. This diff resolves that issue by
 // registering this consume op with correct alias information which is DEFAULT.
 auto reg = torch::RegisterOperators()
-  .op("operator_benchmark::_consume", &consume)
-  .op("operator_benchmark::_clear_cache", &clear_cache);
+  .op("operator_benchmark::_consume", &consume);
 
 PYBIND11_MODULE(cpp_extension, m) {
   m.def("_consume", &consume, "consume");
-  m.def("_clear_cache", &clear_cache, "clear_cache");
 }


### PR DESCRIPTION
Summary: The wipe cache logic was introduced hoping to reduce the variations in the benchmark results. Based on our experiments result, it didn't actually help with that. In addition, several engineers had encountered the issue of missing cpuinfo.h. So this diff removes that feature to ensure smooth installation and running of the op bench.

Differential Revision: D19126970

