### PR TITLE
Don't serialize None values in observer

### DIFF
--- a/torch/quantization/observer.py
+++ b/torch/quantization/observer.py
@@ -137,7 +137,7 @@ class _ObserverBase(ObserverBase):
             scales: Per channel scales tensor of shape (#channels,)
             zero_points: Per channel zero points tensor of shape (#channels,)
         """
-        if min_vals is None or max_vals is None:
+        if min_vals.numel() == 0 or max_vals.numel() == 0:
             warnings.warn(
                 "must run observer before calling calculate_qparams.\
                                     Returning default scale and zero point "
@@ -175,7 +175,7 @@ class _ObserverBase(ObserverBase):
             zero_point: Zero point as a tensor of shape (1,)
         """
 
-        if max_val is None or min_val is None:
+        if max_val.numel() == 0 or min_val.numel() == 0:
             warnings.warn("Must run observer before calling calculate_qparams.\
                            Returning default scale and zero point.")
             return torch.tensor([1.0]), torch.tensor([0])

--- a/torch/quantization/observer.py
+++ b/torch/quantization/observer.py
@@ -284,11 +284,6 @@ class MinMaxObserver(_ObserverBase):
               and zero_point are set to 1.0 and 0.
     """
 
-    __annotations__ = {
-        "min_val": Optional[torch.Tensor],
-        "max_val": Optional[torch.Tensor],
-    }
-
     def __init__(self, dtype=torch.quint8, qscheme=torch.per_tensor_affine,
                  reduce_range=False):
         # For x86 quantized kernels, we need to ensure that the vpmaddubsw
@@ -301,8 +296,8 @@ class MinMaxObserver(_ObserverBase):
         super(MinMaxObserver, self).__init__(dtype=dtype,
                                              qscheme=qscheme,
                                              reduce_range=reduce_range)
-        self.min_val = None
-        self.max_val = None
+        self.min_val = torch.tensor([])
+        self.max_val = torch.tensor([])
         if self.qscheme == torch.per_tensor_symmetric and \
            self.reduce_range and \
            self.dtype == torch.quint8:
@@ -314,7 +309,7 @@ class MinMaxObserver(_ObserverBase):
         x = x_orig.detach()  # avoid keeping autograd tape
         min_val = self.min_val
         max_val = self.max_val
-        if min_val is None or max_val is None:
+        if min_val.numel() == 0 or max_val.numel() == 0:
             min_val = torch.min(x)
             max_val = torch.max(x)
         else:
@@ -332,27 +327,6 @@ class MinMaxObserver(_ObserverBase):
     @torch.jit.export
     def extra_repr(self):
         return "min_val={}, max_val={}".format(self.min_val, self.max_val)
-
-    def _save_to_state_dict(self, destination, prefix, keep_vars):
-        super(MinMaxObserver, self)._save_to_state_dict(destination, prefix, keep_vars)
-        if self.min_val is not None and self.max_val is not None:
-            destination[prefix + 'min_val'] = self.min_val
-            destination[prefix + 'max_val'] = self.max_val
-
-    def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict,
-                              missing_keys, unexpected_keys, error_msgs):
-
-        local_state = ['min_val', 'max_val']
-        optional_keys = ['min_val', 'max_val']
-        for name in local_state:
-            key = prefix + name
-            if key in state_dict:
-                setattr(self, name, state_dict.pop(key))
-            elif strict and key not in optional_keys:
-                missing_keys.append(key)
-        super(MinMaxObserver, self)._load_from_state_dict(state_dict, prefix, local_metadata, strict,
-                                                          missing_keys, unexpected_keys, error_msgs)
-
 
 class MovingAverageMinMaxObserver(MinMaxObserver):
     r"""Observer module for computing the quantization parameters based on the
@@ -406,7 +380,7 @@ class MovingAverageMinMaxObserver(MinMaxObserver):
         x = x_orig.detach()  # avoid keeping autograd tape
         min_val = self.min_val
         max_val = self.max_val
-        if min_val is None or max_val is None:
+        if min_val.numel() == 0 or max_val.numel() == 0:
             min_val = torch.min(x)
             max_val = torch.max(x)
         else:
@@ -440,11 +414,6 @@ class PerChannelMinMaxObserver(_ObserverBase):
     .. note:: If the running minimum equals to the running maximum, the scales
               and zero_points are set to 1.0 and 0.
     """
-    __annotations__ = {
-        "min_vals": Optional[torch.Tensor],
-        "max_vals": Optional[torch.Tensor],
-    }
-
 
     def __init__(self, ch_axis=0, dtype=torch.quint8,
                  qscheme=torch.per_channel_affine, reduce_range=False):
@@ -452,8 +421,8 @@ class PerChannelMinMaxObserver(_ObserverBase):
                                                        qscheme=qscheme,
                                                        reduce_range=reduce_range)
         self.ch_axis = ch_axis
-        self.min_vals = None
-        self.max_vals = None
+        self.min_vals = torch.tensor([])
+        self.max_vals = torch.tensor([])
         if (
             self.qscheme == torch.per_channel_symmetric
             and self.reduce_range
@@ -478,7 +447,7 @@ class PerChannelMinMaxObserver(_ObserverBase):
         new_axis_list[0] = self.ch_axis
         y = x.permute(tuple(new_axis_list))
         y = torch.flatten(y, start_dim=1)
-        if min_vals is None or max_vals is None:
+        if min_vals.numel() == 0 or max_vals.numel() == 0:
             min_vals = torch.min(y, 1)[0]
             max_vals = torch.max(y, 1)[0]
         else:
@@ -499,25 +468,6 @@ class PerChannelMinMaxObserver(_ObserverBase):
 
     def extra_repr(self):
         return "min_val={}, max_val={}".format(self.min_vals, self.max_vals)
-
-    def _save_to_state_dict(self, destination, prefix, keep_vars):
-        super(PerChannelMinMaxObserver, self)._save_to_state_dict(destination, prefix, keep_vars)
-        if self.min_vals is not None and self.max_vals is not None:
-            destination[prefix + 'min_vals'] = self.min_vals
-            destination[prefix + 'max_vals'] = self.max_vals
-
-    def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict,
-                              missing_keys, unexpected_keys, error_msgs):
-        local_state = ['min_vals', 'max_vals']
-        optional_keys = ['min_val', 'max_val']
-        for name in local_state:
-            key = prefix + name
-            if key in state_dict:
-                setattr(self, name, state_dict.pop(key))
-            elif strict and key not in optional_keys:
-                missing_keys.append(key)
-        super(PerChannelMinMaxObserver, self)._load_from_state_dict(state_dict, prefix, local_metadata, strict,
-                                                                    missing_keys, unexpected_keys, error_msgs)
 
 class MovingAveragePerChannelMinMaxObserver(PerChannelMinMaxObserver):
     r"""Observer module for computing the quantization parameters based on the
@@ -562,7 +512,7 @@ class MovingAveragePerChannelMinMaxObserver(PerChannelMinMaxObserver):
         new_axis_list[0] = self.ch_axis
         y = x.permute(tuple(new_axis_list))
         y = torch.flatten(y, start_dim=1)
-        if min_vals is None or max_vals is None:
+        if min_vals.numel() == 0 or max_vals.numel() == 0:
             min_vals = torch.min(y, 1)[0]
             max_vals = torch.max(y, 1)[0]
         else:
@@ -597,11 +547,6 @@ class HistogramObserver(_ObserverBase):
         :class:`~torch.quantization.MinMaxObserver`
     """
 
-    __annotations__ = {
-        "min_val": Optional[torch.Tensor],
-        "max_val": Optional[torch.Tensor],
-    }
-
     def __init__(self, bins=2048, upsample_rate=128, dtype=torch.quint8,
                  qscheme=torch.per_tensor_affine, reduce_range=False):
         # bins: The number of bins used for histogram calculation.
@@ -610,8 +555,8 @@ class HistogramObserver(_ObserverBase):
                                                 reduce_range=reduce_range)
         self.bins = bins
         self.register_buffer('histogram', torch.zeros(self.bins))
-        self.min_val = None
-        self.max_val = None
+        self.min_val = torch.tensor([])
+        self.max_val = torch.tensor([])
         self.dst_nbins = 2 ** torch.iinfo(self.dtype).bits
         self.upsample_rate = upsample_rate
 
@@ -793,7 +738,7 @@ class HistogramObserver(_ObserverBase):
         x = x_orig.detach()
         min_val = self.min_val
         max_val = self.max_val
-        if min_val is None or max_val is None:
+        if min_val.numel() == 0 or max_val.numel() == 0:
             min_val = torch.min(x)
             max_val = torch.max(x)
             self.min_val = min_val
@@ -828,7 +773,7 @@ class HistogramObserver(_ObserverBase):
 
     @torch.jit.export
     def calculate_qparams(self):
-        if self.min_val is None or self.max_val is None:
+        if self.min_val.numel() == 0 or self.max_val.numel() == 0:
             warnings.warn(
                 "must run observer before calling calculate_qparams.\
                                     Returning default scale and zero point "
@@ -842,26 +787,6 @@ class HistogramObserver(_ObserverBase):
         new_min, new_max = self._non_linear_param_search()
 
         return self._calculate_qparams(new_min, new_max)
-
-    def _save_to_state_dict(self, destination, prefix, keep_vars):
-        super(HistogramObserver, self)._save_to_state_dict(destination, prefix, keep_vars)
-        if self.min_val is not None and self.max_val is not None:
-            destination[prefix + 'min_val'] = self.min_val
-            destination[prefix + 'max_val'] = self.max_val
-
-    def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict,
-                              missing_keys, unexpected_keys, error_msgs):
-
-        local_state = ['min_val', 'max_val']
-        optional_keys = ['min_val', 'max_val']
-        for name in local_state:
-            key = prefix + name
-            if key in state_dict:
-                setattr(self, name, state_dict.pop(key))
-            elif strict and key not in optional_keys:
-                missing_keys.append(key)
-        super(HistogramObserver, self)._load_from_state_dict(state_dict, prefix, local_metadata, strict,
-                                                             missing_keys, unexpected_keys, error_msgs)
 
 class RecordingObserver(_ObserverBase):
     r"""

--- a/torch/quantization/observer.py
+++ b/torch/quantization/observer.py
@@ -348,7 +348,7 @@ class MinMaxObserver(_ObserverBase):
             key = prefix + name
             if key in state_dict:
                 setattr(self, name, state_dict.pop(key))
-            elif strict and not key in optional_keys:
+            elif strict and key not in optional_keys:
                 missing_keys.append(key)
         super(MinMaxObserver, self)._load_from_state_dict(state_dict, prefix, local_metadata, strict,
                                                           missing_keys, unexpected_keys, error_msgs)
@@ -514,7 +514,7 @@ class PerChannelMinMaxObserver(_ObserverBase):
             key = prefix + name
             if key in state_dict:
                 setattr(self, name, state_dict.pop(key))
-            elif strict and not key in optional_keys:
+            elif strict and key not in optional_keys:
                 missing_keys.append(key)
         super(PerChannelMinMaxObserver, self)._load_from_state_dict(state_dict, prefix, local_metadata, strict,
                                                                     missing_keys, unexpected_keys, error_msgs)
@@ -858,7 +858,7 @@ class HistogramObserver(_ObserverBase):
             key = prefix + name
             if key in state_dict:
                 setattr(self, name, state_dict.pop(key))
-            elif strict and not key in optional_keys:
+            elif strict and key not in optional_keys:
                 missing_keys.append(key)
         super(HistogramObserver, self)._load_from_state_dict(state_dict, prefix, local_metadata, strict,
                                                              missing_keys, unexpected_keys, error_msgs)

--- a/torch/quantization/observer.py
+++ b/torch/quantization/observer.py
@@ -335,8 +335,9 @@ class MinMaxObserver(_ObserverBase):
 
     def _save_to_state_dict(self, destination, prefix, keep_vars):
         super(MinMaxObserver, self)._save_to_state_dict(destination, prefix, keep_vars)
-        destination[prefix + 'min_val'] = self.min_val
-        destination[prefix + 'max_val'] = self.max_val
+        if self.min_val is not None and self.max_val is not None:
+            destination[prefix + 'min_val'] = self.min_val
+            destination[prefix + 'max_val'] = self.max_val
 
     def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict,
                               missing_keys, unexpected_keys, error_msgs):
@@ -500,8 +501,9 @@ class PerChannelMinMaxObserver(_ObserverBase):
 
     def _save_to_state_dict(self, destination, prefix, keep_vars):
         super(PerChannelMinMaxObserver, self)._save_to_state_dict(destination, prefix, keep_vars)
-        destination[prefix + 'min_vals'] = self.min_vals
-        destination[prefix + 'max_vals'] = self.max_vals
+        if self.min_vals is not None and self.max_vals is not None:
+            destination[prefix + 'min_vals'] = self.min_vals
+            destination[prefix + 'max_vals'] = self.max_vals
 
     def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict,
                               missing_keys, unexpected_keys, error_msgs):
@@ -841,8 +843,9 @@ class HistogramObserver(_ObserverBase):
 
     def _save_to_state_dict(self, destination, prefix, keep_vars):
         super(HistogramObserver, self)._save_to_state_dict(destination, prefix, keep_vars)
-        destination[prefix + 'min_val'] = self.min_val
-        destination[prefix + 'max_val'] = self.max_val
+        if self.min_val is not None and self.max_val is not None:
+            destination[prefix + 'min_val'] = self.min_val
+            destination[prefix + 'max_val'] = self.max_val
 
     def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict,
                               missing_keys, unexpected_keys, error_msgs):

--- a/torch/quantization/observer.py
+++ b/torch/quantization/observer.py
@@ -343,11 +343,12 @@ class MinMaxObserver(_ObserverBase):
                               missing_keys, unexpected_keys, error_msgs):
 
         local_state = ['min_val', 'max_val']
+        optional_keys = ['min_val', 'max_val']
         for name in local_state:
             key = prefix + name
             if key in state_dict:
                 setattr(self, name, state_dict.pop(key))
-            elif strict:
+            elif strict and not key in optional_keys:
                 missing_keys.append(key)
         super(MinMaxObserver, self)._load_from_state_dict(state_dict, prefix, local_metadata, strict,
                                                           missing_keys, unexpected_keys, error_msgs)
@@ -508,11 +509,12 @@ class PerChannelMinMaxObserver(_ObserverBase):
     def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict,
                               missing_keys, unexpected_keys, error_msgs):
         local_state = ['min_vals', 'max_vals']
+        optional_keys = ['min_val', 'max_val']
         for name in local_state:
             key = prefix + name
             if key in state_dict:
                 setattr(self, name, state_dict.pop(key))
-            elif strict:
+            elif strict and not key in optional_keys:
                 missing_keys.append(key)
         super(PerChannelMinMaxObserver, self)._load_from_state_dict(state_dict, prefix, local_metadata, strict,
                                                                     missing_keys, unexpected_keys, error_msgs)
@@ -851,11 +853,12 @@ class HistogramObserver(_ObserverBase):
                               missing_keys, unexpected_keys, error_msgs):
 
         local_state = ['min_val', 'max_val']
+        optional_keys = ['min_val', 'max_val']
         for name in local_state:
             key = prefix + name
             if key in state_dict:
                 setattr(self, name, state_dict.pop(key))
-            elif strict:
+            elif strict and not key in optional_keys:
                 missing_keys.append(key)
         super(HistogramObserver, self)._load_from_state_dict(state_dict, prefix, local_metadata, strict,
                                                              missing_keys, unexpected_keys, error_msgs)


### PR DESCRIPTION
Similar to https://github.com/pytorch/pytorch/pull/32318, we should stop serializing None values since they can't be broadcasted

