### PR TITLE
Add LLVM codegen for tensor expressions.

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -480,12 +480,29 @@ if (NOT INTERN_BUILD_MOBILE OR NOT BUILD_CAFFE2_MOBILE)
     ${TORCH_SRC_DIR}/csrc/jit/tensorexpr/ir_printer.cpp
     ${TORCH_SRC_DIR}/csrc/jit/tensorexpr/ir_visitor.cpp
     ${TORCH_SRC_DIR}/csrc/jit/tensorexpr/kernel.cpp
+    ${TORCH_SRC_DIR}/csrc/jit/tensorexpr/llvm_codegen.cpp
+    ${TORCH_SRC_DIR}/csrc/jit/tensorexpr/llvm_jit.cpp
     ${TORCH_SRC_DIR}/csrc/jit/tensorexpr/mem_arena.cpp
     ${TORCH_SRC_DIR}/csrc/jit/tensorexpr/schedule.cpp
     ${TORCH_SRC_DIR}/csrc/jit/tensorexpr/tensor.cpp
     ${TORCH_SRC_DIR}/csrc/jit/tensorexpr/types.cpp
     ${TORCH_SRC_DIR}/csrc/jit/tensorexpr/unique_name_manager.cpp
     )
+
+  if (USE_LLVM)
+    message(STATUS "Looking for LLVM in ${USE_LLVM}")
+    find_package(LLVM QUIET PATHS ${USE_LLVM} NO_DEFAULT_PATH)
+
+    if (LLVM_FOUND)
+      message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
+      message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
+
+      include_directories(${LLVM_INCLUDE_DIRS})
+      add_definitions(-DENABLE_LLVM ${LLVM_DEFINITIONS})
+    endif (LLVM_FOUND)
+  endif (USE_LLVM)
+
+  set_source_files_properties(${TORCH_SRC_DIR}/csrc/jit/tensorexpr/llvm_jit.cpp PROPERTIES COMPILE_FLAGS -fno-rtti)
 
   if (NOT INTERN_DISABLE_MOBILE_INTERP)
     set (MOBILE_SRCS
@@ -653,6 +670,13 @@ endif()
 
 add_library(torch_cpu ${Caffe2_CPU_SRCS})
 torch_compile_options(torch_cpu)  # see cmake/public/utils.cmake
+
+if (LLVM_FOUND)
+  llvm_map_components_to_libnames(LLVM_LINK_LIBS
+    support core analysis executionengine instcombine
+    scalaropts transformutils native orcjit)
+  target_link_libraries(torch_cpu PRIVATE ${LLVM_LINK_LIBS})
+endif (LLVM_FOUND)
 
 # This is required for older versions of CMake, which don't allow
 # specifying add_library() without a list of source files

--- a/test/cpp/tensorexpr/gtest.cpp
+++ b/test/cpp/tensorexpr/gtest.cpp
@@ -12,6 +12,15 @@ namespace jit {
 TH_FORALL_TESTS(TENSOREXPR_GTEST)
 #undef TENSOREXPR_GTEST
 
+#ifdef ENABLE_LLVM
+#define TENSOREXPR_GTEST_LLVM(name)   \
+  TEST(TensorExprTest, name##_LLVM) { \
+    test##name();                     \
+  }
+TH_FORALL_TESTS_LLVM(TENSOREXPR_GTEST_LLVM)
+#undef TENSOREXPR_GTEST_LLVM
+#endif
+
 #ifdef USE_CUDA
 #define TENSOREXPR_GTEST_CUDA(name)   \
   TEST(TensorExprTest, name##_CUDA) { \

--- a/test/cpp/tensorexpr/test_llvm.cpp
+++ b/test/cpp/tensorexpr/test_llvm.cpp
@@ -1,0 +1,1093 @@
+#ifdef ENABLE_LLVM
+#include "test/cpp/tensorexpr/test_base.h"
+
+#include "test/cpp/tensorexpr/padded_buffer.h"
+#include "test/cpp/tensorexpr/test_utils.h"
+#include "torch/csrc/jit/tensorexpr/buffer.h"
+#include "torch/csrc/jit/tensorexpr/eval.h"
+#include "torch/csrc/jit/tensorexpr/function.h"
+#include "torch/csrc/jit/tensorexpr/ir.h"
+#include "torch/csrc/jit/tensorexpr/ir_printer.h"
+#include "torch/csrc/jit/tensorexpr/llvm_codegen.h"
+#include "torch/csrc/jit/tensorexpr/schedule.h"
+#include "torch/csrc/jit/tensorexpr/tensor.h"
+
+#include <numeric>
+
+namespace torch {
+namespace jit {
+using namespace torch::jit::tensorexpr;
+using namespace torch::jit::tensorexpr::schedule;
+
+using LLVMExprEval = ExprEval<LLVMCodeGen>;
+
+// Typed tests, can't use gtest params here due to the way we instantiate tests.
+#define TEST_LLVM_SCALAR_TYPES(_) \
+  _(uint8_t, Byte, 24)            \
+  _(int8_t, Char, -20)            \
+  _(int16_t, Short, 3332)         \
+  _(int, Int, 123456)             \
+  _(int64_t, Long, 2631563121321) \
+  _(float, Float, 0.122)          \
+  _(double, Double, 0.21312)      \
+  _(at::Half, Half, 0.128f)
+
+#define IMM_TEST(Type, Name, Val)                  \
+  void testLLVM##Name##ImmTest() {                 \
+    KernelScope kernel_scope;                      \
+    auto a = Name##Imm::make(Val);                 \
+    LLVMExprEval cg(a);                            \
+    if (std::is_floating_point<decltype(Val)>()) { \
+      EXPECT_NEAR(cg.value<Type>(), Val, 0.1);     \
+    } else {                                       \
+      EXPECT_EQ(cg.value<Type>(), Val);            \
+    }                                              \
+  }
+TEST_LLVM_SCALAR_TYPES(IMM_TEST)
+#undef IMM_TEST
+
+#define ADD_TEST(Type, Name, Val)                  \
+  void testLLVM##Name##AddTest() {                 \
+    KernelScope kernel_scope;                      \
+    auto a = Name##Imm::make(Val);                 \
+    auto b = Name##Imm::make(Val * 2);             \
+    auto c = Add::make(a, b);                      \
+    LLVMExprEval cg(c);                            \
+    if (std::is_floating_point<decltype(Val)>()) { \
+      EXPECT_NEAR(cg.value<Type>(), Val * 3, 0.1); \
+    } else {                                       \
+      EXPECT_EQ(cg.value<Type>(), Val * 3);        \
+    }                                              \
+  }
+TEST_LLVM_SCALAR_TYPES(ADD_TEST)
+#undef ADD_TEST
+
+#define SUB_TEST(Type, Name, Val)                  \
+  void testLLVM##Name##SubTest() {                 \
+    KernelScope kernel_scope;                      \
+    auto a = Name##Imm::make(Val * 2);             \
+    auto b = Name##Imm::make(Val);                 \
+    auto c = Sub::make(a, b);                      \
+    LLVMExprEval cg(c);                            \
+    if (std::is_floating_point<decltype(Val)>()) { \
+      EXPECT_NEAR(cg.value<Type>(), Val, 0.1);     \
+    } else {                                       \
+      EXPECT_EQ(cg.value<Type>(), Val);            \
+    }                                              \
+  }
+TEST_LLVM_SCALAR_TYPES(SUB_TEST)
+#undef SUB_TEST
+
+#define MUL_TEST(Type, Name, Val)                  \
+  void testLLVM##Name##MulTest() {                 \
+    KernelScope kernel_scope;                      \
+    auto a = Name##Imm::make(Val);                 \
+    auto b = Name##Imm::make((Type)4);             \
+    auto c = Mul::make(a, b);                      \
+    LLVMExprEval cg(c);                            \
+    if (std::is_floating_point<decltype(Val)>()) { \
+      EXPECT_NEAR(cg.value<Type>(), Val * 4, 0.1); \
+    } else {                                       \
+      EXPECT_EQ(cg.value<Type>(), Val * 4);        \
+    }                                              \
+  }
+TEST_LLVM_SCALAR_TYPES(MUL_TEST)
+#undef MUL_TEST
+
+#define DIV_TEST(Type, Name, Val)                  \
+  void testLLVM##Name##DivTest() {                 \
+    KernelScope kernel_scope;                      \
+    auto a = Name##Imm::make((Type)6);             \
+    auto b = Name##Imm::make((Type)3);             \
+    auto c = Div::make(a, b);                      \
+    LLVMExprEval cg(c);                            \
+    if (std::is_floating_point<decltype(Val)>()) { \
+      EXPECT_NEAR(cg.value<Type>(), 2, 0.1);       \
+    } else {                                       \
+      EXPECT_EQ(cg.value<Type>(), 2);              \
+    }                                              \
+  }
+TEST_LLVM_SCALAR_TYPES(DIV_TEST)
+#undef DIV_TEST
+
+void testLLVMIntToFloatCastTest() {
+  KernelScope kernel_scope;
+  auto a = IntImm::make(2);
+  auto b = Cast::make(kFloat, a);
+  LLVMExprEval cg(b, {});
+  EXPECT_EQ(cg.value<float>(), 2.0);
+}
+
+void testLLVMFloatToIntCastTest() {
+  KernelScope kernel_scope;
+  auto a = FloatImm::make(2.0);
+  auto b = Cast::make(kInt, a);
+  LLVMExprEval cg(b);
+  EXPECT_EQ(cg.value<int>(), 2);
+}
+
+void testLLVMIntToLongCastTest() {
+  KernelScope kernel_scope;
+  auto a = IntImm::make(12345);
+  auto b = Cast::make(kLong, a);
+  LLVMExprEval cg(b);
+  EXPECT_EQ(cg.value<int64_t>(), 12345);
+}
+
+void testLLVMByteToCharCastTest() {
+  KernelScope kernel_scope;
+  auto a = ByteImm::make(250);
+  auto b = Cast::make(kChar, a);
+  LLVMExprEval cg(b);
+  EXPECT_EQ(cg.value<int8_t>(), (int8_t)250);
+}
+
+void testLLVMHalfToLongCastTest() {
+  KernelScope kernel_scope;
+  auto a = HalfImm::make(2.0);
+  auto b = Cast::make(kLong, a);
+  LLVMExprEval cg(b);
+  EXPECT_EQ(cg.value<int64_t>(), 2);
+}
+
+void testLLVMByteToDoubleCastTest() {
+  KernelScope kernel_scope;
+  auto a = ByteImm::make(2);
+  auto b = Cast::make(kDouble, a);
+  LLVMExprEval cg(b);
+  EXPECT_EQ(cg.value<double>(), 2);
+}
+
+void testLLVMLetTest01() {
+  KernelScope kernel_scope;
+  VarHandle x("x", kFloat);
+  ExprHandle value = ExprHandle(3.f);
+  ExprHandle body = ExprHandle(2.f) + (x * ExprHandle(3.f) + ExprHandle(4.f));
+  ExprHandle result = Let::make(x, ExprHandle(3.f), body);
+  LLVMExprEval cg(result, {});
+  EXPECT_EQ(cg.value<float>(), 2.f + (3.f * 3.f + 4.f));
+}
+
+void testLLVMLetTest02() {
+  KernelScope kernel_scope;
+  VarHandle x("x", kFloat);
+  VarHandle y("y", kFloat);
+  ExprHandle value = ExprHandle(3.f);
+  ExprHandle body =
+      ExprHandle(2.f) + (x * ExprHandle(3.f) + ExprHandle(4.f) * y);
+  ExprHandle e1 = Let::make(x, ExprHandle(3.f), body);
+  ExprHandle e2 = Let::make(y, ExprHandle(6.f), e1);
+  LLVMExprEval cg(e2, {});
+  EXPECT_EQ(cg.value<float>(), 2.f + (3.f * 3.f + 4.f * 6.f));
+}
+
+void testLLVMLetTestMultitype() {
+  KernelScope kernel_scope;
+  VarHandle x("x", kByte);
+  VarHandle y("y", kHalf);
+  ExprHandle value = ExprHandle((short)3);
+  ExprHandle body = ExprHandle((double)2.f) +
+      (x * ExprHandle(3) + ExprHandle((int64_t)4) * y);
+  ExprHandle e1 = Let::make(x, ExprHandle((uint8_t)3), body);
+  ExprHandle e2 = Let::make(y, ExprHandle((at::Half)6.f), e1);
+  LLVMExprEval cg(e2, {});
+  EXPECT_EQ(cg.value<double>(), 2.f + (3 * 3 + 4 * 6.f));
+}
+
+void testLLVMBufferTest() {
+  KernelScope kernel_scope;
+  Buffer a(VarHandle("A", kHandle), kFloat, {32});
+  std::vector<int32_t> v(5);
+  std::vector<void*> args({v.data()});
+  auto rv = IntImm::make(0);
+  LLVMExprEval cg(rv, {a});
+  EXPECT_EQ(cg.value<int>(args), 0);
+}
+
+void testLLVMBlockTest() {
+  KernelScope kernel_scope;
+  Buffer a(VarHandle("A", kHandle), kInt, {32});
+  std::vector<int32_t> v = {1, 2};
+  std::vector<void*> args({v.data()});
+
+  auto block = Block::make({
+      Store::make(a, IntImm::make(0), IntImm::make(3), IntImm::make(1)),
+      Store::make(a, IntImm::make(1), IntImm::make(4), IntImm::make(1)),
+      Store::make(a, IntImm::make(0), IntImm::make(4), IntImm::make(1)),
+  });
+
+  LLVMCodeGen cg(block, {a});
+  EXPECT_EQ(cg.value<int>(args), 0);
+  EXPECT_EQ(v[0], 4);
+  EXPECT_EQ(v[1], 4);
+}
+
+void testLLVMLoadStoreTest() {
+  KernelScope kernel_scope;
+  Buffer a(VarHandle("A", kHandle), kInt, {1});
+  Buffer b(VarHandle("B", kHandle), kInt, {1});
+  std::vector<int32_t> a_buffer = {42};
+  std::vector<int32_t> b_buffer = {-11};
+
+  auto store = Store::make(
+      b,
+      IntImm::make(0),
+      Load::make(a, IntImm::make(0), IntImm::make(1)),
+      IntImm::make(1));
+  LLVMCodeGen cg(store, {a, b});
+  std::vector<void*> args({a_buffer.data(), b_buffer.data()});
+  EXPECT_EQ(cg.value<int>(args), 0);
+  EXPECT_EQ(a_buffer[0], 42);
+  EXPECT_EQ(b_buffer[0], 42);
+}
+
+void testLLVMIfThenElseTest() {
+  KernelScope kernel_scope;
+  Buffer a(VarHandle("A", kHandle), kInt, {1});
+  Buffer b(VarHandle("B", kHandle), kInt, {1});
+  Buffer c(VarHandle("C", kHandle), kInt, {1});
+  std::vector<int32_t> a_buffer = {42};
+  std::vector<int32_t> b_buffer = {-11};
+  std::vector<int32_t> c_buffer = {1};
+
+  auto store = Store::make(
+      b,
+      IntImm::make(0),
+      IfThenElse::make(
+          Load::make(c, IntImm::make(0), IntImm::make(1)), // cond
+          Load::make(a, IntImm::make(0), IntImm::make(1)), // then
+          IntImm::make(0)), // else
+      IntImm::make(1));
+  LLVMCodeGen cg(store, {a, b, c});
+  std::vector<void*> args({a_buffer.data(), b_buffer.data(), c_buffer.data()});
+  EXPECT_EQ(cg.value<int>(args), 0);
+  EXPECT_EQ(a_buffer[0], 42);
+  EXPECT_EQ(b_buffer[0], 42);
+}
+
+void testLLVMVecLoadStoreTest() {
+  KernelScope kernel_scope;
+  Buffer a(VarHandle("A", kHandle), kInt, {1});
+  Buffer b(VarHandle("B", kHandle), kInt, {1});
+  std::vector<int32_t> a_buffer = {1, 1, 1, 1};
+  std::vector<int32_t> b_buffer = {2, 2, 2, 2};
+
+  auto store = Store::make(
+      b,
+      Ramp::make(0, 1, 4),
+      Load::make(a, Ramp::make(0, 1, 4), Broadcast::make(IntImm::make(1), 4)),
+      Broadcast::make(IntImm::make(1), 4));
+  LLVMCodeGen cg(store, {a, b});
+  std::vector<void*> args({a_buffer.data(), b_buffer.data()});
+  EXPECT_EQ(cg.value<int>(args), 0);
+  EXPECT_EQ(a_buffer[0], 1);
+  EXPECT_EQ(a_buffer[1], 1);
+  EXPECT_EQ(a_buffer[2], 1);
+  EXPECT_EQ(a_buffer[3], 1);
+  EXPECT_EQ(b_buffer[0], 1);
+  EXPECT_EQ(b_buffer[1], 1);
+  EXPECT_EQ(b_buffer[2], 1);
+  EXPECT_EQ(b_buffer[3], 1);
+}
+
+void testLLVMVectorizerLoadStoreTest() {
+  KernelScope kernel_scope;
+  Buffer a(VarHandle("A", kHandle), kInt, {1});
+  Buffer b(VarHandle("B", kHandle), kInt, {1});
+  std::vector<int32_t> a_buffer = {1, 1, 1, 1};
+  std::vector<int32_t> b_buffer = {2, 2, 2, 2};
+
+  auto mask = IntImm::make(1);
+  VarHandle i("i", kInt);
+  auto expr =
+      For::make(i, 0, 4, Store::make(b, i, Load::make(a, i, mask), mask));
+  auto vectorized = Vectorize(expr);
+  EXPECT_EQ(dynamic_cast<For*>(vectorized), nullptr);
+
+  LLVMCodeGen cg(vectorized, {a, b});
+  std::vector<void*> args({a_buffer.data(), b_buffer.data()});
+  EXPECT_EQ(cg.value<int>(args), 0);
+  EXPECT_EQ(a_buffer[0], 1);
+  EXPECT_EQ(a_buffer[1], 1);
+  EXPECT_EQ(a_buffer[2], 1);
+  EXPECT_EQ(a_buffer[3], 1);
+  EXPECT_EQ(b_buffer[0], 1);
+  EXPECT_EQ(b_buffer[1], 1);
+  EXPECT_EQ(b_buffer[2], 1);
+  EXPECT_EQ(b_buffer[3], 1);
+}
+
+void testLLVMMemcpyTest() {
+  KernelScope kernel_scope;
+  constexpr int N = 32;
+  Buffer a(VarHandle("A", kHandle), kInt, {N});
+  Buffer b(VarHandle("B", kHandle), kInt, {N});
+  std::vector<int32_t> a_buffer(N, 42);
+  std::vector<int32_t> b_buffer(N, 0);
+
+  auto mask = IntImm::make(1);
+  VarHandle i("i", kInt);
+  auto expr =
+      For::make(i, 0, N, Store::make(b, i, Load::make(a, i, mask), mask));
+
+  LLVMCodeGen cg(expr, {a, b});
+
+  std::vector<void*> args({a_buffer.data(), b_buffer.data()});
+  ASSERT_EQ(cg.value<int>(args), 0);
+
+  ASSERT_EQ(a_buffer.size(), N);
+  ASSERT_EQ(b_buffer.size(), N);
+  assertAllEqual(a_buffer, 42);
+  assertAllEqual(b_buffer, 42);
+}
+
+void testLLVMBzeroTest() {
+  KernelScope kernel_scope;
+  constexpr int N = 32;
+  Buffer b(VarHandle("B", kHandle), kInt, {N});
+  std::vector<int32_t> b_buffer(N, 11);
+
+  auto mask = IntImm::make(1);
+  VarHandle i("i", kInt);
+  auto expr = For::make(i, 0, N, Store::make(b, i, IntImm::make(0), mask));
+
+  LLVMCodeGen cg(expr, {b});
+
+  std::vector<void*> args({b_buffer.data()});
+  ASSERT_EQ(cg.value<int>(args), 0);
+
+  ASSERT_EQ(b_buffer.size(), N);
+  assertAllEqual(b_buffer, 0);
+}
+
+void testLLVMElemwiseAdd() {
+  KernelScope kernel_scope;
+  constexpr int N = 1024;
+  Buffer a(VarHandle("A", kHandle), kInt, {N});
+  Buffer b(VarHandle("B", kHandle), kInt, {N});
+  Buffer c(VarHandle("C", kHandle), kInt, {N});
+  std::vector<int32_t> a_buffer(N, 41);
+  std::vector<int32_t> b_buffer(N, 1);
+  std::vector<int32_t> c_buffer(N, 1);
+
+  auto mask = IntImm::make(1);
+  VarHandle i("i", kInt);
+  auto expr = For::make(
+      i,
+      0,
+      N,
+      Store::make(
+          c,
+          i,
+          Add::make(Load::make(a, i, mask), Load::make(b, i, mask)),
+          mask));
+
+  LLVMCodeGen cg(expr, {a, b, c});
+
+  std::vector<void*> args({a_buffer.data(), b_buffer.data(), c_buffer.data()});
+  ASSERT_EQ(cg.value<int>(args), 0);
+
+  ASSERT_EQ(a_buffer.size(), N);
+  ASSERT_EQ(b_buffer.size(), N);
+  ASSERT_EQ(c_buffer.size(), N);
+  assertAllEqual(a_buffer, 41);
+  assertAllEqual(b_buffer, 1);
+  assertAllEqual(c_buffer, 42);
+}
+
+void testLLVMElemwiseAddFloat() {
+  KernelScope kernel_scope;
+  constexpr int N = 1024;
+  Buffer a(VarHandle("A", kHandle), kFloat, {N});
+  Buffer b(VarHandle("B", kHandle), kFloat, {N});
+  Buffer c(VarHandle("C", kHandle), kFloat, {N});
+  std::vector<float> a_buffer(N, 41);
+  std::vector<float> b_buffer(N, 1);
+  std::vector<float> c_buffer(N, 1);
+
+  auto mask = IntImm::make(1);
+  VarHandle i("i", kInt);
+  auto expr = For::make(
+      i,
+      0,
+      N,
+      Store::make(c, i, Load::make(a, i, mask) + Load::make(b, i, mask), mask));
+
+  LLVMCodeGen cg(expr, {a, b, c});
+
+  std::vector<void*> args({a_buffer.data(), b_buffer.data(), c_buffer.data()});
+  ASSERT_EQ(cg.value<int>(args), 0);
+
+  ASSERT_EQ(a_buffer.size(), N);
+  ASSERT_EQ(b_buffer.size(), N);
+  ASSERT_EQ(c_buffer.size(), N);
+  assertAllEqual(a_buffer, 41.0f);
+  assertAllEqual(b_buffer, 1.0f);
+  assertAllEqual(c_buffer, 42.0f);
+}
+
+void testLLVMElemwiseLog10Float() {
+  KernelScope kernel_scope;
+  constexpr int N = 1024;
+  Buffer a(VarHandle("A", kHandle), kFloat, {N});
+  Buffer b(VarHandle("B", kHandle), kFloat, {N});
+  std::vector<float> a_buffer(N, 10.0f);
+  std::vector<float> b_buffer(N, 2.0f);
+
+  auto mask = Broadcast::make(IntImm::make(1), 4);
+  VarHandle i("i", kInt);
+  auto expr = For::make(
+      i,
+      0,
+      N / 4,
+      Store::make(
+          b,
+          Ramp::make(i * 4, 1, 4),
+          log10(Load::make(a, Ramp::make(i * 4, 1, 4), mask)),
+          mask));
+
+  LLVMCodeGen cg(expr, {a, b});
+
+  std::vector<void*> args({a_buffer.data(), b_buffer.data()});
+  ASSERT_EQ(cg.value<int>(args), 0);
+
+  ASSERT_EQ(a_buffer.size(), N);
+  ASSERT_EQ(b_buffer.size(), N);
+  assertAllEqual(a_buffer, 10.0f);
+  assertAllEqual(b_buffer, 1.0f);
+}
+
+void testLLVMElemwiseMaxInt() {
+  KernelScope kernel_scope;
+  constexpr int N = 1024;
+  Buffer a(VarHandle("A", kHandle), kInt, {N});
+  Buffer b(VarHandle("B", kHandle), kInt, {N});
+  Buffer c(VarHandle("C", kHandle), kInt, {N});
+  std::vector<int> a_buffer(N, 41);
+  std::vector<int> b_buffer(N, 1);
+  std::vector<int> c_buffer(N, 1);
+
+  auto mask = IntImm::make(1);
+  VarHandle i("i", kInt);
+  auto expr = For::make(
+      i,
+      0,
+      N,
+      Store::make(
+          c,
+          i,
+          Max::make(Load::make(a, i, mask), Load::make(b, i, mask), false),
+          mask));
+
+  LLVMCodeGen cg(expr, {a, b, c});
+
+  std::vector<void*> args({a_buffer.data(), b_buffer.data(), c_buffer.data()});
+  ASSERT_EQ(cg.value<int>(args), 0);
+
+  ASSERT_EQ(a_buffer.size(), N);
+  ASSERT_EQ(b_buffer.size(), N);
+  ASSERT_EQ(c_buffer.size(), N);
+  assertAllEqual(a_buffer, 41);
+  assertAllEqual(b_buffer, 1);
+  assertAllEqual(c_buffer, 41);
+}
+
+void testLLVMElemwiseMinInt() {
+  KernelScope kernel_scope;
+  constexpr int N = 1024;
+  Buffer a(VarHandle("A", kHandle), kInt, {N});
+  Buffer b(VarHandle("B", kHandle), kInt, {N});
+  Buffer c(VarHandle("C", kHandle), kInt, {N});
+  std::vector<int> a_buffer(N, 41);
+  std::vector<int> b_buffer(N, 1);
+  std::vector<int> c_buffer(N, 1);
+
+  auto mask = IntImm::make(1);
+  VarHandle i("i", kInt);
+  auto expr = For::make(
+      i,
+      0,
+      N,
+      Store::make(
+          c,
+          i,
+          Min::make(Load::make(a, i, mask), Load::make(b, i, mask), false),
+          mask));
+
+  LLVMCodeGen cg(expr, {a, b, c});
+
+  std::vector<void*> args({a_buffer.data(), b_buffer.data(), c_buffer.data()});
+  ASSERT_EQ(cg.value<int>(args), 0);
+
+  ASSERT_EQ(a_buffer.size(), N);
+  ASSERT_EQ(b_buffer.size(), N);
+  ASSERT_EQ(c_buffer.size(), N);
+  assertAllEqual(a_buffer, 41);
+  assertAllEqual(b_buffer, 1);
+  assertAllEqual(c_buffer, 1);
+}
+
+void testLLVMElemwiseMaxNumFloat() {
+  KernelScope kernel_scope;
+  constexpr int N = 1024;
+  Buffer a(VarHandle("A", kHandle), kFloat, {N});
+  Buffer b(VarHandle("B", kHandle), kFloat, {N});
+  Buffer c(VarHandle("C", kHandle), kFloat, {N});
+  std::vector<float> a_buffer(N, 41);
+  std::vector<float> b_buffer(N, 1);
+  std::vector<float> c_buffer(N, 1);
+
+  auto mask = IntImm::make(1);
+  VarHandle i("i", kInt);
+  auto expr = For::make(
+      i,
+      0,
+      N,
+      Store::make(
+          c,
+          i,
+          Max::make(Load::make(a, i, mask), Load::make(b, i, mask), false),
+          mask));
+
+  LLVMCodeGen cg(expr, {a, b, c});
+
+  std::vector<void*> args({a_buffer.data(), b_buffer.data(), c_buffer.data()});
+  ASSERT_EQ(cg.value<int>(args), 0);
+
+  ASSERT_EQ(a_buffer.size(), N);
+  ASSERT_EQ(b_buffer.size(), N);
+  ASSERT_EQ(c_buffer.size(), N);
+  assertAllEqual(a_buffer, 41.0f);
+  assertAllEqual(b_buffer, 1.0f);
+  assertAllEqual(c_buffer, 41.0f);
+}
+
+void testLLVMElemwiseMaxNumNaNFloat() {
+  KernelScope kernel_scope;
+  constexpr int N = 1024;
+  Buffer a(VarHandle("A", kHandle), kFloat, {N});
+  Buffer b(VarHandle("B", kHandle), kFloat, {N});
+  Buffer c(VarHandle("C", kHandle), kFloat, {N});
+  std::vector<float> a_buffer(N, NAN);
+  std::vector<float> b_buffer(N, 1);
+  std::vector<float> c_buffer(N, 1);
+
+  auto mask = IntImm::make(1);
+  VarHandle i("i", kInt);
+  auto expr = For::make(
+      i,
+      0,
+      N,
+      Store::make(
+          c,
+          i,
+          Max::make(Load::make(a, i, mask), Load::make(b, i, mask), false),
+          mask));
+
+  LLVMCodeGen cg(expr, {a, b, c});
+
+  std::vector<void*> args({a_buffer.data(), b_buffer.data(), c_buffer.data()});
+  ASSERT_EQ(cg.value<int>(args), 0);
+
+  ASSERT_EQ(a_buffer.size(), N);
+  ASSERT_EQ(b_buffer.size(), N);
+  ASSERT_EQ(c_buffer.size(), N);
+  assertAllEqual(b_buffer, 1.0f);
+  assertAllEqual(c_buffer, 1.0f);
+}
+
+void testLLVMElemwiseMinNumFloat() {
+  KernelScope kernel_scope;
+  constexpr int N = 1024;
+  Buffer a(VarHandle("A", kHandle), kFloat, {N});
+  Buffer b(VarHandle("B", kHandle), kFloat, {N});
+  Buffer c(VarHandle("C", kHandle), kFloat, {N});
+  std::vector<float> a_buffer(N, 41);
+  std::vector<float> b_buffer(N, 1);
+  std::vector<float> c_buffer(N, 1);
+
+  auto mask = IntImm::make(1);
+  VarHandle i("i", kInt);
+  auto expr = For::make(
+      i,
+      0,
+      N,
+      Store::make(
+          c,
+          i,
+          Min::make(Load::make(a, i, mask), Load::make(b, i, mask), false),
+          mask));
+
+  LLVMCodeGen cg(expr, {a, b, c});
+
+  std::vector<void*> args({a_buffer.data(), b_buffer.data(), c_buffer.data()});
+  ASSERT_EQ(cg.value<int>(args), 0);
+
+  ASSERT_EQ(a_buffer.size(), N);
+  ASSERT_EQ(b_buffer.size(), N);
+  ASSERT_EQ(c_buffer.size(), N);
+  assertAllEqual(a_buffer, 41.0f);
+  assertAllEqual(b_buffer, 1.0f);
+  assertAllEqual(c_buffer, 1.0f);
+}
+
+void testLLVMElemwiseMinNumNaNFloat() {
+  KernelScope kernel_scope;
+  constexpr int N = 1024;
+  Buffer a(VarHandle("A", kHandle), kFloat, {N});
+  Buffer b(VarHandle("B", kHandle), kFloat, {N});
+  Buffer c(VarHandle("C", kHandle), kFloat, {N});
+  std::vector<float> a_buffer(N, NAN);
+  std::vector<float> b_buffer(N, 1);
+  std::vector<float> c_buffer(N, 1);
+
+  auto mask = IntImm::make(1);
+  VarHandle i("i", kInt);
+  auto expr = For::make(
+      i,
+      0,
+      N,
+      Store::make(
+          c,
+          i,
+          Min::make(Load::make(a, i, mask), Load::make(b, i, mask), false),
+          mask));
+
+  LLVMCodeGen cg(expr, {a, b, c});
+
+  std::vector<void*> args({a_buffer.data(), b_buffer.data(), c_buffer.data()});
+  ASSERT_EQ(cg.value<int>(args), 0);
+
+  ASSERT_EQ(a_buffer.size(), N);
+  ASSERT_EQ(b_buffer.size(), N);
+  ASSERT_EQ(c_buffer.size(), N);
+  assertAllEqual(b_buffer, 1.0f);
+  assertAllEqual(c_buffer, 1.0f);
+}
+
+#if 1 // LLVM doesn't currently have implementations for maximum/minimum on x86
+void testLLVMElemwiseMaximumFloat() {
+  KernelScope kernel_scope;
+  constexpr int N = 1024;
+  Buffer a(VarHandle("A", kHandle), kFloat, {N});
+  Buffer b(VarHandle("B", kHandle), kFloat, {N});
+  Buffer c(VarHandle("C", kHandle), kFloat, {N});
+  std::vector<float> a_buffer(N, 41);
+  std::vector<float> b_buffer(N, 1);
+  std::vector<float> c_buffer(N, 1);
+
+  auto mask = IntImm::make(1);
+  VarHandle i("i", kInt);
+  auto expr = For::make(
+      i,
+      0,
+      N,
+      Store::make(
+          c,
+          i,
+          Max::make(Load::make(a, i, mask), Load::make(b, i, mask), true),
+          mask));
+
+  LLVMCodeGen cg(expr, {a, b, c});
+
+  std::vector<void*> args({a_buffer.data(), b_buffer.data(), c_buffer.data()});
+  ASSERT_EQ(cg.value<int>(args), 0);
+
+  ASSERT_EQ(a_buffer.size(), N);
+  ASSERT_EQ(b_buffer.size(), N);
+  ASSERT_EQ(c_buffer.size(), N);
+  assertAllEqual(a_buffer, 41.0f);
+  assertAllEqual(b_buffer, 1.0f);
+  assertAllEqual(c_buffer, 41.0f);
+}
+
+void testLLVMElemwiseMaximumNaNFloat() {
+  KernelScope kernel_scope;
+  constexpr int N = 1024;
+  Buffer a(VarHandle("A", kHandle), kFloat, {N});
+  Buffer b(VarHandle("B", kHandle), kFloat, {N});
+  Buffer c(VarHandle("C", kHandle), kFloat, {N});
+  std::vector<float> a_buffer(N, NAN);
+  std::vector<float> b_buffer(N, 1);
+  std::vector<float> c_buffer(N, 1);
+
+  auto mask = IntImm::make(1);
+  VarHandle i("i", kInt);
+  auto expr = For::make(
+      i,
+      0,
+      N,
+      Store::make(
+          c,
+          i,
+          Max::make(Load::make(a, i, mask), Load::make(b, i, mask), true),
+          mask));
+
+  LLVMCodeGen cg(expr, {a, b, c});
+
+  std::vector<void*> args({a_buffer.data(), b_buffer.data(), c_buffer.data()});
+  ASSERT_EQ(cg.value<int>(args), 0);
+
+  ASSERT_EQ(a_buffer.size(), N);
+  ASSERT_EQ(b_buffer.size(), N);
+  ASSERT_EQ(c_buffer.size(), N);
+  for (int i = 0; i < N; ++i) {
+    ASSERT_TRUE(std::isnan(a_buffer[i]));
+    ASSERT_TRUE(std::isnan(c_buffer[i]));
+  }
+}
+
+void testLLVMElemwiseMinimumFloat() {
+  KernelScope kernel_scope;
+  constexpr int N = 1024;
+  Buffer a(VarHandle("A", kHandle), kFloat, {N});
+  Buffer b(VarHandle("B", kHandle), kFloat, {N});
+  Buffer c(VarHandle("C", kHandle), kFloat, {N});
+  std::vector<float> a_buffer(N, 41);
+  std::vector<float> b_buffer(N, 1);
+  std::vector<float> c_buffer(N, 1);
+
+  auto mask = IntImm::make(1);
+  VarHandle i("i", kInt);
+  auto expr = For::make(
+      i,
+      0,
+      N,
+      Store::make(
+          c,
+          i,
+          Min::make(Load::make(a, i, mask), Load::make(b, i, mask), true),
+          mask));
+
+  LLVMCodeGen cg(expr, {a, b, c});
+
+  std::vector<void*> args({a_buffer.data(), b_buffer.data(), c_buffer.data()});
+  ASSERT_EQ(cg.value<int>(args), 0);
+
+  ASSERT_EQ(a_buffer.size(), N);
+  ASSERT_EQ(b_buffer.size(), N);
+  ASSERT_EQ(c_buffer.size(), N);
+  assertAllEqual(a_buffer, 41.0f);
+  assertAllEqual(b_buffer, 1.0f);
+  assertAllEqual(c_buffer, 1.0f);
+}
+
+void testLLVMElemwiseMinimumNaNFloat() {
+  KernelScope kernel_scope;
+  constexpr int N = 1024;
+  Buffer a(VarHandle("A", kHandle), kFloat, {N});
+  Buffer b(VarHandle("B", kHandle), kFloat, {N});
+  Buffer c(VarHandle("C", kHandle), kFloat, {N});
+  std::vector<float> a_buffer(N, NAN);
+  std::vector<float> b_buffer(N, 1);
+  std::vector<float> c_buffer(N, 1);
+
+  auto mask = IntImm::make(1);
+  VarHandle i("i", kInt);
+  auto expr = For::make(
+      i,
+      0,
+      N,
+      Store::make(
+          c,
+          i,
+          Min::make(Load::make(a, i, mask), Load::make(b, i, mask), true),
+          mask));
+
+  LLVMCodeGen cg(expr, {a, b, c});
+
+  std::vector<void*> args({a_buffer.data(), b_buffer.data(), c_buffer.data()});
+  ASSERT_EQ(cg.value<int>(args), 0);
+
+  ASSERT_EQ(a_buffer.size(), N);
+  ASSERT_EQ(b_buffer.size(), N);
+  ASSERT_EQ(c_buffer.size(), N);
+  for (int i = 0; i < N; ++i) {
+    ASSERT_TRUE(std::isnan(a_buffer[i]));
+    ASSERT_TRUE(std::isnan(c_buffer[i]));
+  }
+}
+#endif
+
+void testLLVMCompareSelectIntEQ() {
+  KernelScope kernel_scope;
+  constexpr int N = 1024;
+  Buffer a(VarHandle("A", kHandle), kInt, {N});
+  Buffer b(VarHandle("B", kHandle), kInt, {N});
+  Buffer c(VarHandle("C", kHandle), kInt, {N});
+  std::vector<int> a_buffer(N, 1);
+  std::vector<int> b_buffer(N, 1);
+  std::vector<int> c_buffer(N, 0);
+  std::vector<int> c_ref(N, 1);
+
+  for (int i = 0; i < N / 2; i++) {
+    b_buffer[i] = 0;
+    c_ref[i] = 0;
+  }
+
+  auto mask = IntImm::make(1);
+  VarHandle i("i", kInt);
+  auto expr = For::make(
+      i,
+      0,
+      N,
+      Store::make(
+          c,
+          i,
+          CompareSelect::make(
+              Load::make(a, i, mask),
+              Load::make(b, i, mask),
+              CompareSelectOperation::kEQ),
+          mask));
+
+  LLVMCodeGen cg(expr, {a, b, c});
+
+  std::vector<void*> args({a_buffer.data(), b_buffer.data(), c_buffer.data()});
+  ASSERT_EQ(cg.value<int>(args), 0);
+
+  ASSERT_EQ(a_buffer.size(), N);
+  ASSERT_EQ(b_buffer.size(), N);
+  ASSERT_EQ(c_buffer.size(), N);
+
+  assertAllEqual(a_buffer, 1);
+  for (int i = 0; i < N; i++) {
+    ASSERT_EQ(c_ref[i], c_buffer[i]);
+  }
+}
+
+void testLLVMCompareSelectFloatEQ() {
+  KernelScope kernel_scope;
+  constexpr int N = 1024;
+  Buffer a(VarHandle("A", kHandle), kFloat, {N});
+  Buffer b(VarHandle("B", kHandle), kFloat, {N});
+  Buffer c(VarHandle("C", kHandle), kInt, {N});
+  std::vector<float> a_buffer(N, 1.0f);
+  std::vector<float> b_buffer(N, 1.0f);
+  std::vector<int> c_buffer(N, 0);
+
+  auto mask = IntImm::make(1);
+  VarHandle i("i", kInt);
+  auto expr = For::make(
+      i,
+      0,
+      N,
+      Store::make(
+          c,
+          i,
+          CompareSelect::make(
+              Load::make(a, i, mask),
+              Load::make(b, i, mask),
+              CompareSelectOperation::kEQ),
+          mask));
+
+  LLVMCodeGen cg(expr, {a, b, c});
+
+  std::vector<void*> args({a_buffer.data(), b_buffer.data(), c_buffer.data()});
+  ASSERT_EQ(cg.value<int>(args), 0);
+
+  ASSERT_EQ(a_buffer.size(), N);
+  ASSERT_EQ(b_buffer.size(), N);
+  ASSERT_EQ(c_buffer.size(), N);
+
+  assertAllEqual(a_buffer, 1.0f);
+  assertAllEqual(b_buffer, 1.0f);
+  assertAllEqual(c_buffer, 1);
+}
+
+void testLLVMStoreFloat() {
+  KernelScope kernel_scope;
+  Buffer result(VarHandle("result", kHandle), kFloat, {1});
+  std::vector<float> result_buffer = {0.0f};
+  auto expr = Store::make(
+      result, IntImm::make(0), FloatImm::make(3.14f), IntImm::make(1));
+  LLVMCodeGen cg(expr, {result});
+  std::vector<void*> args({result_buffer.data()});
+  ASSERT_EQ(cg.value<int>(args), 0);
+  EXPECT_EQ(result_buffer[0], 3.14f);
+}
+
+void testLLVMSimpleMath01() {
+  KernelScope kernel_scope;
+  const int N = 1024;
+  Tensor* tensor = Compute("f", {{N, "i"}}, [](const VarHandle& i) {
+    return cast<float>(i * i + 1);
+  });
+  LoopNest l({tensor});
+  Stmt* stmt = l.root_stmt();
+  Buffer f_buf(VarHandle(tensor->func_var()), kFloat, {N});
+  LLVMCodeGen cg(stmt, {f_buf});
+
+  PaddedBuffer<float> f_v(N, "f_v");
+  std::vector<void*> args({f_v.data()});
+  int value = cg.value<int>(args);
+  ASSERT_EQ(value, 0);
+  PaddedBuffer<float> f_ref(N, "f_ref");
+  for (int i = 0; i < N; i++) {
+    f_ref(i) = i * i + 1;
+  }
+  ExpectAllNear(f_v, f_ref, 1e-5);
+}
+
+void testLLVMComputeMul() {
+  KernelScope kernel_scope;
+  const int N = 1024;
+  Buffer a(VarHandle("a", kHandle), kFloat, {N});
+  Buffer b(VarHandle("b", kHandle), kFloat, {N});
+  Tensor* c = Compute("c", {{N, "i"}}, [&](const VarHandle& i) {
+    return Load::make(a, i, 1) * Load::make(b, i, 1);
+  });
+
+  Buffer c_buf(VarHandle(c->func_var()), kFloat, {N});
+  LoopNest l({c});
+  Stmt* s = l.root_stmt();
+
+  LLVMCodeGen cg(s, {a, b, c_buf});
+
+  std::vector<float> a_vec(N, 21.0f);
+  std::vector<float> b_vec(N, 2.0f);
+  std::vector<float> c_vec(N, 0.0f);
+  std::vector<void*> args({a_vec.data(), b_vec.data(), c_vec.data()});
+  ASSERT_EQ(cg.value<int>(args), 0);
+  assertAllEqual(c_vec, 42.0f);
+}
+
+void testLLVMBroadcastAdd() {
+  KernelScope kernel_scope;
+  const int M = 32;
+  const int N = 1024;
+  Buffer a(VarHandle("a", kHandle), kFloat, {M, N});
+  Buffer b(VarHandle("b", kHandle), kFloat, {N});
+  Tensor* c = Compute(
+      "c", {{M, "i"}, {N, "j"}}, [&](const VarHandle& i, const VarHandle& j) {
+        ExprHandle mask(1);
+        return Load::make(a, i * N + j, mask) + Load::make(b, j, mask);
+      });
+
+  Buffer c_buf(VarHandle(c->func_var()), kFloat, {M, N});
+  LoopNest l({c});
+  Stmt* s = l.root_stmt();
+
+  LLVMCodeGen cg(s, {a, b, c_buf});
+
+  std::vector<float> av(M * N);
+  std::iota(av.begin(), av.end(), 0);
+  std::vector<float> bv(N);
+  std::iota(bv.begin(), bv.end(), 0);
+  std::vector<float> cv(M * N, 0);
+  std::vector<void*> args({av.data(), bv.data(), cv.data()});
+  ASSERT_EQ(cg.value<int>(args), 0);
+
+  for (int i = 0; i < M; i++) {
+    for (int j = 0; j < N; j++) {
+      ASSERT_EQ(cv[i * N + j], av[i * N + j] + bv[j]);
+    }
+  }
+}
+
+void testLLVMBitwiseOps() {
+  KernelScope kernel_scope;
+  auto a = IntImm::make(59);
+  auto b = IntImm::make(11);
+  auto c = IntImm::make(101);
+  auto d = IntImm::make(2);
+
+  ExprHandle f = (((a ^ (b << 1)) & c) >> 2) | d;
+  LLVMExprEval cg(f);
+
+  EXPECT_EQ(cg.value<int>(), 11);
+}
+
+void testLLVMDynamicShapeAdd() {
+  KernelScope kernel_scope;
+  auto testWithSize = [](int32_t size) {
+    VarHandle n("n", kInt);
+    Buffer a(VarHandle("a", kHandle), kFloat, {n});
+    Buffer b(VarHandle("b", kHandle), kFloat, {n});
+    Buffer c(VarHandle("c", kHandle), kFloat, {n});
+    VarHandle i("i", kInt);
+    Stmt* s = For::make(i, 0, n, Store::make(c, i, a(i) + b(i), 1));
+    std::vector<float> aData(size, 1.0f);
+    std::vector<float> bData(size, 2.0f);
+    std::vector<float> cData(size, 0.0f);
+    LLVMCodeGen cg(s, {a, b, c, n});
+    std::vector<void*> args({aData.data(), bData.data(), cData.data(), &size});
+    cg.value<float>(args);
+    ExpectAllNear(cData, std::vector<float>(size, 3.0f), 1e-7);
+  };
+  testWithSize(1);
+  testWithSize(16);
+  testWithSize(37);
+}
+
+void testLLVMBindDynamicShapeAdd() {
+  KernelScope kernel_scope;
+  auto testWithSize = [](int32_t size) {
+    VarHandle n("n", kInt);
+    Buffer a(VarHandle("a", kHandle), kFloat, {n});
+    Buffer b(VarHandle("b", kHandle), kFloat, {n});
+    Buffer c(VarHandle("c", kHandle), kFloat, {n});
+    VarHandle i("i", kInt);
+    Stmt* s = For::make(i, 0, n, Store::make(c, i, a(i) + b(i), 1));
+    std::vector<float> aData(size, 1.0f);
+    std::vector<float> bData(size, 2.0f);
+    std::vector<float> cData(size, 0.0f);
+    LLVMCodeGen cg(s, {a, b, c, n});
+    cg.call({aData, bData, cData, size});
+    ExpectAllNear(cData, std::vector<float>(size, 3.0f), 1e-7);
+  };
+  testWithSize(1);
+  testWithSize(16);
+  testWithSize(37);
+}
+
+void testLLVMTensorDynamicShapeAdd() {
+  KernelScope kernel_scope;
+  auto testWithSize = [](int32_t size) {
+    VarHandle n("n", kInt);
+    Buffer a(VarHandle("a", kHandle), kFloat, {n});
+    Buffer b(VarHandle("b", kHandle), kFloat, {n});
+    Tensor* c = Compute(
+        "c", {{n, "n"}}, [&](const VarHandle& i) { return a(i) + b(i); });
+    LoopNest l({c});
+    Stmt* s = l.root_stmt();
+    LLVMCodeGen cg(s, {a, b, c, n});
+    std::vector<float> aData(size, 1.0f);
+    std::vector<float> bData(size, 2.0f);
+    std::vector<float> cData(size, 0.0f);
+    cg.call({aData, bData, cData, size});
+    ExpectAllNear(cData, std::vector<float>(size, 3.0f), 1e-7);
+  };
+  testWithSize(1);
+  testWithSize(16);
+  testWithSize(37);
+}
+
+void testLLVMDynamicShape2D() {
+  KernelScope kernel_scope;
+  auto testWithSize = [](int32_t M, int32_t N) {
+    VarHandle m("m", kInt);
+    VarHandle n("n", kInt);
+    Buffer a(VarHandle("a", kHandle), kFloat, {m, n});
+    Buffer b(VarHandle("b", kHandle), kFloat, {m, n});
+    Tensor* c = Compute(
+        "c", {{m, "m"}, {n, "n"}}, [&](const VarHandle& i, const VarHandle& j) {
+          return a(i, j) + b(i, j);
+        });
+    LoopNest l({c});
+    Stmt* s = l.root_stmt();
+    LLVMCodeGen cg(s, {a, b, c, m, n});
+    std::vector<float> aData(M * N, 1.0f);
+    std::vector<float> bData(M * N, 2.0f);
+    std::vector<float> cData(M * N, 0.0f);
+    cg.call({aData, bData, cData, M, N});
+    ExpectAllNear(cData, std::vector<float>(M * N, 3.0f), 1e-7);
+  };
+  testWithSize(1, 8);
+  testWithSize(16, 32);
+  testWithSize(37, 11);
+}
+
+} // namespace jit
+} // namespace torch
+
+#endif // ENABLE_LLVM

--- a/test/cpp/tensorexpr/tests.h
+++ b/test/cpp/tensorexpr/tests.h
@@ -86,6 +86,85 @@ namespace jit {
   _(ATenleInt)                  \
   _(ATenltInt)
 
+#define TH_FORALL_TESTS_LLVM(_) \
+  _(LLVMByteImmTest)            \
+  _(LLVMCharImmTest)            \
+  _(LLVMShortImmTest)           \
+  _(LLVMIntImmTest)             \
+  _(LLVMLongImmTest)            \
+  _(LLVMFloatImmTest)           \
+  _(LLVMDoubleImmTest)          \
+  _(LLVMHalfImmTest)            \
+  _(LLVMByteAddTest)            \
+  _(LLVMCharAddTest)            \
+  _(LLVMShortAddTest)           \
+  _(LLVMIntAddTest)             \
+  _(LLVMLongAddTest)            \
+  _(LLVMFloatAddTest)           \
+  _(LLVMDoubleAddTest)          \
+  _(LLVMHalfAddTest)            \
+  _(LLVMByteSubTest)            \
+  _(LLVMCharSubTest)            \
+  _(LLVMShortSubTest)           \
+  _(LLVMIntSubTest)             \
+  _(LLVMLongSubTest)            \
+  _(LLVMFloatSubTest)           \
+  _(LLVMDoubleSubTest)          \
+  _(LLVMHalfSubTest)            \
+  _(LLVMByteMulTest)            \
+  _(LLVMCharMulTest)            \
+  _(LLVMShortMulTest)           \
+  _(LLVMIntMulTest)             \
+  _(LLVMLongMulTest)            \
+  _(LLVMFloatMulTest)           \
+  _(LLVMDoubleMulTest)          \
+  _(LLVMHalfMulTest)            \
+  _(LLVMByteDivTest)            \
+  _(LLVMCharDivTest)            \
+  _(LLVMShortDivTest)           \
+  _(LLVMIntDivTest)             \
+  _(LLVMLongDivTest)            \
+  _(LLVMFloatDivTest)           \
+  _(LLVMDoubleDivTest)          \
+  _(LLVMHalfDivTest)            \
+  _(LLVMIntToFloatCastTest)     \
+  _(LLVMFloatToIntCastTest)     \
+  _(LLVMIntToLongCastTest)      \
+  _(LLVMByteToCharCastTest)     \
+  _(LLVMHalfToLongCastTest)     \
+  _(LLVMByteToDoubleCastTest)   \
+  _(LLVMLetTest01)              \
+  _(LLVMLetTest02)              \
+  _(LLVMLetTestMultitype)       \
+  _(LLVMBufferTest)             \
+  _(LLVMBlockTest)              \
+  _(LLVMLoadStoreTest)          \
+  _(LLVMVecLoadStoreTest)       \
+  _(LLVMMemcpyTest)             \
+  _(LLVMBzeroTest)              \
+  _(LLVMElemwiseAdd)            \
+  _(LLVMElemwiseAddFloat)       \
+  _(LLVMElemwiseLog10Float)     \
+  _(LLVMElemwiseMaxInt)         \
+  _(LLVMElemwiseMinInt)         \
+  _(LLVMElemwiseMaxNumFloat)    \
+  _(LLVMElemwiseMaxNumNaNFloat) \
+  _(LLVMElemwiseMinNumFloat)    \
+  _(LLVMElemwiseMinNumNaNFloat) \
+  _(LLVMCompareSelectIntEQ)     \
+  _(LLVMCompareSelectFloatEQ)   \
+  _(LLVMStoreFloat)             \
+  _(LLVMSimpleMath01)           \
+  _(LLVMComputeMul)             \
+  _(LLVMBroadcastAdd)           \
+  _(LLVMBitwiseOps)             \
+  _(LLVMDynamicShapeAdd)        \
+  _(LLVMBindDynamicShapeAdd)    \
+  _(LLVMTensorDynamicShapeAdd)  \
+  _(LLVMDynamicShape2D)         \
+  _(LLVMIfThenElseTest)         \
+  _(LLVMVectorizerLoadStoreTest)
+
 #define TH_FORALL_TESTS_CUDA(_) \
   _(CudaTestVectorAdd01)        \
   _(CudaTestVectorAdd02)        \
@@ -95,6 +174,9 @@ namespace jit {
 
 #define DECLARE_TENSOREXPR_TEST(name) void test##name();
 TH_FORALL_TESTS(DECLARE_TENSOREXPR_TEST)
+#ifdef ENABLE_LLVM
+TH_FORALL_TESTS_LLVM(DECLARE_TENSOREXPR_TEST)
+#endif
 #ifdef USE_CUDA
 TH_FORALL_TESTS_CUDA(DECLARE_TENSOREXPR_TEST)
 #endif

--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -204,6 +204,8 @@ libtorch_sources = [
     "torch/csrc/jit/tensorexpr/ir_printer.cpp",
     "torch/csrc/jit/tensorexpr/ir_visitor.cpp",
     "torch/csrc/jit/tensorexpr/kernel.cpp",
+    "torch/csrc/jit/tensorexpr/llvm_codegen.cpp",
+    "torch/csrc/jit/tensorexpr/llvm_jit.cpp",
     "torch/csrc/jit/tensorexpr/mem_arena.cpp",
     "torch/csrc/jit/tensorexpr/schedule.cpp",
     "torch/csrc/jit/tensorexpr/tensor.cpp",

--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -1018,6 +1018,9 @@ void TensorExprKernel::LowerToBackend(BackendType backend_type) {
     case kCudaCodeGen:
       codegen_name = "cuda_codegen";
       break;
+    case kLLVMCodeGen:
+      codegen_name = "llvm_codegen";
+      break;
     case kSimpleIREval:
       codegen_name = "simple_ir_eval";
       break;
@@ -1043,7 +1046,12 @@ void TensorExprKernel::PickAndCheckBackendType(
   if (device.type() == at::kCUDA) {
     backend_type = kCudaCodeGen;
   } else if (device.type() == at::kCPU) {
+#ifdef ENABLE_LLVM
+    backend_type = kLLVMCodeGen;
+#else
     backend_type = kSimpleIREval;
+    ;
+#endif
   } else {
     throw std::runtime_error("Invalid device type");
   }
@@ -1065,6 +1073,7 @@ void TensorExprKernel::CodeGenRun(
     const std::vector<CodeGen::CallArg>& run_args) {
   switch (backend_type_) {
     case kSimpleIREval:
+    case kLLVMCodeGen:
     case kCudaCodeGen:
       codegen_->call(run_args);
       break;

--- a/torch/csrc/jit/tensorexpr/kernel.h
+++ b/torch/csrc/jit/tensorexpr/kernel.h
@@ -52,6 +52,7 @@ class TensorExprKernel {
   enum BackendType {
     kUninitialized,
     kSimpleIREval,
+    kLLVMCodeGen,
     kCudaCodeGen,
   };
 

--- a/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
@@ -1,0 +1,1161 @@
+#ifdef ENABLE_LLVM
+
+#include "torch/csrc/jit/tensorexpr/llvm_codegen.h"
+
+#include <memory>
+
+#include <llvm/Analysis/TargetTransformInfo.h>
+#include <llvm/ExecutionEngine/Orc/JITTargetMachineBuilder.h>
+#include <llvm/IR/LegacyPassManager.h>
+#include <llvm/IR/Verifier.h>
+#include <llvm/Support/TargetSelect.h>
+#include <llvm/Target/TargetMachine.h>
+#include <llvm/Transforms/IPO/PassManagerBuilder.h>
+
+#include "torch/csrc/jit/tensorexpr/buffer.h"
+#include "torch/csrc/jit/tensorexpr/execution_counter.h"
+#include "torch/csrc/jit/tensorexpr/ir.h"
+#include "torch/csrc/jit/tensorexpr/ir_printer.h"
+#include "torch/csrc/jit/tensorexpr/types.h"
+
+using namespace torch::jit::tensorexpr;
+
+DEFINE_TRIGGER(llvm_codegen_created);
+DEFINE_TRIGGER(llvm_codegen_executed);
+
+static llvm::orc::JITTargetMachineBuilder makeTargetMachineBuilder() {
+#if 0
+  // FIXME: Switch to using detectHost() rather than setting up the JTMB manually
+  // once LLVM 10 is available.
+  return llvm::cantFail(llvm::orc::JITTargetMachineBuilder::detectHost());
+#else
+  llvm::orc::JITTargetMachineBuilder JTMB(
+      (llvm::Triple(llvm::sys::getProcessTriple())));
+
+  // Retrieve host CPU name and sub-target features and add them to builder.
+  // Relocation model, code model and codegen opt level are kept to default
+  // values.
+  llvm::SubtargetFeatures SubtargetFeatures;
+  llvm::StringMap<bool> FeatureMap;
+  llvm::sys::getHostCPUFeatures(FeatureMap);
+  for (auto& Feature : FeatureMap) {
+    SubtargetFeatures.AddFeature(Feature.first(), Feature.second);
+  }
+
+  JTMB.setCodeGenOptLevel(llvm::CodeGenOpt::Default);
+  JTMB.setCPU(llvm::sys::getHostCPUName());
+  JTMB.addFeatures(SubtargetFeatures.getFeatures());
+
+  return JTMB;
+#endif
+}
+
+LLVMCodeGen::LLVMCodeGen(Stmt* stmt)
+    : LLVMCodeGen(stmt, std::vector<BufferArg>()) {}
+
+LLVMCodeGen::LLVMCodeGen(
+    Stmt* stmt,
+    const std::vector<BufferArg>& args,
+    Dtype dtype)
+    : CodeGen(stmt, args),
+      context_(std::make_unique<llvm::LLVMContext>()),
+      irb_(getContext()) {
+  // Manually map types to LLVM types.
+  ByteTy_ = llvm::Type::getInt8Ty(getContext());
+  CharTy_ = llvm::Type::getInt8Ty(getContext());
+  ShortTy_ = llvm::Type::getInt16Ty(getContext());
+  IntTy_ = llvm::Type::getInt32Ty(getContext());
+  LongTy_ = llvm::Type::getInt64Ty(getContext());
+  HalfTy_ = llvm::Type::getHalfTy(getContext());
+  FloatTy_ = llvm::Type::getFloatTy(getContext());
+  DoubleTy_ = llvm::Type::getDoubleTy(getContext());
+
+  llvm::InitializeNativeTarget();
+  llvm::InitializeNativeTargetAsmPrinter();
+
+  auto JTMB = makeTargetMachineBuilder();
+  TM_ = llvm::cantFail(JTMB.createTargetMachine());
+
+  jit_ = std::make_unique<llvm::orc::PytorchLLVMJIT>();
+  module_ = std::make_unique<llvm::Module>("pytorch", getContext());
+  module_->setDataLayout(cantFail(JTMB.getDefaultDataLayoutForTarget()));
+  module_->setTargetTriple(JTMB.getTargetTriple().str());
+
+  // Emit prototype and bind argument Vars to parameter indices.
+  llvm::Type* retTy = dtypeToLLVM(dtype);
+  std::vector<llvm::Type*> params;
+  for (int i = 0; i < args.size(); i++) {
+    auto const& arg = args[i];
+    if (arg.isVar()) {
+      params.push_back(dtypeToLLVM(arg.dtype()));
+    } else {
+      params.push_back(dtypeToLLVMPtr(arg.dtype()));
+    }
+    varToArg_[arg.var()] = i;
+  }
+  llvm::FunctionType* fntype = llvm::FunctionType::get(retTy, params, false);
+  fn_ = llvm::Function::Create(
+      fntype, llvm::Function::PrivateLinkage, "pytorch", module_.get());
+  for (int i = 0; i < args.size(); i++) {
+    if (!args[i].isVar()) {
+      fn_->addParamAttr(i, llvm::Attribute::NoAlias);
+    }
+  }
+
+  emitWrapper(params);
+  emitKernel(stmt, params);
+
+  cantFail(jit_->addModule(
+      llvm::orc::ThreadSafeModule(std::move(module_), context_)));
+  auto sym = jit_->findSymbol("wrapper");
+  kernelAddress_ = cantFail(sym.getAddress());
+
+  USE_TRIGGER(llvm_codegen_created);
+}
+
+llvm::LLVMContext& LLVMCodeGen::getContext() {
+  return *context_.getContext();
+}
+
+llvm::Type* LLVMCodeGen::dtypeToLLVM(Dtype dtype) {
+  switch (dtype.scalar_type()) {
+#define TYPE_CASE(_1, n) \
+  case ScalarType::n:    \
+    return n##Ty_;       \
+    break;
+
+    AT_FORALL_SCALAR_TYPES_AND2(Bool, Half, TYPE_CASE);
+#undef TYPE_CASE
+    default:
+      LOG(FATAL) << "Unhandled dtype: " << dtype;
+  }
+  return nullptr;
+}
+
+llvm::Type* LLVMCodeGen::dtypeToLLVMPtr(Dtype dtype) {
+  return dtypeToLLVM(dtype)->getPointerTo();
+}
+
+void LLVMCodeGen::emitWrapper(const std::vector<llvm::Type*>& params) {
+  auto voidPtrPtrTy = llvm::Type::getInt8PtrTy(getContext())->getPointerTo();
+  auto wrapper = llvm::Function::Create(
+      llvm::FunctionType::get(IntTy_, {voidPtrPtrTy}, false),
+      llvm::Function::ExternalLinkage,
+      "wrapper",
+      module_.get());
+  auto wrapBB = llvm::BasicBlock::Create(getContext(), "wrapBB", wrapper);
+  irb_.SetInsertPoint(wrapBB);
+  llvm::SmallVector<llvm::Value*, 6> wrappedArgs;
+  for (size_t i = 0; i < params.size(); i++) {
+    auto argp = irb_.CreateGEP(
+        wrapper->arg_begin(), llvm::ConstantInt::getSigned(IntTy_, i));
+    if (params[i]->isPointerTy()) {
+      auto arg = irb_.CreatePointerCast(irb_.CreateLoad(argp), params[i]);
+      wrappedArgs.push_back(arg);
+    } else {
+      auto p = irb_.CreatePointerCast(
+          irb_.CreateLoad(argp), params[i]->getPointerTo());
+      auto arg = irb_.CreateLoad(p);
+      wrappedArgs.push_back(arg);
+    }
+  }
+  auto cc = irb_.CreateCall(fn_, wrappedArgs);
+  irb_.CreateRet(cc);
+}
+
+void LLVMCodeGen::emitKernel(
+    Stmt* stmt,
+    const std::vector<llvm::Type*>& params) {
+  // Set insert point to the real function.
+  bb_ = llvm::BasicBlock::Create(getContext(), "entry", fn_);
+  irb_.SetInsertPoint(bb_);
+
+  // Compile the kernel.
+  stmt->accept(this);
+  irb_.CreateRet(value_);
+
+#if DEBUG_PRINT
+  llvm::errs() << *module_;
+#endif
+  CHECK(!llvm::verifyFunction(*fn_, &llvm::outs()))
+      << "Function verification failed";
+  optimize(*module_);
+
+#if DEBUG_PRINT
+  llvm::errs() << *module_;
+  llvm::SmallVector<char, 0> asmBuffer;
+  llvm::raw_svector_ostream asmStream(asmBuffer);
+  llvm::legacy::PassManager PM;
+  TM_->addPassesToEmitFile(
+      PM,
+      asmStream,
+      nullptr,
+      llvm::TargetMachine::CodeGenFileType::CGFT_AssemblyFile);
+  PM.run(*module_);
+  llvm::errs() << asmStream.str();
+#endif
+}
+
+static void* argToPtr(
+    const CodeGen::BufferArg& bufferArg,
+    const CodeGen::CallArg& callArg) {
+  if (!bufferArg.isVar()) {
+    return callArg.data();
+  }
+
+  switch (bufferArg.dtype().scalar_type()) {
+#define TYPE_CASE(_1, Name) \
+  case ScalarType::Name:    \
+    return callArg.Name##Ptr();
+    break;
+
+    AT_FORALL_SCALAR_TYPES_AND2(Bool, Half, TYPE_CASE);
+#undef TYPE_CASE
+
+    default:
+      LOG(FATAL) << "Unhandled dtype for arg: " << bufferArg.var()->name_hint()
+                 << "dtype=" << bufferArg.var()->dtype();
+  }
+  return nullptr;
+}
+
+void LLVMCodeGen::call(const std::vector<CallArg>& args) {
+  CHECK_EQ(args.size(), buffer_args().size())
+      << "args: " << args.size() << ", buffers: " << buffer_args().size();
+  for (size_t i = 0; i < buffer_args().size(); i++) {
+    auto const& bufferArg = buffer_args()[i];
+    auto const& callArg = args[i];
+    args_.push_back(argToPtr(bufferArg, callArg));
+  }
+  value<float>(args_);
+  args_.clear();
+  USE_TRIGGER(llvm_codegen_executed);
+}
+
+// TODO: The binary ops are copypasta.
+
+void LLVMCodeGen::visit(const Add* v) {
+  v->lhs()->accept(this);
+  auto lhs = this->value_;
+  bool lfp = lhs->getType()->isFloatingPointTy();
+  v->rhs()->accept(this);
+  auto rhs = this->value_;
+  bool rfp = rhs->getType()->isFloatingPointTy();
+
+  // TODO: Handle arg promotion.
+  if (lfp && rfp) {
+    value_ = irb_.CreateFAdd(lhs, rhs);
+  } else if (!lfp && !rfp) {
+    value_ = irb_.CreateAdd(lhs, rhs);
+  } else {
+    LOG(FATAL) << "Unhandled mismatch add arg types";
+  }
+}
+
+void LLVMCodeGen::visit(const Sub* v) {
+  v->lhs()->accept(this);
+  auto lhs = this->value_;
+  bool lfp = lhs->getType()->isFloatingPointTy();
+  v->rhs()->accept(this);
+  auto rhs = this->value_;
+  bool rfp = rhs->getType()->isFloatingPointTy();
+
+  // TODO: Handle arg promotion.
+  if (lfp && rfp) {
+    value_ = irb_.CreateFSub(lhs, rhs);
+  } else if (!lfp && !rfp) {
+    value_ = irb_.CreateSub(lhs, rhs);
+  } else {
+    LOG(FATAL) << "Unhandled mismatch sub arg types";
+  }
+}
+
+void LLVMCodeGen::visit(const Mul* v) {
+  v->lhs()->accept(this);
+  auto lhs = this->value_;
+  bool lfp = lhs->getType()->isFloatingPointTy();
+  v->rhs()->accept(this);
+  auto rhs = this->value_;
+  bool rfp = rhs->getType()->isFloatingPointTy();
+
+  // TODO: Handle arg promotion.
+  if (lfp && rfp) {
+    value_ = irb_.CreateFMul(lhs, rhs);
+  } else if (!lfp && !rfp) {
+    value_ = irb_.CreateMul(lhs, rhs);
+  } else {
+    LOG(FATAL) << "Unhandled mismatch mul arg types";
+  }
+}
+
+void LLVMCodeGen::visit(const Div* v) {
+  v->lhs()->accept(this);
+  auto lhs = this->value_;
+  bool lfp = lhs->getType()->isFloatingPointTy();
+  v->rhs()->accept(this);
+  auto rhs = this->value_;
+  bool rfp = rhs->getType()->isFloatingPointTy();
+
+  // TODO: Handle arg promotion.
+  if (lfp && rfp) {
+    value_ = irb_.CreateFDiv(lhs, rhs);
+  } else if (!lfp && !rfp) {
+    value_ = irb_.CreateSDiv(lhs, rhs);
+  } else {
+    LOG(FATAL) << "Unhandled mismatch div arg types";
+  }
+}
+
+void LLVMCodeGen::visit(const And* v) {
+  v->lhs()->accept(this);
+  auto lhs = this->value_;
+  bool lfp = lhs->getType()->isFloatingPointTy();
+  v->rhs()->accept(this);
+  auto rhs = this->value_;
+  bool rfp = rhs->getType()->isFloatingPointTy();
+
+  if (!lfp && !rfp) {
+    value_ = irb_.CreateAnd(lhs, rhs);
+  } else {
+    LOG(FATAL) << "Unhandled mismatch And arg types";
+  }
+}
+
+void LLVMCodeGen::visit(const Or* v) {
+  v->lhs()->accept(this);
+  auto lhs = this->value_;
+  bool lfp = lhs->getType()->isFloatingPointTy();
+  v->rhs()->accept(this);
+  auto rhs = this->value_;
+  bool rfp = rhs->getType()->isFloatingPointTy();
+
+  if (!lfp && !rfp) {
+    value_ = irb_.CreateOr(lhs, rhs);
+  } else {
+    LOG(FATAL) << "Unhandled mismatch Or arg types";
+  }
+}
+
+void LLVMCodeGen::visit(const Xor* v) {
+  v->lhs()->accept(this);
+  auto lhs = this->value_;
+  bool lfp = lhs->getType()->isFloatingPointTy();
+  v->rhs()->accept(this);
+  auto rhs = this->value_;
+  bool rfp = rhs->getType()->isFloatingPointTy();
+
+  if (!lfp && !rfp) {
+    value_ = irb_.CreateXor(lhs, rhs);
+  } else {
+    LOG(FATAL) << "Unhandled mismatch And arg types";
+  }
+}
+
+void LLVMCodeGen::visit(const Lshift* v) {
+  v->lhs()->accept(this);
+  auto lhs = this->value_;
+  bool lfp = lhs->getType()->isFloatingPointTy();
+  v->rhs()->accept(this);
+  auto rhs = this->value_;
+  bool rfp = rhs->getType()->isFloatingPointTy();
+
+  if (!lfp && !rfp) {
+    value_ = irb_.CreateShl(lhs, rhs);
+  } else {
+    LOG(FATAL) << "Unhandled mismatch And arg types";
+  }
+}
+
+void LLVMCodeGen::visit(const Rshift* v) {
+  v->lhs()->accept(this);
+  auto lhs = this->value_;
+  bool lfp = lhs->getType()->isFloatingPointTy();
+  v->rhs()->accept(this);
+  auto rhs = this->value_;
+  bool rfp = rhs->getType()->isFloatingPointTy();
+
+  if (!lfp && !rfp) {
+    value_ = irb_.CreateLShr(lhs, rhs);
+  } else {
+    LOG(FATAL) << "Unhandled mismatch And arg types";
+  }
+}
+
+void LLVMCodeGen::visit(const Mod* v) {
+  throw std::runtime_error("Mod unsupported in LLVM codegen yet");
+}
+
+void LLVMCodeGen::visit(const Max* v) {
+  v->lhs()->accept(this);
+  auto lhs = this->value_;
+  v->rhs()->accept(this);
+  auto rhs = this->value_;
+
+  if (v->dtype() == kInt) {
+    auto icmp = irb_.CreateICmpSGT(lhs, rhs);
+    value_ = irb_.CreateSelect(icmp, lhs, rhs);
+    return;
+  }
+
+  if (v->propagate_nans()) {
+    value_ = irb_.CreateBinaryIntrinsic(llvm::Intrinsic::maximum, lhs, rhs);
+    return;
+  }
+
+  value_ = irb_.CreateSelect(
+      irb_.CreateFCmp(llvm::FCmpInst::FCMP_OGT, lhs, rhs), lhs, rhs);
+}
+
+void LLVMCodeGen::visit(const Min* v) {
+  v->lhs()->accept(this);
+  auto lhs = this->value_;
+  v->rhs()->accept(this);
+  auto rhs = this->value_;
+
+  if (v->dtype() == kInt) {
+    auto icmp = irb_.CreateICmpSLT(lhs, rhs);
+    value_ = irb_.CreateSelect(icmp, lhs, rhs);
+    return;
+  }
+
+  if (v->propagate_nans()) {
+    value_ = irb_.CreateBinaryIntrinsic(llvm::Intrinsic::minimum, lhs, rhs);
+    return;
+  }
+
+  value_ = irb_.CreateSelect(
+      irb_.CreateFCmp(llvm::FCmpInst::FCMP_OLT, lhs, rhs), lhs, rhs);
+}
+
+void LLVMCodeGen::visit(const CompareSelect* v) {
+  v->lhs()->accept(this);
+  auto lhs = this->value_;
+  v->rhs()->accept(this);
+  auto rhs = this->value_;
+  v->ret_val1()->accept(this);
+  auto retval1 = this->value_;
+  v->ret_val2()->accept(this);
+  auto retval2 = this->value_;
+
+  auto type_used = v->lhs()->dtype().scalar_type();
+
+  llvm::Value* cmp_;
+  CompareSelectOperation cmp_op_ = v->compare_select_op();
+
+  if (is_integral(type_used)) {
+    switch (cmp_op_) {
+      case CompareSelectOperation::kEQ:
+        cmp_ = irb_.CreateICmpEQ(lhs, rhs);
+        break;
+      case CompareSelectOperation::kNE:
+        cmp_ = irb_.CreateICmpNE(lhs, rhs);
+        break;
+      case CompareSelectOperation::kGT:
+        cmp_ = irb_.CreateICmpSGT(lhs, rhs);
+        break;
+      case CompareSelectOperation::kGE:
+        cmp_ = irb_.CreateICmpSGE(lhs, rhs);
+        break;
+      case CompareSelectOperation::kLT:
+        cmp_ = irb_.CreateICmpSLT(lhs, rhs);
+        break;
+      case CompareSelectOperation::kLE:
+        cmp_ = irb_.CreateICmpSLE(lhs, rhs);
+        break;
+      default:
+        // TODO: change to a proper error report
+        throw std::runtime_error("invalid operator type");
+    }
+  } else if (is_floating_point(type_used)) { // FP32
+    switch (cmp_op_) {
+      case CompareSelectOperation::kEQ:
+        cmp_ = irb_.CreateFCmpOEQ(lhs, rhs);
+        break;
+      case CompareSelectOperation::kNE:
+        cmp_ = irb_.CreateFCmpONE(lhs, rhs);
+        break;
+      case CompareSelectOperation::kGT:
+        cmp_ = irb_.CreateFCmpOGT(lhs, rhs);
+        break;
+      case CompareSelectOperation::kGE:
+        cmp_ = irb_.CreateFCmpOGE(lhs, rhs);
+        break;
+      case CompareSelectOperation::kLT:
+        cmp_ = irb_.CreateFCmpOLT(lhs, rhs);
+        break;
+      case CompareSelectOperation::kLE:
+        cmp_ = irb_.CreateFCmpOLE(lhs, rhs);
+        break;
+      default:
+        // TODO: change to a proper error report
+        throw std::runtime_error("invalid operator type");
+    }
+  } else {
+    throw std::runtime_error("invalid type for CompareSelect");
+  }
+
+  value_ = irb_.CreateSelect(cmp_, retval1, retval2);
+  return;
+}
+
+template <typename T>
+typename std::enable_if<std::is_integral<T>::value, llvm::Value*>::type
+getFromType(llvm::Type* type, T value) {
+  return llvm::ConstantInt::get(type, value, std::is_signed<T>::value);
+}
+
+template <typename T>
+typename std::enable_if<std::is_floating_point<T>::value, llvm::Value*>::type
+getFromType(llvm::Type* type, T value) {
+  return llvm::ConstantFP::get(type, value);
+}
+
+#define IMM_VISIT_DECLARE(Type, Name)                  \
+  void LLVMCodeGen::visit(const Name##Imm* v) {        \
+    value_ = getFromType<Type>(Name##Ty_, v->value()); \
+  }
+AT_FORALL_SCALAR_TYPES(IMM_VISIT_DECLARE);
+#undef IMM_VISIT_DECLARE
+
+void LLVMCodeGen::visit(const HalfImm* v) {
+  value_ = llvm::ConstantFP::get(HalfTy_, v->value());
+}
+
+void LLVMCodeGen::visit(const BoolImm* v) {
+  value_ = llvm::ConstantInt::get(BoolTy_, v->value());
+}
+
+void LLVMCodeGen::visit(const Cast* v) {
+  v->src_value()->accept(this);
+
+  llvm::Type* dstType = dtypeToLLVM(v->dtype());
+  if (v->dtype().lanes() > 1) {
+    dstType = llvm::VectorType::get(dstType, v->dtype().lanes());
+  }
+  llvm::Type* srcType = dtypeToLLVM(v->src_value()->dtype());
+
+  if (srcType == dstType) {
+    // do nothing.
+    return;
+  }
+
+  bool destUnsigned = v->dtype().scalar_type() == ScalarType::Byte;
+
+  // Scalar casts
+  if (srcType->isFloatingPointTy()) {
+    if (dstType->isFloatingPointTy()) {
+      value_ = irb_.CreateFPCast(value_, dstType);
+    } else if (dstType->isIntegerTy()) {
+      if (destUnsigned) {
+        value_ = irb_.CreateFPToUI(value_, dstType);
+      } else {
+        value_ = irb_.CreateFPToSI(value_, dstType);
+      }
+    } else {
+      LOG(FATAL) << "Unsupported cast!";
+    }
+  } else if (srcType->isIntegerTy()) {
+    if (dstType->isFloatingPointTy()) {
+      if (destUnsigned) {
+        value_ = irb_.CreateUIToFP(value_, dstType);
+      } else {
+        value_ = irb_.CreateSIToFP(value_, dstType);
+      }
+    } else if (dstType->isIntegerTy()) {
+      value_ = irb_.CreateIntCast(value_, dstType, !destUnsigned);
+    } else {
+      LOG(FATAL) << "Unsupported cast!";
+    }
+  }
+}
+
+void LLVMCodeGen::visit(const Var* v) {
+  if (varToArg_.count(v)) {
+    auto idx = varToArg_.at(v);
+    auto arg = fn_->arg_begin() + idx;
+    value_ = arg;
+  } else if (varToVal_.count(v)) {
+    value_ = varToVal_.at(v);
+  }
+}
+
+void LLVMCodeGen::visit(const Let* v) {
+  const Var* var = dynamic_cast<const Var*>(v->var());
+  CHECK(var != nullptr);
+  v->value()->accept(this);
+  auto value = value_;
+  if (!varToVal_.count(var)) {
+    varToVal_.emplace(var, value);
+  } else {
+    throw std::runtime_error("var should not exist before");
+  }
+  v->body()->accept(this);
+  if (varToVal_.count(var)) {
+    varToVal_.erase(var);
+  } else {
+    throw std::runtime_error("erasing var that doesn't exist");
+  }
+}
+
+// TODO: refactor this and merge with Let
+void LLVMCodeGen::visit(const LetStmt* v) {
+  const Var* var = v->var();
+  CHECK(var != nullptr);
+  v->value()->accept(this);
+  auto value = value_;
+  if (!varToVal_.count(var)) {
+    varToVal_.emplace(var, value);
+  } else {
+    throw std::runtime_error("var should not exist before");
+  }
+  v->body()->accept(this);
+  if (varToVal_.count(var)) {
+    varToVal_.erase(var);
+  } else {
+    throw std::runtime_error("erasing var that doesn't exist");
+  }
+}
+
+void LLVMCodeGen::visit(const Ramp* v) {
+  v->base()->accept(this);
+  auto base = this->value_;
+  v->stride()->accept(this);
+  auto stride = this->value_;
+  int lanes = v->lanes();
+
+  llvm::Type* vecType = nullptr;
+  switch (v->dtype().scalar_type()) {
+#define TYPE_CASE(_1, Name)                            \
+  case ScalarType::Name:                               \
+    vecType = llvm::VectorType::get(Name##Ty_, lanes); \
+    break;
+    AT_FORALL_SCALAR_TYPES_AND2(Bool, Half, TYPE_CASE);
+#undef TYPE_CASE
+    default:
+      throw std::runtime_error("invalid dtype in Ramp");
+  }
+
+  value_ = llvm::UndefValue::get(vecType);
+  for (int i = 0; i < lanes; ++i) {
+    value_ = irb_.CreateInsertElement(value_, base, i);
+    base = irb_.CreateAdd(base, stride);
+  }
+}
+
+llvm::Value* LLVMCodeGen::emitUnmaskedLoad(
+    llvm::Value* base,
+    llvm::Value* idx) {
+  auto addr = irb_.CreateGEP(base, idx);
+  return irb_.CreateLoad(addr);
+}
+
+llvm::Value* LLVMCodeGen::emitMaskedLoad(
+    llvm::Value* base,
+    llvm::Value* idx,
+    llvm::Value* mask) {
+  // Create block structure for the masked load.
+  auto preheader = irb_.GetInsertBlock();
+  auto condblock = llvm::BasicBlock::Create(getContext(), "cond", fn_);
+  auto tailblock = llvm::BasicBlock::Create(getContext(), "tail", fn_);
+
+  // Test the mask
+  auto cond = irb_.CreateICmpEQ(mask, llvm::ConstantInt::get(IntTy_, 1));
+  irb_.CreateCondBr(cond, condblock, tailblock);
+
+  // Do the load
+  irb_.SetInsertPoint(condblock);
+  auto addr = irb_.CreateGEP(base, idx);
+  auto load = irb_.CreateLoad(addr);
+  irb_.CreateBr(tailblock);
+
+  // Merge the masked and unmasked CFG edges
+  irb_.SetInsertPoint(tailblock);
+  auto phi = irb_.CreatePHI(load->getType(), 2);
+  phi->addIncoming(llvm::UndefValue::get(load->getType()), preheader);
+  phi->addIncoming(load, condblock);
+
+  return phi;
+}
+
+void LLVMCodeGen::visit(const Load* v) {
+  v->base_handle()->accept(this);
+  auto base = this->value_;
+  v->index()->accept(this);
+  auto idx = this->value_;
+  v->mask()->accept(this);
+  auto mask = this->value_;
+
+  if (v->dtype().lanes() == 1) {
+    auto* maskimm = dynamic_cast<const IntImm*>(v->mask());
+    if (maskimm && maskimm->value() == 1) {
+      value_ = emitUnmaskedLoad(base, idx);
+    } else {
+      value_ = emitMaskedLoad(base, idx, mask);
+    }
+    return;
+  }
+
+  llvm::Type* loadType = nullptr;
+
+  switch (v->dtype().scalar_type()) {
+#define TYPE_CASE(_1, Name)                                          \
+  case ScalarType::Name:                                             \
+    loadType = llvm::VectorType::get(Name##Ty_, v->dtype().lanes()); \
+    break;
+    AT_FORALL_SCALAR_TYPES_AND2(Bool, Half, TYPE_CASE);
+#undef TYPE_CASE
+    default:
+      throw std::runtime_error("invalid dtype in Load");
+  }
+
+  // Detect whether the vector mask is all true
+  bool unmasked_load = false;
+  auto* mask_broadcast = dynamic_cast<const Broadcast*>(v->mask());
+  if (mask_broadcast) {
+    auto* broadcast_imm = dynamic_cast<const IntImm*>(mask_broadcast->value());
+    if (broadcast_imm && broadcast_imm->value() == 1) {
+      unmasked_load = true;
+    }
+  }
+
+  // Handle the case where the load is contiguous and unmasked efficiently
+  auto* idx_ramp = dynamic_cast<const Ramp*>(v->index());
+  if (unmasked_load && idx_ramp) {
+    auto* stride_imm = dynamic_cast<const IntImm*>(idx_ramp->stride());
+    if (stride_imm && stride_imm->value() == 1) {
+      auto first_idx = irb_.CreateExtractElement(idx, uint64_t{0ULL});
+      auto addr = irb_.CreateGEP(base, first_idx);
+      auto vaddr = irb_.CreateBitOrPointerCast(
+          addr, llvm::PointerType::get(loadType, 0));
+      value_ = irb_.CreateAlignedLoad(loadType, vaddr, 4);
+      return;
+    }
+  }
+
+  // Fallback to a scalar implementation
+  llvm::Value* load = llvm::UndefValue::get(loadType);
+  for (int i = 0; i < v->dtype().lanes(); ++i) {
+    auto sub_idx = irb_.CreateExtractElement(idx, i);
+    llvm::Value* sub_load = nullptr;
+    if (unmasked_load) {
+      sub_load = emitUnmaskedLoad(base, sub_idx);
+    } else {
+      auto sub_mask = irb_.CreateExtractElement(mask, i);
+      sub_load = emitMaskedLoad(base, sub_idx, sub_mask);
+    }
+    load = irb_.CreateInsertElement(load, sub_load, i);
+  }
+
+  value_ = load;
+}
+
+void LLVMCodeGen::visit(const For* v) {
+  // Create "start" and "stop" values.
+  v->start()->accept(this);
+  auto start = this->value_;
+  v->stop()->accept(this);
+  auto stop = this->value_;
+
+  // Create block for loop condition test.
+  auto preheader = irb_.GetInsertBlock();
+  auto condBlock = llvm::BasicBlock::Create(getContext(), "cond", fn_);
+  irb_.CreateBr(condBlock);
+  irb_.SetInsertPoint(condBlock);
+
+  // Set up phi node for index variable.
+  auto idx = irb_.CreatePHI(IntTy_, 2);
+  idx->addIncoming(start, preheader);
+  varToVal_.emplace(v->var(), idx);
+
+  // Create the body and exit blocks.
+  auto body = llvm::BasicBlock::Create(getContext(), "body", fn_);
+  auto exit = llvm::BasicBlock::Create(getContext(), "exit", fn_);
+
+  // Create the stop condition.
+  auto cond = irb_.CreateICmpSLT(idx, stop);
+  irb_.CreateCondBr(cond, body, exit);
+
+  // Codegen the body.
+  irb_.SetInsertPoint(body);
+  if (v->body()) {
+    v->body()->accept(this);
+  }
+  // "Body" block may have changed if we generated nested control flow.
+  body = irb_.GetInsertBlock();
+
+  // Increment the index variable and branch back to loop test.
+  auto inc = irb_.CreateAdd(idx, llvm::ConstantInt::getSigned(IntTy_, 1));
+  irb_.CreateBr(condBlock);
+  idx->addIncoming(inc, body);
+
+  // Exit the loop.
+  irb_.SetInsertPoint(exit);
+  value_ = llvm::ConstantInt::get(IntTy_, 0);
+}
+
+void LLVMCodeGen::visit(const Block* v) {
+  for (Stmt* s : v->stmts()) {
+    s->accept(this);
+  }
+}
+
+void LLVMCodeGen::emitUnmaskedStore(
+    llvm::Value* base,
+    llvm::Value* idx,
+    llvm::Value* val) {
+  auto addr = irb_.CreateGEP(base, idx);
+  irb_.CreateStore(val, addr);
+}
+
+void LLVMCodeGen::emitMaskedStore(
+    llvm::Value* base,
+    llvm::Value* idx,
+    llvm::Value* mask,
+    llvm::Value* val) {
+  // Create block structure for the masked store.
+  auto preheader = irb_.GetInsertBlock();
+  auto condblock = llvm::BasicBlock::Create(getContext(), "cond", fn_);
+  auto tailblock = llvm::BasicBlock::Create(getContext(), "tail", fn_);
+
+  // Test the mask
+  auto cond = irb_.CreateICmpEQ(mask, llvm::ConstantInt::get(IntTy_, 1));
+  irb_.CreateCondBr(cond, condblock, tailblock);
+
+  // Do the store
+  irb_.SetInsertPoint(condblock);
+  auto addr = irb_.CreateGEP(base, idx);
+  irb_.CreateStore(val, addr);
+  irb_.CreateBr(tailblock);
+
+  // Merge the masked and unmasked CFG edges
+  irb_.SetInsertPoint(tailblock);
+}
+
+void LLVMCodeGen::visit(const Store* v) {
+  v->base_handle()->accept(this);
+  auto base = this->value_;
+  v->index()->accept(this);
+  auto idx = this->value_;
+  v->mask()->accept(this);
+  auto mask = this->value_;
+  v->value()->accept(this);
+  auto val = this->value_;
+
+  value_ = llvm::ConstantInt::get(IntTy_, 0);
+
+  if (v->value()->dtype().lanes() == 1) {
+    auto* maskimm = dynamic_cast<const IntImm*>(v->mask());
+    if (maskimm && maskimm->value() == 1) {
+      emitUnmaskedStore(base, idx, val);
+    } else {
+      emitMaskedStore(base, idx, mask, val);
+    }
+    return;
+  }
+
+  // Detect whether the vector mask is all true
+  bool unmasked_store = false;
+  auto* mask_broadcast = dynamic_cast<const Broadcast*>(v->mask());
+  if (mask_broadcast) {
+    auto* broadcast_imm = dynamic_cast<const IntImm*>(mask_broadcast->value());
+    if (broadcast_imm && broadcast_imm->value() == 1) {
+      unmasked_store = true;
+    }
+  }
+
+  // Handle the case where the store is contiguous and unmasked efficiently
+  auto* idx_ramp = dynamic_cast<const Ramp*>(v->index());
+  if (unmasked_store && idx_ramp) {
+    auto* stride_imm = dynamic_cast<const IntImm*>(idx_ramp->stride());
+    if (stride_imm && stride_imm->value() == 1) {
+      auto first_idx = irb_.CreateExtractElement(idx, uint64_t{0});
+      auto addr = irb_.CreateGEP(base, first_idx);
+      auto vaddr = irb_.CreateBitOrPointerCast(
+          addr, llvm::PointerType::get(val->getType(), 0));
+      irb_.CreateAlignedStore(val, vaddr, 4);
+      return;
+    }
+  }
+
+  // Fallback to a scalar implementation
+  for (int i = 0; i < v->value()->dtype().lanes(); ++i) {
+    auto sub_idx = irb_.CreateExtractElement(idx, i);
+    auto sub_val = irb_.CreateExtractElement(val, i);
+    if (unmasked_store) {
+      emitUnmaskedStore(base, sub_idx, sub_val);
+    } else {
+      auto sub_mask = irb_.CreateExtractElement(mask, i);
+      emitMaskedStore(base, sub_idx, sub_mask, sub_val);
+    }
+  }
+}
+
+void LLVMCodeGen::visit(const Broadcast* v) {
+  v->value()->accept(this);
+  int lanes = v->lanes();
+  value_ = irb_.CreateVectorSplat(lanes, value_);
+}
+
+void LLVMCodeGen::visit(const IfThenElse* v) {
+  v->condition()->accept(this);
+  llvm::Value* condition = value_;
+  llvm::Value* c =
+      irb_.CreateICmpNE(condition, llvm::ConstantInt::get(IntTy_, 0));
+
+  auto then_block = llvm::BasicBlock::Create(getContext(), "then", fn_);
+  auto else_block = llvm::BasicBlock::Create(getContext(), "else", fn_);
+  auto end_block = llvm::BasicBlock::Create(getContext(), "block", fn_);
+  irb_.CreateCondBr(c, then_block, else_block);
+
+  irb_.SetInsertPoint(then_block);
+  v->true_value()->accept(this);
+  llvm::Value* then_val = value_;
+  then_block = irb_.GetInsertBlock();
+  irb_.CreateBr(end_block);
+
+  irb_.SetInsertPoint(else_block);
+  v->false_value()->accept(this);
+  llvm::Value* else_val = value_;
+  else_block = irb_.GetInsertBlock();
+  irb_.CreateBr(end_block);
+
+  irb_.SetInsertPoint(end_block);
+  llvm::PHINode* phi = irb_.CreatePHI(then_val->getType(), 2);
+  phi->addIncoming(then_val, then_block);
+  phi->addIncoming(else_val, else_block);
+  value_ = phi;
+}
+
+void LLVMCodeGen::visit(const BaseCallNode* v) {
+  LOG(FATAL) << "Unimplemented: BaseCall";
+}
+
+static void applyMathFunctionAttributes(llvm::Function* f) {
+  f->addFnAttr(llvm::Attribute::ReadNone);
+  f->addFnAttr(llvm::Attribute::NoFree);
+  f->addFnAttr(llvm::Attribute::NoUnwind);
+  // TODO: Adding this attr should be correct, but as of LLVM 9.0.1 adding it
+  // causes some math functions to incorrectly be turned into tail calls.
+  // f->addFnAttr(llvm::Attribute::Speculatable);
+  f->addFnAttr(llvm::Attribute::WillReturn);
+}
+
+void LLVMCodeGen::visit(const Intrinsics* v) {
+  llvm::FunctionType* call_ty = nullptr;
+  llvm::Value* call_fn = nullptr;
+
+  if (v->dtype().scalar_type() == ScalarType::Float) {
+    switch (v->op_type()) {
+#define UNARY_INTRIN_CASE(enum, intrin)                 \
+  case enum: {                                          \
+    v->params().front()->accept(this);                  \
+    value_ = irb_.CreateUnaryIntrinsic(intrin, value_); \
+    return;                                             \
+  } break;
+      UNARY_INTRIN_CASE(kLog10, llvm::Intrinsic::log10)
+      UNARY_INTRIN_CASE(kLog, llvm::Intrinsic::log)
+      UNARY_INTRIN_CASE(kLog2, llvm::Intrinsic::log2)
+      UNARY_INTRIN_CASE(kExp, llvm::Intrinsic::exp)
+      UNARY_INTRIN_CASE(kCos, llvm::Intrinsic::cos)
+      UNARY_INTRIN_CASE(kSin, llvm::Intrinsic::sin)
+      UNARY_INTRIN_CASE(kSqrt, llvm::Intrinsic::sqrt)
+      UNARY_INTRIN_CASE(kFabs, llvm::Intrinsic::fabs)
+      UNARY_INTRIN_CASE(kFloor, llvm::Intrinsic::floor)
+      UNARY_INTRIN_CASE(kCeil, llvm::Intrinsic::ceil)
+      UNARY_INTRIN_CASE(kTrunc, llvm::Intrinsic::trunc)
+      UNARY_INTRIN_CASE(kRound, llvm::Intrinsic::round)
+#undef UNARY_INTRIN_CASE
+
+      case kRsqrt: {
+        v->params().front()->accept(this);
+        value_ = irb_.CreateUnaryIntrinsic(llvm::Intrinsic::sqrt, value_);
+        llvm::Value* constant = llvm::ConstantFP::get(FloatTy_, 1.0);
+        if (v->dtype().lanes() > 1) {
+          constant = irb_.CreateVectorSplat(v->dtype().lanes(), constant);
+        }
+        value_ = irb_.CreateFDiv(constant, value_);
+        return;
+      } break;
+
+#define UNARY_MATH_CASE(enum, name, type)                             \
+  case enum: {                                                        \
+    auto callee = module_->getOrInsertFunction(                       \
+        name, llvm::FunctionType::get(type, {type}, false), {});      \
+    call_ty = callee.getFunctionType();                               \
+    call_fn = callee.getCallee();                                     \
+    applyMathFunctionAttributes(llvm::cast<llvm::Function>(call_fn)); \
+  } break;
+        UNARY_MATH_CASE(kErf, "erff", FloatTy_)
+        UNARY_MATH_CASE(kErfc, "erfcf", FloatTy_)
+        UNARY_MATH_CASE(kTan, "tanf", FloatTy_)
+        UNARY_MATH_CASE(kAcos, "acosf", FloatTy_)
+        UNARY_MATH_CASE(kAsin, "asinf", FloatTy_)
+        UNARY_MATH_CASE(kAtan, "atanf", FloatTy_)
+        UNARY_MATH_CASE(kCosh, "coshf", FloatTy_)
+        UNARY_MATH_CASE(kSinh, "sinhf", FloatTy_)
+        UNARY_MATH_CASE(kTanh, "tanhf", FloatTy_)
+        UNARY_MATH_CASE(kExpm1, "expm1f", FloatTy_)
+        UNARY_MATH_CASE(kLgamma, "lgammaf", FloatTy_)
+#undef UNARY_MATH_CASE
+
+#define BINARY_MATH_CASE(enum, name, type)                             \
+  case enum: {                                                         \
+    auto callee = module_->getOrInsertFunction(                        \
+        name, llvm::FunctionType::get(type, {type, type}, false), {}); \
+    call_ty = callee.getFunctionType();                                \
+    call_fn = callee.getCallee();                                      \
+    applyMathFunctionAttributes(llvm::cast<llvm::Function>(call_fn));  \
+  } break;
+        BINARY_MATH_CASE(kRemainder, "remainderf", FloatTy_)
+        BINARY_MATH_CASE(kAtan2, "atan2f", FloatTy_)
+        BINARY_MATH_CASE(kPow, "powf", FloatTy_)
+        BINARY_MATH_CASE(kFmod, "fmodf", FloatTy_)
+#undef BINARY_MATH_CASE
+
+      default: {
+        LOG(FATAL) << "Unimplemented: Intrinsics: " << ExprHandle(v);
+      } break;
+    }
+  } else if (v->dtype().scalar_type() == ScalarType::Double) {
+    switch (v->op_type()) {
+#define UNARY_INTRIN_CASE(enum, intrin)                 \
+  case enum: {                                          \
+    v->params().front()->accept(this);                  \
+    value_ = irb_.CreateUnaryIntrinsic(intrin, value_); \
+    return;                                             \
+  } break;
+      UNARY_INTRIN_CASE(kLog10, llvm::Intrinsic::log10)
+      UNARY_INTRIN_CASE(kLog, llvm::Intrinsic::log)
+      UNARY_INTRIN_CASE(kLog2, llvm::Intrinsic::log2)
+      UNARY_INTRIN_CASE(kExp, llvm::Intrinsic::exp)
+      UNARY_INTRIN_CASE(kCos, llvm::Intrinsic::cos)
+      UNARY_INTRIN_CASE(kSin, llvm::Intrinsic::sin)
+      UNARY_INTRIN_CASE(kSqrt, llvm::Intrinsic::sqrt)
+      UNARY_INTRIN_CASE(kFabs, llvm::Intrinsic::fabs)
+      UNARY_INTRIN_CASE(kFloor, llvm::Intrinsic::floor)
+      UNARY_INTRIN_CASE(kCeil, llvm::Intrinsic::ceil)
+      UNARY_INTRIN_CASE(kTrunc, llvm::Intrinsic::trunc)
+      UNARY_INTRIN_CASE(kRound, llvm::Intrinsic::round)
+#undef UNARY_INTRIN_CASE
+
+      case kRsqrt: {
+        v->params().front()->accept(this);
+        value_ = irb_.CreateUnaryIntrinsic(llvm::Intrinsic::sqrt, value_);
+        llvm::Value* constant = llvm::ConstantFP::get(DoubleTy_, 1.0);
+        if (v->dtype().lanes() > 1) {
+          constant = irb_.CreateVectorSplat(v->dtype().lanes(), constant);
+        }
+        value_ = irb_.CreateFDiv(constant, value_);
+        return;
+      } break;
+
+#define UNARY_MATH_CASE(enum, name, type)                             \
+  case enum: {                                                        \
+    auto callee = module_->getOrInsertFunction(                       \
+        name, llvm::FunctionType::get(type, {type}, false), {});      \
+    call_ty = callee.getFunctionType();                               \
+    call_fn = callee.getCallee();                                     \
+    applyMathFunctionAttributes(llvm::cast<llvm::Function>(call_fn)); \
+  } break;
+        UNARY_MATH_CASE(kErf, "erf", DoubleTy_)
+        UNARY_MATH_CASE(kErfc, "erfc", DoubleTy_)
+        UNARY_MATH_CASE(kTan, "tan", DoubleTy_)
+        UNARY_MATH_CASE(kAcos, "acos", DoubleTy_)
+        UNARY_MATH_CASE(kAsin, "asin", DoubleTy_)
+        UNARY_MATH_CASE(kAtan, "atan", DoubleTy_)
+        UNARY_MATH_CASE(kCosh, "cosh", DoubleTy_)
+        UNARY_MATH_CASE(kSinh, "sinh", DoubleTy_)
+        UNARY_MATH_CASE(kTanh, "tanh", DoubleTy_)
+        UNARY_MATH_CASE(kExpm1, "expm1", DoubleTy_)
+        UNARY_MATH_CASE(kLgamma, "lgamma", DoubleTy_)
+#undef UNARY_MATH_CASE
+
+#define BINARY_MATH_CASE(enum, name, type)                             \
+  case enum: {                                                         \
+    auto callee = module_->getOrInsertFunction(                        \
+        name, llvm::FunctionType::get(type, {type, type}, false), {}); \
+    call_ty = callee.getFunctionType();                                \
+    call_fn = callee.getCallee();                                      \
+    applyMathFunctionAttributes(llvm::cast<llvm::Function>(call_fn));  \
+  } break;
+        BINARY_MATH_CASE(kRemainder, "remainder", DoubleTy_)
+        BINARY_MATH_CASE(kAtan2, "atan2", DoubleTy_)
+        BINARY_MATH_CASE(kPow, "pow", DoubleTy_)
+        BINARY_MATH_CASE(kFmod, "fmod", DoubleTy_)
+#undef BINARY_MATH_CASE
+
+      default: {
+        LOG(FATAL) << "Unimplemented: Intrinsics: " << ExprHandle(v);
+      } break;
+    }
+  }
+
+  std::vector<llvm::Value*> params;
+  for (auto& p : v->params()) {
+    p->accept(this);
+    params.push_back(value_);
+  }
+
+  if (v->dtype().lanes() == 1) {
+    value_ = irb_.CreateCall(call_ty, call_fn, params);
+  } else {
+    llvm::Type* vecType = llvm::VectorType::get(FloatTy_, v->dtype().lanes());
+    value_ = llvm::UndefValue::get(vecType);
+    for (int i = 0; i < v->dtype().lanes(); ++i) {
+      std::vector<llvm::Value*> call_operands;
+      for (auto p : params) {
+        call_operands.push_back(irb_.CreateExtractElement(p, i));
+      }
+
+      llvm::Value* val = irb_.CreateCall(call_ty, call_fn, call_operands);
+      value_ = irb_.CreateInsertElement(value_, val, i);
+    }
+  }
+}
+
+void LLVMCodeGen::visit(const FunctionCall* v) {
+  LOG(FATAL) << "Unimplemented: FunctionCall";
+}
+
+void LLVMCodeGen::visit(const Allocate* v) {
+  LOG(FATAL) << "Unimplemented: Allocate";
+}
+
+void LLVMCodeGen::visit(const Free* v) {
+  LOG(FATAL) << "Unimplemented: Free";
+}
+
+void LLVMCodeGen::visit(const Cond* v) {
+  LOG(FATAL) << "Unimplemented: Cond";
+}
+
+void LLVMCodeGen::optimize(llvm::Module& M) {
+  llvm::legacy::FunctionPassManager FPM(&M);
+  llvm::legacy::PassManager PM;
+
+  // Add internal analysis passes from the target machine.
+  PM.add(
+      llvm::createTargetTransformInfoWrapperPass(TM_->getTargetIRAnalysis()));
+  FPM.add(
+      llvm::createTargetTransformInfoWrapperPass(TM_->getTargetIRAnalysis()));
+
+  llvm::PassManagerBuilder PMB;
+  PMB.OptLevel = 3;
+  PMB.LoopVectorize = true;
+  PMB.SLPVectorize = true;
+  TM_->adjustPassManager(PMB);
+
+  PMB.populateFunctionPassManager(FPM);
+  PMB.populateModulePassManager(PM);
+  FPM.doInitialization();
+  PM.run(M);
+  for (auto& FF : M) {
+    FPM.run(FF);
+  }
+  FPM.doFinalization();
+  PM.run(M);
+}
+
+RegisterCodeGen<LLVMCodeGen> reg("llvm_codegen");
+
+#endif // ENABLE_LLVM

--- a/torch/csrc/jit/tensorexpr/llvm_codegen.h
+++ b/torch/csrc/jit/tensorexpr/llvm_codegen.h
@@ -1,0 +1,135 @@
+#pragma once
+
+#ifdef ENABLE_LLVM
+#include <torch/csrc/WindowsTorchApiMacro.h>
+
+#include "llvm/ExecutionEngine/Orc/ThreadSafeModule.h"
+#include "torch/csrc/jit/tensorexpr/codegen.h"
+#include "torch/csrc/jit/tensorexpr/ir.h"
+#include "torch/csrc/jit/tensorexpr/ir_visitor.h"
+#include "torch/csrc/jit/tensorexpr/llvm_jit.h"
+
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/LegacyPassManager.h>
+#include <llvm/IR/Verifier.h>
+#include <unordered_map>
+#include <vector>
+
+#define DEBUG_PRINT 0
+
+#if DEBUG_PRINT
+#include <llvm/IR/LegacyPassManager.h>
+#endif
+
+namespace torch {
+namespace jit {
+namespace tensorexpr {
+
+class TORCH_API LLVMCodeGen : public CodeGen, public IRVisitor {
+ private:
+  llvm::orc::ThreadSafeContext context_;
+  llvm::IRBuilder<> irb_;
+  std::unique_ptr<llvm::TargetMachine> TM_;
+  std::unique_ptr<llvm::orc::PytorchLLVMJIT> jit_;
+  std::unique_ptr<llvm::Module> module_;
+  llvm::Function* fn_;
+  llvm::BasicBlock* bb_;
+  llvm::Value* value_;
+  llvm::JITTargetAddress kernelAddress_;
+
+#define LLVM_TYPE_DECLARE(_1, Name) llvm::Type* Name##Ty_;
+  AT_FORALL_SCALAR_TYPES_AND2(Bool, Half, LLVM_TYPE_DECLARE);
+#undef LLVM_TYPE_DECLARE
+
+  std::unordered_map<const Var*, int> varToArg_;
+  std::unordered_map<const Var*, llvm::Value*> varToVal_;
+
+  std::vector<void*> args_;
+
+ private:
+  llvm::LLVMContext& getContext();
+  llvm::Type* dtypeToLLVM(Dtype dtype);
+  llvm::Type* dtypeToLLVMPtr(Dtype dtype);
+  void emitWrapper(const std::vector<llvm::Type*>& params);
+  void emitKernel(Stmt* stmt, const std::vector<llvm::Type*>& params);
+
+ public:
+  explicit LLVMCodeGen(
+      Stmt* stmt,
+      const std::vector<BufferArg>& args,
+      Dtype dtype = kInt);
+  explicit LLVMCodeGen(Stmt* stmt);
+
+  ~LLVMCodeGen() override {}
+
+  TORCH_API void call(const std::vector<CallArg>& args) override;
+
+  void visit(const Add* v) override;
+  void visit(const Sub* v) override;
+  void visit(const Mul* v) override;
+  void visit(const Div* v) override;
+  void visit(const Mod* v) override;
+  void visit(const Max* v) override;
+  void visit(const Min* v) override;
+  void visit(const And* v) override;
+  void visit(const Or* v) override;
+  void visit(const Xor* v) override;
+  void visit(const Lshift* v) override;
+  void visit(const Rshift* v) override;
+  void visit(const CompareSelect* v) override;
+
+#define IMM_VISIT_DECLARE(_1, Name) void visit(const Name##Imm* v) override;
+  AT_FORALL_SCALAR_TYPES_AND2(Bool, Half, IMM_VISIT_DECLARE);
+#undef IMM_VISIT_DECLARE
+
+  void visit(const Cast* v) override;
+  void visit(const Var* v) override;
+  void visit(const Let* v) override;
+  void visit(const LetStmt* v) override;
+  void visit(const Ramp* v) override;
+  void visit(const Load* v) override;
+  void visit(const For* v) override;
+  void visit(const Block* v) override;
+  void visit(const Store* v) override;
+  void visit(const Broadcast* v) override;
+  void visit(const IfThenElse* v) override;
+  void visit(const BaseCallNode* v) override;
+  void visit(const Intrinsics* v) override;
+  void visit(const FunctionCall* v) override;
+  void visit(const Allocate* v) override;
+  void visit(const Free* v) override;
+  void visit(const Cond* v) override;
+
+  llvm::Value* emitUnmaskedLoad(llvm::Value* addr, llvm::Value* idx);
+  llvm::Value* emitMaskedLoad(
+      llvm::Value* addr,
+      llvm::Value* idx,
+      llvm::Value* mask);
+  void emitUnmaskedStore(llvm::Value* base, llvm::Value* idx, llvm::Value* val);
+  void emitMaskedStore(
+      llvm::Value* base,
+      llvm::Value* idx,
+      llvm::Value* mask,
+      llvm::Value* val);
+
+  void optimize(llvm::Module& M);
+
+  template <typename T>
+  T value() {
+    std::vector<void*> args;
+    return value<T>(args);
+  }
+
+  template <typename T>
+  T value(std::vector<void*>& args) {
+    T (*fp)(void**) = (T(*)(void**))kernelAddress_;
+    T rv = fp(args.data());
+    return rv;
+  }
+};
+
+} // namespace tensorexpr
+} // namespace jit
+} // namespace torch
+
+#endif // ENABLE_LLVM

--- a/torch/csrc/jit/tensorexpr/llvm_jit.cpp
+++ b/torch/csrc/jit/tensorexpr/llvm_jit.cpp
@@ -1,0 +1,116 @@
+#ifdef ENABLE_LLVM
+
+#include "torch/csrc/jit/tensorexpr/llvm_jit.h"
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <vector>
+#include "llvm/ExecutionEngine/Orc/LLJIT.h"
+
+namespace llvm {
+namespace orc {
+
+// Lightly modified implementation from LLVM's Kaleidoscope JIT tutorial:
+// https://llvm.org/docs/tutorial/BuildingAJIT1.html
+class TORCH_API PytorchLLVMJITImpl {
+ private:
+  std::unique_ptr<LLJIT> LLJ;
+
+ public:
+  PytorchLLVMJITImpl() : LLJ(cantFail(LLJITBuilder().create())) {
+    auto ProcSymbolsGenerator =
+        cantFail(DynamicLibrarySearchGenerator::GetForCurrentProcess(
+            LLJ->getDataLayout().getGlobalPrefix()));
+    LLJ->getMainJITDylib().setGenerator(std::move(ProcSymbolsGenerator));
+
+    // Handle platform-specific symbol mangling
+    MangleAndInterner Mangle(LLJ->getExecutionSession(), LLJ->getDataLayout());
+
+    // Register implementations of intrinsics
+    cantFail(LLJ->defineAbsolute(
+        *Mangle("log10f"), {llvm::pointerToJITTargetAddress(&log10f), {}}));
+    cantFail(LLJ->defineAbsolute(
+        *Mangle("logf"), {llvm::pointerToJITTargetAddress(&logf), {}}));
+    cantFail(LLJ->defineAbsolute(
+        *Mangle("log2f"), {llvm::pointerToJITTargetAddress(&log2f), {}}));
+    cantFail(LLJ->defineAbsolute(
+        *Mangle("expf"), {llvm::pointerToJITTargetAddress(&expf), {}}));
+    cantFail(LLJ->defineAbsolute(
+        *Mangle("erff"), {llvm::pointerToJITTargetAddress(&erff), {}}));
+    cantFail(LLJ->defineAbsolute(
+        *Mangle("cosf"), {llvm::pointerToJITTargetAddress(&cosf), {}}));
+    cantFail(LLJ->defineAbsolute(
+        *Mangle("sinf"), {llvm::pointerToJITTargetAddress(&sinf), {}}));
+    cantFail(LLJ->defineAbsolute(
+        *Mangle("tanf"), {llvm::pointerToJITTargetAddress(&tanf), {}}));
+    cantFail(LLJ->defineAbsolute(
+        *Mangle("acosf"), {llvm::pointerToJITTargetAddress(&acosf), {}}));
+    cantFail(LLJ->defineAbsolute(
+        *Mangle("asinf"), {llvm::pointerToJITTargetAddress(&asinf), {}}));
+    cantFail(LLJ->defineAbsolute(
+        *Mangle("atanf"), {llvm::pointerToJITTargetAddress(&atanf), {}}));
+    cantFail(LLJ->defineAbsolute(
+        *Mangle("coshf"), {llvm::pointerToJITTargetAddress(&coshf), {}}));
+    cantFail(LLJ->defineAbsolute(
+        *Mangle("sinhf"), {llvm::pointerToJITTargetAddress(&sinhf), {}}));
+    cantFail(LLJ->defineAbsolute(
+        *Mangle("tanhf"), {llvm::pointerToJITTargetAddress(&tanhf), {}}));
+    cantFail(LLJ->defineAbsolute(
+        *Mangle("sqrtf"), {llvm::pointerToJITTargetAddress(&sqrtf), {}}));
+    cantFail(LLJ->defineAbsolute(
+        *Mangle("fabsf"), {llvm::pointerToJITTargetAddress(&fabsf), {}}));
+    cantFail(LLJ->defineAbsolute(
+        *Mangle("floorf"), {llvm::pointerToJITTargetAddress(&floorf), {}}));
+    cantFail(LLJ->defineAbsolute(
+        *Mangle("ceilf"), {llvm::pointerToJITTargetAddress(&ceilf), {}}));
+    cantFail(LLJ->defineAbsolute(
+        *Mangle("roundf"), {llvm::pointerToJITTargetAddress(&roundf), {}}));
+    cantFail(LLJ->defineAbsolute(
+        *Mangle("truncf"), {llvm::pointerToJITTargetAddress(&truncf), {}}));
+    cantFail(LLJ->defineAbsolute(
+        *Mangle("atan2f"), {llvm::pointerToJITTargetAddress(&atan2f), {}}));
+    cantFail(LLJ->defineAbsolute(
+        *Mangle("fmodf"), {llvm::pointerToJITTargetAddress(&fmodf), {}}));
+    cantFail(LLJ->defineAbsolute(
+        *Mangle("remainderf"),
+        {llvm::pointerToJITTargetAddress(&remainderf), {}}));
+  }
+
+  Error addModule(ThreadSafeModule M) {
+    if (auto Err = LLJ->addIRModule(std::move(M))) {
+      return Err;
+    }
+    return Error::success();
+  }
+
+  JITSymbol findSymbol(const std::string Name) {
+    return cantFail(LLJ->lookup(Name));
+  }
+
+  const DataLayout& getDataLayout() {
+    return LLJ->getDataLayout();
+  }
+};
+
+PytorchLLVMJIT::PytorchLLVMJIT()
+    : impl_(std::make_unique<PytorchLLVMJITImpl>()) {}
+
+PytorchLLVMJIT::~PytorchLLVMJIT() = default;
+
+Error PytorchLLVMJIT::addModule(ThreadSafeModule M) {
+  return impl_->addModule(std::move(M));
+}
+
+JITSymbol PytorchLLVMJIT::findSymbol(const std::string Name) {
+  return impl_->findSymbol(std::move(Name));
+}
+
+const DataLayout& PytorchLLVMJIT::getDataLayout() {
+  return impl_->getDataLayout();
+}
+
+} // end namespace orc
+} // end namespace llvm
+
+#endif // ENABLE_LLVM

--- a/torch/csrc/jit/tensorexpr/llvm_jit.h
+++ b/torch/csrc/jit/tensorexpr/llvm_jit.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#ifdef ENABLE_LLVM
+#include <torch/csrc/WindowsTorchApiMacro.h>
+
+#include "llvm/ExecutionEngine/JITSymbol.h"
+#include "llvm/ExecutionEngine/Orc/Core.h"
+#include "llvm/ExecutionEngine/Orc/ThreadSafeModule.h"
+#include "llvm/Target/TargetMachine.h"
+
+#include <memory>
+#include <string>
+
+namespace llvm {
+namespace orc {
+
+class PytorchLLVMJITImpl;
+
+class TORCH_API PytorchLLVMJIT {
+ public:
+  PytorchLLVMJIT();
+  ~PytorchLLVMJIT();
+
+  Error addModule(ThreadSafeModule M);
+
+  JITSymbol findSymbol(const std::string Name);
+
+  TargetMachine& getTargetMachine();
+  const DataLayout& getDataLayout();
+
+ private:
+  // Use PImpl idiom here to hide the no-rtti parts of the JIT structure.
+  std::unique_ptr<PytorchLLVMJITImpl> impl_;
+};
+
+} // end namespace orc
+} // end namespace llvm
+
+#endif // ENABLE LLVM


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #34201 [Do not commit] Add HowToRebaseOnMaster.md doc.
* #34200 [WIP] Changes in test/test_jit_fuser.py test/test_jit_fuser_te.py.
* #34199 [WIP] Changes to peephole.cpp.
* #34198 [WIP] Guard elimination changes from bertmaher/pytorch_fusion.
* #34197 Add tensorexpr benchmarks.
* #34196 Add jit_get_te_* python bindings.
* **#34195 Add LLVM codegen for tensor expressions.**
* #34194 Add CUDA codegen for tensorexpressions.
* #34193 Tensorexpr fuser implementation.
* #34192 Move tensor expressions work from bertmaher/pytorch to pytorch/pytorch.

Differential Revision: [D20244099](https://our.internmc.facebook.com/intern/diff/D20244099)