### PR TITLE
indexing: throw exception for masks with dtype=uint8

### DIFF
--- a/aten/src/ATen/native/IndexingUtils.h
+++ b/aten/src/ATen/native/IndexingUtils.h
@@ -11,15 +11,16 @@ static void invalid_mask(const Tensor & self, int64_t idx, const Tensor & mask, 
 
 
 static std::vector<Tensor> expandTensors(const Tensor & self, TensorList indices) {
-  // If indices come in as ByteTensor or BoolTensor (masks), expand them into the equivalent indexing by LongTensors
+  // If indices come in a BoolTensor (masks), expand them into the equivalent
+  // indexing by LongTensors
   std::vector<Tensor> result;
   for (const auto & index : indices) {
-    if (index.scalar_type() == kByte || index.scalar_type() == kBool) {
-      if (index.scalar_type() == kByte) {
-        TORCH_WARN("indexing with dtype torch.uint8 is now deprecated," \
-        " please use a dtype torch.bool instead.");
-      }
-      // The sizes of the ByteTensor mask or bool tensor must match the sizes of the
+    TORCH_CHECK(index.scalar_type() != kByte, 
+        "indexing with dtype torch.uint8 is no longer supported,",
+        " please use dtype torch.bool for a mask or dtype torch.long for",
+        " indices");
+    if (index.scalar_type() == kBool) {
+      // The sizes of the bool tensor mask must match the sizes of the
       // corresponding dimensions in self
       for (int64_t j = 0; j < index.dim(); j++) {
         int64_t srcIdx = result.size() + j;

--- a/aten/src/ATen/native/TensorAdvancedIndexing.cpp
+++ b/aten/src/ATen/native/TensorAdvancedIndexing.cpp
@@ -183,7 +183,7 @@ AdvancedIndex::AdvancedIndex(const Tensor& src, TensorList indices_list)
 
 static AdvancedIndex make_info(Tensor self, TensorList orig) {
   checkIndexTensorTypes(orig);
-  // first expand BoolTensor (masks) or ByteTensor (masks) into 1 or more LongTensors
+  // first expand BoolTensor (masks) into 1 or more LongTensors
   auto indices = expandTensors(self, orig);
   // next broadcast all index tensors together
   try {

--- a/aten/src/ATen/native/cuda/Indexing.cu
+++ b/aten/src/ATen/native/cuda/Indexing.cu
@@ -157,7 +157,7 @@ computeLinearIndex(const Tensor & src, TensorList indices, bool check_range) {
 
 static std::tuple<Tensor, Tensor, int64_t, int64_t, int64_t, std::vector<int64_t>> makeLinearIndex(Tensor self, TensorList orig, bool check_range) {
   checkIndexTensorTypes(orig);
-  // first expand BoolTensor (masks) or ByteTensor (masks) into 1 or more LongTensors
+  // first expand BoolTensor (masks) into 1 or more LongTensors
   auto indices = expandTensors(self, orig);
   // next broadcast all index tensors together
   indices = expand_outplace(indices);

--- a/aten/src/ATen/native/cuda/Indexing.cu
+++ b/aten/src/ATen/native/cuda/Indexing.cu
@@ -157,6 +157,7 @@ computeLinearIndex(const Tensor & src, TensorList indices, bool check_range) {
 
 static std::tuple<Tensor, Tensor, int64_t, int64_t, int64_t, std::vector<int64_t>> makeLinearIndex(Tensor self, TensorList orig, bool check_range) {
   checkIndexTensorTypes(orig);
+
   // first expand BoolTensor (masks) into 1 or more LongTensors
   auto indices = expandTensors(self, orig);
   // next broadcast all index tensors together

--- a/aten/src/ATen/native/cuda/Indexing.cu
+++ b/aten/src/ATen/native/cuda/Indexing.cu
@@ -157,7 +157,6 @@ computeLinearIndex(const Tensor & src, TensorList indices, bool check_range) {
 
 static std::tuple<Tensor, Tensor, int64_t, int64_t, int64_t, std::vector<int64_t>> makeLinearIndex(Tensor self, TensorList orig, bool check_range) {
   checkIndexTensorTypes(orig);
-
   // first expand BoolTensor (masks) into 1 or more LongTensors
   auto indices = expandTensors(self, orig);
   // next broadcast all index tensors together

--- a/test/cpp/api/tensor_indexing.cpp
+++ b/test/cpp/api/tensor_indexing.cpp
@@ -156,18 +156,8 @@ TEST(TensorIndexingTest, TestBoolIndices) {
   {
     auto v = torch::tensor({true, false, true}, torch::kBool);
     auto boolIndices = torch::tensor({true, false, false}, torch::kBool);
-    auto uint8Indices = torch::tensor({1, 0, 0}, torch::kUInt8);
 
-    {
-      std::stringstream buffer;
-      CerrRedirect cerr_redirect(buffer.rdbuf());
-
-      ASSERT_EQ(v.index({boolIndices}).sizes(), v.index({uint8Indices}).sizes());
-      assert_tensor_equal(v.index({boolIndices}), v.index({uint8Indices}));
-      assert_tensor_equal(v.index({boolIndices}), torch::tensor({true}, torch::kBool));
-
-      ASSERT_EQ(count_substr_occurrences(buffer.str(), "indexing with dtype torch.uint8 is now deprecated"), 2);
-    }
+    assert_tensor_equal(v.index({boolIndices}), torch::tensor({true}, torch::kBool));
   }
 }
 
@@ -187,19 +177,12 @@ TEST(TensorIndexingTest, TestMultipleBoolIndices) {
   ASSERT_EQ(v.index({mask1, Slice(), mask2}).sizes(), torch::IntArrayRef({3, 7}));
 }
 
-TEST(TensorIndexingTest, TestByteMask) {
+TEST(TensorIndexingTest, TestBoolMask) {
   {
     auto v = torch::randn({5, 7, 3});
-    auto mask = torch::tensor({1, 0, 1, 1, 0}, torch::kByte);
-    {
-      std::stringstream buffer;
-      CerrRedirect cerr_redirect(buffer.rdbuf());
-
-      ASSERT_EQ(v.index({mask}).sizes(), torch::IntArrayRef({3, 7, 3}));
-      assert_tensor_equal(v.index({mask}), torch::stack({v[0], v[2], v[3]}));
-
-      ASSERT_EQ(count_substr_occurrences(buffer.str(), "indexing with dtype torch.uint8 is now deprecated"), 2);
-    }
+    auto mask = torch::tensor({1, 0, 1, 1, 0}, torch::kBool);
+    ASSERT_EQ(v.index({mask}).sizes(), torch::IntArrayRef({3, 7, 3}));
+    assert_tensor_equal(v.index({mask}), torch::stack({v[0], v[2], v[3]}));
   }
   {
     auto v = torch::tensor({1.});
@@ -207,33 +190,20 @@ TEST(TensorIndexingTest, TestByteMask) {
   }
 }
 
-TEST(TensorIndexingTest, TestByteMaskAccumulate) {
-  auto mask = torch::zeros({10}, torch::kUInt8);
+TEST(TensorIndexingTest, TestBoolMaskAccumulate) {
+  auto mask = torch::zeros({10}, torch::kBool);
   auto y = torch::ones({10, 10});
-  {
-    std::stringstream buffer;
-    CerrRedirect cerr_redirect(buffer.rdbuf());
-
-    y.index_put_({mask}, y.index({mask}), /*accumulate=*/true);
-    assert_tensor_equal(y, torch::ones({10, 10}));
-
-    ASSERT_EQ(count_substr_occurrences(buffer.str(), "indexing with dtype torch.uint8 is now deprecated"), 2);
-  }
+  y.index_put_({mask}, y.index({mask}), /*accumulate=*/true);
+  assert_tensor_equal(y, torch::ones({10, 10}));
 }
 
-TEST(TensorIndexingTest, TestMultipleByteMask) {
+TEST(TensorIndexingTest, TestMultipleBoolMask) {
   auto v = torch::randn({5, 7, 3});
   // note: these broadcast together and are transposed to the first dim
-  auto mask1 = torch::tensor({1, 0, 1, 1, 0}, torch::kByte);
-  auto mask2 = torch::tensor({1, 1, 1}, torch::kByte);
-  {
-    std::stringstream buffer;
-    CerrRedirect cerr_redirect(buffer.rdbuf());
+  auto mask1 = torch::tensor({1, 0, 1, 1, 0}, torch::kBool);
+  auto mask2 = torch::tensor({1, 1, 1}, torch::kBool);
 
-    ASSERT_EQ(v.index({mask1, Slice(), mask2}).sizes(), torch::IntArrayRef({3, 7}));
-
-    ASSERT_EQ(count_substr_occurrences(buffer.str(), "indexing with dtype torch.uint8 is now deprecated"), 2);
-  }
+  ASSERT_EQ(v.index({mask1, Slice(), mask2}).sizes(), torch::IntArrayRef({3, 7}));
 }
 
 TEST(TensorIndexingTest, TestByteMask2d) {
@@ -538,14 +508,7 @@ TEST(TensorIndexingTest, TestByteTensorAssignment) {
   auto b = torch::tensor({true, false, true, false}, torch::kBool);
   auto value = torch::tensor({3., 4., 5., 6.});
 
-  {
-    std::stringstream buffer;
-    CerrRedirect cerr_redirect(buffer.rdbuf());
-
-    x.index_put_({b}, value);
-
-    ASSERT_EQ(count_substr_occurrences(buffer.str(), "indexing with dtype torch.uint8 is now deprecated"), 1);
-  }
+  x.index_put_({b}, value);
 
   assert_tensor_equal(x.index({0}), value);
   assert_tensor_equal(x.index({1}), torch::arange(4, 8).to(torch::kLong));
@@ -703,17 +666,6 @@ TEST(NumpyTests, TestBooleanShapeMismatch) {
 
   index = torch::tensor({false, false, false, false, false, false});
   ASSERT_THROWS_WITH(arr.index({index}), "mask");
-
-  {
-    std::stringstream buffer;
-    CerrRedirect cerr_redirect(buffer.rdbuf());
-
-    index = torch::empty({4, 4}, torch::kByte).zero_();
-    ASSERT_THROWS_WITH(arr.index({index}), "mask");
-    ASSERT_THROWS_WITH(arr.index({Slice(), index}), "mask");
-
-    ASSERT_EQ(count_substr_occurrences(buffer.str(), "indexing with dtype torch.uint8 is now deprecated"), 2);
-  }
 }
 
 TEST(NumpyTests, TestBooleanIndexingOnedim) {

--- a/test/cpp/api/tensor_indexing.cpp
+++ b/test/cpp/api/tensor_indexing.cpp
@@ -535,7 +535,7 @@ TEST(TensorIndexingTest, TestIntAssignment) {
 
 TEST(TensorIndexingTest, TestByteTensorAssignment) {
   auto x = torch::arange(0., 16).to(torch::kFloat).view({4, 4});
-  auto b = torch::tensor({true, false, true, false}, torch::kByte);
+  auto b = torch::tensor({true, false, true, false}, torch::kBool);
   auto value = torch::tensor({3., 4., 5., 6.});
 
   {

--- a/test/onnx/test_pytorch_onnx_caffe2.py
+++ b/test/onnx/test_pytorch_onnx_caffe2.py
@@ -693,7 +693,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
     @skipIfUnsupportedMinOpsetVersion(9)
     def test_tensor_index_advanced_indexing_masked(self):
         self._test_index_generic(
-            lambda input: input[:, torch.tensor([1, 0, 1, 0], dtype=torch.uint8), torch.tensor([[1, 3], [4, 0]]), None])
+            lambda input: input[:, torch.tensor([1, 0, 1, 0], dtype=torch.bool), torch.tensor([[1, 3], [4, 0]]), None])
 
     def test_chunk(self):
         class MyModel(torch.nn.Module):
@@ -2296,7 +2296,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
     def test_masked_fill(self):
         class MaskedFillModel(torch.nn.Module):
             def forward(self, x):
-                mask = torch.tensor([[0, 0, 1], [1, 1, 0]], dtype=torch.uint8)
+                mask = torch.tensor([[0, 0, 1], [1, 1, 0]], dtype=torch.bool)
                 return x.masked_fill(mask, 2)
 
         x = torch.zeros(4, 2, 3, requires_grad=True)

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -398,7 +398,6 @@ class TestONNXRuntime(unittest.TestCase):
 
     @skipIfUnsupportedMinOpsetVersion(9)
     def test_index_mask(self):
-        self._test_index_generic(lambda input: input[torch.tensor([0, 1, 0], dtype=torch.uint8)])
         self._test_index_generic(lambda input: input[torch.tensor([0, 1, 0], dtype=torch.bool)])
 
     def test_dict(self):

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -44,12 +44,7 @@ class TestIndexing(TestCase):
 
         v = torch.tensor([True, False, True], dtype=torch.bool, device=device)
         boolIndices = torch.tensor([True, False, False], dtype=torch.bool, device=device)
-        uint8Indices = torch.tensor([1, 0, 0], dtype=torch.uint8, device=device)
-        with warnings.catch_warnings(record=True) as w:
-            self.assertEqual(v[boolIndices].shape, v[uint8Indices].shape)
-            self.assertEqual(v[boolIndices], v[uint8Indices])
-            self.assertEqual(v[boolIndices], tensor([True], dtype=torch.bool, device=device))
-            self.assertEquals(len(w), 2)
+        self.assertEqual(v[boolIndices], tensor([True], dtype=torch.bool, device=device))
 
     def test_bool_indices_accumulate(self, device):
         mask = torch.zeros(size=(10, ), dtype=torch.bool, device=device)
@@ -67,21 +62,16 @@ class TestIndexing(TestCase):
     def test_byte_mask(self, device):
         v = torch.randn(5, 7, 3, device=device)
         mask = torch.ByteTensor([1, 0, 1, 1, 0]).to(device)
-        with warnings.catch_warnings(record=True) as w:
-            self.assertEqual(v[mask].shape, (3, 7, 3))
-            self.assertEqual(v[mask], torch.stack([v[0], v[2], v[3]]))
-            self.assertEquals(len(w), 2)
+        with self.assertRaisesRegex(RuntimeError,
+                'indexing with dtype torch.uint8 is no longer supported'):
+            v[mask].shape
 
-        v = torch.tensor([1.], device=device)
-        self.assertEqual(v[v == 0], torch.tensor([], device=device))
-
-    def test_byte_mask_accumulate(self, device):
+    def test_index_put_byte_indices(self, device):
         mask = torch.zeros(size=(10, ), dtype=torch.uint8, device=device)
         y = torch.ones(size=(10, 10), device=device)
-        with warnings.catch_warnings(record=True) as w:
-            y.index_put_((mask, ), y[mask], accumulate=True)
-            self.assertEqual(y, torch.ones(size=(10, 10), device=device))
-            self.assertEquals(len(w), 2)
+        with self.assertRaisesRegex(RuntimeError,
+                'indexing with dtype torch.uint8 is no longer supported'):
+            y.index_put_((mask, ), y, accumulate=True)
 
     def test_index_put_accumulate_large_tensor(self, device): 
         # This test is for tensors with number of elements >= INT_MAX (2^31 - 1). 
@@ -99,15 +89,6 @@ class TestIndexing(TestCase):
         self.assertEqual(a[-100], 1)
         self.assertEqual(a[-2], 13)
         self.assertEqual(a[-1], 14)
-
-    def test_multiple_byte_mask(self, device):
-        v = torch.randn(5, 7, 3, device=device)
-        # note: these broadcast together and are transposed to the first dim
-        mask1 = torch.ByteTensor([1, 0, 1, 1, 0]).to(device)
-        mask2 = torch.ByteTensor([1, 1, 1]).to(device)
-        with warnings.catch_warnings(record=True) as w:
-            self.assertEqual(v[mask1, :, mask2].shape, (3, 7))
-            self.assertEquals(len(w), 2)
 
     def test_byte_mask2d(self, device):
         v = torch.randn(5, 7, 3, device=device)
@@ -336,20 +317,6 @@ class TestIndexing(TestCase):
         x[1] = torch.arange(5, 7, device=device)
         self.assertEqual(x.tolist(), [[0, 1], [5, 6]])
 
-    def test_byte_tensor_assignment(self, device):
-        x = torch.arange(0., 16, device=device).view(4, 4)
-        b = torch.ByteTensor([True, False, True, False]).to(device)
-        value = torch.tensor([3., 4., 5., 6.], device=device)
-
-        with warnings.catch_warnings(record=True) as w:
-            x[b] = value
-            self.assertEquals(len(w), 1)
-
-        self.assertEqual(x[0], value)
-        self.assertEqual(x[1], torch.arange(4, 8, device=device))
-        self.assertEqual(x[2], value)
-        self.assertEqual(x[3], torch.arange(12, 16, device=device))
-
     def test_variable_slicing(self, device):
         x = torch.arange(0, 16, device=device).view(4, 4)
         indices = torch.IntTensor([0, 1]).to(device)
@@ -536,10 +503,6 @@ class NumpyTests(TestCase):
 
         index = tensor([False] * 6, device=device)
         self.assertRaisesRegex(IndexError, 'mask', lambda: arr[index])
-
-        index = torch.ByteTensor(4, 4).to(device).zero_()
-        self.assertRaisesRegex(IndexError, 'mask', lambda: arr[index])
-        self.assertRaisesRegex(IndexError, 'mask', lambda: arr[(slice(None), index)])
 
     def test_boolean_indexing_onedim(self, device):
         # Indexing a 2-dimensional array with

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -61,14 +61,16 @@ class TestIndexing(TestCase):
     def test_byte_mask(self, device):
         v = torch.randn(5, 7, 3, device=device)
         mask = torch.ByteTensor([1, 0, 1, 1, 0]).to(device)
-        with self.assertRaisesRegex(RuntimeError,
+        with self.assertRaisesRegex(
+                RuntimeError,
                 'indexing with dtype torch.uint8 is no longer supported'):
             v[mask].shape
 
     def test_index_put_byte_indices(self, device):
         mask = torch.zeros(size=(10, ), dtype=torch.uint8, device=device)
         y = torch.ones(size=(10, 10), device=device)
-        with self.assertRaisesRegex(RuntimeError,
+        with self.assertRaisesRegex(
+                RuntimeError,
                 'indexing with dtype torch.uint8 is no longer supported'):
             y.index_put_((mask, ), y, accumulate=True)
 

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -3,7 +3,6 @@ from torch.testing._internal.common_device_type import instantiate_device_type_t
 import torch
 from torch import tensor
 import unittest
-import warnings
 
 class TestIndexing(TestCase):
     def test_single_int(self, device):


### PR DESCRIPTION
Fixes #33751

