### PR TITLE
[Fuser] Add a knob for disabling/enabling CUDA fuser.

### DIFF
--- a/torch/csrc/jit/fuser/interface.cpp
+++ b/torch/csrc/jit/fuser/interface.cpp
@@ -15,6 +15,8 @@ namespace detail {
 // Note: CPU fusion is currently disabled due to test flakiness
 bool cpu_fuser_enabled = false;
 
+bool gpu_fuser_enabled = true;
+
 } // namespace detail
 
 int64_t registerFusion(const Node* fusion_group) {
@@ -33,11 +35,16 @@ bool canFuseOnCPU() {
 }
 
 bool canFuseOnGPU() {
-  return fuser::hasFusionBackend(at::DeviceType::CUDA);
+  return fuser::hasFusionBackend(at::DeviceType::CUDA) &&
+      detail::gpu_fuser_enabled;
 }
 
 void overrideCanFuseOnCPU(bool value) {
   detail::cpu_fuser_enabled = value;
+}
+
+void overrideCanFuseOnGPU(bool value) {
+  detail::gpu_fuser_enabled = value;
 }
 
 // Uses the above interface by stuffing the graph into a node and treating that

--- a/torch/csrc/jit/fuser/interface.h
+++ b/torch/csrc/jit/fuser/interface.h
@@ -32,6 +32,9 @@ TORCH_API bool canFuseOnGPU();
 // flakiness)
 TORCH_API void overrideCanFuseOnCPU(bool value);
 
+// Sets whether fusion on the GPU is allowed (enabled by default)
+TORCH_API void overrideCanFuseOnGPU(bool value);
+
 // Treats the given graph as a fusion group and launches it on the
 // specified device with the given inputs.
 // Returns the outputs.

--- a/torch/csrc/jit/init.cpp
+++ b/torch/csrc/jit/init.cpp
@@ -321,6 +321,7 @@ void initJITBindings(PyObject* module) {
       .def("_jit_pass_decompose_ops", DecomposeOps)
       .def("_jit_pass_specialize_autogradzero", specializeAutogradZero)
       .def("_jit_override_can_fuse_on_cpu", &overrideCanFuseOnCPU)
+      .def("_jit_override_can_fuse_on_gpu", &overrideCanFuseOnGPU)
       .def(
           "_jit_differentiate",
           [](Graph& g) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#33395 [Fuser] Add a knob for disabling/enabling CUDA fuser.**

By default the GPU fuser stays enabled, but this function allows to
manually disable it. It will be useful for working on other
implementations of fuser.

Differential Revision: [D19926911](https://our.internmc.facebook.com/intern/diff/D19926911)