### PR TITLE
`torch.pow` Add type promotion support and fix issue with __rpow__

### DIFF
--- a/aten/src/ATen/native/Pow.cpp
+++ b/aten/src/ATen/native/Pow.cpp
@@ -27,7 +27,8 @@ Tensor& pow_out(Tensor& result, const Tensor& base, Scalar exp) {
   } else if (exp.toDouble() == 1.0) {
     result.resize_as_(base).copy_(base);
   } else {
-    auto iter = TensorIterator::unary_op(result, base,
+    auto common_dtype = at::result_type(base, exp);
+    auto iter = TensorIterator::unary_op(result, base.to(common_dtype),
                                          /*check_mem_overlap=*/true);
     pow_tensor_scalar_stub(iter.device_type(), iter, exp);
   }
@@ -52,17 +53,20 @@ Tensor& pow_(Tensor& base, Scalar alpha) {
 }
 
 Tensor pow(const Tensor& base, const Tensor& exp) {
-  Tensor result = at::empty({0}, base.options());
+  auto dtype = at::result_type(base, exp);
+  Tensor result = at::empty({0}, base.options().dtype(dtype));
   return native::pow_out(result, base, exp);
 }
 
 Tensor pow(const Tensor& base, Scalar exp) {
-  Tensor result = at::empty_like(base, MemoryFormat::Preserve);
+  auto dtype = at::result_type(base, exp);
+  Tensor result = at::empty_like(base, base.options().dtype(dtype), MemoryFormat::Preserve);
   return native::pow_out(result, base, exp);
 }
 
 Tensor pow(Scalar base, const Tensor& exp) {
-  Tensor result = at::empty_like(exp, MemoryFormat::Preserve);
+  auto dtype = at::result_type(base, exp);
+  Tensor result = at::empty_like(exp, exp.options().dtype(dtype), MemoryFormat::Preserve);
   return native::pow_out(result, base, exp);
 }
 

--- a/aten/src/ATen/native/Pow.h
+++ b/aten/src/ATen/native/Pow.h
@@ -9,6 +9,48 @@ struct TensorIterator;
 
 namespace native {
 
+#if defined(__CUDACC__) || defined(__HIPCC__)
+#define HOST_DEVICE __host__ __device__
+#else
+#define HOST_DEVICE
+#endif
+
+template <class T,
+  typename std::enable_if<std::is_integral<T>::value, T>::type* = nullptr>
+static inline HOST_DEVICE T powi_impl(T a, T b) {
+  T result = 1;
+  while (b) {
+    if (b & 1) {
+       result *= a;
+    }
+    b /= 2;
+    a *= a;
+  }
+  return result;
+}
+
+template <class T,
+  typename std::enable_if<std::is_integral<T>::value && !std::is_signed<T>::value, T>::type* = nullptr>
+static inline HOST_DEVICE T powi(T a, T b) {
+  return powi_impl(a, b);
+}
+
+template <class T,
+  typename std::enable_if<std::is_integral<T>::value && std::is_signed<T>::value, T>::type* = nullptr>
+static inline HOST_DEVICE T powi(T a, T b) {
+  if ( b < 0 ) {
+      if ( a == 1 ) {
+          return 1;
+      } else if ( a == -1 ) {
+          auto negative = (-b) % static_cast<T>(2);
+          return negative ? -1 : 1;
+      } else {
+          return 0;
+      }
+  }
+  return powi_impl(a, b);
+}
+
 using pow_tensor_tensor_fn = void (*)(TensorIterator&);
 using pow_tensor_scalar_fn = void (*)(TensorIterator&, Scalar);
 

--- a/aten/src/ATen/native/cpu/PowKernel.cpp
+++ b/aten/src/ATen/native/cpu/PowKernel.cpp
@@ -27,7 +27,7 @@ void pow_tensor_tensor_kernel(TensorIterator& iter) {
     AT_DISPATCH_INTEGRAL_TYPES(iter.dtype(), "pow", [&]() {
       cpu_kernel(iter,
         [=](scalar_t base, scalar_t exp) -> scalar_t {
-          return std::pow(base, exp);
+          return native::powi(base, exp);
         }
       );
     });
@@ -148,89 +148,13 @@ void pow_tensor_scalar_kernel(TensorIterator& iter, Scalar exp_scalar) {
       }
     });
   } else {
-    // Integral types do not allow AVX2 vector optimizations for pow/sqrt/rsqrt.
-    // Trying to implement pow/sqrt/rsqrt as loop in vec256_int.h does not allow
-    // powering integral tensor to float exponent. That's why we need this code
-    // duplication:
-
-    if (exp_scalar.isIntegral(true) && exp_scalar.to<int64_t>() >= 0) {
-      // Specifically deal with an integer to the power of a positive integer for better efficiency.
-      const auto exp = exp_scalar.to<int64_t>();
-
-      AT_DISPATCH_INTEGRAL_TYPES(iter.dtype(), "pow", [&]() {
-        switch (exp) {
-          case 2:
-            cpu_kernel(iter,
-              [](scalar_t base) -> scalar_t {
-                return base * base;
-              }
-            );
-            break;
-          case 3:
-            cpu_kernel(iter,
-              [](scalar_t base) -> scalar_t {
-                return base * base * base;
-              }
-            );
-            break;
-          default:
-            cpu_kernel(iter,
-              [=](scalar_t base) -> scalar_t {
-                return std::pow(base, exp);
-              }
-            );
-        }
-      });
-    } else {
-      // Casting exponent to double(not tensor.dtype) allows powering integral
-      // tensors to float exponent e.g. tensor([4]).pow(0.5) will be tensor([2])
-      const auto exp = exp_scalar.to<double>();
-      AT_DISPATCH_INTEGRAL_TYPES(iter.dtype(), "pow", [&]() {
-        if (exp == 2) {
-          cpu_kernel(iter,
-            [](scalar_t base) -> scalar_t {
-              return base * base;
-            }
-          );
-        } else if (exp == 3) {
-          cpu_kernel(iter,
-            [](scalar_t base) -> scalar_t {
-              return base * base * base;
-            }
-          );
-        } else if (exp == 0.5) {
-          cpu_kernel(iter,
-            [](scalar_t base) -> scalar_t {
-              return std::sqrt(static_cast<long double>(base));
-            }
-          );
-        } else if (exp == -0.5) {
-          cpu_kernel(iter,
-            [](scalar_t base) -> scalar_t {
-              return 1.0 / std::sqrt(static_cast<long double>(base));
-            }
-          );
-        } else if (exp == -1) {
-          cpu_kernel(iter,
-            [](scalar_t base) -> scalar_t {
-              return 1.0 / static_cast<long double>(base);
-            }
-          );
-        } else if (exp == -2) {
-          cpu_kernel(iter,
-            [](scalar_t base) -> scalar_t {
-              return 1.0 / (base * base);
-            }
-          );
-        } else {
-          cpu_kernel(iter,
-            [=](scalar_t base) -> scalar_t {
-              return std::pow(static_cast<long double>(base), exp);
-            }
-          );
-        }
-      });
-    }
+    AT_DISPATCH_INTEGRAL_TYPES(iter.dtype(), "pow", [&]() {
+      const scalar_t exp = exp_scalar.to<scalar_t>();
+      cpu_kernel(iter,
+        [=](scalar_t base) -> scalar_t {
+          return native::powi(base, exp);
+        });
+    });
   }
 }
 

--- a/aten/src/ATen/native/cuda/PowKernel.cu
+++ b/aten/src/ATen/native/cuda/PowKernel.cu
@@ -9,18 +9,6 @@ namespace at { namespace native {
 
 namespace {
 
-template <typename T>
-static inline __host__ __device__ T powi(T a, T b) {
-  T result = 1;
-  while (b) {
-    if (b & 1) {
-       result *= a;
-    }
-    b /= 2;
-    a *= a;
-  }
-  return result;
-}
 
 // SFINAE doesn't work well with NVCC under Windows for math functions like pow and sqrt.
 // So we need to define the functions with the explicit function signatures.
@@ -54,7 +42,7 @@ static inline __host__ __device__ typename std::enable_if<std::is_floating_point
 template <typename Base_type, typename Exp_type>
 static inline __host__ __device__ typename std::enable_if<std::is_integral<Base_type>::value && std::is_same<Base_type, Exp_type>::value, Base_type>::type
   pow_(Base_type base, Exp_type exp) {
-  return powi(base, exp);
+  return native::powi(base, exp);
 }
 // pow (Otherwise)
 template <typename Base_type, typename Exp_type>
@@ -109,7 +97,7 @@ void pow_tensor_tensor_kernel(TensorIterator& iter) {
   } else {
     AT_DISPATCH_INTEGRAL_TYPES(iter.dtype(), "pow_cuda", [&]() {
       gpu_kernel(iter, []GPU_LAMBDA(scalar_t base, scalar_t exp) -> scalar_t {
-        return powi(base, exp);
+        return native::powi(base, exp);
       });
     });
   }

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3652,12 +3652,15 @@
 
 - func: result_type.Tensor(Tensor tensor, Tensor other) -> ScalarType
   variants: function
+  supports_named_tensor: True
 
 - func: result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType
   variants: function
+  supports_named_tensor: True
 
 - func: result_type.Scalar_Tensor(Scalar scalar, Tensor tensor) -> ScalarType
   variants: function
+  supports_named_tensor: True
 
 - func: result_type.Scalar_Scalar(Scalar scalar1, Scalar scalar2) -> ScalarType
 

--- a/aten/src/ATen/test/pow_test.cpp
+++ b/aten/src/ATen/test/pow_test.cpp
@@ -104,39 +104,53 @@ void assert_eq(T val, T act, T exp) {
   ASSERT_EQ(act, exp);
 }
 
-template<typename Vals, typename Pows>
-void tensor_pow_scalar(const Vals vals, const Pows pows) {
-  using T = typename Vals::value_type;
+template <class T,
+  typename std::enable_if<std::is_floating_point<T>::value,T>::type* = nullptr>
+T typed_pow(T base, T exp) {
+  return std::pow(base, exp);
+}
+template <class T,
+  typename std::enable_if<std::is_integral<T>::value,T>::type* = nullptr>
+T typed_pow(T base, T exp) {
+  return native::powi(base, exp);
+}
 
+template<typename Vals, typename Pows>
+void tensor_pow_scalar(const Vals vals, const Pows pows, const torch::ScalarType dtype) {
   const auto tensor = torch::tensor(vals);
 
   for (const auto pow : pows) {
+    if ( dtype == kInt && pow > std::numeric_limits<int>::max()) {
+      // value cannot be converted to type int without overflow
+      EXPECT_THROW(tensor.pow(pow), std::domain_error);
+      continue;
+    }
     auto actual_pow = tensor.pow(pow);
 
-    auto actual_pow_ = tensor.clone();
+    auto actual_pow_ = torch::empty_like(actual_pow);
+    actual_pow_.copy_(tensor);
     actual_pow_.pow_(pow);
 
-    auto actual_pow_out = torch::empty_like(tensor);
+    auto actual_pow_out = torch::empty_like(actual_pow);
     torch::pow_out(actual_pow_out, tensor, pow);
 
     auto actual_torch_pow = torch::pow(tensor, pow);
 
     int i = 0;
     for (const auto val : vals) {
-      const auto exp = static_cast<T>(
-        std::pow(static_cast<long double>(val), static_cast<double>(pow)));
+      const auto exp = torch::pow(torch::tensor({val}, dtype), torch::tensor(pow, dtype)).template item<double>();
 
-      const auto act_pow = actual_pow[i].template item<T>();
-      assert_eq(val, act_pow, exp);
+      const auto act_pow = actual_pow[i].to(at::kDouble).template item<double>();
+      assert_eq<long double>(val, act_pow, exp);
 
-      const auto act_pow_ = actual_pow_[i].template item<T>();
-      assert_eq(val, act_pow_, exp);
+      const auto act_pow_ = actual_pow_[i].to(at::kDouble).template item<double>();
+      assert_eq<long double>(val, act_pow_, exp);
 
-      const auto act_pow_out = actual_pow_out[i].template item<T>();
-      assert_eq(val, act_pow_out, exp);
+      const auto act_pow_out = actual_pow_out[i].to(at::kDouble).template item<double>();
+      assert_eq<long double>(val, act_pow_out, exp);
 
-      const auto act_torch_pow = actual_torch_pow[i].template item<T>();
-      assert_eq(val, act_torch_pow, exp);
+      const auto act_torch_pow = actual_torch_pow[i].to(at::kDouble).template item<double>();
+      assert_eq<long double>(val, act_torch_pow, exp);
 
       i++;
     }
@@ -151,14 +165,13 @@ void scalar_pow_tensor(const Vals vals, const Pows pows) {
 
   for (const auto val : vals) {
     const auto actual_pow = torch::pow(val, pow_tensor);
-    auto actual_pow_out1 = torch::empty_like(pow_tensor);
+    auto actual_pow_out1 = torch::empty_like(actual_pow);
     const auto actual_pow_out2 =
       torch::pow_out(actual_pow_out1, val, pow_tensor);
 
     int i = 0;
     for (const auto pow : pows) {
-      const auto exp = static_cast<T>(
-        std::pow(static_cast<T>(val), pow));
+      const auto exp = typed_pow(static_cast<T>(val), T(pow));
 
       const auto act_pow = actual_pow[i].template item<T>();
       assert_eq<T>(val, act_pow, exp);
@@ -198,7 +211,7 @@ void tensor_pow_tensor(const Vals vals, Pows pows) {
     int i = 0;
     for (const auto val : vals) {
       const auto pow = pows[i];
-      const auto exp = static_cast<T>(std::pow(val, pow));
+      const auto exp = typed_pow(T(val), T(pow));
 
       const auto act_pow = actual_pow[i].template item<T>();
       assert_eq(val, act_pow, exp);
@@ -219,34 +232,79 @@ void tensor_pow_tensor(const Vals vals, Pows pows) {
   }
 }
 
+template<typename T>
+void test_pow_one(const std::vector<T> vals) {
+  for (const auto val : vals) {
+    ASSERT_EQ(native::powi(val, T(1)), val);
+  }
+}
+
+template<typename T>
+void test_squared(const std::vector<T> vals) {
+  for (const auto val : vals) {
+    ASSERT_EQ(native::powi(val, T(2)), val * val);
+  }
+}
+
+template<typename T>
+void test_cubed(const std::vector<T> vals) {
+  for (const auto val : vals) {
+    ASSERT_EQ(native::powi(val, T(3)), val * val * val);
+  }
+}
+template<typename T>
+void test_inverse(const std::vector<T> vals) {
+  for (const auto val : vals) {
+    // 1 has special checks below
+    if ( val != 1 && val != -1) {
+      ASSERT_EQ(native::powi(val, T(-4)), 0);
+      ASSERT_EQ(native::powi(val, T(-1)), val==1);
+    }
+  }
+  T neg1 = -1;
+  ASSERT_EQ(native::powi(neg1, T(0)), 1);
+  ASSERT_EQ(native::powi(neg1, T(-1)), -1);
+  ASSERT_EQ(native::powi(neg1, T(-2)), 1);
+  ASSERT_EQ(native::powi(neg1, T(-3)), -1);
+  ASSERT_EQ(native::powi(neg1, T(-4)), 1);
+
+  T one = 1;
+  ASSERT_EQ(native::powi(one, T(0)), 1);
+  ASSERT_EQ(native::powi(one, T(-1)), 1);
+  ASSERT_EQ(native::powi(one, T(-2)), 1);
+  ASSERT_EQ(native::powi(one, T(-3)), 1);
+  ASSERT_EQ(native::powi(one, T(-4)), 1);
+
+}
+
 }
 
 TEST(PowTest, IntTensorPowAllScalars) {
-  tensor_pow_scalar(ints, non_neg_ints);
-  tensor_pow_scalar(ints, non_neg_longs);
-  tensor_pow_scalar(ints, floats);
-  tensor_pow_scalar(ints, doubles);
+  tensor_pow_scalar(ints, non_neg_ints, kInt);
+  tensor_pow_scalar(ints, non_neg_longs, kInt);
+  tensor_pow_scalar(ints, floats, kFloat);
+  tensor_pow_scalar(ints, doubles, kDouble);
 }
 
 TEST(PowTest, LongTensorPowAllScalars) {
-  tensor_pow_scalar(longs, non_neg_ints);
-  tensor_pow_scalar(longs, non_neg_longs);
-  tensor_pow_scalar(longs, floats);
-  tensor_pow_scalar(longs, doubles);
+  tensor_pow_scalar(longs, non_neg_ints, kLong);
+  tensor_pow_scalar(longs, non_neg_longs, kLong);
+  tensor_pow_scalar(longs, floats, kFloat);
+  tensor_pow_scalar(longs, doubles, kDouble);
 }
 
 TEST(PowTest, FloatTensorPowAllScalars) {
-  tensor_pow_scalar(floats, ints);
-  tensor_pow_scalar(floats, longs);
-  tensor_pow_scalar(floats, floats);
-  tensor_pow_scalar(floats, doubles);
+  tensor_pow_scalar(floats, ints, kDouble);
+  tensor_pow_scalar(floats, longs, kDouble);
+  tensor_pow_scalar(floats, floats, kFloat);
+  tensor_pow_scalar(floats, doubles, kDouble);
 }
 
 TEST(PowTest, DoubleTensorPowAllScalars) {
-  tensor_pow_scalar(doubles, ints);
-  tensor_pow_scalar(doubles, longs);
-  tensor_pow_scalar(doubles, floats);
-  tensor_pow_scalar(doubles, doubles);
+  tensor_pow_scalar(doubles, ints, kDouble);
+  tensor_pow_scalar(doubles, longs, kDouble);
+  tensor_pow_scalar(doubles, floats, kDouble);
+  tensor_pow_scalar(doubles, doubles, kDouble);
 }
 
 TEST(PowTest, IntScalarPowAllTensors) {
@@ -286,3 +344,18 @@ TEST(PowTest, FloatTensorPowFloatTensor) {
 TEST(PowTest, DoubleTensorPowDoubleTensor) {
   tensor_pow_tensor(doubles, doubles);
 }
+
+TEST(PowTest, TestIntegralPow) {
+  test_pow_one(longs);
+  test_pow_one(ints);
+
+  test_squared(longs);
+  test_squared(ints);
+
+  test_cubed(longs);
+  test_cubed(ints);
+
+  test_inverse(longs);
+  test_inverse(ints);
+}
+

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6174,10 +6174,11 @@ class TestTorchDeviceType(TestCase):
                 actual = base.pow(exponent)
                 self.assertEqual(actual, expected, allow_inf=True)
 
-                actual = base.clone()
-                actual2 = actual.pow_(exponent)
-                self.assertEqual(actual, expected, allow_inf=True)
-                self.assertEqual(actual2, expected, allow_inf=True)
+                if torch.can_cast(torch.result_type(base, exponent), base.dtype):
+                    actual = base.clone()
+                    actual2 = actual.pow_(exponent)
+                    self.assertEqual(actual, expected, allow_inf=True)
+                    self.assertEqual(actual2, expected, allow_inf=True)
 
             actual = torch.pow(base, exponent)
             self.assertEqual(actual, expected, allow_inf=True)
@@ -6526,6 +6527,7 @@ class TestTorchDeviceType(TestCase):
                                                 r'Integers to negative integer powers are not allowed\.'):
                         torch.pow(m1[4], num)
                 else:
+                    expected_dtype = torch.result_type(num, m1[4])
                     # base - tensor, exponent - number
                     # contiguous
                     res1 = torch.pow(m1[4], num)
@@ -6533,6 +6535,12 @@ class TestTorchDeviceType(TestCase):
                     for i in range(res2.size(0)):
                         res2[i] = math.pow(m1[4][i], num)
                     self.assertEqual(res1, res2)
+
+                    # scalar ** tensor to enforce correct handling of dtypes for __rpow__().
+                    res1 = num ** m1[4]
+                    res2 = torch.tensor(num, dtype=expected_dtype, device=device) ** m1[4]
+                    self.assertEqual(res1, res2)
+                    self.assertEqual(res1.dtype, expected_dtype)
 
                     # non-contiguous
                     res1 = torch.pow(m1[:, 4], num)
@@ -6560,6 +6568,7 @@ class TestTorchDeviceType(TestCase):
             out = torch.zeros(1, dtype=dtype, device=device)
             torch.pow(m1, 1, out=out)
             self.assertEqual(out, m1)
+
 
     def test_neg(self, device):
         int_types = [torch.int, torch.short, torch.int8, torch.uint8]

--- a/torch/tensor.py
+++ b/torch/tensor.py
@@ -417,7 +417,8 @@ class Tensor(torch._C._TensorBase):
 
     @_wrap_type_error_to_not_implemented
     def __rpow__(self, other):
-        return self.new_tensor(other) ** self
+        dtype = torch.result_type(other, self)
+        return torch.tensor(other, dtype=dtype, device=self.device) ** self
 
     @_wrap_type_error_to_not_implemented
     def __floordiv__(self, other):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#32781 `torch.pow` Add type promotion support and fix issue with __rpow__**

This is an unstacked cherry pick of https://github.com/pytorch/pytorch/pull/32582

Summary:

Fixes: https://github.com/pytorch/pytorch/issues/32436

The issue caused incorrect handling of dtypes for scalar ** tensor.
e.g. before this change:
```
>>> 5.5 ** torch.ones(5, dtype=torch.int32)
tensor([5, 5, 5, 5, 5], dtype=torch.int32)
```
should return a float tensor.

Also fixes a number of incorrect cases:
 * tensors to negative powers were giving incorrect results (1 instead
    of 0 or error)
 * Behavior wasn't consistent between cuda/cpu
 * large_value ** 1 in some cases gave a result not equal
    to large_value because of truncation in conversion to double and back.

BC-breaking:

Previously incorrect behavior (in 1.4):
```
>>> a
tensor([1, 1, 1, 1, 1], dtype=torch.int32)
>>> a.pow_(.5)
tensor([1, 1, 1, 1, 1], dtype=torch.int32)
```

After this change:
`RuntimeError: result type Float can't be cast to the desired output type Int`