### PR TITLE
duplicate symbols with AT_PARALLEL_OPENMP=0

### DIFF
--- a/aten/src/ATen/ParallelOpenMP.cpp
+++ b/aten/src/ATen/ParallelOpenMP.cpp
@@ -1,4 +1,4 @@
-#ifdef AT_PARALLEL_OPENMP
+#if AT_PARALLEL_OPENMP
 #include <ATen/Parallel.h>
 
 #include <atomic>


### PR DESCRIPTION
Summary: explicitly disabling openmp actually causes it to be used.

Test Plan: CI passes

Differential Revision: D19549732

