### PR TITLE
[caffe2] simplify caffe2 code with fbgemm handling block size 1 emb

### DIFF
--- a/caffe2/perfkernels/adagrad.cc
+++ b/caffe2/perfkernels/adagrad.cc
@@ -56,21 +56,6 @@ void adagrad_fp16_update_prefetch__base(
   internal::adagrad_update_base_inlined(N, w, g, h, nw, nh, 1.0f, epsilon, lr);
 }
 
-void rowwise_adagrad_update__base(
-    int N,
-    float* w,
-    float* w_n, // prefetch ptr
-
-    const float* g,
-
-    float* h,
-    float* h_n, // prefetch ptr
-
-    float epsilon,
-    float lr) {
-  internal::rowwise_adagrad_update_inlined(N, w, w_n, g, h, h_n, epsilon, lr);
-}
-
 // version without prefetching
 decltype(adagrad_update__base) adagrad_update__avx_f16c;
 void adagrad_update(
@@ -179,111 +164,6 @@ void adagrad_fp16_update_prefetch(
       nw_n,
       nh,
       nh_n,
-      epsilon,
-      lr);
-}
-
-decltype(rowwise_adagrad_update__base) rowwise_adagrad_update__avx_f16c;
-void rowwise_adagrad_update(
-    int N,
-    float* w,
-    float* w_n, // prefetch ptr
-
-    const float* g,
-
-    float* h,
-    float* h_n, // prefetch ptr
-
-    float epsilon,
-    float lr) {
-  AVX_F16C_DO(rowwise_adagrad_update, N, w, w_n, g, h, h_n, epsilon, lr);
-  BASE_DO(rowwise_adagrad_update, N, w, w_n, g, h, h_n, epsilon, lr);
-}
-
-SPARSE_ADAGRAD_SPECIALIZATION(int32_t, base);
-
-decltype(sparse_adagrad_int32_t__base) sparse_adagrad_int32_t__avx_f16c;
-template <>
-int sparse_adagrad(
-    int num_rows,
-    int block_size,
-    uint64_t param_size,
-    const float* w,
-    const float* g,
-    const float* h,
-    const int32_t* indices,
-    float* nw,
-    float* nh,
-    float epsilon,
-    float lr) {
-  AVX_F16C_DO(
-      sparse_adagrad_int32_t,
-      num_rows,
-      block_size,
-      param_size,
-      w,
-      g,
-      h,
-      indices,
-      nw,
-      nh,
-      epsilon,
-      lr);
-  BASE_DO(
-      sparse_adagrad_int32_t,
-      num_rows,
-      block_size,
-      param_size,
-      w,
-      g,
-      h,
-      indices,
-      nw,
-      nh,
-      epsilon,
-      lr);
-}
-
-SPARSE_ADAGRAD_SPECIALIZATION(int64_t, base);
-
-decltype(sparse_adagrad_int64_t__base) sparse_adagrad_int64_t__avx_f16c;
-template <>
-int sparse_adagrad(
-    int num_rows,
-    int block_size,
-    uint64_t param_size,
-    const float* w,
-    const float* g,
-    const float* h,
-    const int64_t* indices,
-    float* nw,
-    float* nh,
-    float epsilon,
-    float lr) {
-  AVX_F16C_DO(
-      sparse_adagrad_int64_t,
-      num_rows,
-      block_size,
-      param_size,
-      w,
-      g,
-      h,
-      indices,
-      nw,
-      nh,
-      epsilon,
-      lr);
-  BASE_DO(
-      sparse_adagrad_int64_t,
-      num_rows,
-      block_size,
-      param_size,
-      w,
-      g,
-      h,
-      indices,
-      nw,
-      nh,
       epsilon,
       lr);
 }

--- a/caffe2/perfkernels/adagrad.h
+++ b/caffe2/perfkernels/adagrad.h
@@ -111,73 +111,6 @@ inline void adagrad_update_prefetch_inlined(
       N - i, w + i, g + i, h + i, nw + i, nh + i, 1.0f, epsilon, lr);
 }
 
-inline void rowwise_adagrad_update_inlined(
-    int N,
-    float* w,
-#ifdef CAFFE2_PERFKERNELS_ADAGRAD_H_USE_INTRINSIC
-    float* w_n, // prefetch ptr
-#else
-    float* /* unused */,
-#endif
-
-    const float* g,
-
-    float* h,
-#ifdef CAFFE2_PERFKERNELS_ADAGRAD_H_USE_INTRINSIC
-    float* h_n, // prefetch ptr
-#else
-    float* /* unused */,
-#endif
-
-    float epsilon,
-    float lr) {
-  auto i = 0;
-
-#ifdef CAFFE2_PERFKERNELS_ADAGRAD_H_USE_INTRINSIC
-  constexpr int kSize = 8;
-  _mm_prefetch(reinterpret_cast<const char*>(h_n), _MM_HINT_T0);
-  __m256 partial_sum = _mm256_setzero_ps();
-  for (; i + kSize <= N; i += kSize) {
-    __m256 gi = _mm256_loadu_ps(g + i);
-    partial_sum = _mm256_add_ps(partial_sum, _mm256_mul_ps(gi, gi));
-  }
-  // Reduce sum to 1 value
-  __m256 partial_sum_2 = _mm256_hadd_ps(partial_sum, partial_sum);
-  __m256 partial_sum_3 = _mm256_hadd_ps(partial_sum_2, partial_sum_2);
-  float final_sum = _mm_cvtss_f32(_mm256_castps256_ps128(partial_sum_3)) +
-      _mm_cvtss_f32(_mm256_extractf128_ps(partial_sum_3, 1));
-#else
-  float final_sum = 0.0f;
-#endif
-
-  for (; i < N; ++i) {
-    final_sum += g[i] * g[i];
-  }
-  final_sum /= N;
-
-  float hi = *h = *h + final_sum;
-  float float_step = lr / (std::sqrt(hi) + epsilon);
-
-  i = 0;
-#ifdef CAFFE2_PERFKERNELS_ADAGRAD_H_USE_INTRINSIC
-  __m256 step = _mm256_set1_ps(float_step);
-
-  for (i = 0; i + kSize <= N; i += kSize) {
-    _mm_prefetch(reinterpret_cast<const char*>(&w_n[i]), _MM_HINT_T0);
-
-    __m256 gi = _mm256_loadu_ps(g + i);
-    __m256 wi = _mm256_loadu_ps(w + i);
-
-    _mm256_storeu_ps(w + i, _mm256_add_ps(wi, _mm256_mul_ps(gi, step)));
-  }
-#endif
-
-  for (; i < N; ++i) {
-    float gi = g[i];
-    w[i] = w[i] + gi * float_step;
-  }
-}
-
 } // namespace internal
 
 // version with prefetching
@@ -232,19 +165,6 @@ void adagrad_fp16_update_prefetch(
     float epsilon,
     float lr);
 
-void rowwise_adagrad_update(
-    int N,
-    float* w,
-    float* w_n, // prefetch ptr
-
-    const float* g,
-
-    float* h,
-    float* h_n, // prefetch ptr
-
-    float epsilon,
-    float lr);
-
 // version without prefetching
 void adagrad_update(
     int N,
@@ -256,73 +176,6 @@ void adagrad_update(
     float epsilon,
     float decay,
     float lr);
-
-/**
- * @return num_rows if succeeds otherwise return the row idx where we pass
- *         the boundary of param_size
- */
-template <typename SIndex>
-int sparse_adagrad(
-    int num_rows, // number of rows reading
-    int block_size, // number of parameters per rows
-    std::uint64_t param_size, // total number of parameters
-    const float* w, // input parameters
-    const float* g, // input gradients
-    const float* h, // input momentums
-    const SIndex* indices, // indices of each row
-    float* nw, // output parameters
-    float* nh, // output momentums
-    float epsilon,
-    float lr);
-
-#define SPARSE_ADAGRAD_SPECIALIZATION(SIndex, ISA)                       \
-  int sparse_adagrad_##SIndex##__##ISA(                                  \
-      int num_rows,                                                      \
-      int block_size,                                                    \
-      std::uint64_t param_size,                                          \
-      const float* w,                                                    \
-      const float* g,                                                    \
-      const float* h,                                                    \
-      const SIndex* indices,                                             \
-      float* nw,                                                         \
-      float* nh,                                                         \
-      float epsilon,                                                     \
-      float lr) {                                                        \
-    for (int i = 0; i < num_rows; ++i) {                                 \
-      std::uint64_t idx = indices[i];                                    \
-      auto offsetI = i * block_size;                                     \
-      auto offsetIdx = idx * block_size;                                 \
-                                                                         \
-      if (block_size + offsetIdx > param_size) {                         \
-        return i;                                                        \
-      }                                                                  \
-                                                                         \
-      if (block_size == 1) {                                             \
-        float gi = g[i];                                                 \
-        float hi = nh[idx] = h[idx] + gi * gi;                           \
-        nw[idx] = w[idx] + lr * gi / (std::sqrt(hi) + epsilon);          \
-      } else {                                                           \
-        const int prefdist_T0 = 16;                                      \
-        int i_pref = (i < num_rows - prefdist_T0) ? i + prefdist_T0 : i; \
-        std::uint64_t idx_pref = indices[i_pref];                        \
-                                                                         \
-        adagrad_update_prefetch__##ISA(                                  \
-            block_size,                                                  \
-            w + offsetIdx,                                               \
-            &w[idx_pref * block_size],                                   \
-            g + offsetI,                                                 \
-            h + offsetIdx,                                               \
-            &h[idx_pref * block_size],                                   \
-            nw + offsetIdx,                                              \
-            &nw[idx_pref * block_size],                                  \
-            nh + offsetIdx,                                              \
-            &nh[idx_pref * block_size],                                  \
-            epsilon,                                                     \
-            lr);                                                         \
-      }                                                                  \
-    }                                                                    \
-    return num_rows;                                                     \
-  };
 
 } // namespace caffe2
 

--- a/caffe2/perfkernels/adagrad_avx.cc
+++ b/caffe2/perfkernels/adagrad_avx.cc
@@ -114,22 +114,4 @@ void adagrad_fp16_update_prefetch__avx_f16c(
   }
 }
 
-void rowwise_adagrad_update__avx_f16c(
-    int N,
-    float* w,
-    float* w_n, // prefetch ptr
-
-    const float* g,
-
-    float* h,
-    float* h_n, // prefetch ptr
-
-    float epsilon,
-    float lr) {
-  internal::rowwise_adagrad_update_inlined(N, w, w_n, g, h, h_n, epsilon, lr);
-}
-
-SPARSE_ADAGRAD_SPECIALIZATION(int32_t, avx_f16c);
-SPARSE_ADAGRAD_SPECIALIZATION(int64_t, avx_f16c);
-
 } // namespace caffe2


### PR DESCRIPTION
Summary: Simplify caffe2 code using D19246900

Test Plan: CI

Differential Revision: D20102410

