### PR TITLE
Split deserialize from _run_function in RPC internal.py

### DIFF
--- a/torch/distributed/rpc/internal.py
+++ b/torch/distributed/rpc/internal.py
@@ -98,7 +98,7 @@ class _InternalRPCPickler:
             except_str = str(e) + """ Default RPC pickler does not serialize
             function code. Ensure that UDFs are defined on both caller and
             callee modules."""
-            raise AttributeError(except_str)
+            ret = AttributeError(except_str)
 
         # restore _thread_local_tensor_tables.recv_tables if return
         # from nested call, otherwise clean up the table
@@ -122,7 +122,7 @@ def deserialize(binary_data, tensor_table):
     return _internal_rpc_pickler.deserialize(binary_data, tensor_table)
 
 
-def _run_function(binary_data, tensor_table):
+def _run_function(python_udf):
     r"""
     This function is exclusively called from C++.
     See ``torch/csrc/distributed/rpc/python_rpc_handler.cpp``.
@@ -131,7 +131,8 @@ def _run_function(binary_data, tensor_table):
     Wraps any exception in ``RemoteException`` if the function raises.
     """
     try:
-        python_udf = _internal_rpc_pickler.deserialize(binary_data, tensor_table)
+        if isinstance(python_udf, AttributeError):
+            raise python_udf
         result = python_udf.func(*python_udf.args, **python_udf.kwargs)
     except Exception as e:
         # except str = exception info + traceback string


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #34497 Don't run user function until all UserRRefs in the args are confirmed
* #34496 Split deserialize from runPythonUdf and remove generatePythonUDFResult
* #34495 Use SerializedPyObj in PythonRpcHandler::generatePythonUDFResult
* **#34494 Split deserialize from _run_function in RPC internal.py**
* #34493 Use SerializedPyObj in PythonRpcHandler
* #34492 Remove _load_return_value from RPC internal.py
* #34491 Consolidate Python Messages to use SerializedPyObj
* #34490 Avoid copy contents in SerializedPyObj



Differential Revision: [D20347463](https://our.internmc.facebook.com/intern/diff/D20347463)