### PR TITLE
Make all schemas in native_functions.yaml that have TensorOptions have optional ScalarType, Layout, Device and pin memory

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2190,9 +2190,9 @@
 
 - func: randint_like.low(Tensor self, int low, int high, *, MemoryFormat? memory_format=None) -> Tensor
 
-- func: randint_like.dtype(Tensor self, int high, *, ScalarType dtype, Layout layout, Device device, bool pin_memory=False, MemoryFormat? memory_format=None) -> Tensor
+- func: randint_like.dtype(Tensor self, int high, *, ScalarType? dtype, Layout? layout, Device? device, bool? pin_memory=False, MemoryFormat? memory_format=None) -> Tensor
 
-- func: randint_like.low_dtype(Tensor self, int low, int high, *, ScalarType dtype, Layout layout, Device device, bool pin_memory=False, MemoryFormat? memory_format=None) -> Tensor
+- func: randint_like.low_dtype(Tensor self, int low, int high, *, ScalarType? dtype, Layout? layout, Device? device, bool? pin_memory=False, MemoryFormat? memory_format=None) -> Tensor
 
 - func: randn(int[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
 
@@ -2211,7 +2211,7 @@
 - func: randn_like(Tensor self, *, MemoryFormat? memory_format=None) -> Tensor
   supports_named_tensor: True
 
-- func: randn_like.dtype(Tensor self, *, ScalarType dtype, Layout layout, Device device, bool pin_memory=False, MemoryFormat? memory_format=None) -> Tensor
+- func: randn_like.dtype(Tensor self, *, ScalarType? dtype, Layout? layout, Device? device, bool? pin_memory=False, MemoryFormat? memory_format=None) -> Tensor
   supports_named_tensor: True
 
 - func: randperm(int n, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3342,7 +3342,7 @@
     SparseCUDA: new_with_dims_sparse
   requires_tensor: True
 
-- func: _sparse_coo_tensor_with_dims_and_tensors(int sparse_dim, int dense_dim, int[] size, Tensor indices, Tensor values, *, ScalarType dtype, Layout layout, Device device, bool pin_memory=False) -> Tensor
+- func: _sparse_coo_tensor_with_dims_and_tensors(int sparse_dim, int dense_dim, int[] size, Tensor indices, Tensor values, *, ScalarType? dtype, Layout? layout, Device? device, bool? pin_memory=False) -> Tensor
   dispatch:
     SparseCPU: new_with_dims_and_tensor_sparse
     SparseCUDA: new_with_dims_and_tensor_sparse

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -146,7 +146,7 @@
   dispatch:
     CUDA: _cudnn_rnn_backward
 
-- func: _cudnn_init_dropout_state(float dropout, bool train, int dropout_seed, *, ScalarType dtype, Layout layout, Device device, bool pin_memory=False) -> Tensor
+- func: _cudnn_init_dropout_state(float dropout, bool train, int dropout_seed, *, ScalarType? dtype, Layout? layout, Device? device, bool? pin_memory=False) -> Tensor
   dispatch:
     CUDA: _cudnn_init_dropout_state
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2167,7 +2167,7 @@
 - func: rand_like(Tensor self, *, MemoryFormat? memory_format=None) -> Tensor
   supports_named_tensor: True
 
-- func: rand_like.dtype(Tensor self, *, ScalarType dtype, Layout layout, Device device, bool pin_memory=False, MemoryFormat? memory_format=None) -> Tensor
+- func: rand_like.dtype(Tensor self, *, ScalarType? dtype, Layout? layout, Device? device, bool? pin_memory=False, MemoryFormat? memory_format=None) -> Tensor
   supports_named_tensor: True
 
 - func: randint(int high, int[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1142,7 +1142,7 @@
   device_guard: False
   supports_named_tensor: True
 
-- func: empty_like.dtype(Tensor self, *, ScalarType dtype, Layout layout, Device device, bool pin_memory=False, MemoryFormat? memory_format=None) -> Tensor
+- func: empty_like.dtype(Tensor self, *, ScalarType? dtype, Layout? layout, Device? device, bool? pin_memory=False, MemoryFormat? memory_format=None) -> Tensor
   device_guard: False
   supports_named_tensor: True
 
@@ -1312,7 +1312,7 @@
 - func: full_like(Tensor self, Scalar fill_value, *, MemoryFormat? memory_format=None) -> Tensor
   supports_named_tensor: True
 
-- func: full_like.dtype(Tensor self, Scalar fill_value, *, ScalarType dtype, Layout layout, Device device, bool pin_memory=False, MemoryFormat? memory_format=None) -> Tensor
+- func: full_like.dtype(Tensor self, Scalar fill_value, *, ScalarType? dtype, Layout? layout, Device? device, bool? pin_memory=False, MemoryFormat? memory_format=None) -> Tensor
   supports_named_tensor: True
 
 - func: from_file(str filename, bool? shared=None, int? size=0, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
@@ -2089,7 +2089,7 @@
 - func: ones_like(Tensor self, *, MemoryFormat? memory_format=None) -> Tensor
   supports_named_tensor: True
 
-- func: ones_like.dtype(Tensor self, *, ScalarType dtype, Layout layout, Device device, bool pin_memory=False, MemoryFormat? memory_format=None) -> Tensor
+- func: ones_like.dtype(Tensor self, *, ScalarType? dtype, Layout? layout, Device? device, bool? pin_memory=False, MemoryFormat? memory_format=None) -> Tensor
   supports_named_tensor: True
 
 - func: pairwise_distance(Tensor x1, Tensor x2, float p=2, float eps=1e-06, bool keepdim=False) -> Tensor
@@ -2975,7 +2975,7 @@
 - func: zeros_like(Tensor self, *, MemoryFormat? memory_format=None) -> Tensor
   supports_named_tensor: True
 
-- func: zeros_like.dtype(Tensor self, *, ScalarType dtype, Layout layout, Device device, bool pin_memory=False, MemoryFormat? memory_format=None) -> Tensor
+- func: zeros_like.dtype(Tensor self, *, ScalarType? dtype, Layout? layout, Device? device, bool? pin_memory=False, MemoryFormat? memory_format=None) -> Tensor
   supports_named_tensor: True
 
 - func: _standard_gamma_grad(Tensor self, Tensor output) -> Tensor

--- a/aten/src/ATen/native_parse.py
+++ b/aten/src/ATen/native_parse.py
@@ -226,6 +226,7 @@ def parse_arguments(args, func_variants, declaration, func_return):
     supported_topt_arguments.append(copy.deepcopy(supported_topt_arguments[1]))
     for arg in supported_topt_arguments[2]:
         arg.update({'default': 'c10::nullopt', 'is_nullable': True})
+    
     # add explicit support for what is needed for tril_indices / triu_indices
     supported_topt_arguments.append(
         [
@@ -237,9 +238,24 @@ def parse_arguments(args, func_variants, declaration, func_return):
              'default': 'c10::nullopt', 'is_nullable': True},
             {'name': 'pin_memory', 'type': 'bool', 'annotation': None, 'kwarg_only': True,
              'default': 'c10::nullopt', 'is_nullable': True},
+        ])
+    supported_topt_arguments.append(
+        [
+            {'type': 'ScalarType', 'name': 'dtype', 'is_nullable': True, 'annotation': None, 'kwarg_only': True}, 
+            {'name': 'layout', 'type': 'Layout', 'annotation': None, 'kwarg_only': True, 'is_nullable': True},
+            {'name': 'device', 'type': 'Device', 'annotation': None, 'kwarg_only': True, 'is_nullable': True},
+            {'name': 'pin_memory', 'type': 'bool', 'annotation': None, 'kwarg_only': True, 'default': False, 'is_nullable': True},
         ]
     )
-
+    supported_topt_arguments.append(
+        [
+            {'type': 'ScalarType', 'name': 'dtype', 'is_nullable': True, 'annotation': None, 'kwarg_only': True}, 
+            {'type': 'Layout', 'name': 'layout', 'is_nullable': True, 'annotation': None, 'kwarg_only': True}, 
+            {'type': 'Device', 'name': 'device', 'is_nullable': True, 'annotation': None, 'kwarg_only': True}, 
+            {'type': 'bool', 'name': 'pin_memory', 'is_nullable': True, 'annotation': None, 'default': False, 'kwarg_only': True}
+        ]
+    )
+    
     corresponding_topts = [
         {'type': 'TensorOptions', 'name': 'options', 'is_nullable': False, 'annotation': None},
     ]
@@ -250,12 +266,20 @@ def parse_arguments(args, func_variants, declaration, func_return):
     corresponding_topts.append(
         {'type': 'TensorOptions', 'name': 'options', 'is_nullable': False, 'annotation': None,
          'kwarg_only': True, 'default': 'at::kLong'})
+    corresponding_topts.append(
+        {'type': 'TensorOptions', 'name': 'options', 'is_nullable': False, 'annotation': None,
+         'kwarg_only': True})
 
     def check_topt_representation(topt_representation):
         for idx, supported_topt in enumerate(supported_topt_arguments):
             matches = all(topt_representation[i] == topt for i, topt in enumerate(supported_topt))
             if matches:
                 return corresponding_topts[idx]
+            else:
+                print("\n\n\n")
+                print(topt_representation)
+                print("\nVS")
+                print(supported_topt)
         return None
 
     def is_tensor_option(argument):
@@ -274,7 +298,11 @@ def parse_arguments(args, func_variants, declaration, func_return):
                     break
                 topt_representation.append(argument)
                 idx += 1
+            
             if len(topt_representation) == number_of_arguments:
+                if declaration['name'] == '_cudnn_init_dropout_state':
+                    print("\n\n\n")
+                    print(topt_representation)
                 merged_argument = check_topt_representation(topt_representation)
                 assert merged_argument, \
                     "Unsupported combination of TensorOptions {}, the only currently supported combinations are {}"\

--- a/aten/src/ATen/native_parse.py
+++ b/aten/src/ATen/native_parse.py
@@ -226,7 +226,7 @@ def parse_arguments(args, func_variants, declaration, func_return):
     supported_topt_arguments.append(copy.deepcopy(supported_topt_arguments[1]))
     for arg in supported_topt_arguments[2]:
         arg.update({'default': 'c10::nullopt', 'is_nullable': True})
-    
+
     # add explicit support for what is needed for tril_indices / triu_indices
     supported_topt_arguments.append(
         [
@@ -255,7 +255,7 @@ def parse_arguments(args, func_variants, declaration, func_return):
             {'type': 'bool', 'name': 'pin_memory', 'is_nullable': True, 'annotation': None, 'default': False, 'kwarg_only': True}
         ]
     )
-    
+
     corresponding_topts = [
         {'type': 'TensorOptions', 'name': 'options', 'is_nullable': False, 'annotation': None},
     ]
@@ -275,11 +275,6 @@ def parse_arguments(args, func_variants, declaration, func_return):
             matches = all(topt_representation[i] == topt for i, topt in enumerate(supported_topt))
             if matches:
                 return corresponding_topts[idx]
-            else:
-                print("\n\n\n")
-                print(topt_representation)
-                print("\nVS")
-                print(supported_topt)
         return None
 
     def is_tensor_option(argument):
@@ -298,11 +293,8 @@ def parse_arguments(args, func_variants, declaration, func_return):
                     break
                 topt_representation.append(argument)
                 idx += 1
-            
+
             if len(topt_representation) == number_of_arguments:
-                if declaration['name'] == '_cudnn_init_dropout_state':
-                    print("\n\n\n")
-                    print(topt_representation)
                 merged_argument = check_topt_representation(topt_representation)
                 assert merged_argument, \
                     "Unsupported combination of TensorOptions {}, the only currently supported combinations are {}"\

--- a/aten/src/ATen/native_parse.py
+++ b/aten/src/ATen/native_parse.py
@@ -226,7 +226,6 @@ def parse_arguments(args, func_variants, declaration, func_return):
     supported_topt_arguments.append(copy.deepcopy(supported_topt_arguments[1]))
     for arg in supported_topt_arguments[2]:
         arg.update({'default': 'c10::nullopt', 'is_nullable': True})
-
     # add explicit support for what is needed for tril_indices / triu_indices
     supported_topt_arguments.append(
         [
@@ -293,7 +292,6 @@ def parse_arguments(args, func_variants, declaration, func_return):
                     break
                 topt_representation.append(argument)
                 idx += 1
-
             if len(topt_representation) == number_of_arguments:
                 merged_argument = check_topt_representation(topt_representation)
                 assert merged_argument, \

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -956,7 +956,7 @@
   self: grad.to_dense().sparse_mask(mask).to_dense()
   mask: non_differentiable
 
-- name: _sparse_coo_tensor_with_dims_and_tensors(int sparse_dim, int dense_dim, int[] size, Tensor indices, Tensor values, *, ScalarType dtype, Layout layout, Device device, bool pin_memory=False) -> Tensor
+- name: _sparse_coo_tensor_with_dims_and_tensors(int sparse_dim, int dense_dim, int[] size, Tensor indices, Tensor values, *, ScalarType? dtype, Layout? layout, Device? device, bool? pin_memory=False) -> Tensor
   values: sparse_constructor_values_backward(grad, indices, values.sizes())
 
 - name: _sparse_sum.dim(Tensor self, int[1] dim) -> Tensor

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -929,7 +929,7 @@ bool Node::isNondeterministic() const {
       "aten::rrelu_with_noise(Tensor self, Tensor noise, Scalar lower, Scalar upper, bool training, Generator? generator) -> Tensor",
       "aten::rand(int[] size, *, int? dtype, int? layout, Device? device, bool? pin_memory) -> Tensor",
       "aten::rand_like(Tensor self, *, MemoryFormat? memory_format=None) -> Tensor",
-      "aten::rand_like(Tensor self, *, int dtype, int layout, Device device, bool pin_memory, MemoryFormat? memory_format=None) -> Tensor",
+      "aten::rand_like(Tensor self, *, int? dtype, int? layout, Device? device, bool? pin_memory, MemoryFormat? memory_format=None) -> Tensor",
       "aten::randint(int high, int[] size, *, int? dtype, int? layout, Device? device, bool? pin_memory) -> Tensor",
       "aten::randint(int low, int high, int[] size, *, int? dtype, int? layout, Device? device, bool? pin_memory) -> Tensor",
       "aten::randint_like(Tensor self, int high, *, MemoryFormat? memory_format=None) -> Tensor",

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -934,11 +934,11 @@ bool Node::isNondeterministic() const {
       "aten::randint(int low, int high, int[] size, *, int? dtype, int? layout, Device? device, bool? pin_memory) -> Tensor",
       "aten::randint_like(Tensor self, int high, *, MemoryFormat? memory_format=None) -> Tensor",
       "aten::randint_like(Tensor self, int low, int high, *, MemoryFormat? memory_format=None) -> Tensor",
-      "aten::randint_like(Tensor self, int high, *, int dtype, int layout, Device device, bool pin_memory, MemoryFormat? memory_format=None) -> Tensor",
-      "aten::randint_like(Tensor self, int low, int high, *, int dtype, int layout, Device device, bool pin_memory, MemoryFormat? memory_format=None) -> Tensor",
+      "aten::randint_like(Tensor self, int high, *, int? dtype, int? layout, Device? device, bool? pin_memory, MemoryFormat? memory_format=None) -> Tensor",
+      "aten::randint_like(Tensor self, int low, int high, *, int? dtype, int? layout, Device? device, bool? pin_memory, MemoryFormat? memory_format=None) -> Tensor",
       "aten::randn(int[] size, *, int? dtype, int? layout, Device? device, bool? pin_memory) -> Tensor",
       "aten::randn_like(Tensor self, *, MemoryFormat? memory_format=None) -> Tensor",
-      "aten::randn_like(Tensor self, *, int dtype, int layout, Device device, bool pin_memory, MemoryFormat? memory_format=None) -> Tensor",
+      "aten::randn_like(Tensor self, *, int? dtype, int? layout, Device? device, bool? pin_memory, MemoryFormat? memory_format=None) -> Tensor",
       "aten::randperm(int n, *, int? dtype, int? layout, Device? device, bool? pin_memory) -> Tensor"};
 
   if (nondeterministic_ops.find(this) == nullptr) {

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -1414,7 +1414,7 @@ class ShapePropagator {
             "aten::empty_like(Tensor self, *, int dtype, int layout, Device device, bool pin_memory, MemoryFormat? memory_format=None) -> Tensor",
             "aten::full_like(Tensor self, Scalar fill_value, *, int dtype, int layout, Device device, bool pin_memory, MemoryFormat? memory_format=None) -> Tensor",
             "aten::ones_like(Tensor self, *, int dtype, int layout, Device device, bool pin_memory, MemoryFormat? memory_format=None) -> Tensor",
-            "aten::rand_like(Tensor self, *, int dtype, int layout, Device device, bool pin_memory, MemoryFormat? memory_format=None) -> Tensor",
+            "aten::rand_like(Tensor self, *, int? dtype, int? layout, Device? device, bool? pin_memory, MemoryFormat? memory_format=None) -> Tensor",
             "aten::randint_like(Tensor self, int high, *, int dtype, int layout, Device device, bool pin_memory, MemoryFormat? memory_format=None) -> Tensor",
             "aten::randint_like(Tensor self, int low, int high, *, int dtype, int layout, Device device, bool pin_memory, MemoryFormat? memory_format=None) -> Tensor",
             "aten::randn_like(Tensor self, *, int dtype, int layout, Device device, bool pin_memory, MemoryFormat? memory_format=None) -> Tensor",

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -1411,14 +1411,14 @@ class ShapePropagator {
     //   - has ScalarType dtype, Layeout layout and Device device arguments
     static const register_formula_for like_factories_with_options{
         {
-            "aten::empty_like(Tensor self, *, int dtype, int layout, Device device, bool pin_memory, MemoryFormat? memory_format=None) -> Tensor",
-            "aten::full_like(Tensor self, Scalar fill_value, *, int dtype, int layout, Device device, bool pin_memory, MemoryFormat? memory_format=None) -> Tensor",
-            "aten::ones_like(Tensor self, *, int dtype, int layout, Device device, bool pin_memory, MemoryFormat? memory_format=None) -> Tensor",
+            "aten::empty_like(Tensor self, *, int? dtype, int? layout, Device? device, bool? pin_memory, MemoryFormat? memory_format=None) -> Tensor",
+            "aten::full_like(Tensor self, Scalar fill_value, *, int? dtype, int? layout, Device? device, bool? pin_memory, MemoryFormat? memory_format=None) -> Tensor",
+            "aten::ones_like(Tensor self, *, int? dtype, int? layout, Device? device, bool? pin_memory, MemoryFormat? memory_format=None) -> Tensor",
             "aten::rand_like(Tensor self, *, int? dtype, int? layout, Device? device, bool? pin_memory, MemoryFormat? memory_format=None) -> Tensor",
             "aten::randint_like(Tensor self, int high, *, int? dtype, int? layout, Device? device, bool? pin_memory, MemoryFormat? memory_format=None) -> Tensor",
             "aten::randint_like(Tensor self, int low, int high, *, int? dtype, int? layout, Device? device, bool? pin_memory, MemoryFormat? memory_format=None) -> Tensor",
             "aten::randn_like(Tensor self, *, int? dtype, int? layout, Device? device, bool? pin_memory, MemoryFormat? memory_format=None) -> Tensor",
-            "aten::zeros_like(Tensor self, *, int dtype, int layout, Device device, bool pin_memory, MemoryFormat? memory_format=None) -> Tensor",
+            "aten::zeros_like(Tensor self, *, int? dtype, int? layout, Device? device, bool? pin_memory, MemoryFormat? memory_format=None) -> Tensor",
         },
         [](Node* node) -> type_vec_t {
           if (auto type =

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -1415,9 +1415,9 @@ class ShapePropagator {
             "aten::full_like(Tensor self, Scalar fill_value, *, int dtype, int layout, Device device, bool pin_memory, MemoryFormat? memory_format=None) -> Tensor",
             "aten::ones_like(Tensor self, *, int dtype, int layout, Device device, bool pin_memory, MemoryFormat? memory_format=None) -> Tensor",
             "aten::rand_like(Tensor self, *, int? dtype, int? layout, Device? device, bool? pin_memory, MemoryFormat? memory_format=None) -> Tensor",
-            "aten::randint_like(Tensor self, int high, *, int dtype, int layout, Device device, bool pin_memory, MemoryFormat? memory_format=None) -> Tensor",
-            "aten::randint_like(Tensor self, int low, int high, *, int dtype, int layout, Device device, bool pin_memory, MemoryFormat? memory_format=None) -> Tensor",
-            "aten::randn_like(Tensor self, *, int dtype, int layout, Device device, bool pin_memory, MemoryFormat? memory_format=None) -> Tensor",
+            "aten::randint_like(Tensor self, int high, *, int? dtype, int? layout, Device? device, bool? pin_memory, MemoryFormat? memory_format=None) -> Tensor",
+            "aten::randint_like(Tensor self, int low, int high, *, int? dtype, int? layout, Device? device, bool? pin_memory, MemoryFormat? memory_format=None) -> Tensor",
+            "aten::randn_like(Tensor self, *, int? dtype, int? layout, Device? device, bool? pin_memory, MemoryFormat? memory_format=None) -> Tensor",
             "aten::zeros_like(Tensor self, *, int dtype, int layout, Device device, bool pin_memory, MemoryFormat? memory_format=None) -> Tensor",
         },
         [](Node* node) -> type_vec_t {


### PR DESCRIPTION
Fixing schemas for:
- randint_like
- rand_like
- randn_like
- zeros_like
- ones_like
- full_like
- empty_like
- _cudnn_init_dropout_state
- _sparse_coo_tensor_with_dims_and_tensors