### PR TITLE
Fix crash of SobolEngine if default tensor type is cuda

### DIFF
--- a/torch/quasirandom.py
+++ b/torch/quasirandom.py
@@ -51,7 +51,9 @@ class SobolEngine(object):
         self.scramble = scramble
         self.dimension = dimension
 
-        self.sobolstate = torch.zeros(dimension, self.MAXBIT, dtype=torch.long)
+        cpu = torch.device("cpu")
+
+        self.sobolstate = torch.zeros(dimension, self.MAXBIT, device=cpu, dtype=torch.long)
         torch._sobol_engine_initialize_state_(self.sobolstate, self.dimension)
 
         if self.scramble:
@@ -61,14 +63,15 @@ class SobolEngine(object):
             else:
                 g.seed()
 
-            self.shift = torch.mv(torch.randint(2, (self.dimension, self.MAXBIT), generator=g),
-                                  torch.pow(2, torch.arange(0, self.MAXBIT)))
+            shift_ints = torch.randint(2, (self.dimension, self.MAXBIT), device=cpu, generator=g)
+            self.shift = torch.mv(shift_ints, torch.pow(2, torch.arange(0, self.MAXBIT, device=cpu)))
 
-            ltm = torch.randint(2, (self.dimension, self.MAXBIT, self.MAXBIT), generator=g).tril()
+            ltm_dims = (self.dimension, self.MAXBIT, self.MAXBIT)
+            ltm = torch.randint(2, ltm_dims, device=cpu, generator=g).tril()
 
             torch._sobol_engine_scramble_(self.sobolstate, ltm, self.dimension)
         else:
-            self.shift = torch.zeros(self.dimension, dtype=torch.long)
+            self.shift = torch.zeros(self.dimension, device=cpu, dtype=torch.long)
 
         self.quasi = self.shift.clone(memory_format=torch.contiguous_format)
         self.num_generated = 0


### PR DESCRIPTION
Summary: Addresses https://github.com/pytorch/pytorch/issues/32494

Test Plan:
```
import torch
from torch.quasirandom import SobolEngine

torch.set_default_tensor_type(torch.cuda.FloatTensor)
se = SobolEngine(3)
```

Differential Revision: D19517571

