### PR TITLE
[WIP] Adding dtype argument to the Unary Ops for dtype promotion (testing on expm1 function)

### DIFF
--- a/aten/src/ATen/native/TensorIterator.cpp
+++ b/aten/src/ATen/native/TensorIterator.cpp
@@ -681,7 +681,7 @@ TensorIterator TensorIterator::unary_op(Tensor& out, const Tensor& a,
   iter.add_output(out);
   iter.add_input(a);
   iter.num_outputs_ = 1;
-  if(promoting == true) iter.promote_common_dtype();
+  if(promoting) iter.promote_common_dtype();
   iter.build();
   return iter;
 }

--- a/aten/src/ATen/native/TensorIterator.cpp
+++ b/aten/src/ATen/native/TensorIterator.cpp
@@ -675,12 +675,13 @@ TensorIterator TensorIterator::comparison_op(Tensor& out, const Tensor& a,
 }
 
 TensorIterator TensorIterator::unary_op(Tensor& out, const Tensor& a,
-    bool check_mem_overlap) {
+    bool check_mem_overlap, bool promoting) {
   auto iter = TensorIterator();
   iter.set_check_mem_overlap(check_mem_overlap);
   iter.add_output(out);
   iter.add_input(a);
   iter.num_outputs_ = 1;
+  if(promoting == true) iter.promote_common_dtype();
   iter.build();
   return iter;
 }

--- a/aten/src/ATen/native/TensorIterator.h
+++ b/aten/src/ATen/native/TensorIterator.h
@@ -168,7 +168,7 @@ struct CAFFE2_API TensorIterator {
   static TensorIterator comparison_op(Tensor& out, const Tensor& a, const Tensor& b,
     bool check_mem_overlap = false);
   static TensorIterator unary_op(Tensor& out, const Tensor& a,
-    bool check_mem_overlap = false);
+    bool check_mem_overlap = false, bool promoting = false);
   static TensorIterator nullary_op(Tensor& out);
   static TensorIterator reduce_op(Tensor& out, const Tensor& a);
   static TensorIterator reduce_op(Tensor& out1, Tensor& out2, const Tensor& a);

--- a/aten/src/ATen/native/UnaryOps.cpp
+++ b/aten/src/ATen/native/UnaryOps.cpp
@@ -96,8 +96,7 @@ Tensor ceil(const Tensor& self) { return unary_op_impl(self, at::ceil_out); }
 Tensor& ceil_(Tensor& self) { return unary_op_impl_(self, at::ceil_out); }
 
 Tensor& expm1_out(Tensor& result, const Tensor& self) { 
-  if (result.defined()) return unary_op_impl_out(result, self, expm1_stub, /*strategy_promote=*/ true);
-  else return unary_op_impl_out(result, self, expm1_stub);
+  return unary_op_impl_out(result, self, expm1_stub, /*strategy_promote=*/ true);
 }
 
 Tensor& expm1_out_promoting(Tensor& result, const Tensor& self, bool promoting=false) { return unary_op_impl_out(result, self, expm1_stub, promoting); }

--- a/aten/src/ATen/native/UnaryOps.cpp
+++ b/aten/src/ATen/native/UnaryOps.cpp
@@ -55,7 +55,7 @@ template <typename OutImpl>
 static inline Tensor unary_op_impl(const Tensor& self, OutImpl& out_impl, c10::ScalarType dtype) {
   Tensor result = at::empty({0}, self.options().dtype(dtype));
   out_impl(result, self, true); // true for dtype promotion
-  return result; 
+  return result;
 }
 
 template <typename OutImpl>

--- a/aten/src/ATen/native/UnaryOps.cpp
+++ b/aten/src/ATen/native/UnaryOps.cpp
@@ -55,7 +55,7 @@ template <typename OutImpl>
 static inline Tensor unary_op_impl(const Tensor& self, OutImpl& out_impl, c10::ScalarType dtype) {
   Tensor result = at::empty({0}, self.options().dtype(dtype));
   out_impl(result, self, true); // true for dtype promotion
-  result; 
+  return result; 
 }
 
 template <typename OutImpl>

--- a/aten/src/ATen/native/UnaryOps.cpp
+++ b/aten/src/ATen/native/UnaryOps.cpp
@@ -95,7 +95,11 @@ Tensor& ceil_out(Tensor& result, const Tensor& self) { return unary_op_impl_out(
 Tensor ceil(const Tensor& self) { return unary_op_impl(self, at::ceil_out); }
 Tensor& ceil_(Tensor& self) { return unary_op_impl_(self, at::ceil_out); }
 
-Tensor& expm1_out(Tensor& result, const Tensor& self) { return unary_op_impl_out(result, self, expm1_stub); }
+Tensor& expm1_out(Tensor& result, const Tensor& self) { 
+  if (result.defined()) return unary_op_impl_out(result, self, expm1_stub, /*strategy_promote=*/ true);
+  else return unary_op_impl_out(result, self, expm1_stub);
+}
+
 Tensor& expm1_out_promoting(Tensor& result, const Tensor& self, bool promoting=false) { return unary_op_impl_out(result, self, expm1_stub, promoting); }
 Tensor expm1(const Tensor& self) { return unary_op_impl(self, at::expm1_out); }
 Tensor expm1(const Tensor& self, c10::ScalarType dtype) { return unary_op_impl(self, at::native::expm1_out_promoting, dtype); }

--- a/aten/src/ATen/native/UnaryOps.cpp
+++ b/aten/src/ATen/native/UnaryOps.cpp
@@ -35,9 +35,9 @@ namespace native {
 // macro that implements everything, because the former allows some simple preprocessing that are unique to some
 // operators (more is foreseeable) and is more flexible and elegant than the latter.
 template <typename Stub>
-static inline Tensor& unary_op_impl_out(Tensor& result, const Tensor& self, Stub& stub) {
+static inline Tensor& unary_op_impl_out(Tensor& result, const Tensor& self, Stub& stub, bool strategy_promote=false) {
   auto iter = TensorIterator::unary_op(result, self,
-    /*check_mem_overlap=*/true);
+    /*check_mem_overlap=*/true, /*promoting=*/strategy_promote);
   stub(iter.device_type(), iter);
   return result;
 }
@@ -49,6 +49,13 @@ template <typename OutImpl>
 static inline Tensor unary_op_impl(const Tensor& self, OutImpl& out_impl) {
   Tensor result = at::empty({0}, self.options());
   return out_impl(result, self);
+}
+
+template <typename OutImpl>
+static inline Tensor unary_op_impl(const Tensor& self, OutImpl& out_impl, c10::ScalarType dtype) {
+  Tensor result = at::empty({0}, self.options().dtype(dtype));
+  out_impl(result, self, true); // true for dtype promotion
+  result; 
 }
 
 template <typename OutImpl>
@@ -89,7 +96,9 @@ Tensor ceil(const Tensor& self) { return unary_op_impl(self, at::ceil_out); }
 Tensor& ceil_(Tensor& self) { return unary_op_impl_(self, at::ceil_out); }
 
 Tensor& expm1_out(Tensor& result, const Tensor& self) { return unary_op_impl_out(result, self, expm1_stub); }
+Tensor& expm1_out_promoting(Tensor& result, const Tensor& self, bool promoting=false) { return unary_op_impl_out(result, self, expm1_stub, promoting); }
 Tensor expm1(const Tensor& self) { return unary_op_impl(self, at::expm1_out); }
+Tensor expm1(const Tensor& self, c10::ScalarType dtype) { return unary_op_impl(self, at::native::expm1_out_promoting, dtype); }
 Tensor& expm1_(Tensor& self) { return unary_op_impl_(self, at::expm1_out); }
 
 Tensor& frac_out(Tensor& result, const Tensor& self) { return unary_op_impl_out(result, self, frac_stub); }

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1210,7 +1210,7 @@
   supports_named_tensor: True
   variants: function, method
 
-- func: expm1.dtype(Tensor self, ScalarType dtype) -> Tensor
+- func: expm1.dtype(Tensor self, *, ScalarType dtype) -> Tensor
   supports_named_tensor: True
   variants: function, method
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1210,6 +1210,10 @@
   supports_named_tensor: True
   variants: function, method
 
+- func: expm1.dtype(Tensor self, ScalarType dtype) -> Tensor
+  supports_named_tensor: True
+  variants: function, method
+
 - func: expm1_(Tensor(a!) self) -> Tensor(a!)
   supports_named_tensor: True
   variants: function, method


### PR DESCRIPTION
This PR is currently WIP and is intended for discussion on adding dtype argument for the type promotion support of Unary Ops. This PR:

1. Adds `expm1` overload with `dtype` argument. 
2. Modifies `TensorIterator::unary_op` to have promoting argument (default to false, `CommonDTypeStrategy::CHECK`) - if true, then changes the flag to `PROMOTE`. 
3. Modifies the existing helper functions for Unary Ops (`unary_op_impl` and `unary_op_impl_out`).

The objective is to allow the Unary Ops to have a `dtype` argument, to allow the internal promotion logic to promote the dtype if required (and allowed). The question is, if these changes have any unexpected (and unwanted) effect on the current flow of PyTorch.

cc: @mcarilli @nairbv 