### PR TITLE
separate op for rowwise counter

### DIFF
--- a/caffe2/python/operator_test/rowwise_counter_test.py
+++ b/caffe2/python/operator_test/rowwise_counter_test.py
@@ -1,0 +1,69 @@
+from __future__ import absolute_import, division, print_function
+
+import unittest
+
+import caffe2.python.hypothesis_test_util as hu
+import numpy as np
+from caffe2.python import core, workspace
+
+
+def update_counter_ref(prev_iter, update_counter, indices, curr_iter, counter_halflife):
+    prev_iter_out = prev_iter.copy()
+    update_counter_out = update_counter.copy()
+
+    counter_neg_log_rho = np.log(2) / counter_halflife
+    for i in indices:
+        iter_diff = curr_iter[0] - prev_iter_out[i]
+        prev_iter_out[i] = curr_iter[0]
+        update_counter_out[i] = (
+            1.0 + np.exp(-iter_diff * counter_neg_log_rho) * update_counter_out[i]
+        )
+    return prev_iter_out, update_counter_out
+
+
+class TestRowWiseCounter(hu.HypothesisTestCase):
+    def test_rowwise_counter(self):
+        h = 8 * 20
+        n = 5
+        curr_iter = np.array([100], dtype=np.int64)
+
+        update_counter = np.random.randint(99, size=h).astype(np.float32)
+        prev_iter = np.random.rand(h, 1).astype(np.int64)
+        indices = np.unique(np.random.randint(0, h, size=n))
+        indices.sort(axis=0)
+        counter_halflife = 1
+
+        net = core.Net("test_net")
+        net.Proto().type = "dag"
+
+        workspace.FeedBlob("indices", indices)
+        workspace.FeedBlob("curr_iter", curr_iter)
+        workspace.FeedBlob("update_counter", update_counter)
+        workspace.FeedBlob("prev_iter", prev_iter)
+
+        net.RowWiseCounter(
+            ["prev_iter", "update_counter", "indices", "curr_iter"],
+            ["prev_iter", "update_counter"],
+            counter_halflife=counter_halflife,
+        )
+
+        workspace.RunNetOnce(net)
+
+        prev_iter_out = workspace.FetchBlob("prev_iter")
+        update_counter_out = workspace.FetchBlob("update_counter")
+
+        prev_iter_out_ref, update_counter_out_ref = update_counter_ref(
+            prev_iter,
+            update_counter,
+            indices,
+            curr_iter,
+            counter_halflife=counter_halflife,
+        )
+        assert np.allclose(prev_iter_out, prev_iter_out_ref, rtol=1e-3)
+        assert np.allclose(update_counter_out, update_counter_out_ref, rtol=1e-3)
+
+
+if __name__ == "__main__":
+    global_options = ["caffe2"]
+    core.GlobalInit(global_options)
+    unittest.main()

--- a/caffe2/sgd/rowwise_counter.cc
+++ b/caffe2/sgd/rowwise_counter.cc
@@ -1,0 +1,25 @@
+#include "rowwise_counter.h"
+
+namespace caffe2 {
+
+REGISTER_CPU_OPERATOR(RowWiseCounter, RowWiseCounterOp<float>);
+OPERATOR_SCHEMA(RowWiseCounter)
+    .NumInputs(4)
+    .NumOutputs(2)
+    .EnforceOneToOneInplace()
+    .SetDoc(R"DOC(
+    Count the number recent update on rows. Exponential decay is
+    applied on the counter with decay rate r, such that
+    r^{counter_halflife} = 0.5; If counter_halflife is nonpositive,
+    this operator is turned off.
+)DOC")
+    .Input(0, "prev_iter", "Iter at last update")
+    .Input(1, "update_counter", "update counter")
+    .Input(2, "indices", "Sparse indices")
+    .Input(3, "iter", "current iteration")
+    .Output(0, "output_prev_iter", "Updated iter at last update")
+    .Output(1, "output_update_counter", "Output update counter")
+    .Arg("counter_halflife", "Default -1: off");
+
+SHOULD_NOT_DO_GRADIENT(RowWiseCounter);
+} // namespace caffe2

--- a/caffe2/sgd/rowwise_counter.h
+++ b/caffe2/sgd/rowwise_counter.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include "caffe2/core/operator.h"
+
+namespace caffe2 {
+
+template <typename T>
+class RowWiseCounterOp final : public Operator<CPUContext> {
+ public:
+  RowWiseCounterOp(const OperatorDef& operator_def, Workspace* ws)
+      : Operator<CPUContext>(operator_def, ws),
+        counter_halflife_(
+            this->template GetSingleArgument<int64_t>("counter_halflife", -1)),
+        counter_neg_log_rho_(0.0) {
+    if (counter_halflife_ > 0) {
+      counter_neg_log_rho_ = std::log(2.0) / counter_halflife_;
+    }
+  }
+
+  bool RunOnDevice() override {
+    CAFFE_ENFORCE_EQ(Input(PREV_ITER).numel(), Input(COUNTER).numel());
+    CAFFE_ENFORCE_EQ(Input(ITER).numel(), 1);
+    return DispatchHelper<TensorTypes<int32_t, int64_t>>::call(
+        this, Input(INDICES));
+  }
+
+  template <typename SIndex>
+  bool DoRunWithType() {
+    auto* prev_iter =
+        Output(OUTPUT_PREV_ITER)->template mutable_data<int64_t>();
+    auto* counter = Output(OUTPUT_COUNTER)->template mutable_data<T>();
+
+    const int64_t curr_iter = Input(ITER).template data<int64_t>()[0];
+    const auto* indices = Input(INDICES).template data<SIndex>();
+
+    auto n = Input(INDICES).numel();
+    if (n == 0) {
+      return true;
+    }
+    if (counter_halflife_ <= 0) {
+      return true;
+    }
+
+    for (auto i = 0; i < n; ++i) {
+      const std::size_t idx = indices[i];
+      CAFFE_ENFORCE_GE(
+          Input(COUNTER).numel(),
+          idx,
+          this->debug_def().input(COUNTER),
+          ", out of bound,  idx:",
+          idx,
+          " for input i:",
+          i,
+          " max size:",
+          Input(COUNTER).numel());
+      const int64_t iter_delta =
+          std::max<int64_t>(0, curr_iter - prev_iter[idx]);
+
+      counter[idx] =
+          1.0 + std::exp(-iter_delta * counter_neg_log_rho_) * counter[idx];
+      prev_iter[idx] = std::max<int64_t>(curr_iter, prev_iter[idx]);
+    }
+    return true;
+  }
+
+ protected:
+  int64_t counter_halflife_;
+  double counter_neg_log_rho_;
+  INPUT_TAGS(PREV_ITER, COUNTER, INDICES, ITER);
+  OUTPUT_TAGS(OUTPUT_PREV_ITER, OUTPUT_COUNTER);
+};
+
+} // namespace caffe2


### PR DESCRIPTION
Summary:
Count the number recent update on rows. Exponential decay is applied on the counter with decay rate r, such that
    r^{counter_halflife} = 0.5;
If counter_halflife is nonpositive, this operator is turned off.

Test Plan: added unittest

Differential Revision: D19217921

