### PR TITLE
[Doc Update] Updated documentation for NLLLoss to explain what x, y and w refer to

### DIFF
--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -117,7 +117,7 @@ class NLLLoss(_WeightedLoss):
         l_n = - w_{y_n} x_{n,y_n}, \quad
         w_{c} = \text{weight}[c] \cdot \mathbb{1}\{c \not= \text{ignore\_index}\},
 
-    where :math:`N` is the batch size and :math:y_n is the value of target at index n. If :attr:`reduction` is not ``'none'``
+    where :math:`N` is the batch size and :math:`y_n` is the value of target at index n. If :attr:`reduction` is not ``'none'``
     (default ``'mean'``), then
 
     .. math::

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -117,7 +117,7 @@ class NLLLoss(_WeightedLoss):
         l_n = - w_{y_n} x_{n,y_n}, \quad
         w_{c} = \text{weight}[c] \cdot \mathbb{1}\{c \not= \text{ignore\_index}\},
 
-    where :math:`N` is the batch size and :math:`y_n` is the value of target at index n. If :attr:`reduction` is not ``'none'``
+    where :math:`x` is the input, :math:`y` is the target, :math:`w` is the weight, and :math:`N` is the batch size. If :attr:`reduction` is not ``'none'``
     (default ``'mean'``), then
 
     .. math::

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -117,7 +117,7 @@ class NLLLoss(_WeightedLoss):
         l_n = - w_{y_n} x_{n,y_n}, \quad
         w_{c} = \text{weight}[c] \cdot \mathbb{1}\{c \not= \text{ignore\_index}\},
 
-    where :math:`N` is the batch size. If :attr:`reduction` is not ``'none'``
+    where :math:`N` is the batch size and :math:y_n is the value of target at index n. If :attr:`reduction` is not ``'none'``
     (default ``'mean'``), then
 
     .. math::

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -117,7 +117,8 @@ class NLLLoss(_WeightedLoss):
         l_n = - w_{y_n} x_{n,y_n}, \quad
         w_{c} = \text{weight}[c] \cdot \mathbb{1}\{c \not= \text{ignore\_index}\},
 
-    where :math:`x` is the input, :math:`y` is the target, :math:`w` is the weight, and :math:`N` is the batch size. If :attr:`reduction` is not ``'none'``
+    where :math:`x` is the input, :math:`y` is the target, :math:`w` is the weight, and
+    :math:`N` is the batch size. If :attr:`reduction` is not ``'none'``
     (default ``'mean'``), then
 
     .. math::


### PR DESCRIPTION
Reference: https://github.com/pytorch/pytorch/issues/31385

In the current documentation for NLLLoss, it's unclear what `y` refers to in the math section of the loss description. There was an issue(https://github.com/pytorch/pytorch/issues/31295) filed earlier where there was a confusion if the loss returned for reduction=mean is right or not, perhaps because of lack in clarity of formula symbol description in the current documentation. 
