### PR TITLE
make: Switch to $(RM) variable to force `rm -f`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ ios:
 	@./scripts/build_ios.sh
 
 clean: # This will remove ALL build folders.
-	@rm -r build*/
+	@$(RM) -r build*/
 
 linecount:
 	@cloc --read-lang-def=caffe.cloc caffe2 || \


### PR DESCRIPTION
The `make clean` target previously would fail when no `build/` directory
existed due to only using the `rm` command. `$(RM)` is a built in
variable to make that automatically points to `rm -f` on most machines.
With the `-f` flag `make clean` will no longer fail when the `build/`
directory does not exist.

Before change:
```
> make clean
rm: cannot remove ‘build*/’: No such file or directory
make: *** [Makefile:16: clean] Error 1
```

After change:
```
> make clean
```

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

