### PR TITLE
Enhance reproducibility documentation

### DIFF
--- a/docs/source/notes/randomness.rst
+++ b/docs/source/notes/randomness.rst
@@ -23,29 +23,29 @@ CPU and CUDA)::
 
 
 There are some PyTorch functions that use CUDA functions that can be a source
-of non-determinism. One class of such CUDA functions are atomic operations,
+of nondeterminism. One class of such CUDA functions are atomic operations,
 in particular :attr:`atomicAdd`, which can lead to the order of additions being
-non-determnistic. Because floating-point addition is not perfectly associative
+nondetermnistic. Because floating-point addition is not perfectly associative
 for floating-point operands, :attr:`atomicAdd` with floating-point operands can
 introduce different floating-point rounding errors on each evaluation, which
-introduces a source of non-deterministic variance (aka noise) in the result.
+introduces a source of nondeterministic variance (aka noise) in the result.
 
 PyTorch functions that use :attr:`atomicAdd` in the forward kernels include
 :meth:`torch.Tensor.index_add_`, :meth:`torch.Tensor.scatter_add_`,
 :meth:`torch.bincount`.
 
-A number of operations have backwards kernels that use :attr:`atomicAdd`, in
-particular :meth:`torch.nn.functional.embedding_bag`,
-:meth:`torch.nn.functional.ctc_loss` and many forms of pooling, padding, and
-sampling.
+A number of operations have backwards kernels that use :attr:`atomicAdd`,
+including :meth:`torch.nn.functional.embedding_bag`,
+:meth:`torch.nn.functional.ctc_loss`, :meth:`torch.nn.functional.interpolate`,
+and many forms of pooling, padding, and sampling.
 
-There is currently no simple way of avoiding non-determinism in these functions.
+There is currently no simple way of avoiding nondeterminism in these functions.
 
-In PyTorch version 1.4, :meth:`torch.nn.BCELoss` was found to operate
-non-deterministically when training (with backprop) on the CUDA backend. Whether
-this is due to the use of :attr:`atomicAdd` and whether non-determinism is
-injected in only the foward path or only the backward path is not currently
-known.
+Additionally, the backward path for :meth:`repeat_interleave` operates
+nondeterministically on the CUDA backend because :meth:`repeat_interleave`
+is implemented using :meth:`index_select`, the backward path for
+which is implemented using :meth:`index_add_`, which is known to operate
+nondeterministically (in the forward direction) on the CUDA backend (see above).
 
 CuDNN
 .....
@@ -60,7 +60,7 @@ When running on the CuDNN backend, two further options must be set::
     depending on the composition of your model. Due to different underlying
     operations, which may be slower, the processing speed (e.g. the number of
     batches trained per second) may be lower than when the model functions
-    non-deterministically. However, even though single-run speed may be
+    nondeterministically. However, even though single-run speed may be
     slower, depending on your application determinism may save time by
     facilitating experimentation, debugging, and anti-regression testing.
 

--- a/docs/source/notes/randomness.rst
+++ b/docs/source/notes/randomness.rst
@@ -62,7 +62,7 @@ When running on the CuDNN backend, two further options must be set::
     batches trained per second) may be lower than when the model functions
     nondeterministically. However, even though single-run speed may be
     slower, depending on your application determinism may save time by
-    facilitating experimentation, debugging, and anti-regression testing.
+    facilitating experimentation, debugging, and regression testing.
 
 Numpy
 .....


### PR DESCRIPTION
Improves explanation of non-determinism when running on GPUs. Adds info about `torch.nn.BCELoss` operating non-deterministically on GPUs.