### PR TITLE
clean up GIL usuage

### DIFF
--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -181,15 +181,17 @@ PyObject* rpc_init(PyObject* /* unused */) {
                   If the current node is the owner, returns a reference to the
                   local value. Otherwise, throws an exception.
               )")
-          .def(py::pickle(
-              [](const PyRRef& self) {
-                // __getstate__
-                return self.pickle();
-              },
-              [](py::tuple t) { // NOLINT
-                // __setstate__
-                return PyRRef::unpickle(t);
-              }))
+          .def(
+              py::pickle(
+                  [](const PyRRef& self) {
+                    // __getstate__
+                    return self.pickle();
+                  },
+                  [](py::tuple t) { // NOLINT
+                    // __setstate__
+                    return PyRRef::unpickle(t);
+                  }),
+              py::call_guard<py::gil_scoped_release>())
           // not releasing GIL to avoid context switch
           .def("__str__", &PyRRef::str);
 

--- a/torch/csrc/distributed/rpc/python_rpc_handler.cpp
+++ b/torch/csrc/distributed/rpc/python_rpc_handler.cpp
@@ -25,8 +25,7 @@ struct PythonTypeResolver : public jit::script::Resolver {
     if (name == "PyObject") {
       return PyObjectType::get();
     }
-    auto python_cu = torch::jit::get_python_cu();
-    return python_cu->get_type(name);
+    return PythonRpcHandler::getInstance().jitCompilationUnit()->get_type(name);
   }
 };
 
@@ -61,6 +60,7 @@ void PythonRpcHandler::cleanup() {
   pySerialize_ = py::none();
   pyHandleException_ = py::none();
   jitCompilationUnit_ = nullptr;
+  typeParser_ = nullptr;
 }
 
 PythonRpcHandler& PythonRpcHandler::getInstance() {

--- a/torch/csrc/distributed/rpc/rref_impl.cpp
+++ b/torch/csrc/distributed/rpc/rref_impl.cpp
@@ -43,6 +43,8 @@ RRefForkData::RRefForkData(
       type_str_(std::move(type_str)) {}
 
 py::tuple RRefForkData::toPyTuple() const {
+  // add GIL as it is contructing a py::object
+  pybind11::gil_scoped_acquire ag;
   return py::make_tuple(
       ownerId_,
       rrefId_.createdOn_,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#32748 clean up GIL usuage**

This is to follow up PR #30630, we need to have GIL when calling jit::toPyObject(), for some binded functions need to be taged with GIL release if underneath C++ codes requires GIL. so
1. pyRef::to_here() and pyRef::local_value() added GIL
2. pyRef::pickle and pyRef::unpickle() added GIL release tag
3. in request_callback_impl, also added GIL as needed
4. for typeParser, use cached jitCompilationUnit_, also clean it up in cleanUp() function

Differential Revision: [D19612337](https://our.internmc.facebook.com/intern/diff/D19612337/)