### PR TITLE
Retain the order of parameters while generating ConcreteModuleTypes

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -101,6 +101,8 @@ import unittest
 import warnings
 import zipfile
 import re
+import string
+
 
 RUN_CUDA_HALF = RUN_CUDA
 if torch.cuda.is_available():
@@ -4919,6 +4921,15 @@ def foo(x):
                     'parameters_r': ['P']}
         self.assertEqual(expected, result)
 
+    def test_parameter_order(self):
+        m = nn.Module()
+        for i, name in enumerate(string.ascii_letters):
+            setattr(m, name, nn.Parameter(torch.tensor([float(i)])))
+        ms = torch.jit.script(m)
+        print(torch.cat(list(m.parameters())))
+        print(torch.cat(list(ms.parameters())))
+        self.assertEqual(list(m.parameters()), list(ms.parameters()))
+
     def test_tracing_hooks(self):
         class Net(nn.Module):
             def __init__(self):
@@ -7729,7 +7740,7 @@ a")
         @torch.jit.script
         def foo(x):
             # type: (bool)
-            if x: 
+            if x:
                 a = (None,)
             else:
                 a = ([],)

--- a/torch/csrc/api/include/torch/ordered_dict.h
+++ b/torch/csrc/api/include/torch/ordered_dict.h
@@ -170,6 +170,10 @@ class OrderedDict {
   /// `OrderedDict` into a vector of `std::pair<Key, Value>`.
   ::std::vector<std::pair<Key, Value>> pairs() const;
 
+  /// Returns true if both dicts contain the same keys and values, in the same order.
+  template<typename K, typename V>
+  friend bool operator==(const OrderedDict<K, V> &a, const OrderedDict<K, V> &b);
+
  private:
   /// A mapping from a key to an index into the `items_` vector.
   ::std::unordered_map<Key, size_t> index_;
@@ -486,6 +490,18 @@ template <typename Key, typename Value>
 void OrderedDict<Key, Value>::reserve(size_t requested_capacity) {
   index_.reserve(requested_capacity);
   items_.reserve(requested_capacity);
+}
+
+template<typename K, typename V>
+bool operator==(const torch::OrderedDict<K, V>& a, const torch::OrderedDict<K, V>& b) {
+  using Item = typename torch::OrderedDict<K, V>::Item;
+  if (a.index_ != b.index_) return false;
+  if (a.items_.size() != b.items_.size()) return false;
+  // NOTE: There's no point in comparing keys for items_, as we already know that index is equal.
+  return std::equal(a.items_.begin(), a.items_.end(),
+                    b.items_.begin(),
+                    [](const Item& a, const Item& b)
+                    { return a.value() == b.value(); });
 }
 
 } // namespace torch

--- a/torch/csrc/jit/frontend/concrete_module_type.cpp
+++ b/torch/csrc/jit/frontend/concrete_module_type.cpp
@@ -22,9 +22,9 @@ ClassTypePtr ConcreteModuleTypeBuilder::createTypeFromThis() const {
 
   // populate type with info from the concrete type information
   for (const auto& pr : attributes_) {
-    const auto& name = pr.first;
-    const auto& type = pr.second.type_;
-    const auto& isParameter = pr.second.isParam_;
+    const auto& name = pr.key();
+    const auto& type = pr.value().type_;
+    const auto& isParameter = pr.value().isParam_;
 
     cls->addAttribute(name, type, isParameter);
   }
@@ -200,7 +200,7 @@ void ConcreteModuleTypeBuilder::addAttribute(
   TORCH_INTERNAL_ASSERT(type);
   // Function attributes should be handled separately
   TORCH_INTERNAL_ASSERT(type->cast<FunctionType>() == nullptr);
-  attributes_.emplace(
+  attributes_.insert(
       std::move(name),
       ConcreteModuleTypeBuilder::Attribute(unshapedType(type), isParameter));
 }
@@ -250,7 +250,7 @@ void ConcreteModuleType::dump() const {
   }
   std::cout << "\nAttributes: \n";
   for (const auto& pr : data_.attributes_) {
-    std::cout << "\t" << pr.first << ": " << pr.second.type_->python_str()
+    std::cout << "\t" << pr.key() << ": " << pr.value().type_->python_str()
               << "\n";
   }
   std::cout << "\nSubmodules: \n";
@@ -287,8 +287,8 @@ std::unordered_map<std::string, std::pair<TypePtr, bool>> ConcreteModuleType::
   std::unordered_map<std::string, std::pair<TypePtr, bool>> ret;
   for (auto& pr : data_.attributes_) {
     ret.emplace(
-        pr.first,
-        std::pair<TypePtr, bool>(pr.second.type_, pr.second.isParam_));
+        pr.key(),
+        std::pair<TypePtr, bool>(pr.value().type_, pr.value().isParam_));
   }
   return ret;
 }

--- a/torch/csrc/jit/frontend/concrete_module_type.h
+++ b/torch/csrc/jit/frontend/concrete_module_type.h
@@ -149,7 +149,7 @@ class VISIBILITY_HIDDEN ConcreteModuleTypeBuilder {
   // The value of any constants defined by the module.
   std::unordered_map<std::string, Constant> constants_;
   // The types of any attributes
-  std::unordered_map<std::string, Attribute> attributes_;
+  OrderedDict<std::string, Attribute> attributes_;
   // Overloads, in the same format as `__overloads__` in Python
   std::unordered_map<std::string, std::vector<std::string>> overloads_;
   // Any attributes we failed to convert to TorchScript, along with a hint as to


### PR DESCRIPTION
`ConcreteModuleTypeBuilder` used to keep parameters together with all others attributes in an `unordered_map` often leading to reordering them while building up the type. Parameter order is semantically meaningful, so we need to preserve it.