### PR TITLE
[pytorch][cmake] improve build mobile with host toolchain

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -312,17 +312,17 @@ ENDIF(NOT MSVC)
 
 # Set INTERN_BUILD_MOBILE for all mobile builds. Components that are not
 # applicable to mobile are disabled by this variable.
-if (ANDROID OR IOS)
+# Setting `BUILD_PYTORCH_MOBILE_WITH_HOST_TOOLCHAIN` environment variable can
+# force it to do mobile build with host toolchain - which is useful for testing
+# purpose.
+if (ANDROID OR IOS OR DEFINED ENV{BUILD_PYTORCH_MOBILE_WITH_HOST_TOOLCHAIN})
   set(INTERN_BUILD_MOBILE ON)
-  # Disable developing mobile interpreter for actual mobile build. Enable it elsewhere to capture build error.
-  set(INTERN_DISABLE_MOBILE_INTERP ON)
-endif()
 
-# Setting `PYTORCH_BUILD_MOBILE` environment variable can force it to do mobile
-# build with host toolchain.
-if (DEFINED ENV{PYTORCH_BUILD_MOBILE})
-  set(INTERN_BUILD_MOBILE ON)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DC10_MOBILE")
+  if (DEFINED ENV{BUILD_PYTORCH_MOBILE_WITH_HOST_TOOLCHAIN})
+    # C10_MOBILE is derived from Android/iOS toolchain macros in
+    # c10/macros/Macros.h, so it needs to be explicitly set here.
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DC10_MOBILE")
+  endif()
 endif()
 
 # INTERN_BUILD_ATEN_OPS is used to control whether to build ATen/TH operators.
@@ -351,6 +351,9 @@ if (INTERN_BUILD_MOBILE AND NOT BUILD_CAFFE2_MOBILE)
   set(INTERN_DISABLE_ONNX ON)
   set(INTERN_DISABLE_AUTOGRAD ON)
   set(INTERN_USE_EIGEN_BLAS ON)
+  # Disable developing mobile interpreter for actual mobile build.
+  # Enable it elsewhere to capture build error.
+  set(INTERN_DISABLE_MOBILE_INTERP ON)
 endif()
 
 # ---[ Utils

--- a/scripts/build_mobile.sh
+++ b/scripts/build_mobile.sh
@@ -8,7 +8,7 @@
 
 set -e
 
-export PYTORCH_BUILD_MOBILE=1
+export BUILD_PYTORCH_MOBILE_WITH_HOST_TOOLCHAIN=1
 CAFFE2_ROOT="$( cd "$(dirname "$0")"/.. ; pwd -P)"
 
 echo "Bash: $(/bin/bash --version | head -1)"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#34187 [pytorch][cmake] improve build mobile with host toolchain**

Summary:
Noticed that a recent PR broke Android/iOS CI but didn't break mobile
build with host toolchain. Turns out one mobile related flag was not
set on PYTORCH_BUILD_MOBILE code path:
```
"set(INTERN_DISABLE_MOBILE_INTERP ON)"
```

First, move the INTERN_DISABLE_MOBILE_INTERP macro below, to stay with
other "mobile + pytorch" options - it's not relevant to "mobile + caffe2"
so doesn't need to be set as common "mobile" option;

Second, rename PYTORCH_BUILD_MOBILE env-variable to
BUILD_PYTORCH_MOBILE_WITH_HOST_TOOLCHAIN - it's a bit verbose but
becomes more clear what it does - there is another env-variable
"BUILD_PYTORCH_MOBILE" used in scripts/build_android.sh, build_ios.sh,
which toggles between "mobile + pytorch" v.s. "mobile + caffe2";

Third, combine BUILD_PYTORCH_MOBILE_WITH_HOST_TOOLCHAIN with ANDROID/IOS
to avoid missing common mobile options again in future.

Differential Revision: [D20251864](https://our.internmc.facebook.com/intern/diff/D20251864)