### PR TITLE
Pin Pillow to v6 as PILLOW_VERSION is removed in v7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1495,6 +1495,7 @@ jobs:
             cd ${PROJ_ROOT}/ios/TestApp
             instruments -s -devices
             fastlane scan
+
   # update_s3_htmls job
   # These jobs create html files for every cpu/cu## folder in s3. The html
   # files just store the names of all the files in that folder (which are
@@ -3953,7 +3954,7 @@ workflows:
           context: org-member
           ios_platform: "SIMULATOR"
           ios_arch: "x86_64"
-          requires:
+          requires: 
             - setup
           filters:
             branches:
@@ -3964,7 +3965,7 @@ workflows:
           context: org-member
           ios_arch: "arm64"
           ios_platform: "OS"
-          requires:
+          requires: 
             - setup
           filters:
             branches:
@@ -5779,3 +5780,5 @@ workflows:
             name: ecr_gc_job_for_tensorcomp
             project: tensorcomp
             tags_to_keep: "34"
+
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1485,8 +1485,11 @@ jobs:
             WORKSPACE=/Users/distiller/workspace
             PROJ_ROOT=/Users/distiller/project
             source ~/anaconda/bin/activate
-            #install the latest version of PyTorch and TorchVision
+            # Temporarily pin pillow to 6.2.1 as PILLOW_VERSION is replaced by
+            # _version_ in 7.0.0. Long term fix should be making changes to
+            # torchvision to be compatible with both < and >= v7.0.0.
             pip install pillow==6.2.1
+            #install the latest version of PyTorch and TorchVision
             pip install torch torchvision
             #run unit test
             cd ${PROJ_ROOT}/ios/TestApp/benchmark

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1478,7 +1478,7 @@ jobs:
           no_output_timeout: "2h"
           command: |
             set -e
-            if [ ${IOS_PLATFORM} != "SIMULATOR" ]; then 
+            if [ ${IOS_PLATFORM} != "SIMULATOR" ]; then
               echo "not SIMULATOR build, skip it."
               exit 0
             fi
@@ -1486,6 +1486,7 @@ jobs:
             PROJ_ROOT=/Users/distiller/project
             source ~/anaconda/bin/activate
             #install the latest version of PyTorch and TorchVision
+            pip install pillow==6.2.1
             pip install torch torchvision
             #run unit test
             cd ${PROJ_ROOT}/ios/TestApp/benchmark
@@ -3952,7 +3953,7 @@ workflows:
           context: org-member
           ios_platform: "SIMULATOR"
           ios_arch: "x86_64"
-          requires: 
+          requires:
             - setup
           filters:
             branches:
@@ -3963,7 +3964,7 @@ workflows:
           context: org-member
           ios_arch: "arm64"
           ios_platform: "OS"
-          requires: 
+          requires:
             - setup
           filters:
             branches:
@@ -5778,5 +5779,3 @@ workflows:
             name: ecr_gc_job_for_tensorcomp
             project: tensorcomp
             tags_to_keep: "34"
-
-

--- a/.circleci/docker/common/install_travis_python.sh
+++ b/.circleci/docker/common/install_travis_python.sh
@@ -75,7 +75,7 @@ if [ -n "$TRAVIS_PYTHON_VERSION" ]; then
       hypothesis \
       protobuf \
       pytest \
-      pillow==6.2.1 \
+      pillow \
       typing
 
   as_jenkins pip install mkl mkl-devel

--- a/.circleci/docker/common/install_travis_python.sh
+++ b/.circleci/docker/common/install_travis_python.sh
@@ -75,7 +75,7 @@ if [ -n "$TRAVIS_PYTHON_VERSION" ]; then
       hypothesis \
       protobuf \
       pytest \
-      pillow \
+      pillow==6.2.1 \
       typing
 
   as_jenkins pip install mkl mkl-devel

--- a/.circleci/verbatim-sources/job-specs-custom.yml
+++ b/.circleci/verbatim-sources/job-specs-custom.yml
@@ -464,7 +464,7 @@
           no_output_timeout: "2h"
           command: |
             set -e
-            if [ ${IOS_PLATFORM} != "SIMULATOR" ]; then 
+            if [ ${IOS_PLATFORM} != "SIMULATOR" ]; then
               echo "not SIMULATOR build, skip it."
               exit 0
             fi
@@ -472,7 +472,7 @@
             PROJ_ROOT=/Users/distiller/project
             source ~/anaconda/bin/activate
             #install the latest version of PyTorch and TorchVision
-            pip install pillow=6.2.1
+            pip install pillow==6.2.1
             pip install torch torchvision
             #run unit test
             cd ${PROJ_ROOT}/ios/TestApp/benchmark

--- a/.circleci/verbatim-sources/job-specs-custom.yml
+++ b/.circleci/verbatim-sources/job-specs-custom.yml
@@ -471,8 +471,11 @@
             WORKSPACE=/Users/distiller/workspace
             PROJ_ROOT=/Users/distiller/project
             source ~/anaconda/bin/activate
-            #install the latest version of PyTorch and TorchVision
+            # Temporarily pin pillow to 6.2.1 as PILLOW_VERSION is replaced by
+            # _version_ in 7.0.0. Long term fix should be making changes to
+            # torchvision to be compatible with both < and >= v7.0.0.
             pip install pillow==6.2.1
+            #install the latest version of PyTorch and TorchVision
             pip install torch torchvision
             #run unit test
             cd ${PROJ_ROOT}/ios/TestApp/benchmark

--- a/.circleci/verbatim-sources/job-specs-custom.yml
+++ b/.circleci/verbatim-sources/job-specs-custom.yml
@@ -472,6 +472,7 @@
             PROJ_ROOT=/Users/distiller/project
             source ~/anaconda/bin/activate
             #install the latest version of PyTorch and TorchVision
+            pip install pillow=6.2.1
             pip install torch torchvision
             #run unit test
             cd ${PROJ_ROOT}/ios/TestApp/benchmark


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #31794 Pin hypothesis package to 4.57.1 to avoid test failures
* **#31777 Pin Pillow to v6 as PILLOW_VERSION is removed in v7**

Differential Revision: [D19264247](https://our.internmc.facebook.com/intern/diff/D19264247)