### PR TITLE
Migrating `scatter_add` to ATen with multithreading support.

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -264,7 +264,8 @@
   name: _th_scatter_add_
   return: argument 0
   cname: scatterAdd
-  cpu_bool: True
+  backends:
+    - CUDA
   cuda_bool: True
   variants: function
   arguments:

--- a/aten/src/ATen/native/Indexing.cpp
+++ b/aten/src/ATen/native/Indexing.cpp
@@ -69,6 +69,8 @@ DEFINE_DISPATCH(index_put_stub);
 DEFINE_DISPATCH(index_put_accum_stub);
 REGISTER_NO_CPU_DISPATCH(index_put_accum_stub, index_put_accum_fn);
 
+DEFINE_DISPATCH(scatter_add_stub);
+
 static bool all_strides_match(TensorList tensors) {
   TORCH_CHECK(tensors.size() >= 1);
   auto strides = tensors[0].strides();
@@ -393,161 +395,8 @@ Tensor scatter(const Tensor & self, int64_t dim, const Tensor & index, Scalar so
   return self.clone(at::MemoryFormat::Preserve).scatter_(dim, index, source);
 }
 
-namespace scattergather {
-  int64_t ensure_nonempty_dim(int64_t dim) {
-    return std::max<int64_t>(dim, 1);
-  }
-
-  int64_t ensure_nonempty_size(const Tensor& t, int64_t dim) {
-    return t.dim() == 0 ? 1 : t.size(dim);
-  }
-
-  int64_t ensure_nonempty_stride(const Tensor& t, int64_t dim) {
-    return t.dim() == 0 ? 1 : t.stride(dim);
-  }
-
-  template <typename TSelf, typename TIndex, typename TSrc>
-  struct TensorDimApply3Functor {
-    template <typename SizeCheckFunc, typename KernelOpFunc>
-    void operator()(
-      Tensor& self,
-      const Tensor& index,
-      const Tensor& src,
-      int64_t dim,
-      SizeCheckFunc sizeCheckFunc,
-      KernelOpFunc kernelOpFunc
-    ) {
-      if (index.numel() == 0) {
-        return;
-      }
-
-      sizeCheckFunc(self, index, src, dim);
-
-      TSelf* self_data = self.data_ptr<TSelf>();
-      int64_t self_dim_stride = ensure_nonempty_stride(self, dim);
-      int64_t self_dim_size = ensure_nonempty_size(self, dim);
-
-      const TIndex* index_data = index.data_ptr<TIndex>();
-      int64_t index_dim_stride = ensure_nonempty_stride(index, dim);
-      int64_t index_dim_size = ensure_nonempty_size(index, dim);
-
-      const TSrc* src_data = src.data_ptr<TSrc>();
-      int64_t src_dim_stride = ensure_nonempty_stride(src, dim);
-      int64_t src_dim_size = ensure_nonempty_size(src, dim);
-
-      bool applyHasFinished = false;
-      int64_t index_dim = ensure_nonempty_dim(index.dim());
-      std::vector<int64_t> idxCounter(index_dim, 0);
-      while (!applyHasFinished) {
-        kernelOpFunc(
-          index_dim_size, self_dim_size,
-          self_data, self_dim_stride,
-          index_data, index_dim_stride,
-          src_data, src_dim_stride
-        );
-
-        if (index_dim == 1) {
-          break;
-        }
-        
-        for (int64_t d = 0; d < index_dim; ++d) {
-          if (d == dim) {
-            if (d == (index_dim - 1)) {
-              applyHasFinished = true;
-              break;
-            }
-            continue;
-          }
-
-          idxCounter[d]++;
-          self_data += ensure_nonempty_stride(self, d);
-          index_data += ensure_nonempty_stride(index, d);
-          src_data += ensure_nonempty_stride(src, d);
-
-          if (idxCounter[d] == ensure_nonempty_size(index, d)) {
-            if (d == (index_dim - 1)) {
-              applyHasFinished = true;
-              break;
-            }
-            else {
-              self_data -= idxCounter[d] * ensure_nonempty_stride(self, d);
-              index_data -= idxCounter[d] * ensure_nonempty_stride(index, d);
-              src_data -= idxCounter[d] * ensure_nonempty_stride(src, d);
-              idxCounter[d] = 0;
-            }
-          }
-          else {
-            break;
-          }
-        } // for (d = 0...index_dim-1)
-      } // while (!applyHasFinished)
-    }
-  };
-
-  /*
-   * Used for 'scatter' and 'scatter_add'
-   * 
-   * Tests:
-   *  1. index.size(d) <= src.size(d) for all d
-   *  2. index.size(d) <= self.size(d) for all d != dim
-   */
-  struct ScatterSizeCheckFunctor {
-    void operator()(
-      const Tensor& self, const Tensor& index,
-      const Tensor& src, int64_t dim
-    ) {
-      bool is_wrong_shape = false;
-      int64_t self_dims = ensure_nonempty_dim(self.dim());
-      for (int64_t d = 0; d < self_dims; ++d) {
-        int64_t index_d_size = ensure_nonempty_size(index, d);
-        if (index_d_size > ensure_nonempty_size(src, d)) {
-          is_wrong_shape = true;
-          break;
-        }
-        if (d != dim) {
-          if (index_d_size > ensure_nonempty_size(self, d)) {
-            is_wrong_shape = true;
-            break;
-          }
-        }
-      }
-
-      TORCH_CHECK(!is_wrong_shape,
-        "Expected ", index, " ", index.sizes(),
-        "to be smaller size than ", src, " ", src.sizes(),
-        " and to be smaller than ", self, " ", self.sizes(),
-        " apart from dimension ", dim
-      );
-    }
-  };
-} // namespace scattergather
-
 Tensor & scatter_add_cpu_(Tensor & self, int64_t dim, const Tensor & index, const Tensor & src) {
-  dim = maybe_wrap_dim(dim, self.dim());
-
-  AT_DISPATCH_ALL_TYPES_AND2(
-    ScalarType::Bool, ScalarType::Half, self.scalar_type(),
-    "scatter_add_", [&] {
-      scattergather::TensorDimApply3Functor<scalar_t, int64_t, scalar_t>()(
-        self, index, src, dim,
-        scattergather::ScatterSizeCheckFunctor(),
-        [] (
-          auto elems_per_dim, auto self_dim_size,
-          auto* self_data, auto self_dim_stride,
-          const auto* index_data, auto index_dim_stride,
-          const auto* src_data, auto src_dim_stride
-        ) {
-          for (int64_t i = 0; i < elems_per_dim; ++i) {
-            int64_t idx_dim = index_data[i * index_dim_stride];
-            TORCH_CHECK(idx_dim >= 0 && idx_dim < self_dim_size,
-              "Invalid index in scatter_add");
-            self_data[idx_dim * self_dim_stride] += src_data[i * src_dim_stride];
-          }
-        }
-      );
-    }
-  );
-
+  scatter_add_stub(self.device().type(), self, dim, index, src);
   return self;
 }
 

--- a/aten/src/ATen/native/Indexing.cpp
+++ b/aten/src/ATen/native/Indexing.cpp
@@ -488,6 +488,7 @@ namespace scattergather {
               self_data -= idxCounter[d] * ensure_nonempty_stride(self, d);
               index_data -= idxCounter[d] * ensure_nonempty_stride(index, d);
               src_data -= idxCounter[d] * ensure_nonempty_stride(src, d);
+              idxCounter[d] = 0;
             }
           }
           else {

--- a/aten/src/ATen/native/Indexing.cpp
+++ b/aten/src/ATen/native/Indexing.cpp
@@ -417,11 +417,12 @@ namespace scattergather {
       SizeCheckFunc sizeCheckFunc,
       KernelOpFunc kernelOpFunc
     ) {
-      sizeCheckFunc(self, index, src, dim);
-
       if (index.numel() == 0) {
         return;
       }
+
+      sizeCheckFunc(self, index, src, dim);
+
 
       TSelf* self_data = self.data_ptr<TSelf>();
       int64_t self_dim_stride = ensure_nonempty_stride(self, dim);

--- a/aten/src/ATen/native/Indexing.cpp
+++ b/aten/src/ATen/native/Indexing.cpp
@@ -417,22 +417,6 @@ namespace scattergather {
       SizeCheckFunc sizeCheckFunc,
       KernelOpFunc kernelOpFunc
     ) {
-      int64_t self_dim = ensure_nonempty_dim(self.dim());
-      int64_t index_dim = ensure_nonempty_dim(index.dim());
-      int64_t src_dim = ensure_nonempty_dim(src.dim());
-
-      TORCH_CHECK((dim >= 0) || (dim < index_dim),
-        "Invalid dimesion ", dim, " (expected to be 0 <= dim < ", index_dim, ")"
-      );
-
-      TORCH_CHECK((index_dim == self_dim) && (index_dim == self_dim),
-        "Inconsistent tensor sizes, expected ",
-        index, " ", index.sizes(), ", ",
-        self, " ", self.sizes(), " and ",
-        src, " ", src.sizes(),
-        " to have the same number of dimensions"
-      );
-
       sizeCheckFunc(self, index, src, dim);
 
       if (index.numel() == 0) {
@@ -452,6 +436,7 @@ namespace scattergather {
       int64_t src_dim_size = ensure_nonempty_size(src, dim);
 
       bool applyHasFinished = false;
+      int64_t index_dim = ensure_nonempty_dim(index.dim());
       std::vector<int64_t> idxCounter(index_dim, 0);
       while (!applyHasFinished) {
         kernelOpFunc(

--- a/aten/src/ATen/native/Indexing.h
+++ b/aten/src/ATen/native/Indexing.h
@@ -15,8 +15,12 @@ using index_fn = void(*)(TensorIterator &, IntArrayRef indexed_sizes, IntArrayRe
 using index_put_fn = void(*)(TensorIterator &, IntArrayRef indexed_sizes, IntArrayRef indexed_strides, bool accumulate);
 using index_put_accum_fn = void(*)(Tensor &, TensorList , const Tensor &, bool unsafe);
 
+using scatter_add_fn = void(*)(Tensor& self, int64_t dim, const Tensor& index, const Tensor& src);
+
 DECLARE_DISPATCH(index_fn, index_stub);
 DECLARE_DISPATCH(index_put_fn, index_put_stub);
 DECLARE_DISPATCH(index_put_accum_fn, index_put_accum_stub);
+
+DECLARE_DISPATCH(scatter_add_fn, scatter_add_stub);
 
 }} // namespace at::native

--- a/aten/src/ATen/native/cpu/IndexKernel.cpp
+++ b/aten/src/ATen/native/cpu/IndexKernel.cpp
@@ -117,10 +117,165 @@ void index_put_kernel(TensorIterator& iter, IntArrayRef index_size, IntArrayRef 
   });
 }
 
+inline int64_t ensure_nonempty_dim(int64_t dim) {
+  return std::max<int64_t>(dim, 1);
+}
+
+inline int64_t ensure_nonempty_size(const Tensor& t, int64_t dim) {
+  return t.dim() == 0 ? 1 : t.size(dim);
+}
+
+inline int64_t ensure_nonempty_stride(const Tensor& t, int64_t dim) {
+  return t.dim() == 0 ? 1 : t.stride(dim);
+}
+
+template <typename scalar_t, typename func_t>
+void cpu_apply_dim_kernel(
+  Tensor& self,
+  int64_t dim,
+  const Tensor& index,
+  const Tensor& src,
+  const func_t& f
+) {
+  auto loop = [&](int64_t begin, int64_t end) {
+    scalar_t* self_data = self.data_ptr<scalar_t>();
+    int64_t self_dim_stride = ensure_nonempty_stride(self, dim);
+
+    int64_t* index_data = index.data_ptr<int64_t>();
+    int64_t index_dim_stride = ensure_nonempty_stride(index, dim);
+
+    scalar_t* src_data = src.data_ptr<scalar_t>();
+    int64_t src_dim_stride = ensure_nonempty_stride(src, dim);
+
+    int64_t index_dim = ensure_nonempty_dim(index.dim());
+    auto counter = at::DimCounter(index.sizes(), {begin, end});
+
+    // offset pointers according to counts
+    for (int64_t d = 0; d < index_dim; ++d) {
+      if (d == dim) {
+        continue;
+      }
+      self_data += counter.values[d] * ensure_nonempty_stride(self, d);
+      index_data += counter.values[d] * ensure_nonempty_stride(index, d);
+      src_data += counter.values[d] * ensure_nonempty_stride(src, d);
+    }
+
+    for (int64_t i = begin; i < end; ++i) {
+      f(
+        self_data, self_dim_stride,
+        index_data, index_dim_stride,
+        src_data, src_dim_stride
+      );
+
+      for (int64_t d = 0; d < index_dim; ++d) {
+        if (d == dim) {
+          continue;
+        }
+
+        counter.values[d]++;
+        self_data += ensure_nonempty_stride(self, d);
+        index_data += ensure_nonempty_stride(index, d);
+        src_data += ensure_nonempty_stride(src, d);
+
+        if (counter.values[d] == ensure_nonempty_size(index, d)) {
+          self_data -= counter.values[d] * ensure_nonempty_stride(self, d);
+          index_data -= counter.values[d] * ensure_nonempty_stride(index, d);
+          src_data -= counter.values[d] * ensure_nonempty_stride(src, d);
+          counter.values[d] = 0;
+        }
+        else {
+          break;
+        }
+      }
+    }
+  };
+
+  int64_t max_num_iters = index.numel() / ensure_nonempty_size(index, dim);
+  if (max_num_iters < internal::GRAIN_SIZE || at::get_num_threads() == 1) {
+    loop(0, max_num_iters);
+  }
+  else {
+    at::parallel_for(0, max_num_iters, internal::GRAIN_SIZE, [&](int64_t begin, int64_t end) {
+      loop(begin, end);
+    });
+  }
+}
+
+/*
+  * Used for 'scatter' and 'scatter_add'
+  * 
+  * Tests:
+  *  1. index.size(d) <= src.size(d) for all d
+  *  2. index.size(d) <= self.size(d) for all d != dim
+  */
+struct ScatterSizeCheckFunctor {
+  void operator()(
+    const Tensor& self, int64_t dim,
+    const Tensor& index, const Tensor& src
+  ) {
+    bool is_wrong_shape = false;
+    int64_t self_dims = ensure_nonempty_dim(self.dim());
+    for (int64_t d = 0; d < self_dims; ++d) {
+      int64_t index_d_size = ensure_nonempty_size(index, d);
+      if (index_d_size > ensure_nonempty_size(src, d)) {
+        is_wrong_shape = true;
+        break;
+      }
+      if (d != dim) {
+        if (index_d_size > ensure_nonempty_size(self, d)) {
+          is_wrong_shape = true;
+          break;
+        }
+      }
+    }
+
+    TORCH_CHECK(!is_wrong_shape,
+      "Expected ", index, " ", index.sizes(),
+      "to be smaller size than ", src, " ", src.sizes(),
+      " and to be smaller than ", self, " ", self.sizes(),
+      " apart from dimension ", dim
+    );
+  }
+};
+
+void scatter_add_cpu_kernel(Tensor& self, int64_t dim, const Tensor& index, const Tensor& src) {
+  if (index.numel() == 0) {
+    return;
+  }
+
+  ScatterSizeCheckFunctor()(self, dim, index, src);
+
+  dim = maybe_wrap_dim(dim, self.dim());
+  int64_t index_dim_size = ensure_nonempty_size(index, dim);
+  int64_t self_dim_size = ensure_nonempty_size(self, dim);
+
+  AT_DISPATCH_ALL_TYPES_AND2(
+    ScalarType::Bool, ScalarType::Half, self.scalar_type(),
+    "scatter_add_", [&] {
+      cpu_apply_dim_kernel<scalar_t>(self, dim, index, src,
+        [&] (
+          auto* self_data, auto self_dim_stride,
+          const auto* index_data, auto index_dim_stride,
+          const auto* src_data, auto src_dim_stride
+        ) {
+          for (int64_t i = 0; i < index_dim_size; ++i) {
+            int64_t idx_dim = index_data[i * index_dim_stride];
+            TORCH_CHECK(idx_dim >= 0 && idx_dim < self_dim_size,
+              "Invalid index in scatter_add");
+            self_data[idx_dim * self_dim_stride] += src_data[i * src_dim_stride];
+          }
+        }
+      );
+    }
+  );
+}
+
 } // anonymous namespace
 
 
 REGISTER_DISPATCH(index_stub, &index_kernel);
 REGISTER_DISPATCH(index_put_stub, &index_put_kernel);
+
+REGISTER_DISPATCH(scatter_add_stub, &scatter_add_cpu_kernel);
 
 }} // namespace at::native

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3888,7 +3888,7 @@
 - func: scatter_add_(Tensor(a!) self, int dim, Tensor index, Tensor src) -> Tensor(a!)
   variants: method
   dispatch:
-    CPU: legacy::cpu::_th_scatter_add_
+    CPU: scatter_add_cpu_
     CUDA: legacy::cuda::_th_scatter_add_
 
 - func: scatter_add(Tensor self, int dim, Tensor index, Tensor src) -> Tensor

--- a/aten/src/TH/generic/THTensorEvenMoreMath.cpp
+++ b/aten/src/TH/generic/THTensorEvenMoreMath.cpp
@@ -685,38 +685,6 @@ void THTensor_(scatter)(THTensor *tensor, int dim, THLongTensor *index, THTensor
                        })
 }
 
-void THTensor_(scatterAdd)(THTensor *tensor, int dim, THLongTensor *index, THTensor *src)
-{
-  int64_t elems_per_row, i, idx;
-  int index_ndim_legacy_all = THTensor_nDimensionLegacyAll(index);
-
-  THArgCheck(dim < THTensor_(nDimensionLegacyNoScalars)(tensor), 2, "Index dimension is out of bounds");
-  THArgCheck(index_ndim_legacy_all == 0
-             || THLongTensor_nDimensionLegacyNoScalars(index) == THTensor_(nDimensionLegacyNoScalars)(tensor), 3,
-             "Index tensor must have same dimensions as output tensor");
-  THArgCheck(THTensor_(nDimensionLegacyNoScalars)(src) == THTensor_(nDimensionLegacyNoScalars)(tensor), 4,
-             "Input tensor must have same dimensions as output tensor");
-
-  // no-op if index is empty
-  if (index_ndim_legacy_all == 0)
-      return;
-
-  elems_per_row = THTensor_sizeLegacyNoScalars(index, dim);
-
-  TH_TENSOR_DIM_APPLY3(int64_t, index, scalar_t, tensor, scalar_t, src, dim,
-                       TH_TENSOR_DIM_APPLY3_SIZE_SCATTER,
-                       for (i = 0; i < elems_per_row; ++i)
-                       {
-                         idx = *(index_data + i*index_stride);
-                         if (idx < 0 || idx >= tensor_size)
-                         {
-                           THFree(TH_TENSOR_DIM_APPLY_counter);
-                           THError("Invalid index in scatterAdd");
-                         }
-                         tensor_data[idx * tensor_stride] += *(src_data + i*src_stride);
-                       })
-}
-
 #if !defined(TH_REAL_IS_BOOL)
 
 accreal THTensor_(dot)(THTensor *tensor, THTensor *src)

--- a/aten/src/TH/generic/THTensorMath.h
+++ b/aten/src/TH/generic/THTensorMath.h
@@ -99,7 +99,6 @@ TH_API void THTensor_(indexFill)(THTensor *tensor, int dim, THLongTensor *index,
 
 TH_API void THTensor_(gather)(THTensor *tensor, THTensor *src, int dim, THLongTensor *index);
 TH_API void THTensor_(scatter)(THTensor *tensor, int dim, THLongTensor *index, THTensor *src);
-TH_API void THTensor_(scatterAdd)(THTensor *tensor, int dim, THLongTensor *index, THTensor *src);
 TH_API void THTensor_(scatterFill)(THTensor *tensor, int dim, THLongTensor *index, scalar_t val);
 
 TH_API void THTensor_(cumsum)(THTensor *r_, THTensor *t, int dimension);


### PR DESCRIPTION
Fixes [#24758](https://github.com/pytorch/pytorch/issues/24758).

Similar to [#31525](https://github.com/pytorch/pytorch/pull/31525), but supports multithreading.