### PR TITLE
Allow DDP to handle mixed CPU-GPU models

### DIFF
--- a/test/distributed/test_c10d.py
+++ b/test/distributed/test_c10d.py
@@ -2131,10 +2131,6 @@ class DistributedDataParallelTest(MultiProcessTestCase):
             ddp_model = DistributedDataParallel(
                 model, device_ids=gpus, process_group=process_group)
 
-        with self.assertRaisesRegex(AssertionError, "only works with CUDA devices"):
-            model.fc1 = model.fc1.cpu()
-            ddp_model = DistributedDataParallel(model, process_group=process_group)
-
         model = model.cpu()
         with self.assertRaisesRegex(AssertionError, "device_ids .* single-device CUDA"):
             ddp_model = DistributedDataParallel(

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -263,12 +263,6 @@ class DistributedDataParallel(Module):
 
             self.output_device = _get_device_index(output_device, True)
 
-        if self.is_multi_device_module:
-            assert self.is_cuda, (
-                "DistributedDataParallel with multi-device module only works "
-                "with CUDA devices, but module parameters locate in {}."
-            ).format({p.device for p in module.parameters()})
-
         if process_group is None:
             self.process_group = _get_default_group()
         else:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#32779 Allow DDP to handle mixed CPU-GPU models**

Differential Revision: [D19625701](https://our.internmc.facebook.com/intern/diff/D19625701)