### PR TITLE
Clean up some legacy scalar/empty handling.

### DIFF
--- a/aten/src/TH/generic/THTensorLapack.cpp
+++ b/aten/src/TH/generic/THTensorLapack.cpp
@@ -296,7 +296,8 @@ void THTensor_(potri)(THTensor *ra_, THTensor *a, bool upper)
 {
   char uplo = upper ? 'U' : 'L';
   if (a == NULL) a = ra_;
-  THArgCheck(THTensor_nDimensionLegacyAll(a) == 2, 1, "A should be 2 dimensional");
+  THArgCheck(THTensor_nDimension(a) == 2, 1, "A should be 2 dimensional");
+  THArgCheck(!a->empty(), 1, "A should not be empty")
   THArgCheck(a->size(0) == a->size(1), 1, "A should be square");
 
   int n, lda, info;
@@ -304,7 +305,7 @@ void THTensor_(potri)(THTensor *ra_, THTensor *a, bool upper)
 
   ra__ = THTensor_(cloneColumnMajor)(ra_, a);
 
-  n = THTensor_sizeLegacyNoScalars(ra__, 0);
+  n = THTensor_size(ra__, 0);
   lda = n;
 
   /* Run inverse */
@@ -394,12 +395,13 @@ void THTensor_(geqrf)(THTensor *ra_, THTensor *rtau_, THTensor *a)
 void THTensor_(orgqr)(THTensor *ra_, THTensor *a, THTensor *tau)
 {
   if (a == NULL) a = ra_;
-  THArgCheck(THTensor_nDimensionLegacyAll(a) == 2, 1, "A should be 2 dimensional");
+  THArgCheck(THTensor_nDimension(a) == 2, 1, "A should be 2 dimensional");
+  THArgCheck(!a->empty() == 2, 1, "A should not be empty");
 
   THTensor *ra__ = NULL;
   ra__ = THTensor_(cloneColumnMajor)(ra_, a);
 
-  int m = THTensor_sizeLegacyNoScalars(ra__, 0);
+  int m = THTensor_size(ra__, 0);
   int k = THTensor_sizeLegacyNoScalars(tau, 0);
   int lda = m;
 

--- a/aten/src/TH/generic/THTensorLapack.cpp
+++ b/aten/src/TH/generic/THTensorLapack.cpp
@@ -297,7 +297,7 @@ void THTensor_(potri)(THTensor *ra_, THTensor *a, bool upper)
   char uplo = upper ? 'U' : 'L';
   if (a == NULL) a = ra_;
   THArgCheck(THTensor_nDimension(a) == 2, 1, "A should be 2 dimensional");
-  THArgCheck(!a->empty(), 1, "A should not be empty")
+  THArgCheck(!a->is_empty(), 1, "A should not be empty")
   THArgCheck(a->size(0) == a->size(1), 1, "A should be square");
 
   int n, lda, info;
@@ -396,7 +396,7 @@ void THTensor_(orgqr)(THTensor *ra_, THTensor *a, THTensor *tau)
 {
   if (a == NULL) a = ra_;
   THArgCheck(THTensor_nDimension(a) == 2, 1, "A should be 2 dimensional");
-  THArgCheck(!a->empty() == 2, 1, "A should not be empty");
+  THArgCheck(!a->is_empty() == 2, 1, "A should not be empty");
 
   THTensor *ra__ = NULL;
   ra__ = THTensor_(cloneColumnMajor)(ra_, a);

--- a/aten/src/TH/generic/THTensorLapack.cpp
+++ b/aten/src/TH/generic/THTensorLapack.cpp
@@ -396,7 +396,7 @@ void THTensor_(orgqr)(THTensor *ra_, THTensor *a, THTensor *tau)
 {
   if (a == NULL) a = ra_;
   THArgCheck(THTensor_nDimension(a) == 2, 1, "A should be 2 dimensional");
-  THArgCheck(!a->is_empty() == 2, 1, "A should not be empty");
+  THArgCheck(!a->is_empty(), 1, "A should not be empty");
 
   THTensor *ra__ = NULL;
   ra__ = THTensor_(cloneColumnMajor)(ra_, a);

--- a/aten/src/TH/generic/THTensorLapack.cpp
+++ b/aten/src/TH/generic/THTensorLapack.cpp
@@ -305,7 +305,7 @@ void THTensor_(potri)(THTensor *ra_, THTensor *a, bool upper)
 
   ra__ = THTensor_(cloneColumnMajor)(ra_, a);
 
-  n = THTensor_size(ra__, 0);
+  n = THTensor_(size)(ra__, 0);
   lda = n;
 
   /* Run inverse */
@@ -401,7 +401,7 @@ void THTensor_(orgqr)(THTensor *ra_, THTensor *a, THTensor *tau)
   THTensor *ra__ = NULL;
   ra__ = THTensor_(cloneColumnMajor)(ra_, a);
 
-  int m = THTensor_size(ra__, 0);
+  int m = THTensor_(size)(ra__, 0);
   int k = THTensor_sizeLegacyNoScalars(tau, 0);
   int lda = m;
 

--- a/aten/src/TH/generic/THTensorLapack.cpp
+++ b/aten/src/TH/generic/THTensorLapack.cpp
@@ -297,7 +297,7 @@ void THTensor_(potri)(THTensor *ra_, THTensor *a, bool upper)
   char uplo = upper ? 'U' : 'L';
   if (a == NULL) a = ra_;
   THArgCheck(THTensor_nDimension(a) == 2, 1, "A should be 2 dimensional");
-  THArgCheck(!a->is_empty(), 1, "A should not be empty")
+  THArgCheck(!a->is_empty(), 1, "A should not be empty");
   THArgCheck(a->size(0) == a->size(1), 1, "A should be square");
 
   int n, lda, info;

--- a/aten/src/TH/generic/THTensorMath.cpp
+++ b/aten/src/TH/generic/THTensorMath.cpp
@@ -271,10 +271,10 @@ void THTensor_(addr)(THTensor *r_, THTensor *t, THTensor *vec1, THTensor *vec2, 
   if(t->dim() != 2)
     THError("expected matrix, got %dD tensor for t", t->dim());
 
-  auto vec1_size = THTensor_sizeLegacyNoScalars(vec1, 0);
-  auto vec2_size = THTensor_sizeLegacyNoScalars(vec2, 0);
-  auto vec1_stride = THTensor_strideLegacyNoScalars(vec1, 0);
-  auto vec2_stride = THTensor_strideLegacyNoScalars(vec2, 0);
+  auto vec1_size = THTensor_size(vec1, 0);
+  auto vec2_size = THTensor_size(vec2, 0);
+  auto vec1_stride = THTensor_stride(vec1, 0);
+  auto vec2_stride = THTensor_stride(vec2, 0);
 
   if( (t->size(0) != vec1_size) || (t->size(1) != vec2_size) ) {
     THDescBuff bt  = THTensor_(sizeDesc)(t);

--- a/aten/src/TH/generic/THTensorMath.cpp
+++ b/aten/src/TH/generic/THTensorMath.cpp
@@ -271,10 +271,10 @@ void THTensor_(addr)(THTensor *r_, THTensor *t, THTensor *vec1, THTensor *vec2, 
   if(t->dim() != 2)
     THError("expected matrix, got %dD tensor for t", t->dim());
 
-  auto vec1_size = THTensor_size(vec1, 0);
-  auto vec2_size = THTensor_size(vec2, 0);
-  auto vec1_stride = THTensor_stride(vec1, 0);
-  auto vec2_stride = THTensor_stride(vec2, 0);
+  auto vec1_size = THTensor_(size)(vec1, 0);
+  auto vec2_size = THTensor_(size)(vec2, 0);
+  auto vec1_stride = THTensor_(stride)(vec1, 0);
+  auto vec2_stride = THTensor_(stride)(vec2, 0);
 
   if( (t->size(0) != vec1_size) || (t->size(1) != vec2_size) ) {
     THDescBuff bt  = THTensor_(sizeDesc)(t);

--- a/aten/src/THCUNN/generic/ClassNLLCriterion.cu
+++ b/aten/src/THCUNN/generic/ClassNLLCriterion.cu
@@ -11,7 +11,7 @@ void THNN_(ClassNLLCriterion_updateOutput)(
            THCTensor *weights,
            THCTensor *total_weight,
            int64_t ignore_index) {
-  if (THCIndexTensor_(nDimensionLegacyNoScalars)(state, target) > 1) {
+  if (THCIndexTensor_(nDimension)(state, target) > 1) {
     THError("multi-target not supported");
   }
 

--- a/aten/src/THCUNN/generic/SpatialConvolutionMM.cu
+++ b/aten/src/THCUNN/generic/SpatialConvolutionMM.cu
@@ -82,7 +82,7 @@ static inline void THNN_(SpatialConvolutionMM_shapeCheck)(
       int64_t nOutputPlane = weight->size(0);
       THCUNN_check_dim_size(state, gradOutput, ndim, dimf, nOutputPlane);
     } else if (bias != NULL) {
-      int64_t nOutputPlane = THTensor_sizeLegacyNoScalars(bias, 0);
+      int64_t nOutputPlane = bias->dim() == 0 ? 1 : bias->size(0);
       THCUNN_check_dim_size(state, gradOutput, ndim, dimf, nOutputPlane);
     }
     THCUNN_check_dim_size(state, gradOutput, ndim, dimh, outputHeight);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#34217 Clean up some legacy scalar/empty handling.**

LegacyNoScalar variants cause 0-dim tensors to behave like 1-dim tensors.
LegacyAll variants cause 0-dim tensors to behave like 1-dim tensors, and numel == 0 tensors to be treated like 0-dimensional tensors.

This this was done by codemod, these are often unneeded and often translated incorrectly to ATen.

Differential Revision: [D20249577](https://our.internmc.facebook.com/intern/diff/D20249577)