### PR TITLE
[jit] Fix dict type serialization

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -4014,23 +4014,6 @@ class TestFrontend(JitTestCase):
 
 
 class TestScript(JitTestCase):
-    def test_optional_dict_construct(self):
-        class M(torch.nn.Module):
-            def use(self, buffer: Dict[str, Optional[Tensor]]):
-                return buffer["prev_key"]
-
-            def forward(self, x):
-                prev_key = torch.rand(2, 3)
-                next_key = torch.rand(2, 3)
-                saved_state: Dict[str, Optional[Tensor]] = {
-                    "prev_key": prev_key,
-                    "next_key": next_key,
-                }
-
-                return self.use(saved_state)
-
-        self.checkModule(M(), (torch.rand(2, 2),))
-
     def test_nested_bailouts(self):
         @torch.jit.script
         def fct_loop(x):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -4014,6 +4014,23 @@ class TestFrontend(JitTestCase):
 
 
 class TestScript(JitTestCase):
+    def test_optional_dict_construct(self):
+        class M(torch.nn.Module):
+            def use(self, buffer: Dict[str, Optional[Tensor]]):
+                return buffer["prev_key"]
+
+            def forward(self, x):
+                prev_key = torch.rand(2, 3)
+                next_key = torch.rand(2, 3)
+                saved_state: Dict[str, Optional[Tensor]] = {
+                    "prev_key": prev_key,
+                    "next_key": next_key,
+                }
+
+                return self.use(saved_state)
+
+        self.checkModule(M(), (torch.rand(2, 2),))
+
     def test_nested_bailouts(self):
         @torch.jit.script
         def fct_loop(x):

--- a/test/test_jit_py3.py
+++ b/test/test_jit_py3.py
@@ -12,13 +12,13 @@ import torch.nn as nn
 class TestScriptPy3(JitTestCase):
     def test_optional_dict_construct(self):
         class M(torch.nn.Module):
-            def use(self, buffer: Dict[str, Optional[Tensor]]):
+            def use(self, buffer: Dict[str, Optional[torch.Tensor]]):
                 return buffer["prev_key"]
 
             def forward(self, x):
                 prev_key = torch.rand(2, 3)
                 next_key = torch.rand(2, 3)
-                saved_state: Dict[str, Optional[Tensor]] = {
+                saved_state: Dict[str, Optional[torch.Tensor]] = {
                     "prev_key": prev_key,
                     "next_key": next_key,
                 }

--- a/test/test_jit_py3.py
+++ b/test/test_jit_py3.py
@@ -10,23 +10,6 @@ import torch.testing._internal.jit_utils
 import torch.nn as nn
 
 class TestScriptPy3(JitTestCase):
-    def test_optional_dict_construct(self):
-        class M(torch.nn.Module):
-            def foo(self, buffer: Dict[str, Optional[torch.Tensor]]):
-                return buffer["prev_key"]
-
-            def forward(self, x):
-                prev_key = torch.rand(2, 3)
-                next_key = torch.rand(2, 3)
-                saved_state: Dict[str, Optional[torch.Tensor]] = {
-                    "prev_key": prev_key,
-                    "next_key": next_key,
-                }
-
-                return self.foo(saved_state)
-
-        self.checkModule(M(), (torch.rand(2, 2),))
-
     def test_joined_str(self):
         def func(x):
             hello, test = "Hello", "test"
@@ -50,6 +33,23 @@ class TestScriptPy3(JitTestCase):
 
         self.assertAlmostEqual(out, out_script)
         self.assertEqual(captured, captured_script)
+
+    def test_optional_dict_construct(self):
+        class M(torch.nn.Module):
+            def use(self, buffer: Dict[str, Optional[torch.Tensor]]):
+                return buffer["prev_key"]
+
+            def forward(self, x):
+                prev_key = torch.rand(2, 3)
+                next_key = torch.rand(2, 3)
+                saved_state: Dict[str, Optional[torch.Tensor]] = {
+                    "prev_key": prev_key,
+                    "next_key": next_key,
+                }
+
+                return self.use(saved_state)
+
+        self.checkModule(M(), (torch.rand(2, 2),))
 
     def test_kwarg_support(self):
         with self.assertRaisesRegex(torch.jit.frontend.NotSupportedError, "variable number of arguments"):

--- a/test/test_jit_py3.py
+++ b/test/test_jit_py3.py
@@ -10,6 +10,23 @@ import torch.testing._internal.jit_utils
 import torch.nn as nn
 
 class TestScriptPy3(JitTestCase):
+    def test_optional_dict_construct(self):
+        class M(torch.nn.Module):
+            def use(self, buffer: Dict[str, Optional[Tensor]]):
+                return buffer["prev_key"]
+
+            def forward(self, x):
+                prev_key = torch.rand(2, 3)
+                next_key = torch.rand(2, 3)
+                saved_state: Dict[str, Optional[Tensor]] = {
+                    "prev_key": prev_key,
+                    "next_key": next_key,
+                }
+
+                return self.use(saved_state)
+
+        self.checkModule(M(), (torch.rand(2, 2),))
+
     def test_joined_str(self):
         def func(x):
             hello, test = "Hello", "test"

--- a/test/test_jit_py3.py
+++ b/test/test_jit_py3.py
@@ -12,7 +12,7 @@ import torch.nn as nn
 class TestScriptPy3(JitTestCase):
     def test_optional_dict_construct(self):
         class M(torch.nn.Module):
-            def use(self, buffer: Dict[str, Optional[torch.Tensor]]):
+            def foo(self, buffer: Dict[str, Optional[torch.Tensor]]):
                 return buffer["prev_key"]
 
             def forward(self, x):
@@ -23,7 +23,7 @@ class TestScriptPy3(JitTestCase):
                     "next_key": next_key,
                 }
 
-                return self.use(saved_state)
+                return self.foo(saved_state)
 
         self.checkModule(M(), (torch.rand(2, 2),))
 

--- a/torch/csrc/jit/passes/python_print.cpp
+++ b/torch/csrc/jit/passes/python_print.cpp
@@ -906,32 +906,40 @@ struct PythonPrintImpl {
       case prim::ListConstruct: {
         ListTypePtr list_type = node->output()->type()->expect<ListType>();
         TypePtr elem_type = list_type->getElementType();
-        if (!elem_type->isSubtypeOf(TensorType::get())) {
-          // when the list is empty and is not a list of tensors,
-          // we need to annotate it, otherwise it won't be possible
-          // to infer the type on import
-          if (node->inputs().size() == 0) {
-            stmt << "annotate(" << node->output()->type()->python_str()
-                 << ", [])";
-          } else if (!elementTypeCanBeInferredFromMembers(elem_type)) {
-            stmt << "annotate(" << node->output()->type()->python_str() << ",";
-            printValueList(stmt, node->inputs(), "[", "]");
-            stmt << ")";
-          } else {
-            printValueList(stmt, node->inputs(), "[", "]");
-          }
+        // Empty lists must be annotated with their type so the compiler knows
+        // what type is supposed to be inside them
+        if (node->inputs().size() == 0) {
+          stmt << "annotate(" << node->output()->type()->python_str()
+               << ", [])";
+          // If we can't infer the type based on what's inside, explicitly
+          // annotate it to disambiguate.
+          // This happens for List[Tensor] vs. List[Optional[Tensor]]
+        } else if (!elementTypeCanBeInferredFromMembers(elem_type)) {
+          stmt << "annotate(" << node->output()->type()->python_str() << ", ";
+          printValueList(stmt, node->inputs(), "[", "]");
+          stmt << ")";
+          // Otherwise just print a list
         } else {
           printValueList(stmt, node->inputs(), "[", "]");
         }
       } break;
       case prim::DictConstruct: {
         auto dict_type = node->output()->type()->expect<DictType>();
-        bool is_default_type =
-            dict_type->getKeyType()->isSubtypeOf(StringType::get()) &&
-            dict_type->getKeyType()->isSubtypeOf(TensorType::get());
-        if (node->inputs().size() == 0 && !is_default_type) {
+        // Empty dicts must be annotated with their type so the compiler knows
+        // what type is supposed to be inside them
+        if (node->inputs().size() == 0) {
           stmt << "annotate(" << node->output()->type()->python_str()
                << ", {})";
+          // If we can't infer the type based on what's inside, explicitly
+          // annotate it to disambiguate.
+          // This happens for Dict[str, Tensor] vs. Dict[str, Optional[Tensor]]
+        } else if (
+            !elementTypeCanBeInferredFromMembers(dict_type->getKeyType()) ||
+            !elementTypeCanBeInferredFromMembers(dict_type->getValueType())) {
+          stmt << "annotate(" << node->output()->type()->python_str() << ", ";
+          printDict(stmt, node->inputs());
+          stmt << ")";
+          // Otherwise just print a dict
         } else {
           printDict(stmt, node->inputs());
         }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#32569 [jit] Fix dict type serialization**

If the dict's contained types cannot be inferred from its contents (for
example, `Dict[str, Tensor]` vs. `Dict[str, Optional[Tensor]]`), we must
explicitly annotate the type.

Also this removes some special handling that omits annotations on empty
containers that have the default type. It makes the code more complex
for not too much value, and was wrong for dicts anyway.

Differential Revision: [D19551016](https://our.internmc.facebook.com/intern/diff/D19551016)