### PR TITLE
[jit] Pretranspose addmm

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -417,6 +417,7 @@ if (NOT INTERN_BUILD_MOBILE OR NOT BUILD_CAFFE2_MOBILE)
     ${TORCH_SRC_DIR}/csrc/jit/passes/utils/memory_dag.cpp
     ${TORCH_SRC_DIR}/csrc/jit/passes/quantization.cpp
     ${TORCH_SRC_DIR}/csrc/jit/passes/fuse_linear.cpp
+    ${TORCH_SRC_DIR}/csrc/jit/passes/freeze_module.cpp
     ${TORCH_SRC_DIR}/csrc/jit/print_handler.cpp
     ${TORCH_SRC_DIR}/csrc/jit/fuser/interface.cpp
     ${TORCH_SRC_DIR}/csrc/jit/register_prim_ops.cpp

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -418,6 +418,7 @@ if (NOT INTERN_BUILD_MOBILE OR NOT BUILD_CAFFE2_MOBILE)
     ${TORCH_SRC_DIR}/csrc/jit/passes/quantization.cpp
     ${TORCH_SRC_DIR}/csrc/jit/passes/fuse_linear.cpp
     ${TORCH_SRC_DIR}/csrc/jit/passes/freeze_module.cpp
+    ${TORCH_SRC_DIR}/csrc/jit/passes/pretranspose_weights.cpp
     ${TORCH_SRC_DIR}/csrc/jit/print_handler.cpp
     ${TORCH_SRC_DIR}/csrc/jit/fuser/interface.cpp
     ${TORCH_SRC_DIR}/csrc/jit/register_prim_ops.cpp

--- a/test/jit/test_module_interface.py
+++ b/test/jit/test_module_interface.py
@@ -405,3 +405,36 @@ class TestModuleInterface(JitTestCase):
 
         scripted_mod.proxy_mod = NewScriptModule()
         self.assertEqual(scripted_mod(input), input * (input + 1) + 1)
+
+    # The call to forward of proxy_mod is not inlinable. Making sure
+    # Freezing is perserving proxy_mod.
+    def test_freeze_module_with_interface(self):
+        class OrigMod(torch.nn.Module):
+            def __init__(self):
+                super(OrigMod, self).__init__()
+                self.a = 0
+
+            def forward(self, x):
+                return self.a
+
+        @torch.jit.interface
+        class ModInterface(torch.nn.Module):
+            def forward(self, x):
+                # type:  (Tensor) -> int
+                pass
+
+        class TestModule(torch.nn.Module):
+            proxy_mod : ModInterface
+
+            def __init__(self):
+                super(TestModule, self).__init__()
+                self.proxy_mod = OrigMod()
+
+            def forward(self, x):
+                return self.proxy_mod(x)
+
+        m = torch.jit.script(TestModule())
+        m.eval()
+        mf = torch._C.freeze_module(m._c)
+        self.assertTrue(mf.hasattr('proxy_mod'))
+

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1627,6 +1627,178 @@ graph(%input, %weight):
                    .check('GetAttr[name="_quantized_weight"]') \
                    .run(m._c._get_method('forward').graph)
 
+    @_tmp_donotuse_dont_inline_everything
+    def test_fold_quantize_freeze(self):
+        class M(torch.nn.Module):
+            def __init__(self):
+                super(M, self).__init__()
+                self.weight = torch.nn.Parameter(torch.tensor([2], dtype=torch.float))
+
+            def forward(self, x):
+                return torch.quantize_per_tensor(self.weight, 2.0, 0, torch.quint8)
+
+        m = torch.jit.script(M())
+        m.eval()
+        torch._C._jit_pass_fold_quantize(m._c, 'forward')
+        m._c = torch._C.freeze_module(m._c)
+        self.assertFalse(m._c.hasattr('_quantized_weight'))
+        FileCheck().check_not('GetAttr[name=') \
+                   .run(m._c._get_method('forward').graph)
+
+    @_tmp_donotuse_dont_inline_everything
+    def test_freeze_module(self):
+        class M(torch.nn.Module):
+            def __init__(self):
+                super(M, self).__init__()
+                self.a = 1         # folded
+                self.b = 1.2       # folded
+                self.c = "hello"   # folded
+                self.d = [1, 1]     # folded
+                self.e = [1.0, 1.1]  # not folded. float[] constant not yet supported
+                self.f = ["hello", "world"]
+                self.g = (1, 2)     # not folded. tuple constant not yet supported
+                self.h = {"layer" : "dict"}   # dictionary not supported
+                self.t = torch.tensor([1.2, 2.4], requires_grad=True)  # folded
+                self.ts = [torch.tensor([1.0, 2.0], requires_grad=True), torch.tensor([3.0, 4.0], requires_grad=True)]  # folded
+
+            def forward(self, x):
+                return str(self.a) + str(self.b) + self.c + str(self.d) + \
+                    str(self.e) + str(self.f) + str(self.g) + self.h['layer'] + str(self.t) + str(self.ts)
+
+        m = torch.jit.script(M())
+        m.eval()
+        input = torch.randn(2, 2)
+        output_s = m.forward(input)
+        m._c = torch._C.freeze_module(m._c)
+        self.assertFalse(m._c.hasattr('a'))
+        self.assertFalse(m._c.hasattr('b'))
+        self.assertFalse(m._c.hasattr('c'))
+        self.assertFalse(m._c.hasattr('d'))
+        self.assertTrue(m._c.hasattr('e'))
+        self.assertTrue(m._c.hasattr('f'))
+        self.assertTrue(m._c.hasattr('g'))
+        self.assertTrue(m._c.hasattr('h'))
+        self.assertFalse(m._c.hasattr('t'))
+        self.assertFalse(m._c.hasattr('ts'))
+        output_f = m.forward(input)
+        self.assertEqual(output_s, output_f)
+
+    def test_freeze_module_with_submodule(self):
+        class SubModule(torch.nn.Module):
+            def __init__(self):
+                super(SubModule, self).__init__()
+                self.a = 11
+                self.b = 2
+
+            def forward(self, x):
+                return self.a + self.b
+
+        class SubModule2(torch.nn.Module):
+            def __init__(self):
+                super(SubModule2, self).__init__()
+                self.a = 12
+                self.b = 2
+
+            def forward(self, x):
+                self.b = 30
+                return self.a + self.b
+
+        class TestModule(torch.nn.Module):
+            def __init__(self):
+                super(TestModule, self).__init__()
+                self.sub1 = SubModule()
+                self.sub2 = SubModule2()
+                self.a = 3
+                self.b = 4
+
+            def forward(self, x):
+                self.b = 20
+                return self.sub1(x) + self.a + self.b + self.sub2(x)
+
+        m = torch.jit.script(TestModule())
+        m.eval()
+        input = torch.randn(2, 2)
+        output_s = m.forward(input)
+        m._c = torch._C.freeze_module(m._c)
+        self.assertFalse(m._c.hasattr('sub'))
+        self.assertFalse(m._c.hasattr('a'))
+        self.assertTrue(m._c.hasattr('b'))
+        self.assertTrue(m._c.hasattr('sub2'))
+        output_f = m.forward(input)
+        self.assertEqual(output_s, output_f)
+
+    def test_freeze_module_with_inplace_mutable(self):
+        class FreezeMe2(torch.jit.ScriptModule):
+            def __init__(self):
+                super(FreezeMe2, self).__init__()
+                self.a = [11, 22]
+
+            @torch.jit.script_method
+            def forward(self, x):
+                for i in range(3):
+                    self.a.append(i)
+                return self.a
+
+        m = FreezeMe2()
+        m.eval()
+        m_f = torch._C.freeze_module(m._c)
+        self.assertTrue(m._c.hasattr('a'))
+        m.forward(torch.tensor([3]))
+        out = m_f.forward(torch.tensor([5]))
+        expected = [11, 22, 0, 1, 2, 0, 1, 2]
+        self.assertEqual(out, expected)
+
+    def test_freeze_module_in_training_mode(self):
+        class Net(torch.nn.Module):
+            def __init__(self):
+                super(Net, self).__init__()
+                self.conv1 = torch.nn.Conv2d(1, 32, 3, 1)
+                self.conv2 = torch.nn.Conv2d(32, 64, 3, 1)
+                self.dropout1 = torch.nn.Dropout2d(0.25)
+                self.dropout2 = torch.nn.Dropout2d(0.5)
+                self.fc1 = torch.nn.Linear(9216, 128)
+                self.fc2 = torch.nn.Linear(128, 10)
+
+            def forward(self, x):
+                x = self.conv1(x)
+                x = torch.nn.functional.relu(x)
+                x = self.conv2(x)
+                x = torch.nn.functional.max_pool2d(x, 2)
+                x = self.dropout1(x)
+                x = torch.flatten(x, 1)
+                x = self.fc1(x)
+                x = torch.nn.functional.relu(x)
+                x = self.dropout2(x)
+                x = self.fc2(x)
+                output = torch.nn.functional.log_softmax(x, dim=1)
+                return output
+
+        model = torch.jit.script(Net())
+        model.train()
+
+        with self.assertRaisesRegex(RuntimeError, '!module.is_training()'):
+            mTrain_freezed = torch._C.freeze_module(model._c)
+
+        model.eval()
+        mEval_freezed = torch._C.freeze_module(model._c)
+        self.assertFalse(mEval_freezed.hasattr('conv1'))
+        self.assertFalse(mEval_freezed.hasattr('conv2'))
+        self.assertFalse(mEval_freezed.hasattr('dropout1'))
+        self.assertFalse(mEval_freezed.hasattr('training'))
+        self.assertFalse(mEval_freezed.hasattr('fc1'))
+        self.assertFalse(mEval_freezed.hasattr('dropout2'))
+        self.assertFalse(mEval_freezed.hasattr('fc2'))
+
+    def test_freeze_module_detach_gradient(self):
+        mod = torch.nn.Conv2d(8, 3, 4, 2, 1)
+        self.assertTrue(mod.weight.requires_grad)
+        smod = torch.jit.script(mod)
+        smod.eval()
+        fmod = torch._C.freeze_module(smod._c)
+        self.assertTrue(mod.weight.requires_grad)
+        self.assertTrue(smod.weight.requires_grad)
+        self.assertFalse(fmod.hasattr('weight'))
+
     @unittest.skipUnless(
         'fbgemm' in torch.backends.quantized.supported_engines,
         " Quantized operations require FBGEMM. FBGEMM is only optimized for CPUs"

--- a/tools/build_variables.py
+++ b/tools/build_variables.py
@@ -144,6 +144,7 @@ libtorch_sources = [
     "torch/csrc/jit/passes/subgraph_rewrite.cpp",
     "torch/csrc/jit/passes/utils/subgraph_utils.cpp",
     "torch/csrc/jit/passes/utils/memory_dag.cpp",
+    "torch/csrc/jit/passes/freeze_module.cpp",
     "torch/csrc/jit/print_handler.cpp",
     "torch/csrc/jit/register_prim_ops.cpp",
     "torch/csrc/jit/register_prim_ops_c10.cpp",

--- a/tools/build_variables.py
+++ b/tools/build_variables.py
@@ -145,6 +145,7 @@ libtorch_sources = [
     "torch/csrc/jit/passes/utils/subgraph_utils.cpp",
     "torch/csrc/jit/passes/utils/memory_dag.cpp",
     "torch/csrc/jit/passes/freeze_module.cpp",
+    "torch/csrc/jit/passes/pretranspose_weights.cpp",
     "torch/csrc/jit/print_handler.cpp",
     "torch/csrc/jit/register_prim_ops.cpp",
     "torch/csrc/jit/register_prim_ops_c10.cpp",

--- a/torch/csrc/jit/graph_executor.cpp
+++ b/torch/csrc/jit/graph_executor.cpp
@@ -731,7 +731,7 @@ void runNondiffOptimization(std::shared_ptr<Graph>& graph) {
   }
 }
 
-void runOptimization(std::shared_ptr<Graph>& graph) {
+void runOptimization(std::shared_ptr<Graph>& graph, bool unroll) {
   // Basic graph preprocessing to eliminate noise.
   EliminateDeadCode(graph);
   EliminateCommonSubexpression(graph);
@@ -742,7 +742,8 @@ void runOptimization(std::shared_ptr<Graph>& graph) {
 
   // Unroll small loops, and eliminate expressions that are the same at every
   // iteration.
-  UnrollLoops(graph);
+  if (unroll)
+    UnrollLoops(graph);
   EliminateCommonSubexpression(graph);
 
   CheckInplace(graph);

--- a/torch/csrc/jit/graph_executor_impl.h
+++ b/torch/csrc/jit/graph_executor_impl.h
@@ -31,7 +31,7 @@ namespace jit {
 
 void packGradient(const Gradient& gradient, Node* dnode);
 bool needsGradient(const std::shared_ptr<const Graph>& graph);
-void runOptimization(std::shared_ptr<Graph>& graph);
+void runOptimization(std::shared_ptr<Graph>& graph, bool unroll = true);
 void runNondiffOptimization(std::shared_ptr<Graph>& graph);
 void debugSetAutodiffSubgraphInlining(bool state);
 bool getAutodiffSubgraphInlining();

--- a/torch/csrc/jit/init.cpp
+++ b/torch/csrc/jit/init.cpp
@@ -43,6 +43,7 @@
 #include <torch/csrc/jit/passes/specialize_autogradzero.h>
 #include <torch/csrc/jit/passes/subgraph_rewrite.h>
 #include <torch/csrc/jit/passes/utils/check_alias_annotation.h>
+#include <torch/csrc/jit/passes/freeze_module.h>
 #include <torch/csrc/jit/print_handler.h>
 #include <torch/csrc/jit/pybind_utils.h>
 #include <torch/csrc/jit/python_arg_flatten.h>
@@ -196,6 +197,11 @@ void initJITBindings(PyObject* module) {
           "_jit_pass_quant_fusion",
           [](std::shared_ptr<Graph>& g) { return QuantFusion(g); })
       .def("_jit_pass_fold_convbn", &FoldConvBatchNorm2d)
+      .def("freeze_module",
+          [](script::Module& module) {
+            return freezeModule(module);
+          },
+          py::arg("module"))
       .def("_jit_pass_fuse_linear", &FuseLinear)
       .def(
           "_jit_pass_fold_quantize",

--- a/torch/csrc/jit/init.cpp
+++ b/torch/csrc/jit/init.cpp
@@ -36,6 +36,7 @@
 #include <torch/csrc/jit/passes/onnx/unpack_quantized_weights.h>
 #include <torch/csrc/jit/passes/onnx/prepare_inplace_ops_for_onnx.h>
 #include <torch/csrc/jit/passes/peephole.h>
+#include <torch/csrc/jit/passes/pretranspose_weights.h>
 #include <torch/csrc/jit/passes/quantization.h>
 #include <torch/csrc/jit/passes/remove_expands.h>
 #include <torch/csrc/jit/passes/remove_inplace_ops.h>
@@ -203,6 +204,7 @@ void initJITBindings(PyObject* module) {
           },
           py::arg("module"))
       .def("_jit_pass_fuse_linear", &FuseLinear)
+      .def("_jit_pass_pretranspose_weights", &PretransposeWeights)
       .def(
           "_jit_pass_fold_quantize",
           [](script::Module& module, const std::string& method_name) {

--- a/torch/csrc/jit/passes/alias_analysis.cpp
+++ b/torch/csrc/jit/passes/alias_analysis.cpp
@@ -63,7 +63,8 @@ bool AliasDb::isContainerType(const TypePtr& type) {
 
 AliasDb::~AliasDb() = default;
 
-AliasDb::AliasDb(std::shared_ptr<Graph> graph) : graph_(std::move(graph)) {
+AliasDb::AliasDb(std::shared_ptr<Graph> graph, bool isFrozen)
+    : graph_(std::move(graph)), isFrozen_(isFrozen) {
   memoryDAG_ = torch::make_unique<MemoryDAG>();
   analyze(graph_);
   GRAPH_DEBUG(toString());
@@ -347,9 +348,10 @@ void AliasDb::analyzeImpl(Node* node) {
     case prim::ListUnpack:
     case prim::PythonOp:
     case prim::GetAttr:
-      return analyzeExtractor(node);
     case prim::unchecked_cast:
-      return makePointerTo(node->output(), node->input());
+      if (isFrozen_ && node->kind() == prim::GetAttr)
+        return analyzeCreator(node);
+      return analyzeExtractor(node);
     case prim::ConstantChunk:
       return analyzeChunk(node);
     case prim::BroadcastingChunk:

--- a/torch/csrc/jit/passes/alias_analysis.h
+++ b/torch/csrc/jit/passes/alias_analysis.h
@@ -36,7 +36,9 @@ namespace jit {
  */
 class AliasDb {
  public:
-  TORCH_API explicit AliasDb(std::shared_ptr<Graph> graph);
+  TORCH_API explicit AliasDb(
+      std::shared_ptr<Graph> graphi,
+      bool isFrozen = false);
   TORCH_API ~AliasDb();
 
   // There are limitations to what effects the alias analysis can track. Two
@@ -187,6 +189,11 @@ class AliasDb {
   static bool isContainerType(const TypePtr& type);
 
   std::shared_ptr<Graph> graph_;
+
+  // If the Module is frozen then consider attributes as freshly created
+  // objects. Freezing API invokes alias analysis to check if they are mutated
+  // internally.
+  bool isFrozen_;
 
   // The points-to graph that stores aliasing relationships
   std::unique_ptr<MemoryDAG> memoryDAG_;

--- a/torch/csrc/jit/passes/freeze_module.cpp
+++ b/torch/csrc/jit/passes/freeze_module.cpp
@@ -1,0 +1,305 @@
+#include <torch/csrc/jit/jit_log.h>
+#include <torch/csrc/jit/passes/freeze_module.h>
+
+#include <torch/csrc/jit/graph_executor_impl.h>
+#include <torch/csrc/jit/passes/alias_analysis.h>
+#include <torch/csrc/jit/passes/inliner.h>
+
+#include <stack>
+
+namespace torch {
+namespace jit {
+
+namespace {
+
+class AttributePropagator {
+ public:
+  AttributePropagator(script::Module& module) : module_(module) {}
+
+  void run(std::shared_ptr<Graph>& graph) {
+    Inline(*graph);
+    propagateAttributes(graph);
+    runOptimization(graph, /* unroll? */ false);
+    cleanupFrozenModule(graph);
+  }
+
+ private:
+  // findConstantAttr function locates the sub Module where attributes are
+  // defined. The algorithm chases getAttr chains to locate the submodules.
+  // For example:
+  // module M {
+  //   attributes {
+  //     A = <SubModule at ...>
+  //   }
+  //   ...
+  //   %A = prim::GetAttr[name="A"](%self)
+  //   ...
+  //   %B = prim::GetAttr[name="B"](%A)
+  //   ...
+  //   %weight = prim::GetAttr[name="scale"](%B)
+  //   ...
+  //   submodules {
+  //     module SubModule {
+  //       attributes {
+  //          B = <SubModule2 at ...>
+  //       }
+  //       submodules {
+  //         module SubModule2 {
+  //            attributes {
+  //               scale = 2
+  //            }
+  //         }
+  //       }
+  //     }
+  //   }
+  //
+  // findConstantAttr(%B, "scale", M)  returns true because there are no
+  // explicit SetAttr that modifies %B. attrModule points to the module where
+  // attribute lives (in this example it is <SubModule2 at ...>).
+  //
+  // Note inplace mutations to attributes are checked later using alias
+  // analysis.
+  //
+  // We can use a more efficient algorithm to hash each constant GetAttr to its
+  // corresponding value. Based on initial test on resnet50 and other torch
+  // vision tests. GetAttrs are not too frequent so it is ok to chase GetAttr
+  // chain to retrieve their values.
+  bool findConstantAttr(
+      Node* node,
+      std::string& name,
+      script::Module& attrModule) {
+    std::stack<std::string> names;
+    while (!(node->outputs()[0]->type() == attrModule.type())) {
+      if (node->kind() == prim::GetAttr) {
+        names.push(node->s(attr::name));
+        node = node->inputs()[0]->node();
+      } else {
+        return false;
+      }
+    }
+
+    while (!names.empty()) {
+      auto moduleName = names.top();
+      names.pop();
+      attrModule = attrModule.attr(moduleName).toModule();
+      auto it = preservedAttrs_.find(attrModule._ivalue());
+      if (it != preservedAttrs_.end()) {
+        if (it->second.count(moduleName)) {
+          return false;
+        }
+      }
+    }
+    auto it = preservedAttrs_.find(attrModule._ivalue());
+    return it == preservedAttrs_.end() || !it->second.count(name);
+  }
+
+  void recordMutableAttrs(std::shared_ptr<Graph>& graph) {
+    std::stack<Block*> blocks({graph->block()});
+    std::unique_ptr<AliasDb> aliasDb =
+        torch::make_unique<AliasDb>(graph, /* isFrozen */ true);
+    while (!blocks.empty()) {
+      Block* block = blocks.top();
+      blocks.pop();
+      for (auto n : block->nodes()) {
+        for (Block* sub_block : n->blocks()) {
+          blocks.push(sub_block);
+        }
+        if (n->kind() == prim::SetAttr || n->kind() == prim::GetAttr) {
+          auto name = n->s(attr::name);
+          auto inputNode = n->inputs()[0]->node();
+          auto attrModule = module_;
+          if (!findConstantAttr(inputNode, name, attrModule)) {
+            continue;
+          }
+          if (n->kind() == prim::SetAttr || aliasDb->hasOutputWriters(n)) {
+            GRAPH_DEBUG(
+                n->kind() == prim::GetAttr ? "attribute: " + name + " in %" +
+                        n->outputs()[0]->debugName() + " has inplace writer"
+                                           : "");
+            preservedAttrs_[attrModule._ivalue()].insert(name);
+          }
+        }
+      }
+    }
+  }
+
+  std::set<std::string> recordReferencedAttrs(std::shared_ptr<Graph>& graph) {
+    std::stack<Block*> blocks({graph->block()});
+    while (!blocks.empty()) {
+      Block* block = blocks.top();
+      blocks.pop();
+      for (auto n : block->nodes()) {
+        for (Block* subBlock : n->blocks()) {
+          blocks.push(subBlock);
+        }
+        if (n->kind() == prim::GetAttr) {
+          auto& name = n->s(attr::name);
+          if (module_.hasattr(name)) {
+            preservedAttrs_[module_._ivalue()].insert(name);
+          }
+        }
+      }
+    }
+    auto it = preservedAttrs_.find(module_._ivalue());
+    if (it != preservedAttrs_.end())
+      return it->second;
+    else
+      return std::set<std::string>();
+  }
+
+  // If Module is in eval mode, detach and override requires_grad tensor
+  // attributes to enable freezing.
+  bool shouldFoldAttr(IValue& attr, std::string& name, bool isEval) {
+    if (attr.isTensor()) {
+      auto t = attr.toTensor();
+      if (t.requires_grad()) {
+        t = autograd::as_variable_ref(t).detach();
+        attr = IValue(t);
+        if (isEval) {
+          t.set_requires_grad(false);
+        } else {
+          return false;
+        }
+      }
+    } else if (attr.isTensorList()) {
+      c10::List<at::Tensor> lst = std::move(attr).toTensorList();
+      for (size_t i = 0; i < lst.size(); ++i) {
+        auto t = autograd::as_variable_ref(lst.extract(i)).detach();
+        lst.set(i, t);
+        if (isEval) {
+          t.set_requires_grad(false);
+        } else {
+          return false;
+        }
+      }
+      attr = std::move(lst);
+    }
+
+    // Do not fold training attribute in training mode.
+    return isEval || name != "training";
+  }
+
+  void propagateAttributes(std::shared_ptr<Graph>& graph) {
+    std::unordered_map<
+        script::ModulePtr,
+        std::unordered_map<std::string, Value*>>
+        attrValues;
+    auto isEval = !module_.is_training();
+    GRAPH_DEBUG("Freezing Module in ", isEval ? "eval mode" : "training mode");
+    auto block = graph->block();
+    std::stack<Block*> blocks({block});
+
+    // Record Attributes that are explicitely set in the module. They cannot be
+    // folded.
+    recordMutableAttrs(graph);
+
+    Node* m = *block->nodes().begin();
+    WithInsertPoint guard(m);
+    while (!blocks.empty()) {
+      Block* block = blocks.top();
+      blocks.pop();
+      for (auto it = block->nodes().begin(); it != block->nodes().end();) {
+        Node* n = *it;
+        it++; // advance iterator bc the current node may be destroyed
+
+        for (Block* sub_block : n->blocks()) {
+          blocks.push(sub_block);
+        }
+        if (n->kind() == prim::GetAttr) {
+          auto name = n->s(attr::name);
+          auto attrModule = module_;
+          auto inputNode = n->inputs()[0]->node();
+          if (!findConstantAttr(inputNode, name, attrModule)) {
+            GRAPH_DEBUG("attribute: ", name, " is mutable.")
+            continue;
+          }
+          assert(attrModule.hasattr(name));
+          Value* paramConst = nullptr;
+          auto I = attrValues.find(attrModule._ivalue());
+          if (I != attrValues.end()) {
+            auto II = I->second.find(name);
+            if (II != I->second.end())
+              paramConst = II->second;
+          }
+          if (!paramConst) {
+            auto attr = attrModule.attr(name);
+            if (!shouldFoldAttr(attr, name, isEval))
+              continue;
+            if (auto attrVal = tryInsertConstant(*graph, attr)) {
+              paramConst = *attrVal;
+            } else {
+              GRAPH_DEBUG(
+                  attr.type()->cast<ClassType>() ? "" : "attribute: ",
+                  name,
+                  " is not materializable.");
+              continue;
+            }
+            auto moduleName = attrModule.type()->name()->qualifiedName();
+            moduleName += ".";
+            moduleName += name;
+            paramConst->setDebugName(moduleName);
+            attrValues[attrModule._ivalue()][name] = paramConst;
+          }
+          GRAPH_UPDATE(
+              "Folding GetAttr %",
+              n->outputs()[0]->debugName(),
+              " with ",
+              paramConst->debugName());
+          n->outputs().at(0)->replaceAllUsesWith(paramConst);
+          n->removeAllInputs();
+        }
+      }
+    }
+  }
+
+  // cleanupFrozenModule function cleans up the Frozen module. it performs the
+  // following:
+  // 1) Remove unused attributes.
+  // 2) Remove unreferenced submodules
+  // 3) Remove non pulic unreferenced methods.
+  // TODO: do #3 because there is no API to 'unsafely' remove methods.
+  void cleanupFrozenModule(std::shared_ptr<Graph>& graph) {
+    std::vector<std::string> attrsToRemove;
+    auto type = module_.type();
+    size_t N = type->numAttributes();
+    auto KeepAttrs = recordReferencedAttrs(graph);
+    for (size_t i = 0; i < N; ++i) {
+      auto attrTy = type->getAttribute(i);
+      auto name = type->getAttributeName(i);
+      if (!KeepAttrs.count(name)) {
+        attrsToRemove.push_back(name);
+      }
+    }
+    for (auto& name : attrsToRemove) {
+      module_._ivalue()->unsafeRemoveAttr(name);
+      module_.type()->unsafeRemoveAttribute(name);
+    }
+  }
+
+  // Contains attributes that can't be folded or user directs to keep them.
+  std::unordered_map<script::ModulePtr, std::set<std::string>> preservedAttrs_;
+
+  script::Module& module_;
+}; // class AttributePropagator
+} // namespace
+
+script::Module freezeModule(const script::Module& module) {
+  // Currently freezing module is supported only in eval mode.
+  // If assertion below is commented, this implementation folds attributes
+  // correctly in training mode.Tensor attributes with required_grad set
+  // are not folded and 'training' attribute is also not folded.
+  // TODO: Determine if freezing in training s useful and clarify its semantics.
+  TORCH_INTERNAL_ASSERT(!module.is_training());
+  auto moduleClone = module.clone();
+  AttributePropagator attrPropagator(moduleClone);
+  script::Method method = moduleClone.get_method("forward");
+  auto graph = method.graph();
+  attrPropagator.run(graph);
+  GRAPH_DUMP(
+      moduleClone.type()->name()->name() + "::forward() after freezing module",
+      method.graph());
+  return moduleClone;
+}
+
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/passes/freeze_module.h
+++ b/torch/csrc/jit/passes/freeze_module.h
@@ -1,0 +1,25 @@
+/** \brief This file defines freezing Torchscript module API.
+ *
+ * This API has python-binding and can be invoked directly or as a part of
+ * general optimization pipeline.
+ */
+#pragma once
+
+#include <torch/csrc/jit/ir.h>
+#include <torch/csrc/jit/script/module.h>
+
+/** \brief Freeze Module, i.e., Assume all atrributes are constants.
+ *
+ * Freezing module is a functionality that allows the JIT to internalize
+ * imutable attributes. Combined with inlinig, the module is aggressively
+ * optimized and significant overhead is optimized away. The freezeModule API
+ * produces a cloned frozen module.
+ */
+
+namespace torch {
+namespace jit {
+
+TORCH_API script::Module freezeModule(const script::Module& module);
+
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/passes/pretranspose_weights.cpp
+++ b/torch/csrc/jit/passes/pretranspose_weights.cpp
@@ -1,0 +1,40 @@
+#include <torch/csrc/jit/jit_log.h>
+#include <torch/csrc/jit/passes/pretranspose_weights.h>
+
+namespace torch {
+namespace jit {
+
+namespace {
+class PretransposeWeightsHelper {
+  public:
+    PretransposeWeightsHelper() {}
+    void run(std::shared_ptr<Graph>& graph) {
+      /* We just call contiguous because the tensor passed into addmm is a
+       * transposed, possibly strided tensor
+       */
+      Block* block = graph->block();
+      for (auto it = block->nodes().begin(), end = block->nodes().end();
+           it != end; ++it) {
+        if (it->matches("aten::addmm(Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta, Scalar alpha) -> Tensor")) {
+          auto mat2_tensor = it->get<at::Tensor>(attr::mat2);
+          auto mat2_node = it->namedInput(attr::mat2)->node();
+          if (mat2_node->kind() == prim::Constant &&
+              !mat2_tensor->is_contiguous()) {
+            mat2_node->t_(attr::value, mat2_tensor->contiguous());
+            GRAPH_UPDATE("Pretranspose weight for ", *it);
+          }
+        }
+      }
+    }
+
+};
+} // namespace
+
+void PretransposeWeights(std::shared_ptr<Graph>& g) {
+  PretransposeWeightsHelper pretransposer;
+  pretransposer.run(g);
+  GRAPH_DUMP("After pretranspose weights: ", g);
+}
+
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/passes/pretranspose_weights.h
+++ b/torch/csrc/jit/passes/pretranspose_weights.h
@@ -1,0 +1,19 @@
+/** This file defines pretransposing weight for addmm if it is constant by
+ *  calling contiguous. This is meant to be used after model freezing.
+ */
+#pragma once
+
+#include <torch/csrc/jit/ir.h>
+#include <torch/csrc/jit/script/module.h>
+
+/** Pre-transpose addmm weight, which can be faster on SKL machines
+ *  Currently assumes that module is frozen
+ */
+
+namespace torch {
+namespace jit {
+
+TORCH_API void PretransposeWeights(std::shared_ptr<Graph>& g);
+
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/script/module.h
+++ b/torch/csrc/jit/script/module.h
@@ -178,7 +178,7 @@ struct TORCH_API Module : public Object {
     train(/*on=*/false);
   }
   /// True if the module is in training mode.
-  bool is_training() {
+  bool is_training() const{
     return attr("training", true).toBool();
   }
 


### PR DESCRIPTION
Summary:
Jit transform to call contiguous on weight input to addmm, if it is a constant tensor.
This diff is implemented on top of frozen module.

Graph before diff: P125668807
Graph after diff (it's the same graph compared to only running freezing): P125679499

Test Plan:
```buck test caffe2/test:jit -- 'test_pretranspose_weights'```

Run with ptvsc2 benchmark
```MKL_NUM_THREADS=1 OMP_NUM_THREADS=1 numactl -m 0 -C 3 ./ptvsc2_predictor_bench --scripted_model=/data/ansha/snn_bench_125_frozen_cont/traced_model.pt --pt_inputs=/data/ansha/snn_bench_125_frozen_cont/batch_size_40/container.pt --iters=3000 --warmup_iters=100 --num_threads=1```

On SKL T6, 1 thread, bs=40, tiny model
without diff: 24.2807 ms/iter
with diff: 20.5979 ms/iter

Differential Revision: D19651972

