### PR TITLE
Drop support of the build option USE_GLOO_IBVERBS

### DIFF
--- a/tools/setup_helpers/cmake.py
+++ b/tools/setup_helpers/cmake.py
@@ -218,7 +218,6 @@ class CMake:
             '_GLIBCXX_USE_CXX11_ABI': 'GLIBCXX_USE_CXX11_ABI',
             'CUDNN_LIB_DIR': 'CUDNN_LIBRARY',
             'USE_CUDA_STATIC_LINK': 'CAFFE2_STATIC_LINK_CUDA',
-            'USE_GLOO_IBVERBS': 'USE_IBVERBS'   # Backward compatibility. Will be removed in the future.
         }
         additional_options.update({
             # Build options that have the same environment variable name and CMake variable name and that do not start
@@ -245,9 +244,6 @@ class CMake:
              'ATEN_THREADING',
              'WERROR')
         })
-
-        if 'USE_GLOO_IBVERBS' in my_env:
-            print("WARNING: USE_GLOO_IBVERBS is deprecated. Use USE_IBVERBS instead.")
 
         for var, val in my_env.items():
             # We currently pass over all environment variables that start with "BUILD_", "USE_", and "CMAKE_". This is


### PR DESCRIPTION
Two releases have passed since its deprecation:
8a026d4f74b71944ac2860c315996165a40f5626

