### PR TITLE
Apply clang-format to RPC files

### DIFF
--- a/torch/csrc/distributed/rpc/py_rref.cpp
+++ b/torch/csrc/distributed/rpc/py_rref.cpp
@@ -67,8 +67,7 @@ PyRRef::PyRRef(const py::object& value)
           // that holds an IValue of an pyobject
           elem_type = PyObjectType::get();
         }
-        auto rref =
-            RRefContext::getInstance().createOwnerRRef(elem_type);
+        auto rref = RRefContext::getInstance().createOwnerRRef(elem_type);
         py::object copy(value); // increases refcount
         IValue ivalue = jit::toIValue(std::move(copy), elem_type);
         rref->setValue(std::move(ivalue));
@@ -95,8 +94,7 @@ py::object PyRRef::toHere() {
       // python_rpc_handler deserialization will acquires GIL.
       auto rfr_values = value.toTuple()->elements();
       return PythonRpcHandler::getInstance().deserialize(
-        SerializedPyObj::fromIValues(rfr_values)
-      );
+          SerializedPyObj::fromIValues(rfr_values));
     } else {
       // acquiring GIL as torch::jit::toPyObject creates new py::object
       // without grabbing the GIL.
@@ -131,8 +129,7 @@ std::string PyRRef::str() const {
     ss << "OwnerRRef(" << rref_->rrefId() << ")";
   } else {
     ss << "UserRRef(RRefId = " << rref_->rrefId() << ", ForkId = "
-       << c10::static_intrusive_pointer_cast<UserRRef>(rref_)->forkId()
-       << ")";
+       << c10::static_intrusive_pointer_cast<UserRRef>(rref_)->forkId() << ")";
   }
   return ss.str();
 }
@@ -163,7 +160,6 @@ c10::IValue PyRRef::toIValue() {
   auto rrefPtr = c10::static_intrusive_pointer_cast<c10::RRefInterface>(rref_);
   return IValue(rrefPtr);
 }
-
 
 } // namespace rpc
 } // namespace distributed

--- a/torch/csrc/distributed/rpc/python_rpc_handler.h
+++ b/torch/csrc/distributed/rpc/python_rpc_handler.h
@@ -96,9 +96,9 @@ class PYBIND11_EXPORT PythonRpcHandler {
 
   // Shared ptr to python compilation unit in jit, it is constructed in python
   // side (see _python_cu = torch._C.CompilationUnit() in jit/__init__.py)
-  // and imported in C++ (see get_python_cu() in csrc/jit/python/pybind_utils.h).
-  // We import the compilation unit here only once for less cost and thread
-  // safety.
+  // and imported in C++ (see get_python_cu() in
+  // csrc/jit/python/pybind_utils.h). We import the compilation unit here only
+  // once for less cost and thread safety.
   std::shared_ptr<torch::jit::script::CompilationUnit> jitCompilationUnit_;
 
   // jit type parser to parse type_str back to TypePtr for RRef type

--- a/torch/csrc/distributed/rpc/request_callback_impl.cpp
+++ b/torch/csrc/distributed/rpc/request_callback_impl.cpp
@@ -164,8 +164,7 @@ std::shared_ptr<FutureMessage> RequestCallbackImpl::processRpc(
     case MessageType::SCRIPT_RREF_FETCH_CALL: {
       auto& srf = static_cast<ScriptRRefFetchCall&>(rpc);
       auto& ctx = RRefContext::getInstance();
-      c10::intrusive_ptr<OwnerRRef> rref =
-          ctx.getOwnerRRef(srf.rrefId());
+      c10::intrusive_ptr<OwnerRRef> rref = ctx.getOwnerRRef(srf.rrefId());
       if (rref->hasValue()) { // optional fast-path
         return wrap(ScriptRRefFetchRet({rref->getValue()}).toMessage());
       }
@@ -190,8 +189,7 @@ std::shared_ptr<FutureMessage> RequestCallbackImpl::processRpc(
     case MessageType::PYTHON_RREF_FETCH_CALL: {
       auto& prf = static_cast<PythonRRefFetchCall&>(rpc);
       auto& ctx = RRefContext::getInstance();
-      c10::intrusive_ptr<OwnerRRef> rref =
-          ctx.getOwnerRRef(prf.rrefId());
+      c10::intrusive_ptr<OwnerRRef> rref = ctx.getOwnerRRef(prf.rrefId());
       if (rref->hasValue()) { // optional fast-path
         auto value = rref->getValue();
         py::object pyValue;

--- a/torch/csrc/distributed/rpc/rref_context.cpp
+++ b/torch/csrc/distributed/rpc/rref_context.cpp
@@ -119,7 +119,9 @@ void RRefContext::checkRRefLeaks(bool ignoreRRefLeak) {
   }
 }
 
-c10::intrusive_ptr<UserRRef> RRefContext::createUserRRef(worker_id_t ownerId, const TypePtr& type) {
+c10::intrusive_ptr<UserRRef> RRefContext::createUserRRef(
+    worker_id_t ownerId,
+    const TypePtr& type) {
   TORCH_CHECK(ownerId != getWorkerId(), "Cannot create UserRRef on owner.");
   // Explicitly creating rrefId before forkId to make sure the order is
   // deterministic, as the argument evaluation order is system and compiler
@@ -192,7 +194,7 @@ c10::intrusive_ptr<RRef> RRefContext::getOrCreateRRef(
     // since Tensor can only get specialized with a previous run of local
     // JIT function, and we shouldn't preserve the specialized SubTensorType
     // information on other workers because it's only information only.
-    if(type == TensorType::get()) {
+    if (type == TensorType::get()) {
       TORCH_INTERNAL_ASSERT(ownerRRef->type()->isSubtypeOf(TensorType::get()));
     } else {
       TORCH_INTERNAL_ASSERT(ownerRRef->type() == type);
@@ -213,25 +215,27 @@ c10::intrusive_ptr<OwnerRRef> RRefContext::getOrCreateOwnerRRef(
     //
     // NB: cannot use make_shared here as the constructor of OwnerRRef is
     // private.
-    auto rref =
-        c10::make_intrusive<OwnerRRef>(getWorkerId(), rrefId, type);
+    auto rref = c10::make_intrusive<OwnerRRef>(getWorkerId(), rrefId, type);
     owners_[rref->rrefId()] = rref;
     ownerCV_.notify_all();
     return rref;
   } else {
     // Scenario (2) retrieving an existing RRef
-    auto ownerRRef = c10::static_intrusive_pointer_cast<OwnerRRef>(iter->second);
+    auto ownerRRef =
+        c10::static_intrusive_pointer_cast<OwnerRRef>(iter->second);
     TORCH_INTERNAL_ASSERT(ownerRRef->type() == type);
     return ownerRRef;
   }
 }
 
-c10::intrusive_ptr<OwnerRRef> RRefContext::createOwnerRRef(const TypePtr& type) {
+c10::intrusive_ptr<OwnerRRef> RRefContext::createOwnerRRef(
+    const TypePtr& type) {
   // Don't add this OnwerRRef to the owners_ map yet, otherwise
   // it will never be removed from there. Instead, only add it to the
   // map in prepareChildFork, in case this local RRef is being passed
   // to another worker.
-  return c10::make_intrusive<OwnerRRef>(getWorkerId(), genGloballyUniqueId(), type);
+  return c10::make_intrusive<OwnerRRef>(
+      getWorkerId(), genGloballyUniqueId(), type);
 }
 
 c10::intrusive_ptr<OwnerRRef> RRefContext::getOwnerRRef(const RRefId& rrefId) {
@@ -247,7 +251,8 @@ c10::intrusive_ptr<OwnerRRef> RRefContext::getOwnerRRef(const RRefId& rrefId) {
   }
 }
 
-RRefForkData RRefContext::prepareChildFork(const c10::intrusive_ptr<RRef>& rref) {
+RRefForkData RRefContext::prepareChildFork(
+    const c10::intrusive_ptr<RRef>& rref) {
   auto rrefForkData = rref->fork();
   if (rref->isOwner()) {
     // Note [Early Fork Registration]

--- a/torch/csrc/distributed/rpc/rref_impl.h
+++ b/torch/csrc/distributed/rpc/rref_impl.h
@@ -44,7 +44,6 @@ struct TORCH_API RRefForkData {
       std::string typeStr);
 };
 
-
 // Note [RRef Protocol]
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~
 //
@@ -210,7 +209,7 @@ class TORCH_API RRef : public RRefInterface {
   inline bool isPyObj() {
     return type_ == PyObjectType::get();
   }
-  inline const TypePtr type() const override{
+  inline const TypePtr type() const override {
     return type_;
   }
 
@@ -240,7 +239,11 @@ class TORCH_API UserRRef final : public RRef {
   UserRRef& operator=(const UserRRef& other) = delete;
   UserRRef& operator=(UserRRef&& other) = delete;
 
-  UserRRef(worker_id_t ownerId, const RRefId& rrefId, const ForkId& forkId, TypePtr type);
+  UserRRef(
+      worker_id_t ownerId,
+      const RRefId& rrefId,
+      const ForkId& forkId,
+      TypePtr type);
 
   inline bool isOwner() const override {
     return false;
@@ -274,11 +277,14 @@ class TORCH_API OwnerRRef final : public RRef {
   OwnerRRef(worker_id_t ownerId, const RRefId& rrefId, TypePtr type)
       : OwnerRRef(ownerId, rrefId, type, {}) {}
 
-  OwnerRRef(worker_id_t ownerId, const RRefId& rrefId, TypePtr type, c10::optional<IValue> value)
+  OwnerRRef(
+      worker_id_t ownerId,
+      const RRefId& rrefId,
+      TypePtr type,
+      c10::optional<IValue> value)
       : RRef(ownerId, rrefId, std::move(type)) {
     value_ = std::move(value);
   }
-
 
   inline bool isOwner() const override {
     return true;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#34139 Apply clang-format to RPC files**
* #34095 Use double quotes in C++ to stay consistent with Python RPC docs
* #34081 Improve ProcessGroup RpcBackendOptions Constructor API

Differential Revision: [D20227342](https://our.internmc.facebook.com/intern/diff/D20227342)