### PR TITLE
Use expm1(x) for precision

### DIFF
--- a/test/cpp/api/functional.cpp
+++ b/test/cpp/api/functional.cpp
@@ -774,7 +774,7 @@ TEST_F(FunctionalTest, ELU) {
       auto x = torch::linspace(-10.0, 10.0, size * size * size);
       x.resize_({size, size, size});
       auto y_exp = torch::max(torch::zeros_like(x), x) +
-                torch::min(torch::zeros_like(x), alpha * (torch::exp(x) - 1.0));
+                torch::min(torch::zeros_like(x), alpha * torch::exp1m(x));
       auto y = F::elu(x, F::ELUFuncOptions().alpha(alpha).inplace(inplace));
 
       ASSERT_EQ(y.ndimension(), 3);
@@ -797,7 +797,7 @@ TEST_F(FunctionalTest, SELU) {
       auto expected = scale *
           (torch::max(torch::zeros_like(input), input) +
            torch::min(
-               torch::zeros_like(input), alpha * (torch::exp(input) - 1)));
+               torch::zeros_like(input), alpha * torch::expm1(input));
       auto output = F::selu(input, inplace);
 
       ASSERT_TRUE(output.allclose(expected));
@@ -1371,7 +1371,7 @@ TEST_F(FunctionalTest, CELU) {
       auto x = torch::linspace(-10.0, 10.0, size * size * size);
       x.resize_({size, size, size});
       auto y_exp = torch::max(torch::zeros_like(x), x) +
-        torch::min(torch::zeros_like(x), alpha * (torch::exp(x / alpha) - 1.0));
+        torch::min(torch::zeros_like(x), alpha * torch::expm1(x / alpha));
       auto y = F::celu(x, F::CELUFuncOptions().alpha(alpha).inplace(inplace));
 
       ASSERT_EQ(y.ndimension(), 3);
@@ -1391,7 +1391,7 @@ TEST_F(FunctionalTest, CELUDefaultOptions) {
   auto x = torch::linspace(-10.0, 10.0, size * size * size);
   x.resize_({size, size, size});
   auto y_exp = torch::max(torch::zeros_like(x), x) +
-    torch::min(torch::zeros_like(x), alpha * (torch::exp(x / alpha) - 1.0));
+    torch::min(torch::zeros_like(x), alpha * torch::expm1(x / alpha));
   auto y = F::celu(x);
 
   ASSERT_EQ(y.ndimension(), 3);

--- a/test/cpp/api/functional.cpp
+++ b/test/cpp/api/functional.cpp
@@ -774,7 +774,7 @@ TEST_F(FunctionalTest, ELU) {
       auto x = torch::linspace(-10.0, 10.0, size * size * size);
       x.resize_({size, size, size});
       auto y_exp = torch::max(torch::zeros_like(x), x) +
-                torch::min(torch::zeros_like(x), alpha * torch::exp1m(x));
+                torch::min(torch::zeros_like(x), alpha * torch::expm1(x));
       auto y = F::elu(x, F::ELUFuncOptions().alpha(alpha).inplace(inplace));
 
       ASSERT_EQ(y.ndimension(), 3);
@@ -795,7 +795,7 @@ TEST_F(FunctionalTest, SELU) {
     for (const auto inplace : {false, true}) {
       auto input = torch::randn({5, 5});
       auto expected = scale *
-          (torch::max(torch::zeros_like(input), input) +
+           torch::max(torch::zeros_like(input), input) +
            torch::min(
                torch::zeros_like(input), alpha * torch::expm1(input));
       auto output = F::selu(input, inplace);

--- a/test/cpp/api/modules.cpp
+++ b/test/cpp/api/modules.cpp
@@ -2258,7 +2258,7 @@ TEST_F(ModulesTest, ELU) {
     ASSERT_EQ(y.ndimension(), 3);
     ASSERT_EQ(y.sizes(), std::vector<int64_t>({size, size, size}));
     auto y_exp = torch::max(torch::zeros_like(x), x) +
-                 torch::min(torch::zeros_like(x), alpha * (torch::exp(x) - 1.0));
+                 torch::min(torch::zeros_like(x), alpha * torch::expm1(x));
     ASSERT_TRUE(torch::allclose(y, y_exp));
   }
 }
@@ -2272,7 +2272,7 @@ TEST_F(ModulesTest, SELU) {
   auto zero = torch::zeros_like(input);
   auto expected = scale *
       (torch::max(zero, input) +
-       torch::min(zero, alpha * (torch::exp(input) - 1)));
+       torch::min(zero, alpha * torch::expm1(input));
   auto s = output.sum();
   s.backward();
 
@@ -2519,7 +2519,7 @@ TEST_F(ModulesTest, CELU) {
     ASSERT_EQ(y.ndimension(), 3);
     ASSERT_EQ(y.sizes(), std::vector<int64_t>({size, size, size}));
     auto y_exp = torch::max(torch::zeros_like(x), x) +
-        torch::min(torch::zeros_like(x), alpha * (torch::exp(x / alpha) - 1.0));
+        torch::min(torch::zeros_like(x), alpha * torch::expm1(x / alpha));
     ASSERT_TRUE(torch::allclose(y, y_exp));
   }
 }

--- a/test/cpp/api/modules.cpp
+++ b/test/cpp/api/modules.cpp
@@ -2271,7 +2271,7 @@ TEST_F(ModulesTest, SELU) {
   const double alpha = 1.6732632423543772848170429916717;
   auto zero = torch::zeros_like(input);
   auto expected = scale *
-      (torch::max(zero, input) +
+       torch::max(zero, input) +
        torch::min(zero, alpha * torch::expm1(input));
   auto s = output.sum();
   s.backward();


### PR DESCRIPTION
For small magnitude values of x, expm1(x) may be more accurate than exp(x) - 1

>>> np.exp(1e-99) - 1
0.0
>>> np.expm1(1e-99)
1e-99
 

