### PR TITLE
Fixes #33001

### DIFF
--- a/aten/src/ATen/TensorUtils.cpp
+++ b/aten/src/ATen/TensorUtils.cpp
@@ -351,7 +351,7 @@ c10::optional<std::vector<int64_t>> computeStride(
     return newstride;
   }
 
-  int64_t view_d = newshape.size() - 1;
+  int64_t view_d = (int64_t)newshape.size() - 1;
   // stride for each subspace in the chunk
   int64_t chunk_base_stride = oldstride.back();
   // numel in current chunk


### PR DESCRIPTION
This fixes #33001. 

When subtracting 1 from a empty array, instead of being `-1` as seems to be expected in the later code (while loop), because `size()` seems to be unsigned, it becomes a very large number. This causes a segfault during the while loop later in the code where it tries to access a empty array.

This issue seemed to happen only on the pi with the following example code: `v = torch.FloatTensor(1, 135).fill_(0); v[0, [1]] += 2`.