### PR TITLE
caffe2/core/plan_executor: add cancellation of async nets on error + propagate exceptions via std::exception_ptr for stack traces

### DIFF
--- a/caffe2/core/net.h
+++ b/caffe2/core/net.h
@@ -62,6 +62,8 @@ class CAFFE2_API NetBase : public Observable<NetBase> {
 
   virtual bool RunAsync();
 
+  virtual void Cancel() {}
+
   /* Benchmarks a network for one individual run so that we can feed new
    * inputs on additional calls.
    * This function returns the number of microseconds spent

--- a/caffe2/core/net_async_scheduling.h
+++ b/caffe2/core/net_async_scheduling.h
@@ -14,7 +14,7 @@ class CAFFE2_API AsyncSchedulingNet : public AsyncNetBase {
 
   void Wait() override;
 
-  void Cancel();
+  void Cancel() override;
 
  protected:
   bool RunAsync() override;

--- a/caffe2/core/plan_executor.cc
+++ b/caffe2/core/plan_executor.cc
@@ -21,6 +21,36 @@ namespace caffe2 {
 
 namespace {
 
+class ExceptionWrapper {
+ public:
+  ExceptionWrapper() : hasException_(false) {}
+  ExceptionWrapper(const std::exception& ex)
+      : hasException_(true), exceptionMsg_(ex.what()) {
+#ifdef CAFFE2_USE_EXCEPTION_PTR
+    exception_ = std::current_exception();
+#endif
+  }
+
+  void rethrowException() {
+#ifdef CAFFE2_USE_EXCEPTION_PTR
+    std::rethrow_exception(exception_);
+#else
+    CAFFE_THROW(exceptionMsg_);
+#endif
+  }
+
+  operator bool() {
+    return hasException_;
+  }
+
+ private:
+  bool hasException_;
+#ifdef CAFFE2_USE_EXCEPTION_PTR
+  std::exception_ptr exception_;
+#endif
+  std::string exceptionMsg_;
+};
+
 struct NetDefInfo {
   const NetDef* netDef;
   // in order to keep the "override existing nets" on the top-level workflow,
@@ -100,7 +130,9 @@ std::function<bool(int64_t)> getContinuationTest(
 
 // if the blob doesn't exist or is not initialized, return false
 inline bool getShouldStop(const Blob* b) {
-  if (!b || b->meta().id() == TypeIdentifier::uninitialized()) { // not exist or uninitialized
+  if (!b ||
+      b->meta().id() ==
+          TypeIdentifier::uninitialized()) { // not exist or uninitialized
     return false;
   }
 
@@ -223,6 +255,8 @@ struct ExecutionStepWrapper {
     return guard;
   }
 
+  void Cancel();
+
  private:
   std::unique_ptr<CompiledExecutionStep> doCompile();
 
@@ -321,6 +355,24 @@ struct CompiledExecutionStep {
     };
   }
 
+  // Cancel attempts to cancel the running nets in a best effort way. If the net
+  // or op type does IO and doesn't implement cancellation it may not be
+  // possible to cancel leading to execution getting stuck on error.
+  void Cancel() {
+    for (auto& substep : reportSubsteps) {
+      substep->Cancel();
+    }
+    for (auto& substep : recurringSubsteps) {
+      substep->Cancel();
+    }
+    for (auto& net : networks) {
+      net->Cancel();
+    }
+    if (reportNet) {
+      reportNet->Cancel();
+    }
+  }
+
   const ExecutionStep* step;
   Workspace* workspace;
   vector<std::shared_ptr<ExecutionStepWrapper>> reportSubsteps;
@@ -336,6 +388,12 @@ struct CompiledExecutionStep {
  private:
   std::unique_ptr<Workspace> localWorkspace_;
 };
+
+void ExecutionStepWrapper::Cancel() {
+  if (compiledStep_) {
+    compiledStep_->Cancel();
+  }
+}
 
 std::unique_ptr<CompiledExecutionStep> ExecutionStepWrapper::doCompile() {
   return std::unique_ptr<CompiledExecutionStep>(new CompiledExecutionStep(
@@ -403,7 +461,7 @@ bool ExecuteStepRecursive(ExecutionStepWrapper& stepWrapper) {
 
         std::atomic<int> next_substep{0};
         std::mutex exception_mutex;
-        string first_exception;
+        ExceptionWrapper first_exception;
         auto worker = [&]() {
           auto num_substeps = compiledStep->recurringSubsteps.size();
           int substep_id = next_substep++ % num_substeps;
@@ -417,11 +475,13 @@ bool ExecuteStepRecursive(ExecutionStepWrapper& stepWrapper) {
             }
           } catch (const std::exception& ex) {
             std::lock_guard<std::mutex> guard(exception_mutex);
-            if (!first_exception.size()) {
-              first_exception = c10::GetExceptionString(ex);
-              LOG(ERROR) << "Parallel worker exception:\n" << first_exception;
+            if (!first_exception) {
+              first_exception = ExceptionWrapper(ex);
+              LOG(ERROR) << "Parallel worker exception:\n"
+                         << c10::GetExceptionString(ex);
             }
             compiledStep->gotFailure = true;
+            compiledStep->Cancel();
             if (!FLAGS_caffe2_handle_executor_threads_exceptions) {
               // In complex plans other threads might get stuck if another
               // one fails. So we let exception to go out of thread which
@@ -445,10 +505,8 @@ bool ExecuteStepRecursive(ExecutionStepWrapper& stepWrapper) {
         }
         if (compiledStep->gotFailure) {
           LOG(ERROR) << "One of the workers failed.";
-          if (first_exception.size()) {
-            CAFFE_THROW(
-                "One of the workers died with an unhandled exception ",
-                first_exception);
+          if (first_exception) {
+            first_exception.rethrowException();
           }
           return false;
         }
@@ -473,7 +531,7 @@ bool ExecuteStepRecursive(ExecutionStepWrapper& stepWrapper) {
 }
 
 #undef CHECK_SHOULD_STOP
-}
+} // namespace
 
 bool RunPlanOnWorkspace(
     Workspace* ws,
@@ -519,4 +577,4 @@ bool RunPlanOnWorkspace(
   LOG(INFO) << "Plan " << plan.name() << " executed successfully.";
   return true;
 }
-}
+} // namespace caffe2

--- a/caffe2/core/plan_executor_test.cc
+++ b/caffe2/core/plan_executor_test.cc
@@ -1,0 +1,144 @@
+#include <gtest/gtest.h>
+#include "caffe2/core/init.h"
+#include "caffe2/core/operator.h"
+#include "caffe2/core/plan_executor.h"
+
+namespace caffe2 {
+
+TEST(PlanExecutorTest, EmptyPlan) {
+  PlanDef plan_def;
+  Workspace ws;
+  EXPECT_TRUE(ws.RunPlan(plan_def));
+}
+
+namespace {
+static std::atomic<int> cancelCount{0};
+static std::atomic<bool> stuckRun{false};
+} // namespace
+
+class StuckAsyncOp final : public Operator<CPUContext> {
+ public:
+  StuckAsyncOp(const OperatorDef& operator_def, Workspace* ws)
+      : Operator<CPUContext>(operator_def, ws) {}
+
+  bool RunOnDevice() override {
+    // notify Error op we've ran.
+    stuckRun = true;
+    // explicitly don't call SetFinished so this gets stuck
+    return true;
+  }
+
+  void CancelAsyncCallback() override {
+    LOG(INFO) << "cancelled";
+    cancelCount += 1;
+  }
+
+  bool HasAsyncPart() const override {
+    return true;
+  }
+};
+
+REGISTER_CPU_OPERATOR(StuckAsync, StuckAsyncOp);
+OPERATOR_SCHEMA(StuckAsync).NumInputs(0).NumOutputs(0);
+
+class TestError : public std::exception {
+  const char* what() const noexcept override {
+    return "test error";
+  }
+};
+
+class ErrorOp final : public Operator<CPUContext> {
+ public:
+  ErrorOp(const OperatorDef& operator_def, Workspace* ws)
+      : Operator<CPUContext>(operator_def, ws) {}
+
+  bool RunOnDevice() override {
+    // Wait for StuckAsyncOp to run first.
+    while (!stuckRun) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    throw TestError();
+    return true;
+  }
+};
+
+REGISTER_CPU_OPERATOR(Error, ErrorOp);
+OPERATOR_SCHEMA(Error).NumInputs(0).NumOutputs(0);
+
+PlanDef parallelErrorPlan() {
+  PlanDef plan_def;
+
+  auto* stuck_net = plan_def.add_network();
+  stuck_net->set_name("stuck_net");
+  stuck_net->set_type("async_scheduling");
+  {
+    auto* op = stuck_net->add_op();
+    op->set_type("StuckAsync");
+  }
+
+  auto* error_net = plan_def.add_network();
+  error_net->set_name("error_net");
+  error_net->set_type("async_scheduling");
+  {
+    auto op = error_net->add_op();
+    op->set_type("Error");
+  }
+
+  auto* execution_step = plan_def.add_execution_step();
+  execution_step->set_concurrent_substeps(true);
+  {
+    auto* substep = execution_step->add_substep();
+    substep->add_network(stuck_net->name());
+  }
+  {
+    auto* substep = execution_step->add_substep();
+    substep->add_network(error_net->name());
+  }
+
+  return plan_def;
+}
+
+struct HandleExecutorThreadExceptionsGuard {
+  HandleExecutorThreadExceptionsGuard() {
+    globalInit({
+        "caffe2",
+        "--caffe2_handle_executor_threads_exceptions=1",
+    });
+  }
+
+  ~HandleExecutorThreadExceptionsGuard() {
+    globalInit({
+        "caffe2",
+    });
+  }
+
+  HandleExecutorThreadExceptionsGuard(
+      const HandleExecutorThreadExceptionsGuard&) = delete;
+  void operator=(const HandleExecutorThreadExceptionsGuard&) = delete;
+
+ private:
+  void globalInit(std::vector<std::string> args) {
+    std::vector<char*> args_ptrs;
+    for (auto& arg : args) {
+      args_ptrs.push_back(const_cast<char*>(arg.data()));
+    }
+    char** new_argv = args_ptrs.data();
+    int new_argc = args.size();
+    CAFFE_ENFORCE(GlobalInit(&new_argc, &new_argv));
+  }
+};
+
+TEST(PlanExecutorTest, ErrorAsyncPlan) {
+  HandleExecutorThreadExceptionsGuard guard;
+
+  PlanDef plan_def = parallelErrorPlan();
+  Workspace ws;
+#ifdef ANDROID
+  ASSERT_THROW(ws.RunPlan(plan_def), c10::Error);
+#else
+  ASSERT_THROW(ws.RunPlan(plan_def), TestError);
+#endif
+  ASSERT_EQ(cancelCount, 1);
+}
+
+} // namespace caffe2


### PR DESCRIPTION
Summary:
This has two parts:
* When `--caffe2_handle_executor_threads_exceptions` is set when a parallel execution step throws an exception it can hang waiting for async nets to finish. This adds cancellation code to cancel any async nets.
* This makes the exceptions returned from parallel workers pass a std::exception_ptr so the stack trace can be recorded with folly::SmartExceptionTracer. This does use newer C++ features but per from recent discussion all C++14 features can be used now.

Test Plan: buck test //caffe2/caffe2:caffe2_test_cpu

Differential Revision: D19320177

