### PR TITLE
Workaround performance bug / memory leak in GOMP

### DIFF
--- a/aten/src/ATen/Parallel.h
+++ b/aten/src/ATen/Parallel.h
@@ -22,7 +22,7 @@ CAFFE2_API void init_num_threads();
 // Sets the number of threads to be used in parallel region
 CAFFE2_API void set_num_threads(int);
 
-// Returns the number of threads used in parallel region
+// Returns the maximum number of threads that may be used in a parallel region
 CAFFE2_API int get_num_threads();
 
 // Returns the current thread number (starting from 0)

--- a/aten/src/ATen/ParallelOpenMP.h
+++ b/aten/src/ATen/ParallelOpenMP.h
@@ -25,16 +25,18 @@ inline void parallel_for(
 #ifdef _OPENMP
   std::atomic_flag err_flag = ATOMIC_FLAG_INIT;
   std::exception_ptr eptr;
-  // choose number of tasks based on grain size and number of threads
-  int64_t num_threads = omp_in_parallel() ? 1 : omp_get_max_threads();
-  if (grain_size > 0) {
-    num_threads = std::min(num_threads, divup((end - begin), grain_size));
-  }
 
-#pragma omp parallel num_threads(num_threads)
+#pragma omp parallel if (!omp_in_parallel() && ((end - begin) > grain_size))
   {
+    // choose number of tasks based on grain size and number of threads
+    // can't use num_threads clause due to bugs in GOMP's thread pool (See #32008)
+    int64_t num_threads = omp_get_num_threads();
+    if (grain_size > 0) {
+      num_threads = std::min(num_threads, divup((end - begin), grain_size));
+    }
+
     int64_t tid = omp_get_thread_num();
-    int64_t chunk_size = divup((end - begin), omp_get_num_threads());
+    int64_t chunk_size = divup((end - begin), num_threads);
     int64_t begin_tid = begin + tid * chunk_size;
     if (begin_tid < end) {
       try {


### PR DESCRIPTION
Fixes #32008

This is similar to @CaoZhongZ's patch which runs on all OpenMP threads in the team and selectively exits early to scale the number of threads active. I have also restored the `if` clause from before #26963 so that running on 1 thread should still avoid additional synchronisation.

One comment is that this does slightly change the meaning of `at::get_num_threads` inside of a `parallel_for` loop since it's not guaranteed that the function was called on that many threads. I've looked at the uses within ATen and couldn't see anything that would be problematic. There are a few places in `quantized` that seem to make this assumption but they always use a grain size of 1 so should be safe:
https://github.com/pytorch/pytorch/blob/d9e99ab544cceaf346605db1af4a862197a107cd/aten/src/ATen/native/quantized/cpu/qconv.cpp#L436-L437