### PR TITLE
Change input value in examples of `BCEWithLogitsLoss`

### DIFF
--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -564,11 +564,11 @@ class BCEWithLogitsLoss(_Loss):
     Examples::
 
         >>> target = torch.ones([10, 64], dtype=torch.float32)  # 64 classes, batch size = 10
-        >>> output = torch.full([10, 64], 0.999)  # A prediction (logit)
+        >>> output = torch.full([10, 64], 1.5)  # A prediction (logit)
         >>> pos_weight = torch.ones([64])  # All weights are equal to 1
         >>> criterion = torch.nn.BCEWithLogitsLoss(pos_weight=pos_weight)
-        >>> criterion(output, target)  # -log(sigmoid(0.999))
-        tensor(0.3135)
+        >>> criterion(output, target)  # -log(sigmoid(1.5))
+        tensor(0.2014)
 
     Args:
         weight (Tensor, optional): a manual rescaling weight given to the loss


### PR DESCRIPTION
In the examples of `BCEWithLogitsLoss`, `0.999` is passed as the prediction value. The value `0.999` seems to be a probability, but actually it's not. I think it's better to pass a value that is greater than 1, not to confuse readers.