### PR TITLE
Fix MagmaInitializesCorrectly_CUDA by using an invertible matrix

### DIFF
--- a/test/cpp/api/tensor_cuda.cpp
+++ b/test/cpp/api/tensor_cuda.cpp
@@ -115,8 +115,12 @@ TEST(TensorTest, ToDeviceAndDtype_MultiCUDA) {
 }
 
 TEST(TensorTest, MagmaInitializesCorrectly_CUDA) {
-  auto tensor = at::arange(1, 17, at::TensorOptions(at::kFloat).device(at::Device("cuda")));
-  tensor = tensor.view({4, 4});
+  // Any tensor will work here as long as it's invertible
+  float data[] = { 1, 1, 1, 0,
+                   0, 3, 1, 2,
+                   2, 3, 1, 0,
+                   1, 0, 2, 1 };
+  auto tensor = at::from_blob(data, {4, 4}, at::TensorOptions(at::kFloat)).cuda();
   if (at::hasMAGMA()) {
     at::inverse(tensor);
   }


### PR DESCRIPTION
This test case had been using the tensor

```
1  2  3  4
5  6  7  8
9  10 11 12
13 14 15 16
```

which is not an invertible tensor and causes the test case to fail, even if magma gets initialized just fine. This change uses a tensor that is invertible, and the inverse doesn't include any elements that are close to zero to avoid floating point rounding errors.