### PR TITLE
Make fully_qualified_type_name_impl() compatible with VS2017 15.9

### DIFF
--- a/c10/util/TypeIndex.h
+++ b/c10/util/TypeIndex.h
@@ -60,8 +60,8 @@ template <typename T>
 inline C10_TYPENAME_CONSTEXPR string_view fully_qualified_type_name_impl() noexcept {
 #if defined(_MSC_VER) && !defined(__clang__)
   return extract(
-      "class c10::string_view __cdecl c10::util::detail::fully_qualified_type_name_impl<",
-      ">(void)",
+      "class c10::basic_string_view<char> __cdecl c10::util::detail::fully_qualified_type_name_impl<",
+      ">(void) noexcept",
       __FUNCSIG__);
 #elif defined(__clang__)
   return extract(


### PR DESCRIPTION
Summary: In 15.9, __FUNCSIG__ unwraps using definitions as well as preserves noexcept qualifiers

Test Plan: Build caffe2 on Windows using VS2017

Differential Revision: D19166204

