### PR TITLE
[jit] Support properties on `Device`

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -4341,8 +4341,8 @@ def foo(x):
 
     def _test_device_type(self, dest):
         def fn(x):
-            # type: (Device) -> str
-            return x.type
+            # type: (Device) -> str, Optional[int]
+            return x.type, x.index
 
         device = torch.ones(2).to(dest).device
         self.checkScript(fn, [device])

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -4341,7 +4341,7 @@ def foo(x):
 
     def _test_device_type(self, dest):
         def fn(x):
-            # type: (Device) -> str, Optional[int]
+            # type: (Device) -> Tuple[str, Optional[int]]
             return x.type, x.index
 
         device = torch.ones(2).to(dest).device

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -4339,6 +4339,21 @@ def foo(x):
         cu.define(dedent(inspect.getsource(ok)))
         check(cu.ok)
 
+    def _test_device_type(self, dest):
+        def fn(x):
+            # type: (Device) -> str
+            return x.type
+
+        device = torch.ones(2).to(dest).device
+        self.checkScript(fn, [device])
+
+    def test_device_type(self):
+        self._test_device_type('cpu')
+
+    @unittest.skipIf(not RUN_CUDA, "Requires CUDA")
+    def test_device_type_cuda(self):
+        self._test_device_type('cuda')
+
     def test_eval_python(self):
         def _test(m):
             self.assertTrue(m(torch.ones(2, 2)))

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -601,6 +601,14 @@ RegisterOperators reg(
          },
          aliasAnalysisFromSchema()),
      Operator(
+         "prim::type(Device self) -> str",
+         [](Stack& stack) {
+           auto d = pop(stack);
+           push(stack, d.toDevice().str());
+           return 0;
+         },
+         aliasAnalysisFromSchema()),
+     Operator(
          // TODO return generator object when torchscript supports RNG
          // first-class
          "aten::manual_seed(int seed) -> ()",

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -609,6 +609,18 @@ RegisterOperators reg(
          },
          aliasAnalysisFromSchema()),
      Operator(
+         "prim::index(Device self) -> int?",
+         [](Stack& stack) {
+           auto d = pop(stack).toDevice();
+           if (d.has_index()) {
+             push(stack, d.index());
+           } else {
+             push(stack, IValue());
+           }
+           return 0;
+         },
+         aliasAnalysisFromSchema()),
+     Operator(
          // TODO return generator object when torchscript supports RNG
          // first-class
          "aten::manual_seed(int seed) -> ()",

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -604,7 +604,7 @@ RegisterOperators reg(
          "prim::type(Device self) -> str",
          [](Stack& stack) {
            auto d = pop(stack);
-           push(stack, d.toDevice().str());
+           push(stack, DeviceTypeName(d.toDevice().type()));
            return 0;
          },
          aliasAnalysisFromSchema()),

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -604,7 +604,9 @@ RegisterOperators reg(
          "prim::type(Device self) -> str",
          [](Stack& stack) {
            auto d = pop(stack);
-           push(stack, DeviceTypeName(d.toDevice().type()));
+           push(
+               stack,
+               DeviceTypeName(d.toDevice().type(), /* lower_case=*/true));
            return 0;
          },
          aliasAnalysisFromSchema()),

--- a/torch/csrc/jit/script/sugared_value.cpp
+++ b/torch/csrc/jit/script/sugared_value.cpp
@@ -89,6 +89,19 @@ std::shared_ptr<SugaredValue> SimpleValue::attr(
     }
   }
 
+  if (value_->type()->isSubtypeOf(DeviceObjType::get())) {
+    // if (value_->type()->kind() == TypeKind::DeviceObjType) {
+    // property lookups on Device
+    static const std::unordered_set<std::string> fields = {
+        "type",
+    };
+    if (fields.count(field)) {
+      auto r =
+          m.graph()->insert(Symbol::fromQualString("prim::" + field), {value_});
+      return std::make_shared<SimpleValue>(r);
+    }
+  }
+
   // accessing fields of named tuples
   if (auto tuple_type = value_->type()->cast<TupleType>()) {
     if (tuple_type->schema()) {

--- a/torch/csrc/jit/script/sugared_value.cpp
+++ b/torch/csrc/jit/script/sugared_value.cpp
@@ -89,8 +89,7 @@ std::shared_ptr<SugaredValue> SimpleValue::attr(
   auto kind = value_->type()->kind();
   auto builtin_entry = builtin_properties.find(kind);
   if (builtin_entry != builtin_properties.end()) {
-    auto kind_entry = builtin_entry->second.find(field);
-    if (kind_entry != builtin_entry->second.end()) {
+    if (builtin_entry->second.count(field) > 0) {
       auto r =
           m.graph()->insert(Symbol::fromQualString("prim::" + field), {value_});
       return std::make_shared<SimpleValue>(r);


### PR DESCRIPTION
Stacked PRs
 * #32955 - [jit] Fix flipped PackedSequence outputs in script
 * **#32953 - [jit] Support properties on `Device`**

PyTorch devices have a `index` and `type` property. This PR adds support for both to TorchScript

Differential Revision: [D19849320](https://our.internmc.facebook.com/intern/diff/19849320/)