### PR TITLE
Temporary fix to support building pytorch from fbsource (for xplat dependencies)

### DIFF
--- a/tools/build_variables.py
+++ b/tools/build_variables.py
@@ -402,6 +402,13 @@ def add_torch_libs():
         "-Icaffe2/torch/csrc",
         "-Icaffe2/torch/csrc/nn",
         "-Icaffe2/torch/lib",
+        # T59288529: Temporary hack to support building from xplat.
+        # Remove with a proper fix.
+        "-Ifbcode/caffe2",
+        "-Ifbcode/caffe2/torch/csrc/api/include",
+        "-Ifbcode/caffe2/torch/csrc",
+        "-Ifbcode/caffe2/torch/csrc/nn",
+        "-Ifbcode/caffe2/torch/lib",
     ]
 
     cpp_library(


### PR DESCRIPTION
Summary:
pytorch build was set up with the include paths (-I) relative to fbcode/. This works well for fbcode builds, but doesn't work for the new fbcode_deps args for xplat build targets that work across xplat and fbcode. When these targets are built, the include paths need to be relative to fbsource, so fbcode/ suffix needs to be added to those paths.

Longer term, to properly fix this, we need to use raw_headers with public_include_directories specified for all of these targets.

Test Plan: buck test mode/dev //papaya/integration/service/local/test:mnist_federated_system_test -- 'MnistFederatedSystemTest\.test' --run-disabled

Reviewed By: mzlee

Differential Revision: D19148465

