### PR TITLE
Check for incompatible compilers with mismatching typeids

### DIFF
--- a/c10/util/TypeIndex.cpp
+++ b/c10/util/TypeIndex.cpp
@@ -1,0 +1,14 @@
+#include <c10/util/TypeIndex.h>
+
+namespace c10 {
+namespace util {
+namespace detail {
+
+CompilerClashChecker& CompilerClashChecker::singleton() {
+    static CompilerClashChecker singleton;
+    return singleton;
+}
+
+}
+}
+}

--- a/c10/util/typeid.h
+++ b/c10/util/typeid.h
@@ -63,7 +63,7 @@ class C10_API TypeIdentifier final
    * is generated during run-time. Do NOT serialize the id for storage.
    */
   template <typename T>
-  static C10_HOST_CONSTEXPR TypeIdentifier Get() noexcept {
+  static C10_TYPENAME_CONSTEXPR TypeIdentifier Get() noexcept {
     return TypeIdentifier(c10::util::get_type_index<T>());
   }
 
@@ -282,7 +282,7 @@ class _Uninitialized final {};
 
 template <class T>
 inline TypeMetaData _makeTypeMetaDataInstance() {
-  C10_HOST_CONSTEXPR_VAR auto typeId = TypeIdentifier::Get<T>();
+  C10_TYPENAME_CONSTEXPR auto typeId = TypeIdentifier::Get<T>();
   C10_TYPENAME_CONSTEXPR auto typeName = c10::util::get_fully_qualified_type_name<T>();
 
   return {sizeof(T),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #32259 [wip] fixed type names
* #32161 type index is only constexpr if typeid is
* **#32160 Check for incompatible compilers with mismatching typeids**
* #26628 Remove CAFFE_KNOWN_TYPE

Differential Revision: [D19389124](https://our.internmc.facebook.com/intern/diff/D19389124/)