### PR TITLE
randn and normal_ for complex tensors

### DIFF
--- a/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
@@ -440,24 +440,60 @@ void normal_fill(Tensor& self, const scalar_t mean, const scalar_t std, Generato
   }
 }
 
+std::vector<int64_t> computeStrideForComplex(IntArrayRef oldstride) {
+  auto res = oldstride.vec();
+  for(size_t i = 0; i < res.size(); i++) {
+    res[i] = res[i] * 2;
+  }
+  res.emplace_back(1);
+  return res;
+}
+
+Tensor view_complex_as_float(const Tensor& self) {
+  auto new_sizes = self.sizes().vec();
+  // last dimension will always have two elements containing the real and imag vals
+  new_sizes.emplace_back(2);
+  auto new_strides = computeStrideForComplex(self.strides());
+  if(self.scalar_type() == at::kComplexFloat) {
+    float* data = reinterpret_cast<float*>(self.data_ptr<std::complex<float>>());
+    return at::from_blob(data, new_sizes, ArrayRef<int64_t>(new_strides), dtype(at::kFloat));
+  } else {
+    double* data = reinterpret_cast<double*>(self.data_ptr<std::complex<double>>());
+    return at::from_blob(data, new_sizes, ArrayRef<int64_t>(new_strides), dtype(at::kDouble));
+  }
+  return self;
+}
+
 void normal_kernel(Tensor& self, double mean, double std, Generator* gen) {
-  auto size = self.numel();
-  if (self.scalar_type() == ScalarType::Float && size >= 16 && self.is_contiguous()) {
+  auto float_tensor = self;
+  auto reqd_std = std;
+  if(self.is_complex()) {
+    if(self.scalar_type() == ScalarType::ComplexFloat) {
+      float_tensor = at::native::view_complex_as_float(self);
+    } else {
+      float_tensor = at::native::view_complex_as_float(self);
+    }
+    // variance for normal distribution of the real and imaginary values is half of the
+    // input variance
+    reqd_std = std/(std::sqrt(2));
+  }
+  auto size = float_tensor.numel();
+  if (float_tensor.scalar_type() == ScalarType::Float && size >= 16 && float_tensor.is_contiguous()) {
 #ifdef __AVX2__
-    normal_fill_AVX2(self, static_cast<float>(mean), static_cast<float>(std), gen);
+    normal_fill_AVX2(float_tensor, static_cast<float>(mean), static_cast<float>(std), gen);
 #else
-    normal_fill(self, static_cast<float>(mean), static_cast<float>(std), gen);
+    normal_fill(float_tensor, static_cast<float>(mean), static_cast<float>(std), gen);
 #endif
   } else {
-    AT_DISPATCH_FLOATING_TYPES(self.scalar_type(), "norma_cpu", [&] {
-      if (size >= 16 && self.is_contiguous()) {
-        normal_fill<scalar_t>(self, static_cast<scalar_t>(mean), static_cast<scalar_t>(std), gen);
+    AT_DISPATCH_FLOATING_TYPES(float_tensor.scalar_type(), "norma_cpu", [&] {
+      if (size >= 16 && float_tensor.is_contiguous()) {
+        normal_fill<scalar_t>(float_tensor, static_cast<scalar_t>(mean), static_cast<scalar_t>(std), gen);
       } else {
-        auto iter = TensorIterator::nullary_op(self);
+        auto iter = TensorIterator::nullary_op(float_tensor);
         CPUGenerator* generator = get_generator_or_default<CPUGenerator>(gen, detail::getDefaultCPUGenerator());
         std::lock_guard<std::mutex> lock(generator->mutex_);
-        cpu_serial_kernel(iter, [mean, std, generator]() -> scalar_t {
-          at::normal_distribution<double> normal(mean, std);
+        cpu_serial_kernel(iter, [mean, reqd_std, generator]() -> scalar_t {
+          at::normal_distribution<double> normal(mean, reqd_std);
           return (scalar_t)normal(generator);
         });
       }

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2123,12 +2123,18 @@ class _TestTorchMixin(object):
             self.assertTrue((res1 >= 0).all().item())
 
     def test_randn(self):
-        torch.manual_seed(123456)
-        res1 = torch.randn(SIZE, SIZE)
-        res2 = torch.Tensor()
-        torch.manual_seed(123456)
-        torch.randn(SIZE, SIZE, out=res2)
-        self.assertEqual(res1, res2)
+        def common_routine(dtype):
+            torch.manual_seed(123456)
+            res1 = torch.randn(SIZE, SIZE, dtype=dtype)
+            res2 = torch.tensor([], dtype=dtype)
+            torch.manual_seed(123456)
+            torch.randn(SIZE, SIZE, out=res2)
+            self.assertEqual(res1, res2)
+
+        common_routine(dtype=torch.float32)
+        common_routine(dtype=torch.float64)
+        common_routine(dtype=torch.complex64)
+        common_routine(dtype=torch.complex128)
 
     def test_slice(self):
         empty = torch.empty(0, 4)


### PR DESCRIPTION
1. randn and normal_ methods will work for complex tensors after this PR
2. added an internal function for viewing complex tensors as float tensors which enables us to reuse functions defined for float tensors for complex tensors with change in arguments passed(like size, standard deviation in case of normal_). currently the resultant new float tensor doesn't share the storage with the input complex tensor which means that the version counter wouldn't be updated if any function is called on this resultant tensor, but once the dtype entry is removed from the storage class, this issue will be resolved.

Side notes:
1. didn't add a separate header for the util functions because of this issue https://github.com/pytorch/pytorch/issues/20686#issuecomment-593002293
2. we should eventually have a public API method view_complex_as_float once (2) mentioned above gets resolved