### PR TITLE
Move exponential_ from TH to Aten (CPU)

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -1301,22 +1301,6 @@
     - double std
     - THGenerator* generator
 ]]
-
-[[
-  name: _th_exponential_
-  types:
-    - floating_point
-  backends:
-    - CPU
-  cname: exponential
-  variants: function
-  return: self
-  arguments:
-    - THTensor* self
-    - double lambd
-    - THGenerator* generator
-]]
-
 [[
   name: _th_copy_ignoring_overlaps_
   cname: copyIgnoringOverlaps

--- a/aten/src/ATen/core/DistributionsHelper.h
+++ b/aten/src/ATen/core/DistributionsHelper.h
@@ -12,16 +12,16 @@
 #include <limits>
 #include <cmath>
 
-/** 
+/**
  * Distributions kernel adapted from THRandom.cpp
  * The kernels try to follow std::random distributions signature
  * For instance: in ATen
  *      auto gen = at::detail::createCPUGenerator();
  *      at::uniform_real_distribution<double> uniform(0, 1);
  *      auto sample = uniform(gen.get());
- *      
+ *
  *      vs std::random
- * 
+ *
  *      std::mt19937 gen;
  *      std::uniform_real_distribution uniform(0, 1);
  *      auto sample = uniform(gen);
@@ -97,7 +97,7 @@ struct uniform_real_distribution {
 
   private:
     T a;
-    T b; 
+    T b;
 };
 
 /**
@@ -166,7 +166,7 @@ struct bernoulli_distribution {
     p = p_in;
   }
 
-  inline int operator()(at::CPUGenerator* generator) { 
+  inline int operator()(at::CPUGenerator* generator) {
     uniform_real_distribution<T> uniform(0.0, 1.0);
     return uniform(generator) < p;
   }
@@ -207,6 +207,10 @@ struct exponential_distribution {
   }
 
   inline T operator()(at::CPUGenerator* generator) {
+    // Follows numpy exponential for the case when lambda is zero.
+    if (lambda == static_cast<T>(0.0)) {
+      return static_cast<T>(0.0);
+    }
     uniform_real_distribution<T> uniform(0.0, 1.0);
     dist_acctype<T> sample = uniform(generator);
     return static_cast<T>(-1.0) / lambda * ::log(static_cast<T>(1.0)-sample);

--- a/aten/src/ATen/native/Distributions.cpp
+++ b/aten/src/ATen/native/Distributions.cpp
@@ -114,6 +114,7 @@ namespace native {
 
 DEFINE_DISPATCH(bernoulli_mkl_stub);
 DEFINE_DISPATCH(cauchy_stub);
+DEFINE_DISPATCH(exponential_stub);
 DEFINE_DISPATCH(multinomial_stub);
 DEFINE_DISPATCH(geometric_stub);
 DEFINE_DISPATCH(log_normal_stub);
@@ -195,6 +196,13 @@ Tensor& log_normal_(Tensor& self, double mean, double std, Generator* gen) {
 Tensor& cauchy_(Tensor& self, double median, double sigma, Generator* gen) {
   auto iter = TensorIterator::nullary_op(self);
   cauchy_stub(iter.device_type(), iter, median, sigma, gen);
+  return self;
+}
+
+Tensor& exponential_(Tensor& self, double lambda, Generator* gen) {
+  TORCH_CHECK(lambda >= 0.0, "exponential_ expects lambda >= 0.0, but found lambda=", lambda);
+  auto iter = TensorIterator::nullary_op(self);
+  exponential_stub(iter.device_type(), iter, lambda, gen);
   return self;
 }
 

--- a/aten/src/ATen/native/UnaryOps.h
+++ b/aten/src/ATen/native/UnaryOps.h
@@ -56,6 +56,7 @@ DECLARE_DISPATCH(unary_fn, lgamma_stub);
 
 DECLARE_DISPATCH(void(*)(Tensor&, const double, Generator *), bernoulli_mkl_stub);
 DECLARE_DISPATCH(void(*)(TensorIterator&, const double, const double, Generator *), cauchy_stub);
+DECLARE_DISPATCH(void(*)(TensorIterator&, const double, Generator *), exponential_stub);
 DECLARE_DISPATCH(void(*)(TensorIterator&, const double, Generator *), geometric_stub);
 DECLARE_DISPATCH(void(*)(TensorIterator&, const double, const double, Generator *), log_normal_stub);
 DECLARE_DISPATCH(void(*)(TensorIterator&, const int64_t), polygamma_stub);

--- a/aten/src/ATen/native/cuda/Distributions.cu
+++ b/aten/src/ATen/native/cuda/Distributions.cu
@@ -539,7 +539,7 @@ void cauchy_kernel(TensorIterator& iter, double median_, double sigma_, Generato
    });
 }
 
-void exponential_kernel_cuda(TensorIterator& iter, double lambda_, Generator* gen_) {
+void exponential_kernel(TensorIterator& iter, double lambda_, Generator* gen_) {
   auto gen = get_generator_or_default<CUDAGenerator>(gen_, cuda::detail::getDefaultCUDAGenerator());
   // Note that HIP doesn't support std::nextafter in device code.
   auto nextafter_1_0_float = std::nextafter(1.0f, 0.0f);
@@ -550,6 +550,9 @@ void exponential_kernel_cuda(TensorIterator& iter, double lambda_, Generator* ge
     if (std::is_same<scalar_t, double>::value) {
       // define lambda for exponential transformation
       auto exponential_func = [lambda, nextafter_1_0_double] __device__ (accscalar_t rand) {
+        if (lambda == static_cast<accscalar_t>(0.0)) {
+          return static_cast<scalar_t>(0.0);
+        }
         accscalar_t sample;
         // curand_uniform has (0,1] bounds. log(1) is 0 and exponential excludes 0.
         // Hence, squash the 1 to just below 1.
@@ -567,6 +570,9 @@ void exponential_kernel_cuda(TensorIterator& iter, double lambda_, Generator* ge
     } else {
       // use __logf fast approximation for peak bandwidth
       auto exponential_func = [lambda, nextafter_1_0_float] __device__ (accscalar_t rand) {
+        if (lambda == static_cast<accscalar_t>(0.0)) {
+          return static_cast<scalar_t>(0.0);
+        }
         accscalar_t sample;
         if(rand == static_cast<accscalar_t>(1.0)) {
           sample = __logf(nextafter_1_0_float);
@@ -752,12 +758,6 @@ Tensor normal_cuda(const Tensor& mean, const Tensor& std, Generator* gen) {
   return ret;
 }
 
-Tensor& exponential_cuda_(Tensor& self, double lambda, Generator* gen) {
-  auto iter = TensorIterator::nullary_op(self);
-  exponential_kernel_cuda(iter, lambda, gen);
-  return self;
-}
-
 Tensor& bernoulli_scalar_cuda_(Tensor &self, double p, Generator* gen) {
   TORCH_CHECK(0 <= p && p <= 1, "bernoulli_ expects p to be in [0, 1], but got p=", p);
   auto iter = TensorIterator::nullary_op(self);
@@ -766,6 +766,7 @@ Tensor& bernoulli_scalar_cuda_(Tensor &self, double p, Generator* gen) {
 }
 
 REGISTER_DISPATCH(cauchy_stub, &cauchy_kernel);
+REGISTER_DISPATCH(exponential_stub, &exponential_kernel);
 REGISTER_DISPATCH(geometric_stub, &geometric_kernel_cuda);
 REGISTER_DISPATCH(log_normal_stub, &log_normal_kernel);
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -4292,9 +4292,6 @@
 
 - func: exponential_(Tensor(a!) self, float lambd=1, *, Generator? generator=None) -> Tensor(a!)
   variants: method
-  dispatch:
-    CPU: legacy::cpu::_th_exponential_
-    CUDA: exponential_cuda_
   supports_named_tensor: True
 
 - func: geometric_(Tensor(a!) self, float p, *, Generator? generator=None) -> Tensor(a!)

--- a/aten/src/TH/generic/THTensorRandom.cpp
+++ b/aten/src/TH/generic/THTensorRandom.cpp
@@ -121,16 +121,6 @@ void THTensor_(normal_means_stddevs)(THTensor *self, THTensor *means, THTensor *
   THTensor_(cadd)(self, self, 1, means);
 }
 
-void THTensor_(exponential)(THTensor *self, double lambda, at::Generator *_generator)
-{
-  auto gen = at::get_generator_or_default<at::CPUGenerator>(_generator, at::detail::getDefaultCPUGenerator());
-  // See Note [Acquire lock when using random generators]
-  std::lock_guard<std::mutex> lock(gen->mutex_);
-
-  at::exponential_distribution<double> exponential(lambda);
-  TH_TENSOR_APPLY(scalar_t, self, *self_data = (scalar_t)exponential(gen););
-}
-
 #undef TH_REAL_MIN
 
 void THTensor_(multinomialAliasSetup)(THTensor *probs, THLongTensor *J, THTensor *q)

--- a/aten/src/TH/generic/THTensorRandom.h
+++ b/aten/src/TH/generic/THTensorRandom.h
@@ -15,7 +15,6 @@ TH_API void THTensor_(normal)(THTensor *self, double mean, double stdv, at::Gene
 TH_API void THTensor_(normal_means)(THTensor *self, THTensor *means, double stddev, at::Generator *gen);
 TH_API void THTensor_(normal_stddevs)(THTensor *self, double mean, THTensor *stddevs, at::Generator *gen);
 TH_API void THTensor_(normal_means_stddevs)(THTensor *self, THTensor *means, THTensor *stddevs, at::Generator *gen);
-TH_API void THTensor_(exponential)(THTensor *self, double lambda, at::Generator *_generator);
 TH_API void THTensor_(multinomialAliasSetup)(THTensor *prob_dist, THLongTensor *J, THTensor *q);
 TH_API void THTensor_(multinomialAliasDraw)(THLongTensor *self, THTensor *q, THLongTensor *J, int n_sample, at::Generator *_generator);
 #endif

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -10176,6 +10176,18 @@ class TestTorchDeviceType(TestCase):
         self.assertEqual(a.dtype, torch.float)
         self.assertEqual(a.size(), torch.Size([1]))
 
+    def test_exponential(self, device):
+        a = torch.tensor([10], dtype=torch.float, device=device).exponential_(0.5)
+        self.assertEqual(a.dtype, torch.float)
+        self.assertEqual(a.size(), torch.Size([1]))
+        expected = torch.tensor([10], dtype=torch.float, device=device).exponential_(0)
+        actual = torch.tensor([0.0], dtype=torch.float, device=device)
+        self.assertTrue(torch.allclose(expected, actual, rtol=0, atol=0))
+        # fail with negative lambda
+        self.assertRaises(RuntimeError, lambda: torch.tensor(
+            [10], dtype=torch.float, device=device).exponential_(-0.5))
+
+
     def test_pairwise_distance_empty(self, device):
         shape = (2, 0)
         x = torch.randn(shape, device=device)
@@ -11066,7 +11078,7 @@ class TestTorchDeviceType(TestCase):
 
         # Check linspace for generating with start > end.
         self.assertEqual(torch.linspace(2, 0, 3, device=device, dtype=dtype),
-                         torch.tensor((2, 1, 0), device=device, dtype=dtype), 
+                         torch.tensor((2, 1, 0), device=device, dtype=dtype),
                          0)
 
         # Check linspace for non-contiguous tensors.


### PR DESCRIPTION
Summary:
This diff will address https://github.com/pytorch/pytorch/issues/24699

We ask the input `lambda` to be >= 0 to be same as https://docs.scipy.org/doc/numpy-1.15.0/reference/generated/numpy.random.exponential.html#numpy-random-exponential. This does not exist in the previous implementation.

Benchmark script
```
import torch
import torch.nn as nn
import time

torch.manual_seed(0)

def _time():
    return time.time()

device = "cpu"

#warm up
for n in [10, 100, 1000]:
    input = torch.randn(128, n, requires_grad=False, device=device)
    for i in range(1000):
        input.exponential_()

for n in [1, 10, 100, 1000]:
    fwd_t = 0
    input = torch.randn(128, n, requires_grad=False, device=device)
    for i in range(10000):
        t1 = _time()
        input.exponential_()
        t2 = _time()
        fwd_t = fwd_t + (t2 -t1)
    fwd_avg = fwd_t / 10000 * 1000
    print("input size(128, %d) forward time is %.4f (ms)." % (n, fwd_avg))
```
Output
```
================================================================================
Before the change, Program Output:
================================================================================
Higher priority item already registered, skipping registration of LINUX
input size(128, 1) forward time is 0.0129 (ms).
input size(128, 10) forward time is 0.1069 (ms).
input size(128, 100) forward time is 1.0409 (ms).
input size(128, 1000) forward time is 10.3827 (ms).
================================================================================
After the change, Program Output:
================================================================================
2020-01-22 10:52:06,406 fbpkg.fetch INFO: completed download of bento_kernel_pytorch:641
2020-01-22 10:52:06,407 fbpkg.fetch INFO: extracted bento_kernel_pytorch:641 to bento_kernel_pytorch
All packages downloaded successfully
Higher priority item already registered, skipping registration of LINUX
input size(128, 1) forward time is 0.0129 (ms).
input size(128, 10) forward time is 0.1065 (ms).
input size(128, 100) forward time is 1.0374 (ms).
input size(128, 1000) forward time is 10.3569 (ms).
================================================================================
```

Test Plan: Sandcastle and Github tests

Differential Revision: D19518700

