### PR TITLE
fix #30480 torch.normal shape checking is broken

### DIFF
--- a/aten/src/ATen/ExpandUtils.cpp
+++ b/aten/src/ATen/ExpandUtils.cpp
@@ -9,6 +9,7 @@ std::vector<int64_t> infer_size(IntArrayRef a, IntArrayRef b) {
   std::vector<int64_t> expandedSizes(ndim);
 
   // Use ptrdiff_t to ensure signed comparison.
+  // NOTE: are_expandable did a similar check, please keep them sync if change is needed
   for (ptrdiff_t i = (ptrdiff_t)ndim - 1; i >= 0; --i) {
     ptrdiff_t offset = ndim - 1 - i;
     ptrdiff_t dimA = dimsA - 1 - offset;

--- a/aten/src/ATen/ExpandUtils.h
+++ b/aten/src/ATen/ExpandUtils.h
@@ -16,6 +16,22 @@ inferExpandGeometry(
     IntArrayRef tensor_strides,
     IntArrayRef sizes);
 
+// True if input shapes are expandable
+// NOTE: infer_size did a similar check, please keep them sync if change is needed
+static inline bool are_expandable(IntArrayRef shape1, IntArrayRef shape2) {
+  size_t ndim1 = shape1.size();
+  size_t ndim2 = shape2.size();
+  size_t ndim = ndim1 < ndim2 ? ndim1 : ndim2;
+
+  for (int64_t i = ndim - 1; i >= 0; --i) {
+    if (shape1[--ndim1] == shape2[--ndim2] || shape1[ndim1] == 1 || shape2[ndim2] == 1) {
+      continue;
+    }
+    return false;
+  }
+  return true;
+}
+
 // avoid copy-construction of Tensor by using a reference_wrapper.
 inline void check_defined(std::initializer_list<std::reference_wrapper<const Tensor>> tensors, const char *api_name) {
   for (auto& t : tensors) {
@@ -170,21 +186,6 @@ static inline bool is_expandable_to(IntArrayRef shape, IntArrayRef desired) {
     if (size != target && size != 1) {
       return false;
     }
-  }
-  return true;
-}
-
-// True if the input two shapes are broadcastable from one to the other in any direction
-static inline bool are_expandable(IntArrayRef shape1, IntArrayRef shape2) {
-  size_t ndim1 = shape1.size();
-  size_t ndim2 = shape2.size();
-  size_t ndim = ndim1 < ndim2 ? ndim1 : ndim2;
-
-  for (int64_t i = ndim - 1; i >= 0; --i) {
-    if (shape1[--ndim1] == shape2[--ndim2] || shape1[ndim1] == 1 || shape2[ndim2] == 1) {
-      continue;
-    }
-    return false;
   }
   return true;
 }

--- a/aten/src/ATen/ExpandUtils.h
+++ b/aten/src/ATen/ExpandUtils.h
@@ -174,4 +174,19 @@ static inline bool is_expandable_to(IntArrayRef shape, IntArrayRef desired) {
   return true;
 }
 
+// True if the input two shapes are broadcastable from one to the other in any direction
+static inline bool are_expandable(IntArrayRef shape1, IntArrayRef shape2) {
+  size_t ndim1 = shape1.size();
+  size_t ndim2 = shape2.size();
+  size_t ndim = ndim1 < ndim2 ? ndim1 : ndim2;
+
+  for (int64_t i = ndim - 1; i >= 0; --i) {
+    if (shape1[--ndim1] == shape2[--ndim2] || shape1[ndim1] == 1 || shape2[ndim2] == 1) {
+      continue;
+    }
+    return false;
+  }
+  return true;
+}
+
 }

--- a/aten/src/ATen/native/cuda/Distributions.cu
+++ b/aten/src/ATen/native/cuda/Distributions.cu
@@ -730,7 +730,7 @@ Tensor& normal_out_cuda(Tensor& output, const Tensor& mean, const Tensor& std, G
   if (expandable) {
     auto shape = at::infer_size(mean.sizes(), std.sizes());
     TORCH_CHECK(
-        empty_output || output.sizes().equals(shape), 
+        empty_output || output.sizes().equals(shape),
         "inconsistent tensor, output size (", output.sizes(), ") is not the same as broadcasted mean and std size (", shape, ")");
     if (empty_output) {
       at::native::resize_(output, shape);
@@ -738,11 +738,11 @@ Tensor& normal_out_cuda(Tensor& output, const Tensor& mean, const Tensor& std, G
   }
   else {
     TORCH_CHECK(
-        mean.numel() == std.numel(), 
+        mean.numel() == std.numel(),
         "inconsistent tensor, std and mean are not broadcastable and have different number of elements, "
         "expected mean ", mean.sizes(), " and std ", std.sizes(), " to have same number of elements)");
     TORCH_CHECK(
-        empty_output || output.sizes().equals(mean.sizes()), 
+        empty_output || output.sizes().equals(mean.sizes()),
         "inconsistent tensor, std and mean are not broadcastable, output size (", output.sizes(), ") is not the same as mean size (", mean.sizes(), ")");
     TORCH_WARN_ONCE(
         "std and mean have the same number of elements, but are not broadcastable. This was previously a "

--- a/aten/src/ATen/native/cuda/Distributions.cu
+++ b/aten/src/ATen/native/cuda/Distributions.cu
@@ -731,14 +731,14 @@ Tensor& normal_out_cuda(Tensor& output, const Tensor& mean, const Tensor& std, G
     auto shape = at::infer_size(mean.sizes(), std.sizes());
     TORCH_CHECK(empty_output || output.sizes().equals(shape), "output size is not the same as broadcast size of mean and std");
     if (empty_output) {
-      at::native::resize_(output, shape, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+      at::native::resize_(output, shape);
     }
   }
   else {
     TORCH_CHECK(mean.numel() == std.numel(), "mean and std should have same number of element when nonexpandable");
     TORCH_CHECK(empty_output || output.sizes().equals(mean.sizes()), "output size is not the same as the size of mean");
     if (empty_output) {
-      at::native::resize_(output, mean.sizes(), LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+      at::native::resize_(output, mean.sizes());
     }
   }
 

--- a/aten/src/ATen/native/cuda/Distributions.cu
+++ b/aten/src/ATen/native/cuda/Distributions.cu
@@ -729,14 +729,21 @@ Tensor& normal_out_cuda(Tensor& output, const Tensor& mean, const Tensor& std, G
 
   if (expandable) {
     auto shape = at::infer_size(mean.sizes(), std.sizes());
-    TORCH_CHECK(empty_output || output.sizes().equals(shape), "output size is not the same as broadcasted size of mean and std");
+    TORCH_CHECK(
+        empty_output || output.sizes().equals(shape), 
+        "inconsistent tensor, output size (", output.sizes(), ") is not the same as broadcasted mean and std size (", shape, ")");
     if (empty_output) {
       at::native::resize_(output, shape);
     }
   }
   else {
-    TORCH_CHECK(mean.numel() == std.numel(), "std and mean are not broadcastable and have different number of elements");
-    TORCH_CHECK(empty_output || output.sizes().equals(mean.sizes()), "std and mean are not broadcastable, output size is not the same as mean size");
+    TORCH_CHECK(
+        mean.numel() == std.numel(), 
+        "inconsistent tensor, std and mean are not broadcastable and have different number of elements, "
+        "expected mean ", mean.sizes(), " and std ", std.sizes(), " to have same number of elements)");
+    TORCH_CHECK(
+        empty_output || output.sizes().equals(mean.sizes()), 
+        "inconsistent tensor, std and mean are not broadcastable, output size (", output.sizes(), ") is not the same as mean size (", mean.sizes(), ")");
     TORCH_WARN_ONCE(
         "std and mean have the same number of elements, but are not broadcastable. This was previously a "
         "supported mode of operation, but is now deprecated and the support will be removed in a later release. "

--- a/aten/src/ATen/native/cuda/Distributions.cu
+++ b/aten/src/ATen/native/cuda/Distributions.cu
@@ -724,15 +724,29 @@ Tensor& normal_out_cuda(Tensor& output, double mean, const Tensor& std, Generato
 }
 
 Tensor& normal_out_cuda(Tensor& output, const Tensor& mean, const Tensor& std, Generator* gen) {
+  bool expandable = are_expandable(mean.sizes(), std.sizes());
+  // allow resize if output is an empty tensor
+  if (output.sizes().equals({0})) {
+    if (expandable) {
+      auto shape = at::infer_size(mean.sizes(), std.sizes());
+      at::native::resize_(output, shape, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+    }
+    else {
+      at::native::resize_(output, mean.sizes(), LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+    }
+  }
   normal_cuda_(output, 0, 1, gen);
   // NB: addcmul_out copies the tensor to be added into the output.
   // Please look at aten/src/THC/generic/THCTensorMathPointwise.cu
   // The previous function here was addcmul_out(output, mean, output, std, 1);
   // The third argument is not a constant reference and hence the samples in output are overwritten.
   // Consequently, the computation performed is mean + mean * std instead of mean + output * std
-  if (mean.numel() == std.numel() && !at::is_expandable_to(std.sizes(), mean.sizes())) {
-    TORCH_WARN_ONCE("Reshape std to the same shape of mean due to not broadcastable");
-    //Reshape std to the same shape mean if they have same number of element but not broadcastable
+  if (mean.numel() == std.numel() && !expandable) {
+    TORCH_WARN_ONCE(
+        "std and mean have the same number of elements, but are not broadcastable. This was previously a "
+        "supported mode of operation, but is now deprecated and the support will be removed in a later release. "
+        "Note that the current implementation reshapes std to the shape of mean, which may be incur data copies. "
+        "Please ensure that std and mean are broadcastable to avoid these issues.");
     output.mul_(std.reshape(mean.sizes())).add_(mean);
   }
   else {
@@ -754,7 +768,7 @@ Tensor normal_cuda(double mean, const Tensor& std, Generator* gen) {
 }
 
 Tensor normal_cuda(const Tensor& mean, const Tensor& std, Generator* gen) {
-  Tensor ret = at::empty_like(mean, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+  Tensor ret = at::empty({0}, mean.options(), LEGACY_CONTIGUOUS_MEMORY_FORMAT);
   normal_out_cuda(ret, mean, std, gen);
   return ret;
 }

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -1603,39 +1603,6 @@ class TestDistributions(TestCase):
 
         self._check_log_prob(Normal(loc, scale), ref_log_prob)
 
-    def test_normal_shape(self):
-        for device in torch.testing.get_all_device_types():
-            tensor1 = torch.rand(1, device=device)
-            tensor4 = torch.rand(4, device=device)
-            tensor120 = torch.rand(120, device=device)
-            tensor2145 = torch.rand(2, 1, 4, 5, device=device)
-            tensor2345 = torch.rand(2, 3, 4, 5, device=device)
-            tensor2345_non_contiguous = torch.rand(2, 4, 3, 5, device=device).permute(0, 2, 1, 3)
-            tensor2345_channels_last = tensor2345.contiguous(memory_format=torch.channels_last)
-
-            # inputs have same size
-            self.assertEqual(torch.normal(tensor2345, tensor2345).size(), (2, 3, 4, 5))
-            self.assertEqual(torch.normal(tensor2345_non_contiguous, tensor2345).size(), (2, 3, 4, 5))
-            self.assertEqual(torch.normal(tensor2345, tensor2345_channels_last).size(), (2, 3, 4, 5))
-            self.assertEqual(torch.normal(tensor2345_non_contiguous, tensor2345_channels_last).size(), (2, 3, 4, 5))
-            # scalar case
-            self.assertEqual(torch.normal(tensor2345, 2).size(), (2, 3, 4, 5))
-            self.assertEqual(torch.normal(2, tensor2345).size(), (2, 3, 4, 5))
-            # inputs are expandable tensors
-            if device == 'cpu':
-                # CPU version is written in legacy code (TH), it doesn't support broadcasting
-                with self.assertRaisesRegex(RuntimeError, "inconsistent tensor size"):
-                    torch.normal(tensor2345, tensor2145)
-            else:
-                self.assertEqual(torch.normal(tensor2345, tensor1).size(), (2, 3, 4, 5))
-                self.assertEqual(torch.normal(tensor2145, tensor2345).size(), (2, 3, 4, 5))
-            # inputs are non-expandable tensors, but they have same number of elements
-            self.assertEqual(torch.normal(tensor120, tensor2345).size(), (120,))
-            self.assertEqual(torch.normal(tensor2345, tensor120).size(), (2, 3, 4, 5))
-            # inputs are non-expandable tensors and they don't have same number of elements
-            with self.assertRaises(RuntimeError):
-                torch.normal(tensor2345, tensor4)
-
     @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
     def test_normal_sample(self):
         set_rng_seed(0)  # see Note [Randomized statistical tests]

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -1605,24 +1605,24 @@ class TestDistributions(TestCase):
 
     @unittest.skipIf(not TEST_CUDA, "CUDA not found")
     def test_normal_shape_gpu(self):
-        tensor23 = torch.rand(2,3,device='cuda')
-        tensor21 = torch.rand(2,1,device='cuda')
-        tensor6 = torch.rand(6,device='cuda')
-        tensor4 = torch.rand(4,device='cuda')
-        tensor3 = torch.rand(3,device='cuda')
-        tensor1 = torch.rand(1,device='cuda')
-        #normal case
-        self.assertEqual(torch.normal(tensor23, tensor23).size(), (2,3))
-        #expandable case (including scalar case)
-        self.assertEqual(torch.normal(tensor23, tensor21).size(), (2,3))
-        self.assertEqual(torch.normal(tensor23, tensor3).size(), (2,3))
-        self.assertEqual(torch.normal(tensor23, tensor1).size(), (2,3))
-        self.assertEqual(torch.normal(tensor23, 2).size(), (2,3))
-        self.assertEqual(torch.normal(2, tensor23).size(), (2,3))
-        #non expandable but std and mean have same elements case
-        self.assertEqual(torch.normal(tensor23, tensor6).size(), (2,3))
+        tensor23 = torch.rand(2, 3, device='cuda')
+        tensor21 = torch.rand(2, 1, device='cuda')
+        tensor6 = torch.rand(6, device='cuda')
+        tensor4 = torch.rand(4, device='cuda')
+        tensor3 = torch.rand(3, device='cuda')
+        tensor1 = torch.rand(1, device='cuda')
+        # normal case
+        self.assertEqual(torch.normal(tensor23, tensor23).size(), (2, 3))
+        # expandable case (including scalar case)
+        self.assertEqual(torch.normal(tensor23, tensor21).size(), (2, 3))
+        self.assertEqual(torch.normal(tensor23, tensor3).size(), (2, 3))
+        self.assertEqual(torch.normal(tensor23, tensor1).size(), (2, 3))
+        self.assertEqual(torch.normal(tensor23, 2).size(), (2, 3))
+        self.assertEqual(torch.normal(2, tensor23).size(), (2, 3))
+        # non expandable but std and mean have same elements case
+        self.assertEqual(torch.normal(tensor23, tensor6).size(), (2, 3))
         self.assertEqual(torch.normal(tensor6, tensor23).size(), (6,))
-        #non expandable and std and mean have different number of element
+        # non expandable and std and mean have different number of element
         with self.assertRaises(RuntimeError):
             torch.normal(tensor23, tensor4)
 

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -1626,8 +1626,10 @@ class TestDistributions(TestCase):
 
     @unittest.skipIf(not TEST_CUDA, "CUDA not found")
     def test_normal_shape_gpu(self):
-        tensor23 = torch.rand(2, 3, device='cuda')
+        tensor12 = torch.rand(1, 2, device='cuda')
         tensor21 = torch.rand(2, 1, device='cuda')
+        tensor22 = torch.rand(2, 2, device='cuda')
+        tensor23 = torch.rand(2, 3, device='cuda')
         tensor6 = torch.rand(6, device='cuda')
         tensor4 = torch.rand(4, device='cuda')
         tensor3 = torch.rand(3, device='cuda')
@@ -1638,6 +1640,7 @@ class TestDistributions(TestCase):
         self.assertEqual(torch.normal(tensor23, tensor21).size(), (2, 3))
         self.assertEqual(torch.normal(tensor23, tensor3).size(), (2, 3))
         self.assertEqual(torch.normal(tensor23, tensor1).size(), (2, 3))
+        self.assertEqual(torch.normal(tensor21, tensor12).size(), (2, 2))
         self.assertEqual(torch.normal(tensor23, 2).size(), (2, 3))
         self.assertEqual(torch.normal(2, tensor23).size(), (2, 3))
         # non expandable but std and mean have same elements case
@@ -1646,6 +1649,11 @@ class TestDistributions(TestCase):
         # non expandable and std and mean have different number of element
         with self.assertRaises(RuntimeError):
             torch.normal(tensor23, tensor4)
+        # out version works if the output tensor doesn't need resize
+        self.assertEqual(torch.normal(tensor21, tensor12, out=tensor22).size(), (2, 2))
+        # out version does not allow output tensor resize
+        with self.assertRaises(RuntimeError):
+            torch.normal(tensor21, tensor12, out=tensor1)
 
     @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
     def test_normal_sample(self):

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -1603,6 +1603,29 @@ class TestDistributions(TestCase):
 
         self._check_log_prob(Normal(loc, scale), ref_log_prob)
 
+    @unittest.skipIf(not TEST_CUDA, "CUDA not found")
+    def test_normal_shape_gpu(self):
+        tensor23 = torch.rand(2,3,device='cuda')
+        tensor21 = torch.rand(2,1,device='cuda')
+        tensor6 = torch.rand(6,device='cuda')
+        tensor4 = torch.rand(4,device='cuda')
+        tensor3 = torch.rand(3,device='cuda')
+        tensor1 = torch.rand(1,device='cuda')
+        #normal case
+        self.assertEqual(torch.normal(tensor23, tensor23).size(), (2,3))
+        #expandable case (including scalar case)
+        self.assertEqual(torch.normal(tensor23, tensor21).size(), (2,3))
+        self.assertEqual(torch.normal(tensor23, tensor3).size(), (2,3))
+        self.assertEqual(torch.normal(tensor23, tensor1).size(), (2,3))
+        self.assertEqual(torch.normal(tensor23, 2).size(), (2,3))
+        self.assertEqual(torch.normal(2, tensor23).size(), (2,3))
+        #non expandable but std and mean have same elements case
+        self.assertEqual(torch.normal(tensor23, tensor6).size(), (2,3))
+        self.assertEqual(torch.normal(tensor6, tensor23).size(), (6,))
+        #non expandable and std and mean have different number of element
+        with self.assertRaises(RuntimeError):
+            torch.normal(tensor23, tensor4)
+
     @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
     def test_normal_sample(self):
         set_rng_seed(0)  # see Note [Randomized statistical tests]

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -5977,9 +5977,11 @@ tensor([[[1., 1., 1.,  ..., 1., 1., 1.],
             self.assertEqual(torch.normal(tensor2345_non_contiguous, tensor2345).size(), (2, 3, 4, 5))
             self.assertEqual(torch.normal(tensor2345, tensor2345_channels_last).size(), (2, 3, 4, 5))
             self.assertEqual(torch.normal(tensor2345_non_contiguous, tensor2345_channels_last).size(), (2, 3, 4, 5))
+
             # scalar case
             self.assertEqual(torch.normal(tensor2345, 2).size(), (2, 3, 4, 5))
             self.assertEqual(torch.normal(2, tensor2345).size(), (2, 3, 4, 5))
+
             # inputs are expandable tensors
             if device == 'cpu':
                 # CPU version is written in legacy code (TH), it doesn't support broadcasting
@@ -5988,20 +5990,25 @@ tensor([[[1., 1., 1.,  ..., 1., 1., 1.],
             else:
                 self.assertEqual(torch.normal(tensor2345, tensor1).size(), (2, 3, 4, 5))
                 self.assertEqual(torch.normal(tensor2145, tensor2345).size(), (2, 3, 4, 5))
+
             # inputs are non-expandable tensors, but they have same number of elements
             self.assertEqual(torch.normal(tensor120, tensor2345).size(), (120,))
             self.assertEqual(torch.normal(tensor2345, tensor120).size(), (2, 3, 4, 5))
+
             # inputs are non-expandable tensors and they don't have same number of elements
             with self.assertRaisesRegex(RuntimeError, "inconsistent tensor"):
                 torch.normal(tensor2345, tensor4)
-            # output and inputs are size sompatialbe
+
+            # output and inputs are size compatible
             self.assertEqual(torch.normal(tensor2345, tensor2345, out=output2345).size(), (2, 3, 4, 5))
+
             # output and inputs are not size compatible
-            # CUDA only since CPU version is written in legacy TH, it doesn't care about the size compatiable
+            # CUDA only since CPU version is written in legacy TH, it doesn't care about the size compatible
             if device == 'cuda':
                 with self.assertRaisesRegex(RuntimeError, "inconsistent tensor"):
                     # inputs are expandable but have different broadcasted size than output
                     torch.normal(tensor2345, tensor2145, out=output345)
+                with self.assertRaisesRegex(RuntimeError, "inconsistent tensor"):
                     # inputs are not expandable but reshapeable, output size is not the same as mean
                     torch.normal(tensor2345, tensor120, out=output345)
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -14669,6 +14669,7 @@ class TestDevicePrecision(TestCase):
         output = torch.ones_like(x)
         self.assertEqual(output, expected)
 
+
 # Below are fixtures and functions that generate tensor op comparison tests
 # These tests run a single op on both a CPU and device tensor and compare the
 # the results. In-place variants of the ops can also be run.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#32243 fix #30480 torch.normal shape checking is broken**

Following what @gchanan proposed in #30480 
- If the (logical) shapes of mean and std are broadcastable, we broadcast them for the output
  Done in tensor iterator already.
- If the (logical) shapes of mean and std are not broadcastable and they have the same number of elements, we fall back to the old behavior (pick the shape of mean)
  Done by reshape std to the same shape of mean.
- If the (logical) shapes of mean and std are not broadcastable and don't have the same number of elements, we error out.
  Done by tensor iterator already.

Differential Revision: [D19417087](https://our.internmc.facebook.com/intern/diff/D19417087)

Currently, cpu version is still written in legacy code (TH), it doesn't support broadcasting. This will be solved once it is migrated using new tensor iterator like gpu version. Test cases for cpu and gpu are separated provided at this time. 
I am making sure gpu version behave correctly at this point, and cpu version behave all the same as gpu except tensor broadcasting support.