### PR TITLE
Fix flaky test_nccl_timeout.

### DIFF
--- a/test/distributed/test_c10d.py
+++ b/test/distributed/test_c10d.py
@@ -3276,7 +3276,8 @@ class NcclErrorHandlingTest(MultiProcessTestCase):
         if self.rank == 0:
             # This should timeout in about 1 second.
             start = time.time()
-            with self.assertRaisesRegex(RuntimeError, "Operation timed out!"):
+            # Watchdog may abort timed out work resulting in NCCL error instead of operation timed out.
+            with self.assertRaisesRegex(RuntimeError, "(Operation timed out!)|(NCCL error: unhandled system error)"):
                 c10d.distributed_c10d.all_reduce(torch.rand(10).cuda(self.rank))
         else:
             # Ensure the other rank sleeps to trigger timeout.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#32653 Fix flaky test_nccl_timeout.**

This test was flaky since the watchdog thread could abort the
communicator instead of the thread calling `wait()`. As a result, we could
actually see `NCCL error` instead of `Operation timed out` on the user end.

Closes https://github.com/pytorch/pytorch/issues/32505

Differential Revision: [D19583003](https://our.internmc.facebook.com/intern/diff/D19583003/)