### PR TITLE
Use clog from cpuinfo/deps instead of downloading

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -248,6 +248,11 @@ if (USE_NNPACK OR USE_QNNPACK OR USE_PYTORCH_QNNPACK OR USE_XNNPACK)
     if (NOT DEFINED PTHREADPOOL_SOURCE_DIR)
       set(PTHREADPOOL_SOURCE_DIR "${CAFFE2_THIRD_PARTY_ROOT}/pthreadpool" CACHE STRING "pthreadpool source directory")
     endif()
+    if (NOT DEFINED CLOG_SOURCE_DIR)
+      # XNNPACK gets clog from inside the cpuinfo repository,
+      # so lets just do the same for now.
+      set(CLOG_SOURCE_DIR "${CAFFE2_THIRD_PARTY_ROOT}/cpuinfo/deps/clog" CACHE STRING "cpuinfo source directory")
+    endif()
 
     set(CPUINFO_LIBRARY_TYPE "static" CACHE STRING "")
     set(CPUINFO_LOG_LEVEL "error" CACHE STRING "")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#33947 Use clog from cpuinfo/deps instead of downloading**

Summary:
XNNPACK was downloading clog because we weren't setting CLOG_SOURCE_DIR.
Actually, it was downloading cpuinfo and pointing to the copy of clog
within that.  So let's just point to the copy of clog within the cpuinfo
submodule we already have.

Test Plan:
Ran cmake and didn't see any downloading.
Verified that our clog is the same as the one that was being downloaded
with `diff -Naur`.

Differential Revision: [D20169656](https://our.internmc.facebook.com/intern/diff/D20169656)