### PR TITLE
Move cumsum to Aten(CPU)

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -605,7 +605,8 @@
 [[
   name: _th_cumsum
   cname: cumsum
-  cpu_bool: True
+  backends:
+    - CUDA
   cuda_bool: True
   variants: function
   return: argument 0

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -5237,12 +5237,12 @@
 - func: _cumsum(Tensor self, int dim) -> Tensor
   use_c10_dispatcher: full
   dispatch:
-    CPU: legacy::cpu::_th_cumsum
+    CPU: _cumsum_cpu
     CUDA: legacy::cuda::_th_cumsum
 
 - func: _cumsum.out(Tensor self, int dim, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
-    CPU: legacy::cpu::_th_cumsum_out
+    CPU: _cumsum_out_cpu
     CUDA: legacy::cuda::_th_cumsum_out
 
 - func: _cumprod(Tensor self, int dim) -> Tensor

--- a/aten/src/TH/generic/THTensorMath.h
+++ b/aten/src/TH/generic/THTensorMath.h
@@ -94,7 +94,6 @@ TH_API void THTensor_(indexFill)(THTensor *tensor, int dim, THLongTensor *index,
 TH_API void THTensor_(scatter)(THTensor *tensor, int dim, THLongTensor *index, THTensor *src);
 TH_API void THTensor_(scatterFill)(THTensor *tensor, int dim, THLongTensor *index, scalar_t val);
 
-TH_API void THTensor_(cumsum)(THTensor *r_, THTensor *t, int dimension);
 TH_API void THTensor_(cumprod)(THTensor *r_, THTensor *t, int dimension);
 
 #if !defined(TH_REAL_IS_BOOL) /* non bool only part */

--- a/aten/src/TH/generic/THTensorMoreMath.cpp
+++ b/aten/src/TH/generic/THTensorMoreMath.cpp
@@ -256,24 +256,6 @@ void THTensor_(cmin)(THTensor *r, THTensor *t, THTensor *src) {
                    *r_data = *t_data < *src_data ? *t_data : *src_data;);
 }
 
-void THTensor_(cumsum)(THTensor *r_, THTensor *t, int dimension)
-{
-  dimension = at::maybe_wrap_dim(dimension, t);
-  THArgCheck(dimension >= 0 && dimension < THTensor_(nDimensionLegacyNoScalars)(t), 2, "dimension %d out of range",
-      dimension);
-
-  THTensor_(resizeAs)(r_, t);
-
-  TH_TENSOR_DIM_APPLY2(scalar_t, t, scalar_t, r_, dimension,
-                       accreal cumsum = 0;
-                       int64_t i;
-                       for(i = 0; i < t_size; i++)
-                       {
-                         cumsum += t_data[i*t_stride];
-                         r__data[i*r__stride] = (scalar_t)cumsum;
-                       });
-}
-
 void THTensor_(cumprod)(THTensor *r_, THTensor *t, int dimension)
 {
   dimension = at::maybe_wrap_dim(dimension, t);


### PR DESCRIPTION
This PR is about move cumsum to Aten.
Test script:
```
import torch
 import torch.nn as nn
 import time

 torch.manual_seed(0)

 def _time():
     return time.time()

 device = "cpu"

 #warm up
 for n in [10, 100]:
     for c in [10, 100]:
         for h in [10, 100]:
             input = torch.randn(n, c, h, requires_grad=False, device=device)
             for dim in range(input.dim()):
                 for i in range(1000):
                     output = input.cumsum(dim)
for n in [10, 100]:
     for c in [10, 100]:
         for h in [10, 100]:
             input = torch.randn(n, c, h, requires_grad=False, device=device)
             for dim in range(input.dim()):
                 fwd_t = 0
                 for i in range(10000):
                     t1 = _time()
                     input.cumsum(dim)
                     t2 = _time()
                     fwd_t = fwd_t + (t2 -t1)
                 fwd_avg = fwd_t / 10000 * 1000
                 print("input size(%d, %d, %d) with reduce dim is %d : forward time is %.4f (ms)." % (n, c, h, dim,      fwd_avg))
```
Test device: **skx-8180**.
Before:
```
input size(10, 10, 10) with reduce dim is 0 : forward time is 0.0098 (ms).
input size(10, 10, 10) with reduce dim is 1 : forward time is 0.0090 (ms).
input size(10, 10, 10) with reduce dim is 2 : forward time is 0.0089 (ms).
input size(10, 10, 100) with reduce dim is 0 : forward time is 0.0745 (ms).
input size(10, 10, 100) with reduce dim is 1 : forward time is 0.0654 (ms).
input size(10, 10, 100) with reduce dim is 2 : forward time is 0.0204 (ms).
input size(10, 100, 10) with reduce dim is 0 : forward time is 0.0677 (ms).
input size(10, 100, 10) with reduce dim is 1 : forward time is 0.0204 (ms).
input size(10, 100, 10) with reduce dim is 2 : forward time is 0.0636 (ms).
input size(10, 100, 100) with reduce dim is 0 : forward time is 0.7003 (ms).
input size(10, 100, 100) with reduce dim is 1 : forward time is 0.1889 (ms).
input size(10, 100, 100) with reduce dim is 2 : forward time is 0.1858 (ms).
input size(100, 10, 10) with reduce dim is 0 : forward time is 0.0222 (ms).
input size(100, 10, 10) with reduce dim is 1 : forward time is 0.0606 (ms).
input size(100, 10, 10) with reduce dim is 2 : forward time is 0.0604 (ms).
input size(100, 10, 100) with reduce dim is 0 : forward time is 0.2116 (ms).
input size(100, 10, 100) with reduce dim is 1 : forward time is 0.6120 (ms).
input size(100, 10, 100) with reduce dim is 2 : forward time is 0.1750 (ms).
input size(100, 100, 10) with reduce dim is 0 : forward time is 0.1859 (ms).
input size(100, 100, 10) with reduce dim is 1 : forward time is 0.1709 (ms).
input size(100, 100, 10) with reduce dim is 2 : forward time is 0.5732 (ms).
input size(100, 100, 100) with reduce dim is 0 : forward time is 4.6547 (ms).
input size(100, 100, 100) with reduce dim is 1 : forward time is 4.8224 (ms).
input size(100, 100, 100) with reduce dim is 2 : forward time is 1.7931 (ms).
```
After:
```
input size(10, 10, 10) with reduce dim is 0 : forward time is 0.0052 (ms).
input size(10, 10, 10) with reduce dim is 1 : forward time is 0.0082 (ms).
input size(10, 10, 10) with reduce dim is 2 : forward time is 0.0086 (ms).
input size(10, 10, 100) with reduce dim is 0 : forward time is 0.0106 (ms).
input size(10, 10, 100) with reduce dim is 1 : forward time is 0.0081 (ms).
input size(10, 10, 100) with reduce dim is 2 : forward time is 0.0087 (ms).
input size(10, 100, 10) with reduce dim is 0 : forward time is 0.0137 (ms).
input size(10, 100, 10) with reduce dim is 1 : forward time is 0.0098 (ms).
input size(10, 100, 10) with reduce dim is 2 : forward time is 0.0088 (ms).
input size(10, 100, 100) with reduce dim is 0 : forward time is 0.0723 (ms).
input size(10, 100, 100) with reduce dim is 1 : forward time is 0.0235 (ms).
input size(10, 100, 100) with reduce dim is 2 : forward time is 0.0150 (ms).
input size(100, 10, 10) with reduce dim is 0 : forward time is 0.0203 (ms).
input size(100, 10, 10) with reduce dim is 1 : forward time is 0.0096 (ms).
input size(100, 10, 10) with reduce dim is 2 : forward time is 0.0081 (ms).
input size(100, 10, 100) with reduce dim is 0 : forward time is 0.1101 (ms).
input size(100, 10, 100) with reduce dim is 1 : forward time is 0.0110 (ms).
input size(100, 10, 100) with reduce dim is 2 : forward time is 0.0108 (ms).
input size(100, 100, 10) with reduce dim is 0 : forward time is 0.1082 (ms).
input size(100, 100, 10) with reduce dim is 1 : forward time is 0.0104 (ms).
input size(100, 100, 10) with reduce dim is 2 : forward time is 0.0104 (ms).
input size(100, 100, 100) with reduce dim is 0 : forward time is 1.1523 (ms).
input size(100, 100, 100) with reduce dim is 1 : forward time is 0.0411 (ms).
input size(100, 100, 100) with reduce dim is 2 : forward time is 0.0324 (ms).
```
Fix https://github.com/pytorch/pytorch/issues/24669.