### PR TITLE
Split BinaryMiscOpsKernels into more files for faster build times.

### DIFF
--- a/aten/src/ATen/native/cuda/BinaryBitwiseOpsKernels.cu
+++ b/aten/src/ATen/native/cuda/BinaryBitwiseOpsKernels.cu
@@ -1,0 +1,73 @@
+#include <ATen/Dispatch.h>
+#include <ATen/native/DispatchStub.h>
+#include <ATen/native/cuda/Loops.cuh>
+#include <ATen/native/TensorIterator.h>
+#include <ATen/native/BinaryOps.h>
+
+// NOTE: CUDA on Windows requires that the enclosing function
+// of a __device__ lambda not have internal linkage.
+
+namespace at { namespace native {
+
+void bitwise_and_kernel_cuda(TensorIterator& iter) {
+  if (iter.dtype() == ScalarType::Bool) {
+    gpu_kernel_with_scalars(
+        iter,
+        []GPU_LAMBDA(bool a, bool b) {
+          return a && b;
+    });
+  } else {
+    AT_DISPATCH_INTEGRAL_TYPES(iter.dtype(), "bitwise_and_cuda", [&]() {
+      gpu_kernel_with_scalars(
+          iter,
+          []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
+            return a & b;
+      });
+    });
+  }
+}
+
+void bitwise_or_kernel_cuda(TensorIterator& iter) {
+  if (iter.dtype() == ScalarType::Bool) {
+    gpu_kernel_with_scalars(
+        iter,
+        []GPU_LAMBDA(bool a, bool b) {
+          return a || b;
+    });
+  } else {
+    AT_DISPATCH_INTEGRAL_TYPES(iter.dtype(), "bitwise_or_cuda", [&]() {
+      gpu_kernel_with_scalars(
+          iter,
+          []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
+            return a | b;
+      });
+    });
+  }
+}
+
+void bitwise_xor_kernel_cuda(TensorIterator& iter) {
+  if (iter.dtype() == ScalarType::Bool) {
+    // Boolean type does not work with ^ (bitwise XOR) in C++. bitwise_xor wraps this operation for both Boolean and
+    // integral types.
+    gpu_kernel_with_scalars(
+          iter,
+          []GPU_LAMBDA(bool a, bool b) {
+            return a != b;
+          });
+  } else {
+    AT_DISPATCH_INTEGRAL_TYPES(iter.dtype(), "bitwise_xor_cuda", [&]() {
+      gpu_kernel_with_scalars(
+          iter,
+          []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
+            return a ^ b;
+      });
+    });
+  }
+}
+
+REGISTER_DISPATCH(bitwise_and_stub, &bitwise_and_kernel_cuda);
+REGISTER_DISPATCH(bitwise_or_stub, &bitwise_or_kernel_cuda);
+REGISTER_DISPATCH(bitwise_xor_stub, &bitwise_xor_kernel_cuda);
+
+
+}} // namespace at::native

--- a/aten/src/ATen/native/cuda/BinaryLogicalOpsKernels.cu
+++ b/aten/src/ATen/native/cuda/BinaryLogicalOpsKernels.cu
@@ -1,0 +1,41 @@
+#include <ATen/Dispatch.h>
+#include <ATen/native/DispatchStub.h>
+#include <ATen/native/cuda/Loops.cuh>
+#include <ATen/native/TensorIterator.h>
+#include <ATen/native/BinaryOps.h>
+
+// NOTE: CUDA on Windows requires that the enclosing function
+// of a __device__ lambda not have internal linkage.
+
+namespace at { namespace native {
+
+void logical_and_kernel_cuda(TensorIterator& iter) {
+  AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBool, iter.common_dtype(), "logical_and_cuda", [&]() {
+    gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> bool {
+      return a && b;
+    });
+  });
+}
+
+void logical_or_kernel_cuda(TensorIterator& iter) {
+  AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBool, iter.common_dtype(), "logical_or_cuda", [&]() {
+    gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> bool {
+      return a || b;
+    });
+  });
+}
+
+void logical_xor_kernel_cuda(TensorIterator& iter) {
+  AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBool, iter.common_dtype(), "logical_xor_cuda", [&]() {
+    gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> bool {
+      return bool(a) != bool(b);
+    });
+  });
+}
+
+REGISTER_DISPATCH(logical_and_stub, &logical_and_kernel_cuda);
+REGISTER_DISPATCH(logical_or_stub, &logical_or_kernel_cuda);
+REGISTER_DISPATCH(logical_xor_stub, &logical_xor_kernel_cuda);
+
+
+}} // namespace at::native

--- a/aten/src/ATen/native/cuda/BinaryMiscBackwardOpsKernels.cu
+++ b/aten/src/ATen/native/cuda/BinaryMiscBackwardOpsKernels.cu
@@ -1,0 +1,31 @@
+#include <ATen/Dispatch.h>
+#include <ATen/native/DispatchStub.h>
+#include <ATen/native/cuda/Loops.cuh>
+#include <ATen/native/TensorIterator.h>
+#include <ATen/native/BinaryOps.h>
+
+// NOTE: CUDA on Windows requires that the enclosing function
+// of a __device__ lambda not have internal linkage.
+
+namespace at { namespace native {
+
+void sigmoid_backward_kernel_cuda(TensorIterator& iter) {
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(iter.dtype(), "sigmoid_backward_cuda", [&]() {
+    gpu_kernel(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
+      return a * (scalar_t(1.) - b) * b;
+    });
+  });
+}
+
+void tanh_backward_kernel_cuda(TensorIterator& iter) {
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(iter.dtype(), "tanh_backward_cuda", [&]() {
+    gpu_kernel(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
+      return a * (scalar_t(1.) - b * b);
+    });
+  });
+}
+
+REGISTER_DISPATCH(sigmoid_backward_stub, &sigmoid_backward_kernel_cuda);
+REGISTER_DISPATCH(tanh_backward_stub, &tanh_backward_kernel_cuda);
+
+}} // namespace at::native

--- a/aten/src/ATen/native/cuda/BinaryMiscOpsKernels.cu
+++ b/aten/src/ATen/native/cuda/BinaryMiscOpsKernels.cu
@@ -18,124 +18,6 @@ void atan2_kernel_cuda(TensorIterator& iter) {
   });
 }
 
-void bitwise_and_kernel_cuda(TensorIterator& iter) {
-  if (iter.dtype() == ScalarType::Bool) {
-    gpu_kernel_with_scalars(
-        iter,
-        []GPU_LAMBDA(bool a, bool b) {
-          return a && b;
-    });
-  } else {
-    AT_DISPATCH_INTEGRAL_TYPES(iter.dtype(), "bitwise_and_cuda", [&]() {
-      gpu_kernel_with_scalars(
-          iter,
-          []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
-            return a & b;
-      });
-    });
-  }
-}
-
-void bitwise_or_kernel_cuda(TensorIterator& iter) {
-  if (iter.dtype() == ScalarType::Bool) {
-    gpu_kernel_with_scalars(
-        iter,
-        []GPU_LAMBDA(bool a, bool b) {
-          return a || b;
-    });
-  } else {
-    AT_DISPATCH_INTEGRAL_TYPES(iter.dtype(), "bitwise_or_cuda", [&]() {
-      gpu_kernel_with_scalars(
-          iter,
-          []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
-            return a | b;
-      });
-    });
-  }
-}
-
-void bitwise_xor_kernel_cuda(TensorIterator& iter) {
-  if (iter.dtype() == ScalarType::Bool) {
-    // Boolean type does not work with ^ (bitwise XOR) in C++. bitwise_xor wraps this operation for both Boolean and
-    // integral types.
-    gpu_kernel_with_scalars(
-          iter,
-          []GPU_LAMBDA(bool a, bool b) {
-            return a != b;
-          });
-  } else {
-    AT_DISPATCH_INTEGRAL_TYPES(iter.dtype(), "bitwise_xor_cuda", [&]() {
-      gpu_kernel_with_scalars(
-          iter,
-          []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
-            return a ^ b;
-      });
-    });
-  }
-}
-
-void lshift_kernel_cuda(TensorIterator& iter) {
-  if (iter.dtype() == ScalarType::Float || iter.dtype() == ScalarType::Double) {
-    AT_DISPATCH_FLOATING_TYPES(iter.dtype(), "lshift_cuda", [&]() {
-      gpu_kernel_with_scalars(
-        iter,
-        []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
-          return a * std::pow((scalar_t)(2), b);
-      });
-    });
-  } else {
-    AT_DISPATCH_INTEGRAL_TYPES(iter.dtype(), "lshift_cuda", [&]() {
-      gpu_kernel_with_scalars(iter,
-        []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
-          return a << b;
-      });
-    });
-  }
-}
-
-void rshift_kernel_cuda(TensorIterator& iter) {
-  if (iter.dtype() == ScalarType::Float || iter.dtype() == ScalarType::Double) {
-    AT_DISPATCH_FLOATING_TYPES(iter.dtype(), "rshift_cuda", [&]() {
-      gpu_kernel_with_scalars(
-        iter,
-        []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
-          return a / std::pow((scalar_t)(2), b);
-      });
-    });
-  } else {
-    AT_DISPATCH_INTEGRAL_TYPES(iter.dtype(), "rshift_cuda", [&]() {
-      gpu_kernel_with_scalars(iter,
-        []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
-          return a >> b;
-      });
-    });
-  }
-}
-
-void logical_and_kernel_cuda(TensorIterator& iter) {
-  AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBool, iter.common_dtype(), "logical_and_cuda", [&]() {
-    gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> bool {
-      return a && b;
-    });
-  });
-}
-
-void logical_or_kernel_cuda(TensorIterator& iter) {
-  AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBool, iter.common_dtype(), "logical_or_cuda", [&]() {
-    gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> bool {
-      return a || b;
-    });
-  });
-}
-
-void logical_xor_kernel_cuda(TensorIterator& iter) {
-  AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBool, iter.common_dtype(), "logical_xor_cuda", [&]() {
-    gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> bool {
-      return bool(a) != bool(b);
-    });
-  });
-}
-
 void smooth_l1_kernel_cuda(TensorIterator& iter) {
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(iter.dtype(), "smooth_l1_cuda", [&]() {
     gpu_kernel(iter, [] GPU_LAMBDA (scalar_t a, scalar_t b) -> scalar_t {
@@ -145,21 +27,6 @@ void smooth_l1_kernel_cuda(TensorIterator& iter) {
   });
 }
 
-void sigmoid_backward_kernel_cuda(TensorIterator& iter) {
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(iter.dtype(), "sigmoid_backward_cuda", [&]() {
-    gpu_kernel(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
-      return a * (scalar_t(1.) - b) * b;
-    });
-  });
-}
-
-void tanh_backward_kernel_cuda(TensorIterator& iter) {
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(iter.dtype(), "tanh_backward_cuda", [&]() {
-    gpu_kernel(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
-      return a * (scalar_t(1.) - b * b);
-    });
-  });
-}
 
 void mse_kernel_cuda(TensorIterator& iter) {
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(iter.dtype(), "mse_cuda", [&]() {
@@ -171,17 +38,7 @@ void mse_kernel_cuda(TensorIterator& iter) {
 }
 
 REGISTER_DISPATCH(atan2_stub, &atan2_kernel_cuda);
-REGISTER_DISPATCH(bitwise_and_stub, &bitwise_and_kernel_cuda);
-REGISTER_DISPATCH(bitwise_or_stub, &bitwise_or_kernel_cuda);
-REGISTER_DISPATCH(lshift_stub, &lshift_kernel_cuda);
-REGISTER_DISPATCH(bitwise_xor_stub, &bitwise_xor_kernel_cuda);
-REGISTER_DISPATCH(rshift_stub, &rshift_kernel_cuda);
-REGISTER_DISPATCH(logical_and_stub, &logical_and_kernel_cuda);
-REGISTER_DISPATCH(logical_or_stub, &logical_or_kernel_cuda);
-REGISTER_DISPATCH(logical_xor_stub, &logical_xor_kernel_cuda);
 REGISTER_DISPATCH(smooth_l1_stub, &smooth_l1_kernel_cuda);
-REGISTER_DISPATCH(sigmoid_backward_stub, &sigmoid_backward_kernel_cuda);
-REGISTER_DISPATCH(tanh_backward_stub, &tanh_backward_kernel_cuda);
 REGISTER_DISPATCH(mse_stub, &mse_kernel_cuda);
 
 }} // namespace at::native

--- a/aten/src/ATen/native/cuda/BinaryShiftOpsKernels.cu
+++ b/aten/src/ATen/native/cuda/BinaryShiftOpsKernels.cu
@@ -1,0 +1,54 @@
+#include <ATen/Dispatch.h>
+#include <ATen/native/DispatchStub.h>
+#include <ATen/native/cuda/Loops.cuh>
+#include <ATen/native/TensorIterator.h>
+#include <ATen/native/BinaryOps.h>
+
+// NOTE: CUDA on Windows requires that the enclosing function
+// of a __device__ lambda not have internal linkage.
+
+namespace at { namespace native {
+
+
+void lshift_kernel_cuda(TensorIterator& iter) {
+  if (iter.dtype() == ScalarType::Float || iter.dtype() == ScalarType::Double) {
+    AT_DISPATCH_FLOATING_TYPES(iter.dtype(), "lshift_cuda", [&]() {
+      gpu_kernel_with_scalars(
+        iter,
+        []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
+          return a * std::pow((scalar_t)(2), b);
+      });
+    });
+  } else {
+    AT_DISPATCH_INTEGRAL_TYPES(iter.dtype(), "lshift_cuda", [&]() {
+      gpu_kernel_with_scalars(iter,
+        []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
+          return a << b;
+      });
+    });
+  }
+}
+
+void rshift_kernel_cuda(TensorIterator& iter) {
+  if (iter.dtype() == ScalarType::Float || iter.dtype() == ScalarType::Double) {
+    AT_DISPATCH_FLOATING_TYPES(iter.dtype(), "rshift_cuda", [&]() {
+      gpu_kernel_with_scalars(
+        iter,
+        []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
+          return a / std::pow((scalar_t)(2), b);
+      });
+    });
+  } else {
+    AT_DISPATCH_INTEGRAL_TYPES(iter.dtype(), "rshift_cuda", [&]() {
+      gpu_kernel_with_scalars(iter,
+        []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
+          return a >> b;
+      });
+    });
+  }
+}
+
+REGISTER_DISPATCH(lshift_stub, &lshift_kernel_cuda);
+REGISTER_DISPATCH(rshift_stub, &rshift_kernel_cuda);
+
+}} // namespace at::native


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#33873 Split BinaryMiscOpsKernels into more files for faster build times.**

Differential Revision: [D20140974](https://our.internmc.facebook.com/intern/diff/D20140974)