### PR TITLE
Memory leaks and performance fixes

### DIFF
--- a/aten/src/ATen/core/ivalue.cpp
+++ b/aten/src/ATen/core/ivalue.cpp
@@ -286,7 +286,7 @@ static bool CompareKeys(const std::pair<IValue, IValue>& aWrap,
   AT_ERROR("Illegal dict key");
 }
 
-std::vector<std::pair<IValue, IValue>> iterationOrder(const c10::Dict<IValue, IValue>& dict) {
+std::vector<std::pair<IValue, IValue>> iterationOrder(const c10::Dict<IValue, IValue>&dict) {
   std::vector<std::pair<IValue, IValue>> ordered;
   for (auto& element : dict) {
     ordered.emplace_back(element.key(), element.value());

--- a/aten/src/ATen/core/ivalue.cpp
+++ b/aten/src/ATen/core/ivalue.cpp
@@ -286,7 +286,7 @@ static bool CompareKeys(const std::pair<IValue, IValue>& aWrap,
   AT_ERROR("Illegal dict key");
 }
 
-std::vector<std::pair<IValue, IValue>> iterationOrder(const c10::Dict<IValue, IValue>&dict) {
+std::vector<std::pair<IValue, IValue>> iterationOrder(const c10::Dict<IValue, IValue>& dict) {
   std::vector<std::pair<IValue, IValue>> ordered;
   for (auto& element : dict) {
     ordered.emplace_back(element.key(), element.value());

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -457,7 +457,6 @@ static void check_shape_forward(const at::Tensor& input,
       // If kernel size is incorrect
       std::ostringstream input_ss;
       std::ostringstream kernel_ss;
-      std::ostringstream output_ss;
       std::string separator = "";
 
       for (int i = 0, len = input_shape.size(); i < len; ++i) {

--- a/aten/src/ATen/native/Normalization.cpp
+++ b/aten/src/ATen/native/Normalization.cpp
@@ -457,8 +457,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, int64_t> _batch_norm_impl_index(
     check_dims_match_num_input_features("bias", num_features, bias.numel());
   }
 
-  bool use_cudnn = false;
-  use_cudnn = (input.is_cuda()
+  bool use_cudnn = (input.is_cuda()
                && (input.scalar_type() != at::kHalf
                  || weight.scalar_type() == at::kFloat)
                && weight.defined() && bias.defined()

--- a/aten/src/ATen/native/RNN.cpp
+++ b/aten/src/ATen/native/RNN.cpp
@@ -293,10 +293,10 @@ static std::vector<QuantizedCellParamsDynamic> gather_quantized_params_dynamic(
     auto bias_hh = packed_struct_hh.bias.value_or(undefined);
     result.emplace_back(params[i], params[i + 1], bias_ih, bias_hh);
   }
-  return result;
 #else // USE_FBGEMM
   TORCH_INTERNAL_ASSERT(false, "Tried to use quantized RNN without FBGEMM!")
 #endif // USE_FBGEMM
+  return result;
 }
 
 static std::vector<QuantizedCellParamsFP16> gather_quantized_params_fp16(

--- a/aten/src/TH/THMemoryFile.cpp
+++ b/aten/src/TH/THMemoryFile.cpp
@@ -563,7 +563,7 @@ static ssize_t THMemoryFile_readString(THFile *self, const char *format, char **
   {
     int8_t *p = THCharStorage_data(mfself->storage)+mfself->position;
     int eolFound = 0;
-    ssize_t posEol;
+    ssize_t posEol = 0;
     ssize_t i;
     for(i = 0; i < mfself->size-mfself->position; i++)
     {

--- a/aten/src/TH/vector/VSX.cpp
+++ b/aten/src/TH/vector/VSX.cpp
@@ -1683,6 +1683,7 @@ void test_THDoubleVector_cadd_VSX()
     free(z_standard);
     free(z_optimized);
     free(x);
+    free(y)
 }
 
 void test_THFloatVector_cadd_VSX()
@@ -1754,6 +1755,7 @@ void test_THFloatVector_cadd_VSX()
     free(z_standard);
     free(z_optimized);
     free(x);
+    free(y)
 }
 
 void test_THDoubleVector_adds_VSX()
@@ -1820,6 +1822,7 @@ void test_THDoubleVector_adds_VSX()
     free(y_standard);
     free(y_optimized);
     free(x);
+    free(y)
 }
 
 
@@ -1888,6 +1891,7 @@ void test_THFloatVector_adds_VSX()
     free(y_standard);
     free(y_optimized);
     free(x);
+    free(y)
 }
 
 
@@ -1959,6 +1963,7 @@ void test_THDoubleVector_cmul_VSX()
     free(z_standard);
     free(z_optimized);
     free(x);
+    free(y)
 }
 
 void test_THFloatVector_cmul_VSX()
@@ -2029,6 +2034,7 @@ void test_THFloatVector_cmul_VSX()
     free(z_standard);
     free(z_optimized);
     free(x);
+    free(y)
 }
 
 void test_THDoubleVector_muls_VSX()
@@ -2099,6 +2105,7 @@ void test_THDoubleVector_muls_VSX()
     free(y_standard);
     free(y_optimized);
     free(x);
+    free(y)
 }
 
 void test_THFloatVector_muls_VSX()
@@ -2168,6 +2175,7 @@ void test_THFloatVector_muls_VSX()
     free(y_standard);
     free(y_optimized);
     free(x);
+    free(y)
 }
 
 
@@ -2240,6 +2248,7 @@ void test_THDoubleVector_cdiv_VSX()
     free(z_standard);
     free(z_optimized);
     free(x);
+    free(y)
 }
 
 void test_THFloatVector_cdiv_VSX()
@@ -2310,6 +2319,7 @@ void test_THFloatVector_cdiv_VSX()
     free(z_standard);
     free(z_optimized);
     free(x);
+    free(y)
 }
 
 void test_THDoubleVector_divs_VSX()
@@ -2380,6 +2390,7 @@ void test_THDoubleVector_divs_VSX()
     free(y_standard);
     free(y_optimized);
     free(x);
+    free(y)
 }
 
 void test_THFloatVector_divs_VSX()
@@ -2450,6 +2461,7 @@ void test_THFloatVector_divs_VSX()
     free(y_standard);
     free(y_optimized);
     free(x);
+    free(y)
 }
 
 

--- a/aten/src/THC/THCCachingHostAllocator.cpp
+++ b/aten/src/THC/THCCachingHostAllocator.cpp
@@ -273,7 +273,6 @@ static void THCCachingHostDeleter(void* ptr) {
 
 struct THCCachingHostAllocator final : public at::Allocator {
   at::DataPtr allocate(size_t size) const override {
-    THAssert(size >= 0);
     void *ptr;
     THCudaCheck(allocator.malloc(&ptr, size));
     return {ptr, ptr, &THCCachingHostDeleter, at::DeviceType::CPU};


### PR DESCRIPTION
Memory leaks and some performance fixes

aten/src/ATen/core/ivalue.cpp: 77 and 91 : Function parameter 'start' and 'finish' should be passed by reference instead of value.

aten/src/ATen/native/Convolution.cpp:472: Removed Unused variable: output_ss

aten/src/ATen/native/Normalization.cpp:460 : Variable 'use_cudnn' declared/defined together

aten/src/TH/THMemoryFile.cpp:580: initialize posEol, i = 0

aten/src/TH/vector/VSX.cpp: Memory leak: y multiple locations

aten/src/THC/THCCachingHostAllocator.cpp:276: Unsigned variable 'size' can't be negative so it is unnecessary to test it.	