### PR TITLE
[WIP] Changes in test/test_jit_fuser.py test/test_jit_fuser_te.py.

### DIFF
--- a/test/test_jit_fuser_te.py
+++ b/test/test_jit_fuser_te.py
@@ -1,0 +1,9 @@
+import torch
+from test_jit_fuser import *
+
+
+if __name__ == "__main__":
+    torch._C._jit_override_can_fuse_on_gpu(False)
+    torch._C._jit_override_can_fuse_on_cpu(False)
+    torch._C._jit_set_texpr_fuser_enabled(True)
+    run_tests()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #34201 [Do not commit] Add HowToRebaseOnMaster.md doc.
* **#34200 [WIP] Changes in test/test_jit_fuser.py test/test_jit_fuser_te.py.**
* #34199 [WIP] Changes to peephole.cpp.
* #34198 [WIP] Guard elimination changes from bertmaher/pytorch_fusion.
* #34197 Add tensorexpr benchmarks.
* #34196 Add jit_get_te_* python bindings.
* #34195 Add LLVM codegen for tensor expressions.
* #34194 Add CUDA codegen for tensorexpressions.
* #34193 Tensorexpr fuser implementation.
* #34192 Move tensor expressions work from bertmaher/pytorch to pytorch/pytorch.

Differential Revision: [D20244102](https://our.internmc.facebook.com/intern/diff/D20244102)