### PR TITLE
Fix iOS x86_64 CI failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2079,14 +2079,14 @@ workflows:
             - pytorch_linux_xenial_py3_clang5_android_ndk_r19c_arm_v7a_build
             - pytorch_linux_xenial_py3_clang5_android_ndk_r19c_arm_v8a_build
       # Pytorch iOS PR builds
-     - pytorch_ios_build:
-         name: pytorch_ios_11_2_1_x86_64_build
-         context: org-member
-         build_environment: "pytorch-ios-11.2.1-x86_64_build"
-         ios_arch: "x86_64"
-         ios_platform: "SIMULATOR"
-         requires:
-           - setup
+      - pytorch_ios_build:
+            name: pytorch_ios_11_2_1_x86_64_build
+            context: org-member
+            build_environment: "pytorch-ios-11.2.1-x86_64_build"
+            ios_arch: "x86_64"
+            ios_platform: "SIMULATOR"
+            requires:
+            - setup
       - pytorch_ios_build:
           name: pytorch_ios_11_2_1_arm64_build
           context: org-member

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1493,9 +1493,6 @@ jobs:
             WORKSPACE=/Users/distiller/workspace
             PROJ_ROOT=/Users/distiller/project
             source ~/anaconda/bin/activate
-            # pip install pillow==7.0.0 --progress-bar off
-            #install the latest version of PyTorch and TorchVision
-            # pip install torch "torchvision>=0.5.0" --progress-bar off
             pip install torch torchvision --progress-bar off
             #run unit test
             cd ${PROJ_ROOT}/ios/TestApp/benchmark

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2079,14 +2079,14 @@ workflows:
             - pytorch_linux_xenial_py3_clang5_android_ndk_r19c_arm_v7a_build
             - pytorch_linux_xenial_py3_clang5_android_ndk_r19c_arm_v8a_build
       # Pytorch iOS PR builds
-#      - pytorch_ios_build:
-#          name: pytorch_ios_11_2_1_x86_64_build
-#          context: org-member
-#          build_environment: "pytorch-ios-11.2.1-x86_64_build"
-#          ios_arch: "x86_64"
-#          ios_platform: "SIMULATOR"
-#          requires:
-#            - setup
+     - pytorch_ios_build:
+         name: pytorch_ios_11_2_1_x86_64_build
+         context: org-member
+         build_environment: "pytorch-ios-11.2.1-x86_64_build"
+         ios_arch: "x86_64"
+         ios_platform: "SIMULATOR"
+         requires:
+           - setup
       - pytorch_ios_build:
           name: pytorch_ios_11_2_1_arm64_build
           context: org-member

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2078,12 +2078,12 @@ workflows:
             - pytorch_linux_xenial_py3_clang5_android_ndk_r19c_arm_v8a_build
       # Pytorch iOS PR builds
       - pytorch_ios_build:
-            name: pytorch_ios_11_2_1_x86_64_build
-            context: org-member
-            build_environment: "pytorch-ios-11.2.1-x86_64_build"
-            ios_arch: "x86_64"
-            ios_platform: "SIMULATOR"
-            requires:
+          name: pytorch_ios_11_2_1_x86_64_build
+          context: org-member
+          build_environment: "pytorch-ios-11.2.1-x86_64_build"
+          ios_arch: "x86_64"
+          ios_platform: "SIMULATOR"
+          requires:
             - setup
       - pytorch_ios_build:
           name: pytorch_ios_11_2_1_arm64_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1493,9 +1493,10 @@ jobs:
             WORKSPACE=/Users/distiller/workspace
             PROJ_ROOT=/Users/distiller/project
             source ~/anaconda/bin/activate
-            pip install pillow==7.0.0 --progress-bar off
+            # pip install pillow==7.0.0 --progress-bar off
             #install the latest version of PyTorch and TorchVision
-            pip install torch "torchvision>=0.5.0" --progress-bar off
+            # pip install torch "torchvision>=0.5.0" --progress-bar off
+            pip install torch torchvision --progress-bar off
             #run unit test
             cd ${PROJ_ROOT}/ios/TestApp/benchmark
             python trace_model.py

--- a/.circleci/verbatim-sources/job-specs-custom.yml
+++ b/.circleci/verbatim-sources/job-specs-custom.yml
@@ -477,9 +477,10 @@
             WORKSPACE=/Users/distiller/workspace
             PROJ_ROOT=/Users/distiller/project
             source ~/anaconda/bin/activate
-            pip install pillow==7.0.0 --progress-bar off
+            # pip install pillow==7.0.0 --progress-bar off
             #install the latest version of PyTorch and TorchVision
-            pip install torch "torchvision>=0.5.0" --progress-bar off
+            # pip install torch "torchvision>=0.5.0" --progress-bar off
+            pip install torch torchvision --progress-bar off
             #run unit test
             cd ${PROJ_ROOT}/ios/TestApp/benchmark
             python trace_model.py

--- a/.circleci/verbatim-sources/job-specs-custom.yml
+++ b/.circleci/verbatim-sources/job-specs-custom.yml
@@ -477,9 +477,6 @@
             WORKSPACE=/Users/distiller/workspace
             PROJ_ROOT=/Users/distiller/project
             source ~/anaconda/bin/activate
-            # pip install pillow==7.0.0 --progress-bar off
-            #install the latest version of PyTorch and TorchVision
-            # pip install torch "torchvision>=0.5.0" --progress-bar off
             pip install torch torchvision --progress-bar off
             #run unit test
             cd ${PROJ_ROOT}/ios/TestApp/benchmark

--- a/.circleci/verbatim-sources/workflows-pytorch-ios-builds.yml
+++ b/.circleci/verbatim-sources/workflows-pytorch-ios-builds.yml
@@ -1,12 +1,12 @@
       # Pytorch iOS PR builds
-     - pytorch_ios_build:
-         name: pytorch_ios_11_2_1_x86_64_build
-         context: org-member
-         build_environment: "pytorch-ios-11.2.1-x86_64_build"
-         ios_arch: "x86_64"
-         ios_platform: "SIMULATOR"
-         requires:
-           - setup
+      - pytorch_ios_build:
+            name: pytorch_ios_11_2_1_x86_64_build
+            context: org-member
+            build_environment: "pytorch-ios-11.2.1-x86_64_build"
+            ios_arch: "x86_64"
+            ios_platform: "SIMULATOR"
+            requires:
+            - setup
       - pytorch_ios_build:
           name: pytorch_ios_11_2_1_arm64_build
           context: org-member

--- a/.circleci/verbatim-sources/workflows-pytorch-ios-builds.yml
+++ b/.circleci/verbatim-sources/workflows-pytorch-ios-builds.yml
@@ -1,12 +1,12 @@
       # Pytorch iOS PR builds
-#      - pytorch_ios_build:
-#          name: pytorch_ios_11_2_1_x86_64_build
-#          context: org-member
-#          build_environment: "pytorch-ios-11.2.1-x86_64_build"
-#          ios_arch: "x86_64"
-#          ios_platform: "SIMULATOR"
-#          requires:
-#            - setup
+     - pytorch_ios_build:
+         name: pytorch_ios_11_2_1_x86_64_build
+         context: org-member
+         build_environment: "pytorch-ios-11.2.1-x86_64_build"
+         ios_arch: "x86_64"
+         ios_platform: "SIMULATOR"
+         requires:
+           - setup
       - pytorch_ios_build:
           name: pytorch_ios_11_2_1_arm64_build
           context: org-member

--- a/.circleci/verbatim-sources/workflows-pytorch-ios-builds.yml
+++ b/.circleci/verbatim-sources/workflows-pytorch-ios-builds.yml
@@ -1,11 +1,11 @@
       # Pytorch iOS PR builds
       - pytorch_ios_build:
-            name: pytorch_ios_11_2_1_x86_64_build
-            context: org-member
-            build_environment: "pytorch-ios-11.2.1-x86_64_build"
-            ios_arch: "x86_64"
-            ios_platform: "SIMULATOR"
-            requires:
+          name: pytorch_ios_11_2_1_x86_64_build
+          context: org-member
+          build_environment: "pytorch-ios-11.2.1-x86_64_build"
+          ios_arch: "x86_64"
+          ios_platform: "SIMULATOR"
+          requires:
             - setup
       - pytorch_ios_build:
           name: pytorch_ios_11_2_1_arm64_build


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#33194 Fix iOS x86_64 CI failure**

### Summary

The iOS x86_64 job has been failed for a few days. I haven't found the root cause, but seems like updating the torchvision to its latest version can fix the problem

### Test Plan

- the x86_64 job works

Differential Revision: [D19845079](https://our.internmc.facebook.com/intern/diff/D19845079)