### PR TITLE
Optimize Unfold3dAcc to improve performance of conv3d backward

### DIFF
--- a/aten/src/ATen/native/ConvolutionMM3d.cpp
+++ b/aten/src/ATen/native/ConvolutionMM3d.cpp
@@ -232,12 +232,16 @@ void slow_conv3d_backward_update_grad_input_frame(
   auto grad_output_2d = grad_output.reshape(
       {grad_output.size(0),
        grad_output.size(1) * grad_output.size(2) * grad_output.size(3)});
-  fgrad_input.addmm_(weight, grad_output_2d, 0, 1);
-
-  grad_input.zero_();
-  unfolded3d_acc_kernel_cpu(
+  at::mm_out(fgrad_input, weight, grad_output_2d);
+  Unfold3dAccCPU(
       fgrad_input,
-      grad_input,
+      grad_input.size(0),
+      grad_input.size(1),
+      grad_input.size(2),
+      grad_input.size(3),
+      grad_output.size(1),
+      grad_output.size(2),
+      grad_output.size(3),
       kernel_depth,
       kernel_height,
       kernel_width,
@@ -247,13 +251,7 @@ void slow_conv3d_backward_update_grad_input_frame(
       pad_depth,
       pad_height,
       pad_width,
-      grad_input.size(0),
-      grad_input.size(1),
-      grad_input.size(2),
-      grad_input.size(3),
-      grad_output.size(1),
-      grad_output.size(2),
-      grad_output.size(3));
+      &grad_input);
 }
 
 void slow_conv3d_backward_out_cpu_template(

--- a/aten/src/ATen/native/Unfold3d.cpp
+++ b/aten/src/ATen/native/Unfold3d.cpp
@@ -41,6 +41,34 @@ void MatCopy(
   }
 }
 
+// Y += X
+template <typename T>
+void MatAdd(int64_t M, int64_t N, int64_t ldx, int64_t ldy, const T* X, T* Y) {
+  for (int64_t i = 0; i < M; ++i) {
+    for (int64_t j = 0; j < N; ++j) {
+      Y[i * ldy + j] += X[i * ldx + j];
+    }
+  }
+}
+
+// Y += X
+template <typename T>
+void MatAdd(
+    int64_t M,
+    int64_t N,
+    int64_t ldx,
+    int64_t stridex,
+    int64_t ldy,
+    int64_t stridey,
+    const T* X,
+    T* Y) {
+  for (int64_t i = 0; i < M; ++i) {
+    for (int64_t j = 0; j < N; ++j) {
+      Y[i * ldy + j * stridey] += X[i * ldx + j * stridex];
+    }
+  }
+}
+
 #if AT_MKL_ENABLED()
 
 template <>
@@ -89,6 +117,58 @@ void MatCopy<double>(
     const double* A,
     double* B) {
   mkl_domatcopy2('R', 'N', M, N, 1.0, A, lda, stridea, B, ldb, strideb);
+}
+
+template <>
+void MatAdd<float>(
+    int64_t M,
+    int64_t N,
+    int64_t ldx,
+    int64_t ldy,
+    const float* X,
+    float* Y) {
+  mkl_somatadd('R', 'N', 'N', M, N, 1.0f, X, ldx, 1.0f, Y, ldy, Y, ldy);
+}
+
+template <>
+void MatAdd<double>(
+    int64_t M,
+    int64_t N,
+    int64_t ldx,
+    int64_t ldy,
+    const double* X,
+    double* Y) {
+  mkl_domatadd('R', 'N', 'N', M, N, 1.0, X, ldx, 1.0, Y, ldy, Y, ldy);
+}
+
+template <>
+void MatAdd(
+    int64_t M,
+    int64_t N,
+    int64_t ldx,
+    int64_t stridex,
+    int64_t ldy,
+    int64_t stridey,
+    const float* X,
+    float* Y) {
+  for (int64_t i = 0; i < M; ++i) {
+    cblas_saxpy(N, 1.0f, X + i * ldx, stridex, Y + i * ldy, stridey);
+  }
+}
+
+template <>
+void MatAdd(
+    int64_t M,
+    int64_t N,
+    int64_t ldx,
+    int64_t stridex,
+    int64_t ldy,
+    int64_t stridey,
+    const double* X,
+    double* Y) {
+  for (int64_t i = 0; i < M; ++i) {
+    cblas_daxpy(N, 1.0, X + i * ldx, stridex, Y + i * ldy, stridey);
+  }
 }
 
 #endif // AT_MKL_ENABLED()
@@ -216,105 +296,132 @@ void Unfold3dCopyKernelImpl(
   });
 }
 
-// Kernel for fast unfold+copy
-// Borrowed from Theano
-// Authors: Arjun Jain, Frederic Bastien, Jan Schluter, Nicolas Ballas
-template <typename scalar_t>
-static void unfolded3d_acc(
-    scalar_t* finput_data,
-    scalar_t* input_data,
-    int kT,
-    int kH,
-    int kW,
-    int dT,
-    int dH,
-    int dW,
-    int pT,
-    int pH,
-    int pW,
-    int64_t n_input_plane,
-    int64_t input_depth,
-    int64_t input_height,
-    int64_t input_width,
-    int64_t output_depth,
-    int64_t output_height,
-    int64_t output_width) {
-  int64_t n = n_input_plane * input_height * input_width * input_depth;
-  at::parallel_for(0, n, 0, [&](int64_t start, int64_t end) {
-    int64_t line_index_offset = start;
-    int64_t line_seg_len = (end - start);
-
-    int64_t w = line_index_offset % input_width + pW;
-    int64_t h_index = line_index_offset / input_width;
-    int64_t h = h_index % input_height + pH;
-    int64_t d_index = h_index / input_height;
-    int64_t d = d_index % input_depth + pT;
-    int64_t c = d_index / input_depth;
-
-    int64_t outputHW = output_height * output_width;
-    int64_t outputDHW = output_depth * outputHW;
-    int64_t kHkW = kH * kW;
-    int64_t kTkHkW = kT * kHkW;
-
-    int64_t coeff_d_col = outputHW - dT * kHkW * outputDHW;
-    int64_t coeff_h_col = output_width - dH * kW * outputDHW;
-    int64_t coeff_w_col = (1 - dW * outputDHW);
-
-    int64_t count = 0;
-    while (count < line_seg_len) {
-      // compute the start and end of the output
-      int64_t w_col_start = (w < kW) ? 0 : (w - kW) / dW + 1;
-      int64_t w_col_tmp = w / dW + 1;
-      int64_t w_col_end = w_col_tmp < output_width ? w_col_tmp : output_width;
-
-      int64_t h_col_start = (h < kH) ? 0 : (h - kH) / dH + 1;
-      int64_t h_col_tmp = h / dH + 1;
-      int64_t h_col_end = h_col_tmp < output_height ? h_col_tmp : output_height;
-
-      int64_t d_col_start = (d < kT) ? 0 : (d - kT) / dT + 1;
-      int64_t d_col_tmp = d / dT + 1;
-      int64_t d_col_end = d_col_tmp < output_depth ? d_col_tmp : output_depth;
-
-      scalar_t val = 0;
-      int64_t offset = (c * kTkHkW + d * kHkW + h * kW + w) * outputDHW;
-
-      int64_t offset_w_col_start = w_col_start * coeff_w_col;
-      int64_t offset_d_col_start = d_col_start * coeff_d_col;
-      int64_t offset_h_col_start = h_col_start * coeff_h_col;
-      int64_t offset_w_col = offset_w_col_start + offset;
-      int64_t offset_d_col;
-      int64_t offset_h_col;
-      int64_t w_col, d_col, h_col;
-      for (w_col = w_col_start; w_col < w_col_end; ++w_col) {
-        offset_d_col = offset_d_col_start + offset_w_col;
-        for (d_col = d_col_start; d_col < d_col_end; ++d_col) {
-          offset_h_col = offset_h_col_start + offset_d_col;
-          for (h_col = h_col_start; h_col < h_col_end; ++h_col) {
-            val += finput_data[offset_h_col];
-            offset_h_col += coeff_h_col;
+template <typename T>
+void Unfold3dZeroPaddingAccKernelImpl(
+    int64_t C,
+    int64_t X_D,
+    int64_t X_H,
+    int64_t X_W,
+    int64_t Y_D,
+    int64_t Y_H,
+    int64_t Y_W,
+    int64_t kernel_d,
+    int64_t kernel_h,
+    int64_t kernel_w,
+    int64_t stride_d,
+    int64_t stride_h,
+    int64_t stride_w,
+    const T* src,
+    T* dst) {
+  const int64_t X_size = X_D * X_H * X_W;
+  const int64_t Y_size = Y_D * Y_H * Y_W;
+  const int64_t kernel_size = kernel_d * kernel_h * kernel_w;
+  at::parallel_for(0, C, 0, [=](int64_t begin, int64_t end) {
+    std::memset(dst + begin * X_size, 0, (end - begin) * X_size * sizeof(T));
+    for (int64_t c = begin; c < end; ++c) {
+      for (int64_t kd = 0; kd < kernel_d; ++kd) {
+        for (int64_t kh = 0; kh < kernel_h; ++kh) {
+          for (int64_t kw = 0; kw < kernel_w; ++kw) {
+            const int64_t p =
+                c * kernel_size + kd * kernel_h * kernel_w + kh * kernel_w + kw;
+            for (int64_t yd = 0; yd < Y_D; ++yd) {
+              const int64_t xd = yd * stride_d + kd;
+              const T* src_ptr = src + p * Y_size + yd * Y_H * Y_W;
+              T* dst_ptr = dst + c * X_size + xd * X_H * X_W + kh * X_W + kw;
+              if (stride_w == 1) {
+                MatAdd<T>(Y_H, Y_W, Y_W, stride_h * X_W, src_ptr, dst_ptr);
+              } else {
+                MatAdd<T>(
+                    Y_H,
+                    Y_W,
+                    Y_W,
+                    1,
+                    stride_h * X_W,
+                    stride_w,
+                    src_ptr,
+                    dst_ptr);
+              }
+            }
           }
-          offset_d_col += coeff_d_col;
         }
-        offset_w_col += coeff_w_col;
       }
+    }
+  });
+}
 
-      input_data[line_index_offset + count] = val;
-      count++;
-
-      if (count < line_seg_len) {
-        if (w - pW + 1 == input_width) {
-          w = pW;
-          if (h - pH + 1 == input_height) {
-            h = pH;
-            if (d - pT + 1 == input_depth) {
-              d = pT;
-              c++;
-            } else
-              d++;
-          } else
-            h++;
-        } else
-          w++;
+template <typename T>
+void Unfold3dAccKernelImpl(
+    int64_t C,
+    int64_t X_D,
+    int64_t X_H,
+    int64_t X_W,
+    int64_t Y_D,
+    int64_t Y_H,
+    int64_t Y_W,
+    int64_t kernel_d,
+    int64_t kernel_h,
+    int64_t kernel_w,
+    int64_t stride_d,
+    int64_t stride_h,
+    int64_t stride_w,
+    int64_t pad_d,
+    int64_t pad_h,
+    int64_t pad_w,
+    const T* src,
+    T* dst) {
+  if (pad_d == 0 && pad_h == 0 && pad_w == 0) {
+    Unfold3dZeroPaddingAccKernelImpl<T>(
+        C,
+        X_D,
+        X_H,
+        X_W,
+        Y_D,
+        Y_H,
+        Y_W,
+        kernel_d,
+        kernel_h,
+        kernel_w,
+        stride_d,
+        stride_h,
+        stride_w,
+        src,
+        dst);
+    return;
+  }
+  const int64_t X_size = X_D * X_H * X_W;
+  const int64_t Y_size = Y_D * Y_H * Y_W;
+  const int64_t kernel_size = kernel_d * kernel_h * kernel_w;
+  at::parallel_for(0, C, 0, [=](int64_t begin, int64_t end) {
+    std::memset(dst + begin * X_size, 0, (end - begin) * X_size * sizeof(T));
+    for (int64_t c = begin; c < end; ++c) {
+      T* dst_ptr = dst + c * X_size;
+      for (int64_t kd = 0; kd < kernel_d; ++kd) {
+        for (int64_t kh = 0; kh < kernel_h; ++kh) {
+          for (int64_t kw = 0; kw < kernel_w; ++kw) {
+            const int64_t p =
+                c * kernel_size + kd * kernel_h * kernel_w + kh * kernel_w + kw;
+            const T* src_ptr = src + p * Y_size;
+            for (int64_t yd = 0; yd < Y_D; ++yd) {
+              const int64_t xd = yd * stride_d - pad_d + kd;
+              if (!IsAGeZeroAndALtB(xd, X_D)) {
+                continue;
+              }
+              for (int64_t yh = 0; yh < Y_H; ++yh) {
+                const int64_t xh = yh * stride_h - pad_h + kh;
+                if (!IsAGeZeroAndALtB(xh, X_H)) {
+                  continue;
+                }
+                for (int64_t yw = 0; yw < Y_W; ++yw) {
+                  const int64_t xw = yw * stride_w - pad_w + kw;
+                  if (IsAGeZeroAndALtB(xw, X_W)) {
+                    dst_ptr[xd * X_H * X_W + xh * X_W + xw] +=
+                        src_ptr[yd * Y_H * Y_W + yh * Y_W + yw];
+                  }
+                }
+              }
+            }
+          }
+        }
       }
     }
   });
@@ -368,48 +475,49 @@ void Unfold3dCopyCPU(
       });
 }
 
-void unfolded3d_acc_kernel_cpu(
-    Tensor& finput,
-    Tensor& input,
-    int kT,
-    int kH,
-    int kW,
-    int dT,
-    int dH,
-    int dW,
-    int pT,
-    int pH,
-    int pW,
-    int64_t n_input_plane,
-    int64_t input_depth,
-    int64_t input_height,
-    int64_t input_width,
-    int64_t output_depth,
-    int64_t output_height,
-    int64_t output_width) {
+void Unfold3dAccCPU(
+    const Tensor& src,
+    int64_t C,
+    int64_t X_D,
+    int64_t X_H,
+    int64_t X_W,
+    int64_t Y_D,
+    int64_t Y_H,
+    int64_t Y_W,
+    int64_t kernel_d,
+    int64_t kernel_h,
+    int64_t kernel_w,
+    int64_t stride_d,
+    int64_t stride_h,
+    int64_t stride_w,
+    int64_t pad_d,
+    int64_t pad_h,
+    int64_t pad_w,
+    Tensor* dst) {
   AT_DISPATCH_ALL_TYPES_AND(
-      at::ScalarType::BFloat16, input.scalar_type(), "unfolded3d_acc_cpu", [&] {
-        scalar_t* input_data = input.data_ptr<scalar_t>();
-        scalar_t* finput_data = finput.data_ptr<scalar_t>();
-        unfolded3d_acc(
-            finput_data,
-            input_data,
-            kT,
-            kH,
-            kW,
-            dT,
-            dH,
-            dW,
-            pT,
-            pH,
-            pW,
-            n_input_plane,
-            input_depth,
-            input_height,
-            input_width,
-            output_depth,
-            output_height,
-            output_width);
+      at::ScalarType::BFloat16,
+      src.scalar_type(),
+      "Unfold3dAccCPU",
+      [=, &src]() {
+        Unfold3dAccKernelImpl<scalar_t>(
+            C,
+            X_D,
+            X_H,
+            X_W,
+            Y_D,
+            Y_H,
+            Y_W,
+            kernel_d,
+            kernel_h,
+            kernel_w,
+            stride_d,
+            stride_h,
+            stride_w,
+            pad_d,
+            pad_h,
+            pad_w,
+            src.data_ptr<scalar_t>(),
+            dst->data_ptr<scalar_t>());
       });
 }
 

--- a/aten/src/ATen/native/Unfold3d.h
+++ b/aten/src/ATen/native/Unfold3d.h
@@ -25,25 +25,25 @@ void Unfold3dCopyCPU(
     int64_t pad_w,
     Tensor* dst);
 
-void unfolded3d_acc_kernel_cpu(
-    Tensor& finput,
-    Tensor& input,
-    int kT,
-    int kH,
-    int kW,
-    int dT,
-    int dH,
-    int dW,
-    int pT,
-    int pH,
-    int pW,
-    int64_t n_input_plane,
-    int64_t input_depth,
-    int64_t input_height,
-    int64_t input_width,
-    int64_t output_depth,
-    int64_t output_height,
-    int64_t output_width);
+void Unfold3dAccCPU(
+    const Tensor& src,
+    int64_t C,
+    int64_t X_D,
+    int64_t X_H,
+    int64_t X_W,
+    int64_t Y_D,
+    int64_t Y_H,
+    int64_t Y_W,
+    int64_t kernel_d,
+    int64_t kernel_h,
+    int64_t kernel_w,
+    int64_t stride_d,
+    int64_t stride_h,
+    int64_t stride_w,
+    int64_t pad_d,
+    int64_t pad_h,
+    int64_t pad_w,
+    Tensor* dst);
 
 } // namespace native
 } // namespace at


### PR DESCRIPTION
Summary: Optimize Unfold3dAcc to improve performance of conv3d backward

Test Plan: buck test mode/dev-nosan //caffe2/test:nn -- "Conv3d"

Differential Revision: D19892678

This PR improves backward of Conv3d with input size = [1, 3, 4, 112, 112], kernel_size = [3, 7, 7], stride = [1, 2, 2], padding = [1, 3, 3] from 44ms to 28ms.
