### PR TITLE
Enable inplace relu fusion for training

### DIFF
--- a/torch/quantization/fuse_modules.py
+++ b/torch/quantization/fuse_modules.py
@@ -47,7 +47,6 @@ def fuse_conv_bn_relu(conv, bn, relu):
         "Conv and BN both must be in the same mode (train or eval)."
 
     if conv.training:
-        assert not relu.inplace, 'We only support fusion of non-inplace ReLU.'
         return torch_fused.ConvBnReLU2d(conv, bn, relu)
     else:
         return torch_fused.ConvReLU2d(

--- a/torch/testing/_internal/common_quantization.py
+++ b/torch/testing/_internal/common_quantization.py
@@ -475,7 +475,7 @@ class ModelForFusion(nn.Module):
         super(ModelForFusion, self).__init__()
         self.conv1 = nn.Conv2d(3, 2, 5, bias=None).to(dtype=torch.float)
         self.bn1 = nn.BatchNorm2d(2).to(dtype=torch.float)
-        self.relu1 = nn.ReLU(inplace=False).to(dtype=torch.float)
+        self.relu1 = nn.ReLU(inplace=True).to(dtype=torch.float)
         self.sub1 = SubModelForFusion()
         self.sub2 = SubModelWithoutFusion()
         self.fc = nn.Linear(72, 10).to(dtype=torch.float)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#33105 Enable inplace relu fusion for training**

Support inplace relu for Conv+BN+Relu fusion during training.

Differential Revision: [D19795221](https://our.internmc.facebook.com/intern/diff/D19795221/)