### PR TITLE
Int8 packed weight serializer and deserializer

### DIFF
--- a/caffe2/quantization/server/CMakeLists.txt
+++ b/caffe2/quantization/server/CMakeLists.txt
@@ -9,6 +9,15 @@ set(caffe2_dnnlowp_avx2_ops_SRCS
   "${CMAKE_CURRENT_SOURCE_DIR}/transpose.cc"
   "${CMAKE_CURRENT_SOURCE_DIR}/norm_minimization_avx2.cc")
 
+  add_custom_command(
+    OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/proto/fbgemm_int8.pb.cc" "${CMAKE_CURRENT_SOURCE_DIR}/proto/fbgemm_int8.pb.h" "${CMAKE_CURRENT_SOURCE_DIR}/proto/fbgemm_int8_pb2.py"
+    COMMAND
+      "${CMAKE_CURRENT_SOURCE_DIR}/proto/int8_protobuf.sh"
+      "${CMAKE_CURRENT_SOURCE_DIR}/proto/fbgemm_int8.proto"
+
+    COMMENT "generated int8 proto files located at: ${CMAKE_CURRENT_SOURCE_DIR}/proto/fbgemm_int8.pb.cc and ${CMAKE_CURRENT_SOURCE_DIR}/proto/fbgemm_int8.pb.h"
+  )
+
 # ---[ CPU files only
 list(APPEND Caffe2_CPU_SRCS
   "${CMAKE_CURRENT_SOURCE_DIR}/activation_distribution_observer.cc"

--- a/caffe2/quantization/server/proto/fbgemm_int8.proto
+++ b/caffe2/quantization/server/proto/fbgemm_int8.proto
@@ -1,0 +1,11 @@
+syntax = "proto2";
+
+package fbgemm;
+
+message FbGemmInt8PackedMatrixProto {
+  repeated int32 shape = 1;
+  repeated float scales = 2;
+  repeated int32 zero_points = 3;
+  required bytes bytes_quantized_data = 4;
+  optional bool packed = 5 [default = false];
+}

--- a/caffe2/quantization/server/proto/int8_protobuf.sh
+++ b/caffe2/quantization/server/proto/int8_protobuf.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+(
+    cd "$FBCODE_DIR"/
+    protoc \
+        caffe2/caffe2/quantization/server/proto/fbgemm_int8.proto \
+        --cpp_out="$INSTALL_DIR" \
+        --python_out="$INSTALL_DIR"
+)
+echo "$INSTALL_DIR"/caffe2/caffe2/quantization/server/proto/* "$INSTALL_DIR"
+cp "$INSTALL_DIR"/caffe2/caffe2/quantization/server/proto/* "$INSTALL_DIR"


### PR DESCRIPTION
Summary: Add serializer/deserializer for int8 packed weights without architecture dependent packing

Test Plan:
```
buck test mode/opt caffe2/caffe2/quantization/server:fully_connected_dnnlowp_op_test
```

Differential Revision: D19689332

