### PR TITLE
Cummax and Cummin doc update and performance benchmark

### DIFF
--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -237,7 +237,8 @@ Tensor& cumprod_out(Tensor& result, const Tensor& self, int64_t dim, c10::option
 
 template<typename T1, typename T2, typename Operation>
 void cummax_cummin_helper(const T1* self_data, T1* values_data, T2* indices_data,
-          int self_dim_size, int self_stride, int values_stride, int indices_stride, Operation op) {
+          int self_dim_size, int self_stride, int values_stride, int indices_stride) {
+      Operation op;
       T1 out = self_data[0];
       int idx = 0;
       for(int i = 0; i < self_dim_size; i++) {
@@ -252,10 +253,10 @@ void cummax_cummin_helper(const T1* self_data, T1* values_data, T2* indices_data
 }
 
 void cummax_helper_cpu(const Tensor& self, Tensor& values, Tensor& indices, int64_t dim) {
-  AT_DISPATCH_ALL_TYPES_AND2(at::ScalarType::Bool, at::ScalarType::Half,
+  AT_DISPATCH_ALL_TYPES_AND(at::ScalarType::Bool,
     self.scalar_type(), "cummax_cpu",
     [&] {
-      at::native::tensor_dim_apply3<scalar_t, int64_t>(self, values, indices, dim, std::greater_equal<scalar_t>(), cummax_cummin_helper<scalar_t, int64_t, std::greater_equal<scalar_t>>);
+      at::native::tensor_dim_apply3<scalar_t, int64_t>(self, values, indices, dim, cummax_cummin_helper<scalar_t, int64_t, std::greater_equal<scalar_t>>);
     });
 }
 
@@ -287,10 +288,10 @@ std::tuple<Tensor, Tensor> cummax(const Tensor& self, int64_t dim) {
 }
 
 void cummin_helper_cpu(const Tensor& self, Tensor& values, Tensor& indices, int64_t dim) {
-  AT_DISPATCH_ALL_TYPES_AND2(at::ScalarType::Bool, at::ScalarType::Half,
+  AT_DISPATCH_ALL_TYPES_AND(at::ScalarType::Bool,
     self.scalar_type(), "cummin_cpu",
     [&] {
-      at::native::tensor_dim_apply3<scalar_t, int64_t>(self, values, indices, dim, std::less_equal<scalar_t>(), cummax_cummin_helper<scalar_t, int64_t, std::less_equal<scalar_t>>);
+      at::native::tensor_dim_apply3<scalar_t, int64_t>(self, values, indices, dim, cummax_cummin_helper<scalar_t, int64_t, std::less_equal<scalar_t>>);
     });
 }
 

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -240,7 +240,7 @@ std::tuple<Tensor&, Tensor&> cummax_out(Tensor& values, Tensor& indices, const T
     values.resize_(self.sizes());
     indices.resize_(self.sizes());
     if(self.dim() == 0) {
-      values.fill_(self.item());
+      values.fill_(self);
       indices.fill_(0);
     }
     else if(self.numel() != 0) {
@@ -258,14 +258,14 @@ std::tuple<Tensor&, Tensor&> cummax_out(Tensor& values, Tensor& indices, const T
   }
   namedinference::propagate_names(values, self);
   namedinference::propagate_names(indices, self);
-  return std::tuple<Tensor &,Tensor &>{values, indices};
+  return std::forward_as_tuple(values, indices);
 }
 
 std::tuple<Tensor, Tensor> cummax(const Tensor& self, int64_t dim) {
   auto values = at::empty(self.sizes(), self.options());
   auto indices = at::empty(self.sizes(), self.options().dtype(at::kLong));
   at::cummax_out(values, indices, self, dim);
-  return std::tuple<Tensor &,Tensor &>{values, indices};
+  return std::make_tuple(values, indices);
 }
 
 std::tuple<Tensor&, Tensor&> cummin_out(Tensor& values, Tensor& indices, const Tensor& self, int64_t dim) {
@@ -276,7 +276,7 @@ std::tuple<Tensor&, Tensor&> cummin_out(Tensor& values, Tensor& indices, const T
     values.resize_(self.sizes());
     indices.resize_(self.sizes());
     if(self.dim() == 0) {
-      values.fill_(self.item());
+      values.fill_(self);
       indices.fill_(0);
     }
     else if(self.numel() != 0) {
@@ -294,14 +294,14 @@ std::tuple<Tensor&, Tensor&> cummin_out(Tensor& values, Tensor& indices, const T
   }
   namedinference::propagate_names(values, self);
   namedinference::propagate_names(indices, self);
-  return std::tuple<Tensor &,Tensor &>{values, indices};
+  return std::forward_as_tuple(values, indices);
 }
 
 std::tuple<Tensor, Tensor> cummin(const Tensor& self, int64_t dim) {
   auto values = at::empty(self.sizes(), self.options());
   auto indices = at::empty(self.sizes(), self.options().dtype(at::kLong));
   at::cummin_out(values, indices, self, dim);
-  return std::tuple<Tensor &,Tensor &>{values, indices};
+  return std::make_tuple(values, indices);
 }
 // ALL REDUCE #################################################################
 

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -9,6 +9,7 @@
 #include <ATen/native/TensorIterator.h>
 #include <ATen/NamedTensorUtils.h>
 #include <ATen/native/TensorDimApply.h>
+#include <ATen/native/SharedReduceOps.h>
 
 #include <algorithm>
 #include <functional>
@@ -232,24 +233,48 @@ Tensor& cumprod_out(Tensor& result, const Tensor& self, int64_t dim, c10::option
   return result;
 }
 
-void cummax_helper_cpu(const Tensor& self, Tensor& values, Tensor& indices, int64_t dim) {
+template<typename Operation>
+void cummax_cummin_helper(const Tensor& self, Tensor& values, Tensor& indices, int64_t dim, Operation op, const std::string& op_name) {
   AT_DISPATCH_ALL_TYPES_AND2(at::ScalarType::Bool, at::ScalarType::Half,
-    self.scalar_type(), "cummax_cpu", [&]() -> void {
-    at::native::tensor_dim_apply3<scalar_t, scalar_t, int64_t>(self, values, indices, dim,
-      [](const scalar_t* self_data, scalar_t* values_data, int64_t* indices_data,
-        int self_dim_size, int self_stride, int values_stride, int indices_stride) {
-        auto cummax = self_data[0];
+    self.scalar_type(), op_name, [&]() -> void {
+      at::native::tensor_dim_apply3<scalar_t, int64_t>(self, values, indices, dim, op,
+        [](const scalar_t* self_data, scalar_t* values_data, int64_t* indices_data,
+          int self_dim_size, int self_stride, int values_stride, int indices_stride, Operation op) {
+        scalar_t out = self_data[0];
         int idx = 0;
         for(int i = 0; i < self_dim_size; i++) {
-          if(self_data[i*self_stride] >= cummax) {
-                cummax = self_data[i*self_stride];
-                idx = i;
-            }
-            values_data[i*values_stride] = cummax;
-            indices_data[i*indices_stride] = idx;
+          scalar_t curr_elem = self_data[i*self_stride];
+          if(std::isnan(curr_elem) || (!std::isnan(out) && op(curr_elem, out))) {
+              out = self_data[i*self_stride];
+              idx = i;
+          }
+          values_data[i*values_stride] = out;
+          indices_data[i*indices_stride] = idx;
         }
       });
   });
+}
+
+void cummax_helper_cpu(const Tensor& self, Tensor& values, Tensor& indices, int64_t dim) {
+  cummax_cummin_helper(self, values, indices, dim, std::greater_equal<self.dtype()>(), "cummax_cpu");
+  // AT_DISPATCH_ALL_TYPES_AND2(at::ScalarType::Bool, at::ScalarType::Half,
+  //   self.scalar_type(), "cummax_cpu", [&]() -> void {
+  //     at::native::tensor_dim_apply3<scalar_t, int64_t>(self, values, indices, dim,
+  //       [](const scalar_t* self_data, scalar_t* values_data, int64_t* indices_data,
+  //         int self_dim_size, int self_stride, int values_stride, int indices_stride) {
+  //       scalar_t cummax = self_data[0];
+  //       int idx = 0;
+  //       for(int i = 0; i < self_dim_size; i++) {
+  //         scalar_t curr_elem = self_data[i*self_stride];
+  //         if(std::isnan(curr_elem) || (!std::isnan(cummax) && std::greater_equal<scalar_t>()(curr_elem, cummax))) {
+  //             cummax = self_data[i*self_stride];
+  //             idx = i;
+  //         }
+  //         values_data[i*values_stride] = cummax;
+  //         indices_data[i*indices_stride] = idx;
+  //       }
+  //     });
+  // });
 }
 
 std::tuple<Tensor&, Tensor&> cummax_out(Tensor& values, Tensor& indices, const Tensor& self, int64_t dim) {
@@ -280,23 +305,23 @@ std::tuple<Tensor, Tensor> cummax(const Tensor& self, int64_t dim) {
 }
 
 void cummin_helper_cpu(const Tensor& self, Tensor& values, Tensor& indices, int64_t dim) {
-    AT_DISPATCH_ALL_TYPES_AND2(at::ScalarType::Bool, at::ScalarType::Half,
-      self.scalar_type(), "cummin_cpu", [&]() -> void {
-      at::native::tensor_dim_apply3<scalar_t, scalar_t, int64_t>(self, values, indices, dim,
-        [](const scalar_t* self_data, scalar_t* values_data, int64_t* indices_data,
-          int self_dim_size, int self_stride, int values_stride, int indices_stride) {
-            auto cummin = self_data[0];
-            int idx = 0;
-            for(int i = 0; i < self_dim_size; i++) {
-              if(self_data[i*self_stride] <= cummin) {
-                cummin = self_data[i*self_stride];
-                idx = i;
-              }
-              values_data[i*values_stride] = cummin;
-              indices_data[i*indices_stride] = idx;
-            }
-        });
-    });
+    // AT_DISPATCH_ALL_TYPES_AND2(at::ScalarType::Bool, at::ScalarType::Half,
+    //   self.scalar_type(), "cummin_cpu", [&]() -> void {
+    //   at::native::tensor_dim_apply3<scalar_t, int64_t>(self, values, indices, dim,
+    //     [](const scalar_t* self_data, scalar_t* values_data, int64_t* indices_data,
+    //       int self_dim_size, int self_stride, int values_stride, int indices_stride) {
+    //         auto cummin = self_data[0];
+    //         int idx = 0;
+    //         for(int i = 0; i < self_dim_size; i++) {
+    //           if(self_data[i*self_stride] <= cummin || std::isnan(self_data[i*self_stride])) {
+    //             cummin = self_data[i*self_stride];
+    //             idx = i;
+    //           }
+    //           values_data[i*values_stride] = cummin;
+    //           indices_data[i*indices_stride] = idx;
+    //         }
+    //     });
+    // });
 }
 
 std::tuple<Tensor&, Tensor&> cummin_out(Tensor& values, Tensor& indices, const Tensor& self, int64_t dim) {

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -235,7 +235,7 @@ Tensor& cumprod_out(Tensor& result, const Tensor& self, int64_t dim, c10::option
 void cummax_helper_cpu(const Tensor& self, Tensor& values, Tensor& indices, int64_t dim) {
   AT_DISPATCH_ALL_TYPES_AND2(at::ScalarType::Bool, at::ScalarType::Half,
     self.scalar_type(), "cummax_cpu", [&]() -> void {
-    at::native::tensor_dim_apply3<scalar_t, scalar_t>(self, values, indices, dim,
+    at::native::tensor_dim_apply3<scalar_t, scalar_t, int64_t>(self, values, indices, dim,
       [](const scalar_t* self_data, scalar_t* values_data, int64_t* indices_data,
         int self_dim_size, int self_stride, int values_stride, int indices_stride) {
         auto cummax = self_data[0];
@@ -282,7 +282,7 @@ std::tuple<Tensor, Tensor> cummax(const Tensor& self, int64_t dim) {
 void cummin_helper_cpu(const Tensor& self, Tensor& values, Tensor& indices, int64_t dim) {
     AT_DISPATCH_ALL_TYPES_AND2(at::ScalarType::Bool, at::ScalarType::Half,
       self.scalar_type(), "cummin_cpu", [&]() -> void {
-      at::native::tensor_dim_apply3<scalar_t, scalar_t>(self, values, indices, dim,
+      at::native::tensor_dim_apply3<scalar_t, scalar_t, int64_t>(self, values, indices, dim,
         [](const scalar_t* self_data, scalar_t* values_data, int64_t* indices_data,
           int self_dim_size, int self_stride, int values_stride, int indices_stride) {
             auto cummin = self_data[0];

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -17,6 +17,8 @@
 #include <numeric>
 #include <vector>
 #include <map>
+#include <cmath>
+#include <cfloat>
 
 namespace at {
 namespace native {

--- a/aten/src/ATen/native/TensorDimApply.h
+++ b/aten/src/ATen/native/TensorDimApply.h
@@ -3,8 +3,8 @@
 namespace at {
   namespace native {
     //input tensors are non-zero dim and non-empty
-    template<typename T1, typename T2, typename Operation, typename Function>
-    void tensor_dim_apply3(const Tensor& self, Tensor& values, Tensor& indices, int64_t dim, Operation op, Function func) {
+    template<typename T1, typename T2, typename Function>
+    void tensor_dim_apply3(const Tensor& self, Tensor& values, Tensor& indices, int64_t dim, Function func) {
       int ndims = self.dim();
       int tensor_dim_apply_has_finished = 0;
       std::vector<int64_t> counter(ndims, 0);
@@ -17,7 +17,7 @@ namespace at {
       int self_dim_size = self.size(dim);
 
       while(!tensor_dim_apply_has_finished) {
-        func(self_data, values_data, indices_data, self_dim_size, self_stride, values_stride, indices_stride, op);
+        func(self_data, values_data, indices_data, self_dim_size, self_stride, values_stride, indices_stride);
         if(ndims == 1)
            break;
         for(int dim_i = 0; dim_i < ndims; dim_i++) {

--- a/aten/src/ATen/native/TensorDimApply.h
+++ b/aten/src/ATen/native/TensorDimApply.h
@@ -1,70 +1,66 @@
+#include <ATen/ATen.h>
+#include <ATen/ExpandUtils.h>
+#include <ATen/NativeFunctions.h>
+
+#include <algorithm>
+#include <functional>
+#include <numeric>
+#include <vector>
+
 namespace at {
   namespace native {
-    #define TENSOR_DIM_APPLY3(type1, tensor1, type2, tensor2, type3, tensor3, dim, code) \
-    { \
-      dim = maybe_wrap_dim(dim, tensor1.dim()); \
-      int ndims = tensor1.dim();\
-      if(ndims == 0) { \
-        tensor2.fill_(tensor1); \
-        tensor3.fill_(0); \
-      } \
-      else if(tensor1.numel() != 0) { \
-        int tensor_dim_apply_has_finished = 0; \
-        int tensor_dim_apply_i; \
-        int TENSOR_DIM_APPLY_i;\
-        int64_t tensor_dim_apply_counter[ndims];\
-        for(tensor_dim_apply_i = 0; tensor_dim_apply_i < ndims; tensor_dim_apply_i++) \
-          tensor_dim_apply_counter[tensor_dim_apply_i] = 0; \
-      \
-        type1* tensor1##_data = tensor1.data_ptr<type1>();\
-        type2* tensor2##_data = tensor2.data_ptr<type2>();\
-        type3* tensor3##_data = tensor3.data_ptr<type3>();\
-        int64_t tensor1##_stride = tensor1.stride(dim);\
-        int64_t tensor2##_stride = tensor2.stride(dim);\
-        int64_t tensor3##_stride = tensor3.stride(dim);\
-        while(!tensor_dim_apply_has_finished) \
-        { \
-          code \
-        \
-          if(ndims == 1) \
-             break; \
-        \
-          for(tensor_dim_apply_i = 0; tensor_dim_apply_i < ndims; tensor_dim_apply_i++) \
-          { \
-            if(tensor_dim_apply_i == dim) \
-            { \
-              if(tensor_dim_apply_i == (ndims - 1)) \
-              { \
-                tensor_dim_apply_has_finished = 1; \
-                break; \
-              } \
-              continue; \
-            } \
-            tensor_dim_apply_counter[tensor_dim_apply_i]++; \
-            tensor1##_data += tensor1.stride(tensor_dim_apply_i); \
-            tensor2##_data += tensor2.stride(tensor_dim_apply_i); \
-            tensor3##_data += tensor3.stride(tensor_dim_apply_i); \
-            \
-            if(tensor_dim_apply_counter[tensor_dim_apply_i] == tensor1.size(tensor_dim_apply_i)) \
-            { \
-              if(tensor_dim_apply_i == ndims-1) \
-              { \
-                tensor_dim_apply_has_finished = 1; \
-                break; \
-              } \
-              else \
-              { \
-                tensor1##_data -= tensor_dim_apply_counter[tensor_dim_apply_i]*tensor1.stride(tensor_dim_apply_i); \
-                tensor2##_data -= tensor_dim_apply_counter[tensor_dim_apply_i]*tensor1.stride(tensor_dim_apply_i); \
-                tensor3##_data -= tensor_dim_apply_counter[tensor_dim_apply_i]*tensor3.stride(tensor_dim_apply_i); \
-                tensor_dim_apply_counter[tensor_dim_apply_i] = 0; \
-              } \
-            } \
-            else \
-              break; \
-          } \
-        } \
-      }\
+    template<typename T1, typename T2, typename Operation>
+    void tensor_dim_apply3(const Tensor& self, Tensor& values, Tensor& indices, int64_t dim, Operation op) {
+      int ndims = self.dim();
+      if(ndims == 0) {
+        values.fill_(self);
+        indices.fill_(0);
+      } else if(self.numel() != 0) {
+        int tensor_dim_apply_has_finished = 0;
+        int tensor_dim_apply_i;
+        int64_t tensor_dim_apply_counter[ndims];
+        for(tensor_dim_apply_i = 0; tensor_dim_apply_i < ndims; tensor_dim_apply_i++)
+          tensor_dim_apply_counter[tensor_dim_apply_i] = 0;
+        T1* self_data = self.data_ptr<T1>();
+        T2* values_data = values.data_ptr<T2>();
+        int64_t* indices_data = indices.data_ptr<int64_t>();
+        int64_t self_stride = self.stride(dim);
+        int64_t values_stride = values.stride(dim);
+        int64_t indices_stride = indices.stride(dim);
+        int self_dim_size = self.size(dim);
+
+        while(!tensor_dim_apply_has_finished) {
+          op(self_data, values_data, indices_data, self_dim_size, self_stride, values_stride, indices_stride);
+          if(ndims == 1)
+             break;
+          for(tensor_dim_apply_i = 0; tensor_dim_apply_i < ndims; tensor_dim_apply_i++) {
+            if(tensor_dim_apply_i == dim) {
+              if(tensor_dim_apply_i == (ndims - 1)) {
+                tensor_dim_apply_has_finished = 1;
+                break;
+              }
+              continue;
+            }
+            tensor_dim_apply_counter[tensor_dim_apply_i]++;
+            self_data += self.stride(tensor_dim_apply_i);
+            values_data += values.stride(tensor_dim_apply_i);
+            indices_data += indices.stride(tensor_dim_apply_i);
+
+            if(tensor_dim_apply_counter[tensor_dim_apply_i] == self.size(tensor_dim_apply_i)) {
+              if(tensor_dim_apply_i == ndims-1) {
+                tensor_dim_apply_has_finished = 1;
+                break;
+              } else {
+                self_data -= tensor_dim_apply_counter[tensor_dim_apply_i]*self.stride(tensor_dim_apply_i);
+                values_data -= tensor_dim_apply_counter[tensor_dim_apply_i]*values.stride(tensor_dim_apply_i);
+                indices_data -= tensor_dim_apply_counter[tensor_dim_apply_i]*indices.stride(tensor_dim_apply_i);
+                tensor_dim_apply_counter[tensor_dim_apply_i] = 0;
+              }
+            } else {
+              break;
+           }
+          }
+        }
+      }
     }
-  }
-}
+}}

--- a/aten/src/ATen/native/TensorDimApply.h
+++ b/aten/src/ATen/native/TensorDimApply.h
@@ -1,0 +1,70 @@
+namespace at {
+  namespace native {
+    #define TENSOR_DIM_APPLY3(type1, tensor1, type2, tensor2, type3, tensor3, dim, code) \
+    { \
+      dim = maybe_wrap_dim(dim, tensor1.dim()); \
+      int ndims = tensor1.dim();\
+      if(ndims == 0) { \
+        tensor2.fill_(tensor1); \
+        tensor3.fill_(0); \
+      } \
+      else if(tensor1.numel() != 0) { \
+        int tensor_dim_apply_has_finished = 0; \
+        int tensor_dim_apply_i; \
+        int TENSOR_DIM_APPLY_i;\
+        int64_t tensor_dim_apply_counter[ndims];\
+        for(tensor_dim_apply_i = 0; tensor_dim_apply_i < ndims; tensor_dim_apply_i++) \
+          tensor_dim_apply_counter[tensor_dim_apply_i] = 0; \
+      \
+        type1* tensor1##_data = tensor1.data_ptr<type1>();\
+        type2* tensor2##_data = tensor2.data_ptr<type2>();\
+        type3* tensor3##_data = tensor3.data_ptr<type3>();\
+        int64_t tensor1##_stride = tensor1.stride(dim);\
+        int64_t tensor2##_stride = tensor2.stride(dim);\
+        int64_t tensor3##_stride = tensor3.stride(dim);\
+        while(!tensor_dim_apply_has_finished) \
+        { \
+          code \
+        \
+          if(ndims == 1) \
+             break; \
+        \
+          for(tensor_dim_apply_i = 0; tensor_dim_apply_i < ndims; tensor_dim_apply_i++) \
+          { \
+            if(tensor_dim_apply_i == dim) \
+            { \
+              if(tensor_dim_apply_i == (ndims - 1)) \
+              { \
+                tensor_dim_apply_has_finished = 1; \
+                break; \
+              } \
+              continue; \
+            } \
+            tensor_dim_apply_counter[tensor_dim_apply_i]++; \
+            tensor1##_data += tensor1.stride(tensor_dim_apply_i); \
+            tensor2##_data += tensor2.stride(tensor_dim_apply_i); \
+            tensor3##_data += tensor3.stride(tensor_dim_apply_i); \
+            \
+            if(tensor_dim_apply_counter[tensor_dim_apply_i] == tensor1.size(tensor_dim_apply_i)) \
+            { \
+              if(tensor_dim_apply_i == ndims-1) \
+              { \
+                tensor_dim_apply_has_finished = 1; \
+                break; \
+              } \
+              else \
+              { \
+                tensor1##_data -= tensor_dim_apply_counter[tensor_dim_apply_i]*tensor1.stride(tensor_dim_apply_i); \
+                tensor2##_data -= tensor_dim_apply_counter[tensor_dim_apply_i]*tensor1.stride(tensor_dim_apply_i); \
+                tensor3##_data -= tensor_dim_apply_counter[tensor_dim_apply_i]*tensor3.stride(tensor_dim_apply_i); \
+                tensor_dim_apply_counter[tensor_dim_apply_i] = 0; \
+              } \
+            } \
+            else \
+              break; \
+          } \
+        } \
+      }\
+    }
+  }
+}

--- a/aten/src/ATen/native/TensorDimApply.h
+++ b/aten/src/ATen/native/TensorDimApply.h
@@ -3,7 +3,7 @@
 namespace at {
   namespace native {
     //input tensors are non-zero dim and non-empty
-    template<typename T1, typename T2, typename Function, typename Operation>
+    template<typename T1, typename T2, typename Operation, typename Function>
     void tensor_dim_apply3(const Tensor& self, Tensor& values, Tensor& indices, int64_t dim, Operation op, Function func) {
       int ndims = self.dim();
       int tensor_dim_apply_has_finished = 0;

--- a/aten/src/ATen/native/TensorDimApply.h
+++ b/aten/src/ATen/native/TensorDimApply.h
@@ -1,65 +1,54 @@
 #include <ATen/ATen.h>
-#include <ATen/ExpandUtils.h>
-#include <ATen/NativeFunctions.h>
-
-#include <algorithm>
-#include <functional>
-#include <numeric>
-#include <vector>
 
 namespace at {
   namespace native {
+    //input tensors are non-zero dim and non-empty
     template<typename T1, typename T2, typename Operation>
     void tensor_dim_apply3(const Tensor& self, Tensor& values, Tensor& indices, int64_t dim, Operation op) {
       int ndims = self.dim();
-      if(ndims == 0) {
-        values.fill_(self);
-        indices.fill_(0);
-      } else if(self.numel() != 0) {
-        int tensor_dim_apply_has_finished = 0;
-        int tensor_dim_apply_i;
-        int64_t tensor_dim_apply_counter[ndims];
-        for(tensor_dim_apply_i = 0; tensor_dim_apply_i < ndims; tensor_dim_apply_i++)
-          tensor_dim_apply_counter[tensor_dim_apply_i] = 0;
-        T1* self_data = self.data_ptr<T1>();
-        T2* values_data = values.data_ptr<T2>();
-        int64_t* indices_data = indices.data_ptr<int64_t>();
-        int64_t self_stride = self.stride(dim);
-        int64_t values_stride = values.stride(dim);
-        int64_t indices_stride = indices.stride(dim);
-        int self_dim_size = self.size(dim);
+      int tensor_dim_apply_has_finished = 0;
+      int tensor_dim_apply_i;
+      int64_t tensor_dim_apply_counter[ndims];
+      for(tensor_dim_apply_i = 0; tensor_dim_apply_i < ndims; tensor_dim_apply_i++)
+        tensor_dim_apply_counter[tensor_dim_apply_i] = 0;
+      T1* self_data = self.data_ptr<T1>();
+      T2* values_data = values.data_ptr<T2>();
+      int64_t* indices_data = indices.data_ptr<int64_t>();
+      int64_t self_stride = self.stride(dim);
+      int64_t values_stride = values.stride(dim);
+      int64_t indices_stride = indices.stride(dim);
+      int self_dim_size = self.size(dim);
 
-        while(!tensor_dim_apply_has_finished) {
-          op(self_data, values_data, indices_data, self_dim_size, self_stride, values_stride, indices_stride);
-          if(ndims == 1)
-             break;
-          for(tensor_dim_apply_i = 0; tensor_dim_apply_i < ndims; tensor_dim_apply_i++) {
-            if(tensor_dim_apply_i == dim) {
-              if(tensor_dim_apply_i == (ndims - 1)) {
-                tensor_dim_apply_has_finished = 1;
-                break;
-              }
-              continue;
-            }
-            tensor_dim_apply_counter[tensor_dim_apply_i]++;
-            self_data += self.stride(tensor_dim_apply_i);
-            values_data += values.stride(tensor_dim_apply_i);
-            indices_data += indices.stride(tensor_dim_apply_i);
-
-            if(tensor_dim_apply_counter[tensor_dim_apply_i] == self.size(tensor_dim_apply_i)) {
-              if(tensor_dim_apply_i == ndims-1) {
-                tensor_dim_apply_has_finished = 1;
-                break;
-              } else {
-                self_data -= tensor_dim_apply_counter[tensor_dim_apply_i]*self.stride(tensor_dim_apply_i);
-                values_data -= tensor_dim_apply_counter[tensor_dim_apply_i]*values.stride(tensor_dim_apply_i);
-                indices_data -= tensor_dim_apply_counter[tensor_dim_apply_i]*indices.stride(tensor_dim_apply_i);
-                tensor_dim_apply_counter[tensor_dim_apply_i] = 0;
-              }
-            } else {
+      while(!tensor_dim_apply_has_finished) {
+        op(self_data, values_data, indices_data, self_dim_size, self_stride, values_stride, indices_stride);
+        if(ndims == 1)
+           break;
+        for(tensor_dim_apply_i = 0; tensor_dim_apply_i < ndims; tensor_dim_apply_i++) {
+          if(tensor_dim_apply_i == dim) {
+            if(tensor_dim_apply_i == (ndims - 1)) {
+              tensor_dim_apply_has_finished = 1;
               break;
-           }
+            }
+            continue;
           }
+          tensor_dim_apply_counter[tensor_dim_apply_i]++;
+          self_data += self.stride(tensor_dim_apply_i);
+          values_data += values.stride(tensor_dim_apply_i);
+          indices_data += indices.stride(tensor_dim_apply_i);
+
+          if(tensor_dim_apply_counter[tensor_dim_apply_i] == self.size(tensor_dim_apply_i)) {
+            if(tensor_dim_apply_i == ndims-1) {
+              tensor_dim_apply_has_finished = 1;
+              break;
+            } else {
+              self_data -= tensor_dim_apply_counter[tensor_dim_apply_i]*self.stride(tensor_dim_apply_i);
+              values_data -= tensor_dim_apply_counter[tensor_dim_apply_i]*values.stride(tensor_dim_apply_i);
+              indices_data -= tensor_dim_apply_counter[tensor_dim_apply_i]*indices.stride(tensor_dim_apply_i);
+              tensor_dim_apply_counter[tensor_dim_apply_i] = 0;
+            }
+          } else {
+            break;
+         }
         }
       }
     }

--- a/aten/src/ATen/native/TensorDimApply.h
+++ b/aten/src/ATen/native/TensorDimApply.h
@@ -3,21 +3,21 @@
 namespace at {
   namespace native {
     //input tensors are non-zero dim and non-empty
-    template<typename T1, typename T2, typename T3, typename Operation>
-    void tensor_dim_apply3(const Tensor& self, Tensor& values, Tensor& indices, int64_t dim, Operation op) {
+    template<typename T1, typename T2, typename Function, typename Operation>
+    void tensor_dim_apply3(const Tensor& self, Tensor& values, Tensor& indices, int64_t dim, Operation op, Function func) {
       int ndims = self.dim();
       int tensor_dim_apply_has_finished = 0;
       std::vector<int64_t> counter(ndims, 0);
       T1* self_data = self.data_ptr<T1>();
-      T2* values_data = values.data_ptr<T2>();
-      T3* indices_data = indices.data_ptr<T3>();
+      T1* values_data = values.data_ptr<T1>();
+      T2* indices_data = indices.data_ptr<T2>();
       int64_t self_stride = self.stride(dim);
       int64_t values_stride = values.stride(dim);
       int64_t indices_stride = indices.stride(dim);
       int self_dim_size = self.size(dim);
 
       while(!tensor_dim_apply_has_finished) {
-        op(self_data, values_data, indices_data, self_dim_size, self_stride, values_stride, indices_stride);
+        func(self_data, values_data, indices_data, self_dim_size, self_stride, values_stride, indices_stride, op);
         if(ndims == 1)
            break;
         for(int dim_i = 0; dim_i < ndims; dim_i++) {

--- a/aten/src/ATen/native/cuda/ReduceOpsKernel.cu
+++ b/aten/src/ATen/native/cuda/ReduceOpsKernel.cu
@@ -9,12 +9,22 @@
 #include <ATen/native/DispatchStub.h>
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/ReduceOps.h>
+
+#include <ATen/ATen.h>
+#include <ATen/Tensor.h>
+#include <ATen/NativeFunctions.h>
+#include <ATen/TensorUtils.h>
+#include <ATen/Utils.h>
+#include <ATen/cuda/CUDAApplyUtils.cuh>
+
 #include <limits>
 #include <tuple>
 #include <THC/THCNumerics.cuh>
+#include <THC/THCThrustAllocator.cuh>
 #include <thrust/tuple.h>
 #include <thrust/pair.h>
 
+#include <THC/THCTensorMathReduce.cuh>
 
 namespace at { namespace native {
 
@@ -222,60 +232,253 @@ void argmin_kernel_cuda(TensorIterator& iter) {
   }
 }
 
+
+//TODO: check if I should use unit64_t in place of int
+
+/* Perform an inclusive scan along an outer dimension of a tensor.
+ *
+ * - num_orows is the size of the flattened outer dimensions;
+ * - num_irows is the size of the flattened inner dimensions;
+ * - row_size is the size of the dimension along which to compute the variance;
+ *
+ * The dimensions to the outside and inside of the specified dimension are considered as flattened.
+ * Thread blocks with the same blockIdx.y process an "outer row" (i.e. an element of the flattened
+ * outer dimensions, which contains several "inner rows").
+ * Each thread processes a single inner row at a time.
+ */
+// template<typename scalar_t, class BinaryOp>
+// __global__ void tensor_kernel_scanOuterDim(scalar_t *self_, scalar_t *values_, int64_t *indices_,
+//                                             int num_orows, int num_irows, int row_size,
+//                                             scalar_t init, BinaryOp binary_op)
+// {
+//   for (int orow = blockIdx.x; orow < num_orows; orow += gridDim.x) {
+//     for (int irow = blockIdx.y * blockDim.x + threadIdx.x; irow < num_irows; irow += gridDim.y * blockDim.x) {
+//       scalar_t *self = self_ + orow * row_size * num_irows + irow;
+//       scalar_t *values = values_ + orow * row_size * num_irows + irow;
+//       int64_t *indices = indices_ + orow * row_size * num_irows + irow;
+//       scalar_t acc = init;
+//       int64_t idx = 0;
+//
+//       for (int col = 0; col < row_size; ++col) {
+//         acc = binary_op(acc, *self);
+//         if(acc == *self) {
+//           idx = col;
+//         }
+//         *self = acc;
+//         *indices = idx;
+//         self += num_irows;
+//         values += num_irows;
+//         indices += num_irows;
+//       }
+//     }
+//   }
+// }
+//
+// /* Perform an inclusive scan along the innermost dimension of a tensor.
+//  *
+//  * - num_rows is the size of the flattened outer dimensions;
+//  * - row_size is the size of the innermost dimension;
+//  *
+//  * The outer dimensions of the tensor are considered as a single dimension, i.e. the tensor is
+//  * considered as having 'num_rows' rows of size 'row_size'.
+//  * Each thread block processes one or more sets of contiguous rows (processing multiple rows
+//  * per thread block is quicker than processing a single row, especially for short rows).
+//  */
+// template<typename scalar_t, int num_threads_x, int num_threads_y, class BinaryFunction>
+// __global__ void tensor_kernel_scanInnermostDim(const scalar_t *self_, scalar_t *values_, int64_t *indices_,
+//                                                 int num_rows, int row_size,
+//                                                 scalar_t init, BinaryFunction binary_op)
+// {
+//   __shared__ scalar_t vbuf[num_threads_y][2 * num_threads_x];
+//   __shared__ int64_t ibuf[num_threads_y][2 * num_threads_x];
+//   scalar_t* row_buf = vbuf[threadIdx.y];
+//   scalar_t* row_idx_buf = ibuf[threadIdx.y];
+//
+//   for (int block_row = blockIdx.x * blockDim.y;
+//        block_row < num_rows;
+//        block_row += blockDim.y * gridDim.x) {
+//     int row = block_row + threadIdx.y;
+//     scalar_t *row_self = self_ + row * row_size;
+//     scalar_t *row_values = values_ + row * row_size;
+//     int64_t *row_indices = indices_ + row * row_size;
+//     scalar_t block_total = init;
+//     int64_t block_total_idx;
+//     // Perform scan on one block at a time, keeping track of the total value of
+//     // all blocks processed so far.
+//     for (int block_col = 0; block_col < row_size; block_col += 2 * num_threads_x) {
+//       // Load data into shared memory (two values per thread).
+//       int col1 = block_col + threadIdx.x;
+//       int col2 = block_col + num_threads_x + threadIdx.x;
+//       if (row < num_rows) {
+//         if (col1 < row_size) {
+//           row_buf[threadIdx.x] = row_self[col1];
+//           //TODO: add init for indices
+//         } else {
+//           row_buf[threadIdx.x] = init;
+//           //TODO: add init for indices
+//         }
+//
+//         if (col2 < row_size) {
+//           row_buf[num_threads_x + threadIdx.x] = row_src[col2];
+//         } else {
+//           row_buf[num_threads_x + threadIdx.x] = init;
+//           //TODO: add init for indices
+//         }
+//
+//         // Add the total value of all previous blocks to the first value of this block.
+//         if (threadIdx.x == 0) {
+//           row_buf[0] = binary_op(row_buf[0], block_total);
+//           //TODO: update indices
+//         }
+//       }
+//       __syncthreads();
+//
+//       // Parallel reduction (up-sweep).
+//       for (int s = num_threads_x, d = 1; s >= 1; s >>= 1, d <<= 1) {
+//         if (row < num_rows && threadIdx.x < s) {
+//           int offset = (2 * threadIdx.x + 1) * d - 1;
+//           row_buf[offset + d] = binary_op(row_buf[offset], row_buf[offset + d]);
+//         }
+//         __syncthreads();
+//       }
+//
+//       // Down-sweep.
+//       for (int s = 2, d = num_threads_x / 2; d >= 1; s <<= 1, d >>= 1) {
+//         if (row < num_rows && threadIdx.x < s - 1) {
+//           int offset = 2 * (threadIdx.x + 1) * d - 1;
+//           row_buf[offset + d] = binary_op(row_buf[offset], row_buf[offset + d]);
+//         }
+//         __syncthreads();
+//       }
+//
+//       // Write back to output.
+//       if (row < num_rows) {
+//         if (col1 < row_size) row_values[col1] = row_buf[threadIdx.x];
+//         if (col2 < row_size) row_values[col2] = row_buf[num_threads_x + threadIdx.x];
+//         //TODO:update indices
+//       }
+//       block_total = row_buf[2 * num_threads_x - 1];
+//       __syncthreads();
+//     }
+//   }
+// }
+//
 template<typename scalar_t, typename BinaryFunction>
-void scanThrustWithIndices(Tensor& values, Tensor& indices, const Tensor& self, BinaryFunction binary_op) {
-
+void scanThrustWithIndices(const scalar_t *self, scalar_t *values, int64_t *indices, int dim, BinaryFunction binary_op) {
+  // auto allocator = THCThrustAllocator(globalContext().lazyInitCUDA());
+  // const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  // auto policy = thrust::cuda::par(allocator).on(stream);
+  //
+  // typedef thrust::device_ptr<scalar_t> device_ptr;
+  // // auto self_data = device_ptr(self.data_ptr<scalar_t>());
+  // // auto values_data = device_ptr(values.data_ptr<scalar_t>());
+  // // auto indices_data = device_ptr(indices.data_ptr<scalar_t>());
+  // auto self_stride = self->stride(dim);
+  // auto values_stride = values->stride(dim);
+  // auto indices_stride = indices->stride(dim);
+  // int nelements = self.numel();
+//   thrust::inclusive_scan(
+// #if CUDA_VERSION >= 7000 || defined __HIP_PLATFORM_HCC__
+//       policy,
+// #endif
+//       self_data, self_data + nelements, values_data, indices_data, binary_op);
+  //auto cummax = self[0];
+  int idx = 0;
+  // for(int i = 0; i < self->size(dim); i++) {
+  //   if(self[i*self_stride] >= cummax) {
+  //     cummax = self[i*self_stride];
+  //     idx = i;
+  //   }
+  //   values[i*values_stride] = cummax;
+  //   indices[i*indices_stride] = idx;
+  // }
 }
 
-template <typename scalar_t, typename BinaryFunction>
-void scanDimWithIndices(Tensor& values, Tensor& indices, const Tensor& self, int64_t dim, BinaryFunction binary_op) {
-  int ndim = self.dim();
-  TORCH_CHECK(dim >= 0 && dim < ndim, "dimension ", dim, " out of range");
-   Tensor self_ = self.contiguous();
-   Tensor values_ = values.contiguous();
-   Tensor indices_ = indices.contiguous();
-   auto values__data = values.data_ptr<scalar_t>();
-   auto self__data = self.data_ptr<scalar_t>();
-   auto indices__data = indices.data_ptr<int64_t>();
-   if (!self.is_empty()) {
-     if(scalar_t == at::Half) {
-       if (ndim == 1) {
-         // thrust does not take an "init"
-         // scanThrustWithIndices(values, indices, self, binary_op);
-       }
-     }
-     if (dim == ndim - 1) {
-       // THCTensor_(scanInnermostDim)(state, self, src, init, binary_op);
-     } else {
-       // THCTensor_(scanOuterDim)(state, self, src, dimension, init, binary_op);
-     }
-   }
-   // // cuda blocks & threads:
-   // int blocksH = std::max<int64_t>((int)(16L / sizeD), 1);
-   // dim3 blocks(sizeB * sizeD, blocksH);
-   // dim3 threads(32, 8);
-   //
-   // // run averagepool kernel
-   // adaptiveaveragepool <<<blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>> (
-   //   input_data, output_data,
-   //   isizeH, isizeW, osizeH, osizeW,
-   //   istrideD, istrideH, istrideW);
+template<typename scalar_t, class BinaryFunction>
+__host__ void scanOuterDimWithIndices(const scalar_t *self, scalar_t *values, int64_t *indices,
+                                       int dim, BinaryFunction binary_op)
+{
+  // int ndim = std::max(1, self->dim());
+  // // Treat all outer dimensions (i.e. dim_ < dim) as one.
+  // int num_orows = 1;
+  // for (int dim_ = 0; dim_ < dim; dim_++) {
+  //   num_orows *= self->size(dim_);
+  // }
+  // int row_size = self->size(dim);
+  // // Treat all inner dimensions (i.e. dim > dimension) as one.
+  // int num_irows = 1;
+  // for (int dim_ = dim + 1; dim_ < ndim; dim_++) {
+  //   num_irows *= self->size(dim_);
+  // }
+  //
+  // dim3 threads(std::min(512, num_irows));
+  // int maxGridDim = 1024;
+  // dim3 grid(std::min(maxGridDim, num_orows), std::min(maxGridDim, cuda::ATenCeilDiv(num_irows, int(threads.x))));
+
+  // tensor_kernel_scanOuterDim<scalar_t><<<grid, threads, 0, at::cuda::getCurrentCUDAStream()>>>(
+  //   self, values, indices, num_orows, num_irows, row_size, init, binary_op);
+  AT_CUDA_CHECK(cudaGetLastError());
 }
 
-std::tuple<Tensor&, Tensor&> cummax_helper_out_cuda(Tensor& values, Tensor& indices, const Tensor& self, int64_t dim) {
-  checkAllSameGPU("cummax", {self, values, indices});
-  AT_DISPATCH_ALL_TYPES(self.dtype(), "cummax_cuda", [&]() {
-    scanDimWithIndices<scalar_t, MaxOp<scalar_t>>(values, indices, self, dim, MaxOp<scalar_t>());
+template <typename scalar_t, class BinaryFunction>
+__host__ void scanInnermostDimWithIndices(const scalar_t *self, scalar_t *values, int64_t *indices, BinaryFunction binary_op) {
+  // int ndim = self->dim();
+  // // Treat all outer dimensions as a single dimension.
+  // int row_size = self->size(ndim - 1);
+  // int num_rows = self->numel() / row_size;
+  //
+  // dim3 threads(16, 32);
+  // dim3 grid(std::min(1024, cuda::ATenCeilDiv(num_rows, int(threads.y))));
+  // //
+  // // tensor_kernel_scanInnermostDim<scalar_t, 16, 32><<<grid, threads, 0, THCState_getCurrentStream(state)>>>(
+  // //   THCTensor_(data)(state, tgt), THCTensor_(data)(state, src), num_rows, row_size, init, binary_op);
+  // //
+  // AT_CUDA_CHECK(cudaGetLastError());
+}
+
+// template <class BinaryFunction>
+// template<typename scalar_t, typename BinaryFunction>
+// void scanDimWithIndices(const Tensor& self, Tensor& values, Tensor& indices, //int64_t dim) {
+//      int64_t dim, BinaryFunction binary_op) {
+//
+//   int ndim = self.dim();
+//   Tensor self_ = self.contiguous();
+//   Tensor values_ = values.contiguous();
+//   Tensor indices_ = indices.contiguous();
+//   auto values_data = values_.data_ptr<scalar_t>();
+//   auto self_data = self_.data_ptr<scalar_t>();
+//   auto indices_data = indices_.data_ptr<int64_t>();
+//    if (self.numel() != 0) {
+//      if (ndim == 1) {
+//        //scanThrustWithIndices<scalar_t, BinaryFunction>(self_data, values_data, indices_data, dim, binary_op);
+//      }
+//      else if (dim == ndim - 1) {
+//        scanInnermostDimWithIndices<scalar_t, BinaryFunction>(self_data, values_data, indices_data, binary_op);
+//      } else {
+//        //scanOuterDimWithIndices<scalar_t, BinaryFunction>(self_data, values_data, indices_data, dim, binary_op);
+//      }
+//    }
+// }
+
+void cummax_helper_cuda(const Tensor& self, Tensor& values, Tensor& indices, int64_t dim) {
+  TensorArg output_arg{ values, "output", 1 };
+  TensorArg indices_arg{ indices, "indices", 2 };
+  TensorArg input_arg{ self, "input", 3 };
+  checkAllSameGPU("cummax", {output_arg, indices_arg, input_arg});
+  AT_DISPATCH_ALL_TYPES(self.scalar_type(), "cummax_cuda", [&]() {
+    //scanDimWithIndices<scalar_t, MaxOp<scalar_t>>(self, values, indices, dim, MaxOp<scalar_t>());
+    //scanDimWithIndices<scalar_t>(self, values, indices, dim);
   });
-  return std::forward_as_tuple(values, indices);
 }
 
-std::tuple<Tensor&, Tensor&> cummin_helper_out_cpu(Tensor& values, Tensor& indices, const Tensor& self, int64_t dim) {
-  checkAllSameGPU("cummin", {self, values, indices});
-  AT_DISPATCH_ALL_TYPES(self.dtype(), "cummin_cuda", [&]() {
-    scanDimWithIndices<scalar_t, MinOp<scalar_t>>(values, indices, self, dim, MinOp<scalar_t>());
+void cummin_helper_cuda(const Tensor& self, Tensor& values, Tensor& indices, int64_t dim) {
+  TensorArg output_arg{ values, "output", 1 };
+  TensorArg indices_arg{ indices, "indices", 2 };
+  TensorArg input_arg{ self, "input", 3 };
+  checkAllSameGPU("cummin", {output_arg, indices_arg, input_arg});
+  AT_DISPATCH_ALL_TYPES(self.scalar_type(), "cummin_cuda", [&]() {
+    //scanDimWithIndices<scalar_t, MaxOp<scalar_t>>(self, values, indices, dim, MaxOp<scalar_t>());
   });
-  return std::forward_as_tuple(values, indices);
 }
 
 REGISTER_DISPATCH(std_var_stub, &std_var_kernel_cuda);

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -918,17 +918,11 @@
 - func: cummax.dimname_out(Tensor self, Dimname dim, *, Tensor(a!) values, Tensor(b!) indices) -> (Tensor(a!) values, Tensor(b!) indices)
   supports_named_tensor: True
 
-- func: _cummax_helper(Tensor self, int dim) -> (Tensor values, Tensor indices)
+- func: _cummax_helper(Tensor self, Tensor(a!) values, Tensor(b!) indices, int dim) -> ()
   variants: function
   dispatch:
-    CPU: cummax_helper
-    CUDA: cummax_helper
-
-- func: _cummax_helper.out(Tensor self, int dim, *, Tensor(a!) values, Tensor(b!) indices) -> (Tensor(a!) values, Tensor(b!) indices)
-  variants: function
-  dispatch:
-    CPU: cummax_helper_out_cpu
-    CUDA: cummax_helper_out_cuda
+    CPU: cummax_helper_cpu
+    CUDA: cummax_helper_cuda
 
 - func: cummin(Tensor self, int dim) -> (Tensor values, Tensor indices)
   supports_named_tensor: True
@@ -944,17 +938,11 @@
 - func: cummin.dimname_out(Tensor self, Dimname dim, *, Tensor(a!) values, Tensor(b!) indices) -> (Tensor(a!) values, Tensor(b!) indices)
   supports_named_tensor: True
 
-- func: _cummin_helper(Tensor self, int dim) -> (Tensor values, Tensor indices)
+- func: _cummin_helper(Tensor self, Tensor(a!) values, Tensor(b!) indices, int dim) -> ()
   variants: function
   dispatch:
-    CPU: cummin_helper
-    CUDA: cummin_helper
-
-- func: _cummin_helper.out(Tensor self, int dim, *, Tensor(a!) values, Tensor(b!) indices) -> (Tensor(a!) values, Tensor(b!) indices)
-  variants: function
-  dispatch:
-    CPU: cummin_helper_out_cpu
-    CUDA: cummin_helper_out_cuda
+    CPU: cummin_helper_cpu
+    CUDA: cummin_helper_cuda
 
 - func: cumprod(Tensor self, int dim, *, ScalarType? dtype=None) -> Tensor
   supports_named_tensor: True

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -918,6 +918,18 @@
 - func: cummax.dimname_out(Tensor self, Dimname dim, *, Tensor(a!) values, Tensor(b!) indices) -> (Tensor(a!) values, Tensor(b!) indices)
   supports_named_tensor: True
 
+- func: _cummax_helper(Tensor self, int dim) -> (Tensor values, Tensor indices)
+  variants: function
+  dispatch:
+    CPU: cummax_helper
+    CUDA: cummax_helper
+
+- func: _cummax_helper.out(Tensor self, int dim, *, Tensor(a!) values, Tensor(b!) indices) -> (Tensor(a!) values, Tensor(b!) indices)
+  variants: function
+  dispatch:
+    CPU: cummax_helper_out_cpu
+    CUDA: cummax_helper_out_cuda
+
 - func: cummin(Tensor self, int dim) -> (Tensor values, Tensor indices)
   supports_named_tensor: True
   variants: function, method
@@ -931,6 +943,18 @@
 
 - func: cummin.dimname_out(Tensor self, Dimname dim, *, Tensor(a!) values, Tensor(b!) indices) -> (Tensor(a!) values, Tensor(b!) indices)
   supports_named_tensor: True
+
+- func: _cummin_helper(Tensor self, int dim) -> (Tensor values, Tensor indices)
+  variants: function
+  dispatch:
+    CPU: cummin_helper
+    CUDA: cummin_helper
+
+- func: _cummin_helper.out(Tensor self, int dim, *, Tensor(a!) values, Tensor(b!) indices) -> (Tensor(a!) values, Tensor(b!) indices)
+  variants: function
+  dispatch:
+    CPU: cummin_helper_out_cpu
+    CUDA: cummin_helper_out_cuda
 
 - func: cumprod(Tensor self, int dim, *, ScalarType? dtype=None) -> Tensor
   supports_named_tensor: True

--- a/aten/src/THC/THCTensorMathReduce.cuh
+++ b/aten/src/THC/THCTensorMathReduce.cuh
@@ -588,4 +588,18 @@ struct MulOp {
   }
 };
 
+template <typename T>
+struct MaxOp {
+  __device__ __forceinline__ T operator()(T const &lhs, T const &rhs) {
+    return THCNumerics<T>::max(lhs, rhs);
+  }
+};
+
+template <typename T>
+struct MinOp {
+  __device__ __forceinline__ T operator()(T const &lhs, T const &rhs) {
+    return THCNumerics<T>::min(lhs, rhs);
+  }
+};
+
 #endif // THC_TENSORMATH_REDUCE_CUH

--- a/aten/src/THC/THCTensorMathReduce.cuh
+++ b/aten/src/THC/THCTensorMathReduce.cuh
@@ -591,14 +591,14 @@ struct MulOp {
 template <typename T>
 struct MaxOp {
   __device__ __forceinline__ T operator()(T const &lhs, T const &rhs) {
-    return THCNumerics<T>::max(lhs, rhs);
+    return THCNumerics<T>::gt(lhs, rhs) ? lhs : rhs;
   }
 };
 
 template <typename T>
 struct MinOp {
   __device__ __forceinline__ T operator()(T const &lhs, T const &rhs) {
-    return THCNumerics<T>::min(lhs, rhs);
+    return THCNumerics<T>::lt(lhs, rhs) ? lhs : rhs;
   }
 };
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -10067,11 +10067,10 @@ class TestTorchDeviceType(TestCase):
             self.assertEqual(aRes[0], bRes[0])
             self.assertEqual(aRes[0], expected_output1)
 
-            # test inf and nan
+            # test inf and nan input
             x = torch.tensor([4, inf, 1.5, -inf, 0, nan, 1])
             xRes = op(x, 0)[0]
-            self.assertEqual(xRes.__repr__(), str(xRes))
-            self.assertExpectedInline(str(xRes), expected_output2)
+            self.assertEqual(xRes, expected_output2, allow_inf=True)
 
             # op shouldn't support values, indices with a dtype, device type or layout
             # different from that of input tensor
@@ -10105,15 +10104,15 @@ class TestTorchDeviceType(TestCase):
             # Check that output maintained correct shape
             self.assertEqual(raw_tensor.shape, raw_tensor.grad.shape)
 
-        expected_str_out = '''tensor([4., inf, inf, inf, inf, nan, nan])'''
+        expected_out = torch.tensor([4, inf, inf, inf, inf, nan, nan])
         test_ops(torch.cummax, "cummax", torch.tensor([[1, 0, 1],
                                                        [1, 0, 1],
-                                                       [1, 1, 1]]), expected_str_out)
+                                                       [1, 1, 1]]), expected_out)
 
-        expected_str_out = '''tensor([4.0000, 4.0000, 1.5000,   -inf,   -inf,    nan,    nan])'''
+        expected_out = torch.tensor([4, 4, 1.5, -inf, -inf, nan, nan])
         test_ops(torch.cummin, "cummin", torch.tensor([[1, 0, 1],
                                                        [0, 0, 0],
-                                                       [0, 0, 0]]), expected_str_out)
+                                                       [0, 0, 0]]), expected_out)
 
     def test_std_mean(self, device):
         x = torch.rand(100, 50, 20, device=device)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -10052,8 +10052,8 @@ class TestTorchDeviceType(TestCase):
         def test_ops(op, string_of_function_name, expected_output):
             x = torch.rand(100, 100, device=device)
             out1 = op(x, 1)
-            res2 = torch.Tensor().to(device)
-            indices2 = torch.LongTensor().to(device)
+            res2 = torch.empty(0, device=device)
+            indices2 = torch.empty(0, dtype=torch.int64, device=device)
             op(x, 1, out=(res2, indices2))
             self.assertEqual(out1[0], res2)
             self.assertEqual(out1[1], indices2)
@@ -10070,8 +10070,8 @@ class TestTorchDeviceType(TestCase):
             # op shouldn't support values, indices with a dtype, device type or layout
             # different from that of input tensor
             t = torch.randn(10)
-            values = torch.ShortTensor()
-            indices = torch.LongTensor()
+            values = torch.empty(0, dtype=torch.int16)
+            indices = torch.empty(0, dtype=torch.int64)
             with self.assertRaisesRegex(
                     RuntimeError,
                     'expected scalar_type Float but found Short'):

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -276,10 +276,10 @@
   self: cumsum_backward(grad.to(self.scalar_type()), dim)
 
 - name: cummax(Tensor self, int dim) -> (Tensor values, Tensor indices)
-  self: cummax_backward(indices, grad.to(self.scalar_type()), self, dim)
+  self: cummax_backward(indices, grad, self, dim)
 
 - name: cummin(Tensor self, int dim) -> (Tensor values, Tensor indices)
-  self: cummin_backward(indices, grad.to(self.scalar_type()), self, dim)
+  self: cummin_backward(indices, grad, self, dim)
 
 - name: conv_tbc(Tensor self, Tensor weight, Tensor bias, int pad=0) -> Tensor
   self, weight, bias: conv_tbc_backward(grad, self, weight, bias, pad)

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -1382,16 +1382,20 @@ Example::
 add_docstr(torch.cummax,
            r"""
 cummax(input, dim, out=None) -> (Tensor, LongTensor)
-Returns a namedtuple ``(values, indices)`` where ``values``is the cumulative maximum of
+Returns a namedtuple ``(values, indices)`` where ``values`` is the cumulative maximum of
 elements of :attr:`input` in the dimension :attr:`dim`. And ``indices`` is the index
 location of each maximum value found in the dimension :attr:`dim`.
+
 .. math::
     y_i = max(x_1, x_2, x_3, \dots, x_i)
+
 Args:
     {input}
     dim  (int): the dimension to do the operation over
     out (tuple, optional): the result tuple of two output tensors (values, indices)
+
 Example::
+
     >>> a = torch.randn(10)
     >>> a
     tensor([-0.3449, -1.5447,  0.0685, -1.5104, -1.1706,  0.2259,  1.4696, -1.3284,
@@ -1406,16 +1410,20 @@ Example::
 add_docstr(torch.cummin,
            r"""
 cummin(input, dim, out=None) -> (Tensor, LongTensor)
-Returns a namedtuple ``(values, indices)`` where ``values``is the cumulative maximum of
+Returns a namedtuple ``(values, indices)`` where ``values`` is the cumulative maximum of
 elements of :attr:`input` in the dimension :attr:`dim`. And ``indices`` is the index
 location of each maximum value found in the dimension :attr:`dim`.
+
 .. math::
-    y_i = max(x_1, x_2, x_3, \dots, x_i)
+    y_i = min(x_1, x_2, x_3, \dots, x_i)
+
 Args:
     {input}
     dim  (int): the dimension to do the operation over
     out (tuple, optional): the result tuple of two output tensors (values, indices)
+
 Example::
+
     >>> a = torch.randn(10)
     >>> a
     tensor([-0.2284, -0.6628,  0.0975,  0.2680, -1.3298, -0.4220, -0.3885,  1.1762,


### PR DESCRIPTION
[CPU] Benchmark results for cummax, cummin:

In [1]: import torch

In [2]: x=torch.randn(5,6,7).cuda()

In [3]: %timeit x.cummax(0)
134 µs ± 1.59 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)

In [4]: %timeit x.max(0)
114 µs ± 560 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)

In [5]: %timeit x.cummax(1)
134 µs ± 760 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)

In [6]: %timeit x.max(1)
118 µs ± 514 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)

In [7]: %timeit x.cumsum(0)
97.1 µs ± 6.93 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)

In [8]: %timeit x.cumprod(0)
83.6 µs ± 689 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)

In [9]: %timeit x.cumprod(1)
86.3 µs ± 528 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)

In [10]: y=torch.randn(5,6,7)

In [11]: %timeit y.cummax(0)
148 µs ± 1.43 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)

In [12]: %timeit y.max(0)
111 µs ± 125 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)

In [13]: %timeit y.cumsum(0)
54.8 µs ± 311 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)

In [14]: %timeit y.cumprod(0)
56.2 µs ± 836 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)