### PR TITLE
Add ability to enable/disable MIOpen at runtime

### DIFF
--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -205,6 +205,7 @@ auto ConvParams::use_miopen(const at::Tensor& input, bool bias_defined) const ->
          && input.dim() <= MIOPEN_DIM_MAX
          && !(groups > 1 && is_dilated()) // MIOpen currently does not support dilation with groups of size > 1
          && !(input.scalar_type() == at::kBFloat16 && bias_defined) // MIOpen currently doesn't support bias with bfloat16
+         && cudnn_enabled
          ;
 }
 

--- a/aten/src/ATen/native/Normalization.cpp
+++ b/aten/src/ATen/native/Normalization.cpp
@@ -493,6 +493,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, int64_t> _batch_norm_impl_index(
                && ((running_mean.defined() && running_var.defined())
                  || (!running_mean.defined() && !running_var.defined() && training))
                && detail::getCUDAHooks().compiledWithMIOpen()
+               && cudnn_enabled
                );
 
   if (use_miopen) {

--- a/aten/src/ATen/native/RNN.cpp
+++ b/aten/src/ATen/native/RNN.cpp
@@ -16,7 +16,8 @@ bool use_miopen(const at::Tensor& input, const double dropout_state) {
     bool is_miopen_acceptable = (input.scalar_type() == at::kFloat) &&
                                 (detail::getCUDAHooks().compiledWithMIOpen()) &&
                                 (input.is_cuda()) &&
-                                (dropout_state == 0.0);
+                                (dropout_state == 0.0) &&
+                                (at::globalContext().userEnabledCuDNN());
     return is_miopen_acceptable;
 }
 

--- a/torch/backends/cudnn/__init__.py
+++ b/torch/backends/cudnn/__init__.py
@@ -3,7 +3,7 @@ import ctypes
 import sys
 import torch
 import warnings
-from torch.version import cuda, hip
+from torch.version import cuda
 from contextlib import contextmanager
 from subprocess import Popen, PIPE
 from torch.backends import ContextProp, PropModule, __allow_nonbracketed_mutation
@@ -75,7 +75,7 @@ def _libcudnn():
                 raise RuntimeError(
                     'cuDNN version incompatibility: PyTorch was compiled against {} '
                     'but linked against {}'.format(compile_version, __cudnn_version))
-        elif hip is not None and hasattr(lib, 'miopenGetVersion'):
+        elif hasattr(lib, 'miopenGetVersion'):
             miopen_major = ctypes.c_size_t()
             miopen_minor = ctypes.c_size_t()
             miopen_patch = ctypes.c_size_t()
@@ -177,257 +177,256 @@ def flags(enabled=False, benchmark=False, deterministic=False, verbose=False):
             set_flags(orig_flags[0], orig_flags[1], orig_flags[2], orig_flags[3])
 
 
-if cuda is not None:
-    class CuDNNHandle:
-        def __init__(self):
-            ptr = ctypes.c_void_p()
-            check_error(lib.cudnnCreate(ctypes.byref(ptr)))
-            self._as_parameter_ = ptr
+class CuDNNHandle:
+    def __init__(self):
+        ptr = ctypes.c_void_p()
+        check_error(lib.cudnnCreate(ctypes.byref(ptr)))
+        self._as_parameter_ = ptr
 
-        def __del__(self):
-            check_error(lib.cudnnDestroy(self))
-
-
-    class CuDNNError(RuntimeError):
-        def __init__(self, status):
-            self.status = status
-            msg = '{}: {}'.format(status, get_error_string(status))
-            super(CuDNNError, self).__init__(msg)
+    def __del__(self):
+        check_error(lib.cudnnDestroy(self))
 
 
-    class TensorDescriptor(object):
-        def __init__(self):
-            ptr = ctypes.c_void_p()
-            check_error(lib.cudnnCreateTensorDescriptor(ctypes.byref(ptr)))
-            self._as_parameter_ = ptr
-
-        def __del__(self):
-            check_error(lib.cudnnDestroyTensorDescriptor(self._as_parameter_))
-            del self._as_parameter_
-
-        def set(self, tensor):
-            self._type = tensor.type()
-            self._size = tensor.size()
-            self._stride = tensor.stride()
-            check_error(lib.cudnnSetTensorNdDescriptor(
-                self, _typemap[tensor.type()], tensor.dim(),
-                int_array(tensor.size()), int_array(tensor.stride())))
-
-        def as_tuple(self):
-            return (self._type, tuple(self._size), tuple(self._stride))
+class CuDNNError(RuntimeError):
+    def __init__(self, status):
+        self.status = status
+        msg = '{}: {}'.format(status, get_error_string(status))
+        super(CuDNNError, self).__init__(msg)
 
 
-    class TensorDescriptorArray(object):
-        def __init__(self, N):
-            self.ptrs = (ctypes.c_void_p * N)()
-            for i in range(N):
-                ptr = ctypes.byref(self.ptrs, i * ctypes.sizeof(ctypes.c_void_p))
-                check_error(lib.cudnnCreateTensorDescriptor(ptr))
-            self._as_parameter_ = self.ptrs
+class TensorDescriptor(object):
+    def __init__(self):
+        ptr = ctypes.c_void_p()
+        check_error(lib.cudnnCreateTensorDescriptor(ctypes.byref(ptr)))
+        self._as_parameter_ = ptr
 
-        def __del__(self):
-            for ptr in self.ptrs:
-                check_error(lib.cudnnDestroyTensorDescriptor(ctypes.c_void_p(ptr)))
+    def __del__(self):
+        check_error(lib.cudnnDestroyTensorDescriptor(self._as_parameter_))
+        del self._as_parameter_
 
-        def __getitem__(self, key):
-            return ctypes.c_void_p(self.ptrs[key])
+    def set(self, tensor):
+        self._type = tensor.type()
+        self._size = tensor.size()
+        self._stride = tensor.stride()
+        check_error(lib.cudnnSetTensorNdDescriptor(
+            self, _typemap[tensor.type()], tensor.dim(),
+            int_array(tensor.size()), int_array(tensor.stride())))
 
-        def set_all(self, tensor):
-            _type = _typemap[tensor.type()]
-            _ndim = tensor.dim()
-            _size = int_array(tensor.size())
-            _stride = int_array(tensor.stride())
-            for ptr in self.ptrs:
-                check_error(lib.cudnnSetTensorNdDescriptor(
-                    ctypes.c_void_p(ptr), _type, _ndim, _size, _stride))
+    def as_tuple(self):
+        return (self._type, tuple(self._size), tuple(self._stride))
 
-        def set_raw(self, i, _type, _ndim, _size, _stride):
-            ptr = self.ptrs[i]
+
+class TensorDescriptorArray(object):
+    def __init__(self, N):
+        self.ptrs = (ctypes.c_void_p * N)()
+        for i in range(N):
+            ptr = ctypes.byref(self.ptrs, i * ctypes.sizeof(ctypes.c_void_p))
+            check_error(lib.cudnnCreateTensorDescriptor(ptr))
+        self._as_parameter_ = self.ptrs
+
+    def __del__(self):
+        for ptr in self.ptrs:
+            check_error(lib.cudnnDestroyTensorDescriptor(ctypes.c_void_p(ptr)))
+
+    def __getitem__(self, key):
+        return ctypes.c_void_p(self.ptrs[key])
+
+    def set_all(self, tensor):
+        _type = _typemap[tensor.type()]
+        _ndim = tensor.dim()
+        _size = int_array(tensor.size())
+        _stride = int_array(tensor.stride())
+        for ptr in self.ptrs:
             check_error(lib.cudnnSetTensorNdDescriptor(
                 ctypes.c_void_p(ptr), _type, _ndim, _size, _stride))
 
-
-    class FilterDescriptor(object):
-        def __init__(self):
-            ptr = ctypes.c_void_p()
-            check_error(lib.cudnnCreateFilterDescriptor(ctypes.byref(ptr)))
-            self._as_parameter_ = ptr
-
-        def __del__(self):
-            check_error(lib.cudnnDestroyFilterDescriptor(self._as_parameter_))
-            del self._as_parameter_
-
-        def set(self, weight):
-            self._size = weight.size()
-            datatype = _typemap[weight.type()]
-            check_error(lib.cudnnSetFilterNdDescriptor(
-                self, datatype, CUDNN_TENSOR_NCHW, weight.ndimension(),
-                int_array(weight.size())))
-
-        def as_tuple(self):
-            return tuple(self._size)
+    def set_raw(self, i, _type, _ndim, _size, _stride):
+        ptr = self.ptrs[i]
+        check_error(lib.cudnnSetTensorNdDescriptor(
+            ctypes.c_void_p(ptr), _type, _ndim, _size, _stride))
 
 
-    class DropoutDescriptor(object):
-        def __init__(self, handle, dropout, seed):
-            ptr = ctypes.c_void_p()
-            check_error(lib.cudnnCreateDropoutDescriptor(ctypes.byref(ptr)))
+class FilterDescriptor(object):
+    def __init__(self):
+        ptr = ctypes.c_void_p()
+        check_error(lib.cudnnCreateFilterDescriptor(ctypes.byref(ptr)))
+        self._as_parameter_ = ptr
 
-            self._as_parameter_ = ptr
-            self.state = None
-            self.dropout = dropout
-            self.handle = handle
+    def __del__(self):
+        check_error(lib.cudnnDestroyFilterDescriptor(self._as_parameter_))
+        del self._as_parameter_
 
+    def set(self, weight):
+        self._size = weight.size()
+        datatype = _typemap[weight.type()]
+        check_error(lib.cudnnSetFilterNdDescriptor(
+            self, datatype, CUDNN_TENSOR_NCHW, weight.ndimension(),
+            int_array(weight.size())))
+
+    def as_tuple(self):
+        return tuple(self._size)
+
+
+class DropoutDescriptor(object):
+    def __init__(self, handle, dropout, seed):
+        ptr = ctypes.c_void_p()
+        check_error(lib.cudnnCreateDropoutDescriptor(ctypes.byref(ptr)))
+
+        self._as_parameter_ = ptr
+        self.state = None
+        self.dropout = dropout
+        self.handle = handle
+
+        self._set(dropout, seed)
+
+    def set_dropout(self, dropout, seed):
+        if dropout != self.dropout:
             self._set(dropout, seed)
 
-        def set_dropout(self, dropout, seed):
-            if dropout != self.dropout:
-                self._set(dropout, seed)
-
-        def _set(self, dropout, seed):
-            if self.state is None and dropout > 0:
-                dropout_states_size = ctypes.c_long()
-                check_error(lib.cudnnDropoutGetStatesSize(
-                    self.handle,
-                    ctypes.byref(dropout_states_size)))
-                self.state = torch.cuda.ByteTensor(dropout_states_size.value)
-                state_ptr = self.state.data_ptr()
-                state_size = self.state.size(0)
-            else:
-                state_ptr = None
-                state_size = 0
-
-            check_error(lib.cudnnSetDropoutDescriptor(
-                self,
+    def _set(self, dropout, seed):
+        if self.state is None and dropout > 0:
+            dropout_states_size = ctypes.c_long()
+            check_error(lib.cudnnDropoutGetStatesSize(
                 self.handle,
-                ctypes.c_float(dropout),
-                ctypes.c_void_p(state_ptr),
-                ctypes.c_size_t(state_size),
-                ctypes.c_ulonglong(seed),
+                ctypes.byref(dropout_states_size)))
+            self.state = torch.cuda.ByteTensor(dropout_states_size.value)
+            state_ptr = self.state.data_ptr()
+            state_size = self.state.size(0)
+        else:
+            state_ptr = None
+            state_size = 0
+
+        check_error(lib.cudnnSetDropoutDescriptor(
+            self,
+            self.handle,
+            ctypes.c_float(dropout),
+            ctypes.c_void_p(state_ptr),
+            ctypes.c_size_t(state_size),
+            ctypes.c_ulonglong(seed),
+        ))
+
+        self.dropout = dropout
+
+    def __del__(self):
+        check_error(lib.cudnnDestroyDropoutDescriptor(self))
+
+
+class RNNDescriptor(object):
+    def __init__(self, handle, hidden_size, num_layers, dropout_desc, input_mode,
+                 bidirectional, mode, datatype):
+        ptr = ctypes.c_void_p()
+        check_error(lib.cudnnCreateRNNDescriptor(ctypes.byref(ptr)))
+        self._as_parameter_ = ptr
+        if version() >= 6000:
+            check_error(lib.cudnnSetRNNDescriptor_v6(
+                handle,
+                self,
+                hidden_size,
+                num_layers,
+                dropout_desc,
+                input_mode,
+                bidirectional,
+                mode,
+                CUDNN_RNN_ALGO_STANDARD,
+                datatype
+            ))
+            if version() >= 7000 and int(cuda[0]) >= 9 and (
+                    torch.cuda.get_device_capability(torch.cuda.current_device())[0] >= 7):
+                lib.cudnnSetRNNMatrixMathType(self, CUDNN_DEFAULT_MATH)
+                if datatype == CUDNN_DATA_HALF:
+                    lib.cudnnSetRNNMatrixMathType(self, CUDNN_TENSOR_OP_MATH)
+        else:
+            check_error(lib.cudnnSetRNNDescriptor(
+                self,
+                hidden_size,
+                num_layers,
+                dropout_desc,
+                input_mode,
+                bidirectional,
+                mode,
+                datatype
             ))
 
-            self.dropout = dropout
-
-        def __del__(self):
-            check_error(lib.cudnnDestroyDropoutDescriptor(self))
+    def __del__(self):
+        check_error(lib.cudnnDestroyRNNDescriptor(self))
 
 
-    class RNNDescriptor(object):
-        def __init__(self, handle, hidden_size, num_layers, dropout_desc, input_mode,
-                     bidirectional, mode, datatype):
-            ptr = ctypes.c_void_p()
-            check_error(lib.cudnnCreateRNNDescriptor(ctypes.byref(ptr)))
-            self._as_parameter_ = ptr
-            if version() >= 6000:
-                check_error(lib.cudnnSetRNNDescriptor_v6(
-                    handle,
-                    self,
-                    hidden_size,
-                    num_layers,
-                    dropout_desc,
-                    input_mode,
-                    bidirectional,
-                    mode,
-                    CUDNN_RNN_ALGO_STANDARD,
-                    datatype
-                ))
-                if version() >= 7000 and int(cuda[0]) >= 9 and (
-                        torch.cuda.get_device_capability(torch.cuda.current_device())[0] >= 7):
-                    lib.cudnnSetRNNMatrixMathType(self, CUDNN_DEFAULT_MATH)
-                    if datatype == CUDNN_DATA_HALF:
-                        lib.cudnnSetRNNMatrixMathType(self, CUDNN_TENSOR_OP_MATH)
-            else:
-                check_error(lib.cudnnSetRNNDescriptor(
-                    self,
-                    hidden_size,
-                    num_layers,
-                    dropout_desc,
-                    input_mode,
-                    bidirectional,
-                    mode,
-                    datatype
-                ))
-
-        def __del__(self):
-            check_error(lib.cudnnDestroyRNNDescriptor(self))
+def check_error(status):
+    if status != 0:
+        raise CuDNNError(status)
 
 
-    def check_error(status):
-        if status != 0:
-            raise CuDNNError(status)
+def get_error_string(status):
+    return lib.cudnnGetErrorString(status)
 
 
-    def get_error_string(status):
-        return lib.cudnnGetErrorString(status)
+def get_handle():
+    if _libcudnn() is None:
+        raise RuntimeError('cuDNN not available')
+    current_device = torch.cuda.current_device()
+    handle = _handles.get(current_device, None)
+    if handle is None:
+        handle = CuDNNHandle()
+        _handles[current_device] = handle
+    return handle
 
 
-    def get_handle():
-        if _libcudnn() is None:
-            raise RuntimeError('cuDNN not available')
-        current_device = torch.cuda.current_device()
-        handle = _handles.get(current_device, None)
-        if handle is None:
-            handle = CuDNNHandle()
-            _handles[current_device] = handle
-        return handle
+_typemap = {
+    'torch.cuda.HalfTensor': CUDNN_DATA_HALF,
+    'torch.cuda.FloatTensor': CUDNN_DATA_FLOAT,
+    'torch.cuda.DoubleTensor': CUDNN_DATA_DOUBLE,
+}
+
+_sizeofmap = {
+    CUDNN_DATA_HALF: 2,
+    CUDNN_DATA_FLOAT: 4,
+    CUDNN_DATA_DOUBLE: 8,
+}
 
 
-    _typemap = {
-        'torch.cuda.HalfTensor': CUDNN_DATA_HALF,
-        'torch.cuda.FloatTensor': CUDNN_DATA_FLOAT,
-        'torch.cuda.DoubleTensor': CUDNN_DATA_DOUBLE,
-    }
-
-    _sizeofmap = {
-        CUDNN_DATA_HALF: 2,
-        CUDNN_DATA_FLOAT: 4,
-        CUDNN_DATA_DOUBLE: 8,
-    }
+def c_type(tensor):
+    if isinstance(tensor, torch.cuda.HalfTensor):
+        return ctypes.c_float
+    elif isinstance(tensor, torch.cuda.FloatTensor):
+        return ctypes.c_float
+    elif isinstance(tensor, torch.cuda.DoubleTensor):
+        return ctypes.c_double
+    else:
+        raise ValueError("unknown type '{}'".format(type(tensor)))
 
 
-    def c_type(tensor):
-        if isinstance(tensor, torch.cuda.HalfTensor):
-            return ctypes.c_float
-        elif isinstance(tensor, torch.cuda.FloatTensor):
-            return ctypes.c_float
-        elif isinstance(tensor, torch.cuda.DoubleTensor):
-            return ctypes.c_double
-        else:
-            raise ValueError("unknown type '{}'".format(type(tensor)))
+def int_array(itr):
+    array_type = ctypes.c_int * len(itr)
+    return array_type(*itr)
 
 
-    def int_array(itr):
-        array_type = ctypes.c_int * len(itr)
-        return array_type(*itr)
+def descriptor(tensor, N=None):
+    padded_size = tensor.size() + ((1,) * (5 - tensor.dim()))
+    tensor = tensor.view(padded_size)
+    if N is not None:
+        descriptor = TensorDescriptorArray(N)
+        descriptor.set_all(tensor)
+    else:
+        descriptor = TensorDescriptor()
+        descriptor.set(tensor)
+    return descriptor
 
 
-    def descriptor(tensor, N=None):
-        padded_size = tensor.size() + ((1,) * (5 - tensor.dim()))
-        tensor = tensor.view(padded_size)
-        if N is not None:
-            descriptor = TensorDescriptorArray(N)
-            descriptor.set_all(tensor)
-        else:
-            descriptor = TensorDescriptor()
-            descriptor.set(tensor)
-        return descriptor
+def descriptor_sequence(tensor, batch_sizes):
+    descriptors = TensorDescriptorArray(len(batch_sizes))
+    _type = _typemap[tensor.type()]
+    _ndim = 5
+    dim_pad = (1,) * (5 - tensor.dim())
+    _size = int_array(tensor.size() + dim_pad)
+    _stride = int_array(tensor.stride() + dim_pad)
+    for i, batch_size in enumerate(batch_sizes):
+        _size[0] = batch_size
+        descriptors.set_raw(i, _type, _ndim, _size, _stride)
+    return descriptors
 
 
-    def descriptor_sequence(tensor, batch_sizes):
-        descriptors = TensorDescriptorArray(len(batch_sizes))
-        _type = _typemap[tensor.type()]
-        _ndim = 5
-        dim_pad = (1,) * (5 - tensor.dim())
-        _size = int_array(tensor.size() + dim_pad)
-        _stride = int_array(tensor.stride() + dim_pad)
-        for i, batch_size in enumerate(batch_sizes):
-            _size[0] = batch_size
-            descriptors.set_raw(i, _type, _ndim, _size, _stride)
-        return descriptors
-
-
-    def add_tensor(*args):
-        check_error(lib.cudnnAddTensor(*args))
+def add_tensor(*args):
+    check_error(lib.cudnnAddTensor(*args))
 
 
 # The magic here is to allow us to intercept code like this:

--- a/torch/backends/cudnn/__init__.py
+++ b/torch/backends/cudnn/__init__.py
@@ -81,7 +81,7 @@ def _libcudnn():
             miopen_patch = ctypes.c_size_t()
             # miopen version is MAJOR*1000000 + MINOR*1000 + PATCH
             lib.miopenGetVersion(ctypes.byref(miopen_major), ctypes.byref(miopen_minor), ctypes.byref(miopen_patch))
-            __cudnn_version = miopen_major.value*1000000 + miopen_minor.value*1000 + miopen_patch.value
+            __cudnn_version = miopen_major.value * 1000000 + miopen_minor.value * 1000 + miopen_patch.value
         else:
             lib = None
     return lib
@@ -189,28 +189,28 @@ if cuda is not None:
             ptr = ctypes.c_void_p()
             check_error(lib.cudnnCreate(ctypes.byref(ptr)))
             self._as_parameter_ = ptr
-    
+
         def __del__(self):
             check_error(lib.cudnnDestroy(self))
-    
-    
+
+
     class CuDNNError(RuntimeError):
         def __init__(self, status):
             self.status = status
             msg = '{}: {}'.format(status, get_error_string(status))
             super(CuDNNError, self).__init__(msg)
-    
-    
+
+
     class TensorDescriptor(object):
         def __init__(self):
             ptr = ctypes.c_void_p()
             check_error(lib.cudnnCreateTensorDescriptor(ctypes.byref(ptr)))
             self._as_parameter_ = ptr
-    
+
         def __del__(self):
             check_error(lib.cudnnDestroyTensorDescriptor(self._as_parameter_))
             del self._as_parameter_
-    
+
         def set(self, tensor):
             self._type = tensor.type()
             self._size = tensor.size()
@@ -218,11 +218,11 @@ if cuda is not None:
             check_error(lib.cudnnSetTensorNdDescriptor(
                 self, _typemap[tensor.type()], tensor.dim(),
                 int_array(tensor.size()), int_array(tensor.stride())))
-    
+
         def as_tuple(self):
             return (self._type, tuple(self._size), tuple(self._stride))
-    
-    
+
+
     class TensorDescriptorArray(object):
         def __init__(self, N):
             self.ptrs = (ctypes.c_void_p * N)()
@@ -230,14 +230,14 @@ if cuda is not None:
                 ptr = ctypes.byref(self.ptrs, i * ctypes.sizeof(ctypes.c_void_p))
                 check_error(lib.cudnnCreateTensorDescriptor(ptr))
             self._as_parameter_ = self.ptrs
-    
+
         def __del__(self):
             for ptr in self.ptrs:
                 check_error(lib.cudnnDestroyTensorDescriptor(ctypes.c_void_p(ptr)))
-    
+
         def __getitem__(self, key):
             return ctypes.c_void_p(self.ptrs[key])
-    
+
         def set_all(self, tensor):
             _type = _typemap[tensor.type()]
             _ndim = tensor.dim()
@@ -246,50 +246,50 @@ if cuda is not None:
             for ptr in self.ptrs:
                 check_error(lib.cudnnSetTensorNdDescriptor(
                     ctypes.c_void_p(ptr), _type, _ndim, _size, _stride))
-    
+
         def set_raw(self, i, _type, _ndim, _size, _stride):
             ptr = self.ptrs[i]
             check_error(lib.cudnnSetTensorNdDescriptor(
                 ctypes.c_void_p(ptr), _type, _ndim, _size, _stride))
-    
-    
+
+
     class FilterDescriptor(object):
         def __init__(self):
             ptr = ctypes.c_void_p()
             check_error(lib.cudnnCreateFilterDescriptor(ctypes.byref(ptr)))
             self._as_parameter_ = ptr
-    
+
         def __del__(self):
             check_error(lib.cudnnDestroyFilterDescriptor(self._as_parameter_))
             del self._as_parameter_
-    
+
         def set(self, weight):
             self._size = weight.size()
             datatype = _typemap[weight.type()]
             check_error(lib.cudnnSetFilterNdDescriptor(
                 self, datatype, CUDNN_TENSOR_NCHW, weight.ndimension(),
                 int_array(weight.size())))
-    
+
         def as_tuple(self):
             return tuple(self._size)
-    
-    
+
+
     class DropoutDescriptor(object):
         def __init__(self, handle, dropout, seed):
             ptr = ctypes.c_void_p()
             check_error(lib.cudnnCreateDropoutDescriptor(ctypes.byref(ptr)))
-    
+
             self._as_parameter_ = ptr
             self.state = None
             self.dropout = dropout
             self.handle = handle
-    
+
             self._set(dropout, seed)
-    
+
         def set_dropout(self, dropout, seed):
             if dropout != self.dropout:
                 self._set(dropout, seed)
-    
+
         def _set(self, dropout, seed):
             if self.state is None and dropout > 0:
                 dropout_states_size = ctypes.c_long()
@@ -302,7 +302,7 @@ if cuda is not None:
             else:
                 state_ptr = None
                 state_size = 0
-    
+
             check_error(lib.cudnnSetDropoutDescriptor(
                 self,
                 self.handle,
@@ -311,13 +311,13 @@ if cuda is not None:
                 ctypes.c_size_t(state_size),
                 ctypes.c_ulonglong(seed),
             ))
-    
+
             self.dropout = dropout
-    
+
         def __del__(self):
             check_error(lib.cudnnDestroyDropoutDescriptor(self))
-    
-    
+
+
     class RNNDescriptor(object):
         def __init__(self, handle, hidden_size, num_layers, dropout_desc, input_mode,
                      bidirectional, mode, datatype):
@@ -353,20 +353,20 @@ if cuda is not None:
                     mode,
                     datatype
                 ))
-    
+
         def __del__(self):
             check_error(lib.cudnnDestroyRNNDescriptor(self))
-    
-    
+
+
     def check_error(status):
         if status != 0:
             raise CuDNNError(status)
-    
-    
+
+
     def get_error_string(status):
         return lib.cudnnGetErrorString(status)
-    
-    
+
+
     def get_handle():
         if _libcudnn() is None:
             raise RuntimeError('cuDNN not available')
@@ -376,21 +376,21 @@ if cuda is not None:
             handle = CuDNNHandle()
             _handles[current_device] = handle
         return handle
-    
-    
+
+
     _typemap = {
         'torch.cuda.HalfTensor': CUDNN_DATA_HALF,
         'torch.cuda.FloatTensor': CUDNN_DATA_FLOAT,
         'torch.cuda.DoubleTensor': CUDNN_DATA_DOUBLE,
     }
-    
+
     _sizeofmap = {
         CUDNN_DATA_HALF: 2,
         CUDNN_DATA_FLOAT: 4,
         CUDNN_DATA_DOUBLE: 8,
     }
-    
-    
+
+
     def c_type(tensor):
         if isinstance(tensor, torch.cuda.HalfTensor):
             return ctypes.c_float
@@ -400,13 +400,13 @@ if cuda is not None:
             return ctypes.c_double
         else:
             raise ValueError("unknown type '{}'".format(type(tensor)))
-    
-    
+
+
     def int_array(itr):
         array_type = ctypes.c_int * len(itr)
         return array_type(*itr)
-    
-    
+
+
     def descriptor(tensor, N=None):
         padded_size = tensor.size() + ((1,) * (5 - tensor.dim()))
         tensor = tensor.view(padded_size)
@@ -417,8 +417,8 @@ if cuda is not None:
             descriptor = TensorDescriptor()
             descriptor.set(tensor)
         return descriptor
-    
-    
+
+
     def descriptor_sequence(tensor, batch_sizes):
         descriptors = TensorDescriptorArray(len(batch_sizes))
         _type = _typemap[tensor.type()]
@@ -430,8 +430,8 @@ if cuda is not None:
             _size[0] = batch_size
             descriptors.set_raw(i, _type, _ndim, _size, _stride)
         return descriptors
-    
-    
+
+
     def add_tensor(*args):
         check_error(lib.cudnnAddTensor(*args))
 

--- a/torch/backends/cudnn/__init__.py
+++ b/torch/backends/cudnn/__init__.py
@@ -105,12 +105,6 @@ def is_available():
     return torch._C.has_cudnn
 
 
-if cuda is not None:
-    dnn_lib = "cuDNN"
-else:
-    dnn_lib = "MIOpen"
-
-
 def is_acceptable(tensor):
     if not torch._C._get_cudnn_enabled():
         return False
@@ -118,7 +112,7 @@ def is_acceptable(tensor):
         return False
     if not is_available():
         warnings.warn(
-            "PyTorch was compiled without " + dnn_lib + " support. To use " + dnn_lib + ", rebuild "
+            "PyTorch was compiled without cuDNN/MIOpen support. To use cuDNN/MIOpen, rebuild "
             "PyTorch making sure the library is visible to the build system.")
         return False
     if _libcudnn() is None:

--- a/torch/backends/cudnn/__init__.py
+++ b/torch/backends/cudnn/__init__.py
@@ -161,12 +161,12 @@ def set_flags(_enabled, _benchmark, _deterministic, _verbose):
                   verbose)
     verbose = _verbose
     torch._C._set_cudnn_enabled(_enabled)
-    torch._C._set_cudnn_benchmark(_benchmark if cuda is not None else False)
-    torch._C._set_cudnn_deterministic(_deterministic if cuda is not None else False)
+    torch._C._set_cudnn_benchmark(_benchmark)
+    torch._C._set_cudnn_deterministic(_deterministic)
     return orig_flags
 
 @contextmanager
-def flags(enabled=False, benchmark=False, deterministic=False, verbose=False):
+def flags(enabled=False, benchmark=(False if cuda is not None else True), deterministic=False, verbose=False):
     with __allow_nonbracketed_mutation():
         orig_flags = set_flags(enabled, benchmark, deterministic, verbose)
     try:

--- a/torch/backends/cudnn/__init__.py
+++ b/torch/backends/cudnn/__init__.py
@@ -54,7 +54,7 @@ def _libcudnn():
             lib = find_cudnn_windows_lib()
         else:
             lib = ctypes.cdll.LoadLibrary(None)
-        if cuda is not None and hasattr(lib, 'cudnnGetErrorString'):
+        if hasattr(lib, 'cudnnGetErrorString'):
             lib.cudnnGetErrorString.restype = ctypes.c_char_p
             __cudnn_version = lib.cudnnGetVersion()
             compile_version = torch._C._cudnn_version()

--- a/torch/backends/cudnn/__init__.py
+++ b/torch/backends/cudnn/__init__.py
@@ -19,30 +19,27 @@ __cudnn_version = None
 # TODO: dynamic version checks via cudnnGetVersion
 
 def find_cudnn_windows_lib():
-    if cuda is not None:
-        # Override the default search process
-        # Fixes https://github.com/pytorch/pytorch/issues/20202
-        # The library selection will be done in these directories one by one
-        # 1. [Package Root]\Lib 
-        #    That's where our libraries are in, which should be loaded first.
-        # 2. Default directories
-        #    That is stored in the environment variable `PATH`.
-        test_env = os.environ.copy()
-        old_path = test_env['PATH']
-        th_dll_path = os.path.join(os.path.dirname(
-            os.path.dirname(os.path.dirname(__file__))), 'lib')
-        test_env['PATH'] = ';'.join([th_dll_path, old_path])
-        proc = Popen(['where', 'cudnn64*.dll'], stdout=PIPE,
-                     stderr=PIPE, stdin=PIPE, env=test_env)
-        out, err = proc.communicate()
-        out = out.decode().strip()
-        if len(out) > 0:
-            if out.find('\r\n') != -1:
-                out = out.split('\r\n')[0]
-            cudnn_lib = str(out)
-            return ctypes.cdll.LoadLibrary(cudnn_lib)
-        else:
-            return None
+    # Override the default search process
+    # Fixes https://github.com/pytorch/pytorch/issues/20202
+    # The library selection will be done in these directories one by one
+    # 1. [Package Root]\Lib 
+    #    That's where our libraries are in, which should be loaded first.
+    # 2. Default directories
+    #    That is stored in the environment variable `PATH`.
+    test_env = os.environ.copy()
+    old_path = test_env['PATH']
+    th_dll_path = os.path.join(os.path.dirname(
+        os.path.dirname(os.path.dirname(__file__))), 'lib')
+    test_env['PATH'] = ';'.join([th_dll_path, old_path])
+    proc = Popen(['where', 'cudnn64*.dll'], stdout=PIPE,
+                 stderr=PIPE, stdin=PIPE, env=test_env)
+    out, err = proc.communicate()
+    out = out.decode().strip()
+    if len(out) > 0:
+        if out.find('\r\n') != -1:
+            out = out.split('\r\n')[0]
+        cudnn_lib = str(out)
+        return ctypes.cdll.LoadLibrary(cudnn_lib)
     else:
         return None
 
@@ -116,12 +113,11 @@ def is_acceptable(tensor):
             "PyTorch making sure the library is visible to the build system.")
         return False
     if _libcudnn() is None:
-        if cuda is not None:
-            warnings.warn('cuDNN library not found. Check your {libpath}'.format(
-                libpath={
-                    'darwin': 'DYLD_LIBRARY_PATH',
-                    'win32': 'PATH'
-                }.get(sys.platform, 'LD_LIBRARY_PATH')))
+        warnings.warn('cuDNN/MIOpen library not found. Check your {libpath}'.format(
+            libpath={
+                'darwin': 'DYLD_LIBRARY_PATH',
+                'win32': 'PATH'
+            }.get(sys.platform, 'LD_LIBRARY_PATH')))
         return False
     return True
 

--- a/torch/backends/cudnn/__init__.py
+++ b/torch/backends/cudnn/__init__.py
@@ -3,7 +3,7 @@ import ctypes
 import sys
 import torch
 import warnings
-from torch.version import cuda
+from torch.version import cuda, hip
 from contextlib import contextmanager
 from subprocess import Popen, PIPE
 from torch.backends import ContextProp, PropModule, __allow_nonbracketed_mutation
@@ -12,34 +12,37 @@ from torch.backends import ContextProp, PropModule, __allow_nonbracketed_mutatio
 #
 #   torch.backends.cudnn.enabled = False
 #
-# to globally disable CuDNN
+# to globally disable CuDNN/MIOpen
 
 lib = None
 __cudnn_version = None
 # TODO: dynamic version checks via cudnnGetVersion
 
 def find_cudnn_windows_lib():
-    # Override the default search process
-    # Fixes https://github.com/pytorch/pytorch/issues/20202
-    # The library selection will be done in these directories one by one
-    # 1. [Package Root]\Lib 
-    #    That's where our libraries are in, which should be loaded first.
-    # 2. Default directories
-    #    That is stored in the environment variable `PATH`.
-    test_env = os.environ.copy()
-    old_path = test_env['PATH']
-    th_dll_path = os.path.join(os.path.dirname(
-        os.path.dirname(os.path.dirname(__file__))), 'lib')
-    test_env['PATH'] = ';'.join([th_dll_path, old_path])
-    proc = Popen(['where', 'cudnn64*.dll'], stdout=PIPE,
-                 stderr=PIPE, stdin=PIPE, env=test_env)
-    out, err = proc.communicate()
-    out = out.decode().strip()
-    if len(out) > 0:
-        if out.find('\r\n') != -1:
-            out = out.split('\r\n')[0]
-        cudnn_lib = str(out)
-        return ctypes.cdll.LoadLibrary(cudnn_lib)
+    if cuda is not None:
+        # Override the default search process
+        # Fixes https://github.com/pytorch/pytorch/issues/20202
+        # The library selection will be done in these directories one by one
+        # 1. [Package Root]\Lib 
+        #    That's where our libraries are in, which should be loaded first.
+        # 2. Default directories
+        #    That is stored in the environment variable `PATH`.
+        test_env = os.environ.copy()
+        old_path = test_env['PATH']
+        th_dll_path = os.path.join(os.path.dirname(
+            os.path.dirname(os.path.dirname(__file__))), 'lib')
+        test_env['PATH'] = ';'.join([th_dll_path, old_path])
+        proc = Popen(['where', 'cudnn64*.dll'], stdout=PIPE,
+                     stderr=PIPE, stdin=PIPE, env=test_env)
+        out, err = proc.communicate()
+        out = out.decode().strip()
+        if len(out) > 0:
+            if out.find('\r\n') != -1:
+                out = out.split('\r\n')[0]
+            cudnn_lib = str(out)
+            return ctypes.cdll.LoadLibrary(cudnn_lib)
+        else:
+            return None
     else:
         return None
 
@@ -51,7 +54,7 @@ def _libcudnn():
             lib = find_cudnn_windows_lib()
         else:
             lib = ctypes.cdll.LoadLibrary(None)
-        if hasattr(lib, 'cudnnGetErrorString'):
+        if cuda is not None and hasattr(lib, 'cudnnGetErrorString'):
             lib.cudnnGetErrorString.restype = ctypes.c_char_p
             __cudnn_version = lib.cudnnGetVersion()
             compile_version = torch._C._cudnn_version()
@@ -72,6 +75,13 @@ def _libcudnn():
                 raise RuntimeError(
                     'cuDNN version incompatibility: PyTorch was compiled against {} '
                     'but linked against {}'.format(compile_version, __cudnn_version))
+        elif hip is not None and hasattr(lib, 'miopenGetVersion'):
+            miopen_major = ctypes.c_size_t()
+            miopen_minor = ctypes.c_size_t()
+            miopen_patch = ctypes.c_size_t()
+            # miopen version is MAJOR*1000000 + MINOR*1000 + PATCH
+            lib.miopenGetVersion(ctypes.byref(miopen_major), ctypes.byref(miopen_minor), ctypes.byref(miopen_patch))
+            __cudnn_version = miopen_major.value*1000000 + miopen_minor.value*1000 + miopen_patch.value
         else:
             lib = None
     return lib
@@ -95,6 +105,12 @@ def is_available():
     return torch._C.has_cudnn
 
 
+if cuda is not None:
+    dnn_lib = "cuDNN"
+else:
+    dnn_lib = "MIOpen"
+
+
 def is_acceptable(tensor):
     if not torch._C._get_cudnn_enabled():
         return False
@@ -102,15 +118,16 @@ def is_acceptable(tensor):
         return False
     if not is_available():
         warnings.warn(
-            "PyTorch was compiled without cuDNN support. To use cuDNN, rebuild "
+            "PyTorch was compiled without " + dnn_lib + " support. To use " + dnn_lib + ", rebuild "
             "PyTorch making sure the library is visible to the build system.")
         return False
     if _libcudnn() is None:
-        warnings.warn('cuDNN library not found. Check your {libpath}'.format(
-            libpath={
-                'darwin': 'DYLD_LIBRARY_PATH',
-                'win32': 'PATH'
-            }.get(sys.platform, 'LD_LIBRARY_PATH')))
+        if cuda is not None:
+            warnings.warn('cuDNN library not found. Check your {libpath}'.format(
+                libpath={
+                    'darwin': 'DYLD_LIBRARY_PATH',
+                    'win32': 'PATH'
+                }.get(sys.platform, 'LD_LIBRARY_PATH')))
         return False
     return True
 
@@ -150,8 +167,8 @@ def set_flags(_enabled, _benchmark, _deterministic, _verbose):
                   verbose)
     verbose = _verbose
     torch._C._set_cudnn_enabled(_enabled)
-    torch._C._set_cudnn_benchmark(_benchmark)
-    torch._C._set_cudnn_deterministic(_deterministic)
+    torch._C._set_cudnn_benchmark(_benchmark if cuda is not None else False)
+    torch._C._set_cudnn_deterministic(_deterministic if cuda is not None else False)
     return orig_flags
 
 @contextmanager
@@ -166,256 +183,257 @@ def flags(enabled=False, benchmark=False, deterministic=False, verbose=False):
             set_flags(orig_flags[0], orig_flags[1], orig_flags[2], orig_flags[3])
 
 
-class CuDNNHandle:
-    def __init__(self):
-        ptr = ctypes.c_void_p()
-        check_error(lib.cudnnCreate(ctypes.byref(ptr)))
-        self._as_parameter_ = ptr
-
-    def __del__(self):
-        check_error(lib.cudnnDestroy(self))
-
-
-class CuDNNError(RuntimeError):
-    def __init__(self, status):
-        self.status = status
-        msg = '{}: {}'.format(status, get_error_string(status))
-        super(CuDNNError, self).__init__(msg)
-
-
-class TensorDescriptor(object):
-    def __init__(self):
-        ptr = ctypes.c_void_p()
-        check_error(lib.cudnnCreateTensorDescriptor(ctypes.byref(ptr)))
-        self._as_parameter_ = ptr
-
-    def __del__(self):
-        check_error(lib.cudnnDestroyTensorDescriptor(self._as_parameter_))
-        del self._as_parameter_
-
-    def set(self, tensor):
-        self._type = tensor.type()
-        self._size = tensor.size()
-        self._stride = tensor.stride()
-        check_error(lib.cudnnSetTensorNdDescriptor(
-            self, _typemap[tensor.type()], tensor.dim(),
-            int_array(tensor.size()), int_array(tensor.stride())))
-
-    def as_tuple(self):
-        return (self._type, tuple(self._size), tuple(self._stride))
-
-
-class TensorDescriptorArray(object):
-    def __init__(self, N):
-        self.ptrs = (ctypes.c_void_p * N)()
-        for i in range(N):
-            ptr = ctypes.byref(self.ptrs, i * ctypes.sizeof(ctypes.c_void_p))
-            check_error(lib.cudnnCreateTensorDescriptor(ptr))
-        self._as_parameter_ = self.ptrs
-
-    def __del__(self):
-        for ptr in self.ptrs:
-            check_error(lib.cudnnDestroyTensorDescriptor(ctypes.c_void_p(ptr)))
-
-    def __getitem__(self, key):
-        return ctypes.c_void_p(self.ptrs[key])
-
-    def set_all(self, tensor):
-        _type = _typemap[tensor.type()]
-        _ndim = tensor.dim()
-        _size = int_array(tensor.size())
-        _stride = int_array(tensor.stride())
-        for ptr in self.ptrs:
+if cuda is not None:
+    class CuDNNHandle:
+        def __init__(self):
+            ptr = ctypes.c_void_p()
+            check_error(lib.cudnnCreate(ctypes.byref(ptr)))
+            self._as_parameter_ = ptr
+    
+        def __del__(self):
+            check_error(lib.cudnnDestroy(self))
+    
+    
+    class CuDNNError(RuntimeError):
+        def __init__(self, status):
+            self.status = status
+            msg = '{}: {}'.format(status, get_error_string(status))
+            super(CuDNNError, self).__init__(msg)
+    
+    
+    class TensorDescriptor(object):
+        def __init__(self):
+            ptr = ctypes.c_void_p()
+            check_error(lib.cudnnCreateTensorDescriptor(ctypes.byref(ptr)))
+            self._as_parameter_ = ptr
+    
+        def __del__(self):
+            check_error(lib.cudnnDestroyTensorDescriptor(self._as_parameter_))
+            del self._as_parameter_
+    
+        def set(self, tensor):
+            self._type = tensor.type()
+            self._size = tensor.size()
+            self._stride = tensor.stride()
+            check_error(lib.cudnnSetTensorNdDescriptor(
+                self, _typemap[tensor.type()], tensor.dim(),
+                int_array(tensor.size()), int_array(tensor.stride())))
+    
+        def as_tuple(self):
+            return (self._type, tuple(self._size), tuple(self._stride))
+    
+    
+    class TensorDescriptorArray(object):
+        def __init__(self, N):
+            self.ptrs = (ctypes.c_void_p * N)()
+            for i in range(N):
+                ptr = ctypes.byref(self.ptrs, i * ctypes.sizeof(ctypes.c_void_p))
+                check_error(lib.cudnnCreateTensorDescriptor(ptr))
+            self._as_parameter_ = self.ptrs
+    
+        def __del__(self):
+            for ptr in self.ptrs:
+                check_error(lib.cudnnDestroyTensorDescriptor(ctypes.c_void_p(ptr)))
+    
+        def __getitem__(self, key):
+            return ctypes.c_void_p(self.ptrs[key])
+    
+        def set_all(self, tensor):
+            _type = _typemap[tensor.type()]
+            _ndim = tensor.dim()
+            _size = int_array(tensor.size())
+            _stride = int_array(tensor.stride())
+            for ptr in self.ptrs:
+                check_error(lib.cudnnSetTensorNdDescriptor(
+                    ctypes.c_void_p(ptr), _type, _ndim, _size, _stride))
+    
+        def set_raw(self, i, _type, _ndim, _size, _stride):
+            ptr = self.ptrs[i]
             check_error(lib.cudnnSetTensorNdDescriptor(
                 ctypes.c_void_p(ptr), _type, _ndim, _size, _stride))
-
-    def set_raw(self, i, _type, _ndim, _size, _stride):
-        ptr = self.ptrs[i]
-        check_error(lib.cudnnSetTensorNdDescriptor(
-            ctypes.c_void_p(ptr), _type, _ndim, _size, _stride))
-
-
-class FilterDescriptor(object):
-    def __init__(self):
-        ptr = ctypes.c_void_p()
-        check_error(lib.cudnnCreateFilterDescriptor(ctypes.byref(ptr)))
-        self._as_parameter_ = ptr
-
-    def __del__(self):
-        check_error(lib.cudnnDestroyFilterDescriptor(self._as_parameter_))
-        del self._as_parameter_
-
-    def set(self, weight):
-        self._size = weight.size()
-        datatype = _typemap[weight.type()]
-        check_error(lib.cudnnSetFilterNdDescriptor(
-            self, datatype, CUDNN_TENSOR_NCHW, weight.ndimension(),
-            int_array(weight.size())))
-
-    def as_tuple(self):
-        return tuple(self._size)
-
-
-class DropoutDescriptor(object):
-    def __init__(self, handle, dropout, seed):
-        ptr = ctypes.c_void_p()
-        check_error(lib.cudnnCreateDropoutDescriptor(ctypes.byref(ptr)))
-
-        self._as_parameter_ = ptr
-        self.state = None
-        self.dropout = dropout
-        self.handle = handle
-
-        self._set(dropout, seed)
-
-    def set_dropout(self, dropout, seed):
-        if dropout != self.dropout:
+    
+    
+    class FilterDescriptor(object):
+        def __init__(self):
+            ptr = ctypes.c_void_p()
+            check_error(lib.cudnnCreateFilterDescriptor(ctypes.byref(ptr)))
+            self._as_parameter_ = ptr
+    
+        def __del__(self):
+            check_error(lib.cudnnDestroyFilterDescriptor(self._as_parameter_))
+            del self._as_parameter_
+    
+        def set(self, weight):
+            self._size = weight.size()
+            datatype = _typemap[weight.type()]
+            check_error(lib.cudnnSetFilterNdDescriptor(
+                self, datatype, CUDNN_TENSOR_NCHW, weight.ndimension(),
+                int_array(weight.size())))
+    
+        def as_tuple(self):
+            return tuple(self._size)
+    
+    
+    class DropoutDescriptor(object):
+        def __init__(self, handle, dropout, seed):
+            ptr = ctypes.c_void_p()
+            check_error(lib.cudnnCreateDropoutDescriptor(ctypes.byref(ptr)))
+    
+            self._as_parameter_ = ptr
+            self.state = None
+            self.dropout = dropout
+            self.handle = handle
+    
             self._set(dropout, seed)
-
-    def _set(self, dropout, seed):
-        if self.state is None and dropout > 0:
-            dropout_states_size = ctypes.c_long()
-            check_error(lib.cudnnDropoutGetStatesSize(
+    
+        def set_dropout(self, dropout, seed):
+            if dropout != self.dropout:
+                self._set(dropout, seed)
+    
+        def _set(self, dropout, seed):
+            if self.state is None and dropout > 0:
+                dropout_states_size = ctypes.c_long()
+                check_error(lib.cudnnDropoutGetStatesSize(
+                    self.handle,
+                    ctypes.byref(dropout_states_size)))
+                self.state = torch.cuda.ByteTensor(dropout_states_size.value)
+                state_ptr = self.state.data_ptr()
+                state_size = self.state.size(0)
+            else:
+                state_ptr = None
+                state_size = 0
+    
+            check_error(lib.cudnnSetDropoutDescriptor(
+                self,
                 self.handle,
-                ctypes.byref(dropout_states_size)))
-            self.state = torch.cuda.ByteTensor(dropout_states_size.value)
-            state_ptr = self.state.data_ptr()
-            state_size = self.state.size(0)
-        else:
-            state_ptr = None
-            state_size = 0
-
-        check_error(lib.cudnnSetDropoutDescriptor(
-            self,
-            self.handle,
-            ctypes.c_float(dropout),
-            ctypes.c_void_p(state_ptr),
-            ctypes.c_size_t(state_size),
-            ctypes.c_ulonglong(seed),
-        ))
-
-        self.dropout = dropout
-
-    def __del__(self):
-        check_error(lib.cudnnDestroyDropoutDescriptor(self))
-
-
-class RNNDescriptor(object):
-    def __init__(self, handle, hidden_size, num_layers, dropout_desc, input_mode,
-                 bidirectional, mode, datatype):
-        ptr = ctypes.c_void_p()
-        check_error(lib.cudnnCreateRNNDescriptor(ctypes.byref(ptr)))
-        self._as_parameter_ = ptr
-        if version() >= 6000:
-            check_error(lib.cudnnSetRNNDescriptor_v6(
-                handle,
-                self,
-                hidden_size,
-                num_layers,
-                dropout_desc,
-                input_mode,
-                bidirectional,
-                mode,
-                CUDNN_RNN_ALGO_STANDARD,
-                datatype
+                ctypes.c_float(dropout),
+                ctypes.c_void_p(state_ptr),
+                ctypes.c_size_t(state_size),
+                ctypes.c_ulonglong(seed),
             ))
-            if version() >= 7000 and int(cuda[0]) >= 9 and (
-                    torch.cuda.get_device_capability(torch.cuda.current_device())[0] >= 7):
-                lib.cudnnSetRNNMatrixMathType(self, CUDNN_DEFAULT_MATH)
-                if datatype == CUDNN_DATA_HALF:
-                    lib.cudnnSetRNNMatrixMathType(self, CUDNN_TENSOR_OP_MATH)
+    
+            self.dropout = dropout
+    
+        def __del__(self):
+            check_error(lib.cudnnDestroyDropoutDescriptor(self))
+    
+    
+    class RNNDescriptor(object):
+        def __init__(self, handle, hidden_size, num_layers, dropout_desc, input_mode,
+                     bidirectional, mode, datatype):
+            ptr = ctypes.c_void_p()
+            check_error(lib.cudnnCreateRNNDescriptor(ctypes.byref(ptr)))
+            self._as_parameter_ = ptr
+            if version() >= 6000:
+                check_error(lib.cudnnSetRNNDescriptor_v6(
+                    handle,
+                    self,
+                    hidden_size,
+                    num_layers,
+                    dropout_desc,
+                    input_mode,
+                    bidirectional,
+                    mode,
+                    CUDNN_RNN_ALGO_STANDARD,
+                    datatype
+                ))
+                if version() >= 7000 and int(cuda[0]) >= 9 and (
+                        torch.cuda.get_device_capability(torch.cuda.current_device())[0] >= 7):
+                    lib.cudnnSetRNNMatrixMathType(self, CUDNN_DEFAULT_MATH)
+                    if datatype == CUDNN_DATA_HALF:
+                        lib.cudnnSetRNNMatrixMathType(self, CUDNN_TENSOR_OP_MATH)
+            else:
+                check_error(lib.cudnnSetRNNDescriptor(
+                    self,
+                    hidden_size,
+                    num_layers,
+                    dropout_desc,
+                    input_mode,
+                    bidirectional,
+                    mode,
+                    datatype
+                ))
+    
+        def __del__(self):
+            check_error(lib.cudnnDestroyRNNDescriptor(self))
+    
+    
+    def check_error(status):
+        if status != 0:
+            raise CuDNNError(status)
+    
+    
+    def get_error_string(status):
+        return lib.cudnnGetErrorString(status)
+    
+    
+    def get_handle():
+        if _libcudnn() is None:
+            raise RuntimeError('cuDNN not available')
+        current_device = torch.cuda.current_device()
+        handle = _handles.get(current_device, None)
+        if handle is None:
+            handle = CuDNNHandle()
+            _handles[current_device] = handle
+        return handle
+    
+    
+    _typemap = {
+        'torch.cuda.HalfTensor': CUDNN_DATA_HALF,
+        'torch.cuda.FloatTensor': CUDNN_DATA_FLOAT,
+        'torch.cuda.DoubleTensor': CUDNN_DATA_DOUBLE,
+    }
+    
+    _sizeofmap = {
+        CUDNN_DATA_HALF: 2,
+        CUDNN_DATA_FLOAT: 4,
+        CUDNN_DATA_DOUBLE: 8,
+    }
+    
+    
+    def c_type(tensor):
+        if isinstance(tensor, torch.cuda.HalfTensor):
+            return ctypes.c_float
+        elif isinstance(tensor, torch.cuda.FloatTensor):
+            return ctypes.c_float
+        elif isinstance(tensor, torch.cuda.DoubleTensor):
+            return ctypes.c_double
         else:
-            check_error(lib.cudnnSetRNNDescriptor(
-                self,
-                hidden_size,
-                num_layers,
-                dropout_desc,
-                input_mode,
-                bidirectional,
-                mode,
-                datatype
-            ))
-
-    def __del__(self):
-        check_error(lib.cudnnDestroyRNNDescriptor(self))
-
-
-def check_error(status):
-    if status != 0:
-        raise CuDNNError(status)
-
-
-def get_error_string(status):
-    return lib.cudnnGetErrorString(status)
-
-
-def get_handle():
-    if _libcudnn() is None:
-        raise RuntimeError('cuDNN not available')
-    current_device = torch.cuda.current_device()
-    handle = _handles.get(current_device, None)
-    if handle is None:
-        handle = CuDNNHandle()
-        _handles[current_device] = handle
-    return handle
-
-
-_typemap = {
-    'torch.cuda.HalfTensor': CUDNN_DATA_HALF,
-    'torch.cuda.FloatTensor': CUDNN_DATA_FLOAT,
-    'torch.cuda.DoubleTensor': CUDNN_DATA_DOUBLE,
-}
-
-_sizeofmap = {
-    CUDNN_DATA_HALF: 2,
-    CUDNN_DATA_FLOAT: 4,
-    CUDNN_DATA_DOUBLE: 8,
-}
-
-
-def c_type(tensor):
-    if isinstance(tensor, torch.cuda.HalfTensor):
-        return ctypes.c_float
-    elif isinstance(tensor, torch.cuda.FloatTensor):
-        return ctypes.c_float
-    elif isinstance(tensor, torch.cuda.DoubleTensor):
-        return ctypes.c_double
-    else:
-        raise ValueError("unknown type '{}'".format(type(tensor)))
-
-
-def int_array(itr):
-    array_type = ctypes.c_int * len(itr)
-    return array_type(*itr)
-
-
-def descriptor(tensor, N=None):
-    padded_size = tensor.size() + ((1,) * (5 - tensor.dim()))
-    tensor = tensor.view(padded_size)
-    if N is not None:
-        descriptor = TensorDescriptorArray(N)
-        descriptor.set_all(tensor)
-    else:
-        descriptor = TensorDescriptor()
-        descriptor.set(tensor)
-    return descriptor
-
-
-def descriptor_sequence(tensor, batch_sizes):
-    descriptors = TensorDescriptorArray(len(batch_sizes))
-    _type = _typemap[tensor.type()]
-    _ndim = 5
-    dim_pad = (1,) * (5 - tensor.dim())
-    _size = int_array(tensor.size() + dim_pad)
-    _stride = int_array(tensor.stride() + dim_pad)
-    for i, batch_size in enumerate(batch_sizes):
-        _size[0] = batch_size
-        descriptors.set_raw(i, _type, _ndim, _size, _stride)
-    return descriptors
-
-
-def add_tensor(*args):
-    check_error(lib.cudnnAddTensor(*args))
+            raise ValueError("unknown type '{}'".format(type(tensor)))
+    
+    
+    def int_array(itr):
+        array_type = ctypes.c_int * len(itr)
+        return array_type(*itr)
+    
+    
+    def descriptor(tensor, N=None):
+        padded_size = tensor.size() + ((1,) * (5 - tensor.dim()))
+        tensor = tensor.view(padded_size)
+        if N is not None:
+            descriptor = TensorDescriptorArray(N)
+            descriptor.set_all(tensor)
+        else:
+            descriptor = TensorDescriptor()
+            descriptor.set(tensor)
+        return descriptor
+    
+    
+    def descriptor_sequence(tensor, batch_sizes):
+        descriptors = TensorDescriptorArray(len(batch_sizes))
+        _type = _typemap[tensor.type()]
+        _ndim = 5
+        dim_pad = (1,) * (5 - tensor.dim())
+        _size = int_array(tensor.size() + dim_pad)
+        _stride = int_array(tensor.stride() + dim_pad)
+        for i, batch_size in enumerate(batch_sizes):
+            _size[0] = batch_size
+            descriptors.set_raw(i, _type, _ndim, _size, _stride)
+        return descriptors
+    
+    
+    def add_tensor(*args):
+        check_error(lib.cudnnAddTensor(*args))
 
 
 # The magic here is to allow us to intercept code like this:

--- a/torch/backends/cudnn/__init__.py
+++ b/torch/backends/cudnn/__init__.py
@@ -162,7 +162,7 @@ def set_flags(_enabled, _benchmark, _deterministic, _verbose):
     return orig_flags
 
 @contextmanager
-def flags(enabled=False, benchmark=(False if cuda is not None else True), deterministic=False, verbose=False):
+def flags(enabled=False, benchmark=False, deterministic=False, verbose=False):
     with __allow_nonbracketed_mutation():
         orig_flags = set_flags(enabled, benchmark, deterministic, verbose)
     try:

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -737,7 +737,7 @@ PyObject* initModule() {
     return PyModule_AddObject(module, name, v) == 0;
   };
 
-#if defined(USE_CUDNN) || defined(USE_ROCM)
+#if defined(USE_CUDNN) || defined(__HIP_PLATFORM_HCC__)
   PyObject *has_cudnn = Py_True;
 #else
   PyObject *has_cudnn = Py_False;

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -450,6 +450,10 @@ PyObject *THPModule_setBenchmarkCuDNN(PyObject *_unused, PyObject *arg)
 {
   THPUtils_assert(PyBool_Check(arg), "set_benchmark_cudnn expects a bool, "
           "but got %s", THPUtils_typename(arg));
+#ifdef USE_ROCM
+  fprintf(stderr, "Warning: Disabling benchmark mode for MIOpen is NOT supported. Overriding value to True.\n");
+  arg = Py_True;
+#endif
   at::globalContext().setBenchmarkCuDNN(arg == Py_True);
   Py_RETURN_NONE;
 }

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -731,7 +731,7 @@ PyObject* initModule() {
     return PyModule_AddObject(module, name, v) == 0;
   };
 
-#ifdef USE_CUDNN
+#if defined(USE_CUDNN) || defined(USE_ROCM)
   PyObject *has_cudnn = Py_True;
 #else
   PyObject *has_cudnn = Py_False;

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -451,8 +451,10 @@ PyObject *THPModule_setBenchmarkCuDNN(PyObject *_unused, PyObject *arg)
   THPUtils_assert(PyBool_Check(arg), "set_benchmark_cudnn expects a bool, "
           "but got %s", THPUtils_typename(arg));
 #ifdef USE_ROCM
-  fprintf(stderr, "Warning: Disabling benchmark mode for MIOpen is NOT supported. Overriding value to True.\n");
-  arg = Py_True;
+  if (arg == Py_False) {
+    TORCH_WARN_ONCE("Disabling benchmark mode for MIOpen is NOT supported. Overriding value to True");
+    arg = Py_True;
+  }
 #endif
   at::globalContext().setBenchmarkCuDNN(arg == Py_True);
   Py_RETURN_NONE;

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -450,7 +450,7 @@ PyObject *THPModule_setBenchmarkCuDNN(PyObject *_unused, PyObject *arg)
 {
   THPUtils_assert(PyBool_Check(arg), "set_benchmark_cudnn expects a bool, "
           "but got %s", THPUtils_typename(arg));
-#ifdef USE_ROCM
+#ifdef __HIP_PLATFORM_HCC__
   if (arg == Py_False) {
     TORCH_WARN_ONCE("Disabling benchmark mode for MIOpen is NOT supported. Overriding value to True");
     arg = Py_True;


### PR DESCRIPTION
1. Set `torch._C.has_cudnn` to `True` for ROCm
2. Make MIOpen invocations respect value of `cudnn_enabled` or `at::globalContext().userEnabledCuDNN()`
3. `torch/backends/cudnn/__init__.py`: Add hip-specific changes (use "hide whitespace changes" option to view simpler diff)