### PR TITLE
Update linspace types

### DIFF
--- a/aten/src/ATen/native/RangeFactories.cpp
+++ b/aten/src/ATen/native/RangeFactories.cpp
@@ -20,8 +20,8 @@ Tensor& linspace_cpu_out(Tensor& result, Scalar start, Scalar end, int64_t steps
     // skip
   } else if (steps == 1) {
     r.fill_(start);
-  } else {
-    AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(r.scalar_type(), "linspace_cpu", [&]() {
+  } else if (isComplexType(r.scalar_type())) {
+    AT_DISPATCH_COMPLEX_TYPES(r.scalar_type(), "linspace_cpu", [&]() {
       scalar_t scalar_start = start.to<scalar_t>();
       scalar_t scalar_end = end.to<scalar_t>();
       scalar_t *data_ptr = r.data_ptr<scalar_t>();
@@ -30,6 +30,18 @@ Tensor& linspace_cpu_out(Tensor& result, Scalar start, Scalar end, int64_t steps
         scalar_t is = static_cast<scalar_t>(p_begin);
         for (int64_t i = p_begin; i < p_end; ++i, is+=1) { //std::complex does not support ++operator
           data_ptr[i] = scalar_start + step*is;
+        }
+      });
+    });
+  } else {
+    AT_DISPATCH_ALL_TYPES(r.scalar_type(), "linspace_cpu", [&]() {
+      scalar_t scalar_start = start.to<scalar_t>();
+      scalar_t scalar_end = end.to<scalar_t>();
+      scalar_t *data_ptr = r.data_ptr<scalar_t>();
+      double step = static_cast<double>(scalar_end - scalar_start) / (steps - 1);
+      at::parallel_for(0, steps, internal::GRAIN_SIZE, [&](int64_t p_begin, int64_t p_end) {
+        for (int64_t i = p_begin; i < p_end; ++i) {
+          data_ptr[i] = scalar_start + step*i;
         }
       });
     });

--- a/aten/src/ATen/native/RangeFactories.cpp
+++ b/aten/src/ATen/native/RangeFactories.cpp
@@ -45,18 +45,6 @@ Tensor& linspace_cpu_out(Tensor& result, Scalar start, Scalar end, int64_t steps
         }
       });
     });
-  } else {
-    AT_DISPATCH_ALL_TYPES(r.scalar_type(), "linspace_cpu", [&]() {
-      scalar_t scalar_start = start.to<scalar_t>();
-      scalar_t scalar_end = end.to<scalar_t>();
-      scalar_t *data_ptr = r.data_ptr<scalar_t>();
-      double step = static_cast<double>(scalar_end - scalar_start) / (steps - 1);
-      at::parallel_for(0, steps, internal::GRAIN_SIZE, [&](int64_t p_begin, int64_t p_end) {
-        for (int64_t i = p_begin; i < p_end; ++i) {
-          data_ptr[i] = scalar_start + step*i;
-        }
-      });
-    });
   }
 
   if (!result.is_contiguous()) {

--- a/aten/src/ATen/native/RangeFactories.cpp
+++ b/aten/src/ATen/native/RangeFactories.cpp
@@ -27,7 +27,6 @@ Tensor& linspace_cpu_out(Tensor& result, Scalar start, Scalar end, int64_t steps
       scalar_t *data_ptr = r.data_ptr<scalar_t>();
       scalar_t diff = scalar_end - scalar_start;
       double div = static_cast<double>(steps - 1);
-      
       at::parallel_for(0, steps, internal::GRAIN_SIZE, [&](int64_t p_begin, int64_t p_end) {
         for (int64_t i = p_begin; i < p_end; ++i) {
           data_ptr[i] = scalar_start + (i * diff) / div;
@@ -40,7 +39,6 @@ Tensor& linspace_cpu_out(Tensor& result, Scalar start, Scalar end, int64_t steps
       scalar_t scalar_end = end.to<scalar_t>();
       scalar_t *data_ptr = r.data_ptr<scalar_t>();
       scalar_t step = (scalar_end - scalar_start) / static_cast<scalar_t>(steps - 1);
-      
       at::parallel_for(0, steps, internal::GRAIN_SIZE, [&](int64_t p_begin, int64_t p_end) {
         scalar_t is = static_cast<scalar_t>(p_begin);
         for (int64_t i = p_begin; i < p_end; ++i, is+=1) { //std::complex does not support ++operator

--- a/aten/src/ATen/native/RangeFactories.cpp
+++ b/aten/src/ATen/native/RangeFactories.cpp
@@ -30,7 +30,7 @@ Tensor& linspace_cpu_out(Tensor& result, Scalar start, Scalar end, int64_t steps
       
       at::parallel_for(0, steps, internal::GRAIN_SIZE, [&](int64_t p_begin, int64_t p_end) {
         for (int64_t i = p_begin; i < p_end; ++i) {
-          data_ptr[i] = scalar_start + (i*diff) / div;
+          data_ptr[i] = scalar_start + (i * diff) / div;
         }
       });
     });
@@ -39,12 +39,12 @@ Tensor& linspace_cpu_out(Tensor& result, Scalar start, Scalar end, int64_t steps
       scalar_t scalar_start = start.to<scalar_t>();
       scalar_t scalar_end = end.to<scalar_t>();
       scalar_t *data_ptr = r.data_ptr<scalar_t>();
-      scalar_t step = (scalar_end - scalar_start)/static_cast<scalar_t>(steps-1);
+      scalar_t step = (scalar_end - scalar_start) / static_cast<scalar_t>(steps-1);
       
       at::parallel_for(0, steps, internal::GRAIN_SIZE, [&](int64_t p_begin, int64_t p_end) {
         scalar_t is = static_cast<scalar_t>(p_begin);
         for (int64_t i = p_begin; i < p_end; ++i, is+=1) { //std::complex does not support ++operator
-          data_ptr[i] = scalar_start + is*step;
+          data_ptr[i] = scalar_start + is * step;
         }
       });
     });

--- a/aten/src/ATen/native/RangeFactories.cpp
+++ b/aten/src/ATen/native/RangeFactories.cpp
@@ -25,24 +25,23 @@ Tensor& linspace_cpu_out(Tensor& result, Scalar start, Scalar end, int64_t steps
       scalar_t scalar_start = start.to<scalar_t>();
       scalar_t scalar_end = end.to<scalar_t>();
       scalar_t *data_ptr = r.data_ptr<scalar_t>();
-      scalar_t diff = scalar_end - scalar_start;
-      double div = static_cast<double>(steps - 1);
-      at::parallel_for(0, steps, internal::GRAIN_SIZE, [&](int64_t p_begin, int64_t p_end) {
-        for (int64_t i = p_begin; i < p_end; ++i) {
-          data_ptr[i] = scalar_start + (i * diff) / div;
-        }
-      });
-    });
-  } else {
-    AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(r.scalar_type(), "linspace_cpu", [&]() {
-      scalar_t scalar_start = start.to<scalar_t>();
-      scalar_t scalar_end = end.to<scalar_t>();
-      scalar_t *data_ptr = r.data_ptr<scalar_t>();
       scalar_t step = (scalar_end - scalar_start) / static_cast<scalar_t>(steps - 1);
       at::parallel_for(0, steps, internal::GRAIN_SIZE, [&](int64_t p_begin, int64_t p_end) {
         scalar_t is = static_cast<scalar_t>(p_begin);
         for (int64_t i = p_begin; i < p_end; ++i, is+=1) { //std::complex does not support ++operator
           data_ptr[i] = scalar_start + step*is;
+        }
+      });
+    });
+  } else {
+    AT_DISPATCH_ALL_TYPES(r.scalar_type(), "linspace_cpu", [&]() {
+      scalar_t scalar_start = start.to<scalar_t>();
+      scalar_t scalar_end = end.to<scalar_t>();
+      scalar_t *data_ptr = r.data_ptr<scalar_t>();
+      double step = static_cast<double>(scalar_end - scalar_start) / (steps - 1);
+      at::parallel_for(0, steps, internal::GRAIN_SIZE, [&](int64_t p_begin, int64_t p_end) {
+        for (int64_t i = p_begin; i < p_end; ++i) {
+          data_ptr[i] = scalar_start + step*i;
         }
       });
     });

--- a/aten/src/ATen/native/RangeFactories.cpp
+++ b/aten/src/ATen/native/RangeFactories.cpp
@@ -26,7 +26,7 @@ Tensor& linspace_cpu_out(Tensor& result, Scalar start, Scalar end, int64_t steps
       scalar_t scalar_end = end.to<scalar_t>();
       scalar_t *data_ptr = r.data_ptr<scalar_t>();
       scalar_t diff = scalar_end - scalar_start;
-      double div = static_cast<double>(steps-1);
+      double div = static_cast<double>(steps - 1);
       
       at::parallel_for(0, steps, internal::GRAIN_SIZE, [&](int64_t p_begin, int64_t p_end) {
         for (int64_t i = p_begin; i < p_end; ++i) {
@@ -39,12 +39,12 @@ Tensor& linspace_cpu_out(Tensor& result, Scalar start, Scalar end, int64_t steps
       scalar_t scalar_start = start.to<scalar_t>();
       scalar_t scalar_end = end.to<scalar_t>();
       scalar_t *data_ptr = r.data_ptr<scalar_t>();
-      scalar_t step = (scalar_end - scalar_start) / static_cast<scalar_t>(steps-1);
+      scalar_t step = (scalar_end - scalar_start) / static_cast<scalar_t>(steps - 1);
       
       at::parallel_for(0, steps, internal::GRAIN_SIZE, [&](int64_t p_begin, int64_t p_end) {
         scalar_t is = static_cast<scalar_t>(p_begin);
         for (int64_t i = p_begin; i < p_end; ++i, is+=1) { //std::complex does not support ++operator
-          data_ptr[i] = scalar_start + is * step;
+          data_ptr[i] = scalar_start + step*is;
         }
       });
     });

--- a/aten/src/ATen/native/RangeFactories.cpp
+++ b/aten/src/ATen/native/RangeFactories.cpp
@@ -25,11 +25,12 @@ Tensor& linspace_cpu_out(Tensor& result, Scalar start, Scalar end, int64_t steps
       scalar_t scalar_start = start.to<scalar_t>();
       scalar_t scalar_end = end.to<scalar_t>();
       scalar_t *data_ptr = r.data_ptr<scalar_t>();
-      scalar_t step = (scalar_end - scalar_start) / static_cast<scalar_t>(steps - 1);
+      scalar_t diff = scalar_end - scalar_start;
+      scalar_t div = static_cast<scalar_t>(steps-1);
       at::parallel_for(0, steps, internal::GRAIN_SIZE, [&](int64_t p_begin, int64_t p_end) {
         scalar_t is = static_cast<scalar_t>(p_begin);
         for (int64_t i = p_begin; i < p_end; ++i, is+=1) { //std::complex does not support ++operator
-          data_ptr[i] = scalar_start + step*is;
+          data_ptr[i] = scalar_start + (is*diff) / div;
         }
       });
     });

--- a/aten/src/ATen/native/cuda/RangeFactories.cu
+++ b/aten/src/ATen/native/cuda/RangeFactories.cu
@@ -47,7 +47,7 @@ Tensor& linspace_cuda_out(Tensor& result, Scalar start, Scalar end, int64_t step
     AT_DISPATCH_FLOATING_TYPES_AND_HALF(r.scalar_type(), "linspace_cuda", [&]() {
       scalar_t scalar_start = start.to<scalar_t>();
       scalar_t scalar_end = end.to<scalar_t>();
-      scalar_t diff = scalar_end - scalar_start
+      scalar_t diff = scalar_end - scalar_start;
       double div = static_cast<double>(steps - 1);
 
       auto iter = TensorIterator::nullary_op(r);

--- a/aten/src/ATen/native/cuda/RangeFactories.cu
+++ b/aten/src/ATen/native/cuda/RangeFactories.cu
@@ -47,18 +47,6 @@ Tensor& linspace_cuda_out(Tensor& result, Scalar start, Scalar end, int64_t step
     AT_DISPATCH_FLOATING_TYPES_AND_HALF(r.scalar_type(), "linspace_cuda", [&]() {
       scalar_t scalar_start = start.to<scalar_t>();
       scalar_t scalar_end = end.to<scalar_t>();
-      float step = static_cast<float>(scalar_end - scalar_start) / (steps - 1);
-
-      auto iter = TensorIterator::nullary_op(r);
-      gpu_kernel_with_index(iter, [scalar_start, step]GPU_LAMBDA(int ind) -> scalar_t {
-        scalar_t val = scalar_start + step * ind;
-        return val;
-      });
-    });
-  } else {
-    AT_DISPATCH_FLOATING_TYPES_AND_HALF(r.scalar_type(), "linspace_cuda", [&]() {
-      scalar_t scalar_start = start.to<scalar_t>();
-      scalar_t scalar_end = end.to<scalar_t>();
       scalar_t step = (scalar_end - scalar_start) / static_cast<scalar_t>(steps - 1);
 
       auto iter = TensorIterator::nullary_op(r);

--- a/aten/src/ATen/native/cuda/RangeFactories.cu
+++ b/aten/src/ATen/native/cuda/RangeFactories.cu
@@ -47,8 +47,7 @@ Tensor& linspace_cuda_out(Tensor& result, Scalar start, Scalar end, int64_t step
     AT_DISPATCH_FLOATING_TYPES_AND_HALF(r.scalar_type(), "linspace_cuda", [&]() {
       scalar_t scalar_start = start.to<scalar_t>();
       scalar_t scalar_end = end.to<scalar_t>();
-      scalar_t diff = scalar_end - scalar_start;
-      double div = static_cast<double>(steps - 1);
+      scalar_t step = (scalar_end - scalar_start) / static_cast<scalar_t>(steps - 1);
 
       auto iter = TensorIterator::nullary_op(r);
       gpu_kernel_with_index(iter, [scalar_start, step]GPU_LAMBDA(int ind) -> scalar_t {
@@ -57,17 +56,16 @@ Tensor& linspace_cuda_out(Tensor& result, Scalar start, Scalar end, int64_t step
       });
     });
   } else {
-    AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND1(at::ScalarType::Half, r.scalar_type(), "linspace_cuda", [&]() {
+    AT_DISPATCH_ALL_TYPES_AND(at::ScalarType::Half, r.scalar_type(), "linspace_cuda", [&]() {
       scalar_t scalar_start = start.to<scalar_t>();
       scalar_t scalar_end = end.to<scalar_t>();
-      scalar_t step = (scalar_end - scalar_start) / static_cast<scalar_t>(steps - 1);
+      double step = static_cast<double>(scalar_end - scalar_start) / (steps - 1);
 
       auto iter = TensorIterator::nullary_op(r);
       gpu_kernel_with_index(iter, [scalar_start, step]GPU_LAMBDA(int ind) -> scalar_t {
-          scalar_t inc = step * static_cast<scalar_t>(ind);
-          scalar_t val = scalar_start + inc;
-          return val;
-        });
+        scalar_t val = scalar_start + step * ind;
+        return val;
+      });
     });
   }
 

--- a/aten/src/ATen/native/cuda/RangeFactories.cu
+++ b/aten/src/ATen/native/cuda/RangeFactories.cu
@@ -31,18 +31,29 @@ Tensor& linspace_cuda_out(Tensor& result, Scalar start, Scalar end, int64_t step
     // skip
   } else if (steps == 1) {
     r.fill_(start);
+  } else if (isIntegralType(r.scalar_type(), 0)) {
+    AT_DISPATCH_INTEGRAL_TYPES(at::ScalarType::Half, r.scalar_type(), "linspace_cuda", [&]() {
+      scalar_t scalar_start = start.to<scalar_t>();
+      scalar_t scalar_end = end.to<scalar_t>();
+      float step = static_cast<float>(scalar_end - scalar_start) / (steps - 1);
+
+      auto iter = TensorIterator::nullary_op(r);
+      gpu_kernel_with_index(iter, [scalar_start, step]GPU_LAMBDA(int ind) -> scalar_t {
+        scalar_t val = scalar_start + step * ind;
+        return val;
+      });
+    });
   } else {
-    AT_DISPATCH_ALL_TYPES_AND(at::ScalarType::Half, r.scalar_type(), "linspace_cuda", [&]() {
+    AT_DISPATCH_FLOATING_TYPES_AND_HALF(r.scalar_type(), "linspace_cuda", [&]() {
       scalar_t scalar_start = start.to<scalar_t>();
       scalar_t scalar_end = end.to<scalar_t>();
       scalar_t step = (scalar_end - scalar_start) / static_cast<scalar_t>(steps - 1);
 
       auto iter = TensorIterator::nullary_op(r);
       gpu_kernel_with_index(iter, [scalar_start, step]GPU_LAMBDA(int ind) -> scalar_t {
-          scalar_t inc = step * ind;
-          scalar_t val = scalar_start + inc;
-          return val;
-        });
+        scalar_t val = scalar_start + step * ind;
+        return val;
+      });
     });
   }
 

--- a/aten/src/ATen/native/cuda/RangeFactories.cu
+++ b/aten/src/ATen/native/cuda/RangeFactories.cu
@@ -32,7 +32,7 @@ Tensor& linspace_cuda_out(Tensor& result, Scalar start, Scalar end, int64_t step
   } else if (steps == 1) {
     r.fill_(start);
   } else if (isIntegralType(r.scalar_type(), 0)) {
-    AT_DISPATCH_INTEGRAL_TYPES(at::ScalarType::Half, r.scalar_type(), "linspace_cuda", [&]() {
+    AT_DISPATCH_INTEGRAL_TYPES(r.scalar_type(), "linspace_cuda", [&]() {
       scalar_t scalar_start = start.to<scalar_t>();
       scalar_t scalar_end = end.to<scalar_t>();
       float step = static_cast<float>(scalar_end - scalar_start) / (steps - 1);

--- a/aten/src/ATen/native/cuda/RangeFactories.cu
+++ b/aten/src/ATen/native/cuda/RangeFactories.cu
@@ -60,10 +60,10 @@ Tensor& linspace_cuda_out(Tensor& result, Scalar start, Scalar end, int64_t step
     AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND1(at::ScalarType::Half, r.scalar_type(), "linspace_cuda", [&]() {
       scalar_t scalar_start = start.to<scalar_t>();
       scalar_t scalar_end = end.to<scalar_t>();
-      scalar_t step = (scalar_end - scalar_start)/static_cast<scalar_t>(steps - 1);
+      scalar_t step = (scalar_end - scalar_start) / static_cast<scalar_t>(steps - 1);
 
       auto iter = TensorIterator::nullary_op(r);
-      gpu_kernel_with_index(iter, [scalar_start, diff, div]GPU_LAMBDA(int ind) -> scalar_t {
+      gpu_kernel_with_index(iter, [scalar_start, step]GPU_LAMBDA(int ind) -> scalar_t {
           scalar_t inc = step * static_cast<scalar_t>(ind);
           scalar_t val = scalar_start + inc;
           return val;

--- a/aten/src/ATen/native/cuda/RangeFactories.cu
+++ b/aten/src/ATen/native/cuda/RangeFactories.cu
@@ -47,7 +47,8 @@ Tensor& linspace_cuda_out(Tensor& result, Scalar start, Scalar end, int64_t step
     AT_DISPATCH_FLOATING_TYPES_AND_HALF(r.scalar_type(), "linspace_cuda", [&]() {
       scalar_t scalar_start = start.to<scalar_t>();
       scalar_t scalar_end = end.to<scalar_t>();
-      scalar_t step = (scalar_end - scalar_start) / static_cast<scalar_t>(steps - 1);
+      scalar_t diff = scalar_end - scalar_start;
+      scalar_t div = static_cast<scalar_t>(steps - 1);
 
       auto iter = TensorIterator::nullary_op(r);
       gpu_kernel_with_index(iter, [scalar_start, step]GPU_LAMBDA(int ind) -> scalar_t {

--- a/aten/src/ATen/native/cuda/RangeFactories.cu
+++ b/aten/src/ATen/native/cuda/RangeFactories.cu
@@ -47,7 +47,7 @@ Tensor& linspace_cuda_out(Tensor& result, Scalar start, Scalar end, int64_t step
     AT_DISPATCH_FLOATING_TYPES_AND_HALF(r.scalar_type(), "linspace_cuda", [&]() {
       scalar_t scalar_start = start.to<scalar_t>();
       scalar_t scalar_end = end.to<scalar_t>();
-      scalar_t step = (scalar_end - scalar_start) / static_cast<scalar_t>(steps - 1);
+      float step = static_cast<float>(scalar_end - scalar_start) / (steps - 1);
 
       auto iter = TensorIterator::nullary_op(r);
       gpu_kernel_with_index(iter, [scalar_start, step]GPU_LAMBDA(int ind) -> scalar_t {
@@ -56,10 +56,10 @@ Tensor& linspace_cuda_out(Tensor& result, Scalar start, Scalar end, int64_t step
       });
     });
   } else {
-    AT_DISPATCH_ALL_TYPES_AND(at::ScalarType::Half, r.scalar_type(), "linspace_cuda", [&]() {
+    AT_DISPATCH_FLOATING_TYPES_AND_HALF(r.scalar_type(), "linspace_cuda", [&]() {
       scalar_t scalar_start = start.to<scalar_t>();
       scalar_t scalar_end = end.to<scalar_t>();
-      double step = static_cast<double>(scalar_end - scalar_start) / (steps - 1);
+      scalar_t step = (scalar_end - scalar_start) / static_cast<scalar_t>(steps - 1);
 
       auto iter = TensorIterator::nullary_op(r);
       gpu_kernel_with_index(iter, [scalar_start, step]GPU_LAMBDA(int ind) -> scalar_t {

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -11052,7 +11052,17 @@ class TestTorchDeviceType(TestCase):
         # Check linspace for generating the correct output for each dtype.
         expected_lin = torch.tensor([-100. + (2. / 3.) * i for i in range(301)], device=device, dtype=torch.double)
         actual_lin = torch.linspace(-100, 100, 301, device=device, dtype=dtype)
-        self.assertEqual(expected_lin.to(dtype), actual_lin, 0)
+        #If on GPU, allow for minor error depending on dtype.
+        tol = 0
+        if device=='cuda':
+            if dtype==torch.half:
+                tol = 1e-1
+            elif dtype==torch.float:
+                tol = 1e-5
+            elif dtype==torch.double:
+                tol = 1e-10
+                
+        self.assertEqual(expected_lin.to(dtype), actual_lin, tol)
 
         # Check linspace for generating with start > end.
         self.assertEqual(torch.linspace(2, 0, 3, device=device, dtype=dtype),

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -11037,23 +11037,32 @@ class TestTorchDeviceType(TestCase):
             sz[d] = 0
             self.assertEqual(sz, y.size())
 
-    def test_linspace(self, device):
+    @dtypes(torch.int8, torch.short, torch.int, torch.long, torch.float, torch.double)
+    @dtypesIfCUDA(torch.int8, torch.short, torch.int, torch.long, torch.half, torch.float, torch.double)
+    def test_linspace(self, device, dtype):
         _from = random.random()
         to = _from + random.random()
-        res1 = torch.linspace(_from, to, 137, device=device)
-        res2 = torch.tensor((), device=device)
-        torch.linspace(_from, to, 137, out=res2)
+        res1 = torch.linspace(_from, to, 137, device=device, dtype=dtype)
+        res2 = torch.tensor((), device=device, dtype=dtype)
+        torch.linspace(_from, to, 137, dtype=dtype, out=res2)
         self.assertEqual(res1, res2, 0)
         self.assertRaises(RuntimeError, lambda: torch.linspace(0, 1, -1, device=device))
         self.assertEqual(torch.linspace(0, 1, 1, device=device), torch.zeros(1, device=device), 0)
 
+        # Check linspace for generating the correct output for each dtype.
+        expected_lin = torch.tensor([-100. + (2. / 3.) * i for i in range(301)], device=device, dtype=torch.double)
+        actual_lin = torch.linspace(-100, 100, 301, device=device, dtype=dtype)
+        self.assertEqual(expected_lin.to(dtype), actual_lin, 0)
+
         # Check linspace for generating with start > end.
-        self.assertEqual(torch.linspace(2, 0, 3, device=device), torch.tensor((2, 1, 0), device=device), 0)
+        self.assertEqual(torch.linspace(2, 0, 3, device=device, dtype=dtype),
+                         torch.tensor((2, 1, 0), device=device, dtype=dtype), 
+                         0)
 
         # Check linspace for non-contiguous tensors.
-        x = torch.zeros(2, 3, device=device)
-        y = torch.linspace(0, 3, 4, out=x.narrow(1, 1, 2))
-        self.assertEqual(x, torch.tensor(((0, 0, 1), (0, 2, 3)), device=device), 0)
+        x = torch.zeros(2, 3, device=device, dtype=dtype)
+        y = torch.linspace(0, 3, 4, out=x.narrow(1, 1, 2), dtype=dtype)
+        self.assertEqual(x, torch.tensor(((0, 0, 1), (0, 2, 3)), device=device, dtype=dtype), 0)
 
     def test_logical(self, device):
         for dt in torch.testing.get_all_dtypes():

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -11052,9 +11052,9 @@ class TestTorchDeviceType(TestCase):
         # Check linspace for generating the correct output for each dtype.
         expected_lin = torch.tensor([-100. + .5 * i for i in range(401)], device=device, dtype=torch.double)
         actual_lin = torch.linspace(-100, 100, 401, device=device, dtype=dtype)
-        #If on GPU, allow for minor error depending on dtype.
+        # If on GPU, allow for minor error depending on dtype.
         tol = 0.
-        if device is not 'cpu':
+        if device != 'cpu':
             if dtype==torch.half:
                 tol = 1e-1
             elif dtype==torch.float:

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -11050,18 +11050,18 @@ class TestTorchDeviceType(TestCase):
         self.assertEqual(torch.linspace(0, 1, 1, device=device), torch.zeros(1, device=device), 0)
 
         # Check linspace for generating the correct output for each dtype.
-        expected_lin = torch.tensor([-100. + (2. / 3.) * i for i in range(301)], device=device, dtype=torch.double)
-        actual_lin = torch.linspace(-100, 100, 301, device=device, dtype=dtype)
+        expected_lin = torch.tensor([-100. + .5 * i for i in range(401)], device=device, dtype=torch.double)
+        actual_lin = torch.linspace(-100, 100, 401, device=device, dtype=dtype)
         #If on GPU, allow for minor error depending on dtype.
-        tol = 0
-        if device=='cuda':
+        tol = 0.
+        if device is not 'cpu':
             if dtype==torch.half:
                 tol = 1e-1
             elif dtype==torch.float:
                 tol = 1e-5
             elif dtype==torch.double:
                 tol = 1e-10
-                
+
         self.assertEqual(expected_lin.to(dtype), actual_lin, tol)
 
         # Check linspace for generating with start > end.

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -11055,11 +11055,11 @@ class TestTorchDeviceType(TestCase):
         # If on GPU, allow for minor error depending on dtype.
         tol = 0.
         if device != 'cpu':
-            if dtype==torch.half:
+            if dtype == torch.half:
                 tol = 1e-1
-            elif dtype==torch.float:
+            elif dtype == torch.float:
                 tol = 1e-5
-            elif dtype==torch.double:
+            elif dtype == torch.double:
                 tol = 1e-10
 
         self.assertEqual(expected_lin.to(dtype), actual_lin, tol)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -11050,9 +11050,19 @@ class TestTorchDeviceType(TestCase):
         self.assertEqual(torch.linspace(0, 1, 1, device=device), torch.zeros(1, device=device), 0)
 
         # Check linspace for generating the correct output for each dtype.
-        expected_lin = torch.tensor([-100. + (2. / 3.) * i for i in range(301)], device=device, dtype=torch.double)
-        actual_lin = torch.linspace(-100, 100, 301, device=device, dtype=dtype)
-        self.assertEqual(expected_lin.to(dtype), actual_lin, 0)
+        expected_lin = torch.tensor([-100. + .5 * i for i in range(401)], device=device, dtype=torch.double)
+        actual_lin = torch.linspace(-100, 100, 401, device=device, dtype=dtype)
+        # If on GPU, allow for minor error depending on dtype.
+        tol = 0.
+        if device != 'cpu':
+            if dtype == torch.half:
+                tol = 1e-1
+            elif dtype == torch.float:
+                tol = 1e-5
+            elif dtype == torch.double:
+                tol = 1e-10
+
+        self.assertEqual(expected_lin.to(dtype), actual_lin, tol)
 
         # Check linspace for generating with start > end.
         self.assertEqual(torch.linspace(2, 0, 3, device=device, dtype=dtype),


### PR DESCRIPTION
Changes the linspace functions to be more consistent as requested in #31991. The code has also been updated to avoid an early rounding error; the line `scalar_t step = (scalar_end - scalar_start) / static_cast<static_t>(steps-1)` can result in `step = 0` for integer scalars, and this gives unintended results. I examined the new output using
```
import torch

types = [torch.uint8, torch.int8, torch.short, torch.int, torch.long, torch.half, torch.float, torch.double]

print('Testing linspace:')
for type in types:
    print(type, torch.linspace(-2, 2, 10, dtype=type))
```
which returns
```
Testing linspace:
torch.uint8 tensor([254, 254, 254, 255, 255,   0,   0,   1,   1,   2], dtype=torch.uint8)
torch.int8 tensor([-2, -2, -2, -1, -1,  0,  0,  1,  1,  2], dtype=torch.int8)
torch.int16 tensor([-2, -2, -2, -1, -1,  0,  0,  1,  1,  2], dtype=torch.int16)
torch.int32 tensor([-2, -2, -2, -1, -1,  0,  0,  1,  1,  2], dtype=torch.int32)
torch.int64 tensor([-2, -2, -2, -1, -1,  0,  0,  1,  1,  2])
torch.float16 tensor([-2.0000, -1.5557, -1.1113, -0.6670, -0.2227,  0.2227,  0.6660,  1.1113,
         1.5547,  2.0000], dtype=torch.float16)
torch.float32 tensor([-2.0000, -1.5556, -1.1111, -0.6667, -0.2222,  0.2222,  0.6667,  1.1111,
         1.5556,  2.0000])
torch.float64 tensor([-2.0000, -1.5556, -1.1111, -0.6667, -0.2222,  0.2222,  0.6667,  1.1111,
         1.5556,  2.0000], dtype=torch.float64)
```
which is the expected output: `uint8` overflows as it should, and the result of casting from a floating point to an integer is correct.

This PR does not change the logspace function.