### PR TITLE
Put sparse all reduce results to input tensors

### DIFF
--- a/test/test_distributed.py
+++ b/test/test_distributed.py
@@ -20,6 +20,7 @@ import torch.nn.functional as F
 from common_utils import TestCase, run_tests, skipIfRocm
 from torch._utils_internal import TEST_MASTER_ADDR as MASTER_ADDR
 from torch._utils_internal import TEST_MASTER_PORT as MASTER_PORT
+from common_distributed import simple_sparse_reduce_tests
 
 try:
     import torchvision
@@ -1012,6 +1013,29 @@ class _DistTestBase(object):
         self._test_all_reduce_helper(
             group, group_id, rank, dist.ReduceOp.MAX, -1, 10, 10
         )
+
+    # SPARSE ALL REDUCE
+    def _test_sparse_all_reduce_sum(self, fn):
+        group, group_id, rank = self._init_global_test()
+
+        tests = simple_sparse_reduce_tests(
+            rank,
+            dist.get_world_size(),
+            num_inputs=1)
+        for (inputs, outputs) in tests:
+            tensors = [fn(input) for input in inputs]
+            dist.all_reduce(tensors[0], dist.ReduceOp.SUM, group_id)
+            self.assertEqual(tensors[0], outputs[0])
+
+    @unittest.skipIf(BACKEND == "nccl", "Nccl does not support all reduce on sparse tensors")
+    def test_sparse_all_reduce_sum(self):
+        self._test_sparse_all_reduce_sum(lambda t: t)
+
+    @unittest.skipIf(BACKEND == "nccl", "Nccl does not support all reduce on sparse tensors")
+    @skip_if_not_multigpu
+    @skip_if_rocm
+    def test_sparse_all_reduce_sum_cuda(self):
+        self._test_sparse_all_reduce_sum(lambda t: t.clone().cuda())
 
     # ALL REDUCE - COALESCED
     @staticmethod

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -908,7 +908,6 @@ def all_reduce(tensor,
     else:
         work.wait()
 
-
 def all_reduce_coalesced(tensors,
                          op=ReduceOp.SUM,
                          group=group.WORLD,

--- a/torch/lib/c10d/ProcessGroupGloo.cpp
+++ b/torch/lib/c10d/ProcessGroupGloo.cpp
@@ -976,6 +976,7 @@ class AsyncSparseAllreduceWork : public ProcessGroupGloo::AsyncWork {
     // Copy back to input tensors.
     outputs.reserve(inputs.size());
     for (size_t i = 0; i < inputs.size(); i++) {
+      inputs[i].copy_(output);
       if (output.is_sparse()) {
         outputs.push_back(output.clone());
       } else {
@@ -1199,6 +1200,7 @@ class AsyncSparseAllreduceCUDAWork : public AsyncSparseAllreduceWork {
     for (size_t i = 0; i < inputs.size(); i++) {
       stream_guard.reset_stream(streams[i]);
       outputs.push_back(output.to(inputs[i].device(), /*non_blocking=*/true));
+      inputs[i].copy_(output, /* non_blocking */ true);
       events[i].record(streams[i]);
     }
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

right now if users call torch.dist.all_reduce() on dense tensors, outputs are put in input tensors. but if users call torch.dist.all_reduce() on sparse tensors, outputs are neither returned explicitly to users nor are put in input tensors.

To make torch.dist.all_reduce() API have same behavior on both dense tensors and sparse tensors, this diff is made to make torch.dist.all_reduce() on sparse tensors to put output in input tensors as well. This is acheived by simply calling input_sparse.copy_(output_sparse), see PR https://github.com/pytorch/pytorch/pull/9005 that implemented copy_ for sparse tensors.

close #31413

Differential Revision: [D19192952](https://our.internmc.facebook.com/intern/diff/D19192952/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D19192952/)!