### PR TITLE
.circleci: Switch should_run_job cuda 10.1 -> 10.2

### DIFF
--- a/.circleci/scripts/should_run_job.py
+++ b/.circleci/scripts/should_run_job.py
@@ -13,18 +13,18 @@ default_set = set([
     # Selected oldest Python 2 version to ensure Python 2 coverage
     'pytorch-linux-xenial-py2.7.9',
     # PyTorch CUDA
-    'pytorch-linux-xenial-cuda10.1-cudnn7-py3',
+    'pytorch-linux-xenial-cuda10.2-cudnn7-py3',
     # PyTorch ASAN
     'pytorch-linux-xenial-py3-clang5-asan',
     # PyTorch DEBUG
     'pytorch-linux-xenial-py3.6-gcc5.4',
     # LibTorch
-    'pytorch-libtorch-linux-xenial-cuda10.1-cudnn7-py3',
+    'pytorch-libtorch-linux-xenial-cuda10.2-cudnn7-py3',
 
     # Caffe2 CPU
     'caffe2-py2-mkl-ubuntu16.04',
     # Caffe2 CUDA
-    'caffe2-py3.5-cuda10.1-cudnn7-ubuntu16.04',
+    'caffe2-py3.5-cuda10.2-cudnn7-ubuntu16.04',
     # Caffe2 ONNX
     'caffe2-onnx-py2-gcc5-ubuntu16.04',
     'caffe2-onnx-main-py3.6-clang7-ubuntu16.04',


### PR DESCRIPTION
We updated the default jobs to run in a different PR but neglected to
update this script as well.

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

