### PR TITLE
[JIT] Remove __torch__ from custom class qualname

### DIFF
--- a/torch/csrc/jit/pybind_utils.h
+++ b/torch/csrc/jit/pybind_utils.h
@@ -682,7 +682,7 @@ inline py::object toPyObject(IValue ivalue) {
     }
 
     auto pyCu = get_python_cu();
-    if (obj->name().find("__torch__.torch.classes") == 0) {
+    if (obj->name().find("torch.classes") == 0) {
       return py::cast(script::Object(obj));
     }
     const auto classType = pyCu->get_class(c10::QualifiedName(obj->name()));

--- a/torch/csrc/jit/python_custom_class.cpp
+++ b/torch/csrc/jit/python_custom_class.cpp
@@ -20,8 +20,7 @@ void initPythonCustomClassBindings(PyObject* module) {
   // rather than the None return value from __init__
   m.def("_get_custom_class_python_wrapper", [](const std::string& qualname) {
     auto cu = classCU();
-    c10::NamedTypePtr named_type =
-        cu->get_type("__torch__.torch.classes." + qualname);
+    c10::NamedTypePtr named_type = cu->get_type("torch.classes." + qualname);
     if (!named_type || !named_type->cast<ClassType>()) {
       std::stringstream err;
       err << "Class " << qualname << " not registered!";

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -103,8 +103,7 @@ struct PythonResolver : public Resolver {
       return classType_;
     }
     if (name.find("torch.classes") == 0) {
-      if (auto custom_class_ptr =
-              getCustomClass(std::string("__torch__.") + name)) {
+      if (auto custom_class_ptr = getCustomClass(name)) {
         return custom_class_ptr;
       }
     }

--- a/torch/csrc/jit/script/schema_type_parser.cpp
+++ b/torch/csrc/jit/script/schema_type_parser.cpp
@@ -219,14 +219,8 @@ std::pair<TypePtr, c10::optional<AliasInfo>> SchemaTypeParser::parseType() {
       parseTensorDType(L.cur().text())) {
     value = parseRefinedTensor();
     alias_info = parseAliasAnnotation();
-  } else if (L.cur().kind == TK_IDENT && L.cur().text() == "__torch__") {
+  } else if (L.cur().kind == TK_IDENT && L.cur().text() == "torch") {
     L.next();
-    L.expect('.');
-    auto torch_tok = L.expect(TK_IDENT);
-    if (torch_tok.text() != "torch") {
-      throw ErrorReport(torch_tok.range)
-          << "Expected classes namespace but got " << torch_tok.text();
-    }
     L.expect('.');
     auto classes_tok = L.expect(TK_IDENT);
     if (classes_tok.text() != "classes") {
@@ -235,8 +229,7 @@ std::pair<TypePtr, c10::optional<AliasInfo>> SchemaTypeParser::parseType() {
     }
     L.expect('.');
     auto class_tok = L.expect(TK_IDENT);
-    value = getCustomClass(
-        std::string("__torch__.torch.classes.") + class_tok.text());
+    value = getCustomClass(std::string("torch.classes.") + class_tok.text());
     if (!value) {
       throw ErrorReport(class_tok.range)
           << "Unknown custom class type " << class_tok.text()

--- a/torch/custom_class.h
+++ b/torch/custom_class.h
@@ -61,7 +61,7 @@ class class_ {
   ClassTypePtr classTypePtr;
 
   const std::string parentModule = "classes";
-  const std::string topModule = "__torch__.torch";
+  const std::string topModule = "torch";
 
  public:
   class_(std::string className_) : className(std::move(className_)) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #32320 [JIT] Test passing custom class instance to bound method
* #32312 [JIT] Fix returning instance of custom class from method
* **#32301 [JIT] Remove __torch__ from custom class qualname**
* #32324 Temporary workaround for BC test due to schema parser changes

Differential Revision: [D19431645](https://our.internmc.facebook.com/intern/diff/D19431645)