### PR TITLE
[ONNX] Adding ONNX large model export support in exporter

### DIFF
--- a/test/onnx/test_pytorch_common.py
+++ b/test/onnx/test_pytorch_common.py
@@ -76,5 +76,17 @@ def skipIfUnsupportedOpsetVersion(unsupported_opset_versions):
         return wrapper
     return skip_dec
 
+# skips tests that do not follow ONNX IR v3 (old-style) export.
+# Only tests that follow ONNX IR v3 export, i.e. where 
+# keep_initializers_as_inputs is set to True in torch.onnx.export API call.
+def skipIfNotOnnxIRv3():
+    def skip_dec(func):
+        def wrapper(self):
+            if hasattr(self, 'keep_initializers_as_inputs') and self.keep_initializers_as_inputs is False:
+                raise unittest.SkipTest("Skip test that does not use ONNX IR v3 export.")
+            return func(self)
+        return wrapper
+    return skip_dec
+
 def flatten(x):
     return tuple(function._iter_filter(lambda o: isinstance(o, torch.Tensor))(x))

--- a/test/onnx/test_pytorch_common.py
+++ b/test/onnx/test_pytorch_common.py
@@ -76,17 +76,5 @@ def skipIfUnsupportedOpsetVersion(unsupported_opset_versions):
         return wrapper
     return skip_dec
 
-# skips tests that do not follow ONNX IR v3 (old-style) export.
-# Only tests that follow ONNX IR v3 export, i.e. where 
-# keep_initializers_as_inputs is set to True in torch.onnx.export API call.
-def skipIfNotOnnxIRv3():
-    def skip_dec(func):
-        def wrapper(self):
-            if hasattr(self, 'keep_initializers_as_inputs') and self.keep_initializers_as_inputs is False:
-                raise unittest.SkipTest("Skip test that does not use ONNX IR v3 export.")
-            return func(self)
-        return wrapper
-    return skip_dec
-
 def flatten(x):
     return tuple(function._iter_filter(lambda o: isinstance(o, torch.Tensor))(x))

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -126,8 +126,8 @@ class TestONNXRuntime(unittest.TestCase):
         _run_test(model)
 
     def run_large_model_test(self, model, input, rtol=0.001, atol=1e-7,
-                   example_outputs=None, do_constant_folding=True,
-                   dynamic_axes=None, input_names=None, output_names=None):
+                             example_outputs=None, do_constant_folding=True,
+                             dynamic_axes=None, input_names=None, output_names=None):
         import os
         import tempfile
 
@@ -149,21 +149,21 @@ class TestONNXRuntime(unittest.TestCase):
                 # pdb.set_trace()
                 input_copy = copy.deepcopy(input)
                 torch.onnx.export(model, input_copy, model_file_name,
-                                opset_version=self.opset_version,
-                                example_outputs=output,
-                                verbose=False,
-                                do_constant_folding=do_constant_folding,
-                                keep_initializers_as_inputs=self.keep_initializers_as_inputs,
-                                dynamic_axes=dynamic_axes,
-                                input_names=input_names, output_names=output_names,
-                                use_large_model_format=True)
+                                  opset_version=self.opset_version,
+                                  example_outputs=output,
+                                  verbose=False,
+                                  do_constant_folding=do_constant_folding,
+                                  keep_initializers_as_inputs=self.keep_initializers_as_inputs,
+                                  dynamic_axes=dynamic_axes,
+                                  input_names=input_names, output_names=output_names,
+                                  use_large_model_format=True)
                 # compute onnxruntime output prediction
                 ort_sess = onnxruntime.InferenceSession(model_file_name)
                 input_copy = copy.deepcopy(input)
                 ort_test_with_input(ort_sess, input_copy, output, rtol, atol)
 
 
-    @skipIfUnsupportedMinOpsetVersion(9) # Because large model format was released with Opset 9.
+    @skipIfUnsupportedMinOpsetVersion(9)  # Because large model format was released with Opset 9.
     @skipIfNotOnnxIRv3()
     def test_large_model_export_embed(self):
         class LargeModel(torch.nn.Module):
@@ -177,6 +177,7 @@ class TestONNXRuntime(unittest.TestCase):
                     self.emb,
                     self.lin1,
                 )
+
             def forward(self, input):
                 return self.seq(input)
 

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -145,8 +145,6 @@ class TestONNXRuntime(unittest.TestCase):
             # export the model to ONNX
             with tempfile.TemporaryDirectory() as tmpdirname:
                 model_file_name = os.path.join(tmpdirname, 'model.onnx')
-                # import pdb
-                # pdb.set_trace()
                 input_copy = copy.deepcopy(input)
                 torch.onnx.export(model, input_copy, model_file_name,
                                   opset_version=self.opset_version,

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -144,8 +144,8 @@ class TestONNXRuntime(unittest.TestCase):
             # export the model to ONNX
             with tempfile.TemporaryDirectory() as tmpdirname:
                 model_file_name = os.path.join(tmpdirname, 'model.onnx')
-                import pdb
-                pdb.set_trace()
+                # import pdb
+                # pdb.set_trace()
                 input_copy = copy.deepcopy(input)
                 torch.onnx.export(model, input_copy, model_file_name,
                                 opset_version=self.opset_version,

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -15,8 +15,8 @@ import copy
 from torch.nn.utils import rnn as rnn_utils
 from model_defs.lstm_flattening_result import LstmFlatteningResult
 from model_defs.rnn_model_with_packed_sequence import RnnModelWithPackedSequence
-from test_pytorch_common import skipIfUnsupportedMinOpsetVersion, skipIfNoLapack
-from test_pytorch_common import enableScriptTest, skipIfNotOnnxIRv3
+from test_pytorch_common import skipIfUnsupportedMinOpsetVersion, enableScriptTest
+from test_pytorch_common import skipIfNoLapack, skipIfNotOnnxIRv3
 from test_pytorch_common import BATCH_SIZE
 from test_pytorch_common import RNN_BATCH_SIZE, RNN_SEQUENCE_LENGTH, RNN_INPUT_SIZE, RNN_HIDDEN_SIZE
 import model_defs.word_language_model as word_language_model

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -15,7 +15,8 @@ import copy
 from torch.nn.utils import rnn as rnn_utils
 from model_defs.lstm_flattening_result import LstmFlatteningResult
 from model_defs.rnn_model_with_packed_sequence import RnnModelWithPackedSequence
-from test_pytorch_common import skipIfUnsupportedMinOpsetVersion, skipIfNoLapack, enableScriptTest
+from test_pytorch_common import skipIfUnsupportedMinOpsetVersion, skipIfNoLapack
+from test_pytorch_common import enableScriptTest, skipIfNotOnnxIRv3
 from test_pytorch_common import BATCH_SIZE
 from test_pytorch_common import RNN_BATCH_SIZE, RNN_SEQUENCE_LENGTH, RNN_INPUT_SIZE, RNN_HIDDEN_SIZE
 import model_defs.word_language_model as word_language_model
@@ -162,7 +163,8 @@ class TestONNXRuntime(unittest.TestCase):
                 ort_test_with_input(ort_sess, input_copy, output, rtol, atol)
 
 
-    @skipIfUnsupportedMinOpsetVersion(9)
+    @skipIfUnsupportedMinOpsetVersion(9) # Because large model format was released with Opset 9.
+    @skipIfNotOnnxIRv3()
     def test_large_model_export_embed(self):
         class LargeModel(torch.nn.Module):
             def __init__(self):
@@ -182,7 +184,8 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.tensor([2], dtype=torch.long)
         self.run_large_model_test(model, x)
 
-    @skipIfUnsupportedMinOpsetVersion(9)
+    @skipIfUnsupportedMinOpsetVersion(9)  # Because large model format was released with Opset 9.
+    @skipIfNotOnnxIRv3()
     def test_large_model_export_mobilenet_v2(self):
         model = torchvision.models.mobilenet_v2(pretrained=True)
         x = torch.randn(2, 3, 224, 224, requires_grad=True)

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -15,8 +15,8 @@ import copy
 from torch.nn.utils import rnn as rnn_utils
 from model_defs.lstm_flattening_result import LstmFlatteningResult
 from model_defs.rnn_model_with_packed_sequence import RnnModelWithPackedSequence
-from test_pytorch_common import skipIfUnsupportedMinOpsetVersion, enableScriptTest
-from test_pytorch_common import skipIfNoLapack
+from test_pytorch_common import (skipIfUnsupportedMinOpsetVersion, enableScriptTest,
+                                 skipIfNoLapack)
 from test_pytorch_common import BATCH_SIZE
 from test_pytorch_common import RNN_BATCH_SIZE, RNN_SEQUENCE_LENGTH, RNN_INPUT_SIZE, RNN_HIDDEN_SIZE
 import model_defs.word_language_model as word_language_model
@@ -167,7 +167,7 @@ class TestONNXRuntime(unittest.TestCase):
 
 
     @skipIfUnsupportedMinOpsetVersion(9)  # Because external data format was released with Opset 9.
-    def test_model_with_external_embedding(self):
+    def test_embedding_model_with_external_data(self):
         class LargeModel(torch.nn.Module):
             def __init__(self):
                 super(LargeModel, self).__init__()

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -164,7 +164,6 @@ class TestONNXRuntime(unittest.TestCase):
 
 
     @skipIfUnsupportedMinOpsetVersion(9)  # Because large model format was released with Opset 9.
-    @skipIfNotOnnxIRv3()
     def test_large_model_export_embed(self):
         class LargeModel(torch.nn.Module):
             def __init__(self):

--- a/torch/csrc/jit/export.cpp
+++ b/torch/csrc/jit/export.cpp
@@ -649,18 +649,18 @@ void GraphEncoder::EncodeTensor(
             tensorName[i] = '_';
         }
       }
-      if (tensorName == std::string("features.2.conv.0.0.weight")) {
-        printf("I am here.\n");
-        for (auto d : tensor.sizes()) {
-          printf("%ld, ", d);
-        }
-        printf("TensorSize is %ld.\n",tensorSize);
-        auto qe = t.numel();
-        printf("t.numel() is %ld.\n",qe);
-        auto qe1 = t.element_size();
-        printf("t.element_size() is %ld.\n",qe1);
+      // if (tensorName == std::string("features.2.conv.0.0.weight")) {
+      //   printf("I am here.\n");
+      //   for (auto d : tensor.sizes()) {
+      //     printf("%ld, ", d);
+      //   }
+      //   printf("TensorSize is %ld.\n",tensorSize);
+      //   auto qe = t.numel();
+      //   printf("t.numel() is %ld.\n",qe);
+      //   auto qe1 = t.element_size();
+      //   printf("t.element_size() is %ld.\n",qe1);
         
-      }
+      // }
       std::string fullFilePath = folder + "/" + tensorName;
       FILE* fp = fopen(fullFilePath.c_str(), "wb");
       if (fp == NULL) {

--- a/torch/csrc/jit/export.cpp
+++ b/torch/csrc/jit/export.cpp
@@ -635,7 +635,8 @@ void GraphEncoder::EncodeTensor(
   } else {
     printf("I am in EncodeTensor checkpoint 1b.\n");
     // printf("The parameter name that is considered is %s.\n", external_ref.value().c_str());
-    int64_t tensorSize = std::accumulate(std::begin(tensor.sizes()), std::end(tensor.sizes()), 1, std::multiplies<size_t>());
+    int64_t tensorSize = std::accumulate(std::begin(tensor.sizes()), std::end(tensor.sizes()), 
+                                         static_cast<int64_t>(1), std::multiplies<int64_t>());
     if (use_large_model_format && 
         tensorSize > ParamSizeThresholdForExternalStorage) {
       AT_ASSERT(!onnx_file_path.empty());
@@ -662,6 +663,9 @@ void GraphEncoder::EncodeTensor(
       }
       std::string fullFilePath = folder + "/" + tensorName;
       FILE* fp = fopen(fullFilePath.c_str(), "wb");
+      if (fp == NULL) {
+        throw std::runtime_error(std::string("ONNX export failed. No such file or directory: ") + fullFilePath);
+      }
       fwrite(t.data_ptr(), t.element_size(), t.numel(), fp);
       if (fp) { fclose(fp); }
       onnx::StringStringEntryProto* location = tensor_proto->mutable_external_data()->Add();

--- a/torch/csrc/jit/export.cpp
+++ b/torch/csrc/jit/export.cpp
@@ -644,10 +644,12 @@ void GraphEncoder::EncodeTensor(
     raw_data_export_map_[external_ref.value()] = t;
     tensor_proto->set_raw_data("__EXTERNAL");
   } else {
+    AT_ASSERT(t.is_contiguous());
     size_t tensorSize = static_cast<size_t>(std::accumulate(std::begin(tensor.sizes()), 
                         std::end(tensor.sizes()), static_cast<int64_t>(1), std::multiplies<int64_t>()));
     if (use_large_model_format && tensorSize > ParamSizeThresholdForExternalStorage) {
       AT_ASSERT(!onnx_file_path.empty());
+      AT_ASSERT((external_ref != c10::nullopt) && (external_ref.value() == tensor_proto->name()));
       auto tensorName = GetExternalFileName(external_ref);
       CreateExternalFile(t, tensorName, onnx_file_path);      
       onnx::StringStringEntryProto* location = tensor_proto->mutable_external_data()->Add();

--- a/torch/csrc/jit/export.h
+++ b/torch/csrc/jit/export.h
@@ -33,7 +33,7 @@ TORCH_API std::tuple<std::string, RawDataExportMap> export_onnx(
     bool keep_initializers_as_inputs = true,
     const std::map<std::string, int>& custom_opsets = {},
     bool add_node_names = true,
-    bool use_large_model_format = false,
+    bool use_external_data_format = false,
     const std::string& onnx_file_path = std::string());
 
 TORCH_API void check_onnx_proto(const std::string& proto_string);

--- a/torch/csrc/jit/export.h
+++ b/torch/csrc/jit/export.h
@@ -32,7 +32,9 @@ TORCH_API std::tuple<std::string, RawDataExportMap> export_onnx(
     bool strip_doc_string = true,
     bool keep_initializers_as_inputs = true,
     const std::map<std::string, int>& custom_opsets = {},
-    bool add_node_names = true);
+    bool add_node_names = true,
+    bool use_large_model_format = false,
+    const std::string& onnx_file_path = std::string());
 
 TORCH_API void check_onnx_proto(const std::string& proto_string);
 

--- a/torch/csrc/jit/python_ir.cpp
+++ b/torch/csrc/jit/python_ir.cpp
@@ -237,7 +237,7 @@ void initPythonIRBindings(PyObject* module_) {
              bool keep_initializers_as_inputs,
              const std::map<std::string, int>& custom_opsets,
              bool add_node_names,
-             bool use_large_model_format,
+             bool use_external_data_format,
              const std::string& onnx_file_path) {
             std::string graph;
             RawDataExportMap export_map;
@@ -252,7 +252,7 @@ void initPythonIRBindings(PyObject* module_) {
                 keep_initializers_as_inputs,
                 custom_opsets,
                 add_node_names,
-                use_large_model_format,
+                use_external_data_format,
                 onnx_file_path);
             std::unordered_map<std::string, py::bytes>
                 python_serialized_export_map;
@@ -278,7 +278,7 @@ void initPythonIRBindings(PyObject* module_) {
           py::arg("keep_initializers_as_inputs") = true,
           py::arg("custom_opsets"),
           py::arg("add_node_names") = true,
-          py::arg("use_large_model_format") = false,
+          py::arg("use_external_data_format") = false,
           py::arg("onnx_file_path") = std::string())
       .def(
           "_pretty_print_onnx",

--- a/torch/csrc/jit/python_ir.cpp
+++ b/torch/csrc/jit/python_ir.cpp
@@ -236,7 +236,9 @@ void initPythonIRBindings(PyObject* module_) {
              bool strip_doc_string,
              bool keep_initializers_as_inputs,
              const std::map<std::string, int>& custom_opsets,
-             bool add_node_names) {
+             bool add_node_names,
+             bool use_large_model_format,
+             const std::string& onnx_file_path) {
             std::string graph;
             RawDataExportMap export_map;
             std::tie(graph, export_map) = export_onnx(
@@ -249,7 +251,9 @@ void initPythonIRBindings(PyObject* module_) {
                 strip_doc_string,
                 keep_initializers_as_inputs,
                 custom_opsets,
-                add_node_names);
+                add_node_names,
+                use_large_model_format,
+                onnx_file_path);
             std::unordered_map<std::string, py::bytes>
                 python_serialized_export_map;
             for (auto& kv : export_map) {
@@ -273,7 +277,9 @@ void initPythonIRBindings(PyObject* module_) {
           py::arg("strip_doc_string") = true,
           py::arg("keep_initializers_as_inputs") = true,
           py::arg("custom_opsets"),
-          py::arg("add_node_names") = true)
+          py::arg("add_node_names") = true,
+          py::arg("use_large_model_format") = false,
+          py::arg("onnx_file_path") = std::string())
       .def(
           "_pretty_print_onnx",
           [](const std::shared_ptr<Graph> g,

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -147,6 +147,11 @@ def export(model, args, f, export_params=True, verbose=False, training=False,
             to 1 by default.
         enable_onnx_checker (bool, default True): If True the onnx model checker will be run
             as part of the export, to ensure the exported model is a valid ONNX model.
+        use_large_model_format (bool, default False): If True, then the model is exported
+            in ONNX large model format, in which case some of the model parameters are stored
+            in separate binary files and not in the ONNX model file itself. If False, then the
+            model is stored in regular format, i.e. model and parameters are all in one file. 
+            This argument is ignored for all export types other than ONNX. 
     """
 
     from torch.onnx import utils

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -149,9 +149,11 @@ def export(model, args, f, export_params=True, verbose=False, training=False,
             as part of the export, to ensure the exported model is a valid ONNX model.
         use_large_model_format (bool, default False): If True, then the model is exported
             in ONNX large model format, in which case some of the model parameters are stored
-            in separate binary files and not in the ONNX model file itself. If False, then the
-            model is stored in regular format, i.e. model and parameters are all in one file. 
-            This argument is ignored for all export types other than ONNX. 
+            in separate binary files and not in the ONNX model file itself. Also, in this case,
+            argument 'f' must be a string specifying the location of the model. The separate
+            binary files will be stored in the same location specified by the model location 'f'.
+            If False, then the model is stored in regular format, i.e. model and parameters 
+            are all in one file. This argument is ignored for all export types other than ONNX. 
     """
 
     from torch.onnx import utils

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -32,7 +32,7 @@ def export(model, args, f, export_params=True, verbose=False, training=False,
            operator_export_type=None, opset_version=None, _retain_param_name=True,
            do_constant_folding=True, example_outputs=None, strip_doc_string=True,
            dynamic_axes=None, keep_initializers_as_inputs=None, custom_opsets=None,
-           enable_onnx_checker=True):
+           enable_onnx_checker=True, use_large_model_format=False):
     r"""
     Export a model into ONNX format.  This exporter runs your model
     once in order to get a trace of its execution to be exported;
@@ -155,7 +155,7 @@ def export(model, args, f, export_params=True, verbose=False, training=False,
                         operator_export_type, opset_version, _retain_param_name,
                         do_constant_folding, example_outputs,
                         strip_doc_string, dynamic_axes, keep_initializers_as_inputs,
-                        custom_opsets, enable_onnx_checker)
+                        custom_opsets, enable_onnx_checker, use_large_model_format)
 
 
 def export_to_pretty_string(*args, **kwargs):

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -32,7 +32,7 @@ def export(model, args, f, export_params=True, verbose=False, training=False,
            operator_export_type=None, opset_version=None, _retain_param_name=True,
            do_constant_folding=True, example_outputs=None, strip_doc_string=True,
            dynamic_axes=None, keep_initializers_as_inputs=None, custom_opsets=None,
-           enable_onnx_checker=True, use_large_model_format=False):
+           enable_onnx_checker=True, use_external_data_format=False):
     r"""
     Export a model into ONNX format.  This exporter runs your model
     once in order to get a trace of its execution to be exported;
@@ -147,13 +147,16 @@ def export(model, args, f, export_params=True, verbose=False, training=False,
             to 1 by default.
         enable_onnx_checker (bool, default True): If True the onnx model checker will be run
             as part of the export, to ensure the exported model is a valid ONNX model.
-        use_large_model_format (bool, default False): If True, then the model is exported
-            in ONNX large model format, in which case some of the model parameters are stored
-            in separate binary files and not in the ONNX model file itself. Also, in this case,
-            argument 'f' must be a string specifying the location of the model. The separate
-            binary files will be stored in the same location specified by the model location 'f'.
-            If False, then the model is stored in regular format, i.e. model and parameters 
-            are all in one file. This argument is ignored for all export types other than ONNX. 
+        external_data_format (bool, default False): If True, then the model is exported
+            in ONNX external data format, in which case some of the model parameters are stored
+            in external binary files and not in the ONNX model file itself. See link for format
+            details: 
+            https://github.com/onnx/onnx/blob/8b3f7e2e7a0f2aba0e629e23d89f07c7fc0e6a5e/onnx/onnx.proto#L423
+            Also, in this case,  argument 'f' must be a string specifying the location of the model.
+            The external binary files will be stored in the same location specified by the model 
+            location 'f'. If False, then the model is stored in regular format, i.e. model and
+            parameters are all in one file. This argument is ignored for all export types other
+            than ONNX. 
     """
 
     from torch.onnx import utils
@@ -162,7 +165,7 @@ def export(model, args, f, export_params=True, verbose=False, training=False,
                         operator_export_type, opset_version, _retain_param_name,
                         do_constant_folding, example_outputs,
                         strip_doc_string, dynamic_axes, keep_initializers_as_inputs,
-                        custom_opsets, enable_onnx_checker, use_large_model_format)
+                        custom_opsets, enable_onnx_checker, use_external_data_format)
 
 
 def export_to_pretty_string(*args, **kwargs):

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -50,7 +50,7 @@ def export(model, args, f, export_params=True, verbose=False, training=False,
            operator_export_type=None, opset_version=None, _retain_param_name=True,
            do_constant_folding=True, example_outputs=None, strip_doc_string=True,
            dynamic_axes=None, keep_initializers_as_inputs=None, custom_opsets=None,
-           enable_onnx_checker=True, use_large_model_format=False):
+           enable_onnx_checker=True, use_external_data_format=False):
     if aten or export_raw_ir:
         assert operator_export_type is None
         assert aten ^ export_raw_ir
@@ -66,7 +66,7 @@ def export(model, args, f, export_params=True, verbose=False, training=False,
             example_outputs=example_outputs, strip_doc_string=strip_doc_string,
             dynamic_axes=dynamic_axes, keep_initializers_as_inputs=keep_initializers_as_inputs,
             custom_opsets=custom_opsets, enable_onnx_checker=enable_onnx_checker,
-            use_large_model_format=use_large_model_format)
+            use_external_data_format=use_external_data_format)
 
 
 # ONNX can't handle constants that are lists of tensors, which can
@@ -248,16 +248,16 @@ def _decide_constant_folding(do_constant_folding, operator_export_type):
     return _resolve_args_by_export_type("do_constant_folding", do_constant_folding, operator_export_type)
 
 
-def _decide_large_model_format(use_large_model_format, operator_export_type, f):
-    val_use_large_model_format = _resolve_args_by_export_type("use_large_model_format",
-                                                              use_large_model_format,
-                                                              operator_export_type)
+def _decide_external_data_format(use_external_data_format, operator_export_type, f):
+    val_use_external_data_format = _resolve_args_by_export_type("use_external_data_format",
+                                                                use_external_data_format,
+                                                                operator_export_type)
     # f can be a non-string in regular-sized model export case, but for large model export, f must be a non-empty 
     # string specifying the location of the model. For large model cases, if f is not a non-empty string,
     # then this method returns an empty string, which is an error condition for the large model export code
     # path later (but not for regular model export code path).
-    model_file_location = f if val_use_large_model_format and isinstance(f, str) else str()
-    return val_use_large_model_format, model_file_location
+    model_file_location = f if val_use_external_data_format and isinstance(f, str) else str()
+    return val_use_external_data_format, model_file_location
 
 
 def _trace(func, args, operator_export_type, return_outs=False):
@@ -447,7 +447,7 @@ def _export(model, args, f, export_params=True, verbose=False, training=False,
             opset_version=None, _retain_param_name=False, do_constant_folding=True,
             strip_doc_string=True, dynamic_axes=None, keep_initializers_as_inputs=None,
             fixed_batch_size=False, custom_opsets=None, add_node_names=True,
-            enable_onnx_checker=True, use_large_model_format=False):
+            enable_onnx_checker=True, use_external_data_format=False):
     if isinstance(model, torch.nn.DataParallel):
         raise ValueError('torch.nn.DataParallel is not supported by ONNX '
                          'exporter, please use \'attribute\' module to '
@@ -474,9 +474,9 @@ def _export(model, args, f, export_params=True, verbose=False, training=False,
                                                          opset_version)
         val_add_node_names = _decide_add_node_names(add_node_names, operator_export_type)
         val_do_constant_folding = _decide_constant_folding(do_constant_folding, operator_export_type)
-        val_use_large_model_format, model_file_location = _decide_large_model_format(use_large_model_format,
-                                                                                     operator_export_type,
-                                                                                     f)
+        val_use_external_data_format, model_file_location = _decide_external_data_format(use_external_data_format,
+                                                                                         operator_export_type,
+                                                                                         f)
         graph, params_dict, torch_out = _model_to_graph(model, args, verbose,
                                                         training, input_names,
                                                         output_names, operator_export_type,
@@ -497,16 +497,16 @@ def _export(model, args, f, export_params=True, verbose=False, training=False,
             proto, export_map = graph._export_onnx(
                 params_dict, opset_version, dynamic_axes, defer_weight_export,
                 operator_export_type, strip_doc_string, val_keep_init_as_ip, custom_opsets,
-                val_add_node_names, val_use_large_model_format, model_file_location)
+                val_add_node_names, val_use_external_data_format, model_file_location)
         else:
             proto, export_map = graph._export_onnx(
                 {}, opset_version, dynamic_axes, False, operator_export_type,
                 strip_doc_string, val_keep_init_as_ip, custom_opsets, val_add_node_names,
-                val_use_large_model_format, model_file_location)
+                val_use_external_data_format, model_file_location)
 
         if enable_onnx_checker and \
            operator_export_type is OperatorExportTypes.ONNX_ATEN_FALLBACK and \
-           not val_use_large_model_format:
+           not val_use_external_data_format:
             # Only run checker if enabled and we are not using ATEN fallback and
             # large model format export in not enabled.
             _check_onnx_proto(proto)

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -506,7 +506,8 @@ def _export(model, args, f, export_params=True, verbose=False, training=False,
         if enable_onnx_checker and \
            operator_export_type is OperatorExportTypes.ONNX_ATEN_FALLBACK and \
            not val_use_large_model_format:
-            # Only run checker if enabled and we are not using ATEN fallback
+            # Only run checker if enabled and we are not using ATEN fallback and
+            # large model format export in not enabled.
             _check_onnx_proto(proto)
 
         if export_type == ExportTypes.PROTOBUF_FILE:

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -463,9 +463,6 @@ def _export(model, args, f, export_params=True, verbose=False, training=False,
             else:
                 operator_export_type = OperatorExportTypes.ONNX
 
-            if operator_export_type is OperatorExportTypes.ONNX and export_type is not ExportTypes.PROTOBUF_FILE:
-                raise RuntimeError('If operator export type is ONNX, export_type must be ExportTypes.PROTOBUF_FILE.')
-
         _set_opset_version(opset_version)
         _set_operator_export_type(operator_export_type)
         val_keep_init_as_ip = _decide_keep_init_as_input(keep_initializers_as_inputs,

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -503,7 +503,9 @@ def _export(model, args, f, export_params=True, verbose=False, training=False,
                 strip_doc_string, val_keep_init_as_ip, custom_opsets, val_add_node_names,
                 val_use_large_model_format, model_file_location)
 
-        if enable_onnx_checker and operator_export_type != OperatorExportTypes.ONNX_ATEN_FALLBACK:
+        if enable_onnx_checker and \
+           operator_export_type is OperatorExportTypes.ONNX_ATEN_FALLBACK and \
+           not val_use_large_model_format:
             # Only run checker if enabled and we are not using ATEN fallback
             _check_onnx_proto(proto)
 

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -252,6 +252,10 @@ def _decide_large_model_format(use_large_model_format, operator_export_type, f):
     val_use_large_model_format = _resolve_args_by_export_type("use_large_model_format",
                                                               use_large_model_format,
                                                               operator_export_type)
+    # f can be a non-string in regular-sized model export case, but for large model export, f must be a non-empty 
+    # string specifying the location of the model. For large model cases, if f is not a non-empty string,
+    # then this method returns an empty string, which is an error condition for the large model export code
+    # path later (but not for regular model export code path).
     model_file_location = f if val_use_large_model_format and isinstance(f, str) else str()
     return val_use_large_model_format, model_file_location
 


### PR DESCRIPTION
There are large models such as GPT2-large which cannot be exported with the current exporter because of the 2GB protobuf limit (e.g. see https://github.com/pytorch/pytorch/issues/19277). ONNX spec specifies a special format for large (> 2GB)  models. This PR adds support for exporting large models in ONNX large model format in the PyTorch-ONNX exporter. 

This is the first PR for this feature that enables the end-to-end execution. Tests for large model export have been added. We may need follow-up PRs to refine this workflow based on user feedback.