### PR TITLE
Make TestCuda.test_memory_stats more robust

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -5,6 +5,7 @@ import unittest
 import sys
 from itertools import repeat
 import os
+import gc
 from contextlib import contextmanager
 import threading
 if sys.version_info[0] == 3:
@@ -274,6 +275,7 @@ class TestCuda(TestCase):
         assert_change(0, reset_peak=True)
 
     def test_memory_stats(self):
+        gc.collect()
         torch.cuda.empty_cache()
         for _ in self._test_memory_stats_generator(self):
             self._check_memory_stat_consistency()


### PR DESCRIPTION
IIUC Python does not guarantee when an object is garbage collected. So it is possible that, some other test running before `TestCuda.test_memory_stats` creates object which is only garbage collected during  `TestCuda.test_memory_stats`, causing mem stats to change and causing this test to fail. This kind of failure is very hard to debug (it took me and @mcarilli and @ptrblck quite a while to figure out what is happening), and it is the root cause of @mcarilli's gradient scaling PR https://github.com/pytorch/pytorch/pull/26512 failing on Windows.

cc: @csarofeen 