### PR TITLE
Fix dispatch of argmax/argmin.

### DIFF
--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -694,10 +694,6 @@ Tensor& argmax_out(Tensor& result, const Tensor& self, c10::optional<int64_t> di
     in = self.reshape({-1});
     keepdim = false;
   }
-  if (self.options().backend() != Backend::CPU && self.options().backend() != Backend::CUDA) {
-    Tensor ignored = at::empty({0}, self.options());
-    return std::get<1>(at::max_out(ignored, result, in, dim.value_or(0), keepdim));
-  }
   auto itr = make_reduction("argmax", result, in, dim.value_or(0), keepdim,
       self.scalar_type(), at::kLong);
   argmax_stub(itr.device_type(), itr);
@@ -718,10 +714,6 @@ Tensor& argmin_out(Tensor& result, const Tensor& self, c10::optional<int64_t> di
   } else {
     in = self.reshape({-1});
     keepdim = false;
-  }
-  if (self.options().backend() != Backend::CPU && self.options().backend() != Backend::CUDA) {
-    Tensor ignored = at::empty({0}, self.options());
-    return std::get<1>(at::min_out(ignored, result, in, dim.value_or(0), keepdim));
   }
   auto itr = make_reduction("argmin", result, in, dim.value_or(0), keepdim,
       self.scalar_type(), at::kLong);

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -394,12 +394,16 @@
   use_c10_dispatcher: full
 
 - func: argmax(Tensor self, int? dim=None, bool keepdim=False) -> Tensor
-  use_c10_dispatcher: full
   variants: function, method
+  dispatch:
+    CPU: argmax
+    CUDA: argmax
 
 - func: argmin(Tensor self, int? dim=None, bool keepdim=False) -> Tensor
-  use_c10_dispatcher: full
   variants: function, method
+  dispatch:
+    CPU: argmin
+    CUDA: argmin
 
 - func: as_strided(Tensor(a) self, int[] size, int[] stride, int? storage_offset=None) -> Tensor(a)
   variants: function, method


### PR DESCRIPTION
The way we currently dispatch argmax/argmin to out-of-source devices is bad and caused issues, e.g it doesn't work well when the input requires grad. https://github.com/pytorch/xla/issues/1585.  
Making argmax/argmin dispatch at device level resolves it.
