### PR TITLE
Fix cumsum error for tensors with zero elements

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -10420,7 +10420,7 @@ class TestTorchDeviceType(TestCase):
         # Also check that cumsum over other dimensions in a tensor with a zero-length
         # dimensiuon also works
         # Also include a basic suite of similar tests for other bases cases.
-        shapes = [[2,0], [2,1,4], [0,2,3], [1], [5]]
+        shapes = [[2, 0], [2, 1, 4], [0, 2, 3], [1], [5]]
         for shape in shapes:
             for dim in range(len(shape)):
                 raw_tensor = torch.zeros(*shape, requires_grad=True)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -10416,10 +10416,27 @@ class TestTorchDeviceType(TestCase):
                                              [0, 0, 0],
                                              [1, 2, 3]]))
 
-        # Check that cummulative sum over a zero length dimension doesn't crash on backprop
-        zeroNumelTensor = torch.zeros(2, 0, requires_grad=True)
-        integrated = zeroNumelTensor.cumsum(dim=-1).sum()
-        integrated.backward()
+        # Check that cummulative sum over a zero length dimension doesn't crash on backprop.
+        # Also check that cumsum over other dimensions in a tensor with a zero-length
+        # dimensiuon also works
+        # Also include a basic suite of similar tests for other bases cases.
+        shapes = [[2,0], [2,1,4], [0,2,3], [1], [5]]
+        for shape in shapes:
+            for dim in range(len(shape)):
+                raw_tensor = torch.zeros(*shape, requires_grad=True)
+                integrated = raw_tensor.cumsum(dim=dim)
+                # Check that backward does not crash
+                integrated.sum().backward()
+                # Check that output maintained correct shape
+                self.assertEqual(raw_tensor.shape, raw_tensor.grad.shape)
+
+        # Check a scalar example
+        raw_tensor = torch.tensor(3., requires_grad=True)
+        integrated = raw_tensor.cumsum(dim=-1)
+        # Check that backward does not crash
+        integrated.sum().backward()
+        # Check that output maintained correct shape
+        self.assertEqual(raw_tensor.shape, raw_tensor.grad.shape)
 
     def test_cumprod(self, device):
         x = torch.rand(100, 100, device=device)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -10416,6 +10416,11 @@ class TestTorchDeviceType(TestCase):
                                              [0, 0, 0],
                                              [1, 2, 3]]))
 
+        # Check that cummulative sum over a zero length dimension doesn't crash on backprop
+        zeroNumelTensor = torch.zeros(2, 0, requires_grad=True)
+        integrated = zeroNumelTensor.cumsum(dim=-1).sum()
+        integrated.backward()
+
     def test_cumprod(self, device):
         x = torch.rand(100, 100, device=device)
         res1 = torch.cumprod(x, 1)

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -415,7 +415,7 @@ Tensor solve_backward_A(const Tensor & grad, const Tensor & self, const Tensor &
 }
 
 Tensor cumsum_backward(const Tensor & x, int64_t dim) {
-  if (x.dim() == 0) {
+  if (x.dim() == 0 || x.numel() == 0) {
     return x;
   }
   auto ret = at::cumsum(-x, dim);

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -415,6 +415,7 @@ Tensor solve_backward_A(const Tensor & grad, const Tensor & self, const Tensor &
 }
 
 Tensor cumsum_backward(const Tensor & x, int64_t dim) {
+  // Need to check numel to see if there are no values (such as shape [0,2], and dim to see if x is a scalar.
   if (x.dim() == 0 || x.numel() == 0) {
     return x;
   }


### PR DESCRIPTION
Currently `cumsum` crashes for tensors with non-empty dimensions but with zero elements, which could happen when some dimension is zero. This commit fixes the error by checking both `dim()` and `numel()` in cumsum backward

Fixes #31515

