### PR TITLE
[ROCm] Enable BFloat16 type for pooling ops

### DIFF
--- a/aten/src/ATen/native/cuda/AdaptiveAveragePooling3d.cu
+++ b/aten/src/ATen/native/cuda/AdaptiveAveragePooling3d.cu
@@ -388,17 +388,19 @@ void adaptive_avg_pool3d_out_cuda_template(
     totalZ = sizeB * sizeD * osizeT;
   }
 
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(
+  AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16,
       input.scalar_type(), "adaptive_avg_pool3d_cuda", [&] {
-        scalar_t* input_data = input.data_ptr<scalar_t>();
-        scalar_t* output_data = output.data_ptr<scalar_t>();
+      AT_SKIP_BFLOAT16_IF_NOT_ROCM(scalar_t, "adaptive_avg_pool3d_cuda", [&] {
+          scalar_t* input_data = input.data_ptr<scalar_t>();
+          scalar_t* output_data = output.data_ptr<scalar_t>();
 
-        adaptiveaveragepool_loop(
-            input_data, output_data,
-            totalZ,
-            isizeT, isizeH, isizeW,
-            osizeT, osizeH, osizeW,
-            istrideD, istrideT, istrideH, istrideW);
+          adaptiveaveragepool_loop(
+              input_data, output_data,
+              totalZ,
+              isizeT, isizeH, isizeW,
+              osizeT, osizeH, osizeW,
+              istrideD, istrideT, istrideH, istrideW);
+          });
       });
 }
 
@@ -453,28 +455,32 @@ void adaptive_avg_pool3d_backward_out_cuda_template(
   }
 
   if (atomic) {
-    AT_DISPATCH_FLOATING_TYPES_AND_HALF(
+    AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16,
         input.scalar_type(), "adaptive_avg_pool3d_backward_cuda", [&] {
-          scalar_t* gradInput_data = gradInput.data_ptr<scalar_t>();
-          scalar_t* gradOutput_data = gradOutput.data_ptr<scalar_t>();
+          AT_SKIP_BFLOAT16_IF_NOT_ROCM(scalar_t, "adaptive_avg_pool3d_backward_cuda", [&] {
+            scalar_t* gradInput_data = gradInput.data_ptr<scalar_t>();
+            scalar_t* gradOutput_data = gradOutput.data_ptr<scalar_t>();
 
-          atomicadaptiveaveragegradinput_loop(
-              gradInput_data, gradOutput_data,
-              totalZ,
-              isizeT, isizeH, isizeW,
-              osizeT, osizeH, osizeW);
+            atomicadaptiveaveragegradinput_loop(
+                gradInput_data, gradOutput_data,
+                totalZ,
+                isizeT, isizeH, isizeW,
+                osizeT, osizeH, osizeW);
+            });
         });
   } else {
-    AT_DISPATCH_FLOATING_TYPES_AND_HALF(
+    AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16,
         input.scalar_type(), "adaptive_avg_pool3d_backward_cuda", [&] {
-          scalar_t* gradInput_data = gradInput.data_ptr<scalar_t>();
-          scalar_t* gradOutput_data = gradOutput.data_ptr<scalar_t>();
+          AT_SKIP_BFLOAT16_IF_NOT_ROCM(scalar_t, "adaptive_avg_pool3d_backward_cuda", [&] {
+            scalar_t* gradInput_data = gradInput.data_ptr<scalar_t>();
+            scalar_t* gradOutput_data = gradOutput.data_ptr<scalar_t>();
 
-          adaptiveaveragegradinput_loop(
-              gradInput_data, gradOutput_data,
-              totalZ,
-              isizeT, isizeH, isizeW,
-              osizeT, osizeH, osizeW);
+            adaptiveaveragegradinput_loop(
+                gradInput_data, gradOutput_data,
+                totalZ,
+                isizeT, isizeH, isizeW,
+                osizeT, osizeH, osizeW);
+            });
         });
   }
 }

--- a/aten/src/ATen/native/cuda/AdaptiveMaxPooling2d.cu
+++ b/aten/src/ATen/native/cuda/AdaptiveMaxPooling2d.cu
@@ -229,28 +229,30 @@ void adaptive_max_pool2d_out_cuda_template(
     int64_t istrideH = input.stride(1);
     int64_t istrideW = input.stride(2);
 
-    AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(),
+    AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16, input.scalar_type(),
       "adaptive_max_pool2d_cuda",
       [&] {
-        output.resize_({sizeD, osizeH, osizeW});
-        indices.resize_({sizeD, osizeH, osizeW});
+        AT_SKIP_BFLOAT16_IF_NOT_ROCM(scalar_t, "adaptive_max_pool2d_cuda", [&] {
+          output.resize_({sizeD, osizeH, osizeW});
+          indices.resize_({sizeD, osizeH, osizeW});
 
-        scalar_t *input_data = input.data_ptr<scalar_t>();
-        scalar_t *output_data = output.data_ptr<scalar_t>();
-        int64_t *indices_data = indices.data_ptr<int64_t>();
+          scalar_t *input_data = input.data_ptr<scalar_t>();
+          scalar_t *output_data = output.data_ptr<scalar_t>();
+          int64_t *indices_data = indices.data_ptr<int64_t>();
 
-        // cuda blocks & threads:
-        int blocksH = (int)(16L / sizeD);
-        blocksH = blocksH < 1 ? 1 : blocksH;
-        dim3 blocks(sizeD, blocksH);
-        dim3 threads(32, 8);
+          // cuda blocks & threads:
+          int blocksH = (int)(16L / sizeD);
+          blocksH = blocksH < 1 ? 1 : blocksH;
+          dim3 blocks(sizeD, blocksH);
+          dim3 threads(32, 8);
 
-        // run maxpool kernel
-        adaptivemaxpool <<<blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>> (
-                                   input_data, output_data,
-                                   indices_data,
-                                   isizeH, isizeW, osizeH, osizeW,
-                                   istrideD, istrideH, istrideW);
+          // run maxpool kernel
+          adaptivemaxpool <<<blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>> (
+                                     input_data, output_data,
+                                     indices_data,
+                                     isizeH, isizeW, osizeH, osizeW,
+                                     istrideD, istrideH, istrideW);
+        });
       }
     );
     THCudaCheck(cudaGetLastError());
@@ -266,28 +268,30 @@ void adaptive_max_pool2d_out_cuda_template(
     int64_t istrideH = input_.stride(2);
     int64_t istrideW = input_.stride(3);
 
-    AT_DISPATCH_FLOATING_TYPES_AND_HALF(input_.scalar_type(),
+    AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16, input_.scalar_type(),
       "adaptive_max_pool2d_cuda",
       [&] {
-        output.resize_({sizeB, sizeD, osizeH, osizeW});
-        indices.resize_({sizeB, sizeD, osizeH, osizeW});
+        AT_SKIP_BFLOAT16_IF_NOT_ROCM(scalar_t, "adaptive_max_pool2d_cuda", [&] {
+          output.resize_({sizeB, sizeD, osizeH, osizeW});
+          indices.resize_({sizeB, sizeD, osizeH, osizeW});
 
-        scalar_t *input_data = input_.data_ptr<scalar_t>();
-        scalar_t *output_data = output.data_ptr<scalar_t>();
-        int64_t *indices_data = indices.data_ptr<int64_t>();
+          scalar_t *input_data = input_.data_ptr<scalar_t>();
+          scalar_t *output_data = output.data_ptr<scalar_t>();
+          int64_t *indices_data = indices.data_ptr<int64_t>();
 
-        // cuda blocks & threads:
-        int blocksH = (int)(16L / sizeD);
-        blocksH = blocksH < 1 ? 1 : blocksH;
-        dim3 blocks(sizeB*sizeD, blocksH);
-        dim3 threads(32, 8);
+          // cuda blocks & threads:
+          int blocksH = (int)(16L / sizeD);
+          blocksH = blocksH < 1 ? 1 : blocksH;
+          dim3 blocks(sizeB*sizeD, blocksH);
+          dim3 threads(32, 8);
 
-        // run maxpool kernel
-        adaptivemaxpool <<<blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>> (
-                                   input_data, output_data,
-                                   indices_data,
-                                   isizeH, isizeW, osizeH, osizeW,
-                                   istrideD, istrideH, istrideW);
+          // run maxpool kernel
+          adaptivemaxpool <<<blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>> (
+                                     input_data, output_data,
+                                     indices_data,
+                                     isizeH, isizeW, osizeH, osizeW,
+                                     istrideD, istrideH, istrideW);
+        });
       }
     );
     THCudaCheck(cudaGetLastError());
@@ -326,35 +330,37 @@ void adaptive_max_pool2d_backward_out_cuda_template(
     gradInput.resize_as_(input);
     gradInput.zero_();
 
-    AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(),
+    AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16, input.scalar_type(),
       "adaptive_max_pool2d_backward_cuda",
       [&] {
-        scalar_t *gradInput_data = gradInput.data_ptr<scalar_t>();
-        scalar_t *gradOutput_data = gradOutput.data_ptr<scalar_t>();
-        int64_t *indices_data = indices.data_ptr<int64_t>();
+        AT_SKIP_BFLOAT16_IF_NOT_ROCM(scalar_t, "adaptive_max_pool2d_backward_cuda", [&] {
+          scalar_t *gradInput_data = gradInput.data_ptr<scalar_t>();
+          scalar_t *gradOutput_data = gradOutput.data_ptr<scalar_t>();
+          int64_t *indices_data = indices.data_ptr<int64_t>();
 
-        // cuda blocks & threads:
-        int blocksH = (int)(16L / sizeD);
-        blocksH = blocksH < 1 ? 1 : blocksH;
-        dim3 blocks(sizeD, blocksH);
-        dim3 threads(32, 8);
+          // cuda blocks & threads:
+          int blocksH = (int)(16L / sizeD);
+          blocksH = blocksH < 1 ? 1 : blocksH;
+          dim3 blocks(sizeD, blocksH);
+          dim3 threads(32, 8);
 
-        if(atomic)
-        {
-          // run updateGradInput kernel, accumulate gradients atomically
-          atomicadaptivemaxgradinput <<<blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>> (
-                                              gradInput_data, gradOutput_data,
-                                              indices_data,
-                                              isizeH, isizeW, osizeH, osizeW);
-        }
-        else
-        {
-          // run updateGradInput kernel
-          atomicadaptivemaxgradinput <<<blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>> (
-                                              gradInput_data, gradOutput_data,
-                                              indices_data,
-                                              isizeH, isizeW, osizeH, osizeW);
-        }
+          if(atomic)
+          {
+            // run updateGradInput kernel, accumulate gradients atomically
+            atomicadaptivemaxgradinput <<<blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>> (
+                                                gradInput_data, gradOutput_data,
+                                                indices_data,
+                                                isizeH, isizeW, osizeH, osizeW);
+          }
+          else
+          {
+            // run updateGradInput kernel
+            atomicadaptivemaxgradinput <<<blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>> (
+                                                gradInput_data, gradOutput_data,
+                                                indices_data,
+                                                isizeH, isizeW, osizeH, osizeW);
+          }
+        });
       }
     );
     THCudaCheck(cudaGetLastError());
@@ -372,35 +378,37 @@ void adaptive_max_pool2d_backward_out_cuda_template(
 
     //bool atomic = (isizeH%osizeH != 0) || (isizeW%osizeW != 0);
 
-    AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(),
+    AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16, input.scalar_type(),
       "adaptive_max_pool2d_backward_cuda",
       [&] {
-        scalar_t *gradInput_data = gradInput.data_ptr<scalar_t>();
-        scalar_t *gradOutput_data = gradOutput.data_ptr<scalar_t>();
-        int64_t *indices_data = indices.data_ptr<int64_t>();
+        AT_SKIP_BFLOAT16_IF_NOT_ROCM(scalar_t, "adaptive_max_pool2d_backward_cuda", [&] {
+          scalar_t *gradInput_data = gradInput.data_ptr<scalar_t>();
+          scalar_t *gradOutput_data = gradOutput.data_ptr<scalar_t>();
+          int64_t *indices_data = indices.data_ptr<int64_t>();
 
-        // cuda blocks & threads:
-        int blocksH = (int)(16L / sizeD);
-        blocksH = blocksH < 1 ? 1 : blocksH;
-        dim3 blocks(sizeB*sizeD, blocksH);
-        dim3 threads(32, 8);
+          // cuda blocks & threads:
+          int blocksH = (int)(16L / sizeD);
+          blocksH = blocksH < 1 ? 1 : blocksH;
+          dim3 blocks(sizeB*sizeD, blocksH);
+          dim3 threads(32, 8);
 
-        if(atomic)
-        {
-          // run updateGradInput kernel, accumulate gradients atomically
-          atomicadaptivemaxgradinput <<<blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>> (
-                                              gradInput_data, gradOutput_data,
-                                              indices_data,
-                                              isizeH, isizeW, osizeH, osizeW);
-        }
-        else
-        {
-          // run updateGradInput kernel, accumulate gradients atomically
-          adaptivemaxgradinput <<<blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>> (
-                                              gradInput_data, gradOutput_data,
-                                              indices_data,
-                                              isizeH, isizeW, osizeH, osizeW);
-        }
+          if(atomic)
+          {
+            // run updateGradInput kernel, accumulate gradients atomically
+            atomicadaptivemaxgradinput <<<blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>> (
+                                                gradInput_data, gradOutput_data,
+                                                indices_data,
+                                                isizeH, isizeW, osizeH, osizeW);
+          }
+          else
+          {
+            // run updateGradInput kernel, accumulate gradients atomically
+            adaptivemaxgradinput <<<blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>> (
+                                                gradInput_data, gradOutput_data,
+                                                indices_data,
+                                                isizeH, isizeW, osizeH, osizeW);
+          }
+        });
       }
     );
     THCudaCheck(cudaGetLastError());

--- a/aten/src/ATen/native/cuda/AdaptiveMaxPooling3d.cu
+++ b/aten/src/ATen/native/cuda/AdaptiveMaxPooling3d.cu
@@ -363,16 +363,18 @@ void adaptive_max_pool3d_out_cuda_template(
     totalZ = sizeB * sizeD * osizeT;
   }
 
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(),
+  AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16, input.scalar_type(),
     "adaptive_max_pool3d_cuda",
     [&] {
-      scalar_t *input_data = input.data_ptr<scalar_t>();
-      scalar_t *output_data = output.data_ptr<scalar_t>();
-      int64_t *indices_data = indices.data_ptr<int64_t>();
+      AT_SKIP_BFLOAT16_IF_NOT_ROCM(scalar_t, "adaptive_max_pool3d_cuda", [&] {
+        scalar_t *input_data = input.data_ptr<scalar_t>();
+        scalar_t *output_data = output.data_ptr<scalar_t>();
+        int64_t *indices_data = indices.data_ptr<int64_t>();
 
-      adaptivemaxpool_loop(
-        input_data, output_data, indices_data, totalZ, isizeT, isizeH, isizeW,
-        osizeT, osizeH, osizeW, istrideD, istrideT, istrideH, istrideW);
+        adaptivemaxpool_loop(
+          input_data, output_data, indices_data, totalZ, isizeT, isizeH, isizeW,
+          osizeT, osizeH, osizeW, istrideD, istrideT, istrideH, istrideW);
+      });
     }
   );
 }
@@ -430,31 +432,35 @@ void adaptive_max_pool3d_backward_out_cuda_template(
   }
 
   if (atomic) {
-    AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(),
+    AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16, input.scalar_type(),
       "adaptive_max_pool3d_backward_cuda",
       [&] {
-        scalar_t *gradInput_data = gradInput.data_ptr<scalar_t>();
-        scalar_t *gradOutput_data = gradOutput.data_ptr<scalar_t>();
-        int64_t *indices_data = indices.data_ptr<int64_t>();
+        AT_SKIP_BFLOAT16_IF_NOT_ROCM(scalar_t, "adaptive_max_pool3d_backward_cuda", [&] {
+          scalar_t *gradInput_data = gradInput.data_ptr<scalar_t>();
+          scalar_t *gradOutput_data = gradOutput.data_ptr<scalar_t>();
+          int64_t *indices_data = indices.data_ptr<int64_t>();
 
-        atomicadaptivemaxgradinput_loop(
-          gradInput_data, gradOutput_data, indices_data,
-          totalZ,
-          isizeT, isizeH, isizeW, osizeT, osizeH, osizeW);
+          atomicadaptivemaxgradinput_loop(
+            gradInput_data, gradOutput_data, indices_data,
+            totalZ,
+            isizeT, isizeH, isizeW, osizeT, osizeH, osizeW);
+        });
       }
     );
   } else {
-    AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(),
+    AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16, input.scalar_type(),
       "adaptive_max_pool3d_backward_cuda",
       [&] {
-        scalar_t *gradInput_data = gradInput.data_ptr<scalar_t>();
-        scalar_t *gradOutput_data = gradOutput.data_ptr<scalar_t>();
-        int64_t *indices_data = indices.data_ptr<int64_t>();
+        AT_SKIP_BFLOAT16_IF_NOT_ROCM(scalar_t, "adaptive_max_pool3d_backward_cuda", [&] {
+          scalar_t *gradInput_data = gradInput.data_ptr<scalar_t>();
+          scalar_t *gradOutput_data = gradOutput.data_ptr<scalar_t>();
+          int64_t *indices_data = indices.data_ptr<int64_t>();
 
-        adaptivemaxgradinput_loop(
-          gradInput_data, gradOutput_data, indices_data,
-          totalZ,
-          isizeT, isizeH, isizeW, osizeT, osizeH, osizeW);
+          adaptivemaxgradinput_loop(
+            gradInput_data, gradOutput_data, indices_data,
+            totalZ,
+            isizeT, isizeH, isizeW, osizeT, osizeH, osizeW);
+        });
       }
     );
   }

--- a/aten/src/ATen/native/cuda/AveragePool2d.cu
+++ b/aten/src/ATen/native/cuda/AveragePool2d.cu
@@ -176,75 +176,81 @@ void avg_pool2d_out_cuda_template(
   const uint32_t num_blocks = cuda::ATenCeilDiv<uint32_t>(count, num_threads);
 
   if (divisor_override.has_value()) {
-    AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(),
+    AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16, input.scalar_type(),
       "avg_pool2d_out_cuda_frame",
       [&] {
-        using accscalar_t = acc_type<scalar_t, true>;
+        AT_SKIP_BFLOAT16_IF_NOT_ROCM(scalar_t, "avg_pool2d_out_cuda_frame", [&] {
+          using accscalar_t = acc_type<scalar_t, true>;
 
-        scalar_t *output_data = output.data_ptr<scalar_t>();
-        scalar_t *input_data = input.data_ptr<scalar_t>();
+          scalar_t *output_data = output.data_ptr<scalar_t>();
+          scalar_t *input_data = input.data_ptr<scalar_t>();
 
-        avg_pool2d_out_cuda_frame<scalar_t, accscalar_t, false, true>
-            <<<num_blocks, num_threads, 0, at::cuda::getCurrentCUDAStream()>>>(
-            count,
-                input_data,
-                nbatch,
-                nInputPlane,
-                inputHeight, inputWidth,
-                outputHeight, outputWidth,
-                kH, kW,
-                dH, dW,
-                padH, padW,
-                output_data,
-                divisor_override.value());
+          avg_pool2d_out_cuda_frame<scalar_t, accscalar_t, false, true>
+              <<<num_blocks, num_threads, 0, at::cuda::getCurrentCUDAStream()>>>(
+              count,
+                  input_data,
+                  nbatch,
+                  nInputPlane,
+                  inputHeight, inputWidth,
+                  outputHeight, outputWidth,
+                  kH, kW,
+                  dH, dW,
+                  padH, padW,
+                  output_data,
+                  divisor_override.value());
+        });
       }
     );
   } else {
     if (count_include_pad) {
-      AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(),
+      AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16, input.scalar_type(),
         "avg_pool2d_out_cuda_frame",
         [&] {
-          using accscalar_t = acc_type<scalar_t, true>;
+          AT_SKIP_BFLOAT16_IF_NOT_ROCM(scalar_t, "avg_pool2d_out_cuda_frame", [&] {
+            using accscalar_t = acc_type<scalar_t, true>;
 
-          scalar_t *output_data = output.data_ptr<scalar_t>();
-          scalar_t *input_data = input.data_ptr<scalar_t>();
+            scalar_t *output_data = output.data_ptr<scalar_t>();
+            scalar_t *input_data = input.data_ptr<scalar_t>();
 
-          avg_pool2d_out_cuda_frame<scalar_t, accscalar_t, true, false>
-              <<<num_blocks, num_threads, 0, at::cuda::getCurrentCUDAStream()>>>(
-              count,
-                  input_data,
-                  nbatch,
-                  nInputPlane,
-                  inputHeight, inputWidth,
-                  outputHeight, outputWidth,
-                  kH, kW,
-                  dH, dW,
-                  padH, padW,
-                  output_data, 0);
+            avg_pool2d_out_cuda_frame<scalar_t, accscalar_t, true, false>
+                <<<num_blocks, num_threads, 0, at::cuda::getCurrentCUDAStream()>>>(
+                count,
+                    input_data,
+                    nbatch,
+                    nInputPlane,
+                    inputHeight, inputWidth,
+                    outputHeight, outputWidth,
+                    kH, kW,
+                    dH, dW,
+                    padH, padW,
+                    output_data, 0);
+          });
         }
       );
     }
     else {
-      AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(),
+      AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16, input.scalar_type(),
         "avg_pool2d_out_cuda_frame",
         [&] {
-          using accscalar_t = acc_type<scalar_t, true>;
+          AT_SKIP_BFLOAT16_IF_NOT_ROCM(scalar_t, "avg_pool2d_out_cuda_frame", [&] {
+            using accscalar_t = acc_type<scalar_t, true>;
 
-          scalar_t *output_data = output.data_ptr<scalar_t>();
-          scalar_t *input_data = input.data_ptr<scalar_t>();
+            scalar_t *output_data = output.data_ptr<scalar_t>();
+            scalar_t *input_data = input.data_ptr<scalar_t>();
 
-          avg_pool2d_out_cuda_frame<scalar_t, accscalar_t, false, false>
-              <<<num_blocks, num_threads, 0, at::cuda::getCurrentCUDAStream()>>>(
-              count,
-                  input_data,
-                  nbatch,
-                  nInputPlane,
-                  inputHeight, inputWidth,
-                  outputHeight, outputWidth,
-                  kH, kW,
-                  dH, dW,
-                  padH, padW,
-                  output_data, 0);
+            avg_pool2d_out_cuda_frame<scalar_t, accscalar_t, false, false>
+                <<<num_blocks, num_threads, 0, at::cuda::getCurrentCUDAStream()>>>(
+                count,
+                    input_data,
+                    nbatch,
+                    nInputPlane,
+                    inputHeight, inputWidth,
+                    outputHeight, outputWidth,
+                    kH, kW,
+                    dH, dW,
+                    padH, padW,
+                    output_data, 0);
+          });
         }
       );
     }
@@ -326,9 +332,10 @@ Tensor& avg_pool2d_backward_out_cuda_template(
   const uint32_t num_blocks = cuda::ATenCeilDiv<uint32_t>(count, num_threads);
 
   if (divisor_override.has_value()) {
-    AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(),
+    AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16, input.scalar_type(),
       "avg_pool2d_backward_out_cuda_frame",
       [&] {
+      AT_SKIP_BFLOAT16_IF_NOT_ROCM(scalar_t, "avg_pool2d_backward_out_cuda_frame", [&] {
         using accscalar_t = acc_type<scalar_t, true>;
 
         scalar_t *gradOutput_data = gradOutput.data_ptr<scalar_t>();
@@ -347,54 +354,59 @@ Tensor& avg_pool2d_backward_out_cuda_template(
                 padH, padW,
                 gradInput_data,
                 divisor_override.value());
+        });
       }
     );
   } else {
     if (count_include_pad) {
-      AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(),
+      AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16, input.scalar_type(),
         "avg_pool2d_backward_out_cuda_frame",
         [&] {
-          using accscalar_t = acc_type<scalar_t, true>;
+          AT_SKIP_BFLOAT16_IF_NOT_ROCM(scalar_t, "avg_pool2d_backward_out_cuda_frame", [&] {
+            using accscalar_t = acc_type<scalar_t, true>;
 
-          scalar_t *gradOutput_data = gradOutput.data_ptr<scalar_t>();
-          scalar_t *gradInput_data = gradInput.data_ptr<scalar_t>();
+            scalar_t *gradOutput_data = gradOutput.data_ptr<scalar_t>();
+            scalar_t *gradInput_data = gradInput.data_ptr<scalar_t>();
 
-          avg_pool2d_backward_out_cuda_frame<scalar_t, accscalar_t, true, false>
-            <<<num_blocks, num_threads, 0, at::cuda::getCurrentCUDAStream()>>>(
-               count,
-               gradOutput_data,
-               nbatch,
-               nInputPlane,
-               inputHeight, inputWidth,
-               outputHeight, outputWidth,
-               kH, kW,
-               dH, dW,
-               padH, padW,
-               gradInput_data, 0);
+            avg_pool2d_backward_out_cuda_frame<scalar_t, accscalar_t, true, false>
+              <<<num_blocks, num_threads, 0, at::cuda::getCurrentCUDAStream()>>>(
+                 count,
+                 gradOutput_data,
+                 nbatch,
+                 nInputPlane,
+                 inputHeight, inputWidth,
+                 outputHeight, outputWidth,
+                 kH, kW,
+                 dH, dW,
+                 padH, padW,
+                 gradInput_data, 0);
+          });
         }
       );
     }
     else {
-      AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(),
+      AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16, input.scalar_type(),
         "avg_pool2d_backward_out_cuda_frame",
         [&] {
-          using accscalar_t = acc_type<scalar_t, true>;
+          AT_SKIP_BFLOAT16_IF_NOT_ROCM(scalar_t, "avg_pool2d_backward_out_cuda_frame", [&] {
+            using accscalar_t = acc_type<scalar_t, true>;
 
-          scalar_t *gradOutput_data = gradOutput.data_ptr<scalar_t>();
-          scalar_t *gradInput_data = gradInput.data_ptr<scalar_t>();
+            scalar_t *gradOutput_data = gradOutput.data_ptr<scalar_t>();
+            scalar_t *gradInput_data = gradInput.data_ptr<scalar_t>();
 
-          avg_pool2d_backward_out_cuda_frame<scalar_t, accscalar_t, false, false>
-            <<<num_blocks, num_threads, 0, at::cuda::getCurrentCUDAStream()>>>(
-               count,
-               gradOutput_data,
-               nbatch,
-               nInputPlane,
-               inputHeight, inputWidth,
-               outputHeight, outputWidth,
-               kH, kW,
-               dH, dW,
-               padH, padW,
-               gradInput_data, 0);
+            avg_pool2d_backward_out_cuda_frame<scalar_t, accscalar_t, false, false>
+              <<<num_blocks, num_threads, 0, at::cuda::getCurrentCUDAStream()>>>(
+                 count,
+                 gradOutput_data,
+                 nbatch,
+                 nInputPlane,
+                 inputHeight, inputWidth,
+                 outputHeight, outputWidth,
+                 kH, kW,
+                 dH, dW,
+                 padH, padW,
+                 gradInput_data, 0);
+          });
         }
       );
     }

--- a/aten/src/ATen/native/cuda/DilatedMaxPool3d.cu
+++ b/aten/src/ATen/native/cuda/DilatedMaxPool3d.cu
@@ -360,22 +360,24 @@ void max_pool3d_with_indices_out_cuda_template(
     work_indices = work_indices.reshape({nbatch * nslices, otime, oheight, owidth});
   }
 
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(
+  AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16,
     input.scalar_type(),
     "max_pool3d_with_indices_out_frame",
     [&]{
-      scalar_t *input_data = work_input.data_ptr<scalar_t>();
-      int64_t totalZ = otime * nslices * nbatch;
+      AT_SKIP_BFLOAT16_IF_NOT_ROCM(scalar_t, "max_pool3d_with_indices_out_frame", [&] {
+        scalar_t *input_data = work_input.data_ptr<scalar_t>();
+        int64_t totalZ = otime * nslices * nbatch;
 
-      max_pool3d_with_indices_out_frame(
-        input_data, work_output, work_indices,
-        totalZ,
-        itime, iheight, iwidth,
-        otime, oheight, owidth,
-        kT, kH, kW,
-        dT, dH, dW,
-        pT, pH, pW,
-        dilationT, dilationH, dilationW);
+        max_pool3d_with_indices_out_frame(
+          input_data, work_output, work_indices,
+          totalZ,
+          itime, iheight, iwidth,
+          otime, oheight, owidth,
+          kT, kH, kW,
+          dT, dH, dW,
+          pT, pH, pW,
+          dilationT, dilationH, dilationW);
+      });
     }
   );
 }
@@ -470,20 +472,22 @@ void max_pool3d_with_indices_backward_out_cuda_template(
       work_indices = work_indices.reshape({nbatch * nslices, otime, oheight, owidth});
   }
 
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(),
+  AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16, input.scalar_type(),
     "max_pool3d_with_indices_backward_out_frame",
     [&] {
-      const int64_t totalZ = otime * nslices * nbatch;
-      scalar_t *grad_input_data = work_grad_input.data_ptr<scalar_t>();
+      AT_SKIP_BFLOAT16_IF_NOT_ROCM(scalar_t, "max_pool3d_with_indices_backward_out_frame", [&] {
+        const int64_t totalZ = otime * nslices * nbatch;
+        scalar_t *grad_input_data = work_grad_input.data_ptr<scalar_t>();
 
-      max_pool3d_with_indices_backward_out_frame(
-        grad_input_data, work_grad_output, work_indices,
-        totalZ,
-        itime, iheight, iwidth,
-        owidth, oheight,
-        dT, dH, dW,
-        pT, pH, pW,
-        dilationT, dilationH, dilationW);
+        max_pool3d_with_indices_backward_out_frame(
+          grad_input_data, work_grad_output, work_indices,
+          totalZ,
+          itime, iheight, iwidth,
+          owidth, oheight,
+          dT, dH, dW,
+          pT, pH, pW,
+          dilationT, dilationH, dilationW);
+      });
     }
   );
 }

--- a/aten/src/THC/THCAtomics.cuh
+++ b/aten/src/THC/THCAtomics.cuh
@@ -136,7 +136,6 @@ static inline  __device__ void gpuAtomicAdd(at::Half *address, at::Half val) {
 
 }
 
-#ifdef __HIP_PLATFORM_HCC__
 static inline __device__ void gpuAtomicAdd(at::BFloat16 *address, at::BFloat16 val) {
     unsigned int * address_as_ui =
       (unsigned int *) ((char *)address - ((size_t)address & 2));
@@ -152,7 +151,6 @@ static inline __device__ void gpuAtomicAdd(at::BFloat16 *address, at::BFloat16 v
       old = atomicCAS(address_as_ui, assumed, old);
     } while (assumed != old);
 }
-#endif
 
 #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 600 || CUDA_VERSION < 8000)
 // from CUDA C Programmic Guide

--- a/aten/src/THC/THCAtomics.cuh
+++ b/aten/src/THC/THCAtomics.cuh
@@ -136,6 +136,24 @@ static inline  __device__ void gpuAtomicAdd(at::Half *address, at::Half val) {
 
 }
 
+#ifdef __HIP_PLATFORM_HCC__
+static inline __device__ void gpuAtomicAdd(at::BFloat16 *address, at::BFloat16 val) {
+    unsigned int * address_as_ui =
+      (unsigned int *) ((char *)address - ((size_t)address & 2));
+    unsigned int old = *address_as_ui;
+    unsigned int assumed;
+
+    do {
+      assumed = old;
+      at::BFloat16 bsum;
+      bsum.x = (size_t)address & 2 ? (old >> 16) : (old & 0xffff);
+      bsum = THCNumerics<at::BFloat16>::add(bsum, val);
+      old = (size_t)address & 2 ? (old & 0xffff) | (bsum.x << 16) : (old & 0xffff0000) | bsum.x;
+      old = atomicCAS(address_as_ui, assumed, old);
+    } while (assumed != old);
+}
+#endif
+
 #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 600 || CUDA_VERSION < 8000)
 // from CUDA C Programmic Guide
 static inline __device__ void atomicAdd(double* address, double val)
@@ -194,6 +212,10 @@ static inline __device__ void gpuAtomicAdd(float *address, float val) {
  * continue to provide atomicAdd overloads. 
  */
 static inline __device__ void atomicAdd(at::Half *address, at::Half val) {
+  gpuAtomicAdd(address, val);
+}
+
+static inline __device__ void atomicAdd(at::BFloat16 *address, at::BFloat16 val) {
   gpuAtomicAdd(address, val);
 }
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -10498,37 +10498,37 @@ class TestNNDeviceType(NNTestCase):
         self.assertEqual(output[0, 0, 0, 0], float("-inf"), allow_inf=True)
         self.assertEqual(indices[0, 0, 0, 0], 0)
 
-    @dtypesIfCUDA(torch.half, torch.float, torch.double)
+    @dtypesIfCUDA(*ALL_TENSORTYPES2)
     @dtypes(torch.float)
     def test_MaxPool1d_indices(self, device, dtype):
         self._test_maxpool_indices(1, device=device, dtype=dtype)
 
-    @dtypesIfCUDA(torch.half, torch.float, torch.double)
+    @dtypesIfCUDA(*ALL_TENSORTYPES2)
     @dtypes(torch.float)
     def test_MaxPool2d_indices(self, device, dtype):
         self._test_maxpool_indices(2, device=device, dtype=dtype)
 
-    @dtypesIfCUDA(torch.half, torch.float, torch.double)
+    @dtypesIfCUDA(*ALL_TENSORTYPES2)
     @dtypes(torch.float)
     def test_MaxPool3d_indices(self, device, dtype):
         self._test_maxpool_indices(3, device=device, dtype=dtype)
 
-    @dtypesIfCUDA(torch.half, torch.float, torch.double)
+    @dtypesIfCUDA(*ALL_TENSORTYPES2)
     @dtypes(torch.float)
     def test_AdaptiveMaxPool1d_indices(self, device, dtype):
         self._test_maxpool_indices(1, adaptive=True, device=device, dtype=dtype)
 
-    @dtypesIfCUDA(torch.half, torch.float, torch.double)
+    @dtypesIfCUDA(*ALL_TENSORTYPES2)
     @dtypes(torch.float)
     def test_AdaptiveMaxPool2d_indices(self, device, dtype):
         self._test_maxpool_indices(2, adaptive=True, device=device, dtype=dtype)
 
-    @dtypesIfCUDA(torch.half, torch.float, torch.double)
+    @dtypesIfCUDA(*ALL_TENSORTYPES2)
     @dtypes(torch.float)
     def test_AdaptiveMaxPool3d_indices(self, device, dtype):
         self._test_maxpool_indices(3, adaptive=True, device=device, dtype=dtype)
 
-    @dtypesIfCUDA(torch.half, torch.float, torch.double)
+    @dtypesIfCUDA(*ALL_TENSORTYPES2)
     @dtypes(torch.float)
     def test_max_pool_nan(self, device, dtype):
         for adaptive in ['', 'adaptive_']:
@@ -10539,7 +10539,7 @@ class TestNNDeviceType(NNTestCase):
                 res = fn(x, 1 if adaptive else 3)
                 self.assertTrue(math.isnan(res.item()))
 
-    @dtypesIfCUDA(torch.half, torch.float, torch.double)
+    @dtypesIfCUDA(*ALL_TENSORTYPES2)
     @dtypes(torch.float)
     def test_pool_large_size(self, device, dtype):
         for op in ('max', 'avg'):
@@ -10553,7 +10553,7 @@ class TestNNDeviceType(NNTestCase):
                 # check if the output shape was still computed correctly
                 self.assertEqual(x.shape[2], res.shape[2])
 
-    @dtypesIfCUDA(torch.half, torch.float, torch.double)
+    @dtypesIfCUDA(*ALL_TENSORTYPES2)
     @dtypes(torch.float)
     def test_pool_invalid_size(self, device, dtype):
         for op in ('max', 'avg'):
@@ -10740,6 +10740,33 @@ class TestNNDeviceType(NNTestCase):
         test(torch.nn.Hardshrink())
         test(torch.nn.Softshrink())
         test(torch.nn.LeakyReLU())
+
+    @onlyCUDA
+    @skipCUDAIfNotRocm
+    def test_pooling_bfloat16(self, device):
+        def test(pool_func, inp_dims):
+            # fp32 compute
+            input1 = torch.randn(inp_dims, dtype=torch.float32, device=device, requires_grad=True)
+            out1 = pool_func(input1)
+            grad_input1 = torch.randn_like(out1, device=device)
+            out1.backward(grad_input1)
+
+            # bfloat16 compute
+            pool_func2 = pool_func.bfloat16()
+            input2 = input1.detach().bfloat16().requires_grad_()
+            grad_input2 = grad_input1.bfloat16()
+            out2 = pool_func(input2)
+            out2.backward(grad_input2)
+
+            self.assertEqual(out1, out2, prec=2*1e-2)
+            self.assertEqual(input1.grad.data, input2.grad.data, prec=2*1e-2)
+
+        test(torch.nn.AvgPool1d(3, stride=2), inp_dims=(8, 4, 16))
+        test(torch.nn.AvgPool2d(3, stride=2), inp_dims=(8, 4, 16, 16))
+        test(torch.nn.AvgPool3d(3, stride=2), inp_dims=(8, 4, 16, 16, 16))
+        test(torch.nn.AdaptiveAvgPool1d(3), inp_dims=(8, 4, 16))
+        test(torch.nn.AdaptiveAvgPool2d((3, 5)), inp_dims=(8, 4, 16, 16))
+        test(torch.nn.AdaptiveAvgPool3d((3, 5, 7)), inp_dims=(8, 4, 16, 16, 16))
 
     @onlyCUDA    
     @skipCUDAIfRocm

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -10758,8 +10758,8 @@ class TestNNDeviceType(NNTestCase):
             out2 = pool_func(input2)
             out2.backward(grad_input2)
 
-            self.assertEqual(out1, out2, prec=2*1e-2)
-            self.assertEqual(input1.grad.data, input2.grad.data, prec=2*1e-2)
+            self.assertEqual(out1, out2, prec=0.05)
+            self.assertEqual(input1.grad.data, input2.grad.data, prec=0.05)
 
         test(torch.nn.AvgPool1d(3, stride=2), inp_dims=(8, 4, 16))
         test(torch.nn.AvgPool2d(3, stride=2), inp_dims=(8, 4, 16, 16))


### PR DESCRIPTION
This PR enables bfloat16 type for pooling ops on ROCm. Also adds bfloat16 implementation of atomicAdd since pooling ops use it.

Note: Changes in the lambda function blocks is only indentation as it is now wrapped inside `AT_SKIP_BFLOAT16_IF_NOT_ROCM` macro.

@iotamudelta @ezyang @bddppq 