### PR TITLE
Clean up some IValue list uses

### DIFF
--- a/torch/csrc/jit/passes/python_print.cpp
+++ b/torch/csrc/jit/passes/python_print.cpp
@@ -779,11 +779,10 @@ struct PythonPrintImpl {
 
   void printMaybeAnnotatedConstantList(
       std::ostream& stmt,
-      const char* the_type,
-      size_t list_size,
       const IValue& the_list) {
-    if (list_size == 0) {
-      stmt << "annotate(List[" << the_type << "], [])";
+    auto list = the_list.toList();
+    if (list.size() == 0) {
+      stmt << "annotate(List[" << list.elementType()->python_str() << "], [])";
     } else {
       stmt << the_list;
     }
@@ -809,13 +808,8 @@ struct PythonPrintImpl {
         delim = ", ";
       }
       ss << "]";
-    } else if (v.isBoolList()) {
-      printMaybeAnnotatedConstantList(ss, "bool", v.toBoolList().size(), v);
-    } else if (v.isIntList()) {
-      printMaybeAnnotatedConstantList(ss, "int", v.toIntVector().size(), v);
-    } else if (v.isDoubleList()) {
-      printMaybeAnnotatedConstantList(
-          ss, "float", v.toDoubleVector().size(), v);
+    } else if (v.isList()) {
+      printMaybeAnnotatedConstantList(ss, v);
     } else {
       ss << v;
     }

--- a/torch/csrc/jit/passes/utils/check_alias_annotation.cpp
+++ b/torch/csrc/jit/passes/utils/check_alias_annotation.cpp
@@ -16,13 +16,6 @@ IValue deepCopy(const IValue& self) {
   if (self.isTensor()) {
     return IValue(self.toTensor().clone(at::MemoryFormat::Preserve));
   }
-  if (self.isTensorList()) {
-    c10::List<at::Tensor> newList;
-    for (const at::Tensor& oldTensor : self.toTensorVector()) {
-      newList.push_back(oldTensor.clone(at::MemoryFormat::Preserve));
-    }
-    return newList;
-  }
 
   // Lists of ivalues should recursively deep copy their contents
   if (self.isList()) {
@@ -35,14 +28,7 @@ IValue deepCopy(const IValue& self) {
     return newList;
   }
 
-  // Regular lists can copy assign
-  if (self.isIntList()) {
-    return IValue(self.toIntList().copy());
-  } else if (self.isDoubleList()) {
-    return IValue(self.toDoubleList().copy());
-  } else if (self.isBoolList()) {
-    return IValue(self.toBoolList().copy());
-  } else if (self.isString()) {
+  if (self.isString()) {
     return IValue(self.toStringRef());
   }
 

--- a/torch/csrc/jit/unpickler.cpp
+++ b/torch/csrc/jit/unpickler.cpp
@@ -661,40 +661,11 @@ void Unpickler::readList(IValue list_ivalue) {
   marks_.pop_back();
   auto num_elements = stack_.size() - start;
   auto elements = at::ArrayRef<IValue>(stack_).slice(start);
-  if (list_ivalue.isIntList()) {
-    auto list = std::move(list_ivalue).toIntList();
-    list.reserve(num_elements);
-    for (const auto& elem : elements) {
-      list.emplace_back(elem.toInt());
-    }
-  } else if (list_ivalue.isTensorList()) {
-    auto list = std::move(list_ivalue).toTensorList();
-    list.reserve(num_elements);
-    for (const auto& elem : elements) {
-      list.emplace_back(elem.toTensor());
-    }
-  } else if (list_ivalue.isDoubleList()) {
-    auto list = std::move(list_ivalue).toDoubleList();
-    list.reserve(num_elements);
-    for (const auto& elem : elements) {
-      list.emplace_back(elem.toDouble());
-    }
-  } else if (list_ivalue.isBoolList()) {
-    auto list = std::move(list_ivalue).toBoolList();
-    list.reserve(num_elements);
-    for (const auto& elem : elements) {
-      list.push_back(elem.toBool());
-    }
-  } else if (list_ivalue.isList()) {
-    auto list = std::move(list_ivalue).toList();
-    list.reserve(num_elements);
-    for (const auto& elem : elements) {
-      list.emplace_back(elem);
-    }
-  } else {
-    AT_ERROR("Unknown IValue list kind: ", list_ivalue.tagKind());
+  auto list = std::move(list_ivalue).toList();
+  list.reserve(num_elements);
+  for (const auto& elem : elements) {
+    list.emplace_back(elem);
   }
-
   stack_.erase(stack_.begin() + start, stack_.end());
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#32096 Clean up some IValue list uses**
* #32093 Renaming IValue List functions

Now that lists are not specialized, we can remove some if-statements
handling the different kinds of lists.

Differential Revision: [D19369939](https://our.internmc.facebook.com/intern/diff/D19369939)