### PR TITLE
Fix: add state initialization in step of Adagrad

### DIFF
--- a/torch/optim/adagrad.py
+++ b/torch/optim/adagrad.py
@@ -68,6 +68,11 @@ class Adagrad(Optimizer):
                 grad = p.grad.data
                 state = self.state[p]
 
+                # State initialization
+                if len(state) == 0:
+                    state['step'] = 0
+                    state['sum'] = torch.full_like(p.data, group['initial_accumulator_value'], memory_format=torch.preserve_format)
+
                 state['step'] += 1
 
                 if group['weight_decay'] != 0:


### PR DESCRIPTION
After applying `add_param_group` of Adagrad, KeyError is raised because `state` for newly added parameters is not initialized. This PR fixes this issue.

```python
import torch

def case1():
    linear = torch.nn.Linear(3, 5)
    optimizer = torch.optim.Adagrad(linear.parameters())

    x = torch.randn(2, 3)
    y = linear(x)

    loss = y.sum()
    loss.backward()

    optimizer.step()


def case2():
    linear = torch.nn.Linear(3, 5)
    optimizer = torch.optim.Adagrad(linear.parameters())

    linear2 = torch.nn.Linear(5, 4)
    optimizer.add_param_group({'params': [linear2.weight, linear2.bias]})

    x = torch.randn(2, 3)
    y1 = linear(x)
    y2 = linear2(y1)

    loss = y2.sum()
    loss.backward()

    optimizer.step()


if __name__ == '__main__':
    case1()
    case2()

```
```
Traceback (most recent call last):
  File "test-adagrad.py", line 35, in <module>
    case2()
  File "test-adagrad.py", line 30, in case2
    optimizer.step()
  File "/Users/takuya/.pyenv/versions/3.7.3/lib/python3.7/site-packages/torch/optim/adagrad.py", line 76, in step
    state['step'] += 1
KeyError: 'step'
```