### PR TITLE
[testing]

### DIFF
--- a/aten/src/ATen/test/backend_fallback_test.cpp
+++ b/aten/src/ATen/test/backend_fallback_test.cpp
@@ -128,6 +128,19 @@ TEST(BackendFallbackTest, TestBackendFallbackWithWrapper) {
       DispatchKey::TESTING_ONLY_GenericWrapperTensorId,
       KernelFunction::makeFromBoxedFunction<&generic_wrapper_fallback>()
   );
+  auto registry2 = torch::RegisterOperators()
+      .op(torch::RegisterOperators::options()
+      .schema("aten::conv2d(Tensor input, Tensor weight, Tensor? bias=None, int[2] stride=1, int[2] padding=0, int[2] dilation=1, int groups=1) -> Tensor")
+      .kernel(DispatchKey::TESTING_ONLY_GenericWrapperTensorId,
+              [] (const Tensor& input,
+                  const Tensor& weight,
+                  const Tensor& bias,
+                  IntArrayRef stride,
+                  IntArrayRef padding,
+                  IntArrayRef dilation,
+                  int64_t groups) -> Tensor {
+          return input
+      }));
 
   override_call_count = 0;
   Tensor a = at::detail::make_tensor<GenericWrapperTensorImpl>(ones({5, 5}, kDouble));


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#34370 [testing]**

Registering a kernel for conv2d for
DispatchKey::testing_only_GenericWrapperTensorId fails with:
https://gist.github.com/zou3519/2762c2b6f1f1e9d31822aefc60351758

I'm not really sure what is up here. The original native_functions.yaml
declaration says:
https://github.com/pytorch/pytorch/blob/a7da4490cc44fc9d9740ed508ad5048cbdca9e10/aten/src/ATen/native/native_functions.yaml#L776
and the signature of the function looks correct:
https://github.com/pytorch/pytorch/blob/a7da4490cc44fc9d9740ed508ad5048cbdca9e10/aten/src/ATen/native/Convolution.cpp#L504-L509