### PR TITLE
Add backward Int8Quantize shape inference

### DIFF
--- a/caffe2/opt/bound_shape_inferencer.h
+++ b/caffe2/opt/bound_shape_inferencer.h
@@ -104,6 +104,7 @@ class CAFFE2_API BoundShapeInferencer : public BoundShapeInferencerBase {
   virtual void InferOps(const OperatorDef& op, caffe2::Workspace* ws);
 
   void InferConcatInputs(const OperatorDef& op);
+  void InferInt8QuantizeInput(const OperatorDef& op);
 
   void InferGivenTensorFill(const OperatorDef& op);
   void InferSparseLengthsSum(const OperatorDef& op);


### PR DESCRIPTION
Summary: Propagate the input shape of Int8Quantize backwards.

Test Plan:
```
buck test caffe2/caffe2/opt:bound_shape_inference_test
```

Differential Revision: D20231521

