### PR TITLE
Expose RRef.rref_id() API to return a string of RRefId

### DIFF
--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -160,6 +160,14 @@ PyObject* rpc_init(PyObject* /* unused */) {
                   Returns worker information of the node that owns this ``RRef``.
               )")
           .def(
+              "rref_id",
+              &PyRRef::rrefId,
+              R"(
+                  Returns a string of its RRefId. Different RRefs will have the
+                  same RRefId if they share the same OwnerRRef, i.e., they are
+                  referencing the same data object.
+              )")
+          .def(
               "to_here",
               &PyRRef::toHere,
               py::call_guard<py::gil_scoped_release>(),

--- a/torch/csrc/distributed/rpc/py_rref.cpp
+++ b/torch/csrc/distributed/rpc/py_rref.cpp
@@ -37,6 +37,13 @@ PyRRef::PyRRef(const py::object& value)
         return rref;
       }()) {}
 
+std::string PyRRef::rrefId() const {
+  std::stringstream ss;
+  auto& rrefId = rref_->rrefId();
+  ss << rrefId.createdOn_ << '_' << rrefId.localId_;
+  return ss.str();
+}
+
 bool PyRRef::isOwner() const {
   return rref_->isOwner();
 }

--- a/torch/csrc/distributed/rpc/py_rref.h
+++ b/torch/csrc/distributed/rpc/py_rref.h
@@ -16,6 +16,7 @@ class PyRRef {
   // creates a local RRef with the given object as value
   explicit PyRRef(const py::object& value);
 
+  std::string rrefId() const;
   bool isOwner() const;
   WorkerInfo owner() const;
   py::object toHere();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#31639 Expose RRef.rref_id() API to return a string of RRefId**

The motivation is that applications need to distinguish if two
RRefs share the same `OwnerRRef` (and therefore point to the 
same data object). This can be done by comparing the RRefId. 
This PR expose the RRefId in Python API, and the string format 
is `RRefId.createdOn_ + "_" + RRefId.localId_`. There are several 
alternatives:

1. Extract RRefId from `RRef.str()`: existing `RRef.str()` already
contains the RRefId, e.g. `UserRRef(RRefId = GloballyUniqueId(2, 0), ForkId = GloballyUniqueId(2, 1))`.
However, it would be cumbersome to parse the string.
2. Expose RRefId/ForkId/GloballyUniqueId type in Python. I am a
little hesitate to do this because RRefId is an internal concept
and might subject to change.
3. Return an in64_t. Similar to distributed autograd context id,
we could use the high 16 bits to store the `createdOn_` field
(`worker_id_t`) and use the remaining 48 bits to store `localId_`.
However, I am not sure if 48 bits would be sufficient as there
could be a lot more RRefs than training iterations.

Differential Revision: [D19232860](https://our.internmc.facebook.com/intern/diff/D19232860)