### PR TITLE
caffe2/event: allow multiple errors such as when cancelled

### DIFF
--- a/caffe2/core/event.cc
+++ b/caffe2/core/event.cc
@@ -87,6 +87,14 @@ void EventSetFinishedCPU(const Event* event, const char* err_msg) {
   auto* wrapper = static_cast<CPUEventWrapper*>(event->event_.get());
   std::unique_lock<std::mutex> lock(wrapper->mutex_);
 
+  if (wrapper->status_ == EventStatus::EVENT_FAILED) {
+    LOG(WARNING) << "SetFinished called on a finished event. "
+                 << "Most likely caused by an external cancellation. "
+                 << "old message: " << wrapper->err_msg_ << ", "
+                 << "new message: " << err_msg;
+    return;
+  }
+
   CAFFE_ENFORCE(
       wrapper->status_ == EventStatus::EVENT_INITIALIZED ||
           wrapper->status_ == EventStatus::EVENT_SCHEDULED,

--- a/caffe2/core/event_test.cc
+++ b/caffe2/core/event_test.cc
@@ -22,4 +22,19 @@ TEST(EventCPUTest, EventBasics) {
   event.Wait(CPU, &context);
 }
 
+TEST(EventCPUTest, EventErrors) {
+  DeviceOption device_option;
+  device_option.set_device_type(PROTO_CPU);
+  Event event(device_option);
+
+  event.SetFinished();
+  ASSERT_THROW(event.SetFinished("error"), caffe2::EnforceNotMet);
+  ASSERT_EQ(event.ErrorMessage(), "No error");
+
+  event.Reset();
+  event.SetFinished("error 1");
+  event.SetFinished("error 2");
+  ASSERT_EQ(event.ErrorMessage(), "error 1");
+}
+
 } // namespace caffe2


### PR DESCRIPTION
Summary:
When an error occurs in a net we end up cancelling all the async ops. If one error occurs it's highly likely other errors will occur as well.

Typically we see:
1. SendOp failed due to a network error
2. async scheduling cancels all other ops via `SetFinished("Cancelled");`
3. Another SendOp fails due to a network error and crashes the process when the exception is thrown.

This changes caffe2 ops to allow failing twice.

Test Plan: buck test //caffe2/caffe2:caffe2_test_cpu

Differential Revision: D19106548

