### PR TITLE
Fix the passing-by-ref constructor of OperatorName.

### DIFF
--- a/aten/src/ATen/core/operator_name.h
+++ b/aten/src/ATen/core/operator_name.h
@@ -8,8 +8,8 @@ namespace c10 {
 struct OperatorName final {
   std::string name;
   std::string overload_name;
-  OperatorName(std::string name, const std::string& overload_name)
-      : name(std::move(name)), overload_name(overload_name) {}
+  OperatorName(std::string name, std::string overload_name)
+      : name(std::move(name)), overload_name(std::move(overload_name)) {}
 };
 
 inline bool operator==(const OperatorName& lhs, const OperatorName& rhs) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
Change the overload name from passing by const ref to by value and move. 
* **#32170 Fix the passing-by-ref constructor of OperatorName.**

Differential Revision: [D19396225](https://our.internmc.facebook.com/intern/diff/D19396225)