### PR TITLE
Add warning and example for seeding to DistributedSampler

### DIFF
--- a/torch/utils/data/distributed.py
+++ b/torch/utils/data/distributed.py
@@ -21,6 +21,19 @@ class DistributedSampler(Sampler):
             distributed training.
         rank (optional): Rank of the current process within num_replicas.
         shuffle (optional): If true (default), sampler will shuffle the indices
+
+    .. warning::
+        In distributed mode, calling the ``set_epoch`` method is needed to
+        make shuffling work; each process will use the same random seed
+        otherwise.
+
+    Example::
+
+        >>> sampler = DistributedSampler(dataset) if is_distributed else None
+        >>> loader = DataLoader(dataset, shuffle=(sampler is None),
+        ...                     sampler=sampler)
+        >>> for epoch in range(start_epoch, n_epochs):
+        ...     if is_distributed:
     """
 
     def __init__(self, dataset, num_replicas=None, rank=None, shuffle=True):


### PR DESCRIPTION
Closes gh-31771

Also note that the `epoch` attribute is *only* used as a manual seed in each iteration (so it could easily be changed/renamed).  Seeding consecutive iterations with `[0, 1, 2, ...]` is low-entropy, however in practice it probably doesn't matter when using the sampler in combination with a dataloader (because there won't be enough data nor epochs to run into statistical issues
due to low-entropy seeding). So leaving that as is.

Rendered docstring:

<img width="534" alt="image" src="https://user-images.githubusercontent.com/98330/73701250-35134100-46e9-11ea-97b8-3baeb60fcb37.png">

