### PR TITLE
Add jit_get_te_* python bindings.

### DIFF
--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -58,6 +58,7 @@
 #include <torch/csrc/jit/python/python_tree_views.h>
 #include <torch/csrc/jit/frontend/tracer.h>
 #include <torch/csrc/jit/tensorexpr/execution_counter.h>
+#include <torch/csrc/jit/tensorexpr/kernel.h>
 
 #include <c10/macros/Export.h>
 #include <caffe2/serialize/inline_container.h>
@@ -400,6 +401,42 @@ void initJITBindings(PyObject* module) {
             ExecutionTrigger* trigger =
                 ExecutionTriggerList::GetInstance().FindByName(trigger_name);
             return trigger->value();
+          })
+      .def(
+          "_jit_get_te_cuda_pointwise_loop_levels",
+          []() -> int {
+            using namespace torch::jit::tensorexpr;
+            return GetTECudaPointwiseLoopLevels();
+          })
+      .def(
+          "_jit_set_te_cuda_pointwise_loop_levels",
+          [](int level) {
+            using namespace torch::jit::tensorexpr;
+            return GetTECudaPointwiseLoopLevels() = level;
+          })
+      .def(
+          "_jit_get_te_cuda_pointwise_block_count",
+          []() -> int {
+            using namespace torch::jit::tensorexpr;
+            return GetTECudaPointwiseBlockCount();
+          })
+      .def(
+          "_jit_set_te_cuda_pointwise_block_count",
+          [](int block_count) {
+            using namespace torch::jit::tensorexpr;
+            return GetTECudaPointwiseBlockCount() = block_count;
+          })
+      .def(
+          "_jit_get_te_cuda_pointwise_block_size",
+          []() -> int {
+            using namespace torch::jit::tensorexpr;
+            return GetTECudaPointwiseBlockSize();
+          })
+      .def(
+          "_jit_set_te_cuda_pointwise_block_size",
+          [](int block_size) {
+            using namespace torch::jit::tensorexpr;
+            return GetTECudaPointwiseBlockSize() = block_size;
           })
       .def("_jit_set_texpr_fuser_enabled", &setTensorExprFuserEnabled)
       .def(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #34201 [Do not commit] Add HowToRebaseOnMaster.md doc.
* #34200 [WIP] Changes in test/test_jit_fuser.py test/test_jit_fuser_te.py.
* #34199 [WIP] Changes to peephole.cpp.
* #34198 [WIP] Guard elimination changes from bertmaher/pytorch_fusion.
* #34197 Add tensorexpr benchmarks.
* **#34196 Add jit_get_te_* python bindings.**
* #34195 Add LLVM codegen for tensor expressions.
* #34194 Add CUDA codegen for tensorexpressions.
* #34193 Tensorexpr fuser implementation.
* #34192 Move tensor expressions work from bertmaher/pytorch to pytorch/pytorch.

Differential Revision: [D20244101](https://our.internmc.facebook.com/intern/diff/D20244101)