### PR TITLE
pt benchmarks: update readme with missing step

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -19,6 +19,10 @@ python setup.py build develop
 
 # Check the pytorch installation version
 python -c "import torch; print(torch.__version__)"
+
+# If you are running operator benchmarks, install cpp_extension
+cd $PYTORCH_HOME/benchmarks/operator_benchmark/pt_extension
+python setup.py install
 ```
 
 ## Benchmark List


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#34310 pt benchmarks: update readme with missing step**

Summary:

Adds a missing step to the benchmark environment setup README

Test Plan:

After following this additional step, benchmarking operators works
without errors

Reviewers:

Subscribers:

Tasks:

Tags: