### PR TITLE
[caffe2] make fused rowwise quant/dequant op work for N-dim tensors

### DIFF
--- a/caffe2/operators/fused_rowwise_8bit_conversion_ops.cc
+++ b/caffe2/operators/fused_rowwise_8bit_conversion_ops.cc
@@ -32,7 +32,8 @@ OPERATOR_SCHEMA(FloatToFused8BitRowwiseQuantized)
                                 const vector<TensorShape>& in) {
       vector<TensorShape> out;
       TensorShape X = in[0];
-      X.set_dims(1, X.dims(1) + 8);
+      X.set_dims(
+          X.dims().size() - 1, X.dims(X.dims().size() - 1) + 2 * sizeof(float));
       out.push_back(std::move(X));
       out[0].set_data_type(TensorProto_DataType_UINT8);
       return out;
@@ -45,7 +46,11 @@ matrix, and then scaling each element to an 8-bit number between 0 and
 (bias) are stored alongside the data. More precisely, each row contains
 int8 elements for each quantized element, and the last 8 bytes
 of each row in the output matrix are a float storing the scale
-followed by another float containing the scale.)
+followed by another float containing the scale.
+For N-dimensional input tensor, the first N-1 dimensions are interpreted as
+rows and the last dimension is interpreted as a column. For example, an
+input tensor with dimension 5x2x4 is interpreted as 10 rows and 4 columns.
+)
 )DOC")
     .Input(0, "input", "Float32 input data")
     .Output(0, "output", "Fused scale, bias and quantized data");
@@ -66,7 +71,9 @@ OPERATOR_SCHEMA(FloatToFused8BitRowwiseQuantizedHalfScaleBias)
                                 const vector<TensorShape>& in) {
       vector<TensorShape> out;
       TensorShape X = in[0];
-      X.set_dims(1, X.dims(1) + 4);
+      X.set_dims(
+          X.dims().size() - 1,
+          X.dims(X.dims().size() - 1) + 2 * sizeof(at::Half));
       out.push_back(std::move(X));
       out[0].set_data_type(TensorProto_DataType_UINT8);
       return out;
@@ -100,7 +107,8 @@ OPERATOR_SCHEMA(HalfFloatToFused8BitRowwiseQuantized)
                                 const vector<TensorShape>& in) {
       vector<TensorShape> out;
       TensorShape X = in[0];
-      X.set_dims(1, X.dims(1) + 8);
+      X.set_dims(
+          X.dims().size() - 1, X.dims(X.dims().size() - 1) + 2 * sizeof(float));
       out.push_back(std::move(X));
       out[0].set_data_type(TensorProto_DataType_UINT8);
       return out;
@@ -134,7 +142,9 @@ OPERATOR_SCHEMA(HalfFloatToFused8BitRowwiseQuantizedHalfScaleBias)
                                 const vector<TensorShape>& in) {
       vector<TensorShape> out;
       TensorShape X = in[0];
-      X.set_dims(1, X.dims(1) + 4);
+      X.set_dims(
+          X.dims().size() - 1,
+          X.dims(X.dims().size() - 1) + 2 * sizeof(at::Half));
       out.push_back(std::move(X));
       out[0].set_data_type(TensorProto_DataType_UINT8);
       return out;
@@ -168,7 +178,8 @@ OPERATOR_SCHEMA(Fused8BitRowwiseQuantizedToFloat)
                                 const vector<TensorShape>& in) {
       vector<TensorShape> out;
       TensorShape X = in[0];
-      X.set_dims(1, X.dims(1) - 8);
+      X.set_dims(
+          X.dims().size() - 1, X.dims(X.dims().size() - 1) - 2 * sizeof(float));
       out.push_back(std::move(X));
       out[0].set_data_type(TensorProto_DataType_FLOAT);
       return out;
@@ -206,7 +217,9 @@ OPERATOR_SCHEMA(Fused8BitRowwiseQuantizedHalfScaleBiasToFloat)
                                 const vector<TensorShape>& in) {
       vector<TensorShape> out;
       TensorShape X = in[0];
-      X.set_dims(1, X.dims(1) - 4);
+      X.set_dims(
+          X.dims().size() - 1,
+          X.dims(X.dims().size() - 1) - 2 * sizeof(at::Half));
       out.push_back(std::move(X));
       out[0].set_data_type(TensorProto_DataType_FLOAT);
       return out;
@@ -244,7 +257,8 @@ OPERATOR_SCHEMA(Fused8BitRowwiseQuantizedToHalfFloat)
                                 const vector<TensorShape>& in) {
       vector<TensorShape> out;
       TensorShape X = in[0];
-      X.set_dims(1, X.dims(1) - 8);
+      X.set_dims(
+          X.dims().size() - 1, X.dims(X.dims().size() - 1) - 2 * sizeof(float));
       out.push_back(std::move(X));
       out[0].set_data_type(TensorProto_DataType_FLOAT16);
       return out;
@@ -282,7 +296,9 @@ OPERATOR_SCHEMA(Fused8BitRowwiseQuantizedHalfScaleBiasToHalfFloat)
                                 const vector<TensorShape>& in) {
       vector<TensorShape> out;
       TensorShape X = in[0];
-      X.set_dims(1, X.dims(1) - 4);
+      X.set_dims(
+          X.dims().size() - 1,
+          X.dims(X.dims().size() - 1) - 2 * sizeof(at::Half));
       out.push_back(std::move(X));
       out[0].set_data_type(TensorProto_DataType_FLOAT);
       return out;

--- a/caffe2/python/fused_8bit_rowwise_conversion_ops_test.py
+++ b/caffe2/python/fused_8bit_rowwise_conversion_ops_test.py
@@ -35,28 +35,33 @@ def floats_to_bytes(floats):
 
 
 def fused_rowwise_8bit_quantize_reference(data):
-    minimum = np.min(data, axis=1, keepdims=True)
-    maximum = np.max(data, axis=1, keepdims=True)
+    minimum = np.min(data, axis=-1, keepdims=True)
+    maximum = np.max(data, axis=-1, keepdims=True)
     span = maximum - minimum
     bias = minimum
     scale = span / 255.0
     inverse_scale = 255.0 / (span + 1e-8)
     quantized_data = round_to_nearest((data - bias) * inverse_scale)
     scale_bytes = floats_to_bytes(scale.reshape(-1))
+    scale_bytes = scale_bytes.reshape(data.shape[:-1] + (scale_bytes.shape[-1],))
     bias_bytes = floats_to_bytes(bias.reshape(-1))
-    return np.concatenate([quantized_data, scale_bytes, bias_bytes], axis=1)
+    bias_bytes = bias_bytes.reshape(data.shape[:-1] + (bias_bytes.shape[-1],))
+    print(quantized_data.shape, scale.shape, scale_bytes.shape, bias.shape, bias_bytes.shape)
+    return np.concatenate([quantized_data, scale_bytes, bias_bytes], axis=-1)
 
 
 def fused_rowwise_8bit_quantize_dequantize_reference(data):
     fused_quantized = fused_rowwise_8bit_quantize_reference(data)
-    scale = bytes_to_floats(fused_quantized[:, -8:-4].astype(np.uint8))
-    bias = bytes_to_floats(fused_quantized[:, -4:].astype(np.uint8))
-    quantized_data = fused_quantized[:, :-8]
+    scale = bytes_to_floats(fused_quantized[..., -8:-4].astype(np.uint8).reshape(-1, 4))
+    scale = scale.reshape(fused_quantized.shape[:-1] + (scale.shape[-1],))
+    bias = bytes_to_floats(fused_quantized[..., -4:].astype(np.uint8).reshape(-1, 4))
+    bias = bias.reshape(fused_quantized.shape[:-1] + (bias.shape[-1],))
+    quantized_data = fused_quantized[..., :-8]
     return quantized_data * scale + bias
 
 
 class TestFused8BitRowwiseQuantizationConversion(hu.HypothesisTestCase):
-    @given(input_data=hu.tensor(min_dim=2, max_dim=2, max_value=33))
+    @given(input_data=hu.tensor(min_dim=1, max_dim=3, max_value=33))
     def test_quantize_op(self, input_data):
         quantize = core.CreateOperator(
             'FloatToFused8BitRowwiseQuantized',
@@ -73,7 +78,7 @@ class TestFused8BitRowwiseQuantizationConversion(hu.HypothesisTestCase):
         )
         np.testing.assert_array_almost_equal(quantized_data, reference)
 
-    @given(input_data=hu.tensor(min_dim=2, max_dim=2, max_value=33))
+    @given(input_data=hu.tensor(min_dim=1, max_dim=3, max_value=33))
     def test_quantize_and_dequantize_op(self, input_data):
         quantize = core.CreateOperator(
             'FloatToFused8BitRowwiseQuantized',


### PR DESCRIPTION
Summary: Make 2/4/8-bit fused rowwise conversion operators more general to work for N-dim tensors

Test Plan: CI

Differential Revision: D19943136

