### PR TITLE
Get rid of some unused THGenerate*Type defines.

### DIFF
--- a/aten/src/TH/THGenerateBFloat16Type.h
+++ b/aten/src/TH/THGenerateBFloat16Type.h
@@ -5,7 +5,6 @@
 #include <c10/util/BFloat16.h>
 #define scalar_t at::BFloat16
 #define accreal double
-#define TH_CONVERT_ACCREAL_TO_REAL(_val) (scalar_t)(_val)
 #define Real BFloat16
 #define TH_REAL_IS_BFLOAT16
 #line 1 TH_GENERIC_FILE
@@ -14,7 +13,6 @@
 #undef scalar_t
 #undef Real
 #undef TH_REAL_IS_BFLOAT16
-#undef TH_CONVERT_ACCREAL_TO_REAL
 
 #ifndef THGenerateManyTypes
 #undef TH_GENERIC_FILE

--- a/aten/src/TH/THGenerateBoolType.h
+++ b/aten/src/TH/THGenerateBoolType.h
@@ -3,21 +3,15 @@
 #endif
 
 #define scalar_t bool
-#define ureal bool
 #define accreal int64_t
 #define Real Bool
-#define TH_CONVERT_REAL_TO_ACCREAL(_val) (accreal)(_val)
-#define TH_CONVERT_ACCREAL_TO_REAL(_val) (scalar_t)(_val)
 #define TH_REAL_IS_BOOL
 #line 1 TH_GENERIC_FILE
 #include TH_GENERIC_FILE
 #undef scalar_t
-#undef ureal
 #undef accreal
 #undef Real
 #undef TH_REAL_IS_BOOL
-#undef TH_CONVERT_REAL_TO_ACCREAL
-#undef TH_CONVERT_ACCREAL_TO_REAL
 
 #ifndef THGenerateManyTypes
 #undef TH_GENERIC_FILE

--- a/aten/src/TH/THGenerateByteType.h
+++ b/aten/src/TH/THGenerateByteType.h
@@ -3,23 +3,15 @@
 #endif
 
 #define scalar_t uint8_t
-#define ureal uint8_t
 #define accreal int64_t
 #define Real Byte
-#define TH_CONVERT_REAL_TO_ACCREAL(_val) (accreal)(_val)
-#define TH_CONVERT_ACCREAL_TO_REAL(_val) (scalar_t)(_val)
-#define THInf UCHAR_MAX
 #define TH_REAL_IS_BYTE
 #line 1 TH_GENERIC_FILE
 #include TH_GENERIC_FILE
 #undef scalar_t
-#undef ureal
 #undef accreal
 #undef Real
-#undef THInf
 #undef TH_REAL_IS_BYTE
-#undef TH_CONVERT_REAL_TO_ACCREAL
-#undef TH_CONVERT_ACCREAL_TO_REAL
 
 #ifndef THGenerateManyTypes
 #undef TH_GENERIC_FILE

--- a/aten/src/TH/THGenerateCharType.h
+++ b/aten/src/TH/THGenerateCharType.h
@@ -3,23 +3,15 @@
 #endif
 
 #define scalar_t int8_t
-#define ureal uint8_t
 #define accreal int64_t
 #define Real Char
-#define THInf SCHAR_MAX
-#define TH_CONVERT_REAL_TO_ACCREAL(_val) (accreal)(_val)
-#define TH_CONVERT_ACCREAL_TO_REAL(_val) (scalar_t)(_val)
 #define TH_REAL_IS_CHAR
 #line 1 TH_GENERIC_FILE
 #include TH_GENERIC_FILE
 #undef scalar_t
-#undef ureal
 #undef accreal
 #undef Real
-#undef THInf
 #undef TH_REAL_IS_CHAR
-#undef TH_CONVERT_REAL_TO_ACCREAL
-#undef TH_CONVERT_ACCREAL_TO_REAL
 
 #ifndef THGenerateManyTypes
 #undef TH_GENERIC_FILE

--- a/aten/src/TH/THGenerateDoubleType.h
+++ b/aten/src/TH/THGenerateDoubleType.h
@@ -4,20 +4,14 @@
 
 #define scalar_t double
 #define accreal double
-#define TH_CONVERT_REAL_TO_ACCREAL(_val) (accreal)(_val)
-#define TH_CONVERT_ACCREAL_TO_REAL(_val) (scalar_t)(_val)
 #define Real Double
-#define THInf DBL_MAX
 #define TH_REAL_IS_DOUBLE
 #line 1 TH_GENERIC_FILE
 #include TH_GENERIC_FILE
 #undef accreal
 #undef scalar_t
 #undef Real
-#undef THInf
 #undef TH_REAL_IS_DOUBLE
-#undef TH_CONVERT_REAL_TO_ACCREAL
-#undef TH_CONVERT_ACCREAL_TO_REAL
 
 #ifndef THGenerateManyTypes
 #undef TH_GENERIC_FILE

--- a/aten/src/TH/THGenerateFloatType.h
+++ b/aten/src/TH/THGenerateFloatType.h
@@ -4,20 +4,14 @@
 
 #define scalar_t float
 #define accreal double
-#define TH_CONVERT_REAL_TO_ACCREAL(_val) (accreal)(_val)
-#define TH_CONVERT_ACCREAL_TO_REAL(_val) (scalar_t)(_val)
 #define Real Float
-#define THInf FLT_MAX
 #define TH_REAL_IS_FLOAT
 #line 1 TH_GENERIC_FILE
 #include TH_GENERIC_FILE
 #undef accreal
 #undef scalar_t
 #undef Real
-#undef THInf
 #undef TH_REAL_IS_FLOAT
-#undef TH_CONVERT_REAL_TO_ACCREAL
-#undef TH_CONVERT_ACCREAL_TO_REAL
 
 #ifndef THGenerateManyTypes
 #undef TH_GENERIC_FILE

--- a/aten/src/TH/THGenerateHalfType.h
+++ b/aten/src/TH/THGenerateHalfType.h
@@ -5,20 +5,14 @@
 #include <TH/THHalf.h>
 #define scalar_t THHalf
 #define accreal float
-#define TH_CONVERT_REAL_TO_ACCREAL(_val) (accreal)(_val)
-#define TH_CONVERT_ACCREAL_TO_REAL(_val) (scalar_t)(_val)
 #define Real Half
-#define THInf TH_HALF_BITS_TO_LITERAL(TH_HALF_INF)
 #define TH_REAL_IS_HALF
 #line 1 TH_GENERIC_FILE
 #include TH_GENERIC_FILE
 #undef scalar_t
 #undef accreal
 #undef Real
-#undef THInf
 #undef TH_REAL_IS_HALF
-#undef TH_CONVERT_REAL_TO_ACCREAL
-#undef TH_CONVERT_ACCREAL_TO_REAL
 
 #ifndef THGenerateManyTypes
 #undef TH_GENERIC_FILE

--- a/aten/src/TH/THGenerateIntType.h
+++ b/aten/src/TH/THGenerateIntType.h
@@ -3,23 +3,15 @@
 #endif
 
 #define scalar_t int32_t
-#define ureal uint32_t
 #define accreal int64_t
-#define TH_CONVERT_REAL_TO_ACCREAL(_val) (accreal)(_val)
-#define TH_CONVERT_ACCREAL_TO_REAL(_val) (scalar_t)(_val)
 #define Real Int
-#define THInf INT_MAX
 #define TH_REAL_IS_INT
 #line 1 TH_GENERIC_FILE
 #include TH_GENERIC_FILE
 #undef scalar_t
-#undef ureal
 #undef accreal
 #undef Real
-#undef THInf
 #undef TH_REAL_IS_INT
-#undef TH_CONVERT_REAL_TO_ACCREAL
-#undef TH_CONVERT_ACCREAL_TO_REAL
 
 #ifndef THGenerateManyTypes
 #undef TH_GENERIC_FILE

--- a/aten/src/TH/THGenerateLongType.h
+++ b/aten/src/TH/THGenerateLongType.h
@@ -3,23 +3,15 @@
 #endif
 
 #define scalar_t int64_t
-#define ureal uint64_t
 #define accreal int64_t
-#define TH_CONVERT_REAL_TO_ACCREAL(_val) (accreal)(_val)
-#define TH_CONVERT_ACCREAL_TO_REAL(_val) (scalar_t)(_val)
 #define Real Long
-#define THInf LONG_MAX
 #define TH_REAL_IS_LONG
 #line 1 TH_GENERIC_FILE
 #include TH_GENERIC_FILE
 #undef scalar_t
-#undef ureal
 #undef accreal
 #undef Real
-#undef THInf
 #undef TH_REAL_IS_LONG
-#undef TH_CONVERT_REAL_TO_ACCREAL
-#undef TH_CONVERT_ACCREAL_TO_REAL
 
 #ifndef THGenerateManyTypes
 #undef TH_GENERIC_FILE

--- a/aten/src/TH/THGenerateShortType.h
+++ b/aten/src/TH/THGenerateShortType.h
@@ -3,23 +3,15 @@
 #endif
 
 #define scalar_t int16_t
-#define ureal uint16_t
 #define accreal int64_t
-#define TH_CONVERT_REAL_TO_ACCREAL(_val) (accreal)(_val)
-#define TH_CONVERT_ACCREAL_TO_REAL(_val) (scalar_t)(_val)
 #define Real Short
-#define THInf SHRT_MAX
 #define TH_REAL_IS_SHORT
 #line 1 TH_GENERIC_FILE
 #include TH_GENERIC_FILE
 #undef scalar_t
-#undef ureal
 #undef accreal
 #undef Real
-#undef THInf
 #undef TH_REAL_IS_SHORT
-#undef TH_CONVERT_REAL_TO_ACCREAL
-#undef TH_CONVERT_ACCREAL_TO_REAL
 
 #ifndef THGenerateManyTypes
 #undef TH_GENERIC_FILE


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#32657 Get rid of some unused THGenerate*Type defines.**
* #32600 Kill some more unused code in function_wrapper.py
* #32599 Kill THIntegerTensor, THDenseTensor, THDenseIndexTensor.

The goal here is to simplify the codegen enough that we can just handwrite the bindings, so anything in here is "bad".

Differential Revision: [D19584521](https://our.internmc.facebook.com/intern/diff/D19584521)