### PR TITLE
[JIT] Add support for tolist for GPU-resident Tensors

### DIFF
--- a/test/jit/test_list_dict.py
+++ b/test/jit/test_list_dict.py
@@ -1067,6 +1067,34 @@ class TestList(JitTestCase):
             )
 
 
+    def test_to_list_gpu(self):
+        """GPU tests for Tensor.tolist() function."""
+        if not torch.cuda.is_available() or torch.cuda.device_count() == 0:
+            self.skipTest("CUDA is not available")
+
+        def to_list_bool_1D(x):
+            # type: (torch.Tensor) -> List[bool]
+            li = torch.jit.annotate(List[bool], x.tolist())
+            return li
+
+        def to_list_int_1D(x):
+            # type: (torch.Tensor) -> List[int]
+            li = torch.jit.annotate(List[int], x.tolist())
+            return li
+
+        def to_list_float_1D(x):
+            # type: (torch.Tensor) -> List[float]
+            li = torch.jit.annotate(List[float], x.tolist())
+            return li
+
+        self.checkScript(to_list_bool_1D, (torch.tensor(
+            [True, False, True, False], dtype=torch.bool).cuda(),))
+        self.checkScript(to_list_int_1D, (torch.tensor(
+            [1, 2, 3, 4], dtype=torch.long).cuda(),))
+        self.checkScript(to_list_float_1D, (torch.randn(
+            5, dtype=torch.double).cuda(),))
+
+
 class TestDict(JitTestCase):
     def dict(self):
         return {u'a': torch.ones(1), u'b': torch.ones(1) + 1, u'c': torch.ones(1) + 2}

--- a/torch/csrc/jit/runtime/register_prim_ops.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops.cpp
@@ -1073,6 +1073,11 @@ RegisterOperators reg(
              pop(stack, dim_val);
              pop(stack, t);
 
+             // If the Tensor is not on the CPU, transfer it.
+             if (!t.device().is_cpu()) {
+               t = t.cpu();
+             }
+
              // Rebuild the output type using elem_ty_val and dim_val. Start
              // with the element type corresponding to elem_ty_val.
              TypePtr out_ty;


### PR DESCRIPTION
**Summary**
This commit modifies the JIT implementation of `Tensor.tolist` so that it
can be called on GPU-resident Tensors as well. If the Tensors is not on the
CPU when the operator is invoked, it is copied to the CPU before doing any
of the rest of the work to convert it into a list.

**Testing**
This commit adds GPU versions of some of the existing CPU tests for this
feature.

