### PR TITLE
Disable printing of the histogram when dump

### DIFF
--- a/caffe2/quantization/server/activation_distribution_observer.h
+++ b/caffe2/quantization/server/activation_distribution_observer.h
@@ -142,7 +142,7 @@ class HistogramNetObserver final : public NetObserver {
       string delimiter = " ");
   ~HistogramNetObserver();
   void DumpHistogramFile() {
-    DumpAndReset_(out_file_name_, true);
+    DumpAndReset_(out_file_name_, false);
   }
 
  private:


### PR DESCRIPTION
Summary: Disable printing of the histogram when dump to make the log cleaner.

Test Plan: CI

Differential Revision: D20087735

