### PR TITLE
[JIT] Fix torchbind pickle

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -5058,6 +5058,16 @@ def foo(x):
         traced = torch.jit.trace(TryTracing123(), ())
         self.assertEqual(torch.zeros(4, 4), traced())
 
+    @skipIfRocm
+    @unittest.skipIf(IS_WINDOWS, "TODO: Fix this test case")
+    def test_torchbind_pickle(self):
+        f = torch.classes._TorchScriptTesting_PickleTester([3, 4])
+        x = pickle.dumps(f)
+        print(type(f))
+        with open('/home/jamesreed/lel.pkl', 'wb') as f:
+            f.write(x)
+        # f2 = pickle.loads(x)
+
     def test_jitter_bug(self):
         @torch.jit.script
         def fn2(input, kernel_size):

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -721,6 +721,10 @@ void initJitScriptBindings(PyObject* module) {
       .def(
           "__getattr__",
           [](Object& self, const std::string& name) {
+            if (name == "__reduce__") {
+              if (self.type()->name()) {
+              }
+            }
             if (auto method = self.find_method(name)) {
               return py::cast(*method);
             }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #32854 [JIT] Make IRParser use op schema
* **#32853 [JIT] Fix torchbind pickle**
* #32833 [JIT] Trace uses of torchbind classes as module attributes

Differential Revision: [D19656872](https://our.internmc.facebook.com/intern/diff/D19656872)