### PR TITLE
Clarify when softplus is reverted to linear.

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1164,7 +1164,7 @@ softplus(input, beta=1, threshold=20) -> Tensor
 Applies element-wise, the function :math:`\text{Softplus}(x) = \frac{1}{\beta} * \log(1 + \exp(\beta * x))`.
 
 For numerical stability the implementation reverts to the linear function
-for inputs above :attr:`threshold` (default ``20``).
+when :math:`input \times \beta > threshold`.
 
 See :class:`~torch.nn.Softplus` for more details.
 """)

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -597,7 +597,7 @@ class Softplus(Module):
     to constrain the output of a machine to always be positive.
 
     For numerical stability the implementation reverts to the linear function
-    for inputs above :attr:`threshold` (default ``20``).
+    when :math:`input \times \beta > threshold`.
 
     Args:
         beta: the :math:`\beta` value for the Softplus formulation. Default: 1


### PR DESCRIPTION
The default value is removed because it is explained right below.