### PR TITLE
Move cauchy to Aten(CPU)

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -1424,21 +1424,6 @@
     - THGenerator* generator
 ]]
 [[
-  name: _th_cauchy_
-  types:
-    - floating_point
-  backends:
-    - CPU
-  cname: cauchy
-  variants: function
-  return: self
-  arguments:
-    - THTensor* self
-    - double median
-    - double sigma
-    - THGenerator* generator
-]]
-[[
   name: _th_log_normal_
   cname: logNormal
   variants: function

--- a/aten/src/ATen/native/Distributions.cpp
+++ b/aten/src/ATen/native/Distributions.cpp
@@ -14,6 +14,7 @@
 #include <ATen/native/DispatchStub.h>
 #include <ATen/native/UnaryOps.h>
 #include <ATen/NamedTensorUtils.h>
+#include <ATen/native/TensorIterator.h>
 
 #include <type_traits>
 #include <functional>
@@ -111,6 +112,10 @@ int64_t sample_poisson(double lambda, at::CPUGenerator* generator) {
 namespace at {
 namespace native {
 
+DEFINE_DISPATCH(bernoulli_mkl_stub);
+DEFINE_DISPATCH(cauchy_stub);
+DEFINE_DISPATCH(multinomial_stub);
+
 Tensor bernoulli(const Tensor& self, Generator* gen) {
   return at::empty_like(self, LEGACY_CONTIGUOUS_MEMORY_FORMAT).bernoulli_(self, gen);
 }
@@ -157,8 +162,6 @@ Tensor& bernoulli_tensor_cpu_(Tensor& self, const Tensor& p_, Generator* gen) {
   return self;
 }
 
-DEFINE_DISPATCH(bernoulli_mkl_stub);
-
 Tensor& bernoulli_scalar_cpu_(Tensor& self, double p, Generator* gen) {
   TORCH_CHECK(0 <= p && p <= 1, "bernoulli_ expects p to be in [0, 1], but got p=", p);
 #if AT_MKL_ENABLED()
@@ -180,6 +183,11 @@ Tensor& bernoulli_scalar_cpu_(Tensor& self, double p, Generator* gen) {
   return self;
 }
 
+Tensor& cauchy_(Tensor& self, double median, double sigma, Generator* gen) {
+  auto iter = TensorIterator::nullary_op(self);
+  cauchy_stub(iter.device_type(), iter, median, sigma, gen);
+  return self;
+}
 
 Tensor _standard_gamma_grad_cpu(const Tensor& self, const Tensor& output) {
   Tensor ret = at::empty(self.sizes(), self.options());
@@ -326,7 +334,5 @@ Tensor multinomial(const Tensor& self, int64_t n_sample, bool with_replacement, 
   native::multinomial_out(result, self, n_sample, with_replacement, gen);
   return result;
 }
-
-DEFINE_DISPATCH(multinomial_stub);
 
 }} // namespace at::native

--- a/aten/src/ATen/native/UnaryOps.h
+++ b/aten/src/ATen/native/UnaryOps.h
@@ -55,6 +55,7 @@ DECLARE_DISPATCH(unary_fn, trunc_stub);
 DECLARE_DISPATCH(unary_fn, lgamma_stub);
 
 DECLARE_DISPATCH(void(*)(Tensor&, const double, Generator *), bernoulli_mkl_stub);
+DECLARE_DISPATCH(void(*)(TensorIterator&, const double, const double, Generator *), cauchy_stub);
 DECLARE_DISPATCH(void(*)(TensorIterator&, const int64_t), polygamma_stub);
 DECLARE_DISPATCH(void(*)(TensorIterator&, Scalar a, Scalar b), clamp_stub);
 DECLARE_DISPATCH(void(*)(Tensor&, const Tensor&, int64_t, bool, Generator *), multinomial_stub);

--- a/aten/src/ATen/native/cuda/Distributions.cu
+++ b/aten/src/ATen/native/cuda/Distributions.cu
@@ -4,6 +4,7 @@
 #include <ATen/cuda/CUDAApplyUtils.cuh>
 #include <ATen/AccumulateType.h>
 #include <ATen/CUDAGenerator.h>
+#include <ATen/native/UnaryOps.h>
 
 #include <curand.h>
 #include <curand_kernel.h>
@@ -508,7 +509,7 @@ void normal_kernel_cuda(TensorIterator& iter, double mean_, double std_, Generat
    });
 }
 
-void cauchy_kernel_cuda(TensorIterator& iter, double median_, double sigma_, Generator* gen_) {
+void cauchy_kernel(TensorIterator& iter, double median_, double sigma_, Generator* gen_) {
   auto gen = get_generator_or_default<CUDAGenerator>(gen_, cuda::detail::getDefaultCUDAGenerator());
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(iter.dtype(), "cauchy_cuda", [&] {
     using accscalar_t = at::acc_type<scalar_t, true>;
@@ -751,12 +752,6 @@ Tensor normal_cuda(const Tensor& mean, const Tensor& std, Generator* gen) {
   return ret;
 }
 
-Tensor& cauchy_cuda_(Tensor& self, double median, double sigma, Generator* gen) {
-  auto iter = TensorIterator::nullary_op(self);
-  cauchy_kernel_cuda(iter, median, sigma, gen);
-  return self;
-}
-
 Tensor& exponential_cuda_(Tensor& self, double lambda, Generator* gen) {
   auto iter = TensorIterator::nullary_op(self);
   exponential_kernel_cuda(iter, lambda, gen);
@@ -783,5 +778,7 @@ Tensor& bernoulli_scalar_cuda_(Tensor &self, double p, Generator* gen) {
   bernoulli_scalar_cuda_kernel(iter, p, gen);
   return self;
 }
+
+REGISTER_DISPATCH(cauchy_stub, &cauchy_kernel);
 
 }} // namespace at::native

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -4234,9 +4234,6 @@
 
 - func: cauchy_(Tensor(a!) self, float median=0, float sigma=1, *, Generator? generator=None) -> Tensor(a!)
   variants: method
-  dispatch:
-    CPU: legacy::cpu::_th_cauchy_
-    CUDA: cauchy_cuda_
   supports_named_tensor: True
 
 - func: log_normal_(Tensor(a!) self, float mean=1, float std=2, *, Generator? generator=None) -> Tensor(a!)

--- a/aten/src/TH/generic/THTensorRandom.cpp
+++ b/aten/src/TH/generic/THTensorRandom.cpp
@@ -142,16 +142,6 @@ void THTensor_(exponential)(THTensor *self, double lambda, at::Generator *_gener
 
 #undef TH_REAL_MIN
 
-void THTensor_(cauchy)(THTensor *self, double median, double sigma, at::Generator *_generator)
-{
-  auto gen = at::get_generator_or_default<at::CPUGenerator>(_generator, at::detail::getDefaultCPUGenerator());
-  // See Note [Acquire lock when using random generators]
-  std::lock_guard<std::mutex> lock(gen->mutex_);
-
-  at::cauchy_distribution<double> cauchy(median, sigma);
-  TH_TENSOR_APPLY(scalar_t, self, *self_data = (scalar_t)cauchy(gen););
-}
-
 void THTensor_(logNormal)(THTensor *self, double mean, double stdv, at::Generator *_generator)
 {
   auto gen = at::get_generator_or_default<at::CPUGenerator>(_generator, at::detail::getDefaultCPUGenerator());

--- a/aten/src/TH/generic/THTensorRandom.h
+++ b/aten/src/TH/generic/THTensorRandom.h
@@ -18,7 +18,6 @@ TH_API void THTensor_(normal_means)(THTensor *self, THTensor *means, double stdd
 TH_API void THTensor_(normal_stddevs)(THTensor *self, double mean, THTensor *stddevs, at::Generator *gen);
 TH_API void THTensor_(normal_means_stddevs)(THTensor *self, THTensor *means, THTensor *stddevs, at::Generator *gen);
 TH_API void THTensor_(exponential)(THTensor *self, double lambda, at::Generator *_generator);
-TH_API void THTensor_(cauchy)(THTensor *self, double median, double sigma, at::Generator *_generator);
 TH_API void THTensor_(logNormal)(THTensor *self, double mean, double stdv, at::Generator *_generator);
 TH_API void THTensor_(multinomialAliasSetup)(THTensor *prob_dist, THLongTensor *J, THTensor *q);
 TH_API void THTensor_(multinomialAliasDraw)(THLongTensor *self, THTensor *q, THLongTensor *J, int n_sample, at::Generator *_generator);


### PR DESCRIPTION
Fix #24684.
Benchmark script :
```
import torch
import torch.nn as nn
import time

torch.manual_seed(0)

def _time():
    return time.time()

device = "cpu"

#warm up
for n in [10, 100, 1000]:
    input = torch.randn(128, n, requires_grad=False, device=device)
    for i in range(1000):
        input.cauchy_()

for n in [1, 10, 100, 1000]:
    fwd_t = 0
    input = torch.randn(128, n, requires_grad=False, device=device)
    for i in range(10000):
        t1 = _time()
        input.cauchy_()
        t2 = _time()
        fwd_t = fwd_t + (t2 -t1)
    fwd_avg = fwd_t / 10000 * 1000
    print("input size(128, %d) forward time is %.4f (ms)." % (n, fwd_avg))
```
Test device: **skx-8180**.
Before:
```
input size(128, 1) forward time is 0.0071 (ms).
input size(128, 10) forward time is 0.0596 (ms).
input size(128, 100) forward time is 0.5798 (ms).
input size(128, 1000) forward time is 5.8395 (ms).
```
After:
```
input size(128, 1) forward time is 0.0070 (ms).
input size(128, 10) forward time is 0.0583 (ms).
input size(128, 100) forward time is 0.5714 (ms).
input size(128, 1000) forward time is 5.7674 (ms).
```