### PR TITLE
Remove `using namespace torch::autograd` from header files

### DIFF
--- a/test/cpp/api/CMakeLists.txt
+++ b/test/cpp/api/CMakeLists.txt
@@ -15,6 +15,7 @@ set(TORCH_API_TEST_SOURCES
   ${TORCH_API_TEST_DIR}/module.cpp
   ${TORCH_API_TEST_DIR}/modulelist.cpp
   ${TORCH_API_TEST_DIR}/modules.cpp
+  ${TORCH_API_TEST_DIR}/namespace.cpp
   ${TORCH_API_TEST_DIR}/nn_utils.cpp
   ${TORCH_API_TEST_DIR}/optim.cpp
   ${TORCH_API_TEST_DIR}/ordered_dict.cpp

--- a/test/cpp/api/namespace.cpp
+++ b/test/cpp/api/namespace.cpp
@@ -8,7 +8,7 @@ struct Node {};
 // ```
 // void NotLeakingSymbolsFromTorchAutogradNamespace_test_func(Node *node) {}
 //                                                            ^
-// error: reference to ‘Node’ is ambiguous
+// error: reference to `Node` is ambiguous
 // ```
 void NotLeakingSymbolsFromTorchAutogradNamespace_test_func(Node *node) {}
 

--- a/test/cpp/api/namespace.cpp
+++ b/test/cpp/api/namespace.cpp
@@ -1,0 +1,19 @@
+#include <gtest/gtest.h>
+
+#include <torch/torch.h>
+
+struct Node {};
+
+// If `torch::autograd::Note` is leaked into the root namespace, the following compile error would throw:
+// ```
+// void NotLeakingSymbolsFromTorchAutogradNamespace_test_func(Node *node) {}
+//                                                            ^
+// error: reference to ‘Node’ is ambiguous
+// ```
+void NotLeakingSymbolsFromTorchAutogradNamespace_test_func(Node *node) {}
+
+TEST(NamespaceTests, NotLeakingSymbolsFromTorchAutogradNamespace) {
+  // Checks that we are not leaking symbols from the
+  // `torch::autograd` namespace to the root namespace
+  NotLeakingSymbolsFromTorchAutogradNamespace_test_func(nullptr);
+}

--- a/torch/csrc/api/include/torch/nn/modules/_functions.h
+++ b/torch/csrc/api/include/torch/nn/modules/_functions.h
@@ -5,22 +5,21 @@
 #include <torch/types.h>
 #include <torch/nn/options/normalization.h>
 
-using namespace torch::autograd;
-
 namespace torch {
 namespace nn {
 namespace functions {
 
 class CrossMapLRN2d : public torch::autograd::Function<CrossMapLRN2d> {
  public:
-  static Variable forward(
-      AutogradContext *ctx, 
-      const Variable& input,
+  static torch::autograd::Variable forward(
+      torch::autograd::AutogradContext *ctx,
+      const torch::autograd::Variable& input,
       const CrossMapLRN2dOptions& options);
   
-  static variable_list backward(AutogradContext *ctx, variable_list grad_output);
+  static torch::autograd::variable_list backward(
+    torch::autograd::AutogradContext *ctx, torch::autograd::variable_list grad_output);
 };
 
-}
-}
-}
+} // namespace functions
+} // namespace nn
+} // namespace torch

--- a/torch/csrc/api/src/nn/modules/_functions.cpp
+++ b/torch/csrc/api/src/nn/modules/_functions.cpp
@@ -1,5 +1,7 @@
 #include <torch/nn/modules/_functions.h>
 
+using namespace torch::autograd;
+
 namespace torch {
 namespace nn {
 namespace functions {


### PR DESCRIPTION
This PR prevents leaking symbols from `torch::autograd` namespace to the root namespace.
Fixes https://github.com/pytorch/pytorch/issues/34371.