### PR TITLE
Ensure autograd callbacks are called only once for reentrant backward.

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -3351,6 +3351,49 @@ for shape in [(1,), ()]:
         mean_combined = torch.stack(feat_combined).mean()
         mean_combined.backward()
 
+    def test_reentrant_with_callbacks(self):
+        counter = [0]
+
+        def inc_counter():
+            counter[0] += 1
+
+        class MyFunc(Function):
+            @staticmethod
+            def forward(ctx, input):
+                return input
+
+            @staticmethod
+            @once_differentiable
+            def backward(ctx, input):
+                # Add a callback to execute.
+                Variable._execution_engine.queue_callback(inc_counter)
+
+                return input
+
+        class MyReentrantFunc(Function):
+            @staticmethod
+            def forward(ctx, input):
+                return input
+
+            @staticmethod
+            @once_differentiable
+            def backward(ctx, input):
+                # Reentrant backward call.
+                tmp_inp = input.detach().requires_grad_()
+                with torch.enable_grad():
+                    tmp_out = (MyFunc.apply(tmp_inp)).sum()
+                tmp_out.backward()
+                return input
+
+        t1 = torch.rand((3, 3), requires_grad=True)
+        t2 = MyReentrantFunc.apply(t1)
+        t3 = t2.sum()
+        torch.autograd.backward([t3])
+
+        # Verify callback is called only once.
+        self.assertEquals(1, counter[0])
+
+
 def index_variable(shape, max_indices):
     if not isinstance(shape, tuple):
         shape = (shape,)

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -756,12 +756,14 @@ std::shared_ptr<FutureVariableList> Engine::execute_with_graph_task(
       --current_depth;
       --total_depth;
 
-      // Check for errors, call callbacks and sync streams. We return a
-      // completed future here since 'thread_main' above is a call blocking an
-      // autograd engine thread and not the thread the user called
+      // The graph task should have completed and the associated future should
+      // be marked completed as well.
+      TORCH_INTERNAL_ASSERT(graph_task->future_result_->completed());
+
+      // We return a completed future here since 'thread_main' above is a call
+      // blocking an autograd engine thread and not the thread the user called
       // 'execute_with_graph_task' from.
-      return std::make_shared<FutureVariableList>(
-          graph_task_exec_post_processing(graph_task));
+      return graph_task->future_result_;
     }
   }
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#31909 Ensure autograd callbacks are called only once for reentrant backward.**

https://github.com/pytorch/pytorch/pull/31230 introduced a bug where
we would end up calling `graph_task_post_processing` twice for reentrant
backward calls (once when we mark the future completed and then we we called
graph_task_post_processing in execute_with_graph_task).

This PR fixes the issues by verifying the future we return in that case is
completed and we remove the call to graph_task_post_processing.

In addition to that I added a test that reproduced the problem and verified it
is fixed by this PR.

Differential Revision: [D19296363](https://our.internmc.facebook.com/intern/diff/D19296363/)