### PR TITLE
DO NOT MERGE: debugging ROCm failure

### DIFF
--- a/aten/src/ATen/native/cuda/DistributionBernoulli.cu
+++ b/aten/src/ATen/native/cuda/DistributionBernoulli.cu
@@ -41,7 +41,7 @@ void bernoulli_tensor_cuda_kernel(
 
   at::native::gpu_kernel(iter,
     [seeds] GPU_LAMBDA (prob_t p) -> scalar_t {
-      #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+      #if defined(__CUDA_ARCH__) || defined(__HIP_PLATFORM_HCC__)
       curandStatePhilox4_32_10_t state;
       curand_init(
           seeds.first,

--- a/aten/src/ATen/native/cuda/Distributions.cu
+++ b/aten/src/ATen/native/cuda/Distributions.cu
@@ -41,7 +41,7 @@ void poisson_cuda_kernel(
   iter.build();
   at::native::gpu_kernel(iter,
     [seeds] GPU_LAMBDA (scalar_t lambda) -> scalar_t {
-      #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+      #if defined(__CUDA_ARCH__) || defined(__HIP_PLATFORM_HCC__)
       curandStatePhilox4_32_10_t state;
       curand_init(
           seeds.first,
@@ -84,7 +84,7 @@ void gamma_cuda_kernel(
 
   at::native::gpu_kernel(iter,
     [seeds] GPU_LAMBDA (scalar_t alpha) {
-      #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+      #if defined(__CUDA_ARCH__) || defined(__HIP_PLATFORM_HCC__)
       curandStatePhilox4_32_10_t state;
       curand_init(
           seeds.first,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#34091 DO NOT MERGE: debugging ROCm failure**
* #34007 Completely kill CUDA_tensor_apply2
* #34006 Migrate bernoulli from CUDA_tensor_apply2 to TensorIterator
* #34005 Migrate gamma from CUDA_tensor_apply2 to TensorIterator
* #34004 Migrate poisson from CUDA_tensor_apply2 to TensorIterator
* #34003 Migrate prelu from CUDA_tensor_apply2 to TensorIterator

