### PR TITLE
Added upsample_neartest2d op for lite interpreter.

### DIFF
--- a/test/cpp/jit/test_lite_interpreter.cpp
+++ b/test/cpp/jit/test_lite_interpreter.cpp
@@ -9,6 +9,29 @@
 namespace torch {
 namespace jit {
 
+void testLiteInterpreterUpsampleNearest2d() {
+  script::Module m("m");
+  m.define(R"(
+    def forward(self, input: Tensor, scale:float):
+      return torch.upsample_nearest2d(input, [1, 1], float(scale), float(scale))
+  )");
+
+  std::vector<IValue> inputs;
+  inputs.emplace_back(torch::rand({1, 3, 128, 128}));
+  inputs.emplace_back(at::Scalar(2.0));
+  auto ref = m.forward(inputs);
+
+  std::stringstream ss;
+  m._save_for_mobile(ss);
+  mobile::Module bc = _load_for_mobile(ss);
+  IValue res;
+  res = bc.forward(inputs);
+
+  auto resd = res.toTensor();
+  auto refd = ref.toTensor();
+  AT_ASSERT(resd.equal(refd));
+}
+
 void testLiteInterpreterAdd() {
   script::Module m("m");
   m.register_parameter("foo", torch::ones({}), false);

--- a/test/cpp/jit/tests.h
+++ b/test/cpp/jit/tests.h
@@ -75,6 +75,7 @@ namespace jit {
   _(LiteInterpreterInline)             \
   _(LiteInterpreterTuple)              \
   _(LiteInterpreterPrimOverload)       \
+  _(LiteInterpreterUpsampleNearest2d)  \
   _(CommonAncestor)                    \
   _(AutogradSymbols)                   \
   _(MobileTypeParser)                  \

--- a/torch/csrc/jit/mobile/register_mobile_ops.cpp
+++ b/torch/csrc/jit/mobile/register_mobile_ops.cpp
@@ -116,6 +116,17 @@ void softmax_kernel(const c10::OperatorHandle& op, Stack* stack) {
   pack(*stack, std::move(result_));
 }
 
+void upsample_nearest2d_kernel(const c10::OperatorHandle& op, Stack* stack) {
+  auto result_ = at::upsample_nearest2d(
+    (std::move(peek(*stack, 0, 4))).toTensor(),
+    (std::move(peek(*stack, 1, 4))).toIntVector(),
+    (std::move(peek(*stack, 2, 4))).toOptional<double>(),
+    (std::move(peek(*stack, 3, 4))).toOptional<double>()
+  );
+  drop(*stack, 4);
+  pack(*stack, std::move(result_));
+}
+
 void warn_kernel(const c10::OperatorHandle& op, Stack* stack) {
   drop(*stack, 1);
   pop(*stack);
@@ -347,6 +358,9 @@ static auto registry = torch::RegisterOperators().op(
   [](const Tensor & self, const Tensor & other) {
      return at::mul(self, other);
   })
+).op(
+  "_aten::upsample_nearest2d(Tensor self, int[2] output_size, float? scales_h=None, float? scales_w=None) -> Tensor",
+  torch::RegisterOperators::options().kernel<&upsample_nearest2d_kernel>(c10::DispatchKey::CPUTensorId)
 ).op(
   "_aten::tanh(Tensor self) -> Tensor",
   torch::RegisterOperators::options().kernel(c10::DispatchKey::CPUTensorId,


### PR DESCRIPTION
Summary: This enables mobile detection and tracking models.

Test Plan: buck test caffe2/test/cpp/jit:jit -- JitTest.LiteInterpreterUpsampleNearest2d

Reviewed By: iseeyuan

Differential Revision: D19664502

