### PR TITLE
Removing @expectedFailureXLA from test_nll_loss_empty_tensor_reduction_mean

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -10647,7 +10647,6 @@ class TestNNDeviceType(NNTestCase):
         self._nll_loss_helper([2, 3, 5, 7, 0], "none", torch.empty([2, 5, 7, 0], device=device), device)
 
     @unittest.skipIf(TEST_WITH_UBSAN, "division-by-zero error with UBSAN")
-    @expectedFailureXLA  # https://github.com/pytorch/xla/issues/1539
     def test_nll_loss_empty_tensor_reduction_mean(self, device):
         nan = torch.tensor(float('nan'), device=device)
         self._nll_loss_helper([0, 3], "mean", nan, device)


### PR DESCRIPTION
Because it's disabled in XLA(https://github.com/pytorch/xla/pull/1563)
Discussed in https://github.com/pytorch/xla/issues/1539

Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#32701 Removing @expectedFailureXLA from test_nll_loss_empty_tensor_reduction_mean**

Differential Revision: [D19633349](https://our.internmc.facebook.com/intern/diff/D19633349)