### PR TITLE
[C2] Native GPU implementation for bucketize

### DIFF
--- a/caffe2/operators/bucketize_op.cc
+++ b/caffe2/operators/bucketize_op.cc
@@ -5,21 +5,21 @@
 
 namespace caffe2 {
 
-template <typename T, class Context>
-bool BucketizeOp<T, Context>::RunOnDevice() {
+template <>
+bool BucketizeOp<CPUContext>::RunOnDevice() {
   auto& input = Input(X);
   CAFFE_ENFORCE_GE(input.dim(), 1);
 
   auto N = input.numel();
-  auto* output = Output(INDICES, input.sizes(), at::dtype<T>());
+  auto* output = Output(INDICES, input.sizes(), at::dtype<int32_t>());
   const auto* input_data = input.template data<float>();
-  auto* output_data = output->template mutable_data<T>();
+  auto* output_data = output->template mutable_data<int32_t>();
 
-  math::Set<T, Context>(output->numel(), 0.0, output_data, &context_);
+  math::Set<int32_t, CPUContext>(output->numel(), 0.0, output_data, &context_);
 
   for (int64_t pos = 0; pos < N; pos++) {
     // here we assume the boundary values for each feature are sorted
-    int64_t bucket_idx =
+    auto bucket_idx =
         std::lower_bound(
             boundaries_.begin(), boundaries_.end(), input_data[pos]) -
         boundaries_.begin();
@@ -28,7 +28,7 @@ bool BucketizeOp<T, Context>::RunOnDevice() {
 
   return true;
 };
-REGISTER_CPU_OPERATOR(Bucketize, BucketizeOp<int32_t, CPUContext>);
+REGISTER_CPU_OPERATOR(Bucketize, BucketizeOp<CPUContext>);
 
 OPERATOR_SCHEMA(Bucketize)
     .NumInputs(1)
@@ -69,7 +69,7 @@ output = [[1, 2], [2, 1], [1, 2]]
 NO_GRADIENT(BucketizeOp);
 } // namespace caffe2
 
-using BucketizeInt = caffe2::BucketizeOp<int, caffe2::CPUContext>;
+using BucketizeInt = caffe2::BucketizeOp<caffe2::CPUContext>;
 
 C10_EXPORT_CAFFE2_OP_TO_C10_CPU(
     Bucketize,

--- a/caffe2/operators/bucketize_op.cu
+++ b/caffe2/operators/bucketize_op.cu
@@ -1,7 +1,54 @@
 #include "caffe2/core/context_gpu.h"
 #include "caffe2/operators/bucketize_op.h"
-#include "caffe2/operators/operator_fallback_gpu.h"
+
+#include <thrust/binary_search.h>
+#include <thrust/device_vector.h>
 
 namespace caffe2 {
-REGISTER_CUDA_OPERATOR(Bucketize, GPUFallbackOp);
+
+__global__ void BucketizeOpKernel(
+    const int N,
+    const int M,
+    const float* bounds,
+    const float* X,
+    int32_t* out) {
+  CUDA_1D_KERNEL_LOOP(i, N) {
+    int32_t low = -1, high = M;
+    while (high - low > 1) {
+      int32_t median = (high + low) / 2;
+      if (bounds[median] < X[i]) {
+        low = median;
+      } else {
+        high = median;
+      }
+    }
+    out[i] = high;
+  }
+}
+
+template <>
+bool BucketizeOp<CUDAContext>::RunOnDevice() {
+  auto& input = Input(X);
+  CAFFE_ENFORCE_GE(input.dim(), 1);
+
+  auto N = input.numel();
+  auto* output = Output(INDICES, input.sizes(), at::dtype<int32_t>());
+  const auto* input_data = input.template data<float>();
+  auto* output_data = output->template mutable_data<int32_t>();
+
+  BucketizeOpKernel<<<
+      CAFFE_GET_BLOCKS(N),
+      CAFFE_CUDA_NUM_THREADS,
+      0,
+      context_.cuda_stream()>>>(
+      N,
+      boundaries_device_.numel(),
+      boundaries_device_.data<float>(),
+      input_data,
+      output_data);
+
+  return true;
+};
+
+REGISTER_CUDA_OPERATOR(Bucketize, BucketizeOp<CUDAContext>);
 } // namespace caffe2

--- a/caffe2/operators/bucketize_op.h
+++ b/caffe2/operators/bucketize_op.h
@@ -13,7 +13,7 @@ C10_DECLARE_EXPORT_CAFFE2_OP_TO_C10(BucketizeOp);
 
 namespace caffe2 {
 
-template <typename T, class Context>
+template <class Context>
 class BucketizeOp final : public Operator<Context> {
  public:
   USE_OPERATOR_CONTEXT_FUNCTIONS;
@@ -25,6 +25,13 @@ class BucketizeOp final : public Operator<Context> {
     CAFFE_ENFORCE(
         std::is_sorted(boundaries_.begin(), boundaries_.end()),
         "The boundaries need to be monotonically increasing");
+
+    boundaries_device_.Resize(boundaries_.size());
+    context_.template CopyFromCPU<float>(
+        boundaries_.size(),
+        boundaries_.data(),
+        boundaries_device_.mutable_data<float>());
+    context_.FinishDeviceComputation();
   }
 
   bool RunOnDevice() override;
@@ -35,6 +42,7 @@ class BucketizeOp final : public Operator<Context> {
 
  private:
   std::vector<float> boundaries_;
+  Tensor boundaries_device_{Context::GetDeviceType()};
 };
 
 } // namespace caffe2


### PR DESCRIPTION
Summary:
Current version goes through GPU -> CPU -> GPU copy and is pretty slow: ~19 ms
for 1M elements with 20 possible buckets based on benchmark.

This new version is ~0.2 on the same

Test Plan: benchmark + unit-test

Differential Revision: D19969518

