### PR TITLE
AccumulateGrad: ensure sparse tensor indices and values refcount is always 1

### DIFF
--- a/torch/csrc/autograd/functions/accumulate_grad.h
+++ b/torch/csrc/autograd/functions/accumulate_grad.h
@@ -54,8 +54,10 @@ struct TORCH_API AccumulateGrad : public Node {
           !GradMode::is_enabled() && new_grad.is_sparse() &&
           new_grad._indices().is_contiguous() &&
           new_grad._values().is_contiguous() &&
-          new_grad._indices().use_count() <= num_expected_refs &&
-          new_grad._values().use_count() <= num_expected_refs &&
+          // Use count for indices and values should always be <=1 since the
+          // SparseTensor should be the only one holding a reference to these.
+          new_grad._indices().use_count() <= 1 &&
+          new_grad._values().use_count() <= 1 &&
           new_grad.use_count() <= num_expected_refs) {
         // Can't detach sparse tensor (since metadata changes are not allowed
         // after detach), so just create a new one for the grad which is a


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#34559 AccumulateGrad: ensure sparse tensor indices and values refcount is always 1**

We check the use_count for indices and values when we avoid a clone
for sparse tensors. The sparse tensor grad itself might have a higher refcount
due to DDP hooks/dist autograd structures holding refs, but the indices and
values inside the sparse tensor should always have a refcount of 1.

Differential Revision: [D20375239](https://our.internmc.facebook.com/intern/diff/D20375239/)