### PR TITLE
[JIT] catch all exceptions in converting default values to ivalues

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -3563,6 +3563,11 @@ graph(%Ra, %Rb):
             def hints_bad_types(x, a=10, b=0.5):  # noqa: T484
                 # type: (Tensor, float, int) -> Tensor
                 return x + a + b
+        with self.assertRaisesRegex(RuntimeError, "Expected a default value"):
+            @torch.jit.script
+            def add_tensor_tensor(x : Dict[str, int] = None):
+                return x
+
 
     def test_module_default_values(self):
         four = torch.tensor(4)

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -3565,7 +3565,8 @@ graph(%Ra, %Rb):
                 return x + a + b
         with self.assertRaisesRegex(RuntimeError, "Expected a default value"):
             @torch.jit.script
-            def add_tensor_tensor(x : Dict[str, int] = None):
+            def bad_no_optional(x=None):
+                # type: (Dict[str, int]) -> Dict[str, int]
                 return x
 
 

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -208,7 +208,7 @@ c10::optional<IValue> tryCalculateDefaultParam(
     } else {
       return toIValue(def_value, arg.type());
     }
-  } catch (py::cast_error& e) {
+  } catch (...) {
     return c10::nullopt;
   }
 }


### PR DESCRIPTION
Previously we would only catch `py::cast_error` which led to incomprehensible error messages like: `TypeError: 'NoneType' object is not iterable`. We are running arbitrary pybind code here, and not doing anything with the error message, so we should be less restrictive with the types of errors we catch.