### PR TITLE
Add layout.html to template for stable docs

### DIFF
--- a/docs/source/_templates-stable/layout.html
+++ b/docs/source/_templates-stable/layout.html
@@ -1,0 +1,33 @@
+{% extends "!layout.html" %}
+
+{% block menu %}
+
+{{ super() }}
+{% endblock %}
+
+{% block footer %}
+{{ super() }}
+<script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+  ga('create', 'UA-90545585-1', 'auto');
+  ga('send', 'pageview');
+
+</script>
+
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-117752657-2"></script>
+
+<script>
+  window.dataLayer = window.dataLayer || [];
+
+  function gtag(){dataLayer.push(arguments);}
+
+  gtag('js', new Date());
+  gtag('config', 'UA-117752657-2');
+</script>
+
+<img height="1" width="1" style="border-style:none;" alt="" src="https://www.googleadservices.com/pagead/conversion/795629140/?label=txkmCPmdtosBENSssfsC&amp;guid=ON&amp;script=0"/>
+{% endblock %}

--- a/docs/source/_templates-stable/layout.html
+++ b/docs/source/_templates-stable/layout.html
@@ -1,4 +1,5 @@
 {% extends "!layout.html" %}
+<link rel="canonical" href="{{ theme_canonical_url }}{{ pagename }}.html" />
 
 {% block menu %}
 


### PR DESCRIPTION
When docs are built, conf.py points to a _templates-stable/layout.html that does not exist. 
Adding this file here so future stable docs will build with Google Analytics tags and without the unstable able that is in _templates/layout.html