### PR TITLE
[jit] Fix ModuleDict type sharing

### DIFF
--- a/test/jit/test_type_sharing.py
+++ b/test/jit/test_type_sharing.py
@@ -475,3 +475,29 @@ class TestTypeSharing(JitTestCase):
         a()
         b = package(A())
         b()
+
+    def test_module_dict_same_type_different_name(self):
+        """
+        We should be able to differentiate between two ModuleDict instances
+        that have different keys but the same value types.
+        """
+        class A(torch.nn.Module):
+            def __init__(self):
+                super(A, self).__init__()
+
+            def forward(self, x):
+                return x
+
+        class Foo(torch.nn.Module):
+            def __init__(self, s):
+                super(Foo, self).__init__()
+                self.dict = torch.nn.ModuleDict(s)
+
+            def forward(self, x):
+                return x
+
+        a = Foo({'foo': A()})
+        b = Foo({'bar': A()})
+        c = Foo({'bar': A()})
+        self.assertDifferentType(a, b)
+        self.assertSameType(b, c)

--- a/torch/csrc/jit/script/concrete_module_type.cpp
+++ b/torch/csrc/jit/script/concrete_module_type.cpp
@@ -72,7 +72,7 @@ ConcreteModuleType::ConcreteModuleType(ConcreteModuleTypeBuilder data)
 bool operator==(
     const ConcreteModuleTypeBuilder::ModuleInfo& lhs,
     const ConcreteModuleTypeBuilder::ModuleInfo& rhs) {
-  return lhs.meta_->equals(*rhs.meta_);
+  return lhs.name_ == rhs.name_ && lhs.meta_->equals(*rhs.meta_);
 }
 
 bool ConcreteModuleTypeBuilder::equals(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#33515 [jit] Fix ModuleDict type sharing**

Previously, if we had a `ModuleDict` with the same value types but
different names for keys, they would share types under certain
conditions. This only happens for `ModuleDict`, because in other cases
a simple Python class check invalidates the class.

Differential Revision: [D19978552](https://our.internmc.facebook.com/intern/diff/D19978552)