### PR TITLE
[jit] Restore old annotate(Tensor, None) behavior

### DIFF
--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -2429,6 +2429,14 @@ struct to_ir {
             emitExpr(apply.inputs()[1], type),
             /*allow_conversions=*/true);
 
+        if (expr->type()->kind() == TypeKind::NoneType &&
+            type->kind() == TypeKind::TensorType) {
+          // This check is only here to preserve backwards compatibility. We
+          // previously allowed torch.jit.annotate(Tensor, None) and need to be
+          // able to load it back in.
+          type = OptionalType::create(type);
+        }
+
         std::stringstream why_not;
         if (!expr->type()->isSubtypeOfExt(type, &why_not)) {
           throw ErrorReport(apply.inputs())

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -2431,9 +2431,6 @@ struct to_ir {
 
         if (expr->type()->kind() == TypeKind::NoneType &&
             type->kind() == TypeKind::TensorType) {
-          // This check is only here to preserve backwards compatibility. We
-          // previously allowed torch.jit.annotate(Tensor, None) and need to be
-          // able to load it back in.
           type = OptionalType::create(type);
         }
 


### PR DESCRIPTION
Until #25361, we allowed `annotate(Tensor, None)` to result in an `Optional[Tensor]` type. While this case looks like some bad implicit type behavior / maybe something left over from undefined tensor days, it exists in some serialized models (see [forum post here](https://discuss.pytorch.org/t/upgrade-issue-with-trace-and-autograd-from-torch-1-0-1-to-torch-1-3-1/65606/9)), so we should preserve its behavior for backwards-compatibility.

