### PR TITLE
Per channel quantization performance improvement

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
+++ b/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
@@ -1117,7 +1117,7 @@ void fake_quantize_grad_tensor_kernel(
   });
 }
 
-void fake_quant_by_channel_cpu(TensorIterator &iter, int64_t quant_min, int64_t quant_max) {
+void fake_quant_per_channel_cpu(TensorIterator &iter, int64_t quant_min, int64_t quant_max) {
   cpu_kernel(iter,
     [=](float self, float scale, int64_t zero_point) -> float {
       float inv_scale = 1.0f / scale;
@@ -1132,7 +1132,7 @@ void fake_quant_by_channel_cpu(TensorIterator &iter, int64_t quant_min, int64_t 
     });
 }
 
-void fake_quant_grad_by_channel_cpu(TensorIterator &iter, int64_t quant_min, int64_t quant_max) {
+void fake_quant_grad_per_channel_cpu(TensorIterator &iter, int64_t quant_min, int64_t quant_max) {
   cpu_kernel(iter,
     [=](float x, float dy, float scale, int64_t zero_point) -> float {
       float inv_scale = 1.0f / scale;
@@ -1165,8 +1165,8 @@ REGISTER_DISPATCH(qtopk_stub, &qtopk_kernel);
 REGISTER_DISPATCH(qbatch_norm_stub, &q_batch_norm_kernel<false>);
 REGISTER_DISPATCH(fake_quant_tensor_stub, &fake_quantize_tensor_kernel);
 REGISTER_DISPATCH(fake_quant_grad_tensor_stub, &fake_quantize_grad_tensor_kernel);
-REGISTER_DISPATCH(fake_quant_by_channel_stub, &fake_quant_by_channel_cpu);
-REGISTER_DISPATCH(fake_quant_grad_by_channel_stub, &fake_quant_grad_by_channel_cpu);
+REGISTER_DISPATCH(fake_quant_per_channel_stub, &fake_quant_per_channel_cpu);
+REGISTER_DISPATCH(fake_quant_grad_per_channel_stub, &fake_quant_grad_per_channel_cpu);
 
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
+++ b/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
@@ -1117,7 +1117,7 @@ void fake_quantize_grad_tensor_kernel(
   });
 }
 
-void fake_quant_by_channel_cuda(TensorIterator &iter, int64_t quant_min, int64_t quant_max) {
+void fake_quant_by_channel_cpu(TensorIterator &iter, int64_t quant_min, int64_t quant_max) {
   cpu_kernel(iter,
     [=](float self, float scale, int64_t zero_point) -> float {
       float inv_scale = 1.0f / scale;
@@ -1132,7 +1132,7 @@ void fake_quant_by_channel_cuda(TensorIterator &iter, int64_t quant_min, int64_t
     });
 }
 
-void fake_quant_grad_by_channel_cuda(TensorIterator &iter, int64_t quant_min, int64_t quant_max) {
+void fake_quant_grad_by_channel_cpu(TensorIterator &iter, int64_t quant_min, int64_t quant_max) {
   cpu_kernel(iter,
     [=](float x, float dy, float scale, int64_t zero_point) -> float {
       float inv_scale = 1.0f / scale;

--- a/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
+++ b/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
@@ -1080,7 +1080,7 @@ void q_batch_norm_kernel(
 
 }
 
-void fake_quantize_slice_kernel(
+void fake_quantize_tensor_kernel(
     Tensor& output,
     const Tensor& input,
     float sc,
@@ -1101,7 +1101,7 @@ void fake_quantize_slice_kernel(
   });
 }
 
-void fake_quantize_grad_slice_kernel(
+void fake_quantize_grad_tensor_kernel(
     Tensor& input_grad,
     const Tensor& input,
     const Tensor& output_grad,
@@ -1115,6 +1115,30 @@ void fake_quantize_grad_slice_kernel(
     int64_t xq = static_cast<int64_t>(std::nearbyint(x * inv_scale + z_point));
     return dy * (xq >= quant_min && xq <= quant_max);
   });
+}
+
+void fake_quant_by_channel_cuda(TensorIterator &iter, int64_t quant_min, int64_t quant_max) {
+  cpu_kernel(iter,
+    [=](float self, float scale, int64_t zero_point) -> float {
+      float inv_scale = 1.0f / scale;
+      return (std::fmin(
+                std::fmax(
+                    static_cast<int64_t>(
+                        std::nearbyint(self * inv_scale + zero_point)),
+                    quant_min),
+                quant_max) -
+            zero_point) *
+        scale;
+    });
+}
+
+void fake_quant_grad_by_channel_cuda(TensorIterator &iter, int64_t quant_min, int64_t quant_max) {
+  cpu_kernel(iter,
+    [=](float x, float dy, float scale, int64_t zero_point) -> float {
+      float inv_scale = 1.0f / scale;
+      int64_t xq = static_cast<int64_t>(std::nearbyint(x * inv_scale + zero_point));
+      return dy * (xq >= quant_min && xq <= quant_max);
+    });
 }
 
 } // namespace
@@ -1139,8 +1163,10 @@ REGISTER_DISPATCH(qcat_nhwc_stub, &qcat_nhwc_kernel<false>);
 REGISTER_DISPATCH(qcat_relu_nhwc_stub, &qcat_nhwc_kernel<true>);
 REGISTER_DISPATCH(qtopk_stub, &qtopk_kernel);
 REGISTER_DISPATCH(qbatch_norm_stub, &q_batch_norm_kernel<false>);
-REGISTER_DISPATCH(fake_quant_slice_stub, &fake_quantize_slice_kernel);
-REGISTER_DISPATCH(fake_quant_grad_slice_stub, &fake_quantize_grad_slice_kernel);
+REGISTER_DISPATCH(fake_quant_tensor_stub, &fake_quantize_tensor_kernel);
+REGISTER_DISPATCH(fake_quant_grad_tensor_stub, &fake_quantize_grad_tensor_kernel);
+REGISTER_DISPATCH(fake_quant_by_channel_stub, &fake_quant_by_channel_cpu);
+REGISTER_DISPATCH(fake_quant_grad_by_channel_stub, &fake_quant_grad_by_channel_cpu);
 
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/native/quantized/cuda/fake_quantize_core.cu
+++ b/aten/src/ATen/native/quantized/cuda/fake_quantize_core.cu
@@ -2,6 +2,8 @@
 #include <ATen/NativeFunctions.h>
 #include <ATen/cuda/CUDAApplyUtils.cuh>
 #include <ATen/native/quantized/fake_quant_affine.h>
+#include <ATen/native/TensorIterator.h>
+#include <ATen/native/cuda/Loops.cuh>
 #include <cmath>
 
 /* Fake quantize a tensor

--- a/aten/src/ATen/native/quantized/cuda/fake_quantize_core.cu
+++ b/aten/src/ATen/native/quantized/cuda/fake_quantize_core.cu
@@ -72,7 +72,7 @@ void fake_quantize_grad_tensor_kernel_cuda(
 REGISTER_DISPATCH(fake_quant_tensor_stub, &fake_quantize_tensor_kernel_cuda);
 REGISTER_DISPATCH(fake_quant_grad_tensor_stub, &fake_quantize_grad_tensor_kernel_cuda);
 
-// Fake quantize by channel
+// Fake quantize per channel
 
 void fake_quant_per_channel_cuda(TensorIterator &iter, int64_t quant_min, int64_t quant_max) {
   gpu_kernel(iter,

--- a/aten/src/ATen/native/quantized/cuda/fake_quantize_core.cu
+++ b/aten/src/ATen/native/quantized/cuda/fake_quantize_core.cu
@@ -74,7 +74,7 @@ REGISTER_DISPATCH(fake_quant_grad_tensor_stub, &fake_quantize_grad_tensor_kernel
 
 // Fake quantize by channel
 
-void fake_quant_by_channel_cuda(TensorIterator &iter, int64_t quant_min, int64_t quant_max) {
+void fake_quant_per_channel_cuda(TensorIterator &iter, int64_t quant_min, int64_t quant_max) {
   gpu_kernel(iter,
     [=] GPU_LAMBDA (float input_val, float scale, int64_t zero_point) -> float {
       float inv_scale = 1.0f / scale;
@@ -89,7 +89,7 @@ void fake_quant_by_channel_cuda(TensorIterator &iter, int64_t quant_min, int64_t
     });
 }
 
-void fake_quant_grad_by_channel_cuda(TensorIterator &iter, int64_t quant_min, int64_t quant_max) {
+void fake_quant_grad_per_channel_cuda(TensorIterator &iter, int64_t quant_min, int64_t quant_max) {
   gpu_kernel(iter,
     [=] GPU_LAMBDA (float x, float dy, float scale, int64_t zero_point) -> float {
       float inv_scale = 1.0f / scale;
@@ -98,8 +98,8 @@ void fake_quant_grad_by_channel_cuda(TensorIterator &iter, int64_t quant_min, in
     });
 }
 
-REGISTER_DISPATCH(fake_quant_by_channel_stub, &fake_quant_by_channel_cuda);
-REGISTER_DISPATCH(fake_quant_grad_by_channel_stub, &fake_quant_grad_by_channel_cuda);
+REGISTER_DISPATCH(fake_quant_per_channel_stub, &fake_quant_per_channel_cuda);
+REGISTER_DISPATCH(fake_quant_grad_per_channel_stub, &fake_quant_grad_per_channel_cuda);
 
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/native/quantized/cuda/fake_quantize_core.cu
+++ b/aten/src/ATen/native/quantized/cuda/fake_quantize_core.cu
@@ -4,7 +4,7 @@
 #include <ATen/native/quantized/fake_quant_affine.h>
 #include <cmath>
 
-/* Fake quantize a tensor, common block for per-channel & per-tensor fake quant
+/* Fake quantize a tensor
 Args:
   output: output tensor.
   input : input tensor.
@@ -17,7 +17,7 @@ Returns:
 */
 namespace at {
 namespace native {
-void fake_quantize_slice_kernel_cuda(
+void fake_quantize_tensor_kernel_cuda(
     Tensor& output,
     const Tensor& input,
     float scale,
@@ -38,7 +38,7 @@ void fake_quantize_slice_kernel_cuda(
       });
 }
 
-void fake_quantize_grad_slice_kernel_cuda(
+void fake_quantize_grad_tensor_kernel_cuda(
     Tensor& input_grad,
     const Tensor& input,
     const Tensor& output_grad,
@@ -57,8 +57,37 @@ void fake_quantize_grad_slice_kernel_cuda(
       });
 }
 
-REGISTER_DISPATCH(fake_quant_slice_stub, &fake_quantize_slice_kernel_cuda);
-REGISTER_DISPATCH(fake_quant_grad_slice_stub, &fake_quantize_grad_slice_kernel_cuda);
+REGISTER_DISPATCH(fake_quant_tensor_stub, &fake_quantize_tensor_kernel_cuda);
+REGISTER_DISPATCH(fake_quant_grad_tensor_stub, &fake_quantize_grad_tensor_kernel_cuda);
+
+// Fake quantize by channel
+
+void fake_quant_by_channel_cuda(TensorIterator &iter, int64_t quant_min, int64_t quant_max) {
+  gpu_kernel(iter,
+    [=] GPU_LAMBDA (float input_val, float scale, int64_t zero_point) -> float {
+      float inv_scale = 1.0f / scale;
+      return (fminf(
+                quant_max,
+                fmaxf(
+                    quant_min,
+                    static_cast<int64_t>(std::nearbyint(
+                        input_val * inv_scale + zero_point)))) -
+            zero_point) *
+          scale;
+    });
+}
+
+void fake_quant_grad_by_channel_cuda(TensorIterator &iter, int64_t quant_min, int64_t quant_max) {
+  gpu_kernel(iter,
+    [=] GPU_LAMBDA (float x, float dy, float scale, int64_t zero_point) -> float {
+      float inv_scale = 1.0f / scale;
+      int64_t Xq = std::nearbyint(x * inv_scale + zero_point);
+      return (Xq >= quant_min && Xq <= quant_max) * dy;
+    });
+}
+
+REGISTER_DISPATCH(fake_quant_by_channel_stub, &fake_quant_by_channel_cuda);
+REGISTER_DISPATCH(fake_quant_grad_by_channel_stub, &fake_quant_grad_by_channel_cuda);
 
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/native/quantized/fake_quant_affine.h
+++ b/aten/src/ATen/native/quantized/fake_quant_affine.h
@@ -3,9 +3,9 @@
 #include <ATen/ATen.h>
 #include <ATen/native/DispatchStub.h>
 
-class TensorIterator;
-
 namespace at {
+
+class TensorIterator;
 
 namespace native {
 

--- a/aten/src/ATen/native/quantized/fake_quant_affine.h
+++ b/aten/src/ATen/native/quantized/fake_quant_affine.h
@@ -29,13 +29,13 @@ using fake_quant_grad_tensor_fn = void (*)(
 DECLARE_DISPATCH(fake_quant_tensor_fn, fake_quant_tensor_stub);
 DECLARE_DISPATCH(fake_quant_grad_tensor_fn, fake_quant_grad_tensor_stub);
 
-using fake_quant_by_channel_fn = void (*)(
+using fake_quant_per_channel_fn = void (*)(
     TensorIterator &iter,
     int64_t quant_min,
     int64_t quant_max);
 
-DECLARE_DISPATCH(fake_quant_by_channel_fn, fake_quant_by_channel_stub);
-DECLARE_DISPATCH(fake_quant_by_channel_fn, fake_quant_grad_by_channel_stub);
+DECLARE_DISPATCH(fake_quant_per_channel_fn, fake_quant_per_channel_stub);
+DECLARE_DISPATCH(fake_quant_per_channel_fn, fake_quant_grad_per_channel_stub);
 
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/native/quantized/fake_quant_affine.h
+++ b/aten/src/ATen/native/quantized/fake_quant_affine.h
@@ -34,13 +34,8 @@ using fake_quant_by_channel_fn = void (*)(
     int64_t quant_min,
     int64_t quant_max);
 
-using fake_quant_grad_by_channel_fn = void (*)(
-    TensorIterator &iter,
-    int64_t quant_min,
-    int64_t quant_max);
-
 DECLARE_DISPATCH(fake_quant_by_channel_fn, fake_quant_by_channel_stub);
-DECLARE_DISPATCH(fake_quant_grad_by_channel_fn, fake_quant_grad_by_channel_stub);
+DECLARE_DISPATCH(fake_quant_by_channel_fn, fake_quant_grad_by_channel_stub);
 
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/native/quantized/fake_quant_affine.h
+++ b/aten/src/ATen/native/quantized/fake_quant_affine.h
@@ -5,7 +5,7 @@
 
 namespace at {
 
-class TensorIterator;
+struct TensorIterator;
 
 namespace native {
 

--- a/aten/src/ATen/native/quantized/fake_quant_affine.h
+++ b/aten/src/ATen/native/quantized/fake_quant_affine.h
@@ -3,11 +3,13 @@
 #include <ATen/ATen.h>
 #include <ATen/native/DispatchStub.h>
 
+class TensorIterator;
+
 namespace at {
 
 namespace native {
 
-using fake_quant_slice_fn = void (*)(
+using fake_quant_tensor_fn = void (*)(
     Tensor& output,
     const Tensor& input,
     float sc,
@@ -15,7 +17,7 @@ using fake_quant_slice_fn = void (*)(
     int64_t quant_min,
     int64_t quant_max);
 
-using fake_quant_grad_slice_fn = void (*)(
+using fake_quant_grad_tensor_fn = void (*)(
     Tensor& input_grad,
     const Tensor& input,
     const Tensor& output_grad,
@@ -24,8 +26,21 @@ using fake_quant_grad_slice_fn = void (*)(
     int64_t quant_min,
     int64_t quant_max);
 
-DECLARE_DISPATCH(fake_quant_slice_fn, fake_quant_slice_stub);
-DECLARE_DISPATCH(fake_quant_grad_slice_fn, fake_quant_grad_slice_stub);
+DECLARE_DISPATCH(fake_quant_tensor_fn, fake_quant_tensor_stub);
+DECLARE_DISPATCH(fake_quant_grad_tensor_fn, fake_quant_grad_tensor_stub);
+
+using fake_quant_by_channel_fn = void (*)(
+    TensorIterator &iter,
+    int64_t quant_min,
+    int64_t quant_max);
+
+using fake_quant_grad_by_channel_fn = void (*)(
+    TensorIterator &iter,
+    int64_t quant_min,
+    int64_t quant_max);
+
+DECLARE_DISPATCH(fake_quant_by_channel_fn, fake_quant_by_channel_stub);
+DECLARE_DISPATCH(fake_quant_grad_by_channel_fn, fake_quant_grad_by_channel_stub);
 
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/native/quantized/fake_quant_per_channel_affine.cpp
+++ b/aten/src/ATen/native/quantized/fake_quant_per_channel_affine.cpp
@@ -55,20 +55,19 @@ Tensor fake_quantize_per_channel_affine(
       "`axis` must be between 0 and number of dimensions of input");
 
   auto Y = at::empty_like(self, self.options(), MemoryFormat::Preserve);
-  for (int i = 0; i < self.size(axis); i++) {
-    auto input_slice = self.slice(axis, i, i + 1);
-    auto output_slice = Y.slice(axis, i, i + 1);
-    float sc = scale[i].item().toFloat();
-    int64_t z_point = zero_point[i].item().toLong();
-    fake_quant_slice_stub(
-        self.device().type(),
-        output_slice,
-        input_slice,
-        sc,
-        z_point,
-        quant_min,
-        quant_max);
-  }
+
+  std::vector<int64_t> expected_shape(self.dim(), 1);
+  expected_shape[axis] = self.size(axis);
+
+  TensorIterator iter;
+  iter.dont_compute_common_dtype();
+  iter.add_output(Y);
+  iter.add_input(self);
+  iter.add_input(scale.reshape(expected_shape));
+  iter.add_input(zero_point.reshape(expected_shape));
+  iter.build();
+
+  fake_quant_by_channel_stub(iter.device_type(), iter, quant_min, quant_max);
 
   return Y;
 }
@@ -133,22 +132,19 @@ Tensor fake_quantize_per_channel_affine_backward(
 
   auto dX = at::empty_like(X, X.options(), MemoryFormat::Preserve);
 
-  for (int i = 0; i < X.size(axis); i++) {
-    auto X_slice = X.slice(axis, i, i + 1);
-    auto dY_slice = dY.slice(axis, i, i + 1);
-    auto dX_slice = dX.slice(axis, i, i + 1);
-    float sc = scale[i].item().toFloat();
-    int64_t z_point = zero_point[i].item().toLong();
-    fake_quant_grad_slice_stub(
-        X.device().type(),
-        dX_slice,
-        X_slice,
-        dY_slice,
-        sc,
-        z_point,
-        quant_min,
-        quant_max);
-  }
+  std::vector<int64_t> expected_shape(X.dim(), 1);
+  expected_shape[axis] = X.size(axis);
+
+  TensorIterator iter;
+  iter.dont_compute_common_dtype();
+  iter.add_output(dX);
+  iter.add_input(X);
+  iter.add_input(dY);
+  iter.add_input(scale.reshape(expected_shape));
+  iter.add_input(zero_point.reshape(expected_shape));
+  iter.build();
+
+  fake_quant_grad_by_channel_stub(iter.device_type(), iter, quant_min, quant_max);
 
   return dX;
 }

--- a/aten/src/ATen/native/quantized/fake_quant_per_channel_affine.cpp
+++ b/aten/src/ATen/native/quantized/fake_quant_per_channel_affine.cpp
@@ -67,8 +67,8 @@ Tensor fake_quantize_per_channel_affine(
   iter.dont_compute_common_dtype();
   iter.add_output(Y);
   iter.add_input(self);
-  iter.add_input(scale.reshape(expected_shape));
-  iter.add_input(zero_point.reshape(expected_shape));
+  iter.add_input(native::_unsafe_view(scale, expected_shape));
+  iter.add_input(native::_unsafe_view(zero_point, expected_shape));
   iter.build();
 
   fake_quant_per_channel_stub(iter.device_type(), iter, quant_min, quant_max);
@@ -144,8 +144,8 @@ Tensor fake_quantize_per_channel_affine_backward(
   iter.add_output(dX);
   iter.add_input(X);
   iter.add_input(dY);
-  iter.add_input(scale.reshape(expected_shape));
-  iter.add_input(zero_point.reshape(expected_shape));
+  iter.add_input(native::_unsafe_view(scale, expected_shape));
+  iter.add_input(native::_unsafe_view(zero_point, expected_shape));
   iter.build();
 
   fake_quant_grad_per_channel_stub(iter.device_type(), iter, quant_min, quant_max);

--- a/aten/src/ATen/native/quantized/fake_quant_per_channel_affine.cpp
+++ b/aten/src/ATen/native/quantized/fake_quant_per_channel_affine.cpp
@@ -9,6 +9,10 @@
 namespace at {
 namespace native {
 
+// Use REGISTER_DISPATCH to run CPU and CUDA backend.
+DEFINE_DISPATCH(fake_quant_per_channel_stub);
+DEFINE_DISPATCH(fake_quant_grad_per_channel_stub);
+
 /* Per channel fake-quantizes the 'inputs' tensor.
 Args:
   X: Forward input tensor.
@@ -67,7 +71,7 @@ Tensor fake_quantize_per_channel_affine(
   iter.add_input(zero_point.reshape(expected_shape));
   iter.build();
 
-  fake_quant_by_channel_stub(iter.device_type(), iter, quant_min, quant_max);
+  fake_quant_per_channel_stub(iter.device_type(), iter, quant_min, quant_max);
 
   return Y;
 }
@@ -144,7 +148,7 @@ Tensor fake_quantize_per_channel_affine_backward(
   iter.add_input(zero_point.reshape(expected_shape));
   iter.build();
 
-  fake_quant_grad_by_channel_stub(iter.device_type(), iter, quant_min, quant_max);
+  fake_quant_grad_per_channel_stub(iter.device_type(), iter, quant_min, quant_max);
 
   return dX;
 }

--- a/aten/src/ATen/native/quantized/fake_quant_per_tensor_affine.cpp
+++ b/aten/src/ATen/native/quantized/fake_quant_per_tensor_affine.cpp
@@ -10,8 +10,8 @@ namespace at {
 namespace native {
 
 // Use REGISTER_DISPATCH to run CPU and CUDA backend.
-DEFINE_DISPATCH(fake_quant_slice_stub);
-DEFINE_DISPATCH(fake_quant_grad_slice_stub);
+DEFINE_DISPATCH(fake_quant_tensor_stub);
+DEFINE_DISPATCH(fake_quant_grad_tensor_stub);
 
 /* Fake-quantizes the 'inputs' tensor.
 Args:
@@ -41,7 +41,7 @@ Tensor fake_quantize_per_tensor_affine(
       "`zero_point` must be between `quant_min` and `quant_max`.");
 
   auto Y = at::empty_like(self, self.options(), MemoryFormat::Preserve);
-  fake_quant_slice_stub(
+  fake_quant_tensor_stub(
       self.device().type(), Y, self, scale, zero_point, quant_min, quant_max);
   return Y;
 }
@@ -89,7 +89,7 @@ Tensor fake_quantize_per_tensor_affine_backward(
   }
 
   auto dX = at::empty_like(X, X.options(), MemoryFormat::Preserve);
-  fake_quant_grad_slice_stub(
+  fake_quant_grad_tensor_stub(
       X.device().type(), dX, X, dY, scale, zero_point, quant_min, quant_max);
   return dX;
 }

--- a/test/test_fake_quant.py
+++ b/test/test_fake_quant.py
@@ -14,15 +14,15 @@ import unittest
 
 # Reference method for fake quantize
 def _fake_quantize_per_tensor_affine_reference(X, scale, zero_point, quant_min, quant_max):
-    res = (torch.clamp(torch.round(X.cpu() * (1.0 / scale) + zero_point), quant_min, quant_max) - zero_point) * scale
+    res = (torch.clamp(torch.round(X * (1.0 / scale) + zero_point), quant_min, quant_max) - zero_point) * scale
     return res
 
 # Reference method for the gradient of the fake quantize operator
 def _fake_quantize_per_tensor_affine_grad_reference(dY, X, scale, zero_point, quant_min, quant_max):
-    Xq = torch.round(X.cpu() * (1.0 / scale) + zero_point)
+    Xq = torch.round(X * (1.0 / scale) + zero_point)
     mask = (Xq >= quant_min) * (Xq <= quant_max)
-    res = torch.zeros_like(dY.cpu())
-    res[mask] = dY.cpu()[mask]
+    res = torch.zeros_like(dY)
+    res[mask] = dY[mask]
     return res
 
 # Helper function used to simulate per-channel fake-quant against any axis

--- a/torch/quantization/fake_quantize.py
+++ b/torch/quantization/fake_quantize.py
@@ -78,7 +78,8 @@ class FakeQuantize(Module):
     def forward(self, X):
         if self.observer_enabled:
             self.activation_post_process(X.detach())
-            self.scale, self.zero_point = self.calculate_qparams()
+            _scale, _zero_point = self.calculate_qparams()
+            self.scale, self.zero_point = _scale.to(self.scale.device), _zero_point.to(self.zero_point.device)
         if self.fake_quant_enabled:
             if self.qscheme == torch.per_channel_symmetric or self.qscheme == torch.per_channel_affine:
                 X = torch.fake_quantize_per_channel_affine(X, self.scale, self.zero_point,


### PR DESCRIPTION
Benchmark:
NVIDIA GTX 1650 + AMD Ryzen Threadripper 3970X
```python
import torch
print(torch.__version__)

for i in range(1000):
    torch.randn(1024 * 128, device='cuda')

def cuda(e):
    a = torch.randn(2 ** e, 32, device='cuda')
    s = torch.randn(32, device='cuda')
    z = torch.randn(32, device='cuda')
    torch.cuda.synchronize()
    %timeit torch.fake_quantize_per_channel_affine(a, s, z, 1, -999, 999); torch.cuda.synchronize()
    
def cpu(e):
    a = torch.randn(2 ** e, 32, device='cpu')
    s = torch.randn(32, device='cpu')
    z = torch.randn(32, device='cpu')
    %timeit torch.fake_quantize_per_channel_affine(a, s, z, 1, -999, 999);
    
for i in range(10, 24):
    cuda(i)
print()
for i in range(10, 32):
    cpu(i)
```
Before
```
1.5.0a0+9bc922d
849 µs ± 44.8 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
817 µs ± 30.4 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
814 µs ± 2.93 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
1.11 ms ± 1.32 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
1.19 ms ± 4.19 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
1.6 ms ± 5.58 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
2.44 ms ± 14.1 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
4.14 ms ± 2.55 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
7.41 ms ± 2.46 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
13.9 ms ± 2.3 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
26.9 ms ± 254 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
52.6 ms ± 260 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
104 ms ± 176 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
207 ms ± 1.24 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

249 µs ± 158 ns per loop (mean ± std. dev. of 7 runs, 1000 loops each)
420 µs ± 230 ns per loop (mean ± std. dev. of 7 runs, 1000 loops each)
766 µs ± 391 ns per loop (mean ± std. dev. of 7 runs, 1000 loops each)
1.45 ms ± 574 ns per loop (mean ± std. dev. of 7 runs, 1000 loops each)
2.84 ms ± 34.6 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
5.69 ms ± 83 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
7.29 ms ± 2.58 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
7.32 ms ± 13.5 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
17.4 ms ± 38.6 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
47.5 ms ± 264 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
187 ms ± 1.19 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
379 ms ± 5.05 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
652 ms ± 11.4 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
1.22 s ± 4.58 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
2.34 s ± 8.77 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
4.56 s ± 7.15 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
8.97 s ± 33.6 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
17.8 s ± 32.3 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
35.2 s ± 167 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
After
```
1.5.0a0+a7ec8cc
92.5 µs ± 2.03 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
97.7 µs ± 469 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
109 µs ± 4.73 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
119 µs ± 6.17 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
146 µs ± 1.84 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
211 µs ± 2.45 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
347 µs ± 4.18 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
624 µs ± 14.9 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
1.17 ms ± 16.8 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
2.25 ms ± 48.3 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
4.43 ms ± 220 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
8.51 ms ± 44.3 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
16.9 ms ± 30.2 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
33.7 ms ± 7.64 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)

201 µs ± 234 ns per loop (mean ± std. dev. of 7 runs, 1000 loops each)
285 µs ± 465 ns per loop (mean ± std. dev. of 7 runs, 1000 loops each)
287 µs ± 214 ns per loop (mean ± std. dev. of 7 runs, 1000 loops each)
287 µs ± 221 ns per loop (mean ± std. dev. of 7 runs, 1000 loops each)
287 µs ± 761 ns per loop (mean ± std. dev. of 7 runs, 1000 loops each)
347 µs ± 399 ns per loop (mean ± std. dev. of 7 runs, 1000 loops each)
675 µs ± 213 ns per loop (mean ± std. dev. of 7 runs, 1000 loops each)
1.34 ms ± 643 ns per loop (mean ± std. dev. of 7 runs, 1000 loops each)
4.82 ms ± 34.7 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
10.7 ms ± 88.5 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
20.3 ms ± 25.6 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
39.4 ms ± 242 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
78.8 ms ± 2 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
153 ms ± 786 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
285 ms ± 911 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)
541 ms ± 1.09 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
1.03 s ± 1.67 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
1.97 s ± 8.59 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
3.81 s ± 10.2 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

Fixes #33647 