### PR TITLE
Use numeric limits to define TensorTypeSet(FULL) representation

### DIFF
--- a/c10/core/TensorTypeSet.h
+++ b/c10/core/TensorTypeSet.h
@@ -41,7 +41,7 @@ public:
   TensorTypeSet()
     : repr_(0) {}
   TensorTypeSet(Full)
-    : repr_(-1) {}
+    : repr_(std::numeric_limits<decltype(repr_)>::max()) {}
   // Public version of TensorTypeSet(uint64_t) API; external users
   // must be explicit when they do this!
   TensorTypeSet(Raw, uint64_t x)


### PR DESCRIPTION
Summary: This also removes an annoying warning about change of sign conversion

Test Plan: Run unit tests

Differential Revision: D19238631

