### PR TITLE
Vectorize in-place comparison operators

### DIFF
--- a/aten/src/ATen/cpu/vec256/vec256_base.h
+++ b/aten/src/ATen/cpu/vec256/vec256_base.h
@@ -398,6 +398,7 @@ public:
 private:
   template <typename Op>
   inline Vec256<T> binary_pred(const Vec256<T>& other, Op op) const {
+    // All bits are set to 1 if the pred is true, otherwise 0.
     Vec256<T> vec;
     for (int64_t i = 0; i != size(); i++) {
       if (op(values[i], other.values[i])) {
@@ -416,6 +417,25 @@ public:
   Vec256<T> operator<=(const Vec256<T>& other) const { return binary_pred(other, std::less_equal<T>()); }
   Vec256<T> operator>(const Vec256<T>& other) const { return binary_pred(other, std::greater<T>()); }
   Vec256<T> operator<(const Vec256<T>& other) const { return binary_pred(other, std::less<T>()); }
+
+private:
+  template <typename Op>
+  inline Vec256<T> binary_pred_bool(const Vec256<T>& other, Op op) const {
+    // 1 if the pred is true, otherwise 0.
+    Vec256<T> vec;
+    for (int i = 0; i != size(); ++ i) {
+      vec[i] = bool(op(values[i], other.values[i]));
+    }
+    return vec;
+  }
+
+public:
+  Vec256<T> eq(const Vec256<T>& other) const { return binary_pred_bool(other, std::equal_to<T>()); }
+  Vec256<T> ne(const Vec256<T>& other) const { return binary_pred_bool(other, std::not_equal_to<T>()); }
+  Vec256<T> gt(const Vec256<T>& other) const { return binary_pred_bool(other, std::greater<T>()); }
+  Vec256<T> ge(const Vec256<T>& other) const { return binary_pred_bool(other, std::greater_equal<T>()); }
+  Vec256<T> lt(const Vec256<T>& other) const { return binary_pred_bool(other, std::less<T>()); }
+  Vec256<T> le(const Vec256<T>& other) const { return binary_pred_bool(other, std::less_equal<T>()); }
 };
 
 template <class T> Vec256<T> inline operator+(const Vec256<T> &a, const Vec256<T> &b) {

--- a/aten/src/ATen/cpu/vec256/vec256_complex_double.h
+++ b/aten/src/ATen/cpu/vec256/vec256_complex_double.h
@@ -16,6 +16,7 @@ namespace {
 template <> class Vec256<std::complex<double>> {
 private:
   __m256d values;
+  static const Vec256<std::complex<double>> ones;
 public:
   using value_type = std::complex<double>;
   static constexpr int size() {
@@ -297,6 +298,13 @@ public:
   Vec256<std::complex<double>> operator>=(const Vec256<std::complex<double>>& other) const {
     AT_ERROR("not supported for complex numbers");
   }
+
+  Vec256<std::complex<double>> eq(const Vec256<std::complex<double>>& other) const;
+  Vec256<std::complex<double>> ne(const Vec256<std::complex<double>>& other) const;
+  Vec256<std::complex<double>> lt(const Vec256<std::complex<double>>& other) const;
+  Vec256<std::complex<double>> le(const Vec256<std::complex<double>>& other) const;
+  Vec256<std::complex<double>> gt(const Vec256<std::complex<double>>& other) const;
+  Vec256<std::complex<double>> ge(const Vec256<std::complex<double>>& other) const;
 };
 
 template <> Vec256<std::complex<double>> inline operator+(const Vec256<std::complex<double>> &a, const Vec256<std::complex<double>> &b) {
@@ -417,6 +425,16 @@ Vec256<std::complex<double>> inline operator|(const Vec256<std::complex<double>>
 template <>
 Vec256<std::complex<double>> inline operator^(const Vec256<std::complex<double>>& a, const Vec256<std::complex<double>>& b) {
   return _mm256_xor_pd(a, b);
+}
+
+const Vec256<std::complex<double>> Vec256<std::complex<double>>::ones(_mm256_set1_pd(1.0));
+
+Vec256<std::complex<double>> Vec256<std::complex<double>>::eq(const Vec256<std::complex<double>>& other) const {
+  return (*this == other) & Vec256<std::complex<double>>::ones;
+}
+
+Vec256<std::complex<double>> Vec256<std::complex<double>>::ne(const Vec256<std::complex<double>>& other) const {
+  return (*this != other) & Vec256<std::complex<double>>::ones;
 }
 
 #ifdef __AVX2__

--- a/aten/src/ATen/cpu/vec256/vec256_complex_float.h
+++ b/aten/src/ATen/cpu/vec256/vec256_complex_float.h
@@ -16,6 +16,7 @@ namespace {
 template <> class Vec256<std::complex<float>> {
 private:
   __m256 values;
+  static const Vec256<std::complex<float>> ones;
 public:
   using value_type = std::complex<float>;
   static constexpr int size() {
@@ -335,6 +336,13 @@ public:
   Vec256<std::complex<float>> operator>=(const Vec256<std::complex<float>>& other) const {
     AT_ERROR("not supported for complex numbers");
   }
+
+  Vec256<std::complex<float>> eq(const Vec256<std::complex<float>>& other) const;
+  Vec256<std::complex<float>> ne(const Vec256<std::complex<float>>& other) const;
+  Vec256<std::complex<float>> lt(const Vec256<std::complex<float>>& other) const;
+  Vec256<std::complex<float>> le(const Vec256<std::complex<float>>& other) const;
+  Vec256<std::complex<float>> gt(const Vec256<std::complex<float>>& other) const;
+  Vec256<std::complex<float>> ge(const Vec256<std::complex<float>>& other) const;
 };
 
 template <> Vec256<std::complex<float>> inline operator+(const Vec256<std::complex<float>> &a, const Vec256<std::complex<float>> &b) {
@@ -457,6 +465,18 @@ Vec256<std::complex<float>> inline operator|(const Vec256<std::complex<float>>& 
 template <>
 Vec256<std::complex<float>> inline operator^(const Vec256<std::complex<float>>& a, const Vec256<std::complex<float>>& b) {
   return _mm256_xor_ps(a, b);
+}
+
+const Vec256<std::complex<float>> Vec256<std::complex<float>>::ones(_mm256_set1_ps(1.0f));
+
+Vec256<std::complex<float>> Vec256<std::complex<float>>::eq(
+    const Vec256<std::complex<float>>& other) const {
+  return (*this == other) & Vec256<std::complex<float>>::ones;
+}
+
+Vec256<std::complex<float>> Vec256<std::complex<float>>::ne(
+    const Vec256<std::complex<float>>& other) const {
+  return (*this != other) & Vec256<std::complex<float>>::ones;
 }
 
 #ifdef __AVX2__

--- a/aten/src/ATen/cpu/vec256/vec256_double.h
+++ b/aten/src/ATen/cpu/vec256/vec256_double.h
@@ -16,6 +16,7 @@ namespace {
 template <> class Vec256<double> {
 private:
   __m256d values;
+  static const Vec256<double> ones;
 public:
   using value_type = double;
   static constexpr int size() {
@@ -231,6 +232,13 @@ public:
   Vec256<double> operator>=(const Vec256<double>& other) const {
     return _mm256_cmp_pd(values, other.values, _CMP_GE_OQ);
   }
+
+  Vec256<double> eq(const Vec256<double>& other) const;
+  Vec256<double> ne(const Vec256<double>& other) const;
+  Vec256<double> lt(const Vec256<double>& other) const;
+  Vec256<double> le(const Vec256<double>& other) const;
+  Vec256<double> gt(const Vec256<double>& other) const;
+  Vec256<double> ge(const Vec256<double>& other) const;
 };
 
 template <>
@@ -306,6 +314,32 @@ Vec256<double> inline operator|(const Vec256<double>& a, const Vec256<double>& b
 template <>
 Vec256<double> inline operator^(const Vec256<double>& a, const Vec256<double>& b) {
   return _mm256_xor_pd(a, b);
+}
+
+const Vec256<double> Vec256<double>::ones(1.0);
+
+Vec256<double> Vec256<double>::eq(const Vec256<double>& other) const {
+  return (*this == other) & Vec256<double>::ones;
+}
+
+Vec256<double> Vec256<double>::ne(const Vec256<double>& other) const {
+  return (*this != other) & Vec256<double>::ones;
+}
+
+Vec256<double> Vec256<double>::gt(const Vec256<double>& other) const {
+  return (*this > other) & Vec256<double>::ones;
+}
+
+Vec256<double> Vec256<double>::ge(const Vec256<double>& other) const {
+  return (*this >= other) & Vec256<double>::ones;
+}
+
+Vec256<double> Vec256<double>::lt(const Vec256<double>& other) const {
+  return (*this < other) & Vec256<double>::ones;
+}
+
+Vec256<double> Vec256<double>::le(const Vec256<double>& other) const {
+  return (*this <= other) & Vec256<double>::ones;
 }
 
 template <>

--- a/aten/src/ATen/cpu/vec256/vec256_float.h
+++ b/aten/src/ATen/cpu/vec256/vec256_float.h
@@ -16,6 +16,7 @@ namespace {
 template <> class Vec256<float> {
 private:
   __m256 values;
+  static const Vec256<float> ones;
 public:
   using value_type = float;
   static constexpr int size() {
@@ -238,6 +239,13 @@ public:
   Vec256<float> operator>=(const Vec256<float>& other) const {
     return _mm256_cmp_ps(values, other.values, _CMP_GE_OQ);
   }
+
+  Vec256<float> eq(const Vec256<float>& other) const;
+  Vec256<float> ne(const Vec256<float>& other) const;
+  Vec256<float> gt(const Vec256<float>& other) const;
+  Vec256<float> ge(const Vec256<float>& other) const;
+  Vec256<float> lt(const Vec256<float>& other) const;
+  Vec256<float> le(const Vec256<float>& other) const;
 };
 
 template <>
@@ -313,6 +321,32 @@ Vec256<float> inline operator|(const Vec256<float>& a, const Vec256<float>& b) {
 template <>
 Vec256<float> inline operator^(const Vec256<float>& a, const Vec256<float>& b) {
   return _mm256_xor_ps(a, b);
+}
+
+const Vec256<float> Vec256<float>::ones(1.0f);
+
+Vec256<float> Vec256<float>::eq(const Vec256<float>& other) const {
+  return (*this == other) & Vec256<float>::ones;
+}
+
+Vec256<float> Vec256<float>::ne(const Vec256<float>& other) const {
+  return (*this != other) & Vec256<float>::ones;
+}
+
+Vec256<float> Vec256<float>::gt(const Vec256<float>& other) const {
+  return (*this > other) & Vec256<float>::ones;
+}
+
+Vec256<float> Vec256<float>::ge(const Vec256<float>& other) const {
+  return (*this >= other) & Vec256<float>::ones;
+}
+
+Vec256<float> Vec256<float>::lt(const Vec256<float>& other) const {
+  return (*this < other) & Vec256<float>::ones;
+}
+
+Vec256<float> Vec256<float>::le(const Vec256<float>& other) const {
+  return (*this <= other) & Vec256<float>::ones;
 }
 
 template <>

--- a/aten/src/ATen/cpu/vec256/vec256_int.h
+++ b/aten/src/ATen/cpu/vec256/vec256_int.h
@@ -34,7 +34,10 @@ struct Vec256i {};  // dummy definition to make Vec256i always defined
 #ifdef __AVX2__
 
 template <>
-struct Vec256<int64_t> : public Vec256i {
+class Vec256<int64_t> : public Vec256i {
+private:
+  static const Vec256<int64_t> ones;
+public:
   using value_type = int64_t;
   static constexpr int size() {
     return 4;
@@ -142,10 +145,20 @@ struct Vec256<int64_t> : public Vec256i {
   Vec256<int64_t> operator>=(const Vec256<int64_t>& other) const {
     return invert(_mm256_cmpgt_epi64(other.values, values));
   }
+
+  Vec256<int64_t> eq(const Vec256<int64_t>& other) const;
+  Vec256<int64_t> ne(const Vec256<int64_t>& other) const;
+  Vec256<int64_t> gt(const Vec256<int64_t>& other) const;
+  Vec256<int64_t> ge(const Vec256<int64_t>& other) const;
+  Vec256<int64_t> lt(const Vec256<int64_t>& other) const;
+  Vec256<int64_t> le(const Vec256<int64_t>& other) const;
 };
 
 template <>
-struct Vec256<int32_t> : public Vec256i {
+class Vec256<int32_t> : public Vec256i {
+private:
+  static const Vec256<int32_t> ones;
+public:
   using value_type = int32_t;
   static constexpr int size() {
     return 8;
@@ -252,6 +265,12 @@ struct Vec256<int32_t> : public Vec256i {
   Vec256<int32_t> operator>=(const Vec256<int32_t>& other) const {
     return invert(_mm256_cmpgt_epi32(other.values, values));
   }
+  Vec256<int32_t> eq(const Vec256<int32_t>& other) const;
+  Vec256<int32_t> ne(const Vec256<int32_t>& other) const;
+  Vec256<int32_t> gt(const Vec256<int32_t>& other) const;
+  Vec256<int32_t> ge(const Vec256<int32_t>& other) const;
+  Vec256<int32_t> lt(const Vec256<int32_t>& other) const;
+  Vec256<int32_t> le(const Vec256<int32_t>& other) const;
 };
 
 template <>
@@ -295,7 +314,10 @@ inline void convert(const int32_t *src, double *dst, int64_t n) {
 }
 
 template <>
-struct Vec256<int16_t> : public Vec256i {
+class Vec256<int16_t> : public Vec256i {
+private:
+  static const Vec256<int16_t> ones;
+public:
   using value_type = int16_t;
   static constexpr int size() {
     return 16;
@@ -451,6 +473,13 @@ struct Vec256<int16_t> : public Vec256i {
   Vec256<int16_t> operator>=(const Vec256<int16_t>& other) const {
     return invert(_mm256_cmpgt_epi16(other.values, values));
   }
+
+  Vec256<int16_t> eq(const Vec256<int16_t>& other) const;
+  Vec256<int16_t> ne(const Vec256<int16_t>& other) const;
+  Vec256<int16_t> gt(const Vec256<int16_t>& other) const;
+  Vec256<int16_t> ge(const Vec256<int16_t>& other) const;
+  Vec256<int16_t> lt(const Vec256<int16_t>& other) const;
+  Vec256<int16_t> le(const Vec256<int16_t>& other) const;
 };
 
 template <>
@@ -689,6 +718,84 @@ inline Vec256<T> operator|(const Vec256<T>& a, const Vec256<T>& b) {
 template<class T, typename std::enable_if_t<std::is_integral<T>::value && std::is_base_of<Vec256i, Vec256<T>>::value, int> = 0>
 inline Vec256<T> operator^(const Vec256<T>& a, const Vec256<T>& b) {
   return _mm256_xor_si256(a, b);
+}
+
+const Vec256<int64_t> Vec256<int64_t>::ones(1);
+
+Vec256<int64_t> Vec256<int64_t>::eq(const Vec256<int64_t>& other) const {
+  return (*this == other) & Vec256<int64_t>::ones;
+}
+
+Vec256<int64_t> Vec256<int64_t>::ne(const Vec256<int64_t>& other) const {
+  return (*this != other) & Vec256<int64_t>::ones;
+}
+
+Vec256<int64_t> Vec256<int64_t>::gt(const Vec256<int64_t>& other) const {
+  return (*this > other) & Vec256<int64_t>::ones;
+}
+
+Vec256<int64_t> Vec256<int64_t>::ge(const Vec256<int64_t>& other) const {
+  return (*this >= other) & Vec256<int64_t>::ones;
+}
+
+Vec256<int64_t> Vec256<int64_t>::lt(const Vec256<int64_t>& other) const {
+  return (*this < other) & Vec256<int64_t>::ones;
+}
+
+Vec256<int64_t> Vec256<int64_t>::le(const Vec256<int64_t>& other) const {
+  return (*this <= other) & Vec256<int64_t>::ones;
+}
+
+const Vec256<int32_t> Vec256<int32_t>::ones(1);
+
+Vec256<int32_t> Vec256<int32_t>::eq(const Vec256<int32_t>& other) const {
+  return (*this == other) & Vec256<int32_t>::ones;
+}
+
+Vec256<int32_t> Vec256<int32_t>::ne(const Vec256<int32_t>& other) const {
+  return (*this != other) & Vec256<int32_t>::ones;
+}
+
+Vec256<int32_t> Vec256<int32_t>::gt(const Vec256<int32_t>& other) const {
+  return (*this > other) & Vec256<int32_t>::ones;
+}
+
+Vec256<int32_t> Vec256<int32_t>::ge(const Vec256<int32_t>& other) const {
+  return (*this >= other) & Vec256<int32_t>::ones;
+}
+
+Vec256<int32_t> Vec256<int32_t>::lt(const Vec256<int32_t>& other) const {
+  return (*this < other) & Vec256<int32_t>::ones;
+}
+
+Vec256<int32_t> Vec256<int32_t>::le(const Vec256<int32_t>& other) const {
+  return (*this <= other) & Vec256<int32_t>::ones;
+}
+
+const Vec256<int16_t> Vec256<int16_t>::ones(1);
+
+Vec256<int16_t> Vec256<int16_t>::eq(const Vec256<int16_t>& other) const {
+  return (*this == other) & Vec256<int16_t>::ones;
+}
+
+Vec256<int16_t> Vec256<int16_t>::ne(const Vec256<int16_t>& other) const {
+  return (*this != other) & Vec256<int16_t>::ones;
+}
+
+Vec256<int16_t> Vec256<int16_t>::gt(const Vec256<int16_t>& other) const {
+  return (*this > other) & Vec256<int16_t>::ones;
+}
+
+Vec256<int16_t> Vec256<int16_t>::ge(const Vec256<int16_t>& other) const {
+  return (*this >= other) & Vec256<int16_t>::ones;
+}
+
+Vec256<int16_t> Vec256<int16_t>::lt(const Vec256<int16_t>& other) const {
+  return (*this < other) & Vec256<int16_t>::ones;
+}
+
+Vec256<int16_t> Vec256<int16_t>::le(const Vec256<int16_t>& other) const {
+  return (*this <= other) & Vec256<int16_t>::ones;
 }
 
 #endif

--- a/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
@@ -311,17 +311,21 @@ void lt_kernel(TensorIterator& iter) {
   if (iter.dtype() == ScalarType::Bool) {
     AT_DISPATCH_ALL_TYPES_AND2(kBool, kBFloat16, iter.input_dtype(), "lt_cpu", [&]() {
       cpu_kernel(iter,
-       [=](scalar_t a, scalar_t b) -> bool {
+       [](scalar_t a, scalar_t b) -> bool {
          return a < b;
        });
     });
   } else {
     AT_DISPATCH_ALL_TYPES_AND(kBFloat16, iter.dtype(), "lt_cpu", [&]() {
-      cpu_kernel(iter,
-       [=](scalar_t a, scalar_t b) -> scalar_t {
-         return a < b;
-       });
-    });
+      cpu_kernel_vec(
+        iter,
+        [](scalar_t a, scalar_t b) -> scalar_t {
+          return a < b;
+        },
+        [](Vec256<scalar_t> a, Vec256<scalar_t> b) -> Vec256<scalar_t> {
+          return a.lt(b);
+        });
+      });
   }
 }
 
@@ -329,17 +333,21 @@ void le_kernel(TensorIterator& iter) {
   if (iter.dtype() == ScalarType::Bool) {
     AT_DISPATCH_ALL_TYPES_AND2(kBool, kBFloat16, iter.input_dtype(), "le_cpu", [&]() {
       cpu_kernel(iter,
-       [=](scalar_t a, scalar_t b) -> bool {
+       [](scalar_t a, scalar_t b) -> bool {
          return a <= b;
        });
     });
   } else {
     AT_DISPATCH_ALL_TYPES_AND(kBFloat16, iter.dtype(), "le_cpu", [&]() {
-      cpu_kernel(iter,
-       [=](scalar_t a, scalar_t b) -> scalar_t {
-         return a <= b;
-       });
-    });
+      cpu_kernel_vec(
+        iter,
+        [](scalar_t a, scalar_t b) -> scalar_t {
+          return a <= b;
+        },
+        [](Vec256<scalar_t> a, Vec256<scalar_t> b) -> Vec256<scalar_t> {
+          return a.le(b);
+        });
+      });
   }
 }
 
@@ -353,11 +361,15 @@ void gt_kernel(TensorIterator& iter) {
     });
   } else {
     AT_DISPATCH_ALL_TYPES_AND(kBFloat16, iter.dtype(), "gt_cpu", [&]() {
-      cpu_kernel(iter,
-       [=](scalar_t a, scalar_t b) -> scalar_t {
-         return a > b;
-       });
-    });
+      cpu_kernel_vec(
+        iter,
+        [](scalar_t a, scalar_t b) -> scalar_t {
+          return a > b;
+        },
+        [](Vec256<scalar_t> a, Vec256<scalar_t> b) -> Vec256<scalar_t> {
+          return a.gt(b);
+        });
+      });
   }
 }
 
@@ -365,17 +377,21 @@ void ge_kernel(TensorIterator& iter) {
   if (iter.dtype() == ScalarType::Bool) {
     AT_DISPATCH_ALL_TYPES_AND2(kBool, kBFloat16, iter.input_dtype(), "ge_cpu", [&]() {
       cpu_kernel(iter,
-       [=](scalar_t a, scalar_t b) -> bool {
+       [](scalar_t a, scalar_t b) -> bool {
          return a >= b;
        });
     });
   } else {
     AT_DISPATCH_ALL_TYPES_AND(kBFloat16, iter.dtype(), "ge_cpu", [&]() {
-      cpu_kernel(iter,
-       [=](scalar_t a, scalar_t b) -> scalar_t {
-         return a >= b;
-       });
-    });
+      cpu_kernel_vec(
+        iter,
+        [](scalar_t a, scalar_t b) -> scalar_t {
+          return a >= b;
+        },
+        [](Vec256<scalar_t> a, Vec256<scalar_t> b) -> Vec256<scalar_t> {
+          return a.ge(b);
+        });
+      });
   }
 }
 
@@ -383,17 +399,21 @@ void eq_kernel(TensorIterator& iter) {
   if (iter.dtype() == ScalarType::Bool) {
     AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(kBool, kBFloat16, iter.input_dtype(), "eq_cpu", [&]() {
       cpu_kernel(iter,
-       [=](scalar_t a, scalar_t b) -> bool {
+       [](scalar_t a, scalar_t b) -> bool {
          return a == b;
        });
     });
   } else {
     AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND(kBFloat16, iter.dtype(), "eq_cpu", [&]() {
-      cpu_kernel(iter,
-       [=](scalar_t a, scalar_t b) -> scalar_t {
-         return a == b;
-       });
-    });
+      cpu_kernel_vec(
+        iter,
+        [](scalar_t a, scalar_t b) -> scalar_t {
+          return a == b;
+        },
+        [](Vec256<scalar_t> a, Vec256<scalar_t> b) -> Vec256<scalar_t> {
+          return a.eq(b);
+        });
+      });
   }
 }
 
@@ -401,17 +421,21 @@ void ne_kernel(TensorIterator& iter) {
   if (iter.dtype() == ScalarType::Bool) {
     AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(kBool, kBFloat16, iter.input_dtype(), "ne_cpu", [&]() {
       cpu_kernel(iter,
-       [=](scalar_t a, scalar_t b) -> bool {
+       [](scalar_t a, scalar_t b) -> bool {
          return a != b;
        });
     });
   } else {
     AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND(kBFloat16, iter.dtype(), "ne_cpu", [&]() {
-      cpu_kernel(iter,
-       [=](scalar_t a, scalar_t b) -> scalar_t {
-         return a != b;
-       });
-    });
+      cpu_kernel_vec(
+        iter,
+        [](scalar_t a, scalar_t b) -> scalar_t {
+          return a != b;
+        },
+        [](Vec256<scalar_t> a, Vec256<scalar_t> b) -> Vec256<scalar_t> {
+          return a.ne(b);
+        });
+      });
   }
 }
 


### PR DESCRIPTION
Benchmark: (Debian 10, Release build, gcc 8.3, no turbo, Intel(R) Xeon(R) E-2136 CPU @ 3.30GHz)

```python
import timeit
for op in ('gt', 'lt', 'ge', 'le', 'eq', 'ne'):
    for dtype in ('torch.float', 'torch.double', 'torch.int16', 'torch.int32', 'torch.int64'):
        for n, t in [(10_000, 100000),
                    (100_000, 10000)]:
            print(f'a.{op}_(b), numel() == {n} for {t} times, dtype={dtype}')
            print(timeit.timeit(f'a.{op}_(b)', setup=f'import torch; a = torch.arange(1, {n}, dtype={dtype}); b = torch.arange({n}, 1, -1, dtype={dtype})', number=t))
```

Before:

```
a.gt_(b), numel() == 10000 for 100000 times, dtype=torch.float
0.778998922000028
a.gt_(b), numel() == 100000 for 10000 times, dtype=torch.float
0.6359690249992127
a.gt_(b), numel() == 10000 for 100000 times, dtype=torch.double
1.0801493119997758
a.gt_(b), numel() == 100000 for 10000 times, dtype=torch.double
0.9360321379990637
a.gt_(b), numel() == 10000 for 100000 times, dtype=torch.int16
0.7341018620008981
a.gt_(b), numel() == 100000 for 10000 times, dtype=torch.int16
0.6345281440007966
a.gt_(b), numel() == 10000 for 100000 times, dtype=torch.int32
0.7396387640001194
a.gt_(b), numel() == 100000 for 10000 times, dtype=torch.int32
0.6429641230006382
a.gt_(b), numel() == 10000 for 100000 times, dtype=torch.int64
0.7759611700003006
a.gt_(b), numel() == 100000 for 10000 times, dtype=torch.int64
0.6672059659995284
a.lt_(b), numel() == 10000 for 100000 times, dtype=torch.float
0.7724312530008319
a.lt_(b), numel() == 100000 for 10000 times, dtype=torch.float
0.6392585769990546
a.lt_(b), numel() == 10000 for 100000 times, dtype=torch.double
0.7917451840003196
a.lt_(b), numel() == 100000 for 10000 times, dtype=torch.double
0.6455550159989798
a.lt_(b), numel() == 10000 for 100000 times, dtype=torch.int16
0.739991647998977
a.lt_(b), numel() == 100000 for 10000 times, dtype=torch.int16
0.6572993859990675
a.lt_(b), numel() == 10000 for 100000 times, dtype=torch.int32
0.7627949479992822
a.lt_(b), numel() == 100000 for 10000 times, dtype=torch.int32
0.6476544910001394
a.lt_(b), numel() == 10000 for 100000 times, dtype=torch.int64
0.7965036850000615
a.lt_(b), numel() == 100000 for 10000 times, dtype=torch.int64
0.6780715599998075
a.ge_(b), numel() == 10000 for 100000 times, dtype=torch.float
0.7653547080008138
a.ge_(b), numel() == 100000 for 10000 times, dtype=torch.float
0.6383065829995758
a.ge_(b), numel() == 10000 for 100000 times, dtype=torch.double
0.7895260240002244
a.ge_(b), numel() == 100000 for 10000 times, dtype=torch.double
0.6508346030004759
a.ge_(b), numel() == 10000 for 100000 times, dtype=torch.int16
0.7409299750015634
a.ge_(b), numel() == 100000 for 10000 times, dtype=torch.int16
0.6383492870008922
a.ge_(b), numel() == 10000 for 100000 times, dtype=torch.int32
0.7620547579990671
a.ge_(b), numel() == 100000 for 10000 times, dtype=torch.int32
0.6474270239996258
a.ge_(b), numel() == 10000 for 100000 times, dtype=torch.int64
0.8070051169997896
a.ge_(b), numel() == 100000 for 10000 times, dtype=torch.int64
0.6712598600006459
a.le_(b), numel() == 10000 for 100000 times, dtype=torch.float
0.7627660060006747
a.le_(b), numel() == 100000 for 10000 times, dtype=torch.float
0.6406353189995571
a.le_(b), numel() == 10000 for 100000 times, dtype=torch.double
1.0826010620003217
a.le_(b), numel() == 100000 for 10000 times, dtype=torch.double
0.9391552950000914
a.le_(b), numel() == 10000 for 100000 times, dtype=torch.int16
0.7427801039993938
a.le_(b), numel() == 100000 for 10000 times, dtype=torch.int16
0.6365172640016681
a.le_(b), numel() == 10000 for 100000 times, dtype=torch.int32
0.7679271510005492
a.le_(b), numel() == 100000 for 10000 times, dtype=torch.int32
0.6453389289999905
a.le_(b), numel() == 10000 for 100000 times, dtype=torch.int64
0.788032889000533
a.le_(b), numel() == 100000 for 10000 times, dtype=torch.int64
0.6708840760002204
a.eq_(b), numel() == 10000 for 100000 times, dtype=torch.float
1.078837263999958
a.eq_(b), numel() == 100000 for 10000 times, dtype=torch.float
0.9397531720005645
a.eq_(b), numel() == 10000 for 100000 times, dtype=torch.double
1.1031508050000411
a.eq_(b), numel() == 100000 for 10000 times, dtype=torch.double
0.9412319389994082
a.eq_(b), numel() == 10000 for 100000 times, dtype=torch.int16
0.7509566959997755
a.eq_(b), numel() == 100000 for 10000 times, dtype=torch.int16
0.638570957000411
a.eq_(b), numel() == 10000 for 100000 times, dtype=torch.int32
0.7592877549996047
a.eq_(b), numel() == 100000 for 10000 times, dtype=torch.int32
0.6458840529994632
a.eq_(b), numel() == 10000 for 100000 times, dtype=torch.int64
0.7984061539991671
a.eq_(b), numel() == 100000 for 10000 times, dtype=torch.int64
0.6776346309998189
a.ne_(b), numel() == 10000 for 100000 times, dtype=torch.float
0.7724407899986545
a.ne_(b), numel() == 100000 for 10000 times, dtype=torch.float
0.6581534130000364
a.ne_(b), numel() == 10000 for 100000 times, dtype=torch.double
0.8303323249983805
a.ne_(b), numel() == 100000 for 10000 times, dtype=torch.double
0.6954390920000151
a.ne_(b), numel() == 10000 for 100000 times, dtype=torch.int16
0.745512373998281
a.ne_(b), numel() == 100000 for 10000 times, dtype=torch.int16
0.6360954970004968
a.ne_(b), numel() == 10000 for 100000 times, dtype=torch.int32
0.7569978400006221
a.ne_(b), numel() == 100000 for 10000 times, dtype=torch.int32
0.6450422030011396
a.ne_(b), numel() == 10000 for 100000 times, dtype=torch.int64
0.7889118379989668
a.ne_(b), numel() == 100000 for 10000 times, dtype=torch.int64
0.6693385389989999
```

After:

```
a.gt_(b), numel() == 10000 for 100000 times, dtype=torch.float
0.2444220920006046
a.gt_(b), numel() == 100000 for 10000 times, dtype=torch.float
0.2031730359994981
a.gt_(b), numel() == 10000 for 100000 times, dtype=torch.double
0.35491806199934217
a.gt_(b), numel() == 100000 for 10000 times, dtype=torch.double
0.3905606850003096
a.gt_(b), numel() == 10000 for 100000 times, dtype=torch.int16
0.16665379499863775
a.gt_(b), numel() == 100000 for 10000 times, dtype=torch.int16
0.10095906300011848
a.gt_(b), numel() == 10000 for 100000 times, dtype=torch.int32
0.21650469999985944
a.gt_(b), numel() == 100000 for 10000 times, dtype=torch.int32
0.18737469400002738
a.gt_(b), numel() == 10000 for 100000 times, dtype=torch.int64
0.35481256200000644
a.gt_(b), numel() == 100000 for 10000 times, dtype=torch.int64
0.36696120199849247
a.lt_(b), numel() == 10000 for 100000 times, dtype=torch.float
0.21976138800164335
a.lt_(b), numel() == 100000 for 10000 times, dtype=torch.float
0.20275393200063263
a.lt_(b), numel() == 10000 for 100000 times, dtype=torch.double
0.3695997209997586
a.lt_(b), numel() == 100000 for 10000 times, dtype=torch.double
0.39441510399956314
a.lt_(b), numel() == 10000 for 100000 times, dtype=torch.int16
0.15657078300137073
a.lt_(b), numel() == 100000 for 10000 times, dtype=torch.int16
0.0992998069996247
a.lt_(b), numel() == 10000 for 100000 times, dtype=torch.int32
0.20425128799979575
a.lt_(b), numel() == 100000 for 10000 times, dtype=torch.int32
0.20352934599941364
a.lt_(b), numel() == 10000 for 100000 times, dtype=torch.int64
0.35883567900054913
a.lt_(b), numel() == 100000 for 10000 times, dtype=torch.int64
0.39059587599876977
a.ge_(b), numel() == 10000 for 100000 times, dtype=torch.float
0.21457727400047588
a.ge_(b), numel() == 100000 for 10000 times, dtype=torch.float
0.18836135499986995
a.ge_(b), numel() == 10000 for 100000 times, dtype=torch.double
0.35971907199927955
a.ge_(b), numel() == 100000 for 10000 times, dtype=torch.double
0.3688875009993353
a.ge_(b), numel() == 10000 for 100000 times, dtype=torch.int16
0.1576009280015569
a.ge_(b), numel() == 100000 for 10000 times, dtype=torch.int16
0.09524034199966991
a.ge_(b), numel() == 10000 for 100000 times, dtype=torch.int32
0.2064543649994448
a.ge_(b), numel() == 100000 for 10000 times, dtype=torch.int32
0.18726435600001423
a.ge_(b), numel() == 10000 for 100000 times, dtype=torch.int64
0.35351785300008487
a.ge_(b), numel() == 100000 for 10000 times, dtype=torch.int64
0.3680737989998306
a.le_(b), numel() == 10000 for 100000 times, dtype=torch.float
0.2132134399998904
a.le_(b), numel() == 100000 for 10000 times, dtype=torch.float
0.2140274829998816
a.le_(b), numel() == 10000 for 100000 times, dtype=torch.double
0.36539215199991304
a.le_(b), numel() == 100000 for 10000 times, dtype=torch.double
0.39128020300086064
a.le_(b), numel() == 10000 for 100000 times, dtype=torch.int16
0.15712150600120367
a.le_(b), numel() == 100000 for 10000 times, dtype=torch.int16
0.10149904400168452
a.le_(b), numel() == 10000 for 100000 times, dtype=torch.int32
0.2103407699996751
a.le_(b), numel() == 100000 for 10000 times, dtype=torch.int32
0.2134442910009966
a.le_(b), numel() == 10000 for 100000 times, dtype=torch.int64
0.35387034300038067
a.le_(b), numel() == 100000 for 10000 times, dtype=torch.int64
0.38917528399906587
a.eq_(b), numel() == 10000 for 100000 times, dtype=torch.float
0.2190484450002259
a.eq_(b), numel() == 100000 for 10000 times, dtype=torch.float
0.2030815980015177
a.eq_(b), numel() == 10000 for 100000 times, dtype=torch.double
0.3710030169986567
a.eq_(b), numel() == 100000 for 10000 times, dtype=torch.double
0.36419657899932645
a.eq_(b), numel() == 10000 for 100000 times, dtype=torch.int16
0.15986497499943653
a.eq_(b), numel() == 100000 for 10000 times, dtype=torch.int16
0.10145393699895067
a.eq_(b), numel() == 10000 for 100000 times, dtype=torch.int32
0.21011781599918322
a.eq_(b), numel() == 100000 for 10000 times, dtype=torch.int32
0.20121852699958254
a.eq_(b), numel() == 10000 for 100000 times, dtype=torch.int64
0.36681504499938455
a.eq_(b), numel() == 100000 for 10000 times, dtype=torch.int64
0.364472848999867
a.ne_(b), numel() == 10000 for 100000 times, dtype=torch.float
0.2290963309988001
a.ne_(b), numel() == 100000 for 10000 times, dtype=torch.float
0.21674784300012107
a.ne_(b), numel() == 10000 for 100000 times, dtype=torch.double
0.3829616689999966
a.ne_(b), numel() == 100000 for 10000 times, dtype=torch.double
0.39437660300063726
a.ne_(b), numel() == 10000 for 100000 times, dtype=torch.int16
0.1661020749997988
a.ne_(b), numel() == 100000 for 10000 times, dtype=torch.int16
0.10052955100036343
a.ne_(b), numel() == 10000 for 100000 times, dtype=torch.int32
0.21827425599985872
a.ne_(b), numel() == 100000 for 10000 times, dtype=torch.int32
0.21522501399886096
a.ne_(b), numel() == 10000 for 100000 times, dtype=torch.int64
0.37058242300008715
a.ne_(b), numel() == 100000 for 10000 times, dtype=torch.int64
0.39304063900090114
```

