### PR TITLE
[1/n][multi-tower] add partition info in dper3_backend net reconstruction

### DIFF
--- a/caffe2/python/predictor/predictor_py_utils.py
+++ b/caffe2/python/predictor/predictor_py_utils.py
@@ -15,6 +15,7 @@ def create_predict_net(predictor_export_meta):
     # Construct a new net to clear the existing settings.
     net = core.Net(predictor_export_meta.predict_net.name or "predict")
     net.Proto().op.extend(predictor_export_meta.predict_net.op)
+    net.Proto().partition_info.extend(predictor_export_meta.predict_net.partition_info)
     net.Proto().external_input.extend(
         predictor_export_meta.inputs + predictor_export_meta.parameters)
     net.Proto().external_output.extend(predictor_export_meta.outputs)


### PR DESCRIPTION
Summary: to incorporate PartitionInfo added in D20015493

Test Plan:
buck test //dper3/dper3_backend/delivery/tests:dper3_model_export_test

https://pxl.cl/12kD4

Differential Revision: D20133759

