### PR TITLE
Freezing Torchscript modules

### DIFF
--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -1740,6 +1740,15 @@ struct CAFFE2_API ClassType : public NamedType {
   void addMethod(Function* method);
   Function* getMethod(const std::string& name) const;
 
+  // [Internal Only] Remove method from the ClassType
+  // caller is responsible to make sure the modification is safe:
+  // it is unsafe to having existing allocations
+  // of this object around anymore, and any code that works on
+  // the attribute is now invalid. Only newly created code is
+  // valid again.
+  // Note this method is intended for freezing only.
+  void unsafeRemoveMethod(const std::string& name);
+
   std::shared_ptr<CompilationUnit> compilation_unit();
   std::shared_ptr<const CompilationUnit> compilation_unit() const;
 

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -432,6 +432,7 @@ if (NOT INTERN_BUILD_MOBILE OR NOT BUILD_CAFFE2_MOBILE)
     ${TORCH_SRC_DIR}/csrc/jit/passes/utils/memory_dag.cpp
     ${TORCH_SRC_DIR}/csrc/jit/passes/quantization.cpp
     ${TORCH_SRC_DIR}/csrc/jit/passes/fuse_linear.cpp
+    ${TORCH_SRC_DIR}/csrc/jit/passes/freeze_module.cpp
     ${TORCH_SRC_DIR}/csrc/jit/runtime/print_handler.cpp
     ${TORCH_SRC_DIR}/csrc/jit/codegen/fuser/interface.cpp
     ${TORCH_SRC_DIR}/csrc/jit/runtime/register_prim_ops.cpp

--- a/test/jit/test_freezing.py
+++ b/test/jit/test_freezing.py
@@ -1,0 +1,569 @@
+import torch
+import torch.nn as nn
+from torch.testing._internal.jit_utils import JitTestCase
+
+from torch.testing import FileCheck
+
+import io
+
+if __name__ == '__main__':
+    raise RuntimeError("This test file is not meant to be run directly, use:\n\n"
+                       "\tpython test/test_jit.py TESTNAME\n\n"
+                       "instead.")
+
+class TestFreezing(JitTestCase):
+    def test_fold_quantize_freeze(self):
+        class M(nn.Module):
+            def __init__(self):
+                super(M, self).__init__()
+                self.weight = nn.Parameter(torch.tensor([2], dtype=torch.float))
+
+            def forward(self, x):
+                return torch.quantize_per_tensor(self.weight, 2.0, 0, torch.quint8)
+
+        m = torch.jit.script(M())
+        m.eval()
+        torch._C._jit_pass_fold_quantize(m._c, 'forward')
+        m._c = torch._C._freeze_module(m._c)
+        self.assertFalse(m._c.hasattr('_quantized_weight'))
+        FileCheck().check_not('GetAttr[name=') \
+                   .run(m._c._get_method('forward').graph)
+        buffer = io.BytesIO()
+        torch.jit.save(m, buffer)
+        buffer.seek(0)
+        m_l = torch.jit.load(buffer)
+        self.assertFalse(m_l._c.hasattr('_quantized_weight'))
+        FileCheck().check_not('GetAttr[name=') \
+                   .run(m_l._c._get_method('forward').graph)
+
+    def test_freeze_module(self):
+        class M(nn.Module):
+            def __init__(self):
+                super(M, self).__init__()
+                self.a = 1         # folded
+                self.b = 1.2       # folded
+                self.c = "hello"   # folded
+                self.d = [1, 1]     # folded
+                self.e = [1.0, 1.1]  # folded
+                self.f = ["hello", "world"]  # folded
+                self.g = ([1, 2], 3.2, "4.4", torch.tensor([5.5], requires_grad=True))     # folded
+                self.h = {"layer" : "dict"}   # not folded. dictionary not yet supported
+                self.t = torch.tensor([1.2, 2.4], requires_grad=True)  # folded
+                self.ts = [torch.tensor([1.0, 2.0], requires_grad=True), torch.tensor([3.0, 4.0], requires_grad=True)]  # folded
+                self.tt = [[torch.tensor([3.3, 2.3], requires_grad=True), None]]  # not folded. Generic list not yet folded
+
+            def forward(self, x):
+                return str(self.a) + str(self.b) + self.c + str(self.d) + \
+                    str(self.e) + str(self.f) + str(self.g) + self.h['layer'] + str(self.t) + str(self.ts) + str(self.tt)
+
+
+        m = torch.jit.script(M())
+        m.eval()
+        input = torch.randn(2, 2)
+        output_s = m.forward(input)
+        m._c = torch._C._freeze_module(m._c)
+        self.assertFalse(m._c.hasattr('a'))
+        self.assertFalse(m._c.hasattr('b'))
+        self.assertFalse(m._c.hasattr('c'))
+        self.assertFalse(m._c.hasattr('d'))
+        self.assertFalse(m._c.hasattr('e'))
+        self.assertFalse(m._c.hasattr('f'))
+        self.assertFalse(m._c.hasattr('g'))
+        self.assertTrue(m._c.hasattr('h'))
+        self.assertFalse(m._c.hasattr('t'))
+        self.assertFalse(m._c.hasattr('ts'))
+        self.assertTrue(m._c.hasattr('tt'))
+        output_f = m.forward(input)
+        self.assertEqual(output_s, output_f)
+
+    def test_freeze_module_with_submodule(self):
+        class SubModule(nn.Module):
+            def __init__(self):
+                super(SubModule, self).__init__()
+                self.a = 11
+                self.b = 2
+
+            def forward(self, x):
+                return self.a + self.b
+
+        class SubModule2(nn.Module):
+            def __init__(self):
+                super(SubModule2, self).__init__()
+                self.a = 12
+                self.b = 2
+
+            def forward(self, x):
+                self.b = 30
+                return self.a + self.b
+
+        class TestModule(nn.Module):
+            def __init__(self):
+                super(TestModule, self).__init__()
+                self.sub1 = SubModule()
+                self.sub2 = SubModule2()
+                self.a = 3
+                self.b = 4
+
+            def forward(self, x):
+                self.b = 20
+                return self.sub1(x) + self.a + self.b + self.sub2(x)
+
+        m = torch.jit.script(TestModule())
+        m.eval()
+        input = torch.randn(2, 2)
+        output_s = m.forward(input)
+        mf = torch._C._freeze_module(m._c)
+        self.assertFalse(mf.hasattr('sub1'))
+        self.assertFalse(mf.hasattr('a'))
+        self.assertTrue(mf.hasattr('b'))
+        self.assertTrue(mf.hasattr('sub2'))
+        output_f = mf.forward(input)
+        self.assertEqual(output_s, output_f)
+
+    def test_freeze_module_with_inplace_mutable(self):
+        class FreezeMe(torch.jit.ScriptModule):
+            def __init__(self):
+                super(FreezeMe, self).__init__()
+                self.a = [11, 22]
+
+            @torch.jit.script_method
+            def forward(self, x):
+                for i in range(3):
+                    self.a.append(i)
+                return self.a
+
+        m = FreezeMe()
+        m.eval()
+        m_f = torch._C._freeze_module(m._c)
+        self.assertTrue(m_f.hasattr('a'))
+        m.forward(torch.tensor([3]))
+        out = m_f.forward(torch.tensor([5]))
+        expected = [11, 22, 0, 1, 2, 0, 1, 2]
+        self.assertEqual(out, expected)
+
+    # Mutable attributes
+    def test_freeze_module_with_mutable_list(self):
+        class FreezeMe(nn.Module):
+            def __init__(self):
+                super(FreezeMe, self).__init__()
+                self.a = [1, 2]
+
+            def forward(self, x):
+                return self.a
+
+        m = FreezeMe()
+        m.eval()
+        m.a.append(3)
+        m_s = torch.jit.script(m)
+        v = m_s.a
+        v.append(4)
+        m_s.a = v
+        m_s.eval()
+        m_f = torch._C._freeze_module(m_s._c)
+        # Post-freezing mutating m_s.a  does not affect m_f (m_f has its own copy).
+        v = m_s.a
+        v.append(5)
+        m_s.a = v
+        self.assertFalse(m_f.hasattr('a'))
+        out = m_f.forward(torch.tensor([5]))
+        expected = [1, 2, 3, 4]
+        self.assertEqual(out, expected)
+
+    def test_freeze_module_with_mutable_dict(self):
+        class FreezeMe(nn.Module):
+            def __init__(self):
+                super(FreezeMe, self).__init__()
+                self.a = {"layer" : "4"}
+
+            def forward(self, x):
+                return self.a
+
+            @torch.jit.export
+            def modify_a(self, x):
+                self.a["layer"] = self.a["layer"] + "1"
+                return self.a
+
+        m = FreezeMe()
+        m.eval()
+        m.a["layer2"] = "3"
+        m_s = torch.jit.script(m)
+        t = torch.tensor(5)
+        m_s.modify_a(t)
+        m_s.eval()
+        m_f = torch._C._freeze_module(m_s._c)
+        m.a["layer2"] += "2"
+        m_s.modify_a(t)
+        self.assertTrue(m_f.hasattr('a'))
+        out = m_f.forward(t)
+        expected = {"layer" : "411", "layer2" : "3"}
+        self.assertEqual(out, expected)
+
+    def test_freeze_module_with_mutable_tensor(self):
+        class FreezeMe(nn.Module):
+            def __init__(self):
+                super(FreezeMe, self).__init__()
+                self.a = torch.tensor([1., 2., 3.])
+
+            def forward(self, x):
+                return self.a
+
+        m = FreezeMe()
+        m_s = torch.jit.script(m)
+        m_s.a[1] += 3.0
+        m_s.eval()
+        m_f = torch._C._freeze_module(m_s._c)
+        # Post-freezing tensor attribute mutations affect m_f.
+        # FIXME: deep copy all folded attributes so that m_f has full ownership.
+        m_s.a[0] += 5.0
+        self.assertFalse(m_f.hasattr('a'))
+        out = m_f.forward(torch.tensor([5]))
+        expected = [6., 5., 3.]
+        self.assertEqual(out, expected)
+
+    def test_freeze_module_with_tuple(self):
+        class FreezeMe(nn.Module):
+            def __init__(self):
+                super(FreezeMe, self).__init__()
+                self.a = (torch.tensor([1, 2, 3, 4, 5, 6]), "hi")
+
+            def forward(self, x):
+                if (x[0] == 2.0):
+                    self.a[0][0] = 10
+                return self.a[0].sum()
+
+        m = FreezeMe()
+        m_s = torch.jit.script(m)
+        m_s.eval()
+        inp = torch.tensor([2.0])
+        expected = m_s.forward(inp)
+        m_s.a[0][0] = 1
+        m_f = torch._C._freeze_module(m_s._c)
+        self.assertFalse(m_f.hasattr('a'))
+        out = m_f.forward(inp)
+        self.assertEqual(out, expected)
+
+    def test_freeze_module_with_tensor(self):
+        class FreezeMe(nn.Module):
+            def __init__(self):
+                super(FreezeMe, self).__init__()
+                self.a = torch.tensor([1, 2, 3, 4, 5, 6])
+
+            def forward(self, x):
+                x = self.a.view(2, 3)
+                x[0][0] += 10
+                return self.a.sum()
+
+        m = FreezeMe()
+        m_s = torch.jit.script(m)
+        m_s.eval()
+        inp = torch.tensor([5])
+        expected = m_s.forward(inp)
+        m_f = torch._C._freeze_module(m_s._c)
+        self.assertTrue(m_f.hasattr('a'))
+        m_f.a[0] -= 10
+        out = m_f.forward(inp)
+        self.assertEqual(out, expected)
+
+    def test_freeze_module_with_list(self):
+        class FreezeMe(nn.Module):
+            def __init__(self):
+                super(FreezeMe, self).__init__()
+                self.a = [torch.tensor([1, 2, 3, 4, 5, 6])]
+
+            def forward(self, x):
+                self.a[0][1] += 10
+                return self.a[0].sum()
+
+        m = FreezeMe()
+        m_s = torch.jit.script(m)
+        m_s.eval()
+        inp = torch.tensor([5])
+        expected = m_s.forward(inp)
+        m_s.a[0][1] -= 10
+        m_f = torch._C._freeze_module(m_s._c)
+        self.assertFalse(m_f.hasattr('a'))
+        out = m_f.forward(inp)
+        self.assertEqual(out, expected)
+
+    def test_freeze_module_with_aliased_tensor_attr(self):
+        class FreezeMe(nn.Module):
+            def __init__(self):
+                super(FreezeMe, self).__init__()
+                self.a = torch.tensor([1, 2, 3, 4, 5, 6])
+                self.b = self.a.view(2, 3)
+
+            def forward(self, x):
+                self.b[1] += 10
+                return self.a.sum()
+
+        m = FreezeMe()
+        m_s = torch.jit.script(m)
+        m_s.eval()
+        m_f = torch._C._freeze_module(m_s._c)
+        self.assertTrue(m_f.hasattr('a'))
+        inp = torch.tensor([5])
+        out = m_f.forward(inp)
+        expected = torch.tensor(51)  # 1+2+3+14+15+16
+        self.assertEqual(out, expected)
+
+    def test_freeze_module_with_aliased_tensor_attr2(self):
+        class FreezeMe(nn.Module):
+            def __init__(self):
+                super(FreezeMe, self).__init__()
+                self.a = torch.tensor([1, 2, 3, 4, 5, 6])
+                self.b = {"layer" : ([self.a.view(2, 3), torch.tensor([10])], 20)}
+                self.c = ([self.a.view(2, 3), torch.tensor([10])], 20)
+                self.d = (self.a.view(2, 3), 20)
+
+            def forward(self, x):
+                self.d[0][0] += 10
+                return self.a.sum() 
+
+        m = FreezeMe()
+        m_s = torch.jit.script(m)
+        m_s.eval()
+        inp = torch.tensor([5])
+        expected = m_s.forward(inp)
+        with self.assertRaisesRegex(RuntimeError, "module contains attributes values that overlaps"):
+            m_f = torch._C._freeze_module(m_s._c)
+
+    def test_freeze_module_with_aliased_tensor_attr3(self):
+        class FreezeMe(nn.Module):
+            def __init__(self):
+                super(FreezeMe, self).__init__()
+                self.a = torch.tensor([1, 2, 3, 4, 5, 6])
+                self.b = [self.a, torch.tensor([10])]
+
+            def forward(self, x):
+                self.a[1] += 10
+                return self.b[0].sum()
+
+        m = FreezeMe()
+        m_s = torch.jit.script(m)
+        m_s.eval()
+        inp = torch.tensor([5])
+        expected = m_s.forward(inp)
+        m_f = torch._C._freeze_module(m_s._c)
+        self.assertTrue(m_f.hasattr('a'))
+        self.assertTrue(m_f.hasattr('b'))
+        out = m_f.forward(inp)
+        expected += 10  # account for  self.a += 10.
+        self.assertEqual(out, expected)
+
+    def test_freeze_module_with_aliased_tensor_attr4(self):
+        class FreezeMe(nn.Module):
+            def __init__(self):
+                super(FreezeMe, self).__init__()
+                self.a = torch.tensor([1, 2, 3, 4, 5, 6])
+                self.b = [self.a, torch.tensor([10])]
+
+            def forward(self, x):
+                self.b[0][0] += 10
+                return self.a.sum()
+
+        m = FreezeMe()
+        m_s = torch.jit.script(m)
+        m_s.eval()
+        inp = torch.tensor([5])
+        expected = m_s.forward(inp)
+        m_s.a[0] -= 10
+        with self.assertRaisesRegex(RuntimeError, "module contains attributes values that overlaps"):
+            m_f = torch._C._freeze_module(m_s._c)
+
+    def test_freeze_module_with_overlapping_attrs(self):
+        a = torch.tensor([1, 2, 3, 4, 5, 6])
+
+        class FreezeMe(nn.Module):
+            def __init__(self):
+                super(FreezeMe, self).__init__()
+                self.b = [a.view(3, 2), torch.tensor([10])]
+                self.c = (20, a.view(2, 3))
+
+            def forward(self, x):
+                self.b[0][0] += 10
+                return self.c[1].sum()
+
+        m = FreezeMe()
+        m_s = torch.jit.script(m)
+        m_s.eval()
+        inp = torch.tensor([5])
+        expected = m_s.forward(inp)
+        a[0] -= 10
+        with self.assertRaisesRegex(RuntimeError, "module contains attributes values that overlaps"):
+            m_f = torch._C._freeze_module(m_s._c)
+
+    def test_freeze_module_with_aliased_attr(self):
+        class FreezeMe(nn.Module):
+            def __init__(self):
+                super(FreezeMe, self).__init__()
+                self.a = [1, 2, 3, 4, 5, 6]
+                self.b = self.a
+                self.c = (self.a, 10)
+
+            def forward(self, x):
+                self.b[1] += 10
+                return str(self.a) + str(self.c)
+
+        m = FreezeMe()
+        m_s = torch.jit.script(m)
+        m_s.eval()
+        m_f = torch._C._freeze_module(m_s._c)
+        # FIXME: It should be assertTrue. Currently scripting is making a copy for setting self.b (see #33034)
+        self.assertFalse(m_f.hasattr('a'))
+        self.assertFalse(m_f.hasattr('c'))
+        inp = torch.tensor([5])
+        out = m_f.forward(inp)
+        expected = m_s.forward(inp)
+        self.assertEqual(out, expected)
+
+    # Check attribute a is preserved. Alias analysis detects that 'a' has output writers.
+    # In this example, 'a' is not mutated. However, we do not track which sub
+    # values of a composite ivalue is mutated.
+    def test_freeze_module_with_aliased_attr2(self):
+        class FreezeMe(nn.Module):
+            def __init__(self):
+                super(FreezeMe, self).__init__()
+                self.a = [1, 2, 3, 4, 5, 6]
+                self.b = ([11], [10])
+
+            def forward(self, x):
+                v = self.a
+                self.b = (v, [12])
+                v2 = self.b[1]
+                v2.append(7)
+                return str(v) + str(v2)
+
+        m = FreezeMe()
+        m_s = torch.jit.script(m)
+        m_s.eval()
+        m_f = torch._C._freeze_module(m_s._c)
+        self.assertTrue(m_f.hasattr('a'))
+        inp = torch.tensor([5])
+        out = m_f.forward(inp)
+        expected = m.forward(inp)
+        self.assertEqual(out, expected)
+
+    def test_freeze_module_with_aliased_attr3(self):
+        class FreezeMe(nn.Module):
+            def __init__(self):
+                super(FreezeMe, self).__init__()
+                self.a = [1, 2, 3, 4, 5, 6]
+                self.b = ([11], [10])
+
+            def forward(self, x):
+                v = self.a
+                v2 = (v, [12])
+                v3 = v2[0]
+                v3.append(7)
+                return str(self.a)
+
+        m = FreezeMe()
+        m_s = torch.jit.script(m)
+        m_s.eval()
+        m_f = torch._C._freeze_module(m_s._c)
+        self.assertTrue(m_f.hasattr('a'))
+        inp = torch.tensor([5])
+        out = m_f.forward(inp)
+        expected = m.forward(inp)
+        self.assertEqual(out, expected)
+
+    def test_freeze_module_return_self(self):
+        class FreezeMe(nn.Module):
+            def __init__(self):
+                super(FreezeMe, self).__init__()
+                self.a = torch.tensor([1., 2., 3.])
+
+            def forward(self, x):
+                return self
+
+        m = FreezeMe()
+        m_s = torch.jit.script(m)
+        m_s.eval()
+        with self.assertRaisesRegex(RuntimeError, "attempted to freeze a module that return itself"):
+            m_f = torch._C._freeze_module(m_s._c)
+
+    def test_freeze_module_return_sub_module(self):
+
+        class FreezeMe(nn.Module):
+            def __init__(self):
+                super(FreezeMe, self).__init__()
+                self.conv1 = nn.Conv2d(1, 32, 3, 1)
+
+            def forward(self, x):
+                return self.conv1
+
+        m = FreezeMe()
+        m_s = torch.jit.script(m)
+        m_s.eval()
+        m_f = torch._C._freeze_module(m_s._c)
+        self.assertTrue(m_f.hasattr('conv1'))
+
+
+    def test_freeze_module_in_training_mode(self):
+        class Net(nn.Module):
+            def __init__(self):
+                super(Net, self).__init__()
+                self.conv1 = nn.Conv2d(1, 32, 3, 1)
+                self.conv2 = nn.Conv2d(32, 64, 3, 1)
+                self.dropout1 = nn.Dropout2d(0.25)
+                self.dropout2 = nn.Dropout2d(0.5)
+                self.fc1 = nn.Linear(9216, 128)
+                self.fc2 = nn.Linear(128, 10)
+
+            def forward(self, x):
+                x = self.conv1(x)
+                x = nn.functional.relu(x)
+                x = self.conv2(x)
+                x = nn.functional.max_pool2d(x, 2)
+                x = self.dropout1(x)
+                x = torch.flatten(x, 1)
+                x = self.fc1(x)
+                x = nn.functional.relu(x)
+                x = self.dropout2(x)
+                x = self.fc2(x)
+                output = nn.functional.log_softmax(x, dim=1)
+                return output
+
+        model = torch.jit.script(Net())
+        model.train()
+
+        with self.assertRaisesRegex(RuntimeError, '!module.is_training()'):
+            mTrain_freezed = torch._C._freeze_module(model._c)
+
+        model.eval()
+        mEval_freezed = torch._C._freeze_module(model._c)
+        self.assertFalse(mEval_freezed.hasattr('conv1'))
+        self.assertFalse(mEval_freezed.hasattr('conv2'))
+        self.assertFalse(mEval_freezed.hasattr('dropout1'))
+        self.assertFalse(mEval_freezed.hasattr('training'))
+        self.assertFalse(mEval_freezed.hasattr('fc1'))
+        self.assertFalse(mEval_freezed.hasattr('dropout2'))
+        self.assertFalse(mEval_freezed.hasattr('fc2'))
+        with self.assertRaisesRegex(RuntimeError, "does not have a field with name 'state_dict'"):
+            print(mEval_freezed.state_dict())
+        buffer = io.BytesIO()
+        torch.jit.save(mEval_freezed, buffer)
+        buffer.seek(0)
+        m = torch.jit.load(buffer)
+        FileCheck().check_not('GetAttr[name=') \
+                   .run(m._c._get_method('forward').graph)
+
+
+
+    def test_freeze_module_detach_gradient(self):
+        mod = nn.Conv2d(8, 3, 4, 2, 1)
+        self.assertTrue(mod.weight.requires_grad)
+        smod = torch.jit.script(mod)
+        smod.eval()
+        fmod = torch._C._freeze_module(smod._c)
+        self.assertTrue(mod.weight.requires_grad)
+        self.assertTrue(smod.weight.requires_grad)
+        self.assertFalse(fmod.hasattr('weight'))
+        inp = torch.ones(1, 8, 32, 32)
+        out1 = fmod.forward(inp)
+        # FIXME: frozen module mutated from outside (original module).
+        smod.weight[0, 0, 0, 0] += 100.0
+        out2 = fmod.forward(inp)
+        out3 = smod(inp)
+        self.assertNotEqual(out1, out2)
+        self.assertEqual(out2, out3)

--- a/test/jit/test_module_interface.py
+++ b/test/jit/test_module_interface.py
@@ -405,3 +405,44 @@ class TestModuleInterface(JitTestCase):
 
         scripted_mod.proxy_mod = NewScriptModule()
         self.assertEqual(scripted_mod(input), input * (input + 1) + 1)
+
+    # The call to forward of proxy_mod cannot be inlined. Making sure
+    # Freezing is throwing an error for now.
+    def test_freeze_module_with_interface(self):
+        class SubModule(torch.nn.Module):
+            def __init__(self):
+                super(SubModule, self).__init__()
+                self.b = 20
+
+            def forward(self, x):
+                return self.b
+
+        class OrigMod(torch.nn.Module):
+            def __init__(self):
+                super(OrigMod, self).__init__()
+                self.a = 0
+
+            def forward(self, x):
+                return self.a
+
+        @torch.jit.interface
+        class ModInterface(torch.nn.Module):
+            def forward(self, x):
+                # type:  (Tensor) -> int
+                pass
+
+        class TestModule(torch.nn.Module):
+            proxy_mod : ModInterface
+
+            def __init__(self):
+                super(TestModule, self).__init__()
+                self.proxy_mod = OrigMod()
+                self.sub = SubModule()  # folded
+
+            def forward(self, x):
+                return self.proxy_mod(x) + self.sub(x)
+
+        m = torch.jit.script(TestModule())
+        m.eval()
+        with self.assertRaisesRegex(RuntimeError, "attempted to freeze a module that uses interface attributes"):
+            mf = torch._C._freeze_module(m._c)

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -22,6 +22,7 @@ from jit.test_export_modes import TestExportModes  # noqa: F401
 from jit.test_class_type import TestClassType  # noqa: F401
 from jit.test_builtins import TestBuiltins, TestTensorBuiltins  # noqa: F401
 from jit.test_unsupported_ops import TestUnsupportedOps  # noqa: F401
+from jit.test_freezing import TestFreezing  # noqa: F401
 
 # Torch
 from torch import Tensor

--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -145,6 +145,7 @@ libtorch_sources = [
     "torch/csrc/jit/passes/tensorexpr_fuser.cpp",
     "torch/csrc/jit/passes/utils/subgraph_utils.cpp",
     "torch/csrc/jit/passes/utils/memory_dag.cpp",
+    "torch/csrc/jit/passes/freeze_module.cpp",
     "torch/csrc/jit/runtime/print_handler.cpp",
     "torch/csrc/jit/runtime/register_prim_ops.cpp",
     "torch/csrc/jit/runtime/register_prim_ops_c10.cpp",

--- a/torch/csrc/jit/api/compilation_unit.h
+++ b/torch/csrc/jit/api/compilation_unit.h
@@ -223,6 +223,19 @@ struct TORCH_API CompilationUnit {
     classDict_.clear();
   }
 
+  // [Internal Only] Remove method.
+  // Note Used for freezing.
+  void unsafeRemoveMethod(const c10::QualifiedName& method_name) {
+    auto it = dict_.find(method_name);
+    TORCH_CHECK(
+        it != dict_.end(),
+        "method '",
+        method_name.qualifiedName(),
+        "' does not exist.");
+    functions_[it->second] = nullptr;
+    dict_.erase(it);
+  }
+
   // [name mangling] All code objects must have a unique qualified name in a
   // CompilationUnit. In Python, sometimes functions won't have unique qualified
   // name (for example, nested functions). So we mangle Python functions to

--- a/torch/csrc/jit/api/module.h
+++ b/torch/csrc/jit/api/module.h
@@ -178,7 +178,7 @@ struct TORCH_API Module : public Object {
     train(/*on=*/false);
   }
   /// True if the module is in training mode.
-  bool is_training() {
+  bool is_training() const {
     return attr("training", true).toBool();
   }
 

--- a/torch/csrc/jit/ir/alias_analysis.h
+++ b/torch/csrc/jit/ir/alias_analysis.h
@@ -36,7 +36,9 @@ namespace jit {
  */
 class AliasDb {
  public:
-  TORCH_API explicit AliasDb(std::shared_ptr<Graph> graph);
+  TORCH_API explicit AliasDb(
+      std::shared_ptr<Graph> graphi,
+      bool isFrozen = false);
   TORCH_API ~AliasDb();
 
   // There are limitations to what effects the alias analysis can track. Two
@@ -187,6 +189,11 @@ class AliasDb {
   static bool isContainerType(const TypePtr& type);
 
   std::shared_ptr<Graph> graph_;
+
+  // If the Module is frozen then consider attributes as freshly created
+  // objects. Freezing API invokes alias analysis to check if they are mutated
+  // internally.
+  bool isFrozen_;
 
   // The points-to graph that stores aliasing relationships
   std::unique_ptr<MemoryDAG> memoryDAG_;

--- a/torch/csrc/jit/ir/class_type.cpp
+++ b/torch/csrc/jit/ir/class_type.cpp
@@ -122,6 +122,23 @@ size_t ClassType::addConstant(const std::string& name, const IValue& value) {
   return slot;
 }
 
+void ClassType::unsafeRemoveMethod(const std::string& name) {
+  size_t slot = 0;
+  for (auto method : methods_) {
+    if (method->name() == name) {
+      methods_.erase(methods_.begin() + slot);
+      return;
+    }
+    slot++;
+  }
+  TORCH_CHECK(
+      false,
+      "Can't delete undefined method ",
+      name,
+      " on class: ",
+      python_str());
+}
+
 IValue ClassType::getConstant(const std::string& name) const {
   const auto& v = findConstant(name);
   TORCH_CHECK(

--- a/torch/csrc/jit/passes/freeze_module.cpp
+++ b/torch/csrc/jit/passes/freeze_module.cpp
@@ -1,0 +1,388 @@
+#include <torch/csrc/jit/jit_log.h>
+#include <torch/csrc/jit/passes/freeze_module.h>
+
+#include <torch/csrc/jit/graph_executor_impl.h>
+#include <torch/csrc/jit/passes/alias_analysis.h>
+#include <torch/csrc/jit/passes/inliner.h>
+
+#include <stack>
+
+namespace torch {
+namespace jit {
+
+namespace {
+
+class AttributePropagator {
+ public:
+  AttributePropagator(script::Module& module) : module_(module) {}
+
+  void run(std::shared_ptr<Graph>& graph) {
+    Inline(*graph);
+    propagateAttributes(graph);
+    runOptimization(graph, /* unroll? */ false);
+    cleanupFrozenModule(graph);
+  }
+
+ private:
+  // findConstantAttr function locates the sub Module where attributes are
+  // defined. The algorithm chases getAttr chains to locate the submodules.
+  // For example:
+  // module M {
+  //   attributes {
+  //     A = <SubModule at ...>
+  //   }
+  //   ...
+  //   %A = prim::GetAttr[name="A"](%self)
+  //   ...
+  //   %B = prim::GetAttr[name="B"](%A)
+  //   ...
+  //   %weight = prim::GetAttr[name="scale"](%B)
+  //   ...
+  //   submodules {
+  //     module SubModule {
+  //       attributes {
+  //          B = <SubModule2 at ...>
+  //       }
+  //       submodules {
+  //         module SubModule2 {
+  //            attributes {
+  //               scale = 2
+  //            }
+  //         }
+  //       }
+  //     }
+  //   }
+  //
+  // findConstantAttr(%B, "scale", M)  returns true because there are no
+  // explicit SetAttr that modifies %B. attrModule points to the module where
+  // attribute lives (in this example it is <SubModule2 at ...>).
+  //
+  // Note inplace mutations to attributes are checked later using alias
+  // analysis.
+  //
+  // We can use a more efficient algorithm to hash each constant GetAttr to its
+  // corresponding value. Based on initial test on resnet50 and other torch
+  // vision tests. GetAttrs are not too frequent so it is ok to chase GetAttr
+  // chain to retrieve their values.
+  bool findConstantAttr(
+      Node* node,
+      std::string& name,
+      script::Module& attrModule) {
+    names_.clear();
+    while (!(node->outputs()[0]->type() == attrModule.type())) {
+      if (node->kind() == prim::GetAttr) {
+        names_.push_front(node->s(attr::name));
+        node = node->inputs()[0]->node();
+      } else {
+        return false;
+      }
+    }
+
+    for (auto& moduleName : names_) {
+      auto it = preservedAttrs_.find(attrModule._ivalue());
+      if (it != preservedAttrs_.end()) {
+        if (it->second.count(attrModule.attr(moduleName))) {
+          return false;
+        }
+      }
+      attrModule = attrModule.attr(moduleName).toModule();
+    }
+
+    auto attr = attrModule.attr(name);
+    if (!AliasDb::mutableType(attr.type())) {
+      auto it = preservedScalarAttrs_.find(attrModule._ivalue());
+      return it == preservedScalarAttrs_.end() || !it->second.count(name);
+    }
+
+    auto it = preservedAttrs_.find(attrModule._ivalue());
+    if (it == preservedAttrs_.end()) {
+      return true;
+    }
+    if (it->second.count(attr)) {
+      return false;
+    }
+    if (!attr.type()->cast<ClassType>()) {
+      for (auto& ivalue : it->second) {
+        if (!ivalue.isObject() && ivalue.overlaps(attr)) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  void insertMutableAttr(
+      const std::string& name,
+      const IValue& attr,
+      script::Module& attrModule) {
+    if (AliasDb::mutableType(attr.type())) {
+      preservedAttrs_[attrModule._ivalue()].insert(attr);
+    } else {
+      preservedScalarAttrs_[attrModule._ivalue()].insert(name);
+    }
+  }
+
+  void recordMutableAttrs(std::shared_ptr<Graph>& graph) {
+    std::stack<Block*> blocks({graph->block()});
+    std::unique_ptr<AliasDb> aliasDb =
+        torch::make_unique<AliasDb>(graph, /* isFrozen */ true);
+    IValue::HashAliasedIValues usedAttrs;
+    while (!blocks.empty()) {
+      Block* block = blocks.top();
+      blocks.pop();
+      for (auto n : block->nodes()) {
+        for (Block* sub_block : n->blocks()) {
+          blocks.push(sub_block);
+        }
+        if (n->kind() == prim::SetAttr || n->kind() == prim::GetAttr) {
+          // TODO: handle interface attributes. For now, Exit if Module uses
+          // inteface attributes
+          if (n->kind() == prim::GetAttr) {
+            TORCH_CHECK(
+                !n->output()->type()->cast<InterfaceType>(),
+                "attempted to freeze a module that uses interface attributes");
+          }
+          auto inputNode = n->inputs()[0]->node();
+          auto name = n->s(attr::name);
+          auto attrModule = module_;
+          if (!findConstantAttr(inputNode, name, attrModule)) {
+            continue;
+          }
+
+          auto attr = attrModule.attr(name);
+          if (n->kind() == prim::GetAttr) {
+            auto type = n->output()->type();
+            // Do not record submodules. Their attributes are tracked
+            // individually.
+            if (attr.isObject() || !AliasDb::mutableType(attr.type())) {
+              continue;
+            }
+            usedAttrs.insert(attr);
+          }
+
+          if (n->kind() == prim::SetAttr || aliasDb->hasOutputWriters(n)) {
+            GRAPH_DEBUG(
+                n->kind() == prim::GetAttr ? "attribute: " + name + " in %" +
+                        n->output()->debugName() + " has inplace writer"
+                                           : "attribute: " + name + " is set");
+            insertMutableAttr(name, attr, attrModule);
+          }
+        }
+      }
+    }
+    // FIXME: Current Alias analysis fails to track subvalues.
+    // This is not a common scenario, for freezing, detect and error out.
+    for (auto it = usedAttrs.begin(); it != usedAttrs.end();) {
+      auto& val = *it;
+      it++;
+      for (auto rhs = it; rhs != usedAttrs.end(); rhs++) {
+        TORCH_CHECK(
+            !val.overlaps(*rhs),
+            "module contains attributes values that overlaps ",
+            val,
+            " and ",
+            *rhs);
+      }
+    }
+  }
+
+  // Prepraring for clean up phase. At this point, record all  subModules that
+  // contains mutable attributes.
+  void recordReferencedAttrs(std::shared_ptr<Graph>& graph) {
+    std::stack<Block*> blocks({graph->block()});
+    while (!blocks.empty()) {
+      Block* block = blocks.top();
+      blocks.pop();
+      for (auto n : block->nodes()) {
+        for (Block* subBlock : n->blocks()) {
+          blocks.push(subBlock);
+        }
+        if (n->kind() == prim::GetAttr) {
+          auto& name = n->s(attr::name);
+          if (module_.hasattr(name)) {
+            auto attr = module_.attr(name);
+            insertMutableAttr(name, attr, module_);
+          }
+        }
+      }
+    }
+  }
+
+  IValue overrideGradient(IValue attr) {
+    if (attr.isTensor()) {
+      auto t = attr.toTensor();
+      if (t.requires_grad()) {
+        t = autograd::as_variable_ref(t).detach();
+        t.set_requires_grad(false);
+        attr = IValue(t);
+      }
+    } else if (attr.isTuple()) {
+      std::vector<IValue>& elems = attr.toTuple()->elements();
+      for (auto& elem : elems) {
+        elem = overrideGradient(elem);
+      }
+    } else if (attr.isList()) {
+      c10::List<IValue> elems = std::move(attr).toList();
+      for (size_t i = 0; i < elems.size(); i++) {
+        elems.set(i, overrideGradient(elems.extract(i)));
+      }
+      attr = std::move(elems);
+    }
+
+    return attr;
+  }
+
+  void propagateAttributes(std::shared_ptr<Graph>& graph) {
+    std::unordered_map<
+        script::ModulePtr,
+        std::unordered_map<std::string, Value*>>
+        attrValues;
+    auto isEval = !module_.is_training();
+    GRAPH_DEBUG("Freezing Module in ", isEval ? "eval mode" : "training mode");
+    auto block = graph->block();
+    std::stack<Block*> blocks({block});
+
+    // Record Attributes that are explicitely set in the module. They cannot be
+    // folded.
+    recordMutableAttrs(graph);
+
+    Node* m = *block->nodes().begin();
+    WithInsertPoint guard(m);
+    while (!blocks.empty()) {
+      Block* block = blocks.top();
+      blocks.pop();
+      for (auto it = block->nodes().begin(); it != block->nodes().end();) {
+        Node* n = *it;
+        it++; // advance iterator bc the current node may be destroyed
+
+        for (Block* sub_block : n->blocks()) {
+          blocks.push(sub_block);
+        }
+        if (n->kind() == prim::GetAttr) {
+          auto name = n->s(attr::name);
+          auto attrModule = module_;
+          auto inputNode = n->inputs()[0]->node();
+          if (!findConstantAttr(inputNode, name, attrModule)) {
+            GRAPH_DEBUG("attribute: ", name, " is mutable.")
+            continue;
+          }
+          TORCH_INTERNAL_ASSERT(attrModule.hasattr(name));
+          Value* paramConst = nullptr;
+          auto I = attrValues.find(attrModule._ivalue());
+          if (I != attrValues.end()) {
+            auto II = I->second.find(name);
+            if (II != I->second.end())
+              paramConst = II->second;
+          }
+          if (!paramConst) {
+            auto attr = attrModule.attr(name);
+            if (isEval)
+              attr = overrideGradient(attr);
+            if (auto attrVal = tryInsertConstant(*graph, attr)) {
+              paramConst = *attrVal;
+            } else {
+              GRAPH_DEBUG(
+                  attr.type()->cast<ClassType>() ? "" : "attribute: ",
+                  name,
+                  " is not materializable.");
+              continue;
+            }
+            std::string fullName("self.");
+            for (auto& name : names_) {
+              fullName += name + '.';
+            }
+            fullName += name;
+            paramConst->setDebugName(fullName);
+            attrValues[attrModule._ivalue()][name] = paramConst;
+          }
+          GRAPH_UPDATE(
+              "Folding GetAttr %",
+              n->outputs()[0]->debugName(),
+              " with ",
+              paramConst->debugName());
+          n->outputs().at(0)->replaceAllUsesWith(paramConst);
+          n->removeAllInputs();
+        }
+      }
+    }
+  }
+
+  // cleanupFrozenModule function cleans up the Frozen module. it performs the
+  // following:
+  // 1) Remove unused attributes.
+  // 2) Remove unreferenced submodules
+  // 3) Remove non public unreferenced methods.
+  // TODO: do #3 because there is no API to 'unsafely' remove methods.
+  void cleanupFrozenModule(std::shared_ptr<Graph>& graph) {
+    std::vector<std::string> attrsToRemove;
+    auto type = module_.type();
+    size_t N = type->numAttributes();
+    recordReferencedAttrs(graph);
+    auto it = preservedAttrs_.find(module_._ivalue());
+    auto it2 = preservedScalarAttrs_.find(module_._ivalue());
+    for (size_t i = 0; i < N; ++i) {
+      auto attrTy = type->getAttribute(i);
+      auto name = type->getAttributeName(i);
+      auto attr = module_.attr(name);
+      bool immutable;
+      if (AliasDb::mutableType(attrTy)) {
+        immutable = it == preservedAttrs_.end() || !it->second.count(attr);
+      } else {
+        immutable =
+            it2 == preservedScalarAttrs_.end() || !it2->second.count(name);
+      }
+      if (immutable) {
+        attrsToRemove.push_back(name);
+      }
+    }
+    for (auto& name : attrsToRemove) {
+      module_._ivalue()->unsafeRemoveAttr(name);
+      module_.type()->unsafeRemoveAttribute(name);
+    }
+  }
+
+  // Contains attributes that can't be folded or user directs to keep them.
+  std::unordered_map<script::ModulePtr, IValue::HashAliasedIValues>
+      preservedAttrs_;
+  // Tracked immutable types (Scalars) by their attribute names not
+  // IValues.
+  std::unordered_map<script::ModulePtr, std::unordered_set<std::string>>
+      preservedScalarAttrs_;
+
+  script::Module& module_;
+
+  // Contains the attributes names (e.g. {"self", "subModule", "a"}
+  std::deque<std::string> names_;
+}; // class AttributePropagator
+} // namespace
+
+script::Module freeze_module(const script::Module& module) {
+  // Currently freezing module is supported only in eval mode.
+  // If assertion below is commented and module is in training mode then this
+  // implementation folds attributes correctly. Tensor attributes with
+  // required_grad set are not folded and 'training' attribute is also not
+  // folded.
+  // TODO: Determine if freezing in training mode is useful and further clarify
+  // its semantics.
+  TORCH_CHECK(!module.is_training());
+
+  script::Method method = module.get_method("forward");
+  // Check that module does not return itself.
+  for (auto& output : method.graph()->outputs())
+    TORCH_CHECK(
+        output->type() != module.type(),
+        "attempted to freeze a module that return itself");
+
+  auto moduleClone = module.clone();
+  AttributePropagator attrPropagator(moduleClone);
+  method = moduleClone.get_method("forward");
+  auto graph = method.graph();
+  attrPropagator.run(graph);
+  GRAPH_DUMP(
+      moduleClone.type()->name()->name() + "::forward() after freezing module",
+      method.graph());
+  return moduleClone;
+}
+
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/passes/freeze_module.cpp
+++ b/torch/csrc/jit/passes/freeze_module.cpp
@@ -339,6 +339,13 @@ class AttributePropagator {
       module_._ivalue()->unsafeRemoveAttr(name);
       module_.type()->unsafeRemoveAttribute(name);
     }
+    for (auto& fn : type->methods()) {
+      auto& name = fn->name();
+      if ("forward" == name)
+        continue;
+      type->unsafeRemoveMethod(name);
+      module_._ivalue()->compilation_unit()->unsafeRemoveMethod(fn->qualname());
+    }
   }
 
   // Contains attributes that can't be folded or user directs to keep them.

--- a/torch/csrc/jit/passes/freeze_module.cpp
+++ b/torch/csrc/jit/passes/freeze_module.cpp
@@ -1,8 +1,8 @@
 #include <torch/csrc/jit/jit_log.h>
 #include <torch/csrc/jit/passes/freeze_module.h>
 
-#include <torch/csrc/jit/graph_executor_impl.h>
-#include <torch/csrc/jit/passes/alias_analysis.h>
+#include <torch/csrc/jit/runtime/graph_executor_impl.h>
+#include <torch/csrc/jit/ir/alias_analysis.h>
 #include <torch/csrc/jit/passes/inliner.h>
 
 #include <stack>

--- a/torch/csrc/jit/passes/freeze_module.h
+++ b/torch/csrc/jit/passes/freeze_module.h
@@ -1,0 +1,25 @@
+/** \brief This file defines freezing Torchscript module API.
+ *
+ * This API has python-binding and can be invoked directly or as a part of
+ * general optimization pipeline.
+ */
+#pragma once
+
+#include <torch/csrc/jit/ir.h>
+#include <torch/csrc/jit/script/module.h>
+
+/** \brief Freeze Module, i.e., Assume all atrributes are constants.
+ *
+ * Freezing module is a functionality that allows the JIT to internalize
+ * imutable attributes. Combined with inlinig, the module is aggressively
+ * optimized and significant overhead is optimized away. The freezeModule API
+ * produces a cloned frozen module.
+ */
+
+namespace torch {
+namespace jit {
+
+TORCH_API script::Module freeze_module(const script::Module& module);
+
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/passes/freeze_module.h
+++ b/torch/csrc/jit/passes/freeze_module.h
@@ -5,8 +5,8 @@
  */
 #pragma once
 
-#include <torch/csrc/jit/ir.h>
-#include <torch/csrc/jit/script/module.h>
+#include <torch/csrc/jit/ir/ir.h>
+#include <torch/csrc/jit/api/module.h>
 
 /** \brief Freeze Module, i.e., Assume all atrributes are constants.
  *

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -44,6 +44,7 @@
 #include <torch/csrc/jit/passes/subgraph_rewrite.h>
 #include <torch/csrc/jit/passes/tensorexpr_fuser.h>
 #include <torch/csrc/jit/passes/utils/check_alias_annotation.h>
+#include <torch/csrc/jit/passes/freeze_module.h>
 #include <torch/csrc/jit/runtime/print_handler.h>
 #include <torch/csrc/jit/python/pybind_utils.h>
 #include <torch/csrc/jit/python/python_arg_flatten.h>
@@ -197,6 +198,11 @@ void initJITBindings(PyObject* module) {
           "_jit_pass_quant_fusion",
           [](std::shared_ptr<Graph>& g) { return QuantFusion(g); })
       .def("_jit_pass_fold_convbn", &FoldConvBatchNorm2d)
+      .def("_freeze_module",
+          [](script::Module& module) {
+            return freeze_module(module);
+          },
+          py::arg("module"))
       .def("_jit_pass_fuse_linear", &FuseLinear)
       .def(
           "_jit_pass_fold_quantize",

--- a/torch/csrc/jit/runtime/graph_executor.cpp
+++ b/torch/csrc/jit/runtime/graph_executor.cpp
@@ -739,7 +739,7 @@ void runNondiffOptimization(
   }
 }
 
-void runOptimization(std::shared_ptr<Graph>& graph) {
+void runOptimization(std::shared_ptr<Graph>& graph, bool unroll) {
   // Basic graph preprocessing to eliminate noise.
   EliminateDeadCode(graph);
   EliminateCommonSubexpression(graph);
@@ -750,7 +750,8 @@ void runOptimization(std::shared_ptr<Graph>& graph) {
 
   // Unroll small loops, and eliminate expressions that are the same at every
   // iteration.
-  UnrollLoops(graph);
+  if (unroll)
+    UnrollLoops(graph);
   EliminateCommonSubexpression(graph);
 
   CheckInplace(graph);

--- a/torch/csrc/jit/runtime/graph_executor_impl.h
+++ b/torch/csrc/jit/runtime/graph_executor_impl.h
@@ -31,7 +31,7 @@ namespace jit {
 
 void packGradient(const Gradient& gradient, Node* dnode);
 bool needsGradient(const std::shared_ptr<const Graph>& graph);
-void runOptimization(std::shared_ptr<Graph>& graph);
+void runOptimization(std::shared_ptr<Graph>& graph, bool unroll = true);
 void runNondiffOptimization(
     std::shared_ptr<Graph>& graph,
     bool strict_fuser_check = false);


### PR DESCRIPTION
This patch enables folding GetAttr nodes with their corresponding
values. _jit_pass_freeze_module API returns a new TorchScipt module
where all function calls and get attributes are inlined.
Usage:

frozen_model = torch._C._freeze_module(scrited_model._c)
frozen_model.forward(...)

This API currently optimizes the forward method. We will follow up to
to preserve and optimize methods and attributes that are annotated as
 @torch.jit.interface.

Several future improvements to JIT optimizations are required to maximize
clean up/de-sugar the graph and eliminate redundancies.
Ideally, we want to produce a graph that can easily be lowered to
GLOW and other low-level backends.
__

