### PR TITLE
[ONNX/Caffe2] Align Caffe2 Slice op with ONNX Slice during ONNX backend conversion using extended axes argument in Caffe2 Slice operator

### DIFF
--- a/caffe2/operators/quantized/int8_slice_op.cc
+++ b/caffe2/operators/quantized/int8_slice_op.cc
@@ -38,6 +38,7 @@ Example:
     .Arg("Y_zero_point", "Output tensor quantization offset")
     .Arg("starts", "List of starting indices")
     .Arg("ends", "List of ending indices")
+    .Arg("axes", "1-D tensor: axes that `starts` and `ends` apply to")
     .Arg(
         "dim",
         "(Optional) The dimension to slice over. If specified start_idx and end_idx should also be given and it takes precedence over starts and ends")

--- a/caffe2/operators/quantized/int8_slice_op.h
+++ b/caffe2/operators/quantized/int8_slice_op.h
@@ -27,14 +27,17 @@ class Int8SliceOp final : public SliceOp<CPUContext> {
   template <typename SIndex>
   bool DoRunWithType() {
     if (InputSize() > 1) {
-      ReinitializeAndCopyFrom(&starts_host_, at::dtype<SIndex>().device(CPU), Input(1));
-      ReinitializeAndCopyFrom(&ends_host_, at::dtype<SIndex>().device(CPU), Input(2));
+      ReinitializeAndCopyFrom(
+          &starts_host_, at::dtype<SIndex>().device(CPU), Input(1));
+      ReinitializeAndCopyFrom(
+          &ends_host_, at::dtype<SIndex>().device(CPU), Input(2));
     } else {
       if (!statically_inited_) {
-
-        if (HasArgument("dim") && HasArgument("start_idx") && HasArgument("end_idx")) {
+        if (HasArgument("dim") && HasArgument("start_idx") &&
+            HasArgument("end_idx")) {
           auto dim = this->template GetSingleArgument<int>("dim", 0);
-          auto start = this->template GetSingleArgument<int64_t>("start_idx", 0);
+          auto start =
+              this->template GetSingleArgument<int64_t>("start_idx", 0);
           auto end = this->template GetSingleArgument<int64_t>("end_idx", -1);
           auto& input_tensor = Inputs()[0]->Get<Int8TensorCPU>();
           auto rank = input_tensor.t.sizes().size();
@@ -49,9 +52,13 @@ class Int8SliceOp final : public SliceOp<CPUContext> {
         CAFFE_ENFORCE_EQ(starts_.size(), ends_.size());
 
         ReinitializeTensor(
-            &starts_host_, {static_cast<int64_t>(starts_.size())}, at::dtype<SIndex>().device(CPU));
+            &starts_host_,
+            {static_cast<int64_t>(starts_.size())},
+            at::dtype<SIndex>().device(CPU));
         ReinitializeTensor(
-            &ends_host_, {static_cast<int64_t>(ends_.size())}, at::dtype<SIndex>().device(CPU));
+            &ends_host_,
+            {static_cast<int64_t>(ends_.size())},
+            at::dtype<SIndex>().device(CPU));
 
         memcpy(
             starts_host_.template mutable_data<SIndex>(),
@@ -74,8 +81,11 @@ class Int8SliceOp final : public SliceOp<CPUContext> {
     Y->scale = Y_scale;
     Y->zero_point = Y_offset;
 
+    if (HasArgument(("axes"))) {
+      CAFFE_ENFORCE_EQ(starts_host_.numel(), axes_.size());
+    }
     return SliceImpl<SIndex, CPUContext>(
-        &Y->t, X.t, starts_host_, ends_host_, &context_);
+        &Y->t, X.t, starts_host_, ends_host_, axes_, &context_);
   }
 };
 

--- a/caffe2/operators/slice_op.cc
+++ b/caffe2/operators/slice_op.cc
@@ -74,6 +74,9 @@ Y:
         "(*Tensor`<int>`*): 1D tensor of end-indices for each dimension of data")
     .Arg("starts", "(*Tuple(int)*): list of starting indices")
     .Arg("ends", "(*Tuple(int)*): list of ending indices")
+    .Arg(
+        "axes",
+        "(*Tuple(int)*): 1-D tensor of axes that `starts` and `ends` apply to")
     .TensorInferenceFunction([](const OperatorDef& def,
                                 const vector<TensorShape>& in) {
       if (in.size() > 1) {
@@ -86,6 +89,7 @@ Y:
       ArgumentHelper helper(def);
       auto starts = helper.GetRepeatedArgument<int>("starts", vector<int>());
       auto ends = helper.GetRepeatedArgument<int>("ends", vector<int>());
+      auto axes = helper.GetRepeatedArgument<int>("axes", vector<int>());
       vector<int> dst_sizes(data.dims_size());
 
       for (int i = 0; i < data.dims_size(); ++i) {
@@ -133,6 +137,6 @@ struct GetSliceGradient : public GradientMakerBase {
     }
   }
 };
-}
+} // namespace
 REGISTER_GRADIENT(Slice, GetSliceGradient);
 } // namespace caffe2

--- a/caffe2/opt/onnxifi_op.cc
+++ b/caffe2/opt/onnxifi_op.cc
@@ -293,7 +293,12 @@ void OnnxifiOp<CPUContext>::maybeAdjustOutputBatchSizes() {
     } else {
       // We need to use generic Slice
       SliceImpl<int32_t, CPUContext>(
-          &tmp, *output_tensor, output_reshape_info_.begins[i], end, &context);
+          &tmp,
+          *output_tensor,
+          output_reshape_info_.begins[i],
+          end,
+          {},
+          &context);
       output_tensor->CopyFrom(tmp);
     }
   }

--- a/caffe2/python/operator_test/slice_op_test.py
+++ b/caffe2/python/operator_test/slice_op_test.py
@@ -1,0 +1,142 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import random
+import unittest
+
+import numpy as np
+import six
+from caffe2.proto import caffe2_pb2
+from caffe2.python import core, workspace
+from hypothesis import assume, given
+
+
+class TestSliceOp(unittest.TestCase):
+    def _test_slice(self):
+        X = np.random.randn(20, 10, 5).astype(np.float32)
+
+        starts = np.array([1], dtype=np.int64)
+        ends = np.array([7], dtype=np.int64)
+        axes = np.array([1], dtype=np.int64)
+        Y = X[:, 1:7]
+
+        op = core.CreateOperator(
+            "Slice", ["X"], ["Y"], starts=starts, ends=ends, axes=axes
+        )
+
+        workspace.FeedBlob("X", X)
+        workspace.RunOperatorOnce(op)
+        Z = workspace.FetchBlob("Y")
+        np.testing.assert_array_equal(Y, Z)
+        self.assertEqual(Y.tobytes(), Z.tobytes())
+
+    def test_slice_null_axes(self):
+        X = np.random.randn(20, 10, 5).astype(np.float32)
+
+        starts = np.array([5, 0, 0], dtype=np.int64)
+        ends = np.array([16, 10, 5], dtype=np.int64)
+        Y = X[5:16, :]
+
+        op = core.CreateOperator("Slice", ["X"], ["Y"], starts=starts, ends=ends)
+
+        workspace.FeedBlob("X", X)
+        workspace.RunOperatorOnce(op)
+        Z = workspace.FetchBlob("Y")
+        np.testing.assert_array_equal(Y, Z)
+        self.assertEqual(Y.tobytes(), Z.tobytes())
+
+    def test_slice_null_axes_partial(self):
+        X = np.random.randn(20, 10, 5).astype(np.float32)
+
+        starts = np.array([5, 0], dtype=np.int64)
+        ends = np.array([16, 10], dtype=np.int64)
+        Y = X[5:16, :]
+
+        op = core.CreateOperator("Slice", ["X"], ["Y"], starts=starts, ends=ends)
+
+        workspace.FeedBlob("X", X)
+        workspace.RunOperatorOnce(op)
+        Z = workspace.FetchBlob("Y")
+        np.testing.assert_array_equal(Y, Z)
+        self.assertEqual(Y.tobytes(), Z.tobytes())
+
+    def test_slice_null_axes_out_of_range(self):
+        X = np.random.randn(20, 10, 5).astype(np.float32)
+
+        starts = np.array([0, 3, 0], dtype=np.int64)
+        ends = np.array([20, 4, 1000], dtype=np.int64)
+        Y = X[:, 3:4, 0:1000]
+
+        op = core.CreateOperator("Slice", ["X"], ["Y"], starts=starts, ends=ends)
+
+        workspace.FeedBlob("X", X)
+        workspace.RunOperatorOnce(op)
+        Z = workspace.FetchBlob("Y")
+        np.testing.assert_array_equal(Y, Z)
+        self.assertEqual(Y.tobytes(), Z.tobytes())
+
+    def test_slice_null_axes_partial_out_of_range(self):
+        X = np.random.randn(20, 10, 5).astype(np.float32)
+
+        starts = np.array([0, 6], dtype=np.int64)
+        ends = np.array([100, 9], dtype=np.int64)
+        Y = X[:, 6:9, :]
+
+        op = core.CreateOperator("Slice", ["X"], ["Y"], starts=starts, ends=ends)
+
+        workspace.FeedBlob("X", X)
+        workspace.RunOperatorOnce(op)
+        Z = workspace.FetchBlob("Y")
+        np.testing.assert_array_equal(Y, Z)
+        self.assertEqual(Y.tobytes(), Z.tobytes())
+
+    def _test_slice_out_of_range(self):
+        X = np.random.randn(20, 10, 5).astype(np.float32)
+
+        starts = np.array([1], dtype=np.int64)
+        ends = np.array([1000], dtype=np.int64)
+        axes = np.array([1], dtype=np.int64)
+        Y = X[:, 1:1000]
+
+        op = core.CreateOperator(
+            "Slice", ["X"], ["Y"], starts=starts, ends=ends, axes=axes
+        )
+
+        workspace.FeedBlob("X", X)
+        workspace.RunOperatorOnce(op)
+        Z = workspace.FetchBlob("Y")
+        np.testing.assert_array_equal(Y, Z)
+        self.assertEqual(Y.tobytes(), Z.tobytes())
+
+    def _test_slice_neg_axes(self):
+        X = np.random.randn(20, 10, 5).astype(np.float32)
+        starts = np.array([0, 0, 3], dtype=np.int64)
+        ends = np.array([20, 10, 4], dtype=np.int64)
+        axes = np.array([0, -2, -1], dtype=np.int64)
+        Y = X[:, :, 3:4]
+
+        op = core.CreateOperator(
+            "Slice", ["X"], ["Y"], starts=starts, ends=ends, axes=axes
+        )
+
+        workspace.FeedBlob("X", X)
+        workspace.RunOperatorOnce(op)
+        Z = workspace.FetchBlob("Y")
+        np.testing.assert_array_equal(Y, Z)
+        self.assertEqual(Y.tobytes(), Z.tobytes())
+
+    def _test_slice_unordered_axes(self):
+        X = np.random.randn(20, 10, 5, 33).astype(np.float32)
+        starts = np.array([0, 0, 0], dtype=np.int64)
+        ends = np.array([20, 5, 10], dtype=np.int64)
+        axes = np.array([0, -1, 1], dtype=np.int64)
+        Y = X[:, :, :, 0:5]
+
+        op = core.CreateOperator(
+            "Slice", ["X"], ["Y"], starts=starts, ends=ends, axes=axes
+        )
+
+        workspace.FeedBlob("X", X)
+        workspace.RunOperatorOnce(op)
+        Z = workspace.FetchBlob("Y")
+        np.testing.assert_array_equal(Y, Z)
+        self.assertEqual(Y.tobytes(), Z.tobytes())


### PR DESCRIPTION
Summary: Aligned Caffe2 Slice operator with ONNX Slice operator, reducing previously 6+ ops to 1 single op in converted Caffe2, with the help of newly extended axes argument in the Caffe2 Slice op.

Differential Revision: D19588582

