### PR TITLE
Docfix for #31986

### DIFF
--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -978,7 +978,7 @@ class Module(object):
                 yield name, module
 
     def modules(self):
-        r"""Returns an iterator over all modules in the network.
+        r"""Returns an iterator over all modules in the network including ``self`` if called inside a ``torch.nn.Module``.
 
         Yields:
             Module: a module in the network

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -978,7 +978,7 @@ class Module(object):
                 yield name, module
 
     def modules(self):
-        r"""Returns an iterator over all modules in the network including ``self`` if called inside a ``torch.nn.Module``.
+        r"""Returns an iterator over all modules in the network including the network module.
 
         Yields:
             Module: a module in the network


### PR DESCRIPTION
Docfix for ``torch.nn.Module.modules()``  [(https://github.com/pytorch/pytorch/issues/31986)].

If ``modules()`` is called inside a module, it also returns itself which can lead to unbounded recursion causing the system to abort the function call.