### PR TITLE
[JIT] Add more ops to 'removableGuard' in guard elimination pass.

### DIFF
--- a/torch/csrc/jit/passes/guard_elimination.cpp
+++ b/torch/csrc/jit/passes/guard_elimination.cpp
@@ -221,7 +221,23 @@ private:
     case aten::div:
     case aten::t:
     case aten::sigmoid:
+    case aten::sin:
+    case aten::cos:
+    case aten::tan:
+    case aten::sinh:
+    case aten::cosh:
     case aten::tanh:
+    case aten::asin:
+    case aten::acos:
+    case aten::atan:
+    case aten::atan2:
+    case aten::floor:
+    case aten::fmod:
+    case aten::ceil:
+    case aten::trunc:
+    case aten::sqrt:
+    case aten::rsqrt:
+    case aten::remainder:
     case aten::mm:
     case aten::min:
     case aten::max:
@@ -246,6 +262,16 @@ private:
     case aten::rand_like:
     case aten::erf:
     case aten::erfc:
+    case aten::exp:
+    case aten::expm1:
+    case aten::log:
+    case aten::log2:
+    case aten::log10:
+    case aten::frac:
+    case aten::lerp:
+    case aten::lgamma:
+    case aten::reciprocal:
+    case aten::addcmul:
       return checkInputs(n, no_exceptions);
     case aten::slice:
       return !n->input(0)->type()->expect<TensorType>()->isSummarized() &&


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#33465 [JIT] Add more ops to 'removableGuard' in guard elimination pass.**



Differential Revision: [D19958385](https://our.internmc.facebook.com/intern/diff/D19958385)