### PR TITLE
[C++ API] Update torch::nn layer docs

### DIFF
--- a/.circleci/scripts/cpp_doc_push_script.sh
+++ b/.circleci/scripts/cpp_doc_push_script.sh
@@ -72,10 +72,10 @@ time python tools/setup_helpers/generate_code.py \
 
 # Build the docs
 pushd docs/cpp
-pip install breathe==4.11.1 bs4 lxml six
+pip install breathe>=4.13.0 bs4 lxml six
 pip install --no-cache-dir -e "git+https://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme"
 pip install exhale>=0.2.1
-pip install sphinx==1.8.5
+pip install sphinx>=2.0
 # Uncomment once it is fixed
 # pip install -r requirements.txt
 time make VERBOSE=1 html -j

--- a/docs/cpp/source/Doxyfile
+++ b/docs/cpp/source/Doxyfile
@@ -42,7 +42,7 @@ RECURSIVE              = YES
 EXCLUDE = ../../../torch/csrc/api/include/torch/nn/pimpl-inl.h \
           ../../../torch/csrc/api/include/torch/detail
 # Increase the max node size for our large files
-DOT_GRAPH_MAX_NODES    = 5
+DOT_GRAPH_MAX_NODES    = 100
 ################################################################################
 # Output formats for Doxygen to create.                                        #
 ################################################################################

--- a/docs/cpp/source/Doxyfile
+++ b/docs/cpp/source/Doxyfile
@@ -29,8 +29,7 @@ HTML_OUTPUT            = doxygen_html
 # {repo_root}/docs/cpp/source/../../.. -> {repo_root}
 STRIP_FROM_PATH        = ../../..
 # What folders / files Doxygen should process.
-INPUT                  = ../../../torch/csrc/api/include \
-                         ../../../torch/csrc/api/src
+INPUT                  = ../../../torch/csrc/api/include/torch/nn
 # Don't include .cpp files!
 FILE_PATTERNS          = *.h
 # If you need this to be YES, exhale will probably break.

--- a/docs/cpp/source/Doxyfile
+++ b/docs/cpp/source/Doxyfile
@@ -29,7 +29,37 @@ HTML_OUTPUT            = doxygen_html
 # {repo_root}/docs/cpp/source/../../.. -> {repo_root}
 STRIP_FROM_PATH        = ../../..
 # What folders / files Doxygen should process.
-INPUT                  = ../../../torch/csrc/api/include/torch/nn
+INPUT                  = ../../../aten/src/ATen/ATen.h \
+                         ../../../aten/src/ATen/Backend.h \
+                         ../../../aten/src/ATen/core/ivalue.h \
+                         ../../../aten/src/ATen/core/ScalarType.h \
+                         ../../../aten/src/ATen/cuda/CUDAContext.h \
+                         ../../../aten/src/ATen/cudnn/Descriptors.h \
+                         ../../../aten/src/ATen/cudnn/Handles.h \
+                         ../../../aten/src/ATen/cudnn/Types.h \
+                         ../../../aten/src/ATen/cudnn/Utils.h \
+                         ../../../aten/src/ATen/DeviceGuard.h \
+                         ../../../aten/src/ATen/Layout.h \
+                         ../../../aten/src/ATen/mkl/Descriptors.h \
+                         ../../../aten/src/ATen/Scalar.h \
+                         ../../../aten/src/ATen/TensorOptions.h \
+                         ../../../aten/src/ATen/core/Tensor.h \
+                         ../../../build/aten/src/ATen/Functions.h \
+                         ../../../build/aten/src/ATen/core/TensorBody.h \
+                         ../../../c10/core/Device.h \
+                         ../../../c10/core/DeviceType.h \
+                         ../../../c10/util/Half.h \
+                         ../../../c10/util/ArrayRef.h \
+                         ../../../c10/util/Exception.h \
+                         ../../../c10/util/Optional.h \
+                         ../../../c10/cuda/CUDAGuard.h \
+                         ../../../c10/cuda/CUDAStream.h \
+                         ../../../torch/csrc/api/include \
+                         ../../../torch/csrc/api/src \
+                         ../../../torch/csrc/autograd/generated/variable_factories.h \
+                         ../../../torch/csrc/jit/runtime/custom_operator.h \
+                         ../../../torch/csrc/jit/serialization/import.h \
+                         ../../../torch/csrc/jit/api/module.h
 # Don't include .cpp files!
 FILE_PATTERNS          = *.h
 # If you need this to be YES, exhale will probably break.

--- a/docs/cpp/source/Doxyfile
+++ b/docs/cpp/source/Doxyfile
@@ -29,36 +29,8 @@ HTML_OUTPUT            = doxygen_html
 # {repo_root}/docs/cpp/source/../../.. -> {repo_root}
 STRIP_FROM_PATH        = ../../..
 # What folders / files Doxygen should process.
-INPUT                  = ../../../aten/src/ATen/ATen.h \
-                         ../../../aten/src/ATen/Backend.h \
-                         ../../../aten/src/ATen/core/ivalue.h \
-                         ../../../aten/src/ATen/core/ScalarType.h \
-                         ../../../aten/src/ATen/cuda/CUDAContext.h \
-                         ../../../aten/src/ATen/cudnn/Descriptors.h \
-                         ../../../aten/src/ATen/cudnn/Handles.h \
-                         ../../../aten/src/ATen/cudnn/Types.h \
-                         ../../../aten/src/ATen/cudnn/Utils.h \
-                         ../../../aten/src/ATen/DeviceGuard.h \
-                         ../../../aten/src/ATen/Layout.h \
-                         ../../../aten/src/ATen/mkl/Descriptors.h \
-                         ../../../aten/src/ATen/Scalar.h \
-                         ../../../aten/src/ATen/TensorOptions.h \
-                         ../../../aten/src/ATen/core/Tensor.h \
-                         ../../../build/aten/src/ATen/Functions.h \
-                         ../../../c10/core/Device.h \
-                         ../../../c10/core/DeviceType.h \
-                         ../../../c10/util/Half.h \
-                         ../../../c10/util/ArrayRef.h \
-                         ../../../c10/util/Exception.h \
-                         ../../../c10/util/Optional.h \
-                         ../../../c10/cuda/CUDAGuard.h \
-                         ../../../c10/cuda/CUDAStream.h \
-                         ../../../torch/csrc/api/include \
-                         ../../../torch/csrc/api/src \
-                         ../../../torch/csrc/autograd/generated/variable_factories.h \
-                         ../../../torch/csrc/jit/runtime/custom_operator.h \
-                         ../../../torch/csrc/jit/serialization/import.h \
-                         ../../../torch/csrc/jit/api/module.h
+INPUT                  = ../../../torch/csrc/api/include \
+                         ../../../torch/csrc/api/src
 # Don't include .cpp files!
 FILE_PATTERNS          = *.h
 # If you need this to be YES, exhale will probably break.
@@ -71,7 +43,7 @@ RECURSIVE              = YES
 EXCLUDE = ../../../torch/csrc/api/include/torch/nn/pimpl-inl.h \
           ../../../torch/csrc/api/include/torch/detail
 # Increase the max node size for our large files
-DOT_GRAPH_MAX_NODES    = 100
+DOT_GRAPH_MAX_NODES    = 5
 ################################################################################
 # Output formats for Doxygen to create.                                        #
 ################################################################################

--- a/test/cpp/api/modules.cpp
+++ b/test/cpp/api/modules.cpp
@@ -4065,11 +4065,7 @@ TEST_F(ModulesTest, PrettyPrintBatchNorm1d) {
   ASSERT_EQ(
       c10::str(BatchNorm1d(
           BatchNorm1dOptions(4).eps(0.5).momentum(0.1).affine(false)
-          ///
-/// Example:
-/// ```
-/// BatchNorm1d model(BatchNorm1dOptions(4).eps(0.5).momentum(0.1).affine(false).track_running_stats(true));
-/// ```)),
+          .track_running_stats(true))),
       "torch::nn::BatchNorm1d(4, eps=0.5, momentum=0.1, affine=false, track_running_stats=true)");
 }
 

--- a/test/cpp/api/modules.cpp
+++ b/test/cpp/api/modules.cpp
@@ -4065,7 +4065,11 @@ TEST_F(ModulesTest, PrettyPrintBatchNorm1d) {
   ASSERT_EQ(
       c10::str(BatchNorm1d(
           BatchNorm1dOptions(4).eps(0.5).momentum(0.1).affine(false)
-          .track_running_stats(true))),
+          ///
+/// Example:
+/// ```
+/// BatchNorm1d model(BatchNorm1dOptions(4).eps(0.5).momentum(0.1).affine(false).track_running_stats(true));
+/// ```)),
       "torch::nn::BatchNorm1d(4, eps=0.5, momentum=0.1, affine=false, track_running_stats=true)");
 }
 

--- a/torch/csrc/api/include/torch/nn/modules/activation.h
+++ b/torch/csrc/api/include/torch/nn/modules/activation.h
@@ -16,6 +16,14 @@ namespace nn {
 /// Applies elu over a given input.
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.ELU to learn
 /// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::ELUOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// ELU model(ELUOptions().alpha(42.42).inplace(true));
+/// ```
 class TORCH_API ELUImpl : public torch::nn::Cloneable<ELUImpl> {
  public:
   explicit ELUImpl(const ELUOptions& options_ = {});
@@ -31,6 +39,11 @@ class TORCH_API ELUImpl : public torch::nn::Cloneable<ELUImpl> {
   ELUOptions options;
 };
 
+/// A `ModuleHolder` subclass for `ELUImpl`.
+/// See the documentation for `ELUImpl` class to learn what methods it
+/// provides, and examples of how to use `ELU` with `torch::nn::ELUOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
+/// module storage semantics.
 TORCH_MODULE(ELU);
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ SELU ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -38,6 +51,14 @@ TORCH_MODULE(ELU);
 /// Applies the selu function element-wise.
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.SELU to learn
 /// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::SELUOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// SELU model(SELUOptions().inplace(true));
+/// ```
 class TORCH_API SELUImpl : public torch::nn::Cloneable<SELUImpl> {
  public:
   explicit SELUImpl(const SELUOptions& options_ = {});
@@ -53,6 +74,11 @@ class TORCH_API SELUImpl : public torch::nn::Cloneable<SELUImpl> {
   SELUOptions options;
 };
 
+/// A `ModuleHolder` subclass for `SELUImpl`.
+/// See the documentation for `SELUImpl` class to learn what methods it
+/// provides, and examples of how to use `SELU` with `torch::nn::SELUOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
+/// module storage semantics.
 TORCH_MODULE(SELU);
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Hardshrink ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -60,6 +86,14 @@ TORCH_MODULE(SELU);
 /// Applies the hard shrinkage function element-wise.
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.Hardshrink to learn
 /// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::HardshrinkOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// Hardshrink model(HardshrinkOptions().lambda(42.42));
+/// ```
 class TORCH_API HardshrinkImpl : public torch::nn::Cloneable<HardshrinkImpl> {
  public:
   explicit HardshrinkImpl(const HardshrinkOptions& options_ = {});
@@ -75,6 +109,11 @@ class TORCH_API HardshrinkImpl : public torch::nn::Cloneable<HardshrinkImpl> {
   HardshrinkOptions options;
 };
 
+/// A `ModuleHolder` subclass for `HardshrinkImpl`.
+/// See the documentation for `HardshrinkImpl` class to learn what methods it
+/// provides, and examples of how to use `Hardshrink` with `torch::nn::HardshrinkOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
+/// module storage semantics.
 TORCH_MODULE(Hardshrink);
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Hardtanh ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -82,6 +121,14 @@ TORCH_MODULE(Hardshrink);
 /// Applies the HardTanh function element-wise.
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.Hardtanh to learn
 /// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::HardtanhOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// Hardtanh model(HardtanhOptions().min_val(-42.42).max_val(0.42).inplace(true));
+/// ```
 class TORCH_API HardtanhImpl : public torch::nn::Cloneable<HardtanhImpl> {
  public:
   explicit HardtanhImpl(const HardtanhOptions& options_ = {});
@@ -97,6 +144,11 @@ class TORCH_API HardtanhImpl : public torch::nn::Cloneable<HardtanhImpl> {
   HardtanhOptions options;
 };
 
+/// A `ModuleHolder` subclass for `HardtanhImpl`.
+/// See the documentation for `HardtanhImpl` class to learn what methods it
+/// provides, and examples of how to use `Hardtanh` with `torch::nn::HardtanhOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
+/// module storage semantics.
 TORCH_MODULE(Hardtanh);
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ LeakyReLU ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -104,6 +156,14 @@ TORCH_MODULE(Hardtanh);
 /// Applies the LeakyReLU function element-wise.
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.LeakyReLU to learn
 /// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::LeakyReLUOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// LeakyReLU model(LeakyReLUOptions().negative_slope(0.42).inplace(true));
+/// ```
 class TORCH_API LeakyReLUImpl : public torch::nn::Cloneable<LeakyReLUImpl> {
  public:
   explicit LeakyReLUImpl(const LeakyReLUOptions& options_ = {});
@@ -119,6 +179,11 @@ class TORCH_API LeakyReLUImpl : public torch::nn::Cloneable<LeakyReLUImpl> {
   LeakyReLUOptions options;
 };
 
+/// A `ModuleHolder` subclass for `LeakyReLUImpl`.
+/// See the documentation for `LeakyReLUImpl` class to learn what methods it
+/// provides, and examples of how to use `LeakyReLU` with `torch::nn::LeakyReLUOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
+/// module storage semantics.
 TORCH_MODULE(LeakyReLU);
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ LogSigmoid ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -136,6 +201,10 @@ class TORCH_API LogSigmoidImpl : public torch::nn::Cloneable<LogSigmoidImpl> {
   void pretty_print(std::ostream& stream) const override;
 };
 
+/// A `ModuleHolder` subclass for `LogSigmoidImpl`.
+/// See the documentation for `LogSigmoidImpl` class to learn what methods it
+/// provides, or the documentation for `ModuleHolder` to learn about PyTorch's
+/// module storage semantics.
 TORCH_MODULE(LogSigmoid);
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Softmax ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -143,6 +212,14 @@ TORCH_MODULE(LogSigmoid);
 /// Applies the Softmax function.
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.Softmax to learn
 /// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::SoftmaxOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// Softmax model(SoftmaxOptions(1));
+/// ```
 class TORCH_API SoftmaxImpl : public torch::nn::Cloneable<SoftmaxImpl> {
  public:
   explicit SoftmaxImpl(int64_t dim) : SoftmaxImpl(SoftmaxOptions(dim)) {}
@@ -158,6 +235,11 @@ class TORCH_API SoftmaxImpl : public torch::nn::Cloneable<SoftmaxImpl> {
   SoftmaxOptions options;
 };
 
+/// A `ModuleHolder` subclass for `SoftmaxImpl`.
+/// See the documentation for `SoftmaxImpl` class to learn what methods it
+/// provides, and examples of how to use `Softmax` with `torch::nn::SoftmaxOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
+/// module storage semantics.
 TORCH_MODULE(Softmax);
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Softmin ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -165,6 +247,14 @@ TORCH_MODULE(Softmax);
 /// Applies the Softmin function element-wise.
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.Softmin to learn
 /// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::SoftminOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// Softmin model(SoftminOptions(1));
+/// ```
 class TORCH_API SoftminImpl : public torch::nn::Cloneable<SoftminImpl> {
  public:
   explicit SoftminImpl(int64_t dim) : SoftminImpl(SoftminOptions(dim)) {}
@@ -180,6 +270,11 @@ class TORCH_API SoftminImpl : public torch::nn::Cloneable<SoftminImpl> {
   SoftminOptions options;
 };
 
+/// A `ModuleHolder` subclass for `SoftminImpl`.
+/// See the documentation for `SoftminImpl` class to learn what methods it
+/// provides, and examples of how to use `Softmin` with `torch::nn::SoftminOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
+/// module storage semantics.
 TORCH_MODULE(Softmin);
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ LogSoftmax ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -187,6 +282,14 @@ TORCH_MODULE(Softmin);
 /// Applies the LogSoftmax function element-wise.
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.LogSoftmax to learn
 /// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::LogSoftmaxOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// LogSoftmax model(LogSoftmaxOptions(1));
+/// ```
 class TORCH_API LogSoftmaxImpl : public torch::nn::Cloneable<LogSoftmaxImpl> {
  public:
   explicit LogSoftmaxImpl(int64_t dim) : LogSoftmaxImpl(LogSoftmaxOptions(dim)) {}
@@ -202,6 +305,11 @@ class TORCH_API LogSoftmaxImpl : public torch::nn::Cloneable<LogSoftmaxImpl> {
   LogSoftmaxOptions options;
 };
 
+/// A `ModuleHolder` subclass for `LogSoftmaxImpl`.
+/// See the documentation for `LogSoftmaxImpl` class to learn what methods it
+/// provides, and examples of how to use `LogSoftmax` with `torch::nn::LogSoftmaxOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
+/// module storage semantics.
 TORCH_MODULE(LogSoftmax);
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Softmax2d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -219,6 +327,10 @@ class TORCH_API Softmax2dImpl : public torch::nn::Cloneable<Softmax2dImpl> {
   void pretty_print(std::ostream& stream) const override;
 };
 
+/// A `ModuleHolder` subclass for `Softmax2dImpl`.
+/// See the documentation for `Softmax2dImpl` class to learn what methods it
+/// provides, or the documentation for `ModuleHolder` to learn about PyTorch's
+/// module storage semantics.
 TORCH_MODULE(Softmax2d);
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ PReLU ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -226,6 +338,14 @@ TORCH_MODULE(Softmax2d);
 /// Applies the PReLU function element-wise.
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.PReLU to learn
 /// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::PReLUOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// PReLU model(PReLUOptions().num_parameters(42));
+/// ```
 class TORCH_API PReLUImpl : public torch::nn::Cloneable<PReLUImpl> {
  public:
   explicit PReLUImpl(const PReLUOptions& options_ = {});
@@ -244,6 +364,11 @@ class TORCH_API PReLUImpl : public torch::nn::Cloneable<PReLUImpl> {
   Tensor weight;
 };
 
+/// A `ModuleHolder` subclass for `PReLUImpl`.
+/// See the documentation for `PReLUImpl` class to learn what methods it
+/// provides, and examples of how to use `PReLU` with `torch::nn::PReLUOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
+/// module storage semantics.
 TORCH_MODULE(PReLU);
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ReLU ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -251,6 +376,14 @@ TORCH_MODULE(PReLU);
 /// Applies the ReLU function element-wise.
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.ReLU to learn
 /// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::ReLUOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// ReLU model(ReLUOptions().inplace(true));
+/// ```
 class TORCH_API ReLUImpl : public torch::nn::Cloneable<ReLUImpl> {
  public:
   explicit ReLUImpl(const ReLUOptions& options_ = {});
@@ -266,6 +399,11 @@ class TORCH_API ReLUImpl : public torch::nn::Cloneable<ReLUImpl> {
   ReLUOptions options;
 };
 
+/// A `ModuleHolder` subclass for `ReLUImpl`.
+/// See the documentation for `ReLUImpl` class to learn what methods it
+/// provides, and examples of how to use `ReLU` with `torch::nn::ReLUOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
+/// module storage semantics.
 TORCH_MODULE(ReLU);
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ReLU6 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -273,6 +411,14 @@ TORCH_MODULE(ReLU);
 /// Applies the ReLU6 function element-wise.
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.ReLU6 to learn
 /// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::ReLU6Options` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// ReLU6 model(ReLU6Options().inplace(true));
+/// ```
 class TORCH_API ReLU6Impl : public torch::nn::Cloneable<ReLU6Impl> {
  public:
   explicit ReLU6Impl(const ReLU6Options& options_ = {});
@@ -288,6 +434,11 @@ class TORCH_API ReLU6Impl : public torch::nn::Cloneable<ReLU6Impl> {
   ReLU6Options options;
 };
 
+/// A `ModuleHolder` subclass for `ReLU6Impl`.
+/// See the documentation for `ReLU6Impl` class to learn what methods it
+/// provides, and examples of how to use `ReLU6` with `torch::nn::ReLU6Options`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
+/// module storage semantics.
 TORCH_MODULE(ReLU6);
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ RReLU ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -295,6 +446,14 @@ TORCH_MODULE(ReLU6);
 /// Applies the RReLU function element-wise.
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.RReLU to learn
 /// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::RReLUOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// RReLU model(RReLUOptions().lower(0.24).upper(0.42).inplace(true));
+/// ```
 class TORCH_API RReLUImpl : public torch::nn::Cloneable<RReLUImpl> {
  public:
   explicit RReLUImpl(const RReLUOptions& options_ = {});
@@ -310,6 +469,11 @@ class TORCH_API RReLUImpl : public torch::nn::Cloneable<RReLUImpl> {
   RReLUOptions options;
 };
 
+/// A `ModuleHolder` subclass for `RReLUImpl`.
+/// See the documentation for `RReLUImpl` class to learn what methods it
+/// provides, and examples of how to use `RReLU` with `torch::nn::RReLUOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
+/// module storage semantics.
 TORCH_MODULE(RReLU);
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ CELU ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -317,6 +481,14 @@ TORCH_MODULE(RReLU);
 /// Applies celu over a given input.
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.CELU to learn
 /// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::CELUOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// CELU model(CELUOptions().alpha(42.42).inplace(true));
+/// ```
 class TORCH_API CELUImpl : public torch::nn::Cloneable<CELUImpl> {
  public:
   explicit CELUImpl(const CELUOptions& options_ = {});
@@ -332,6 +504,11 @@ class TORCH_API CELUImpl : public torch::nn::Cloneable<CELUImpl> {
   CELUOptions options;
 };
 
+/// A `ModuleHolder` subclass for `CELUImpl`.
+/// See the documentation for `CELUImpl` class to learn what methods it
+/// provides, and examples of how to use `CELU` with `torch::nn::CELUOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
+/// module storage semantics.
 TORCH_MODULE(CELU);
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ GLU ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -339,6 +516,14 @@ TORCH_MODULE(CELU);
 /// Applies glu over a given input.
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.GLU to learn
 /// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::GLUOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// GLU model(GLUOptions(1));
+/// ```
 class TORCH_API GLUImpl : public torch::nn::Cloneable<GLUImpl> {
  public:
   explicit GLUImpl(const GLUOptions& options_ = {});
@@ -354,6 +539,11 @@ class TORCH_API GLUImpl : public torch::nn::Cloneable<GLUImpl> {
   GLUOptions options;
 };
 
+/// A `ModuleHolder` subclass for `GLUImpl`.
+/// See the documentation for `GLUImpl` class to learn what methods it
+/// provides, and examples of how to use `GLU` with `torch::nn::GLUOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
+/// module storage semantics.
 TORCH_MODULE(GLU);
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ GELU ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -371,6 +561,10 @@ class TORCH_API GELUImpl : public torch::nn::Cloneable<GELUImpl> {
   void pretty_print(std::ostream& stream) const override;
 };
 
+/// A `ModuleHolder` subclass for `GELUImpl`.
+/// See the documentation for `GELUImpl` class to learn what methods it
+/// provides, or the documentation for `ModuleHolder` to learn about PyTorch's
+/// module storage semantics.
 TORCH_MODULE(GELU);
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Sigmoid ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -388,6 +582,10 @@ class TORCH_API SigmoidImpl : public torch::nn::Cloneable<SigmoidImpl> {
   void pretty_print(std::ostream& stream) const override;
 };
 
+/// A `ModuleHolder` subclass for `SigmoidImpl`.
+/// See the documentation for `SigmoidImpl` class to learn what methods it
+/// provides, or the documentation for `ModuleHolder` to learn about PyTorch's
+/// module storage semantics.
 TORCH_MODULE(Sigmoid);
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Softplus ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -395,6 +593,14 @@ TORCH_MODULE(Sigmoid);
 /// Applies softplus over a given input.
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.Softplus to learn
 /// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::SoftplusOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// Softplus model(SoftplusOptions().beta(0.24).threshold(42.42));
+/// ```
 class TORCH_API SoftplusImpl : public torch::nn::Cloneable<SoftplusImpl> {
  public:
   explicit SoftplusImpl(const SoftplusOptions& options_ = {});
@@ -410,6 +616,11 @@ class TORCH_API SoftplusImpl : public torch::nn::Cloneable<SoftplusImpl> {
   SoftplusOptions options;
 };
 
+/// A `ModuleHolder` subclass for `SoftplusImpl`.
+/// See the documentation for `SoftplusImpl` class to learn what methods it
+/// provides, and examples of how to use `Softplus` with `torch::nn::SoftplusOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
+/// module storage semantics.
 TORCH_MODULE(Softplus);
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Softshrink ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -417,6 +628,14 @@ TORCH_MODULE(Softplus);
 /// Applies the soft shrinkage function element-wise.
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.Softshrink to learn
 /// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::SoftshrinkOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// Softshrink model(SoftshrinkOptions(42.42));
+/// ```
 class TORCH_API SoftshrinkImpl : public torch::nn::Cloneable<SoftshrinkImpl> {
  public:
   explicit SoftshrinkImpl(const SoftshrinkOptions& options_ = {});
@@ -432,6 +651,11 @@ class TORCH_API SoftshrinkImpl : public torch::nn::Cloneable<SoftshrinkImpl> {
   SoftshrinkOptions options;
 };
 
+/// A `ModuleHolder` subclass for `SoftshrinkImpl`.
+/// See the documentation for `SoftshrinkImpl` class to learn what methods it
+/// provides, and examples of how to use `Softshrink` with `torch::nn::SoftshrinkOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
+/// module storage semantics.
 TORCH_MODULE(Softshrink);
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Softsign ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -449,6 +673,10 @@ class TORCH_API SoftsignImpl : public torch::nn::Cloneable<SoftsignImpl> {
   void pretty_print(std::ostream& stream) const override;
 };
 
+/// A `ModuleHolder` subclass for `SoftsignImpl`.
+/// See the documentation for `SoftsignImpl` class to learn what methods it
+/// provides, or the documentation for `ModuleHolder` to learn about PyTorch's
+/// module storage semantics.
 TORCH_MODULE(Softsign);
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Tanh ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -466,6 +694,10 @@ class TORCH_API TanhImpl : public torch::nn::Cloneable<TanhImpl> {
   void pretty_print(std::ostream& stream) const override;
 };
 
+/// A `ModuleHolder` subclass for `TanhImpl`.
+/// See the documentation for `TanhImpl` class to learn what methods it
+/// provides, or the documentation for `ModuleHolder` to learn about PyTorch's
+/// module storage semantics.
 TORCH_MODULE(Tanh);
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Tanhshrink ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -483,6 +715,10 @@ class TORCH_API TanhshrinkImpl : public torch::nn::Cloneable<TanhshrinkImpl> {
   void pretty_print(std::ostream& stream) const override;
 };
 
+/// A `ModuleHolder` subclass for `TanhshrinkImpl`.
+/// See the documentation for `TanhshrinkImpl` class to learn what methods it
+/// provides, or the documentation for `ModuleHolder` to learn about PyTorch's
+/// module storage semantics.
 TORCH_MODULE(Tanhshrink);
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Threshold ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -490,6 +726,14 @@ TORCH_MODULE(Tanhshrink);
 /// Applies the Threshold function element-wise.
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.Threshold to learn
 /// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::ThresholdOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// Threshold model(ThresholdOptions(42.42, 24.24).inplace(true));
+/// ```
 class TORCH_API ThresholdImpl : public torch::nn::Cloneable<ThresholdImpl> {
  public:
   ThresholdImpl(double threshold, double value)
@@ -507,6 +751,11 @@ class TORCH_API ThresholdImpl : public torch::nn::Cloneable<ThresholdImpl> {
   ThresholdOptions options;
 };
 
+/// A `ModuleHolder` subclass for `ThresholdImpl`.
+/// See the documentation for `ThresholdImpl` class to learn what methods it
+/// provides, and examples of how to use `Threshold` with `torch::nn::ThresholdOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
+/// module storage semantics.
 TORCH_MODULE(Threshold);
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ MultiheadAttention ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -514,6 +763,14 @@ TORCH_MODULE(Threshold);
 /// Applies the MultiheadAttention function element-wise.
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.MultiheadAttention
 /// to learn about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::MultiheadAttentionOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// MultiheadAttention model(MultiheadAttentionOptions(20, 10).bias(false));
+/// ```
 class TORCH_API MultiheadAttentionImpl
   : public torch::nn::Cloneable<MultiheadAttentionImpl> {
  public:
@@ -547,6 +804,11 @@ class TORCH_API MultiheadAttentionImpl
   int64_t head_dim;
 };
 
+/// A `ModuleHolder` subclass for `MultiheadAttentionImpl`.
+/// See the documentation for `MultiheadAttentionImpl` class to learn what methods it
+/// provides, and examples of how to use `MultiheadAttention` with `torch::nn::MultiheadAttentionOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
+/// module storage semantics.
 TORCH_MODULE(MultiheadAttention);
 
 } // namespace nn

--- a/torch/csrc/api/include/torch/nn/modules/batchnorm.h
+++ b/torch/csrc/api/include/torch/nn/modules/batchnorm.h
@@ -194,6 +194,14 @@ class BatchNormImplBase : public NormImplBase<D, Derived, BatchNormOptions> {
 /// Applies the BatchNorm1d function.
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.BatchNorm1d to learn
 /// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::BatchNorm1dOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// BatchNorm1d model(BatchNorm1dOptions(4).eps(0.5).momentum(0.1).affine(false).track_running_stats(true));
+/// ```
 class TORCH_API BatchNorm1dImpl : public BatchNormImplBase<1, BatchNorm1dImpl> {
  protected:
   virtual void _check_input_dim(const Tensor& input) override;
@@ -202,11 +210,24 @@ class TORCH_API BatchNorm1dImpl : public BatchNormImplBase<1, BatchNorm1dImpl> {
   using BatchNormImplBase<1, BatchNorm1dImpl>::BatchNormImplBase;
 };
 
+/// A `ModuleHolder` subclass for `BatchNorm1dImpl`.
+/// See the documentation for `BatchNorm1dImpl` class to learn what methods it
+/// provides, and examples of how to use `BatchNorm1d` with `torch::nn::BatchNorm1dOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
+/// module storage semantics.
 TORCH_MODULE(BatchNorm1d);
 
 /// Applies the BatchNorm2d function.
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.BatchNorm2d to learn
 /// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::BatchNorm2dOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// BatchNorm2d model(BatchNorm2dOptions(4).eps(0.5).momentum(0.1).affine(false).track_running_stats(true));
+/// ```
 class TORCH_API BatchNorm2dImpl : public BatchNormImplBase<2, BatchNorm2dImpl> {
  protected:
   virtual void _check_input_dim(const Tensor& input) override;
@@ -215,11 +236,24 @@ class TORCH_API BatchNorm2dImpl : public BatchNormImplBase<2, BatchNorm2dImpl> {
   using BatchNormImplBase<2, BatchNorm2dImpl>::BatchNormImplBase;
 };
 
+/// A `ModuleHolder` subclass for `BatchNorm2dImpl`.
+/// See the documentation for `BatchNorm2dImpl` class to learn what methods it
+/// provides, and examples of how to use `BatchNorm2d` with `torch::nn::BatchNorm2dOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
+/// module storage semantics.
 TORCH_MODULE(BatchNorm2d);
 
 /// Applies the BatchNorm3d function.
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.BatchNorm3d to learn
 /// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::BatchNorm3dOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// BatchNorm3d model(BatchNorm3dOptions(4).eps(0.5).momentum(0.1).affine(false).track_running_stats(true));
+/// ```
 class TORCH_API BatchNorm3dImpl : public BatchNormImplBase<3, BatchNorm3dImpl> {
  protected:
   virtual void _check_input_dim(const Tensor& input) override;
@@ -228,6 +262,11 @@ class TORCH_API BatchNorm3dImpl : public BatchNormImplBase<3, BatchNorm3dImpl> {
   using BatchNormImplBase<3, BatchNorm3dImpl>::BatchNormImplBase;
 };
 
+/// A `ModuleHolder` subclass for `BatchNorm3dImpl`.
+/// See the documentation for `BatchNorm3dImpl` class to learn what methods it
+/// provides, and examples of how to use `BatchNorm3d` with `torch::nn::BatchNorm3dOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
+/// module storage semantics.
 TORCH_MODULE(BatchNorm3d);
 
 } // namespace nn

--- a/torch/csrc/api/include/torch/nn/modules/conv.h
+++ b/torch/csrc/api/include/torch/nn/modules/conv.h
@@ -114,15 +114,13 @@ class ConvNdImpl : public torch::nn::Cloneable<Derived> {
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.Conv1d to learn about
 /// the exact behavior of this module.
 ///
-/// yf225 TODO experiment:
+/// See the documentation for `torch::nn::Conv1dOptions` class to learn what
+/// constructor arguments are supported for this module.
 ///
 /// Example:
-/// ```
+/// ```cpp
 /// auto m = torch::nn::Conv1d(torch::nn::Conv1dOptions(1, 2, 3));
 /// ```
-///
-/// See `torch::nn::Conv1dOptions` or `Conv1dOptions` to learn what arguments
-/// are supported in `Conv1dOptions`
 class TORCH_API Conv1dImpl : public ConvNdImpl<1, Conv1dImpl> {
  public:
   Conv1dImpl(
@@ -137,7 +135,8 @@ class TORCH_API Conv1dImpl : public ConvNdImpl<1, Conv1dImpl> {
 
 /// A `ModuleHolder` subclass for `Conv1dImpl`.
 /// See the documentation for `Conv1dImpl` class to learn what methods it
-/// provides, or the documentation for `ModuleHolder` to learn about PyTorch's
+/// provides, and examples of how to use `Conv1d` with `torch::nn::Conv1dOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
 /// module storage semantics.
 TORCH_MODULE(Conv1d);
 

--- a/torch/csrc/api/include/torch/nn/modules/conv.h
+++ b/torch/csrc/api/include/torch/nn/modules/conv.h
@@ -113,6 +113,16 @@ class ConvNdImpl : public torch::nn::Cloneable<Derived> {
 /// Applies convolution over a 1-D input.
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.Conv1d to learn about
 /// the exact behavior of this module.
+///
+/// yf225 TODO experiment:
+///
+/// Example:
+/// ```
+/// auto m = torch::nn::Conv1d(torch::nn::Conv1dOptions(1, 2, 3));
+/// ```
+///
+/// See `torch::nn::Conv1dOptions` or `Conv1dOptions` to learn what arguments
+/// are supported in `Conv1dOptions`
 class TORCH_API Conv1dImpl : public ConvNdImpl<1, Conv1dImpl> {
  public:
   Conv1dImpl(

--- a/torch/csrc/api/include/torch/nn/modules/conv.h
+++ b/torch/csrc/api/include/torch/nn/modules/conv.h
@@ -118,7 +118,7 @@ class ConvNdImpl : public torch::nn::Cloneable<Derived> {
 /// constructor arguments are supported for this module.
 ///
 /// Example:
-/// ```cpp
+/// ```
 /// auto m = torch::nn::Conv1d(torch::nn::Conv1dOptions(1, 2, 3));
 /// ```
 class TORCH_API Conv1dImpl : public ConvNdImpl<1, Conv1dImpl> {

--- a/torch/csrc/api/include/torch/nn/modules/conv.h
+++ b/torch/csrc/api/include/torch/nn/modules/conv.h
@@ -145,6 +145,14 @@ TORCH_MODULE(Conv1d);
 /// Applies convolution over a 2-D input.
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.Conv2d to learn about
 /// the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::Conv2dOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// Conv2d model(Conv2dOptions(3, 2, 3).stride(1).bias(false));
+/// ```
 class TORCH_API Conv2dImpl : public ConvNdImpl<2, Conv2dImpl> {
  public:
   Conv2dImpl(
@@ -159,7 +167,8 @@ class TORCH_API Conv2dImpl : public ConvNdImpl<2, Conv2dImpl> {
 
 /// A `ModuleHolder` subclass for `Conv2dImpl`.
 /// See the documentation for `Conv2dImpl` class to learn what methods it
-/// provides, or the documentation for `ModuleHolder` to learn about PyTorch's
+/// provides, and examples of how to use `Conv2d` with `torch::nn::Conv2dOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
 /// module storage semantics.
 TORCH_MODULE(Conv2d);
 
@@ -168,6 +177,14 @@ TORCH_MODULE(Conv2d);
 /// Applies convolution over a 3-D input.
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.Conv3d to learn about
 /// the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::Conv3dOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// Conv3d model(Conv3dOptions(3, 2, 3).stride(1).bias(false));
+/// ```
 class TORCH_API Conv3dImpl : public ConvNdImpl<3, Conv3dImpl> {
  public:
   Conv3dImpl(
@@ -182,7 +199,8 @@ class TORCH_API Conv3dImpl : public ConvNdImpl<3, Conv3dImpl> {
 
 /// A `ModuleHolder` subclass for `Conv3dImpl`.
 /// See the documentation for `Conv3dImpl` class to learn what methods it
-/// provides, or the documentation for `ModuleHolder` to learn about PyTorch's
+/// provides, and examples of how to use `Conv3d` with `torch::nn::Conv3dOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
 /// module storage semantics.
 TORCH_MODULE(Conv3d);
 
@@ -235,26 +253,12 @@ class ConvTransposeNdImpl : public ConvNdImpl<D, Derived> {
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.ConvTranspose1d to
 /// learn about the exact behavior of this module.
 ///
-/// NOTE: `ConvTranspose1d` currently cannot be used in a `Sequential` module,
-/// because `Sequential` module doesn't support modules with forward method that takes
-/// optional arguments. Users should create their own wrapper for `ConvTranspose1d`
-/// and have its forward method just accept a tensor, if they want to use it in a
-/// `Sequential` module.
+/// See the documentation for `torch::nn::ConvTranspose1dOptions` class to learn what
+/// constructor arguments are supported for this module.
 ///
 /// Example:
 /// ```
-/// struct ConvTranspose1dWrapperImpl : public torch::nn::ConvTranspose1dImpl {
-///   using torch::nn::ConvTranspose1dImpl::ConvTranspose1dImpl;
-///
-///   torch::Tensor forward(const torch::Tensor& input) {
-///     return torch::nn::ConvTranspose1dImpl::forward(input, c10::nullopt);
-///   }
-/// };
-///
-/// TORCH_MODULE(ConvTranspose1dWrapper);
-///
-/// torch::nn::Sequential sequential(
-///   ConvTranspose1dWrapper(torch::nn::ConvTranspose1dOptions(3, 3, 4));
+/// ConvTranspose1d model(ConvTranspose1dOptions(3, 2, 3).stride(1).bias(false));
 /// ```
 class TORCH_API ConvTranspose1dImpl : public ConvTransposeNdImpl<1, ConvTranspose1dImpl> {
  public:
@@ -271,6 +275,11 @@ class TORCH_API ConvTranspose1dImpl : public ConvTransposeNdImpl<1, ConvTranspos
   FORWARD_HAS_DEFAULT_ARGS({1, AnyValue(c10::optional<at::IntArrayRef>())})
 };
 
+/// A `ModuleHolder` subclass for `ConvTranspose1dImpl`.
+/// See the documentation for `ConvTranspose1dImpl` class to learn what methods it
+/// provides, and examples of how to use `ConvTranspose1d` with `torch::nn::ConvTranspose1dOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
+/// module storage semantics.
 TORCH_MODULE(ConvTranspose1d);
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ConvTranspose2d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -279,26 +288,12 @@ TORCH_MODULE(ConvTranspose1d);
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.ConvTranspose2d to
 /// learn about the exact behavior of this module.
 ///
-/// NOTE: `ConvTranspose2d` currently cannot be used in a `Sequential` module,
-/// because `Sequential` module doesn't support modules with forward method that takes
-/// optional arguments. Users should create their own wrapper for `ConvTranspose2d`
-/// and have its forward method just accept a tensor, if they want to use it in a
-/// `Sequential` module.
+/// See the documentation for `torch::nn::ConvTranspose2dOptions` class to learn what
+/// constructor arguments are supported for this module.
 ///
 /// Example:
 /// ```
-/// struct ConvTranspose2dWrapperImpl : public torch::nn::ConvTranspose2dImpl {
-///   using torch::nn::ConvTranspose2dImpl::ConvTranspose2dImpl;
-///
-///   torch::Tensor forward(const torch::Tensor& input) {
-///     return torch::nn::ConvTranspose2dImpl::forward(input, c10::nullopt);
-///   }
-/// };
-///
-/// TORCH_MODULE(ConvTranspose2dWrapper);
-///
-/// torch::nn::Sequential sequential(
-///   ConvTranspose2dWrapper(torch::nn::ConvTranspose2dOptions(3, 3, 4));
+/// ConvTranspose2d model(ConvTranspose2dOptions(3, 2, 3).stride(1).bias(false));
 /// ```
 class TORCH_API ConvTranspose2dImpl : public ConvTransposeNdImpl<2, ConvTranspose2dImpl> {
  public:
@@ -315,6 +310,11 @@ class TORCH_API ConvTranspose2dImpl : public ConvTransposeNdImpl<2, ConvTranspos
   FORWARD_HAS_DEFAULT_ARGS({1, AnyValue(c10::optional<at::IntArrayRef>())})
 };
 
+/// A `ModuleHolder` subclass for `ConvTranspose2dImpl`.
+/// See the documentation for `ConvTranspose2dImpl` class to learn what methods it
+/// provides, and examples of how to use `ConvTranspose2d` with `torch::nn::ConvTranspose2dOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
+/// module storage semantics.
 TORCH_MODULE(ConvTranspose2d);
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ConvTranspose3d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -323,26 +323,12 @@ TORCH_MODULE(ConvTranspose2d);
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.ConvTranspose3d to
 /// learn about the exact behavior of this module.
 ///
-/// NOTE: `ConvTranspose3d` currently cannot be used in a `Sequential` module,
-/// because `Sequential` module doesn't support modules with forward method that takes
-/// optional arguments. Users should create their own wrapper for `ConvTranspose3d`
-/// and have its forward method just accept a tensor, if they want to use it in a
-/// `Sequential` module.
+/// See the documentation for `torch::nn::ConvTranspose3dOptions` class to learn what
+/// constructor arguments are supported for this module.
 ///
 /// Example:
 /// ```
-/// struct ConvTranspose3dWrapperImpl : public torch::nn::ConvTranspose3dImpl {
-///   using torch::nn::ConvTranspose3dImpl::ConvTranspose3dImpl;
-///
-///   torch::Tensor forward(const torch::Tensor& input) {
-///     return torch::nn::ConvTranspose3dImpl::forward(input, c10::nullopt);
-///   }
-/// };
-///
-/// TORCH_MODULE(ConvTranspose3dWrapper);
-///
-/// torch::nn::Sequential sequential(
-///   ConvTranspose3dWrapper(torch::nn::ConvTranspose3dOptions(3, 3, 4));
+/// ConvTranspose3d model(ConvTranspose3dOptions(2, 2, 2).stride(1).bias(false));
 /// ```
 class TORCH_API ConvTranspose3dImpl : public ConvTransposeNdImpl<3, ConvTranspose3dImpl> {
  public:
@@ -359,6 +345,11 @@ class TORCH_API ConvTranspose3dImpl : public ConvTransposeNdImpl<3, ConvTranspos
   FORWARD_HAS_DEFAULT_ARGS({1, AnyValue(c10::optional<at::IntArrayRef>())})
 };
 
+/// A `ModuleHolder` subclass for `ConvTranspose3dImpl`.
+/// See the documentation for `ConvTranspose3dImpl` class to learn what methods it
+/// provides, and examples of how to use `ConvTranspose3d` with `torch::nn::ConvTranspose3dOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
+/// module storage semantics.
 TORCH_MODULE(ConvTranspose3d);
 
 } // namespace nn

--- a/torch/csrc/api/include/torch/nn/modules/conv.h
+++ b/torch/csrc/api/include/torch/nn/modules/conv.h
@@ -119,7 +119,7 @@ class ConvNdImpl : public torch::nn::Cloneable<Derived> {
 ///
 /// Example:
 /// ```
-/// auto m = torch::nn::Conv1d(torch::nn::Conv1dOptions(1, 2, 3));
+/// Conv1d model(Conv1dOptions(3, 2, 3).stride(1).bias(false));
 /// ```
 class TORCH_API Conv1dImpl : public ConvNdImpl<1, Conv1dImpl> {
  public:

--- a/torch/csrc/api/include/torch/nn/modules/distance.h
+++ b/torch/csrc/api/include/torch/nn/modules/distance.h
@@ -13,6 +13,16 @@ namespace nn {
 
 /// Returns the cosine similarity between :math:`x_1` and :math:`x_2`, computed
 /// along `dim`.
+/// See https://pytorch.org/docs/master/nn.html#torch.nn.CosineSimilarity to
+/// learn about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::CosineSimilarityOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// CosineSimilarity model(CosineSimilarityOptions().dim(0).eps(0.5));
+/// ```
 class TORCH_API CosineSimilarityImpl : public Cloneable<CosineSimilarityImpl> {
  public:
   explicit CosineSimilarityImpl(const CosineSimilarityOptions& options_ = {});
@@ -29,15 +39,26 @@ class TORCH_API CosineSimilarityImpl : public Cloneable<CosineSimilarityImpl> {
 };
 
 /// A `ModuleHolder` subclass for `CosineSimilarityImpl`.
-/// See the documentation for `CosineSimilarityImpl` class to learn what methods
-/// it provides, or the documentation for `ModuleHolder` to learn about
-/// Pytorch's module storage semantics.
+/// See the documentation for `CosineSimilarityImpl` class to learn what methods it
+/// provides, and examples of how to use `CosineSimilarity` with `torch::nn::CosineSimilarityOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
+/// module storage semantics.
 TORCH_MODULE(CosineSimilarity);
 
 // ============================================================================
 
 /// Returns the batchwise pairwise distance between vectors :math:`v_1`,
 /// :math:`v_2` using the p-norm.
+/// See https://pytorch.org/docs/master/nn.html#torch.nn.PairwiseDistance to
+/// learn about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::PairwiseDistanceOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// PairwiseDistance model(PairwiseDistanceOptions().p(3).eps(0.5).keepdim(true));
+/// ```
 class TORCH_API PairwiseDistanceImpl : public Cloneable<PairwiseDistanceImpl> {
  public:
   explicit PairwiseDistanceImpl(const PairwiseDistanceOptions& options_ = {});
@@ -54,9 +75,10 @@ class TORCH_API PairwiseDistanceImpl : public Cloneable<PairwiseDistanceImpl> {
 };
 
 /// A `ModuleHolder` subclass for `PairwiseDistanceImpl`.
-/// See the documentation for `PairwiseDistanceImpl` class to learn what methods
-/// it provides, or the documentation for `ModuleHolder` to learn about
-/// Pytorch's module storage semantics.
+/// See the documentation for `PairwiseDistanceImpl` class to learn what methods it
+/// provides, and examples of how to use `PairwiseDistance` with `torch::nn::PairwiseDistanceOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
+/// module storage semantics.
 TORCH_MODULE(PairwiseDistance);
 
 } // namespace nn

--- a/torch/csrc/api/include/torch/nn/modules/dropout.h
+++ b/torch/csrc/api/include/torch/nn/modules/dropout.h
@@ -43,6 +43,14 @@ class _DropoutNd : public torch::nn::Cloneable<Derived> {
 /// Applies dropout over a 1-D input.
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.Dropout to learn
 /// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::DropoutOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// Dropout model(DropoutOptions().p(0.42).inplace(true));
+/// ```
 class TORCH_API DropoutImpl : public detail::_DropoutNd<DropoutImpl> {
 public:
   using detail::_DropoutNd<DropoutImpl>::_DropoutNd;
@@ -55,7 +63,8 @@ public:
 
 /// A `ModuleHolder` subclass for `DropoutImpl`.
 /// See the documentation for `DropoutImpl` class to learn what methods it
-/// provides, or the documentation for `ModuleHolder` to learn about PyTorch's
+/// provides, and examples of how to use `Dropout` with `torch::nn::DropoutOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
 /// module storage semantics.
 TORCH_MODULE(Dropout);
 
@@ -64,6 +73,14 @@ TORCH_MODULE(Dropout);
 /// Applies dropout over a 2-D input.
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.Dropout2d to learn
 /// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::Dropout2dOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// Dropout2d model(Dropout2dOptions().p(0.42).inplace(true));
+/// ```
 class TORCH_API Dropout2dImpl : public detail::_DropoutNd<Dropout2dImpl> {
 public:
   using detail::_DropoutNd<Dropout2dImpl>::_DropoutNd;
@@ -76,7 +93,8 @@ public:
 
 /// A `ModuleHolder` subclass for `Dropout2dImpl`.
 /// See the documentation for `Dropout2dImpl` class to learn what methods it
-/// provides, or the documentation for `ModuleHolder` to learn about PyTorch's
+/// provides, and examples of how to use `Dropout2d` with `torch::nn::Dropout2dOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
 /// module storage semantics.
 TORCH_MODULE(Dropout2d);
 
@@ -85,6 +103,14 @@ TORCH_MODULE(Dropout2d);
 /// Applies dropout over a 3-D input.
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.Dropout3d to learn
 /// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::Dropout3dOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// Dropout3d model(Dropout3dOptions().p(0.42).inplace(true));
+/// ```
 class TORCH_API Dropout3dImpl : public detail::_DropoutNd<Dropout3dImpl> {
 public:
   using detail::_DropoutNd<Dropout3dImpl>::_DropoutNd;
@@ -97,7 +123,8 @@ public:
 
 /// A `ModuleHolder` subclass for `Dropout3dImpl`.
 /// See the documentation for `Dropout3dImpl` class to learn what methods it
-/// provides, or the documentation for `ModuleHolder` to learn about PyTorch's
+/// provides, and examples of how to use `Dropout3d` with `torch::nn::Dropout3dOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
 /// module storage semantics.
 TORCH_MODULE(Dropout3d);
 
@@ -131,6 +158,17 @@ TORCH_MODULE(FeatureDropout);
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ AlphaDropout ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+/// Applies Alpha Dropout over the input.
+/// See https://pytorch.org/docs/master/nn.html#torch.nn.AlphaDropout to learn
+/// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::AlphaDropoutOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// AlphaDropout model(AlphaDropoutOptions(0.2).inplace(true));
+/// ```
 class TORCH_API AlphaDropoutImpl
     : public detail::_DropoutNd<AlphaDropoutImpl> {
  public:
@@ -142,10 +180,22 @@ class TORCH_API AlphaDropoutImpl
   void pretty_print(std::ostream& stream) const override;
 };
 
+/// A `ModuleHolder` subclass for `AlphaDropoutImpl`.
+/// See the documentation for `AlphaDropoutImpl` class to learn what methods it
+/// provides, and examples of how to use `AlphaDropout` with `torch::nn::AlphaDropoutOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
+/// module storage semantics.
 TORCH_MODULE(AlphaDropout);
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ FeatureAlphaDropout ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+/// See the documentation for `torch::nn::FeatureAlphaDropoutOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// FeatureAlphaDropout model(FeatureAlphaDropoutOptions(0.2).inplace(true));
+/// ```
 class TORCH_API FeatureAlphaDropoutImpl
     : public detail::_DropoutNd<FeatureAlphaDropoutImpl> {
  public:
@@ -157,6 +207,11 @@ class TORCH_API FeatureAlphaDropoutImpl
   void pretty_print(std::ostream& stream) const override;
 };
 
+/// A `ModuleHolder` subclass for `FeatureAlphaDropoutImpl`.
+/// See the documentation for `FeatureAlphaDropoutImpl` class to learn what methods it
+/// provides, and examples of how to use `FeatureAlphaDropout` with `torch::nn::FeatureAlphaDropoutOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
+/// module storage semantics.
 TORCH_MODULE(FeatureAlphaDropout);
 
 } // namespace nn

--- a/torch/csrc/api/include/torch/nn/modules/embedding.h
+++ b/torch/csrc/api/include/torch/nn/modules/embedding.h
@@ -12,7 +12,19 @@
 namespace torch {
 namespace nn {
 
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Embedding ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 /// Performs a lookup in a fixed size embedding table.
+/// See https://pytorch.org/docs/master/nn.html#torch.nn.Embedding to learn
+/// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::EmbeddingOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// Embedding model(EmbeddingOptions(10, 2).padding_idx(3).max_norm(2).norm_type(2.5).scale_grad_by_freq(true).sparse(true));
+/// ```
 class TORCH_API EmbeddingImpl : public torch::nn::Cloneable<EmbeddingImpl> {
  public:
   EmbeddingImpl(int64_t num_embeddings, int64_t embedding_dim)
@@ -40,12 +52,15 @@ class TORCH_API EmbeddingImpl : public torch::nn::Cloneable<EmbeddingImpl> {
 
 /// A `ModuleHolder` subclass for `EmbeddingImpl`.
 /// See the documentation for `EmbeddingImpl` class to learn what methods it
-/// provides, or the documentation for `ModuleHolder` to learn about PyTorch's
+/// provides, and examples of how to use `Embedding` with `torch::nn::EmbeddingOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
 /// module storage semantics.
 class Embedding : public torch::nn::ModuleHolder<EmbeddingImpl> {
  public:
   using torch::nn::ModuleHolder<EmbeddingImpl>::ModuleHolder;
 
+  /// See the documentation for `torch::nn::EmbeddingFromPretrainedOptions` class to learn what
+  /// optional arguments are supported for this function.
   static Embedding from_pretrained(const torch::Tensor& embeddings, const EmbeddingFromPretrainedOptions& options = {}) {
     TORCH_CHECK(embeddings.dim() == 2, "Embeddings parameter is expected to be 2-dimensional");
 
@@ -66,6 +81,20 @@ class Embedding : public torch::nn::ModuleHolder<EmbeddingImpl> {
   }
 };
 
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ EmbeddingBag ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+/// Computes sums or means of 'bags' of embeddings, without instantiating the
+/// intermediate embeddings.
+/// See https://pytorch.org/docs/master/nn.html#torch.nn.EmbeddingBag to learn
+/// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::EmbeddingBagOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// EmbeddingBag model(EmbeddingBagOptions(10, 2).max_norm(2).norm_type(2.5).scale_grad_by_freq(true).sparse(true).mode(torch::kSum));
+/// ```
 class TORCH_API EmbeddingBagImpl : public torch::nn::Cloneable<EmbeddingBagImpl> {
  public:
   EmbeddingBagImpl(int64_t num_embeddings, int64_t embedding_dim)
@@ -91,12 +120,15 @@ class TORCH_API EmbeddingBagImpl : public torch::nn::Cloneable<EmbeddingBagImpl>
 
 /// A `ModuleHolder` subclass for `EmbeddingBagImpl`.
 /// See the documentation for `EmbeddingBagImpl` class to learn what methods it
-/// provides, or the documentation for `ModuleHolder` to learn about PyTorch's
+/// provides, and examples of how to use `EmbeddingBag` with `torch::nn::EmbeddingBagOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
 /// module storage semantics.
 class EmbeddingBag : public torch::nn::ModuleHolder<EmbeddingBagImpl> {
  public:
   using torch::nn::ModuleHolder<EmbeddingBagImpl>::ModuleHolder;
 
+  /// See the documentation for `torch::nn::EmbeddingBagFromPretrainedOptions` class to learn what
+  /// optional arguments are supported for this function.
   static EmbeddingBag from_pretrained(const torch::Tensor& embeddings, const EmbeddingBagFromPretrainedOptions& options = {}) {
     TORCH_CHECK(embeddings.dim() == 2, "Embeddings parameter is expected to be 2-dimensional");
 

--- a/torch/csrc/api/include/torch/nn/modules/fold.h
+++ b/torch/csrc/api/include/torch/nn/modules/fold.h
@@ -13,6 +13,14 @@ namespace nn {
 /// Applies fold over a 3-D input.
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.Fold to learn about
 /// the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::FoldOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// Fold model(FoldOptions({8, 8}, {3, 3}).dilation(2).padding({2, 1}).stride(2));
+/// ```
 class TORCH_API FoldImpl : public torch::nn::Cloneable<FoldImpl> {
  public:
   FoldImpl(ExpandingArray<2> output_size, ExpandingArray<2> kernel_size)
@@ -32,7 +40,8 @@ class TORCH_API FoldImpl : public torch::nn::Cloneable<FoldImpl> {
 
 /// A `ModuleHolder` subclass for `FoldImpl`.
 /// See the documentation for `FoldImpl` class to learn what methods it
-/// provides, or the documentation for `ModuleHolder` to learn about PyTorch's
+/// provides, and examples of how to use `Fold` with `torch::nn::FoldOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
 /// module storage semantics.
 TORCH_MODULE(Fold);
 
@@ -41,6 +50,14 @@ TORCH_MODULE(Fold);
 /// Applies unfold over a 4-D input.
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.Unfold to learn about
 /// the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::UnfoldOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// Unfold model(UnfoldOptions({2, 4}).dilation(2).padding({2, 1}).stride(2));
+/// ```
 class TORCH_API UnfoldImpl : public Cloneable<UnfoldImpl> {
  public:
   UnfoldImpl(ExpandingArray<2> kernel_size)
@@ -60,7 +77,8 @@ class TORCH_API UnfoldImpl : public Cloneable<UnfoldImpl> {
 
 /// A `ModuleHolder` subclass for `UnfoldImpl`.
 /// See the documentation for `UnfoldImpl` class to learn what methods it
-/// provides, or the documentation for `ModuleHolder` to learn about PyTorch's
+/// provides, and examples of how to use `Unfold` with `torch::nn::UnfoldOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
 /// module storage semantics.
 TORCH_MODULE(Unfold);
 

--- a/torch/csrc/api/include/torch/nn/modules/instancenorm.h
+++ b/torch/csrc/api/include/torch/nn/modules/instancenorm.h
@@ -23,9 +23,19 @@ class InstanceNormImpl : public torch::nn::NormImplBase<D, Derived, InstanceNorm
   void pretty_print(std::ostream& stream) const override;
 };
 
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ InstanceNorm1d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 /// Applies the InstanceNorm1d function.
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.InstanceNorm1d to learn
 /// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::InstanceNorm1dOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// InstanceNorm1d model(InstanceNorm1dOptions(4).eps(0.5).momentum(0.1).affine(false).track_running_stats(true));
+/// ```
 class TORCH_API InstanceNorm1dImpl : public InstanceNormImpl<1, InstanceNorm1dImpl> {
  protected:
   virtual void _check_input_dim(const Tensor& input) override;
@@ -34,11 +44,26 @@ class TORCH_API InstanceNorm1dImpl : public InstanceNormImpl<1, InstanceNorm1dIm
   using InstanceNormImpl<1, InstanceNorm1dImpl>::InstanceNormImpl;
 };
 
+/// A `ModuleHolder` subclass for `InstanceNorm1dImpl`.
+/// See the documentation for `InstanceNorm1dImpl` class to learn what methods it
+/// provides, and examples of how to use `InstanceNorm1d` with `torch::nn::InstanceNorm1dOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
+/// module storage semantics.
 TORCH_MODULE(InstanceNorm1d);
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ InstanceNorm2d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the InstanceNorm2d function.
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.InstanceNorm2d to learn
 /// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::InstanceNorm2dOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// InstanceNorm2d model(InstanceNorm2dOptions(4).eps(0.5).momentum(0.1).affine(false).track_running_stats(true));
+/// ```
 class TORCH_API InstanceNorm2dImpl : public InstanceNormImpl<2, InstanceNorm2dImpl> {
  protected:
   virtual void _check_input_dim(const Tensor& input) override;
@@ -47,11 +72,26 @@ class TORCH_API InstanceNorm2dImpl : public InstanceNormImpl<2, InstanceNorm2dIm
   using InstanceNormImpl<2, InstanceNorm2dImpl>::InstanceNormImpl;
 };
 
+/// A `ModuleHolder` subclass for `InstanceNorm2dImpl`.
+/// See the documentation for `InstanceNorm2dImpl` class to learn what methods it
+/// provides, and examples of how to use `InstanceNorm2d` with `torch::nn::InstanceNorm2dOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
+/// module storage semantics.
 TORCH_MODULE(InstanceNorm2d);
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ InstanceNorm3d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the InstanceNorm3d function.
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.InstanceNorm3d to learn
 /// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::InstanceNorm3dOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// InstanceNorm3d model(InstanceNorm3dOptions(4).eps(0.5).momentum(0.1).affine(false).track_running_stats(true));
+/// ```
 class TORCH_API InstanceNorm3dImpl : public InstanceNormImpl<3, InstanceNorm3dImpl> {
  protected:
   virtual void _check_input_dim(const Tensor& input) override;
@@ -60,6 +100,11 @@ class TORCH_API InstanceNorm3dImpl : public InstanceNormImpl<3, InstanceNorm3dIm
   using InstanceNormImpl<3, InstanceNorm3dImpl>::InstanceNormImpl;
 };
 
+/// A `ModuleHolder` subclass for `InstanceNorm3dImpl`.
+/// See the documentation for `InstanceNorm3dImpl` class to learn what methods it
+/// provides, and examples of how to use `InstanceNorm3d` with `torch::nn::InstanceNorm3dOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
+/// module storage semantics.
 TORCH_MODULE(InstanceNorm3d);
 
 } // namespace nn

--- a/torch/csrc/api/include/torch/nn/modules/linear.h
+++ b/torch/csrc/api/include/torch/nn/modules/linear.h
@@ -13,7 +13,11 @@
 namespace torch {
 namespace nn {
 
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Identity ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 /// A placeholder identity operator that is argument-insensitive.
+/// See https://pytorch.org/docs/master/nn.html#torch.nn.Identity to learn
+/// about the exact behavior of this module.
 class TORCH_API IdentityImpl : public Cloneable<IdentityImpl> {
  public:
   void reset() override;
@@ -30,9 +34,19 @@ class TORCH_API IdentityImpl : public Cloneable<IdentityImpl> {
 /// module storage semantics.
 TORCH_MODULE(Identity);
 
-// ============================================================================
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Linear ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies a linear transformation with optional bias.
+/// See https://pytorch.org/docs/master/nn.html#torch.nn.Linear to learn
+/// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::LinearOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// Linear model(LinearOptions(5, 2).bias(false));
+/// ```
 class TORCH_API LinearImpl : public Cloneable<LinearImpl> {
  public:
   LinearImpl(int64_t in_features, int64_t out_features)
@@ -63,13 +77,24 @@ class TORCH_API LinearImpl : public Cloneable<LinearImpl> {
 
 /// A `ModuleHolder` subclass for `LinearImpl`.
 /// See the documentation for `LinearImpl` class to learn what methods it
-/// provides, or the documentation for `ModuleHolder` to learn about PyTorch's
+/// provides, and examples of how to use `Linear` with `torch::nn::LinearOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
 /// module storage semantics.
 TORCH_MODULE(Linear);
 
-// ============================================================================
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Flatten ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// A placeholder for Flatten operator
+/// See https://pytorch.org/docs/master/nn.html#torch.nn.Flatten to learn
+/// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::FlattenOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// Flatten model(FlattenOptions().start_dim(2).end_dim(4));
+/// ```
 class TORCH_API FlattenImpl : public Cloneable<FlattenImpl> {
  public:
   explicit FlattenImpl(const FlattenOptions& options_ = {});
@@ -88,13 +113,24 @@ class TORCH_API FlattenImpl : public Cloneable<FlattenImpl> {
 
 /// A `ModuleHolder` subclass for `FlattenImpl`.
 /// See the documentation for `FlattenImpl` class to learn what methods it
-/// provides, or the documentation for `ModuleHolder` to learn about PyTorch's
+/// provides, and examples of how to use `Flatten` with `torch::nn::FlattenOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
 /// module storage semantics.
 TORCH_MODULE(Flatten);
 
-// ============================================================================
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Bilinear ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies a billinear transformation with optional bias.
+/// See https://pytorch.org/docs/master/nn.html#torch.nn.Bilinear to learn
+/// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::BilinearOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// Bilinear model(BilinearOptions(3, 2, 4).bias(false));
+/// ```
 class TORCH_API BilinearImpl : public Cloneable<BilinearImpl> {
  public:
   BilinearImpl(int64_t in1_features, int64_t in2_features, int64_t out_features) : BilinearImpl(BilinearOptions(in1_features, in2_features, out_features)) {}
@@ -125,7 +161,8 @@ class TORCH_API BilinearImpl : public Cloneable<BilinearImpl> {
 
 /// A `ModuleHolder` subclass for `BilinearImpl`.
 /// See the documentation for `BilinearImpl` class to learn what methods it
-/// provides, or the documentation for `ModuleHolder` to learn about PyTorch's
+/// provides, and examples of how to use `Bilinear` with `torch::nn::BilinearOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
 /// module storage semantics.
 TORCH_MODULE(Bilinear);
 

--- a/torch/csrc/api/include/torch/nn/modules/loss.h
+++ b/torch/csrc/api/include/torch/nn/modules/loss.h
@@ -15,8 +15,20 @@
 namespace torch {
 namespace nn {
 
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ L1Loss ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 /// Creates a criterion that measures the mean absolute error (MAE) between each
 /// element in the input : math :`x` and target : `y`.
+/// See https://pytorch.org/docs/master/nn.html#torch.nn.L1Loss to learn
+/// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::L1LossOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// L1Loss model(L1LossOptions(torch::kNone));
+/// ```
 struct TORCH_API L1LossImpl : Cloneable<L1LossImpl> {
   explicit L1LossImpl(const L1LossOptions& options_ = {});
 
@@ -33,24 +45,24 @@ struct TORCH_API L1LossImpl : Cloneable<L1LossImpl> {
 
 /// A `ModuleHolder` subclass for `L1LossImpl`.
 /// See the documentation for `L1LossImpl` class to learn what methods it
-/// provides, or the documentation for `ModuleHolder` to learn about PyTorch's
+/// provides, and examples of how to use `L1Loss` with `torch::nn::L1LossOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
 /// module storage semantics.
 TORCH_MODULE(L1Loss);
 
-// ============================================================================
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ KLDivLoss ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 /// The `Kullback-Leibler divergence`_ Loss
+/// See https://pytorch.org/docs/master/nn.html#torch.nn.KLDivLoss to learn
+/// about the exact behavior of this module.
 ///
-/// KL divergence is a useful distance measure for continuous distributions
-/// and is often useful when performing direct regression over the space of
-/// (discretely sampled) continuous output distributions.
+/// See the documentation for `torch::nn::KLDivLossOptions` class to learn what
+/// constructor arguments are supported for this module.
 ///
-/// As with :class:`~torch.nn.NLLLoss`, the `input` given is expected to contain
-/// *log-probabilities* and is not restricted to a 2D Tensor.
-/// The targets are given as *probabilities* (i.e. without taking the
-/// logarithm).
-///
-/// This criterion expects a `target` `Tensor` of the same size as the
-/// `input` `Tensor`.
+/// Example:
+/// ```
+/// KLDivLoss model(KLDivLossOptions(torch::kNone));
+/// ```
 struct TORCH_API KLDivLossImpl : Cloneable<KLDivLossImpl> {
   explicit KLDivLossImpl(const KLDivLossOptions& options_ = {});
 
@@ -67,14 +79,25 @@ struct TORCH_API KLDivLossImpl : Cloneable<KLDivLossImpl> {
 
 /// A `ModuleHolder` subclass for `KLDivLossImpl`.
 /// See the documentation for `KLDivLossImpl` class to learn what methods it
-/// provides, or the documentation for `ModuleHolder` to learn about PyTorch's
+/// provides, and examples of how to use `KLDivLoss` with `torch::nn::KLDivLossOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
 /// module storage semantics.
 TORCH_MODULE(KLDivLoss);
 
-// ============================================================================
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ MSELoss ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Creates a criterion that measures the mean squared error (squared L2 norm)
 /// between each element in the input :math:`x` and target :math:`y`.
+/// See https://pytorch.org/docs/master/nn.html#torch.nn.MSELoss to learn
+/// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::MSELossOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// MSELoss model(MSELossOptions(torch::kNone));
+/// ```
 struct TORCH_API MSELossImpl : Cloneable<MSELossImpl> {
   explicit MSELossImpl(const MSELossOptions& options_ = {});
 
@@ -91,14 +114,25 @@ struct TORCH_API MSELossImpl : Cloneable<MSELossImpl> {
 
 /// A `ModuleHolder` subclass for `MSELossImpl`.
 /// See the documentation for `MSELossImpl` class to learn what methods it
-/// provides, or the documentation for `ModuleHolder` to learn about PyTorch's
+/// provides, and examples of how to use `MSELoss` with `torch::nn::MSELossOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
 /// module storage semantics.
 TORCH_MODULE(MSELoss);
 
-// ============================================================================
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ BCELoss ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Creates a criterion that measures the Binary Cross Entropy
 /// between the target and the output.
+/// See https://pytorch.org/docs/master/nn.html#torch.nn.BCELoss to learn
+/// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::BCELossOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// BCELoss model(BCELossOptions().reduction(torch::kNone).weight(weight));
+/// ```
 struct TORCH_API BCELossImpl : Cloneable<BCELossImpl> {
   explicit BCELossImpl(const BCELossOptions& options_ = {});
 
@@ -115,17 +149,25 @@ struct TORCH_API BCELossImpl : Cloneable<BCELossImpl> {
 
 /// A `ModuleHolder` subclass for `BCELossImpl`.
 /// See the documentation for `BCELossImpl` class to learn what methods it
-/// provides, or the documentation for `ModuleHolder` to learn about PyTorch's
+/// provides, and examples of how to use `BCELoss` with `torch::nn::BCELossOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
 /// module storage semantics.
 TORCH_MODULE(BCELoss);
 
-// ============================================================================
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ HingeEmbeddingLoss ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Creates a criterion that measures the loss given an input tensor :math:`x`
-/// and a labels tensor :math:`y` (containing 1 or -1). This is usually used for
-/// measuring whether two inputs are similar or dissimilar, e.g. using the L1
-/// pairwise distance as :math:`x`, and is typically used for learning nonlinear
-/// embeddings or semi-supervised learning.
+/// and a labels tensor :math:`y` (containing 1 or -1).
+/// See https://pytorch.org/docs/master/nn.html#torch.nn.HingeEmbeddingLoss to learn
+/// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::HingeEmbeddingLossOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// HingeEmbeddingLoss model(HingeEmbeddingLossOptions().margin(4).reduction(torch::kNone));
+/// ```
 struct TORCH_API HingeEmbeddingLossImpl : Cloneable<HingeEmbeddingLossImpl> {
   explicit HingeEmbeddingLossImpl(
       const HingeEmbeddingLossOptions& options_ = {});
@@ -142,17 +184,28 @@ struct TORCH_API HingeEmbeddingLossImpl : Cloneable<HingeEmbeddingLossImpl> {
 };
 
 /// A `ModuleHolder` subclass for `HingeEmbeddingLossImpl`.
-/// See the documentation for `HingeEmbeddingLossImpl` class to learn what
-/// methods it provides, or the documentation for `ModuleHolder` to learn about
-/// PyTorch's module storage semantics.
+/// See the documentation for `HingeEmbeddingLossImpl` class to learn what methods it
+/// provides, and examples of how to use `HingeEmbeddingLoss` with `torch::nn::HingeEmbeddingLossOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
+/// module storage semantics.
 TORCH_MODULE(HingeEmbeddingLoss);
 
-// ============================================================================
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ MultiMarginLoss ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Creates a criterion that optimizes a multi-class classification hinge
 /// loss (margin-based loss) between input :math:`x` (a 2D mini-batch `Tensor`) and
 /// output :math:`y` (which is a 1D tensor of target class indices,
-/// :math:`0 \leq y \leq \text{x.size}(1)-1`):
+/// :math:`0 \leq y \leq \text{x.size}(1)-1`).
+/// See https://pytorch.org/docs/master/nn.html#torch.nn.MultiMarginLoss to learn
+/// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::MultiMarginLossOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// MultiMarginLoss model(MultiMarginLossOptions().margin(2).weight(weight));
+/// ```
 struct TORCH_API MultiMarginLossImpl : public Cloneable<MultiMarginLossImpl> {
   explicit MultiMarginLossImpl(
       const MultiMarginLossOptions& options_ = {});
@@ -169,18 +222,29 @@ struct TORCH_API MultiMarginLossImpl : public Cloneable<MultiMarginLossImpl> {
 };
 
 /// A `ModuleHolder` subclass for `MultiMarginLossImpl`.
-/// See the documentation for `MultiMarginLossImpl` class to learn what
-/// methods it provides, or the documentation for `ModuleHolder` to learn about
-/// PyTorch's module storage semantics.
+/// See the documentation for `MultiMarginLossImpl` class to learn what methods it
+/// provides, and examples of how to use `MultiMarginLoss` with `torch::nn::MultiMarginLossOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
+/// module storage semantics.
 TORCH_MODULE(MultiMarginLoss);
 
-// ============================================================================
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ CosineEmbeddingLoss ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Creates a criterion that measures the loss given input tensors
 /// `input1`, `input2`, and a `Tensor` label `target` with values 1 or
 /// -1. This is used for measuring whether two inputs are similar or
 /// dissimilar, using the cosine distance, and is typically used for learning
 /// nonlinear embeddings or semi-supervised learning.
+/// See https://pytorch.org/docs/master/nn.html#torch.nn.CosineEmbeddingLoss to learn
+/// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::CosineEmbeddingLossOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// CosineEmbeddingLoss model(CosineEmbeddingLossOptions().margin(0.5));
+/// ```
 struct TORCH_API CosineEmbeddingLossImpl : public Cloneable<CosineEmbeddingLossImpl> {
   explicit CosineEmbeddingLossImpl(
       const CosineEmbeddingLossOptions& options_ = {});
@@ -200,18 +264,29 @@ struct TORCH_API CosineEmbeddingLossImpl : public Cloneable<CosineEmbeddingLossI
 };
 
 /// A `ModuleHolder` subclass for `CosineEmbeddingLossImpl`.
-/// See the documentation for `CosineEmbeddingLossImpl` class to learn what
-/// methods it provides, or the documentation for `ModuleHolder` to learn about
-/// PyTorch's module storage semantics.
+/// See the documentation for `CosineEmbeddingLossImpl` class to learn what methods it
+/// provides, and examples of how to use `CosineEmbeddingLoss` with `torch::nn::CosineEmbeddingLossOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
+/// module storage semantics.
 TORCH_MODULE(CosineEmbeddingLoss);
 
-// ============================================================================
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ SmoothL1Loss ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Creates a criterion that uses a squared term if the absolute
 /// element-wise error falls below 1 and an L1 term otherwise.
 /// It is less sensitive to outliers than the `MSELoss` and in some cases
 /// prevents exploding gradients (e.g. see `Fast R-CNN` paper by Ross Girshick).
 /// Also known as the Huber loss.
+/// See https://pytorch.org/docs/master/nn.html#torch.nn.SmoothL1Loss to learn
+/// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::SmoothL1LossOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// SmoothL1Loss model(SmoothL1LossOptions(torch::kNone));
+/// ```
 struct TORCH_API SmoothL1LossImpl : public Cloneable<SmoothL1LossImpl> {
   explicit SmoothL1LossImpl(const SmoothL1LossOptions& options_ = {});
 
@@ -228,15 +303,26 @@ struct TORCH_API SmoothL1LossImpl : public Cloneable<SmoothL1LossImpl> {
 
 /// A `ModuleHolder` subclass for `SmoothL1LossImpl`.
 /// See the documentation for `SmoothL1LossImpl` class to learn what methods it
-/// provides, or the documentation for `ModuleHolder` to learn about PyTorch's
+/// provides, and examples of how to use `SmoothL1Loss` with `torch::nn::SmoothL1LossOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
 /// module storage semantics.
 TORCH_MODULE(SmoothL1Loss);
 
-// ============================================================================
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ MultiLabelMarginLoss ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   
 /// Creates a criterion that optimizes a multi-class multi-classification
 /// hinge loss (margin-based loss) between input :math:`x` (a 2D mini-batch `Tensor`)
 /// and output :math:`y` (which is a 2D `Tensor` of target class indices).
+/// See https://pytorch.org/docs/master/nn.html#torch.nn.MultiLabelMarginLoss to learn
+/// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::MultiLabelMarginLossOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// MultiLabelMarginLoss model(MultiLabelMarginLossOptions(torch::kNone));
+/// ```
 struct TORCH_API MultiLabelMarginLossImpl : public Cloneable<MultiLabelMarginLossImpl> {
   explicit MultiLabelMarginLossImpl(
     const MultiLabelMarginLossOptions& options_ = {});
@@ -254,15 +340,26 @@ struct TORCH_API MultiLabelMarginLossImpl : public Cloneable<MultiLabelMarginLos
 
 /// A `ModuleHolder` subclass for `MultiLabelMarginLossImpl`.
 /// See the documentation for `MultiLabelMarginLossImpl` class to learn what methods it
-/// provides, or the documentation for `ModuleHolder` to learn about PyTorch's
+/// provides, and examples of how to use `MultiLabelMarginLoss` with `torch::nn::MultiLabelMarginLossOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
 /// module storage semantics.
 TORCH_MODULE(MultiLabelMarginLoss);
 
-// ============================================================================
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ SoftMarginLoss ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Creates a criterion that optimizes a two-class classification
 /// logistic loss between input tensor :math:`x` and target tensor :math:`y`
 /// (containing 1 or -1).
+/// See https://pytorch.org/docs/master/nn.html#torch.nn.SoftMarginLoss to learn
+/// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::SoftMarginLossOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// SoftMarginLoss model(SoftMarginLossOptions(torch::kNone));
+/// ```
 struct TORCH_API SoftMarginLossImpl : public Cloneable<SoftMarginLossImpl> {
   explicit SoftMarginLossImpl(const SoftMarginLossOptions& options_ = {});
 
@@ -279,15 +376,26 @@ struct TORCH_API SoftMarginLossImpl : public Cloneable<SoftMarginLossImpl> {
 
 /// A `ModuleHolder` subclass for `SoftMarginLossImpl`.
 /// See the documentation for `SoftMarginLossImpl` class to learn what methods it
-/// provides, or the documentation for `ModuleHolder` to learn about PyTorch's
+/// provides, and examples of how to use `SoftMarginLoss` with `torch::nn::SoftMarginLossOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
 /// module storage semantics.
 TORCH_MODULE(SoftMarginLoss);
 
-// ============================================================================
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ MultiLabelSoftMarginLoss ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Creates a criterion that optimizes a multi-label one-versus-all
 /// loss based on max-entropy, between input :math:`x` and target :math:`y` of size
 /// :math:`(N, C)`.
+/// See https://pytorch.org/docs/master/nn.html#torch.nn.MultiLabelSoftMarginLoss to learn
+/// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::MultiLabelSoftMarginLossOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// MultiLabelSoftMarginLoss model(MultiLabelSoftMarginLossOptions().reduction(torch::kNone).weight(weight));
+/// ```
 struct TORCH_API MultiLabelSoftMarginLossImpl : public Cloneable<MultiLabelSoftMarginLossImpl> {
   explicit MultiLabelSoftMarginLossImpl(
     const MultiLabelSoftMarginLossOptions& options_ = {});
@@ -305,18 +413,29 @@ struct TORCH_API MultiLabelSoftMarginLossImpl : public Cloneable<MultiLabelSoftM
 
 /// A `ModuleHolder` subclass for `MultiLabelSoftMarginLossImpl`.
 /// See the documentation for `MultiLabelSoftMarginLossImpl` class to learn what methods it
-/// provides, or the documentation for `ModuleHolder` to learn about PyTorch's
+/// provides, and examples of how to use `MultiLabelSoftMarginLoss` with `torch::nn::MultiLabelSoftMarginLossOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
 /// module storage semantics.
 TORCH_MODULE(MultiLabelSoftMarginLoss);
 
-// ============================================================================
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ TripletMarginLoss ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Creates a criterion that measures the triplet loss given an input
 /// tensors :math:`x1`, :math:`x2`, :math:`x3` and a margin with a value greater 
 /// than :math:`0`. This is used for measuring a relative similarity between
 /// samples. A triplet is composed by `a`, `p` and `n` (i.e., `anchor`, 
 /// `positive examples` and `negative examples` respectively). The
-/// shapes of all input tensors should be :math:`(N, D)`
+/// shapes of all input tensors should be :math:`(N, D)`.
+/// See https://pytorch.org/docs/master/nn.html#torch.nn.TripletMarginLoss to learn
+/// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::TripletMarginLossOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// TripletMarginLoss model(TripletMarginLossOptions().margin(3).p(2).eps(1e-06).swap(false));
+/// ```
 struct TORCH_API TripletMarginLossImpl : public Cloneable<TripletMarginLossImpl> {
   explicit TripletMarginLossImpl(
       const TripletMarginLossOptions& options_ = {});
@@ -335,20 +454,26 @@ struct TORCH_API TripletMarginLossImpl : public Cloneable<TripletMarginLossImpl>
   TripletMarginLossOptions options;
 };
 
-/// A `ModuleHolder` subclass for `TripletMarginLoss`.
-/// See the documentation for `TripletMarginLossImpl` class to learn what
-/// methods it provides, or the documentation for `ModuleHolder` to learn about
-/// PyTorch's module storage semantics.
+/// A `ModuleHolder` subclass for `TripletMarginLossImpl`.
+/// See the documentation for `TripletMarginLossImpl` class to learn what methods it
+/// provides, and examples of how to use `TripletMarginLoss` with `torch::nn::TripletMarginLossOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
+/// module storage semantics.
 TORCH_MODULE(TripletMarginLoss);
 
-// ============================================================================
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ CTCLoss ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-/// Calculates loss between a continuous (unsegmented) time series and a target
-/// sequence. CTCLoss sums over the probability of possible alignments of input
-/// to target, producing a loss value which is differentiable with respect
-/// to each input node. The alignment of input to target is assumed
-/// to be "many-to-one", which limits the length of the target sequence
-/// such that it must be less than or equal to the input length.
+/// The Connectionist Temporal Classification loss.
+/// See https://pytorch.org/docs/master/nn.html#torch.nn.CTCLoss to learn
+/// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::CTCLossOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// CTCLoss model(CTCLossOptions().blank(42).zero_infinity(false).reduction(torch::kSum));
+/// ```
 struct TORCH_API CTCLossImpl : public Cloneable<CTCLossImpl> {
 
   explicit CTCLossImpl(const CTCLossOptions& options_ = {});
@@ -366,13 +491,25 @@ struct TORCH_API CTCLossImpl : public Cloneable<CTCLossImpl> {
 };
 
 /// A `ModuleHolder` subclass for `CTCLossImpl`.
-/// See the documentation for `CTCLoss` class to learn what
-/// methods it provides, or the documentation for `ModuleHolder` to learn about
-/// PyTorch's module storage semantics.
+/// See the documentation for `CTCLossImpl` class to learn what methods it
+/// provides, and examples of how to use `CTCLoss` with `torch::nn::CTCLossOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
+/// module storage semantics.
 TORCH_MODULE(CTCLoss);
 
-// ============================================================================
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ PoissonNLLLoss ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+/// Negative log likelihood loss with Poisson distribution of target.
+/// See https://pytorch.org/docs/master/nn.html#torch.nn.PoissonNLLLoss to learn
+/// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::PoissonNLLLossOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// PoissonNLLLoss model(PoissonNLLLossOptions().log_input(false).full(true).eps(0.42).reduction(torch::kSum));
+/// ```
 struct TORCH_API PoissonNLLLossImpl : public Cloneable<PoissonNLLLossImpl> {
   explicit PoissonNLLLossImpl(const PoissonNLLLossOptions& options_ = {});
 
@@ -388,13 +525,27 @@ struct TORCH_API PoissonNLLLossImpl : public Cloneable<PoissonNLLLossImpl> {
 };
 
 /// A `ModuleHolder` subclass for `PoissonNLLLossImpl`.
-/// See the documentation for `PoissonNLLLoss` class to learn what
-/// methods it provides, or the documentation for `ModuleHolder` to learn about
-/// PyTorch's module storage semantics.
+/// See the documentation for `PoissonNLLLossImpl` class to learn what methods it
+/// provides, and examples of how to use `PoissonNLLLoss` with `torch::nn::PoissonNLLLossOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
+/// module storage semantics.
 TORCH_MODULE(PoissonNLLLoss);
 
-// ============================================================================
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ MarginRankingLoss ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+/// Creates a criterion that measures the loss given
+/// inputs :math:`x1`, :math:`x2`, two 1D mini-batch `Tensors`,
+/// and a label 1D mini-batch tensor :math:`y` (containing 1 or -1).
+/// See https://pytorch.org/docs/master/nn.html#torch.nn.MarginRankingLoss to learn
+/// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::MarginRankingLossOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// MarginRankingLoss model(MarginRankingLossOptions().margin(0.5).reduction(torch::kSum));
+/// ```
 struct TORCH_API MarginRankingLossImpl : public Cloneable<MarginRankingLossImpl> {
   explicit MarginRankingLossImpl(const MarginRankingLossOptions& options_ = {});
 
@@ -411,18 +562,26 @@ struct TORCH_API MarginRankingLossImpl : public Cloneable<MarginRankingLossImpl>
 };
 
 /// A `ModuleHolder` subclass for `MarginRankingLossImpl`.
-/// See the documentation for `MarginRankingLoss` class to learn what
-/// methods it provides, or the documentation for `ModuleHolder` to learn about
-/// PyTorch's module storage semantics.
+/// See the documentation for `MarginRankingLossImpl` class to learn what methods it
+/// provides, and examples of how to use `MarginRankingLoss` with `torch::nn::MarginRankingLossOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
+/// module storage semantics.
 TORCH_MODULE(MarginRankingLoss);
 
-// ============================================================================
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ NLLLoss ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// The negative log likelihood loss. It is useful to train a classification
-/// problem with `C` classes. The `input` given through a forward call is expected
-/// to contain log-probabilities of each class. `input` has to be a Tensor of size
-/// either :math:`(minibatch, C)` or :math:`(minibatch, C, d_1, d_2, ..., d_K)`
-/// with :math:`K \geq 1` for the `K`-dimensional case (described later).
+/// problem with `C` classes.
+/// See https://pytorch.org/docs/master/nn.html#torch.nn.NLLLoss to learn
+/// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::NLLLossOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// NLLLoss model(NLLLossOptions().ignore_index(-100).reduction(torch::kMean));
+/// ```
 struct TORCH_API NLLLossImpl : public Cloneable<NLLLossImpl> {
   explicit NLLLossImpl(
       const NLLLossOptions& options_ = {});
@@ -443,18 +602,27 @@ struct TORCH_API NLLLossImpl : public Cloneable<NLLLossImpl> {
   Tensor weight;
 };
 
-/// A `ModuleHolder` subclass for `NLLLoss`.
-/// See the documentation for `NLLLossImpl` class to learn what
-/// methods it provides, or the documentation for `ModuleHolder` to learn about
-/// PyTorch's module storage semantics.
+/// A `ModuleHolder` subclass for `NLLLossImpl`.
+/// See the documentation for `NLLLossImpl` class to learn what methods it
+/// provides, and examples of how to use `NLLLoss` with `torch::nn::NLLLossOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
+/// module storage semantics.
 TORCH_MODULE(NLLLoss);
 
-// ============================================================================
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ CrossEntropyLoss ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Creates a criterion that combines :func:`nn.LogSoftmax` and
-/// :func:`nn.NLLLoss` in one single class. It is useful when training a 
-/// classification problem with `C` classes. If provided, the optional argument
-/// :attr:`weight` should be a 1D `Tensor` assigning weight to each of the classes.
+/// :func:`nn.NLLLoss` in one single class.
+/// See https://pytorch.org/docs/master/nn.html#torch.nn.CrossEntropyLoss to learn
+/// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::CrossEntropyLossOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// CrossEntropyLoss model(CrossEntropyLossOptions().ignore_index(-100).reduction(torch::kMean));
+/// ```
 struct TORCH_API CrossEntropyLossImpl : public Cloneable<CrossEntropyLossImpl> {
   explicit CrossEntropyLossImpl(
       const CrossEntropyLossOptions& options_ = {});
@@ -475,14 +643,29 @@ struct TORCH_API CrossEntropyLossImpl : public Cloneable<CrossEntropyLossImpl> {
   Tensor weight;
 };
 
-/// A `ModuleHolder` subclass for `CrossEntropyLoss`.
-/// See the documentation for `CrossEntropyLossImpl` class to learn what
-/// methods it provides, or the documentation for `ModuleHolder` to learn about
-/// PyTorch's module storage semantics.
+/// A `ModuleHolder` subclass for `CrossEntropyLossImpl`.
+/// See the documentation for `CrossEntropyLossImpl` class to learn what methods it
+/// provides, and examples of how to use `CrossEntropyLoss` with `torch::nn::CrossEntropyLossOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
+/// module storage semantics.
 TORCH_MODULE(CrossEntropyLoss);
 
-// ============================================================================
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ BCEWithLogitsLoss ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+/// This loss combines a `Sigmoid` layer and the `BCELoss` in one single
+/// class. This version is more numerically stable than using a plain `Sigmoid`
+/// followed by a `BCELoss` as, by combining the operations into one layer,
+/// we take advantage of the log-sum-exp trick for numerical stability.
+/// See https://pytorch.org/docs/master/nn.html#torch.nn.BCEWithLogitsLoss to learn
+/// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::BCEWithLogitsLossOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// BCEWithLogitsLoss model(BCEWithLogitsLossOptions().reduction(torch::kNone).weight(weight));
+/// ```
 struct TORCH_API BCEWithLogitsLossImpl : public Cloneable<BCEWithLogitsLossImpl> {
   explicit BCEWithLogitsLossImpl(const BCEWithLogitsLossOptions& options_ = {});
 
@@ -504,9 +687,10 @@ struct TORCH_API BCEWithLogitsLossImpl : public Cloneable<BCEWithLogitsLossImpl>
 };
 
 /// A `ModuleHolder` subclass for `BCEWithLogitsLossImpl`.
-/// See the documentation for `BCEWithLogitsLoss` class to learn what
-/// methods it provides, or the documentation for `ModuleHolder` to learn about
-/// PyTorch's module storage semantics.
+/// See the documentation for `BCEWithLogitsLossImpl` class to learn what methods it
+/// provides, and examples of how to use `BCEWithLogitsLoss` with `torch::nn::BCEWithLogitsLossOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
+/// module storage semantics.
 TORCH_MODULE(BCEWithLogitsLoss);
 
 } // namespace nn

--- a/torch/csrc/api/include/torch/nn/modules/normalization.h
+++ b/torch/csrc/api/include/torch/nn/modules/normalization.h
@@ -13,6 +13,20 @@
 namespace torch {
 namespace nn {
 
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ LayerNorm ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+/// Applies Layer Normalization over a mini-batch of inputs as described in
+/// the paper `Layer Normalization`_ .
+/// See https://pytorch.org/docs/master/nn.html#torch.nn.LayerNorm to learn
+/// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::LayerNormOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// LayerNorm model(LayerNormOptions({2, 2}).elementwise_affine(false).eps(2e-5));
+/// ```
 class TORCH_API LayerNormImpl : public torch::nn::Cloneable<LayerNormImpl> {
  public:
   LayerNormImpl(std::vector<int64_t> normalized_shape)
@@ -50,7 +64,8 @@ class TORCH_API LayerNormImpl : public torch::nn::Cloneable<LayerNormImpl> {
 
 /// A `ModuleHolder` subclass for `LayerNormImpl`.
 /// See the documentation for `LayerNormImpl` class to learn what methods it
-/// provides, or the documentation for `ModuleHolder` to learn about PyTorch's
+/// provides, and examples of how to use `LayerNorm` with `torch::nn::LayerNormOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
 /// module storage semantics.
 TORCH_MODULE(LayerNorm);
 
@@ -58,9 +73,17 @@ TORCH_MODULE(LayerNorm);
 
 /// Applies local response normalization over an input signal composed
 /// of several input planes, where channels occupy the second dimension.
-/// Applies normalization across channels
+/// Applies normalization across channels.
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.LocalResponseNorm to learn
 /// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::LocalResponseNormOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// LocalResponseNorm model(LocalResponseNormOptions(2).alpha(0.0002).beta(0.85).k(2.));
+/// ```
 class TORCH_API LocalResponseNormImpl : public Cloneable<LocalResponseNormImpl> {
  public:
   LocalResponseNormImpl(int64_t size)
@@ -78,10 +101,22 @@ class TORCH_API LocalResponseNormImpl : public Cloneable<LocalResponseNormImpl> 
   LocalResponseNormOptions options;
 };
 
+/// A `ModuleHolder` subclass for `LocalResponseNormImpl`.
+/// See the documentation for `LocalResponseNormImpl` class to learn what methods it
+/// provides, and examples of how to use `LocalResponseNorm` with `torch::nn::LocalResponseNormOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
+/// module storage semantics.
 TORCH_MODULE(LocalResponseNorm);
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ CrossMapLRN2d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+/// See the documentation for `torch::nn::CrossMapLRN2dOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// CrossMapLRN2d model(CrossMapLRN2dOptions(3).alpha(1e-5).beta(0.1).k(10));
+/// ```
 class TORCH_API CrossMapLRN2dImpl : public torch::nn::Cloneable<CrossMapLRN2dImpl> {
  public:
   CrossMapLRN2dImpl(int64_t size)
@@ -99,10 +134,27 @@ class TORCH_API CrossMapLRN2dImpl : public torch::nn::Cloneable<CrossMapLRN2dImp
   CrossMapLRN2dOptions options;
 };
 
+/// A `ModuleHolder` subclass for `CrossMapLRN2dImpl`.
+/// See the documentation for `CrossMapLRN2dImpl` class to learn what methods it
+/// provides, and examples of how to use `CrossMapLRN2d` with `torch::nn::CrossMapLRN2dOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
+/// module storage semantics.
 TORCH_MODULE(CrossMapLRN2d);
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ GroupNorm ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+/// Applies Group Normalization over a mini-batch of inputs as described in
+/// the paper `Group Normalization`_ .
+/// See https://pytorch.org/docs/master/nn.html#torch.nn.GroupNorm to learn
+/// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::GroupNormOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// GroupNorm model(GroupNormOptions(2, 2).eps(2e-5).affine(false));
+/// ```
 class TORCH_API GroupNormImpl : public torch::nn::Cloneable<GroupNormImpl> {
  public:
   GroupNormImpl(int64_t num_groups, int64_t num_channels)
@@ -130,7 +182,8 @@ class TORCH_API GroupNormImpl : public torch::nn::Cloneable<GroupNormImpl> {
 
 /// A `ModuleHolder` subclass for `GroupNormImpl`.
 /// See the documentation for `GroupNormImpl` class to learn what methods it
-/// provides, or the documentation for `ModuleHolder` to learn about PyTorch's
+/// provides, and examples of how to use `GroupNorm` with `torch::nn::GroupNormOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
 /// module storage semantics.
 TORCH_MODULE(GroupNorm);
 

--- a/torch/csrc/api/include/torch/nn/modules/padding.h
+++ b/torch/csrc/api/include/torch/nn/modules/padding.h
@@ -33,6 +33,14 @@ class TORCH_API ReflectionPadImpl : public torch::nn::Cloneable<Derived> {
 /// Applies ReflectionPad over a 1-D input.
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.ReflectionPad1d to learn
 /// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::ReflectionPad1dOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// ReflectionPad1d model(ReflectionPad1dOptions({3, 1}));
+/// ```
 class TORCH_API ReflectionPad1dImpl : public ReflectionPadImpl<1, ReflectionPad1dImpl> {
  public:
   using ReflectionPadImpl<1, ReflectionPad1dImpl>::ReflectionPadImpl;
@@ -40,7 +48,8 @@ class TORCH_API ReflectionPad1dImpl : public ReflectionPadImpl<1, ReflectionPad1
 
 /// A `ModuleHolder` subclass for `ReflectionPad1dImpl`.
 /// See the documentation for `ReflectionPad1dImpl` class to learn what methods it
-/// provides, or the documentation for `ModuleHolder` to learn about PyTorch's
+/// provides, and examples of how to use `ReflectionPad1d` with `torch::nn::ReflectionPad1dOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
 /// module storage semantics.
 TORCH_MODULE(ReflectionPad1d);
 
@@ -49,6 +58,14 @@ TORCH_MODULE(ReflectionPad1d);
 /// Applies ReflectionPad over a 2-D input.
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.ReflectionPad2d to learn
 /// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::ReflectionPad2dOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// ReflectionPad2d model(ReflectionPad2dOptions({1, 1, 2, 0}));
+/// ```
 class TORCH_API ReflectionPad2dImpl : public ReflectionPadImpl<2, ReflectionPad2dImpl> {
  public:
   using ReflectionPadImpl<2, ReflectionPad2dImpl>::ReflectionPadImpl;
@@ -56,7 +73,8 @@ class TORCH_API ReflectionPad2dImpl : public ReflectionPadImpl<2, ReflectionPad2
 
 /// A `ModuleHolder` subclass for `ReflectionPad2dImpl`.
 /// See the documentation for `ReflectionPad2dImpl` class to learn what methods it
-/// provides, or the documentation for `ModuleHolder` to learn about PyTorch's
+/// provides, and examples of how to use `ReflectionPad2d` with `torch::nn::ReflectionPad2dOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
 /// module storage semantics.
 TORCH_MODULE(ReflectionPad2d);
 
@@ -86,6 +104,14 @@ class TORCH_API ReplicationPadImpl : public torch::nn::Cloneable<Derived> {
 /// Applies ReplicationPad over a 1-D input.
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.ReplicationPad1d to learn
 /// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::ReplicationPad1dOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// ReplicationPad1d model(ReplicationPad1dOptions({3, 1}));
+/// ```
 class TORCH_API ReplicationPad1dImpl : public ReplicationPadImpl<1, ReplicationPad1dImpl> {
  public:
   using ReplicationPadImpl<1, ReplicationPad1dImpl>::ReplicationPadImpl;
@@ -93,7 +119,8 @@ class TORCH_API ReplicationPad1dImpl : public ReplicationPadImpl<1, ReplicationP
 
 /// A `ModuleHolder` subclass for `ReplicationPad1dImpl`.
 /// See the documentation for `ReplicationPad1dImpl` class to learn what methods it
-/// provides, or the documentation for `ModuleHolder` to learn about PyTorch's
+/// provides, and examples of how to use `ReplicationPad1d` with `torch::nn::ReplicationPad1dOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
 /// module storage semantics.
 TORCH_MODULE(ReplicationPad1d);
 
@@ -102,6 +129,14 @@ TORCH_MODULE(ReplicationPad1d);
 /// Applies ReplicationPad over a 2-D input.
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.ReplicationPad2d to learn
 /// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::ReplicationPad2dOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// ReplicationPad2d model(ReplicationPad2dOptions({1, 1, 2, 0}));
+/// ```
 class TORCH_API ReplicationPad2dImpl : public ReplicationPadImpl<2, ReplicationPad2dImpl> {
  public:
   using ReplicationPadImpl<2, ReplicationPad2dImpl>::ReplicationPadImpl;
@@ -109,7 +144,8 @@ class TORCH_API ReplicationPad2dImpl : public ReplicationPadImpl<2, ReplicationP
 
 /// A `ModuleHolder` subclass for `ReplicationPad2dImpl`.
 /// See the documentation for `ReplicationPad2dImpl` class to learn what methods it
-/// provides, or the documentation for `ModuleHolder` to learn about PyTorch's
+/// provides, and examples of how to use `ReplicationPad2d` with `torch::nn::ReplicationPad2dOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
 /// module storage semantics.
 TORCH_MODULE(ReplicationPad2d);
 
@@ -118,6 +154,14 @@ TORCH_MODULE(ReplicationPad2d);
 /// Applies ReplicationPad over a 3-D input.
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.ReplicationPad3d to learn
 /// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::ReplicationPad3dOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// ReplicationPad3d model(ReplicationPad3dOptions({1, 2, 1, 2, 1, 2}));
+/// ```
 class TORCH_API ReplicationPad3dImpl : public ReplicationPadImpl<3, ReplicationPad3dImpl> {
  public:
   using ReplicationPadImpl<3, ReplicationPad3dImpl>::ReplicationPadImpl;
@@ -125,15 +169,24 @@ class TORCH_API ReplicationPad3dImpl : public ReplicationPadImpl<3, ReplicationP
 
 /// A `ModuleHolder` subclass for `ReplicationPad3dImpl`.
 /// See the documentation for `ReplicationPad3dImpl` class to learn what methods it
-/// provides, or the documentation for `ModuleHolder` to learn about PyTorch's
+/// provides, and examples of how to use `ReplicationPad3d` with `torch::nn::ReplicationPad3dOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
 /// module storage semantics.
 TORCH_MODULE(ReplicationPad3d);
 
-// ============================================================================
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ZeroPad2d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies ZeroPad over a 2-D input.
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.ZeroPad2d to learn
 /// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::ZeroPad2dOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// ZeroPad2d model(ZeroPad2dOptions({1, 1, 2, 0}));
+/// ```
 class TORCH_API ZeroPad2dImpl : public Cloneable<ZeroPad2dImpl> {
  public:
   ZeroPad2dImpl(ExpandingArray<4> padding)
@@ -153,7 +206,8 @@ class TORCH_API ZeroPad2dImpl : public Cloneable<ZeroPad2dImpl> {
 
 /// A `ModuleHolder` subclass for `ZeroPad2dImpl`.
 /// See the documentation for `ZeroPad2dImpl` class to learn what methods it
-/// provides, or the documentation for `ModuleHolder` to learn about PyTorch's
+/// provides, and examples of how to use `ZeroPad2d` with `torch::nn::ZeroPad2dOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
 /// module storage semantics.
 TORCH_MODULE(ZeroPad2d);
 
@@ -183,6 +237,14 @@ class TORCH_API ConstantPadImpl : public torch::nn::Cloneable<Derived> {
 /// Applies ConstantPad over a 1-D input.
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.ConstantPad1d to learn
 /// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::ConstantPad1dOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// ConstantPad1d model(ConstantPad1dOptions({3, 1}, 3.5));
+/// ```
 class TORCH_API ConstantPad1dImpl : public ConstantPadImpl<1, ConstantPad1dImpl> {
  public:
   using ConstantPadImpl<1, ConstantPad1dImpl>::ConstantPadImpl;
@@ -190,7 +252,8 @@ class TORCH_API ConstantPad1dImpl : public ConstantPadImpl<1, ConstantPad1dImpl>
 
 /// A `ModuleHolder` subclass for `ConstantPad1dImpl`.
 /// See the documentation for `ConstantPad1dImpl` class to learn what methods it
-/// provides, or the documentation for `ModuleHolder` to learn about PyTorch's
+/// provides, and examples of how to use `ConstantPad1d` with `torch::nn::ConstantPad1dOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
 /// module storage semantics.
 TORCH_MODULE(ConstantPad1d);
 
@@ -199,6 +262,14 @@ TORCH_MODULE(ConstantPad1d);
 /// Applies ConstantPad over a 2-D input.
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.ConstantPad2d to learn
 /// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::ConstantPad2dOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// ConstantPad2d model(ConstantPad2dOptions({3, 0, 2, 1}, 3.5));
+/// ```
 class TORCH_API ConstantPad2dImpl : public ConstantPadImpl<2, ConstantPad2dImpl> {
  public:
   using ConstantPadImpl<2, ConstantPad2dImpl>::ConstantPadImpl;
@@ -206,7 +277,8 @@ class TORCH_API ConstantPad2dImpl : public ConstantPadImpl<2, ConstantPad2dImpl>
 
 /// A `ModuleHolder` subclass for `ConstantPad2dImpl`.
 /// See the documentation for `ConstantPad2dImpl` class to learn what methods it
-/// provides, or the documentation for `ModuleHolder` to learn about PyTorch's
+/// provides, and examples of how to use `ConstantPad2d` with `torch::nn::ConstantPad2dOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
 /// module storage semantics.
 TORCH_MODULE(ConstantPad2d);
 
@@ -215,6 +287,14 @@ TORCH_MODULE(ConstantPad2d);
 /// Applies ConstantPad over a 3-D input.
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.ConstantPad3d to learn
 /// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::ConstantPad3dOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// ConstantPad3d model(ConstantPad3dOptions({1, 2, 1, 2, 1, 2}, 3.5));
+/// ```
 class TORCH_API ConstantPad3dImpl : public ConstantPadImpl<3, ConstantPad3dImpl> {
  public:
   using ConstantPadImpl<3, ConstantPad3dImpl>::ConstantPadImpl;
@@ -222,7 +302,8 @@ class TORCH_API ConstantPad3dImpl : public ConstantPadImpl<3, ConstantPad3dImpl>
 
 /// A `ModuleHolder` subclass for `ConstantPad3dImpl`.
 /// See the documentation for `ConstantPad3dImpl` class to learn what methods it
-/// provides, or the documentation for `ModuleHolder` to learn about PyTorch's
+/// provides, and examples of how to use `ConstantPad3d` with `torch::nn::ConstantPad3dOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
 /// module storage semantics.
 TORCH_MODULE(ConstantPad3d);
 

--- a/torch/csrc/api/include/torch/nn/modules/pixelshuffle.h
+++ b/torch/csrc/api/include/torch/nn/modules/pixelshuffle.h
@@ -9,13 +9,20 @@
 namespace torch {
 namespace nn {
 
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ PixelShuffle ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 /// Rearranges elements in a tensor of shape :math:`(*, C \times r^2, H, W)`
 /// to a tensor of shape :math:`(*, C, H \times r, W \times r)`.
-/// This is useful for implementing efficient sub-pixel convolution
-/// with a stride of :math:`1/r`.
-/// Look at the paper:
-/// `Real-Time Single Image and Video Super-Resolution Using an Efficient Sub-Pixel Convolutional Neural Network`_
-/// by Shi et. al (2016) for more details.
+/// See https://pytorch.org/docs/master/nn.html#torch.nn.PixelShuffle to learn
+/// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::PixelShuffleOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// PixelShuffle model(PixelShuffleOptions(5));
+/// ```
 struct TORCH_API PixelShuffleImpl : public torch::nn::Cloneable<PixelShuffleImpl> {
   explicit PixelShuffleImpl(const PixelShuffleOptions& options_);
 
@@ -30,6 +37,11 @@ struct TORCH_API PixelShuffleImpl : public torch::nn::Cloneable<PixelShuffleImpl
   PixelShuffleOptions options;
 };
 
+/// A `ModuleHolder` subclass for `PixelShuffleImpl`.
+/// See the documentation for `PixelShuffleImpl` class to learn what methods it
+/// provides, and examples of how to use `PixelShuffle` with `torch::nn::PixelShuffleOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
+/// module storage semantics.
 TORCH_MODULE(PixelShuffle);
 
 } // namespace nn

--- a/torch/csrc/api/include/torch/nn/modules/pooling.h
+++ b/torch/csrc/api/include/torch/nn/modules/pooling.h
@@ -33,6 +33,14 @@ class TORCH_API AvgPoolImpl : public torch::nn::Cloneable<Derived> {
 /// Applies avgpool over a 1-D input.
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.AvgPool1d to learn
 /// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::AvgPool1dOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// AvgPool1d model(AvgPool1dOptions(3).stride(2));
+/// ```
 class TORCH_API AvgPool1dImpl : public AvgPoolImpl<1, AvgPool1dImpl> {
  public:
   using AvgPoolImpl<1, AvgPool1dImpl>::AvgPoolImpl;
@@ -41,7 +49,8 @@ class TORCH_API AvgPool1dImpl : public AvgPoolImpl<1, AvgPool1dImpl> {
 
 /// A `ModuleHolder` subclass for `AvgPool1dImpl`.
 /// See the documentation for `AvgPool1dImpl` class to learn what methods it
-/// provides, or the documentation for `ModuleHolder` to learn about PyTorch's
+/// provides, and examples of how to use `AvgPool1d` with `torch::nn::AvgPool1dOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
 /// module storage semantics.
 TORCH_MODULE(AvgPool1d);
 
@@ -50,6 +59,14 @@ TORCH_MODULE(AvgPool1d);
 /// Applies avgpool over a 2-D input.
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.AvgPool2d to learn
 /// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::AvgPool2dOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// AvgPool2d model(AvgPool2dOptions({3, 2}).stride({2, 2}));
+/// ```
 class TORCH_API AvgPool2dImpl : public AvgPoolImpl<2, AvgPool2dImpl> {
  public:
   using AvgPoolImpl<2, AvgPool2dImpl>::AvgPoolImpl;
@@ -58,7 +75,8 @@ class TORCH_API AvgPool2dImpl : public AvgPoolImpl<2, AvgPool2dImpl> {
 
 /// A `ModuleHolder` subclass for `AvgPool2dImpl`.
 /// See the documentation for `AvgPool2dImpl` class to learn what methods it
-/// provides, or the documentation for `ModuleHolder` to learn about PyTorch's
+/// provides, and examples of how to use `AvgPool2d` with `torch::nn::AvgPool2dOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
 /// module storage semantics.
 TORCH_MODULE(AvgPool2d);
 
@@ -67,15 +85,24 @@ TORCH_MODULE(AvgPool2d);
 /// Applies avgpool over a 3-D input.
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.AvgPool3d to learn
 /// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::AvgPool3dOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// AvgPool3d model(AvgPool3dOptions(5).stride(2));
+/// ```
 class TORCH_API AvgPool3dImpl : public AvgPoolImpl<3, AvgPool3dImpl> {
  public:
   using AvgPoolImpl<3, AvgPool3dImpl>::AvgPoolImpl;
   Tensor forward(const Tensor& input);
 };
 
-/// A `ModuleHolder` subclass for `AvgPool2dImpl`.
-/// See the documentation for `AvgPool2dImpl` class to learn what methods it
-/// provides, or the documentation for `ModuleHolder` to learn about PyTorch's
+/// A `ModuleHolder` subclass for `AvgPool3dImpl`.
+/// See the documentation for `AvgPool3dImpl` class to learn what methods it
+/// provides, and examples of how to use `AvgPool3d` with `torch::nn::AvgPool3dOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
 /// module storage semantics.
 TORCH_MODULE(AvgPool3d);
 
@@ -103,6 +130,14 @@ class TORCH_API MaxPoolImpl : public torch::nn::Cloneable<Derived> {
 /// Applies maxpool over a 1-D input.
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.MaxPool1d to learn
 /// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::MaxPool1dOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// MaxPool1d model(MaxPool1dOptions(3).stride(2));
+/// ```
 class TORCH_API MaxPool1dImpl : public MaxPoolImpl<1, MaxPool1dImpl> {
  public:
   using MaxPoolImpl<1, MaxPool1dImpl>::MaxPoolImpl;
@@ -115,7 +150,8 @@ class TORCH_API MaxPool1dImpl : public MaxPoolImpl<1, MaxPool1dImpl> {
 
 /// A `ModuleHolder` subclass for `MaxPool1dImpl`.
 /// See the documentation for `MaxPool1dImpl` class to learn what methods it
-/// provides, or the documentation for `ModuleHolder` to learn about PyTorch's
+/// provides, and examples of how to use `MaxPool1d` with `torch::nn::MaxPool1dOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
 /// module storage semantics.
 TORCH_MODULE(MaxPool1d);
 
@@ -124,6 +160,14 @@ TORCH_MODULE(MaxPool1d);
 /// Applies maxpool over a 2-D input.
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.MaxPool2d to learn
 /// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::MaxPool2dOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// MaxPool2d model(MaxPool2dOptions({3, 2}).stride({2, 2}));
+/// ```
 class TORCH_API MaxPool2dImpl : public MaxPoolImpl<2, MaxPool2dImpl> {
  public:
   using MaxPoolImpl<2, MaxPool2dImpl>::MaxPoolImpl;
@@ -136,7 +180,8 @@ class TORCH_API MaxPool2dImpl : public MaxPoolImpl<2, MaxPool2dImpl> {
 
 /// A `ModuleHolder` subclass for `MaxPool2dImpl`.
 /// See the documentation for `MaxPool2dImpl` class to learn what methods it
-/// provides, or the documentation for `ModuleHolder` to learn about PyTorch's
+/// provides, and examples of how to use `MaxPool2d` with `torch::nn::MaxPool2dOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
 /// module storage semantics.
 TORCH_MODULE(MaxPool2d);
 
@@ -145,6 +190,14 @@ TORCH_MODULE(MaxPool2d);
 /// Applies maxpool over a 3-D input.
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.MaxPool3d to learn
 /// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::MaxPool3dOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// MaxPool3d model(MaxPool3dOptions(3).stride(2));
+/// ```
 class TORCH_API MaxPool3dImpl : public MaxPoolImpl<3, MaxPool3dImpl> {
  public:
   using MaxPoolImpl<3, MaxPool3dImpl>::MaxPoolImpl;
@@ -157,7 +210,8 @@ class TORCH_API MaxPool3dImpl : public MaxPoolImpl<3, MaxPool3dImpl> {
 
 /// A `ModuleHolder` subclass for `MaxPool3dImpl`.
 /// See the documentation for `MaxPool3dImpl` class to learn what methods it
-/// provides, or the documentation for `ModuleHolder` to learn about PyTorch's
+/// provides, and examples of how to use `MaxPool3d` with `torch::nn::MaxPool3dOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
 /// module storage semantics.
 TORCH_MODULE(MaxPool3d);
 
@@ -183,8 +237,16 @@ class TORCH_API AdaptiveMaxPoolImpl : public torch::nn::Cloneable<Derived> {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~ AdaptiveMaxPool1d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies adaptive maxpool over a 1-D input.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.AdaptiveMaxPool1d
-/// to learn about the exact behavior of this module.
+/// See https://pytorch.org/docs/master/nn.html#torch.nn.AdaptiveMaxPool1d to learn
+/// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::AdaptiveMaxPool1dOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// AdaptiveMaxPool1d model(AdaptiveMaxPool1dOptions(3));
+/// ```
 class TORCH_API AdaptiveMaxPool1dImpl :
   public AdaptiveMaxPoolImpl<1, AdaptiveMaxPool1dImpl> {
  public:
@@ -199,15 +261,24 @@ class TORCH_API AdaptiveMaxPool1dImpl :
 
 /// A `ModuleHolder` subclass for `AdaptiveMaxPool1dImpl`.
 /// See the documentation for `AdaptiveMaxPool1dImpl` class to learn what methods it
-/// provides, or the documentation for `ModuleHolder` to learn about PyTorch's
+/// provides, and examples of how to use `AdaptiveMaxPool1d` with `torch::nn::AdaptiveMaxPool1dOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
 /// module storage semantics.
 TORCH_MODULE(AdaptiveMaxPool1d);
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ AdaptiveMaxPool2d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies adaptive maxpool over a 2-D input.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.AdaptiveMaxPool2d
-/// to learn about the exact behavior of this module.
+/// See https://pytorch.org/docs/master/nn.html#torch.nn.AdaptiveMaxPool2d to learn
+/// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::AdaptiveMaxPool2dOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// AdaptiveMaxPool2d model(AdaptiveMaxPool2dOptions({3, 2}));
+/// ```
 class TORCH_API AdaptiveMaxPool2dImpl :
   public AdaptiveMaxPoolImpl<2, AdaptiveMaxPool2dImpl> {
  public:
@@ -222,15 +293,24 @@ class TORCH_API AdaptiveMaxPool2dImpl :
 
 /// A `ModuleHolder` subclass for `AdaptiveMaxPool2dImpl`.
 /// See the documentation for `AdaptiveMaxPool2dImpl` class to learn what methods it
-/// provides, or the documentation for `ModuleHolder` to learn about PyTorch's
+/// provides, and examples of how to use `AdaptiveMaxPool2d` with `torch::nn::AdaptiveMaxPool2dOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
 /// module storage semantics.
 TORCH_MODULE(AdaptiveMaxPool2d);
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ AdaptiveMaxPool3d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies adaptive maxpool over a 3-D input.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.AdaptiveMaxPool3d
-/// to learn about the exact behavior of this module.
+/// See https://pytorch.org/docs/master/nn.html#torch.nn.AdaptiveMaxPool3d to learn
+/// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::AdaptiveMaxPool3dOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// AdaptiveMaxPool3d model(AdaptiveMaxPool3dOptions(3));
+/// ```
 class TORCH_API AdaptiveMaxPool3dImpl :
   public AdaptiveMaxPoolImpl<3, AdaptiveMaxPool3dImpl> {
  public:
@@ -245,7 +325,8 @@ class TORCH_API AdaptiveMaxPool3dImpl :
 
 /// A `ModuleHolder` subclass for `AdaptiveMaxPool3dImpl`.
 /// See the documentation for `AdaptiveMaxPool3dImpl` class to learn what methods it
-/// provides, or the documentation for `ModuleHolder` to learn about PyTorch's
+/// provides, and examples of how to use `AdaptiveMaxPool3d` with `torch::nn::AdaptiveMaxPool3dOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
 /// module storage semantics.
 TORCH_MODULE(AdaptiveMaxPool3d);
 
@@ -271,8 +352,16 @@ class TORCH_API AdaptiveAvgPoolImpl : public torch::nn::Cloneable<Derived> {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~ AdaptiveAvgPool1d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies adaptive avgpool over a 1-D input.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.AdaptiveAvgPool1d
-/// to learn about the exact behavior of this module.
+/// See https://pytorch.org/docs/master/nn.html#torch.nn.AdaptiveAvgPool1d to learn
+/// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::AdaptiveAvgPool1dOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// AdaptiveAvgPool1d model(AdaptiveAvgPool1dOptions(5));
+/// ```
 class TORCH_API AdaptiveAvgPool1dImpl :
   public AdaptiveAvgPoolImpl<1, AdaptiveAvgPool1dImpl> {
  public:
@@ -283,15 +372,24 @@ class TORCH_API AdaptiveAvgPool1dImpl :
 
 /// A `ModuleHolder` subclass for `AdaptiveAvgPool1dImpl`.
 /// See the documentation for `AdaptiveAvgPool1dImpl` class to learn what methods it
-/// provides, or the documentation for `ModuleHolder` to learn about PyTorch's
+/// provides, and examples of how to use `AdaptiveAvgPool1d` with `torch::nn::AdaptiveAvgPool1dOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
 /// module storage semantics.
 TORCH_MODULE(AdaptiveAvgPool1d);
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~ AdaptiveAvgPool2d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies adaptive avgpool over a 2-D input.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.AdaptiveAvgPool2d
-/// to learn about the exact behavior of this module.
+/// See https://pytorch.org/docs/master/nn.html#torch.nn.AdaptiveAvgPool2d to learn
+/// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::AdaptiveAvgPool2dOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// AdaptiveAvgPool2d model(AdaptiveAvgPool2dOptions({3, 2}));
+/// ```
 class TORCH_API AdaptiveAvgPool2dImpl :
   public AdaptiveAvgPoolImpl<2, AdaptiveAvgPool2dImpl> {
  public:
@@ -302,15 +400,24 @@ class TORCH_API AdaptiveAvgPool2dImpl :
 
 /// A `ModuleHolder` subclass for `AdaptiveAvgPool2dImpl`.
 /// See the documentation for `AdaptiveAvgPool2dImpl` class to learn what methods it
-/// provides, or the documentation for `ModuleHolder` to learn about PyTorch's
+/// provides, and examples of how to use `AdaptiveAvgPool2d` with `torch::nn::AdaptiveAvgPool2dOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
 /// module storage semantics.
 TORCH_MODULE(AdaptiveAvgPool2d);
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~ AdaptiveAvgPool3d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies adaptive avgpool over a 3-D input.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.AdaptiveAvgPool3d
-/// to learn about the exact behavior of this module.
+/// See https://pytorch.org/docs/master/nn.html#torch.nn.AdaptiveAvgPool3d to learn
+/// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::AdaptiveAvgPool3dOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// AdaptiveAvgPool3d model(AdaptiveAvgPool3dOptions(3));
+/// ```
 class TORCH_API AdaptiveAvgPool3dImpl :
   public AdaptiveAvgPoolImpl<3, AdaptiveAvgPool3dImpl> {
  public:
@@ -321,7 +428,8 @@ class TORCH_API AdaptiveAvgPool3dImpl :
 
 /// A `ModuleHolder` subclass for `AdaptiveAvgPool3dImpl`.
 /// See the documentation for `AdaptiveAvgPool3dImpl` class to learn what methods it
-/// provides, or the documentation for `ModuleHolder` to learn about PyTorch's
+/// provides, and examples of how to use `AdaptiveAvgPool3d` with `torch::nn::AdaptiveAvgPool3dOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
 /// module storage semantics.
 TORCH_MODULE(AdaptiveAvgPool3d);
 
@@ -349,6 +457,14 @@ class TORCH_API MaxUnpoolImpl : public torch::nn::Cloneable<Derived> {
 /// Applies maxunpool over a 1-D input.
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.MaxUnpool1d to learn
 /// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::MaxUnpool1dOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// MaxUnpool1d model(MaxUnpool1dOptions(3).stride(2).padding(1));
+/// ```
 class TORCH_API MaxUnpool1dImpl : public MaxUnpoolImpl<1, MaxUnpool1dImpl> {
  public:
   using MaxUnpoolImpl<1, MaxUnpool1dImpl>::MaxUnpoolImpl;
@@ -360,7 +476,8 @@ class TORCH_API MaxUnpool1dImpl : public MaxUnpoolImpl<1, MaxUnpool1dImpl> {
 
 /// A `ModuleHolder` subclass for `MaxUnpool1dImpl`.
 /// See the documentation for `MaxUnpool1dImpl` class to learn what methods it
-/// provides, or the documentation for `ModuleHolder` to learn about PyTorch's
+/// provides, and examples of how to use `MaxUnpool1d` with `torch::nn::MaxUnpool1dOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
 /// module storage semantics.
 TORCH_MODULE(MaxUnpool1d);
 
@@ -369,6 +486,14 @@ TORCH_MODULE(MaxUnpool1d);
 /// Applies maxunpool over a 2-D input.
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.MaxUnpool2d to learn
 /// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::MaxUnpool2dOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// MaxUnpool2d model(MaxUnpool2dOptions(3).stride(2).padding(1));
+/// ```
 class TORCH_API MaxUnpool2dImpl : public MaxUnpoolImpl<2, MaxUnpool2dImpl> {
  public:
   using MaxUnpoolImpl<2, MaxUnpool2dImpl>::MaxUnpoolImpl;
@@ -380,7 +505,8 @@ class TORCH_API MaxUnpool2dImpl : public MaxUnpoolImpl<2, MaxUnpool2dImpl> {
 
 /// A `ModuleHolder` subclass for `MaxUnpool2dImpl`.
 /// See the documentation for `MaxUnpool2dImpl` class to learn what methods it
-/// provides, or the documentation for `ModuleHolder` to learn about PyTorch's
+/// provides, and examples of how to use `MaxUnpool2d` with `torch::nn::MaxUnpool2dOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
 /// module storage semantics.
 TORCH_MODULE(MaxUnpool2d);
 
@@ -389,6 +515,14 @@ TORCH_MODULE(MaxUnpool2d);
 /// Applies maxunpool over a 3-D input.
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.MaxUnpool3d to learn
 /// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::MaxUnpool3dOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// MaxUnpool3d model(MaxUnpool3dOptions(3).stride(2).padding(1));
+/// ```
 class TORCH_API MaxUnpool3dImpl : public MaxUnpoolImpl<3, MaxUnpool3dImpl> {
  public:
   using MaxUnpoolImpl<3, MaxUnpool3dImpl>::MaxUnpoolImpl;
@@ -400,7 +534,8 @@ class TORCH_API MaxUnpool3dImpl : public MaxUnpoolImpl<3, MaxUnpool3dImpl> {
 
 /// A `ModuleHolder` subclass for `MaxUnpool3dImpl`.
 /// See the documentation for `MaxUnpool3dImpl` class to learn what methods it
-/// provides, or the documentation for `ModuleHolder` to learn about PyTorch's
+/// provides, and examples of how to use `MaxUnpool3d` with `torch::nn::MaxUnpool3dOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
 /// module storage semantics.
 TORCH_MODULE(MaxUnpool3d);
 
@@ -409,6 +544,14 @@ TORCH_MODULE(MaxUnpool3d);
 /// Applies fractional maxpool over a 2-D input.
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.FractionalMaxPool2d to learn
 /// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::FractionalMaxPool2dOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// FractionalMaxPool2d model(FractionalMaxPool2dOptions(5).output_size(1));
+/// ```
 class TORCH_API FractionalMaxPool2dImpl : public torch::nn::Cloneable<FractionalMaxPool2dImpl> {
  public:
   FractionalMaxPool2dImpl(ExpandingArray<2> kernel_size)
@@ -434,13 +577,24 @@ class TORCH_API FractionalMaxPool2dImpl : public torch::nn::Cloneable<Fractional
 
 /// A `ModuleHolder` subclass for `FractionalMaxPool2dImpl`.
 /// See the documentation for `FractionalMaxPool2dImpl` class to learn what methods it
-/// provides, or the documentation for `ModuleHolder` to learn about PyTorch's
+/// provides, and examples of how to use `FractionalMaxPool2d` with `torch::nn::FractionalMaxPool2dOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
 /// module storage semantics.
 TORCH_MODULE(FractionalMaxPool2d);
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ FractionalMaxPool3d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies fractional maxpool over a 3-D input.
+/// See https://pytorch.org/docs/master/nn.html#torch.nn.FractionalMaxPool3d to learn
+/// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::FractionalMaxPool3dOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// FractionalMaxPool3d model(FractionalMaxPool3dOptions(5).output_size(1));
+/// ```
 class TORCH_API FractionalMaxPool3dImpl : public torch::nn::Cloneable<FractionalMaxPool3dImpl> {
  public:
   FractionalMaxPool3dImpl(ExpandingArray<3> kernel_size)
@@ -466,11 +620,12 @@ class TORCH_API FractionalMaxPool3dImpl : public torch::nn::Cloneable<Fractional
 
 /// A `ModuleHolder` subclass for `FractionalMaxPool3dImpl`.
 /// See the documentation for `FractionalMaxPool3dImpl` class to learn what methods it
-/// provides, or the documentation for `ModuleHolder` to learn about PyTorch's
+/// provides, and examples of how to use `FractionalMaxPool3d` with `torch::nn::FractionalMaxPool3dOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
 /// module storage semantics.
 TORCH_MODULE(FractionalMaxPool3d);
 
-// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ LPPool ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// ============================================================================
 
 /// Base class for all (dimension-specialized) lppool modules.
 template <size_t D, typename Derived>
@@ -488,9 +643,19 @@ class TORCH_API LPPoolImpl : public torch::nn::Cloneable<Derived> {
   LPPoolOptions<D> options;
 };
 
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ LPPool1d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 /// Applies the LPPool1d function element-wise.
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.LPPool1d to learn
 /// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::LPPool1dOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// LPPool1d model(LPPool1dOptions(1, 2).stride(5).ceil_mode(true));
+/// ```
 class TORCH_API LPPool1dImpl : public LPPoolImpl<1, LPPool1dImpl> {
  public:
   using LPPoolImpl<1, LPPool1dImpl>::LPPoolImpl;
@@ -499,11 +664,26 @@ class TORCH_API LPPool1dImpl : public LPPoolImpl<1, LPPool1dImpl> {
 
 };
 
+/// A `ModuleHolder` subclass for `LPPool1dImpl`.
+/// See the documentation for `LPPool1dImpl` class to learn what methods it
+/// provides, and examples of how to use `LPPool1d` with `torch::nn::LPPool1dOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
+/// module storage semantics.
 TORCH_MODULE(LPPool1d);
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ LPPool2d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the LPPool2d function element-wise.
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.LPPool2d to learn
 /// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::LPPool2dOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// LPPool2d model(LPPool2dOptions(1, std::vector<int64_t>({3, 4})).stride({5, 6}).ceil_mode(true));
+/// ```
 class TORCH_API LPPool2dImpl : public LPPoolImpl<2, LPPool2dImpl> {
  public:
   using LPPoolImpl<2, LPPool2dImpl>::LPPoolImpl;
@@ -512,6 +692,11 @@ class TORCH_API LPPool2dImpl : public LPPoolImpl<2, LPPool2dImpl> {
 
 };
 
+/// A `ModuleHolder` subclass for `LPPool2dImpl`.
+/// See the documentation for `LPPool2dImpl` class to learn what methods it
+/// provides, and examples of how to use `LPPool2d` with `torch::nn::LPPool2dOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
+/// module storage semantics.
 TORCH_MODULE(LPPool2d);
 
 } // namespace nn

--- a/torch/csrc/api/include/torch/nn/modules/upsampling.h
+++ b/torch/csrc/api/include/torch/nn/modules/upsampling.h
@@ -14,11 +14,20 @@
 namespace torch {
 namespace nn {
 
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Upsample ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 /// Upsamples a given multi-channel 1D (temporal), 2D (spatial) or 3D
 /// (volumetric) data.
+/// See https://pytorch.org/docs/master/nn.html#torch.nn.Upsample to learn
+/// about the exact behavior of this module.
 ///
-/// See https://pytorch.org/docs/stable/nn.html#Upsample to learn more
-/// about the exact semantics of this module.
+/// See the documentation for `torch::nn::UpsampleOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// Upsample model(UpsampleOptions().scale_factor({3}).mode(torch::kLinear).align_corners(false));
+/// ```
 class TORCH_API UpsampleImpl : public Cloneable<UpsampleImpl> {
  public:
   explicit UpsampleImpl(const UpsampleOptions& options_ = {});
@@ -35,9 +44,10 @@ class TORCH_API UpsampleImpl : public Cloneable<UpsampleImpl> {
 };
 
 /// A `ModuleHolder` subclass for `UpsampleImpl`.
-/// See the documentation for `UpsampleImpl` class to learn what
-/// methods it provides, or the documentation for `ModuleHolder` to learn about
-/// PyTorch's module storage semantics.
+/// See the documentation for `UpsampleImpl` class to learn what methods it
+/// provides, and examples of how to use `Upsample` with `torch::nn::UpsampleOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
+/// module storage semantics.
 TORCH_MODULE(Upsample);
 
 } // namespace nn

--- a/torch/csrc/api/include/torch/nn/options/activation.h
+++ b/torch/csrc/api/include/torch/nn/options/activation.h
@@ -9,6 +9,11 @@ namespace torch {
 namespace nn {
 
 /// Options for ELU functional and module.
+///
+/// Example:
+/// ```
+/// ELU model(ELUOptions().alpha(42.42).inplace(true));
+/// ```
 struct TORCH_API ELUOptions {
   /// The `alpha` value for the ELU formulation. Default: 1.0
   TORCH_ARG(double, alpha) = 1.0;
@@ -22,6 +27,11 @@ TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(ELU, ELUFuncOptions)
 // ============================================================================
 
 /// Options for SELU functional and module.
+///
+/// Example:
+/// ```
+/// SELU model(SELUOptions().inplace(true));
+/// ```
 struct TORCH_API SELUOptions {
   /* implicit */ SELUOptions(bool inplace = false);
 
@@ -34,6 +44,11 @@ TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(SELU, SELUFuncOptions)
 // ============================================================================
 
 /// Options for GLU functional and module.
+///
+/// Example:
+/// ```
+/// GLU model(GLUOptions(1));
+/// ```
 struct TORCH_API GLUOptions {
   /* implicit */ GLUOptions(int64_t dim = -1);
 
@@ -46,6 +61,11 @@ TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(GLU, GLUFuncOptions)
 // ============================================================================
 
 /// Options for Hardshrink functional and module.
+///
+/// Example:
+/// ```
+/// Hardshrink model(HardshrinkOptions().lambda(42.42));
+/// ```
 struct TORCH_API HardshrinkOptions {
   /* implicit */ HardshrinkOptions(double lambda = 0.5);
 
@@ -58,6 +78,11 @@ TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(Hardshrink, HardshrinkFuncOptions)
 // ============================================================================
 
 /// Options for Hardtanh functional and module.
+///
+/// Example:
+/// ```
+/// Hardtanh model(HardtanhOptions().min_val(-42.42).max_val(0.42).inplace(true));
+/// ```
 struct TORCH_API HardtanhOptions {
   /// minimum value of the linear region range. Default: -1
   TORCH_ARG(double, min_val) = -1.0;
@@ -74,6 +99,11 @@ TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(Hardtanh, HardtanhFuncOptions)
 // ============================================================================
 
 /// Options for LeakyReLU functional and module.
+///
+/// Example:
+/// ```
+/// LeakyReLU model(LeakyReLUOptions().negative_slope(0.42).inplace(true));
+/// ```
 struct TORCH_API LeakyReLUOptions {
   /// Controls the angle of the negative slope. Default: 1e-2
   TORCH_ARG(double, negative_slope) = 1e-2;
@@ -87,6 +117,11 @@ TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(LeakyReLU, LeakyReLUFuncOptions)
 // ============================================================================
 
 /// Options for the Softmax functional and module.
+///
+/// Example:
+/// ```
+/// Softmax model(SoftmaxOptions(1));
+/// ```
 struct TORCH_API SoftmaxOptions {
   SoftmaxOptions(int64_t dim);
 
@@ -115,6 +150,11 @@ struct TORCH_API SoftmaxFuncOptions {
 // ============================================================================
 
 /// Options for the Softmin functional and module.
+///
+/// Example:
+/// ```
+/// Softmin model(SoftminOptions(1));
+/// ```
 struct TORCH_API SoftminOptions {
   SoftminOptions(int64_t dim);
 
@@ -143,6 +183,11 @@ struct TORCH_API SoftminFuncOptions {
 // ============================================================================
 
 /// Options for the LogSoftmax functional and module.
+///
+/// Example:
+/// ```
+/// LogSoftmax model(LogSoftmaxOptions(1));
+/// ```
 struct TORCH_API LogSoftmaxOptions {
   LogSoftmaxOptions(int64_t dim);
 
@@ -171,6 +216,11 @@ struct TORCH_API LogSoftmaxFuncOptions {
 // ============================================================================
 
 /// Options for PReLU functional and module.
+///
+/// Example:
+/// ```
+/// PReLU model(PReLUOptions().num_parameters(42));
+/// ```
 struct TORCH_API PReLUOptions {
   /// number of `a` to learn. Although it takes an int as input, there is only
   /// two values are legitimate: 1, or the number of channels at input. Default: 1
@@ -185,6 +235,11 @@ TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(PReLU, PReLUFuncOptions)
 // ============================================================================
 
 /// Options for ReLU functional and module.
+///
+/// Example:
+/// ```
+/// ReLU model(ReLUOptions().inplace(true));
+/// ```
 struct TORCH_API ReLUOptions {
   /* implicit */ ReLUOptions(bool inplace = false);
 
@@ -197,6 +252,11 @@ TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(ReLU, ReLUFuncOptions)
 // ============================================================================
 
 /// Options for ReLU6 functional and module.
+///
+/// Example:
+/// ```
+/// ReLU6 model(ReLU6Options().inplace(true));
+/// ```
 struct TORCH_API ReLU6Options {
   /* implicit */ ReLU6Options(bool inplace = false);
 
@@ -209,6 +269,11 @@ TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(ReLU6, ReLU6FuncOptions)
 // ============================================================================
 
 /// Options for RReLU functional and module.
+///
+/// Example:
+/// ```
+/// RReLU model(RReLUOptions().lower(0.24).upper(0.42).inplace(true));
+/// ```
 struct TORCH_API RReLUOptions {
   /// lower bound of the uniform distribution. Default: 1/8
   TORCH_ARG(double, lower) = 1.0 / 8.0;
@@ -242,6 +307,11 @@ struct TORCH_API RReLUFuncOptions {
 // ============================================================================
 
 /// Options for CELU functional and module.
+///
+/// Example:
+/// ```
+/// CELU model(CELUOptions().alpha(42.42).inplace(true));
+/// ```
 struct TORCH_API CELUOptions {
   /// The `alpha` value for the CELU formulation. Default: 1.0
   TORCH_ARG(double, alpha) = 1.0;
@@ -255,6 +325,11 @@ TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(CELU, CELUFuncOptions)
 // ============================================================================
 
 /// Options for Softplus functional and module.
+///
+/// Example:
+/// ```
+/// Softplus model(SoftplusOptions().beta(0.24).threshold(42.42));
+/// ```
 struct TORCH_API SoftplusOptions {
   /// the `beta` value for the Softplus formulation. Default: 1
   TORCH_ARG(double, beta) = 1.0;
@@ -268,6 +343,11 @@ TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(Softplus, SoftplusFuncOptions)
 // ============================================================================
 
 /// Options for Softshrink functional and module.
+///
+/// Example:
+/// ```
+/// Softshrink model(SoftshrinkOptions(42.42));
+/// ```
 struct TORCH_API SoftshrinkOptions {
   /* implicit */ SoftshrinkOptions(double lambda = 0.5);
 
@@ -280,6 +360,11 @@ TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(Softshrink, SoftshrinkFuncOptions)
 // ============================================================================
 
 /// Options for Threshold functional and module.
+///
+/// Example:
+/// ```
+/// Threshold model(ThresholdOptions(42.42, 24.24).inplace(true));
+/// ```
 struct TORCH_API ThresholdOptions {
   ThresholdOptions(double threshold, double value)
    : threshold_(threshold), value_(value) {}
@@ -318,6 +403,11 @@ struct TORCH_API GumbelSoftmaxFuncOptions {
 // ============================================================================
 
 /// Options for MultiheadAttention functional and module.
+///
+/// Example:
+/// ```
+/// MultiheadAttention model(MultiheadAttentionOptions(20, 10).bias(false));
+/// ```
 struct TORCH_API MultiheadAttentionOptions {
   MultiheadAttentionOptions(int64_t embed_dim, int64_t num_heads);
 

--- a/torch/csrc/api/include/torch/nn/options/activation.h
+++ b/torch/csrc/api/include/torch/nn/options/activation.h
@@ -8,7 +8,7 @@
 namespace torch {
 namespace nn {
 
-/// Options for ELU functional and module.
+/// Options for ELU module.
 struct TORCH_API ELUOptions {
   /// The `alpha` value for the ELU formulation. Default: 1.0
   TORCH_ARG(double, alpha) = 1.0;
@@ -17,6 +17,7 @@ struct TORCH_API ELUOptions {
   TORCH_ARG(bool, inplace) = false;
 };
 
+/// Options for `torch::nn::functional::elu`. See `torch::nn::ELUOptions` for the arugments it accepts.
 TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(ELU, ELUFuncOptions)
 
 // ============================================================================

--- a/torch/csrc/api/include/torch/nn/options/activation.h
+++ b/torch/csrc/api/include/torch/nn/options/activation.h
@@ -17,7 +17,6 @@ struct TORCH_API ELUOptions {
   TORCH_ARG(bool, inplace) = false;
 };
 
-/// Options for `torch::nn::functional::elu`. See `torch::nn::ELUOptions` for the arugments it accepts.
 TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(ELU, ELUFuncOptions)
 
 // ============================================================================

--- a/torch/csrc/api/include/torch/nn/options/activation.h
+++ b/torch/csrc/api/include/torch/nn/options/activation.h
@@ -8,7 +8,7 @@
 namespace torch {
 namespace nn {
 
-/// Options for ELU module.
+/// Options for ELU functional and module.
 struct TORCH_API ELUOptions {
   /// The `alpha` value for the ELU formulation. Default: 1.0
   TORCH_ARG(double, alpha) = 1.0;

--- a/torch/csrc/api/include/torch/nn/options/batchnorm.h
+++ b/torch/csrc/api/include/torch/nn/options/batchnorm.h
@@ -35,8 +35,28 @@ struct TORCH_API BatchNormOptions {
   TORCH_ARG(bool, track_running_stats) = true;
 };
 
+/// Options for the `BatchNorm1d` module.
+///
+/// Example:
+/// ```
+/// BatchNorm1d model(BatchNorm1dOptions(4).eps(0.5).momentum(0.1).affine(false).track_running_stats(true));
+/// ```
 using BatchNorm1dOptions = BatchNormOptions;
+
+/// Options for the `BatchNorm2d` module.
+///
+/// Example:
+/// ```
+/// BatchNorm2d model(BatchNorm2dOptions(4).eps(0.5).momentum(0.1).affine(false).track_running_stats(true));
+/// ```
 using BatchNorm2dOptions = BatchNormOptions;
+
+/// Options for the `BatchNorm3d` module.
+///
+/// Example:
+/// ```
+/// BatchNorm3d model(BatchNorm3dOptions(4).eps(0.5).momentum(0.1).affine(false).track_running_stats(true));
+/// ```
 using BatchNorm3dOptions = BatchNormOptions;
 
 // ============================================================================

--- a/torch/csrc/api/include/torch/nn/options/conv.h
+++ b/torch/csrc/api/include/torch/nn/options/conv.h
@@ -149,9 +149,19 @@ struct ConvOptions {
 using Conv1dOptions = ConvOptions<1>;
 
 /// `ConvOptions` specialized for 2-D convolution.
+///
+/// Example:
+/// ```
+/// Conv2d model(Conv2dOptions(3, 2, 3).stride(1).bias(false));
+/// ```
 using Conv2dOptions = ConvOptions<2>;
 
 /// `ConvOptions` specialized for 3-D convolution.
+///
+/// Example:
+/// ```
+/// Conv3d model(Conv3dOptions(3, 2, 3).stride(1).bias(false));
+/// ```
 using Conv3dOptions = ConvOptions<3>;
 
 // ============================================================================
@@ -260,12 +270,27 @@ struct ConvTransposeOptions {
 };
 
 /// `ConvTransposeOptions` specialized for 1-D convolution.
+///
+/// Example:
+/// ```
+/// ConvTranspose1d model(ConvTranspose1dOptions(3, 2, 3).stride(1).bias(false));
+/// ```
 using ConvTranspose1dOptions = ConvTransposeOptions<1>;
 
 /// `ConvTransposeOptions` specialized for 2-D convolution.
+///
+/// Example:
+/// ```
+/// ConvTranspose2d model(ConvTranspose2dOptions(3, 2, 3).stride(1).bias(false));
+/// ```
 using ConvTranspose2dOptions = ConvTransposeOptions<2>;
 
 /// `ConvTransposeOptions` specialized for 3-D convolution.
+///
+/// Example:
+/// ```
+/// ConvTranspose3d model(ConvTranspose3dOptions(2, 2, 2).stride(1).bias(false));
+/// ```
 using ConvTranspose3dOptions = ConvTransposeOptions<3>;
 
 // ============================================================================

--- a/torch/csrc/api/include/torch/nn/options/conv.h
+++ b/torch/csrc/api/include/torch/nn/options/conv.h
@@ -141,6 +141,11 @@ struct ConvOptions {
 };
 
 /// `ConvOptions` specialized for 1-D convolution.
+///
+/// Example:
+/// ```
+/// Conv1d model(Conv1dOptions(3, 2, 3).stride(1).bias(false));
+/// ```
 using Conv1dOptions = ConvOptions<1>;
 
 /// `ConvOptions` specialized for 2-D convolution.

--- a/torch/csrc/api/include/torch/nn/options/distance.h
+++ b/torch/csrc/api/include/torch/nn/options/distance.h
@@ -9,6 +9,11 @@ namespace torch {
 namespace nn {
 
 /// Options for the `CosineSimilarity` module.
+///
+/// Example:
+/// ```
+/// CosineSimilarity model(CosineSimilarityOptions().dim(0).eps(0.5));
+/// ```
 struct TORCH_API CosineSimilarityOptions {
   /// Dimension where cosine similarity is computed. Default: 1
   TORCH_ARG(int64_t, dim) = 1;
@@ -21,6 +26,11 @@ TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(CosineSimilarity, CosineSimilarityFuncOpt
 // ============================================================================
 
 /// Options for the `PairwiseDistance` module.
+///
+/// Example:
+/// ```
+/// PairwiseDistance model(PairwiseDistanceOptions().p(3).eps(0.5).keepdim(true));
+/// ```
 struct TORCH_API PairwiseDistanceOptions {
   /// The norm degree. Default: 2
   TORCH_ARG(double, p) = 2.0;

--- a/torch/csrc/api/include/torch/nn/options/dropout.h
+++ b/torch/csrc/api/include/torch/nn/options/dropout.h
@@ -8,6 +8,11 @@ namespace torch {
 namespace nn {
 
 /// Options for `Dropout` module.
+///
+/// Example:
+/// ```
+/// Dropout model(DropoutOptions().p(0.42).inplace(true));
+/// ```
 struct TORCH_API DropoutOptions {
   /* implicit */ DropoutOptions(double p = 0.5);
 
@@ -19,18 +24,38 @@ struct TORCH_API DropoutOptions {
 };
 
 /// Options for `Dropout2d` module.
+///
+/// Example:
+/// ```
+/// Dropout2d model(Dropout2dOptions().p(0.42).inplace(true));
+/// ```
 using Dropout2dOptions = DropoutOptions;
 
 /// Options for `Dropout3d` module.
+///
+/// Example:
+/// ```
+/// Dropout3d model(Dropout3dOptions().p(0.42).inplace(true));
+/// ```
 using Dropout3dOptions = DropoutOptions;
 
 /// Options for `FeatureDropout` module.
 using FeatureDropoutOptions = DropoutOptions;
 
 /// Options for `AlphaDropout` module.
+///
+/// Example:
+/// ```
+/// AlphaDropout model(AlphaDropoutOptions(0.2).inplace(true));
+/// ```
 using AlphaDropoutOptions = DropoutOptions;
 
 /// Options for `FeatureAlphaDropout` module.
+///
+/// Example:
+/// ```
+/// FeatureAlphaDropout model(FeatureAlphaDropoutOptions(0.2).inplace(true));
+/// ```
 using FeatureAlphaDropoutOptions = DropoutOptions;
 
 namespace functional {

--- a/torch/csrc/api/include/torch/nn/options/embedding.h
+++ b/torch/csrc/api/include/torch/nn/options/embedding.h
@@ -9,6 +9,11 @@ namespace torch {
 namespace nn {
 
 /// Options for the `Embedding` module.
+///
+/// Example:
+/// ```
+/// Embedding model(EmbeddingOptions(10, 2).padding_idx(3).max_norm(2).norm_type(2.5).scale_grad_by_freq(true).sparse(true));
+/// ```
 struct TORCH_API EmbeddingOptions {
   EmbeddingOptions(int64_t num_embeddings, int64_t embedding_dim);
 
@@ -73,6 +78,11 @@ struct TORCH_API EmbeddingFuncOptions {
 typedef c10::variant<enumtype::kSum, enumtype::kMean, enumtype::kMax> EmbeddingBagMode;
 
 /// Options for the `EmbeddingBag` module.
+///
+/// Example:
+/// ```
+/// EmbeddingBag model(EmbeddingBagOptions(10, 2).max_norm(2).norm_type(2.5).scale_grad_by_freq(true).sparse(true).mode(torch::kSum));
+/// ```
 struct TORCH_API EmbeddingBagOptions {
   EmbeddingBagOptions(int64_t num_embeddings, int64_t embedding_dim);
 

--- a/torch/csrc/api/include/torch/nn/options/fold.h
+++ b/torch/csrc/api/include/torch/nn/options/fold.h
@@ -10,6 +10,11 @@ namespace torch {
 namespace nn {
 
 /// Options for a fold module.
+///
+/// Example:
+/// ```
+/// Fold model(FoldOptions({8, 8}, {3, 3}).dilation(2).padding({2, 1}).stride(2));
+/// ```
 struct TORCH_API FoldOptions {
   FoldOptions(ExpandingArray<2> output_size, ExpandingArray<2> kernel_size)
       : output_size_(std::move(output_size)),
@@ -40,6 +45,11 @@ TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(Fold, FoldFuncOptions)
 // ============================================================================
 
 /// Options for an Unfold functional and module.
+///
+/// Example:
+/// ```
+/// Unfold model(UnfoldOptions({2, 4}).dilation(2).padding({2, 1}).stride(2));
+/// ```
 struct TORCH_API UnfoldOptions {
   UnfoldOptions(ExpandingArray<2> kernel_size)
       : kernel_size_(std::move(kernel_size)) {}

--- a/torch/csrc/api/include/torch/nn/options/instancenorm.h
+++ b/torch/csrc/api/include/torch/nn/options/instancenorm.h
@@ -30,8 +30,28 @@ struct TORCH_API InstanceNormOptions {
   TORCH_ARG(bool, track_running_stats) = false;
 };
 
+/// Options for `InstanceNorm1d` module.
+///
+/// Example:
+/// ```
+/// InstanceNorm1d model(InstanceNorm1dOptions(4).eps(0.5).momentum(0.1).affine(false).track_running_stats(true));
+/// ```
 using InstanceNorm1dOptions = InstanceNormOptions;
+
+/// Options for `InstanceNorm2d` module.
+///
+/// Example:
+/// ```
+/// InstanceNorm2d model(InstanceNorm2dOptions(4).eps(0.5).momentum(0.1).affine(false).track_running_stats(true));
+/// ```
 using InstanceNorm2dOptions = InstanceNormOptions;
+
+/// Options for `InstanceNorm3d` module.
+///
+/// Example:
+/// ```
+/// InstanceNorm3d model(InstanceNorm3dOptions(4).eps(0.5).momentum(0.1).affine(false).track_running_stats(true));
+/// ```
 using InstanceNorm3dOptions = InstanceNormOptions;
 
 namespace functional {

--- a/torch/csrc/api/include/torch/nn/options/linear.h
+++ b/torch/csrc/api/include/torch/nn/options/linear.h
@@ -8,6 +8,11 @@ namespace torch {
 namespace nn {
 
 /// Options for the `Linear` module.
+///
+/// Example:
+/// ```
+/// Linear model(LinearOptions(5, 2).bias(false));
+/// ```
 struct TORCH_API LinearOptions {
   LinearOptions(int64_t in_features, int64_t out_features);
   /// size of each input sample
@@ -23,6 +28,11 @@ struct TORCH_API LinearOptions {
 // ============================================================================
 
 /// Options for the `Flatten` module.
+///
+/// Example:
+/// ```
+/// Flatten model(FlattenOptions().start_dim(2).end_dim(4));
+/// ```
 struct TORCH_API FlattenOptions {
   /// first dim to flatten
   TORCH_ARG(int64_t, start_dim) = 1;
@@ -33,6 +43,11 @@ struct TORCH_API FlattenOptions {
 // ============================================================================
 
 /// Options for the `Bilinear` module.
+///
+/// Example:
+/// ```
+/// Bilinear model(BilinearOptions(3, 2, 4).bias(false));
+/// ```
 struct TORCH_API BilinearOptions {
   BilinearOptions(int64_t in1_features, int64_t in2_features, int64_t out_features);
   /// The number of features in input 1 (columns of the input1 matrix).

--- a/torch/csrc/api/include/torch/nn/options/loss.h
+++ b/torch/csrc/api/include/torch/nn/options/loss.h
@@ -10,6 +10,11 @@ namespace torch {
 namespace nn {
 
 /// Options for a L1 loss module.
+///
+/// Example:
+/// ```
+/// L1Loss model(L1LossOptions(torch::kNone));
+/// ```
 struct TORCH_API L1LossOptions {
   typedef c10::variant<enumtype::kNone, enumtype::kMean, enumtype::kSum> reduction_t;
 
@@ -24,6 +29,11 @@ TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(L1Loss, L1LossFuncOptions)
 // ============================================================================
 
 /// Options for a KLDiv loss module.
+///
+/// Example:
+/// ```
+/// KLDivLoss model(KLDivLossOptions(torch::kNone));
+/// ```
 struct TORCH_API KLDivLossOptions {
   typedef c10::variant<enumtype::kNone, enumtype::kBatchMean, enumtype::kSum, enumtype::kMean> reduction_t;
 
@@ -39,6 +49,11 @@ TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(KLDivLoss, KLDivFuncOptions)
 // ============================================================================
 
 /// Options for a MSE loss module.
+///
+/// Example:
+/// ```
+/// MSELoss model(MSELossOptions(torch::kNone));
+/// ```
 struct TORCH_API MSELossOptions {
   typedef c10::variant<enumtype::kNone, enumtype::kMean, enumtype::kSum> reduction_t;
 
@@ -54,6 +69,11 @@ TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(MSELoss, MSELossFuncOptions)
 // ============================================================================
 
 /// Options for a BCE loss module.
+///
+/// Example:
+/// ```
+/// BCELoss model(BCELossOptions().reduction(torch::kNone).weight(weight));
+/// ```
 struct TORCH_API BCELossOptions {
   typedef c10::variant<enumtype::kNone, enumtype::kMean, enumtype::kSum> reduction_t;
 
@@ -69,6 +89,11 @@ TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(BCELoss, BinaryCrossEntropyFuncOptions)
 // ============================================================================
 
 /// Options for a Hinge Embedding loss functional and module.
+///
+/// Example:
+/// ```
+/// HingeEmbeddingLoss model(HingeEmbeddingLossOptions().margin(4).reduction(torch::kNone));
+/// ```
 struct TORCH_API HingeEmbeddingLossOptions {
   typedef c10::variant<enumtype::kNone, enumtype::kMean, enumtype::kSum> reduction_t;
 
@@ -84,6 +109,11 @@ TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(HingeEmbeddingLoss, HingeEmbeddingLossFun
 // ============================================================================
 
 /// Options for a multi-margin loss functional and module.
+///
+/// Example:
+/// ```
+/// MultiMarginLoss model(MultiMarginLossOptions().margin(2).weight(weight));
+/// ```
 struct TORCH_API MultiMarginLossOptions {
   typedef c10::variant<enumtype::kNone, enumtype::kMean, enumtype::kSum> reduction_t;
 
@@ -107,7 +137,12 @@ TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(MultiMarginLoss, MultiMarginLossFuncOptio
 
 // ============================================================================
 
-/// Options for a Hinge Embedding loss functional and module.
+/// Options for a Cosine Embedding loss functional and module.
+///
+/// Example:
+/// ```
+/// CosineEmbeddingLoss model(CosineEmbeddingLossOptions().margin(0.5));
+/// ```
 struct TORCH_API CosineEmbeddingLossOptions {
   typedef c10::variant<enumtype::kNone, enumtype::kMean, enumtype::kSum> reduction_t;
 
@@ -124,6 +159,11 @@ TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(CosineEmbeddingLoss, CosineEmbeddingLossF
 // ============================================================================
 
 /// Options for a multi-label margin loss functional and module.
+///
+/// Example:
+/// ```
+/// MultiLabelMarginLoss model(MultiLabelMarginLossOptions(torch::kNone));
+/// ```
 struct TORCH_API MultiLabelMarginLossOptions {
   typedef c10::variant<enumtype::kNone, enumtype::kMean, enumtype::kSum> reduction_t;
 
@@ -141,6 +181,11 @@ TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(MultiLabelMarginLoss, MultiLabelMarginLos
 // ============================================================================
 
 /// Options for a soft margin loss functional and module.
+///
+/// Example:
+/// ```
+/// SoftMarginLoss model(SoftMarginLossOptions(torch::kNone));
+/// ```
 struct TORCH_API SoftMarginLossOptions {
   typedef c10::variant<enumtype::kNone, enumtype::kMean, enumtype::kSum> reduction_t;
 
@@ -158,6 +203,11 @@ TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(SoftMarginLoss, SoftMarginLossFuncOptions
 // ============================================================================
 
 /// Options for a multi-label soft margin loss functional and module.
+///
+/// Example:
+/// ```
+/// MultiLabelSoftMarginLoss model(MultiLabelSoftMarginLossOptions().reduction(torch::kNone).weight(weight));
+/// ```
 struct TORCH_API MultiLabelSoftMarginLossOptions {
   typedef c10::variant<enumtype::kNone, enumtype::kMean, enumtype::kSum> reduction_t;
 
@@ -178,6 +228,11 @@ TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(MultiLabelSoftMarginLoss, MultiLabelSoftM
 // ============================================================================
 
 /// Options for a triplet-margin-Loss functional and module.
+///
+/// Example:
+/// ```
+/// TripletMarginLoss model(TripletMarginLossOptions().margin(3).p(2).eps(1e-06).swap(false));
+/// ```
 struct TORCH_API TripletMarginLossOptions {
   typedef c10::variant<enumtype::kNone, enumtype::kMean, enumtype::kSum> reduction_t;
 
@@ -200,6 +255,11 @@ TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(TripletMarginLoss, TripletMarginLossFuncO
 // ============================================================================
 
 /// Options for The Connectionist Temporal Classification loss functional and module.
+///
+/// Example:
+/// ```
+/// CTCLoss model(CTCLossOptions().blank(42).zero_infinity(false).reduction(torch::kSum));
+/// ```
 struct TORCH_API CTCLossOptions {
   typedef c10::variant<enumtype::kNone, enumtype::kMean, enumtype::kSum> reduction_t;
 
@@ -218,6 +278,11 @@ TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(CTCLoss, CTCLossFuncOptions)
 // ============================================================================
 
 /// Options for a smooth L1 loss functional and module.
+///
+/// Example:
+/// ```
+/// SmoothL1Loss model(SmoothL1LossOptions(torch::kNone));
+/// ```
 struct TORCH_API SmoothL1LossOptions {
   typedef c10::variant<enumtype::kNone, enumtype::kMean, enumtype::kSum> reduction_t;
 
@@ -235,6 +300,11 @@ TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(SmoothL1Loss, SmoothL1LossFuncOptions)
 // ============================================================================
 
 /// Options for PoissonNLLLoss functional and module.
+///
+/// Example:
+/// ```
+/// PoissonNLLLoss model(PoissonNLLLossOptions().log_input(false).full(true).eps(0.42).reduction(torch::kSum));
+/// ```
 struct TORCH_API PoissonNLLLossOptions {
   typedef c10::variant<enumtype::kNone, enumtype::kMean, enumtype::kSum> reduction_t;
 
@@ -256,6 +326,11 @@ TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(PoissonNLLLoss, PoissonNLLLossFuncOptions
 // ============================================================================
 
 /// Options for MarginRankingLoss functional and module.
+///
+/// Example:
+/// ```
+/// MarginRankingLoss model(MarginRankingLossOptions().margin(0.5).reduction(torch::kSum));
+/// ```
 struct TORCH_API MarginRankingLossOptions {
   typedef c10::variant<enumtype::kNone, enumtype::kMean, enumtype::kSum> reduction_t;
 
@@ -270,6 +345,11 @@ TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(MarginRankingLoss, MarginRankingLossFuncO
 // ============================================================================
 
 /// Options for an nll-loss functional and module.
+///
+/// Example:
+/// ```
+/// NLLLoss model(NLLLossOptions().ignore_index(-100).reduction(torch::kMean));
+/// ```
 struct TORCH_API NLLLossOptions {
   typedef c10::variant<enumtype::kNone, enumtype::kMean, enumtype::kSum> reduction_t;
 
@@ -289,6 +369,11 @@ TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(NLLLoss, NLLLossFuncOptions)
 // ============================================================================
 
 /// Options for a cross-entropy-Loss functional and module.
+///
+/// Example:
+/// ```
+/// CrossEntropyLoss model(CrossEntropyLossOptions().ignore_index(-100).reduction(torch::kMean));
+/// ```
 struct TORCH_API CrossEntropyLossOptions {
   typedef c10::variant<enumtype::kNone, enumtype::kMean, enumtype::kSum> reduction_t;
 
@@ -307,6 +392,11 @@ TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(CrossEntropyLoss, CrossEntropyFuncOptions
 // ============================================================================
 
 /// Options for BCEWithLogitsLoss functional and module.
+///
+/// Example:
+/// ```
+/// BCEWithLogitsLoss model(BCEWithLogitsLossOptions().reduction(torch::kNone).weight(weight));
+/// ```
 struct TORCH_API BCEWithLogitsLossOptions {
   typedef c10::variant<enumtype::kNone, enumtype::kMean, enumtype::kSum> reduction_t;
   /// A manual rescaling weight given to the loss of each batch element.

--- a/torch/csrc/api/include/torch/nn/options/normalization.h
+++ b/torch/csrc/api/include/torch/nn/options/normalization.h
@@ -10,6 +10,11 @@ namespace torch {
 namespace nn {
 
 /// Options for the `LayerNorm` module.
+///
+/// Example:
+/// ```
+/// LayerNorm model(LayerNormOptions({2, 2}).elementwise_affine(false).eps(2e-5));
+/// ```
 struct TORCH_API LayerNormOptions {
   /* implicit */ LayerNormOptions(std::vector<int64_t> normalized_shape);
   /// input shape from an expected input.
@@ -26,7 +31,7 @@ struct TORCH_API LayerNormOptions {
 
 namespace functional {
 
-/// Options for the `LayerNorm` module.
+/// Options for the `LayerNorm` functional.
 struct TORCH_API LayerNormFuncOptions {
   /* implicit */ LayerNormFuncOptions(std::vector<int64_t> normalized_shape);
   /// input shape from an expected input.
@@ -45,6 +50,11 @@ struct TORCH_API LayerNormFuncOptions {
 // ============================================================================
 
 /// Options for LocalResponseNorm functional and module.
+///
+/// Example:
+/// ```
+/// LocalResponseNorm model(LocalResponseNormOptions(2).alpha(0.0002).beta(0.85).k(2.));
+/// ```
 struct TORCH_API LocalResponseNormOptions {
   /* implicit */ LocalResponseNormOptions(int64_t size) : size_(size) {}
   /// amount of neighbouring channels used for normalization
@@ -65,6 +75,11 @@ TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(LocalResponseNorm, LocalResponseNormFuncO
 // ============================================================================
 
 /// Options for the CrossMapLRN2d module.
+///
+/// Example:
+/// ```
+/// CrossMapLRN2d model(CrossMapLRN2dOptions(3).alpha(1e-5).beta(0.1).k(10));
+/// ```
 struct TORCH_API CrossMapLRN2dOptions {
   CrossMapLRN2dOptions(int64_t size);
 
@@ -100,6 +115,11 @@ struct TORCH_API NormalizeFuncOptions {
 // ============================================================================
 
 /// Options for the `GroupNorm` module.
+///
+/// Example:
+/// ```
+/// GroupNorm model(GroupNormOptions(2, 2).eps(2e-5).affine(false));
+/// ```
 struct TORCH_API GroupNormOptions {
   /* implicit */ GroupNormOptions(int64_t num_groups, int64_t num_channels);
 

--- a/torch/csrc/api/include/torch/nn/options/padding.h
+++ b/torch/csrc/api/include/torch/nn/options/padding.h
@@ -23,9 +23,19 @@ struct TORCH_API ReflectionPadOptions {
 };
 
 /// `ReflectionPadOptions` specialized for 1-D ReflectionPad.
+///
+/// Example:
+/// ```
+/// ReflectionPad1d model(ReflectionPad1dOptions({3, 1}));
+/// ```
 using ReflectionPad1dOptions = ReflectionPadOptions<1>;
 
 /// `ReflectionPadOptions` specialized for 2-D ReflectionPad.
+///
+/// Example:
+/// ```
+/// ReflectionPad2d model(ReflectionPad2dOptions({1, 1, 2, 0}));
+/// ```
 using ReflectionPad2dOptions = ReflectionPadOptions<2>;
 
 // ============================================================================
@@ -45,17 +55,37 @@ struct TORCH_API ReplicationPadOptions {
 };
 
 /// `ReplicationPadOptions` specialized for 1-D ReplicationPad.
+///
+/// Example:
+/// ```
+/// ReplicationPad1d model(ReplicationPad1dOptions({3, 1}));
+/// ```
 using ReplicationPad1dOptions = ReplicationPadOptions<1>;
 
 /// `ReplicationPadOptions` specialized for 2-D ReplicationPad.
+///
+/// Example:
+/// ```
+/// ReplicationPad2d model(ReplicationPad2dOptions({1, 1, 2, 0}));
+/// ```
 using ReplicationPad2dOptions = ReplicationPadOptions<2>;
 
 /// `ReplicationPadOptions` specialized for 3-D ReplicationPad.
+///
+/// Example:
+/// ```
+/// ReplicationPad3d model(ReplicationPad3dOptions({1, 2, 1, 2, 1, 2}));
+/// ```
 using ReplicationPad3dOptions = ReplicationPadOptions<3>;
 
 // ============================================================================
 
 /// Options for a ZeroPad2d module.
+///
+/// Example:
+/// ```
+/// ZeroPad2d model(ZeroPad2dOptions({1, 1, 2, 0}));
+/// ```
 struct TORCH_API ZeroPad2dOptions {
   ZeroPad2dOptions(ExpandingArray<4> padding) : padding_(padding) {}
 
@@ -85,12 +115,27 @@ struct TORCH_API ConstantPadOptions {
 };
 
 /// `ConstantPadOptions` specialized for 1-D ConstantPad.
+///
+/// Example:
+/// ```
+/// ConstantPad1d model(ConstantPad1dOptions({3, 1}, 3.5));
+/// ```
 using ConstantPad1dOptions = ConstantPadOptions<1>;
 
 /// `ConstantPadOptions` specialized for 2-D ConstantPad.
+///
+/// Example:
+/// ```
+/// ConstantPad2d model(ConstantPad2dOptions({3, 0, 2, 1}, 3.5));
+/// ```
 using ConstantPad2dOptions = ConstantPadOptions<2>;
 
 /// `ConstantPadOptions` specialized for 3-D ConstantPad.
+///
+/// Example:
+/// ```
+/// ConstantPad3d model(ConstantPad3dOptions({1, 2, 1, 2, 1, 2}, 3.5));
+/// ```
 using ConstantPad3dOptions = ConstantPadOptions<3>;
 
 // ============================================================================

--- a/torch/csrc/api/include/torch/nn/options/pixelshuffle.h
+++ b/torch/csrc/api/include/torch/nn/options/pixelshuffle.h
@@ -9,6 +9,11 @@ namespace torch {
 namespace nn {
 
 /// Options for the PixelShuffle module.
+///
+/// Example:
+/// ```
+/// PixelShuffle model(PixelShuffleOptions(5));
+/// ```
 struct TORCH_API PixelShuffleOptions {
   PixelShuffleOptions(int64_t upscale_factor)
       : upscale_factor_(upscale_factor) {}

--- a/torch/csrc/api/include/torch/nn/options/pooling.h
+++ b/torch/csrc/api/include/torch/nn/options/pooling.h
@@ -35,12 +35,27 @@ struct AvgPoolOptions {
 };
 
 /// `AvgPoolOptions` specialized for 1-D avgpool.
+///
+/// Example:
+/// ```
+/// AvgPool1d model(AvgPool1dOptions(3).stride(2));
+/// ```
 using AvgPool1dOptions = AvgPoolOptions<1>;
 
 /// `AvgPoolOptions` specialized for 2-D avgpool.
+///
+/// Example:
+/// ```
+/// AvgPool2d model(AvgPool2dOptions({3, 2}).stride({2, 2}));
+/// ```
 using AvgPool2dOptions = AvgPoolOptions<2>;
 
 /// `AvgPoolOptions` specialized for 3-D avgpool.
+///
+/// Example:
+/// ```
+/// AvgPool3d model(AvgPool3dOptions(5).stride(2));
+/// ```
 using AvgPool3dOptions = AvgPoolOptions<3>;
 
 TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(AvgPool1d, AvgPool1dFuncOptions)
@@ -72,12 +87,27 @@ struct MaxPoolOptions {
 };
 
 /// `MaxPoolOptions` specialized for 1-D maxpool.
+///
+/// Example:
+/// ```
+/// MaxPool1d model(MaxPool1dOptions(3).stride(2));
+/// ```
 using MaxPool1dOptions = MaxPoolOptions<1>;
 
 /// `MaxPoolOptions` specialized for 2-D maxpool.
+///
+/// Example:
+/// ```
+/// MaxPool2d model(MaxPool2dOptions({3, 2}).stride({2, 2}));
+/// ```
 using MaxPool2dOptions = MaxPoolOptions<2>;
 
 /// `MaxPoolOptions` specialized for 3-D maxpool.
+///
+/// Example:
+/// ```
+/// MaxPool3d model(MaxPool3dOptions(3).stride(2));
+/// ```
 using MaxPool3dOptions = MaxPoolOptions<3>;
 
 TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(MaxPool1d, MaxPool1dFuncOptions)
@@ -97,12 +127,27 @@ struct AdaptiveMaxPoolOptions {
 };
 
 /// `AdaptiveMaxPoolOptions` specialized for 1-D maxpool.
+///
+/// Example:
+/// ```
+/// AdaptiveMaxPool1d model(AdaptiveMaxPool1dOptions(3));
+/// ```
 using AdaptiveMaxPool1dOptions = AdaptiveMaxPoolOptions<1>;
 
 /// `AdaptiveMaxPoolOptions` specialized for 2-D adaptive maxpool.
+///
+/// Example:
+/// ```
+/// AdaptiveMaxPool2d model(AdaptiveMaxPool2dOptions({3, 2}));
+/// ```
 using AdaptiveMaxPool2dOptions = AdaptiveMaxPoolOptions<2>;
 
 /// `AdaptiveMaxPoolOptions` specialized for 3-D adaptive maxpool.
+///
+/// Example:
+/// ```
+/// AdaptiveMaxPool3d model(AdaptiveMaxPool3dOptions(3));
+/// ```
 using AdaptiveMaxPool3dOptions = AdaptiveMaxPoolOptions<3>;
 
 TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(AdaptiveMaxPool1d, AdaptiveMaxPool1dFuncOptions)
@@ -122,12 +167,27 @@ struct AdaptiveAvgPoolOptions {
 };
 
 /// `AdaptiveAvgPoolOptions` specialized for 1-D adaptive avgpool.
+///
+/// Example:
+/// ```
+/// AdaptiveAvgPool1d model(AdaptiveAvgPool1dOptions(5));
+/// ```
 using AdaptiveAvgPool1dOptions = AdaptiveAvgPoolOptions<1>;
 
 /// `AdaptiveAvgPoolOptions` specialized for 2-D adaptive avgpool.
+///
+/// Example:
+/// ```
+/// AdaptiveAvgPool2d model(AdaptiveAvgPool2dOptions({3, 2}));
+/// ```
 using AdaptiveAvgPool2dOptions = AdaptiveAvgPoolOptions<2>;
 
 /// `AdaptiveAvgPoolOptions` specialized for 3-D adaptive avgpool.
+///
+/// Example:
+/// ```
+/// AdaptiveAvgPool3d model(AdaptiveAvgPool3dOptions(3));
+/// ```
 using AdaptiveAvgPool3dOptions = AdaptiveAvgPoolOptions<3>;
 
 TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(AdaptiveAvgPool1d, AdaptiveAvgPool1dFuncOptions)
@@ -153,12 +213,27 @@ struct MaxUnpoolOptions {
 };
 
 /// `MaxUnpoolOptions` specialized for 1-D maxunpool.
+///
+/// Example:
+/// ```
+/// MaxUnpool1d model(MaxUnpool1dOptions(3).stride(2).padding(1));
+/// ```
 using MaxUnpool1dOptions = MaxUnpoolOptions<1>;
 
 /// `MaxUnpoolOptions` specialized for 2-D maxunpool.
+///
+/// Example:
+/// ```
+/// MaxUnpool2d model(MaxUnpool2dOptions(3).stride(2).padding(1));
+/// ```
 using MaxUnpool2dOptions = MaxUnpoolOptions<2>;
 
 /// `MaxUnpoolOptions` specialized for 3-D maxunpool.
+///
+/// Example:
+/// ```
+/// MaxUnpool3d model(MaxUnpool3dOptions(3).stride(2).padding(1));
+/// ```
 using MaxUnpool3dOptions = MaxUnpoolOptions<3>;
 
 // ============================================================================
@@ -218,9 +293,19 @@ struct FractionalMaxPoolOptions {
 };
 
 /// `FractionalMaxPoolOptions` specialized for 2-D maxpool.
+///
+/// Example:
+/// ```
+/// FractionalMaxPool2d model(FractionalMaxPool2dOptions(5).output_size(1));
+/// ```
 using FractionalMaxPool2dOptions = FractionalMaxPoolOptions<2>;
 
 /// `FractionalMaxPoolOptions` specialized for 3-D maxpool.
+///
+/// Example:
+/// ```
+/// FractionalMaxPool3d model(FractionalMaxPool3dOptions(5).output_size(1));
+/// ```
 using FractionalMaxPool3dOptions = FractionalMaxPoolOptions<3>;
 
 TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(FractionalMaxPool2d, FractionalMaxPool2dFuncOptions)
@@ -247,9 +332,19 @@ struct LPPoolOptions {
 };
 
 /// `LPPoolOptions` specialized for 1-D lppool.
+///
+/// Example:
+/// ```
+/// LPPool1d model(LPPool1dOptions(1, 2).stride(5).ceil_mode(true));
+/// ```
 using LPPool1dOptions = LPPoolOptions<1>;
 
 /// `LPPoolOptions` specialized for 2-D lppool.
+///
+/// Example:
+/// ```
+/// LPPool2d model(LPPool2dOptions(1, std::vector<int64_t>({3, 4})).stride({5, 6}).ceil_mode(true));
+/// ```
 using LPPool2dOptions = LPPoolOptions<2>;
 
 TORCH_NN_FUNCTIONAL_USE_MODULE_OPTIONS(LPPool1d, LPPool1dFuncOptions)

--- a/torch/csrc/api/include/torch/nn/options/upsampling.h
+++ b/torch/csrc/api/include/torch/nn/options/upsampling.h
@@ -13,6 +13,11 @@ namespace torch {
 namespace nn {
 
 /// Options for a `D`-dimensional Upsample module.
+///
+/// Example:
+/// ```
+/// Upsample model(UpsampleOptions().scale_factor({3}).mode(torch::kLinear).align_corners(false));
+/// ```
 struct TORCH_API UpsampleOptions {
   /// output spatial sizes.
   TORCH_ARG(std::vector<int64_t>, size) = {};


### PR DESCRIPTION
This PR updates C++ API torch::nn layer docs:

* torch::nn layer doc must provide example for how to use the corresponding layer options
* torch::nn layer doc must link to the corresponding layer options doc