### PR TITLE
.circleci: Bump nvidia driver 430.40 -> 440.64

### DIFF
--- a/.circleci/scripts/setup_ci_environment.sh
+++ b/.circleci/scripts/setup_ci_environment.sh
@@ -45,8 +45,9 @@ retry () {
 retry sudo pip -q install awscli==1.16.35
 
 if [ -n "${USE_CUDA_DOCKER_RUNTIME:-}" ]; then
-  DRIVER_FN="NVIDIA-Linux-x86_64-430.40.run"
-  wget "https://s3.amazonaws.com/ossci-linux/nvidia_driver/$DRIVER_FN"
+  DRIVER_FN="NVIDIA-Linux-x86_64-440.64.run"
+  # hosted on the pytorch S3 account, check there to update
+  wget "https://pytorch-ci-utils.s3.us-east-2.amazonaws.com/nvidia-drivers/$DRIVER_FN"
   sudo /bin/bash "$DRIVER_FN" -s --no-drm || (sudo cat /var/log/nvidia-installer.log && false)
   nvidia-smi
 fi

--- a/aten/tools/valgrind.sup
+++ b/aten/tools/valgrind.sup
@@ -9,3 +9,17 @@
    fun:handle_ld_preload
    ...
 }
+
+{
+   Cond_cuda
+   Memcheck:Cond
+   obj:*libcuda.so*
+   ...
+}
+
+{
+   Value8_cuda
+   Memcheck:Value8
+   obj:*libcuda.so*
+   ...
+}


### PR DESCRIPTION
Needed for eventual CUDA 10.2 upgrade.

Trying to test out the memory leak that was introduced as part of #33471 

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

