### PR TITLE
Bump numba version in circleCI config to 0.46.0.

### DIFF
--- a/.circleci/docker/common/install_conda.sh
+++ b/.circleci/docker/common/install_conda.sh
@@ -88,7 +88,7 @@ if [ -n "$ANACONDA_PYTHON_VERSION" ]; then
   # scikit-learn is pinned because of
   # https://github.com/scikit-learn/scikit-learn/issues/14485 (affects gcc 5.5
   # only)
-  as_jenkins pip install --progress-bar off pytest scipy==1.1.0 scikit-learn==0.20.3 scikit-image librosa>=0.6.2 psutil numba==0.43.1 llvmlite==0.28.0
+  as_jenkins pip install --progress-bar off pytest scipy==1.1.0 scikit-learn==0.20.3 scikit-image librosa>=0.6.2 psutil numba==0.46.0 llvmlite==0.28.0
 
   popd
 fi


### PR DESCRIPTION
The current numba version doesn't appear to actually work with our numba-cuda tests (numba.cuda.is_available()) fails.

Previous attempts to upgrade were blocked by https://github.com/numba/numba/issues/4368.

It's a bit unclear to me, but I believe 0.46.0 fixes the above version.  I'm verify that we catch that issue in CI via https://github.com/pytorch/pytorch/pull/31434.

