### PR TITLE
Make sure temporary vectors are properly initialized in avx2 code

### DIFF
--- a/aten/src/ATen/cpu/vec256/vec256_base.h
+++ b/aten/src/ATen/cpu/vec256/vec256_base.h
@@ -153,11 +153,6 @@ public:
   }
   static Vec256<T> loadu(const void* ptr, int64_t count) {
     Vec256 vec;
-    // Ensure uninitialized memory does not change the output value
-    // See https://github.com/pytorch/pytorch/issues/32502 for more details
-    for (auto i = 0; i < vec.size(); ++i) {
-      vec.values[i] = 0.0;
-    }
     std::memcpy(vec.values, ptr, count * sizeof(T));
     return vec;
   }

--- a/aten/src/ATen/cpu/vec256/vec256_base.h
+++ b/aten/src/ATen/cpu/vec256/vec256_base.h
@@ -153,6 +153,11 @@ public:
   }
   static Vec256<T> loadu(const void* ptr, int64_t count) {
     Vec256 vec;
+    // Ensure uninitialized memory does not change the output value
+    // See https://github.com/pytorch/pytorch/issues/32502 for more details
+    for (auto i = 0; i < vec.size(); ++i) {
+      vec.values[i] = 0.0;
+    }
     std::memcpy(vec.values, ptr, count * sizeof(T));
     return vec;
   }

--- a/aten/src/ATen/cpu/vec256/vec256_complex_double.h
+++ b/aten/src/ATen/cpu/vec256/vec256_complex_double.h
@@ -75,6 +75,11 @@ public:
       return _mm256_loadu_pd(reinterpret_cast<const double*>(ptr));
 
     __at_align32__ double tmp_values[2*size()];
+    // Ensure uninitialized memory does not change the output value
+    // See https://github.com/pytorch/pytorch/issues/32502 for more details
+    for (auto i = 0; i < 2*size(); ++i) {
+      tmp_values[i] = 0.0;
+    }
     std::memcpy(
         tmp_values,
         reinterpret_cast<const double*>(ptr),

--- a/aten/src/ATen/cpu/vec256/vec256_complex_float.h
+++ b/aten/src/ATen/cpu/vec256/vec256_complex_float.h
@@ -111,6 +111,11 @@ public:
       return _mm256_loadu_ps(reinterpret_cast<const float*>(ptr));
 
     __at_align32__ float tmp_values[2*size()];
+    // Ensure uninitialized memory does not change the output value
+    // See https://github.com/pytorch/pytorch/issues/32502 for more details
+    for (auto i = 0; i < 2*size(); ++i) {
+      tmp_values[i] = 0.0;
+    }
     std::memcpy(
         tmp_values,
         reinterpret_cast<const float*>(ptr),

--- a/aten/src/ATen/cpu/vec256/vec256_double.h
+++ b/aten/src/ATen/cpu/vec256/vec256_double.h
@@ -61,7 +61,13 @@ public:
     if (count == size())
       return _mm256_loadu_pd(reinterpret_cast<const double*>(ptr));
 
+
     __at_align32__ double tmp_values[size()];
+    // Ensure uninitialized memory does not change the output value
+    // See https://github.com/pytorch/pytorch/issues/32502 for more details
+    for (auto i = 0; i < size(); ++i) {
+      tmp_values[i] = 0.0;
+    }
     std::memcpy(
         tmp_values,
         reinterpret_cast<const double*>(ptr),

--- a/aten/src/ATen/cpu/vec256/vec256_float.h
+++ b/aten/src/ATen/cpu/vec256/vec256_float.h
@@ -72,6 +72,11 @@ public:
     if (count == size())
       return _mm256_loadu_ps(reinterpret_cast<const float*>(ptr));
     __at_align32__ float tmp_values[size()];
+    // Ensure uninitialized memory does not change the output value
+    // See https://github.com/pytorch/pytorch/issues/32502 for more details
+    for (auto i = 0; i < size(); ++i) {
+      tmp_values[i] = 0.0;
+    }
     std::memcpy(
         tmp_values, reinterpret_cast<const float*>(ptr), count * sizeof(float));
     return _mm256_loadu_ps(tmp_values);

--- a/aten/src/ATen/cpu/vec256/vec256_int.h
+++ b/aten/src/ATen/cpu/vec256/vec256_int.h
@@ -77,6 +77,11 @@ struct Vec256<int64_t> : public Vec256i {
   }
   static Vec256<int64_t> loadu(const void* ptr, int64_t count) {
     __at_align32__ int64_t tmp_values[size()];
+    // Ensure uninitialized memory does not change the output value
+    // See https://github.com/pytorch/pytorch/issues/32502 for more details
+    for (auto i = 0; i < size(); ++i) {
+      tmp_values[i] = 0.0;
+    }
     std::memcpy(tmp_values, ptr, count * sizeof(int64_t));
     return loadu(tmp_values);
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#32722 Make sure temporary vectors are properly initialized in avx2 code**

Fix #32502
Checked using [this](https://godbolt.org/z/uAaE9R) that it gives the correct assembly.

Differential Revision: [D19610012](https://our.internmc.facebook.com/intern/diff/D19610012)