### PR TITLE
enable empty batch for all flavor of convolutions

### DIFF
--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -593,7 +593,7 @@ at::Tensor _convolution(
 
   check_shape_forward(input, weight_sizes, bias, params, input_is_mkldnn);
 
-  if (input.size(0) == 0 || input.size(1) == 0) {    
+  if (input.size(0) == 0) {    
     // don't send empty inputs through backends
     // but need to compute correct output size first and set up history for params
     std::vector<int64_t> o;

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -565,10 +565,11 @@ at::Tensor _convolution(
   auto k = weight.ndimension();
   // mkldnn conv2d weights could have been re-ordered to 5d by
   // mkldnn_reorder_conv2d_weight
+  std::vector<int64_t> weight_sizes_mkl;
   c10::IntArrayRef weight_sizes = weight.sizes();
   if (input_is_mkldnn && (k == input.ndimension() + 1)) {
     k = input.ndimension();
-    std::vector<int64_t> weight_sizes_mkl(k);
+    weight_sizes_mkl.resize(k);
     weight_sizes_mkl[0] = weight.size(0) * weight.size(1);
     std::copy_n(
         weight.sizes().cbegin() + 2, k - 1, weight_sizes_mkl.begin() + 1);
@@ -605,7 +606,7 @@ at::Tensor _convolution(
                            params.stride, params.dilation);
     }
     //return a view of input rather than empty tensor to not break the gradient chain
-    return input.view(o);
+    return input.clone().view(o);
   }
 
   if (k == 3) {

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -405,7 +405,7 @@ static void check_shape_forward(const at::Tensor& input,
 
   TORCH_CHECK(weight_dim == k,
            "Expected ", weight_dim, "-dimensional input for ", weight_dim,
-           "-dimensional weight [", weight_sizes, "], but got ", k, "-dimensional input of size ",
+           "-dimensional weight ", weight_sizes, ", but got ", k, "-dimensional input of size ",
            input.sizes(), " instead");
   TORCH_CHECK(weight_sizes[0] >= groups,
            "Given groups=", groups, ", expected weight to be at least ", groups,

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -388,22 +388,10 @@ auto ConvParams::use_cudnn_depthwise(
 }
 
 static void check_shape_forward(const at::Tensor& input,
-                                const at::Tensor& weight, const at::Tensor& bias,
+                                const c10::IntArrayRef& weight_sizes, const at::Tensor& bias,
                                 const ConvParams& params, bool input_is_mkldnn) {
   int64_t k = input.ndimension();
-  int64_t weight_dim = weight.ndimension();
-  std::vector<int64_t> weight_sizes(weight_dim);
-  // mkldnn conv2d weights could have been re-ordered to 5d by
-  // mkldnn_reorder_conv2d_weight
-  if ((weight_dim == k + 1) && input_is_mkldnn) {
-    weight_sizes[0] = weight.size(0) * weight.size(1);
-    std::copy_n(
-        weight.sizes().cbegin() + 2, k - 1, weight_sizes.begin() + 1);
-    weight_dim = k;
-  } else {
-    std::copy_n(
-        weight.sizes().cbegin(), weight_dim, weight_sizes.begin());
-  }
+  int64_t weight_dim = weight_sizes.size();
   int64_t groups = params.groups;
   auto padding = params.padding;
   auto output_padding = params.output_padding;
@@ -577,10 +565,17 @@ at::Tensor _convolution(
   auto k = weight.ndimension();
   // mkldnn conv2d weights could have been re-ordered to 5d by
   // mkldnn_reorder_conv2d_weight
+  c10::IntArrayRef weight_sizes = weight.sizes();
   if (input_is_mkldnn && (k == input.ndimension() + 1)) {
     k = input.ndimension();
+    std::vector<int64_t> weight_sizes_mkl(k);
+    weight_sizes_mkl[0] = weight.size(0) * weight.size(1);
+    std::copy_n(
+        weight.sizes().cbegin() + 2, k - 1, weight_sizes_mkl.begin() + 1);
+    weight_sizes = c10::IntArrayRef(weight_sizes_mkl);
   }
   int64_t dim = k - 2;
+  
 
   TORCH_CHECK(dim > 0, "weight should have at least three dimensions");
 
@@ -595,7 +590,23 @@ at::Tensor _convolution(
   params.deterministic = deterministic;
   params.cudnn_enabled = cudnn_enabled;
 
-  check_shape_forward(input, weight, bias, params, input_is_mkldnn);
+  check_shape_forward(input, weight_sizes, bias, params, input_is_mkldnn);
+
+  if (input.size(0) == 0 || input.size(1) == 0) {
+    // don't send empty inputs through backends
+    // but need to compute correct output size first
+    std::vector<int64_t> o;
+    if (params.transposed) {
+      o = conv_input_size(input.sizes(), weight_sizes, params.padding,
+                          params.output_padding, params.stride, params.dilation,
+                          params.groups);
+    } else {
+      o = conv_output_size(input.sizes(), weight_sizes, params.padding,
+                           params.stride, params.dilation);
+    }
+    //return a view of input rather than empty tensor to not break the gradient chain
+    return input.view(o);
+  }
 
   if (k == 3) {
     // avoid accidentally going through NHWC for permuted 3d input.

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9054,6 +9054,14 @@ class TestNNDeviceType(NNTestCase):
             with torch.backends.cudnn.flags(enabled=False):
                 self._test_module_empty_input(mod, inp, check_size=False)
 
+    def test_ConvTranspose_empty(self, device):
+        mod = torch.nn.ConvTranspose2d(4, 4, stride=2, kernel_size=3, padding=1).to(device)
+        inp = torch.randn(0, 4, 4, 4)
+        self._test_module_empty_input(mod, inp, check_size=False)
+        if self.device_type == 'cuda' and self.has_cudnn():
+            with torch.backends.cudnn.flags(enabled=False):
+                self._test_module_empty_input(mod, inp, check_size=False)
+
     def test_one_hot(self, device):
         with self.assertRaises(RuntimeError):
             torch.nn.functional.one_hot(torch.tensor([3, 4, -1, 0], device=device), -1)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -918,7 +918,7 @@ class TestNN(NNTestCase):
         w = torch.randn(6, 1, 5, 5)
 
         with self.assertRaisesRegex(RuntimeError,
-                                    r'Expected 4-dimensional input for 4-dimensional weight 6 1 5 5,' +
+                                    r'Expected 4-dimensional input for 4-dimensional weight \[6, 1, 5, 5\],' +
                                     r' but got 5-dimensional input of size \[1, 10, 1, 28, 28\] instead'):
 
             F.conv2d(x, w)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -8937,7 +8937,7 @@ class TestNNDeviceType(NNTestCase):
         output.sum().backward()
         self.assertEqual(output.type(), input.type())
 
-    def _test_module_empty_input(self, module, inp, check_size = True):
+    def _test_module_empty_input(self, module, inp, check_size=True):
         inp.requires_grad_(True)
         out = module(inp)
         gO = torch.rand_like(out)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9048,7 +9048,7 @@ class TestNNDeviceType(NNTestCase):
 
     def test_group_conv_empty(self, device):
         mod = torch.nn.Conv2d(4, 4, stride=2, kernel_size=3, padding=1, groups=4).to(device)
-        inp = torch.randn(0, 4, 4, 4)
+        inp = torch.randn(0, 4, 4, 4, device=device)
         self._test_module_empty_input(mod, inp, check_size=False)
         if self.device_type == 'cuda' and self.has_cudnn():
             with torch.backends.cudnn.flags(enabled=False):
@@ -9056,7 +9056,7 @@ class TestNNDeviceType(NNTestCase):
 
     def test_ConvTranspose_empty(self, device):
         mod = torch.nn.ConvTranspose2d(4, 4, stride=2, kernel_size=3, padding=1).to(device)
-        inp = torch.randn(0, 4, 4, 4)
+        inp = torch.randn(0, 4, 4, 4, device=device)
         self._test_module_empty_input(mod, inp, check_size=False)
         if self.device_type == 'cuda' and self.has_cudnn():
             with torch.backends.cudnn.flags(enabled=False):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -8932,7 +8932,7 @@ class TestNNDeviceType(NNTestCase):
         output.sum().backward()
         self.assertEqual(output.type(), input.type())
 
-    def _test_module_empty_input(self, module, inp, check_size = True):
+    def _test_module_empty_input(self, module, inp, check_size=True):
         inp.requires_grad_(True)
         out = module(inp)
         gO = torch.rand_like(out)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9039,6 +9039,14 @@ class TestNNDeviceType(NNTestCase):
             with torch.backends.cudnn.flags(enabled=False):
                 self._test_module_empty_input(mod, inp, check_size=False)
 
+    def test_ConvTranspose_empty(self, device):
+        mod = torch.nn.ConvTranspose2d(4, 4, stride=2, kernel_size=3, padding=1).to(device)
+        inp = torch.randn(0, 4, 4, 4)
+        self._test_module_empty_input(mod, inp, check_size=False)
+        if self.device_type == 'cuda' and self.has_cudnn():
+            with torch.backends.cudnn.flags(enabled=False):
+                self._test_module_empty_input(mod, inp, check_size=False)
+
     def test_one_hot(self, device):
         with self.assertRaises(RuntimeError):
             torch.nn.functional.one_hot(torch.tensor([3, 4, -1, 0], device=device), -1)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -8932,12 +8932,13 @@ class TestNNDeviceType(NNTestCase):
         output.sum().backward()
         self.assertEqual(output.type(), input.type())
 
-    def _test_module_empty_input(self, module, inp):
+    def _test_module_empty_input(self, module, inp, check_size = True):
         inp.requires_grad_(True)
         out = module(inp)
         gO = torch.rand_like(out)
         out.backward(gO)
-        self.assertEqual(out.size(), inp.size())
+        if check_size:
+            self.assertEqual(out.size(), inp.size())
         for p in module.parameters():
             # TODO: p.grad should not be None, but this is not yet supported
             # (https://github.com/pytorch/pytorch/issues/12013)
@@ -9029,6 +9030,14 @@ class TestNNDeviceType(NNTestCase):
         if self.device_type == 'cuda' and self.has_cudnn():
             with torch.backends.cudnn.flags(enabled=False):
                 self._test_module_empty_input(mod, inp)
+
+    def test_group_conv_empty(self, device):
+        mod = torch.nn.Conv2d(4, 4, stride=2, kernel_size=3, padding=1, groups=4).to(device)
+        inp = torch.randn(0, 4, 4, 4)
+        self._test_module_empty_input(mod, inp, check_size=False)
+        if self.device_type == 'cuda' and self.has_cudnn():
+            with torch.backends.cudnn.flags(enabled=False):
+                self._test_module_empty_input(mod, inp, check_size=False)
 
     def test_one_hot(self, device):
         with self.assertRaises(RuntimeError):


### PR DESCRIPTION
resubmitting #32612 after a merge gone wrong. Enables convolution with an empty batch or number of channels for all flavors of convolution (grouped convolution, convTranspose). Would make #31658 unnecessary. Also returns zero gradients for the parameters, that's necessary for correct DDP operation. 