### PR TITLE
parallel.scatter_gather.scatter does not preserve named tuples

### DIFF
--- a/torch/nn/parallel/scatter_gather.py
+++ b/torch/nn/parallel/scatter_gather.py
@@ -11,6 +11,8 @@ def scatter(inputs, target_gpus, dim=0):
     def scatter_map(obj):
         if isinstance(obj, torch.Tensor):
             return Scatter.apply(target_gpus, None, dim, obj)
+        if isinstance(obj, tuple) and hasattr(obj, '_fields'):  # namedtuple                                                                                                                                                                                                        
+            return list(map(lambda x: type(obj)(*x), zip(*map(scatter_map, obj))))
         if isinstance(obj, tuple) and len(obj) > 0:
             return list(zip(*map(scatter_map, obj)))
         if isinstance(obj, list) and len(obj) > 0:


### PR DESCRIPTION
Scattering a batch between multiple processes using torch.nn.parallel.DistributedDataParallel does not preserve named tuples. This adds an additional check, which should be sufficient for pretty much all use cases.

This PR is very much related to #16440 and the solution is almost identical.
