### PR TITLE
Minimize the cases where we have to cpu_zero.

### DIFF
--- a/aten/src/ATen/native/BlasWrappersCPU.cpp
+++ b/aten/src/ATen/native/BlasWrappersCPU.cpp
@@ -9,9 +9,6 @@ namespace native {
 
 Tensor & mv_cpu_out(Tensor & result, const Tensor & self, const Tensor & vec) {
   result.resize_({ self.size(0) });
-  // we likely don't need to do this, see [NOTE: cpu_zero].
-  // We should do a full accounting that all cases are handled correctly, without it, though.
-  result.zero_();
   return legacy::cpu::_th_addmv_out(result, result, self, vec, 0, 1);
 }
 
@@ -22,9 +19,6 @@ Tensor mv_cpu(const Tensor & self, const Tensor & vec) {
 
 Tensor & mm_cpu_out(Tensor & result, const Tensor & self, const Tensor & mat2) {
   result.resize_({ self.size(0), mat2.size(1) });
-  // we likely don't need to do this, see [NOTE: cpu_zero].
-  // We should do a full accounting that all cases are handled correctly, without it, though.
-  result.zero_();
   return legacy::cpu::_th_addmm_out(result, result, self, mat2, 0, 1);
 }
 

--- a/aten/src/TH/generic/THBlas.cpp
+++ b/aten/src/TH/generic/THBlas.cpp
@@ -81,23 +81,22 @@ void THBlas_(scal)(int64_t n, scalar_t a, scalar_t *x, int64_t incx)
   if(n == 1)
     incx = 1;
 
+  // [NOTE: cpu_zero]
+  // at least on the following version of BLAS this does not folllow the same semantics
+  // when a == 0 and there exists a NaN in the input.  Namely, the non-BLAS code below results
+  // in a value of 0, whereas this results in a value of NaN.  This is problematic because a
+  // NaN in an output tensor needs to be zero'ed explicitly through a separate mechanism.
+  // At the ATen/TH binding layer, this was via "cpu_zero", which would zero out the output
+  // tensor.
+  // BLAS version:
+  // [conda] blas                      1.0                         mkl
+  // [conda] mkl                       2019.4                      243
 #if defined(USE_BLAS) && (defined(TH_REAL_IS_DOUBLE) || defined(TH_REAL_IS_FLOAT))
-  if( (n <= INT_MAX) && (incx <= INT_MAX) )
+  if( (n <= INT_MAX) && (incx <= INT_MAX) && (a != 0))
   {
     int i_n = (int)n;
     int i_incx = (int)incx;
 
-    // [NOTE: cpu_zero]
-    // at least on the following version of BLAS this does not folllow the same semantics
-    // when a == 0 and there exists a NaN in the input.  Namely, the non-BLAS code below results
-    // in a value of 0, whereas this results in a value of NaN.  This is problematic because a
-    // NaN in an output tensor needs to be zero'ed explicitly through a separate mechanism.
-    // At the ATen/TH binding layer, this was via "cpu_zero", which would zero out the output
-    // tensor.  This probably isn't necessary if we avoid these calls, but I haven't done a
-    // full analysis of the code.
-    // BLAS version:
-    // [conda] blas                      1.0                         mkl
-    // [conda] mkl                       2019.4                      243
 #if defined(TH_REAL_IS_DOUBLE)
     dscal_(&i_n, &a, x, &i_incx);
 #else


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#33570 Minimize the cases where we have to cpu_zero.**
* #31666 Fix NaN handling in torch.mv.

In this PR, we are a bit more careful about avoiding zero-ing the output.  Analysis as follows:
1) `mm` doesn't need zero_ because it never calls scal, which is the underlying problem.
2) for `mv`, which does call scal (in certain cases), we can just move the zeroing to where it would actually be a problem, namely when the scalar value is 0.
In this case we just run the non-BLAS version of the code.

Differential Revision: [D20007665](https://our.internmc.facebook.com/intern/diff/D20007665)