### PR TITLE
add additional types to indexing operations dispatch

### DIFF
--- a/aten/src/ATen/AccumulateType.h
+++ b/aten/src/ATen/AccumulateType.h
@@ -32,6 +32,7 @@ template <> struct AccumulateType<char, true> { using type = int64_t; };
 template <> struct AccumulateType<int16_t, true> { using type = int64_t; };
 template <> struct AccumulateType<int32_t, true> { using type = int64_t; };
 template <> struct AccumulateType<int64_t, true> { using type = int64_t; };
+template <> struct AccumulateType<bool, true> {using type = bool; };
 template <> struct AccumulateType<BFloat16, false> { using type = float; };
 template <> struct AccumulateType<float, false> { using type = double; };
 template <> struct AccumulateType<double, false> { using type = double; };

--- a/aten/src/ATen/native/cpu/IndexKernel.cpp
+++ b/aten/src/ATen/native/cpu/IndexKernel.cpp
@@ -93,7 +93,8 @@ void cpu_index_kernel(TensorIterator& iter, IntArrayRef index_size, IntArrayRef 
 }
 
 void index_kernel(TensorIterator& iter, IntArrayRef index_size, IntArrayRef index_stride) {
-  AT_DISPATCH_ALL_TYPES_AND2(at::ScalarType::Half, at::ScalarType::Bool, iter.dtype(), "index_cpu", [&] {
+  AT_DISPATCH_ALL_TYPES_AND3(at::ScalarType::Half, at::ScalarType::Bool, at::ScalarType::BFloat16,
+    iter.dtype(), "index_cpu", [&] {
     cpu_index_kernel<scalar_t>(iter, index_size, index_stride, [](char* dst, char* src, int64_t offset) {
       *(scalar_t*)dst = *(scalar_t*)(src + offset);
     });
@@ -102,7 +103,8 @@ void index_kernel(TensorIterator& iter, IntArrayRef index_size, IntArrayRef inde
 
 void index_put_kernel(TensorIterator& iter, IntArrayRef index_size, IntArrayRef index_stride, bool accumulate) {
   // NOTE: duplicate indices are only supported if accumulate is true.
-  AT_DISPATCH_ALL_TYPES_AND2(at::ScalarType::Half, at::ScalarType::Bool, iter.dtype(), "index_put", [&] {
+  AT_DISPATCH_ALL_TYPES_AND3(at::ScalarType::Half, at::ScalarType::Bool, at::ScalarType::BFloat16,
+    iter.dtype(), "index_put", [&] {
     if (accumulate) {
       // TODO: investigate parallelization of the accumulate kernel. Unlike the non-accumulate case,
       // this needs to be thread-safe.

--- a/aten/src/ATen/native/cuda/IndexKernel.cu
+++ b/aten/src/ATen/native/cuda/IndexKernel.cu
@@ -88,7 +88,7 @@ void index_put_kernel_impl(TensorIterator& iter, IntArrayRef index_size, IntArra
 }
 
 static void index_kernel(TensorIterator& iter, IntArrayRef index_size, IntArrayRef index_stride) {
-  AT_DISPATCH_ALL_TYPES_AND2(at::ScalarType::Half, at::ScalarType::Bool, iter.dtype(), "index_cuda", [&] {
+  AT_DISPATCH_ALL_TYPES_AND3(at::ScalarType::Half, at::ScalarType::Bool, at::ScalarType::BFloat16, iter.dtype(), "index_cuda", [&] {
     using dtype = OpaqueType<sizeof(scalar_t)>;
     index_kernel_impl<dtype>(iter, index_size, index_stride);
   });

--- a/aten/src/ATen/native/cuda/Indexing.cu
+++ b/aten/src/ATen/native/cuda/Indexing.cu
@@ -224,8 +224,9 @@ void index_put_accum_kernel(Tensor & self, TensorList indices, const Tensor & va
            std::min<int>(at::cuda::getCurrentDeviceProperties()->maxGridSize[1], THCCeilDiv(sliceSize, (int64_t) (C10_WARP_SIZE*UNROLL))),
            std::min(std::max<int>(1,nElemBefore), at::cuda::getCurrentDeviceProperties()->maxGridSize[2]));
       dim3 block(C10_WARP_SIZE, indices_per_block);
-  
-      AT_DISPATCH_FLOATING_TYPES_AND_HALF(value_.scalar_type(), "embedding_backward", [&] {
+      
+      AT_DISPATCH_ALL_TYPES_AND2(at::ScalarType::Half, at::ScalarType::Bool,
+      value_.scalar_type(), "indexing_backward", [&] {
       indexing_backward_kernel<scalar_t, UNROLL><<<grid, block, 0, stream>>>(
         sorted_indices.data_ptr<int64_t>(),
         orig_indices.data_ptr<int64_t>(),

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -1,5 +1,5 @@
 from common_utils import TestCase, run_tests
-from common_device_type import instantiate_device_type_tests, onlyCUDA
+from common_device_type import instantiate_device_type_tests, onlyCUDA, dtypesIfCPU, dtypesIfCUDA
 import torch
 from torch import tensor
 import unittest
@@ -104,6 +104,26 @@ class TestIndexing(TestCase):
         self.assertEqual(v[[0, 4, 2]].shape, (3, 7, 3))
         self.assertEqual(v[:, [0, 4, 2]].shape, (5, 3, 3))
         self.assertEqual(v[:, [[0, 1], [4, 3]]].shape, (5, 2, 2, 3))
+
+    @dtypesIfCPU(torch.float, torch.long, torch.bool, torch.bfloat16)
+    @dtypesIfCUDA(torch.half, torch.long, torch.bool)
+    def test_index_put_src_datatype(self, device, dtype):
+        src = torch.ones(3, 2, 4, device=device, dtype=dtype)
+        vals = torch.ones(3, 2, 4, device=device, dtype=dtype)
+        indices = (torch.tensor([0, 2, 1]),)
+        res = src.index_put_(indices, vals, accumulate=True)
+        self.assertEqual(res.shape, src.shape)
+
+    @dtypesIfCPU(torch.float, torch.long, torch.bfloat16, torch.bool)
+    @dtypesIfCUDA(torch.half, torch.long, torch.bfloat16, torch.bool)
+    def test_index_src_datatype(self, device, dtype):
+        src = torch.ones(3, 2, 4, device=device, dtype=dtype)
+        # test index
+        res = src[[0, 2, 1], :, :]
+        self.assertEqual(res.shape, src.shape)
+        # test index_put, no accum
+        src[[0, 2, 1], :, :] = res
+        self.assertEqual(res.shape, src.shape)
 
     def test_int_indices2d(self, device):
         # From the NumPy indexing example

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -1,5 +1,5 @@
 from common_utils import TestCase, run_tests
-from common_device_type import instantiate_device_type_tests, onlyCUDA, dtypesIfCPU, dtypesIfCUDA
+from common_device_type import instantiate_device_type_tests, onlyCUDA, dtypes, dtypesIfCPU, dtypesIfCUDA
 import torch
 from torch import tensor
 import unittest
@@ -105,6 +105,7 @@ class TestIndexing(TestCase):
         self.assertEqual(v[:, [0, 4, 2]].shape, (5, 3, 3))
         self.assertEqual(v[:, [[0, 1], [4, 3]]].shape, (5, 2, 2, 3))
 
+    @dtypes(torch.float, torch.bfloat16, torch.long, torch.bool)
     @dtypesIfCPU(torch.float, torch.long, torch.bool, torch.bfloat16)
     @dtypesIfCUDA(torch.half, torch.long, torch.bool)
     def test_index_put_src_datatype(self, device, dtype):
@@ -114,6 +115,7 @@ class TestIndexing(TestCase):
         res = src.index_put_(indices, vals, accumulate=True)
         self.assertEqual(res.shape, src.shape)
 
+    @dtypes(torch.float, torch.bfloat16, torch.long, torch.bool)
     @dtypesIfCPU(torch.float, torch.long, torch.bfloat16, torch.bool)
     @dtypesIfCUDA(torch.half, torch.long, torch.bfloat16, torch.bool)
     def test_index_src_datatype(self, device, dtype):


### PR DESCRIPTION
- Fixes #31672 
- Adds Bfloat16 dispatch to the indexing operations that were missing it
    - index_put on cuda does not have bfloat16 dispatch, because I'm not sure bfloat16 math ops work on cuda

Note: `index_put_` with `accum=True` is enabled for `bool`, which does not make much sense, but I'm not the one who started it, so this behavior is preserved. 
