### PR TITLE
Eliminate unnecessary std::any() in a depth first search of the autograd graph

### DIFF
--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -992,30 +992,48 @@ void GraphTask::init_to_execute(Node& graph_root, const edge_list& outputs) {
       return nullptr;
     }
   };
+  auto nodeShouldExecute = [this](Node *fn) {
+    auto it = exec_info_.find(fn);
+    return it != exec_info_.end() && it->second.should_execute();
+  };
+
   std::vector<Frame> stack;
   std::unordered_set<Node*> seen;
-  for (const auto & input : graph_root.next_edges()) {
-    if (seen.count(input.function.get()) > 0) continue;
+  for (const auto &input : graph_root.next_edges()) {
+    if (seen.count(input.function.get()) > 0) {
+      continue;
+    }
     stack.emplace_back(input.function.get());
+    // Create an entry for this root node in 'exec_info_' if it doesn't
+    // already exsit, because the DFS below may not do that.
+    exec_info_.emplace(stack.back().fn_, ExecInfo());
+
     while (!stack.empty()) {
-      auto &frame = stack.back();
-      if (Node *next_fn = frame.get_next_fn()) {
-        if (/* bool unseen = */ seen.emplace(next_fn).second) {
-          stack.emplace_back(next_fn);
-          continue; // recurse
+      auto& frame = stack.back();
+      const auto fn = frame.fn_;
+      // Try to find next unseen child.
+      Node *child_fn = nullptr;
+      while ((child_fn = frame.get_next_fn()) &&
+             /* bool seen = */ !seen.emplace(child_fn).second) {
+        // This child node is already seen and the graph is a DAG.
+        // Therefore, it is not currently in the stack and its 'needed_' has
+        // been finalized. Update its parent's 'needed_'.
+        if (nodeShouldExecute(child_fn)) {
+          exec_info_[fn].needed_ = true;
         }
-      } else {
-        // NB: if we were using real recursion we could have saved some lookups
-        // using a return value from recursive call. It would make this manually unrolled
-        // version a lot more complicated, so I skipped that.
-        const auto & next_edges = frame.fn_->next_edges();
-        const bool needed = std::any_of(
-            next_edges.begin(), next_edges.end(), [&](const Edge& edge) {
-              auto it = exec_info_.find(edge.function.get());
-              return it != exec_info_.end() && it->second.should_execute();
-            });
-        exec_info_[frame.fn_].needed_ = needed;
-        stack.pop_back();
+      }
+
+      if (child_fn) {
+        // This is an unseen child node. Do a recursion.
+        stack.emplace_back(child_fn);
+        continue; // recurse
+      }
+
+      stack.pop_back();
+      // No more unseen child.  This node's 'needed_' is finalized,
+      // so contribute back its value to its parent node, which is in the stack.
+      if (!stack.empty() && nodeShouldExecute(fn)) {
+        exec_info_[stack.back().fn_].needed_ = true;
       }
     }
   }


### PR DESCRIPTION
This is an optimization and doesn't change any logic. All existing tests should cover it.