### PR TITLE
Migrate prelu from CUDA_tensor_apply2 to TensorIterator

### DIFF
--- a/aten/src/ATen/native/cuda/Activation.cu
+++ b/aten/src/ATen/native/cuda/Activation.cu
@@ -24,15 +24,15 @@ void prelu_cuda_kernel_share_weights(
   const Tensor& input,
   Tensor& result,
   const scalar_t* weight_data) {
+  at::TensorIterator iter;
+  iter.add_output(result);
+  iter.add_input(input);
+  iter.build();
 
-  at::cuda::CUDA_tensor_apply2<scalar_t, scalar_t>(
-    input,
-    result,
-    [=] __device__ (
-      const scalar_t& input_val,
-      scalar_t& result_val) {
-        result_val = (input_val > 0) ? input_val : *weight_data * input_val;
-  });
+  at::native::gpu_kernel(iter,
+    [=] GPU_LAMBDA (scalar_t input_val) {
+        return (input_val > 0) ? input_val : *weight_data * input_val;
+    });
 }
 
 template <typename scalar_t>

--- a/aten/src/ATen/native/cuda/Activation.cu
+++ b/aten/src/ATen/native/cuda/Activation.cu
@@ -30,7 +30,7 @@ void prelu_cuda_kernel_share_weights(
   iter.build();
 
   at::native::gpu_kernel(iter,
-    [=] GPU_LAMBDA (scalar_t input_val) {
+    [weight_data] GPU_LAMBDA (scalar_t input_val) {
         return (input_val > 0) ? input_val : *weight_data * input_val;
     });
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #34007 Completely kill CUDA_tensor_apply2
* #34006 Migrate bernoulli from CUDA_tensor_apply2 to TensorIterator
* #34005 Migrate gamma from CUDA_tensor_apply2 to TensorIterator
* #34004 Migrate poisson from CUDA_tensor_apply2 to TensorIterator
* **#34003 Migrate prelu from CUDA_tensor_apply2 to TensorIterator**

Differential Revision: [D20196994](https://our.internmc.facebook.com/intern/diff/D20196994)