### PR TITLE
Wrap TypeErrors to NotImplemented Errors for Tensor Magic Methods

### DIFF
--- a/torch/tensor.py
+++ b/torch/tensor.py
@@ -404,7 +404,7 @@ class Tensor(torch._C._TensorBase):
         else:
             return (self.double().reciprocal() * other).type_as(self)
 
-    __rtruediv__ = _wrap_type_error_to_not_implemented(__rdiv__)
+    __rtruediv__ = __rdiv__
     __itruediv__ = _C._TensorBase.__idiv__
 
     __pow__ = _C._TensorBase.pow

--- a/torch/tensor.py
+++ b/torch/tensor.py
@@ -434,8 +434,8 @@ class Tensor(torch._C._TensorBase):
 
     __neg__ = _C._TensorBase.neg
     
-    __add__ = _wrap_type_error_to_not_implemented(_C.TensorBase.add)
-    __radd__ = _wrap_type_error_to_not_implemented(_C.TensorBase.radd)
+    __add__ = _wrap_type_error_to_not_implemented(_C._TensorBase.add)
+    __radd__ = _wrap_type_error_to_not_implemented(_C._TensorBase.radd)
 
     __eq__ = _wrap_type_error_to_not_implemented(_C._TensorBase.eq)
     __ne__ = _wrap_type_error_to_not_implemented(_C._TensorBase.ne)

--- a/torch/tensor.py
+++ b/torch/tensor.py
@@ -434,8 +434,8 @@ class Tensor(torch._C._TensorBase):
 
     __neg__ = _C._TensorBase.neg
 
-    __add__ = _wrap_type_error_to_not_implemented(_C._TensorBase.add)
-    __radd__ = _wrap_type_error_to_not_implemented(_C._TensorBase.radd)
+    __add__ = _wrap_type_error_to_not_implemented(_C._TensorBase.__add__)
+    __radd__ = _wrap_type_error_to_not_implemented(_C._TensorBase.__radd__)
 
     __eq__ = _wrap_type_error_to_not_implemented(_C._TensorBase.eq)
     __ne__ = _wrap_type_error_to_not_implemented(_C._TensorBase.ne)

--- a/torch/tensor.py
+++ b/torch/tensor.py
@@ -393,16 +393,18 @@ class Tensor(torch._C._TensorBase):
         """
         return torch.unique_consecutive(self, return_inverse=return_inverse, return_counts=return_counts, dim=dim)
 
+    @_wrap_type_error_to_not_implemented
     def __rsub__(self, other):
         return _C._VariableFunctions.rsub(self, other)
 
+    @_wrap_type_error_to_not_implemented
     def __rdiv__(self, other):
         if self.dtype.is_floating_point:
             return self.reciprocal() * other
         else:
             return (self.double().reciprocal() * other).type_as(self)
 
-    __rtruediv__ = __rdiv__
+    __rtruediv__ = _wrap_type_error_to_not_implemented(__rdiv__)
     __itruediv__ = _C._TensorBase.__idiv__
 
     __pow__ = _C._TensorBase.pow
@@ -431,6 +433,9 @@ class Tensor(torch._C._TensorBase):
         return result
 
     __neg__ = _C._TensorBase.neg
+    
+    __add__ = _wrap_type_error_to_not_implemented(_C.TensorBase.add)
+    __radd__ = _wrap_type_error_to_not_implemented(_C.TensorBase.radd)
 
     __eq__ = _wrap_type_error_to_not_implemented(_C._TensorBase.eq)
     __ne__ = _wrap_type_error_to_not_implemented(_C._TensorBase.ne)

--- a/torch/tensor.py
+++ b/torch/tensor.py
@@ -433,7 +433,7 @@ class Tensor(torch._C._TensorBase):
         return result
 
     __neg__ = _C._TensorBase.neg
-    
+
     __add__ = _wrap_type_error_to_not_implemented(_C._TensorBase.add)
     __radd__ = _wrap_type_error_to_not_implemented(_C._TensorBase.radd)
 


### PR DESCRIPTION
Wrapping the following magic methods to return/raise `NotImplementedError` instead of `TypeError` to allow things like `torch.tensor([1]) + my_fancy_class` if `my_fancy_class` implements `__radd__`:

* `__rsub__`
* `__rdiv__`
* `__add__`
* `__radd__`

I have not found any tests related to this return type, so I have not added tests for that. If I should add some, please let me know.

