### PR TITLE
Remove needs_dynamic_casting from TensorIterator and move it to Loops.cuh

### DIFF
--- a/aten/src/ATen/native/TensorIterator.cpp
+++ b/aten/src/ATen/native/TensorIterator.cpp
@@ -235,10 +235,6 @@ void TensorIterator::compute_types() {
       }
     }
 
-    if (is_different && !skip_output) {
-      have_differing_types_ = true;
-    }
-
     if (op.tensor.defined() && op.device != op.tensor.device()) {
       if (op.is_output) {
         TORCH_CHECK(false, "output with device ", op.tensor.device(),
@@ -675,7 +671,6 @@ TensorIterator TensorIterator::comparison_op(Tensor& out, const Tensor& a,
   iter.allow_cpu_scalars_ = true;
   iter.compute_common_dtype_only_for_inputs();
   iter.build();
-  iter.dynamic_cast_if(iter.dtype() != kBool);
   return iter;
 }
 

--- a/aten/src/ATen/native/TensorIterator.h
+++ b/aten/src/ATen/native/TensorIterator.h
@@ -299,10 +299,6 @@ struct CAFFE2_API TensorIterator {
   /// CUDA reductions.
   bool is_final_output() const { return final_output_; }
 
-  bool needs_dynamic_casting() const {
-    return force_dynamic_casting_ || ((common_dtype_strategy_ != CommonDTypeStrategy::NONE) && have_differing_types_);
-  }
-
   bool has_contiguous_first_dim() const {
     int num_tensors = ntensors();
     for (int i = 0; i < num_tensors; i++) {
@@ -352,10 +348,6 @@ struct CAFFE2_API TensorIterator {
     resize_outputs_ = false;
   }
 
-  void dynamic_cast_if(bool condition) {
-    force_dynamic_casting_ = force_dynamic_casting_ || condition;
-  }
-
   void build();
 
 protected:
@@ -391,8 +383,6 @@ protected:
   bool promote_gpu_output_dtypes_ = false;
   bool final_output_ = true;
   bool check_mem_overlap_ = false;
-  bool have_differing_types_ = false;
-  bool force_dynamic_casting_ = false;
   bool all_ops_same_shape_ = false;
   bool requires_channels_last_output_ = false;
 };

--- a/aten/src/ATen/native/cuda/Copy.cu
+++ b/aten/src/ATen/native/cuda/Copy.cu
@@ -58,7 +58,6 @@ void copy_device_to_device(TensorIterator& iter, bool non_blocking) {
         cudaMemcpyDeviceToDevice,
         copy_stream));
   } else {
-    iter.dynamic_cast_if(true);
     AT_DISPATCH_ALL_TYPES_AND3(kHalf, kBool, kBFloat16, iter.dtype(0), "copy_", [&] {
       gpu_kernel(iter, []GPU_LAMBDA(scalar_t x) { return x; });
     });

--- a/aten/src/ATen/native/cuda/Loops.cuh
+++ b/aten/src/ATen/native/cuda/Loops.cuh
@@ -287,7 +287,7 @@ static void launch_kernel(int64_t N, const func_t& f, array_t data) {
 
 } // namespace modern
 
-template<func_t>
+template<typename func_t>
 bool needs_dynamic_casting(TensorIterator& iter) {
   using traits = function_traits<func_t>;
   if (iter.dtype(0) != c10::impl::CPPTypeToScalarType<typename traits::result_type>::value) {

--- a/aten/src/ATen/native/cuda/Loops.cuh
+++ b/aten/src/ATen/native/cuda/Loops.cuh
@@ -325,8 +325,6 @@ void gpu_kernel_impl(TensorIterator& iter, const func_t& f) {
     dtypes[i] = iter.tensor(i).scalar_type();
   }
 
-  std::cout << "needs_dynamic_casting = " << needs_dynamic_casting<func_t>::check(iter) << std::endl;
-
   int64_t numel = iter.numel();
   if (iter.is_trivial_1d()) {
     auto inner_strides = iter.get_inner_strides();

--- a/aten/src/ATen/native/cuda/Loops.cuh
+++ b/aten/src/ATen/native/cuda/Loops.cuh
@@ -37,7 +37,7 @@
 #include <ATen/detail/FunctionTraits.h>
 #include <ATen/native/TensorIterator.h>
 #include <c10/macros/Macros.h>
-#include <c10/util/ScalarType.h>
+#include <c10/core/ScalarType.h>
 #include <c10/util/TypeCast.h>
 
 // Marks a lambda as executable on both the host and device. The __host__

--- a/aten/src/ATen/native/cuda/Loops.cuh
+++ b/aten/src/ATen/native/cuda/Loops.cuh
@@ -443,7 +443,7 @@ void gpu_kernel_with_index_impl(TensorIterator& iter, const func_t& f) {
       strides[i] = inner_strides[i];
     }
 
-    if (iter.needs_dynamic_casting()) {
+    if (needs_dynamic_casting<func_t>(iter)) {
       legacy::launch_kernel<launch_size_1d, 1>(numel, [=]GPU_LAMBDA(int idx) {
         void* out = data[0] + strides[0] * idx;
         arg0_t result = legacy::invoke_with_index(f, &data.data[1], &strides.data[1], &dtypes.data[1], idx, idx);
@@ -457,7 +457,7 @@ void gpu_kernel_with_index_impl(TensorIterator& iter, const func_t& f) {
     }
   } else {
     auto offset_calc = legacy::make_offset_calculator<traits::arity>(iter);
-    if (iter.needs_dynamic_casting()) {
+    if (needs_dynamic_casting<func_t>(iter)) {
       legacy::launch_kernel<launch_size_nd, launch_bound2>(numel, [=]GPU_LAMBDA(int idx) {
         auto offsets = offset_calc.get(idx);
         void* out = data[0] + offsets[0];

--- a/c10/core/ScalarType.h
+++ b/c10/core/ScalarType.h
@@ -2,6 +2,7 @@
 
 #include <c10/util/ArrayRef.h>
 #include <c10/util/Half.h>
+#include <c10/util/BFloat16.h>
 #include <c10/util/Optional.h>
 #include <c10/util/typeid.h>
 
@@ -117,6 +118,24 @@ struct ScalarTypeToCPPType<c10::ScalarType::Long> {
   // TODO: remove once the bug is fixed.
   static type t;
 };
+
+// These are used to map C++ types to ScalarTypes. Feel free to add more or even
+// macro generate this; the examples here are just those we have found to be
+// necessary.
+
+template <typename scalar_t>
+struct CPPTypeToScalarType {
+  constexpr static c10::ScalarType value = c10::ScalarType::Undefined;
+};
+
+#define SPECIALIZE_CPPTypeToScalarType(scalar_t, scalar_type)                  \
+  template <>                                                                  \
+  struct CPPTypeToScalarType<scalar_t> {                                       \
+    constexpr static c10::ScalarType value = c10::ScalarType::scalar_type;     \
+  };
+
+AT_FORALL_SCALAR_TYPES_WITH_COMPLEX_AND_QINTS(SPECIALIZE_CPPTypeToScalarType);
+
 }
 
 #define AT_FORALL_SCALAR_TYPES(_) \

--- a/c10/core/ScalarType.h
+++ b/c10/core/ScalarType.h
@@ -37,7 +37,7 @@ namespace c10 {
   _(c10::qint8, QInt8) /* 12 */                          \
   _(c10::quint8, QUInt8) /* 13 */                        \
   _(c10::qint32, QInt32) /* 14 */                        \
-  _(c10::BFloat16, BFloat16) /* 15 */
+  _(at::BFloat16, BFloat16) /* 15 */
 
 
 // If you want to support ComplexHalf for real, add ComplexHalf

--- a/c10/core/ScalarType.h
+++ b/c10/core/ScalarType.h
@@ -119,9 +119,7 @@ struct ScalarTypeToCPPType<c10::ScalarType::Long> {
   static type t;
 };
 
-// These are used to map C++ types to ScalarTypes. Feel free to add more or even
-// macro generate this; the examples here are just those we have found to be
-// necessary.
+// These are used to map C++ types to ScalarTypes.
 
 template <typename>
 struct CPPTypeToScalarType {

--- a/c10/core/ScalarType.h
+++ b/c10/core/ScalarType.h
@@ -37,7 +37,7 @@ namespace c10 {
   _(c10::qint8, QInt8) /* 12 */                          \
   _(c10::quint8, QUInt8) /* 13 */                        \
   _(c10::qint32, QInt32) /* 14 */                        \
-  _(at::BFloat16, BFloat16) /* 15 */
+  _(c10::BFloat16, BFloat16) /* 15 */
 
 
 // If you want to support ComplexHalf for real, add ComplexHalf
@@ -123,18 +123,20 @@ struct ScalarTypeToCPPType<c10::ScalarType::Long> {
 // macro generate this; the examples here are just those we have found to be
 // necessary.
 
-template <typename scalar_t>
+template <typename>
 struct CPPTypeToScalarType {
   constexpr static c10::ScalarType value = c10::ScalarType::Undefined;
 };
 
-#define SPECIALIZE_CPPTypeToScalarType(scalar_t, scalar_type)                  \
+#define SPECIALIZE_CPPTypeToScalarType(cpp_type, scalar_type)                  \
   template <>                                                                  \
-  struct CPPTypeToScalarType<scalar_t> {                                       \
+  struct CPPTypeToScalarType<cpp_type> {                                       \
     constexpr static c10::ScalarType value = c10::ScalarType::scalar_type;     \
   };
 
-AT_FORALL_SCALAR_TYPES_WITH_COMPLEX_AND_QINTS(SPECIALIZE_CPPTypeToScalarType);
+AT_FORALL_SCALAR_TYPES_WITH_COMPLEX_AND_QINTS(SPECIALIZE_CPPTypeToScalarType)
+
+#undef SPECIALIZE_CPPTypeToScalarType
 
 }
 


### PR DESCRIPTION
Remove `needs_dynamic_casting` from TensorIterator and move it to `Loops.cuh`.

The original design of `needs_dynamic_casting` is fundamentally flawed: it injects logics into TensorIterator and uses a bunch of boolean values to test whether the dynamic casting is needed. This makes it very fragile, as the TensorIterator is so complicated and it is easy to introduce unnecessary dynamic casts. It also makes the `gpu_kernel` very unflexible, differently cases needs to manipulate TensorIterator to make it work.

For example, currently
```python
torch.zeros(10, device='cuda').mul_(0.9)
```
needs dynamic cast, but it shouldn't.

Testing whether dynamic casting is needed could be easy: just compare the dtypes of the lambda with the dtypes of operands. If they don't match, then dynamically cast, otherwise don't cast.