### PR TITLE
[BC Check] Print all broken ops instead of the first one

### DIFF
--- a/test/backward_compatibility/check_backward_compatibility.py
+++ b/test/backward_compatibility/check_backward_compatibility.py
@@ -71,9 +71,9 @@ def check_bc(new_schema_dict):
         print('Found backward compatible schemas for all existing schemas')
     else:
         print('The PR is introducing backward incompatible changes to the '
-                'operator library. Please contact PyTorch team to confirm '
-                'whether this change is wanted or not. \n\nBroken ops: '
-                '[\n\t{}\n]'.format("\n\t".join(broken_ops)))
+              'operator library. Please contact PyTorch team to confirm '
+              'whether this change is wanted or not. \n\nBroken ops: '
+              '[\n\t{}\n]'.format("\n\t".join(broken_ops)))
     return is_bc
 
 

--- a/test/backward_compatibility/check_backward_compatibility.py
+++ b/test/backward_compatibility/check_backward_compatibility.py
@@ -45,6 +45,8 @@ def white_listed(schema, white_list):
 
 def check_bc(new_schema_dict):
     existing_schemas = torch._C._jit_get_all_schemas()
+    is_bc = True
+    broken_ops = []
     for existing_schema in existing_schemas:
         if white_listed(existing_schema, white_list):
             print("skipping schema: ", str(existing_schema))
@@ -62,13 +64,17 @@ def check_bc(new_schema_dict):
                   .format(
                       str(existing_schema),
                       "\n\t".join(str(s) for s in new_schemas)))
-            print('The PR is introducing backward incompatible changes to the '
-                  'operator library. Please contact PyTorch team to confirm '
-                  'whether this change is wanted or not.')
             # TODO Print out more details about why candidates don't match.
-            return False
-    print('Found backward compatible schemas for all existing schemas')
-    return True
+            broken_ops.append(str(existing_schema))
+            is_bc = False
+    if is_bc:
+        print('Found backward compatible schemas for all existing schemas')
+    else:
+        print('The PR is introducing backward incompatible changes to the '
+                'operator library. Please contact PyTorch team to confirm '
+                'whether this change is wanted or not. \n\nBroken ops: '
+                '[\n\t{}\n]'.format("\n\t".join(broken_ops)))
+    return is_bc
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Originally, we only print one broken schema. With this changeset, all the broken schemas are printed out.