### PR TITLE
[pytorch] gate torch_global_deps with BUILD_SHARED_LIBS flag

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -1092,24 +1092,25 @@ endif()
 # namespaces, so libtorch is loaded with all its dependencies in a local scope.
 # That usually leads to missing symbol errors at run-time, so to avoid a situation like
 # this we have to preload those libs in a global namespace.
-add_library(torch_global_deps SHARED ${TORCH_SRC_DIR}/csrc/empty.c)
-set_target_properties(torch_global_deps PROPERTIES LINKER_LANGUAGE C)
-if (USE_MPI)
-    target_link_libraries(torch_global_deps ${MPI_CXX_LIBRARIES})
-endif()
-target_link_libraries(torch_global_deps ${MKL_LIBRARIES})
-# The CUDA libraries are linked here for a different reason: in some
-# cases we load these libraries with ctypes, and if they weren't opened
-# with RTLD_GLOBAL, we'll do the "normal" search process again (and
-# not find them, because they're usually in non-standard locations)
-if (USE_CUDA)
-  target_link_libraries(torch_global_deps ${TORCH_CUDA_LIBRARIES})
-  target_link_libraries(torch_global_deps ${Caffe2_PUBLIC_CUDA_DEPENDENCY_LIBS})
-  target_link_libraries(torch_global_deps torch::cudart)
-endif()
+if (BUILD_SHARED_LIBS)
+  add_library(torch_global_deps SHARED ${TORCH_SRC_DIR}/csrc/empty.c)
+  set_target_properties(torch_global_deps PROPERTIES LINKER_LANGUAGE C)
+  if (USE_MPI)
+      target_link_libraries(torch_global_deps ${MPI_CXX_LIBRARIES})
+  endif()
+  target_link_libraries(torch_global_deps ${MKL_LIBRARIES})
+  # The CUDA libraries are linked here for a different reason: in some
+  # cases we load these libraries with ctypes, and if they weren't opened
+  # with RTLD_GLOBAL, we'll do the "normal" search process again (and
+  # not find them, because they're usually in non-standard locations)
+  if (USE_CUDA)
+    target_link_libraries(torch_global_deps ${TORCH_CUDA_LIBRARIES})
+    target_link_libraries(torch_global_deps ${Caffe2_PUBLIC_CUDA_DEPENDENCY_LIBS})
+    target_link_libraries(torch_global_deps torch::cudart)
+  endif()
 
-install(TARGETS torch_global_deps DESTINATION "${TORCH_INSTALL_LIB_DIR}")
-
+  install(TARGETS torch_global_deps DESTINATION "${TORCH_INSTALL_LIB_DIR}")
+endif()
 
 # ---[ Caffe2 HIP sources.
 if(USE_ROCM)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #30937 [pytorch] integrate op dependency analysis process into CI
* #31848 [pytorch] update docker image version
* #32027 [pytorch] skip TEST_DILL on Python2
* **#32011 [pytorch] gate torch_global_deps with BUILD_SHARED_LIBS flag**

Summary:
Run into build problem with Ninja + code analysis build as follows:
```
The install of the torch_global_deps target requires changing an RPATH from
the build tree, but this is not supported with the Ninja generator unless
on an ELF-based platform.
```

Seems we don't need build the target for static build mode?

Verified code analyzer works with the patch.

Differential Revision: [D19336818](https://our.internmc.facebook.com/intern/diff/D19336818)