### PR TITLE
[jit] use expect instead of casting in register_c10_ops

### DIFF
--- a/torch/csrc/jit/register_c10_ops.cpp
+++ b/torch/csrc/jit/register_c10_ops.cpp
@@ -44,8 +44,7 @@ Operator createOperatorFromC10(const c10::OperatorHandle& op) {
               node->addInput(none);
               continue;
             } else {
-              type =
-                  reinterpret_cast<OptionalType*>(type.get())->getElementType();
+              type = type->expect<OptionalType>()->getElementType();
             }
           }
           if (type->isSubtypeOf(TensorType::get())) {
@@ -65,8 +64,7 @@ Operator createOperatorFromC10(const c10::OperatorHandle& op) {
             tracer::addInputs(
                 node, args[i].name().c_str(), iter->toStringRef());
           } else if (type->kind() == TypeKind::ListType) {
-            const auto& elem_type =
-                reinterpret_cast<ListType*>(type.get())->getElementType();
+            const auto& elem_type = type->expect<ListType>()->getElementType();
             if (elem_type->isSubtypeOf(TensorType::get())) {
               AT_ASSERT(iter->isTensorList());
               auto list = iter->toTensorListRef();
@@ -124,8 +122,7 @@ Operator createOperatorFromC10(const c10::OperatorHandle& op) {
             AT_ASSERT(iter->isTensor());
             tracer::addOutput(node, iter->toTensor());
           } else if (type->kind() == TypeKind::ListType) {
-            const auto& elem_type =
-                reinterpret_cast<ListType*>(type.get())->getElementType();
+            const auto& elem_type = type->expect<ListType>()->getElementType();
             if (elem_type->isSubtypeOf(TensorType::get())) {
               AT_ASSERT(iter->isTensorList());
               tracer::addOutput(node, iter->toTensorList());


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#31401 [jit] use expect instead of casting in register_c10_ops**

As title, just a mechanical change

Differential Revision: [D19152965](https://our.internmc.facebook.com/intern/diff/D19152965)