### PR TITLE
[ONNX] Export split with list of sizes

### DIFF
--- a/aten/src/ATen/core/interned_strings.h
+++ b/aten/src/ATen/core/interned_strings.h
@@ -209,6 +209,7 @@ namespace c10 {
   _(onnx, Mod)                       \
   _(onnx, Sqrt)                      \
   _(onnx, SplitToSequence)           \
+  _(onnx, SequenceAt)                \
   _(onnx, SequenceConstruct)         \
   _(onnx, SequenceEmpty)             \
   _(onnx, SequenceInsert)            \

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -1907,6 +1907,19 @@ class TestONNXRuntime(unittest.TestCase):
         self.run_test(SplitModel2(), x)
 
     @skipIfUnsupportedMinOpsetVersion(11)
+    def test_split_size_as_list(self):
+        class SplitModel(torch.nn.Module):
+            def forward(self, input):
+                out = []
+                split_sizes = [input.shape[0] - 1, 1]
+                for ob in input.split(split_sizes):
+                    out.append(ob)
+                return torch.cat(out, dim=0)
+
+        x = torch.randn(5, 4, 3)
+        self.run_test(SplitModel(), x)
+
+    @skipIfUnsupportedMinOpsetVersion(11)
     def test_split_dynamic(self):
         class SplitModel(torch.jit.ScriptModule):
             @torch.jit.script_method

--- a/torch/csrc/jit/passes/onnx/peephole.cpp
+++ b/torch/csrc/jit/passes/onnx/peephole.cpp
@@ -663,9 +663,8 @@ static void fuseUnbindListUnpack(Block *b) {
 
 // Traced Split with list of sizes is being converted to ONNX as SplitToSequence + SequenceAt.
 // Example IR
-//  %2 : int = prim::Constant[value=0]
-//  %3 : Tensor[] = aten::split_with_sizes(%input, %split_list, %2)
-//  %4 : Float(), %5 : Float() = prim::ListUnpack(%3)
+//  %2 : Tensor[] = onnx::SplitToSequence[axis=0](%input, %split_list)
+//  %3 : Float(), %4 : Float() = prim::ListUnpack(%2)
 //
 // Translates to ONNX:
 //  %2 : Tensor[] = onnx::SplitToSequence[axis=0](%input, %split_list)

--- a/torch/csrc/jit/passes/onnx/peephole.cpp
+++ b/torch/csrc/jit/passes/onnx/peephole.cpp
@@ -661,6 +661,46 @@ static void fuseUnbindListUnpack(Block *b) {
   }
 }
 
+// Traced Split with list of sizes is being converted to ONNX as SplitToSequence + SequenceAt.
+// Example IR
+//  %2 : int = prim::Constant[value=0]
+//  %3 : Tensor[] = aten::split_with_sizes(%input, %split_list, %2)
+//  %4 : Float(), %5 : Float() = prim::ListUnpack(%3)
+//
+// Translates to ONNX:
+//  %2 : Tensor[] = onnx::SplitToSequence[axis=0](%input, %split_list)
+//  %3 : Tensor = onnx::Constant[value={1}]()
+//  %4 : Float() = onnx::SequenceAt(%2, %3)
+//  %5 : Tensor = onnx::Constant[value={0}]()
+//  %6 : Float() = onnx::SequenceAt(%2, %5)
+static void fuseSplitToSequenceListUnpack(Block *b) {
+  for (auto it = b->nodes().begin(), end = b->nodes().end(); it != end; ++it) {
+    for (auto* child_block : it->blocks()) {
+      fuseSplitToSequenceListUnpack(child_block);
+    }
+    if (it->kind() == prim::ListUnpack &&
+        it->input()->node()->kind() == onnx::SplitToSequence) {
+      Node* orig_split_to_sequence_node = it->input()->node();
+      for (size_t i = 0; i < it->outputs().size(); ++i) {
+        Node* split_const_node =  b->owningGraph()->create(onnx::Constant, 1);
+        auto tensor = at::empty(1, c10::kLong);
+        int64_t* data = tensor.data_ptr<int64_t>();
+        *data = i;
+        split_const_node->t_(
+          attr::value,
+          autograd::make_variable(tensor));
+        split_const_node->insertAfter(orig_split_to_sequence_node);
+        Node* seq_at_node =  b->owningGraph()->create(onnx::SequenceAt, {it->input(), split_const_node->output()});
+        seq_at_node->output()->copyMetadata(it->output(i));
+        it->output(i)->replaceAllUsesWith(seq_at_node->output());
+        seq_at_node->insertAfter(split_const_node);
+      }
+      it->removeAllInputs();
+      it.destroyCurrent();
+    }
+  }
+}
+
 // For ops such as meshgrid where output is a list of Tensors
 // (returns prim::ListConstruct), we need to unpack the list
 // before the pass which deletes ListConstruct.
@@ -734,7 +774,6 @@ static void convertSplitToDynamic(Block *b, int opset_version) {
     for (auto* child_block : it->blocks()) {
       convertSplitToDynamic(child_block, opset_version);
     }
-
     if (it->kind() == onnx::Split) {
       if (it->outputs().size() == 1 && it->output()->type()->kind() == TypeKind::ListType) {
         auto dim = it->i(attr::axis);
@@ -813,6 +852,7 @@ void PeepholeOptimizeONNX(std::shared_ptr<Graph>& graph, int opset_version, bool
   fuseTransposeIntoGemm(graph->block());
   speculateOps(graph->block());
   fuseListConstructListUnpack(graph->block());
+  fuseSplitToSequenceListUnpack(graph->block());
   fuseSplitListUnpack(graph->block());
   convertUnbindToSplit(graph->block(), opset_version);
   convertSplitToDynamic(graph->block(), opset_version);

--- a/torch/onnx/symbolic_opset11.py
+++ b/torch/onnx/symbolic_opset11.py
@@ -342,7 +342,7 @@ def split_with_sizes(g, self, split_sizes, dim):
     if sym_help._is_value(split_sizes) and split_sizes.node().kind() == 'prim::ListConstruct':
         return g.op("SplitToSequence", self, split_sizes, axis_i=dim)
     else:
-        torch.onnx.symbolic_opset9.split_with_sizes(g, self, split_sizes, dim)
+        return torch.onnx.symbolic_opset9.split_with_sizes(g, self, split_sizes, dim)
 
 
 # Generate paddings in ONNX order based on pad in pytorch.

--- a/torch/onnx/symbolic_opset11.py
+++ b/torch/onnx/symbolic_opset11.py
@@ -337,6 +337,14 @@ def round(g, self):
     return g.op("Round", self)
 
 
+@parse_args('v', 'v', 'i')
+def split_with_sizes(g, self, split_sizes, dim):
+    if sym_help._is_value(split_sizes) and split_sizes.node().kind() == 'prim::ListConstruct':
+        return g.op("SplitToSequence", self, split_sizes, axis_i=dim)
+    else:
+        torch.onnx.symbolic_opset9.split_with_sizes(g, self, split_sizes, dim)
+
+
 # Generate paddings in ONNX order based on pad in pytorch.
 # Arguments:
 #     dim: the dimension of the tensor.


### PR DESCRIPTION
Exporting Split with a dynamic list of split_sizes is not supported.
This PR enables export using onnx SplitToSequence + SequenceAt