### PR TITLE
[aten] Don't deadlock in IValue::Future impl callbacks

### DIFF
--- a/test/cpp/jit/test_ivalue.cpp
+++ b/test/cpp/jit/test_ivalue.cpp
@@ -143,7 +143,7 @@ void testIValueFuture() {
         }
       }
     });
-    FutureError err("My Error");
+    ivalue::Future::FutureError err("My Error");
     f3->markCompleted(std::move(err));
     EXPECT_EQ(calledTimes, 1);
   }

--- a/test/cpp/jit/test_ivalue.cpp
+++ b/test/cpp/jit/test_ivalue.cpp
@@ -95,19 +95,19 @@ void testIValue() {
 void testIValueFuture() {
   // Basic set value
   {
-    IValue iv;
-    auto f1 = iv.toFuture();
+    auto f1 = c10::make_intrusive<ivalue::Future>(IntType::get());
     EXPECT_FALSE(f1->completed());
 
     f1->markCompleted(IValue(42));
     EXPECT_TRUE(f1->completed());
     EXPECT_EQ(42, f1->value().toInt());
+    IValue iv(f1);
+    EXPECT_EQ(42, iv.toFuture()->value().toInt());
   }
 
   // Callbacks
   {
-    IValue iv;
-    auto f2 = iv.toFuture();
+    auto f2 = c10::make_intrusive<ivalue::Future>(IntType::get());
     int calledTimesA = 0;
     int calledTimesB = 0;
     f2->addCallback([f2, &calledTimesA]() {
@@ -130,8 +130,7 @@ void testIValueFuture() {
 
   // Exceptions
   {
-    IValue iv;
-    auto f3 = iv.toFuture();
+    auto f3 = c10::make_intrusive<ivalue::Future>(IntType::get());
     int calledTimes = 0;
     f3->addCallback([f3, &calledTimes]() {
       EXPECT_TRUE(f3->completed());

--- a/test/cpp/jit/test_ivalue.cpp
+++ b/test/cpp/jit/test_ivalue.cpp
@@ -96,13 +96,13 @@ void testIValueFuture() {
   // Basic set value
   {
     auto f1 = c10::make_intrusive<ivalue::Future>(IntType::get());
-    EXPECT_FALSE(f1->completed());
+    ASSERT_FALSE(f1->completed());
 
     f1->markCompleted(IValue(42));
-    EXPECT_TRUE(f1->completed());
-    EXPECT_EQ(42, f1->value().toInt());
+    ASSERT_TRUE(f1->completed());
+    ASSERT_EQ(42, f1->value().toInt());
     IValue iv(f1);
-    EXPECT_EQ(42, iv.toFuture()->value().toInt());
+    ASSERT_EQ(42, iv.toFuture()->value().toInt());
   }
 
   // Callbacks
@@ -111,21 +111,21 @@ void testIValueFuture() {
     int calledTimesA = 0;
     int calledTimesB = 0;
     f2->addCallback([f2, &calledTimesA]() {
-      EXPECT_TRUE(f2->completed());
-      EXPECT_EQ(f2->value().toInt(), 43);
+      ASSERT_TRUE(f2->completed());
+      ASSERT_EQ(f2->value().toInt(), 43);
       ++calledTimesA;
     });
     f2->markCompleted(IValue(43));
-    EXPECT_EQ(calledTimesA, 1);
-    EXPECT_EQ(calledTimesB, 0);
+    ASSERT_EQ(calledTimesA, 1);
+    ASSERT_EQ(calledTimesB, 0);
     // Post-markCompleted()
     f2->addCallback([f2, &calledTimesB]() {
-      EXPECT_TRUE(f2->completed());
-      EXPECT_EQ(f2->value().toInt(), 43);
+      ASSERT_TRUE(f2->completed());
+      ASSERT_EQ(f2->value().toInt(), 43);
       ++calledTimesB;
     });
-    EXPECT_EQ(calledTimesA, 1);
-    EXPECT_EQ(calledTimesB, 1);
+    ASSERT_EQ(calledTimesA, 1);
+    ASSERT_EQ(calledTimesB, 1);
   }
 
   // Exceptions
@@ -133,7 +133,7 @@ void testIValueFuture() {
     auto f3 = c10::make_intrusive<ivalue::Future>(IntType::get());
     int calledTimes = 0;
     f3->addCallback([f3, &calledTimes]() {
-      EXPECT_TRUE(f3->completed());
+      ASSERT_TRUE(f3->completed());
       try {
         (void)f3->value();
       } catch (const std::exception& e) {
@@ -144,7 +144,7 @@ void testIValueFuture() {
     });
     ivalue::Future::FutureError err("My Error");
     f3->markCompleted(std::move(err));
-    EXPECT_EQ(calledTimes, 1);
+    ASSERT_EQ(calledTimes, 1);
   }
 }
 

--- a/test/cpp/jit/tests.h
+++ b/test/cpp/jit/tests.h
@@ -27,6 +27,7 @@ namespace jit {
   _(FromQualString)                    \
   _(InternedStrings)                   \
   _(IValue)                            \
+  _(IValueFuture)                      \
   _(PassManagement)                    \
   _(Proto)                             \
   _(RegisterFusionCachesKernel)        \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #34109 [jit] In RPC Server, handle TorchScript continuations asynchronously
* **#34099 [aten] Don't deadlock in IValue::Future impl callbacks**

This change effectively applies into IValue's future impl a few fixes
we discovered when using the torch::utils::Future<T> impl.

The parallel impls should probably eventually be merged, but until then:

  - Don't hold the lock when invoking the callbacks. This makes
    it effectively impossible (deadlocks) to call value() to get
    the value from inside the callback.

  - We discovered that it was slightly cleaner in practice to
    notify condition variables prior to invoking callbacks
    (best to unblock paused threads ASAP, before spawning new work).

  - Fix some var naming inconsistency.
  - Add a some caffe2 cpp test coverage.

Differential Revision: [D20203278](https://our.internmc.facebook.com/intern/diff/D20203278/)