### PR TITLE
Some Performance Fixes.

### DIFF
--- a/aten/src/ATen/core/ivalue.cpp
+++ b/aten/src/ATen/core/ivalue.cpp
@@ -74,7 +74,7 @@ namespace {
 
 template<class T>
 std::ostream& printList(std::ostream & out, const c10::List<T> &v,
-  const std::string start, const std::string finish) {
+  const std::string &start, const std::string &finish) {
   out << start;
   for(size_t i = 0; i < v.size(); ++i) {
     if(i > 0)
@@ -88,7 +88,7 @@ std::ostream& printList(std::ostream & out, const c10::List<T> &v,
 
 template<class T>
 std::ostream& printList(std::ostream & out, const std::vector<T> &v,
-  const std::string start, const std::string finish) {
+  const std::string &start, const std::string &finish) {
   out << start;
   for(size_t i = 0; i < v.size(); ++i) {
     if(i > 0)

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -469,7 +469,6 @@ static void check_shape_forward(const at::Tensor& input,
       // If kernel size is incorrect
       std::ostringstream input_ss;
       std::ostringstream kernel_ss;
-      std::ostringstream output_ss;
       std::string separator = "";
 
       for (int i = 0, len = input_shape.size(); i < len; ++i) {

--- a/aten/src/ATen/native/Normalization.cpp
+++ b/aten/src/ATen/native/Normalization.cpp
@@ -457,8 +457,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, int64_t> _batch_norm_impl_index(
     check_dims_match_num_input_features("bias", num_features, bias.numel());
   }
 
-  bool use_cudnn = false;
-  use_cudnn = (input.is_cuda()
+  bool use_cudnn = (input.is_cuda()
                && (input.scalar_type() != at::kHalf
                  || weight.scalar_type() == at::kFloat)
                && weight.defined() && bias.defined()

--- a/aten/src/ATen/native/RNN.cpp
+++ b/aten/src/ATen/native/RNN.cpp
@@ -278,12 +278,12 @@ static std::vector<QuantizedCellParams> gather_quantized_params(TensorList param
 static std::vector<QuantizedCellParamsDynamic> gather_quantized_params_dynamic(
     TensorList params) {
   static at::Tensor undefined;
-  std::vector<QuantizedCellParamsDynamic> result;
   TORCH_CHECK(
       params.size() % 2 == 0,
       "got an incorrect number of quantized RNN parameters");
   // PackedLinearWeight is only defined when USE_FBGEMM is defined
 #ifdef USE_FBGEMM
+  std::vector<QuantizedCellParamsDynamic> result;
   for (size_t i = 0; i < params.size(); i += 2) {
     auto& packed_struct_ih =
         cpp_custom_type_hack::cast<PackedLinearWeight>(params[i]);
@@ -1238,7 +1238,7 @@ std::tuple<Tensor, Tensor, Tensor> quantized_lstm(
 #define DEFINE_QUANTIZED_RNN_CELL(name, hx_type, cell_type, return_type, prepare_hx_fn) \
 return_type name( \
     const Tensor& input, \
-    hx_type hx, \
+    hx_type &hx, \
     const Tensor& w_ih, \
     const Tensor& w_hh, \
     const Tensor& b_ih, \

--- a/aten/src/TH/THMemoryFile.cpp
+++ b/aten/src/TH/THMemoryFile.cpp
@@ -563,8 +563,8 @@ static ssize_t THMemoryFile_readString(THFile *self, const char *format, char **
   {
     int8_t *p = THCharStorage_data(mfself->storage)+mfself->position;
     int eolFound = 0;
-    ssize_t posEol;
-    ssize_t i;
+    ssize_t posEol = 0;
+    ssize_t i = 0;
     for(i = 0; i < mfself->size-mfself->position; i++)
     {
       if(p[i] == '\n')

--- a/aten/src/TH/vector/VSX.cpp
+++ b/aten/src/TH/vector/VSX.cpp
@@ -1683,6 +1683,7 @@ void test_THDoubleVector_cadd_VSX()
     free(z_standard);
     free(z_optimized);
     free(x);
+    free(y);
 }
 
 void test_THFloatVector_cadd_VSX()
@@ -1754,6 +1755,7 @@ void test_THFloatVector_cadd_VSX()
     free(z_standard);
     free(z_optimized);
     free(x);
+    free(y);
 }
 
 void test_THDoubleVector_adds_VSX()
@@ -1959,6 +1961,7 @@ void test_THDoubleVector_cmul_VSX()
     free(z_standard);
     free(z_optimized);
     free(x);
+    free(y);
 }
 
 void test_THFloatVector_cmul_VSX()
@@ -2029,6 +2032,7 @@ void test_THFloatVector_cmul_VSX()
     free(z_standard);
     free(z_optimized);
     free(x);
+    free(y);
 }
 
 void test_THDoubleVector_muls_VSX()
@@ -2240,6 +2244,7 @@ void test_THDoubleVector_cdiv_VSX()
     free(z_standard);
     free(z_optimized);
     free(x);
+    free(y);
 }
 
 void test_THFloatVector_cdiv_VSX()
@@ -2310,6 +2315,7 @@ void test_THFloatVector_cdiv_VSX()
     free(z_standard);
     free(z_optimized);
     free(x);
+    free(y);
 }
 
 void test_THDoubleVector_divs_VSX()

--- a/aten/src/THC/THCCachingHostAllocator.cpp
+++ b/aten/src/THC/THCCachingHostAllocator.cpp
@@ -273,7 +273,6 @@ static void THCCachingHostDeleter(void* ptr) {
 
 struct THCCachingHostAllocator final : public at::Allocator {
   at::DataPtr allocate(size_t size) const override {
-    THAssert(size >= 0);
     void *ptr;
     THCudaCheck(allocator.malloc(&ptr, size));
     return {ptr, ptr, &THCCachingHostDeleter, at::DeviceType::CPU};


### PR DESCRIPTION
aten/src/ATen/core/ivalue.cpp: 77 and 91 : Function parameter 'start' and 'finish' should be passed by reference instead of value.

aten/src/ATen/native/Convolution.cpp:472: Removed Unused variable: output_ss

aten/src/ATen/native/Normalization.cpp:460 : Variable 'use_cudnn' declared/defined together

aten/src/ATen/native/RNN.cpp:281: Reduced scope of the variable: result

aten/src/ATen/native/RNN.cpp:1241: Pass hx by reference instead of value.

aten/src/TH/THMemoryFile.cpp:580: initialize posEol, i = 0

aten/src/TH/vector/VSX.cpp: Memory leak: y multiple locations

aten/src/THC/THCCachingHostAllocator.cpp:276: Unsigned variable 'size' can't be negative so it is unnecessary to test it.