### PR TITLE
Add device to the test tensor. Default device type is CPU, in pytorch…

### DIFF
--- a/test/test_type_promotion.py
+++ b/test/test_type_promotion.py
@@ -388,7 +388,7 @@ class TestTypePromotion(TestCase):
             self.assertTrue(actual, expected)
             self.assertTrue(actual.dtype == torch.bool)
 
-            actual = x < torch.tensor(0.5)
+            actual = x < torch.tensor(0.5, device=device)
             self.assertTrue(actual, expected)
             self.assertTrue(actual.dtype == torch.bool)
 
@@ -398,7 +398,7 @@ class TestTypePromotion(TestCase):
             self.assertTrue(actual, expected)
             self.assertTrue(actual.dtype == torch.bool)
 
-            actual = x < torch.tensor(0.5)
+            actual = x < torch.tensor(0.5, device=device)
             self.assertTrue(actual, expected)
             self.assertTrue(actual.dtype == torch.bool)
 


### PR DESCRIPTION
…/xla this will result in a failure since it is comparing a XLA tensor with a CPU tensor.

