### PR TITLE
[JIT interpreter fix] Disable interpreter inline for Fusion

### DIFF
--- a/torch/csrc/jit/runtime/interpreter.cpp
+++ b/torch/csrc/jit/runtime/interpreter.cpp
@@ -252,6 +252,8 @@ struct CanEmitInline {
            // instruction stack
            // by the later BailOut in createBailoutBlock and its jf_index
            // will become invalid.
+           v->node()->kind() != prim::FusionGroup &&
+           v->node()->kind() != prim::CudaFusionGroup &&
            v->node()->kind() != prim::BailOut && v->uses().size() == 1 &&
            v->node()->outputs().size() == 1;
   }


### PR DESCRIPTION
Inlining fusion node is NOT an optimization.