### PR TITLE
[JIT] namedtuple constants

### DIFF
--- a/test/test_jit_py3.py
+++ b/test/test_jit_py3.py
@@ -87,6 +87,17 @@ class TestScriptPy3(JitTestCase):
 
         self.assertEqual(foo(torch.rand(3, 4)), 18.0)
 
+    def test_named_tuple_constant(self):
+        class Tup(NamedTuple):
+            a: int
+            b: int
+
+        @torch.jit.script
+        def foo():
+            return Tup(1, 2)
+
+        self.assertEqual(foo(), Tup(1, 2))
+
     @unittest.skipIf(sys.version_info[0] < 3 and sys.version_info[1] < 6, "dict not ordered")
     def test_dict_preserves_order(self):
         def dict_ordering():

--- a/torch/csrc/jit/passes/python_print.cpp
+++ b/torch/csrc/jit/passes/python_print.cpp
@@ -783,6 +783,11 @@ struct PythonPrintImpl {
         ss << "CONSTANTS.c" << getOrAddTensorConstant(v.toTensor());
         return true;
       }
+      if (v.isTuple() && v.type()->expect<TupleType>()->schema()) {
+        // print the namedtuple constructor and let rest of tuple printing
+        // continue
+        ss << v.type()->expect<TupleType>()->python_str();
+      }
       return false;
     };
 


### PR DESCRIPTION
If there was a namedtuple with immutable constant inputs, that was also the input / output of a function which expected a namedtuple it would fail. Fix by using namedtuple constructor on serialization. (no one has run into this bug yet).