### PR TITLE
Use SerializedPyObj in PythonRpcHandler::generatePythonUDFResult

### DIFF
--- a/torch/csrc/distributed/rpc/python_rpc_handler.cpp
+++ b/torch/csrc/distributed/rpc/python_rpc_handler.cpp
@@ -91,15 +91,11 @@ std::shared_ptr<torch::jit::script::CompilationUnit> PythonRpcHandler::
   return jitCompilationUnit_;
 }
 
-std::string PythonRpcHandler::generatePythonUDFResult(
-    const SerializedPyObj& serializedPyObj,
-    std::vector<torch::Tensor>& responseTensorTable) {
+SerializedPyObj PythonRpcHandler::generatePythonUDFResult(
+    const SerializedPyObj& serializedPyObj) {
   PROFILE_GIL_SCOPED_ACQUIRE;
   auto pythonUdf = deserialize(serializedPyObj);
-  py::tuple pres = pySerialize_(pyRunFunction_(std::move(pythonUdf)));
-  const auto& presStr = pres[0].cast<std::string>();
-  responseTensorTable = pres[1].cast<std::vector<torch::Tensor>>();
-  return std::move(presStr);
+  return serialize(pyRunFunction_(std::move(pythonUdf)));
 }
 
 py::object PythonRpcHandler::runPythonUDF(

--- a/torch/csrc/distributed/rpc/python_rpc_handler.h
+++ b/torch/csrc/distributed/rpc/python_rpc_handler.h
@@ -20,9 +20,8 @@ class PYBIND11_EXPORT PythonRpcHandler {
   static PythonRpcHandler& getInstance();
 
   // Deserialize Python function, run it, and serialize its return value.
-  std::string generatePythonUDFResult(
-      const SerializedPyObj& serializedPyObj,
-      std::vector<torch::Tensor>& responseTensorTable);
+  SerializedPyObj generatePythonUDFResult(
+      const SerializedPyObj& serializedPyObj);
 
   // Run a pickled Python UDF and return the result py::object
   py::object runPythonUDF(const SerializedPyObj& serializedObj);

--- a/torch/csrc/distributed/rpc/request_callback_impl.cpp
+++ b/torch/csrc/distributed/rpc/request_callback_impl.cpp
@@ -70,11 +70,9 @@ std::shared_ptr<FutureMessage> RequestCallbackImpl::processRpc(
     }
     case MessageType::PYTHON_CALL: {
       auto& pyCall = static_cast<PythonCall&>(rpc);
-      std::vector<torch::Tensor> responseTensorTable;
-      auto payload = PythonRpcHandler::getInstance().generatePythonUDFResult(
-          pyCall.serializedPyObj(), responseTensorTable);
-      SerializedPyObj serializedPyObj(
-          std::move(payload), std::move(responseTensorTable));
+      auto serializedPyObj =
+          PythonRpcHandler::getInstance().generatePythonUDFResult(
+              pyCall.serializedPyObj());
       return
           wrap(std::move(PythonResp(std::move(serializedPyObj))).toMessage());
     }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #34497 Don't run user function until all UserRRefs in the args are confirmed
* #34496 Split deserialize from runPythonUdf and remove generatePythonUDFResult
* **#34495 Use SerializedPyObj in PythonRpcHandler::generatePythonUDFResult**
* #34494 Split deserialize from _run_function in RPC internal.py
* #34493 Use SerializedPyObj in PythonRpcHandler
* #34492 Remove _load_return_value from RPC internal.py
* #34491 Consolidate Python Messages to use SerializedPyObj
* #34490 Avoid copy contents in SerializedPyObj



Differential Revision: [D20347466](https://our.internmc.facebook.com/intern/diff/D20347466)