### PR TITLE
Update old scheduler example usage

### DIFF
--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -941,12 +941,12 @@ class CosineAnnealingWarmRestarts(_LRScheduler):
             >>> for epoch in range(20):
             >>>     for i, sample in enumerate(dataloader):
             >>>         inputs, labels = sample['inputs'], sample['labels']
-            >>>         scheduler.step(epoch + i / iters)
             >>>         optimizer.zero_grad()
             >>>         outputs = net(inputs)
             >>>         loss = criterion(outputs, labels)
             >>>         loss.backward()
             >>>         optimizer.step()
+            >>>         scheduler.step(epoch + i / iters)
 
         This function can be called in an interleaved way.
 


### PR DESCRIPTION
Update the old example usage in CosineAnnealingWarm, `scheduler.step()` should be called after `optimizer.step()`.

https://github.com/pytorch/pytorch/issues/20028#issuecomment-566061580