### PR TITLE
Specify requires_grad for Parameter replica so it's not always set to True by default

### DIFF
--- a/torch/nn/parallel/replicate.py
+++ b/torch/nn/parallel/replicate.py
@@ -143,7 +143,7 @@ def replicate(network, devices, detach=False):
                 for j in range(num_replicas):
                     replica = module_copies[j][i]
                     param = param_copies[j][param_idx]
-                    setattr(replica, key, Parameter(param))
+                    setattr(replica, key, Parameter(param, requires_grad=param.requires_grad))
                     # TODO: We need to manually set _parameters with a bare
                     # non-parameter Tensor, otherwise gradients don't
                     # accumulate in the original parameters when you call


### PR DESCRIPTION
This is the proposed fix for issue #32018 

