### PR TITLE
Fixed the flaky test_rref_context_debug_info

### DIFF
--- a/torch/testing/_internal/dist_utils.py
+++ b/torch/testing/_internal/dist_utils.py
@@ -5,6 +5,7 @@ from functools import partial, wraps
 
 import torch.distributed as dist
 import torch.distributed.rpc as rpc
+from torch.distributed.rpc import _rref_context_get_debug_info
 
 
 if not dist.is_available():
@@ -109,6 +110,23 @@ def get_shutdown_error_regex():
     ]
     error_regex = "".join(["({})|".format(error_str) for error_str in error_regexes])
     return error_regex
+
+def wait_until_pending_users_flushed():
+    '''
+    The RRef protocol holds forkIds of rrefs in a map until those forks are
+    confirmed by the owner. The message confirming the fork may arrive after
+    our tests check whether this map is empty, which leads to failures and
+    flaky tests. to_here also does not guarantee that we have finished
+    processind the owner's confirmation message for the RRef. This function
+    loops until the map is empty, which means the messages have been received
+    as processed. Call this function before asserting the map returned by
+    _get_debug_info is empty.
+    '''
+    num_pending_users = int(_rref_context_get_debug_info()["num_pending_users"])
+    while num_pending_users != 0:
+        time.sleep(0.1)
+        num_pending_users = int(_rref_context_get_debug_info()["num_pending_users"])
+    return
 
 def initialize_pg(init_method, rank, world_size):
     # This is for tests using `dist.barrier`.


### PR DESCRIPTION
Summary:
`test_rref_context_debug_info` was flaky since the message from owner RRef confirming fork could rarely arrive after the test checked whether the pending User RRefs map was empty - leading to an assertion error. This diff creates a utility function that should be used by any test to wait for this message to complete processing before doing any assertions related to the pending User RRefs map.

GitHub Issue: https://github.com/pytorch/pytorch/issues/30988

Test Plan: Stress tested `test_rref_context_debug_info` 200 times.

Differential Revision: D19612289

