### PR TITLE
[pytorch] add MemoryFormatType to jit_type

### DIFF
--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -55,6 +55,7 @@ using OptNameList = c10::optional<std::vector<std::string>>;
   _(QSchemeType)            \
   _(LayoutType)             \
   _(ScalarTypeType)         \
+  _(MemoryFormatType)       \
   _(AnyListType)            \
   _(AnyTupleType)
 
@@ -1842,52 +1843,71 @@ struct CAFFE2_API InterfaceType : public NamedType {
 
 template <TypeKind K>
 struct EnumerationType : public Type {
-static const TypeKind Kind = K;
+  static const TypeKind Kind = K;
 
-bool operator==(const Type& rhs) const override {
-  return rhs.kind() == kind();
-}
+  bool operator==(const Type& rhs) const override {
+    return rhs.kind() == kind();
+  }
 
 protected:
-EnumerationType() : Type(Kind) {}
+  EnumerationType() : Type(Kind) {}
 };
 
 struct LayoutType;
 using LayoutTypePtr = std::shared_ptr<LayoutType>;
-// This type represents a Generator
+// This type represents a Layout
 struct CAFFE2_API LayoutType : public EnumerationType<TypeKind::LayoutType> {
-static LayoutTypePtr create() {
-return LayoutTypePtr(
-    new LayoutType()); // NOLINT(modernize-make-shared)
-}
-std::string str() const override {
-return "Layout";
-}
-static const TypeKind Kind = TypeKind::LayoutType;
-// global singleton
-static LayoutTypePtr get();
+  static LayoutTypePtr create() {
+  return LayoutTypePtr(
+      new LayoutType()); // NOLINT(modernize-make-shared)
+  }
+  std::string str() const override {
+    return "Layout";
+  }
+  static const TypeKind Kind = TypeKind::LayoutType;
+  // global singleton
+  static LayoutTypePtr get();
 
 private:
-LayoutType() : EnumerationType() {}
+  LayoutType() : EnumerationType() {}
 };
 
 struct ScalarTypeType;
 using ScalarTypeTypePtr = std::shared_ptr<ScalarTypeType>;
-// This type represents a Generator
+// This type represents a ScalarType
 struct CAFFE2_API ScalarTypeType : public EnumerationType<TypeKind::ScalarTypeType> {
-static ScalarTypeTypePtr create() {
-return ScalarTypeTypePtr(
-    new ScalarTypeType()); // NOLINT(modernize-make-shared)
-}
-std::string str() const override {
-return "ScalarType";
-}
-static const TypeKind Kind = TypeKind::ScalarTypeType;
-// global singleton
-static ScalarTypeTypePtr get();
+  static ScalarTypeTypePtr create() {
+  return ScalarTypeTypePtr(
+      new ScalarTypeType()); // NOLINT(modernize-make-shared)
+  }
+  std::string str() const override {
+    return "ScalarType";
+  }
+  static const TypeKind Kind = TypeKind::ScalarTypeType;
+  // global singleton
+  static ScalarTypeTypePtr get();
 
 private:
-ScalarTypeType() : EnumerationType() {}
+  ScalarTypeType() : EnumerationType() {}
+};
+
+struct MemoryFormatType;
+using MemoryFormatTypePtr = std::shared_ptr<MemoryFormatType>;
+// This type represents a MemoryFormat
+struct CAFFE2_API MemoryFormatType : public EnumerationType<TypeKind::MemoryFormatType> {
+  static MemoryFormatTypePtr create() {
+    return MemoryFormatTypePtr(
+        new MemoryFormatType()); // NOLINT(modernize-make-shared)
+  }
+  std::string str() const override {
+    return "MemoryFormat";
+  }
+  static const TypeKind Kind = TypeKind::MemoryFormatType;
+  // global singleton
+  static MemoryFormatTypePtr get();
+
+private:
+  MemoryFormatType() : EnumerationType() {}
 };
 
 // the common supertype of all lists,

--- a/aten/src/ATen/core/type.cpp
+++ b/aten/src/ATen/core/type.cpp
@@ -163,12 +163,16 @@ DeviceObjTypePtr DeviceObjType::get() {
   return value;
 }
 ScalarTypeTypePtr ScalarTypeType::get() {
-static auto value = ScalarTypeType::create();
-return value;
+  static auto value = ScalarTypeType::create();
+  return value;
 }
 LayoutTypePtr LayoutType::get() {
-static auto value = LayoutType::create();
-return value;
+  static auto value = LayoutType::create();
+  return value;
+}
+MemoryFormatTypePtr MemoryFormatType::get() {
+  static auto value = MemoryFormatType::create();
+  return value;
 }
 OptionalTypePtr OptionalType::ofTensor() {
   static auto value = OptionalType::create(TensorType::get());

--- a/torch/csrc/jit/pybind_utils.h
+++ b/torch/csrc/jit/pybind_utils.h
@@ -7,6 +7,7 @@
 #include <torch/csrc/Device.h>
 #include <torch/csrc/Dtype.h>
 #include <torch/csrc/Layout.h>
+#include <torch/csrc/MemoryFormat.h>
 #include <torch/csrc/QScheme.h>
 #include <torch/csrc/WindowsTorchApiMacro.h>
 #include <torch/csrc/jit/operator.h>
@@ -384,6 +385,7 @@ inline IValue toIValue(
     // TODO(xintchen): Handling LayoutType and ScalarTypeType correctly.
     case TypeKind::LayoutType:
     case TypeKind::ScalarTypeType:
+    case TypeKind::MemoryFormatType:
       if (THPDtype_Check(obj.ptr())) {
         auto dtype = reinterpret_cast<THPDtype*>(obj.ptr());
         return static_cast<int64_t>(dtype->scalar_type);
@@ -395,6 +397,10 @@ inline IValue toIValue(
       if (THPLayout_Check(obj.ptr())) {
         auto layout = reinterpret_cast<THPLayout*>(obj.ptr());
         return static_cast<int8_t>(layout->layout);
+      }
+      if (THPMemoryFormat_Check(obj.ptr())) {
+        auto memory_format = reinterpret_cast<THPMemoryFormat*>(obj.ptr());
+        return static_cast<int8_t>(memory_format->memory_format);
       }
       return py::cast<int64_t>(obj);
     case TypeKind::NoneType:

--- a/torch/csrc/jit/unpickler.cpp
+++ b/torch/csrc/jit/unpickler.cpp
@@ -65,6 +65,7 @@ void restoreAccurateTypeTags(const IValue& root, const TypePtr& type_tag) {
       case QSchemeType::Kind:
       case LayoutType::Kind:
       case ScalarTypeType::Kind:
+      case MemoryFormatType::Kind:
       case RRefType::Kind:
         // no op, there is nothing to tag
         break;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#33624 [pytorch] add MemoryFormatType to jit_type**

Summary:
A baby step to fill the gaps listed on #32366.

ScalarType / Layout were introduced to jit_type earlier in #31074 -
This PR simply follows what was done there.

These enums can already convert from/to IValue as Int.

Will work on deeper integration next.

Test Plan:
- CI

Differential Revision: [D20037683](https://our.internmc.facebook.com/intern/diff/D20037683)