### PR TITLE
fix typing bug of LambdaLR.__init__

### DIFF
--- a/torch/optim/lr_scheduler.pyi
+++ b/torch/optim/lr_scheduler.pyi
@@ -1,4 +1,4 @@
-from typing import Iterable, Any, Optional, Callable
+from typing import Iterable, Any, Optional, Callable, Union, List
 from .optimizer import Optimizer
 
 class _LRScheduler:
@@ -9,7 +9,7 @@ class _LRScheduler:
     def step(self, epoch: Optional[int]=...) -> None: ...
 
 class LambdaLR(_LRScheduler):
-    def __init__(self, optimizer: Optimizer, lr_lambda: float, last_epoch: int=...) -> None: ...
+    def __init__(self, optimizer: Optimizer, lr_lambda: Union[Callable[[int], float], List[Callable[[int], float]]], last_epoch: int=...) -> None: ...
 
 class StepLR(_LRScheduler):
     def __init__(self, optimizer: Optimizer, step_size: int, gamma: float=..., last_epoch: int=...) -> None:...


### PR DESCRIPTION
## problem

```python
class LambdaLR(_LRScheduler):
    """Sets the learning rate of each parameter group to the initial lr
    times a given function. When last_epoch=-1, sets initial lr as lr.

    Args:
        optimizer (Optimizer): Wrapped optimizer.
        lr_lambda (function or list): A function which computes a multiplicative
            factor given an integer parameter epoch, or a list of such
            functions, one for each group in optimizer.param_groups.
        last_epoch (int): The index of last epoch. Default: -1.

    Example:
        >>> # Assuming optimizer has two groups.
        >>> lambda1 = lambda epoch: epoch // 30
        >>> lambda2 = lambda epoch: 0.95 ** epoch
        >>> scheduler = LambdaLR(optimizer, lr_lambda=[lambda1, lambda2])
        >>> for epoch in range(100):
        >>>     train(...)
        >>>     validate(...)
        >>>     scheduler.step()
    """
```

`LambdaLR` takes a lambda that returns a float and takes a int, or a list of such lambdas.

## related issue

Resolve #32645