### PR TITLE
Get rid of some template arguments in GPU loop

### DIFF
--- a/aten/src/ATen/native/cuda/CUDALoops.cuh
+++ b/aten/src/ATen/native/cuda/CUDALoops.cuh
@@ -211,7 +211,7 @@ __device__ inline void elementwise_kernel_helper(func_t f, array_t data, policy_
   constexpr int nargs = traits::arity == 0 ? 1 : traits::arity;
 
   // compute base pointers for this block
-  int idx = policy_t::block_work_size * blockIdx.x;
+  int idx = block_work_size * blockIdx.x;
   return_t *result_base = reinterpret_cast<return_t *>(data[0]) + idx;
   arg_t *args_base[nargs];
   #pragma unroll
@@ -219,8 +219,8 @@ __device__ inline void elementwise_kernel_helper(func_t f, array_t data, policy_
     args_base[i] = reinterpret_cast<arg_t *>(data[i + 1]) + idx;
   }
 
-  return_t results[policy_t::thread_work_size];
-  arg_t args[policy_t::thread_work_size][nargs];
+  return_t results[thread_work_size];
+  arg_t args[thread_work_size][nargs];
 
   // load
   #pragma unroll
@@ -231,7 +231,7 @@ __device__ inline void elementwise_kernel_helper(func_t f, array_t data, policy_
 
   // compute
   #pragma unroll
-  for (int i = 0; i < policy_t::thread_work_size; i++) {
+  for (int i = 0; i < thread_work_size; i++) {
     results[i] = detail::invoke_with_array(f, args[i]);
   }
 
@@ -240,40 +240,38 @@ __device__ inline void elementwise_kernel_helper(func_t f, array_t data, policy_
   policy.store(result_accessor, result_base);
 }
 
-template<int vec_size, int num_threads, int thread_work_size, typename func_t, typename array_t>
+template<int vec_size, typename func_t, typename array_t>
 C10_LAUNCH_BOUNDS_1(num_threads)
 __global__ void elementwise_kernel(int N, func_t f, array_t data) {
   using return_t = typename function_traits<func_t>::result_type;
-  using policies = memory::policies<num_threads, thread_work_size>;
-  int remaining = N - policies::common::block_work_size * blockIdx.x;
+  int remaining = N - block_work_size * blockIdx.x;
 
-  if (remaining < policies::common::block_work_size) {  // if this block handles the reminder, just do a naive unrolled loop
-    elementwise_kernel_helper(f, data, typename policies::checked_unroll(remaining));
+  if (remaining < block_work_size) {  // if this block handles the reminder, just do a naive unrolled loop
+    elementwise_kernel_helper(f, data, typename memory::policies::checked_unroll(remaining));
   } else {  // if this block has a full `block_work_size` data to handle, use vectorized memory access
-    elementwise_kernel_helper(f, data, typename policies::template vectorized<vec_size>());
+    elementwise_kernel_helper(f, data, typename memory::policies::template vectorized<vec_size>());
   }
 }
 
 // TODO (@zasdfgbnm): this function assume trivial 1d and no dynamic casting
-template<int nt, int vt, typename func_t, typename array_t, std::enable_if_t<detail::has_same_arg_types<func_t>::value, int> = 0>
+template<typename func_t, typename array_t, std::enable_if_t<detail::has_same_arg_types<func_t>::value, int> = 0>
 static void launch_kernel(int64_t N, const func_t& f, array_t data) {
   TORCH_INTERNAL_ASSERT(N >= 0 && N <= std::numeric_limits<int32_t>::max());
   if (N == 0) {
     return;
   }
-  dim3 block(nt);
-  dim3 grid((N + block.x * vt - 1) / (block.x * vt));
+  int64_t grid = (N + block_work_size - 1) / block_work_size;
   auto stream = at::cuda::getCurrentCUDAStream();
   int vec_size = detail::can_vectorize_up_to<func_t>(data);
   switch (vec_size) {
   case 4:
-    elementwise_kernel<4, nt, vt, func_t, array_t><<<grid, block, 0, stream>>>(N, f, data);
+    elementwise_kernel<4, func_t, array_t><<<grid, num_threads, 0, stream>>>(N, f, data);
     break;
   case 2:
-    elementwise_kernel<2, nt, vt, func_t, array_t><<<grid, block, 0, stream>>>(N, f, data);
+    elementwise_kernel<2, func_t, array_t><<<grid, num_threads, 0, stream>>>(N, f, data);
     break;
   case 1:
-    elementwise_kernel<1, nt, vt, func_t, array_t><<<grid, block, 0, stream>>>(N, f, data);
+    elementwise_kernel<1, func_t, array_t><<<grid, num_threads, 0, stream>>>(N, f, data);
     break;
   default:
     TORCH_INTERNAL_ASSERT(false, "Unexpected vectorization size");
@@ -281,7 +279,7 @@ static void launch_kernel(int64_t N, const func_t& f, array_t data) {
   AT_CUDA_CHECK(cudaGetLastError());
 }
 
-template<int nt, int vt, typename func_t, typename array_t, std::enable_if_t<!detail::has_same_arg_types<func_t>::value, int> = 0>
+template<typename func_t, typename array_t, std::enable_if_t<!detail::has_same_arg_types<func_t>::value, int> = 0>
 static void launch_kernel(int64_t N, const func_t& f, array_t data) {}
 
 } // namespace modern

--- a/aten/src/ATen/native/cuda/MemoryAccess.cuh
+++ b/aten/src/ATen/native/cuda/MemoryAccess.cuh
@@ -15,94 +15,85 @@ struct alignas(sizeof(scalar_t) * vec_size) aligned_vector {
   scalar_t val[vec_size];
 };
 
-template <
-  int num_threads_,        // number of threads in a block.
-  int thread_work_size_    // number of elements each block needs to handle.
->
-struct policies {
+namespace policies {
 
-  struct common {
-    static constexpr int num_threads = num_threads_;
-    static constexpr int thread_work_size = thread_work_size_;
-    static constexpr int block_work_size = thread_work_size_ * num_threads_;
-  };
+struct checked_unroll {
 
-  struct checked_unroll : public common {
+  int remaining;
 
-    int remaining;
+  __device__ checked_unroll(int remaining): remaining(remaining) {}
 
-    __device__ checked_unroll(int remaining): remaining(remaining) {}
-
-    template<typename accessor_t, typename scalar_t>
-    __device__ inline void load(accessor_t to, scalar_t *from) {
-      int thread_idx = threadIdx.x;
-      #pragma unroll
-      for (int i = 0; i < thread_work_size_; i++) {
-        if (thread_idx >= remaining) {
-          return;
-        }
-        to(i) = from[thread_idx];
-        thread_idx += num_threads_;
+  template<typename accessor_t, typename scalar_t>
+  __device__ inline void load(accessor_t to, scalar_t *from) {
+    int thread_idx = threadIdx.x;
+    #pragma unroll
+    for (int i = 0; i < thread_work_size; i++) {
+      if (thread_idx >= remaining) {
+        return;
       }
+      to(i) = from[thread_idx];
+      thread_idx += num_threads;
     }
+  }
 
-    template<typename accessor_t, typename scalar_t>
-    __device__ inline void store(accessor_t from, scalar_t *to) {
-      int thread_idx = threadIdx.x;
-      #pragma unroll
-      for (int i = 0; i < thread_work_size_; i++) {
-        if (thread_idx >= remaining) {
-          return;
-        }
-        to[thread_idx] = from(i);
-        thread_idx += num_threads_;
+  template<typename accessor_t, typename scalar_t>
+  __device__ inline void store(accessor_t from, scalar_t *to) {
+    int thread_idx = threadIdx.x;
+    #pragma unroll
+    for (int i = 0; i < thread_work_size; i++) {
+      if (thread_idx >= remaining) {
+        return;
       }
+      to[thread_idx] = from(i);
+      thread_idx += num_threads;
     }
-  };
-
-  // Functions here does not do boundary check. It assumes the whole block
-  // has its job to do. So the reminders should be handled by the the caller
-  // manually.
-
-  template <int vec_size>  // vec_size: number of scalars, can be 1, 2, or 4.
-  struct vectorized : public common {
-
-    static_assert(thread_work_size_ % vec_size == 0, "The workload per thread must be a multiple of vec_size");
-    static constexpr int loop_size = thread_work_size_ / vec_size;
-
-    template<typename accessor_t, typename scalar_t>
-    __device__ inline void load(accessor_t to, scalar_t *from) {
-      using vec_t = aligned_vector<scalar_t, vec_size>;
-      vec_t *from_ = reinterpret_cast<vec_t *>(from);
-      int thread_idx = threadIdx.x;
-      #pragma unroll
-      for (int i = 0; i < loop_size; i++) {
-        int index = thread_idx + i * num_threads_;
-        vec_t v = from_[index];
-        #pragma unroll
-        for (int j = 0; j < vec_size; j++) {
-          to(vec_size * i + j) = v.val[j];
-        }
-      }
-    }
-
-    template<typename accessor_t, typename scalar_t>
-    __device__ inline void store(accessor_t from, scalar_t *to) {
-      using vec_t = aligned_vector<scalar_t, vec_size>;
-      vec_t *to_ = reinterpret_cast<vec_t *>(to);
-      int thread_idx = threadIdx.x;
-      #pragma unroll
-      for (int i = 0; i < loop_size; i++) {
-        int index = thread_idx + i * num_threads_;
-        vec_t v;
-        for (int j = 0; j < vec_size; j++) {
-          v.val[j] = from(vec_size * i + j);
-        }
-        to_[index] = v;
-      }
-    }
-  };
+  }
 };
+
+// Functions here does not do boundary check. It assumes the whole block
+// has its job to do. So the reminders should be handled by the the caller
+// manually.
+
+template <int vec_size>  // vec_size: number of scalars, can be 1, 2, or 4.
+struct vectorized {
+
+  static_assert(thread_work_size % vec_size == 0, "The workload per thread must be a multiple of vec_size");
+  static constexpr int loop_size = thread_work_size / vec_size;
+
+  template<typename accessor_t, typename scalar_t>
+  __device__ inline void load(accessor_t to, scalar_t *from) {
+    using vec_t = aligned_vector<scalar_t, vec_size>;
+    vec_t *from_ = reinterpret_cast<vec_t *>(from);
+    int thread_idx = threadIdx.x;
+    #pragma unroll
+    for (int i = 0; i < loop_size; i++) {
+      int index = thread_idx + i * num_threads;
+      vec_t v = from_[index];
+      #pragma unroll
+      for (int j = 0; j < vec_size; j++) {
+        to(vec_size * i + j) = v.val[j];
+      }
+    }
+  }
+
+  template<typename accessor_t, typename scalar_t>
+  __device__ inline void store(accessor_t from, scalar_t *to) {
+    using vec_t = aligned_vector<scalar_t, vec_size>;
+    vec_t *to_ = reinterpret_cast<vec_t *>(to);
+    int thread_idx = threadIdx.x;
+    #pragma unroll
+    for (int i = 0; i < loop_size; i++) {
+      int index = thread_idx + i * num_threads;
+      vec_t v;
+      for (int j = 0; j < vec_size; j++) {
+        v.val[j] = from(vec_size * i + j);
+      }
+      to_[index] = v;
+    }
+  }
+};
+
+}  // namespace policies
 
 template<typename scalar_t>
 inline int can_vectorize_up_to(char *pointer) {

--- a/aten/src/ATen/native/cuda/ROCmLoops.cuh
+++ b/aten/src/ATen/native/cuda/ROCmLoops.cuh
@@ -233,7 +233,7 @@ __global__ void elementwise_kernel(int N, func_t f, array_t data) {
   #pragma unroll
   for (int i = 0; i < thread_work_size; i++) {
     if (idx + num_threads * i < N) {
-      *(result_base + i * nt) = results[i];
+      *(result_base + i * num_threads) = results[i];
     }
   }
 }

--- a/aten/src/ATen/native/cuda/ROCmLoops.cuh
+++ b/aten/src/ATen/native/cuda/ROCmLoops.cuh
@@ -180,8 +180,8 @@ using type = typename arg_type_helper<func_t, function_traits<func_t>::arity>::t
 
 }  // namespace detail
 
-template<int nt, int vt, typename func_t, typename array_t>
-C10_LAUNCH_BOUNDS_1(nt)
+template<typename func_t, typename array_t>
+C10_LAUNCH_BOUNDS_1(num_threads)
 __global__ void elementwise_kernel(int N, func_t f, array_t data) {
   // Assumption:
   // 1. all arguments of `f` have the same type, which could be different from the return type of `f`
@@ -198,8 +198,7 @@ __global__ void elementwise_kernel(int N, func_t f, array_t data) {
   constexpr int nargs = traits::arity == 0 ? 1 : traits::arity;
 
   int tid = threadIdx.x;
-  int nv = nt * vt;
-  int idx = nv * blockIdx.x + tid;
+  int idx = block_work_size * blockIdx.x + tid;
 
   // compute base pointers
   return_t *result_base = reinterpret_cast<return_t *>(data[0]) + idx;
@@ -210,50 +209,49 @@ __global__ void elementwise_kernel(int N, func_t f, array_t data) {
   }
 
   // fetch data
-  return_t results[vt];
-  arg_t args[vt][nargs];
+  return_t results[thread_work_size];
+  arg_t args[thread_work_size][nargs];
   #pragma unroll
-  for (int i = 0; i < vt; i++) {
-    if (idx + nt * i < N) {
+  for (int i = 0; i < thread_work_size; i++) {
+    if (idx + num_threads * i < N) {
       #pragma unroll
       for (int j = 0; j < arity; j++) {
-        args[i][j] = *(args_base[j] + i * nt);
+        args[i][j] = *(args_base[j] + i * num_threads);
       }
     }
   }
 
   // compute
   #pragma unroll
-  for (int i = 0; i < vt; i++) {
-    if (idx + nt * i < N) {
+  for (int i = 0; i < thread_work_size; i++) {
+    if (idx + num_threads * i < N) {
       results[i] = detail::invoke_with_array<func_t, arg_t[nargs]>(f, args[i]);
     }
   }
 
   // store data
   #pragma unroll
-  for (int i = 0; i < vt; i++) {
-    if (idx + nt * i < N) {
+  for (int i = 0; i < thread_work_size; i++) {
+    if (idx + num_threads * i < N) {
       *(result_base + i * nt) = results[i];
     }
   }
 }
 
 // TODO (@zasdfgbnm): this function assume trivial 1d and no dynamic casting
-template<int nt, int vt, typename func_t, typename array_t, std::enable_if_t<detail::has_same_arg_types<func_t>::value, int> = 0>
+template<typename func_t, typename array_t, std::enable_if_t<detail::has_same_arg_types<func_t>::value, int> = 0>
 static void launch_kernel(int64_t N, const func_t& f, array_t data) {
   TORCH_INTERNAL_ASSERT(N >= 0 && N <= std::numeric_limits<int32_t>::max());
   if (N == 0) {
     return;
   }
-  dim3 block(nt);
-  dim3 grid((N + block.x * vt - 1) / (block.x * vt));
+  int64_t grid = (N + block_work_size - 1) / block_work_size;
   auto stream = at::cuda::getCurrentCUDAStream();
-  elementwise_kernel<nt, vt, func_t, array_t><<<grid, block, 0, stream>>>(N, f, data);
+  elementwise_kernel<func_t, array_t><<<grid, num_threads, 0, stream>>>(N, f, data);
   AT_CUDA_CHECK(cudaGetLastError());
 }
 
-template<int nt, int vt, typename func_t, typename array_t, std::enable_if_t<!detail::has_same_arg_types<func_t>::value, int> = 0>
+template<typename func_t, typename array_t, std::enable_if_t<!detail::has_same_arg_types<func_t>::value, int> = 0>
 static void launch_kernel(int64_t N, const func_t& f, array_t data) {}
 
 } // namespace modern

--- a/aten/src/ATen/test/cuda_vectorized_test.cu
+++ b/aten/src/ATen/test/cuda_vectorized_test.cu
@@ -1,7 +1,7 @@
 #include <gtest/gtest.h>
 #include <ATen/ATen.h>
-#include <ATen/native/cuda/MemoryAccess.cuh>
 #include <ATen/native/cuda/Loops.cuh>
+#include <ATen/native/cuda/MemoryAccess.cuh>
 #include <ATen/cuda/CUDAContext.h>
 
 using namespace at::native::memory;
@@ -69,9 +69,9 @@ TEST(TestVectorizedMemoryAccess, CanVectorizeUpTo) {
 // defined in `ATen/native/cuda/MemoryAccess.cuh`
 template <typename scalar_t, int vec_size>
 __global__ void vectorized_copy(scalar_t *dst, scalar_t *src) {
-  using vectorized = policies<64, 4>::vectorized<vec_size>;
+  using vectorized = policies::vectorized<vec_size>;
   auto policy = vectorized();
-  scalar_t buf[vectorized::thread_work_size];
+  scalar_t buf[thread_work_size];
   auto accessor = [&](int index) -> scalar_t & { return buf[index]; };
   policy.load(accessor, src + 256 * blockIdx.x);
   policy.store(accessor, dst + 256 * blockIdx.x);

--- a/aten/src/ATen/test/cuda_vectorized_test.cu
+++ b/aten/src/ATen/test/cuda_vectorized_test.cu
@@ -4,7 +4,9 @@
 #include <ATen/native/cuda/MemoryAccess.cuh>
 #include <ATen/cuda/CUDAContext.h>
 
+using namespace at::native;
 using namespace at::native::memory;
+
 __managed__ double4 buffer1[1024];
 __managed__ double4 buffer2[1024];
 


### PR DESCRIPTION
Globally define
```C++
constexpr int num_threads = C10_WARP_SIZE * 2;
constexpr int thread_work_size = 4;
constexpr int block_work_size = thread_work_size * num_threads;
```
and kill all the template arguments passing these values.

These are effectively global, but we are now passing them around by template arguments, causing many inconvenience in coding.