### PR TITLE
Remove execution_counter include from eval.h.

### DIFF
--- a/torch/csrc/jit/tensorexpr/eval.h
+++ b/torch/csrc/jit/tensorexpr/eval.h
@@ -7,7 +7,6 @@
 #include <c10/util/Logging.h>
 #include "torch/csrc/jit/tensorexpr/buffer.h"
 #include "torch/csrc/jit/tensorexpr/codegen.h"
-#include "torch/csrc/jit/tensorexpr/execution_counter.h"
 #include "torch/csrc/jit/tensorexpr/function.h"
 #include "torch/csrc/jit/tensorexpr/ir.h"
 #include "torch/csrc/jit/tensorexpr/ir_printer.h"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #34235 [Do not commit] Add HowToRebaseOnMaster.md doc.
* #34234 [WIP] Changes in test/test_jit_fuser.py test/test_jit_fuser_te.py.
* #34233 [WIP] Changes to peephole.cpp.
* #34231 [WIP] Guard elimination changes from bertmaher/pytorch_fusion.
* #34230 Add tensorexpr benchmarks.
* #34229 Add jit_get_te_* python bindings.
* #34228 Add LLVM codegen for tensor expressions.
* #34227 Add CUDA codegen for tensorexpressions.
* #34226 Tensorexpr fuser implementation.
* **#34225 Remove execution_counter include from eval.h.**
* #34224 Move tensor expressions work from bertmaher/pytorch to pytorch/pytorch.

Differential Revision: [D20251833](https://our.internmc.facebook.com/intern/diff/D20251833)