### PR TITLE
Dirac init compatibility with group convolutions

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -8211,7 +8211,7 @@ class TestNNInit(TestCase):
                 self.assertEqual(input_tensor[:, :, 1:-1], 
                                  output_tensor[:, eff_out_c*g:eff_out_c*g+in_c, :])  
                 # Assert extra outputs are 0
-                assert torch.nonzero(output_tensor[:, eff_out_c*g+in_c:eff_out_c*(g+1), :]).numel() == 0  
+                assert torch.nonzero(output_tensor[:, eff_out_c * g + in_c:eff_out_c * (g + 1), :]).numel() == 0  
 
             # Test 2D
             input_var = torch.randn(batch, in_c, size, size)
@@ -8223,9 +8223,9 @@ class TestNNInit(TestCase):
             for g in range(groups):
                 # Assert in_c outputs are preserved (per each group)
                 self.assertEqual(input_tensor[:, :, 1:-1, 1:-1], 
-                                 output_tensor[:, eff_out_c*g:eff_out_c*g+in_c, :, :])  
+                                 output_tensor[:, eff_out_c * g:eff_out_c * g + in_c, :, :])  
                 # Assert extra outputs are 0
-                assert torch.nonzero(output_tensor[:, eff_out_c*g+in_c:eff_out_c*(g+1), :, :]).numel() == 0  
+                assert torch.nonzero(output_tensor[:, eff_out_c * g + in_c:eff_out_c * (g + 1), :, :]).numel() == 0  
 
             # Test 3D
             input_var = torch.randn(batch, in_c, size, size, size)
@@ -8237,9 +8237,9 @@ class TestNNInit(TestCase):
             for g in range(groups):
                 # Assert in_c outputs are preserved (per each group)
                 self.assertEqual(input_tensor[:, :, 1:-1, 1:-1, 1:-1], 
-                                 output_tensor[:, eff_out_c*g:eff_out_c*g+in_c, :, :, :])  
+                                 output_tensor[:, eff_out_c * g:eff_out_c * g + in_c, :, :, :])  
                 # Assert extra outputs are 0
-                assert torch.nonzero(output_tensor[:, eff_out_c*g+in_c:eff_out_c*(g+1), :, :, :]).numel() == 0  
+                assert torch.nonzero(output_tensor[:, eff_out_c * g + in_c:eff_out_c * (g + 1), :, :, :]).numel() == 0  
 
     def test_dirac_only_works_on_3_4_5d_inputs(self):
         for dims in [1, 2, 6]:

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -8215,10 +8215,11 @@ class TestNNInit(TestCase):
 
             # Test 2D
             input_var = torch.randn(batch, in_c, size, size)
-            filter_var = torch.zeros(out_c, in_c, kernel_size, kernel_size)
+            filter_var = torch.zeros(eff_out_c, in_c, kernel_size, kernel_size)
             filter_var = torch.cat([filter_var] * groups)
             init.dirac_(filter_var, groups)
             output_var = F.conv2d(input_var, filter_var)
+            input_tensor, output_tensor = input_var.data, output_var.data  # Variables do not support nonzero
             for g in range(groups):
                 # Assert in_c outputs are preserved (per each group)
                 self.assertEqual(input_tensor[:, :, 1:-1, 1:-1], 
@@ -8228,7 +8229,7 @@ class TestNNInit(TestCase):
 
             # Test 3D
             input_var = torch.randn(batch, in_c, size, size, size)
-            filter_var = torch.zeros(out_c, in_c, kernel_size, kernel_size, kernel_size)
+            filter_var = torch.zeros(eff_out_c, in_c, kernel_size, kernel_size, kernel_size)
             filter_var = torch.cat([filter_var] * groups)
             init.dirac_(filter_var, groups)
             output_var = F.conv3d(input_var, filter_var)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -8179,11 +8179,11 @@ class TestNNInit(TestCase):
         for dims in [3, 4, 5]:
             for groups in [1, 2, 3]:
                 # prepare random tensor with random sizes, but fits groups
-                a, c, d, e = (random.randint(1,5) for _ in range(4))
-                b = random.randint(1,5 * groups)  # same range as a*groups but all range allowed
+                a, c, d, e = (random.randint(1, 5) for _ in range(4))
+                b = random.randint(1, 5 * groups)  # same range as a*groups but all range allowed
                 # make sure first dim divides by groups
                 input_tensor = torch.randn((a * groups, b, c, d, e)[:dims])
-                
+
                 init.dirac_(input_tensor, groups)
 
                 c_out, c_in = input_tensor.size(0) // groups, input_tensor.size(1)
@@ -8195,7 +8195,7 @@ class TestNNInit(TestCase):
 
 
     def test_dirac_identity(self):
-        for groups in [1,3]:
+        for groups in [1, 3]:
             batch, in_c, out_c, size, kernel_size = 8, 3, 9, 5, 3  # in_c, out_c must divide by groups
             eff_out_c = out_c // groups
 
@@ -8209,7 +8209,7 @@ class TestNNInit(TestCase):
             for g in range(groups):
                 # Assert in_c outputs are preserved (per each group)
                 self.assertEqual(input_tensor[:, :, 1:-1], 
-                                 output_tensor[:, eff_out_c*g:eff_out_c*g+in_c, :])  
+                                 output_tensor[:, eff_out_c * g:eff_out_c * g + in_c, :])  
                 # Assert extra outputs are 0
                 assert torch.nonzero(output_tensor[:, eff_out_c * g + in_c:eff_out_c * (g + 1), :]).numel() == 0  
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -8177,44 +8177,68 @@ class TestNNInit(TestCase):
 
     def test_dirac_properties(self):
         for dims in [3, 4, 5]:
-            input_tensor = self._create_random_nd_tensor(dims, size_min=1, size_max=5)
-            init.dirac_(input_tensor)
+            for groups in [1, 2, 3]:
+                # prepare random tensor with random sizes, but fits groups
+                a, c, d, e = (random.randint(1,5) for _ in range(4))
+                b = random.randint(1,5 * groups)  # same range as a*groups but all range allowed
+                # make sure first dim divides by groups
+                input_tensor = torch.randn((a * groups, b, c, d, e)[:dims])
+                
+                init.dirac_(input_tensor, groups)
 
-            c_out, c_in = input_tensor.size(0), input_tensor.size(1)
-            min_d = min(c_out, c_in)
-            # Check number of nonzeros is equivalent to smallest dim
-            assert torch.nonzero(input_tensor).size(0) == min_d
-            # Check sum of values (can have precision issues, hence assertEqual) is also equivalent
-            self.assertEqual(input_tensor.sum(), min_d)
+                c_out, c_in = input_tensor.size(0) // groups, input_tensor.size(1)
+                min_d = min(c_out, c_in)
+                # Check number of nonzeros is equivalent to smallest dim (for each group)
+                assert torch.nonzero(input_tensor).size(0) == min_d * groups
+                # Check sum of values (can have precision issues, hence assertEqual) is also equivalent
+                self.assertEqual(input_tensor.sum(), min_d * groups)
+
 
     def test_dirac_identity(self):
-        batch, in_c, out_c, size, kernel_size = 8, 3, 4, 5, 3
-        # Test 1D
-        input_var = torch.randn(batch, in_c, size)
-        filter_var = torch.zeros(out_c, in_c, kernel_size)
-        init.dirac_(filter_var)
-        output_var = F.conv1d(input_var, filter_var)
-        input_tensor, output_tensor = input_var.data, output_var.data  # Variables do not support nonzero
-        self.assertEqual(input_tensor[:, :, 1:-1], output_tensor[:, :in_c, :])  # Assert in_c outputs are preserved
-        assert torch.nonzero(output_tensor[:, in_c:, :]).numel() == 0  # Assert extra outputs are 0
+        for groups in [1,3]:
+            batch, in_c, out_c, size, kernel_size = 8, 3, 9, 5, 3  # in_c, out_c must divide by groups
+            eff_out_c = out_c // groups
 
-        # Test 2D
-        input_var = torch.randn(batch, in_c, size, size)
-        filter_var = torch.zeros(out_c, in_c, kernel_size, kernel_size)
-        init.dirac_(filter_var)
-        output_var = F.conv2d(input_var, filter_var)
-        input_tensor, output_tensor = input_var.data, output_var.data
-        self.assertEqual(input_tensor[:, :, 1:-1, 1:-1], output_tensor[:, :in_c, :, :])
-        assert torch.nonzero(output_tensor[:, in_c:, :, :]).numel() == 0
+            # Test 1D
+            input_var = torch.randn(batch, in_c, size)
+            filter_var = torch.zeros(eff_out_c, in_c, kernel_size)
+            filter_var = torch.cat([filter_var] * groups)
+            init.dirac_(filter_var, groups)
+            output_var = F.conv1d(input_var, filter_var)
+            input_tensor, output_tensor = input_var.data, output_var.data  # Variables do not support nonzero
+            for g in range(groups):
+                # Assert in_c outputs are preserved (per each group)
+                self.assertEqual(input_tensor[:, :, 1:-1], 
+                                 output_tensor[:, eff_out_c*g:eff_out_c*g+in_c, :])  
+                # Assert extra outputs are 0
+                assert torch.nonzero(output_tensor[:, eff_out_c*g+in_c:eff_out_c*(g+1), :]).numel() == 0  
 
-        # Test 3D
-        input_var = torch.randn(batch, in_c, size, size, size)
-        filter_var = torch.zeros(out_c, in_c, kernel_size, kernel_size, kernel_size)
-        init.dirac_(filter_var)
-        output_var = F.conv3d(input_var, filter_var)
-        input_tensor, output_tensor = input_var.data, output_var.data
-        self.assertEqual(input_tensor[:, :, 1:-1, 1:-1, 1:-1], output_tensor[:, :in_c, :, :])
-        assert torch.nonzero(output_tensor[:, in_c:, :, :, :]).numel() == 0
+            # Test 2D
+            input_var = torch.randn(batch, in_c, size, size)
+            filter_var = torch.zeros(out_c, in_c, kernel_size, kernel_size)
+            filter_var = torch.cat([filter_var] * groups)
+            init.dirac_(filter_var, groups)
+            output_var = F.conv2d(input_var, filter_var)
+            for g in range(groups):
+                # Assert in_c outputs are preserved (per each group)
+                self.assertEqual(input_tensor[:, :, 1:-1, 1:-1], 
+                                 output_tensor[:, eff_out_c*g:eff_out_c*g+in_c, :, :])  
+                # Assert extra outputs are 0
+                assert torch.nonzero(output_tensor[:, eff_out_c*g+in_c:eff_out_c*(g+1), :, :]).numel() == 0  
+
+            # Test 3D
+            input_var = torch.randn(batch, in_c, size, size, size)
+            filter_var = torch.zeros(out_c, in_c, kernel_size, kernel_size, kernel_size)
+            filter_var = torch.cat([filter_var] * groups)
+            init.dirac_(filter_var, groups)
+            output_var = F.conv3d(input_var, filter_var)
+            input_tensor, output_tensor = input_var.data, output_var.data
+            for g in range(groups):
+                # Assert in_c outputs are preserved (per each group)
+                self.assertEqual(input_tensor[:, :, 1:-1, 1:-1, 1:-1], 
+                                 output_tensor[:, eff_out_c*g:eff_out_c*g+in_c, :, :, :])  
+                # Assert extra outputs are 0
+                assert torch.nonzero(output_tensor[:, eff_out_c*g+in_c:eff_out_c*(g+1), :, :, :]).numel() == 0  
 
     def test_dirac_only_works_on_3_4_5d_inputs(self):
         for dims in [1, 2, 6]:

--- a/torch/nn/init.py
+++ b/torch/nn/init.py
@@ -168,34 +168,46 @@ def eye_(tensor):
     return tensor
 
 
-def dirac_(tensor):
+def dirac_(tensor, groups=1):
     r"""Fills the {3, 4, 5}-dimensional input `Tensor` with the Dirac
     delta function. Preserves the identity of the inputs in `Convolutional`
-    layers, where as many input channels are preserved as possible.
+    layers, where as many input channels are preserved as possible. In case
+    of groups>1, each group of channels preserves identity
 
     Args:
         tensor: a {3, 4, 5}-dimensional `torch.Tensor`
-
+        groups: number of groups in the conv layer
     Examples:
         >>> w = torch.empty(3, 16, 5, 5)
         >>> nn.init.dirac_(w)
+        >>> w = torch.empty(3, 24, 5, 5)
+        >>> nn.init.dirac_(w, 3)
     """
     dimensions = tensor.ndimension()
     if dimensions not in [3, 4, 5]:
         raise ValueError("Only tensors with 3, 4, or 5 dimensions are supported")
 
     sizes = tensor.size()
+
+    if sizes[0] % groups != 0:
+        raise ValueError('out_channels must be divisible by groups')
+
+    if sizes[1] % groups != 0:
+        raise ValueError('in_channels must be divisible by groups')
+
     min_dim = min(sizes[0], sizes[1])
+
     with torch.no_grad():
         tensor.zero_()
 
-        for d in range(min_dim):
-            if dimensions == 3:  # Temporal convolution
-                tensor[d, d, tensor.size(2) // 2] = 1
-            elif dimensions == 4:  # Spatial convolution
-                tensor[d, d, tensor.size(2) // 2, tensor.size(3) // 2] = 1
-            else:  # Volumetric convolution
-                tensor[d, d, tensor.size(2) // 2, tensor.size(3) // 2, tensor.size(4) // 2] = 1
+        for g in range(groups):
+            for d in range(min_dim // groups):
+                if dimensions == 3:  # Temporal convolution
+                    tensor[g + d, d, tensor.size(2) // 2] = 1
+                elif dimensions == 4:  # Spatial convolution
+                    tensor[g + d, d, tensor.size(2) // 2, tensor.size(3) // 2] = 1
+                else:  # Volumetric convolution
+                    tensor[g + d, d, tensor.size(2) // 2, tensor.size(3) // 2, tensor.size(4) // 2] = 1
     return tensor
 
 

--- a/torch/nn/init.py
+++ b/torch/nn/init.py
@@ -176,7 +176,7 @@ def dirac_(tensor, groups=1):
 
     Args:
         tensor: a {3, 4, 5}-dimensional `torch.Tensor`
-        groups: number of groups in the conv layer
+        groups (optional): number of groups in the conv layer (default: 1)
     Examples:
         >>> w = torch.empty(3, 16, 5, 5)
         >>> nn.init.dirac_(w)

--- a/torch/nn/init.py
+++ b/torch/nn/init.py
@@ -190,24 +190,24 @@ def dirac_(tensor, groups=1):
     sizes = tensor.size()
 
     if sizes[0] % groups != 0:
-        raise ValueError('out_channels must be divisible by groups')
+        raise ValueError('dim 0 must be divisible by groups')
 
-    if sizes[1] % groups != 0:
-        raise ValueError('in_channels must be divisible by groups')
-
-    min_dim = min(sizes[0], sizes[1])
+    out_chans_per_grp = sizes[0] // groups
+    min_dim = min(out_chans_per_grp, sizes[1])
 
     with torch.no_grad():
         tensor.zero_()
 
         for g in range(groups):
-            for d in range(min_dim // groups):
+            for d in range(min_dim):
                 if dimensions == 3:  # Temporal convolution
-                    tensor[g + d, d, tensor.size(2) // 2] = 1
+                    tensor[g * out_chans_per_grp + d, d, tensor.size(2) // 2] = 1
                 elif dimensions == 4:  # Spatial convolution
-                    tensor[g + d, d, tensor.size(2) // 2, tensor.size(3) // 2] = 1
+                    tensor[g * out_chans_per_grp + d, d, tensor.size(2) // 2,
+                           tensor.size(3) // 2] = 1
                 else:  # Volumetric convolution
-                    tensor[g + d, d, tensor.size(2) // 2, tensor.size(3) // 2, tensor.size(4) // 2] = 1
+                    tensor[g * out_chans_per_grp + d, d, tensor.size(2) // 2,
+                           tensor.size(3) // 2, tensor.size(4) // 2] = 1
     return tensor
 
 


### PR DESCRIPTION
Initializing weights of group-conv with init.dirac_, and applying, previously resulted in an output that makes no sense:
```
x = torch.randn([1, 3, 3, 3])
print('input:\n', x)
conv_layer = torch.nn.Conv2d(3, 3, 3, padding=1, groups=3, bias=False)
torch.nn.init.dirac_(conv_layer.weight.data)
print('\noutput (before this PR):\n',conv_layer(x))


input:
 tensor([[[[ 0.5369, -1.1428,  0.1031],
          [ 0.4638, -0.0854, -0.6553],
          [ 0.8321, -2.5926, -0.3214]],

         [[-0.2289, -0.0895,  0.4407],
          [ 1.2309, -1.2096, -1.5216],
          [-0.1798,  1.1694,  0.3469]],

         [[ 0.1905,  0.8095,  0.5490],
          [-0.4525, -0.4284, -0.1141],
          [ 1.1857, -0.9246, -0.5119]]]])

output (before this PR):
 tensor([[[[ 0.5369, -1.1428,  0.1031],
          [ 0.4638, -0.0854, -0.6553],
          [ 0.8321, -2.5926, -0.3214]],

         [[ 0.0000,  0.0000,  0.0000],
          [ 0.0000,  0.0000,  0.0000],
          [ 0.0000,  0.0000,  0.0000]],

         [[ 0.0000,  0.0000,  0.0000],
          [ 0.0000,  0.0000,  0.0000],
          [ 0.0000,  0.0000,  0.0000]]]], grad_fn=<MkldnnConvolutionBackward>)
````

This PR allows introducing groups to the initialization:
```
torch.nn.init.dirac_(conv_layer.weight.data, groups=3)
print('output (after this PR):\n', conv_layer(x))

output (after this PR):
 tensor([[[[ 0.5369, -1.1428,  0.1031],
          [ 0.4638, -0.0854, -0.6553],
          [ 0.8321, -2.5926, -0.3214]],

         [[-0.2289, -0.0895,  0.4407],
          [ 1.2309, -1.2096, -1.5216],
          [-0.1798,  1.1694,  0.3469]],

         [[ 0.1905,  0.8095,  0.5490],
          [-0.4525, -0.4284, -0.1141],
          [ 1.1857, -0.9246, -0.5119]]]], grad_fn=<MkldnnConvolutionBackward>)
``` 

When out_channels is different than input_channels, it does the natural thing which is applying identity in each group separately:

```
x = torch.randn([1, 2, 3, 3])
print('input:\n', x)
conv_layer = torch.nn.Conv2d(2, 4, 3, padding=1, groups=2, bias=False)
torch.nn.init.dirac_(conv_layer.weight.data, groups=2)
print('\noutput:\n', conv_layer(x))


input:
 tensor([[[[ 1.2205, -0.6608,  0.8640],
          [-0.5464,  1.1288,  1.4726],
          [-0.6693,  0.4000, -1.7613]],

         [[-0.8760, -0.8814, -0.4705],
          [ 0.6283, -0.5943,  0.6873],
          [-0.6852,  1.4723,  0.3325]]]])

output:
 tensor([[[[ 1.2205, -0.6608,  0.8640],
          [-0.5464,  1.1288,  1.4726],
          [-0.6693,  0.4000, -1.7613]],

         [[ 0.0000,  0.0000,  0.0000],
          [ 0.0000,  0.0000,  0.0000],
          [ 0.0000,  0.0000,  0.0000]],

         [[-0.8760, -0.8814, -0.4705],
          [ 0.6283, -0.5943,  0.6873],
          [-0.6852,  1.4723,  0.3325]],

         [[ 0.0000,  0.0000,  0.0000],
          [ 0.0000,  0.0000,  0.0000],
          [ 0.0000,  0.0000,  0.0000]]]], grad_fn=<MkldnnConvolutionBackward>)
```

Argument 'groups' defaults to 1 so it is backward compatible.  

Tests are modified to include cases of with groups>1 but also contain groups=1 cases.