### PR TITLE
Disable the rebase logic to make the CI pass

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -307,27 +307,28 @@ jobs:
           time docker pull ${DOCKER_IMAGE} >/dev/null
           export id=$(docker run --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --cap-add=SYS_PTRACE --security-opt seccomp=unconfined -t -d -w /var/lib/jenkins ${DOCKER_IMAGE})
 
-          # TODO We may want to move the rebase logic to a separate step after checkout
-          # Rebase to master only if in xenial_py3_6_gcc5_4 case
-          if [[ "${CIRCLE_BRANCH}" != "master" && "${BUILD_ENVIRONMENT}" == *"gcc5"* ]]; then
-            echo "Merge master branch into $CIRCLE_BRANCH before build in environment $BUILD_ENVIRONMENT"
-            set -x
-            git config --global user.email "circleci.ossci@gmail.com"
-            git config --global user.name "CircleCI"
-            git config remote.origin.url https://github.com/pytorch/pytorch.git
-            git config --add remote.origin.fetch +refs/heads/master:refs/remotes/origin/master
-            git fetch --tags --progress https://github.com/pytorch/pytorch.git +refs/heads/master:refs/remotes/origin/master --depth=100 --quiet
-            export GIT_MERGE_TARGET=`git log -n 1 --pretty=format:"%H" origin/master`
-            echo "GIT_MERGE_TARGET: " ${GIT_MERGE_TARGET}
-            export GIT_COMMIT=${CIRCLE_SHA1}
-            echo "GIT_COMMIT: " ${GIT_COMMIT}
-            git checkout -f ${GIT_COMMIT}
-            git reset --hard ${GIT_COMMIT}
-            git merge --allow-unrelated-histories --no-edit --no-ff ${GIT_MERGE_TARGET}
-            set +x
-          else
-            echo "Do NOT merge master branch into $CIRCLE_BRANCH in environment $BUILD_ENVIRONMENT"
-          fi
+          # NB: Temporarily disable the rebase logic in v1.4.0, don't merge this change into master
+          # # TODO We may want to move the rebase logic to a separate step after checkout
+          # # Rebase to master only if in xenial_py3_6_gcc5_4 case
+          # if [[ "${CIRCLE_BRANCH}" != "master" && "${BUILD_ENVIRONMENT}" == *"gcc5"* ]]; then
+          #   echo "Merge master branch into $CIRCLE_BRANCH before build in environment $BUILD_ENVIRONMENT"
+          #   set -x
+          #   git config --global user.email "circleci.ossci@gmail.com"
+          #   git config --global user.name "CircleCI"
+          #   git config remote.origin.url https://github.com/pytorch/pytorch.git
+          #   git config --add remote.origin.fetch +refs/heads/master:refs/remotes/origin/master
+          #   git fetch --tags --progress https://github.com/pytorch/pytorch.git +refs/heads/master:refs/remotes/origin/master --depth=100 --quiet
+          #   export GIT_MERGE_TARGET=`git log -n 1 --pretty=format:"%H" origin/master`
+          #   echo "GIT_MERGE_TARGET: " ${GIT_MERGE_TARGET}
+          #   export GIT_COMMIT=${CIRCLE_SHA1}
+          #   echo "GIT_COMMIT: " ${GIT_COMMIT}
+          #   git checkout -f ${GIT_COMMIT}
+          #   git reset --hard ${GIT_COMMIT}
+          #   git merge --allow-unrelated-histories --no-edit --no-ff ${GIT_MERGE_TARGET}
+          #   set +x
+          # else
+          #   echo "Do NOT merge master branch into $CIRCLE_BRANCH in environment $BUILD_ENVIRONMENT"
+          # fi
 
           git submodule sync && git submodule update -q --init --recursive
 

--- a/.circleci/verbatim-sources/pytorch-job-specs.yml
+++ b/.circleci/verbatim-sources/pytorch-job-specs.yml
@@ -19,27 +19,28 @@ jobs:
           time docker pull ${DOCKER_IMAGE} >/dev/null
           export id=$(docker run --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --cap-add=SYS_PTRACE --security-opt seccomp=unconfined -t -d -w /var/lib/jenkins ${DOCKER_IMAGE})
 
-          # TODO We may want to move the rebase logic to a separate step after checkout
-          # Rebase to master only if in xenial_py3_6_gcc5_4 case
-          if [[ "${CIRCLE_BRANCH}" != "master" && "${BUILD_ENVIRONMENT}" == *"gcc5"* ]]; then
-            echo "Merge master branch into $CIRCLE_BRANCH before build in environment $BUILD_ENVIRONMENT"
-            set -x
-            git config --global user.email "circleci.ossci@gmail.com"
-            git config --global user.name "CircleCI"
-            git config remote.origin.url https://github.com/pytorch/pytorch.git
-            git config --add remote.origin.fetch +refs/heads/master:refs/remotes/origin/master
-            git fetch --tags --progress https://github.com/pytorch/pytorch.git +refs/heads/master:refs/remotes/origin/master --depth=100 --quiet
-            export GIT_MERGE_TARGET=`git log -n 1 --pretty=format:"%H" origin/master`
-            echo "GIT_MERGE_TARGET: " ${GIT_MERGE_TARGET}
-            export GIT_COMMIT=${CIRCLE_SHA1}
-            echo "GIT_COMMIT: " ${GIT_COMMIT}
-            git checkout -f ${GIT_COMMIT}
-            git reset --hard ${GIT_COMMIT}
-            git merge --allow-unrelated-histories --no-edit --no-ff ${GIT_MERGE_TARGET}
-            set +x
-          else
-            echo "Do NOT merge master branch into $CIRCLE_BRANCH in environment $BUILD_ENVIRONMENT"
-          fi
+          # NB: Temporarily disable the rebase logic in v1.4.0, don't merge this change into master
+          # # TODO We may want to move the rebase logic to a separate step after checkout
+          # # Rebase to master only if in xenial_py3_6_gcc5_4 case
+          # if [[ "${CIRCLE_BRANCH}" != "master" && "${BUILD_ENVIRONMENT}" == *"gcc5"* ]]; then
+          #   echo "Merge master branch into $CIRCLE_BRANCH before build in environment $BUILD_ENVIRONMENT"
+          #   set -x
+          #   git config --global user.email "circleci.ossci@gmail.com"
+          #   git config --global user.name "CircleCI"
+          #   git config remote.origin.url https://github.com/pytorch/pytorch.git
+          #   git config --add remote.origin.fetch +refs/heads/master:refs/remotes/origin/master
+          #   git fetch --tags --progress https://github.com/pytorch/pytorch.git +refs/heads/master:refs/remotes/origin/master --depth=100 --quiet
+          #   export GIT_MERGE_TARGET=`git log -n 1 --pretty=format:"%H" origin/master`
+          #   echo "GIT_MERGE_TARGET: " ${GIT_MERGE_TARGET}
+          #   export GIT_COMMIT=${CIRCLE_SHA1}
+          #   echo "GIT_COMMIT: " ${GIT_COMMIT}
+          #   git checkout -f ${GIT_COMMIT}
+          #   git reset --hard ${GIT_COMMIT}
+          #   git merge --allow-unrelated-histories --no-edit --no-ff ${GIT_MERGE_TARGET}
+          #   set +x
+          # else
+          #   echo "Do NOT merge master branch into $CIRCLE_BRANCH in environment $BUILD_ENVIRONMENT"
+          # fi
 
           git submodule sync && git submodule update -q --init --recursive
 


### PR DESCRIPTION
We don't need to rebase to master, since the BC doesn't give much meaningful signals.