### PR TITLE
TORCH_INTERNAL_ASSERT_DEBUG_ONLY not eating message string

### DIFF
--- a/c10/util/Exception.h
+++ b/c10/util/Exception.h
@@ -277,7 +277,7 @@ inline std::string if_empty_then(std::string x, std::string y) {
   while (false)           \
   TORCH_INTERNAL_ASSERT(__VA_ARGS__)
 #else
-#define TORCH_INTERNAL_ASSERT_DEBUG_ONLY(...) TORCH_INTERNAL_ASSERT(__VA_ARGS__)
+#define TORCH_INTERNAL_ASSERT_DEBUG_ONLY(...) C10_EXPAND_MSVC_WORKAROUND(TORCH_INTERNAL_ASSERT(__VA_ARGS__))
 #endif
 
 // TODO: We're going to get a lot of similar looking string literals


### PR DESCRIPTION
Summary: Somehow this was preventing `c10::Error` exceptions from ever being thrown on windows when `defined(NDEBUG) == false`. Kinda scary.

Test Plan: sandcastle green, made sure `intrusive_ptr_test.cpp` (givenStackObject_whenReclaimed_thenCrashes) passed inside ovrsource using `mode/win/dev-debug`

Differential Revision: D19865667

