### PR TITLE
faster bailout tests

### DIFF
--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -458,6 +458,7 @@ struct CAFFE2_API TensorType : public Type {
     return requires_grad_ ? *requires_grad_ : true;
   }
 
+  bool isCompatibleWith(at::Tensor& t, bool print) const;
 
   bool operator==(const Type& rhs) const override {
     if (rhs.kind() != kind()) {

--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -458,7 +458,7 @@ struct CAFFE2_API TensorType : public Type {
     return requires_grad_ ? *requires_grad_ : true;
   }
 
-  bool isCompatibleWith(at::Tensor& t) const;
+  bool isCompatibleWithInCurrentExecutionContext(at::Tensor& t) const;
 
   bool operator==(const Type& rhs) const override {
     if (rhs.kind() != kind()) {
@@ -583,6 +583,10 @@ struct CAFFE2_API TensorType : public Type {
         strides_(tensor.sizes().size()),
         requires_grad_(tensor.requires_grad()),
         undefined_(!tensor.defined()) {
+    // any updates to `isSubtypeOf`, TensorType c-tor or
+    // `isCompatibleWithInCurrentExecutionContext` need to maintain the
+    // following `TensorType::create(actual_tensor)->isSubtypeOf(expected_type)
+    //  == expected_type->isCompatibleWithInCurrentExecutionContext(t)`
     if (!tensor.is_mkldnn() && !tensor.is_sparse()) {
       sizes_ = tensor.sizes().vec();
       strides_ = tensor.strides().vec();

--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -458,7 +458,7 @@ struct CAFFE2_API TensorType : public Type {
     return requires_grad_ ? *requires_grad_ : true;
   }
 
-  bool isCompatibleWith(at::Tensor& t, bool print) const;
+  bool isCompatibleWith(at::Tensor& t) const;
 
   bool operator==(const Type& rhs) const override {
     if (rhs.kind() != kind()) {

--- a/aten/src/ATen/core/type.cpp
+++ b/aten/src/ATen/core/type.cpp
@@ -3,7 +3,7 @@
 #include <ATen/core/function_schema.h>
 #include <ATen/core/jit_type.h>
 #include <c10/macros/Macros.h>
-#include <torch/csrc/autograd/grad_mode.h>
+#include <ATen/core/grad_mode.h>
 #include <iostream>
 
 namespace c10 {

--- a/aten/src/ATen/core/type.cpp
+++ b/aten/src/ATen/core/type.cpp
@@ -1,10 +1,10 @@
-#include <ATen/core/jit_type.h>
-#include <ATen/core/function_schema.h>
 #include <ATen/core/Dict.h>
-#include <iostream>
-#include <c10/macros/Macros.h>
 #include <ATen/core/Tensor.h>
+#include <ATen/core/function_schema.h>
+#include <ATen/core/jit_type.h>
+#include <c10/macros/Macros.h>
 #include <torch/csrc/autograd/grad_mode.h>
+#include <iostream>
 
 namespace c10 {
 
@@ -71,14 +71,12 @@ AnyTypePtr AnyType::get() {
   return value;
 }
 
-
 template <typename T>
 static bool test_primitive(c10::optional<T> e, T a) {
   return !e.has_value() || e.value() == a;
 }
 
 static bool test_varying_shape(const VaryingShape& e, at::IntArrayRef a) {
-
   if (!e.size().has_value()) {
     return true;
   }
@@ -97,18 +95,17 @@ static bool test_varying_shape(const VaryingShape& e, at::IntArrayRef a) {
 }
 
 bool TensorType::isCompatibleWith(at::Tensor& t) const {
-
   if (!t.defined()) {
     return test_primitive(undefined(), !t.defined());
   }
 
-return
-  test_varying_shape(sizes(), t.sizes()) &&
-    (t.is_sparse() || t.is_mkldnn() || test_varying_shape(strides(), t.strides())) &&
-    test_primitive(requiresGrad(),t.requires_grad() && at::GradMode::is_enabled()) &&
-    test_primitive(scalarType(), t.scalar_type()) &&
-    test_primitive(device(), t.device());
-
+  return test_varying_shape(sizes(), t.sizes()) &&
+      (t.is_sparse() || t.is_mkldnn() ||
+       test_varying_shape(strides(), t.strides())) &&
+      test_primitive(
+             requiresGrad(), t.requires_grad() && at::GradMode::is_enabled()) &&
+      test_primitive(scalarType(), t.scalar_type()) &&
+      test_primitive(device(), t.device());
 }
 
 TensorTypePtr TensorType::get() {

--- a/aten/src/ATen/core/type.cpp
+++ b/aten/src/ATen/core/type.cpp
@@ -96,35 +96,19 @@ static bool test_varying_shape(const VaryingShape& e, at::IntArrayRef a) {
   return true;
 }
 
-bool TensorType::isCompatibleWith(at::Tensor& t, bool print) const {
+bool TensorType::isCompatibleWith(at::Tensor& t) const {
 
   if (!t.defined()) {
     return test_primitive(undefined(), !t.defined());
   }
 
-bool result =
+return
   test_varying_shape(sizes(), t.sizes()) &&
     (t.is_sparse() || t.is_mkldnn() || test_varying_shape(strides(), t.strides())) &&
     test_primitive(requiresGrad(),t.requires_grad() && at::GradMode::is_enabled()) &&
     test_primitive(scalarType(), t.scalar_type()) &&
     test_primitive(device(), t.device());
 
-    if (print) {
-      std::cout << "isCompatibleWith = " << result << std::endl;
-      std::cout << "t = " << t.toString() << std::endl;
-      std::cout << "expected = " << *this << std::endl;
-      std::cout << "requires_grad " << (requiresGrad().has_value() ? (int)*requiresGrad() : -1) << std::endl;
-      std::cout << "unknown " << (undefined().has_value() ? (int)*undefined() : -1) << std::endl;
-      std::cout << "unknown = " << test_primitive(undefined(), !t.defined()) << std::endl;
-      std::cout << "sizes = " << test_varying_shape(sizes(), t.sizes()) << std::endl;
-      std::cout << "strides = " << test_varying_shape(strides(), t.strides()) << std::endl;
-      std::cout << "requiresGrad = " << test_primitive(requiresGrad(),t.requires_grad() && at::GradMode::is_enabled()) << std::endl;
-      std::cout << "scalarType = " << test_primitive(scalarType(), t.scalar_type()) << std::endl;
-      std::cout << "device = " << test_primitive(device(), t.device()) << std::endl;
-    }
-
-
-  return result;
 }
 
 TensorTypePtr TensorType::get() {

--- a/torch/csrc/jit/interpreter.cpp
+++ b/torch/csrc/jit/interpreter.cpp
@@ -1078,7 +1078,12 @@ struct InterpreterStateImpl : c10::intrusive_ptr_target {
             auto t = stack.back().toTensor();
             auto actual = tensorTypeInCurrentExecutionContext(t);
             const TypePtr& expected = af.types[inst.X];
-            push(stack, *expected == *actual);
+            auto test = expected->cast<TensorType>()->isCompatibleWith(t, false);
+            if (test != actual->isSubtypeOf(expected)) {
+              auto merged_type = expected->cast<TensorType>()->merge(actual);
+              auto test2 = expected->cast<TensorType>()->isCompatibleWith(t, true);
+            }
+            push(stack, test);
             ++af.pc;
           } break;
           case TAIL_CALL: {

--- a/torch/csrc/jit/interpreter.cpp
+++ b/torch/csrc/jit/interpreter.cpp
@@ -1077,7 +1077,8 @@ struct InterpreterStateImpl : c10::intrusive_ptr_target {
           case GUARD: {
             auto t = stack.back().toTensor();
             const TypePtr& expected = af.types[inst.X];
-            auto comp = expected->cast<TensorType>()->isCompatibleWith(t);
+            bool comp = expected->cast<TensorType>()
+                            ->isCompatibleWithInCurrentExecutionContext(t);
             push(stack, comp);
             ++af.pc;
           } break;

--- a/torch/csrc/jit/interpreter.cpp
+++ b/torch/csrc/jit/interpreter.cpp
@@ -1076,14 +1076,9 @@ struct InterpreterStateImpl : c10::intrusive_ptr_target {
           }
           case GUARD: {
             auto t = stack.back().toTensor();
-            auto actual = tensorTypeInCurrentExecutionContext(t);
             const TypePtr& expected = af.types[inst.X];
-            auto test = expected->cast<TensorType>()->isCompatibleWith(t, false);
-            if (test != actual->isSubtypeOf(expected)) {
-              auto merged_type = expected->cast<TensorType>()->merge(actual);
-              auto test2 = expected->cast<TensorType>()->isCompatibleWith(t, true);
-            }
-            push(stack, test);
+            auto comp = expected->cast<TensorType>()->isCompatibleWith(t);
+            push(stack, comp);
             ++af.pc;
           } break;
           case TAIL_CALL: {


### PR DESCRIPTION
Reduces the overhead of `prim::BailOut` nodes.