### PR TITLE
[Lite Trainer] An extention of lite interpreter to have autograd features

### DIFF
--- a/tools/autograd/templates/VariableType.cpp
+++ b/tools/autograd/templates/VariableType.cpp
@@ -31,9 +31,7 @@ using namespace torch::autograd::generated;
 namespace torch { namespace autograd {
 
 namespace VariableType {
-namespace {
 ${type_derived_method_definitions}
-}
 }
 
 namespace {

--- a/torch/csrc/jit/mobile/register_mobile_autograd.cpp
+++ b/torch/csrc/jit/mobile/register_mobile_autograd.cpp
@@ -11,50 +11,8 @@ using at::Scalar;
 namespace torch {
 namespace autograd {
 namespace VariableType {
-Tensor mul_no_trace(const Tensor & self, const Tensor & other) {
-  RECORD_FUNCTION("mul", std::vector<c10::IValue>({self, other}), Node::peek_at_next_sequence_nr());
-  auto& self_ = unpack(self, "self", 0);
-  auto& other_ = unpack(other, "other", 1);
-  std::shared_ptr<MulBackward0> grad_fn;
-  if (compute_requires_grad( self, other )) {
-    grad_fn = std::shared_ptr<MulBackward0>(new MulBackward0(), deleteNode);
-    grad_fn->set_next_edges(collect_next_edges( self, other ));
-    if (grad_fn->should_compute_output(1)) {
-      grad_fn->self_ = SavedVariable(self, false);
-    }
-    if (grad_fn->should_compute_output(0)) {
-      grad_fn->other_ = SavedVariable(other, false);
-    }
-  }
-  auto tmp = ([&]() {
-    at::AutoNonVariableTypeMode non_var_type_mode(true);
-    return at::mul(self_, other_);
-  })();
-  auto result = std::move(tmp);
-  if (grad_fn) {
-      set_history(flatten_tensor_args( result ), grad_fn);
-  }
-  return result;
-}
-
-Tensor add_no_trace(const Tensor & self, Scalar other, Scalar alpha) {
-  RECORD_FUNCTION("add", std::vector<c10::IValue>({self, other, alpha}), Node::peek_at_next_sequence_nr());
-  auto& self_ = unpack(self, "self", 0);
-  std::shared_ptr<AddBackward1> grad_fn;
-  if (compute_requires_grad( self )) {
-    grad_fn = std::shared_ptr<AddBackward1>(new AddBackward1(), deleteNode);
-    grad_fn->set_next_edges(collect_next_edges( self ));
-  }
-  auto tmp = ([&]() {
-    at::AutoNonVariableTypeMode non_var_type_mode(true);
-    return at::add(self_, other, alpha);
-  })();
-  auto result = std::move(tmp);
-  if (grad_fn) {
-      set_history(flatten_tensor_args( result ), grad_fn);
-  }
-  return result;
-}
+Tensor mul(const Tensor & self, const Tensor & other);
+Tensor add(const Tensor & self, Scalar other, Scalar alpha);
 }
 }
 }
@@ -62,10 +20,11 @@ Tensor add_no_trace(const Tensor & self, Scalar other, Scalar alpha) {
 namespace {
 static auto registry = torch::RegisterOperators().op(
     "_aten::add.Scalar",
-    torch::RegisterOperators::options().kernel(c10::DispatchKey::VariableTensorId, &torch::autograd::VariableType::add_no_trace)
+    torch::RegisterOperators::options().kernel(c10::DispatchKey::VariableTensorId, &torch::autograd::VariableType::add)
 ).op(
     "_aten::mul.Tensor(Tensor self, Tensor other) -> Tensor",
-    torch::RegisterOperators::options().kernel(c10::DispatchKey::VariableTensorId, &torch::autograd::VariableType::mul_no_trace)
+    torch::RegisterOperators::options().kernel(c10::DispatchKey::VariableTensorId, &torch::autograd::VariableType::mul)
         .aliasAnalysis(c10::AliasAnalysisKind::FROM_SCHEMA)
 );
 }
+


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #33717 [Lite Trainer] Add necessary registrations for MNIST model
* **#33716 [Lite Trainer] An extention of lite interpreter to have autograd features**
* #33715 Make tracing in code gen optional
* #32359 Add and test training in lite interpreter.

The new BUCK target, xplat/caffe2:torch_mobile_train, can be used as a light weighted library for both training and inference, while the original target, torch_mobile_core, is for inference only.

Differential Revision: [D19689384](https://our.internmc.facebook.com/intern/diff/D19689384/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D19689384/)!