### PR TITLE
[c10] remove calling __host__ from __device__ not allowed warning

### DIFF
--- a/c10/util/TypeCast.h
+++ b/c10/util/TypeCast.h
@@ -59,6 +59,9 @@ struct maybe_real {
 
 template<typename src_t>
 struct maybe_real<true, src_t> {
+#ifdef __CUDACC__
+#pragma nv_exec_check_disable
+#endif
   C10_HOST_DEVICE static inline auto apply(src_t src) -> decltype(src.real()) {
     return src.real();
   }
@@ -67,6 +70,9 @@ struct maybe_real<true, src_t> {
 
 template <typename dest_t, typename src_t>
 struct static_cast_with_inter_type {
+#ifdef __CUDACC__
+#pragma nv_exec_check_disable
+#endif
   C10_HOST_DEVICE static inline dest_t apply(src_t src) {
     constexpr bool real = needs_real<dest_t, src_t>::value;
     return static_cast<dest_t>(


### PR DESCRIPTION
Summary:
Remove warning
```
caffe2/c10/util/TypeCast.h(80): warning: calling a constexpr __host__ function from a __host__ __device__ function is not allowed. The experimental flag '--expt-relaxed-constexpr' can be used to allow this.
```

Test Plan: CI

Differential Revision: D20185011

