### PR TITLE
[JIT] dict type unification fix

### DIFF
--- a/test/cpp/jit/test_jit_type.cpp
+++ b/test/cpp/jit/test_jit_type.cpp
@@ -31,6 +31,18 @@ void testUnifyTypes() {
   testing::FileCheck()
       .check("Optional[Tuple[Optional[int], Optional[int]]]")
       ->run(ss.str());
+
+  auto fut_1 = FutureType::create(IntType::get());
+  auto fut_2 = FutureType::create(NoneType::get());
+  auto fut_out = unifyTypes(fut_1, fut_2);
+  TORCH_INTERNAL_ASSERT(fut_out);
+  TORCH_INTERNAL_ASSERT((*fut_out)->isSubtypeOf(
+      FutureType::create(OptionalType::create(NoneType::get()))));
+
+  auto dict_1 = DictType::create(NoneType::get(), NoneType::get());
+  auto dict_2 = DictType::create(IntType::get(), NoneType::get());
+  auto dict_out = unifyTypes(dict_1, dict_2);
+  TORCH_INTERNAL_ASSERT(!dict_out);
 }
 
 } // namespace jit

--- a/test/cpp/jit/test_jit_type.cpp
+++ b/test/cpp/jit/test_jit_type.cpp
@@ -37,10 +37,10 @@ void testUnifyTypes() {
   auto fut_out = unifyTypes(fut_1, fut_2);
   TORCH_INTERNAL_ASSERT(fut_out);
   TORCH_INTERNAL_ASSERT((*fut_out)->isSubtypeOf(
-      FutureType::create(OptionalType::create(NoneType::get()))));
+      FutureType::create(OptionalType::create(IntType::get()))));
 
-  auto dict_1 = DictType::create(NoneType::get(), NoneType::get());
-  auto dict_2 = DictType::create(IntType::get(), NoneType::get());
+  auto dict_1 = DictType::create(IntType::get(), NoneType::get());
+  auto dict_2 = DictType::create(IntType::get(), IntType::get());
   auto dict_out = unifyTypes(dict_1, dict_2);
   TORCH_INTERNAL_ASSERT(!dict_out);
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#32185 [JIT] dict type unification fix**

Previously we would unify the contained types of dictionaries, however this breaks type safety.
```
@torch.jit.script
def test(input: Dict[str, None], cond):
    if cond:
        out = input
    else:
        out: {"1": 1}
    out["hi"] = 3
```
   
This would only occur if a dictionary is being re-assigned across an if condition with different contained types, which is pretty unlikely. I tested `model_backward_compatibility` for all fb models and this didn't break anything. This PR is a precursor to alias analysis changes. 

Also fixes `Future` type unification. Because `Future` is an immutable type, it is okay to unify the contained type.

Differential Revision: [D19398585](https://our.internmc.facebook.com/intern/diff/D19398585)