### PR TITLE
Adding elementwise kernel also operating on index (#28175)

### DIFF
--- a/aten/src/ATen/native/cuda/RangeFactories.cu
+++ b/aten/src/ATen/native/cuda/RangeFactories.cu
@@ -6,38 +6,10 @@
 #include <cmath>
 #include <limits>
 
-#include <thrust/device_ptr.h>
-#include <thrust/sequence.h>
-#include <thrust/execution_policy.h>
+#include <ATen/native/cuda/Loops.cuh>
 
 namespace at {
 namespace native {
-
-template<typename T, typename accT = T>
-struct LinspaceOp {
-  __host__ __device__ LinspaceOp(accT start, accT step):
-    start_(start), step_(step) { }
-  __device__ __forceinline__ T operator()(ptrdiff_t index) {
-    accT increment = step_ * static_cast<accT>(index);
-    accT value = start_ + increment;
-    return static_cast<T>(value);
-  }
-
-  const accT start_, step_;
-};
-
-template<typename T, typename accT = T>
-struct LogspaceOp {
-  __host__ __device__ LogspaceOp(accT start, accT step, accT base):
-    start_(start), step_(step), base_(base) { }
-  __device__ __forceinline__ T operator()(ptrdiff_t index) {
-    accT increment = step_ * static_cast<accT>(index);
-    accT value = std::pow(base_, start_ + increment);
-    return static_cast<T>(value);
-  }
-
-  const accT start_, step_, base_;
-};
 
 Tensor& linspace_cuda_out(Tensor& result, Scalar start, Scalar end, int64_t steps) {
   TORCH_CHECK(steps >= 0, "number of steps must be non-negative");
@@ -45,28 +17,39 @@ Tensor& linspace_cuda_out(Tensor& result, Scalar start, Scalar end, int64_t step
   if (result.numel() != steps) {
     result.resize_({steps});
   }
-  Tensor r = result.is_contiguous() ? result : result.contiguous();
+  // Using TensorIter, output no longer need to be contiguous
+  // We still need to check if there is internal overlap
+  // YES: error out, TOO_HARD: fallback to copy behavior, NO: use result directly
+  auto overlap = has_internal_overlap(result);
+  TORCH_CHECK(overlap != MemOverlap::YES,
+              "unsupported operation: more than one element of the written-to tensor "
+              "refers to a single memory location. Please clone() the tensor before "
+              "performing the operation.");
+  Tensor r = (overlap == MemOverlap::TOO_HARD) ?  at::empty_like(result, LEGACY_CONTIGUOUS_MEMORY_FORMAT) : result;
 
   if (steps == 0) {
     // skip
   } else if (steps == 1) {
     r.fill_(start);
   } else {
-    AT_DISPATCH_FLOATING_TYPES(r.scalar_type(), "linspace_cuda", [&]() {
+    AT_DISPATCH_ALL_TYPES_AND(at::ScalarType::Half, r.scalar_type(), "linspace_cuda", [&]() {
       scalar_t scalar_start = start.to<scalar_t>();
       scalar_t scalar_end = end.to<scalar_t>();
       scalar_t step = (scalar_end - scalar_start) / static_cast<scalar_t>(steps - 1);
-      LinspaceOp<scalar_t> linspace_method(scalar_start, step);
-      thrust::device_ptr<scalar_t> data_(r.data_ptr<scalar_t>());
-      cudaStream_t stream = at::cuda::getCurrentCUDAStream();
-      auto policy = thrust::cuda::par.on(stream);
-      thrust::tabulate(policy, data_, data_ + steps, linspace_method);
+
+      auto iter = TensorIterator::nullary_op(r);
+      gpu_kernel_with_index(iter, [scalar_start, step]GPU_LAMBDA(int ind) -> scalar_t {
+          scalar_t inc = step * ind;
+          scalar_t val = scalar_start + inc;
+          return val;
+        });
     });
   }
 
-  if (!result.is_contiguous()) {
+  if(overlap == MemOverlap::TOO_HARD) {
     result.copy_(r);
   }
+
   AT_CUDA_CHECK(cudaGetLastError());
   return result;
 }
@@ -77,29 +60,40 @@ Tensor& logspace_cuda_out(Tensor& result, Scalar start, Scalar end, int64_t step
   if (result.numel() != steps) {
     result.resize_({steps});
   }
-  Tensor r = result.is_contiguous() ? result : result.contiguous();
+  // Using TensorIter, output no longer need to be contiguous
+  // We still need to check if there is internal overlap
+  // YES: error out, TOO_HARD: fallback to copy behavior, NO: use result directly
+  auto overlap = has_internal_overlap(result);
+  TORCH_CHECK(overlap != MemOverlap::YES,
+              "unsupported operation: more than one element of the written-to tensor "
+              "refers to a single memory location. Please clone() the tensor before "
+              "performing the operation.");
+  Tensor r = (overlap == MemOverlap::TOO_HARD) ?  at::empty_like(result, LEGACY_CONTIGUOUS_MEMORY_FORMAT) : result;
 
   if (steps == 0) {
     // skip
   } else if (steps == 1) {
     r.fill_(std::pow(base, start.to<double>()));
   } else {
-    AT_DISPATCH_FLOATING_TYPES(r.scalar_type(), "logspace_cuda", [&]() {
+    AT_DISPATCH_ALL_TYPES_AND(at::ScalarType::Half, r.scalar_type(), "logspace_cuda", [&]() {
       scalar_t scalar_base = static_cast<scalar_t>(base);
       scalar_t scalar_start = start.to<scalar_t>();
       scalar_t scalar_end = end.to<scalar_t>();
       scalar_t step = (scalar_end - scalar_start) / static_cast<scalar_t>(steps - 1);
-      LogspaceOp<scalar_t> logspace_method(scalar_start, step, scalar_base);
-      thrust::device_ptr<scalar_t> data_(r.data_ptr<scalar_t>());
-      cudaStream_t stream = at::cuda::getCurrentCUDAStream();
-      auto policy = thrust::cuda::par.on(stream);
-      thrust::tabulate(policy, data_, data_ + steps, logspace_method);
+
+      auto iter = TensorIterator::nullary_op(r);
+      gpu_kernel_with_index(iter, [scalar_start, step, scalar_base]GPU_LAMBDA(int ind) -> scalar_t {
+          scalar_t inc = step * ind;
+          scalar_t val = std::pow(scalar_base, scalar_start + inc);
+          return val;
+        });
     });
   }
 
-  if (!result.is_contiguous()) {
+  if(overlap == MemOverlap::TOO_HARD) {
     result.copy_(r);
   }
+
   AT_CUDA_CHECK(cudaGetLastError());
   return result;
 }
@@ -118,19 +112,31 @@ Tensor& range_cuda_out(Tensor& result, Scalar start, Scalar end, Scalar step) {
     TORCH_CHECK(((xstep > 0) && (xend >= xstart)) || ((xstep < 0) && (xend <= xstart)),
              "upper bound and larger bound inconsistent with step sign");
     int64_t size = static_cast<int64_t>(((xend - xstart) / xstep) + 1);
+
     if (result.numel() != size) {
       result.resize_({size});
     }
-    Tensor r = result.is_contiguous() ? result : result.contiguous();
-    LinspaceOp<scalar_t, accscalar_t> linspace_method(xstart, xstep);
-    cudaStream_t stream = at::cuda::getCurrentCUDAStream();
-    auto policy = thrust::cuda::par.on(stream);
-    thrust::device_ptr<scalar_t> data_ptr(r.data_ptr<scalar_t>());
-    thrust::tabulate(policy, data_ptr, data_ptr + size, linspace_method);
+    // Using TensorIter, output no longer need to be contiguous
+    // We still need to check if there is internal overlap
+    // YES: error out, TOO_HARD: fallback to copy behavior, NO: use result directly
+    auto overlap = has_internal_overlap(result);
+    TORCH_CHECK(overlap != MemOverlap::YES,
+                "unsupported operation: more than one element of the written-to tensor "
+                "refers to a single memory location. Please clone() the tensor before "
+                "performing the operation.");
+    Tensor r = (overlap == MemOverlap::TOO_HARD) ?  at::empty_like(result, LEGACY_CONTIGUOUS_MEMORY_FORMAT) : result;
 
-    if (!result.is_contiguous()) {
+    auto iter = TensorIterator::nullary_op(r);
+    gpu_kernel_with_index(iter, [xstart, xstep]GPU_LAMBDA(int ind) -> scalar_t {
+        accscalar_t inc = xstep * static_cast<accscalar_t>(ind);
+        accscalar_t val = xstart + inc;
+        return static_cast<scalar_t>(val);
+    });
+
+    if(overlap == MemOverlap::TOO_HARD) {
       result.copy_(r);
     }
+
   });
 
   AT_CUDA_CHECK(cudaGetLastError());
@@ -181,16 +187,27 @@ Tensor& arange_cuda_out(Tensor& result, Scalar start, Scalar end, Scalar step) {
       }
       result.resize_({size});
     }
-    Tensor r = result.is_contiguous() ? result : result.contiguous();
-    LinspaceOp<scalar_t, accscalar_t> linspace_method(xstart, xstep);
-    cudaStream_t stream = at::cuda::getCurrentCUDAStream();
-    auto policy = thrust::cuda::par.on(stream);
-    thrust::device_ptr<scalar_t> data_ptr(r.data_ptr<scalar_t>());
-    thrust::tabulate(policy, data_ptr, data_ptr + size, linspace_method);
+    // Using TensorIter, output no longer need to be contiguous
+    // We still need to check if there is internal overlap
+    // YES: error out, TOO_HARD: fallback to copy behavior, NO: use result directly
+    auto overlap = has_internal_overlap(result);
+    TORCH_CHECK(overlap != MemOverlap::YES,
+                "unsupported operation: more than one element of the written-to tensor "
+                "refers to a single memory location. Please clone() the tensor before "
+                "performing the operation.");
+    Tensor r = (overlap == MemOverlap::TOO_HARD) ?  at::empty_like(result, LEGACY_CONTIGUOUS_MEMORY_FORMAT) : result;
 
-    if (!result.is_contiguous()) {
+    auto iter = TensorIterator::nullary_op(r);
+    gpu_kernel_with_index(iter, [xstart, xstep]GPU_LAMBDA(int ind) -> scalar_t {
+        accscalar_t inc = xstep * static_cast<accscalar_t>(ind);
+        accscalar_t val = xstart + inc;
+        return static_cast<scalar_t>(val);
+    });
+
+    if(overlap == MemOverlap::TOO_HARD) {
       result.copy_(r);
     }
+
   });
 
   AT_CUDA_CHECK(cudaGetLastError());


### PR DESCRIPTION
Summary:
This PR add `gpu_kernel_with_index` as an addition to element-wise kernel template. It allows kernel to not only operate on input tensor value, but also each values index(view as 1d, so from 0 to numel) within the lambda.
Direct use case here is to replace thrust::tabulate used in range/arange/linspace. Benifits are:
- thrust::tabulate causes additional unneccessary synchronization on cpu.
- Now it works with tensor iterator, output no longer needs to be contiguous and a memcpy is saved

It can also potentially be reused to add new function to pytorch later, if we see use case both value and index is needed.(for example unify tril/triu into tensor iterator element-wise? add other pattern?)

Known issues:
https://github.com/pytorch/pytorch/pull/23586 is needed to enable non-contiguous case work properly, since overlapping needs to be checked. Currently non-contiguous tensor falls into TOO_HARD. I could write proper check in this file but I figured using exist method is better. jjsjann123
It does not work beyond 32bit indexing. But thrust was erroring on those case too. We could split tensor in caller to enable this. Index changes after split, so it is easier for caller to pass different lambda, and harder for the template to handle it in general.
Pull Request resolved: https://github.com/pytorch/pytorch/pull/28175

Differential Revision: D18708649

Pulled By: ngimel

fbshipit-source-id: 382081c96f266ae7b61095fc1f2af41c6b210fa9

