### PR TITLE
[caffe2] Remove python2 from operator_test

### DIFF
--- a/caffe2/python/rnn_cell.py
+++ b/caffe2/python/rnn_cell.py
@@ -1644,9 +1644,16 @@ class UnrolledCell(RNNCell):
                 axis=0)[0]
             for full_output in all_states
         ]
+        # Interleave the state values similar to
+        #
+        #   x = [1, 3, 5]
+        #   y = [2, 4, 6]
+        #   z = [val for pair in zip(x, y) for val in pair]
+        #   # z is [1, 2, 3, 4, 5, 6]
+        #
+        # and returns it as outputs
         outputs = tuple(
-            six.next(it) for it in
-            itertools.cycle([iter(all_states), iter(states)])
+            state for state_pair in zip(all_states, states) for state in state_pair
         )
         outputs_without_grad = set(range(len(outputs))) - set(
             outputs_with_grads)


### PR DESCRIPTION
Summary: Removing python2 from operator_test so we can retire python2 support for PyTorch.

Test Plan: waitforsandcastle

Differential Revision: D20129500

