### PR TITLE
[caffe2] do not declare __assert_fail in clang builds

### DIFF
--- a/c10/macros/Macros.h
+++ b/c10/macros/Macros.h
@@ -221,12 +221,16 @@ extern "C" {
 #if defined(__CUDA_ARCH__) || !defined(__clang__)
   [[noreturn]]
 #endif
-#if defined(__CUDA_ARCH__) || defined(__HIP_ARCH__) || defined(__HIP__)
-    __host__ __device__
+#if (defined(__CUDA_ARCH__) && !(defined(__clang__) && defined(__CUDA__))) || \
+    defined(__HIP_ARCH__) || defined(__HIP__)
+__host__ __device__
 #endif // __CUDA_ARCH__
-  void __assert_fail(const char *assertion, const char *file,
-                unsigned int line, const char *function)
-                throw();
+    void
+    __assert_fail(
+        const char* assertion,
+        const char* file,
+        unsigned int line,
+        const char* function) throw();
 }
 #endif // NDEBUG
 #define CUDA_ALWAYS_ASSERT(cond)                                         \


### PR DESCRIPTION
Summary: It appears that when Clang drives CUDA compilation ` __assert_fail` is always defined.

Test Plan:
```lang=bash
buck build mode/opt -c fbcode.cuda_use_clang=true -c cxx.untracked_headers=ignore //fblearner/flow/projects/dper:workflow
```

Differential Revision: D20145034

