### PR TITLE
[pytorch] Set alias analysis kind to FROM_SCHEMA for qadd, qmul, qclamp, qconcat

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qadd.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qadd.cpp
@@ -244,32 +244,40 @@ static auto registry = c10::RegisterOperators()
 .op("quantized::add(Tensor qa, Tensor qb, float scale, int zero_point)"
      "-> Tensor qc",
     c10::RegisterOperators::options()
+      .aliasAnalysis(at::AliasAnalysisKind::FROM_SCHEMA)
       .kernel<QAdd</*ReLUFused=*/false>>(DispatchKey::QuantizedCPUTensorId))
 .op("quantized::add_relu(Tensor qa, Tensor qb, float scale, int zero_point)"
      "-> Tensor qc",
     c10::RegisterOperators::options()
+      .aliasAnalysis(at::AliasAnalysisKind::FROM_SCHEMA)
       .kernel<QAdd</*ReLUFused=*/true>>(DispatchKey::QuantizedCPUTensorId))
-.op("quantized::add_out(Tensor qa, Tensor qb, Tensor out)"
-     "-> Tensor out",
+.op("quantized::add_out(Tensor qa, Tensor qb, Tensor(a!) out)"
+     "-> Tensor(a!) out",
     c10::RegisterOperators::options()
+      .aliasAnalysis(at::AliasAnalysisKind::FROM_SCHEMA)
       .kernel<QAddOut</*ReLUFused=*/false>>(DispatchKey::QuantizedCPUTensorId))
-.op("quantized::add_relu_out(Tensor qa, Tensor qb, Tensor out)"
-     "-> Tensor out",
+.op("quantized::add_relu_out(Tensor qa, Tensor qb, Tensor(a!) out)"
+     "-> Tensor(a!) out",
     c10::RegisterOperators::options()
+      .aliasAnalysis(at::AliasAnalysisKind::FROM_SCHEMA)
       .kernel<QAddOut</*ReLUFused=*/true>>(DispatchKey::QuantizedCPUTensorId))
 .op("quantized::add_scalar(Tensor qa, Scalar b) -> Tensor qc",
     c10::RegisterOperators::options()
+      .aliasAnalysis(at::AliasAnalysisKind::FROM_SCHEMA)
       .kernel<QAddScalar</*ReLUFused=*/false>>(DispatchKey::QuantizedCPUTensorId))
 .op("quantized::add_scalar_relu(Tensor qa, Scalar b) -> Tensor qc",
     c10::RegisterOperators::options()
+      .aliasAnalysis(at::AliasAnalysisKind::FROM_SCHEMA)
       .kernel<QAddScalar</*ReLUFused=*/true>>(DispatchKey::QuantizedCPUTensorId))
-.op("quantized::add_scalar_out(Tensor qa, Scalar b, Tensor out)"
-     "-> Tensor out",
+.op("quantized::add_scalar_out(Tensor qa, Scalar b, Tensor(a!) out)"
+     "-> Tensor(a!) out",
     c10::RegisterOperators::options()
+      .aliasAnalysis(at::AliasAnalysisKind::FROM_SCHEMA)
       .kernel<QAddScalarOut</*ReLUFused=*/false>>(DispatchKey::QuantizedCPUTensorId))
-.op("quantized::add_scalar_relu_out(Tensor qa, Scalar b, Tensor out)"
-     "-> Tensor out",
+.op("quantized::add_scalar_relu_out(Tensor qa, Scalar b, Tensor(a!) out)"
+     "-> Tensor(a!) out",
     c10::RegisterOperators::options()
+      .aliasAnalysis(at::AliasAnalysisKind::FROM_SCHEMA)
       .kernel<QAddScalarOut</*ReLUFused=*/true>>(DispatchKey::QuantizedCPUTensorId));
 }  // namespace
 }}  // namespace at::native

--- a/aten/src/ATen/native/quantized/cpu/qclamp.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qclamp.cpp
@@ -52,8 +52,9 @@ class QClamp final : public c10::OperatorKernel {
 
 static auto registry = c10::RegisterOperators().op(
     "quantized::clamp(Tensor qx, Scalar? min, Scalar? max) -> Tensor qy",
-    c10::RegisterOperators::options().kernel<QClamp>(
-        DispatchKey::QuantizedCPUTensorId));
+    c10::RegisterOperators::options()
+        .aliasAnalysis(at::AliasAnalysisKind::FROM_SCHEMA)
+        .kernel<QClamp>(DispatchKey::QuantizedCPUTensorId));
 } // namespace
 
 } // namespace native

--- a/aten/src/ATen/native/quantized/cpu/qconcat.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconcat.cpp
@@ -110,20 +110,24 @@ static auto registry =
     torch::RegisterOperators()
         .op("quantized::cat(Tensor[] qx, int dim, float? scale, int? zero_point)"
             " -> Tensor",
-            torch::RegisterOperators::options().kernel<QCat<false>>(
-                DispatchKey::QuantizedCPUTensorId))
+            torch::RegisterOperators::options()
+                .aliasAnalysis(at::AliasAnalysisKind::FROM_SCHEMA)
+                .kernel<QCat<false>>(DispatchKey::QuantizedCPUTensorId))
         .op("quantized::cat_relu(Tensor[] qx, int dim, float? scale, int? zero_point)"
             " -> Tensor",
-            torch::RegisterOperators::options().kernel<QCat<true>>(
-                DispatchKey::QuantizedCPUTensorId))
-        .op("quantized::cat_out(Tensor[] qx, int dim, Tensor out)"
-            " -> Tensor",
-            torch::RegisterOperators::options().kernel<QCatOut<false>>(
-                DispatchKey::QuantizedCPUTensorId))
-        .op("quantized::cat_relu_out(Tensor[] qx, int dim, Tensor out)"
-            " -> Tensor",
-            torch::RegisterOperators::options().kernel<QCatOut<true>>(
-                DispatchKey::QuantizedCPUTensorId));
+            torch::RegisterOperators::options()
+                .aliasAnalysis(at::AliasAnalysisKind::FROM_SCHEMA)
+                .kernel<QCat<true>>(DispatchKey::QuantizedCPUTensorId))
+        .op("quantized::cat_out(Tensor[] qx, int dim, Tensor(a!) out)"
+            " -> Tensor(a!)",
+            torch::RegisterOperators::options()
+                .aliasAnalysis(at::AliasAnalysisKind::FROM_SCHEMA)
+                .kernel<QCatOut<false>>(DispatchKey::QuantizedCPUTensorId))
+        .op("quantized::cat_relu_out(Tensor[] qx, int dim, Tensor(a!) out)"
+            " -> Tensor(a!)",
+            torch::RegisterOperators::options()
+                .aliasAnalysis(at::AliasAnalysisKind::FROM_SCHEMA)
+                .kernel<QCatOut<true>>(DispatchKey::QuantizedCPUTensorId));
 
 } // namespace
 

--- a/aten/src/ATen/native/quantized/cpu/qmul.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qmul.cpp
@@ -156,41 +156,51 @@ static auto registry =
     c10::RegisterOperators()
         .op("quantized::mul(Tensor qa, Tensor qb, float scale, int zero_point)"
             "-> Tensor qc",
-            c10::RegisterOperators::options().kernel<QMul</*ReLUFused=*/false>>(
-                DispatchKey::QuantizedCPUTensorId))
+            c10::RegisterOperators::options()
+                .aliasAnalysis(at::AliasAnalysisKind::FROM_SCHEMA)
+                .kernel<QMul</*ReLUFused=*/false>>(
+                    DispatchKey::QuantizedCPUTensorId))
         .op("quantized::mul_relu(Tensor qa, Tensor qb, float scale, int zero_point)"
             "-> Tensor qc",
-            c10::RegisterOperators::options().kernel<QMul</*ReLUFused=*/true>>(
-                DispatchKey::QuantizedCPUTensorId))
-        .op("quantized::mul_out(Tensor qa, Tensor qb, Tensor out)"
-            "-> Tensor out",
             c10::RegisterOperators::options()
+                .aliasAnalysis(at::AliasAnalysisKind::FROM_SCHEMA)
+                .kernel<QMul</*ReLUFused=*/true>>(
+                    DispatchKey::QuantizedCPUTensorId))
+        .op("quantized::mul_out(Tensor qa, Tensor qb, Tensor(a!) out)"
+            "-> Tensor(a!) out",
+            c10::RegisterOperators::options()
+                .aliasAnalysis(at::AliasAnalysisKind::FROM_SCHEMA)
                 .kernel<QMulOut</*ReLUFused=*/false>>(
                     DispatchKey::QuantizedCPUTensorId))
-        .op("quantized::mul_relu_out(Tensor qa, Tensor qb, Tensor out)"
-            "-> Tensor out",
+        .op("quantized::mul_relu_out(Tensor qa, Tensor qb, Tensor(a!) out)"
+            "-> Tensor(a!) out",
             c10::RegisterOperators::options()
+                .aliasAnalysis(at::AliasAnalysisKind::FROM_SCHEMA)
                 .kernel<QMulOut</*ReLUFused=*/true>>(
                     DispatchKey::QuantizedCPUTensorId))
 
         .op("quantized::mul_scalar(Tensor qa, Scalar b)"
             "-> Tensor qc",
             c10::RegisterOperators::options()
+                .aliasAnalysis(at::AliasAnalysisKind::FROM_SCHEMA)
                 .kernel<QMulScalar</*ReLUFused=*/false>>(
                     DispatchKey::QuantizedCPUTensorId))
         .op("quantized::mul_scalar_relu(Tensor qa, Scalar b)"
             "-> Tensor qc",
             c10::RegisterOperators::options()
+                .aliasAnalysis(at::AliasAnalysisKind::FROM_SCHEMA)
                 .kernel<QMulScalar</*ReLUFused=*/true>>(
                     DispatchKey::QuantizedCPUTensorId))
-        .op("quantized::mul_scalar_out(Tensor qa, Scalar b, Tensor out)"
-            "-> Tensor out",
+        .op("quantized::mul_scalar_out(Tensor qa, Scalar b, Tensor(a!) out)"
+            "-> Tensor(a!) out",
             c10::RegisterOperators::options()
+                .aliasAnalysis(at::AliasAnalysisKind::FROM_SCHEMA)
                 .kernel<QMulScalarOut</*ReLUFused=*/false>>(
                     DispatchKey::QuantizedCPUTensorId))
-        .op("quantized::mul_scalar_relu_out(Tensor qa, Scalar b, Tensor out)"
-            "-> Tensor out",
+        .op("quantized::mul_scalar_relu_out(Tensor qa, Scalar b, Tensor(a!) out)"
+            "-> Tensor(a!) out",
             c10::RegisterOperators::options()
+                .aliasAnalysis(at::AliasAnalysisKind::FROM_SCHEMA)
                 .kernel<QMulScalarOut</*ReLUFused=*/true>>(
                     DispatchKey::QuantizedCPUTensorId));
 }  // namespace

--- a/test/backward_compatibility/check_backward_compatibility.py
+++ b/test/backward_compatibility/check_backward_compatibility.py
@@ -54,6 +54,9 @@ white_list = [
     ('_prim::TupleUnpack', datetime.date(2020, 3, 1)),
     ('_aten::format', datetime.date(2020, 3, 1)),
     ('aten::random_', datetime.date(2020, 3, 1)),
+    ('quantized::add_(scalar_)?(relu_)?out', datetime.date(2020, 3, 1)),
+    ('quantized::cat_(relu_)?out', datetime.date(2020, 3, 1)),
+    ('quantized::mul_(scalar_)?(relu_)?out', datetime.date(2020, 3, 1)),
 ]
 
 


### PR DESCRIPTION
Summary:
Updated alias analysis kind to FROM_SCHEMA so input tensors can be marked as nonmutable
when appropriate, allowing for constant folding of these tensors.

Needed to update the schemas of the _out variants with annotations to mark the output input
tensor as aliased and mutable.

Test Plan:
```
import torch

class M(torch.nn.Module):
    def __init__(self):
        super(M, self).__init__()

    def forward(self, x):
        w = torch.tensor([3], dtype=torch.float)
        w = torch.quantize_per_tensor(w, 1.0, 0, torch.qint8)
        y = torch.tensor([3], dtype=torch.float)
        y = torch.quantize_per_tensor(w, 1.0, 0, torch.qint8)
        return torch.ops.quantized.add_out(x, w, y)

m = torch.jit.script(M())
torch._C._jit_pass_constant_propagation(m.graph)
print(m.graph)
```
```
graph(%self : __torch__.___torch_mangle_9.M,
      %x.1 : Tensor):
  %11 : int = prim::Constant[value=12]() # <ipython-input-11-1dd94c30cb58>:9:49
  %9 : float = prim::Constant[value=1.]() # <ipython-input-11-1dd94c30cb58>:9:41
  %10 : int = prim::Constant[value=0]() # <ipython-input-11-1dd94c30cb58>:9:46
  %36 : QInt8(1) = prim::Constant[value={3}]()
  %y.2 : Tensor = aten::quantize_per_tensor(%36, %9, %10, %11) # <ipython-input-11-1dd94c30cb58>:11:12
  %24 : Tensor = quantized::add_out(%x.1, %36, %y.2) # <ipython-input-11-1dd94c30cb58>:12:15
  return (%24)
```
As expected, the aten::quantize_per_tensor() for w is now folded. The aten::quantize_per_tensor()
for y is not folded, since that tensor is aliased/modified.

Differential Revision: D19910667

