### PR TITLE
[pytorch] skip TEST_DILL on Python2

### DIFF
--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -261,7 +261,9 @@ TEST_NUMPY = _check_module_exists('numpy')
 TEST_SCIPY = _check_module_exists('scipy')
 TEST_MKL = torch.backends.mkl.is_available()
 TEST_NUMBA = _check_module_exists('numba')
-TEST_DILL = _check_module_exists('dill')
+
+# Skip the test until issue #28313 gets fixed on Py2.
+TEST_DILL = _check_module_exists('dill') and PY3
 
 # On Py2, importing librosa 0.6.1 triggers a TypeError (if using newest joblib)
 # see librosa/librosa#729.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #30937 [pytorch] integrate op dependency analysis process into CI
* #31848 [pytorch] update docker image version
* **#32027 [pytorch] skip TEST_DILL on Python2**
* #32011 [pytorch] gate torch_global_deps with BUILD_SHARED_LIBS flag

Summary:
The test was added in #30985 for #28313. Seems the fix only works for
Python3 but doesn't work on Python2. The current Python2 CI docker image
doesn't have `dill` module installed at all so it's not captured.

I'm trying to build and push new CI docker image which has `dill` installed
and I verified it's the latest version 0.3.1.1 but the fix doesn't seem
to work and blocks me from upgrading image version. It works for Python3
docker image though...

Here is a succeeded job with old image (no dill installed):
https://app.circleci.com/jobs/github/pytorch/pytorch/4192688

Here is a failed job with new image (dill installed):
https://app.circleci.com/jobs/github/pytorch/pytorch/4192679

This PR bypasses the test for Py2 to unblock docker image change. We
can figure out a proper fix for Py2 later.

Differential Revision: [D19341451](https://our.internmc.facebook.com/intern/diff/D19341451)