### PR TITLE
Kill some unused (TH)Storage-based APIs.

### DIFF
--- a/aten/src/TH/generic/THTensor.cpp
+++ b/aten/src/TH/generic/THTensor.cpp
@@ -98,25 +98,6 @@ THTensor *THTensor_(newWithStorage2d)(THStorage *storage, ptrdiff_t storageOffse
   return THTensor_(newWithStorage)(storage, storageOffset, {size0, size1}, {stride0, stride1});
 }
 
-THTensor *THTensor_(newWithStorage3d)(THStorage *storage, ptrdiff_t storageOffset,
-                               int64_t size0, int64_t stride0,
-                               int64_t size1, int64_t stride1,
-                               int64_t size2, int64_t stride2)
-{
-  return THTensor_(newWithStorage)(storage, storageOffset, {size0, size1, size2}, {stride0, stride1, stride2});
-}
-
-THTensor *THTensor_(newWithStorage4d)(THStorage *storage, ptrdiff_t storageOffset,
-                               int64_t size0, int64_t stride0,
-                               int64_t size1, int64_t stride1,
-                               int64_t size2, int64_t stride2,
-                               int64_t size3, int64_t stride3)
-{
-  return THTensor_(newWithStorage)(storage, storageOffset,
-                                          {size0, size1, size2, size3},
-                                          {stride0, stride1, stride2, stride3});
-}
-
 THTensor *THTensor_(newWithSize)(at::IntArrayRef size, at::IntArrayRef stride)
 {
   return THTensor_(newWithStorage)(NULL, 0, size, stride);

--- a/aten/src/TH/generic/THTensor.h
+++ b/aten/src/TH/generic/THTensor.h
@@ -42,15 +42,6 @@ TH_API THTensor *THTensor_(newWithStorage1d)(THStorage *storage_, ptrdiff_t stor
 TH_API THTensor *THTensor_(newWithStorage2d)(THStorage *storage_, ptrdiff_t storageOffset_,
                                 int64_t size0_, int64_t stride0_,
                                 int64_t size1_, int64_t stride1_);
-TH_API THTensor *THTensor_(newWithStorage3d)(THStorage *storage_, ptrdiff_t storageOffset_,
-                                int64_t size0_, int64_t stride0_,
-                                int64_t size1_, int64_t stride1_,
-                                int64_t size2_, int64_t stride2_);
-TH_API THTensor *THTensor_(newWithStorage4d)(THStorage *storage_, ptrdiff_t storageOffset_,
-                                int64_t size0_, int64_t stride0_,
-                                int64_t size1_, int64_t stride1_,
-                                int64_t size2_, int64_t stride2_,
-                                int64_t size3_, int64_t stride3_);
 
 /* stride might be NULL */
 TH_API THTensor *THTensor_(newWithSize1d)(int64_t size0_);

--- a/aten/src/THC/generic/THCTensor.cpp
+++ b/aten/src/THC/generic/THCTensor.cpp
@@ -105,25 +105,6 @@ THCTensor *THCTensor_(newWithStorage2d)(THCState *state, THCStorage *storage, pt
   return THCTensor_(newWithStorage)(state, storage, storageOffset, {size0, size1}, {stride0, stride1});
 }
 
-THCTensor *THCTensor_(newWithStorage3d)(THCState *state, THCStorage *storage, ptrdiff_t storageOffset,
-                               int64_t size0, int64_t stride0,
-                               int64_t size1, int64_t stride1,
-                               int64_t size2, int64_t stride2)
-{
-  return THCTensor_(newWithStorage)(state, storage, storageOffset, {size0, size1, size2}, {stride0, stride1, stride2});
-}
-
-THCTensor *THCTensor_(newWithStorage4d)(THCState *state, THCStorage *storage, ptrdiff_t storageOffset,
-                               int64_t size0, int64_t stride0,
-                               int64_t size1, int64_t stride1,
-                               int64_t size2, int64_t stride2,
-                               int64_t size3, int64_t stride3)
-{
-  return THCTensor_(newWithStorage)(state, storage, storageOffset,
-                                            {size0, size1, size2, size3},
-                                            {stride0, stride1, stride2, stride3});
-}
-
 THCTensor *THCTensor_(newWithSize)(THCState *state, at::IntArrayRef size, at::IntArrayRef stride)
 {
   return THCTensor_(newWithStorage)(state, NULL, 0, size, stride);

--- a/aten/src/THC/generic/THCTensor.h
+++ b/aten/src/THC/generic/THCTensor.h
@@ -44,15 +44,6 @@ THC_API THCTensor *THCTensor_(newWithStorage1d)(THCState *state, THCStorage *sto
 THC_API THCTensor *THCTensor_(newWithStorage2d)(THCState *state, THCStorage *storage_, ptrdiff_t storageOffset_,
                                 int64_t size0_, int64_t stride0_,
                                 int64_t size1_, int64_t stride1_);
-THC_API THCTensor *THCTensor_(newWithStorage3d)(THCState *state, THCStorage *storage_, ptrdiff_t storageOffset_,
-                                int64_t size0_, int64_t stride0_,
-                                int64_t size1_, int64_t stride1_,
-                                int64_t size2_, int64_t stride2_);
-THC_API THCTensor *THCTensor_(newWithStorage4d)(THCState *state, THCStorage *storage_, ptrdiff_t storageOffset_,
-                                int64_t size0_, int64_t stride0_,
-                                int64_t size1_, int64_t stride1_,
-                                int64_t size2_, int64_t stride2_,
-                                int64_t size3_, int64_t stride3_);
 
 /* stride might be NULL */
 THC_API THCTensor *THCTensor_(newWithSize1d)(THCState *state, int64_t size0_);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #33823 Get rid of newWithStorage2d calls.
* **#33815 Kill some unused (TH)Storage-based APIs.**
* #33735 remove setStorage with null StorageImpl support.
* #33734 Remove some dead THStorage related code.
* #33695 Kill dead scalar_check.

Differential Revision: [D20119333](https://our.internmc.facebook.com/intern/diff/D20119333)