### PR TITLE
Fix case when hash returns negative integer

### DIFF
--- a/caffe2/contrib/tensorboard/tensorboard.py
+++ b/caffe2/contrib/tensorboard/tensorboard.py
@@ -158,8 +158,11 @@ def tensorboard_events(c2_dir, tf_dir):
         return [(n, s) for (n, s) in summaries if s]
 
     def inferred_histo(summary, samples=1000):
-        np.random.seed(hash(
-            summary.std + summary.mean + summary.min + summary.max))
+        np.random.seed(
+            hash(
+                summary.std + summary.mean + summary.min + summary.max
+            ) % np.iinfo(np.int32).max
+        )
         samples = np.random.randn(samples) * summary.std + summary.mean
         samples = np.clip(samples, a_min=summary.min, a_max=summary.max)
         (hist, edges) = np.histogram(samples)


### PR DESCRIPTION
Summary: Update tensorboard binary and unit tests to python 3

Test Plan:
```
> buck test //caffe2/caffe2/contrib/tensorboard:tensorboard_test
```
```
> buck test //caffe2/caffe2/contrib/tensorboard:tensorboard_exporter_test
```

Reviewed By: sanekmelnikov

Differential Revision: D19670873

