### PR TITLE
Remove refs from ArrayRef arguments

### DIFF
--- a/torch/csrc/jit/fuser/executor.cpp
+++ b/torch/csrc/jit/fuser/executor.cpp
@@ -138,7 +138,7 @@ static bool shouldExpandArgs(
 }
 
 // Note: assumes that inputs are 32-bit addressable
-static uint32_t computeNumel(const at::ArrayRef<int64_t>& sizes) {
+static uint32_t computeNumel(const at::ArrayRef<int64_t> sizes) {
   uint32_t result = 1;
 
   for (const auto& size : sizes)

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -48,7 +48,7 @@ std::ostream& operator<<(std::ostream& out, const std::vector<T>& nodes) {
 template <typename T>
 static std::ostream& printValueRefs(
     std::ostream& out,
-    const at::ArrayRef<T>& nodes) {
+    const at::ArrayRef<T> nodes) {
   size_t i = 0;
   for (auto n : nodes) {
     if (i++ > 0) {
@@ -64,11 +64,11 @@ static std::ostream& printValueRefs(
 
 std::ostream& operator<<(
     std::ostream& out,
-    const at::ArrayRef<const Value*>& nodes) {
+    const at::ArrayRef<const Value*> nodes) {
   return printValueRefs(out, nodes);
 }
 
-std::ostream& operator<<(std::ostream& out, const at::ArrayRef<Value*>& nodes) {
+std::ostream& operator<<(std::ostream& out, const at::ArrayRef<Value*> nodes) {
   return printValueRefs(out, nodes);
 }
 

--- a/torch/csrc/jit/passes/alias_analysis.cpp
+++ b/torch/csrc/jit/passes/alias_analysis.cpp
@@ -850,8 +850,8 @@ bool AliasDb::mayContainAlias(Value* a, Value* b) const {
 }
 
 bool AliasDb::mayContainAlias(
-    const at::ArrayRef<Value*>& a,
-    const at::ArrayRef<Value*>& b) const {
+    const at::ArrayRef<Value*> a,
+    const at::ArrayRef<Value*> b) const {
   std::vector<Element*> a_elements;
   for (const auto& val : a) {
     if (cannotCheckAliasContainment(val)) {

--- a/torch/csrc/jit/passes/alias_analysis.h
+++ b/torch/csrc/jit/passes/alias_analysis.h
@@ -52,8 +52,8 @@ class AliasDb {
   // Do any values in group `a` share a memory location or hold in memory
   // any element that exists in group `b`
   TORCH_API bool mayContainAlias(
-      const at::ArrayRef<Value*>& a,
-      const at::ArrayRef<Value*>& b) const;
+      const at::ArrayRef<Value*> a,
+      const at::ArrayRef<Value*> b) const;
 
   // Do `a` and `b` potentially share a memory location?
   TORCH_API bool mayAlias(const Value* a, const Value* b) const;

--- a/torch/csrc/jit/passes/bailout_graph.cpp
+++ b/torch/csrc/jit/passes/bailout_graph.cpp
@@ -105,8 +105,8 @@ struct BailOutGraphBuilderForNode {
   }
 
   void mapValues(
-      const at::ArrayRef<Value*>& block_outputs,
-      const at::ArrayRef<Value*>& carried_deps) {
+      const at::ArrayRef<Value*> block_outputs,
+      const at::ArrayRef<Value*> carried_deps) {
     TORCH_INTERNAL_ASSERT(block_outputs.size() == carried_deps.size());
     for (size_t i = 0; i < block_outputs.size(); i++) {
       auto nv = getOrAddInputForValue(block_outputs[i]);
@@ -185,7 +185,7 @@ struct BailOutGraphBuilderForNode {
   }
 
   void buildBailOutIf(
-      const at::ArrayRef<Value*>& block_outputs,
+      const at::ArrayRef<Value*> block_outputs,
       Node* outer_node) {
     auto if_outputs = outer_node->outputs();
     mapValues(block_outputs, if_outputs);

--- a/torch/csrc/jit/passes/utils/memory_dag.cpp
+++ b/torch/csrc/jit/passes/utils/memory_dag.cpp
@@ -74,8 +74,8 @@ bool MemoryDAG::mayContainAliasImpl(const Element* a, const Element* b) const {
 }
 
 bool MemoryDAG::mayContainAlias(
-    const at::ArrayRef<Element*>& a,
-    const at::ArrayRef<Element*>& b) const {
+    const at::ArrayRef<Element*> a,
+    const at::ArrayRef<Element*> b) const {
   if (a.size() == 0 || b.size() == 0) {
     return false;
   }

--- a/torch/csrc/jit/passes/utils/memory_dag.h
+++ b/torch/csrc/jit/passes/utils/memory_dag.h
@@ -59,8 +59,8 @@ class TORCH_API MemoryDAG {
   bool mayContainAlias(Element* a, Element* b) const;
 
   bool mayContainAlias(
-      const at::ArrayRef<Element*>& a,
-      const at::ArrayRef<Element*>& b) const;
+      const at::ArrayRef<Element*> a,
+      const at::ArrayRef<Element*> b) const;
 
   // Converts from the compressed index representation
   const Element* fromIndex(unsigned x) const;

--- a/torch/lib/c10d/Utils.hpp
+++ b/torch/lib/c10d/Utils.hpp
@@ -95,7 +95,7 @@ inline void assertSameSizeAndType(const std::vector<at::Tensor>& tensors) {
 inline void assertTypeMatch(
     std::function<void(const std::string&)> fn,
     const at::DeprecatedTypeProperties& type,
-    const at::ArrayRef<at::Tensor>& tensors,
+    const at::ArrayRef<at::Tensor> tensors,
     size_t index) {
   if (!tensors[index].options().type_equal(type.options())) {
     fn("invalid tensor type at index " + std::to_string(index) + " (expected " +
@@ -106,7 +106,7 @@ inline void assertTypeMatch(
 inline void assertTypeMatch(
     std::function<void(const std::string&)> fn,
     const at::TensorOptions& options,
-    const at::ArrayRef<at::Tensor>& tensors,
+    const at::ArrayRef<at::Tensor> tensors,
     size_t index) {
   if (!tensors[index].options().type_equal(options)) {
     fn("invalid tensor type at index " + std::to_string(index) + " (expected " +
@@ -118,7 +118,7 @@ inline void assertTypeMatch(
 inline void assertSizesMatch(
     std::function<void(const std::string&)> fn,
     const at::IntArrayRef& sizes,
-    const at::ArrayRef<at::Tensor>& tensors,
+    const at::ArrayRef<at::Tensor> tensors,
     size_t index) {
   if (tensors[index].sizes() != sizes) {
     fn("invalid tensor size at index " + std::to_string(index) + " (expected " +
@@ -129,7 +129,7 @@ inline void assertSizesMatch(
 inline void assertLayoutMatch(
     std::function<void(const std::string&)> fn,
     const c10::Layout& expected,
-    const at::ArrayRef<at::Tensor>& tensors,
+    const at::ArrayRef<at::Tensor> tensors,
     size_t index) {
   const auto& actual = tensors[index].layout();
   if (actual != expected) {
@@ -140,7 +140,7 @@ inline void assertLayoutMatch(
 
 inline void assertLayoutMatch(
     std::function<void(const std::string&)> fn,
-    const at::ArrayRef<at::Tensor>& tensors) {
+    const at::ArrayRef<at::Tensor> tensors) {
   const auto& layout = tensors[0].layout();
   for (size_t i = 1; i < tensors.size(); i++) {
     assertLayoutMatch(fn, layout, tensors, i);
@@ -149,7 +149,7 @@ inline void assertLayoutMatch(
 
 inline void assertNonEmpty(
     std::function<void(const std::string&)> fn,
-    const at::ArrayRef<at::Tensor>& tensors) {
+    const at::ArrayRef<at::Tensor> tensors) {
   if (tensors.size() == 0) {
     fn("requires non-empty tensor list");
   }
@@ -157,7 +157,7 @@ inline void assertNonEmpty(
 
 inline void assertSingleElement(
     std::function<void(const std::string&)> fn,
-    const at::ArrayRef<at::Tensor>& tensors) {
+    const at::ArrayRef<at::Tensor> tensors) {
   if (tensors.size() != 1) {
     fn("requires a single-element tensor list");
   }
@@ -165,7 +165,7 @@ inline void assertSingleElement(
 
 inline void assertSingleElementInput(
     std::function<void(const std::string&)> fn,
-    const at::ArrayRef<at::Tensor>& tensors) {
+    const at::ArrayRef<at::Tensor> tensors) {
   if (tensors.size() != 1) {
     fn("requires a single-element input tensor list");
   }
@@ -173,7 +173,7 @@ inline void assertSingleElementInput(
 
 inline void assertSingleElementOutput(
     std::function<void(const std::string&)> fn,
-    const at::ArrayRef<at::Tensor>& tensors) {
+    const at::ArrayRef<at::Tensor> tensors) {
   if (tensors.size() != 1) {
     fn("requires a single-element output tensor list");
   }
@@ -199,7 +199,7 @@ inline void assertRootTensor(
 
 inline void assertDense(
     std::function<void(const std::string&)> fn,
-    const at::ArrayRef<at::Tensor>& tensors) {
+    const at::ArrayRef<at::Tensor> tensors) {
   const auto& layout = tensors[0].layout();
   if (layout != at::kStrided) {
     fn("only supports dense tensors");
@@ -208,7 +208,7 @@ inline void assertDense(
 
 inline void assertCPU(
     std::function<void(const std::string&)> fn,
-    const at::ArrayRef<at::Tensor>& tensors) {
+    const at::ArrayRef<at::Tensor> tensors) {
   const auto& device = tensors[0].device();
   if (device.type() != at::kCPU) {
     fn("only supports CPU tensors");
@@ -217,7 +217,7 @@ inline void assertCPU(
 
 inline void assertSameDevice(
     std::function<void(const std::string&)> fn,
-    const at::ArrayRef<at::Tensor>& tensors) {
+    const at::ArrayRef<at::Tensor> tensors) {
   if (tensors.size() < 2) {
     return;
   }
@@ -231,7 +231,7 @@ inline void assertSameDevice(
 
 inline void assertTypeAndSizesMatch(
     std::function<void(const std::string&)> fn,
-    const at::ArrayRef<at::Tensor>& tensors,
+    const at::ArrayRef<at::Tensor> tensors,
     const at::DeprecatedTypeProperties& type,
     const at::IntArrayRef& sizes) {
   for (size_t i = 0; i < tensors.size(); i++) {
@@ -242,7 +242,7 @@ inline void assertTypeAndSizesMatch(
 
 inline void assertTypeAndSizesMatch(
     std::function<void(const std::string&)> fn,
-    const at::ArrayRef<at::Tensor>& tensors,
+    const at::ArrayRef<at::Tensor> tensors,
     const at::TensorOptions& options,
     const at::IntArrayRef& sizes) {
   for (size_t i = 0; i < tensors.size(); i++) {
@@ -253,7 +253,7 @@ inline void assertTypeAndSizesMatch(
 
 inline void assertTypeAndSizesMatch(
     std::function<void(const std::string&)> fn,
-    const at::ArrayRef<at::Tensor>& tensors) {
+    const at::ArrayRef<at::Tensor> tensors) {
   const auto& options = tensors[0].options();
   const auto sizes = tensors[0].sizes();
   assertTypeAndSizesMatch(fn, tensors.slice(1), options, sizes);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#31845 Remove refs from ArrayRef arguments**

ArrayRef is trivially copyable and should be passed by value. Removing
unnecessary `&`s.

Differential Revision: [D19278523](https://our.internmc.facebook.com/intern/diff/D19278523)