### PR TITLE
Use shim executable sccache-cl as the compiler instead of sccache cl

### DIFF
--- a/.jenkins/pytorch/win-test-helpers/build_pytorch.bat
+++ b/.jenkins/pytorch/win-test-helpers/build_pytorch.bat
@@ -85,8 +85,8 @@ if "%TORCH_CUDA_ARCH_LIST%" == "" set TORCH_CUDA_ARCH_LIST=5.2
 sccache --stop-server
 sccache --start-server
 sccache --zero-stats
-set CC=sccache cl
-set CXX=sccache cl
+set CC=sccache-cl
+set CXX=sccache-cl
 
 set CMAKE_GENERATOR=Ninja
 

--- a/.jenkins/pytorch/win-test-helpers/installation-helpers/install_sccache.bat
+++ b/.jenkins/pytorch/win-test-helpers/installation-helpers/install_sccache.bat
@@ -4,11 +4,14 @@ if "%REBUILD%"=="" (
   :check_sccache
   %TMP_DIR_WIN%\bin\sccache.exe --show-stats || (
     taskkill /im sccache.exe /f /t || ver > nul
-    del %TMP_DIR_WIN%\bin\sccache.exe
+    del %TMP_DIR_WIN%\bin\sccache.exe || ver > nul
+    del %TMP_DIR_WIN%\bin\sccache-cl.exe || ver > nul
     if "%BUILD_ENVIRONMENT%"=="" (
       curl --retry 3 -k https://s3.amazonaws.com/ossci-windows/sccache.exe --output %TMP_DIR_WIN%\bin\sccache.exe
+      curl --retry 3 -k https://s3.amazonaws.com/ossci-windows/sccache-cl.exe --output %TMP_DIR_WIN%\bin\sccache-cl.exe
     ) else (
       aws s3 cp s3://ossci-windows/sccache.exe %TMP_DIR_WIN%\bin\sccache.exe
+      aws s3 cp s3://ossci-windows/sccache-cl.exe %TMP_DIR_WIN%\bin\sccache-cl.exe
     )
     goto :check_sccache
   )


### PR DESCRIPTION
CMake only views the first item of `CC` and `CXX` as executable. So calling `sccache.exe` directly won't work. Using a shim executable resolves this problem.