### PR TITLE
[Redo][ATen] Remove AT_ASSERTM from Blob::free_()

### DIFF
--- a/aten/src/ATen/core/blob.h
+++ b/aten/src/ATen/core/blob.h
@@ -155,11 +155,10 @@ class CAFFE2_API Blob final : public c10::intrusive_ptr_target {
         TypeMeta::Make<typename std::remove_const<T>::type>()));
   }
 
-  // TODO Remove ShareExternal() and have Blob always own its content
   void* ShareExternal(void* allocated, const TypeMeta& meta) {
     free_();
     meta_ = meta;
-    pointer_ = static_cast<void*>(allocated);
+    pointer_ = allocated;
     has_ownership_ = false;
     return allocated;
   }
@@ -186,15 +185,14 @@ class CAFFE2_API Blob final : public c10::intrusive_ptr_target {
 
  private:
   void free_() {
-    if (has_ownership_) {
-      AT_ASSERTM(pointer_ != nullptr, "Can't have ownership of nullptr");
+    if (has_ownership_ && pointer_ != nullptr) {
       (*meta_.deleteFn())(pointer_);
     }
   }
 
   TypeMeta meta_;
-  void* pointer_ = nullptr;
-  bool has_ownership_ = false;
+  void* pointer_;
+  bool has_ownership_;
 
   C10_DISABLE_COPY_AND_ASSIGN(Blob);
 };


### PR DESCRIPTION
Summary:
Redo D19153199. It was reverted because it broke CI, due to the change of `AT_ASSERTM` to `TORCH_INTERNAL_ASSERT_DEBUG_ONLY`. Two problems:
1) bug in `TORCH_INTERNAL_ASSERT_DEBUG_ONLY` about MSVC. I'm sending another diff to fix this bug.
2) BlobTest was expecting `Blob::template Get<T>()` to throw when there is a type mismatch.

For now I'll leave `AT_ASSERTM` as it is.

Test Plan:
```
buck test mode/dev //caffe2/caffe2:caffe2_test_cpu -- 'BlobTest' --run-disabled
buck test mode/opt //caffe2/caffe2:caffe2_test_cpu -- 'BlobTest' --run-disabled
```

Differential Revision: D20235225

