### PR TITLE
[jit] stop printing crap in test_jit

### DIFF
--- a/test/jit/test_class_type.py
+++ b/test/jit/test_class_type.py
@@ -926,8 +926,8 @@ class TestClassType(JitTestCase):
 
             def forward(self, x):
                 # Make sure class constant is accessible in method
-                print(self.w)
-                return x
+                y = self.w
+                return x, y
 
         # Test serialization/deserialization of class constant
         for c in (2, 1.0, None, True, 'str', (2, 3), [5.9, 7.3]):

--- a/test/jit/test_export_modes.py
+++ b/test/jit/test_export_modes.py
@@ -13,7 +13,7 @@ from torch.autograd import Variable
 pytorch_test_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 sys.path.append(pytorch_test_dir)
 from torch.testing._internal.jit_utils import JitTestCase
-from torch.testing._internal.common_utils import skipIfNoLapack
+from torch.testing._internal.common_utils import skipIfNoLapack, suppress_warnings
 
 if __name__ == '__main__':
     raise RuntimeError("This test file is not meant to be run directly, use:\n\n"
@@ -79,6 +79,8 @@ class TestExportModes(JitTestCase):
         f = io.BytesIO()
         torch.onnx.export_to_pretty_string(
             ModelWithAtenNotONNXOp(), (x, y), f,
+            add_node_names=False,
+            do_constant_folding=False,
             operator_export_type=OperatorExportTypes.ONNX_ATEN_FALLBACK)
 
     # torch.fmod is using to test ONNX_ATEN.
@@ -94,4 +96,6 @@ class TestExportModes(JitTestCase):
         y = torch.randn(3, 4, dtype=torch.float32)
         torch.onnx.export_to_pretty_string(
             ModelWithAtenFmod(), (x, y), f,
+            add_node_names=False,
+            do_constant_folding=False,
             operator_export_type=OperatorExportTypes.ONNX_ATEN)

--- a/test/jit/test_models.py
+++ b/test/jit/test_models.py
@@ -396,6 +396,8 @@ class TestModels(JitTestCase):
         self._test_snli(self, device='cpu')
 
     if 'fbgemm' in torch.backends.quantized.supported_engines:
+        # Suppression: this exercises a deprecated API
+        @suppress_warnings
         def test_snli_quantized(self):
             self._test_snli(self, device='cpu', quantized=True)
 
@@ -540,6 +542,8 @@ class TestModels(JitTestCase):
         self._test_vae(self, device='cpu')
 
     if 'fbgemm' in torch.backends.quantized.supported_engines:
+        # Suppression: this exercises a deprecated API
+        @suppress_warnings
         def test_vae_quantized(self):
             self._test_vae(self, device='cpu', quantized=True)
 

--- a/test/jit/test_recursive_script.py
+++ b/test/jit/test_recursive_script.py
@@ -5,7 +5,6 @@ from typing import List, Dict, Optional, Tuple
 
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
 from torch import Tensor
 from torch.testing import FileCheck
 from collections import OrderedDict
@@ -65,7 +64,7 @@ class TestRecursiveScript(JitTestCase):
             def forward(self, x):
                 return self.fn(x)
 
-        mod = M(F.sigmoid)
+        mod = M(torch.sigmoid)
 
         self.checkModule(mod, (torch.randn(2, 2),))
 

--- a/test/jit/test_unsupported_ops.py
+++ b/test/jit/test_unsupported_ops.py
@@ -120,7 +120,7 @@ class TestUnsupportedOps(JitTestCase):
             return torch.nn.init.orthogonal_(torch.empty(3, 5))
 
         def sparse():
-            return torch.nn.init.sparse(torch.empty(3, 5), sparsity=.1)
+            return torch.nn.init.sparse_(torch.empty(3, 5), sparsity=.1)
 
         for func in [calculate_gain, eye_, dirac_, kaiming_uniform_, orthogonal_, sparse]:
             # doesn't error in eager

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1159,7 +1159,6 @@ graph(%x : Tensor,
                 weight=weight_observer._c)
         }
         torch._C._jit_pass_insert_observers(m._c, "forward", qconfig_dict, True)
-        print()
         dtypes = set([obs.getattr('dtype') for x, obs in m.conv._modules._c.items()
                       if x.startswith('_observer_')])
         assert len(dtypes) == 2, 'Expected to have 2 different types of dtype'
@@ -1245,6 +1244,10 @@ graph(%x : Tensor,
 
         m = torch.jit.script(M())
         observer = torch.jit.script(default_observer())
+
+        # run the observer once to avoid warning on an empty observer
+        observer(torch.rand(2, 2))
+
         qconfig_dict = {
             '':
             QConfig(
@@ -1942,19 +1945,6 @@ graph(%Ra, %Rb):
 
         self.checkTrace(f, (x,), (torch.ones(2, 2, requires_grad=True),))
 
-    def test_legacy_fail(self):
-        class MyLegacyFn(Function):
-            def forward(self, x):
-                return x
-
-            def backward(self, grad_output):
-                return grad_output
-
-        x = torch.tensor([0.], requires_grad=True)
-        with warnings.catch_warnings(record=True):
-            with self.assertRaisesRegex(RuntimeError, "MyLegacyFn"):
-                torch.jit._get_trace_graph(lambda x: MyLegacyFn()(x), (x,))
-
     def test_inplace_transplant(self):
         x = torch.tensor([0.], requires_grad=True)
 
@@ -2108,6 +2098,9 @@ graph(%Ra, %Rb):
         self.assertEqual(ge(y).shape, y.shape)
         self.assertEqual(ge(x).shape, x.shape)
 
+    # Suppression: we are intentionally slicing a tensor, we don't care that it
+    # will be constantified
+    @suppress_warnings
     def do_trace_slice(self, requires_grad):
         def slice(x):
             results = []
@@ -4282,7 +4275,7 @@ class TestScript(JitTestCase):
             def forward(self, x):
                 return self.fn(x)
 
-        m = M(F.sigmoid)
+        m = M(torch.sigmoid)
         inp = torch.rand(2, 3)
         self.checkModule(m, (inp, ))
 
@@ -4890,12 +4883,12 @@ def foo(x):
             check_weight = torch.rand(1, 1, 3, 3)
             check_forward_input = torch.rand(1, 1, 3, 3)
             check_inputs.append({'forward' : check_forward_input, 'weighted_kernel_sum' : check_weight})
-        module = torch.jit.trace_module(n, inputs, True, True, check_inputs)
+        module = torch.jit.trace_module(n, inputs, check_trace=True, check_inputs=check_inputs)
         self.assertTrue(module._c._has_method("forward"))
         self.assertTrue(module._c._has_method("weighted_kernel_sum"))
 
         module = torch.jit.trace(n.forward, example_forward_input)
-        module = torch.jit.trace(n.forward, example_forward_input, True, [example_forward_input])
+        module = torch.jit.trace(n.forward, example_forward_input, check_trace=True, check_inputs=[example_forward_input])
         with self.assertRaisesRegex(AttributeError, "trace doesn't support compiling individual module's functions"):
             module = torch.jit.trace(n.weighted_kernel_sum, inputs)
 
@@ -10896,6 +10889,8 @@ a")
         # test copy
         m_c = m.copy()
 
+    # Suppression: ONNX warns when exporting RNNs because of potential batch size mismatch.
+    @suppress_warnings
     @skipIfCompiledWithoutNumpy
     def test_rnn_trace_override(self):
         from torch.nn.utils.rnn import pack_padded_sequence, pad_packed_sequence
@@ -11871,6 +11866,7 @@ a")
             mte, (torch.zeros(1, 2, 3),), None, verbose=False,
             example_outputs=outputs)
 
+    @suppress_warnings
     def test_onnx_export_script_truediv(self):
         class ModuleToExport(torch.jit.ScriptModule):
             def __init__(self):
@@ -11883,8 +11879,9 @@ a")
 
         mte = ModuleToExport()
         outputs = mte(torch.zeros(1, 2, 3))
+
         torch.onnx.export_to_pretty_string(
-            mte, (torch.zeros(1, 2, 3),), None, verbose=False,
+            mte, (torch.zeros(1, 2, 3, dtype=torch.float),), None, verbose=False,
             example_outputs=outputs)
 
     def test_onnx_raw_export_script_truediv(self):
@@ -11901,6 +11898,7 @@ a")
         outputs = mte(torch.zeros(1, 2, 3))
         torch.onnx.export_to_pretty_string(
             mte, (torch.zeros(1, 2, 3),), None, verbose=False,
+            add_node_names=False, do_constant_folding=False,
             example_outputs=outputs, export_raw_ir=True)
 
     def test_onnx_export_script_non_alpha_add_sub(self):
@@ -14482,6 +14480,8 @@ a")
         f = io.BytesIO()
         torch.onnx.export_to_pretty_string(
             FooMod(), (torch.rand(3, 4),), f,
+            add_node_names=False,
+            do_constant_folding=False,
             operator_export_type=OperatorExportTypes.ONNX_ATEN_FALLBACK)
 
     @suppress_warnings
@@ -14514,6 +14514,8 @@ a")
             traced = torch.jit.trace(foo, torch.rand(3, 4), check_inputs=[(torch.rand(3, 4),)])
 
     if 'fbgemm' in torch.backends.quantized.supported_engines:
+        # Suppression: using deprecated quant api
+        @suppress_warnings
         def test_quantization_modules(self):
             K1, N1 = 2, 2
 

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -252,7 +252,7 @@ def _decide_external_data_format(use_external_data_format, operator_export_type,
     val_use_external_data_format = _resolve_args_by_export_type("use_external_data_format",
                                                                 use_external_data_format,
                                                                 operator_export_type)
-    # f can be a non-string in regular-sized model export case, but for large model export, f must be a non-empty 
+    # f can be a non-string in regular-sized model export case, but for large model export, f must be a non-empty
     # string specifying the location of the model. For large model cases, if f is not a non-empty string,
     # then this method returns an empty string, which is an error condition for the large model export code
     # path later (but not for regular model export code path).
@@ -392,7 +392,8 @@ def export_to_pretty_string(model, args, f, export_params=True, verbose=False, t
                             operator_export_type=None, export_type=ExportTypes.PROTOBUF_FILE,
                             example_outputs=None, propagate=False, google_printer=False,
                             opset_version=None, _retain_param_name=True,
-                            keep_initializers_as_inputs=None, custom_opsets=None):
+                            keep_initializers_as_inputs=None, custom_opsets=None, add_node_names=True,
+                            do_constant_folding=True):
     if aten or export_raw_ir:
         assert operator_export_type is None
         assert aten ^ export_raw_ir
@@ -403,6 +404,8 @@ def export_to_pretty_string(model, args, f, export_params=True, verbose=False, t
                                     input_names, output_names, operator_export_type,
                                     export_type, example_outputs, propagate, google_printer,
                                     opset_version, _retain_param_name,
+                                    do_constant_folding=do_constant_folding,
+                                    add_node_names=add_node_names,
                                     keep_initializers_as_inputs=keep_initializers_as_inputs,
                                     custom_opsets=custom_opsets)
 

--- a/torch/testing/_internal/jit_utils.py
+++ b/torch/testing/_internal/jit_utils.py
@@ -385,7 +385,9 @@ class JitTestCase(TestCase):
                         source,
                         inputs,
                         script.__name__,
-                        capture_output,
+                        optimize=optimize,
+                        inputs_requires_grad=inputs_requires_grad,
+                        capture_output=capture_output,
                         profiling=profiling,
                         frames_up=2)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#33779 [jit] stop printing crap in test_jit**

This should eliminate random warnings and print spew from test_jit.

It also fixes a bug where we weren't properly comparing captured outputs
(!)

Differential Revision: [D20124224](https://our.internmc.facebook.com/intern/diff/D20124224)