### PR TITLE
Guard ternary with throw when compiling CUDA code

### DIFF
--- a/c10/util/TypeIndex.h
+++ b/c10/util/TypeIndex.h
@@ -53,7 +53,7 @@ inline constexpr string_view extract(
     string_view prefix,
     string_view suffix,
     string_view str) {
-#if !defined(__CUDA_ARCH__) // CUDA doesn't like std::logic_error in device code
+#if !defined(__CUDACC__) // CUDA doesn't like std::logic_error in device code
   return (!str.starts_with(prefix) || !str.ends_with(suffix))
       ? (throw std::logic_error("Invalid pattern"), string_view())
       : str.substr(prefix.size(), str.size() - prefix.size() - suffix.size());


### PR DESCRIPTION
Summary: Both host and device sides of CUDA compiler are better to see identical code

Test Plan: Compile and run

Differential Revision: D19387880

