### PR TITLE
Add All-to-all comms support to distributed module and MPI backend

### DIFF
--- a/docs/source/distributed.rst
+++ b/docs/source/distributed.rst
@@ -39,6 +39,8 @@ MPI supports CUDA only if the implementation used to build PyTorch supports it.
 +----------------+-----+-----+-----+-----+-----+-----+
 | reduce_scatter | ✘   | ✘   | ✘   | ✘   | ✘   | ✓   |
 +----------------+-----+-----+-----+-----+-----+-----+
+| all_to_all     | ✘   | ✘   | ✓   | ?   | ✘   | ✘   |
++----------------+-----+-----+-----+-----+-----+-----+
 | barrier        | ✓   | ✘   | ✓   | ?   | ✘   | ✓   |
 +----------------+-----+-----+-----+-----+-----+-----+
 
@@ -320,6 +322,8 @@ Collective functions
 .. autofunction:: scatter
 
 .. autofunction:: reduce_scatter
+
+.. autofunction:: all_to_all
 
 .. autofunction:: barrier
 

--- a/test/distributed/test_distributed.py
+++ b/test/distributed/test_distributed.py
@@ -1512,6 +1512,92 @@ class _DistTestBase(object):
             output_tensors_lists, input_tensors, expected_tensors, group_id)
         self._barrier()
 
+    # AllToAll
+    def _test_all_to_all_single_equal_split_helper(self, group, group_id, rank):
+        if group_id is not None:
+            size = len(group)
+            in_tensor = torch.ones([size, size]) * rank
+            expected_tensor = torch.cat([torch.ones([1, size]) * i for i in group])
+            out_tensor = torch.ones([size, size]) * -1
+            dist.all_to_all_single(out_tensor, in_tensor, group=group_id)
+            self.assertEqual(out_tensor, expected_tensor)
+        self._barrier()
+
+    def _test_all_to_all_single_unequal_split_helper(self, group, group_id, rank):
+        if group_id is not None:
+            size = len(group)
+            in_splits = [i + 1 for i in group]
+            out_splits = [rank + 1 for _ in group]
+            in_tensor = torch.ones([sum(in_splits), size]) * rank
+            out_tensor = torch.ones([(rank + 1) * size, size])
+            expected_tensor = torch.cat([torch.ones([rank + 1, size]) * i for i in group])
+            dist.all_to_all_single(
+                out_tensor, in_tensor, out_splits, in_splits, group=group_id)
+            self.assertEqual(out_tensor, expected_tensor)
+        self._barrier()
+
+    def _test_all_to_all_helper(self, group, group_id, rank):
+        if group_id is not None:
+            size = len(group)
+            in_splits = [i + 1 for i in group]
+            in_tensors = [
+                torch.ones([in_splits[i], size]) * rank for i, _ in enumerate(group)
+            ]
+            out_tensors = [torch.ones([(rank + 1), size]) for _ in group]
+            expected_tensors = [torch.ones([rank + 1, size]) * i for i in group]
+            dist.all_to_all(out_tensors, in_tensors, group=group_id)
+            for t1, t2 in zip(out_tensors, expected_tensors):
+                self.assertEqual(t1, t2)
+        self._barrier()
+
+    @unittest.skipIf(BACKEND != "mpi", "Only MPI supports all_to_all_single")
+    def test_all_to_all_single_equal_split(self):
+        group, group_id, rank = self._init_global_test()
+        self._test_all_to_all_single_equal_split_helper(group, group_id, rank)
+
+    @unittest.skipIf(BACKEND != "mpi", "Only MPI supports all_to_all_single")
+    def test_all_to_all_single_unequal_split(self):
+        group, group_id, rank = self._init_global_test()
+        self._test_all_to_all_single_unequal_split_helper(group, group_id, rank)
+
+    @unittest.skipIf(BACKEND != "mpi", "Only MPI supports all_to_all")
+    def test_all_to_all(self):
+        group, group_id, rank = self._init_global_test()
+        self._test_all_to_all_helper(group, group_id, rank)
+
+    @unittest.skipIf(BACKEND != "mpi", "Only MPI supports all_to_all_single")
+    @skip_if_small_worldsize
+    def test_all_to_all_single_equal_split_group(self):
+        group, group_id, rank = self._init_group_test()
+        self._test_all_to_all_single_equal_split_helper(group, group_id, rank)
+
+    @unittest.skipIf(BACKEND != "mpi", "Only MPI supports all_to_all_single")
+    @skip_if_small_worldsize
+    def test_all_to_all_single_unequal_split_group(self):
+        group, group_id, rank = self._init_group_test()
+        self._test_all_to_all_single_unequal_split_helper(group, group_id, rank)
+
+    @unittest.skipIf(BACKEND != "mpi", "Only MPI supports all_to_all")
+    @skip_if_small_worldsize
+    def test_all_to_all_group(self):
+        group, group_id, rank = self._init_group_test()
+        self._test_all_to_all_helper(group, group_id, rank)
+
+    @unittest.skipIf(BACKEND != "mpi", "Only MPI supports all_to_all_single")
+    def test_all_to_all_single_equal_split_full_group(self):
+        group, group_id, rank = self._init_full_group_test()
+        self._test_all_to_all_single_equal_split_helper(group, group_id, rank)
+
+    @unittest.skipIf(BACKEND != "mpi", "Only MPI supports all_to_all_single")
+    def test_all_to_all_single_unequal_split_full_group(self):
+        group, group_id, rank = self._init_full_group_test()
+        self._test_all_to_all_single_unequal_split_helper(group, group_id, rank)
+
+    @unittest.skipIf(BACKEND != "mpi", "Only MPI supports all_to_all")
+    def test_all_to_all_full_group(self):
+        group, group_id, rank = self._init_full_group_test()
+        self._test_all_to_all_helper(group, group_id, rank)
+
     # BARRIER
     def _test_barrier_helper(
             self, group, group_id, rank, cuda=False, rank_to_GPU=None):

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -204,6 +204,10 @@ They are used in specifying strategies for reduction collectives, e.g.,
       .def(py::init<>())
       .def_readwrite("timeout", &::c10d::BarrierOptions::timeout);
 
+  py::class_<::c10d::AllToAllOptions>(module, "AllToAllOptions")
+      .def(py::init<>())
+      .def_readwrite("timeout", &::c10d::AllToAllOptions::timeout);
+
   auto store =
       py::class_<::c10d::Store, std::shared_ptr<::c10d::Store>, PythonStore>(
           module, "Store")
@@ -467,6 +471,55 @@ They are used in specifying strategies for reduction collectives, e.g.,
               },
               py::arg("output_tensors"),
               py::arg("input_tensor"),
+              py::call_guard<py::gil_scoped_release>())
+
+          .def(
+              "alltoall_base",
+              &::c10d::ProcessGroup::alltoall_base,
+              py::arg("output_tensor"),
+              py::arg("input_tensor"),
+              py::arg("output_split_sizes"),
+              py::arg("input_split_sizes"),
+              py::arg("opts") = ::c10d::AllToAllOptions(),
+              py::call_guard<py::gil_scoped_release>())
+
+          .def(
+              "alltoall_base",
+              [](::c10d::ProcessGroup& pg,
+                 at::Tensor& output,
+                 at::Tensor& input,
+                 std::vector<int64_t> outputSplitSizes,
+                 std::vector<int64_t> inputSplitSizes) {
+                return pg.alltoall_base(
+                    output,
+                    input,
+                    outputSplitSizes,
+                    inputSplitSizes,
+                    ::c10d::AllToAllOptions());
+              },
+              py::arg("output"),
+              py::arg("input"),
+              py::arg("output_split_sizes"),
+              py::arg("input_split_sizes"),
+              py::call_guard<py::gil_scoped_release>())
+
+          .def(
+              "alltoall",
+              &::c10d::ProcessGroup::alltoall,
+              py::arg("output_tensor"),
+              py::arg("input_tensor"),
+              py::arg("opts") = ::c10d::AllToAllOptions(),
+              py::call_guard<py::gil_scoped_release>())
+
+          .def(
+              "alltoall",
+              [](::c10d::ProcessGroup& pg,
+                 std::vector<at::Tensor>& output,
+                 std::vector<at::Tensor>& input) {
+                return pg.alltoall(output, input, ::c10d::AllToAllOptions());
+              },
+              py::arg("output"),
+              py::arg("input"),
               py::call_guard<py::gil_scoped_release>())
 
           .def(

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -11,6 +11,7 @@ from .rendezvous import rendezvous, register_rendezvous_handler  # noqa: F401
 from . import (
     AllreduceOptions,
     AllreduceCoalescedOptions,
+    AllToAllOptions,
     BroadcastOptions,
     GatherOptions,
     ReduceOptions,
@@ -1454,6 +1455,193 @@ def reduce_scatter(output,
         work = _default_pg.reduce_scatter([output], [input_list], opts)
     else:
         work = group.reduce_scatter([output], [input_list], opts)
+
+    if async_op:
+        return work
+    else:
+        work.wait()
+
+
+def all_to_all_single(output,
+                      input,
+                      output_split_sizes=None,
+                      input_split_sizes=None,
+                      group=group.WORLD,
+                      async_op=False):
+    """
+    Each process splits input tensor and then scatters the split list
+    to all processes in a group. Then concatenate the received tensors from all
+    the processes in the group and return single output tensor.
+
+    Arguments:
+        output (Tensor): Gathered cancatenated output tensor.
+        input (Tensor): Input tensor to scatter.
+        output_split_sizes: (list[Int], optional): Output split sizes for dim 0
+            if specified None or empty, dim 0 of ``output`` tensor must divide
+            equally by ``world_size``.
+        input_split_sizes: (list[Int], optional): Input split sizes for dim 0
+            if specified None or empty, dim 0 of ``input`` tensor must divide
+            equally by ``world_size``.
+        group (ProcessGroup, optional): The process group to work on.
+        async_op (bool, optional): Whether this op should be an async op.
+
+    Returns:
+        Async work handle, if async_op is set to True.
+        None, if not async_op or if not part of the group.
+
+    .. warning::
+        `all_to_all_single` is experimental and subject to change.
+
+    Examples:
+        >>> input = torch.arange(4) + rank * 4
+        >>> input
+        tensor([0, 1, 2, 3])     # Rank 0
+        tensor([4, 5, 6, 7])     # Rank 1
+        tensor([8, 9, 10, 11])   # Rank 2
+        tensor([12, 13, 14, 15]) # Rank 3
+        >>> output = torch.empty([4], dtype=torch.int64)
+        >>> dist.all_to_all_single(output, input)
+        >>> output
+        tensor([0, 4, 8, 12])    # Rank 0
+        tensor([1, 5, 9, 13])    # Rank 1
+        tensor([2, 6, 10, 14])   # Rank 2
+        tensor([3, 7, 11, 15])   # Rank 3
+
+        >>> # Essentially, it is similar to following operation:
+        >>> scatter_list = list(input.chunk(world_size))
+        >>> gather_list  = list(output.chunk(world_size))
+        >>> for i in range(world_size):
+        >>>   dist.scatter(gather_list[i], scatter_list if i == rank else [], src = i)
+
+        >>> # Another example with uneven split
+        >>> input
+        tensor([0, 1, 2, 3, 4, 5])                                       # Rank 0
+        tensor([10, 11, 12, 13, 14, 15, 16, 17, 18])                     # Rank 1
+        tensor([20, 21, 22, 23, 24])                                     # Rank 2
+        tensor([30, 31, 32, 33, 34, 35, 36])                             # Rank 3
+        >>> input_splits
+        [2, 2, 1, 1]                                                     # Rank 0
+        [3, 2, 2, 2]                                                     # Rank 1
+        [2, 1, 1, 1]                                                     # Rank 2
+        [2, 2, 2, 1]                                                     # Rank 3
+        >>> output_splits
+        [2, 3, 2, 2]                                                     # Rank 0
+        [2, 2, 1, 2]                                                     # Rank 1
+        [1, 2, 1, 2]                                                     # Rank 2
+        [1, 2, 1, 1]                                                     # Rank 3
+        >>> output = ...
+        >>> dist.all_to_all_single(output, input, output_splits, input_splits)
+        >>> output
+        tensor([ 0,  1, 10, 11, 12, 20, 21, 30, 31])                     # Rank 0
+        tensor([ 2,  3, 13, 14, 22, 32, 33])                             # Rank 1
+        tensor([ 4, 15, 16, 23, 34, 35])                                 # Rank 2
+        tensor([ 5, 17, 18, 24, 36])                                     # Rank 3
+    """
+    if _rank_not_in_group(group):
+        return
+
+    opts = AllToAllOptions()
+    _check_single_tensor(output, "output")
+    _check_single_tensor(input, "input")
+    output_split_sizes = [] if output_split_sizes is None else output_split_sizes
+    input_split_sizes = [] if input_split_sizes is None else input_split_sizes
+
+    if group == GroupMember.WORLD:
+        _check_default_pg()
+        work = _default_pg.alltoall_base(output, input, output_split_sizes, input_split_sizes, opts)
+    else:
+        work = group.alltoall_base(output, input, output_split_sizes, input_split_sizes, opts)
+
+    if async_op:
+        return work
+    else:
+        work.wait()
+
+def all_to_all(output_tensor_list,
+               input_tensor_list,
+               group=group.WORLD,
+               async_op=False):
+    """
+    Each process scatters list of input tensors to all processes in a group and
+    return gathered list of tensors in output list.
+
+    Arguments:
+        output_tensor_list (list[Tensor]): List of tensors to be gathered one 
+            per rank.
+        input_tensor_list (list[Tensor]): List of tensors to scatter one per rank.
+        group (ProcessGroup, optional): The process group to work on.
+        async_op (bool, optional): Whether this op should be an async op.
+
+    Returns:
+        Async work handle, if async_op is set to True.
+        None, if not async_op or if not part of the group.
+
+    .. warning::
+        `all_to_all` is experimental and subject to change.
+
+    Examples:
+        >>> input = torch.arange(4) + rank * 4
+        >>> input = list(input.chunk(4))
+        >>> input
+        [tensor([0]), tensor([1]), tensor([2]), tensor([3])]     # Rank 0
+        [tensor([4]), tensor([5]), tensor([6]), tensor([7])]     # Rank 1
+        [tensor([8]), tensor([9]), tensor([10]), tensor([11])]   # Rank 2
+        [tensor([12]), tensor([13]), tensor([14]), tensor([15])] # Rank 3
+        >>> output = list(torch.empty([4], dtype=torch.int64).chunk(4))
+        >>> dist.all_to_all(output, input)
+        >>> output
+        [tensor([0]), tensor([4]), tensor([8]), tensor([12])]    # Rank 0
+        [tensor([1]), tensor([5]), tensor([9]), tensor([13])]    # Rank 1
+        [tensor([2]), tensor([6]), tensor([10]), tensor([14])]   # Rank 2
+        [tensor([3]), tensor([7]), tensor([11]), tensor([15])]   # Rank 3
+
+        >>> # Essentially, it is similar to following operation:
+        >>> scatter_list = input
+        >>> gather_list  = output
+        >>> for i in range(world_size):
+        >>>   dist.scatter(gather_list[i], scatter_list if i == rank else [], src = i)
+
+        >>> input
+        tensor([0, 1, 2, 3, 4, 5])                                       # Rank 0
+        tensor([10, 11, 12, 13, 14, 15, 16, 17, 18])                     # Rank 1
+        tensor([20, 21, 22, 23, 24])                                     # Rank 2
+        tensor([30, 31, 32, 33, 34, 35, 36])                             # Rank 3
+        >>> input_splits
+        [2, 2, 1, 1]                                                     # Rank 0
+        [3, 2, 2, 2]                                                     # Rank 1
+        [2, 1, 1, 1]                                                     # Rank 2
+        [2, 2, 2, 1]                                                     # Rank 3
+        >>> output_splits
+        [2, 3, 2, 2]                                                     # Rank 0
+        [2, 2, 1, 2]                                                     # Rank 1
+        [1, 2, 1, 2]                                                     # Rank 2
+        [1, 2, 1, 1]                                                     # Rank 3
+        >>> input = list(input.split(input_splits))
+        >>> input
+        [tensor([0, 1]), tensor([2, 3]), tensor([4]), tensor([5])]                   # Rank 0
+        [tensor([10, 11, 12]), tensor([13, 14]), tensor([15, 16]), tensor([17, 18])] # Rank 1
+        [tensor([20, 21]), tensor([22]), tensor([23]), tensor([24])]                 # Rank 2
+        [tensor([30, 31]), tensor([32, 33]), tensor([34, 35]), tensor([36])]         # Rank 3
+        >>> output = ...
+        >>> dist.all_to_all(output, input)
+        >>> output
+        [tensor([0, 1]), tensor([10, 11, 12]), tensor([20, 21]), tensor([30, 31])]   # Rank 0
+        [tensor([2, 3]), tensor([13, 14]), tensor([22]), tensor([32, 33])]           # Rank 1
+        [tensor([4]), tensor([15, 16]), tensor([23]), tensor([34, 35])]              # Rank 2
+        [tensor([5]), tensor([17, 18]), tensor([24]), tensor([36])]                  # Rank 3
+    """
+    if _rank_not_in_group(group):
+        return
+
+    opts = AllToAllOptions()
+    _check_tensor_list(output_tensor_list, "output_tensor_list")
+    _check_tensor_list(input_tensor_list, "input_tensor_list")
+
+    if group == GroupMember.WORLD:
+        _check_default_pg()
+        work = _default_pg.alltoall(output_tensor_list, input_tensor_list, opts)
+    else:
+        work = group.alltoall(output_tensor_list, input_tensor_list, opts)
 
     if async_op:
         return work

--- a/torch/lib/c10d/ProcessGroup.hpp
+++ b/torch/lib/c10d/ProcessGroup.hpp
@@ -162,6 +162,22 @@ class ProcessGroup {
       std::vector<std::vector<at::Tensor>>& inputTensors,
       const ReduceScatterOptions& opts = ReduceScatterOptions()) = 0;
 
+  virtual std::shared_ptr<ProcessGroup::Work> alltoall_base(
+      at::Tensor& outputTensor,
+      at::Tensor& inputTensor,
+      std::vector<int64_t>& outputSplitSizes,
+      std::vector<int64_t>& inputSplitSizes,
+      const AllToAllOptions& opts = AllToAllOptions()) {
+    throw std::runtime_error("ProcessGroup does not support alltoall");
+  }
+
+  virtual std::shared_ptr<ProcessGroup::Work> alltoall(
+      std::vector<at::Tensor>& outputTensors,
+      std::vector<at::Tensor>& inputTensors,
+      const AllToAllOptions& opts = AllToAllOptions()) {
+    throw std::runtime_error("ProcessGroup does not support alltoall");
+  }
+
   virtual std::shared_ptr<ProcessGroup::Work> send(
       std::vector<at::Tensor>& tensors,
       int dstRank,

--- a/torch/lib/c10d/ProcessGroupMPI.cpp
+++ b/torch/lib/c10d/ProcessGroupMPI.cpp
@@ -1,5 +1,6 @@
 #include <c10d/ProcessGroupMPI.hpp>
 
+#include <limits>
 #include <map>
 
 #include <c10/core/DeviceGuard.h>
@@ -89,6 +90,72 @@ void checkSameSizeAndType(
     }
     checkSingleTensorHelper(tensors[i]);
   }
+}
+
+void checkSplitSizes(
+    const std::vector<int64_t>& split_sizes,
+    const at::Tensor& tensor,
+    int group_size) {
+  if (split_sizes.size() == 0) {
+    TORCH_CHECK(
+        tensor.size(0) % group_size == 0,
+        "Tensor's dim 0 does not divide equally across group size");
+  } else {
+    TORCH_CHECK(
+        split_sizes.size() == group_size,
+        "Number of tensor splits not equal to group size");
+    int sum = std::accumulate(split_sizes.begin(), split_sizes.end(), 0);
+    TORCH_CHECK(
+        sum == tensor.size(0), "Split sizes doesn't match total dim 0 size");
+  }
+}
+
+int64_t computeLengthsAndOffsets(
+    const std::vector<int64_t>& split_sizes,
+    const at::Tensor& tensor,
+    std::vector<int>* lengths,
+    std::vector<int>* offsets) {
+  int64_t group_size = lengths->size();
+  bool equal_splits = false;
+  int64_t dim0_size = tensor.size(0);
+  int64_t row_size = (dim0_size ? tensor.numel() / dim0_size : 1);
+  int64_t split_size = 0;
+  int64_t offset = 0;
+
+  if (split_sizes.size() == 0) {
+    equal_splits = true;
+    split_size = tensor.size(0) / group_size;
+  }
+  for (int i = 0; i < group_size; i++) {
+    int64_t length = row_size * (equal_splits ? split_size : split_sizes[i]);
+    TORCH_INTERNAL_ASSERT(
+        length <= std::numeric_limits<int>::max() &&
+            offset <= std::numeric_limits<int>::max(),
+        "Length or offset larger than INT_MAX not supported");
+    (*lengths)[i] = length;
+    (*offsets)[i] = offset;
+    offset += length;
+  }
+  return offset;
+}
+
+int64_t computeLengthsAndOffsets(
+    const std::vector<at::Tensor>& tensors,
+    std::vector<int>* lengths,
+    std::vector<int>* offsets) {
+  int64_t group_size = lengths->size();
+  int64_t offset = 0;
+  for (int i = 0; i < group_size; i++) {
+    int64_t length = tensors[i].numel();
+    TORCH_INTERNAL_ASSERT(
+        length <= std::numeric_limits<int>::max() &&
+            offset <= std::numeric_limits<int>::max(),
+        "Length or offset larger than INT_MAX not supported");
+    (*lengths)[i] = length;
+    (*offsets)[i] = offset;
+    offset += length;
+  }
+  return offset;
 }
 
 } // namespace
@@ -586,6 +653,139 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupMPI::reduce_scatter(
     std::vector<std::vector<at::Tensor>>& inputTensors,
     const ReduceScatterOptions& opts) {
   throw std::runtime_error("ProcessGroupMPI does not support reduce_scatter");
+}
+
+std::shared_ptr<ProcessGroup::Work> ProcessGroupMPI::alltoall_base(
+    at::Tensor& outputTensor,
+    at::Tensor& inputTensor,
+    std::vector<int64_t>& outputSplitSizes,
+    std::vector<int64_t>& inputSplitSizes,
+    const AllToAllOptions& opts) {
+  checkSingleTensorHelper(inputTensor);
+  checkSingleTensorHelper(outputTensor);
+
+  if (outputSplitSizes.size() == 0 && inputSplitSizes.size() == 0) {
+    // We can use alltoall
+    TORCH_CHECK(
+        outputTensor.numel() == inputTensor.numel() &&
+            outputTensor.type() == inputTensor.type(),
+        "Tensors are not equal in size or data type");
+    TORCH_CHECK(
+        outputTensor.size(0) % size_ == 0,
+        "Tensor's dim 0 does not divide equally across group size");
+
+    std::function<void(std::unique_ptr<WorkEntry>&)> runFunc =
+        [opts, this](std::unique_ptr<WorkEntry>& entry) {
+          auto srcdata = (entry->src)[0];
+          auto dstdata = (entry->dst)[0];
+          c10::DeviceGuard guard(srcdata.device());
+          std::unique_lock<std::mutex> globalLock(pgGlobalMutex_);
+          MPI_CHECK(MPI_Alltoall(
+              srcdata.data_ptr(),
+              srcdata.numel() / size_,
+              mpiDatatype.at(srcdata.scalar_type()),
+              dstdata.data_ptr(),
+              dstdata.numel() / size_,
+              mpiDatatype.at(dstdata.scalar_type()),
+              pgComm_));
+        };
+    std::vector<at::Tensor> inputTensors = {inputTensor};
+    std::vector<at::Tensor> outputTensors = {outputTensor};
+    auto entry = std::unique_ptr<WorkEntry>(
+        new WorkEntry(&inputTensors, &outputTensors, std::move(runFunc)));
+    return enqueue(std::move(entry));
+  } else {
+    // Need alltoallv
+    checkSplitSizes(inputSplitSizes, inputTensor, size_);
+    checkSplitSizes(outputSplitSizes, outputTensor, size_);
+    std::function<void(std::unique_ptr<WorkEntry>&)> runFunc =
+        [opts, this, inputSplitSizes, outputSplitSizes](
+            std::unique_ptr<WorkEntry>& entry) {
+          auto srcdata = (entry->src)[0];
+          auto dstdata = (entry->dst)[0];
+          std::vector<int> send_lengths(size_);
+          std::vector<int> recv_lengths(size_);
+          std::vector<int> send_offsets(size_);
+          std::vector<int> recv_offsets(size_);
+          computeLengthsAndOffsets(
+              inputSplitSizes, srcdata, &send_lengths, &send_offsets);
+          computeLengthsAndOffsets(
+              outputSplitSizes, dstdata, &recv_lengths, &recv_offsets);
+          c10::DeviceGuard guard(srcdata.device());
+          std::unique_lock<std::mutex> globalLock(pgGlobalMutex_);
+          MPI_CHECK(MPI_Alltoallv(
+              srcdata.data_ptr(),
+              send_lengths.data(),
+              send_offsets.data(),
+              mpiDatatype.at(srcdata.scalar_type()),
+              dstdata.data_ptr(),
+              recv_lengths.data(),
+              recv_offsets.data(),
+              mpiDatatype.at(dstdata.scalar_type()),
+              pgComm_));
+        };
+    std::vector<at::Tensor> inputTensors = {inputTensor};
+    std::vector<at::Tensor> outputTensors = {outputTensor};
+    auto entry = std::unique_ptr<WorkEntry>(
+        new WorkEntry(&inputTensors, &outputTensors, std::move(runFunc)));
+    return enqueue(std::move(entry));
+  }
+}
+std::shared_ptr<ProcessGroup::Work> ProcessGroupMPI::alltoall(
+    std::vector<at::Tensor>& outputTensors,
+    std::vector<at::Tensor>& inputTensors,
+    const AllToAllOptions& opts) {
+  TORCH_CHECK(
+      inputTensors.size() == size_,
+      "Number of input tensors are not equal to group size");
+  TORCH_CHECK(
+      outputTensors.size() == size_,
+      "Number of output tensors are not equal to group size");
+  std::function<void(std::unique_ptr<WorkEntry>&)> runFunc =
+      [opts, this](std::unique_ptr<WorkEntry>& entry) {
+        std::vector<int> send_lengths(size_);
+        std::vector<int> recv_lengths(size_);
+        std::vector<int> send_offsets(size_);
+        std::vector<int> recv_offsets(size_);
+        auto srcdata = entry->src;
+        auto dstdata = entry->dst;
+        int64_t src_len =
+            computeLengthsAndOffsets(srcdata, &send_lengths, &send_offsets);
+        int64_t dst_len =
+            computeLengthsAndOffsets(dstdata, &recv_lengths, &recv_offsets);
+        std::vector<int64_t> send_lengthsL(
+            send_lengths.begin(), send_lengths.end());
+        std::vector<int64_t> recv_lengthsL(
+            recv_lengths.begin(), recv_lengths.end());
+        at::Tensor srcFlatData = at::empty({src_len}, srcdata[0].options());
+        at::Tensor dstFlatData = at::empty({dst_len}, dstdata[0].options());
+        auto srcFlatDataSplits =
+            srcFlatData.split_with_sizes(c10::IntArrayRef(send_lengthsL), 0);
+        for (int i = 0; i < size_; i++) {
+          srcFlatDataSplits[i].copy_(srcdata[i].view({-1}));
+        }
+        c10::DeviceGuard guard1(srcdata[0].device());
+        std::unique_lock<std::mutex> globalLock(pgGlobalMutex_);
+        MPI_CHECK(MPI_Alltoallv(
+            srcFlatData.data_ptr(),
+            send_lengths.data(),
+            send_offsets.data(),
+            mpiDatatype.at(srcdata[0].scalar_type()),
+            dstFlatData.data_ptr(),
+            recv_lengths.data(),
+            recv_offsets.data(),
+            mpiDatatype.at(dstdata[0].scalar_type()),
+            pgComm_));
+
+        auto dstFlatDataSplits =
+            dstFlatData.split_with_sizes(c10::IntArrayRef(recv_lengthsL), 0);
+        for (int i = 0; i < size_; i++) {
+          dstdata[i].view({-1}).copy_(dstFlatDataSplits[i]);
+        }
+      };
+  auto entry = std::unique_ptr<WorkEntry>(
+      new WorkEntry(&inputTensors, &outputTensors, std::move(runFunc)));
+  return enqueue(std::move(entry));
 }
 
 std::shared_ptr<ProcessGroup::Work> ProcessGroupMPI::send(

--- a/torch/lib/c10d/ProcessGroupMPI.hpp
+++ b/torch/lib/c10d/ProcessGroupMPI.hpp
@@ -155,6 +155,18 @@ class ProcessGroupMPI : public ProcessGroup {
       std::vector<std::vector<at::Tensor>>& inputTensors,
       const ReduceScatterOptions& opts = ReduceScatterOptions()) override;
 
+  std::shared_ptr<ProcessGroup::Work> alltoall_base(
+      at::Tensor& outputTensor,
+      at::Tensor& inputTensor,
+      std::vector<int64_t>& outputSplitSizes,
+      std::vector<int64_t>& inputSplitSizes,
+      const AllToAllOptions& opts = AllToAllOptions()) override;
+
+  std::shared_ptr<ProcessGroup::Work> alltoall(
+      std::vector<at::Tensor>& outputTensors,
+      std::vector<at::Tensor>& inputTensors,
+      const AllToAllOptions& opts = AllToAllOptions()) override;
+
   std::shared_ptr<ProcessGroup::Work> send(
       std::vector<at::Tensor>& tensors,
       int dstRank,

--- a/torch/lib/c10d/Types.hpp
+++ b/torch/lib/c10d/Types.hpp
@@ -57,6 +57,10 @@ struct ReduceScatterOptions {
   std::chrono::milliseconds timeout = kUnsetTimeout;
 };
 
+struct AllToAllOptions {
+  std::chrono::milliseconds timeout = kUnsetTimeout;
+};
+
 struct BarrierOptions {
   std::chrono::milliseconds timeout = kUnsetTimeout;
 };


### PR DESCRIPTION
As described in #32345, a prototype implementation to add an alltoall communication primitive to torch.distributed module and ProcessGroup abstract interface. Also, implements alltoall in ProcessGroupMPI backend.

@mnaumovfb @JianpingChen066 @dmudiger @srinivas212 @Jianhui-Li @mshiryaev @ftian1

cc @pietern @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @xush6528 @osalpekar