### PR TITLE
Remove -Werror from test/cpp_extensions/setup.py

### DIFF
--- a/test/cpp_extensions/setup.py
+++ b/test/cpp_extensions/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 from torch.utils.cpp_extension import BuildExtension, CppExtension, CUDAExtension
 from torch.utils.cpp_extension import CUDA_HOME
 
-CXX_FLAGS = ['/sdl', '/permissive-'] if sys.platform == 'win32' else ['-g', '-Werror']
+CXX_FLAGS = ['/sdl', '/permissive-'] if sys.platform == 'win32' else ['-g']
 
 ext_modules = [
     CppExtension(

--- a/test/test_cpp_extensions.py
+++ b/test/test_cpp_extensions.py
@@ -21,7 +21,7 @@ try:
 except ImportError:
     warnings.warn(
         "test_cpp_extensions.py cannot be invoked directly. Run "
-        "`python run_test.py -i cpp_extensions` instead."
+        "`python run_test.py -i test_cpp_extensions` instead."
     )
 
 


### PR DESCRIPTION
-Werror is too aggressive check for test cpp extensions because it fails even on deprecation warnings which is are included from core codebase.

Fixes #32136

Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#32704 Remove -Werror from test/cpp_extensions/setup.py**

Differential Revision: [D19620190](https://our.internmc.facebook.com/intern/diff/D19620190)