### PR TITLE
Revert "Move AutogradMeta and DeviceGuardImplInterface virtual methods out-of-line."

### DIFF
--- a/c10/core/impl/DeviceGuardImplInterface.cpp
+++ b/c10/core/impl/DeviceGuardImplInterface.cpp
@@ -3,34 +3,6 @@
 namespace c10 {
 namespace impl {
 
-Stream DeviceGuardImplInterface::getDefaultStream(Device) const {
-  TORCH_CHECK(false, "Backend doesn't support acquiring a default stream.")
-}
-
-void DeviceGuardImplInterface::destroyEvent (
-  void* event,
-  const DeviceIndex device_index) const noexcept { }
-
-void DeviceGuardImplInterface::record(
-  void** event,
-  const Stream& stream,
-  const DeviceIndex device_index,
-  const c10::EventFlag flag) const {
-  TORCH_CHECK(false, "Backend doesn't support events.");
-}
-
-void DeviceGuardImplInterface::block(
-  void* event,
-  const Stream& stream) const {
-  TORCH_CHECK(false, "Backend doesn't support events.");
-}
-
-bool DeviceGuardImplInterface::queryEvent(void* event) const {
-  TORCH_CHECK(false, "Backend doesn't support events.");
-}
-
-DeviceGuardImplInterface::~DeviceGuardImplInterface() = default;
-
 std::atomic<const DeviceGuardImplInterface*>
 device_guard_impl_registry[static_cast<size_t>(DeviceType::COMPILE_TIME_MAX_DEVICE_TYPES)];
 

--- a/c10/core/impl/DeviceGuardImplInterface.h
+++ b/c10/core/impl/DeviceGuardImplInterface.h
@@ -105,7 +105,9 @@ struct C10_API DeviceGuardImplInterface {
   /**
    * Get the default stream for a given device.
    */
-  virtual Stream getDefaultStream(Device) const;
+  virtual Stream getDefaultStream(Device) const {
+    TORCH_CHECK(false, "Backend doesn't support acquiring a default stream.")
+  }
 
   /**
    * Set a stream to be the thread local current stream for its device.
@@ -119,7 +121,7 @@ struct C10_API DeviceGuardImplInterface {
  */
   virtual void destroyEvent (
     void* event,
-    const DeviceIndex device_index) const noexcept;
+    const DeviceIndex device_index) const noexcept { }
 
 /**
  * Increments the event's version and enqueues a job with this version
@@ -131,7 +133,9 @@ struct C10_API DeviceGuardImplInterface {
     void** event,
     const Stream& stream,
     const DeviceIndex device_index,
-    const c10::EventFlag flag) const;
+    const c10::EventFlag flag) const {
+    TORCH_CHECK(false, "Backend doesn't support events.");
+  }
 
 /**
  * Does nothing if the event has not been scheduled to be recorded.
@@ -143,7 +147,9 @@ struct C10_API DeviceGuardImplInterface {
  */
   virtual void block(
     void* event,
-    const Stream& stream) const;
+    const Stream& stream) const {
+    TORCH_CHECK(false, "Backend doesn't support events.");
+  }
 
 /**
  * Returns true if (and only if)
@@ -151,7 +157,9 @@ struct C10_API DeviceGuardImplInterface {
  *  (2) the current version is marked as recorded.
  * Returns false otherwise.
  */
-  virtual bool queryEvent(void* event) const;
+  virtual bool queryEvent(void* event) const {
+    TORCH_CHECK(false, "Backend doesn't support events.");
+  }
 
   /**
    * Get the number of devices.  WARNING: This is REQUIRED to not raise
@@ -164,7 +172,7 @@ struct C10_API DeviceGuardImplInterface {
    * Intended use of this class is to leak the DeviceGuardImpl at program end.
    * So you better not call the destructor, buster!
    */
-  virtual ~DeviceGuardImplInterface();
+  virtual ~DeviceGuardImplInterface() = default;
 };
 
 // The registry is NON-owning.  Each stored pointer is std::atomic so

--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -24,40 +24,6 @@
 namespace torch {
 namespace autograd {
 
-void AutogradMeta::set_requires_grad(bool requires_grad, at::TensorImpl* self_impl) {
-  TORCH_CHECK(
-    !requires_grad || at::isFloatingType(at::typeMetaToScalarType(self_impl->dtype())),
-    "Only Tensors of floating point dtype can require gradients");
-  requires_grad_ = requires_grad;
-}
-
-bool AutogradMeta::requires_grad() const {
-  return requires_grad_ || grad_fn_;
-}
-
-Variable& AutogradMeta::grad() {
-  return grad_;
-}
-
-const Variable& AutogradMeta::grad() const {
-  return grad_;
-}
-
-AutogradMeta::AutogradMeta(at::TensorImpl* self_impl, bool requires_grad, Edge gradient_edge) {
-  grad_fn_ = std::move(gradient_edge.function);
-  requires_grad_ = false;
-  is_view_ = false;
-  output_nr_ = gradient_edge.input_nr;
-
-  // set_requires_grad also checks error conditions.
-  if (requires_grad) {
-    TORCH_INTERNAL_ASSERT(self_impl);
-    set_requires_grad(requires_grad, self_impl);
-  }
-  TORCH_CHECK(
-      !grad_fn_ || !requires_grad_,
-      "requires_grad should be false if grad_fn is set");
-}
 
 DifferentiableViewMeta::DifferentiableViewMeta(at::TensorImpl* self_impl, Variable base)
     : AutogradMeta(self_impl, false) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#31899 Revert "Move AutogradMeta and DeviceGuardImplInterface virtual methods out-of-line."**
* #31162 Don't use RTLD_GLOBAL to load _C.
* #31161 Uniformly apply Windows logic in cpp_extensions everywhere
* #31236 Don't unconditionally compile runJITCPPTests
* #31176 Move AutogradMeta and DeviceGuardImplInterface virtual methods out-of-line.
* #31157 Add missing TORCH_CUDA_API annotation to throw_nccl_error
* #31155 Remove dead CAFFE2_LIBS variable
* #31152 Remove LibIRC logic from cmake.

This reverts commit 05e30c058d51200dfb527ca147d9bdaa657fdef3.