### PR TITLE
fix windows clang attributes

### DIFF
--- a/caffe2/core/common.h
+++ b/caffe2/core/common.h
@@ -54,8 +54,8 @@ using std::vector;
 #define CAFFE_NOT_IMPLEMENTED CAFFE_THROW("Not Implemented.")
 
 // suppress an unused variable.
-#ifdef _MSC_VER
-#define CAFFE2_UNUSED
+#if defined(_MSC_VER) && !defined(__clang__)
+#define CAFFE2_UNUSED __pragma(warning(suppress : 4100 4101))
 #define CAFFE2_USED
 #else
 #define CAFFE2_UNUSED __attribute__((__unused__))
@@ -63,7 +63,7 @@ using std::vector;
 #endif //_MSC_VER
 
 // Define alignment macro that is cross platform
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && !defined(__clang__)
 #define CAFFE2_ALIGNED(x) __declspec(align(x))
 #else
 #define CAFFE2_ALIGNED(x) __attribute__((aligned(x)))
@@ -132,11 +132,11 @@ namespace internal {
 // Caffe2 core that cuda runtime has been loaded.
 CAFFE2_API void SetCudaRuntimeFlag();
 CAFFE2_API void SetHipRuntimeFlag();
-}
+} // namespace internal
 // Returns which setting Caffe2 was configured and built with (exported from
 // CMake)
 CAFFE2_API const std::map<string, string>& GetBuildOptions();
 
 } // namespace caffe2
 
-#endif  // CAFFE2_CORE_COMMON_H_
+#endif // CAFFE2_CORE_COMMON_H_


### PR DESCRIPTION
Summary:
make sure clang on windows uses correct attributes.
add support for cl.exe style pragma attributes

Test Plan: CI green

Differential Revision: D20153548

