### PR TITLE
Emit the C++ version when compiling pytorch from source.

### DIFF
--- a/aten/src/ATen/Version.cpp
+++ b/aten/src/ATen/Version.cpp
@@ -101,6 +101,12 @@ std::string show_config() {
   }
 #endif
 
+#if defined(__cplusplus)
+  {
+    ss << "  - C++ Version: " << __cplusplus << "\n";
+  }
+#endif
+
 #if defined(__clang_major__)
   {
     ss << "  - clang " << __clang_major__ << "." << __clang_minor__ << "." << __clang_patchlevel__ << "\n";


### PR DESCRIPTION
The need for this is felt because sometimes we change a build script and change the `std=c++XX` flag, which does not get caught until the compilation has progressed for a while.

https://github.com/pytorch/pytorch/issues/31757