### PR TITLE
Properly update _flat_weights in RNN models

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -5752,7 +5752,7 @@ class TestNN(NNTestCase):
         # does not throw an error
         m.cuda()
         # recompute the weight and make sure that module can be used
-        setattr(m, "weight_hh_l0", weight_orig.cuda())
+        m.weight_hh_l0 = weight_orig.cuda()
         inp = inp.cuda()
         # otherwise, subsequent warnings will be hidden, and further tests rely on them
         warnings.simplefilter("always")

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -5741,13 +5741,23 @@ class TestNN(NNTestCase):
         hidden_size = 6
         num_layers = 2
 
-        # creates an RNN (LSTM) and deletes an attribute
         m = nn.LSTM(input_size, hidden_size, num_layers)
+        inp = torch.randn(3, 2, 10)
+        out_expected = m(inp)
+        # deletes an attribute of original LSTM
+        weight_orig = m.weight_hh_l0
         del m.weight_hh_l0
-
+        self.assertFalse(hasattr(m, "weight_hh_l0"))
         # verifies that moving to CUDA with only some attributes defined
         # does not throw an error
         m.cuda()
+        # recompute the weight and make sure that module can be used
+        setattr(m, "weight_hh_l0", weight_orig.cuda())
+        inp = inp.cuda()
+        # otherwise, subsequent warnings will be hidden, and further tests rely on them
+        warnings.simplefilter("always")
+        self.assertEqual(m(inp)[0].cpu(), out_expected[0])
+
 
     @unittest.skipIf(not (TEST_CUDNN and (TEST_CUDNN_VERSION if TEST_CUDNN_VERSION else 0) >= 5103), "needs cudnn >= 5.1")
     def test_RNN_dropout(self):

--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -85,7 +85,7 @@ class RNNBase(Module):
                 self._flat_weights_names.extend(param_names)
                 self._all_weights.append(param_names)
 
-        self._flat_weights = [getattr(self, weight) for weight in self._flat_weights_names if hasattr(self, weight)]
+        self._flat_weights = [(lambda wn: getattr(self, wn) if hasattr(self, wn) else None)(wn) for wn in self._flat_weights_names]
         self.flatten_parameters()
         self.reset_parameters()
 
@@ -106,11 +106,13 @@ class RNNBase(Module):
         if len(self._flat_weights) != len(self._flat_weights_names):
             return
 
+        for w in self._flat_weights:
+            if not torch.is_tensor(w):
+                return
         # Short-circuits if any tensor in self._flat_weights is not acceptable to cuDNN
         # or the tensors in _flat_weights are of different dtypes
-        first_fw = self._flat_weights[0].data
-        if not torch.is_tensor(first_fw):
-            return
+
+        first_fw = self._flat_weights[0]
         dtype = first_fw.dtype
         for fw in self._flat_weights:
             if (not torch.is_tensor(fw.data) or not (fw.data.dtype == dtype) or
@@ -143,8 +145,7 @@ class RNNBase(Module):
         # Resets _flat_weights
         # Note: be v. careful before removing this, as 3rd party device types
         # likely rely on this behavior to properly .to() modules like LSTM.
-        self._flat_weights = [getattr(self, weight) for weight in self._flat_weights_names if hasattr(self, weight)]
-
+        self._flat_weights = [(lambda wn: getattr(self, wn) if hasattr(self, wn) else None)(wn) for wn in self._flat_weights_names]
         # Flattens params (on CUDA)
         self.flatten_parameters()
 
@@ -270,7 +271,7 @@ class RNNBase(Module):
                 else:
                     self._all_weights += [weights[:2]]
                     self._flat_weights_names.extend(weights[:2])
-        self._flat_weights = [getattr(self, weight) for weight in self._flat_weights_names if hasattr(self, weight)]
+        self._flat_weights = [(lambda wn: getattr(self, wn) if hasattr(self, wn) else None)(wn) for wn in self._flat_weights_names]
 
     @property
     def all_weights(self):


### PR DESCRIPTION
Resubmitting #32939
Should fix #32346 hopefully. Now when _flat_weights list is updated, None elements are appended to it if some weights are missing, subsequent setattr calls for the missing weights should repair _flat_weights and make it suitable to use in the backend.