### PR TITLE
Fix mobile build

### DIFF
--- a/tools/jit/templates/register_aten_ops.cpp
+++ b/tools/jit/templates/register_aten_ops.cpp
@@ -100,10 +100,10 @@ c10::OperatorOptions atenOperatorOptions() {
   return result;
 }
 
-int (*DUMMY_OPERATION)(Stack&) = [](Stack& stack) -> int {
-  TORCH_CHECK(false, "Operator has been stripped in the custom build.")
-  return 0;
-};
+KernelFunction::InternalBoxedKernelFunction *DUMMY_OPERATION =
+  [](c10::OperatorKernel *, const c10::OperatorHandle &, std::vector<c10::IValue> *) -> void {
+    TORCH_CHECK(false, "Operator has been stripped in the custom build.")
+  };
 
 class Registerer final {
 public:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#33985 Fix mobile build**
* #32521 Use codegen'ed unboxing wrappers
* #33732 Remove unnecessary tensor copies

This was broken by https://github.com/pytorch/pytorch/pull/32521 but only showed up in master CI builds

Differential Revision: [D20172782](https://our.internmc.facebook.com/intern/diff/D20172782/)