### PR TITLE
Show errors from the tasks in the thread pool

### DIFF
--- a/c10/core/thread_pool.cpp
+++ b/c10/core/thread_pool.cpp
@@ -1,5 +1,7 @@
 #include <c10/core/thread_pool.h>
 
+#include <c10/util/Logging.h>
+
 namespace c10 {
 
 ThreadPool::ThreadPool(
@@ -108,7 +110,10 @@ void ThreadPool::main_loop(std::size_t index) {
         } else {
           tasks.no_id();
         }
-      } catch (const std::exception&) {
+      } catch (const std::exception& e) {
+        C10_LOG_EVERY_MS(ERROR, 1000) << "Exception in thread pool task: " << e.what();
+      } catch (...) {
+        C10_LOG_EVERY_MS(ERROR, 1000) << "Exception in thread pool task: unknown";
       }
 
       // Update status of empty, maybe

--- a/c10/core/thread_pool.cpp
+++ b/c10/core/thread_pool.cpp
@@ -1,7 +1,5 @@
 #include <c10/core/thread_pool.h>
 
-#include <c10/util/Logging.h>
-
 namespace c10 {
 
 ThreadPool::ThreadPool(
@@ -111,9 +109,9 @@ void ThreadPool::main_loop(std::size_t index) {
           tasks.no_id();
         }
       } catch (const std::exception& e) {
-        C10_LOG_EVERY_MS(ERROR, 1000) << "Exception in thread pool task: " << e.what();
+        LOG(ERROR) << "Exception in thread pool task: " << e.what();
       } catch (...) {
-        C10_LOG_EVERY_MS(ERROR, 1000) << "Exception in thread pool task: unknown";
+        LOG(ERROR) << "Exception in thread pool task: unknown";
       }
 
       // Update status of empty, maybe


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#33938 Show errors from the tasks in the thread pool**

Summary:
Making sure we don't silently ignore exceptions from the tasks in the
thread pool

Test Plan:
python setup.py clean && python setup.py develop install

Differential Revision: [D20178603](https://our.internmc.facebook.com/intern/diff/D20178603)