### PR TITLE
[JIT] Fix custom C++ classes to not call the __init__ wrapper in script

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -4764,6 +4764,11 @@ def foo(x):
             return ss, clone
 
         scripted = torch.jit.script(foo)
+        # Ensure we are creating the object and calling __init__
+        # rather than calling the __init__wrapper nonsense
+        fc = FileCheck().check('prim::CreateObject()')\
+                        .check('prim::CallMethod[name="__init__"]')
+        fc.run(str(scripted.graph))
         out = scripted()
         self.assertEqual(out[0].pop(), "hi")
         self.assertEqual(out[1].pop(), "mom")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #32514 Revert "Remove __torch__ from custom class qualname"
* **#32513 [JIT] Fix custom C++ classes to not call the __init__ wrapper in script**
* #32508 [JIT] Add torch.classes.load_library
* #32477 [JIT] Support returning tuple from custom bound C++ method
* #32471 [JIT] Fix custom class method binding for const methods
* #32470 [JIT] Test __getstate__ and __setstate__ for custom bound C++ classes
* #32260 [JIT] Passing custom class as arg

Differential Revision: [D19525174](https://our.internmc.facebook.com/intern/diff/D19525174)