### PR TITLE
[NHWC] cudnn grouped convolution nhwc patch

### DIFF
--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -355,9 +355,12 @@ auto ConvParams::use_cudnn_depthwise(
 
 auto ConvParams::cudnn_use_channels_last(
         const at::Tensor& input, const at::Tensor& weight) const -> bool {
+  if (!detail::getCUDAHooks().compiledWithCuDNN()) {
+    return false;
+  }
   long cudnn_version = detail::getCUDAHooks().versionCuDNN();
   // old cudnn version has sparse group convolution support for NHWC layout
-  return (groups == 1 || cudnn_version >= 7600) &&
+  return (groups == 1 || cudnn_version >= 7603) &&
       (input.suggest_memory_format() == at::MemoryFormat::ChannelsLast);
 }
 

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -36,6 +36,7 @@ struct ConvParams {
   bool use_cpu_depthwise3x3_winograd(const at::Tensor& input, const at::Tensor& weight) const;
   bool use_cudnn(const at::Tensor& input) const;
   bool use_cudnn_depthwise(const at::Tensor& input, const at::Tensor& weight) const;
+  bool cudnn_use_channels_last(const at::Tensor& input, const at::Tensor& weight) const;
   bool use_miopen(const at::Tensor& input) const;
   bool use_mkldnn(const at::Tensor& input) const;
   bool use_nnpack(const at::Tensor& input) const;
@@ -326,7 +327,6 @@ bool check_cudnn_depthwise_workload(const at::Tensor& input, int stride) {
   }
   return false;
 }
-
 // Use cudnn for FP16 depthwise convolutions
 auto ConvParams::use_cudnn_depthwise(
         const at::Tensor& input, const at::Tensor& weight) const -> bool {
@@ -351,6 +351,14 @@ auto ConvParams::use_cudnn_depthwise(
   } else {
     return false;
   }
+}
+
+auto ConvParams::cudnn_use_channels_last(
+        const at::Tensor& input, const at::Tensor& weight) const -> bool {
+  long cudnn_version = detail::getCUDAHooks().versionCuDNN();
+  // old cudnn version has sparse group convolution support for NHWC layout
+  return (groups == 1 || cudnn_version >= 7600) &&
+      (input.suggest_memory_format() == at::MemoryFormat::ChannelsLast);
 }
 
 static void check_shape_forward(const at::Tensor& input,
@@ -573,6 +581,9 @@ at::Tensor _convolution(
     weight = view4d(weight);
   }
 
+  at::MemoryFormat cudnn_memory_format = params.cudnn_use_channels_last(input, weight) ?
+      at::MemoryFormat::ChannelsLast : at::MemoryFormat::Contiguous;
+
   Tensor output;
   if (params.is_depthwise(input, weight)) {
       /* output.resize_(output_size(input, weight)); */
@@ -583,7 +594,7 @@ at::Tensor _convolution(
       auto dilation = params.dilation;
       if (params.use_cudnn_depthwise(input, weight)) {
         output = at::cudnn_convolution(
-            input.contiguous(input.suggest_memory_format()), weight, bias,
+            input.contiguous(cudnn_memory_format), weight, bias,
             padding, stride, dilation, params.groups, params.benchmark, params.deterministic);
 
       } else if (params.use_miopen(input)){
@@ -603,11 +614,11 @@ at::Tensor _convolution(
 
     if (params.transposed) {
       output = at::cudnn_convolution_transpose(
-          input.contiguous(input.suggest_memory_format()), weight, bias,
+          input.contiguous(cudnn_memory_format), weight, bias,
           params.padding, params.output_padding, params.stride, params.dilation, params.groups, params.benchmark, params.deterministic);
     } else {
       output = at::cudnn_convolution(
-          input.contiguous(input.suggest_memory_format()), weight, bias,
+          input.contiguous(cudnn_memory_format), weight, bias,
           params.padding, params.stride, params.dilation, params.groups, params.benchmark, params.deterministic);
     }
   } else if (params.use_miopen(input)) {

--- a/aten/src/ATen/native/cudnn/Conv.cpp
+++ b/aten/src/ATen/native/cudnn/Conv.cpp
@@ -201,9 +201,12 @@ Tensor narrowGroup(const Tensor& t, int dim, int group_idx, int64_t groups) {
 }
 
 bool support_channels_last(const Tensor& input, const Tensor& weight, int groups) {
+  if (!detail::getCUDAHooks().compiledWithCuDNN()) {
+    return false;
+  }
   long cudnn_version = detail::getCUDAHooks().versionCuDNN();
-  return (groups == 1 || cudnn_version >= 7600) &&
-      input.suggest_memory_format() == at::MemoryFormat::ChannelsLast;
+  return (groups == 1 || cudnn_version >= 7603) &&
+      (input.suggest_memory_format() == at::MemoryFormat::ChannelsLast);
 }
 
 // ---------------------------------------------------------------------

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7554,6 +7554,17 @@ class TestNN(NNTestCase):
         self.assertEqual(conv.bias.grad, ref_conv.bias.grad)
         self.assertEqual(input.grad, ref_input.grad)
 
+    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
+    @unittest.skipIf(not TEST_CUDNN, "needs cudnn")
+    @skipIfRocm
+    def test_grouped_conv_cudnn_nhwc_support(self):
+        # in order to catch the hols in grouped convolution in nhwc support for earlier cudnn version
+        input = torch.randn((16, 16, 8, 8), device="cuda").to(memory_format=torch.channels_last)
+        weight = torch.randn((8, 4, 3, 3), device="cuda").to(memory_format=torch.channels_last)
+        out = torch.cudnn_convolution(input, weight, None, (1, 1), (1, 1), (1, 1), 4, False, False)
+        input = torch.randn((16, 8, 8, 8), device="cuda").to(memory_format=torch.channels_last)
+        out = torch.cudnn_convolution_transpose(input, weight, None, (1, 1), (0, 0), (1, 1), (1, 1), 4, False, False)
+
     @unittest.expectedFailure
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     @unittest.skipIf(not TEST_CUDNN, "needs cudnn")

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7559,10 +7559,10 @@ class TestNN(NNTestCase):
     @skipIfRocm
     def test_grouped_conv_cudnn_nhwc_support(self):
         # in order to catch the hols in grouped convolution in nhwc support for earlier cudnn version
-        input = torch.randn((16, 16, 8, 8), device="cuda").to(memory_format=torch.channels_last)
-        weight = torch.randn((8, 4, 3, 3), device="cuda").to(memory_format=torch.channels_last)
+        input = torch.randn((16, 16, 8, 8), dtype=torch.float16, device="cuda").to(memory_format=torch.channels_last)
+        weight = torch.randn((8, 4, 3, 3), dtype=torch.float16, device="cuda").to(memory_format=torch.channels_last)
         out = torch.cudnn_convolution(input, weight, None, (1, 1), (1, 1), (1, 1), 4, False, False)
-        input = torch.randn((16, 8, 8, 8), device="cuda").to(memory_format=torch.channels_last)
+        input = torch.randn((16, 8, 8, 8), dtype=torch.float16, device="cuda").to(memory_format=torch.channels_last)
         out = torch.cudnn_convolution_transpose(input, weight, None, (1, 1), (0, 0), (1, 1), (1, 1), 4, False, False)
 
     @unittest.expectedFailure


### PR DESCRIPTION
Earlier cudnn version doesn't support grouped convolution in NHWC well. Legit
configuration in later cudnn version might return CUDNN_STATUS_NOT_SUPPORTED.
We are falling back to NCHW when runtime check of cudnn version is < 7.6.0 to
keep the logic simple.

Note:
We might update the heuristics, 7.6.0 is very conservative.

