### PR TITLE
Tensorexpr fuser implementation.

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -479,6 +479,7 @@ if (NOT INTERN_BUILD_MOBILE OR NOT BUILD_CAFFE2_MOBILE)
     ${TORCH_SRC_DIR}/csrc/jit/tensorexpr/ir_mutator.cpp
     ${TORCH_SRC_DIR}/csrc/jit/tensorexpr/ir_printer.cpp
     ${TORCH_SRC_DIR}/csrc/jit/tensorexpr/ir_visitor.cpp
+    ${TORCH_SRC_DIR}/csrc/jit/tensorexpr/kernel.cpp
     ${TORCH_SRC_DIR}/csrc/jit/tensorexpr/mem_arena.cpp
     ${TORCH_SRC_DIR}/csrc/jit/tensorexpr/schedule.cpp
     ${TORCH_SRC_DIR}/csrc/jit/tensorexpr/tensor.cpp

--- a/test/test_tensorexpr.py
+++ b/test/test_tensorexpr.py
@@ -1,0 +1,1039 @@
+import contextlib
+import numpy as np
+import torch
+import torch.nn.functional as F
+import unittest
+
+
+@contextlib.contextmanager
+def num_profiled_runs(num_runs):
+    old_num_runs = torch._C._jit_set_num_profiled_runs(num_runs)
+    try:
+        yield
+    finally:
+        torch._C._jit_set_num_profiled_runs(old_num_runs)
+
+
+class BaseTestClass(unittest.TestCase):
+    def setUp(self):
+        # TODO: read the old value and restore it rather than always set to True
+        # on exit
+        torch._C._jit_override_can_fuse_on_gpu(False)
+        torch._C._jit_register_tensorexpr_fuser()
+
+    def tearDown(self):
+        torch._C._jit_override_can_fuse_on_gpu(True)
+
+class ExecutionCounter(object):
+    def __init__(self, name):
+        self.name = name
+        self.start_value = torch._C._jit_get_trigger_value(self.name)
+
+    def elapsed_value(self):
+        value = torch._C._jit_get_trigger_value(self.name)
+        return value - self.start_value
+
+
+class SimpleIREvalExecuted(ExecutionCounter):
+    def __init__(self):
+        super(SimpleIREvalExecuted, self).__init__("simple_ir_eval_executed")
+
+class TestTensorExprFuser(BaseTestClass):
+    def test_easy(self):
+        def easy(x, y):
+            aaa = torch.add(x, y)
+            return aaa
+
+        traced = torch.jit.trace(easy, (torch.rand(1024), torch.rand(1024)))
+
+        a = torch.rand(1024)
+        b = torch.rand(1024)
+        x = traced(a, b)
+        np.testing.assert_allclose(a.numpy() + b.numpy(), x.numpy())
+
+
+    def test_three_arg(self):
+        simple_ir_eval_executed = SimpleIREvalExecuted()
+
+        def easy(x, y, z):
+            aaa = torch.add(x, y)
+            bbb = torch.add(aaa, z)
+            return bbb
+
+        traced = torch.jit.trace(
+            easy, (torch.rand(1024), torch.rand(1024), torch.rand(1024))
+        )
+
+        a = torch.rand(1024)
+        b = torch.rand(1024)
+        c = torch.rand(1024)
+        x = traced(a, b, c)
+        npr = a.numpy() + b.numpy() + c.numpy()
+        np.testing.assert_allclose(npr, x.numpy())
+        assert (
+            simple_ir_eval_executed.elapsed_value() >= 1
+        )
+
+
+    def test_four_arg(self):
+        def run_addcmul(x, y, z, w):
+            c = torch.addcmul(torch.add(x, y), z, w)
+            return c
+
+        device_options = ["cpu"]
+        for dev in device_options:
+            rand_a = torch.rand(1024, dtype=torch.float, device=dev)
+            rand_b = torch.rand(1024, dtype=torch.float, device=dev)
+            rand_c = torch.rand(1024, dtype=torch.float, device=dev)
+            rand_d = torch.rand(1024, dtype=torch.float, device=dev)
+
+            traced = torch.jit.trace(
+                run_addcmul,
+                (
+                    torch.zeros(1024, dtype=torch.float, device=dev),
+                    torch.zeros(1024, dtype=torch.float, device=dev),
+                    torch.zeros(1024, dtype=torch.float, device=dev),
+                    torch.zeros(1024, dtype=torch.float, device=dev),
+                ),
+            )
+
+            x = traced(rand_a, rand_b, rand_c, rand_d)
+            y = run_addcmul(rand_a, rand_b, rand_c, rand_d)
+            np.testing.assert_allclose(x.cpu().numpy(), y.cpu().numpy(), atol=1e-6)
+
+
+    def test_all_combos(self):
+        def easy(x, y, z):
+            a = torch.add(x, y)
+            b = torch.add(a, z)
+            c = torch.add(x, b)
+            d = torch.add(c, a)
+            return d
+
+        def np_easy(x, y, z):
+            a = x + y
+            b = a + z
+            c = x + b
+            d = c + a
+            return d
+
+        traced = torch.jit.trace(
+            easy, (torch.rand(1024), torch.rand(1024), torch.rand(1024))
+        )
+
+        a = torch.rand(1024)
+        b = torch.rand(1024)
+        c = torch.rand(1024)
+        x = traced(a, b, c)
+        npr = np_easy(a.numpy(), b.numpy(), c.numpy())
+        np.testing.assert_allclose(npr, x.numpy())
+
+
+    def test_rank_two(self):
+        def easy(x, y, z):
+            a = torch.add(x, y)
+            b = torch.add(a, z)
+            c = torch.add(x, b)
+            d = torch.add(c, a)
+            return d
+
+        def np_easy(x, y, z):
+            a = x + y
+            b = a + z
+            c = x + b
+            d = c + a
+            return d
+
+        shape = 32, 32
+        traced = torch.jit.trace(
+            easy, (torch.rand(shape), torch.rand(shape), torch.rand(shape))
+        )
+
+        a = torch.rand(shape)
+        b = torch.rand(shape)
+        c = torch.rand(shape)
+        x = traced(a, b, c)
+        npr = np_easy(a.numpy(), b.numpy(), c.numpy())
+        np.testing.assert_allclose(npr, x.numpy())
+
+
+    def test_broadcast(self):
+        def easy(x, y, z):
+            a = torch.add(x, y)
+            b = torch.add(a, z)
+            return b
+
+        def np_easy(x, y, z):
+            a = x + y
+            b = a + z
+            return b
+
+        N = 32
+        traced = torch.jit.trace(easy, (torch.rand(N, N), torch.rand(N), torch.rand(N, N)))
+
+        a = torch.rand(N, N)
+        b = torch.rand(N)
+        c = torch.rand(N, N)
+        x = traced(a, b, c)
+        npr = np_easy(a.numpy(), b.numpy(), c.numpy())
+        np.testing.assert_allclose(npr, x.numpy())
+
+
+    def test_broadcast_2(self):
+        zero = torch.tensor([0.0], dtype=torch.float)
+
+        def foo(x, y, z):
+            aaa = torch.add(x, y)
+            bbb = torch.add(zero, aaa)
+            return torch.add(bbb, z)
+
+        def foo_np(x, y, z):
+            a = x + y
+            b = zero.numpy() + a
+            return b + z
+
+        x = torch.rand(3, 4)
+        y = torch.ones(3, 1)
+        z = torch.rand(4)
+        traced = torch.jit.trace(foo, (x, y, z))
+
+        r = traced(x, y, z)
+        rnp = foo_np(x.numpy(), y.numpy(), z.numpy())
+        np.testing.assert_allclose(r, rnp)
+
+
+    def test_broadcast_big2(self):
+        zero = torch.tensor([0.0], dtype=torch.float)
+
+        def foo(x, y, z):
+            aaa = torch.add(x, y)
+            bbb = torch.add(zero, aaa)
+            return torch.add(bbb, z)
+
+        def foo_np(x, y, z):
+            a = x + y
+            b = zero.numpy() + a
+            return b + z
+
+        x = torch.rand(32, 1024)
+        y = torch.ones(32, 1)
+        z = torch.rand(1024)
+        traced = torch.jit.trace(foo, (x, y, z))
+
+        r = traced(x, y, z)
+        rnp = foo_np(x.numpy(), y.numpy(), z.numpy())
+        np.testing.assert_allclose(r, rnp)
+
+
+    def test_alpha(self):
+        def alpha(x):
+            aaa = torch.add(x, x, alpha=2.0)
+            return aaa
+
+        traced = torch.jit.trace(alpha, (torch.tensor([1.0])))
+
+        a = torch.tensor([1.0])
+        x = traced(a)
+        np.testing.assert_allclose(a.numpy() + 2.0 * a.numpy(), x.numpy())
+
+
+    def test_constant(self):
+        def constant(x):
+            bbb = torch.tensor([1.0])
+            aaa = torch.add(x, bbb)
+            return aaa
+
+        traced = torch.jit.trace(constant, (torch.tensor([1.0])))
+
+        a = torch.tensor([1.0])
+        x = traced(a)
+        np.testing.assert_allclose(a.numpy() + 1.0, x.numpy())
+
+
+    def test_add_sub(self):
+        def easy(x, y, z):
+            aaa = torch.add(x, y)
+            bbb = torch.sub(aaa, z)
+            return bbb
+
+        traced = torch.jit.trace(
+            easy, (torch.rand(1024), torch.rand(1024), torch.rand(1024))
+        )
+
+        a = torch.rand(1024)
+        b = torch.rand(1024)
+        c = torch.rand(1024)
+        x = traced(a, b, c)
+        np.testing.assert_allclose(a.numpy() + b.numpy() - c.numpy(), x.numpy())
+
+
+    def test_promotion(self):
+        def easy(x, y):
+            aaa = torch.add(x, y)
+            return aaa
+
+        traced = torch.jit.trace(
+            easy,
+            (torch.zeros(1024, dtype=torch.int32), torch.rand(1024, dtype=torch.float32)),
+        )
+
+        a = torch.zeros(1024, dtype=torch.int32)
+        b = torch.rand(1024, dtype=torch.float32)
+        x = traced(a, b)
+        np.testing.assert_allclose(a.numpy() + b.numpy(), x.numpy())
+
+    def test_double(self):
+        TENSOR_LEN = 8
+        def easy(x, y):
+            aaa = torch.add(x, y)
+            bbb = torch.mul(aaa, y);
+            return bbb
+
+        traced = torch.jit.trace(
+            easy,
+            (torch.rand(TENSOR_LEN, dtype=torch.float64), torch.full((TENSOR_LEN,), 0.5, dtype=torch.float64)),
+        )
+
+        a = torch.rand(TENSOR_LEN, dtype=torch.double)
+        b = torch.full((TENSOR_LEN,), 0.5, dtype=torch.double)
+        x = traced(a, b)
+        np.testing.assert_allclose((a.numpy() + b.numpy()) * b.numpy(), x.numpy())
+
+    def test_short(self):
+        TENSOR_LEN = 8
+        def easy(x, y):
+            aaa = torch.add(x, y)
+            bbb = torch.mul(aaa, y);
+            return bbb
+
+        traced = torch.jit.trace(
+            easy,
+            (torch.randint(TENSOR_LEN, (TENSOR_LEN,), dtype=torch.int16), torch.randint(TENSOR_LEN, (TENSOR_LEN,), dtype=torch.int16)),
+        )
+
+        a = torch.randint(TENSOR_LEN, (TENSOR_LEN,), dtype=torch.int16)
+        b = torch.randint(TENSOR_LEN, (TENSOR_LEN,), dtype=torch.int16)
+        x = traced(a, b)
+        np.testing.assert_allclose((a.numpy() + b.numpy()) * b.numpy(), x.numpy())
+
+    def test_char(self):
+        TENSOR_LEN = 8
+        def easy(x, y):
+            aaa = torch.add(x, y)
+            bbb = torch.mul(aaa, y);
+            return bbb
+
+        traced = torch.jit.trace(
+            easy,
+            (torch.randint(TENSOR_LEN, (TENSOR_LEN,), dtype=torch.int8), torch.randint(TENSOR_LEN, (TENSOR_LEN,), dtype=torch.uint8)),
+        )
+
+        a = torch.randint(TENSOR_LEN, (TENSOR_LEN,), dtype=torch.int8)
+        b = torch.randint(TENSOR_LEN, (TENSOR_LEN,), dtype=torch.uint8)
+        x = traced(a, b)
+        np.testing.assert_allclose((a.numpy() + b.numpy()) * b.numpy(), x.numpy())
+
+    def test_int64_promotion(self):
+        TENSOR_LEN = 8
+        def easy(x, y):
+            aaa = torch.add(x, y)
+            bbb = torch.mul(aaa, y);
+            return bbb
+
+        traced = torch.jit.trace(
+            easy,
+            (torch.randint(TENSOR_LEN, (TENSOR_LEN,), dtype=torch.int8), torch.randint(TENSOR_LEN, (TENSOR_LEN,), dtype=torch.int64)),
+        )
+
+        a = torch.randint(TENSOR_LEN, (TENSOR_LEN,), dtype=torch.int8)
+        b = torch.randint(TENSOR_LEN, (TENSOR_LEN,), dtype=torch.int64)
+        x = traced(a, b)
+        np.testing.assert_allclose((a.numpy() + b.numpy()) * b.numpy(), x.numpy())
+
+    def test_eq(self):
+        def easy(x, y):
+            c = torch.eq(x, y)
+            return c
+
+        traced = torch.jit.trace(easy, (torch.zeros(1024), torch.zeros(1024)))
+        a = torch.zeros(1024, dtype=torch.int32)
+        b = torch.zeros(1024, dtype=torch.int32)
+        x = traced(a, b)
+        np.testing.assert_allclose(np.ones(1024), x.numpy())
+
+
+    def test_ne(self):
+        def easy(x, y):
+            c = torch.ne(x, y)
+            return c
+
+        traced = torch.jit.trace(easy, (torch.zeros(1024), torch.zeros(1024)))
+        a = torch.zeros(1024, dtype=torch.int32)
+        b = torch.ones(1024, dtype=torch.int32)
+        x = traced(a, b)
+        np.testing.assert_allclose(np.ones(1024), x.numpy())
+
+
+    def test_ge(self):
+        def easy(x, y):
+            c = torch.ge(x, y)
+            return c
+
+        traced = torch.jit.trace(easy, (torch.zeros(1024), torch.zeros(1024)))
+        aa = np.array(1024, dtype=int)
+        aa.fill(5)
+        a = torch.from_numpy(aa)
+        b = torch.zeros(1024, dtype=torch.int32)
+        x = traced(a, b)
+        np.testing.assert_allclose(np.ones(1024), x.numpy())
+
+
+    def test_gt(self):
+        def easy(x, y):
+            c = torch.gt(x, y)
+            return c
+
+        traced = torch.jit.trace(easy, (torch.zeros(1024), torch.zeros(1024)))
+        a = torch.ones(1024, dtype=torch.int32)
+        b = torch.zeros(1024, dtype=torch.int32)
+        x = traced(a, b)
+        np.testing.assert_allclose(np.ones(1024), x.numpy())
+
+
+    def test_le(self):
+        def easy(x, y):
+            c = torch.le(x, y)
+            return c
+
+        traced = torch.jit.trace(easy, (torch.zeros(1024), torch.zeros(1024)))
+        aa = np.array(1024, dtype=int)
+        aa.fill(5)
+        a = torch.from_numpy(aa)
+        b = torch.zeros(1024, dtype=torch.int32)
+        x = traced(a, b)
+        np.testing.assert_allclose(np.zeros(1024), x.numpy())
+
+
+    def test_lt(self):
+        def easy(x, y):
+            c = torch.lt(x, y)
+            return c
+
+        device_options = ["cpu"]
+        for dev in device_options:
+            traced = torch.jit.trace(easy, (torch.zeros(1024, device=dev), torch.zeros(1024, device=dev)))
+            a = torch.ones(1024, dtype=torch.int32, device=dev)
+            b = torch.zeros(1024, dtype=torch.int32, device=dev)
+            x = traced(a, b)
+            np.testing.assert_allclose(np.zeros(1024), x.cpu().numpy())
+
+
+    def test_min_max(self):
+        def test(x, y):
+            return torch.max(torch.min(x, y), torch.tensor([4.0]))
+
+        traced = torch.jit.trace(test, (torch.zeros(1024), torch.zeros(1024)))
+        a = 8.0 * torch.rand(1024)
+        b = 8.0 * torch.rand(1024)
+        np.testing.assert_allclose(
+            traced(a, b), np.maximum(np.minimum(a.numpy(), b.numpy()), [4.0])
+        )
+
+
+    def test_clamp(self):
+        def test(x):
+            return torch.clamp(x + 3.0, 0.0, 6.0)
+
+        device_options = ["cpu"]
+
+        for dev in device_options:
+            traced = torch.jit.trace(test, (torch.zeros(1024, device=dev)))
+            a = 20.0 * torch.rand(1024, device=dev) - 10.0
+            an = a.cpu().numpy()
+            np.testing.assert_allclose(traced(a).cpu(), np.clip(an + 3.0, 0.0, 6.0))
+
+    def test_relu(self):
+        def test(x):
+            return torch.clamp(F.relu(x), 0, 0.5)
+
+        device_options = ["cpu"]
+        for dev in device_options:
+            traced = torch.jit.trace(test, (torch.zeros(1024, device=dev)))
+            a = 20.0 * torch.rand(1024, device=dev) - 10.0
+            an = a.cpu().numpy()
+            np.testing.assert_allclose(traced(a).cpu(), np.clip((np.maximum(0, an)), 0, 0.5))
+
+
+    def test_reps(self):
+        def easy(x, y):
+            c = torch.add(x, y)
+            return c
+
+        traced = torch.jit.trace(easy, (torch.rand(1024), torch.rand(1024)))
+
+        for _ in range(32):
+            a = torch.ones(1024)
+            b = torch.zeros(1024)
+            x = traced(a, b)
+            np.testing.assert_allclose(np.ones(1024), x.numpy())
+
+
+    def test_add_const_rhs(self):
+        def test(x):
+            return x + 3.0
+
+        traced = torch.jit.trace(test, torch.rand(4))
+        x = torch.rand(4)
+        y = traced(x)
+        np.testing.assert_allclose(x.numpy() + 3.0, y.numpy())
+
+
+    def test_int_output(self):
+        def test(x, y, z):
+            return x * y * z
+
+        xs = [(torch.rand(4) * 3 + 1).to(torch.int32) for i in range(3)]
+        x, y, z = xs
+        xn, yn, zn = [t.numpy() for t in xs]
+        traced = torch.jit.trace(test, (x, y, z))
+        res = traced(x, y, z)
+        np.testing.assert_allclose(xn * yn * zn, res.numpy())
+
+    def test_binary_ops(self):
+        def test_atan2(x, y):
+            c = torch.atan2(torch.add(x, y), y)
+            return c
+
+        def test_gt(x, y):
+            c = torch.gt(torch.add(x, y), y)
+            return c
+
+        def test_ge(x, y):
+            c = torch.ge(torch.add(x, y), y)
+            return c
+
+        def test_lt(x, y):
+            c = torch.lt(torch.add(x, y), y)
+            return c
+
+        def test_le(x, y):
+            c = torch.le(torch.add(x, y), y)
+            return c
+
+        def test_lerp(x, y):
+            c = torch.lerp(torch.add(x, 1), x, 2.0)
+            return c
+
+        def test_mul(x, y):
+            c = torch.mul(torch.add(x, y), y)
+            return c
+
+        def test_ne(x, y):
+            c = torch.ne(torch.add(x, y), y)
+            return c
+
+        def test_div(x, y):
+            c = torch.div(torch.add(x, y), 2)
+            return c
+
+        def test_eq(x, y):
+            c = torch.eq(torch.add(x, y), y)
+            return c
+
+        def test_fmod(x, y):
+            c = torch.fmod(torch.add(x, y), 2)
+            return c
+
+        def test_sub(x, y):
+            c = torch.sub(torch.add(x, y), x)
+            return c
+
+        def test_remainder(x, y):
+            c = torch.remainder(torch.add(x, y), 3.0)
+            return c
+
+        def test_pow(x, y):
+            c = torch.pow(torch.add(x, y), 2.0)
+            return c
+
+        def test_sigmoid_backward(x, y):
+            x_2 = torch.mul(x, x)
+            c = torch.sigmoid(x_2)
+            torch.autograd.backward(c, y)
+            return c.detach()
+
+        def test_tanh_backward(x, y):
+            x_2 = torch.mul(x, x)
+            c = torch.tanh(x_2)
+            torch.autograd.backward(c, y)
+            return c.detach()
+
+        def test_type_as(x, y):
+            return x.type_as(torch.add(x, y))
+
+        fns = {
+            test_atan2,
+            test_gt,
+            test_ge,
+            test_lt,
+            test_le,
+            test_lerp,
+            test_mul,
+            test_ne,
+            test_div,
+            test_eq,
+            test_fmod,
+            test_sub,
+            test_remainder,
+            test_pow,
+            # to fix the backward path, need script instead of trace
+            # test_sigmoid_backward,
+            # test_tanh_backward,
+            test_type_as,
+        }
+        device_options = ["cpu"]
+        for torch_fn in fns:
+            for dev in device_options:
+                rand_a = torch.rand(1024, device=dev)
+                rand_b = torch.rand(1024, device=dev)
+                in1 = 20 * torch.rand(1024, device=dev)
+                in2 = 20 * torch.rand(1024, device=dev)
+                traced = torch.jit.trace(torch_fn, (in1, in2))
+                x = traced(rand_a, rand_b)
+                y = torch_fn(rand_a, rand_b)
+                np.testing.assert_allclose(x.cpu().numpy(), y.cpu().numpy(), atol=2e-3)
+
+    def test_unary_ops(self):
+        def test_cast_float(x, y):
+            c = torch.ops.aten._cast_Float(torch.add(x, y))
+            return c
+
+        def test_round(x, y):
+            c = torch.round(torch.add(x, y))
+            return c
+
+        def test_sin(x, y):
+            c = torch.sin(torch.add(x, y))
+            return c
+
+        def test_asin(x, y):
+            c = torch.asin(torch.add(x, y))
+            return c
+
+        def test_sinh(x, y):
+            c = torch.sinh(torch.add(x, y))
+            return c
+
+        def test_cos(x, y):
+            c = torch.cos(torch.add(x, y))
+            return c
+
+        def test_acos(x, y):
+            c = torch.acos(torch.add(x, y))
+            return c
+
+        def test_cosh(x, y):
+            c = torch.cosh(torch.add(x, y))
+            return c
+
+        def test_tan(x, y):
+            c = torch.tan(torch.add(x, y))
+            return c
+
+        def test_atan(x, y):
+            c = torch.atan(torch.add(x, y))
+            return c
+
+        def test_tanh(x, y):
+            c = torch.tanh(torch.add(x, y))
+            return c
+
+        def test_sqrt(x, y):
+            c = torch.sqrt(torch.add(x, y))
+            return c
+
+        def test_rsqrt(x, y):
+            c = torch.rsqrt(torch.add(x, y))
+            return c
+
+        def test_floor(x, y):
+            c = torch.floor(torch.add(x, y))
+            return c
+
+        def test_ceil(x, y):
+            c = torch.ceil(torch.add(x, y))
+            return c
+
+        def test_trunc(x, y):
+            c = torch.trunc(torch.add(x, y))
+            return c
+
+        def test_abs(x, y):
+            c = torch.abs(torch.add(x, y))
+            return c
+
+        def test_log(x, y):
+            c = torch.log(torch.add(x, y))
+            return c
+
+        def test_log2(x, y):
+            c = torch.log2(torch.add(x, y))
+            return c
+
+        def test_log10(x, y):
+            c = torch.log10(torch.add(x, y))
+            return c
+
+        def test_log1p(x, y):
+            c = torch.log1p(torch.add(x, y))
+            return c
+
+        def test_rqrt(x, y):
+            c = torch.rsqrt(torch.add(x, y))
+            return c
+
+        def test_erf(x, y):
+            c = torch.erf(torch.add(x, y))
+            return c
+
+        def test_exp(x, y):
+            c = torch.exp(torch.add(x, y))
+            return c
+
+        def test_expm1(x, y):
+            c = torch.expm1(torch.add(x, y))
+            return c
+
+        def test_erfc(x, y):
+            c = torch.erfc(torch.add(x, y))
+            return c
+
+        def test_frac(x, y):
+            c = torch.frac(torch.add(x, y))
+            return c
+
+        def test_lgamma(x, y):
+            c = torch.lgamma(torch.add(x, y))
+            return c
+
+        def test_sigmoid(x, y):
+            c = torch.sigmoid(torch.add(x, y))
+            return c
+
+        def test_reciprocal(x, y):
+            c = torch.reciprocal(torch.add(x, y))
+            return c
+
+        def test_neg(x, y):
+            c = torch.neg(torch.add(x, y))
+            return c
+
+        def test_relu(x, y):
+            c = torch.relu(torch.add(x, y))
+            return c
+
+        def test_threshold(x, y):
+            c = F.threshold(torch.add(x, y), 0.5, 10)
+            return c
+
+        fns = {
+            test_round,
+            test_sin,
+            test_asin,
+            test_sinh,
+            test_cos,
+            test_acos,
+            test_cosh,
+            test_tan,
+            test_atan,
+            test_tanh,
+            test_sqrt,
+            test_floor,
+            test_ceil,
+            test_trunc,
+            test_abs,
+            test_log,
+            test_log2,
+            test_log10,
+            test_log1p,
+            test_rsqrt,
+            test_exp,
+            test_expm1,
+            test_erf,
+            test_erfc,
+            test_frac,
+            test_lgamma,
+            test_sigmoid,
+            test_reciprocal,
+            test_threshold,
+            test_neg,
+            test_relu,
+        }
+        device_options = ["cpu"]
+
+        for torch_fn in fns:
+            for dev in device_options:
+                rand_a = torch.rand(1024, device=dev)
+                rand_b = torch.rand(1024, device=dev)
+                ins = 20 * torch.rand(1024, device=dev)
+                cc = np.array(1024, dtype=float)
+                cc.fill(np.nan)
+                nans = torch.from_numpy(cc).to(dev)
+                traced = torch.jit.trace(torch_fn, (ins, ins))
+                x = traced(rand_a, rand_b)
+                y = torch_fn(rand_a, rand_b)
+                np.testing.assert_allclose(x.cpu().numpy(), y.cpu().numpy(), atol=2e-3)
+                # nans
+                traced = torch.jit.trace(torch_fn, (ins, ins))
+                x = traced(nans, rand_b)
+                y = torch_fn(nans, rand_b)
+                np.testing.assert_allclose(x.cpu().numpy(), y.cpu().numpy())
+
+
+    def test_nans(self):
+        def test_max(x, y):
+            return torch.max(2 * x, 2 * y)
+
+        def test_min(x, y):
+            return torch.min(2 * x, 2 * y)
+
+        tmax = torch.jit.trace(test_max, (torch.rand(1), torch.rand(1)))
+        tmin = torch.jit.trace(test_min, (torch.rand(1), torch.rand(1)))
+
+        x = torch.tensor([np.nan])
+        y = torch.tensor([1.0])
+
+        assert not np.isnan(tmin(x, y).item())
+        assert np.isnan(tmin(y, x).item())
+        assert not np.isnan(tmax(x, y).item())
+        assert np.isnan(tmax(y, x).item())
+
+
+    def test_remainder(self):
+        def run_remainder(x, y):
+            c = torch.remainder(torch.add(x, y), x)
+            return c
+
+        a = torch.rand(1024, dtype=float)
+        b = torch.rand(1024, dtype=float)
+        zeros = torch.zeros(1024, dtype=float)
+        cc = np.array(1024, dtype=float)
+        cc.fill(np.nan)
+        nans = torch.from_numpy(cc)
+
+        # random floats
+        traced = torch.jit.trace(run_remainder, (torch.zeros(1024), torch.zeros(1024)))
+        x = traced(a, b)
+        y = run_remainder(a, b)
+        np.testing.assert_allclose(x.numpy(), y.numpy())
+
+        # div by 0
+        traced = torch.jit.trace(run_remainder, (torch.zeros(1024), torch.zeros(1024)))
+        x = traced(zeros, a)
+        y = run_remainder(zeros, a)
+        np.testing.assert_allclose(x.numpy(), y.numpy())
+
+        # numerators and denominatos are nan
+        traced = torch.jit.trace(run_remainder, (torch.zeros(1024), torch.zeros(1024)))
+        x = traced(nans, a)
+        y = run_remainder(nans, a)
+        np.testing.assert_allclose(x.numpy(), y.numpy())
+
+
+    def test_multioutput(self):
+        def easy(x):
+            b = x + 1
+            c = b + b
+            return (b, c)
+
+        traced = torch.jit.trace(easy, (torch.zeros(1024)))
+
+        a = torch.zeros(1024)
+        b, c = traced(a)
+        bp = a.numpy() + 1
+        cp = bp + bp
+        np.testing.assert_allclose(b.numpy(), bp)
+        np.testing.assert_allclose(c.numpy(), cp)
+
+
+    def test_chunk(self):
+        def easy(x):
+            y = x + 1
+            aaa, bbb = torch.chunk(y, 2)
+            return aaa + bbb
+
+        traced = torch.jit.trace(easy, (torch.zeros(1024, 1024)))
+
+        a = torch.zeros(1024, 1024)
+        x = traced(a)
+        npr = a.numpy()
+        npr2 = npr + 1
+        npr_a, npr_b = np.array_split(npr2, 2)
+        np.testing.assert_allclose(npr_a + npr_b, x.numpy())
+
+    def _test_cat(self, device):
+        def easy(*args):
+            args_2 = [v + i for i, v in enumerate(args)]
+            v = torch.cat(args_2, dim=1)
+            return v
+
+        M = 1024
+        Ns = [1024, 512, 256, 128]
+        values = [torch.zeros(M, N, device=device) for N in Ns]
+        traced = torch.jit.trace(easy, values)
+
+        x = traced(*values)
+        npr = [v.cpu().numpy() for v in values]
+        npr_2 = [v + i for i, v in enumerate(npr)]
+        npr_x = np.concatenate(npr_2, axis=1)
+        np.testing.assert_allclose(npr_x, x.cpu().numpy())
+
+    def test_cat_cpu(self):
+        self._test_cat('cpu')
+
+    def test_scalar(self):
+        @torch.jit.script
+        def test_float(x, y, z, a, b):
+            # type: (Tensor, Tensor, Tensor, float, float) -> Tensor
+            return torch.add(torch.add(x, y, alpha=a), z, alpha=b)
+
+        @torch.jit.script
+        def test_int(x, y, z, a, b):
+            # type: (Tensor, Tensor, Tensor, int, int) -> Tensor
+            return torch.add(torch.add(x, y, alpha=a), z, alpha=b)
+
+        for test in (test_float, test_int):
+            interp = SimpleIREvalExecuted()
+            x, y, z = [torch.rand(4) for i in range(3)]
+            a, b = 1, 2
+            test(x, y, z, a, b)
+            r = test(x, y, z, a, b)
+            xn, yn, zn = [t.numpy() for t in (x, y, z)]
+            np.testing.assert_allclose(r.numpy(), xn + yn * a + zn * b)
+            assert interp.elapsed_value() == 1
+
+# FIXME: Blocked on profiling executor changes
+# def test_loop():
+#    @torch.jit.script
+#    def test(x, y, z):
+#    # type: (Tensor, Tensor, int) -> Tensor
+#        b = y
+#        for i in range(0, z):
+#            a = x + y
+#            b = b + y
+#        return b
+#
+#    interp = SimpleIREvalExecuted()
+#    x, y, z = (torch.zeros(32, 32), torch.ones(32, 32), 4)
+#    test(x, y, z)
+#    r = test(x, y, z)
+#    assert interp.elapsed_value() == 1
+
+    def test_slice(self):
+        def easy(x, y):
+            a = x[0:512:2]
+            b = y[0:512:2]
+            return a + b
+
+        traced = torch.jit.trace(easy, (torch.ones(1024, 1024), torch.zeros(1024, 1024)))
+
+        interp = SimpleIREvalExecuted()
+
+        a = torch.ones(1024, 1024)
+        x = traced(a, a)
+        npr = a[0:512:2]
+        npr = npr + npr
+        np.testing.assert_allclose(npr.numpy(), x.numpy())
+        assert interp.elapsed_value() == 1
+
+
+    @unittest.skip("fails on trunk")
+    def test_unsqueeze(self):
+        def easy(x, y):
+            a = torch.unsqueeze(x, 0)
+            b = torch.unsqueeze(y, 0)
+            return a + b
+
+        traced = torch.jit.trace(easy, (torch.ones(1024, 1024), torch.zeros(1024, 1024)))
+
+        interp = SimpleIREvalExecuted()
+
+        a = torch.rand(1024, 1024)
+        x = traced(a, a)
+        npr = np.expand_dims(a, 0)
+        npr = npr + npr
+        np.testing.assert_allclose(npr, x.numpy())
+        assert interp.elapsed_value() == 1
+
+
+    def test_transpose(self):
+        @torch.jit.script
+        def test(x, y, z):
+            return x.transpose(0, 1) + y + z
+        interp = SimpleIREvalExecuted()
+        x = torch.rand(4, 5, 2, 3)
+        y = torch.rand(5, 4, 2, 3)
+        z = torch.rand(5, 4, 2, 3)
+        ref = test(x, y, z)
+        res = test(x, y, z)
+        np.testing.assert_allclose(ref.numpy(), res.numpy())
+        assert interp.elapsed_value() == 1
+
+
+    def test_sliced_stride(self):
+        @torch.jit.script
+        def test(x, y, z):
+            return x + y + z
+        interp = SimpleIREvalExecuted()
+        x = torch.rand(16, 4, 2, 3)[::2]
+        y = torch.rand(8, 4, 2, 3)
+        z = torch.rand(8, 4, 2, 3)
+        ref = test(x, y, z)
+        res = test(x, y, z)
+        np.testing.assert_allclose(ref.numpy(), res.numpy())
+        assert interp.elapsed_value() == 1
+
+
+    def test_bitwise_ops(self):
+        devices = ["cpu"]
+        def run_and(x, y):
+            return x & (x & y)
+
+        def run_or(x, y):
+            return x & (x | y)
+
+        def run_xor(x, y):
+            return x ^ (x ^ y)
+
+        def run_lshift(x, y):
+            return x & (x << y)
+
+        def run_rshift(x, y):
+            return x & (x >> y)
+
+        fns = {run_and, run_or, run_xor, run_lshift, run_rshift}
+
+        for device in devices:
+            for fn in fns:
+                a = torch.ones(128, dtype=torch.int32, device=device)
+                b = torch.zeros(128, dtype=torch.int32, device=device)
+                inp = torch.ones(128, dtype=torch.int32, device=device)
+                traced = torch.jit.trace(fn, (inp, inp))
+                x = traced(a, b)
+                y = fn(a, b)
+                np.testing.assert_allclose(x.cpu().numpy(), y.cpu().numpy())
+
+    def test_where(self):
+        def run_where(x, y):
+            return torch.where(torch.gt(x, y), x, y)
+
+        a = torch.rand(1024, dtype=float)
+        b = torch.rand(1024, dtype=float)
+        traced = torch.jit.trace(run_where, (torch.zeros(1024), torch.zeros(1024)))
+        x = traced(a, b)
+        y = run_where(a, b)
+        np.testing.assert_allclose(x.numpy(), y.numpy())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -203,6 +203,7 @@ libtorch_sources = [
     "torch/csrc/jit/tensorexpr/ir_mutator.cpp",
     "torch/csrc/jit/tensorexpr/ir_printer.cpp",
     "torch/csrc/jit/tensorexpr/ir_visitor.cpp",
+    "torch/csrc/jit/tensorexpr/kernel.cpp",
     "torch/csrc/jit/tensorexpr/mem_arena.cpp",
     "torch/csrc/jit/tensorexpr/schedule.cpp",
     "torch/csrc/jit/tensorexpr/tensor.cpp",

--- a/torch/csrc/jit/passes/tensorexpr_fuser.cpp
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.cpp
@@ -1,16 +1,22 @@
 #include <torch/csrc/jit/passes/tensorexpr_fuser.h>
 #include <torch/csrc/autograd/record_function.h>
-#include <torch/csrc/jit/runtime/custom_operator.h>
-#include <torch/csrc/jit/jit_log.h>
-#include <torch/csrc/jit/runtime/operator_options.h>
-#include <torch/csrc/jit/passes/pass_manager.h>
 #include <torch/csrc/jit/ir/alias_analysis.h>
+#include <torch/csrc/jit/jit_log.h>
 #include <torch/csrc/jit/passes/common_subexpression_elimination.h>
 #include <torch/csrc/jit/passes/dead_code_elimination.h>
+#include <torch/csrc/jit/passes/pass_manager.h>
 #include <torch/csrc/jit/passes/utils/subgraph_utils.h>
+#include <torch/csrc/jit/runtime/custom_operator.h>
+#include <torch/csrc/jit/runtime/operator_options.h>
+#include <torch/csrc/jit/tensorexpr/kernel.h>
 
 namespace torch {
 namespace jit {
+
+static bool texpr_fuser_enabled = true;
+void setTensorExprFuserEnabled(bool val) {
+  texpr_fuser_enabled = val;
+}
 
 const Symbol& getTensorExprSymbol() {
   static Symbol s = Symbol::fromQualString("tensorexpr::Group");
@@ -36,9 +42,88 @@ value_list sortReverseTopological(
   return result;
 }
 
+bool isSupported(Node* node) {
+  // TODO:
+  switch (node->kind()) {
+    case aten::add:
+    case aten::_cast_Float:
+    case aten::type_as:
+    case aten::sub:
+    case aten::mul:
+    case aten::div:
+    case aten::eq:
+    case aten::ne:
+    case aten::ge:
+    case aten::gt:
+    case aten::le:
+    case aten::lt:
+    case aten::min:
+    case aten::max:
+    case aten::pow:
+    case aten::clamp:
+    case aten::lerp:
+    case aten::log10:
+    case aten::log:
+    case aten::log2:
+    case aten::exp:
+    case aten::erf:
+    case aten::erfc:
+    case aten::fmod:
+    case aten::cos:
+    case aten::sin:
+    case aten::tan:
+    case aten::acos:
+    case aten::asin:
+    case aten::atan:
+    case aten::atan2:
+    case aten::cosh:
+    case aten::sinh:
+    case aten::tanh:
+    case aten::sqrt:
+    case aten::rsqrt:
+    case aten::abs:
+    case aten::floor:
+    case aten::ceil:
+    case aten::round:
+    case aten::trunc:
+    case aten::threshold:
+    case aten::remainder:
+    case prim::ConstantChunk:
+    case aten::cat:
+    case prim::ListConstruct:
+    case aten::sigmoid:
+    case aten::relu:
+    case aten::addcmul:
+    case aten::neg:
+    case aten::reciprocal:
+    case aten::expm1:
+    case aten::lgamma:
+    case aten::slice:
+    case aten::unsqueeze:
+    case aten::frac:
+    case aten::rand_like:
+    case aten::_sigmoid_backward:
+    case aten::_tanh_backward:
+    case aten::__and__:
+    case aten::__or__:
+    case aten::__xor__:
+    case aten::__lshift__:
+    case aten::__rshift__:
+    case aten::where:
+      return true;
+    default:
+      return false;
+  }
+}
+
 bool canHandle(Node* node, AliasDb& aliasDb) {
-  // TODO: actually support some ops
-  return false;
+  if (node->kind() == prim::Constant) {
+    return true;
+  }
+  if (node->kind() == prim::Loop) {
+    return false; // TODO
+  }
+  return isSupported(node);
 }
 
 #define REQ(cond)                           \
@@ -65,6 +150,36 @@ bool canMerge(Node* consumer, Node* producer, AliasDb& aliasDb) {
   // Alias checks
   REQ(aliasDb.couldMoveAfterTopologically(consumer, producer));
 
+  // Ops that return aliases can only be folded if this is the only use.
+  if (producer->kind() == aten::slice || producer->kind() == aten::unsqueeze ||
+      producer->kind() == prim::ConstantChunk) {
+    for (auto& use : producer->output(0)->uses()) {
+      REQ(use.user == consumer);
+    }
+  }
+
+  if (!consumer->hasAttribute(attr::Subgraph) &&
+      consumer->kind() != getTensorExprSymbol()) {
+    // Don't initiate a fusion group from prim::ListConstruct
+    REQ(consumer->kind() != prim::ListConstruct);
+    REQ(consumer->kind() != aten::slice);
+    REQ(consumer->kind() != aten::unsqueeze);
+    REQ(consumer->kind() != prim::ConstantChunk);
+
+    // Don't initiate a fusion group just for a constant operand
+    REQ(producer->kind() != prim::Constant);
+  }
+
+  if (producer->kind() == aten::cat) {
+    REQ(producer->inputs()[0]->node()->kind() == prim::ListConstruct);
+    REQ(producer->inputs()[0]->uses().size() == 1);
+    REQ(producer->inputs()[1]->node()->kind() == prim::Constant);
+  } else if (consumer->kind() == aten::cat) {
+    REQ(consumer->inputs()[0]->node()->kind() == prim::ListConstruct);
+    REQ(consumer->inputs()[0]->uses().size() == 1);
+    REQ(consumer->inputs()[1]->node()->kind() == prim::Constant);
+  }
+
   return true;
 }
 #undef REQ
@@ -73,7 +188,10 @@ Node* getOrCreateTensorExprSubgraph(Node* n) {
   if (n->hasAttribute(attr::Subgraph) && n->kind() == getTensorExprSymbol()) {
     return n;
   }
-  return SubgraphUtils::createSingletonSubgraph(n, getTensorExprSymbol());
+  auto te_group =
+      SubgraphUtils::createSingletonSubgraph(n, getTensorExprSymbol());
+  GRAPH_UPDATE("getOrCreateTensorExprSubgraph: ", *te_group);
+  return te_group;
 }
 
 c10::optional<Node*> tryMerge(
@@ -82,9 +200,9 @@ c10::optional<Node*> tryMerge(
     AliasDb& aliasDb) {
   GRAPH_DEBUG(
       "Trying producer ",
-      producer->kind().toQualString(),
+      getHeader(producer),
       " and consumer ",
-      consumer->kind().toQualString(),
+      getHeader(consumer),
       ":\n");
 
   if (!canMerge(consumer, producer, aliasDb)) {
@@ -93,8 +211,24 @@ c10::optional<Node*> tryMerge(
 
   consumer = getOrCreateTensorExprSubgraph(consumer);
 
-  aliasDb.moveAfterTopologicallyValid(consumer, producer);
-  SubgraphUtils::mergeNodeIntoSubgraph(producer, consumer);
+  if (producer->kind() == aten::cat) {
+    Node* listconstruct = producer->inputs()[0]->node();
+
+    aliasDb.moveAfterTopologicallyValid(consumer, producer);
+    GRAPH_UPDATE(
+        "Merging ", getHeader(producer), " into ", getHeader(consumer));
+    SubgraphUtils::mergeNodeIntoSubgraph(producer, consumer);
+
+    aliasDb.moveAfterTopologicallyValid(consumer, listconstruct);
+    GRAPH_UPDATE(
+        "Merging ", getHeader(listconstruct), " into ", getHeader(consumer));
+    SubgraphUtils::mergeNodeIntoSubgraph(listconstruct, consumer);
+  } else {
+    aliasDb.moveAfterTopologicallyValid(consumer, producer);
+    GRAPH_UPDATE(
+        "Merging ", getHeader(producer), " into ", getHeader(consumer));
+    SubgraphUtils::mergeNodeIntoSubgraph(producer, consumer);
+  }
 
   return consumer;
 }
@@ -120,28 +254,10 @@ std::pair<graph_node_list::iterator, bool> scanNode(
   return {++(++iter), false};
 }
 
-Operation createTensorExprOp(const Node* node) {
-  // TODO: actually compile the fusion group.
-  return [](Stack& stack) {
-    RECORD_FUNCTION("TensorExpr", std::vector<c10::IValue>());
-    return 0;
-  };
-}
-
-c10::OperatorOptions getAliasAnalysisOption(AliasAnalysisKind k) {
-  auto options = c10::OperatorOptions();
-  options.setAliasAnalysis(k);
-  return options;
-}
-
-RegisterOperators TensorExprOps({
-    torch::jit::Operator(
-        getTensorExprSymbol(),
-        createTensorExprOp,
-        getAliasAnalysisOption(AliasAnalysisKind::PURE_FUNCTION)),
-});
-
 void fuseTensorExprs(std::shared_ptr<Graph>& graph) {
+  if (!texpr_fuser_enabled) {
+    return;
+  }
   GRAPH_DUMP("Before TExprFuser: ", graph);
 
   // Get rid of dead code so that we don't waste effort fusing it.
@@ -193,6 +309,29 @@ void fuseTensorExprs(std::shared_ptr<Graph>& graph) {
 
   GRAPH_DUMP("After TExprFuser: ", graph);
 }
+
+Operation createTensorExprOp(const Node* node) {
+  auto kernel =
+      std::make_shared<tensorexpr::TensorExprKernel>(*node->g(attr::Subgraph));
+  return [kernel](Stack& stack) {
+    RECORD_FUNCTION("TensorExpr", std::vector<c10::IValue>());
+    kernel->run(stack);
+    return 0;
+  };
+}
+
+c10::OperatorOptions getAliasAnalysisOption(AliasAnalysisKind k) {
+  auto options = c10::OperatorOptions();
+  options.setAliasAnalysis(k);
+  return options;
+}
+
+RegisterOperators TensorExprOps({
+    torch::jit::Operator(
+        getTensorExprSymbol(),
+        createTensorExprOp,
+        getAliasAnalysisOption(AliasAnalysisKind::PURE_FUNCTION)),
+});
 
 void registerTensorExprFuser() {
   static bool already_registered = false;

--- a/torch/csrc/jit/passes/tensorexpr_fuser.h
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.h
@@ -14,5 +14,7 @@ TORCH_API void fuseTensorExprs(std::shared_ptr<Graph>& graph);
 // Register TensorExpressions-based fuser in custom passes.
 TORCH_API void registerTensorExprFuser();
 
+TORCH_API void setTensorExprFuserEnabled(bool val);
+
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -57,6 +57,7 @@
 #include <torch/csrc/jit/api/module.h>
 #include <torch/csrc/jit/python/python_tree_views.h>
 #include <torch/csrc/jit/frontend/tracer.h>
+#include <torch/csrc/jit/tensorexpr/execution_counter.h>
 
 #include <c10/macros/Export.h>
 #include <caffe2/serialize/inline_container.h>
@@ -392,6 +393,15 @@ void initJITBindings(PyObject* module) {
             }
             return nullptr;
           })
+      .def(
+          "_jit_get_trigger_value",
+          [](const std::string& trigger_name) {
+            using namespace torch::jit::tensorexpr;
+            ExecutionTrigger* trigger =
+                ExecutionTriggerList::GetInstance().FindByName(trigger_name);
+            return trigger->value();
+          })
+      .def("_jit_set_texpr_fuser_enabled", &setTensorExprFuserEnabled)
       .def(
           "_jit_fuser_get_fused_kernel_code",
           [](Graph& g, std::vector<at::Tensor> inps) {

--- a/torch/csrc/jit/tensorexpr/eval.cpp
+++ b/torch/csrc/jit/tensorexpr/eval.cpp
@@ -4,6 +4,8 @@ namespace torch {
 namespace jit {
 namespace tensorexpr {
 
+DEFINE_TRIGGER(simple_ir_eval_executed);
+
 RegisterCodeGen<SimpleIREvaluator> reg("simple_ir_eval");
 
 } // namespace tensorexpr

--- a/torch/csrc/jit/tensorexpr/eval.h
+++ b/torch/csrc/jit/tensorexpr/eval.h
@@ -18,6 +18,8 @@ namespace torch {
 namespace jit {
 namespace tensorexpr {
 
+DECLARE_TRIGGER(simple_ir_eval_executed);
+
 class Value {
  public:
   Value() : dtype_(kInt) {
@@ -107,6 +109,7 @@ class SimpleIREvaluator : public CodeGen, public IRVisitor {
     eval_context_.clear();
     buffer_mapping_.clear();
     internal_buffers_.clear();
+    USE_TRIGGER(simple_ir_eval_executed);
   }
 
   void bind(const BufferArg& buf, const CallArg& data) {

--- a/torch/csrc/jit/tensorexpr/execution_counter.h
+++ b/torch/csrc/jit/tensorexpr/execution_counter.h
@@ -1,0 +1,118 @@
+#pragma once
+
+#include "torch/csrc/WindowsTorchApiMacro.h"
+
+#include <string>
+#include <unordered_map>
+
+namespace torch {
+namespace jit {
+namespace tensorexpr {
+
+/*
+ExecutionTrigger and ExecutionCounter builds instrumentation counters so
+underlying functionalities can be checked.
+
+In the code to be instrumented:
+
+// worker.cpp
+DEFINE_TRIGGER(useful_work_done);  // this defines a trigger "useful_work_done"
+void run() {
+  USE_TRIGGER(useful_work_done);   // this triggers the underlying counter
+                                   // in  "useful_work_done"
+}
+
+// in C++ client.cpp
+
+DECLARE_TRIGGER(useful_work_done);  // Optional: this declares a trigger that
+                                    // will be defined elsewhere
+ExecutionCounter counter(useful_work_done); // This starts the counter from the
+                                            // underlying trigger.
+... call run() ...
+counter.elapsed_value();   // this returns the incremented value from the
+                           // trigger since the creation of the counter
+
+// in Python client.py
+counter = ExecutionCounter("useful_work_done") // this starts the counter from
+                                               // the underlying trigger
+... call C++ run() ...
+counter.elapsed_value()    // This returns the incremented value from the
+                           // trigger since the creation of the counter.
+*/
+
+class ExecutionTrigger;
+class ExecutionTriggerList {
+ public:
+  TORCH_API static ExecutionTriggerList& GetInstance() {
+    static ExecutionTriggerList instance;
+    return instance;
+  }
+
+  ExecutionTrigger* FindByName(const std::string& name) const {
+    auto iter = trigger_list_.find(name);
+    if (iter == trigger_list_.end()) {
+      throw std::runtime_error("Invalid trigger name: " + name);
+    }
+    return iter->second;
+  }
+
+ private:
+  friend class ExecutionTrigger;
+
+  ExecutionTriggerList() {}
+  ExecutionTriggerList(const ExecutionTriggerList&) = delete;
+  ExecutionTriggerList& operator=(const ExecutionTriggerList&) = delete;
+
+  void AddTrigger(const std::string& name, ExecutionTrigger* trigger) {
+    auto insert_ret = trigger_list_.insert(std::make_pair(name, trigger));
+    if (!insert_ret.second) {
+      throw std::runtime_error("Duplicated trigger name: " + name);
+    }
+  }
+
+  std::unordered_map<std::string, ExecutionTrigger*> trigger_list_;
+};
+
+class ExecutionTrigger {
+ public:
+  explicit ExecutionTrigger(const std::string& name) : name_(name) {
+    ExecutionTriggerList::GetInstance().AddTrigger(name, this);
+  }
+
+  int value() const {
+    return value_;
+  }
+
+  void trigger() {
+    value_++;
+  }
+
+ private:
+  ExecutionTrigger(const ExecutionTrigger&) = delete;
+  ExecutionTrigger& operator=(const ExecutionTrigger&) = delete;
+  int value_ = 0;
+  const std::string name_;
+};
+
+class ExecutionCounter {
+ public:
+  explicit ExecutionCounter(ExecutionTrigger& trigger) : trigger_(trigger) {
+    start_value_ = trigger_.value();
+  }
+
+  int elapsed_value() const {
+    return trigger_.value() - start_value_;
+  }
+
+ private:
+  ExecutionTrigger& trigger_;
+  int start_value_ = 0;
+};
+
+#define DEFINE_TRIGGER(name) TORCH_API ExecutionTrigger name(#name)
+#define DECLARE_TRIGGER(name) TORCH_API extern ExecutionTrigger name
+#define USE_TRIGGER(name) (name).trigger()
+
+} // namespace tensorexpr
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -1,0 +1,1175 @@
+#include <torch/csrc/jit/tensorexpr/kernel.h>
+#include <torch/csrc/jit/tensorexpr/ir_printer.h>
+#include <torch/csrc/jit/tensorexpr/schedule.h>
+
+using namespace torch::jit;
+using namespace torch::jit::tensorexpr;
+
+static at::ScalarType tensorType(Tensor* t) {
+  return static_cast<at::ScalarType>(t->body()->dtype().scalar_type());
+}
+
+static std::vector<ExprHandle> texprSizes(const c10::VaryingShape& shape) {
+  std::vector<ExprHandle> dims;
+  for (size_t i = 0; i < *shape.size(); i++) {
+    dims.push_back(IntImm::make(*shape[i]));
+  }
+  return dims;
+}
+
+static std::vector<DimArg> texprDims(const torch::jit::Value* v) {
+  CHECK(v->type()->kind() == TypeKind::TensorType);
+  auto tt = v->type()->cast<TensorType>();
+  std::vector<DimArg> dimArgs;
+  int i = 0;
+  for (auto const& s : texprSizes(tt->sizes())) {
+    dimArgs.push_back({s, "i" + std::to_string(i++)});
+  }
+  return dimArgs;
+}
+
+template <typename T>
+int64_t bufferSize(T t) {
+  int64_t size = 1;
+  for (int i = 0; i < t.ndim(); i++) {
+    size *= t.dim(i).template AsNode<IntImm>()->value();
+  }
+  return size;
+}
+
+ExprHandle TensorExprKernel::constant(const torch::jit::Value* v) {
+  if (v->node()->kind() == prim::Constant) {
+    const auto val = toIValue(v).value();
+    if (val.isDouble()) {
+      return FloatImm::make(val.toDouble());
+    } else if (val.isInt()) {
+      return IntImm::make(val.toInt());
+    } else if (val.isNone()) {
+      // This is just a placeholder so we don't throw.  None-handling
+      // is operator-specific and should be handled properly in
+      // the operator-specific lowering code.
+      return IntImm::make(0);
+    } else {
+      LOG(FATAL) << "Unhandled constant datatype";
+    }
+  }
+  CHECK(scalars_.count(v->unique())) << "Couldn't find scalar value";
+  return scalars_.at(v->unique());
+}
+
+void TensorExprKernel::promoteInputs(std::vector<ExprHandle>& inputs) {
+  if (inputs.empty()) {
+    return;
+  }
+
+  // Find the highest type among the inputs.
+  ScalarType highType = inputs[0].dtype().scalar_type();
+  for (int i = 0; i < inputs.size(); ++i) {
+    ScalarType iType = inputs[i].dtype().scalar_type();
+    if (iType == ScalarType::Bool) {
+      continue;
+    }
+    highType = promoteTypes(highType, iType);
+  }
+
+  for (ExprHandle& e : inputs) {
+    if (e.dtype().scalar_type() == ScalarType::Bool) {
+      continue;
+    }
+
+    if (e.dtype().scalar_type() == highType) {
+      continue;
+    }
+
+    switch (highType) {
+#define TYPE_CASE(Type, Name) \
+  case ScalarType::Name:      \
+    e = cast<Type>(e);        \
+    break;
+      AT_FORALL_SCALAR_TYPES_AND(Half, TYPE_CASE);
+#undef TYPE_CASE
+      default:
+        LOG(FATAL) << "Unsupported datatype: " << highType;
+    }
+  }
+}
+
+ExprHandle TensorExprKernel::demoteOutput(
+    const ExprHandle& e,
+    const torch::jit::Value* v) {
+  CHECK(v->type()->kind() == TypeKind::TensorType);
+  auto tt = *v->type()->cast<TensorType>()->scalarType();
+
+  if (tt == static_cast<at::ScalarType>(e.dtype().scalar_type())) {
+    return e;
+  }
+
+  switch (tt) {
+#define TYPE_CASE(Type, Name) \
+  case at::ScalarType::Name:  \
+    return cast<Type>(e);
+    AT_FORALL_SCALAR_TYPES_AND(Half, TYPE_CASE);
+#undef TYPE_CASE
+    case at::ScalarType::Bool:
+      return e;
+    default:
+      LOG(FATAL) << "Unsupported datatype";
+  }
+
+  return e;
+}
+
+static bool isOne(ExprHandle e) {
+  auto const& n = e.AsNode<IntImm>();
+  if (!n) {
+    return false;
+  }
+  return n->value() == 1;
+}
+
+static std::vector<ExprHandle> broadcastShapes(
+    const std::vector<ExprHandle>& a,
+    const std::vector<ExprHandle>& b) {
+  auto at = a.rbegin();
+  auto bt = b.rbegin();
+  std::vector<ExprHandle> ret;
+  while (at != a.rend() || bt != b.rend()) {
+    if (at == a.rend()) {
+      ret.push_back(*bt++);
+      continue;
+    }
+    if (bt == b.rend()) {
+      ret.push_back(*at++);
+      continue;
+    }
+    // TODO: if neither *at nor *bt is 1, ensure they are identical
+    // expressions.  Nb: `==` doesn't work since that simply produces a new
+    // ExprHandle.
+    ExprHandle dim = isOne(*at) ? *bt : *at;
+    ret.push_back(dim);
+    at++;
+    bt++;
+  }
+  std::reverse(ret.begin(), ret.end());
+  return ret;
+}
+
+template <typename... Args>
+static std::vector<ExprHandle> broadcastShapes(
+    const std::vector<ExprHandle>& a,
+    const std::vector<ExprHandle>& b,
+    Args... args) {
+  return broadcastShapes(broadcastShapes(a, b), args...);
+}
+
+std::vector<ExprHandle> TensorExprKernel::valueShape(
+    const torch::jit::Value* v) {
+  auto it = tensors_.find(v->unique());
+  if (it == tensors_.end()) {
+    return {};
+  }
+  return ExprVectorToExprHandleVector(it->second->dims());
+}
+
+Tensor* TensorExprKernel::ComputeOneOperand(
+    const std::string& name,
+    const torch::jit::Value* v,
+    std::function<ExprHandle(const ExprHandle&)> inner_expr) {
+  auto const& n = v->node();
+  auto const& shape = valueShape(n->inputs()[0]);
+  return Compute(
+      name,
+      c10::fmap<DimArg>(shape),
+      [this, v, inner_expr](const std::vector<VarHandle>& axes) {
+        auto const& n = v->node();
+        std::vector<ExprHandle> inputs = {
+            tensorOrConstant(n->inputs()[0], axes)};
+
+        promoteInputs(inputs);
+        ExprHandle compute = inner_expr(inputs[0]);
+        return demoteOutput(compute, n->output());
+      });
+}
+
+Tensor* TensorExprKernel::ComputeTwoOperand(
+    const std::string& name,
+    const torch::jit::Value* v,
+    std::function<ExprHandle(const ExprHandle&, const ExprHandle&)>
+        inner_expr) {
+  auto const& n = v->node();
+  auto const& shape =
+      broadcastShapes(valueShape(n->inputs()[0]), valueShape(n->inputs()[1]));
+  return Compute(
+      name,
+      c10::fmap<DimArg>(shape),
+      [this, v, inner_expr](const std::vector<VarHandle>& axes) {
+        auto const& n = v->node();
+        std::vector<ExprHandle> inputs = {
+            tensorOrConstant(n->inputs()[0], axes),
+            tensorOrConstant(n->inputs()[1], axes),
+        };
+
+        promoteInputs(inputs);
+        ExprHandle compute = inner_expr(inputs[0], inputs[1]);
+        return demoteOutput(compute, n->output());
+      });
+}
+
+Tensor* TensorExprKernel::ComputeTwoOperandWithAlpha(
+    const std::string& name,
+    const torch::jit::Value* v,
+    std::function<ExprHandle(const ExprHandle&, const ExprHandle&)>
+        inner_expr) {
+  auto const& n = v->node();
+  auto const& shape =
+      broadcastShapes(valueShape(n->inputs()[0]), valueShape(n->inputs()[1]));
+  return Compute(
+      name,
+      c10::fmap<DimArg>(shape),
+      [this, v, inner_expr](const std::vector<VarHandle>& axes) {
+        auto const& n = v->node();
+        std::vector<ExprHandle> inputs = {
+            tensorOrConstant(n->inputs()[0], axes),
+            tensorOrConstant(n->inputs()[1], axes),
+            tensorOrConstant(n->inputs()[2], axes),
+        };
+
+        promoteInputs(inputs);
+        ExprHandle compute = inner_expr(inputs[0], inputs[2] * inputs[1]);
+        return demoteOutput(compute, n->output());
+      });
+}
+
+Tensor* TensorExprKernel::ComputeConditionWithTwoOperand(
+    const std::string& name,
+    const torch::jit::Value* v,
+    std::function<
+        ExprHandle(const ExprHandle&, const ExprHandle&, const ExprHandle&)>
+        inner_expr) {
+  auto const& n = v->node();
+  auto const& shape = broadcastShapes(
+      valueShape(n->inputs()[0]),
+      valueShape(n->inputs()[1]),
+      valueShape(n->inputs()[2]));
+  return Compute(
+      name,
+      c10::fmap<DimArg>(shape),
+      [this, v, inner_expr](const std::vector<VarHandle>& axes) {
+        auto const& n = v->node();
+        std::vector<ExprHandle> inputs = {
+            tensorOrConstant(n->inputs()[1], axes),
+            tensorOrConstant(n->inputs()[2], axes),
+        };
+
+        promoteInputs(inputs);
+        // First expr is the condition, which we don't promote
+        inputs.emplace(inputs.begin(), tensorOrConstant(n->inputs()[0], axes));
+        ExprHandle compute = inner_expr(inputs[0], inputs[1], inputs[2]);
+        return demoteOutput(compute, n->output());
+      });
+}
+
+Tensor* TensorExprKernel::ComputeThreeOperand(
+    const std::string& name,
+    const torch::jit::Value* v,
+    std::function<
+        ExprHandle(const ExprHandle&, const ExprHandle&, const ExprHandle&)>
+        inner_expr) {
+  auto const& n = v->node();
+  auto const& shape = broadcastShapes(
+      valueShape(n->inputs()[0]),
+      valueShape(n->inputs()[1]),
+      valueShape(n->inputs()[2]));
+  return Compute(
+      name,
+      c10::fmap<DimArg>(shape),
+      [this, v, inner_expr](const std::vector<VarHandle>& axes) {
+        auto const& n = v->node();
+        std::vector<ExprHandle> inputs = {
+            tensorOrConstant(n->inputs()[0], axes),
+            tensorOrConstant(n->inputs()[1], axes),
+            tensorOrConstant(n->inputs()[2], axes),
+        };
+
+        promoteInputs(inputs);
+        ExprHandle compute = inner_expr(inputs[0], inputs[1], inputs[2]);
+        return demoteOutput(compute, n->output());
+      });
+}
+
+Tensor* TensorExprKernel::ComputeFourOperand(
+    const std::string& name,
+    const torch::jit::Value* v,
+    std::function<ExprHandle(
+        const ExprHandle&,
+        const ExprHandle&,
+        const ExprHandle&,
+        const ExprHandle&)> inner_expr) {
+  auto const& n = v->node();
+  auto const& shape = broadcastShapes(
+      valueShape(n->inputs()[0]),
+      valueShape(n->inputs()[1]),
+      valueShape(n->inputs()[2]),
+      valueShape(n->inputs()[3]));
+  return Compute(
+      name,
+      c10::fmap<DimArg>(shape),
+      [this, v, inner_expr](const std::vector<VarHandle>& axes) {
+        auto const& n = v->node();
+        std::vector<ExprHandle> inputs = {
+            tensorOrConstant(n->inputs()[0], axes),
+            tensorOrConstant(n->inputs()[1], axes),
+            tensorOrConstant(n->inputs()[2], axes),
+            tensorOrConstant(n->inputs()[3], axes),
+        };
+
+        promoteInputs(inputs);
+        ExprHandle compute =
+            inner_expr(inputs[0], inputs[1], inputs[2], inputs[3]);
+        return demoteOutput(compute, n->output());
+      });
+}
+
+Tensor* TensorExprKernel::ComputeValue(const torch::jit::Value* v) {
+  switch (v->node()->kind()) {
+    case aten::add: {
+      return ComputeTwoOperandWithAlpha(
+          "aten_add", v, [](const ExprHandle& lhs, const ExprHandle& rhs) {
+            return lhs + rhs;
+          });
+    } break;
+
+    case aten::_cast_Float: {
+      return ComputeOneOperand("aten_cast_float", v, [](const ExprHandle& a) {
+        return cast<float>(a);
+      });
+    } break;
+
+    case aten::sub: {
+      return ComputeTwoOperandWithAlpha(
+          "aten_sub", v, [](const ExprHandle& lhs, const ExprHandle& rhs) {
+            return lhs - rhs;
+          });
+    } break;
+
+    case aten::mul: {
+      return ComputeTwoOperand(
+          "aten_mul", v, [](const ExprHandle& lhs, const ExprHandle& rhs) {
+            return lhs * rhs;
+          });
+    } break;
+
+    case aten::div: {
+      return ComputeTwoOperand(
+          "aten_div", v, [](const ExprHandle& lhs, const ExprHandle& rhs) {
+            return lhs / rhs;
+          });
+    } break;
+
+    case aten::__and__: {
+      return ComputeTwoOperand(
+          "aten_and", v, [](const ExprHandle& lhs, const ExprHandle& rhs) {
+            return lhs & rhs;
+          });
+    } break;
+
+    case aten::__or__: {
+      return ComputeTwoOperand(
+          "aten_or", v, [](const ExprHandle& lhs, const ExprHandle& rhs) {
+            return lhs | rhs;
+          });
+    } break;
+
+    case aten::__xor__: {
+      return ComputeTwoOperand(
+          "aten_xor", v, [](const ExprHandle& lhs, const ExprHandle& rhs) {
+            return lhs ^ rhs;
+          });
+    } break;
+
+    case aten::__lshift__: {
+      return ComputeTwoOperand(
+          "aten_lshift", v, [](const ExprHandle& lhs, const ExprHandle& rhs) {
+            return lhs << rhs;
+          });
+    } break;
+
+    case aten::__rshift__: {
+      return ComputeTwoOperand(
+          "aten_rshift", v, [](const ExprHandle& lhs, const ExprHandle& rhs) {
+            return lhs >> rhs;
+          });
+    } break;
+
+    case aten::addcmul: {
+      return ComputeFourOperand(
+          "aten_addcmul",
+          v,
+          [](const ExprHandle& a0,
+             const ExprHandle& a1,
+             const ExprHandle& a2,
+             const ExprHandle& a3) { return a0 + a3 * a1 * a2; });
+    } break;
+
+    case aten::eq: {
+      return ComputeTwoOperand(
+          "aten_eq", v, [](const ExprHandle& lhs, const ExprHandle& rhs) {
+            return lhs == rhs;
+          });
+    } break;
+
+    case aten::ne: {
+      return ComputeTwoOperand(
+          "aten_ne", v, [](const ExprHandle& lhs, const ExprHandle& rhs) {
+            return lhs != rhs;
+          });
+    } break;
+    case aten::ge: {
+      return ComputeTwoOperand(
+          "aten_ge", v, [](const ExprHandle& lhs, const ExprHandle& rhs) {
+            return lhs >= rhs;
+          });
+    } break;
+
+    case aten::gt: {
+      return ComputeTwoOperand(
+          "aten_gt", v, [](const ExprHandle& lhs, const ExprHandle& rhs) {
+            return lhs > rhs;
+          });
+    } break;
+
+    case aten::le: {
+      return ComputeTwoOperand(
+          "aten_le", v, [](const ExprHandle& lhs, const ExprHandle& rhs) {
+            return lhs <= rhs;
+          });
+    } break;
+
+    case aten::lt: {
+      return ComputeTwoOperand(
+          "aten_lt", v, [](const ExprHandle& lhs, const ExprHandle& rhs) {
+            return lhs < rhs;
+          });
+    } break;
+
+    case aten::min: {
+      return ComputeTwoOperand(
+          "aten_min", v, [](const ExprHandle& lhs, const ExprHandle& rhs) {
+            return Min::make(lhs, rhs, false);
+          });
+    } break;
+
+    case aten::max: {
+      return ComputeTwoOperand(
+          "aten_max", v, [](const ExprHandle& lhs, const ExprHandle& rhs) {
+            return Max::make(lhs, rhs, false);
+          });
+    } break;
+
+    case aten::clamp: {
+      bool no_min = false;
+      bool no_max = false;
+      if (v->node()->input(1)->node()->kind() == prim::Constant) {
+        const auto val = toIValue(v->node()->input(1)).value();
+        if (val.isNone()) {
+          no_min = true;
+        }
+      }
+
+      if (v->node()->input(2)->node()->kind() == prim::Constant) {
+        const auto val = toIValue(v->node()->input(2)).value();
+        if (val.isNone()) {
+          no_max = true;
+        }
+      }
+
+      return ComputeThreeOperand(
+          "aten_clamp",
+          v,
+          [no_min, no_max](
+              const ExprHandle& in,
+              const ExprHandle& min,
+              const ExprHandle& max) {
+            if (no_min && no_max) {
+              return in;
+            } else if (no_min) {
+              return Min::make(in, max, false);
+            } else if (no_max) {
+              return Max::make(in, min, false);
+            } else {
+              return Max::make(Min::make(in, max, false), min, false);
+            }
+          });
+    } break;
+
+    case aten::sigmoid: {
+      return ComputeOneOperand("aten_sigmoid", v, [](const ExprHandle& a) {
+        return ExprHandle(1.0f) /
+            (ExprHandle(1.0f) + exp(ExprHandle(-0.0f) - a));
+      });
+    } break;
+
+    case aten::reciprocal: {
+      return ComputeOneOperand("aten_reciprocal", v, [](const ExprHandle& a) {
+        return ExprHandle(1.0f) / a;
+      });
+    } break;
+
+    case aten::neg: {
+      return ComputeOneOperand("aten_neg", v, [](const ExprHandle& a) {
+        return ExprHandle(-0) - a;
+      });
+    } break;
+
+    case aten::relu: {
+      return ComputeOneOperand("aten_relu", v, [](const ExprHandle& a) {
+        return Max::make(a, 0, false);
+      });
+    } break;
+
+    case aten::log: {
+      return ComputeOneOperand(
+          "aten_log", v, [](const ExprHandle& a) { return log(a); });
+    } break;
+
+    case aten::log10: {
+      return ComputeOneOperand(
+          "aten_log10", v, [](const ExprHandle& a) { return log10(a); });
+    } break;
+
+    case aten::log2: {
+      return ComputeOneOperand(
+          "aten_log2", v, [](const ExprHandle& a) { return log2(a); });
+    } break;
+
+    case aten::exp: {
+      return ComputeOneOperand(
+          "aten_exp", v, [](const ExprHandle& a) { return exp(a); });
+    } break;
+
+    case aten::expm1: {
+      return ComputeOneOperand(
+          "aten_expm1", v, [](const ExprHandle& a) { return expm1(a); });
+    } break;
+
+    case aten::erf: {
+      return ComputeOneOperand(
+          "aten_erf", v, [](const ExprHandle& a) { return erf(a); });
+    } break;
+
+    case aten::erfc: {
+      return ComputeOneOperand(
+          "aten_erfc", v, [](const ExprHandle& a) { return erfc(a); });
+    } break;
+
+    case aten::cos: {
+      return ComputeOneOperand(
+          "aten_cos", v, [](const ExprHandle& a) { return cos(a); });
+    } break;
+
+    case aten::sin: {
+      return ComputeOneOperand(
+          "aten_sin", v, [](const ExprHandle& a) { return sin(a); });
+    } break;
+
+    case aten::tan: {
+      return ComputeOneOperand(
+          "aten_tan", v, [](const ExprHandle& a) { return tan(a); });
+    } break;
+
+    case aten::type_as: {
+      return ComputeTwoOperand(
+          "aten_type_as", v, [](const ExprHandle& lhs, const ExprHandle& rhs) {
+            return Cast::make(rhs.dtype(), lhs);
+          });
+    } break;
+
+    case aten::rand_like: {
+      return ComputeOneOperand("aten_rand_like", v, [](const ExprHandle& a) {
+        return Intrinsics::make(IntrinsicsOp::kRand, a.dtype());
+      });
+    } break;
+
+    case aten::pow: {
+      return ComputeTwoOperand(
+          "aten_pow", v, [](const ExprHandle& lhs, const ExprHandle& rhs) {
+            const FloatImm* float_imm = rhs.AsNode<FloatImm>();
+            if (float_imm) {
+              float imm = float_imm->value();
+              if (imm == 1.0f) {
+                return lhs;
+              } else if (imm == 2.0f) {
+                return lhs * lhs;
+              } else if (imm == 3.0f) {
+                return (lhs * lhs) * lhs;
+              } else if (imm == 4.0f) {
+                ExprHandle tmp = lhs * lhs;
+                return tmp * tmp;
+              } else if (imm == 0.5f) {
+                return sqrt(lhs);
+              } else if (imm == 0.0f) {
+                return ExprHandle(1.0f);
+              } else if (imm == -0.5f) {
+                return rsqrt(lhs);
+              } else if (imm == -1.0f) {
+                return ExprHandle(1.0f) / lhs;
+              } else if (imm == -2.0f) {
+                return ExprHandle(1.0f) / (lhs * lhs);
+              }
+            }
+
+            const Cast* float_cast = rhs.AsNode<Cast>();
+            if (float_cast) {
+              const IntImm* int_imm =
+                  dynamic_cast<const IntImm*>(float_cast->src_value());
+              if (int_imm) {
+                float imm = int_imm->value();
+                if (imm == 1) {
+                  return lhs;
+                } else if (imm == 2) {
+                  return lhs * lhs;
+                } else if (imm == 3) {
+                  return (lhs * lhs) * lhs;
+                } else if (imm == 4) {
+                  ExprHandle tmp = lhs * lhs;
+                  return tmp * tmp;
+                } else if (imm == 0) {
+                  return ExprHandle(1.0f);
+                } else if (imm == -1) {
+                  return ExprHandle(1.0f) / lhs;
+                } else if (imm == -2) {
+                  return ExprHandle(1.0f) / (lhs * lhs);
+                }
+              }
+            }
+            return pow(lhs, rhs);
+          });
+    } break;
+
+    case aten::fmod: {
+      return ComputeTwoOperand(
+          "aten_fmod", v, [](const ExprHandle& lhs, const ExprHandle& rhs) {
+            return fmod(lhs, rhs);
+          });
+    } break;
+
+    case aten::lerp: {
+      return ComputeThreeOperand(
+          "aten_lerp",
+          v,
+          [](const ExprHandle& a,
+             const ExprHandle& end,
+             const ExprHandle& weight) { return a + weight * (end - a); });
+    } break;
+    case aten::remainder: {
+      return ComputeTwoOperand(
+          "aten_remainder",
+          v,
+          [](const ExprHandle& lhs, const ExprHandle& rhs) {
+            return fmod((rhs + fmod(lhs, rhs)), rhs);
+          });
+
+    } break;
+
+    case aten::acos: {
+      return ComputeOneOperand(
+          "aten_acos", v, [](const ExprHandle& a) { return acos(a); });
+    } break;
+
+    case aten::asin: {
+      return ComputeOneOperand(
+          "aten_asin", v, [](const ExprHandle& a) { return asin(a); });
+    } break;
+
+    case aten::cosh: {
+      return ComputeOneOperand(
+          "aten_cosh", v, [](const ExprHandle& a) { return cosh(a); });
+    } break;
+
+    case aten::sinh: {
+      return ComputeOneOperand(
+          "aten_sinh", v, [](const ExprHandle& a) { return sinh(a); });
+    } break;
+
+    case aten::atan: {
+      return ComputeOneOperand(
+          "aten_atan", v, [](const ExprHandle& a) { return atan(a); });
+    } break;
+
+    case aten::atan2: {
+      return ComputeTwoOperand(
+          "aten_atan2", v, [](const ExprHandle& lhs, const ExprHandle& rhs) {
+            return atan2(lhs, rhs);
+          });
+    } break;
+
+    case aten::tanh: {
+      return ComputeOneOperand("aten_tanh", v, [](const ExprHandle& a) {
+        // return
+        // (ExprHandle(-.67436811832e-5f)+(ExprHandle(.2468149110712040f)+(ExprHandle(.583691066395175e-1f)+ExprHandle(.3357335044280075e-1f)*a)*a)*a)/(ExprHandle(.2464845986383725f)+(ExprHandle(.609347197060491e-1f)+(ExprHandle(.1086202599228572f)+ExprHandle(.2874707922475963e-1f)*a)*a)*a);
+        return tanh(a);
+      });
+    } break;
+
+    case aten::sqrt: {
+      return ComputeOneOperand(
+          "aten_sqrt", v, [](const ExprHandle& a) { return sqrt(a); });
+    } break;
+
+    case aten::rsqrt: {
+      return ComputeOneOperand(
+          "aten_rsqrt", v, [](const ExprHandle& a) { return rsqrt(a); });
+    } break;
+
+    case aten::abs: {
+      return ComputeOneOperand(
+          "aten_abs", v, [](const ExprHandle& a) { return fabs(a); });
+    } break;
+
+    case aten::ceil: {
+      return ComputeOneOperand(
+          "aten_ceil", v, [](const ExprHandle& a) { return ceil(a); });
+    } break;
+
+    case aten::floor: {
+      return ComputeOneOperand(
+          "aten_floor", v, [](const ExprHandle& a) { return floor(a); });
+    } break;
+
+    case aten::round: {
+      return ComputeOneOperand(
+          "aten_round", v, [](const ExprHandle& a) { return round(a); });
+    } break;
+
+    case aten::trunc: {
+      return ComputeOneOperand(
+          "aten_trunc", v, [](const ExprHandle& a) { return trunc(a); });
+    } break;
+
+    case aten::threshold: {
+      return ComputeThreeOperand(
+          "aten_threshold",
+          v,
+          [](const ExprHandle& a,
+             const ExprHandle& threshold,
+             const ExprHandle& value) {
+            return ifThenElse(CompareSelect::make(a, threshold, kGT), a, value);
+          });
+    } break;
+
+    case aten::where: {
+      return ComputeConditionWithTwoOperand(
+          "aten_where",
+          v,
+          [](const ExprHandle& a0, const ExprHandle& a1, const ExprHandle& a2) {
+            return ifThenElse(a0, a1, a2);
+          });
+    } break;
+
+    case aten::frac: {
+      return ComputeOneOperand(
+          "aten_frac", v, [](const ExprHandle& a) { return a - floor(a); });
+    } break;
+
+    case aten::lgamma: {
+      return ComputeOneOperand(
+          "aten_lgamma", v, [](const ExprHandle& a) { return lgamma(a); });
+    } break;
+
+    case prim::ConstantChunk: {
+      return Compute(
+          "prim_constantchunk",
+          texprDims(v),
+          [this, v](const std::vector<VarHandle>& axes) {
+            auto const& n = v->node();
+            int64_t dim = n->i(attr::dim);
+            int64_t chunks = n->i(attr::chunks);
+            return chunk(
+                tensors_.at(n->inputs()[0]->unique()),
+                v->offset(),
+                dim,
+                chunks,
+                axes);
+          });
+    }
+
+    case aten::cat: {
+      return Compute(
+          "aten_cat",
+          texprDims(v),
+          [this, v](const std::vector<VarHandle>& axes) {
+            auto const& n = v->node();
+            auto inputs = n->inputs()[0]->node()->inputs();
+            size_t dim = n->inputs()[1]->node()->i(attr::value);
+
+            std::vector<ExprHandle> new_axes(axes.begin(), axes.end());
+            ExprHandle load = tensorOrConstant(inputs[0], new_axes);
+            size_t offset = bufferSizes(tensors_.at(inputs[0]->unique()))[dim];
+            new_axes[dim] = new_axes[dim] - IntImm::make(offset);
+
+            for (int ii = 1; ii < inputs.size(); ++ii) {
+              load = ifThenElse(
+                  CompareSelect::make(axes[dim], IntImm::make(offset), kLT),
+                  load,
+                  tensorOrConstant(inputs[ii], new_axes));
+              offset += bufferSizes(tensors_.at(inputs[ii]->unique()))[dim];
+              new_axes[dim] = axes[dim] - IntImm::make(offset);
+            }
+
+            return load;
+          });
+    }
+
+    case aten::slice: {
+      return Compute(
+          "aten_slice",
+          texprDims(v),
+          [this, v](const std::vector<VarHandle>& axes) {
+            auto const& n = v->node();
+            int dim = constant(n->inputs()[1]).AsNode<IntImm>()->value();
+            ExprHandle start = constant(n->inputs()[2]);
+            ExprHandle stride = constant(n->inputs()[4]);
+
+            std::vector<ExprHandle> new_axes(axes.begin(), axes.end());
+            new_axes[dim] = stride * new_axes[dim] + start;
+            return tensorOrConstant(n->inputs()[0], new_axes);
+          });
+    }
+
+    case aten::unsqueeze: {
+      return Compute(
+          "aten_unsqueeze",
+          texprDims(v),
+          [this, v](const std::vector<VarHandle>& axes) {
+            auto const& n = v->node();
+            int dim = constant(n->inputs()[1]).AsNode<IntImm>()->value();
+            if (dim < 0) {
+              dim += axes.size() - 1;
+            }
+
+            std::vector<ExprHandle> new_axes(axes.begin(), axes.end());
+            new_axes.erase(new_axes.begin() + dim);
+            return tensorOrConstant(n->inputs()[0], new_axes);
+          });
+    }
+
+    case aten::_sigmoid_backward: {
+      return ComputeTwoOperand(
+          "aten_sigmoid_backward",
+          v,
+          [](const ExprHandle& lhs, const ExprHandle& rhs) {
+            return lhs * rhs * (ExprHandle(1.0f) - rhs);
+          });
+    }
+
+    case aten::_tanh_backward: {
+      return ComputeTwoOperand(
+          "aten_tanh_backward",
+          v,
+          [](const ExprHandle& lhs, const ExprHandle& rhs) {
+            return lhs * (ExprHandle(1.0f) - rhs * rhs);
+          });
+    }
+
+    default: {
+      throw std::runtime_error("Unhandled node kind");
+    }
+  }
+}
+
+void TensorExprKernel::LowerToBackend(BackendType backend_type) {
+  std::vector<Tensor*> tensor_outputs(tensor_outputs_);
+
+  torch::jit::tensorexpr::schedule::LoopNest l(tensor_outputs);
+
+  // Compute non-output tensors_ inline
+  for (auto& p : tensors_) {
+    l.ComputeInline(l.getLoopBodyFor(p.second));
+  }
+
+  l.ApplyInlines();
+  Stmt* stmt = l.root_stmt();
+
+  // Set up formal params (inputs, then outputs) for kernel.
+  std::vector<CodeGen::BufferArg> params;
+  for (auto const& arg : kernelArgs_) {
+    params.push_back(arg.buffer());
+    for (auto const& size : arg.sizes()) {
+      params.push_back(size.var);
+    }
+    for (auto const& stride : arg.strides()) {
+      params.push_back(stride.var);
+    }
+  }
+  for (auto& o : tensor_outputs) {
+    params.push_back(o);
+  }
+
+  // Generate code.
+  std::string codegen_name;
+  switch (backend_type_) {
+    case kSimpleIREval:
+      codegen_name = "simple_ir_eval";
+      break;
+    default:
+      throw std::runtime_error(
+          "invalid backend type: " +
+          std::to_string(static_cast<int>(backend_type_)));
+  }
+  codegen_ = CreateCodeGen(codegen_name, stmt, params);
+}
+
+void TensorExprKernel::PickAndCheckBackendType(
+    const at::ArrayRef<IValue>& inputs) {
+  at::Device device = [&inputs]() {
+    for (auto const& input : inputs) {
+      if (input.isTensor()) {
+        return input.toTensor().device();
+      }
+    }
+    throw std::runtime_error("No tensor inputs");
+  }();
+  BackendType backend_type = BackendType::kUninitialized;
+  if (device.type() == at::kCPU) {
+    backend_type = kSimpleIREval;
+  } else {
+    throw std::runtime_error("Invalid device type");
+  }
+
+  if (backend_type_ == kUninitialized) {
+    backend_type_ = backend_type;
+    device_ = device;
+    LowerToBackend(backend_type);
+  } else if (backend_type_ != backend_type) {
+    // TODO: if we have to support muliptole backends with the same subgraph,
+    // we need to add kernel caching.
+    throw std::runtime_error(
+        "Inconsistent backend_type: " + std::to_string(backend_type_) + " vs " +
+        std::to_string(backend_type));
+  }
+}
+
+void TensorExprKernel::CodeGenRun(
+    const std::vector<CodeGen::CallArg>& run_args) {
+  switch (backend_type_) {
+    case kSimpleIREval:
+      codegen_->call(run_args);
+      break;
+    default:
+      throw std::runtime_error(
+          "Invalid backend type: " + std::to_string(backend_type_));
+  }
+}
+
+ExprHandle TensorExprKernel::createInputIndexExpr(
+    const Buffer& buffer,
+    const std::vector<VarHandle>& axes,
+    const c10::VaryingShape& sizes,
+    const c10::VaryingStrides& strides,
+    const c10::VaryingStrides& contiguity,
+    const std::unordered_map<int64_t, VarHandle>& sizeVars) {
+  TORCH_CHECK(
+      axes.size() == strides.size(), "strides and axes are not the same size");
+
+  std::vector<ShapeArg> strideArgs;
+  std::vector<ShapeArg> sizeArgs;
+  ExprHandle stride = 1;
+  ExprHandle index = 0;
+  int n = axes.size() - 1;
+
+  for (int i = 0; i < axes.size(); i++) {
+    // For discontiguous tensors, create a parameter to represent stride.
+    if (!*contiguity[i]) {
+      VarHandle v = VarHandle{
+          "stride_" + buffer.data()->name_hint() + "_" + std::to_string(i),
+          kInt};
+      strideArgs.emplace_back(n - i, v);
+      stride = v;
+    }
+
+    // If size is dynamic (indicated by negative value) create a size param.
+    ExprHandle size;
+    auto sizeVal = *sizes[n - i];
+    if (sizeVal < 0) {
+      auto it = sizeVars.find(sizeVal);
+      TORCH_CHECK(it != sizeVars.end());
+      auto const& v = it->second;
+      sizeArgs.emplace_back(n - i, v);
+      size = v;
+    } else {
+      size = int32_t{sizeVal};
+    }
+
+    index = index + axes[n - i] * stride;
+    stride = stride * size;
+  }
+
+  kernelArgs_.emplace_back(buffer, std::move(sizeArgs), std::move(strideArgs));
+  return buffer(index);
+}
+
+void TensorExprKernel::bindInput(const torch::jit::Value* input) {
+  auto const& t = input->type();
+  switch (t->kind()) {
+    case TypeKind::TensorType: {
+      auto tt = input->type()->cast<TensorType>();
+      Buffer in_buffer(
+          "t" + input->debugName(),
+          ToDtype(static_cast<ScalarType>(*tt->scalarType())),
+          {0});
+      std::vector<DimArg> inputTensorDims;
+      std::unordered_map<int64_t, VarHandle> sizeVars;
+      for (int i = 0; i < *tt->sizes().size(); i++) {
+        auto const& size = *tt->sizes()[i];
+        if (size < 0) {
+          VarHandle v(
+              "size_" + std::to_string(input->unique()) + "_" +
+                  std::to_string(i),
+              kInt);
+          sizeVars.emplace(size, v);
+          inputTensorDims.push_back(v);
+        } else {
+          inputTensorDims.push_back({int32_t{size}, "i" + std::to_string(i)});
+        }
+      }
+#ifdef DYNAMIC_SHAPES
+      tensors_.emplace(
+          input->unique(),
+          Compute(
+              "input",
+              inputTensorDims,
+              [&](const std::vector<VarHandle>& axes) {
+                return createInputIndexExpr(
+                    in_buffer,
+                    axes,
+                    tt->sizes(),
+                    tt->strides(),
+                    tt->contiguity(),
+                    sizeVars);
+              }));
+#else
+      auto const& strides = tt->strides();
+      tensors_.emplace(
+          input->unique(),
+          Compute(
+              "input",
+              inputTensorDims,
+              [&](const std::vector<VarHandle>& axes) {
+                ExprHandle idx = 0;
+                for (int64_t i = 0; i < axes.size(); i++) {
+                  idx = idx + axes[i] * int32_t{*strides[i]};
+                }
+                return in_buffer(idx);
+              }));
+      kernelArgs_.emplace_back(
+          in_buffer, std::vector<ShapeArg>(), std::vector<ShapeArg>());
+#endif
+      break;
+    }
+    case TypeKind::FloatType: {
+      VarHandle v("v" + input->debugName(), kFloat);
+      kernelArgs_.push_back(v);
+      scalars_.emplace(input->unique(), v);
+      break;
+    }
+    case TypeKind::IntType: {
+      VarHandle v("v" + input->debugName(), kInt);
+      kernelArgs_.push_back(v);
+      scalars_.emplace(input->unique(), v);
+      break;
+    }
+    default: {
+      LOG(FATAL) << "Unhandled input type: " << *t;
+      break;
+    }
+  }
+}
+
+TensorExprKernel::TensorExprKernel(const Graph& subgraph) {
+  KernelScope kernel_scope(&kernel_arena_);
+
+  // Bind inputs to buffers.
+  n_inputs_ = subgraph.inputs().size();
+  for (auto const& input : subgraph.inputs()) {
+    bindInput(input);
+  }
+
+  // Bind nodes to tensor compute expressions.
+  for (auto const& n : subgraph.nodes()) {
+    if (n->kind() == prim::Constant || n->kind() == prim::ListConstruct) {
+      continue;
+    } else {
+      for (auto const& output : n->outputs()) {
+        if (output->hasUses()) {
+          tensors_.emplace(output->unique(), ComputeValue(output));
+        }
+      }
+    }
+  }
+
+  // Move output operands from `tensors_` to `tensor_outputs_`
+  for (const auto& output : subgraph.outputs()) {
+    CHECK(tensors_.count(output->unique())) << "Output must be a tensor";
+    tensor_outputs_.emplace_back(tensors_.at(output->unique()));
+    tensors_.erase(output->unique());
+  }
+}
+
+void TensorExprKernel::run(Stack& stack) {
+  KernelScope kernel_scope(&kernel_arena_);
+  // Set up arguments (inputs, then outputs) for kernel call.
+  auto inputs = last(stack, n_inputs_);
+  PickAndCheckBackendType(inputs);
+
+  std::map<const Expr*, int32_t> varToSize;
+
+  std::vector<CodeGen::CallArg> run_args;
+  for (int i = 0; i < inputs.size(); i++) {
+    auto const& input = inputs[i];
+    if (input.isInt()) {
+      run_args.push_back((int32_t)input.toInt());
+    } else if (input.isDouble()) {
+      run_args.push_back((float)input.toDouble());
+    } else if (input.isTensor()) {
+      auto const& tensor = input.toTensor();
+      run_args.push_back(tensor.data_ptr());
+      for (auto const& size : kernelArgs_[i].sizes()) {
+        int32_t s = tensor.sizes()[size.idx];
+        run_args.push_back(s);
+        varToSize[size.var.node()] = s;
+      }
+      for (auto const& stride : kernelArgs_[i].strides()) {
+        int32_t s = tensor.strides()[stride.idx];
+        run_args.push_back(s);
+      }
+    }
+  }
+
+  std::vector<at::Tensor> outputs;
+  for (auto& o : tensor_outputs_) {
+    std::vector<int64_t> tensorSize;
+    for (const Expr* dim : o->dims()) {
+      auto it = varToSize.find(dim);
+      if (it != varToSize.end()) {
+        tensorSize.push_back(it->second);
+      } else {
+        const IntImm* s = dynamic_cast<const IntImm*>(dim);
+        TORCH_CHECK(s);
+        tensorSize.push_back(s->value());
+      }
+    }
+
+    outputs.push_back(at::empty(
+        tensorSize, c10::TensorOptions(tensorType(o)).device(device_)));
+    run_args.push_back(outputs.back().data_ptr());
+  }
+
+  // Call the kernel.
+  CodeGenRun(run_args);
+
+  // Update the stack.
+  drop(stack, n_inputs_);
+  for (auto& o : outputs) {
+    push_one(stack, std::move(o));
+  }
+}

--- a/torch/csrc/jit/tensorexpr/kernel.h
+++ b/torch/csrc/jit/tensorexpr/kernel.h
@@ -1,0 +1,210 @@
+#pragma once
+
+#include <torch/csrc/jit/ir/ir.h>
+#include <torch/csrc/jit/tensorexpr/codegen.h>
+#include <torch/csrc/jit/tensorexpr/tensor.h>
+
+namespace torch {
+namespace jit {
+namespace tensorexpr {
+
+template <typename T>
+inline std::vector<int64_t> bufferSizes(const T& t) {
+  std::vector<int64_t> sizes;
+  for (int i = 0; i < t->function()->ndim(); i++) {
+    sizes.push_back(
+        dynamic_cast<const IntImm*>(t->function()->dim(i))->value());
+  }
+  return sizes;
+}
+
+template <typename T>
+inline std::vector<ExprHandle> computeIndicesToBroadcast(
+    const std::vector<T>& output_axes,
+    const std::vector<ExprHandle>& input_sizes) {
+  TORCH_CHECK(
+      output_axes.size() >= input_sizes.size(),
+      "Cannot broadcast to a lower rank tensor");
+  std::vector<ExprHandle> bcast;
+  auto axis_it = output_axes.rbegin();
+  auto size_it = input_sizes.rbegin();
+  while (size_it != input_sizes.rend()) {
+    auto const& size = size_it->AsNode<IntImm>();
+    if (size && size->value() == 1) {
+      bcast.push_back(0);
+    } else {
+      bcast.push_back(*axis_it);
+    }
+    ++axis_it;
+    ++size_it;
+  }
+  std::reverse(bcast.begin(), bcast.end());
+  return bcast;
+}
+
+class TensorExprKernel {
+ public:
+  explicit TensorExprKernel(const Graph& subgraph);
+
+  void run(Stack& stack);
+
+ private:
+  enum BackendType {
+    kUninitialized,
+    kSimpleIREval,
+  };
+
+  ExprHandle constant(const torch::jit::Value* v);
+
+  template <typename T, typename T1>
+  ExprHandle broadcast(const T& t, const std::vector<T1>& axes) {
+    return t->call(computeIndicesToBroadcast(
+        axes, ExprVectorToExprHandleVector(t->function()->dims())));
+  }
+
+  template <typename T, typename T1>
+  ExprHandle chunk(
+      const T& t,
+      size_t chunk_idx,
+      size_t dim,
+      size_t chunks,
+      const std::vector<T1>& axes) {
+    auto sizes = bufferSizes(t);
+    size_t step = sizes[dim] / chunks;
+
+    std::vector<ExprHandle> indices;
+    for (size_t i = 0; i < axes.size(); ++i) {
+      if (i == dim) {
+        indices.push_back(axes[i] + IntImm::make(chunk_idx * step));
+      } else {
+        indices.push_back(axes[i]);
+      }
+    }
+
+    return t->call(indices);
+  }
+
+  std::vector<ExprHandle> valueShape(const torch::jit::Value* v);
+
+  void promoteInputs(std::vector<ExprHandle>& inputs);
+
+  ExprHandle demoteOutput(const ExprHandle& e, const torch::jit::Value* v);
+
+  template <typename T>
+  ExprHandle tensorOrConstant(
+      const torch::jit::Value* v,
+      const std::vector<T>& axes) {
+    auto ti = tensors_.find(v->unique());
+    if (ti != tensors_.end()) {
+      return broadcast(ti->second, axes);
+    }
+    return constant(v);
+  }
+
+  Tensor* ComputeOneOperand(
+      const std::string& name,
+      const torch::jit::Value* v,
+      std::function<ExprHandle(const ExprHandle&)> inner_expr);
+
+  Tensor* ComputeTwoOperand(
+      const std::string& name,
+      const torch::jit::Value* v,
+      std::function<ExprHandle(const ExprHandle&, const ExprHandle&)>
+          inner_expr);
+
+  Tensor* ComputeTwoOperandWithAlpha(
+      const std::string& name,
+      const torch::jit::Value* v,
+      std::function<ExprHandle(const ExprHandle&, const ExprHandle&)>
+          inner_expr);
+
+  Tensor* ComputeThreeOperand(
+      const std::string& name,
+      const torch::jit::Value* v,
+      std::function<
+          ExprHandle(const ExprHandle&, const ExprHandle&, const ExprHandle&)>
+          inner_expr);
+
+  Tensor* ComputeConditionWithTwoOperand(
+      const std::string& name,
+      const torch::jit::Value* v,
+      std::function<
+          ExprHandle(const ExprHandle&, const ExprHandle&, const ExprHandle&)>
+          inner_expr);
+
+  Tensor* ComputeFourOperand(
+      const std::string& name,
+      const torch::jit::Value* v,
+      std::function<ExprHandle(
+          const ExprHandle&,
+          const ExprHandle&,
+          const ExprHandle&,
+          const ExprHandle&)> inner_expr);
+
+  Tensor* ComputeValue(const torch::jit::Value* v);
+
+  void LowerToBackend(BackendType backend_type);
+
+  void PickAndCheckBackendType(const at::ArrayRef<IValue>& inputs);
+
+  void CodeGenRun(const std::vector<CodeGen::CallArg>& run_args);
+
+  void bindInput(const torch::jit::Value* input);
+
+  ExprHandle createInputIndexExpr(
+      const Buffer& buffer,
+      const std::vector<VarHandle>& axes,
+      const c10::VaryingShape& sizes,
+      const c10::VaryingStrides& strides,
+      const c10::VaryingStrides& contiguity,
+      const std::unordered_map<int64_t, VarHandle>& sizeVars);
+
+ private:
+  struct ShapeArg {
+    size_t idx;
+    VarHandle var;
+
+    ShapeArg(size_t i, VarHandle v) : idx(i), var(v) {}
+  };
+
+  struct KernelArg {
+    template <typename B>
+    KernelArg(B&& b) : bufferArg_(std::forward<B>(b)) {}
+
+    template <typename B, typename T>
+    KernelArg(B&& b, T&& sizes, T&& strides)
+        : bufferArg_(b),
+          sizeArgs_(std::forward<T>(sizes)),
+          strideArgs_(std::forward<T>(strides)) {}
+
+    const CodeGen::BufferArg& buffer() const {
+      return bufferArg_;
+    }
+
+    const std::vector<ShapeArg>& sizes() const {
+      return sizeArgs_;
+    }
+
+    const std::vector<ShapeArg>& strides() const {
+      return strideArgs_;
+    }
+
+    CodeGen::BufferArg bufferArg_;
+    std::vector<ShapeArg> sizeArgs_;
+    std::vector<ShapeArg> strideArgs_;
+  };
+
+  int64_t n_inputs_ = 0;
+  std::vector<KernelArg> kernelArgs_;
+  std::vector<Tensor*> tensor_outputs_;
+  std::unordered_map<int64_t, Tensor*> tensors_;
+  std::unordered_map<int64_t, VarHandle> scalars_;
+  std::unique_ptr<CodeGen> codegen_;
+  KernelArena kernel_arena_;
+  BackendType backend_type_ = BackendType::kUninitialized;
+  at::Device device_ = at::kCPU;
+};
+
+} // namespace tensorexpr
+} // namespace jit
+} // namespace torch


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #34201 [Do not commit] Add HowToRebaseOnMaster.md doc.
* #34200 [WIP] Changes in test/test_jit_fuser.py test/test_jit_fuser_te.py.
* #34199 [WIP] Changes to peephole.cpp.
* #34198 [WIP] Guard elimination changes from bertmaher/pytorch_fusion.
* #34197 Add tensorexpr benchmarks.
* #34196 Add jit_get_te_* python bindings.
* #34195 Add LLVM codegen for tensor expressions.
* #34194 Add CUDA codegen for tensorexpressions.
* **#34193 Tensorexpr fuser implementation.**
* #34192 Move tensor expressions work from bertmaher/pytorch to pytorch/pytorch.

Differential Revision: [D20244100](https://our.internmc.facebook.com/intern/diff/D20244100)