### PR TITLE
Fix bug where we were trying to get a schema for prim::Constant, which is not registered as an operator.

### DIFF
--- a/torch/csrc/jit/autodiff.cpp
+++ b/torch/csrc/jit/autodiff.cpp
@@ -140,7 +140,11 @@ static c10::optional<std::vector<Value*>> build_script_grad(
     Node* node,
     const ArrayRef<Value*>& grads) {
   auto graph = node->owningGraph();
-  auto compiled_graphs = gradientInfoForSchema(node->schema());
+  auto maybe_schema = node->maybeSchema();
+  if (!maybe_schema) {
+    return c10::nullopt;
+  }
+  auto compiled_graphs = gradientInfoForSchema(*maybe_schema);
   if (!compiled_graphs) {
     return c10::nullopt;
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#33645 Fix bug where we were trying to get a schema for prim::Constant, which is not registered as an operator.**

Fix bug where we were trying to get a schema for prim::Constant, which is not registered as an operator.

Differential Revision: [D20050833](https://our.internmc.facebook.com/intern/diff/D20050833/)