### PR TITLE
fix handling of replica parameters in DataParallel

### DIFF
--- a/test/distributed/test_data_parallel.py
+++ b/test/distributed/test_data_parallel.py
@@ -52,7 +52,7 @@ class TestDataParallel(TestCase):
                 return self.rnn(x)
 
         def step(model):
-            opt = torch.optim.SGD(model.parameters(), lr=0.1)
+            opt = torch.optim.SGD(model.parameters(), lr=10)
             input = torch.ones(4, 4, 300).to(0)
             output = model(input)
             loss = F.mse_loss(output[0], torch.zeros_like(output[0]))
@@ -71,7 +71,7 @@ class TestDataParallel(TestCase):
         step(model_dp)
 
         for p1, p2 in zip(model.parameters(), model_dp.parameters()):
-            p1.allclose(p2)
+            self.assertTrue(p1.allclose(p2))
 
     @unittest.skipIf(not TEST_MULTIGPU, "multi-GPU not supported")
     def test_parallel_apply(self):

--- a/torch/nn/parallel/replicate.py
+++ b/torch/nn/parallel/replicate.py
@@ -144,7 +144,10 @@ def replicate(network, devices, detach=False):
                     param = param_copies[j][param_idx]
                     # parameters in replicas are no longer leaves, so remove them from _parameters
                     # and setattr them as non-parameter attributes
-                    del replica._parameters[key]
+                    # scripted modules don't allow deleting parameters, but also don't complain
+                    # on assigning non-Parameter type
+                    if (not _is_script_module(replica)):
+                        del replica._parameters[key]
                     setattr(replica, key, param)
         for key, buf in module._buffers.items():
             if buf is None:

--- a/torch/nn/parallel/replicate.py
+++ b/torch/nn/parallel/replicate.py
@@ -143,12 +143,10 @@ def replicate(network, devices, detach=False):
                 for j in range(num_replicas):
                     replica = module_copies[j][i]
                     param = param_copies[j][param_idx]
-                    setattr(replica, key, Parameter(param, requires_grad=param.requires_grad))
-                    # TODO: We need to manually set _parameters with a bare
-                    # non-parameter Tensor, otherwise gradients don't
-                    # accumulate in the original parameters when you call
-                    # backwards() on the DataParallel module.
-                    replica._parameters[key] = param
+                    # parameters in replicas are no longer leaves, so remove them from _parameters
+                    # and setattr them as non-parameter attributes
+                    del replica._parameters[key]
+                    setattr(replica, key, param)
         for key, buf in module._buffers.items():
             if buf is None:
                 for j in range(num_replicas):

--- a/torch/nn/parallel/replicate.py
+++ b/torch/nn/parallel/replicate.py
@@ -1,7 +1,6 @@
 import torch
 import torch.cuda.comm as comm
 from torch.cuda._utils import _get_device_index
-from torch.nn import Parameter
 
 
 def _is_script_module(module):


### PR DESCRIPTION
In DataParallel, replica parameters are not leaves (because they are computed via broadcast from master parameters), and should be treated as such. Fixes #33552