### PR TITLE
Fix C++ at::Tensor docs generation

### DIFF
--- a/docs/cpp/source/Doxyfile
+++ b/docs/cpp/source/Doxyfile
@@ -45,6 +45,7 @@ INPUT                  = ../../../aten/src/ATen/ATen.h \
                          ../../../aten/src/ATen/TensorOptions.h \
                          ../../../aten/src/ATen/core/Tensor.h \
                          ../../../build/aten/src/ATen/Functions.h \
+                         ../../../build/aten/src/ATen/core/TensorBody.h \
                          ../../../c10/core/Device.h \
                          ../../../c10/core/DeviceType.h \
                          ../../../c10/util/Half.h \


### PR DESCRIPTION
https://github.com/pytorch/cppdocs/tree/56bb551cb855831c7146076db081c2b6f724fadf/api was the last commit that has `classat_1_1_tensor.html`.
https://github.com/pytorch/cppdocs/tree/a8abfffb7a2ba258cf8304c8724993bb02bef19f/api is the first commit that has no `classat_1_1_tensor.html`.

This PR brings back the missing `classat_1_1_tensor.html`

Fixes https://github.com/pytorch/pytorch/issues/25845.

**Test Plan:**
Check `pytorch_cpp_doc_push` CI job, and see if there is `classat_1_1_tensor` generated (similar to `structat_1_1native_1_1_convolution_descriptor`).