### PR TITLE
Enable personalized FC weight_init and sparse_emb weight_init

### DIFF
--- a/caffe2/python/layers/fc.py
+++ b/caffe2/python/layers/fc.py
@@ -27,6 +27,7 @@ class FC(SamplingTrainableMixin, ModelLayer):
                  bias_init=None, weight_optim=None, bias_optim=None, name='fc',
                  weight_reg=None, bias_reg=None, clip_param=None,
                  max_fc_size=None, axis=1, transposed=False,
+                 uniform_weight_init_scale_numerator=1.0,
                  **kwargs):
         super(FC, self).__init__(model, name, input_record, **kwargs)
         assert isinstance(input_record, schema.Scalar), (
@@ -61,7 +62,7 @@ class FC(SamplingTrainableMixin, ModelLayer):
             if clip_max is not None:
                 self.clip_args['max'] = clip_max
 
-        scale = math.sqrt(1.0 / input_dims)
+        scale = math.sqrt(uniform_weight_init_scale_numerator / input_dims)
         weight_init = weight_init if weight_init else (
             'UniformFill', {'min': -scale, 'max': scale})
         bias_init = bias_init if bias_init else (

--- a/caffe2/python/layers/fc_without_bias.py
+++ b/caffe2/python/layers/fc_without_bias.py
@@ -22,6 +22,7 @@ class FCWithoutBias(SamplingTrainableMixin, ModelLayer):
         weight_init=None,
         weight_optim=None,
         name='fc_without_bias',
+        uniform_weight_init_scale_numerator=1.0,
         **kwargs
     ):
         super(FCWithoutBias, self).__init__(model, name, input_record, **kwargs)
@@ -40,7 +41,7 @@ class FCWithoutBias(SamplingTrainableMixin, ModelLayer):
             self.get_next_blob_reference('output')
         )
 
-        scale = math.sqrt(1.0 / input_dims)
+        scale = math.sqrt(uniform_weight_init_scale_numerator / input_dims)
         weight_init = weight_init if weight_init else (
             'UniformFill', {'min': -scale,
                             'max': scale}

--- a/caffe2/python/layers/sparse_lookup.py
+++ b/caffe2/python/layers/sparse_lookup.py
@@ -130,7 +130,8 @@ class SparseLookup(ModelLayer):
 
     def __init__(self, model, input_record, inner_shape, reducer,
                  weight_init=None, weight_optim=None,
-                 name='sparse_lookup', regularizer=None, use_external_weights=False, **kwargs):
+                 name='sparse_lookup', regularizer=None, use_external_weights=False,
+                 uniform_weight_init_scale_numerator=1.0, **kwargs):
 
         super(SparseLookup, self).__init__(model, name, input_record, **kwargs)
 
@@ -186,6 +187,7 @@ class SparseLookup(ModelLayer):
             weight_optim
         )
 
+        self.uniform_weight_init_scale_numerator = uniform_weight_init_scale_numerator
         default_init_op = self._get_default_init_op()
 
         self.weight_init = weight_init or default_init_op
@@ -286,7 +288,7 @@ class SparseLookup(ModelLayer):
             return [RowwiseQuantized8BitsWeight(self.w, self.scale_bias)]
 
     def _get_default_init_op(self):
-        scale = math.sqrt(1.0 / self.input_dim)
+        scale = math.sqrt(self.uniform_weight_init_scale_numerator / self.input_dim)
 
         if self.trainer_version == 'fp32':
             default_weight_init = ('UniformFill', {'min': -scale, 'max': scale})


### PR DESCRIPTION
Summary:
Change the initialization value for FC weight init and sparse embedding lookup init.

Previous default initialization is uniform(-\sqrt(1/input_dim), \sqrt(1/input_dim)); Now pass into a flexible hyperparameter, say \alpha into it, to change into uniform(-\sqrt(\alpha/input_dim), \sqrt(\alpha/input_dim));

