### PR TITLE
[BC-Breaking] Rename at::Tensor::base() to _base()

### DIFF
--- a/aten/src/ATen/core/Tensor.cpp
+++ b/aten/src/ATen/core/Tensor.cpp
@@ -59,7 +59,7 @@ bool Tensor::is_view() const {
   return impl::GetVariableHooks()->is_view(*this);
 }
 
-const Tensor& Tensor::base() const {
+const Tensor& Tensor::_base() const {
   return impl::GetVariableHooks()->base(*this);
 }
 

--- a/aten/src/ATen/templates/TensorBody.h
+++ b/aten/src/ATen/templates/TensorBody.h
@@ -503,7 +503,7 @@ public:
 
   /// Returns the `Variable` that this `Variable` is a view of. If this
   /// `Variable` is not a view, throw a `std::runtime_error`.
-  const Tensor& base() const;
+  const Tensor& _base() const;
 
   // Miscellaneous
   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/aten/src/ATen/test/undefined_tensor_test.cpp
+++ b/aten/src/ATen/test/undefined_tensor_test.cpp
@@ -31,7 +31,7 @@ TEST(TestUndefined, UndefinedTest) {
   ASSERT_ANY_THROW(und.variable_data());
   ASSERT_ANY_THROW(und.tensor_data());
   ASSERT_ANY_THROW(und.is_view());
-  ASSERT_ANY_THROW(und.base());
+  ASSERT_ANY_THROW(und._base());
   ASSERT_ANY_THROW(und.name());
   ASSERT_ANY_THROW(und.grad_fn());
   ASSERT_ANY_THROW(und.remove_hook(0));

--- a/torch/csrc/autograd/VariableTypeUtils.h
+++ b/torch/csrc/autograd/VariableTypeUtils.h
@@ -111,7 +111,7 @@ template<typename... Args> inline variable_list flatten_tensor_args(Args&&... ar
 inline Tensor as_view(const Tensor & base, Tensor tensor, bool is_differentiable, bool allow_rebase_history=true) {
   auto base_var = Variable(base);
   if (base_var.is_view()) {
-    base_var = base_var.base();
+    base_var = base_var._base();
   }
   if (is_differentiable) {
     return make_variable_differentiable_view(std::move(base_var), std::move(tensor), allow_rebase_history);
@@ -126,7 +126,7 @@ inline std::vector<Tensor> as_view(const Tensor & base, std::vector<Tensor> tens
                                    bool allow_rebase_history=true) {
   auto base_var = Variable(base);
   if (base_var.is_view()) {
-    base_var = base_var.base();
+    base_var = base_var._base();
   }
   for(Tensor &tensor : tensors) {
     if (is_differentiable) {

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -426,7 +426,7 @@ PyObject *THPVariable_get_base(THPVariable *self, void *unused)
 {
   HANDLE_TH_ERRORS
   if (self->cdata.is_view()) {
-    return THPVariable_Wrap(self->cdata.base());
+    return THPVariable_Wrap(self->cdata._base());
   }
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS

--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -30,7 +30,7 @@ DifferentiableViewMeta::DifferentiableViewMeta(at::TensorImpl* self_impl, Variab
   base_ = std::move(base);
   TORCH_CHECK(base_.defined(), "base is undefined");
   if (base_.is_view()) {
-    base_ = base_.base();
+    base_ = base_._base();
   }
   is_view_ = true;
   self_impl->set_version_counter(impl::version_counter(base_));


### PR DESCRIPTION
This PR renames `at::Tensor::base()` to `at::Tensor::_base()`, to achieve parity with Python `torch.Tensor._base` API.

----

This PR is BC-breaking in the following way:

Previously, to get the tensor that this tensor is a view of, the user would call `tensor.base()` in C++. Now, they must call `tensor._base()`.