### PR TITLE
[autograd] fix allow_unused checking for C++ API

### DIFF
--- a/test/cpp/api/autograd.cpp
+++ b/test/cpp/api/autograd.cpp
@@ -121,6 +121,9 @@ TEST(AutogradAPITests, GradUnreachableTest) {
 
   ASSERT_VARIABLE_EQ(grad_res[0], x * 2);
   ASSERT_FALSE(grad_res[1].defined());
+
+  // allow_unused=False, but grads contains None inside, should throw
+  ASSERT_THROWS_WITH(grad({x * 2}, {x, y}, {}, {}, false, false), "Set allow_unused=True");
 }
 
 TEST(AutogradAPITests, RetainGrad) {

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -484,6 +484,11 @@ class TestAutograd(TestCase):
         self.assertEqual(grad_x, x * 2)
         self.assertIsNone(grad_z)
 
+        # allow_unused=False, but grads contains None inside, should throw
+        with self.assertRaisesRegex(RuntimeError,
+                                    "Set allow_unused=True"):
+            grad_x, grad_y = torch.autograd.grad(x * 2, [x, y], allow_unused=False)
+
     def test_hooks(self):
         x = torch.ones(5, 5, requires_grad=True)
         y = torch.ones(5, 5) * 4

--- a/torch/csrc/autograd/autograd.cpp
+++ b/torch/csrc/autograd/autograd.cpp
@@ -100,7 +100,7 @@ variable_list run_backward(
   variable_list grad_inputs = Engine::get_default_engine().execute(
       roots, grad_outputs, keep_graph, create_graph, output_edges);
   // check if grad_inputs contains None or not base on the allow_unused flag
-  if (inputs.empty()) {
+  if (!inputs.empty()) {
     size_t num_inputs = inputs.size();
     for (size_t i = 0; i < num_inputs; ++i) {
       TORCH_CHECK(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#34035 [autograd] fix allow_unused checking for C++ API**

Bug for the conditon check in https://github.com/pytorch/pytorch/pull/24342, realized we don't have tests in either
python or cpp to catch this, so added testes for both python and cpp.

Thanks @hczhu on capturing it!

Differential Revision: [D20198837](https://our.internmc.facebook.com/intern/diff/D20198837)