### PR TITLE
Fix ivalue_inl.h:353:29: warning: comparison of unsigned expression >= 0 is always true

### DIFF
--- a/aten/src/ATen/core/ivalue_inl.h
+++ b/aten/src/ATen/core/ivalue_inl.h
@@ -350,7 +350,7 @@ struct C10_EXPORT ivalue::Object final : c10::intrusive_ptr_target {
   }
 
   const IValue& getSlot(size_t slot) const {
-    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(slot >= 0 && slot < slots_.size());
+    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(slot < slots_.size());
     // NOTE: This lookup is fairly hot, so we use unchecked access to the
     // vector.  Errors should still be detectable with ASan.
     return slots_[slot];


### PR DESCRIPTION
`slot` is unsigned integer which is `always >= 0`

