### PR TITLE
Guard intrusive_ptr asserts with a flag.

### DIFF
--- a/c10/util/intrusive_ptr.h
+++ b/c10/util/intrusive_ptr.h
@@ -93,12 +93,18 @@ class C10_API intrusive_ptr_target {
 #  pragma GCC diagnostic ignored "-Wterminate"
 #  pragma GCC diagnostic ignored "-Wexceptions"
 #endif
+// When making changes to intrusive pointer, enable this define and run the tests
+// to ensure intrusive_ptr is not broken. These are not part of the normal code becuase
+// they add significant overhead.
+// #define TORCH_INTRUSIVE_PTR_ASSERTS
+#ifdef TORCH_INTRUSIVE_PTR_ASSERTS
     AT_ASSERTM(
         refcount_.load() == 0,
         "Tried to destruct an intrusive_ptr_target that still has intrusive_ptr to it");
     AT_ASSERTM(
         weakcount_.load() == 0,
         "Tried to destruct an intrusive_ptr_target that still has weak_intrusive_ptr to it");
+#endif
 #if defined(_MSC_VER) && !defined(__clang__)
 #  pragma warning(pop)
 #else
@@ -185,9 +191,11 @@ class intrusive_ptr final {
   void retain_() {
     if (target_ != NullType::singleton()) {
       size_t new_refcount = ++target_->refcount_;
+#ifdef TORCH_INTRUSIVE_PTR_ASSERTS
       AT_ASSERTM(
           new_refcount != 1,
           "intrusive_ptr: Cannot increase refcount after it reached zero.");
+#endif
     }
   }
 
@@ -369,9 +377,11 @@ class intrusive_ptr final {
    */
   static intrusive_ptr unsafe_reclaim_from_nonowning(TTarget* raw_ptr) {
     // See Note [Stack allocated intrusive_ptr_target safety]
+#ifdef TORCH_INTRUSIVE_PTR_ASSERTS
     AT_ASSERTM(
         raw_ptr == NullType::singleton() || raw_ptr->refcount_.load() > 0,
         "intrusive_ptr: Can only reclaim pointers that are owned by someone");
+#endif
     auto ptr = reclaim(raw_ptr); // doesn't increase refcount
     ptr.retain_();
     return ptr;
@@ -442,9 +452,11 @@ class weak_intrusive_ptr final {
   void retain_() {
     if (target_ != NullType::singleton()) {
       size_t new_weakcount = ++target_->weakcount_;
+#ifdef TORCH_INTRUSIVE_PTR_ASSERTS
       AT_ASSERTM(
           new_weakcount != 1,
           "weak_intrusive_ptr: Cannot increase weakcount after it reached zero.");
+#endif
     }
   }
 

--- a/c10/util/intrusive_ptr.h
+++ b/c10/util/intrusive_ptr.h
@@ -94,7 +94,7 @@ class C10_API intrusive_ptr_target {
 #  pragma GCC diagnostic ignored "-Wexceptions"
 #endif
 // When making changes to intrusive pointer, enable this define and run the tests
-// to ensure intrusive_ptr is not broken. These are not part of the normal code becuase
+// to ensure intrusive_ptr is not broken. These are not part of the normal code because
 // they add significant overhead.
 // #define TORCH_INTRUSIVE_PTR_ASSERTS
 #ifdef TORCH_INTRUSIVE_PTR_ASSERTS
@@ -191,6 +191,7 @@ class intrusive_ptr final {
   void retain_() {
     if (target_ != NullType::singleton()) {
       size_t new_refcount = ++target_->refcount_;
+      (void) new_refcount;
 #ifdef TORCH_INTRUSIVE_PTR_ASSERTS
       AT_ASSERTM(
           new_refcount != 1,

--- a/c10/util/intrusive_ptr.h
+++ b/c10/util/intrusive_ptr.h
@@ -453,6 +453,7 @@ class weak_intrusive_ptr final {
   void retain_() {
     if (target_ != NullType::singleton()) {
       size_t new_weakcount = ++target_->weakcount_;
+      (void) new_weakcount;
 #ifdef TORCH_INTRUSIVE_PTR_ASSERTS
       AT_ASSERTM(
           new_weakcount != 1,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#31387 Guard intrusive_ptr asserts with a flag.**

These asserts add measurable performance overhead, but are really only
useful for debugging changes to intrusive_ptr itself, which is a
rare occurance. By putting them under a ifdef, we avoid overhead,
while still leaving them as a reference for when we are making changes
to intrusive_ptr.

Differential Revision: [D19148930](https://our.internmc.facebook.com/intern/diff/D19148930)