### PR TITLE
[WIP Patched] Cudnn grouped convolution nhwc patch

### DIFF
--- a/aten/src/ATen/native/cudnn/Conv.cpp
+++ b/aten/src/ATen/native/cudnn/Conv.cpp
@@ -130,6 +130,15 @@ Tensor narrowGroup(const Tensor& t, int dim, int group_idx, int64_t groups) {
   return t.narrow(dim, group_idx * group_size, group_size);
 }
 
+bool support_channels_last(const Tensor& input, const Tensor& weight, int groups) {
+  if (!detail::getCUDAHooks().compiledWithCuDNN()) {
+    return false;
+  }
+  long cudnn_version = detail::getCUDAHooks().versionCuDNN();
+  return (groups == 1 || cudnn_version >= 7603) &&
+      (input.suggest_memory_format() == at::MemoryFormat::ChannelsLast);
+}
+
 // ---------------------------------------------------------------------
 //
 // Checking
@@ -909,11 +918,13 @@ Tensor cudnn_convolution_forward(
   checkAllSameType(c, {input, weight});
   checkAllSameGPU(c, {input, weight});
 
+  auto layout = support_channels_last(*input, *weight, groups) ?
+      at::MemoryFormat::ChannelsLast : at::MemoryFormat::Contiguous;
   auto output_t = at::empty(
                     conv_output_size(input->sizes(), weight->sizes(),
                                      padding, stride, dilation),
                     input->options(),
-                    input->suggest_memory_format());
+                    layout);
 
   if (output_t.numel() == 0) {
     return output_t;
@@ -924,11 +935,12 @@ Tensor cudnn_convolution_forward(
   convolution_shape_check(c, input, weight, output, padding, stride, dilation, groups);
 
   // See #4500
-  Tensor weight_contig = weight->contiguous(input->suggest_memory_format());
-  weight_contig.resize_(weight_contig.sizes(), input->suggest_memory_format());
+  Tensor weight_contig = weight->contiguous(layout);
+  weight_contig.resize_(weight_contig.sizes(), layout);
+  Tensor input_contig = input->contiguous(layout);
 
   raw_cudnn_convolution_forward_out(
-      *output, *input, weight_contig,
+      *output, input_contig, weight_contig,
       padding, stride, dilation, groups, benchmark, deterministic);
 
   return *output;
@@ -1065,19 +1077,23 @@ Tensor cudnn_convolution_backward_input(
   checkAllSameType(c, {grad_output, weight});
   checkAllSameGPU(c, {grad_output, weight});
 
-  auto grad_input_t = at::empty(input_size, grad_output->options(), grad_output->suggest_memory_format());
+  auto layout = support_channels_last(*grad_output, *weight, groups) ?
+      at::MemoryFormat::ChannelsLast : at::MemoryFormat::Contiguous;
+  auto grad_input_t = at::empty(input_size, grad_output->options(), layout);
 
   // Avoid "grad_input" when this is being used as transposed convolution
   TensorArg grad_input{ grad_input_t, "result", 0 };
   convolution_shape_check(c, grad_input, weight, grad_output, padding, stride, dilation, groups);
 
   // See #4500
-  Tensor weight_contig = weight->contiguous(grad_output->suggest_memory_format());
+  Tensor weight_contig = weight->contiguous(layout);
   // Make sure that NC11 strides follow formula
-  weight_contig.resize_(weight_contig.sizes(), grad_output->suggest_memory_format());
+  weight_contig.resize_(weight_contig.sizes(), layout);
+  Tensor grad_output_contig = grad_output->contiguous(layout);
+
 
   raw_cudnn_convolution_backward_input_out(
-      *grad_input, *grad_output, weight_contig,
+      *grad_input, grad_output_contig, weight_contig,
       padding, stride, dilation, groups, benchmark, deterministic);
 
   return *grad_input;

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7554,6 +7554,17 @@ class TestNN(NNTestCase):
         self.assertEqual(conv.bias.grad, ref_conv.bias.grad)
         self.assertEqual(input.grad, ref_input.grad)
 
+    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
+    @unittest.skipIf(not TEST_CUDNN, "needs cudnn")
+    @skipIfRocm
+    def test_grouped_conv_cudnn_nhwc_support(self):
+        # in order to catch the hols in grouped convolution in nhwc support for earlier cudnn version
+        input = torch.randn((16, 16, 8, 8), dtype=torch.float16, device="cuda").to(memory_format=torch.channels_last)
+        weight = torch.randn((8, 4, 3, 3), dtype=torch.float16, device="cuda").to(memory_format=torch.channels_last)
+        out = torch.cudnn_convolution(input, weight, None, (1, 1), (1, 1), (1, 1), 4, False, False)
+        input = torch.randn((16, 8, 8, 8), dtype=torch.float16, device="cuda").to(memory_format=torch.channels_last)
+        out = torch.cudnn_convolution_transpose(input, weight, None, (1, 1), (0, 0), (1, 1), (1, 1), 4, False, False)
+
     @unittest.expectedFailure
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     @unittest.skipIf(not TEST_CUDNN, "needs cudnn")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#31633 [WIP Patched] Cudnn grouped convolution nhwc patch**
* #31428 WIP
* #31139 [WIP] Fix cudnn channels_last descriptio problem
* #31131 Add memory_format support to `zeros`, `ones`, `full`

Earlier cudnn version doesn't support grouped convolution in NHWC well. Legit
configuration in later cudnn version might return CUDNN_STATUS_NOT_SUPPORTED.
We are falling back to NCHW when runtime check of cudnn version is < 7.6.0 to
keep the logic simple.

Note:
We might update the heuristics, 7.6.0 is very conservative.