### PR TITLE
reimplement __torch_function__ overrides for torch.functional using inline logic

### DIFF
--- a/test/onnx/expect/TestOperators.test_frobenius_norm.expect
+++ b/test/onnx/expect/TestOperators.test_frobenius_norm.expect
@@ -3,8 +3,8 @@ producer_name: "pytorch"
 producer_version: "1.4"
 graph {
   node {
-    input: "0"
-    input: "0"
+    input: "x"
+    input: "x"
     output: "1"
     name: "Mul_0"
     op_type: "Mul"
@@ -34,7 +34,7 @@ graph {
   }
   name: "torch-jit-export"
   input {
-    name: "0"
+    name: "x"
     type {
       tensor_type {
         elem_type: 1

--- a/test/onnx/expect/TestOperators.test_meshgrid.expect
+++ b/test/onnx/expect/TestOperators.test_meshgrid.expect
@@ -17,7 +17,7 @@ graph {
     }
   }
   node {
-    input: "0"
+    input: "x"
     input: "3"
     output: "4"
     name: "Reshape_1"
@@ -38,7 +38,7 @@ graph {
     }
   }
   node {
-    input: "1"
+    input: "y"
     input: "5"
     output: "6"
     name: "Reshape_3"
@@ -59,7 +59,7 @@ graph {
     }
   }
   node {
-    input: "2"
+    input: "z"
     input: "7"
     output: "8"
     name: "Reshape_5"
@@ -221,7 +221,7 @@ graph {
   }
   name: "torch-jit-export"
   input {
-    name: "0"
+    name: "x"
     type {
       tensor_type {
         elem_type: 1
@@ -234,7 +234,7 @@ graph {
     }
   }
   input {
-    name: "1"
+    name: "y"
     type {
       tensor_type {
         elem_type: 1
@@ -247,7 +247,7 @@ graph {
     }
   }
   input {
-    name: "2"
+    name: "z"
     type {
       tensor_type {
         elem_type: 1

--- a/test/onnx/expect/TestOperators.test_unique.expect
+++ b/test/onnx/expect/TestOperators.test_unique.expect
@@ -3,7 +3,7 @@ producer_name: "pytorch"
 producer_version: "1.4"
 graph {
   node {
-    input: "0"
+    input: "x"
     output: "1"
     output: "2"
     output: "3"
@@ -23,7 +23,7 @@ graph {
   }
   name: "torch-jit-export"
   input {
-    name: "0"
+    name: "x"
     type {
       tensor_type {
         elem_type: 1

--- a/torch/_overrides.py
+++ b/torch/_overrides.py
@@ -4,11 +4,9 @@ Python implementation of __torch_function__
 While most of the torch API and handling for __torch_function__ happens
 at the C++ level, some of the torch API is written in Python so we need
 python-level handling for __torch_function__ overrides as well. The main
-developer-facing functionality in this file is the
-torch_function_dispatch decorator. This function can be applied to
-python functions in the torch.functional module to enable
-__torch_function__ overrides for that function. See the examples in the
-docstrings for torch_function_dispatch for details.
+developer-facing functionality in this file are handle_torch_function and 
+has_torch_function. See torch/functional.py and test/test_overrides.py
+for usage examples.
 
 NOTE: heavily inspired by NumPy's ``__array_function__`` (see:
 https://github.com/pytorch/pytorch/issues/24015 and
@@ -17,26 +15,8 @@ https://www.numpy.org/neps/nep-0018-array-function-protocol.html
 
 """
 
-import functools
-import textwrap
-from . import _six
-if _six.PY3:
-    from inspect import getfullargspec
-    import collections
-    ArgSpec = collections.namedtuple('ArgSpec', 'args varargs keywords defaults')
 
-    def getargspec(func):
-        spec = getfullargspec(func)
-        return ArgSpec(spec.args, spec.varargs, spec.varkw, spec.defaults)
-else:
-    from inspect import getargspec
-
-from .tensor import Tensor
-
-
-_TENSOR_ONLY = [Tensor]
-
-def _get_overloaded_types_and_args(relevant_args):
+def _get_overloaded_args(relevant_args):
     """Returns a list of arguments on which to call __torch_function__.
 
     Checks arguments in relevant_args for __torch_function__ implementations,
@@ -96,11 +76,11 @@ def _get_overloaded_types_and_args(relevant_args):
                 overloaded_types = [arg_type]
                 overloaded_args = [arg]
 
-    return overloaded_types, overloaded_args
+    return overloaded_args
 
 
-def _implement_torch_function(
-        implementation, public_api, relevant_args, args, kwargs):
+def handle_torch_function(
+        public_api, relevant_args, *args, **kwargs):
     """Implement a function with checks for __torch_function__ overrides.
 
     See torch::autograd::handle_torch_function for the equivalent of this
@@ -108,9 +88,6 @@ def _implement_torch_function(
 
     Arguments
     ---------
-    implementation : function
-        Function that implements the operation on ``torch.Tensor`` without
-        overrides when called like ``implementation(*args, **kwargs)``.
     public_api : function
         Function exposed by the public torch API originally called like
         ``public_api(*args, **kwargs)`` on which arguments are now being
@@ -133,11 +110,7 @@ def _implement_torch_function(
 
     """
     # Check for __torch_function__ methods.
-    types, overloaded_args = _get_overloaded_types_and_args(relevant_args)
-    # Short-cut for common cases: no overload or only Tensor overload
-    # (directly or with subclasses that do not override __torch_function__).
-    if not overloaded_args or types == _TENSOR_ONLY:
-        return implementation(*args, **kwargs)
+    overloaded_args = _get_overloaded_args(relevant_args)
 
     # Call overrides
     for overloaded_arg in overloaded_args:
@@ -153,128 +126,17 @@ def _implement_torch_function(
                     '__torch_function__: {}'
                     .format(func_name, list(map(type, overloaded_args))))
 
+def has_torch_function(relevant_args):
+    """Check for __torch_function__ implementations in the elements of an iterable
 
-def _verify_matching_signatures(implementation, dispatcher):
-    """Verify that a dispatcher function has the right signature."""
-    implementation_spec = getargspec(implementation)
-    dispatcher_spec = getargspec(dispatcher)
-
-    if (implementation_spec.args != dispatcher_spec.args or
-        implementation_spec.varargs != dispatcher_spec.varargs or
-        implementation_spec.keywords != dispatcher_spec.keywords or
-        (bool(implementation_spec.defaults) !=
-         bool(dispatcher_spec.defaults)) or
-        (implementation_spec.defaults is not None and
-         len(implementation_spec.defaults) !=
-         len(dispatcher_spec.defaults))):
-        raise RuntimeError('implementation and dispatcher for %s have '
-                           'different function signatures' % implementation)
-
-
-_wrapped_func_source = textwrap.dedent("""
-    @functools.wraps(implementation)
-    def {name}(*args, **kwargs):
-        relevant_args = dispatcher(*args, **kwargs)
-        return implement_torch_function(
-            implementation, {name}, relevant_args, args, kwargs)
-    """)
-
-def torch_function_dispatch(dispatcher, module=None, verify=True):
-    """Decorator for adding dispatch with the __torch_function__ protocol.
-
-    If you define a function in Python and would like to permit user-defined
-    tensor-like types to override it using __torch_function__, please apply this
-    decorator on this function together with a custom dispatcher that indicates
-    which arguments should be checked for the presence of __torch_function__.
-
-    Suppose we'd like to apply this function to torch.frob, which has the
-    following definition:
-
-        def frob(input, bias, option=None):
-            return input + bias
-
-    We'd need to define a dispatcher for frob that has the same signature and
-    returns the elements of the signature that should be checked for
-    `__torch_function__`. If any of the arguments has a `__torch_function__`
-    attribute, that function will be called to handle custom dispatch. Assuming
-    that `bias` can be a tensor-like, our dispatcher would look like:
-
-        def _frob_dispatcher(input, bias, option=None):
-            return (input, bias)
-
-    The dispatcher must return an iterable, so return a single-element tuple if
-    only one argument should be checked. We would then modify the original
-    definition for torch.frob to look like:
-
-        @torch_function_dispatch(_frob_dispatcher)
-        def frob(input, bias, option=None):
-             return input + bias
-
-    See ``torch/functional.py`` for more usage examples.
-
-    Parameters
-    ----------
-    dispatcher : callable
-        Function that when called like ``dispatcher(*args, **kwargs)`` with
-        arguments from the NumPy function call returns an iterable of
-        array-like arguments to check for ``__torch_function__``.
-    module : str, optional
-        ``__module__`` attribute to set on new function, e.g.,
-        ``module='torch'``.  By default, module is copied from the decorated
-        function.
-    verify : bool, optional
-        If True, verify the that the signature of the dispatcher and decorated
-        function signatures match exactly: all required and optional arguments
-        should appear in order with the same names, but the default values for
-        all optional arguments should be ``None``. Only disable verification
-        if the dispatcher's signature needs to deviate for some particular
-        reason, e.g., because the function has a signature like
-        ``func(*args, **kwargs)``.
+    Arguments
+    ---------
+    relevant_args : iterable
+        Iterable or aguments to check for __torch_function__ methods.
 
     Returns
     -------
-    dispatcher : callable
-        Function suitable for decorating the implementation of a NumPy
-        function.
-
-    Notes
-    -----
-    The dispatcher should normally return a tuple containing all input
-    arguments that may have a ``__torch_function__`` attribute.
-
-    In some cases where that's not easily possible, e.g. ``torch.cat``, it is
-    also valid (if a little slower) to make the dispatcher function a generator
-    (i.e. use ``yield`` to return arguments one by one).
-
+    True if any of the elements of relevant_args have __torch_function__
+    implementations, False otherwise.
     """
-    def decorator(implementation):
-        if verify:
-            _verify_matching_signatures(implementation, dispatcher)
-
-        # Equivalently, we could define this function directly instead of using
-        # exec. This version has the advantage of giving the helper function a
-        # more interpretable name. Otherwise, the original function does not
-        # show up at all in many cases, e.g., if it's written in C++ or if the
-        # dispatcher gets an invalid keyword argument.
-        source = _wrapped_func_source.format(name=implementation.__name__)
-
-        source_object = compile(
-            source, filename='<__torch_function__ internals>', mode='exec')
-        scope = {
-            'implementation': implementation,
-            'dispatcher': dispatcher,
-            'functools': functools,
-            'implement_torch_function': _implement_torch_function,
-        }
-        _six.exec_(source_object, scope)
-
-        public_api = scope[implementation.__name__]
-
-        if module is not None:
-            public_api.__module__ = module
-
-        public_api._implementation = implementation
-
-        return public_api
-
-    return decorator
+    return any(hasattr(a, '__torch_function__') for a in relevant_args)


### PR DESCRIPTION
Fixes #30831.

This improves the performance of operators in the `torch.functional` namespace that are overridable by `__torch_function__` implementations when supplied with `Tensor` operands.

Running the split benchmark in various configurations produces the following timings:

<details>
<summary>Expand for timings on <code>master</code> </summary>

```
# ----------------------------------------
# PyTorch/Caffe2 Operator Micro-benchmarks
# ----------------------------------------
# Tag : short

# Benchmarking PyTorch: split
# Mode: Eager
# Name: split_M8_N8_parts2_cpu
# Input: M: 8, N: 8, parts: 2, device: cpu
Forward Execution Time (us) : 3.340

# Benchmarking PyTorch: split
# Mode: Eager
# Name: split_M8_N8_parts2_cuda
# Input: M: 8, N: 8, parts: 2, device: cuda
Forward Execution Time (us) : 3.333

# Benchmarking PyTorch: split
# Mode: Eager
# Name: split_M256_N512_parts2_cpu
# Input: M: 256, N: 512, parts: 2, device: cpu
Forward Execution Time (us) : 3.366

# Benchmarking PyTorch: split
# Mode: Eager
# Name: split_M256_N512_parts2_cuda
# Input: M: 256, N: 512, parts: 2, device: cuda
Forward Execution Time (us) : 3.385

# Benchmarking PyTorch: split
# Mode: Eager
# Name: split_M512_N512_parts2_cpu
# Input: M: 512, N: 512, parts: 2, device: cpu
Forward Execution Time (us) : 3.468

# Benchmarking PyTorch: split
# Mode: Eager
# Name: split_M512_N512_parts2_cuda
# Input: M: 512, N: 512, parts: 2, device: cuda
Forward Execution Time (us) : 3.416
```
</details>

<details>
<summary>Expand for timings with this pull request applied</summary>

```
# ----------------------------------------
# PyTorch/Caffe2 Operator Micro-benchmarks
# ----------------------------------------
# Tag : short

# Benchmarking PyTorch: split
# Mode: Eager
# Name: split_M8_N8_parts2_cpu
# Input: M: 8, N: 8, parts: 2, device: cpu
Forward Execution Time (us) : 2.261

# Benchmarking PyTorch: split
# Mode: Eager
# Name: split_M8_N8_parts2_cuda
# Input: M: 8, N: 8, parts: 2, device: cuda
Forward Execution Time (us) : 2.223

# Benchmarking PyTorch: split
# Mode: Eager
# Name: split_M256_N512_parts2_cpu
# Input: M: 256, N: 512, parts: 2, device: cpu
Forward Execution Time (us) : 2.237

# Benchmarking PyTorch: split
# Mode: Eager
# Name: split_M256_N512_parts2_cuda
# Input: M: 256, N: 512, parts: 2, device: cuda
Forward Execution Time (us) : 2.218

# Benchmarking PyTorch: split
# Mode: Eager
# Name: split_M512_N512_parts2_cpu
# Input: M: 512, N: 512, parts: 2, device: cpu
Forward Execution Time (us) : 2.259

# Benchmarking PyTorch: split
# Mode: Eager
# Name: split_M512_N512_parts2_cuda
# Input: M: 512, N: 512, parts: 2, device: cuda
Forward Execution Time (us) : 2.234
```

</details>

<details>
<summary>Expand for timings on <code>master</code> with <code>__torch_function__</code> dispatch disabled </summary>

```
# ----------------------------------------
# PyTorch/Caffe2 Operator Micro-benchmarks
# ----------------------------------------
# Tag : short

# Benchmarking PyTorch: split
# Mode: Eager
# Name: split_M8_N8_parts2_cpu
# Input: M: 8, N: 8, parts: 2, device: cpu
Forward Execution Time (us) : 2.180

# Benchmarking PyTorch: split
# Mode: Eager
# Name: split_M8_N8_parts2_cuda
# Input: M: 8, N: 8, parts: 2, device: cuda
Forward Execution Time (us) : 2.172

# Benchmarking PyTorch: split
# Mode: Eager
# Name: split_M256_N512_parts2_cpu
# Input: M: 256, N: 512, parts: 2, device: cpu
Forward Execution Time (us) : 2.171

# Benchmarking PyTorch: split
# Mode: Eager
# Name: split_M256_N512_parts2_cuda
# Input: M: 256, N: 512, parts: 2, device: cuda
Forward Execution Time (us) : 2.146

# Benchmarking PyTorch: split
# Mode: Eager
# Name: split_M512_N512_parts2_cpu
# Input: M: 512, N: 512, parts: 2, device: cpu
Forward Execution Time (us) : 2.175

# Benchmarking PyTorch: split
# Mode: Eager
# Name: split_M512_N512_parts2_cuda
# Input: M: 512, N: 512, parts: 2, device: cuda
Forward Execution Time (us) : 2.152
```

</details>

So at least on the machine I'm testing on, this brings the overhead down to less than 100 ns. For comparison, the overhead for `__array_function__` in NumPy is about 850 ns on the same machine.

<details>
<summary>Expand for timings for NumPy <code>__array_function__</code> dispatch </summary>

```
In [1]: import numpy as np

In [2]: %timeit np.mean([1])
8.89 µs ± 17.6 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

In [3]: %timeit np.mean._implementation([1])
8.04 µs ± 28.2 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
```

See [the implementation in NumPy](https://github.com/numpy/numpy/blob/master/numpy/core/overrides.py#L195) for why this measures `__array_function__` overhead.

</details>