### PR TITLE
[flaky-tests][rpc] fix test_process_group_debug_info flaky test

### DIFF
--- a/test/rpc_test.py
+++ b/test/rpc_test.py
@@ -1203,11 +1203,17 @@ class RpcTest(RpcAgentTestFixture):
         # barrier after check 3
         dist.barrier()
 
-    @unittest.skip("Test is flaky, see https://github.com/pytorch/pytorch/issues/31112")
     @dist_init
     @requires_process_group_agent("PROCESS_GROUP rpc backend specific test, skip")
     def test_process_group_debug_info(self):
         from torch.distributed.rpc.api import _agent
+        if not dist.is_initialized():
+            dist.init_process_group(
+                backend="gloo",
+                init_method=self.init_method,
+                rank=self.rank,
+                world_size=self.world_size,
+            )
 
         NUM_THREAD = self.rpc_backend_options.num_send_recv_threads
 
@@ -1218,7 +1224,10 @@ class RpcTest(RpcAgentTestFixture):
         self.assertEqual(int(info["num_pending_requests"]), 0)
         self.assertEqual(int(info["thread_pool_size"]), NUM_THREAD)
         self.assertEqual(int(info["num_idle_threads"]), NUM_THREAD)
-
+        # for the above check, add a barrier to ensure that another worker
+        # cannot send a request before we check num_idle_threads, since we'd
+        # use up an idle thread if we start processing that request.
+        dist.barrier()
         dst_rank = (self.rank + 1) % self.world_size
         fut = rpc.rpc_async(
             "worker{}".format(dst_rank),
@@ -1238,14 +1247,6 @@ class RpcTest(RpcAgentTestFixture):
         # as we cannot know for sure whether the send thread has returned, there
         # might be either 1 or 2 busy threads
         self.assertTrue(num_idle_threads in [NUM_THREAD - 1, NUM_THREAD - 2])
-
-        if not dist.is_initialized():
-            dist.init_process_group(
-                backend="gloo",
-                init_method=self.init_method,
-                rank=self.rank,
-                world_size=self.world_size,
-            )
 
         # add a barrier to make sure the request is not finished before checking
         # num_pending_requests


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#31533 [flaky-tests][rpc] fix test_process_group_debug_info flaky test**

Fixes `test_process_group_debug_info` which has been flaky and has been disabled (see
https://github.com/pytorch/pytorch/issues/31112).

The fix is to add a `dist.barrier()` after checking the number of idle threads. Without this barrier, another process could have made more progress and sent a request to the local worker, and if we began processing this then the assert would fail.

Test plan: Ran the test 1000 times and it passed every time.

Differential Revision: [D19203366](https://our.internmc.facebook.com/intern/diff/D19203366/)