### PR TITLE
[c10] Make __assert_fail CUDA definition compilable with clang host compiler

### DIFF
--- a/c10/macros/Macros.h
+++ b/c10/macros/Macros.h
@@ -218,7 +218,9 @@ constexpr uint32_t CUDA_THREADS_PER_BLOCK_FALLBACK = 256;
 #else // __APPLE__, _MSC_VER
 #if defined(NDEBUG)
 extern "C" {
+#if defined(__CUDA_ARCH__) || !defined(__clang__)
   [[noreturn]]
+#endif
 #if defined(__CUDA_ARCH__) || defined(__HIP_ARCH__) || defined(__HIP__)
     __host__ __device__
 #endif // __CUDA_ARCH__


### PR DESCRIPTION
Summary:
if nvcc is invoked with clang host compiler, it will fail with the following error due to the decorators mismatch defined in cuda and c10:
```
 error: attribute "noreturn" did not appear on original declaration
```

Test Plan: Build pytorch with clang

Differential Revision: D20204951

