### PR TITLE
Kill torch.range

### DIFF
--- a/aten/src/ATen/native/RangeFactories.cpp
+++ b/aten/src/ATen/native/RangeFactories.cpp
@@ -100,40 +100,6 @@ Tensor& logspace_cpu_out(Tensor& result, Scalar start, Scalar end, int64_t steps
   return result;
 }
 
-Tensor& range_cpu_out(Tensor& result, Scalar start, Scalar end, Scalar step) {
-  AT_DISPATCH_ALL_TYPES(result.scalar_type(), "range_cpu", [&]() {
-    using accscalar_t = at::acc_type<scalar_t, false>;
-    auto xstart = start.to<accscalar_t>();
-    auto xend = end.to<accscalar_t>();
-    auto xstep = step.to<accscalar_t>();
-
-    TORCH_CHECK(xstep > 0 || xstep < 0, "step must be nonzero");
-    TORCH_CHECK(std::isfinite(static_cast<double>(xstart)) &&
-             std::isfinite(static_cast<double>(xend)),
-             "unsupported range: ", xstart, " -> ", xend);
-    TORCH_CHECK(((xstep > 0) && (xend >= xstart)) || ((xstep < 0) && (xend <= xstart)),
-             "upper bound and larger bound inconsistent with step sign");
-    int64_t size = static_cast<int64_t>(((xend - xstart) / xstep) + 1);
-    if (result.numel() != size) {
-      result.resize_({size});
-    }
-    Tensor r = result.is_contiguous() ? result : result.contiguous();
-    scalar_t *data_ptr = r.data_ptr<scalar_t>();
-
-    at::parallel_for(0, size, internal::GRAIN_SIZE, [&](int64_t p_begin, int64_t p_end) {
-      scalar_t is = p_begin;
-      for (int64_t i = p_begin; i < p_end; ++i, ++is) {
-        data_ptr[i] = xstart + is * xstep;
-      }
-    });
-    if (!result.is_contiguous()) {
-      result.copy_(r);
-    }
-  });
-
-  return result;
-}
-
 Tensor& arange_cpu_out(Tensor& result, Scalar start, Scalar end, Scalar step) {
   AT_DISPATCH_ALL_TYPES(result.scalar_type(), "arange_cpu", [&]() {
     using accscalar_t = at::acc_type<scalar_t, false>;

--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -656,24 +656,6 @@ Tensor& randperm_out_cpu(Tensor& result, int64_t n, Generator* generator) {
   return result;
 }
 
-// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ range ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Tensor range(
-    Scalar start,
-    Scalar end,
-    Scalar step,
-    const TensorOptions& options) {
-  Tensor result = at::empty({0}, options);
-  return at::range_out(result, start, end, step);
-}
-
-Tensor range(
-    Scalar start,
-    Scalar end,
-    const TensorOptions& options) {
-  return at::native::range(start, end, 1, options);
-}
-
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ triangle ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Tensor tril_indices_cpu(

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2230,15 +2230,6 @@
     CPU: randperm_out_cpu
     CUDA: randperm_out_cuda
 
-- func: range.step(Scalar start, Scalar end, Scalar step=1, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
-
-- func: range(Scalar start, Scalar end, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
-
-- func: range.out(Scalar start, Scalar end, Scalar step=1, *, Tensor(a!) out) -> Tensor(a!)
-  dispatch:
-    CPU: range_cpu_out
-    CUDA: range_cuda_out
-
 - func: reciprocal(Tensor self) -> Tensor
   use_c10_dispatcher: full
   supports_named_tensor: True

--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -43,7 +43,6 @@ Creation Ops
 .. autofunction:: ones
 .. autofunction:: ones_like
 .. autofunction:: arange
-.. autofunction:: range
 .. autofunction:: linspace
 .. autofunction:: logspace
 .. autofunction:: eye

--- a/test/backward_compatibility/check_backward_compatibility.py
+++ b/test/backward_compatibility/check_backward_compatibility.py
@@ -27,6 +27,7 @@ white_list = [
     ('aten::_ncf_unsqueeze', datetime.date(2020, 3, 1)),
     ('prim::Load', datetime.date(2020, 3, 1)),
     ('prim::ImplicitTensorToNum', datetime.date(2020, 3, 1)),
+    ('aten::range', datetime.date(2020, 3, 1)),
 ]
 
 

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -4228,9 +4228,9 @@ class TestTransforms(TestCase):
 
 class TestFunctors(TestCase):
     def test_cat_transform(self):
-        x1 = -1 * torch.range(1, 100).view(-1, 100)
-        x2 = (torch.range(1, 100).view(-1, 100) - 1) / 100
-        x3 = torch.range(1, 100).view(-1, 100)
+        x1 = -1 * torch.arange(1.0, 101.0).view(-1, 100)
+        x2 = (torch.arange(1.0, 101.0).view(-1, 100) - 1) / 100
+        x3 = torch.arange(1.0, 101.0).view(-1, 100)
         t1, t2, t3 = ExpTransform(), AffineTransform(1, 100), identity_transform
         dim = 0
         x = torch.cat([x1, x2, x3], dim=dim)
@@ -4243,9 +4243,9 @@ class TestFunctors(TestCase):
         actual = t(x)
         expected = torch.cat([t1(x1), t2(x2), t3(x3)], dim=dim)
         self.assertEqual(expected, actual)
-        y1 = torch.range(1, 100).view(-1, 100)
-        y2 = torch.range(1, 100).view(-1, 100)
-        y3 = torch.range(1, 100).view(-1, 100)
+        y1 = torch.arange(1.0, 101.0).view(-1, 100)
+        y2 = torch.arange(1.0, 101.0).view(-1, 100)
+        y3 = torch.arange(1.0, 101.0).view(-1, 100)
         y = torch.cat([y1, y2, y3], dim=dim)
         actual_cod_check = t.codomain.check(y)
         expected_cod_check = torch.cat([t1.codomain.check(y1),
@@ -4262,9 +4262,9 @@ class TestFunctors(TestCase):
         self.assertEqual(actual_jac, expected_jac)
 
     def test_cat_transform_non_uniform(self):
-        x1 = -1 * torch.range(1, 100).view(-1, 100)
-        x2 = torch.cat([(torch.range(1, 100).view(-1, 100) - 1) / 100,
-                        torch.range(1, 100).view(-1, 100)])
+        x1 = -1 * torch.arange(1.0, 101.0).view(-1, 100)
+        x2 = torch.cat([(torch.arange(1.0, 101.0).view(-1, 100) - 1) / 100,
+                        torch.arange(1.0, 101.0).view(-1, 100)])
         t1 = ExpTransform()
         t2 = CatTransform([AffineTransform(1, 100), identity_transform], dim=0)
         dim = 0
@@ -4277,9 +4277,9 @@ class TestFunctors(TestCase):
         actual = t(x)
         expected = torch.cat([t1(x1), t2(x2)], dim=dim)
         self.assertEqual(expected, actual)
-        y1 = torch.range(1, 100).view(-1, 100)
-        y2 = torch.cat([torch.range(1, 100).view(-1, 100),
-                        torch.range(1, 100).view(-1, 100)])
+        y1 = torch.arange(1.0, 101.0).view(-1, 100)
+        y2 = torch.cat([torch.arange(1.0, 101.0).view(-1, 100),
+                        torch.arange(1.0, 101.0).view(-1, 100)])
         y = torch.cat([y1, y2], dim=dim)
         actual_cod_check = t.codomain.check(y)
         expected_cod_check = torch.cat([t1.codomain.check(y1),
@@ -4294,9 +4294,9 @@ class TestFunctors(TestCase):
         self.assertEqual(actual_jac, expected_jac)
 
     def test_stack_transform(self):
-        x1 = -1 * torch.range(1, 100)
-        x2 = (torch.range(1, 100) - 1) / 100
-        x3 = torch.range(1, 100)
+        x1 = -1 * torch.arange(1.0, 101.0)
+        x2 = (torch.arange(1.0, 101.0) - 1) / 100
+        x3 = torch.arange(1.0, 101.0)
         t1, t2, t3 = ExpTransform(), AffineTransform(1, 100), identity_transform
         dim = 0
         x = torch.stack([x1, x2, x3], dim=dim)
@@ -4309,9 +4309,9 @@ class TestFunctors(TestCase):
         actual = t(x)
         expected = torch.stack([t1(x1), t2(x2), t3(x3)], dim=dim)
         self.assertEqual(expected, actual)
-        y1 = torch.range(1, 100)
-        y2 = torch.range(1, 100)
-        y3 = torch.range(1, 100)
+        y1 = torch.arange(1.0, 101.0)
+        y2 = torch.arange(1.0, 101.0)
+        y3 = torch.arange(1.0, 101.0)
         y = torch.stack([y1, y2, y3], dim=dim)
         actual_cod_check = t.codomain.check(y)
         expected_cod_check = torch.stack([t1.codomain.check(y1),

--- a/test/test_overrides.py
+++ b/test/test_overrides.py
@@ -360,7 +360,6 @@ IGNORED_TORCH_FUNCTIONS = (
     torch.randn,
     torch.randint,
     torch.randperm,
-    torch.range,
     torch.sparse_coo_tensor,
     torch.zeros,
 )

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -23,7 +23,7 @@ from torch import multiprocessing as mp
 from torch.testing._internal.common_methods_invocations import tri_tests_args, run_additional_tri_tests, \
     _compare_trilu_indices
 from torch.testing._internal.common_utils import TestCase, iter_indices, TEST_NUMPY, TEST_SCIPY, TEST_MKL, \
-    TEST_LIBROSA, TEST_WITH_ROCM, run_tests, skipIfNoLapack, suppress_warnings, \
+    TEST_LIBROSA, TEST_WITH_ROCM, run_tests, skipIfNoLapack, \
     IS_WINDOWS, PY3, NO_MULTIPROCESSING_SPAWN, do_test_dtypes, do_test_empty_full, \
     IS_SANDCASTLE, load_tests, pdist_single, brute_cdist, slowTest, \
     skipCUDANonDefaultStreamIf, skipCUDAMemoryLeakCheckIf, BytesIOContext, skipIfRocm

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1540,50 +1540,6 @@ class _TestTorchMixin(object):
         self._spawn_method(test_method, torch.Tensor([1, 1, nan]))
         self._spawn_method(test_method, torch.Tensor([0, 1, 0]))
 
-    @suppress_warnings
-    def test_range(self):
-        res1 = torch.range(0, 1)
-        res2 = torch.Tensor()
-        torch.range(0, 1, out=res2)
-        self.assertEqual(res1, res2, 0)
-
-        # Check range for non-contiguous tensors.
-        x = torch.zeros(2, 3)
-        torch.range(0, 3, out=x.narrow(1, 1, 2))
-        res2 = torch.Tensor(((0, 0, 1), (0, 2, 3)))
-        self.assertEqual(x, res2, 1e-16)
-
-        # Check negative
-        res1 = torch.Tensor((1, 0))
-        res2 = torch.Tensor()
-        torch.range(1, 0, -1, out=res2)
-        self.assertEqual(res1, res2, 0)
-
-        # Equal bounds
-        res1 = torch.ones(1)
-        res2 = torch.Tensor()
-        torch.range(1, 1, -1, out=res2)
-        self.assertEqual(res1, res2, 0)
-        torch.range(1, 1, 1, out=res2)
-        self.assertEqual(res1, res2, 0)
-
-        # FloatTensor
-        res1 = torch.range(0.6, 0.9, 0.1, out=torch.FloatTensor())
-        self.assertEqual(res1.size(0), 4)
-        res1 = torch.range(1, 10, 0.3, out=torch.FloatTensor())
-        self.assertEqual(res1.size(0), 31)
-
-        # DoubleTensor
-        res1 = torch.range(0.6, 0.9, 0.1, out=torch.DoubleTensor())
-        self.assertEqual(res1.size(0), 4)
-        res1 = torch.range(1, 10, 0.3, out=torch.DoubleTensor())
-        self.assertEqual(res1.size(0), 31)
-
-    def test_range_warning(self):
-        with warnings.catch_warnings(record=True) as w:
-            torch.range(0, 10)
-            self.assertEqual(len(w), 1)
-
     def test_arange(self):
         res1 = torch.arange(0, 1)
         res2 = torch.Tensor()

--- a/tools/autograd/templates/python_torch_functions.cpp
+++ b/tools/autograd/templates/python_torch_functions.cpp
@@ -155,19 +155,6 @@ static PyObject * THPVariable_arange(PyObject* self, PyObject* args, PyObject* k
   END_HANDLE_TH_ERRORS
 }
 
-inline Tensor dispatch_range(Scalar start, Scalar end, Scalar step, Tensor result) {
-  pybind11::gil_scoped_release no_gil;
-  OptionalDeviceGuard device_guard(device_of(result));
-  return at::range_out(result, start, end, step);
-}
-
-inline Tensor dispatch_range(Scalar start, Scalar end, Scalar step, const TensorOptions& options) {
-  torch::utils::maybe_initialize_cuda(options);
-  pybind11::gil_scoped_release no_gil;
-  DeviceGuard device_guard(options.device());
-  return torch::range(start, end, step, options);
-}
-
 inline Tensor dispatch_randint(int64_t high, IntArrayRef size, Generator * generator, Tensor result) {
   pybind11::gil_scoped_release no_gil;
   return at::randint_out(result, high, size, generator);
@@ -366,7 +353,6 @@ static PyMethodDef torch_functions[] = {
   {"hsmm", (PyCFunction)(void(*)(void))THPVariable_hspmm, METH_VARARGS | METH_KEYWORDS | METH_STATIC, NULL},
   {"nonzero", (PyCFunction)(void(*)(void))THPVariable_nonzero, METH_VARARGS | METH_KEYWORDS | METH_STATIC, NULL},
   {"randint", (PyCFunction)(void(*)(void))THPVariable_randint, METH_VARARGS | METH_KEYWORDS | METH_STATIC, NULL},
-  {"range", (PyCFunction)(void(*)(void))THPVariable_range, METH_VARARGS | METH_KEYWORDS | METH_STATIC, NULL},
   {"saddmm", (PyCFunction)(void(*)(void))THPVariable_sspaddmm, METH_VARARGS | METH_KEYWORDS | METH_STATIC, NULL},
   {"sparse_coo_tensor", (PyCFunction)(void(*)(void))THPVariable_sparse_coo_tensor, METH_VARARGS | METH_KEYWORDS | METH_STATIC, NULL},
   {"spmm", (PyCFunction)(void(*)(void))THPVariable_mm, METH_VARARGS | METH_KEYWORDS | METH_STATIC, NULL},

--- a/tools/autograd/templates/python_torch_functions.cpp
+++ b/tools/autograd/templates/python_torch_functions.cpp
@@ -168,37 +168,6 @@ inline Tensor dispatch_range(Scalar start, Scalar end, Scalar step, const Tensor
   return torch::range(start, end, step, options);
 }
 
-static PyObject * THPVariable_range(PyObject* self, PyObject* args, PyObject* kwargs)
-{
-  HANDLE_TH_ERRORS
-  static PythonArgParser parser({
-    "range(Scalar start, Scalar end, Scalar step=1, *, Tensor out=None, ScalarType dtype=None, Layout layout=torch.strided, Device device=None, bool requires_grad=False)",
-  });
-
-  ParsedArgs<8> parsed_args;
-  auto r = parser.parse(args, kwargs, parsed_args);
-  if (r.idx == 0) {
-    PyErr_WarnEx(PyExc_UserWarning, "torch.range is deprecated in favor of torch.arange "
-        "and will be removed in 0.5. Note that arange generates values in [start; end), "
-        "not [start; end].", 1);
-    if (r.isNone(3)) {
-      const auto options = TensorOptions()
-          .dtype(r.scalartype(4))
-          .device(r.device(6))
-          .layout(r.layout(5).layout)
-          .requires_grad(r.toBool(7));
-      return wrap(dispatch_range(r.scalar(0), r.scalar(1), r.scalar(2), options));
-    } else {
-      check_out_type_matches(r.tensor(3), r.scalartype(4), r.isNone(4),
-                             r.layout(5), r.isNone(5),
-                             r.device(6), r.isNone(6));
-      return wrap(dispatch_range(r.scalar(0), r.scalar(1), r.scalar(2), r.tensor(3)).set_requires_grad(r.toBool(7)));
-    }
-  }
-  Py_RETURN_NONE;
-  END_HANDLE_TH_ERRORS
-}
-
 inline Tensor dispatch_randint(int64_t high, IntArrayRef size, Generator * generator, Tensor result) {
   pybind11::gil_scoped_release no_gil;
   return at::randint_out(result, high, size, generator);

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -4681,42 +4681,6 @@ Example::
     tensor([])
 """.format(**factory_data_common_args))
 
-add_docstr(torch.range,
-           r"""
-range(start=0, end, step=1, out=None, dtype=None, layout=torch.strided, device=None, requires_grad=False) -> Tensor
-
-Returns a 1-D tensor of size :math:`\left\lfloor \frac{\text{end} - \text{start}}{\text{step}} \right\rfloor + 1`
-with values from :attr:`start` to :attr:`end` with step :attr:`step`. Step is
-the gap between two values in the tensor.
-
-.. math::
-    \text{out}_{i+1} = \text{out}_i + \text{step}.
-""" + r"""
-.. warning::
-    This function is deprecated in favor of :func:`torch.arange`.
-
-Args:
-    start (float): the starting value for the set of points. Default: ``0``.
-    end (float): the ending value for the set of points
-    step (float): the gap between each pair of adjacent points. Default: ``1``.
-    {out}
-    {dtype} If `dtype` is not given, infer the data type from the other input
-        arguments. If any of `start`, `end`, or `stop` are floating-point, the
-        `dtype` is inferred to be the default dtype, see
-        :meth:`~torch.get_default_dtype`. Otherwise, the `dtype` is inferred to
-        be `torch.int64`.
-    {layout}
-    {device}
-    {requires_grad}
-
-Example::
-
-    >>> torch.range(1, 4)
-    tensor([ 1.,  2.,  3.,  4.])
-    >>> torch.range(1, 4, 0.5)
-    tensor([ 1.0000,  1.5000,  2.0000,  2.5000,  3.0000,  3.5000,  4.0000])
-""".format(**factory_common_args))
-
 add_docstr(torch.arange,
            r"""
 arange(start=0, end, step=1, out=None, dtype=None, layout=torch.strided, device=None, requires_grad=False) -> Tensor

--- a/torch/distributions/transforms.py
+++ b/torch/distributions/transforms.py
@@ -558,7 +558,7 @@ class CatTransform(Transform):
     in a way compatible with :func:`torch.cat`.
 
     Example::
-       x0 = torch.cat([torch.range(1, 10), torch.range(1, 10)], dim=0)
+       x0 = torch.cat([torch.arange(1.0, 11.0), torch.arange(1.0, 11.0)], dim=0)
        x = torch.cat([x0, x0], dim=0)
        t0 = CatTransform([ExpTransform(), identity_transform], dim=0, lengths=[10, 10])
        t = CatTransform([t0, t0], dim=0, lengths=[20, 20])
@@ -636,7 +636,7 @@ class StackTransform(Transform):
     in a way compatible with :func:`torch.stack`.
 
     Example::
-       x = torch.stack([torch.range(1, 10), torch.range(1, 10)], dim=1)
+       x = torch.stack([torch.arange(1.0, 11.0), torch.arange(1.0, 11.0)], dim=1)
        t = StackTransform([ExpTransform(), identity_transform], dim=1)
        y = t(x)
     """


### PR DESCRIPTION
It is deprecated and should be removed on 0.5
```C++
  if (r.idx == 0) {	
    PyErr_WarnEx(PyExc_UserWarning, "torch.range is deprecated in favor of torch.arange "	
        "and will be removed in 0.5. Note that arange generates values in [start; end), "	
        "not [start; end].", 1);
```