### PR TITLE
optimize UpSampleNearest 1d 2d and 3d performance on CPU

### DIFF
--- a/aten/src/ATen/native/UpSample.h
+++ b/aten/src/ATen/native/UpSample.h
@@ -45,9 +45,10 @@
 namespace at {
 namespace native {
 
-using upsampling_1d = void(*)(Tensor& output, const Tensor& input, double scales_1);
-using upsampling_2d = void(*)(Tensor& output, const Tensor& input, double scales_1, double scales_2);
-using upsampling_3d = void(*)(Tensor& output, const Tensor& input, double scales_1, double scales_2, double scales_3);
+using scale_t = c10::optional<double>;
+using upsampling_1d = void(*)(Tensor& output, const Tensor& input, scale_t scales_w);
+using upsampling_2d = void(*)(Tensor& output, const Tensor& input, scale_t scales_h, scale_t scales_w);
+using upsampling_3d = void(*)(Tensor& output, const Tensor& input, scale_t scales_d, scale_t scales_h, scale_t scales_w);
 DECLARE_DISPATCH(upsampling_1d, upsample_nearest1d_kernel);
 DECLARE_DISPATCH(upsampling_2d, upsample_nearest2d_kernel);
 DECLARE_DISPATCH(upsampling_3d, upsample_nearest3d_kernel);

--- a/aten/src/ATen/native/UpSample.h
+++ b/aten/src/ATen/native/UpSample.h
@@ -2,6 +2,7 @@
 
 #include <ATen/ATen.h>
 #include <ATen/TensorUtils.h>
+#include <ATen/native/DispatchStub.h>
 
 
 /**
@@ -43,6 +44,16 @@
 
 namespace at {
 namespace native {
+
+using upsampling_1d = void(*)(Tensor& output, const Tensor& input, double scales_1);
+using upsampling_2d = void(*)(Tensor& output, const Tensor& input, double scales_1, double scales_2);
+using upsampling_3d = void(*)(Tensor& output, const Tensor& input, double scales_1, double scales_2, double scales_3);
+DECLARE_DISPATCH(upsampling_1d, upsample_nearest1d_kernel);
+DECLARE_DISPATCH(upsampling_2d, upsample_nearest2d_kernel);
+DECLARE_DISPATCH(upsampling_3d, upsample_nearest3d_kernel);
+DECLARE_DISPATCH(upsampling_1d, upsample_nearest1d_backward_kernel);
+DECLARE_DISPATCH(upsampling_2d, upsample_nearest2d_backward_kernel);
+DECLARE_DISPATCH(upsampling_3d, upsample_nearest3d_backward_kernel);
 
 static inline void upsample_1d_shape_check(
     const Tensor& input,

--- a/aten/src/ATen/native/UpSampleNearest1d.cpp
+++ b/aten/src/ATen/native/UpSampleNearest1d.cpp
@@ -6,95 +6,9 @@ namespace at {
 namespace native {
 namespace {
 
-template <typename scalar_t>
-static void upsample_nearest1d_out_frame(
-    scalar_t* odata,
-    scalar_t* idata,
-    int64_t input_width,
-    int64_t output_width,
-    int64_t nbatch,
-    int64_t channels,
-    c10::optional<double> scales) {
-  const float scale = compute_scales_value<float>(scales, input_width, output_width);
-  channels = channels * nbatch;
-
-  // special case: just copy
-  if (input_width == output_width) {
-    for (int64_t w2 = 0; w2 < output_width; ++w2) {
-      const int64_t w1 = w2;
-      const scalar_t* pos1 = &idata[w1];
-      scalar_t* pos2 = &odata[w2];
-
-      for (int64_t c = 0; c < channels; ++c) {
-        pos2[0] = pos1[0];
-        pos1 += input_width;
-        pos2 += output_width;
-      }
-    }
-    return;
-  }
-
-  for (int64_t w2 = 0; w2 < output_width; ++w2) {
-    const scalar_t src_x =
-        nearest_neighbor_compute_source_index(scale, w2, input_width);
-    const int64_t w1 = src_x;
-    const scalar_t* pos1 = &idata[w1];
-    scalar_t* pos2 = &odata[w2];
-
-    for (int64_t c = 0; c < channels; ++c) {
-      pos2[0] = pos1[0];
-      pos1 += input_width;
-      pos2 += output_width;
-    }
-  }
-}
-
-template <typename scalar_t>
-static void upsample_nearest1d_backward_out_frame(
-    scalar_t* odata,
-    scalar_t* idata,
-    int64_t input_width,
-    int64_t output_width,
-    int64_t nbatch,
-    int64_t channels,
-    c10::optional<double> scales) {
-  const float scale = compute_scales_value<float>(scales, input_width, output_width);
-  channels = channels * nbatch;
-
-  // special case: same-size matching grids
-  if (input_width == output_width) {
-    for (int64_t w2 = 0; w2 < output_width; ++w2) {
-      const int64_t w1 = w2;
-      scalar_t* pos1 = &idata[w1];
-      const scalar_t* pos2 = &odata[w2];
-
-      for (int64_t c = 0; c < channels; ++c) {
-        pos1[0] += pos2[0];
-        pos1 += input_width;
-        pos2 += output_width;
-      }
-    }
-    return;
-  }
-
-  for (int64_t w2 = 0; w2 < output_width; ++w2) {
-    const int64_t w1 =
-        nearest_neighbor_compute_source_index(scale, w2, input_width);
-
-    scalar_t* pos1 = &idata[w1];
-    const scalar_t* pos2 = &odata[w2];
-
-    for (int64_t c = 0; c < channels; ++c) {
-      pos1[0] += pos2[0];
-      pos1 += input_width;
-      pos2 += output_width;
-    }
-  }
-}
-
 static void upsample_nearest1d_out_cpu_template(
     Tensor& output,
-    const Tensor& input_,
+    const Tensor& input,
     IntArrayRef output_size,
     c10::optional<double> scales) {
   TORCH_CHECK(
@@ -104,43 +18,27 @@ static void upsample_nearest1d_out_cpu_template(
 
   int64_t output_width = output_size[0];
 
-  int64_t nbatch = input_.size(0);
-  int64_t channels = input_.size(1);
-  int64_t input_width = input_.size(2);
+  int64_t nbatch = input.size(0);
+  int64_t channels = input.size(1);
+  int64_t input_width = input.size(2);
 
   upsample_1d_shape_check(
-      input_,
+      input,
       Tensor(),
       nbatch,
       channels,
       input_width,
       output_width);
 
-  auto input = input_.contiguous();
-
   output.resize_({nbatch, channels, output_width});
-  output.zero_();
 
   AT_ASSERT(input_width > 0 && output_width > 0);
-
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(), "upsample_nearest1d", [&] {
-    auto* idata = input.data_ptr<scalar_t>();
-    auto* odata = output.data_ptr<scalar_t>();
-
-    upsample_nearest1d_out_frame<scalar_t>(
-        odata,
-        idata,
-        input_width,
-        output_width,
-        nbatch,
-        channels,
-        scales);
-  });
+  upsample_nearest1d_kernel(kCPU, output, input, scales);
 }
 
 static void upsample_nearest1d_backward_out_cpu_template(
     Tensor& grad_input,
-    const Tensor& grad_output_,
+    const Tensor& grad_output,
     IntArrayRef output_size,
     IntArrayRef input_size,
     c10::optional<double> scales) {
@@ -162,31 +60,16 @@ static void upsample_nearest1d_backward_out_cpu_template(
 
   upsample_1d_shape_check(
       Tensor(),
-      grad_output_,
+      grad_output,
       nbatch,
       channels,
       input_width,
       output_width);
 
-  auto grad_output = grad_output_.contiguous();
-
   grad_input.resize_({nbatch, channels, input_width});
   grad_input.zero_();
 
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-      grad_output.scalar_type(), "upsample_nearest1d_backward", [&] {
-        scalar_t* idata = grad_input.data_ptr<scalar_t>();
-        scalar_t* odata = grad_output.data_ptr<scalar_t>();
-
-        upsample_nearest1d_backward_out_frame<scalar_t>(
-            odata,
-            idata,
-            input_width,
-            output_width,
-            nbatch,
-            channels,
-            scales);
-      });
+  upsample_nearest1d_backward_kernel(kCPU, grad_input, grad_output, scales_1);
 }
 } // namespace
 
@@ -226,6 +109,9 @@ Tensor upsample_nearest1d_backward_cpu(
       grad_input, grad_output, output_size, input_size, scales);
   return grad_input;
 }
+
+DEFINE_DISPATCH(upsample_nearest1d_kernel);
+DEFINE_DISPATCH(upsample_nearest1d_backward_kernel);
 
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/native/UpSampleNearest1d.cpp
+++ b/aten/src/ATen/native/UpSampleNearest1d.cpp
@@ -69,7 +69,7 @@ static void upsample_nearest1d_backward_out_cpu_template(
   grad_input.resize_({nbatch, channels, input_width});
   grad_input.zero_();
 
-  upsample_nearest1d_backward_kernel(kCPU, grad_input, grad_output, scales_1);
+  upsample_nearest1d_backward_kernel(kCPU, grad_input, grad_output, scales);
 }
 } // namespace
 

--- a/aten/src/ATen/native/UpSampleNearest2d.cpp
+++ b/aten/src/ATen/native/UpSampleNearest2d.cpp
@@ -6,123 +6,9 @@ namespace at {
 namespace native {
 namespace {
 
-template <typename scalar_t>
-static void upsample_nearest2d_out_frame(
-    scalar_t* odata,
-    scalar_t* idata,
-    int64_t input_height,
-    int64_t input_width,
-    int64_t output_height,
-    int64_t output_width,
-    int64_t nbatch,
-    int64_t channels,
-    c10::optional<double> scales_h,
-    c10::optional<double> scales_w) {
-  const float height_scale = compute_scales_value<float>(scales_h, input_height, output_height);
-  const float width_scale = compute_scales_value<float>(scales_w, input_width, output_width);
-
-  channels = channels * nbatch;
-
-  // special case: just copy
-  if (input_height == output_height && input_width == output_width) {
-    for (int64_t h2 = 0; h2 < output_height; ++h2) {
-      const int64_t h1 = h2;
-
-      for (int64_t w2 = 0; w2 < output_width; ++w2) {
-        const int64_t w1 = w2;
-        const scalar_t* pos1 = &idata[h1 * input_width + w1];
-        scalar_t* pos2 = &odata[h2 * output_width + w2];
-
-        for (int64_t c = 0; c < channels; ++c) {
-          pos2[0] = pos1[0];
-          pos1 += input_height * input_width;
-          pos2 += output_height * output_width;
-        }
-      }
-    }
-    return;
-  }
-
-  for (int64_t h2 = 0; h2 < output_height; ++h2) {
-    const int64_t h1 =
-        nearest_neighbor_compute_source_index(height_scale, h2, input_height);
-
-    for (int64_t w2 = 0; w2 < output_width; ++w2) {
-      const int64_t w1 =
-          nearest_neighbor_compute_source_index(width_scale, w2, input_width);
-
-      const scalar_t* pos1 = &idata[h1 * input_width + w1];
-      scalar_t* pos2 = &odata[h2 * output_width + w2];
-
-      for (int64_t c = 0; c < channels; ++c) {
-        pos2[0] = pos1[0];
-        pos1 += input_height * input_width;
-        pos2 += output_height * output_width;
-      }
-    }
-  }
-}
-
-template <typename scalar_t>
-static void upsample_nearest2d_backward_out_frame(
-    scalar_t* odata,
-    scalar_t* idata,
-    int64_t input_height,
-    int64_t input_width,
-    int64_t output_height,
-    int64_t output_width,
-    int64_t nbatch,
-    int64_t channels,
-    c10::optional<double> scales_h,
-    c10::optional<double> scales_w) {
-
-  const float height_scale = compute_scales_value<float>(scales_h, input_height, output_height);
-  const float width_scale = compute_scales_value<float>(scales_w, input_width, output_width);
-
-  channels = channels * nbatch;
-
-  // special case: just copy
-  if (input_height == output_height && input_width == output_width) {
-    for (int64_t h2 = 0; h2 < output_height; ++h2) {
-      const int64_t h1 = h2;
-
-      for (int64_t w2 = 0; w2 < output_width; ++w2) {
-        const int64_t w1 = w2;
-        scalar_t* pos1 = &idata[h1 * input_width + w1];
-        const scalar_t* pos2 = &odata[h2 * output_width + w2];
-
-        for (int64_t c = 0; c < channels; ++c) {
-          pos1[0] = pos2[0];
-          pos1 += input_height * input_width;
-          pos2 += output_height * output_width;
-        }
-      }
-    }
-    return;
-  }
-
-  for (int64_t h2 = 0; h2 < output_height; ++h2) {
-    const int64_t h1 =
-        nearest_neighbor_compute_source_index(height_scale, h2, input_height);
-
-    for (int64_t w2 = 0; w2 < output_width; ++w2) {
-      const int64_t w1 =
-          nearest_neighbor_compute_source_index(width_scale, w2, input_width);
-      scalar_t* pos1 = &idata[h1 * input_width + w1];
-      const scalar_t* pos2 = &odata[h2 * output_width + w2];
-
-      for (int64_t c = 0; c < channels; ++c) {
-        pos1[0] += pos2[0];
-        pos1 += input_height * input_width;
-        pos2 += output_height * output_width;
-      }
-    }
-  }
-}
-
 static void upsample_nearest2d_out_cpu_template(
     Tensor& output,
-    const Tensor& input_,
+    const Tensor& input,
     IntArrayRef output_size,
     c10::optional<double> scales_h,
     c10::optional<double> scales_w) {
@@ -134,13 +20,13 @@ static void upsample_nearest2d_out_cpu_template(
   int64_t output_height = output_size[0];
   int64_t output_width = output_size[1];
 
-  int64_t nbatch = input_.size(0);
-  int64_t channels = input_.size(1);
-  int64_t input_height = input_.size(2);
-  int64_t input_width = input_.size(3);
+  int64_t nbatch = input.size(0);
+  int64_t channels = input.size(1);
+  int64_t input_height = input.size(2);
+  int64_t input_width = input.size(3);
 
   upsample_2d_shape_check(
-      input_,
+      input,
       Tensor(),
       nbatch,
       channels,
@@ -149,34 +35,15 @@ static void upsample_nearest2d_out_cpu_template(
       output_height,
       output_width);
 
-  auto input = input_.contiguous();
-
   output.resize_({nbatch, channels, output_height, output_width});
-  output.zero_();
 
   AT_ASSERT(input_width > 0 && output_width > 0);
-
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(), "upsample_nearest2d", [&] {
-    auto* idata = input.data_ptr<scalar_t>();
-    auto* odata = output.data_ptr<scalar_t>();
-
-    upsample_nearest2d_out_frame<scalar_t>(
-        odata,
-        idata,
-        input_height,
-        input_width,
-        output_height,
-        output_width,
-        nbatch,
-        channels,
-        scales_h,
-        scales_w);
-  });
+  upsample_nearest2d_kernel(kCPU, output, input, scales_h, scales_w);
 }
 
 static void upsample_nearest2d_backward_out_cpu_template(
     Tensor& grad_input,
-    const Tensor& grad_output_,
+    const Tensor& grad_output,
     IntArrayRef output_size,
     IntArrayRef input_size,
     c10::optional<double> scales_h,
@@ -201,7 +68,7 @@ static void upsample_nearest2d_backward_out_cpu_template(
 
   upsample_2d_shape_check(
       Tensor(),
-      grad_output_,
+      grad_output,
       nbatch,
       channels,
       input_height,
@@ -212,25 +79,7 @@ static void upsample_nearest2d_backward_out_cpu_template(
   grad_input.resize_({nbatch, channels, input_height, input_width});
   grad_input.zero_();
 
-  auto grad_output = grad_output_.contiguous();
-
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-      grad_output.scalar_type(), "upsample_nearest2d_backward", [&] {
-        scalar_t* idata = grad_input.data_ptr<scalar_t>();
-        scalar_t* odata = grad_output.data_ptr<scalar_t>();
-
-        upsample_nearest2d_backward_out_frame<scalar_t>(
-            odata,
-            idata,
-            input_height,
-            input_width,
-            output_height,
-            output_width,
-            nbatch,
-            channels,
-            scales_h,
-            scales_w);
-      });
+  upsample_nearest2d_backward_kernel(kCPU, grad_input, grad_output, scales_h, scales_w);
 }
 } // namespace
 
@@ -273,6 +122,9 @@ Tensor upsample_nearest2d_backward_cpu(
       grad_input, grad_output, output_size, input_size, scales_h, scales_w);
   return grad_input;
 }
+
+DEFINE_DISPATCH(upsample_nearest2d_kernel);
+DEFINE_DISPATCH(upsample_nearest2d_backward_kernel);
 
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/native/UpSampleNearest3d.cpp
+++ b/aten/src/ATen/native/UpSampleNearest3d.cpp
@@ -6,159 +6,9 @@ namespace at {
 namespace native {
 namespace {
 
-template <typename scalar_t>
-static void upsample_nearest3d_out_frame(
-    scalar_t* odata,
-    scalar_t* idata,
-    int64_t input_depth,
-    int64_t input_height,
-    int64_t input_width,
-    int64_t output_depth,
-    int64_t output_height,
-    int64_t output_width,
-    int64_t nbatch,
-    int64_t channels,
-    c10::optional<double> scales_d,
-    c10::optional<double> scales_h,
-    c10::optional<double> scales_w) {
-  const float depth_scale = compute_scales_value<float>(scales_d, input_depth, output_depth);
-  const float height_scale = compute_scales_value<float>(scales_h, input_height, output_height);
-  const float width_scale = compute_scales_value<float>(scales_w, input_width, output_width);
-
-  channels = channels * nbatch;
-
-  // special case: just copy
-  if (input_depth == output_depth && input_height == output_height &&
-      input_width == output_width) {
-    for (int64_t d2 = 0; d2 < output_depth; ++d2) {
-      const int64_t d1 = d2;
-
-      for (int64_t h2 = 0; h2 < output_height; ++h2) {
-        const int64_t h1 = h2;
-
-        for (int64_t w2 = 0; w2 < output_width; ++w2) {
-          const int64_t w1 = w2;
-          const scalar_t* pos1 =
-              &idata[d1 * input_height * input_width + h1 * input_width + w1];
-          scalar_t* pos2 =
-              &odata
-                  [d2 * output_height * output_width + h2 * output_width + w2];
-
-          for (int64_t c = 0; c < channels; ++c) {
-            pos2[0] = pos1[0];
-            pos1 += input_depth * input_height * input_width;
-            pos2 += output_depth * output_height * output_width;
-          }
-        }
-      }
-    }
-    return;
-  }
-
-  for (int64_t d2 = 0; d2 < output_depth; ++d2) {
-    const int64_t d1 =
-        nearest_neighbor_compute_source_index(depth_scale, d2, input_depth);
-
-    for (int64_t h2 = 0; h2 < output_height; ++h2) {
-      const int64_t h1 =
-          nearest_neighbor_compute_source_index(height_scale, h2, input_height);
-
-      for (int64_t w2 = 0; w2 < output_width; ++w2) {
-        const int64_t w1 =
-            nearest_neighbor_compute_source_index(width_scale, w2, input_width);
-        const scalar_t* pos1 =
-            &idata[d1 * input_height * input_width + h1 * input_width + w1];
-        scalar_t* pos2 =
-            &odata[d2 * output_height * output_width + h2 * output_width + w2];
-
-        for (int64_t c = 0; c < channels; ++c) {
-          pos2[0] = pos1[0];
-          pos1 += input_depth * input_height * input_width;
-          pos2 += output_depth * output_height * output_width;
-        }
-      }
-    }
-  }
-}
-
-template <typename scalar_t>
-static void upsample_nearest3d_backward_out_frame(
-    scalar_t* odata,
-    scalar_t* idata,
-    int64_t input_depth,
-    int64_t input_height,
-    int64_t input_width,
-    int64_t output_depth,
-    int64_t output_height,
-    int64_t output_width,
-    int64_t nbatch,
-    int64_t channels,
-    c10::optional<double> scales_d,
-    c10::optional<double> scales_h,
-    c10::optional<double> scales_w) {
-  const float depth_scale = compute_scales_value<float>(scales_d, input_depth, output_depth);
-  const float height_scale = compute_scales_value<float>(scales_h, input_height, output_height);
-  const float width_scale = compute_scales_value<float>(scales_w, input_width, output_width);
-
-  channels = channels * nbatch;
-
-  // special case: just copy
-  if (input_depth == output_depth && input_height == output_height &&
-      input_width == output_width) {
-    for (int64_t d2 = 0; d2 < output_depth; ++d2) {
-      const int64_t d1 = d2;
-
-      for (int64_t h2 = 0; h2 < output_height; ++h2) {
-        const int64_t h1 = h2;
-
-        for (int64_t w2 = 0; w2 < output_width; ++w2) {
-          const int64_t w1 = w2;
-          scalar_t* pos1 =
-              &idata[d1 * input_height * input_width + h1 * input_width + w1];
-          const scalar_t* pos2 =
-              &odata
-                  [d2 * output_height * output_width + h2 * output_width + w2];
-
-          for (int64_t c = 0; c < channels; ++c) {
-            pos1[0] += pos2[0];
-            pos1 += input_depth * input_height * input_width;
-            pos2 += output_depth * output_height * output_width;
-          }
-        }
-      }
-    }
-    return;
-  }
-
-  for (int64_t d2 = 0; d2 < output_depth; ++d2) {
-    const int64_t d1 =
-        nearest_neighbor_compute_source_index(depth_scale, d2, input_depth);
-
-    for (int64_t h2 = 0; h2 < output_height; ++h2) {
-      const int64_t h1 =
-          nearest_neighbor_compute_source_index(height_scale, h2, input_height);
-
-      for (int64_t w2 = 0; w2 < output_width; ++w2) {
-        const int64_t w1 =
-            nearest_neighbor_compute_source_index(width_scale, w2, input_width);
-        scalar_t* pos1 =
-            &idata[d1 * input_height * input_width + h1 * input_width + w1];
-        const scalar_t* pos2 =
-            &odata[d2 * output_height * output_width + h2 * output_width + w2];
-
-        for (int64_t c = 0; c < channels; ++c) {
-          pos1[0] += pos2[0];
-          pos1 += input_depth * input_height * input_width;
-          pos2 += output_depth * output_height * output_width;
-        }
-      }
-    }
-  }
-}
-
 static void upsample_nearest3d_out_cpu_template(
     Tensor& output,
-    const Tensor& input_,
+    const Tensor& input,
     IntArrayRef output_size,
     c10::optional<double> scales_d,
     c10::optional<double> scales_h,
@@ -172,14 +22,14 @@ static void upsample_nearest3d_out_cpu_template(
   int64_t output_height = output_size[1];
   int64_t output_width = output_size[2];
 
-  int64_t nbatch = input_.size(0);
-  int64_t channels = input_.size(1);
-  int64_t input_depth = input_.size(2);
-  int64_t input_height = input_.size(3);
-  int64_t input_width = input_.size(4);
+  int64_t nbatch = input.size(0);
+  int64_t channels = input.size(1);
+  int64_t input_depth = input.size(2);
+  int64_t input_height = input.size(3);
+  int64_t input_width = input.size(4);
 
   upsample_3d_shape_check(
-      input_,
+      input,
       Tensor(),
       nbatch,
       channels,
@@ -190,39 +40,16 @@ static void upsample_nearest3d_out_cpu_template(
       output_height,
       output_width);
 
-  auto input = input_.contiguous();
-
   output.resize_({nbatch, channels, output_depth, output_height, output_width});
-  output.zero_();
-
   AT_ASSERT(
       input_depth > 0 && input_height > 0 && input_width > 0 &&
       output_depth > 0 && output_height > 0 && output_width > 0);
-
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(), "upsample_nearest3d", [&] {
-    auto* idata = input.data_ptr<scalar_t>();
-    auto* odata = output.data_ptr<scalar_t>();
-
-    upsample_nearest3d_out_frame<scalar_t>(
-        odata,
-        idata,
-        input_depth,
-        input_height,
-        input_width,
-        output_depth,
-        output_height,
-        output_width,
-        nbatch,
-        channels,
-        scales_d,
-        scales_h,
-        scales_w);
-  });
+  upsample_nearest3d_kernel(kCPU, output, input, scales_d, scales_h, scales_w);
 }
 
 static void upsample_nearest3d_backward_out_cpu_template(
     Tensor& grad_input,
-    const Tensor& grad_output_,
+    const Tensor& grad_output,
     IntArrayRef output_size,
     IntArrayRef input_size,
     c10::optional<double> scales_d,
@@ -250,7 +77,7 @@ static void upsample_nearest3d_backward_out_cpu_template(
 
   upsample_3d_shape_check(
       Tensor(),
-      grad_output_,
+      grad_output,
       nbatch,
       channels,
       input_depth,
@@ -264,28 +91,7 @@ static void upsample_nearest3d_backward_out_cpu_template(
       {nbatch, channels, input_depth, input_height, input_width});
   grad_input.zero_();
 
-  auto grad_output = grad_output_.contiguous();
-
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-      grad_output.scalar_type(), "upsample_nearest3d_backward", [&] {
-        scalar_t* idata = grad_input.data_ptr<scalar_t>();
-        scalar_t* odata = grad_output.data_ptr<scalar_t>();
-
-        upsample_nearest3d_backward_out_frame<scalar_t>(
-            odata,
-            idata,
-            input_depth,
-            input_height,
-            input_width,
-            output_depth,
-            output_height,
-            output_width,
-            nbatch,
-            channels,
-            scales_d,
-            scales_h,
-            scales_w);
-      });
+  upsample_nearest3d_backward_kernel(kCPU, grad_input, grad_output, scales_d, scales_h, scales_w);
 }
 } // namespace
 
@@ -332,6 +138,9 @@ Tensor upsample_nearest3d_backward_cpu(
       grad_input, grad_output, output_size, input_size, scales_d, scales_h, scales_w);
   return grad_input;
 }
+
+DEFINE_DISPATCH(upsample_nearest3d_kernel);
+DEFINE_DISPATCH(upsample_nearest3d_backward_kernel);
 
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/native/cpu/UpSampleKernel.cpp
+++ b/aten/src/ATen/native/cpu/UpSampleKernel.cpp
@@ -127,6 +127,7 @@ void cpu_upsample_nearest(
     at::parallel_for(0, numel, at::internal::GRAIN_SIZE, loop2d);
   } else {
     // upsample nearest 3d
+    TORCH_INTERNAL_ASSERT(ndim == 5);
     at::parallel_for(0, numel, at::internal::GRAIN_SIZE, loop3d);
   }
 
@@ -216,6 +217,7 @@ void cpu_upsample_nearest_backward(
     at::parallel_for(0, channels, at::internal::GRAIN_SIZE / output_slice_size , loop2d);
   } else {
     // upsample nearest 3d
+    TORCH_INTERNAL_ASSERT(ndim == 5);
     at::parallel_for(0, channels, at::internal::GRAIN_SIZE / output_slice_size, loop3d);
   }
 

--- a/aten/src/ATen/native/cpu/UpSampleKernel.cpp
+++ b/aten/src/ATen/native/cpu/UpSampleKernel.cpp
@@ -1,0 +1,311 @@
+#include <ATen/ATen.h>
+
+#include <ATen/Dispatch.h>
+#include <ATen/native/UpSample.h>
+#include <ATen/native/TensorIterator.h>
+#include <ATen/native/cpu/Loops.h>
+
+namespace at {
+namespace native {
+namespace {
+
+template <typename T>
+inline T data_index_init(T offset) {
+  return offset;
+}
+
+template <typename T, typename... Args>
+inline T data_index_init(T offset, T &x, const T &X, Args &&... args) {
+  offset = data_index_init(offset, std::forward<Args>(args)...);
+  x = offset % X;
+  return offset / X;
+}
+
+inline bool data_index_step() {
+  return true;
+}
+
+template <typename T, typename... Args>
+inline bool data_index_step(T &x, const T &X, Args &&... args) {
+  if (data_index_step(std::forward<Args>(args)...)) {
+    x = ((x + 1) == X) ? 0 : (x + 1);
+    return x == 0;
+  }
+  return false;
+}
+
+static inline int64_t nearest_idx(
+    int64_t output_index,
+    int64_t input_size,
+    int64_t output_size,
+    double scales_1) {
+  if (output_size == input_size) {
+    // simply copy
+    return output_index;
+  } else if (output_size == 2 * input_size && scales_1 < 0.) {
+    // scale_factor = 2
+    return output_index >> 1;
+  } else {
+    float scale = compute_scales_value<float>(scales_1, input_size, output_size);
+    return nearest_neighbor_compute_source_index(scale, output_index, input_size);
+  }
+}
+
+template <typename scalar_t, typename scale_type>
+void cpu_upsample_nearest(
+    Tensor& output_,
+    const Tensor& input_,
+    const scale_type& scales) {
+  TORCH_CHECK(input_.dtype() == output_.dtype(), "expected dtype ", input_.dtype(),
+              " for `output` but got dtype ", output_.dtype());
+  auto input = input_.contiguous();
+  auto output = output_.contiguous();
+
+  auto output_data_base = output.data_ptr<scalar_t>();
+  auto input_sizes = input.sizes().vec();
+  auto output_sizes = output.sizes().vec();
+  auto ndim = input_sizes.size();
+
+  // treat nbatch and channels as one dimension
+  int64_t channels = input_sizes[0] * input_sizes[1];
+  int64_t input_depth = (ndim == 5) ? input_sizes[2] : 0;
+  int64_t output_depth = (ndim == 5) ? output_sizes[2] : 0;
+  int64_t input_height = (ndim >= 4) ? input_sizes[ndim - 2] : 0;
+  int64_t output_height = (ndim >= 4) ? output_sizes[ndim - 2] : 0;
+  int64_t input_width = input_sizes[ndim - 1];
+  int64_t output_width = output_sizes[ndim - 1];
+
+  auto loop1d = [&](char** data, const int64_t* strides, int64_t n) {
+    auto output_data = (scalar_t*)data[0];
+    auto input_data = (scalar_t*)data[1];
+
+    int64_t c = 0;
+    int64_t ow = 0;
+    int64_t offset = output_data - output_data_base;
+    data_index_init(offset, c, channels, ow, output_width);
+
+    for (int64_t i = 0; i < n; i++) {
+      int64_t iw = nearest_idx(ow, input_width, output_width, scales[0]);
+      output_data[i] = input_data[c * input_width + iw];
+      data_index_step(c, channels, ow, output_width);
+    }
+  };
+
+  auto loop2d = [&](char** data, const int64_t* strides, int64_t n) {
+    auto output_data = (scalar_t*)data[0];
+    auto input_data = (scalar_t*)data[1];
+
+    int64_t c = 0;
+    int64_t oh = 0;
+    int64_t ow = 0;
+    int64_t offset = output_data - output_data_base;
+    data_index_init(offset, c, channels, oh, output_height, ow, output_width);
+
+    for (int64_t i = 0; i < n; i++) {
+      int64_t ih = nearest_idx(oh, input_height, output_height, scales[0]);
+      int64_t iw = nearest_idx(ow, input_width, output_width, scales[1]);
+      output_data[i] = input_data[c * input_height * input_width + ih * input_width + iw];
+      data_index_step(c, channels, oh, output_height, ow, output_width);
+    }
+  };
+
+  auto loop3d = [&](char** data, const int64_t* strides, int64_t n) {
+    auto output_data = (scalar_t*)data[0];
+    auto input_data = (scalar_t*)data[1];
+
+    int64_t c = 0;
+    int64_t od = 0;
+    int64_t oh = 0;
+    int64_t ow = 0;
+    int64_t offset = output_data - output_data_base;
+    data_index_init(offset, c, channels, od, output_depth, oh, output_height, ow, output_width);
+
+    for (int64_t i = 0; i < n; i++) {
+      int64_t id = nearest_idx(od, input_depth, output_depth, scales[0]);
+      int64_t ih = nearest_idx(oh, input_height, output_height, scales[1]);
+      int64_t iw = nearest_idx(ow, input_width, output_width, scales[2]);
+      int64_t j = c * input_depth * input_height * input_width +
+                  id * input_height * input_width + ih * input_width + iw;
+      output_data[i] = input_data[j];
+      data_index_step(c, channels, od, output_depth, oh, output_height, ow, output_width);
+    }
+  };
+
+  std::vector<int64_t> strides(input_sizes.size(), 0);
+  auto input_expand = input.as_strided(output_sizes, strides);
+
+  auto iter = TensorIterator();
+  iter.set_check_mem_overlap(true);
+  iter.add_output(output);
+  iter.add_input(input_expand);
+  iter.build();
+
+  if (ndim == 3) {
+    // upsample nearest 1d
+    iter.for_each(loop1d);
+  } else if (ndim == 4) {
+    // upsample nearest 2d
+    iter.for_each(loop2d);
+  } else {
+    // upsample nearest 3d
+    iter.for_each(loop3d);
+  }
+
+  if (!output_.is_contiguous()) {
+    output_.copy_(output);
+  }
+}
+
+template <typename scalar_t, typename scale_type>
+void cpu_upsample_nearest_backward(
+    Tensor& grad_input_,
+    const Tensor& grad_output_,
+    const scale_type& scales) {
+  TORCH_CHECK(grad_input_.dtype() == grad_output_.dtype(), "expected dtype ", grad_output_.dtype(),
+              " for `grad_input` but got dtype ", grad_input_.dtype());
+  auto grad_output = grad_output_.contiguous();
+  auto grad_input = grad_input_.contiguous();
+
+  auto grad_output_data_base = grad_output.data_ptr<scalar_t>();
+  auto input_sizes = grad_input.sizes().vec();
+  auto output_sizes = grad_output.sizes().vec();
+  auto ndim = input_sizes.size();
+
+  // treat nbatch and channels as one dimension
+  int64_t channels = input_sizes[0] * input_sizes[1];
+  int64_t input_depth = (ndim == 5) ? input_sizes[2] : 0;
+  int64_t output_depth = (ndim == 5) ? output_sizes[2] : 0;
+  int64_t input_height = (ndim >= 4) ? input_sizes[ndim - 2] : 0;
+  int64_t output_height = (ndim >= 4) ? output_sizes[ndim - 2] : 0;
+  int64_t input_width = input_sizes[ndim - 1];
+  int64_t output_width = output_sizes[ndim - 1];
+
+  auto loop1d = [&](char** data, const int64_t* strides, int64_t n) {
+    auto grad_input_data = (scalar_t*)data[0];
+    auto grad_output_data = (scalar_t*)data[1];
+
+    int64_t c = 0;
+    int64_t ow = 0;
+    int64_t offset = grad_output_data - grad_output_data_base;
+    data_index_init(offset, c, channels, ow, output_width);
+
+    for (int64_t i = 0; i < n; i++) {
+      int64_t iw = nearest_idx(ow, input_width, output_width, scales[0]);
+      grad_input_data[c * input_width + iw] += grad_output_data[i];
+      data_index_step(c, channels, ow, output_width);
+    }
+  };
+
+  auto loop2d = [&](char** data, const int64_t* strides, int64_t n) {
+    auto grad_input_data = (scalar_t*)data[0];
+    auto grad_output_data = (scalar_t*)data[1];
+
+    int64_t c = 0;
+    int64_t oh = 0;
+    int64_t ow = 0;
+    int64_t offset = grad_output_data - grad_output_data_base;
+    data_index_init(offset, c, channels, oh, output_height, ow, output_width);
+
+    for (int64_t i = 0; i < n; i++) {
+      int64_t ih = nearest_idx(oh, input_height, output_height, scales[0]);
+      int64_t iw = nearest_idx(ow, input_width, output_width, scales[1]);
+      grad_input_data[c * input_height * input_width + ih * input_width + iw] += grad_output_data[i];
+      data_index_step(c, channels, oh, output_height, ow, output_width);
+    }
+  };
+
+  auto loop3d = [&](char** data, const int64_t* strides, int64_t n) {
+    auto grad_input_data = (scalar_t*)data[0];
+    auto grad_output_data = (scalar_t*)data[1];
+
+    int64_t c = 0;
+    int64_t od = 0;
+    int64_t oh = 0;
+    int64_t ow = 0;
+    int64_t offset = grad_output_data - grad_output_data_base;
+    data_index_init(offset, c, channels, od, output_depth, oh, output_height, ow, output_width);
+
+    for (int64_t i = 0; i < n; i++) {
+      int64_t id = nearest_idx(od, input_depth, output_depth, scales[0]);
+      int64_t ih = nearest_idx(oh, input_height, output_height, scales[1]);
+      int64_t iw = nearest_idx(ow, input_width, output_width, scales[2]);
+      int64_t j = c * input_depth * input_height * input_width +
+                  id * input_height * input_width + ih * input_width + iw;
+      grad_input_data[j] += grad_output_data[i];
+      data_index_step(c, channels, od, output_depth, oh, output_height, ow, output_width);
+    }
+  };
+
+  std::vector<int64_t> strides(input_sizes.size(), 0);
+  auto grad_input_expand = grad_input.as_strided(output_sizes, strides);
+
+  auto iter = TensorIterator();
+  iter.add_output(grad_input_expand);
+  iter.add_input(grad_output);
+  iter.build();
+
+  if (ndim == 3) {
+    // upsample nearest 1d
+    iter.for_each(loop1d);
+  } else if (ndim == 4) {
+    // upsample nearest 2d
+    iter.for_each(loop2d);
+  } else {
+    // upsample nearest 3d
+    iter.for_each(loop3d);
+  }
+
+  if (!grad_input_.is_contiguous()) {
+    grad_input_.copy_(grad_input);
+  }
+}
+
+using scale_t = std::vector<double>;
+void upsample_nearest1d_kernel_impl(Tensor& output, const Tensor& input, double scales_1) {
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(), "upsample_nearest1d", [&] {
+    cpu_upsample_nearest<scalar_t, scale_t>(output, input, {scales_1});
+  });
+}
+
+void upsample_nearest2d_kernel_impl(Tensor& output, const Tensor& input, double scales_1, double scales_2) {
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(), "upsample_nearest2d", [&] {
+    cpu_upsample_nearest<scalar_t, scale_t>(output, input, {scales_1, scales_2});
+  });
+}
+
+void upsample_nearest3d_kernel_impl(Tensor& output, const Tensor& input, double scales_1, double scales_2, double scales_3) {
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(), "upsample_nearest3d", [&] {
+    cpu_upsample_nearest<scalar_t, scale_t>(output, input, {scales_1, scales_2, scales_3});
+  });
+}
+
+void upsample_nearest1d_backward_kernel_impl(Tensor& grad_input, const Tensor& grad_output, double scales_1) {
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(grad_output.scalar_type(), "upsample_nearest1d_backward", [&] {
+    cpu_upsample_nearest_backward<scalar_t, scale_t>(grad_input, grad_output, {scales_1});
+  });
+}
+
+void upsample_nearest2d_backward_kernel_impl(Tensor& grad_input, const Tensor& grad_output, double scales_1,  double scales_2) {
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(grad_output.scalar_type(), "upsample_nearest2d_backward", [&] {
+    cpu_upsample_nearest_backward<scalar_t, scale_t>(grad_input, grad_output, {scales_1, scales_2});
+  });
+}
+
+void upsample_nearest3d_backward_kernel_impl(Tensor& grad_input, const Tensor& grad_output, double scales_1, double scales_2, double scales_3) {
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(grad_output.scalar_type(), "upsample_nearest3d_backward", [&] {
+    cpu_upsample_nearest_backward<scalar_t, scale_t>(grad_input, grad_output, {scales_1, scales_2, scales_3});
+  });
+}
+
+
+} // anonymous namespace
+
+REGISTER_DISPATCH(upsample_nearest1d_kernel, &upsample_nearest1d_kernel_impl);
+REGISTER_DISPATCH(upsample_nearest2d_kernel, &upsample_nearest2d_kernel_impl);
+REGISTER_DISPATCH(upsample_nearest3d_kernel, &upsample_nearest3d_kernel_impl);
+REGISTER_DISPATCH(upsample_nearest1d_backward_kernel, &upsample_nearest1d_backward_kernel_impl);
+REGISTER_DISPATCH(upsample_nearest2d_backward_kernel, &upsample_nearest2d_backward_kernel_impl);
+REGISTER_DISPATCH(upsample_nearest3d_backward_kernel, &upsample_nearest3d_backward_kernel_impl);
+
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/native/cpu/UpSampleKernel.cpp
+++ b/aten/src/ATen/native/cpu/UpSampleKernel.cpp
@@ -261,37 +261,61 @@ void cpu_upsample_nearest_backward(
 }
 
 using scale_t = std::vector<double>;
-void upsample_nearest1d_kernel_impl(Tensor& output, const Tensor& input, double scales_1) {
+void upsample_nearest1d_kernel_impl(
+    Tensor& output,
+    const Tensor& input,
+    double scales_1) {
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(), "upsample_nearest1d", [&] {
     cpu_upsample_nearest<scalar_t, scale_t>(output, input, {scales_1});
   });
 }
 
-void upsample_nearest2d_kernel_impl(Tensor& output, const Tensor& input, double scales_1, double scales_2) {
+void upsample_nearest2d_kernel_impl(
+    Tensor& output,
+    const Tensor& input,
+    double scales_1,
+    double scales_2) {
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(), "upsample_nearest2d", [&] {
     cpu_upsample_nearest<scalar_t, scale_t>(output, input, {scales_1, scales_2});
   });
 }
 
-void upsample_nearest3d_kernel_impl(Tensor& output, const Tensor& input, double scales_1, double scales_2, double scales_3) {
+void upsample_nearest3d_kernel_impl(
+    Tensor& output,
+    const Tensor& input,
+    double scales_1,
+    double scales_2,
+    double scales_3) {
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(), "upsample_nearest3d", [&] {
     cpu_upsample_nearest<scalar_t, scale_t>(output, input, {scales_1, scales_2, scales_3});
   });
 }
 
-void upsample_nearest1d_backward_kernel_impl(Tensor& grad_input, const Tensor& grad_output, double scales_1) {
+void upsample_nearest1d_backward_kernel_impl(
+    Tensor& grad_input,
+    const Tensor& grad_output,
+    double scales_1) {
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(grad_output.scalar_type(), "upsample_nearest1d_backward", [&] {
     cpu_upsample_nearest_backward<scalar_t, scale_t>(grad_input, grad_output, {scales_1});
   });
 }
 
-void upsample_nearest2d_backward_kernel_impl(Tensor& grad_input, const Tensor& grad_output, double scales_1,  double scales_2) {
+void upsample_nearest2d_backward_kernel_impl(
+    Tensor& grad_input,
+    const Tensor& grad_output,
+    double scales_1,
+    double scales_2) {
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(grad_output.scalar_type(), "upsample_nearest2d_backward", [&] {
     cpu_upsample_nearest_backward<scalar_t, scale_t>(grad_input, grad_output, {scales_1, scales_2});
   });
 }
 
-void upsample_nearest3d_backward_kernel_impl(Tensor& grad_input, const Tensor& grad_output, double scales_1, double scales_2, double scales_3) {
+void upsample_nearest3d_backward_kernel_impl(
+    Tensor& grad_input,
+    const Tensor& grad_output,
+    double scales_1,
+    double scales_2,
+    double scales_3) {
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(grad_output.scalar_type(), "upsample_nearest3d_backward", [&] {
     cpu_upsample_nearest_backward<scalar_t, scale_t>(grad_input, grad_output, {scales_1, scales_2, scales_3});
   });


### PR DESCRIPTION
This PR aims at improving `UpSample` performance with `mode='nearest'` on 1D 2D and 3D, both inference and training are covered. Current implementation from 'ATen' doesn't have parallelization.

1. single socket inference speedup for 1d, 2d and 3d: **63x, 57x, 46x**.
2. single core inference speedup for 1d, 2d and 3d: **5.9x, 4.6x, 3.4x**.
3. dual sockets training speedup for 1d, 2d and 3d: **38x, 33x, 65x**