### PR TITLE
Remove unnecessary assert in autograd engine

### DIFF
--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -326,9 +326,7 @@ auto Engine::thread_main(
     // for reentrant execution.
     std::shared_ptr<GraphTask> local_graph_task;
     if (!(local_graph_task = task.base_.lock())) {
-      // Reentrant thread's graph task should not expire since we hold a
-      // reference to it in this method.
-      TORCH_INTERNAL_ASSERT(!reentrant_thread);
+      // If the task's graph_task expired, just ignore the task.
       LOG(INFO) << "GraphTask for function " << task.fn_->name()
                 << " is no longer valid, skipping execution";
       continue;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#34307 Remove unnecessary assert in autograd engine**

This is valid when:
- The thread currently running is a re-entrant thread
- The original backward fails and so it's graph_task is reset
- The reentrant worker thread gets a task from the original backward.

Differential Revision: [D20283401](https://our.internmc.facebook.com/intern/diff/D20283401)