### PR TITLE
[quant] Remove qconfig_dict in top level eager mode quantization API

### DIFF
--- a/torch/quantization/quantize.py
+++ b/torch/quantization/quantize.py
@@ -122,10 +122,10 @@ def add_quant_dequant(module):
         module._modules[name] = add_quant_dequant(child)
     return module
 
-def prepare(model, qconfig_dict=None, inplace=False):
+def prepare(model, inplace=False):
     r"""Prepares a copy of the model for quantization calibration or quantization-aware training.
 
-    Quantization configuration can be passed as an `qconfig_dict` or assigned preemptively
+    Quantization configuration should be assigned preemptively
     to individual submodules in `.qconfig` attribute.
 
     The model will be attached with observer or fake quant modules, and qconfig
@@ -133,10 +133,6 @@ def prepare(model, qconfig_dict=None, inplace=False):
 
     Args:
         model: input model to be modified in-place
-        qconfig_dict: dictionary that maps from name or type of submodule to quantization
-            configuration, qconfig applies to all submodules of a given
-            module unless qconfig for the submodules are specified (when the
-            submodule already has qconfig attribute)
         inplace: carry out model transformations in-place, the original module is mutated
     """
     if not inplace:
@@ -248,8 +244,8 @@ def prepare_qat(model, mapping=None, inplace=False):
     Prepares a copy of the model for quantization calibration or
     quantization-aware training and convers it to quantized version.
 
-    Quantization configuration can be passed as an `qconfig_dict` or assigned
-    preemptively to individual submodules in `.qconfig` attribute.
+    Quantization configuration should be assigned preemptively
+    to individual submodules in `.qconfig` attribute.
 
     Args:
         model: input model to be modified in-place


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#31972 [quant] Remove qconfig_dict in top level eager mode quantization API**

Summary:
Since eager mode quantization requires many user modifications, we can't
consistently quantize a given model by just changing qconfig_dict, therefore
the top level `qconfig_dict` is not that useful.
fixes: https://github.com/pytorch/pytorch/issues/31549

Test Plan:
.

Reviewers:
pt1quant

Subscribers:

Tasks:

Tags:

Differential Revision: [D19330691](https://our.internmc.facebook.com/intern/diff/D19330691)