### PR TITLE
[JIT] hook back on container magic methods on save and load

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -9863,6 +9863,24 @@ a")
             with self.assertRaisesRegex(Exception, "object is not iterable"):
                 print([val for val in m])
 
+        # test magic methods save load
+        m = M()
+        buffer = io.BytesIO()
+        torch.jit.save(m, buffer)
+        buffer.seek(0)
+        m = torch.jit.load(buffer)
+        with torch.jit.optimized_execution(False):
+            i = torch.Tensor(2)
+            m = M()
+            o = m(i)
+            v = i
+            for sub in m.mods:
+                v = sub(v)
+            self.assertEqual(o, v)
+
+            with self.assertRaisesRegex(Exception, ""):
+                print([val for val in m])
+
     def test_attr_qscheme_script(self):
         class Foo(torch.nn.Module):
             def __init__(self):

--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -8,6 +8,7 @@ import inspect
 import weakref
 import warnings
 import torch
+import sys
 from torch._six import builtins
 from torch._utils_internal import get_source_lines_and_file
 
@@ -713,3 +714,14 @@ def _qualified_name(obj):
                            "'{}' is not a valid identifier".format(name, name))
 
     return module_name + "." + name
+
+def _try_get_module_class_from_qual_name(qual_name):
+    assert qual_name.find("__torch__.") == 0
+    qual_name = qual_name[len("__torch__."):]
+    attrs = qual_name.split(".")
+    if attrs[0] not in sys.modules:
+        return None
+    value = sys.modules[attrs[0]]
+    for i in range(1, len(attrs)):
+        value = getattr(value, attrs[i], None)
+    return value

--- a/torch/jit/_recursive.py
+++ b/torch/jit/_recursive.py
@@ -72,6 +72,7 @@ def infer_concrete_type_builder(nn_module):
     if isinstance(nn_module, (torch.nn.ModuleList, torch.nn.Sequential)):
         concrete_type_builder.set_module_list()
 
+    setattr(nn_module, "_original_qual_name", torch.jit._qualified_name(type(nn_module)))
     class_annotations = getattr(nn_module, '__annotations__', {})
 
     # try to infer the type from type annotation or from the object itself
@@ -297,6 +298,15 @@ def create_script_module(nn_module, stubs_fn, share_types=True):
 
     return create_script_module_impl(nn_module, concrete_type, stubs_fn)
 
+def _add_copy_to_script_methods(nn_module_type, script_module):
+    # copy over python methods to script module if they aren't defined on the script module
+    # this is currently an internal api used only on module containers
+    for name in dir(nn_module_type):
+        item = getattr(nn_module_type, name, None)
+        if _jit_internal.get_torchscript_modifier(item) is _jit_internal.FunctionModifiers.COPY_TO_SCRIPT_WRAPPER:
+            add_python_attr_to_scripted_model(script_module, nn_module_type, name)
+
+
 def create_script_module_impl(nn_module, concrete_type, stubs_fn):
     """
     Convert an nn.Module to a RecursiveScriptModule.
@@ -370,13 +380,7 @@ def create_script_module_impl(nn_module, concrete_type, stubs_fn):
         # nn.Module.forward)
         script_module.__dict__[name] = script_method
 
-
-    # copy over python methods to script module if they aren't defined on the script module
-    # this is currently an internal api used only on module containers
-    for name in dir(nn_module):
-        item = getattr(nn_module, name, None)
-        if _jit_internal.get_torchscript_modifier(item) is _jit_internal.FunctionModifiers.COPY_TO_SCRIPT_WRAPPER:
-            add_python_attr_to_scripted_model(script_module, nn_module, name)
+    _add_copy_to_script_methods(type(nn_module), script_module)
 
     return script_module
 
@@ -384,18 +388,24 @@ def create_script_module_impl(nn_module, concrete_type, stubs_fn):
 # We define shims of certain attributes on the RecursiveScriptModule to support
 # magic methods. To check if a script model defines an attribute we need
 # to also check that the attribute is not the shim
-def script_model_defines_attr(script_model, attr):
+def script_model_doesnt_define_attr(script_model, attr):
     script_attr = getattr(script_model, attr, None)
     if script_attr is None:
-        return False
+        return True
     default_attr = get_function_from_type(torch.jit.RecursiveScriptModule, attr)
     if default_attr is None:
         return False
     return script_attr != default_attr
 
-def add_python_attr_to_scripted_model(script_model, orig, attr):
-    if hasattr(orig, attr) and script_model_defines_attr(script_model, attr):
-        setattr(script_model, attr, getattr(orig, attr))
+def add_python_attr_to_scripted_model(script_model, nn_module_type, attr):
+    if hasattr(nn_module_type, attr) and script_model_doesnt_define_attr(script_model, attr):
+        unbound_method = getattr(nn_module_type, attr)
+        # function should be unbound
+        assert not hasattr(unbound_method, "__self__")
+
+        def add_self_arg(*args, **kwargs):
+            return unbound_method(script_model, *args, **kwargs)
+        setattr(script_model, attr, add_self_arg)
 
 def get_overload_annotations(mod):
     # original function => [(mangled overload name, overload function)]
@@ -551,7 +561,7 @@ def try_compile_fn(fn, loc):
     rcb = _jit_internal.createResolutionCallbackFromClosure(fn)
     return torch.jit.script(fn, _rcb=rcb)
 
-def wrap_cpp_module(cpp_module):
+def wrap_cpp_module(cpp_module_inner):
     """
     Wrap this torch._C.ScriptModule in a Python ScriptModule, recursively for all submodules
     """
@@ -559,7 +569,12 @@ def wrap_cpp_module(cpp_module):
         for name, cpp_module in torch._C.ModuleDict(script_module._c).items():
             setattr(script_module, name, wrap_cpp_module(cpp_module))
         script_module._concrete_type = torch._C.ConcreteModuleType.from_jit_type(script_module._c._type())
-    return torch.jit.RecursiveScriptModule._construct(cpp_module, init_fn)
+        if cpp_module_inner.hasattr("_original_qual_name"):
+            nn_module = torch._jit_internal._try_get_module_class_from_qual_name(cpp_module_inner._original_qual_name)
+            if nn_module:
+                _add_copy_to_script_methods(nn_module, script_module)
+
+    return torch.jit.RecursiveScriptModule._construct(cpp_module_inner, init_fn)
 
 def compile_unbound_method(concrete_type, fn):
     if _jit_internal.is_ignored_fn(fn):

--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -130,6 +130,7 @@ class ModuleList(Module):
         if modules is not None:
             self += modules
 
+    @_copy_to_script_wrapper
     def _get_abs_string_index(self, idx):
         """Get the absolute index for the list of modules"""
         idx = operator.index(idx)


### PR DESCRIPTION
In order to continue to support the exposing magic methods of modules which inherit from nn containers we copy over the python magic methods to their scripted versions. This PR extends that behavior to saved & loaded modules by saving the fully qualified name of a module, and looking up the python methods to copy on the original module it was saved from.

A follow up PR to this could fix the problem we had of `isinstance(MyMod, torch.jit.script(MyMod))` returning false.