### PR TITLE
remove unused code after refactoring optimizations into profiling-sensitive and profiling-insensitive

### DIFF
--- a/torch/csrc/jit/autodiff.cpp
+++ b/torch/csrc/jit/autodiff.cpp
@@ -793,24 +793,6 @@ static void lambdaLiftReverse(Gradient& grad_desc, ReverseDetails& rev_info) {
     return grad_desc.df->inputs()[capture_to_formal_index.at(v)];
   });
 
-  // if we actually profile we can rely on profiling information
-  // so we don't have to mark every gradient as possibly undefined
-  if (!getProfilingMode() && getExecutorMode()) {
-    for (size_t i = 0; i < grad_desc.df_input_vjps.size(); i++) {
-      auto tt = grad_desc.df->block()->inputs().at(i);
-      if (auto ttt = tt->type()->cast<TensorType>()) {
-        tt->setType(ttt->withPossiblyUndefined());
-      } else if (auto lt = tt->type()->cast<ListType>()) {
-        auto undef_type =
-            lt->getElementType()->expect<TensorType>()->withPossiblyUndefined();
-        tt->setType(ListType::create(undef_type));
-      } else {
-        // unexpected type
-        TORCH_INTERNAL_ASSERT(false);
-      }
-    }
-  }
-
   GRAPH_DUMP(" forward graph: ", &graph);
   GRAPH_DEBUG(" backward graph: ", *(reverse_block->owningNode()));
   // reverse_node was just to hold onto reverse_block in a debuggable way

--- a/torch/csrc/jit/graph_executor.cpp
+++ b/torch/csrc/jit/graph_executor.cpp
@@ -690,22 +690,9 @@ bool needsGradient(const std::shared_ptr<const Graph>& graph) {
     return true;
   }
 
-  if (getProfilingMode()) {
-    for (const Value* input : graph->inputs()) {
-      for (const auto& use : input->uses()) {
-        if (use.user->kind() == prim::BailOut) {
-          auto ptt = use.user->output()->type()->expect<TensorType>();
-          if (ptt->requiresGrad() && *ptt->requiresGrad()) {
-            return true;
-          }
-        }
-      }
-    }
-  } else {
-    for (const Value* input : graph->inputs()) {
-      if (input->type()->requires_grad()) {
-        return true;
-      }
+  for (const Value* input : graph->inputs()) {
+    if (input->type()->requires_grad()) {
+      return true;
     }
   }
 

--- a/torch/csrc/jit/profiling_graph_executor_impl.cpp
+++ b/torch/csrc/jit/profiling_graph_executor_impl.cpp
@@ -104,7 +104,7 @@ void ProfilingGraphExecutorImpl::runProfilingInsensitiveOptimizations(
   LowerGradOf(*copy);
   GRAPH_DUMP("runProfilingInsensitiveOptimizations", copy);
   // clear any residual undefinedness
-  // double backward graph inputs'
+  // as double backward graph inputs'
   // may carry over undefinedness
   // from profiled backward graphs
   ClearUndefinedness(copy);

--- a/torch/csrc/jit/profiling_graph_executor_impl.cpp
+++ b/torch/csrc/jit/profiling_graph_executor_impl.cpp
@@ -103,9 +103,12 @@ void ProfilingGraphExecutorImpl::runProfilingInsensitiveOptimizations(
     std::shared_ptr<Graph>& copy) {
   LowerGradOf(*copy);
   GRAPH_DUMP("runProfilingInsensitiveOptimizations", copy);
-  if (getProfilingMode()) {
-    ClearUndefinedness(copy);
-  }
+  // clear any residual undefinedness
+  // double backward graph inputs'
+  // when constructed carry over
+  // undefinedness from profiled
+  // backward graphs
+  ClearUndefinedness(copy);
   runRequiredPasses(copy);
   if (!getGraphExecutorOptimize()) {
     return;

--- a/torch/csrc/jit/profiling_graph_executor_impl.cpp
+++ b/torch/csrc/jit/profiling_graph_executor_impl.cpp
@@ -105,9 +105,8 @@ void ProfilingGraphExecutorImpl::runProfilingInsensitiveOptimizations(
   GRAPH_DUMP("runProfilingInsensitiveOptimizations", copy);
   // clear any residual undefinedness
   // double backward graph inputs'
-  // when constructed carry over
-  // undefinedness from profiled
-  // backward graphs
+  // may carry over undefinedness
+  // from profiled backward graphs
   ClearUndefinedness(copy);
   runRequiredPasses(copy);
   if (!getGraphExecutorOptimize()) {


### PR DESCRIPTION
After we removed `Specialize_AutogradZero` from the optimization pipeline of the simple executor mode, we don't need to mark any inputs as undefined in `autodiff`. Also, `needsGradient` in `graph_executor.cpp` never runs on graph with profiling information, so I removed that code as well.  