### PR TITLE
Opitmize Unfold3d to improve performance of Conv3d

### DIFF
--- a/aten/src/ATen/native/Unfold3d.cpp
+++ b/aten/src/ATen/native/Unfold3d.cpp
@@ -1,134 +1,216 @@
 #include <ATen/ATen.h>
+#include <ATen/Config.h>
 #include <ATen/Parallel.h>
+
+#if AT_MKL_ENABLED()
+#include <mkl.h>
+#endif // AT_MKL_ENABLED()
 
 namespace at {
 namespace native {
 
 namespace {
 
-/*
-  Modified from the version of CUDA implementation, but the loop iterations is
-  larger than that one. The larger loop could lower the proportion of openmp
-  overhead. And the inner part in loop is simpler. The naive code is below:
+bool IsAGeZeroAndALtB(int64_t a, int64_t b) {
+  return static_cast<uint64_t>(a) < static_cast<uint64_t>(b);
+}
 
-  scalar_t *input_data = input->data<scalar_t>();
-  scalar_t *finput_data = finput->data<scalar_t>();
+template <typename T>
+void MatCopy(int64_t M, int64_t N, int64_t lda, int64_t ldb, const T* A, T* B) {
+  for (int64_t i = 0; i < M; ++i) {
+    std::memcpy(B + i * ldb, A + i * lda, N * sizeof(T));
+  }
+}
 
-  int64_t n = n_input_plane*kT*kH*kW*output_depth*output_width*output_height;
-  #pragma omp parallel for firstprivate(finput_data, input_data, output_width,
-  output_height, output_depth, kW, kH, kT, dW, dH, dT, pW, pH, pT, input_height,
-  input_width, input_depth) for (int64_t idx = 0; idx < n ; ++idx) { int64_t
-  w_out = line_index_offset % output_width; int64_t remained = line_index_offset
-  / output_width; int64_t h_out = remained % output_height; remained /=
-  output_height; int64_t d_out = remained % output_depth; remained /=
-  output_depth; int k = remained % kW; remained /= kW; int j = remained % kH;
-    remained /= kH;
-    int i = remained % kT;
-    int64_t nip = remained / kT;
+template <typename T>
+void MatCopy(
+    int64_t M,
+    int64_t N,
+    int64_t lda,
+    int64_t stridea,
+    int64_t ldb,
+    int64_t strideb,
+    const T* A,
+    T* B) {
+  for (int64_t i = 0; i < M; ++i) {
+    const T* A_ptr = A + i * lda;
+    T* B_ptr = B + i * ldb;
+    for (int64_t j = 0; j < N; ++j) {
+      B_ptr[j * strideb] = A_ptr[j * stridea];
+    }
+  }
+}
 
-    int64_t d = d_out * dT - pT + i;
-    int64_t h = h_out * dH - pH + j;
-    int64_t w = w_out * dW - pW + k;
+#if AT_MKL_ENABLED()
 
-    finput_data[idx] = (h >= 0 && w >= 0 && d >= 0 && h < input_height && w <
-  input_width && d < input_depth) ?
-      input_data[nip*input_depth*input_width*input_height+
-  d*input_height*input_width
-  + h*input_width + w] : 0;
+template <>
+void MatCopy<float>(
+    int64_t M,
+    int64_t N,
+    int64_t lda,
+    int64_t ldb,
+    const float* A,
+    float* B) {
+  mkl_somatcopy('R', 'N', M, N, 1.0f, A, lda, B, ldb);
+}
+
+template <>
+void MatCopy<double>(
+    int64_t M,
+    int64_t N,
+    int64_t lda,
+    int64_t ldb,
+    const double* A,
+    double* B) {
+  mkl_domatcopy('R', 'N', M, N, 1.0, A, lda, B, ldb);
+}
+
+template <>
+void MatCopy<float>(
+    int64_t M,
+    int64_t N,
+    int64_t lda,
+    int64_t stridea,
+    int64_t ldb,
+    int64_t strideb,
+    const float* A,
+    float* B) {
+  mkl_somatcopy2('R', 'N', M, N, 1.0f, A, lda, stridea, B, ldb, strideb);
+}
+
+template <>
+void MatCopy<double>(
+    int64_t M,
+    int64_t N,
+    int64_t lda,
+    int64_t stridea,
+    int64_t ldb,
+    int64_t strideb,
+    const double* A,
+    double* B) {
+  mkl_domatcopy2('R', 'N', M, N, 1.0, A, lda, stridea, B, ldb, strideb);
+}
+
+#endif // AT_MKL_ENABLED()
+
+template <typename T>
+void Unfold3dZeroPaddingCopyKernelImpl(
+    int64_t C,
+    int64_t X_D,
+    int64_t X_H,
+    int64_t X_W,
+    int64_t Y_D,
+    int64_t Y_H,
+    int64_t Y_W,
+    int64_t kernel_d,
+    int64_t kernel_h,
+    int64_t kernel_w,
+    int64_t stride_d,
+    int64_t stride_h,
+    int64_t stride_w,
+    const T* src,
+    T* dst) {
+  const int64_t n = C * kernel_d * kernel_h * kernel_w;
+  const int64_t X_size = X_D * X_H * X_W;
+  const int64_t Y_size = Y_D * Y_H * Y_W;
+  at::parallel_for(0, n, 0, [=](int64_t begin, int64_t end) {
+    for (int64_t p = begin; p < end; ++p) {
+      int64_t c = p;
+      const int64_t kw = c % kernel_w;
+      c /= kernel_w;
+      const int64_t kh = c % kernel_h;
+      c /= kernel_h;
+      const int64_t kd = c % kernel_d;
+      c /= kernel_d;
+      for (int64_t yd = 0; yd < Y_D; ++yd) {
+        const int64_t xd = yd * stride_d + kd;
+        const T* src_ptr = src + c * X_size + xd * X_H * X_W + kh * X_W + kw;
+        T* dst_ptr = dst + p * Y_size + yd * Y_H * Y_W;
+        if (stride_w == 1) {
+          MatCopy<T>(Y_H, Y_W, stride_h * X_W, Y_W, src_ptr, dst_ptr);
+        } else {
+          MatCopy<T>(
+              Y_H, Y_W, stride_h * X_W, stride_w, Y_W, 1, src_ptr, dst_ptr);
+        }
+      }
+    }
+  });
+}
+
+template <typename T>
+void Unfold3dCopyKernelImpl(
+    int64_t C,
+    int64_t X_D,
+    int64_t X_H,
+    int64_t X_W,
+    int64_t Y_D,
+    int64_t Y_H,
+    int64_t Y_W,
+    int64_t kernel_d,
+    int64_t kernel_h,
+    int64_t kernel_w,
+    int64_t stride_d,
+    int64_t stride_h,
+    int64_t stride_w,
+    int64_t pad_d,
+    int64_t pad_h,
+    int64_t pad_w,
+    const T* src,
+    T* dst) {
+  if (pad_d == 0 && pad_h == 0 && pad_w == 0) {
+    Unfold3dZeroPaddingCopyKernelImpl<T>(
+        C,
+        X_D,
+        X_H,
+        X_W,
+        Y_D,
+        Y_H,
+        Y_W,
+        kernel_d,
+        kernel_h,
+        kernel_w,
+        stride_d,
+        stride_h,
+        stride_w,
+        src,
+        dst);
+    return;
   }
 
-  However, there are 6 quotient and 6 module operations which are very
-  time-consuming. So we choose relatively more complex but more efficient
-  pattern.
-*/
-template <typename scalar_t>
-static void unfolded3d_copy(
-    scalar_t* finput_data,
-    scalar_t* input_data,
-    int kT,
-    int kH,
-    int kW,
-    int dT,
-    int dH,
-    int dW,
-    int pT,
-    int pH,
-    int pW,
-    int64_t n_input_plane,
-    int64_t input_depth,
-    int64_t input_height,
-    int64_t input_width,
-    int64_t output_depth,
-    int64_t output_height,
-    int64_t output_width) {
-  const int64_t n = n_input_plane * kT * kH * kW * output_depth * output_width *
-      output_height;
-  at::parallel_for(0, n, 0, [&](int64_t start, int64_t end) {
-    int64_t line_index_offset = start;
-    int64_t line_seg_len = (end - start);
-
-    int64_t w_out = line_index_offset % output_width;
-    int64_t remained = line_index_offset / output_width;
-    int64_t h_out = remained % output_height;
-    remained /= output_height;
-    int64_t d_out = remained % output_depth;
-    remained /= output_depth;
-    int k = remained % kW;
-    remained /= kW;
-    int j = remained % kH;
-    remained /= kH;
-    int i = remained % kT;
-    int64_t nip = remained / kT;
-
-    int64_t count = 0;
-    scalar_t* dst = finput_data + line_index_offset;
-    const int64_t input_hw = input_height * input_width;
-    const int64_t input_dhw = input_hw * input_depth;
-
-    // the following variables are updated outside the most inner loop
-    int64_t d = d_out * dT - pT + i;
-    int64_t h = h_out * dH - pH + j;
-    int64_t ofs = nip * input_dhw + d * input_hw + h * input_width;
-    bool d_valid = d >= 0 && d < input_depth;
-    bool dh_valid = d_valid && h >= 0 && h < input_height;
-
-    while (count < line_seg_len) {
-      int64_t w = w_out * dW - pW + k;
-
-      *dst = (dh_valid && w >= 0 && w < input_width) ? input_data[ofs + w]
-                                                     : static_cast<scalar_t>(0);
-
-      count++;
-      dst++;
-      w_out++;
-      if (w_out == output_width) {
-        w_out = 0;
-        h_out++;
-        if (h_out == output_height) {
-          h_out = 0;
-          d_out++;
-          if (d_out == output_depth) {
-            d_out = 0;
-            k++;
-            if (k == kW) {
-              k = 0;
-              j++;
-              if (j == kH) {
-                j = 0;
-                i++;
-                if (i == kT) {
-                  i = 0;
-                  nip++;
-                }
-              }
-            }
-          }
-          d = d_out * dT - pT + i;
-          d_valid = d >= 0 && d < input_depth;
+  const int64_t n = C * kernel_d * kernel_h * kernel_w;
+  const int64_t X_size = X_D * X_H * X_W;
+  const int64_t Y_size = Y_D * Y_H * Y_W;
+  at::parallel_for(0, n, 0, [=](int64_t begin, int64_t end) {
+    for (int64_t p = begin; p < end; ++p) {
+      int64_t c = p;
+      const int64_t kw = c % kernel_w;
+      c /= kernel_w;
+      const int64_t kh = c % kernel_h;
+      c /= kernel_h;
+      const int64_t kd = c % kernel_d;
+      c /= kernel_d;
+      const T* src_ptr = src + c * X_size;
+      T* dst_ptr = dst + p * Y_size;
+      for (int64_t yd = 0; yd < Y_D; ++yd) {
+        const int64_t xd = yd * stride_d - pad_d + kd;
+        if (!IsAGeZeroAndALtB(xd, X_D)) {
+          std::memset(dst_ptr + yd * Y_H * Y_W, 0, Y_H * Y_W * sizeof(T));
+          continue;
         }
-        h = h_out * dH - pH + j;
-        dh_valid = d_valid && h >= 0 && h < input_height;
-        ofs = nip * input_dhw + d * input_hw + h * input_width;
+        for (int64_t yh = 0; yh < Y_H; ++yh) {
+          const int64_t xh = yh * stride_h - pad_h + kh;
+          if (!IsAGeZeroAndALtB(xh, X_H)) {
+            std::memset(
+                dst_ptr + yd * Y_H * Y_W + yh * Y_W, 0, Y_W * sizeof(T));
+            continue;
+          }
+          for (int64_t yw = 0; yw < Y_W; ++yw) {
+            const int64_t xw = yw * stride_w - pad_w + kw;
+            dst_ptr[yd * Y_H * Y_W + yh * Y_W + yw] = IsAGeZeroAndALtB(xw, X_W)
+                ? src_ptr[xd * X_H * X_W + xh * X_W + xw]
+                : T(0);
+          }
+        }
       }
     }
   });
@@ -240,51 +322,49 @@ static void unfolded3d_acc(
 
 } // namespace
 
-void unfolded3d_copy_kernel_cpu(
-    Tensor& finput,
-    Tensor& input,
-    int kT,
-    int kH,
-    int kW,
-    int dT,
-    int dH,
-    int dW,
-    int pT,
-    int pH,
-    int pW,
-    int64_t n_input_plane,
-    int64_t input_depth,
-    int64_t input_height,
-    int64_t input_width,
-    int64_t output_depth,
-    int64_t output_height,
-    int64_t output_width) {
+void Unfold3dCopyCPU(
+    const Tensor& src,
+    int64_t C,
+    int64_t X_D,
+    int64_t X_H,
+    int64_t X_W,
+    int64_t Y_D,
+    int64_t Y_H,
+    int64_t Y_W,
+    int64_t kernel_d,
+    int64_t kernel_h,
+    int64_t kernel_w,
+    int64_t stride_d,
+    int64_t stride_h,
+    int64_t stride_w,
+    int64_t pad_d,
+    int64_t pad_h,
+    int64_t pad_w,
+    Tensor* dst) {
   AT_DISPATCH_ALL_TYPES_AND(
       at::ScalarType::BFloat16,
-      input.scalar_type(),
-      "unfolded3d_copy_cpu",
-      [&] {
-        scalar_t* input_data = input.data_ptr<scalar_t>();
-        scalar_t* finput_data = finput.data_ptr<scalar_t>();
-        unfolded3d_copy(
-            finput_data,
-            input_data,
-            kT,
-            kH,
-            kW,
-            dT,
-            dH,
-            dW,
-            pT,
-            pH,
-            pW,
-            n_input_plane,
-            input_depth,
-            input_height,
-            input_width,
-            output_depth,
-            output_height,
-            output_width);
+      src.scalar_type(),
+      "Unfold3dCopyCPU",
+      [=, &src]() {
+        Unfold3dCopyKernelImpl<scalar_t>(
+            C,
+            X_D,
+            X_H,
+            X_W,
+            Y_D,
+            Y_H,
+            Y_W,
+            kernel_d,
+            kernel_h,
+            kernel_w,
+            stride_d,
+            stride_h,
+            stride_w,
+            pad_d,
+            pad_h,
+            pad_w,
+            src.data_ptr<scalar_t>(),
+            dst->data_ptr<scalar_t>());
       });
 }
 

--- a/aten/src/ATen/native/Unfold3d.h
+++ b/aten/src/ATen/native/Unfold3d.h
@@ -5,25 +5,26 @@
 namespace at {
 namespace native {
 
-void unfolded3d_copy_kernel_cpu(
-    Tensor& finput,
-    Tensor& input,
-    int kT,
-    int kH,
-    int kW,
-    int dT,
-    int dH,
-    int dW,
-    int pT,
-    int pH,
-    int pW,
-    int64_t n_input_plane,
-    int64_t input_depth,
-    int64_t input_height,
-    int64_t input_width,
-    int64_t output_depth,
-    int64_t output_height,
-    int64_t output_width);
+void Unfold3dCopyCPU(
+    const Tensor& src,
+    int64_t C,
+    int64_t X_D,
+    int64_t X_H,
+    int64_t X_W,
+    int64_t Y_D,
+    int64_t Y_H,
+    int64_t Y_W,
+    int64_t kernel_d,
+    int64_t kernel_h,
+    int64_t kernel_w,
+    int64_t stride_d,
+    int64_t stride_h,
+    int64_t stride_w,
+    int64_t pad_d,
+    int64_t pad_h,
+    int64_t pad_w,
+    Tensor* dst);
+
 void unfolded3d_acc_kernel_cpu(
     Tensor& finput,
     Tensor& input,


### PR DESCRIPTION
Summary: Opitmize Unfold3d to improve performance of Conv3d forward

Test Plan: buck test mode/dev-nosan //caffe2/test:nn -- "Conv3d"

Differential Revision: D19821946

For input shape = [1, 3, 4, 112, 112], kernel = [3, 7, 7], stride = [1, 2, 2], padding = [1, 3, 3], bias = False case, this PR can improve performance from 27ms to 20ms on the same machine.
