### PR TITLE
Remove warning about building from source to use the NCCL backend

### DIFF
--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -348,7 +348,7 @@ def init_process_group(backend,
         group_name (str, optional, deprecated): Group name.
 
     To enable ``backend == Backend.MPI``, PyTorch needs to built from source
-    on a system that supports MPI. The same applies to NCCL as well.
+    on a system that supports MPI.
 
     """
     global _pg_group_ranks


### PR DESCRIPTION
I think this warning isn't true anymore, and the NCCL backend works without PyTorch needing to be built from source.