### PR TITLE
[jit] Document `IValue`

### DIFF
--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -59,8 +59,39 @@ struct Object;
   _(Uninitialized) \
   _(Capsule)
 
+// [doxygen private]
+// These methods are not actually private but we don't want to document them, so
+// they are marked `@private`, which hides them on the doxygen documentation for
+// this page.
+
+
+/// IValue (Interpreter Value) is a tagged union over the types supported by the
+/// TorchScript interpreter. IValues contain their values as an `IValue::Payload`,
+/// which holds primitive types (`int64_t`, `bool`, `double`, `Device`), as
+/// values and all other types as a `c10::intrusive_ptr`.
+///
+/// IValues are used as inputs to and outputs from the TorchScript interpreter.
+/// To retrieve the value contained within an IValue, use the `.toX()` methods,
+/// where `X` is the type you are trying to get. Note that neither the `.toX()`
+/// methods nor the templated `.to<T>` functions do any kind of casting, they
+/// only unwrap the contained value. For example:
+///
+/// \rst
+/// .. code-block:: cpp
+///
+///   // Make the IValue
+///   torch::IValue my_ivalue(26);
+///   std::cout << my_ivalue << "\n";
+///
+///   // Unwrap the IValue
+///   int64_t my_int = my_ivalue.toInt()
+///   std::cout << my_int << "\n";
+///
+///   // This will throw an error!
+///   // `my_ivalue` is tagged as an int and cannot be used as another type
+///   torch::Tensor my_tensor = my_ivalue.toTensor()
+/// \endrst
 struct CAFFE2_API IValue final {
-  IValue() : payload{0}, tag(Tag::None), is_intrusive_ptr(false) {}
   IValue(const IValue& rhs)
       : IValue(rhs.payload, rhs.tag, rhs.is_intrusive_ptr) {
     if (is_intrusive_ptr) {
@@ -70,22 +101,23 @@ struct CAFFE2_API IValue final {
   IValue(IValue&& rhs) noexcept : IValue() {
     swap(rhs);
   }
+  /// @private [doxygen private]
   ~IValue() {
     if (is_intrusive_ptr) {
       c10::raw::intrusive_ptr::decref(payload.as_intrusive_ptr);
     }
   }
-  IValue & operator=(IValue && rhs) & noexcept {
+  IValue& operator=(IValue&& rhs) & noexcept {
     IValue(std::move(rhs)).swap(*this); // this also sets rhs to None
     return *this;
   }
-  IValue & operator=(IValue const & rhs) & {
+  IValue& operator=(IValue const& rhs) & {
     IValue(rhs).swap(*this);
     return *this;
   }
-
   void dump() const;
 
+  /// @private [doxygen private]
   bool isAliasOf(const IValue& rhs) const {
     if (this->tag != rhs.tag) {
       // Trivially don't alias if the type is different
@@ -110,6 +142,7 @@ struct CAFFE2_API IValue final {
     return this->payload.as_intrusive_ptr == rhs.payload.as_intrusive_ptr;
   }
 
+  /// @private [doxygen private]
   size_t use_count() const noexcept {
     if (!is_intrusive_ptr) {
       return 1;
@@ -118,6 +151,7 @@ struct CAFFE2_API IValue final {
     return c10::raw::intrusive_ptr::use_count(payload.as_intrusive_ptr);
   }
 
+  /// @private [doxygen private]
   void swap(IValue & rhs) noexcept {
     std::swap(payload, rhs.payload);
     std::swap(is_intrusive_ptr, rhs.is_intrusive_ptr);
@@ -128,7 +162,6 @@ struct CAFFE2_API IValue final {
   // While some of these accessors could be generated through templates,
   // we prefer to write them manually for clarity
 
-  // Tensor
   IValue(at::Tensor t)
   : tag(Tag::Tensor), is_intrusive_ptr(t.defined())  {
     // Note: the undefined tensor is not refcounted, so while it
@@ -152,16 +185,23 @@ struct CAFFE2_API IValue final {
     return *this;
   }
 
+  /// @private [doxygen private]
   IValue(intrusive_ptr<caffe2::Blob> blob)
   : tag(Tag::Blob), is_intrusive_ptr(true) {
     // TODO (after Tensor merge) If we pass in a Blob holding a Tensor, extract
     // and store it as a Tensor instead.
     payload.as_intrusive_ptr = blob.release();
   }
+
+  /// @private [doxygen private]
   bool isBlob() const {
     return Tag::Blob == tag;
   }
+
+  /// @private [doxygen private]
   c10::intrusive_ptr<caffe2::Blob> toBlob() &&;
+
+  /// @private [doxygen private]
   c10::intrusive_ptr<caffe2::Blob> toBlob() const &;
 
   // Capsule
@@ -331,6 +371,7 @@ struct CAFFE2_API IValue final {
   bool isModule() const;
 
   // None
+  IValue() : payload{0}, tag(Tag::None), is_intrusive_ptr(false) {}
   bool isNone() const {
     return Tag::None == tag;
   }
@@ -437,7 +478,8 @@ struct CAFFE2_API IValue final {
   template<typename T>
   optional<T> toOptional();
 
-  // this is a shallow comparison of two IValues to test the object identity
+  /// @private [doxygen private]
+  /// this is a shallow comparison of two IValues to test the object identity
   bool isSameIdentity(const IValue& rhs) const;
 
   CAFFE2_API friend std::ostream& operator<<(
@@ -448,6 +490,7 @@ struct CAFFE2_API IValue final {
     return is_intrusive_ptr;
   }
 
+  /// @private [doxygen private]
   const void* internalToPointer() const {
     TORCH_INTERNAL_ASSERT(isPtrType(), "Can only call internalToPointer() for pointer types");
     return payload.as_intrusive_ptr;

--- a/docs/cpp/source/Doxyfile
+++ b/docs/cpp/source/Doxyfile
@@ -99,7 +99,6 @@ PREDEFINED            += DOXYGEN_SHOULD_SKIP_THIS
 SEARCH_INCLUDES        = YES
 INCLUDE_PATH           = ../../.. \
                          ../../../torch/csrc/api/include \
-                         ../../../aten/src \
                          ../../../build/aten/src
 ################################################################################
 # Compound extraction control.                                                 #
@@ -108,7 +107,8 @@ EXTRACT_ALL            = YES
 EXTRACT_PACKAGE        = YES
 EXTRACT_STATIC         = YES
 CASE_SENSE_NAMES       = NO
-EXCLUDE_SYMBOLS        = c10::* caffe2::* cereal* DL* TH* cudnn* std::*
+EXCLUDE_SYMBOLS        = caffe2::* cereal* DL* TH* cudnn* std::*
+# EXCLUDE_SYMBOLS        = c10::* caffe2::* cereal* DL* TH* cudnn* std::*
 ################################################################################
 # Docstring control / customization.                                           #
 ################################################################################

--- a/docs/cpp/source/_static/cpp_theme.css
+++ b/docs/cpp/source/_static/cpp_theme.css
@@ -1,0 +1,23 @@
+/* These are hacks on top of pytorch-sphinx-theme to fix random problems when
+it is applied to C++ docs */
+
+/* Fix clickable types floating to the right */
+a.reference.internal {
+    position: static !important;
+}
+
+/* Clickable links should have a underline */
+a.reference.internal:hover {
+    text-decoration: underline !important;
+}
+
+/* Non-clickable type properties should match C++ syntax and be black */
+.function em.property {
+    text-transform: none !important;
+    color: #262626 !important;
+}
+
+/* This was broken for some reason and wasn't using the right font */
+.function a.anchorjs-link {
+    font-family: anchorjs-icons !important;
+}

--- a/docs/cpp/source/conf.py
+++ b/docs/cpp/source/conf.py
@@ -179,7 +179,7 @@ html_logo = os.path.join(
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 # NOTE: sharing python docs resources
-html_static_path = [os.path.join(repo_root, 'docs', 'source', '_static')]
+html_static_path = [os.path.join(repo_root, 'docs', 'cpp', 'source', '_static')]
 
 
 # Called automatically by Sphinx, making this `conf.py` an "extension".
@@ -187,7 +187,7 @@ def setup(app):
     # NOTE: in Sphinx 1.8+ `html_css_files` is an official configuration value
     # and can be moved outside of this function (and the setup(app) function
     # can be deleted).
-    html_css_files = []
+    html_css_files = ['cpp_theme.css']
 
     # In Sphinx 1.8 it was renamed to `add_css_file`, 1.7 and prior it is
     # `add_stylesheet` (deprecated in 1.8).


### PR DESCRIPTION
This is a first pass attempt at documenting `IValue` to help with problems like in #17165. Most users are probably concerned with
 * how to make an `IValue` that matches the input type to their graph (most of the constructors are pretty self explanatory, so as long as they are in the docs I think its enough)
 * how to extract the results after running their graph (there is a small note on the behavior of `.toX()` based on confusions we've had in the past)

Preview:
https://driazati.github.io/pytorch_doc_previews/31904/api/structc10_1_1_i_value.html#exhale-struct-structc10-1-1-i-value

There are also some random CSS fixes to clean up the style.

Differential Revision: [D19318733](https://our.internmc.facebook.com/intern/diff/19318733/)