### PR TITLE
Fixes cuda->numpy and non-strided->numpy segfaults

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -2146,5 +2146,9 @@ t2.start()
         self.assertEqual(val, 1)
         self.assertEqual(idx, x.shape[0] - 1)
 
+    def test_to_numpy(self):
+        self.assertRaises(TypeError, lambda: torch.empty(1, device="cuda").numpy())
+
+
 if __name__ == '__main__':
     run_tests()

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -24,7 +24,7 @@ from torch.testing._internal.common_methods_invocations import tri_tests_args, t
     _compare_trilu_indices, _compare_large_trilu_indices
 from torch.testing._internal.common_utils import TestCase, get_gpu_type, freeze_rng_state, run_tests, \
     PY3, IS_WINDOWS, NO_MULTIPROCESSING_SPAWN, skipIfRocm, \
-    load_tests, slowTest, skipCUDANonDefaultStreamIf, TEST_WITH_ROCM
+    load_tests, slowTest, skipCUDANonDefaultStreamIf, TEST_WITH_ROCM, TEST_NUMPY
 
 # load_tests from common_utils is used to automatically filter tests for
 # sharding on sandcastle. This line silences flake warnings
@@ -2146,6 +2146,7 @@ t2.start()
         self.assertEqual(val, 1)
         self.assertEqual(idx, x.shape[0] - 1)
 
+    @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
     def test_to_numpy(self):
         self.assertRaises(TypeError, lambda: torch.empty(1, device="cuda").numpy())
 

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -2136,6 +2136,13 @@ class TestSparse(TestCase):
                                lambda: torch.tensor(1., device=self.device).to_sparse()
                                / torch.tensor(1., device=self.device).to_sparse())
 
+    def test_sparse_to_numpy(self):
+        i = torch.LongTensor([[0, 1, 1],
+                              [2, 0, 2]])
+        v = torch.FloatTensor([3, 4, 5])
+        st = torch.sparse.FloatTensor(i, v, torch.Size([2, 3]))
+        self.assertRaises(TypeError, lambda: st.numpy())
+
 
 class TestUncoalescedSparse(TestSparse):
     def setUp(self):

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -2137,11 +2137,8 @@ class TestSparse(TestCase):
                                / torch.tensor(1., device=self.device).to_sparse())
 
     def test_sparse_to_numpy(self):
-        i = torch.LongTensor([[0, 1, 1],
-                              [2, 0, 2]])
-        v = torch.FloatTensor([3, 4, 5])
-        st = torch.sparse.FloatTensor(i, v, torch.Size([2, 3]))
-        self.assertRaises(TypeError, lambda: st.numpy())
+        t = torch.sparse_coo_tensor(torch.tensor(([0, 0], [2, 0])), torch.tensor([1, 4]))
+        self.assertRaises(TypeError, lambda: t.numpy())
 
 
 class TestUncoalescedSparse(TestSparse):

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -10,7 +10,7 @@ import random
 import sys
 import unittest
 from torch.testing._internal.common_utils import TestCase, run_tests, skipIfRocm, do_test_dtypes, \
-    do_test_empty_full, load_tests
+    do_test_empty_full, load_tests, TEST_NUMPY
 from torch.testing._internal.common_cuda import TEST_CUDA
 from numbers import Number
 from torch.autograd.gradcheck import gradcheck
@@ -2136,6 +2136,7 @@ class TestSparse(TestCase):
                                lambda: torch.tensor(1., device=self.device).to_sparse()
                                / torch.tensor(1., device=self.device).to_sparse())
 
+    @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
     def test_sparse_to_numpy(self):
         t = torch.sparse_coo_tensor(torch.tensor(([0, 0], [2, 0])), torch.tensor([1, 4]))
         self.assertRaises(TypeError, lambda: t.numpy())

--- a/torch/csrc/utils/tensor_numpy.cpp
+++ b/torch/csrc/utils/tensor_numpy.cpp
@@ -74,11 +74,13 @@ static std::vector<int64_t> seq_to_aten_shape(PyObject *py_seq) {
 }
 
 PyObject* tensor_to_numpy(const at::Tensor& tensor) {
+  // std::cout << "tensor_numpy.cpp: tensor_to_numpy" << std::endl;
   if (tensor.device().type() != DeviceType::CPU) {
-      throw TypeError(
-        "can't convert %s device type tensor to numpy. Use Tensor.cpu() to "
-        "copy the tensor to host memory first.", tensor.device().type());
+    throw TypeError(
+      "can't convert non-cpu device type tensor to numpy. Use Tensor.cpu() to "
+      "copy the tensor to host memory first.");
   }
+  std::cout << "tensor_numpy.cpp A" << std::endl;
   if (tensor.layout() != Layout::Strided) {
       throw TypeError(
         "can't convert %s layout tensor to numpy."

--- a/torch/csrc/utils/tensor_numpy.cpp
+++ b/torch/csrc/utils/tensor_numpy.cpp
@@ -74,17 +74,15 @@ static std::vector<int64_t> seq_to_aten_shape(PyObject *py_seq) {
 }
 
 PyObject* tensor_to_numpy(const at::Tensor& tensor) {
-  // std::cout << "tensor_numpy.cpp: tensor_to_numpy" << std::endl;
   if (tensor.device().type() != DeviceType::CPU) {
     throw TypeError(
-      "can't convert non-cpu device type tensor to numpy. Use Tensor.cpu() to "
+      "can't convert non-cpu tensor to numpy. Use Tensor.cpu() to "
       "copy the tensor to host memory first.");
   }
-  std::cout << "tensor_numpy.cpp A" << std::endl;
   if (tensor.layout() != Layout::Strided) {
       throw TypeError(
-        "can't convert %s layout tensor to numpy."
-        "convert the tensor to a strided layout first.", tensor.layout());
+        "can't convert non-strided tensor to numpy."
+        "convert the tensor to a strided layout first.");
   }
   if (tensor.requires_grad()) {
     throw std::runtime_error(


### PR DESCRIPTION
Addresses https://github.com/pytorch/pytorch/issues/33300.

Calling .numpy() on a CUDA or non-strided (e.g. sparse) tensor segfaults in current PyTorch. This fixes the segfaults and throws the appropriate TypeError, as was intended. 

Two tests, one in test_cuda.py and the other in test_sparse.py, are added to verify the behavior.