### PR TITLE
Bug fix of norm minimization for dev mode

### DIFF
--- a/caffe2/quantization/server/norm_minimization.cc
+++ b/caffe2/quantization/server/norm_minimization.cc
@@ -41,7 +41,6 @@ GetNorm(float begin, float end, float density, NormMinimization::Kind kind) {
   return density * norm;
 }
 
-
 // Filter out outliers in input distributions
 // Exploit the input distributions for the quick search
 TensorQuantizationParams NormMinimization::NonlinearQuantizationParamsSearch(
@@ -58,6 +57,11 @@ TensorQuantizationParams NormMinimization::NonlinearQuantizationParamsSearch(
   vector<float> bins_f(dnnlowp::adjust_hist_to_include_zero(hist, &min, &max));
   int nbins = bins_f.size();
   float bin_width = (max - min) / nbins;
+  if (bin_width == 0) {
+    QuantizationFactory* qfactory = QuantizationFactory::GetDefaultInstance();
+    return qfactory->ChooseQuantizationParams(
+        min, max, precision, preserve_sparsity);
+  }
   int dst_nbins = 1 << precision;
 
   float org_max = max;


### PR DESCRIPTION
Summary: Fix the divide by zero issue in norm minimization in dev mode

Test Plan: buck run mode/dev vision/video_modeling/classification/tools:test_octGloRe_quantization -- --test_data=/mnt/vol/gfsadslearner-frc3c01/fblearner_flow/users/summerdeng/xray_video/deep_vision_video_yufei_test_data_fcc_v4p2_10.csv --output_dir /mnt/vol/gfsadslearner-frc3c01/fblearner_flow/users/summerdeng/xray_video/octGloRe --load_model_path=/mnt/vol/gfsfblearner-oregon/flow/data/2019-10-15/e2681db8-e4f5-4b70-ae18-45bf0b8fbfbc/train_model_epoch0_inputcount0_final.mdl --dataset_name="FCC V4P2" --num_labels=1099 --column_handle="handle" --clip_per_video=1 --num_groups=24 --width_per_group=2 --batch_size=32 --histogram_file=/mnt/vol/gfsadslearner-frc3c01/fblearner_flow/users/summerdeng/xray_video/octGloRe/hist_octGloRe_final_24x2_fcc_v4p2_1clip_f144586257_nullfix_100k_compiled.hist --int8_model_type="pb"  --int8_predict_net_path="reproduce_octGloRe_final_24x2_predict_net_int8_l2approx_wminmax_from_mdl.pb" --int8_init_net_path="reproduce_octGloRe_final_24x2_init_net_int8_l2approx_wminmax_from_mdl.pb" --weight_quant="l2_approx" --activation_quant="l2_approx"  --print_model --int8_model_saved --num_iter 10

Differential Revision: D19172591

