### PR TITLE
[pytorch] update code analyzer script to cover new c10::Module::def API

### DIFF
--- a/test/mobile/op_deps/simple_ops.cpp
+++ b/test/mobile/op_deps/simple_ops.cpp
@@ -62,35 +62,26 @@ Tensor FF_op(const Tensor& self) {
 
 namespace {
 
-auto registerer = torch::RegisterOperators()
-  .op(torch::RegisterOperators::options()
-    .schema("aten::AA(Tensor self) -> Tensor")
-    .kernel<decltype(AA_op), &AA_op>(DispatchKey::CPUTensorId))
-  .op(torch::RegisterOperators::options()
-    .schema("aten::BB(Tensor self) -> Tensor")
-    .catchAllKernel<decltype(BB_op), &BB_op>())
-  .op(torch::RegisterOperators::options()
-    .schema("aten::CC(Tensor self) -> Tensor")
-    .kernel(DispatchKey::CPUTensorId, &CC_op))
-  .op(torch::RegisterOperators::options()
-    .schema("aten::DD(Tensor self) -> Tensor")
-    .catchAllKernel(&DD_op))
-  .op(torch::RegisterOperators::options()
-    .schema("aten::EE(Tensor self) -> Tensor")
-    .impl_unboxedOnlyKernel<decltype(EE_op), &EE_op>(DispatchKey::CPUTensorId))
-  .op(torch::RegisterOperators::options()
-    .schema("aten::FF(Tensor self) -> Tensor")
-    .impl_unboxedOnlyCatchAllKernel<decltype(FF_op), &FF_op>())
-  .op(torch::RegisterOperators::options()
-    .schema("aten::GG(Tensor self) -> Tensor")
-    .kernel(DispatchKey::CPUTensorId, [] (Tensor a) -> Tensor {
+auto registerer = torch::import()
+  .def("aten::AA(Tensor self) -> Tensor",
+    torch::dispatch(DispatchKey::CPUTensorId, &AA_op))
+  .def("aten::BB(Tensor self) -> Tensor", &BB_op)
+  .impl("aten::CC(Tensor self) -> Tensor",
+    torch::dispatch(DispatchKey::CPUTensorId, &CC_op))
+  .impl("aten::DD(Tensor self) -> Tensor", &DD_op)
+  .def("aten::EE(Tensor self) -> Tensor", torch::dispatch(
+    DispatchKey::CPUTensorId,
+    CppFunction::makeUnboxedOnly(EE_op)))
+  .def("aten::FF(Tensor self) -> Tensor",
+    CppFunction::makeUnboxedOnly(FF_op))
+  .impl("aten::GG(Tensor self) -> Tensor", torch::dispatch(
+    DispatchKey::CPUTensorId, [] (Tensor a) -> Tensor {
       return call_FF_op(a);
     }))
-  .op(torch::RegisterOperators::options()
-    .schema("aten::HH(Tensor self) -> Tensor")
-    .catchAllKernel([] (Tensor a) -> Tensor {
+  .impl("aten::HH(Tensor self) -> Tensor",
+    [] (Tensor a) -> Tensor {
       return a;
-    }));
+    });
 
 } // namespace
 

--- a/tools/code_analyzer/run_analyzer.sh
+++ b/tools/code_analyzer/run_analyzer.sh
@@ -10,7 +10,7 @@ echo "Analyze: ${INPUT}"
 
 "${ANALYZER_BIN}" \
   -op_schema_pattern="^(_aten|_prim|aten|quantized|profiler|_test)::[^ ]+" \
-  -op_register_pattern="c10::RegisterOperators::(op|checkSchemaAndRegisterOp_)" \
+  -op_register_pattern="c10::RegisterOperators::(op|checkSchemaAndRegisterOp_)|c10::Module::(def|impl)" \
   -op_invoke_pattern="c10::Dispatcher::findSchema|callOp" \
   -format="${FORMAT}" \
   ${EXTRA_ANALYZER_FLAGS} \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#33975 [pytorch] update code analyzer script to cover new c10::Module::def API**

Summary:
Currently the code analysis script doesn't go beyond the scope of the
registration API call, i.e. calling registration via a wrapper will not
be covered by the analysis - currently the new API is essentially a
wrapper around old API.

Simply adding the new API signature to the registration API pattern can
solve the problem for now. We might need change the analyzer code if
things change significantly in the future.

Test Plan:
- update test project to use the new API;
- run analyzer against pytorch codebase;

Differential Revision: [D20169549](https://our.internmc.facebook.com/intern/diff/D20169549)