### PR TITLE
weird clang windows linking issue

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qbatch_norm.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qbatch_norm.cpp
@@ -98,6 +98,9 @@ Tensor q_batch_norm_impl(
       alpha_data,
       beta_data);
 
+#if defined(__clang__) && defined(_WIN32)
+  TORCH_INTERNAL_ASSERT(false, "qbatch_norm_stub not linking correctly on windows clang. Requires investigation.");
+#else
   qbatch_norm_stub(
       qx.device().type(),
       N,
@@ -109,6 +112,8 @@ Tensor q_batch_norm_impl(
       alpha,
       beta,
       qy);
+#endif
+
   return qy;
 }
 


### PR DESCRIPTION
Summary:
anyone have any ideas here?
`clang` complains about missing symbols (default, AVX, AVX2) versions of `qbatch_norm_stub`.
the same Buck targets work for `cl.exe` and `clang` on linux.
`QuantizedOpKernels.cpp` is for sure being compiled (or else other compilers would fail too).

Test Plan: clang on windows unit tests link

Differential Revision: D20153499

