### PR TITLE
[pytorch][buck] fix selective buck build

### DIFF
--- a/aten/src/ATen/templates/PerOpRegistration.cpp
+++ b/aten/src/ATen/templates/PerOpRegistration.cpp
@@ -9,7 +9,7 @@ namespace at {
 
 #ifndef USE_STATIC_DISPATCH
 namespace {
-auto registerer = torch::RegisterOperators()
+auto registerer = torch::import()
   ${function_registrations};
 }
 #endif


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#34090 [pytorch][buck] fix selective buck build**

Update the per-op-registration template file to use the new c10 registration API.

Differential Revision: [D20200452](https://our.internmc.facebook.com/intern/diff/D20200452/)