### PR TITLE
[pytorch] run code analysis against mobile interpreter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -302,6 +302,8 @@ ENDIF(NOT MSVC)
 # applicable to mobile are disabled by this variable.
 if (ANDROID OR IOS)
   set(INTERN_BUILD_MOBILE ON)
+  # Disable developing mobile interpreter for actual mobile build. Enable it elsewhere to capture build error.
+  set(INTERN_DISABLE_MOBILE_INTERP ON)
 endif()
 
 # Setting `PYTORCH_BUILD_MOBILE` environment variable can force it to do mobile

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -463,7 +463,7 @@ if (NOT INTERN_BUILD_MOBILE OR NOT BUILD_CAFFE2_MOBILE)
     ${TORCH_SRC_DIR}/csrc/jit/vararg_functions.cpp
     )
 
-  if (NOT INTERN_BUILD_MOBILE)
+  if (NOT INTERN_DISABLE_MOBILE_INTERP)
     set (MOBILE_SRCS
         ${TORCH_SRC_DIR}/csrc/jit/mobile/function.cpp
         ${TORCH_SRC_DIR}/csrc/jit/mobile/import.cpp

--- a/tools/code_analyzer/build.sh
+++ b/tools/code_analyzer/build.sh
@@ -77,7 +77,7 @@ call_analyzer() {
     -load="${BUILD_ROOT}/libOpDependencyPass.so" \
     -op_dependency \
     -disable-output \
-    -op_schema_pattern="^(aten|quantized|profiler|_test)::[^ ]+" \
+    -op_schema_pattern="^(_aten|_prim|aten|quantized|profiler|_test)::[^ ]+" \
     -op_register_pattern="c10::RegisterOperators::(op|checkSchemaAndRegisterOp_)" \
     -op_invoke_pattern="c10::Dispatcher::findSchema|callOp" \
     -format="${FORMAT}" \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #32281 [pytorch] codegen flags to whitelist op registrations / generate to separate files
* **#32276 [pytorch] run code analysis against mobile interpreter**
* #32275 [pytorch] move type_derived_methods out of anonymous namespace

Summary:
Include mobile interpreter in mobile code analysis pass, which has some
manually registered ops in temporary namespaces.

The mobile interpreter is still under development and these ops will be
removed in the future. This is a temporary step for internal build
experiment.

Differential Revision: [D19426818](https://our.internmc.facebook.com/intern/diff/D19426818)