### PR TITLE
Add Scalar::type()

### DIFF
--- a/c10/core/Scalar.h
+++ b/c10/core/Scalar.h
@@ -98,6 +98,20 @@ class C10_API Scalar {
 
   Scalar operator-() const;
 
+  ScalarType type() const {
+    if (isComplex()) {
+      return ScalarType::ComplexDouble;
+    } else if (isFloatingPoint()) {
+      return ScalarType::Double;
+    } else if (isIntegral(/*includeBool=*/false)) {
+      return ScalarType::Long;
+    } else if (isBoolean()) {
+      return ScalarType::Bool;
+    } else {
+      throw std::runtime_error("Unknown scalar type.");
+    }
+  }
+
  private:
     template<typename T,
              typename std::enable_if<std::numeric_limits<T>::is_integer && ! std::is_same<T, bool>::value, bool>::type* =

--- a/caffe2/contrib/aten/gen_op.py
+++ b/caffe2/contrib/aten/gen_op.py
@@ -73,7 +73,7 @@ def value_is_tensor_type(v):
 # for each aten type, how do we handle a return value of that type?
 RETURN_MAP = {
     'Tensor': 'assignTo(Output(${offset}),${output});',
-    'Scalar': 'assignTo(Output(${offset}),self.scalar_type(), ${output});',
+    'Scalar': 'assignTo(Output(${offset}),${output}.type(), ${output});',
     'bool': 'assignToValue<int64_t>(Output(${offset}),${output});',
     'int64_t': 'assignToValue<int64_t>(Output(${offset}),${output});',
     'std::vector<Tensor>': 'assignListStartingAt(${offset}, ${output});',


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #29238 Remove specific processing of declarations of add, sub, mul, div, rsub
* #29602 Add functions add/sub/rsub/mul/div that accept a scalar as first arg
* **#33603 Add Scalar::type()**

This function returns ScalarType based on its value. This is helpful
to avoid code generated in aten_op.h has returned Scalars depending on
arg self to determine its type.

Differential Revision: [D20100218](https://our.internmc.facebook.com/intern/diff/D20100218)