### PR TITLE
[c10] remove warning attribute does not apply to any entity

### DIFF
--- a/c10/util/Deprecated.h
+++ b/c10/util/Deprecated.h
@@ -51,7 +51,7 @@
 // technically [[deprecated]] syntax is from c++14 standard, but it works in
 // many compilers.
 #if defined(__has_cpp_attribute)
-#if __has_cpp_attribute(deprecated)
+#if __has_cpp_attribute(deprecated) && !defined(__CUDACC__)
 # define C10_DEFINE_DEPRECATED_USING(TypeName, TypeThingy) using TypeName [[deprecated]] = TypeThingy;
 #endif
 #endif


### PR DESCRIPTION
Summary:
Remove warning
```
caffe2/c10/util/ArrayRef.h(278): warning: attribute does not apply to any entity
```

Test Plan: CI

Differential Revision: D20181191

