### PR TITLE
[rpc] fix assertion errors in record_function scope when running profiler with
rpc

### DIFF
--- a/torch/csrc/autograd/record_function.h
+++ b/torch/csrc/autograd/record_function.h
@@ -130,7 +130,9 @@ struct TORCH_API RecordFunction {
   std::vector<c10::IValue> inputs_;
   // parent_ points to the parent RecordFunction and must out live this.
   RecordFunction* parent_ = nullptr;
-
+  // Pointer to thread_local_func pointer and mutex to serialize access.
+  std::mutex original_mutex;
+  RecordFunction** original_thread_local_func = nullptr;
   bool initialized_ = false;
   bool run_sampled_ = false;
   // The thread_id that this RecordFunction was created with. If 0, this means


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#32566 [rpc] fix assertion errors in record_function scope when running profiler with
rpc**

rpc

Fix for GH issue https://github.com/pytorch/pytorch/issues/32517. The
issue is that the `record_function` decorator uses nested RecordFunction
scopes that are handled by appropriately setting `parent_` and a thread_local
pointer to the current RecordFunction. This was not properly set with RPC
profiling, since `RecordFunction::end()` is called from a different thread so
the original thread_local object is invalid.

This fixes the issue by saving a pointer to the `thread_local` pointer, and
then properly setting the pointer to the parent_ RecordFunction.

There are still some issues with the profiler output with RPC and the
`record_function` decorator. Namely if we do
```
with record_function("foo"):
   rpc.rpc_sync(...)
```

we'd expect the sum of rpc_sync and foo() to be 100% of CPU time, like it is
for other ops, but this is not currently the case. We should fix this.

Differential Revision: [D19549107](https://our.internmc.facebook.com/intern/diff/D19549107/)