### PR TITLE
Optimize error checking in mvlgamma

### DIFF
--- a/aten/src/ATen/native/UnaryOps.cpp
+++ b/aten/src/ATen/native/UnaryOps.cpp
@@ -276,23 +276,23 @@ Tensor& _clamp_min_out_cpu(Tensor& result, const Tensor& self, Scalar min) {
   return result;
 }
 
-Tensor mvlgamma(const Tensor& self, int64_t p) {
+static inline void mvlgamma_check(const Tensor& self, int64_t p) {
   TORCH_CHECK(at::isFloatingType(self.scalar_type()),
-           "mvlgamma is not implemented for ", self.scalar_type());
-  TORCH_CHECK((self > 0.5 * (p - 1.)).all().item<uint8_t>(),
-           "Condition for computing multivariate log-gamma not met");
+              "mvlgamma is not implemented for ", self.scalar_type());
+  TORCH_CHECK((self > 0.5f * (p - 1)).all().item<bool>(),
+              "All elements must be greater than (p-1)/2");
   TORCH_CHECK(p >= 1, "p has to be greater than or equal to 1");
+}
+
+Tensor mvlgamma(const Tensor& self, int64_t p) {
+  mvlgamma_check(self, p);
   Tensor args = native::arange(-p / 2. + 0.5, 0.5, 0.5, self.options());
   args = args.add(self.unsqueeze(-1));
   return args.lgamma_().sum(-1).add_(p * (p - 1) * std::log(M_PI) / 4.);
 }
 
 Tensor& mvlgamma_(Tensor& self, int64_t p) {
-  TORCH_CHECK(at::isFloatingType(self.scalar_type()),
-           "mvlgamma is not implemented for ", self.scalar_type());
-  TORCH_CHECK((self > 0.5 * (p - 1.)).all().item<uint8_t>(),
-           "Condition for computing multivariate log-gamma not met");
-  TORCH_CHECK(p >= 1, "p has to be greater than or equal to 1");
+  mvlgamma_check(self, p);
   Tensor args = native::arange(-p / 2. + 0.5, 0.5, 0.5, self.options());
   args = args.add(self.unsqueeze(-1));
   return self.copy_(args.lgamma_().sum(-1).add_(p * (p - 1) * std::log(M_PI) / 4.));

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -368,7 +368,7 @@ class _TestTorchMixin(object):
             input = torch.linspace((d - 2) / 2, 10, 10)
             torch.mvlgamma(input, d)
 
-        with self.assertRaisesRegex(RuntimeError, "Condition for computing multivariate log-gamma not met"):
+        with self.assertRaisesRegex(RuntimeError, r"All elements must be greater than \(p-1\)/2"):
             run_test(3)
 
     def test_msnpu_error(self):


### PR DESCRIPTION
- Clean up error checking code
- Avoid unecessary floating-point computation
- Use float instead of double when possible to avoid massive cast in the tensor
- Use bool instead of uint8_t for clear Boolean purpose
- Improve error message

