### PR TITLE
[AMD] Remove num_gpu check for remote execution

### DIFF
--- a/caffe2/python/_import_c_extension.py
+++ b/caffe2/python/_import_c_extension.py
@@ -31,9 +31,11 @@ with extension_loader.DlopenGuard():
         logging.info('Failed to import cuda module: {}'.format(gpu_e))
         try:
             from caffe2.python.caffe2_pybind11_state_hip import *  # noqa
-            if num_hip_devices():
-                has_gpu_support = has_hip_support = True
-                logging.info('This caffe2 python run has AMD GPU support!')
+            # we stop checking whether we have AMD GPU devices on the host,
+            # because we may be constructing a net on a machine without GPU,
+            # and run the net on another one with GPU
+            has_gpu_support = has_hip_support = True
+            logging.info('This caffe2 python run has AMD GPU support!')
         except ImportError as hip_e:
             logging.info('Failed to import AMD hip module: {}'.format(hip_e))
 


### PR DESCRIPTION
Summary: Stop checking whether we have AMD GPU devices on the host, because we may be constructing a net on a machine without GPU, and run the net on another one with GPU

Reviewed By: ajauhri

Differential Revision: D20269562

