### PR TITLE
move docker image html to correct bucket

### DIFF
--- a/.circleci/ecr_gc_docker/gc.py
+++ b/.circleci/ecr_gc_docker/gc.py
@@ -57,7 +57,7 @@ def save_to_s3(project, data):
     # and later one we can config docker.pytorch.org to point to the location
 
     client.put_object(
-        Bucket="ossci-docker",
+        Bucket="docker.pytorch.org",
         ACL="public-read",
         Key="{project}.html".format(project=project),
         Body=html_body,


### PR DESCRIPTION
save docker image version to docker.pytorch.org bucket to be served with http://docker.pytorch.org

test result: https://s3.amazonaws.com/docker.pytorch.org/pytorch.html 