### PR TITLE
Solves Issue #32750 - torch.prod now works fine with FP16 Input Tensor and FP32 Output Tensor

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -13571,14 +13571,12 @@ class TestTorchDeviceType(TestCase):
         # Check all combinations: fp16 input - fp16 output, fp16 input - fp32
         # output, fp32 input - fp16 output, fp32 input - fp32 output
         for dtype_output in [torch.float16, torch.float32]:
-            result_expected = torch.tensor([2592], dtype=dtype_output, device=device)
+            result_expected = torch.tensor(2592, dtype=dtype_output, device=device)
             output = torch.prod(x, dtype=dtype_output)
-            result = torch.tensor([output.item()], dtype=output.dtype, device=output.device)
-            self.assertEqual(result, result_expected)
+            self.assertEqual(output, result_expected)
 
             output = x.prod(dtype=dtype_output)
-            result = torch.tensor([output.item()], dtype=output.dtype, device=output.device)
-            self.assertEqual(result, result_expected)
+            self.assertEqual(output, result_expected)
 
     @onlyCPU
     @dtypes(torch.float)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -13563,6 +13563,23 @@ class TestTorchDeviceType(TestCase):
     def test_cpow(self, device, dtype):
         self._test_cop(torch.pow, lambda x, y: nan if x < 0 else math.pow(x, y), dtype, device)
 
+    @onlyCUDA
+    @dtypes(torch.float16, torch.float32)
+    def test_prod_gpu(self, device, dtype):
+        x = torch.tensor([2, 3, 6, 9, 8], dtype=dtype, device=device)
+
+        # Check all combinations: fp16 input - fp16 output, fp16 input - fp32
+        # output, fp32 input - fp16 output, fp32 input - fp32 output
+        for dtype_output in [torch.float16, torch.float32]:
+            result_expected = torch.tensor([2592], dtype=dtype_output, device=device)
+            output = torch.prod(x, dtype=dtype_output)
+            result = torch.tensor([output.item()], dtype=output.dtype, device=output.device)
+            self.assertEqual(result, result_expected)
+
+            output = x.prod(dtype=dtype_output)
+            result = torch.tensor([output.item()], dtype=output.dtype, device=output.device)
+            self.assertEqual(result, result_expected)
+
     @onlyCPU
     @dtypes(torch.float)
     def test_prod(self, device, dtype):


### PR DESCRIPTION
This PR solves Issue #32750. 

- Changes function prod_kernel_impl to use `out_t` argument instead of `scalar_t` (which caused the garbage output for FP16 input and FP32 output tensor type). 
- Adds test case for `torch.prod` (for CUDA): tests both `torch.prod` and `torch.tensor.prod`. Checks all the combinations for dtypes: `torch.float16` and `torch.float32`. 
