### PR TITLE
Change default value of MemoryFormat? to None

### DIFF
--- a/aten/src/ATen/native/TensorConversions.cpp
+++ b/aten/src/ATen/native/TensorConversions.cpp
@@ -39,8 +39,7 @@ static inline Tensor to_impl(const Tensor& self, const TensorOptions& options, b
       memory_format = self.suggest_memory_format();
     }
   }
-  // See Note [Explicit nullopt MemoryFormat argument]
-  auto r = at::empty(self.sizes(), options.memory_format(memory_format), c10::nullopt);
+  auto r = at::empty(self.sizes(), options.memory_format(memory_format));
   r.copy_(self, non_blocking);
   return r;
 }

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1143,14 +1143,14 @@
   variants: method
 
 # other overrides are to provide a more helpful error message that dtype is required
-- func: _empty_affine_quantized(int[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, float scale=1, int zero_point=0, MemoryFormat? memory_format=contiguous_format) -> Tensor
+- func: _empty_affine_quantized(int[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, float scale=1, int zero_point=0, MemoryFormat? memory_format=None) -> Tensor
   dispatch:
     CPU: empty_affine_quantized_other_backends_stub
     QuantizedCPU: empty_affine_quantized_cpu
 
 # it's a factory function receiving a tensor argument, thus overriding explicitly
 # other overrides are to provide a more helpful error message that dtype is required
-- func: _empty_per_channel_affine_quantized(int[] size, *, Tensor scales, Tensor zero_points, int axis, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=contiguous_format) -> Tensor
+- func: _empty_per_channel_affine_quantized(int[] size, *, Tensor scales, Tensor zero_points, int axis, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
   category_override: factory
   dispatch:
     CPU: empty_per_channel_affine_quantized_other_backends_stub

--- a/test/backward_compatibility/check_backward_compatibility.py
+++ b/test/backward_compatibility/check_backward_compatibility.py
@@ -67,6 +67,8 @@ white_list = [
     ('aten::ones_like', datetime.date(2020, 3, 15)),
     ('aten::randint_like', datetime.date(2020, 3, 15)),
     ('aten::zeros_like', datetime.date(2020, 3, 15)),
+    ('aten::_empty_affine_quantized', datetime.date(2020, 3, 15)),
+    ('aten::_empty_per_channel_affine_quantized', datetime.date(2020, 3, 15)),
 ]
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#34247 Change default value of MemoryFormat? to None**
* #34246 Standardize expanded TensorOptions representation in native_functions.yaml
* #34245 Calls to Tensor::to pass MemoryFormat by TensorOptions
* #34244 Calls to _empty_affine_quantized pass MemoryFormat by TensorOptions

It turns out that the correct defaults are already set inside
the kernels themselves, so make them None for uniformity (makes
it easier to do further refactors; we can consider switching the
defaults back when we're done.)

Signed-off-by: Edward Z. Yang <ezyang@fb.com>