### PR TITLE
Pin Pillow to latest and use a torchvision that works with it

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1479,12 +1479,9 @@ jobs:
             WORKSPACE=/Users/distiller/workspace
             PROJ_ROOT=/Users/distiller/project
             source ~/anaconda/bin/activate
-            # Temporarily pin pillow to 6.2.1 as PILLOW_VERSION is replaced by
-            # _version_ in 7.0.0. Long term fix should be making changes to
-            # torchvision to be compatible with both < and >= v7.0.0.
-            pip install pillow==6.2.1 --progress-bar off
+            pip install pillow==7.0.0 --progress-bar off
             #install the latest version of PyTorch and TorchVision
-            pip install torch torchvision --progress-bar off
+            pip install torch "torchvision>=0.5.0" --progress-bar off
             #run unit test
             cd ${PROJ_ROOT}/ios/TestApp/benchmark
             python trace_model.py

--- a/.circleci/verbatim-sources/job-specs-custom.yml
+++ b/.circleci/verbatim-sources/job-specs-custom.yml
@@ -471,12 +471,9 @@
             WORKSPACE=/Users/distiller/workspace
             PROJ_ROOT=/Users/distiller/project
             source ~/anaconda/bin/activate
-            # Temporarily pin pillow to 6.2.1 as PILLOW_VERSION is replaced by
-            # _version_ in 7.0.0. Long term fix should be making changes to
-            # torchvision to be compatible with both < and >= v7.0.0.
-            pip install pillow==6.2.1 --progress-bar off
+            pip install pillow==7.0.0 --progress-bar off
             #install the latest version of PyTorch and TorchVision
-            pip install torch torchvision --progress-bar off
+            pip install torch "torchvision>=0.5.0" --progress-bar off
             #run unit test
             cd ${PROJ_ROOT}/ios/TestApp/benchmark
             python trace_model.py


### PR DESCRIPTION
Follow on from https://github.com/pytorch/pytorch/pull/31777, as suggested in https://github.com/pytorch/pytorch/pull/31777#issuecomment-575166543.

Pillow 7.0.0 removed `PILLOW_VERSION` and `__version__` should be used instead.

torchvision 0.5.0 switched from using `PILLOW_VERSION` to `__version__`.

