### PR TITLE
Run RPC JIT tests with variable type hints only in Python >=3.6

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -80,7 +80,6 @@ if PY33:
         'distributed/rpc/test_rpc_spawn',
         'distributed/rpc/test_dist_autograd_spawn',
         'distributed/rpc/test_dist_optimizer_spawn',
-        'distributed/rpc/jit/test_rpc_spawn',
         'distributed/rpc/jit/test_dist_autograd_spawn',
     ])
 
@@ -88,6 +87,7 @@ if PY33:
 if PY36:
     TESTS.extend([
         'test_jit_py3',
+        'distributed/rpc/jit/test_rpc_spawn',
     ])
 
 WINDOWS_BLACKLIST = [


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#34284 Run RPC JIT tests with variable type hints only in Python >=3.6**

Python 3.5 only supports function type hints.
Variable type hints are introduced in Python 3.6.
So these tests with JIT type hints will fail with "Syntax Error" in Python 3.5 environment.

Differential Revision: [D7348891](https://our.internmc.facebook.com/intern/diff/D7348891/)