### PR TITLE
Add a loop test for onnxified net

### DIFF
--- a/caffe2/operators/reduce_ops.cc
+++ b/caffe2/operators/reduce_ops.cc
@@ -202,6 +202,43 @@ Y:
 </details>
 
 )DOC")
+    .TensorInferenceFunction([](const OperatorDef& def,
+                                const std::vector<TensorShape>& in) {
+      if (in.size() != 1) {
+        return std::vector<TensorShape>{
+            CreateTensorShape({}, TensorProto_DataType_UNDEFINED)};
+      }
+
+      const auto& dims = in.front().dims();
+      ArgumentHelper helper(def);
+      std::vector<TensorShape> out;
+      out.emplace_back();
+      auto& ts = out.back();
+      auto axis = helper.GetRepeatedArgument<int32_t>("axes");
+      std::sort(axis.begin(), axis.end());
+      auto keepdims = helper.GetSingleArgument<bool>("keepdims", true);
+      size_t cursor = 0;
+      size_t id = 0;
+      for (const auto d : dims) {
+        if (cursor < axis.size() && id == axis[cursor]) {
+          if (keepdims) {
+            ts.add_dims(d == 0 ? 0 : 1);
+          }
+          ++cursor;
+        } else {
+          ts.add_dims(d);
+        }
+        ++id;
+      }
+      if (ts.dims_size() == 0 && dims.size() != 0) {
+        ts.add_dims(1);
+      }
+      if (cursor != axis.size()) {
+        ts.set_unknown_shape(true);
+      }
+      ts.set_data_type(in.front().data_type());
+      return out;
+    })
     .Arg("axes", "(*Tuple(int)*): list of axes to reduce")
     .Arg(
         "keepdims",

--- a/caffe2/opt/backend_transformer_base.cc
+++ b/caffe2/opt/backend_transformer_base.cc
@@ -43,9 +43,9 @@ std::string BackendTransformerBase::getModelId(const NetDef& net) {
   return model_id;
 }
 
-TensorProto BackendTransformerBase::wrapShapeInfoIntoTensorProto(
+TensorProto wrapShapeInfoIntoTensorProto(
     const std::string& name,
-    const ShapeInfo& shape_info) const {
+    const ShapeInfo& shape_info) {
   TensorProto t;
   t.set_name(name);
   t.set_data_type(shape_info.shape.data_type());
@@ -58,9 +58,9 @@ TensorProto BackendTransformerBase::wrapShapeInfoIntoTensorProto(
   return t;
 }
 
-QTensorProto BackendTransformerBase::wrapShapeInfoIntoQTensorProto(
+QTensorProto wrapShapeInfoIntoQTensorProto(
     const std::string& name,
-    const ShapeInfo& shape_info) const {
+    const ShapeInfo& shape_info) {
   QTensorProto t;
   CAFFE_ENFORCE(
       shape_info.is_quantized == true,

--- a/caffe2/opt/backend_transformer_base.h
+++ b/caffe2/opt/backend_transformer_base.h
@@ -29,6 +29,16 @@ struct BackendTransformOptions {
   BoundShapeSpec bound_shape_spec;
 };
 
+// Wrap TensorShape into TensorProto
+TensorProto wrapShapeInfoIntoTensorProto(
+    const std::string& name,
+    const ShapeInfo& shape_info);
+
+// Wrap Quantized TensorShape into QTensorProto
+QTensorProto wrapShapeInfoIntoQTensorProto(
+    const std::string& name,
+    const ShapeInfo& shape_info);
+
 // This class contains some common functions for backend lowering and graph
 // cutting
 class BackendTransformerBase {
@@ -72,16 +82,6 @@ class BackendTransformerBase {
       Workspace* ws,
       NetDef* pred_net,
       const ShapeInfoMap& input_shape_hints);
-
-  // Wrap TensorShape into TensorProto
-  TensorProto wrapShapeInfoIntoTensorProto(
-      const std::string& name,
-      const ShapeInfo& shape_info) const;
-
-  // Wrap Quantized TensorShape into QTensorProto
-  QTensorProto wrapShapeInfoIntoQTensorProto(
-      const std::string& name,
-      const ShapeInfo& shape_info) const;
 
   // Do bound shape inference and collect shape infos
   ShapeInfoMap inferShapes(

--- a/caffe2/opt/bound_shape_inferencer.cc
+++ b/caffe2/opt/bound_shape_inferencer.cc
@@ -23,7 +23,9 @@ std::vector<TensorBoundShape::DimType> setDimTypeWithFirst(
     uint32_t n) {
   std::vector<TensorBoundShape::DimType> dimTypes(
       n, TensorBoundShape_DimType_CONSTANT);
-  dimTypes[0] = firstDimType;
+  if (dimTypes.size() > 0) {
+    dimTypes[0] = firstDimType;
+  }
   return dimTypes;
 }
 

--- a/caffe2/opt/custom/glow_net_transform.cc
+++ b/caffe2/opt/custom/glow_net_transform.cc
@@ -13,6 +13,11 @@ C10_DEFINE_bool(
     "Attach AdjustBatch ops at input/outputs of the Onnxifi ops");
 
 C10_DEFINE_bool(
+    onnxifi_loop_test_mode,
+    false,
+    "For test purpose only. Build a dummy net just to test the functionality");
+
+C10_DEFINE_bool(
     merge_fp32_inputs_into_fp16,
     false,
     "Merge all the fp32 input tensors into one, convert it to fp16 and split it back");
@@ -121,6 +126,7 @@ void onnxifi(
   opts.min_ops = FLAGS_onnxifi_min_ops;
   opts.load_model_by_blob = load_model_by_blob;
   opts.merge_fp32_inputs_into_fp16 = FLAGS_merge_fp32_inputs_into_fp16;
+  opts.loop_test = FLAGS_onnxifi_loop_test_mode;
 
   auto more_shape_hints = shape_hints;
   if (!FLAGS_onnxifi_shape_hints.empty()) {

--- a/caffe2/opt/onnxifi_transformer.h
+++ b/caffe2/opt/onnxifi_transformer.h
@@ -31,6 +31,9 @@ struct OnnxifiTransformerOptions final : public BackendTransformOptions {
   // Whether to combine fp32 batched inputs into one tensor and convert it to
   // fp16 or not
   bool merge_fp32_inputs_into_fp16{false};
+
+  // Enter loop test mode
+  bool loop_test{false};
 };
 
 class CAFFE2_API OnnxifiTransformer final : public BackendTransformerBase {


### PR DESCRIPTION
Summary: Mock away the content of onnxified net with some low cost ops so that we can still mimic the input/output transfer while doing minimal work on the card.

Test Plan:
```
buck run glow/fb/test:sparsenn_test -- --gtest_filter='SparseNNTest.vanillaC2' --onnxifi_debug_mode --onnxifi_loop_test_mode --nocaffe2_predictor_use_memonger
```

Differential Revision: D19631971

