### PR TITLE
Move deprecation warning out of generated code into python_arg_parser.

### DIFF
--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -800,20 +800,6 @@ static PyObject * ${pycname}(PyObject* self_, PyObject* args, PyObject* kwargs)
 
   ParsedArgs<${max_args}> parsed_args;
   auto _r = parser.parse(args, kwargs, parsed_args);
-  if (_r.signature.deprecated) {
-    auto msg = c10::str(
-        "This overload of ", _r.signature.name, " is deprecated:\n",
-        "${name}", _r.signature.toString());
-    auto signatures = parser.get_signatures();
-    if (!signatures.empty()) {
-      msg += "\nConsider using one of the following signatures instead:";
-      for (const auto & sig : signatures) {
-        msg += "\n${name}";
-        msg += sig;
-      }
-    }
-    TORCH_WARN_ONCE(msg);
-  }
   ${check_has_torch_function}
   switch (_r.idx) {
     ${dispatch}
@@ -1055,7 +1041,9 @@ def group_overloads(declarations, is_python_method):
     result = []
     for x, dictionary in sorted(grouped.items()):
         if 'base' not in dictionary:
-            raise RuntimeError("'base' not in dictionary for " + str(x), dictionary)
+            raise RuntimeError(
+                "'base' not in dictionary for {}. keys are {}".format(
+                    x, list(dictionary.keys())))
         result.append(dictionary)
     return sort_declarations(result)
 

--- a/torch/csrc/utils/python_arg_parser.cpp
+++ b/torch/csrc/utils/python_arg_parser.cpp
@@ -684,7 +684,7 @@ PythonArgParser::PythonArgParser(std::vector<std::string> fmts, bool traceable)
 void PythonArgParser::check_deprecated(const FunctionSignature & signature) {
   if (signature.deprecated) {
     auto msg = c10::str(
-      "This overload of ", signature.name, " is deprecated:\n\t", 
+      "This overload of ", signature.name, " is deprecated:\n\t",
       signature.name, signature.toString());
     auto signatures = get_signatures();
     if (!signatures.empty()) {

--- a/torch/csrc/utils/python_arg_parser.cpp
+++ b/torch/csrc/utils/python_arg_parser.cpp
@@ -681,15 +681,35 @@ PythonArgParser::PythonArgParser(std::vector<std::string> fmts, bool traceable)
     });
 }
 
+void PythonArgParser::check_deprecated(const FunctionSignature & signature) {
+  if (signature.deprecated) {
+    auto msg = c10::str(
+      "This overload of ", signature.name, " is deprecated:\n\t", 
+      signature.name, signature.toString());
+    auto signatures = get_signatures();
+    if (!signatures.empty()) {
+      msg += "\nConsider using one of the following signatures instead:";
+      for (const auto & sig : signatures) {
+        msg += "\n\t";
+        msg += signature.name;
+        msg += sig;
+      }
+    }
+    TORCH_WARN_ONCE(msg);
+  }
+}
+
 PythonArgs PythonArgParser::raw_parse(PyObject* args, PyObject* kwargs, PyObject* parsed_args[]) {
   if (signatures_.size() == 1) {
     auto& signature = signatures_[0];
     signature.parse(args, kwargs, parsed_args, true);
+    check_deprecated(signature);
     return PythonArgs(traceable, signature, parsed_args);
   }
 
   for (auto& signature : signatures_) {
     if (signature.parse(args, kwargs, parsed_args, false)) {
+      check_deprecated(signature);
       return PythonArgs(traceable, signature, parsed_args);
     }
   }

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -104,6 +104,7 @@ struct PythonArgParser {
 private:
   [[noreturn]]
   void print_error(PyObject* args, PyObject* kwargs, PyObject* parsed_args[]);
+  void check_deprecated(const FunctionSignature & signature);
   PythonArgs raw_parse(PyObject* args, PyObject* kwargs, PyObject* parsed_args[]);
 
   std::vector<FunctionSignature> signatures_;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#32907 Move deprecation warning out of generated code into python_arg_parser.**

All op-specific information used in this logic was available to the
parser itself, so the check can be done in that context, no codegen
needed. 

No change in the warning behavior itself, mod minor formatting tweak - 
passes existing tests. Saves like ~275K binary size on mac:
```
-rwxr-xr-x  1 bhosmer  1876110778   16502064 Feb  1 00:43 torch/lib/libtorch_python.dylib
-rwxr-xr-x  1 bhosmer  1876110778   16247888 Feb  1 00:44 torch/lib/libtorch_python.dylib
```

[codegen diff](https://github.com/bhosmer/scratch/compare/deprecation_warning_before...deprecation_warning_after)

More important than the size savings is the minimization of codegen. Ideally the generated artifact should express distinctive per-op properties in as minimal a form as practically possible - e.g. here instead of generating check-and-warn behavior into every binding, we generate only the data that triggers the behavior in the parser. (And actually we were generating it already.)

Differential Revision: [D19679928](https://our.internmc.facebook.com/intern/diff/D19679928)