### PR TITLE
Stop building documentation in pytorch_linux_xenial_cuda*_build

### DIFF
--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -205,16 +205,6 @@ if [[ "$BUILD_ENVIRONMENT" != *libtorch* ]]; then
 
   assert_git_not_dirty
 
-  # Test documentation build
-  if [[ "$BUILD_ENVIRONMENT" == *xenial-cuda10.1-cudnn7-py3* ]]; then
-    pushd docs
-    # TODO: Don't run this here
-    pip_install -r requirements.txt || true
-    LC_ALL=C make html
-    popd
-    assert_git_not_dirty
-  fi
-
   # Build custom operator tests.
   CUSTOM_OP_BUILD="$PWD/../custom-op-build"
   CUSTOM_OP_TEST="$PWD/test/custom_operator"

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -17602,8 +17602,9 @@ class TestDocs(unittest.TestCase):
         def report_error(result):
             out = result.stdout.decode('utf-8')
             err = result.stderr.decode('utf-8')
-            raise RuntimeError("{}\n{}\nDocs build failed (run `cd docs && pip install -r requirements.txt && make doctest`)".format(err, out))
-
+            raise RuntimeError("{}\n{}\n".format(err, out) +
+                               "Docs build failed (run `cd docs && " +
+                               "pip install -r requirements.txt && make doctest`)")
         result = subprocess.run(
             ['pip', 'install', '-r', 'requirements.txt'],
             stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=docs_dir)

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -17599,11 +17599,22 @@ class TestDocs(unittest.TestCase):
         docs_dir = [os.path.dirname(__file__), '..', 'docs']
         docs_dir = os.path.join(*docs_dir)
 
-        result = subprocess.run(['make', 'doctest'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=docs_dir)
-        if result.returncode != 0:
+        def report_error(result):
             out = result.stdout.decode('utf-8')
             err = result.stderr.decode('utf-8')
-            raise RuntimeError("{}\n{}\nDocs build failed (run `cd docs && make doctest`)".format(err, out))
+            raise RuntimeError("{}\n{}\nDocs build failed (run `cd docs && pip install -r requirements.txt && make doctest`)".format(err, out))
+
+        result = subprocess.run(
+            ['pip', 'install', '-r', 'requirements.txt'],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=docs_dir)
+        if result.returncode != 0:
+            report_error(result)
+
+        result = subprocess.run(
+            ['make', 'doctest'],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=docs_dir)
+        if result.returncode != 0:
+            report_error(result)
 
 for test in autograd_method_tests():
     add_autograd_test(*test)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#32187 Stop building documentation in pytorch_linux_xenial_cuda*_build**

Fixes #32058. Previously we would build documentation during the pytorch
linux cuda build. We don't actually need to do this because we have a
dedicated python_doc_build job that builds the docs. With this change,
the CUDA build should run ~10 minutes faster, giving devs faster signal.

I needed to modify TestDocs.test_docs inside test_jit.py. This was
incorrectly assuming that the dependencies for the docs exist already;
I modified it to install the dependencies before testing.

Test Plan:
- Check the CUDA (10.1) build on this PR, make sure it doesn't build the docs.
- Run the modified test_docs locally and check that it passes.

Differential Revision: [D19400417](https://our.internmc.facebook.com/intern/diff/D19400417)