### PR TITLE
cuDNN conv add bias 32bit split

### DIFF
--- a/aten/src/ATen/native/cudnn/Conv.cpp
+++ b/aten/src/ATen/native/cudnn/Conv.cpp
@@ -747,10 +747,10 @@ void cudnn_convolution_add_bias_(CheckedFrom c, const TensorArg& output, const T
   }
 
   int64_t n = output.tensor.size(0);
-  int64_t inner_dim = output_numel / n;
-  TORCH_INTERNAL_ASSERT(inner_dim <= int_max, "This case should not be dispatched to cuDNN.");
+  int64_t inner_size = output_numel / n;
+  TORCH_INTERNAL_ASSERT(inner_size <= int_max, "This case should not be dispatched to cuDNN.");
   constexpr int64_t max_worksize = 1024 * 1024 * 512;
-  int64_t split_size = std::max<int64_t>(max_worksize / max_inner_size, 1L);
+  int64_t split_size = std::max<int64_t>(max_worksize / inner_size, 1L);
   int64_t num_splits = (n + split_size - 1) / split_size;
 
   for (int64_t i = 0; i < num_splits; i++) {

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9314,19 +9314,14 @@ class TestNNDeviceType(NNTestCase):
             self.assertEqual(out1, out2)
 
     @unittest.skipIf(not TEST_LARGE_TENSOR, "not enough memory to run test")
-    def test_conv_transposed_large(self, device):
+    def test_conv_large(self, device):
         dtype = torch.half if self.device_type == 'cuda' else torch.float
-        conv = nn.ConvTranspose2d(1, 1, 1, 1, bias=True).to(device).to(dtype)
-        input_large = torch.randn(4096, 1, 512, 1024, dtype=dtype, device=device)
+        conv = nn.Conv2d(2, 2, 1, 1, bias=True).to(device).to(dtype)
+        input_large = torch.randn(4096, 2, 512, 512, dtype=dtype, device=device)
         ret = conv(input_large)
-        maxdiff0 = (ret.narrow(0, 0, 1024) - conv(input_large.narrow(0, 0, 1024))).abs_().max().item()
-        maxdiff1 = (ret.narrow(0, 1024, 1024) - conv(input_large.narrow(0, 1024, 1024))).abs_().max().item()
-        maxdiff2 = (ret.narrow(0, 2048, 1024) - conv(input_large.narrow(0, 2048, 1024))).abs_().max().item()
-        maxdiff3 = (ret.narrow(0, 3072, 1024) - conv(input_large.narrow(0, 3072, 1024))).abs_().max().item()
-        self.assertEqual(maxdiff0, 0)
-        self.assertEqual(maxdiff1, 0)
-        self.assertEqual(maxdiff2, 0)
-        self.assertEqual(maxdiff3, 0)
+        print(ret.shape)
+        self.assertEqual(ret[:2048], conv(input_large[:2048]))
+        self.assertEqual(ret[2048:], conv(input_large[2048:]))
 
     def _test_gumbel_softmax_st_shapes(self, device, dtype, shape, dim, count_expected):
         logits = torch.randn(shape, dtype=torch.float, device=device)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9313,6 +9313,21 @@ class TestNNDeviceType(NNTestCase):
             out2 = conv1(input_c)
             self.assertEqual(out1, out2)
 
+    @unittest.skipIf(not TEST_LARGE_TENSOR, "not enough memory to run test")
+    def test_conv_transposed_large(self, device):
+        dtype = torch.half if self.device_type == 'cuda' else torch.float
+        conv = nn.ConvTranspose2d(1, 1, 1, 1, bias=True).to(device).to(dtype)
+        input_large = torch.randn(4096, 1, 512, 1024, dtype=dtype, device=device)
+        ret = conv(input_large)
+        maxdiff0 = (ret.narrow(0, 0, 1024) - conv(input_large.narrow(0, 0, 1024))).abs_().max().item()
+        maxdiff1 = (ret.narrow(0, 1024, 1024) - conv(input_large.narrow(0, 1024, 1024))).abs_().max().item()
+        maxdiff2 = (ret.narrow(0, 2048, 1024) - conv(input_large.narrow(0, 2048, 1024))).abs_().max().item()
+        maxdiff3 = (ret.narrow(0, 3072, 1024) - conv(input_large.narrow(0, 3072, 1024))).abs_().max().item()
+        self.assertEqual(maxdiff0, 0)
+        self.assertEqual(maxdiff1, 0)
+        self.assertEqual(maxdiff2, 0)
+        self.assertEqual(maxdiff3, 0)
+
     def _test_gumbel_softmax_st_shapes(self, device, dtype, shape, dim, count_expected):
         logits = torch.randn(shape, dtype=torch.float, device=device)
         logits = logits.to(dtype)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9319,9 +9319,9 @@ class TestNNDeviceType(NNTestCase):
         conv = nn.Conv2d(2, 2, 1, 1, bias=True).to(device).to(dtype)
         input_large = torch.randn(4096, 2, 512, 512, dtype=dtype, device=device)
         ret = conv(input_large)
-        print(ret.shape)
-        self.assertEqual(ret[:2048], conv(input_large[:2048]))
-        self.assertEqual(ret[2048:], conv(input_large[2048:]))
+        for i in range(4096 // 128):
+            maxdiff = (ret.narrow(0, 128 * i, 128) - conv(input_large.narrow(0, 128 * i, 128))).abs_().max().item()
+            self.assertEqual(maxdiff, 0)
 
     def _test_gumbel_softmax_st_shapes(self, device, dtype, shape, dim, count_expected):
         logits = torch.randn(shape, dtype=torch.float, device=device)


### PR DESCRIPTION
Changes in `Conv.cpp` is independent, but the test requires https://github.com/pytorch/pytorch/pull/31379 to pass. The test for large tensor is never run on our CI, so we could land this independently with #31379 ... (I have tested to merge them locally and test passes)