### PR TITLE
convert counter to dict for simple serialization

### DIFF
--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -386,7 +386,7 @@ class MultiStepLR(_LRScheduler):
     """
 
     def __init__(self, optimizer, milestones, gamma=0.1, last_epoch=-1):
-        self.milestones = Counter(milestones)
+        self.milestones = dict(Counter(milestones))
         self.gamma = gamma
         super(MultiStepLR, self).__init__(optimizer, last_epoch)
 

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -4,7 +4,7 @@ from torch._six import inf
 from functools import wraps
 import warnings
 import weakref
-from collections import Counter
+from collections import Counter, OrderedDict
 from bisect import bisect_right
 
 from .optimizer import Optimizer
@@ -386,7 +386,7 @@ class MultiStepLR(_LRScheduler):
     """
 
     def __init__(self, optimizer, milestones, gamma=0.1, last_epoch=-1):
-        self.milestones = dict(Counter(milestones))
+        self.milestones = OrderedDict(Counter(sorted(milestones)))
         self.gamma = gamma
         super(MultiStepLR, self).__init__(optimizer, last_epoch)
 


### PR DESCRIPTION
Following [comment](https://github.com/pytorch/pytorch/issues/33229#issuecomment-589343826), a counter is harder to serialize than a dictionary.

* The ordering is needed only for the closed form, in anticipation of #34325.
* OrderedDict is needed for python 2.7.

This is bc-breaking since users may have serialized Counter objects to save the state.