### PR TITLE
ONNX Error Message on Missing Op

### DIFF
--- a/torch/onnx/symbolic_registry.py
+++ b/torch/onnx/symbolic_registry.py
@@ -86,9 +86,25 @@ def is_registered_op(opname, domain, version):
     global _registry
     return (domain, version) in _registry and opname in _registry[(domain, version)]
 
+def get_op_supported_version(opname, domain, version):
+    iter_version = version
+    while iter_version <= _onnx_stable_opsets[-1]:
+        ops = [op[0] for op in get_ops_in_version(iter_version)]
+        if opname in ops:
+            return iter_version
+        iter_version += 1
+    return None
 
 def get_registered_op(opname, domain, version):
     if domain is None or version is None:
         warnings.warn("ONNX export failed. The ONNX domain and/or version are None.")
     global _registry
+    if not is_registered_op(opname, domain, version):
+        msg = "Exporting " + opname + " in ONNX is not supported in opset version " + str(version) + ". "
+        supported_version = get_op_supported_version(opname, domain, version)
+        if supported_version is not None:
+            msg += "Support for this operator was added in version " + str(supported_version) + ", try exporting with this version."
+        else:
+            msg += "Please open a bug to request ONNX export support for the missing operator."
+        raise RuntimeError(msg)
     return _registry[(domain, version)][opname]

--- a/torch/onnx/symbolic_registry.py
+++ b/torch/onnx/symbolic_registry.py
@@ -100,7 +100,7 @@ def get_registered_op(opname, domain, version):
         warnings.warn("ONNX export failed. The ONNX domain and/or version are None.")
     global _registry
     if not is_registered_op(opname, domain, version):
-        msg = "Exporting " + opname + " in ONNX is not supported in opset version " + str(version) + ". "
+        msg = "Exporting the operator " + opname + " to ONNX opset version " + str(version) + " is not supported. "
         supported_version = get_op_supported_version(opname, domain, version)
         if supported_version is not None:
             msg += "Support for this operator was added in version " + str(supported_version) + ", try exporting with this version."


### PR DESCRIPTION
Print a complete and comprehensive error message with a description of the issue when an op is missing during ONNX export (previously an ambiguous "key not in registry" error was thrown which was not helpful for the user to understand the failure).