### PR TITLE
fix windows build failure for no operator[] in random iterator

### DIFF
--- a/aten/src/ATen/core/List.h
+++ b/aten/src/ATen/core/List.h
@@ -140,6 +140,10 @@ public:
     return {iterator_};
   }
 
+  ListElementReference<T, Iterator> operator[](std::size_t pos) const {
+    return {iterator_ + pos};
+  }
+
 private:
   explicit ListIterator(Iterator iterator): iterator_(std::move(iterator)) {}
 


### PR DESCRIPTION
Some code use std::sort, and thus lead to failure when building on Windows, because MSVC's STL implementation use [] operator of ListIterator.