### PR TITLE
Bugfix for add_hparams #32651

### DIFF
--- a/torch/utils/tensorboard/writer.py
+++ b/torch/utils/tensorboard/writer.py
@@ -299,16 +299,11 @@ class SummaryWriter(object):
             raise TypeError('hparam_dict and metric_dict should be dictionary.')
         exp, ssi, sei = hparams(hparam_dict, metric_dict)
 
-        logdir = os.path.join(
-            self._get_file_writer().get_logdir(),
-            str(time.time())
-        )
-        with SummaryWriter(log_dir=logdir) as w_hp:
-            w_hp.file_writer.add_summary(exp)
-            w_hp.file_writer.add_summary(ssi)
-            w_hp.file_writer.add_summary(sei)
-            for k, v in metric_dict.items():
-                w_hp.add_scalar(k, v)
+        self._get_file_writer().add_summary(exp)
+        self._get_file_writer().add_summary(ssi)
+        self._get_file_writer().add_summary(sei)
+        for k, v in metric_dict.items():
+            self._get_file_writer().add_scalar(k, v)
 
     def add_scalar(self, tag, scalar_value, global_step=None, walltime=None):
         """Add scalar data to summary.

--- a/torch/utils/tensorboard/writer.py
+++ b/torch/utils/tensorboard/writer.py
@@ -303,7 +303,7 @@ class SummaryWriter(object):
         self._get_file_writer().add_summary(ssi)
         self._get_file_writer().add_summary(sei)
         for k, v in metric_dict.items():
-            self._get_file_writer().add_scalar(k, v)
+            self._get_file_writer().add_summary(scalar(k, v))
 
     def add_scalar(self, tag, scalar_value, global_step=None, walltime=None):
         """Add scalar data to summary.


### PR DESCRIPTION
Removed a bit of code that appends the current time to the directory for the SummaryWriter and changed the add_summary function to operate directly on self._get_file_writer() instead of creating a new SummaryWriter. The result is hyperparameters logged in the same record file where add_scalar() also logs.