### PR TITLE
Fix cusparse version check

### DIFF
--- a/aten/src/ATen/native/sparse/cuda/SparseCUDABlas.cu
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDABlas.cu
@@ -8,7 +8,7 @@
 
 #include <cusparse.h>
 
-#if (!((CUSPARSE_VER_MAJOR >= 10) && (CUSPARSE_VER_MINOR >= 2)))
+#if !defined(CUSPARSE_VERSION) || (CUSPARSE_VERSION < 10200)
 const char* cusparseGetErrorString(cusparseStatus_t status) {
   switch(status)
   {


### PR DESCRIPTION
The current version check doesn't use proper lexicographic comparison and so will break for future versions of cuSPARSE with `CUSPARSE_VER_MAJOR > 10` and `CUSPARSE_VER_MINOR < 2`. Also, my cusparse headers for CUDA 9 don't seem to include version macros at all, so added `if !defined` to be explicit about that.