### PR TITLE
Created a jit post pass which removes branches that contain exceptions.

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -2421,10 +2421,12 @@ class TestONNXRuntime(unittest.TestCase):
         model = torch.nn.ReflectionPad1d(2)
         x = torch.randn(2, 4, 4)
         self.run_test(model, x)
+        self.run_test(torch.jit.script(model), x)
 
         model = torch.nn.ReflectionPad2d((3, 0, 2, 1))
         x = torch.randn(2, 2, 4, 4)
         self.run_test(model, x)
+        self.run_test(torch.jit.script(model), x)
 
     def test_replication_pad(self):
         model = torch.nn.ReplicationPad1d(2)

--- a/tools/build_variables.py
+++ b/tools/build_variables.py
@@ -316,6 +316,7 @@ def add_torch_libs():
         "torch/csrc/jit/passes/onnx/cast_all_constant_to_floating.cpp",
         "torch/csrc/jit/passes/onnx/constant_fold.cpp",
         "torch/csrc/jit/passes/onnx/fixup_onnx_conditionals.cpp",
+        "torch/csrc/jit/passes/onnx/fixup_jit_exceptions.cpp",
         "torch/csrc/jit/passes/onnx/fixup_onnx_loop.cpp",
         "torch/csrc/jit/passes/onnx/helper.cpp",
         "torch/csrc/jit/passes/onnx/peephole.cpp",

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -71,6 +71,7 @@ set(TORCH_PYTHON_SRCS
     ${TORCH_SRC_DIR}/csrc/jit/init.cpp
     ${TORCH_SRC_DIR}/csrc/jit/passes/onnx.cpp
     ${TORCH_SRC_DIR}/csrc/jit/passes/onnx/fixup_onnx_conditionals.cpp
+    ${TORCH_SRC_DIR}/csrc/jit/passes/onnx/fixup_jit_exceptions.cpp
     ${TORCH_SRC_DIR}/csrc/jit/passes/onnx/fixup_onnx_loop.cpp
     ${TORCH_SRC_DIR}/csrc/jit/passes/onnx/helper.cpp
     ${TORCH_SRC_DIR}/csrc/jit/passes/onnx/prepare_division_for_onnx.cpp

--- a/torch/csrc/jit/init.cpp
+++ b/torch/csrc/jit/init.cpp
@@ -30,6 +30,7 @@
 #include <torch/csrc/jit/passes/onnx/constant_fold.h>
 #include <torch/csrc/jit/passes/onnx/fixup_onnx_loop.h>
 #include <torch/csrc/jit/passes/onnx/fixup_onnx_conditionals.h>
+#include <torch/csrc/jit/passes/onnx/fixup_jit_exceptions.h>
 #include <torch/csrc/jit/passes/onnx/peephole.h>
 #include <torch/csrc/jit/passes/onnx/prepare_division_for_onnx.h>
 #include <torch/csrc/jit/passes/onnx/scalar_type_analysis.h>
@@ -317,6 +318,7 @@ void initJITBindings(PyObject* module) {
       .def("_jit_pass_onnx_block", BlockToONNX)
       .def("_jit_pass_fixup_onnx_loops", FixupONNXLoops)
       .def("_jit_pass_fixup_onnx_conditionals", FixupONNXConditionals)
+      .def("_jit_pass_fixup_jit_exceptions", FixupJitExceptions)
       .def("_jit_pass_canonicalize_ops", CanonicalizeOps)
       .def("_jit_pass_decompose_ops", DecomposeOps)
       .def("_jit_pass_specialize_autogradzero", specializeAutogradZero)

--- a/torch/csrc/jit/passes/onnx/fixup_jit_exceptions.cpp
+++ b/torch/csrc/jit/passes/onnx/fixup_jit_exceptions.cpp
@@ -1,0 +1,89 @@
+#include <torch/csrc/jit/passes/onnx/fixup_jit_exceptions.h>
+
+namespace torch {
+namespace jit {
+
+namespace onnx{
+using namespace ::c10::onnx;
+}
+
+bool IsExceptionBlock(Block* block) {
+  for (auto* output : block->outputs()) {
+    if (output->node()->kind() == ::c10::prim::Uninitialized) {
+      return true;
+    }
+  }
+  return false;
+}
+void RemoveUninitialized(Block* block) {
+  std::vector<Node*> to_destroy;
+  for (auto* node : block->nodes()) {
+    if (node->kind() == ::c10::prim::Uninitialized) {
+      to_destroy.push_back(node);
+    }
+    for (Block* sub_block : node->blocks()) {
+      RemoveUninitialized(sub_block);
+    }
+  }
+  for (auto* node : to_destroy) {
+    node->destroy();
+  }
+}
+
+bool RemoveExceptionBranches(Block* block) {
+  bool pathRemoved = false;
+  std::vector<Node*> to_destroy;
+  for (auto* node : block->nodes()) {
+    for (Block* sub_block : node->blocks()) {
+      pathRemoved |= RemoveExceptionBranches(sub_block);
+    }
+    if (node->kind() == ::c10::prim::If) {
+      auto* graph = node->owningGraph();
+      Block* valid_path = nullptr;
+      bool foundException = false;
+      for (Block* sub_block : node->blocks()) {
+        if (IsExceptionBlock(sub_block)) {
+          foundException = true;
+        }
+        else {
+          valid_path = sub_block;
+        }
+      }
+      if (foundException && valid_path) {
+        std::vector<Node*> tmp;
+        for (auto* valid_node : valid_path->nodes()) {
+          tmp.push_back(valid_node);
+        }
+        Node* cur = node;
+        for (auto* valid_node : tmp) {
+          valid_node->moveAfter(cur);
+          cur = valid_node;
+        }
+        for (size_t i = 0; i <  node->blocks().size(); ++i) {
+          node->eraseBlock(0);
+        }
+        node->replaceAllUsesWith(cur);
+        to_destroy.push_back(node);
+      }
+    }
+  }
+  for (auto* node : to_destroy) {
+    TORCH_WARN("Eliminating branch which throws an exception, removing Node: ", *node);
+    pathRemoved = true;
+    node->destroy();
+  }
+  return pathRemoved;
+}
+
+void HandleExceptionBranches(Block* block) {
+  if (RemoveExceptionBranches(block)) {
+    RemoveUninitialized(block);
+  }
+}
+
+void FixupJitExceptions(std::shared_ptr<Graph>& graph) {
+  HandleExceptionBranches(graph->block());
+}
+
+} //jit
+} //torch

--- a/torch/csrc/jit/passes/onnx/fixup_jit_exceptions.cpp
+++ b/torch/csrc/jit/passes/onnx/fixup_jit_exceptions.cpp
@@ -50,19 +50,21 @@ bool RemoveExceptionBranches(Block* block) {
         }
       }
       if (foundException && valid_path) {
-        std::vector<Node*> tmp;
+        std::vector<Node*> nodes_in_valid_path;
         for (auto* valid_node : valid_path->nodes()) {
-          tmp.push_back(valid_node);
+          nodes_in_valid_path.push_back(valid_node);
         }
         Node* cur = node;
-        for (auto* valid_node : tmp) {
+        for (auto* valid_node : nodes_in_valid_path) {
           valid_node->moveAfter(cur);
           cur = valid_node;
+        }
+        for(auto i = 0; i < valid_path->return_node()->inputs().size(); ++i) {
+          node->outputs()[i]->replaceAllUsesWith(valid_path->return_node()->inputs()[i]);
         }
         while(!node->blocks().empty()) {
           node->eraseBlock(0);
         }
-        node->replaceAllUsesWith(cur);
         to_destroy.push_back(node);
       }
     }

--- a/torch/csrc/jit/passes/onnx/fixup_jit_exceptions.cpp
+++ b/torch/csrc/jit/passes/onnx/fixup_jit_exceptions.cpp
@@ -59,7 +59,7 @@ bool RemoveExceptionBranches(Block* block) {
           valid_node->moveAfter(cur);
           cur = valid_node;
         }
-        for (size_t i = 0; i <  node->blocks().size(); ++i) {
+        while(!node->blocks().empty()) {
           node->eraseBlock(0);
         }
         node->replaceAllUsesWith(cur);

--- a/torch/csrc/jit/passes/onnx/fixup_jit_exceptions.h
+++ b/torch/csrc/jit/passes/onnx/fixup_jit_exceptions.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <torch/csrc/jit/ir.h>
+
+namespace torch {
+namespace jit {
+
+/*
+ * Since ONNX has no concept of an exception need
+ * to remove them prior to generating ONNX graph
+ */
+void FixupJitExceptions(std::shared_ptr<Graph>& graph);
+
+}
+} // namespace torch

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -150,6 +150,8 @@ def _optimize_graph(graph, operator_export_type, _disable_torch_constant_prop=Fa
         # onnx only supports tensors, so we turn all out number types into tensors
         torch._C._jit_pass_erase_number_types(graph)
 
+        torch._C._jit_pass_fixup_jit_exceptions(graph)
+
         graph = torch._C._jit_pass_onnx(graph, operator_export_type)
         torch._C._jit_pass_lint(graph)
 


### PR DESCRIPTION
Since ONNX does not support the concept of an exception, there is no way
to replicate such behavior in ONNX. We must instead remove branches of
code that throw exceptions, and have undefined behavior for bad input.

