### PR TITLE
Calls to _empty_affine_quantized pass MemoryFormat by TensorOptions

### DIFF
--- a/aten/src/ATen/native/quantized/QTensor.cpp
+++ b/aten/src/ATen/native/quantized/QTensor.cpp
@@ -170,10 +170,9 @@ Tensor quantized_clone(const Tensor& self, c10::optional<c10::MemoryFormat> opti
 
   Tensor dst = at::_empty_affine_quantized(
       self.sizes(),
-      self.options(),
+      self.options().memory_format(memory_format),
       self.q_scale(),
-      self.q_zero_point(),
-      memory_format);
+      self.q_zero_point());
 
   at::native::copy_(dst, self, false);
 

--- a/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
+++ b/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
@@ -76,10 +76,9 @@ Tensor qcat_nhwc_kernel(
 
   auto output = at::_empty_affine_quantized(
       {N, C_out, H, W},
-      qx0.options(),
+      qx0.options().memory_format(MemoryFormat::ChannelsLast),
       scale,
-      zero_point,
-      MemoryFormat::ChannelsLast);
+      zero_point);
 
   // N, H, and W are explicitly captured here because there's a bug in GCC5
   // which causes an internal compiler error if they're not
@@ -157,10 +156,9 @@ void qrelu_kernel(const Tensor& qx, Tensor& qy) {
   AT_DISPATCH_QINT_TYPES(qx.scalar_type(), "qrelu", [&]() {
     qy = at::_empty_affine_quantized(
         qx.sizes(),
-        at::device(kCPU).dtype(SCALAR_TYPE),
+        at::device(kCPU).dtype(SCALAR_TYPE).memory_format(qx.suggest_memory_format()),
         qx.q_scale(),
-        qx.q_zero_point(),
-        qx.suggest_memory_format());
+        qx.q_zero_point());
     using Vec = Vec256<scalar_t>;
     auto zero_point_vec = Vec(scalar_t(zero_point));
     auto iter = TensorIterator::unary_op(qy, qx);
@@ -178,10 +176,9 @@ void qrelu6_kernel(const Tensor& qx, Tensor& qy) {
   AT_DISPATCH_QINT_TYPES(qx.scalar_type(), "qrelu6", [&]() {
     qy = at::_empty_affine_quantized(
         qx.sizes(),
-        at::device(kCPU).dtype(SCALAR_TYPE),
+        at::device(kCPU).dtype(SCALAR_TYPE).memory_format(qx.suggest_memory_format()),
         qx.q_scale(),
-        qx.q_zero_point(),
-        qx.suggest_memory_format());
+        qx.q_zero_point());
     using Vec = Vec256<scalar_t>;
     auto iter = TensorIterator::unary_op(qy, qx);
     scalar_t six =
@@ -275,10 +272,9 @@ void qsigmoid_kernel(const Tensor& qx, Tensor& qy) {
 
     qy = at::_empty_affine_quantized(
         qx.sizes(),
-        at::device(kCPU).dtype(SCALAR_TYPE),
+        at::device(kCPU).dtype(SCALAR_TYPE).memory_format(qx.suggest_memory_format()),
         output_scale,
-        output_zero_point,
-        qx.suggest_memory_format());
+        output_zero_point);
     auto iter = TensorIterator::unary_op(qy, qx);
 
     using Vec = Vec256<scalar_t>;
@@ -314,10 +310,9 @@ void qclamp_kernel(
   AT_DISPATCH_QINT_TYPES(qx.scalar_type(), "qclamp", [&]() {
     qy = at::_empty_affine_quantized(
         qx.sizes(),
-        at::device(kCPU).dtype(SCALAR_TYPE),
+        at::device(kCPU).dtype(SCALAR_TYPE).memory_format(qx.suggest_memory_format()),
         qx.q_scale(),
-        qx.q_zero_point(),
-        qx.suggest_memory_format());
+        qx.q_zero_point());
     using Vec = Vec256<scalar_t>;
     auto iter = TensorIterator::unary_op(qy, qx);
     auto min = min_scalar.to<float>();
@@ -366,10 +361,9 @@ void qtanh_kernel(const Tensor& qx, Tensor& qy) {
 
     qy = at::_empty_affine_quantized(
         qx.sizes(),
-        at::device(kCPU).dtype(SCALAR_TYPE),
+        at::device(kCPU).dtype(SCALAR_TYPE).memory_format(qx.suggest_memory_format()),
         output_scale,
-        output_zero_point,
-        qx.suggest_memory_format());
+        output_zero_point);
     auto iter = TensorIterator::unary_op(qy, qx);
 
     using Vec = Vec256<scalar_t>;

--- a/aten/src/ATen/native/quantized/cpu/q_adaavgpool.cpp
+++ b/aten/src/ATen/native/quantized/cpu/q_adaavgpool.cpp
@@ -146,10 +146,9 @@ Tensor q_adaptive_avg_pool2d(const Tensor& input, IntArrayRef output_size) {
     // Fast path for NHWC
     Tensor output = at::_empty_affine_quantized(
         output_shape,
-        input.options(),
+        input.options().memory_format(input.suggest_memory_format()),
         input.q_scale(),
-        input.q_zero_point(),
-        input.suggest_memory_format());
+        input.q_zero_point());
     if (input.dim() == 3 || input.size(0) == 1) {
       qadaptive_avg_pool2d_nhwc_stub(
           input.device().type(),

--- a/aten/src/ATen/native/quantized/cpu/q_avgpool.cpp
+++ b/aten/src/ATen/native/quantized/cpu/q_avgpool.cpp
@@ -190,10 +190,9 @@ Tensor q_avg_pool2d(
   if (input.is_contiguous(c10::MemoryFormat::ChannelsLast)) {
     auto output = at::_empty_affine_quantized(
         output_shape,
-        input.options(),
+        input.options().memory_format(input.suggest_memory_format()),
         input.q_scale(),
-        input.q_zero_point(),
-        input.suggest_memory_format());
+        input.q_zero_point());
     // fast path for channel last: qavg_pool_2d_nhwc_stub
     if (output_shape.size() == 3) {
       qavg_pool2d_nhwc_stub(

--- a/aten/src/ATen/native/quantized/cpu/qadd.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qadd.cpp
@@ -200,10 +200,11 @@ Tensor qnnpack_add(Tensor qa, Tensor qb, double scale, int64_t zero_point) {
 #endif
     auto qc = at::_empty_affine_quantized(
         qa.sizes(),
-        at::device(kCPU).dtype(qa.scalar_type()),
+        at::device(kCPU)
+           .dtype(qa.scalar_type())
+           .memory_format(qa.suggest_memory_format()),
         scale,
-        zero_point,
-        qa.suggest_memory_format());
+        zero_point);
     return _add_out<ReLUFused>(qc, qa, qb);
   }
 };

--- a/aten/src/ATen/native/quantized/cpu/qbatch_norm.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qbatch_norm.cpp
@@ -81,10 +81,11 @@ Tensor q_batch_norm_impl(
   auto qx_nhwc = qx.contiguous(MemoryFormat::ChannelsLast);
   Tensor qy = at::_empty_affine_quantized(
       oSizes,
-      at::device(kCPU).dtype(qx_nhwc.scalar_type()),
+      at::device(kCPU)
+         .dtype(qx_nhwc.scalar_type())
+         .memory_format(MemoryFormat::ChannelsLast),
       output_scale,
-      output_zero_point,
-      MemoryFormat::ChannelsLast);
+      output_zero_point);
 
   compute_fused_params(
       C,

--- a/aten/src/ATen/native/quantized/cpu/qconv.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv.cpp
@@ -419,10 +419,11 @@ class QConvInt8 final : public c10::OperatorKernel {
     Tensor output = kSpatialDim == 2
         ? _empty_affine_quantized(
               output_shape,
-              device(kCPU).dtype(kQUInt8),
+              device(kCPU)
+                .dtype(kQUInt8)
+                .memory_format(MemoryFormat::ChannelsLast),
               output_scale,
-              output_zero_point,
-              MemoryFormat::ChannelsLast)
+              output_zero_point)
         : fbgemm_utils::MakeEmptyAffineQuantizedChannelsLast3dTensor(
               output_shape[0],
               output_shape[1],
@@ -574,10 +575,11 @@ class QConvInt8 final : public c10::OperatorKernel {
           reinterpret_cast<int8_t*>(weight_contig.data_ptr<c10::qint8>());
       Tensor qnnp_weight = at::_empty_affine_quantized(
           weight_contig.sizes(),
-          at::device(kCPU).dtype(kQUInt8),
+          at::device(kCPU)
+             .dtype(kQUInt8)
+             .memory_format(MemoryFormat::ChannelsLast),
           kernel_scale,
-          kernel_zp,
-          MemoryFormat::ChannelsLast);
+          kernel_zp);
       auto* qnnp_w_data = qnnp_weight.data_ptr<c10::quint8>();
       auto wt_numel = weight_contig.numel();
       for (int i = 0; i < wt_numel; ++i) {
@@ -609,10 +611,11 @@ class QConvInt8 final : public c10::OperatorKernel {
     // Allocate output Tensor and a buffer for QNNPACK to use
     Tensor output = at::_empty_affine_quantized(
         output_shape,
-        at::device(kCPU).dtype(kQUInt8),
+        at::device(kCPU)
+           .dtype(kQUInt8)
+           .memory_format(MemoryFormat::ChannelsLast),
         output_scale,
-        output_zero_point,
-        MemoryFormat::ChannelsLast);
+        output_zero_point);
 
     const pytorch_qnnp_status run_status = qnnpack::qnnpackConv(
         conv_p,

--- a/aten/src/ATen/native/quantized/cpu/qconv_unpack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv_unpack.cpp
@@ -79,10 +79,9 @@ class QConvUnpackWeightsInt8 final : public c10::OperatorKernel {
       unpacked_weights = kSpatialDim == 2
           ? _empty_affine_quantized(
                 {output_channels, C_per_G, kernel_h, kernel_w},
-                device(kCPU).dtype(kQInt8),
+                device(kCPU).dtype(kQInt8).memory_format(MemoryFormat::ChannelsLast),
                 pack_ptr.w_scale[0],
-                pack_ptr.w_zp[0],
-                MemoryFormat::ChannelsLast)
+                pack_ptr.w_zp[0])
           : fbgemm_utils::MakeEmptyAffineQuantizedChannelsLast3dTensor(
                 output_channels,
                 C_per_G,

--- a/aten/src/ATen/native/quantized/cpu/qpool.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qpool.cpp
@@ -150,10 +150,11 @@ Tensor q_maxpool_2d(
     // vectorization.
     Tensor qy = at::_empty_affine_quantized(
         oSizes,
-        qx.options().dtype(toQIntType(qx.scalar_type())),
+        qx.options()
+          .dtype(toQIntType(qx.scalar_type()))
+          .memory_format(qx.suggest_memory_format()),
         qx.q_scale(),
-        qx.q_zero_point(),
-        qx.suggest_memory_format());
+        qx.q_zero_point());
     qmaxpool_2d_nhwc_stub(qx.device().type(), qx, iC, iH, iW, oH, oW, kH, kW, sH, sW, pH, pW, dH, dW, qy);
     return qy;
   } else {

--- a/aten/src/ATen/native/quantized/cpu/qupsample_bilinear2d.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qupsample_bilinear2d.cpp
@@ -118,10 +118,9 @@ Tensor quantized_upsample_bilinear2d_cpu(
   if (input.is_contiguous(c10::MemoryFormat::ChannelsLast)) {
     Tensor output = at::_empty_affine_quantized(
         {nbatch, channels, output_height, output_width},
-        input.options(),
+        input.options().memory_format(input.suggest_memory_format()),
         input.q_scale(),
-        input.q_zero_point(),
-        input.suggest_memory_format());
+        input.q_zero_point());
 
     qupsample_bilinear2d_nhwc_stub(
         input.device().type(),

--- a/aten/src/ATen/native/quantized/cpu/qupsample_nearest2d.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qupsample_nearest2d.cpp
@@ -121,10 +121,9 @@ Tensor quantized_upsample_nearest2d_cpu(
   if (input.is_contiguous(c10::MemoryFormat::ChannelsLast)) {
     Tensor output = at::_empty_affine_quantized(
         {nbatch, channels, output_height, output_width},
-        input.options(),
+        input.options().memory_format(input.suggest_memory_format()),
         input.q_scale(),
-        input.q_zero_point(),
-        input.suggest_memory_format());
+        input.q_zero_point());
 
     AT_DISPATCH_QINT_TYPES(input.scalar_type(), "upsample_nearest2d", [&] {
       auto* idata = static_cast<scalar_t*>(input.data_ptr());


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #34247 Change default value of MemoryFormat? to None
* #34246 Standardize expanded TensorOptions representation in native_functions.yaml
* #34245 Calls to Tensor::to pass MemoryFormat by TensorOptions
* **#34244 Calls to _empty_affine_quantized pass MemoryFormat by TensorOptions**

This argument will no longer exist in positional form when MemoryFormat
is moved into TensorOptions by codegen, so we must stop using it when
we make calls from C++.  This diff eliminates all direct positional
calls, making them be passed in using TensorOptions.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>