### PR TITLE
[distributions] use cholesky_inverse to compute precision matrix

### DIFF
--- a/torch/distributions/lowrank_multivariate_normal.py
+++ b/torch/distributions/lowrank_multivariate_normal.py
@@ -52,8 +52,8 @@ class LowRankMultivariateNormal(Distribution):
 
     Example:
 
-        >>> m = LowRankMultivariateNormal(torch.zeros(2), torch.tensor([1, 0]), torch.tensor([1, 1]))
-        >>> m.sample()  # normally distributed with mean=`[0,0]`, cov_factor=`[1,0]`, cov_diag=`[1,1]`
+        >>> m = LowRankMultivariateNormal(torch.zeros(2), torch.tensor([[1.], [0.]]), torch.ones(2))
+        >>> m.sample()  # normally distributed with mean=`[0,0]`, cov_factor=`[[1],[0]]`, cov_diag=`[1,1]`
         tensor([-0.2102, -0.5429])
 
     Args:

--- a/torch/distributions/multivariate_normal.py
+++ b/torch/distributions/multivariate_normal.py
@@ -182,9 +182,7 @@ class MultivariateNormal(Distribution):
 
     @lazy_property
     def precision_matrix(self):
-        # TODO: use `torch.potri` on `scale_tril` once a backwards pass is implemented.
-        scale_tril_inv = torch.inverse(self._unbroadcasted_scale_tril)
-        return torch.matmul(scale_tril_inv.transpose(-1, -2), scale_tril_inv).expand(
+        return torch.cholesky_inverse(self._unbroadcasted_scale_tril).expand(
             self._batch_shape + self._event_shape + self._event_shape)
 
     @property

--- a/torch/distributions/multivariate_normal.py
+++ b/torch/distributions/multivariate_normal.py
@@ -182,7 +182,9 @@ class MultivariateNormal(Distribution):
 
     @lazy_property
     def precision_matrix(self):
-        return torch.cholesky_inverse(self._unbroadcasted_scale_tril).expand(
+        identity = torch.eye(self.loc.size(-1), device=self.loc.device, dtype=self.loc.dtype)
+        # TODO: use cholesky_inverse when its batching is supported
+        return torch.cholesky_solve(identity, self._unbroadcasted_scale_tril).expand(
             self._batch_shape + self._event_shape + self._event_shape)
 
     @property


### PR DESCRIPTION
Resolves a long-standing TODO. :D 

I also fix the docs of lowrank_mvn which is raised at [forum](https://discuss.pytorch.org/t/lowrankmultivariatenormal-example-raises-valueerror/65381).

cc @vishwakftw 