### PR TITLE
[pytorch] Fix broken hypothesis timeout setting

### DIFF
--- a/test/test_fake_quant.py
+++ b/test/test_fake_quant.py
@@ -10,7 +10,6 @@ from torch.testing._internal.common_utils import run_tests, TestCase
 from torch.quantization import FakeQuantize
 from torch.quantization import default_observer, default_per_channel_weight_observer
 import io
-import unittest
 
 # Reference method for fake quantize
 def _fake_quantize_per_tensor_affine_reference(X, scale, zero_point, quant_min, quant_max):
@@ -85,7 +84,6 @@ class TestFakeQuantizePerTensor(TestCase):
     @given(device=st.sampled_from(['cpu', 'cuda'] if torch.cuda.is_available() else ['cpu']),
            X=hu.tensor(shapes=hu.array_shapes(1, 5,),
                        qparams=hu.qparams(dtypes=torch.quint8)))
-    @unittest.skip("temporarily disable the test")
     def test_backward_per_tensor(self, device, X):
         r"""Tests the backward method.
         """
@@ -108,8 +106,6 @@ class TestFakeQuantizePerTensor(TestCase):
     @given(device=st.sampled_from(['cpu', 'cuda'] if torch.cuda.is_available() else ['cpu']),
            X=hu.tensor(shapes=hu.array_shapes(1, 5,),
                        qparams=hu.qparams(dtypes=torch.quint8)))
-    # https://github.com/pytorch/pytorch/issues/30604
-    @unittest.skip("temporarily disable the test")
     def test_numerical_consistency_per_tensor(self, device, X):
         r"""Comparing numerical consistency between CPU quantize/dequantize op and the CPU fake quantize op
         """
@@ -249,7 +245,6 @@ class TestFakeQuantizePerChannel(TestCase):
     @given(device=st.sampled_from(['cpu', 'cuda'] if torch.cuda.is_available() else ['cpu']),
            X=hu.per_channel_tensor(shapes=hu.array_shapes(1, 5,),
            qparams=hu.qparams(dtypes=torch.quint8)))
-    @unittest.skip("temporarily disable the test")
     def test_numerical_consistency_per_channel(self, device, X):
         r"""Comparing numerical consistency between CPU quantize/dequantize op and the CPU fake quantize op
         """

--- a/test/test_quantization.py
+++ b/test/test_quantization.py
@@ -534,7 +534,6 @@ class PostTrainingDynamicQuantTest(QuantizationTestCase):
         model = quantize_dynamic(NestedModel().eval(), qconfig_dict)
         checkQuantized(model)
 
-    @unittest.skip("temporarily disable the test")
     @given(qengine=st.sampled_from(("qnnpack", "fbgemm")))
     def test_quantized_rnn(self, qengine):
         d_in, d_hid = 2, 2

--- a/torch/testing/_internal/hypothesis_utils.py
+++ b/torch/testing/_internal/hypothesis_utils.py
@@ -52,7 +52,7 @@ def _floats_wrapper(*args, **kwargs):
 def floats(*args, **kwargs):
     if 'width' not in kwargs:
         kwargs['width'] = 32
-    return st.floats(*args, **kwargs)
+    return _floats_wrapper(*args, **kwargs)
 
 """Hypothesis filter to avoid overflows with quantized tensors.
 
@@ -317,7 +317,11 @@ hypothesis_version = hypothesis.version.__version_info__
 current_settings = settings._profiles[settings._current_profile].__dict__
 current_settings['deadline'] = None
 if hypothesis_version >= (3, 16, 0) and hypothesis_version < (5, 0, 0):
-    current_settings['timeout'] = hypothesis.unlimited
+    if hypothesis_version < (4, 8, 0):
+        current_settings['timeout'] = -1
+    else:
+        current_settings['timeout'] = hypothesis.unlimited
+
 def assert_deadline_disabled():
     if hypothesis_version < (3, 27, 0):
         import warnings


### PR DESCRIPTION
Summary:
For `hypothesis` versions ranging from `3.16.0` to `5.0.0`, we attempt to override the `timeout` value with `hypothesis.unlimited`. As settings objects are immutable, we have to modify `__dict__` directly, bypassing the validator that has the following definition:
```
def _validate_timeout(n):
    if n is unlimited:
        return -1
    else:
        return n
```
Accordingly, the correct setting for us is `-1`, not `hypothesis.unlimited`.

As a result of this error, it appears that any test that imported `hypothesis_utils` for the above `hypothesis` versions never ran successfully. A number of tests seem to have been disabled due to the side-effects of this bug, so re-enabling as part of the fix.

Test Plan: `buck test`, broken hypothesis tests now pass

Differential Revision: D19873984

