### PR TITLE
Set rpath for JNI library on Mac

### DIFF
--- a/android/pytorch_android/CMakeLists.txt
+++ b/android/pytorch_android/CMakeLists.txt
@@ -48,6 +48,14 @@ add_library(pytorch_jni SHARED
     ${pytorch_android_SOURCES}
 )
 
+if (APPLE)
+  # Need to add rpath so dlopen can find dependencies.
+  add_custom_command(TARGET pytorch_jni
+      POST_BUILD COMMAND
+      ${CMAKE_INSTALL_NAME_TOOL} -add_rpath "@loader_path"
+        $<TARGET_FILE:pytorch_jni>)
+endif()
+
 target_compile_options(pytorch_jni PRIVATE
   -fexceptions
 )


### PR DESCRIPTION
Summary:
Without this, dlopen won't look in the proper directory for dependencies
(like libtorch and fbjni).

Test Plan:
Build libpytorch_jni.dylib on Mac, replaced the one from the libtorch
nightly, and was able to run the Java demo.

