### PR TITLE
[caffe2] fix field initialization after base Clang errors

### DIFF
--- a/aten/src/ATen/native/cuda/Reduce.cuh
+++ b/aten/src/ATen/native/cuda/Reduce.cuh
@@ -302,9 +302,20 @@ struct ReduceOp {
   bool final_output;
   int noutputs;
 
-  ReduceOp(ops_t ops, ReduceConfig config, InputCalculator input_calc, OutputCalculator output_calc,
-      const void* src, char* dst0, optional<char*> dst1, void* acc_buf, void* cta_buf, int* semaphores,
-      arg_t ident, int noutputs, int64_t base_idx)
+  ReduceOp(
+      ops_t ops,
+      ReduceConfig config,
+      InputCalculator input_calc,
+      OutputCalculator output_calc,
+      const void* src,
+      char* dst0,
+      optional<char*> dst1,
+      void* acc_buf,
+      void* cta_buf,
+      int* semaphores,
+      arg_t ident,
+      int noutputs,
+      int64_t base_idx)
       : ops(ops),
         ident(ident),
         config(config),
@@ -314,8 +325,8 @@ struct ReduceOp {
         acc_buf(acc_buf),
         cta_buf(cta_buf),
         semaphores(semaphores),
-        noutputs(noutputs),
-        base_idx(base_idx){
+        base_idx(base_idx),
+        noutputs(noutputs) {
     dst[0] = dst0;
     if (dst1.has_value()) {
       dst[1] = dst1.value();

--- a/caffe2/operators/channelwise_conv3d_op_cudnn.cu
+++ b/caffe2/operators/channelwise_conv3d_op_cudnn.cu
@@ -324,8 +324,7 @@ __global__ void DepthwiseConv3dBackpropInputGPUKernelNCHW(
           sum += __ldg(out_backprop + out_backprop_offset) *
               __ldg(filter + filter_offset);
 #else
-          sum += out_backprop[out_backprop_offset] *
-              filter[filter_offset];
+          sum += out_backprop[out_backprop_offset] * filter[filter_offset];
 #endif
         }
       }
@@ -464,8 +463,8 @@ class ChannelwiseConv3dGradientOp final : public ConvPoolOpBase<CUDAContext> {
  public:
   USE_CONV_POOL_BASE_FUNCTIONS(CUDAContext);
   ChannelwiseConv3dGradientOp(const OperatorDef& operator_def, Workspace* ws)
-      : cudnn_wrapper_(&context_),
-        ConvPoolOpBase<CUDAContext>(operator_def, ws),
+      : ConvPoolOpBase<CUDAContext>(operator_def, ws),
+        cudnn_wrapper_(&context_),
         no_bias_(OperatorBase::GetSingleArgument<int>("no_bias", 0)) {
     CAFFE_ENFORCE(
         !(no_bias_ && OutputSize() == 3),

--- a/caffe2/operators/depthwise_3x3_conv_op_cudnn.cu
+++ b/caffe2/operators/depthwise_3x3_conv_op_cudnn.cu
@@ -367,8 +367,8 @@ class Depthwise3x3ConvGradientOp final : public ConvPoolOpBase<CUDAContext> {
  public:
   USE_CONV_POOL_BASE_FUNCTIONS(CUDAContext);
   Depthwise3x3ConvGradientOp(const OperatorDef& operator_def, Workspace* ws)
-      : cudnn_wrapper_(&context_),
-        ConvPoolOpBase<CUDAContext>(operator_def, ws),
+      : ConvPoolOpBase<CUDAContext>(operator_def, ws),
+        cudnn_wrapper_(&context_),
         no_bias_(OperatorBase::GetSingleArgument<int>("no_bias", 0)) {
     CAFFE_ENFORCE(
         !(no_bias_ && OutputSize() == 3),


### PR DESCRIPTION
Summary:
Fix several places exposed by Clang where order of member initializer list doesn't actually match the actual initialization order. The fix is to simply reorder member initializer lists.

Also accepted formatting changes suggested by clang-format linter.

Test Plan:
```lang=bash
buck build mode/opt -c fbcode.cuda_use_clang=true //fblearner/flow/projects/dper:workflow
buck build mode/opt //fblearner/flow/projects/dper:workflow

Differential Revision: D20004834

