### PR TITLE
Remove unnecessary dynamic casting in TensorIterator

### DIFF
--- a/aten/src/ATen/native/TensorIterator.cpp
+++ b/aten/src/ATen/native/TensorIterator.cpp
@@ -235,10 +235,6 @@ void TensorIterator::compute_types() {
       }
     }
 
-    if (is_different && !skip_output) {
-      have_differing_types_ = true;
-    }
-
     if (op.tensor.defined() && op.device != op.tensor.device()) {
       if (op.is_output) {
         TORCH_CHECK(false, "output with device ", op.tensor.device(),

--- a/aten/src/ATen/native/cuda/Loops.cuh
+++ b/aten/src/ATen/native/cuda/Loops.cuh
@@ -305,10 +305,6 @@ void gpu_kernel_impl(TensorIterator& iter, const func_t& f) {
     dtypes[i] = iter.tensor(i).scalar_type();
   }
 
-  if (iter.needs_dynamic_casting()) {
-    std::cout << "iter.needs_dynamic_casting()" << std::endl;
-  }
-
   int64_t numel = iter.numel();
   if (iter.is_trivial_1d()) {
     auto inner_strides = iter.get_inner_strides();

--- a/aten/src/ATen/native/cuda/Loops.cuh
+++ b/aten/src/ATen/native/cuda/Loops.cuh
@@ -305,6 +305,10 @@ void gpu_kernel_impl(TensorIterator& iter, const func_t& f) {
     dtypes[i] = iter.tensor(i).scalar_type();
   }
 
+  if (iter.needs_dynamic_casting()) {
+    std::cout << "iter.needs_dynamic_casting()" << std::endl;
+  }
+
   int64_t numel = iter.numel();
   if (iter.is_trivial_1d()) {
     auto inner_strides = iter.get_inner_strides();


### PR DESCRIPTION
Postpone the computation of `needs_dynamic_casting` from build time to dispatch time so that if the operand list is changed after build, we can still get the updated result. This will improve the vectorization coverage of https://github.com/pytorch/pytorch/pull/32678 a lot at `optimizer.step()`.

Previously
```python
torch.zeros(10, device='cuda').mul_(0.9)
```
requires dynamic casting, but after this PR it won't.

New C++ tests are added to test for different cases to make sure dynamic casting is not turned on for unnecessary cases.