### PR TITLE
Rename {Post,Pre}FusionPasses to {Post,Pre}Passes.

### DIFF
--- a/torch/csrc/jit/graph_executor.cpp
+++ b/torch/csrc/jit/graph_executor.cpp
@@ -711,7 +711,7 @@ void runNondiffOptimization(
     std::shared_ptr<Graph>& graph,
     bool strict_fuser_check) {
   // Run custom passes that different backends can register.
-  for (const auto& pass : getCustomPreFusionPasses()) {
+  for (const auto& pass : getCustomPrePasses()) {
     pass(graph);
   }
 
@@ -734,7 +734,7 @@ void runNondiffOptimization(
   FuseGraph(graph, strict_fuser_check);
 
   // Run custom post-fusion passes
-  for (const auto& pass : getCustomPostFusionPasses()) {
+  for (const auto& pass : getCustomPostPasses()) {
     pass(graph);
   }
 }

--- a/torch/csrc/jit/pass_manager.cpp
+++ b/torch/csrc/jit/pass_manager.cpp
@@ -3,22 +3,22 @@
 namespace torch {
 namespace jit {
 
-std::vector<Pass>& getCustomPostFusionPasses() {
+std::vector<Pass>& getCustomPostPasses() {
   static std::vector<Pass> passes;
   return passes;
 }
 
-std::vector<Pass>& getCustomPreFusionPasses() {
+std::vector<Pass>& getCustomPrePasses() {
   static std::vector<Pass> passes;
   return passes;
 }
 
 RegisterPostFusionPass::RegisterPostFusionPass(Pass p) {
-  getCustomPostFusionPasses().emplace_back(std::move(p));
+  getCustomPostPasses().emplace_back(std::move(p));
 }
 
 RegisterPreFusionPass::RegisterPreFusionPass(Pass p) {
-  getCustomPreFusionPasses().emplace_back(std::move(p));
+  getCustomPrePasses().emplace_back(std::move(p));
 }
 
 } // namespace jit

--- a/torch/csrc/jit/pass_manager.h
+++ b/torch/csrc/jit/pass_manager.h
@@ -2,11 +2,11 @@
 
 #include <torch/csrc/jit/ir.h>
 
-/* `getCustomPreFusionPasses()` returns a vector of passes that will be executed
+/* `getCustomPrePasses()` returns a vector of passes that will be executed
  * after differentiation but before any fusion. This is the de-facto location
  * for compiler backends to insert passes.
  *
- * `getCustomPostFusionPasses()` returns a vector of passes that will be
+ * `getCustomPostPasses()` returns a vector of passes that will be
  * executed after differentiation and after fusion (if any). This is the
  * location for fusion cleanup passes if they are needed.
  *
@@ -23,8 +23,8 @@ namespace jit {
 // A pass modifies a Graph in place.
 using Pass = std::function<void(std::shared_ptr<Graph>&)>;
 
-TORCH_API std::vector<Pass>& getCustomPostFusionPasses();
-TORCH_API std::vector<Pass>& getCustomPreFusionPasses();
+TORCH_API std::vector<Pass>& getCustomPostPasses();
+TORCH_API std::vector<Pass>& getCustomPrePasses();
 
 struct TORCH_API RegisterPostFusionPass {
   RegisterPostFusionPass(Pass p);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#33674 Rename {Post,Pre}FusionPasses to {Post,Pre}Passes.**

Differential Revision: [D20062113](https://our.internmc.facebook.com/intern/diff/D20062113)