### PR TITLE
Remove javasphinx

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,4 +2,4 @@ sphinx
 -e git+https://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme
 sphinxcontrib.katex
 matplotlib
-javasphinx
+


### PR DESCRIPTION
Remove javasphinx because previous PR: https://github.com/pytorch/pytorch/pull/31955 was merged

