### PR TITLE
[jit] Minor: avoid recalculating some keys for map accesses in pickler.

### DIFF
--- a/torch/csrc/jit/pickler.cpp
+++ b/torch/csrc/jit/pickler.cpp
@@ -133,13 +133,14 @@ void Pickler::pushIValueImpl(const IValue& ivalue) {
 
 void Pickler::pushDevice(const IValue& ivalue) {
   auto device = ivalue.toDevice();
-  auto it = memoized_devices_map_.find(device.str());
+  auto deviceStr = device.str();
+  auto it = memoized_devices_map_.find(deviceStr);
   if (it == memoized_devices_map_.end()) {
     pushGlobal("torch", "device");
-    pushString(ivalue.toDevice().str());
+    pushString(deviceStr);
     push<PickleOpCode>(PickleOpCode::TUPLE1);
     push<PickleOpCode>(PickleOpCode::REDUCE);
-    memoized_devices_map_[device.str()] = pushNextBinPut();
+    memoized_devices_map_[deviceStr] = pushNextBinPut();
   } else {
     pushBinGet(it->second);
   }
@@ -170,7 +171,7 @@ void Pickler::pushIValue(const IValue& ivalue) {
     pushIValueImpl(ivalue);
 
     memoized_ivalues_.push_back(ivalue);
-    memoized_ivalue_map_[ivalue.internalToPointer()] = pushNextBinPut();
+    memoized_ivalue_map_[ptr] = pushNextBinPut();
   } else {
     pushIValueImpl(ivalue);
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#33060 [jit] Minor: avoid recalculating some keys for map accesses in pickler.**

Noticed this when tracking down a partially-related SIGSEGV.
If inserting a non-present key into a memoized map, don't re-calculate it twice
(probably safer that way anyway).

Differential Revision: [D19778008](https://our.internmc.facebook.com/intern/diff/D19778008/)