### PR TITLE
type index is only constexpr if typeid is

### DIFF
--- a/c10/test/util/TypeIndex_test.cpp
+++ b/c10/test/util/TypeIndex_test.cpp
@@ -8,6 +8,8 @@ using c10::util::get_type_index;
 
 namespace {
 
+namespace test_simple_types {
+#if C10_TYPENAME_SUPPORTS_CONSTEXPR
 static_assert(get_type_index<int>() == get_type_index<int>(), "");
 static_assert(get_type_index<float>() == get_type_index<float>(), "");
 static_assert(get_type_index<int>() != get_type_index<float>(), "");
@@ -30,7 +32,31 @@ static_assert(
     get_type_index<std::function<int(double, double)>>() !=
         get_type_index<std::function<int(double)>>(),
     "");
+#endif
+TEST(TypeIndex, SimpleTypes) {
+    EXPECT_EQ(get_type_index<int>(), get_type_index<int>());
+    EXPECT_EQ(get_type_index<float>(), get_type_index<float>());
+    EXPECT_NE(get_type_index<int>(), get_type_index<float>());
+    EXPECT_EQ(
+        get_type_index<int(double, double)>(),
+        get_type_index<int(double, double)>());
+    EXPECT_NE(
+        get_type_index<int(double, double)>(),
+        get_type_index<int(double)>());
+    EXPECT_EQ(
+        get_type_index<int(double, double)>(),
+        get_type_index<int (*)(double, double)>());
+    EXPECT_EQ(
+        get_type_index<std::function<int(double, double)>>(),
+        get_type_index<std::function<int(double, double)>>());
+    EXPECT_NE(
+        get_type_index<std::function<int(double, double)>>(),
+        get_type_index<std::function<int(double)>>());
+}
+}
 
+namespace test_references_and_pointers {
+#if C10_TYPENAME_SUPPORTS_CONSTEXPR
 static_assert(get_type_index<int>() == get_type_index<int&>(), "");
 static_assert(get_type_index<int>() == get_type_index<int&&>(), "");
 static_assert(get_type_index<int>() == get_type_index<const int&>(), "");
@@ -42,16 +68,40 @@ static_assert(
     get_type_index<int(double&, double)>() !=
         get_type_index<int(double, double)>(),
     "");
+#endif
+TEST(TypeIndex, ReferencesAndPointers) {
+    EXPECT_EQ(get_type_index<int>(), get_type_index<int&>());
+    EXPECT_EQ(get_type_index<int>(), get_type_index<int&&>());
+    EXPECT_EQ(get_type_index<int>(), get_type_index<const int&>());
+    EXPECT_EQ(get_type_index<int>(), get_type_index<const int>());
+    EXPECT_EQ(get_type_index<const int>(), get_type_index<int&>());
+    EXPECT_NE(get_type_index<int>(), get_type_index<int*>());
+    EXPECT_NE(get_type_index<int*>(), get_type_index<int**>());
+    EXPECT_NE(
+        get_type_index<int(double&, double)>(),
+        get_type_index<int(double, double)>());
+}
+}
 
+namespace test_function_traits {
 struct Dummy final {};
 struct Functor final {
   int64_t operator()(uint32_t, Dummy&&, const Dummy&) const;
 };
+#if C10_TYPENAME_SUPPORTS_CONSTEXPR
 static_assert(
     get_type_index<int64_t(uint32_t, Dummy&&, const Dummy&)>() ==
         get_type_index<
             c10::guts::infer_function_traits_t<Functor>::func_type>(),
     "");
+#endif
+TEST(TypeIndex, FunctionTraits) {
+    EXPECT_EQ(
+        get_type_index<int64_t(uint32_t, Dummy&&, const Dummy&)>(),
+        get_type_index<
+            c10::guts::infer_function_traits_t<Functor>::func_type>());
+}
+}
 
 namespace test_top_level_name {
 #if C10_TYPENAME_SUPPORTS_CONSTEXPR

--- a/c10/util/TypeIndex.h
+++ b/c10/util/TypeIndex.h
@@ -89,7 +89,7 @@ inline C10_TYPENAME_CONSTEXPR c10::string_view fully_qualified_type_name_impl() 
 }
 
 template <typename T>
-inline constexpr uint64_t type_index_impl() {
+inline C10_TYPENAME_CONSTEXPR uint64_t type_index_impl() {
 #if !defined(__CUDA_ARCH__)
 // Idea: __PRETTY_FUNCTION__ (or __FUNCSIG__ on msvc) contains a qualified name
 // of this function, including its template parameter, i.e. including the
@@ -110,13 +110,17 @@ inline constexpr uint64_t type_index_impl() {
 } // namespace detail
 
 template <typename T>
-inline constexpr type_index get_type_index() {
+inline C10_TYPENAME_CONSTEXPR type_index get_type_index() {
 #if !defined(__CUDA_ARCH__)
   // To enforce that this is really computed at compile time, we pass the
   // type index through std::integral_constant.
+#if C10_TYPENAME_SUPPORTS_CONSTEXPR
   return type_index{std::integral_constant<
       uint64_t,
       detail::type_index_impl<std::remove_cv_t<std::decay_t<T>>>()>::value};
+#else
+  return type_index{detail::type_index_impl<std::remove_cv_t<std::decay_t<T>>>()};
+#endif
 #else
   // There's nothing in theory preventing us from running this on device code
   // except for nvcc throwing a compiler error if we enable it.

--- a/c10/util/TypeIndex.h
+++ b/c10/util/TypeIndex.h
@@ -152,8 +152,8 @@ public:
       if (*id_for_float != get_type_index<float>()) {
         TORCH_INTERNAL_ASSERT(false,
           "PyTorch was compiled using multiple different and incompatible compilers. ",
-          "One compiler assigned float the typeid ", *id_for_float,
-          " while the other compiler assigned it the typeid ", get_type_index<float>());
+          "A compiler whose code got loaded previously had assigned float the typeid ", *id_for_float,
+          " but the current one assigns it the typeid ", get_type_index<float>());
       }
     } else {
       id_for_float = get_type_index<float>();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #32259 [wip] fixed type names
* **#32161 type index is only constexpr if typeid is**
* #32160 Check for incompatible compilers with mismatching typeids
* #26628 Remove CAFFE_KNOWN_TYPE

Differential Revision: [D19389125](https://our.internmc.facebook.com/intern/diff/D19389125/)