### PR TITLE
[caffe2] use Clang identification macro in various places

### DIFF
--- a/caffe2/utils/conversions.h
+++ b/caffe2/utils/conversions.h
@@ -13,7 +13,8 @@
 
 // See Note [hip-clang differences to hcc]
 
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__) || defined(__HIP__)
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__) || \
+    defined(__HIP__) || (defined(__clang__) && defined(__CUDA__))
 #define CONVERSIONS_DECL __host__ __device__ inline
 #else
 #define CONVERSIONS_DECL inline

--- a/caffe2/utils/fixed_divisor.h
+++ b/caffe2/utils/fixed_divisor.h
@@ -7,7 +7,8 @@
 
 // See Note [hip-clang differences to hcc]
 
-#if defined(__CUDA_ARCH__) || defined(__HIP_ARCH__) || defined(__HIP__)
+#if defined(__CUDA_ARCH__) || defined(__HIP_ARCH__) || defined(__HIP__) || \
+    (defined(__clang__) && defined(__CUDA__))
 #define FIXED_DIVISOR_DECL inline __host__ __device__
 #else
 #define FIXED_DIVISOR_DECL inline

--- a/caffe2/utils/math/utils.h
+++ b/caffe2/utils/math/utils.h
@@ -6,7 +6,7 @@
 #include "caffe2/core/common.h"
 
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__) || \
-    defined(__HIP__)
+    defined(__HIP__) || (defined(__clang__) && defined(__CUDA__))
 #define MATH_UTILS_DECL inline __host__ __device__
 #else
 #define MATH_UTILS_DECL inline


### PR DESCRIPTION
Summary:
Sprinkle with Clang identification macro places that otherwise would cause build errors when Clang is used to drive the CUDA compilation.

Note: `__clang__` is defined when either Clang is used as host compiler by NVCC or when Clang drives the compilation. `__CUDA__` is defined only for the latter case.

Test Plan:
```lang=bash
buck build mode/opt -c fbcode.cuda_use_clang=true //fblearner/flow/projects/dper:workflow
buck build mode/opt //fblearner/flow/projects/dper:workflow
```

Differential Revision: D20007440

