### PR TITLE
Clean up a warning message (unreachable statement)

### DIFF
--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -1361,8 +1361,10 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
             dim() == 5,
             "required rank 5 tensor to use channels_last_3d format");
         TORCH_CHECK(false, "unsupported memory format ", memory_format);
-        //TODO Implement set_sizes_and_strides for channels last 3d
-        break;
+        // TODO Implement set_sizes_and_strides for channels last 3d
+        // Cleaning warning messages, no need to break as TORCH_CHECK(false)
+        // terminates flow.
+        // break;
       }
       case MemoryFormat::Preserve:
         TORCH_CHECK(false, "unsupported memory format ", memory_format);


### PR DESCRIPTION
This is to get rid of this massive warning:

```
pytorch/c10/core/TensorImpl.h(1365): warning: statement is unreachable
```

