### PR TITLE
Check fuser results when profiling

### DIFF
--- a/test/test_jit_fuser.py
+++ b/test/test_jit_fuser.py
@@ -64,14 +64,12 @@ class TestFuser(JitTestCase):
         self.assertTrue([node.kind() for node in graph.nodes()].count('prim::FusionGroup') == 1)
 
     def _test_fused_abs(self, device='cpu'):
-
-        @torch.jit.script
         def func(x):
             return x.abs() * 2
 
         a = torch.randn(5, device=device)
-        self.assertEqual(func(a), a.abs() * 2)
-        self.assertAllFused(func.graph_for(a))
+        scripted = self.checkScript(func, (a,))
+        self.assertAllFused(scripted.graph_for(a))
 
     @unittest.skipIf(IS_SANDCASTLE, "NYI: fuser CPU support for Sandcastle")
     @enable_cpu_fuser
@@ -162,7 +160,6 @@ class TestFuser(JitTestCase):
         # We shouldn't treat cat nodes as broadcasting. All their inputs
         # need to be checked for having the same map size, before we can
         # run the kernel.
-        @torch.jit.script
         def f(x, y):
             return torch.cat([x + 2 * x + x ** 2, y + 4 * y + y ** 3], dim=0)
 
@@ -171,8 +168,8 @@ class TestFuser(JitTestCase):
         x = torch.randn(2, 4, dtype=torch.float, device='cuda')
         y = torch.randn(1, 4, dtype=torch.float, device='cuda')
 
-        self.assertEqual(f(x, y).shape, (3, 4))
-        self.assertAllFused(f.graph_for(x, y))
+        scripted = self.checkScript(f, (x, y))
+        self.assertAllFused(scripted.graph_for(x, y))
 
     @unittest.skipIf(not RUN_CUDA, "No CUDA")
     def test_chunk_cuda(self):
@@ -522,9 +519,7 @@ class TestFuser(JitTestCase):
             return torch.threshold(x, 0, -10) + x + x + x
 
         x = torch.tensor([-1, -0.5, 0, 1, 2, 3], device='cuda')
-        scripted = torch.jit.script(f)
-
-        self.assertEqual(f(x), scripted(x))
+        scripted = self.checkScript(f, (x,))
         self.assertAllFused(scripted.graph_for(x))
 
     @unittest.skipIf(not RUN_CUDA, "fuser requires CUDA")
@@ -535,8 +530,7 @@ class TestFuser(JitTestCase):
 
         x = torch.randn(4, 4, dtype=torch.float, device='cuda')
         p = 3
-        scripted = torch.jit.script(fn_test_scalar_arg, (x, p))
-        self.assertEqual(fn_test_scalar_arg(x, p), scripted(x, p))
+        scripted = self.checkScript(fn_test_scalar_arg, (x, p))
         self.assertAllFused(scripted.graph_for(x, p))
 
         x.requires_grad_(True)
@@ -894,15 +888,10 @@ class TestFuser(JitTestCase):
             res = torch.where(mask, x, y)
             return mask, res
 
-        script_f = torch.jit.script(f)
-
         x = torch.randn(4, 4, dtype=torch.double)
         y = torch.randn(4, 4, dtype=torch.double)
 
-        result1, result2 = script_f(x, y)
-        expected1, expected2 = f(x, y)
-        self.assertEqual(result1, expected1)
-        self.assertEqual(result2, expected2)
+        script_f = self.checkScript(f, (x, y))
         self.assertAllFused(script_f.graph_for(x, y), except_for={'prim::TupleConstruct'})
 
     @unittest.skipIf(not RUN_CUDA, "fuser requires CUDA")


### PR DESCRIPTION
With the profiling executor enabled the fuser won't be invoked until the second pass over a script function, so some of these tests weren't correctly comparing the fused output with the interpreter output.  I've used the `checkScript` method where applicable, which seems to do the right thing.

Test Plan:
Locally inject obvious errors into the fuser and verify that the updated tests fail when they're supposed to.