### PR TITLE
vmap proof of concept (python)

### DIFF
--- a/vmap.py
+++ b/vmap.py
@@ -1,0 +1,106 @@
+import torch
+import functools
+from torch import Tensor
+
+
+HANDLED_FUNCTIONS_BATCHED = {}
+VMAP_LAYER = 0
+
+def implements_batched(torch_function):
+    @functools.wraps(torch_function)
+    def decorator(func):
+        HANDLED_FUNCTIONS_BATCHED[torch_function] = func
+        return func
+    return decorator
+
+
+class Batched(object):
+    handled_functions = HANDLED_FUNCTIONS_BATCHED
+
+    def __init__(self, value, bdim, layer=None):
+        # Keep track of the value (tensor), batch dim, and which layer of nesting.
+        self.value = value
+        self.bdim = bdim
+        if layer is None:
+            self.layer = VMAP_LAYER
+        else:
+            self.layer = layer
+
+    def __repr__(self):
+        return "Batched_{}_{}_{}".format(self.value.size(), self.bdim, self.layer)
+
+    def __torch_function__(self, func, args=(), kwargs=None):
+        if kwargs is None:
+            kwargs = {}
+        if func not in self.handled_functions:
+            return NotImplemented
+        return self.handled_functions[func](*args, **kwargs)
+
+    def size(self):
+        return self.value.size()
+
+    def unsqueeze(self, dim):
+        return Batched(
+            self.value.unsqueeze(dim),
+            self.bdim if self.bdim < dim else self.bdim + dim + 1,
+            self.layer)
+
+
+def lift_to_layer(arr, layer):
+    if isinstance(arr, Batched) and arr.layer == layer:
+        return arr
+    else:
+        return Batched(arr, None)
+
+
+@implements_batched(torch.add)
+def add(arr1, arr2):
+    max_layer = max([arr.layer for arr in [arr1, arr2] if hasattr(arr, 'layer')])
+    arr1 = lift_to_layer(arr1, max_layer)
+    arr2 = lift_to_layer(arr2, max_layer)
+
+    # Unwrap one vmap nesting layer.
+    result = add_batched([arr1.value, arr2.value], [arr1.bdim, arr2.bdim])
+    return Batched(*result, layer=max_layer)
+
+
+def move_bdim_to_front(x, bdim):
+    if bdim is None:
+        return x.unsqueeze(0)
+    return x.transpose(bdim, 0)
+
+
+def add_batched(args, dims):
+    inputs = [move_bdim_to_front(arg, bdim) for arg, bdim in zip(args, dims)]
+    output = torch.add(*inputs)
+    return (output, 0)
+
+
+def vmap(fn, in_axes):
+    global VMAP_LAYER
+    VMAP_LAYER += 1
+
+    def wrapped(*args):
+        global VMAP_LAYER
+        batched_inputs = [Batched(arg, dim) for arg, dim in zip(args, in_axes)]
+        output = fn(*batched_inputs)
+        VMAP_LAYER -= 1
+        return output.value
+    return wrapped
+
+
+x3 = torch.ones(3)
+x23 = torch.ones(2, 3)
+x53 = torch.ones(5, 3)
+
+# Elementwise
+output = vmap(torch.add, [0, 0])(x23, x23)
+assert list(output.shape) == [2, 3]
+
+# Batched + unbatched
+output = vmap(torch.add, [0, None])(x23, x3)
+assert list(output.shape) == [2, 3]
+
+# Nested
+output = vmap(lambda xx: vmap(lambda yy: torch.add(xx, yy), [0])(x53), [0])(x23)
+assert list(output.shape) == [2, 5, 3]


### PR DESCRIPTION
See #32558 for another proof of concept.

I was curious if we could do this entirely in Python. This POC puts
together a really simple version of approximately what I understand
jax's vmap to do. It supports nested vmaps and tracks batching at a
per-tensor basis.

The high level approach is:
- we have an add_batched function defined that understands how to do a
"batched addition" of two tensors with batch dimension indices. We can
extend this design to support other operators.
- vmap(foo)(args) replaces all args with `Batched` objects and then
calls `foo` on those `Batched` objects. Each Batched object keeps track
of the input tensor, the batch dimension to be batched over, and what
nesting level of vmap it was constructed at.
- Calling pytorch ops on `Batched` objects return new `Batched` objects.
This is done via the `__torch_function__` dispatch mechanism.
- At the end of the day, only one add "kernel" gets called --
operations on `Batched` objects desugar into either unsqueezes/transposes
or the final add operation.

