### PR TITLE
Normalize reward-to-go in C++ actor-critic

### DIFF
--- a/test/cpp/api/integration.cpp
+++ b/test/cpp/api/integration.cpp
@@ -205,7 +205,7 @@ TEST_F(IntegrationTest, CartPole) {
     optimizer.zero_grad();
     loss.backward();
     optimizer.step();
-    
+
     rewards.clear();
     saved_log_probs.clear();
     saved_values.clear();

--- a/test/cpp/api/integration.cpp
+++ b/test/cpp/api/integration.cpp
@@ -204,7 +204,9 @@ TEST_F(IntegrationTest, CartPole) {
 
     optimizer.zero_grad();
     loss.backward();
-    optimizer.step().clear();
+    optimizer.step();
+    
+    rewards.clear();
     saved_log_probs.clear();
     saved_values.clear();
   };

--- a/test/cpp/api/integration.cpp
+++ b/test/cpp/api/integration.cpp
@@ -193,10 +193,10 @@ TEST_F(IntegrationTest, CartPole) {
     std::vector<torch::Tensor> policy_loss;
     std::vector<torch::Tensor> value_loss;
     for (auto i = 0U; i < saved_log_probs.size(); i++) {
-      auto r = rewards[i] - saved_values[i].item<float>();
-      policy_loss.push_back(-r * saved_log_probs[i]);
+      auto advantage = r_t[i] - saved_values[i].item<float>();
+      policy_loss.push_back(-advantage * saved_log_probs[i]);
       value_loss.push_back(
-          torch::smooth_l1_loss(saved_values[i], torch::ones(1) * rewards[i]));
+          torch::smooth_l1_loss(saved_values[i], torch::ones(1) * r_t[i]));
     }
 
     auto loss =
@@ -204,9 +204,7 @@ TEST_F(IntegrationTest, CartPole) {
 
     optimizer.zero_grad();
     loss.backward();
-    optimizer.step();
-
-    rewards.clear();
+    optimizer.step().clear();
     saved_log_probs.clear();
     saved_values.clear();
   };


### PR DESCRIPTION
Comparing to the [Python implementation](https://github.com/pytorch/examples/blob/master/reinforcement_learning/actor_critic.py), it seems like the tensor of normalized reward-to-go is computed but never used. Even if it's just an integration test, this PR switches to the normalized version for better convergence.