### PR TITLE
Rename Tensor::index(TensorList indices) to advanced_index(TensorList indices)

### DIFF
--- a/aten/src/ATen/ATen.h
+++ b/aten/src/ATen/ATen.h
@@ -25,3 +25,4 @@
 #include <ATen/core/Reduction.h>
 #include <c10/util/Exception.h>
 #include <ATen/core/UnsafeFromTH.h>
+#include <ATen/native/TensorIndexing.h>

--- a/aten/src/ATen/native/Embedding.cpp
+++ b/aten/src/ATen/native/Embedding.cpp
@@ -16,7 +16,7 @@ Tensor embedding(const Tensor & weight, const Tensor & indices,
   auto indices_arg = TensorArg(indices, "indices", 1);
   checkScalarType("embedding", indices_arg, kLong);
 
-  // TODO: use tensor.index() after improving perf
+  // TODO: use tensor.advanced_index() after improving perf
   if (indices.dim() == 1) {
     return weight.index_select(0, indices);
   }
@@ -57,8 +57,8 @@ Tensor embedding_sparse_backward(
   Tensor grad = grad_;
   if (padding_idx != -1) {
     auto c = indices != padding_idx;
-    indices = indices.index(c);
-    grad = grad.index(c);
+    indices = indices.advanced_index(c);
+    grad = grad.advanced_index(c);
   }
 
   int64_t num_features = grad_.size(-1);

--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -31,7 +31,7 @@ static inline std::tuple<Tensor, Tensor> _lu_det_P_diag_U(const Tensor& self) {
 
   // We have to manually set the diagonal to 0 due to an issue with MAGMA's getrf_batched routine
   if (self.dim() > 2 && self.is_cuda()) {
-    u_diagonal.index_put_(infos.nonzero_numpy(), at::zeros({}, self.options()));
+    u_diagonal.advanced_index_put_(infos.nonzero_numpy(), at::zeros({}, self.options()));
   }
   return std::tuple<Tensor, Tensor>(num_exchanges.mul_(-2).add_(1), u_diagonal);
 }
@@ -63,7 +63,7 @@ Tensor logdet(const Tensor& self) {
   // U is singular when U(i, i) = 0 for some i in [1, self.size(-1)].
   Tensor logdet_vals = diag_U.abs_().log_().sum(-1);
   if (self.dim() > 2) {
-    logdet_vals.index_put_((det_sign < 0).nonzero_numpy(), at::full({}, NAN, self.options()));
+    logdet_vals.advanced_index_put_((det_sign < 0).nonzero_numpy(), at::full({}, NAN, self.options()));
   } else if (det_sign.item<double>() < 0) {
     logdet_vals.fill_(NAN);
   }

--- a/aten/src/ATen/native/TensorAdvancedIndexing.cpp
+++ b/aten/src/ATen/native/TensorAdvancedIndexing.cpp
@@ -236,7 +236,7 @@ static TensorIterator make_index_iterator(const AdvancedIndex& info) {
   return iter;
 }
 
-Tensor index(const Tensor & self, TensorList indices) {
+Tensor advanced_index(const Tensor & self, TensorList indices) {
   TORCH_CHECK_INDEX(indices.size() <= (size_t)self.dim(), "too many indices for tensor of dimension ", self.dim(), " (got ", indices.size(), ")");
 
   auto info = make_info(self, indices);
@@ -245,11 +245,11 @@ Tensor index(const Tensor & self, TensorList indices) {
   return iter.output();
 }
 
-Tensor index_put(const Tensor & self, TensorList indices, const Tensor & value, bool accumulate) {
-  return self.clone(at::MemoryFormat::Preserve).index_put_(indices, value, accumulate);
+Tensor advanced_index_put(const Tensor & self, TensorList indices, const Tensor & value, bool accumulate) {
+  return self.clone(at::MemoryFormat::Preserve).advanced_index_put_(indices, value, accumulate);
 }
 
-Tensor & _index_put_impl_(Tensor & self, TensorList indices, const Tensor & value, const bool accumulate, const bool unsafe) {
+Tensor & _advanced_index_put_impl_(Tensor & self, TensorList indices, const Tensor & value, const bool accumulate, const bool unsafe) {
     TORCH_CHECK_INDEX(indices.size() <= (size_t)self.dim(), "too many indices for tensor of dimension ", self.dim(), " (got ", indices.size(), ")");
   if (accumulate && self.device().type() == kCUDA) {
       TORCH_CHECK(value.device() == self.device(), "expected device ", self.device(), " but got device ",
@@ -264,8 +264,8 @@ Tensor & _index_put_impl_(Tensor & self, TensorList indices, const Tensor & valu
 }
 
 
-Tensor & index_put_(Tensor & self, TensorList indices, const Tensor & value, const bool accumulate) {
-  return at::_index_put_impl_(self, indices, value, accumulate, /*unsafe=*/false);
+Tensor & advanced_index_put_(Tensor & self, TensorList indices, const Tensor & value, const bool accumulate) {
+  return at::_advanced_index_put_impl_(self, indices, value, accumulate, /*unsafe=*/false);
 }
 
 Tensor & index_copy_(Tensor & self, int64_t dim, const Tensor & index, const Tensor & source) {

--- a/aten/src/ATen/native/TensorIndexing.h
+++ b/aten/src/ATen/native/TensorIndexing.h
@@ -461,11 +461,11 @@ static inline Tensor applySlicing(
 } // namespace impl
 
 static inline Tensor dispatch_index(const Tensor& self, std::vector<Tensor>&& indices) {
-  return self.index(impl::typeConvertIndices(self, std::move(indices)));
+  return self.advanced_index(impl::typeConvertIndices(self, std::move(indices)));
 }
 
 static inline Tensor dispatch_index_put_(Tensor& self, std::vector<Tensor>&& indices, const Tensor& value) {
-  return self.index_put_(impl::typeConvertIndices(self, std::move(indices)), value);
+  return self.advanced_index_put_(impl::typeConvertIndices(self, std::move(indices)), value);
 }
 
 // NOTE [ Setting `disable_slice_optimization` when calling C++ tensor indexing functions from Python ]

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1446,7 +1446,7 @@
 - func: _cufft_clear_plan_cache(int device_index) -> ()
   use_c10_dispatcher: unboxed_only
 
-- func: index.Tensor(Tensor self, Tensor?[] indices) -> Tensor
+- func: advanced_index.Tensor(Tensor self, Tensor?[] indices) -> Tensor
   variants: function, method
   # NB: This function is special-cased in tools/autograd/gen_variable_type.py
   # NB: The following functions are declared in aten/src/ATen/templates/TensorBody.h and defined in aten/src/ATen/native/TensorIndexing.cpp:
@@ -1466,7 +1466,7 @@
 - func: index_copy.dimname(Tensor self, Dimname dim, Tensor index, Tensor source) -> Tensor
   variants: function, method
 
-- func: index_put_(Tensor(a!) self, Tensor?[] indices, Tensor values, bool accumulate=False) -> Tensor(a!)
+- func: advanced_index_put_(Tensor(a!) self, Tensor?[] indices, Tensor values, bool accumulate=False) -> Tensor(a!)
   variants: function, method
   # NB: The following functions are declared in aten/src/ATen/templates/TensorBody.h and defined in aten/src/ATen/native/TensorIndexing.cpp:
   # - Tensor & Tensor::index_put_(ArrayRef<TensorIndex> indices, Tensor const & rhs)
@@ -1474,10 +1474,10 @@
   # - Tensor & Tensor::index_put_(std::initializer_list<TensorIndex> indices, Tensor const & rhs)
   # - Tensor & Tensor::index_put_(std::initializer_list<TensorIndex> indices, Scalar v)
 
-- func: index_put(Tensor self, Tensor?[] indices, Tensor values, bool accumulate=False) -> Tensor
+- func: advanced_index_put(Tensor self, Tensor?[] indices, Tensor values, bool accumulate=False) -> Tensor
   variants: function, method
 
-- func: _index_put_impl_(Tensor(a!) self, Tensor?[] indices, Tensor values, bool accumulate=False, bool unsafe=False) -> Tensor(a!)
+- func: _advanced_index_put_impl_(Tensor(a!) self, Tensor?[] indices, Tensor values, bool accumulate=False, bool unsafe=False) -> Tensor(a!)
   variants: function
 
 - func: instance_norm(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool use_input_stats, float momentum, float eps, bool cudnn_enabled) -> Tensor

--- a/aten/src/ATen/native/sparse/SparseTensor.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensor.cpp
@@ -323,7 +323,7 @@ SparseTensor dense_to_sparse(const Tensor& self, int64_t sparse_dim){
   Tensor values;
   if (self.dim() > 0) {
     std::vector<Tensor> ix = indices.chunk(indices.size(0), 0);
-    values = self.index(ix).squeeze(0).clone(at::MemoryFormat::Preserve);
+    values = self.advanced_index(ix).squeeze(0).clone(at::MemoryFormat::Preserve);
   } else {
     AT_ASSERT(nz.sizes().equals({0, 1}));
     // In this cases, indices is a clone of nz, which is a tensor of shape (0, 1).

--- a/test/cpp/api/tensor_indexing.cpp
+++ b/test/cpp/api/tensor_indexing.cpp
@@ -1,8 +1,5 @@
 #include <gtest/gtest.h>
 
-// TODO: Move the include into `ATen/ATen.h`, once C++ tensor indexing
-// is ready to ship.
-#include <ATen/native/TensorIndexing.h>
 #include <torch/torch.h>
 
 #include <test/cpp/api/support.h>

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -417,8 +417,8 @@
 - name: imag(Tensor self) -> Tensor
   self: Scalar(std::complex<double>{0.0, 1.0})*grad.to(self.scalar_type())
 
-- name: index.Tensor(Tensor self, Tensor?[] indices) -> Tensor
-  self: index_backward(zeros_like(self), indices, grad)
+- name: advanced_index.Tensor(Tensor self, Tensor?[] indices) -> Tensor
+  self: advanced_index_backward(zeros_like(self), indices, grad)
   indices: TensorList()
 
 - name: index_add_(Tensor(a!) self, int dim, Tensor index, Tensor source) -> Tensor(a!)
@@ -440,11 +440,11 @@
   value: grad.index_select(dim, index).sum()
   index: non_differentiable
 
-- name: index_put_(Tensor(a!) self, Tensor?[] indices, Tensor values, bool accumulate=False) -> Tensor(a!)
+- name: advanced_index_put_(Tensor(a!) self, Tensor?[] indices, Tensor values, bool accumulate=False) -> Tensor(a!)
   self: "accumulate ? grad : grad.clone().index_put_(indices, zeros_like(values), false)"
   values: grad.index(indices)
 
-- name: _index_put_impl_(Tensor(a!) self, Tensor?[] indices, Tensor values, bool accumulate=False, bool unsafe=False) -> Tensor(a!)
+- name: _advanced_index_put_impl_(Tensor(a!) self, Tensor?[] indices, Tensor values, bool accumulate=False, bool unsafe=False) -> Tensor(a!)
   self: "accumulate ? grad : grad.clone().index_put_(indices, zeros_like(values), false)"
   values: grad.index(indices)
 

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -2559,8 +2559,8 @@ Tensor embedding_dense_double_backward(const Tensor & grad, const Tensor & indic
   return gg_weight.view(size);
 }
 
-Tensor index_backward(Tensor zeros_like_self, TensorList indices, const Tensor& grad) {
-   return at::_index_put_impl_(zeros_like_self, indices, grad, true, true);
+Tensor advanced_index_backward(Tensor zeros_like_self, TensorList indices, const Tensor& grad) {
+   return at::_advanced_index_put_impl_(zeros_like_self, indices, grad, true, true);
 }
 
 Tensor _cudnn_ctc_loss_backward(const Tensor& grad_out, const Tensor& loss, const Tensor& raw_grad, bool zero_infinity) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #30427 C++ tensor indexing: more indexing tests
* **#33775 Rename Tensor::index(TensorList indices) to advanced_index(TensorList indices)**
* #30426 Add assert_tensor_equal and assert_tensor_not_equal to test/cpp/api/support.h

