### PR TITLE
Fix MKLDNN conv2d 5d weight handling

### DIFF
--- a/aten/src/ATen/native/mkldnn/MKLDNNConversions.cpp
+++ b/aten/src/ATen/native/mkldnn/MKLDNNConversions.cpp
@@ -56,6 +56,17 @@ Tensor mkldnn_reorder_conv2d_weight(
   auto dilation_vec = expand_param_if_needed(dilation, "dilation", 2);
 
   ideep::tensor w = itensor_from_mkldnn(self).as_weights();
+
+  // Legacy mkldnn conv2d jitted module may contain a 5-d weight with an extra
+  // dimension when groups > 1, having dimension [g, o/g, i, h, w] instead of
+  // [o, i, h, w]. Ideally we should reorder the weight back in serialization.
+  // For backward compatibility, we squash the first two dims (g * o/g) back to
+  // its original form.
+  if (w.ndims() == 5) {
+    auto wdims = w.get_dims();
+    w.reshape({wdims[0] * wdims[1], wdims[2], wdims[3], wdims[4]});
+  }
+
   w.make_group(groups);
   ideep::tensor::descriptor desc =
       ideep::convolution_forward::expected_weights_descriptor(

--- a/torch/utils/mkldnn.py
+++ b/torch/utils/mkldnn.py
@@ -44,7 +44,12 @@ class MkldnnConv2d(torch.jit.ScriptModule):
         self.dilation = dense_module.dilation
         self.groups = dense_module.groups
 
-        self.register_buffer('weight', dense_module.weight.to_mkldnn())
+        self.register_buffer('weight', torch._C._nn.mkldnn_reorder_conv2d_weight(
+            dense_module.weight.to_mkldnn(),
+            self.padding,
+            self.stride,
+            self.dilation,
+            self.groups))
         if dense_module.bias is not None:
             self.register_buffer('bias', dense_module.bias.to_mkldnn())
         else:


### PR DESCRIPTION
Effectively backporting https://github.com/pytorch/pytorch/pull/32422/commits/c5c00c119fd2631e8500747a04ea2ca9c9933741 before that PR lands

The bug didn't manifesting itself earlier because MkldnnConv2d constructor didn't reorder the weights. So the issue was arising only on second serialization/deserialization. This also fixes the constructor to deliver better perf right away.

Note, that I still serialize 5d tensor - it was the previous behavior, we have to handle it anyway and with #32422 the output of `mkldnn_reorder_conv2d_weight` will always be 4d.

cc @pinzhenx