### PR TITLE
Use SerializedPyObj in PythonRpcHandler

### DIFF
--- a/torch/csrc/distributed/rpc/python_call.cpp
+++ b/torch/csrc/distributed/rpc/python_call.cpp
@@ -29,14 +29,6 @@ const SerializedPyObj& PythonCall::serializedPyObj() const {
   return serializedPyObj_;
 }
 
-const std::string& PythonCall::pickledPayload() const {
-  return serializedPyObj_.payload_;
-}
-
-const std::vector<torch::Tensor>& PythonCall::tensors() const {
-  return serializedPyObj_.tensors_;
-}
-
 } // namespace rpc
 } // namespace distributed
 } // namespace torch

--- a/torch/csrc/distributed/rpc/python_call.h
+++ b/torch/csrc/distributed/rpc/python_call.h
@@ -18,10 +18,6 @@ class TORCH_API PythonCall final : public RpcCommandBase {
 
   const SerializedPyObj& serializedPyObj() const;
 
-  const std::string& pickledPayload() const;
-
-  const std::vector<torch::Tensor>& tensors() const;
-
  private:
   SerializedPyObj serializedPyObj_;
 };

--- a/torch/csrc/distributed/rpc/python_resp.cpp
+++ b/torch/csrc/distributed/rpc/python_resp.cpp
@@ -29,14 +29,6 @@ const SerializedPyObj& PythonResp::serializedPyObj() const {
   return serializedPyObj_;
 }
 
-const std::string& PythonResp::pickledPayload() const {
-  return serializedPyObj_.payload_;
-}
-
-const std::vector<torch::Tensor>& PythonResp::tensors() const {
-  return serializedPyObj_.tensors_;
-}
-
 } // namespace rpc
 } // namespace distributed
 } // namespace torch

--- a/torch/csrc/distributed/rpc/python_resp.h
+++ b/torch/csrc/distributed/rpc/python_resp.h
@@ -18,10 +18,6 @@ class TORCH_API PythonResp final : public RpcCommandBase {
 
   const SerializedPyObj& serializedPyObj() const;
 
-  const std::string& pickledPayload() const;
-
-  const std::vector<torch::Tensor>& tensors() const;
-
  private:
   SerializedPyObj serializedPyObj_;
 };

--- a/torch/csrc/distributed/rpc/python_rpc_handler.cpp
+++ b/torch/csrc/distributed/rpc/python_rpc_handler.cpp
@@ -92,12 +92,12 @@ std::shared_ptr<torch::jit::script::CompilationUnit> PythonRpcHandler::
 }
 
 std::string PythonRpcHandler::generatePythonUDFResult(
-    const std::string& pickledPayload,
-    const std::vector<torch::Tensor>& requestTensorTable,
+    const SerializedPyObj& serializedPyObj,
     std::vector<torch::Tensor>& responseTensorTable) {
   PROFILE_GIL_SCOPED_ACQUIRE;
-  auto pargs = py::bytes(pickledPayload);
-  py::tuple pres = pySerialize_(pyRunFunction_(pargs, requestTensorTable));
+  auto pargs = py::bytes(serializedPyObj.payload_);
+  py::tuple pres = pySerialize_(
+      pyRunFunction_(pargs, serializedPyObj.tensors_));
   const auto& presStr = pres[0].cast<std::string>();
   responseTensorTable = pres[1].cast<std::vector<torch::Tensor>>();
   return std::move(presStr);

--- a/torch/csrc/distributed/rpc/python_rpc_handler.h
+++ b/torch/csrc/distributed/rpc/python_rpc_handler.h
@@ -21,8 +21,7 @@ class PYBIND11_EXPORT PythonRpcHandler {
 
   // Deserialize Python function, run it, and serialize its return value.
   std::string generatePythonUDFResult(
-      const std::string& pickledPayload,
-      const std::vector<torch::Tensor>& requestTensorTable,
+      const SerializedPyObj& serializedPyObj,
       std::vector<torch::Tensor>& responseTensorTable);
 
   // Run a pickled Python UDF and return the result py::object

--- a/torch/csrc/distributed/rpc/request_callback_impl.cpp
+++ b/torch/csrc/distributed/rpc/request_callback_impl.cpp
@@ -72,7 +72,7 @@ std::shared_ptr<FutureMessage> RequestCallbackImpl::processRpc(
       auto& pyCall = static_cast<PythonCall&>(rpc);
       std::vector<torch::Tensor> responseTensorTable;
       auto payload = PythonRpcHandler::getInstance().generatePythonUDFResult(
-          pyCall.pickledPayload(), pyCall.tensors(), responseTensorTable);
+          pyCall.serializedPyObj(), responseTensorTable);
       SerializedPyObj serializedPyObj(
           std::move(payload), std::move(responseTensorTable));
       return


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #34497 Don't run user function until all UserRRefs in the args are confirmed
* #34496 Split deserialize from runPythonUdf and remove generatePythonUDFResult
* #34495 Use SerializedPyObj in PythonRpcHandler::generatePythonUDFResult
* #34494 Split deserialize from _run_function in RPC internal.py
* **#34493 Use SerializedPyObj in PythonRpcHandler**
* #34492 Remove _load_return_value from RPC internal.py
* #34491 Consolidate Python Messages to use SerializedPyObj
* #34490 Avoid copy contents in SerializedPyObj



Differential Revision: [D20347462](https://our.internmc.facebook.com/intern/diff/D20347462)