### PR TITLE
[resubmit] try to infer rref type from python

### DIFF
--- a/aten/src/ATen/core/ivalue.cpp
+++ b/aten/src/ATen/core/ivalue.cpp
@@ -48,7 +48,7 @@ TypePtr IValue::type() const {
     case Tag::Future:
       return toFuture()->type();
     case Tag::RRef:
-      return toRRef()->type();
+      return RRefType::create(toRRef()->type());
     case Tag::Device:
       return DeviceObjType::get();
     case Tag::Object:

--- a/torch/csrc/jit/python/pybind_utils.h
+++ b/torch/csrc/jit/python/pybind_utils.h
@@ -177,6 +177,11 @@ inline InferredType tryToInferType(py::handle input) {
   if (py::isinstance<script::Object>(input)) {
     auto object = py::cast<script::Object>(input);
     return InferredType(object.type());
+#ifdef USE_DISTRIBUTED
+  } else if (py::isinstance<torch::distributed::rpc::PyRRef>(input)) {
+    auto rref_ivalue = input.cast<torch::distributed::rpc::PyRRef>().toIValue();
+    return InferredType(rref_ivalue.type());
+#endif
   }
 
   // Try container types

--- a/torch/testing/_internal/distributed/rpc/jit/rpc_test.py
+++ b/torch/testing/_internal/distributed/rpc/jit/rpc_test.py
@@ -17,6 +17,23 @@ def one_arg(value):
     return value + 1
 
 
+class MyScriptModuleWithRRefs(torch.jit.ScriptModule):
+    def __init__(self, dst_worker):
+        super().__init__()
+        self.rrefs = []
+        for _ in range(4):
+            self.rrefs.append(rpc_return_rref(dst_worker))
+
+    @torch.jit.script_method
+    def forward(self):
+        # type: () -> Tensor
+        res_tensor = torch.ones(2, 2)
+        for rref in self.rrefs:
+            res_tensor += rref.to_here()
+
+        return res_tensor
+
+
 @torch.jit.script
 class MyScriptClass:
     def __init__(self):
@@ -204,6 +221,15 @@ class JitRpcTest(RpcAgentTestFixture):
 
         res = rref_tensor_is_owner(rref_var)
         self.assertEqual(res, False)
+
+    @dist_init
+    def test_my_script_module_with_rrefs(self):
+        n = self.rank + 1
+        dst_rank = n % self.world_size
+
+        module_with_rrefs = MyScriptModuleWithRRefs("worker{}".format(dst_rank))
+        res = module_with_rrefs()
+        self.assertEqual(res, torch.ones(2, 2) * 9)
 
     @dist_init
     def test_rref_python_annotation(self):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#33992 [resubmit] try to infer rref type from python**

resubmit of https://github.com/pytorch/pytorch/pull/33369 (reverted in https://github.com/pytorch/pytorch/pull/33920), with tweak on when the rref type being created to ensure ivalue->type() hold the correct RRef type inside of inner element type.

Differential Revision: [D20175043](https://our.internmc.facebook.com/intern/diff/D20175043)