### PR TITLE
modify model to enable loading by blob

### DIFF
--- a/caffe2/opt/bound_shape_inferencer.cc
+++ b/caffe2/opt/bound_shape_inferencer.cc
@@ -160,7 +160,11 @@ TensorShape& BoundShapeInferencer::CheckAndSetTensorBoundShape(
   }
   if (!rt.second) {
     // Check shape consistency
-    CAFFE_ENFORCE_EQ(shape.dims_size(), bound_dims.size());
+    CAFFE_ENFORCE_EQ(
+        shape.dims_size(),
+        bound_dims.size(),
+        "Dim size inconsistency found in tensor ",
+        name);
     // For shapes that was provided as a hint at the input of the net, fix the
     // batch size first.
     if ((!shape_info.dimTypeIsSet() ||


### PR DESCRIPTION
Summary:
This script is used to generate a model with bound shape inference and
blob reorder, which are requirements for big model loading on T17.
1. Load existing model.
2. Do bound shape inference and blob reorder (put embedding blobs at the end).
3. Save the modified model.

Test Plan:
Generated a new moel and tested on NNPI.
P124181047 (mismatch is AA variance)

Differential Revision: D19165467

