### PR TITLE
Use double quotes in C++ to stay consistent with Python RPC docs

### DIFF
--- a/docs/source/rpc.rst
+++ b/docs/source/rpc.rst
@@ -62,11 +62,11 @@ across RPC boundaries. These features can be categorized into four sets of APIs.
    :meth:`~torch.optim.Optimizer` (e.g., :meth:`~torch.optim.SGD`,
    :meth:`~torch.optim.Adagrad`, etc.) and a list of parameter RRefs, creates an
    :meth:`~torch.optim.Optimizer` instance on each distinct RRef owner, and
-   updates parameters accordingly when running `step()`. When you have
+   updates parameters accordingly when running ``step()``. When you have
    distributed forward and backward passes, parameters and gradients will be
    scattered across multiple workers, and hence it requires an optimizer on each
    of the involved workers. Distributed Optimizer wraps all those local
-   optimizers into one, and provides a concise constructor and `step()` API.
+   optimizers into one, and provides a concise constructor and ``step()`` API.
 
 
 .. _rpc:
@@ -78,8 +78,8 @@ Before using RPC and distributed autograd primitives, initialization must take
 place. To initialize the RPC framework we need to use
 :meth:`~torch.distributed.rpc.init_rpc` which would initialize the RPC
 framework, RRef framework and distributed autograd. By default, this will also
-initialize the `ProcessGroup` (:meth:`~torch.distributed.init_process_group`)
-backend for RPC communication. The `ProcessGroup` backend internally uses gloo
+initialize the ``ProcessGroup`` (:meth:`~torch.distributed.init_process_group`)
+backend for RPC communication. The ``ProcessGroup`` backend internally uses gloo
 for communication.
 
 
@@ -88,8 +88,8 @@ for communication.
 
 The following APIs allow users to remotely execute functions as well as create
 references (RRefs) to remote data objects. In these APIs, when passing a
-`Tensor` as an argument or a return value, the destination worker will try to
-create a `Tensor` with the same meta (i.e., device, stride, etc.), which might
+``Tensor`` as an argument or a return value, the destination worker will try to
+create a ``Tensor`` with the same meta (i.e., device, stride, etc.), which might
 crash if the device lists on source and destination workers are different. In
 such cases, applications can always feed in CPU tensors and manually move it
 to appropriate devices if necessary.
@@ -109,11 +109,12 @@ to appropriate devices if necessary.
 
 .. _rref:
 
+
 RRef
 ----
 
-An `RRef` (Remote REFerence) is a reference to a value of some type `T`
-(e.g. `Tensor`) on a remote worker. This handle keeps the referenced remote
+An ``RRef`` (Remote REFerence) is a reference to a value of some type ``T``
+(e.g. ``Tensor``) on a remote worker. This handle keeps the referenced remote
 value alive on the owner, but there is no implication that the value will be
 transferred to the local worker in the future. RRefs can be used in
 multi-machine training by holding references to `nn.Modules

--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -43,13 +43,13 @@ PyObject* rpc_init(PyObject* /* unused */) {
             backend. An instance of this class can be passed in to
             :meth:`~torch.distributed.rpc.init_rpc` in order to initialize RPC
             with specific configurations, such as the RPC timeout and
-            `init_method` to be used. )")
+            ``init_method`` to be used. )")
           .def_readwrite(
               "rpc_timeout",
               &RpcBackendOptions::rpcTimeout_,
-              R"(A `datetime.timedelta` indicating the timeout to use for all RPCs.
-                If an RPC does not complete in this timeframe, it will complete
-                with an exception indicating that it has timed out.)")
+              R"(A ``datetime.timedelta`` indicating the timeout to use for all
+                RPCs. If an RPC does not complete in this timeframe, it will
+                complete with an exception indicating that it has timed out.)")
           .def_readwrite(
               "init_method",
               &RpcBackendOptions::initMethod_,
@@ -485,7 +485,7 @@ If the future completes with an error, an exception is thrown.
           Retrieve the timeout for all RPCs that was set during RPC initialization.
 
           Returns:
-            `datetime.timedelta` instance indicating the RPC timeout.
+            ``datetime.timedelta`` instance indicating the RPC timeout.
       )");
 
   module.def(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #34139 Apply clang-format to RPC files
* **#34095 Use double quotes in C++ to stay consistent with Python RPC docs**
* #34081 Improve ProcessGroup RpcBackendOptions Constructor API

Differential Revision: [D20227343](https://our.internmc.facebook.com/intern/diff/D20227343)