### PR TITLE
Preserve Backward compatibility of models serialized before #31040

### DIFF
--- a/test/test_quantized_tensor.py
+++ b/test/test_quantized_tensor.py
@@ -237,7 +237,7 @@ class TestQuantizedTensor(TestCase):
 
     def test_qtensor_per_channel_load_save(self):
         r = torch.rand(20, 10, dtype=torch.float) * 4 - 2
-        scales = torch.rand(10) * 0.02 + 0.01
+        scales = torch.rand(10, dtype=torch.double) * 0.02 + 0.01
         zero_points = torch.round(torch.rand(10) * 20 + 1).to(torch.long)
         # quint32 is not supported yet
         for dtype in [torch.quint8, torch.qint8]:

--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -165,7 +165,7 @@ def _rebuild_qtensor(storage, storage_offset, size, stride, quantizer_params, re
             scales = torch.tensor(scales, dtype=torch.double)
             zero_points = torch.tensor(zero_points, dtype=torch.long)
         tensor = torch._empty_per_channel_affine_quantized(
-            size, scales, zero_points, axis=axis, dtype=storage.dtype)
+            size, scales=scales, zero_points=zero_points, axis=axis, dtype=storage.dtype)
     else:
         raise RuntimeError("Can't deserialize quantized tensor with qscheme {}".format(qscheme))
     tensor.set_(storage, storage_offset, size, stride)

--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -161,8 +161,11 @@ def _rebuild_qtensor(storage, storage_offset, size, stride, quantizer_params, re
         tensor = torch._empty_affine_quantized(size, scale=scale, zero_point=zero_point, dtype=storage.dtype)
     elif qscheme == torch.per_channel_affine:
         _, scales, zero_points, axis = quantizer_params
+        if type(scales) is list and type(zero_points) is list:
+            scales = torch.tensor(scales, dtype=torch.double)
+            zero_points = torch.tensor(zero_points, dtype=torch.long)
         tensor = torch._empty_per_channel_affine_quantized(
-            size, scales=scales, zero_points=zero_points, axis=axis, dtype=storage.dtype)
+            size, scales, zero_points, axis=axis, dtype=storage.dtype)
     else:
         raise RuntimeError("Can't deserialize quantized tensor with qscheme {}".format(qscheme))
     tensor.set_(storage, storage_offset, size, stride)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#33796 Preserve Backward compatibility of models serialized before #31040**

Differential Revision: [D20109662](https://our.internmc.facebook.com/intern/diff/D20109662)