### PR TITLE
Revert "Use [[deprecated]] instead of C10_DEPRECATED (#30918)"

### DIFF
--- a/aten/src/ATen/Dispatch.h
+++ b/aten/src/ATen/Dispatch.h
@@ -26,19 +26,19 @@ inline at::ScalarType scalar_type(at::ScalarType s) {
   return s;
 }
 
-[[deprecated("passing at::DeprecatedTypeProperties to an AT_DISPATCH macro is deprecated, " \
-                       "pass an at::ScalarType instead")]]
+C10_DEPRECATED_MESSAGE("passing at::DeprecatedTypeProperties to an AT_DISPATCH macro is deprecated, " \
+                       "pass an at::ScalarType instead")
 inline at::ScalarType scalar_type(const at::DeprecatedTypeProperties &t) {
   return t.scalarType();
 }
 
-[[deprecated("AT_DISPATCH_ALL_TYPES_AND_HALF is deprecated, " \
-                       "use AT_DISPATCH_ALL_TYPES_AND(at::ScalarType::Half, ...) instead")]]
+C10_DEPRECATED_MESSAGE("AT_DISPATCH_ALL_TYPES_AND_HALF is deprecated, " \
+                       "use AT_DISPATCH_ALL_TYPES_AND(at::ScalarType::Half, ...) instead")
 inline void deprecated_AT_DISPATCH_ALL_TYPES_AND_HALF() {}
 
-[[deprecated("AT_DISPATCH_ALL_TYPES_AND_HALF_AND_COMPLEX is deprecated, "            \
+C10_DEPRECATED_MESSAGE("AT_DISPATCH_ALL_TYPES_AND_HALF_AND_COMPLEX is deprecated, "            \
                        "use AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND(at::ScalarType::Half, ...) " \
-                       "instead")]]
+                       "instead")
 inline void deprecated_AT_DISPATCH_ALL_TYPES_AND_HALF_AND_COMPLEX() {}
 
 }

--- a/aten/src/ATen/core/TensorAccessor.h
+++ b/aten/src/ATen/core/TensorAccessor.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <c10/macros/Macros.h>
+#include <c10/util/Deprecated.h>
 #include <stdint.h>
 #include <cstddef>
 
@@ -219,7 +220,7 @@ public:
 
 // Old name for `GenericPackedTensorAccessor`
 template <typename T, size_t N, template <typename U> class PtrTraits = DefaultPtrTraits, typename index_t = int64_t>
-using PackedTensorAccessor [[deprecated]] = AT_X;
+C10_DEFINE_DEPRECATED_USING(PackedTensorAccessor, AT_X)
 
 #undef AT_X
 

--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -237,7 +237,7 @@ struct CAFFE2_API IValue final {
   IValue(c10::List<int64_t> v);
   IValue(c10::ArrayRef<int64_t> v);
   /// \cond DOXYGEN_CANNOT_HANDLE_CONSTRUCTORS_WITH_MACROS_SO_EXCLUDE_THIS_LINE_FROM_DOXYGEN
-  [[deprecated("IValues based on std::vector<T> are potentially slow and deprecated. Please use c10::List<T> instead.")]]
+  C10_DEPRECATED_MESSAGE("IValues based on std::vector<T> are potentially slow and deprecated. Please use c10::List<T> instead.")
   /// \endcond
   IValue(std::vector<int64_t> v);
   bool isIntList() const { return Tag::IntList == tag; }
@@ -257,7 +257,7 @@ struct CAFFE2_API IValue final {
   // DoubleList
   IValue(c10::List<double> v);
   /// \cond DOXYGEN_CANNOT_HANDLE_CONSTRUCTORS_WITH_MACROS_SO_EXCLUDE_THIS_LINE_FROM_DOXYGEN
-  [[deprecated("IValues based on std::vector<T> are potentially slow and deprecated. Please use c10::List<T> instead.")]]
+  C10_DEPRECATED_MESSAGE("IValues based on std::vector<T> are potentially slow and deprecated. Please use c10::List<T> instead.")
   /// \endcond
   IValue(std::vector<double> v);
   bool isDoubleList() const { return Tag::DoubleList == tag; }
@@ -268,7 +268,7 @@ struct CAFFE2_API IValue final {
   // BoolList
   IValue(c10::List<bool> v);
   /// \cond DOXYGEN_CANNOT_HANDLE_CONSTRUCTORS_WITH_MACROS_SO_EXCLUDE_THIS_LINE_FROM_DOXYGEN
-  [[deprecated("IValues based on std::vector<T> are potentially slow and deprecated. Please use c10::List<T> instead.")]]
+  C10_DEPRECATED_MESSAGE("IValues based on std::vector<T> are potentially slow and deprecated. Please use c10::List<T> instead.")
   /// \endcond
   IValue(std::vector<bool> v);
   bool isBoolList() const { return Tag::BoolList == tag; }
@@ -278,7 +278,7 @@ struct CAFFE2_API IValue final {
   //TensorList
   IValue(c10::List<at::Tensor> v);
   /// \cond DOXYGEN_CANNOT_HANDLE_CONSTRUCTORS_WITH_MACROS_SO_EXCLUDE_THIS_LINE_FROM_DOXYGEN
-  [[deprecated("IValues based on std::vector<T> are potentially slow and deprecated. Please use c10::List<T> instead.")]]
+  C10_DEPRECATED_MESSAGE("IValues based on std::vector<T> are potentially slow and deprecated. Please use c10::List<T> instead.")
   /// \endcond
   IValue(std::vector<at::Tensor> v);
   bool isTensorList() const { return Tag::TensorList == tag; }
@@ -297,7 +297,7 @@ struct CAFFE2_API IValue final {
   IValue(c10::List<T> v);
   template<class T>
   /// \cond DOXYGEN_CANNOT_HANDLE_CONSTRUCTORS_WITH_MACROS_SO_EXCLUDE_THIS_LINE_FROM_DOXYGEN
-  [[deprecated("IValues based on std::vector<T> are potentially slow and deprecated. Please use c10::List<T> instead.")]]
+  C10_DEPRECATED_MESSAGE("IValues based on std::vector<T> are potentially slow and deprecated. Please use c10::List<T> instead.")
   /// \endcond
   IValue(std::vector<T> v);
 
@@ -312,7 +312,7 @@ struct CAFFE2_API IValue final {
 
   template<class Key, class Value>
   /// \cond DOXYGEN_CANNOT_HANDLE_CONSTRUCTORS_WITH_MACROS_SO_EXCLUDE_THIS_LINE_FROM_DOXYGEN
-  [[deprecated("IValues based on std::unordered_map<K, V> are slow and deprecated. Please use c10::Dict<K, V> instead.")]]
+  C10_DEPRECATED_MESSAGE("IValues based on std::unordered_map<K, V> are slow and deprecated. Please use c10::Dict<K, V> instead.")
   /// \endcond
   IValue(std::unordered_map<Key, Value> v);
 

--- a/aten/src/ATen/core/ivalue_inl.h
+++ b/aten/src/ATen/core/ivalue_inl.h
@@ -471,7 +471,7 @@ struct _fake_type {};
 // based on the return type.
 template <class Elem>
 // TODO this is deprecated but we don't throw a warning because a lot of ops in native_functions.yaml still return std::vector.
-//[[deprecated("IValues based on std::vector<T> are potentially slow and deprecated. Please use torch::List<T> instead.")]]
+//C10_DEPRECATED_MESSAGE("IValues based on std::vector<T> are potentially slow and deprecated. Please use torch::List<T> instead.")
 std::vector<Elem> generic_to(
     IValue ivalue,
     _fake_type<std::vector<Elem>>) {
@@ -519,7 +519,7 @@ c10::Dict<Key, Value> generic_to(
 }
 
 template <typename K, typename V>
-[[deprecated("IValues based on std::unordered_map are slow and deprecated. Please use c10::Dict<K, V> instead.")]]
+C10_DEPRECATED_MESSAGE("IValues based on std::unordered_map are slow and deprecated. Please use c10::Dict<K, V> instead.")
 std::unordered_map<K, V> generic_to(
     IValue ivalue,
     _fake_type<std::unordered_map<K, V>>) {

--- a/aten/src/ATen/core/op_registration/op_registration.h
+++ b/aten/src/ATen/core/op_registration/op_registration.h
@@ -553,7 +553,7 @@ public:
     }
 
     template<class Lambda>
-    [[deprecated("Registering operator kernels with stateful lambdas (i.e. lambdas with a capture) has non-obvious behavior. This is deprecated. Please use a lambda without a capture or a functor class instead.")]]
+    C10_DEPRECATED_MESSAGE("Registering operator kernels with stateful lambdas (i.e. lambdas with a capture) has non-obvious behavior. This is deprecated. Please use a lambda without a capture or a functor class instead.")
     // enable_if: only enable it if Lambda is actually a functor but not a stateless lambda
     std::enable_if_t<guts::is_functor<Lambda>::value && !guts::is_stateless_lambda<std::decay_t<Lambda>>::value, RegisterOperators&&>
     op(const std::string& schemaOrName, Lambda&& lambda, Options&& options = RegisterOperators::options()) && {

--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -153,7 +153,7 @@ static inline ${return_type} ${api_name}(${formals_with_defaults});
 """)
 # add a method declaration in Functions.h
 DEPRECATED_FUNCTION_DECLARATION = CodeTemplate("""\
-[[deprecated]] static inline ${return_type} ${api_name}(${formals_with_defaults});
+C10_DEPRECATED static inline ${return_type} ${api_name}(${formals_with_defaults});
 """)
 # add method definition in Functions.h
 C10_FUNCTION_DEFINITION = CodeTemplate("""\

--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -10,6 +10,7 @@
 #include <ATen/Dispatch.h>
 #include <ATen/NativeFunctions.h>
 #include <c10/core/ScalarType.h>
+#include <c10/util/Deprecated.h>
 #include <ATen/native/Resize.h>
 #include <ATen/native/TensorFactories.h>
 #include <c10/core/TensorOptions.h>

--- a/aten/src/ATen/templates/Functions.h
+++ b/aten/src/ATen/templates/Functions.h
@@ -6,6 +6,7 @@
 #include <ATen/Tensor.h>
 #include <c10/core/Storage.h>
 #include <ATen/core/Generator.h>
+#include <c10/util/Deprecated.h>
 #include <ATen/NativeFunctions.h>
 #include <ATen/DeviceGuard.h>
 #include <c10/core/TensorOptions.h>

--- a/aten/src/ATen/templates/TensorBody.h
+++ b/aten/src/ATen/templates/TensorBody.h
@@ -11,6 +11,7 @@
 #include <c10/core/TensorImpl.h>
 #include <c10/core/UndefinedTensorImpl.h>
 #include <c10/util/Exception.h>
+#include <c10/util/Deprecated.h>
 #include <c10/util/Optional.h>
 #include <c10/util/intrusive_ptr.h>
 #include <ATen/core/DeprecatedTypePropertiesRegistry.h>
@@ -234,7 +235,7 @@ class CAFFE2_API Tensor {
     return impl_->itemsize();
   }
 
-  [[deprecated("Tensor.type() is deprecated. Instead use Tensor.options(), which in many cases (e.g. in a constructor) is a drop-in replacement. If you were using data from type(), that is now available from Tensor itself, so instead of tensor.type().scalar_type(), use tensor.scalar_type() instead and instead of tensor.type().backend() use tensor.device().")]]
+  C10_DEPRECATED_MESSAGE("Tensor.type() is deprecated. Instead use Tensor.options(), which in many cases (e.g. in a constructor) is a drop-in replacement. If you were using data from type(), that is now available from Tensor itself, so instead of tensor.type().scalar_type(), use tensor.scalar_type() instead and instead of tensor.type().backend() use tensor.device().")
   DeprecatedTypeProperties & type() const {
     return globalDeprecatedTypePropertiesRegistry().getDeprecatedTypeProperties(
         tensorTypeIdToBackend(legacyExtractTypeId(type_set())),
@@ -258,7 +259,7 @@ class CAFFE2_API Tensor {
   Tensor toType(ScalarType t) const;
   Tensor toBackend(Backend b) const;
 
-  [[deprecated("Tensor.is_variable() is deprecated; everything is a variable now. (If you want to assert that variable has been appropriately handled already, use at::impl::variable_excluded_from_dispatch())")]]
+  C10_DEPRECATED_MESSAGE("Tensor.is_variable() is deprecated; everything is a variable now. (If you want to assert that variable has been appropriately handled already, use at::impl::variable_excluded_from_dispatch())")
   bool is_variable() const noexcept {
     return !at::impl::variable_excluded_from_dispatch();
   }
@@ -313,7 +314,7 @@ class CAFFE2_API Tensor {
   T * data_ptr() const;
 
   template<typename T>
-  [[deprecated("Tensor.data<T>() is deprecated. Please use Tensor.data_ptr<T>() instead.")]]
+  C10_DEPRECATED_MESSAGE("Tensor.data<T>() is deprecated. Please use Tensor.data_ptr<T>() instead.")
   T * data() const {
     return data_ptr<T>();
   }
@@ -364,12 +365,12 @@ class CAFFE2_API Tensor {
   PackedTensorAccessor64<T,N,PtrTraits> packed_accessor64() && = delete;
 
   template<typename T, size_t N, template <typename U> class PtrTraits = DefaultPtrTraits, typename index_t = int64_t>
-  [[deprecated("packed_accessor is deprecated, use packed_accessor32 or packed_accessor64 instead")]]
+  C10_DEPRECATED_MESSAGE("packed_accessor is deprecated, use packed_accessor32 or packed_accessor64 instead")
   GenericPackedTensorAccessor<T,N,PtrTraits,index_t> packed_accessor() const & {
     return generic_packed_accessor<T,N,PtrTraits,index_t>();
   }
   template<typename T, size_t N, template <typename U> class PtrTraits = DefaultPtrTraits, typename index_t = int64_t>
-  [[deprecated("packed_accessor is deprecated, use packed_accessor32 or packed_accessor64 instead")]]
+  C10_DEPRECATED_MESSAGE("packed_accessor is deprecated, use packed_accessor32 or packed_accessor64 instead")
   GenericPackedTensorAccessor<T,N,PtrTraits,index_t> packed_accessor() && = delete;
 
   Tensor operator-() const;

--- a/c10/core/MemoryFormat.h
+++ b/c10/core/MemoryFormat.h
@@ -31,7 +31,7 @@ enum class MemoryFormat : int8_t { Contiguous, Preserve, ChannelsLast };
 // behaviour of contiguous
 #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
 
-[[deprecated]] inline MemoryFormat get_contiguous_memory_format() {
+C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
   return MemoryFormat::Contiguous;
 }
 

--- a/c10/core/Scalar.h
+++ b/c10/core/Scalar.h
@@ -80,7 +80,7 @@ class C10_API Scalar {
     return Tag::HAS_d == tag;
   }
 
-  [[deprecated("isIntegral is deprecated. Please use the overload with 'includeBool' parameter instead.")]]
+  C10_DEPRECATED_MESSAGE("isIntegral is deprecated. Please use the overload with 'includeBool' parameter instead.")
   bool isIntegral() const {
     return Tag::HAS_i == tag;
   }

--- a/c10/core/ScalarType.h
+++ b/c10/core/ScalarType.h
@@ -253,7 +253,7 @@ static inline size_t elementSize(ScalarType t) {
 #undef CASE_ELEMENTSIZE_CASE
 }
 
-[[deprecated("isIntegralType is deprecated. Please use the overload with 'includeBool' parameter instead.")]]
+C10_DEPRECATED_MESSAGE("isIntegralType is deprecated. Please use the overload with 'includeBool' parameter instead.")
 static inline bool isIntegralType(ScalarType t) {
   return (
       t == ScalarType::Byte || t == ScalarType::Char || t == ScalarType::Int ||

--- a/c10/util/ArrayRef.h
+++ b/c10/util/ArrayRef.h
@@ -18,6 +18,7 @@
 #include <c10/util/SmallVector.h>
 #include <c10/util/C++17.h>
 #include <c10/util/Exception.h>
+#include <c10/util/Deprecated.h>
 
 #include <array>
 #include <iterator>
@@ -274,6 +275,6 @@ using IntArrayRef = ArrayRef<int64_t>;
 
 // This alias is deprecated because it doesn't make ownership
 // semantics obvious.  Use IntArrayRef instead!
-[[deprecated]] typedef ArrayRef<int64_t> IntList;
+C10_DEFINE_DEPRECATED_USING(IntList, ArrayRef<int64_t>)
 
 } // namespace c10

--- a/c10/util/Deprecated.h
+++ b/c10/util/Deprecated.h
@@ -1,0 +1,101 @@
+#pragma once
+
+/**
+ * This file provides portable macros for marking declarations
+ * as deprecated.  You should generally use C10_DEPRECATED,
+ * except when marking 'using' declarations as deprecated,
+ * in which case you should use C10_DEFINE_DEPRECATED_USING
+ * (due to portability concerns).
+ */
+
+// Sample usage:
+//
+//    C10_DEPRECATED void bad_func();
+//    struct C10_DEPRECATED BadStruct {
+//      ...
+//    };
+
+// NB: In PyTorch, this block is not actually used at the moment
+// because we are C++11.  However, aspirationally, we would like
+// to use this version, because as of C++14 it is the correct and
+// portable way to declare something deprecated.
+// NB: __cplusplus doesn't work for MSVC, so for now MSVC always uses
+// the "__declspec(deprecated)" implementation and not the C++14 "[[deprecated]]"
+// attribute. We tried enabling "[[deprecated]]" for C++14 on MSVC, but
+// ran into issues with some older MSVC versions.
+#if (defined(__cplusplus) && __cplusplus >= 201402L)
+# define C10_DEPRECATED [[deprecated]]
+# define C10_DEPRECATED_MESSAGE(message) [[deprecated(message)]]
+#elif defined(__GNUC__)
+# define C10_DEPRECATED __attribute__((deprecated))
+// TODO Is there some way to implement this?
+# define C10_DEPRECATED_MESSAGE(message) __attribute__((deprecated))
+
+#elif defined(_MSC_VER)
+# define C10_DEPRECATED __declspec(deprecated)
+# define C10_DEPRECATED_MESSAGE(message) __declspec(deprecated(message))
+#else
+# warning "You need to implement C10_DEPRECATED for this compiler"
+# define C10_DEPRECATED
+#endif
+
+
+// Sample usage:
+//
+//    C10_DEFINE_DEPRECATED_USING(BadType, int)
+//
+//   which is the portable version of
+//
+//    using BadType [[deprecated]] = int;
+
+// technically [[deprecated]] syntax is from c++14 standard, but it works in
+// many compilers.
+#if defined(__has_cpp_attribute)
+#if __has_cpp_attribute(deprecated)
+# define C10_DEFINE_DEPRECATED_USING(TypeName, TypeThingy) using TypeName [[deprecated]] = TypeThingy;
+#endif
+#endif
+
+#if defined(_MSC_VER)
+#if defined(__CUDACC__)
+// neither [[deprecated]] nor __declspec(deprecated) work on nvcc on Windows;
+// you get the error:
+//
+//    error: attribute does not apply to any entity
+//
+// So we just turn the macro off in this case.
+#if defined(C10_DEFINE_DEPRECATED_USING)
+# undef C10_DEFINE_DEPRECATED_USING
+#endif
+# define C10_DEFINE_DEPRECATED_USING(TypeName, TypeThingy) using TypeName = TypeThingy;
+#else
+// [[deprecated]] does work in windows without nvcc, though msc doesn't support
+// `__has_cpp_attribute` when c++14 is supported, otherwise __declspec(deprecated)
+// is used as the alternative.
+#ifndef C10_DEFINE_DEPRECATED_USING
+#if defined(_MSVC_LANG) && _MSVC_LANG >= 201402L
+# define C10_DEFINE_DEPRECATED_USING(TypeName, TypeThingy) using TypeName [[deprecated]] = TypeThingy;
+#else
+# define C10_DEFINE_DEPRECATED_USING(TypeName, TypeThingy) using TypeName = __declspec(deprecated) TypeThingy;
+#endif
+#endif
+#endif
+#endif
+
+#if !defined(C10_DEFINE_DEPRECATED_USING) && defined(__GNUC__)
+// nvcc has a bug where it doesn't understand __attribute__((deprecated))
+// declarations even when the host compiler supports it. We'll only use this gcc
+// attribute when not cuda, and when using a GCC compiler that doesn't support
+// the c++14 syntax we checked for above (available in __GNUC__ >= 5)
+#if !defined(__CUDACC__)
+# define C10_DEFINE_DEPRECATED_USING(TypeName, TypeThingy) using TypeName __attribute__((deprecated)) = TypeThingy;
+#else
+// using cuda + gcc < 5, neither deprecated syntax is available so turning off.
+# define C10_DEFINE_DEPRECATED_USING(TypeName, TypeThingy) using TypeName = TypeThingy;
+#endif
+#endif
+
+#if ! defined(C10_DEFINE_DEPRECATED_USING)
+# warning "You need to implement C10_DEFINE_DEPRECATED_USING for this compiler"
+# define C10_DEFINE_DEPRECATED_USING
+#endif

--- a/c10/util/Exception.h
+++ b/c10/util/Exception.h
@@ -3,6 +3,7 @@
 
 #include "c10/macros/Macros.h"
 #include "c10/util/StringUtil.h"
+#include "c10/util/Deprecated.h"
 
 #include <cstddef>
 #include <exception>
@@ -321,38 +322,38 @@ namespace c10 { namespace detail {
 
 /*
 // Deprecation disabled until we fix sites in our codebase
-[[deprecated("AT_ERROR(msg) is deprecated, use TORCH_CHECK(false, msg) instead.")]]
+C10_DEPRECATED_MESSAGE("AT_ERROR(msg) is deprecated, use TORCH_CHECK(false, msg) instead.")
 */
 inline void deprecated_AT_ERROR() {}
 
 /*
 // Deprecation disabled until we fix sites in our codebase
-[[deprecated("AT_INDEX_ERROR(msg) is deprecated, use TORCH_CHECK_INDEX(false, msg) instead.")]]
+C10_DEPRECATED_MESSAGE("AT_INDEX_ERROR(msg) is deprecated, use TORCH_CHECK_INDEX(false, msg) instead.")
 */
 inline void deprecated_AT_INDEX_ERROR() {}
 
 /*
 // Deprecation disabled until we fix sites in our codebase
-[[deprecated("AT_WARN is deprecated, use TORCH_WARN instead.")]]
+C10_DEPRECATED_MESSAGE("AT_WARN is deprecated, use TORCH_WARN instead.")
 */
 inline void deprecated_AT_WARN() {}
 
-[[deprecated("AT_CHECK is deprecated, use TORCH_CHECK instead.")]]
+C10_DEPRECATED_MESSAGE("AT_CHECK is deprecated, use TORCH_CHECK instead.")
 inline void deprecated_AT_CHECK() {}
 
 /*
 // Deprecation disabled until we fix sites in our codebase
-[[deprecated("AT_ASSERT is deprecated, if you mean to indicate an internal invariant failure, use " \
+C10_DEPRECATED_MESSAGE("AT_ASSERT is deprecated, if you mean to indicate an internal invariant failure, use " \
                        "TORCH_INTERNAL_ASSERT instead; if you mean to do user error checking, use " \
-                       "TORCH_CHECK.  See https://github.com/pytorch/pytorch/issues/20287 for more details.")]]
+                       "TORCH_CHECK.  See https://github.com/pytorch/pytorch/issues/20287 for more details.")
 */
 inline void deprecated_AT_ASSERT() {}
 
 /*
 // Deprecation disabled until we fix sites in our codebase
-[[deprecated("AT_ASSERTM is deprecated, if you mean to indicate an internal invariant failure, use " \
+C10_DEPRECATED_MESSAGE("AT_ASSERTM is deprecated, if you mean to indicate an internal invariant failure, use " \
                        "TORCH_INTERNAL_ASSERT instead; if you mean to do user error checking, use " \
-                       "TORCH_CHECK.  See https://github.com/pytorch/pytorch/issues/20287 for more details.")]]
+                       "TORCH_CHECK.  See https://github.com/pytorch/pytorch/issues/20287 for more details.")
 */
 inline void deprecated_AT_ASSERTM() {}
 

--- a/torch/csrc/api/include/torch/nn/modules/container/named_any.h
+++ b/torch/csrc/api/include/torch/nn/modules/container/named_any.h
@@ -93,9 +93,9 @@ class NamedAnyModule {
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
-[[deprecated("`torch::nn::modules_ordered_dict` is deprecated. " \
+C10_DEPRECATED_MESSAGE("`torch::nn::modules_ordered_dict` is deprecated. " \
                        "To construct a `Sequential` with named submodules, " \
-                       "you can do `Sequential sequential({{\"m1\", MyModule(1)}, {\"m2\", MyModule(2)}})`")]]
+                       "you can do `Sequential sequential({{\"m1\", MyModule(1)}, {\"m2\", MyModule(2)}})`")
 TORCH_API torch::OrderedDict<std::string, AnyModule> modules_ordered_dict(
   std::initializer_list<NamedAnyModule> named_modules);
 

--- a/torch/csrc/utils/auto_gil.h
+++ b/torch/csrc/utils/auto_gil.h
@@ -2,14 +2,15 @@
 
 // RAII structs to acquire and release Python's global interpreter lock (GIL)
 
+#include <c10/util/Deprecated.h>
 #include <torch/csrc/python_headers.h>
 
 // TODO: Deprecate these structs after we land this diff
 // (to avoid -Werror failures)
 
 // Acquires the GIL on construction
-struct /* [[deprecated(
-    "Use pybind11::gil_scoped_acquire instead")]] */ AutoGIL {
+struct /* C10_DEPRECATED_MESSAGE(
+    "Use pybind11::gil_scoped_acquire instead") */ AutoGIL {
   AutoGIL() : gstate(PyGILState_Ensure()) {}
   ~AutoGIL() {
     PyGILState_Release(gstate);
@@ -19,8 +20,8 @@ struct /* [[deprecated(
 };
 
 // Releases the GIL on construction
-struct /* [[deprecated(
-    "Use pybind11::gil_scoped_release instead")]] */ AutoNoGIL {
+struct /* C10_DEPRECATED_MESSAGE(
+    "Use pybind11::gil_scoped_release instead") */ AutoNoGIL {
   AutoNoGIL() : save(PyEval_SaveThread()) {}
   ~AutoNoGIL() {
     PyEval_RestoreThread(save);
@@ -31,7 +32,7 @@ struct /* [[deprecated(
 
 // Runs the function without the GIL
 template <typename F>
-/* [[deprecated]] */ inline void with_no_gil(F f) {
+/* C10_DEPRECATED */ inline void with_no_gil(F f) {
   // TODO: The deprecation here triggers a deprecated use warning
   // on some versions of compilers; need to avoid this
   AutoNoGIL no_gil;

--- a/torch/lib/c10d/ProcessGroupNCCL.hpp
+++ b/torch/lib/c10d/ProcessGroupNCCL.hpp
@@ -146,7 +146,7 @@ class ProcessGroupNCCL : public ProcessGroup {
   // This constructor includes the deprecated `groupName` argument.
   // If you have existing code that uses the `groupName`, you can replace
   // it by specifying a `c10d::PrefixStore(groupName, store)` for store.
-  [[deprecated]] ProcessGroupNCCL(
+  C10_DEPRECATED ProcessGroupNCCL(
       const std::shared_ptr<Store>& store,
       int rank,
       int size,


### PR DESCRIPTION
This reverts commit f0243ea7129cea3b6e1042057503a4da15fadec2.
This fixes https://github.com/pytorch/pytorch/issues/31418 and https://github.com/pytorch/pytorch/issues/31585, and restores VS 2017 build into a working state.

