### PR TITLE
fast setup for output tensor in tensor iterator

### DIFF
--- a/aten/src/ATen/native/TensorIterator.cpp
+++ b/aten/src/ATen/native/TensorIterator.cpp
@@ -909,33 +909,51 @@ bool TensorIterator::fast_set_up() {
     return false;
   }
   // allocate memory for output, memory format depends on setup_type
-  // find the index of a defined tensor in operands which will be used for NON_CONTIGUOUS case
-  int i_defined;
-  for (i_defined = ntensors() - 1; i_defined >= 0; --i_defined) {
-    if (operands_[i_defined].tensor.defined()) break;
-  }
-
-  for (int i = 0; i < num_outputs_; i++){
-    auto& op = operands_[i];
-    if (!op.tensor.defined()) {
-      TORCH_INTERNAL_ASSERT(op.is_type_defined(), "no type for operand", i);
-      switch (setup_type)
-      {
-        case FastSetupType::CONTIGUOUS:
+  switch (setup_type) {
+    case FastSetupType::CONTIGUOUS:
+    {
+      for (int i = 0; i < num_outputs_; i++){
+        auto& op = operands_[i];
+        if (!op.tensor.defined()) {
+          TORCH_INTERNAL_ASSERT(op.is_type_defined(), "no type for operand", i);
           op.tensor = at::empty(shape_, op.options(), MemoryFormat::Contiguous);
-          break;
-        case FastSetupType::CHANNELS_LAST:
-          op.tensor = at::empty(shape_, op.options(), MemoryFormat::ChannelsLast);
-          break;
-        case FastSetupType::NON_CONTIGUOUS:
-          TORCH_CHECK(i_defined >= 0, "Can not find a defined tensor when fast allocating memory to outputs");
-          op.tensor = at::empty_strided(shape_, operands_[i_defined].tensor.strides(), op.options());
-          break;
-        default:
-          TORCH_CHECK(false, "Unsupported fast setup type", std::to_string((int)setup_type));
+          op.current_dtype = op.target_dtype;
+        }
       }
-      op.current_dtype = op.target_dtype;
+      break;
     }
+    case FastSetupType::CHANNELS_LAST:
+    {
+      for (int i = 0; i < num_outputs_; i++){
+        auto& op = operands_[i];
+        if (!op.tensor.defined()) {
+          TORCH_INTERNAL_ASSERT(op.is_type_defined(), "no type for operand", i);
+          op.tensor = at::empty(shape_, op.options(), MemoryFormat::ChannelsLast);
+          op.current_dtype = op.target_dtype;
+        }
+      }
+      break;
+    }
+    case FastSetupType::NON_CONTIGUOUS:
+    {
+      // find the index of a defined tensor in operands_
+      int i_defined;
+      for (i_defined = ntensors() - 1; i_defined >= 0; --i_defined) {
+        if (operands_[i_defined].tensor.defined()) break;
+      }
+      TORCH_CHECK(i_defined >= 0, "Can not find a defined tensor when fast allocating memory to outputs");
+      for (int i = 0; i < num_outputs_; i++){
+        auto& op = operands_[i];
+        if (!op.tensor.defined()) {
+          TORCH_INTERNAL_ASSERT(op.is_type_defined(), "no type for operand", i);
+          op.tensor = at::empty_strided(shape_, operands_[i_defined].tensor.strides(), op.options());
+          op.current_dtype = op.target_dtype;
+        }
+      }
+      break;
+    }
+    default:
+      TORCH_CHECK(false, "Unsupported fast setup type", std::to_string((int)setup_type));
   }
   //coalescing dimensions consists of collapsing dimensions to 1 (we are limited to contiguous no-broadcast cases here)
   if (ndim() > 1){

--- a/aten/src/ATen/native/TensorIterator.cpp
+++ b/aten/src/ATen/native/TensorIterator.cpp
@@ -899,20 +899,43 @@ int TensorIterator::get_dim_to_split() const {
   return dim_to_split;
 }
 
-void TensorIterator::fast_set_up() {
-  //this function is called if all the inputs are contiguous to avoid needless reordering of dimensions
-  //and tracking output strides
-  //TODO enable fast handling for reductions
-  //TODO enable fast handling for channels_last
+bool TensorIterator::fast_set_up() {
+  // This function trys to do a fast setup to avoid needless reordering of dimensions and tracking output strides
+  // Return true if it can do fast setup or false otherwise
+  // TODO enable fast handling for reductions
 
-  //allocate contiguous tensor for output
+  FastSetupType setup_type = compute_fast_setup_type();
+  if (setup_type == FastSetupType::NONE) {
+    return false;
+  }
+  // allocate memory for output, memory format depends on setup_type
+  // find the index of a defined tensor in operands which will be used for NON_CONTIGUOUS case
+  int i_defined;
+  for (i_defined = ntensors() - 1; i_defined >= 0; --i_defined) {
+    if (operands_[i_defined].tensor.defined()) break;
+  }
+
   for (int i = 0; i < num_outputs_; i++){
-      auto& op = operands_[i];
-      if (!op.tensor.defined()) {
-        TORCH_INTERNAL_ASSERT(op.is_type_defined(), "no type for operand", i);
-        op.tensor = at::empty(shape_, op.options());
+    auto& op = operands_[i];
+    if (!op.tensor.defined()) {
+      TORCH_INTERNAL_ASSERT(op.is_type_defined(), "no type for operand", i);
+      switch (setup_type)
+      {
+        case FastSetupType::CONTIGUOUS:
+          op.tensor = at::empty(shape_, op.options(), MemoryFormat::Contiguous);
+          break;
+        case FastSetupType::CHANNELS_LAST:
+          op.tensor = at::empty(shape_, op.options(), MemoryFormat::ChannelsLast);
+          break;
+        case FastSetupType::NON_CONTIGUOUS:
+          TORCH_CHECK(i_defined >= 0, "Can not find a defined tensor when fast allocating memory to outputs");
+          op.tensor = at::empty_strided(shape_, operands_[i_defined].tensor.strides(), op.options());
+          break;
+        default:
+          TORCH_CHECK(false, "Unsupported fast setup type", std::to_string((int)setup_type));
       }
       op.current_dtype = op.target_dtype;
+    }
   }
   //coalescing dimensions consists of collapsing dimensions to 1 (we are limited to contiguous no-broadcast cases here)
   if (ndim() > 1){
@@ -929,21 +952,50 @@ void TensorIterator::fast_set_up() {
       op.stride_bytes[0] = element_size_in_bytes;
     }
   }
+  return true;
 }
 
-bool TensorIterator::can_use_fast_set_up() {
-  if (is_reduction_) return false;
-  if (!all_ops_same_shape_) {
-    return false;
+FastSetupType TensorIterator::compute_fast_setup_type() {
+  if (is_reduction_ || !all_ops_same_shape_) {
+    return FastSetupType::NONE;
   }
+
+  bool is_contiguous = true;
+  bool is_channels_last = true;
+  bool is_non_overlapping_and_dense = true;
   for (auto& op : operands_) {
     if (op.tensor.defined()) {
-      if (!op.tensor.is_contiguous()) {
-        return false;
-      }
+      is_contiguous &= op.tensor.is_contiguous(at::MemoryFormat::Contiguous);
+      is_channels_last &= op.tensor.is_contiguous(at::MemoryFormat::ChannelsLast);
+      is_non_overlapping_and_dense &= op.tensor.is_non_overlapping_and_dense();
     }
   }
-  return true;
+
+  if (is_contiguous) {
+    return FastSetupType::CONTIGUOUS;
+  }
+  if (is_channels_last) {
+    if (requires_channels_last_output_) {
+      return FastSetupType::CHANNELS_LAST;
+    }
+    return FastSetupType::NONE;
+  }
+  if (is_non_overlapping_and_dense) {
+    int64_t prev = -1;
+    for (int64_t i = 0; i < ntensors(); ++i) {
+      if (operands_[i].tensor.defined()) {
+        if (prev < 0) {
+          prev = i;
+          continue;
+        }
+        if (!operands_[prev].tensor.strides().equals(operands_[i].tensor.strides())) {
+          return FastSetupType::NONE;
+        }
+      }
+    }
+    return FastSetupType::NON_CONTIGUOUS;
+  }
+  return FastSetupType::NONE;
 }
 
 void TensorIterator::build() {
@@ -960,9 +1012,8 @@ void TensorIterator::build() {
   compute_shape();
   // compute the result dtype and device
   compute_types();
-  if (can_use_fast_set_up()) {
-    fast_set_up();
-  } else {
+  // try fast setup output tensor, if failed, fallback to normal setup
+  if (!fast_set_up()) {
     // compute each tensor's stride after broadcasting
     compute_strides();
     // re-order dimensions to improve coalescing

--- a/aten/src/ATen/native/TensorIterator.h
+++ b/aten/src/ATen/native/TensorIterator.h
@@ -132,6 +132,13 @@ struct CAFFE2_API OperandInfo {
 
 struct SplitUntil32Bit;
 
+enum class FastSetupType : uint8_t {
+  NONE,
+  CONTIGUOUS,
+  CHANNELS_LAST,
+  NON_CONTIGUOUS
+};
+
 enum class CommonDTypeStrategy : uint8_t {
   NONE, // Do not compute a common dtype
   CHECK, // Compute and validate a common dtype but don't promote.
@@ -368,8 +375,8 @@ protected:
   void compute_types();
   std::tuple<Device, ScalarType, bool> compute_common_type();
   void allocate_outputs();
-  void fast_set_up();
-  bool can_use_fast_set_up();
+  bool fast_set_up();
+  FastSetupType compute_fast_setup_type();
   void compute_names();
   void propagate_names_to_outputs();
   void coalesce_dimensions();

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -5951,7 +5951,7 @@ tensor([[[1., 1., 1.,  ..., 1., 1., 1.],
 
     def test_tensoriterator_output_setup(self):
         # Test whether the output's memory layout is correct
-        def test_memory_layout(x, y, out):
+        def test_memory_layout(x, y, scale, zero_point, out):
             self.assertEqual(x.dim(), 4)
             self.assertEqual(x.size(), y.size())
             self.assertEqual(y.size(), out.size())
@@ -5961,25 +5961,45 @@ tensor([[[1., 1., 1.,  ..., 1., 1., 1.],
                 for c in range(shape[1]):
                     for h in range(shape[2]):
                         for w in range(shape[3]):
-                            self.assertEqual(out[n][c][h][w], x[n][c][h][w] + y[n][c][h][w])
+                            if scale is not None and zero_point is not None:
+                                self.assertEqual(
+                                    out[n][c][h][w],
+                                    torch.ops.quantized.add(x[n][c][h][w], y[n][c][h][w], scale, zero_point))
+                            else:
+                                self.assertEqual(out[n][c][h][w], x[n][c][h][w] + y[n][c][h][w])
 
         xraw = torch.rand(2, 3, 4, 4)
         yraw = torch.rand(2, 3, 4, 4)
+        qxraw = torch.quantize_per_tensor(xraw, 0.1, 5, torch.quint8)
+        qyraw = torch.quantize_per_tensor(yraw, 0.1, 5, torch.quint8)
 
         # contiguous case fast setup
-        test_memory_layout(xraw, yraw, xraw + yraw)
+        test_memory_layout(xraw, yraw, None, None, xraw + yraw)
+        test_memory_layout(qxraw, qyraw, 0.1, 5, torch.ops.quantized.add(qxraw, qyraw, 0.1, 5))
+
         # channels last case fast setup
         x = xraw.contiguous(memory_format=torch.channels_last)
         y = yraw.contiguous(memory_format=torch.channels_last)
-        test_memory_layout(x, y, x + y)
+        test_memory_layout(x, y, None, None, x + y)
+        qx = qxraw.contiguous(memory_format=torch.channels_last)
+        qy = qyraw.contiguous(memory_format=torch.channels_last)
+        test_memory_layout(qx, qy, 0.1, 5, torch.ops.quantized.add(qx, qy, 0.1, 5))
+
         # non contiguous case fast setup (dense, non-overlapping, same shape and sizes)
         x = xraw.permute(0, 2, 3, 1)
         y = yraw.permute(0, 2, 3, 1)
-        test_memory_layout(x, y, x + y)
+        test_memory_layout(x, y, None, None, x + y)
+        qx = qxraw.permute(0, 2, 3, 1)
+        qy = qyraw.permute(0, 2, 3, 1)
+        test_memory_layout(qx, qy, 0.1, 5, torch.ops.quantized.add(qx, qy, 0.1, 5))
+
         # non contiguous case non fast setup
         x = xraw.permute(0, 2, 3, 1)
         y = yraw.permute(0, 3, 2, 1)
-        test_memory_layout(x, y, x + y)
+        test_memory_layout(x, y, None, None, x + y)
+        qx = qxraw.permute(0, 2, 3, 1)
+        qy = qyraw.permute(0, 3, 2, 1)
+        test_memory_layout(qx, qy, 0.1, 5, torch.ops.quantized.add(qx, qy, 0.1, 5))
 
     def test_tensor_grad_warnings(self):
         dummy = torch.empty(1)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#32736 fast setup for output tensor in tensor iterator**

Differential Revision: [D19610704](https://our.internmc.facebook.com/intern/diff/D19610704)

Adding fast setup support for two more cases besides contiguous:
1. channels last contiguous tensors.
2. non-contiguous but having exactly same shape/stride, no overlapping and dense tensors.

This supported quantized tensor as well.