### PR TITLE
Revert "Revert D19975411: Remove special case codegen for tril_indices/triu_indices."

### DIFF
--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -677,7 +677,10 @@ Tensor range(
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ triangle ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Tensor tril_indices_cpu(
-    int64_t row, int64_t col, int64_t offset, const TensorOptions& options) {
+    int64_t row, int64_t col, int64_t offset, const TensorOptions& options_) {
+
+  TensorOptions options = options_.dtype(options_.dtype_opt().value_or(scalarTypeToTypeMeta(kLong)));
+
   check_args(row, col, options);
 
   auto tril_size = get_tril_size(row, col, offset);
@@ -722,7 +725,10 @@ Tensor tril_indices_cpu(
 }
 
 Tensor triu_indices_cpu(
-    int64_t row, int64_t col, int64_t offset, const TensorOptions& options) {
+    int64_t row, int64_t col, int64_t offset, const TensorOptions& options_) {
+
+  TensorOptions options = options_.dtype(options_.dtype_opt().value_or(scalarTypeToTypeMeta(kLong)));
+
   check_args(row, col, options);
 
   auto triu_size = row * col - get_tril_size(row, col, offset - 1);

--- a/aten/src/ATen/native/cuda/TensorFactories.cu
+++ b/aten/src/ATen/native/cuda/TensorFactories.cu
@@ -321,7 +321,10 @@ void tril_indices_kernel(scalar_t * tensor,
 // implementation, please enable them in test/test_cuda.py and make sure they
 // pass on your local server.
 Tensor tril_indices_cuda(
-    int64_t row, int64_t col, int64_t offset, const TensorOptions& options) {
+    int64_t row, int64_t col, int64_t offset, const TensorOptions& options_) {
+
+  TensorOptions options = options_.dtype(options_.dtype_opt().value_or(scalarTypeToTypeMeta(kLong)));
+
   check_args(row, col, options);
 
   auto tril_size = get_tril_size(row, col, offset);
@@ -395,7 +398,10 @@ void triu_indices_kernel(scalar_t * tensor,
 // implementation, please enable them in test/test_cuda.py and make sure they
 // pass on your local server.
 Tensor triu_indices_cuda(
-    int64_t row, int64_t col, int64_t offset, const TensorOptions& options) {
+    int64_t row, int64_t col, int64_t offset, const TensorOptions& options_) {
+
+  TensorOptions options = options_.dtype(options_.dtype_opt().value_or(scalarTypeToTypeMeta(kLong)));
+
   check_args(row, col, options);
 
   auto triu_size = row * col - get_tril_size(row, col, offset - 1);

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -4382,12 +4382,12 @@
   use_c10_dispatcher: full
   variants: method, function
 
-- func: tril_indices(int row, int col, int offset=0, *, ScalarType? dtype=long, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: tril_indices(int row, int col, int offset=0, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
   dispatch:
     CPU: tril_indices_cpu
     CUDA: tril_indices_cuda
 
-- func: triu_indices(int row, int col, int offset=0, *, ScalarType? dtype=long, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: triu_indices(int row, int col, int offset=0, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
   dispatch:
     CPU: triu_indices_cpu
     CUDA: triu_indices_cuda

--- a/aten/src/ATen/native_parse.py
+++ b/aten/src/ATen/native_parse.py
@@ -226,19 +226,6 @@ def parse_arguments(args, func_variants, declaration, func_return):
     supported_topt_arguments.append(copy.deepcopy(supported_topt_arguments[1]))
     for arg in supported_topt_arguments[2]:
         arg.update({'default': 'c10::nullopt', 'is_nullable': True})
-    # add explicit support for what is needed for tril_indices / triu_indices
-    supported_topt_arguments.append(
-        [
-            {'name': 'dtype', 'type': 'ScalarType', 'annotation': None, 'kwarg_only': True,
-             'default': 'long', 'is_nullable': True},
-            {'name': 'layout', 'type': 'Layout', 'annotation': None, 'kwarg_only': True,
-             'default': 'c10::nullopt', 'is_nullable': True},
-            {'name': 'device', 'type': 'Device', 'annotation': None, 'kwarg_only': True,
-             'default': 'c10::nullopt', 'is_nullable': True},
-            {'name': 'pin_memory', 'type': 'bool', 'annotation': None, 'kwarg_only': True,
-             'default': 'c10::nullopt', 'is_nullable': True},
-        ]
-    )
 
     corresponding_topts = [
         {'type': 'TensorOptions', 'name': 'options', 'is_nullable': False, 'annotation': None},

--- a/test/backward_compatibility/check_backward_compatibility.py
+++ b/test/backward_compatibility/check_backward_compatibility.py
@@ -21,6 +21,8 @@ white_list = [
     # We export some functions and classes for test_jit.py directly from libtorch.so,
     # it's not important to have BC for them
     ('_TorchScriptTesting.*', datetime.date(9999, 1, 1)),
+    ('aten::tril_indices', datetime.date(2020, 3, 1)),
+    ('aten::triu_indices', datetime.date(2020, 3, 1)),
     ('prim::Drop', datetime.date(2020, 3, 1)),
     ('prim::Store', datetime.date(2020, 3, 1)),
     ('aten::_ncf_view', datetime.date(2020, 3, 1)),

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -1293,7 +1293,7 @@ def make_python_arglists(declaration, is_python_method):
 
 # TODO blowtorch
 def dtype_default_type_hack(name):
-    if name.startswith('randperm') or name == 'tril_indices' or name == 'triu_indices':
+    if name.startswith('randperm'):
         return 'torch.int64'
     else:
         return 'None'


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#33572 Revert "Revert D19975411: Remove special case codegen for tril_indices/triu_indices."**

This reverts commit 687a7e4a2566861c53c8fb53a80b198465168b38.

Original PR #33305

Reland with BC tests whitelisted. See https://github.com/pytorch/pytorch/issues/33580 for reasoning why this change is not actually BC breaking.

Differential Revision: [D20011011](https://our.internmc.facebook.com/intern/diff/D20011011)