### PR TITLE
Use the C++ current RpcAgent pointer to eliminate the unnecessary argument passing from Python world

### DIFF
--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -282,25 +282,22 @@ If the future completes with an error, an exception is thrown.
 
   module.def(
       "_invoke_rpc_builtin",
-      [](RpcAgent& agent,
-         const WorkerInfo& dst,
+      [](const WorkerInfo& dst,
          const std::string& opName,
          const std::shared_ptr<torch::autograd::profiler::RecordFunction>& rf,
          const py::args& args,
          const py::kwargs& kwargs) {
-        return pyRpcBuiltin(agent, dst, opName, rf, args, kwargs);
+        return pyRpcBuiltin(dst, opName, rf, args, kwargs);
       });
 
   module.def(
       "_invoke_rpc_python_udf",
-      [](RpcAgent& agent,
-         const WorkerInfo& dst,
+      [](const WorkerInfo& dst,
          std::string& pickledPythonUDF,
          std::vector<torch::Tensor>& tensors,
          const std::shared_ptr<torch::autograd::profiler::RecordFunction>& rf) {
-        return pyRpcPythonUdf(agent, dst, pickledPythonUDF, tensors, rf);
+        return pyRpcPythonUdf(dst, pickledPythonUDF, tensors, rf);
       },
-      py::arg("agent"),
       py::arg("dst"),
       py::arg("pickledPythonUDF"),
       py::arg("tensors"),
@@ -360,13 +357,12 @@ If the future completes with an error, an exception is thrown.
 
   module.def(
       "_invoke_remote_builtin",
-      [](RpcAgent& agent,
-         const WorkerInfo& dst,
+      [](const WorkerInfo& dst,
          const std::string& opName,
          const std::shared_ptr<torch::autograd::profiler::RecordFunction>& rf,
          const py::args& args,
          const py::kwargs& kwargs) {
-        return pyRemoteBuiltin(agent, dst, opName, rf, args, kwargs);
+        return pyRemoteBuiltin(dst, opName, rf, args, kwargs);
       });
 
   module.def(
@@ -389,14 +385,12 @@ If the future completes with an error, an exception is thrown.
 
   module.def(
       "_invoke_remote_python_udf",
-      [](RpcAgent& agent,
-         const WorkerInfo& dst,
+      [](const WorkerInfo& dst,
          std::string& pickledPythonUDF,
          std::vector<torch::Tensor>& tensors,
          const std::shared_ptr<torch::autograd::profiler::RecordFunction>& rf) {
-        return pyRemotePythonUdf(agent, dst, pickledPythonUDF, tensors, rf);
+        return pyRemotePythonUdf(dst, pickledPythonUDF, tensors, rf);
       },
-      py::arg("agent"),
       py::arg("dst"),
       py::arg("pickledPythonUDF"),
       py::arg("tensors"),

--- a/torch/csrc/distributed/rpc/python_functions.cpp
+++ b/torch/csrc/distributed/rpc/python_functions.cpp
@@ -72,7 +72,6 @@ void finishCreatingOwnerRRef(
 }
 
 std::shared_ptr<FutureMessage> sendPythonRemoteCall(
-    RpcAgent& agent,
     const WorkerInfo& dst,
     SerializedPyObj serializedPyObj,
     const IValue& rrefId,
@@ -83,8 +82,9 @@ std::shared_ptr<FutureMessage> sendPythonRemoteCall(
 
   // set forceGradRecording to true as even if the args does not contain any
   // tensor, the return value might still contain tensors.
+  auto agent = RpcAgent::getDefaultRpcAgent();
   return torch::distributed::autograd::sendMessageWithAutograd(
-      agent,
+      *agent,
       dst,
       std::move(*pythonRemoteCall).toMessage(),
       true /*forceGradRecording*/,
@@ -128,7 +128,6 @@ py::object toPyObj(const Message& message) {
 }
 
 std::shared_ptr<FutureMessage> pyRpcBuiltin(
-    RpcAgent& agent,
     const WorkerInfo& dst,
     const std::string& opName,
     const std::shared_ptr<torch::autograd::profiler::RecordFunction>& rf,
@@ -137,12 +136,12 @@ std::shared_ptr<FutureMessage> pyRpcBuiltin(
   Stack stack;
   auto op = matchBuiltinOp(opName, args, kwargs, stack);
   auto scriptCall = std::make_unique<ScriptCall>(op, std::move(stack));
+  auto agent = RpcAgent::getDefaultRpcAgent();
   return sendMessageWithAutograd(
-      agent, dst, std::move(*scriptCall).toMessage(), false, rf);
+      *agent, dst, std::move(*scriptCall).toMessage(), false, rf);
 }
 
 PyRRef pyRemoteBuiltin(
-    RpcAgent& agent,
     const WorkerInfo& dst,
     const std::string& opName,
     const std::shared_ptr<torch::autograd::profiler::RecordFunction>& rf,
@@ -162,8 +161,9 @@ PyRRef pyRemoteBuiltin(
   auto scriptRemoteCall = std::make_unique<ScriptRemoteCall>(
       op, std::move(stack), userRRef->rrefId(), userRRef->forkId());
 
+  auto agent = RpcAgent::getDefaultRpcAgent();
   auto fm = sendMessageWithAutograd(
-      agent, dst, std::move(*scriptRemoteCall).toMessage(), false, rf);
+      *agent, dst, std::move(*scriptRemoteCall).toMessage(), false, rf);
 
   ctx.addPendingUser(userRRef->forkId(), userRRef);
   fm->addCallback(callback::confirmPendingUser);
@@ -171,7 +171,6 @@ PyRRef pyRemoteBuiltin(
 }
 
 std::shared_ptr<FutureMessage> pyRpcPythonUdf(
-    RpcAgent& agent,
     const WorkerInfo& dst,
     std::string& pickledPythonUDF,
     std::vector<torch::Tensor>& tensors,
@@ -179,8 +178,10 @@ std::shared_ptr<FutureMessage> pyRpcPythonUdf(
   auto pythonCall = std::make_unique<PythonCall>(
       std::vector<char>(pickledPythonUDF.begin(), pickledPythonUDF.end()),
       tensors);
+
+  auto agent = RpcAgent::getDefaultRpcAgent();
   return sendMessageWithAutograd(
-      agent,
+      *agent,
       dst,
       std::move(*pythonCall).toMessage(),
       true /*forceGradRecording*/,
@@ -188,7 +189,6 @@ std::shared_ptr<FutureMessage> pyRpcPythonUdf(
 }
 
 PyRRef pyRemotePythonUdf(
-    RpcAgent& agent,
     const WorkerInfo& dst,
     std::string& pickledPythonUDF,
     std::vector<torch::Tensor>& tensors,
@@ -196,11 +196,11 @@ PyRRef pyRemotePythonUdf(
   auto& ctx = RRefContext::getInstance();
   auto serializedPyObj =
       SerializedPyObj(std::move(pickledPythonUDF), std::move(tensors));
+  auto agent = RpcAgent::getDefaultRpcAgent();
   if (ctx.getWorkerId() != dst.id_) {
     auto userRRef = ctx.createUserRRef(dst.id_, PyObjectType::get());
     ctx.addPendingUser(userRRef->forkId(), userRRef);
     auto fm = sendPythonRemoteCall(
-        agent,
         dst,
         std::move(serializedPyObj),
         userRRef->rrefId().toIValue(),
@@ -214,7 +214,6 @@ PyRRef pyRemotePythonUdf(
     // prevent this owner RRef be deleted due to other forks
     ctx.addSelfAsFork(ownerRRef);
     auto fm = sendPythonRemoteCall(
-        agent,
         dst,
         std::move(serializedPyObj),
         ownerRRef->rrefId().toIValue(),

--- a/torch/csrc/distributed/rpc/python_functions.h
+++ b/torch/csrc/distributed/rpc/python_functions.h
@@ -12,7 +12,6 @@ namespace rpc {
 py::object toPyObj(const Message& message);
 
 std::shared_ptr<FutureMessage> pyRpcBuiltin(
-    RpcAgent& agent,
     const WorkerInfo& dst,
     const std::string& opName,
     const std::shared_ptr<torch::autograd::profiler::RecordFunction>& rf,
@@ -20,14 +19,12 @@ std::shared_ptr<FutureMessage> pyRpcBuiltin(
     const py::kwargs& kwargs);
 
 std::shared_ptr<FutureMessage> pyRpcPythonUdf(
-    RpcAgent& agent,
     const WorkerInfo& dst,
     std::string& pickledPythonUDF,
     std::vector<torch::Tensor>& tensors,
     const std::shared_ptr<torch::autograd::profiler::RecordFunction>& rf);
 
 PyRRef pyRemoteBuiltin(
-    RpcAgent& agent,
     const WorkerInfo& dst,
     const std::string& opName,
     const std::shared_ptr<torch::autograd::profiler::RecordFunction>& rf,
@@ -35,7 +32,6 @@ PyRRef pyRemoteBuiltin(
     const py::kwargs& kwargs);
 
 PyRRef pyRemotePythonUdf(
-    RpcAgent& agent,
     const WorkerInfo& dst,
     std::string& pickledPythonUDF,
     std::vector<torch::Tensor>& tensors,

--- a/torch/distributed/rpc/api.py
+++ b/torch/distributed/rpc/api.py
@@ -464,12 +464,12 @@ def _invoke_rpc(to, func, rpc_type, args=None, kwargs=None):
     kwargs = kwargs if kwargs else {}
 
     if qualified_name is not None:
-        fut = _invoke_rpc_builtin(get_current_rpc_agent(), info, qualified_name, rf, *args, **kwargs)
+        fut = _invoke_rpc_builtin(info, qualified_name, rf, *args, **kwargs)
     else:
         (pickled_python_udf, tensors) = _default_pickler.serialize(
             PythonUDF(func, args, kwargs)
         )
-        fut = _invoke_rpc_python_udf(get_current_rpc_agent(), info, pickled_python_udf, tensors, rf)
+        fut = _invoke_rpc_python_udf(info, pickled_python_udf, tensors, rf)
     return fut
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

With the source of truth of current RPC agent moved to C++ world, there is no point of passing current RPC agent from Python world to C++ world.

Differential Revision: [D5703519](https://our.internmc.facebook.com/intern/diff/D5703519/)