### PR TITLE
[SummaryWriter] [Bug fix] fixed scale_factor calculation for uint8 tensor

### DIFF
--- a/test/test_tensorboard.py
+++ b/test/test_tensorboard.py
@@ -171,6 +171,16 @@ class TestTensorBoardUtils(BaseTestCase):
         converted = convert_to_HWC(test_image, 'hw')
         self.assertEqual(converted.shape, (32, 32, 3))
 
+    def test_convert_to_HWC_dtype_remains_same(self):
+        # test to ensure convert_to_HWC restores the dtype of input np array and
+        # thus the scale_factor calculated for the image is 1
+        test_image=torch.tensor([[[[1, 2, 3], [4, 5, 6]]]], dtype=torch.uint8)
+        tensor = make_np(test_image)
+        tensor = convert_to_HWC(tensor, 'NCHW')
+        scale_factor = summary._calc_scale_factor(tensor)
+        self.assertEqual(scale_factor, 1, 'Values are already in [0, 255], scale factor should be 1')
+
+
     def test_prepare_video(self):
         # At each timeframe, the sum over all other
         # dimensions of the video should be the same.

--- a/test/test_tensorboard.py
+++ b/test/test_tensorboard.py
@@ -174,7 +174,7 @@ class TestTensorBoardUtils(BaseTestCase):
     def test_convert_to_HWC_dtype_remains_same(self):
         # test to ensure convert_to_HWC restores the dtype of input np array and
         # thus the scale_factor calculated for the image is 1
-        test_image=torch.tensor([[[[1, 2, 3], [4, 5, 6]]]], dtype=torch.uint8)
+        test_image = torch.tensor([[[[1, 2, 3], [4, 5, 6]]]], dtype=torch.uint8)
         tensor = make_np(test_image)
         tensor = convert_to_HWC(tensor, 'NCHW')
         scale_factor = summary._calc_scale_factor(tensor)

--- a/torch/utils/tensorboard/_utils.py
+++ b/torch/utils/tensorboard/_utils.py
@@ -79,7 +79,7 @@ def make_grid(I, ncols=8):
     W = I.shape[3]
     ncols = min(nimg, ncols)
     nrows = int(np.ceil(float(nimg) / ncols))
-    canvas = np.zeros((3, H * nrows, W * ncols))
+    canvas = np.zeros((3, H * nrows, W * ncols), dtype=I.dtype)
     i = 0
     for y in range(nrows):
         for x in range(ncols):


### PR DESCRIPTION
When calling the add_images() method on the tensorboard SummaryWriter with a uint8 NCHW tensor, the tensor is incorrectly scaled, resulting in overflow behavior. This leads to incorrect images being displayed in tensorboard.

Issue: https://github.com/pytorch/pytorch/issues/31459

Local Testing (ran this code with and without the PR changes and printed scale_factor):

import torch
import torchvision
from torch.utils.tensorboard import SummaryWriter

writer = SummaryWriter()
x=torch.tensor([[[[1, 2, 3], [4, 5, 6]]]], dtype=torch.uint8)
writer.add_images("images", x)

Before- scale_factor: 255, After- scale_factor: 1
