### PR TITLE
[caffe2] std::numeric_limits<double>::quiet_NaN() use instead of ::nan("")

### DIFF
--- a/aten/src/THCUNN/ClassNLLCriterion.cu
+++ b/aten/src/THCUNN/ClassNLLCriterion.cu
@@ -1,3 +1,5 @@
+#include <limits>
+
 #include <THCUNN/THCUNN.h>
 #include <THCUNN/common.h>
 #include <TH/THHalf.h>
@@ -128,7 +130,7 @@ __global__ void cunn_ClassNLLCriterion_updateOutput_kernel(Dtype *output,
     if (size_average) {
       if (nframe == 0) {
         // Mean reduction on empty tensors produces NaN
-        *output = ::nan("");
+        *output = std::numeric_limits<double>::quiet_NaN();
       }
       if (*total_weight != 0) {
         *output = ScalarConvert<Acctype, Dtype>::to(outputAcc / total_weightAcc);

--- a/aten/src/THCUNN/SpatialClassNLLCriterion.cu
+++ b/aten/src/THCUNN/SpatialClassNLLCriterion.cu
@@ -1,3 +1,5 @@
+#include <limits>
+
 #include <THCUNN/THCUNN.h>
 #include <TH/THHalf.h>
 #include <THC/THCNumerics.cuh>
@@ -126,7 +128,7 @@ __global__ void cunn_SpatialClassNLLCriterion_sizeAverage_kernel(
 {
   if (nElement == 0) {
     // Mean reduction on empty tensors produces NaN
-    *output = ::nan("");
+    *output = std::numeric_limits<double>::quiet_NaN();
   }
   if (*total_weight != 0) {
     *output = THCNumerics<T>::div(*output, *total_weight);


### PR DESCRIPTION
Test Plan:
```lang=bash
buck build mode/opt -c fbcode.cuda_use_clang=true //fblearner/flow/projects/dper:workflow
buck build mode/opt //fblearner/flow/projects/dper:workflow
```

Differential Revision: D20006447

