### PR TITLE
Better error msg for autograd profiler + multi-worker dataloader crash

### DIFF
--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -233,6 +233,12 @@ class profile(object):
         This context managers should not be called recursively, i.e. at most one
         instance should be enabled at any given time.
 
+    .. warning:
+        Due to some CUDA multiprocessing limitations (multiprocessing-cuda-note_),
+        one cannot use the profiler with ``use_cuda = True`` to benchmark
+        DataLoaders with ``num_workers > 0``. If you wish to benchmark data loading,
+        please use ``use_cuda = False`` or ``num_workers = 0``.
+
     Example:
         >>> x = torch.randn((1, 1), requires_grad=True)
         >>> with torch.autograd.profiler.profile() as prof:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#31473 Better error msg for autograd profiler + multi-worker dataloader crash**

Mitigates #6313

A common use case for the autograd profiler is to use it to run over an
entire model, including dataloading. The following will crash:
- run autograd profiler in CUDA mode
- Use a multi-worker DataLoader (presumably with the 'fork' spawn
method)
- because the autograd profiler initializes CUDA and forking after CUDA is
initialized is bad.

This PR puts in a nice error message when this happens so that users
aren't too confused. The new error message looks like:
https://gist.github.com/zou3519/903f15c3e86bad4585b7e5ce14cc1b70

Test Plan:
- Tested locally.
- I didn't add a test case for this because it's hard to write a test
case that doesn't completely stop the rest of our test suite from
running.

Differential Revision: [D19178080](https://our.internmc.facebook.com/intern/diff/D19178080)