### PR TITLE
[quant] Regsiter fake_quant and observer attributes as buffers

### DIFF
--- a/torch/quantization/fake_quantize.py
+++ b/torch/quantization/fake_quantize.py
@@ -52,8 +52,8 @@ class FakeQuantize(Module):
         self.activation_post_process = observer(**observer_kwargs)
         assert torch.iinfo(self.activation_post_process.dtype).min <= quant_min, 'quant_min out of bound'
         assert quant_max <= torch.iinfo(self.activation_post_process.dtype).max, 'quant_max out of bound'
-        self.scale = torch.tensor([1.0])
-        self.zero_point = torch.tensor([0])
+        self.register_buffer('scale', torch.tensor([1.0]))
+        self.register_buffer('zero_point', torch.tensor([0]))
         self.dtype = self.activation_post_process.dtype
         self.qscheme = self.activation_post_process.qscheme
         self.ch_axis = self.activation_post_process.ch_axis if hasattr(self.activation_post_process, 'ch_axis') else None

--- a/torch/quantization/fake_quantize.py
+++ b/torch/quantization/fake_quantize.py
@@ -106,7 +106,8 @@ class FakeQuantize(Module):
 
     def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict,
                               missing_keys, unexpected_keys, error_msgs):
-
+        # Removing this function throws an error that the the size of the loaded tensor does not match the original size
+        # i.e., These buffers start out with numel 0 and become numel 1 once they have their first forward pass.
         local_state = ['scale', 'zero_point']
         for name in local_state:
             key = prefix + name

--- a/torch/quantization/fake_quantize.py
+++ b/torch/quantization/fake_quantize.py
@@ -111,7 +111,8 @@ class FakeQuantize(Module):
         for name in local_state:
             key = prefix + name
             if key in state_dict:
-                setattr(self, name, state_dict.pop(key))
+                val = state_dict[key]
+                setattr(self, name, val)
             elif strict:
                 missing_keys.append(key)
         super(FakeQuantize, self)._load_from_state_dict(state_dict, prefix, local_metadata, strict,

--- a/torch/quantization/observer.py
+++ b/torch/quantization/observer.py
@@ -339,8 +339,8 @@ class MinMaxObserver(_ObserverBase):
         local_state = ['min_val', 'max_val']
         for name in local_state:
             key = prefix + name
-            val = state_dict[key]
             if key in state_dict:
+                val = state_dict[key]
                 setattr(self, name, val)
             elif strict:
                 missing_keys.append(key)
@@ -501,8 +501,8 @@ class PerChannelMinMaxObserver(_ObserverBase):
         local_state = ['min_vals', 'max_vals']
         for name in local_state:
             key = prefix + name
-            val = state_dict[key]
             if key in state_dict:
+                val = state_dict[key]
                 setattr(self, name, val)
             elif strict:
                 missing_keys.append(key)
@@ -839,8 +839,8 @@ class HistogramObserver(_ObserverBase):
         local_state = ['min_val', 'max_val']
         for name in local_state:
             key = prefix + name
-            val = state_dict[key]
             if key in state_dict:
+                val = state_dict[key]
                 setattr(self, name, val)
             elif strict:
                 missing_keys.append(key)

--- a/torch/quantization/observer.py
+++ b/torch/quantization/observer.py
@@ -296,8 +296,8 @@ class MinMaxObserver(_ObserverBase):
         super(MinMaxObserver, self).__init__(dtype=dtype,
                                              qscheme=qscheme,
                                              reduce_range=reduce_range)
-        self.min_val = torch.tensor([])
-        self.max_val = torch.tensor([])
+        self.register_buffer('min_val', torch.tensor([]))
+        self.register_buffer('max_val', torch.tensor([]))
         if self.qscheme == torch.per_tensor_symmetric and \
            self.reduce_range and \
            self.dtype == torch.quint8:
@@ -440,8 +440,8 @@ class PerChannelMinMaxObserver(_ObserverBase):
                                                        qscheme=qscheme,
                                                        reduce_range=reduce_range)
         self.ch_axis = ch_axis
-        self.min_vals = torch.tensor([])
-        self.max_vals = torch.tensor([])
+        self.register_buffer('min_vals', torch.tensor([]))
+        self.register_buffer('max_vals', torch.tensor([]))
         if (
             self.qscheme == torch.per_channel_symmetric
             and self.reduce_range
@@ -591,8 +591,8 @@ class HistogramObserver(_ObserverBase):
                                                 reduce_range=reduce_range)
         self.bins = bins
         self.register_buffer('histogram', torch.zeros(self.bins))
-        self.min_val = torch.tensor([])
-        self.max_val = torch.tensor([])
+        self.register_buffer('min_val', torch.tensor([]))
+        self.register_buffer('max_val', torch.tensor([]))
         self.dst_nbins = 2 ** torch.iinfo(self.dtype).bits
         self.upsample_rate = upsample_rate
 

--- a/torch/quantization/observer.py
+++ b/torch/quantization/observer.py
@@ -489,12 +489,10 @@ class PerChannelMinMaxObserver(_ObserverBase):
     def extra_repr(self):
         return "min_val={}, max_val={}".format(self.min_vals, self.max_vals)
 
-
     def _save_to_state_dict(self, destination, prefix, keep_vars):
         super(PerChannelMinMaxObserver, self)._save_to_state_dict(destination, prefix, keep_vars)
         destination[prefix + 'min_vals'] = self.min_vals
         destination[prefix + 'max_vals'] = self.max_vals
-
 
     def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict,
                               missing_keys, unexpected_keys, error_msgs):

--- a/torch/quantization/observer.py
+++ b/torch/quantization/observer.py
@@ -339,8 +339,9 @@ class MinMaxObserver(_ObserverBase):
         local_state = ['min_val', 'max_val']
         for name in local_state:
             key = prefix + name
+            val = state_dict[key]
             if key in state_dict:
-                setattr(self, name, state_dict.pop(key))
+                setattr(self, name, val)
             elif strict:
                 missing_keys.append(key)
         super(MinMaxObserver, self)._load_from_state_dict(state_dict, prefix, local_metadata, strict,
@@ -488,18 +489,21 @@ class PerChannelMinMaxObserver(_ObserverBase):
     def extra_repr(self):
         return "min_val={}, max_val={}".format(self.min_vals, self.max_vals)
 
+
     def _save_to_state_dict(self, destination, prefix, keep_vars):
         super(PerChannelMinMaxObserver, self)._save_to_state_dict(destination, prefix, keep_vars)
         destination[prefix + 'min_vals'] = self.min_vals
         destination[prefix + 'max_vals'] = self.max_vals
+
 
     def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict,
                               missing_keys, unexpected_keys, error_msgs):
         local_state = ['min_vals', 'max_vals']
         for name in local_state:
             key = prefix + name
+            val = state_dict[key]
             if key in state_dict:
-                setattr(self, name, state_dict.pop(key))
+                setattr(self, name, val)
             elif strict:
                 missing_keys.append(key)
         super(PerChannelMinMaxObserver, self)._load_from_state_dict(state_dict, prefix, local_metadata, strict,
@@ -835,8 +839,9 @@ class HistogramObserver(_ObserverBase):
         local_state = ['min_val', 'max_val']
         for name in local_state:
             key = prefix + name
+            val = state_dict[key]
             if key in state_dict:
-                setattr(self, name, state_dict.pop(key))
+                setattr(self, name, val)
             elif strict:
                 missing_keys.append(key)
         super(HistogramObserver, self)._load_from_state_dict(state_dict, prefix, local_metadata, strict,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#33626 [quant] Regsiter fake_quant and observer attributes as buffers**

Summary: For DDP we require the attributes to be registered as buffers. By doing this the value is broadcast from one device to the rest.

Test Plan:
Tested on actual model on GPU

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D20038839](https://our.internmc.facebook.com/intern/diff/D20038839)