### PR TITLE
make test_distributed run on file store only

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -228,12 +228,19 @@ def test_distributed(executable, test_module, test_directory, options):
             os.environ['BACKEND'] = backend
             os.environ['INIT_METHOD'] = 'env://'
             os.environ.update(env_vars)
-            if with_init_file:
-                if test_module == "test_distributed":
-                    init_method = 'file://{}/'.format(tmp_dir)
-                else:
-                    init_method = 'file://{}/shared_init_file'.format(tmp_dir)
+
+            # Tests are flaky if using TCP store in test_distributed.py,
+            # as ports could be racy, see flaky test
+            # https://github.com/pytorch/pytorch/issues/30676.
+            # Since test_distributed.py does not have TCP store related tests,
+            # making test_distributed to use file store only.
+            if test_module == "test_distributed":
+                init_method = 'file://{}/'.format(tmp_dir)
                 os.environ['INIT_METHOD'] = init_method
+            elif with_init_file:
+                init_method = 'file://{}/shared_init_file'.format(tmp_dir)
+                os.environ['INIT_METHOD'] = init_method
+
             try:
                 os.mkdir(os.path.join(tmp_dir, 'barrier'))
                 os.mkdir(os.path.join(tmp_dir, 'test_dir'))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#33726 make test_distributed run on file store only**

as mentioned in https://github.com/pytorch/pytorch/issues/30676, TCP store could be racy in unit tests, make test_distributed.py to run on file store only, as there is no TCP store related tests in test_distributed.py

Differential Revision: [D20078964](https://our.internmc.facebook.com/intern/diff/D20078964/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D20078964/)!