### PR TITLE
[rpc] use unordered_set instead of vector for futureTimeouts key in
process_group_agent

### DIFF
--- a/torch/csrc/distributed/rpc/process_group_agent.h
+++ b/torch/csrc/distributed/rpc/process_group_agent.h
@@ -198,10 +198,11 @@ class ProcessGroupAgent : public RpcAgent {
   // A map to keep track of when futures time out. The map is keyed by the time
   // (millisecond level precision) the future will expire. This is so that timed
   // out futures can be efficiently cleaned up, and we can quickly exit if we
-  // find a future that has not timed out. The values correspond to a vector of
-  // future ids that started at that time. This map must be kept in sync with
-  // the above futures_ map.
-  std::map<steady_clock_time_point, std::vector<int64_t>> futureTimeouts_;
+  // find a future that has not timed out. The values correspond to an
+  // unordered_set of future ids that started at that time. This map must be
+  // kept in sync with the above futures_ map.
+  std::map<steady_clock_time_point, std::unordered_set<int64_t>>
+      futureTimeouts_;
   mutable std::mutex futureMutex_;
   mutable std::condition_variable futureCV_;
   // CV to wake up watchdog thread that watches for timed out futures.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#31813 [rpc] use unordered_set instead of vector for futureTimeouts key in
process_group_agent**

Closes https://github.com/pytorch/pytorch/issues/31804. We were using
an `std::vector` for the key for a map that keeps track of futures to mark them
if they timeout, but we can instead use an `unordered_set`. This results in a
faster lookup in the code block where we remove futureIDs from this set when
they complete successfully. Previously we were finding them via a linear
`std::find`. Switching it to a constant time find will help performance in the
case where a large number of futures are scheduled to time out at the same
time, or if there is no timeout enforced.

To benchmark a rough perf improvement, I created 50k futures with the same
timeout. Before this PR, the lookup `std::find(futuresAtTime.begin(),
futuresAtTime.end(), id)` took ~200us, now with a `unordered_set` lookup, it takes 1us.

Differential Revision: [D19269798](https://our.internmc.facebook.com/intern/diff/D19269798/)