### PR TITLE
make tests for empty inputs check zero parameter grads

### DIFF
--- a/aten/src/ATen/native/Normalization.cpp
+++ b/aten/src/ATen/native/Normalization.cpp
@@ -532,7 +532,11 @@ Tensor batch_norm(
     const Tensor& running_mean /* optional */, const Tensor& running_var /* optional */,
     bool training, double momentum, double eps, bool cudnn_enabled) {
   if (input.numel()==0){
-    return input; //return input instead of new empty tensor, because new empty tensor breaks the gradient chain
+    //don't return view of input, don't return empty tensor because it will break gradient chain
+    auto out = input.clone();
+    if (weight.defined()) out = out*weight[0];
+    if (bias.defined()) out = out + bias[0];
+    return out; 
   }
   return std::get<0>(at::_batch_norm_impl_index(input, weight, bias, running_mean, running_var,
                                                 training, momentum, eps, cudnn_enabled));

--- a/aten/src/ATen/native/Normalization.cpp
+++ b/aten/src/ATen/native/Normalization.cpp
@@ -534,7 +534,7 @@ Tensor batch_norm(
   if (input.numel()==0){
     //don't return view of input, don't return empty tensor because it will break gradient chain
     auto out = input.clone();
-    if (weight.defined()) out = out*weight[0];
+    if (weight.defined()) out = out * weight[0];
     if (bias.defined()) out = out + bias[0];
     return out; 
   }

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -8983,17 +8983,16 @@ class TestNNDeviceType(NNTestCase):
         output.sum().backward()
         self.assertEqual(output.type(), input.type())
 
-    def _test_module_empty_input(self, module, inp, check_size=True, check_parameter_grads=True):
+    def _test_module_empty_input(self, module, inp, check_size=True):
         inp.requires_grad_(True)
         out = module(inp)
         gO = torch.rand_like(out)
         out.backward(gO)
         if check_size:
             self.assertEqual(out.size(), inp.size())
-        if check_parameter_grads:
-            for p in module.parameters():
-                if p.requires_grad:
-                    self.assertEqual(p.grad, torch.zeros_like(p.grad))
+        for p in module.parameters():
+            if p.requires_grad:
+                self.assertEqual(p.grad, torch.zeros_like(p.grad))
         self.assertEqual(inp.grad, torch.zeros_like(inp))
 
     def test_Dropout(self, device):


### PR DESCRIPTION
Make batch norm with empty inputs return zero parameter gradients. Now batch norm, group norm and convolutions now return zero grads for parameters, so make tests check that. Fixes some bullet points in #12013 (interpolate is not fixed by this PR, is being fixed in other PRs) 