### PR TITLE
[caffe2] Redundant condition

### DIFF
--- a/caffe2/operators/conv_transpose_op_mobile_test.cc
+++ b/caffe2/operators/conv_transpose_op_mobile_test.cc
@@ -140,8 +140,7 @@ void compare(int N, int inputC, int H, int W,
           // For small values / small difference, the relative error
           // can be huge but the absolute error will be small
           EXPECT_TRUE(relErr <= maxRelErr ||
-                      (relErr > maxRelErr &&
-                       absErr <= absErrForRelErrFailure)) <<
+                      (absErr <= absErrForRelErrFailure)) <<
             v1 << " " << v2 << " (rel err " << relErr << ") " <<
             "(" << n << " " << c << " " << h << " " << w << ") " <<
             "running N " << N << " inputC " << inputC <<


### PR DESCRIPTION
Optimize expression: 'A || (!A && B)' <=> 'A || B'

A: relErr <= maxRelErr
!A : relErr > maxRelErr
B: absErr <= absErrForRelErrFailure