### PR TITLE
[toDLPack] return a unique ptr to avoid memory leak

### DIFF
--- a/aten/src/ATen/DLConvertor.cpp
+++ b/aten/src/ATen/DLConvertor.cpp
@@ -159,8 +159,9 @@ void deleter(DLManagedTensor* arg) {
 
 // This function returns a shared_ptr to memory managed DLpack tensor
 // constructed out of ATen tensor
-DLManagedTensor* toDLPack(const Tensor& src) {
-  ATenDLMTensor* atDLMTensor(new ATenDLMTensor);
+std::unique_ptr<atDLMTensor> toDLPack(const Tensor& src) {
+  auto atDLMTensor = std::unique_ptr<atDLMTensor>(new ATenDLMTensor);
+  //ATenDLMTensor* atDLMTensor(new ATenDLMTensor);
   atDLMTensor->handle = src;
   atDLMTensor->tensor.manager_ctx = atDLMTensor;
   atDLMTensor->tensor.deleter = &deleter;
@@ -177,7 +178,7 @@ DLManagedTensor* toDLPack(const Tensor& src) {
   atDLMTensor->tensor.dl_tensor.strides =
       const_cast<int64_t*>(src.strides().data());
   atDLMTensor->tensor.dl_tensor.byte_offset = 0;
-  return &(atDLMTensor->tensor);
+  return atDLMTensor->tensor;
 }
 
 Tensor fromDLPack(const DLManagedTensor* src) {

--- a/aten/src/ATen/DLConvertor.h
+++ b/aten/src/ATen/DLConvertor.h
@@ -3,6 +3,7 @@
 #include <ATen/Tensor.h>
 #include <ATen/ATen.h>
 #include <ATen/dlpack.h>
+#include <memory>
 
 // this convertor will:
 // 1) take a Tensor object and wrap it in the DLPack tensor
@@ -11,7 +12,7 @@
 namespace at {
 
 CAFFE2_API ScalarType toScalarType(const DLDataType& dtype);
-CAFFE2_API DLManagedTensor* toDLPack(const Tensor& src);
+CAFFE2_API std::unique_ptr<atDLMTensor> toDLPack(const Tensor& src);
 CAFFE2_API Tensor fromDLPack(const DLManagedTensor* src);
 CAFFE2_API DLDataType getDLDataType(const Tensor& t);
 CAFFE2_API DLContext getDLContext(const Tensor& tensor, const int64_t& device_id);

--- a/aten/src/ATen/test/dlconvertor_test.cpp
+++ b/aten/src/ATen/test/dlconvertor_test.cpp
@@ -12,7 +12,7 @@ TEST(TestDlconvertor, TestDlconvertor) {
   manual_seed(123);
 
   Tensor a = rand({3, 4});
-  DLManagedTensor* dlMTensor = toDLPack(a);
+  auto dlMTensor = toDLPack(a);
 
   Tensor b = fromDLPack(dlMTensor);
 
@@ -23,7 +23,7 @@ TEST(TestDlconvertor, TestDlconvertorNoStrides) {
   manual_seed(123);
 
   Tensor a = rand({3, 4});
-  DLManagedTensor* dlMTensor = toDLPack(a);
+  auto dlMTensor = toDLPack(a);
   dlMTensor->dl_tensor.strides = nullptr;
 
   Tensor b = fromDLPack(dlMTensor);

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -371,7 +371,7 @@ PyObject *THPModule_toDLPack(PyObject *_unused, PyObject *data)
 {
   HANDLE_TH_ERRORS
   THPUtils_assert(THPVariable_Check(data), "data must be a Tensor");
-  DLManagedTensor* dlMTensor = at::toDLPack(THPVariable_Unpack(data));
+  auto dlMTensor = at::toDLPack(THPVariable_Unpack(data));
   return PyCapsule_New(dlMTensor, "dltensor", DLPack_Capsule_Destructor);
   END_HANDLE_TH_ERRORS
 }


### PR DESCRIPTION
No need to return shared/raw ptr since the owner(src) already has its own copy. Return a unique_ptr to avoid a memory leak.