### PR TITLE
Remove _load_return_value from RPC internal.py

### DIFF
--- a/torch/csrc/distributed/rpc/py_rref.cpp
+++ b/torch/csrc/distributed/rpc/py_rref.cpp
@@ -128,8 +128,11 @@ py::object PyRRef::toHere() {
     if (rref_->isPyObj()) {
       // python_rpc_handler deserialization will acquires GIL.
       auto rfr_values = value.toTuple()->elements();
-      return PythonRpcHandler::getInstance().deserialize(
+      auto& pythonRpcHandler = PythonRpcHandler::getInstance();
+      auto ret = pythonRpcHandler.deserialize(
           SerializedPyObj::fromIValues(rfr_values));
+      pythonRpcHandler.handleException(ret);
+      return ret;
     } else {
       // acquiring GIL as torch::jit::toPyObject creates new py::object
       // without grabbing the GIL.

--- a/torch/csrc/distributed/rpc/python_call.cpp
+++ b/torch/csrc/distributed/rpc/python_call.cpp
@@ -25,6 +25,10 @@ std::unique_ptr<PythonCall> PythonCall::fromMessage(const Message& message) {
   return std::make_unique<PythonCall>(std::move(serializedPyObj));
 }
 
+const SerializedPyObj& PythonCall::serializedPyObj() const {
+  return serializedPyObj_;
+}
+
 const std::string& PythonCall::pickledPayload() const {
   return serializedPyObj_.payload_;
 }

--- a/torch/csrc/distributed/rpc/python_call.h
+++ b/torch/csrc/distributed/rpc/python_call.h
@@ -16,6 +16,8 @@ class TORCH_API PythonCall final : public RpcCommandBase {
 
   static std::unique_ptr<PythonCall> fromMessage(const Message& message);
 
+  const SerializedPyObj& serializedPyObj() const;
+
   const std::string& pickledPayload() const;
 
   const std::vector<torch::Tensor>& tensors() const;

--- a/torch/csrc/distributed/rpc/python_functions.cpp
+++ b/torch/csrc/distributed/rpc/python_functions.cpp
@@ -99,9 +99,10 @@ py::object toPyObjInternal(RpcCommandBase& rpc, MessageType messageType) {
     case MessageType::PYTHON_RET: {
       // TODO: Try to avoid a copy here.
       auto& resp = static_cast<PythonResp&>(rpc);
-
-      return PythonRpcHandler::getInstance().loadPythonUDFResult(
-          resp.pickledPayload(), resp.tensors());
+      auto& pythonRpcHandler = PythonRpcHandler::getInstance();
+      py::object ret = pythonRpcHandler.deserialize(resp.serializedPyObj());
+      pythonRpcHandler.handleException(ret);
+      return ret;
     }
     default: {
       TORCH_CHECK(false, "Unrecognized response message type ", messageType);

--- a/torch/csrc/distributed/rpc/python_resp.cpp
+++ b/torch/csrc/distributed/rpc/python_resp.cpp
@@ -25,6 +25,10 @@ std::unique_ptr<PythonResp> PythonResp::fromMessage(const Message& message) {
   return std::make_unique<PythonResp>(std::move(serializedPyObj));
 }
 
+const SerializedPyObj& PythonResp::serializedPyObj() const {
+  return serializedPyObj_;
+}
+
 const std::string& PythonResp::pickledPayload() const {
   return serializedPyObj_.payload_;
 }

--- a/torch/csrc/distributed/rpc/python_resp.h
+++ b/torch/csrc/distributed/rpc/python_resp.h
@@ -16,6 +16,8 @@ class TORCH_API PythonResp final : public RpcCommandBase {
 
   static std::unique_ptr<PythonResp> fromMessage(const Message& message);
 
+  const SerializedPyObj& serializedPyObj() const;
+
   const std::string& pickledPayload() const;
 
   const std::vector<torch::Tensor>& tensors() const;

--- a/torch/csrc/distributed/rpc/python_rpc_handler.cpp
+++ b/torch/csrc/distributed/rpc/python_rpc_handler.cpp
@@ -62,8 +62,8 @@ PythonRpcHandler::PythonRpcHandler() {
   PROFILE_GIL_SCOPED_ACQUIRE;
   py::object module = py::module::import("torch.distributed.rpc.internal");
   pyRunFunction_ = getFunction(module, "_run_function");
-  pyLoadReturnValue_ = getFunction(module, "_load_return_value");
   pySerialize_ = getFunction(module, "serialize");
+  pyDeserialize_ = getFunction(module, "deserialize");
   pyHandleException_ = getFunction(module, "_handle_exception");
   jitCompilationUnit_ = torch::jit::get_python_cu();
   typeParser_ = std::make_shared<jit::script::ScriptTypeParser>(
@@ -73,8 +73,8 @@ PythonRpcHandler::PythonRpcHandler() {
 void PythonRpcHandler::cleanup() {
   PROFILE_GIL_SCOPED_ACQUIRE;
   pyRunFunction_ = py::none();
-  pyLoadReturnValue_ = py::none();
   pySerialize_ = py::none();
+  pyDeserialize_ = py::none();
   pyHandleException_ = py::none();
   jitCompilationUnit_ = nullptr;
   typeParser_ = nullptr;
@@ -103,14 +103,6 @@ std::string PythonRpcHandler::generatePythonUDFResult(
   return std::move(presStr);
 }
 
-py::object PythonRpcHandler::loadPythonUDFResult(
-    const std::string& pickledPayload,
-    const std::vector<torch::Tensor>& tensorTable) {
-  PROFILE_GIL_SCOPED_ACQUIRE;
-  auto pargs = py::bytes(pickledPayload);
-  return pyLoadReturnValue_(pargs, tensorTable);
-}
-
 py::object PythonRpcHandler::runPythonUDF(
     const SerializedPyObj& serializedObj) {
   PROFILE_GIL_SCOPED_ACQUIRE;
@@ -127,7 +119,7 @@ SerializedPyObj PythonRpcHandler::serialize(const py::object& obj) {
 
 py::object PythonRpcHandler::deserialize(const SerializedPyObj& serializedObj) {
   PROFILE_GIL_SCOPED_ACQUIRE;
-  return pyLoadReturnValue_(
+  return pyDeserialize_(
       py::bytes(serializedObj.payload_), serializedObj.tensors_);
 }
 

--- a/torch/csrc/distributed/rpc/python_rpc_handler.h
+++ b/torch/csrc/distributed/rpc/python_rpc_handler.h
@@ -25,12 +25,6 @@ class PYBIND11_EXPORT PythonRpcHandler {
       const std::vector<torch::Tensor>& requestTensorTable,
       std::vector<torch::Tensor>& responseTensorTable);
 
-  // Returned python UDF result is pickled binary string, so run python
-  // function to unpickle the python UDF result and return py::object to user
-  py::object loadPythonUDFResult(
-      const std::string& pickledPayload,
-      const std::vector<torch::Tensor>& tensorTable);
-
   // Run a pickled Python UDF and return the result py::object
   py::object runPythonUDF(const SerializedPyObj& serializedObj);
 
@@ -85,11 +79,11 @@ class PYBIND11_EXPORT PythonRpcHandler {
   // Ref to `torch.distributed.rpc.internal._run_function`.
   py::object pyRunFunction_;
 
-  // Ref to `torch.distributed.rpc.internal._load_return_value`.
-  py::object pyLoadReturnValue_;
-
   // Ref to `torch.distributed.rpc.internal.serialize`.
   py::object pySerialize_;
+
+  // Ref to `torch.distributed.rpc.internal.deserialize`.
+  py::object pyDeserialize_;
 
   // Ref to 'torch.distributed.rpc.internal._handle_exception'
   py::object pyHandleException_;

--- a/torch/distributed/rpc/internal.py
+++ b/torch/distributed/rpc/internal.py
@@ -118,6 +118,10 @@ def serialize(obj):
     return _internal_rpc_pickler.serialize(obj)
 
 
+def deserialize(binary_data, tensor_table):
+    return _internal_rpc_pickler.deserialize(binary_data, tensor_table)
+
+
 def _run_function(binary_data, tensor_table):
     r"""
     This function is exclusively called from C++.
@@ -139,19 +143,6 @@ def _run_function(binary_data, tensor_table):
 def _handle_exception(result):
     if isinstance(result, RemoteException):
         raise result.exception_type(result.msg)
-
-
-def _load_return_value(binary_data, tensor_table):
-    r"""
-    This function is exclusively called from C++.
-    See ``torch/csrc/distributed/rpc/python_rpc_handler.cpp``.
-
-    Processes the return value of a Python function.
-    Raises exception if the return value is a wrapped exception.
-    """
-    result = _internal_rpc_pickler.deserialize(binary_data, tensor_table)
-    _handle_exception(result)
-    return result
 
 
 def _start_record_function(exec_type, func_name, current_worker_name, dest_worker_name):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #34497 Don't run user function until all UserRRefs in the args are confirmed
* #34496 Split deserialize from runPythonUdf and remove generatePythonUDFResult
* #34495 Use SerializedPyObj in PythonRpcHandler::generatePythonUDFResult
* #34494 Split deserialize from _run_function in RPC internal.py
* #34493 Use SerializedPyObj in PythonRpcHandler
* **#34492 Remove _load_return_value from RPC internal.py**
* #34491 Consolidate Python Messages to use SerializedPyObj
* #34490 Avoid copy contents in SerializedPyObj



Differential Revision: [D20347468](https://our.internmc.facebook.com/intern/diff/D20347468)