### PR TITLE
Migrate `set_` from the TH to ATen (CPU)

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -2,10 +2,9 @@
   name: _th_set_
   cname: set
   variants: function
-  cpu_half: True
-  cpu_bool: True
+  backends:
+    - CUDA
   cuda_bool: True
-  cpu_bfloat16: True
   cuda_bfloat16: True
   device_guard: False
   return: argument 0

--- a/aten/src/ATen/native/Resize.h
+++ b/aten/src/ATen/native/Resize.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ATen/ATen.h>
+#include <ATen/native/TensorShape.h>
 #include <TH/THTensor.hpp>
 
 namespace at { namespace native {
@@ -17,7 +18,8 @@ static inline void maybe_resize_storage_cpu(TensorImpl* self, int64_t new_size) 
   // (same comment is in Resize.cuh)
   if (new_size > 0) {
     if (!THTensor_getStoragePtr(self)) {
-      THTensor_stealAndSetStoragePtr(self, THStorage_new(self->dtype()));
+      Storage storage(self->dtype(), 0, c10::GetAllocator(kCPU), true);
+      set_tensor_storage(THTensor_wrap(self), storage, 0);
     }
     if (new_size + self->storage_offset() > self->storage().numel()) {
       THStorage_resize(

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -96,7 +96,7 @@ Tensor& set_cpu_(
 
 Tensor& set_cpu_(Tensor& result) {
   Storage storage(result.dtype(), 0, c10::GetAllocator(kCPU), true);
-  return set_cpu_(result, storage, 0, {0}, {});
+  return at::native::set_cpu_(result, storage, 0, {0}, {});
 }
 
 std::vector<Tensor> broadcast_tensors(TensorList tensors) {

--- a/aten/src/ATen/native/TensorShape.h
+++ b/aten/src/ATen/native/TensorShape.h
@@ -1,0 +1,11 @@
+#pragma once
+#include <ATen/Tensor.h>
+
+namespace at {
+namespace native {
+
+TORCH_API void set_tensor_storage(const Tensor& tensor, at::Storage storage, ptrdiff_t storage_offset);
+Tensor& set_cpu_(Tensor& self, Storage storage, ptrdiff_t storage_offset, IntArrayRef size, IntArrayRef stride);
+Tensor& set_cpu_(Tensor& self);
+
+}} // at::native

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3799,7 +3799,7 @@
   variants: method
   device_guard: False
   dispatch:
-    CPU: legacy::cpu::_th_set_
+    CPU: set_cpu_
     CUDA: legacy::cuda::_th_set_
     QuantizedCPU: set_storage
 

--- a/aten/src/TH/THTensor.hpp
+++ b/aten/src/TH/THTensor.hpp
@@ -104,9 +104,6 @@ inline std::vector<int64_t> THTensor_stridesLegacyNoScalars(const THTensor *self
   }
 }
 
-// NB: Steals ownership of storage
-TH_API void THTensor_stealAndSetStoragePtr(THTensor* tensor, THStorage* storage);
-
 TH_API void THTensor_free(THTensor *self);
 TH_API void THTensor_setStorageNd(THTensor *self, THStorage *storage, ptrdiff_t storageOffset, int nDimension, const int64_t *size, const int64_t *stride);
 TH_API void THTensor_resizeNd(THTensor *self, int nDimension, const int64_t *size, const int64_t *stride);

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -5146,7 +5146,7 @@ tensor([[[1., 1., 1.,  ..., 1., 1., 1.],
                 t.set_()
             with self.assertRaisesRegex(
                     RuntimeError,
-                    "set_storage_offset is not allowed on a Tensor created from .data or .detach()"):
+                    "set_storage is not allowed on a Tensor created from .data or .detach()"):
                 t.set_(t.storage(), 0, t.size(), list(t.stride()))
 
         do_test(torch.tensor([[1, 2]]).data)


### PR DESCRIPTION
Closes #24759

For whatever reason, the `TH` code actually calls back and forth between `TH` and `ATen` quite a bit. Particularly `maybe_resize_storage_cpu` which is more like `TH` code, even though it's in the `at::native` namespace. 

I've tried move all the core logic into `ATen`, leaving only a few thin wrappers in `TH`.