### PR TITLE
Add MemoryFormat to TensorOptions in codegen.

### DIFF
--- a/aten/src/ATen/native/Distance.cpp
+++ b/aten/src/ATen/native/Distance.cpp
@@ -123,7 +123,7 @@ Tensor _cdist_backward(const Tensor& grad, const Tensor& x1, const Tensor& x2, c
   TORCH_CHECK(device2 == kCPU || device2 == kCUDA, "_cdist_backward only supports CPU and CUDA devices, X2 got: ", device2);
   IntArrayRef batch_tensor1(x1.sizes().data(), std::max<int64_t>(x1.dim() - 2, 0));
   int batch_product = std::accumulate(batch_tensor1.begin(), batch_tensor1.end(), 1, std::multiplies<int64_t>());
-  Tensor grad_x1 = at::empty_like(x1, x1.options(), LEGACY_CONTIGUOUS_MEMORY_FORMAT).view({batch_product, n, m});
+  Tensor grad_x1 = at::empty_like(x1, x1.options().memory_format(LEGACY_CONTIGUOUS_MEMORY_FORMAT)).view({batch_product, n, m});
   cdist_backward_stub(device1, grad_x1, grad, x1, x2, p, cdist);
   return grad_x1;
 }
@@ -132,7 +132,7 @@ Tensor _pdist_forward(const Tensor& self, const double p) {
   TORCH_CHECK(self.is_contiguous(), "_pdist_forward requires contiguous input");
   auto device = self.device().type();
   TORCH_CHECK(device == kCPU || device == kCUDA, "_pdist_forward only supports CPU and CUDA devices, got: ", device);
-  Tensor result = at::empty({0}, self.options(), LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+  Tensor result = at::empty({0}, self.options().memory_format(LEGACY_CONTIGUOUS_MEMORY_FORMAT));
   if (self.size(0) <= 1) {
     result.resize_({0});
   } else {

--- a/aten/src/ATen/native/Distributions.cpp
+++ b/aten/src/ATen/native/Distributions.cpp
@@ -258,7 +258,7 @@ Tensor normal_cpu(double mean, const Tensor& std, Generator* gen) {
 }
 
 Tensor normal_cpu(const Tensor& mean, const Tensor& std, Generator* gen) {
-  Tensor ret = at::empty({0}, mean.options(), MemoryFormat::Contiguous);
+  Tensor ret = at::empty({0}, mean.options().memory_format(MemoryFormat::Contiguous));
   normal_out_cpu(ret, mean, std, gen);
   return ret;
 }

--- a/aten/src/ATen/native/QuantizedLinear.cpp
+++ b/aten/src/ATen/native/QuantizedLinear.cpp
@@ -97,8 +97,8 @@ Tensor fbgemm_linear_int8_weight_fp32_activation(
   // Allocate output Tensor and a buffer for fbgemmPacked to use
   std::vector<int64_t> output_size = input.sizes().vec();
   output_size.back() = N;
-  Tensor output = at::empty(output_size, input.options().dtype(at::kFloat), LEGACY_CONTIGUOUS_MEMORY_FORMAT);
-  Tensor buffer = at::empty(output_size, input.options().dtype(at::kInt), LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+  Tensor output = at::empty(output_size, input.options().dtype(at::kFloat).memory_format(LEGACY_CONTIGUOUS_MEMORY_FORMAT));
+  Tensor buffer = at::empty(output_size, input.options().dtype(at::kInt).memory_format(LEGACY_CONTIGUOUS_MEMORY_FORMAT));
 
   // Pull out the PackBMatrix instance from the owning tensor
   auto& pack_b =
@@ -248,7 +248,7 @@ std::tuple<Tensor, Tensor, double, int64_t> fbgemm_linear_quantize_weight(
   // Calculate column offsets of the weight and store them away in a tensor.
   // Similarly to quantization, this can be done once and cached.
   Tensor col_offsets = at::empty(
-      {weight_contig.size(0)}, weight_contig.options().dtype(at::kInt), LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+      {weight_contig.size(0)}, weight_contig.options().dtype(at::kInt).memory_format(LEGACY_CONTIGUOUS_MEMORY_FORMAT));
   CalcColOffsetsTranspose(
       /*K=*/quantized.size(1),
       /*N=*/quantized.size(0),

--- a/aten/src/ATen/native/QuantizedLinear.cpp
+++ b/aten/src/ATen/native/QuantizedLinear.cpp
@@ -236,7 +236,7 @@ std::tuple<Tensor, Tensor, double, int64_t> fbgemm_linear_quantize_weight(
   q_params.precision = kPrecision;
 
   Tensor quantized = at::native::empty_like(
-      weight_contig, weight_contig.options().dtype(at::kChar), LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+      weight_contig, weight_contig.options().dtype(at::kChar).memory_format(LEGACY_CONTIGUOUS_MEMORY_FORMAT));
   // Tensor quantized = at::native::empty_cpu(
   //     weight_contig.sizes(), weight_contig.options().dtype(at::kChar));
   fbgemm::Quantize<int8_t>(

--- a/aten/src/ATen/native/TensorCompare.cpp
+++ b/aten/src/ATen/native/TensorCompare.cpp
@@ -65,7 +65,7 @@ Tensor isnan(const Tensor& self) {
 Tensor isinf(const Tensor &self) {
   // Integral tensor types are always not inf
   if (isIntegralType(self.scalar_type())) {
-    return at::zeros_like(self, at::kBool, at::MemoryFormat::Preserve);
+    return at::zeros_like(self, at::dtype(at::kBool).memory_format(at::MemoryFormat::Preserve));
   }
   return AT_DISPATCH_FLOATING_TYPES_AND_HALF(self.scalar_type(), "isinf", [&]() {
     return self.abs() == std::numeric_limits<scalar_t>::infinity();
@@ -75,7 +75,7 @@ Tensor isinf(const Tensor &self) {
 Tensor isfinite(const Tensor& self) {
   // Integral tensor types are finite
   if (!self.is_floating_point()) {
-    return at::ones_like(self, at::kBool, at::MemoryFormat::Preserve);
+    return at::ones_like(self, at::dtype(at::kBool).memory_format(at::MemoryFormat::Preserve));
   }
   return AT_DISPATCH_FLOATING_TYPES_AND_HALF(self.scalar_type(), "isfinite", [&]() {
     return (self == self) * (self.abs() != std::numeric_limits<scalar_t>::infinity());

--- a/aten/src/ATen/native/TensorConversions.cpp
+++ b/aten/src/ATen/native/TensorConversions.cpp
@@ -44,13 +44,7 @@ static inline Tensor to_impl(const Tensor& self, const TensorOptions& options, b
   return r;
 }
 
-Tensor to(const Tensor& self, const TensorOptions& options_, bool non_blocking, bool copy, c10::optional<c10::MemoryFormat> optional_memory_format) {
-
-  TORCH_CHECK(
-    !(options_.has_memory_format() && optional_memory_format.has_value()),
-    "Cannot set memory_format both in TensorOptions and explicit argument; please delete "
-    "the redundant setter.");
-  auto options = options_.merge_in(TensorOptions().memory_format(optional_memory_format));
+Tensor to(const Tensor& self, const TensorOptions& options, bool non_blocking, bool copy) {
 
   auto memory_format = options.memory_format_opt().value_or(MemoryFormat::Contiguous);
 
@@ -78,7 +72,7 @@ Tensor to(const Tensor& self, const TensorOptions& options_, bool non_blocking, 
   if (dtype_opt) {
     specified_options = specified_options.dtype(dtype_opt.value());
   }
-  return to_impl(self, specified_options.memory_format(optional_memory_format), non_blocking, copy);
+  return to_impl(self, specified_options, non_blocking, copy);
 }
 
 Tensor to(const Tensor& self, Device device, ScalarType dtype, bool non_blocking, bool copy, c10::optional<c10::MemoryFormat> optional_memory_format) {

--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -98,13 +98,7 @@ Tensor _dim_arange(const Tensor& like, int64_t dim) {
 }
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ empty ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Tensor empty_cpu(IntArrayRef size, const TensorOptions& options_, c10::optional<c10::MemoryFormat> optional_memory_format) {
-
-  TORCH_CHECK(
-    !(options_.has_memory_format() && optional_memory_format.has_value()),
-    "Cannot set memory_format both in TensorOptions and explicit argument; please delete "
-    "the redundant setter.");
-  TensorOptions options = options_.merge_in(TensorOptions().memory_format(optional_memory_format));
+Tensor empty_cpu(IntArrayRef size, const TensorOptions& options) {
 
   AT_ASSERT(options.device().type() == DeviceType::CPU);
   TORCH_INTERNAL_ASSERT(impl::variable_excluded_from_dispatch());
@@ -142,7 +136,7 @@ Tensor empty(
     at::optional<DimnameList> names,
     const TensorOptions& options) {
   if (!names.has_value()) {
-    return at::empty(size, options, optional_memory_format);
+    return at::empty(size, options);
   }
   TORCH_CHECK(options.layout() == Layout::Strided,
       "NYI: named tensors only support strided layout");
@@ -190,22 +184,12 @@ AT_FORALL_SCALAR_TYPES_AND3(Bool, Half, BFloat16, DEFINE_CAST_OP)
 
 Tensor empty_like(
     const Tensor& self,
-    const TensorOptions& options_,
-    c10::optional<c10::MemoryFormat> optional_memory_format) {
+    const TensorOptions& options_) {
+
+  TensorOptions options = self.options().merge_in(options_);
 
   TORCH_CHECK(
-    !(options_.has_memory_format() && optional_memory_format.has_value()),
-    "Cannot set memory_format both in TensorOptions and explicit argument; please delete "
-    "the redundant setter.");
-
-  TensorOptions options =
-      self.options()
-          .merge_in(options_)
-          .merge_in(TensorOptions().memory_format(optional_memory_format));
-
-  TORCH_CHECK(
-      !(options.layout() != kStrided &&
-          optional_memory_format.has_value()),
+      !(options.layout() != kStrided && options.has_memory_format()),
       "memory format option is only supported by strided tensors");
   if (options.layout() == kSparse && self.is_sparse()) {
     auto result = at::empty({0}, options); // to be resized
@@ -220,7 +204,7 @@ Tensor empty_like(
 
     // TODO: To support all features of MemoryFormat::Preserve we need to add
     // _empty_affine_quantized_strided function and use it similarly to
-    // Tensor clone(const Tensor& src, c10::optional<c10::MemoryFormat> optional_memory_format)
+    // Tensor clone(const Tensor& src)
     // if (self.is_non_overlapping_and_dense()) -> _empty_affine_quantized_strided
     if (memory_format == MemoryFormat::Preserve) {
       memory_format = self.suggest_memory_format();
@@ -336,9 +320,8 @@ Tensor& full_out(Tensor& result, IntArrayRef size, Scalar fill_value) {
 Tensor full_like(
     const Tensor& self,
     Scalar fill_value,
-    const TensorOptions& options,
-    c10::optional<c10::MemoryFormat> optional_memory_format) {
-  auto result = at::empty_like(self, options, optional_memory_format);
+    const TensorOptions& options) {
+  auto result = at::empty_like(self);
   return result.fill_(fill_value);
 }
 
@@ -388,9 +371,8 @@ Tensor& ones_out(Tensor& result, IntArrayRef size) {
 
 Tensor ones_like(
     const Tensor& self,
-    const TensorOptions& options,
-    c10::optional<c10::MemoryFormat> optional_memory_format) {
-  auto result = at::empty_like(self, options, optional_memory_format);
+    const TensorOptions& options) {
+  auto result = at::empty_like(self, options);
   return result.fill_(1);
 }
 
@@ -434,9 +416,8 @@ Tensor& rand_out(Tensor& result, IntArrayRef size, Generator* generator) {
 
 Tensor rand_like(
     const Tensor& self,
-    const TensorOptions& options,
-    c10::optional<c10::MemoryFormat> optional_memory_format) {
-  auto result = at::empty_like(self, options, optional_memory_format);
+    const TensorOptions& options) {
+  auto result = at::empty_like(self, options);
   return result.uniform_(0, 1, nullptr);
 }
 
@@ -502,9 +483,8 @@ Tensor& randint_out(
 Tensor randint_like(
     const Tensor& self,
     int64_t high,
-    const TensorOptions& options,
-    c10::optional<c10::MemoryFormat> optional_memory_format) {
-  auto result = at::empty_like(self, options, optional_memory_format);
+    const TensorOptions& options) {
+  auto result = at::empty_like(self, options);
   return result.random_(0, high, nullptr);
   return native::randint(high, self.sizes(), nullptr, options);
 }
@@ -513,9 +493,8 @@ Tensor randint_like(
     const Tensor& self,
     int64_t low,
     int64_t high,
-    const TensorOptions& options,
-    c10::optional<c10::MemoryFormat> optional_memory_format) {
-  auto result = at::empty_like(self, options, optional_memory_format);
+    const TensorOptions& options) {
+  auto result = at::empty_like(self, options);
   return result.random_(low, high, nullptr);
 }
 
@@ -553,9 +532,8 @@ Tensor& normal_out(Tensor& result, double mean, double std,
 
 Tensor randn_like(
     const Tensor& self,
-    const TensorOptions& options,
-    c10::optional<c10::MemoryFormat> optional_memory_format) {
-  auto result = at::empty_like(self, options, optional_memory_format);
+    const TensorOptions& options) {
+  auto result = at::empty_like(self, options);
   return result.normal_(0, 1, nullptr);
 }
 
@@ -732,15 +710,14 @@ Tensor& zeros_out(Tensor& result, IntArrayRef size) {
 
 Tensor zeros_like(
     const Tensor& self,
-    const TensorOptions& options,
-    c10::optional<c10::MemoryFormat> optional_memory_format) {
+    const TensorOptions& options) {
   if (options.layout() == kSparse && self.is_sparse()) {
     auto res = at::empty({0}, options); // to be resized
     res.sparse_resize_and_clear_(
         self.sizes(), self.sparse_dim(), self.dense_dim());
     return res;
   }
-  auto result = at::empty_like(self, options, optional_memory_format);
+  auto result = at::empty_like(self, options);
   return result.zero_();
 }
 
@@ -921,7 +898,7 @@ Tensor clone(const Tensor& src, c10::optional<c10::MemoryFormat> optional_memory
       memory_format = src.suggest_memory_format();
     }
   }
-  auto self = at::empty_like(src, src.options(), memory_format);
+  auto self = at::empty_like(src, src.options().memory_format(memory_format));
   self.copy_(src);
   return self;
 }

--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -140,8 +140,7 @@ Tensor empty_cpu(IntArrayRef size, const TensorOptions& options_, c10::optional<
 Tensor empty(
     IntArrayRef size,
     at::optional<DimnameList> names,
-    const TensorOptions& options,
-    optional<MemoryFormat> optional_memory_format) {
+    const TensorOptions& options) {
   if (!names.has_value()) {
     return at::empty(size, options, optional_memory_format);
   }
@@ -149,7 +148,7 @@ Tensor empty(
       "NYI: named tensors only support strided layout");
   TORCH_CHECK(options.device().type() == DeviceType::CPU || options.device().type() == DeviceType::CUDA,
       "NYI: named tensors only support CPU and CUDA tensors");
-  auto result = at::empty(size, options, optional_memory_format);
+  auto result = at::empty(size, options);
   internal_set_names_inplace(result, names);
   return result;
 }
@@ -163,13 +162,7 @@ Tensor empty_strided_cpu(IntArrayRef size, IntArrayRef stride, const TensorOptio
 
 Tensor& empty_out(
     Tensor& result,
-    IntArrayRef size,
-    c10::optional<c10::MemoryFormat> optional_memory_format) {
-  // Preferably, this argument would not be accepted by _out, but the code
-  // generator requires the out and non-out overloads to match exactly
-  TORCH_CHECK(
-      !optional_memory_format.has_value(),
-      "'memory_format' argument is incompatible with 'out' tensor argument");
+    IntArrayRef size) {
   check_size_nonnegative(size);
   if (result.is_sparse()) {
     result.sparse_resize_and_clear_(size, size.size(), 0);

--- a/aten/src/ATen/native/TensorIterator.cpp
+++ b/aten/src/ATen/native/TensorIterator.cpp
@@ -912,7 +912,7 @@ bool TensorIterator::fast_set_up() {
           auto& op = operands_[i];
           if (!op.tensor.defined()) {
             TORCH_INTERNAL_ASSERT(op.is_type_defined(), "no type for operand", i);
-            op.tensor = at::empty(shape_, op.options(), MemoryFormat::Contiguous);
+            op.tensor = at::empty(shape_, op.options().memory_format(MemoryFormat::Contiguous));
             op.current_dtype = op.target_dtype;
           }
         }
@@ -924,7 +924,7 @@ bool TensorIterator::fast_set_up() {
           auto& op = operands_[i];
           if (!op.tensor.defined()) {
             TORCH_INTERNAL_ASSERT(op.is_type_defined(), "no type for operand", i);
-            op.tensor = at::empty(shape_, op.options(), MemoryFormat::ChannelsLast);
+            op.tensor = at::empty(shape_, op.options().memory_format(MemoryFormat::ChannelsLast));
             op.current_dtype = op.target_dtype;
           }
         }

--- a/aten/src/ATen/native/TensorIterator.cpp
+++ b/aten/src/ATen/native/TensorIterator.cpp
@@ -153,7 +153,7 @@ static void maybe_copy_casting_to_common_dtype(OperandInfo& op, ScalarType commo
       op.tensor = op.tensor.to(common_dtype);
     } else {
       op.tensor =
-          at::empty_like(op.tensor, op.tensor.options().dtype(common_dtype), LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+          at::empty_like(op.tensor, op.tensor.options().dtype(common_dtype).memory_format(LEGACY_CONTIGUOUS_MEMORY_FORMAT));
     }
     op.current_dtype = common_dtype;
   }

--- a/aten/src/ATen/native/TensorProperties.cpp
+++ b/aten/src/ATen/native/TensorProperties.cpp
@@ -93,7 +93,7 @@ Tensor contiguous(const Tensor& self, MemoryFormat memory_format) {
       memory_format != MemoryFormat::Preserve,
       "preserve memory format is unsupported by the contiguous operator");
 
-  auto result = at::empty_like(self, self.options(), memory_format);
+  auto result = at::empty_like(self, self.options().memory_format(memory_format));
   return result.copy_(self);
 }
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -152,7 +152,7 @@
   dispatch:
     CUDA: _cudnn_rnn_backward
 
-- func: _cudnn_init_dropout_state(float dropout, bool train, int dropout_seed, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: _cudnn_init_dropout_state(float dropout, bool train, int dropout_seed, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
   dispatch:
     CUDA: _cudnn_init_dropout_state
 
@@ -378,11 +378,11 @@
 
 - func: any.dimname_out(Tensor self, Dimname dim, bool keepdim=False, *, Tensor(a!) out) -> Tensor(a!)
 
-- func: arange(Scalar end, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: arange(Scalar end, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
 
-- func: arange.start(Scalar start, Scalar end, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: arange.start(Scalar start, Scalar end, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
 
-- func: arange.start_step(Scalar start, Scalar end, Scalar step, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: arange.start_step(Scalar start, Scalar end, Scalar step, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
 
 - func: arange.out(Scalar end, *, Tensor(a!) out) -> Tensor(a!)
 
@@ -476,9 +476,9 @@
     CPU: baddbmm_out_cpu
     CUDA: baddbmm_out_cuda
 
-- func: bartlett_window(int window_length, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: bartlett_window(int window_length, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
 
-- func: bartlett_window.periodic(int window_length, bool periodic, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: bartlett_window.periodic(int window_length, bool periodic, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
 
 - func: batch_norm(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float momentum, float eps, bool cudnn_enabled) -> Tensor
 
@@ -633,9 +633,9 @@
     CUDA: logical_or_out
   supports_named_tensor: True
 
-- func: blackman_window(int window_length, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: blackman_window(int window_length, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
 
-- func: blackman_window.periodic(int window_length, bool periodic, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: blackman_window.periodic(int window_length, bool periodic, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
 
 - func: bmm(Tensor self, Tensor mat2) -> Tensor
   use_c10_dispatcher: full
@@ -1129,17 +1129,17 @@
     SparseCPU: empty_sparse
     SparseCUDA: empty_sparse
 
-- func: new_empty(Tensor self, int[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: new_empty(Tensor self, int[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
   variants: method
 
-- func: new_full(Tensor self, int[] size, Scalar fill_value, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: new_full(Tensor self, int[] size, Scalar fill_value, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
   variants: method
 
-- func: new_zeros(Tensor self, int[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: new_zeros(Tensor self, int[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
   variants: method
 
 # other overrides are to provide a more helpful error message that dtype is required
-- func: _empty_affine_quantized(int[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, float scale=1, int zero_point=0, MemoryFormat? memory_format=None) -> Tensor
+- func: _empty_affine_quantized(int[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None, float scale=1, int zero_point=0) -> Tensor
   dispatch:
     CPU: empty_affine_quantized_other_backends_stub
     QuantizedCPU: empty_affine_quantized_cpu
@@ -1158,14 +1158,14 @@
   variants: method
   device_guard: False
 
-- func: empty.out(int[] size, *, MemoryFormat? memory_format=None, Tensor(a!) out) -> Tensor(a!)
+- func: empty.out(int[] size, *, Tensor(a!) out) -> Tensor(a!)
   device_guard: False
 
 - func: empty_like(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
   device_guard: False
   supports_named_tensor: True
 
-- func: empty_strided(int[] size, int[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: empty_strided(int[] size, int[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
   dispatch:
     CPU: empty_strided_cpu
     CUDA: empty_strided_cuda
@@ -1249,9 +1249,9 @@
   variants: method  # This is method-only to match the previous tensor API. In the future we could make this a function too.
   device_guard: False
 
-- func: eye(int n, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: eye(int n, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
 
-- func: eye.m(int n, int m, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: eye.m(int n, int m, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
 
 - func: eye.out(int n, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
@@ -1321,17 +1321,17 @@
 - func: frac.out(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
   supports_named_tensor: True
 
-- func: full.names(int[] size, Scalar fill_value, *, Dimname[]? names, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: full.names(int[] size, Scalar fill_value, *, Dimname[]? names, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
   device_guard: False
 
-- func: full(int[] size, Scalar fill_value, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: full(int[] size, Scalar fill_value, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
 
 - func: full.out(int[] size, Scalar fill_value, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: full_like(Tensor self, Scalar fill_value, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
   supports_named_tensor: True
 
-- func: from_file(str filename, bool? shared=None, int? size=0, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: from_file(str filename, bool? shared=None, int? size=0, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
   dispatch:
     CPU: from_file
 
@@ -1371,17 +1371,17 @@
     CPU: grid_sampler_3d_backward_cpu
     CUDA: grid_sampler_3d_backward_cuda
 
-- func: hann_window(int window_length, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: hann_window(int window_length, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
 
-- func: hann_window.periodic(int window_length, bool periodic, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: hann_window.periodic(int window_length, bool periodic, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
 
-- func: hamming_window(int window_length, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: hamming_window(int window_length, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
 
-- func: hamming_window.periodic(int window_length, bool periodic, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: hamming_window.periodic(int window_length, bool periodic, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
 
-- func: hamming_window.periodic_alpha(int window_length, bool periodic, float alpha, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: hamming_window.periodic_alpha(int window_length, bool periodic, float alpha, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
 
-- func: hamming_window.periodic_alpha_beta(int window_length, bool periodic, float alpha, float beta, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: hamming_window.periodic_alpha_beta(int window_length, bool periodic, float alpha, float beta, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
 
 - func: hinge_embedding_loss(Tensor self, Tensor target, float margin=1.0, int reduction=Mean) -> Tensor
   use_c10_dispatcher: full
@@ -1594,7 +1594,7 @@
 - func: fbgemm_pack_quantized_matrix.KN(Tensor input, int K, int N) -> Tensor
   use_c10_dispatcher: full
 
-- func: linspace(Scalar start, Scalar end, int steps=100, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: linspace(Scalar start, Scalar end, int steps=100, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
 
 - func: linspace.out(Scalar start, Scalar end, int steps=100, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
@@ -1672,7 +1672,7 @@
   use_c10_dispatcher: full
   variants: function, method
 
-- func: logspace(Scalar start, Scalar end, int steps=100, float base=10.0, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: logspace(Scalar start, Scalar end, int steps=100, float base=10.0, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
 
 - func: logspace.out(Scalar start, Scalar end, int steps=100, float base=10.0, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
@@ -2095,10 +2095,10 @@
 - func: _nnpack_spatial_convolution_backward_weight(Tensor input, int[] weightsize, Tensor grad_output, int[2] padding) -> Tensor
   variants: function
 
-- func: ones.names(int[] size, *, Dimname[]? names, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: ones.names(int[] size, *, Dimname[]? names, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
   device_guard: False
 
-- func: ones(int[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: ones(int[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
 
 - func: ones.out(int[] size, *, Tensor(a!) out) -> Tensor(a!)
 
@@ -2161,17 +2161,17 @@
   use_c10_dispatcher: full
   variants: function
 
-- func: scalar_tensor(Scalar s, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: scalar_tensor(Scalar s, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
 
-- func: rand.names(int[] size, *, Dimname[]? names, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: rand.names(int[] size, *, Dimname[]? names, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
   device_guard: False
 
-- func: rand.generator_with_names(int[] size, *, Generator? generator, Dimname[]? names, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: rand.generator_with_names(int[] size, *, Generator? generator, Dimname[]? names, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
   device_guard: False
 
-- func: rand(int[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: rand(int[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
 
-- func: rand.generator(int[] size, *, Generator? generator, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: rand.generator(int[] size, *, Generator? generator, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
 
 - func: rand.out(int[] size, *, Tensor(a!) out) -> Tensor(a!)
 
@@ -2180,13 +2180,13 @@
 - func: rand_like(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
   supports_named_tensor: True
 
-- func: randint(int high, int[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: randint(int high, int[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
 
-- func: randint.generator(int high, int[] size, *, Generator? generator, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: randint.generator(int high, int[] size, *, Generator? generator, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
 
-- func: randint.low(int low, int high, int[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: randint.low(int low, int high, int[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
 
-- func: randint.low_generator(int low, int high, int[] size, *, Generator? generator, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: randint.low_generator(int low, int high, int[] size, *, Generator? generator, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
 
 - func: randint.out(int high, int[] size, *, Tensor(a!) out) -> Tensor(a!)
 
@@ -2200,14 +2200,14 @@
 
 - func: randint_like.low_dtype(Tensor self, int low, int high, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
 
-- func: randn(int[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: randn(int[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
 
-- func: randn.generator(int[] size, *, Generator? generator, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: randn.generator(int[] size, *, Generator? generator, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
 
-- func: randn.names(int[] size, *, Dimname[]? names, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: randn.names(int[] size, *, Dimname[]? names, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
   device_guard: False
 
-- func: randn.generator_with_names(int[] size, *, Generator? generator, Dimname[]? names, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: randn.generator_with_names(int[] size, *, Generator? generator, Dimname[]? names, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
   device_guard: False
 
 - func: randn.out(int[] size, *, Tensor(a!) out) -> Tensor(a!)
@@ -2217,9 +2217,9 @@
 - func: randn_like(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
   supports_named_tensor: True
 
-- func: randperm(int n, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: randperm(int n, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
 
-- func: randperm.generator(int n, *, Generator? generator, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: randperm.generator(int n, *, Generator? generator, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
 
 - func: randperm.out(int n, *, Tensor(a!) out) -> Tensor(a!)
 
@@ -2228,9 +2228,9 @@
     CPU: randperm_out_cpu
     CUDA: randperm_out_cuda
 
-- func: range.step(Scalar start, Scalar end, Scalar step=1, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: range.step(Scalar start, Scalar end, Scalar step=1, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
 
-- func: range(Scalar start, Scalar end, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: range(Scalar start, Scalar end, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
 
 - func: range.out(Scalar start, Scalar end, Scalar step=1, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
@@ -2968,10 +2968,10 @@
 - func: _weight_norm_differentiable_backward(Tensor grad_w, Tensor saved_v, Tensor saved_g, Tensor saved_norms, int dim) -> (Tensor, Tensor)
   variants: function
 
-- func: zeros.names(int[] size, *, Dimname[]? names, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: zeros.names(int[] size, *, Dimname[]? names, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
   device_guard: False
 
-- func: zeros(int[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: zeros(int[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
 
 - func: zeros.out(int[] size, *, Tensor(a!) out) -> Tensor(a!)
 
@@ -3328,21 +3328,21 @@
 
 # FIXME: would be nicer if TensorOptions was optional based; not adding default arguments for options given
 # the default would never make sense.
-- func: sparse_coo_tensor.size(int[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: sparse_coo_tensor.size(int[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
 
-- func: sparse_coo_tensor.indices(Tensor indices, Tensor values, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: sparse_coo_tensor.indices(Tensor indices, Tensor values, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
 
-- func: sparse_coo_tensor.indices_size(Tensor indices, Tensor values, int[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: sparse_coo_tensor.indices_size(Tensor indices, Tensor values, int[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
 
-- func: _sparse_coo_tensor_unsafe(Tensor indices, Tensor values, int[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: _sparse_coo_tensor_unsafe(Tensor indices, Tensor values, int[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
 
-- func: _sparse_coo_tensor_with_dims(int sparse_dim, int dense_dim, int[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: _sparse_coo_tensor_with_dims(int sparse_dim, int dense_dim, int[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
   dispatch:
     SparseCPU: new_with_dims_sparse
     SparseCUDA: new_with_dims_sparse
   requires_tensor: True
 
-- func: _sparse_coo_tensor_with_dims_and_tensors(int sparse_dim, int dense_dim, int[] size, Tensor indices, Tensor values, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: _sparse_coo_tensor_with_dims_and_tensors(int sparse_dim, int dense_dim, int[] size, Tensor indices, Tensor values, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
   dispatch:
     SparseCPU: new_with_dims_and_tensor_sparse
     SparseCUDA: new_with_dims_and_tensor_sparse
@@ -3647,7 +3647,7 @@
 # to(Device) must not exist because all constructors of Device also works for
 # TensorOptions. Otherwise, an ambiguity error is thrown.
 # See NOTE [ TensorOptions Constructors ].
-- func: to.dtype_layout(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, bool non_blocking=False, bool copy=False, MemoryFormat? memory_format=None) -> Tensor
+- func: to.dtype_layout(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None, bool non_blocking=False, bool copy=False) -> Tensor
   variants: method
   device_guard: False
   supports_named_tensor: True
@@ -4359,12 +4359,12 @@
   use_c10_dispatcher: full
   variants: method, function
 
-- func: tril_indices(int row, int col, int offset=0, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: tril_indices(int row, int col, int offset=0, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
   dispatch:
     CPU: tril_indices_cpu
     CUDA: tril_indices_cuda
 
-- func: triu_indices(int row, int col, int offset=0, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: triu_indices(int row, int col, int offset=0, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
   dispatch:
     CPU: triu_indices_cpu
     CUDA: triu_indices_cuda
@@ -5199,7 +5199,7 @@
     CPU: normal_cpu
     CUDA: normal_cuda
 
-- func: normal.float_float(float mean, float std, int[] size, *, Generator? generator=None, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: normal.float_float(float mean, float std, int[] size, *, Generator? generator=None, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
 
 - func: normal.float_float_out(float mean, float std, int[] size, *, Generator? generator=None, Tensor(a!) out) -> Tensor(a!)
 

--- a/aten/src/ATen/native/quantized/QTensor.cpp
+++ b/aten/src/ATen/native/quantized/QTensor.cpp
@@ -71,8 +71,7 @@ Tensor int_repr_quant(const Tensor& self) {
   AT_DISPATCH_QINT_TYPES(self.scalar_type(), "int_repr", [&]() {
     dst = at::empty(
         self.sizes(),
-        self.options().dtype(UNDERLYING_TYPE),
-        self.suggest_memory_format());
+        self.options().dtype(UNDERLYING_TYPE).memory_format(self.suggest_memory_format()));
     auto iter = TensorIterator();
     iter.add_output(dst);
     iter.add_input(self);

--- a/aten/src/ATen/native/quantized/TensorFactories.cpp
+++ b/aten/src/ATen/native/quantized/TensorFactories.cpp
@@ -12,15 +12,9 @@ namespace native {
 // change to use quantizer
 Tensor empty_affine_quantized_cpu(
     IntArrayRef size,
-    const TensorOptions& options_,
+    const TensorOptions& options,
     double scale,
-    int64_t zero_point,
-    c10::optional<c10::MemoryFormat> optional_memory_format) {
-  TORCH_CHECK(
-    !(options_.has_memory_format() && optional_memory_format.has_value()),
-    "Cannot set memory_format both in TensorOptions and explicit argument; please delete "
-    "the redundant setter.");
-  auto options = options_.merge_in(TensorOptions().memory_format(optional_memory_format));
+    int64_t zero_point) {
   TORCH_CHECK(
       options.has_dtype(),
       "Must provide data type for Tensor creation functions.");
@@ -36,13 +30,7 @@ Tensor empty_per_channel_affine_quantized_cpu(
     const Tensor& scales,
     const Tensor& zero_points,
     int64_t axis,
-    const TensorOptions& options_,
-    c10::optional<c10::MemoryFormat> optional_memory_format) {
-  TORCH_CHECK(
-    !(options_.has_memory_format() && optional_memory_format.has_value()),
-    "Cannot set memory_format both in TensorOptions and explicit argument; please delete "
-    "the redundant setter.");
-  auto options = options_.merge_in(TensorOptions().memory_format(optional_memory_format));
+    const TensorOptions& options) {
   TORCH_CHECK(
       options.has_dtype(),
       "Must provide data type for Tensor creation functions.");
@@ -64,8 +52,7 @@ Tensor empty_affine_quantized_other_backends_stub(
     IntArrayRef,
     const TensorOptions&,
     double,
-    int64_t,
-    c10::optional<c10::MemoryFormat>) {
+    int64_t) {
   TORCH_CHECK(false, "Creation of quantized tensor requires quantized dtype like torch.quint8");
 }
 
@@ -74,8 +61,7 @@ Tensor empty_per_channel_affine_quantized_other_backends_stub(
     const Tensor&,
     const Tensor&,
     int64_t,
-    const TensorOptions&,
-    c10::optional<c10::MemoryFormat>) {
+    const TensorOptions&) {
   TORCH_CHECK(false, "Creation of quantized tensor requires quantized dtype like torch.quint8");
 }
 

--- a/aten/src/ATen/native/quantized/cpu/fake_quantize_per_channel_affine.cpp
+++ b/aten/src/ATen/native/quantized/cpu/fake_quantize_per_channel_affine.cpp
@@ -56,7 +56,7 @@ Tensor fake_quantize_per_channel_affine_cpu(
       axis >= 0 && axis <= self.dim(),
       "`axis` must be between 0 and number of dimensions of input");
 
-  auto Y = at::empty_like(self, self.options(), MemoryFormat::Preserve);
+  auto Y = at::empty_like(self, self.options().memory_format(MemoryFormat::Preserve));
   for (int i = 0; i < self.size(axis); i++) {
     auto input_slice = self.slice(axis, i, i + 1);
     auto output_slice = Y.slice(axis, i, i + 1);
@@ -129,7 +129,7 @@ Tensor fake_quantize_per_channel_affine_backward_cpu(
     return X;
   }
 
-  auto dX = at::empty_like(X, X.options(), MemoryFormat::Preserve);
+  auto dX = at::empty_like(X, X.options().memory_format(MemoryFormat::Preserve));
 
   for (int i = 0; i < X.size(axis); i++) {
     auto X_slice = X.slice(axis, i, i + 1);

--- a/aten/src/ATen/native/quantized/cpu/fake_quantize_per_tensor_affine.cpp
+++ b/aten/src/ATen/native/quantized/cpu/fake_quantize_per_tensor_affine.cpp
@@ -35,7 +35,7 @@ Tensor fake_quantize_per_tensor_affine_cpu(
       zero_point >= quant_min && zero_point <= quant_max,
       "`zero_point` must be between `quant_min` and `quant_max`.");
 
-  auto Y = at::empty_like(self, self.options(), MemoryFormat::Preserve);
+  auto Y = at::empty_like(self, self.options().memory_format(MemoryFormat::Preserve));
   fake_quantize_slice(Y, self, scale, zero_point, quant_min, quant_max);
   return Y;
 }
@@ -81,7 +81,7 @@ Tensor fake_quantize_per_tensor_affine_backward_cpu(
     return X;
   }
 
-  auto dX = at::empty_like(X, X.options(), MemoryFormat::Preserve);
+  auto dX = at::empty_like(X, X.options().memory_format(MemoryFormat::Preserve));
   fake_quantize_grad_slice(dX, X, dY, scale, zero_point, quant_min, quant_max);
   return dX;
 }

--- a/aten/src/ATen/native/quantized/cpu/qconv_unpack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv_unpack.cpp
@@ -104,8 +104,7 @@ class QConvUnpackWeightsInt8 final : public c10::OperatorKernel {
                 scales.toType(kDouble),
                 zero_points.toType(kLong),
                 0, /* The output channel axis is 0 */
-                device(kCPU).dtype(kQInt8),
-                MemoryFormat::ChannelsLast)
+                device(kCPU).dtype(kQInt8).memory_format(MemoryFormat::ChannelsLast))
           : fbgemm_utils::
                 MakeEmptyPerChannelAffineQuantizedChannelsLast3dTensor(
                     output_channels,

--- a/aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp
@@ -105,8 +105,7 @@ class QLinearDynamicInt8 final : public torch::OperatorKernel {
     auto output = at::empty(out_sizes, input.options().dtype(at::kFloat));
     auto buffer = at::empty_like(
         output,
-        output.options().dtype(at::kInt),
-        LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+        output.options().dtype(at::kInt).memory_format(LEGACY_CONTIGUOUS_MEMORY_FORMAT));
 
     int num_tasks = at::get_num_threads();
     at::parallel_for(0, num_tasks, 1, [&](int64_t begin, int64_t end) {

--- a/aten/src/ATen/native/quantized/cpu/qlinear_unpack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear_unpack.cpp
@@ -100,7 +100,7 @@ class QLinearUnpackWeightFp16 final : public c10::OperatorKernel {
     auto ncols = packed_weight_ptr->numCols();
 
     at::Tensor unpacked_weight =
-        at::empty({ncols, nrows}, at::kHalf, MemoryFormat::Contiguous);
+        at::empty({ncols, nrows}, at::dtype(at::kHalf).memory_format(MemoryFormat::Contiguous));
     packed_weight_ptr->unpack(
         static_cast<fbgemm::float16*>(unpacked_weight.data_ptr()),
         fbgemm::matrix_op_t::Transpose);

--- a/aten/src/ATen/native/sparse/SparseTensorMath.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensorMath.cpp
@@ -1207,7 +1207,7 @@ Tensor _sparse_sum_backward_cpu(const Tensor& grad_, const SparseTensor& input_,
     Tensor grad_input_values;
     if (sum_sparse_dim) {
       // see NOTE [ sparse.sum() backward ]
-      grad_input_values = at::zeros_like(input_values, grad_values.options(), LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+      grad_input_values = at::zeros_like(input_values, grad_values.options().memory_format(LEGACY_CONTIGUOUS_MEMORY_FORMAT));
 
       // get flatten indices for grad and input
       auto grad_sparse_dim_to_keep_v = std::vector<int64_t>(grad_sparse_dim);

--- a/aten/src/ATen/native_parse.py
+++ b/aten/src/ATen/native_parse.py
@@ -227,6 +227,7 @@ def parse_arguments(name, args, func_variants, declaration, func_return):
         make_topt_arg('layout', 'Layout'),
         make_topt_arg('device', 'Device'),
         make_topt_arg('pin_memory', 'bool'),
+        make_topt_arg('memory_format', 'MemoryFormat'),
     ]
 
     corresponding_topt = {
@@ -246,7 +247,7 @@ def parse_arguments(name, args, func_variants, declaration, func_return):
             return None
 
     def is_tensor_option(argument):
-        return argument['name'] in ['dtype', 'layout', 'device', 'pin_memory']
+        return argument['name'] in ['dtype', 'layout', 'device', 'pin_memory', 'memory_format']
 
     new_arguments = []
     idx = 0

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -956,7 +956,7 @@
   self: grad.to_dense().sparse_mask(mask).to_dense()
   mask: non_differentiable
 
-- name: _sparse_coo_tensor_with_dims_and_tensors(int sparse_dim, int dense_dim, int[] size, Tensor indices, Tensor values, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- name: _sparse_coo_tensor_with_dims_and_tensors(int sparse_dim, int dense_dim, int[] size, Tensor indices, Tensor values, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
   values: sparse_constructor_values_backward(grad, indices, values.sizes())
 
 - name: _sparse_sum.dim(Tensor self, int[1] dim) -> Tensor

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -245,7 +245,7 @@ UNPACK_WITH_DEFAULT_METHODS = {
     'const Device &': 'deviceWithDefault',
 }
 
-def parsed_arg_expr(arg, arg_index):
+def parsed_arg_expr(op_name, arg, arg_index):
     # e.g. for arg name 'foo', arg type 'bool', arg_index = 2, returns '_r.toBool(2)'
     typename = arg['type']
 
@@ -271,7 +271,8 @@ def parsed_arg_expr(arg, arg_index):
 
     unpack = UNPACK_METHODS.get(typename)
     if unpack is None:
-        raise RuntimeError('type \'{}\' is not supported'.format(typename))
+        raise RuntimeError('type \'{}\' is not supported (found in {})'
+                           .format(typename, op_name))
 
     return '_r.{}({})'.format(unpack, arg_index)
 
@@ -288,9 +289,9 @@ def unpack_optional_dimname_list_hack(name, expr):
     return [line.strip() for line in result.split('\n')]
 
 
-def parse_arg(arg, arg_index, unpack_to_local=False):
+def parse_arg(op_name, arg, arg_index, unpack_to_local=False):
     # get parsed rhs
-    expr = parsed_arg_expr(arg, arg_index)
+    expr = parsed_arg_expr(op_name, arg, arg_index)
 
     # maybe unpack to local
     name = arg['name']
@@ -420,7 +421,8 @@ const auto ${name} = TensorOptions()
     .device(${device})
     .layout(${layout}.layout)
     .requires_grad(${requires_grad})
-    .pinned_memory(${pin_memory});
+    .pinned_memory(${pin_memory})
+    .memory_format(${memory_format});
 """)
 
 # addition to output-variant handler in which tensor options params
@@ -475,7 +477,7 @@ def emit_single_dispatch(declaration, is_python_method, output_gap=0):
 
     for i, arg in enumerate(args):
         unpack = is_scatter(arg) or (has_options and is_tensor_self(arg))
-        arg_expr, unpack_stmts = parse_arg(arg, i, unpack_to_local=unpack)
+        arg_expr, unpack_stmts = parse_arg(declaration['name'], arg, i, unpack_to_local=unpack)
         inits.extend(unpack_stmts)
         if is_scatter(arg):
             for j, elem in enumerate(arg['scatter_args']):
@@ -527,6 +529,7 @@ TENSOR_OPTIONS_FIELDS = {
     'layout': 'Layout',
     'pin_memory': 'bool',
     'requires_grad': 'bool',
+    'memory_format': 'MemoryFormat',
 }
 
 def handle_python_binding_args(declaration, output_gap):
@@ -555,7 +558,7 @@ def handle_python_binding_args(declaration, output_gap):
 
     def parse_binding_arg(name):
         binding_arg = python_binding_args[binding_arg_offsets[name]]
-        expr, _ = parse_arg(binding_arg, binding_arg_index(name))
+        expr, _ = parse_arg(declaration['name'], binding_arg, binding_arg_index(name))
         return expr
 
     has_output = len(pa['output_args']) == 1
@@ -590,6 +593,7 @@ def handle_python_binding_args(declaration, output_gap):
             'device': parse_binding_arg('device'),
             'requires_grad': parse_binding_arg('requires_grad'),
             'pin_memory': parse_binding_arg('pin_memory'),
+            'memory_format': parse_binding_arg('memory_format'),
         }))
         inits.append('torch::utils::maybe_initialize_cuda({});'.format(argname))
         # and add to op arg map
@@ -1381,6 +1385,15 @@ def make_python_binding_args(declaration):
             'simple_type': 'bool',
         }
         python_binding_arguments.append(pin_memory_arg)
+        memory_format_arg = {
+            'default': False,
+            'dynamic_type': 'MemoryFormat',
+            'kwarg_only': True,
+            'name': 'memory_format',
+            'type': 'MemoryFormat',
+            'simple_type': 'MemoryFormat',
+        }
+        python_binding_arguments.append(memory_format_arg)
 
     if is_factory_or_like_or_new_function:
         requires_grad_arg = {

--- a/tools/pyi/gen_pyi.py
+++ b/tools/pyi/gen_pyi.py
@@ -278,7 +278,8 @@ def generate_type_hints(fname, decls, is_tensor=False):
             python_args += ["dtype: _dtype=None",
                             "layout: _layout=strided",
                             "device: Union[_device, str, None]=None",
-                            "requires_grad:_bool=False"]
+                            "requires_grad: _bool=False",
+                            "memory_format: Optional[memory_format]=None"]
 
         python_args_s = ', '.join(python_args)
         python_returns = [type_to_python(r['dynamic_type']) for r in decl['returns']]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#33634 Add MemoryFormat to TensorOptions in codegen.**
* #33633 Calls to Tensor::to pass MemoryFormat by TensorOptions
* #33627 Calls to _empty_affine_quantized pass MemoryFormat by TensorOptions
* #33619 Change default value of MemoryFormat? to None
* #33362 Standardize expanded TensorOptions representation in native_functions.yaml
* #33518 Collapse _like overloads into a single overload.
* #33516 Add MemoryFormat to TensorOptions, but not codegen.
* #33510 Correctly preserve "not set anywhere" TensorOptions when merging.
* #33505 Switch empty_like to use merge_in to process TensorOptions.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>