### PR TITLE
set stream everytime when we get a cuBlas handle

### DIFF
--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -157,7 +157,6 @@ void gemm<double>(CUDABLAS_GEMM_ARGTYPES(double)) {
   cublasOperation_t opb = _cublasOpFromChar(transb);
   _cublasAdjustLdLevel3(transa, transb, m, n, k, &lda, &ldb, &ldc);
   GEMM_CHECK_ARGVALUES(double);
-  TORCH_CUDABLAS_CHECK(cublasSetStream(handle, stream));
   TORCH_CUDABLAS_CHECK(cublasDgemm(
       handle, opa, opb, m, n, k, &alpha, a, lda, b, ldb, &beta, c, ldc));
 }
@@ -169,7 +168,6 @@ void gemm<float>(CUDABLAS_GEMM_ARGTYPES(float)) {
   cublasOperation_t opb = _cublasOpFromChar(transb);
   _cublasAdjustLdLevel3(transa, transb, m, n, k, &lda, &ldb, &ldc);
   GEMM_CHECK_ARGVALUES(float);
-  TORCH_CUDABLAS_CHECK(cublasSetStream(handle, stream));
   TORCH_CUDABLAS_CHECK(cublasSgemm(
       handle, opa, opb, m, n, k, &alpha, a, lda, b, ldb, &beta, c, ldc));
 }
@@ -183,7 +181,6 @@ void gemm<at::Half>(CUDABLAS_GEMM_ARGTYPES(at::Half)) {
   float fbeta = beta;
   _cublasAdjustLdLevel3(transa, transb, m, n, k, &lda, &ldb, &ldc);
   GEMM_CHECK_ARGVALUES(at::Half);
-  TORCH_CUDABLAS_CHECK(cublasSetStream(handle, stream));
 #ifdef __HIP_PLATFORM_HCC__
   TORCH_CUDABLAS_CHECK(rocblas_gemm_ex(
       handle,
@@ -273,7 +270,6 @@ void gemm<at::BFloat16>(CUDABLAS_GEMM_ARGTYPES(at::BFloat16)) {
   float fbeta = beta;
   _cublasAdjustLdLevel3(transa, transb, m, n, k, &lda, &ldb, &ldc);
   GEMM_CHECK_ARGVALUES(at::BFloat16);
-  TORCH_CUDABLAS_CHECK(cublasSetStream(handle, stream));
   TORCH_CUDABLAS_CHECK(rocblas_gemm_ex(
       handle,
       opa,
@@ -320,7 +316,6 @@ void gemv<double>(CUDABLAS_GEMV_ARGTYPES(double)) {
   cublasOperation_t op = _cublasOpFromChar(trans);
   _cublasAdjustLdLevel2(m, n, &lda);
   GEMV_CHECK_ARGVALUES(double);
-  TORCH_CUDABLAS_CHECK(cublasSetStream(handle, stream));
   TORCH_CUDABLAS_CHECK(
       cublasDgemv(handle, op, m, n, &alpha, a, lda, x, incx, &beta, y, incy));
 }
@@ -331,7 +326,6 @@ void gemv<float>(CUDABLAS_GEMV_ARGTYPES(float)) {
   cublasOperation_t op = _cublasOpFromChar(trans);
   _cublasAdjustLdLevel2(m, n, &lda);
   GEMV_CHECK_ARGVALUES(float);
-  TORCH_CUDABLAS_CHECK(cublasSetStream(handle, stream));
   TORCH_CUDABLAS_CHECK(
       cublasSgemv(handle, op, m, n, &alpha, a, lda, x, incx, &beta, y, incy));
 }
@@ -345,7 +339,7 @@ void gemv<at::Half>(CUDABLAS_GEMV_ARGTYPES(at::Half)) {
       incy == 1,
       "at::cuda::blas::gemv<Half>: support for incy != 1 not implemented");
   gemm<at::Half>(
-      stream, trans, 'n', m, 1, n, alpha, a, n, x, n, beta, y, m);
+      trans, 'n', m, 1, n, alpha, a, n, x, n, beta, y, m);
 }
 
 #ifdef __HIP_PLATFORM_HCC__
@@ -358,7 +352,7 @@ void gemv<at::BFloat16>(CUDABLAS_GEMV_ARGTYPES(at::BFloat16)) {
       incy == 1,
       "at::cuda::blas::gemv<at::BFloat16>: support for incy != 1 not implemented");
   gemm<at::BFloat16>(
-      stream, trans, 'n', m, 1, n, alpha, a, n, x, n, beta, y, m);
+      trans, 'n', m, 1, n, alpha, a, n, x, n, beta, y, m);
 }
 #endif
 

--- a/aten/src/ATen/cuda/CUDABlas.h
+++ b/aten/src/ATen/cuda/CUDABlas.h
@@ -2,10 +2,10 @@
 /*
   Provides a subset of CUDA BLAS functions as templates:
 
-    gemm<Dtype>(stream, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
+    gemm<Dtype>(transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
   ldc)
 
-    gemv<Dtype>(stream, transa, m, n, alpha, a, lda, x, incx, beta, y, incy)
+    gemv<Dtype>(transa, m, n, alpha, a, lda, x, incx, beta, y, incy)
 
   where Dtype is double, float, at::Half or at::BFloat16(ROCm). The functions are
   available in at::cuda::blas namespace.
@@ -20,7 +20,7 @@ namespace blas {
 /* LEVEL 3 BLAS FUNCTIONS */
 
 #define CUDABLAS_GEMM_ARGTYPES(Dtype)                                      \
-  cudaStream_t stream, char transa, char transb, int64_t m, int64_t n,     \
+      char transa, char transb, int64_t m, int64_t n,                      \
       int64_t k, Dtype alpha, const Dtype *a, int64_t lda, const Dtype *b, \
       int64_t ldb, Dtype beta, Dtype *c, int64_t ldc
 
@@ -43,7 +43,7 @@ void gemm<at::BFloat16>(CUDABLAS_GEMM_ARGTYPES(at::BFloat16));
 /* LEVEL 2 BLAS FUNCTIONS */
 
 #define CUDABLAS_GEMV_ARGTYPES(Dtype)                                        \
-  cudaStream_t stream, char trans, int64_t m, int64_t n, Dtype alpha,        \
+      char trans, int64_t m, int64_t n, Dtype alpha,                         \
       const Dtype *a, int64_t lda, const Dtype *x, int64_t incx, Dtype beta, \
       Dtype *y, int64_t incy
 

--- a/aten/src/ATen/cuda/CublasHandlePool.cpp
+++ b/aten/src/ATen/cuda/CublasHandlePool.cpp
@@ -38,8 +38,10 @@ cublasHandle_t getCurrentCUDABlasHandle() {
 
   if (!myPoolWindow)
     myPoolWindow.reset(pool.newPoolWindow());
-
-  return myPoolWindow->reserve(device);
+  auto handle = myPoolWindow->reserve(device);
+  auto stream = c10::cuda::getCurrentCUDAStream();
+  TORCH_CUDABLAS_CHECK(cublasSetStream(handle, stream));
+  return handle;
 }
 
 }} // namespace at::cuda

--- a/aten/src/ATen/native/cuda/NaiveConvolutionTranspose2d.cu
+++ b/aten/src/ATen/native/cuda/NaiveConvolutionTranspose2d.cu
@@ -474,6 +474,7 @@ static void slow_conv_transpose2d_backward_out_cuda_template(
 
           // Extract columns:
           im2col<scalar_t>(
+              at::cuda::getCurrentCUDAStream(),
               grad_output_n.data_ptr<scalar_t>(),
               n_output_plane,
               output_height,
@@ -682,6 +683,7 @@ void slow_conv_transpose2d_acc_grad_parameters_cuda_template(
 
             // Extract columns:
             im2col<scalar_t>(
+                at::cuda::getCurrentCUDAStream(),
                 grad_output_n.data_ptr<scalar_t>(),
                 n_output_plane,
                 output_height,

--- a/aten/src/ATen/native/cuda/NaiveConvolutionTranspose2d.cu
+++ b/aten/src/ATen/native/cuda/NaiveConvolutionTranspose2d.cu
@@ -279,7 +279,6 @@ void slow_conv_transpose2d_out_cuda_template(
           // Do GEMM (note: this is a bit confusing because gemm assumes
           // column-major matrices)
           at::cuda::blas::gemm<scalar_t>(
-              at::cuda::getCurrentCUDAStream(),
               'n',
               't',
               n,
@@ -324,7 +323,6 @@ void slow_conv_transpose2d_out_cuda_template(
           // column-major matrices)
           if (bias.defined()) {
             at::cuda::blas::gemm<scalar_t>(
-                at::cuda::getCurrentCUDAStream(),
                 't',
                 'n',
                 n_,
@@ -476,7 +474,6 @@ static void slow_conv_transpose2d_backward_out_cuda_template(
 
           // Extract columns:
           im2col<scalar_t>(
-              at::cuda::getCurrentCUDAStream(),
               grad_output_n.data_ptr<scalar_t>(),
               n_output_plane,
               output_height,
@@ -502,7 +499,6 @@ static void slow_conv_transpose2d_backward_out_cuda_template(
           // Do GEMM (note: this is a bit confusing because gemm assumes
           // column-major matrices)
           at::cuda::blas::gemm<scalar_t>(
-              at::cuda::getCurrentCUDAStream(),
               'n',
               'n',
               n,
@@ -686,7 +682,6 @@ void slow_conv_transpose2d_acc_grad_parameters_cuda_template(
 
             // Extract columns:
             im2col<scalar_t>(
-                at::cuda::getCurrentCUDAStream(),
                 grad_output_n.data_ptr<scalar_t>(),
                 n_output_plane,
                 output_height,
@@ -712,7 +707,6 @@ void slow_conv_transpose2d_acc_grad_parameters_cuda_template(
             // Do GEMM (note: this is a bit confusing because gemm assumes
             // column-major matrices)
             at::cuda::blas::gemm<scalar_t>(
-                at::cuda::getCurrentCUDAStream(),
                 't',
                 'n',
                 n,
@@ -738,7 +732,6 @@ void slow_conv_transpose2d_acc_grad_parameters_cuda_template(
             // Do GEMV (note: this is a bit confusing because gemv assumes
             // column-major matrices)
             at::cuda::blas::gemv<scalar_t>(
-                at::cuda::getCurrentCUDAStream(),
                 't',
                 k_,
                 m_,

--- a/aten/src/ATen/native/cuda/NaiveConvolutionTranspose3d.cu
+++ b/aten/src/ATen/native/cuda/NaiveConvolutionTranspose3d.cu
@@ -321,7 +321,6 @@ void slow_conv_transpose3d_out_cuda_template(
           // Do GEMM (note: this is a bit confusing because gemm assumes
           // column-major matrices)
           at::cuda::blas::gemm<scalar_t>(
-              at::cuda::getCurrentCUDAStream(),
               'n',
               't',
               n,
@@ -372,7 +371,6 @@ void slow_conv_transpose3d_out_cuda_template(
           // column-major matrices)
           if (bias.defined()) {
             at::cuda::blas::gemm<scalar_t>(
-                at::cuda::getCurrentCUDAStream(),
                 't',
                 'n',
                 n_,
@@ -580,7 +578,6 @@ void slow_conv_transpose3d_backward_out_cuda_template(
           // Do GEMM (note: this is a bit confusing because gemm assumes
           // column-major matrices)
           at::cuda::blas::gemm<scalar_t>(
-              at::cuda::getCurrentCUDAStream(),
               'n',
               'n',
               n,
@@ -818,7 +815,6 @@ void slow_conv_transpose3d_acc_grad_parameters_cuda(
             // Do GEMM (note: this is a bit confusing because gemm assumes
             // column-major matrices)
             at::cuda::blas::gemm<scalar_t>(
-                at::cuda::getCurrentCUDAStream(),
                 't',
                 'n',
                 n,
@@ -844,7 +840,6 @@ void slow_conv_transpose3d_acc_grad_parameters_cuda(
             // Do GEMV (note: this is a bit confusing because gemv assumes
             // column-major matrices)
             at::cuda::blas::gemv<scalar_t>(
-                at::cuda::getCurrentCUDAStream(),
                 't',
                 k_,
                 m_,

--- a/aten/src/ATen/native/cuda/NaiveDilatedConvolution.cu
+++ b/aten/src/ATen/native/cuda/NaiveDilatedConvolution.cu
@@ -224,7 +224,6 @@ void slow_conv_dilated_all_cuda_template(
      branching outside the CPP macro: */
 #define CALCULATE_GRAD_BIAS                          \
   at::cuda::blas::gemv<scalar_t>(                    \
-      stream,                                        \
       /*trans=*/'t',                                 \
       /*    m=*/output_vsize,                        \
       /*    n=*/nOutputPlane,                        \
@@ -279,7 +278,6 @@ void slow_conv_dilated_all_cuda_template(
                slow_conv_dilated_all_cuda_template in
                ATen/native/DilatedConvolution.cpp */
             at::cuda::blas::gemm<scalar_t>(
-                stream,
                 /*transa=*/'n',
                 /*transb=*/'n',
                 /*     m=*/columns.size(1),
@@ -305,7 +303,6 @@ void slow_conv_dilated_all_cuda_template(
                slow_conv_dilated_all_cuda_template in
                ATen/native/DilatedConvolution.cpp */
             at::cuda::blas::gemm<scalar_t>(
-                stream,
                 /*transa=*/'n',
                 /*transb=*/'t',
                 /*     m=*/columns.size(1),
@@ -355,7 +352,6 @@ void slow_conv_dilated_all_cuda_template(
                slow_conv_dilated_all_cuda_template in
                ATen/native/DilatedConvolution.cpp */
             at::cuda::blas::gemm<scalar_t>(
-                stream,
                 /*transa=*/'t',
                 /*transb=*/'n',
                 /*     m=*/columns.size(0),

--- a/aten/src/THC/THCBlas.cu
+++ b/aten/src/THC/THCBlas.cu
@@ -20,7 +20,6 @@ float THCudaBlas_Sdot(THCState *state, int64_t n, float *x, int64_t incx, float 
     int i_incy = (int)incy;
     float result;
     cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
-    cublasSetStream(handle, at::cuda::getCurrentCUDAStream().stream());
     THCublasCheck(cublasSdot(handle, i_n, x, i_incx, y, i_incy, &result));
     return result;
   }
@@ -43,7 +42,6 @@ double THCudaBlas_Ddot(THCState *state, int64_t n, double *x, int64_t incx, doub
     int i_incy = (int)incy;
     double result;
     cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
-    cublasSetStream(handle, at::cuda::getCurrentCUDAStream().stream());
     THCublasCheck(cublasDdot(handle, i_n, x, i_incx, y, i_incy, &result));
     return result;
   }
@@ -64,7 +62,6 @@ at::Half THCudaBlas_Hdot(THCState *state, int64_t n, at::Half *x, int64_t incx, 
   if ((n <= INT_MAX) && (incx <= INT_MAX) && (incy <= INT_MAX)) {
     at::Half result;
     cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
-    cublasSetStream(handle, at::cuda::getCurrentCUDAStream().stream());
     THCublasCheck(cublasDotEx(handle, n,
                               x, CUDA_R_16F, incx,
                               y, CUDA_R_16F, incy,
@@ -95,12 +92,12 @@ void adjustLdLevel2(int64_t m, int64_t n, int64_t *lda)
 
 void THCudaBlas_Sgemv(THCState *state, char trans, int64_t m, int64_t n, float alpha, float *a, int64_t lda, float *x, int64_t incx, float beta, float *y, int64_t incy)
 {
-  at::cuda::blas::gemv<float>(at::cuda::getCurrentCUDAStream().stream(), trans, m, n, alpha, a, lda, x, incx, beta, y, incy);
+  at::cuda::blas::gemv<float>(trans, m, n, alpha, a, lda, x, incx, beta, y, incy);
 }
 
 void THCudaBlas_Dgemv(THCState *state, char trans, int64_t m, int64_t n, double alpha, double *a, int64_t lda, double *x, int64_t incx, double beta, double *y, int64_t incy)
 {
-  at::cuda::blas::gemv<double>(at::cuda::getCurrentCUDAStream().stream(), trans, m, n, alpha, a, lda, x, incx, beta, y, incy);
+  at::cuda::blas::gemv<double>(trans, m, n, alpha, a, lda, x, incx, beta, y, incy);
 }
 
 void THCudaBlas_Sger(THCState *state, int64_t m, int64_t n, float alpha, float *x, int64_t incx, float *y, int64_t incy, float *a, int64_t lda)
@@ -116,7 +113,6 @@ void THCudaBlas_Sger(THCState *state, int64_t m, int64_t n, float alpha, float *
       int i_incy = (int)incy;
 
       cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
-      cublasSetStream(handle, at::cuda::getCurrentCUDAStream().stream());
       THCublasCheck(cublasSger(handle, i_m, i_n, &alpha, x, i_incx, y, i_incy, a, i_lda));
       return;
     }
@@ -137,7 +133,6 @@ void THCudaBlas_Dger(THCState *state, int64_t m, int64_t n, double alpha, double
       int i_incy = (int)incy;
 
       cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
-      cublasSetStream(handle, at::cuda::getCurrentCUDAStream().stream());
       THCublasCheck(cublasDger(handle, i_m, i_n, &alpha, x, i_incx, y, i_incy, a, i_lda));
       return;
     }
@@ -214,7 +209,7 @@ static void checkCuda90Bug(int i_m, int i_n, int i_k)
 void THCudaBlas_Sgemm(THCState *state, char transa, char transb, int64_t m, int64_t n, int64_t k, float alpha, float *a, int64_t lda, float *b, int64_t ldb, float beta, float *c, int64_t ldc)
 {
   checkCuda90Bug((int)m, (int)n, (int)k);
-  at::cuda::blas::gemm<float>(at::cuda::getCurrentCUDAStream().stream(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc);
+  at::cuda::blas::gemm<float>(atransa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc);
 }
 
 // In CUDA 8.0, definition of data types for sgemmex changed
@@ -225,19 +220,19 @@ void THCudaBlas_Sgemm(THCState *state, char transa, char transb, int64_t m, int6
 void THCudaBlas_Hgemm(THCState *state, char transa, char transb, int64_t m, int64_t n, int64_t k, at::Half alpha, at::Half *a, int64_t lda, at::Half *b, int64_t ldb, at::Half beta, at::Half *c, int64_t ldc)
 {
   checkCuda90Bug((int)m, (int)n, (int)k);
-  at::cuda::blas::gemm<at::Half>(at::cuda::getCurrentCUDAStream().stream(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc);
+  at::cuda::blas::gemm<at::Half>(transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc);
 }
 
 #ifdef __HIP_PLATFORM_HCC__
 void THCudaBlas_Bgemm(THCState *state, char transa, char transb, int64_t m, int64_t n, int64_t k, at::BFloat16 alpha, at::BFloat16 *a, int64_t lda, at::BFloat16 *b, int64_t ldb, at::BFloat16 beta, at::BFloat16 *c, int64_t ldc)
 {
-  at::cuda::blas::gemm<at::BFloat16>(THCState_getCurrentStream(state), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc);
+  at::cuda::blas::gemm<at::BFloat16>(transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc);
 }
 #endif
 
 void THCudaBlas_Dgemm(THCState *state, char transa, char transb, int64_t m, int64_t n, int64_t k, double alpha, double *a, int64_t lda, double *b, int64_t ldb, double beta, double *c, int64_t ldc)
 {
-  at::cuda::blas::gemm<double>(at::cuda::getCurrentCUDAStream().stream(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc);
+  at::cuda::blas::gemm<double>(transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc);
 }
 
 #if CUDA_VERSION >= 9010  || defined __HIP_PLATFORM_HCC__
@@ -257,7 +252,6 @@ void THCudaBlas_HgemmStridedBatched(THCState *state, char transa, char transb, i
   cublasOperation_t opb = convertTransToCublasOperation(transb);
 
   cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
-  cublasSetStream(handle, at::cuda::getCurrentCUDAStream().stream());
   float fAlpha = alpha;
   float fBeta = beta;
 #ifdef __HIP_PLATFORM_HCC__
@@ -298,7 +292,6 @@ void THCudaBlas_BgemmStridedBatched(THCState *state, char transa, char transb, i
   cublasOperation_t opb = convertTransToCublasOperation(transb);
 
   cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
-  cublasSetStream(handle, at::cuda::getCurrentCUDAStream().stream());
   float fAlpha = alpha;
   float fBeta = beta;
   THCublasCheck(rocblas_gemm_strided_batched_ex(handle, opa, opb, (int)m, (int)n, (int)k,
@@ -336,7 +329,6 @@ void THCudaBlas_SgemmBatched(THCState *state, char transa, char transb, int64_t 
   cublasOperation_t opb = convertTransToCublasOperation(transb);
 
   cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
-  cublasSetStream(handle, at::cuda::getCurrentCUDAStream().stream());
   THCublasCheck(cublasSgemmBatched(handle,
                                    opa, opb, (int)m, (int)n, (int)k,
                                    &alpha, a, (int)lda, b, (int)ldb, &beta, c, (int)ldc,
@@ -361,7 +353,6 @@ void THCudaBlas_SgemmStridedBatched(THCState *state, char transa, char transb, i
   cublasOperation_t opb = convertTransToCublasOperation(transb);
 
   cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
-  cublasSetStream(handle, at::cuda::getCurrentCUDAStream().stream());
   THCublasCheck(cublasSgemmStridedBatched(handle,
                                    opa, opb, (int)m, (int)n, (int)k,
                                    &alpha, a, (int)lda, strideA, b, (int)ldb, strideB, &beta, c, (int)ldc, strideC,
@@ -394,7 +385,6 @@ void THCudaBlas_DgemmBatched(THCState *state, char transa, char transb, int64_t 
   cublasOperation_t opb = convertTransToCublasOperation(transb);
 
   cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
-  cublasSetStream(handle, at::cuda::getCurrentCUDAStream().stream());
   THCublasCheck(cublasDgemmBatched(handle,
                                    opa, opb, (int)m, (int)n, (int)k,
                                    &alpha, a, (int)lda, b, (int)ldb, &beta, c, (int)ldc,
@@ -418,7 +408,6 @@ void THCudaBlas_DgemmStridedBatched(THCState *state, char transa, char transb, i
   cublasOperation_t opb = convertTransToCublasOperation(transb);
 
   cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
-  cublasSetStream(handle, at::cuda::getCurrentCUDAStream().stream());
   THCublasCheck(cublasDgemmStridedBatched(handle,
                                    opa, opb, (int)m, (int)n, (int)k,
                                    &alpha, a, (int)lda, strideA, b, (int)ldb, strideB, &beta, c, (int)ldc, strideC,

--- a/aten/src/THC/THCBlas.cu
+++ b/aten/src/THC/THCBlas.cu
@@ -209,7 +209,7 @@ static void checkCuda90Bug(int i_m, int i_n, int i_k)
 void THCudaBlas_Sgemm(THCState *state, char transa, char transb, int64_t m, int64_t n, int64_t k, float alpha, float *a, int64_t lda, float *b, int64_t ldb, float beta, float *c, int64_t ldc)
 {
   checkCuda90Bug((int)m, (int)n, (int)k);
-  at::cuda::blas::gemm<float>(atransa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc);
+  at::cuda::blas::gemm<float>(transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc);
 }
 
 // In CUDA 8.0, definition of data types for sgemmex changed


### PR DESCRIPTION
I don't see any reason for not doing so, because it is a common error that people forget to set the stream. And I don't think there is a reason for not running on the current stream.

This is just for cublas, cusparse and cudnn should be modified also.