### PR TITLE
[caffe2] add missing fmaxType overloads in THCHalfAutoNumerics.cuh

### DIFF
--- a/aten/src/THCUNN/LogSigmoid.cu
+++ b/aten/src/THCUNN/LogSigmoid.cu
@@ -3,26 +3,11 @@
 #include <THCUNN/THCHalfAutoNumerics.cuh>
 #include <THC/THCApply.cuh>
 
-#if defined(_MSC_VER) || defined(__HIP_PLATFORM_HCC__)
-#define ZERO_MACRO zero<T>()
-template <typename T>
-inline __device__ typename std::enable_if<std::is_same<T, double>::value, T>::type zero() {
-        return 0.;
-}
-
-template <typename T>
-inline __device__ typename std::enable_if<!std::is_same<T, double>::value, T>::type zero() {
-        return 0.f;
-}
-#else
-#define ZERO_MACRO 0.f
-#endif
-
 template <typename T>
 struct logSigmoid_updateOutput_functor
 {
   __device__ void operator()(T *output, const T *input) const {
-    const T max = fmaxType(ZERO_MACRO, -*input);
+    const T max = fmaxType(T{0}, -*input);
     const T z = THCNumerics<T>::exp(-max) + THCNumerics<T>::exp(-*input -max);
     *output = -(max + static_cast<T>(std::log(z)));
   }
@@ -33,7 +18,7 @@ template <typename T>
 struct logSigmoid_updateGradInput_functor
 {
   __device__ void operator()(T *gradInput, const T *input, const T *gradOutput) const {
-    const T max = fmaxType(ZERO_MACRO, -*input);
+    const T max = fmaxType(T{0}, -*input);
     const T z = THCNumerics<T>::exp(-max) + THCNumerics<T>::exp(-*input -max);
     T max_deriv = 0.f;
     T sign = -1.f;


### PR DESCRIPTION
Summary: Clang reported a few places where a call to `fmaxType` is ambiguous. In all cases one of the arguments is `double` and another is `float`. Fix the error by adding the missing overloads.

Test Plan:
```lang=bash
buck build mode/opt -c fbcode.cuda_use_clang=true //fblearner/flow/projects/dper:workflow
buck build mode/opt //fblearner/flow/projects/dper:workflow
```

Differential Revision: D20006926

