### PR TITLE
[quantization][fix] Running weight_post_process for qat

### DIFF
--- a/torch/nn/quantized/modules/conv.py
+++ b/torch/nn/quantized/modules/conv.py
@@ -247,7 +247,7 @@ class Conv2d(_ConvNd):
             else:
                 activation_post_process = mod.activation_post_process
             weight_post_process = mod.qconfig.weight()
-            weight_post_process(mod.weight)
+        weight_post_process(mod.weight)
         act_scale, act_zp = activation_post_process.calculate_qparams()
         assert weight_post_process.dtype == torch.qint8, \
             'Weight observer must have a dtype of qint8'


### PR DESCRIPTION
Missed running this function for weight which will make convert immediately after prepare_qat fail since we didn't run the observer for weight.

