### PR TITLE
.cirlceci: Swap PYTORCH_BUILD_VERSION if on tag

### DIFF
--- a/.circleci/scripts/binary_populate_env.sh
+++ b/.circleci/scripts/binary_populate_env.sh
@@ -55,10 +55,19 @@ fi
 
 # We put this here so that OVERRIDE_PACKAGE_VERSION below can read from it
 export DATE="$(date -u +%Y%m%d)"
+#TODO: We should be pulling semver version from the base version.txt
+BASE_BUILD_VERSION="1.5.0.dev$DATE"
+# Change BASE_BUILD_VERSION to git tag when on a git tag
+if git describe --tags --exact >/dev/null 2>/dev/null; then
+  # Grab git tag, remove prefixed v and remove everything after -
+  # Used to clean up tags that are for release candidates like v1.5.0-rc1
+  # Turns tag v1.5.0-rc1 -> v1.5.0
+  BASE_BUILD_VERSION="$(git describe --tags | sed -e 's/^v//' -e 's/-.*$//')"
+fi
 if [[ "$(uname)" == 'Darwin' ]] || [[ "$DESIRED_CUDA" == "cu101" ]] || [[ "$PACKAGE_TYPE" == conda ]]; then
-  export PYTORCH_BUILD_VERSION="1.5.0.dev$DATE"
+  export PYTORCH_BUILD_VERSION="${BASE_BUILD_VERSION}"
 else
-  export PYTORCH_BUILD_VERSION="1.5.0.dev$DATE+$DESIRED_CUDA"
+  export PYTORCH_BUILD_VERSION="${BASE_BUILD_VERSION}+$DESIRED_CUDA"
 fi
 export PYTORCH_BUILD_NUMBER=1
 


### PR DESCRIPTION
Basically just fills out PYTORCH_BUILD_VERSION to the correct version
baesd on the git tag.

This makes it so that we don't have to continually edit this file
when doing releases.

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

