### PR TITLE
Throw in aten::slice when it is used with a negative step

### DIFF
--- a/torch/csrc/jit/runtime/register_prim_ops.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops.cpp
@@ -1875,6 +1875,10 @@ int listSlice(Stack& stack) {
   int64_t start = pop(stack).to<int64_t>();
   c10::List<T> list = pop(stack).to<c10::List<T>>();
 
+  TORCH_CHECK(step != 0, "slice step cannot be zero");
+  // TODO: Remove once this is implemented!
+  TORCH_CHECK(step > 0, "slicing with negative step sizes is not supported");
+
   const int64_t list_size = list.size();
 
   // clamp start and end to the bounds of the list


### PR DESCRIPTION
Right now an expression like `lst[::-1]` throws this:
```
RuntimeError: vector::_M_range_check: __n (which is 18446744073709551615) >= this->size() (which is 5)
The above operation failed in interpreter.
Traceback (most recent call last):
  File "abcd.py", line 99, in reverse
def reverse(lst):
    # type: (List[Tensor]) -> List[Tensor]
    return lst[::-1]
           ~~~~~~~~ <--- HERE
```

Also, having a step equal to 0 would cause the code to enter an infinite loop.

Ideally we would implement support for this, but I'm not sure what the best strategy is. Turns out that semantics for slices are highly non-trivial (as seen in [the implementation of slice helpers](https://github.com/python/cpython/blob/bed4817d52d7b5a383b1b61269c1337b61acc493/Objects/sliceobject.c#L197-L282)). It seems like our only option are to either (1) use Python APIs to unpack slices which is bad because it introduces Python dependencies in libtorch (2) copy the source of those methods which I really don't like, but I'm not sure what other option there is.