### PR TITLE
Expose Channel Last 3d enum

### DIFF
--- a/c10/core/MemoryFormat.h
+++ b/c10/core/MemoryFormat.h
@@ -24,7 +24,7 @@
 
 
 namespace c10 {
-enum class MemoryFormat : int8_t { Contiguous, Preserve, ChannelsLast };
+enum class MemoryFormat : int8_t { Contiguous, Preserve, ChannelsLast, ChannelsLast3d };
 
 // If you are seeing this, it means that this call site was not checked if
 // the memory format could be preserved, and it was switched to old default
@@ -45,6 +45,8 @@ inline std::ostream& operator<<(
       return stream << "Contiguous";
     case MemoryFormat::ChannelsLast:
       return stream << "ChannelsLast";
+    case MemoryFormat::ChannelsLast3d:
+      return stream << "ChannelsLast3d";
     default:
       AT_ERROR("Unknown memory format");
   }
@@ -62,12 +64,12 @@ inline std::vector<int64_t> get_channels_last_strides(IntArrayRef sizes) {
 
 // Note [Ambiguous is_channels_last_strides]
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-// The flaw of carrying memory_format implicitly through strides is very hard 
+// The flaw of carrying memory_format implicitly through strides is very hard
 // to WAR properly. issue #24090
 // Without the history of permutation, we can't infer the memory_format of a
 // tensor from the snapshot of its size & stride
 // e.g.
-// 
+//
 // 1. We can NOT specify the memory_format of N111 tensor through strides in a
 //  meaningful way;
 //
@@ -79,7 +81,7 @@ inline std::vector<int64_t> get_channels_last_strides(IntArrayRef sizes) {
 //
 // Due to the limitations, our temporary WAR `is_channels_last_strides` does the
 // best effort to infer whether the original memory_format of a tensor is
-// at::MemoryFormat::ChannelsLast. The two objectives of this function (ordered 
+// at::MemoryFormat::ChannelsLast. The two objectives of this function (ordered
 // by their importance):
 //   1. Ensure that normal shape manipulation does not accidentally change the
 //      MemoryFormat of an existing tensor.

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -1360,6 +1360,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
         TORCH_CHECK(
             dim() == 5,
             "required rank 5 tensor to use channels_last_3d format");
+        TORCH_CHECK(false, "unsupported memory format ", memory_format);
         //TODO Implement set_sizes_and_strides for channels last 3d
         break;
       }

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -1356,6 +1356,13 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
         set_sizes_and_strides(sizes(), get_channels_last_strides(sizes()));
         break;
       }
+      case MemoryFormat::ChannelsLast3d: {
+        TORCH_CHECK(
+            dim() == 5,
+            "required rank 5 tensor to use channels_last_3d format");
+        //TODO Implement set_sizes_and_strides for channels last 3d
+        break;
+      }
       case MemoryFormat::Preserve:
         TORCH_CHECK(false, "unsupported memory format ", memory_format);
         // Cleaning warning messages, no need to break as TORCH_CHECK(false)

--- a/torch/csrc/utils/tensor_memoryformats.cpp
+++ b/torch/csrc/utils/tensor_memoryformats.cpp
@@ -31,6 +31,7 @@ void initializeMemoryFormats() {
   _ADD_MEMORY_FORMAT(at::MemoryFormat::Preserve, "preserve_format");
   _ADD_MEMORY_FORMAT(at::MemoryFormat::Contiguous, "contiguous_format");
   _ADD_MEMORY_FORMAT(at::MemoryFormat::ChannelsLast, "channels_last");
+  _ADD_MEMORY_FORMAT(at::MemoryFormat::ChannelsLast3d, "_channels_last_3d");
 
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#32947 Expose Channel Last 3d enum**

This is the 1st step for supporting Channels Last 3d memory format.
Expose new enum, eliminated all compile warning caused by not handling the new enum inside switch case control flow.

Differential Revision: [D19707716](https://our.internmc.facebook.com/intern/diff/D19707716)