### PR TITLE
Interpolate Float [] support in ONNX

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -1026,9 +1026,6 @@ class TestONNXRuntime(unittest.TestCase):
         self.run_test(MyModel(), x)
 
     def _interpolate_script(self, x, mode, use_size, is_upsample, align_corners=False):
-        return  # TEMPORARILY DISABLED Until ONNX Export of List[Float] constants fixe
-
-
         class MyModel(torch.jit.ScriptModule):
             __constants__ = ['mode', 'use_size', 'is_upsample', 'size', 'scale', 'size_array', 'scale_array', 'align_corners']
 

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -2488,7 +2488,7 @@ def interpolate(input, size=None, scale_factor=None, mode='nearest', align_corne
         be used to infer new scales for the interpolation. This is the current
         default behavior when recompute_scale_factor is not specified.
         The default behavior for recompute_scale_factor will change to False
-        in 1.5.0, and scale_factor will be used in the interpolation
+        in 1.6.0, and scale_factor will be used in the interpolation
         calculation.
 
     .. include:: cuda_deterministic_backward.rst
@@ -2510,7 +2510,7 @@ def interpolate(input, size=None, scale_factor=None, mode='nearest', align_corne
             is_float_scale_factor = any(not float(scale).is_integer() for scale in _ntuple(dim)(scale_factor))
             if is_float_scale_factor:
                 warnings.warn("The default behavior for interpolate/upsample with float scale_factor will change "
-                              "in 1.5.0 to align with other frameworks/libraries, and use scale_factor directly, "
+                              "in 1.6.0 to align with other frameworks/libraries, and use scale_factor directly, "
                               "instead of relying on the computed output size. "
                               "If you wish to keep the old behavior, please set recompute_scale_factor=True. "
                               "See the documentation of nn.Upsample for details. ")

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -299,13 +299,8 @@ def _get_interpolate_attributes(g, mode, args):
 
 def _interpolate_get_scales(g, scale_factor, dim):
     offsets = g.op("Constant", value_t=torch.ones(2, dtype=torch.float32))
-    if _is_packed_list(scale_factor):
-        scale_factor = _unpack_list(scale_factor)
-        scales = []
-        for dim_scale_factor in scale_factor:
-            dim_scale_factor = _unsqueeze_helper(g, dim_scale_factor, 0)
-            dim_scale_factor = g.op("Cast", dim_scale_factor, to_i=cast_pytorch_to_onnx["Float"])
-            scales.append(dim_scale_factor)
+    if isinstance(scale_factor.type(), torch._C.ListType):
+        return g.op("Concat", offsets, scale_factor, axis_i=0)
     else:
         scale_factor = _unsqueeze_helper(g, scale_factor, 0)
         scale_factor = g.op("Cast", scale_factor, to_i=cast_pytorch_to_onnx["Float"])

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -719,6 +719,9 @@ def _run_symbolic_function(g, n, inputs, env, operator_export_type=OperatorExpor
                 elif n.kindOf("value") == "is":
                     value = torch.stack([torch.tensor(v) for v in n["value"]]) if n["value"] else []
                     return g.op("Constant", value_t=value)
+                elif n.kindOf("value") == "fs":
+                    value = torch.stack([torch.tensor(v) for v in n["value"]]) if n["value"] else []
+                    return g.op("Constant", value_t=value)
                 elif n.output().type().kind() == "DeviceObjType":
                     return None
                 else:


### PR DESCRIPTION
The PR https://github.com/pytorch/pytorch/pull/31791 adds support for float[] constant, which affects some cases of ONNX interpolate support.
This PR adds float[] constants support in ONNX, updates interpolate in ONNX, and re-enable the disabled tests.