### PR TITLE
Fix 'template' keyword warning with clang-cl and clang.exe

### DIFF
--- a/caffe2/operators/quantized/int8_conv_op.h
+++ b/caffe2/operators/quantized/int8_conv_op.h
@@ -88,7 +88,7 @@ class Int8ConvOp final : public ConvPoolOpBase<CPUContext> {
             X.scale,
             W.zero_point,
             W.scale,
-#ifndef _MSC_VER
+#if !defined(_MSC_VER) || defined(__clang__)
             W.t.template data<uint8_t>(),
             B.t.template data<int32_t>(),
 #else


### PR DESCRIPTION
Summary:
Fixes these warnings:
```
xplat\caffe2\caffe2Windows#header-mode-symlink-tree-only,headers\caffe2\operators\quantized\int8_conv_op.h(96,17): warning: use 'template' keyword to treat 'data' as a dependent template name
            W.t.data<uint8_t>(),
                ^
                template
xplat\caffe2\caffe2Windows#header-mode-symlink-tree-only,headers\caffe2\operators\quantized\int8_conv_op.h(97,17): warning: use 'template' keyword to treat 'data' as a dependent template name
            B.t.data<int32_t>(),
                ^
                template
```

Test Plan: Tested locally with clang-cl and CI for other toolchains

Differential Revision: D19353563

