### PR TITLE
Use global lock instead of per instance lock.

### DIFF
--- a/torch/distributed/optim/optimizer.py
+++ b/torch/distributed/optim/optimizer.py
@@ -6,17 +6,25 @@ from threading import Lock
 
 
 class _LocalOptimizer:
+    # Ideally we would only need to share a lock for instances of
+    # _LocalOptimizer that deal with the same parameters. We are
+    # making a simplifying assumption here that if there is more
+    # than one instance of _LocalOptimizer per worker, they will
+    # be optimizing the same parameters (e.g. each data parallel
+    # trainer will create its own instance of _LocalOptimizer but
+    # they will all optimize the same parameters on each worker)
+    global_lock = Lock()
+
     def __init__(self, optim_cls, local_params_rref, *args, **kwargs):
         self.optim = optim_cls(
             [rref.local_value() for rref in local_params_rref],
             *args,
             **kwargs)
-        self.lock = Lock()
 
     def step(self, autograd_ctx_id):
         all_local_grads = dist_autograd.get_gradients(autograd_ctx_id)
 
-        with self.lock:
+        with _LocalOptimizer.global_lock:
             for param, grad in all_local_grads.items():
                 param.grad = grad
             self.optim.step()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#31404 Use global lock instead of per instance lock.**

Multiple "trainers" could each create different instances of DistributedOptimizer, which means we can still have a race condition unless we do a trully global per worker lock.

Differential Revision: [D19154248](https://our.internmc.facebook.com/intern/diff/D19154248/)