### PR TITLE
Use default scale/zero_point in fake_quantize module instead of None

### DIFF
--- a/torch/quantization/fake_quantize.py
+++ b/torch/quantization/fake_quantize.py
@@ -52,8 +52,8 @@ class FakeQuantize(Module):
         self.activation_post_process = observer(**observer_kwargs)
         assert torch.iinfo(self.activation_post_process.dtype).min <= quant_min, 'quant_min out of bound'
         assert quant_max <= torch.iinfo(self.activation_post_process.dtype).max, 'quant_max out of bound'
-        self.scale = None
-        self.zero_point = None
+        self.scale = torch.tensor([1.0])
+        self.zero_point = torch.tensor([0])
         self.dtype = self.activation_post_process.dtype
         self.qscheme = self.activation_post_process.qscheme
         self.ch_axis = self.activation_post_process.ch_axis if hasattr(self.activation_post_process, 'ch_axis') else None


### PR DESCRIPTION
Distributed data parallel can not broadcast None so when we prepare the model for QAT and trying to save the model it will error out.
fixes: #32082

