### PR TITLE
[fbgemm] Fix the errror in logging SpMM generated code

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -105,7 +105,7 @@
 [submodule "third_party/fbgemm"]
     ignore = dirty
     path = third_party/fbgemm
-    url = https://github.com/pytorch/fbgemm
+    url = https://github.com/jiecaoyu/fbgemm
 [submodule "third_party/foxi"]
     ignore = dirty
     path = third_party/foxi


### PR DESCRIPTION
Summary: Fix the error in ```src/FbgemmSpMM.cc``` when logging the generated kernel code.

Test Plan: Add ```#define FBGEMM_LOG_CODE 1``` in ```deeplearning/fbgemm/src/FbgemmSpMM.cc```.

```
$ buck run @mode/opt deeplearning/fbgemm:
```

An example of the generated code (first 50 lines in ```SpMM_int8_avx2_M-240_N-174_K-396_LDA-792_LDB-348_LDC-348.txt```, full file in P126804757):
```
     1 .section .text {#0}
     2 vbroadcastss ymm0, [L3]
     3 vmovups ymm1, [L1]
     4 push rsi
     5 push rdi
     6 mov r8, 0
     7 L5:
     8 add r8, 1
     9 call L4
    10 add rdi, 32
    11 add rsi, 32
    12 cmp r8, 21
    13 short jl L5
    14 vmovups ymm1, [L2]
    15 call L4
    16 pop rdi
    17 pop rsi
    18 add rsi, 8352
    19 vmovups ymm1, [L1]
    20 push rsi
    21 push rdi
    22 mov r8, 0
    23 L7:
    24 add r8, 1
    25 call L6
    26 add rdi, 32
    27 add rsi, 32
    28 cmp r8, 21
    29 short jl L7
    30 vmovups ymm1, [L2]
    31 call L6
    32 pop rdi
    33 pop rsi
    34 add rsi, 8352
    35 vmovups ymm1, [L1]
    36 push rsi
    37 push rdi
    38 mov r8, 0
    39 L9:
    40 add r8, 1
    41 call L8
    42 add rdi, 32
    43 add rsi, 32
    44 cmp r8, 21
    45 short jl L9
    46 vmovups ymm1, [L2]
    47 call L8
    48 pop rdi
    49 pop rsi
    50 add rsi, 8352
```

Reviewers:

Subscribers:

Tasks:

Tags:

