### PR TITLE
omit constexpr with nvcc on clang

### DIFF
--- a/c10/util/TypeIndex.h
+++ b/c10/util/TypeIndex.h
@@ -10,13 +10,45 @@
 namespace c10 {
 namespace util {
 
-#if (defined(_MSC_VER) && defined(__CUDACC__)) || (!defined(__clang__) && !defined(_MSC_VER) && defined(__GNUC__) && __GNUC__ < 9)
-// GCC<9 has issues with our implementation for constexpr typenames.
-// So does nvcc on Windows.
-// Any version of MSVC or Clang and GCC 9 are fine with it.
 // TODO Make it work for more compilers
+
+// Clang works
+#if defined(__clang__)
+
+// except for NVCC
+#if defined(__CUDACC__)
 #define C10_TYPENAME_SUPPORTS_CONSTEXPR 0
 #define C10_TYPENAME_CONSTEXPR
+#else
+#define C10_TYPENAME_SUPPORTS_CONSTEXPR 1
+#define C10_TYPENAME_CONSTEXPR constexpr
+#endif
+
+// Windows works
+#elif defined(_MSC_VER)
+
+// except for NVCC
+#if defined(__CUDACC__)
+#define C10_TYPENAME_SUPPORTS_CONSTEXPR 0
+#define C10_TYPENAME_CONSTEXPR
+#else
+#define C10_TYPENAME_SUPPORTS_CONSTEXPR 1
+#define C10_TYPENAME_CONSTEXPR constexpr
+#endif
+
+// GCC works
+#elif defined(__GNUC__)
+
+// except when gcc < 9
+#if (__GNUC__ < 9)
+#define C10_TYPENAME_SUPPORTS_CONSTEXPR 0
+#define C10_TYPENAME_CONSTEXPR
+#else
+#define C10_TYPENAME_SUPPORTS_CONSTEXPR 1
+#define C10_TYPENAME_CONSTEXPR constexpr
+#endif
+
+// some other compiler we don't know about
 #else
 #define C10_TYPENAME_SUPPORTS_CONSTEXPR 1
 #define C10_TYPENAME_CONSTEXPR constexpr


### PR DESCRIPTION
Summary: This is an attempt at clarifying some of the preprocessor boolean logic that was getting more and more complicated. The previous logic used constexpr with nvcc on clang; which we were getting compiler failures on in ovrsource with mode/linux/* (based on platform007).

Test Plan:
ovrsource xplat/caffe2 compiles
fbsource sandcastle green

Differential Revision: D19385409

Error String:
```
xplat/caffe2/c10/util/TypeIndex.h(135): error: expression must have a constant value
xplat/caffe2/c10/util/TypeIndex.h(59): note: expression cannot be interpreted
xplat/caffe2/c10/util/TypeIndex.h(74): note: called from:
          detected during:
            instantiation of "c10::string_view c10::util::get_fully_qualified_type_name<T>() [with T=caffe2::Tensor]" 
xplat/caffe2/c10/util/typeid.h(416): here
            instantiation of "c10::string_view caffe2::TypeMeta::TypeName<T>() [with T=caffe2::Tensor]" 
xplat/caffe2/caffe2/core/blob.h(89): here

```