### PR TITLE
[torch/multiprocessing] Add start_process_in_context method that takes a multiprocessing context from user

### DIFF
--- a/torch/multiprocessing/__init__.py
+++ b/torch/multiprocessing/__init__.py
@@ -42,7 +42,14 @@ if sys.version_info < (3, 3):
 
 """Add helper function to spawn N processes and wait for completion of any of
 them. This depends `mp.get_context` which was added in Python 3.4."""
-from .spawn import spawn, SpawnContext, _supports_context, start_processes, ProcessContext
+from .spawn import (
+    ProcessContext,
+    SpawnContext,
+    _supports_context,
+    spawn,
+    start_processes,
+    start_processes_in_context,
+)
 
 
 if sys.platform == 'darwin' or sys.platform == 'win32':

--- a/torch/multiprocessing/spawn.py
+++ b/torch/multiprocessing/spawn.py
@@ -135,13 +135,23 @@ class SpawnContext(ProcessContext):
 # Currently we only add this API first, we can consider adding it to documentation as
 # needed in the future.
 def start_processes(fn, args=(), nprocs=1, join=True, daemon=False, start_method='spawn'):
+    mp_context = multiprocessing.get_context(start_method)
+    start_process_in_context(mp_context, fn, args, nprocs, join, daemon)
+
+
+def start_processes_in_context(mp_context, fn, args=(), nprocs=1, join=True, daemon=False):
+    r""" A more general method to ``torch.muliprocessing.spawn`` in which
+    the processes are started in the provided ``mp_context``. Useful when
+    ``fn`` needs a multiprocessing data structure that needs to be created in the
+    same multiprocessing context as the process.
+    """
+
     _python_version_check()
-    mp = multiprocessing.get_context(start_method)
     error_queues = []
     processes = []
     for i in range(nprocs):
-        error_queue = mp.SimpleQueue()
-        process = mp.Process(
+        error_queue = mp_context.SimpleQueue()
+        process = mp_context.Process(
             target=_wrap,
             args=(fn, i, args, error_queue),
             daemon=daemon,


### PR DESCRIPTION
Summary: Allows user to pass a multiprocessing context so that they can create any multiprocessing datastructures on them to use in their sub-processes.

Test Plan: sandcastle

Differential Revision: D20104741

