### PR TITLE
Fix #33562 (uncaught domain_error on macOS)

### DIFF
--- a/aten/src/ATen/test/scalar_test.cpp
+++ b/aten/src/ATen/test/scalar_test.cpp
@@ -41,15 +41,15 @@ void test_overflow() {
   ASSERT_EQ(s1.toFloat(), 100000.0);
   ASSERT_EQ(s1.toInt(), 100000);
 
-  ASSERT_THROW(s1.toHalf(), std::domain_error);
+  ASSERT_THROW(s1.toHalf(), std::runtime_error);
 
   s1 = Scalar(NAN);
   ASSERT_TRUE(std::isnan(s1.toFloat()));
-  ASSERT_THROW(s1.toInt(), std::domain_error);
+  ASSERT_THROW(s1.toInt(), std::runtime_error);
 
   s1 = Scalar(INFINITY);
   ASSERT_TRUE(std::isinf(s1.toFloat()));
-  ASSERT_THROW(s1.toInt(), std::domain_error);
+  ASSERT_THROW(s1.toInt(), std::runtime_error);
 }
 
 TEST(TestScalar, TestScalar) {

--- a/c10/util/TypeCast.h
+++ b/c10/util/TypeCast.h
@@ -180,7 +180,7 @@ To checked_convert(From f, const char* name) {
     std::ostringstream oss;
     oss << "value cannot be converted to type " << name
         << " without overflow: " << f;
-    throw std::domain_error(oss.str());
+    throw std::runtime_error(oss.str());  // rather than domain_error (issue 33562)
   }
   return convert<To, From>(f);
 }


### PR DESCRIPTION
Tries to fix #33562 by raising `std::runtime_error` instead of `std::domain_error`.
* The Python tests already expect `RuntimeError` so this shouldn't affect Python users of PyTorch.
* If someone out there is using C10 or ATen from C++ and tries to catch `std::domain_error` or `std::logic_error` specifically, this fix would break their code. Hopefully that's not the case.

Alternative to this PR is someone try to really get to the bottom of why `std::domain_error` isn't being caught.