### PR TITLE
[C++ API] Fix ModuleList compile error: error: 'begin' was not declared in this scope

### DIFF
--- a/test/cpp/api/modulelist.cpp
+++ b/test/cpp/api/modulelist.cpp
@@ -286,3 +286,16 @@ TEST_F(ModuleListTest, PrettyPrintModuleList) {
       "  (5): torch::nn::LSTM(input_size=4, hidden_size=5, layers=1, dropout=0)\n"
       ")");
 }
+
+TEST_F(ModuleListTest, RangeBasedForLoop) {
+  torch::nn::ModuleList mlist(
+    torch::nn::Linear(3, 4),
+    torch::nn::BatchNorm(4),
+    torch::nn::Dropout(0.5)
+  );
+
+  std::stringstream buffer;
+  for (const auto &module : *mlist) {
+    module->pretty_print(buffer);
+  }
+}

--- a/torch/csrc/api/include/torch/nn/modules/container/modulelist.h
+++ b/torch/csrc/api/include/torch/nn/modules/container/modulelist.h
@@ -19,8 +19,8 @@ namespace nn {
 ///     torch::nn::Dropout(0.5)
 ///   );
 ///
-///   for (const auto &module : mlist) {
-///     module.pretty_print();
+///   for (const auto &module : *mlist) {
+///     module->pretty_print(std::cout);
 ///   }
 ///
 /// \endrst


### PR DESCRIPTION
One example in the current docs for `torch::nn::ModuleList` doesn't compile, and this PR fixes it. 
Fixes https://github.com/pytorch/pytorch/issues/32414.