### PR TITLE
Restructure docs organization and naming

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -17,13 +17,13 @@ PyTorch is an optimized tensor library for deep learning using GPUs and CPUs.
 
    notes/*
    PyTorch on XLA Devices <http://pytorch.org/xla/>
-
+   
 .. toctree::
-  :glob:
-  :maxdepth: 1
-  :caption: Community
+   :maxdepth: 1
+   :caption: Language Bindings
 
-  community/*
+   C++ API <https://pytorch.org/cppdocs/>
+   packages
 
 .. toctree::
    :maxdepth: 1
@@ -80,11 +80,11 @@ PyTorch is an optimized tensor library for deep learning using GPUs and CPUs.
    torchtext <https://pytorch.org/text>
 
 .. toctree::
+   :glob:
    :maxdepth: 1
-   :caption: Other Languages
+   :caption: Community
 
-   C++ API <https://pytorch.org/cppdocs/>
-   packages
+   community/*
 
 Indices and tables
 ==================


### PR DESCRIPTION
* Rename “Other Languages” → “Language Bindings”
* Move the Community section to the bottom
* Move "Language Bindings" above "Python API"

