### PR TITLE
.circleci: Divert packages to test channel on tag

### DIFF
--- a/.circleci/scripts/binary_linux_upload.sh
+++ b/.circleci/scripts/binary_linux_upload.sh
@@ -12,11 +12,14 @@ declare -x "AWS_SECRET_ACCESS_KEY=${PYTORCH_BINARY_AWS_SECRET_ACCESS_KEY}"
 set -eux -o pipefail
 export PATH="$MINICONDA_ROOT/bin:$PATH"
 
+# This gets set in binary_populate_env.sh, but lets have a sane default just in case
+PIP_UPLOAD_FOLDER=${PIP_UPLOAD_FOLDER:-nightly}
+
 # Upload the package to the final location
 pushd /home/circleci/project/final_pkgs
 if [[ "$PACKAGE_TYPE" == conda ]]; then
   retry conda install -yq anaconda-client
-  anaconda -t "${CONDA_PYTORCHBOT_TOKEN}" upload  "$(ls)" -u pytorch-nightly --label main --no-progress --force
+  anaconda -t "${CONDA_PYTORCHBOT_TOKEN}" upload  "$(ls)" -u "pytorch-${PIP_UPLOAD_FOLDER}" --label main --no-progress --force
 elif [[ "$PACKAGE_TYPE" == libtorch ]]; then
   retry pip install -q awscli
   s3_dir="s3://pytorch/libtorch/${PIP_UPLOAD_FOLDER}${DESIRED_CUDA}/"

--- a/.circleci/scripts/binary_macos_upload.sh
+++ b/.circleci/scripts/binary_macos_upload.sh
@@ -13,10 +13,13 @@ set -eux -o pipefail
 source "/Users/distiller/project/env"
 export "PATH=$workdir/miniconda/bin:$PATH"
 
+# This gets set in binary_populate_env.sh, but lets have a sane default just in case
+PIP_UPLOAD_FOLDER=${PIP_UPLOAD_FOLDER:-nightly}
+
 pushd "$workdir/final_pkgs"
 if [[ "$PACKAGE_TYPE" == conda ]]; then
   retry conda install -yq anaconda-client
-  retry anaconda -t "${CONDA_PYTORCHBOT_TOKEN}" upload "$(ls)" -u pytorch-nightly --label main --no-progress --force
+  retry anaconda -t "${CONDA_PYTORCHBOT_TOKEN}" upload "$(ls)" -u "pytorch-${PIP_UPLOAD_FOLDER}" --label main --no-progress --force
 elif [[ "$PACKAGE_TYPE" == libtorch ]]; then
   retry pip install -q awscli
   s3_dir="s3://pytorch/libtorch/${PIP_UPLOAD_FOLDER}${DESIRED_CUDA}/"

--- a/.circleci/scripts/binary_populate_env.sh
+++ b/.circleci/scripts/binary_populate_env.sh
@@ -40,25 +40,16 @@ if [[ -z "$DOCKER_IMAGE" ]]; then
   fi
 fi
 
-# Upload to parallel folder for devtoolsets
-# All nightlies used to be devtoolset3, then devtoolset7 was added as a build
-# option, so the upload was redirected to nightly/devtoolset7 to avoid
-# conflicts with other binaries (there shouldn't be any conflicts). Now we are
-# making devtoolset7 the default.
-if [[ "$DESIRED_DEVTOOLSET" == 'devtoolset7' || "$DESIRED_DEVTOOLSET" == *"cxx11-abi"* || "$(uname)" == 'Darwin' ]]; then
-  export PIP_UPLOAD_FOLDER='nightly/'
-else
-  # On linux machines, this shouldn't actually be called anymore. This is just
-  # here for extra safety.
-  export PIP_UPLOAD_FOLDER='nightly/devtoolset3/'
-fi
-
+# Default to nightly, since that's where this normally uploads to
+PIP_UPLOAD_FOLDER='nightly/'
 # We put this here so that OVERRIDE_PACKAGE_VERSION below can read from it
 export DATE="$(date -u +%Y%m%d)"
 #TODO: We should be pulling semver version from the base version.txt
 BASE_BUILD_VERSION="1.5.0.dev$DATE"
 # Change BASE_BUILD_VERSION to git tag when on a git tag
 if git describe --tags --exact >/dev/null 2>/dev/null; then
+  # Switch upload folder to 'test/' if we are on a tag
+  PIP_UPLOAD_FOLDER='test/'
   # Grab git tag, remove prefixed v and remove everything after -
   # Used to clean up tags that are for release candidates like v1.5.0-rc1
   # Turns tag v1.5.0-rc1 -> v1.5.0


### PR DESCRIPTION
This sets up PIP_UPLOAD_FOLDER to point to the correct channel for
release candidates as opposed to nightlies.

Removes an old safety check that's not needed anymore for devtoolset3

And provides a nice default for PIP_UPLOAD_FOLDER, which should clear up
confusion on where it's initially set

This is a stepping stone towards the promotable pipeline.

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

