### PR TITLE
Issue a warning when zero_grad is used in DataParallel

### DIFF
--- a/test/distributed/test_data_parallel.py
+++ b/test/distributed/test_data_parallel.py
@@ -642,7 +642,7 @@ class TestDataParallel(TestCase):
             def forward(self, x):
                 self._testcase.assertWarnsRegex(
                     lambda: self.zero_grad(),
-                    "The parameters in data parallel modules are copied from the original module.")
+                    "Calling .zero_grad() from a module that was passed to a nn.DataParallel() has no effect.")
                 return x
 
         module = Net(self).cuda()

--- a/test/distributed/test_data_parallel.py
+++ b/test/distributed/test_data_parallel.py
@@ -642,7 +642,7 @@ class TestDataParallel(TestCase):
             def forward(self, x):
                 self._testcase.assertWarnsRegex(
                     lambda: self.zero_grad(),
-                    "Calling .zero_grad() from a module that was passed to a nn.DataParallel() has no effect.")
+                    r"Calling \.zero_grad\(\) from a module that was passed to a nn\.DataParallel\(\) has no effect.")
                 return x
 
         module = Net(self).cuda()

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -1173,8 +1173,9 @@ class Module(object):
 
         def zero_grad():
             warnings.warn(
-                "The parameters in data parallel modules are copied from the original module."
-                "This means they are not leaf nodes in autograd and so don't accumulate gradients.\n"
+                "Calling .zero_grad() from a module that was passed to a nn.DataParallel() has no effect. "
+                "The parameters are copied (in a differentiable manner) from the original module. "
+                "This means they are not leaf nodes in autograd and so don't accumulate gradients. "
                 "If you need gradients in your forward method, consider using autograd.grad instead.")
             replica = weak_self()
             if replica:


### PR DESCRIPTION
Fixes #31768, second attempt of #32870

DataParallel creates replicas of the original `nn.Module` with the parameters duplicated onto the destination devices. Calling `backwards` will propagate gradients onto the original module parameters but calling `zero_grad` on the replica module doesn't clear the gradients from the parent module. However, any replica using backwards was broken anyway since the replica's parameters are not leaf nodes in autograd. So, we should issue a warning.