### PR TITLE
Pin hypothesis package to 4.57.1 to avoid test failures

### DIFF
--- a/.jenkins/pytorch/macos-test.sh
+++ b/.jenkins/pytorch/macos-test.sh
@@ -4,7 +4,7 @@
 source "$(dirname "${BASH_SOURCE[0]}")/macos-common.sh"
 
 conda install -y six
-pip install -q hypothesis "librosa>=0.6.2" psutil
+pip install -q hypothesis==4.57.1 "librosa>=0.6.2" psutil
 
 # TODO move this to docker
 pip install unittest-xml-reporting


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#31794 Pin hypothesis package to 4.57.1 to avoid test failures**
* #31777 Pin Pillow to v6 as PILLOW_VERSION is removed in v7

Differential Revision: [D19266039](https://our.internmc.facebook.com/intern/diff/D19266039)