### PR TITLE
C++ added 3rd arg of false to BatchNorm/InstanceNorm register_parameter …

### DIFF
--- a/torch/csrc/api/include/torch/nn/modules/batchnorm.h
+++ b/torch/csrc/api/include/torch/nn/modules/batchnorm.h
@@ -95,8 +95,8 @@ class NormImplBase : public torch::nn::Cloneable<Derived> {
       weight = this->register_parameter("weight", torch::empty({options.num_features()}));
       bias = this->register_parameter("bias", torch::empty({options.num_features()}));
     } else {
-      weight = this->register_parameter("weight", Tensor());
-      bias = this->register_parameter("bias", Tensor());
+      weight = this->register_parameter("weight", Tensor(), /*requires_grad=*/false);
+      bias = this->register_parameter("bias", Tensor(), /*requires_grad=*/false);
     }
     if (options.track_running_stats()) {
       running_mean = this->register_buffer("running_mean", torch::zeros({options.num_features()}));


### PR DESCRIPTION
Fix for issue #31680 
C++ BatchNorm & InstanceNorm attempt to register undefined tensors when affine is false.

Fixes #31680 
