### PR TITLE
Consolidate Python Messages to use SerializedPyObj

### DIFF
--- a/torch/csrc/distributed/rpc/python_call.cpp
+++ b/torch/csrc/distributed/rpc/python_call.cpp
@@ -6,29 +6,31 @@ namespace torch {
 namespace distributed {
 namespace rpc {
 
-PythonCall::PythonCall(
-    std::vector<char> pickledPayload,
-    std::vector<torch::Tensor> tensors)
-    : pickledPayload_(std::move(pickledPayload)),
-      tensors_(std::move(tensors)) {}
+PythonCall::PythonCall(SerializedPyObj&& serializedPyObj)
+    : serializedPyObj_(std::move(serializedPyObj)) {}
 
 Message PythonCall::toMessage() && {
+  auto payload = std::vector<char>(
+      serializedPyObj_.payload_.begin(), serializedPyObj_.payload_.end());
   return Message(
-      std::move(pickledPayload_),
-      std::move(tensors_),
+      std::move(payload),
+      std::move(std::move(serializedPyObj_.tensors_)),
       MessageType::PYTHON_CALL);
 }
 
 std::unique_ptr<PythonCall> PythonCall::fromMessage(const Message& message) {
-  return std::make_unique<PythonCall>(message.payload(), message.tensors());
+  std::string payload(message.payload().begin(), message.payload().end());
+  std::vector<Tensor> tensors = message.tensors();
+  SerializedPyObj serializedPyObj(std::move(payload), std::move(tensors));
+  return std::make_unique<PythonCall>(std::move(serializedPyObj));
 }
 
-const std::vector<char>& PythonCall::pickledPayload() const {
-  return pickledPayload_;
+const std::string& PythonCall::pickledPayload() const {
+  return serializedPyObj_.payload_;
 }
 
 const std::vector<torch::Tensor>& PythonCall::tensors() const {
-  return tensors_;
+  return serializedPyObj_.tensors_;
 }
 
 } // namespace rpc

--- a/torch/csrc/distributed/rpc/python_call.cpp
+++ b/torch/csrc/distributed/rpc/python_call.cpp
@@ -14,7 +14,7 @@ Message PythonCall::toMessage() && {
       serializedPyObj_.payload_.begin(), serializedPyObj_.payload_.end());
   return Message(
       std::move(payload),
-      std::move(std::move(serializedPyObj_.tensors_)),
+      std::move(serializedPyObj_.tensors_),
       MessageType::PYTHON_CALL);
 }
 

--- a/torch/csrc/distributed/rpc/python_call.h
+++ b/torch/csrc/distributed/rpc/python_call.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <torch/csrc/distributed/rpc/rpc_command_base.h>
+#include <torch/csrc/distributed/rpc/types.h>
 
 namespace torch {
 namespace distributed {
@@ -9,21 +10,18 @@ namespace rpc {
 // RPC call representing calling a Python function over RPC.
 class TORCH_API PythonCall final : public RpcCommandBase {
  public:
-  explicit PythonCall(
-      std::vector<char> pickledPayload,
-      std::vector<torch::Tensor> tensors);
+  explicit PythonCall(SerializedPyObj&& serializedPyObj);
 
   Message toMessage() && override;
 
   static std::unique_ptr<PythonCall> fromMessage(const Message& message);
 
-  const std::vector<char>& pickledPayload() const;
+  const std::string& pickledPayload() const;
 
   const std::vector<torch::Tensor>& tensors() const;
 
  private:
-  std::vector<char> pickledPayload_;
-  std::vector<torch::Tensor> tensors_;
+  SerializedPyObj serializedPyObj_;
 };
 
 } // namespace rpc

--- a/torch/csrc/distributed/rpc/python_functions.cpp
+++ b/torch/csrc/distributed/rpc/python_functions.cpp
@@ -167,9 +167,9 @@ std::shared_ptr<FutureMessage> pyRpcPythonUdf(
     std::string& pickledPythonUDF,
     std::vector<torch::Tensor>& tensors,
     const std::shared_ptr<torch::autograd::profiler::RecordFunction>& rf) {
-  auto pythonCall = std::make_unique<PythonCall>(
-      std::vector<char>(pickledPythonUDF.begin(), pickledPythonUDF.end()),
-      tensors);
+  auto serializedPyObj =
+      SerializedPyObj(std::move(pickledPythonUDF), std::move(tensors));
+  auto pythonCall = std::make_unique<PythonCall>(std::move(serializedPyObj));
 
   auto agent = RpcAgent::getCurrentRpcAgent();
   return sendMessageWithAutograd(

--- a/torch/csrc/distributed/rpc/python_resp.cpp
+++ b/torch/csrc/distributed/rpc/python_resp.cpp
@@ -14,7 +14,7 @@ Message PythonResp::toMessage() && {
       serializedPyObj_.payload_.begin(), serializedPyObj_.payload_.end());
   return Message(
       std::move(payload),
-      std::move(std::move(serializedPyObj_.tensors_)),
+      std::move(serializedPyObj_.tensors_),
       MessageType::PYTHON_RET);
 }
 

--- a/torch/csrc/distributed/rpc/python_resp.cpp
+++ b/torch/csrc/distributed/rpc/python_resp.cpp
@@ -6,27 +6,31 @@ namespace torch {
 namespace distributed {
 namespace rpc {
 
-PythonResp::PythonResp(
-    std::vector<char> pickledPayload,
-    std::vector<torch::Tensor> tensors)
-    : pickledPayload_(std::move(pickledPayload)),
-      tensors_(std::move(tensors)) {}
+PythonResp::PythonResp(SerializedPyObj&& serializedPyObj)
+    : serializedPyObj_(std::move(serializedPyObj)) {}
 
 Message PythonResp::toMessage() && {
+  auto payload = std::vector<char>(
+      serializedPyObj_.payload_.begin(), serializedPyObj_.payload_.end());
   return Message(
-      std::move(pickledPayload_), std::move(tensors_), MessageType::PYTHON_RET);
+      std::move(payload),
+      std::move(std::move(serializedPyObj_.tensors_)),
+      MessageType::PYTHON_RET);
 }
 
 std::unique_ptr<PythonResp> PythonResp::fromMessage(const Message& message) {
-  return std::make_unique<PythonResp>(message.payload(), message.tensors());
+  std::string payload(message.payload().begin(), message.payload().end());
+  std::vector<Tensor> tensors = message.tensors();
+  SerializedPyObj serializedPyObj(std::move(payload), std::move(tensors));
+  return std::make_unique<PythonResp>(std::move(serializedPyObj));
 }
 
-const std::vector<char>& PythonResp::pickledPayload() const {
-  return pickledPayload_;
+const std::string& PythonResp::pickledPayload() const {
+  return serializedPyObj_.payload_;
 }
 
 const std::vector<torch::Tensor>& PythonResp::tensors() const {
-  return tensors_;
+  return serializedPyObj_.tensors_;
 }
 
 } // namespace rpc

--- a/torch/csrc/distributed/rpc/python_resp.h
+++ b/torch/csrc/distributed/rpc/python_resp.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <torch/csrc/distributed/rpc/rpc_command_base.h>
+#include <torch/csrc/distributed/rpc/types.h>
 
 namespace torch {
 namespace distributed {
@@ -9,21 +10,18 @@ namespace rpc {
 // RPC call representing the response of a Python UDF over RPC.
 class TORCH_API PythonResp final : public RpcCommandBase {
  public:
-  explicit PythonResp(
-      std::vector<char> pickledPayload,
-      std::vector<torch::Tensor> tensors);
+  explicit PythonResp(SerializedPyObj&& serializedPyObj);
 
   Message toMessage() && override;
 
   static std::unique_ptr<PythonResp> fromMessage(const Message& message);
 
-  const std::vector<char>& pickledPayload() const;
+  const std::string& pickledPayload() const;
 
   const std::vector<torch::Tensor>& tensors() const;
 
  private:
-  std::vector<char> pickledPayload_;
-  std::vector<torch::Tensor> tensors_;
+  SerializedPyObj serializedPyObj_;
 };
 
 } // namespace rpc

--- a/torch/csrc/distributed/rpc/python_rpc_handler.cpp
+++ b/torch/csrc/distributed/rpc/python_rpc_handler.cpp
@@ -91,24 +91,23 @@ std::shared_ptr<torch::jit::script::CompilationUnit> PythonRpcHandler::
   return jitCompilationUnit_;
 }
 
-std::vector<char> PythonRpcHandler::generatePythonUDFResult(
-    const std::vector<char>& pickledPayload,
+std::string PythonRpcHandler::generatePythonUDFResult(
+    const std::string& pickledPayload,
     const std::vector<torch::Tensor>& requestTensorTable,
     std::vector<torch::Tensor>& responseTensorTable) {
   PROFILE_GIL_SCOPED_ACQUIRE;
-  auto pargs = py::bytes(pickledPayload.data(), pickledPayload.size());
+  auto pargs = py::bytes(pickledPayload);
   py::tuple pres = pySerialize_(pyRunFunction_(pargs, requestTensorTable));
   const auto& presStr = pres[0].cast<std::string>();
   responseTensorTable = pres[1].cast<std::vector<torch::Tensor>>();
-  std::vector<char> payload(presStr.begin(), presStr.end());
-  return payload;
+  return std::move(presStr);
 }
 
 py::object PythonRpcHandler::loadPythonUDFResult(
-    const std::vector<char>& pickledPayload,
+    const std::string& pickledPayload,
     const std::vector<torch::Tensor>& tensorTable) {
   PROFILE_GIL_SCOPED_ACQUIRE;
-  auto pargs = py::bytes(pickledPayload.data(), pickledPayload.size());
+  auto pargs = py::bytes(pickledPayload);
   return pyLoadReturnValue_(pargs, tensorTable);
 }
 

--- a/torch/csrc/distributed/rpc/python_rpc_handler.h
+++ b/torch/csrc/distributed/rpc/python_rpc_handler.h
@@ -20,15 +20,15 @@ class PYBIND11_EXPORT PythonRpcHandler {
   static PythonRpcHandler& getInstance();
 
   // Deserialize Python function, run it, and serialize its return value.
-  std::vector<char> generatePythonUDFResult(
-      const std::vector<char>& pickledPayload,
+  std::string generatePythonUDFResult(
+      const std::string& pickledPayload,
       const std::vector<torch::Tensor>& requestTensorTable,
       std::vector<torch::Tensor>& responseTensorTable);
 
   // Returned python UDF result is pickled binary string, so run python
   // function to unpickle the python UDF result and return py::object to user
   py::object loadPythonUDFResult(
-      const std::vector<char>& pickledPayload,
+      const std::string& pickledPayload,
       const std::vector<torch::Tensor>& tensorTable);
 
   // Run a pickled Python UDF and return the result py::object

--- a/torch/csrc/distributed/rpc/request_callback_impl.cpp
+++ b/torch/csrc/distributed/rpc/request_callback_impl.cpp
@@ -75,8 +75,8 @@ std::shared_ptr<FutureMessage> RequestCallbackImpl::processRpc(
           pyCall.pickledPayload(), pyCall.tensors(), responseTensorTable);
       SerializedPyObj serializedPyObj(
           std::move(payload), std::move(responseTensorTable));
-      return
-          wrap(std::move(PythonResp(std::move(serializedPyObj))).toMessage());
+      return wrap(
+          std::move(PythonResp(std::move(serializedPyObj))).toMessage());
     }
     case MessageType::SCRIPT_REMOTE_CALL: {
       auto& scriptRemoteCall = static_cast<ScriptRemoteCall&>(rpc);

--- a/torch/csrc/distributed/rpc/request_callback_impl.cpp
+++ b/torch/csrc/distributed/rpc/request_callback_impl.cpp
@@ -73,10 +73,10 @@ std::shared_ptr<FutureMessage> RequestCallbackImpl::processRpc(
       std::vector<torch::Tensor> responseTensorTable;
       auto payload = PythonRpcHandler::getInstance().generatePythonUDFResult(
           pyCall.pickledPayload(), pyCall.tensors(), responseTensorTable);
-      return wrap(
-          std::move(
-              PythonResp(std::move(payload), std::move(responseTensorTable)))
-              .toMessage());
+      SerializedPyObj serializedPyObj(
+          std::move(payload), std::move(responseTensorTable));
+      return
+          wrap(std::move(PythonResp(std::move(serializedPyObj))).toMessage());
     }
     case MessageType::SCRIPT_REMOTE_CALL: {
       auto& scriptRemoteCall = static_cast<ScriptRemoteCall&>(rpc);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #34497 Don't run user function until all UserRRefs in the args are confirmed
* #34496 Split deserialize from runPythonUdf and remove generatePythonUDFResult
* #34495 Use SerializedPyObj in PythonRpcHandler::generatePythonUDFResult
* #34494 Split deserialize from _run_function in RPC internal.py
* #34493 Use SerializedPyObj in PythonRpcHandler
* #34492 Remove _load_return_value from RPC internal.py
* **#34491 Consolidate Python Messages to use SerializedPyObj**
* #34490 Avoid copy contents in SerializedPyObj



Differential Revision: [D20347467](https://our.internmc.facebook.com/intern/diff/D20347467)