### PR TITLE
Fix race condition for backward ops that span devices

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1898,6 +1898,48 @@ class TestCuda(TestCase):
         self.assertEqual(x.grad, torch.ones_like(x) * 5)
 
     @unittest.skipIf(not TEST_MULTIGPU, "only one GPU detected")
+    def test_streaming_backwards_device_transfer(self):
+        # This function must run with non-default current streams on all devices, otherwise it's meaningless.
+        # The intention is to test that to()'s backward (CopyBackward) interacts properly with the
+        # synchronization logic in torch/csrc/autograd/input_buffer.cpp.
+        dev0 = torch.device("cuda:0")
+        dev1 = torch.device("cuda:1")
+
+        # Unfortunately I need to make the tensors largeish.
+        # Bigger tensors = longer D2D transfers = more likely to expose races.
+        size = 2**26
+
+        a = torch.full((size,), 1, device=dev1, dtype=torch.float64, requires_grad=True)
+        b = torch.full((size,), 1, device=dev1, dtype=torch.float64, requires_grad=True)
+
+        # Here to_backward_recipient = a*b is used only once, so MulBackward's InputBuffer slot only expects 1 input.
+        # This tests the situation where we don't call InputBuffer::accumulate for MulBackward's InputBuffer.
+        to_backward_recipient = a * b
+        s = to_backward_recipient.to(device="cuda:0").sum()
+        torch.cuda.synchronize(device=dev0)
+        torch.cuda.synchronize(device=dev1)
+        s.backward()
+        self.assertTrue(a.grad.sum().item() == size)
+        self.assertTrue(b.grad.sum().item() == size)
+
+        # Here to_backward_recipient = a*b is used twice, so MulBackward's InputBuffer slot expects 2 inputs.
+        # This tests the situation where we do call InputBuffer::accumulate for MulBackward's InputBuffer.
+        a.grad = None
+        b.grad = None
+        to_backward_recipient = a * b
+        # Multiply by 2 here so to's backward creates gradient values that are different from the case above,
+        # to mitigate weirdness if the caching allocator happens to reuse memory regions that were populated
+        # with 1s by the case above
+        s0 = to_backward_recipient.to(device="cuda:0").sum() * 2.
+        s1 = to_backward_recipient.to(device="cuda:0").sum() * 2.
+        torch.cuda.synchronize(device=dev0)
+        torch.cuda.synchronize(device=dev1)
+        s0.backward(retain_graph=True)
+        s1.backward()
+        self.assertTrue(a.grad.sum().item() == 4 * size)
+        self.assertTrue(b.grad.sum().item() == 4 * size)
+
+    @unittest.skipIf(not TEST_MULTIGPU, "only one GPU detected")
     def test_cuda_init_race(self):
         # See https://github.com/pytorch/pytorch/issues/16559
         import subprocess

--- a/torch/csrc/autograd/input_buffer.cpp
+++ b/torch/csrc/autograd/input_buffer.cpp
@@ -98,10 +98,6 @@ namespace torch { namespace autograd {
       opt_var_stream = get_stream_helper.getDefaultStream(*device_of(var));
     }
 
-    // If the consumer's original forward-pass output was on a particular device,
-    // I think we can safely say it expects the grad for that output to be on the same device
-    TORCH_INTERNAL_ASSERT(opt_var_stream->device() == opt_consumer_stream->device());
-
     if (opt_var_stream != opt_consumer_stream) {
       // Sync consumer with var stream
       // Events are associated with the current device on construction, and

--- a/torch/csrc/autograd/input_buffer.cpp
+++ b/torch/csrc/autograd/input_buffer.cpp
@@ -45,21 +45,42 @@ namespace torch { namespace autograd {
 
   // Switches to accumulate device
   // The device (and stream) chosen for accumulation is:
-  //  (1) If the variable is not a CUDA variable, accumulation happens on the
-  //      device of the variable.
-  //  (2) If the variable is a CUDA variable, and the producer and consumer
-  //      share its device, then:
-  //        (2a) if the producer and consumer do not share a stream,
-  //             the consumer is synced with the producer.
-  //        (2b) accumulation happens on the consumer's stream
-  //  (3) If the variable is a CUDA variable but it, the producer, and the
-  //      consumer are on multiple devices, then:
-  //        (3a) We assume var was created on its device's current stream.
-  //             We further assume (and assert) that var's device's current stream
-  //             is its default stream.
-  //        (3b) Accumulation happens on var's device's current stream (default stream).
-  //             If that stream is different from the consumer stream, we then sync
-  //             the consumer stream with it.
+  //  (1) If var is not a CUDA variable, accumulation happens on var's device.
+  //  (2) If var is a CUDA variable, and opt_producer_stream and opt_consumer_stream
+  //      share its device:
+  //        (2a) if opt_producer_stream != opt_consumer_stream,
+  //             sync opt_consumer_stream with opt_producer_stream.
+  //        (2b) accumulation happens on opt_consumer_stream.
+  //  (3) If var is a CUDA variable, and it's on opt_consumer_stream's device but not
+  //      opt_producer_stream's device:
+  //        (3a) Assume var was populated on its device's current stream.  In this sense,
+  //             var's device's current stream is the "effective producer stream."
+  //             The stream guard in Engine::evaluate_function (which calls InputBuffer::add)
+  //             has set opt_producer_stream on opt_producer_stream's device, but that didn't
+  //             affect var's device.  Therefore, we further assume (and assert) that var's
+  //             device's current stream is its default stream.  Putting the pieces together,
+  //             this tells us var's device's default stream is the "effective producer stream."
+  //             If this "effective producer stream" != opt_consumer_stream,
+  //             sync opt_consumer_stream with effective producer stream.
+  //        (3b) accumulation happens on opt_consumer_stream.
+  //  (4) If var is a CUDA variable, and it's on opt_producer_stream's device but not
+  //      opt_consumer_stream's device:
+  //        (4a) Assume var was populated on opt_producer_stream.
+  //             During the consumer op's evaluation, opt_consumer_stream will be made current
+  //             on the consumer device.  But this won't affect var's device, so at that time
+  //             the current stream on var's device should be its default stream.
+  //             In general, ops that collect grads from other devices (like BroadcastBackward's
+  //             gather) should internally sync with the current streams of those other devices
+  //             before using the gradients.  They would be crazy not to, right?
+  //             In other words, we anticipate the consumer op will sync with the default stream
+  //             of var's device before using var.  var's device's default stream is the
+  //             "effective consumer stream" in the sense that it's the stream the consumer op
+  //             will internally sync on during evaluation.
+  //             If opt_producer_stream != var's device's default stream (aka the producer device's
+  //             default stream), sync var's device's default stream with opt_producer_stream.
+  //        (4b) accumulation happens on var's device's default stream (the "effective consumer stream").
+  //  (5) If var is on neither opt_producer_stream nor opt_consumer_stream's device(s),
+  //      throw an error (assume this never happens).
 
   TORCH_INTERNAL_ASSERT(device_of(var));
   c10::optional<c10::Stream> opt_accumulate_stream = c10::nullopt;
@@ -70,71 +91,60 @@ namespace torch { namespace autograd {
                         && device_of(var) == opt_consumer_stream->device();
     if (on_producer && on_consumer) {
       // (2) CUDA variable with producer and consumer sharing a device
-      //     Accumulation happens on consumer's stream
+      // Accumulation happens on opt_consumer_stream
       opt_accumulate_stream = opt_consumer_stream;
-      if (opt_producer_stream != opt_consumer_stream) {
-        // (2a) Syncs consumer with producer
+      if (opt_accumulate_stream != opt_producer_stream) {
+        // (2a) Sync accumulate with producer
         auto event = c10::Event{c10::DeviceType::CUDA};
         event.record(*opt_producer_stream);
-        opt_consumer_stream->wait(event);
-        // TODO:  I think we need
-        // c10::cuda::CUDACachingAllocator::recordStream(var.storage().data_ptr(), opt_consumer_stream);
-        // but I'm not sure if a call to c10::cuda::xyz here will allow a CPU-only build to compile.
+        opt_accumulate_stream->wait(event);
       }
-    } else {
-      // (3) CUDA variable with multiple devices
-      //     Accumulation happens on variable's device's default stream
-      //
-      // The current stream for each device is thread local.  User-side calls that set streams affect the
-      // current stream in the main thread.  However, backward is executed on new threads (one per device).
-      // Therefore, we expect that the ambient current stream in backward-pass threads is the default stream,
-      // unless it's been explicitly changed by something on that same thread (e.g. the stream guard in
-      // Engine::evaluate_function).  For cross-device backward ops in particular, however, that stream guard
-      // only sets the stream on the producer device (opt_producer_stream).  If the gradient (var) that the op
-      // created is on a different device, that device wasn't affected by the stream guard.
-      // Therefore, if var is not on the producer device, var's device's current stream should be the
-      // ambient current stream that the backward thread holds for var's device, which should be that
-      // device's default stream.
-      //
-      // tldr: for case (3) we assume var was populated on its device's default stream.
-
-      //  guard is a hack to access streams that will compile even if the build is CPU-only.
+    } else if (on_consumer && !on_producer) {
+      // (3) CUDA variable, on consumer stream's device but not on producer stream's device
+      // Accumulation happens on opt_consumer_stream
+      opt_accumulate_stream = opt_consumer_stream;
+      // var's device's default stream is the "effective producer"
       const auto guard = c10::impl::VirtualGuardImpl{c10::DeviceType::CUDA};
       const auto default_stream = guard.getDefaultStream(*device_of(var));
-      if (!on_producer) {
-        // double check our belief that the current stream on var's device is the default stream
-        TORCH_INTERNAL_ASSERT(guard.getStream(*device_of(var)) == default_stream);
+      // double check our belief that var's device's current stream is its default stream
+      TORCH_INTERNAL_ASSERT(guard.getStream(*device_of(var)) == default_stream);
+      if (opt_accumulate_stream != default_stream) {
+        // (3a) Sync accumulate with default_stream (the "effective producer")
+        //      For this purpose, we'd like to record an event in that default stream.
+        //      The cuda api says we must create that event on the same device as the stream.
+        //      However, calling code has made the producer stream (and device) current,
+        //      so we temporarily guard onto default_stream's device.
+        c10::OptionalDeviceGuard device_guard{default_stream->device()};
+        auto event = c10::Event{c10::DeviceType::CUDA};
+        event.record(*default_stream);
+        opt_accumulate_stream->wait(event);
       }
+    } else if (on_producer && !on_consumer) {
+      // (4) CUDA variable, on producer stream's device but not consumer stream's device
+      // Accumulation happens on var's device's default stream
+      const auto guard = c10::impl::VirtualGuardImpl{c10::DeviceType::CUDA};
+      const auto default_stream = guard.getDefaultStream(*device_of(var));
       opt_accumulate_stream = default_stream;
+      if (opt_accumulate_stream != opt_producer_stream) {
+        // (4a) Sync accumulate with producer
+        auto event = c10::Event{c10::DeviceType::CUDA};
+        event.record(*opt_producer_stream);
+        opt_accumulate_stream->wait(event);
+      }
+    } else {
+      // (5) CUDA variable on neither producer stream nor consumer stream's device(s)
+      AT_ERROR("Gradient (var) is on an unexpected device.");
     }
   }
+      c10::OptionalStreamGuard stream_guard{opt_accumulate_stream};
 
   auto& old_var = buffer[pos];
   if (!old_var.defined()) {
     buffer[pos] = std::move(var);
-    if (opt_accumulate_stream != opt_consumer_stream) {
-      // (3b) Sync consumer with accumulate
-      c10::OptionalStreamGuard stream_guard{opt_accumulate_stream};
-      auto event = c10::Event{c10::DeviceType::CUDA};
-      event.record(*opt_accumulate_stream);
-      opt_consumer_stream->wait(event);
-      // TODO:  I think we need
-      // c10::cuda::CUDACachingAllocator::recordStream(var.storage().data_ptr(), opt_consumer_stream);
-      // but I'm not sure if a call to c10::cuda::xyz here will allow a CPU-only build to compile.
-    }
   } else {
     if (opt_accumulate_stream) {
       c10::OptionalStreamGuard stream_guard{opt_accumulate_stream};
       accumulate(buffer, pos, std::move(var));
-      if (opt_accumulate_stream != opt_consumer_stream) {
-        // (3b) Sync consumer with accumulate
-        auto event = c10::Event{c10::DeviceType::CUDA};
-        event.record(*opt_accumulate_stream);
-        opt_consumer_stream->wait(event);
-        // TODO:  I think we need
-        // c10::cuda::CUDACachingAllocator::recordStream(var.storage().data_ptr(), opt_consumer_stream);
-        // but I'm not sure if a call to c10::cuda::xyz here will allow a CPU-only build to compile.
-      }
     } else {
       // (1) non-CUDA variable
       //     Accumulation happens on variable's device

--- a/torch/csrc/autograd/input_buffer.cpp
+++ b/torch/csrc/autograd/input_buffer.cpp
@@ -45,12 +45,14 @@ namespace torch { namespace autograd {
 
   // Switches to accumulate device
   // The device (and stream) chosen for accumulation is:
-  //  (1) If var is not a CUDA variable, accumulation happens on var's device.
-  //  (2) If var is a CUDA variable, and the producer and consumer share its device, then:
+  //  (1) If the variable is not a CUDA variable, accumulation happens on the
+  //      device of the variable.
+  //  (2) If the variable is a CUDA variable, and the producer and consumer
+  //      share its device, then:
   //        (2a) if the producer and consumer do not share a stream,
   //             the consumer is synced with the producer.
   //        (2b) accumulation happens on the consumer's stream
-  //  (3) If var is a CUDA variable but it, the producer, and the
+  //  (3) If the variable is a CUDA variable but it, the producer, and the
   //      consumer are on multiple devices, then:
   //        (3a) We assume var was created on its device's current stream.
   //             We further assume (and assert) that var's device's current stream

--- a/torch/csrc/autograd/input_buffer.cpp
+++ b/torch/csrc/autograd/input_buffer.cpp
@@ -77,6 +77,9 @@ namespace torch { namespace autograd {
         auto event = c10::Event{c10::DeviceType::CUDA};
         event.record(*opt_producer_stream);
         opt_consumer_stream->wait(event);
+        // TODO:  I think we need
+        // c10::cuda::CUDACachingAllocator::recordStream(var.storage().data_ptr(), opt_consumer_stream);
+        // but I'm not sure if a call to c10::cuda::xyz here will allow a CPU-only build to compile.
       }
     } else {
       // (3) CUDA variable with multiple devices
@@ -112,6 +115,9 @@ namespace torch { namespace autograd {
       auto event = c10::Event{c10::DeviceType::CUDA};
       event.record(*opt_accumulate_stream);
       opt_consumer_stream->wait(event);
+      // TODO:  I think we need
+      // c10::cuda::CUDACachingAllocator::recordStream(var.storage().data_ptr(), opt_consumer_stream);
+      // but I'm not sure if a call to c10::cuda::xyz here will allow a CPU-only build to compile.
     }
   } else {
     if (opt_accumulate_stream) {
@@ -122,6 +128,9 @@ namespace torch { namespace autograd {
         auto event = c10::Event{c10::DeviceType::CUDA};
         event.record(*opt_accumulate_stream);
         opt_consumer_stream->wait(event);
+        // TODO:  I think we need
+        // c10::cuda::CUDACachingAllocator::recordStream(var.storage().data_ptr(), opt_consumer_stream);
+        // but I'm not sure if a call to c10::cuda::xyz here will allow a CPU-only build to compile.
       }
     } else {
       // (1) non-CUDA variable


### PR DESCRIPTION
While putting finishing touches on the gradient scaling PR (https://github.com/pytorch/pytorch/pull/26512), I discovered my multi-GPU test (which uses `to()` to transfer tensors between devices) was intermittently failing with bad numerics.  I knew it was going to be [a weird case from the start](https://www.imdb.com/title/tt8946378/quotes/qt4868203) and spent a week descending into madness.  It turns out, for backward ops that create gradients on a different device from the device on whose stream the op is executed, the streaming backward synchronizations in [input_buffer.cpp](https://github.com/pytorch/pytorch/blob/master/torch/csrc/autograd/input_buffer.cpp#L46-L83) do not properly tell later ops to wait on the population/creation of those gradients.  For example, a cross-device `to()` backward (CopyBackward Node) enqueues a cudaMemcpyAsync on the current stream of the source (incoming gradient's) device, then [syncs getCurrentCUDAStream on the destination device with the cudaMemcpyAsync](https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/cuda/Copy.cu#L76).  However, `input_buffer.cpp` in such cases ([case (3)](https://github.com/pytorch/pytorch/blob/master/torch/csrc/autograd/input_buffer.cpp#L77-L81)) was not properly telling `opt_consumer_stream` to wait on the current stream of the destination device (`var`'s device).

Circumstances needed to repro in current master (see [my test](https://github.com/pytorch/pytorch/compare/master...mcarilli:backward_to_race_fix#diff-e68a7bc6ba14f212e5e7eb3727394b40R1901)):
- 2 devices, with non-default streams used for forward-pass ops on both devices (which is the default behavior in test_cuda.py)
- A `to()` that transfers a tensor requiring grad from one device to another (other cross-device ops like broadcast are also vulnerable, but `to()` is the most natural/commonly used)
- A backward pass that routes back through `to()`'s backward (aka CopyBackward).

Under these circumstances, backward ops following CopyBackward on CopyBackward's destination device (aka the original forward-pass source device) race with the device-to-device transfer, and execute using partially-transferred data.

The present PR fixes the race condition and ensures that later ops wait on the CopyBackward transfer.  This PR should also make streaming backward safe for other backward ops that span devices, as long as they play nice and populate any new gradients they create using the "current stream" of the device(s) on which they create those gradients.

There are a couple minor issues where I'm not sure of the best approach:
- Should we guard onto the var's device for the entire body of InputBuffer::add?
- I'm fairly sure we need to `recordStream` on `var` if the consumer stream is different from the stream on which (we expect) `var` was created, but calling `c10::cuda::CUDACachingAllocator::recordStream` in input_buffer.cpp might break CPU-only builds.  I couldn't find a different API call to record streams that seemed CPU-build-agnostic.  Could I wrap the call with a macro?

Thanks to @mruberry for helpful suggestions and also the organization/naming of the stream pool and streaming backward code that allowed me to (just barely) wrap my head around the issue. 