### PR TITLE
prevent crash on exit from static destructor race

### DIFF
--- a/c10/util/Logging.cpp
+++ b/c10/util/Logging.cpp
@@ -92,13 +92,20 @@ void SetAPIUsageLogger(std::function<void(const std::string&)> logger) {
   *GetAPIUsageLogger() = logger;
 }
 
-void LogAPIUsage(const std::string& event) {
-  (*GetAPIUsageLogger())(event);
+void LogAPIUsage(const std::string& event) try {
+  if (auto logger = GetAPIUsageLogger())
+    (*logger)(event);
+} catch (std::bad_function_call&) {
+  // static destructor race
 }
 
 namespace detail {
-bool LogAPIUsageFakeReturn(const std::string& event) {
-  (*GetAPIUsageLogger())(event);
+bool LogAPIUsageFakeReturn(const std::string& event) try {
+  if (auto logger = GetAPIUsageLogger())
+    (*logger)(event);
+  return true;
+} catch (std::bad_function_call&) {
+  // static destructor race
   return true;
 }
 } // namespace detail


### PR DESCRIPTION
Summary: unit tests on windows (clang and cl) were crashing on exit due to racing with static variable destruction.

Test Plan: CI green

Differential Revision: D20153587

