### PR TITLE
Code cleaning: Some iterating variables in builtin_functions.cpp can be const

### DIFF
--- a/torch/csrc/jit/script/builtin_functions.cpp
+++ b/torch/csrc/jit/script/builtin_functions.cpp
@@ -93,8 +93,8 @@ struct BuiltinFunctionRegistry {
         str_pair("triple", "3"),
         str_pair("quadruple", "4"),
     };
-    for (auto scalar : {"float", "int"}) {
-      for (auto pair : name_len) {
+    for (const auto scalar : {"float", "int"}) {
+      for (const auto& pair : name_len) {
         TemplateEnv env;
         env.s("Scalar", scalar);
         env.s("name", pair.first);


### PR DESCRIPTION

To suppress a clang-tidy warning:

    torch/csrc/jit/script/builtin_functions.cpp#L89

    [performance-for-range-copy] warning: loop variable is copied but only
    used as const reference; consider making it a const reference

Also make the const qualifier of scalar explicit.

