### PR TITLE
[android] Fix androidTest - exclude host tests from it

### DIFF
--- a/android/pytorch_android/build.gradle
+++ b/android/pytorch_android/build.gradle
@@ -33,6 +33,11 @@ android {
             }
             jniLibs.srcDirs = ['src/main/jniLibs']
         }
+        androidTest {
+            java {
+                exclude 'org/pytorch/PytorchHostTests.java'
+            }
+        }
     }
     externalNativeBuild {
         cmake {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#31522 [android] Fix androidTest - exclude host tests from it**

Differential Revision: [D19200861](https://our.internmc.facebook.com/intern/diff/D19200861)

Test plan
`gradle -p android cAT`