### PR TITLE
[WIP, not yet ready for review] fix record_function scope with RPC in autograd profiler

### DIFF
--- a/torch/csrc/autograd/profiler.cpp
+++ b/torch/csrc/autograd/profiler.cpp
@@ -163,6 +163,7 @@ void enableProfiler(ProfilerConfig config) {
       },
       [](const RecordFunction& fn) {
         if (fn.getThreadId() != 0) {
+          std::cout << "Running RPC code path." << std::endl;
           // If we've overridden the thread_id on the RecordFunction, then find
           //  the eventList that was created for the original thread_id. Then,
           // record the end event on this list so that the block is added to

--- a/torch/csrc/autograd/record_function.h
+++ b/torch/csrc/autograd/record_function.h
@@ -130,7 +130,13 @@ struct TORCH_API RecordFunction {
   std::vector<c10::IValue> inputs_;
   // parent_ points to the parent RecordFunction and must out live this.
   RecordFunction* parent_ = nullptr;
-
+  std::mutex original_mutex;
+  RecordFunction** original_thread_local_func = nullptr;
+// uint16_t next_thread_id = 0;
+// // Protects access to next_thread_id and all_event_lists_map.
+// std::mutex all_event_lists_map_mutex;
+// std::unordered_map<uint16_t, std::shared_ptr<RangeEventList>>
+//     all_event_lists_map;
   bool initialized_ = false;
   bool run_sampled_ = false;
   // The thread_id that this RecordFunction was created with. If 0, this means


### PR DESCRIPTION
Fixes the issue described by https://github.com/pytorch/pytorch/issues/32517