### PR TITLE
[ROCm] Adjust elementwise_kernel settings on ROCm

### DIFF
--- a/aten/src/ATen/native/cuda/Loops.cuh
+++ b/aten/src/ATen/native/cuda/Loops.cuh
@@ -56,8 +56,8 @@
 
 #ifdef __HIP_PLATFORM_HCC__
 static constexpr int launch_size_1d = 1024;
-static constexpr int launch_size_nd = 1024;
-static constexpr int launch_bound2 = 1;
+static constexpr int launch_size_nd = 128;
+static constexpr int launch_bound2 = 4;
 #else
 static constexpr int launch_size_1d = 512;
 static constexpr int launch_size_nd = 128;

--- a/aten/src/ATen/native/cuda/Loops.cuh
+++ b/aten/src/ATen/native/cuda/Loops.cuh
@@ -54,15 +54,9 @@
 #define ASSERT_HOST_DEVICE_LAMBDA(type)
 #endif
 
-#ifdef __HIP_PLATFORM_HCC__
-static constexpr int launch_size_1d = 1024;
-static constexpr int launch_size_nd = 128;
-static constexpr int launch_bound2 = 4;
-#else
 static constexpr int launch_size_1d = 512;
 static constexpr int launch_size_nd = 128;
 static constexpr int launch_bound2 = 4;
-#endif
 
 
 namespace at { namespace native {

--- a/aten/src/ATen/native/cuda/Loops.cuh
+++ b/aten/src/ATen/native/cuda/Loops.cuh
@@ -54,15 +54,9 @@
 #define ASSERT_HOST_DEVICE_LAMBDA(type)
 #endif
 
-#ifdef __HIP_PLATFORM_HCC__
 static constexpr int launch_size_1d = 512;
 static constexpr int launch_size_nd = 128;
 static constexpr int launch_bound2 = 4;
-#else
-static constexpr int launch_size_1d = 512;
-static constexpr int launch_size_nd = 128;
-static constexpr int launch_bound2 = 4;
-#endif
 
 
 namespace at { namespace native {

--- a/aten/src/ATen/native/cuda/Loops.cuh
+++ b/aten/src/ATen/native/cuda/Loops.cuh
@@ -54,9 +54,15 @@
 #define ASSERT_HOST_DEVICE_LAMBDA(type)
 #endif
 
+#ifdef __HIP_PLATFORM_HCC__
+static constexpr int launch_size_1d = 1024;
+static constexpr int launch_size_nd = 128;
+static constexpr int launch_bound2 = 4;
+#else
 static constexpr int launch_size_1d = 512;
 static constexpr int launch_size_nd = 128;
 static constexpr int launch_bound2 = 4;
+#endif
 
 
 namespace at { namespace native {

--- a/aten/src/ATen/native/cuda/Loops.cuh
+++ b/aten/src/ATen/native/cuda/Loops.cuh
@@ -55,7 +55,7 @@
 #endif
 
 #ifdef __HIP_PLATFORM_HCC__
-static constexpr int launch_size_1d = 1024;
+static constexpr int launch_size_1d = 512;
 static constexpr int launch_size_nd = 128;
 static constexpr int launch_bound2 = 4;
 #else


### PR DESCRIPTION
Recent PR #31974 and upcoming PR #32383 are changing the behavior of the elementwise_kernel infrastructure on CUDA.

In order to stay in sync, change the nd-loop behavior to match ROCm and CUDA for now. Once the full rework is done, the ROCm settings will likely diverge again.