### PR TITLE
.circleci: Remove Python 2.7 tests

### DIFF
--- a/.circleci/cimodel/data/binary_build_data.py
+++ b/.circleci/cimodel/data/binary_build_data.py
@@ -34,8 +34,6 @@ def get_processor_arch_name(cuda_version):
 
 LINUX_PACKAGE_VARIANTS = OrderedDict(
     manywheel=[
-        "2.7m",
-        "2.7mu",
         "3.5m",
         "3.6m",
         "3.7m",

--- a/.circleci/cimodel/data/dimensions.py
+++ b/.circleci/cimodel/data/dimensions.py
@@ -8,7 +8,6 @@ CUDA_VERSIONS = [
 ]
 
 STANDARD_PYTHON_VERSIONS = [
-    "2.7",
     "3.5",
     "3.6",
     "3.7",

--- a/.circleci/cimodel/data/pytorch_build_data.py
+++ b/.circleci/cimodel/data/pytorch_build_data.py
@@ -4,8 +4,6 @@ from cimodel.lib.conf_tree import ConfigNode, X, XImportant
 CONFIG_TREE_DATA = [
     ("xenial", [
         (None, [
-            XImportant("2.7.9"),
-            X("2.7"),
             XImportant("3.5"),  # Not run on all PRs, but should be included on [test all]
             X("nightly"),
         ]),

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1723,44 +1723,6 @@ workflows:
             - pytorch_windows_build
       - setup
       - pytorch_linux_build:
-          name: pytorch_linux_xenial_py2_7_9_build
-          requires:
-            - setup
-          build_environment: "pytorch-linux-xenial-py2.7.9-build"
-          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py2.7.9:07597f23-fa81-474c-8bef-5c8a91b50595"
-      - pytorch_linux_test:
-          name: pytorch_linux_xenial_py2_7_9_test
-          requires:
-            - setup
-            - pytorch_linux_xenial_py2_7_9_build
-          build_environment: "pytorch-linux-xenial-py2.7.9-test"
-          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py2.7.9:07597f23-fa81-474c-8bef-5c8a91b50595"
-          resource_class: large
-      - pytorch_linux_build:
-          name: pytorch_linux_xenial_py2_7_build
-          requires:
-            - setup
-          filters:
-            branches:
-              only:
-                - master
-                - /ci-all\/.*/
-          build_environment: "pytorch-linux-xenial-py2.7-build"
-          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py2.7:07597f23-fa81-474c-8bef-5c8a91b50595"
-      - pytorch_linux_test:
-          name: pytorch_linux_xenial_py2_7_test
-          requires:
-            - setup
-            - pytorch_linux_xenial_py2_7_build
-          filters:
-            branches:
-              only:
-                - master
-                - /ci-all\/.*/
-          build_environment: "pytorch-linux-xenial-py2.7-test"
-          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py2.7:07597f23-fa81-474c-8bef-5c8a91b50595"
-          resource_class: large
-      - pytorch_linux_build:
           name: pytorch_linux_xenial_py3_5_build
           requires:
             - setup
@@ -2187,23 +2149,11 @@ workflows:
       # at https://github.com/ezyang/pytorch-ci-hud/blob/master/src/BuildHistoryDisplay.js
 
       - binary_linux_build:
-          name: binary_linux_manywheel_2_7mu_cpu_devtoolset7_build
-          build_environment: "manywheel 2.7mu cpu devtoolset7"
-          requires:
-            - setup
-          docker_image: "pytorch/manylinux-cuda100"
-      - binary_linux_build:
           name: binary_linux_manywheel_3_7m_cu100_devtoolset7_build
           build_environment: "manywheel 3.7m cu100 devtoolset7"
           requires:
             - setup
           docker_image: "pytorch/manylinux-cuda100"
-      - binary_linux_build:
-          name: binary_linux_conda_2_7_cpu_devtoolset7_build
-          build_environment: "conda 2.7 cpu devtoolset7"
-          requires:
-            - setup
-          docker_image: "pytorch/conda-cuda"
       # This binary build is currently broken, see https://github_com/pytorch/pytorch/issues/16710
       # - binary_linux_conda_3_6_cu90_devtoolset7_build
       - binary_linux_build:
@@ -2228,23 +2178,11 @@ workflows:
           requires:
             - setup
       - binary_mac_build:
-          name: binary_macos_conda_2_7_cpu_build
-          build_environment: "conda 2.7 cpu"
-          requires:
-            - setup
-      - binary_mac_build:
           name: binary_macos_libtorch_2_7_cpu_build
           build_environment: "libtorch 2.7 cpu"
           requires:
             - setup
 
-      - binary_linux_test:
-          name: binary_linux_manywheel_2_7mu_cpu_devtoolset7_test
-          build_environment: "manywheel 2.7mu cpu devtoolset7"
-          requires:
-            - setup
-            - binary_linux_manywheel_2_7mu_cpu_devtoolset7_build
-          docker_image: "pytorch/manylinux-cuda100"
       - binary_linux_test:
           name: binary_linux_manywheel_3_7m_cu100_devtoolset7_test
           build_environment: "manywheel 3.7m cu100 devtoolset7"
@@ -2254,13 +2192,6 @@ workflows:
           docker_image: "pytorch/manylinux-cuda100"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
-      - binary_linux_test:
-          name: binary_linux_conda_2_7_cpu_devtoolset7_test
-          build_environment: "conda 2.7 cpu devtoolset7"
-          requires:
-            - setup
-            - binary_linux_conda_2_7_cpu_devtoolset7_build
-          docker_image: "pytorch/conda-cuda"
       # This binary build is currently broken, see https://github_com/pytorch/pytorch/issues/16710
       # - binary_linux_conda_3_6_cu90_devtoolset7_test:
       - binary_linux_test:
@@ -2280,28 +2211,6 @@ workflows:
           libtorch_variant: "shared-with-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
 
-      - smoke_linux_test:
-          name: smoke_linux_manywheel_2_7m_cpu_devtoolset7_nightly
-          build_environment: "manywheel 2.7m cpu devtoolset7"
-          requires:
-            - setup
-            - update_s3_htmls_for_nightlies
-            - update_s3_htmls_for_nightlies_devtoolset7
-          filters:
-            branches:
-              only: postnightly
-          docker_image: "pytorch/manylinux-cuda100"
-      - smoke_linux_test:
-          name: smoke_linux_manywheel_2_7mu_cpu_devtoolset7_nightly
-          build_environment: "manywheel 2.7mu cpu devtoolset7"
-          requires:
-            - setup
-            - update_s3_htmls_for_nightlies
-            - update_s3_htmls_for_nightlies_devtoolset7
-          filters:
-            branches:
-              only: postnightly
-          docker_image: "pytorch/manylinux-cuda100"
       - smoke_linux_test:
           name: smoke_linux_manywheel_3_5m_cpu_devtoolset7_nightly
           build_environment: "manywheel 3.5m cpu devtoolset7"
@@ -2335,32 +2244,6 @@ workflows:
             branches:
               only: postnightly
           docker_image: "pytorch/manylinux-cuda100"
-      - smoke_linux_test:
-          name: smoke_linux_manywheel_2_7m_cu92_devtoolset7_nightly
-          build_environment: "manywheel 2.7m cu92 devtoolset7"
-          requires:
-            - setup
-            - update_s3_htmls_for_nightlies
-            - update_s3_htmls_for_nightlies_devtoolset7
-          filters:
-            branches:
-              only: postnightly
-          docker_image: "pytorch/manylinux-cuda92"
-          use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
-      - smoke_linux_test:
-          name: smoke_linux_manywheel_2_7mu_cu92_devtoolset7_nightly
-          build_environment: "manywheel 2.7mu cu92 devtoolset7"
-          requires:
-            - setup
-            - update_s3_htmls_for_nightlies
-            - update_s3_htmls_for_nightlies_devtoolset7
-          filters:
-            branches:
-              only: postnightly
-          docker_image: "pytorch/manylinux-cuda92"
-          use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
       - smoke_linux_test:
           name: smoke_linux_manywheel_3_5m_cu92_devtoolset7_nightly
           build_environment: "manywheel 3.5m cu92 devtoolset7"
@@ -2398,32 +2281,6 @@ workflows:
             branches:
               only: postnightly
           docker_image: "pytorch/manylinux-cuda92"
-          use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
-      - smoke_linux_test:
-          name: smoke_linux_manywheel_2_7m_cu100_devtoolset7_nightly
-          build_environment: "manywheel 2.7m cu100 devtoolset7"
-          requires:
-            - setup
-            - update_s3_htmls_for_nightlies
-            - update_s3_htmls_for_nightlies_devtoolset7
-          filters:
-            branches:
-              only: postnightly
-          docker_image: "pytorch/manylinux-cuda100"
-          use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
-      - smoke_linux_test:
-          name: smoke_linux_manywheel_2_7mu_cu100_devtoolset7_nightly
-          build_environment: "manywheel 2.7mu cu100 devtoolset7"
-          requires:
-            - setup
-            - update_s3_htmls_for_nightlies
-            - update_s3_htmls_for_nightlies_devtoolset7
-          filters:
-            branches:
-              only: postnightly
-          docker_image: "pytorch/manylinux-cuda100"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
@@ -2466,32 +2323,6 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
-          name: smoke_linux_manywheel_2_7m_cu101_devtoolset7_nightly
-          build_environment: "manywheel 2.7m cu101 devtoolset7"
-          requires:
-            - setup
-            - update_s3_htmls_for_nightlies
-            - update_s3_htmls_for_nightlies_devtoolset7
-          filters:
-            branches:
-              only: postnightly
-          docker_image: "pytorch/manylinux-cuda101"
-          use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
-      - smoke_linux_test:
-          name: smoke_linux_manywheel_2_7mu_cu101_devtoolset7_nightly
-          build_environment: "manywheel 2.7mu cu101 devtoolset7"
-          requires:
-            - setup
-            - update_s3_htmls_for_nightlies
-            - update_s3_htmls_for_nightlies_devtoolset7
-          filters:
-            branches:
-              only: postnightly
-          docker_image: "pytorch/manylinux-cuda101"
-          use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
-      - smoke_linux_test:
           name: smoke_linux_manywheel_3_5m_cu101_devtoolset7_nightly
           build_environment: "manywheel 3.5m cu101 devtoolset7"
           requires:
@@ -2531,17 +2362,6 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
-          name: smoke_linux_conda_2_7_cpu_devtoolset7_nightly
-          build_environment: "conda 2.7 cpu devtoolset7"
-          requires:
-            - setup
-            - update_s3_htmls_for_nightlies
-            - update_s3_htmls_for_nightlies_devtoolset7
-          filters:
-            branches:
-              only: postnightly
-          docker_image: "pytorch/conda-cuda"
-      - smoke_linux_test:
           name: smoke_linux_conda_3_5_cpu_devtoolset7_nightly
           build_environment: "conda 3.5 cpu devtoolset7"
           requires:
@@ -2574,19 +2394,6 @@ workflows:
             branches:
               only: postnightly
           docker_image: "pytorch/conda-cuda"
-      - smoke_linux_test:
-          name: smoke_linux_conda_2_7_cu92_devtoolset7_nightly
-          build_environment: "conda 2.7 cu92 devtoolset7"
-          requires:
-            - setup
-            - update_s3_htmls_for_nightlies
-            - update_s3_htmls_for_nightlies_devtoolset7
-          filters:
-            branches:
-              only: postnightly
-          docker_image: "pytorch/conda-cuda"
-          use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
       - smoke_linux_test:
           name: smoke_linux_conda_3_5_cu92_devtoolset7_nightly
           build_environment: "conda 3.5 cu92 devtoolset7"
@@ -2627,19 +2434,6 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
-          name: smoke_linux_conda_2_7_cu100_devtoolset7_nightly
-          build_environment: "conda 2.7 cu100 devtoolset7"
-          requires:
-            - setup
-            - update_s3_htmls_for_nightlies
-            - update_s3_htmls_for_nightlies_devtoolset7
-          filters:
-            branches:
-              only: postnightly
-          docker_image: "pytorch/conda-cuda"
-          use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
-      - smoke_linux_test:
           name: smoke_linux_conda_3_5_cu100_devtoolset7_nightly
           build_environment: "conda 3.5 cu100 devtoolset7"
           requires:
@@ -2668,19 +2462,6 @@ workflows:
       - smoke_linux_test:
           name: smoke_linux_conda_3_7_cu100_devtoolset7_nightly
           build_environment: "conda 3.7 cu100 devtoolset7"
-          requires:
-            - setup
-            - update_s3_htmls_for_nightlies
-            - update_s3_htmls_for_nightlies_devtoolset7
-          filters:
-            branches:
-              only: postnightly
-          docker_image: "pytorch/conda-cuda"
-          use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
-      - smoke_linux_test:
-          name: smoke_linux_conda_2_7_cu101_devtoolset7_nightly
-          build_environment: "conda 2.7 cu101 devtoolset7"
           requires:
             - setup
             - update_s3_htmls_for_nightlies
@@ -3163,16 +2944,6 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_mac_test:
-          name: smoke_macos_wheel_2_7_cpu_nightly
-          build_environment: "wheel 2.7 cpu"
-          requires:
-            - setup
-            - update_s3_htmls_for_nightlies
-            - update_s3_htmls_for_nightlies_devtoolset7
-          filters:
-            branches:
-              only: postnightly
-      - smoke_mac_test:
           name: smoke_macos_wheel_3_5_cpu_nightly
           build_environment: "wheel 3.5 cpu"
           requires:
@@ -3195,16 +2966,6 @@ workflows:
       - smoke_mac_test:
           name: smoke_macos_wheel_3_7_cpu_nightly
           build_environment: "wheel 3.7 cpu"
-          requires:
-            - setup
-            - update_s3_htmls_for_nightlies
-            - update_s3_htmls_for_nightlies_devtoolset7
-          filters:
-            branches:
-              only: postnightly
-      - smoke_mac_test:
-          name: smoke_macos_conda_2_7_cpu_nightly
-          build_environment: "conda 2.7 cpu"
           requires:
             - setup
             - update_s3_htmls_for_nightlies
@@ -3253,24 +3014,6 @@ workflows:
             branches:
               only: postnightly
       - binary_linux_build:
-          name: binary_linux_manywheel_2_7m_cpu_devtoolset7_nightly_build
-          build_environment: "manywheel 2.7m cpu devtoolset7"
-          requires:
-            - setup
-          filters:
-            branches:
-              only: nightly
-          docker_image: "pytorch/manylinux-cuda100"
-      - binary_linux_build:
-          name: binary_linux_manywheel_2_7mu_cpu_devtoolset7_nightly_build
-          build_environment: "manywheel 2.7mu cpu devtoolset7"
-          requires:
-            - setup
-          filters:
-            branches:
-              only: nightly
-          docker_image: "pytorch/manylinux-cuda100"
-      - binary_linux_build:
           name: binary_linux_manywheel_3_5m_cpu_devtoolset7_nightly_build
           build_environment: "manywheel 3.5m cpu devtoolset7"
           requires:
@@ -3297,24 +3040,6 @@ workflows:
             branches:
               only: nightly
           docker_image: "pytorch/manylinux-cuda100"
-      - binary_linux_build:
-          name: binary_linux_manywheel_2_7m_cu92_devtoolset7_nightly_build
-          build_environment: "manywheel 2.7m cu92 devtoolset7"
-          requires:
-            - setup
-          filters:
-            branches:
-              only: nightly
-          docker_image: "pytorch/manylinux-cuda92"
-      - binary_linux_build:
-          name: binary_linux_manywheel_2_7mu_cu92_devtoolset7_nightly_build
-          build_environment: "manywheel 2.7mu cu92 devtoolset7"
-          requires:
-            - setup
-          filters:
-            branches:
-              only: nightly
-          docker_image: "pytorch/manylinux-cuda92"
       - binary_linux_build:
           name: binary_linux_manywheel_3_5m_cu92_devtoolset7_nightly_build
           build_environment: "manywheel 3.5m cu92 devtoolset7"
@@ -3343,24 +3068,6 @@ workflows:
               only: nightly
           docker_image: "pytorch/manylinux-cuda92"
       - binary_linux_build:
-          name: binary_linux_manywheel_2_7m_cu100_devtoolset7_nightly_build
-          build_environment: "manywheel 2.7m cu100 devtoolset7"
-          requires:
-            - setup
-          filters:
-            branches:
-              only: nightly
-          docker_image: "pytorch/manylinux-cuda100"
-      - binary_linux_build:
-          name: binary_linux_manywheel_2_7mu_cu100_devtoolset7_nightly_build
-          build_environment: "manywheel 2.7mu cu100 devtoolset7"
-          requires:
-            - setup
-          filters:
-            branches:
-              only: nightly
-          docker_image: "pytorch/manylinux-cuda100"
-      - binary_linux_build:
           name: binary_linux_manywheel_3_5m_cu100_devtoolset7_nightly_build
           build_environment: "manywheel 3.5m cu100 devtoolset7"
           requires:
@@ -3387,24 +3094,6 @@ workflows:
             branches:
               only: nightly
           docker_image: "pytorch/manylinux-cuda100"
-      - binary_linux_build:
-          name: binary_linux_manywheel_2_7m_cu101_devtoolset7_nightly_build
-          build_environment: "manywheel 2.7m cu101 devtoolset7"
-          requires:
-            - setup
-          filters:
-            branches:
-              only: nightly
-          docker_image: "pytorch/manylinux-cuda101"
-      - binary_linux_build:
-          name: binary_linux_manywheel_2_7mu_cu101_devtoolset7_nightly_build
-          build_environment: "manywheel 2.7mu cu101 devtoolset7"
-          requires:
-            - setup
-          filters:
-            branches:
-              only: nightly
-          docker_image: "pytorch/manylinux-cuda101"
       - binary_linux_build:
           name: binary_linux_manywheel_3_5m_cu101_devtoolset7_nightly_build
           build_environment: "manywheel 3.5m cu101 devtoolset7"
@@ -3433,15 +3122,6 @@ workflows:
               only: nightly
           docker_image: "pytorch/manylinux-cuda101"
       - binary_linux_build:
-          name: binary_linux_conda_2_7_cpu_devtoolset7_nightly_build
-          build_environment: "conda 2.7 cpu devtoolset7"
-          requires:
-            - setup
-          filters:
-            branches:
-              only: nightly
-          docker_image: "pytorch/conda-cuda"
-      - binary_linux_build:
           name: binary_linux_conda_3_5_cpu_devtoolset7_nightly_build
           build_environment: "conda 3.5 cpu devtoolset7"
           requires:
@@ -3462,15 +3142,6 @@ workflows:
       - binary_linux_build:
           name: binary_linux_conda_3_7_cpu_devtoolset7_nightly_build
           build_environment: "conda 3.7 cpu devtoolset7"
-          requires:
-            - setup
-          filters:
-            branches:
-              only: nightly
-          docker_image: "pytorch/conda-cuda"
-      - binary_linux_build:
-          name: binary_linux_conda_2_7_cu92_devtoolset7_nightly_build
-          build_environment: "conda 2.7 cu92 devtoolset7"
           requires:
             - setup
           filters:
@@ -3505,15 +3176,6 @@ workflows:
               only: nightly
           docker_image: "pytorch/conda-cuda"
       - binary_linux_build:
-          name: binary_linux_conda_2_7_cu100_devtoolset7_nightly_build
-          build_environment: "conda 2.7 cu100 devtoolset7"
-          requires:
-            - setup
-          filters:
-            branches:
-              only: nightly
-          docker_image: "pytorch/conda-cuda"
-      - binary_linux_build:
           name: binary_linux_conda_3_5_cu100_devtoolset7_nightly_build
           build_environment: "conda 3.5 cu100 devtoolset7"
           requires:
@@ -3534,15 +3196,6 @@ workflows:
       - binary_linux_build:
           name: binary_linux_conda_3_7_cu100_devtoolset7_nightly_build
           build_environment: "conda 3.7 cu100 devtoolset7"
-          requires:
-            - setup
-          filters:
-            branches:
-              only: nightly
-          docker_image: "pytorch/conda-cuda"
-      - binary_linux_build:
-          name: binary_linux_conda_2_7_cu101_devtoolset7_nightly_build
-          build_environment: "conda 2.7 cu101 devtoolset7"
           requires:
             - setup
           filters:
@@ -3897,14 +3550,6 @@ workflows:
           libtorch_variant: "static-without-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
       - binary_mac_build:
-          name: binary_macos_wheel_2_7_cpu_nightly_build
-          build_environment: "wheel 2.7 cpu"
-          requires:
-            - setup
-          filters:
-            branches:
-              only: nightly
-      - binary_mac_build:
           name: binary_macos_wheel_3_5_cpu_nightly_build
           build_environment: "wheel 3.5 cpu"
           requires:
@@ -3923,14 +3568,6 @@ workflows:
       - binary_mac_build:
           name: binary_macos_wheel_3_7_cpu_nightly_build
           build_environment: "wheel 3.7 cpu"
-          requires:
-            - setup
-          filters:
-            branches:
-              only: nightly
-      - binary_mac_build:
-          name: binary_macos_conda_2_7_cpu_nightly_build
-          build_environment: "conda 2.7 cpu"
           requires:
             - setup
           filters:
@@ -4061,26 +3698,6 @@ workflows:
 # Nightly tests
 ##############################################################################
       - binary_linux_test:
-          name: binary_linux_manywheel_2_7m_cpu_devtoolset7_nightly_test
-          build_environment: "manywheel 2.7m cpu devtoolset7"
-          requires:
-            - setup
-            - binary_linux_manywheel_2_7m_cpu_devtoolset7_nightly_build
-          filters:
-            branches:
-              only: nightly
-          docker_image: "pytorch/manylinux-cuda100"
-      - binary_linux_test:
-          name: binary_linux_manywheel_2_7mu_cpu_devtoolset7_nightly_test
-          build_environment: "manywheel 2.7mu cpu devtoolset7"
-          requires:
-            - setup
-            - binary_linux_manywheel_2_7mu_cpu_devtoolset7_nightly_build
-          filters:
-            branches:
-              only: nightly
-          docker_image: "pytorch/manylinux-cuda100"
-      - binary_linux_test:
           name: binary_linux_manywheel_3_5m_cpu_devtoolset7_nightly_test
           build_environment: "manywheel 3.5m cpu devtoolset7"
           requires:
@@ -4110,30 +3727,6 @@ workflows:
             branches:
               only: nightly
           docker_image: "pytorch/manylinux-cuda100"
-      - binary_linux_test:
-          name: binary_linux_manywheel_2_7m_cu92_devtoolset7_nightly_test
-          build_environment: "manywheel 2.7m cu92 devtoolset7"
-          requires:
-            - setup
-            - binary_linux_manywheel_2_7m_cu92_devtoolset7_nightly_build
-          filters:
-            branches:
-              only: nightly
-          docker_image: "pytorch/manylinux-cuda92"
-          use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
-      - binary_linux_test:
-          name: binary_linux_manywheel_2_7mu_cu92_devtoolset7_nightly_test
-          build_environment: "manywheel 2.7mu cu92 devtoolset7"
-          requires:
-            - setup
-            - binary_linux_manywheel_2_7mu_cu92_devtoolset7_nightly_build
-          filters:
-            branches:
-              only: nightly
-          docker_image: "pytorch/manylinux-cuda92"
-          use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
       - binary_linux_test:
           name: binary_linux_manywheel_3_5m_cu92_devtoolset7_nightly_test
           build_environment: "manywheel 3.5m cu92 devtoolset7"
@@ -4168,30 +3761,6 @@ workflows:
             branches:
               only: nightly
           docker_image: "pytorch/manylinux-cuda92"
-          use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
-      - binary_linux_test:
-          name: binary_linux_manywheel_2_7m_cu100_devtoolset7_nightly_test
-          build_environment: "manywheel 2.7m cu100 devtoolset7"
-          requires:
-            - setup
-            - binary_linux_manywheel_2_7m_cu100_devtoolset7_nightly_build
-          filters:
-            branches:
-              only: nightly
-          docker_image: "pytorch/manylinux-cuda100"
-          use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
-      - binary_linux_test:
-          name: binary_linux_manywheel_2_7mu_cu100_devtoolset7_nightly_test
-          build_environment: "manywheel 2.7mu cu100 devtoolset7"
-          requires:
-            - setup
-            - binary_linux_manywheel_2_7mu_cu100_devtoolset7_nightly_build
-          filters:
-            branches:
-              only: nightly
-          docker_image: "pytorch/manylinux-cuda100"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
@@ -4231,30 +3800,6 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
-          name: binary_linux_manywheel_2_7m_cu101_devtoolset7_nightly_test
-          build_environment: "manywheel 2.7m cu101 devtoolset7"
-          requires:
-            - setup
-            - binary_linux_manywheel_2_7m_cu101_devtoolset7_nightly_build
-          filters:
-            branches:
-              only: nightly
-          docker_image: "pytorch/manylinux-cuda101"
-          use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
-      - binary_linux_test:
-          name: binary_linux_manywheel_2_7mu_cu101_devtoolset7_nightly_test
-          build_environment: "manywheel 2.7mu cu101 devtoolset7"
-          requires:
-            - setup
-            - binary_linux_manywheel_2_7mu_cu101_devtoolset7_nightly_build
-          filters:
-            branches:
-              only: nightly
-          docker_image: "pytorch/manylinux-cuda101"
-          use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
-      - binary_linux_test:
           name: binary_linux_manywheel_3_5m_cu101_devtoolset7_nightly_test
           build_environment: "manywheel 3.5m cu101 devtoolset7"
           requires:
@@ -4291,16 +3836,6 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
-          name: binary_linux_conda_2_7_cpu_devtoolset7_nightly_test
-          build_environment: "conda 2.7 cpu devtoolset7"
-          requires:
-            - setup
-            - binary_linux_conda_2_7_cpu_devtoolset7_nightly_build
-          filters:
-            branches:
-              only: nightly
-          docker_image: "pytorch/conda-cuda"
-      - binary_linux_test:
           name: binary_linux_conda_3_5_cpu_devtoolset7_nightly_test
           build_environment: "conda 3.5 cpu devtoolset7"
           requires:
@@ -4330,18 +3865,6 @@ workflows:
             branches:
               only: nightly
           docker_image: "pytorch/conda-cuda"
-      - binary_linux_test:
-          name: binary_linux_conda_2_7_cu92_devtoolset7_nightly_test
-          build_environment: "conda 2.7 cu92 devtoolset7"
-          requires:
-            - setup
-            - binary_linux_conda_2_7_cu92_devtoolset7_nightly_build
-          filters:
-            branches:
-              only: nightly
-          docker_image: "pytorch/conda-cuda"
-          use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
       - binary_linux_test:
           name: binary_linux_conda_3_5_cu92_devtoolset7_nightly_test
           build_environment: "conda 3.5 cu92 devtoolset7"
@@ -4379,18 +3902,6 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
-          name: binary_linux_conda_2_7_cu100_devtoolset7_nightly_test
-          build_environment: "conda 2.7 cu100 devtoolset7"
-          requires:
-            - setup
-            - binary_linux_conda_2_7_cu100_devtoolset7_nightly_build
-          filters:
-            branches:
-              only: nightly
-          docker_image: "pytorch/conda-cuda"
-          use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
-      - binary_linux_test:
           name: binary_linux_conda_3_5_cu100_devtoolset7_nightly_test
           build_environment: "conda 3.5 cu100 devtoolset7"
           requires:
@@ -4420,18 +3931,6 @@ workflows:
           requires:
             - setup
             - binary_linux_conda_3_7_cu100_devtoolset7_nightly_build
-          filters:
-            branches:
-              only: nightly
-          docker_image: "pytorch/conda-cuda"
-          use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
-      - binary_linux_test:
-          name: binary_linux_conda_2_7_cu101_devtoolset7_nightly_test
-          build_environment: "conda 2.7 cu101 devtoolset7"
-          requires:
-            - setup
-            - binary_linux_conda_2_7_cu101_devtoolset7_nightly_build
           filters:
             branches:
               only: nightly
@@ -4886,26 +4385,6 @@ workflows:
 
       # Nightly uploads
       - binary_linux_upload:
-          name: binary_linux_manywheel_2_7m_cpu_devtoolset7_nightly_upload
-          build_environment: "manywheel 2.7m cpu devtoolset7"
-          requires:
-            - setup
-            - binary_linux_manywheel_2_7m_cpu_devtoolset7_nightly_test
-          filters:
-            branches:
-              only: nightly
-          context: org-member
-      - binary_linux_upload:
-          name: binary_linux_manywheel_2_7mu_cpu_devtoolset7_nightly_upload
-          build_environment: "manywheel 2.7mu cpu devtoolset7"
-          requires:
-            - setup
-            - binary_linux_manywheel_2_7mu_cpu_devtoolset7_nightly_test
-          filters:
-            branches:
-              only: nightly
-          context: org-member
-      - binary_linux_upload:
           name: binary_linux_manywheel_3_5m_cpu_devtoolset7_nightly_upload
           build_environment: "manywheel 3.5m cpu devtoolset7"
           requires:
@@ -4931,26 +4410,6 @@ workflows:
           requires:
             - setup
             - binary_linux_manywheel_3_7m_cpu_devtoolset7_nightly_test
-          filters:
-            branches:
-              only: nightly
-          context: org-member
-      - binary_linux_upload:
-          name: binary_linux_manywheel_2_7m_cu92_devtoolset7_nightly_upload
-          build_environment: "manywheel 2.7m cu92 devtoolset7"
-          requires:
-            - setup
-            - binary_linux_manywheel_2_7m_cu92_devtoolset7_nightly_test
-          filters:
-            branches:
-              only: nightly
-          context: org-member
-      - binary_linux_upload:
-          name: binary_linux_manywheel_2_7mu_cu92_devtoolset7_nightly_upload
-          build_environment: "manywheel 2.7mu cu92 devtoolset7"
-          requires:
-            - setup
-            - binary_linux_manywheel_2_7mu_cu92_devtoolset7_nightly_test
           filters:
             branches:
               only: nightly
@@ -4986,26 +4445,6 @@ workflows:
               only: nightly
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_manywheel_2_7m_cu100_devtoolset7_nightly_upload
-          build_environment: "manywheel 2.7m cu100 devtoolset7"
-          requires:
-            - setup
-            - binary_linux_manywheel_2_7m_cu100_devtoolset7_nightly_test
-          filters:
-            branches:
-              only: nightly
-          context: org-member
-      - binary_linux_upload:
-          name: binary_linux_manywheel_2_7mu_cu100_devtoolset7_nightly_upload
-          build_environment: "manywheel 2.7mu cu100 devtoolset7"
-          requires:
-            - setup
-            - binary_linux_manywheel_2_7mu_cu100_devtoolset7_nightly_test
-          filters:
-            branches:
-              only: nightly
-          context: org-member
-      - binary_linux_upload:
           name: binary_linux_manywheel_3_5m_cu100_devtoolset7_nightly_upload
           build_environment: "manywheel 3.5m cu100 devtoolset7"
           requires:
@@ -5031,26 +4470,6 @@ workflows:
           requires:
             - setup
             - binary_linux_manywheel_3_7m_cu100_devtoolset7_nightly_test
-          filters:
-            branches:
-              only: nightly
-          context: org-member
-      - binary_linux_upload:
-          name: binary_linux_manywheel_2_7m_cu101_devtoolset7_nightly_upload
-          build_environment: "manywheel 2.7m cu101 devtoolset7"
-          requires:
-            - setup
-            - binary_linux_manywheel_2_7m_cu101_devtoolset7_nightly_test
-          filters:
-            branches:
-              only: nightly
-          context: org-member
-      - binary_linux_upload:
-          name: binary_linux_manywheel_2_7mu_cu101_devtoolset7_nightly_upload
-          build_environment: "manywheel 2.7mu cu101 devtoolset7"
-          requires:
-            - setup
-            - binary_linux_manywheel_2_7mu_cu101_devtoolset7_nightly_test
           filters:
             branches:
               only: nightly
@@ -5086,16 +4505,6 @@ workflows:
               only: nightly
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_conda_2_7_cpu_devtoolset7_nightly_upload
-          build_environment: "conda 2.7 cpu devtoolset7"
-          requires:
-            - setup
-            - binary_linux_conda_2_7_cpu_devtoolset7_nightly_test
-          filters:
-            branches:
-              only: nightly
-          context: org-member
-      - binary_linux_upload:
           name: binary_linux_conda_3_5_cpu_devtoolset7_nightly_upload
           build_environment: "conda 3.5 cpu devtoolset7"
           requires:
@@ -5121,16 +4530,6 @@ workflows:
           requires:
             - setup
             - binary_linux_conda_3_7_cpu_devtoolset7_nightly_test
-          filters:
-            branches:
-              only: nightly
-          context: org-member
-      - binary_linux_upload:
-          name: binary_linux_conda_2_7_cu92_devtoolset7_nightly_upload
-          build_environment: "conda 2.7 cu92 devtoolset7"
-          requires:
-            - setup
-            - binary_linux_conda_2_7_cu92_devtoolset7_nightly_test
           filters:
             branches:
               only: nightly
@@ -5166,16 +4565,6 @@ workflows:
               only: nightly
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_conda_2_7_cu100_devtoolset7_nightly_upload
-          build_environment: "conda 2.7 cu100 devtoolset7"
-          requires:
-            - setup
-            - binary_linux_conda_2_7_cu100_devtoolset7_nightly_test
-          filters:
-            branches:
-              only: nightly
-          context: org-member
-      - binary_linux_upload:
           name: binary_linux_conda_3_5_cu100_devtoolset7_nightly_upload
           build_environment: "conda 3.5 cu100 devtoolset7"
           requires:
@@ -5201,16 +4590,6 @@ workflows:
           requires:
             - setup
             - binary_linux_conda_3_7_cu100_devtoolset7_nightly_test
-          filters:
-            branches:
-              only: nightly
-          context: org-member
-      - binary_linux_upload:
-          name: binary_linux_conda_2_7_cu101_devtoolset7_nightly_upload
-          build_environment: "conda 2.7 cu101 devtoolset7"
-          requires:
-            - setup
-            - binary_linux_conda_2_7_cu101_devtoolset7_nightly_test
           filters:
             branches:
               only: nightly
@@ -5598,16 +4977,6 @@ workflows:
           libtorch_variant: "static-without-deps"
           context: org-member
       - binary_mac_upload:
-          name: binary_macos_wheel_2_7_cpu_nightly_upload
-          build_environment: "wheel 2.7 cpu"
-          requires:
-            - setup
-            - binary_macos_wheel_2_7_cpu_nightly_build
-          filters:
-            branches:
-              only: nightly
-          context: org-member
-      - binary_mac_upload:
           name: binary_macos_wheel_3_5_cpu_nightly_upload
           build_environment: "wheel 3.5 cpu"
           requires:
@@ -5633,16 +5002,6 @@ workflows:
           requires:
             - setup
             - binary_macos_wheel_3_7_cpu_nightly_build
-          filters:
-            branches:
-              only: nightly
-          context: org-member
-      - binary_mac_upload:
-          name: binary_macos_conda_2_7_cpu_nightly_upload
-          build_environment: "conda 2.7 cpu"
-          requires:
-            - setup
-            - binary_macos_conda_2_7_cpu_nightly_build
           filters:
             branches:
               only: nightly
@@ -5729,20 +5088,11 @@ workflows:
           name: "pytorch-linux-xenial-cuda10.1-cudnn7-py3-gcc7"
           image_name: "pytorch-linux-xenial-cuda10.1-cudnn7-py3-gcc7"
       - docker_build_job:
-          name: "pytorch-linux-xenial-cuda9-cudnn7-py2"
-          image_name: "pytorch-linux-xenial-cuda9-cudnn7-py2"
-      - docker_build_job:
           name: "pytorch-linux-xenial-cuda9-cudnn7-py3"
           image_name: "pytorch-linux-xenial-cuda9-cudnn7-py3"
       - docker_build_job:
           name: "pytorch-linux-xenial-cuda9.2-cudnn7-py3-gcc7"
           image_name: "pytorch-linux-xenial-cuda9.2-cudnn7-py3-gcc7"
-      - docker_build_job:
-          name: "pytorch-linux-xenial-py2.7.9"
-          image_name: "pytorch-linux-xenial-py2.7.9"
-      - docker_build_job:
-          name: "pytorch-linux-xenial-py2.7"
-          image_name: "pytorch-linux-xenial-py2.7"
       - docker_build_job:
           name: "pytorch-linux-xenial-py3-clang5-android-ndk-r19c"
           image_name: "pytorch-linux-xenial-py3-clang5-android-ndk-r19c"

--- a/.circleci/verbatim-sources/workflows-binary-builds-smoke-subset.yml
+++ b/.circleci/verbatim-sources/workflows-binary-builds-smoke-subset.yml
@@ -6,23 +6,11 @@
       # at https://github.com/ezyang/pytorch-ci-hud/blob/master/src/BuildHistoryDisplay.js
 
       - binary_linux_build:
-          name: binary_linux_manywheel_2_7mu_cpu_devtoolset7_build
-          build_environment: "manywheel 2.7mu cpu devtoolset7"
-          requires:
-            - setup
-          docker_image: "pytorch/manylinux-cuda100"
-      - binary_linux_build:
           name: binary_linux_manywheel_3_7m_cu100_devtoolset7_build
           build_environment: "manywheel 3.7m cu100 devtoolset7"
           requires:
             - setup
           docker_image: "pytorch/manylinux-cuda100"
-      - binary_linux_build:
-          name: binary_linux_conda_2_7_cpu_devtoolset7_build
-          build_environment: "conda 2.7 cpu devtoolset7"
-          requires:
-            - setup
-          docker_image: "pytorch/conda-cuda"
       # This binary build is currently broken, see https://github_com/pytorch/pytorch/issues/16710
       # - binary_linux_conda_3_6_cu90_devtoolset7_build
       - binary_linux_build:
@@ -47,23 +35,11 @@
           requires:
             - setup
       - binary_mac_build:
-          name: binary_macos_conda_2_7_cpu_build
-          build_environment: "conda 2.7 cpu"
-          requires:
-            - setup
-      - binary_mac_build:
           name: binary_macos_libtorch_2_7_cpu_build
           build_environment: "libtorch 2.7 cpu"
           requires:
             - setup
 
-      - binary_linux_test:
-          name: binary_linux_manywheel_2_7mu_cpu_devtoolset7_test
-          build_environment: "manywheel 2.7mu cpu devtoolset7"
-          requires:
-            - setup
-            - binary_linux_manywheel_2_7mu_cpu_devtoolset7_build
-          docker_image: "pytorch/manylinux-cuda100"
       - binary_linux_test:
           name: binary_linux_manywheel_3_7m_cu100_devtoolset7_test
           build_environment: "manywheel 3.7m cu100 devtoolset7"
@@ -73,13 +49,6 @@
           docker_image: "pytorch/manylinux-cuda100"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
-      - binary_linux_test:
-          name: binary_linux_conda_2_7_cpu_devtoolset7_test
-          build_environment: "conda 2.7 cpu devtoolset7"
-          requires:
-            - setup
-            - binary_linux_conda_2_7_cpu_devtoolset7_build
-          docker_image: "pytorch/conda-cuda"
       # This binary build is currently broken, see https://github_com/pytorch/pytorch/issues/16710
       # - binary_linux_conda_3_6_cu90_devtoolset7_test:
       - binary_linux_test:

--- a/.circleci/verbatim-sources/workflows-docker-builder.yml
+++ b/.circleci/verbatim-sources/workflows-docker-builder.yml
@@ -18,20 +18,11 @@
           name: "pytorch-linux-xenial-cuda10.1-cudnn7-py3-gcc7"
           image_name: "pytorch-linux-xenial-cuda10.1-cudnn7-py3-gcc7"
       - docker_build_job:
-          name: "pytorch-linux-xenial-cuda9-cudnn7-py2"
-          image_name: "pytorch-linux-xenial-cuda9-cudnn7-py2"
-      - docker_build_job:
           name: "pytorch-linux-xenial-cuda9-cudnn7-py3"
           image_name: "pytorch-linux-xenial-cuda9-cudnn7-py3"
       - docker_build_job:
           name: "pytorch-linux-xenial-cuda9.2-cudnn7-py3-gcc7"
           image_name: "pytorch-linux-xenial-cuda9.2-cudnn7-py3-gcc7"
-      - docker_build_job:
-          name: "pytorch-linux-xenial-py2.7.9"
-          image_name: "pytorch-linux-xenial-py2.7.9"
-      - docker_build_job:
-          name: "pytorch-linux-xenial-py2.7"
-          image_name: "pytorch-linux-xenial-py2.7"
       - docker_build_job:
           name: "pytorch-linux-xenial-py3-clang5-android-ndk-r19c"
           image_name: "pytorch-linux-xenial-py3-clang5-android-ndk-r19c"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -81,43 +81,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  flake8-py2:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Setup Python
-        uses: actions/setup-python@v1
-        with:
-          python-version: 2.x
-          architecture: x64
-      - name: Fetch PyTorch
-        uses: actions/checkout@v1
-      - name: Checkout PR tip
-        run: |
-          set -eux
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            # We are on a PR, so actions/checkout leaves us on a merge commit.
-            # Check out the actual tip of the branch.
-            git checkout ${{ github.event.pull_request.head.sha }}
-          fi
-          echo ::set-output name=commit_sha::$(git rev-parse HEAD)
-        id: get_pr_tip
-      - name: Run flake8
-        run: |
-          set -eux
-          pip install flake8
-          rm -rf .circleci
-          flake8 --exit-zero > ${GITHUB_WORKSPACE}/flake8-output.txt
-          cat ${GITHUB_WORKSPACE}/flake8-output.txt
-      - name: Add annotations
-        uses: pytorch/add-annotations-github-action@master
-        with:
-          check_name: 'flake8-py2'
-          linter_output_path: 'flake8-output.txt'
-          commit_sha: ${{ steps.get_pr_tip.outputs.commit_sha }}
-          regex: '^(?<filename>.*?):(?<lineNumber>\d+):(?<columnNumber>\d+): (?<errorCode>\w\d+) (?<errorDesc>.*)'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
 
   clang-tidy:
     if: github.event_name == 'pull_request'


### PR DESCRIPTION
Python 2.7 was EOL as of January 1, 2020

PyTorch 1.4 was the last release to support Python 2.7

`libtorch` is currently named with a `2_7` suffix on the builds and should be changed to not represent any python version, but that can come in a later PR.


These are the list of tests that were ultimately removed:

<details>
<summary> Click me to expand </summary>

```
❯ git show | grep "^\-[ ]*name:"
-          name: pytorch_linux_xenial_py2_7_9_build
-          name: pytorch_linux_xenial_py2_7_9_test
-          name: pytorch_linux_xenial_py2_7_build
-          name: pytorch_linux_xenial_py2_7_test
-          name: binary_linux_manywheel_2_7mu_cpu_devtoolset7_build
-          name: binary_linux_conda_2_7_cpu_devtoolset7_build
-          name: binary_macos_conda_2_7_cpu_build
-          name: binary_linux_manywheel_2_7mu_cpu_devtoolset7_test
-          name: binary_linux_conda_2_7_cpu_devtoolset7_test
-          name: smoke_linux_manywheel_2_7m_cpu_devtoolset7_nightly
-          name: smoke_linux_manywheel_2_7mu_cpu_devtoolset7_nightly
-          name: smoke_linux_manywheel_2_7m_cu92_devtoolset7_nightly
-          name: smoke_linux_manywheel_2_7mu_cu92_devtoolset7_nightly
-          name: smoke_linux_manywheel_2_7m_cu100_devtoolset7_nightly
-          name: smoke_linux_manywheel_2_7mu_cu100_devtoolset7_nightly
-          name: smoke_linux_manywheel_2_7m_cu101_devtoolset7_nightly
-          name: smoke_linux_manywheel_2_7mu_cu101_devtoolset7_nightly
-          name: smoke_linux_conda_2_7_cpu_devtoolset7_nightly
-          name: smoke_linux_conda_2_7_cu92_devtoolset7_nightly
-          name: smoke_linux_conda_2_7_cu100_devtoolset7_nightly
-          name: smoke_linux_conda_2_7_cu101_devtoolset7_nightly
-          name: smoke_macos_wheel_2_7_cpu_nightly
-          name: smoke_macos_conda_2_7_cpu_nightly
-          name: binary_linux_manywheel_2_7m_cpu_devtoolset7_nightly_build
-          name: binary_linux_manywheel_2_7mu_cpu_devtoolset7_nightly_build
-          name: binary_linux_manywheel_2_7m_cu92_devtoolset7_nightly_build
-          name: binary_linux_manywheel_2_7mu_cu92_devtoolset7_nightly_build
-          name: binary_linux_manywheel_2_7m_cu100_devtoolset7_nightly_build
-          name: binary_linux_manywheel_2_7mu_cu100_devtoolset7_nightly_build
-          name: binary_linux_manywheel_2_7m_cu101_devtoolset7_nightly_build
-          name: binary_linux_manywheel_2_7mu_cu101_devtoolset7_nightly_build
-          name: binary_linux_conda_2_7_cpu_devtoolset7_nightly_build
-          name: binary_linux_conda_2_7_cu92_devtoolset7_nightly_build
-          name: binary_linux_conda_2_7_cu100_devtoolset7_nightly_build
-          name: binary_linux_conda_2_7_cu101_devtoolset7_nightly_build
-          name: binary_macos_wheel_2_7_cpu_nightly_build
-          name: binary_macos_conda_2_7_cpu_nightly_build
-          name: binary_linux_manywheel_2_7m_cpu_devtoolset7_nightly_test
-          name: binary_linux_manywheel_2_7mu_cpu_devtoolset7_nightly_test
-          name: binary_linux_manywheel_2_7m_cu92_devtoolset7_nightly_test
-          name: binary_linux_manywheel_2_7mu_cu92_devtoolset7_nightly_test
-          name: binary_linux_manywheel_2_7m_cu100_devtoolset7_nightly_test
-          name: binary_linux_manywheel_2_7mu_cu100_devtoolset7_nightly_test
-          name: binary_linux_manywheel_2_7m_cu101_devtoolset7_nightly_test
-          name: binary_linux_manywheel_2_7mu_cu101_devtoolset7_nightly_test
-          name: binary_linux_conda_2_7_cpu_devtoolset7_nightly_test
-          name: binary_linux_conda_2_7_cu92_devtoolset7_nightly_test
-          name: binary_linux_conda_2_7_cu100_devtoolset7_nightly_test
-          name: binary_linux_conda_2_7_cu101_devtoolset7_nightly_test
-          name: binary_linux_manywheel_2_7m_cpu_devtoolset7_nightly_upload
-          name: binary_linux_manywheel_2_7mu_cpu_devtoolset7_nightly_upload
-          name: binary_linux_manywheel_2_7m_cu92_devtoolset7_nightly_upload
-          name: binary_linux_manywheel_2_7mu_cu92_devtoolset7_nightly_upload
-          name: binary_linux_manywheel_2_7m_cu100_devtoolset7_nightly_upload
-          name: binary_linux_manywheel_2_7mu_cu100_devtoolset7_nightly_upload
-          name: binary_linux_manywheel_2_7m_cu101_devtoolset7_nightly_upload
-          name: binary_linux_manywheel_2_7mu_cu101_devtoolset7_nightly_upload
-          name: binary_linux_conda_2_7_cpu_devtoolset7_nightly_upload
-          name: binary_linux_conda_2_7_cu92_devtoolset7_nightly_upload
-          name: binary_linux_conda_2_7_cu100_devtoolset7_nightly_upload
-          name: binary_linux_conda_2_7_cu101_devtoolset7_nightly_upload
-          name: binary_macos_wheel_2_7_cpu_nightly_upload
-          name: binary_macos_conda_2_7_cpu_nightly_upload
-          name: "pytorch-linux-xenial-cuda9-cudnn7-py2"
-          name: "pytorch-linux-xenial-py2.7.9"
-          name: "pytorch-linux-xenial-py2.7"
-          name: binary_linux_manywheel_2_7mu_cpu_devtoolset7_build
-          name: binary_linux_conda_2_7_cpu_devtoolset7_build
-          name: binary_macos_conda_2_7_cpu_build
-          name: binary_linux_manywheel_2_7mu_cpu_devtoolset7_test
-          name: binary_linux_conda_2_7_cpu_devtoolset7_test
-          name: "pytorch-linux-xenial-cuda9-cudnn7-py2"
-          name: "pytorch-linux-xenial-py2.7.9"
-          name: "pytorch-linux-xenial-py2.7"
```
Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

</summary>