### PR TITLE
Fix input_channels divisibility check in concat_split_op

### DIFF
--- a/caffe2/operators/concat_split_op.cc
+++ b/caffe2/operators/concat_split_op.cc
@@ -55,7 +55,7 @@ vector<TensorShape> TensorInferenceForSplit(
     // We cannot infer output shape until we see the value of split input
     return ret_invalid_shape();
   } else if (split.empty()) {
-    if (!input_channels % output_size) {
+    if (input_channels % output_size != 0) {
       LOG(WARNING) << "Input channels (" << input_channels
                    << ") should be divisible by number of outputs ("
                    << output_size << ")";


### PR DESCRIPTION
Summary: Replace `(!x%y)` with `(x%y != 0)`

Test Plan: CI

Differential Revision: D19165492

