### PR TITLE
Make save_for_lite_interpreter private

### DIFF
--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1653,9 +1653,9 @@ if _enabled:
             """
             return self._c.save(*args, **kwargs)
 
-        def _save_for_mobile(self, *args, **kwargs):
+        def _save_for_lite_interpreter(self, *args, **kwargs):
             r"""
-            _save_for_mobile(f)
+            _save_for_lite_interpreter(f)
 
             Add (or update) the bytecode session to the script model. The updated model is used
             in lite interpreter for mobile applications.

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1653,7 +1653,7 @@ if _enabled:
             """
             return self._c.save(*args, **kwargs)
 
-        def save_for_mobile(self, *args, **kwargs):
+        def _save_for_mobile(self, *args, **kwargs):
             r"""
             _save_for_mobile(f)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#32771 Make save_for_lite_interpreter private**
It's a patch to #32621, make the api private.

Differential Revision: [D19657307](https://our.internmc.facebook.com/intern/diff/D19657307)