### PR TITLE
fix derivative of exponent for tensor^tensor

### DIFF
--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -147,7 +147,7 @@ Tensor pow_backward_self(Tensor grad, const Tensor & self, const Tensor & expone
 }
 
 Tensor pow_backward_exponent(Tensor grad, const Tensor & self, Tensor result) {
-  return grad * result * self.log();
+  return at::where(self == 0, at::zeros({}, grad.options()), grad * result * self.log());
 }
 
 Tensor pow_backward_exponent(Tensor grad, const Scalar & base, Tensor result) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #32063 Fix scalar^tensor derivative for scalars that are zero
* #32062 Fix tensor^tensor derivative for 0 base entries
* **#32061 fix derivative of exponent for tensor^tensor**

