### PR TITLE
Remove GIL from RRefContext

### DIFF
--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -269,7 +269,12 @@ If the future completes with an error, an exception is thrown.
   });
 
   module.def("_destroy_rref_context", [](bool ignoreRRefLeak) {
-    RRefContext::getInstance().destroyInstance(ignoreRRefLeak);
+    auto deletedRRefs =
+        RRefContext::getInstance().destroyInstance(ignoreRRefLeak);
+    if (!deletedRRefs.empty()) {
+      pybind11::gil_scoped_acquire ag;
+      deletedRRefs.clear();
+    }
   });
 
   module.def("_rref_context_get_debug_info", []() {

--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -269,12 +269,11 @@ If the future completes with an error, an exception is thrown.
   });
 
   module.def("_destroy_rref_context", [](bool ignoreRRefLeak) {
-    auto deletedRRefs =
-        RRefContext::getInstance().destroyInstance(ignoreRRefLeak);
-    if (!deletedRRefs.empty()) {
-      pybind11::gil_scoped_acquire ag;
-      deletedRRefs.clear();
-    }
+    // NB: do not release GIL in the function. The destroyInstance() method
+    // returns a list of deleted OwnerRRefs that hold py::object instances.
+    // Clearing those OwnerRRefs are likely to trigger Python deref, which
+    // requires GIL.
+    RRefContext::getInstance().destroyInstance(ignoreRRefLeak).clear();
   });
 
   module.def("_rref_context_get_debug_info", []() {

--- a/torch/csrc/distributed/rpc/py_rref.cpp
+++ b/torch/csrc/distributed/rpc/py_rref.cpp
@@ -110,7 +110,6 @@ PyRRef PyRRef::unpickle(const py::tuple& t) {
   TypePtr rref_type =
       PythonRpcHandler::getInstance().parseTypeFromStr(rfd.type_str_);
   rref = ctx.getOrCreateRRef(rfd, rref_type);
-
   ctx.notifyOwnerAndParentOfFork(rfd.forkId_, rfd.parent_, rref);
   return PyRRef(std::move(rref));
 }

--- a/torch/csrc/distributed/rpc/python_functions.cpp
+++ b/torch/csrc/distributed/rpc/python_functions.cpp
@@ -68,7 +68,11 @@ void finishCreatingOwnerRRef(
       rr->rrefId() == rr->forkId(),
       "Expecting an OwnerRRef as RemoteRet but got a fork.");
   auto& ctx = RRefContext::getInstance();
-  ctx.delForkOfOwner(rr->rrefId(), rr->rrefId());
+  auto deletedRRef = ctx.delForkOfOwner(rr->rrefId(), rr->rrefId());
+  if (deletedRRef && deletedRRef->isPyObj()) {
+    pybind11::gil_scoped_acquire ag;
+    deletedRRef.reset();
+  }
 }
 
 std::shared_ptr<FutureMessage> sendPythonRemoteCall(

--- a/torch/csrc/distributed/rpc/request_callback_impl.cpp
+++ b/torch/csrc/distributed/rpc/request_callback_impl.cpp
@@ -212,7 +212,11 @@ std::shared_ptr<FutureMessage> RequestCallbackImpl::processRpc(
     case MessageType::RREF_USER_DELETE: {
       auto& rud = static_cast<RRefUserDelete&>(rpc);
       auto& ctx = RRefContext::getInstance();
-      ctx.delForkOfOwner(rud.rrefId(), rud.forkId());
+      auto deletedRRef = ctx.delForkOfOwner(rud.rrefId(), rud.forkId());
+      if (deletedRRef && deletedRRef->isPyObj()) {
+        pybind11::gil_scoped_acquire ag;
+        deletedRRef.reset();
+      }
       return wrap(std::move(RRefAck()).toMessage());
     }
     case MessageType::RREF_CHILD_ACCEPT: {

--- a/torch/csrc/distributed/rpc/rref_context.cpp
+++ b/torch/csrc/distributed/rpc/rref_context.cpp
@@ -37,7 +37,7 @@ std::vector<std::shared_ptr<RRef>> RRefContext::destroyInstance(
   }
   ctx.checkRRefLeaks(ignoreRRefLeak);
   std::vector<std::shared_ptr<RRef>> deletedRRefs;
-  for (auto& entry: ctx.owners_) {
+  for (auto& entry : ctx.owners_) {
     auto rref = entry.second;
     if (rref->isPyObj()) {
       deletedRRefs.emplace_back(std::move(rref));
@@ -61,10 +61,9 @@ RRefContext::RRefContext(std::shared_ptr<RpcAgent> agent)
 
 RRefContext::~RRefContext() {
   if (!owners_.empty()) {
-    VLOG(1)
-        << "Destructing RRefContext with non-empty OwnerRRef set. "
-        << "This would likely cause Python deref error. "
-        << "Make sure destroyInstance() is invoked before destruction.";
+    VLOG(1) << "Destructing RRefContext with non-empty OwnerRRef set. "
+            << "This would likely cause Python deref error. "
+            << "Make sure destroyInstance() is invoked before destruction.";
   }
 }
 
@@ -266,8 +265,10 @@ void RRefContext::notifyOwnerAndParentOfFork(
       if (deletedRRef) {
         TORCH_INTERNAL_ASSERT(
             deletedRRef->rrefId() == rref->rrefId(),
-            "Deleting a fork of ", rref->rrefId(), " triggered deleting the "
-            "OwnerRRef of ", deletedRRef->rrefId());
+            "Deleting a fork of ",
+            rref->rrefId(),
+            " triggered deleting the OwnerRRef of ",
+            deletedRRef->rrefId());
         // NB: not necessary to reset deletedRRef as rref is another shared_ptr
         // instance pointing to the same OwnerRRef.
       }
@@ -384,7 +385,8 @@ void RRefContext::addForkOfOwner(const RRefId& rrefId, const ForkId& forkId) {
 }
 
 std::shared_ptr<RRef> RRefContext::delForkOfOwner(
-    const RRefId& rrefId, const ForkId& forkId) {
+    const RRefId& rrefId,
+    const ForkId& forkId) {
   std::shared_ptr<RRef> deletedRRef = nullptr;
   {
     std::lock_guard<std::mutex> lock(mutex_);

--- a/torch/csrc/distributed/rpc/rref_context.h
+++ b/torch/csrc/distributed/rpc/rref_context.h
@@ -23,7 +23,13 @@ void confirmPendingUser(
 class RRefContext {
  public:
   static RRefContext& getInstance();
-  static void destroyInstance(bool ignoreRRefLeak = true);
+  // NB: This method must be called before destructing RRefContext singleton.
+  // Similar to delForkOfOwner, this method returns a vector of OwnerRRefs that
+  // hold py::object. The call-site is also responsible for resetting those
+  // shared_ptr objects with a GIL. See comments at delForkOfOwner() for more
+  // details.
+  static std::vector<std::shared_ptr<RRef>> destroyInstance(
+      bool ignoreRRefLeak = true);
 
   static void handleException(const c10::optional<utils::FutureError>& futErr);
 
@@ -93,7 +99,15 @@ class RRefContext {
   void addForkOfOwner(const RRefId& rrefId, const ForkId& forkId);
   // Delete a fork of the ``OwnerRRef``. NB: this could trigger deletion on the
   // IValue or py::object. For the later, this method will acquire GIL.
-  void delForkOfOwner(const RRefId& rrefId, const ForkId& forkId);
+  // NB: If this fork deletion triggered deleting OwnerRRef, this method will
+  // return a shared_ptr to the OwnerRRef, which is likely to be the last
+  // shared_ptr instance for it. Therefore, deleting this shared_ptr<OwnerRRef>
+  // will also trigger deleting the object it points to. If OwnerRRef holds a
+  // py::object, deleting it require GIL. The call site should guarded it with
+  // a GIL and reset the shared_ptr. The GIL-guarded deletion is intentionally
+  // left out of this function to avoid creating dependency on pybind.
+  std::shared_ptr<RRef> delForkOfOwner(
+      const RRefId& rrefId, const ForkId& forkId);
 
   // Invoked when pickling an RRef to setup child/fork properly
   RRefForkData prepareChildFork(const std::shared_ptr<RRef>& rref);

--- a/torch/csrc/distributed/rpc/rref_context.h
+++ b/torch/csrc/distributed/rpc/rref_context.h
@@ -107,7 +107,8 @@ class RRefContext {
   // a GIL and reset the shared_ptr. The GIL-guarded deletion is intentionally
   // left out of this function to avoid creating dependency on pybind.
   std::shared_ptr<RRef> delForkOfOwner(
-      const RRefId& rrefId, const ForkId& forkId);
+      const RRefId& rrefId,
+      const ForkId& forkId);
 
   // Invoked when pickling an RRef to setup child/fork properly
   RRefForkData prepareChildFork(const std::shared_ptr<RRef>& rref);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#32807 Remove GIL from RRefContext**

After this commit, RRefContext no longer depends on pybind.

Differential Revision: [D19636316](https://our.internmc.facebook.com/intern/diff/D19636316)