### PR TITLE
Make RRef leak detection always print a warning log

### DIFF
--- a/test/rpc_test.py
+++ b/test/rpc_test.py
@@ -1097,17 +1097,10 @@ class RpcTest(RpcAgentTestFixture):
         if ignore_leak:
             import torch.distributed.rpc.api as api
             api._ignore_rref_leak = True
-
-        try:
-            if not ignore_leak:
-                assert_context = self.assertRaisesRegex(RuntimeError, "Leaking RRef")
-                assert_context.__enter__()
-
             rpc.shutdown(graceful=False)
-        except BaseException:
-            if not ignore_leak:
-                if not assert_context.__exit__(*sys.exc_info()):
-                    raise
+        else:
+            with self.assertRaisesRegex(RuntimeError, "Leaking RRef"):
+                rpc.shutdown(graceful=False)
 
     @dist_init(setup_rpc=False)
     def test_rref_leak(self):

--- a/test/rpc_test.py
+++ b/test/rpc_test.py
@@ -1094,13 +1094,14 @@ class RpcTest(RpcAgentTestFixture):
             args=(torch.ones(2, 2), 1)
         )
 
+        import torch.distributed.rpc.api as api
         if ignore_leak:
-            import torch.distributed.rpc.api as api
             api._ignore_rref_leak = True
-            rpc.shutdown(graceful=False)
+            rpc.shutdown(graceful=True)
         else:
+            api._ignore_rref_leak = False
             with self.assertRaisesRegex(RuntimeError, "Leaking RRef"):
-                rpc.shutdown(graceful=False)
+                rpc.shutdown(graceful=True)
 
     @dist_init(setup_rpc=False)
     def test_rref_leak(self):

--- a/torch/csrc/distributed/rpc/rref_context.cpp
+++ b/torch/csrc/distributed/rpc/rref_context.cpp
@@ -67,18 +67,17 @@ void RRefContext::checkRRefLeaks(bool ignoreRRefLeak) {
       }
     }
 
-    if (ignoreRRefLeak) {
-      LOG(WARNING)
-          << "Detected RRef Leaks during shutdown. This usually "
-          << "occurs when the application code still holds references to RRef "
-          << "instances when calling shutdown(). If the program has "
-          << "completed correctly and the process is exiting, it is OK to "
-          << "ignore these leaks. However, if you program will keep running "
-          << "after this, these leaks could result in memory leaks on RRef "
-          << "owners. Please make sure all RRefs are out of scope and Python "
-          << "GC has deleted them before calling shutdown(): \n"
-          << ss.str();
-    } else {
+    LOG(WARNING)
+        << "Detected RRef Leaks during shutdown. This usually "
+        << "occurs when the application code still holds references to RRef "
+        << "instances when calling shutdown(). If the program has "
+        << "completed correctly and the process is exiting, it is OK to "
+        << "ignore these leaks. However, if you program will keep running "
+        << "after this, these leaks could result in memory leaks on RRef "
+        << "owners. Please make sure all RRefs are out of scope and Python "
+        << "GC has deleted them before calling shutdown(): \n"
+        << ss.str();
+    if (!ignoreRRefLeak) {
       TORCH_CHECK(false, ss.str());
     }
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #31888 Implement backend-agnostic rpc._wait_all_workers() utility
* **#31922 Make RRef leak detection always print a warning log**

For better debugging `test_rref_leak` failure in https://app.circleci.com/jobs/github/pytorch/pytorch/4135881, as per discussion in https://github.com/pytorch/pytorch/pull/31888.

- Always print RRef leak logs.
- Make the exception assertion in the scope of the UserRRef var, so that the UserRRef is not deleted before the assertion. 

Differential Revision: [D19302814](https://our.internmc.facebook.com/intern/diff/D19302814/)