### PR TITLE
C++ make torch::nn::Sequential push_back(AnyModule) methods public

### DIFF
--- a/test/cpp/api/sequential.cpp
+++ b/test/cpp/api/sequential.cpp
@@ -155,6 +155,18 @@ TEST_F(SequentialTest, PushBackAddsAnElement) {
   sequential_named->push_back(std::string("m2"), M(1));
   ASSERT_EQ(sequential_named->size(), 6);
   ASSERT_EQ(sequential_named->named_children()[5].key(), "m2");
+
+  // named and unnamed AnyModule's
+  Sequential sequential_any;
+  auto a=torch::nn::AnyModule(torch::nn::Linear(1,2));
+  ASSERT_EQ(sequential_any->size(), 0);
+  ASSERT_TRUE(sequential_any->is_empty());
+  sequential_any->push_back(a);
+  ASSERT_EQ(sequential_any->size(), 1);
+  ASSERT_EQ(sequential_any->named_children()[0].key(), "0");
+  sequential_any->push_back("fc", a);
+  ASSERT_EQ(sequential_any->size(), 2);
+  ASSERT_EQ(sequential_any->named_children()[1].key(), "fc");
 }
 
 TEST_F(SequentialTest, AccessWithAt) {

--- a/torch/csrc/api/include/torch/nn/modules/container/sequential.h
+++ b/torch/csrc/api/include/torch/nn/modules/container/sequential.h
@@ -243,6 +243,17 @@ class SequentialImpl : public Cloneable<SequentialImpl> {
     }
   }
 
+  /// Adds a type-erased `AnyModule` to the `Sequential`.
+  void push_back(AnyModule any_module) {
+    push_back(c10::to_string(modules_.size()), std::move(any_module));
+  }
+
+  void push_back(std::string name, AnyModule any_module) {
+    modules_.push_back(std::move(any_module));
+    const auto index = modules_.size() - 1;
+    register_module(std::move(name), modules_[index].ptr());
+  }
+
   /// Returns an iterator to the start of the `Sequential`.
   Iterator begin() {
     return modules_.begin();
@@ -339,17 +350,6 @@ class SequentialImpl : public Cloneable<SequentialImpl> {
     // Recursively calls this method, until the parameter pack only thas this
     // entry left. Then calls `push_back()` a final time (above).
     push_back(std::forward<Second>(second), std::forward<Rest>(rest)...);
-  }
-
-  /// Adds a type-erased `AnyModule` to the `Sequential`.
-  void push_back(AnyModule any_module) {
-    push_back(c10::to_string(modules_.size()), std::move(any_module));
-  }
-
-  void push_back(std::string name, AnyModule any_module) {
-    modules_.push_back(std::move(any_module));
-    const auto index = modules_.size() - 1;
-    register_module(std::move(name), modules_[index].ptr());
   }
 
   /// The base case, when the list of modules is empty.


### PR DESCRIPTION
Issue #33192
Moves Sequential::push_back methods with AnyModule from private -> public
Allows adding an existing AnyModule via something like:

```
  torch::nn::Sequential q;
  auto a=torch::nn::AnyModule(torch::nn::Linear(1,2));
  q->push_back(a);
  q->push_back("fc",a);
```
