### PR TITLE
add note that we dont support nn.Module apis

### DIFF
--- a/docs/source/jit_unsupported.rst
+++ b/docs/source/jit_unsupported.rst
@@ -101,3 +101,7 @@ we suggest using :meth:`torch.jit.trace`.
   * :class:`torch.autograd.no_grad`
   * :class:`torch.autograd.enable_grad`
   * :class:`torch._C.Generator`
+
+Additionally, TorchScript is unable to compile almost all `nn.Module` APIs. The only
+supported methods are ``forward``, and ``__iter__`` of classes inheriting from ``nn.ModuleList``,
+``nn.Sequential``, and ``nn.ModuleDict``.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#31790 add note that we dont support nn.Module apis**
* #31789 move unsupported_ops -> test_unsupported_ops

