### PR TITLE
Optimize zero length input

### DIFF
--- a/caffe2/opt/onnxifi_op.h
+++ b/caffe2/opt/onnxifi_op.h
@@ -256,6 +256,7 @@ class OnnxifiOp final : public Operator<Context> {
               weight_descs.size(),
               weight_descs.data(),
               &graph,
+              static_cast<uint32_t>(max_seq_size_),
               defered_blob_reader),
           ONNXIFI_STATUS_SUCCESS);
 


### PR DESCRIPTION
Summary: Zero length input is something we hit fairly frequently in practice. Previous handling of global TensorPool involves two locks per input (acquire and reclaim). Here we use a specialized anchor tensor to host zero length input. Note that it is only padded to max sequence length. If necessary, an easy extension can be added to pad to max `InputPlaceholder.getType().size()`.

Differential Revision: D19192467

