### PR TITLE
Fix SIGABRT caused by double exception in PyTorchStreamReader when file not found.

### DIFF
--- a/caffe2/serialize/inline_container.cc
+++ b/caffe2/serialize/inline_container.cc
@@ -246,6 +246,7 @@ size_t PyTorchStreamReader::getRecordOffset(const std::string& name) {
 
 
 PyTorchStreamReader::~PyTorchStreamReader() {
+  mz_zip_clear_last_error(ar_.get());
   mz_zip_reader_end(ar_.get());
   valid("closing reader for archive ", archive_name_.c_str());
 }

--- a/test/cpp/jit/test_lite_interpreter.cpp
+++ b/test/cpp/jit/test_lite_interpreter.cpp
@@ -1,4 +1,3 @@
-#include <gtest/gtest.h>
 #include <test/cpp/jit/test_base.h>
 #include <torch/csrc/jit/script/module.h>
 #include <torch/csrc/autograd/generated/variable_factories.h>
@@ -188,7 +187,7 @@ void testLiteInterpreterLoadOrigJit() {
   )");
   std::stringstream ss;
   m.save(ss);
-  EXPECT_THROW(_load_for_mobile(ss), c10::Error);
+  ASSERT_THROWS_WITH(_load_for_mobile(ss), "file not found");
 }
 
 } // namespace jit

--- a/test/cpp/jit/test_lite_interpreter.cpp
+++ b/test/cpp/jit/test_lite_interpreter.cpp
@@ -1,3 +1,4 @@
+#include <gtest/gtest.h>
 #include <test/cpp/jit/test_base.h>
 #include <torch/csrc/jit/script/module.h>
 #include <torch/csrc/autograd/generated/variable_factories.h>
@@ -176,5 +177,19 @@ void testLiteInterpreterPrim() {
   auto refi = ref.toInt();
   AT_ASSERT(resi == refi);
 }
-} // namespace torch
+
+void testLiteInterpreterLoadOrigJit() {
+  script::Module m("m");
+  m.register_parameter("foo", torch::ones({}), false);
+  m.define(R"(
+    def forward(self, x):
+      b = 4
+      return self.foo + x + b
+  )");
+  std::stringstream ss;
+  m.save(ss);
+  EXPECT_THROW(_load_for_mobile(ss), c10::Error);
+}
+
 } // namespace jit
+} // namespace torch

--- a/test/cpp/jit/tests.h
+++ b/test/cpp/jit/tests.h
@@ -80,7 +80,8 @@ namespace jit {
   _(CommonAncestor)                    \
   _(AutogradSymbols)                   \
   _(MobileTypeParser)                  \
-  _(LiteInterpreterPrim)
+  _(LiteInterpreterPrim)               \
+  _(LiteInterpreterLoadOrigJit)
 
 #define TH_FORALL_TESTS_CUDA(_) \
   _(ArgumentSpec)               \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#33243 Fix SIGABRT caused by double exception in PyTorchStreamReader when file not found.**

If a file does not exist in an archive, PyTorchStreamReader throws an exception. However, when PyTorchStreamReader is destructed another exception is thrown while processing the first exception. As a result of this double exception there is SIGABRT.

Thanks @dreiss for catching this bug and suggesting the fix. It happened when he used _load_for_mobile to load a torch script file without bytecode session. A unittest is added to test this case.

Differential Revision: [D19859205](https://our.internmc.facebook.com/intern/diff/D19859205)