### PR TITLE
BUG: fixed module parameter still references original tensor even after pruning 

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2697,6 +2697,20 @@ class TestNN(NNTestCase):
         pruned_tensor = p.prune(t, default_mask)
         self.assertEqual(t * expected_mask, pruned_tensor)
 
+    @unittest.skipIf(not PY3, "mock is not available in Python 2")
+    def test_pruning_update_named_parameter(self):
+        """
+        Test that the registered parameters of a module are appropriately
+        updated after pruning. The module's parameters should be the prune tensor
+        """
+        def names(named_parameters):
+            return [k for k, _ in named_parameters]
+
+        m = nn.Linear(4, 2)
+        prune.l1_unstructured(m, 'weight', amount=2)
+
+        expected_parameter_names = ["weight", 'bias']
+        self.assertEqual(expected_parameter_names,  names(m.named_parameters()))
 
     def test_weight_norm(self):
         input = torch.randn(3, 5)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2710,7 +2710,9 @@ class TestNN(NNTestCase):
         prune.l1_unstructured(m, 'weight', amount=2)
 
         expected_parameter_names = sorted(["weight", 'bias'])
-        self.assertEqual(expected_parameter_names,  sorted(names(m.named_parameters())))
+        self.assertEqual(expected_parameter_names,
+                         sorted(names(m.named_parameters())))
+
 
     def test_weight_norm(self):
         input = torch.randn(3, 5)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2709,8 +2709,8 @@ class TestNN(NNTestCase):
         m = nn.Linear(4, 2)
         prune.l1_unstructured(m, 'weight', amount=2)
 
-        expected_parameter_names = ["weight", 'bias']
-        self.assertEqual(expected_parameter_names,  names(m.named_parameters()))
+        expected_parameter_names = sorted(["weight", 'bias'])
+        self.assertEqual(expected_parameter_names,  sorted(names(m.named_parameters())))
 
     def test_weight_norm(self):
         input = torch.randn(3, 5)

--- a/torch/nn/utils/prune.py
+++ b/torch/nn/utils/prune.py
@@ -182,7 +182,7 @@ class BasePruningMethod(ABC):
             # reparametrize by saving mask to `module[name + '_mask']`...
             module.register_buffer(name + "_mask", mask)
             # ... and the new pruned tensor to `module[name]`
-            module.register_parameter(name,  method.apply_mask(module))
+            module.register_parameter(name,  torch.nn.Parameter(method.apply_mask(module)))
             # associate the pruning method to the module via a hook to
             # compute the function before every forward() (compile by run)
             module.register_forward_pre_hook(method)

--- a/torch/nn/utils/prune.py
+++ b/torch/nn/utils/prune.py
@@ -164,7 +164,7 @@ class BasePruningMethod(ABC):
         # and deleting the original parameter
         if not isinstance(method, PruningContainer):
             # copy `module[name]` to `module[name + '_orig']`
-            module.register_parameter(name + "_orig", orig)
+            setattr(module, name + "_orig", orig)
             # temporarily delete `module[name]`
             del module._parameters[name]
             default_mask = torch.ones_like(orig)  # temp
@@ -182,7 +182,7 @@ class BasePruningMethod(ABC):
             # reparametrize by saving mask to `module[name + '_mask']`...
             module.register_buffer(name + "_mask", mask)
             # ... and the new pruned tensor to `module[name]`
-            setattr(module, name, method.apply_mask(module))
+            module.register_parameter(name,  method.apply_mask(module))
             # associate the pruning method to the module via a hook to
             # compute the function before every forward() (compile by run)
             module.register_forward_pre_hook(method)

--- a/torch/nn/utils/prune.py
+++ b/torch/nn/utils/prune.py
@@ -32,7 +32,7 @@ class BasePruningMethod(ABC):
             module (nn.Module): module containing the tensor to prune
             inputs: not used.
         """
-        setattr(module, self._tensor_name, self.apply_mask(module))
+        setattr(module, self._tensor_name, torch.nn.Parameter(self.apply_mask(module)))
 
     @abstractmethod
     def compute_mask(self, t, default_mask):
@@ -164,7 +164,7 @@ class BasePruningMethod(ABC):
         # and deleting the original parameter
         if not isinstance(method, PruningContainer):
             # copy `module[name]` to `module[name + '_orig']`
-            setattr(module, name + "_orig", orig)
+            setattr(module, name + "_orig", orig.data)
             # temporarily delete `module[name]`
             del module._parameters[name]
             default_mask = torch.ones_like(orig)  # temp


### PR DESCRIPTION

Pruning does not update and register parameters appropriately 

```
from torch import nn
from torch.nn.utils import prune


m = nn.Linear(4, 2)
prune.l1_unstructured(m, 'weight', amount=0.2)
param_names = []

for n, p in m.named_parameters():
    param_names.append(n)

print(param_names)
```

Expected 

```
[weight, bias]
```

Results

```
[bias, weight_orig]
```

Also, the underlying data of parameter is the original tensor, not the pruned version. 