### PR TITLE
Change python/cpp docs CI to use a CPU-only image

### DIFF
--- a/.circleci/cimodel/data/pytorch_build_definitions.py
+++ b/.circleci/cimodel/data/pytorch_build_definitions.py
@@ -160,6 +160,11 @@ def gen_dependent_configs(xenial_parent_config):
 
         configs.append(c)
 
+    return configs
+
+def gen_docs_configs(xenial_parent_config):
+    configs = []
+
     for x in ["pytorch_python_doc_push", "pytorch_cpp_doc_push"]:
         configs.append(HiddenConf(x, parent_build=xenial_parent_config))
 
@@ -246,6 +251,15 @@ def instantiate_configs():
             is_important=is_important,
             parallel_backend=parallel_backend,
         )
+
+        # run docs builds on "pytorch-linux-xenial-py3.6-gcc5.4". Docs builds
+        # should run on a CPU-only build that runs on all PRs.
+        if distro_name == 'xenial' and fc.find_prop("pyver") == '3.6' \
+                and cuda_version is None \
+                and parallel_backend is None \
+                and compiler_name == 'gcc' \
+                and fc.find_prop('compiler_version') == '5.4':
+            c.dependent_tests = gen_docs_configs(c)
 
         if cuda_version == "9" and python_version == "3.6" and not is_libtorch:
             c.dependent_tests = gen_dependent_configs(c)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1016,7 +1016,7 @@ jobs:
     environment:
       BUILD_ENVIRONMENT: pytorch-python-doc-push
       # TODO: stop hardcoding this
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py3:a8006f9a-272d-4478-b137-d121c6f05c83"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3.6-gcc5.4:a8006f9a-272d-4478-b137-d121c6f05c83"
     resource_class: large
     machine:
       image: ubuntu-1604:201903-01
@@ -1061,7 +1061,7 @@ jobs:
   pytorch_cpp_doc_push:
     environment:
       BUILD_ENVIRONMENT: pytorch-cpp-doc-push
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py3:a8006f9a-272d-4478-b137-d121c6f05c83"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3.6-gcc5.4:a8006f9a-272d-4478-b137-d121c6f05c83"
     resource_class: large
     machine:
       image: ubuntu-1604:201903-01
@@ -1818,6 +1818,12 @@ workflows:
           build_environment: "pytorch-linux-xenial-py3.6-gcc5.4-test"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3.6-gcc5.4:a8006f9a-272d-4478-b137-d121c6f05c83"
           resource_class: large
+      - pytorch_python_doc_push:
+          requires:
+            - pytorch_linux_xenial_py3_6_gcc5_4_build
+      - pytorch_cpp_doc_push:
+          requires:
+            - pytorch_linux_xenial_py3_6_gcc5_4_build
       - pytorch_linux_test:
           name: pytorch_linux_backward_compatibility_check_test
           requires:
@@ -1965,12 +1971,6 @@ workflows:
           build_environment: "pytorch-linux-xenial-cuda9-cudnn7-py3-nogpu-test"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py3:a8006f9a-272d-4478-b137-d121c6f05c83"
           resource_class: large
-      - pytorch_python_doc_push:
-          requires:
-            - pytorch_linux_xenial_cuda9_cudnn7_py3_build
-      - pytorch_cpp_doc_push:
-          requires:
-            - pytorch_linux_xenial_cuda9_cudnn7_py3_build
       - pytorch_linux_build:
           name: pytorch_libtorch_linux_xenial_cuda9_cudnn7_py3_build
           requires:

--- a/.circleci/verbatim-sources/job-specs-custom.yml
+++ b/.circleci/verbatim-sources/job-specs-custom.yml
@@ -2,7 +2,7 @@
     environment:
       BUILD_ENVIRONMENT: pytorch-python-doc-push
       # TODO: stop hardcoding this
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py3:a8006f9a-272d-4478-b137-d121c6f05c83"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3.6-gcc5.4:a8006f9a-272d-4478-b137-d121c6f05c83"
     resource_class: large
     machine:
       image: ubuntu-1604:201903-01
@@ -47,7 +47,7 @@
   pytorch_cpp_doc_push:
     environment:
       BUILD_ENVIRONMENT: pytorch-cpp-doc-push
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py3:a8006f9a-272d-4478-b137-d121c6f05c83"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3.6-gcc5.4:a8006f9a-272d-4478-b137-d121c6f05c83"
     resource_class: large
     machine:
       image: ubuntu-1604:201903-01


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#32102 Change python/cpp docs CI to use a CPU-only image**

Previously, the docs CI depended on our CUDA xenial py3 build. This
meant that the turnaround time to get signal for docs was very slow
(I've seen builds that go as much as 3 hours).

Fortunately, the docs CI do not (and should not!) rely on CUDA. This
PR changes it so that the docs CI runs on a CPU-only machine.

Fixes #29995

Test Plan:
- Check CI status on this PR by reading logs for the python and cpp docs
builds.
- I built the docs locally, once for CPU, and once for CUDA, and
verified (via diff) that the pages were exactly the same)

Differential Revision: [D19374078](https://our.internmc.facebook.com/intern/diff/D19374078)