### PR TITLE
[JIT] Don't run constant propagation on values that escape

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -3144,6 +3144,17 @@ graph(%Ra, %Rb):
 
         FileCheck().check_not("prim::If").run(fn.graph)
 
+    def test_constant_prop_escapes_scope(self):
+        @torch.jit.script
+        def foo():
+            return torch.tensor([2])
+
+        self.run_pass('constant_propagation', foo.graph)
+        FileCheck().check("aten::tensor").run(foo.graph)
+        out = foo()
+        out[0] = 4
+        self.assertEqual(foo(), torch.tensor([2]))
+
     def test_short_circuit_optimization(self):
         @torch.jit.script
         def const_expressions(x):

--- a/torch/csrc/jit/passes/alias_analysis.h
+++ b/torch/csrc/jit/passes/alias_analysis.h
@@ -90,6 +90,9 @@ class AliasDb {
       const at::ArrayRef<Value*>& a,
       const at::ArrayRef<Value*>& b) const;
 
+  // does any value in `vs` potentially escape the current graph scope
+  bool escapesScope(const at::ArrayRef<Value*>& vs) const;
+
   // Move 'n' (already in the graph) after 'movePoint' in the topological order.
   //
   // Tries to preserve value dependencies, so other nodes might be moved. We
@@ -145,8 +148,6 @@ class AliasDb {
 
   // Is this a value which will not alias
   bool nonAliasingValue(const Value* elem) const;
-
-  bool escapesScope(const at::ArrayRef<Value*>& vs) const;
 
   /**
    * Special analysis methods

--- a/torch/csrc/jit/passes/constant_propagation.cpp
+++ b/torch/csrc/jit/passes/constant_propagation.cpp
@@ -270,7 +270,7 @@ struct ConstantPropagator {
     if (aliasDb_) {
       no_mutation = !aliasDb_->hasWriters(n);
       // outputs may be written to if they escape scope
-      no_mutation = no_mutation && !aliasDb_->escapesScope(n->outputs())
+      no_mutation = no_mutation && !aliasDb_->escapesScope(n->outputs());
     } else {
       no_mutation =
           noMutableValues(n->inputs()) && noMutableValues(n->outputs());


### PR DESCRIPTION
We shouldn't run constant propagation on mutable values that escape, because they might be mutated outside of the current scope. This hasn't been a problem because we inline everything, but better to be more safe here.

EDIT: maybe we don't want this PR until we track contained elements of lists / dictionaries