### PR TITLE
Unittests for quantized LSTM (static)

### DIFF
--- a/test/common_quantized.py
+++ b/test/common_quantized.py
@@ -25,6 +25,26 @@ def _quantize(x, scale, zero_point, qmin=None, qmax=None, dtype=np.uint8):
     return qx
 
 
+def quantize(x, qtype, scale=None, zero_point=None):
+    """Quantizes the tensor x.
+    The scale and zero_point are derived from min/max."""
+    qinfo = torch.iinfo(qtype)
+    qmin = qinfo.min
+    qmax = qinfo.max
+
+    fmin = x.cpu().detach().min().item()
+    fmax = x.cpu().detach().max().item()
+
+    fmin = min(fmin, 0)
+    fmax = max(fmax, 0)
+
+    if scale is None:
+        scale = (fmax - fmin) / (qmax - qmin)
+    if zero_point is None:
+        zero_point = qmin - int(round(fmin / scale))
+    return torch.quantize_per_tensor(x, scale, zero_point, qtype)
+
+
 def _dequantize(qx, scale, zero_point):
     """Dequantizes a numpy array."""
     x = (qx.astype(np.float) - zero_point) * scale
@@ -37,6 +57,7 @@ def _requantize(x, multiplier, zero_point, qmin=0, qmax=255, qtype=np.uint8):
     qx = (x * multiplier).round() + zero_point
     qx = np.clip(qx, qmin, qmax).astype(qtype)
     return qx
+
 
 def _calculate_dynamic_qparams(X, dtype):
     """Calculate the dynamic quantization parameters (scale, zero_point)

--- a/test/test_quantized.py
+++ b/test/test_quantized.py
@@ -16,8 +16,11 @@ import hypothesis_utils as hu
 hu.assert_deadline_disabled()
 
 from common_utils import TEST_WITH_UBSAN, TestCase, run_tests, IS_PPC, IS_MACOS
-from common_quantized import _quantize, _dequantize, _calculate_dynamic_qparams, \
-    override_quantized_engine
+from common_quantized import (_quantize,
+                              _dequantize,
+                              _calculate_dynamic_qparams,
+                              override_quantized_engine,
+                              quantize)
 
 # Make sure we won't have overflows from vpmaddubsw instruction used in FBGEMM.
 # On the current Intel x86 architecture, we need to utilize vpmaddubsw instruction
@@ -1070,6 +1073,61 @@ class TestQuantizedOps(TestCase):
 
         self.assertEqual(qX.equal(qX), equal_ref(qX, qX))
         self.assertEqual(qX.equal(qX2), equal_ref(qX, qX2))
+
+
+class TestStaticRNN(TestCase):
+
+    """Tests the static LSTM implementation."""
+    def test_lstm(self):
+        batch_size = 16
+        input_size = 16
+        hidden_size = 16
+        num_layers = 16
+        seq_len = 16
+        bias = True
+        bidirectional = True
+
+        num_directions = int(bidirectional) + 1
+
+        x = torch.randn(seq_len, batch_size, input_size)
+        h = torch.randn(num_layers * num_directions, batch_size, hidden_size)
+        c = torch.randn(num_layers * num_directions, batch_size, hidden_size)
+
+        qx = quantize(x, torch.quint8)
+        qh = quantize(h, torch.quint8)
+        qc = quantize(c, torch.qint32, scale=1e-6, zero_point=0)
+
+        f_lstm = torch.nn.LSTM(input_size=input_size,
+                               hidden_size=hidden_size,
+                               num_layers=num_layers,
+                               bias=bias,
+                               batch_first=False,
+                               dropout=0.0,
+                               bidirectional=bidirectional)
+        flat_weights_names = f_lstm._flat_weights_names
+        flat_weights = f_lstm._flat_weights
+        q_lstm = torch.nn.quantized.LSTM(input_size=input_size,
+                                         hidden_size=hidden_size,
+                                         num_layers=num_layers,
+                                         bias=bias,
+                                         batch_first=False,
+                                         dropout=0.0,
+                                         bidirectional=bidirectional,
+                                         # Quantization parameters
+                                         flat_weights_names=flat_weights_names,
+                                         flat_weights=flat_weights,
+                                         weights_scale=None,
+                                         weights_zero_point=None)
+
+        f_out, (f_h, f_c) = f_lstm(x, (h, c))
+        q_out, (q_h, q_c) = q_lstm(qx, (qh, qc))
+
+        self.assertEqual(f_out, q_out.dequantize(), prec=0.2,
+                         message="Output not equal: {} vs. {}".format(f_out, q_out))
+        self.assertEqual(f_h, q_h.dequantize(), prec=0.2,
+                         message="H not equal: {} vs. {}".format(f_h, q_h))
+        self.assertEqual(f_c, q_c.dequantize(), prec=0.2,
+                         message="C not equal: {} vs. {}".format(f_c, q_c))
 
 
 @unittest.skipUnless('fbgemm' in torch.backends.quantized.supported_engines,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #32335 Benchmarks for quantized LSTM (static)
* **#32334 Unittests for quantized LSTM (static)**
* #32074 Static quantization for LSTM (front)
* #31934 Static quantization for LSTM (back)
* #31851 Quantized sigmoid function
* #32252 Adding native qconcat

Differential Revision: [D19442266](https://our.internmc.facebook.com/intern/diff/D19442266)