### PR TITLE
[Shape Inference] Update shape inference in dper3 backend - C2 part

### DIFF
--- a/caffe2/opt/bound_shape_inferencer.h
+++ b/caffe2/opt/bound_shape_inferencer.h
@@ -113,6 +113,7 @@ class CAFFE2_API BoundShapeInferencer : public BoundShapeInferencerBase {
   void InferShape(const OperatorDef& op);
   void InferReshape(const OperatorDef& op);
   void InferLengthsRangeFill(const OperatorDef& op);
+  void InferQuantization(const OperatorDef& op);
 
   // Standard shape/type inference using op schema registered shape inference
   // function

--- a/caffe2/proto/metanet.proto
+++ b/caffe2/proto/metanet.proto
@@ -44,4 +44,5 @@ message MetaNetDef {
   repeated StringMap applicationSpecificInfo = 5;
   repeated string blobsOrder = 6;
   repeated string preLoadBlobs = 7;
+  optional TensorBoundShapes tensorBoundShapes = 8;
 }

--- a/caffe2/python/predictor/predictor_py_utils.py
+++ b/caffe2/python/predictor/predictor_py_utils.py
@@ -143,6 +143,14 @@ def AddNet(meta_net_def, net_name, net_def):
     meta_net_def.nets.add(key=net_name, value=net_def)
 
 
+def SetBlobsOrder(meta_net_def, blobs_order):
+    for blob in blobs_order:
+        meta_net_def.blobsOrder.append(blob)
+
+def SetPreLoadBlobs(meta_net_def, pre_load_blobs):
+    for blob in pre_load_blobs:
+        meta_net_def.preLoadBlobs.append(blob)
+
 def GetArgumentByName(net_def, arg_name):
     for arg in net_def.arg:
         if arg.name == arg_name:


### PR DESCRIPTION
Summary: Add InferQuantization - set current_dim_type_ to CONSTANT for quantization ops.

Test Plan: buck test mode/opt-clang caffe2/caffe2/opt:bound_shape_inference_test

Differential Revision: D20332703

