### PR TITLE
[2/3] Bind Bucketize to PyTorch

### DIFF
--- a/caffe2/operators/bucketize_op.cc
+++ b/caffe2/operators/bucketize_op.cc
@@ -68,3 +68,10 @@ output = [[1, 2], [2, 1], [1, 2]]
 
 NO_GRADIENT(BucketizeOp);
 } // namespace caffe2
+
+using BucketizeInt = caffe2::BucketizeOp<int, caffe2::CPUContext>;
+
+C10_EXPORT_CAFFE2_OP_TO_C10_CPU(
+    Bucketize,
+    "_caffe2::Bucketize(Tensor data, float[] boundaries) -> Tensor output",
+    BucketizeInt);

--- a/caffe2/operators/bucketize_op.h
+++ b/caffe2/operators/bucketize_op.h
@@ -4,9 +4,12 @@
 #define CAFFE2_OPERATORS_BUCKETIZE_OP_H_
 
 #include "caffe2/core/context.h"
+#include "caffe2/core/export_caffe2_op_to_c10.h"
 #include "caffe2/core/logging.h"
 #include "caffe2/core/operator.h"
 #include "caffe2/utils/math.h"
+
+C10_DECLARE_EXPORT_CAFFE2_OP_TO_C10(BucketizeOp);
 
 namespace caffe2 {
 
@@ -14,8 +17,10 @@ template <typename T, class Context>
 class BucketizeOp final : public Operator<Context> {
  public:
   USE_OPERATOR_CONTEXT_FUNCTIONS;
-  BucketizeOp(const OperatorDef& operator_def, Workspace* ws)
-      : Operator<Context>(operator_def, ws),
+
+  template <class... Args>
+  explicit BucketizeOp(Args&&... args)
+      : Operator<Context>(std::forward<Args>(args)...),
         boundaries_(this->template GetRepeatedArgument<float>("boundaries")) {
     CAFFE_ENFORCE(
         std::is_sorted(boundaries_.begin(), boundaries_.end()),

--- a/caffe2/python/operator_test/torch_integration_test.py
+++ b/caffe2/python/operator_test/torch_integration_test.py
@@ -804,6 +804,24 @@ class TorchIntegration(hu.HypothesisTestCase):
 
         torch.testing.assert_allclose(expected_output, actual_output.cpu())
 
+    def test_bucketize_op(self):
+        data = np.random.rand(8, 10).astype(np.float32) * 1000
+        boundaries = np.array([1, 10, 100, 1000, 100000]).astype(np.float32)
+
+        def _bucketize_ref(X):
+            ref_op = core.CreateOperator(
+                "Bucketize", ["X"], ["Y"], boundaries=boundaries
+            )
+            workspace.FeedBlob("X", X)
+            workspace.RunOperatorOnce(ref_op)
+            return workspace.FetchBlob("Y")
+
+        expected_output = _bucketize_ref(data)
+        actual_output = torch.ops._caffe2.Bucketize(
+            torch.tensor(data), boundaries
+        )
+        torch.testing.assert_allclose(expected_output, actual_output.cpu())
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Summary: Export Bucketize to PyTorch.

Test Plan: buck test caffe2/caffe2/python/operator_test:torch_integration_test

Differential Revision: D19737534

