### PR TITLE
Migrate dropout inference from CUDA_tensor_apply3 to TensorIterator

### DIFF
--- a/aten/src/ATen/native/cuda/Dropout.cu
+++ b/aten/src/ATen/native/cuda/Dropout.cu
@@ -7,6 +7,8 @@
 #include <c10/macros/Macros.h>
 #include <curand_kernel.h>
 
+#include <ATen/native/TensorIterator.h>
+#include <ATen/native/cuda/Loops.cuh>
 #include <THC/THCGeneral.h>
 
 namespace at{
@@ -80,9 +82,19 @@ fused_dropout_kernel(cuda::detail::TensorInfo<scalar_t, IndexType> a,
 
 template<typename scalar_t, typename accscalar_t>
 void masked_scale_kernel(at::Tensor& ret, const at::Tensor src, const at::Tensor mask, accscalar_t scale){
-   at::cuda::CUDA_tensor_apply3<scalar_t, scalar_t, uint8_t>(ret, src, mask, [scale]__device__(scalar_t& ret_val, const scalar_t& src_val, const uint8_t mask_val){
-       ret_val = (float)mask_val * src_val * scale;
-  });
+  auto iter = at::TensorIterator();
+  iter.add_output(ret);
+  iter.add_input(src);
+  iter.add_input(mask);
+  iter.dont_compute_common_dtype();
+
+  iter.build();
+
+  at::native::gpu_kernel(
+      iter,
+      [=]GPU_LAMBDA(const scalar_t src_val, const uint8_t mask_val) -> scalar_t {
+         return (float)mask_val * src_val * scale;
+      });
 }
 } //anonymous namespace
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #34026 Completely kill CUDA_tensor_apply3
* #34025 Migrate lerp from CUDA_tensor_apply3 to TensorIterator
* **#34024 Migrate dropout inference from CUDA_tensor_apply3 to TensorIterator**
* #34023 Migrate bce loss from CUDA_tensor_apply3 to TensorIterator
* #34022 Migrate kl_div_backward from CUDA_tensor_apply3 to TensorIterator
* #34021 Migrate dirichlet from CUDA_tensor_apply3 to TensorIterator
* #34020 Migrate gamma grad from CUDA_tensor_apply3 to TensorIterator

Copied from https://github.com/pytorch/pytorch/pull/33879

Differential Revision: [D20196081](https://our.internmc.facebook.com/intern/diff/D20196081)