### PR TITLE
Bounds checking for functor execution in vectorized/unrolled kernels

### DIFF
--- a/aten/src/ATen/native/cuda/CUDALoops.cuh
+++ b/aten/src/ATen/native/cuda/CUDALoops.cuh
@@ -261,7 +261,9 @@ __device__ inline void elementwise_kernel_helper(func_t f, array_t data, policy_
   // compute
   #pragma unroll
   for (int i = 0; i < thread_work_size; i++) {
-    results[i] = c10::guts::apply(f, args[i]);
+    if (policy.check_inbounds(i)) {
+      results[i] = c10::guts::apply(f, args[i]);
+    }
   }
 
   // store

--- a/aten/src/ATen/native/cuda/MemoryAccess.cuh
+++ b/aten/src/ATen/native/cuda/MemoryAccess.cuh
@@ -24,6 +24,10 @@ struct checked_unroll {
 
   __device__ checked_unroll(int remaining): remaining(remaining) {}
 
+  __device__ inline bool check_inbounds(int thread_work_elem) {
+    return ((threadIdx.x  + thread_work_elem*num_threads) < remaining);
+  }
+
   template<typename accessor_t, typename scalar_t>
   __device__ inline void load(accessor_t to, scalar_t *from) {
     int thread_idx = threadIdx.x;
@@ -60,6 +64,10 @@ struct vectorized {
 
   static_assert(thread_work_size % vec_size == 0, "The workload per thread must be a multiple of vec_size");
   static constexpr int loop_size = thread_work_size / vec_size;
+
+  __device__ inline constexpr bool check_inbounds(int thread_work_elem) {
+    return true;
+  }
 
   template<typename accessor_t, typename scalar_t>
   __device__ inline void load(accessor_t to, scalar_t *from) {


### PR DESCRIPTION
The current logic for vectorized/unrolled operations in CUDALoops.cuh applies bounds checking to loads and stores, [but not to the actual functor's execution](https://github.com/pytorch/pytorch/blob/16d6c17845426294274850f9161e292345f2afa5/aten/src/ATen/native/cuda/CUDALoops.cuh#L264).  In other words, for a block acting on the tail of a tensor that doesn't require the whole block to participate in memory transactions, many threads execute their functor on uninitialized data.  For functors that only communicate with the outside world via the bounds-checked loads and stores, that's ok.  The threads acting on garbage data never actually write their results.  But [my proposed inf/nan checking kernel](https://github.com/pytorch/pytorch/pull/33366/files#diff-9701a2b34900195d160bdc234e001b79R70-R79) has the additional side effect of writing to a `found_inf` flag in global memory.  For irregularly-shaped tensors where tail threads execute the functor on garbage data, these threads would sometimes see and report spurious infs/nans.

In general, we can't guarantee functors won't have side effects.  For safety (and efficiency) we should apply bounds checking to the functor execution as well as the loads and stores.

Is it possible that other elementwise kernels (in addition to the strided/vectorized implementation) are also executing functors unconditionally?  That would cause similar failures.