### PR TITLE
[C2] Fix slowness of the ReshapeOp.

### DIFF
--- a/caffe2/operators/reshape_op.h
+++ b/caffe2/operators/reshape_op.h
@@ -44,17 +44,38 @@ class ReshapeOp : public Operator<Context> {
           "New shape is specified by the input blob, do not pass in "
           "the argument `shape`.");
 
-      auto& shape = Input(1);
-      CAFFE_ENFORCE(shape.dim() == 1, "Shape should be 1-D");
-
-      const T* shape_data = shape.template data<T>();
-
-      // Bit awkward, but needed so works on both CPU and CUDA contexts
-      std::vector<T> tmpv(shape.numel());
-      if (shape.numel() > 0) {
-        context_.CopyBytesToCPU(
-            shape.numel() * sizeof(T), shape_data, &tmpv[0]);
-        actual_new_shape.assign(tmpv.begin(), tmpv.begin() + shape.numel());
+      // Shape should be always stored only on CPU
+      // Just in case if for some reason shape is on GPU
+      if (this->InputIsTensorType(1, CPU)) {
+        // originally, shape input must be in CPU context
+        auto& shape = this->template Input<Tensor>(1, CPU);
+        CAFFE_ENFORCE_EQ(
+            shape.dim(),
+            1,
+            "When input_as_shape is true, the input must be a 1D tensor of "
+            "data type int64_t");
+        CAFFE_ENFORCE(shape.numel() > 0);
+        auto* shape_data = shape.template data<T>();
+        actual_new_shape.insert(
+            actual_new_shape.end(), shape_data, shape_data + shape.dim32(0));
+      } else {
+        auto& shape = Input(1);
+        CAFFE_ENFORCE_EQ(
+            shape.dim(),
+            1,
+            "When input_as_shape is true, the input must be a 1D tensor of "
+            "data type int64_t");
+        CAFFE_ENFORCE(shape.numel() > 0);
+        auto* shape_data = shape.template data<T>();
+        // Fetch copy from
+        std::unique_ptr<T[]> shape_data_copy =
+            std::make_unique<T[]>(shape.dim32(0));
+        context_.template CopyToCPU<T>(
+            shape.dim32(0), shape_data, shape_data_copy.get());
+        actual_new_shape.insert(
+            actual_new_shape.end(),
+            shape_data_copy.get(),
+            shape_data_copy.get() + shape.dim32(0));
       }
     }
 
@@ -127,10 +148,12 @@ class ReshapeOp : public Operator<Context> {
     }
 
     // Write the original shape to the second output.
-    auto* old_shape = Output(1, {input.dim()}, at::dtype<T>());
+    auto* old_shape = this->template Output<Tensor>(1, CPU);
+    old_shape->Resize(input.sizes().size());
     T* old_shape_data = old_shape->template mutable_data<T>();
-    for (int i = 0; i < input.dim(); ++i) {
-      math::Set<T, Context>(1, input.size(i), old_shape_data + i, &context_);
+    std::vector<T> old_shape_vector(input.sizes().begin(), input.sizes().end());
+    for (int i = 0; i < old_shape_vector.size(); ++i) {
+      old_shape_data[i] = old_shape_vector[i];
     }
 
     output->Resize(actual_new_shape);


### PR DESCRIPTION
Summary:
ReshapeOp is doing some useless movements of data between CPU and GPU, which results in crazy amount of kernel calls from this operator. Which makes this operator ridiculosly slow compared to BatchMatMul for cases of pretty cheap models (for example on some versions of GAT).

This diff is moving ReshapeOp to leverage CPU storage and reduce amount of kernel calls from num_dims + 3 calls for case of 3-D
tensor to 2 calls.

Test Plan:
Unit-tests are still passing.

TODO: perf testing

Reviewed By: akyrola

Differential Revision: D19659491

