### PR TITLE
Fix index truncation in argmin/max for large tensors

### DIFF
--- a/aten/src/ATen/native/SharedReduceOps.h
+++ b/aten/src/ATen/native/SharedReduceOps.h
@@ -102,6 +102,11 @@ struct WelfordOps {
 #endif
     return results;
   }
+
+  static C10_DEVICE acc_t translate_idx(acc_t acc, int64_t /*base_idx*/) {
+    return acc;
+  }
+
 #if defined(__CUDACC__) || defined(__HIPCC__)
   inline __device__ acc_t warp_shfl_down(acc_t acc, int offset) const {
     return {
@@ -133,6 +138,10 @@ struct MeanOps {
     return a * factor;
   }
 
+  static C10_DEVICE acc_t translate_idx(acc_t acc, int64_t /*base_idx*/) {
+    return acc;
+  }
+
 #if defined(__CUDACC__) || defined(__HIPCC__)
   inline C10_DEVICE acc_t warp_shfl_down(acc_t data, int offset) const {
     return WARP_SHFL_DOWN(data, offset);
@@ -158,6 +167,10 @@ struct AbsMinOps {
     return a;
   }
 
+  static C10_DEVICE acc_t translate_idx(acc_t acc, int64_t /*base_idx*/) {
+    return acc;
+  }
+
 #if defined(__CUDACC__) || defined(__HIPCC__)
   inline C10_DEVICE acc_t warp_shfl_down(acc_t data, int offset) const {
     return WARP_SHFL_DOWN(data, offset);
@@ -178,6 +191,10 @@ struct AbsMaxOps {
 
   inline C10_DEVICE acc_t project(acc_t a) const {
     return a;
+  }
+
+  static C10_DEVICE acc_t translate_idx(acc_t acc, int64_t /*base_idx*/) {
+    return acc;
   }
 
 #if defined(__CUDACC__) || defined(__HIPCC__)
@@ -201,6 +218,10 @@ struct NormOps {
 
   inline C10_DEVICE acc_t project(acc_t a) const {
     return compat_pow(a, acc_t(1.0)/norm_);
+  }
+
+  static C10_DEVICE acc_t translate_idx(acc_t acc, int64_t /*base_idx*/) {
+    return acc;
   }
 
 #if defined(__CUDACC__) || defined(__HIPCC__)
@@ -227,6 +248,11 @@ struct NormZeroOps {
     return a;
   }
 
+  static C10_DEVICE acc_t translate_idx(acc_t acc, int64_t /*base_idx*/) {
+    return acc;
+  }
+
+
 #if defined(__CUDACC__) || defined(__HIPCC__)
   inline C10_DEVICE acc_t warp_shfl_down(acc_t data, int offset) const {
     return WARP_SHFL_DOWN(data, offset);
@@ -248,6 +274,10 @@ struct NormOneOps {
     return a;
   }
 
+  static C10_DEVICE acc_t translate_idx(acc_t acc, int64_t /*base_idx*/) {
+    return acc;
+  }
+
 #if defined(__CUDACC__) || defined(__HIPCC__)
   inline C10_DEVICE acc_t warp_shfl_down(acc_t data, int offset) const {
     return WARP_SHFL_DOWN(data, offset);
@@ -267,6 +297,10 @@ struct NormTwoOps {
 
   inline C10_DEVICE acc_t project(acc_t a) const {
     return device_sqrt(a);
+  }
+
+  static C10_DEVICE acc_t translate_idx(acc_t acc, int64_t /*base_idx*/) {
+    return acc;
   }
 
 #if defined(__CUDACC__) || defined(__HIPCC__)
@@ -314,6 +348,10 @@ struct ArgReductionOps {
 
   static C10_DEVICE arg_t combine(arg_t a, arg_t b) {
     return comp_t{}(a.first, b.first) ? a : b;
+  }
+
+  static C10_DEVICE arg_t translate_idx(arg_t a, int64_t base_idx) {
+    return {a.first, a.second + base_idx};
   }
 
 #if defined(__CUDACC__) || defined(__HIPCC__)

--- a/aten/src/ATen/native/TensorIterator.cpp
+++ b/aten/src/ATen/native/TensorIterator.cpp
@@ -630,6 +630,7 @@ void TensorIterator::remove_dimension(int dim) {
 void TensorIterator::narrow(int dim, int64_t start, int64_t size) {
   TORCH_INTERNAL_ASSERT(dim < ndim() && size >= 1);
   shape_[dim] = size;
+  view_offsets_[dim] += start;
   for (auto& op : operands_) {
     op.data = ((char*)op.data) + op.stride_bytes[dim] * start;
   }
@@ -974,6 +975,9 @@ void TensorIterator::build() {
     TORCH_INTERNAL_ASSERT(op.tensor.defined());
     op.data = op.tensor.data_ptr();
   }
+
+  // zero out offsets
+  view_offsets_ = DimVector(ndim(), 0);
 }
 
 SplitUntil32Bit TensorIterator::with_32bit_indexing() const {

--- a/aten/src/ATen/native/TensorIterator.h
+++ b/aten/src/ATen/native/TensorIterator.h
@@ -179,6 +179,7 @@ struct CAFFE2_API TensorIterator {
   int ntensors() const { return operands_.size(); }
   int noutputs() const { return num_outputs_; }
   int ninputs() const { return ntensors() - noutputs(); }
+  IntArrayRef view_offsets() const { return view_offsets_; }
 
   /// number of elements in the output operand. this is the same as numel() for
   /// operations that are not reductions.
@@ -370,6 +371,8 @@ protected:
 protected:
   DimVector shape_;
   DimVector perm_;
+  /// The index offsets into the original tensors for each dimension
+  DimVector view_offsets_;
   NameVector names_;
   SmallVector<OperandInfo, 4> operands_;
   int num_outputs_ = 0;

--- a/aten/src/ATen/native/cpu/Reduce.h
+++ b/aten/src/ATen/native/cpu/Reduce.h
@@ -214,7 +214,7 @@ void binary_kernel_reduce(TensorIterator& iter, ops_t ops, init_t init) {
           in += stride;
         }
       }, {begin, end});
-      return acc;
+      return ops.translate_idx(acc, sub_iter.view_offsets()[0]);
     };
     acc_t total_acc = init;
     auto numel = sub_iter.numel();

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -8453,14 +8453,14 @@ class TestTorchDeviceType(TestCase):
         # Regression test for gh-32863
         # Requires > 8 GB of memory. So, if allocation fails just skip it.
         try:
-            x = torch.zeros((2, 2**32), device=device, dtype=torch.uint8)
+            x = torch.zeros((2, 2**32), device=device, dtype=torch.int8)
             x[:, -1] = 1
             self.assertEqual(x.argmax(1), [x.shape[1] - 1] * 2)
             x[:, -1] = -1
             self.assertEqual(x.argmin(1), [x.shape[1] - 1] * 2)
         except RuntimeError as e:
             if 'memory' in str(e):
-                raise unittest.SkipTest('Not enough cuda memory')
+                raise unittest.SkipTest('Insufficient memory')
             raise
 
     def test_remainder_overflow(self, device):


### PR DESCRIPTION
Fixes the `TensorIterator` parts of #32863 (THC is still broken)

`TensorIterator::split` now keeps track of the `view_offsets` into the full tensor range. With this, I can take the base offset for the reduced dimension and translate partial results from the sub-iter into the index range of the full tensor. This happens only once for each intermediate result, so we should still benefit from the performance of 32-bit indexing in loops.