### PR TITLE
Enable test_DistributedDataParallel_SyncBatchNorm_2D_Input unit test

### DIFF
--- a/test/distributed/test_distributed.py
+++ b/test/distributed/test_distributed.py
@@ -1947,7 +1947,6 @@ class _DistTestBase(object):
                      "Only Nccl & Gloo backend support DistributedDataParallel")
     @skip_if_no_cuda_distributed
     @skip_if_no_gpu
-    @skip_if_rocm
     def test_DistributedDataParallel_SyncBatchNorm_2D_Input(self):
         group, group_id, rank = self._init_global_test()
         rank_to_GPU = self._init_multigpu_helper()


### PR DESCRIPTION
Test needs ability to toggle cuDNN/MIOpen at runtime (enabled in PR #33118)

