### PR TITLE
[Aten] Suppress valgrind leaks in libcuda

### DIFF
--- a/aten/tools/valgrind.sup
+++ b/aten/tools/valgrind.sup
@@ -9,3 +9,17 @@
    fun:handle_ld_preload
    ...
 }
+
+{
+   Cond_cuda
+   Memcheck:Cond
+   obj:*libcuda.so*
+   ...
+}
+
+{
+   Value8_cuda
+   Memcheck:Value8
+   obj:*libcuda.so*
+   ...
+}


### PR DESCRIPTION
Summary: Valgrind have no insight how memory is being initialized by ioctls()

Test Plan: CI

Differential Revision: D20235974

