### PR TITLE
Avoid copy contents in SerializedPyObj

### DIFF
--- a/torch/csrc/distributed/rpc/python_remote_call.cpp
+++ b/torch/csrc/distributed/rpc/python_remote_call.cpp
@@ -15,7 +15,7 @@ PythonRemoteCall::PythonRemoteCall(
       retForkId_(std::move(retForkId)) {}
 
 Message PythonRemoteCall::toMessage() && {
-  std::vector<IValue> ivalues = serializedPyObj_.toIValues();
+  std::vector<IValue> ivalues = std::move(serializedPyObj_).toIValues();
   ivalues.emplace_back(retRRefId_);
   ivalues.emplace_back(retForkId_);
 

--- a/torch/csrc/distributed/rpc/python_remote_call.h
+++ b/torch/csrc/distributed/rpc/python_remote_call.h
@@ -33,7 +33,7 @@ class TORCH_API PythonRemoteCall : public RpcCommandBase {
   static std::unique_ptr<PythonRemoteCall> fromMessage(const Message& message);
 
  private:
-  const SerializedPyObj serializedPyObj_;
+  SerializedPyObj serializedPyObj_;
   const at::IValue retRRefId_;
   const at::IValue retForkId_;
 };

--- a/torch/csrc/distributed/rpc/request_callback_impl.cpp
+++ b/torch/csrc/distributed/rpc/request_callback_impl.cpp
@@ -199,8 +199,8 @@ std::shared_ptr<FutureMessage> RequestCallbackImpl::processRpc(
         }
         SerializedPyObj result =
             PythonRpcHandler::getInstance().serialize(pyValue);
-        return
-            wrap(PythonRRefFetchRet(std::move(result).toIValues()).toMessage());
+        return wrap(
+            PythonRRefFetchRet(std::move(result).toIValues()).toMessage());
       }
 
       auto whenValueSet = rref->getFuture();

--- a/torch/csrc/distributed/rpc/request_callback_impl.cpp
+++ b/torch/csrc/distributed/rpc/request_callback_impl.cpp
@@ -199,7 +199,8 @@ std::shared_ptr<FutureMessage> RequestCallbackImpl::processRpc(
         }
         SerializedPyObj result =
             PythonRpcHandler::getInstance().serialize(pyValue);
-        return wrap(PythonRRefFetchRet(result.toIValues()).toMessage());
+        return
+            wrap(PythonRRefFetchRet(std::move(result).toIValues()).toMessage());
       }
 
       auto whenValueSet = rref->getFuture();
@@ -219,7 +220,8 @@ std::shared_ptr<FutureMessage> RequestCallbackImpl::processRpc(
               }
               SerializedPyObj result =
                   PythonRpcHandler::getInstance().serialize(pyValue);
-              Message m = PythonRRefFetchRet(result.toIValues()).toMessage();
+              Message m =
+                  PythonRRefFetchRet(std::move(result).toIValues()).toMessage();
               m.setId(messageId);
               responseFuture->markCompleted(std::move(m));
             } else {

--- a/torch/csrc/distributed/rpc/types.cpp
+++ b/torch/csrc/distributed/rpc/types.cpp
@@ -61,13 +61,13 @@ std::ostream& operator<<(std::ostream& os, GloballyUniqueId const& globalId) {
 
 ///////////////////////////  SerializedPyObj   ///////////////////////////
 
-std::vector<at::IValue> SerializedPyObj::toIValues() const {
+std::vector<at::IValue> SerializedPyObj::toIValues() && {
   std::vector<at::IValue> ivalues;
   ivalues.reserve(tensors_.size() + 1);
   for (auto& tensor : tensors_) {
-    ivalues.emplace_back(tensor);
+    ivalues.emplace_back(std::move(tensor));
   }
-  ivalues.emplace_back(payload_);
+  ivalues.emplace_back(std::move(payload_));
   return ivalues;
 }
 

--- a/torch/csrc/distributed/rpc/types.h
+++ b/torch/csrc/distributed/rpc/types.h
@@ -44,11 +44,11 @@ struct TORCH_API SerializedPyObj final {
   SerializedPyObj(std::string&& payload, std::vector<at::Tensor>&& tensors)
       : payload_(std::move(payload)), tensors_(std::move(tensors)) {}
 
-  std::vector<at::IValue> toIValues() const;
+  std::vector<at::IValue> toIValues() &&;
   static SerializedPyObj fromIValues(std::vector<at::IValue> value);
 
-  const std::string payload_;
-  const std::vector<at::Tensor> tensors_;
+  std::string payload_;
+  std::vector<at::Tensor> tensors_;
 };
 
 } // namespace rpc


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #34497 Don't run user function until all UserRRefs in the args are confirmed
* #34496 Split deserialize from runPythonUdf and remove generatePythonUDFResult
* #34495 Use SerializedPyObj in PythonRpcHandler::generatePythonUDFResult
* #34494 Split deserialize from _run_function in RPC internal.py
* #34493 Use SerializedPyObj in PythonRpcHandler
* #34492 Remove _load_return_value from RPC internal.py
* #34491 Consolidate Python Messages to use SerializedPyObj
* **#34490 Avoid copy contents in SerializedPyObj**



Differential Revision: [D20347465](https://our.internmc.facebook.com/intern/diff/D20347465)