### PR TITLE
Ensure that lambda is no less than zero in softshrink

### DIFF
--- a/aten/src/ATen/native/Activation.cpp
+++ b/aten/src/ATen/native/Activation.cpp
@@ -592,13 +592,20 @@ Tensor hardshrink_backward(const Tensor & grad, const Tensor & self, Scalar lamb
   return out_tensor;
 }
 
+static inline void softshrink_check(Scalar lambd) {
+  double lamb = lambd.to<double>();
+  TORCH_CHECK(lamb >= 0, "lambda must be greater or equal to 0, but found to be ", lamb, ".");
+}
+
 Tensor& softshrink_out(Tensor& result, const Tensor & self, Scalar lambd) {
+  softshrink_check(lambd);
   auto iter = TensorIterator::unary_op(result, self);
   softshrink_stub(iter.device_type(), iter, lambd);
   return result;
 }
 
 Tensor softshrink(const Tensor & self, Scalar lambd) {
+  softshrink_check(lambd);
   Tensor result;
   auto iter = TensorIterator::unary_op(result, self);
   softshrink_stub(iter.device_type(), iter, lambd);

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -10855,6 +10855,13 @@ class TestNNDeviceType(NNTestCase):
         helper([2, 3, 5, 7])
         helper([2, 3, 5, 7, 9])
 
+    def test_softshrink_negative(self, device):
+        input = torch.randn(5, device=device, requires_grad=True)
+        m = torch.nn.Softshrink(-1)
+        with self.assertRaisesRegex(RuntimeError,
+                                    r'lambda must be greater or equal to 0, but found to be -1\.'):
+            m(input)
+
 instantiate_device_type_tests(TestNNDeviceType, globals())
 
 if __name__ == '__main__':

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -642,7 +642,7 @@ class Softshrink(Module):
         \end{cases}
 
     Args:
-        lambd: the :math:`\lambda` value for the Softshrink formulation. Default: 0.5
+        lambd: the :math:`\lambda` (must be no less than zero) value for the Softshrink formulation. Default: 0.5
 
     Shape:
         - Input: :math:`(N, *)` where `*` means, any number of additional


### PR DESCRIPTION
Softshrink is ill-defined when `lambda < 0`.