### PR TITLE
Kill _th_max, _th_min overloads that aren't used.

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -310,14 +310,6 @@
       return: real
       arguments:
         - THTensor* self
-    - cname: cmin
-      return: argument 0
-      arguments:
-      - arg: THTensor* result
-        output: True
-      - arg: THTensor* self
-        broadcast: other fallback
-      - THTensor* other
 ]]
 [[
   name: _th_min
@@ -347,14 +339,6 @@
       return: real
       arguments:
         - THTensor* self
-    - cname: cmax
-      return: argument 0
-      arguments:
-      - arg: THTensor* result
-        output: True
-      - arg: THTensor* self
-        broadcast: other fallback
-      - THTensor* other
 ]]
 [[
   name: _th_max


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #32982 Move some broadcasting logic away from codegen.
* **#32981 Kill _th_max, _th_min overloads that aren't used.**

Differential Revision: [D19726831](https://our.internmc.facebook.com/intern/diff/D19726831)