### PR TITLE
Make HashNode visible

### DIFF
--- a/torch/csrc/jit/ir/node_hashing.h
+++ b/torch/csrc/jit/ir/node_hashing.h
@@ -5,11 +5,11 @@
 namespace torch {
 namespace jit {
 
-struct HashNode {
+struct TORCH_API HashNode {
   size_t operator()(const Node* k) const;
 };
 
-struct EqualNode {
+struct TORCH_API EqualNode {
   bool operator()(const Node* lhs, const Node* rhs) const;
 };
 


### PR DESCRIPTION
HashNode and EqualNode are useful functions for handling jit::Node. This is to unblock https://github.com/pytorch/glow/pull/4235. 