### PR TITLE
Make zip serialization the default

### DIFF
--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -331,7 +331,7 @@ def _check_dill_version(pickle_module):
                 pickle_module.__version__
             ))
 
-def save(obj, f, pickle_module=pickle, pickle_protocol=DEFAULT_PROTOCOL, _use_new_zipfile_serialization=False):
+def save(obj, f, pickle_module=pickle, pickle_protocol=DEFAULT_PROTOCOL, _use_new_zipfile_serialization=True):
     """Saves an object to a disk file.
 
     See also: :ref:`recommend-saving-models`


### PR DESCRIPTION
Stacked PRs
 * **#32958 - Make zip serialization the default**
 * #32244 - Fix some bugs with zipfile serialization

This flips the flag to change our eager serialization format to a zipfile as described in #26567. I'm not sure if we should flip the flag just yet since there's still some perf issues, the zip file format is about [10% slower for big files](https://gist.github.com/a5bee3ae642b144ad089e8b30eff6d3f)

Fixes #24045