### PR TITLE
Use simd version for fp16 conversions

### DIFF
--- a/caffe2/operators/half_float_ops.cc
+++ b/caffe2/operators/half_float_ops.cc
@@ -40,12 +40,8 @@ bool FloatToHalfOp<CPUContext>::RunOnDevice() {
   auto N = input.numel();
 
 #ifdef USE_FBGEMM
-  if (GetCpuId().avx2()) {
-    fbgemm::FloatToFloat16_avx2(
-        data, reinterpret_cast<fbgemm::float16*>(out), N, clip_);
-  } else {
-    FloatToFloat16_ref(data, out, N, clip_);
-  }
+  fbgemm::FloatToFloat16_simd(
+      data, reinterpret_cast<fbgemm::float16*>(out), N, clip_);
 #else
   FloatToFloat16_ref(data, out, N, clip_);
 #endif
@@ -63,12 +59,8 @@ bool HalfToFloatOp<CPUContext>::RunOnDevice() {
   auto N = input.numel();
 
 #ifdef USE_FBGEMM
-  if (GetCpuId().avx2()) {
-    fbgemm::Float16ToFloat_avx2(
-        reinterpret_cast<const fbgemm::float16*>(data), out, N);
-  } else {
-    Float16ToFloat_ref(data, out, N);
-  }
+  fbgemm::Float16ToFloat_simd(
+      reinterpret_cast<const fbgemm::float16*>(data), out, N);
 #else
   Float16ToFloat_ref(data, out, N);
 #endif


### PR DESCRIPTION
Summary: Previous version only use avx2. The _simd version uses avx512 if CPU is capable of that.

Test Plan: Unitttest

Reviewed By: tracelogfb

Differential Revision: D19291499

