### PR TITLE
Add _from_natural_params and product_along_axis function to ExponentialFamily class

### DIFF
--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -881,10 +881,10 @@ class TestDistributions(TestCase):
         self.assertEqual(Bernoulli(torch.tensor([0.0])).entropy(), torch.tensor([0.0]))
         self.assertEqual(Bernoulli(s).entropy(), torch.tensor(0.6108), prec=1e-4)
 
-        # check _from_natural_params and product_along_axis
+        # check _from_natural_params and normalized_product
         dist_np = Bernoulli._from_natural_params(*Bernoulli(p)._natural_params)
         self.assertEqual(Bernoulli(p).probs, dist_np.probs)
-        self.assertEqual(Bernoulli(p).product_along_axis(keepdim=False).sample().size(), ())
+        self.assertEqual(Bernoulli(p).normalized_product(keepdim=False).sample().size(), ())
 
     def test_bernoulli_enumerate_support(self):
         examples = [
@@ -1183,11 +1183,11 @@ class TestDistributions(TestCase):
         self.assertEqual(Poisson(rate_1d).sample((1,)).size(), (1, 1))
         self.assertEqual(Poisson(2.0).sample((2,)).size(), (2,))
 
-        # check _from_natural_params and product_along_axis
+        # check _from_natural_params and normalized_product
         dist_np = Poisson._from_natural_params(*Poisson(rate)._natural_params)
         self.assertEqual(Poisson(rate).mean, dist_np.mean)
-        self.assertEqual(Poisson(rate).product_along_axis(keepdim=False).sample().size(), (2,))
-        self.assertEqual(Poisson(rate).product_along_axis(keepdim=False).rate, rate.prod(dim=-1))
+        self.assertEqual(Poisson(rate).normalized_product(keepdim=False).sample().size(), (2,))
+        self.assertEqual(Poisson(rate).normalized_product(keepdim=False).rate, rate.prod(dim=-1))
 
     @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
     def test_poisson_log_prob(self):
@@ -1614,11 +1614,11 @@ class TestDistributions(TestCase):
 
         self._check_log_prob(Normal(loc, scale), ref_log_prob)
 
-        # check _from_natural_params and product_along_axis
+        # check _from_natural_params and normalized_product
         dist_np = Normal._from_natural_params(*Normal(loc, scale)._natural_params)
         self.assertEqual(Normal(loc, scale).mean, dist_np.mean)
         self.assertEqual(Normal(loc, scale).variance, dist_np.variance)
-        self.assertEqual(Normal(loc, scale).product_along_axis(keepdim=False).sample().size(), (5,))
+        self.assertEqual(Normal(loc, scale).normalized_product(keepdim=False).sample().size(), (5,))
 
     @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
     def test_normal_sample(self):
@@ -1914,11 +1914,11 @@ class TestDistributions(TestCase):
 
         self._check_log_prob(Exponential(rate), ref_log_prob)
 
-        # check _from_natural_params and product_along_axis
+        # check _from_natural_params and normalized_product
         dist_np = Exponential._from_natural_params(*Exponential(rate)._natural_params)
         self.assertEqual(Exponential(rate).mean, dist_np.mean)
         self.assertEqual(Exponential(rate).variance, dist_np.variance)
-        self.assertEqual(Exponential(rate).product_along_axis(keepdim=False).sample().size(), (5,))
+        self.assertEqual(Exponential(rate).normalized_product(keepdim=False).sample().size(), (5,))
 
     @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
     def test_exponential_sample(self):
@@ -2000,11 +2000,11 @@ class TestDistributions(TestCase):
 
         self._check_log_prob(Gamma(alpha, beta), ref_log_prob)
 
-        # check _from_natural_params and product_along_axis
+        # check _from_natural_params and normalized_product
         dist_np = Gamma._from_natural_params(*Gamma(alpha, beta)._natural_params)
         self.assertEqual(Gamma(alpha, beta).mean, dist_np.mean)
         self.assertEqual(Gamma(alpha, beta).variance, dist_np.variance)
-        self.assertEqual(Gamma(alpha, beta).product_along_axis(keepdim=False).sample().size(), (2,))
+        self.assertEqual(Gamma(alpha, beta).normalized_product(keepdim=False).sample().size(), (2,))
 
     @unittest.skipIf(not TEST_CUDA, "CUDA not found")
     @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
@@ -2215,11 +2215,11 @@ class TestDistributions(TestCase):
         self.assertEqual(Dirichlet(alpha_1d).sample().size(), (4,))
         self.assertEqual(Dirichlet(alpha_1d).sample((1,)).size(), (1, 4))
 
-        # check _from_natural_params and product_along_axis
+        # check _from_natural_params and normalized_product
         dist_np = Dirichlet._from_natural_params(*Dirichlet(alpha)._natural_params)
         self.assertEqual(Dirichlet(alpha).mean, dist_np.mean)
         self.assertEqual(Dirichlet(alpha).variance, dist_np.variance)
-        self.assertEqual(Dirichlet(alpha).product_along_axis(keepdim=False).sample().size(), (3,))
+        self.assertEqual(Dirichlet(alpha).normalized_product(keepdim=False).sample().size(), (3,))
 
     @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
     def test_dirichlet_log_prob(self):
@@ -2253,11 +2253,11 @@ class TestDistributions(TestCase):
         self.assertEqual(Beta(0.1, 0.3).sample().size(), ())
         self.assertEqual(Beta(0.1, 0.3).sample((5,)).size(), (5,))
 
-        # check _from_natural_params and product_along_axis
+        # check _from_natural_params and normalized_product
         dist_np = Beta._from_natural_params(*Beta(con1, con0)._natural_params)
         self.assertEqual(Beta(con1, con0).mean, dist_np.mean)
         self.assertEqual(Beta(con1, con0).variance, dist_np.variance)
-        self.assertEqual(Beta(con1, con0).product_along_axis(keepdim=False).sample().size(), (2,))
+        self.assertEqual(Beta(con1, con0).normalized_product(keepdim=False).sample().size(), (2,))
 
     @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
     def test_beta_log_prob(self):

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -881,6 +881,11 @@ class TestDistributions(TestCase):
         self.assertEqual(Bernoulli(torch.tensor([0.0])).entropy(), torch.tensor([0.0]))
         self.assertEqual(Bernoulli(s).entropy(), torch.tensor(0.6108), prec=1e-4)
 
+        # check _from_natural_params and product_along_axis
+        dist_np = Bernoulli._from_natural_params(*Bernoulli(p)._natural_params)
+        self.assertEqual(Bernoulli(p).probs, dist_np.probs)
+        self.assertEqual(Bernoulli(p).product_along_axis(keepdim=False).sample().size(), ())
+
     def test_bernoulli_enumerate_support(self):
         examples = [
             ({"probs": [0.1]}, [[0], [1]]),
@@ -1177,6 +1182,12 @@ class TestDistributions(TestCase):
         self.assertEqual(Poisson(rate_1d).sample().size(), (1,))
         self.assertEqual(Poisson(rate_1d).sample((1,)).size(), (1, 1))
         self.assertEqual(Poisson(2.0).sample((2,)).size(), (2,))
+
+        # check _from_natural_params and product_along_axis
+        dist_np = Poisson._from_natural_params(*Poisson(rate)._natural_params)
+        self.assertEqual(Poisson(rate).mean, dist_np.mean)
+        self.assertEqual(Poisson(rate).product_along_axis(keepdim=False).sample().size(), (2,))
+        self.assertEqual(Poisson(rate).product_along_axis(keepdim=False).rate, rate.prod(dim=-1))
 
     @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
     def test_poisson_log_prob(self):
@@ -1603,6 +1614,12 @@ class TestDistributions(TestCase):
 
         self._check_log_prob(Normal(loc, scale), ref_log_prob)
 
+        # check _from_natural_params and product_along_axis
+        dist_np = Normal._from_natural_params(*Normal(loc, scale)._natural_params)
+        self.assertEqual(Normal(loc, scale).mean, dist_np.mean)
+        self.assertEqual(Normal(loc, scale).variance, dist_np.variance)
+        self.assertEqual(Normal(loc, scale).product_along_axis(keepdim=False).sample().size(), (5,))
+
     @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
     def test_normal_sample(self):
         set_rng_seed(0)  # see Note [Randomized statistical tests]
@@ -1897,6 +1914,12 @@ class TestDistributions(TestCase):
 
         self._check_log_prob(Exponential(rate), ref_log_prob)
 
+        # check _from_natural_params and product_along_axis
+        dist_np = Exponential._from_natural_params(*Exponential(rate)._natural_params)
+        self.assertEqual(Exponential(rate).mean, dist_np.mean)
+        self.assertEqual(Exponential(rate).variance, dist_np.variance)
+        self.assertEqual(Exponential(rate).product_along_axis(keepdim=False).sample().size(), (5,))
+
     @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
     def test_exponential_sample(self):
         set_rng_seed(1)  # see Note [Randomized statistical tests]
@@ -1976,6 +1999,12 @@ class TestDistributions(TestCase):
             self.assertAlmostEqual(log_prob, expected, places=3)
 
         self._check_log_prob(Gamma(alpha, beta), ref_log_prob)
+
+        # check _from_natural_params and product_along_axis
+        dist_np = Gamma._from_natural_params(*Gamma(alpha, beta)._natural_params)
+        self.assertEqual(Gamma(alpha, beta).mean, dist_np.mean)
+        self.assertEqual(Gamma(alpha, beta).variance, dist_np.variance)
+        self.assertEqual(Gamma(alpha, beta).product_along_axis(keepdim=False).sample().size(), (2,))
 
     @unittest.skipIf(not TEST_CUDA, "CUDA not found")
     @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
@@ -2186,6 +2215,12 @@ class TestDistributions(TestCase):
         self.assertEqual(Dirichlet(alpha_1d).sample().size(), (4,))
         self.assertEqual(Dirichlet(alpha_1d).sample((1,)).size(), (1, 4))
 
+        # check _from_natural_params and product_along_axis
+        dist_np = Dirichlet._from_natural_params(*Dirichlet(alpha)._natural_params)
+        self.assertEqual(Dirichlet(alpha).mean, dist_np.mean)
+        self.assertEqual(Dirichlet(alpha).variance, dist_np.variance)
+        self.assertEqual(Dirichlet(alpha).product_along_axis(keepdim=False).sample().size(), (3,))
+
     @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
     def test_dirichlet_log_prob(self):
         num_samples = 10
@@ -2217,6 +2252,12 @@ class TestDistributions(TestCase):
         self.assertEqual(Beta(con1_1d, con0_1d).sample((1,)).size(), (1, 4))
         self.assertEqual(Beta(0.1, 0.3).sample().size(), ())
         self.assertEqual(Beta(0.1, 0.3).sample((5,)).size(), (5,))
+
+        # check _from_natural_params and product_along_axis
+        dist_np = Beta._from_natural_params(*Beta(con1, con0)._natural_params)
+        self.assertEqual(Beta(con1, con0).mean, dist_np.mean)
+        self.assertEqual(Beta(con1, con0).variance, dist_np.variance)
+        self.assertEqual(Beta(con1, con0).product_along_axis(keepdim=False).sample().size(), (2,))
 
     @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
     def test_beta_log_prob(self):

--- a/torch/distributions/bernoulli.py
+++ b/torch/distributions/bernoulli.py
@@ -108,5 +108,9 @@ class Bernoulli(ExponentialFamily):
     def _natural_params(self):
         return (torch.log(self.probs / (1 - self.probs)), )
 
+    @staticmethod
+    def _from_natural_params(p, **kwargs):
+        return Bernoulli(logits=p, **kwargs)
+
     def _log_normalizer(self, x):
         return torch.log(1 + torch.exp(x))

--- a/torch/distributions/beta.py
+++ b/torch/distributions/beta.py
@@ -86,5 +86,9 @@ class Beta(ExponentialFamily):
     def _natural_params(self):
         return (self.concentration1, self.concentration0)
 
+    @staticmethod
+    def _from_natural_params(p1, p2, **kwargs):
+        return Beta(p1, p2, **kwargs)
+
     def _log_normalizer(self, x, y):
         return torch.lgamma(x) + torch.lgamma(y) - torch.lgamma(x + y)

--- a/torch/distributions/dirichlet.py
+++ b/torch/distributions/dirichlet.py
@@ -91,5 +91,9 @@ class Dirichlet(ExponentialFamily):
     def _natural_params(self):
         return (self.concentration, )
 
+    @staticmethod
+    def _from_natural_params(p, **kwargs):
+        return Dirichlet(p, **kwargs)
+
     def _log_normalizer(self, x):
         return x.lgamma().sum(-1) - torch.lgamma(x.sum(-1))

--- a/torch/distributions/exp_family.py
+++ b/torch/distributions/exp_family.py
@@ -63,7 +63,7 @@ class ExponentialFamily(Distribution):
     def _from_natural_params(*params):
         raise NotImplementedError
 
-    def normalized_product(self, dim=-1, keepdim=True):
+    def normalized_product(self, dim=-1, keepdim=False):
         r"""
         Returns a new distribution object whose probability mass/density function is the normalized product 
         of the probability mass/density functions along given axis. The product of exponential family 

--- a/torch/distributions/exp_family.py
+++ b/torch/distributions/exp_family.py
@@ -65,19 +65,19 @@ class ExponentialFamily(Distribution):
 
     def normalized_product(self, dim=-1, keepdim=False):
         r"""
-        Returns a new distribution object whose probability mass/density function is the normalized product 
-        of the probability mass/density functions along given axis. The product of exponential family 
-        distributions results in a distribution in the same family, but with new natural parameters :math:`\sum(\theta)` 
+        Returns a new distribution object whose probability mass/density function is the normalized product
+        of the probability mass/density functions along given axis. The product of exponential family
+        distributions results in a distribution in the same family, but with new natural parameters :math:`\sum(\theta)`
 
         .. math::
 
             \frac{1}{c} \prod_i p_{F}(x; \theta_i) = \exp(\langle t(x), \sum_i\theta_i\rangle - F(\sum_i\theta_i) + k(x))
 
-        where c is the normalization constant and i is the index along given dimension.
+        where :math:`c` is the normalization constant and :math:`i` is the index along given dimension.
 
         For a batched distribution d and a single observation x::
 
-        d.prod(dim).log_prob(x) = d.log_prob(x).sum(dim) + c
+            d.prod(dim).log_prob(x) = d.log_prob(x).sum(dim) + constant
 
         This might be useful for models such as Product-of-Experts (Hinton, 1999):
 
@@ -85,9 +85,9 @@ class ExponentialFamily(Distribution):
 
             p(\textbf{d}; \theta_1...\theta_n) = \frac{\prod_m p_m(\textbf{d}|\theta_m)}{\sum_i\prod_m p_m(\textbf{c}_i|\theta_m)}
 
-        where d is a data vector in a discrete space, m is all the parameters of individual model m, 
-        :math:`p_m(\textbf{d}|\theta_m)` is the probability of d under model m, and i is an index over all possible 
-        vectors in the data space.
+        where :math:`\textbf{d}` is a data vector in a discrete space, :math:`\theta_m` is all the parameters of individual model m,
+        :math:`p_m(\textbf{d}|\theta_m)` is the probability of :math:`\textbf{d}` under model :math:`m`, and :math:`i` is an index
+        over all possible vectors in the data space.
         """
 
         if dim >= 0:

--- a/torch/distributions/exp_family.py
+++ b/torch/distributions/exp_family.py
@@ -58,3 +58,14 @@ class ExponentialFamily(Distribution):
         for np, g in zip(nparams, gradients):
             result -= np * g
         return result
+
+    @staticmethod
+    def _from_natural_params(*params):
+        raise NotImplementedError
+
+    def product_along_axis(self, dim=-1, keepdim=True):
+        if dim >= 0:
+            dim = dim - len(self.batch_shape) - 1
+        dim = dim - len(self.event_shape)
+        params = [p.sum(dim, keepdim=keepdim) for p in self._natural_params]
+        return self._from_natural_params(*params)

--- a/torch/distributions/exp_family.py
+++ b/torch/distributions/exp_family.py
@@ -64,7 +64,7 @@ class ExponentialFamily(Distribution):
         raise NotImplementedError
 
     def normalized_product(self, dim=-1, keepdim=True):
-        """
+        r"""
         Returns a new distribution object whose probability mass/density function is the normalized product 
         of the probability mass/density functions along given axis. The product of exponential family 
         distributions results in a distribution in the same family, but with new natural parameters :math:`\sum(\theta)` 
@@ -86,9 +86,10 @@ class ExponentialFamily(Distribution):
             p(\textbf{d}; \theta_1...\theta_n) = \frac{\prod_m p_m(\textbf{d}|\theta_m)}{\sum_i\prod_m p_m(\textbf{c}_i|\theta_m)}
 
         where d is a data vector in a discrete space, m is all the parameters of individual model m, 
-        :math:`p_m(\textbf{d}|\theta_m)` is the probability of d under model m, and i is an index over all possible vectors in the data space.
-
+        :math:`p_m(\textbf{d}|\theta_m)` is the probability of d under model m, and i is an index over all possible 
+        vectors in the data space.
         """
+
         if dim >= 0:
             dim = dim - len(self.batch_shape) - 1
         dim = dim - len(self.event_shape)

--- a/torch/distributions/exponential.py
+++ b/torch/distributions/exponential.py
@@ -79,5 +79,9 @@ class Exponential(ExponentialFamily):
     def _natural_params(self):
         return (-self.rate, )
 
+    @staticmethod
+    def _from_natural_params(p, **kwargs):
+        return Exponential(rate=-p, **kwargs)
+
     def _log_normalizer(self, x):
         return -torch.log(-x)

--- a/torch/distributions/gamma.py
+++ b/torch/distributions/gamma.py
@@ -78,5 +78,11 @@ class Gamma(ExponentialFamily):
     def _natural_params(self):
         return (self.concentration - 1, -self.rate)
 
+    @staticmethod
+    def _from_natural_params(p1, p2, **kwargs):
+        concentration = p1 + 1
+        rate = -p2
+        return Gamma(concentration, rate, **kwargs)
+
     def _log_normalizer(self, x, y):
         return torch.lgamma(x + 1) + (x + 1) * torch.log(-y.reciprocal())

--- a/torch/distributions/normal.py
+++ b/torch/distributions/normal.py
@@ -92,5 +92,11 @@ class Normal(ExponentialFamily):
     def _natural_params(self):
         return (self.loc / self.scale.pow(2), -0.5 * self.scale.pow(2).reciprocal())
 
+    @staticmethod
+    def _from_natural_params(p1, p2, **kwargs):
+        loc = (-0.5) * p1 / p2
+        scale = torch.rsqrt(p2 * (-2))
+        return Normal(loc, scale, **kwargs)
+
     def _log_normalizer(self, x, y):
         return -0.25 * x.pow(2) / y + 0.5 * torch.log(-math.pi / y)

--- a/torch/distributions/normal.py
+++ b/torch/distributions/normal.py
@@ -94,8 +94,9 @@ class Normal(ExponentialFamily):
 
     @staticmethod
     def _from_natural_params(p1, p2, **kwargs):
-        loc = (-0.5) * p1 / p2
-        scale = torch.rsqrt(p2 * (-2))
+        p2_ = p2 * -2
+        loc = p1 / p2_
+        scale = p2_.rsqrt_()
         return Normal(loc, scale, **kwargs)
 
     def _log_normalizer(self, x, y):

--- a/torch/distributions/poisson.py
+++ b/torch/distributions/poisson.py
@@ -66,9 +66,9 @@ class Poisson(ExponentialFamily):
     def _natural_params(self):
         return (torch.log(self.rate), )
 
-    def _log_normalizer(self, x):
-        return torch.exp(x)
-
     @staticmethod
     def _from_natural_params(p, **kwargs):
         return Poisson(torch.exp(p), **kwargs)
+
+    def _log_normalizer(self, x):
+        return torch.exp(x)

--- a/torch/distributions/poisson.py
+++ b/torch/distributions/poisson.py
@@ -68,3 +68,7 @@ class Poisson(ExponentialFamily):
 
     def _log_normalizer(self, x):
         return torch.exp(x)
+
+    @staticmethod
+    def _from_natural_params(p, **kwargs):
+        return Poisson(torch.exp(p), **kwargs)


### PR DESCRIPTION
For implementing models like IOMM (http://mlg.eng.cam.ac.uk/zoubin/papers/HelGha07over.pdf) or Product of Experts (https://www.cs.toronto.edu/~hinton/absps/icann-99.pdf), we need the product of PDFs. Interestingly, the product of exponential family distributions is also an exponential family distribution where the natural parameters are just summed up (see IOMM paper for a derivation).

With the help of @fritzo, I implemented two small methods, `_from_natural_params` and `product_along_axis` to ExponentialFamily class and relevant exponential family classes and added tests. 

For a quick test, you can check `Poisson(torch.tensor([3., 10., 2.])).product_along_axis(keepdim=False).rate` is 60.

