### PR TITLE
Migrate Lerp from CUDA_tensor_apply4 to TensorIterator

### DIFF
--- a/aten/src/ATen/native/cuda/Lerp.cu
+++ b/aten/src/ATen/native/cuda/Lerp.cu
@@ -2,24 +2,32 @@
 #include <ATen/cuda/CUDAApplyUtils.cuh>
 #include <ATen/Dispatch.h>
 #include <ATen/ExpandUtils.h>
+#include <ATen/native/cuda/Loops.cuh>
+#include <ATen/native/TensorIterator.h>
 
 namespace {
-template <typename scalar_t>
-void lerp_cuda(at::Tensor& ret, const at::Tensor& self, const at::Tensor& end, const at::Tensor& weight) {
-  at::cuda::CUDA_tensor_apply4<scalar_t, scalar_t, scalar_t, scalar_t>(
-      ret, self, end, weight,
-      [] __device__(
-         scalar_t& ret_val,
-         const scalar_t& self_val,
-         const scalar_t& end_val,
-         const scalar_t& weight_val) {
-        ret_val = (weight_val < 0.5) ?
-            self_val + weight_val * (end_val - self_val) : end_val - (end_val - self_val) * (1 - weight_val);
+
+inline void lerp_cuda(at::Tensor& ret, const at::Tensor& self, const at::Tensor& end, const at::Tensor& weight) {
+  at::TensorIterator iter;
+  iter.add_output(ret);
+  iter.add_input(self);
+  iter.add_input(end);
+  iter.add_input(weight);
+  iter.build();
+  AT_DISPATCH_FLOATING_TYPES(iter.common_dtype(), "lerp_cuda", [&]{
+    at::native::gpu_kernel(iter,
+      [] GPU_LAMBDA (
+          scalar_t self_val,
+          scalar_t end_val,
+          scalar_t weight_val) -> scalar_t {
+          return (weight_val < 0.5) ?
+              self_val + weight_val * (end_val - self_val) : end_val - (end_val - self_val) * (1 - weight_val);
+        });
       });
 }
 
 template <typename scalar_t>
-void lerp_cuda(at::Tensor& ret, const at::Tensor& self, const at::Tensor& end, scalar_t weight_val) {
+void lerp_scalar_cuda(at::Tensor& ret, const at::Tensor& self, const at::Tensor& end, scalar_t weight_val) {
   at::cuda::CUDA_tensor_apply3<scalar_t, scalar_t, scalar_t>(
       ret, self, end,
       [=] __device__(
@@ -42,9 +50,7 @@ Tensor& lerp_cuda_tensor_out(Tensor& result, const Tensor& self,
            "weight should be of dimension max(self.dim(), end.dim()) or lesser");
   std::tie(b_self, b_end, b_weight) = expand_outplace(self, end, weight, "lerp_out_cuda");
   result.resize_as_(b_self);
-  AT_DISPATCH_FLOATING_TYPES(self.scalar_type(), "lerp_out_cuda", [&]{
-    lerp_cuda<scalar_t>(result, b_self, b_end, b_weight);
-  });
+  lerp_cuda(result, b_self, b_end, b_weight);
   return result;
 }
 
@@ -54,7 +60,7 @@ Tensor& lerp_cuda_scalar_out(Tensor& result, const Tensor& self,
   std::tie(b_self, b_end) = expand_outplace(self, end, "lerp_out_cuda");
   result.resize_as_(b_self);
   AT_DISPATCH_FLOATING_TYPES(self.scalar_type(), "lerp_out_cuda", [&]{
-    lerp_cuda<scalar_t>(result, b_self, b_end, weight.to<scalar_t>());
+    lerp_scalar_cuda<scalar_t>(result, b_self, b_end, weight.to<scalar_t>());
   });
   return result;
 }
@@ -67,9 +73,7 @@ Tensor& lerp_cuda_tensor_(Tensor& self, const Tensor& end, const Tensor& weight)
            " doesn't match the broadcast shape ", b_self.sizes());
   TORCH_CHECK(weight.dim() <= std::max(self.dim(), end.dim()),
            "weight should be of dimension max(self.dim(), end.dim()) or lesser");
-  AT_DISPATCH_FLOATING_TYPES(self.scalar_type(), "lerp__cuda", [&]{
-    lerp_cuda<scalar_t>(self, b_self, b_end, b_weight);
-  });
+  lerp_cuda(self, b_self, b_end, b_weight);
   return self;
 }
 
@@ -80,7 +84,7 @@ Tensor& lerp_cuda_scalar_(Tensor& self, const Tensor& end, Scalar weight) {
            "output with shape ", self.sizes(),
            " doesn't match the broadcast shape ", b_self.sizes());
   AT_DISPATCH_FLOATING_TYPES(self.scalar_type(), "lerp__cuda", [&]{
-    lerp_cuda<scalar_t>(self, b_self, b_end, weight.to<scalar_t>());
+    lerp_scalar_cuda<scalar_t>(self, b_self, b_end, weight.to<scalar_t>());
   });
   return self;
 }
@@ -91,9 +95,7 @@ Tensor lerp_cuda_tensor(const Tensor& self, const Tensor& end, const Tensor& wei
            "weight should be of dimension max(self.dim(), end.dim()) or lesser");
   std::tie(b_self, b_end, b_weight) = expand_outplace(self, end, weight, "lerp_cuda");
   Tensor result = at::empty_like(b_self, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
-  AT_DISPATCH_FLOATING_TYPES(self.scalar_type(), "lerp_cuda", [&]{
-    lerp_cuda<scalar_t>(result, b_self, b_end, b_weight);
-  });
+  lerp_cuda(result, b_self, b_end, b_weight);
   return result;
 }
 
@@ -102,7 +104,7 @@ Tensor lerp_cuda_scalar(const Tensor& self, const Tensor& end, Scalar weight) {
   std::tie(b_self, b_end) = expand_outplace(self, end, "lerp_cuda");
   Tensor result = at::empty_like(b_self, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
   AT_DISPATCH_FLOATING_TYPES(self.scalar_type(), "lerp_cuda", [&]{
-    lerp_cuda<scalar_t>(result, b_self, b_end, weight.to<scalar_t>());
+    lerp_scalar_cuda<scalar_t>(result, b_self, b_end, weight.to<scalar_t>());
   });
   return result;
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #33998 Kill CUDA_tensor_apply4
* #33997 Migrate prelu_cuda_backward from CUDA_tensor_apply4 to TensorIterator
* #33996 Migrate dirichlet_grad from CUDA_tensor_apply4 to TensorIterator
* #33995 Migrate binary_cross_entropy_backward from CUDA_tensor_apply4 to
* **#33994 Migrate Lerp from CUDA_tensor_apply4 to TensorIterator**

Differential Revision: [D20196788](https://our.internmc.facebook.com/intern/diff/D20196788)