### PR TITLE
Fix -Wundef warning in conversions.h

### DIFF
--- a/caffe2/utils/conversions.h
+++ b/caffe2/utils/conversions.h
@@ -7,7 +7,7 @@
 // has necessary diagnostic guards.
 #include <caffe2/core/common_gpu.h>
 #endif
-#if __HIP_DEVICE_COMPILE__
+#ifdef __HIP_DEVICE_COMPILE__
 #include <caffe2/core/hip/common_gpu.h>
 #endif
 


### PR DESCRIPTION
Test Plan:
* CI builds including GPU and OSS-build tests
* The `defined(__HIP_DEVICE_COMPILE__) ` instance a few lines below is proof that this is a define/undef flag, not a define01 flag

Differential Revision: D19296560

