### PR TITLE
[c10] Fix typo in __assert_fail noreturn modifier guard

### DIFF
--- a/c10/macros/Macros.h
+++ b/c10/macros/Macros.h
@@ -218,7 +218,7 @@ constexpr uint32_t CUDA_THREADS_PER_BLOCK_FALLBACK = 256;
 #else // __APPLE__, _MSC_VER
 #if defined(NDEBUG)
 extern "C" {
-#if defined(__CUDA_ARCH__) || !defined(__clang__)
+#if !defined(__CUDA_ARCH__)  || !defined(__clang__)
   [[noreturn]]
 #endif
 #if defined(__CUDA_ARCH__) || defined(__HIP_ARCH__) || defined(__HIP__)


### PR DESCRIPTION
Summary: `[[noreturn]` only conficts with CUDA __asert_fail defition if clang is used if host compiler

Test Plan: CI

Differential Revision: D20232088

