### PR TITLE
[iOS]Add CI scripts for Custom Build 

### DIFF
--- a/ios/TestApp/custom_build/custom_build.py
+++ b/ios/TestApp/custom_build/custom_build.py
@@ -1,0 +1,11 @@
+import torch
+import torchvision
+import yaml
+
+model = torchvision.models.mobilenet_v2(pretrained=True)
+model.eval()
+example = torch.rand(1, 3, 224, 224)
+traced_script_module = torch.jit.trace(model, example)
+ops = torch.jit.export_opnames(traced_script_module)
+with open('mobilenetv2.yaml','w') as output:
+    yaml.dump(ops, output)

--- a/ios/TestApp/custom_build/custom_build.py
+++ b/ios/TestApp/custom_build/custom_build.py
@@ -7,5 +7,5 @@ model.eval()
 example = torch.rand(1, 3, 224, 224)
 traced_script_module = torch.jit.trace(model, example)
 ops = torch.jit.export_opnames(traced_script_module)
-with open('mobilenetv2.yaml','w') as output:
+with open('mobilenetv2.yaml', 'w') as output:
     yaml.dump(ops, output)

--- a/ios/TestApp/custom_build/mobilenetv2.yaml
+++ b/ios/TestApp/custom_build/mobilenetv2.yaml
@@ -1,0 +1,10 @@
+- aten::_convolution
+- aten::add.Tensor
+- aten::addmm
+- aten::batch_norm
+- aten::dropout
+- aten::hardtanh_
+- aten::mean.dim
+- aten::t
+- prim::Constant
+- prim::ListConstruct


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #32323 [iOS][CI] Add a new job to support custom build
* **#32316 [iOS]Add CI scripts for Custom Build**

### Summary

Since the Custom Build has been released in 1.4.0, it's time setup CI. To do that, we need

1.  Add a python script to generate the yaml file
2. Add new build scripts to circle CI (arm64 only). 

### Test Plan

- Don't break the current iOS CIs

Differential Revision: [D19437362](https://our.internmc.facebook.com/intern/diff/D19437362)