### PR TITLE
add dtype attributes is_integral and is_quantized.

### DIFF
--- a/docs/source/tensor_attributes.rst
+++ b/docs/source/tensor_attributes.rst
@@ -31,8 +31,9 @@ Data type                  dtype                                         Tensor 
 Boolean                    ``torch.bool``                                ``torch.*.BoolTensor``
 ========================   ===========================================   ===========================
 
-To find out if a :class:`torch.dtype` is a floating point data type, the property :attr:`is_floating_point`
-can be used, which returns ``True`` if the data type is a floating point data type.
+Properties :attr:`is_floating_point`, :attr:`is_signed`, :attr:`is_integral`, :attr:`is_quantized`, and
+:attr:`is_complex` can be used to find information about the data type represented
+by a :class:`torch.dtype`.
 
 .. _type-promotion-doc:
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2439,13 +2439,25 @@ class _TestTorchMixin(object):
         x = torch.Tensor([1, nan, 2])
         self.assertEqual(torch.isnan(x), torch.tensor([False, True, False]))
 
-    def test_dtype_is_signed(self):
-        for dtype in torch.testing.get_all_dtypes():
-            self.assertEqual(dtype.is_signed, torch.is_signed(torch.tensor(0, dtype=dtype)))
+    def test_dtype_attributes(self):
+        qtypes = [torch.quint8, torch.qint8, torch.qint32]
+        for t in qtypes:
+            self.assertEqual(t.is_quantized, True)
 
         self.assertRaisesRegex(RuntimeError, 'not supported for quantized', lambda: torch.quint8.is_signed)
         self.assertRaisesRegex(RuntimeError, 'not supported for quantized', lambda: torch.qint8.is_signed)
         self.assertRaisesRegex(RuntimeError, 'not supported for quantized', lambda: torch.qint32.is_signed)
+
+        for dtype in torch.testing.get_all_dtypes():
+            example = torch.tensor(0, dtype=dtype)
+            self.assertEqual(dtype.is_signed, torch.is_signed(example))
+            # There are currently no quantized or complex types in get_all_dtypes.
+            self.assertEqual(dtype.is_quantized, False)
+            self.assertEqual(dtype.is_complex, False)
+            if dtype==torch.bool:
+                self.assertEqual(dtype.is_integral, False)
+            else:
+                self.assertEqual(dtype.is_floating_point, not dtype.is_integral)
 
     def test_RNGState(self):
         state = torch.get_rng_state()

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2454,7 +2454,7 @@ class _TestTorchMixin(object):
             # There are currently no quantized or complex types in get_all_dtypes.
             self.assertEqual(dtype.is_quantized, False)
             self.assertEqual(dtype.is_complex, False)
-            if dtype==torch.bool:
+            if dtype == torch.bool:
                 self.assertEqual(dtype.is_integral, False)
             else:
                 self.assertEqual(dtype.is_floating_point, not dtype.is_integral)

--- a/torch/csrc/Dtype.cpp
+++ b/torch/csrc/Dtype.cpp
@@ -33,7 +33,7 @@ PyObject *THPDtype_is_floating_point(THPDtype *self, PyObject *noargs)
 
 PyObject *THPDtype_is_integral(THPDtype *self, PyObject *noargs)
 {
-  if (at::isIntegralType(self->scalar_type, /* include_bool=*/false)) {
+  if (at::isIntegralType(self->scalar_type, /* includeBool=*/false)) {
     Py_RETURN_TRUE;
   } else {
     Py_RETURN_FALSE;

--- a/torch/csrc/Dtype.cpp
+++ b/torch/csrc/Dtype.cpp
@@ -31,6 +31,24 @@ PyObject *THPDtype_is_floating_point(THPDtype *self, PyObject *noargs)
   }
 }
 
+PyObject *THPDtype_is_integral(THPDtype *self, PyObject *noargs)
+{
+  if (at::isIntegralType(self->scalar_type, /* include_bool=*/false)) {
+    Py_RETURN_TRUE;
+  } else {
+    Py_RETURN_FALSE;
+  }
+}
+
+PyObject *THPDtype_is_quantized(THPDtype *self, PyObject *noargs)
+{
+  if (at::isQIntType(self->scalar_type)) {
+    Py_RETURN_TRUE;
+  } else {
+    Py_RETURN_FALSE;
+  }
+}
+
 PyObject *THPDtype_is_complex(THPDtype *self, PyObject *noargs)
 {
   if (at::isComplexType(self->scalar_type)) {
@@ -64,6 +82,8 @@ typedef PyObject *(*getter)(PyObject *, void *);
 
 static struct PyGetSetDef THPDtype_properties[] = {
   {"is_floating_point", (getter)THPDtype_is_floating_point, nullptr, nullptr, nullptr},
+  {"is_quantized", (getter)THPDtype_is_quantized, nullptr, nullptr, nullptr},
+  {"is_integral", (getter)THPDtype_is_integral, nullptr, nullptr, nullptr},
   {"is_complex", (getter)THPDtype_is_complex, nullptr, nullptr, nullptr},
   {"is_signed", (getter)THPDtype_is_signed, nullptr, nullptr, nullptr},
   {nullptr}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#34312 add dtype attributes is_integral and is_quantized.**

Adding dtype type attributes because they are handy in unit testing.

I want to keep `is_integral` simple (no parameters), and we have to decide if it should include boolean. I'd prefer to include it, but went with excluding it to be consistent with documentation where we have "categories" of types described as:

```
* If the type of a scalar operand is of a higher category than tensor operands
  (where floating > integral > boolean), we promote to a type with sufficient size to hold
  all scalar operands of that category.
```

I'm open to arguments for having it include boolean though.
