### PR TITLE
Delete redundant aliasAnalysis annotations from VariableType.

### DIFF
--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -184,14 +184,12 @@ UNBOXEDONLY_WRAPPER_REGISTRATION = CodeTemplate("""\
 .op(torch::RegisterOperators::options()
   .schema("${schema_string}")
   .impl_unboxedOnlyKernel<${return_type} (${formal_types}), &VariableType::${api_name}>(DispatchKey::VariableTensorId)
-  .aliasAnalysis(c10::AliasAnalysisKind::FROM_SCHEMA))
 """)
 
 WRAPPER_REGISTRATION = CodeTemplate("""\
 .op(torch::RegisterOperators::options()
   .schema("${schema_string}")
   .kernel<${return_type} (${formal_types})>(DispatchKey::VariableTensorId, &VariableType::${api_name})
-  .aliasAnalysis(c10::AliasAnalysisKind::FROM_SCHEMA))
 """)
 
 UNPACK_TENSOR = CodeTemplate("""\


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #33097 Stop generating out full function type for registration, use decltype or infer it
* #33093 Delete unnecessary aliasAnalysis specification from operator registrations.
* **#33092 Delete redundant aliasAnalysis annotations from VariableType.**
* #33011 Beef up documentation on DispatchKey.h

A lot of people look at VariableType to work out how they should
write registrations, so it's important to not put extra goop in
them.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>