### PR TITLE
[jit] allow compilation using optional modules

### DIFF
--- a/test/jit/test_recursive_script.py
+++ b/test/jit/test_recursive_script.py
@@ -650,3 +650,20 @@ class TestRecursiveScript(JitTestCase):
                 return self.encoder(input)
 
         self.checkModule(ContainsLoaded(), (torch.rand(2, 3), ))
+
+    def test_optional_module(self):
+        class Dummy(nn.Module):
+            def __init__(self):
+                super(Dummy, self).__init__()
+                self.foo = nn.Linear(2, 2)
+
+            def forward(self, x):
+                if self.foo is not None:
+                    return self.foo(x)
+                return x
+
+        mod = Dummy()
+        torch.jit.script(mod)
+
+        mod.foo = None
+        torch.jit.script(mod)

--- a/test/jit/test_recursive_script.py
+++ b/test/jit/test_recursive_script.py
@@ -663,7 +663,6 @@ class TestRecursiveScript(JitTestCase):
                 return x
 
         mod = Dummy()
-        torch.jit.script(mod)
-
+        self.checkModule(mod, (torch.rand(2, 2),))
         mod.foo = None
-        torch.jit.script(mod)
+        self.checkModule(mod, (torch.rand(2, 2),))

--- a/torch/csrc/jit/python_ir.cpp
+++ b/torch/csrc/jit/python_ir.cpp
@@ -688,7 +688,10 @@ void initPythonIRBindings(PyObject* module_) {
           "isSubtypeOf",
           [](std::shared_ptr<Type>& self, std::shared_ptr<Type> other) {
             return self->isSubtypeOf(other);
-          });
+          })
+      .def("is_interface_type", [](const std::shared_ptr<Type>& self) {
+        return self->cast<InterfaceType>() != nullptr;
+      });
 
   py::class_<AnyType, Type, std::shared_ptr<AnyType>>(m, "AnyType")
       .def_static("get", &AnyType::get);

--- a/torch/jit/_recursive.py
+++ b/torch/jit/_recursive.py
@@ -114,7 +114,13 @@ def infer_concrete_type_builder(nn_module):
 
     for name, item in nn_module._modules.items():
         attr_type = infer_type(name, item)
+        if item is None:
+            # Modules can be None. We don't have direct support for optional
+            # Modules, so the register it as an NoneType attribute instead.
+            concrete_type_builder.add_attribute(name, attr_type, False)
+            continue
         if attr_type is not None:
+            assert attr_type.is_interface_type()
             # if the type can be inferred, it should be a module interface type
             sub_concrete_type = torch._C.ConcreteModuleType.from_jit_type(attr_type)
         else:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#32539 [jit] allow compilation using optional modules**

Before: if something in `_modules` was `None`, we would barf. This is
incorrect because it's allowed for users to put `None` there, in case a
module is optional.

This case ought to be handled correctly during scripting. Fixes https://github.com/pytorch/pytorch/issues/32469

Differential Revision: [D19552346](https://our.internmc.facebook.com/intern/diff/D19552346)