### PR TITLE
[C++ API Parity] rmsprop optimizer update

### DIFF
--- a/test/cpp/api/optim.cpp
+++ b/test/cpp/api/optim.cpp
@@ -202,14 +202,14 @@ TEST(OptimTest, XORConvergence_Adagrad) {
       AdagradOptions(1.0).weight_decay(1e-6).lr_decay(1e-3)));
 }
 
-// TEST(OptimTest, XORConvergence_RMSprop) {
-//   ASSERT_TRUE(test_optimizer_xor<RMSprop>(RMSpropOptions(0.1).centered(true)));
-// }
-//
-// TEST(OptimTest, XORConvergence_RMSpropWithMomentum) {
-//   ASSERT_TRUE(test_optimizer_xor<RMSprop>(
-//       RMSpropOptions(0.1).momentum(0.9).weight_decay(1e-6)));
-// }
+TEST(OptimTest, XORConvergence_RMSprop) {
+  ASSERT_TRUE(test_optimizer_xor<RMSprop>(RMSpropOptions(0.1).centered(true)));
+}
+
+TEST(OptimTest, XORConvergence_RMSpropWithMomentum) {
+  ASSERT_TRUE(test_optimizer_xor<RMSprop>(
+      RMSpropOptions(0.1).momentum(0.9).weight_decay(1e-6)));
+}
 
 TEST(OptimTest, XORConvergence_Adam) {
   ASSERT_TRUE(test_optimizer_xor<Adam>(AdamOptions(0.1).weight_decay(1e-6)));
@@ -253,31 +253,31 @@ TEST(OptimTest, ProducesPyTorchValues_AdagradWithWeightDecayAndLRDecay) {
       expected_parameters::Adagrad_with_weight_decay_and_lr_decay());
 }
 
-// TEST(OptimTest, ProducesPyTorchValues_RMSprop) {
-//   check_exact_values<RMSprop>(
-//       RMSpropOptions(0.1), expected_parameters::RMSprop());
-// }
-//
-// TEST(OptimTest, ProducesPyTorchValues_RMSpropWithWeightDecay) {
-//   check_exact_values<RMSprop>(
-//       RMSpropOptions(0.1).weight_decay(1e-2),
-//       expected_parameters::RMSprop_with_weight_decay());
-// }
-//
-// TEST(OptimTest, ProducesPyTorchValues_RMSpropWithWeightDecayAndCentered) {
-//   check_exact_values<RMSprop>(
-//       RMSpropOptions(0.1).weight_decay(1e-6).centered(true),
-//       expected_parameters::RMSprop_with_weight_decay_and_centered());
-// }
-//
-// TEST(
-//     OptimTest,
-//     ProducesPyTorchValues_RMSpropWithWeightDecayAndCenteredAndMomentum) {
-//   check_exact_values<RMSprop>(
-//       RMSpropOptions(0.1).weight_decay(1e-6).centered(true).momentum(0.9),
-//       expected_parameters::
-//           RMSprop_with_weight_decay_and_centered_and_momentum());
-// }
+TEST(OptimTest, ProducesPyTorchValues_RMSprop) {
+  check_exact_values<RMSprop>(
+      RMSpropOptions(0.1), expected_parameters::RMSprop());
+}
+
+TEST(OptimTest, ProducesPyTorchValues_RMSpropWithWeightDecay) {
+  check_exact_values<RMSprop>(
+      RMSpropOptions(0.1).weight_decay(1e-2),
+      expected_parameters::RMSprop_with_weight_decay());
+}
+
+TEST(OptimTest, ProducesPyTorchValues_RMSpropWithWeightDecayAndCentered) {
+  check_exact_values<RMSprop>(
+      RMSpropOptions(0.1).weight_decay(1e-6).centered(true),
+      expected_parameters::RMSprop_with_weight_decay_and_centered());
+}
+
+TEST(
+    OptimTest,
+    ProducesPyTorchValues_RMSpropWithWeightDecayAndCenteredAndMomentum) {
+  check_exact_values<RMSprop>(
+      RMSpropOptions(0.1).weight_decay(1e-6).centered(true).momentum(0.9),
+      expected_parameters::
+          RMSprop_with_weight_decay_and_centered_and_momentum());
+}
 
 TEST(OptimTest, ProducesPyTorchValues_SGD) {
   check_exact_values<SGD>(SGDOptions(0.1), expected_parameters::SGD());

--- a/test/cpp/api/optim.cpp
+++ b/test/cpp/api/optim.cpp
@@ -202,14 +202,14 @@ TEST(OptimTest, XORConvergence_Adagrad) {
       AdagradOptions(1.0).weight_decay(1e-6).lr_decay(1e-3)));
 }
 
-TEST(OptimTest, XORConvergence_RMSprop) {
-  ASSERT_TRUE(test_optimizer_xor<RMSprop>(RMSpropOptions(0.1).centered(true)));
-}
-
-TEST(OptimTest, XORConvergence_RMSpropWithMomentum) {
-  ASSERT_TRUE(test_optimizer_xor<RMSprop>(
-      RMSpropOptions(0.1).momentum(0.9).weight_decay(1e-6)));
-}
+// TEST(OptimTest, XORConvergence_RMSprop) {
+//   ASSERT_TRUE(test_optimizer_xor<RMSprop>(RMSpropOptions(0.1).centered(true)));
+// }
+//
+// TEST(OptimTest, XORConvergence_RMSpropWithMomentum) {
+//   ASSERT_TRUE(test_optimizer_xor<RMSprop>(
+//       RMSpropOptions(0.1).momentum(0.9).weight_decay(1e-6)));
+// }
 
 TEST(OptimTest, XORConvergence_Adam) {
   ASSERT_TRUE(test_optimizer_xor<Adam>(AdamOptions(0.1).weight_decay(1e-6)));
@@ -253,31 +253,31 @@ TEST(OptimTest, ProducesPyTorchValues_AdagradWithWeightDecayAndLRDecay) {
       expected_parameters::Adagrad_with_weight_decay_and_lr_decay());
 }
 
-TEST(OptimTest, ProducesPyTorchValues_RMSprop) {
-  check_exact_values<RMSprop>(
-      RMSpropOptions(0.1), expected_parameters::RMSprop());
-}
-
-TEST(OptimTest, ProducesPyTorchValues_RMSpropWithWeightDecay) {
-  check_exact_values<RMSprop>(
-      RMSpropOptions(0.1).weight_decay(1e-2),
-      expected_parameters::RMSprop_with_weight_decay());
-}
-
-TEST(OptimTest, ProducesPyTorchValues_RMSpropWithWeightDecayAndCentered) {
-  check_exact_values<RMSprop>(
-      RMSpropOptions(0.1).weight_decay(1e-6).centered(true),
-      expected_parameters::RMSprop_with_weight_decay_and_centered());
-}
-
-TEST(
-    OptimTest,
-    ProducesPyTorchValues_RMSpropWithWeightDecayAndCenteredAndMomentum) {
-  check_exact_values<RMSprop>(
-      RMSpropOptions(0.1).weight_decay(1e-6).centered(true).momentum(0.9),
-      expected_parameters::
-          RMSprop_with_weight_decay_and_centered_and_momentum());
-}
+// TEST(OptimTest, ProducesPyTorchValues_RMSprop) {
+//   check_exact_values<RMSprop>(
+//       RMSpropOptions(0.1), expected_parameters::RMSprop());
+// }
+//
+// TEST(OptimTest, ProducesPyTorchValues_RMSpropWithWeightDecay) {
+//   check_exact_values<RMSprop>(
+//       RMSpropOptions(0.1).weight_decay(1e-2),
+//       expected_parameters::RMSprop_with_weight_decay());
+// }
+//
+// TEST(OptimTest, ProducesPyTorchValues_RMSpropWithWeightDecayAndCentered) {
+//   check_exact_values<RMSprop>(
+//       RMSpropOptions(0.1).weight_decay(1e-6).centered(true),
+//       expected_parameters::RMSprop_with_weight_decay_and_centered());
+// }
+//
+// TEST(
+//     OptimTest,
+//     ProducesPyTorchValues_RMSpropWithWeightDecayAndCenteredAndMomentum) {
+//   check_exact_values<RMSprop>(
+//       RMSpropOptions(0.1).weight_decay(1e-6).centered(true).momentum(0.9),
+//       expected_parameters::
+//           RMSprop_with_weight_decay_and_centered_and_momentum());
+// }
 
 TEST(OptimTest, ProducesPyTorchValues_SGD) {
   check_exact_values<SGD>(SGDOptions(0.1), expected_parameters::SGD());

--- a/test/cpp/api/serialize.cpp
+++ b/test/cpp/api/serialize.cpp
@@ -136,7 +136,7 @@ void test_serialize_optimizer(DerivedOptimizerOptions options) {
   for (int i = 0; i < optim3_2_param_groups.size(); i++) {
     is_optimizer_param_group_equal<DerivedOptimizerOptions>(
       optim3_2_param_groups[i], optim3_param_groups[i]);
-    is_optimizer_state_equal<DerivedOptimizerParamState>(optim3_2_state, optim3_state);
+    //is_optimizer_state_equal<DerivedOptimizerParamState>(optim3_2_state, optim3_state);
   }
 
   // Do step2 for model 3

--- a/test/cpp/api/serialize.cpp
+++ b/test/cpp/api/serialize.cpp
@@ -603,6 +603,51 @@ TEST(SerializeTest, Optim_Adam) {
   is_optimizer_state_equal<AdamParamState>(optim1.state(), optim1_2.state());
 }
 
+TEST(SerializeTest, Optim_RMSprop) {
+  test_serialize_optimizer<RMSprop, RMSpropOptions, RMSpropParamState>(RMSpropOptions(0.1).momentum(0.9));
+
+  // bc compatibility check
+  auto model1 = Linear(5, 2);
+  auto model1_params = model1->parameters();
+  // added a tensor for lazy init check - when all params do not have a momentum buffer entry
+  model1_params.emplace_back(torch::randn({2,3}));
+  auto optim1 = torch::optim::RMSprop(model1_params, torch::optim::RMSpropOptions(0.1).momentum(0.9));
+
+  auto x = torch::ones({10, 5});
+  auto step = [&x](torch::optim::Optimizer& optimizer, Linear model) {
+    optimizer.zero_grad();
+    auto y = model->forward(x).sum();
+    y.backward();
+    optimizer.step();
+  };
+  step(optim1, model1);
+
+  std::vector<at::Tensor> square_average_buffers;
+  std::vector<at::Tensor> momentum_buffers;
+  std::vector<at::Tensor> grad_average_buffers;
+  const auto& params_ = optim1.param_groups()[0].params();
+  const auto& optim1_state = optim1.state();
+  for (size_t i = 0; i < params_.size(); i++) {
+    if(i != (params_.size() - 1)) {
+      auto key_ = c10::guts::to_string(params_[i].unsafeGetTensorImpl());
+      const RMSpropParamState& curr_state_ = static_cast<const RMSpropParamState&>(*(optim1_state.at(key_).get()));
+      square_average_buffers.emplace_back(curr_state_.square_avg());
+      momentum_buffers.emplace_back(curr_state_.momentum_buffer());
+      grad_average_buffers.emplace_back(curr_state_.grad_avg());
+    }
+  }
+  // write momentum_buffers to the file
+  auto optim_tempfile_old_format = c10::make_tempfile();
+  torch::serialize::OutputArchive output_archive;
+  write_tensors_to_archive(output_archive, "square_average_buffers", square_average_buffers);
+  write_tensors_to_archive(output_archive, "momentum_buffers", momentum_buffers);
+  write_tensors_to_archive(output_archive, "grad_average_buffers", momentum_buffers);
+  output_archive.save_to(optim_tempfile_old_format.name);
+  auto optim1_2 = RMSprop(model1_params, torch::optim::RMSpropOptions(0.1).momentum(0.9));
+  OLD_SERIALIZATION_LOGIC_WARNING_CHECK(torch::load, optim1_2, optim_tempfile_old_format.name);
+  is_optimizer_state_equal<RMSpropParamState>(optim1.state(), optim1_2.state());
+}
+
 TEST(SerializeTest, XOR_CUDA) {
   torch::manual_seed(0);
   // We better be able to save and load a XOR model!

--- a/test/cpp/api/serialize.cpp
+++ b/test/cpp/api/serialize.cpp
@@ -136,7 +136,7 @@ void test_serialize_optimizer(DerivedOptimizerOptions options) {
   for (int i = 0; i < optim3_2_param_groups.size(); i++) {
     is_optimizer_param_group_equal<DerivedOptimizerOptions>(
       optim3_2_param_groups[i], optim3_param_groups[i]);
-    //is_optimizer_state_equal<DerivedOptimizerParamState>(optim3_2_state, optim3_state);
+    is_optimizer_state_equal<DerivedOptimizerParamState>(optim3_2_state, optim3_state);
   }
 
   // Do step2 for model 3
@@ -561,7 +561,7 @@ TEST(SerializeTest, Optim_Adam) {
   auto model1_params = model1->parameters();
   // added a tensor for lazy init check - when all params do not have entry in buffers
   model1_params.emplace_back(torch::randn({2,3}));
-  auto optim1 = torch::optim::Adam(model1_params, torch::optim::AdamOptions());
+  auto optim1 = torch::optim::Adam(model1_params, torch::optim::AdamOptions().weight_decay(0.5));
 
   auto x = torch::ones({10, 5});
   auto step = [&x](torch::optim::Optimizer& optimizer, Linear model) {
@@ -604,14 +604,16 @@ TEST(SerializeTest, Optim_Adam) {
 }
 
 TEST(SerializeTest, Optim_RMSprop) {
-  test_serialize_optimizer<RMSprop, RMSpropOptions, RMSpropParamState>(RMSpropOptions(0.1).momentum(0.9));
+  auto options = RMSpropOptions(0.1).momentum(0.9).centered(true);
+  test_serialize_optimizer<RMSprop, RMSpropOptions, RMSpropParamState>(options);
 
   // bc compatibility check
   auto model1 = Linear(5, 2);
   auto model1_params = model1->parameters();
+
   // added a tensor for lazy init check - when all params do not have a momentum buffer entry
   model1_params.emplace_back(torch::randn({2,3}));
-  auto optim1 = torch::optim::RMSprop(model1_params, torch::optim::RMSpropOptions(0.1).momentum(0.9));
+  auto optim1 = torch::optim::RMSprop(model1_params, options);
 
   auto x = torch::ones({10, 5});
   auto step = [&x](torch::optim::Optimizer& optimizer, Linear model) {
@@ -632,19 +634,35 @@ TEST(SerializeTest, Optim_RMSprop) {
       auto key_ = c10::guts::to_string(params_[i].unsafeGetTensorImpl());
       const RMSpropParamState& curr_state_ = static_cast<const RMSpropParamState&>(*(optim1_state.at(key_).get()));
       square_average_buffers.emplace_back(curr_state_.square_avg());
-      momentum_buffers.emplace_back(curr_state_.momentum_buffer());
-      grad_average_buffers.emplace_back(curr_state_.grad_avg());
+      if(curr_state_.momentum_buffer().defined()) {
+        momentum_buffers.emplace_back(curr_state_.momentum_buffer());
+      }
+      if(curr_state_.grad_avg().defined()) {
+        grad_average_buffers.emplace_back(curr_state_.grad_avg());
+      }
     }
   }
-  // write momentum_buffers to the file
+  // write buffers to the file
   auto optim_tempfile_old_format = c10::make_tempfile();
   torch::serialize::OutputArchive output_archive;
   write_tensors_to_archive(output_archive, "square_average_buffers", square_average_buffers);
   write_tensors_to_archive(output_archive, "momentum_buffers", momentum_buffers);
-  write_tensors_to_archive(output_archive, "grad_average_buffers", momentum_buffers);
+  write_tensors_to_archive(output_archive, "grad_average_buffers", grad_average_buffers);
   output_archive.save_to(optim_tempfile_old_format.name);
-  auto optim1_2 = RMSprop(model1_params, torch::optim::RMSpropOptions(0.1).momentum(0.9));
+  auto optim1_2 = RMSprop(model1_params, options);
   OLD_SERIALIZATION_LOGIC_WARNING_CHECK(torch::load, optim1_2, optim_tempfile_old_format.name);
+  const auto& params1_2_ = optim1_2.param_groups()[0].params();
+  auto& optim1_2_state = optim1_2.state();
+  // old RMSprop didn't track step value
+  for (size_t i = 0; i < params1_2_.size(); i++) {
+    if(i != (params1_2_.size() - 1)) {
+      auto key_ = c10::guts::to_string(params_[i].unsafeGetTensorImpl());
+      auto key1_2_ = c10::guts::to_string(params1_2_[i].unsafeGetTensorImpl());
+      const RMSpropParamState& curr_state_ = static_cast<const RMSpropParamState&>(*(optim1_state.at(key_).get()));
+      RMSpropParamState& curr_state1_2_ = static_cast<RMSpropParamState&>(*(optim1_2_state.at(key_).get()));
+      curr_state1_2_.step(curr_state_.step());
+    }
+  }
   is_optimizer_state_equal<RMSpropParamState>(optim1.state(), optim1_2.state());
 }
 

--- a/torch/csrc/api/include/torch/optim/adagrad.h
+++ b/torch/csrc/api/include/torch/optim/adagrad.h
@@ -35,7 +35,7 @@ public:
 
 struct TORCH_API AdagradParamState : public OptimizerCloneableParamState<AdagradParamState> {
   TORCH_ARG(torch::Tensor, sum);
-  TORCH_ARG(int64_t, step);
+  TORCH_ARG(int64_t, step) = 0;
 
 public:
   void serialize(torch::serialize::InputArchive& archive) override;

--- a/torch/csrc/api/include/torch/optim/adam.h
+++ b/torch/csrc/api/include/torch/optim/adam.h
@@ -34,7 +34,7 @@ public:
 };
 
 struct TORCH_API AdamParamState : public OptimizerCloneableParamState<AdamParamState> {
-  TORCH_ARG(int64_t, step);
+  TORCH_ARG(int64_t, step) = 0;
   TORCH_ARG(torch::Tensor, exp_avg);
   TORCH_ARG(torch::Tensor, exp_avg_sq);
   TORCH_ARG(torch::Tensor, max_exp_avg_sq) = {};

--- a/torch/csrc/api/include/torch/optim/rmsprop.h
+++ b/torch/csrc/api/include/torch/optim/rmsprop.h
@@ -4,6 +4,7 @@
 #include <torch/nn/module.h>
 #include <torch/optim/optimizer.h>
 #include <torch/optim/serialize.h>
+#include <torch/serialize/archive.h>
 #include <torch/types.h>
 
 #include <functional>
@@ -21,44 +22,67 @@ class InputArchive;
 namespace torch {
 namespace optim {
 
-struct TORCH_API RMSpropOptions {
-  RMSpropOptions(double learning_rate);
-  TORCH_ARG(double, learning_rate);
+struct TORCH_API RMSpropOptions : public OptimizerCloneableOptions<RMSpropOptions> {
+  RMSpropOptions(double lr);
+  TORCH_ARG(double, lr) = 1e-2;
   TORCH_ARG(double, alpha) = 0.99;
   TORCH_ARG(double, eps) = 1e-8;
   TORCH_ARG(double, weight_decay) = 0;
   TORCH_ARG(double, momentum) = 0;
   TORCH_ARG(bool, centered) = false;
+public:
+void serialize(torch::serialize::InputArchive& archive) override;
+void serialize(torch::serialize::OutputArchive& archive) const override;
+TORCH_API friend bool operator==(const RMSpropOptions& lhs, const RMSpropOptions& rhs);
+~RMSpropOptions() = default;
+};
+
+struct TORCH_API RMSpropParamState : public OptimizerCloneableParamState<RMSpropParamState> {
+  TORCH_ARG(int64_t, step);
+  TORCH_ARG(torch::Tensor, momentum_buffer);
+  TORCH_ARG(torch::Tensor, square_avg);
+  TORCH_ARG(torch::Tensor, grad_avg);
+
+public:
+  void serialize(torch::serialize::InputArchive& archive) override;
+  void serialize(torch::serialize::OutputArchive& archive) const override;
+  TORCH_API friend bool operator==(const RMSpropParamState& lhs, const RMSpropParamState& rhs);
+  ~RMSpropParamState() = default;
 };
 
 class TORCH_API RMSprop : public Optimizer {
  public:
   template <typename ParameterContainer>
-  explicit RMSprop(
-      ParameterContainer&& parameters,
-      const RMSpropOptions& options_)
-      : Optimizer(std::forward<ParameterContainer>(parameters)),
-        options(options_) {}
+  explicit RMSprop(std::vector<OptimizerParamGroup> param_groups,
+      RMSpropOptions defaults) : Optimizer(std::move(param_groups), std::make_unique<RMSpropOptions>(defaults)) {
+    TORCH_CHECK(defaults.lr() >= 0, "Invalid learning rate: ", defaults.lr());
+    TORCH_CHECK(defaults.eps() >= 0, "Invalid epsilon value: ", defaults.eps());
+    TORCH_CHECK(defaults.momentum() >= 0, "Invalid momentum value: ", defaults.momentum());
+    TORCH_CHECK(defaults.weight_decay() >= 0, "Invalid weight_decay value: ", defaults.weight_decay());
+    TORCH_CHECK(defaults.alpha() >= 0, "Invalid alpha value: ", defaults.alpha());
+  }
 
   void step() override;
 
-  RMSpropOptions options;
+  /// Returns the number of parameters referenced by the optimizer.
+  size_t size() const noexcept override;
+
+  /// Adds the given vector of parameters to the optimizer's parameter list.
+  void add_parameters(const std::vector<Tensor>& parameters) override;
+
+  /// Provides a const reference to the parameters this optimizer holds.
+  const std::vector<Tensor>& parameters() const noexcept override;
+
+  /// Provides a reference to the parameters this optimizer holds.
+  std::vector<Tensor>& parameters() noexcept override;
 
   void save(serialize::OutputArchive& archive) const override;
   void load(serialize::InputArchive& archive) override;
 
-  std::vector<Tensor> square_average_buffers;
-  std::vector<Tensor> momentum_buffers;
-  std::vector<Tensor> grad_average_buffers;
-
  private:
-  RMSprop() : options(0) {}
-
   template <typename Self, typename Archive>
   static void serialize(Self& self, Archive& archive) {
-    _TORCH_OPTIM_SERIALIZE(square_average_buffers);
-    _TORCH_OPTIM_SERIALIZE(momentum_buffers);
-    _TORCH_OPTIM_SERIALIZE(grad_average_buffers);
+    //_TORCH_OPTIM_SERIALIZE_WITH_TEMPLATE_ARG(RMSprop);
   }
 };
 } // namespace optim

--- a/torch/csrc/api/include/torch/optim/rmsprop.h
+++ b/torch/csrc/api/include/torch/optim/rmsprop.h
@@ -23,7 +23,7 @@ namespace torch {
 namespace optim {
 
 struct TORCH_API RMSpropOptions : public OptimizerCloneableOptions<RMSpropOptions> {
-  RMSpropOptions(double lr);
+  RMSpropOptions(double lr = 1e-2);
   TORCH_ARG(double, lr) = 1e-2;
   TORCH_ARG(double, alpha) = 0.99;
   TORCH_ARG(double, eps) = 1e-8;
@@ -31,7 +31,7 @@ struct TORCH_API RMSpropOptions : public OptimizerCloneableOptions<RMSpropOption
   TORCH_ARG(double, momentum) = 0;
   TORCH_ARG(bool, centered) = false;
 
-public:
+ public:
   void serialize(torch::serialize::InputArchive& archive) override;
   void serialize(torch::serialize::OutputArchive& archive) const override;
   TORCH_API friend bool operator==(const RMSpropOptions& lhs, const RMSpropOptions& rhs);
@@ -39,12 +39,12 @@ public:
 };
 
 struct TORCH_API RMSpropParamState : public OptimizerCloneableParamState<RMSpropParamState> {
-  TORCH_ARG(int64_t, step);
+  TORCH_ARG(int64_t, step) = 0;
   TORCH_ARG(torch::Tensor, square_avg);
   TORCH_ARG(torch::Tensor, momentum_buffer) = {};
   TORCH_ARG(torch::Tensor, grad_avg) = {};
 
-public:
+ public:
   void serialize(torch::serialize::InputArchive& archive) override;
   void serialize(torch::serialize::OutputArchive& archive) const override;
   TORCH_API friend bool operator==(const RMSpropParamState& lhs, const RMSpropParamState& rhs);

--- a/torch/csrc/api/include/torch/optim/rmsprop.h
+++ b/torch/csrc/api/include/torch/optim/rmsprop.h
@@ -30,11 +30,12 @@ struct TORCH_API RMSpropOptions : public OptimizerCloneableOptions<RMSpropOption
   TORCH_ARG(double, weight_decay) = 0;
   TORCH_ARG(double, momentum) = 0;
   TORCH_ARG(bool, centered) = false;
+
 public:
-void serialize(torch::serialize::InputArchive& archive) override;
-void serialize(torch::serialize::OutputArchive& archive) const override;
-TORCH_API friend bool operator==(const RMSpropOptions& lhs, const RMSpropOptions& rhs);
-~RMSpropOptions() = default;
+  void serialize(torch::serialize::InputArchive& archive) override;
+  void serialize(torch::serialize::OutputArchive& archive) const override;
+  TORCH_API friend bool operator==(const RMSpropOptions& lhs, const RMSpropOptions& rhs);
+  ~RMSpropOptions() = default;
 };
 
 struct TORCH_API RMSpropParamState : public OptimizerCloneableParamState<RMSpropParamState> {
@@ -52,7 +53,6 @@ public:
 
 class TORCH_API RMSprop : public Optimizer {
  public:
-  template <typename ParameterContainer>
   explicit RMSprop(std::vector<OptimizerParamGroup> param_groups,
       RMSpropOptions defaults) : Optimizer(std::move(param_groups), std::make_unique<RMSpropOptions>(defaults)) {
     TORCH_CHECK(defaults.lr() >= 0, "Invalid learning rate: ", defaults.lr());
@@ -61,6 +61,9 @@ class TORCH_API RMSprop : public Optimizer {
     TORCH_CHECK(defaults.weight_decay() >= 0, "Invalid weight_decay value: ", defaults.weight_decay());
     TORCH_CHECK(defaults.alpha() >= 0, "Invalid alpha value: ", defaults.alpha());
   }
+
+  explicit RMSprop(std::vector<Tensor> params,
+      RMSpropOptions defaults) : RMSprop({std::move(OptimizerParamGroup(params))}, defaults) {}
 
   void step() override;
 
@@ -82,7 +85,7 @@ class TORCH_API RMSprop : public Optimizer {
  private:
   template <typename Self, typename Archive>
   static void serialize(Self& self, Archive& archive) {
-    //_TORCH_OPTIM_SERIALIZE_WITH_TEMPLATE_ARG(RMSprop);
+    _TORCH_OPTIM_SERIALIZE_WITH_TEMPLATE_ARG(RMSprop);
   }
 };
 } // namespace optim

--- a/torch/csrc/api/include/torch/optim/rmsprop.h
+++ b/torch/csrc/api/include/torch/optim/rmsprop.h
@@ -40,9 +40,9 @@ public:
 
 struct TORCH_API RMSpropParamState : public OptimizerCloneableParamState<RMSpropParamState> {
   TORCH_ARG(int64_t, step);
-  TORCH_ARG(torch::Tensor, momentum_buffer);
   TORCH_ARG(torch::Tensor, square_avg);
-  TORCH_ARG(torch::Tensor, grad_avg);
+  TORCH_ARG(torch::Tensor, momentum_buffer) = {};
+  TORCH_ARG(torch::Tensor, grad_avg) = {};
 
 public:
   void serialize(torch::serialize::InputArchive& archive) override;

--- a/torch/csrc/api/src/optim/adagrad.cpp
+++ b/torch/csrc/api/src/optim/adagrad.cpp
@@ -56,6 +56,7 @@ void AdagradParamState::serialize(torch::serialize::InputArchive& archive) {
 /// Adapted from
 /// https://github.com/pytorch/pytorch/blob/master/torch/optim/adagrad.py
 void Adagrad::step() {
+  NoGradGuard no_grad;
   for (auto& group : param_groups_) {
     for (auto& p : group.params()) {
       if (!p.grad().defined()) {

--- a/torch/csrc/api/src/optim/adagrad.cpp
+++ b/torch/csrc/api/src/optim/adagrad.cpp
@@ -62,7 +62,7 @@ void Adagrad::step() {
       if (!p.grad().defined()) {
         continue;
       }
-      auto grad = p.grad().data();
+      auto grad = p.grad();
       TORCH_INTERNAL_ASSERT(state_[c10::guts::to_string(p.unsafeGetTensorImpl())] != nullptr, "state found NULL for the Tensor ", p);
       auto& state = static_cast<AdagradParamState&>(*state_[c10::guts::to_string(p.unsafeGetTensorImpl())]);
       auto& options = static_cast<AdagradOptions&>(group.options());
@@ -70,8 +70,8 @@ void Adagrad::step() {
       state.step(state.step() + 1);
 
       if (options.weight_decay() != 0) {
-        TORCH_CHECK(!p.grad().data().is_sparse(), "weight_decay option is not compatible with sparse gradients");
-        grad = grad.add(p.data(), options.weight_decay());
+        TORCH_CHECK(!p.grad().is_sparse(), "weight_decay option is not compatible with sparse gradients");
+        grad = grad.add(p, options.weight_decay());
       }
       const auto clr = options.lr() /
           (1 + static_cast<double>(state.step() - 1) * options.lr_decay());
@@ -92,12 +92,12 @@ void Adagrad::step() {
         auto std = state.sum().sparse_mask(grad);
         const auto std_values = std._values().sqrt_().add_(options.eps());
 
-        p.data().add_(make_sparse(grad_values / std_values), -clr);
+        p.add_(make_sparse(grad_values / std_values), -clr);
       }
       else {
         state.sum(state.sum().addcmul_(grad, grad, 1.0));
         const auto std = state.sum().sqrt().add_(options.eps());
-        p.data().addcdiv_(grad, std, -clr);
+        p.addcdiv_(grad, std, -clr);
       }
     }
   }

--- a/torch/csrc/api/src/optim/adam.cpp
+++ b/torch/csrc/api/src/optim/adam.cpp
@@ -68,7 +68,7 @@ void Adam::step() {
       if (!p.grad().defined()) {
         continue;
       }
-      auto grad = p.grad().data();
+      auto grad = p.grad();
       TORCH_CHECK(!grad.is_sparse(), "Adam does not support sparse gradients"/*, please consider SparseAdam instead*/);
       auto param_state = state_.find(c10::guts::to_string(p.unsafeGetTensorImpl()));
       auto& options = static_cast<AdamOptions&>(group.options());
@@ -78,12 +78,12 @@ void Adam::step() {
         auto state = std::make_unique<AdamParamState>();
         state->step(0);
         // Exponential moving average of gradient values
-        state->exp_avg(torch::zeros_like(p.data(), MemoryFormat::Preserve));
+        state->exp_avg(torch::zeros_like(p, MemoryFormat::Preserve));
         // Exponential moving average of squared gradient values
-        state->exp_avg_sq(torch::zeros_like(p.data(), MemoryFormat::Preserve));
+        state->exp_avg_sq(torch::zeros_like(p, MemoryFormat::Preserve));
         if(options.amsgrad()) {
           // Maintains max of all exp. moving avg. of sq. grad. values
-          state->max_exp_avg_sq(torch::zeros_like(p.data(), MemoryFormat::Preserve));
+          state->max_exp_avg_sq(torch::zeros_like(p, MemoryFormat::Preserve));
         }
         state_[c10::guts::to_string(p.unsafeGetTensorImpl())] = std::move(state);
       }
@@ -119,7 +119,7 @@ void Adam::step() {
       }
 
       auto step_size = options.lr() / bias_correction1;
-      p.data().addcdiv_(exp_avg, denom, -step_size);
+      p.addcdiv_(exp_avg, denom, -step_size);
     }
   }
 }

--- a/torch/csrc/api/src/optim/rmsprop.cpp
+++ b/torch/csrc/api/src/optim/rmsprop.cpp
@@ -11,55 +11,118 @@
 namespace torch {
 namespace optim {
 
-RMSpropOptions::RMSpropOptions(double learning_rate)
-    : learning_rate_(learning_rate) {}
+RMSpropOptions::RMSpropOptions(double lr)
+    : lr_(lr) {}
+
+bool operator==(const RMSpropOptions& lhs, const RMSpropOptions& rhs) {
+  return (lhs.lr() == rhs.lr()) &&
+          (lhs.alpha() == rhs.alpha()) &&
+          (lhs.eps() == rhs.eps()) &&
+          (lhs.weight_decay() == rhs.weight_decay()) &&
+          (lhs.momentum() == rhs.momentum()) &&
+          (lhs.centered() == rhs.centered());
+}
+
+void RMSpropOptions::serialize(torch::serialize::OutputArchive& archive) const {
+  _TORCH_OPTIM_SERIALIZE_TORCH_ARG(lr);
+  _TORCH_OPTIM_SERIALIZE_TORCH_ARG(alpha);
+  _TORCH_OPTIM_SERIALIZE_TORCH_ARG(eps);
+  _TORCH_OPTIM_SERIALIZE_TORCH_ARG(weight_decay);
+  _TORCH_OPTIM_SERIALIZE_TORCH_ARG(momentum);
+  _TORCH_OPTIM_SERIALIZE_TORCH_ARG(centered);
+}
+
+void RMSpropOptions::serialize(torch::serialize::InputArchive& archive) {
+  _TORCH_OPTIM_DESERIALIZE_TORCH_ARG(double, lr);
+  _TORCH_OPTIM_DESERIALIZE_TORCH_ARG(double, alpha);
+  _TORCH_OPTIM_DESERIALIZE_TORCH_ARG(double, eps);
+  _TORCH_OPTIM_DESERIALIZE_TORCH_ARG(double, weight_decay);
+  _TORCH_OPTIM_DESERIALIZE_TORCH_ARG(double, momentum);
+  _TORCH_OPTIM_DESERIALIZE_TORCH_ARG(bool, centered);
+}
+
+bool operator==(const RMSpropParamState& lhs, const RMSpropParamState& rhs) {
+  return (lhs.step() == rhs.step()) &&
+         torch::equal(lhs.momentum_buffer(), rhs.momentum_buffer()) &&
+         torch::equal(lhs.square_avg(), rhs.square_avg()) &&
+         torch::equal(lhs.grad_avg(), rhs.grad_avg());
+}
+
+void RMSpropParamState::serialize(torch::serialize::OutputArchive& archive) const {
+  _TORCH_OPTIM_SERIALIZE_TORCH_ARG(step);
+  _TORCH_OPTIM_SERIALIZE_TORCH_ARG(momentum_buffer);
+  _TORCH_OPTIM_SERIALIZE_TORCH_ARG(square_avg);
+  _TORCH_OPTIM_SERIALIZE_TORCH_ARG(grad_avg);
+}
+
+void RMSpropParamState::serialize(torch::serialize::InputArchive& archive) {
+  _TORCH_OPTIM_DESERIALIZE_TORCH_ARG(int64_t, step);
+  _TORCH_OPTIM_DESERIALIZE_TORCH_ARG(Tensor, momentum_buffer);
+  _TORCH_OPTIM_DESERIALIZE_TORCH_ARG(Tensor, square_avg);
+  _TORCH_OPTIM_DESERIALIZE_TORCH_ARG(Tensor, grad_avg);
+}
 
 /// Adapted from
 /// https://github.com/pytorch/pytorch/blob/master/torch/optim/rmsprop.py
 void RMSprop::step() {
-  for (size_t i = 0; i < parameters_.size(); ++i) {
-    Tensor p = parameters_.at(i);
-    if (!p.grad().defined()) {
-      continue;
-    }
+  for (auto& group : param_groups_) {
+    for (auto& p : group.params()) {
+      if (!p.grad().defined()) {
+        continue;
+      }
+      auto grad = p.grad().data();
+      TORCH_CHECK(!grad.is_sparse(), "RMSprop does not support sparse gradients");
+      auto param_state = state_.find(c10::guts::to_string(p.unsafeGetTensorImpl()));
+      auto& options = static_cast<RMSpropOptions&>(group.options());
 
-    if (options.weight_decay() > 0) {
-      NoGradGuard guard;
-      p.grad() = p.grad() + options.weight_decay() * p;
-    }
+      if(param_state == state_.end()) {
+        auto state = std::make_unique<RMSpropParamState>();
+        state->step(0);
+        state->square_avg(torch::zeros_like(p.data(), MemoryFormat::Preserve));
+        // TODO: think and test if I need to initialize momentum_buffer with an empty tensor when momentum is neg
+        if(options.momentum() > 0) {
+          state->momentum_buffer(torch::zeros_like(p.data(), MemoryFormat::Preserve));
+        }
+        // TODO: think and test if I need to initialize grad_avg with an empty tensor when centered is False
+        if(options.centered()) {
+          state->grad_avg(torch::zeros_like(p.data(), MemoryFormat::Preserve));
+        }
+        state_[c10::guts::to_string(p.unsafeGetTensorImpl())] = std::move(state);
+      }
 
-    auto square_average = buffer_at(square_average_buffers, i);
-    square_average.mul_(options.alpha())
-        .addcmul_(p.grad(), p.grad(), 1.0 - options.alpha());
-
-    Tensor average;
-    if (options.centered() > 0) {
-      auto& grad_average = buffer_at(grad_average_buffers, i);
-      grad_average.mul_(options.alpha()).add_(p.grad(), 1.0 - options.alpha());
-      average = square_average.addcmul(grad_average, grad_average, -1.0)
-                    .sqrt()
-                    .add_(options.eps());
-    } else {
-      average = square_average.sqrt().add_(options.eps());
+    //  auto square_avg = state_[c10::guts::to_string(p.unsafeGetTensorImpl())].square_avg();
+    //  auto alpha = group['alpha']
+      if (options.weight_decay() != 0) {
+        grad = grad.add(p.data(), options.weight_decay());
+      }
+      // if (momentum != 0) {
+      //   Tensor buf;
+      //   auto param_state = state_.find(c10::guts::to_string(p.unsafeGetTensorImpl()));
+      //   if(param_state == state_.end()) {
+      //     buf = torch::clone(d_p).detach();
+      //     auto state = std::make_unique<SGDParamState>();
+      //     state->momentum_buffer(buf);
+      //     state_[c10::guts::to_string(p.unsafeGetTensorImpl())] = std::move(state);
+      //   } else {
+      //     buf = static_cast<SGDParamState&>(*param_state->second).momentum_buffer();
+      //     buf.mul_(momentum).add_(d_p, 1 - dampening);
+      //   }
+      //   if (nesterov) {
+      //     d_p = d_p.add(buf, momentum);
+      //   } else {
+      //     d_p = buf;
+      //   }
+      }
+      p.data().add_(d_p, -1 * options.lr());
     }
-
-    NoGradGuard guard;
-    if (options.momentum() > 0) {
-      auto& momentum = buffer_at(momentum_buffers, i);
-      momentum.mul_(options.momentum()).addcdiv_(p.grad(), average);
-      p.add_(momentum, -options.learning_rate());
-    } else {
-      p.addcdiv_(p.grad(), average, -options.learning_rate());
-    }
-  }
 }
 
 void RMSprop::save(serialize::OutputArchive& archive) const {
-  serialize(*this, archive);
+  //serialize(*this, archive);
 }
 
 void RMSprop::load(serialize::InputArchive& archive) {
-  serialize(*this, archive);
+  //serialize(*this, archive);
 }
 } // namespace optim
 } // namespace torch

--- a/torch/csrc/api/src/optim/sgd.cpp
+++ b/torch/csrc/api/src/optim/sgd.cpp
@@ -53,6 +53,7 @@ void SGDParamState::serialize(torch::serialize::InputArchive& archive) {
 }
 
 void SGD::step() {
+  NoGradGuard no_grad;
   for (auto& group : param_groups_) {
     auto& options = static_cast<SGDOptions&>(group.options());
     auto weight_decay = options.weight_decay();


### PR DESCRIPTION
**This PR is BC-breaking in the following way:**

In RMSpropOptions:
1. learning_rate is renamed to lr.

**Test plan before 1.5 release:**

Test that in 1.5 we can load a C++ RMSprop optimizer that was serialized in 1.4, and their states are the same (except `step` in parameter state which should be set to 0 in the deserialized optimizer).

Test script:

optim_save_1_4.cpp
https://gist.github.com/yf225/b1c036c9b9c990ef20737a662bc927d7
optim_load_1_5.h
https://gist.github.com/yf225/84a47a40846b0eff6b87999986690fe0
optim_load_1_5.cpp
https://gist.github.com/yf225/44edfc6f4fe1a92be9232d402ece3714