### PR TITLE
Fixed error in sample code of documentation

### DIFF
--- a/docs/source/notes/extending.rst
+++ b/docs/source/notes/extending.rst
@@ -200,8 +200,8 @@ This is how a ``Linear`` module can be implemented::
         def extra_repr(self):
             # (Optional)Set the extra information about this module. You can test
             # it by printing an object of this class.
-            return 'in_features={}, out_features={}, bias={}'.format(
-                self.in_features, self.out_features, self.bias is not None
+            return 'input_features={}, output_features={}, bias={}'.format(
+                self.input_features, self.output_features, self.bias is not None
             )
 
 Extending :mod:`torch`


### PR DESCRIPTION
"in_features" and "out_features" are not defined. Possibly a typo. They should be "input_features" and "output_features" instead

