### PR TITLE
Error out if legacy Tensor.new is called on alternate layouts / dtypes

### DIFF
--- a/test/test_mkldnn.py
+++ b/test/test_mkldnn.py
@@ -394,6 +394,16 @@ class TestMkldnn(TestCase):
         self.assertFalse(x.is_mkldnn)
         self.assertTrue(x.to_mkldnn().is_mkldnn)
 
+    # legacy constructor/new doesn't support mkldnn tensors
+    def test_legacy_new_failure(self):
+        x = torch.randn(1, dtype=torch.float32)
+        x_mkldnn = x.to_mkldnn()
+        self.assertRaises(RuntimeError, lambda: x_mkldnn.new(device='cpu'))
+        self.assertRaises(RuntimeError, lambda: x_mkldnn.new(x.storage()))
+        self.assertRaises(RuntimeError, lambda: x_mkldnn.new(x))
+        self.assertRaises(RuntimeError, lambda: x_mkldnn.new(torch.Size([2, 3])))
+        self.assertRaises(RuntimeError, lambda: x_mkldnn.new([6]))
+
     def test_is_mkldnn_jit(self):
         class EnsureMkldnn(torch.jit.ScriptModule):
             @torch.jit.script_method

--- a/test/test_quantized_tensor.py
+++ b/test/test_quantized_tensor.py
@@ -70,6 +70,18 @@ class TestQuantizedTensor(TestCase):
         rqr = qr.dequantize()
         self.assertTrue(np.allclose(r.numpy(), rqr.numpy(), atol=2 / scale))
 
+    # legacy constructor/new doesn't support qtensors
+    def test_qtensor_legacy_new_failure(self):
+        r = torch.rand(3, 2, dtype=torch.float) * 4 - 2
+        scale = 0.02
+        zero_point = 2
+        qr = torch.quantize_per_tensor(r, scale, zero_point, torch.quint8)
+        self.assertRaises(RuntimeError, lambda: qr.new(device='cpu'))
+        self.assertRaises(RuntimeError, lambda: qr.new(r.storage()))
+        self.assertRaises(RuntimeError, lambda: qr.new(r))
+        self.assertRaises(RuntimeError, lambda: qr.new(torch.Size([2, 3])))
+        self.assertRaises(RuntimeError, lambda: qr.new([6]))
+
     def test_per_channel_qtensor_creation(self):
         numel = 10
         ch_axis = 0

--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -18,6 +18,8 @@
 #include <ATen/ATen.h>
 #include <ATen/InitialTensorOptions.h>
 #include <ATen/NamedTensorUtils.h>
+#include <c10/core/Backend.h>
+#include <c10/core/Layout.h>
 #include <c10/util/Exception.h>
 #include <c10/util/Optional.h>
 
@@ -319,6 +321,31 @@ Tensor legacy_new_from_sequence(
   return internal_new_from_data(type_id, scalar_type, std::move(device), data, false, false, false);
 }
 
+// "base" here refers to the Tensor type on which the function was invoked, e.g.:
+// in x.new(y), 'x' is the base.
+void check_base_legacy_new(c10::TensorTypeId type_id, at::Layout expected_layout) {
+  auto backend = c10::tensorTypeIdToBackend(type_id);
+  if (expected_layout == c10::kStrided) {
+    TORCH_CHECK(type_id == c10::TensorTypeId::CPUTensorId
+                || type_id == c10::TensorTypeId::CUDATensorId
+                || type_id == c10::TensorTypeId::HIPTensorId,
+                "new(): expected TensorTypeId: ", c10::TensorTypeId::CPUTensorId,
+                " or ", c10::TensorTypeId::CUDATensorId,
+                " or ", c10::TensorTypeId::HIPTensorId,
+                " but got: ", type_id);
+  } else if(expected_layout == c10::kSparse) {
+    TORCH_CHECK(type_id == c10::TensorTypeId::SparseCPUTensorId
+                || type_id == c10::TensorTypeId::SparseCUDATensorId
+                || type_id == c10::TensorTypeId::SparseHIPTensorId,
+                "new(): expected TensorTypeId: ", c10::TensorTypeId::SparseCPUTensorId,
+                " or ", c10::TensorTypeId::SparseCUDATensorId,
+                " or ", c10::TensorTypeId::SparseHIPTensorId,
+                " but got: ", type_id);
+  } else {
+    TORCH_INTERNAL_ASSERT(false, "unexpected layout");
+  }
+}
+
 void check_legacy_ctor_device(c10::TensorTypeId type_id, c10::optional<Device> device) {
   if (device.has_value()) {
     TORCH_CHECK(computeDeviceType(type_id) == device.value().type(),
@@ -377,6 +404,7 @@ Tensor legacy_sparse_tensor_new(c10::TensorTypeId type_id, at::ScalarType scalar
     "new(Tensor indices, Tensor values, IntArrayRef size, *, Device? device=None)",
     "new(IntArrayRef size, *, Device? device=None)",
   });
+  check_base_legacy_new(type_id, c10::kSparse);
   ParsedArgs<5> parsed_args;
   auto r = parser.parse(args, kwargs, parsed_args);
   if (r.idx == 0) {
@@ -488,6 +516,7 @@ Tensor legacy_tensor_new(c10::TensorTypeId type_id, at::ScalarType scalar_type, 
     return legacy_sparse_tensor_new(type_id, scalar_type, args, kwargs);
   }
 
+  check_base_legacy_new(type_id, c10::kStrided);
   ParsedArgs<3> parsed_args;
   auto r = parser.parse(args, kwargs, parsed_args);
   if (r.idx == 0) {

--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -324,16 +324,18 @@ Tensor legacy_new_from_sequence(
 // "base" here refers to the Tensor type on which the function was invoked, e.g.:
 // in x.new(y), 'x' is the base.
 void check_base_legacy_new(c10::TensorTypeId type_id, at::Layout expected_layout) {
-  auto backend = c10::tensorTypeIdToBackend(type_id);
   if (expected_layout == c10::kStrided) {
     TORCH_CHECK(type_id == c10::TensorTypeId::CPUTensorId
                 || type_id == c10::TensorTypeId::CUDATensorId
-                || type_id == c10::TensorTypeId::HIPTensorId,
+                || type_id == c10::TensorTypeId::HIPTensorId
+                || type_id == c10::XLATensorId(),
                 "new(): expected TensorTypeId: ", c10::TensorTypeId::CPUTensorId,
                 " or ", c10::TensorTypeId::CUDATensorId,
                 " or ", c10::TensorTypeId::HIPTensorId,
+                " or ", c10::TensorTypeId::XLATensorId,
                 " but got: ", type_id);
   } else if(expected_layout == c10::kSparse) {
+    // NOTE: no sparse XLA
     TORCH_CHECK(type_id == c10::TensorTypeId::SparseCPUTensorId
                 || type_id == c10::TensorTypeId::SparseCUDATensorId
                 || type_id == c10::TensorTypeId::SparseHIPTensorId,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #31490 Ensure legacy sparse constructor/new doesn't interpret python data as tensor data.
* **#31485 Error out if legacy Tensor.new is called on alternate layouts / dtypes**

Fixes: https://github.com/pytorch/pytorch/issues/22158

Differential Revision: [D19196499](https://our.internmc.facebook.com/intern/diff/D19196499)