### PR TITLE
Fixing issue https://github.com/pytorch/pytorch/issues/31515

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -10416,6 +10416,11 @@ class TestTorchDeviceType(TestCase):
                                              [0, 0, 0],
                                              [1, 2, 3]]))
 
+        # Check that cummulative sum over a zero length dimension doesn't crash on backprop
+        zeroNumelTensor = torch.zeros(2, 0, requires_grad=True)
+        integrated = zeroNumelTensor.cumsum(dim=-1).sum()
+        integrated.backward()
+
     def test_cumprod(self, device):
         x = torch.rand(100, 100, device=device)
         res1 = torch.cumprod(x, 1)
@@ -10440,6 +10445,11 @@ class TestTorchDeviceType(TestCase):
         self.assertEqual(aRes, torch.tensor([[1, 0, 0],
                                              [0, 0, 0],
                                              [1, 1, 1]]))
+
+        # Check that cummulative product over a zero length dimension doesn't crash on backprop
+        zeroNumelTensor = torch.zeros(2, 0, requires_grad=True)
+        integrated = zeroNumelTensor.cumprod(dim=-1).sum()
+        integrated.backward()
 
     def test_std_mean(self, device):
         x = torch.rand(100, 50, 20, device=device)

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -351,7 +351,7 @@ Tensor cumprod_backward(const Tensor &grad, const Tensor &input, int64_t dim) {
     dy_j / dx_k = 0, which is done right after the assert.
   */
 
-  if (input.dim() == 0) {
+  if (input.numel() == 0) {
     return grad;
   }
   dim = at::maybe_wrap_dim(dim, input.sizes().size());
@@ -415,7 +415,7 @@ Tensor solve_backward_A(const Tensor & grad, const Tensor & self, const Tensor &
 }
 
 Tensor cumsum_backward(const Tensor & x, int64_t dim) {
-  if (x.dim() == 0) {
+  if (x.numel() == 0) {
     return x;
   }
   auto ret = at::cumsum(-x, dim);


### PR DESCRIPTION
Fixing bug to handle cumsum and cumprod with 0 elements, such as non-…zero dimensional tensors aggregating over a dimension with 0 length. Previously backprop in this setting caused an exception. 

Fixing issue https://github.com/pytorch/pytorch/issues/31515