### PR TITLE
Fix SELECTED_OP_LIST file path issue

### DIFF
--- a/scripts/build_android.sh
+++ b/scripts/build_android.sh
@@ -51,7 +51,6 @@ echo "Android NDK version: $ANDROID_NDK_VERSION"
 BUILD_ROOT=${BUILD_ROOT:-"$CAFFE2_ROOT/build_android"}
 INSTALL_PREFIX=${BUILD_ROOT}/install
 mkdir -p $BUILD_ROOT
-cd $BUILD_ROOT
 
 CMAKE_ARGS=()
 
@@ -63,6 +62,12 @@ if [ -n "${BUILD_PYTORCH_MOBILE:-}" ]; then
   CMAKE_ARGS+=("-DBUILD_CUSTOM_PROTOBUF=OFF")
   # custom build with selected ops
   if [ -n "${SELECTED_OP_LIST}" ]; then
+    SELECTED_OP_LIST="$(cd $(dirname $SELECTED_OP_LIST); pwd -P)/$(basename $SELECTED_OP_LIST)"
+    echo "Choose OP_LIST file: $SELECTED_OP_LIST"
+    if [ ! -r ${SELECTED_OP_LIST} ]; then
+      echo "Error: OP_LIST file ${SELECTED_OP_LIST} not found."
+      exit 1
+    fi
     CMAKE_ARGS+=("-DSELECTED_OP_LIST=${SELECTED_OP_LIST}")
   fi
 else
@@ -118,6 +123,7 @@ fi
 # Use-specified CMake arguments go last to allow overridding defaults
 CMAKE_ARGS+=($@)
 
+cd $BUILD_ROOT
 cmake "$CAFFE2_ROOT" \
     -DCMAKE_INSTALL_PREFIX=$INSTALL_PREFIX \
     -DCMAKE_BUILD_TYPE=Release \

--- a/scripts/build_ios.sh
+++ b/scripts/build_ios.sh
@@ -13,7 +13,6 @@ CAFFE2_ROOT="$( cd "$(dirname "$0")"/.. ; pwd -P)"
 BUILD_ROOT=${BUILD_ROOT:-"$CAFFE2_ROOT/build_ios"}
 INSTALL_PREFIX=${BUILD_ROOT}/install
 mkdir -p $BUILD_ROOT
-cd $BUILD_ROOT
 
 CMAKE_ARGS=()
 
@@ -25,6 +24,12 @@ if [ -n "${BUILD_PYTORCH_MOBILE:-}" ]; then
   CMAKE_ARGS+=("-DBUILD_CUSTOM_PROTOBUF=OFF")
   # custom build with selected ops
   if [ -n "${SELECTED_OP_LIST}" ]; then
+    SELECTED_OP_LIST="$(cd $(dirname $SELECTED_OP_LIST); pwd -P)/$(basename $SELECTED_OP_LIST)"
+    echo "Choose OP_LIST file: $SELECTED_OP_LIST"
+    if [ ! -r ${SELECTED_OP_LIST} ]; then
+      echo "Error: OP_LIST file ${SELECTED_OP_LIST} not found."
+      exit 1
+    fi
     CMAKE_ARGS+=("-DSELECTED_OP_LIST=${SELECTED_OP_LIST}")
   fi
   # bitcode
@@ -104,6 +109,7 @@ if [ "${VERBOSE:-}" == '1' ]; then
   CMAKE_ARGS+=("-DCMAKE_VERBOSE_MAKEFILE=1")
 fi
 
+cd $BUILD_ROOT
 cmake "$CAFFE2_ROOT" \
     -DCMAKE_INSTALL_PREFIX=$INSTALL_PREFIX \
     -DCMAKE_BUILD_TYPE=MinSizeRel \

--- a/scripts/build_mobile.sh
+++ b/scripts/build_mobile.sh
@@ -18,7 +18,6 @@ echo "Caffe2 path: $CAFFE2_ROOT"
 BUILD_ROOT=${BUILD_ROOT:-"$CAFFE2_ROOT/build_mobile"}
 INSTALL_PREFIX=${BUILD_ROOT}/install
 mkdir -p $BUILD_ROOT
-cd $BUILD_ROOT
 
 CMAKE_ARGS=()
 CMAKE_ARGS+=("-DBUILD_CAFFE2_MOBILE=OFF")
@@ -29,6 +28,12 @@ CMAKE_ARGS+=("-DBUILD_CUSTOM_PROTOBUF=OFF")
 CMAKE_ARGS+=("-DBUILD_SHARED_LIBS=OFF")
 # custom build with selected ops
 if [ -n "${SELECTED_OP_LIST}" ]; then
+  SELECTED_OP_LIST="$(cd $(dirname $SELECTED_OP_LIST); pwd -P)/$(basename $SELECTED_OP_LIST)"
+  echo "Choose OP_LIST file: $SELECTED_OP_LIST"
+  if [ ! -r ${SELECTED_OP_LIST} ]; then
+    echo "Error: OP_LIST file ${SELECTED_OP_LIST} not found."
+    exit 1
+  fi
   CMAKE_ARGS+=("-DSELECTED_OP_LIST=${SELECTED_OP_LIST}")
 fi
 
@@ -54,6 +59,7 @@ fi
 # Use-specified CMake arguments go last to allow overridding defaults
 CMAKE_ARGS+=("$@")
 
+cd $BUILD_ROOT
 cmake "$CAFFE2_ROOT" \
     -DCMAKE_INSTALL_PREFIX=$INSTALL_PREFIX \
     -DCMAKE_BUILD_TYPE=Release \


### PR DESCRIPTION
If SELECTED_OP_LIST is specified as a relative path in command line, CMake build will fail.