### PR TITLE
Move some broadcasting logic away from codegen.

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -33,8 +33,7 @@
   return: self
   options:
     - arguments:
-      - arg: THTensor* self
-        broadcast: mask inplace fallback types:Byte
+      - THTensor* self
       - THByteTensor* mask
       - real value
 ]]
@@ -49,8 +48,7 @@
   return: self
   options:
     - arguments:
-      - arg: THTensor* self
-        broadcast: mask inplace fallback types:Bool
+      - THTensor* self
       - THBoolTensor* mask
       - real value
 ]]
@@ -64,8 +62,7 @@
   variants: function
   return: self
   arguments:
-    - arg: THTensor* self
-      broadcast: mask inplace fallback types:Byte
+    - THTensor* self
     - THByteTensor* mask
     - THTensor* source
 ]]
@@ -79,8 +76,7 @@
   variants: function
   return: self
   arguments:
-    - arg: THTensor* self
-      broadcast: mask inplace fallback types:Bool
+    - THTensor* self
     - THBoolTensor* mask
     - THTensor* source
 ]]

--- a/aten/src/ATen/native/LegacyDefinitions.cpp
+++ b/aten/src/ATen/native/LegacyDefinitions.cpp
@@ -2,6 +2,7 @@
 #include <ATen/NativeFunctions.h>
 #include <ATen/LegacyTHFunctionsCPU.h>
 #include <ATen/NamedTensorUtils.h>
+#include <ATen/ExpandUtils.h>
 
 namespace at { namespace native {
 
@@ -9,14 +10,16 @@ namespace at { namespace native {
 
 Tensor & masked_fill__cpu(Tensor& self, const Tensor & mask, Scalar value) {
   auto maybe_outnames = namedinference::broadcast_to_outnames(self, mask, "masked_fill_");
+  Tensor b_mask;
+  std::tie(b_mask) = expand_inplace(self, mask, "masked_fill_");
   // As we dispatch on self and TH is type-checked, we need different definitions.
   // This can be fixed by moving to ATen.
-  if (mask.dtype() == at::ScalarType::Byte) {
+  if (b_mask.dtype() == at::ScalarType::Byte) {
     AT_WARN("masked_fill_ received a mask with dtype torch.uint8, this behavior is now deprecated," \
             "please use a mask with dtype torch.bool instead.");
-    legacy::cpu::_th_masked_fill_(self, mask, value);
+    legacy::cpu::_th_masked_fill_(self, b_mask, value);
   } else {
-    legacy::cpu::_th_masked_fill_bool_(self, mask, value);
+    legacy::cpu::_th_masked_fill_bool_(self, b_mask, value);
   }
   namedinference::propagate_names_if_nonempty(self, maybe_outnames);
   return self;
@@ -27,28 +30,32 @@ Tensor & masked_fill__cpu(Tensor& self, const Tensor & mask, const Tensor & valu
 
   TORCH_CHECK(value.dim() == 0, "masked_fill_ only supports a 0-dimensional value tensor, but got tensor "
       "with ", value.dim(), " dimension(s).");
+  Tensor b_mask;
+  std::tie(b_mask) = expand_inplace(self, mask, "masked_fill_");
   // As we dispatch on self and TH is type-checked, we need different definitions.
   // This can be fixed by moving to ATen.
-  if (mask.dtype() == at::ScalarType::Byte) {
+  if (b_mask.dtype() == at::ScalarType::Byte) {
     AT_WARN("masked_fill_ received a mask with dtype torch.uint8, this behavior is now deprecated," \
             "please use a mask with dtype torch.bool instead.");
-    legacy::cpu::_th_masked_fill_(self, mask, value.item());
+    legacy::cpu::_th_masked_fill_(self, b_mask, value.item());
   } else {
-    legacy::cpu::_th_masked_fill_bool_(self, mask, value.item());
+    legacy::cpu::_th_masked_fill_bool_(self, b_mask, value.item());
   }
   namedinference::propagate_names_if_nonempty(self, maybe_outnames);
   return self;
 }
 
 Tensor & masked_scatter__cpu(Tensor& self, const Tensor & mask, const Tensor & source) {
+  Tensor b_mask;
+  std::tie(b_mask) = expand_inplace(self, mask, "masked_scatter_");
   // As we dispatch on self and TH is type-checked, we need different definitions.
   // This can be fixed by moving to ATen.
-  if (mask.dtype() == at::ScalarType::Byte) {
+  if (b_mask.dtype() == at::ScalarType::Byte) {
     AT_WARN("masked_scatter_ received a mask with dtype torch.uint8, this behavior is now deprecated," \
             "please use a mask with dtype torch.bool instead.");
-    return legacy::cpu::_th_masked_scatter_(self, mask, source);
+    return legacy::cpu::_th_masked_scatter_(self, b_mask, source);
   } else {
-    return legacy::cpu::_th_masked_scatter_bool_(self, mask, source);
+    return legacy::cpu::_th_masked_scatter_bool_(self, b_mask, source);
   }
 }
 

--- a/aten/src/ATen/native/cuda/LegacyDefinitions.cpp
+++ b/aten/src/ATen/native/cuda/LegacyDefinitions.cpp
@@ -2,6 +2,7 @@
 #include <ATen/NativeFunctions.h>
 #include <ATen/LegacyTHFunctionsCUDA.h>
 #include <ATen/NamedTensorUtils.h>
+#include <ATen/ExpandUtils.h>
 
 namespace at { namespace native {
 
@@ -9,14 +10,16 @@ namespace at { namespace native {
 
 Tensor & masked_fill__cuda(Tensor& self, const Tensor & mask, Scalar value) {
   auto maybe_outnames = namedinference::broadcast_to_outnames(self, mask, "masked_fill_");
+  Tensor b_mask;
+  std::tie(b_mask) = expand_inplace(self, mask, "masked_fill_");
   // As we dispatch on self and TH is type-checked, we need different definitions.
   // This can be fixed by moving to ATen.
-  if (mask.dtype() == at::ScalarType::Byte) {
+  if (b_mask.dtype() == at::ScalarType::Byte) {
     AT_WARN("masked_fill_ received a mask with dtype torch.uint8, this behavior is now deprecated," \
             "please use a mask with dtype torch.bool instead.");
-    legacy::cuda::_th_masked_fill_(self, mask, value);
+    legacy::cuda::_th_masked_fill_(self, b_mask, value);
   } else {
-    legacy::cuda::_th_masked_fill_bool_(self, mask, value);
+    legacy::cuda::_th_masked_fill_bool_(self, b_mask, value);
   }
   namedinference::propagate_names_if_nonempty(self, maybe_outnames);
   return self;
@@ -27,28 +30,32 @@ Tensor & masked_fill__cuda(Tensor& self, const Tensor & mask, const Tensor & val
 
   TORCH_CHECK(value.dim() == 0, "masked_fill_ only supports a 0-dimensional value tensor, but got tensor "
       "with ", value.dim(), " dimension(s).");
+  Tensor b_mask;
+  std::tie(b_mask) = expand_inplace(self, mask, "masked_fill_");
   // As we dispatch on self and TH is type-checked, we need different definitions.
   // This can be fixed by moving to ATen.
-  if (mask.dtype() == at::ScalarType::Byte) {
+  if (b_mask.dtype() == at::ScalarType::Byte) {
     AT_WARN("masked_fill_ received a mask with dtype torch.uint8, this behavior is now deprecated," \
             "please use a mask with dtype torch.bool instead.");
-    legacy::cuda::_th_masked_fill_(self, mask, value.item());
+    legacy::cuda::_th_masked_fill_(self, b_mask, value.item());
   } else {
-    legacy::cuda::_th_masked_fill_bool_(self, mask, value.item());
+    legacy::cuda::_th_masked_fill_bool_(self, b_mask, value.item());
   }
   namedinference::propagate_names_if_nonempty(self, maybe_outnames);
   return self;
 }
 
 Tensor & masked_scatter__cuda(Tensor& self, const Tensor & mask, const Tensor & source) {
+  Tensor b_mask;
+  std::tie(b_mask) = expand_inplace(self, mask, "masked_scatter_");
   // As we dispatch on self and TH is type-checked, we need different definitions.
   // This can be fixed by moving to ATen.
-  if (mask.dtype() == at::ScalarType::Byte) {
+  if (b_mask.dtype() == at::ScalarType::Byte) {
     AT_WARN("masked_scatter_ received a mask with dtype torch.uint8, this behavior is now deprecated," \
             "please use a mask with dtype torch.bool instead.");
-    return legacy::cuda::_th_masked_scatter_(self, mask, source);
+    return legacy::cuda::_th_masked_scatter_(self, b_mask, source);
   } else {
-    return legacy::cuda::_th_masked_scatter_bool_(self, mask, source);
+    return legacy::cuda::_th_masked_scatter_bool_(self, b_mask, source);
   }
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#32982 Move some broadcasting logic away from codegen.**
* #32981 Kill _th_max, _th_min overloads that aren't used.

For masked_scatter_ and masked_fill_ (which already have manually written wrappers), move the broadcasting logic into the manually written wrappers.

Differential Revision: [D19726830](https://our.internmc.facebook.com/intern/diff/D19726830)