### PR TITLE
[ONNX] Added cons folding for ONNX mul, div, sqrt ops

### DIFF
--- a/aten/src/ATen/core/interned_strings.h
+++ b/aten/src/ATen/core/interned_strings.h
@@ -206,6 +206,7 @@ namespace c10 {
   _(onnx, ConstantOfShape)           \
   _(onnx, Cast)                      \
   _(onnx, Mod)                       \
+  _(onnx, Sqrt)                      \
   _(onnx, SplitToSequence)           \
   _(onnx, SequenceConstruct)         \
   _(onnx, SequenceEmpty)             \

--- a/torch/csrc/jit/passes/onnx/constant_fold.cpp
+++ b/torch/csrc/jit/passes/onnx/constant_fold.cpp
@@ -204,6 +204,18 @@ c10::optional<at::Tensor> runTorchBackendForOnnx(
     updated_val =
         at::cat(at::TensorList(inputTensorValues), node->i(attr::axis));
     return c10::optional<at::Tensor>(updated_val);
+  } else if (node->kind() == onnx::Sqrt) {
+    updated_val =
+        at::sqrt(inputTensorValues[0]);
+    return c10::optional<at::Tensor>(updated_val);
+  } else if (node->kind() == onnx::Div) {
+    updated_val =
+        at::div(inputTensorValues[0], inputTensorValues[1]);
+    return c10::optional<at::Tensor>(updated_val);
+  } else if (node->kind() == onnx::Mul) {
+    updated_val =
+        at::mul(inputTensorValues[0], inputTensorValues[1]);
+    return c10::optional<at::Tensor>(updated_val);
   } else if (node->kind() == onnx::Unsqueeze) {
     assert(inputTensorValues.size() == 1);
     if (!node->hasAttributeS("axes")) {


### PR DESCRIPTION
An example of a model with such leaf nodes is faster_rcnn model. This PR helps optimizing onnx ops.