### PR TITLE
Put sparse all reduce results to input tensors

### DIFF
--- a/test/test_c10d.py
+++ b/test/test_c10d.py
@@ -944,9 +944,10 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
                 self.world_size,
                 num_inputs=num_inputs_per_rank)
             for (inputs, outputs) in tests:
-                work = pg.allreduce([fn(input) for input in inputs])
+                tensors = [fn(input) for input in inputs]
+                work = pg.allreduce(tensors)
                 work.wait()
-                self.assertEqual(work.result(), outputs)
+                self.assertEqual(tensors, outputs)
 
     def test_sparse_allreduce_basics(self):
         self._test_sparse_allreduce_basics(lambda t: t)

--- a/torch/lib/c10d/ProcessGroupGloo.cpp
+++ b/torch/lib/c10d/ProcessGroupGloo.cpp
@@ -976,6 +976,7 @@ class AsyncSparseAllreduceWork : public ProcessGroupGloo::AsyncWork {
     // Copy back to input tensors.
     outputs.reserve(inputs.size());
     for (size_t i = 0; i < inputs.size(); i++) {
+      inputs[i].copy_(output);
       if (output.is_sparse()) {
         outputs.push_back(output.clone());
       } else {
@@ -1199,6 +1200,7 @@ class AsyncSparseAllreduceCUDAWork : public AsyncSparseAllreduceWork {
     for (size_t i = 0; i < inputs.size(); i++) {
       stream_guard.reset_stream(streams[i]);
       outputs.push_back(output.to(inputs[i].device(), /*non_blocking=*/true));
+      inputs[i].copy_(output, /* non_blocking */ true);
       events[i].record(streams[i]);
     }
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#31511 Put sparse all reduce results to input tensors**

right now if users call torch.dist.all_reduce() on dense tensors, outputs are put in input tensors. but if users call torch.dist.all_reduce() on sparse tensors, outputs are neither returned explicitly to users nor are put in input tensors.

To make torch.dist.all_reduce() API have same behavior on both dense tensors and sparse tensors, this diff is made to make torch.dist.all_reduce() on sparse tensors to put output in input tensors as well.

close #31413

Differential Revision: [D19192952](https://our.internmc.facebook.com/intern/diff/D19192952/)