### PR TITLE
Move rshift to Aten

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -306,46 +306,6 @@
     - THTensor* other
 ]]
 [[
-  name: _th_rshift
-  cname: __rshift__
-  variants:
-    - function
-  return: argument 0
-  options:
-    - cname: rshift
-      arguments:
-        - arg: THTensor* result
-          output: True
-        - THTensor* self
-        - real other
-    - cname: crshift
-      arguments:
-        - arg: THTensor* result
-          output: True
-        - arg: THTensor* self
-          broadcast: other fallback
-        - THTensor* other
-]]
-[[
-  name: _th_irshift_
-  cname: __irshift__
-  variants:
-    - function
-  return: argument 0
-  options:
-    - cname: rshift
-      arguments:
-        - THTensor* self
-        - THTensor* self
-        - real other
-    - cname: crshift
-      arguments:
-        - THTensor* self
-        - arg: THTensor* self
-          broadcast: other inplace fallback
-        - THTensor* other
-]]
-[[
   name: _th_min
   cpu_bool: True
   cuda_bool: True

--- a/aten/src/ATen/native/BinaryOps.cpp
+++ b/aten/src/ATen/native/BinaryOps.cpp
@@ -19,6 +19,7 @@ DEFINE_DISPATCH(bitwise_and_stub);
 DEFINE_DISPATCH(bitwise_or_stub);
 DEFINE_DISPATCH(bitwise_xor_stub);
 DEFINE_DISPATCH(lshift_stub);
+DEFINE_DISPATCH(rshift_stub);
 DEFINE_DISPATCH(logical_and_stub);
 DEFINE_DISPATCH(logical_or_stub);
 DEFINE_DISPATCH(logical_xor_stub);
@@ -403,6 +404,34 @@ Tensor& __ilshift__(Tensor& self, Scalar other) {
   auto wrapper = wrapped_scalar_tensor(other).toType(self.scalar_type());
   auto iter = TensorIterator::binary_op(self, self, wrapper);
   lshift_stub(iter.device_type(), iter);
+  return self;
+}
+
+Tensor __rshift__(const Tensor& self, const Tensor& other) {
+  Tensor result;
+  auto iter = TensorIterator::binary_op(result, self, other);
+  rshift_stub(iter.device_type(), iter);
+  return iter.output();
+}
+
+Tensor __rshift__(const Tensor& self, Scalar other) { 
+  Tensor result;
+  auto wrapper = wrapped_scalar_tensor(other).toType(self.scalar_type());
+  auto iter = TensorIterator::binary_op(result, self, wrapper);
+  rshift_stub(iter.device_type(), iter);
+  return iter.output();
+}
+
+Tensor& __irshift__(Tensor& self, const Tensor& other) {
+  auto iter = TensorIterator::binary_op(self, self, other);
+  rshift_stub(iter.device_type(), iter);
+  return self;
+}
+
+Tensor& __irshift__(Tensor& self, Scalar other) {
+  auto wrapper = wrapped_scalar_tensor(other).toType(self.scalar_type());
+  auto iter = TensorIterator::binary_op(self, self, wrapper);
+  rshift_stub(iter.device_type(), iter);
   return self;
 }
 

--- a/aten/src/ATen/native/BinaryOps.h
+++ b/aten/src/ATen/native/BinaryOps.h
@@ -36,6 +36,7 @@ DECLARE_DISPATCH(binary_fn, bitwise_and_stub);
 DECLARE_DISPATCH(binary_fn, bitwise_or_stub);
 DECLARE_DISPATCH(binary_fn, bitwise_xor_stub);
 DECLARE_DISPATCH(binary_fn, lshift_stub);
+DECLARE_DISPATCH(binary_fn, rshift_stub);
 DECLARE_DISPATCH(binary_fn, logical_xor_stub);
 DECLARE_DISPATCH(binary_fn, logical_and_stub);
 DECLARE_DISPATCH(binary_fn, logical_or_stub);

--- a/aten/src/ATen/native/cuda/BinaryMiscOpsKernels.cu
+++ b/aten/src/ATen/native/cuda/BinaryMiscOpsKernels.cu
@@ -93,6 +93,25 @@ void lshift_kernel_cuda(TensorIterator& iter) {
   }
 }
 
+void rshift_kernel_cuda(TensorIterator& iter) {
+  if (iter.dtype() == ScalarType::Float || iter.dtype() == ScalarType::Double) {
+    AT_DISPATCH_FLOATING_TYPES(iter.dtype(), "rshift_cuda", [&]() {
+      gpu_kernel_with_scalars(
+        iter,
+        []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
+          return a / std::pow((scalar_t)(2), b);
+      });
+    });
+  } else {
+    AT_DISPATCH_INTEGRAL_TYPES(iter.dtype(), "rshift_cuda", [&]() {
+      gpu_kernel_with_scalars(iter,
+        []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
+          return a >> b;
+      });
+    });
+  }
+}
+
 void logical_and_kernel_cuda(TensorIterator& iter) {
   AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBool, iter.common_dtype(), "logical_and_cuda", [&]() {
     gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> bool {
@@ -156,6 +175,7 @@ REGISTER_DISPATCH(bitwise_and_stub, &bitwise_and_kernel_cuda);
 REGISTER_DISPATCH(bitwise_or_stub, &bitwise_or_kernel_cuda);
 REGISTER_DISPATCH(lshift_stub, &lshift_kernel_cuda);
 REGISTER_DISPATCH(bitwise_xor_stub, &bitwise_xor_kernel_cuda);
+REGISTER_DISPATCH(rshift_stub, &rshift_kernel_cuda);
 REGISTER_DISPATCH(logical_and_stub, &logical_and_kernel_cuda);
 REGISTER_DISPATCH(logical_or_stub, &logical_or_kernel_cuda);
 REGISTER_DISPATCH(logical_xor_stub, &logical_xor_kernel_cuda);

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -4084,27 +4084,27 @@
   use_c10_dispatcher: full
   variants: method, function
   dispatch:
-    CPU: legacy::cpu::_th_rshift
-    CUDA: legacy::cuda::_th_rshift
+    CPU: __rshift__
+    CUDA: __rshift__
 
 - func: __rshift__.Tensor(Tensor self, Tensor other) -> Tensor
   use_c10_dispatcher: full
   variants: method, function
   dispatch:
-    CPU: legacy::cpu::_th_rshift
-    CUDA: legacy::cuda::_th_rshift
+    CPU: __rshift__
+    CUDA: __rshift__
 
 - func: __irshift__.Scalar(Tensor(a!) self, Scalar other) -> Tensor(a!)
   variants: method
   dispatch:
-    CPU: legacy::cpu::_th_irshift_
-    CUDA: legacy::cuda::_th_irshift_
+    CPU: __irshift__
+    CUDA: __irshift__
 
 - func: __irshift__.Tensor(Tensor(a!) self, Tensor other) -> Tensor(a!)
   variants: method
   dispatch:
-    CPU: legacy::cpu::_th_irshift_
-    CUDA: legacy::cuda::_th_irshift_
+    CPU: __irshift__
+    CUDA: __irshift__
 
 - func: lgamma_(Tensor(a!) self) -> Tensor(a!)
   supports_named_tensor: True

--- a/aten/src/TH/generic/THTensorEvenMoreMath.cpp
+++ b/aten/src/TH/generic/THTensorEvenMoreMath.cpp
@@ -620,44 +620,6 @@ accreal THTensor_(dot)(THTensor *tensor, THTensor *src)
   return sum;
 }
 
-void THTensor_(rshift)(THTensor *r_, THTensor *t, scalar_t value)
-{
-#if defined(TH_REAL_IS_FLOAT)
-  return THTensor_(div)(r_, t, powf(2, value));
-#elif defined(TH_REAL_IS_DOUBLE)
-  return THTensor_(div)(r_, t, pow(2, value));
-#elif defined(TH_REAL_IS_HALF)
-  return THError("rshift is not supported for torch.HalfTensor");
-#elif defined(TH_REAL_IS_BFLOAT16)
-  return THError("rshift is not supported for torch.BFloat16Tensor");
-#else
-  THTensor_(resizeAs)(r_, t);
-  int64_t r_Size = THTensor_(nElement)(r_);
-  int r_Contig = THTensor_(isContiguous)(r_);
-  int tContig = THTensor_(isContiguous)(t);
-  if (r_Contig && tContig) {
-    scalar_t *tp = t->data<scalar_t>();
-    scalar_t *rp = r_->data<scalar_t>();
-    at::parallel_for(0, r_Size, TH_OMP_OVERHEAD_THRESHOLD * 100,
-        [&](int64_t start, int64_t end) {
-      for (auto i = start; i < end; i++) {
-#if defined(TH_REAL_IS_BYTE)
-        rp[i] = ((scalar_t) tp[i]) >> value;
-#else
-        rp[i] = ((ureal) tp[i]) >> value;
-#endif
-      }
-    });
-  } else {
-#if defined(TH_REAL_IS_BYTE)
-    TH_TENSOR_APPLY2_PARALLEL(r_Size, r_Contig, tContig, scalar_t, r_, scalar_t, t, *r__data = (((scalar_t) *t_data) >> value);, UNCERTAIN_TH_OMP_OVERHEAD_THRESHOLD);
-#else
-    TH_TENSOR_APPLY2_PARALLEL(r_Size, r_Contig, tContig, scalar_t, r_, scalar_t, t, *r__data = (((ureal) *t_data) >> value);, UNCERTAIN_TH_OMP_OVERHEAD_THRESHOLD);
-#endif
-  }
-#endif
-}
-
 void THTensor_(fmod)(THTensor *r_, THTensor *t, scalar_t value)
 {
   THTensor_(resizeAs)(r_, t);

--- a/aten/src/TH/generic/THTensorMath.cpp
+++ b/aten/src/TH/generic/THTensorMath.cpp
@@ -402,60 +402,6 @@ void THTensor_(cdiv)(THTensor *r_, THTensor *t, THTensor *src)
   }
 }
 
-void THTensor_(crshift)(THTensor *r_, THTensor *t, THTensor *src)
-{
-#if defined(TH_REAL_IS_HALF)
-  return THError("crshift is not supported for torch.HalfTensor");
-#endif
-  THTensor_(resizeAs)(r_, t);
-  int64_t r_Size = THTensor_(nElement)(r_);
-  int64_t srcSize = THTensor_(nElement)(src);
-  int r_Contig = THTensor_(isContiguous)(r_);
-  int tContig = THTensor_(isContiguous)(t);
-  int srcContig = THTensor_(isContiguous)(src);
-  if (srcSize == r_Size){
-    if (r_Contig && tContig && srcContig) {
-      scalar_t *tp = t->data<scalar_t>();
-      scalar_t *sp = src->data<scalar_t>();
-      scalar_t *rp = r_->data<scalar_t>();
-      at::parallel_for(0, r_Size, TH_OMP_OVERHEAD_THRESHOLD,
-          [&](int64_t start, int64_t end) {
-        for (auto i = start; i < end; i++) {
-#if defined(TH_REAL_IS_FLOAT)
-          rp[i] = tp[i] / powf(2, sp[i]);
-#elif defined(TH_REAL_IS_DOUBLE)
-          rp[i] = tp[i] / pow(2, sp[i]);
-#elif defined(TH_REAL_IS_BYTE)
-          rp[i] = ((scalar_t) tp[i]) >> sp[i];
-#else
-          rp[i] = ((ureal) tp[i]) >> sp[i];
-#endif
-        }
-      });
-    } else {
-#if defined(TH_REAL_IS_FLOAT)
-      TH_TENSOR_APPLY3_PARALLEL(r_Size, r_Contig, tContig, srcContig, scalar_t, r_, scalar_t, t, scalar_t, src, *r__data = *t_data / powf(2, *src_data);, UNCERTAIN_TH_OMP_OVERHEAD_THRESHOLD);
-#elif defined(TH_REAL_IS_DOUBLE)
-      TH_TENSOR_APPLY3_PARALLEL(r_Size, r_Contig, tContig, srcContig, scalar_t, r_, scalar_t, t, scalar_t, src, *r__data = *t_data / pow(2, *src_data);, UNCERTAIN_TH_OMP_OVERHEAD_THRESHOLD);
-#elif defined(TH_REAL_IS_BYTE)
-      TH_TENSOR_APPLY3_PARALLEL(r_Size, r_Contig, tContig, srcContig, scalar_t, r_, scalar_t, t, scalar_t, src, *r__data = ((scalar_t)*t_data) >> *src_data;, UNCERTAIN_TH_OMP_OVERHEAD_THRESHOLD);
-#else
-      TH_TENSOR_APPLY3_PARALLEL(r_Size, r_Contig, tContig, srcContig, scalar_t, r_, scalar_t, t, scalar_t, src, *r__data = ((ureal)*t_data) >> *src_data;, UNCERTAIN_TH_OMP_OVERHEAD_THRESHOLD);
-#endif
-    }
-  } else {
-#if defined(TH_REAL_IS_FLOAT)
-      TH_TENSOR_APPLY3(scalar_t, r_, scalar_t, t, scalar_t, src, *r__data = *t_data / powf(2, *src_data););
-#elif defined(TH_REAL_IS_DOUBLE)
-      TH_TENSOR_APPLY3(scalar_t, r_, scalar_t, t, scalar_t, src, *r__data = *t_data / pow(2, *src_data););
-#elif defined(TH_REAL_IS_BYTE)
-      TH_TENSOR_APPLY3(scalar_t, r_, scalar_t, t, scalar_t, src, *r__data = ((scalar_t)*t_data) >> *src_data;);
-#else
-      TH_TENSOR_APPLY3(scalar_t, r_, scalar_t, t, scalar_t, src, *r__data = ((ureal)*t_data) >> *src_data;);
-#endif
-  }
-}
-
 void THTensor_(cfmod)(THTensor *r_, THTensor *t, THTensor *src)
 {
   THTensor_(resizeAs)(r_, t);

--- a/aten/src/TH/generic/THTensorMath.h
+++ b/aten/src/TH/generic/THTensorMath.h
@@ -103,7 +103,6 @@ TH_API void THTensor_(cumprod)(THTensor *r_, THTensor *t, int dimension);
 
 TH_API accreal THTensor_(dot)(THTensor *t, THTensor *src);
 
-TH_API void THTensor_(rshift)(THTensor *r_, THTensor *t, scalar_t value);
 TH_API void THTensor_(fmod)(THTensor *r_, THTensor *t, scalar_t value);
 TH_API void THTensor_(remainder)(THTensor *r_, THTensor *t, scalar_t value);
 TH_API void THTensor_(clamp)(THTensor *r_, THTensor *t, scalar_t min_value, scalar_t max_value);
@@ -112,7 +111,6 @@ TH_API void THTensor_(cadd)(THTensor *r_, THTensor *t, scalar_t value, THTensor 
 TH_API void THTensor_(csub)(THTensor *self, THTensor *src1, scalar_t value, THTensor *src2);
 TH_API void THTensor_(cmul)(THTensor *r_, THTensor *t, THTensor *src);
 TH_API void THTensor_(cdiv)(THTensor *r_, THTensor *t, THTensor *src);
-TH_API void THTensor_(crshift)(THTensor *r_, THTensor *t, THTensor *src);
 TH_API void THTensor_(cfmod)(THTensor *r_, THTensor *t, THTensor *src);
 TH_API void THTensor_(cremainder)(THTensor *r_, THTensor *t, THTensor *src);
 

--- a/aten/src/THC/THCTensorMathPairwise.cu
+++ b/aten/src/THC/THCTensorMathPairwise.cu
@@ -231,20 +231,6 @@ struct TensorTriOp {
   const int64_t stride0, stride1, k;
 };
 
-template <typename T>
-struct TensorRShiftConstantOp {
-  TensorRShiftConstantOp(T v) : val(v) {}
-  __device__ __forceinline__ void operator()(T* out, T* in) {
-    *out = *in >> val;
-  }
-
-  __device__ __forceinline__ void operator()(T* v) {
-    *v >>= val;
-  }
-
-  const T val;
-};
-
 #include <THC/generic/THCTensorMathPairwise.cu>
 #include <THC/THCGenerateAllTypes.h>
 

--- a/aten/src/THC/THCTensorMathPointwise.cuh
+++ b/aten/src/THC/THCTensorMathPointwise.cuh
@@ -243,43 +243,4 @@ struct TensorMinValueOp {
   T val;
 };
 
-template <typename T>
-struct TensorRShiftOp {
-  __device__ __forceinline__ void
-  operator()(T* out, T* in) {
-    *out >>= *in;
-  }
-
-  __device__ __forceinline__ void
-  operator()(T* out, T* in1, T* in2) {
-    *out = *in1 >> *in2;
-  }
-};
-
-template <>
-struct TensorRShiftOp<float> {
-  __device__ __forceinline__ void
-  operator()(float* out, float* in) {
-    *out /= powf(2.0f, *in);
-  }
-
-  __device__ __forceinline__ void
-  operator()(float* out, float* in1, float* in2) {
-    *out = *in1 / powf(2.0f, *in2);
-  }
-};
-
-template <>
-struct TensorRShiftOp<double> {
-  __device__ __forceinline__ void
-  operator()(double* out, double* in) {
-    *out /= pow(2.0, *in);
-  }
-
-  __device__ __forceinline__ void
-  operator()(double* out, double* in1, double* in2) {
-    *out = *in1 / pow(2.0, *in2);
-  }
-};
-
 #endif // THC_TENSORMATH_POINTWISE_CUH

--- a/aten/src/THC/generic/THCTensorMathPairwise.cu
+++ b/aten/src/THC/generic/THCTensorMathPairwise.cu
@@ -79,29 +79,6 @@ void THCTensor_(div)(THCState* state, THCTensor *self_, THCTensor *src_, scalar_
   THCudaCheck(cudaGetLastError());
 }
 
-void THCTensor_(rshift)(THCState* state, THCTensor *self_, THCTensor *src_, scalar_t value)
-{
-#if defined(THC_REAL_IS_FLOAT) || defined(THC_REAL_IS_DOUBLE)
-  THCTensor_(mul)(state, self_, src_, pow(2, -value));
-#elif defined(THC_REAL_IS_HALF)
-  return THError("rshift not supported for torch.CudaHalfTensor");
-#else
-  if (self_ == src_) {
-    if (!THC_pointwiseApply1<scalar_t>(state, self_, TensorRShiftConstantOp<scalar_t>(value))) {
-      THArgCheck(false, 2, CUTORCH_DIM_WARNING);
-    }
-  } else {
-    THCTensor_(resizeAs)(state, self_, src_);
-
-    if (!THC_pointwiseApply2<scalar_t, scalar_t>(state, self_, src_, TensorRShiftConstantOp<scalar_t>(value))) {
-      THArgCheck(false, 2, CUTORCH_DIM_WARNING);
-    }
-  }
-
-  THCudaCheck(cudaGetLastError());
-#endif
-}
-
 void THCTensor_(fmod)(THCState *state, THCTensor *self_, THCTensor *src_, scalar_t value)
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, self_, src_));

--- a/aten/src/THC/generic/THCTensorMathPairwise.h
+++ b/aten/src/THC/generic/THCTensorMathPairwise.h
@@ -8,7 +8,6 @@ THC_API int THCTensor_(equal)(THCState *state, THCTensor *self, THCTensor *src);
 
 THC_API void THCTensor_(mul)(THCState *state, THCTensor *self, THCTensor *src, scalar_t value);
 THC_API void THCTensor_(div)(THCState *state, THCTensor *self, THCTensor *src, scalar_t value);
-THC_API void THCTensor_(rshift)(THCState *state, THCTensor *self, THCTensor *src, scalar_t value);
 THC_API void THCTensor_(fmod)(THCState *state, THCTensor *self, THCTensor *src, scalar_t value);
 THC_API void THCTensor_(remainder)(THCState *state, THCTensor *self, THCTensor *src, scalar_t value);
 

--- a/aten/src/THC/generic/THCTensorMathPointwise.cu
+++ b/aten/src/THC/generic/THCTensorMathPointwise.cu
@@ -207,33 +207,6 @@ void THCTensor_(cdiv)(THCState* state, THCTensor *self_, THCTensor *src1, THCTen
   at::div_out(out, at::Tensor(retainTensorImpl(src1)), at::Tensor(retainTensorImpl(src2)));
 }
 
-void THCTensor_(crshift)(THCState* state, THCTensor *self_, THCTensor *src1, THCTensor *src2)
-{
-#if defined(THC_REAL_IS_HALF)
-  return THError("crshift not supported for torch.CudaHalfTensor");
-#else
-  THAssert(THCTensor_(checkGPU)(state, 3, self_, src1, src2));
-  THArgCheck(THCTensor_(nElement)(state, src1) ==
-             THCTensor_(nElement)(state, src2), 3, "sizes do not match");
-
-  if (self_ == src1) {
-    // self /= src2
-    if (!THC_pointwiseApply2<scalar_t, scalar_t>(state, self_, src2, TensorRShiftOp<scalar_t>())) {
-      THArgCheck(false, 2, CUTORCH_DIM_WARNING);
-    }
-  } else {
-    THCTensor_(resizeAs)(state, self_, src1);
-
-    // self = src1 / src2
-    if (!THC_pointwiseApply3<scalar_t, scalar_t, scalar_t>(state, self_, src1, src2, TensorRShiftOp<scalar_t>())) {
-      THArgCheck(false, 2, CUTORCH_DIM_WARNING);
-    }
-  }
-
-  THCudaCheck(cudaGetLastError());
-#endif
-}
-
 void THCTensor_(cremainder)(THCState *state, THCTensor *self, THCTensor *src1, THCTensor *src2)
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 3, self, src1, src2));


### PR DESCRIPTION
@VitalyFedyunin , this PR is about move rshift to Aten.
Benchmark script :
```
import timeit
import torch
torch.manual_seed(1)

for n, t in [(10, 100000),(1000, 10000)]:
    print('__rshift__ (a.numel() == {}) for {} times'.format(n, t))
    for device in ('cpu', 'cuda'):
        for dtype in ('torch.int8', 'torch.uint8', 'torch.int16', 'torch.int32', 'torch.int64'):
            print(f'device: {device}, dtype: {dtype}, {t} times', end='\t\t')
            print(timeit.timeit(f'a >> b\nif "{device}" == "cuda": torch.cuda.synchronize()', setup=f'import torch; a = torch.randint(0, 10, ({n},), dtype = {dtype}, device="{device}"); b = torch.randint(0, 10, ({n},), dtype = {dtype}, device="{device}")', number=t))
        for dtype in ('torch.float32', 'torch.float64'):
            print(f'device: {device}, dtype: {dtype}, {t} times', end='\t\t')
            print(timeit.timeit(f'a >> b\nif "{device}" == "cuda": torch.cuda.synchronize()', setup=f'import torch; a = torch.randn({n}, dtype = {dtype}, device="{device}"); b = torch.randn({n}, dtype = {dtype}, device="{device}")', number=t))


for n, t in [(10, 100000),(1000, 10000)]:
    print('__irshift__ (a.numel() == {}) for {} times'.format(n, t))
    for device in ('cpu', 'cuda'):
        for dtype in ('torch.int8', 'torch.uint8', 'torch.int16', 'torch.int32', 'torch.int64'):
            print(f'device: {device}, dtype: {dtype}, {t} times', end='\t\t')
            print(timeit.timeit(f'a >> b\nif "{device}" == "cuda": torch.cuda.synchronize()', setup=f'import torch; a = torch.randint(0, 10, ({n},), dtype = {dtype}, device="{device}"); b = torch.tensor(5, dtype = {dtype}, device="{device}")', number=t))
        for dtype in ('torch.float32', 'torch.float64'):
            print(f'device: {device}, dtype: {dtype}, {t} times', end='\t\t')
            print(timeit.timeit(f'a >> b\nif "{device}" == "cuda": torch.cuda.synchronize()', setup=f'import torch; a = torch.randn({n}, dtype = {dtype}, device="{device}"); b = torch.tensor(5, dtype = {dtype}, device="{device}")', number=t))
```
Device: **Tesla P100, skx-8180**
Cuda verison: **9.0.176**

Before:
```
__rshift__ (a.numel() == 10) for 100000 times
device: cpu, dtype: torch.int8, 100000 times            0.17183916084468365
device: cpu, dtype: torch.uint8, 100000 times           0.16587729007005692
device: cpu, dtype: torch.int16, 100000 times           0.16659130714833736
device: cpu, dtype: torch.int32, 100000 times           0.17177579551935196
device: cpu, dtype: torch.int64, 100000 times           0.17860156949609518
device: cpu, dtype: torch.float32, 100000 times         0.23938780091702938
device: cpu, dtype: torch.float64, 100000 times         0.22591270506381989
device: cuda, dtype: torch.int8, 100000 times           1.2709560776129365
device: cuda, dtype: torch.uint8, 100000 times          1.2692269310355186
device: cuda, dtype: torch.int16, 100000 times          1.2785452520474792
device: cuda, dtype: torch.int32, 100000 times          1.2733035255223513
device: cuda, dtype: torch.int64, 100000 times          1.2785427365452051
device: cuda, dtype: torch.float32, 100000 times                1.2980637094005942
device: cuda, dtype: torch.float64, 100000 times                1.3062487514689565
__rshift__ (a.numel() == 1000) for 10000 times
device: cpu, dtype: torch.int8, 10000 times             0.03122080024331808
device: cpu, dtype: torch.uint8, 10000 times            0.030290847644209862
device: cpu, dtype: torch.int16, 10000 times            0.024531075730919838
device: cpu, dtype: torch.int32, 10000 times            0.024743229150772095
device: cpu, dtype: torch.int64, 10000 times            0.025563121773302555
device: cpu, dtype: torch.float32, 10000 times          0.6707976600155234
device: cpu, dtype: torch.float64, 10000 times          0.5344798369333148
device: cuda, dtype: torch.int8, 10000 times            0.12768010422587395
device: cuda, dtype: torch.uint8, 10000 times           0.12681372743099928
device: cuda, dtype: torch.int16, 10000 times           0.12995595764368773
device: cuda, dtype: torch.int32, 10000 times           0.12989260721951723
device: cuda, dtype: torch.int64, 10000 times           0.12804713658988476
device: cuda, dtype: torch.float32, 10000 times         0.13013121113181114
device: cuda, dtype: torch.float64, 10000 times         0.1406280631199479
__irshift__ (a.numel() == 10) for 100000 times
device: cpu, dtype: torch.int8, 100000 times            0.3805475188419223
device: cpu, dtype: torch.uint8, 100000 times           0.36341007333248854
device: cpu, dtype: torch.int16, 100000 times           0.36908434610813856
device: cpu, dtype: torch.int32, 100000 times           0.3669992135837674
device: cpu, dtype: torch.int64, 100000 times           0.37847711704671383
device: cpu, dtype: torch.float32, 100000 times         0.4311870699748397
device: cpu, dtype: torch.float64, 100000 times         0.44503832422196865
device: cuda, dtype: torch.int8, 100000 times           1.4343859804794192
device: cuda, dtype: torch.uint8, 100000 times          1.4298221375793219
device: cuda, dtype: torch.int16, 100000 times          1.4460898758843541
device: cuda, dtype: torch.int32, 100000 times          1.4518025070428848
device: cuda, dtype: torch.int64, 100000 times          1.4456725595518947
device: cuda, dtype: torch.float32, 100000 times                1.4610810624435544
device: cuda, dtype: torch.float64, 100000 times                1.4736663019284606
__irshift__ (a.numel() == 1000) for 10000 times
device: cpu, dtype: torch.int8, 10000 times             0.05944254994392395
device: cpu, dtype: torch.uint8, 10000 times            0.058085592463612556
device: cpu, dtype: torch.int16, 10000 times            0.05094402376562357
device: cpu, dtype: torch.int32, 10000 times            0.050842881202697754
device: cpu, dtype: torch.int64, 10000 times            0.06223891582340002
device: cpu, dtype: torch.float32, 10000 times          0.7006897022947669
device: cpu, dtype: torch.float64, 10000 times          0.5614962242543697
device: cuda, dtype: torch.int8, 10000 times            0.1461706068366766
device: cuda, dtype: torch.uint8, 10000 times           0.14335164614021778
device: cuda, dtype: torch.int16, 10000 times           0.1448021186515689
device: cuda, dtype: torch.int32, 10000 times           0.14513055887073278
device: cuda, dtype: torch.int64, 10000 times           0.1439579650759697
device: cuda, dtype: torch.float32, 10000 times         0.14666561130434275
device: cuda, dtype: torch.float64, 10000 times         0.1540807681158185
```
After:
```
_rshift__ (a.numel() == 10) for 100000 times
device: cpu, dtype: torch.int8, 100000 times            0.16366520430892706
device: cpu, dtype: torch.uint8, 100000 times           0.16091545950621367
device: cpu, dtype: torch.int16, 100000 times           0.1659633992239833
device: cpu, dtype: torch.int32, 100000 times           0.1682385364547372
device: cpu, dtype: torch.int64, 100000 times           0.17289020214229822
device: cpu, dtype: torch.float32, 100000 times         0.24359441827982664
device: cpu, dtype: torch.float64, 100000 times         0.21783945057541132
device: cuda, dtype: torch.int8, 100000 times           1.2517220517620444
device: cuda, dtype: torch.uint8, 100000 times          1.260181212797761
device: cuda, dtype: torch.int16, 100000 times          1.2681935774162412
device: cuda, dtype: torch.int32, 100000 times          1.2764465296640992
device: cuda, dtype: torch.int64, 100000 times          1.294325228780508
device: cuda, dtype: torch.float32, 100000 times                1.3062216322869062
device: cuda, dtype: torch.float64, 100000 times                1.303224254399538
__rshift__ (a.numel() == 1000) for 10000 times
device: cpu, dtype: torch.int8, 10000 times             0.027045012451708317
device: cpu, dtype: torch.uint8, 10000 times            0.026978280395269394
device: cpu, dtype: torch.int16, 10000 times            0.025594274513423443
device: cpu, dtype: torch.int32, 10000 times            0.02593063935637474
device: cpu, dtype: torch.int64, 10000 times            0.02668109256774187
device: cpu, dtype: torch.float32, 10000 times          0.09746317192912102
device: cpu, dtype: torch.float64, 10000 times          0.1644029449671507
device: cuda, dtype: torch.int8, 10000 times            0.12530914042145014
device: cuda, dtype: torch.uint8, 10000 times           0.12615622486919165
device: cuda, dtype: torch.int16, 10000 times           0.12741118855774403
device: cuda, dtype: torch.int32, 10000 times           0.1284919548779726
device: cuda, dtype: torch.int64, 10000 times           0.12974756956100464
device: cuda, dtype: torch.float32, 10000 times         0.13044228963553905
device: cuda, dtype: torch.float64, 10000 times         0.13918257877230644
__irshift__ (a.numel() == 10) for 100000 times
device: cpu, dtype: torch.int8, 100000 times            0.19456563983112574
device: cpu, dtype: torch.uint8, 100000 times           0.190769555978477
device: cpu, dtype: torch.int16, 100000 times           0.2002257639542222
device: cpu, dtype: torch.int32, 100000 times           0.20456529594957829
device: cpu, dtype: torch.int64, 100000 times           0.2043834924697876
device: cpu, dtype: torch.float32, 100000 times         0.2832390898838639
device: cpu, dtype: torch.float64, 100000 times         0.2582795573398471
device: cuda, dtype: torch.int8, 100000 times           1.304957083426416
device: cuda, dtype: torch.uint8, 100000 times          1.3216373259201646
device: cuda, dtype: torch.int16, 100000 times          1.3238621400669217
device: cuda, dtype: torch.int32, 100000 times          1.333009460940957
device: cuda, dtype: torch.int64, 100000 times          1.3835567953065038
device: cuda, dtype: torch.float32, 100000 times                1.4483617274090648
device: cuda, dtype: torch.float64, 100000 times                1.4179155295714736
__irshift__ (a.numel() == 1000) for 10000 times
device: cpu, dtype: torch.int8, 10000 times             0.03196091763675213
device: cpu, dtype: torch.uint8, 10000 times            0.03048650734126568
device: cpu, dtype: torch.int16, 10000 times            0.03048624936491251
device: cpu, dtype: torch.int32, 10000 times            0.030591044574975967
device: cpu, dtype: torch.int64, 10000 times            0.031246556900441647
device: cpu, dtype: torch.float32, 10000 times          0.10918692220002413
device: cpu, dtype: torch.float64, 10000 times          0.18057993799448013
device: cuda, dtype: torch.int8, 10000 times            0.13614848721772432
device: cuda, dtype: torch.uint8, 10000 times           0.130373639985919
device: cuda, dtype: torch.int16, 10000 times           0.1332557238638401
device: cuda, dtype: torch.int32, 10000 times           0.1331850504502654
device: cuda, dtype: torch.int64, 10000 times           0.1363008264452219
device: cuda, dtype: torch.float32, 10000 times         0.1370363561436534
device: cuda, dtype: torch.float64, 10000 times         0.1442740885540843
```
Fix #24512 #24516  #24659  #24663 