### PR TITLE
[aten] fix shadowing variable warning

### DIFF
--- a/aten/src/ATen/ParallelOpenMP.h
+++ b/aten/src/ATen/ParallelOpenMP.h
@@ -33,9 +33,8 @@ inline void parallel_for(
 
 #pragma omp parallel num_threads(num_threads)
   {
-    int64_t num_threads = omp_get_num_threads();
     int64_t tid = omp_get_thread_num();
-    int64_t chunk_size = divup((end - begin), num_threads);
+    int64_t chunk_size = divup((end - begin), omp_get_num_threads());
     int64_t begin_tid = begin + tid * chunk_size;
     if (begin_tid < end) {
       try {


### PR DESCRIPTION
Summary:
Fix the following warning
```
caffe2/aten/src/ATen/ParallelOpenMP.h:36:9: warning: declaration of ‘num_threads’ shadows a previous local [-Wshadow=compatible-local]
     int64_t num_threads = omp_get_num_threads();
         ^~~~~~~~~~~
caffe2/aten/src/ATen/ParallelOpenMP.h:29:9: note: shadowed declaration is here
   int64_t num_threads = omp_in_parallel() ? 1 : omp_get_max_threads();
         ^~~~~~~~~~~
```

Test Plan: CI

Differential Revision: D19552578

