### PR TITLE
Improve dll loading logic on Windows

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -58,12 +58,13 @@ if platform.system() == 'Windows':
     else:
         cuda_path = ''
 
-    if not is_conda and sys.version_info >= (3, 8):
+    if sys.version_info >= (3, 8):
         dll_paths = list(filter(os.path.exists, [th_dll_path, py_dll_path, nvtoolsext_dll_path, cuda_path]))
 
         for dll_path in dll_paths:
             os.add_dll_directory(dll_path)
-    else:
+
+    if is_conda or sys.version_info < (3, 8):
         dll_paths = [th_dll_path, py_dll_path, nvtoolsext_dll_path, cuda_path]
         dll_paths = list(filter(os.path.exists, dll_paths)) + [os.environ['PATH']]
 


### PR DESCRIPTION
The way it works on the Anaconda distribution of Python 3.8 is a bit different. Loading DLLs explicitly  (e.g. `ctype.CDLL`) relies on paths appended by `os.add_dll_directory`. But if you try to load DLLs implicitly (e.g. `from torch._C import *`), it will rely on `PATH`.

Fixes https://github.com/pytorch/vision/issues/1916.