### PR TITLE
[pytorch] convert code analyzer to a binary

### DIFF
--- a/tools/code_analyzer/CMakeLists.txt
+++ b/tools/code_analyzer/CMakeLists.txt
@@ -8,15 +8,15 @@ add_definitions(${LLVM_DEFINITIONS})
 include_directories(${LLVM_INCLUDE_DIRS})
 link_directories(${LLVM_LIBRARY_DIRS})
 
-add_library(OpDependencyPass MODULE
+# Main executable
+add_executable(analyzer
+  analyzer.cpp
   op_dependency.cpp
 )
 
-set_target_properties(OpDependencyPass PROPERTIES
+set_target_properties(analyzer PROPERTIES
     COMPILE_FLAGS "-fno-rtti -O3")
 
-if(APPLE)
-  set_target_properties(OpDependencyPass PROPERTIES
-      LINK_FLAGS "-undefined dynamic_lookup"
-  )
-endif(APPLE)
+llvm_map_components_to_libnames(llvm_libs core irreader support)
+
+target_link_libraries(analyzer ${llvm_libs})

--- a/tools/code_analyzer/analyzer.cpp
+++ b/tools/code_analyzer/analyzer.cpp
@@ -22,8 +22,7 @@ int main(int argc, char **argv) {
   LLVMContext Context;
   cl::ParseCommandLineOptions(argc, argv);
   SMDiagnostic Err;
-  std::unique_ptr<Module> M = parseIRFile(
-      InputFilename, Err, Context, true /*!NoVerify*/, "" /*ClDataLayout*/);
+  std::unique_ptr<Module> M = parseIRFile(InputFilename, Err, Context);
 
   auto opDependencyPass = PassRegistry::getPassRegistry()
       ->getPassInfo(StringRef("op_dependency"))

--- a/tools/code_analyzer/analyzer.cpp
+++ b/tools/code_analyzer/analyzer.cpp
@@ -4,7 +4,6 @@
 #include "llvm/Pass.h"
 #include "llvm/PassRegistry.h"
 #include "llvm/Support/CommandLine.h"
-#include "llvm/Support/InitLLVM.h"
 #include "llvm/Support/SourceMgr.h"
 
 using namespace llvm;
@@ -20,7 +19,6 @@ cl::opt<std::string> InputFilename(
 } // namespace
 
 int main(int argc, char **argv) {
-  InitLLVM X(argc, argv);
   LLVMContext Context;
   cl::ParseCommandLineOptions(argc, argv);
   SMDiagnostic Err;

--- a/tools/code_analyzer/analyzer.cpp
+++ b/tools/code_analyzer/analyzer.cpp
@@ -1,0 +1,35 @@
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/Module.h"
+#include "llvm/IRReader/IRReader.h"
+#include "llvm/Pass.h"
+#include "llvm/PassRegistry.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/InitLLVM.h"
+#include "llvm/Support/SourceMgr.h"
+
+using namespace llvm;
+
+namespace {
+
+cl::opt<std::string> InputFilename(
+    cl::Positional,
+    cl::desc("<input bitcode file>"),
+    cl::init("-"),
+    cl::value_desc("filename"));
+
+} // namespace
+
+int main(int argc, char **argv) {
+  InitLLVM X(argc, argv);
+  LLVMContext Context;
+  cl::ParseCommandLineOptions(argc, argv);
+  SMDiagnostic Err;
+  std::unique_ptr<Module> M = parseIRFile(
+      InputFilename, Err, Context, true /*!NoVerify*/, "" /*ClDataLayout*/);
+
+  auto opDependencyPass = PassRegistry::getPassRegistry()
+      ->getPassInfo(StringRef("op_dependency"))
+      ->createPass();
+  static_cast<ModulePass*>(opDependencyPass)->runOnModule(*M);
+  return 0;
+}

--- a/tools/code_analyzer/build.sh
+++ b/tools/code_analyzer/build.sh
@@ -72,21 +72,10 @@ build_test_project() {
 }
 
 call_analyzer() {
-  echo "Analyze: ${INPUT}"
-
-  "${LLVM_DIR}/bin/opt" \
-    -load="${BUILD_ROOT}/libOpDependencyPass.so" \
-    -op_dependency \
-    -disable-output \
-    -op_schema_pattern="^(_aten|_prim|aten|quantized|profiler|_test)::[^ ]+" \
-    -op_register_pattern="c10::RegisterOperators::(op|checkSchemaAndRegisterOp_)" \
-    -op_invoke_pattern="c10::Dispatcher::findSchema|callOp" \
-    -format="${FORMAT}" \
-    ${EXTRA_ANALYZER_FLAGS} \
-    "${INPUT}" \
-    > "${OUTPUT}"
-
-  echo "Result: ${OUTPUT}"
+  ANALYZER_BIN="${BUILD_ROOT}/analyzer" \
+    INPUT="${INPUT}" OUTPUT="${OUTPUT}" FORMAT="${FORMAT}" \
+    EXTRA_ANALYZER_FLAGS="${EXTRA_ANALYZER_FLAGS}" \
+    "${ANALYZER_SRC_HOME}/run_analyzer.sh"
 }
 
 analyze_torch_mobile() {

--- a/tools/code_analyzer/run_analyzer.sh
+++ b/tools/code_analyzer/run_analyzer.sh
@@ -1,3 +1,9 @@
+#!/bin/bash
+##############################################################################
+# Invoke code analyzer binary with pre-defined parameters for LibTorch.
+# This script should be called via build.sh. Do NOT use it directly.
+##############################################################################
+
 set -exu
 
 echo "Analyze: ${INPUT}"

--- a/tools/code_analyzer/run_analyzer.sh
+++ b/tools/code_analyzer/run_analyzer.sh
@@ -1,0 +1,14 @@
+set -exu
+
+echo "Analyze: ${INPUT}"
+
+"${ANALYZER_BIN}" \
+  -op_schema_pattern="^(_aten|_prim|aten|quantized|profiler|_test)::[^ ]+" \
+  -op_register_pattern="c10::RegisterOperators::(op|checkSchemaAndRegisterOp_)" \
+  -op_invoke_pattern="c10::Dispatcher::findSchema|callOp" \
+  -format="${FORMAT}" \
+  ${EXTRA_ANALYZER_FLAGS} \
+  "${INPUT}" \
+  > "${OUTPUT}"
+
+echo "Result: ${OUTPUT}"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#33102 [pytorch] convert code analyzer to a binary**

Summary:
Add a simple main() to build code analyzer as a binary. This enables
easier integration with FB internal build environment.

Test Plan:
- CI

Differential Revision: [D19798560](https://our.internmc.facebook.com/intern/diff/D19798560)