### PR TITLE
fix bugs in gen_pyi.py

### DIFF
--- a/tools/pyi/gen_pyi.py
+++ b/tools/pyi/gen_pyi.py
@@ -534,15 +534,15 @@ def gen_pyi(declarations_path, out):
         for inplace in [True, False]:
             out_suffix = ', *, out: Optional[Tensor]=None'
             if inplace:
-                name += '_'
+                binop += '_'
                 out_suffix = ''
-            unsorted_tensor_method_hints[name].append(
+            unsorted_tensor_method_hints[binop].append(
                 'def {}(self, other: Union[Tensor, Number]{})'
-                ' -> Tensor: ...'.format(name, out_suffix))
-            unsorted_tensor_method_hints[name].append(
+                ' -> Tensor: ...'.format(binop, out_suffix))
+            unsorted_tensor_method_hints[binop].append(
                 'def {}(self, value: Number,'
                 ' other: Union[Tensor, Number]{})'
-                ' -> Tensor: ...'.format(name, out_suffix))
+                ' -> Tensor: ...'.format(binop, out_suffix))
     simple_conversions = ['byte', 'char', 'cpu', 'double', 'float',
                           'half', 'int', 'long', 'short', 'bool']
     for name in simple_conversions:


### PR DESCRIPTION
This loop should generate type hints for inplace binary operator methods (`binop` variable) but had been using `name` variable. That's why that wrong type hints had been generated.

Resolve #33698 

---

Current `__init__.pyi` has these type hints.

```python
class Tensor:

    # some codes here...

    @overload
    def zeros_like_(self, other: Union[Tensor, Number]) -> Tensor: ...
    @overload
    def zeros_like_(self, value: Number, other: Union[Tensor, Number]) -> Tensor: ...
    @overload
    def zeros_like_(self, other: Union[Tensor, Number], *, out: Optional[Tensor]=None) -> Tensor: ...
    @overload
    def zeros_like_(self, value: Number, other: Union[Tensor, Number], *, out: Optional[Tensor]=None) -> Tensor: ...
    @overload
    def zeros_like__(self, other: Union[Tensor, Number]) -> Tensor: ...
    @overload
    def zeros_like__(self, value: Number, other: Union[Tensor, Number]) -> Tensor: ...
    @overload
    def zeros_like__(self, other: Union[Tensor, Number], *, out: Optional[Tensor]=None) -> Tensor: ...
    @overload
    def zeros_like__(self, value: Number, other: Union[Tensor, Number], *, out: Optional[Tensor]=None) -> Tensor: ...
    @overload
    def zeros_like___(self, other: Union[Tensor, Number]) -> Tensor: ...
    @overload
    def zeros_like___(self, value: Number, other: Union[Tensor, Number]) -> Tensor: ...
    @overload
    def zeros_like___(self, other: Union[Tensor, Number], *, out: Optional[Tensor]=None) -> Tensor: ...
    @overload
    def zeros_like___(self, value: Number, other: Union[Tensor, Number], *, out: Optional[Tensor]=None) -> Tensor: ...
    @overload
    def zeros_like____(self, other: Union[Tensor, Number]) -> Tensor: ...
    @overload
    def zeros_like____(self, value: Number, other: Union[Tensor, Number]) -> Tensor: ...
    @overload
    def zeros_like____(self, other: Union[Tensor, Number], *, out: Optional[Tensor]=None) -> Tensor: ...
    @overload
    def zeros_like____(self, value: Number, other: Union[Tensor, Number], *, out: Optional[Tensor]=None) -> Tensor: ...

    # some codes here...
```

But `__init__.pyi` should generate these type hints.

```python
class Tensor:

    # some codes here...

    @overload
    def add_(self, other: Union[Tensor, Number]) -> Tensor: ...
    @overload
    def add_(self, value: Number, other: Union[Tensor, Number]) -> Tensor: ...
    @overload
    def add_(self, other: Union[Tensor, Number], *, out: Optional[Tensor]=None) -> Tensor: ...
    @overload
    def add_(self, value: Number, other: Union[Tensor, Number], *, out: Optional[Tensor]=None) -> Tensor: ...

    # some codes here...

    @overload
    def div_(self, other: Union[Tensor, Number]) -> Tensor: ...
    @overload
    def div_(self, value: Number, other: Union[Tensor, Number]) -> Tensor: ...
    @overload
    def div_(self, other: Union[Tensor, Number], *, out: Optional[Tensor]=None) -> Tensor: ...
    @overload
    def div_(self, value: Number, other: Union[Tensor, Number], *, out: Optional[Tensor]=None) -> Tensor: ...

    # some codes here...

    @overload
    def mul_(self, other: Union[Tensor, Number]) -> Tensor: ...
    @overload
    def mul_(self, value: Number, other: Union[Tensor, Number]) -> Tensor: ...
    @overload
    def mul_(self, other: Union[Tensor, Number], *, out: Optional[Tensor]=None) -> Tensor: ...
    @overload
    def mul_(self, value: Number, other: Union[Tensor, Number], *, out: Optional[Tensor]=None) -> Tensor: ...

    # some codes here...

    @overload
    def sub_(self, other: Union[Tensor, Number]) -> Tensor: ...
    @overload
    def sub_(self, value: Number, other: Union[Tensor, Number]) -> Tensor: ...
    @overload
    def sub_(self, other: Union[Tensor, Number], *, out: Optional[Tensor]=None) -> Tensor: ...
    @overload
    def sub_(self, value: Number, other: Union[Tensor, Number], *, out: Optional[Tensor]=None) -> Tensor: ...

    # some codes here...
```