### PR TITLE
Workaround NVCC+MSVC static constexpr bug

### DIFF
--- a/torch/csrc/jit/argument_spec.cpp
+++ b/torch/csrc/jit/argument_spec.cpp
@@ -26,7 +26,7 @@ void ArgumentSpecCreator::scan(
   };
   // the simple vm that scans instructions_ has a limited stack depth,
   // this prevents going deeper than that.
-  if (depth >= DEPTH_LIMIT) {
+  if (depth >= ARG_SPEC_DEPTH_LIMIT) {
     instructions_.emplace_back(SKIP);
   }
   if (typ->isSubtypeOf(TensorType::get())) {
@@ -130,7 +130,7 @@ void ArgumentSpecCreator::dump() const {
 ArgumentSpec ArgumentSpecCreator::create(bool with_grad, const Stack& input)
     const {
   ArgumentSpec spec(num_tensors_, num_optionals_);
-  const IValue* stack[DEPTH_LIMIT]; // The stack of IValue lists
+  const IValue* stack[ARG_SPEC_DEPTH_LIMIT]; // The stack of IValue lists
   // The stack gets initialized with the input list
   stack[0] = last(input, num_inputs_).begin();
   size_t stack_top = 0; // offset to the top of the stack

--- a/torch/csrc/jit/argument_spec.h
+++ b/torch/csrc/jit/argument_spec.h
@@ -157,6 +157,10 @@ struct ArgumentSpec {
   std::vector<bool> optional_presence;
 };
 
+namespace {
+static constexpr size_t ARG_SPEC_DEPTH_LIMIT = 128;
+}
+
 // ArgumentSpecCreator takes an initial graph and comes up with a set
 // of simple instructions to compute the ArgumentSpec given a set of
 // input tensors.
@@ -187,7 +191,6 @@ struct TORCH_API ArgumentSpecCreator {
   using WrittenSlots = std::unordered_set<std::string>;
 
  private:
-  static constexpr size_t DEPTH_LIMIT = 128;
   void scan(
       const TypePtr& typ,
       size_t depth,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#33002 Attempt to workaround MSVC17 static constexpr bug**

See also https://github.com/pytorch/extension-cpp/issues/37

Differential Revision: [D19739097](https://our.internmc.facebook.com/intern/diff/D19739097)