### PR TITLE
Use direct vector indexing in Object::getSlot() instead of at().

### DIFF
--- a/aten/src/ATen/core/ivalue_inl.h
+++ b/aten/src/ATen/core/ivalue_inl.h
@@ -341,7 +341,9 @@ struct C10_EXPORT ivalue::Object final : c10::intrusive_ptr_target {
   }
 
   const IValue& getSlot(size_t slot) const {
-    return slots_.at(slot);
+    // NOTE: This lookup is fairly hot, so we use unchecked access to the
+    // vector.  Errors should still be detectable with ASan.
+    return slots_[slot];
   }
 
   void unsafeRemoveSlot(size_t slot) {


### PR DESCRIPTION
This method is pretty hot.  In an internal workload, this single
call to at() accounted for ~2% of overall cycles.

