### PR TITLE
Abstract atomic add calls

### DIFF
--- a/aten/src/ATen/native/cuda/AdaptiveAveragePooling.cu
+++ b/aten/src/ATen/native/cuda/AdaptiveAveragePooling.cu
@@ -5,6 +5,7 @@
 #include "ATen/TensorUtils.h"
 #include "ATen/Utils.h"
 #include "c10/util/Exception.h"
+#include <THC/THCAtomics.cuh>
 #include <THC/THCGeneral.h>
 #include "THC/THCNumerics.cuh"
 #include <ATen/native/cuda/LaunchUtils.h>
@@ -199,7 +200,7 @@ namespace {
         for(ih = 0; ih < kH; ++ih) {
           for(iw = 0; iw < kW; ++iw) {
             // atomic add since different threads could update same variable
-            atomicAdd(&(ptr_gradInput[iw]), grad_delta);
+            gpuAtomicAdd(&(ptr_gradInput[iw]), grad_delta);
           }
           ptr_gradInput += isizeW; // next input line
         }

--- a/aten/src/ATen/native/cuda/AdaptiveAveragePooling3d.cu
+++ b/aten/src/ATen/native/cuda/AdaptiveAveragePooling3d.cu
@@ -6,7 +6,7 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <THC/THCGeneral.h>
 #include <THC/THCNumerics.cuh>
-#include <THC/THCAtomics.cuh>  // for atomicAdd
+#include <THC/THCAtomics.cuh>  // for gpuAtomicAdd
 #include <c10/util/Exception.h>
 
 #include <algorithm>
@@ -287,7 +287,7 @@ __global__ void atomicadaptiveaveragegradinput(
       for (it = 0; it < kT; ++it) {
         for (ih = 0; ih < kH; ++ih) {
           for (iw = 0; iw < kW; ++iw) {
-            atomicAdd(&(ptr_gradInput[ih*isizeW + iw]), grad_delta);
+            gpuAtomicAdd(&(ptr_gradInput[ih*isizeW + iw]), grad_delta);
           }
         }
         ptr_gradInput += isizeH*isizeW; // next input frame

--- a/aten/src/ATen/native/cuda/AdaptiveMaxPooling2d.cu
+++ b/aten/src/ATen/native/cuda/AdaptiveMaxPooling2d.cu
@@ -5,6 +5,7 @@
 #include <ATen/TensorUtils.h>
 #include <ATen/Utils.h>
 #include <c10/util/Exception.h>
+#include <THC/THCAtomics.cuh>
 #include <THC/THCGeneral.h>
 #include <THC/THCNumerics.cuh>
 
@@ -184,7 +185,7 @@ __global__ void atomicadaptivemaxgradinput(
       int argmax = (*ptr_ind);
 
       // atomic add since different threads could update same variable
-      atomicAdd(&(gradInput[argmax]), z);
+      gpuAtomicAdd(&(gradInput[argmax]), z);
     }
   }
 }

--- a/aten/src/ATen/native/cuda/AdaptiveMaxPooling3d.cu
+++ b/aten/src/ATen/native/cuda/AdaptiveMaxPooling3d.cu
@@ -5,6 +5,7 @@
 #include <ATen/TensorUtils.h>
 #include <ATen/Utils.h>
 #include <c10/util/Exception.h>
+#include <THC/THCAtomics.cuh>
 #include <THC/THCGeneral.h>
 #include <THC/THCNumerics.cuh>
 
@@ -262,7 +263,7 @@ __global__ void atomicadaptivemaxgradinput(
       int64_t *ptr_ind = indices_dt + oh*osizeW + ow;
       T grad_delta = *ptr_gradOutput;
       int64_t argmax = (*ptr_ind);
-      atomicAdd(&(gradInput_d[argmax]), grad_delta);
+      gpuAtomicAdd(&(gradInput_d[argmax]), grad_delta);
     }
   }
 }

--- a/aten/src/ATen/native/cuda/DilatedMaxPool3d.cu
+++ b/aten/src/ATen/native/cuda/DilatedMaxPool3d.cu
@@ -5,6 +5,7 @@
 #include <ATen/cuda/detail/TensorInfo.cuh>
 #include <ATen/cuda/detail/IndexUtils.cuh>
 #include <ATen/cuda/detail/KernelUtils.h>
+#include <THC/THCAtomics.cuh>
 #include <THC/THCNumerics.cuh>
 #include <c10/macros/Macros.h>
 
@@ -226,7 +227,7 @@ __global__ static void max_pool3d_with_indices_backward_single_out_frame(
   {
     int maxIndex = indices[slice][oFrame][oRow][oColumn];
     if (maxIndex != -1) {
-      atomicAdd(&gradInputData[slice * itime * iheight * iwidth + maxIndex],
+      gpuAtomicAdd(&gradInputData[slice * itime * iheight * iwidth + maxIndex],
                 gradOutput[slice][oFrame][oRow][oColumn]);
     }
   }

--- a/aten/src/ATen/native/cuda/EmbeddingBag.cu
+++ b/aten/src/ATen/native/cuda/EmbeddingBag.cu
@@ -208,7 +208,7 @@ __global__ void EmbeddingBag_accGradParametersKernel_max(
       int64_t word_idx = max_indices[bag * stride + featureDim];
       if (word_idx >= 0) {
         // If bag is empty, we have max_indices[idx] set to -1 in forward.
-        atomicAdd(&(gradWeight[word_idx * stride + featureDim]),
+        gpuAtomicAdd(&(gradWeight[word_idx * stride + featureDim]),
                 gradOutput[bag * stride + featureDim]);
       }
     }

--- a/aten/src/ATen/native/cuda/FractionalMaxPool2d.cu
+++ b/aten/src/ATen/native/cuda/FractionalMaxPool2d.cu
@@ -8,6 +8,7 @@
 #include <ATen/TensorUtils.h>
 #include <ATen/Utils.h>
 #include <c10/util/Exception.h>
+#include <THC/THCAtomics.cuh>
 
 #include <algorithm>
 #include <cfloat>
@@ -115,7 +116,7 @@ __global__ void fractional_max_pool2d_backward_out_cuda_frame(
     int inputH = index / gradInput.size(3);
     assert(inputH < gradInput.size(2));
 
-    atomicAdd(
+    gpuAtomicAdd(
       &gradInput[batch][plane][inputH][inputW],
       gradOutput[batch][plane][outputH][outputW]
     );

--- a/aten/src/ATen/native/cuda/FractionalMaxPool3d.cu
+++ b/aten/src/ATen/native/cuda/FractionalMaxPool3d.cu
@@ -9,6 +9,7 @@
 #include <ATen/TensorUtils.h>
 #include <ATen/Utils.h>
 #include <c10/util/Exception.h>
+#include <THC/THCAtomics.cuh>
 
 #include <algorithm>
 #include <cfloat>
@@ -135,7 +136,7 @@ __global__ void fractional_max_pool3d_backward_out_frame(
       gradInput.size(4));
     assert(inputT < gradInput.size(2));
 
-    atomicAdd(
+    gpuAtomicAdd(
       &gradInput[batch][plane][inputT][inputH][inputW],
       gradOutput[batch][plane][outputT][outputH][outputW]
       );

--- a/aten/src/ATen/native/cuda/GridSampler.cuh
+++ b/aten/src/ATen/native/cuda/GridSampler.cuh
@@ -1,6 +1,7 @@
 #include <ATen/ATen.h>
 #include <ATen/NativeFunctions.h>
 #include <ATen/cuda/CUDAApplyUtils.cuh>
+#include <THC/THCAtomics.cuh>
 
 namespace at { namespace native {
 
@@ -213,7 +214,7 @@ void safe_add_2d(scalar_t *data, int h, int w,
                  int sH, int sW, int H, int W,
                  scalar_t delta) {
   if (within_bounds_2d(h, w, H, W)) {
-    atomicAdd(data + h * sH + w * sW, delta);
+    gpuAtomicAdd(data + h * sH + w * sW, delta);
   }
 }
 
@@ -223,7 +224,7 @@ void safe_add_3d(scalar_t *data, int d, int h, int w,
                  int sD, int sH, int sW, int D, int H, int W,
                  scalar_t delta) {
   if (within_bounds_3d(d, h, w, D, H, W)) {
-    atomicAdd(data + d * sD + h * sH + w * sW, delta);
+    gpuAtomicAdd(data + d * sD + h * sH + w * sW, delta);
   }
 }
 

--- a/aten/src/ATen/native/cuda/KernelUtils.cuh
+++ b/aten/src/ATen/native/cuda/KernelUtils.cuh
@@ -1,5 +1,6 @@
 #pragma once
 #include <ATen/ATen.h>
+#include <THC/THCAtomics.cuh>
 
 namespace at {
 namespace native {
@@ -16,7 +17,7 @@ __device__ __forceinline__ void fastSpecializedAtomicAdd(
 #if (                         \
     (CUDA_VERSION < 10000) || \
     (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 700)))
-  atomicAdd(
+  gpuAtomicAdd(
       reinterpret_cast<at::Half*>(tensor) + index,
       static_cast<at::Half>(value));
 #else
@@ -51,7 +52,7 @@ __device__ __forceinline__ void fastSpecializedAtomicAdd(
     size_t index,
     const size_t numel,
     scalar_t value) {
-  atomicAdd(tensor + index, value);
+  gpuAtomicAdd(tensor + index, value);
 }
 
 template <class scalar_t>
@@ -64,7 +65,7 @@ __device__ __forceinline__ void fastAtomicAdd(
   if (fast_atomics) {
     fastSpecializedAtomicAdd(tensor, index, numel, value);
   } else {
-    atomicAdd(tensor + index, value);
+    gpuAtomicAdd(tensor + index, value);
   }
 }
 

--- a/aten/src/ATen/native/cuda/LossCTC.cu
+++ b/aten/src/ATen/native/cuda/LossCTC.cu
@@ -16,6 +16,8 @@
 #include <ATen/Dispatch.h>
 #include <ATen/cuda/CUDAApplyUtils.cuh>
 
+#include <THC/THCAtomics.cuh>
+
 #include <type_traits>
 #include <numeric>
 
@@ -453,7 +455,7 @@ ctc_loss_backward_collect_nonblank_gpu_kernel(scalar_t* __restrict__ gradient_da
 
   for (int64_t t = 0; t < input_length; t++) {
     scalar_t lp = log_probs_data[lp_batch_offset + t * lp_input_stride + lp_char_stride * target];
-    atomicAdd(&gradient_data[gr_batch_offset + t * gr_input_stride + gr_char_stride * target],
+    gpuAtomicAdd(&gradient_data[gr_batch_offset + t * gr_input_stride + gr_char_stride * target],
               -std::exp(log_alpha_data[la_batch_offset + la_input_stride * t + la_target_stride * (s*2+1)]
                         + log_beta_data[lb_batch_offset + lb_input_stride * t + lb_target_stride * (s*2+1)]
                         + nll - lp) * gr);

--- a/aten/src/ATen/native/cuda/ReflectionPad.cu
+++ b/aten/src/ATen/native/cuda/ReflectionPad.cu
@@ -4,7 +4,7 @@
 #include <ATen/NativeFunctions.h>
 #include <ATen/TensorUtils.h>
 #include <ATen/Utils.h>
-// keeping THC headers for atomicAdd
+// keeping THC headers for gpuAtomicAdd
 #include <THC/THCAtomics.cuh>
 
 #include <thrust/pair.h>
@@ -101,7 +101,7 @@ __global__ void reflection_pad1d_backward_out_kernel(
 
   if (output_x < output_w) {
     auto index_pair = get_index_mapping1d(input_w, output_w, output_x, pad_l);
-    atomicAdd(
+    gpuAtomicAdd(
       &grad_input[index_pair.first], grad_output[index_pair.second]);
   }
 }
@@ -142,7 +142,7 @@ __global__ void reflection_pad2d_backward_out_kernel(
       pad_l, pad_t,
       output_xy);
 
-    atomicAdd(&grad_input[index_pair.first], grad_output[index_pair.second]);
+    gpuAtomicAdd(&grad_input[index_pair.first], grad_output[index_pair.second]);
   }
 }
 

--- a/aten/src/ATen/native/cuda/ReplicationPadding.cu
+++ b/aten/src/ATen/native/cuda/ReplicationPadding.cu
@@ -5,6 +5,7 @@
 #include "ATen/TensorUtils.h"
 #include "ATen/Utils.h"
 #include "c10/util/Exception.h"
+#include <THC/THCAtomics.cuh>
 #include <THC/THCGeneral.h>
 #include "THC/THCNumerics.cuh"
 #include "THC/THCDeviceUtils.cuh"
@@ -68,7 +69,7 @@ __global__ void replication_pad_backward_kernel(
   int inputPointX = imin(imax(padL, outputPointX), gradInput.size(2) + padL - 1) - oStartX + iStartX;
 
   scalar_t valueToCopy = gradOutput[batch][plane][outputPointX];
-  atomicAdd(&gradInput[batch][plane][inputPointX], valueToCopy);
+  gpuAtomicAdd(&gradInput[batch][plane][inputPointX], valueToCopy);
 }
 
 template <typename scalar_t>
@@ -122,7 +123,7 @@ __global__ void replication_pad_backward_kernel(
   int inputPointY = imin(imax(padT, outputPointY), gradInput.size(2) + padT - 1) - oStartY + iStartY;
 
   scalar_t valueToCopy = gradOutput[batch][plane][outputPointY][outputPointX];
-  atomicAdd(&gradInput[batch][plane][inputPointY][inputPointX], valueToCopy);
+  gpuAtomicAdd(&gradInput[batch][plane][inputPointY][inputPointX], valueToCopy);
 }
 
 template <typename scalar_t>
@@ -196,7 +197,7 @@ __global__ void replication_pad_backward_kernel(
 
   scalar_t valueToCopy =
     gradOutput[batch][plane][outputPointZ][outputPointY][outputPointX];
-  atomicAdd(&gradInput[batch][plane][inputPointZ][inputPointY][inputPointX],
+  gpuAtomicAdd(&gradInput[batch][plane][inputPointZ][inputPointY][inputPointX],
       valueToCopy);
 }
 

--- a/aten/src/ATen/native/cuda/SortingRadixSelect.cuh
+++ b/aten/src/ATen/native/cuda/SortingRadixSelect.cuh
@@ -1,3 +1,5 @@
+#include <THC/THCAtomics.cuh>
+
 namespace at {
 namespace native {
 
@@ -199,7 +201,7 @@ __device__ void countRadixUsingMask(
   if (getLaneId() == 0) {
 #pragma unroll
     for (uint32_t i = 0; i < RadixSize; ++i) {
-      atomicAdd(&smem[i], counts[i]);
+      gpuAtomicAdd(&smem[i], counts[i]);
     }
   }
 

--- a/aten/src/ATen/native/cuda/UpSample.cuh
+++ b/aten/src/ATen/native/cuda/UpSample.cuh
@@ -1,6 +1,7 @@
 #include <ATen/ATen.h>
 #include <ATen/TensorUtils.h>
 #include <ATen/cuda/CUDAApplyUtils.cuh>
+#include <THC/THCAtomics.cuh>
 
 #include <math.h>
 
@@ -215,7 +216,7 @@ __device__ __forceinline__ static void upsample_increment_value_bounded(
   /* TODO: result here is trucated to scalar_t,
      check: https://github.com/pytorch/pytorch/pull/19630#discussion_r281426912
    */
-  atomicAdd(
+  gpuAtomicAdd(
       &data[batch][channel][access_y][access_x], static_cast<scalar_t>(value));
 }
 

--- a/aten/src/ATen/native/cuda/UpSampleLinear1d.cu
+++ b/aten/src/ATen/native/cuda/UpSampleLinear1d.cu
@@ -8,6 +8,7 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/CUDAApplyUtils.cuh>
 #include <ATen/native/cuda/UpSample.cuh>
+#include <THC/THCAtomics.cuh>
 
 namespace at {
 namespace native {
@@ -103,8 +104,8 @@ __global__ void upsample_linear1d_out_frame_backward(
     for (int n = 0; n < batchsize; n++) {
       for (int c = 0; c < channels; ++c) {
         const scalar_t d2val = odata[n][c][w2];
-        atomicAdd(&idata[n][c][w1], static_cast<scalar_t>(w0lambda * d2val));
-        atomicAdd(
+        gpuAtomicAdd(&idata[n][c][w1], static_cast<scalar_t>(w0lambda * d2val));
+        gpuAtomicAdd(
             &idata[n][c][w1 + w1p], static_cast<scalar_t>(w1lambda * d2val));
       }
     }

--- a/aten/src/ATen/native/cuda/UpSampleTrilinear3d.cu
+++ b/aten/src/ATen/native/cuda/UpSampleTrilinear3d.cu
@@ -8,6 +8,7 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/CUDAApplyUtils.cuh>
 #include <ATen/native/cuda/UpSample.cuh>
+#include <THC/THCAtomics.cuh>
 
 namespace at {
 namespace native {
@@ -161,28 +162,28 @@ __global__ void upsample_trilinear3d_backward_out_frame(
     for (int n = 0; n < batchsize; n++) {
       for (int c = 0; c < channels; ++c) {
         const scalar_t d2val = odata[n][c][t2][h2][w2];
-        atomicAdd(
+        gpuAtomicAdd(
             &idata[n][c][t1][h1][w1],
             static_cast<scalar_t>(t0lambda * h0lambda * w0lambda * d2val));
-        atomicAdd(
+        gpuAtomicAdd(
             &idata[n][c][t1][h1][w1 + w1p],
             static_cast<scalar_t>(t0lambda * h0lambda * w1lambda * d2val));
-        atomicAdd(
+        gpuAtomicAdd(
             &idata[n][c][t1][h1 + h1p][w1],
             static_cast<scalar_t>(t0lambda * h1lambda * w0lambda * d2val));
-        atomicAdd(
+        gpuAtomicAdd(
             &idata[n][c][t1][h1 + h1p][w1 + w1p],
             static_cast<scalar_t>(t0lambda * h1lambda * w1lambda * d2val));
-        atomicAdd(
+        gpuAtomicAdd(
             &idata[n][c][t1 + t1p][h1][w1],
             static_cast<scalar_t>(t1lambda * h0lambda * w0lambda * d2val));
-        atomicAdd(
+        gpuAtomicAdd(
             &idata[n][c][t1 + t1p][h1][w1 + w1p],
             static_cast<scalar_t>(t1lambda * h0lambda * w1lambda * d2val));
-        atomicAdd(
+        gpuAtomicAdd(
             &idata[n][c][t1 + t1p][h1 + h1p][w1],
             static_cast<scalar_t>(t1lambda * h1lambda * w0lambda * d2val));
-        atomicAdd(
+        gpuAtomicAdd(
             &idata[n][c][t1 + t1p][h1 + h1p][w1 + w1p],
             static_cast<scalar_t>(t1lambda * h1lambda * w1lambda * d2val));
       }

--- a/aten/src/THC/THCAtomics.cuh
+++ b/aten/src/THC/THCAtomics.cuh
@@ -178,4 +178,36 @@ static inline __device__ void gpuAtomicAdd(float *address, float val) {
   atomicAdd(address, val);
 }
 
+/* Note [gpuAtomicAdd vs atomicAdd]
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ * We are trying to standardize inside the PyTorch backend on using gpuAtomicAdd()
+ * without a return. These may either be resolved through library functions or
+ * implemented internally. Some extensions such as torchvision call atomicAdd()
+ * directly and require non-library provided data type support. Only for these, we
+ * continue to provide atomicAdd overloads. 
+ */
+static inline __device__ void atomicAdd(at::Half *address, at::Half val) {
+  gpuAtomicAdd(address, val);
+}
+
+static inline __device__ void atomicAdd(uint8_t *address, uint8_t val) {
+  gpuAtomicAdd(address, val);
+}
+
+static inline  __device__ void atomicAdd(int8_t *address, int8_t val) {
+  gpuAtomicAdd(address, val);
+}
+
+static inline  __device__ void atomicAdd(int16_t *address, int16_t val) {
+  gpuAtomicAdd(address, val);
+}
+
+static inline __device__ void atomicAdd(int64_t *address, int64_t val) {
+  gpuAtomicAdd(address, val);
+}
+
+static inline __device__ void atomicAdd(bool *address, bool val) {
+  gpuAtomicAdd(address, val);
+}
+
 #endif // THC_ATOMICS_INC

--- a/aten/src/THC/THCAtomics.cuh
+++ b/aten/src/THC/THCAtomics.cuh
@@ -87,19 +87,23 @@ struct AtomicAddIntegerImpl<T, 8> {
   }
 };
 
-static inline __device__ void atomicAdd(uint8_t *address, uint8_t val) {
+static inline __device__ void gpuAtomicAdd(uint8_t *address, uint8_t val) {
   AtomicAddIntegerImpl<uint8_t, sizeof(uint8_t)>()(address, val);
 }
 
-static inline  __device__ void atomicAdd(int8_t *address, int8_t val) {
+static inline  __device__ void gpuAtomicAdd(int8_t *address, int8_t val) {
   AtomicAddIntegerImpl<int8_t, sizeof(int8_t)>()(address, val);
 }
 
-static inline  __device__ void atomicAdd(int16_t *address, int16_t val) {
+static inline  __device__ void gpuAtomicAdd(int16_t *address, int16_t val) {
   AtomicAddIntegerImpl<int16_t, sizeof(int16_t)>()(address, val);
 }
 
-static inline __device__ void atomicAdd(int64_t *address, int64_t val) {
+static inline __device__ void gpuAtomicAdd(int32_t *address, int32_t val) {
+  atomicAdd(address, val);
+}
+
+static inline __device__ void gpuAtomicAdd(int64_t *address, int64_t val) {
 #ifdef __HIP_PLATFORM_HCC__
   __atomic_fetch_add(address, val, __ATOMIC_RELAXED);
 #else
@@ -107,11 +111,11 @@ static inline __device__ void atomicAdd(int64_t *address, int64_t val) {
 #endif
 }
 
-static inline __device__ void atomicAdd(bool *address, bool val) {
+static inline __device__ void gpuAtomicAdd(bool *address, bool val) {
   *address = address && val;
 }
 
-static inline  __device__ void atomicAdd(at::Half *address, at::Half val) {
+static inline  __device__ void gpuAtomicAdd(at::Half *address, at::Half val) {
   #if ((CUDA_VERSION < 10000) || (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 700)))
     unsigned int * address_as_ui =
       (unsigned int *) ((char *)address - ((size_t)address & 2));
@@ -165,5 +169,13 @@ static inline  __device__  void atomicAdd(double *address, double val) {
   static inline  __device__  void atomicAdd(double *address, double val) { }
 #endif
 #endif
+
+static inline __device__ void gpuAtomicAdd(double *address, double val) {
+  atomicAdd(address, val);
+}
+
+static inline __device__ void gpuAtomicAdd(float *address, float val) {
+  atomicAdd(address, val);
+}
 
 #endif // THC_ATOMICS_INC

--- a/aten/src/THC/THCTensorIndex.cu
+++ b/aten/src/THC/THCTensorIndex.cu
@@ -148,7 +148,7 @@ __global__ void indexAddSmallIndex(TensorInfo<T, IndexType> dst,
         IndexToOffset<T, IndexType, SrcDim>::get(linearIndex, src);
       srcOffset += srcIndex * src.strides[srcAddDim];
 
-      atomicAdd(&dst.data[dstOffset], src.data[srcOffset]);
+      gpuAtomicAdd(&dst.data[dstOffset], src.data[srcOffset]);
     }
   }
 }
@@ -197,7 +197,7 @@ __global__ void indexAddLargeIndex(TensorInfo<T, IndexType> dst,
       IndexToOffset<T, IndexType, SrcDim>::get(elementInSlice, src);
     srcOffset += srcIndex * src.strides[srcAddDim];
 
-    atomicAdd(&dst.data[dstOffset], src.data[srcOffset]);
+    gpuAtomicAdd(&dst.data[dstOffset], src.data[srcOffset]);
   }
 }
 

--- a/aten/src/THC/THCTensorScatterGather.cu
+++ b/aten/src/THC/THCTensorScatterGather.cu
@@ -161,7 +161,7 @@ __global__ void THCudaTensor_scatterAddKernel(
     CUDA_KERNEL_ASSERT(indexValue >= 0 && indexValue < tensor.sizes[dim]);
     tensorOffset += indexValue * tensor.strides[dim];
 
-    atomicAdd(&tensor.data[tensorOffset], src.data[srcOffset]);
+    gpuAtomicAdd(&tensor.data[tensorOffset], src.data[srcOffset]);
   }
 }
 

--- a/aten/src/THCUNN/SpatialClassNLLCriterion.cu
+++ b/aten/src/THCUNN/SpatialClassNLLCriterion.cu
@@ -113,8 +113,8 @@ __global__ void cunn_SpatialClassNLLCriterion_updateOutput_kernel(
   acc_weight = reduceBlock(partial_sums, blockDim.x, acc_weight, thrust::plus<AccumT>(), AccumT(0));
 
   if (threadIdx.x == 0) {
-    atomicAdd(total_weight, ScalarConvert<AccumT, T>::to(acc_weight));
-    atomicAdd(output, ScalarConvert<AccumT, T>::to(input_sum));
+    gpuAtomicAdd(total_weight, ScalarConvert<AccumT, T>::to(acc_weight));
+    gpuAtomicAdd(output, ScalarConvert<AccumT, T>::to(input_sum));
   }
 }
 

--- a/docs/cpp/source/notes/tensor_basics.rst
+++ b/docs/cpp/source/notes/tensor_basics.rst
@@ -79,7 +79,7 @@ CUDA accessors
       PackedTensorAccessor64<float, 2> foo,
       float* trace) {
     int i=threadIdx.x
-    atomicAdd(trace, foo[i][i])
+    gpuAtomicAdd(trace, foo[i][i])
   }
 
   torch::Tensor foo = torch::rand({12, 12});


### PR DESCRIPTION
Instead of a mixture of direct calls to library provided atomicAdd calls, such as float atomicAdd(float*, float) and calls provided internally, such as void atomicAdd(long*, long), abstract to one API void gpuAtomicAdd(T*, T) in THCAtomics.cuh for the PyTorch backend.

The advantage of this approach is that it allows us to more easily distinguish between capabiltiies of different platforms (and their versions). Additionally, the abstraction of void returning atomicAdds allows us to, in the future, support fast HW instructions on some platforms that will not return the previous value.

Call sites that do not satisfy above conditions and are either highly platform specific (__half2 atomicAdd fast path in one operator) or require the return explicitly (some int atomicAdd invocations) are left untouched. The Caffe2 backend also remains untouched.

While here, add a bunch of includes of THCAtomics.cuh that were missing before.