### PR TITLE
blacklist spatialBN until bitwise matching

### DIFF
--- a/caffe2/opt/custom/fakefp16_transform.cc
+++ b/caffe2/opt/custom/fakefp16_transform.cc
@@ -38,7 +38,7 @@ std::unordered_map<std::string, std::string> getFakeFp16OpMapping(
        "SparseLengthsMeanFused8BitRowwiseFakeFP16AccFP16"},
       {"BatchMatMul", "BatchMatMulFP16Acc32Fake"},
       {"Sigmoid", "SigmoidFakeFp16"},
-      {"SpatialBN", "SpatialBNFakeFp16NNPI"},
+      // {"SpatialBN", "SpatialBNFakeLoweredFp16NNPI"},
       {"Tanh", "TanhFakeFp16"},
       {"Relu", "ReluFakeFp16"},
       {"Add", "AddFakeFp16"},


### PR DESCRIPTION
Summary: Disable op in transform map until we get bitwise matching to ice-ref

Test Plan: CI

Reviewed By: hyuen

Differential Revision: D20177936

