### PR TITLE
Fix version counter bump in cpp Function

### DIFF
--- a/torch/csrc/autograd/custom_function.cpp
+++ b/torch/csrc/autograd/custom_function.cpp
@@ -175,7 +175,10 @@ void AutogradContext::mark_non_differentiable(const variable_list &outputs) {
   }
 }
 
-const std::unordered_set<at::TensorImpl*>& AutogradContext::get_dirty() const {
+const std::unordered_set<at::TensorImpl*>& AutogradContext::get_and_bump_dirty() const {
+  for (auto& var : dirty_inputs_) {
+    var->bump_version();
+  }
   return dirty_inputs_;
 }
 

--- a/torch/csrc/autograd/custom_function.h
+++ b/torch/csrc/autograd/custom_function.h
@@ -98,7 +98,7 @@ struct TORCH_API AutogradContext {
   // save_for_backward(). Before returning them to the user, a check is made to
   // ensure that they were not modified by any in-place operations.
   variable_list get_saved_variables() const;
-  const std::unordered_set<at::TensorImpl*>& get_dirty() const;
+  const std::unordered_set<at::TensorImpl*>& get_and_bump_dirty() const;
   const std::unordered_set<at::TensorImpl*>& get_non_differentiable() const;
 
 private:
@@ -203,7 +203,7 @@ auto Function<T>::apply(Args&&... args) -> std::enable_if_t<std::is_same<X,T>::v
     outputs = T::forward(&node->ctx_, std::forward<Args>(args)...);
   }
 
-  auto wrapped_outputs = _wrap_outputs(input_vars, node->ctx_.get_non_differentiable(), node->ctx_.get_dirty(), outputs, is_executable ? node : nullptr);
+  auto wrapped_outputs = _wrap_outputs(input_vars, node->ctx_.get_non_differentiable(), node->ctx_.get_and_bump_dirty(), outputs, is_executable ? node : nullptr);
 
   node->output_info_.reserve(wrapped_outputs.size());
   for (auto& output : wrapped_outputs) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #33069 Add more checks to custom Function
* **#33068 Fix version counter bump in cpp Function**

The version counter is already tracked if we use pytorch's functions but not if the user unpack the Tensor and modifies it by hand or with a third party library.

Differential Revision: [D19791564](https://our.internmc.facebook.com/intern/diff/D19791564)