### PR TITLE
Enable RTTI for mobile builds, to enable custom class via torchbind in mobile

### DIFF
--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -701,8 +701,6 @@ struct TORCH_API StrongTypePtr {
 
 TORCH_API std::unordered_map<std::string, c10::ClassTypePtr>& getCustomClassTypeMap();
 
-#ifndef C10_MOBILE
-
 template<typename T>
 c10::ClassTypePtr getCustomClassType() {
   auto tmap = c10::getCustomClassTypeMap();
@@ -718,20 +716,6 @@ inline bool isCustomClassRegistered() {
   auto tmap = c10::getCustomClassTypeMap();
   return tmap.find(typeid(T).name()) != tmap.end();
 }
-
-#else  // C10_MOBILE
-
-template<typename T>
-c10::ClassTypePtr getCustomClassType() {
-  throw c10::Error("Custom class is not supported on mobile.", "");
-}
-
-template<typename T>
-inline bool isCustomClassRegistered() {
-  return false;
-}
-
-#endif  // C10_MOBILE
 
 TORCH_API std::unordered_map<std::string, std::function<PyObject*(void*)>>&
 getClassConverter();


### PR DESCRIPTION
Summary:
Custom classes via torchbind requires runtime type information.
We are trying to enable custom class based graph rewrite for XNNPACK in
this stacked PRs: https://github.com/pytorch/pytorch/pull/34047.
They require RTTI enabled for mobile. Mobile builds are failing
currently without it.

Test Plan:
Build pytorch_linux_xenial_py3_clang5_mobile_custom_build_static fails for this PR: https://github.com/pytorch/pytorch/pull/34047, with following error:
```
Mar 06 15:57:06 + ./Predictor /var/lib/jenkins/workspace/build_test_custom_build/MobileNetV2.pt
Mar 06 15:57:06 terminate called after throwing an instance of 'c10::Error'
Mar 06 15:57:06   what():  Type could not be converted to any of the known types.
```
Current PR fixes that.


Reviewers:

Subscribers:

Tasks:

Tags:

