### PR TITLE
[PyTorch][Dist] Trigger pre/post hooks of output function nodes under distributed autograd

### DIFF
--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -631,13 +631,13 @@ void Engine::evaluate_function(
     if (auto* capture_vec = fn_info.captures_.get()) {
       // Lock mutex for writing to graph_task->captured_vars_.
       std::lock_guard<std::mutex> lock(graph_task->mutex_);
+      for (auto& hook : fn_info.hooks_) {
+        inputs.inputVariables() = (*hook)(inputs.inputVariables());
+      }
       for (auto capture : *capture_vec) {
         graph_task->captured_vars_[capture.output_idx_] =
             inputs[capture.input_idx_];
       }
-    }
-    for (auto& hook : fn_info.hooks_) {
-      (*hook)(inputs.getInputs());
     }
     if (!fn_info.needed_) {
       // Skip execution if we don't need to execute the function.

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -636,6 +636,9 @@ void Engine::evaluate_function(
             inputs[capture.input_idx_];
       }
     }
+    for (auto& hook : fn_info.hooks_) {
+      (*hook)(inputs.toVariables());
+    }
     if (!fn_info.needed_) {
       // Skip execution if we don't need to execute the function.
       return;

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -637,7 +637,7 @@ void Engine::evaluate_function(
       }
     }
     for (auto& hook : fn_info.hooks_) {
-      (*hook)(inputs.toVariables());
+      (*hook)(inputs.getInputs());
     }
     if (!fn_info.needed_) {
       // Skip execution if we don't need to execute the function.

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -632,11 +632,11 @@ void Engine::evaluate_function(
       // Lock mutex for writing to graph_task->captured_vars_.
       std::lock_guard<std::mutex> lock(graph_task->mutex_);
       for (const auto& capture : *capture_vec) {
+        auto& captured_grad = graph_task->captured_vars_[capture.output_idx_];
+        captured_grad = inputs[capture.input_idx_];
         for (auto& hook : capture.hooks_) {
-          inputs[capture.input_idx_] = (*hook)(inputs[capture.input_idx_]);
+          captured_grad = (*hook)(captured_grad);
         }
-        graph_task->captured_vars_[capture.output_idx_] =
-            inputs[capture.input_idx_];
       }
     }
     if (!fn_info.needed_) {

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -631,10 +631,10 @@ void Engine::evaluate_function(
     if (auto* capture_vec = fn_info.captures_.get()) {
       // Lock mutex for writing to graph_task->captured_vars_.
       std::lock_guard<std::mutex> lock(graph_task->mutex_);
-      for (auto& hook : fn_info.hooks_) {
-        inputs.inputVariables() = (*hook)(inputs.inputVariables());
-      }
-      for (auto capture : *capture_vec) {
+      for (const auto& capture : *capture_vec) {
+        for (auto& hook : capture.hooks_) {
+          inputs[capture.input_idx_] = (*hook)(inputs[capture.input_idx_]);
+        }
         graph_task->captured_vars_[capture.output_idx_] =
             inputs[capture.input_idx_];
       }

--- a/torch/csrc/autograd/engine.h
+++ b/torch/csrc/autograd/engine.h
@@ -64,9 +64,9 @@ struct GraphTask {
 
   // This hook will be executed when the grad is ready for an function
   // node regardless of whether the node will be applied.
-  struct GraphTaskFunctionPreHook {
-    virtual ~GraphTaskFunctionPreHook() = default;
-    virtual void operator()(const variable_list& grads) = 0;
+  struct GradCapturePreHook {
+    virtual ~GradCapturePreHook() = default;
+    virtual variable_list operator()(const variable_list& grads) = 0;
   };
 
   struct ExecInfo {
@@ -83,8 +83,9 @@ struct GraphTask {
 
     bool needed_ = false;
     std::unique_ptr<std::vector<Capture>> captures_;
-    // The hooks will be executed regardless of 'needed_' is true or false.
-    std::vector<std::unique_ptr<GraphTaskFunctionPreHook>> hooks_;
+    // The hooks will be executed, as long as 'captures_' is not nullptr,
+    // regardless of 'needed_' is true or false.
+    std::vector<std::unique_ptr<GradCapturePreHook>> hooks_;
   };
   // Exec info has a bit complicated semantics. If it's empty, it means the task
   // is run in a "default" mode, which means that all next_edges we encounter

--- a/torch/csrc/autograd/engine.h
+++ b/torch/csrc/autograd/engine.h
@@ -62,6 +62,8 @@ struct GraphTask {
   std::unordered_map<Node*, InputBuffer> not_ready_;
   std::unordered_map<Node*, int> dependencies_;
 
+  // This hook will be executed when the grad is ready for an function
+  // node regardless of whether the node will be applied.
   struct GraphTaskFunctionPreHook {
     virtual ~GraphTaskFunctionPreHook() = default;
     virtual void operator()(const variable_list& grads) = 0;

--- a/torch/csrc/autograd/engine.h
+++ b/torch/csrc/autograd/engine.h
@@ -62,6 +62,11 @@ struct GraphTask {
   std::unordered_map<Node*, InputBuffer> not_ready_;
   std::unordered_map<Node*, int> dependencies_;
 
+  struct GraphTaskFunctionPreHook {
+    virtual ~GraphTaskFunctionPreHook() = default;
+    virtual void operator()(const variable_list& grads) = 0;
+  };
+
   struct ExecInfo {
     struct Capture {
       Capture(int input_idx, int output_idx)
@@ -76,6 +81,8 @@ struct GraphTask {
 
     bool needed_ = false;
     std::unique_ptr<std::vector<Capture>> captures_;
+    // The hooks will be executed regardless of 'needed_' is true or false.
+    std::vector<std::unique_ptr<GraphTaskFunctionPreHook>> hooks_;
   };
   // Exec info has a bit complicated semantics. If it's empty, it means the task
   // is run in a "default" mode, which means that all next_edges we encounter

--- a/torch/csrc/autograd/engine.h
+++ b/torch/csrc/autograd/engine.h
@@ -62,19 +62,18 @@ struct GraphTask {
   std::unordered_map<Node*, InputBuffer> not_ready_;
   std::unordered_map<Node*, int> dependencies_;
 
-  // This hook will be executed when the grad is ready for an function
-  // node regardless of whether the node will be applied.
-  struct GradCapturePreHook {
-    virtual ~GradCapturePreHook() = default;
-    virtual variable_list operator()(const variable_list& grads) = 0;
-  };
-
   struct ExecInfo {
     struct Capture {
       Capture(int input_idx, int output_idx)
           : input_idx_(input_idx), output_idx_(output_idx) {}
       int input_idx_; // within Node inputs
       int output_idx_; // within the output vector of a GraphTask
+    };
+    // This hook will be executed when the grad is ready for an function
+    // node regardless of whether the node will be applied.
+    struct GradCapturePreHook {
+      virtual ~GradCapturePreHook() = default;
+      virtual variable_list operator()(const variable_list& grads) = 0;
     };
 
     bool should_execute() const {

--- a/torch/csrc/autograd/engine.h
+++ b/torch/csrc/autograd/engine.h
@@ -73,13 +73,17 @@ struct GraphTask {
       int input_idx_; // within Node inputs
       int output_idx_; // within the output vector of a GraphTask
 
-      // This hook will be executed before a grad is captured. The engine will
-      // capture the returned value.
-      struct GradCapturePreHook {
-        virtual ~GradCapturePreHook() = default;
+      // This hook will be executed after a grad is captured. The captured
+      // grad will be replaced by the return value of the hook.
+      struct GradCaptureHook {
+        virtual ~GradCaptureHook() = default;
         virtual torch::Tensor operator()(const torch::Tensor& grad) = 0;
       };
-      std::vector<std::unique_ptr<GradCapturePreHook>> hooks_;
+      // The hooks will be called one by one in the order. The input grad of a
+      // hook will be the output of its preceding hook. The first hook will take
+      // the captured grad as the input. The output of the last hook will
+      // replace the captured grad.
+      std::vector<std::unique_ptr<GradCaptureHook>> hooks_;
     };
 
     bool should_execute() const {

--- a/torch/csrc/autograd/engine.h
+++ b/torch/csrc/autograd/engine.h
@@ -3,6 +3,7 @@
 // Engine implements backpropagation from output variables and their gradients
 // to "root" variables (variables created by the user with requires_grad=True).
 
+#include <ATen/Tensor.h>
 #include <ATen/ThreadLocalState.h>
 #include <torch/csrc/WindowsTorchApiMacro.h>
 #include <torch/csrc/autograd/anomaly_mode.h>
@@ -10,7 +11,6 @@
 #include <torch/csrc/autograd/functions/basic_ops.h>
 #include <torch/csrc/autograd/input_buffer.h>
 #include <torch/csrc/utils/future.h>
-#include <torch/types.h>
 
 #include <deque>
 #include <exception>
@@ -77,7 +77,7 @@ struct GraphTask {
       // grad will be replaced by the return value of the hook.
       struct GradCaptureHook {
         virtual ~GradCaptureHook() = default;
-        virtual torch::Tensor operator()(const torch::Tensor& grad) = 0;
+        virtual at::Tensor operator()(const at::Tensor& grad) = 0;
       };
       // The hooks will be called one by one in the order. The input grad of a
       // hook will be the output of its preceding hook. The first hook will take

--- a/torch/csrc/autograd/engine.h
+++ b/torch/csrc/autograd/engine.h
@@ -79,10 +79,10 @@ struct GraphTask {
         virtual ~GradCaptureHook() = default;
         virtual at::Tensor operator()(const at::Tensor& grad) = 0;
       };
-      // The hooks will be called one by one in the order. The input grad of a
-      // hook will be the output of its preceding hook. The first hook will take
-      // the captured grad as the input. The output of the last hook will
-      // replace the captured grad.
+      // The hooks will be called one by one in the order as they were added.
+      // The input grad of a hook will be the output of its preceding hook. The
+      // first hook will take the captured grad as the input. The output of the
+      // last hook will replace the captured grad.
       std::vector<std::unique_ptr<GradCaptureHook>> hooks_;
     };
 

--- a/torch/csrc/autograd/input_buffer.h
+++ b/torch/csrc/autograd/input_buffer.h
@@ -33,7 +33,12 @@ struct InputBuffer {
 
   at::Device device() const;
 
-  Variable operator[](size_t pos) { return buffer[pos]; }
+  Variable operator[](size_t pos) {
+    return buffer[pos];
+  }
+  const std::vector<Variable>& toVariables() const {
+    return buffer;
+  }
 
   // Returns the inputs as a list of variables. Destroys given InputBuffer.
   static std::vector<Variable> variables(InputBuffer&& g);

--- a/torch/csrc/autograd/input_buffer.h
+++ b/torch/csrc/autograd/input_buffer.h
@@ -33,6 +33,9 @@ struct InputBuffer {
 
   at::Device device() const;
 
+
+  Variable operator[](size_t pos) { return buffer[pos]; }
+
   std::vector<Variable>& inputVariables() & {
     return buffer;
   }

--- a/torch/csrc/autograd/input_buffer.h
+++ b/torch/csrc/autograd/input_buffer.h
@@ -34,11 +34,8 @@ struct InputBuffer {
   at::Device device() const;
 
 
-  Variable operator[](size_t pos) { return buffer[pos]; }
-
-  std::vector<Variable>& inputVariables() & {
-    return buffer;
-  }
+  Variable operator[](size_t pos) const { return buffer[pos]; }
+  Variable& operator[](size_t pos) { return buffer[pos]; }
 
   // Returns the inputs as a list of variables. Destroys given InputBuffer.
   static std::vector<Variable> variables(InputBuffer&& g);

--- a/torch/csrc/autograd/input_buffer.h
+++ b/torch/csrc/autograd/input_buffer.h
@@ -33,10 +33,7 @@ struct InputBuffer {
 
   at::Device device() const;
 
-  Variable operator[](size_t pos) {
-    return buffer[pos];
-  }
-  const std::vector<Variable>& getInputs() const {
+  std::vector<Variable>& inputVariables() & {
     return buffer;
   }
 

--- a/torch/csrc/autograd/input_buffer.h
+++ b/torch/csrc/autograd/input_buffer.h
@@ -36,7 +36,7 @@ struct InputBuffer {
   Variable operator[](size_t pos) {
     return buffer[pos];
   }
-  const std::vector<Variable>& toVariables() const {
+  const std::vector<Variable>& getInputs() const {
     return buffer;
   }
 

--- a/torch/csrc/autograd/input_buffer.h
+++ b/torch/csrc/autograd/input_buffer.h
@@ -33,9 +33,7 @@ struct InputBuffer {
 
   at::Device device() const;
 
-
-  Variable operator[](size_t pos) const { return buffer[pos]; }
-  Variable& operator[](size_t pos) { return buffer[pos]; }
+  Variable operator[](size_t pos) { return buffer[pos]; }
 
   // Returns the inputs as a list of variables. Destroys given InputBuffer.
   static std::vector<Variable> variables(InputBuffer&& g);

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -544,7 +544,7 @@ static void _trace_post_record(
     return;
   }
 
-  node->i_(attr::inplace, is_inplace);
+  node->i_(jit::attr::inplace, is_inplace);
 
   // Isolate C variable ptrs in a vector
   int num_outputs = PyTuple_GET_SIZE(output_objects);

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -35,7 +35,7 @@ static bool in_bad_fork = false;  // True for children forked after cuda init
 // Called in the forked child if cuda has already been initialized
 static void forked_child() {
   in_bad_fork = true;
-  utils::set_run_yet_variable_to_false();
+  torch::utils::set_run_yet_variable_to_false();
   state = nullptr;
 }
 #endif

--- a/torch/csrc/distributed/autograd/context/context.h
+++ b/torch/csrc/distributed/autograd/context/context.h
@@ -71,7 +71,7 @@ class TORCH_API DistAutogradContext {
   friend class BackwardPassCleanupGuard;
   friend class DistEngine;
   friend class RecvRpcBackward;
-  friend class AccumulateGradPreHook;
+  friend class DistAccumulateGradPreHook;
 
   // Record that we would like to accumulate the provided gradient on the given
   // variable.

--- a/torch/csrc/distributed/autograd/context/context.h
+++ b/torch/csrc/distributed/autograd/context/context.h
@@ -71,6 +71,7 @@ class TORCH_API DistAutogradContext {
   friend class BackwardPassCleanupGuard;
   friend class DistEngine;
   friend class RecvRpcBackward;
+  friend class AccumulateGradPreHook;
 
   // Record that we would like to accumulate the provided gradient on the given
   // variable.

--- a/torch/csrc/distributed/autograd/context/context.h
+++ b/torch/csrc/distributed/autograd/context/context.h
@@ -71,7 +71,7 @@ class TORCH_API DistAutogradContext {
   friend class BackwardPassCleanupGuard;
   friend class DistEngine;
   friend class RecvRpcBackward;
-  friend class DistAccumulateGradPreHook;
+  friend class DistAccumulateGradCapturePreHook;
 
   // Record that we would like to accumulate the provided gradient on the given
   // variable.

--- a/torch/csrc/distributed/autograd/context/context.h
+++ b/torch/csrc/distributed/autograd/context/context.h
@@ -71,7 +71,7 @@ class TORCH_API DistAutogradContext {
   friend class BackwardPassCleanupGuard;
   friend class DistEngine;
   friend class RecvRpcBackward;
-  friend class DistAccumulateGradCapturePreHook;
+  friend class DistAccumulateGradCaptureHook;
 
   // Record that we would like to accumulate the provided gradient on the given
   // variable.

--- a/torch/csrc/distributed/autograd/engine/dist_engine.cpp
+++ b/torch/csrc/distributed/autograd/engine/dist_engine.cpp
@@ -29,7 +29,8 @@ static constexpr char* kNumAutogradContexts = "num_autograd_contexts";
 // This hook does 2 things:
 //   1. Accumuate the gard to RPC context.
 //   2. Call post hooks of the original AccumulateGrad.
-struct DistAccumulateGradCapturePreHook : GraphTask::GradCapturePreHook {
+struct DistAccumulateGradCapturePreHook
+    : GraphTask::ExecInfo::GradCapturePreHook {
   DistAccumulateGradCapturePreHook(
       std::shared_ptr<AccumulateGrad> accumulateGrad,
       ContextPtr autogradContext)

--- a/torch/csrc/distributed/autograd/engine/dist_engine.cpp
+++ b/torch/csrc/distributed/autograd/engine/dist_engine.cpp
@@ -1,6 +1,5 @@
 #include <queue>
 
-#include <torch/csrc/autograd/functions/utils.h>
 #include <torch/csrc/autograd/functions/accumulate_grad.h>
 #include <torch/csrc/autograd/input_buffer.h>
 #include <torch/csrc/distributed/autograd/context/container.h>

--- a/torch/csrc/distributed/autograd/engine/dist_engine.cpp
+++ b/torch/csrc/distributed/autograd/engine/dist_engine.cpp
@@ -27,8 +27,9 @@ static constexpr char* kNumAutogradContexts = "num_autograd_contexts";
 //   1. Accumuate the gard to RPC context.
 //   2. Call pre hooks of the original AccumulateGrad to modify the input grad.
 //   3. Call post hooks of the original AccumulateGrad.
-struct DistAccumulateGradCaptureHook
-    : GraphTask::ExecInfo::Capture::GradCaptureHook {
+class DistAccumulateGradCaptureHook
+    : public GraphTask::ExecInfo::Capture::GradCaptureHook {
+ public:
   DistAccumulateGradCaptureHook(
       std::shared_ptr<AccumulateGrad> accumulateGrad,
       ContextPtr autogradContext)

--- a/torch/csrc/distributed/autograd/engine/dist_engine.cpp
+++ b/torch/csrc/distributed/autograd/engine/dist_engine.cpp
@@ -39,15 +39,13 @@ struct DistAccumulateGradCaptureHook
     variable_list inputGrads = {grad};
     // It's intended that pre/post hooks are still called even if the grad is
     // undenfined here.
-    if (!accumulateGrad_->pre_hooks().empty()) {
-      for (const auto& hook : accumulateGrad_->pre_hooks()) {
-        inputGrads = (*hook)(inputGrads);
-        // A pre-hook should return a varaible list of the same size as the
-        // function's inputs.
-        TORCH_INTERNAL_ASSERT(inputGrads.size() == 1);
-      }
+    for (const auto& hook : accumulateGrad_->pre_hooks()) {
+      inputGrads = (*hook)(inputGrads);
+      // A pre-hook should return a varaible list of the same size as the
+      // function's inputs.
+      TORCH_INTERNAL_ASSERT(inputGrads.size() == 1);
     }
-  
+
     // It is possible that the grad is not defined since a separate
     // invocation of the autograd engine on the same node might actually
     // compute this gradient.
@@ -56,14 +54,12 @@ struct DistAccumulateGradCaptureHook
           accumulateGrad_->variable, inputGrads[0], 1 /* num_expected_refs */);
     }
 
-    if (!accumulateGrad_->post_hooks().empty()) {
-      const variable_list kEmptyOuput;
-      for (const auto& hook : accumulateGrad_->post_hooks()) {
-        const auto postHookOutput = (*hook)(kEmptyOuput, inputGrads);
-        // A post hook should return a varaible list of the same size as the
-        // function's outputs.
-        TORCH_INTERNAL_ASSERT(postHookOutput.empty());
-      }
+    const variable_list kEmptyOuput;
+    for (const auto& hook : accumulateGrad_->post_hooks()) {
+      const auto postHookOutput = (*hook)(kEmptyOuput, inputGrads);
+      // A post hook should return a varaible list of the same size as the
+      // function's outputs.
+      TORCH_INTERNAL_ASSERT(postHookOutput.empty());
     }
     return inputGrads[0];
   }

--- a/torch/csrc/distributed/autograd/engine/dist_engine.cpp
+++ b/torch/csrc/distributed/autograd/engine/dist_engine.cpp
@@ -23,9 +23,10 @@ using torch::autograd::variable_list;
 static constexpr char* kNumBackwardPasses = "num_current_backward_passes";
 static constexpr char* kNumAutogradContexts = "num_autograd_contexts";
 
-// This hook does 2 things:
+// This hook does 3 things:
 //   1. Accumuate the gard to RPC context.
-//   2. Call post hooks of the original AccumulateGrad.
+//   2. Call pre hooks of the original AccumulateGrad to modify the input grad.
+//   3. Call post hooks of the original AccumulateGrad.
 struct DistAccumulateGradCaptureHook
     : GraphTask::ExecInfo::Capture::GradCaptureHook {
   DistAccumulateGradCaptureHook(

--- a/torch/csrc/distributed/autograd/engine/dist_engine.cpp
+++ b/torch/csrc/distributed/autograd/engine/dist_engine.cpp
@@ -48,8 +48,14 @@ class DistAccumulateGradCaptureHook
     // invocation of the autograd engine on the same node might actually
     // compute this gradient.
     if (inputGrads[0].defined()) {
+      // Three internal references to 'inputGrads[0]' at this moment:
+      //   1. 'inputGrads[0]'
+      //   2. 'grad'
+      //   3. The captured grad in the callsite.
       autogradContext_->accumulateGrad(
-          accumulateGrad_->variable, inputGrads[0], 1 /* num_expected_refs */);
+          accumulateGrad_->variable,
+          inputGrads[0],
+          3 /* num_expected_refs */);
     }
 
     const variable_list kEmptyOuput;

--- a/torch/testing/_internal/distributed/rpc/dist_autograd_test.py
+++ b/torch/testing/_internal/distributed/rpc/dist_autograd_test.py
@@ -2111,7 +2111,7 @@ class DistAutogradTest(RpcAgentTestFixture):
             loss = a.sum()
             dist_autograd.backward(context_id, [loss])
             self.assertEqual(3, self.hook_called_times)
-            self.assertEqual(7, len(dist_autograd.get_gradients(context_id)))
+            self.assertEqual(1, len(dist_autograd.get_gradients(context_id)))
 
 @unittest.skipIf(
     not torch._six.PY3,

--- a/torch/testing/_internal/distributed/rpc/dist_autograd_test.py
+++ b/torch/testing/_internal/distributed/rpc/dist_autograd_test.py
@@ -2111,7 +2111,7 @@ class DistAutogradTest(RpcAgentTestFixture):
             loss = a.sum()
             dist_autograd.backward(context_id, [loss])
             self.assertEqual(3, self.hook_called_times)
-            self.assertEqual(1, len(dist_autograd.get_gradients(context_id)))
+            self.assertEqual(7, len(dist_autograd.get_gradients(context_id)))
 
 @unittest.skipIf(
     not torch._six.PY3,

--- a/torch/testing/_internal/distributed/rpc/dist_autograd_test.py
+++ b/torch/testing/_internal/distributed/rpc/dist_autograd_test.py
@@ -2083,7 +2083,6 @@ class DistAutogradTest(RpcAgentTestFixture):
             dist_autograd.backward(context_id, [loss], retain_graph=True)
             grads = dist_autograd.get_gradients(context_id)
             p_g = MyFunc.static_grad_ptr
-            self.assertTrue(a in grads)
             p_a = grads[a]._values().data_ptr()
             self.assertIsNotNone(MyFunc.static_grad_indices_ref)
             self.assertIsNotNone(MyFunc.static_grad_values_ref)


### PR DESCRIPTION
# Goals
Do the following things during a distributed backward pass.
1. Accumulate the gradient of a variable to RPC context once the gradient is ready instead of at the very end of the backward pass.
2. Run post/pre hooks installed in`AccumulateGrad` nodes once the gradient is ready for the variable. Currently, the hooks in `AccumulateGrad` are not executed just because the function `AccumulateGrad` itself is not even evaluated by the local engine.
3. Make it extensible to support post hooks installed by DDP's reducer.


# Introduce GradCapturePreHook

## Why do we need this?

### Root issue:

* dist engine uses the autograd.grad-like API on the vanilla engine and then in the Future callback populates the context with the gradients. This is a bad emulation of the .backward() call on the vanilla engine.

### Practical issue: 

* The leaf’s hook are not called (because associated with the AccumulateGrad that is not call in the autograd.grad-like API). Modules like DDP rely on these hooks.
* The Future is marked as completed before the context is actually populated with the grads leading to unexpected behavior on the user side.
* The Future callback is only called at the complete end of the backward and so too late for DDP if they want to overlap compute/transfert.

### Proposed solution:

* Provide hooks in the autograd.grad-like API that will allow the distributed engine to populate the context and call the hooks to better emulate the .backward call.

## Who can install a grad capture pre-hook?

This will be an internal hook at C++ level and it won’t be exposed to PyThon code. Only call-sites directly interacting with the local engine can install such hooks.

## Signature
The returned `grad` will be captured.
```
virtual const torch::Tensor& grad operator()(const torch::Tensor& grads) = 0;
```

## Where are hooks installed?

Grad capture pre-hooks are install in GraphTask::ExecInfo::Capture. ExecInfo is per node. Every backward run will have its own GraphTask instance.

## When/How will hooks be called?

When the local engine captures the grads for a node, all grad capture pre hooks are called one by one in the order they are added. The output grads of the hooks will replace the original grads.
The output of the last hook will be used for grad capturing.

# Test plan

All existing tests should pass.
```
python setup.py develop

python test/distributed/rpc/test_dist_autograd_spawn.py DistAutogradTestWithSpawn.test_post_hooks

make test_dist_autograd && bin/test_dist_autograd

```