### PR TITLE
Call RandomNumberSeed() on-demand

### DIFF
--- a/caffe2/core/context.h
+++ b/caffe2/core/context.h
@@ -6,11 +6,11 @@
 #include <random>
 #include <unordered_map>
 
+#include <c10/util/typeid.h>
 #include "caffe2/core/allocator.h"
 #include "caffe2/core/context_base.h"
 #include "caffe2/core/event.h"
 #include "caffe2/core/logging.h"
-#include <c10/util/typeid.h>
 #include "caffe2/proto/caffe2_pb.h"
 
 #include <c10/util/ArrayRef.h>
@@ -40,11 +40,10 @@ CAFFE2_API uint32_t RandomNumberSeed();
 class CAFFE2_API CPUContext final : public BaseContext {
  public:
   typedef std::mt19937 rand_gen_type;
-  CPUContext() : random_seed_(RandomNumberSeed()) {}
+  CPUContext() {}
   explicit CPUContext(const DeviceOption& option)
-      : random_seed_(
-            option.has_random_seed() ? option.random_seed()
-                                     : RandomNumberSeed()) {
+      : random_seed_(option.has_random_seed() ? option.random_seed() : 1701),
+        random_seed_set_(option.has_random_seed() ? true : false) {
     CAFFE_ENFORCE_EQ(option.device_type(), PROTO_CPU);
   }
   explicit CPUContext(const at::Device& device)
@@ -69,6 +68,10 @@ class CAFFE2_API CPUContext final : public BaseContext {
 
   inline rand_gen_type& RandGenerator() {
     if (!random_generator_.get()) {
+      if (!random_seed_set_) {
+        random_seed_ = RandomNumberSeed();
+        random_seed_set_ = true;
+      }
       random_generator_.reset(new rand_gen_type(random_seed_));
     }
     return *random_generator_.get();
@@ -153,6 +156,7 @@ class CAFFE2_API CPUContext final : public BaseContext {
  protected:
   // TODO(jiayq): instead of hard-coding a generator, make it more flexible.
   int random_seed_{1701};
+  bool random_seed_set_{false};
   std::unique_ptr<rand_gen_type> random_generator_;
 };
 
@@ -169,6 +173,6 @@ inline void CPUContext::CopyBytes<CPUContext, CPUContext>(
   memcpy(dst, src, nbytes);
 }
 
-}  // namespace caffe2
+} // namespace caffe2
 
-#endif  // CAFFE2_CORE_CONTEXT_H_
+#endif // CAFFE2_CORE_CONTEXT_H_


### PR DESCRIPTION
Summary: We rarely use the `random_seed_` in context but we always initialize it with `RandomNumberSeed()` which isn't trivial. This diff makes it that we only call `RandomNumberSeed()` once when we want to use `random_seed_`.

Test Plan: unittests.

Differential Revision: D19993190

