### PR TITLE
[JIT] Remove capsule type handling of node hashing

### DIFF
--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -1166,7 +1166,8 @@ struct VarType : public Type {
 
 struct CapsuleType;
 using CapsuleTypePtr = std::shared_ptr<CapsuleType>;
-// This type represents a Python Capsule
+// This type represents a Python Capsule.
+// It does not appear in the IR and is only used during runtime
 struct CAFFE2_API CapsuleType : public Type {
   static CapsuleTypePtr create() {
     return CapsuleTypePtr(new CapsuleType()); // NOLINT(modernize-make-shared)

--- a/torch/csrc/jit/node_hashing.cpp
+++ b/torch/csrc/jit/node_hashing.cpp
@@ -147,8 +147,6 @@ bool EqualNode::operator()(const Node* lhs, const Node* rhs) const {
   for (size_t i = 0; i < lhs_outputs.size(); ++i) {
     if (*lhs_outputs[i]->type() != *rhs_outputs[i]->type())
       return false;
-    if (lhs_outputs[i]->type() == CapsuleType::get())
-      return false;
   }
 
   // Check whether the inputs are the same.


### PR DESCRIPTION
Capsule Type doesn't appear in the IR, it is purely used in the runtime. So we should not have to handle it node hashing... Let's see if this breaks anything.