### PR TITLE
.circleci: Remove trailing slash, fix conda upload

### DIFF
--- a/.circleci/scripts/binary_linux_upload.sh
+++ b/.circleci/scripts/binary_linux_upload.sh
@@ -14,12 +14,16 @@ export PATH="$MINICONDA_ROOT/bin:$PATH"
 
 # This gets set in binary_populate_env.sh, but lets have a sane default just in case
 PIP_UPLOAD_FOLDER=${PIP_UPLOAD_FOLDER:-nightly}
+# TODO: Combine CONDA_UPLOAD_CHANNEL and PIP_UPLOAD_FOLDER into one variable
+#       The only difference is the trailing slash
+# Strip trailing slashes if there
+CONDA_UPLOAD_CHANNEL=$(echo "${PIP_UPLOAD_FOLDER}" | sed 's:/*$::')
 
 # Upload the package to the final location
 pushd /home/circleci/project/final_pkgs
 if [[ "$PACKAGE_TYPE" == conda ]]; then
   retry conda install -yq anaconda-client
-  anaconda -t "${CONDA_PYTORCHBOT_TOKEN}" upload  "$(ls)" -u "pytorch-${PIP_UPLOAD_FOLDER}" --label main --no-progress --force
+  anaconda -t "${CONDA_PYTORCHBOT_TOKEN}" upload  "$(ls)" -u "pytorch-${CONDA_UPLOAD_CHANNEL}" --label main --no-progress --force
 elif [[ "$PACKAGE_TYPE" == libtorch ]]; then
   retry pip install -q awscli
   s3_dir="s3://pytorch/libtorch/${PIP_UPLOAD_FOLDER}${DESIRED_CUDA}/"

--- a/.circleci/scripts/binary_macos_upload.sh
+++ b/.circleci/scripts/binary_macos_upload.sh
@@ -15,11 +15,15 @@ export "PATH=$workdir/miniconda/bin:$PATH"
 
 # This gets set in binary_populate_env.sh, but lets have a sane default just in case
 PIP_UPLOAD_FOLDER=${PIP_UPLOAD_FOLDER:-nightly}
+# TODO: Combine CONDA_UPLOAD_CHANNEL and PIP_UPLOAD_FOLDER into one variable
+#       The only difference is the trailing slash
+# Strip trailing slashes if there
+CONDA_UPLOAD_CHANNEL=$(echo "${PIP_UPLOAD_FOLDER}" | sed 's:/*$::')
 
 pushd "$workdir/final_pkgs"
 if [[ "$PACKAGE_TYPE" == conda ]]; then
   retry conda install -yq anaconda-client
-  retry anaconda -t "${CONDA_PYTORCHBOT_TOKEN}" upload "$(ls)" -u "pytorch-${PIP_UPLOAD_FOLDER}" --label main --no-progress --force
+  retry anaconda -t "${CONDA_PYTORCHBOT_TOKEN}" upload "$(ls)" -u "pytorch-${CONDA_UPLOAD_CHANNEL}" --label main --no-progress --force
 elif [[ "$PACKAGE_TYPE" == libtorch ]]; then
   retry pip install -q awscli
   s3_dir="s3://pytorch/libtorch/${PIP_UPLOAD_FOLDER}${DESIRED_CUDA}/"


### PR DESCRIPTION
Conda registers a suffixed slash as a new user so it was failing to
upload the anaconda packages.

In the future this should be handled through a single variable that can
be used for both but until then this will have to do.

Bug was introduced in #33842 

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

