### PR TITLE
Throw an exception when method cannot be found from mobile module.

### DIFF
--- a/test/cpp/jit/test_lite_interpreter.cpp
+++ b/test/cpp/jit/test_lite_interpreter.cpp
@@ -190,5 +190,22 @@ void testLiteInterpreterLoadOrigJit() {
   ASSERT_THROWS_WITH(_load_for_mobile(ss), "file not found");
 }
 
+void testLiteInterpreterWrongMethodName() {
+  script::Module m("m");
+  m.register_parameter("foo", torch::ones({}), false);
+  m.define(R"(
+    def add(self, x):
+      b = 4
+      return self.foo + x + b
+  )");
+  std::stringstream ss;
+  m._save_for_mobile(ss);
+  mobile::Module bc = _load_for_mobile(ss);
+  std::vector<IValue> inputs;
+  auto minput = 5 * torch::ones({});
+  inputs.emplace_back(minput);
+  ASSERT_THROWS_WITH(bc.run_method("forward", inputs), "is not defined");
+}
+
 } // namespace jit
 } // namespace torch

--- a/test/cpp/jit/tests.h
+++ b/test/cpp/jit/tests.h
@@ -83,7 +83,8 @@ namespace jit {
   _(AutogradSymbols)                   \
   _(MobileTypeParser)                  \
   _(LiteInterpreterPrim)               \
-  _(LiteInterpreterLoadOrigJit)
+  _(LiteInterpreterLoadOrigJit)        \
+  _(LiteInterpreterWrongMethodName)
 
 #define TH_FORALL_TESTS_CUDA(_) \
   _(ArgumentSpec)               \

--- a/torch/csrc/jit/mobile/module.cpp
+++ b/torch/csrc/jit/mobile/module.cpp
@@ -49,7 +49,7 @@ Function* Module::find_method(const std::string& basename) const {
       return fn.get();
     }
   }
-  return nullptr;
+  AT_ERROR("Method '", basename, "' is not defined.");
 }
 
 } // namespace mobile


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#33972 Throw an exception when method cannot be found from mobile module.**

Differential Revision: [D20168965](https://our.internmc.facebook.com/intern/diff/D20168965)

Throw exception when a method is not found in mobile module. 
1. Better exit and error control.
2. Consistent to jit::Module. 

Thanks @dreiss for pointing this bug out!