### PR TITLE
[caffe2] fix no return statement in constexpr function Clang error in TypeIndex.h

### DIFF
--- a/c10/util/TypeIndex.h
+++ b/c10/util/TypeIndex.h
@@ -118,9 +118,9 @@ inline C10_TYPENAME_CONSTEXPR c10::string_view fully_qualified_type_name_impl() 
 #endif
 }
 
+#if !defined(__CUDA_ARCH__)
 template <typename T>
 inline constexpr uint64_t type_index_impl() {
-#if !defined(__CUDA_ARCH__)
 // Idea: __PRETTY_FUNCTION__ (or __FUNCSIG__ on msvc) contains a qualified name
 // of this function, including its template parameter, i.e. including the
 // type we want an id for. We use this name and run crc64 on it to get a type
@@ -132,10 +132,8 @@ inline constexpr uint64_t type_index_impl() {
 #elif defined(__GNUC__)
   return crc64(__PRETTY_FUNCTION__, sizeof(__PRETTY_FUNCTION__)).checksum();
 #endif
-#else
-  throw std::logic_error("This should not be called on device code");
-#endif
 }
+#endif
 
 } // namespace detail
 


### PR DESCRIPTION
Summary:
`throw` statement at the end of `constexpr` is ill-formed according to Clang. It happens when Clang is driving CUDA compilation and compiles for device the effected code. Due to its compilation model it requires host code to be well-formed even when compiling for device.

Fix the error by guarding the entire definition of `type_index_impl` with `__CUDA_ARCH__` check.

Test Plan:
```lang=bash
buck build mode/opt -c fbcode.cuda_use_clang=true //fblearner/flow/projects/dper:workflow
buck build mode/opt //fblearner/flow/projects/dper:workflow
```

Differential Revision: D20008881

