### PR TITLE
Make CUDA OOM error a type

### DIFF
--- a/aten/src/ATen/native/cudnn/Conv.cpp
+++ b/aten/src/ATen/native/cudnn/Conv.cpp
@@ -689,7 +689,7 @@ Workspace chooseAlgorithm(
   using search = algorithm_search<perf_t>;
   try {
     return Workspace(algoPerf->memory);
-  } catch (const std::exception& e) {
+  } catch (const c10::CUDAOutOfMemoryError& e) {
 
     cudaGetLastError(); // clear OOM error
 

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -278,7 +278,7 @@ class THCCachingAllocator {
         // Note that at this point cuda_malloc_with_retry has already returned all
         // possible "cached" memory to the driver. The only remaining "cached"
         // memory is split from a larger block that is partially in-use.
-        AT_ERROR(
+        TORCH_CHECK_WITH(CUDAOutOfMemoryError, false,
           "CUDA out of memory. Tried to allocate ", format_size(alloc_size),
           " (GPU ", device, "; ",
           format_size(device_total), " total capacity; ",

--- a/c10/cuda/CUDACachingAllocator.h
+++ b/c10/cuda/CUDACachingAllocator.h
@@ -11,7 +11,7 @@
 
 namespace c10 {
 
-class C10_CUDA_API CUDAOutOfMemoryError : public Error {}
+class C10_CUDA_API CUDAOutOfMemoryError : public Error {};
 
 // Caching allocator will execute every registered callback if it unable to find
 // block inside of already allocated area.

--- a/c10/cuda/CUDACachingAllocator.h
+++ b/c10/cuda/CUDACachingAllocator.h
@@ -11,7 +11,9 @@
 
 namespace c10 {
 
-class C10_CUDA_API CUDAOutOfMemoryError : public Error {};
+class C10_CUDA_API CUDAOutOfMemoryError : public c10::Error {
+  using Error::Error;
+};
 
 // Caching allocator will execute every registered callback if it unable to find
 // block inside of already allocated area.

--- a/c10/cuda/CUDACachingAllocator.h
+++ b/c10/cuda/CUDACachingAllocator.h
@@ -11,7 +11,7 @@
 
 namespace c10 {
 
-class C10_CUDA_API CUDAOutOfMemoryError : public c10::Error {}
+class C10_CUDA_API CUDAOutOfMemoryError : public Error {}
 
 // Caching allocator will execute every registered callback if it unable to find
 // block inside of already allocated area.

--- a/c10/cuda/CUDACachingAllocator.h
+++ b/c10/cuda/CUDACachingAllocator.h
@@ -11,6 +11,8 @@
 
 namespace c10 {
 
+class C10_CUDA_API CUDAOutOfMemoryError : public c10::Error {}
+
 // Caching allocator will execute every registered callback if it unable to find
 // block inside of already allocated area.
 class C10_CUDA_API FreeMemoryCallback {

--- a/c10/util/Exception.h
+++ b/c10/util/Exception.h
@@ -245,17 +245,17 @@ inline std::string if_empty_then(std::string x, std::string y) {
 // (unlike CHECK() from glog.)
 //
 #ifdef STRIP_ERROR_MESSAGES
-#define TORCH_CHECK(cond, ...)                \
+#define TORCH_CHECK_WITH(error_t, cond, ...)  \
   if (C10_UNLIKELY_OR_CONST(!(cond))) {       \
-    C10_THROW_ERROR(Error,                    \
+    C10_THROW_ERROR(error_t,                  \
         #cond " CHECK FAILED at "             \
         __FILE__                              \
     );                                        \
   }
 #else
-#define TORCH_CHECK(cond, ...)                              \
+#define TORCH_CHECK_WITH(error_t, cond, ...)                \
   if (C10_UNLIKELY_OR_CONST(!(cond))) {                     \
-    C10_THROW_ERROR(Error,                                  \
+    C10_THROW_ERROR(error_t,                                \
       ::c10::detail::if_empty_then(                         \
         ::c10::str(__VA_ARGS__),                            \
         "Expected " #cond " to be true, but got false.  "   \
@@ -265,6 +265,7 @@ inline std::string if_empty_then(std::string x, std::string y) {
     );                                                      \
   }
 #endif
+#define TORCH_CHECK(cond, ...) TORCH_CHECK_WITH(Error, cond, __VA_ARGS__)
 
 // Debug only version of TORCH_INTERNAL_ASSERT. This macro only checks in debug
 // build, and does nothing in release build.  It is appropriate to use


### PR DESCRIPTION
There are cases when we want to recover from CUDA OOM, for example, some cuDNN algorithms use huge workspace and we want to recover from OOM to pick a different algorithm, in such cases, there is no reason to catch all errors.