### PR TITLE
Add the 3d avg pool for video related model

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -5825,6 +5825,7 @@
   dispatch:
     CPU: avg_pool3d_cpu
     CUDA: avg_pool3d_cuda
+    QuantizedCPU: quantized_avg_pool3d
 
 - func: avg_pool3d_backward.grad_input(Tensor grad_output, Tensor self, int[3] kernel_size, int[3] stride, int[3] padding, bool ceil_mode, bool count_include_pad, int? divisor_override, *, Tensor(a!) grad_input) -> Tensor(a!)
   python_module: nn

--- a/aten/src/ATen/native/quantized/cpu/q_avgpool3d.cpp
+++ b/aten/src/ATen/native/quantized/cpu/q_avgpool3d.cpp
@@ -70,9 +70,9 @@ static void avg_pool3d_out_frame(
             int64_t hend = std::min(hstart + kH, inputHeight + padH);
             int64_t wend = std::min(wstart + kW, inputWidth + padW);
             int64_t pool_size = (dend - dstart) * (hend - hstart) * (wend - wstart);
-            dstart = std::max(dstart, 0L);
-            hstart = std::max(hstart, 0L);
-            wstart = std::max(wstart, 0L);
+            dstart = std::max(dstart, static_cast<int64_t>(0));
+            hstart = std::max(hstart, static_cast<int64_t>(0));
+            wstart = std::max(wstart, static_cast<int64_t>(0));
             dend = std::min(dend, inputDepth);
             hend = std::min(hend, inputHeight);
             wend = std::min(wend, inputWidth);

--- a/aten/src/ATen/native/quantized/cpu/q_avgpool3d.cpp
+++ b/aten/src/ATen/native/quantized/cpu/q_avgpool3d.cpp
@@ -1,0 +1,365 @@
+#include <ATen/ATen.h>
+#include <ATen/NativeFunctions.h>
+#include <ATen/Parallel.h>
+#include <ATen/native/Pool.h>
+#include <ATen/native/quantized/cpu/init_qnnpack.h>
+#include <ATen/native/quantized/cpu/qnnpack_utils.h>
+#include <ATen/native/quantized/cpu/quantized_ops.h>
+#include <caffe2/utils/threadpool/ThreadPoolMobile.h>
+#include <c10/util/math_compat.h>
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <vector>
+
+namespace at {
+namespace native {
+
+DEFINE_DISPATCH(qavg_pool3d_nhwc_stub);
+
+namespace {
+
+template <typename scalar_t>
+static void avg_pool3d_out_frame(
+    const Tensor& input,
+    Tensor& output,
+    int64_t b,
+    int64_t nInputPlane,
+    int64_t inputWidth,
+    int64_t inputHeight,
+    int64_t inputDepth,
+    int64_t outputWidth,
+    int64_t outputHeight,
+    int64_t outputDepth,
+    int kW,
+    int kH,
+    int kD,
+    int dW,
+    int dH,
+    int dD,
+    int padW,
+    int padH,
+    int padD,
+    bool count_include_pad,
+    c10::optional<int64_t> divisor_override) {
+  at::parallel_for(0, nInputPlane, 0, [&](int64_t start, int64_t end) {
+    for (auto k = start; k < end; k++) {
+      int64_t xx, yy, zz;
+      /* For all output pixels... */
+      auto input_data = input.contiguous().data_ptr<scalar_t>();
+      auto output_data = output.data_ptr<scalar_t>();
+      scalar_t* ptr_output = output_data +
+          b * nInputPlane * outputWidth * outputHeight * outputDepth +
+          k * outputWidth * outputHeight * outputDepth;
+      const scalar_t* ptr_input = input_data +
+          b * nInputPlane * inputWidth * inputHeight * inputDepth +
+          k * inputWidth * inputHeight * inputDepth;
+      auto minimum =
+          std::numeric_limits<typename scalar_t::underlying>::lowest();
+      auto maximum = std::numeric_limits<typename scalar_t::underlying>::max();
+
+      for (zz = 0; zz < outputDepth; zz++) {
+        for (yy = 0; yy < outputHeight; yy++) {
+          for (xx = 0; xx < outputWidth; xx++) {
+            /* Compute the mean of the input image... */
+            int64_t dstart = zz * dD - padD;
+            int64_t hstart = yy * dH - padH;
+            int64_t wstart = xx * dW - padW;
+            int64_t dend = std::min(dstart + kD, inputDepth + padD);
+            int64_t hend = std::min(hstart + kH, inputHeight + padH);
+            int64_t wend = std::min(wstart + kW, inputWidth + padW);
+            int64_t pool_size = (dend - dstart) * (hend - hstart) * (wend - wstart);
+            dstart = std::max(dstart, (int64_t)0);
+            hstart = std::max(hstart, (int64_t)0);
+            wstart = std::max(wstart, (int64_t)0);
+            dend = std::min(dend, inputDepth);
+            hend = std::min(hend, inputHeight);
+            wend = std::min(wend, inputWidth);
+
+            int sum_int = 0;
+            ptr_output->val_ = 0;
+
+            int64_t divide_factor;
+            int64_t size = (dend - dstart) * (hend - hstart) * (wend - wstart);
+            if (divisor_override.has_value()) {
+              divide_factor = divisor_override.value();
+            } else {
+              if (count_include_pad) {
+                divide_factor = pool_size;
+              } else {
+                divide_factor = (dend - dstart) * (hend - hstart) * (wend - wstart);
+              }
+            }
+
+            int64_t kx, ky, kz;
+            for (kz = dstart; kz < dend; kz++) {
+              for (ky = hstart; ky < hend; ky++) {
+                for (kx = wstart; kx < wend; kx++)
+                  sum_int += (ptr_input + kz * inputHeight * inputWidth + ky * inputWidth + kx)->val_;
+              }
+            }
+            float multiplier = input.q_scale() / output.q_scale() / divide_factor;
+
+            sum_int -= size * input.q_zero_point();
+            float sum = sum_int * 1.0;
+            /* Update output by requantizing the result */
+            ptr_output->val_ =
+                static_cast<typename scalar_t::underlying>(std::min<int32_t>(
+                    std::max<int32_t>(
+                        std::nearbyint(sum * multiplier + output.q_zero_point()),
+                        minimum),
+                    maximum));
+            ptr_output++;
+          }
+        }
+      }
+    }
+  });
+}
+
+inline std::tuple<int, int, int> get_kernel(IntArrayRef kernel_size) {
+  TORCH_CHECK(
+      kernel_size.size() == 1 || kernel_size.size() == 3,
+      "avg_pool3d: kernel_size must either be a single int, or a tuple of three ints");
+  const int kD = safe_downcast<int, int64_t>(kernel_size[0]);
+  const int kH = kernel_size.size() == 1
+      ? kD
+      : safe_downcast<int, int64_t>(kernel_size[1]);
+  const int kW = kernel_size.size() == 1
+      ? kD
+      : safe_downcast<int, int64_t>(kernel_size[2]);
+  return std::make_tuple(kW, kH, kD);
+}
+
+inline std::tuple<int, int, int> get_stride(IntArrayRef stride, int kW, int kH, int kD) {
+  TORCH_CHECK(
+      stride.empty() || stride.size() == 1 || stride.size() == 3,
+      "avg_pool3d: stride must either be omitted, a single int, or a tuple of three ints");
+  const int dD = stride.empty() ? kD : safe_downcast<int, int64_t>(stride[0]);
+  const int dH = stride.empty()
+      ? kH
+      : stride.size() == 1 ? dD : safe_downcast<int, int64_t>(stride[1]);
+  const int dW = stride.empty()
+      ? kW
+      : stride.size() == 1 ? dD : safe_downcast<int, int64_t>(stride[2]);
+  return std::make_tuple(dW, dH, dD);
+}
+
+inline std::tuple<int, int, int> get_padding(IntArrayRef padding) {
+  TORCH_CHECK(
+      padding.size() == 1 || padding.size() == 3,
+      "avg_pool3d: padding must either be a single int, or a tuple of three ints");
+  const int padD = safe_downcast<int, int64_t>(padding[0]);
+  const int padH =
+      padding.size() == 1 ? padD : safe_downcast<int, int64_t>(padding[1]);
+  const int padW =
+      padding.size() == 1 ? padD : safe_downcast<int, int64_t>(padding[2]);
+  return std::make_tuple(padW, padH, padD);
+}
+
+std::vector<int64_t> get_output_shape(
+    const Tensor& input_,
+    int kW,
+    int kH,
+    int kD,
+    int dW,
+    int dH,
+    int dD,
+    int padW,
+    int padH,
+    int padD,
+    bool ceil_mode) {
+  const int64_t nbatch = input_.ndimension() == 5 ? input_.size(-5) : 1;
+  const int64_t nInputPlane = input_.size(-4);
+  const int64_t inputDepth = input_.size(-3);
+  const int64_t inputHeight = input_.size(-2);
+  const int64_t inputWidth = input_.size(-1);
+  const int64_t outputDepth =
+      pooling_output_shape<int64_t>(inputDepth, kD, padD, dD, 1, ceil_mode);
+  const int64_t outputHeight =
+      pooling_output_shape<int64_t>(inputHeight, kH, padH, dH, 1, ceil_mode);
+  const int64_t outputWidth =
+      pooling_output_shape<int64_t>(inputWidth, kW, padW, dW, 1, ceil_mode);
+  if (input_.ndimension() == 4) {
+    return {nInputPlane, outputDepth, outputHeight, outputWidth};
+  }
+  return {nbatch, nInputPlane, outputDepth, outputHeight, outputWidth};
+}
+
+template <typename scalar_t>
+Tensor q_avg_pool3d(
+    const Tensor& input,
+    IntArrayRef kernel_size,
+    IntArrayRef stride,
+    IntArrayRef padding,
+    bool ceil_mode,
+    bool count_include_pad,
+    c10::optional<int64_t> divisor_override) {
+  int kD, kW, kH, dD, dW, dH, padD, padW, padH;
+  std::tie(kW, kH, kD) = get_kernel(kernel_size);
+  std::tie(dW, dH, dD) = get_stride(stride, kW, kH, kD);
+  std::tie(padW, padH, padD) = get_padding(padding);
+
+  const int64_t nbatch = input.ndimension() == 5 ? input.size(-5) : 1;
+  const int64_t nInputPlane = input.size(-4);
+  const int64_t inputDepth = input.size(-3);
+  const int64_t inputHeight = input.size(-2);
+  const int64_t inputWidth = input.size(-1);
+
+  TORCH_CHECK(
+      !divisor_override.has_value() || divisor_override.value() != 0,
+      "divisor must be not zero");
+
+  auto output_shape =
+      get_output_shape(input, kW, kH, kD, dW, dH, dD, padW, padH, padD, ceil_mode);
+  const int64_t outputDepth = output_shape[output_shape.size() - 3];
+  const int64_t outputHeight = output_shape[output_shape.size() - 2];
+  const int64_t outputWidth = output_shape[output_shape.size() - 1];
+
+  if (input.is_contiguous(c10::MemoryFormat::ChannelsLast)) {
+    auto output = at::_empty_affine_quantized(
+        output_shape,
+        input.options(),
+        input.q_scale(),
+        input.q_zero_point(),
+        input.suggest_memory_format());
+    // fast path for channel last: qavg_pool_2d_nhwc_stub
+    if (output_shape.size() == 4) {
+      qavg_pool3d_nhwc_stub(
+          input.device().type(),
+          input,
+          output,
+          0,
+          nInputPlane,
+          inputWidth,
+          inputHeight,
+          inputDepth,
+          outputWidth,
+          outputHeight,
+          outputDepth,
+          kW,
+          kH,
+          kD,
+          dW,
+          dH,
+          dD,
+          padW,
+          padH,
+          padD,
+          count_include_pad,
+          divisor_override);
+    } else {
+      at::parallel_for(0, nbatch, 0, [&](int64_t start, int64_t end) {
+        for (auto b = start; b < end; b++) {
+          qavg_pool3d_nhwc_stub(
+              input.device().type(),
+              input,
+              output,
+              b,
+              nInputPlane,
+              inputWidth,
+              inputHeight,
+              inputDepth,
+              outputWidth,
+              outputHeight,
+              outputDepth,
+              kW,
+              kH,
+              kD,
+              dW,
+              dH,
+              dD,
+              padW,
+              padH,
+              padD,
+              count_include_pad,
+              divisor_override);
+        }
+      });
+    }
+    return output;
+  } else {
+    auto output = at::_empty_affine_quantized(
+        output_shape, input.options(), input.q_scale(), input.q_zero_point());
+    if (output_shape.size() == 4) {
+      avg_pool3d_out_frame<scalar_t>(
+          input,
+          output,
+          0,
+          nInputPlane,
+          inputWidth,
+          inputHeight,
+          inputDepth,
+          outputWidth,
+          outputHeight,
+          outputDepth,
+          kW,
+          kH,
+          kD,
+          dW,
+          dH,
+          dD,
+          padW,
+          padH,
+          padD,
+          count_include_pad,
+          divisor_override);
+    } else {
+      at::parallel_for(0, nbatch, 0, [&](int64_t start, int64_t end) {
+        for (auto b = start; b < end; b++) {
+          avg_pool3d_out_frame<scalar_t>(
+              input,
+              output,
+              b,
+              nInputPlane,
+              inputWidth,
+              inputHeight,
+              inputDepth,
+              outputWidth,
+              outputHeight,
+              outputDepth,
+              kW,
+              kH,
+              kD,
+              dW,
+              dH,
+              dD,
+              padW,
+              padH,
+              padD,
+              count_include_pad,
+              divisor_override);
+        }
+      });
+    }
+    return output;
+  }
+}
+
+} // namespace
+
+Tensor quantized_avg_pool3d(
+    const Tensor& input,
+    IntArrayRef kernel_size,
+    IntArrayRef stride,
+    IntArrayRef padding,
+    bool ceil_mode,
+    bool count_include_pad,
+    c10::optional<int64_t> divisor_override) {
+  Tensor output;
+  AT_DISPATCH_QINT_TYPES(input.scalar_type(), "quantized_avg_pool3d", [&]() {
+    output = q_avg_pool3d<scalar_t>(
+        input,
+        kernel_size,
+        stride,
+        padding,
+        ceil_mode,
+        count_include_pad,
+        divisor_override);
+  });
+  return output;
+}
+
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/native/quantized/cpu/quantized_ops.h
+++ b/aten/src/ATen/native/quantized/cpu/quantized_ops.h
@@ -37,13 +37,13 @@ using qadaptive_avg_pool2d_fn = void (*)(
     const Tensor& qx,
     Tensor& qy,
     int64_t b,
-    int64_t sizeD,
+    int64_t sizeC,
     int64_t isizeH,
     int64_t isizeW,
     int64_t osizeH,
     int64_t osizeW,
     int64_t istrideB,
-    int64_t istrideD,
+    int64_t istrideC,
     int64_t istrideH,
     int64_t istrideW);
 
@@ -62,6 +62,29 @@ using qavg_pool2d_fn = void (*)(
     int dH,
     int padW,
     int padH,
+    bool count_include_pad,
+    c10::optional<int64_t> divisor_override);
+
+using qavg_pool3d_fn = void (*)(
+    const Tensor& qx,
+    Tensor& qy,
+    int64_t b,
+    int64_t nInputPlane,
+    int64_t inputWidth,
+    int64_t inputHeight,
+    int64_t inputDepth,
+    int64_t outputWidth,
+    int64_t outputHeight,
+    int64_t outputDepth,
+    int kW,
+    int kH,
+    int kD,
+    int dW,
+    int dH,
+    int dD,
+    int padW,
+    int padH,
+    int padD,
     bool count_include_pad,
     c10::optional<int64_t> divisor_override);
 
@@ -99,6 +122,7 @@ DECLARE_DISPATCH(qadd_fn, qadd_relu_stub);
 DECLARE_DISPATCH(qmaxpool_2d_fn, qmaxpool_2d_nhwc_stub);
 DECLARE_DISPATCH(qadaptive_avg_pool2d_fn, qadaptive_avg_pool2d_nhwc_stub);
 DECLARE_DISPATCH(qavg_pool2d_fn, qavg_pool2d_nhwc_stub);
+DECLARE_DISPATCH(qavg_pool3d_fn, qavg_pool3d_nhwc_stub);
 DECLARE_DISPATCH(qupsample_bilinear2d_fn, qupsample_bilinear2d_nhwc_stub);
 DECLARE_DISPATCH(qcat_nhwc_fn, qcat_nhwc_stub);
 DECLARE_DISPATCH(qcat_nhwc_fn, qcat_relu_nhwc_stub);

--- a/torch/nn/quantized/functional.py
+++ b/torch/nn/quantized/functional.py
@@ -43,6 +43,36 @@ def avg_pool2d(input, kernel_size, stride=None, padding=0, ceil_mode=False,
                                           ceil_mode, count_include_pad,
                                           divisor_override)
 
+def avg_pool3d(input, kernel_size, stride=None, padding=0, ceil_mode=False,
+               count_include_pad=True, divisor_override=None):
+    r"""
+    Applies 3D average-pooling operation in :math:`kD \ times kH \times kW` regions by step size
+    :math:`sD \times sH \times sW` steps. The number of output features is equal to the number of
+    input planes.
+
+    .. note:: The input quantization parameters propagate to the output.
+
+    Args:
+        input: quantized input tensor :math:`(\text{minibatch} , \text{in\_channels} , iH , iW)`
+        kernel_size: size of the pooling region. Can be a single number or a
+          tuple `(kD, kH, kW)`
+        stride: stride of the pooling operation. Can be a single number or a
+          tuple `(sD, sH, sW)`. Default: :attr:`kernel_size`
+        padding: implicit zero paddings on both sides of the input. Can be a
+          single number or a tuple `(padD, padH, padW)`. Default: 0
+        ceil_mode: when True, will use `ceil` instead of `floor` in the formula
+            to compute the output shape. Default: ``False``
+        count_include_pad: when True, will include the zero-padding in the
+            averaging calculation. Default: ``True``
+        divisor_override: if specified, it will be used as divisor, otherwise
+             size of the pooling region will be used. Default: None
+    """
+    if not input.is_quantized:
+        raise ValueError("Input to 'quantized.avg_pool3d' must be quantized!")
+    return torch.nn.functional.avg_pool3d(input, kernel_size, stride, padding,
+                                          ceil_mode, count_include_pad,
+                                          divisor_override)
+
 def adaptive_avg_pool2d(input, output_size):
     # type: (Tensor, BroadcastingList2[int]) -> Tensor
     r"""


### PR DESCRIPTION
```
import torch, time

for dtype in [torch.qint8, torch.quint8, torch.qint32]:
    print('****', str(dtype), '*****')
    x = torch.rand(1, 5, 56, 56, 256)

    q_x = torch.quantize_per_tensor(x, 0.5, 1, dtype)
    q_x = q_x.permute([0, 4, 1, 2, 3])

    x = x.permute([0, 4, 1, 2, 3])

    NITER = 10

    s = time.time()
    for i in range(NITER):
        float_out = torch.nn.functional.avg_pool3d(x, kernel_size=3, stride=None, padding=0)
    time_per_iter_float = (time.time() - s) / NITER

    s = time.time()
    for i in range(NITER):
        quant_out = torch.nn.quantized.functional.avg_pool3d(q_x, kernel_size=3, stride=None, padding=0)
    time_per_iter_quant = (time.time() - s) / NITER
    print('time/iter ms (float)', 'time/iter ms (quant)', 'quant/float', sep='\t')
    print(time_per_iter_float * 1000, time_per_iter_quant * 1000, time_per_iter_quant / time_per_iter_float, sep='\t')
```

```
**** torch.qint8 *****
time/iter ms (float)  time/iter ms (quant)  quant/float
16.286182403564453  0.7308721542358398  0.04487682479080417
**** torch.quint8 *****
time/iter ms (float)  time/iter ms (quant)  quant/float
15.364313125610352  0.6497383117675781  0.042288796541418254
**** torch.qint32 *****
time/iter ms (float)  time/iter ms (quant)  quant/float
15.649032592773438  13.879132270812988  0.8869003363966556
```