### PR TITLE
Turn on exact_dtype by default on test_sparse.py (#34489)

### DIFF
--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -47,6 +47,7 @@ class TestSparse(TestCase):
         self.is_cuda = False
         self.is_uncoalesced = False
         self.device = 'cpu'
+        self.exact_dtype = True
         self.value_dtype = torch.float64
         self.index_tensor = lambda *args: torch.tensor(*args, dtype=torch.int64, device=self.device)
         self.value_empty = lambda *args: torch.empty(*args, dtype=self.value_dtype, device=self.device)
@@ -227,8 +228,11 @@ class TestSparse(TestCase):
             x.to_dense()  # Tests triple to_dense for memory corruption
             x.to_dense()
             x.to_dense()
-            self.assertEqual(res, x.to_dense())
-            self.assertEqual(res, self.safeToDense(x))
+            # We dont have to_dense for half types, so we don't request 
+            # exact_dtype when testing. We allow to_dense to convert dtype
+            # to torch.float64
+            self.assertEqual(res, x.to_dense(), exact_dtype=False)
+            self.assertEqual(res, self.safeToDense(x), exact_dtype=False)
 
             def fn(x):
                 return x.to_dense()
@@ -243,6 +247,7 @@ class TestSparse(TestCase):
         # we don't have to_dense for half types on CPU because it is implemented
         # with a slower add_ operation
         for dtype in [torch.float16, torch.float64] if self.device != 'cpu' else [torch.float64]:
+
             v = self.value_tensor([2, 1, 3, 4]).to(dtype=dtype)
             x = self.sparse_tensor(i, v, torch.Size([3, 4, 5]))
             res = self.value_tensor([
@@ -1135,7 +1140,7 @@ class TestSparse(TestCase):
         # sum an empty tensor
         empty_S = torch.sparse_coo_tensor(size=with_size)
         self.assertRaises(RuntimeError, lambda: torch.sparse.sum(empty_S, [0]))
-        self.assertEqual(torch.sparse.sum(empty_S), torch.tensor(0,))
+        self.assertEqual(torch.sparse.sum(empty_S), torch.tensor(0, dtype=torch.float64))
         empty_S.requires_grad_(True)
         empty_S_sum = torch.sparse.sum(empty_S)
         empty_S_sum.backward()
@@ -1468,7 +1473,7 @@ class TestSparse(TestCase):
             torch.FloatTensor([3, 4, 5]),
             torch.Size([3]),
             device=self.device)
-        self._test_log1p_tensor(input, torch.as_tensor([3., 4., 5.]))
+        self._test_log1p_tensor(input, torch.as_tensor([3, 4, 5], dtype=torch.float32))
 
         # test uncoalesced input
         input_uncoalesced = torch.sparse_coo_tensor(
@@ -1476,7 +1481,7 @@ class TestSparse(TestCase):
             torch.FloatTensor([2, 3, 4, 1, 1, 1]),
             torch.Size([3]),
             device=self.device)
-        self._test_log1p_tensor(input_uncoalesced, torch.as_tensor([3., 4., 5.]))
+        self._test_log1p_tensor(input_uncoalesced, torch.as_tensor([3, 4, 5], dtype=torch.float32))
 
         input = torch.sparse_coo_tensor(
             torch.zeros([2, 0]),
@@ -1713,8 +1718,8 @@ class TestSparse(TestCase):
                 t = torch.sparse_coo_tensor(torch.empty(i_shape), torch.empty(v_shape), torch.Size(size), device=device)
             else:
                 t = torch.sparse_coo_tensor(torch.empty(i_shape), torch.empty(v_shape), device=device)
-            expected_indices = torch.empty(i_shape, device=device)
-            expected_values = torch.empty(v_shape, device=device)
+            expected_indices = torch.empty(i_shape, device=device, dtype=torch.int64)
+            expected_values = torch.empty(v_shape, device=device, dtype=torch.float64)
             expected_size = torch.Size(expected_size)
             self.assertEqual(t._indices(), expected_indices)
             self.assertEqual(t._values(), expected_values)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#34542 Turn on exact_dtype by default on test_sparse.py (#34489)**

Turn on exact_dtype by default on test_sparse.py (#34489)

Summary:
Pull Request resolved: #34489

Test Plan:

```
python test/test_sparse.py
```

Reviewers:

Subscribers:

Tasks:
https://github.com/pytorch/pytorch/issues/34489

Tags:

Differential Revision: [D20369764](https://our.internmc.facebook.com/intern/diff/D20369764)