### PR TITLE
[iOS][CI]Add File existence checking

### DIFF
--- a/.circleci/scripts/binary_ios_upload.sh
+++ b/.circleci/scripts/binary_ios_upload.sh
@@ -17,8 +17,12 @@ cd ${ZIP_DIR}/install/lib
 target_libs=(libc10.a libclog.a libcpuinfo.a libeigen_blas.a libpytorch_qnnpack.a libtorch_cpu.a libtorch.a)
 for lib in ${target_libs[*]}
 do
-    libs=(${ARTIFACTS_DIR}/x86_64/lib/${lib} ${ARTIFACTS_DIR}/arm64/lib/${lib})
-    lipo -create "${libs[@]}" -o ${ZIP_DIR}/install/lib/${lib}
+    lib_x86="${ARTIFACTS_DIR}/x86_64/lib/${lib}"
+    lib_arm64="${ARTIFACTS_DIR}/arm64/lib/${lib}"
+    if [ -f "${lib_x86}" ] && [ -f "${lib_arm64}" ]; then
+        libs=(${lib_x86} ${lib_arm64})
+        lipo -create "${libs[@]}" -o ${ZIP_DIR}/install/lib/${lib}
+    fi
 done
 # for nnpack, we only support arm64 build
 cp ${ARTIFACTS_DIR}/arm64/lib/libnnpack.a ./

--- a/.circleci/scripts/binary_ios_upload.sh
+++ b/.circleci/scripts/binary_ios_upload.sh
@@ -17,10 +17,8 @@ cd ${ZIP_DIR}/install/lib
 target_libs=(libc10.a libclog.a libcpuinfo.a libeigen_blas.a libpytorch_qnnpack.a libtorch_cpu.a libtorch.a)
 for lib in ${target_libs[*]}
 do
-    lib_x86="${ARTIFACTS_DIR}/x86_64/lib/${lib}"
-    lib_arm64="${ARTIFACTS_DIR}/arm64/lib/${lib}"
-    if [ -f "${lib_x86}" ] && [ -f "${lib_arm64}" ]; then
-        libs=(${lib_x86} ${lib_arm64})
+    if [ -f "${ARTIFACTS_DIR}/x86_64/lib/${lib}" ] && [ -f "${ARTIFACTS_DIR}/arm64/lib/${lib}" ]; then
+        libs=("${ARTIFACTS_DIR}/x86_64/lib/${lib}" "${ARTIFACTS_DIR}/arm64/lib/${lib}")
         lipo -create "${libs[@]}" -o ${ZIP_DIR}/install/lib/${lib}
     fi
 done


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#32208 [iOS][CI]Add File existence checking**

### Summary

Since the master branch will generate `libtorch_cpu.a`, which is different from the release branch. This PR will skip the missing libs before archiving them.

### Test Plan

- don't break the nightly build

Differential Revision: [D19420042](https://our.internmc.facebook.com/intern/diff/D19420042)