### PR TITLE
[1.5 Release][RPC Reliability] RRef Idempotency and RPC Retry enablement

### DIFF
--- a/test/distributed/rpc/faulty_agent/test_dist_autograd_spawn.py
+++ b/test/distributed/rpc/faulty_agent/test_dist_autograd_spawn.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+import unittest
+
+from torch.testing._internal.common_distributed import MultiProcessTestCase
+from torch.testing._internal.common_utils import TEST_WITH_ASAN, run_tests
+from torch.testing._internal.distributed.rpc.dist_autograd_test import (
+    FaultyAgentDistAutogradTest,
+)
+
+
+@unittest.skipIf(
+    TEST_WITH_ASAN, "Skip ASAN as torch + multiprocessing spawn have known issues"
+)
+class FaultyAgentDistAutogradTestWithSpawn(MultiProcessTestCase, FaultyAgentDistAutogradTest):
+    def setUp(self):
+        super(FaultyAgentDistAutogradTestWithSpawn, self).setUp()
+        self._spawn_processes()
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/distributed/rpc/faulty_agent/test_rpc_spawn.py
+++ b/test/distributed/rpc/faulty_agent/test_rpc_spawn.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+import unittest
+
+from torch.testing._internal.common_distributed import MultiProcessTestCase
+from torch.testing._internal.common_utils import TEST_WITH_ASAN, run_tests
+from torch.testing._internal.distributed.rpc.rpc_test import FaultyAgentRpcTest
+
+
+@unittest.skipIf(
+    TEST_WITH_ASAN, "Skip ASAN as torch + multiprocessing spawn have known issues"
+)
+class FaultyAgentRpcTestWithSpawn(MultiProcessTestCase, FaultyAgentRpcTest):
+    def setUp(self):
+        super(FaultyAgentRpcTestWithSpawn, self).setUp()
+        self._spawn_processes()
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -76,10 +76,12 @@ TESTS = [
 # skip python2 for rpc and dist_autograd tests that do not support python2
 if PY33:
     TESTS.extend([
-        'distributed/rpc/test_rpc_spawn',
+        'distributed/rpc/faulty_agent/test_dist_autograd_spawn',
+        'distributed/rpc/faulty_agent/test_rpc_spawn',
+        'distributed/rpc/jit/test_dist_autograd_spawn',
         'distributed/rpc/test_dist_autograd_spawn',
         'distributed/rpc/test_dist_optimizer_spawn',
-        'distributed/rpc/jit/test_dist_autograd_spawn',
+        'distributed/rpc/test_rpc_spawn',
     ])
 
 # skip < 3.6 b/c fstrings added in 3.6
@@ -88,27 +90,32 @@ if PY36:
         'test_jit_py3',
         'test_determination',
         'distributed/rpc/jit/test_rpc_spawn',
+        'distributed/rpc/faulty_agent/test_rpc_spawn',
     ])
 
 WINDOWS_BLACKLIST = [
-    'distributed/test_distributed',
-    'distributed/rpc/test_rpc_spawn',
+    'distributed/rpc/faulty_agent/test_dist_autograd_spawn',
+    'distributed/rpc/faulty_agent/test_rpc_spawn',
+    'distributed/rpc/jit/test_dist_autograd_spawn',
+    'distributed/rpc/jit/test_rpc_spawn',
     'distributed/rpc/test_dist_autograd_spawn',
     'distributed/rpc/test_dist_optimizer_spawn',
-    'distributed/rpc/jit/test_rpc_spawn',
-    'distributed/rpc/jit/test_dist_autograd_spawn',
+    'distributed/rpc/test_rpc_spawn',
+    'distributed/test_distributed',
 ]
 
 ROCM_BLACKLIST = [
-    'test_cpp_extensions_aot_ninja',
-    'test_cpp_extensions_jit',
-    'test_multiprocessing',
-    'distributed/rpc/test_rpc_spawn',
+    'distributed/rpc/faulty_agent/test_dist_autograd_spawn',
+    'distributed/rpc/faulty_agent/test_rpc_spawn',
+    'distributed/rpc/jit/test_dist_autograd_spawn',
+    'distributed/rpc/jit/test_rpc_spawn',
     'distributed/rpc/test_dist_autograd_spawn',
     'distributed/rpc/test_dist_optimizer_spawn',
-    'distributed/rpc/jit/test_rpc_spawn',
-    'distributed/rpc/jit/test_dist_autograd_spawn',
+    'distributed/rpc/test_rpc_spawn',
+    'test_cpp_extensions_aot_ninja',
+    'test_cpp_extensions_jit',
     'test_determination',
+    'test_multiprocessing',
 ]
 
 # These tests are slow enough that it's worth calculating whether the patch

--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -348,6 +348,8 @@ def add_torch_libs():
         "torch/csrc/distributed/rpc/python_functions.cpp",
         "torch/csrc/distributed/rpc/python_rpc_handler.cpp",
         "torch/csrc/distributed/rpc/request_callback_impl.cpp",
+        "torch/csrc/distributed/rpc/testing/faulty_process_group_agent.cpp",
+        "torch/csrc/distributed/rpc/testing/init.cpp",
         "torch/csrc/distributed/rpc/unpickled_python_call.cpp",
         "torch/csrc/distributed/rpc/unpickled_python_remote_call.cpp",
         "torch/csrc/jit/python/init.cpp",

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -258,6 +258,8 @@ if (USE_DISTRIBUTED)
         ${TORCH_SRC_DIR}/csrc/distributed/rpc/python_functions.cpp
         ${TORCH_SRC_DIR}/csrc/distributed/rpc/python_rpc_handler.cpp
         ${TORCH_SRC_DIR}/csrc/distributed/rpc/request_callback_impl.cpp
+        ${TORCH_SRC_DIR}/csrc/distributed/rpc/testing/faulty_process_group_agent.cpp
+        ${TORCH_SRC_DIR}/csrc/distributed/rpc/testing/init.cpp
         ${TORCH_SRC_DIR}/csrc/distributed/rpc/unpickled_python_call.cpp
         ${TORCH_SRC_DIR}/csrc/distributed/rpc/unpickled_python_remote_call.cpp
         ${TORCH_SRC_DIR}/csrc/jit/runtime/register_distributed_ops.cpp

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -52,6 +52,7 @@
 #include <torch/csrc/distributed/autograd/autograd.h>
 #include <torch/csrc/distributed/c10d/c10d.h>
 #include <torch/csrc/distributed/rpc/rpc.h>
+#include <torch/csrc/distributed/rpc/testing/testing.h>
 #endif
 #endif
 
@@ -638,6 +639,7 @@ PyObject* initModule() {
   THPUtils_addPyMethodDefs(methods, torch::distributed::rpc::python_functions());
   THPUtils_addPyMethodDefs(
       methods, torch::distributed::autograd::python_functions());
+  THPUtils_addPyMethodDefs(methods, torch::distributed::rpc::testing::python_functions());
 #endif
 #endif
 

--- a/torch/csrc/distributed/rpc/request_callback_impl.cpp
+++ b/torch/csrc/distributed/rpc/request_callback_impl.cpp
@@ -337,7 +337,7 @@ void RequestCallbackImpl::processRpc(
     case MessageType::RREF_FORK_REQUEST: {
       auto& rfr = static_cast<RRefForkRequest&>(rpc);
       auto& ctx = RRefContext::getInstance();
-      ctx.addForkOfOwner(rfr.rrefId(), rfr.forkId());
+      ctx.addForkOfOwnerIfNotPresent(rfr.rrefId(), rfr.forkId());
       markComplete(RRefAck().toMessage());
       return;
     }

--- a/torch/csrc/distributed/rpc/rpc_agent.h
+++ b/torch/csrc/distributed/rpc/rpc_agent.h
@@ -80,7 +80,7 @@ struct TORCH_API RpcRetryOptions {
   // sendWithRetries function.
   RpcRetryOptions() = default;
   // Maximum number of times we will retry the RPC
-  int maxRetries{3};
+  int maxRetries{5};
   // Initial duration between consecutive RPC send attempts
   std::chrono::milliseconds rpcRetryDuration{std::chrono::milliseconds(1000)};
   // Constant for exponential backoff used while calculating future wait
@@ -155,7 +155,7 @@ class TORCH_API RpcAgent {
   //
   // Sends ``message`` to the ``RpcAgent`` of id ``to`` and returns a
   // ``FutureMessage`` ptr, just like send(). Caller can specify the maximum
-  // number of retries for this RPC (default is 3), initial duration between
+  // number of retries for this RPC (default is 5), initial duration between
   // sends (default is 1000ms), and backoff constant (default is 1.5) by
   // passing in the RpcRetryOptions struct. This API might end up
   // executing a method twice on the remote end (it does not guarantee

--- a/torch/csrc/distributed/rpc/rref_context.cpp
+++ b/torch/csrc/distributed/rpc/rref_context.cpp
@@ -39,6 +39,7 @@ c10::intrusive_ptr<RRef> finishCreatingOwnerRRef(
 // Keys for RRef-related debug information.
 const std::string kNumOwnerRRefs = "num_owner_rrefs";
 const std::string kNumPendingUsers = "num_pending_users";
+const std::string kNumForks = "num_forks";
 
 RRefContext& RRefContext::getInstance() {
   // Leaky singleton to avoid module destructor races.
@@ -90,9 +91,14 @@ std::unordered_map<std::string, std::string> RRefContext::getDebugInfo() {
   std::unique_lock<std::mutex> lock(mutex_);
   auto ownerSize = owners_.size();
   auto numPendingUsers = pendingUsers_.size();
+  int numForks = 0;
+  for (const auto& owner : forks_) {
+    numForks += owner.second.size();
+  }
   lock.unlock();
   info[kNumOwnerRRefs] = c10::to_string(ownerSize);
   info[kNumPendingUsers] = c10::to_string(numPendingUsers);
+  info[kNumForks] = c10::to_string(numForks);
   return info;
 }
 
@@ -164,7 +170,10 @@ void RRefContext::delUser(
   {
     std::lock_guard<std::mutex> lock(destroyedMutex_);
     if (!destroyed_) {
-      auto fm = agent_->send(
+      // Sending an RRefUserDelete causes the receiver to run delForkOfOwner,
+      // which is now idempotent. See the comment at RRefContext::delForkOfOwner
+      // for more details.
+      auto fm = agent_->sendWithRetries(
           agent_->getWorkerInfo(owner),
           RRefUserDelete(rrefId, forkId).toMessage());
 
@@ -378,14 +387,14 @@ void RRefContext::notifyOwnerAndParentOfFork(
     // In this case, the owner is the caller, and it does not add the fork id
     // into forks_. Because, there will be no real `UserRRef` associated
     // with this fork ID.
-    auto fm = agent_->send(
+    auto fm = agent_->sendWithRetries(
         agent_->getWorkerInfo(parent), RRefChildAccept(forkId).toMessage());
     fm->addCallback([](const Message& /* unused */,
                        const c10::optional<utils::FutureError>& futErr) {
       handleException(futErr);
     });
   } else {
-    auto fm = agent_->send(
+    auto fm = agent_->sendWithRetries(
         agent_->getWorkerInfo(rref->owner()),
         RRefForkRequest(rref->rrefId(), forkId).toMessage());
 
@@ -419,19 +428,24 @@ void RRefContext::delPendingChild(const ForkId& forkId) {
   {
     std::lock_guard<std::mutex> lock(mutex_);
     auto iter = pendingChildren_.find(forkId);
-    TORCH_INTERNAL_ASSERT(
-        iter != pendingChildren_.end(),
-        "Inconsistent states: attempt to delete a non-exist child fork.");
-
-    // Since this UserRRef is removed from the map,
-    // the refcount of this UserRRef could reach to 0,
-    // so the "destructor", `release_resources()`, might be called,
-    // in which the lock is acquired again.
-    // So it must be destructed with the lock released.
-    // Meet this constraint by creating a temporary pointer to increase the
-    // refcount, extending its lifetime untill lock released.
-    deletedUser = iter->second; // Increase refcount.
-    pendingChildren_.erase(iter); // Decrease refcount.
+    // We first check whether the child exists in pendingChildren_. It's
+    // possible the child may have been removed by a previous send attempt, and
+    // this check (as opposed to an assertion here) ensures that messages that
+    // trigger this function are idempotent.
+    if (iter != pendingChildren_.end()) {
+      // Since this UserRRef is removed from the map,
+      // the refcount of this UserRRef could reach to 0,
+      // so the "destructor", `release_resources()`, might be called,
+      // in which the lock is acquired again.
+      // So it must be destructed with the lock released.
+      // Meet this constraint by creating a temporary pointer to increase the
+      // refcount, extending its lifetime untill lock released.
+      deletedUser = iter->second; // Increase refcount.
+      pendingChildren_.erase(iter); // Decrease refcount.
+    } else {
+      LOG(INFO) << "Ignoring duplicate request to delete child UserRRef with "
+                << "ForkId = " << forkId;
+    }
   }
   deleteAllUsersCV_.notify_all();
   // The refcount of this UserRRef could reach to 0,
@@ -556,7 +570,7 @@ void RRefContext::clearRecordedPendingRRefsOnError() {
 
 void RRefContext::finishForkRequest(const ForkId& forkId, worker_id_t parent) {
   delPendingUser(forkId);
-  auto fm = agent_->send(
+  auto fm = agent_->sendWithRetries(
       agent_->getWorkerInfo(parent), RRefChildAccept(forkId).toMessage());
 
   fm->addCallback([](const Message& /* unused */,
@@ -587,34 +601,60 @@ void RRefContext::addForkOfOwner(const RRefId& rrefId, const ForkId& forkId) {
   rrefForks.insert(forkId);
 }
 
+void RRefContext::addForkOfOwnerIfNotPresent(
+    const RRefId& rrefId,
+    const ForkId& forkId) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  auto& rrefForks = forks_[rrefId];
+  // We first check whether the child exists in rrefForks. It's possible
+  // the child may have been added by a previous send attempt, and this check
+  // (as opposed to an assertion here) ensures that messages that trigger this
+  // function are idempotent.
+  if (rrefForks.find(forkId) == rrefForks.end()) {
+    rrefForks.insert(forkId);
+  } else {
+    LOG(INFO) << "Ignoring duplicate request to add Fork of OwnerRRef with "
+              << "RRefId = " << rrefId << ", ForkId = " << forkId;
+  }
+}
+
 c10::intrusive_ptr<RRef> RRefContext::delForkOfOwner(
     const RRefId& rrefId,
     const ForkId& forkId) {
   c10::intrusive_ptr<RRef> deletedRRef;
   bool ownerReduced = false;
+  // There were previously multiple TORCH_CHECKs in this function that checked
+  // whether the passed in fork was known by the user and whether the fork had
+  // already been deleted. These assertions are now replaced with nested if
+  // statements to ensure this function is idempotent. This makes it safe to
+  // retry RRefUserDelete messages.
   {
     std::lock_guard<std::mutex> lock(mutex_);
     auto rrefIter = forks_.find(rrefId);
-    TORCH_INTERNAL_ASSERT(
-        rrefIter != forks_.end(),
-        "Inconsistent states, deleting a fork before the owner knows it.");
-    auto& rrefForks = rrefIter->second;
-    auto forkIter = rrefForks.find(forkId);
-    TORCH_INTERNAL_ASSERT(
-        forkIter != rrefForks.end(),
-        "Attempt to delete a non-exist fork ",
-        forkId);
-
-    rrefForks.erase(forkId);
-
-    if (rrefForks.empty()) {
-      auto ownerIter = owners_.find(rrefId);
-      if (ownerIter != owners_.end()) {
-        deletedRRef = ownerIter->second;
-        owners_.erase(ownerIter);
-        ownerReduced = true;
+    if (rrefIter != forks_.end()) {
+      auto& rrefForks = rrefIter->second;
+      auto forkIter = rrefForks.find(forkId);
+      if (forkIter != rrefForks.end()) {
+        rrefForks.erase(forkId);
+      } else {
+        LOG(INFO)
+            << "Could not find UserRRef instance, "
+            << "RRefId = " << rrefId << ", ForkId = " << forkId
+            << ", likely because it was deleted by a previously retried message";
       }
-      forks_.erase(rrefIter);
+      if (rrefForks.empty()) {
+        auto ownerIter = owners_.find(rrefId);
+        if (ownerIter != owners_.end()) {
+          deletedRRef = ownerIter->second;
+          owners_.erase(ownerIter);
+          ownerReduced = true;
+        }
+        forks_.erase(rrefIter);
+      }
+    } else {
+      LOG(INFO)
+          << "Could not find OwnerRRef with RRefId = " << rrefId
+          << ", likely because it was deleted by a previously retried message";
     }
   }
   if (ownerReduced) {

--- a/torch/csrc/distributed/rpc/rref_context.h
+++ b/torch/csrc/distributed/rpc/rref_context.h
@@ -105,6 +105,10 @@ class TORCH_API RRefContext {
   // Register a fork of the ``OwnerRRef``, and inserts a intrusive_ptr of the
   // ``OwnerRRef`` in a map to keep it alive.
   void addForkOfOwner(const RRefId& rrefId, const ForkId& forkId);
+  // Performs the same function as addForkOfOwner but ignores duplicate
+  // requests. This idempotent function is used with RREF_FORK_REQUEST calls,
+  // whereas all other message types use the non-idempotent variant.
+  void addForkOfOwnerIfNotPresent(const RRefId& rrefId, const ForkId& forkId);
   // Delete a fork of the ``OwnerRRef``. NB: this could trigger deletion on the
   // IValue or py::object. For the later, this method will acquire GIL.
   // NB: If this fork deletion triggered deleting OwnerRRef, this method will

--- a/torch/csrc/distributed/rpc/testing/faulty_process_group_agent.cpp
+++ b/torch/csrc/distributed/rpc/testing/faulty_process_group_agent.cpp
@@ -1,0 +1,87 @@
+#include <torch/csrc/distributed/rpc/testing/faulty_process_group_agent.h>
+
+namespace torch {
+namespace distributed {
+namespace rpc {
+
+std::string fromVec(const std::vector<char>& vec) {
+  return std::string(vec.begin(), vec.end());
+}
+
+FaultyProcessGroupAgent::FaultyProcessGroupAgent(
+    std::string workerName,
+    std::shared_ptr<c10d::ProcessGroup> pg,
+    int numSendRecvThreads,
+    std::chrono::milliseconds rpcTimeout,
+    const std::vector<std::string>& messagesToFail,
+    int failNumSends)
+    : ProcessGroupAgent(
+          std::move(workerName),
+          std::move(pg),
+          numSendRecvThreads,
+          rpcTimeout),
+      failNumSends_(failNumSends),
+      messageTypesToFail_(parseMessagesToFailInput(messagesToFail)) {}
+
+std::vector<MessageType> FaultyProcessGroupAgent::parseMessagesToFailInput(
+    const std::vector<std::string>& messagesToFail) const {
+  // Since we can only pass strings corresponding to the Message Types from the
+  // python tests, we must parse the list of strings and resolve the actual
+  // types. We will then check this list of types in the send function to
+  // determine whether we should fail or not.
+  std::vector<MessageType> messageTypesToFail;
+  for (const auto& msgString : messagesToFail) {
+    if (msgString == "RREF_FORK_REQUEST") {
+      messageTypesToFail.emplace_back(MessageType::RREF_FORK_REQUEST);
+    } else if (msgString == "RREF_CHILD_ACCEPT") {
+      messageTypesToFail.emplace_back(MessageType::RREF_CHILD_ACCEPT);
+    } else if (msgString == "RREF_USER_DELETE") {
+      messageTypesToFail.emplace_back(MessageType::RREF_USER_DELETE);
+    } else if (msgString == "CLEANUP_AUTOGRAD_CONTEXT_REQ") {
+      messageTypesToFail.emplace_back(
+          MessageType::CLEANUP_AUTOGRAD_CONTEXT_REQ);
+    }
+  }
+  return messageTypesToFail;
+}
+
+std::shared_ptr<FutureMessage> FaultyProcessGroupAgent::send(
+    const WorkerInfo& to,
+    Message&& message) {
+  // We only fail control messages that have been specified by the test case.
+  // For all other messages, we just send them without any failures.
+  if (!shouldFailMessage(message.type())) {
+    return ProcessGroupAgent::send(to, std::move(message));
+  }
+  // This send function checks the failMessageCountMap_ to check whether
+  // we must fail the next send. If the send must be failed, we set an error
+  // on the returned future immediately and increment the counter in the map,
+  // otherwise we just call the ProcessGroupAgent send.
+  const auto key = fromVec(message.payload());
+  std::unique_lock<std::mutex> lock(failMapMutex_);
+  auto it = failMessageCountMap_.find(key);
+  if (it == failMessageCountMap_.end()) {
+    failMessageCountMap_[key] = 0;
+  }
+  if (failMessageCountMap_[key] < failNumSends_) {
+    failMessageCountMap_[key]++;
+    lock.unlock();
+    auto fm = std::make_shared<FutureMessage>();
+    fm->setError(c10::str("Send attempt failed intentionally for ", key));
+    return fm;
+  } else {
+    lock.unlock();
+    return ProcessGroupAgent::send(to, std::move(message));
+  }
+}
+
+bool FaultyProcessGroupAgent::shouldFailMessage(MessageType type) const {
+  // Return true if the input message type is in the messageTypesToFail_ list
+  return (
+      std::find(messageTypesToFail_.begin(), messageTypesToFail_.end(), type) !=
+      messageTypesToFail_.end());
+}
+
+} // namespace rpc
+} // namespace distributed
+} // namespace torch

--- a/torch/csrc/distributed/rpc/testing/faulty_process_group_agent.h
+++ b/torch/csrc/distributed/rpc/testing/faulty_process_group_agent.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <torch/csrc/distributed/rpc/message.h>
+#include <torch/csrc/distributed/rpc/process_group_agent.h>
+
+namespace torch {
+namespace distributed {
+namespace rpc {
+
+struct FaultyProcessGroupRpcBackendOptions
+    : public ProcessGroupRpcBackendOptions {
+  FaultyProcessGroupRpcBackendOptions(
+      int num_send_recv_threads,
+      std::chrono::milliseconds rpc_timeout,
+      std::string init_method,
+      std::vector<std::string> messages_to_fail,
+      int num_fail_sends = 0)
+      : ProcessGroupRpcBackendOptions(
+            num_send_recv_threads,
+            rpc_timeout,
+            std::move(init_method)),
+        messagesToFail(std::move(messages_to_fail)),
+        numFailSends(num_fail_sends) {
+    TORCH_CHECK(numFailSends >= 0, "numFailSends should be non-negative");
+  }
+
+  std::vector<std::string> messagesToFail;
+  int numFailSends;
+};
+
+class FaultyProcessGroupAgent : public ProcessGroupAgent {
+ public:
+  FaultyProcessGroupAgent(
+      std::string workerName,
+      std::shared_ptr<c10d::ProcessGroup> pg,
+      int numSendRecvThreads,
+      std::chrono::milliseconds rpcTimeout,
+      const std::vector<std::string>& messagesToFail,
+      int failNumSends = 0);
+
+  // Faulty send function for this class.
+  std::shared_ptr<FutureMessage> send(const WorkerInfo& to, Message&& message)
+      override;
+
+ protected:
+  // This function checks the messageTypesToFail_ to determine whether to use
+  // the faulty send or not.
+  virtual bool shouldFailMessage(MessageType type) const;
+
+ private:
+  // This function parses the list of strings passed in by the python tests and
+  // resolves the Message Types that must use the faulty send.
+  std::vector<MessageType> parseMessagesToFailInput(
+      const std::vector<std::string>& messagesToFail) const;
+
+  // Number of sends to intentionally fail before allowing one to succeed.
+  const int failNumSends_;
+
+  // Vector of the MessageTypes that we must use the faulty send for. This is
+  // parsed based on a list of strings passed in by the python tests.
+  const std::vector<MessageType> messageTypesToFail_;
+
+  // Map to track the number of sends we've failed for each RPC.
+  std::unordered_map<std::string, int> failMessageCountMap_;
+
+  // Mutex to guard failMessageCountMap_
+  std::mutex failMapMutex_;
+};
+} // namespace rpc
+} // namespace distributed
+} // namespace torch

--- a/torch/csrc/distributed/rpc/testing/init.cpp
+++ b/torch/csrc/distributed/rpc/testing/init.cpp
@@ -1,0 +1,118 @@
+#include <torch/csrc/python_headers.h>
+
+#include <torch/csrc/distributed/rpc/process_group_agent.h>
+#include <torch/csrc/distributed/rpc/rpc_agent.h>
+#include <torch/csrc/distributed/rpc/testing/faulty_process_group_agent.h>
+#include <torch/csrc/utils/pybind.h>
+
+#include <pybind11/chrono.h>
+
+namespace torch {
+namespace distributed {
+namespace rpc {
+namespace testing {
+
+namespace {
+
+template <typename T>
+using shared_ptr_class_ = py::class_<T, std::shared_ptr<T>>;
+
+PyObject* faulty_agent_init(PyObject* /* unused */) {
+  // Add the FaultyProcessGroupAgent and its backend options object to the
+  // python module torch.distributed.rpc._testing
+  auto faulty_agent_module =
+      THPObjectPtr(PyImport_ImportModule("torch.distributed.rpc._testing"));
+  if (!faulty_agent_module) {
+    throw python_error();
+  }
+
+  auto module = py::handle(faulty_agent_module).cast<py::module>();
+
+  // Import the rpc_module so we can subclass ProcessGroupAgent
+  py::module rpc_module = py::module::import("torch.distributed.rpc");
+
+  shared_ptr_class_<FaultyProcessGroupRpcBackendOptions>(
+      module,
+      "FaultyProcessGroupRpcBackendOptions",
+      rpc_module.attr("ProcessGroupRpcBackendOptions"))
+      .def(
+          py::init<
+              int,
+              std::chrono::milliseconds,
+              std::string,
+              std::vector<std::string>,
+              int>(),
+          py::arg("num_send_recv_threads"),
+          py::arg("rpc_timeout"),
+          py::arg("init_method"),
+          py::arg("messages_to_fail"),
+          py::arg("num_fail_sends"))
+      .def_readwrite(
+          "num_send_recv_threads",
+          &ProcessGroupRpcBackendOptions::numSendRecvThreads)
+      .def_readwrite(
+          "messages_to_fail",
+          &FaultyProcessGroupRpcBackendOptions::messagesToFail)
+      .def_readwrite(
+          "num_fail_sends", &FaultyProcessGroupRpcBackendOptions::numFailSends);
+
+  shared_ptr_class_<FaultyProcessGroupAgent>(
+      module, "FaultyProcessGroupAgent", rpc_module.attr("ProcessGroupAgent"))
+      .def(
+          py::init<
+              std::string,
+              std::shared_ptr<::c10d::ProcessGroup>,
+              int,
+              std::chrono::milliseconds,
+              std::vector<std::string>,
+              int>(),
+          py::arg("name"),
+          py::arg("process_group"),
+          py::arg("num_send_recv_threads"),
+          py::arg("rpc_timeout"),
+          py::arg("messages_to_fail"),
+          py::arg("failNumSends"))
+      .def(
+          "join",
+          &ProcessGroupAgent::join,
+          py::call_guard<py::gil_scoped_release>())
+      .def(
+          "shutdown",
+          &ProcessGroupAgent::shutdown,
+          py::call_guard<py::gil_scoped_release>())
+      .def(
+          "get_worker_info",
+          (const WorkerInfo& (ProcessGroupAgent::*)(void)const) &
+              RpcAgent::getWorkerInfo,
+          py::call_guard<py::gil_scoped_release>())
+      .def(
+          "get_worker_info",
+          (const WorkerInfo& (ProcessGroupAgent::*)(const std::string&)const) &
+              ProcessGroupAgent::getWorkerInfo,
+          py::call_guard<py::gil_scoped_release>())
+      .def(
+          "get_worker_infos",
+          (std::vector<WorkerInfo>(ProcessGroupAgent::*)() const) &
+              ProcessGroupAgent::getWorkerInfos,
+          py::call_guard<py::gil_scoped_release>());
+
+  Py_RETURN_TRUE;
+}
+
+} // namespace
+
+static PyMethodDef methods[] = { // NOLINT
+    {"_faulty_agent_init",
+     (PyCFunction)faulty_agent_init,
+     METH_NOARGS,
+     nullptr},
+    {nullptr, nullptr, 0, nullptr}};
+
+PyMethodDef* python_functions() {
+  return methods;
+}
+
+} // namespace testing
+} // namespace rpc
+} // namespace distributed
+} // namespace torch

--- a/torch/csrc/distributed/rpc/testing/testing.h
+++ b/torch/csrc/distributed/rpc/testing/testing.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <torch/csrc/python_headers.h>
+
+namespace torch {
+namespace distributed {
+namespace rpc {
+namespace testing {
+
+PyMethodDef* python_functions();
+
+} // namespace testing
+} // namespace rpc
+} // namespace distributed
+} // namespace torch

--- a/torch/distributed/rpc/_testing/__init__.py
+++ b/torch/distributed/rpc/_testing/__init__.py
@@ -1,0 +1,14 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import torch
+
+
+def is_available():
+    return hasattr(torch._C, "_faulty_agent_init")
+
+
+if is_available() and not torch._C._faulty_agent_init():
+    raise RuntimeError("Failed to initialize torch.distributed.rpc._testing")
+
+if is_available():
+    from . import faulty_agent_backend_registry

--- a/torch/distributed/rpc/_testing/faulty_agent_backend_registry.py
+++ b/torch/distributed/rpc/_testing/faulty_agent_backend_registry.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+
+import torch.distributed as dist
+import torch.distributed.rpc as rpc
+import torch.distributed.distributed_c10d as dc10d
+from torch.distributed.rpc import constants as rpc_constants
+
+def _faulty_process_group_construct_rpc_backend_options_handler(
+    rpc_timeout,
+    init_method,
+    num_send_recv_threads,
+    messages_to_fail,
+    num_fail_sends,
+    **kwargs
+):
+    from . import FaultyProcessGroupRpcBackendOptions
+
+    return FaultyProcessGroupRpcBackendOptions(
+        rpc_timeout=rpc_timeout,
+        init_method=init_method,
+        num_send_recv_threads=num_send_recv_threads,
+        messages_to_fail=messages_to_fail,
+        num_fail_sends=num_fail_sends,
+    )
+
+def _faulty_process_group_init_backend_handler(
+    store, name, rank, world_size, rpc_backend_options
+):
+    from . import FaultyProcessGroupAgent
+
+    if dist.is_initialized():
+        raise RuntimeError(
+            "Process group must not be initialized before init_rpc."
+        )
+
+    process_group_timeout = rpc_constants.DEFAULT_PROCESS_GROUP_TIMEOUT
+
+    dist.init_process_group(
+        backend=dist.Backend.GLOO,
+        store=store,
+        rank=rank,
+        world_size=world_size,
+        timeout=process_group_timeout,
+    )
+
+    try:
+        group = dc10d._get_default_group()
+        assert group is not None, "Failed to initialize default ProcessGroup."
+
+        if (rank != -1) and (rank != group.rank()):
+            raise RuntimeError(
+                "rank argument {} doesn't match pg rank {}".format(rank, group.rank())
+            )
+        if (world_size != -1) and (world_size != group.size()):
+            raise RuntimeError(
+                "world_size argument {} doesn't match pg size {}".format(
+                    world_size, group.size()
+                )
+            )
+
+        return FaultyProcessGroupAgent(
+            name,
+            group,
+            rpc_backend_options.num_send_recv_threads,
+            rpc_backend_options.rpc_timeout,
+            rpc_backend_options.messages_to_fail,
+            rpc_backend_options.num_fail_sends,
+        )
+    except Exception as ex:
+        dist.destroy_process_group()
+        raise ex
+
+rpc.backend_registry.register_backend(
+    "FAULTY_PROCESS_GROUP",
+    _faulty_process_group_construct_rpc_backend_options_handler,
+    _faulty_process_group_init_backend_handler,
+)

--- a/torch/testing/_internal/distributed/rpc/dist_autograd_test.py
+++ b/torch/testing/_internal/distributed/rpc/dist_autograd_test.py
@@ -23,6 +23,9 @@ from torch.testing._internal.dist_utils import (
 from torch.testing._internal.distributed.rpc.rpc_agent_test_fixture import (
     RpcAgentTestFixture,
 )
+from torch.testing._internal.distributed.rpc.faulty_rpc_agent_test_fixture import (
+    FaultyRpcAgentTestFixture,
+)
 
 
 # Right now we test up to 3-layer nested rpc calls.
@@ -2061,3 +2064,51 @@ class DistAutogradTest(RpcAgentTestFixture):
             # static_grad_values_ref are holding onto views and don't bump the
             # refcount.
             self.assertTrue(p_g == p_a)
+
+@unittest.skipIf(
+    not torch._six.PY3,
+    "Pytorch distributed autograd package does not support python2",
+)
+class FaultyAgentDistAutogradTest(FaultyRpcAgentTestFixture):
+    # Reusing a simplified helper function from DistAutogradTest to ensure
+    # autograd context is successfully cleaned up even when RPCs are failing.
+    def context_cleanup_test_helper(self, rpc_args, func):
+        initialize_pg(self.init_method, self.rank, self.world_size)
+
+        # test that in dist autograd, in the case that tensors communicated over RPC do
+        # NOT require grad, we still cleanup the dist autograd contexts created
+        # on other nodes. This is because the autograd context is still
+        # communicated over RPC even if tensor arguments do not require grad, as
+        # it is possible that the response could.
+        dst_ranks = {rank for rank in range(self.world_size) if rank != self.rank}
+
+        with dist_autograd.context() as context_id:
+            for dst_rank in dst_ranks:
+                rpc.rpc_sync("worker{}".format(dst_rank), func, args=rpc_args)
+                rpc.rpc_sync(
+                    "worker{}".format(dst_rank), _set_rpc_done, args=(context_id, 1)
+                )
+        # the thread's context id should be cleaned up
+        with self.assertRaises(RuntimeError):
+            dist_autograd._retrieve_context(context_id)
+        # Ensure all peers have finished mutating the
+        # `known_context_ids` set.
+        dist.barrier()
+        # check that all contexts have been cleaned up.
+        success = _all_contexts_cleaned_up()
+        self.assertTrue(success)
+
+    # no faulty_messages defined so this fails all retryable messages - see
+    # faulty_rpc_agent_test_fixture.py for the list of retryable messages.
+    @dist_init
+    def test_context_cleanup_tensor_with_grad(self):
+        t1 = torch.ones(3, 3, requires_grad=True)
+        t2 = torch.zeros(3, 3, requires_grad=True)
+        self.context_cleanup_test_helper(rpc_args=(t1, t2), func=torch.add)
+
+    @dist_init
+    def test_verify_backend_options(self):
+        self.assertEqual(self.rpc_backend, rpc.backend_registry.BackendType.FAULTY_PROCESS_GROUP)
+        self.assertEqual(self.rpc_backend_options.num_send_recv_threads, 8)
+        self.assertEqual(self.rpc_backend_options.num_fail_sends, 3)
+        self.assertEqual(len(self.rpc_backend_options.messages_to_fail), 4)

--- a/torch/testing/_internal/distributed/rpc/faulty_rpc_agent_test_fixture.py
+++ b/torch/testing/_internal/distributed/rpc/faulty_rpc_agent_test_fixture.py
@@ -1,0 +1,31 @@
+import torch.distributed.rpc as rpc
+import torch.testing._internal.dist_utils
+import torch.distributed.rpc._testing  # noqa
+from torch.testing._internal.distributed.rpc.rpc_agent_test_fixture import (
+    RpcAgentTestFixture,
+)
+
+# The following message types are currently retried in the RREF protocol and
+# distributed autograd. Thus only these messages should be tested with the
+# Faulty RPC Agent.
+retryable_message_types = ["RREF_FORK_REQUEST",
+                           "RREF_CHILD_ACCEPT",
+                           "RREF_USER_DELETE",
+                           "CLEANUP_AUTOGRAD_CONTEXT_REQ"]
+
+class FaultyRpcAgentTestFixture(RpcAgentTestFixture):
+    @property
+    def rpc_backend(self):
+        return rpc.backend_registry.BackendType[
+            "FAULTY_PROCESS_GROUP"
+        ]
+
+    @property
+    def rpc_backend_options(self):
+        return rpc.backend_registry.construct_rpc_backend_options(
+            self.rpc_backend,
+            init_method=self.init_method,
+            num_send_recv_threads=8,
+            num_fail_sends=3,
+            messages_to_fail=retryable_message_types,
+        )

--- a/torch/testing/_internal/distributed/rpc/rpc_test.py
+++ b/torch/testing/_internal/distributed/rpc/rpc_test.py
@@ -11,7 +11,7 @@ import torch.distributed as dist
 import torch.distributed.rpc as rpc
 import torch.testing._internal.dist_utils as dist_utils
 from torch.distributed.rpc import RRef, _get_debug_info, _rref_context_get_debug_info
-from torch.distributed.rpc.api import _use_rpc_pickler
+from torch.distributed.rpc.api import _delete_all_user_rrefs, _use_rpc_pickler
 from torch.distributed.rpc.internal import PythonUDF, RPCExecMode, _internal_rpc_pickler
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_utils import IS_MACOS, load_tests
@@ -27,6 +27,9 @@ from torch.testing._internal.distributed.rpc.rpc_agent_test_fixture import (
     RpcAgentTestFixture,
 )
 from torch.testing._internal.common_utils import TemporaryFileName
+from torch.testing._internal.distributed.rpc.faulty_rpc_agent_test_fixture import (
+    FaultyRpcAgentTestFixture,
+)
 
 
 def foo_add():
@@ -1840,3 +1843,33 @@ class RpcTest(RpcAgentTestFixture):
         with TemporaryFileName() as fname:
             with self.assertRaisesRegex(RuntimeError, "Can not pickle rref in python pickler"):
                 torch.save(local_rref, fname)
+
+@unittest.skipIf(
+    not torch._six.PY3,
+    "Pytorch distributed autograd package does not support python2",
+)
+class FaultyAgentRpcTest(FaultyRpcAgentTestFixture):
+
+    # no faulty_messages defined so this fails all retryable messages - see
+    # faulty_rpc_agent_test_fixture.py for the list of retryable messages.
+    @dist_init
+    def test_check_failed_messages(self):
+        if self.rank == 0:
+            dst_worker_b = "worker{}".format((self.rank + 1) % self.world_size)
+            dst_worker_c = "worker{}".format((self.rank + 2) % self.world_size)
+
+            # Worker0 sends RPC to Worker1 and creates an RRef there
+            rref = rpc.remote(dst_worker_b, torch.add, args=(torch.ones(2, 2), torch.ones(2, 2)))
+            # Worker0 sends an RPC to Worker2 with the RRef as an arg
+            rpc.remote(dst_worker_c, add_rref_to_value, args=(rref, torch.ones(2, 2)))
+            # check if the output is as expected
+            self.assertEqual(rref.to_here(), torch.add(torch.ones(2, 2), torch.ones(2, 2)))
+        # explicitly delete all User RRefs
+        _delete_all_user_rrefs()
+
+    @dist_init
+    def test_verify_backend_options(self):
+        self.assertEqual(self.rpc_backend, rpc.backend_registry.BackendType.FAULTY_PROCESS_GROUP)
+        self.assertEqual(self.rpc_backend_options.num_send_recv_threads, 8)
+        self.assertEqual(self.rpc_backend_options.num_fail_sends, 3)
+        self.assertEqual(len(self.rpc_backend_options.messages_to_fail), 4)


### PR DESCRIPTION
Summary:
Fixes https://github.com/pytorch/pytorch/issues/32119, https://github.com/pytorch/pytorch/issues/26116, https://github.com/pytorch/pytorch/issues/33072, https://github.com/pytorch/pytorch/issues/28123

Makes RRef control messages idempotent and enables sending with retries for distributed autograd cleanup and RRef internal messages.

In order to effectively test whether these RRef and distributed autograd cleanup work with network failures/retries, I implemented an RPC Agent with a faulty send function, and enabled running tests using this as a third backend (in addition to Thrift and PGA). The tests using this backend are in a separate class (the test cases are similar but with minor changes to ensure short-running tests wait for retried RPCs to finish).

This faulty RPC Agent is pretty configurable. The tests can configure which messages types to fail, and how many messages to fail, but going forward, other RPC functionality can be overriden with faulty methods to test with failures injected.

Differential Revision: D20019236

