### PR TITLE
Fixes moving after weight norm application

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -5732,6 +5732,7 @@ class TestNN(NNTestCase):
         m = torch.nn.utils.remove_weight_norm(m, name=name)
         self.assertEqual(m(input), expected_output)
 
+    @unittest.skipIf(not TEST_CUDA, 'CUDA not available')
     def test_partial_flat_weights(self):
         input_size = 10
         hidden_size = 6

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -5710,12 +5710,20 @@ class TestNN(NNTestCase):
         num_layers = 2
         seq_length = 7
         batch = 6
-        m = nn.LSTM(input_size, hidden_size, num_layers).cuda()
-        input = torch.randn(seq_length, batch, input_size).cuda()
+
+        # runs on CPU to acquire expected output
+        m = nn.LSTM(input_size, hidden_size, num_layers)
+        input = torch.randn(seq_length, batch, input_size)
         expected_output = m(input)
-        # add weight normalization
+
+        # adds weight normalization
         name = 'weight_hh_l0'
         m = torch.nn.utils.weight_norm(m, name=name)
+
+        # moves to CUDA
+        m = m.cuda()
+        input = input.cuda()
+
         # otherwise, subsequent warnings will be hidden, and further tests rely on them
         warnings.simplefilter("always")
         self.assertEqual(m(input), expected_output)
@@ -5723,6 +5731,19 @@ class TestNN(NNTestCase):
         # remove weight norm
         m = torch.nn.utils.remove_weight_norm(m, name=name)
         self.assertEqual(m(input), expected_output)
+
+    def test_partial_flat_weights(self):
+        input_size = 10
+        hidden_size = 6
+        num_layers = 2
+
+        # creates an RNN (LSTM) and deletes an attribute
+        m = nn.LSTM(input_size, hidden_size, num_layers)
+        del m.weight_hh_l0
+
+        # verifies that moving to CUDA with only some attributes defined
+        # does not throw an error
+        m.cuda()
 
     @unittest.skipIf(not (TEST_CUDNN and (TEST_CUDNN_VERSION if TEST_CUDNN_VERSION else 0) >= 5103), "needs cudnn >= 5.1")
     def test_RNN_dropout(self):

--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -113,7 +113,9 @@ class RNNBase(Module):
             return
         dtype = first_fw.dtype
         for fw in self._flat_weights:
-            if not torch.is_tensor(fw.data) or not (fw.data.dtype == dtype) or not fw.data.is_cuda or not torch.backends.cudnn.is_acceptable(fw.data):
+            if (not torch.is_tensor(fw.data) or not (fw.data.dtype == dtype) or
+                    not fw.data.is_cuda or
+                    not torch.backends.cudnn.is_acceptable(fw.data)):
                 return
 
         # If any parameters alias, we fall back to the slower, copying code path. This is

--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -127,11 +127,9 @@ class RNNBase(Module):
         with torch.cuda.device_of(first_fw):
             import torch.backends.cudnn.rnn as rnn
 
-            # NB: This is a temporary hack while we still don't have Tensor
-            # bindings for ATen functions
+            # Note: no_grad() is necessary since _cudnn_rnn_flatten_weight is
+            # an inplace operation on self._flat_weights
             with torch.no_grad():
-                # NB: this is an INPLACE function on self._flat_weights, that's why the
-                # no_grad() is necessary.
                 torch._cudnn_rnn_flatten_weight(
                     self._flat_weights, (4 if self.bias else 2),
                     self.input_size, rnn.get_cudnn_mode(self.mode), self.hidden_size, self.num_layers,

--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -124,7 +124,7 @@ class RNNBase(Module):
         if len(unique_data_ptrs) != len(self._flat_weights):
             return
 
-        with torch.cuda.device_of(any_param):
+        with torch.cuda.device_of(first_fw):
             import torch.backends.cudnn.rnn as rnn
 
             # NB: This is a temporary hack while we still don't have Tensor

--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -85,7 +85,7 @@ class RNNBase(Module):
                 self._flat_weights_names.extend(param_names)
                 self._all_weights.append(param_names)
 
-        self._flat_weights = [getattr(self, weight) for weight in self._flat_weights_names]
+        self._flat_weights = [getattr(self, weight) for weight in self._flat_weights_names if hasattr(self, weight)]
         self.flatten_parameters()
         self.reset_parameters()
 
@@ -102,17 +102,26 @@ class RNNBase(Module):
         Right now, this works only if the module is on the GPU and cuDNN is enabled.
         Otherwise, it's a no-op.
         """
-        any_param = next(self.parameters()).data
-        if not any_param.is_cuda or not torch.backends.cudnn.is_acceptable(any_param):
+        # Short-circuits if _flat_weights is only partially instantiated
+        if len(self._flat_weights) != len(self._flat_weights_names):
             return
+
+        # Short-circuits if any tensor in self._flat_weights is not acceptable to cuDNN
+        # or the tensors in _flat_weights are of different dtypes
+        first_fw = self._flat_weights[0].data
+        if not torch.is_tensor(first_fw):
+            return
+        dtype = first_fw.dtype
+        for fw in self._flat_weights:
+            if not torch.is_tensor(fw.data) or not (fw.data.dtype == dtype) or not fw.data.is_cuda or not torch.backends.cudnn.is_acceptable(fw.data):
+                return
 
         # If any parameters alias, we fall back to the slower, copying code path. This is
         # a sufficient check, because overlapping parameter buffers that don't completely
         # alias would break the assumptions of the uniqueness check in
         # Module.named_parameters().
-        all_weights = self._flat_weights
-        unique_data_ptrs = set(p.data_ptr() for p in all_weights)
-        if len(unique_data_ptrs) != len(all_weights):
+        unique_data_ptrs = set(p.data_ptr() for p in self._flat_weights)
+        if len(unique_data_ptrs) != len(self._flat_weights):
             return
 
         with torch.cuda.device_of(any_param):
@@ -121,10 +130,10 @@ class RNNBase(Module):
             # NB: This is a temporary hack while we still don't have Tensor
             # bindings for ATen functions
             with torch.no_grad():
-                # NB: this is an INPLACE function on all_weights, that's why the
+                # NB: this is an INPLACE function on self._flat_weights, that's why the
                 # no_grad() is necessary.
                 torch._cudnn_rnn_flatten_weight(
-                    all_weights, (4 if self.bias else 2),
+                    self._flat_weights, (4 if self.bias else 2),
                     self.input_size, rnn.get_cudnn_mode(self.mode), self.hidden_size, self.num_layers,
                     self.batch_first, bool(self.bidirectional))
 
@@ -134,7 +143,7 @@ class RNNBase(Module):
         # Resets _flat_weights
         # Note: be v. careful before removing this, as 3rd party device types
         # likely rely on this behavior to properly .to() modules like LSTM.
-        self._flat_weights = [getattr(self, weight) for weight in self._flat_weights_names]
+        self._flat_weights = [getattr(self, weight) for weight in self._flat_weights_names if hasattr(self, weight)]
 
         # Flattens params (on CUDA)
         self.flatten_parameters()
@@ -261,7 +270,7 @@ class RNNBase(Module):
                 else:
                     self._all_weights += [weights[:2]]
                     self._flat_weights_names.extend(weights[:2])
-        self._flat_weights = [getattr(self, weight) for weight in self._flat_weights_names]
+        self._flat_weights = [getattr(self, weight) for weight in self._flat_weights_names if hasattr(self, weight)]
 
     @property
     def all_weights(self):


### PR DESCRIPTION
This PR updates how RNNs handle their "flat weights." In particular, it allows for only some flat weights to be "materialized" when apply is called, and it updates the flattening behavior to only apply if all flat weights are (1) materialized, (2) share a dtype and (3) are acceptable to cuDNN.

One test is modified and another created to test these changes. One practical effect of this change is that weight norm can be successfully applied to a module BEFORE that module is moved to an accelerator. Previously doing so would throw an error.