### PR TITLE
Adds true_divide function, analogous to Python 's, JAX's,  NumPy's (true) division

### DIFF
--- a/aten/src/ATen/native/BinaryOps.cpp
+++ b/aten/src/ATen/native/BinaryOps.cpp
@@ -92,18 +92,22 @@ Tensor& true_divide_out(Tensor& result, const Tensor& self, const Tensor& diviso
 }
 
 Tensor true_divide(const Tensor& self, const Tensor& divisor) {
+  // If both inputs have integral (or bool) types, sets the output to have
+  // the default (floating) scalar type
   if (isIntegralType(self.scalar_type(), /*includeBool=*/ true)
    && isIntegralType(divisor.scalar_type(), /*includeBool=*/ true)) {
     const auto scalar_type = typeMetaToScalarType(c10::get_default_dtype());
     Tensor result = at::empty({0}, self.options().dtype(scalar_type));
 
-    auto iter = TensorIterator::binary_op(result, self, divisor, /*check_mem_overlap=*/ true);
+    auto iter = TensorIterator::binary_op(result, self, divisor);
     div_stub(iter.device_type(), iter);
     return result;
   }
 
+  // If at least one input is non-integral (or bool) participates in
+  // type promotion like other binary ufuncs
   Tensor result;
-  auto iter = TensorIterator::binary_op(result, self, divisor, /*check_mem_overlap=*/ true);
+  auto iter = TensorIterator::binary_op(result, self, divisor);
   div_stub(iter.device_type(), iter);
   return iter.output();
 }

--- a/aten/src/ATen/native/BinaryOps.cpp
+++ b/aten/src/ATen/native/BinaryOps.cpp
@@ -82,6 +82,32 @@ Tensor truncate(const Tensor& tensor) {
   return tensor;
 }
 
+Tensor& true_divide_out(Tensor& result, const Tensor& self, const Tensor& divisor) {
+  TORCH_CHECK(!isIntegralType(result.scalar_type(), /*includeBool=*/ true),
+            "True division requires a floating output type, but got ",
+            result.scalar_type());
+  auto iter = TensorIterator::binary_op(result, self, divisor, /*check_mem_overlap=*/ true);
+  div_stub(iter.device_type(), iter);
+  return result;
+}
+
+Tensor true_divide(const Tensor& self, const Tensor& divisor) {
+  if (isIntegralType(self.scalar_type(), /*includeBool=*/ true)
+   && isIntegralType(divisor.scalar_type(), /*includeBool=*/ true)) {
+    const auto scalar_type = typeMetaToScalarType(c10::get_default_dtype());
+    Tensor result = at::empty({0}, self.options().dtype(scalar_type));
+
+    auto iter = TensorIterator::binary_op(result, self, divisor, /*check_mem_overlap=*/ true);
+    div_stub(iter.device_type(), iter);
+    return result;
+  }
+
+  Tensor result;
+  auto iter = TensorIterator::binary_op(result, self, divisor, /*check_mem_overlap=*/ true);
+  div_stub(iter.device_type(), iter);
+  return iter.output();
+}
+
 Tensor floor_divide(const Tensor& input, const Tensor& other) {
   Tensor out = input / other;
   return truncate(out);
@@ -390,7 +416,7 @@ Tensor __lshift__(const Tensor& self, const Tensor& other) {
   return iter.output();
 }
 
-Tensor __lshift__(const Tensor& self, Scalar other) { 
+Tensor __lshift__(const Tensor& self, Scalar other) {
   Tensor result;
   auto wrapper = wrapped_scalar_tensor(other).toType(self.scalar_type());
   auto iter = TensorIterator::binary_op(result, self, wrapper);
@@ -418,7 +444,7 @@ Tensor __rshift__(const Tensor& self, const Tensor& other) {
   return iter.output();
 }
 
-Tensor __rshift__(const Tensor& self, Scalar other) { 
+Tensor __rshift__(const Tensor& self, Scalar other) {
   Tensor result;
   auto wrapper = wrapped_scalar_tensor(other).toType(self.scalar_type());
   auto iter = TensorIterator::binary_op(result, self, wrapper);
@@ -620,6 +646,10 @@ Tensor& fmod_(Tensor& self, const Tensor& other) {
 
 Tensor& fmod_(Tensor& self, Scalar other) {
   return at::fmod_out(self, self, other);
+}
+
+Tensor true_divide(const Tensor& self, Scalar divisor) {
+  return at::true_divide(self, wrapped_scalar_tensor(divisor)); // redispatch!
 }
 
 }

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2842,6 +2842,29 @@
 - func: triplet_margin_loss(Tensor anchor, Tensor positive, Tensor negative, float margin=1.0, float p=2, float eps=1e-06, bool swap=False, int reduction=Mean) -> Tensor
   use_c10_dispatcher: full
 
+- func: true_divide.Tensor(Tensor self, Tensor other) -> Tensor
+  use_c10_dispatcher: full
+  variants: function
+  dispatch:
+    CPU: true_divide
+    CUDA: true_divide
+    SparseCPU: true_divide_sparse
+    SparseCUDA: true_divide_sparse
+  supports_named_tensor: True
+
+- func: true_divide.out(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
+  dispatch:
+    CPU: true_divide_out
+    CUDA: true_divide_out
+    SparseCPU: true_divide_out_sparse_zerodim
+    SparseCUDA: true_divide_out_sparse_zerodim
+  supports_named_tensor: True
+
+- func: true_divide.Scalar(Tensor self, Scalar other) -> Tensor
+  use_c10_dispatcher: full
+  variants: function
+  supports_named_tensor: True
+
 - func: trunc(Tensor self) -> Tensor
   use_c10_dispatcher: full
   supports_named_tensor: True

--- a/aten/src/ATen/native/sparse/SparseTensorMath.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensorMath.cpp
@@ -214,8 +214,6 @@ SparseTensor& div_out_sparse_scalar(SparseTensor& r, const SparseTensor& t, Scal
 // true_divide(SparseTensor, Scalar)
 // --------------------------------------------------------------------
 
-SparseTensor& true_divide_out_sparse_zerodim(SparseTensor& r, const SparseTensor& t, const Tensor& value);
-
 Tensor true_divide_sparse(const Tensor& self, const Tensor& value) {
   auto commonDtype = at::result_type(self, value);
 

--- a/aten/src/ATen/native/sparse/SparseTensorMath.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensorMath.cpp
@@ -211,6 +211,62 @@ SparseTensor& div_out_sparse_scalar(SparseTensor& r, const SparseTensor& t, Scal
 }
 
 // --------------------------------------------------------------------
+// true_divide(SparseTensor, Scalar)
+// --------------------------------------------------------------------
+
+SparseTensor& true_divide_out_sparse_zerodim(SparseTensor& r, const SparseTensor& t, const Tensor& value);
+
+Tensor true_divide_sparse(const Tensor& self, const Tensor& value) {
+  auto commonDtype = at::result_type(self, value);
+
+  // Ensures floating dtype
+  if (isIntegralType(commonDtype, /*includeBool=*/ true)) {
+    commonDtype = typeMetaToScalarType(c10::get_default_dtype());
+  }
+
+  Tensor result = at::empty({0}, self.options().dtype(commonDtype));
+  return div_out_sparse_zerodim(result, self, value);
+}
+
+SparseTensor& true_divide_out_sparse_zerodim(
+    SparseTensor& result,
+    const SparseTensor& dividend,
+    const Tensor& divisor) {
+  TORCH_CHECK(divisor.dim() == 0, "Sparse true division only supports",
+    " scalar or zero-dim dense tensor divisors (got shape ", divisor.sizes());
+  TORCH_CHECK(!divisor.is_sparse(), "A Sparse Tensor can only be divided by",
+    " a scalar or zero-dim dense tensor divisor, but got a sparse divisor.");
+
+  AT_ASSERT(result.is_sparse());
+  AT_ASSERT(dividend.is_sparse());
+
+  // Short-circuits if result and dividend are the same tensor
+  if (is_same_tensor(result, dividend)) {
+    Tensor result_values = result._values();
+    at::true_divide_out(result_values, result_values, divisor);
+  } else {
+    Tensor dividend_tmp = dividend;
+    result.resize_as_(dividend_tmp);
+    auto indices = result._indices();
+    indices.resize_as_(dividend_tmp.indices());
+    indices.copy_(dividend_tmp._indices());
+    Tensor result_values = result._values();
+    at::true_divide_out(result_values, dividend_tmp._values(), divisor);
+    get_sparse_impl(result)->set_nnz_and_narrow(dividend_tmp._nnz());
+    result._coalesced_(dividend_tmp.is_coalesced());
+  }
+
+  return result;
+}
+
+SparseTensor& true_divide_out_sparse_scalar(
+    SparseTensor& result,
+    const SparseTensor& dividend,
+    Scalar divisor) {
+  return true_divide_out_sparse_zerodim(result, dividend, wrapped_scalar_tensor(divisor));
+}
+
+// --------------------------------------------------------------------
 // norm(SparseTensor, Scalar)
 // --------------------------------------------------------------------
 

--- a/docs/source/onnx.rst
+++ b/docs/source/onnx.rst
@@ -404,6 +404,7 @@ The following operators are supported:
 * to
 * topk
 * transpose
+* true_divide
 * type_as
 * unbind
 * unfold (experimental support with ATen-Caffe2 integration)

--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -250,6 +250,7 @@ Pointwise Ops
 .. autofunction:: square
 .. autofunction:: tan
 .. autofunction:: tanh
+.. autofunction:: true_divide
 .. autofunction:: trunc
 
 

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -742,7 +742,16 @@ class TestONNXRuntime(unittest.TestCase):
 
         x = torch.randn(2, 3, 4).to(torch.int)
         y = torch.arange(1, 2 * 3 * 4 + 1).reshape(2, 3, 4).to(torch.int)
+
+        prev_default = torch.get_default_dtype()
+
+        torch.set_default_dtype(torch.float)
         self.run_test(torch.jit.trace(TrueDivModule(), (x, y)), (x, y))
+
+        torch.set_default_dtype(torch.double)
+        self.run_test(torch.jit.trace(TrueDivModule(), (x, y)), (x, y))
+
+        torch.set_default_dtype(prev_default)
 
     def test_slice_trace(self):
         class MyModule(torch.nn.Module):

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -156,12 +156,12 @@ class TestONNXRuntime(unittest.TestCase):
                                   dynamic_axes=dynamic_axes,
                                   input_names=input_names, output_names=output_names,
                                   use_external_data_format=True)
-                # compute onnxruntime output prediction                
+                # compute onnxruntime output prediction
                 ort_sess_opt = onnxruntime.SessionOptions()
                 ort_sess_opt.graph_optimization_level = \
                     onnxruntime.GraphOptimizationLevel.ORT_ENABLE_EXTENDED if ort_optim_on else \
                     onnxruntime.GraphOptimizationLevel.ORT_DISABLE_ALL
-                ort_sess = onnxruntime.InferenceSession(model_file_name, sess_options=ort_sess_opt)                
+                ort_sess = onnxruntime.InferenceSession(model_file_name, sess_options=ort_sess_opt)
                 input_copy = copy.deepcopy(input)
                 ort_test_with_input(ort_sess, input_copy, output, rtol, atol)
 
@@ -194,7 +194,7 @@ class TestONNXRuntime(unittest.TestCase):
         # We are turning off Onnx Runtime optimization off in this test,
         # because external data format is not supported to in ORT optimizer.
         # Once that support is added, we can set ort_optim_on=True (default).
-        self.run_model_test_with_external_data(model, x, rtol=1e-3, atol=1e-5, 
+        self.run_model_test_with_external_data(model, x, rtol=1e-3, atol=1e-5,
                                                ort_optim_on=False)
 
     # Export Torchvision models
@@ -719,6 +719,30 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.randn(2, 3, 4)
         y = torch.randn(2, 3, 4)
         self.run_test(FloorDivModule(), (x, y))
+
+    def test_true_div(self):
+        class TrueDivModule(torch.nn.Module):
+            def forward(self, x, y):
+                return torch.true_divide(x, y)
+
+        x = torch.randn(2, 3, 4).to(torch.int)
+        y = torch.arange(1, 2 * 3 * 4 + 1).reshape(2, 3, 4).to(torch.int)
+        self.run_test(TrueDivModule(), (x, y))
+        self.run_test(TrueDivModule(), (x.float(), y))
+        self.run_test(TrueDivModule(), (x.to(torch.short), y.to(torch.short)))
+
+    # Note: true_divide cannot (generally) be exported via scripting
+    # since its type promotion logic is dependent on knowing the scalar types
+    # of the input tensors. That is, the ONNX graph is dependent on the
+    # data type of the inputs. This makes it appropriate for tracing only.
+    def test_true_div_trace(self):
+        class TrueDivModule(torch.nn.Module):
+            def forward(self, x, y):
+                return torch.true_divide(x, y)
+
+        x = torch.randn(2, 3, 4).to(torch.int)
+        y = torch.arange(1, 2 * 3 * 4 + 1).reshape(2, 3, 4).to(torch.int)
+        self.run_test(torch.jit.trace(TrueDivModule(), (x, y)), (x, y))
 
     def test_slice_trace(self):
         class MyModule(torch.nn.Module):
@@ -2813,7 +2837,7 @@ class TestONNXRuntime(unittest.TestCase):
 
         def run_model():
             SplitModel(x)
-        self.assertRaises(TypeError, run_model)            
+        self.assertRaises(TypeError, run_model)
 
     def _dispatch_rnn_test(self, name, *args, **kwargs):
         if name == 'elman':

--- a/test/test_namedtensor.py
+++ b/test/test_namedtensor.py
@@ -751,6 +751,7 @@ class TestNamedTensor(TestCase):
             fn_method_and_inplace('atan2'),
             method('copy_'),
             function('floor_divide'),
+            function('true_divide'),
         ]
         tests = flatten(tests)
 

--- a/test/test_overrides.py
+++ b/test/test_overrides.py
@@ -849,6 +849,7 @@ TENSOR_LIKE_TORCH_IMPLEMENTATIONS = (
      reduce=None, reduction='mean': -1),
     (torch.triu, lambda input, diagonal=0, out=None: -1),
     (torch.triu_indices, lambda row, col, offset=0, dtype=torch.long, device='cpu', layout=torch.strided: -1),
+    (torch.true_divide, lambda input, other: -1),
     (torch.trunc, lambda input, out=None: -1),
     (torch.unbind, lambda input, dim=0: -1),
     (torch.unique, lambda input, sorted=True, return_inverse=False, return_counts=False, dim=None: -1),

--- a/test/test_type_promotion.py
+++ b/test/test_type_promotion.py
@@ -447,6 +447,21 @@ class TestTypePromotion(TestCase):
         casting_result = dividend.to(torch.get_default_dtype()) / divisor.to(torch.get_default_dtype())
         self.assertEqual(casting_result, torch.true_divide(dividend, divisor))
 
+    @dtypes(torch.bool, torch.short, torch.uint8, torch.int, torch.long)
+    def test_true_divide_out(self, device, dtype):
+        dividend = torch.randn(5, device=device).to(dtype)
+        divisor = torch.arange(1, 6, device=device).to(dtype)
+
+        # Tests that requests for an integer quotient fail
+        integral_quotient = torch.empty(5, device=device, dtype=dtype)
+        with self.assertRaises(RuntimeError):
+            torch.true_divide(dividend, divisor, out=integral_quotient)
+
+        # Tests that requests for a floating quotient succeed
+        floating_quotient = torch.empty(5, device=device, dtype=torch.get_default_dtype())
+        casting_result = dividend.to(torch.get_default_dtype()) / divisor.to(torch.get_default_dtype())
+        self.assertEqual(casting_result, torch.true_divide(dividend, divisor, out=floating_quotient))
+
     def _test_sparse_op_input_tensors(self, device, dtype, coalesced, zeros=True):
         t = self._get_test_tensor(device, dtype, not zeros)
         if zeros and dtype != torch.bool:

--- a/test/test_type_promotion.py
+++ b/test/test_type_promotion.py
@@ -4,7 +4,8 @@ import torch
 import itertools
 
 from torch.testing._internal.common_utils import TestCase, run_tests, load_tests
-from torch.testing._internal.common_device_type import instantiate_device_type_tests, onlyOnCPUAndCUDA
+from torch.testing._internal.common_device_type import (instantiate_device_type_tests, onlyOnCPUAndCUDA,
+    dtypes)
 
 # load_tests from torch.testing._internal.common_utils is used to automatically filter tests for
 # sharding on sandcastle. This line silences flake warnings
@@ -438,6 +439,14 @@ class TestTypePromotion(TestCase):
         a = torch.tensor([[True, True], [False, True]], device=device)
         self.assertEqual(a.t() == 0, a.t() == False)  # noqa: E712
 
+    @dtypes(torch.bool, torch.short, torch.uint8, torch.int, torch.long)
+    @float_double_default_dtype
+    def test_true_divide(self, device, dtype):
+        dividend = torch.randn(5, device=device).to(dtype)
+        divisor = torch.arange(1, 6, device=device).to(dtype)
+        casting_result = dividend.to(torch.get_default_dtype()) / divisor.to(torch.get_default_dtype())
+        self.assertEqual(casting_result, torch.true_divide(dividend, divisor))
+
     def _test_sparse_op_input_tensors(self, device, dtype, coalesced, zeros=True):
         t = self._get_test_tensor(device, dtype, not zeros)
         if zeros and dtype != torch.bool:
@@ -558,6 +567,17 @@ class TestTypePromotion(TestCase):
     @onlyOnCPUAndCUDA
     def test_sparse_sub(self, device):
         self._run_all_tests_for_sparse_op('sub', device)
+
+    @onlyOnCPUAndCUDA
+    @dtypes(torch.bool, torch.short, torch.uint8, torch.int, torch.long)
+    @float_double_default_dtype
+    def test_sparse_true_divide(self, device, dtype):
+        dividend = torch.randn(5, device=device).to(dtype)
+        divisor = 2
+        dividend_sparse = dividend.to_sparse()
+        casting_result = dividend.to(torch.get_default_dtype()) / 2
+        self.assertEqual(casting_result, torch.true_divide(dividend_sparse, 2).to_dense())
+
 
 instantiate_device_type_tests(TestTypePromotion, globals())
 

--- a/test/test_type_promotion.py
+++ b/test/test_type_promotion.py
@@ -5,7 +5,7 @@ import itertools
 
 from torch.testing._internal.common_utils import TestCase, run_tests, load_tests
 from torch.testing._internal.common_device_type import (instantiate_device_type_tests, onlyOnCPUAndCUDA,
-    dtypes)
+                                                        dtypes)
 
 # load_tests from torch.testing._internal.common_utils is used to automatically filter tests for
 # sharding on sandcastle. This line silences flake warnings

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -899,6 +899,15 @@
 - name: triu(Tensor self, int diagonal=0) -> Tensor
   self: grad.triu(diagonal)
 
+  # Note: true_divide uses the division operator for backward
+  # since grad is always a floating tensor.
+- name: true_divide.Tensor(Tensor self, Tensor other) -> Tensor
+  self: grad / other
+  other: -grad * self / (other * other)
+
+- name: true_divide.Scalar(Tensor self, Scalar other) -> Tensor
+  self: grad / other
+
 - name: trunc(Tensor self) -> Tensor
   self: zeros_like(grad, at::MemoryFormat::Preserve)
 

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -6167,7 +6167,7 @@ add_docstr(torch.true_divide,
            r"""
 true_divide(dividend, divisor) -> Tensor
 
-Performs "true division" that always computes the dividend divided by the divisor
+Performs "true division" that always computes the division
 in floating point. Analogous to division in Python 3 and equivalent to
 :func:`torch.div` except when both inputs have bool or integer scalar types,
 in which case they are cast to the default (floating) scalar type before the division.

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -6163,6 +6163,35 @@ Example::
             [1, 2, 2]])
 """.format(**factory_common_args))
 
+add_docstr(torch.true_divide,
+           r"""
+true_divide(dividend, divisor) -> Tensor
+
+Performs "true division" that always computes the dividend divided by the divisor
+in floating point. Analogous to division in Python 3 and equivalent to
+:func:`torch.div` except when both inputs have bool or integer scalar types,
+in which case they are cast to the default (floating) scalar type before the division.
+
+.. math::
+    \text{{out}}_i = \frac{{\text{{dividend}}_i}}{{\text{{divisor}}}}
+
+Args:
+    dividend (Tensor): the dividend
+    divisor (Tensor or Scalar): the divisor
+
+Keyword args:
+    {out}
+
+Example::
+
+    >>> dividend = torch.tensor([5, 3], dtype=torch.int)
+    >>> divisor = torch.tensor([3, 2], dtype=torch.int)
+    >>> torch.true_divide(dividend, divisor)
+    tensor([1.6667, 1.5000])
+    >>> torch.true_divide(dividend, 2)
+    tensor([2.5000, 1.5000])
+""".format(**common_args))
+
 add_docstr(torch.trunc,
            r"""
 trunc(input, out=None) -> Tensor

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -138,7 +138,7 @@ def floor_divide(g, self, other):
 # Division where both inputs are cast to floating types
 # If both inputs are floating, performs div as usual
 # If only one input is a floating type, the other input is cast to its type
-# If neither input is a floating type, both inputs are case to float
+# If neither input is a floating type, both inputs are cast to the default scalar type
 def true_divide(g, self, other):
     # Case 1: both values are floating
     # Performs div as usual
@@ -158,9 +158,15 @@ def true_divide(g, self, other):
         return div(g, self, other)
 
     # Case 4: neither is floating
-    # Casts inputs to float
-    g.op("Cast", self, to_i=sym_help.cast_pytorch_to_onnx['Float'])
-    g.op("Cast", other, to_i=sym_help.cast_pytorch_to_onnx['Float'])
+    # Casts both inputs to the default scalar type
+    scalar_type = torch.get_default_dtype()
+    onnx_scalar_type = sym_help.cast_pytorch_to_onnx['Float']
+    assert scalar_type is torch.float or scalar_type is torch.double
+    if torch.get_default_dtype() is torch.double:
+        onnx_scalar_type = sym_help.cast_pytorch_to_onnx['Double']
+
+    g.op("Cast", self, to_i=onnx_scalar_type)
+    g.op("Cast", other, to_i=onnx_scalar_type)
     return div(g, self, other)
 
 

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -135,6 +135,35 @@ def floor_divide(g, self, other):
     return out
 
 
+# Division where both inputs are cast to floating types
+# If both inputs are floating, performs div as usual
+# If only one input is a floating type, the other input is cast to its type
+# If neither input is a floating type, both inputs are case to float
+def true_divide(g, self, other):
+    # Case 1: both values are floating
+    # Performs div as usual
+    if sym_help._is_fp(self) and sym_help._is_fp(other):
+        return div(g, self, other)
+
+    # Case 2: self is floating, other is not
+    # Casts other to self's dtype
+    if sym_help._is_fp(self):
+        g.op("Cast", other, to_i=sym_help.cast_pytorch_to_onnx[self.type().scalarType()])
+        return div(g, self, other)
+
+    # Case 3: other is floating, self is not
+    # Casts self to other's dtype
+    if sym_help._is_fp(other):
+        g.op("Cast", other, to_i=sym_help.cast_pytorch_to_onnx[other.type().scalarType()])
+        return div(g, self, other)
+
+    # Case 4: neither is floating
+    # Casts inputs to float
+    g.op("Cast", self, to_i=sym_help.cast_pytorch_to_onnx['Float'])
+    g.op("Cast", other, to_i=sym_help.cast_pytorch_to_onnx['Float'])
+    return div(g, self, other)
+
+
 def reciprocal(g, self):
     return g.op("Div", torch.ones(1), self)
 


### PR DESCRIPTION
See NumPy's division documentation here: https://numpy.org/doc/1.18/reference/generated/numpy.divide.html#numpy.divide. 

True division is the same as PyTorch's default division except when both inputs are integer or bool tensors. In the latter case the inputs are (conceptually) cast to the default floating type before the division is performed.

The function is implemented for dense and sparse tensors and supports exporting to ONNX from PyTorch's eager mode or JIT traces. The function is inherently incompatible with exporting to ONNX via JIT script, and is another datapoint suggesting we should deprecate exporting scripted graphs to ONNX.

Tests are added for the type promotion, named tensor, and ONNX export behavior.