### PR TITLE
improve the doc of enforce_sorted in pack_padded_sequence

### DIFF
--- a/torch/nn/utils/rnn.py
+++ b/torch/nn/utils/rnn.py
@@ -209,7 +209,7 @@ def pack_padded_sequence(input, lengths, batch_first=False, enforce_sorted=True)
             format.
         enforce_sorted (bool, optional): if ``True``, the input is expected to
             contain sequences sorted by length in a decreasing order. If
-            ``False``, this condition is not checked. Default: ``True``.
+            ``False``, the input will get sorted unconditionally. Default: ``True``.
 
     Returns:
         a :class:`PackedSequence` object


### PR DESCRIPTION
this is a follow up PR to https://github.com/pytorch/pytorch/issues/33602:

torch/nn/utils/rnn.html:

`pack_padded_sequence` has a confusing and incomplete description of the `enforce_sorted` param. Currently it goes:

```
        enforce_sorted (bool, optional): if ``True``, the input is expected to
            contain sequences sorted by length in a decreasing order. If
            ``False``, this condition is not checked. Default: ``True``.
```

The second part "this condition is not checked" (1) makes no sense since the alluded to condition is not described and (2) it's incomplete as it doesn't reflect the important part, that it actually does the sorting. I think it should say something like:

```
        enforce_sorted (bool, optional): if ``True``, the input is expected to
            contain sequences sorted by length in a decreasing order. If
            ``False``, the input will get sorted unconditionally. Default: ``True``.
```