### PR TITLE
CUDA Vectorized Dropout

### DIFF
--- a/aten/src/ATen/native/cuda/Dropout.cu
+++ b/aten/src/ATen/native/cuda/Dropout.cu
@@ -158,13 +158,14 @@ void masked_scale_kernel(at::Tensor& ret, const at::Tensor src, const at::Tensor
    iter.add_output(ret);
    iter.add_input(src);
    iter.add_input(mask);
+   iter.dont_compute_common_dtype();
 
    iter.build();
 
    at::native::gpu_kernel(
        iter,
-       [=]GPU_LAMBDA(const scalar_t src_val, const uint8_t mask_val, accscalar_t scale_val) -> scalar_t {
-          return (float)mask_val * src_val * scale_val;
+       [=]GPU_LAMBDA(const scalar_t src_val, const uint8_t mask_val) -> scalar_t {
+          return (float)mask_val * src_val * scale;
        });
 }
 

--- a/aten/src/ATen/native/cuda/Dropout.cu
+++ b/aten/src/ATen/native/cuda/Dropout.cu
@@ -42,7 +42,7 @@ fused_dropout_kernel_vec(at::cuda::detail::TensorInfo<scalar_t, IndexType> a,
                            ) {
 
   // make sure we don't break assumption that we can't have > 4 elements / thread
-  static_assert(VEC <= 4);
+  static_assert(VEC <= 4, "Value of VEC must be in [2, 4]");
 
   using LoadT = memory::aligned_vector<scalar_t, VEC>;
   using MaskLoadT = memory::aligned_vector<uint8_t, VEC>;

--- a/aten/src/ATen/native/cuda/Dropout.cu
+++ b/aten/src/ATen/native/cuda/Dropout.cu
@@ -203,7 +203,7 @@ int get_vector_size(at::Tensor self, at::Tensor ret, at::Tensor mask) {
 std::tuple<Tensor,Tensor>
 fused_dropout_cuda(const Tensor& self, double p, Generator * gen_){
   auto gen = get_generator_or_default<CUDAGenerator>(gen_, cuda::detail::getDefaultCUDAGenerator());
-  Tensor ret = at::empty_like(self, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+  Tensor ret = at::empty_like(self, self.suggest_memory_format());
   Tensor mask = at::empty(self.sizes(), self.options().dtype(kByte));
   const int64_t nelem = self.numel();
 //empty tensors should not get here, but just in case, avoid FPE


### PR DESCRIPTION
Add vectorization to dropout kernels for both reads & writes. Moved the `masked_scale_kernel` implementation to `TensorIterator` to pick up recent autovectorization additions by @zasdfgbnm , and wrote a vectorized specialization of the dropout training kernel (along with some fairly conservative dispatch logic).