### PR TITLE
`Engine::~Engine()` should wait for non-reentrant threads to shutdown

### DIFF
--- a/torch/csrc/autograd/engine.h
+++ b/torch/csrc/autograd/engine.h
@@ -209,6 +209,9 @@ struct TORCH_API Engine {
 
   size_t ready_queue_size(at::Device device);
 
+  // Should be called after fork to notify that worker threads are gone
+  void release_workers();
+
  protected:
   Engine();
   void compute_dependencies(Node* root, GraphTask& task);
@@ -266,6 +269,12 @@ struct TORCH_API Engine {
  std::shared_ptr<ThreadPoolShared> thread_pool_shared_;
 
 private:
+  // Number of non-reentrant threads
+  std::atomic<uint32_t> non_reentrant_thread_count_;
+  // Destructor will wait for non-reentrant threads to finish
+  std::condition_variable non_reentrant_thread_finish_;
+  std::mutex non_reentrant_thread_finish_mutex_;
+
  void graph_task_exec_post_processing(
      const std::shared_ptr<GraphTask>& graph_task);
  void mark_graph_task_completed(std::shared_ptr<GraphTask>& graph_task);

--- a/torch/csrc/autograd/python_engine.cpp
+++ b/torch/csrc/autograd/python_engine.cpp
@@ -38,6 +38,7 @@ Engine& PythonEngine::get_python_engine() {
   // backwards threads hold a lock, we'll probably deadlock in the engine
   // destructor.
   if (_reinitialize_engine) {
+    engine.release_workers();
     engine.~PythonEngine();
     new (&engine) torch::autograd::python::PythonEngine();
     _reinitialize_engine = false;


### PR DESCRIPTION
Because `this` must be valid while `Engine::main_thread` is running, at least for non-reentrant worker threads

Test Plan: Run `test_api --gtest-filter=ModulesTest.InstanceNorm1d` in a loop

