### PR TITLE
Add type annotation for bias in _ConvNd

### DIFF
--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -7,7 +7,7 @@ from .. import functional as F
 from .. import init
 from .module import Module
 from .utils import _single, _pair, _triple, _repeat_tuple
-from ..._jit_internal import List
+from ..._jit_internal import List, Optional
 
 
 class _ConvNd(Module):
@@ -15,6 +15,9 @@ class _ConvNd(Module):
     __constants__ = ['stride', 'padding', 'dilation', 'groups',
                      'padding_mode', 'output_padding', 'in_channels',
                      'out_channels', 'kernel_size']
+    __annotations__ = {
+        'bias': Optional[torch.Tensor]
+    }
 
     def __init__(self, in_channels, out_channels, kernel_size, stride,
                  padding, dilation, transposed, output_padding,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #32816 [quant][graphmode] Add add_relu pattern in skip values
* #32815 [quant][graphmode] Add asserts for Conv and ReLU modules
* #32814 [quant][graphmode] Skip quantizing input in matched module
* #32813 [quant][graphmode][refactor] Separate preprocess step for insertObserver
* #32812 [quant][graphmode][refactor] Change signature of getModuleAccessPath
* #32811 [quant][graphmode][refactor] test_jit.py - test_insert_observers_skip_values
* #32810 [quant][graphmode][refactor] Change order of calling insertObservers for invoked methods
* #32809 [quant][graphmode][refactor] Move the check for qconfig inside insertObserver call
* #32379 [quant][graphmode] FoldConvBatchNorm2d support shared ClassTypes
* **#32808 Add type annotation for bias in _ConvNd**

Summary:
att

Test Plan:
.

Reviewers:
suo

Subscribers:

Tasks:

Tags: