### PR TITLE
Add support for negative step size in list slicing

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -5805,6 +5805,13 @@ a")
 
         self.checkScript(func4, [x], optimize=True)
 
+        def func5(x):
+            return x[::-1]
+
+        with self.assertRaisesRegex(RuntimeError, 'slice step must be positive'):
+            scripted_fn = torch.jit.script(func5)
+            scripted_fn(x)
+
     def test_gather(self):
         def func(x):
             return x[0]

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -2965,6 +2965,7 @@ struct to_ir {
 
     auto step = emitExpr(Expr(slice.stepOr(1)));
     NamedValue step_nv = NamedValue(loc, "step", step);
+    TORCH_CHECK(getSliceInd(step_nv.value(*graph), loc) > 0, "slice step must be positive");
     return emitBuiltinCall(loc, *graph, aten::slice, args, {step_nv});
   }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#32922 Add support for negative step size in list slicing**

Add support for negative step size in list slicing to address https://github.com/pytorch/pytorch/issues/25135.
New test case for negative step size slicing added as well.

Since ```at::slice()``` does not support negative step size as well, I just give a compile error for now.

Testing:
1) The following code will generate Runtime Error during jit **compilation** now instead of when the compiled the jit script is executed.
```
import torch

def fn():
    x = [1,2,3]
    sliced_x = x[::-1]
    return sliced_x

scripted_fn = torch.jit.script(fn)
# Show the IR (intermediate representation) of the TorchScript code
print(scripted_fn.graph)

# Run the function in Python
print(fn())

# Run the function using the TorchScript interpreter (this fails)
print(scripted_fn())
```

```
Traceback (most recent call last):
  File "bug_test.py", line 19, in <module>
    scripted_fn = torch.jit.script(fn)
  File "/home/cyk/pytorch/torch/jit/__init__.py", line 1305, in script
    fn = torch._C._jit_script_compile(qualified_name, ast, _rcb, get_default_args(obj))
RuntimeError: slice step must be positive (emitSlice at ../torch/csrc/jit/script/compiler.cpp:2968)
```

2) all test case passed.
```
python test/test_jit.py TestScript.test_slice
```

