### PR TITLE
Standardize expanded TensorOptions representation in native_functions.yaml

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -152,7 +152,7 @@
   dispatch:
     CUDA: _cudnn_rnn_backward
 
-- func: _cudnn_init_dropout_state(float dropout, bool train, int dropout_seed, *, ScalarType dtype, Layout layout, Device device, bool pin_memory=False) -> Tensor
+- func: _cudnn_init_dropout_state(float dropout, bool train, int dropout_seed, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
   dispatch:
     CUDA: _cudnn_init_dropout_state
 
@@ -3347,7 +3347,7 @@
 
 # FIXME: would be nicer if TensorOptions was optional based; not adding default arguments for options given
 # the default would never make sense.
-- func: sparse_coo_tensor.size(int[] size, *, ScalarType dtype, Layout layout, Device device, bool pin_memory=False) -> Tensor
+- func: sparse_coo_tensor.size(int[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
 
 - func: sparse_coo_tensor.indices(Tensor indices, Tensor values, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
 
@@ -3355,13 +3355,13 @@
 
 - func: _sparse_coo_tensor_unsafe(Tensor indices, Tensor values, int[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
 
-- func: _sparse_coo_tensor_with_dims(int sparse_dim, int dense_dim, int[] size, *, ScalarType dtype, Layout layout, Device device, bool pin_memory=False) -> Tensor
+- func: _sparse_coo_tensor_with_dims(int sparse_dim, int dense_dim, int[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
   dispatch:
     SparseCPU: new_with_dims_sparse
     SparseCUDA: new_with_dims_sparse
   requires_tensor: True
 
-- func: _sparse_coo_tensor_with_dims_and_tensors(int sparse_dim, int dense_dim, int[] size, Tensor indices, Tensor values, *, ScalarType dtype, Layout layout, Device device, bool pin_memory=False) -> Tensor
+- func: _sparse_coo_tensor_with_dims_and_tensors(int sparse_dim, int dense_dim, int[] size, Tensor indices, Tensor values, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
   dispatch:
     SparseCPU: new_with_dims_and_tensor_sparse
     SparseCUDA: new_with_dims_and_tensor_sparse
@@ -3657,7 +3657,7 @@
 # to(Device) must not exist because all constructors of Device also works for
 # TensorOptions. Otherwise, an ambiguity error is thrown.
 # See NOTE [ TensorOptions Constructors ].
-- func: to.dtype_layout(Tensor self, *, ScalarType dtype, Layout layout, Device device, bool pin_memory=False, bool non_blocking=False, bool copy=False, MemoryFormat? memory_format=None) -> Tensor
+- func: to.dtype_layout(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, bool non_blocking=False, bool copy=False, MemoryFormat? memory_format=None) -> Tensor
   variants: method
   device_guard: False
   supports_named_tensor: True
@@ -4360,12 +4360,12 @@
   use_c10_dispatcher: full
   variants: method, function
 
-- func: tril_indices(int row, int col, int offset=0, *, ScalarType? dtype=long, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: tril_indices(int row, int col, int offset=0, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
   dispatch:
     CPU: tril_indices_cpu
     CUDA: tril_indices_cuda
 
-- func: triu_indices(int row, int col, int offset=0, *, ScalarType? dtype=long, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: triu_indices(int row, int col, int offset=0, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
   dispatch:
     CPU: triu_indices_cpu
     CUDA: triu_indices_cuda

--- a/test/jit/test_unsupported_ops.py
+++ b/test/jit/test_unsupported_ops.py
@@ -42,21 +42,6 @@ class TestUnsupportedOps(JitTestCase):
             with self.assertRaisesRegex(Exception, "Keyword argument requires_grad unknown"):
                 torch.jit.script(func)
 
-    def test_tensor_options_behavior_mismatch(self):
-        # Any schema declaration which contains a non-optional (ScalarType dtype, Layout layout, Device device)
-        # tuple is implicitly made to be optional for pytorch eager code. This makes the schema incorrect for JIT / C++ api.
-
-        # Complete issue and set of ops is https://github.com/pytorch/pytorch/issues/30763
-        # only testing one here because they should be fixed all at once
-        # ezyang: But actually, I handled all of the _like overloads first
-        # because they're special
-
-        with self.assertRaisesRegex(Exception, "Argument layout not provided."):
-            def foo():
-                return torch.sparse_coo_tensor((2, 2), dtype=torch.double)
-            foo()
-            print(torch.jit.script(foo).graph)
-
     def test_ops_bound_in_functional(self):
         ops_bound_in_functional = "unique",
         tensor = torch.tensor([2])

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -14325,6 +14325,17 @@ a")
 
         self.checkScript(really_slice_out_of_bounds, [])
 
+    def test_tensor_options_behavior_mismatch(self):
+        # Tests for https://github.com/pytorch/pytorch/issues/30763
+
+        def sparse_coo():
+            return torch.sparse_coo_tensor((2, 2), dtype=torch.double)
+        self.checkScript(sparse_coo, ())
+
+        def zeros_like(x):
+            return torch.zeros_like(x, dtype=torch.double)
+        self.checkScript(zeros_like, (torch.randn(2, 3), ))
+
     def test_namedtuple_attr(self):
         def f(x):
             return x.max(dim=1).indices + torch.max(x, dim=1).indices

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -956,7 +956,7 @@
   self: grad.to_dense().sparse_mask(mask).to_dense()
   mask: non_differentiable
 
-- name: _sparse_coo_tensor_with_dims_and_tensors(int sparse_dim, int dense_dim, int[] size, Tensor indices, Tensor values, *, ScalarType dtype, Layout layout, Device device, bool pin_memory=False) -> Tensor
+- name: _sparse_coo_tensor_with_dims_and_tensors(int sparse_dim, int dense_dim, int[] size, Tensor indices, Tensor values, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
   values: sparse_constructor_values_backward(grad, indices, values.sizes())
 
 - name: _sparse_sum.dim(Tensor self, int[1] dim) -> Tensor

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -237,6 +237,7 @@ UNPACK_METHODS = {
     'int64_t': 'toInt64',
     'bool': 'toBool',
     'double': 'toDouble',
+    'MemoryFormat': 'memoryformat',
     'std::string': 'string',
 }
 

--- a/torch/csrc/jit/ir/ir.cpp
+++ b/torch/csrc/jit/ir/ir.cpp
@@ -991,6 +991,8 @@ Operation Node::getOperation() const {
 }
 
 bool Node::isNondeterministic() const {
+  // TODO: This should match against operator NAME only (do not include
+  // overload, do not include schema string)
   static const OperatorSet nondeterministic_ops = {
       "aten::dropout(Tensor input, float p, bool train) -> Tensor",
       "aten::_fused_dropout(Tensor self, float p, Generator? generator) -> (Tensor, Tensor)",

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -1439,14 +1439,14 @@ class ShapePropagator {
     //   arguments
     static const register_formula_for size_factories_with_options{
         {
-            "aten::empty(int[] size, *, int? dtype, int? layout, Device? device, bool? pin_memory, MemoryFormat? memory_format=contiguous_format) -> Tensor",
-            "aten::full(int[] size, Scalar fill_value, *, int? dtype, int? layout, Device? device, bool? pin_memory) -> Tensor",
-            "aten::ones(int[] size, *, int? dtype, int? layout, Device? device, bool? pin_memory) -> Tensor",
-            "aten::rand(int[] size, *, int? dtype, int? layout, Device? device, bool? pin_memory) -> Tensor",
-            "aten::randn(int[] size, *, int? dtype, int? layout, Device? device, bool? pin_memory) -> Tensor",
-            "aten::zeros(int[] size, *, int? dtype, int? layout, Device? device, bool? pin_memory) -> Tensor",
-            "aten::randint(int high, int[] size, *, int? dtype, int? layout, Device? device, bool? pin_memory) -> Tensor",
-            "aten::randint(int low, int high, int[] size, *, int? dtype, int? layout, Device? device, bool? pin_memory) -> Tensor",
+            "aten::empty(int[] size, *, int? dtype=None, int? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=contiguous_format) -> Tensor",
+            "aten::full(int[] size, Scalar fill_value, *, int? dtype=None, int? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+            "aten::ones(int[] size, *, int? dtype=None, int? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+            "aten::rand(int[] size, *, int? dtype=None, int? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+            "aten::randn(int[] size, *, int? dtype=None, int? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+            "aten::zeros(int[] size, *, int? dtype=None, int? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+            "aten::randint(int high, int[] size, *, int? dtype=None, int? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+            "aten::randint(int low, int high, int[] size, *, int? dtype=None, int? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
         },
         [](Node* node) -> type_vec_t {
           if (auto maybe_size = node->get<c10::List<int64_t>>(attr::size)) {

--- a/torch/csrc/jit/runtime/operator.cpp
+++ b/torch/csrc/jit/runtime/operator.cpp
@@ -69,7 +69,7 @@ struct OperatorRegistry {
           op_ptr_it != operators_by_sig.end(),
           "Couldn't find an operator for ",
           name,
-          ". Do you have to update a set of hardcoded JIT ops?");
+          ". Do you have to update a set of hardcoded JIT ops (e.g., in torch/csrc/jit/ir.cpp)?");
       it = operators_by_sig_literal.emplace_hint(it, name, op_ptr_it->second);
     }
     return it->second;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #34247 Change default value of MemoryFormat? to None
* **#34246 Standardize expanded TensorOptions representation in native_functions.yaml**
* #34245 Calls to Tensor::to pass MemoryFormat by TensorOptions
* #34244 Calls to _empty_affine_quantized pass MemoryFormat by TensorOptions

Here is the line of thinking that went into the patch:

- In native_parse.py. we have three different ways you can write the
  expanded form of TensorOptions arguments.  This is dumb, there should
  be exactly one form of TensorOptions that is valid, everything
  else should be disallowed.  So I fiat that all TensorOptions arguments
  must have the form

      *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool pin_memory=False

  and I fix all entries in native_functions.yaml to abide by this specific
  format.

  There was a little bit of hemming and hawing about whether or not
  it should be bool pin_memory=False or bool? pin_memory=None.  In the
  end, I believe making pin_memory a nullable parameter is the epitome
  of "foolish consistency", and we should abide by how things are
  documented in Python (which matches the above form).

- By doing this, I have transformed some previously mandatory overloads
  of TensorOptions into optional overloads of TensorOptions, in the
  C++ API.  For all _like() factory functions, this makes the TensorOptions
  function ambiguous with the MemoryFormat overload, which is also optional.
  These overloads should never have existed in the first place, so I hack around
  this by just making the parameter on the MemoryFormat overload mandatory, so that I pick the TensorOptions
  overload when no arguments are provided.  There's one minor but obvious fix
  for Python argument parsing when I do this.  TorchScript exported model BC can
  <redacted> <redacted> <redacted>.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>