### PR TITLE
Fix visibility of torch::nn::RNNImpl::options

### DIFF
--- a/torch/csrc/api/include/torch/nn/modules/rnn.h
+++ b/torch/csrc/api/include/torch/nn/modules/rnn.h
@@ -136,7 +136,7 @@ class TORCH_API RNNImpl : public detail::RNNImplBase<RNNImpl> {
   RNNOutput forward(const Tensor& input, Tensor state = {});
  protected:
   FORWARD_HAS_DEFAULT_ARGS({1, AnyValue(Tensor())})
-
+ public:
   RNNOptions options;
 };
 


### PR DESCRIPTION
In PR #33027, `options` in RNNImpl was mistakenly changed to `protected` (it was `public` before)

```
 protected:
  FORWARD_HAS_DEFAULT_ARGS({1, AnyValue(Tensor())})

  RNNOptions options;
```

This PR changes it back to `public` again.

Fixes https://github.com/pytorch/pytorch/issues/33694.