### PR TITLE
[ATen] Remove `AT_ASSERTM` from Blob::free_()

### DIFF
--- a/aten/src/ATen/core/blob.h
+++ b/aten/src/ATen/core/blob.h
@@ -69,7 +69,7 @@ class CAFFE2_API Blob final : public c10::intrusive_ptr_target {
   // TODO(jerryzh): add a Get(DeviceType) function?
   template <class T>
   const T& Get() const {
-    AT_ASSERTM(
+    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
         IsType<T>(),
         "wrong type for the Blob instance. Blob contains ",
         meta_.name(),
@@ -155,11 +155,10 @@ class CAFFE2_API Blob final : public c10::intrusive_ptr_target {
         TypeMeta::Make<typename std::remove_const<T>::type>()));
   }
 
-  // TODO Remove ShareExternal() and have Blob always own its content
   void* ShareExternal(void* allocated, const TypeMeta& meta) {
     free_();
     meta_ = meta;
-    pointer_ = static_cast<void*>(allocated);
+    pointer_ = allocated;
     has_ownership_ = false;
     return allocated;
   }
@@ -186,15 +185,14 @@ class CAFFE2_API Blob final : public c10::intrusive_ptr_target {
 
  private:
   void free_() {
-    if (has_ownership_) {
-      AT_ASSERTM(pointer_ != nullptr, "Can't have ownership of nullptr");
+    if (has_ownership_ && pointer_ != nullptr) {
       (*meta_.deleteFn())(pointer_);
     }
   }
 
   TypeMeta meta_;
-  void* pointer_ = nullptr;
-  bool has_ownership_ = false;
+  void* pointer_;
+  bool has_ownership_;
 
   C10_DISABLE_COPY_AND_ASSIGN(Blob);
 };


### PR DESCRIPTION
Summary:
`Blob::~Blob()` calls `Blob::free_()`. `Blob::free_()` throws and destructors should not throw.

A few other minor tweaks include:
- Move `static_assert(std::is_default_constructible<T>::value)` into the `else` branch.
- Remove `static_cast<void*>()` in `ShareExternal`

Test Plan:
```
buck test caffe2/caffe2:caffe2_test_cpu
```

Differential Revision: D19153199

