### PR TITLE
port 'scatter_add' to ATen for CPU only.

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -264,7 +264,8 @@
   name: _th_scatter_add_
   return: argument 0
   cname: scatterAdd
-  cpu_bool: True
+  backends:
+    - CUDA
   cuda_bool: True
   variants: function
   arguments:

--- a/aten/src/ATen/native/Indexing.cpp
+++ b/aten/src/ATen/native/Indexing.cpp
@@ -488,6 +488,7 @@ namespace scattergather {
               self_data -= idxCounter[d] * ensure_nonempty_stride(self, d);
               index_data -= idxCounter[d] * ensure_nonempty_stride(index, d);
               src_data -= idxCounter[d] * ensure_nonempty_stride(src, d);
+              idxCounter[d] = 0;
             }
           }
           else {

--- a/aten/src/ATen/native/Indexing.cpp
+++ b/aten/src/ATen/native/Indexing.cpp
@@ -417,11 +417,12 @@ namespace scattergather {
       SizeCheckFunc sizeCheckFunc,
       KernelOpFunc kernelOpFunc
     ) {
-      sizeCheckFunc(self, index, src, dim);
-
       if (index.numel() == 0) {
         return;
       }
+
+      sizeCheckFunc(self, index, src, dim);
+
 
       TSelf* self_data = self.data_ptr<TSelf>();
       int64_t self_dim_stride = ensure_nonempty_stride(self, dim);

--- a/aten/src/ATen/native/Indexing.cpp
+++ b/aten/src/ATen/native/Indexing.cpp
@@ -417,22 +417,6 @@ namespace scattergather {
       SizeCheckFunc sizeCheckFunc,
       KernelOpFunc kernelOpFunc
     ) {
-      int64_t self_dim = ensure_nonempty_dim(self.dim());
-      int64_t index_dim = ensure_nonempty_dim(index.dim());
-      int64_t src_dim = ensure_nonempty_dim(src.dim());
-
-      TORCH_CHECK((dim >= 0) || (dim < index_dim),
-        "Invalid dimesion ", dim, " (expected to be 0 <= dim < ", index_dim, ")"
-      );
-
-      TORCH_CHECK((index_dim == self_dim) && (index_dim == self_dim),
-        "Inconsistent tensor sizes, expected ",
-        index, " ", index.sizes(), ", ",
-        self, " ", self.sizes(), " and ",
-        src, " ", src.sizes(),
-        " to have the same number of dimensions"
-      );
-
       sizeCheckFunc(self, index, src, dim);
 
       if (index.numel() == 0) {
@@ -452,6 +436,7 @@ namespace scattergather {
       int64_t src_dim_size = ensure_nonempty_size(src, dim);
 
       bool applyHasFinished = false;
+      int64_t index_dim = ensure_nonempty_dim(index.dim());
       std::vector<int64_t> idxCounter(index_dim, 0);
       while (!applyHasFinished) {
         kernelOpFunc(

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3888,7 +3888,7 @@
 - func: scatter_add_(Tensor(a!) self, int dim, Tensor index, Tensor src) -> Tensor(a!)
   variants: method
   dispatch:
-    CPU: legacy::cpu::_th_scatter_add_
+    CPU: scatter_add_cpu_
     CUDA: legacy::cuda::_th_scatter_add_
 
 - func: scatter_add(Tensor self, int dim, Tensor index, Tensor src) -> Tensor

--- a/aten/src/TH/generic/THTensorEvenMoreMath.cpp
+++ b/aten/src/TH/generic/THTensorEvenMoreMath.cpp
@@ -685,38 +685,6 @@ void THTensor_(scatter)(THTensor *tensor, int dim, THLongTensor *index, THTensor
                        })
 }
 
-void THTensor_(scatterAdd)(THTensor *tensor, int dim, THLongTensor *index, THTensor *src)
-{
-  int64_t elems_per_row, i, idx;
-  int index_ndim_legacy_all = THTensor_nDimensionLegacyAll(index);
-
-  THArgCheck(dim < THTensor_(nDimensionLegacyNoScalars)(tensor), 2, "Index dimension is out of bounds");
-  THArgCheck(index_ndim_legacy_all == 0
-             || THLongTensor_nDimensionLegacyNoScalars(index) == THTensor_(nDimensionLegacyNoScalars)(tensor), 3,
-             "Index tensor must have same dimensions as output tensor");
-  THArgCheck(THTensor_(nDimensionLegacyNoScalars)(src) == THTensor_(nDimensionLegacyNoScalars)(tensor), 4,
-             "Input tensor must have same dimensions as output tensor");
-
-  // no-op if index is empty
-  if (index_ndim_legacy_all == 0)
-      return;
-
-  elems_per_row = THTensor_sizeLegacyNoScalars(index, dim);
-
-  TH_TENSOR_DIM_APPLY3(int64_t, index, scalar_t, tensor, scalar_t, src, dim,
-                       TH_TENSOR_DIM_APPLY3_SIZE_SCATTER,
-                       for (i = 0; i < elems_per_row; ++i)
-                       {
-                         idx = *(index_data + i*index_stride);
-                         if (idx < 0 || idx >= tensor_size)
-                         {
-                           THFree(TH_TENSOR_DIM_APPLY_counter);
-                           THError("Invalid index in scatterAdd");
-                         }
-                         tensor_data[idx * tensor_stride] += *(src_data + i*src_stride);
-                       })
-}
-
 #if !defined(TH_REAL_IS_BOOL)
 
 accreal THTensor_(dot)(THTensor *tensor, THTensor *src)

--- a/aten/src/TH/generic/THTensorMath.h
+++ b/aten/src/TH/generic/THTensorMath.h
@@ -99,7 +99,6 @@ TH_API void THTensor_(indexFill)(THTensor *tensor, int dim, THLongTensor *index,
 
 TH_API void THTensor_(gather)(THTensor *tensor, THTensor *src, int dim, THLongTensor *index);
 TH_API void THTensor_(scatter)(THTensor *tensor, int dim, THLongTensor *index, THTensor *src);
-TH_API void THTensor_(scatterAdd)(THTensor *tensor, int dim, THLongTensor *index, THTensor *src);
 TH_API void THTensor_(scatterFill)(THTensor *tensor, int dim, THLongTensor *index, scalar_t val);
 
 TH_API void THTensor_(cumsum)(THTensor *r_, THTensor *t, int dimension);


### PR DESCRIPTION
Fixes [24758](https://github.com/pytorch/pytorch/issues/24758)

Pretty straightforward port, but seems to be 10-20% faster than the TH version on my machine for some reason.
