### PR TITLE
[ROCm] Support PyTorch ROCm CI on Ubuntu18.04

### DIFF
--- a/docker/caffe2/jenkins/common/install_clang.sh
+++ b/docker/caffe2/jenkins/common/install_clang.sh
@@ -7,7 +7,7 @@ set -ex
 
 if [[ "$CLANG_VERSION" == "6.0" || "$CLANG_VERSION" == "7" || "$CLANG_VERSION" == "8" ]]; then
   apt-get update
-  apt-get install -y --no-install-recommends software-properties-common wget
+  apt-get install -y --no-install-recommends software-properties-common wget gpg-agent
   wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
   if [[ "$UBUNTU_VERSION" == 16.04 ]]; then
       apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-${CLANG_VERSION} main"

--- a/docker/caffe2/jenkins/common/install_python.sh
+++ b/docker/caffe2/jenkins/common/install_python.sh
@@ -38,6 +38,7 @@ install_ubuntu() {
       ;;
     3.7)
       install_ubuntu_deadsnakes python3.7-dev
+      apt-get install -y python3-distutils
       PYTHON=python3.7
       INSTALL_SETUPTOOLS=yes
       ;;

--- a/docker/caffe2/jenkins/common/install_python.sh
+++ b/docker/caffe2/jenkins/common/install_python.sh
@@ -32,6 +32,7 @@ install_ubuntu() {
       ;;
     3.6)
       install_ubuntu_deadsnakes python3.6-dev
+      apt-get install -y python3-distutils
       PYTHON=python3.6
       INSTALL_SETUPTOOLS=yes
       ;;

--- a/docker/caffe2/jenkins/common/install_rocm.sh
+++ b/docker/caffe2/jenkins/common/install_rocm.sh
@@ -8,8 +8,11 @@ install_ubuntu() {
     apt-get install -y libopenblas-dev
 
     # Need the libc++1 and libc++abi1 libraries to allow torch._C to load at runtime
-    apt-get install libc++1
-    apt-get install libc++abi1
+    apt-get install -y libc++1
+    apt-get install -y libc++abi1
+
+    # cmake needs libidn11
+    apt-get install -y libidn11
 
     DEB_ROCM_REPO=http://repo.radeon.com/rocm/apt/debian
     # Add rocm repository

--- a/docker/caffe2/jenkins/ubuntu-rocm/Dockerfile
+++ b/docker/caffe2/jenkins/ubuntu-rocm/Dockerfile
@@ -1,6 +1,9 @@
 ARG UBUNTU_VERSION
 FROM ubuntu:${UBUNTU_VERSION}
 
+# set this to noninteractive so that the installer knows
+ENV DEBIAN_FRONTEND=noninteractive
+
 # Include BUILD_ENVIRONMENT environment variable in image
 ARG BUILD_ENVIRONMENT
 ENV BUILD_ENVIRONMENT ${BUILD_ENVIRONMENT}


### PR DESCRIPTION
In order to support Ubuntu18.04, some changes to the scripts are required.
* install dependencies with -y flag
* mark install noninteractive
* install some required dependencies (gpg-agent, python3-distutils, libidn11)