### PR TITLE
Remove the support of build options like NO_*, WITH_*

### DIFF
--- a/tools/setup_helpers/env.py
+++ b/tools/setup_helpers/env.py
@@ -33,40 +33,6 @@ def lib_paths_from_base(base_path):
     return [os.path.join(base_path, s) for s in ['lib/x64', 'lib', 'lib64']]
 
 
-def hotpatch_var(var, prefix='USE_'):
-    def print_warning(good_prefix, bad_prefix, var):
-        print(("The use of {bad_prefix}{var} is deprecated and will be removed on Feb 20, 2020."
-               "Please use {good_prefix}{var} instead.").format(
-                   good_prefix=good_prefix, bad_prefix=bad_prefix, var=var))
-
-    if check_env_flag('NO_' + var):
-        print_warning(prefix, 'NO_', var)
-        os.environ[prefix + var] = '0'
-    elif check_negative_env_flag('NO_' + var):
-        print_warning(prefix, 'NO_', var)
-        os.environ[prefix + var] = '1'
-    elif check_env_flag('WITH_' + var):
-        print_warning(prefix, 'WITH_', var)
-        os.environ[prefix + var] = '1'
-    elif check_negative_env_flag('WITH_' + var):
-        print_warning(prefix, 'WITH_', var)
-        os.environ[prefix + var] = '0'
-
-
-def hotpatch_build_env_vars():
-    # Before we run the setup_helpers, let's look for NO_* and WITH_* variables and hotpatch environment with the USE_*
-    # equivalent The use of NO_* and WITH_* is deprecated and will be removed in Feb 20, 2020.
-    use_env_vars = ['CUDA', 'CUDNN', 'FBGEMM', 'MKLDNN', 'NNPACK', 'DISTRIBUTED',
-                    'OPENCV', 'TENSORRT', 'QNNPACK', 'FFMPEG', 'SYSTEM_NCCL',
-                    'GLOO_IBVERBS']
-    list(map(hotpatch_var, use_env_vars))
-
-    # Also hotpatch a few with BUILD_* equivalent
-    build_env_vars = ['BINARY', 'TEST', 'CAFFE2_OPS']
-    [hotpatch_var(v, 'BUILD_') for v in build_env_vars]
-
-hotpatch_build_env_vars()
-
 # We promised that CXXFLAGS should also be affected by CFLAGS
 if 'CFLAGS' in os.environ and 'CXXFLAGS' not in os.environ:
     os.environ['CXXFLAGS'] = os.environ['CFLAGS']


### PR DESCRIPTION
We will now use USE_*, BUILD_* consistently. The backward compatibility
for NO_* and WITH_* is hereby removed in this commit, as promised in the
comment (next release is beyond Feb 20):

    # Before we run the setup_helpers, let's look for NO_* and WITH_* variables and hotpatch environment with the USE_*
    # equivalent The use of NO_* and WITH_* is deprecated and will be removed in Feb 20, 2020.

