### PR TITLE
Throw an error if nbytes is called on a sparse tensor.

### DIFF
--- a/aten/src/ATen/templates/TensorBody.h
+++ b/aten/src/ATen/templates/TensorBody.h
@@ -227,7 +227,10 @@ class CAFFE2_API Tensor {
   // it reports the memory the tensor would take *if* it were contiguous.
   // Defined to be numel() * itemsize()
   size_t nbytes() const {
-    return impl_->numel() * impl_->itemsize();
+    AT_CHECK(layout () != at::kSparse,
+             "nbytes is not defined for sparse tensors.  If you want the size of the constituent " \
+             "tensors, add the nbytes of the indices and values.  If you want the size of the  " \
+             "equivalent dense tensor, multiply numel() by element_size()");
   }
 
   int64_t numel() const {

--- a/aten/src/ATen/test/basic.cpp
+++ b/aten/src/ATen/test/basic.cpp
@@ -3,6 +3,7 @@
 #include <ATen/ATen.h>
 #include <ATen/core/Reduction.h>
 #include <torch/cuda.h>
+#include "test_assert.h"
 
 // for TH compat test only...
 struct THFloatTensor;
@@ -405,6 +406,7 @@ TEST(BasicTest, FactoryMethodsTest) {
     ASSERT_EQ(tensor1.dtype(), at::kHalf);
     ASSERT_EQ(tensor1.layout(), at::kSparse);
     ASSERT_TRUE(tensor1.device().is_cuda());
+    ASSERT_THROWS(tensor1.nbytes());
 
     // This is a bug
     // Issue https://github.com/pytorch/pytorch/issues/30405


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#33894 Throw an error if nbytes is called on a sparse tensor.**

