### PR TITLE
add bfloat16 conversion method in type stub (__init__.pyi)

### DIFF
--- a/tools/pyi/gen_pyi.py
+++ b/tools/pyi/gen_pyi.py
@@ -544,7 +544,8 @@ def gen_pyi(declarations_path, out):
                 ' other: Union[Tensor, Number]{})'
                 ' -> Tensor: ...'.format(name, out_suffix))
     simple_conversions = ['byte', 'char', 'cpu', 'double', 'float',
-                          'half', 'int', 'long', 'short', 'bool']
+                          'half', 'int', 'long', 'short', 'bool',
+                          'bfloat16']
     for name in simple_conversions:
         unsorted_tensor_method_hints[name].append('def {}(self) -> Tensor: ...'.format(name))
 


### PR DESCRIPTION
Resolve #33699 

`torch/__init__.pyi` will be generated like

```python
# TODO: One downside of doing it this way, is direct use of
# torch.tensor.Tensor doesn't get type annotations.  Nobody
# should really do that, so maybe this is not so bad.
class Tensor:
    requires_grad: _bool = ...
    grad: Optional[Tensor] = ...

    # some methods here...

    @overload
    def bernoulli_(self, p: _float=0.5, *, generator: Generator=None) -> Tensor: ...
    def bfloat16(self) -> Tensor: ...
    def bincount(self, weights: Optional[Tensor]=None, minlength: _int=0) -> Tensor: ...

    # some methods here...
```