### PR TITLE
add cdf to mixture of same family

### DIFF
--- a/torch/distributions/mixture_same_family.py
+++ b/torch/distributions/mixture_same_family.py
@@ -135,12 +135,19 @@ class MixtureSameFamily(Distribution):
                                   dim=-1 - self._event_ndims)
         return mean_cond_var + var_cond_mean
 
+    def cdf(self, x):
+        x = self._pad(x)
+        cdf_x = self.component_distribution.cdf(x)
+        mix_prob = self.mixture_distribution.probs
+
+        return torch.sum(cdf_x * mix_prob[None], dim=-1)
+
     def log_prob(self, x):
         x = self._pad(x)
         log_prob_x = self.component_distribution.log_prob(x)  # [S, B, k]
         log_mix_prob = torch.log_softmax(self.mixture_distribution.logits,
                                          dim=-1)  # [B, k]
-        return torch.logsumexp(log_prob_x + log_mix_prob, dim=-1)  # [S, B]
+        return torch.logsumexp(log_prob_x + log_mix_prob[None], dim=-1)  # [S, B]
 
     def sample(self, sample_shape=torch.Size()):
         with torch.no_grad():


### PR DESCRIPTION
The new added mixture_same_family should support cdf if the family has cdf implemented.

This is very useful for flow models where cdf of mixture of gassian/logistic is used to model flow
Also, make broadcasting less ambiguous.