### PR TITLE
[C++ API Parity] Adam: updated step and class design 

### DIFF
--- a/test/cpp/api/optim.cpp
+++ b/test/cpp/api/optim.cpp
@@ -211,30 +211,30 @@ TEST(OptimTest, XORConvergence_RMSpropWithMomentum) {
       RMSpropOptions(0.1).momentum(0.9).weight_decay(1e-6)));
 }
 
-TEST(OptimTest, XORConvergence_Adam) {
-  ASSERT_TRUE(test_optimizer_xor<Adam>(AdamOptions(0.1).weight_decay(1e-6)));
-}
-
-TEST(OptimTest, XORConvergence_AdamWithAmsgrad) {
-  ASSERT_TRUE(test_optimizer_xor<Adam>(
-      AdamOptions(0.1).weight_decay(1e-6).amsgrad(true)));
-}
-
-TEST(OptimTest, ProducesPyTorchValues_Adam) {
-  check_exact_values<Adam>(AdamOptions(1.0), expected_parameters::Adam());
-}
-
-TEST(OptimTest, ProducesPyTorchValues_AdamWithWeightDecay) {
-  check_exact_values<Adam>(
-      AdamOptions(1.0).weight_decay(1e-2),
-      expected_parameters::Adam_with_weight_decay());
-}
-
-TEST(OptimTest, ProducesPyTorchValues_AdamWithWeightDecayAndAMSGrad) {
-  check_exact_values<Adam>(
-      AdamOptions(1.0).weight_decay(1e-6).amsgrad(true),
-      expected_parameters::Adam_with_weight_decay_and_amsgrad());
-}
+// TEST(OptimTest, XORConvergence_Adam) {
+//   ASSERT_TRUE(test_optimizer_xor<Adam>(AdamOptions(0.1).weight_decay(1e-6)));
+// }
+//
+// TEST(OptimTest, XORConvergence_AdamWithAmsgrad) {
+//   ASSERT_TRUE(test_optimizer_xor<Adam>(
+//       AdamOptions(0.1).weight_decay(1e-6).amsgrad(true)));
+// }
+//
+// TEST(OptimTest, ProducesPyTorchValues_Adam) {
+//   check_exact_values<Adam>(AdamOptions(1.0), expected_parameters::Adam());
+// }
+//
+// TEST(OptimTest, ProducesPyTorchValues_AdamWithWeightDecay) {
+//   check_exact_values<Adam>(
+//       AdamOptions(1.0).weight_decay(1e-2),
+//       expected_parameters::Adam_with_weight_decay());
+// }
+//
+// TEST(OptimTest, ProducesPyTorchValues_AdamWithWeightDecayAndAMSGrad) {
+//   check_exact_values<Adam>(
+//       AdamOptions(1.0).weight_decay(1e-6).amsgrad(true),
+//       expected_parameters::Adam_with_weight_decay_and_amsgrad());
+// }
 
 TEST(OptimTest, ProducesPyTorchValues_Adagrad) {
   check_exact_values<Adagrad>(

--- a/test/cpp/api/optim.cpp
+++ b/test/cpp/api/optim.cpp
@@ -211,30 +211,30 @@ TEST(OptimTest, XORConvergence_RMSpropWithMomentum) {
       RMSpropOptions(0.1).momentum(0.9).weight_decay(1e-6)));
 }
 
-// TEST(OptimTest, XORConvergence_Adam) {
-//   ASSERT_TRUE(test_optimizer_xor<Adam>(AdamOptions(0.1).weight_decay(1e-6)));
-// }
-//
-// TEST(OptimTest, XORConvergence_AdamWithAmsgrad) {
-//   ASSERT_TRUE(test_optimizer_xor<Adam>(
-//       AdamOptions(0.1).weight_decay(1e-6).amsgrad(true)));
-// }
-//
-// TEST(OptimTest, ProducesPyTorchValues_Adam) {
-//   check_exact_values<Adam>(AdamOptions(1.0), expected_parameters::Adam());
-// }
-//
-// TEST(OptimTest, ProducesPyTorchValues_AdamWithWeightDecay) {
-//   check_exact_values<Adam>(
-//       AdamOptions(1.0).weight_decay(1e-2),
-//       expected_parameters::Adam_with_weight_decay());
-// }
-//
-// TEST(OptimTest, ProducesPyTorchValues_AdamWithWeightDecayAndAMSGrad) {
-//   check_exact_values<Adam>(
-//       AdamOptions(1.0).weight_decay(1e-6).amsgrad(true),
-//       expected_parameters::Adam_with_weight_decay_and_amsgrad());
-// }
+TEST(OptimTest, XORConvergence_Adam) {
+  ASSERT_TRUE(test_optimizer_xor<Adam>(AdamOptions(0.1).weight_decay(1e-6)));
+}
+
+TEST(OptimTest, XORConvergence_AdamWithAmsgrad) {
+  ASSERT_TRUE(test_optimizer_xor<Adam>(
+      AdamOptions(0.1).weight_decay(1e-6).amsgrad(true)));
+}
+
+TEST(OptimTest, ProducesPyTorchValues_Adam) {
+  check_exact_values<Adam>(AdamOptions(1.0), expected_parameters::Adam());
+}
+
+TEST(OptimTest, ProducesPyTorchValues_AdamWithWeightDecay) {
+  check_exact_values<Adam>(
+      AdamOptions(1.0).weight_decay(1e-2),
+      expected_parameters::Adam_with_weight_decay());
+}
+
+TEST(OptimTest, ProducesPyTorchValues_AdamWithWeightDecayAndAMSGrad) {
+  check_exact_values<Adam>(
+      AdamOptions(1.0).weight_decay(1e-6).amsgrad(true),
+      expected_parameters::Adam_with_weight_decay_and_amsgrad());
+}
 
 TEST(OptimTest, ProducesPyTorchValues_Adagrad) {
   check_exact_values<Adagrad>(

--- a/test/cpp/api/serialize.cpp
+++ b/test/cpp/api/serialize.cpp
@@ -89,8 +89,6 @@ void test_serialize_optimizer(DerivedOptimizerOptions options) {
       model2->parameters(), options);
   auto optim2_2 = OptimizerClass(
       model2->parameters(), options);
-  auto optim2_3 = OptimizerClass(
-      model2->parameters(), options);
   auto optim3 = OptimizerClass(
       model3->parameters(), options);
   auto optim3_2 = OptimizerClass(
@@ -106,22 +104,14 @@ void test_serialize_optimizer(DerivedOptimizerOptions options) {
   };
 
   // Do 2 steps of model1
-  std::cout<<"step1 model1\n";
   step(optim1, model1);
-  std::cout<<"step2 model1\n";
   step(optim1, model1);
-  std::cout<<"step3 model1\n";
-  step(optim1, model1);
+
   // Do 2 steps of model 2 without saving the optimizer
-  std::cout<<"step1 model2\n";
   step(optim2, model2);
-  std::cout<<"step1 model2\n";
   step(optim2_2, model2);
-  std::cout<<"step1 model2\n";
-  step(optim2_3, model2);
 
   // Do 1 step of model 3
-  std::cout<<"step1 model3\n";
   step(optim3, model3);
 
   // save the optimizer
@@ -150,10 +140,8 @@ void test_serialize_optimizer(DerivedOptimizerOptions options) {
   }
 
   // Do step2 for model 3
-  std::cout<<"step2 model3\n";
   step(optim3_2, model3);
-  std::cout<<"step3 model3\n";
-  step(optim3_2, model3);
+
   param1 = model1->named_parameters();
   param2 = model2->named_parameters();
   param3 = model3->named_parameters();
@@ -566,7 +554,7 @@ TEST(SerializeTest, Optim_SGD) {
 }
 
 TEST(SerializeTest, Optim_Adam) {
-  test_serialize_optimizer<Adam, AdamOptions, AdamParamState>(AdamOptions().amsgrad(true).weight_decay(1e-2).betas(std::make_tuple(0.9, 0.99)));
+  test_serialize_optimizer<Adam, AdamOptions, AdamParamState>(AdamOptions().lr(0.99999).amsgrad(true).weight_decay(0.5));
 
   // bc compatibility check
   auto model1 = Linear(5, 2);

--- a/test/cpp/api/serialize.cpp
+++ b/test/cpp/api/serialize.cpp
@@ -89,6 +89,8 @@ void test_serialize_optimizer(DerivedOptimizerOptions options) {
       model2->parameters(), options);
   auto optim2_2 = OptimizerClass(
       model2->parameters(), options);
+  auto optim2_3 = OptimizerClass(
+      model2->parameters(), options);
   auto optim3 = OptimizerClass(
       model3->parameters(), options);
   auto optim3_2 = OptimizerClass(
@@ -104,14 +106,22 @@ void test_serialize_optimizer(DerivedOptimizerOptions options) {
   };
 
   // Do 2 steps of model1
+  std::cout<<"step1 model1\n";
   step(optim1, model1);
+  std::cout<<"step2 model1\n";
   step(optim1, model1);
-
+  std::cout<<"step3 model1\n";
+  step(optim1, model1);
   // Do 2 steps of model 2 without saving the optimizer
+  std::cout<<"step1 model2\n";
   step(optim2, model2);
+  std::cout<<"step1 model2\n";
   step(optim2_2, model2);
+  std::cout<<"step1 model2\n";
+  step(optim2_3, model2);
 
   // Do 1 step of model 3
+  std::cout<<"step1 model3\n";
   step(optim3, model3);
 
   // save the optimizer
@@ -140,8 +150,10 @@ void test_serialize_optimizer(DerivedOptimizerOptions options) {
   }
 
   // Do step2 for model 3
+  std::cout<<"step2 model3\n";
   step(optim3_2, model3);
-
+  std::cout<<"step3 model3\n";
+  step(optim3_2, model3);
   param1 = model1->named_parameters();
   param2 = model2->named_parameters();
   param3 = model3->named_parameters();
@@ -554,7 +566,7 @@ TEST(SerializeTest, Optim_SGD) {
 }
 
 TEST(SerializeTest, Optim_Adam) {
-  test_serialize_optimizer<Adam, AdamOptions, AdamParamState>(AdamOptions().amsgrad(true).weight_decay(1e-2));
+  test_serialize_optimizer<Adam, AdamOptions, AdamParamState>(AdamOptions().amsgrad(true).weight_decay(1e-2).betas(std::make_tuple(0.9, 0.99)));
 
   // bc compatibility check
   auto model1 = Linear(5, 2);

--- a/test/cpp/api/serialize.cpp
+++ b/test/cpp/api/serialize.cpp
@@ -127,7 +127,6 @@ void test_serialize_optimizer(DerivedOptimizerOptions options) {
   // optim3_2 and optim1 should have param_groups and state of size 1 and 2 respectively
   ASSERT_TRUE(optim3_2_param_groups.size() == 1);
   ASSERT_TRUE(optim3_2_state.size() == 2);
-
   // optim3_2 and optim1 should have param_groups and state of same size
   ASSERT_TRUE(optim3_2_param_groups.size() == optim3_param_groups.size());
   ASSERT_TRUE(optim3_2_state.size() == optim3_state.size());
@@ -551,6 +550,56 @@ TEST(SerializeTest, Optim_SGD) {
   auto optim1_2 = SGD(model1_params, torch::optim::SGDOptions(1e-1).momentum(0.9));
   OLD_SERIALIZATION_LOGIC_WARNING_CHECK(torch::load, optim1_2, optim_tempfile_old_format.name);
   is_optimizer_state_equal<SGDParamState>(optim1.state(), optim1_2.state());
+}
+
+TEST(SerializeTest, Optim_Adam) {
+  test_serialize_optimizer<Adam, AdamOptions, AdamParamState>(AdamOptions());
+
+  // bc compatibility check
+  auto model1 = Linear(5, 2);
+  auto model1_params = model1->parameters();
+  // added a tensor for lazy init check - when all params do not have a momentum buffer entry
+  model1_params.emplace_back(torch::randn({2,3}));
+  auto optim1 = torch::optim::Adam(model1_params, torch::optim::AdamOptions());
+
+  auto x = torch::ones({10, 5});
+  auto step = [&x](torch::optim::Optimizer& optimizer, Linear model) {
+    optimizer.zero_grad();
+    auto y = model->forward(x).sum();
+    y.backward();
+    optimizer.step();
+  };
+  step(optim1, model1);
+
+  std::vector<int64_t> step_buffers;
+  std::vector<at::Tensor> exp_average_buffers;
+  std::vector<at::Tensor> exp_average_sq_buffers;
+  std::vector<at::Tensor> max_exp_average_sq_buffers;
+  const auto& params_ = optim1.param_groups()[0].params();
+  const auto& optim1_state = optim1.state();
+  for (size_t i = 0; i < params_.size(); i++) {
+    if(i != (params_.size() - 1)) {
+      auto key_ = c10::guts::to_string(params_[i].unsafeGetTensorImpl());
+      const AdamParamState& curr_state_ = static_cast<const AdamParamState&>(*(optim1_state.at(key_).get()));
+      step_buffers.emplace_back(curr_state_.step());
+      exp_average_buffers.emplace_back(curr_state_.exp_avg());
+      exp_average_sq_buffers.emplace_back(curr_state_.exp_avg_sq());
+      if(curr_state_.max_exp_avg_sq().defined()) {
+        max_exp_average_sq_buffers.emplace_back(curr_state_.max_exp_avg_sq());
+      }
+    }
+  }
+  // write momentum_buffers to the file
+  auto optim_tempfile_old_format = c10::make_tempfile();
+  torch::serialize::OutputArchive output_archive;
+  write_step_buffers(output_archive, "step_buffers", step_buffers);
+  write_tensors_to_archive(output_archive, "exp_average_buffers", exp_average_buffers);
+  write_tensors_to_archive(output_archive, "exp_average_sq_buffers", exp_average_sq_buffers);
+  write_tensors_to_archive(output_archive, "max_exp_average_sq_buffers", max_exp_average_sq_buffers);
+  output_archive.save_to(optim_tempfile_old_format.name);
+  auto optim1_2 = Adam(model1_params, torch::optim::AdamOptions());
+  OLD_SERIALIZATION_LOGIC_WARNING_CHECK(torch::load, optim1_2, optim_tempfile_old_format.name);
+  is_optimizer_state_equal<AdamParamState>(optim1.state(), optim1_2.state());
 }
 
 TEST(SerializeTest, XOR_CUDA) {

--- a/torch/csrc/api/include/torch/optim/adam.h
+++ b/torch/csrc/api/include/torch/optim/adam.h
@@ -18,44 +18,55 @@ class InputArchive;
 namespace torch {
 namespace optim {
 
-struct TORCH_API AdamOptions {
-  /* implicit */ AdamOptions(double learning_rate);
-  TORCH_ARG(double, learning_rate);
+struct TORCH_API AdamOptions : public OptimizerCloneableOptions<AdamOptions> {
+  AdamOptions(double learning_rate);
+  TORCH_ARG(double, lr) = 1e-3;
   TORCH_ARG(double, beta1) = 0.9;
   TORCH_ARG(double, beta2) = 0.999;
-  TORCH_ARG(double, weight_decay) = 0;
   TORCH_ARG(double, eps) = 1e-8;
+  TORCH_ARG(double, weight_decay) = 0;
   TORCH_ARG(bool, amsgrad) = false;
+public:
+  void serialize(torch::serialize::InputArchive& archive) override;
+  void serialize(torch::serialize::OutputArchive& archive) const override;
+  TORCH_API friend bool operator==(const AdamOptions& lhs, const AdamOptions& rhs);
+  ~AdamOptions() = default;
+};
+
+struct TORCH_API AdamParamState : public OptimizerCloneableParamState<AdamParamState> {
+  TORCH_ARG(int64_t, step);
+  TORCH_ARG(torch::Tensor, exp_avg);
+  TORCH_ARG(torch::Tensor, exp_avg_sq);
+  TORCH_ARG(torch::Tensor, max_exp_avg_sq);
+
+public:
+  void serialize(torch::serialize::InputArchive& archive) override;
+  void serialize(torch::serialize::OutputArchive& archive) const override;
+  TORCH_API friend bool operator==(const AdamParamState& lhs, const AdamParamState& rhs);
+  ~AdamParamState() = default;
 };
 
 class TORCH_API Adam : public Optimizer {
  public:
-  template <typename ParameterContainer>
-  explicit Adam(ParameterContainer&& parameters, const AdamOptions& options_)
-      : Optimizer(std::forward<ParameterContainer>(parameters)),
-        options(options_) {}
+   explicit Adam(std::vector<OptimizerParamGroup> param_groups,
+       AdamOptions defaults) : Optimizer(std::move(param_groups), std::make_unique<AdamOptions>(defaults)) {}
+   explicit Adam(
+       std::vector<Tensor> params,
+       AdamOptions defaults) : Adam({std::move(OptimizerParamGroup(params))}, defaults) {}
 
   void step() override;
-
   void save(serialize::OutputArchive& archive) const override;
   void load(serialize::InputArchive& archive) override;
 
-  AdamOptions options;
-
-  std::vector<int64_t> step_buffers;
-  std::vector<Tensor> exp_average_buffers;
-  std::vector<Tensor> exp_average_sq_buffers;
-  std::vector<Tensor> max_exp_average_sq_buffers;
+  void add_parameters(const std::vector<Tensor>& parameters) override;
+  const std::vector<Tensor>& parameters() const noexcept override;
+  std::vector<Tensor>& parameters() noexcept override;
+  size_t size() const noexcept override;
 
  private:
-  Adam() : options(0) {}
-
   template <typename Self, typename Archive>
   static void serialize(Self& self, Archive& archive) {
-    _TORCH_OPTIM_SERIALIZE(step_buffers);
-    _TORCH_OPTIM_SERIALIZE(exp_average_buffers);
-    _TORCH_OPTIM_SERIALIZE(exp_average_sq_buffers);
-    _TORCH_OPTIM_SERIALIZE(max_exp_average_sq_buffers);
+    //_TORCH_OPTIM_SERIALIZE_WITH_TEMPLATE_ARG(Adam);
   }
 };
 } // namespace optim

--- a/torch/csrc/api/include/torch/optim/adam.h
+++ b/torch/csrc/api/include/torch/optim/adam.h
@@ -19,7 +19,7 @@ namespace torch {
 namespace optim {
 
 struct TORCH_API AdamOptions : public OptimizerCloneableOptions<AdamOptions> {
-  AdamOptions(double learning_rate);
+  AdamOptions(double learning_rate = 1e-3);
   TORCH_ARG(double, lr) = 1e-3;
   TORCH_ARG(double, beta1) = 0.9;
   TORCH_ARG(double, beta2) = 0.999;
@@ -66,7 +66,7 @@ class TORCH_API Adam : public Optimizer {
  private:
   template <typename Self, typename Archive>
   static void serialize(Self& self, Archive& archive) {
-    //_TORCH_OPTIM_SERIALIZE_WITH_TEMPLATE_ARG(Adam);
+    _TORCH_OPTIM_SERIALIZE_WITH_TEMPLATE_ARG(Adam);
   }
 };
 } // namespace optim

--- a/torch/csrc/api/include/torch/optim/optimizer.h
+++ b/torch/csrc/api/include/torch/optim/optimizer.h
@@ -114,19 +114,24 @@ class TORCH_API OptimizerBase {
   /// Adds the given vector of parameters to the optimizer's parameter list.
   virtual void add_parameters(const std::vector<Tensor>& parameters);
 
+  virtual void _add_parameters_new_design(const std::vector<Tensor>& parameters);
+
   /// Zeros out the gradients of all parameters.
   virtual void zero_grad();
 
   /// Provides a const reference to the parameters this optimizer holds.
   virtual const std::vector<Tensor>& parameters() const noexcept;
 
+  virtual const std::vector<Tensor>& _parameters_new_design() const noexcept;
+
   /// Provides a reference to the parameters this optimizer holds.
   virtual std::vector<Tensor>& parameters() noexcept;
+
+  virtual std::vector<Tensor>& _parameters_new_design() noexcept;
 
   /// Returns the number of parameters referenced by the optimizer.
   virtual size_t size() const noexcept;
 
-  /// Returns the number of parameters referenced by the optimizer.
   virtual size_t _size_new_design() const noexcept;
 
   OptimizerOptions& defaults() noexcept;

--- a/torch/csrc/api/include/torch/optim/serialize.h
+++ b/torch/csrc/api/include/torch/optim/serialize.h
@@ -214,18 +214,21 @@ void serialize(
   torch::optim::serialize<OptimizerName##ParamState, OptimizerName##Options>(archive, self)
 
 #define _TORCH_OPTIM_SERIALIZE_TORCH_ARG(name) \
-  archive.write(#name, IValue(name()))
+  archive.write(#name, IValue(name())); \
+
+// serialize only if the tensor is defined
+#define _TORCH_OPTIM_SERIALIZE_TORCH_ARG_IF_DEFINED(name) \
+{ \
+  if(name().defined()) \
+    _TORCH_OPTIM_SERIALIZE_TORCH_ARG(name); \
+} \
 
 #define _TORCH_OPTIM_DESERIALIZE_TORCH_ARG(T, name) \
 { \
   c10::IValue ivalue; \
   bool exists = archive.try_read(#name, ivalue); \
-  if(exists) { \
+  if (exists) \
     name(ivalue.to<T>()); \
-  } else { \
-    /*undefined tensor*/ \
-    name({}); \
-  } \
 }
 } // namespace optim
 } // namespace torch

--- a/torch/csrc/api/include/torch/optim/serialize.h
+++ b/torch/csrc/api/include/torch/optim/serialize.h
@@ -214,14 +214,13 @@ void serialize(
   torch::optim::serialize<OptimizerName##ParamState, OptimizerName##Options>(archive, self)
 
 #define _TORCH_OPTIM_SERIALIZE_TORCH_ARG(name) \
-  archive.write(#name, IValue(name())); \
-
-// serialize only if the tensor is defined
-#define _TORCH_OPTIM_SERIALIZE_TORCH_ARG_IF_DEFINED(name) \
 { \
-  if(name().defined()) \
-    _TORCH_OPTIM_SERIALIZE_TORCH_ARG(name); \
-} \
+  auto ivalue = torch::IValue(name()); \
+  /* do not serialize if name is an undefined tensor*/ \
+  if (!(ivalue.isTensor() && ivalue.unsafeToTensorImpl() == at::UndefinedTensorImpl::singleton())) { \
+    archive.write(#name, ivalue); \
+  } \
+}
 
 #define _TORCH_OPTIM_DESERIALIZE_TORCH_ARG(T, name) \
 { \

--- a/torch/csrc/api/include/torch/optim/serialize.h
+++ b/torch/csrc/api/include/torch/optim/serialize.h
@@ -219,8 +219,13 @@ void serialize(
 #define _TORCH_OPTIM_DESERIALIZE_TORCH_ARG(T, name) \
 { \
   c10::IValue ivalue; \
-  archive.read(#name, ivalue); \
-  name(ivalue.to<T>()); \
+  bool exists = archive.try_read(#name, ivalue); \
+  if(exists) { \
+    name(ivalue.to<T>()); \
+  } else { \
+    /*undefined tensor*/ \
+    name({}); \
+  } \
 }
 } // namespace optim
 } // namespace torch

--- a/torch/csrc/api/src/optim/adagrad.cpp
+++ b/torch/csrc/api/src/optim/adagrad.cpp
@@ -103,15 +103,15 @@ void Adagrad::step() {
 }
 
 void Adagrad::add_parameters(const std::vector<Tensor>& parameters) {
-  param_groups_.emplace_back(OptimizerParamGroup(parameters, defaults_->clone()));
+  return _add_parameters_new_design(parameters);
 }
 
 const std::vector<Tensor>& Adagrad::parameters() const noexcept {
-  return param_groups_.at(0).params();
+  return _parameters_new_design();
 }
 
 std::vector<Tensor>& Adagrad::parameters() noexcept {
-  return param_groups_.at(0).params();
+  return _parameters_new_design();
 }
 
 size_t Adagrad::size() const noexcept {

--- a/torch/csrc/api/src/optim/adam.cpp
+++ b/torch/csrc/api/src/optim/adam.cpp
@@ -12,57 +12,137 @@
 
 namespace torch {
 namespace optim {
-AdamOptions::AdamOptions(double learning_rate)
-    : learning_rate_(learning_rate) {}
+AdamOptions::AdamOptions(double lr) : lr_(lr) {}
+
+bool operator==(const AdamOptions& lhs, const AdamOptions& rhs) {
+  return (lhs.lr() == rhs.lr()) &&
+         (lhs.beta1() == rhs.beta1()) &&
+         (lhs.beta2() == rhs.beta2()) &&
+         (lhs.eps() == rhs.eps()) &&
+         (lhs.weight_decay() == rhs.weight_decay() &&
+         (lhs.amsgrad() == rhs.amsgrad()));
+}
+
+void AdamOptions::serialize(torch::serialize::OutputArchive& archive) const {
+  _TORCH_OPTIM_SERIALIZE_TORCH_ARG(lr);
+  _TORCH_OPTIM_SERIALIZE_TORCH_ARG(beta1);
+  _TORCH_OPTIM_SERIALIZE_TORCH_ARG(beta2);
+  _TORCH_OPTIM_SERIALIZE_TORCH_ARG(eps);
+  _TORCH_OPTIM_SERIALIZE_TORCH_ARG(weight_decay);
+  _TORCH_OPTIM_SERIALIZE_TORCH_ARG(amsgrad);
+}
+
+void AdamOptions::serialize(torch::serialize::InputArchive& archive) {
+  _TORCH_OPTIM_DESERIALIZE_TORCH_ARG(double, lr);
+  _TORCH_OPTIM_DESERIALIZE_TORCH_ARG(double, beta1);
+  _TORCH_OPTIM_DESERIALIZE_TORCH_ARG(double, beta2);
+  _TORCH_OPTIM_DESERIALIZE_TORCH_ARG(double, eps);
+  _TORCH_OPTIM_DESERIALIZE_TORCH_ARG(double, weight_decay);
+  _TORCH_OPTIM_DESERIALIZE_TORCH_ARG(bool, amsgrad);
+}
+
+bool operator==(const AdamParamState& lhs, const AdamParamState& rhs) {
+  return (lhs.step() == rhs.step()) &&
+          torch::equal(lhs.exp_avg(), rhs.exp_avg()) &&
+          torch::equal(lhs.exp_avg_sq(), rhs.exp_avg_sq()) &&
+          torch::equal(lhs.max_exp_avg_sq(), rhs.max_exp_avg_sq());
+}
+
+void AdamParamState::serialize(torch::serialize::OutputArchive& archive) const {
+  _TORCH_OPTIM_SERIALIZE_TORCH_ARG(step);
+  _TORCH_OPTIM_SERIALIZE_TORCH_ARG(exp_avg);
+  _TORCH_OPTIM_SERIALIZE_TORCH_ARG(exp_avg_sq);
+  _TORCH_OPTIM_SERIALIZE_TORCH_ARG(max_exp_avg_sq);
+}
+
+void AdamParamState::serialize(torch::serialize::InputArchive& archive) {
+  _TORCH_OPTIM_DESERIALIZE_TORCH_ARG(int64_t, step);
+  _TORCH_OPTIM_DESERIALIZE_TORCH_ARG(Tensor, exp_avg);
+  _TORCH_OPTIM_DESERIALIZE_TORCH_ARG(Tensor, exp_avg_sq);
+  _TORCH_OPTIM_DESERIALIZE_TORCH_ARG(Tensor, max_exp_avg_sq);
+}
 
 void Adam::step() {
-  for (size_t i = 0; i < parameters_.size(); ++i) {
-    Tensor p = parameters_.at(i);
-    if (!p.grad().defined()) {
-      continue;
+  for (auto& group : param_groups_) {
+    for (auto& p : group.params()) {
+      if (!p.grad().defined()) {
+        continue;
+      }
+      auto grad = p.grad().data();
+      TORCH_CHECK(!grad.is_sparse(), "Adam does not support sparse gradients"/*, please consider SparseAdam instead*/);
+      auto param_state = state_.find(c10::guts::to_string(p.unsafeGetTensorImpl()));
+      auto& options = static_cast<AdamOptions&>(group.options());
+      // State initialization
+      if(param_state == state_.end()) {
+        auto state = std::make_unique<AdamParamState>();
+        state->step(0);
+        state->exp_avg(torch::zeros_like(p.data(), MemoryFormat::Preserve));
+        state->exp_avg_sq(torch::zeros_like(p.data(), MemoryFormat::Preserve));
+        if(options.amsgrad()) {
+          state->max_exp_avg_sq(torch::zeros_like(p.data(), MemoryFormat::Preserve));
+        }
+        state_[c10::guts::to_string(p.unsafeGetTensorImpl())] = std::move(state);
+      }
+      auto state = static_cast<AdamParamState&>(*state_[c10::guts::to_string(p.unsafeGetTensorImpl())]);
+      // Exponential moving average of gradient values
+      auto exp_avg = state.exp_avg();
+      // Exponential moving average of squared gradient values
+      auto exp_avg_sq = state.exp_avg_sq();
+      Tensor max_exp_avg_sq;
+      if(options.amsgrad()) {
+        // Maintains max of all exp. moving avg. of sq. grad. values
+        max_exp_avg_sq = state.max_exp_avg_sq();
+      }
+      state.step(state.step()+1);
+      auto bias_correction1 = 1 - std::pow(options.beta1(), state.step());
+      auto bias_correction2 = 1 - std::pow(options.beta2(), state.step());
+
+      if(options.weight_decay() != 0) {
+        grad = grad.add(p.data(), options.weight_decay());
+      }
+
+      // Decay the first and second moment running average coefficient
+      exp_avg.mul_(options.beta1()).add_(grad, 1 - options.beta1());
+      exp_avg_sq.mul_(options.beta2()).addcmul_(grad, grad, 1 - options.beta2());
+
+      Tensor denom;
+      if(options.amsgrad()) {
+        // Maintains the maximum of all 2nd moment running avg. till now
+        at::max_out(max_exp_avg_sq, exp_avg_sq, max_exp_avg_sq);
+        // Use the max. for normalizing running avg. of gradient
+        denom = (max_exp_avg_sq.sqrt() / sqrt(bias_correction2)).add_(options.eps());
+      } else {
+        denom = (exp_avg_sq.sqrt() / sqrt(bias_correction2)).add_(options.eps());
+      }
+
+      auto step_size = options.lr() / bias_correction1;
+      p.data().addcdiv_(exp_avg, denom, -step_size);
     }
-
-    if (options.weight_decay() > 0) {
-      NoGradGuard guard;
-      p.grad() = p.grad() + options.weight_decay() * p;
-    }
-
-    auto& exp_average = buffer_at(exp_average_buffers, i);
-    auto& exp_average_sq = buffer_at(exp_average_sq_buffers, i);
-
-    buffer_at(step_buffers, i) += 1;
-    const auto bias_correction1 =
-        1 - std::pow(options.beta1(), buffer_at(step_buffers, i));
-    const auto bias_correction2 =
-        1 - std::pow(options.beta2(), buffer_at(step_buffers, i));
-
-    exp_average.mul_(options.beta1()).add_(p.grad(), 1 - options.beta1());
-    exp_average_sq.mul_(options.beta2())
-        .addcmul_(p.grad(), p.grad(), 1 - options.beta2());
-
-    Tensor denom;
-    if (options.amsgrad()) {
-      auto& max_exp_average_sq = buffer_at(max_exp_average_sq_buffers, i);
-      max_exp_average_sq = torch::max(max_exp_average_sq, exp_average_sq);
-      denom = max_exp_average_sq / bias_correction2;
-    } else {
-      denom = exp_average_sq / bias_correction2;
-    }
-
-    const auto step_size =
-        options.learning_rate() / bias_correction1;
-
-    NoGradGuard guard;
-    p.addcdiv_(exp_average, denom.sqrt() + options.eps(), -step_size);
   }
 }
 
+void Adam::add_parameters(const std::vector<Tensor>& parameters) {
+  param_groups_.emplace_back(OptimizerParamGroup(parameters, defaults_->clone()));
+}
+
+const std::vector<Tensor>& Adam::parameters() const noexcept {
+  return param_groups_.at(0).params();
+}
+
+std::vector<Tensor>& Adam::parameters() noexcept {
+  return param_groups_.at(0).params();
+}
+
+size_t Adam::size() const noexcept {
+  return _size_new_design();
+}
+
 void Adam::save(serialize::OutputArchive& archive) const {
-  serialize(*this, archive);
+  // serialize(*this, archive);
 }
 
 void Adam::load(serialize::InputArchive& archive) {
-  serialize(*this, archive);
+  // serialize(*this, archive);
 }
 } // namespace optim
 } // namespace torch

--- a/torch/csrc/api/src/optim/adam.cpp
+++ b/torch/csrc/api/src/optim/adam.cpp
@@ -91,6 +91,7 @@ void Adam::step() {
       auto& max_exp_avg_sq = state.max_exp_avg_sq();
 
       state.step(state.step()+1);
+      std::cout<<"step_val: "<<state.step();
       auto beta1 = std::get<0>(options.betas());
       auto beta2 = std::get<1>(options.betas());
 
@@ -116,7 +117,11 @@ void Adam::step() {
       }
 
       auto step_size = options.lr() / bias_correction1;
+      std::cout<<"before --- p.data(): "<<p.data();
+      std::cout<<"\nexp_avg: "<<exp_avg<<"\ndenom: "<<denom<<"\n-step_size: "<<step_size;
       p.data().addcdiv_(exp_avg, denom, -step_size);
+      std::cout<<"\nafter ---- p.data(): "<<p.data();
+      std::cout<<"\np.grad.data(): "<<p.grad().data();
     }
   }
 }

--- a/torch/csrc/api/src/optim/adam.cpp
+++ b/torch/csrc/api/src/optim/adam.cpp
@@ -16,8 +16,8 @@ AdamOptions::AdamOptions(double lr) : lr_(lr) {}
 
 bool operator==(const AdamOptions& lhs, const AdamOptions& rhs) {
   return (lhs.lr() == rhs.lr()) &&
-         (lhs.beta1() == rhs.beta1()) &&
-         (lhs.beta2() == rhs.beta2()) &&
+         (std::get<0>(lhs.betas()) == std::get<0>(rhs.betas())) &&
+         (std::get<1>(lhs.betas()) == std::get<1>(rhs.betas())) &&
          (lhs.eps() == rhs.eps()) &&
          (lhs.weight_decay() == rhs.weight_decay() &&
          (lhs.amsgrad() == rhs.amsgrad()));
@@ -25,8 +25,7 @@ bool operator==(const AdamOptions& lhs, const AdamOptions& rhs) {
 
 void AdamOptions::serialize(torch::serialize::OutputArchive& archive) const {
   _TORCH_OPTIM_SERIALIZE_TORCH_ARG(lr);
-  _TORCH_OPTIM_SERIALIZE_TORCH_ARG(beta1);
-  _TORCH_OPTIM_SERIALIZE_TORCH_ARG(beta2);
+  _TORCH_OPTIM_SERIALIZE_TORCH_ARG(betas);
   _TORCH_OPTIM_SERIALIZE_TORCH_ARG(eps);
   _TORCH_OPTIM_SERIALIZE_TORCH_ARG(weight_decay);
   _TORCH_OPTIM_SERIALIZE_TORCH_ARG(amsgrad);
@@ -34,8 +33,7 @@ void AdamOptions::serialize(torch::serialize::OutputArchive& archive) const {
 
 void AdamOptions::serialize(torch::serialize::InputArchive& archive) {
   _TORCH_OPTIM_DESERIALIZE_TORCH_ARG(double, lr);
-  _TORCH_OPTIM_DESERIALIZE_TORCH_ARG(double, beta1);
-  _TORCH_OPTIM_DESERIALIZE_TORCH_ARG(double, beta2);
+  _TORCH_OPTIM_DESERIALIZE_TORCH_ARG(betas_t, betas);
   _TORCH_OPTIM_DESERIALIZE_TORCH_ARG(double, eps);
   _TORCH_OPTIM_DESERIALIZE_TORCH_ARG(double, weight_decay);
   _TORCH_OPTIM_DESERIALIZE_TORCH_ARG(bool, amsgrad);
@@ -52,9 +50,7 @@ void AdamParamState::serialize(torch::serialize::OutputArchive& archive) const {
   _TORCH_OPTIM_SERIALIZE_TORCH_ARG(step);
   _TORCH_OPTIM_SERIALIZE_TORCH_ARG(exp_avg);
   _TORCH_OPTIM_SERIALIZE_TORCH_ARG(exp_avg_sq);
-  if(max_exp_avg_sq().defined()) {
-    _TORCH_OPTIM_SERIALIZE_TORCH_ARG(max_exp_avg_sq);
-  }
+  _TORCH_OPTIM_SERIALIZE_TORCH_ARG_IF_DEFINED(max_exp_avg_sq);
 }
 
 void AdamParamState::serialize(torch::serialize::InputArchive& archive) {
@@ -78,41 +74,41 @@ void Adam::step() {
       if(param_state == state_.end()) {
         auto state = std::make_unique<AdamParamState>();
         state->step(0);
+        // Exponential moving average of gradient values
         state->exp_avg(torch::zeros_like(p.data(), MemoryFormat::Preserve));
+        // Exponential moving average of squared gradient values
         state->exp_avg_sq(torch::zeros_like(p.data(), MemoryFormat::Preserve));
         if(options.amsgrad()) {
+          // Maintains max of all exp. moving avg. of sq. grad. values
           state->max_exp_avg_sq(torch::zeros_like(p.data(), MemoryFormat::Preserve));
-        } else {
-          state->max_exp_avg_sq({});
         }
         state_[c10::guts::to_string(p.unsafeGetTensorImpl())] = std::move(state);
       }
-      auto state = static_cast<AdamParamState&>(*state_[c10::guts::to_string(p.unsafeGetTensorImpl())]);
-      // Exponential moving average of gradient values
-      auto exp_avg = state.exp_avg();
-      // Exponential moving average of squared gradient values
-      auto exp_avg_sq = state.exp_avg_sq();
-      Tensor max_exp_avg_sq;
-      if(options.amsgrad()) {
-        // Maintains max of all exp. moving avg. of sq. grad. values
-        max_exp_avg_sq = state.max_exp_avg_sq();
-      }
+
+      auto& state = static_cast<AdamParamState&>(*state_[c10::guts::to_string(p.unsafeGetTensorImpl())]);
+      auto& exp_avg = state.exp_avg();
+      auto& exp_avg_sq = state.exp_avg_sq();
+      auto& max_exp_avg_sq = state.max_exp_avg_sq();
+
       state.step(state.step()+1);
-      auto bias_correction1 = 1 - std::pow(options.beta1(), state.step());
-      auto bias_correction2 = 1 - std::pow(options.beta2(), state.step());
+      auto beta1 = std::get<0>(options.betas());
+      auto beta2 = std::get<1>(options.betas());
+
+      auto bias_correction1 = 1 - std::pow(beta1, state.step());
+      auto bias_correction2 = 1 - std::pow(beta2, state.step());
 
       if(options.weight_decay() != 0) {
         grad = grad.add(p.data(), options.weight_decay());
       }
 
       // Decay the first and second moment running average coefficient
-      exp_avg.mul_(options.beta1()).add_(grad, 1 - options.beta1());
-      exp_avg_sq.mul_(options.beta2()).addcmul_(grad, grad, 1 - options.beta2());
+      exp_avg.mul_(beta1).add_(grad, 1 - beta1);
+      exp_avg_sq.mul_(beta2).addcmul_(grad, grad, 1 - beta2);
 
       Tensor denom;
       if(options.amsgrad()) {
         // Maintains the maximum of all 2nd moment running avg. till now
-        at::max_out(max_exp_avg_sq, exp_avg_sq, max_exp_avg_sq);
+        torch::max_out(max_exp_avg_sq, exp_avg_sq, max_exp_avg_sq);
         // Use the max. for normalizing running avg. of gradient
         denom = (max_exp_avg_sq.sqrt() / sqrt(bias_correction2)).add_(options.eps());
       } else {
@@ -126,15 +122,15 @@ void Adam::step() {
 }
 
 void Adam::add_parameters(const std::vector<Tensor>& parameters) {
-  param_groups_.emplace_back(OptimizerParamGroup(parameters, defaults_->clone()));
+  return _add_parameters_new_design(parameters);
 }
 
 const std::vector<Tensor>& Adam::parameters() const noexcept {
-  return param_groups_.at(0).params();
+  return _parameters_new_design();
 }
 
 std::vector<Tensor>& Adam::parameters() noexcept {
-  return param_groups_.at(0).params();
+  return _parameters_new_design();
 }
 
 size_t Adam::size() const noexcept {
@@ -166,15 +162,15 @@ void Adam::load(serialize::InputArchive& archive) {
     std::vector<Tensor> params = param_groups_.at(0).params();
     for (size_t idx = 0; idx < step_buffers.size(); idx++) {
       auto state = std::make_unique<AdamParamState>();
-      state->step(step_buffers[idx]);
-      state->exp_avg(exp_average_buffers[idx]);
-      state->exp_avg_sq(exp_average_sq_buffers[idx]);
+      state->step(step_buffers.at(idx));
+      state->exp_avg(exp_average_buffers.at(idx));
+      state->exp_avg_sq(exp_average_sq_buffers.at(idx));
       if(idx < max_exp_average_sq_buffers.size()) {
-        state->max_exp_avg_sq(max_exp_average_sq_buffers[idx]);
+        state->max_exp_avg_sq(max_exp_average_sq_buffers.at(idx));
       } else {
         state->max_exp_avg_sq({});
       }
-      state_[c10::guts::to_string(params[idx].unsafeGetTensorImpl())] = std::move(state);
+      state_[c10::guts::to_string(params.at(idx).unsafeGetTensorImpl())] = std::move(state);
     }
   }
 }

--- a/torch/csrc/api/src/optim/adam.cpp
+++ b/torch/csrc/api/src/optim/adam.cpp
@@ -40,21 +40,18 @@ void AdamOptions::serialize(torch::serialize::InputArchive& archive) {
 }
 
 bool operator==(const AdamParamState& lhs, const AdamParamState& rhs) {
-  bool is_max_exp_avg_sq_defined_and_equal = !(lhs.max_exp_avg_sq().defined() ^ rhs.max_exp_avg_sq().defined());
-  if(!is_max_exp_avg_sq_defined_and_equal) {
-    is_max_exp_avg_sq_defined_and_equal = torch::equal(lhs.max_exp_avg_sq(), rhs.max_exp_avg_sq());
-  }
   return (lhs.step() == rhs.step()) &&
           torch::equal(lhs.exp_avg(), rhs.exp_avg()) &&
           torch::equal(lhs.exp_avg_sq(), rhs.exp_avg_sq()) &&
-          is_max_exp_avg_sq_defined_and_equal;
+          ((!lhs.max_exp_avg_sq().defined() && !rhs.max_exp_avg_sq().defined()) ||
+           (lhs.max_exp_avg_sq().defined() && rhs.max_exp_avg_sq().defined() && torch::equal(lhs.max_exp_avg_sq(), rhs.max_exp_avg_sq())));
 }
 
 void AdamParamState::serialize(torch::serialize::OutputArchive& archive) const {
   _TORCH_OPTIM_SERIALIZE_TORCH_ARG(step);
   _TORCH_OPTIM_SERIALIZE_TORCH_ARG(exp_avg);
   _TORCH_OPTIM_SERIALIZE_TORCH_ARG(exp_avg_sq);
-  _TORCH_OPTIM_SERIALIZE_TORCH_ARG_IF_DEFINED(max_exp_avg_sq);
+  _TORCH_OPTIM_SERIALIZE_TORCH_ARG(max_exp_avg_sq);
 }
 
 void AdamParamState::serialize(torch::serialize::InputArchive& archive) {

--- a/torch/csrc/api/src/optim/optimizer.cpp
+++ b/torch/csrc/api/src/optim/optimizer.cpp
@@ -100,6 +100,10 @@ void OptimizerBase::add_parameters(const std::vector<Tensor>& parameters) {
   parameters_.insert(parameters_.end(), parameters.begin(), parameters.end());
 }
 
+void OptimizerBase::_add_parameters_new_design(const std::vector<Tensor>& parameters) {
+  param_groups_.emplace_back(OptimizerParamGroup(parameters, defaults_->clone()));
+}
+
 void OptimizerBase::zero_grad() {
   for (auto& parameter : parameters_) {
     if (parameter.grad().defined()) {
@@ -122,9 +126,17 @@ const std::vector<Tensor>& OptimizerBase::parameters() const noexcept {
   return parameters_;
 }
 
+const std::vector<Tensor>& OptimizerBase::_parameters_new_design() const noexcept {
+   return param_groups_.at(0).params();
+}
+
 // TODO: remove this function after all the optimizers use the new design
 std::vector<Tensor>& OptimizerBase::parameters() noexcept {
   return parameters_;
+}
+
+std::vector<Tensor>& OptimizerBase::_parameters_new_design() noexcept {
+   return param_groups_.at(0).params();
 }
 
 // TODO: update size to return the sum of #params in all param_groups

--- a/torch/csrc/api/src/optim/sgd.cpp
+++ b/torch/csrc/api/src/optim/sgd.cpp
@@ -92,15 +92,15 @@ void SGD::step() {
 }
 
 void SGD::add_parameters(const std::vector<Tensor>& parameters) {
-  param_groups_.emplace_back(OptimizerParamGroup(parameters, defaults_->clone()));
+  return _add_parameters_new_design(parameters);
 }
 
 const std::vector<Tensor>& SGD::parameters() const noexcept {
-  return param_groups_.at(0).params();
+  return _parameters_new_design();
 }
 
 std::vector<Tensor>& SGD::parameters() noexcept {
-  return param_groups_.at(0).params();
+  return _parameters_new_design();
 }
 
 size_t SGD::size() const noexcept {


### PR DESCRIPTION
**This PR is BC-breaking in the following way:**

In AdamOptions:
1. learning_rate is renamed to lr.
2. beta1 and beta2 are replaced by a tuple betas

**Test plan before 1.5 release:**

Test that in 1.5 we can load a C++ Adam optimizer that was serialized in 1.4, and their states are the same.

Test script:

optim_save_1_4.cpp
https://gist.github.com/yf225/b1c036c9b9c990ef20737a662bc927d7
optim_load_1_5.h
https://gist.github.com/yf225/84a47a40846b0eff6b87999986690fe0
optim_load_1_5.cpp
https://gist.github.com/yf225/44edfc6f4fe1a92be9232d402ece3714