### PR TITLE
[ONNX] Support one_hot

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -1521,6 +1521,19 @@ class TestONNXRuntime(unittest.TestCase):
         self.run_test(ScatterModel(), input=(input, indices, values))
 
     @skipIfUnsupportedMinOpsetVersion(9)
+    def test_one_hot(self):
+        class OneHot(torch.nn.Module):
+            def __init__(self, num_classes):
+                super().__init__()
+                self.num_classes = num_classes
+
+            def forward(self, x):
+                return torch.nn.functional.one_hot(x, self.num_classes)
+
+        x = torch.arange(10)
+        self.run_test(OneHot(15), (x))
+
+    @skipIfUnsupportedMinOpsetVersion(9)
     def test_gather(self):
         class GatherModel(torch.nn.Module):
             def forward(self, input, indices):

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -1895,6 +1895,13 @@ def prim_shape(g, self):
     return g.op('Shape', self)
 
 
+@parse_args('v', 'i')
+def one_hot(g, self, num_classes):
+    values = g.op("Constant", value_t=torch.LongTensor([0, 1]))
+    depth = g.op("Constant", value_t=torch.LongTensor([num_classes]))
+    return g.op("OneHot", self, depth, values, axis_i=-1)
+
+
 @parse_args('v', 'i', 'v', 'v')
 def gather(g, self, dim, index, sparse_grad=False):
     if sym_help._maybe_get_const(sparse_grad, 'i'):


### PR DESCRIPTION
This PR resolves #22534 by adding a converter for the `torch.nn.functional.one_hot` function, and covering it with a test.

Are there other places this should be tested?