### PR TITLE
Lock graph_task before writing leaf_streams.

### DIFF
--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -562,6 +562,7 @@ void Engine::evaluate_function(
     // Records leaf stream (if applicable)
     // See note "Streaming backwards"
     if (opt_parent_stream) {
+      std::lock_guard<std::mutex> lock(graph_task->mutex_);
       graph_task->leaf_streams.emplace(*opt_parent_stream);
     }
     return;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#31995 Lock graph_task before writing leaf_streams.**

Fixes #31906.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D19331259](https://our.internmc.facebook.com/intern/diff/D19331259)