### PR TITLE
[CI] Run a non-quiet submodule update to prevent timeouts on Circle CI

### DIFF
--- a/.circleci/scripts/binary_checkout.sh
+++ b/.circleci/scripts/binary_checkout.sh
@@ -39,7 +39,7 @@ else
   echo "Can't tell what to checkout"
   exit 1
 fi
-retry git submodule update --init --recursive --quiet
+retry git submodule update --init --recursive
 echo "Using Pytorch from "
 git --no-pager log --max-count 1
 popd


### PR DESCRIPTION
As in title, this PR will disable the `--quiet` flag used in the CI as a workaround to a timeout hitting Mac OS CI.  Circle CI works by timing out when no text has been printed for 10 min.