### PR TITLE
[WIP] Move schema inference into KernelFunction factory.

### DIFF
--- a/aten/src/ATen/core/boxing/KernelFunction.h
+++ b/aten/src/ATen/core/boxing/KernelFunction.h
@@ -5,6 +5,7 @@
 #include <ATen/core/boxing/kernel_functor.h>
 #include <ATen/core/boxing/kernel_function.h>
 #include <ATen/core/boxing/kernel_lambda.h>
+#include <ATen/core/op_registration/infer_schema.h>
 
 namespace c10 {
 
@@ -209,9 +210,13 @@ public:
   template<bool AllowLegacyTypes = false, class Lambda>
   static KernelFunction makeFromUnboxedLambda(Lambda&& lambda);
 
+  FunctionSchema* inferred_function_schema() const {
+    return inferred_function_schema_.get();
+  }
+
 private:
 
-  explicit KernelFunction(std::function<std::unique_ptr<OperatorKernel>()> functorFactory, std::unique_ptr<OperatorKernel> functor, InternalBoxedKernelFunction* boxed_kernel_func, void* unboxed_kernel_func);
+  explicit KernelFunction(std::function<std::unique_ptr<OperatorKernel>()> functorFactory, std::unique_ptr<OperatorKernel> functor, InternalBoxedKernelFunction* boxed_kernel_func, void* unboxed_kernel_func, std::unique_ptr<FunctionSchema> inferred_function_schema);
 
   template<BoxedKernelFunction* func>
   static void make_boxed_function(OperatorKernel*, const OperatorHandle& opHandle, Stack* stack);
@@ -233,6 +238,8 @@ private:
 
   InternalBoxedKernelFunction* boxed_kernel_func_;
   void* unboxed_kernel_func_;
+
+  std::shared_ptr<FunctionSchema> inferred_function_schema_;
 };
 
 }

--- a/aten/src/ATen/core/boxing/kernel_functor.h
+++ b/aten/src/ATen/core/boxing/kernel_functor.h
@@ -305,6 +305,9 @@ namespace detail {
   class FunctionSchemaInferer final {
   public:
     using func_type = typename c10::guts::infer_function_traits_t<KernelFunctor>::func_type;
+    std::unique_ptr<FunctionSchema> run() const {
+      return inferFunctionSchema_<func_type>();
+    }
     std::unique_ptr<FunctionSchema> operator()() const {
       return inferFunctionSchema_<func_type>();
     }

--- a/aten/src/ATen/core/op_registration/op_registration.cpp
+++ b/aten/src/ATen/core/op_registration/op_registration.cpp
@@ -44,11 +44,11 @@ void RegisterOperators::checkSchemaAndRegisterOp_(Options&& options) {
     const FunctionSchema& schema = options.schemaOrName_->right();
 
     for (auto& kernel : options.kernels) {
-      if (nullptr != kernel.inferred_function_schema.get()) {
-        c10::optional<std::string> schema_difference = findSchemaDifferences(schema, *kernel.inferred_function_schema);
+      if (nullptr != kernel.func.inferred_function_schema()) {
+        c10::optional<std::string> schema_difference = findSchemaDifferences(schema, *kernel.func.inferred_function_schema());
         if (schema_difference.has_value()) {
           TORCH_CHECK(false, "In operator registration: Specified function schema [", toString(schema), "] ",
-                   "doesn't match inferred function schema [", toString(*kernel.inferred_function_schema), "]. ",
+                   "doesn't match inferred function schema [", toString(*kernel.func.inferred_function_schema()), "]. ",
                    *schema_difference);
         }
       }
@@ -92,16 +92,16 @@ c10::FunctionSchema RegisterOperators::inferSchemaFromKernels_(const OperatorNam
 
   c10::optional<FunctionSchema> inferred_schema = c10::nullopt;
   for (const auto& kernel : options.kernels) {
-    if (nullptr != kernel.inferred_function_schema.get()) {
+    if (nullptr != kernel.func.inferred_function_schema()) {
       if (inferred_schema.has_value()) {
-        c10::optional<std::string> schema_difference = findSchemaDifferences(*inferred_schema, *kernel.inferred_function_schema);
+        c10::optional<std::string> schema_difference = findSchemaDifferences(*inferred_schema, *kernel.func.inferred_function_schema());
         if (schema_difference.has_value()) {
           TORCH_CHECK(false, "In operator registration: Tried to register kernels for same operator that infer a different function schema: [", toString(*inferred_schema), "] ",
-                   "doesn't match [", toString(*kernel.inferred_function_schema), "]. ",
+                   "doesn't match [", toString(*kernel.func.inferred_function_schema()), "]. ",
                    *schema_difference);
         }
       } else {
-        inferred_schema = *kernel.inferred_function_schema;
+        inferred_schema = *kernel.func.inferred_function_schema();
       }
     }
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#33158 [WIP] Move schema inference into KernelFunction factory.**
* #33097 Stop generating out full function type for registration, use decltype or infer it
* #33093 Delete unnecessary aliasAnalysis specification from operator registrations.
* #33011 Beef up documentation on DispatchKey.h

Signed-off-by: Edward Z. Yang <ezyang@fb.com>