### PR TITLE
Fix deprecated python "add" calls 

### DIFF
--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -185,7 +185,7 @@ In-place version of :meth:`~Tensor.acos`
 add_docstr_all('add',
                r"""
 add(value) -> Tensor
-add(other, *, value=1) -> Tensor
+add(other, *, alpha=1) -> Tensor
 
 See :func:`torch.add`
 """)
@@ -193,7 +193,7 @@ See :func:`torch.add`
 add_docstr_all('add_',
                r"""
 add_(value) -> Tensor
-add_(other, *, value=1) -> Tensor
+add_(other, *, alpha=1) -> Tensor
 
 In-place version of :meth:`~Tensor.add`
 """)

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -184,7 +184,7 @@ In-place version of :meth:`~Tensor.acos`
 
 add_docstr_all('add',
                r"""
-add(value) -> Tensor
+add(other) -> Tensor
 add(other, *, alpha=1) -> Tensor
 
 See :func:`torch.add`
@@ -192,7 +192,7 @@ See :func:`torch.add`
 
 add_docstr_all('add_',
                r"""
-add_(value) -> Tensor
+add_(other) -> Tensor
 add_(other, *, alpha=1) -> Tensor
 
 In-place version of :meth:`~Tensor.add`

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -184,15 +184,21 @@ In-place version of :meth:`~Tensor.acos`
 
 add_docstr_all('add',
                r"""
-add(other) -> Tensor
 add(other, *, alpha=1) -> Tensor
+
+Add a scalar or tensor to :attr:`self` tensor. If both :attr:`alpha`
+and :attr:`other` are specified, each element of :attr:`other` is scaled by
+:attr:`alpha` before being used.
+
+When :attr:`other` is a tensor, the shape of :attr:`other` must be
+:ref:`broadcastable <broadcasting-semantics>` with the shape of the underlying
+tensor
 
 See :func:`torch.add`
 """)
 
 add_docstr_all('add_',
                r"""
-add_(other) -> Tensor
 add_(other, *, alpha=1) -> Tensor
 
 In-place version of :meth:`~Tensor.add`
@@ -2727,7 +2733,7 @@ tensor.
 
 add_docstr_all('sub_',
                r"""
-sub_(x, *, alpha=1) -> Tensor
+sub_(other, *, alpha=1) -> Tensor
 
 In-place version of :meth:`~Tensor.sub`
 """)

--- a/torch/nn/modules/_functions.py
+++ b/torch/nn/modules/_functions.py
@@ -153,11 +153,11 @@ class CrossMapLRN2d(Function):
             scale_current.copy_(scale_previous)
             if c < channels - pre_pad + 1:
                 square_next = input_square.select(1, c + pre_pad - 1)
-                scale_current.add_(1, square_next)
+                scale_current.add_(square_next, alpha=1)
 
             if c > pre_pad:
                 square_previous = input_square.select(1, c - pre_pad)
-                scale_current.add_(-1, square_previous)
+                scale_current.add_(square_previous, alpha=-1)
 
         ctx.scale.mul_(ctx.alpha / ctx.size).add_(ctx.k)
 
@@ -199,6 +199,6 @@ class CrossMapLRN2d(Function):
                 accum_ratio.add_(paddded_ratio[c + ctx.size - 1])
                 grad_input[n][c].addcmul_(-cache_ratio_value, input[n][c],
                                           accum_ratio)
-                accum_ratio.add_(-1, paddded_ratio[c])
+                accum_ratio.add_(paddded_ratio[c], alpha=-1)
 
         return grad_input, None, None, None, None

--- a/torch/nn/modules/_functions.py
+++ b/torch/nn/modules/_functions.py
@@ -197,8 +197,7 @@ class CrossMapLRN2d(Function):
                 paddded_ratio.narrow(0, 0, ctx.size - 1), 0, keepdim=False, out=accum_ratio)
             for c in range(channels):
                 accum_ratio.add_(paddded_ratio[c + ctx.size - 1])
-                grad_input[n][c].addcmul_(-cache_ratio_value, input[n][c],
-                                          accum_ratio)
+                grad_input[n][c].addcmul_(input[n][c], accum_ratio, value=-cache_ratio_value)
                 accum_ratio.add_(paddded_ratio[c], alpha=-1)
 
         return grad_input, None, None, None, None

--- a/torch/optim/adadelta.py
+++ b/torch/optim/adadelta.py
@@ -69,10 +69,10 @@ class Adadelta(Optimizer):
                 if group['weight_decay'] != 0:
                     grad = grad.add(p.data, alpha=group['weight_decay'])
 
-                square_avg.mul_(rho).addcmul_(1 - rho, grad, grad)
+                square_avg.mul_(rho).addcmul_(grad, grad, value=1 - rho)
                 std = square_avg.add(eps).sqrt_()
                 delta = acc_delta.add(eps).sqrt_().div_(std).mul_(grad)
                 p.data.add_(delta, alpha=-group['lr'])
-                acc_delta.mul_(rho).addcmul_(1 - rho, delta, delta)
+                acc_delta.mul_(rho).addcmul_(delta, delta, value=1 - rho)
 
         return loss

--- a/torch/optim/adadelta.py
+++ b/torch/optim/adadelta.py
@@ -67,12 +67,12 @@ class Adadelta(Optimizer):
                 state['step'] += 1
 
                 if group['weight_decay'] != 0:
-                    grad = grad.add(group['weight_decay'], p.data)
+                    grad = grad.add(p.data, alpha=group['weight_decay'])
 
                 square_avg.mul_(rho).addcmul_(1 - rho, grad, grad)
                 std = square_avg.add(eps).sqrt_()
                 delta = acc_delta.add(eps).sqrt_().div_(std).mul_(grad)
-                p.data.add_(-group['lr'], delta)
+                p.data.add_(delta, alpha=-group['lr'])
                 acc_delta.mul_(rho).addcmul_(1 - rho, delta, delta)
 
         return loss

--- a/torch/optim/adagrad.py
+++ b/torch/optim/adagrad.py
@@ -95,6 +95,6 @@ class Adagrad(Optimizer):
                 else:
                     state['sum'].addcmul_(grad, grad, value=1)
                     std = state['sum'].sqrt().add_(group['eps'])
-                    p.data.addcdiv_(-clr, grad, std)
+                    p.data.addcdiv_(grad, std, value=-clr)
 
         return loss

--- a/torch/optim/adagrad.py
+++ b/torch/optim/adagrad.py
@@ -73,7 +73,7 @@ class Adagrad(Optimizer):
                 if group['weight_decay'] != 0:
                     if p.grad.data.is_sparse:
                         raise RuntimeError("weight_decay option is not compatible with sparse gradients")
-                    grad = grad.add(group['weight_decay'], p.data)
+                    grad = grad.add(p.data, alpha=group['weight_decay'])
 
                 clr = group['lr'] / (1 + (state['step'] - 1) * group['lr_decay'])
 
@@ -91,7 +91,7 @@ class Adagrad(Optimizer):
                     state['sum'].add_(make_sparse(grad_values.pow(2)))
                     std = state['sum'].sparse_mask(grad)
                     std_values = std._values().sqrt_().add_(group['eps'])
-                    p.data.add_(-clr, make_sparse(grad_values / std_values))
+                    p.data.add_(make_sparse(grad_values / std_values), alpha=-clr)
                 else:
                     state['sum'].addcmul_(1, grad, grad)
                     std = state['sum'].sqrt().add_(group['eps'])

--- a/torch/optim/adagrad.py
+++ b/torch/optim/adagrad.py
@@ -93,7 +93,7 @@ class Adagrad(Optimizer):
                     std_values = std._values().sqrt_().add_(group['eps'])
                     p.data.add_(make_sparse(grad_values / std_values), alpha=-clr)
                 else:
-                    state['sum'].addcmul_(1, grad, grad)
+                    state['sum'].addcmul_(grad, grad, value=1)
                     std = state['sum'].sqrt().add_(group['eps'])
                     p.data.addcdiv_(-clr, grad, std)
 

--- a/torch/optim/adam.py
+++ b/torch/optim/adam.py
@@ -104,6 +104,6 @@ class Adam(Optimizer):
 
                 step_size = group['lr'] / bias_correction1
 
-                p.data.addcdiv_(-step_size, exp_avg, denom)
+                p.data.addcdiv_(exp_avg, denom, value=-step_size)
 
         return loss

--- a/torch/optim/adam.py
+++ b/torch/optim/adam.py
@@ -89,10 +89,10 @@ class Adam(Optimizer):
                 bias_correction2 = 1 - beta2 ** state['step']
 
                 if group['weight_decay'] != 0:
-                    grad = grad.add(group['weight_decay'], p.data)
+                    grad = grad.add(p.data, alpha=group['weight_decay'])
 
                 # Decay the first and second moment running average coefficient
-                exp_avg.mul_(beta1).add_(1 - beta1, grad)
+                exp_avg.mul_(beta1).add_(grad, alpha=1 - beta1)
                 exp_avg_sq.mul_(beta2).addcmul_(1 - beta2, grad, grad)
                 if amsgrad:
                     # Maintains the maximum of all 2nd moment running avg. till now

--- a/torch/optim/adam.py
+++ b/torch/optim/adam.py
@@ -93,7 +93,7 @@ class Adam(Optimizer):
 
                 # Decay the first and second moment running average coefficient
                 exp_avg.mul_(beta1).add_(grad, alpha=1 - beta1)
-                exp_avg_sq.mul_(beta2).addcmul_(1 - beta2, grad, grad)
+                exp_avg_sq.mul_(beta2).addcmul_(grad, grad, value=1 - beta2)
                 if amsgrad:
                     # Maintains the maximum of all 2nd moment running avg. till now
                     torch.max(max_exp_avg_sq, exp_avg_sq, out=max_exp_avg_sq)

--- a/torch/optim/adamax.py
+++ b/torch/optim/adamax.py
@@ -69,10 +69,10 @@ class Adamax(Optimizer):
                 state['step'] += 1
 
                 if group['weight_decay'] != 0:
-                    grad = grad.add(group['weight_decay'], p.data)
+                    grad = grad.add(p.data, alpha=group['weight_decay'])
 
                 # Update biased first moment estimate.
-                exp_avg.mul_(beta1).add_(1 - beta1, grad)
+                exp_avg.mul_(beta1).add_(grad, alpha=1 - beta1)
                 # Update the exponentially weighted infinity norm.
                 norm_buf = torch.cat([
                     exp_inf.mul_(beta2).unsqueeze(0),

--- a/torch/optim/adamax.py
+++ b/torch/optim/adamax.py
@@ -83,6 +83,6 @@ class Adamax(Optimizer):
                 bias_correction = 1 - beta1 ** state['step']
                 clr = group['lr'] / bias_correction
 
-                p.data.addcdiv_(-clr, exp_avg, exp_inf)
+                p.data.addcdiv_(exp_avg, exp_inf, value=-clr)
 
         return loss

--- a/torch/optim/adamw.py
+++ b/torch/optim/adamw.py
@@ -98,7 +98,7 @@ class AdamW(Optimizer):
 
                 # Decay the first and second moment running average coefficient
                 exp_avg.mul_(beta1).add_(grad, alpha=1 - beta1)
-                exp_avg_sq.mul_(beta2).addcmul_(1 - beta2, grad, grad)
+                exp_avg_sq.mul_(beta2).addcmul_(grad, grad, value=1 - beta2)
                 if amsgrad:
                     # Maintains the maximum of all 2nd moment running avg. till now
                     torch.max(max_exp_avg_sq, exp_avg_sq, out=max_exp_avg_sq)

--- a/torch/optim/adamw.py
+++ b/torch/optim/adamw.py
@@ -109,6 +109,6 @@ class AdamW(Optimizer):
 
                 step_size = group['lr'] / bias_correction1
 
-                p.data.addcdiv_(-step_size, exp_avg, denom)
+                p.data.addcdiv_(exp_avg, denom, value=-step_size)
 
         return loss

--- a/torch/optim/adamw.py
+++ b/torch/optim/adamw.py
@@ -97,7 +97,7 @@ class AdamW(Optimizer):
                 bias_correction2 = 1 - beta2 ** state['step']
 
                 # Decay the first and second moment running average coefficient
-                exp_avg.mul_(beta1).add_(1 - beta1, grad)
+                exp_avg.mul_(beta1).add_(grad, alpha=1 - beta1)
                 exp_avg_sq.mul_(beta2).addcmul_(1 - beta2, grad, grad)
                 if amsgrad:
                     # Maintains the maximum of all 2nd moment running avg. till now

--- a/torch/optim/asgd.py
+++ b/torch/optim/asgd.py
@@ -62,13 +62,13 @@ class ASGD(Optimizer):
                 state['step'] += 1
 
                 if group['weight_decay'] != 0:
-                    grad = grad.add(group['weight_decay'], p.data)
+                    grad = grad.add(p.data, alpha=group['weight_decay'])
 
                 # decay term
                 p.data.mul_(1 - group['lambd'] * state['eta'])
 
                 # update parameter
-                p.data.add_(-state['eta'], grad)
+                p.data.add_(grad, alpha=-state['eta'])
 
                 # averaging
                 if state['mu'] != 1:

--- a/torch/optim/lbfgs.py
+++ b/torch/optim/lbfgs.py
@@ -261,7 +261,7 @@ class LBFGS(Optimizer):
         for p in self._params:
             numel = p.numel()
             # view as to avoid deprecated pointwise semantics
-            p.data.add_(step_size, update[offset:offset + numel].view_as(p.data))
+            p.data.add_(update[offset:offset + numel].view_as(p.data), alpha=step_size)
             offset += numel
         assert offset == self._numel()
 
@@ -375,14 +375,14 @@ class LBFGS(Optimizer):
                 q = flat_grad.neg()
                 for i in range(num_old - 1, -1, -1):
                     al[i] = old_stps[i].dot(q) * ro[i]
-                    q.add_(-al[i], old_dirs[i])
+                    q.add_(old_dirs[i], alpha=-al[i])
 
                 # multiply by initial Hessian
                 # r/d is the final direction
                 d = r = torch.mul(q, H_diag)
                 for i in range(num_old):
                     be_i = old_dirs[i].dot(r) * ro[i]
-                    r.add_(al[i] - be_i, old_stps[i])
+                    r.add_(old_stps[i], alpha=al[i] - be_i)
 
             if prev_flat_grad is None:
                 prev_flat_grad = flat_grad.clone(memory_format=torch.contiguous_format)

--- a/torch/optim/rmsprop.py
+++ b/torch/optim/rmsprop.py
@@ -103,6 +103,6 @@ class RMSprop(Optimizer):
                     buf.mul_(group['momentum']).addcdiv_(grad, avg)
                     p.data.add_(buf, alpha=-group['lr'])
                 else:
-                    p.data.addcdiv_(-group['lr'], grad, avg)
+                    p.data.addcdiv_(grad, avg, value=-group['lr'])
 
         return loss

--- a/torch/optim/rmsprop.py
+++ b/torch/optim/rmsprop.py
@@ -87,13 +87,13 @@ class RMSprop(Optimizer):
                 state['step'] += 1
 
                 if group['weight_decay'] != 0:
-                    grad = grad.add(group['weight_decay'], p.data)
+                    grad = grad.add(p.data, alpha=group['weight_decay'])
 
                 square_avg.mul_(alpha).addcmul_(1 - alpha, grad, grad)
 
                 if group['centered']:
                     grad_avg = state['grad_avg']
-                    grad_avg.mul_(alpha).add_(1 - alpha, grad)
+                    grad_avg.mul_(alpha).add_(grad, alpha=1 - alpha)
                     avg = square_avg.addcmul(-1, grad_avg, grad_avg).sqrt_().add_(group['eps'])
                 else:
                     avg = square_avg.sqrt().add_(group['eps'])
@@ -101,7 +101,7 @@ class RMSprop(Optimizer):
                 if group['momentum'] > 0:
                     buf = state['momentum_buffer']
                     buf.mul_(group['momentum']).addcdiv_(grad, avg)
-                    p.data.add_(-group['lr'], buf)
+                    p.data.add_(buf, alpha=-group['lr'])
                 else:
                     p.data.addcdiv_(-group['lr'], grad, avg)
 

--- a/torch/optim/rmsprop.py
+++ b/torch/optim/rmsprop.py
@@ -89,12 +89,12 @@ class RMSprop(Optimizer):
                 if group['weight_decay'] != 0:
                     grad = grad.add(p.data, alpha=group['weight_decay'])
 
-                square_avg.mul_(alpha).addcmul_(1 - alpha, grad, grad)
+                square_avg.mul_(alpha).addcmul_(grad, grad, value=1 - alpha)
 
                 if group['centered']:
                     grad_avg = state['grad_avg']
                     grad_avg.mul_(alpha).add_(grad, alpha=1 - alpha)
-                    avg = square_avg.addcmul(-1, grad_avg, grad_avg).sqrt_().add_(group['eps'])
+                    avg = square_avg.addcmul(grad_avg, grad_avg, value=-1).sqrt_().add_(group['eps'])
                 else:
                     avg = square_avg.sqrt().add_(group['eps'])
 

--- a/torch/optim/rprop.py
+++ b/torch/optim/rprop.py
@@ -71,7 +71,7 @@ class Rprop(Optimizer):
                 grad[sign.eq(etaminus)] = 0
 
                 # update parameters
-                p.data.addcmul_(-1, grad.sign(), step_size)
+                p.data.addcmul_(grad.sign(), step_size, value=-1)
 
                 state['prev'].copy_(grad)
 

--- a/torch/optim/sgd.py
+++ b/torch/optim/sgd.py
@@ -94,19 +94,19 @@ class SGD(Optimizer):
                     continue
                 d_p = p.grad.data
                 if weight_decay != 0:
-                    d_p = d_p.add(weight_decay, p.data)
+                    d_p = d_p.add(p.data, alpha=weight_decay)
                 if momentum != 0:
                     param_state = self.state[p]
                     if 'momentum_buffer' not in param_state:
                         buf = param_state['momentum_buffer'] = torch.clone(d_p).detach()
                     else:
                         buf = param_state['momentum_buffer']
-                        buf.mul_(momentum).add_(1 - dampening, d_p)
+                        buf.mul_(momentum).add_(d_p, alpha=1 - dampening)
                     if nesterov:
-                        d_p = d_p.add(momentum, buf)
+                        d_p = d_p.add(buf, alpha=momentum)
                     else:
                         d_p = buf
 
-                p.data.add_(-group['lr'], d_p)
+                p.data.add_(d_p, alpha=-group['lr'])
 
         return loss


### PR DESCRIPTION
This PR fixed those python "add" calls using deprecated signature `add(Scalar, Tensor)`. The alternative signature `add(Tensor, alpha = Scalar)` is used. 

cc @csarofeen @zasdfgbnm @ptrblck @ngimel 

Fixes #33801