### PR TITLE
[wip] fixed type names

### DIFF
--- a/c10/test/util/TypeIndex_test.cpp
+++ b/c10/test/util/TypeIndex_test.cpp
@@ -104,6 +104,7 @@ TEST(TypeIndex, FunctionTraits) {
 }
 
 namespace test_top_level_name {
+class Dummy {};
 #if C10_TYPENAME_SUPPORTS_CONSTEXPR
 static_assert(
     string_view::npos != get_fully_qualified_type_name<Dummy>().find("Dummy"),
@@ -273,3 +274,95 @@ TEST(TypeIndex, FunctionArgumentsAndReturns) {
 }
 } // namespace test_function_arguments_and_returns
 } // namespace
+
+namespace test_type_names_are_well_defined {
+// Our type_index computation works by taking the fully qualified type name and hashing it.
+// Type names are compiler specific and different compilers can have different ways of printing
+// a name for the same type. To make sure they get the same type_index, we need to make sure
+// they get the same type name. This test case here ensures that the type name is what we expect.
+// If one of these tests fails, we have to change the type name computation for that compiler
+// so that it aligns with what the other compilers output for this type.
+struct Dummy final {};
+struct Functor final {
+  int64_t operator()(uint32_t, Dummy&&, const Dummy&) const;
+};
+template <class T>
+struct Outer final {};
+struct Inner final {};
+template <size_t N>
+struct Class final {};
+template <class T>
+struct Type final {
+  using type = const T*;
+};
+#if C10_TYPENAME_SUPPORTS_CONSTEXPR
+static_assert("int" == get_fully_qualified_type_name<int>(), "");
+static_assert("float" == get_fully_qualified_type_name<float>(), "");
+static_assert("double" == get_fully_qualified_type_name<double>(), "");
+static_assert("int (double, double)" == get_fully_qualified_type_name<int(double, double)>(), "");
+static_assert("int (*)(double, double)" == get_fully_qualified_type_name<int (*)(double, double)>(), "");
+static_assert("std::function<int (double, double)>" == get_fully_qualified_type_name<std::function<int(double, double)>>(), "");
+static_assert("int &" == get_fully_qualified_type_name<int&>(), "");
+static_assert("int &&" == get_fully_qualified_type_name<int&&>(), "");
+static_assert("const int &" == get_fully_qualified_type_name<const int&>(), "");
+static_assert("const int" == get_fully_qualified_type_name<const int>(), "");
+static_assert("int *" == get_fully_qualified_type_name<int*>(), "");
+static_assert("int **" == get_fully_qualified_type_name<int**>(), "");
+static_assert("int (double &, double)" ==
+        get_fully_qualified_type_name<int(double&, double)>(),
+    "");
+static_assert(
+    "long (unsigned int, test_type_names_are_well_defined::Dummy &&, const test_type_names_are_well_defined::Dummy &)" ==
+        get_fully_qualified_type_name<c10::guts::infer_function_traits_t<Functor>::func_type>(),
+    "");
+static_assert(
+    "test_type_names_are_well_defined::Outer<test_type_names_are_well_defined::Inner>" ==
+        get_fully_qualified_type_name<Outer<Inner>>(),
+    "");
+static_assert(
+    "test_type_names_are_well_defined::Class<38474355>" ==
+        get_fully_qualified_type_name<Class<38474355>>(),
+    "");
+static_assert(
+    "const int *" ==
+        get_fully_qualified_type_name<typename Type<int>::type>(),
+    "");
+static_assert(
+    "const int" ==
+        get_fully_qualified_type_name<
+            typename std::remove_pointer<typename Type<int>::type>::type>(),
+    "");
+#endif
+TEST(TypeIndex, TypeNamesAreWellDefined) {
+    EXPECT_EQ("int", get_fully_qualified_type_name<int>());
+    EXPECT_EQ("float", get_fully_qualified_type_name<float>());
+    EXPECT_EQ("double", get_fully_qualified_type_name<double>());
+    EXPECT_EQ("int (double, double)", get_fully_qualified_type_name<int(double, double)>());
+    EXPECT_EQ("int (*)(double, double)", get_fully_qualified_type_name<int (*)(double, double)>());
+    EXPECT_EQ("std::function<int (double, double)>", get_fully_qualified_type_name<std::function<int(double, double)>>());
+    EXPECT_EQ("int &", get_fully_qualified_type_name<int&>());
+    EXPECT_EQ("int &&", get_fully_qualified_type_name<int&&>());
+    EXPECT_EQ("const int &", get_fully_qualified_type_name<const int&>());
+    EXPECT_EQ("const int", get_fully_qualified_type_name<const int>());
+    EXPECT_EQ("int *", get_fully_qualified_type_name<int*>());
+    EXPECT_EQ("int **", get_fully_qualified_type_name<int**>());
+    EXPECT_EQ("int (double &, double)",
+            get_fully_qualified_type_name<int(double&, double)>());
+    EXPECT_EQ("long (unsigned int, test_type_names_are_well_defined::Dummy &&, const test_type_names_are_well_defined::Dummy &)",
+        get_fully_qualified_type_name<
+            c10::guts::infer_function_traits_t<Functor>::func_type>());
+    EXPECT_EQ(
+        "test_type_names_are_well_defined::Outer<test_type_names_are_well_defined::Inner>",
+            get_fully_qualified_type_name<Outer<Inner>>());
+    EXPECT_EQ(
+        "test_type_names_are_well_defined::Class<38474355>",
+            get_fully_qualified_type_name<Class<38474355>>());
+    EXPECT_EQ(
+        "const int *",
+            get_fully_qualified_type_name<typename Type<int>::type>());
+    EXPECT_EQ(
+        "const int",
+            get_fully_qualified_type_name<
+                typename std::remove_pointer<typename Type<int>::type>::type>());
+}
+}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#32259 [wip] fixed type names**
* #32161 type index is only constexpr if typeid is
* #32160 Check for incompatible compilers with mismatching typeids
* #26628 Remove CAFFE_KNOWN_TYPE

Differential Revision: [D19423875](https://our.internmc.facebook.com/intern/diff/D19423875/)