### PR TITLE
API for testing bailouts

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -3981,6 +3981,30 @@ class TestFrontend(JitTestCase):
 
 
 class TestScript(JitTestCase):
+
+    def test_request_bailout(self):
+        with enable_profiling_mode():
+
+            def fct_loop(x):
+                for i in range(3):
+                    x = torch.cat((x, x), 0)
+                return x
+
+            x = torch.ones(2, 3, 4, dtype=torch.float32)
+            expected = fct_loop(x)
+            jitted = torch.jit.script(fct_loop)
+            # profile
+            jitted(x)
+            # optimize
+            jitted(x)
+            dstate = jitted.get_debug_state()
+            eplan = get_execution_plan(dstate)
+            num_bailouts = eplan.code.num_bailouts()
+
+            for i in range(0, num_bailouts):
+                eplan.code.request_bailout(i)
+                self.assertEqual(jitted(x), expected)
+
     def test_nested_bailouts(self):
         @torch.jit.script
         def fct_loop(x):

--- a/torch/csrc/jit/init.cpp
+++ b/torch/csrc/jit/init.cpp
@@ -404,13 +404,20 @@ void initJITBindings(PyObject* module) {
       });
   // NOLINTNEXTLINE(bugprone-unused-raii)
   py::class_<ArgumentSpec>(m, "ArgumentSpec");
-  py::class_<Code>(m, "Code").def("grad_executor_states", [](Code& c) {
-    std::vector<GraphExecutorState> states;
-    for (auto& e : c.grad_executors()) {
-      states.emplace_back(e->getDebugState());
-    }
-    return states;
-  });
+  py::class_<Code>(m, "Code")
+      .def(
+          "grad_executor_states",
+          [](Code& c) {
+            std::vector<GraphExecutorState> states;
+            for (auto& e : c.grad_executors()) {
+              states.emplace_back(e->getDebugState());
+            }
+            return states;
+          })
+      .def("num_bailouts", [](Code& c) { return c.num_bailouts(); })
+      .def("request_bailout", [](Code& c, size_t index) {
+        c.request_bailout(index);
+      });
 
   py::class_<ExecutionPlan>(m, "ExecutionPlan")
       .def_property_readonly("graph", [](ExecutionPlan& s) { return s.graph; })

--- a/torch/csrc/jit/instruction.h
+++ b/torch/csrc/jit/instruction.h
@@ -33,7 +33,8 @@ namespace jit {
   _(RET, "") /* exit execution */                                           \
   _(WAIT, "") /* wait for a future to be complete */                        \
   _(CALL, "F") /* call function X */                                        \
-  _(GUARD, "T") /* check guard against type_table, true if passes */        \
+  _(GUARD, "T") /* check a guard against type_table, true if passes */      \
+  _(FAIL_GUARD, "T") /* fail a guard, patch back to GUARD */                \
   _(TAIL_CALL, "F") /* replace current frame with function F */             \
   _(INTERFACE_CALL, "CI") /* call method X on the first argument (of N) */  \
   _(GET_ATTR, "S") /* get attribute from slot X in an Object */             \

--- a/torch/csrc/jit/interpreter.cpp
+++ b/torch/csrc/jit/interpreter.cpp
@@ -1046,9 +1046,10 @@ struct InterpreterStateImpl : c10::intrusive_ptr_target {
             ++af.pc;
           } break;
           case GUARD: {
+
             if (frames.back().function->bailout_requests_.count(inst.X) != 0) {
               GRAPH_DEBUG(
-                "Bailout ", inst.X, " triggered via bailout_requests_!");
+                  "Bailout ", inst.X, " triggered via bailout_requests_!");
               frames.back().function->bailout_requests_.erase(inst.X);
               push(stack, false);
             } else {

--- a/torch/csrc/jit/interpreter.cpp
+++ b/torch/csrc/jit/interpreter.cpp
@@ -10,8 +10,9 @@
 #include <torch/csrc/jit/constants.h>
 #include <torch/csrc/jit/exception_message.h>
 #include <torch/csrc/jit/graph_executor.h>
-#include <torch/csrc/jit/ir.h>
 #include <torch/csrc/jit/instruction.h>
+#include <torch/csrc/jit/ir.h>
+#include <torch/csrc/jit/jit_log.h>
 #include <torch/csrc/jit/operator.h>
 #include <torch/csrc/jit/passes/bailout_graph.h>
 #include <torch/csrc/jit/script/compilation_unit.h>
@@ -352,6 +353,7 @@ struct CodeImpl {
   std::vector<Operation> operator_table_;
   std::vector<Function*> function_table_;
   std::vector<TypePtr> type_table_;
+  std::unordered_set<size_t> bailout_requests_;
   int register_size_ = 0;
   size_t n_outputs;
   size_t n_inputs;
@@ -1044,13 +1046,21 @@ struct InterpreterStateImpl : c10::intrusive_ptr_target {
             ++af.pc;
           } break;
           case GUARD: {
-            auto t = stack.back().toTensor();
-            auto actual = tensorTypeInCurrentExecutionContext(t);
-            const TypePtr& expected = af.types[inst.X];
-            push(stack, *expected == *actual);
+            if (frames.back().function->bailout_requests_.count(inst.X) != 0) {
+              GRAPH_DEBUG(
+                "Bailout ", inst.X, " triggered via bailout_requests_!");
+              frames.back().function->bailout_requests_.erase(inst.X);
+              push(stack, false);
+            } else {
+              auto t = stack.back().toTensor();
+              auto actual = tensorTypeInCurrentExecutionContext(t);
+              const TypePtr& expected = af.types[inst.X];
+              push(stack, *expected == *actual);
+            }
             ++af.pc;
           } break;
           case TAIL_CALL: {
+            GRAPH_DEBUG("running TAIL_CALL for ", inst.X);
             af.functions[inst.X]->ensure_defined();
             size_t remaining_bailout_depth =
                 frames.back().function->remaining_bailout_depth_ > 0
@@ -1170,6 +1180,15 @@ Code::~Code() = default;
 
 const std::vector<GraphExecutor*>& Code::grad_executors() {
   return pImpl->grad_executors();
+}
+
+size_t Code::num_bailouts() const {
+  return pImpl->type_table_.size();
+}
+
+void Code::request_bailout(size_t index) {
+  pImpl->bailout_requests_.insert(index);
+  GRAPH_DEBUG("Added a bailout request for ", index);
 }
 
 size_t Code::num_inputs() const {

--- a/torch/csrc/jit/interpreter.h
+++ b/torch/csrc/jit/interpreter.h
@@ -48,11 +48,12 @@ struct TORCH_API Code {
   }
   size_t num_inputs() const;
   size_t num_outputs() const;
+  size_t num_bailouts() const;
   const std::vector<c10::IValue>& constant_table() const;
   const std::vector<Instruction>& instructions() const;
   const std::vector<Node*>& instructions_source() const;
+  void request_bailout(size_t index);
   size_t register_size() const;
-
  private:
   std::shared_ptr<CodeImpl> pImpl;
   friend struct InterpreterStateImpl;


### PR DESCRIPTION
This API seems to be quite useful to make sure all bailouts in a graph are triggered. I used it for testing torchvision models and I was wondering if this might be something we might actually want to have? @zdevito 