### PR TITLE
[jit] Make `ModuleList`s a sugared value

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -10393,8 +10393,6 @@ a")
                 return thing - self.i
 
         class M(torch.nn.Module):
-            __constants__ = ['mods']
-
             def __init__(self):
                 super(M, self).__init__()
                 self.mods = nn.ModuleList([Sub(i) for i in range(10)])
@@ -10407,6 +10405,19 @@ a")
 
         x = torch.tensor(1)
         self.checkModule(M(), (x,))
+
+        class MForward(torch.nn.Module):
+            def __init__(self):
+                super(MForward, self).__init__()
+                self.mods = nn.ModuleList([Sub(i) for i in range(10)])
+
+            def forward(self, v):
+                v = self.mods[4](v)
+                v = self.mods[-1](v)
+                v = self.mods[-9](v)
+                return v
+
+        self.checkModule(MForward(), (torch.tensor(1),))
 
         class M2(M):
             def __init__(self):

--- a/torch/csrc/jit/frontend/ir_emitter.cpp
+++ b/torch/csrc/jit/frontend/ir_emitter.cpp
@@ -2660,6 +2660,9 @@ struct to_ir {
         auto apply = Apply(tree);
         return emitApplyExpr(apply, n_binders, type_hint);
       } break;
+      case TK_SUBSCRIPT: {
+        return emitSubscript(Subscript(tree));
+      } break;
       default:
         return std::make_shared<SimpleValue>(emitSimpleExpr(tree, type_hint));
     }
@@ -2910,9 +2913,6 @@ struct to_ir {
       } break;
       case TK_NONE: {
         return graph->insertConstant(IValue(), tree->range());
-      } break;
-      case TK_SUBSCRIPT: {
-        return emitSubscript(Subscript(tree));
       } break;
       case TK_IF_EXPR: {
         return emitTernaryIf(TernaryIf(tree));
@@ -3393,18 +3393,18 @@ struct to_ir {
         ->output();
   }
 
-  Value* emitSubscript(const Subscript& subscript) {
+  std::shared_ptr<SugaredValue> emitSubscript(const Subscript& subscript) {
     const SugaredValuePtr sv = emitSugaredExpr(subscript.value(), 1);
     const List<Expr>& subscript_exprs = subscript.subscript_exprs();
     const SourceRange& range = subscript.range();
     const SourceRange& val_range = subscript.value().range();
     if (subscript_exprs.size() != 1) {
-      return emitMultidimSlicing(
-          range, sv->asValue(val_range, method), subscript_exprs);
+      return std::make_shared<SimpleValue>(emitMultidimSlicing(
+          range, sv->asValue(val_range, method), subscript_exprs));
     }
     if (subscript_exprs[0].kind() == TK_SLICE_EXPR) {
-      return emitBasicSlice(
-          range, sv->asValue(val_range, method), subscript_exprs);
+      return std::make_shared<SimpleValue>(emitBasicSlice(
+          range, sv->asValue(val_range, method), subscript_exprs));
     } else {
       // Desugars gather syntactic sugar foo[i]
       Value* idx = emitExpr(subscript_exprs[0]);
@@ -3412,11 +3412,13 @@ struct to_ir {
       AT_ASSERT(subscript_exprs.size() == 1);
 
       if (val->type()->cast<TupleType>()) {
-        return emitTupleIndex(range, sv->asValue(val_range, method), idx);
+        return std::make_shared<SimpleValue>(
+            emitTupleIndex(range, sv->asValue(val_range, method), idx));
       } else if (val->type()->isSubtypeOf(TensorType::get())) {
-        return emitMultidimSlicing(range, val, subscript_exprs);
+        return std::make_shared<SimpleValue>(
+            emitMultidimSlicing(range, val, subscript_exprs));
       } else {
-        return sv->getitem(range, method, idx)->asValue(range, method);
+        return sv->getitem(range, method, idx);
       }
     }
   }

--- a/torch/csrc/jit/python/python_sugared_value.cpp
+++ b/torch/csrc/jit/python/python_sugared_value.cpp
@@ -227,7 +227,7 @@ SugaredValuePtr ModuleValue::getitem(
     return getSugaredModuleDict(loc, m)->getModules()->getitem(loc, m, idx);
   }
   throw ErrorReport(loc)
-      << "Only ModuleLists, Sequentials, and ModuleDict Modules are subscriptable";
+      << "Only ModuleList, Sequential, and ModuleDict modules are subscriptable";
 }
 
 void recurseThroughNestedModules(


### PR DESCRIPTION
Previously when emitting subscripts we only emitted actual values, but
now they may sometimes emit a `ModuleValue`, so it should stay as a
`SugaredValue`. This allows for the result of the subscript to be
treated as a real module (i.e. you can just do `self.modlist[1](inputs)`
instead of `self.modlist[1].forward(inputs)`)

Differential Revision: [D20345642](https://our.internmc.facebook.com/intern/diff/20345642/)