### PR TITLE
windows template specialization bug

### DIFF
--- a/c10/util/C++17.h
+++ b/c10/util/C++17.h
@@ -40,7 +40,7 @@ make_unique_base(Args&&... args) {
 
 
 
-#ifdef __cpp_lib_logical_traits
+#if defined(__cpp_lib_logical_traits) && !(defined(_MSC_VER) && _MSC_VER < 1920)
 
 template <class... B>
 using conjunction = std::conjunction<B...>;


### PR DESCRIPTION
Summary: attempt at fixing https://github.com/pytorch/pytorch/issues/30886

Test Plan: circleCI with `call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" x64 -vcvars_ver=14.16` passes

Differential Revision: D19784550

