### PR TITLE
[pt][quant] Enable the dynamic quant LSTM unit test by removing hypothesis

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/fc-dynamic-run.cc
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/fc-dynamic-run.cc
@@ -19,7 +19,7 @@ struct q8gemm_dq_context {
 };
 
 static void compute_q8gemm_dq(
-    const struct q8gemm_dq_context* context,
+    struct q8gemm_dq_context* context,
     size_t group_index,
     size_t pixel_index,
     size_t mr_block_start,

--- a/test/test_quantization.py
+++ b/test/test_quantization.py
@@ -534,205 +534,204 @@ class PostTrainingDynamicQuantTest(QuantizationTestCase):
         model = quantize_dynamic(NestedModel().eval(), qconfig_dict)
         checkQuantized(model)
 
-    @unittest.skip("temporarily disable the test")
-    @given(qengine=st.sampled_from(("qnnpack", "fbgemm")))
-    def test_quantized_rnn(self, qengine):
-        d_in, d_hid = 2, 2
+    def test_quantized_rnn(self):
+        for qengine in ("qnnpack", "fbgemm"):
+            d_in, d_hid = 2, 2
 
-        with override_quantized_engine(qengine):
-            model = LSTMDynamicModel().eval()
-            cell = model.lstm
+            with override_quantized_engine(qengine):
+                model = LSTMDynamicModel().eval()
+                cell = model.lstm
 
-            # Replace parameter values s.t. the range of values is exactly
-            # 255, thus we will have 0 quantization error in the quantized
-            # GEMM call. This i s for testing purposes.
-            #
-            # Note that the current implementation does not support
-            # accumulation values outside of the range representable by a
-            # 16 bit integer, instead resulting in a saturated value. We
-            # must take care that in our test we do not end up with a dot
-            # product that overflows the int16 range, e.g.
-            # (255*127+255*127) = 64770. So, we hardcode the test values
-            # here and ensure a mix of signedness.
-            vals = [[100, -155],
-                    [100, -155],
-                    [-155, 100],
-                    [-155, 100],
-                    [100, -155],
-                    [-155, 100],
-                    [-155, 100],
-                    [100, -155]]
-            if isinstance(cell, torch.nn.LSTM):
-                num_chunks = 4
-            vals = vals[:d_hid * num_chunks]
-            cell.weight_ih_l0 = torch.nn.Parameter(
-                torch.tensor(vals, dtype=torch.float),
-                requires_grad=False)
-            cell.weight_hh_l0 = torch.nn.Parameter(
-                torch.tensor(vals, dtype=torch.float),
-                requires_grad=False)
+                # Replace parameter values s.t. the range of values is exactly
+                # 255, thus we will have 0 quantization error in the quantized
+                # GEMM call. This i s for testing purposes.
+                #
+                # Note that the current implementation does not support
+                # accumulation values outside of the range representable by a
+                # 16 bit integer, instead resulting in a saturated value. We
+                # must take care that in our test we do not end up with a dot
+                # product that overflows the int16 range, e.g.
+                # (255*127+255*127) = 64770. So, we hardcode the test values
+                # here and ensure a mix of signedness.
+                vals = [[100, -155],
+                        [100, -155],
+                        [-155, 100],
+                        [-155, 100],
+                        [100, -155],
+                        [-155, 100],
+                        [-155, 100],
+                        [100, -155]]
+                if isinstance(cell, torch.nn.LSTM):
+                    num_chunks = 4
+                vals = vals[:d_hid * num_chunks]
+                cell.weight_ih_l0 = torch.nn.Parameter(
+                    torch.tensor(vals, dtype=torch.float),
+                    requires_grad=False)
+                cell.weight_hh_l0 = torch.nn.Parameter(
+                    torch.tensor(vals, dtype=torch.float),
+                    requires_grad=False)
 
-            ref = copy.deepcopy(cell)
+                ref = copy.deepcopy(cell)
 
-            model_int8 = quantize_dynamic(model=model, dtype=torch.qint8)
-            model_fp16 = quantize_dynamic(model=model, dtype=torch.float16)
+                model_int8 = quantize_dynamic(model=model, dtype=torch.qint8)
+                model_fp16 = quantize_dynamic(model=model, dtype=torch.float16)
 
-            # Smoke test extra reprs
-            self.assertTrue('DynamicQuantizedLSTM' in str(model_int8))
-            self.assertTrue('DynamicQuantizedLSTM' in str(model_fp16))
-            cell_int8 = model_int8.lstm
-            cell_fp16 = model_fp16.lstm
+                # Smoke test extra reprs
+                self.assertTrue('DynamicQuantizedLSTM' in str(model_int8))
+                self.assertTrue('DynamicQuantizedLSTM' in str(model_fp16))
+                cell_int8 = model_int8.lstm
+                cell_fp16 = model_fp16.lstm
 
-            assert type(cell_int8) == torch.nn.quantized.dynamic.LSTM, \
-                'torch.nn.LSTM should be converted to torch.nn.quantized.dynamic.LSTM after quantize_dynamic'
-            assert type(cell_fp16) == torch.nn.quantized.dynamic.LSTM, \
-                'torch.nn.LSTM should be converted to torch.nn.quantized.dynamic.LSTM after quantize_dynamic'
+                assert type(cell_int8) == torch.nn.quantized.dynamic.LSTM, \
+                    'torch.nn.LSTM should be converted to torch.nn.quantized.dynamic.LSTM after quantize_dynamic'
+                assert type(cell_fp16) == torch.nn.quantized.dynamic.LSTM, \
+                    'torch.nn.LSTM should be converted to torch.nn.quantized.dynamic.LSTM after quantize_dynamic'
 
-            niter = 10
-            x = torch.tensor([[100, -155],
-                              [-155, 100],
-                              [100, -155]], dtype=torch.float).unsqueeze(0).repeat(niter, 1, 1)
+                niter = 10
+                x = torch.tensor([[100, -155],
+                                  [-155, 100],
+                                  [100, -155]], dtype=torch.float).unsqueeze(0).repeat(niter, 1, 1)
 
-            h0_vals = [[-155, 100],
-                       [-155, 155],
-                       [100, -155]]
+                h0_vals = [[-155, 100],
+                           [-155, 155],
+                           [100, -155]]
 
-            hx = torch.tensor(h0_vals, dtype=torch.float).unsqueeze(0)
-            cx = torch.tensor(h0_vals, dtype=torch.float).unsqueeze(0)
+                hx = torch.tensor(h0_vals, dtype=torch.float).unsqueeze(0)
+                cx = torch.tensor(h0_vals, dtype=torch.float).unsqueeze(0)
 
-            if isinstance(ref, torch.nn.LSTM):
-                hiddens = (hx, cx)
+                if isinstance(ref, torch.nn.LSTM):
+                    hiddens = (hx, cx)
 
-            ref_out, ref_hid = ref(x, hiddens)
+                ref_out, ref_hid = ref(x, hiddens)
 
-            # Compare int8 quantized to unquantized
-            output_int8, final_hiddens_int8 = cell_int8(x, hiddens)
+                # Compare int8 quantized to unquantized
+                output_int8, final_hiddens_int8 = cell_int8(x, hiddens)
 
-            torch.testing.assert_allclose(output_int8, ref_out)
-            self.assertEqual(output_int8, ref_out)
-            for out_val, ref_val in zip(final_hiddens_int8, ref_hid):
-                torch.testing.assert_allclose(out_val, ref_val)
+                torch.testing.assert_allclose(output_int8, ref_out)
+                self.assertEqual(output_int8, ref_out)
+                for out_val, ref_val in zip(final_hiddens_int8, ref_hid):
+                    torch.testing.assert_allclose(out_val, ref_val)
 
-            class ScriptWrapper(torch.nn.Module):
-                def __init__(self, cell):
-                    super(ScriptWrapper, self).__init__()
-                    self.cell = cell
+                class ScriptWrapper(torch.nn.Module):
+                    def __init__(self, cell):
+                        super(ScriptWrapper, self).__init__()
+                        self.cell = cell
 
-                def forward(self, x, hiddens):
-                    # type: (torch.Tensor, Tuple[torch.Tensor, torch.Tensor])
-                    # -> Tuple[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]
-                    return self.cell(x, hiddens)
+                    def forward(self, x, hiddens):
+                        # type: (torch.Tensor, Tuple[torch.Tensor, torch.Tensor])
+                        # -> Tuple[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]
+                        return self.cell(x, hiddens)
 
-            # TODO: TorchScript overloads don't work without this wrapper
-            cell_script = torch.jit.script(ScriptWrapper(cell_int8))
-            out_script, hid_script = cell_script(x, hiddens)
-            self.assertEqual(len(out_script), len(ref_out))
-            for out_val, ref_val in zip(out_script, ref_out):
-                torch.testing.assert_allclose(out_val, ref_val)
+                # TODO: TorchScript overloads don't work without this wrapper
+                cell_script = torch.jit.script(ScriptWrapper(cell_int8))
+                out_script, hid_script = cell_script(x, hiddens)
+                self.assertEqual(len(out_script), len(ref_out))
+                for out_val, ref_val in zip(out_script, ref_out):
+                    torch.testing.assert_allclose(out_val, ref_val)
 
-            # Test save/load
-            b = io.BytesIO()
-            torch.jit.save(cell_script, b)
-            b.seek(0)
-            loaded = torch.jit.load(b)
-            out_loaded, hid_loaded = loaded(x, hiddens)
-            for loaded_val, ref_val in zip(out_loaded, ref_out):
-                torch.testing.assert_allclose(loaded_val, ref_val)
+                # Test save/load
+                b = io.BytesIO()
+                torch.jit.save(cell_script, b)
+                b.seek(0)
+                loaded = torch.jit.load(b)
+                out_loaded, hid_loaded = loaded(x, hiddens)
+                for loaded_val, ref_val in zip(out_loaded, ref_out):
+                    torch.testing.assert_allclose(loaded_val, ref_val)
 
-            # Compare fp16 quantized to unquantized
-            output_fp16, final_hiddens_fp16 = cell_fp16(x, hiddens)
+                # Compare fp16 quantized to unquantized
+                output_fp16, final_hiddens_fp16 = cell_fp16(x, hiddens)
 
-            torch.testing.assert_allclose(output_fp16, ref_out)
-            self.assertEqual(output_fp16, ref_out)
-            for out, ref_val in zip(final_hiddens_fp16, ref_hid):
-                torch.testing.assert_allclose(out, ref_val)
+                torch.testing.assert_allclose(output_fp16, ref_out)
+                self.assertEqual(output_fp16, ref_out)
+                for out, ref_val in zip(final_hiddens_fp16, ref_hid):
+                    torch.testing.assert_allclose(out, ref_val)
 
-            # Test tracing
-            # TODO: TorchScript overloads don't work without this wrapper
-            cell_trace = torch.jit.trace(ScriptWrapper(cell_int8), (x, (hx, cx)))
-            out_script, hid_script = cell_trace(x, hiddens)
-            for out_val, ref_val in zip(out_script, ref_out):
-                torch.testing.assert_allclose(out_val, ref_val)
+                # Test tracing
+                # TODO: TorchScript overloads don't work without this wrapper
+                cell_trace = torch.jit.trace(ScriptWrapper(cell_int8), (x, (hx, cx)))
+                out_script, hid_script = cell_trace(x, hiddens)
+                for out_val, ref_val in zip(out_script, ref_out):
+                    torch.testing.assert_allclose(out_val, ref_val)
 
-            # print(cell_trace.code)
+                # print(cell_trace.code)
 
-            # Test save/load
-            b = io.BytesIO()
-            torch.jit.save(cell_trace, b)
-            b.seek(0)
-            loaded = torch.jit.load(b)
-            out_loaded, hid_loaded = loaded(x, hiddens)
-            for loaded_val, ref_val in zip(out_loaded, ref_out):
-                torch.testing.assert_allclose(loaded_val, ref_val)
+                # Test save/load
+                b = io.BytesIO()
+                torch.jit.save(cell_trace, b)
+                b.seek(0)
+                loaded = torch.jit.load(b)
+                out_loaded, hid_loaded = loaded(x, hiddens)
+                for loaded_val, ref_val in zip(out_loaded, ref_out):
+                    torch.testing.assert_allclose(loaded_val, ref_val)
 
-            # Compare fp16 quantized to unquantized
-            output_fp16, final_hiddens_fp16 = cell_fp16(x, hiddens)
+                # Compare fp16 quantized to unquantized
+                output_fp16, final_hiddens_fp16 = cell_fp16(x, hiddens)
 
-            torch.testing.assert_allclose(output_fp16, ref_out)
-            self.assertEqual(output_fp16, ref_out)
-            for out, ref_val in zip(final_hiddens_fp16, ref_hid):
-                torch.testing.assert_allclose(out, ref_val)
+                torch.testing.assert_allclose(output_fp16, ref_out)
+                self.assertEqual(output_fp16, ref_out)
+                for out, ref_val in zip(final_hiddens_fp16, ref_hid):
+                    torch.testing.assert_allclose(out, ref_val)
 
-            class ScriptWrapperPacked(torch.nn.Module):
-                def __init__(self, cell):
-                    super(ScriptWrapperPacked, self).__init__()
-                    self.cell = cell
+                class ScriptWrapperPacked(torch.nn.Module):
+                    def __init__(self, cell):
+                        super(ScriptWrapperPacked, self).__init__()
+                        self.cell = cell
 
-                def forward(self,
-                            x,  # type: PackedSequence
-                            hiddens  # type: Tuple[torch.Tensor, torch.Tensor]
-                            ):
-                    # type: (...) -> Tuple[PackedSequence, Tuple[torch.Tensor, torch.Tensor]]
-                    return self.cell(x, hiddens)
+                    def forward(self,
+                                x,  # type: PackedSequence
+                                hiddens  # type: Tuple[torch.Tensor, torch.Tensor]
+                                ):
+                        # type: (...) -> Tuple[PackedSequence, Tuple[torch.Tensor, torch.Tensor]]
+                        return self.cell(x, hiddens)
 
-            cell_packed = torch.jit.script(ScriptWrapperPacked(cell_int8))
-            packed_input = torch.nn.utils.rnn.pack_padded_sequence(x, torch.tensor([10, 5, 2]))
-            ref_out_packed, ref_hid_packed = ref(packed_input, hiddens)
-            output_packed, hiddens_packed = cell_packed(packed_input, hiddens)
+                cell_packed = torch.jit.script(ScriptWrapperPacked(cell_int8))
+                packed_input = torch.nn.utils.rnn.pack_padded_sequence(x, torch.tensor([10, 5, 2]))
+                ref_out_packed, ref_hid_packed = ref(packed_input, hiddens)
+                output_packed, hiddens_packed = cell_packed(packed_input, hiddens)
 
-            for packed_val, ref_val in zip(output_packed, ref_out_packed):
-                if isinstance(packed_val, torch.Tensor):
-                    torch.testing.assert_allclose(packed_val, ref_val)
-                else:
-                    self.assertEqual(packed_val, ref_val)
+                for packed_val, ref_val in zip(output_packed, ref_out_packed):
+                    if isinstance(packed_val, torch.Tensor):
+                        torch.testing.assert_allclose(packed_val, ref_val)
+                    else:
+                        self.assertEqual(packed_val, ref_val)
 
-            # Test save/load
-            b = io.BytesIO()
-            torch.jit.save(cell_packed, b)
-            b.seek(0)
-            loaded_packed = torch.jit.load(b)
-            out_loaded_packed, hid_loaded_packed = loaded_packed(packed_input, hiddens)
-            for packed_val, ref_val in zip(out_loaded_packed, ref_out_packed):
-                if isinstance(packed_val, torch.Tensor):
-                    torch.testing.assert_allclose(packed_val, ref_val)
-                else:
-                    self.assertEqual(packed_val, ref_val)
+                # Test save/load
+                b = io.BytesIO()
+                torch.jit.save(cell_packed, b)
+                b.seek(0)
+                loaded_packed = torch.jit.load(b)
+                out_loaded_packed, hid_loaded_packed = loaded_packed(packed_input, hiddens)
+                for packed_val, ref_val in zip(out_loaded_packed, ref_out_packed):
+                    if isinstance(packed_val, torch.Tensor):
+                        torch.testing.assert_allclose(packed_val, ref_val)
+                    else:
+                        self.assertEqual(packed_val, ref_val)
 
-            # Test default instantiation
-            seq_len = 128
-            batch = 16
-            input_size = 3
-            hidden_size = 7
-            num_layers = 2
-            bias = True
-            bidirectional = False
+                # Test default instantiation
+                seq_len = 128
+                batch = 16
+                input_size = 3
+                hidden_size = 7
+                num_layers = 2
+                bias = True
+                bidirectional = False
 
-            x = torch.rand(seq_len, batch, input_size)
-            h = torch.rand(num_layers * (bidirectional + 1), batch, hidden_size)
-            c = torch.rand(num_layers * (bidirectional + 1), batch, hidden_size)
+                x = torch.rand(seq_len, batch, input_size)
+                h = torch.rand(num_layers * (bidirectional + 1), batch, hidden_size)
+                c = torch.rand(num_layers * (bidirectional + 1), batch, hidden_size)
 
-            dtype = torch.qint8
+                dtype = torch.qint8
 
-            cell_dq = torch.nn.quantized.dynamic.LSTM(input_size=input_size,
-                                                      hidden_size=hidden_size,
-                                                      num_layers=num_layers,
-                                                      bias=bias,
-                                                      batch_first=False,
-                                                      dropout=0.0,
-                                                      bidirectional=bidirectional,
-                                                      dtype=dtype)
+                cell_dq = torch.nn.quantized.dynamic.LSTM(input_size=input_size,
+                                                          hidden_size=hidden_size,
+                                                          num_layers=num_layers,
+                                                          bias=bias,
+                                                          batch_first=False,
+                                                          dropout=0.0,
+                                                          bidirectional=bidirectional,
+                                                          dtype=dtype)
 
-            y, (h, c) = cell_dq(x, (h, c))
+                y, (h, c) = cell_dq(x, (h, c))
 
 
 @unittest.skipUnless('fbgemm' in torch.backends.quantized.supported_engines,

--- a/test/test_quantization.py
+++ b/test/test_quantization.py
@@ -536,6 +536,8 @@ class PostTrainingDynamicQuantTest(QuantizationTestCase):
 
     def test_quantized_rnn(self):
         for qengine in ("qnnpack", "fbgemm"):
+            print("qengine:")
+            print(qengine)
             d_in, d_hid = 2, 2
 
             with override_quantized_engine(qengine):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#33594 [pt][quant] Enable the dynamic quant LSTM unit test by removing hypothesis**

Check more discussions in https://github.com/pytorch/pytorch/issues/32644.

Previously, after landing https://github.com/pytorch/pytorch/pull/32757, we found the flaky tests on `test_quantized_rnn` in some specific CI environment, where we cannot reproduce in our devserver.

The error is reported as it failed the `scale > 0` check in https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/quantized/cpu/quant_utils.h#L69 .

- Step 1: we disabled the unit tests in https://github.com/pytorch/pytorch/pull/32742

- Step 2: we investigated the FBGEMM `ChooseQuantizationParams` routine and added assert for min, max, qmin, qmax, but we didn't find the abnormal numbers :
https://github.com/pytorch/pytorch/pull/32739

scale is calculated as the following:
float scale = (static_cast<double>(max) - min) / (qmax - qmin);

If max is larger than min, and qmax is larger than qmin, then scale should be always positive.

- Step 3: we tried to print the intermediate result of x_min and x_max in https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp#L59-L63. Check https://github.com/pytorch/pytorch/pull/33167 for the places we add the prints.

One interesting test case caused the failure:
```
Jan 29 23:46:57 x_min: -nan, x_max: -nan
Jan 29 23:46:57 input: -nan 0.195275 -0.380797 -0.510193 -0.662963 0.761594 0.923773 -nan -0.123308 -0.380797 -0.761594 -0.603171 0.906278 0.000028 -nan 0.462941 -0.380797 -0.651336 0.717926 0.761594 0.460751 -nan 0.945544 -0.380797 -0.334840 0.831535 0.761594 0.793159 -nan -0.752703 -0.380797 -0.761594 0.809177 0.761594 0.955718 -nan -0.717292 -0.380797 -0.650404 0.790869 0.761594 0.812008 -nan 0.917088 -0.380797 -0.761594 0.829536 0.761594 0.000000 -nan 0.855218 -0.380796 -0.036113 0.815578 0.761594 0.942870 -nan -0.675926 -0.380797 -0.755426 -0.658459 0.000000 0.000000 -nan 0.490974 -0.380797 -0.725917 -0.539679 0.761594 0.836110 -nan -0.714314 -0.380797 -0.761594 -0.738534 0.761594 0.791485 -nan 0.345541 -0.380797 -0.670953 -0.609272 0.962786 0.834005 -nan -0.583866 -0.380797 -0.761594 -0.620485 0.750284 0.854029 -nan -0.661655 -0.380797 -0.282387 0.863691 0.761593 0.956279 -nan -0.667277 -0.380797 -0.730052 -0.732839 0.761594 0.002185 -nan 0.380570 -0.380797 -0.453875 -0.523069 0.834210 0.792132
```

More detailed test results are here:
https://circleci.com/gh/pytorch/pytorch/4374802?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

Basically, x_min and x_max are both -nan, which failed the check for x_min <= x_max. Actually if any operands for a comparison is nan (e.g., nan < 3, nan < nan, nan <= nan), the result for the comparison will always be False. The culprit should be this NaN value.

The issue is where we generated such NaN value?

- Step 4:
We analyzed that NaN can possibly come from two sources:

    - Unit test: when when we initialize the `torch.Tensor` or `torch.rand` somewhere, it generates NaN number;

    - Somewhere in `aten/src/ATen/native/RNN.cpp` or `torch/nn/quantized/dynamic/modules/rnn.py`, we used some illegal instructions.

As there is no such issue before https://github.com/pytorch/pytorch/pull/32757, we suspect some changes in that PR triggered this issue.

In https://github.com/pytorch/pytorch/pull/33167, we avoided using hypothesis by removing `@given(qengine=st.sampled_from(("qnnpack", "fbgemm"))):` and all tests pass.

It looks like that the hypothesis added in https://github.com/pytorch/pytorch/pull/32757 triggered the generation of NaN in some input tensors.


- Step 5:

We still need to find the root cause for NaN, either it is the problem of hypothesis itself, or hypothesis generated more random cases which helped triggered some NaN numbers in `RNN.cpp` or `rnn.py`.

Differential Revision: [D20016038](https://our.internmc.facebook.com/intern/diff/D20016038/)