### PR TITLE
Grad input padding support for dilation argument

### DIFF
--- a/torch/nn/grad.py
+++ b/torch/nn/grad.py
@@ -4,7 +4,7 @@ import torch
 from .modules.utils import _single, _pair, _triple
 
 
-def _grad_input_padding(grad_output, input_size, stride, padding, kernel_size):
+def _grad_input_padding(grad_output, input_size, stride, padding, kernel_size, dilation):
     input_size = list(input_size)
     k = grad_output.dim() - 2
 
@@ -15,8 +15,8 @@ def _grad_input_padding(grad_output, input_size, stride, padding, kernel_size):
                          .format(k + 2, len(input_size)))
 
     def dim_size(d):
-        return ((grad_output.size(d + 2) - 1) * stride[d] - 2 * padding[d] +
-                kernel_size[d])
+        return ((grad_output.size(d + 2) - 1) * stride[d] - 2 * padding[d] + 1 
+                + dilation[d] * (kernel_size[d] - 1))
 
     min_sizes = [dim_size(d) for d in range(k)]
     max_sizes = [min_sizes[d] + stride[d] - 1 for d in range(k)]
@@ -65,7 +65,7 @@ def conv1d_input(input_size, weight, grad_output, stride=1, padding=0, dilation=
         raise ValueError("grad.conv1d_input requires specifying an input_size")
 
     grad_input_padding = _grad_input_padding(grad_output, input_size, stride,
-                                             padding, kernel_size)
+                                             padding, kernel_size, dilation)
 
     return torch.conv_transpose1d(
         grad_output, weight, None, stride, padding, grad_input_padding, groups,
@@ -154,7 +154,7 @@ def conv2d_input(input_size, weight, grad_output, stride=1, padding=0, dilation=
         raise ValueError("grad.conv2d_input requires specifying an input_size")
 
     grad_input_padding = _grad_input_padding(grad_output, input_size, stride,
-                                             padding, kernel_size)
+                                             padding, kernel_size, dilation)
 
     return torch.conv_transpose2d(
         grad_output, weight, None, stride, padding, grad_input_padding, groups,
@@ -247,7 +247,7 @@ def conv3d_input(input_size, weight, grad_output, stride=1, padding=0, dilation=
         raise ValueError("grad.conv3d_input requires specifying an input_size")
 
     grad_input_padding = _grad_input_padding(grad_output, input_size, stride,
-                                             padding, kernel_size)
+                                             padding, kernel_size, dilation)
 
     return torch.conv_transpose3d(
         grad_output, weight, None, stride, padding, grad_input_padding, groups,

--- a/torch/nn/grad.py
+++ b/torch/nn/grad.py
@@ -2,9 +2,15 @@
 
 import torch
 from .modules.utils import _single, _pair, _triple
+import warnings
 
 
-def _grad_input_padding(grad_output, input_size, stride, padding, kernel_size, dilation):
+def _grad_input_padding(grad_output, input_size, stride, padding, kernel_size, dilation=None):
+    if dilation is None:
+        # For backward compatibility
+        warnings.warn("_grad_input_padding 'dilation' argument not provided. Default of 1 is used.")
+        dilation = [1] * len(stride)
+
     input_size = list(input_size)
     k = grad_output.dim() - 2
 
@@ -15,7 +21,7 @@ def _grad_input_padding(grad_output, input_size, stride, padding, kernel_size, d
                          .format(k + 2, len(input_size)))
 
     def dim_size(d):
-        return ((grad_output.size(d + 2) - 1) * stride[d] - 2 * padding[d] + 1 
+        return ((grad_output.size(d + 2) - 1) * stride[d] - 2 * padding[d] + 1
                 + dilation[d] * (kernel_size[d] - 1))
 
     min_sizes = [dim_size(d) for d in range(k)]


### PR DESCRIPTION
Fix https://github.com/pytorch/pytorch/issues/16012

It replaces https://github.com/pytorch/pytorch/pull/20684 that has gone stale and simply adds tests on top of it.
These calls used to crash, they now work and return the same value as the backward using the autograd engine.