### PR TITLE
Properly handle NaN in binary max and min

### DIFF
--- a/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
@@ -430,7 +430,11 @@ void max_elementwise_kernel(TensorIterator& iter) {
     AT_DISPATCH_FLOATING_TYPES(iter.dtype(), "max_elementwise_cpu", [&]() {
       cpu_kernel_vec(iter,
         [](scalar_t a, scalar_t b) -> scalar_t {
-          return std::max(a, b);
+          if (std::isnan(a) || std::isnan(b)) {
+            return std::numeric_limits<scalar_t>::quiet_NaN();
+          } else {
+            return std::max(a, b);
+          }
         },
         [](Vec256<scalar_t> a, Vec256<scalar_t> b) { return at::vec256::maximum(a, b); });
     });
@@ -453,7 +457,11 @@ void min_elementwise_kernel(TensorIterator& iter) {
     AT_DISPATCH_FLOATING_TYPES(iter.dtype(), "min_elementwise_cpu", [&]() {
       cpu_kernel_vec(iter,
         [](scalar_t a, scalar_t b) -> scalar_t {
-          return std::min(a, b);
+          if (std::isnan(a) || std::isnan(b)) {
+            return std::numeric_limits<scalar_t>::quiet_NaN();
+          } else {
+            return std::min(a, b);
+          }
         },
         [](Vec256<scalar_t> a, Vec256<scalar_t> b) { return at::vec256::minimum(a, b); });
     });

--- a/aten/src/ATen/native/cuda/BinaryCompareKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryCompareKernel.cu
@@ -1,9 +1,10 @@
+#include <ATen/AccumulateType.h>
 #include <ATen/Dispatch.h>
+#include <ATen/native/BinaryOps.h>
 #include <ATen/native/DispatchStub.h>
+#include <ATen/native/TensorIterator.h>
 #include <ATen/native/cuda/Loops.cuh>
 #include <ATen/native/cuda/zmath.cuh>
-#include <ATen/native/TensorIterator.h>
-#include <ATen/native/BinaryOps.h>
 
 // NOTE: CUDA on Windows requires that the enclosing function
 // of a __device__ lambda not have internal linkage.
@@ -74,7 +75,16 @@ void max_elementwise_kernel_cuda(TensorIterator& iter) {
   } else {
     AT_DISPATCH_FLOATING_TYPES_AND_HALF(iter.dtype(), "max_elementwise_cuda", [&]() {
       gpu_kernel(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
-        return ::max(a, b);
+        // isnan(half) breaks the Windows build. We explicitly cast half to float.
+        using acc_type = typename AccumulateType<scalar_t, /*is_cuda=*/true>::type;
+        // We avoid using nan or nanf because we want to return the same type as scalar_t.
+        if (::isnan(static_cast<acc_type>(a))) {
+          return a;
+        } else if (::isnan(static_cast<acc_type>(b))) {
+          return b;
+        } else {
+          return ::max(a, b);
+        }
       });
     });
   }
@@ -94,7 +104,16 @@ void min_elementwise_kernel_cuda(TensorIterator& iter) {
   } else {
     AT_DISPATCH_FLOATING_TYPES_AND_HALF(iter.dtype(), "min_elementwise_cuda", [&]() {
       gpu_kernel(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
-        return ::min(a, b);
+        // isnan(half) breaks the Windows build. We explicitly cast half to float.
+        using acc_type = typename AccumulateType<scalar_t, /*is_cuda=*/true>::type;
+        // We avoid using nan or nanf because we want to return the same type as scalar_t.
+        if (::isnan(static_cast<acc_type>(a))) {
+          return a;
+        } else if (::isnan(static_cast<acc_type>(b))) {
+          return b;
+        } else {
+          return ::min(a, b);
+        }
       });
     });
   }

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -13805,6 +13805,32 @@ class TestTorchDeviceType(TestCase):
         res_csub.sub_(scalar)
         self.assertEqual(res_add, res_csub)
 
+    @dtypesIfCUDA(torch.half, torch.float, torch.double)
+    @dtypes(torch.float, torch.double)
+    def test_min_max_binary_op_nan(self, device, dtype):
+        a = torch.rand(1000, dtype=dtype, device=device)
+        b = torch.rand(1000, dtype=dtype, device=device)
+
+        # 0:250: a -- nan, b -- not nan
+        a[:250] = float('nan')
+        # 250:500: a -- not nan, b -- nan
+        b[250:500] = float('nan')
+        # 500:750: a and b both nan
+        a[500:750] = float('nan')
+        b[500:750] = float('nan')
+        # 750:1000: neither nan
+
+        ma = torch.max(a, b)
+        mi = torch.min(a, b)
+
+        for i in range(750):
+            self.assertTrue(torch.isnan(ma[i]), "max(a, b): {}, a: {}, b: {}".format(ma[i], a[i], b[i]))
+            self.assertTrue(torch.isnan(mi[i]), "min(a, b): {}, a: {}, b: {}".format(mi[i], a[i], b[i]))
+
+        for i in range(750, 1000):
+            self.assertFalse(torch.isnan(ma[i]), "max(a, b): {}, a: {}, b: {}".format(ma[i], a[i], b[i]))
+            self.assertFalse(torch.isnan(mi[i]), "min(a, b): {}, a: {}, b: {}".format(mi[i], a[i], b[i]))
+
     @onlyCPU
     @dtypes(*torch.testing.get_all_math_dtypes('cpu'))
     def test_threshold(self, device, dtype):


### PR DESCRIPTION
The output depends asymmetrically on whether the first or the second
argument is NaN. See #25016 for detail of the issue.

This is part of a continuing effort that was dropped in #30851

The failure in #27185 is resolved by explicitly casting a half type number to float when applying `isnan`.

Close #25016

