### PR TITLE
Disable ROCM when building mobile libtorch.

### DIFF
--- a/scripts/build_mobile.sh
+++ b/scripts/build_mobile.sh
@@ -37,6 +37,7 @@ if [ -x "$(command -v ninja)" ]; then
 fi
 
 # Disable unused dependencies
+CMAKE_ARGS+=("-DUSE_ROCM=OFF")
 CMAKE_ARGS+=("-DUSE_CUDA=OFF")
 CMAKE_ARGS+=("-DUSE_GFLAGS=OFF")
 CMAKE_ARGS+=("-DUSE_OPENCV=OFF")


### PR DESCRIPTION
When a system has ROCm dev tools installed, `scripts/build_mobile.sh` tried to use it.
This PR fixes looking up unused ROCm library when building libtorch mobile.
