### PR TITLE
[ONNX][v1.4.0] Cherry-pick Add ONNX Export Support to floor_divide

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -487,6 +487,30 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.randn(2, 3, 4)
         self.run_test(ArithmeticModule(), x)
 
+    def test_floor_div(self):
+        class FloorDivModule(torch.nn.Module):
+            def forward(self, x, y):
+                return x // 3, x // 2., \
+                    x.to(dtype=torch.float64) // 3, x.to(dtype=torch.float64) // 2., \
+                    x.to(dtype=torch.int64) // 3, x.to(dtype=torch.int64) // 2., \
+                    x // (y + 1.).to(dtype=torch.int64), x // y, \
+                    x.to(dtype=torch.float64) // y.to(dtype=torch.int64), x.to(dtype=torch.float64) // y.to(dtype=torch.float64), \
+                    x.to(dtype=torch.int64) // y.to(dtype=torch.int64), x.to(dtype=torch.int64) // y
+
+        x = torch.randn(2, 3, 4)
+        y = torch.arange(1, 2 * 3 * 4 + 1).reshape(2, 3, 4)
+        self.run_test(FloorDivModule(), (x, y))
+
+    def test_floor_div_script(self):
+        class FloorDivModule(torch.jit.ScriptModule):
+            @torch.jit.script_method
+            def forward(self, x, y):
+                return x // 3, x // 2., x // y
+
+        x = torch.randn(2, 3, 4)
+        y = torch.randn(2, 3, 4)
+        self.run_test(FloorDivModule(), (x, y))
+
     def test_slice_trace(self):
         class MyModule(torch.nn.Module):
             def forward(self, x):


### PR DESCRIPTION
Original commit: https://github.com/pytorch/pytorch/commit/79c27ba4ef609c56907c504e15737fbaf8cc8f87
Original PR: https://github.com/pytorch/pytorch/pull/31081
This is needed to unblock onnx export for torchvision models.