### PR TITLE
autograd/profiler: make record_function more threadsafe

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -2720,6 +2720,21 @@ class TestAutograd(TestCase):
 
         self.assertTrue('my_func' in str(p))
 
+    def test_record_function_multithreaded(self):
+        rf = record_function("outer")
+        rf.__enter__()
+        with profile():
+            # test that exiting the record function after starting a profile
+            # doesn't throw.
+            rf.__exit__()
+
+        with profile():
+            rf.__enter__()
+        # test that exiting the record function after the profile has ended
+        # doesn't throw.
+        rf.__exit__()
+
+
     def test_dir(self):
         x = torch.randn(10, 10)
         keys = dir(x)

--- a/torch/csrc/autograd/record_function.h
+++ b/torch/csrc/autograd/record_function.h
@@ -97,6 +97,10 @@ struct TORCH_API RecordFunction {
     return parent_;
   }
 
+  bool active() const {
+    return initialized_;
+  }
+
   void setRunSampled(bool run_sampled) {
     run_sampled_ = run_sampled;
   }

--- a/torch/csrc/autograd/record_function_ops.cpp
+++ b/torch/csrc/autograd/record_function_ops.cpp
@@ -32,10 +32,15 @@ void record_function_exit(const at::Tensor& handle) {
   // We don't actually need to do anything with handle just need to persist the
   // lifetime until now.
   auto& rec = at::cpp_custom_type_hack::cast<RecordFunction>(handle);
-  if (auto* current = RecordFunction::current()) {
-    AT_ASSERT(current->parent() == &rec, "rec must be parent");
-    AT_ASSERT(current->name() == StringView("profiler::_record_function_exit"));
-    current->end();
+  auto* current = RecordFunction::current();
+  if (rec.active() && current) {
+    if (current != &rec) {
+      AT_ASSERT(current->parent() == &rec, "rec must be parent");
+      AT_ASSERT(current->name() == StringView("profiler::_record_function_exit"));
+      current->end();
+    } else {
+      AT_ASSERT(current == &rec, "rec must be active");
+    }
     rec.end();
   }
 }


### PR DESCRIPTION
Summary:
This makes it so that if profiling is enabled/disabled from a different thread while a RecordFunction span is active via an op it doesn't crash the process.

We currently see when using torch.distributed.rpc to enable/disable profiling on other nodes while other things are running.

Test Plan: buck test //caffe2/test:autograd -- test_record_function

Differential Revision: D19133258

