### PR TITLE
[torch] Fix sign-compare warning in `torch::utils::rnn:pack_sequence`

### DIFF
--- a/torch/csrc/api/include/torch/nn/utils/rnn.h
+++ b/torch/csrc/api/include/torch/nn/utils/rnn.h
@@ -333,7 +333,7 @@ inline Tensor pad_sequence(
 ///     a `PackedSequence` object
 inline PackedSequence pack_sequence(ArrayRef<Tensor> sequences, bool enforce_sorted = true) {
   Tensor lengths = torch::empty({(int64_t)sequences.size()}, kInt64);
-  for (int64_t i = 0; i < sequences.size(); i++) {
+  for (size_t i = 0; i < sequences.size(); i++) {
     lengths[i] = sequences[i].size(0);
   }
   return pack_padded_sequence(


### PR DESCRIPTION
Summary: ArrayRef<T>::size() is size_t

Test Plan: CI

Differential Revision: D20241552

