### PR TITLE
Added error message to indicate that reduction operations are not supported for dim>=64

### DIFF
--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -41,6 +41,9 @@ static inline Tensor integer_upcast(const Tensor& self, optional<ScalarType> dty
 using DimMask = TensorIterator::DimMask;
 
 static DimMask make_dim_mask(IntArrayRef dims, int64_t ndim) {
+  for(size_t idx =0; idx=dims.size(); idx++) {
+    TORCH_CHECK(dims[idx]<64, "PyTorch doesn't support reduction operations for dim>=64");
+  }
   auto mask = DimMask();
   if (dims.empty()) {
     mask.flip();

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -41,14 +41,12 @@ static inline Tensor integer_upcast(const Tensor& self, optional<ScalarType> dty
 using DimMask = TensorIterator::DimMask;
 
 static DimMask make_dim_mask(IntArrayRef dims, int64_t ndim) {
-  for(size_t idx =0; idx=dims.size(); idx++) {
-    TORCH_CHECK(dims[idx]<64, "PyTorch doesn't support reduction operations for dim>=64");
-  }
   auto mask = DimMask();
   if (dims.empty()) {
     mask.flip();
   } else {
     for (int64_t dim : dims) {
+      TORCH_CHECK(dim < 64, "PyTorch doesn't support reduction operations for dim>=64");
       mask.set(maybe_wrap_dim(dim, ndim));
     }
   }

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -677,6 +677,12 @@ class _TestTorchMixin(object):
         torch.sum(x, 0, out=y)
         self.assertEqual(x.sum(0, dtype=torch.uint8), y)
 
+    def test_dim_reduction_less_than_64(self):
+        sizes = [1]*65
+        x = torch.randn(sizes)
+        with self.assertRaisesRegex(RuntimeError, "PyTorch doesn't support reduction operations for dim>=64"):
+            torch.sum(x, 64)
+
     @unittest.skipIf(not TEST_SCIPY, "Scipy not found")
     def test_logsumexp(self):
         from scipy.special import logsumexp
@@ -5324,7 +5330,7 @@ tensor([[[1., 1., 1.,  ..., 1., 1., 1.],
             tensor[0] = np_val
             self.assertEqual(tensor[0], np_val)
 
-            # Original reported issue, np integral type parses to the correct 
+            # Original reported issue, np integral type parses to the correct
             # PyTorch integral type when passed for a `Scalar` parameter in
             # arithmetic operations:
             t = torch.from_numpy(np_arr)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -678,7 +678,7 @@ class _TestTorchMixin(object):
         self.assertEqual(x.sum(0, dtype=torch.uint8), y)
 
     def test_dim_reduction_less_than_64(self):
-        sizes = [1]*65
+        sizes = [1] * 65
         x = torch.randn(sizes)
         with self.assertRaisesRegex(RuntimeError, "PyTorch doesn't support reduction operations for dim>=64"):
             torch.sum(x, 64)


### PR DESCRIPTION
Reference: https://github.com/pytorch/pytorch/issues/23159
Currently we don't support reduction operations for dim>=64 and we should give a descriptive RuntimeError indicating the same
Diff: D19179039