### PR TITLE
caffe2::TypeInfo fix when using clang-cl on Windows

### DIFF
--- a/c10/util/TypeIndex.h
+++ b/c10/util/TypeIndex.h
@@ -58,7 +58,7 @@ inline constexpr string_view extract(
 
 template <typename T>
 inline C10_TYPENAME_CONSTEXPR string_view fully_qualified_type_name_impl() noexcept {
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && !defined(__clang__)
   return extract(
       "class c10::string_view __cdecl c10::util::detail::fully_qualified_type_name_impl<",
       ">(void)",


### PR DESCRIPTION
Summary: clang-cl defines both `_MSC_VER` and `__clang__`. Names are mangled clang style though. calling `extract` with the wrong name mangling pattern will throw `std::logic_error`. This crashes on Windows when `get_fully_qualified_type_name` is called because it is marked with `noexcept`.

Test Plan: Windows builds no longer crash on startup.

Differential Revision: D19142064

