### PR TITLE
[aten] remove variable set but never used warning

### DIFF
--- a/aten/src/ATen/native/cuda/BatchLinearAlgebra.cu
+++ b/aten/src/ATen/native/cuda/BatchLinearAlgebra.cu
@@ -1397,7 +1397,6 @@ AT_ERROR("lu_solve: MAGMA library not found in "
 
   int info_tmp = 0;
   if (b.dim() == 2) {
-    magma_int_t info = 0;
     Tensor pivots_tmp = pivots.cpu();
     magmaLuSolve<scalar_t>(n, nrhs, lu_data, n, pivots_tmp.data_ptr<magma_int_t>(), b_data, n, &info_tmp);
     info = info_tmp;


### PR DESCRIPTION
Summary:
Remove warning
```
caffe2/aten/src/ATen/native/cuda/BatchLinearAlgebra.cu(1400): warning: variable "info" was set but never used
```

Test Plan: CI

Differential Revision: D20181160

