### PR TITLE
fix #30480 torch.normal shape checking is broken (#32243)

### DIFF
--- a/aten/src/ATen/ExpandUtils.cpp
+++ b/aten/src/ATen/ExpandUtils.cpp
@@ -2,6 +2,7 @@
 
 namespace at {
 
+// NOTE: are_expandable did a similar check, please keep them sync if change is needed
 std::vector<int64_t> infer_size(IntArrayRef a, IntArrayRef b) {
   size_t dimsA = a.size();
   size_t dimsB = b.size();

--- a/aten/src/ATen/ExpandUtils.cpp
+++ b/aten/src/ATen/ExpandUtils.cpp
@@ -9,6 +9,7 @@ std::vector<int64_t> infer_size(IntArrayRef a, IntArrayRef b) {
   std::vector<int64_t> expandedSizes(ndim);
 
   // Use ptrdiff_t to ensure signed comparison.
+  // NOTE: are_expandable did a similar check, please keep them sync if change is needed
   for (ptrdiff_t i = (ptrdiff_t)ndim - 1; i >= 0; --i) {
     ptrdiff_t offset = ndim - 1 - i;
     ptrdiff_t dimA = dimsA - 1 - offset;

--- a/aten/src/ATen/ExpandUtils.cpp
+++ b/aten/src/ATen/ExpandUtils.cpp
@@ -9,7 +9,6 @@ std::vector<int64_t> infer_size(IntArrayRef a, IntArrayRef b) {
   std::vector<int64_t> expandedSizes(ndim);
 
   // Use ptrdiff_t to ensure signed comparison.
-  // NOTE: are_expandable did a similar check, please keep them sync if change is needed
   for (ptrdiff_t i = (ptrdiff_t)ndim - 1; i >= 0; --i) {
     ptrdiff_t offset = ndim - 1 - i;
     ptrdiff_t dimA = dimsA - 1 - offset;

--- a/aten/src/ATen/ExpandUtils.h
+++ b/aten/src/ATen/ExpandUtils.h
@@ -16,6 +16,22 @@ inferExpandGeometry(
     IntArrayRef tensor_strides,
     IntArrayRef sizes);
 
+// True if input shapes are expandable
+// NOTE: infer_size did a similar check, please keep them sync if change is needed
+inline bool are_expandable(IntArrayRef shape1, IntArrayRef shape2) {
+  size_t ndim1 = shape1.size();
+  size_t ndim2 = shape2.size();
+  size_t ndim = ndim1 < ndim2 ? ndim1 : ndim2;
+
+  for (int64_t i = ndim - 1; i >= 0; --i) {
+    if (shape1[--ndim1] == shape2[--ndim2] || shape1[ndim1] == 1 || shape2[ndim2] == 1) {
+      continue;
+    }
+    return false;
+  }
+  return true;
+}
+
 // avoid copy-construction of Tensor by using a reference_wrapper.
 inline void check_defined(std::initializer_list<std::reference_wrapper<const Tensor>> tensors, const char *api_name) {
   for (auto& t : tensors) {

--- a/aten/src/ATen/ExpandUtils.h
+++ b/aten/src/ATen/ExpandUtils.h
@@ -16,6 +16,22 @@ inferExpandGeometry(
     IntArrayRef tensor_strides,
     IntArrayRef sizes);
 
+// True if input shapes are expandable
+// NOTE: infer_size did a similar check, please keep them sync if change is needed
+static inline bool are_expandable(IntArrayRef shape1, IntArrayRef shape2) {
+  size_t ndim1 = shape1.size();
+  size_t ndim2 = shape2.size();
+  size_t ndim = ndim1 < ndim2 ? ndim1 : ndim2;
+
+  for (int64_t i = ndim - 1; i >= 0; --i) {
+    if (shape1[--ndim1] == shape2[--ndim2] || shape1[ndim1] == 1 || shape2[ndim2] == 1) {
+      continue;
+    }
+    return false;
+  }
+  return true;
+}
+
 // avoid copy-construction of Tensor by using a reference_wrapper.
 inline void check_defined(std::initializer_list<std::reference_wrapper<const Tensor>> tensors, const char *api_name) {
   for (auto& t : tensors) {

--- a/aten/src/ATen/ExpandUtils.h
+++ b/aten/src/ATen/ExpandUtils.h
@@ -16,22 +16,6 @@ inferExpandGeometry(
     IntArrayRef tensor_strides,
     IntArrayRef sizes);
 
-// True if input shapes are expandable
-// NOTE: infer_size did a similar check, please keep them sync if change is needed
-static inline bool are_expandable(IntArrayRef shape1, IntArrayRef shape2) {
-  size_t ndim1 = shape1.size();
-  size_t ndim2 = shape2.size();
-  size_t ndim = ndim1 < ndim2 ? ndim1 : ndim2;
-
-  for (int64_t i = ndim - 1; i >= 0; --i) {
-    if (shape1[--ndim1] == shape2[--ndim2] || shape1[ndim1] == 1 || shape2[ndim2] == 1) {
-      continue;
-    }
-    return false;
-  }
-  return true;
-}
-
 // avoid copy-construction of Tensor by using a reference_wrapper.
 inline void check_defined(std::initializer_list<std::reference_wrapper<const Tensor>> tensors, const char *api_name) {
   for (auto& t : tensors) {

--- a/aten/src/ATen/native/Distributions.cpp
+++ b/aten/src/ATen/native/Distributions.cpp
@@ -234,6 +234,14 @@ Tensor& normal_out_cpu(Tensor& output, double mean, const Tensor& std, Generator
 }
 
 Tensor& normal_out_cpu(Tensor& output, const Tensor& mean, const Tensor& std, Generator* gen) {
+  auto shape = at::infer_size(mean.sizes(), std.sizes());
+  if (output.numel() == 0) {
+    at::native::resize_(output, shape);
+  }
+
+  TORCH_CHECK(output.sizes().equals(shape),
+    "output size (", output.sizes(), ") is not the same as broadcasted mean and std size (", shape, ")");
+
   normal_cpu_(output, 0, 1, gen);
   output.mul_(std).add_(mean);
   return output;
@@ -252,7 +260,7 @@ Tensor normal_cpu(double mean, const Tensor& std, Generator* gen) {
 }
 
 Tensor normal_cpu(const Tensor& mean, const Tensor& std, Generator* gen) {
-  Tensor ret = at::empty_like(mean, MemoryFormat::Contiguous);
+  Tensor ret = at::empty({0}, mean.options(), MemoryFormat::Contiguous);
   normal_out_cpu(ret, mean, std, gen);
   return ret;
 }

--- a/aten/src/ATen/native/Distributions.cpp
+++ b/aten/src/ATen/native/Distributions.cpp
@@ -234,16 +234,43 @@ Tensor& normal_out_cpu(Tensor& output, double mean, const Tensor& std, Generator
 }
 
 Tensor& normal_out_cpu(Tensor& output, const Tensor& mean, const Tensor& std, Generator* gen) {
-  auto shape = at::infer_size(mean.sizes(), std.sizes());
-  if (output.numel() == 0) {
-    at::native::resize_(output, shape);
+  bool expandable = are_expandable(mean.sizes(), std.sizes());
+  bool empty_output = output.numel() == 0;
+
+  if (expandable) {
+    auto shape = at::infer_size(mean.sizes(), std.sizes());
+    TORCH_CHECK(
+        empty_output || output.sizes().equals(shape),
+        "inconsistent tensor, output size (", output.sizes(), ") is not the same as broadcasted mean and std size (", shape, ")");
+    if (empty_output) {
+      at::native::resize_(output, shape);
+    }
+  }
+  else {
+    TORCH_CHECK(
+        mean.numel() == std.numel(),
+        "inconsistent tensor, std and mean are not broadcastable and have different number of elements, "
+        "expected mean ", mean.sizes(), " and std ", std.sizes(), " to have same number of elements)");
+    TORCH_CHECK(
+        empty_output || output.sizes().equals(mean.sizes()),
+        "inconsistent tensor, std and mean are not broadcastable, output size (", output.sizes(), ") is not the same as mean size (", mean.sizes(), ")");
+    TORCH_WARN_ONCE(
+        "std and mean have the same number of elements, but are not broadcastable. This was previously a "
+        "supported mode of operation, but is now deprecated and the support will be removed in a later release. "
+        "Note that the current implementation reshapes std to the shape of mean, which may be incur data copies. "
+        "Please ensure that std and mean are broadcastable to avoid these issues.");
+    if (empty_output) {
+      at::native::resize_(output, mean.sizes());
+    }
   }
 
-  TORCH_CHECK(output.sizes().equals(shape),
-    "output size (", output.sizes(), ") is not the same as broadcasted mean and std size (", shape, ")");
-
   normal_cpu_(output, 0, 1, gen);
-  output.mul_(std).add_(mean);
+  if (!expandable) {
+    output.mul_(std.reshape(mean.sizes())).add_(mean);
+  }
+  else {
+    output.mul_(std).add_(mean);
+  }
   return output;
 }
 

--- a/aten/src/ATen/native/Distributions.h
+++ b/aten/src/ATen/native/Distributions.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ATen/ATen.h>
+#include <ATen/ExpandUtils.h>
 #include <c10/macros/Macros.h>
 
 // ROCM hcc doesn't work well with using std:: in kernel functions
@@ -384,6 +385,47 @@ C10_DEVICE static inline scalar_t dirichlet_grad_one(scalar_t x, scalar_t alpha,
   }
   const accscalar_t approx = x_ * (digamma_one<scalar_t, accscalar_t>(total_) - digamma_one<scalar_t, accscalar_t>(alpha_)) / beta_;
   return static_cast<scalar_t>(p / q * approx);
+}
+
+// This function computes broadcasted size of mean and std, resize the output to the broadcasted size if it was empty
+// [Note] The following features will be deprecated in version 1.6 release and function signature will be changed after
+//   When mean and std are not broadcastable but have same number of elements:
+//     This function will resize the output to the size of mean if it was empty.
+//     This function will reshape the std to the shape of mean.
+//     This function will return true in deprecated case, false in broadcastable case and throw in all other cases before deprecation.
+//     This function will not return and throw if mean and std are not broadcastable after deprecation
+bool resize_output_for_normal(at::Tensor& output, const at::Tensor& mean, const at::Tensor& std) {
+  bool expandable = at::are_expandable(mean.sizes(), std.sizes());
+  bool empty_output = output.numel() == 0;
+
+  if (expandable) {
+    auto shape = at::infer_size(mean.sizes(), std.sizes());
+    TORCH_CHECK(
+        empty_output || output.sizes().equals(shape),
+        "inconsistent tensor, output size (", output.sizes(), ") is not the same as broadcasted mean and std size (", shape, ")");
+    if (empty_output) {
+      at::native::resize_(output, shape);
+    }
+    return false;
+  }
+  else {
+    TORCH_CHECK(
+        mean.numel() == std.numel(),
+        "inconsistent tensor, std and mean are not broadcastable and have different number of elements, "
+        "expected mean ", mean.sizes(), " and std ", std.sizes(), " to have same number of elements)");
+    TORCH_CHECK(
+        empty_output || output.sizes().equals(mean.sizes()),
+        "inconsistent tensor, std and mean are not broadcastable, output size (", output.sizes(), ") is not the same as mean size (", mean.sizes(), ")");
+    TORCH_WARN_ONCE(
+        "std and mean have the same number of elements, but are not broadcastable. This was previously a "
+        "supported mode of operation, but is now deprecated and the support will be removed in version 1.6 release. "
+        "Note that the current implementation reshapes std to the shape of mean, which may be incur data copies. "
+        "Please ensure that std and mean are broadcastable to avoid these issues.");
+    if (empty_output) {
+      at::native::resize_(output, mean.sizes());
+    }
+    return true;
+  }
 }
 
 } // namespace

--- a/aten/src/ATen/native/cuda/Distributions.cu
+++ b/aten/src/ATen/native/cuda/Distributions.cu
@@ -730,48 +730,21 @@ Tensor& normal_out_cuda(Tensor& output, double mean, const Tensor& std, Generato
 }
 
 Tensor& normal_out_cuda(Tensor& output, const Tensor& mean, const Tensor& std, Generator* gen) {
-  bool expandable = are_expandable(mean.sizes(), std.sizes());
-  bool empty_output = output.numel() == 0;
-
-  if (expandable) {
-    auto shape = at::infer_size(mean.sizes(), std.sizes());
-    TORCH_CHECK(
-        empty_output || output.sizes().equals(shape),
-        "inconsistent tensor, output size (", output.sizes(), ") is not the same as broadcasted mean and std size (", shape, ")");
-    if (empty_output) {
-      at::native::resize_(output, shape);
-    }
-  }
-  else {
-    TORCH_CHECK(
-        mean.numel() == std.numel(),
-        "inconsistent tensor, std and mean are not broadcastable and have different number of elements, "
-        "expected mean ", mean.sizes(), " and std ", std.sizes(), " to have same number of elements)");
-    TORCH_CHECK(
-        empty_output || output.sizes().equals(mean.sizes()),
-        "inconsistent tensor, std and mean are not broadcastable, output size (", output.sizes(), ") is not the same as mean size (", mean.sizes(), ")");
-    TORCH_WARN_ONCE(
-        "std and mean have the same number of elements, but are not broadcastable. This was previously a "
-        "supported mode of operation, but is now deprecated and the support will be removed in a later release. "
-        "Note that the current implementation reshapes std to the shape of mean, which may be incur data copies. "
-        "Please ensure that std and mean are broadcastable to avoid these issues.");
-    if (empty_output) {
-      at::native::resize_(output, mean.sizes());
-    }
+  auto shape = at::infer_size(mean.sizes(), std.sizes());
+  if (output.numel() == 0) {
+    at::native::resize_(output, shape);    
   }
 
+  TORCH_CHECK(output.sizes().equals(shape), 
+    "output size (", output.sizes(), ") is not the same as broadcasted mean and std size (", shape, ")");
+  
   normal_cuda_(output, 0, 1, gen);
   // NB: addcmul_out copies the tensor to be added into the output.
   // Please look at aten/src/THC/generic/THCTensorMathPointwise.cu
   // The previous function here was addcmul_out(output, mean, output, std, 1);
   // The third argument is not a constant reference and hence the samples in output are overwritten.
   // Consequently, the computation performed is mean + mean * std instead of mean + output * std
-  if (!expandable) {
-    output.mul_(std.reshape(mean.sizes())).add_(mean);
-  }
-  else {
-    output.mul_(std).add_(mean);
-  }
+  output.mul_(std).add_(mean);
   return output;
 }
 

--- a/aten/src/ATen/native/cuda/Distributions.cu
+++ b/aten/src/ATen/native/cuda/Distributions.cu
@@ -730,21 +730,48 @@ Tensor& normal_out_cuda(Tensor& output, double mean, const Tensor& std, Generato
 }
 
 Tensor& normal_out_cuda(Tensor& output, const Tensor& mean, const Tensor& std, Generator* gen) {
-  auto shape = at::infer_size(mean.sizes(), std.sizes());
-  if (output.numel() == 0) {
-    at::native::resize_(output, shape);    
+  bool expandable = are_expandable(mean.sizes(), std.sizes());
+  bool empty_output = output.numel() == 0;
+
+  if (expandable) {
+    auto shape = at::infer_size(mean.sizes(), std.sizes());
+    TORCH_CHECK(
+        empty_output || output.sizes().equals(shape),
+        "inconsistent tensor, output size (", output.sizes(), ") is not the same as broadcasted mean and std size (", shape, ")");
+    if (empty_output) {
+      at::native::resize_(output, shape);
+    }
+  }
+  else {
+    TORCH_CHECK(
+        mean.numel() == std.numel(),
+        "inconsistent tensor, std and mean are not broadcastable and have different number of elements, "
+        "expected mean ", mean.sizes(), " and std ", std.sizes(), " to have same number of elements)");
+    TORCH_CHECK(
+        empty_output || output.sizes().equals(mean.sizes()),
+        "inconsistent tensor, std and mean are not broadcastable, output size (", output.sizes(), ") is not the same as mean size (", mean.sizes(), ")");
+    TORCH_WARN_ONCE(
+        "std and mean have the same number of elements, but are not broadcastable. This was previously a "
+        "supported mode of operation, but is now deprecated and the support will be removed in a later release. "
+        "Note that the current implementation reshapes std to the shape of mean, which may be incur data copies. "
+        "Please ensure that std and mean are broadcastable to avoid these issues.");
+    if (empty_output) {
+      at::native::resize_(output, mean.sizes());
+    }
   }
 
-  TORCH_CHECK(output.sizes().equals(shape), 
-    "output size (", output.sizes(), ") is not the same as broadcasted mean and std size (", shape, ")");
-  
   normal_cuda_(output, 0, 1, gen);
   // NB: addcmul_out copies the tensor to be added into the output.
   // Please look at aten/src/THC/generic/THCTensorMathPointwise.cu
   // The previous function here was addcmul_out(output, mean, output, std, 1);
   // The third argument is not a constant reference and hence the samples in output are overwritten.
   // Consequently, the computation performed is mean + mean * std instead of mean + output * std
-  output.mul_(std).add_(mean);
+  if (!expandable) {
+    output.mul_(std.reshape(mean.sizes())).add_(mean);
+  }
+  else {
+    output.mul_(std).add_(mean);
+  }
   return output;
 }
 

--- a/aten/src/ATen/native/cuda/Distributions.cu
+++ b/aten/src/ATen/native/cuda/Distributions.cu
@@ -730,43 +730,14 @@ Tensor& normal_out_cuda(Tensor& output, double mean, const Tensor& std, Generato
 }
 
 Tensor& normal_out_cuda(Tensor& output, const Tensor& mean, const Tensor& std, Generator* gen) {
-  bool expandable = are_expandable(mean.sizes(), std.sizes());
-  bool empty_output = output.numel() == 0;
-
-  if (expandable) {
-    auto shape = at::infer_size(mean.sizes(), std.sizes());
-    TORCH_CHECK(
-        empty_output || output.sizes().equals(shape),
-        "inconsistent tensor, output size (", output.sizes(), ") is not the same as broadcasted mean and std size (", shape, ")");
-    if (empty_output) {
-      at::native::resize_(output, shape);
-    }
-  }
-  else {
-    TORCH_CHECK(
-        mean.numel() == std.numel(),
-        "inconsistent tensor, std and mean are not broadcastable and have different number of elements, "
-        "expected mean ", mean.sizes(), " and std ", std.sizes(), " to have same number of elements)");
-    TORCH_CHECK(
-        empty_output || output.sizes().equals(mean.sizes()),
-        "inconsistent tensor, std and mean are not broadcastable, output size (", output.sizes(), ") is not the same as mean size (", mean.sizes(), ")");
-    TORCH_WARN_ONCE(
-        "std and mean have the same number of elements, but are not broadcastable. This was previously a "
-        "supported mode of operation, but is now deprecated and the support will be removed in a later release. "
-        "Note that the current implementation reshapes std to the shape of mean, which may be incur data copies. "
-        "Please ensure that std and mean are broadcastable to avoid these issues.");
-    if (empty_output) {
-      at::native::resize_(output, mean.sizes());
-    }
-  }
-
+  bool is_deprecated_th_impl = resize_output_for_normal(output, mean, std);
   normal_cuda_(output, 0, 1, gen);
   // NB: addcmul_out copies the tensor to be added into the output.
   // Please look at aten/src/THC/generic/THCTensorMathPointwise.cu
   // The previous function here was addcmul_out(output, mean, output, std, 1);
   // The third argument is not a constant reference and hence the samples in output are overwritten.
   // Consequently, the computation performed is mean + mean * std instead of mean + output * std
-  if (!expandable) {
+  if (is_deprecated_th_impl) {
     output.mul_(std.reshape(mean.sizes())).add_(mean);
   }
   else {

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -5307,6 +5307,59 @@ tensor([[[1., 1., 1.,  ..., 1., 1., 1.],
             foo = dummy.grad
             self.assertEqual(len(w), 1)
 
+    def test_normal_shape(self):
+        for device in torch.testing.get_all_device_types():
+            tensor1 = torch.rand(1, device=device)
+            tensor4 = torch.rand(4, device=device)
+            tensor120 = torch.rand(120, device=device)
+            tensor2145 = torch.rand(2, 1, 4, 5, device=device)
+            tensor2345 = torch.rand(2, 3, 4, 5, device=device)
+            tensor2345_non_contiguous = torch.rand(2, 4, 3, 5, device=device).permute(0, 2, 1, 3)
+            tensor2345_channels_last = tensor2345.contiguous(memory_format=torch.channels_last)
+            output2345 = torch.zeros(2, 3, 4, 5, device=device)
+            output345 = torch.zeros(3, 4, 5, device=device)
+
+            # inputs have same size
+            self.assertEqual(torch.normal(tensor2345, tensor2345).size(), (2, 3, 4, 5))
+            self.assertEqual(torch.normal(tensor2345_non_contiguous, tensor2345).size(), (2, 3, 4, 5))
+            self.assertEqual(torch.normal(tensor2345, tensor2345_channels_last).size(), (2, 3, 4, 5))
+            self.assertEqual(torch.normal(tensor2345_non_contiguous, tensor2345_channels_last).size(), (2, 3, 4, 5))
+
+            # scalar case
+            self.assertEqual(torch.normal(tensor2345, 2).size(), (2, 3, 4, 5))
+            self.assertEqual(torch.normal(2, tensor2345).size(), (2, 3, 4, 5))
+
+            # inputs are expandable tensors
+            if device == 'cpu':
+                # CPU version is written in legacy code (TH), it doesn't support broadcasting
+                with self.assertRaisesRegex(RuntimeError, "inconsistent tensor"):
+                    torch.normal(tensor2345, tensor2145)
+            else:
+                self.assertEqual(torch.normal(tensor2345, tensor1).size(), (2, 3, 4, 5))
+                self.assertEqual(torch.normal(tensor2145, tensor2345).size(), (2, 3, 4, 5))
+
+            # inputs are non-expandable tensors, but they have same number of elements
+            self.assertEqual(torch.normal(tensor120, tensor2345).size(), (120,))
+            self.assertEqual(torch.normal(tensor2345, tensor120).size(), (2, 3, 4, 5))
+
+            # inputs are non-expandable tensors and they don't have same number of elements
+            with self.assertRaisesRegex(RuntimeError, "inconsistent tensor"):
+                torch.normal(tensor2345, tensor4)
+
+            # output and inputs are size compatible
+            self.assertEqual(torch.normal(tensor2345, tensor2345, out=output2345).size(), (2, 3, 4, 5))
+
+            # output and inputs are not size compatible
+            # CUDA only since CPU version is written in legacy TH, it doesn't care about the size compatible
+            if device == 'cuda':
+                with self.assertRaisesRegex(RuntimeError, "inconsistent tensor"):
+                    # inputs are expandable but have different broadcasted size than output
+                    torch.normal(tensor2345, tensor2145, out=output345)
+                with self.assertRaisesRegex(RuntimeError, "inconsistent tensor"):
+                    # inputs are not expandable but reshapeable, output size is not the same as mean
+                    torch.normal(tensor2345, tensor120, out=output345)
+
+
 # Functions to test negative dimension wrapping
 METHOD = 1
 INPLACE_METHOD = 2

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -5330,34 +5330,27 @@ tensor([[[1., 1., 1.,  ..., 1., 1., 1.],
             self.assertEqual(torch.normal(2, tensor2345).size(), (2, 3, 4, 5))
 
             # inputs are expandable tensors
-            if device == 'cpu':
-                # CPU version is written in legacy code (TH), it doesn't support broadcasting
-                with self.assertRaisesRegex(RuntimeError, "inconsistent tensor"):
-                    torch.normal(tensor2345, tensor2145)
-            else:
-                self.assertEqual(torch.normal(tensor2345, tensor1).size(), (2, 3, 4, 5))
-                self.assertEqual(torch.normal(tensor2145, tensor2345).size(), (2, 3, 4, 5))
+            self.assertEqual(torch.normal(tensor2345, tensor1).size(), (2, 3, 4, 5))
+            self.assertEqual(torch.normal(tensor2145, tensor2345).size(), (2, 3, 4, 5))
 
-            # inputs are non-expandable tensors, but they have same number of elements
-            self.assertEqual(torch.normal(tensor120, tensor2345).size(), (120,))
-            self.assertEqual(torch.normal(tensor2345, tensor120).size(), (2, 3, 4, 5))
-
-            # inputs are non-expandable tensors and they don't have same number of elements
-            with self.assertRaisesRegex(RuntimeError, "inconsistent tensor"):
+            # inputs are non-expandable tensors
+            with self.assertRaisesRegex(RuntimeError, "must match the size"):
+                self.assertEqual(torch.normal(tensor120, tensor2345).size(), (120,))
+            with self.assertRaisesRegex(RuntimeError, "must match the size"):
+                self.assertEqual(torch.normal(tensor2345, tensor120).size(), (2, 3, 4, 5))
+            with self.assertRaisesRegex(RuntimeError, "must match the size"):
                 torch.normal(tensor2345, tensor4)
 
             # output and inputs are size compatible
             self.assertEqual(torch.normal(tensor2345, tensor2345, out=output2345).size(), (2, 3, 4, 5))
 
             # output and inputs are not size compatible
-            # CUDA only since CPU version is written in legacy TH, it doesn't care about the size compatible
-            if device == 'cuda':
-                with self.assertRaisesRegex(RuntimeError, "inconsistent tensor"):
-                    # inputs are expandable but have different broadcasted size than output
-                    torch.normal(tensor2345, tensor2145, out=output345)
-                with self.assertRaisesRegex(RuntimeError, "inconsistent tensor"):
-                    # inputs are not expandable but reshapeable, output size is not the same as mean
-                    torch.normal(tensor2345, tensor120, out=output345)
+            with self.assertRaisesRegex(RuntimeError, "not the same as broadcasted"):
+                # inputs are expandable but have different broadcasted size than output
+                torch.normal(tensor2345, tensor2145, out=output345)
+            with self.assertRaisesRegex(RuntimeError, "must match the size"):
+                # inputs are not expandable
+                torch.normal(tensor2345, tensor120, out=output345)
 
 
 # Functions to test negative dimension wrapping

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -5334,7 +5334,10 @@ tensor([[[1., 1., 1.,  ..., 1., 1., 1.],
             self.assertEqual(torch.normal(tensor2145, tensor2345).size(), (2, 3, 4, 5))
 
             # inputs are non-expandable tensors, but they have same number of elements
-            self.assertEqual(torch.normal(tensor120, tensor2345).size(), (120,))
+            # TORCH_WARN_ONCE is used in torch.normal, only 1st assertEqual will show warn msg
+            self.assertWarnsRegex(
+                    lambda: self.assertEqual(torch.normal(tensor120, tensor2345).size(), (120,)),
+                    "deprecated and the support will be removed")
             self.assertEqual(torch.normal(tensor2345, tensor120).size(), (2, 3, 4, 5))
 
             # inputs are non-expandable tensors and they don't have same number of elements

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -5336,8 +5336,8 @@ tensor([[[1., 1., 1.,  ..., 1., 1., 1.],
             # inputs are non-expandable tensors, but they have same number of elements
             # TORCH_WARN_ONCE is used in torch.normal, only 1st assertEqual will show warn msg
             self.assertWarnsRegex(
-                    lambda: self.assertEqual(torch.normal(tensor120, tensor2345).size(), (120,)),
-                    "deprecated and the support will be removed")
+                lambda: self.assertEqual(torch.normal(tensor120, tensor2345).size(), (120,)),
+                "deprecated and the support will be removed")
             self.assertEqual(torch.normal(tensor2345, tensor120).size(), (2, 3, 4, 5))
 
             # inputs are non-expandable tensors and they don't have same number of elements

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -5333,23 +5333,23 @@ tensor([[[1., 1., 1.,  ..., 1., 1., 1.],
             self.assertEqual(torch.normal(tensor2345, tensor1).size(), (2, 3, 4, 5))
             self.assertEqual(torch.normal(tensor2145, tensor2345).size(), (2, 3, 4, 5))
 
-            # inputs are non-expandable tensors
-            with self.assertRaisesRegex(RuntimeError, "must match the size"):
-                self.assertEqual(torch.normal(tensor120, tensor2345).size(), (120,))
-            with self.assertRaisesRegex(RuntimeError, "must match the size"):
-                self.assertEqual(torch.normal(tensor2345, tensor120).size(), (2, 3, 4, 5))
-            with self.assertRaisesRegex(RuntimeError, "must match the size"):
+            # inputs are non-expandable tensors, but they have same number of elements
+            self.assertEqual(torch.normal(tensor120, tensor2345).size(), (120,))
+            self.assertEqual(torch.normal(tensor2345, tensor120).size(), (2, 3, 4, 5))
+
+            # inputs are non-expandable tensors and they don't have same number of elements
+            with self.assertRaisesRegex(RuntimeError, "inconsistent tensor"):
                 torch.normal(tensor2345, tensor4)
 
             # output and inputs are size compatible
             self.assertEqual(torch.normal(tensor2345, tensor2345, out=output2345).size(), (2, 3, 4, 5))
 
             # output and inputs are not size compatible
-            with self.assertRaisesRegex(RuntimeError, "not the same as broadcasted"):
+            with self.assertRaisesRegex(RuntimeError, "inconsistent tensor"):
                 # inputs are expandable but have different broadcasted size than output
                 torch.normal(tensor2345, tensor2145, out=output345)
-            with self.assertRaisesRegex(RuntimeError, "must match the size"):
-                # inputs are not expandable
+            with self.assertRaisesRegex(RuntimeError, "inconsistent tensor"):
+                # inputs are not expandable but reshapeable, output size is not the same as mean
                 torch.normal(tensor2345, tensor120, out=output345)
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#33050 fix #30480 torch.normal shape checking is broken (#32243)**

Summary:
Following what @gchanan proposed in #30480

If the (logical) shapes of mean and std are broadcastable, we broadcast them for the output
If the (logical) shapes of mean and std are not broadcastable and they have the same number of elements, we fall back to the old behavior (pick the shape of mean)
If the (logical) shapes of mean and std are not broadcastable and don't have the same number of elements, we error out.

Also adding backward compatible for ATen cpu version normal(). Cpu version normal() is migrated from TH to ATen recently, but lack of backward compatible support.

Differential Revision: [D19771186](https://our.internmc.facebook.com/intern/diff/D19771186)