### PR TITLE
Add allow_rebase_history flag to differentiable views

### DIFF
--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -145,6 +145,10 @@ namespace impl {
   /// Variable.
   TORCH_API void rebase_history(const Variable&, Edge gradient_edge);
 
+  /// Mark a view such that its history cannot be rebased.
+  /// This is only valid to call on views.
+  TORCH_API void disable_rebase_history(Variable&);
+
   /// Gets the raw gradient function pointer, whatever it currently is.
   TORCH_API Node* grad_fn_unsafe(const Variable&);
 
@@ -323,6 +327,10 @@ struct TORCH_API DifferentiableViewMeta : public AutogradMeta {
   /// grad_fn field is stale if attr_version !=
   /// version_counter.current_version().
   uint32_t attr_version;
+
+  /// Boolean flag that signifies if the history of this Tensor can be rebased
+  /// or if it is forbidden.
+  bool allow_rebase_history;
 
   bool requires_grad() const override {
     return requires_grad_ || grad_fn_ || (is_view_ && base_.requires_grad());


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #31990 Make autogen functions correct for multiple outputs and views
* **#31989 Add allow_rebase_history flag to differentiable views**

This PR adds a new flag to the autograd metadata of the views.
This flag can be set to forbid rebasing the history of a given view.

This is needed to ensure correctness of some of the autograd constructs we currently use (and that are broken if their history is rebased).
