### PR TITLE
Migrate gamma grad from CUDA_tensor_apply3 to TensorIterator

### DIFF
--- a/aten/src/ATen/native/Distributions.h
+++ b/aten/src/ATen/native/Distributions.h
@@ -177,7 +177,7 @@ C10_DEVICE static inline scalar_t digamma_one(scalar_t x) {
 // Computes the reparameterized gradient -(d/dalpha cdf(x;alpha)) / pdf(x;alpha)
 // for random number x drawn from a standard Gamma distribution Gamma(alpha).
 template <typename scalar_t, typename accscalar_t>
-C10_DEVICE scalar_t standard_gamma_grad_one(scalar_t alpha_, scalar_t x_) {
+C10_HOST_DEVICE scalar_t standard_gamma_grad_one(scalar_t alpha_, scalar_t x_) {
   // Use a Taylor series expansion for small x.
   accscalar_t x = static_cast<accscalar_t>(x_);
   accscalar_t alpha = static_cast<accscalar_t>(alpha_);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #34026 Completely kill CUDA_tensor_apply3
* #34025 Migrate lerp from CUDA_tensor_apply3 to TensorIterator
* #34024 Migrate dropout inference from CUDA_tensor_apply3 to TensorIterator
* #34023 Migrate bce loss from CUDA_tensor_apply3 to TensorIterator
* #34022 Migrate kl_div_backward from CUDA_tensor_apply3 to TensorIterator
* #34021 Migrate dirichlet from CUDA_tensor_apply3 to TensorIterator
* **#34020 Migrate gamma grad from CUDA_tensor_apply3 to TensorIterator**

Differential Revision: [D20196083](https://our.internmc.facebook.com/intern/diff/D20196083)