### PR TITLE
Fix test_data_parallel name errors and add to run_test.py

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -27,6 +27,7 @@ TESTS = [
     'cuda',
     'cuda_primary_ctx',
     'dataloader',
+    'data_parallel',
     'distributed',
     'distributions',
     'docs_coverage',

--- a/test/test_data_parallel.py
+++ b/test/test_data_parallel.py
@@ -1,9 +1,16 @@
 import contextlib
 import unittest
+from copy import deepcopy
+from collections import OrderedDict
+
 import torch
 import torch.nn.parallel as dp
 from common_cuda import TEST_MULTIGPU, TEST_CUDA
-from common_utils import run_tests, TestCase, skipIfRocm, repeat_test_for_types, ALL_TENSORTYPES
+from common_utils import (run_tests, TestCase, skipIfRocm,
+                          repeat_test_for_types, ALL_TENSORTYPES, PY3)
+from torch import nn
+import torch.nn.functional as F
+from test_nn import _assertGradAndGradgradChecks, dtype2prec
 
 class TestDataParallel(TestCase):
 


### PR DESCRIPTION
While working on #31768 and trying to add tests for `DataParallel`, I discovered that: 
- `test_data_parallel.py` can't be run through `run_test.py`
- running it with `pytest` fails with many name errors 

`test_data_parallel.py` seems to have been split from `test_nn.py` in #28297 but not in a state where it can actually be run. Presumably `DataParallel` hasn't been tested by CI in the time since.