### PR TITLE
[fix] Using _floats_wrapper in per_channel_tensor generation

### DIFF
--- a/test/hypothesis_utils.py
+++ b/test/hypothesis_utils.py
@@ -40,12 +40,17 @@ def _get_valid_min_max(qparams):
     max_value = min((long_max - zero_point) * scale, (long_max / scale + zero_point))
     return np.float32(min_value), np.float32(max_value)
 
-# This wrapper around `st.floats` checks the version of `hypothesis`, and if
+# This wrapper wraps around `st.floats` and checks the version of `hypothesis`, if
 # it is too old, removes the `width` parameter (which was introduced)
 # in 3.67.0
 def _floats_wrapper(*args, **kwargs):
     if 'width' in kwargs and hypothesis.version.__version_info__ < (3, 67, 0):
         kwargs.pop('width')
+    return st.floats(*args, **kwargs)
+
+def floats(*args, **kwargs):
+    if 'width' not in kwargs:
+        kwargs['width'] = 32
     return st.floats(*args, **kwargs)
 
 """Hypothesis filter to avoid overflows with quantized tensors.
@@ -109,7 +114,7 @@ def qparams(draw, dtypes=None, scale_min=None, scale_max=None,
         scale_min = torch.finfo(torch.float).eps
     if scale_max is None:
         scale_max = torch.finfo(torch.float).max
-    scale = draw(_floats_wrapper(min_value=scale_min, max_value=scale_max, width=32))
+    scale = draw(floats(min_value=scale_min, max_value=scale_max, width=32))
 
     return scale, zero_point, quantized_type
 
@@ -165,14 +170,14 @@ def tensor(draw, shapes=None, elements=None, qparams=None):
         _shape = draw(st.sampled_from(shapes))
     if qparams is None:
         if elements is None:
-            elements = _floats_wrapper(-1e6, 1e6, allow_nan=False, width=32)
+            elements = floats(-1e6, 1e6, allow_nan=False, width=32)
         X = draw(stnp.arrays(dtype=np.float32, elements=elements, shape=_shape))
         assume(not (np.isnan(X).any() or np.isinf(X).any()))
         return X, None
     qparams = draw(qparams)
     if elements is None:
         min_value, max_value = _get_valid_min_max(qparams)
-        elements = _floats_wrapper(min_value, max_value, allow_infinity=False,
+        elements = floats(min_value, max_value, allow_infinity=False,
                                    allow_nan=False, width=32)
     X = draw(stnp.arrays(dtype=np.float32, elements=elements, shape=_shape))
     # Recompute the scale and zero_points according to the X statistics.
@@ -190,14 +195,14 @@ def per_channel_tensor(draw, shapes=None, elements=None, qparams=None):
         _shape = draw(st.sampled_from(shapes))
     if qparams is None:
         if elements is None:
-            elements = _floats_wrapper(-1e6, 1e6, allow_nan=False, width=32)
+            elements = floats(-1e6, 1e6, allow_nan=False, width=32)
         X = draw(stnp.arrays(dtype=np.float32, elements=elements, shape=_shape))
         assume(not (np.isnan(X).any() or np.isinf(X).any()))
         return X, None
     qparams = draw(qparams)
     if elements is None:
         min_value, max_value = _get_valid_min_max(qparams)
-        elements = _floats_wrapper(min_value, max_value, allow_infinity=False,
+        elements = floats(min_value, max_value, allow_infinity=False,
                                    allow_nan=False, width=32)
     X = draw(stnp.arrays(dtype=np.float32, elements=elements, shape=_shape))
     # Recompute the scale and zero_points according to the X statistics.

--- a/test/hypothesis_utils.py
+++ b/test/hypothesis_utils.py
@@ -190,15 +190,15 @@ def per_channel_tensor(draw, shapes=None, elements=None, qparams=None):
         _shape = draw(st.sampled_from(shapes))
     if qparams is None:
         if elements is None:
-            elements = st.floats(-1e6, 1e6, allow_nan=False)
+            elements = _floats_wrapper(-1e6, 1e6, allow_nan=False, width=32)
         X = draw(stnp.arrays(dtype=np.float32, elements=elements, shape=_shape))
         assume(not (np.isnan(X).any() or np.isinf(X).any()))
         return X, None
     qparams = draw(qparams)
     if elements is None:
         min_value, max_value = _get_valid_min_max(qparams)
-        elements = st.floats(min_value, max_value, allow_infinity=False,
-                             allow_nan=False)
+        elements = _floats_wrapper(min_value, max_value, allow_infinity=False,
+                                   allow_nan=False, width=32)
     X = draw(stnp.arrays(dtype=np.float32, elements=elements, shape=_shape))
     # Recompute the scale and zero_points according to the X statistics.
     scale, zp = _calculate_dynamic_per_channel_qparams(X, qparams[2])

--- a/test/hypothesis_utils.py
+++ b/test/hypothesis_utils.py
@@ -178,7 +178,7 @@ def tensor(draw, shapes=None, elements=None, qparams=None):
     if elements is None:
         min_value, max_value = _get_valid_min_max(qparams)
         elements = floats(min_value, max_value, allow_infinity=False,
-                                   allow_nan=False, width=32)
+                          allow_nan=False, width=32)
     X = draw(stnp.arrays(dtype=np.float32, elements=elements, shape=_shape))
     # Recompute the scale and zero_points according to the X statistics.
     scale, zp = _calculate_dynamic_qparams(X, qparams[2])
@@ -203,7 +203,7 @@ def per_channel_tensor(draw, shapes=None, elements=None, qparams=None):
     if elements is None:
         min_value, max_value = _get_valid_min_max(qparams)
         elements = floats(min_value, max_value, allow_infinity=False,
-                                   allow_nan=False, width=32)
+                          allow_nan=False, width=32)
     X = draw(stnp.arrays(dtype=np.float32, elements=elements, shape=_shape))
     # Recompute the scale and zero_points according to the X statistics.
     scale, zp = _calculate_dynamic_per_channel_qparams(X, qparams[2])

--- a/test/test_quantized.py
+++ b/test/test_quantized.py
@@ -1548,11 +1548,11 @@ class TestQuantizedConv(unittest.TestCase):
            pad_h=st.integers(0, 2),
            pad_w=st.integers(0, 2),
            dilation=st.integers(1, 2),
-           X_scale=hu.floats(1.2, 1.6),
+           X_scale=st.floats(1.2, 1.6),
            X_zero_point=st.integers(0, 4),
-           W_scale=st.lists(hu.floats(0.2, 1.6), min_size=1, max_size=2),
+           W_scale=st.lists(st.floats(0.2, 1.6), min_size=1, max_size=2),
            W_zero_point=st.lists(st.integers(-5, 5), min_size=1, max_size=2),
-           Y_scale=hu.floats(4.2, 5.6),
+           Y_scale=st.floats(4.2, 5.6),
            Y_zero_point=st.integers(0, 4),
            use_bias=st.booleans(),
            use_relu=st.booleans(),
@@ -1674,11 +1674,11 @@ class TestQuantizedConv(unittest.TestCase):
            pad_h=st.integers(0, 2),
            pad_w=st.integers(0, 2),
            dilation=st.integers(1, 2),
-           X_scale=hu.floats(1.2, 1.6),
+           X_scale=st.floats(1.2, 1.6),
            X_zero_point=st.integers(0, 4),
-           W_scale=st.lists(hu.floats(0.2, 1.6), min_size=1, max_size=2),
+           W_scale=st.lists(st.floats(0.2, 1.6), min_size=1, max_size=2),
            W_zero_point=st.lists(st.integers(-5, 5), min_size=1, max_size=2),
-           Y_scale=hu.floats(4.2, 5.6),
+           Y_scale=st.floats(4.2, 5.6),
            Y_zero_point=st.integers(0, 4),
            use_bias=st.booleans(),
            use_relu=st.booleans(),
@@ -1925,7 +1925,7 @@ class TestQNNPackOps(TestCase):
            kernel=st.integers(2, 5),
            stride=st.integers(1, 2),
            padding=st.integers(1, 2),
-           scale=hu.floats(0.2, 1.6),
+           scale=st.floats(0.2, 1.6),
            zero_point=st.integers(0, 25)
            )
     def test_avg_pool2d(
@@ -1979,7 +1979,7 @@ class TestQNNPackOps(TestCase):
            channels=st.sampled_from([2, 4, 5, 8, 16, 32]),
            height=st.integers(4, 10),
            width=st.integers(4, 10),
-           scale=hu.floats(0.02, 2.6),
+           scale=st.floats(0.02, 2.6),
            zero_point=st.integers(0, 25))
     def test_mean(self, batch_size, channels, height, width, scale, zero_point):
         with override_quantized_engine('qnnpack'):

--- a/test/test_quantized.py
+++ b/test/test_quantized.py
@@ -146,10 +146,10 @@ class TestQuantizedOps(TestCase):
 
     """Tests the correctness of the quantized::clamp op."""
     @given(X=hu.tensor(shapes=hu.array_shapes(1, 8, 1, 8),
-                       elements=st.floats(-1e6, 1e6, allow_nan=False),
+                       elements=hu.floats(-1e6, 1e6, allow_nan=False),
                        qparams=hu.qparams()),
-           min_val=st.floats(-1e6, 1e6, allow_nan=False),
-           max_val=st.floats(-1e6, 1e6, allow_nan=False))
+           min_val=hu.floats(-1e6, 1e6, allow_nan=False),
+           max_val=hu.floats(-1e6, 1e6, allow_nan=False))
     def test_qclamp(self, X, min_val, max_val):
         X, (scale, zero_point, torch_type) = X
 
@@ -173,7 +173,7 @@ class TestQuantizedOps(TestCase):
 
     """Tests the correctness of the scalar addition."""
     @given(A=hu.tensor(shapes=hu.array_shapes(1, 4, 1, 5),
-                       elements=st.floats(-1e6, 1e6, allow_nan=False),
+                       elements=hu.floats(-1e6, 1e6, allow_nan=False),
                        qparams=hu.qparams()),
            b=hu.floats(-1e6, 1e6, allow_nan=False, allow_infinity=False))
     def test_qadd_scalar_relu(self, A, b):
@@ -1548,11 +1548,11 @@ class TestQuantizedConv(unittest.TestCase):
            pad_h=st.integers(0, 2),
            pad_w=st.integers(0, 2),
            dilation=st.integers(1, 2),
-           X_scale=st.floats(1.2, 1.6),
+           X_scale=hu.floats(1.2, 1.6),
            X_zero_point=st.integers(0, 4),
-           W_scale=st.lists(st.floats(0.2, 1.6), min_size=1, max_size=2),
+           W_scale=st.lists(hu.floats(0.2, 1.6), min_size=1, max_size=2),
            W_zero_point=st.lists(st.integers(-5, 5), min_size=1, max_size=2),
-           Y_scale=st.floats(4.2, 5.6),
+           Y_scale=hu.floats(4.2, 5.6),
            Y_zero_point=st.integers(0, 4),
            use_bias=st.booleans(),
            use_relu=st.booleans(),
@@ -1674,11 +1674,11 @@ class TestQuantizedConv(unittest.TestCase):
            pad_h=st.integers(0, 2),
            pad_w=st.integers(0, 2),
            dilation=st.integers(1, 2),
-           X_scale=st.floats(1.2, 1.6),
+           X_scale=hu.floats(1.2, 1.6),
            X_zero_point=st.integers(0, 4),
-           W_scale=st.lists(st.floats(0.2, 1.6), min_size=1, max_size=2),
+           W_scale=st.lists(hu.floats(0.2, 1.6), min_size=1, max_size=2),
            W_zero_point=st.lists(st.integers(-5, 5), min_size=1, max_size=2),
-           Y_scale=st.floats(4.2, 5.6),
+           Y_scale=hu.floats(4.2, 5.6),
            Y_zero_point=st.integers(0, 4),
            use_bias=st.booleans(),
            use_relu=st.booleans(),
@@ -1925,7 +1925,7 @@ class TestQNNPackOps(TestCase):
            kernel=st.integers(2, 5),
            stride=st.integers(1, 2),
            padding=st.integers(1, 2),
-           scale=st.floats(0.2, 1.6),
+           scale=hu.floats(0.2, 1.6),
            zero_point=st.integers(0, 25)
            )
     def test_avg_pool2d(
@@ -1979,7 +1979,7 @@ class TestQNNPackOps(TestCase):
            channels=st.sampled_from([2, 4, 5, 8, 16, 32]),
            height=st.integers(4, 10),
            width=st.integers(4, 10),
-           scale=st.floats(0.02, 2.6),
+           scale=hu.floats(0.02, 2.6),
            zero_point=st.integers(0, 25))
     def test_mean(self, batch_size, channels, height, width, scale, zero_point):
         with override_quantized_engine('qnnpack'):
@@ -2031,7 +2031,7 @@ class TestComparatorOps(TestCase):
     @unittest.skip("FIXME: Failing due to overflow error without width option")
     @given(A=hu.tensor(shapes=((3, 4, 5),),
                        qparams=hu.qparams()),
-           b=st.floats(allow_infinity=False, allow_nan=False))
+           b=hu.floats(allow_infinity=False, allow_nan=False))
     def test_compare_tensor_scalar(self, A, b):
         A, (scale_a, zero_point_a, dtype_a) = A
         tA = torch.from_numpy(A)

--- a/test/test_quantized.py
+++ b/test/test_quantized.py
@@ -175,7 +175,7 @@ class TestQuantizedOps(TestCase):
     @given(A=hu.tensor(shapes=hu.array_shapes(1, 4, 1, 5),
                        elements=st.floats(-1e6, 1e6, allow_nan=False),
                        qparams=hu.qparams()),
-           b=st.floats(-1e6, 1e6, allow_nan=False, allow_infinity=False))
+           b=hu.floats(-1e6, 1e6, allow_nan=False, allow_infinity=False))
     def test_qadd_scalar_relu(self, A, b):
         import copy
         add_scalar = torch.ops.quantized.add_scalar


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#31780 [fix] Using _floats_wrapper in per_channel_tensor generation**

Summary:
We need to specify width to ensure the generated float is representable by `float32`
fixes: https://github.com/pytorch/pytorch/issues/31774

Test Plan:
ci

Reviewers:
pt1quant

Subscribers:

Tasks:

Tags:

Differential Revision: [D19275165](https://our.internmc.facebook.com/intern/diff/D19275165)