### PR TITLE
Fix logging for aborted communicators in ProcessGroupNCCL.

### DIFF
--- a/torch/lib/c10d/ProcessGroupNCCL.cpp
+++ b/torch/lib/c10d/ProcessGroupNCCL.cpp
@@ -328,10 +328,10 @@ void ProcessGroupNCCL::ncclCommWatchdogInternal() {
         }
 
         if (checkForNCCLErrors(ncclComms)) {
-          LOG(INFO) << "Received NCCL errors for communicators in the cache, "
-                       "aborting the communicators.";
+          LOG(INFO) << "Received NCCL errors for communicators in the cache";
 
           if (blockingWait_) {
+            LOG(INFO) << "Aborting communicators that received errors";
             // We should not abort the communicators if we are performing a
             // non-blocking wait(). The reason for this is that if we abort the
             // nccl communicator, wait() might not throw exceptions and


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#33147 Fix logging for aborted communicators in ProcessGroupNCCL.**

The log mentioned that it is aborting communicators even if
`blockingWait_` was false. This was incorrect, and I updated the logging to
reflect the appropriate behavior.

Differential Revision: [D19817967](https://our.internmc.facebook.com/intern/diff/D19817967/)