### PR TITLE
[docs] add experimental warning to TorchScript classes in language reference

### DIFF
--- a/docs/source/jit_language_reference.rst
+++ b/docs/source/jit_language_reference.rst
@@ -302,6 +302,13 @@ Example (refining types on parameters and locals):
 
 TorchScript Classes
 ^^^^^^^^^^^^^^^^^^^
+
+.. warning::
+
+    TorchScript class support is experimental. Currently it is best suited
+    for simple record-like types (think a ``NamedTuple`` with methods
+    attached).
+
 Python classes can be used in TorchScript if they are annotated with :func:`@torch.jit.script <torch.jit.script>`,
 similar to how you would declare a TorchScript function:
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#33697 [docs] add experimental warning to TorchScript classes in language**

reference

Differential Revision: [D20070220](https://our.internmc.facebook.com/intern/diff/D20070220)