### PR TITLE
[caffe2][core] Redundant file ptr repositioning

### DIFF
--- a/caffe2/core/db.cc
+++ b/caffe2/core/db.cc
@@ -131,7 +131,6 @@ class MiniDB : public DB {
         break;
       case WRITE:
         file_ = fopen(source.c_str(), "ab");
-        fseek(file_, 0, SEEK_END);
         break;
       case READ:
         file_ = fopen(source.c_str(), "rb");


### PR DESCRIPTION
File already opened in append mode. No need for reposition fseek to the eof.