### PR TITLE
Apply clang-format to csrc/distributed/rpc

### DIFF
--- a/torch/csrc/distributed/rpc/python_call.cpp
+++ b/torch/csrc/distributed/rpc/python_call.cpp
@@ -20,8 +20,7 @@ Message PythonCall::toMessage() && {
 }
 
 std::unique_ptr<PythonCall> PythonCall::fromMessage(const Message& message) {
-  return std::make_unique<PythonCall>(
-      message.payload(), message.tensors());
+  return std::make_unique<PythonCall>(message.payload(), message.tensors());
 }
 
 const std::vector<char>& PythonCall::pickledPayload() const {

--- a/torch/csrc/distributed/rpc/python_resp.cpp
+++ b/torch/csrc/distributed/rpc/python_resp.cpp
@@ -18,8 +18,7 @@ Message PythonResp::toMessage() && {
 }
 
 std::unique_ptr<PythonResp> PythonResp::fromMessage(const Message& message) {
-  return std::make_unique<PythonResp>(
-      message.payload(), message.tensors());
+  return std::make_unique<PythonResp>(message.payload(), message.tensors());
 }
 
 const std::vector<char>& PythonResp::pickledPayload() const {

--- a/torch/csrc/distributed/rpc/rref_proto.cpp
+++ b/torch/csrc/distributed/rpc/rref_proto.cpp
@@ -176,8 +176,7 @@ std::unique_ptr<RRefChildAccept> RRefChildAccept::fromMessage(
   auto values = toIValues(message, MessageType::RREF_CHILD_ACCEPT);
   TORCH_INTERNAL_ASSERT(values.size() == 1, "Expect 1 IValues from message.");
 
-  return std::make_unique<RRefChildAccept>(
-      ForkId::fromIValue(values.back()));
+  return std::make_unique<RRefChildAccept>(ForkId::fromIValue(values.back()));
 }
 
 std::unique_ptr<RRefForkRequest> RRefForkRequest::fromMessage(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#31681 Apply clang-format to csrc/distributed/rpc**
* #28942 Split RRef class into abstract RRef and RRefBase

Differential Revision: [D19247085](https://our.internmc.facebook.com/intern/diff/D19247085)