### PR TITLE
Remove temporary test function.

### DIFF
--- a/aten/src/ATen/native/Pooling.cpp
+++ b/aten/src/ATen/native/Pooling.cpp
@@ -138,14 +138,5 @@ Tensor max_pool3d(
       self, kernel_size, stride, padding, dilation, ceil_mode);
   return std::get<0>(output_and_indices);
 }
-
-Tensor _test_optional_float(const Tensor & self, c10::optional<double> scale) {
-  if (scale.has_value()) {
-    return at::full({}, scale.value(), self.options());
-  } else {
-    return at::empty({0}, self.options());
-  }
-}
-
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -6074,9 +6074,6 @@
     CPU: replication_pad3d_backward_cpu
     CUDA: replication_pad3d_backward_cuda
 
-- func: _test_optional_float(Tensor self, *, float? scale=None) -> Tensor
-  variants: function
-
 - func: upsample_linear1d.out(Tensor self, int[1] output_size, bool align_corners, float scales_1=-1.0, *, Tensor(a!) out) -> Tensor(a!)
   python_module: nn
   dispatch:

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -7327,15 +7327,6 @@ a")
         self.checkScript(func1, (), optimize=True)
         self.checkScript(func2, (), optimize=True)
 
-    # FIXME: get rid of this once we have actual ops using optional floats
-    def test_optional_float(self):
-        def _test_optional_float(x, scale):
-            # type: (Tensor, Optional[float]) -> torch.Tensor
-            return torch._test_optional_float(x, scale=scale)
-
-        self.assertEqual([0], torch.jit.script(_test_optional_float)(torch.randn(()), None).shape)
-        self.assertEqual((), torch.jit.script(_test_optional_float)(torch.randn(()), 2.5).shape)
-
     def _test_tensor_number_math(self, device='cpu'):
         template = dedent('''
         def func(t):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1826,13 +1826,6 @@ class _TestTorchMixin(object):
         x = torch.tensor(2., requires_grad=True)
         self.assertRaises(Exception, lambda: y.addcmul(y, y, value=x))
 
-    # FIXME: get rid of this once we have actual ops using optional floats
-    def test_optional_floats(self):
-        x = torch.randn(())
-        self.assertEqual(torch._test_optional_float(x), torch.empty((0,)))
-        self.assertEqual(torch._test_optional_float(x, scale=None), torch.empty((0,)))
-        self.assertEqual(torch._test_optional_float(x, scale=2.5), torch.full((), 2.5))
-
     def test_copy_broadcast(self):
         torch.zeros(5, 6).copy_(torch.zeros(6))
         self.assertRaises(RuntimeError, lambda: torch.zeros(5, 6).copy_(torch.zeros(30)))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#31535 Remove temporary test function.**
* #31517 Support optional float parameters (float?, optional<double>).

This was just for testing until https://github.com/pytorch/pytorch/pull/31526 lands.

Differential Revision: [D19203678](https://our.internmc.facebook.com/intern/diff/D19203678)