### PR TITLE
misc windows warning fixes

### DIFF
--- a/aten/src/ATen/native/cpu/Activation.cpp
+++ b/aten/src/ATen/native/cpu/Activation.cpp
@@ -1,4 +1,6 @@
+#ifndef _USE_MATH_DEFINES
 #define _USE_MATH_DEFINES
+#endif
 
 #include <ATen/native/Activation.h>
 

--- a/c10/macros/Macros.h
+++ b/c10/macros/Macros.h
@@ -84,8 +84,8 @@
 #endif
 
 // suppress an unused variable.
-#ifdef _MSC_VER
-#define C10_UNUSED
+#if defined(_MSC_VER) && !defined(__clang__)
+#define C10_UNUSED __pragma(warning(suppress: 4100 4101))
 #else
 #define C10_UNUSED __attribute__((__unused__))
 #endif //_MSC_VER

--- a/caffe2/serialize/inline_container.h
+++ b/caffe2/serialize/inline_container.h
@@ -1,16 +1,15 @@
 #pragma once
 
+#include <cerrno>
 #include <cstdio>
 #include <cstring>
-#include <cerrno>
+#include <fstream>
 #include <istream>
 #include <ostream>
-#include <fstream>
 
 #include <c10/core/Allocator.h>
 #include <c10/core/Backend.h>
 
-#include "caffe2/core/logging.h"
 #include "caffe2/serialize/istream_adapter.h"
 #include "caffe2/serialize/read_adapter_interface.h"
 
@@ -34,10 +33,12 @@ typedef struct mz_zip_archive mz_zip_archive;
 //          ...
 //        # code entries will only exist for modules that have methods attached
 //        code/
-//          archive_name.py # serialized torch script code (python syntax, using PythonPrint)
-//          archive_name_my_submodule.py # submodules have separate files
+//          archive_name.py # serialized torch script code (python syntax, using
+//          PythonPrint) archive_name_my_submodule.py # submodules have separate
+//          files
 //
-// The PyTorchStreamWriter also ensures additional useful properties for these files
+// The PyTorchStreamWriter also ensures additional useful properties for these
+// files
 // 1. All files are stored uncompressed.
 // 2. All files in the archive are aligned to 64 byte boundaries such that
 //    it is possible to mmap the entire file and get an aligned pointer to
@@ -49,8 +50,8 @@ typedef struct mz_zip_archive mz_zip_archive;
 //    zip tools. This means that even though our writer doesn't compress files,
 //    the reader can still read files that were compressed.
 // 2. It provides a getRecordOffset function which returns the offset into the
-//    raw file where file data lives. If the file was written with PyTorchStreamWriter
-//    it is guaranteed to be 64 byte aligned.
+//    raw file where file data lives. If the file was written with
+//    PyTorchStreamWriter it is guaranteed to be 64 byte aligned.
 
 // PyTorchReader/Writer handle checking the version number on the archive format
 // and ensure that all files are written to a archive_name directory so they
@@ -75,9 +76,9 @@ typedef struct mz_zip_archive mz_zip_archive;
 //         not put any indicies into the header to fulfill this constraint.
 
 // The model.json, which contains all the metadata information,
-// should be written as the last file. One reason is that the size of tensor data is
-// usually stable. As long as the shape and type of the tensor do not change,
-// the size of the data won't change. On the other sied, the size of the
+// should be written as the last file. One reason is that the size of tensor
+// data is usually stable. As long as the shape and type of the tensor do not
+// change, the size of the data won't change. On the other sied, the size of the
 // serialized model is likely to change, so we store it as the last record, and
 // we don't need to move previous records when updating the model data.
 
@@ -112,6 +113,7 @@ class CAFFE2_API PyTorchStreamReader final {
   uint64_t version() const {
     return version_;
   }
+
  private:
   void init();
   size_t read(uint64_t pos, char* buf, size_t n);
@@ -151,7 +153,7 @@ class CAFFE2_API PyTorchStreamWriter final {
   ~PyTorchStreamWriter();
 
  private:
-  void setup(const string& file_name);
+  void setup(const std::string& file_name);
   void valid(const char* what, const char* info = "");
   size_t current_pos_ = 0;
   std::unique_ptr<mz_zip_archive> ar_;


### PR DESCRIPTION
Summary:
* `inline_container.h` was unnecessarily exposing all includers to caffe2 headers via `caffe2/core/logging.h`
* Add msvc version of hiding unused warnings.
* Make sure clang on windows does not use msvc pragmas.
* Don't redefine math macro.

Test Plan: CI green

Differential Revision: D20017046

