### PR TITLE
Delete GetTensorInfoCall and relative registry 

### DIFF
--- a/caffe2/core/tensor.cc
+++ b/caffe2/core/tensor.cc
@@ -105,25 +105,6 @@ GetInt8TensorInfo(const void* c, size_t* capacity, DeviceOption* device) {
   return GetTensorInfo(&(int8_tensor->t), capacity, device);
 }
 
-// since we only have one tensor, probably need to remove this at some point?
-static CaffeMap<TypeIdentifier, TensorInfoCall> tensor_info_call_registry_{
-    {TypeMeta::Id<Tensor>(), GetTensorInfo},
-    {TypeMeta::Id<int8::Int8TensorCPU>(), GetInt8TensorInfo},
-};
-
-// TODO: Remove this code in a separate diff, since we only have one
-// GetTensorInfo function now
-TensorInfoCall GetTensorInfoFunction(TypeIdentifier id) {
-  auto f = tensor_info_call_registry_.find(id);
-  if (f == tensor_info_call_registry_.end()) {
-    return nullptr;
-  }
-  return f->second;
-}
-
-void RegisterTensorInfoFunction(TypeIdentifier id, TensorInfoCall c) {
-  tensor_info_call_registry_[id] = c;
-}
 
 void TensorVectorResize(
     std::vector<Tensor>& tensors,

--- a/caffe2/core/tensor.h
+++ b/caffe2/core/tensor.h
@@ -628,8 +628,6 @@ typedef vector<int64_t> (*TensorInfoCall)(
     const void*,
     size_t* capacity,
     DeviceOption* device);
-TensorInfoCall GetTensorInfoFunction(TypeIdentifier id);
-void RegisterTensorInfoFunction(TypeIdentifier id, TensorInfoCall c);
 
 // resize helper function
 void TensorVectorResize(

--- a/caffe2/core/workspace.cc
+++ b/caffe2/core/workspace.cc
@@ -26,16 +26,13 @@ void Workspace::PrintBlobSizes() {
   vector<std::pair<size_t, std::string>> blob_sizes;
   for (const auto& s : blobs) {
     Blob* b = this->GetBlob(s);
-    TensorInfoCall shape_fun = GetTensorInfoFunction(b->meta().id());
-    if (shape_fun) {
-      size_t capacity;
-      DeviceOption _device;
-      auto shape = shape_fun(b->GetRaw(), &capacity, &_device);
-      // NB: currently it overcounts capacity of shared storages
-      // TODO: fix it after the storage sharing is merged
-      cumtotal += capacity;
-      blob_sizes.push_back(make_pair(capacity, s));
-    }
+    size_t capacity;
+    DeviceOption _device;
+    auto shape = GetTensorInfo(b->GetRaw(), &capacity, &_device);
+    // NB: currently it overcounts capacity of shared storages
+    // TODO: fix it after the storage sharing is merged
+    cumtotal += capacity;
+    blob_sizes.push_back(make_pair(capacity, s));
   }
   std::sort(
       blob_sizes.begin(),
@@ -50,12 +47,10 @@ void Workspace::PrintBlobSizes() {
   LOG(INFO) << "name;current shape;capacity bytes;percentage";
   for (const auto& sb : blob_sizes) {
     Blob* b = this->GetBlob(sb.second);
-    TensorInfoCall shape_fun = GetTensorInfoFunction(b->meta().id());
-    CHECK(shape_fun != nullptr);
     size_t capacity;
     DeviceOption _device;
 
-    auto shape = shape_fun(b->GetRaw(), &capacity, &_device);
+    auto shape = GetTensorInfo(b->GetRaw(), &capacity, &_device);
     std::stringstream ss;
     ss << sb.second << ";";
     for (const auto d : shape) {


### PR DESCRIPTION
For now we only have one GetTensorInfo function , so GetTensorInfoCall and relative tensor info registry is no longer needed