### PR TITLE
[JIT] fix unchecked cast alias analysis

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -3096,6 +3096,20 @@ graph(%Ra, %Rb):
         self.run_pass('peephole', graph)
         FileCheck().check("prim::unchecked_cast").run(graph)
 
+    def test_unchecked_cast(self):
+        def test(cond: bool):
+            a = torch.tensor([10])
+            if cond:
+                b = None
+            else:
+                b = a
+            if b is not None:
+                b[0] = 5
+            return a.int()
+
+        self.checkScript(test, (True,))
+        self.checkScript(test, (False,))
+
     def test_trace_records_names(self):
         def foo(bar, baz):
             baz = bar + 3

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -3097,7 +3097,8 @@ graph(%Ra, %Rb):
         FileCheck().check("prim::unchecked_cast").run(graph)
 
     def test_unchecked_cast(self):
-        def test(cond: bool):
+        def test(cond):
+            # type: (bool)
             a = torch.tensor([10])
             if cond:
                 b = None

--- a/torch/csrc/jit/passes/alias_analysis.cpp
+++ b/torch/csrc/jit/passes/alias_analysis.cpp
@@ -336,8 +336,9 @@ void AliasDb::analyzeImpl(Node* node) {
     case prim::ListUnpack:
     case prim::PythonOp:
     case prim::GetAttr:
-    case prim::unchecked_cast:
       return analyzeExtractor(node);
+    case prim::unchecked_cast:
+      return makePointerTo(node->output(), node->input());
     case prim::ConstantChunk:
       return analyzeChunk(node);
     case prim::BroadcastingChunk:


### PR DESCRIPTION
Unchecked cast just refines the type of a value, the value stays the same, so the output should alias the input. 