### PR TITLE
[JIT] fix alias assertion

### DIFF
--- a/torch/csrc/jit/ir/ir.cpp
+++ b/torch/csrc/jit/ir/ir.cpp
@@ -717,7 +717,7 @@ void Value::inferTypeFrom(const at::Tensor& output) {
 }
 
 bool Value::mustBeNone() const {
-  return node_->mustBeNone();
+  return type()->cast<NoneType>() || node_->mustBeNone();
 }
 bool Value::mustNotBeNone() const {
   return node_->kind() != prim::AutogradAdd && type() != NoneType::get() &&


### PR DESCRIPTION
[This check](https://github.com/eellison/pytorch/blob/019ffdca310d22fdcdc66154fbb79f1b028f24b3/torch/csrc/jit/ir/alias_analysis.cpp#L772) wasn't being triggered for None outputs of ifs, because `mustBeNone` would return false if `num_outputs != 1`.  This caused an assertion to fail in alias analysis. It's kind of a convoluted case to repro and I wasn't able to make a succinct one, but I tested internally and it fixed the bug. 