### PR TITLE
clang intrinsics targeting

### DIFF
--- a/aten/src/ATen/cpu/vec256/intrinsics.h
+++ b/aten/src/ATen/cpu/vec256/intrinsics.h
@@ -1,6 +1,8 @@
 #pragma once
-
-#if defined(_MSC_VER)
+#if defined(__clang__) && (defined(__x86_64__) || defined(__i386__))
+/* Clang-compatible compiler, targeting x86/x86-64 */
+#include <x86intrin.h>
+#elif defined(_MSC_VER)
 /* Microsoft C/C++-compatible compiler */
 #include <intrin.h>
 #if _MSC_VER <= 1900

--- a/aten/src/ATen/native/cpu/Intrinsics.h
+++ b/aten/src/ATen/native/cpu/Intrinsics.h
@@ -1,6 +1,9 @@
 #pragma once
 
-#if defined(_MSC_VER)
+#if defined(__clang__) && (defined(__x86_64__) || defined(__i386__))
+/* Clang-compatible compiler, targeting x86/x86-64 */
+#include <x86intrin.h>
+#elif defined(_MSC_VER)
 /* Microsoft C/C++-compatible compiler */
 #include <intrin.h>
 #if _MSC_VER <= 1900


### PR DESCRIPTION
Summary: look for clang intrinsic headers on windows

Test Plan: CI green

Differential Revision: D20153573

