### PR TITLE
[pytorch] remove boilerplate setQEngine() from PyTorch mobile predictors

### DIFF
--- a/android/pytorch_android/src/main/cpp/pytorch_jni_jit.cpp
+++ b/android/pytorch_android/src/main/cpp/pytorch_jni_jit.cpp
@@ -104,11 +104,6 @@ class PytorchJni : public facebook::jni::HybridClass<PytorchJni> {
     }();
     ((void)once);
 
-    auto qengines = at::globalContext().supportedQEngines();
-    if (std::find(qengines.begin(), qengines.end(), at::QEngine::QNNPACK) !=
-        qengines.end()) {
-      at::globalContext().setQEngine(at::QEngine::QNNPACK);
-    }
 #ifdef TRACE_ENABLED
     torch::autograd::profiler::pushCallback(
         &onFunctionEnter,

--- a/android/pytorch_android/src/main/cpp/pytorch_jni_lite.cpp
+++ b/android/pytorch_android/src/main/cpp/pytorch_jni_lite.cpp
@@ -31,11 +31,6 @@ class PytorchJni : public facebook::jni::HybridClass<PytorchJni> {
   }
 
   PytorchJni(facebook::jni::alias_ref<jstring> modelPath) {
-    auto qengines = at::globalContext().supportedQEngines();
-    if (std::find(qengines.begin(), qengines.end(), at::QEngine::QNNPACK) !=
-        qengines.end()) {
-      at::globalContext().setQEngine(at::QEngine::QNNPACK);
-    }
     module_ = torch::jit::_load_for_mobile(std::move(modelPath->toStdString()));
   }
 

--- a/binaries/speed_benchmark_torch.cc
+++ b/binaries/speed_benchmark_torch.cc
@@ -134,10 +134,6 @@ int main(int argc, char** argv) {
     inputs[0].push_back(stensor);
   }
 
-  auto qengines = at::globalContext().supportedQEngines();
-  if (std::find(qengines.begin(), qengines.end(), at::QEngine::QNNPACK) != qengines.end()) {
-    at::globalContext().setQEngine(at::QEngine::QNNPACK);
-  }
   torch::autograd::AutoGradMode guard(false);
   torch::jit::GraphOptimizerEnabledGuard no_optimizer_guard(false);
   auto module = torch::jit::load(FLAGS_model);

--- a/ios/TestApp/TestApp/Benchmark.mm
+++ b/ios/TestApp/TestApp/Benchmark.mm
@@ -65,10 +65,6 @@ static int iter = 10;
     }
   }
 
-  auto qengines = at::globalContext().supportedQEngines();
-  if (std::find(qengines.begin(), qengines.end(), at::QEngine::QNNPACK) != qengines.end()) {
-    at::globalContext().setQEngine(at::QEngine::QNNPACK);
-  }
   torch::autograd::AutoGradMode guard(false);
   torch::jit::GraphOptimizerEnabledGuard opguard(false);
   auto module = torch::jit::load(model);

--- a/ios/TestApp/TestAppTests/TestAppTests.mm
+++ b/ios/TestApp/TestAppTests/TestAppTests.mm
@@ -12,10 +12,6 @@
 
 + (void)setUp {
   [super setUp];
-  auto qengines = at::globalContext().supportedQEngines();
-  if (std::find(qengines.begin(), qengines.end(), at::QEngine::QNNPACK) != qengines.end()) {
-    at::globalContext().setQEngine(at::QEngine::QNNPACK);
-  }
 }
 
 - (void)setUp {

--- a/test/mobile/custom_build/predictor.cpp
+++ b/test/mobile/custom_build/predictor.cpp
@@ -24,10 +24,6 @@ struct MobileCallGuard {
   torch::jit::GraphOptimizerEnabledGuard no_optimizer_guard{false};
 };
 
-void init() {
-  at::globalContext().setQEngine(at::QEngine::QNNPACK);
-}
-
 torch::jit::script::Module loadModel(const std::string& path) {
   MobileCallGuard guard;
   auto module = torch::jit::load(path);
@@ -42,7 +38,6 @@ int main(int argc, const char* argv[]) {
     std::cerr << "Usage: " << argv[0] << " <model_path>\n";
     return 1;
   }
-  init();
   auto module = loadModel(argv[1]);
   auto input = torch::ones({1, 3, 224, 224});
   auto output = [&]() {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#34556 [pytorch] remove boilerplate setQEngine() from PyTorch mobile predictors**

Summary:
According to
https://github.com/pytorch/pytorch/pull/34012#discussion_r388581548,
this `at::globalContext().setQEngine(at::QEngine::QNNPACK);` call isn't
really necessary for mobile.

In Context.cpp it selects the last available QEngine if the engine isn't
set explicitly. For OSS mobile prebuild it should only include QNNPACK
engine so the default behavior should already be desired behavior.

It makes difference only when USE_FBGEMM is set - but it should be off
for both OSS mobile build and internal mobile build.

Differential Revision: [D20374522](https://our.internmc.facebook.com/intern/diff/D20374522)