### PR TITLE
Avoid clone for sparse tensors during accumulation of grads.

### DIFF
--- a/torch/csrc/autograd/functions/accumulate_grad.cpp
+++ b/torch/csrc/autograd/functions/accumulate_grad.cpp
@@ -51,6 +51,10 @@ void AccumulateGrad::accumulateGradAndCallHooks(
       // call_function in Engine.cpp will temporarily bump the refcount by one,
       // hence the addition of has_post_hooks.
       update_grad_fn(new_grad_copy.detach());
+    } else if (
+        !GradMode::is_enabled() && new_grad_copy.is_sparse() &&
+        new_grad_use_count <= num_expected_refs + has_post_hooks) {
+      update_grad_fn(new_grad_copy.detach());
     } else {
       if (new_grad_copy.is_sparse()) {
         update_grad_fn(new_grad_copy.clone());
@@ -62,23 +66,28 @@ void AccumulateGrad::accumulateGradAndCallHooks(
     // This case is not strictly necessary, but it makes the first-order only case
     // slightly more efficient.
     if (variable_grad.is_sparse() && !new_grad_copy.is_sparse()) {
-      // If `grad_variable` is sparse and `new_grad_copy` is not sparse, their
+      // If `variable_grad` is sparse and `new_grad_copy` is not sparse, their
       // sum is not sparse, and we must change the TensorImpl type of
-      // `grad_variable` for it to store the result. However, changing the
+      // `variable_grad` for it to store the result. However, changing the
       // TensorImpl type of a tensor requires changing the tensor itself, and
       // thus in this case we have to change the grad tensor.
       update_grad_fn(new_grad_copy + variable_grad);
+    } else if (variable_grad.is_sparse() && !variable_grad.unsafeGetTensorImpl()->allow_tensor_metadata_change()) {
+      // In case the current grad is sparse and we're not allowed to change
+      // tensor metadata (due to detach() earlier). Create a new tensor
+      // instead of accumulating the grad in place.
+      update_grad_fn(variable_grad + new_grad_copy);
     } else {
       // In this case we can avoid changing the grad tensor. There are three
       // scenarios when we'll hit this case:
       //
-      // 1. `grad_variable` is sparse, and `new_grad_copy` is sparse.
-      // 2. `grad_variable` is dense, and `new_grad_copy` is sparse.
-      // 3. `grad_variable` is dense, and `new_grad_copy` is dense.
+      // 1. `variable_grad` is sparse, and `new_grad_copy` is sparse.
+      // 2. `variable_grad` is dense, and `new_grad_copy` is sparse.
+      // 3. `variable_grad` is dense, and `new_grad_copy` is dense.
       //
-      // In all of these three cases, `grad_variable += new_grad_copy` is a
-      // valid operation which adds `new_grad_copy` to `grad_variable` in place.
-      // `grad_variable` is thus still referring to the same tensor after the
+      // In all of these three cases, `variable_grad += new_grad_copy` is a
+      // valid operation which adds `new_grad_copy` to `variable_grad` in place.
+      // `variable_grad` is thus still referring to the same tensor after the
       // operation.
       variable_grad += new_grad_copy;
     }

--- a/torch/testing/_internal/distributed/rpc/dist_autograd_test.py
+++ b/torch/testing/_internal/distributed/rpc/dist_autograd_test.py
@@ -1869,6 +1869,82 @@ class DistAutogradTest(RpcAgentTestFixture):
             # check one of them is using the computed buffer
             self.assertTrue(p_a == p_g or p_b == p_g)
 
+    @dist_init
+    def test_no_grad_copy_sparse(self):
+        # create autograd function that saves grad pointer as class static
+        class MyFunc(Function):
+            static_grad_ptr = None
+
+            @staticmethod
+            def forward(ctx, inp1, inp2):
+                return inp1 + inp2
+
+            @staticmethod
+            def backward(ctx, grad):
+                MyFunc.static_grad_ptr = grad._values().data_ptr()
+                return grad, grad
+
+        class NonContGradFunc(Function):
+            static_grad_ptr = None
+
+            @staticmethod
+            def forward(ctx, inp1, inp2):
+                return inp1 + inp2
+
+            @staticmethod
+            def backward(ctx, grad):
+                # Create a sparse tensor with non-contigous indices and values
+                # and return as grad.
+                v = torch.rand(1, 3)
+                i = torch.ones(1, 1, dtype=torch.long)
+                nv = v.expand(8, 3)
+                ni = i.expand(1, 8)
+                ngrad = torch.sparse.FloatTensor(ni, nv, torch.Size([10, 3]))
+                MyFunc.static_grad_ptr = ngrad._values().data_ptr()
+                return ngrad, ngrad
+
+        a = torch.randn(10, 3, requires_grad=True)
+        b = torch.randn(10, 3, requires_grad=True)
+        input = torch.tensor([1, 2, 4, 5, 4, 3, 2, 9])
+        offsets = torch.tensor([0, 4])
+        import torch.nn.functional as F
+
+        # test case that should trigger no copy for one of a,b
+        with dist_autograd.context() as context_id:
+            emb_matrix = MyFunc.apply(a, b)
+            loss = F.embedding_bag(emb_matrix, input, offsets, sparse=True).sum()
+            dist_autograd.backward([loss], retain_graph=True)
+            grads = dist_autograd.get_gradients(context_id)
+            p_g = MyFunc.static_grad_ptr
+            p_a = grads[a]._values().data_ptr()
+            p_b = grads[b]._values().data_ptr()
+            # check a,b uses different grad buffer
+            self.assertFalse(p_a == p_b)
+            # check one of them is using the computed buffer
+            self.assertTrue(p_a == p_g or p_b == p_g)
+
+            # Run backwards multiple times.
+            for i in range(100):
+                dist_autograd.backward([loss], retain_graph=True)
+
+        # non-contiguous indices and value should not trigger copy either.
+        with dist_autograd.context() as context_id:
+            emb_matrix = NonContGradFunc.apply(a, b)
+            loss = F.embedding_bag(emb_matrix, input, offsets, sparse=True).sum()
+            dist_autograd.backward([loss], retain_graph=True)
+            grads = dist_autograd.get_gradients(context_id)
+            p_g = MyFunc.static_grad_ptr
+            p_a = grads[a]._values().data_ptr()
+            p_b = grads[b]._values().data_ptr()
+            # check a,b uses different grad buffer
+            self.assertFalse(p_a == p_b)
+            # check one of them is using the computed buffer
+            self.assertTrue(p_a == p_g or p_b == p_g)
+
+            # Run backwards multiple times.
+            for i in range(100):
+                dist_autograd.backward([loss], retain_graph=True)
+
 
 @unittest.skipIf(
     not torch._six.PY3,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#33393 Avoid clone for sparse tensors during accumulation of grads.**
* #33214 Unify gradient accumulation between distributed autograd and local autograd engine.

This PR is an attempt to avoid clone for sparse tensors similar to how
we avoid clone for dense tensors currently.

As per my understanding even if the 'indices' and 'values' of a sparse tensor
are non-continguous, operations like 'add' are still supported. As a result,
the major change in this PR is to use detach() instead of clone() for sparse
tensors and then if the sparse grad Tensor cannot change its metadata, then we
can't accumulate grads inplace and instead need to create a new Tensor.

Differential Revision: [D19926698](https://our.internmc.facebook.com/intern/diff/D19926698/)