### PR TITLE
Preserve Lengths Device in `pack_padded_sequence`

### DIFF
--- a/torch/nn/utils/rnn.py
+++ b/torch/nn/utils/rnn.py
@@ -220,7 +220,7 @@ def pack_padded_sequence(input, lengths, batch_first=False, enforce_sorted=True)
                       'values, and it will treat them as constants, likely rendering '
                       'the trace incorrect for any other combination of lengths.',
                       stacklevel=2)
-    lengths = torch.as_tensor(lengths, dtype=torch.int64)
+    lengths = torch.as_tensor(lengths, dtype=torch.int64, device=lengths.device)
     if enforce_sorted:
         sorted_indices = None
     else:


### PR DESCRIPTION
If the default tensor type is cuda, and this function gets called, it will internally move `lengths` from cpu to cuda, which the function subsequently complains about.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pytorch/pytorch/33032)
<!-- Reviewable:end -->
