### PR TITLE
Make RecordFunction more robust for async use cases

### DIFF
--- a/test/cpp/jit/test_misc.cpp
+++ b/test/cpp/jit/test_misc.cpp
@@ -736,12 +736,12 @@ void checkTracedInputs(const TracedTestInputs& inputs) {
       found_test = true;
       TORCH_CHECK(sizes.size() == 1);
       TORCH_CHECK(sizes[0] == std::vector<int64_t>({1, 2, 3}));
-    } else if (fn == "test::pow") {
+    } else if (fn == "pow") {
       found_pow = true;
       TORCH_CHECK(sizes.size() == 2);
       TORCH_CHECK(sizes[0] == std::vector<int64_t>({1, 2, 3}));
       TORCH_CHECK(sizes[1].empty());
-    } else if (fn.find("::mul") != std::string::npos) {
+    } else if (fn == "mul") {
       found_mul = true;
       TORCH_CHECK(sizes.size() > 1);
       TORCH_CHECK(sizes[0] == std::vector<int64_t>({1, 2, 3}));
@@ -750,19 +750,6 @@ void checkTracedInputs(const TracedTestInputs& inputs) {
   TORCH_CHECK(found_test);
   TORCH_CHECK(found_pow);
   TORCH_CHECK(found_mul);
-}
-
-std::string getFullName(const autograd::profiler::RecordFunction* fn_ptr) {
-  std::string full_name = "";
-  while (fn_ptr != nullptr) {
-    if (!full_name.empty()) {
-      full_name = std::string(fn_ptr->name().str()) + "::" + full_name;
-    } else {
-      full_name = fn_ptr->name().str();
-    }
-    fn_ptr = fn_ptr->parent();
-  }
-  return full_name;
 }
 
 void testRecordFunction() {
@@ -780,7 +767,7 @@ void testRecordFunction() {
           }
         }
         traced_inputs.push_back(
-            std::make_tuple(std::string(getFullName(&fn)), sizes));
+            std::make_tuple(fn.name().str(), sizes));
       },
       [](const autograd::profiler::RecordFunction&) {},
       /* needs_inputs */ true);

--- a/torch/csrc/autograd/profiler.cpp
+++ b/torch/csrc/autograd/profiler.cpp
@@ -161,8 +161,9 @@ void enableProfiler(ProfilerConfig config) {
         }
       },
       [](const RecordFunction& fn) {
-        if (fn.getThreadId() != RecordFunction::getCurrentThreadId()) {
-          // If we've not in a thread that ran start callbacks, then find
+        if (fn.getStartCallbacksThreadId() !=
+                RecordFunction::getCurrentThreadId()) {
+          // If we're not in a thread that ran start callbacks, then find
           // the eventList that was created for the original thread_id. Then,
           // record the end event on this list so that the block is added to
           // the correct list, instead of to a new list. This should only run
@@ -172,17 +173,17 @@ void enableProfiler(ProfilerConfig config) {
           } else {
             std::lock_guard<std::mutex> guard(all_event_lists_map_mutex);
             const auto& eventListIter =
-                all_event_lists_map.find(fn.getThreadId());
+                all_event_lists_map.find(fn.getStartCallbacksThreadId());
             TORCH_INTERNAL_ASSERT(
                 eventListIter != all_event_lists_map.end(),
                 "Did not find thread_id matching ",
-                fn.getThreadId());
+                fn.getStartCallbacksThreadId());
 
             auto& eventList = eventListIter->second;
             eventList->record(
                       EventKind::PopRange,
                       StringView(""),
-                      fn.getThreadId(),
+                      fn.getStartCallbacksThreadId(),
                       state == ProfilerState::CUDA);
           }
         } else {

--- a/torch/csrc/autograd/profiler.h
+++ b/torch/csrc/autograd/profiler.h
@@ -25,8 +25,6 @@ struct Node;
 
 namespace profiler {
 
-TORCH_API uint16_t getThreadId();
-
 struct TORCH_API CUDAStubs {
   virtual void record(int* device, CUDAEventStub* event, int64_t* cpu_ns) {
     fail();

--- a/torch/csrc/autograd/record_function.h
+++ b/torch/csrc/autograd/record_function.h
@@ -111,14 +111,14 @@ struct TORCH_API RecordFunction {
   // Executes end callbacks
   void end();
 
-  // Retrieves the thread_id that this RecordFunction was created with. Useful
-  // if we need to access Events created by the original thread in a different
-  // thread.
-  inline uint16_t getThreadId() const {
+  // Retrieves the thread_id that this RecordFunction ran start callbacks with.
+  // Useful for writing thread safe end callbacks that may be potentially
+  // executed in a different thread (async ops)
+  inline uint16_t getStartCallbacksThreadId() const {
     return threadId_;
   }
 
-  // Get thread_id for the current thread
+  // Get logical thread_id for the current thread
   static uint16_t getCurrentThreadId();
 
  private:
@@ -134,8 +134,14 @@ struct TORCH_API RecordFunction {
 
   bool initialized_ = false;
   bool run_sampled_ = false;
+
+  // is_current_ true means that this record function updates thread local
+  // current record function pointer;
+  // true only in case of scope-based record functions, i.e.
+  // RECORD_FUNCTION macro
   bool is_current_ = false;
-  // The thread_id that this RecordFunction was created with.
+
+  // The logical thread_id that this RecordFunction was created with.
   uint16_t threadId_ = 0;
 };
 

--- a/torch/csrc/distributed/autograd/utils.cpp
+++ b/torch/csrc/distributed/autograd/utils.cpp
@@ -125,9 +125,6 @@ std::shared_ptr<FutureMessage> sendMessageWithAutograd(
 
   auto fut = agent.send(dst, std::move(msg));
   if (rf != nullptr) {
-    // save the local threadId so that end() callbacks can be correctly invoked
-    // from a different thread.
-    rf->setThreadId();
     // Add a callback to
     // the future that captures the RecordFunction to persist it for the
     // lifetime of the future. When the future is completed, this will run the


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#34122 Make RecordFunction more robust for async use cases**

Summary:
Earlier work added support for async rpc cases when RecordFunction's
end callbacks might be called in a different thread; in addition some
extra care was needed to handle pointer to parent function;

This PR makes RecordFunction aware of potentially multiple threads in
use, as well as removes unused parent() call and restricts current()
RecordFunction to scope-based record functions (RECORD_FUNCTION macro)

Test Plan:
unit tests

Differential Revision: [D20297709](https://our.internmc.facebook.com/intern/diff/D20297709)