### PR TITLE
[caffe2] fix invalid % escape in inline assembly strings

### DIFF
--- a/aten/src/THC/THCAsmUtils.cuh
+++ b/aten/src/THC/THCAsmUtils.cuh
@@ -87,7 +87,7 @@ __device__ __forceinline__ int getLaneId() {
   return __lane_id();
 #else
   int laneId;
-  asm("mov.s32 %0, %laneid;" : "=r"(laneId) );
+  asm("mov.s32 %0, %%laneid;" : "=r"(laneId) );
   return laneId;
 #endif
 }

--- a/caffe2/utils/GpuDefs.cuh
+++ b/caffe2/utils/GpuDefs.cuh
@@ -109,7 +109,7 @@ __device__ __forceinline__ int getLaneId() {
   return __lane_id();
 #else
   int laneId;
-  asm("mov.s32 %0, %laneid;" : "=r"(laneId) );
+  asm("mov.s32 %0, %%laneid;" : "=r"(laneId) );
   return laneId;
 #endif // __HIP_PLATFORM_HCC__
 }


### PR DESCRIPTION
Summary:
NVCC/GCC accepts the existing syntax, but not Clang which requires a proper escape. Here `%laneid` is one of the many registers that CUDA's pseudo-asm provides [1]. And using the extra `%` doesn't change the semantics, as PTX expects `%laneid` value after it's processed by the asm tool.

1. https://docs.nvidia.com/cuda/parallel-thread-execution/index.html

Test Plan:
```lang=bash
buck build mode/opt -c fbcode.cuda_use_clang=true //fblearner/flow/projects/dper:workflow
buck build mode/opt //fblearner/flow/projects/dper:workflow

Differential Revision: D20003621

