### PR TITLE
[caffe2] SWA operator

### DIFF
--- a/caffe2/python/optimizer.py
+++ b/caffe2/python/optimizer.py
@@ -437,7 +437,7 @@ class FP16SgdOptimizer(SgdOptimizer):
                     param = param_info.blob_copy[core.DataType.FLOAT16]
                     param_fp32 = param_info.blob
                 else:
-                    assert (False), (
+                    AssertionError(
                         "Unrecognized parameter format to be updated "
                         "by FP16 Optimizer. Parameter: {}".format(param_info.name)
                     )
@@ -520,7 +520,7 @@ class AdagradOptimizer(Optimizer):
                  sparse_dedup_aggregator=None, rowWise=False, engine='',
                  lars=None, output_effective_lr=False,
                  output_effective_lr_and_update=False,
-                 pruning_options=None, **kwargs):
+                 pruning_options=None, swa_options=None, **kwargs):
         super(AdagradOptimizer, self).__init__()
         self.alpha = alpha
         self.epsilon = epsilon
@@ -535,6 +535,16 @@ class AdagradOptimizer(Optimizer):
         self.init_kwargs = kwargs
 
         self._process_pruning_options(pruning_options)
+        self._process_swa_options(swa_options)
+
+    def _process_swa_options(self, swa_options):
+        self.swa_enabled = True if swa_options else False
+        if self.swa_enabled:
+            self.swa_avg_start_it = swa_options.get("swa_avg_start_it", None)
+            self.swa_avg_end_it = swa_options.get("swa_avg_end_it", None)
+            self.swa_feedback_start_it = swa_options.get("swa_feedback_start_it", None)
+            self.swa_feedback_step = swa_options.get("swa_feedback_step", None)
+            self.swa_feedback_end_it = swa_options.get("swa_feedback_end_it", None)
 
     def _process_pruning_options(self, pruning_options):
         self.use_mask = False
@@ -598,7 +608,7 @@ class AdagradOptimizer(Optimizer):
                     and core.IsGPUDeviceType(current_scope.device_type)),
             )
 
-        lr, _ = self.build_lr(
+        lr, iteration = self.build_lr(
             net, param_init_net,
             base_learning_rate=self.alpha,
             policy=self.policy,
@@ -730,6 +740,24 @@ class AdagradOptimizer(Optimizer):
                     decay=float(self.decay),
                     engine=self.engine
                 )
+
+                if self.swa_enabled:
+                    param_swa = str(param) + "_swa"
+                    if not param_init_net.BlobIsDefined(param_swa):
+                        param_init_net.ConstantFill(
+                            [param], param_swa, value=0.0, 
+                        )
+                        self._aux_params.local.append(param_swa)  
+
+                    net.SWA(
+                        [param, param_swa, iteration],
+                        [param, param_swa],
+                        avg_start=self.swa_avg_start_it,
+                        avg_end=self.swa_avg_end_it,
+                        feedback_start=self.swa_feedback_start_it,
+                        feedback_step=self.swa_feedback_step,
+                        feedback_end=self.swa_feedback_end_it,
+                    )
 
     def scale_learning_rate(self, scale):
         self.alpha *= scale


### PR DESCRIPTION
Summary:
# SWA operator
In this diff, we added a new operator `SWA` which will be used in `AdaGradOptimizer`.

The algorithm looks like:

{F230902995}

# Background

In our testings, we found that this operator could improve our models' reproducibility a lot. (KT: 0.86 -> .92)

So we hope to land this operator and in future, enable this by default in our Models.

Test Plan:
Local build `aml.dper3 pkg`(4db9060d598a49e28ca983e6aaac4a3d) and `Dper3` bento kernel.
- Local test: n213184
- Testing flow:
  - V8: f173326189
  - V4: f173097225

FBPKG:
  - v8: `aml.dper3:4db9060d598a49e28ca983e6aaac4a3d`
  - v4: `aml.dper3:abaf67ef14fd41d68147ee4060485f61`

Differential Revision: D20165239

