### PR TITLE
[JIT] Fix returning instance of custom class from method

### DIFF
--- a/aten/src/ATen/core/ivalue_inl.h
+++ b/aten/src/ATen/core/ivalue_inl.h
@@ -819,7 +819,7 @@ IValue from_(c10::intrusive_ptr<T> x, std::false_type) {
     throw c10::Error("Trying to return a class that we don't support and isn't a registered custom class.", "");
   }
   auto res = getCustomClassType<inputType>();
-  auto retObject = ivalue::Object::create(res->second, 1);
+  auto retObject = ivalue::Object::create(res, 1);
   auto objPtr = c10::static_intrusive_pointer_cast<torch::jit::CustomClassHolder>(x);
 
   retObject->setSlot(0, IValue(objPtr));

--- a/test/cpp/jit/test_custom_class.cpp
+++ b/test/cpp/jit/test_custom_class.cpp
@@ -44,6 +44,10 @@ struct Stack : torch::jit::CustomClassHolder {
     stack_.pop_back();
     return val;
   }
+
+  c10::intrusive_ptr<Stack> clone() {
+    return c10::make_intrusive<Stack>(stack_);
+  }
 };
 
 static auto test = torch::jit::class_<Foo>("_TorchScriptTesting_Foo")
@@ -58,7 +62,8 @@ static auto testStack =
     torch::jit::class_<Stack<std::string>>("_TorchScriptTesting_StackString")
         .def(torch::jit::init<std::vector<std::string>>())
         .def("push", &Stack<std::string>::push)
-        .def("pop", &Stack<std::string>::pop);
+        .def("pop", &Stack<std::string>::pop)
+        .def("clone", &Stack<std::string>::clone);
 
 } // namespace
 

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -4647,6 +4647,29 @@ def foo(x):
         script_output = scripted(script_input)
         self.assertEqual(script_output.pop(), "lel")
 
+    def test_torchbind_return_instance(self):
+        def foo():
+            ss = torch.classes._TorchScriptTesting_StackString(["hi", "mom"])
+            return ss
+
+        scripted = torch.jit.script(foo)
+        out = scripted()
+        self.assertEqual(out.pop(), "mom")
+        self.assertEqual(out.pop(), "hi")
+
+    def test_torchbind_return_instance_from_method(self):
+        def foo():
+            ss = torch.classes._TorchScriptTesting_StackString(["hi", "mom"])
+            clone = ss.clone()
+            ss.pop()
+            return ss, clone
+
+        scripted = torch.jit.script(foo)
+        out = scripted()
+        self.assertEqual(out[0].pop(), "hi")
+        self.assertEqual(out[1].pop(), "mom")
+        self.assertEqual(out[1].pop(), "hi")
+
     def test_jitter_bug(self):
         @torch.jit.script
         def fn2(input, kernel_size):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #32320 [JIT] Test passing custom class instance to bound method
* **#32312 [JIT] Fix returning instance of custom class from method**
* #32301 [JIT] Remove __torch__ from custom class qualname
* #32324 Temporary workaround for BC test due to schema parser changes

Differential Revision: [D19433511](https://our.internmc.facebook.com/intern/diff/D19433511)