### PR TITLE
add diag into pt operator microbenchmark

### DIFF
--- a/benchmarks/operator_benchmark/benchmark_all_other_test.py
+++ b/benchmarks/operator_benchmark/benchmark_all_other_test.py
@@ -5,10 +5,10 @@ from __future__ import unicode_literals
 
 import operator_benchmark as op_bench
 from pt import ( # noqa
-    add_test, batchnorm_test, cat_test, chunk_test, conv_test,  # noqa
+    add_test, as_strided_test, batchnorm_test, binary_test, cat_test,  # noqa
+    chunk_test, conv_test, diag_test, embeddingbag_test, fill_test,  # noqa
     gather_test, linear_test, matmul_test, pool_test,  # noqa
-    softmax_test, split_test, fill_test, as_strided_test,  # noqa
-    embeddingbag_test, binary_test  # noqa
+    softmax_test  # noqa
 )
 
 if __name__ == "__main__":

--- a/benchmarks/operator_benchmark/pt/diag_test.py
+++ b/benchmarks/operator_benchmark/pt/diag_test.py
@@ -1,0 +1,43 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import operator_benchmark as op_bench
+import torch
+
+
+"""Microbenchmarks for diag operator"""
+
+
+# Configs for PT diag operator
+diag_configs_short = op_bench.config_list(
+    attr_names=['dim', 'M', 'N', 'diagonal', 'out'],
+    attrs=[
+        [1, 64, 64, 0, True],
+        [2, 128, 128, -10, False],
+        [1, 256, 256, 20, True],
+    ],
+    cross_product_configs={
+        'device': ['cpu', 'cuda'],
+    },
+    tags=['short'],
+)
+
+
+class DiagBenchmark(op_bench.TorchBenchmarkBase):
+    def init(self, dim, M, N, diagonal, out, device):
+        self.input = torch.rand(M, N, device=device) if dim == 2 else torch.rand(M, device=device)
+        self.diagonal = diagonal
+        self.out = torch.tensor((),) if out else None
+        self.set_module_name('diag')
+
+    def forward(self):
+        return torch.diag(self.input, diagonal=self.diagonal, out=self.out)
+
+
+op_bench.generate_pt_test(diag_configs_short, DiagBenchmark)
+
+
+if __name__ == "__main__":
+    op_bench.benchmark_runner.main()


### PR DESCRIPTION
Summary: Currently, there is no benchmark test about diag operator. This diff will add one into the suite.

Test Plan:
```
# ----------------------------------------
# PyTorch/Caffe2 Operator Micro-benchmarks
# ----------------------------------------
# Tag : short

# Benchmarking PyTorch: diag
# Mode: Eager
# Name: diag_dim1_M64_N64_diagonal0_outTrue_cpu
# Input: dim: 1, M: 64, N: 64, diagonal: 0, out: True, device: cpu
Forward Execution Time (us) : 28.496

# Benchmarking PyTorch: diag
# Mode: Eager
# Name: diag_dim2_M128_N128_diagonal-10_outFalse_cpu
# Input: dim: 2, M: 128, N: 128, diagonal: -10, out: False, device: cpu
Forward Execution Time (us) : 45.179

# Benchmarking PyTorch: diag
# Mode: Eager
# Name: diag_dim1_M256_N256_diagonal20_outTrue_cpu
# Input: dim: 1, M: 256, N: 256, diagonal: 20, out: True, device: cpu
Forward Execution Time (us) : 49.009
```

Differential Revision: D19564024

