### PR TITLE
[jit] fix parser for one-line functions

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -4014,6 +4014,10 @@ class TestFrontend(JitTestCase):
 
 
 class TestScript(JitTestCase):
+    def test_oneline_func(self):
+        def fn(x): return x  # noqa: E704
+
+        self.checkScript(fn, (torch.ones(2, 2), ))
 
     def test_request_bailout(self):
         with enable_profiling_mode():

--- a/torch/csrc/jit/script/parser.cpp
+++ b/torch/csrc/jit/script/parser.cpp
@@ -668,16 +668,30 @@ TreeRef parseClass() {
     auto name = parseIdent();
     auto decl = parseDecl();
 
-    // Handle type annotations specified in a type comment as the first line of
-    // the function.
-    L.expect(TK_INDENT);
-    if (L.cur().kind == TK_TYPE_COMMENT) {
-      auto type_annotation_decl = Decl(parseTypeComment());
-      L.expect(TK_NEWLINE);
-      decl = mergeTypesFromTypeComment(decl, type_annotation_decl, is_method);
+    TreeRef stmts_list;
+    if (L.nextIf(TK_INDENT)) {
+      // Handle type annotations specified in a type comment as the first line
+      // of the function.
+      if (L.cur().kind == TK_TYPE_COMMENT) {
+        auto type_annotation_decl = Decl(parseTypeComment());
+        L.expect(TK_NEWLINE);
+        decl = mergeTypesFromTypeComment(decl, type_annotation_decl, is_method);
+      }
+
+      stmts_list = parseStatements(false);
+    } else {
+      // Special case: the Python grammar allows one-line functions with a
+      // single statement.
+      if (L.cur().kind == TK_TYPE_COMMENT) {
+        auto type_annotation_decl = Decl(parseTypeComment());
+        decl = mergeTypesFromTypeComment(decl, type_annotation_decl, is_method);
+      }
+
+      TreeList stmts;
+      stmts.push_back(parseStmt(is_method));
+      stmts_list = create_compound(TK_LIST, L.cur().range, std::move(stmts));
     }
 
-    auto stmts_list = parseStatements(false);
     return Def::create(
         name.range(), Ident(name), Decl(decl), List<Stmt>(stmts_list));
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#32941 [jit] fix parser for one-line functions**

The Python grammar allows single-statement one-line functions. So we
should allow it in the string parser.

Differential Revision: [D19704153](https://our.internmc.facebook.com/intern/diff/D19704153)