### PR TITLE
[1/3] Bind IndexHash to PyTorch

### DIFF
--- a/caffe2/operators/index_hash_ops.cc
+++ b/caffe2/operators/index_hash_ops.cc
@@ -31,3 +31,8 @@ SHOULD_NOT_DO_GRADIENT(IndexHash);
 
 } // namespace
 } // namespace caffe2
+
+C10_EXPORT_CAFFE2_OP_TO_C10_CPU(
+    IndexHash,
+    "_caffe2::IndexHash(Tensor indices, int seed, int modulo) -> Tensor hashed_indices",
+    caffe2::IndexHashOp<caffe2::CPUContext>);

--- a/caffe2/operators/index_hash_ops.h
+++ b/caffe2/operators/index_hash_ops.h
@@ -2,8 +2,11 @@
 #define CAFFE2_OPERATORS_INDEX_HASH_OPS_H_
 
 #include "caffe2/core/asan.h"
+#include "caffe2/core/export_caffe2_op_to_c10.h"
 #include "caffe2/core/logging.h"
 #include "caffe2/core/operator.h"
+
+C10_DECLARE_EXPORT_CAFFE2_OP_TO_C10(IndexHash);
 
 namespace caffe2 {
 
@@ -49,7 +52,8 @@ class IndexHashOp : public Operator<Context> {
 
  protected:
   template <typename T>
-  CAFFE2_NO_SANITIZE("signed-integer-overflow") T hash(T id) {
+  CAFFE2_NO_SANITIZE("signed-integer-overflow")
+  T hash(T id) {
     int8_t* bytes = (int8_t*)&id;
     T hashed = seed_ * 0xDEADBEEF;
     for (int i = 0; i < sizeof(T) / sizeof(int8_t); i++) {


### PR DESCRIPTION
Summary: Export IndexHash to PyTorch

Test Plan:
buck test caffe2/caffe2/python/operator_test:torch_integration_test

      ✓ caffe2/caffe2/python/operator_test:torch_integration_test-2.7 - test_index_hash_op (caffe2.caffe2.python.operator_test.torch_integration_test.TorchIntegration) 0.151 44/50 (passed)

Differential Revision: D19727301

