### PR TITLE
Implement backend-agnostic rpc._wait_all_workers() utility

### DIFF
--- a/test/dist_autograd_test.py
+++ b/test/dist_autograd_test.py
@@ -1430,7 +1430,7 @@ class DistAutogradTest(RpcAgentTestFixture):
         # receive gradients from the node that received an error (and as a
         # result it didn't execute the rest of the graph).
         dist.barrier()
-        rpc.shutdown()
+        rpc.shutdown(graceful=False)
         sys.exit(0)
 
     @classmethod

--- a/test/dist_autograd_test.py
+++ b/test/dist_autograd_test.py
@@ -1430,7 +1430,7 @@ class DistAutogradTest(RpcAgentTestFixture):
         # receive gradients from the node that received an error (and as a
         # result it didn't execute the rest of the graph).
         dist.barrier()
-        rpc.shutdown(graceful=False)
+        rpc.shutdown()
         sys.exit(0)
 
     @classmethod

--- a/test/dist_utils.py
+++ b/test/dist_utils.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import threading
 from functools import partial, wraps
 
 import torch.distributed as dist
@@ -23,30 +22,6 @@ class TestConfig:
 
 TEST_CONFIG = TestConfig()
 INIT_METHOD_TEMPLATE = "file://{file_name}"
-
-
-MASTER_RANK = 0
-_ALL_NODE_NAMES = set()
-_DONE_NODE_NAMES = set()
-_TERMINATION_SIGNAL = threading.Event()
-
-
-def on_master_follower_report_done(worker_name):
-    assert (
-        worker_name in _ALL_NODE_NAMES
-    ), "{worker_name} is not expected by master.".format(worker_name=worker_name)
-    assert (
-        worker_name not in _DONE_NODE_NAMES
-    ), "{worker_name} report done twice.".format(worker_name=worker_name)
-    _DONE_NODE_NAMES.add(worker_name)
-    if _ALL_NODE_NAMES != _DONE_NODE_NAMES:
-        return
-    set_termination_signal()
-
-
-def set_termination_signal():
-    assert not _TERMINATION_SIGNAL.is_set(), "Termination signal got set twice."
-    _TERMINATION_SIGNAL.set()
 
 
 def dist_init(old_test_method=None, setup_rpc=True, clean_shutdown=True):
@@ -96,38 +71,7 @@ def dist_init(old_test_method=None, setup_rpc=True, clean_shutdown=True):
         return_value = old_test_method(self, *arg, **kwargs)
 
         if setup_rpc:
-            if clean_shutdown:
-                # Follower reports done.
-                if self.rank == MASTER_RANK:
-                    on_master_follower_report_done("worker{}".format(MASTER_RANK))
-                else:
-                    rpc.rpc_async(
-                        "worker{}".format(MASTER_RANK),
-                        on_master_follower_report_done,
-                        args=("worker{}".format(self.rank),),
-                    )
-
-                # Master waits for followers to report done.
-                # Follower waits for master's termination command.
-                _TERMINATION_SIGNAL.wait()
-                if self.rank == MASTER_RANK:
-                    # Master sends termination command.
-                    futs = []
-                    for dst_rank in range(self.world_size):
-                        # torch.distributed.rpc module does not support sending to self.
-                        if dst_rank == MASTER_RANK:
-                            continue
-                        dst_name = "worker{}".format(dst_rank)
-                        fut = rpc.rpc_async(dst_name, set_termination_signal, args=())
-                        futs.append(fut)
-                    for fut in futs:
-                        assert fut.wait() is None, "Sending termination signal failed."
-
-            # Close RPC. Need to do this even if we don't have a clean shutdown
-            # since we need to shutdown the RPC agent. If we don't shutdown the
-            # RPC agent, tests would fail since RPC agent threads, locks and
-            # condition variables are not properly terminated.
-            rpc.shutdown()
+            rpc.shutdown(graceful=clean_shutdown)
 
         return return_value
 

--- a/test/dist_utils.py
+++ b/test/dist_utils.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import threading
 from functools import partial, wraps
 
 import torch.distributed as dist
@@ -22,6 +23,30 @@ class TestConfig:
 
 TEST_CONFIG = TestConfig()
 INIT_METHOD_TEMPLATE = "file://{file_name}"
+
+
+MASTER_RANK = 0
+_ALL_NODE_NAMES = set()
+_DONE_NODE_NAMES = set()
+_TERMINATION_SIGNAL = threading.Event()
+
+
+def on_master_follower_report_done(worker_name):
+    assert (
+        worker_name in _ALL_NODE_NAMES
+    ), "{worker_name} is not expected by master.".format(worker_name=worker_name)
+    assert (
+        worker_name not in _DONE_NODE_NAMES
+    ), "{worker_name} report done twice.".format(worker_name=worker_name)
+    _DONE_NODE_NAMES.add(worker_name)
+    if _ALL_NODE_NAMES != _DONE_NODE_NAMES:
+        return
+    set_termination_signal()
+
+
+def set_termination_signal():
+    assert not _TERMINATION_SIGNAL.is_set(), "Termination signal got set twice."
+    _TERMINATION_SIGNAL.set()
 
 
 def dist_init(old_test_method=None, setup_rpc=True, clean_shutdown=True):
@@ -71,7 +96,38 @@ def dist_init(old_test_method=None, setup_rpc=True, clean_shutdown=True):
         return_value = old_test_method(self, *arg, **kwargs)
 
         if setup_rpc:
-            rpc.shutdown(graceful=clean_shutdown)
+            if clean_shutdown:
+                # Follower reports done.
+                if self.rank == MASTER_RANK:
+                    on_master_follower_report_done("worker{}".format(MASTER_RANK))
+                else:
+                    rpc.rpc_async(
+                        "worker{}".format(MASTER_RANK),
+                        on_master_follower_report_done,
+                        args=("worker{}".format(self.rank),),
+                    )
+
+                # Master waits for followers to report done.
+                # Follower waits for master's termination command.
+                _TERMINATION_SIGNAL.wait()
+                if self.rank == MASTER_RANK:
+                    # Master sends termination command.
+                    futs = []
+                    for dst_rank in range(self.world_size):
+                        # torch.distributed.rpc module does not support sending to self.
+                        if dst_rank == MASTER_RANK:
+                            continue
+                        dst_name = "worker{}".format(dst_rank)
+                        fut = rpc.rpc_async(dst_name, set_termination_signal, args=())
+                        futs.append(fut)
+                    for fut in futs:
+                        assert fut.wait() is None, "Sending termination signal failed."
+
+            # Close RPC. Need to do this even if we don't have a clean shutdown
+            # since we need to shutdown the RPC agent. If we don't shutdown the
+            # RPC agent, tests would fail since RPC agent threads, locks and
+            # condition variables are not properly terminated.
+            rpc.shutdown()
 
         return return_value
 

--- a/test/rpc_test.py
+++ b/test/rpc_test.py
@@ -32,6 +32,19 @@ VALUE_FUTURE = concurrent.futures.Future()
 DONE_FUTURE = concurrent.futures.Future()
 
 
+class StubRpcAgent:
+    def __init__(self, world_size):
+        self.world_size = world_size
+
+    def get_worker_infos(self):
+        return {
+            rpc.WorkerInfo(
+                name="worker{}".format(rank),
+                id=rank,
+            ) for rank in range(self.world_size)
+        }
+
+
 def _stub_construct_rpc_backend_options_handler(
     **kwargs
 ):
@@ -41,7 +54,7 @@ def _stub_construct_rpc_backend_options_handler(
 def _stub_start_rpc_backend_handler(
     store, name, rank, world_size, rpc_backend_options
 ):
-    return mock.Mock()  # RpcAgent.
+    return StubRpcAgent(world_size=world_size)
 
 
 def set_value(value):
@@ -360,7 +373,6 @@ class RpcTest(RpcAgentTestFixture):
                 world_size=self.world_size,
                 rpc_backend_options=self.rpc_backend_options,
             )
-        rpc.shutdown()
 
     @dist_init(setup_rpc=False)
     def test_reinit(self):
@@ -504,8 +516,51 @@ class RpcTest(RpcAgentTestFixture):
                 args=(torch.ones(n, n), torch.ones(n, n)),
             )
 
-        # it's safe to call shutdown() multiple times
-        rpc.shutdown()
+    def test_wait_all_workers(self):
+        rpc.init_rpc(
+            name="worker%d" % self.rank,
+            backend=self.rpc_backend,
+            rank=self.rank,
+            world_size=self.world_size,
+            rpc_backend_options=self.rpc_backend_options,
+        )
+
+        # worker0 drives and waits for worker1 and worker2
+        # throughout the test.
+        if self.rank == 0:
+            self.assertTrue(self.world_size >= 3)
+
+            num_repeat = 30
+
+            # Phase 1: Only worker1 has workload.
+            dst = "worker1"
+            futs = []
+            for _ in range(num_repeat):
+                fut = rpc.rpc_async(dst, heavy_rpc, args=(torch.ones(100, 100),))
+                futs.append(fut)
+
+            for fut in futs:
+                fut.wait()
+                self.assertEqual(fut.wait(), 0)
+
+            # Phase 2: Only worker2 has workload.
+            # If join is not correctly implemented,
+            # worker2 should be closed by now.
+            dst = "worker2"
+            futs = []
+            for _ in range(num_repeat):
+                fut = rpc.rpc_async(dst, heavy_rpc, args=(torch.ones(100, 100),))
+                futs.append(fut)
+
+            for fut in futs:
+                fut.wait()
+                self.assertEqual(fut.wait(), 0)
+
+        # worker0 calls this at the end after waiting for RPC responses.
+        # worker1/2 calls this immediately and has some works after it.
+        # worker3 calls this immediately and has no more work.
+        rpc.api._wait_all_workers()
+        rpc.shutdown(graceful=False)
 
     @dist_init
     def test_expected_src(self):
@@ -714,10 +769,10 @@ class RpcTest(RpcAgentTestFixture):
             assert self.world_size >= 3
 
             num_repeat = 100
-            futs = []
 
             # Phase 1: Only worker1 has workload.
             dst = "worker1"
+            futs = []
             for _ in range(num_repeat):
                 fut = rpc.rpc_async(dst, heavy_rpc, args=(torch.ones(100, 100),))
                 futs.append(fut)
@@ -730,6 +785,7 @@ class RpcTest(RpcAgentTestFixture):
             # If join is not correctly implemented,
             # worker2 should be closed by now.
             dst = "worker2"
+            futs = []
             for _ in range(num_repeat):
                 fut = rpc.rpc_async(dst, heavy_rpc, args=(torch.ones(100, 100),))
                 futs.append(fut)
@@ -1291,9 +1347,7 @@ class RpcTest(RpcAgentTestFixture):
         # without sending any messages.
         rpc.init_rpc(
             name="worker%d" % self.rank,
-            backend=rpc.backend_registry.BackendType[
-                dist_utils.TEST_CONFIG.rpc_backend_name
-            ],
+            backend=self.rpc_backend,
             rank=self.rank,
             world_size=self.world_size,
             rpc_backend_options=self.rpc_backend_options,
@@ -1331,9 +1385,7 @@ class RpcTest(RpcAgentTestFixture):
         # test that we can start RPC, send RPCs, and then run local shutdown.
         rpc.init_rpc(
             name="worker%d" % self.rank,
-            backend=rpc.backend_registry.BackendType[
-                dist_utils.TEST_CONFIG.rpc_backend_name
-            ],
+            backend=self.rpc_backend,
             rank=self.rank,
             world_size=self.world_size,
             rpc_backend_options=self.rpc_backend_options,
@@ -1367,7 +1419,7 @@ class RpcTest(RpcAgentTestFixture):
         # multiple times.
         rpc.init_rpc(
             name="worker%d" % self.rank,
-            backend=rpc.backend_registry.BackendType[dist_utils.TEST_CONFIG.rpc_backend_name],
+            backend=self.rpc_backend,
             rank=self.rank,
             world_size=self.world_size,
             rpc_backend_options=self.rpc_backend_options
@@ -1375,7 +1427,7 @@ class RpcTest(RpcAgentTestFixture):
         from torch.distributed.rpc.api import _wait_all_workers
         # intentional call to internal _wait_all_workers.
         _wait_all_workers()
-        rpc.shutdown()
+        rpc.shutdown(graceful=False)
 
     @dist_init(setup_rpc=False)
     def test_get_rpc_timeout(self):

--- a/test/rpc_test.py
+++ b/test/rpc_test.py
@@ -32,19 +32,6 @@ VALUE_FUTURE = concurrent.futures.Future()
 DONE_FUTURE = concurrent.futures.Future()
 
 
-class StubRpcAgent:
-    def __init__(self, world_size):
-        self.world_size = world_size
-
-    def get_worker_infos(self):
-        return {
-            rpc.WorkerInfo(
-                name="worker{}".format(rank),
-                id=rank,
-            ) for rank in range(self.world_size)
-        }
-
-
 def _stub_construct_rpc_backend_options_handler(
     **kwargs
 ):
@@ -54,7 +41,7 @@ def _stub_construct_rpc_backend_options_handler(
 def _stub_start_rpc_backend_handler(
     store, name, rank, world_size, rpc_backend_options
 ):
-    return StubRpcAgent(world_size=world_size)
+    return mock.Mock()  # RpcAgent.
 
 
 def set_value(value):
@@ -373,6 +360,7 @@ class RpcTest(RpcAgentTestFixture):
                 world_size=self.world_size,
                 rpc_backend_options=self.rpc_backend_options,
             )
+        rpc.shutdown()
 
     @dist_init(setup_rpc=False)
     def test_reinit(self):
@@ -516,51 +504,8 @@ class RpcTest(RpcAgentTestFixture):
                 args=(torch.ones(n, n), torch.ones(n, n)),
             )
 
-    def test_wait_all_workers(self):
-        rpc.init_rpc(
-            name="worker%d" % self.rank,
-            backend=self.rpc_backend,
-            rank=self.rank,
-            world_size=self.world_size,
-            rpc_backend_options=self.rpc_backend_options,
-        )
-
-        # worker0 drives and waits for worker1 and worker2
-        # throughout the test.
-        if self.rank == 0:
-            self.assertTrue(self.world_size >= 3)
-
-            num_repeat = 30
-
-            # Phase 1: Only worker1 has workload.
-            dst = "worker1"
-            futs = []
-            for _ in range(num_repeat):
-                fut = rpc.rpc_async(dst, heavy_rpc, args=(torch.ones(100, 100),))
-                futs.append(fut)
-
-            for fut in futs:
-                fut.wait()
-                self.assertEqual(fut.wait(), 0)
-
-            # Phase 2: Only worker2 has workload.
-            # If join is not correctly implemented,
-            # worker2 should be closed by now.
-            dst = "worker2"
-            futs = []
-            for _ in range(num_repeat):
-                fut = rpc.rpc_async(dst, heavy_rpc, args=(torch.ones(100, 100),))
-                futs.append(fut)
-
-            for fut in futs:
-                fut.wait()
-                self.assertEqual(fut.wait(), 0)
-
-        # worker0 calls this at the end after waiting for RPC responses.
-        # worker1/2 calls this immediately and has some works after it.
-        # worker3 calls this immediately and has no more work.
-        rpc.api._wait_all_workers()
-        rpc.shutdown(graceful=False)
+        # it's safe to call shutdown() multiple times
+        rpc.shutdown()
 
     @dist_init
     def test_expected_src(self):
@@ -769,10 +714,10 @@ class RpcTest(RpcAgentTestFixture):
             assert self.world_size >= 3
 
             num_repeat = 100
+            futs = []
 
             # Phase 1: Only worker1 has workload.
             dst = "worker1"
-            futs = []
             for _ in range(num_repeat):
                 fut = rpc.rpc_async(dst, heavy_rpc, args=(torch.ones(100, 100),))
                 futs.append(fut)
@@ -785,7 +730,6 @@ class RpcTest(RpcAgentTestFixture):
             # If join is not correctly implemented,
             # worker2 should be closed by now.
             dst = "worker2"
-            futs = []
             for _ in range(num_repeat):
                 fut = rpc.rpc_async(dst, heavy_rpc, args=(torch.ones(100, 100),))
                 futs.append(fut)
@@ -1122,7 +1066,7 @@ class RpcTest(RpcAgentTestFixture):
 
         self.assertEqual(result, sum(vals))
 
-    def _test_rref_leak(self, ignore_leak=False):
+    def _test_rref_leak(self, ignore_leak):
         rpc.init_rpc(
             name="worker{}".format(self.rank),
             backend=self.rpc_backend,
@@ -1154,12 +1098,18 @@ class RpcTest(RpcAgentTestFixture):
             import torch.distributed.rpc.api as api
             api._ignore_rref_leak = True
 
-        rpc.shutdown()
+        if not ignore_leak:
+            assert_context = self.assertRaisesRegex(RuntimeError, "Leaking RRef")
+            assert_context.__enter__()
+
+        rpc.shutdown(graceful=False)
+
+        if not ignore_leak:
+            assert_context.__exit__()
 
     @dist_init(setup_rpc=False)
     def test_rref_leak(self):
-        with self.assertRaisesRegex(RuntimeError, "Leaking RRef"):
-            self._test_rref_leak()
+        self._test_rref_leak(ignore_leak=False)
 
     @dist_init(setup_rpc=False)
     def test_ignore_rref_leak(self):
@@ -1347,7 +1297,9 @@ class RpcTest(RpcAgentTestFixture):
         # without sending any messages.
         rpc.init_rpc(
             name="worker%d" % self.rank,
-            backend=self.rpc_backend,
+            backend=rpc.backend_registry.BackendType[
+                dist_utils.TEST_CONFIG.rpc_backend_name
+            ],
             rank=self.rank,
             world_size=self.world_size,
             rpc_backend_options=self.rpc_backend_options,
@@ -1385,7 +1337,9 @@ class RpcTest(RpcAgentTestFixture):
         # test that we can start RPC, send RPCs, and then run local shutdown.
         rpc.init_rpc(
             name="worker%d" % self.rank,
-            backend=self.rpc_backend,
+            backend=rpc.backend_registry.BackendType[
+                dist_utils.TEST_CONFIG.rpc_backend_name
+            ],
             rank=self.rank,
             world_size=self.world_size,
             rpc_backend_options=self.rpc_backend_options,
@@ -1419,7 +1373,7 @@ class RpcTest(RpcAgentTestFixture):
         # multiple times.
         rpc.init_rpc(
             name="worker%d" % self.rank,
-            backend=self.rpc_backend,
+            backend=rpc.backend_registry.BackendType[dist_utils.TEST_CONFIG.rpc_backend_name],
             rank=self.rank,
             world_size=self.world_size,
             rpc_backend_options=self.rpc_backend_options
@@ -1427,7 +1381,7 @@ class RpcTest(RpcAgentTestFixture):
         from torch.distributed.rpc.api import _wait_all_workers
         # intentional call to internal _wait_all_workers.
         _wait_all_workers()
-        rpc.shutdown(graceful=False)
+        rpc.shutdown()
 
     @dist_init(setup_rpc=False)
     def test_get_rpc_timeout(self):

--- a/torch/csrc/distributed/rpc/rpc_agent.h
+++ b/torch/csrc/distributed/rpc/rpc_agent.h
@@ -146,7 +146,6 @@ class TORCH_API RpcAgent {
 
  protected:
   const WorkerInfo workerInfo_;
-  const std::string workerName_;
   const std::unique_ptr<RequestCallback> cb_;
   std::atomic<std::chrono::milliseconds> rpcTimeout_;
 

--- a/torch/csrc/distributed/rpc/rpc_agent.h
+++ b/torch/csrc/distributed/rpc/rpc_agent.h
@@ -146,6 +146,7 @@ class TORCH_API RpcAgent {
 
  protected:
   const WorkerInfo workerInfo_;
+  const std::string workerName_;
   const std::unique_ptr<RequestCallback> cb_;
   std::atomic<std::chrono::milliseconds> rpcTimeout_;
 

--- a/torch/csrc/distributed/rpc/rref_context.cpp
+++ b/torch/csrc/distributed/rpc/rref_context.cpp
@@ -67,18 +67,17 @@ void RRefContext::checkRRefLeaks(bool ignoreRRefLeak) {
       }
     }
 
-    if (ignoreRRefLeak) {
-      LOG(WARNING)
-          << "Detected RRef Leaks during shutdown. This usually "
-          << "occurs when the application code still holds references to RRef "
-          << "instances when calling shutdown(). If the program has "
-          << "completed correctly and the process is exiting, it is OK to "
-          << "ignore these leaks. However, if you program will keep running "
-          << "after this, these leaks could result in memory leaks on RRef "
-          << "owners. Please make sure all RRefs are out of scope and Python "
-          << "GC has deleted them before calling shutdown(): \n"
-          << ss.str();
-    } else {
+    LOG(WARNING)
+        << "Detected RRef Leaks during shutdown. This usually "
+        << "occurs when the application code still holds references to RRef "
+        << "instances when calling shutdown(). If the program has "
+        << "completed correctly and the process is exiting, it is OK to "
+        << "ignore these leaks. However, if you program will keep running "
+        << "after this, these leaks could result in memory leaks on RRef "
+        << "owners. Please make sure all RRefs are out of scope and Python "
+        << "GC has deleted them before calling shutdown(): \n"
+        << ss.str();
+    if (!ignoreRRefLeak) {
       TORCH_CHECK(false, ss.str());
     }
   }

--- a/torch/distributed/rpc/api.py
+++ b/torch/distributed/rpc/api.py
@@ -7,18 +7,24 @@ from . import (
     _invoke_remote_python_udf,
     _invoke_rpc_builtin,
     _invoke_rpc_python_udf,
+    _set_rpc_timeout,
     _start_rpc_agent,
     backend_registry,
 )
 from .internal import _internal_rpc_pickler, PythonUDF
 
 import contextlib
+from datetime import timedelta
 import functools
 import numbers
 import sys
+import logging
+import threading
 import torch
 import torch.distributed as dist
 
+logging.basicConfig()
+logger = logging.getLogger(__name__)
 
 _agent = None
 # NB: Ignoring RRef leaks during shutdown. Without this, applications have to
@@ -58,6 +64,42 @@ def _require_initialized(func):
     return wrapper
 
 
+# States used by `def _wait_all_workers()`.
+# `_ALL_WORKER_NAMES` is initialized on initiaizing RPC layer.
+_ALL_WORKER_NAMES = None
+# `_SHUTDOWN_INTENT_WORKER_NAMES` is an empty set at beginning.
+# It's only used by leader worker. Leader worker is elected as the first
+# worker in a sorted worker name list.
+# Whenever there is a worker showing shutdown intention to the leader, by
+# calling _wait_all_workers()`, the leader adds this worker's name to the set.
+# The leader also adds itself's name to the set on calling
+# `_wait_all_workers()`. We need this because, we confine `_wait_all_workers()`
+# to be called only once, by examing if leader's name has been added to the set.
+_SHUTDOWN_INTENT_WORKER_NAMES = set()
+# Once `_SHUTDOWN_INTENT_WORKER_NAMES == _ALL_WORKER_NAMES`,
+# we flip `_SHUTDOWN_PROCEED_SIGNAL` on the leader, and leader will send RPCs
+# to follower workers to flip their `_SHUTDOWN_PROCEED_SIGNAL`s.
+_SHUTDOWN_PROCEED_SIGNAL = threading.Event()
+
+
+def _on_leader_follower_report_shutdown_intent(worker_name):
+    assert (
+        worker_name in _ALL_WORKER_NAMES
+    ), "{worker_name} is not expected by leader.".format(worker_name=worker_name)
+    assert (
+        worker_name not in _SHUTDOWN_INTENT_WORKER_NAMES
+    ), "{worker_name} reported intent twice. ".format(worker_name=worker_name)
+    _SHUTDOWN_INTENT_WORKER_NAMES.add(worker_name)
+    if _ALL_WORKER_NAMES == _SHUTDOWN_INTENT_WORKER_NAMES:
+        _set_proceed_shutdown_signal()
+
+
+def _set_proceed_shutdown_signal():
+    assert not _SHUTDOWN_PROCEED_SIGNAL.is_set(), "Termination signal got set twice."
+    _SHUTDOWN_PROCEED_SIGNAL.set()
+
+
+@_require_initialized
 def _wait_all_workers():
     r"""
     Block until all local and remote RPC processes reach this method and wait
@@ -66,11 +108,55 @@ def _wait_all_workers():
     terminate the RPC framework, and there is no guarantee that the RPC
     framework will work after this method returns.
     """
-    global _agent
+    assert (
+        _ALL_WORKER_NAMES is not None
+    ), "`_ALL_WORKER_NAMES` is not initialized for `def _wait_all_workers`."
+    leader_worker_name = sorted(_ALL_WORKER_NAMES)[0]
 
-    if _agent:
-        _agent.join()
+    self_worker_name = _agent.get_worker_info().name
+    assert (
+        self_worker_name not in _SHUTDOWN_INTENT_WORKER_NAMES
+    ), "Can not call `_wait_all_workers()` twice."
 
+    is_leader_worker = leader_worker_name == self_worker_name
+
+    # Phase 1: Followers send intents.
+    # All followers report intents to the leader.
+    if is_leader_worker:
+        _on_leader_follower_report_shutdown_intent(self_worker_name)
+    else:
+        rpc_sync(
+            leader_worker_name,
+            _on_leader_follower_report_shutdown_intent,
+            args=(self_worker_name,),
+        )
+
+    _SHUTDOWN_PROCEED_SIGNAL.wait()
+
+    # Phase 2: Leader asks followers to proceed.
+    # Leader's signal is the first to be unblocked,
+    # after receiving all followers' intents.
+    if is_leader_worker:
+        # The leader sends out proceeed signals to all followers.
+        timeout = timedelta(seconds=5)
+        _set_rpc_timeout(timeout)
+        worker_name_to_response_future_dict = dict()
+        for follower_worker_name in _ALL_WORKER_NAMES - {leader_worker_name}:
+            fut = rpc_async(follower_worker_name, _set_proceed_shutdown_signal, args=())
+            worker_name_to_response_future_dict[follower_worker_name] = fut
+        for follower_worker_name, fut in worker_name_to_response_future_dict.items():
+            try:
+                fut.wait()
+            except RuntimeError as ex:
+                logger.error(
+                    "{worker_name} failed to respond to 'Shutdown Proceed.' request in {timeout}".format(
+                        worker_name=follower_worker_name,
+                        timeout=timeout,
+                    )
+                )
+
+
+@_require_initialized
 def shutdown(graceful=True):
     r"""
     Perform a shutdown of the RPC agent, and then destroy the RPC agent. This
@@ -113,17 +199,19 @@ def shutdown(graceful=True):
         >>> rpc.shutdown()
     """
     global _agent
-    if _agent:
-        if graceful:
-            _wait_all_workers()
-        _destroy_rref_context(_ignore_rref_leak)
-        _agent.shutdown()
-        # clean up python rpc handler in shutdown(), see comments in
-        # PythonRpcHandler::cleanup(), call it in python API because the
-        # cleanup() function has python dependency, it assumes python
-        # interpreter exists
-        _cleanup_python_rpc_handler()
-        _agent = None
+
+    if graceful:
+        _wait_all_workers()
+        _agent.join()
+    _destroy_rref_context(_ignore_rref_leak)
+    _agent.shutdown()
+    # clean up python rpc handler in shutdown(), see comments in
+    # PythonRpcHandler::cleanup(), call it in python API because the
+    # cleanup() function has python dependency, it assumes python
+    # interpreter exists
+    _cleanup_python_rpc_handler()
+    _agent = None
+
 
 # TODO: add a context manager to wrap _init_rpc_backend and shutdown
 def _init_rpc_backend(
@@ -155,6 +243,10 @@ def _init_rpc_backend(
         rpc_backend_options=rpc_backend_options,
     )
     _start_rpc_agent(_agent)
+
+    worker_infos = _agent.get_worker_infos()
+    global _ALL_WORKER_NAMES
+    _ALL_WORKER_NAMES = {worker_info.name for worker_info in worker_infos}
 
 
 @_require_initialized

--- a/torch/distributed/rpc/api.py
+++ b/torch/distributed/rpc/api.py
@@ -242,11 +242,12 @@ def _init_rpc_backend(
         world_size=world_size,
         rpc_backend_options=rpc_backend_options,
     )
-    _start_rpc_agent(_agent)
 
     worker_infos = _agent.get_worker_infos()
     global _ALL_WORKER_NAMES
     _ALL_WORKER_NAMES = {worker_info.name for worker_info in worker_infos}
+
+    _start_rpc_agent(_agent)
 
 
 @_require_initialized

--- a/torch/distributed/rpc/api.py
+++ b/torch/distributed/rpc/api.py
@@ -7,24 +7,18 @@ from . import (
     _invoke_remote_python_udf,
     _invoke_rpc_builtin,
     _invoke_rpc_python_udf,
-    _set_rpc_timeout,
     _start_rpc_agent,
     backend_registry,
 )
 from .internal import _internal_rpc_pickler, PythonUDF
 
 import contextlib
-from datetime import timedelta
 import functools
 import numbers
 import sys
-import logging
-import threading
 import torch
 import torch.distributed as dist
 
-logging.basicConfig()
-logger = logging.getLogger(__name__)
 
 _agent = None
 # NB: Ignoring RRef leaks during shutdown. Without this, applications have to
@@ -64,42 +58,6 @@ def _require_initialized(func):
     return wrapper
 
 
-# States used by `def _wait_all_workers()`.
-# `_ALL_WORKER_NAMES` is initialized on initiaizing RPC layer.
-_ALL_WORKER_NAMES = None
-# `_SHUTDOWN_INTENT_WORKER_NAMES` is an empty set at beginning.
-# It's only used by leader worker. Leader worker is elected as the first
-# worker in a sorted worker name list.
-# Whenever there is a worker showing shutdown intention to the leader, by
-# calling _wait_all_workers()`, the leader adds this worker's name to the set.
-# The leader also adds itself's name to the set on calling
-# `_wait_all_workers()`. We need this because, we confine `_wait_all_workers()`
-# to be called only once, by examing if leader's name has been added to the set.
-_SHUTDOWN_INTENT_WORKER_NAMES = set()
-# Once `_SHUTDOWN_INTENT_WORKER_NAMES == _ALL_WORKER_NAMES`,
-# we flip `_SHUTDOWN_PROCEED_SIGNAL` on the leader, and leader will send RPCs
-# to follower workers to flip their `_SHUTDOWN_PROCEED_SIGNAL`s.
-_SHUTDOWN_PROCEED_SIGNAL = threading.Event()
-
-
-def _on_leader_follower_report_shutdown_intent(worker_name):
-    assert (
-        worker_name in _ALL_WORKER_NAMES
-    ), "{worker_name} is not expected by leader.".format(worker_name=worker_name)
-    assert (
-        worker_name not in _SHUTDOWN_INTENT_WORKER_NAMES
-    ), "{worker_name} reported intent twice. ".format(worker_name=worker_name)
-    _SHUTDOWN_INTENT_WORKER_NAMES.add(worker_name)
-    if _ALL_WORKER_NAMES == _SHUTDOWN_INTENT_WORKER_NAMES:
-        _set_proceed_shutdown_signal()
-
-
-def _set_proceed_shutdown_signal():
-    assert not _SHUTDOWN_PROCEED_SIGNAL.is_set(), "Termination signal got set twice."
-    _SHUTDOWN_PROCEED_SIGNAL.set()
-
-
-@_require_initialized
 def _wait_all_workers():
     r"""
     Block until all local and remote RPC processes reach this method and wait
@@ -108,55 +66,11 @@ def _wait_all_workers():
     terminate the RPC framework, and there is no guarantee that the RPC
     framework will work after this method returns.
     """
-    assert (
-        _ALL_WORKER_NAMES is not None
-    ), "`_ALL_WORKER_NAMES` is not initialized for `def _wait_all_workers`."
-    leader_worker_name = sorted(_ALL_WORKER_NAMES)[0]
+    global _agent
 
-    self_worker_name = _agent.get_worker_info().name
-    assert (
-        self_worker_name not in _SHUTDOWN_INTENT_WORKER_NAMES
-    ), "Can not call `_wait_all_workers()` twice."
+    if _agent:
+        _agent.join()
 
-    is_leader_worker = leader_worker_name == self_worker_name
-
-    # Phase 1: Followers send intents.
-    # All followers report intents to the leader.
-    if is_leader_worker:
-        _on_leader_follower_report_shutdown_intent(self_worker_name)
-    else:
-        rpc_sync(
-            leader_worker_name,
-            _on_leader_follower_report_shutdown_intent,
-            args=(self_worker_name,),
-        )
-
-    _SHUTDOWN_PROCEED_SIGNAL.wait()
-
-    # Phase 2: Leader asks followers to proceed.
-    # Leader's signal is the first to be unblocked,
-    # after receiving all followers' intents.
-    if is_leader_worker:
-        # The leader sends out proceeed signals to all followers.
-        timeout = timedelta(seconds=5)
-        _set_rpc_timeout(timeout)
-        worker_name_to_response_future_dict = dict()
-        for follower_worker_name in _ALL_WORKER_NAMES - {leader_worker_name}:
-            fut = rpc_async(follower_worker_name, _set_proceed_shutdown_signal, args=())
-            worker_name_to_response_future_dict[follower_worker_name] = fut
-        for follower_worker_name, fut in worker_name_to_response_future_dict.items():
-            try:
-                fut.wait()
-            except RuntimeError as ex:
-                logger.error(
-                    "{worker_name} failed to respond to 'Shutdown Proceed.' request in {timeout}".format(
-                        worker_name=follower_worker_name,
-                        timeout=timeout,
-                    )
-                )
-
-
-@_require_initialized
 def shutdown(graceful=True):
     r"""
     Perform a shutdown of the RPC agent, and then destroy the RPC agent. This
@@ -199,19 +113,17 @@ def shutdown(graceful=True):
         >>> rpc.shutdown()
     """
     global _agent
-
-    if graceful:
-        _wait_all_workers()
-        _agent.join()
-    _destroy_rref_context(_ignore_rref_leak)
-    _agent.shutdown()
-    # clean up python rpc handler in shutdown(), see comments in
-    # PythonRpcHandler::cleanup(), call it in python API because the
-    # cleanup() function has python dependency, it assumes python
-    # interpreter exists
-    _cleanup_python_rpc_handler()
-    _agent = None
-
+    if _agent:
+        if graceful:
+            _wait_all_workers()
+        _destroy_rref_context(_ignore_rref_leak)
+        _agent.shutdown()
+        # clean up python rpc handler in shutdown(), see comments in
+        # PythonRpcHandler::cleanup(), call it in python API because the
+        # cleanup() function has python dependency, it assumes python
+        # interpreter exists
+        _cleanup_python_rpc_handler()
+        _agent = None
 
 # TODO: add a context manager to wrap _init_rpc_backend and shutdown
 def _init_rpc_backend(
@@ -243,10 +155,6 @@ def _init_rpc_backend(
         rpc_backend_options=rpc_backend_options,
     )
     _start_rpc_agent(_agent)
-
-    worker_infos = _agent.get_worker_infos()
-    global _ALL_WORKER_NAMES
-    _ALL_WORKER_NAMES = {worker_info.name for worker_info in worker_infos}
 
 
 @_require_initialized


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#31888 Implement backend-agnostic rpc._wait_all_workers() utility**
* #31922 Make RRef leak detection always print a warning log

We need a backend-agnostic mechanism to do barrier-like operation before locally destroy RRef context and shutdown RPC Agent.

- Sort worker names.
- Elect the first name as the leader in the ordered worker names.
- Followers reports therir intent to synchronize to the leader.
- Leader also reports to itself, when `_wait_all_workers()` called.
- If all workers report their intent to proceed, leader send the command to every one to proceed.

Differential Revision: [D19290954](https://our.internmc.facebook.com/intern/diff/D19290954/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D19290954/)!