### PR TITLE
use 2-stage EmbeddingSpMDM interface

### DIFF
--- a/caffe2/operators/lengths_reducer_fused_8bit_rowwise_ops.h
+++ b/caffe2/operators/lengths_reducer_fused_8bit_rowwise_ops.h
@@ -8,10 +8,13 @@
 #include "caffe2/operators/reducer_functors.h"
 #include "caffe2/perfkernels/fused_8bit_rowwise_embedding_lookup.h"
 #include "caffe2/utils/math.h"
+#ifdef USE_FBGEMM
+#include "fbgemm/Fbgemm.h"
+#endif
 
 namespace caffe2 {
 
-template <class Context, bool with_weights = 0, bool is_mean = 0>
+template <class Context, bool with_weights = false, bool is_mean = false>
 class SparseLengthsFused8BitRowwiseOp : public Operator<Context> {
  public:
   static_assert(
@@ -52,19 +55,105 @@ class SparseLengthsFused8BitRowwiseOp : public Operator<Context> {
     const std::vector<int64_t> shape = {lengths.size(0), data.size(1) - 8};
     auto* output = Output(0, shape, at::dtype<float>());
 
+    std::int64_t block_size = output->size(1);
+    auto output_size = output->size(0);
+    auto index_size = indices.numel();
+    auto data_size = data.size(0);
+    const std::uint8_t* input_data = data.template data<std::uint8_t>();
+    const int* lengths_data = lengths.template data<int>();
+    float* output_data = output->template mutable_data<float>();
+
+#ifdef USE_FBGEMM
+    // Calling the JITed kernel from FBGEMM
+    // Will Remove the call to C2/perfkernels/
+
+    // If this is the first call or block size has changed (should never happen
+    // actually), generate a kernel.
+    if (block_size != last_block_size) {
+      last_block_size = block_size;
+      if (std::is_same<IndexType, std::int32_t>::value) {
+        kernel32_ = fbgemm::GenerateEmbeddingSpMDM<std::uint8_t, std::int32_t>(
+            block_size,
+            with_weights,
+            is_mean,
+            /*prefetch distance*/ 16);
+      } else {
+        CAFFE_ENFORCE((std::is_same<IndexType, std::int64_t>::value));
+        kernel64_ = fbgemm::GenerateEmbeddingSpMDM<std::uint8_t, std::int64_t>(
+            block_size,
+            with_weights,
+            is_mean,
+            /*prefetch distance*/ 16);
+      }
+    }
+
+    bool success;
+    if (std::is_same<IndexType, std::int32_t>::value) {
+      success = kernel32_(
+          output_size,
+          index_size,
+          data_size,
+          input_data,
+          indices.template data<std::int32_t>(),
+          lengths_data,
+          weights,
+          output_data);
+    } else {
+      success = kernel64_(
+          output_size,
+          index_size,
+          data_size,
+          input_data,
+          indices.template data<std::int64_t>(),
+          lengths_data,
+          weights,
+          output_data);
+    }
+
+    if (success) {
+      return true;
+    }
+
+    auto indices_data = indices.template data<IndexType>();
+
+    int64_t current = 0;
+    for (int m = 0; m < output_size; ++m) {
+      for (int i = 0; i < lengths_data[m]; ++i) {
+        CAFFE_ENFORCE_LT(current, index_size);
+        IndexType idx = indices_data[current];
+        CAFFE_ENFORCE(
+            0 <= idx && idx < data_size,
+            "Index ",
+            current,
+            " is out of bounds: ",
+            idx,
+            ", range 0 to ",
+            data_size);
+        ++current;
+      }
+    }
+    CAFFE_ENFORCE_EQ(
+        current,
+        index_size,
+        "Your input seems to be incorrect: the sum of lengths values should be "
+        "the size of the indices tensor, but it appears not.");
+
+    return false;
+#else
     Fused8BitRowwiseEmbeddingLookup(
-        /*block_size=*/output->size(1),
-        /*output_size=*/output->size(0),
-        /*index_size=*/indices.numel(),
-        /*data_size=*/data.size(0),
-        /*input=*/data.template data<uint8_t>(),
-        /*indices=*/indices.template data<IndexType>(),
-        /*lengths=*/lengths.template data<int>(),
-        /*weights=*/weights,
-        /*normalize_by_lengths=*/is_mean,
-        /*out=*/output->template mutable_data<float>());
+        block_size,
+        output_size,
+        index_size,
+        data_size,
+        input_data,
+        indices.template data<IndexType>(),
+        lengths_data,
+        weights,
+        is_mean,
+        output_data);
 
     return true;
+#endif
   }
 
   enum {
@@ -73,6 +162,15 @@ class SparseLengthsFused8BitRowwiseOp : public Operator<Context> {
     INDICES = 1 + with_weights,
     LENGTHS = 2 + with_weights,
   };
+
+#ifdef USE_FBGEMM
+ private:
+  std::int64_t last_block_size{-1};
+  fbgemm::EmbeddingSpMDMKernelSignature<std::uint8_t, std::int32_t>::Type
+      kernel32_;
+  fbgemm::EmbeddingSpMDMKernelSignature<std::uint8_t, std::int64_t>::Type
+      kernel64_;
+#endif
 };
 
 } // namespace caffe2

--- a/caffe2/python/operator_test/sparse_lengths_sum_benchmark.py
+++ b/caffe2/python/operator_test/sparse_lengths_sum_benchmark.py
@@ -16,7 +16,13 @@ DTYPES = {
 
 
 def benchmark_sparse_lengths_sum(
-    dtype_str, categorical_limit, embedding_size, average_len, batch_size, iterations, flush_cache
+    dtype_str,
+    categorical_limit,
+    embedding_size,
+    average_len,
+    batch_size,
+    iterations,
+    flush_cache,
 ):
     print("Preparing lookup table. " + str(datetime.datetime.now()))
 
@@ -39,13 +45,16 @@ def benchmark_sparse_lengths_sum(
     # Python operator in the net to generate them.
     def f(_, outputs):
         lengths = np.random.randint(
-            int(average_len * 0.75), int(average_len * 1.25), batch_size
+            int(np.round(average_len * 0.75)),
+            int(np.round(average_len * 1.25)) + 1,
+            batch_size,
         ).astype(np.int32)
         indices = np.random.randint(0, categorical_limit, np.sum(lengths)).astype(
             np.int64
         )
         outputs[0].feed(indices)
         outputs[1].feed(lengths)
+
     init_net = core.Net("init_net")
     init_net.Python(f)([], ["indices", "lengths"])
     workspace.RunNetOnce(init_net)


### PR DESCRIPTION
Summary: Use the 2-stage EmbeddingSpMDM interface in D19425982 to reduce the overhead of code cache lookup and lock contention

Test Plan: CI

Differential Revision: D19425987

