### PR TITLE
Remove `clean_tag` from tensorboard

### DIFF
--- a/torch/utils/tensorboard/summary.py
+++ b/torch/utils/tensorboard/summary.py
@@ -6,7 +6,6 @@ import json
 import logging
 import numpy as np
 import os
-import re as _re
 
 # pylint: disable=unused-import
 from six.moves import range
@@ -21,9 +20,6 @@ from tensorboard.plugins.pr_curve.plugin_data_pb2 import PrCurvePluginData
 from tensorboard.plugins.custom_scalar import layout_pb2
 from ._convert_np import make_np
 from ._utils import _prepare_video, convert_to_HWC
-
-
-_INVALID_TAG_CHARACTERS = _re.compile(r'[^-/\w\.]')
 
 
 def _calc_scale_factor(tensor):

--- a/torch/utils/tensorboard/summary.py
+++ b/torch/utils/tensorboard/summary.py
@@ -31,24 +31,6 @@ def _calc_scale_factor(tensor):
     return 1 if converted.dtype == np.uint8 else 255
 
 
-def _clean_tag(name):
-    # In the past, the first argument to summary ops was a tag, which allowed
-    # arbitrary characters. Now we are changing the first argument to be the node
-    # name. This has a number of advantages (users of summary ops now can
-    # take advantage of the tf name scope system) but risks breaking existing
-    # usage, because a much smaller set of characters are allowed in node names.
-    # This function replaces all illegal characters with _s, and logs a warning.
-    # It also strips leading slashes from the name.
-    if name is not None:
-        new_name = _INVALID_TAG_CHARACTERS.sub('_', name)
-        new_name = new_name.lstrip('/')  # Remove leading slashes
-        if new_name != name:
-            logging.info(
-                'Summary name %s is illegal; using %s instead.' % (name, new_name))
-            name = new_name
-    return name
-
-
 def _draw_single_box(image, xmin, ymin, xmax, ymax, display_str, color='black', color_text='black', thickness=2):
     from PIL import ImageDraw, ImageFont
     font = ImageFont.load_default()
@@ -192,7 +174,6 @@ def scalar(name, scalar, collections=None):
     Raises:
       ValueError: If tensor has the wrong shape or type.
     """
-    name = _clean_tag(name)
     scalar = make_np(scalar)
     assert(scalar.squeeze().ndim == 0), 'scalar should be 0D'
     scalar = float(scalar)
@@ -245,7 +226,6 @@ def histogram(name, values, bins, max_bins=None):
       A scalar `Tensor` of type `string`. The serialized `Summary` protocol
       buffer.
     """
-    name = _clean_tag(name)
     values = make_np(values)
     hist = make_histogram(values.astype(float), bins, max_bins)
     return Summary(value=[Summary.Value(tag=name, histo=hist)])
@@ -322,7 +302,6 @@ def image(tag, tensor, rescale=1, dataformats='NCHW'):
       A scalar `Tensor` of type `string`. The serialized `Summary` protocol
       buffer.
     """
-    tag = _clean_tag(tag)
     tensor = make_np(tensor)
     tensor = convert_to_HWC(tensor, dataformats)
     # Do not assume that user passes in values in [0, 255], use data type to detect
@@ -383,7 +362,6 @@ def make_image(tensor, rescale=1, rois=None):
 
 
 def video(tag, tensor, fps=4):
-    tag = _clean_tag(tag)
     tensor = make_np(tensor)
     tensor = _prepare_video(tensor)
     # If user passes in uint8, then we don't need to rescale by 255


### PR DESCRIPTION
The function originally comes from https://github.com/tensorflow/tensorflow/blob/4279f99847e9fcce9410bda61d3b71065e0df65f/tensorflow/python/ops/summary_op_util.py#L45-L68

As its comment says:
```   
    # In the past, the first argument to summary ops was a tag, which allowed
    # arbitrary characters. Now we are changing the first argument to be the node
    # name. This has a number of advantages (users of summary ops now can
    # take advantage of the tf name scope system) but risks breaking existing
    # usage, because a much smaller set of characters are allowed in node names.
    # This function replaces all illegal characters with _s, and logs a warning.
    # It also strips leading slashes from the name.
```

This function is only for compatibility with TF's operator name restrictions, and is therefore no longer valid in pytorch. By removing it, tensorboard summaries can use more characters in the names.

Before:
![0209-12:10:14](https://user-images.githubusercontent.com/1381301/74109072-37382e00-4b35-11ea-8c9f-ab37a8bd5808.png)


After:
![0209-12:10:57](https://user-images.githubusercontent.com/1381301/74109081-4323f000-4b35-11ea-9dab-447f8466a41e.png)
