### PR TITLE
[WIP] cap the maximum depth of bailout chains at 1

### DIFF
--- a/torch/csrc/jit/graph_executor.cpp
+++ b/torch/csrc/jit/graph_executor.cpp
@@ -495,7 +495,8 @@ struct GraphExecutorImpl : public GraphExecutorImplBase {
         logging::runtime_counters::GRAPH_EXECUTORS_CONSTRUCTED, 1.0);
   }
 
-  ExecutionPlan getPlanFor(Stack& stack, size_t num_bailouts) override {
+  ExecutionPlan getPlanFor(Stack& stack, size_t remaining_bailout_depth)
+      override {
     return getGraphExecutorOptimize() ? getOrCompile(stack)
                                       : getOrCompileFallback();
   }
@@ -637,8 +638,10 @@ size_t GraphExecutor::getDefaultNumBailOuts() {
   return getProfilingMode() ? 1 : 0;
 }
 
-ExecutionPlan GraphExecutor::getPlanFor(Stack& inputs, size_t num_bailouts) {
-  return pImpl->getPlanFor(inputs, num_bailouts);
+ExecutionPlan GraphExecutor::getPlanFor(
+    Stack& inputs,
+    size_t remaining_bailout_depth) {
+  return pImpl->getPlanFor(inputs, remaining_bailout_depth);
 }
 
 std::shared_ptr<Graph> GraphExecutor::graph() const {

--- a/torch/csrc/jit/graph_executor.cpp
+++ b/torch/csrc/jit/graph_executor.cpp
@@ -477,7 +477,8 @@ void GraphExecutorImplBase::run(Stack& stack) {
   logging::getLogger()->addStatValue(
       logging::runtime_counters::GRAPH_EXECUTOR_INVOCATIONS, 1.0);
 
-  ExecutionPlan plan = getPlanFor(stack);
+  ExecutionPlan plan =
+      getPlanFor(stack, GraphExecutor::getDefaultNumBailOuts());
   InterpreterState(plan.code).run(stack);
   last_executed_optimized_graph = plan.graph;
 }
@@ -494,8 +495,8 @@ struct GraphExecutorImpl : public GraphExecutorImplBase {
         logging::runtime_counters::GRAPH_EXECUTORS_CONSTRUCTED, 1.0);
   }
 
-  ExecutionPlan getPlanFor(Stack& stack) override {
-   return getGraphExecutorOptimize() ? getOrCompile(stack)
+  ExecutionPlan getPlanFor(Stack& stack, size_t num_bailouts) override {
+    return getGraphExecutorOptimize() ? getOrCompile(stack)
                                       : getOrCompileFallback();
   }
 
@@ -632,8 +633,12 @@ void GraphExecutor::run(Stack& inputs) {
   return pImpl->run(inputs);
 }
 
-ExecutionPlan GraphExecutor::getPlanFor(Stack& inputs) {
-  return pImpl->getPlanFor(inputs);
+size_t GraphExecutor::getDefaultNumBailOuts() {
+  return getProfilingMode() ? 1 : 0;
+}
+
+ExecutionPlan GraphExecutor::getPlanFor(Stack& inputs, size_t num_bailouts) {
+  return pImpl->getPlanFor(inputs, num_bailouts);
 }
 
 std::shared_ptr<Graph> GraphExecutor::graph() const {

--- a/torch/csrc/jit/graph_executor.h
+++ b/torch/csrc/jit/graph_executor.h
@@ -42,12 +42,14 @@ struct TORCH_API GraphExecutor {
   GraphExecutor() = default;
   GraphExecutor(std::shared_ptr<Graph> graph);
   void run(Stack& inputs);
-  ExecutionPlan getPlanFor(Stack& inputs);
+  ExecutionPlan getPlanFor(Stack& inputs, size_t num_bailouts);
   explicit operator bool() const {
     return pImpl != nullptr;
   }
   std::shared_ptr<Graph> graph() const;
   GraphExecutorState getDebugState();
+
+  static size_t getDefaultNumBailOuts();
 
  private:
   std::shared_ptr<GraphExecutorImplBase> pImpl;

--- a/torch/csrc/jit/graph_executor.h
+++ b/torch/csrc/jit/graph_executor.h
@@ -16,8 +16,10 @@ struct Code;
 
 struct ExecutionPlan {
   ExecutionPlan() = default;
-  ExecutionPlan(std::shared_ptr<Graph> graph, size_t num_bailouts = 0)
-      : code(graph, num_bailouts), graph(std::move(graph)) {}
+  ExecutionPlan(
+      std::shared_ptr<Graph> graph,
+      size_t remaining_bailout_depth = 0)
+      : code(graph, remaining_bailout_depth), graph(std::move(graph)) {}
 
   operator bool() const {
     return static_cast<bool>(graph);
@@ -42,15 +44,16 @@ struct TORCH_API GraphExecutor {
   GraphExecutor() = default;
   GraphExecutor(std::shared_ptr<Graph> graph);
   void run(Stack& inputs);
-  // `num_bailouts` stands for the maximum number of profiled and specialized
-  // recompilations allowed for the current `GraphExecutor`. if num_bailouts is
-  // equal to 0, `GraphExecutor` won't perform any profiling and specialization.
-  // This is also equivalent to the SIMPLE_EXECUTOR mode. if num_bailouts is
-  // greater than 0, `GraphExecutor` will profile and specialize its input graph
-  // based on the profiled information whenever a bailout check is
-  // failed/triggered, a new `GraphExecutor` will be created. This new
-  // `GraphExecutor`'s num_bailouts will be reduced by 1.
-  ExecutionPlan getPlanFor(Stack& inputs, size_t num_bailouts);
+  // `remaining_bailout_depth` stands for the maximum number of profiled and
+  // specialized recompilations allowed for the current `GraphExecutor`. if
+  // remaining_bailout_depth is equal to 0, `GraphExecutor` won't perform any
+  // profiling and specialization. This is also equivalent to the
+  // SIMPLE_EXECUTOR mode. if remaining_bailout_depth is greater than 0,
+  // `GraphExecutor` will profile and specialize its input graph based on the
+  // profiled information whenever a bailout check is failed/triggered, a new
+  // `GraphExecutor` will be created. This new `GraphExecutor`'s
+  // remaining_bailout_depth will be reduced by 1.
+  ExecutionPlan getPlanFor(Stack& inputs, size_t remaining_bailout_depth);
   explicit operator bool() const {
     return pImpl != nullptr;
   }

--- a/torch/csrc/jit/graph_executor.h
+++ b/torch/csrc/jit/graph_executor.h
@@ -16,8 +16,8 @@ struct Code;
 
 struct ExecutionPlan {
   ExecutionPlan() = default;
-  ExecutionPlan(std::shared_ptr<Graph> graph)
-      : code(graph), graph(std::move(graph)) {}
+  ExecutionPlan(std::shared_ptr<Graph> graph, size_t num_bailouts = 0)
+      : code(graph, num_bailouts), graph(std::move(graph)) {}
 
   operator bool() const {
     return static_cast<bool>(graph);
@@ -42,6 +42,14 @@ struct TORCH_API GraphExecutor {
   GraphExecutor() = default;
   GraphExecutor(std::shared_ptr<Graph> graph);
   void run(Stack& inputs);
+  // `num_bailouts` stands for the maximum number of profiled and specialized
+  // recompilations allowed for the current `GraphExecutor`. if num_bailouts is
+  // equal to 0, `GraphExecutor` won't perform any profiling and specialization.
+  // This is also equivalent to the SIMPLE_EXECUTOR mode. if num_bailouts is
+  // greater than 0, `GraphExecutor` will profile and specialize its input graph
+  // based on the profiled information whenever a bailout check is
+  // failed/triggered, a new `GraphExecutor` will be created. This new
+  // `GraphExecutor`'s num_bailouts will be reduced by 1.
   ExecutionPlan getPlanFor(Stack& inputs, size_t num_bailouts);
   explicit operator bool() const {
     return pImpl != nullptr;

--- a/torch/csrc/jit/graph_executor_impl.h
+++ b/torch/csrc/jit/graph_executor_impl.h
@@ -62,7 +62,9 @@ struct GraphExecutorImplBase {
   // entry point where execution begins
   void run(Stack& stack);
 
-  virtual ExecutionPlan getPlanFor(Stack& stack, size_t num_bailouts) = 0;
+  virtual ExecutionPlan getPlanFor(
+      Stack& stack,
+      size_t remaining_bailout_depth) = 0;
   virtual GraphExecutorState getDebugState() = 0;
   virtual ~GraphExecutorImplBase() = default;
 

--- a/torch/csrc/jit/graph_executor_impl.h
+++ b/torch/csrc/jit/graph_executor_impl.h
@@ -62,7 +62,7 @@ struct GraphExecutorImplBase {
   // entry point where execution begins
   void run(Stack& stack);
 
-  virtual ExecutionPlan getPlanFor(Stack& stack) = 0;
+  virtual ExecutionPlan getPlanFor(Stack& stack, size_t num_bailouts) = 0;
   virtual GraphExecutorState getDebugState() = 0;
   virtual ~GraphExecutorImplBase() = default;
 

--- a/torch/csrc/jit/interpreter.cpp
+++ b/torch/csrc/jit/interpreter.cpp
@@ -381,12 +381,12 @@ struct CodeImpl {
   // out-of-line jumps for bailouts that are patched in at the end
   std::vector<BailoutBlock> bailout_blocks_;
   std::vector<std::unique_ptr<Function>> bailout_functions_;
-  size_t num_bailouts_;
+  size_t remaining_bailout_depth_;
 
-  CodeImpl(const std::shared_ptr<Graph>& graph, size_t num_bailouts)
+  CodeImpl(const std::shared_ptr<Graph>& graph, size_t remaining_bailout_depth)
       : preprocess_(*graph),
         current_node_(preprocess_.graph->return_node()),
-        num_bailouts_(num_bailouts) {
+        remaining_bailout_depth_(remaining_bailout_depth) {
     graph_ = preprocess_.graph;
     n_outputs = graph_->outputs().size();
     if (n_outputs == 1) {
@@ -939,13 +939,13 @@ struct InterpreterStateImpl : c10::intrusive_ptr_target {
           } break;
           case CALL: {
             const Code& code =
-                // consider passing `frames.back().function->num_bailouts_`
-                // into `get_executor().getPlanFor()`
-                // to propagate caller's depth restrictions onto children
-                // while this strategy has a potential to reduce the number
-                // of compilations for too dynamic callers
-                // we might miss opportunities where a caller is dynamic
-                // but a callee gets stable arguments
+                // consider passing
+                // `frames.back().function->remaining_bailout_depth_` into
+                // `get_executor().getPlanFor()` to propagate caller's depth
+                // restrictions onto children while this strategy has a
+                // potential to reduce the number of compilations for too
+                // dynamic callers we might miss opportunities where a caller is
+                // dynamic but a callee gets stable arguments
                 af.functions[inst.X]
                     ->get_executor()
                     .getPlanFor(stack, GraphExecutor::getDefaultNumBailOuts())
@@ -960,13 +960,13 @@ struct InterpreterStateImpl : c10::intrusive_ptr_target {
             // of the hashing computation or storing the offset when
             // the object is turned into an interface
 
-            // consider passing `frames.back().function->num_bailouts_`
-            // into `get_executor().getPlanFor()`
-            // to propagate caller's depth restrictions onto children
-            // while this strategy has a potential to reduce the number
-            // of compilations for too dynamic callers
-            // we might miss opportunities where a caller is dynamic
-            // but a callee gets stable arguments
+            // consider passing
+            // `frames.back().function->remaining_bailout_depth_` into
+            // `get_executor().getPlanFor()` to propagate caller's depth
+            // restrictions onto children while this strategy has a potential to
+            // reduce the number of compilations for too dynamic callers we
+            // might miss opportunities where a caller is dynamic but a callee
+            // gets stable arguments
             auto function = peek(stack, 0, inst.N)
                                 .toObject()
                                 ->type()
@@ -1052,12 +1052,13 @@ struct InterpreterStateImpl : c10::intrusive_ptr_target {
           } break;
           case TAIL_CALL: {
             af.functions[inst.X]->ensure_defined();
-            size_t num_bailouts = frames.back().function->num_bailouts_ > 0
-                ? frames.back().function->num_bailouts_ - 1
+            size_t remaining_bailout_depth =
+                frames.back().function->remaining_bailout_depth_ > 0
+                ? frames.back().function->remaining_bailout_depth_ - 1
                 : 0;
             const Code& code = af.functions[inst.X]
                                    ->get_executor()
-                                   .getPlanFor(stack, num_bailouts)
+                                   .getPlanFor(stack, remaining_bailout_depth)
                                    .code;
             size_t num_inputs = code.num_inputs();
             size_t base_pointer = frames.back().base_pointer;
@@ -1163,8 +1164,8 @@ std::ostream& operator<<(std::ostream& out, const Code& code) {
   return out;
 }
 
-Code::Code(const std::shared_ptr<Graph>& graph, size_t num_bailouts)
-    : pImpl(new CodeImpl(graph, num_bailouts)) {}
+Code::Code(const std::shared_ptr<Graph>& graph, size_t remaining_bailout_depth)
+    : pImpl(new CodeImpl(graph, remaining_bailout_depth)) {}
 Code::~Code() = default;
 
 const std::vector<GraphExecutor*>& Code::grad_executors() {

--- a/torch/csrc/jit/interpreter.cpp
+++ b/torch/csrc/jit/interpreter.cpp
@@ -383,10 +383,10 @@ struct CodeImpl {
   std::vector<std::unique_ptr<Function>> bailout_functions_;
   size_t num_bailouts_;
 
-  CodeImpl(const std::shared_ptr<Graph>& graph)
+  CodeImpl(const std::shared_ptr<Graph>& graph, size_t num_bailouts)
       : preprocess_(*graph),
         current_node_(preprocess_.graph->return_node()),
-        num_bailouts_(0) {
+        num_bailouts_(num_bailouts) {
     graph_ = preprocess_.graph;
     n_outputs = graph_->outputs().size();
     if (n_outputs == 1) {
@@ -432,10 +432,6 @@ struct CodeImpl {
       }
       last_inserted_op_ = current_node_;
     }
-  }
-
-  void setNumBailOuts(size_t num_bailouts) {
-    num_bailouts_ = num_bailouts;
   }
 
   void truncateInstructions(size_t size) {
@@ -1167,7 +1163,8 @@ std::ostream& operator<<(std::ostream& out, const Code& code) {
   return out;
 }
 
-Code::Code(const std::shared_ptr<Graph>& graph) : pImpl(new CodeImpl(graph)) {}
+Code::Code(const std::shared_ptr<Graph>& graph, size_t num_bailouts)
+    : pImpl(new CodeImpl(graph, num_bailouts)) {}
 Code::~Code() = default;
 
 const std::vector<GraphExecutor*>& Code::grad_executors() {
@@ -1180,10 +1177,6 @@ size_t Code::num_inputs() const {
 
 size_t Code::num_outputs() const {
   return pImpl->n_outputs;
-}
-
-void Code::setNumBailOuts(size_t num_bailouts) {
-  return pImpl->setNumBailOuts(num_bailouts);
 }
 
 const std::vector<c10::IValue>& Code::constant_table() const {

--- a/torch/csrc/jit/interpreter.h
+++ b/torch/csrc/jit/interpreter.h
@@ -33,10 +33,12 @@ using c10::ivalue::Future;
 
 struct TORCH_API Code {
   Code() : pImpl(nullptr) {}
-  // num_bailouts is irrelevant in a `Code` object unless the `Code` is directly
-  // created by `GraphExecutor` in which case it's likely to contain
+  // remaining_bailout_depth is irrelevant in a `Code` object unless the `Code`
+  // is directly created by `GraphExecutor` in which case it's likely to contain
   // `prim::BailOut`s to control the maximum depth of bailout chains
-  explicit Code(const std::shared_ptr<Graph>& graph, size_t num_bailouts = 0);
+  explicit Code(
+      const std::shared_ptr<Graph>& graph,
+      size_t remaining_bailout_depth = 0);
   ~Code();
 
   const std::vector<GraphExecutor*>& grad_executors();

--- a/torch/csrc/jit/interpreter.h
+++ b/torch/csrc/jit/interpreter.h
@@ -47,6 +47,7 @@ struct TORCH_API Code {
   const std::vector<Instruction>& instructions() const;
   const std::vector<Node*>& instructions_source() const;
   size_t register_size() const;
+  void setNumBailOuts(size_t num_bailouts);
 
  private:
   std::shared_ptr<CodeImpl> pImpl;

--- a/torch/csrc/jit/interpreter.h
+++ b/torch/csrc/jit/interpreter.h
@@ -33,7 +33,10 @@ using c10::ivalue::Future;
 
 struct TORCH_API Code {
   Code() : pImpl(nullptr) {}
-  explicit Code(const std::shared_ptr<Graph>& graph);
+  // num_bailouts is irrelevant in a `Code` object unless the `Code` is directly
+  // created by `GraphExecutor` in which case it's likely to contain
+  // `prim::BailOut`s to control the maximum depth of bailout chains
+  explicit Code(const std::shared_ptr<Graph>& graph, size_t num_bailouts = 0);
   ~Code();
 
   const std::vector<GraphExecutor*>& grad_executors();
@@ -47,7 +50,6 @@ struct TORCH_API Code {
   const std::vector<Instruction>& instructions() const;
   const std::vector<Node*>& instructions_source() const;
   size_t register_size() const;
-  void setNumBailOuts(size_t num_bailouts);
 
  private:
   std::shared_ptr<CodeImpl> pImpl;

--- a/torch/csrc/jit/profiling_graph_executor_impl.cpp
+++ b/torch/csrc/jit/profiling_graph_executor_impl.cpp
@@ -126,7 +126,9 @@ ProfilingGraphExecutorImpl::ProfilingGraphExecutorImpl(
     const std::shared_ptr<Graph>& graph)
     : GraphExecutorImplBase(graph) {}
 
-ExecutionPlan ProfilingGraphExecutorImpl::getPlanFor(Stack& stack) {
+ExecutionPlan ProfilingGraphExecutorImpl::getPlanFor(
+    Stack& stack,
+    size_t num_bailouts) {
   std::lock_guard<std::mutex> lock(compile_mutex);
   GRAPH_DEBUG("Running ProfilingGraphExecutorImpl ", this);
 
@@ -135,7 +137,7 @@ ExecutionPlan ProfilingGraphExecutorImpl::getPlanFor(Stack& stack) {
   }
 
   // simple executor
-  if (!getProfilingMode()) {
+  if (num_bailouts == 0) {
     auto copy = graph->copy();
     runProfilingInsensitiveOptimizations(copy);
     GRAPH_DUMP("Optimized SimpleExecutor Graph : ", copy);
@@ -163,6 +165,7 @@ ExecutionPlan ProfilingGraphExecutorImpl::getPlanFor(Stack& stack) {
   runProfilingOptimizations(copy);
   // cache
   optimized_plan_ = ExecutionPlan(copy);
+  optimized_plan_->code.setNumBailOuts(num_bailouts);
   return *optimized_plan_;
 }
 

--- a/torch/csrc/jit/profiling_graph_executor_impl.cpp
+++ b/torch/csrc/jit/profiling_graph_executor_impl.cpp
@@ -128,7 +128,7 @@ ProfilingGraphExecutorImpl::ProfilingGraphExecutorImpl(
 
 ExecutionPlan ProfilingGraphExecutorImpl::getPlanFor(
     Stack& stack,
-    size_t num_bailouts) {
+    size_t remaining_bailout_depth) {
   std::lock_guard<std::mutex> lock(compile_mutex);
   GRAPH_DEBUG("Running ProfilingGraphExecutorImpl ", this);
 
@@ -137,7 +137,7 @@ ExecutionPlan ProfilingGraphExecutorImpl::getPlanFor(
   }
 
   // simple executor
-  if (num_bailouts == 0) {
+  if (remaining_bailout_depth == 0) {
     auto copy = graph->copy();
     runProfilingInsensitiveOptimizations(copy);
     GRAPH_DUMP("Optimized SimpleExecutor Graph : ", copy);
@@ -164,7 +164,7 @@ ExecutionPlan ProfilingGraphExecutorImpl::getPlanFor(
   auto copy = pr_->graph()->copy();
   runProfilingOptimizations(copy);
   // cache
-  optimized_plan_ = ExecutionPlan(copy, num_bailouts);
+  optimized_plan_ = ExecutionPlan(copy, remaining_bailout_depth);
   return *optimized_plan_;
 }
 

--- a/torch/csrc/jit/profiling_graph_executor_impl.cpp
+++ b/torch/csrc/jit/profiling_graph_executor_impl.cpp
@@ -164,8 +164,7 @@ ExecutionPlan ProfilingGraphExecutorImpl::getPlanFor(
   auto copy = pr_->graph()->copy();
   runProfilingOptimizations(copy);
   // cache
-  optimized_plan_ = ExecutionPlan(copy);
-  optimized_plan_->code.setNumBailOuts(num_bailouts);
+  optimized_plan_ = ExecutionPlan(copy, num_bailouts);
   return *optimized_plan_;
 }
 

--- a/torch/csrc/jit/profiling_graph_executor_impl.h
+++ b/torch/csrc/jit/profiling_graph_executor_impl.h
@@ -7,7 +7,8 @@ namespace jit {
 struct ProfilingGraphExecutorImpl : public GraphExecutorImplBase {
   ProfilingGraphExecutorImpl(const std::shared_ptr<Graph>& graph);
 
-  ExecutionPlan getPlanFor(Stack& stack, size_t num_bailouts) override;
+  ExecutionPlan getPlanFor(Stack& stack, size_t remaining_bailout_depth)
+      override;
   GraphExecutorState getDebugState() override;
   ~ProfilingGraphExecutorImpl() override = default;
 

--- a/torch/csrc/jit/profiling_graph_executor_impl.h
+++ b/torch/csrc/jit/profiling_graph_executor_impl.h
@@ -7,7 +7,7 @@ namespace jit {
 struct ProfilingGraphExecutorImpl : public GraphExecutorImplBase {
   ProfilingGraphExecutorImpl(const std::shared_ptr<Graph>& graph);
 
-  ExecutionPlan getPlanFor(Stack& stack) override;
+  ExecutionPlan getPlanFor(Stack& stack, size_t num_bailouts) override;
   GraphExecutorState getDebugState() override;
   ~ProfilingGraphExecutorImpl() override = default;
 


### PR DESCRIPTION
This is another implementation of the maximum bailout depth.
The first version was implemented in https://github.com/pytorch/pytorch/pull/31521
This one has advantages that 
* the bailout depth only exists in `CodeImpl` which seems to be an appropriate place to keep it in.
* threading many objects is reduced to threading through CodeImpl and getPlanFor