### PR TITLE
Fix grid_sample gradients at image borders

### DIFF
--- a/aten/src/ATen/native/GridSampler.h
+++ b/aten/src/ATen/native/GridSampler.h
@@ -67,6 +67,8 @@ static inline scalar_t clip_coordinates(scalar_t in, int64_t clip_limit) {
 template<typename scalar_t>
 static inline scalar_t clip_coordinates_set_grad(scalar_t in, int64_t clip_limit,
                                                  scalar_t *grad_in) {
+  // Note that it is important for the gradient calculation that borders
+  // are considered out of bounds.
   if (in <= static_cast<scalar_t>(0)) {
     *grad_in = static_cast<scalar_t>(0);
     return static_cast<scalar_t>(0);
@@ -154,9 +156,9 @@ static inline scalar_t grid_sampler_compute_source_index(
       coord = reflect_coordinates(coord, 0, 2*(size - 1));
     } else {
       coord = reflect_coordinates(coord, -1, 2*size - 1);
-      // when align_corners=False, reflection does not auto clip coords
-      coord = clip_coordinates(coord, size);
     }
+    // clip coordinates to image borders
+    coord = clip_coordinates(coord, size);
   }
   return coord;
 }
@@ -182,16 +184,12 @@ static inline scalar_t grid_sampler_compute_source_index_set_grad(
     // reflect coordinates by image borders
     if (align_corners) {
       coord = reflect_coordinates_set_grad(coord, 0, 2*(size - 1), &grad_refl);
-      *grad_in = (*grad_in) * grad_refl;
-      if (coord == size - 1 || coord == 0) {
-        *grad_in = static_cast<scalar_t>(0);
-      }
     } else {
       coord = reflect_coordinates_set_grad(coord, -1, 2*size - 1, &grad_refl);
-      // when align_corners=False, reflection does not auto clip coords
-      coord = clip_coordinates_set_grad(coord, size, &grad_clip);
-      *grad_in = (*grad_in) * grad_refl * grad_clip;
     }
+    // clip coordinates to image borders
+    coord = clip_coordinates_set_grad(coord, size, &grad_clip);
+    *grad_in = (*grad_in) * grad_refl * grad_clip;
   }
   return coord;
 }

--- a/aten/src/ATen/native/GridSampler.h
+++ b/aten/src/ATen/native/GridSampler.h
@@ -67,12 +67,12 @@ static inline scalar_t clip_coordinates(scalar_t in, int64_t clip_limit) {
 template<typename scalar_t>
 static inline scalar_t clip_coordinates_set_grad(scalar_t in, int64_t clip_limit,
                                                  scalar_t *grad_in) {
-  if (in < static_cast<scalar_t>(0)) {
+  if (in <= static_cast<scalar_t>(0)) {
     *grad_in = static_cast<scalar_t>(0);
     return static_cast<scalar_t>(0);
   } else {
     scalar_t max = static_cast<scalar_t>(clip_limit - 1);
-    if (in > max) {
+    if (in >= max) {
       *grad_in = static_cast<scalar_t>(0);
       return max;
     } else {
@@ -183,6 +183,9 @@ static inline scalar_t grid_sampler_compute_source_index_set_grad(
     if (align_corners) {
       coord = reflect_coordinates_set_grad(coord, 0, 2*(size - 1), &grad_refl);
       *grad_in = (*grad_in) * grad_refl;
+      if (coord == size - 1 || coord == 0) {
+        *grad_in = static_cast<scalar_t>(0);
+      }
     } else {
       coord = reflect_coordinates_set_grad(coord, -1, 2*size - 1, &grad_refl);
       // when align_corners=False, reflection does not auto clip coords

--- a/aten/src/ATen/native/cpu/GridSamplerKernel.cpp
+++ b/aten/src/ATen/native/cpu/GridSamplerKernel.cpp
@@ -213,6 +213,8 @@ struct ComputeLocationBase<scalar_t, /*align_corners=*/true> {
     // Integral type equality comparison is very very fast because it just looks
     // at the bits. Casting is free too. So we use the following pattern instead
     // of comparison + blendv.
+    // Note that it is important for the gradient calculation that borders
+    // are considered out of bounds.
     auto in_bound_lo = cast<scalar_t>(cast<int_t>(bounded_lo) != cast<int_t>(Vec(0)));
     auto res = minimum(bounded_lo, Vec(max_val));
     auto in_bound_hi = cast<scalar_t>(cast<int_t>(res) != cast<int_t>(Vec(max_val)));
@@ -292,6 +294,8 @@ struct ComputeLocationBase<scalar_t, /*align_corners=*/false> {
     // Integral type equality comparison is very very fast because it just looks
     // at the bits. Casting is free too. So we use the following pattern instead
     // of comparison + blendv.
+    // Note that it is important for the gradient calculation that borders
+    // are considered out of bounds.
     auto in_bound_lo = cast<scalar_t>(cast<int_t>(bounded_lo) != cast<int_t>(Vec(0)));
     auto res = minimum(bounded_lo, Vec(max_val));
     auto in_bound_hi = cast<scalar_t>(cast<int_t>(res) != cast<int_t>(Vec(max_val)));

--- a/aten/src/ATen/native/cpu/GridSamplerKernel.cpp
+++ b/aten/src/ATen/native/cpu/GridSamplerKernel.cpp
@@ -213,9 +213,9 @@ struct ComputeLocationBase<scalar_t, /*align_corners=*/true> {
     // Integral type equality comparison is very very fast because it just looks
     // at the bits. Casting is free too. So we use the following pattern instead
     // of comparison + blendv.
-    auto in_bound_lo = cast<scalar_t>(cast<int_t>(bounded_lo) == cast<int_t>(in));
+    auto in_bound_lo = cast<scalar_t>(cast<int_t>(bounded_lo) != cast<int_t>(Vec(0)));
     auto res = minimum(bounded_lo, Vec(max_val));
-    auto in_bound_hi = cast<scalar_t>(cast<int_t>(res) == cast<int_t>(in));
+    auto in_bound_hi = cast<scalar_t>(cast<int_t>(res) != cast<int_t>(Vec(max_val)));
     return std::make_pair(res, in_bound_lo & in_bound_hi);
   }
 
@@ -292,9 +292,9 @@ struct ComputeLocationBase<scalar_t, /*align_corners=*/false> {
     // Integral type equality comparison is very very fast because it just looks
     // at the bits. Casting is free too. So we use the following pattern instead
     // of comparison + blendv.
-    auto in_bound_lo = cast<scalar_t>(cast<int_t>(bounded_lo) == cast<int_t>(in));
+    auto in_bound_lo = cast<scalar_t>(cast<int_t>(bounded_lo) != cast<int_t>(Vec(0)));
     auto res = minimum(bounded_lo, Vec(max_val));
-    auto in_bound_hi = cast<scalar_t>(cast<int_t>(res) == cast<int_t>(in));
+    auto in_bound_hi = cast<scalar_t>(cast<int_t>(res) != cast<int_t>(Vec(max_val)));
     return std::make_pair(res, in_bound_lo & in_bound_hi);
   }
 
@@ -390,10 +390,7 @@ struct ComputeLocation<scalar_t, GridSamplerPadding::Reflection, align_corners>
 
   inline Vec apply(const Vec &in) const {
     auto res = reflect_coordinates(unnormalize(in));
-    // when align_corners=False, reflection does not auto clip coords
-    if (!align_corners) {
-      res = clip_coordinates(res);
-    }
+    res = clip_coordinates(res);
     return res;
   }
 
@@ -401,10 +398,8 @@ struct ComputeLocation<scalar_t, GridSamplerPadding::Reflection, align_corners>
     Vec res, grad_refl, grad_clip, grad(scaling_factor);
     std::tie(res, grad_refl) = reflect_coordinates_get_grad(unnormalize(in));
     grad = grad_refl * grad;
-    if (!align_corners) {
-      std::tie(res, grad_clip) = clip_coordinates_get_grad(res);
-      grad = grad_clip & grad;
-    }
+    std::tie(res, grad_clip) = clip_coordinates_get_grad(res);
+    grad = grad_clip & grad;
     return std::make_pair(res, grad);
   }
 };

--- a/aten/src/ATen/native/cuda/GridSampler.cuh
+++ b/aten/src/ATen/native/cuda/GridSampler.cuh
@@ -69,12 +69,12 @@ scalar_t clip_coordinates(scalar_t in, int clip_limit) {
 template <typename scalar_t>
 static __forceinline__ __device__
 scalar_t clip_coordinates_set_grad(scalar_t in, int clip_limit, scalar_t *grad_in) {
-  if (in < static_cast<scalar_t>(0)) {
+  if (in <= static_cast<scalar_t>(0)) {
     *grad_in = static_cast<scalar_t>(0);
     return static_cast<scalar_t>(0);
   } else {
     scalar_t max = static_cast<scalar_t>(clip_limit - 1);
-    if (in > max) {
+    if (in >= max) {
       *grad_in = static_cast<scalar_t>(0);
       return max;
     } else {
@@ -188,6 +188,9 @@ scalar_t grid_sampler_compute_source_index_set_grad(
     if (align_corners) {
       coord = reflect_coordinates_set_grad(coord, 0, 2*(size - 1), &grad_refl);
       *grad_in = (*grad_in) * grad_refl;
+      if (coord == size - 1 || coord == 0) {
+        *grad_in = static_cast<scalar_t>(0);
+      }
     } else {
       coord = reflect_coordinates_set_grad(coord, -1, 2*size - 1, &grad_refl);
       // when align_corners=False, reflection does not auto clip coords

--- a/aten/src/ATen/native/cuda/GridSampler.cuh
+++ b/aten/src/ATen/native/cuda/GridSampler.cuh
@@ -69,6 +69,8 @@ scalar_t clip_coordinates(scalar_t in, int clip_limit) {
 template <typename scalar_t>
 static __forceinline__ __device__
 scalar_t clip_coordinates_set_grad(scalar_t in, int clip_limit, scalar_t *grad_in) {
+  // Note that it is important for the gradient calculation that borders
+  // are considered out of bounds.
   if (in <= static_cast<scalar_t>(0)) {
     *grad_in = static_cast<scalar_t>(0);
     return static_cast<scalar_t>(0);
@@ -158,9 +160,9 @@ scalar_t grid_sampler_compute_source_index(
       coord = reflect_coordinates(coord, 0, 2*(size - 1));
     } else {
       coord = reflect_coordinates(coord, -1, 2*size - 1);
-      // when align_corners=False, reflection does not auto clip coords
-      coord = clip_coordinates(coord, size);
     }
+    // clip coordinates to image borders
+    coord = clip_coordinates(coord, size);
   }
   return coord;
 }
@@ -187,16 +189,12 @@ scalar_t grid_sampler_compute_source_index_set_grad(
     // reflect coordinates by image borders
     if (align_corners) {
       coord = reflect_coordinates_set_grad(coord, 0, 2*(size - 1), &grad_refl);
-      *grad_in = (*grad_in) * grad_refl;
-      if (coord == size - 1 || coord == 0) {
-        *grad_in = static_cast<scalar_t>(0);
-      }
     } else {
       coord = reflect_coordinates_set_grad(coord, -1, 2*size - 1, &grad_refl);
-      // when align_corners=False, reflection does not auto clip coords
-      coord = clip_coordinates_set_grad(coord, size, &grad_clip);
-      *grad_in = (*grad_in) * grad_refl * grad_clip;
     }
+    // clip coordinates to image borders
+    coord = clip_coordinates_set_grad(coord, size, &grad_clip);
+    *grad_in = (*grad_in) * grad_refl * grad_clip;
   }
   return coord;
 }

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -6815,6 +6815,53 @@ class TestNN(NNTestCase):
                                      "groundtruth comparison failed for mode={}, "
                                      "padding_mode={}".format(mode, padding_mode))
 
+                    # explicit check for gradient edge cases
+                    input = torch.arange(0., 5).expand((1, 1, 5, 5)).requires_grad_()
+                    grid = torch.tensor(
+                        [[[1.0, 1.0], [1.0, -1.0], [0.8, 0.8], [0.8, -0.8]],
+                         [[-1.0, -1.0], [-1.0, 1.0], [-0.8, -0.8], [-0.8, 0.8]]]).view(1, 2, 4, 2).requires_grad_()
+                    if mode == 'bilinear':
+                        if padding_mode == 'zeros':
+                            if align_corners:
+                                groundtruth = torch.tensor(
+                                    [[[[-8., -8.], [-8., 0.], [2., 0.], [2., 0.]],
+                                      [[2., 0.], [2., 0.], [2., 0.], [2., 0.]]]]).view(1, 2, 4, 2)
+                            else:
+                                groundtruth = torch.tensor(
+                                    [[[[-5., -5.], [-5., 5.], [-10., -10.], [-10., 10.]],
+                                      [[0., 0.], [0., 0.], [0., 0.], [0., 0.]]]]).view(1, 2, 4, 2)
+                        elif padding_mode == 'border':
+                            if align_corners:
+                                groundtruth = torch.tensor(
+                                    [[[[-0., -0.], [-0., 0.], [2., 0.], [2., 0.]],
+                                      [[0., 0.], [0., 0.], [2., 0.], [2., 0.]]]]).view(1, 2, 4, 2)
+                            else:
+                                groundtruth = torch.tensor(
+                                    [[[[-0., -0.], [-0., 0.], [-0., -0.], [-0., 0.]],
+                                      [[0., 0.], [0., 0.], [0., 0.], [0., 0.]]]]).view(1, 2, 4, 2)
+                        elif padding_mode == 'reflection':
+                            if align_corners:
+                                groundtruth = torch.tensor(
+                                    [[[[-0., -0.], [-0., 0.], [2., 0.], [2., 0.]],
+                                      [[0., 0.], [0., 0.], [2., 0.], [2., 0.]]]]).view(1, 2, 4, 2)
+                            else:
+                                groundtruth = torch.tensor(
+                                    [[[[-0., -0.], [-0., 0.], [-0., -0.], [-0., 0.]],
+                                      [[0., 0.], [0., 0.], [0., 0.], [0., 0.]]]]).view(1, 2, 4, 2)
+                        else:
+                            raise AssertionError("missing gradient groundtruth test for padding mode '{}'".format(padding_mode))
+                    elif mode == 'nearest':
+                        groundtruth = torch.tensor(
+                            [[[[-0., -0.], [-0., 0.], [-0., -0.], [-0., 0.]],
+                              [[0., 0.], [0., 0.], [0., 0.], [0., 0.]]]]).view(1, 2, 4, 2)
+                    else:
+                        raise AssertionError("missing gradient groundtruth test for interpolation mode '{}'".format(mode))
+                    F.grid_sample(input, grid, mode=mode, padding_mode=padding_mode,
+                                  align_corners=align_corners).sum().backward()
+                    self.assertEqual(grid.grad, groundtruth,
+                                     "gradient groundtruth comparison failed for mode={}, "
+                                     "padding_mode={}".format(mode, padding_mode))
+
                     # do gradcheck
                     N = random.randint(2, 8)
                     C = random.randint(2, 6)


### PR DESCRIPTION
Fixes #23925

This fixes the incorrect gradients returned by `F.grid_sample` at image borders under `"border"` and `"reflection"` padding modes.

At nondifferentiable points, the choice of which gradient to return among its super- or subgradients is rather arbitrary and generally does not affect training. Before this change, however, a bug in the code meant that the gradient returned at the exact borders was not selected from among the super- or subgradients.

The gradient is now set to zero at the borders, which is a defensible choice for both the `"border"` and `"reflection"` padding modes:
* For `"border"` padding, this effectively means that the exact borders of the image are now considered out of bounds, and therefore receive zero gradient.
* For `"reflection"` padding, this effectively treats the exact borders as extrema.

