### PR TITLE
run peephole to do profile-based optimizations

### DIFF
--- a/torch/csrc/jit/profiling_graph_executor_impl.cpp
+++ b/torch/csrc/jit/profiling_graph_executor_impl.cpp
@@ -84,6 +84,7 @@ void ProfilingGraphExecutorImpl::runProfilingOptimizations(
   specializeAutogradZero(*copy);
 
   runRequiredPasses(copy);
+  PeepholeOptimize(copy);
   ConstantPropagation(copy);
   runOptimization(copy);
 


### PR DESCRIPTION
We need to run a peephole before constant propagation in the profiling pipeline, so we fold `prim::shape` for inputs with complete tensor types.
