### PR TITLE
Updates numpy to tensor negative stride error message

### DIFF
--- a/torch/csrc/utils/tensor_numpy.cpp
+++ b/torch/csrc/utils/tensor_numpy.cpp
@@ -149,10 +149,10 @@ at::Tensor tensor_from_numpy(PyObject* obj) {
   for (int i = 0; i < ndim; i++) {
     if (strides[i] < 0) {
       throw ValueError(
-          "At least one stride in the given numpy array is negative. "
-          "Tensors with negative strides are not currently supprted. "
-          "You can make your numpy array contiguous with np.ascontiguousarray() "
-          "to workaround this issue. (Doing so may copy your data.) ");
+          "At least one stride in the given numpy array is negative, "
+          "and tensors with negative strides are not currently supported. "
+          "(You can probably work around this by making a copy of your array "
+          " with array.copy().) ");
     }
     // XXX: this won't work for negative strides
     storage_size += (sizes[i] - 1) * strides[i];

--- a/torch/csrc/utils/tensor_numpy.cpp
+++ b/torch/csrc/utils/tensor_numpy.cpp
@@ -149,8 +149,10 @@ at::Tensor tensor_from_numpy(PyObject* obj) {
   for (int i = 0; i < ndim; i++) {
     if (strides[i] < 0) {
       throw ValueError(
-          "some of the strides of a given numpy array are negative. This is "
-          "currently not supported, but will be added in future releases.");
+          "At least one stride in the given numpy array is negative. "
+          "Tensors with negative strides are not currently supprted. "
+          "You can make your numpy array contiguous with np.ascontiguousarray() "
+          "to workaround this issue. (Doing so may copy your data.) ");
     }
     // XXX: this won't work for negative strides
     storage_size += (sizes[i] - 1) * strides[i];


### PR DESCRIPTION
See https://discuss.pytorch.org/t/bugs-about-torch-from-numpy-array/43312.

This update incorporates @albanD 's suggestion into the error message, saving future users from having to ask or look on the forums if they encounter this issue and don't mind making their arrays contiguous. 