### PR TITLE
[caffe2] Use log1p for precision

### DIFF
--- a/caffe2/operators/cross_entropy_op.cc
+++ b/caffe2/operators/cross_entropy_op.cc
@@ -6,7 +6,7 @@ namespace caffe2 {
 namespace {
 
 inline float sigmoid_xent_forward(float lgt, float tgt) {
-  return lgt * (tgt - (lgt >= 0)) - log(1 + exp(lgt - 2 * lgt * (lgt >= 0)));
+  return lgt * (tgt - (lgt >= 0)) - log1p( exp(lgt - 2 * lgt * (lgt >= 0)));
 }
 
 inline float sigmoid_xent_backward(float lgt, float tgt) {
@@ -15,7 +15,7 @@ inline float sigmoid_xent_backward(float lgt, float tgt) {
 
 inline float sigmoid_partition(float lgt) {
   // computes log(1 + exp(lgt)) with only exp(x) function when x >= 0
-  return lgt * (lgt >= 0) + log(1 + exp(lgt - 2 * lgt * (lgt >= 0)));
+  return lgt * (lgt >= 0) + log1p(exp(lgt - 2 * lgt * (lgt >= 0)));
 }
 
 inline float sigmoid_xent_forward_with_log_d_trick(float lgt, float tgt) {
@@ -28,7 +28,7 @@ inline float sigmoid_xent_backward_with_log_d_trick(float lgt, float tgt) {
 
 inline float unjoined_sigmoid_xent_forward(float lgt, float tgt) {
   return lgt * tgt + (tgt - 1) * lgt * (lgt >= 0) -
-      (1 - tgt) * log(1 + exp(lgt - 2 * lgt * (lgt >= 0)));
+      (1 - tgt) * log1p(exp(lgt - 2 * lgt * (lgt >= 0)));
 }
 
 inline float unjoined_sigmoid_xent_backward(float lgt, float tgt) {

--- a/caffe2/operators/experimental/c10/cpu/sigmoid_cross_entropy_with_logits_cpu.cc
+++ b/caffe2/operators/experimental/c10/cpu/sigmoid_cross_entropy_with_logits_cpu.cc
@@ -9,11 +9,11 @@ namespace caffe2 {
 namespace {
 inline float sigmoid_partition(float lgt) {
   // computes log(1 + exp(lgt)) with only exp(x) function when x >= 0
-  return lgt * (lgt >= 0) + log(1 + exp(lgt - 2 * lgt * (lgt >= 0)));
+  return lgt * (lgt >= 0) + log1p(exp(lgt - 2 * lgt * (lgt >= 0)));
 }
 
 inline float sigmoid_xent_forward(float lgt, float tgt) {
-  return lgt * (tgt - (lgt >= 0)) - log(1 + exp(lgt - 2 * lgt * (lgt >= 0)));
+  return lgt * (tgt - (lgt >= 0)) - log1p(exp(lgt - 2 * lgt * (lgt >= 0)));
 }
 
 inline float sigmoid_xent_forward_with_log_d_trick(float lgt, float tgt) {
@@ -22,7 +22,7 @@ inline float sigmoid_xent_forward_with_log_d_trick(float lgt, float tgt) {
 
 inline float unjoined_sigmoid_xent_forward(float lgt, float tgt) {
   return lgt * tgt + (tgt - 1) * lgt * (lgt >= 0) -
-      (1 - tgt) * log(1 + exp(lgt - 2 * lgt * (lgt >= 0)));
+      (1 - tgt) * log1p(exp(lgt - 2 * lgt * (lgt >= 0)));
 }
 
 void sigmoid_cross_entropy_with_logits_op_cpu_impl(

--- a/caffe2/operators/rank_loss_op.cc
+++ b/caffe2/operators/rank_loss_op.cc
@@ -15,7 +15,7 @@ inline T logLogit(T x) {
   if (x > -kMinLogDiff) {
     return x;
   }
-  return std::log(std::exp(x) + 1);
+  return std::log1p(std::exp(x));
 }
 }
 


### PR DESCRIPTION
For small magnitude values of x, log1p(x) may be more accurate than log (1 + x)

>>> np.log1p(1e-99)
1e-99
>>> np.log(1 + 1e-99)
0.0