### PR TITLE
Add more tests to TorchBind to point out missing functionality

### DIFF
--- a/test/cpp/jit/test_custom_class.cpp
+++ b/test/cpp/jit/test_custom_class.cpp
@@ -26,6 +26,19 @@ struct Foo : torch::jit::CustomClassHolder {
   int64_t combine(c10::intrusive_ptr<Foo> b) {
     return this->info() + b->info();
   }
+  // Note: there are some issues with returning tuples from custom ops currently,
+  // thus using string
+  std::string __getstate__() {
+    std::stringstream ss;
+    ss << "magickey " << x << " " << y;
+    return ss.str();
+  }
+  void __setstate__(const std::string& data) {
+    std::stringstream ss(data);
+    std::string magic;
+    ss >> magic >> x >> y;
+    TORCH_CHECK(magic == "magickey");
+  }
   ~Foo() {
     // std::cout<<"Destroying object with values: "<<x<<' '<<y<<std::endl;
   }
@@ -48,17 +61,29 @@ struct Stack : torch::jit::CustomClassHolder {
 
 static auto test = torch::jit::class_<Foo>("_TorchScriptTesting_Foo")
                        .def(torch::jit::init<int64_t, int64_t>())
+                       // TODO: multiple overloads of the method are not supported because of different override names
                        // .def(torch::jit::init<>())
                        .def("info", &Foo::info)
                        .def("increment", &Foo::increment)
                        .def("add", &Foo::add)
-                       .def("combine", &Foo::combine);
+                       .def("combine", &Foo::combine)
+                       // TODO: we might need a different mechanism for binding __setstate__ such that it also constructs
+                       // the object. See how pybind11 does it:
+                       // https://pybind11.readthedocs.io/en/stable/advanced/classes.html#pickling-support
+                       .def("__getstate__", &Foo::__getstate__)
+                       .def("__setstate__", &Foo::__setstate__);
 
 static auto testStack =
     torch::jit::class_<Stack<std::string>>("_TorchScriptTesting_StackString")
         .def(torch::jit::init<std::vector<std::string>>())
         .def("push", &Stack<std::string>::push)
         .def("pop", &Stack<std::string>::pop);
+
+torch::RegisterOperators reg(
+    "_TorchScriptTesting::standalone_multiply_mutable", [](int64_t factor, c10::intrusive_ptr<Foo> arg) {
+      arg->x *= factor;
+      arg->y *= factor;
+    });
 
 } // namespace
 

--- a/test/custom_operator/test_custom_classes.py
+++ b/test/custom_operator/test_custom_classes.py
@@ -5,14 +5,16 @@ import torch.jit as jit
 import glob
 import os
 import sys
+import pickle
 
-def get_custom_class_library_path():
-    library_filename = glob.glob("build/*custom_class*")
-    assert (len(library_filename) == 1)
-    library_filename = library_filename[0]
-    path = os.path.abspath(library_filename)
-    assert os.path.exists(path), path
-    return path
+# TODO: we should stop doing relative imports for test utils
+pytorch_test_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+sys.path.insert(-1, pytorch_test_dir)
+from common_utils import TemporaryFileName
+
+# NB: the test classes for this unittest are built into the main libtorch
+# library. We might want to separate it at some point, but right now they
+# are available from torch.classes._TorchScriptTesting_*
 
 def test_equality(f, cmp_key):
     obj1 = f()
@@ -31,7 +33,8 @@ class TestCustomOperators(unittest.TestCase):
         assertNotRegex = unittest.TestCase.assertNotRegexpMatches
 
     def setUp(self):
-        ops.load_library(get_custom_class_library_path())
+        #ops.load_library(get_custom_class_library_path())
+        pass
 
     def test_no_return_class(self):
         def f():
@@ -72,6 +75,17 @@ class TestCustomOperators(unittest.TestCase):
 
         self.assertEqual(*test_equality(f, lambda x: x.info()))
 
+    def test_input_class_type_regular_op(self):
+        def f():
+            val = torch.classes._TorchScriptTesting_Foo(1, 2)
+            torch.ops._TorchScriptTesting.standalone_multiply_mutable(2, val)
+            assert val.info() == 8
+            return val
+
+        self.assertEqual(8, torch.jit.script(f)().info())
+        # Doesn't work yet on python level
+        # self.assertEqual(*test_equality(f, lambda x: x.info()))
+
     def test_stack_string(self):
         def f():
             val = torch.classes._TorchScriptTesting_StackString(["asdf", "bruh"])
@@ -85,6 +99,52 @@ class TestCustomOperators(unittest.TestCase):
             val.push(val2.pop())
             return val.pop() + val2.pop()
         self.assertEqual(*test_equality(f, lambda x: x))
+
+    @unittest.skip("Serialization with pickle doesn't work yet")
+    def test_pickle_serialization(self):
+        # Note: so far we produce wrong pickle output and segfault at unpickling. Dump:
+        #     0: \x80 PROTO      3
+        #     2: c    GLOBAL     'torch._C ScriptObject'
+        #    25: q    BINPUT     0
+        #    27: )    EMPTY_TUPLE
+        #    28: \x81 NEWOBJ
+        #    29: q    BINPUT     1
+        #    31: X    BINUNICODE 'magickey_123_456'
+        #    52: q    BINPUT     2
+        #    54: b    BUILD
+        #    55: .    STOP
+        val = torch.classes._TorchScriptTesting_Foo(123, 456)
+        x = pickle.dumps(val)
+        val2 = pickle.loads(x)
+        self.assertEqual(val.info(), val2.info())
+
+    def test_getstate_setstate(self):
+        def f():
+            val = torch.classes._TorchScriptTesting_Foo(3, 5)
+            s = val.__getstate__()
+            # TODO: sort out whether unpickler should call __new__ or __init__
+            val2 = torch.classes._TorchScriptTesting_Foo(0, 0)
+            val2.__setstate__(s)
+            return val.info(), val2.info()
+        ret = f()
+        self.assertEqual(ret[0], ret[1])
+
+        ret = torch.jit.script(f)()
+        self.assertEqual(ret[0], ret[1])
+
+    @unittest.skip("Serialization with torch.save doesn't work yet")
+    def test_torch_serialization(self):
+        def f(fn):
+            val = torch.classes._TorchScriptTesting_Foo(3, 5)
+            torch.save(val, fn)
+            val2 = torch.load(fn)
+            return val.info(), val2.info()
+        with TemporaryFileName() as fname:
+            ret = f(fname)
+            self.assertEqual(ret[0], ret[1])
+        with TemporaryFileName() as fname:
+            ret = torch.jit.script(f)(fname)
+            self.assertEqual(ret[0], ret[1])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Played with TorchBind a bit to highlight missing functionality:
- passing custom classes as arguments works only in script but misses toPyObject bindings to work in python
- we need to figure out right mechanism for custom serialization. `__setstate__` is particularly a problem since it has to be called on already constructed instance. Python solves it by calling `__new__` instead of `__init__`, but in C++ we don't have alternative for it. The choice is probably to make `__setstate__` a static method on C++ side - this is the path that pybind11 takes, though I didn't dig yet exactly how it's implemented.

Also, the test running was broken - are these tests part of CI? :)