### PR TITLE
Make rpc.shutdown()/rpc._wait_all_workers() accept user-specified leader worker

### DIFF
--- a/torch/distributed/rpc/api.py
+++ b/torch/distributed/rpc/api.py
@@ -107,7 +107,7 @@ def _set_proceed_shutdown_signal():
 
 
 @_require_initialized
-def _wait_all_workers():
+def _wait_all_workers(exit_on_worker_done=None):
     r"""
     Block until all local and remote RPC processes reach this method and wait
     for all outstanding work to complete. Every RPC process must call this
@@ -118,7 +118,10 @@ def _wait_all_workers():
     assert (
         _ALL_WORKER_NAMES is not None
     ), "`_ALL_WORKER_NAMES` is not initialized for `def _wait_all_workers`."
-    leader_worker_name = sorted(_ALL_WORKER_NAMES)[0]
+    if exit_on_worker_done is not None:
+        leader_worker_name = _to_worker_info(exit_on_worker_done).name
+    else:
+        leader_worker_name = sorted(_ALL_WORKER_NAMES)[0]
 
     self_worker_name = _agent.get_worker_info().name
     assert (
@@ -132,13 +135,15 @@ def _wait_all_workers():
     if is_leader_worker:
         _on_leader_follower_report_shutdown_intent(self_worker_name)
     else:
-        rpc_sync(
-            leader_worker_name,
-            _on_leader_follower_report_shutdown_intent,
-            args=(self_worker_name,),
-        )
+        if exit_on_worker_done is None:
+            rpc_sync(
+                leader_worker_name,
+                _on_leader_follower_report_shutdown_intent,
+                args=(self_worker_name,),
+            )
 
-    _SHUTDOWN_PROCEED_SIGNAL.wait()
+    if not is_leader_worker or (is_leader_worker and exit_on_worker_done is None):
+        _SHUTDOWN_PROCEED_SIGNAL.wait()
 
     # Phase 2: Leader asks followers to proceed.
     # Leader's signal is the first to be unblocked,
@@ -164,7 +169,7 @@ def _wait_all_workers():
 
 
 @_require_initialized
-def shutdown(graceful=True):
+def shutdown(graceful=True, exit_on_worker_done=None):
     r"""
     Perform a shutdown of the RPC agent, and then destroy the RPC agent. This
     stops the local agent from  accepting outstanding requests, and shuts
@@ -179,6 +184,10 @@ def shutdown(graceful=True):
                          this will block until all local and remote RPC
                          processes have reached this method and wait for all
                          outstanding work to complete.
+        exit_on_worker_done (str or WorkerInfo): The worker to act as the leader in
+            sending out the termination command. Other workers act as followers.
+            Notice all workers should pass the same value as this argument,
+            otherwise they would hang on termination.
 
     Example::
         Make sure that ``MASTER_ADDRESS`` and ``MASTER_PORT`` are set properly
@@ -208,7 +217,7 @@ def shutdown(graceful=True):
     global _agent
 
     if graceful:
-        _wait_all_workers()
+        _wait_all_workers(exit_on_worker_done=exit_on_worker_done)
         _agent.join()
     try:
         # This raises a `TORCH_CHECK()` exception on RRef leak detected.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #32635 Use the C++ current RpcAgent pointer to eliminate the unnecessary argument passing from Python world
* #32633 Make C++ RpcAgent::defaultRPCAgent() the source of truth of current RPC Agent
* #32624 Make _wait_all_workers() support being called for multiple times
* **#32623 Make rpc.shutdown()/rpc._wait_all_workers() accept user-specified leader worker**

In the current `_wait_all_worker()` implementation, the procesure is as follows,
- A leader is elected.
- Every worker shows the shutdown intention to the leader node.
- After receiving intentions from all workers, the leader broadcasts the shutdown request to all follower nodes.

While in a user use case, (training toolkit), user has a similar implementation that, where
- The leader is specified by user.
- The termination is initialized by the "leader" node, regardless of the follower nodes' progress.

This PR adds the second protocol, with only one extra argument added.
This helps reduce duplicate implementations scattered around in user codebase.

Differential Revision: [D16453494](https://our.internmc.facebook.com/intern/diff/D16453494/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D16453494/)!