### PR TITLE
[WIP] Add a new Python unit test for combining DDP and Distributed Autograd/Optimizer

### DIFF
--- a/test/distributed/test_ddp_with_rpc.py
+++ b/test/distributed/test_ddp_with_rpc.py
@@ -1,8 +1,7 @@
+import logging
 import multiprocessing
 import os
 import sys
-import logging
-import time
 
 import torch.distributed.autograd as dist_autograd
 from torch.distributed import rpc
@@ -17,41 +16,66 @@ from torch._utils_internal import TEST_MASTER_ADDR as MASTER_ADDR
 from torch._utils_internal import TEST_MASTER_PORT as MASTER_PORT
 
 
+def init_logger():
+    logger = logging.getLogger(__name__)
+    logger.setLevel(logging.INFO)
+    console = logging.StreamHandler()
+    console.setLevel(logging.INFO)
+    formatter = logging.Formatter(
+        "%(asctime)s %(filename)s:%(lineno)s %(levelname)s: %(message)s"
+    )
+    console.setFormatter(formatter)
+    # add the handlers to the logger
+    logger.addHandler(console)
+    logger.info("Set up a logger.")
+    return logger
+
+
+gLogger = init_logger()
+
+
 def _call_method(method, rref, *args, **kwargs):
     return method(rref.local_value(), *args, **kwargs)
 
 
 def _remote_method(method, rref, *args, **kwargs):
-    args = [method, rref] + list(args)
-    return rpc.rpc_sync(rref.owner(), _call_method, args=args, kwargs=kwargs)
+    args_tup = tuple([method, rref] + list(args))
+    return rpc.rpc_sync(
+        rref.owner(), _call_method, args=args_tup, kwargs=kwargs
+    )
 
 
 class SimpleNet(nn.Module):
     def __init__(self, d_in, d_out):
+        gLogger.info(f"Initing SimpleNet with {d_in} {d_out}")
         super(SimpleNet, self).__init__()
         self.net = nn.Linear(d_in, d_out)
         self.relu = nn.ReLU()
 
     def forward(self, input):
-        print("Running simple net: {input}")
+        gLogger.info(f"Running SimpleNet.forward on: {input}")
         return self.relu(self.net(input))
 
 
 class DdpModelWithRpc(nn.Module):
-    def __init__(self, remote_server, process_group_name):
+    def __init__(self, remote_server, process_group_name=None):
+        ddp_transform = (
+            lambda net, process_group_name: net if process_group_name is None else DDP
+        )
         super(DdpModelWithRpc, self).__init__()
-        self.net1 = DDP(SimpleNet(5, 8), process_group=process_group_name)
-        self.rref = rpc.remote(remote_server, SimpleNet, 8, 5)
-        self.net2 = DDP(SimpleNet(5, 3), process_group=process_group_name)
+        self.net1 = ddp_transform(SimpleNet(4, 3), process_group_name)
+        self.rref = rpc.remote(remote_server, SimpleNet, args=(3, 2))
+        self.net2 = ddp_transform(SimpleNet(2, 1), process_group_name)
 
     def forward(self, x):
+        gLogger.info(f"Running DdpModelWithRpc.forward on {x}")
         x = self.net1(x)
         x = _remote_method(SimpleNet.forward, self.rref, x)
         return self.net2(x)
 
 
 class TestDdpWithRpc(TestCase):
-    TRAINER_NAME_TEMPLATE = "trainer:{:02d}"
+    TRAINER_NAME_TEMPLATE = "trainer{:02d}"
     REMOTE_WORKER_NAME = "remote_worker"
     TRAINER_GROUP = "trainer_group"
     NUM_TRAINERS = 3
@@ -72,6 +96,7 @@ class TestDdpWithRpc(TestCase):
         for p in self.processes:
             p.join()
 
+    # TODO: make it work
     def run_one_mini_batch(self):
         with dist_autograd.context() as context_id:
             # Forward pass (create references on remote nodes).
@@ -90,23 +115,23 @@ class TestDdpWithRpc(TestCase):
             # Run the distributed optimizer step.
             dist_optim.step()
 
-    def run_trainer(self, rank, func):
+    def run_trainer(self, rank, func, use_ddp=True):
         trainer_name = self.TRAINER_NAME_TEMPLATE.format(rank)
-        print(f"Starting trainer: {trainer_name}...")
-        #  For DDP communications
-        dist.init_process_group(
-            # TODO: test other rpc backend.
-            "gloo",
-            group_name=self.TRAINER_GROUP,
-            rank=rank,
-            world_size=self.NUM_TRAINERS,
-        )
+        gLogger.info(f"Starting trainer: {trainer_name}...")
+        if use_ddp:
+            dist.init_process_group(
+                # TODO: test other rpc backend.
+                "gloo",
+                group_name=self.TRAINER_GROUP,
+                rank=rank,
+                world_size=self.NUM_TRAINERS,
+            )
         # This group includes the remote worker
         rpc.init_rpc(
             name=trainer_name, rank=rank, world_size=self.NUM_TRAINERS + 1
         )
         self.model = DdpModelWithRpc(
-            self.REMOTE_WORKER_NAME, self.TRAINER_GROUP
+            self.REMOTE_WORKER_NAME, self.TRAINER_GROUP if use_ddp else None
         )
         func()
         rpc.shutdown()
@@ -122,15 +147,12 @@ class TestDdpWithRpc(TestCase):
         )
         rpc.shutdown()
 
-    def spawn_processes(self):
-        def trainer_func():
-            print(f"Forward pass on {self.model(torch.randn((3, 5)))}")
-
+    def spawn_processes(self, func, use_ddp=True):
         for rank in range(self.NUM_TRAINERS):
             process = multiprocessing.Process(
                 target=self.run_trainer,
                 name=self.TRAINER_NAME_TEMPLATE.format(rank),
-                args=(rank, trainer_func),
+                args=(rank, func, use_ddp),
             )
             process.start()
             self.processes.append(process)
@@ -140,21 +162,14 @@ class TestDdpWithRpc(TestCase):
         )
         remote_worker_process.start()
         self.processes.append(remote_worker_process)
-        # time.sleep(30)
 
-    def test_forward_pass(self):
-        self.spawn_processes()
+    def test_rpc(self):
+        def run_one_forward():
+            gLogger.info(f"Forward pass on {self.model(torch.randn((2, 4)))}")
+
+        self.spawn_processes(run_one_forward, False)
         self.join_processes()
 
 
-def init_logger():
-    FORMAT = "%(asctime)s %(filename)s:%(lineno)s %(levelname)s: %(message)s"
-    logging.basicConfig(format=FORMAT, stream=sys.stderr, level=logging.INFO)
-    logger = logging.getLogger(__name__)
-    logger.setLevel(logging.INFO)
-    print("Got a logger.")
-
-
 if __name__ == "__main__":
-    init_logger()
     run_tests()

--- a/test/distributed/test_ddp_with_rpc.py
+++ b/test/distributed/test_ddp_with_rpc.py
@@ -1,5 +1,8 @@
 import multiprocessing
 import os
+import sys
+import logging
+import time
 
 import torch.distributed.autograd as dist_autograd
 from torch.distributed import rpc
@@ -30,6 +33,7 @@ class SimpleNet(nn.Module):
         self.relu = nn.ReLU()
 
     def forward(self, input):
+        print("Running simple net: {input}")
         return self.relu(self.net(input))
 
 
@@ -37,7 +41,7 @@ class DdpModelWithRpc(nn.Module):
     def __init__(self, remote_server, process_group_name):
         super(DdpModelWithRpc, self).__init__()
         self.net1 = DDP(SimpleNet(5, 8), process_group=process_group_name)
-        self.rref = rpc.remote(remote_server, 8, 5)
+        self.rref = rpc.remote(remote_server, SimpleNet, 8, 5)
         self.net2 = DDP(SimpleNet(5, 3), process_group=process_group_name)
 
     def forward(self, x):
@@ -47,22 +51,26 @@ class DdpModelWithRpc(nn.Module):
 
 
 class TestDdpWithRpc(TestCase):
-    TRAINER_NAME_TEMPLATE = "trainer.{:02d}"
+    TRAINER_NAME_TEMPLATE = "trainer:{:02d}"
     REMOTE_WORKER_NAME = "remote_worker"
     TRAINER_GROUP = "trainer_group"
-    NUM_TRAINERS = 4
+    NUM_TRAINERS = 3
 
     def setUp(self):
         super(TestDdpWithRpc, self).setUp()
         self.processes = []
         os.environ["MASTER_ADDR"] = str(MASTER_ADDR)
         os.environ["MASTER_PORT"] = str(MASTER_PORT)
-        # os.environ["WORLD_SIZE"] = str(self.NUM_TRAINERS + 1)
+        os.environ["WORLD_SIZE"] = str(self.NUM_TRAINERS + 1)
 
     def tearDown(self):
         super(TestDdpWithRpc, self).tearDown()
         for p in self.processes:
             p.terminate()
+
+    def join_processes(self):
+        for p in self.processes:
+            p.join()
 
     def run_one_mini_batch(self):
         with dist_autograd.context() as context_id:
@@ -84,6 +92,7 @@ class TestDdpWithRpc(TestCase):
 
     def run_trainer(self, rank, func):
         trainer_name = self.TRAINER_NAME_TEMPLATE.format(rank)
+        print(f"Starting trainer: {trainer_name}...")
         #  For DDP communications
         dist.init_process_group(
             # TODO: test other rpc backend.
@@ -100,23 +109,22 @@ class TestDdpWithRpc(TestCase):
             self.REMOTE_WORKER_NAME, self.TRAINER_GROUP
         )
         func()
-        self.clean_up()
-
-    def clean_up(self):
-        dist.destroy_process_group()
         rpc.shutdown()
+        dist.destroy_process_group()
 
     def run_remote_worker(self):
+        print(f"Starting the remote worker...")
         # This group includes the remote worker
         rpc.init_rpc(
             name=self.REMOTE_WORKER_NAME,
             rank=self.NUM_TRAINERS,
             world_size=self.NUM_TRAINERS + 1,
         )
+        rpc.shutdown()
 
     def spawn_processes(self):
         def trainer_func():
-            print(self.model(torch.randn((3, 5))))
+            print(f"Forward pass on {self.model(torch.randn((3, 5)))}")
 
         for rank in range(self.NUM_TRAINERS):
             process = multiprocessing.Process(
@@ -126,14 +134,27 @@ class TestDdpWithRpc(TestCase):
             )
             process.start()
             self.processes.append(process)
+
         remote_worker_process = multiprocessing.Process(
             target=self.run_remote_worker, name=self.REMOTE_WORKER_NAME
         )
+        remote_worker_process.start()
         self.processes.append(remote_worker_process)
+        # time.sleep(30)
 
     def test_forward_pass(self):
         self.spawn_processes()
+        self.join_processes()
+
+
+def init_logger():
+    FORMAT = "%(asctime)s %(filename)s:%(lineno)s %(levelname)s: %(message)s"
+    logging.basicConfig(format=FORMAT, stream=sys.stderr, level=logging.INFO)
+    logger = logging.getLogger(__name__)
+    logger.setLevel(logging.INFO)
+    print("Got a logger.")
 
 
 if __name__ == "__main__":
+    init_logger()
     run_tests()

--- a/test/distributed/test_ddp_with_rpc.py
+++ b/test/distributed/test_ddp_with_rpc.py
@@ -1,0 +1,32 @@
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+from torch.distributed import rpc
+
+from torch.nn.parallel import DistributedDataParallel as DDP
+
+
+def _remote_method(method, rref, *args, **kwargs):
+    args = [method, rref] + list(args)
+    return rpc.rpc_sync(rref.owner(), _call_method, args=args, kwargs=kwargs)
+
+
+class FakeEmbeddingTable(nn.Module):
+    def __init__(self):
+        super(FakeEmbeddingTable, self).__init__()
+        # 1 token only
+        self.em = nn.Embedding(1, 8)
+
+    def forward(self, input):
+        return self.em(input)
+
+
+class DdpModelWithRpc(nn.Module):
+    def __init__(self, ps):
+        super(MultiMachineModel, self).__init__()
+        self.em_rref = rpc.remote(ps, FakeEmbeddingTable)
+        self.net = DDP(torch.nn.Linear(ninp, 10))
+
+    def forward(self, x):
+        emb = _remote_method(EmbeddingTable.forward, self.em_rref, x)
+        return self.net(emb)

--- a/test/distributed/test_ddp_with_rpc.py
+++ b/test/distributed/test_ddp_with_rpc.py
@@ -1,3 +1,7 @@
+import multiprocessing
+import os
+
+import torch.distributed.autograd as dist_autograd
 from torch.distributed import rpc
 from torch.distributed.optim import DistributedOptimizer
 from torch.nn.parallel import DistributedDataParallel as DDP
@@ -10,6 +14,10 @@ from torch._utils_internal import TEST_MASTER_ADDR as MASTER_ADDR
 from torch._utils_internal import TEST_MASTER_PORT as MASTER_PORT
 
 
+def _call_method(method, rref, *args, **kwargs):
+    return method(rref.local_value(), *args, **kwargs)
+
+
 def _remote_method(method, rref, *args, **kwargs):
     args = [method, rref] + list(args)
     return rpc.rpc_sync(rref.owner(), _call_method, args=args, kwargs=kwargs)
@@ -19,47 +27,84 @@ class SimpleNet(nn.Module):
     def __init__(self, d_in, d_out):
         super(SimpleNet, self).__init__()
         self.net = nn.Linear(d_in, d_out)
+        self.relu = nn.ReLU()
 
     def forward(self, input):
-        return nn.ReLU(self.net(input))
+        return self.relu(self.net(input))
 
 
 class DdpModelWithRpc(nn.Module):
-    def __init__(self, remote_server):
+    def __init__(self, remote_server, process_group_name):
         super(DdpModelWithRpc, self).__init__()
-        self.net1 = DDP(SimpleNet(5, 8))
+        self.net1 = DDP(SimpleNet(5, 8), process_group=process_group_name)
         self.rref = rpc.remote(remote_server, 8, 5)
-        self.net2 = DDP(SimpleNet(5, 3))
+        self.net2 = DDP(SimpleNet(5, 3), process_group=process_group_name)
 
     def forward(self, x):
         x = self.net1(x)
         x = _remote_method(SimpleNet.forward, self.rref, x)
         return self.net2(x)
 
+
 class TestDdpWithRpc(TestCase):
-    TRAINER_NAME_TEMPLATE = 'trainer.{:02d}'
-    REMOTE_WORKER_NAME = 'remote_worker'
-    TRAINER_GROUP = 'trainer_group'
+    TRAINER_NAME_TEMPLATE = "trainer.{:02d}"
+    REMOTE_WORKER_NAME = "remote_worker"
+    TRAINER_GROUP = "trainer_group"
     NUM_TRAINERS = 4
 
     def setUp(self):
         super(TestDdpWithRpc, self).setUp()
-        self.model = DdpModelWithRpc()
+        self.processes = []
         os.environ["MASTER_ADDR"] = str(MASTER_ADDR)
         os.environ["MASTER_PORT"] = str(MASTER_PORT)
         # os.environ["WORLD_SIZE"] = str(self.NUM_TRAINERS + 1)
 
+    def tearDown(self):
+        super(TestDdpWithRpc, self).tearDown()
+        for p in self.processes:
+            p.terminate()
 
-    def run_trainer(self, rank):
+    def run_one_mini_batch(self):
+        with dist_autograd.context() as context_id:
+            # Forward pass (create references on remote nodes).
+            rref1 = rpc.remote(dst_name, random_tensor)
+            rref2 = rpc.remote(dst_name, random_tensor)
+            loss = rref1.to_here() + rref2.to_here()
+
+            # Backward pass (run distributed autograd).
+            dist_autograd.backward([loss.sum()])
+
+            # Build DistributedOptimizer.
+            dist_optim = DistributedOptimizer(
+                optim.SGD, [rref1, rref2], lr=0.05
+            )
+
+            # Run the distributed optimizer step.
+            dist_optim.step()
+
+    def run_trainer(self, rank, func):
         trainer_name = self.TRAINER_NAME_TEMPLATE.format(rank)
         #  For DDP communications
-        dist.init_process_group("gloo", group_name=self.TRAINER_GROUP, rank=rank, world_size=self.NUM_TRAINERS)
+        dist.init_process_group(
+            # TODO: test other rpc backend.
+            "gloo",
+            group_name=self.TRAINER_GROUP,
+            rank=rank,
+            world_size=self.NUM_TRAINERS,
+        )
         # This group includes the remote worker
         rpc.init_rpc(
-            name=trainer_name,
-            rank=rank,
-            world_size=self.NUM_TRAINERS + 1,
+            name=trainer_name, rank=rank, world_size=self.NUM_TRAINERS + 1
         )
+        self.model = DdpModelWithRpc(
+            self.REMOTE_WORKER_NAME, self.TRAINER_GROUP
+        )
+        func()
+        self.clean_up()
+
+    def clean_up(self):
+        dist.destroy_process_group()
+        rpc.shutdown()
 
     def run_remote_worker(self):
         # This group includes the remote worker
@@ -69,6 +114,26 @@ class TestDdpWithRpc(TestCase):
             world_size=self.NUM_TRAINERS + 1,
         )
 
+    def spawn_processes(self):
+        def trainer_func():
+            print(self.model(torch.randn((3, 5))))
+
+        for rank in range(self.NUM_TRAINERS):
+            process = multiprocessing.Process(
+                target=self.run_trainer,
+                name=self.TRAINER_NAME_TEMPLATE.format(rank),
+                args=(rank, trainer_func),
+            )
+            process.start()
+            self.processes.append(process)
+        remote_worker_process = multiprocessing.Process(
+            target=self.run_remote_worker, name=self.REMOTE_WORKER_NAME
+        )
+        self.processes.append(remote_worker_process)
+
+    def test_forward_pass(self):
+        self.spawn_processes()
+
 
 if __name__ == "__main__":
-    print("Running as main")
+    run_tests()

--- a/test/distributed/test_ddp_with_rpc.py
+++ b/test/distributed/test_ddp_with_rpc.py
@@ -138,7 +138,7 @@ class TestDdpWithRpc(TestCase):
         dist.destroy_process_group()
 
     def run_remote_worker(self):
-        print(f"Starting the remote worker...")
+        gLogger.info(f"Starting the remote worker...")
         # This group includes the remote worker
         rpc.init_rpc(
             name=self.REMOTE_WORKER_NAME,

--- a/test/distributed/test_ddp_with_rpc.py
+++ b/test/distributed/test_ddp_with_rpc.py
@@ -1,9 +1,13 @@
+from torch.distributed import rpc
+from torch.distributed.optim import DistributedOptimizer
+from torch.nn.parallel import DistributedDataParallel as DDP
+from torch.testing._internal.common_utils import TestCase, run_tests
 import torch
 import torch.distributed as dist
 import torch.nn as nn
-from torch.distributed import rpc
 
-from torch.nn.parallel import DistributedDataParallel as DDP
+from torch._utils_internal import TEST_MASTER_ADDR as MASTER_ADDR
+from torch._utils_internal import TEST_MASTER_PORT as MASTER_PORT
 
 
 def _remote_method(method, rref, *args, **kwargs):
@@ -31,3 +35,40 @@ class DdpModelWithRpc(nn.Module):
         x = self.net1(x)
         x = _remote_method(SimpleNet.forward, self.rref, x)
         return self.net2(x)
+
+class TestDdpWithRpc(TestCase):
+    TRAINER_NAME_TEMPLATE = 'trainer.{:02d}'
+    REMOTE_WORKER_NAME = 'remote_worker'
+    TRAINER_GROUP = 'trainer_group'
+    NUM_TRAINERS = 4
+
+    def setUp(self):
+        super(TestDdpWithRpc, self).setUp()
+        self.model = DdpModelWithRpc()
+        os.environ["MASTER_ADDR"] = str(MASTER_ADDR)
+        os.environ["MASTER_PORT"] = str(MASTER_PORT)
+        # os.environ["WORLD_SIZE"] = str(self.NUM_TRAINERS + 1)
+
+
+    def run_trainer(self, rank):
+        trainer_name = self.TRAINER_NAME_TEMPLATE.format(rank)
+        #  For DDP communications
+        dist.init_process_group("gloo", group_name=self.TRAINER_GROUP, rank=rank, world_size=self.NUM_TRAINERS)
+        # This group includes the remote worker
+        rpc.init_rpc(
+            name=trainer_name,
+            rank=rank,
+            world_size=self.NUM_TRAINERS + 1,
+        )
+
+    def run_remote_worker(self):
+        # This group includes the remote worker
+        rpc.init_rpc(
+            name=self.REMOTE_WORKER_NAME,
+            rank=self.NUM_TRAINERS,
+            world_size=self.NUM_TRAINERS + 1,
+        )
+
+
+if __name__ == "__main__":
+    print("Running as main")


### PR DESCRIPTION
Summary:
This test construct a distributed model, which calls a RPC as one of the forward steps. The computation steps are:
`input ==> local DDP net1 ==> remote net (on another node) ==> local DDP net2`

DDP will update the weights of `net1` and `net2`. While distributed optimizer will update `remote net`.

Test Plan:

`python test/distributed/test_ddp_with_rpc.py`
