### PR TITLE
Update the descriptive error message for enforce fail

### DIFF
--- a/c10/util/Exception.h
+++ b/c10/util/Exception.h
@@ -115,6 +115,12 @@ class C10_API IndexError : public Error {
 };
 
 
+// Used in ATen for non finite indices.  These turn into
+// ExitException when they cross to Python.
+class C10_API EnforceFiniteError : public Error {
+  using Error::Error;
+};
+
 // A utility function to return an exception std::string by prepending its
 // exception type before its what() content
 C10_API std::string GetExceptionString(const std::exception& e);

--- a/c10/util/Logging.cpp
+++ b/c10/util/Logging.cpp
@@ -49,6 +49,18 @@ void ThrowEnforceNotMet(
   throw e;
 }
 
+
+void ThrowEnforceFiniteNotMet(
+    const char* file,
+    const int line,
+    const char* condition,
+    const std::string& msg,
+    const void* caller) {
+    throw c10::EnforceFiniteError(
+      file, line, condition, msg, (*GetFetchStackTrace())(), caller
+    );
+}
+
 // PyTorch-style error message
 // (This must be defined here for access to GetFetchStackTrace)
 Error::Error(SourceLocation source_location, const std::string& msg)

--- a/c10/util/Logging.h
+++ b/c10/util/Logging.h
@@ -69,6 +69,13 @@ C10_API void UpdateLoggingLevelsFromFlags();
     const std::string& msg,
     const void* caller = nullptr);
 
+[[noreturn]] C10_API void ThrowEnforceFiniteNotMet(
+    const char* file,
+    const int line,
+    const char* condition,
+    const std::string& msg,
+    const void* caller = nullptr);
+
 constexpr bool IsUsingGoogleLogging() {
 #ifdef C10_USE_GLOG
   return true;
@@ -98,6 +105,14 @@ using EnforceNotMet = ::c10::Error;
           __FILE__, __LINE__, #condition, ::c10::str(__VA_ARGS__)); \
     }                                                               \
   } while (false)
+
+#define CAFFE_ENFORCE_FINITE(condition, ...)                        \
+    do {                                                            \
+      if (C10_UNLIKELY(!(condition))) {                             \
+        ::c10::ThrowEnforceFiniteNotMet(                            \
+          __FILE__, __LINE__, #condition, ::c10::str(__VA_ARGS__)); \
+      }                                                             \
+    } while (false)
 
 #define CAFFE_ENFORCE_WITH_CALLER(condition, ...)                         \
   do {                                                                    \

--- a/caffe2/operators/enforce_finite_op.h
+++ b/caffe2/operators/enforce_finite_op.h
@@ -32,7 +32,7 @@ class EnforceFiniteOp final : public Operator<Context> {
     auto size = input.numel();
 
     for (auto i = 0; i < size; i++) {
-      CAFFE_ENFORCE(
+      CAFFE_ENFORCE_FINITE(
           std::isfinite(input_data[i]),
           "Index ",
           i,


### PR DESCRIPTION
Summary:
We need a new exception class specifically for the enforce_finite operator, because we need to map it to a specific python exception ExitException, not the RuntimeError type that all c10::Errors get mapped to by default. This diff includes:
- Define c10::EnforceFiniteNotMet
- API to throw c10::EnforceFiniteNotMet
- Map from c10::EnforceFiniteNotMet to python ExitException

Test Plan: integration test

Differential Revision: D19206240

