### PR TITLE
Use leaky singletons for torch.distributed.

### DIFF
--- a/torch/csrc/distributed/autograd/context/container.cpp
+++ b/torch/csrc/distributed/autograd/context/container.cpp
@@ -59,8 +59,9 @@ DistAutogradContainer& DistAutogradContainer::getInstance() {
 }
 
 DistAutogradContainer& DistAutogradContainer::getInstanceInternal() {
-  static DistAutogradContainer container;
-  return container;
+  // Leaky singleton to avoid module destructor race.
+  static DistAutogradContainer* container = new DistAutogradContainer();
+  return *container;
 }
 
 int64_t DistAutogradContainer::newAutogradMessageId() {

--- a/torch/csrc/distributed/autograd/engine/dist_engine.cpp
+++ b/torch/csrc/distributed/autograd/engine/dist_engine.cpp
@@ -28,8 +28,9 @@ DistEngine::DistEngine()
     : initializedContextIds_(), engine_(Engine::get_default_engine()) {}
 
 DistEngine& DistEngine::getInstance() {
-  static DistEngine engine;
-  return engine;
+  // Leaky singleton to avoid module destructor race.
+  static DistEngine* engine = new DistEngine();
+  return *engine;
 }
 
 void DistEngine::validateRootsAndRetrieveEdges(

--- a/torch/csrc/distributed/rpc/python_rpc_handler.cpp
+++ b/torch/csrc/distributed/rpc/python_rpc_handler.cpp
@@ -64,8 +64,9 @@ void PythonRpcHandler::cleanup() {
 }
 
 PythonRpcHandler& PythonRpcHandler::getInstance() {
-  static PythonRpcHandler handler;
-  return handler;
+  // Leaky singleton to avoid module destructor race.
+  static PythonRpcHandler* handler = new PythonRpcHandler();
+  return *handler;
 }
 
 std::shared_ptr<torch::jit::script::CompilationUnit> PythonRpcHandler::


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#32923 Use leaky singletons for torch.distributed.**

As per
https://isocpp.org/wiki/faq/ctors#construct-on-first-use-v2 and
https://isocpp.org/wiki/faq/ctors#static-init-order-on-first-use-members, we
should be using leaky singletons to avoid static initialization order problem.

Closes https://github.com/pytorch/pytorch/issues/27412

Differential Revision: [D19688986](https://our.internmc.facebook.com/intern/diff/D19688986/)