### PR TITLE
[ONNX] Fix translation for -1 in Expand op

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -607,6 +607,15 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.randn(2, 3, 4)
         self.run_test(Unsqueeze(), x)
 
+    @skipIfUnsupportedMinOpsetVersion(8)
+    def test_expand(self):
+        class Expand(torch.nn.Module):
+            def forward(self, x):
+                return x.expand((5, -1, 2, 3, 1))
+
+        x = torch.randn(3, 2, 1, 1)
+        self.run_test(Expand(), x)
+
     def test_maxpool_default_stride(self):
         class MaxPoolModel(torch.nn.Module):
             def forward(self, x):

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -304,6 +304,7 @@ def t(g, self):
 def expand(g, self, size, implicit):
     size = sym_help._maybe_get_const(size, 'is')
     if not sym_help._is_value(size):
+        size = [1 if d == -1 else d for d in size]
         size = g.op("Constant", value_t=torch.LongTensor(size))
     return g.op("Expand", self, size)
 


### PR DESCRIPTION
PyTorch's expand uses -1 to tell the dimension should not change while ONNX's Expand uses 1.

This fixes #32926.

