### PR TITLE
Delete unused bernoulli_Tensor from THTensorRandom.h

### DIFF
--- a/aten/src/TH/generic/THTensorRandom.h
+++ b/aten/src/TH/generic/THTensorRandom.h
@@ -10,7 +10,6 @@ TH_API void THTensor_(clampedRandom)(THTensor *self, int64_t min, int64_t max, a
 TH_API void THTensor_(cappedRandom)(THTensor *self, int64_t max, at::Generator *_generator);
 
 #if defined(TH_REAL_IS_FLOAT) || defined(TH_REAL_IS_DOUBLE)
-TH_API void THTensor_(bernoulli_Tensor)(THTensor *self, at::Generator *_generator, THTensor *p);
 TH_API void THTensor_(uniform)(THTensor *self, double a, double b, at::Generator *_generator);
 TH_API void THTensor_(normal)(THTensor *self, double mean, double stdv, at::Generator *_generator);
 TH_API void THTensor_(normal_means)(THTensor *self, THTensor *means, double stddev, at::Generator *gen);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#32328 Delete unused bernoulli_Tensor from THTensorRandom.h**

Differential Revision: [D19448736](https://our.internmc.facebook.com/intern/diff/D19448736)