### PR TITLE
[DO NOT MERGE] Make all weak references into strong references

### DIFF
--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -1693,7 +1693,6 @@ protected:
 //
 //    vtable pointer
 //    strong refcount           TODO: pack these into one word
-//    weak refcount
 //    storage pointer
 //    autograd metadata pointer
 //    version counter pointer
@@ -1722,7 +1721,7 @@ protected:
 //    miscellaneous bitfield
 //
 static_assert(sizeof(void*) != sizeof(int64_t) || // if 64-bit...
-              sizeof(TensorImpl) == sizeof(int64_t) * 30,
+              sizeof(TensorImpl) == sizeof(int64_t) * 29,
               "You changed the size of TensorImpl on 64-bit arch."
               "See Note [TensorImpl size constraints] on how to proceed.");
 } // namespace c10


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#32713 [DO NOT MERGE] Make all weak references into strong references**

This patch can be used for performance benchmarking the impact
of eliminating weak references.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D19626984](https://our.internmc.facebook.com/intern/diff/D19626984)