### PR TITLE
port masked_fill from TH to ATen

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -20,12 +20,12 @@
 ]]
 [[
   name: _th_masked_fill_
-  cpu_bool: True
   cuda_bool: True
-  cpu_bfloat16: True
   cuda_bfloat16: True
   cname: maskedFill
   variants: function
+  backends:
+    - CUDA
   return: self
   options:
     - arguments:
@@ -35,12 +35,12 @@
 ]]
 [[
   name: _th_masked_fill_bool_
-  cpu_bool: True
   cuda_bool: True
-  cpu_bfloat16: True
   cuda_bfloat16: True
   cname: maskedFillBool
   variants: function
+  backends:
+    - CUDA
   return: self
   options:
     - arguments:

--- a/aten/src/ATen/native/LegacyDefinitions.cpp
+++ b/aten/src/ATen/native/LegacyDefinitions.cpp
@@ -8,43 +8,6 @@ namespace at { namespace native {
 
 // Methods
 
-Tensor & masked_fill__cpu(Tensor& self, const Tensor & mask, Scalar value) {
-  auto maybe_outnames = namedinference::broadcast_to_outnames(self, mask, "masked_fill_");
-  Tensor b_mask;
-  std::tie(b_mask) = expand_inplace(self, mask, "masked_fill_");
-  // As we dispatch on self and TH is type-checked, we need different definitions.
-  // This can be fixed by moving to ATen.
-  if (b_mask.dtype() == at::ScalarType::Byte) {
-    AT_WARN("masked_fill_ received a mask with dtype torch.uint8, this behavior is now deprecated," \
-            "please use a mask with dtype torch.bool instead.");
-    legacy::cpu::_th_masked_fill_(self, b_mask, value);
-  } else {
-    legacy::cpu::_th_masked_fill_bool_(self, b_mask, value);
-  }
-  namedinference::propagate_names_if_nonempty(self, maybe_outnames);
-  return self;
-}
-
-Tensor & masked_fill__cpu(Tensor& self, const Tensor & mask, const Tensor & value) {
-  auto maybe_outnames = namedinference::broadcast_to_outnames(self, mask, "masked_fill_");
-
-  TORCH_CHECK(value.dim() == 0, "masked_fill_ only supports a 0-dimensional value tensor, but got tensor "
-      "with ", value.dim(), " dimension(s).");
-  Tensor b_mask;
-  std::tie(b_mask) = expand_inplace(self, mask, "masked_fill_");
-  // As we dispatch on self and TH is type-checked, we need different definitions.
-  // This can be fixed by moving to ATen.
-  if (b_mask.dtype() == at::ScalarType::Byte) {
-    AT_WARN("masked_fill_ received a mask with dtype torch.uint8, this behavior is now deprecated," \
-            "please use a mask with dtype torch.bool instead.");
-    legacy::cpu::_th_masked_fill_(self, b_mask, value.item());
-  } else {
-    legacy::cpu::_th_masked_fill_bool_(self, b_mask, value.item());
-  }
-  namedinference::propagate_names_if_nonempty(self, maybe_outnames);
-  return self;
-}
-
 Tensor & masked_scatter__cpu(Tensor& self, const Tensor & mask, const Tensor & source) {
   Tensor b_mask;
   std::tie(b_mask) = expand_inplace(self, mask, "masked_scatter_");

--- a/aten/src/ATen/native/TensorAdvancedIndexing.h
+++ b/aten/src/ATen/native/TensorAdvancedIndexing.h
@@ -14,6 +14,7 @@ namespace at { namespace native {
 using index_fn = void(*)(TensorIterator &, IntArrayRef indexed_sizes, IntArrayRef indexed_strides);
 using index_put_fn = void(*)(TensorIterator &, IntArrayRef indexed_sizes, IntArrayRef indexed_strides, bool accumulate);
 using index_put_accum_fn = void(*)(Tensor &, TensorList , const Tensor &, bool unsafe);
+using masked_fill_fn = void(*)(TensorIterator &, Scalar scalar);
 
 using gather_fn = void (*)(Tensor & result, const Tensor & self, int64_t dim, const Tensor & index);
 using scatter_fn = void(*)(Tensor& self, int64_t dim, const Tensor& index, const Tensor& src);
@@ -23,6 +24,7 @@ using scatter_add_fn = void(*)(Tensor& self, int64_t dim, const Tensor& index, c
 DECLARE_DISPATCH(index_fn, index_stub);
 DECLARE_DISPATCH(index_put_fn, index_put_stub);
 DECLARE_DISPATCH(index_put_accum_fn, index_put_accum_stub);
+DECLARE_DISPATCH(masked_fill_fn, masked_fill_stub);
 
 DECLARE_DISPATCH(gather_fn, gather_stub);
 DECLARE_DISPATCH(scatter_fn, scatter_stub);

--- a/aten/src/ATen/native/cpu/IndexKernel.cpp
+++ b/aten/src/ATen/native/cpu/IndexKernel.cpp
@@ -119,10 +119,43 @@ void index_put_kernel(TensorIterator& iter, IntArrayRef index_size, IntArrayRef 
   });
 }
 
+template <typename scalar_t, typename mask_t>
+void cpu_masked_fill_kernel(TensorIterator& iter, scalar_t value) {
+  auto is_mask_bool = std::is_same<mask_t, bool>::value;
+  auto loop = [&](char** data, const int64_t* strides, int64_t n) {
+    char* dst = data[0];
+    char* mask = data[1];
+    for (int64_t i = 0; i < n; i++) {
+      mask_t mask_value = *(mask_t*)(mask + strides[1] * i);
+      if (!is_mask_bool) {
+        TORCH_CHECK(mask_value == 0 || mask_value == 1, "Mask tensor can take 0 and 1 values only");
+      }
+      if (mask_value) {
+        *(scalar_t*)(dst + strides[0] * i) = value;
+      }
+    }
+  };
+  iter.for_each(loop);
+}
+
+void masked_fill_kernel(TensorIterator& iter, Scalar value) {
+  AT_DISPATCH_ALL_TYPES_AND2(at::ScalarType::Bool, at::ScalarType::BFloat16,
+    iter.dtype(), "masked_fill", [&] {
+      scalar_t scalar_val = value.to<scalar_t>();
+      auto mask_dtype = iter.input_dtype(0);
+      if (mask_dtype == at::ScalarType::Bool) {
+        cpu_masked_fill_kernel<scalar_t, bool>(iter, scalar_val);
+      } else {
+        cpu_masked_fill_kernel<scalar_t, unsigned char>(iter, scalar_val);
+      }
+    });
+}
+
 } // anonymous namespace
 
 
 REGISTER_DISPATCH(index_stub, &index_kernel);
 REGISTER_DISPATCH(index_put_stub, &index_put_kernel);
+REGISTER_DISPATCH(masked_fill_stub, &masked_fill_kernel);
 
 }} // namespace at::native

--- a/aten/src/TH/generic/THTensorEvenMoreMath.cpp
+++ b/aten/src/TH/generic/THTensorEvenMoreMath.cpp
@@ -119,54 +119,6 @@ void THTensor_(maskedSelectBool)(THTensor *tensor, THTensor *src, THBoolTensor *
                    });
 }
 
-void THTensor_(maskedFill)(THTensor *tensor, THByteTensor *mask, scalar_t value)
-{
-  at::NoNamesGuard guard;
-  int64_t tensor_size = THTensor_(nElement)(tensor);
-  int tensor_contig = THTensor_(isContiguous)(tensor);
-  int mask_contig = THTensor_(isContiguous)(mask);
-  if (tensor_contig && mask_contig) {
-    TH_TENSOR_APPLY2_PARALLEL(tensor_size, tensor_contig, mask_contig,
-      scalar_t, tensor, unsigned char, mask,
-      if (*mask_data > 1) {
-        THError("Mask tensor can take 0 and 1 values only");
-      } else if (*mask_data == 1) {
-        *tensor_data = value;
-      },
-      TH_OMP_OVERHEAD_THRESHOLD);
-  } else {
-    TH_TENSOR_APPLY2(scalar_t, tensor, unsigned char, mask,
-      if (*mask_data > 1) {
-        THFree(mask_counter);
-        THFree(tensor_counter);
-        THError("Mask tensor can take 0 and 1 values only");
-      } else if (*mask_data == 1) {
-        *tensor_data = value;
-      });
-    }
-}
-
-void THTensor_(maskedFillBool)(THTensor *tensor, THBoolTensor *mask, scalar_t value)
-{
-  at::NoNamesGuard guard;
-  int64_t tensor_size = THTensor_(nElement)(tensor);
-  int tensor_contig = THTensor_(isContiguous)(tensor);
-  int mask_contig = THTensor_(isContiguous)(mask);
-  if (tensor_contig && mask_contig) {
-    TH_TENSOR_APPLY2_PARALLEL(tensor_size, tensor_contig, mask_contig,
-      scalar_t, tensor, bool, mask,
-      if (*mask_data) {
-        *tensor_data = value;
-      },
-      TH_OMP_OVERHEAD_THRESHOLD);
-  } else {
-    TH_TENSOR_APPLY2(scalar_t, tensor, bool, mask,
-      if (*mask_data) {
-        *tensor_data = value;
-      });
-    }
-}
-
 void THTensor_(maskedCopy)(THTensor *tensor, THByteTensor *mask, THTensor* src )
 {
   THTensor *srct = THTensor_(newContiguous)(src);

--- a/aten/src/TH/generic/THTensorMath.h
+++ b/aten/src/TH/generic/THTensorMath.h
@@ -54,8 +54,6 @@ TH_API void THTensor_(eqTensorByte)(THByteTensor *r_, THTensor *ta, THTensor *tb
 
 TH_API void THTensor_(maskedSelect)(THTensor *tensor, THTensor* src, THByteTensor *mask);
 TH_API void THTensor_(maskedSelectBool)(THTensor *tensor, THTensor* src, THBoolTensor *mask);
-TH_API void THTensor_(maskedFill)(THTensor *tensor, THByteTensor *mask, scalar_t value);
-TH_API void THTensor_(maskedFillBool)(THTensor *tensor, THBoolTensor *mask, scalar_t value);
 TH_API void THTensor_(maskedCopy)(THTensor *tensor, THByteTensor *mask, THTensor* src);
 TH_API void THTensor_(maskedCopyBool)(THTensor *tensor, THBoolTensor *mask, THTensor* src);
 


### PR DESCRIPTION
port `masked_fill` from TH to ATen with TensorIterator.

single core performance roughly stays the same, single socket performance has **3~16x** boost.

`masked_fill` is missing from https://github.com/pytorch/pytorch/issues/24507