### PR TITLE
[WIP] Guard elimination changes from bertmaher/pytorch_fusion.

### DIFF
--- a/torch/csrc/jit/passes/guard_elimination.cpp
+++ b/torch/csrc/jit/passes/guard_elimination.cpp
@@ -12,8 +12,7 @@ namespace jit {
 
 struct GuardElimination {
   GuardElimination(std::shared_ptr<Graph> graph)
-      : graph_(std::move(graph)),
-        aliasDb_(std::make_unique<AliasDb>(graph_)) {}
+      : graph_(std::move(graph)), aliasDb_(std::make_unique<AliasDb>(graph_)) {}
 
   void run() {
     const size_t MAX_ATTEMPTS = 5;
@@ -123,8 +122,11 @@ struct GuardElimination {
     auto it = guard;
     while (it != output) {
       if (it->kind() != prim::Guard && it->kind() != prim::Constant) {
-        GRAPH_DEBUG("found an unexpected node ", *it,
-                    " while trying to eliminate ", *guard);
+        GRAPH_DEBUG(
+            "found an unexpected node ",
+            *it,
+            " while trying to eliminate ",
+            *guard);
         return false;
       }
       it = it->prev();
@@ -161,7 +163,7 @@ struct GuardElimination {
   // on inputs to `n`. The invariants must hold, or an input must
   // be a `prim::Constant` or be of `NumberType` or be included
   // as an exception in `except`
-  bool checkInputs(Node *n, const std::unordered_set<size_t> &except) {
+  bool checkInputs(Node* n, const std::unordered_set<size_t>& except) {
     bool all_inputs_guarded = true;
     size_t i = 0;
     for (auto input : n->inputs()) {
@@ -174,8 +176,11 @@ struct GuardElimination {
             input->node()->kind() != prim::Guard ||
             input->type()->expect<TensorType>());
       } else {
-        GRAPH_DEBUG("input ", input->debugName(), " isn't guarded, type ",
-                    *input->type());
+        GRAPH_DEBUG(
+            "input ",
+            input->debugName(),
+            " isn't guarded, type ",
+            *input->type());
         all_inputs_guarded = false;
         break;
       }
@@ -184,7 +189,7 @@ struct GuardElimination {
     return all_inputs_guarded;
   }
 
-private:
+ private:
   // `removableGuard` relies on the properties checked by `isSummarized()`
   // and passes shouldn't insert nodes between a guard and its uses that
   // may alter those properties.
@@ -211,139 +216,146 @@ private:
   //   Guards can be removed if all inputs are guarded and `isSummarized()`
   //   returns
   //   false or inputs are `prim::Constant`
-  bool removableGuard(Node *n) {
-
+  bool removableGuard(Node* n) {
     const static auto no_exceptions = std::unordered_set<size_t>{};
     switch (n->kind()) {
-    case aten::add:
-    case aten::sub:
-    case aten::mul:
-    case aten::div:
-    case aten::t:
-    case aten::sigmoid:
-    case aten::sin:
-    case aten::cos:
-    case aten::tan:
-    case aten::sinh:
-    case aten::cosh:
-    case aten::tanh:
-    case aten::asin:
-    case aten::acos:
-    case aten::atan:
-    case aten::atan2:
-    case aten::floor:
-    case aten::fmod:
-    case aten::ceil:
-    case aten::trunc:
-    case aten::sqrt:
-    case aten::rsqrt:
-    case aten::remainder:
-    case aten::mm:
-    case aten::min:
-    case aten::max:
-    case aten::type_as:
-    case aten::ge:
-    case aten::gt:
-    case aten::lt:
-    case aten::le:
-    case aten::eq:
-    case aten::ne:
-    case aten::neg:
-    case prim::ConstantChunk:
-    case aten::size:
-    case aten::abs:
-    case aten::sign:
-    case aten::pow:
-    case aten::relu:
-    case aten::threshold:
-    case aten::avg_pool2d:
-    case prim::AutogradAdd:
-    case prim::AutogradZero:
-    case aten::rand_like:
-    case aten::erf:
-    case aten::erfc:
-    case aten::exp:
-    case aten::expm1:
-    case aten::log:
-    case aten::log2:
-    case aten::log10:
-    case aten::frac:
-    case aten::lerp:
-    case aten::lgamma:
-    case aten::reciprocal:
-    case aten::addcmul:
-    case aten::where:
-     return checkInputs(n, no_exceptions);
-    case aten::slice:
-      return !n->input(0)->type()->expect<TensorType>()->isSummarized() &&
-             // check that the dimension argument is constant
-             n->input(1)->node()->kind() == prim::Constant &&
-             // the start offset is constant
-             n->input(2)->node()->kind() == prim::Constant &&
-             // the end offset is constant
-             n->input(3)->node()->kind() == prim::Constant &&
-             // the stride is constant
-             n->input(4)->node()->kind() == prim::Constant;
-    case aten::unsqueeze:
-     // check that the dimension argument is constant
-     return !n->input(0)->type()->expect<TensorType>()->isSummarized() &&
+      case aten::add:
+      case aten::sub:
+      case aten::mul:
+      case aten::div:
+      case aten::t:
+      case aten::sigmoid:
+      case aten::sin:
+      case aten::cos:
+      case aten::tan:
+      case aten::sinh:
+      case aten::cosh:
+      case aten::tanh:
+      case aten::asin:
+      case aten::acos:
+      case aten::atan:
+      case aten::atan2:
+      case aten::floor:
+      case aten::fmod:
+      case aten::ceil:
+      case aten::trunc:
+      case aten::sqrt:
+      case aten::rsqrt:
+      case aten::remainder:
+      case aten::mm:
+      case aten::min:
+      case aten::max:
+      case aten::type_as:
+      case aten::ge:
+      case aten::gt:
+      case aten::lt:
+      case aten::le:
+      case aten::eq:
+      case aten::ne:
+      case aten::neg:
+      case prim::ConstantChunk:
+      case aten::size:
+      case aten::abs:
+      case aten::sign:
+      case aten::pow:
+      case aten::relu:
+      case aten::threshold:
+      case aten::avg_pool2d:
+      case prim::AutogradAdd:
+      case prim::AutogradZero:
+      case aten::rand_like:
+      case aten::erf:
+      case aten::erfc:
+      case aten::exp:
+      case aten::expm1:
+      case aten::log:
+      case aten::log2:
+      case aten::log10:
+      case aten::frac:
+      case aten::lerp:
+      case aten::lgamma:
+      case aten::reciprocal:
+      case aten::addcmul:
+      case aten::_cast_Float:
+      case aten::_sigmoid_backward:
+      case aten::_tanh_backward:
+      case aten::__and__:
+      case aten::__or__:
+      case aten::__xor__:
+      case aten::__lshift__:
+      case aten::__rshift__:
+      case aten::where:
+        return checkInputs(n, no_exceptions);
+      case aten::slice:
+        return !n->input(0)->type()->expect<TensorType>()->isSummarized() &&
+            // check that the dimension argument is constant
+            n->input(1)->node()->kind() == prim::Constant &&
+            // the start offset is constant
+            n->input(2)->node()->kind() == prim::Constant &&
+            // the end offset is constant
+            n->input(3)->node()->kind() == prim::Constant &&
+            // the stride is constant
+            n->input(4)->node()->kind() == prim::Constant;
+      case aten::unsqueeze:
+        // check that the dimension argument is constant
+        return !n->input(0)->type()->expect<TensorType>()->isSummarized() &&
             n->input(1)->node()->kind() == prim::Constant;
-    case aten::cat:
-      // check that the dimension argument is constant
-      return n->input(1)->node()->kind() == prim::Constant &&
-             n->input(0)->node()->kind() == prim::ListConstruct &&
-             // no extra nodes in between aten::cat and prim::ListConstruct
-             n->prev() == n->input(0)->node() &&
-             // check the inputs to prim::ListConstruct (not aten::cat)
-             checkInputs(n->input(0)->node(), no_exceptions);
-    case aten::clamp:
-      // the second and third args do not affect shapes
-      return checkInputs(n, std::unordered_set<size_t>{1, 2});
-    // after some optimizations we might end up with two Guards back-to-back
-    // which case we can remove the one whose input is also prim::Guard
-    case aten::_grad_sum_to_size:
-      // skip checking size argument
-      if (checkInputs(n, std::unordered_set<size_t>{1})) {
-        auto asize = n->input(1)->node();
-        if (asize->kind() == prim::Constant) {
-          return true;
-        } else if (asize->matches("aten::size(Tensor self) -> int[]")) {
-          // aten::size is effectively a constant
-          if (asize->input()
-                  ->type()
-                  ->expect<TensorType>()
-                  ->sizes()
-                  .concrete_sizes()) {
+      case aten::cat:
+        // check that the dimension argument is constant
+        return n->input(1)->node()->kind() == prim::Constant &&
+            n->input(0)->node()->kind() == prim::ListConstruct &&
+            // no extra nodes in between aten::cat and prim::ListConstruct
+            n->prev() == n->input(0)->node() &&
+            // check the inputs to prim::ListConstruct (not aten::cat)
+            checkInputs(n->input(0)->node(), no_exceptions);
+      case aten::clamp:
+        // the second and third args do not affect shapes
+        return checkInputs(n, std::unordered_set<size_t>{1, 2});
+      // after some optimizations we might end up with two Guards back-to-back
+      // which case we can remove the one whose input is also prim::Guard
+      case aten::_grad_sum_to_size:
+        // skip checking size argument
+        if (checkInputs(n, std::unordered_set<size_t>{1})) {
+          auto asize = n->input(1)->node();
+          if (asize->kind() == prim::Constant) {
             return true;
+          } else if (asize->matches("aten::size(Tensor self) -> int[]")) {
+            // aten::size is effectively a constant
+            if (asize->input()
+                    ->type()
+                    ->expect<TensorType>()
+                    ->sizes()
+                    .concrete_sizes()) {
+              return true;
+            }
           }
         }
-      }
-      return false;
+        return false;
 
-    // this is checked by one of the tests in test_jit_fuser.py
-    case prim::ListUnpack: {
-      // check if the input is a constant chunk
-      // used for LSTM fusions
-      auto chunk = n->input(0)->node();
-      if (chunk->kind() != aten::chunk) {
-        return false;
+      // this is checked by one of the tests in test_jit_fuser.py
+      case prim::ListUnpack: {
+        // check if the input is a constant chunk
+        // used for LSTM fusions
+        auto chunk = n->input(0)->node();
+        if (chunk->kind() != aten::chunk) {
+          return false;
+        }
+        return checkInputs(chunk, no_exceptions);
       }
-      return checkInputs(chunk, no_exceptions);
-    }
-    // this is checked by one of the tests in test_jit_fuser.py
-    case aten::broadcast_tensors: {
-      auto list_construct = n->input(0)->node();
-      if (list_construct->kind() != prim::ListConstruct) {
-        return false;
+      // this is checked by one of the tests in test_jit_fuser.py
+      case aten::broadcast_tensors: {
+        auto list_construct = n->input(0)->node();
+        if (list_construct->kind() != prim::ListConstruct) {
+          return false;
+        }
+        return checkInputs(list_construct, no_exceptions);
       }
-      return checkInputs(list_construct, no_exceptions);
-    }
-    case prim::Guard:
-    case prim::GradOf:
-      return true;
-    default:
-      GRAPH_DEBUG("cannot remove ", n->kind().toQualString());
-      return false;
+      case prim::Guard:
+      case prim::GradOf:
+        return true;
+      default:
+        GRAPH_DEBUG("cannot remove ", n->kind().toQualString());
+        return false;
     }
   }
 
@@ -351,7 +363,6 @@ private:
   std::unique_ptr<AliasDb> aliasDb_;
   static std::unordered_set<Symbol> simple_ops_;
 };
-
 
 void EliminateRedundantGuards(std::shared_ptr<Graph> graph) {
   GuardElimination ge(std::move(graph));


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #34201 [Do not commit] Add HowToRebaseOnMaster.md doc.
* #34200 [WIP] Changes in test/test_jit_fuser.py test/test_jit_fuser_te.py.
* #34199 [WIP] Changes to peephole.cpp.
* **#34198 [WIP] Guard elimination changes from bertmaher/pytorch_fusion.**
* #34197 Add tensorexpr benchmarks.
* #34196 Add jit_get_te_* python bindings.
* #34195 Add LLVM codegen for tensor expressions.
* #34194 Add CUDA codegen for tensorexpressions.
* #34193 Tensorexpr fuser implementation.
* #34192 Move tensor expressions work from bertmaher/pytorch to pytorch/pytorch.

Differential Revision: [D20244104](https://our.internmc.facebook.com/intern/diff/D20244104)