### PR TITLE
Move exponential to Aten and also optimized by MKL

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -1497,20 +1497,6 @@
     - THGenerator* generator
 ]]
 [[
-  name: _th_exponential_
-  types:
-    - floating_point
-  backends:
-    - CPU
-  cname: exponential
-  variants: function
-  return: self
-  arguments:
-    - THTensor* self
-    - double lambd
-    - THGenerator* generator
-]]
-[[
   name: _th_geometric_
   backends:
     - CPU
@@ -1522,7 +1508,6 @@
     - double p
     - THGenerator* generator
 ]]
-
 [[
   name: _th_copy_ignoring_overlaps_
   cname: copyIgnoringOverlaps

--- a/aten/src/ATen/native/UnaryOps.h
+++ b/aten/src/ATen/native/UnaryOps.h
@@ -55,6 +55,7 @@ DECLARE_DISPATCH(unary_fn, trunc_stub);
 DECLARE_DISPATCH(unary_fn, lgamma_stub);
 
 DECLARE_DISPATCH(void(*)(Tensor&, const double, Generator *), bernoulli_mkl_stub);
+DECLARE_DISPATCH(void(*)(Tensor&, const double, Generator *), exponential_mkl_stub);
 DECLARE_DISPATCH(void(*)(TensorIterator&, const int64_t), polygamma_stub);
 DECLARE_DISPATCH(void(*)(TensorIterator&, Scalar a, Scalar b), clamp_stub);
 DECLARE_DISPATCH(void(*)(Tensor&, const Tensor&, int64_t, bool, Generator *), multinomial_stub);

--- a/aten/src/ATen/native/cuda/Distributions.cu
+++ b/aten/src/ATen/native/cuda/Distributions.cu
@@ -758,6 +758,7 @@ Tensor& cauchy_cuda_(Tensor& self, double median, double sigma, Generator* gen) 
 }
 
 Tensor& exponential_cuda_(Tensor& self, double lambda, Generator* gen) {
+  TORCH_CHECK(lambda > 0, "exponential__ expects lambda greate 0, but got lambda=", lambda);
   auto iter = TensorIterator::nullary_op(self);
   exponential_kernel_cuda(iter, lambda, gen);
   return self;

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -4237,7 +4237,7 @@
 - func: exponential_(Tensor(a!) self, float lambd=1, *, Generator? generator=None) -> Tensor(a!)
   variants: method
   dispatch:
-    CPU: legacy::cpu::_th_exponential_
+    CPU: exponential_cpu_
     CUDA: exponential_cuda_
   supports_named_tensor: True
 

--- a/aten/src/TH/generic/THTensorRandom.cpp
+++ b/aten/src/TH/generic/THTensorRandom.cpp
@@ -130,16 +130,6 @@ void THTensor_(normal_means_stddevs)(THTensor *self, THTensor *means, THTensor *
   THTensor_(cadd)(self, self, 1, means);
 }
 
-void THTensor_(exponential)(THTensor *self, double lambda, at::Generator *_generator)
-{
-  auto gen = at::get_generator_or_default<at::CPUGenerator>(_generator, at::detail::getDefaultCPUGenerator());
-  // See Note [Acquire lock when using random generators]
-  std::lock_guard<std::mutex> lock(gen->mutex_);
-
-  at::exponential_distribution<double> exponential(lambda);
-  TH_TENSOR_APPLY(scalar_t, self, *self_data = (scalar_t)exponential(gen););
-}
-
 #undef TH_REAL_MIN
 
 void THTensor_(cauchy)(THTensor *self, double median, double sigma, at::Generator *_generator)

--- a/aten/src/TH/generic/THTensorRandom.h
+++ b/aten/src/TH/generic/THTensorRandom.h
@@ -17,7 +17,6 @@ TH_API void THTensor_(normal)(THTensor *self, double mean, double stdv, at::Gene
 TH_API void THTensor_(normal_means)(THTensor *self, THTensor *means, double stddev, at::Generator *gen);
 TH_API void THTensor_(normal_stddevs)(THTensor *self, double mean, THTensor *stddevs, at::Generator *gen);
 TH_API void THTensor_(normal_means_stddevs)(THTensor *self, THTensor *means, THTensor *stddevs, at::Generator *gen);
-TH_API void THTensor_(exponential)(THTensor *self, double lambda, at::Generator *_generator);
 TH_API void THTensor_(cauchy)(THTensor *self, double median, double sigma, at::Generator *_generator);
 TH_API void THTensor_(logNormal)(THTensor *self, double mean, double stdv, at::Generator *_generator);
 TH_API void THTensor_(multinomialAliasSetup)(THTensor *prob_dist, THLongTensor *J, THTensor *q);


### PR DESCRIPTION
@VitalyFedyunin , this PR is about move exponential distribution to Aten and also use MKL to improve the performance.
Benchmark:
```
import torch
import torch.nn as nn
import time

torch.manual_seed(0)

def _time():
    return time.time()

device = "cpu"

#warm up
for n in [10, 100, 1000]:
    input = torch.randn(128, n, requires_grad=False, device=device)
    for i in range(1000):
        input.exponential_()

for n in [1, 10, 100, 1000]:
    fwd_t = 0
    input = torch.randn(128, n, requires_grad=False, device=device)
    for i in range(10000):
        t1 = _time()
        input.exponential_()
        t2 = _time()
        fwd_t = fwd_t + (t2 -t1)
    fwd_avg = fwd_t / 10000 * 1000
    print("input size(128, %d) forward time is %.4f (ms)." % (n, fwd_avg))
```
Test device: **skx-8180**.
Before:
```
input size(128, 1) forward time is 0.0067 (ms).
input size(128, 10) forward time is 0.0560 (ms).
input size(128, 100) forward time is 0.5478 (ms).
input size(128, 1000) forward time is 5.4507 (ms).
```
After:
```
input size(128, 1) forward time is 0.0024 (ms).
input size(128, 10) forward time is 0.0053 (ms).
input size(128, 100) forward time is 0.0071 (ms).
input size(128, 1000) forward time is 0.0138 (ms).
```
Fix #24699