### PR TITLE
NNPI op mapping correct SpatialBN NNPI op name

### DIFF
--- a/caffe2/opt/custom/fakefp16_transform.cc
+++ b/caffe2/opt/custom/fakefp16_transform.cc
@@ -38,7 +38,7 @@ std::unordered_map<std::string, std::string> getFakeFp16OpMapping(
        "SparseLengthsMeanFused8BitRowwiseFakeFP16AccFP16"},
       {"BatchMatMul", "BatchMatMulFP16Acc32Fake"},
       {"Sigmoid", "SigmoidFakeFp16"},
-      {"SpatialBN", "SpatialBNFakeFp16Op"},
+      {"SpatialBN", "SpatialBNFakeFp16NNPI"},
       {"Tanh", "TanhFakeFp16"},
       {"Relu", "ReluFakeFp16"},
       {"Add", "AddFakeFp16"},


### PR DESCRIPTION
Summary: Wrong operator name for the NNPI SpatialBN

Test Plan: flow canary

Differential Revision: D20237933

