### PR TITLE
Fractional Max Pooling: output ratios defined as double

### DIFF
--- a/torch/csrc/api/include/torch/nn/functional/pooling.h
+++ b/torch/csrc/api/include/torch/nn/functional/pooling.h
@@ -499,7 +499,7 @@ inline std::tuple<Tensor, Tensor> fractional_max_pool2d_with_indices(
     const Tensor& input,
     const ExpandingArray<2>& kernel_size,
     const c10::optional<ExpandingArray<2>>& output_size,
-    const c10::optional<ExpandingArray<2>>& output_ratio,
+    const c10::optional<ExpandingArray<2,double>>& output_ratio,
     const Tensor& _random_samples) {
   if (output_size == c10::nullopt && output_ratio == c10::nullopt) {
     TORCH_CHECK(
@@ -536,7 +536,7 @@ namespace detail {
 inline Tensor fractional_max_pool2d(const Tensor& input,
                                     ExpandingArray<2> kernel_size,
                                     c10::optional<ExpandingArray<2>> output_size,
-                                    c10::optional<ExpandingArray<2>> output_ratio,
+                                    c10::optional<ExpandingArray<2,double>> output_ratio,
                                     const Tensor& _random_samples) {
   return std::get<0>(fractional_max_pool2d_with_indices(input, kernel_size, output_size,
                                                         output_ratio, _random_samples));
@@ -557,7 +557,7 @@ inline std::tuple<Tensor, Tensor> fractional_max_pool3d_with_indices(
     const Tensor& input,
     const ExpandingArray<3>& kernel_size,
     const c10::optional<ExpandingArray<3>>& output_size,
-    const c10::optional<ExpandingArray<3>>& output_ratio,
+    const c10::optional<ExpandingArray<3,double>>& output_ratio,
     const Tensor& _random_samples) {
   if (output_size == c10::nullopt && output_ratio == c10::nullopt) {
     TORCH_CHECK(
@@ -595,7 +595,7 @@ namespace detail {
 inline Tensor fractional_max_pool3d(const Tensor& input,
                                     ExpandingArray<3> kernel_size,
                                     c10::optional<ExpandingArray<3>> output_size,
-                                    c10::optional<ExpandingArray<3>> output_ratio,
+                                    c10::optional<ExpandingArray<3,double>> output_ratio,
                                     const Tensor& _random_samples) {
   return std::get<0>(fractional_max_pool3d_with_indices(input, kernel_size, output_size,
                                                         output_ratio, _random_samples));

--- a/torch/csrc/api/include/torch/nn/options/pooling.h
+++ b/torch/csrc/api/include/torch/nn/options/pooling.h
@@ -211,7 +211,8 @@ struct FractionalMaxPoolOptions {
 
   /// If one wants to have an output size as a ratio of the input size, this option can be given.
   /// This has to be a number or tuple in the range (0, 1)
-  TORCH_ARG(c10::optional<ExpandingArray<D>>, output_ratio) = c10::nullopt;
+  using ExpandingArrayDouble=torch::ExpandingArray<D,double>;
+  TORCH_ARG(c10::optional<ExpandingArrayDouble>, output_ratio) = c10::nullopt;
 
   TORCH_ARG(torch::Tensor, _random_samples) = Tensor();
 };

--- a/torch/csrc/api/src/nn/modules/pooling.cpp
+++ b/torch/csrc/api/src/nn/modules/pooling.cpp
@@ -290,7 +290,7 @@ void FractionalMaxPool2dImpl::reset() {
     TORCH_CHECK(false, "only one of output_size and output_ratio may be specified");
   }
   if (options.output_ratio() != c10::nullopt) {
-    at::IntArrayRef output_ratio = at::IntArrayRef(options.output_ratio().value());
+    at::ArrayRef<double> output_ratio = at::ArrayRef<double>(options.output_ratio().value());
     if (!(0 < output_ratio[0] && output_ratio[0] < 1 &&
           0 < output_ratio[1] && output_ratio[1] < 1)) {
       TORCH_CHECK(false, "output_ratio must be between 0 and 1 (got ", output_ratio, ")");
@@ -331,7 +331,7 @@ void FractionalMaxPool3dImpl::reset() {
     TORCH_CHECK(false, "only one of output_size and output_ratio may be specified");
   }
   if (options.output_ratio() != c10::nullopt) {
-    at::IntArrayRef output_ratio = at::IntArrayRef(options.output_ratio().value());
+    at::ArrayRef<double> output_ratio = at::ArrayRef<double>(options.output_ratio().value());
     if (!(0 < output_ratio[0] && output_ratio[0] < 1 && 
           0 < output_ratio[1] && output_ratio[1] < 1 &&
           0 < output_ratio[2] && output_ratio[2] < 1)) {


### PR DESCRIPTION
References #33240 
Changes options.output_ratio from long integer to double to allow ratios to used to calculate output size from inputs.