### PR TITLE
Move lshift to Aten

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -306,46 +306,6 @@
     - THTensor* other
 ]]
 [[
-  name: _th_lshift
-  cname: __lshift__
-  variants:
-    - function
-  return: argument 0
-  options:
-    - cname: lshift
-      arguments:
-        - arg: THTensor* result
-          output: True
-        - THTensor* self
-        - real other
-    - cname: clshift
-      arguments:
-        - arg: THTensor* result
-          output: True
-        - arg: THTensor* self
-          broadcast: other fallback
-        - THTensor* other
-]]
-[[
-  name: _th_ilshift_
-  cname:: __ilshift__
-  variants:
-    - function
-  return: argument 0
-  options:
-    - cname: lshift
-      arguments:
-        - THTensor* self
-        - THTensor* self
-        - real other
-    - cname: clshift
-      arguments:
-        - THTensor* self
-        - arg: THTensor* self
-          broadcast: other inplace fallback
-        - THTensor* other
-]]
-[[
   name: _th_rshift
   cname: __rshift__
   variants:

--- a/aten/src/ATen/native/BinaryOps.cpp
+++ b/aten/src/ATen/native/BinaryOps.cpp
@@ -18,6 +18,7 @@ DEFINE_DISPATCH(atan2_stub);
 DEFINE_DISPATCH(bitwise_and_stub);
 DEFINE_DISPATCH(bitwise_or_stub);
 DEFINE_DISPATCH(bitwise_xor_stub);
+DEFINE_DISPATCH(lshift_stub);
 DEFINE_DISPATCH(logical_and_stub);
 DEFINE_DISPATCH(logical_or_stub);
 DEFINE_DISPATCH(logical_xor_stub);
@@ -375,6 +376,34 @@ Tensor& __ixor__(Tensor& self, const Tensor& other) {
 
 Tensor& __ixor__(Tensor& self, Scalar other) {
   return self.bitwise_xor_(other);
+}
+
+Tensor __lshift__(const Tensor& self, const Tensor& other) {
+  Tensor result;
+  auto iter = TensorIterator::binary_op(result, self, other);
+  lshift_stub(iter.device_type(), iter);
+  return iter.output();
+}
+
+Tensor __lshift__(const Tensor& self, Scalar other) { 
+  Tensor result;
+  auto wrapper = wrapped_scalar_tensor(other).toType(self.scalar_type());
+  auto iter = TensorIterator::binary_op(result, self, wrapper);
+  lshift_stub(iter.device_type(), iter);
+  return iter.output();
+}
+
+Tensor& __ilshift__(Tensor& self, const Tensor& other) {
+  auto iter = TensorIterator::binary_op(self, self, other);
+  lshift_stub(iter.device_type(), iter);
+  return self;
+}
+
+Tensor& __ilshift__(Tensor& self, Scalar other) {
+  auto wrapper = wrapped_scalar_tensor(other).toType(self.scalar_type());
+  auto iter = TensorIterator::binary_op(self, self, wrapper);
+  lshift_stub(iter.device_type(), iter);
+  return self;
 }
 
 template <typename Stub>

--- a/aten/src/ATen/native/BinaryOps.h
+++ b/aten/src/ATen/native/BinaryOps.h
@@ -35,6 +35,7 @@ DECLARE_DISPATCH(binary_fn, atan2_stub);
 DECLARE_DISPATCH(binary_fn, bitwise_and_stub);
 DECLARE_DISPATCH(binary_fn, bitwise_or_stub);
 DECLARE_DISPATCH(binary_fn, bitwise_xor_stub);
+DECLARE_DISPATCH(binary_fn, lshift_stub);
 DECLARE_DISPATCH(binary_fn, logical_xor_stub);
 DECLARE_DISPATCH(binary_fn, logical_and_stub);
 DECLARE_DISPATCH(binary_fn, logical_or_stub);

--- a/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
@@ -158,6 +158,50 @@ void bitwise_xor_kernel(TensorIterator& iter) {
   }
 }
 
+template<typename scalar_t>
+static inline scalar_t lshift_wrapper(scalar_t a, scalar_t b) {
+  return a << b;
+}
+
+static inline int8_t lshift_wrapper(int8_t a, int8_t b) {
+  return ((uint8_t)a) << b;
+}
+
+static inline int16_t lshift_wrapper(int16_t a, int16_t b) {
+  return ((uint16_t)a) << b;
+}
+
+static inline int32_t lshift_wrapper(int32_t a, int32_t b) {
+  return ((uint32_t)a) << b;
+}
+
+static inline int64_t lshift_wrapper(int64_t a, int64_t b) {
+  return ((uint64_t)a) << b;
+}
+
+void lshift_kernel(TensorIterator& iter) {
+  if (iter.dtype() == ScalarType::Float || iter.dtype() == ScalarType::Double) {
+    AT_DISPATCH_FLOATING_TYPES(iter.dtype(), "lshift_cpu", [&]() {
+      auto base_vec = Vec256<scalar_t>((scalar_t)(2));
+      cpu_kernel_vec(
+        iter,
+        [=](scalar_t a, scalar_t b) -> scalar_t {
+          return a * std::pow((scalar_t)(2), b);
+        },
+        [=](Vec256<scalar_t> a, Vec256<scalar_t> b) {
+          return a * base_vec.pow(b);
+      });
+    });
+  } else {
+    AT_DISPATCH_INTEGRAL_TYPES(iter.dtype(), "lshift_cpu", [&]() {
+      cpu_kernel(iter,
+        [](scalar_t a, scalar_t b) -> scalar_t {
+          return lshift_wrapper(a, b);
+      });
+    });
+  }
+}
+
 void logical_and_kernel(TensorIterator& iter) {
   // We use if-else here specifically for bool instead of using iter.common_dtype() like the CUDA implementation because
   // common_dtype() is unavailable for bfloat16.
@@ -386,6 +430,7 @@ REGISTER_DISPATCH(atan2_stub, &atan2_kernel);
 REGISTER_DISPATCH(bitwise_and_stub, &bitwise_and_kernel);
 REGISTER_DISPATCH(bitwise_or_stub, &bitwise_or_kernel);
 REGISTER_DISPATCH(bitwise_xor_stub, &bitwise_xor_kernel);
+REGISTER_DISPATCH(lshift_stub, &lshift_kernel);
 REGISTER_DISPATCH(logical_xor_stub, &logical_xor_kernel);
 REGISTER_DISPATCH(logical_and_stub, &logical_and_kernel);
 REGISTER_DISPATCH(logical_or_stub, &logical_or_kernel);

--- a/aten/src/ATen/native/cuda/BinaryMiscOpsKernels.cu
+++ b/aten/src/ATen/native/cuda/BinaryMiscOpsKernels.cu
@@ -74,6 +74,25 @@ void bitwise_xor_kernel_cuda(TensorIterator& iter) {
   }
 }
 
+void lshift_kernel_cuda(TensorIterator& iter) {
+  if (iter.dtype() == ScalarType::Float || iter.dtype() == ScalarType::Double) {
+    AT_DISPATCH_FLOATING_TYPES(iter.dtype(), "lshift_cuda", [&]() {
+      gpu_kernel_with_scalars(
+        iter,
+        []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
+          return a * std::pow((scalar_t)(2), b);
+      });
+    });
+  } else {
+    AT_DISPATCH_INTEGRAL_TYPES(iter.dtype(), "lshift_cuda", [&]() {
+      gpu_kernel_with_scalars(iter,
+        []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
+          return a << b;
+      });
+    });
+  }
+}
+
 void logical_and_kernel_cuda(TensorIterator& iter) {
   AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBool, iter.common_dtype(), "logical_and_cuda", [&]() {
     gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> bool {
@@ -135,6 +154,7 @@ void mse_kernel_cuda(TensorIterator& iter) {
 REGISTER_DISPATCH(atan2_stub, &atan2_kernel_cuda);
 REGISTER_DISPATCH(bitwise_and_stub, &bitwise_and_kernel_cuda);
 REGISTER_DISPATCH(bitwise_or_stub, &bitwise_or_kernel_cuda);
+REGISTER_DISPATCH(lshift_stub, &lshift_kernel_cuda);
 REGISTER_DISPATCH(bitwise_xor_stub, &bitwise_xor_kernel_cuda);
 REGISTER_DISPATCH(logical_and_stub, &logical_and_kernel_cuda);
 REGISTER_DISPATCH(logical_or_stub, &logical_or_kernel_cuda);

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -4058,27 +4058,27 @@
   use_c10_dispatcher: full
   variants: method, function
   dispatch:
-    CPU: legacy::cpu::_th_lshift
-    CUDA: legacy::cuda::_th_lshift
+    CPU: __lshift__
+    CUDA: __lshift__
 
 - func: __lshift__.Tensor(Tensor self, Tensor other) -> Tensor
   use_c10_dispatcher: full
   variants: method, function
   dispatch:
-    CPU: legacy::cpu::_th_lshift
-    CUDA: legacy::cuda::_th_lshift
+    CPU: __lshift__
+    CUDA: __lshift__
 
 - func: __ilshift__.Scalar(Tensor(a!) self, Scalar other) -> Tensor(a!)
   variants: method
   dispatch:
-    CPU: legacy::cpu::_th_ilshift_
-    CUDA: legacy::cuda::_th_ilshift_
+    CPU: __ilshift__
+    CUDA: __ilshift__
 
 - func: __ilshift__.Tensor(Tensor(a!) self, Tensor other) -> Tensor(a!)
   variants: method
   dispatch:
-    CPU: legacy::cpu::_th_ilshift_
-    CUDA: legacy::cuda::_th_ilshift_
+    CPU: __ilshift__
+    CUDA: __ilshift__
 
 - func: __rshift__.Scalar(Tensor self, Scalar other) -> Tensor
   use_c10_dispatcher: full

--- a/aten/src/TH/generic/THTensorEvenMoreMath.cpp
+++ b/aten/src/TH/generic/THTensorEvenMoreMath.cpp
@@ -620,44 +620,6 @@ accreal THTensor_(dot)(THTensor *tensor, THTensor *src)
   return sum;
 }
 
-void THTensor_(lshift)(THTensor *r_, THTensor *t, scalar_t value)
-{
-#if defined(TH_REAL_IS_FLOAT)
-  return THTensor_(mul)(r_, t, powf(2, value));
-#elif defined(TH_REAL_IS_DOUBLE)
-  return THTensor_(mul)(r_, t, pow(2, value));
-#elif defined(TH_REAL_IS_HALF)
-  return THError("lshift is not supported for torch.HalfTensor");
-#elif defined(TH_REAL_IS_BFLOAT16)
-  return THError("lshift is not supported for torch.BFloat16Tensor");
-#else
-  THTensor_(resizeAs)(r_, t);
-  int64_t r_Size = THTensor_(nElement)(r_);
-  int r_Contig = THTensor_(isContiguous)(r_);
-  int tContig = THTensor_(isContiguous)(t);
-  if (r_Contig && tContig) {
-    scalar_t *tp = t->data<scalar_t>();
-    scalar_t *rp = r_->data<scalar_t>();
-    at::parallel_for(0, r_Size, TH_OMP_OVERHEAD_THRESHOLD * 100,
-        [&](int64_t start, int64_t end) {
-      for (auto i = start; i < end; i++) {
-#if defined(TH_REAL_IS_BYTE)
-        rp[i] = ((scalar_t) tp[i]) << value;
-#else
-        rp[i] = ((ureal) tp[i]) << value;
-#endif
-      }
-    });
-  } else {
-#if defined(TH_REAL_IS_BYTE)
-    TH_TENSOR_APPLY2_PARALLEL(r_Size, r_Contig, tContig, scalar_t, r_, scalar_t, t, *r__data = (((scalar_t) *t_data) << value);, UNCERTAIN_TH_OMP_OVERHEAD_THRESHOLD);
-#else
-    TH_TENSOR_APPLY2_PARALLEL(r_Size, r_Contig, tContig, scalar_t, r_, scalar_t, t, *r__data = (((ureal) *t_data) << value);, UNCERTAIN_TH_OMP_OVERHEAD_THRESHOLD);
-#endif
-  }
-#endif
-}
-
 void THTensor_(rshift)(THTensor *r_, THTensor *t, scalar_t value)
 {
 #if defined(TH_REAL_IS_FLOAT)

--- a/aten/src/TH/generic/THTensorMath.cpp
+++ b/aten/src/TH/generic/THTensorMath.cpp
@@ -402,60 +402,6 @@ void THTensor_(cdiv)(THTensor *r_, THTensor *t, THTensor *src)
   }
 }
 
-void THTensor_(clshift)(THTensor *r_, THTensor *t, THTensor *src)
-{
-#if defined(TH_REAL_IS_HALF)
-  return THError("clshift is not supported for torch.HalfTensor");
-#endif
-  THTensor_(resizeAs)(r_, t);
-  int64_t r_Size = THTensor_(nElement)(r_);
-  int64_t srcSize = THTensor_(nElement)(src);
-  int r_Contig = THTensor_(isContiguous)(r_);
-  int tContig = THTensor_(isContiguous)(t);
-  int srcContig = THTensor_(isContiguous)(src);
-  if (srcSize == r_Size){
-    if (r_Contig && tContig && srcContig) {
-      scalar_t *tp = t->data<scalar_t>();
-      scalar_t *sp = src->data<scalar_t>();
-      scalar_t *rp = r_->data<scalar_t>();
-      at::parallel_for(0, r_Size, TH_OMP_OVERHEAD_THRESHOLD,
-          [&](int64_t start, int64_t end) {
-        for (auto i = start; i < end; i++) {
-#if defined(TH_REAL_IS_FLOAT)
-          rp[i] = tp[i] * powf(2, sp[i]);
-#elif defined(TH_REAL_IS_DOUBLE)
-          rp[i] = tp[i] * pow(2, sp[i]);
-#elif defined(TH_REAL_IS_BYTE)
-          rp[i] = ((scalar_t) tp[i]) << sp[i];
-#else
-          rp[i] = ((ureal) tp[i]) << sp[i];
-#endif
-        }
-      });
-    } else {
-#if defined(TH_REAL_IS_FLOAT)
-      TH_TENSOR_APPLY3_PARALLEL(r_Size, r_Contig, tContig, srcContig, scalar_t, r_, scalar_t, t, scalar_t, src, *r__data = *t_data * powf(2, *src_data);, UNCERTAIN_TH_OMP_OVERHEAD_THRESHOLD);
-#elif defined(TH_REAL_IS_DOUBLE)
-      TH_TENSOR_APPLY3_PARALLEL(r_Size, r_Contig, tContig, srcContig, scalar_t, r_, scalar_t, t, scalar_t, src, *r__data = *t_data * pow(2, *src_data);, UNCERTAIN_TH_OMP_OVERHEAD_THRESHOLD);
-#elif defined(TH_REAL_IS_BYTE)
-      TH_TENSOR_APPLY3_PARALLEL(r_Size, r_Contig, tContig, srcContig, scalar_t, r_, scalar_t, t, scalar_t, src, *r__data = ((scalar_t)*t_data) << *src_data;, UNCERTAIN_TH_OMP_OVERHEAD_THRESHOLD);
-#else
-      TH_TENSOR_APPLY3_PARALLEL(r_Size, r_Contig, tContig, srcContig, scalar_t, r_, scalar_t, t, scalar_t, src, *r__data = ((ureal)*t_data) << *src_data;, UNCERTAIN_TH_OMP_OVERHEAD_THRESHOLD);
-#endif
-    }
-  } else {
-#if defined(TH_REAL_IS_FLOAT)
-      TH_TENSOR_APPLY3(scalar_t, r_, scalar_t, t, scalar_t, src, *r__data = *t_data * powf(2, *src_data););
-#elif defined(TH_REAL_IS_DOUBLE)
-      TH_TENSOR_APPLY3(scalar_t, r_, scalar_t, t, scalar_t, src, *r__data = *t_data * pow(2, *src_data););
-#elif defined(TH_REAL_IS_BYTE)
-      TH_TENSOR_APPLY3(scalar_t, r_, scalar_t, t, scalar_t, src, *r__data = ((scalar_t)*t_data) << *src_data;);
-#else
-      TH_TENSOR_APPLY3(scalar_t, r_, scalar_t, t, scalar_t, src, *r__data = ((ureal)*t_data) << *src_data;);
-#endif
-  }
-}
-
 void THTensor_(crshift)(THTensor *r_, THTensor *t, THTensor *src)
 {
 #if defined(TH_REAL_IS_HALF)

--- a/aten/src/TH/generic/THTensorMath.h
+++ b/aten/src/TH/generic/THTensorMath.h
@@ -103,7 +103,6 @@ TH_API void THTensor_(cumprod)(THTensor *r_, THTensor *t, int dimension);
 
 TH_API accreal THTensor_(dot)(THTensor *t, THTensor *src);
 
-TH_API void THTensor_(lshift)(THTensor *r_, THTensor *t, scalar_t value);
 TH_API void THTensor_(rshift)(THTensor *r_, THTensor *t, scalar_t value);
 TH_API void THTensor_(fmod)(THTensor *r_, THTensor *t, scalar_t value);
 TH_API void THTensor_(remainder)(THTensor *r_, THTensor *t, scalar_t value);
@@ -113,7 +112,6 @@ TH_API void THTensor_(cadd)(THTensor *r_, THTensor *t, scalar_t value, THTensor 
 TH_API void THTensor_(csub)(THTensor *self, THTensor *src1, scalar_t value, THTensor *src2);
 TH_API void THTensor_(cmul)(THTensor *r_, THTensor *t, THTensor *src);
 TH_API void THTensor_(cdiv)(THTensor *r_, THTensor *t, THTensor *src);
-TH_API void THTensor_(clshift)(THTensor *r_, THTensor *t, THTensor *src);
 TH_API void THTensor_(crshift)(THTensor *r_, THTensor *t, THTensor *src);
 TH_API void THTensor_(cfmod)(THTensor *r_, THTensor *t, THTensor *src);
 TH_API void THTensor_(cremainder)(THTensor *r_, THTensor *t, THTensor *src);

--- a/aten/src/THC/THCTensorMathPairwise.cu
+++ b/aten/src/THC/THCTensorMathPairwise.cu
@@ -232,20 +232,6 @@ struct TensorTriOp {
 };
 
 template <typename T>
-struct TensorLShiftConstantOp {
-  TensorLShiftConstantOp(T v) : val(v) {}
-  __device__ __forceinline__ void operator()(T* out, T* in) {
-    *out = *in << val;
-  }
-
-  __device__ __forceinline__ void operator()(T* v) {
-    *v <<= val;
-  }
-
-  const T val;
-};
-
-template <typename T>
 struct TensorRShiftConstantOp {
   TensorRShiftConstantOp(T v) : val(v) {}
   __device__ __forceinline__ void operator()(T* out, T* in) {

--- a/aten/src/THC/THCTensorMathPointwise.cuh
+++ b/aten/src/THC/THCTensorMathPointwise.cuh
@@ -244,45 +244,6 @@ struct TensorMinValueOp {
 };
 
 template <typename T>
-struct TensorLShiftOp {
-  __device__ __forceinline__ void
-  operator()(T* out, T* in) {
-    *out <<= *in;
-  }
-
-  __device__ __forceinline__ void
-  operator()(T* out, T* in1, T* in2) {
-    *out = *in1 << *in2;
-  }
-};
-
-template <>
-struct TensorLShiftOp<float> {
-  __device__ __forceinline__ void
-  operator()(float* out, float* in) {
-    *out *= powf(2.0f, *in);
-  }
-
-  __device__ __forceinline__ void
-  operator()(float* out, float* in1, float* in2) {
-    *out = *in1 * powf(2.0f, *in2);
-  }
-};
-
-template <>
-struct TensorLShiftOp<double> {
-  __device__ __forceinline__ void
-  operator()(double* out, double* in) {
-    *out *= pow(2.0, *in);
-  }
-
-  __device__ __forceinline__ void
-  operator()(double* out, double* in1, double* in2) {
-    *out = *in1 * pow(2.0, *in2);
-  }
-};
-
-template <typename T>
 struct TensorRShiftOp {
   __device__ __forceinline__ void
   operator()(T* out, T* in) {

--- a/aten/src/THC/generic/THCTensorMathPairwise.cu
+++ b/aten/src/THC/generic/THCTensorMathPairwise.cu
@@ -79,29 +79,6 @@ void THCTensor_(div)(THCState* state, THCTensor *self_, THCTensor *src_, scalar_
   THCudaCheck(cudaGetLastError());
 }
 
-void THCTensor_(lshift)(THCState* state, THCTensor *self_, THCTensor *src_, scalar_t value)
-{
-#if defined(THC_REAL_IS_FLOAT) || defined(THC_REAL_IS_DOUBLE)
-  THCTensor_(mul)(state, self_, src_, pow(2, value));
-#elif defined(THC_REAL_IS_HALF)
-  return THError("lshift not supported for torch.CudaHalfTensor");
-#else
-  if (self_ == src_) {
-    if (!THC_pointwiseApply1<scalar_t>(state, self_, TensorLShiftConstantOp<scalar_t>(value))) {
-      THArgCheck(false, 2, CUTORCH_DIM_WARNING);
-    }
-  } else {
-    THCTensor_(resizeAs)(state, self_, src_);
-
-    if (!THC_pointwiseApply2<scalar_t, scalar_t>(state, self_, src_, TensorLShiftConstantOp<scalar_t>(value))) {
-      THArgCheck(false, 2, CUTORCH_DIM_WARNING);
-    }
-  }
-
-  THCudaCheck(cudaGetLastError());
-#endif
-}
-
 void THCTensor_(rshift)(THCState* state, THCTensor *self_, THCTensor *src_, scalar_t value)
 {
 #if defined(THC_REAL_IS_FLOAT) || defined(THC_REAL_IS_DOUBLE)

--- a/aten/src/THC/generic/THCTensorMathPairwise.h
+++ b/aten/src/THC/generic/THCTensorMathPairwise.h
@@ -8,7 +8,6 @@ THC_API int THCTensor_(equal)(THCState *state, THCTensor *self, THCTensor *src);
 
 THC_API void THCTensor_(mul)(THCState *state, THCTensor *self, THCTensor *src, scalar_t value);
 THC_API void THCTensor_(div)(THCState *state, THCTensor *self, THCTensor *src, scalar_t value);
-THC_API void THCTensor_(lshift)(THCState *state, THCTensor *self, THCTensor *src, scalar_t value);
 THC_API void THCTensor_(rshift)(THCState *state, THCTensor *self, THCTensor *src, scalar_t value);
 THC_API void THCTensor_(fmod)(THCState *state, THCTensor *self, THCTensor *src, scalar_t value);
 THC_API void THCTensor_(remainder)(THCState *state, THCTensor *self, THCTensor *src, scalar_t value);

--- a/aten/src/THC/generic/THCTensorMathPointwise.cu
+++ b/aten/src/THC/generic/THCTensorMathPointwise.cu
@@ -207,33 +207,6 @@ void THCTensor_(cdiv)(THCState* state, THCTensor *self_, THCTensor *src1, THCTen
   at::div_out(out, at::Tensor(retainTensorImpl(src1)), at::Tensor(retainTensorImpl(src2)));
 }
 
-void THCTensor_(clshift)(THCState* state, THCTensor *self_, THCTensor *src1, THCTensor *src2)
-{
-#if defined(THC_REAL_IS_HALF)
-  return THError("clshift not supported for torch.CudaHalfTensor");
-#else
-  THAssert(THCTensor_(checkGPU)(state, 3, self_, src1, src2));
-  THArgCheck(THCTensor_(nElement)(state, src1) ==
-             THCTensor_(nElement)(state, src2), 3, "sizes do not match");
-
-  if (self_ == src1) {
-    // self /= src2
-    if (!THC_pointwiseApply2<scalar_t, scalar_t>(state, self_, src2, TensorLShiftOp<scalar_t>())) {
-      THArgCheck(false, 2, CUTORCH_DIM_WARNING);
-    }
-  } else {
-    THCTensor_(resizeAs)(state, self_, src1);
-
-    // self = src1 / src2
-    if (!THC_pointwiseApply3<scalar_t, scalar_t, scalar_t>(state, self_, src1, src2, TensorLShiftOp<scalar_t>())) {
-      THArgCheck(false, 2, CUTORCH_DIM_WARNING);
-    }
-  }
-
-  THCudaCheck(cudaGetLastError());
-#endif
-}
-
 void THCTensor_(crshift)(THCState* state, THCTensor *self_, THCTensor *src1, THCTensor *src2)
 {
 #if defined(THC_REAL_IS_HALF)


### PR DESCRIPTION
@VitalyFedyunin , this PR is about move lshift to Aten. 
Benchmark script :
```
import timeit
import torch
torch.manual_seed(1)

for n, t in [(10, 100000),(1000, 10000)]:
    print('__lshift__ (a.numel() == {}) for {} times'.format(n, t))
    for device in ('cpu', 'cuda'):
        for dtype in ('torch.int8', 'torch.uint8', 'torch.int16', 'torch.int32', 'torch.int64'):
            print(f'device: {device}, dtype: {dtype}, {t} times', end='\t\t')
            print(timeit.timeit(f'a << b\nif "{device}" == "cuda": torch.cuda.synchronize()', setup=f'import torch; a = torch.randint(0, 10, ({n},), dtype = {dtype}, device="{device}"); b = torch.randint(0, 10, ({n},), dtype = {dtype}, device="{device}")', number=t))
        for dtype in ('torch.float32', 'torch.float64'):
            print(f'device: {device}, dtype: {dtype}, {t} times', end='\t\t')
            print(timeit.timeit(f'a << b\nif "{device}" == "cuda": torch.cuda.synchronize()', setup=f'import torch; a = torch.randn({n}, dtype = {dtype}, device="{device}"); b = torch.randn({n}, dtype = {dtype}, device="{device}")', number=t))


for n, t in [(10, 100000),(1000, 10000)]:
    print('__ilshift__ (a.numel() == {}) for {} times'.format(n, t))
    for device in ('cpu', 'cuda'):
        for dtype in ('torch.int8', 'torch.uint8', 'torch.int16', 'torch.int32', 'torch.int64'):
            print(f'device: {device}, dtype: {dtype}, {t} times', end='\t\t')
            print(timeit.timeit(f'a << b\nif "{device}" == "cuda": torch.cuda.synchronize()', setup=f'import torch; a = torch.randint(0, 10, ({n},), dtype = {dtype}, device="{device}"); b = torch.tensor(5, dtype = {dtype}, device="{device}")', number=t))
        for dtype in ('torch.float32', 'torch.float64'):
            print(f'device: {device}, dtype: {dtype}, {t} times', end='\t\t')
            print(timeit.timeit(f'a << b\nif "{device}" == "cuda": torch.cuda.synchronize()', setup=f'import torch; a = torch.randn({n}, dtype = {dtype}, device="{device}"); b = torch.tensor(5, dtype = {dtype}, device="{device}")', number=t))
```
Device: **Tesla P100, skx-8180**
Cuda verison: **9.0.176**

Before:
```
__lshift__ (a.numel() == 10) for 100000 times
device: cpu, dtype: torch.int8, 100000 times            0.31618343852460384
device: cpu, dtype: torch.uint8, 100000 times           0.31258584931492805
device: cpu, dtype: torch.int16, 100000 times           0.3140896391123533
device: cpu, dtype: torch.int32, 100000 times           0.34389012958854437
device: cpu, dtype: torch.int64, 100000 times           0.339566046372056
device: cpu, dtype: torch.float32, 100000 times         0.4180623721331358
device: cpu, dtype: torch.float64, 100000 times         0.4165227338671684
device: cuda, dtype: torch.int8, 100000 times           1.7851383443921804
device: cuda, dtype: torch.uint8, 100000 times          1.7842160519212484
device: cuda, dtype: torch.int16, 100000 times          1.789359962567687
device: cuda, dtype: torch.int32, 100000 times          1.7822618428617716
device: cuda, dtype: torch.int64, 100000 times          1.7968465769663453
device: cuda, dtype: torch.float32, 100000 times                1.8066061967983842
device: cuda, dtype: torch.float64, 100000 times                1.8046843251213431
__lshift__ (a.numel() == 1000) for 10000 times
device: cpu, dtype: torch.int8, 10000 times             0.04618230368942022
device: cpu, dtype: torch.uint8, 10000 times            0.04634759668260813
device: cpu, dtype: torch.int16, 10000 times            0.040676115080714226
device: cpu, dtype: torch.int32, 10000 times            0.04404774494469166
device: cpu, dtype: torch.int64, 10000 times            0.04511771444231272
device: cpu, dtype: torch.float32, 10000 times          0.6887832451611757
device: cpu, dtype: torch.float64, 10000 times          0.5559549620375037
device: cuda, dtype: torch.int8, 10000 times            0.17996764183044434
device: cuda, dtype: torch.uint8, 10000 times           0.17970609478652477
device: cuda, dtype: torch.int16, 10000 times           0.17873135022819042
device: cuda, dtype: torch.int32, 10000 times           0.1781835313886404
device: cuda, dtype: torch.int64, 10000 times           0.17846618220210075
device: cuda, dtype: torch.float32, 10000 times         0.18056879844516516
device: cuda, dtype: torch.float64, 10000 times         0.18132662680000067
__ilshift__ (a.numel() == 10) for 100000 times
device: cpu, dtype: torch.int8, 100000 times            0.61110960226506
device: cpu, dtype: torch.uint8, 100000 times           0.6333359787240624
device: cpu, dtype: torch.int16, 100000 times           0.6345370784401894
device: cpu, dtype: torch.int32, 100000 times           0.6470990972593427
device: cpu, dtype: torch.int64, 100000 times           0.6587044578045607
device: cpu, dtype: torch.float32, 100000 times         0.7269002720713615
device: cpu, dtype: torch.float64, 100000 times         0.7217964073643088
device: cuda, dtype: torch.int8, 100000 times           1.9880435159429908
device: cuda, dtype: torch.uint8, 100000 times          1.986489498987794
device: cuda, dtype: torch.int16, 100000 times          2.0059875370934606
device: cuda, dtype: torch.int32, 100000 times          1.995262237265706
device: cuda, dtype: torch.int64, 100000 times          1.9974954994395375
device: cuda, dtype: torch.float32, 100000 times                2.00442770216614
device: cuda, dtype: torch.float64, 100000 times                2.009664717130363
__ilshift__ (a.numel() == 1000) for 10000 times
device: cpu, dtype: torch.int8, 10000 times             0.08199594635516405
device: cpu, dtype: torch.uint8, 10000 times            0.08096733782440424
device: cpu, dtype: torch.int16, 10000 times            0.0734213450923562
device: cpu, dtype: torch.int32, 10000 times            0.0769620593637228
device: cpu, dtype: torch.int64, 10000 times            0.08650507684797049
device: cpu, dtype: torch.float32, 10000 times          0.7196345143020153
device: cpu, dtype: torch.float64, 10000 times          0.597336508333683
device: cuda, dtype: torch.int8, 10000 times            0.19723015930503607
device: cuda, dtype: torch.uint8, 10000 times           0.19754122477024794
device: cuda, dtype: torch.int16, 10000 times           0.19710093270987272
device: cuda, dtype: torch.int32, 10000 times           0.19611249305307865
device: cuda, dtype: torch.int64, 10000 times           0.19750046730041504
device: cuda, dtype: torch.float32, 10000 times         0.19680574722588062
device: cuda, dtype: torch.float64, 10000 times         0.19689027685672045
```
After:
```
__lshift__ (a.numel() == 10) for 100000 times
device: cpu, dtype: torch.int8, 100000 times            0.3031281465664506
device: cpu, dtype: torch.uint8, 100000 times           0.30772678554058075
device: cpu, dtype: torch.int16, 100000 times           0.3088294789195061
device: cpu, dtype: torch.int32, 100000 times           0.30907699652016163
device: cpu, dtype: torch.int64, 100000 times           0.31315001379698515
device: cpu, dtype: torch.float32, 100000 times         0.38823566399514675
device: cpu, dtype: torch.float64, 100000 times         0.39300001971423626
device: cuda, dtype: torch.int8, 100000 times           1.3225595457479358
device: cuda, dtype: torch.uint8, 100000 times          1.31739442050457
device: cuda, dtype: torch.int16, 100000 times          1.3198596313595772
device: cuda, dtype: torch.int32, 100000 times          1.309600466862321
device: cuda, dtype: torch.int64, 100000 times          1.3264533821493387
device: cuda, dtype: torch.float32, 100000 times                1.3377520674839616
device: cuda, dtype: torch.float64, 100000 times                1.3343619462102652
__lshift__ (a.numel() == 1000) for 10000 times
device: cpu, dtype: torch.int8, 10000 times             0.02718757465481758
device: cpu, dtype: torch.uint8, 10000 times            0.02701799664646387
device: cpu, dtype: torch.int16, 10000 times            0.025483975186944008
device: cpu, dtype: torch.int32, 10000 times            0.025557605549693108
device: cpu, dtype: torch.int64, 10000 times            0.026179466396570206
device: cpu, dtype: torch.float32, 10000 times          0.0962932649999857
device: cpu, dtype: torch.float64, 10000 times          0.1611471576616168
device: cuda, dtype: torch.int8, 10000 times            0.13165222201496363
device: cuda, dtype: torch.uint8, 10000 times           0.13358880020678043
device: cuda, dtype: torch.int16, 10000 times           0.1342075066640973
device: cuda, dtype: torch.int32, 10000 times           0.1328689968213439
device: cuda, dtype: torch.int64, 10000 times           0.13336248509585857
device: cuda, dtype: torch.float32, 10000 times         0.1345295710489154
device: cuda, dtype: torch.float64, 10000 times         0.14084953162819147
__ilshift__ (a.numel() == 10) for 100000 times
device: cpu, dtype: torch.int8, 100000 times            0.19080814253538847
device: cpu, dtype: torch.uint8, 100000 times           0.18541878275573254
device: cpu, dtype: torch.int16, 100000 times           0.19136024825274944
device: cpu, dtype: torch.int32, 100000 times           0.1916898973286152
device: cpu, dtype: torch.int64, 100000 times           0.1973192635923624
device: cpu, dtype: torch.float32, 100000 times         0.2668355852365494
device: cpu, dtype: torch.float64, 100000 times         0.24472137168049812
device: cuda, dtype: torch.int8, 100000 times           1.3581306440755725
device: cuda, dtype: torch.uint8, 100000 times          1.3522163443267345
device: cuda, dtype: torch.int16, 100000 times          1.366145665757358
device: cuda, dtype: torch.int32, 100000 times          1.3674909211695194
device: cuda, dtype: torch.int64, 100000 times          1.3734915973618627
device: cuda, dtype: torch.float32, 100000 times                1.3831533305346966
device: cuda, dtype: torch.float64, 100000 times                1.396162535995245
__ilshift__ (a.numel() == 1000) for 10000 times
device: cpu, dtype: torch.int8, 10000 times             0.02847585454583168
device: cpu, dtype: torch.uint8, 10000 times            0.02960751298815012
device: cpu, dtype: torch.int16, 10000 times            0.028516249731183052
device: cpu, dtype: torch.int32, 10000 times            0.02842544950544834
device: cpu, dtype: torch.int64, 10000 times            0.029186096973717213
device: cpu, dtype: torch.float32, 10000 times          0.0999628696590662
device: cpu, dtype: torch.float64, 10000 times          0.16676222812384367
device: cuda, dtype: torch.int8, 10000 times            0.13856443110853434
device: cuda, dtype: torch.uint8, 10000 times           0.13766566663980484
device: cuda, dtype: torch.int16, 10000 times           0.13652489613741636
device: cuda, dtype: torch.int32, 10000 times           0.13678150344640017
device: cuda, dtype: torch.int64, 10000 times           0.13749946560710669
device: cuda, dtype: torch.float32, 10000 times         0.13879029918462038
device: cuda, dtype: torch.float64, 10000 times         0.14587809145450592
```

Fix #24510 #24514 #24657  #24661 