### PR TITLE
remove setStorage with null StorageImpl support.

### DIFF
--- a/aten/src/TH/THTensor.cpp
+++ b/aten/src/TH/THTensor.cpp
@@ -48,14 +48,13 @@ void THTensor_setStorageNd(THTensor *self, THStorage *storage, ptrdiff_t storage
     if (!THTensor_getStoragePtr(self)) {
       THError("Tensor: invalid null storage");
     }
-    auto data_type = THTensor_getStoragePtr(self)->dtype();
     if(storage)
     {
       c10::raw::intrusive_ptr::incref(storage);
       THTensor_stealAndSetStoragePtr(self, storage);
     }
     else {
-      THTensor_stealAndSetStoragePtr(self, THStorage_new(data_type));
+      THError("Tensor: invalid null new storage");
     }
   }
 

--- a/aten/src/TH/THTensor.cpp
+++ b/aten/src/TH/THTensor.cpp
@@ -54,7 +54,7 @@ void THTensor_setStorageNd(THTensor *self, THStorage *storage, ptrdiff_t storage
       THTensor_stealAndSetStoragePtr(self, storage);
     }
     else {
-      THError("Tensor: invalid null new storage");
+      THError("Tensor: invalid new null storage");
     }
   }
 

--- a/aten/src/TH/generic/THTensor.cpp
+++ b/aten/src/TH/generic/THTensor.cpp
@@ -74,11 +74,12 @@ THTensor *THTensor_(newWithStorage)(THStorage *storage, ptrdiff_t storageOffset,
   if (strides.data()) {
     TORCH_CHECK(sizes.size() == strides.size(), "number of sizes and strides must match");
   }
+  THStorage *new_storage = THStorage_(new)();
   THTensor *self = c10::make_intrusive<at::TensorImpl, at::UndefinedTensorImpl>(
-    c10::intrusive_ptr<at::StorageImpl>::reclaim(THStorage_(new)()),
+    c10::intrusive_ptr<at::StorageImpl>::reclaim(new_storage),
     at::DispatchKey::CPUTensorId
   ).release();
-  THTensor_(setStorageNd)(self, storage, storageOffset, sizes.size(),
+  THTensor_(setStorageNd)(self, storage != nullptr ? storage : new_storage, storageOffset, sizes.size(),
                           const_cast<int64_t*>(sizes.data()), const_cast<int64_t*>(strides.data()));
 
   return self;

--- a/aten/src/THC/THCTensor.cpp
+++ b/aten/src/THC/THCTensor.cpp
@@ -153,12 +153,11 @@ void THCTensor_setStorageNd(THCState *state, THCTensor *self, THCStorage *storag
     if (!THTensor_getStoragePtr(self)) {
       THError("Tensor: invalid null storage");
     }
-    auto data_type = THTensor_getStoragePtr(self)->dtype();
     if (storage) {
       c10::raw::intrusive_ptr::incref(storage);
       THTensor_stealAndSetStoragePtr(self, storage);
     } else {
-      THTensor_stealAndSetStoragePtr(self, THCStorage_new(state, data_type));
+      THError("Tensor: invalid null new storage");
     }
   }
 

--- a/aten/src/THC/THCTensor.cpp
+++ b/aten/src/THC/THCTensor.cpp
@@ -157,7 +157,7 @@ void THCTensor_setStorageNd(THCState *state, THCTensor *self, THCStorage *storag
       c10::raw::intrusive_ptr::incref(storage);
       THTensor_stealAndSetStoragePtr(self, storage);
     } else {
-      THError("Tensor: invalid null new storage");
+      THError("Tensor: invalid new null storage");
     }
   }
 

--- a/aten/src/THC/generic/THCTensor.cpp
+++ b/aten/src/THC/generic/THCTensor.cpp
@@ -81,11 +81,12 @@ THCTensor *THCTensor_(newWithStorage)(THCState *state, THCStorage *storage, ptrd
   if (strides.data()) {
     TORCH_CHECK(sizes.size() == strides.size(), "number of sizes and strides must match");
   }
+  THCStorage *new_storage = THCStorage_(new)(state);
   THCTensor *self = c10::make_intrusive<at::TensorImpl, at::UndefinedTensorImpl>(
-    c10::intrusive_ptr<at::StorageImpl>::reclaim(THCStorage_(new)(state)),
+    c10::intrusive_ptr<at::StorageImpl>::reclaim(new_storage),
     at::DispatchKey::CUDATensorId
   ).release();
-  THCTensor_(setStorageNd)(state, self, storage, storageOffset, sizes.size(),
+  THCTensor_(setStorageNd)(state, self, storage != nullptr ? storage : new_storage, storageOffset, sizes.size(),
                            const_cast<int64_t*>(sizes.data()), const_cast<int64_t*>(strides.data()));
 
   return self;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #33823 Get rid of newWithStorage2d calls.
* #33815 Kill some unused (TH)Storage-based APIs.
* **#33735 remove setStorage with null StorageImpl support.**
* #33734 Remove some dead THStorage related code.
* #33695 Kill dead scalar_check.

This apparently used to create a new storage, but I couldn't find anywhere in the code where this actually happens.

Changing it to an assert to see what happens.

Differential Revision: [D20084029](https://our.internmc.facebook.com/intern/diff/D20084029)