### PR TITLE
[wip] Allow large tensors to be mmap'd during torch.jit.load

### DIFF
--- a/caffe2/serialize/file_adapter.cc
+++ b/caffe2/serialize/file_adapter.cc
@@ -2,10 +2,16 @@
 #include <c10/util/Exception.h>
 #include "caffe2/core/common.h"
 
+#include <sys/mman.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
 namespace caffe2 {
 namespace serialize {
 
-FileAdapter::FileAdapter(const std::string& file_name) {
+FileAdapter::FileAdapter(const std::string& file_name)
+: file_name_(file_name) {
   file_stream_.open(file_name, std::ifstream::in | std::ifstream::binary);
   if (!file_stream_) {
     AT_ERROR("open file failed, file path: ", file_name);
@@ -20,6 +26,70 @@ size_t FileAdapter::size() const {
 size_t FileAdapter::read(uint64_t pos, void* buf, size_t n, const char* what)
     const {
   return istream_adapter_->read(pos, buf, n, what);
+}
+
+
+bool FileAdapter::canMMap() const {
+  // TODO MMAP windows off
+  return true;
+}
+
+struct MMapFile {
+  MMapFile(const std::string& file_name) {
+    fd_ = open(file_name.c_str(), O_RDONLY);
+    if (fd_ == -1) {
+      AT_ERROR("open file failed for mmap, file path: ", file_name);
+    }
+  }
+  ~MMapFile() {
+    if (fd_ != -1) {
+      close(fd_);
+    }
+  }
+  int fd_;
+};
+
+
+namespace {
+
+struct Mapping {
+  Mapping(std::shared_ptr<MMapFile> file, off_t offset, size_t entry_size)
+  : file_(std::move(file)) {
+    entry_size_ = entry_size;
+    static const size_t page_size = sysconf(_SC_PAGE_SIZE);
+    size_t remainder = offset % page_size;
+    size_t offset_aligned = offset - remainder;
+    allocation_size_ = remainder + entry_size;
+    allocation_data_ = mmap(nullptr, allocation_size_, PROT_READ | PROT_WRITE, MAP_PRIVATE, file_->fd_, offset_aligned);
+    AT_ASSERT(allocation_data_ != nullptr, "mmap failed");
+    entry_data_ = (char*)allocation_data_ + remainder;
+  }
+  ~Mapping() {
+    munmap(allocation_data_, allocation_size_);
+  }
+  void* entry_data_;
+  size_t entry_size_;
+
+  // because the offset into the file must be page aligned, the actually
+  // allocation into the file will be bigger than what the offset is.
+  void* allocation_data_;
+  size_t allocation_size_;
+
+  std::shared_ptr<MMapFile> file_;
+};
+
+}
+
+c10::DataPtr FileAdapter::mmap(uint64_t pos, size_t n) {
+  if (!mmap_file_) {
+    mmap_file_ = std::make_shared<MMapFile>(file_name_);
+  }
+  Mapping* mapping = new Mapping(mmap_file_, pos, n);
+  DataPtr result(mapping->entry_data_, mapping, [](void* ctx) {
+    Mapping* mapping = static_cast<Mapping*>(ctx);
+    delete mapping;
+  }, DeviceType::CPU);
+  return result;
 }
 
 FileAdapter::~FileAdapter() {}

--- a/caffe2/serialize/file_adapter.h
+++ b/caffe2/serialize/file_adapter.h
@@ -10,6 +10,8 @@
 namespace caffe2 {
 namespace serialize {
 
+struct MMapFile;
+
 class CAFFE2_API FileAdapter final : public ReadAdapterInterface {
  public:
   C10_DISABLE_COPY_AND_ASSIGN(FileAdapter);
@@ -18,10 +20,14 @@ class CAFFE2_API FileAdapter final : public ReadAdapterInterface {
   size_t read(uint64_t pos, void* buf, size_t n, const char* what = "")
       const override;
   ~FileAdapter();
+  bool canMMap() const override;
+  c10::DataPtr mmap(uint64_t pos, size_t n) override;
 
  private:
+  std::string file_name_;
   std::ifstream file_stream_;
   std::unique_ptr<IStreamAdapter> istream_adapter_;
+  std::shared_ptr<MMapFile> mmap_file_;
 };
 
 } // namespace serialize

--- a/caffe2/serialize/inline_container.h
+++ b/caffe2/serialize/inline_container.h
@@ -99,6 +99,7 @@ constexpr uint64_t kFieldAlignment = 64;
 class CAFFE2_API PyTorchStreamReader final {
  public:
   explicit PyTorchStreamReader(const std::string& file_name);
+  explicit PyTorchStreamReader(const std::string& file_name, size_t mmap_threshold);
   explicit PyTorchStreamReader(std::istream* in);
   explicit PyTorchStreamReader(std::unique_ptr<ReadAdapterInterface> in);
 
@@ -117,6 +118,7 @@ class CAFFE2_API PyTorchStreamReader final {
   size_t read(uint64_t pos, char* buf, size_t n);
   void valid(const char* what, const char* info = "");
   size_t getRecordID(const std::string& name);
+  size_t getRecordOffset(void* stat);
 
   friend size_t
   istream_read_func(void* pOpaque, uint64_t file_ofs, void* pBuf, size_t n);
@@ -124,6 +126,7 @@ class CAFFE2_API PyTorchStreamReader final {
   std::string archive_name_;
   std::string archive_name_plus_slash_;
   std::unique_ptr<ReadAdapterInterface> in_;
+  size_t mmap_threshold_ = 4*1024*1024/*4MB*/;
   int64_t version_;
 };
 

--- a/caffe2/serialize/read_adapter_interface.h
+++ b/caffe2/serialize/read_adapter_interface.h
@@ -4,6 +4,7 @@
 #include <cstdint>
 
 #include "c10/macros/Macros.h"
+#include "c10/core/Allocator.h"
 
 namespace caffe2 {
 namespace serialize {
@@ -16,6 +17,15 @@ class CAFFE2_API ReadAdapterInterface {
   virtual size_t size() const = 0;
   virtual size_t read(uint64_t pos, void* buf, size_t n, const char* what = "")
       const = 0;
+
+  virtual bool canMMap() const {
+    return false;
+  }
+
+  virtual c10::DataPtr mmap(uint64_t pos, size_t n) {
+    AT_ERROR("Unimplemented");
+  }
+
   virtual ~ReadAdapterInterface();
 };
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#32382 [wip] Allow large tensors to be mmap'd during torch.jit.load**

This allows tensors to be copied into RAM lazily rather than when
the archive is loaded. This means that the archive can be larger than
the entire RAM on the machine, assuming the program takes care to
process and discard the tensors incrementally.

* wip - needs flags or ifdef for windows to work
* wip - needs testing, typical tests do not use real files, so they
        skip this pathway

Small benchmark shows that the tensor comes back correctly, but
loads from the archive faster.

There is an adjustable threshold for when to use mmap'd tensors since
there up to PAGE_SIZE (i.e. 4k) of waste per tensor.

```
import torch
from time import time
class Foo(torch.nn.Module):
    def __init__(self):
        super().__init__()
        self.foo2 = torch.rand(128, 1024, 1024)
        self.foo = torch.rand(1, 512, 1024)

m = torch.jit.script(Foo())
m.save('what.pt')

b = time()
m2 = torch.jit.load('what.pt')
e = time()
print(e - b)

print(torch.all(torch.eq(m.foo2, m2.foo2)))
print(torch.all(torch.eq(m.foo, m2.foo)))
```