### PR TITLE
try to find cudnn header in /usr/include/cuda

### DIFF
--- a/cmake/Modules_CUDA_fix/FindCUDNN.cmake
+++ b/cmake/Modules_CUDA_fix/FindCUDNN.cmake
@@ -27,7 +27,7 @@ set(CUDNN_INCLUDE_DIR $ENV{CUDNN_INCLUDE_DIR} CACHE PATH "Folder containing NVID
 
 find_path(CUDNN_INCLUDE_PATH cudnn.h
   HINTS ${CUDNN_INCLUDE_DIR}
-  PATH_SUFFIXES cuda/include include)
+  PATH_SUFFIXES cuda/include cuda include)
 
 option(CUDNN_STATIC "Look for static CUDNN" OFF)
 if (CUDNN_STATIC)


### PR DESCRIPTION
With fedora negativo17 repo, the cudnn headers are installed in /usr/include/cuda directory, along side with other cuda libraries.
