### PR TITLE
Scale init for batch-norm and layer-norm

### DIFF
--- a/caffe2/python/layers/batch_normalization.py
+++ b/caffe2/python/layers/batch_normalization.py
@@ -19,6 +19,7 @@ class BatchNormalization(ModelLayer):
         bias_optim=None,
         momentum=0.9,
         order='NCHW',
+        scale_init_value=1.0,
         **kwargs
     ):
         super(BatchNormalization, self).__init__(
@@ -50,7 +51,7 @@ class BatchNormalization(ModelLayer):
 
         self.scale = self.create_param(param_name='scale',
                                        shape=[input_dims],
-                                       initializer=('ConstantFill', {'value': 1.0}),
+                                       initializer=('ConstantFill', {'value': scale_init_value}),
                                        optimizer=scale_optim)
         self.bias = self.create_param(param_name='bias',
                                        shape=[input_dims],

--- a/caffe2/python/layers/layer_normalization.py
+++ b/caffe2/python/layers/layer_normalization.py
@@ -20,6 +20,7 @@ class LayerNormalization(ModelLayer):
         epsilon=1e-4,
         axis=1,
         use_layer_norm_op=True,
+        scale_init_value=1.0,
         **kwargs
     ):
         super(LayerNormalization, self).__init__(
@@ -42,7 +43,7 @@ class LayerNormalization(ModelLayer):
 
         self.scale = self.create_param(param_name='scale',
                                        shape=[input_dims],
-                                       initializer=('ConstantFill', {'value': 1.0}),
+                                       initializer=('ConstantFill', {'value': scale_init_value}),
                                        optimizer=scale_optim)
         self.bias = self.create_param(param_name='bias',
                                        shape=[input_dims],

--- a/caffe2/python/normalizer.py
+++ b/caffe2/python/normalizer.py
@@ -20,23 +20,25 @@ class Normalizer(object):
 
 
 class BatchNormalizer(Normalizer):
-    def __init__(self, momentum):
+    def __init__(self, momentum, scale_init_value=1.0):
         super(BatchNormalizer, self).__init__()
         self._momentum = float(momentum)
+        self._scale_init_value = float(scale_init_value)
 
     def _run(self, layer_model, param):
         return layer_model.BatchNormalization(
-            param, momentum=self._momentum
+            param, momentum=self._momentum, scale_init_value=self._scale_init_value
         )
 
 
 class LayerNormalizer(Normalizer):
-    def __init__(self, epsilon, use_layer_norm_op=True):
+    def __init__(self, epsilon, use_layer_norm_op=True, scale_init_value=1.0):
         super(LayerNormalizer, self).__init__()
         self._epsilon = float(epsilon)
         self._use_layer_norm_op = use_layer_norm_op
+        self._scale_init_value = float(scale_init_value)
 
     def _run(self, layer_model, param):
         return layer_model.LayerNormalization(
-            param, epsilon=self._epsilon, use_layer_norm_op=self._use_layer_norm_op
+            param, epsilon=self._epsilon, use_layer_norm_op=self._use_layer_norm_op, scale_init_value=self._scale_init_value
         )


### PR DESCRIPTION
Summary:
Per discussion with Fei Tian, we need to add a `scale_init_value` to scale down the output of normalization such as batch-norm and layer-norm.

Currently we have `sparse_normalization_options` to normalize embedding pooling output. By default, scale = 1.0, we found it's better to set scale from 0.025 to 0.1 https://fb.quip.com/MiKUAibEaYhH

Besides, I am removing the tags from normalizers because it makes more sense to calculate norm ops in distributed trainers, not ps.

Test Plan:
Testing LN and BN after sum-pooling --
baseline f160348514
LN: f160348609
BN: f160348710

{F226106518}

Layer norm after sum-pooling fwd_net https://fburl.com/sa4j207n
Layer norm after dot-prod fwd_net https://fburl.com/twggwyvb

## Unit Tests
Testing normalization after pooling
```
buck test caffe2/caffe2/fb/dper/layer_models/tests/split_1:sparse_nn_test_4 -- test_sparse_pooling_batch_normalization
buck test caffe2/caffe2/fb/dper/layer_models/tests/split_1:sparse_nn_test_4 -- test_dense_sparse_pooling_batch_normalization
buck test caffe2/caffe2/fb/dper/layer_models/tests/split_1:sparse_nn_test_4 -- test_sparse_pooling_layer_normalization
buck test caffe2/caffe2/fb/dper/layer_models/tests/split_1:sparse_nn_test_4 -- test_dense_sparse_pooling_layer_normalization
```

Testing normalization after dot-prod
```
buck test caffe2/caffe2/fb/dper/layer_models/tests/split_1:sparse_nn_test -- test_last_layer_use_batch_norm
buck test caffe2/caffe2/fb/dper/layer_models/tests/split_1:sparse_nn_test -- test_last_layer_use_layer_norm
```

Differential Revision: D19277618

