### PR TITLE
Skip same tests in ONNX Python3 CI as in Python2

### DIFF
--- a/scripts/onnx/test.sh
+++ b/scripts/onnx/test.sh
@@ -43,12 +43,14 @@ if [[ $PARALLEL == 1 ]]; then
   args+=("3")
 fi
 
+# Skipped tests
+args+=("-k")
+args+=('not (TestOperators and test_full_like) and not (TestOperators and test_zeros_like) and not (TestOperators and test_ones_like) and not (TestModels and test_vgg16) and not (TestModels and test_vgg16_bn) and not (TestModels and test_vgg19) and not (TestModels and test_vgg19_bn)')
+
 # These exclusions are for tests that take a long time / a lot of GPU
 # memory to run; they should be passing (and you will test them if you
 # run them locally
 pytest "${args[@]}" \
-  -k \
-  'not (TestOperators and test_full_like) and not (TestOperators and test_zeros_like) and not (TestOperators and test_ones_like) and not (TestModels and test_vgg16) and not (TestModels and test_vgg16_bn) and not (TestModels and test_vgg19) and not (TestModels and test_vgg19_bn)' \
   --ignore "$top_dir/test/onnx/test_pytorch_onnx_onnxruntime.py" \
   --ignore "$top_dir/test/onnx/test_custom_ops.py" \
   --ignore "$top_dir/test/onnx/test_models_onnxruntime.py" \
@@ -57,8 +59,8 @@ pytest "${args[@]}" \
 # onnxruntime only support py3
 # "Python.h" not found in py2, needed by TorchScript custom op compilation.
 if [[ "$BUILD_ENVIRONMENT" == *py3* ]]; then
-  pytest "${args[@]}" "$top_dir/test/onnx/test_pytorch_onnx_onnxruntime.py"
-  pytest "${args[@]}" "$top_dir/test/onnx/test_custom_ops.py"
-  pytest "${args[@]}" "$top_dir/test/onnx/test_models_onnxruntime.py"
+  pytest "${args[@]}" \
+    "$top_dir/test/onnx/test_pytorch_onnx_onnxruntime.py" \
+    "$top_dir/test/onnx/test_custom_ops.py" \
+    "$top_dir/test/onnx/test_models_onnxruntime.py"
 fi
-


### PR DESCRIPTION
resolve #31103

vgg models were not tested in Python2 but are turned on in Python3 