### PR TITLE
[JIT] hook back on container magic methods on save and load

### DIFF
--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -1448,7 +1448,8 @@ struct CAFFE2_API ClassType : public NamedType {
   static ClassTypePtr create(
       c10::optional<QualifiedName> qualifiedName,
       std::weak_ptr<CompilationUnit> cu,
-      bool is_module = false);
+      bool is_module = false,
+      c10::optional<std::string> original_qual_name = c10::nullopt);
 
   bool operator==(const Type& rhs) const override {
     if (auto user_rhs = rhs.cast<ClassType>()) {
@@ -1684,6 +1685,11 @@ struct CAFFE2_API ClassType : public NamedType {
   bool is_module() const override {
     return bool(parameterSlots_);
   }
+
+  c10::optional<std::string> getOriginalQualName() {
+    return original_qual_name_;
+  }
+
   bool is_parameter(size_t slot) const {
     TORCH_INTERNAL_ASSERT(
         is_module(), "asking for parameterSlots of non-Module");
@@ -1712,7 +1718,8 @@ struct CAFFE2_API ClassType : public NamedType {
   ClassType(
       c10::optional<QualifiedName> name,
       std::weak_ptr<CompilationUnit> cu,
-      bool is_module);
+      bool is_module,
+      c10::optional<std::string> original_qual_name);
 
   // Mapping of attribute names -> their type.
   // NOTE: this does not contain methods, which are stored in the module
@@ -1731,6 +1738,7 @@ struct CAFFE2_API ClassType : public NamedType {
   // if present, this class inherits from torch.nn.Module
   // and these are the indices of the attributes which are parameters
   std::shared_ptr<std::vector<bool>> parameterSlots_;
+  c10::optional<std::string> original_qual_name_ = c10::nullopt;
 
   // List of methods associated with this class.
   std::vector<Function*> methods_;

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -9863,6 +9863,24 @@ a")
             with self.assertRaisesRegex(Exception, "object is not iterable"):
                 print([val for val in m])
 
+        # test magic methods save load
+        m = M()
+        buffer = io.BytesIO()
+        torch.jit.save(m, buffer)
+        buffer.seek(0)
+        m = torch.jit.load(buffer)
+        with torch.jit.optimized_execution(False):
+            i = torch.Tensor(2)
+            m = M()
+            o = m(i)
+            v = i
+            for sub in m.mods:
+                v = sub(v)
+            self.assertEqual(o, v)
+
+            with self.assertRaisesRegex(Exception, ""):
+                print([val for val in m])
+
     def test_attr_qscheme_script(self):
         class Foo(torch.nn.Module):
             def __init__(self):

--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -8,6 +8,7 @@ import inspect
 import weakref
 import warnings
 import torch
+import sys
 from torch._six import builtins
 from torch._utils_internal import get_source_lines_and_file
 
@@ -713,3 +714,14 @@ def _qualified_name(obj):
                            "'{}' is not a valid identifier".format(name, name))
 
     return module_name + "." + name
+
+def _try_get_module_class_from_qual_name(qual_name):
+    assert qual_name.find("__torch__.") == 0
+    qual_name = qual_name[len("__torch__."):]
+    attrs = qual_name.split(".")
+    if attrs[0] not in sys.modules:
+        return None
+    value = sys.modules[attrs[0]]
+    for i in range(1, len(attrs)):
+        value = getattr(value, attrs[i], None)
+    return value

--- a/torch/csrc/jit/passes/python_print.cpp
+++ b/torch/csrc/jit/passes/python_print.cpp
@@ -1218,7 +1218,10 @@ struct PythonPrintImpl {
         }
         body_ << "]\n";
       }
-
+      indent();
+      if (auto original_qual_name = moduleType->getOriginalQualName()) {
+        body_ << "__original_qual_name__ = '" << *original_qual_name << "'\n";
+      }
       for (size_t i = 0; i < numAttrs; i++) {
         const auto& name = classType->getAttributeName(i);
         const auto& type = classType->getAttribute(i);

--- a/torch/csrc/jit/passes/python_print.cpp
+++ b/torch/csrc/jit/passes/python_print.cpp
@@ -1217,10 +1217,11 @@ struct PythonPrintImpl {
           body_ << "\"" << param << "\", ";
         }
         body_ << "]\n";
-      }
-      indent();
-      if (auto original_qual_name = moduleType->getOriginalQualName()) {
-        body_ << "__original_qual_name__ = '" << *original_qual_name << "'\n";
+        indent();
+        // print original qualified name (unmangled)
+        if (auto original_qual_name = classType->getOriginalQualName()) {
+          body_ << "__original_qual_name__ = '" << *original_qual_name << "'\n";
+        }
       }
       for (size_t i = 0; i < numAttrs; i++) {
         const auto& name = classType->getAttributeName(i);

--- a/torch/csrc/jit/script/class_type.cpp
+++ b/torch/csrc/jit/script/class_type.cpp
@@ -7,19 +7,22 @@ namespace c10 {
 ClassTypePtr ClassType::create(
     c10::optional<QualifiedName> qualifiedName,
     std::weak_ptr<CompilationUnit> cu,
-    bool is_module) {
-  return ClassTypePtr(
-      new ClassType(std::move(qualifiedName), std::move(cu), is_module));
+    bool is_module,
+    c10::optional<std::string> original_qual_name) {
+  return ClassTypePtr(new ClassType(
+      std::move(qualifiedName), std::move(cu), is_module, original_qual_name));
 }
 
 ClassType::ClassType(
     c10::optional<QualifiedName> name,
     std::weak_ptr<CompilationUnit> cu,
-    bool is_module)
+    bool is_module,
+    c10::optional<std::string> original_qual_name = c10::nullopt)
     : NamedType(TypeKind::ClassType, std::move(name)),
       compilation_unit_(std::move(cu)) {
   if (is_module) {
     parameterSlots_ = std::make_shared<std::vector<bool>>();
+    original_qual_name_ = std::move(original_qual_name);
   }
 }
 

--- a/torch/csrc/jit/script/concrete_module_type.cpp
+++ b/torch/csrc/jit/script/concrete_module_type.cpp
@@ -14,10 +14,15 @@ ClassTypePtr ConcreteModuleTypeBuilder::createTypeFromThis() const {
   if (className.prefix().empty()) {
     className = c10::QualifiedName("__torch__", className.name());
   }
+  auto orig_class_name = className;
   if (cu->get_class(className) != nullptr) {
     className = cu->mangle(className);
   }
-  auto cls = ClassType::create(std::move(className), cu, /*is_module=*/true);
+  auto cls = ClassType::create(
+      std::move(className),
+      cu,
+      /*is_module=*/true,
+      orig_class_name.qualifiedName());
   cu->register_type(cls);
 
   // populate type with info from the concrete type information

--- a/torch/csrc/jit/script/concrete_module_type.h
+++ b/torch/csrc/jit/script/concrete_module_type.h
@@ -197,6 +197,10 @@ class VISIBILITY_HIDDEN ConcreteModuleType {
       const std::string& name) const;
   c10::optional<std::string> findFailedAttribute(const std::string& name) const;
 
+  c10::optional<std::string> getOriginalQualName() const {
+    return jitType_->expect<ClassType>()->getOriginalQualName();
+  };
+
   // These getters are only here to return things as types that can be
   // automatically converted by pybind.
   std::unordered_map<std::string, py::object> getConstantsPy() const;

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -1251,6 +1251,7 @@ void initJitScriptBindings(PyObject* module) {
       .def("get_attributes", &ConcreteModuleType::getAttributesPy)
       .def("get_modules", &ConcreteModuleType::getModulesPy)
       .def("dump", &ConcreteModuleType::dump)
+      .def("get_original_qual_name", &ConcreteModuleType::getOriginalQualName)
       .def(
           "equals",
           [](const ConcreteModuleType& self, const ConcreteModuleType& other) {

--- a/torch/jit/_recursive.py
+++ b/torch/jit/_recursive.py
@@ -72,6 +72,7 @@ def infer_concrete_type_builder(nn_module):
     if isinstance(nn_module, (torch.nn.ModuleList, torch.nn.Sequential)):
         concrete_type_builder.set_module_list()
 
+    setattr(nn_module, "_original_qual_name", torch.jit._qualified_name(type(nn_module)))
     class_annotations = getattr(nn_module, '__annotations__', {})
 
     # try to infer the type from type annotation or from the object itself
@@ -297,6 +298,15 @@ def create_script_module(nn_module, stubs_fn, share_types=True):
 
     return create_script_module_impl(nn_module, concrete_type, stubs_fn)
 
+def _add_copy_to_script_methods(nn_module_type, script_module):
+    # copy over python methods to script module if they aren't defined on the script module
+    # this is currently an internal api used only on module containers
+    for name in dir(nn_module_type):
+        item = getattr(nn_module_type, name, None)
+        if _jit_internal.get_torchscript_modifier(item) is _jit_internal.FunctionModifiers.COPY_TO_SCRIPT_WRAPPER:
+            add_python_attr_to_scripted_model(script_module, nn_module_type, name)
+
+
 def create_script_module_impl(nn_module, concrete_type, stubs_fn):
     """
     Convert an nn.Module to a RecursiveScriptModule.
@@ -370,13 +380,7 @@ def create_script_module_impl(nn_module, concrete_type, stubs_fn):
         # nn.Module.forward)
         script_module.__dict__[name] = script_method
 
-
-    # copy over python methods to script module if they aren't defined on the script module
-    # this is currently an internal api used only on module containers
-    for name in dir(nn_module):
-        item = getattr(nn_module, name, None)
-        if _jit_internal.get_torchscript_modifier(item) is _jit_internal.FunctionModifiers.COPY_TO_SCRIPT_WRAPPER:
-            add_python_attr_to_scripted_model(script_module, nn_module, name)
+    _add_copy_to_script_methods(type(nn_module), script_module)
 
     return script_module
 
@@ -384,18 +388,24 @@ def create_script_module_impl(nn_module, concrete_type, stubs_fn):
 # We define shims of certain attributes on the RecursiveScriptModule to support
 # magic methods. To check if a script model defines an attribute we need
 # to also check that the attribute is not the shim
-def script_model_defines_attr(script_model, attr):
+def script_model_doesnt_define_attr(script_model, attr):
     script_attr = getattr(script_model, attr, None)
     if script_attr is None:
-        return False
+        return True
     default_attr = get_function_from_type(torch.jit.RecursiveScriptModule, attr)
     if default_attr is None:
         return False
     return script_attr != default_attr
 
-def add_python_attr_to_scripted_model(script_model, orig, attr):
-    if hasattr(orig, attr) and script_model_defines_attr(script_model, attr):
-        setattr(script_model, attr, getattr(orig, attr))
+def add_python_attr_to_scripted_model(script_model, nn_module_type, attr):
+    if hasattr(nn_module_type, attr) and script_model_doesnt_define_attr(script_model, attr):
+        unbound_method = getattr(nn_module_type, attr)
+        # function should be unbound
+        assert not hasattr(unbound_method, "__self__")
+
+        def add_self_arg(*args, **kwargs):
+            return unbound_method(script_model, *args, **kwargs)
+        setattr(script_model, attr, add_self_arg)
 
 def get_overload_annotations(mod):
     # original function => [(mangled overload name, overload function)]
@@ -551,7 +561,7 @@ def try_compile_fn(fn, loc):
     rcb = _jit_internal.createResolutionCallbackFromClosure(fn)
     return torch.jit.script(fn, _rcb=rcb)
 
-def wrap_cpp_module(cpp_module):
+def wrap_cpp_module(cpp_module_inner):
     """
     Wrap this torch._C.ScriptModule in a Python ScriptModule, recursively for all submodules
     """
@@ -559,7 +569,12 @@ def wrap_cpp_module(cpp_module):
         for name, cpp_module in torch._C.ModuleDict(script_module._c).items():
             setattr(script_module, name, wrap_cpp_module(cpp_module))
         script_module._concrete_type = torch._C.ConcreteModuleType.from_jit_type(script_module._c._type())
-    return torch.jit.RecursiveScriptModule._construct(cpp_module, init_fn)
+        if cpp_module_inner.hasattr("_original_qual_name"):
+            nn_module = torch._jit_internal._try_get_module_class_from_qual_name(cpp_module_inner._original_qual_name)
+            if nn_module:
+                _add_copy_to_script_methods(nn_module, script_module)
+
+    return torch.jit.RecursiveScriptModule._construct(cpp_module_inner, init_fn)
 
 def compile_unbound_method(concrete_type, fn):
     if _jit_internal.is_ignored_fn(fn):

--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -130,6 +130,7 @@ class ModuleList(Module):
         if modules is not None:
             self += modules
 
+    @_copy_to_script_wrapper
     def _get_abs_string_index(self, idx):
         """Get the absolute index for the list of modules"""
         idx = operator.index(idx)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#32796 [JIT] hook back on container magic methods on save and load**

In order to continue to support exposing magic methods of modules which inherit from nn containers we copy over the python magic methods to their scripted versions. This PR extends that behavior to saved & loaded modules by saving the fully qualified name of a module when it is scripted. When we load a scripted module, we look up the python methods to copy on the original module it was saved from.

A follow up PR to this could fix the problem we had of isinstance(MyMod, torch.jit.script(MyMod)) returning false now that we save the qualified name of module on scripting.
