### PR TITLE
[android][fix] Tensor class created from java does not call native methods

### DIFF
--- a/android/pytorch_android/src/main/java/org/pytorch/Module.java
+++ b/android/pytorch_android/src/main/java/org/pytorch/Module.java
@@ -34,6 +34,7 @@ public class Module {
    * @return return value from the 'forward' method.
    */
   public IValue forward(IValue... inputs) {
+    android.util.Log.i("XXX", "Module.forward mNativePeer:"+mNativePeer+ " inputs:" + inputs);
     return mNativePeer.forward(inputs);
   }
 

--- a/android/pytorch_android/src/main/java/org/pytorch/Module.java
+++ b/android/pytorch_android/src/main/java/org/pytorch/Module.java
@@ -34,7 +34,6 @@ public class Module {
    * @return return value from the 'forward' method.
    */
   public IValue forward(IValue... inputs) {
-    android.util.Log.i("XXX", "Module.forward mNativePeer:"+mNativePeer+ " inputs:" + inputs);
     return mNativePeer.forward(inputs);
   }
 

--- a/android/pytorch_android/src/main/java/org/pytorch/Tensor.java
+++ b/android/pytorch_android/src/main/java/org/pytorch/Tensor.java
@@ -2,6 +2,8 @@ package org.pytorch;
 
 import com.facebook.jni.annotations.DoNotStrip;
 import com.facebook.jni.HybridData;
+import com.facebook.soloader.nativeloader.NativeLoader;
+import com.facebook.soloader.nativeloader.SystemDelegate;
 
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
@@ -31,6 +33,13 @@ import java.util.Locale;
  * is always copied.
  */
 public abstract class Tensor {
+  static {
+    if (!NativeLoader.isInitialized()) {
+      NativeLoader.init(new SystemDelegate());
+    }
+    NativeLoader.loadLibrary("pytorch_jni");
+  }
+
   private static final String ERROR_MSG_DATA_BUFFER_NOT_NULL = "Data buffer must be not null";
   private static final String ERROR_MSG_DATA_ARRAY_NOT_NULL = "Data array must be not null";
   private static final String ERROR_MSG_SHAPE_NOT_NULL = "Shape must be not null";

--- a/android/pytorch_android/src/main/java/org/pytorch/Tensor.java
+++ b/android/pytorch_android/src/main/java/org/pytorch/Tensor.java
@@ -33,13 +33,6 @@ import java.util.Locale;
  * is always copied.
  */
 public abstract class Tensor {
-  static {
-    if (!NativeLoader.isInitialized()) {
-      NativeLoader.init(new SystemDelegate());
-    }
-    NativeLoader.loadLibrary("pytorch_jni");
-  }
-
   private static final String ERROR_MSG_DATA_BUFFER_NOT_NULL = "Data buffer must be not null";
   private static final String ERROR_MSG_DATA_ARRAY_NOT_NULL = "Data array must be not null";
   private static final String ERROR_MSG_SHAPE_NOT_NULL = "Shape must be not null";
@@ -130,7 +123,7 @@ public abstract class Tensor {
     checkShapeAndDataCapacityConsistency(data.length, shape);
     final ByteBuffer byteBuffer = allocateByteBuffer((int) numel(shape));
     byteBuffer.put(data);
-    return initHybrid(new Tensor_uint8(byteBuffer, shape));
+    return new Tensor_uint8(byteBuffer, shape);
   }
 
   /**
@@ -147,7 +140,7 @@ public abstract class Tensor {
     checkShapeAndDataCapacityConsistency(data.length, shape);
     final ByteBuffer byteBuffer = allocateByteBuffer((int) numel(shape));
     byteBuffer.put(data);
-    return initHybrid(new Tensor_int8(byteBuffer, shape));
+    return new Tensor_int8(byteBuffer, shape);
   }
 
   /**
@@ -164,7 +157,7 @@ public abstract class Tensor {
     checkShapeAndDataCapacityConsistency(data.length, shape);
     final IntBuffer intBuffer = allocateIntBuffer((int) numel(shape));
     intBuffer.put(data);
-    return initHybrid(new Tensor_int32(intBuffer, shape));
+    return new Tensor_int32(intBuffer, shape);
   }
 
   /**
@@ -181,7 +174,7 @@ public abstract class Tensor {
     checkShapeAndDataCapacityConsistency(data.length, shape);
     final FloatBuffer floatBuffer = allocateFloatBuffer((int) numel(shape));
     floatBuffer.put(data);
-    return initHybrid(new Tensor_float32(floatBuffer, shape));
+    return new Tensor_float32(floatBuffer, shape);
   }
 
   /**
@@ -198,7 +191,7 @@ public abstract class Tensor {
     checkShapeAndDataCapacityConsistency(data.length, shape);
     final LongBuffer longBuffer = allocateLongBuffer((int) numel(shape));
     longBuffer.put(data);
-    return initHybrid(new Tensor_int64(longBuffer, shape));
+    return new Tensor_int64(longBuffer, shape);
   }
 
   /**
@@ -215,7 +208,7 @@ public abstract class Tensor {
     checkShapeAndDataCapacityConsistency(data.length, shape);
     final DoubleBuffer doubleBuffer = allocateDoubleBuffer((int) numel(shape));
     doubleBuffer.put(data);
-    return initHybrid(new Tensor_float64(doubleBuffer, shape));
+    return new Tensor_float64(doubleBuffer, shape);
   }
 
   /**
@@ -235,7 +228,7 @@ public abstract class Tensor {
     checkArgument(
         (data.order() == ByteOrder.nativeOrder()),
         ERROR_MSG_DATA_BUFFER_MUST_HAVE_NATIVE_BYTE_ORDER);
-    return initHybrid(new Tensor_uint8(data, shape));
+    return new Tensor_uint8(data, shape);
   }
 
   /**
@@ -255,7 +248,7 @@ public abstract class Tensor {
     checkArgument(
         (data.order() == ByteOrder.nativeOrder()),
         ERROR_MSG_DATA_BUFFER_MUST_HAVE_NATIVE_BYTE_ORDER);
-    return initHybrid(new Tensor_int8(data, shape));
+    return new Tensor_int8(data, shape);
   }
 
   /**
@@ -275,7 +268,7 @@ public abstract class Tensor {
     checkArgument(
         (data.order() == ByteOrder.nativeOrder()),
         ERROR_MSG_DATA_BUFFER_MUST_HAVE_NATIVE_BYTE_ORDER);
-    return initHybrid(new Tensor_int32(data, shape));
+    return new Tensor_int32(data, shape);
   }
 
   /**
@@ -295,7 +288,7 @@ public abstract class Tensor {
     checkArgument(
         (data.order() == ByteOrder.nativeOrder()),
         ERROR_MSG_DATA_BUFFER_MUST_HAVE_NATIVE_BYTE_ORDER);
-    return initHybrid(new Tensor_float32(data, shape));
+    return new Tensor_float32(data, shape);
   }
 
   /**
@@ -315,7 +308,7 @@ public abstract class Tensor {
     checkArgument(
         (data.order() == ByteOrder.nativeOrder()),
         ERROR_MSG_DATA_BUFFER_MUST_HAVE_NATIVE_BYTE_ORDER);
-    return initHybrid(new Tensor_int64(data, shape));
+    return new Tensor_int64(data, shape);
   }
 
   /**
@@ -335,17 +328,10 @@ public abstract class Tensor {
     checkArgument(
         (data.order() == ByteOrder.nativeOrder()),
         ERROR_MSG_DATA_BUFFER_MUST_HAVE_NATIVE_BYTE_ORDER);
-    return initHybrid(new Tensor_float64(data, shape));
+    return new Tensor_float64(data, shape);
   }
 
   @DoNotStrip private HybridData mHybridData;
-
-  @DoNotStrip private native HybridData initHybrid();
-
-  private static Tensor initHybrid(Tensor tensor) {
-    tensor.mHybridData = tensor.initHybrid();
-    return tensor;
-  }
 
   private Tensor(long[] shape) {
     checkShape(shape);

--- a/android/pytorch_android/src/main/java/org/pytorch/Tensor.java
+++ b/android/pytorch_android/src/main/java/org/pytorch/Tensor.java
@@ -2,8 +2,6 @@ package org.pytorch;
 
 import com.facebook.jni.annotations.DoNotStrip;
 import com.facebook.jni.HybridData;
-import com.facebook.soloader.nativeloader.NativeLoader;
-import com.facebook.soloader.nativeloader.SystemDelegate;
 
 import java.nio.Buffer;
 import java.nio.ByteBuffer;

--- a/android/test_app/app/src/main/java/org/pytorch/testapp/MainActivity.java
+++ b/android/test_app/app/src/main/java/org/pytorch/testapp/MainActivity.java
@@ -91,9 +91,9 @@ public class MainActivity extends AppCompatActivity {
   @Nullable
   protected Result doModuleForward() {
     if (mModule == null) {
-      mModule = PyTorchAndroid.loadModuleFromAsset(getAssets(), BuildConfig.MODULE_ASSET_NAME);
       mInputTensorBuffer = Tensor.allocateFloatBuffer(3 * 224 * 224);
       mInputTensor = Tensor.fromBlob(mInputTensorBuffer, new long[]{1, 3, 224, 224});
+      mModule = PyTorchAndroid.loadModuleFromAsset(getAssets(), BuildConfig.MODULE_ASSET_NAME);
     }
 
     final long startTime = SystemClock.elapsedRealtime();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#31520 [android][fix] Tensor class created from java does not call native methods**

Differential Revision: [D19199477](https://our.internmc.facebook.com/intern/diff/D19199477)
Fix for the issue: https://github.com/pytorch/pytorch/issues/31419

After this fix `org.pytorch.Tensor` if created from java will not create it's cxx part (at::Tensor) - it will be converted to it lazily during `Module.forward/runMethod` as it was before making Tensor hybrid in https://github.com/pytorch/pytorch/commit/930d0751e6a3006c6251c095ead4dcab71b83d52

Test Plan:
Changes in test_app/MainActivity.java to call Tensor.fromBlob before Module.load
```
      mInputTensor = Tensor.fromBlob(mInputTensorBuffer, new long[]{1, 3, 224, 224});
      mModule = PyTorchAndroid.loadModuleFromAsset(getAssets(), BuildConfig.MODULE_ASSET_NAME);
```
gradle -p android test_app:installMobNet2QuantDebug

Before change - fails, Unsatisfied link error
After - works ok