### PR TITLE
[tensorboard] Let hparam render values correctly

### DIFF
--- a/test/expect/TestTensorBoard.test_hparams_bool.expect
+++ b/test/expect/TestTensorBoard.test_hparams_bool.expect
@@ -1,0 +1,28 @@
+(value {
+  tag: "_hparams_/experiment"
+  metadata {
+    plugin_data {
+      plugin_name: "hparams"
+      content: "\022\034\"\014\n\010bool_var \003*\014\n\n\022\010accuracy"
+    }
+  }
+}
+, value {
+  tag: "_hparams_/session_start_info"
+  metadata {
+    plugin_data {
+      plugin_name: "hparams"
+      content: "\032\027\n\025\n\010bool_var\022\t\021\000\000\000\000\000\000\360?"
+    }
+  }
+}
+, value {
+  tag: "_hparams_/session_end_info"
+  metadata {
+    plugin_data {
+      plugin_name: "hparams"
+      content: "\"\002\010\001"
+    }
+  }
+}
+)

--- a/test/expect/TestTensorBoard.test_hparams_number.expect
+++ b/test/expect/TestTensorBoard.test_hparams_number.expect
@@ -1,0 +1,28 @@
+(value {
+  tag: "_hparams_/experiment"
+  metadata {
+    plugin_data {
+      plugin_name: "hparams"
+      content: "\022\026\"\006\n\002lr \003*\014\n\n\022\010accuracy"
+    }
+  }
+}
+, value {
+  tag: "_hparams_/session_start_info"
+  metadata {
+    plugin_data {
+      plugin_name: "hparams"
+      content: "\032\021\n\017\n\002lr\022\t\021\232\231\231\231\231\231\271?"
+    }
+  }
+}
+, value {
+  tag: "_hparams_/session_end_info"
+  metadata {
+    plugin_data {
+      plugin_name: "hparams"
+      content: "\"\002\010\001"
+    }
+  }
+}
+)

--- a/test/expect/TestTensorBoard.test_hparams_string.expect
+++ b/test/expect/TestTensorBoard.test_hparams_string.expect
@@ -1,0 +1,28 @@
+(value {
+  tag: "_hparams_/experiment"
+  metadata {
+    plugin_data {
+      plugin_name: "hparams"
+      content: "\022\036\"\016\n\nstring_var \001*\014\n\n\022\010accuracy"
+    }
+  }
+}
+, value {
+  tag: "_hparams_/session_start_info"
+  metadata {
+    plugin_data {
+      plugin_name: "hparams"
+      content: "\032\024\n\022\n\nstring_var\022\004\032\002hi"
+    }
+  }
+}
+, value {
+  tag: "_hparams_/session_end_info"
+  metadata {
+    plugin_data {
+      plugin_name: "hparams"
+      content: "\"\002\010\001"
+    }
+  }
+}
+)

--- a/test/test_tensorboard.py
+++ b/test/test_tensorboard.py
@@ -446,6 +446,21 @@ class TestTensorBoardSummary(BaseTestCase):
             with self.createSummaryWriter() as writer:
                 writer.add_hparams({'pytorch': 1.0}, {'accuracy': [1, 2]})
 
+    def test_hparams_number(self):
+        hp = {'lr': 0.1}
+        mt = {'accuracy': 0.1}
+        self.assertTrue(compare_proto(summary.hparams(hp, mt), self))
+
+    def test_hparams_bool(self):
+        hp = {'bool_var': True}
+        mt = {'accuracy': 0.1}
+        self.assertTrue(compare_proto(summary.hparams(hp, mt), self))
+
+    def test_hparams_string(self):
+        hp = {'string_var': "hi"}
+        mt = {'accuracy': 0.1}
+        self.assertTrue(compare_proto(summary.hparams(hp, mt), self))
+
     def test_mesh(self):
         v = np.array([[[1, 1, 1], [-1, -1, 1], [1, -1, -1], [-1, 1, -1]]], dtype=float)
         c = np.array([[[255, 0, 0], [0, 255, 0], [0, 0, 255], [255, 0, 255]]], dtype=int)

--- a/torch/utils/tensorboard/summary.py
+++ b/torch/utils/tensorboard/summary.py
@@ -108,23 +108,23 @@ def hparams(hparam_dict=None, metric_dict=None):
             continue
         if isinstance(v, int) or isinstance(v, float):
             ssi.hparams[k].number_value = v
-            hps.append(HParamInfo(name=k, type=DataType.DATA_TYPE_FLOAT64))
+            hps.append(HParamInfo(name=k, type=DataType.Value("DATA_TYPE_FLOAT64")))
             continue
 
         if isinstance(v, string_types):
             ssi.hparams[k].string_value = v
-            hps.append(HParamInfo(name=k, type=DataType.DATA_TYPE_STRING))
+            hps.append(HParamInfo(name=k, type=DataType.Value("DATA_TYPE_STRING")))
             continue
 
         if isinstance(v, bool):
             ssi.hparams[k].bool_value = v
-            hps.append(HParamInfo(name=k, type=DataType.DATA_TYPE_BOOL))
+            hps.append(HParamInfo(name=k, type=DataType.Value("DATA_TYPE_BOOL")))
             continue
 
         if isinstance(v, torch.Tensor):
             v = make_np(v)[0]
             ssi.hparams[k].number_value = v
-            hps.append(HParamInfo(name=k, type=DataType.DATA_TYPE_FLOAT64))
+            hps.append(HParamInfo(name=k, type=DataType.Value("DATA_TYPE_FLOAT64")))
             continue
         raise ValueError('value should be one of int, float, str, bool, or torch.Tensor')
 

--- a/torch/utils/tensorboard/summary.py
+++ b/torch/utils/tensorboard/summary.py
@@ -70,7 +70,7 @@ def hparams(hparam_dict=None, metric_dict=None):
     import torch
     from six import string_types
     from tensorboard.plugins.hparams.api_pb2 import (
-        Experiment, HParamInfo, MetricInfo, MetricName, Status
+        Experiment, HParamInfo, MetricInfo, MetricName, Status, DataType
     )
     from tensorboard.plugins.hparams.metadata import (
         PLUGIN_NAME,
@@ -99,19 +99,8 @@ def hparams(hparam_dict=None, metric_dict=None):
         logging.warning('parameter: metric_dict should be a dictionary, nothing logged.')
         raise TypeError('parameter: metric_dict should be a dictionary, nothing logged.')
 
-    hps = [HParamInfo(name=k) for k in hparam_dict.keys()]
-    mts = [MetricInfo(name=MetricName(tag=k)) for k in metric_dict.keys()]
+    hps = []
 
-    exp = Experiment(hparam_infos=hps, metric_infos=mts)
-
-    content = HParamsPluginData(experiment=exp, version=PLUGIN_DATA_VERSION)
-    smd = SummaryMetadata(
-        plugin_data=SummaryMetadata.PluginData(
-            plugin_name=PLUGIN_NAME,
-            content=content.SerializeToString()
-        )
-    )
-    exp = Summary(value=[Summary.Value(tag=EXPERIMENT_TAG, metadata=smd)])
 
     ssi = SessionStartInfo()
     for k, v in hparam_dict.items():
@@ -119,19 +108,23 @@ def hparams(hparam_dict=None, metric_dict=None):
             continue
         if isinstance(v, int) or isinstance(v, float):
             ssi.hparams[k].number_value = v
+            hps.append(HParamInfo(name=k, type=DataType.DATA_TYPE_FLOAT64))
             continue
 
         if isinstance(v, string_types):
             ssi.hparams[k].string_value = v
+            hps.append(HParamInfo(name=k, type=DataType.DATA_TYPE_STRING))
             continue
 
         if isinstance(v, bool):
             ssi.hparams[k].bool_value = v
+            hps.append(HParamInfo(name=k, type=DataType.DATA_TYPE_BOOL))
             continue
 
         if isinstance(v, torch.Tensor):
             v = make_np(v)[0]
             ssi.hparams[k].number_value = v
+            hps.append(HParamInfo(name=k, type=DataType.DATA_TYPE_FLOAT64))
             continue
         raise ValueError('value should be one of int, float, str, bool, or torch.Tensor')
 
@@ -144,6 +137,19 @@ def hparams(hparam_dict=None, metric_dict=None):
         )
     )
     ssi = Summary(value=[Summary.Value(tag=SESSION_START_INFO_TAG, metadata=smd)])
+
+    mts = [MetricInfo(name=MetricName(tag=k)) for k in metric_dict.keys()]
+
+    exp = Experiment(hparam_infos=hps, metric_infos=mts)
+
+    content = HParamsPluginData(experiment=exp, version=PLUGIN_DATA_VERSION)
+    smd = SummaryMetadata(
+        plugin_data=SummaryMetadata.PluginData(
+            plugin_name=PLUGIN_NAME,
+            content=content.SerializeToString()
+        )
+    )
+    exp = Summary(value=[Summary.Value(tag=EXPERIMENT_TAG, metadata=smd)])
 
     sei = SessionEndInfo(status=Status.Value('STATUS_SUCCESS'))
     content = HParamsPluginData(session_end_info=sei, version=PLUGIN_DATA_VERSION)


### PR DESCRIPTION
The root cause of incorrect rendering is that numbers are treated as a string if the data type is not specified. Therefore the data is sort based on the first digit.

closes #29906 
 cc @orionr @sanekmelnikov 