### PR TITLE
[C++ API] Remove init-list form of at::indexing::Slice

### DIFF
--- a/test/cpp/api/tensor_indexing.cpp
+++ b/test/cpp/api/tensor_indexing.cpp
@@ -49,24 +49,24 @@ TEST(TensorIndexingTest, TensorIndex) {
     ASSERT_EQ(c10::str(indices[5]), c10::str("1:", INDEX_MAX, ":2"));
   }
 
-  ASSERT_EQ(c10::str(std::vector<TensorIndex>({{}})), c10::str("(0:", INDEX_MAX, ":1)"));
-  ASSERT_EQ(c10::str(std::vector<TensorIndex>({{None, None}})), c10::str("(0:", INDEX_MAX, ":1)"));
-  ASSERT_EQ(c10::str(std::vector<TensorIndex>({{None, None, None}})), c10::str("(0:", INDEX_MAX, ":1)"));
+  ASSERT_EQ(c10::str(std::vector<TensorIndex>({Slice()})), c10::str("(0:", INDEX_MAX, ":1)"));
+  ASSERT_EQ(c10::str(std::vector<TensorIndex>({Slice(None, None)})), c10::str("(0:", INDEX_MAX, ":1)"));
+  ASSERT_EQ(c10::str(std::vector<TensorIndex>({Slice(None, None, None)})), c10::str("(0:", INDEX_MAX, ":1)"));
 
-  ASSERT_EQ(c10::str(std::vector<TensorIndex>({{1, None}})), c10::str("(1:", INDEX_MAX, ":1)"));
-  ASSERT_EQ(c10::str(std::vector<TensorIndex>({{1, None, None}})), c10::str("(1:", INDEX_MAX, ":1)"));
-  ASSERT_EQ(c10::str(std::vector<TensorIndex>({{None, 3}})), c10::str("(0:3:1)"));
-  ASSERT_EQ(c10::str(std::vector<TensorIndex>({{None, 3, None}})), c10::str("(0:3:1)"));
-  ASSERT_EQ(c10::str(std::vector<TensorIndex>({{None, None, 2}})), c10::str("(0:", INDEX_MAX, ":2)"));
-  ASSERT_EQ(c10::str(std::vector<TensorIndex>({{None, None, -1}})), c10::str("(", INDEX_MAX, ":", INDEX_MIN, ":-1)"));
+  ASSERT_EQ(c10::str(std::vector<TensorIndex>({Slice(1, None)})), c10::str("(1:", INDEX_MAX, ":1)"));
+  ASSERT_EQ(c10::str(std::vector<TensorIndex>({Slice(1, None, None)})), c10::str("(1:", INDEX_MAX, ":1)"));
+  ASSERT_EQ(c10::str(std::vector<TensorIndex>({Slice(None, 3)})), c10::str("(0:3:1)"));
+  ASSERT_EQ(c10::str(std::vector<TensorIndex>({Slice(None, 3, None)})), c10::str("(0:3:1)"));
+  ASSERT_EQ(c10::str(std::vector<TensorIndex>({Slice(None, None, 2)})), c10::str("(0:", INDEX_MAX, ":2)"));
+  ASSERT_EQ(c10::str(std::vector<TensorIndex>({Slice(None, None, -1)})), c10::str("(", INDEX_MAX, ":", INDEX_MIN, ":-1)"));
 
-  ASSERT_EQ(c10::str(std::vector<TensorIndex>({{1, 3}})), c10::str("(1:3:1)"));
-  ASSERT_EQ(c10::str(std::vector<TensorIndex>({{1, None, 2}})), c10::str("(1:", INDEX_MAX, ":2)"));
-  ASSERT_EQ(c10::str(std::vector<TensorIndex>({{1, None, -1}})), c10::str("(1:", INDEX_MIN, ":-1)"));
-  ASSERT_EQ(c10::str(std::vector<TensorIndex>({{None, 3, 2}})), c10::str("(0:3:2)"));
-  ASSERT_EQ(c10::str(std::vector<TensorIndex>({{None, 3, -1}})), c10::str("(", INDEX_MAX, ":3:-1)"));
+  ASSERT_EQ(c10::str(std::vector<TensorIndex>({Slice(1, 3)})), c10::str("(1:3:1)"));
+  ASSERT_EQ(c10::str(std::vector<TensorIndex>({Slice(1, None, 2)})), c10::str("(1:", INDEX_MAX, ":2)"));
+  ASSERT_EQ(c10::str(std::vector<TensorIndex>({Slice(1, None, -1)})), c10::str("(1:", INDEX_MIN, ":-1)"));
+  ASSERT_EQ(c10::str(std::vector<TensorIndex>({Slice(None, 3, 2)})), c10::str("(0:3:2)"));
+  ASSERT_EQ(c10::str(std::vector<TensorIndex>({Slice(None, 3, -1)})), c10::str("(", INDEX_MAX, ":3:-1)"));
 
-  ASSERT_EQ(c10::str(std::vector<TensorIndex>({{1, 3, 2}})), c10::str("(1:3:2)"));
+  ASSERT_EQ(c10::str(std::vector<TensorIndex>({Slice(1, 3, 2)})), c10::str("(1:3:2)"));
 }
 
 TEST(TensorIndexingTest, TestNoIndices) {

--- a/test/cpp/api/tensor_indexing.cpp
+++ b/test/cpp/api/tensor_indexing.cpp
@@ -558,7 +558,7 @@ TEST(TensorIndexingTest, TestVariableSlicing) {
   auto indices = torch::tensor({0, 1}, torch::kInt);
   int i = indices[0].item<int>();
   int j = indices[1].item<int>();
-  assert_tensor_equal(x.index({{i, j}}), x.index({{0, 1}}));
+  assert_tensor_equal(x.index({Slice(i, j)}), x.index({Slice(0, 1)}));
 }
 
 TEST(TensorIndexingTest, TestEllipsisTensor) {
@@ -692,7 +692,7 @@ TEST(NumpyTests, TestSingleBoolIndex) {
                    {7, 8, 9}});
 
   assert_tensor_equal(a.index({true}), a.index({None}));
-  assert_tensor_equal(a.index({false}), a.index({None}).index({{0, 0}}));
+  assert_tensor_equal(a.index({false}), a.index({None}).index({Slice(0, 0)}));
 }
 
 TEST(NumpyTests, TestBooleanShapeMismatch) {
@@ -738,7 +738,7 @@ TEST(NumpyTests, TestBooleanAssignmentValueMismatch) {
 
   ASSERT_THROWS_WITH(f(a, {}), "shape mismatch");
   ASSERT_THROWS_WITH(f(a, {1, 2, 3}), "shape mismatch");
-  ASSERT_THROWS_WITH(f(a.index({{None, 1}}), {1, 2, 3}), "shape mismatch");
+  ASSERT_THROWS_WITH(f(a.index({Slice(None, 1)}), {1, 2, 3}), "shape mismatch");
 }
 
 TEST(NumpyTests, TestBooleanIndexingTwodim) {

--- a/torch/csrc/autograd/python_variable_indexing.cpp
+++ b/torch/csrc/autograd/python_variable_indexing.cpp
@@ -148,7 +148,7 @@ static inline Variable applySlicing(
           if (is_tracing) {
             recordSliceTrace(obj);
           }
-          return at::indexing::TensorIndex({start, stop, step});
+          return at::indexing::TensorIndex(at::indexing::Slice(start, stop, step));
         } else if (obj == Py_Ellipsis) {
           return at::indexing::TensorIndex(at::indexing::Ellipsis);
         } else if (obj == Py_None) {
@@ -281,7 +281,7 @@ PyObject* THPVariable_getitem(PyObject* self, PyObject* index) {
       recordSliceTrace(index);
     }
     return THPVariable_Wrap(
-      at::indexing::get_item(self_, {at::indexing::TensorIndex({start, stop, step})}));
+      at::indexing::get_item(self_, {at::indexing::TensorIndex(at::indexing::Slice(start, stop, step))}));
   } else if (index == Py_False || index == Py_True) {
     return THPVariable_Wrap(([&]() {
       pybind11::gil_scoped_release no_gil;
@@ -371,7 +371,7 @@ int THPVariable_setitem(PyObject* self, PyObject* index, PyObject* py_value) {
     }
     // See NOTE [ Setting `disable_slice_optimization` when calling C++ tensor indexing functions from Python ]
     at::indexing::set_item(
-      self_, {at::indexing::TensorIndex({start, stop, step})}, value, /*disable_slice_optimization=*/is_tracing);
+      self_, {at::indexing::TensorIndex(at::indexing::Slice(start, stop, step))}, value, /*disable_slice_optimization=*/is_tracing);
     return 0;
   }
 


### PR DESCRIPTION
The init-list form of `at::indexing::Slice` (i.e. `tensor.index({{1, None, 2}, ...})` instead of `tensor.index({Slice(1, None, 2), ...})`) in C++ API can be easily confused with the list-form indexing in Python API (e.g. `tensor[[1, 3, 2], ...]`), which is not good from readability perspective. This PR removes the init-list form of `at::indexing::Slice` to make the API less confusing.