### PR TITLE
[Pytorch] Propagate errors in clearAndWaitForOutstandingRpcsAsync.

### DIFF
--- a/torch/csrc/distributed/autograd/context/context.cpp
+++ b/torch/csrc/distributed/autograd/context/context.cpp
@@ -121,20 +121,36 @@ std::shared_ptr<rpc::FutureMessage> DistAutogradContext::
         : future(std::make_shared<rpc::FutureMessage>()), remaining(count) {}
     std::shared_ptr<rpc::FutureMessage> future;
     std::atomic<int32_t> remaining;
+    std::atomic<bool> alreadySentError{false};
   };
   auto state = std::make_shared<State>(outStandingRpcs.size());
   if (outStandingRpcs.empty()) {
     state->future->markCompleted(rpc::Message());
   } else {
     for (auto& rpc : outStandingRpcs) {
-      rpc->addCallback(
-          [state](
-              const rpc::Message& /* unused */,
-              const c10::optional<utils::FutureError>& /* unused */) {
-            if (--state->remaining == 0) {
-              state->future->markCompleted(rpc::Message());
-            }
-          });
+      rpc->addCallback([state](
+                           const rpc::Message& /* unused */,
+                           const c10::optional<utils::FutureError>& err) {
+        if (err) {
+          // If there's an error, we want to setError() on the future, unless
+          // another error has already been sent - use a CAS to guard.
+          //
+          // Don't decrement num remaining here! (We don't need to, since memory
+          // handling is separate). If we simply don't decrement on errors,
+          // reaching 0 means that there were no errors - and hence, we can just
+          // markCompleted() without any other checking there.
+          bool expectedAlreadySent = false;
+          if (state->alreadySentError.compare_exchange_strong(
+                  expectedAlreadySent, true)) {
+            state->future->setError(err->what());
+          }
+          return;
+        }
+
+        if (--state->remaining == 0) {
+          state->future->markCompleted(rpc::Message());
+        }
+      });
     }
   }
   return state->future;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#32952 [Pytorch] Propagate errors in clearAndWaitForOutstandingRpcsAsync.**

When the Async() version of clearAndWaitForOutstandingRpcs() was written,
we didn't yet have the generic Future<T> class, and hadn't worked out our
error model fully.

This change fixes that method to properly propagate the first encountered error
to the future, using a bool+CAS.

Differential Revision: [D19710337](https://our.internmc.facebook.com/intern/diff/D19710337/)