### PR TITLE
Fix iterator for ncclCommWatchdog.

### DIFF
--- a/torch/lib/c10d/ProcessGroupNCCL.hpp
+++ b/torch/lib/c10d/ProcessGroupNCCL.hpp
@@ -277,6 +277,8 @@ class ProcessGroupNCCL : public ProcessGroup {
   // object might get destroyed before the WorkNCCL object.
   void ncclCommWatchdog();
 
+  void ncclCommWatchdogInternal();
+
  protected:
   static const int64_t kWatchdogThreadSleepMillis;
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#32571 Fix iterator for ncclCommWatchdog.**

The watchdog thread would erase an element and call `it--` (implicitly
relying on `it++` in the for loop to position correctly). Although, `it--`
would cause undefined behavior if the iterator is pointing to begin(). As a
result, I've modified the logic to update the iterator appropriately.

I've also enhanced the watchdog thread to catch and log exceptions.

Differential Revision: [D19551365](https://our.internmc.facebook.com/intern/diff/D19551365/)