### PR TITLE
Per sample unjoined loss

### DIFF
--- a/caffe2/operators/cross_entropy_op.h
+++ b/caffe2/operators/cross_entropy_op.h
@@ -108,6 +108,27 @@ class SigmoidCrossEntropyWithLogitsGradientOp final : public Operator<Context> {
 };
 
 template <typename T, class Context>
+class PerSampleUnjoinedSigmoidCrossEntropyWithLogitsOp final
+    : public Operator<Context> {
+ public:
+  USE_SIMPLE_CTOR_DTOR(PerSampleUnjoinedSigmoidCrossEntropyWithLogitsOp);
+  USE_OPERATOR_CONTEXT_FUNCTIONS;
+
+  bool RunOnDevice() override;
+};
+
+template <typename T, class Context>
+class PerSampleUnjoinedSigmoidCrossEntropyWithLogitsGradientOp final
+    : public Operator<Context> {
+ public:
+  USE_SIMPLE_CTOR_DTOR(
+      PerSampleUnjoinedSigmoidCrossEntropyWithLogitsGradientOp);
+  USE_OPERATOR_CONTEXT_FUNCTIONS;
+
+  bool RunOnDevice() override;
+};
+
+template <typename T, class Context>
 class WeightedSigmoidCrossEntropyWithLogitsOp final : public Operator<Context> {
  public:
   USE_SIMPLE_CTOR_DTOR(WeightedSigmoidCrossEntropyWithLogitsOp);


### PR DESCRIPTION
Summary:
Implements per sample unjoined loss.

In unjoined training data each positive sample has equivalent negative sample. This negative sample needs to be ignored. Special loss function is necessary to achieve this.

This loss function allows mixture of "unjoined" training data and "joined" (the usual) training data in one pipeline. Samples from each can be differenciated using special supervision signal.

Differential Revision: D19602938

