### PR TITLE
[JIT] Fixes to prim ops

### DIFF
--- a/test/jit/test_list_dict.py
+++ b/test/jit/test_list_dict.py
@@ -356,6 +356,14 @@ class TestList(JitTestCase):
         test_mutation()
         FileCheck().check("aten::sort").run(test_mutation.graph_for())
 
+        def test_sorted_copy():
+            a = [torch.tensor(2), torch.tensor(0), torch.tensor(1)]
+            b = sorted(a)
+            a[0] = torch.tensor(10)
+            return a, b
+
+        self.checkScript(test_sorted_copy, ())
+
     def test_list_slice(self):
         def test_regular_slice():
             a = [0, 1, 2, 3, 4]

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -2060,10 +2060,9 @@ int listCopyAndSort(Stack& stack) {
 template <>
 int listCopyAndSort<at::Tensor>(Stack& stack) {
   c10::List<at::Tensor> list = pop(stack).toTensorList();
+  auto list_copied = list.copy();
   std::sort(
-      list.begin(),
-      list.end(),
-      [](const at::Tensor& a, const at::Tensor& b) {
+      list.begin(), list.end(), [](const at::Tensor& a, const at::Tensor& b) {
         return a.lt(b).is_nonzero();
       });
   push(stack, list);
@@ -3090,12 +3089,12 @@ RegisterOperators reg2({
           aliasAnalysisFromSchema()),                                         \
       Operator(                                                               \
           "aten::setdefault(Dict(" key_type ", t)(a!) self, " key_type        \
-          " key, t default_value) -> t(*)",                                   \
+          "(b -> *) key, t(c -> *) default_value) -> t(*)",                   \
           dictSetDefault,                                                     \
           aliasAnalysisFromSchema()),                                         \
       Operator(                                                               \
           "aten::Delete(Dict(" key_type ", t)(a!) self, " key_type            \
-          " key) -> ()",                                                    \
+          " key) -> ()",                                                      \
           dictDelete,                                                         \
           aliasAnalysisFromSchema()),                                         \
       Operator(                                                               \
@@ -3138,12 +3137,12 @@ RegisterOperators reg2({
           aliasAnalysisFromSchema()),                                         \
       Operator(                                                               \
           "aten::_set_item(Dict(" key_type ", t)(a!) l, " key_type            \
-          " idx, t(b -> *) v) -> ()",                                         \
+          "(b -> *) idx, t(c -> *) v) -> ()",                                 \
           dictSetItem,                                                        \
           aliasAnalysisFromSchema()),                                         \
       Operator(                                                               \
           "aten::dict((" key_type ", tVal)[] inputs) -> Dict(" key_type       \
-          ", tVal)",                                                          \
+          "(a -> *), tVal(b -> *))",                                          \
           dictConstructFromList,                                              \
           aliasAnalysisFromSchema())
 

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -2062,10 +2062,12 @@ int listCopyAndSort<at::Tensor>(Stack& stack) {
   c10::List<at::Tensor> list = pop(stack).toTensorList();
   auto list_copied = list.copy();
   std::sort(
-      list.begin(), list.end(), [](const at::Tensor& a, const at::Tensor& b) {
+      list_copied.begin(),
+      list_copied.end(),
+      [](const at::Tensor& a, const at::Tensor& b) {
         return a.lt(b).is_nonzero();
       });
-  push(stack, list);
+  push(stack, list_copied);
   return 0;
 }
 

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -3144,7 +3144,7 @@ RegisterOperators reg2({
           aliasAnalysisFromSchema()),                                         \
       Operator(                                                               \
           "aten::dict((" key_type ", tVal)[] inputs) -> Dict(" key_type       \
-          "(a -> *), tVal(b -> *))",                                          \
+          ", tVal)",                                                          \
           dictConstructFromList,                                              \
           aliasAnalysisFromSchema())
 

--- a/torch/csrc/jit/script/schema_type_parser.h
+++ b/torch/csrc/jit/script/schema_type_parser.h
@@ -10,10 +10,9 @@ namespace jit {
 namespace script {
 
 using TypePtr = c10::TypePtr;
-using TypeAndAlias = std::pair<TypePtr, c10::optional<c10::AliasInfo>>;
 
 struct CAFFE2_API SchemaTypeParser {
-  TypeAndAlias parseBaseType();
+  TypePtr parseBaseType();
   c10::optional<c10::AliasInfo> parseAliasAnnotation();
   std::pair<TypePtr, c10::optional<c10::AliasInfo>> parseType();
   c10::optional<at::ScalarType> parseTensorDType(const std::string& dtype);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#32179 [JIT] Fixes to prim ops**

Tensors are used as keys in dictionaries, so we need to annotate that key insertion into a dictionary inserts the key into the wildcard set. Also fixes bug with `listCopyAndSort` not copying the input list.

Differential Revision: [D19397555](https://our.internmc.facebook.com/intern/diff/D19397555)