### PR TITLE
Rename TORCH_DCHECK to TORCH_INTERNAL_ASSERT_DEBUG_ONLY

### DIFF
--- a/c10/test/util/exception_test.cpp
+++ b/c10/test/util/exception_test.cpp
@@ -8,13 +8,13 @@ bool throw_func() {
 }
 } // namespace
 
-TEST(ExceptionTest, TORCH_DCHECK) {
+TEST(ExceptionTest, TORCH_INTERNAL_ASSERT_DEBUG_ONLY) {
 #ifdef NDEBUG
-  ASSERT_NO_THROW(TORCH_DCHECK(false));
+  ASSERT_NO_THROW(TORCH_INTERNAL_ASSERT_DEBUG_ONLY(false));
   // Does nothing - `throw_func()` should not be evaluated
-  ASSERT_NO_THROW(TORCH_DCHECK(throw_func()));
+  ASSERT_NO_THROW(TORCH_INTERNAL_ASSERT_DEBUG_ONLY(throw_func()));
 #else
-  ASSERT_THROW(TORCH_DCHECK(false), c10::Error);
-  ASSERT_NO_THROW(TORCH_DCHECK(true));
+  ASSERT_THROW(TORCH_INTERNAL_ASSERT_DEBUG_ONLY(false), c10::Error);
+  ASSERT_NO_THROW(TORCH_INTERNAL_ASSERT_DEBUG_ONLY(true));
 #endif
 }

--- a/c10/util/Exception.h
+++ b/c10/util/Exception.h
@@ -266,15 +266,17 @@ inline std::string if_empty_then(std::string x, std::string y) {
   }
 #endif
 
-// Debug only version of TORCH_CHECK. This macro only checks in debug
-// build, and does nothing in release build.
+// Debug only version of TORCH_INTERNAL_ASSERT. This macro only checks in debug
+// build, and does nothing in release build.  It is appropriate to use
+// in situations where you want to add an assert to a hotpath, but it is
+// too expensive to run this assert on production builds.
 #ifdef NDEBUG
 // Optimized version - generates no code.
-#define TORCH_DCHECK(...) \
+#define TORCH_INTERNAL_ASSERT_DEBUG_ONLY(...) \
   while (false)           \
-  TORCH_CHECK(__VA_ARGS__)
+  TORCH_INTERNAL_ASSERT(__VA_ARGS__)
 #else
-#define TORCH_DCHECK(...) TORCH_CHECK(__VA_ARGS__)
+#define TORCH_INTERNAL_ASSERT_DEBUG_ONLY(...) TORCH_INTERNAL_ASSERT(__VA_ARGS__)
 #endif
 
 // TODO: We're going to get a lot of similar looking string literals

--- a/c10/util/intrusive_ptr.h
+++ b/c10/util/intrusive_ptr.h
@@ -93,10 +93,10 @@ class C10_API intrusive_ptr_target {
 #  pragma GCC diagnostic ignored "-Wterminate"
 #  pragma GCC diagnostic ignored "-Wexceptions"
 #endif
-    TORCH_DCHECK(
+    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
         refcount_.load() == 0,
         "Tried to destruct an intrusive_ptr_target that still has intrusive_ptr to it");
-    TORCH_DCHECK(
+    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
         weakcount_.load() == 0,
         "Tried to destruct an intrusive_ptr_target that still has weak_intrusive_ptr to it");
 #if defined(_MSC_VER) && !defined(__clang__)
@@ -185,7 +185,7 @@ class intrusive_ptr final {
   void retain_() {
     if (target_ != NullType::singleton()) {
       size_t new_refcount = ++target_->refcount_;
-      TORCH_DCHECK(
+      TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
           new_refcount != 1,
           "intrusive_ptr: Cannot increase refcount after it reached zero.");
     }
@@ -369,7 +369,7 @@ class intrusive_ptr final {
    */
   static intrusive_ptr unsafe_reclaim_from_nonowning(TTarget* raw_ptr) {
     // See Note [Stack allocated intrusive_ptr_target safety]
-    TORCH_DCHECK(
+    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
         raw_ptr == NullType::singleton() || raw_ptr->refcount_.load() > 0,
         "intrusive_ptr: Can only reclaim pointers that are owned by someone");
     auto ptr = reclaim(raw_ptr); // doesn't increase refcount
@@ -442,7 +442,7 @@ class weak_intrusive_ptr final {
   void retain_() {
     if (target_ != NullType::singleton()) {
       size_t new_weakcount = ++target_->weakcount_;
-      TORCH_DCHECK(
+      TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
           new_weakcount != 1,
           "weak_intrusive_ptr: Cannot increase weakcount after it reached zero.");
     }
@@ -620,7 +620,7 @@ class weak_intrusive_ptr final {
     // if refcount > 0, weakcount must be >1 for weak references to exist.
     // see weak counting explanation at top of this file.
     // if refcount == 0, weakcount only must be >0.
-    TORCH_DCHECK(
+    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
         owning_weak_ptr == NullType::singleton() ||
         owning_weak_ptr->weakcount_.load() > 1 ||
             (owning_weak_ptr->refcount_.load() == 0 &&


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#31917 Rename TORCH_DCHECK to TORCH_INTERNAL_ASSERT_DEBUG_ONLY**

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D19301480](https://our.internmc.facebook.com/intern/diff/D19301480)