### PR TITLE
[v1.4.0] Fix reading `__cuda_array_interface__` inferred strides, add…

### DIFF
--- a/test/test_numba_integration.py
+++ b/test/test_numba_integration.py
@@ -312,6 +312,30 @@ class TestNumbaIntegration(common.TestCase):
     @unittest.skipIf(not TEST_NUMPY, "No numpy")
     @unittest.skipIf(not TEST_CUDA, "No cuda")
     @unittest.skipIf(not TEST_NUMBA_CUDA, "No numba.cuda")
+    def test_from_cuda_array_interface_inferred_strides(self):
+        """torch.as_tensor(numba_ary) should have correct inferred (contiguous) strides"""
+        # This could, in theory, be combined with test_from_cuda_array_interface but that test
+        # is overly strict: it checks that the exported protocols are exactly the same, which
+        # cannot handle differening exported protocol versions.
+        dtypes = [
+            numpy.float64,
+            numpy.float32,
+            numpy.int64,
+            numpy.int32,
+            numpy.int16,
+            numpy.int8,
+            numpy.uint8,
+        ]
+        for dtype in dtypes:
+            numpy_ary = numpy.arange(6).reshape(2, 3).astype(dtype),
+            numba_ary = numba.cuda.to_device(numpy_ary)
+            self.assertTrue(numba_ary.is_c_contiguous())
+            torch_ary = torch.as_tensor(numba_ary, device="cuda")
+            self.assertTrue(torch_ary.is_contiguous())
+
+    @unittest.skipIf(not TEST_NUMPY, "No numpy")
+    @unittest.skipIf(not TEST_CUDA, "No cuda")
+    @unittest.skipIf(not TEST_NUMBA_CUDA, "No numba.cuda")
     def test_from_cuda_array_interface_lifetime(self):
         """torch.as_tensor(obj) tensor grabs a reference to obj so that the lifetime of obj exceeds the tensor"""
         numba_ary = numba.cuda.to_device(numpy.arange(6))

--- a/torch/csrc/utils/tensor_numpy.cpp
+++ b/torch/csrc/utils/tensor_numpy.cpp
@@ -299,18 +299,18 @@ at::Tensor tensor_from_cuda_array_interface(PyObject* obj) {
         throw TypeError("strides must be a sequence of the same length as shape");
       }
       strides = seq_to_aten_shape(py_strides);
+
+      // __cuda_array_interface__ strides use bytes. Torch strides use element counts.
+      for (auto& stride : strides) {
+        if (stride%dtype_size_in_bytes != 0) {
+          throw ValueError(
+              "given array strides not a multiple of the element byte size. "
+              "Make a copy of the array to reallocate the memory.");
+          }
+        stride /= dtype_size_in_bytes;
+      }
     } else {
       strides = at::detail::defaultStrides(sizes);
-    }
-
-    // __cuda_array_interface__ strides use bytes. Torch strides use element counts.
-    for (auto& stride : strides) {
-      if (stride%dtype_size_in_bytes != 0) {
-        throw ValueError(
-            "given array strides not a multiple of the element byte size. "
-            "Make a copy of the array to reallocate the memory.");
-        }
-      stride /= dtype_size_in_bytes;
     }
   }
 


### PR DESCRIPTION
… test.

This is a simpler fix than https://github.com/pytorch/pytorch/pull/24947, which both fixed the bug and updated the protocol version.
This also adds a test (which the previous PR did not).

So the plan is that master (1.5) will have the new protocol version (and a test), 1.4 will have the old protocol version and the test.

