### PR TITLE
Support left and right shift operators in JIT

### DIFF
--- a/aten/src/ATen/core/interned_strings.h
+++ b/aten/src/ATen/core/interned_strings.h
@@ -109,6 +109,8 @@ namespace c10 {
   _(aten, __range_length)            \
   _(aten, __derive_index)            \
   _(aten, __round_to_zero_floordiv)  \
+  _(aten, leftshift)                 \
+  _(aten, rightshift)                \
   _(aten, is_scripting)              \
   _(aten, _unwrap_optional)          \
   _(prim, fork)                      \

--- a/aten/src/ATen/core/interned_strings.h
+++ b/aten/src/ATen/core/interned_strings.h
@@ -109,8 +109,6 @@ namespace c10 {
   _(aten, __range_length)            \
   _(aten, __derive_index)            \
   _(aten, __round_to_zero_floordiv)  \
-  _(aten, leftshift)                 \
-  _(aten, rightshift)                \
   _(aten, is_scripting)              \
   _(aten, _unwrap_optional)          \
   _(prim, fork)                      \

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -8288,17 +8288,10 @@ a")
                    .check("Traceback") \
                    .check("in foo").check("in baz").run(str(cm.exception))
 
-    def test_binop_unsupported_error(self):
-        with self.assertRaisesRegex(NotSupportedError, "unsupported binary operator:"):
-            @torch.jit.script
-            def binop(x, y):
-                # Replace this with another unsupported op when/if it gets supported
-                return x << y
-
     def test_bitwise_ops(self):
 
         def int_test():
-            return 2 & 3, 2 ^ 3, 2 | 3
+            return 2 & 3, 2 ^ 3, 2 | 3, 2 << 3, 2 >> 3
 
         self.checkScript(int_test, ())
 

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -8297,7 +8297,7 @@ a")
             # TODO we need to test exponent operator '**' and bitwise not
             # operator '~' once they are properly supported.
             list = [0, 1, 2, 3]
-            result = list[1:3][0] + double(4)  + (-3 + 8) * 6 // 2 % 4 << 2 + 1 >> 1 | 23 & 16 + 3 ^ 4
+            result = list[1:3][0] + double(4) + (-3 + 8) * 6 // 2 % 4 << 2 + 1 >> 1 | 23 & 16 + 3 ^ 4
             return result
 
         self.checkScript(complicated_arithmetic_operation, ())

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -8290,29 +8290,17 @@ a")
 
     def test_operator_precedence(self):
         def double(x):
+            # type: (int) -> int
             return 2 * x
 
         def complicated_arithmetic_operation():
+            # TODO we need to test exponent operator '**' and bitwise not
+            # operator '~' once they are properly supported.
             list = [0, 1, 2, 3]
-            result = list[1:3][0] + 3 ** 2 - double(4) + (-3 + 4) * 6 // 2 % 2 << 2 + 1 >> 1 & 4 ^ 2 + 1 | 13 + ~4
-            # result = list[1:3][0] + 3 ** 2 - double(4) + 1 * 6 // 2 % 2 << 2 + 1 >> 1 & 4 ^ 2 + 1 | 13 + ~4
-            # result = list[1:3][0] + 3 ** 2 - 8 + 1 * 6 // 2 % 2 << 2 + 1 >> 1 & 4 ^ 2 + 1 | 13 + ~4
-            # result = [1, 2][0] + 3 ** 2 - 8 + 1 * 6 // 2 % 2 << 2 + 1 >> 1 & 4 ^ 2 + 1 | 13 + ~4
-            # result = 1 + 3 ** 2 - 8 + 1 * 6 // 2 % 2 << 2 + 1 >> 1 & 4 ^ 2 + 1 | 13 + ~4
-            # result = 1 + 9 - 8 + 1 * 6 // 2 % 2 << 2 + 1 >> 1 & 4 ^ 2 + 1 | 13 + ~4
-            # result = 1 + 9 - 8 + 1 * 6 // 2 % 2 << 2 + 1 >> 1 & 4 ^ 2 + 1 | 13 + -5
-            # result = 1 + 9 - 8 + 6 // 2 % 2 << 2 + 1 >> 1 & 4 ^ 2 + 1 | 13 + -5
-            # result = 1 + 9 - 8 + 3 % 2 << 2 + 1 >> 1 & 4 ^ 2 + 1 | 13 + -5
-            # result = 1 + 9 - 8 + 1 << 2 + 1 >> 1 & 4 ^ 2 + 1 | 13 + -5
-            # result = 3 << 3 >> 1 & 4 ^ 3 | 8
-            # result = 24 >> 1 & 4 ^ 3 | 8
-            # result = 12 & 4 ^ 3 | 8
-            # result = 4 ^ 3 | 8
-            # result = 7 | 8
-            # result = 15
+            result = list[1:3][0] + double(4)  + (-3 + 8) * 6 // 2 % 4 << 2 + 1 >> 1 | 23 & 16 + 3 ^ 4
             return result
 
-        self.assertEqual(complicated_arithmetic_operation(), 15)
+        self.checkScript(complicated_arithmetic_operation, ())
 
     def test_bitwise_ops(self):
 

--- a/torch/csrc/jit/frontend/ir_emitter.cpp
+++ b/torch/csrc/jit/frontend/ir_emitter.cpp
@@ -2279,6 +2279,10 @@ struct to_ir {
         return aten::__not__;
       case TK_FLOOR_DIV:
         return aten::floordiv;
+      case TK_LSHIFT:
+        return aten::leftshift;
+      case TK_RSHIFT:
+        return aten::rightshift;
       case '&':
         return aten::__and__;
       case '|':
@@ -2330,6 +2334,10 @@ struct to_ir {
         return "__xor__";
       case TK_IN:
         return "__contains__";
+      case TK_LSHIFT:
+        return "<<";
+      case TK_RSHIFT:
+        return ">>";
       default:
         throw std::runtime_error("unknown kind " + c10::to_string(kind));
     }
@@ -2866,7 +2874,9 @@ struct to_ir {
       case '%':
       case '&':
       case '|':
-      case '^': {
+      case '^':
+      case TK_LSHIFT:
+      case TK_RSHIFT: {
         const auto& inputs = tree->trees();
         auto kind = getNodeKind(tree->kind(), inputs.size());
         auto overload = getOperatorOverload(tree->kind(), inputs.size());

--- a/torch/csrc/jit/frontend/ir_emitter.cpp
+++ b/torch/csrc/jit/frontend/ir_emitter.cpp
@@ -2280,9 +2280,9 @@ struct to_ir {
       case TK_FLOOR_DIV:
         return aten::floordiv;
       case TK_LSHIFT:
-        return aten::leftshift;
+        return aten::__lshift__;
       case TK_RSHIFT:
-        return aten::rightshift;
+        return aten::__rshift__;
       case '&':
         return aten::__and__;
       case '|':

--- a/torch/csrc/jit/frontend/ir_emitter.cpp
+++ b/torch/csrc/jit/frontend/ir_emitter.cpp
@@ -2335,9 +2335,9 @@ struct to_ir {
       case TK_IN:
         return "__contains__";
       case TK_LSHIFT:
-        return "<<";
+        return "__lshift__";
       case TK_RSHIFT:
-        return ">>";
+        return "__rshift__";
       default:
         throw std::runtime_error("unknown kind " + c10::to_string(kind));
     }

--- a/torch/csrc/jit/frontend/lexer.cpp
+++ b/torch/csrc/jit/frontend/lexer.cpp
@@ -29,21 +29,23 @@ static const std::unordered_map<int, int> binary_prec = {
     {'|', 5},
     {'^', 6},
     {'&', 7},
-    {'+', 8},
-    {'-', 8},
-    {'*', 9},
-    {'/', 9},
-    {TK_FLOOR_DIV, 9},
-    {'%', 9},
-    {'@', 9},
-    {TK_POW, 10},
+    {TK_LSHIFT, 8},
+    {TK_RSHIFT, 8},
+    {'+', 9},
+    {'-', 9},
+    {'*', 10},
+    {'/', 10},
+    {TK_FLOOR_DIV, 10},
+    {'%', 10},
+    {'@', 10},
+    {TK_POW, 11},
 };
 
 static const std::unordered_map<int, int> unary_prec = {
     {TK_NOT, 3},
     {'~', 3},
-    {'-', 9},
-    {'*', 9},
+    {'-', 10},
+    {'*', 10},
 };
 
 bool SharedParserData::isUnary(int kind, int* prec) {

--- a/torch/csrc/jit/frontend/lexer.h
+++ b/torch/csrc/jit/frontend/lexer.h
@@ -73,6 +73,8 @@ namespace script {
   _(TK_AND, "and", "and")                        \
   _(TK_OR, "or", "or")                           \
   _(TK_NOT, "not", "not")                        \
+  _(TK_LSHIFT, "<<", "<<")                       \
+  _(TK_RSHIFT, ">>", ">>")                       \
   _(TK_CAST, "cast", "")                         \
   _(TK_PLUS_EQ, "+=", "+=")                      \
   _(TK_MINUS_EQ, "-=", "-=")                     \

--- a/torch/csrc/jit/frontend/tree_views.h
+++ b/torch/csrc/jit/frontend/tree_views.h
@@ -299,6 +299,8 @@ struct Expr : public TreeView {
       case TK_DICT_LITERAL:
       case '@':
       case TK_POW:
+      case TK_LSHIFT:
+      case TK_RSHIFT:
       case TK_FLOOR_DIV:
       case '&':
       case '^':
@@ -740,6 +742,8 @@ struct BinOp : public Expr {
       case '-':
       case '@':
       case TK_POW:
+      case TK_LSHIFT:
+      case TK_RSHIFT:
       case '%':
       case '&':
       case '^':

--- a/torch/csrc/jit/runtime/register_prim_ops.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops.cpp
@@ -2749,6 +2749,8 @@ RegisterOperators reg2({
     DEFINE_INT_OP(aten::__and__, a& b),
     DEFINE_INT_OP(aten::__or__, a | b),
     DEFINE_INT_OP(aten::__xor__, a ^ b),
+    DEFINE_INT_OP(aten::leftshift, a << b),
+    DEFINE_INT_OP(aten::rightshift, a >> b),
 
     DEFINE_UNARY_OP(aten::floor, floor(a), int, int),
     DEFINE_UNARY_OP(aten::ceil, ceil(a), int, int),

--- a/torch/csrc/jit/runtime/register_prim_ops.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops.cpp
@@ -2749,8 +2749,8 @@ RegisterOperators reg2({
     DEFINE_INT_OP(aten::__and__, a& b),
     DEFINE_INT_OP(aten::__or__, a | b),
     DEFINE_INT_OP(aten::__xor__, a ^ b),
-    DEFINE_INT_OP(aten::leftshift, a << b),
-    DEFINE_INT_OP(aten::rightshift, a >> b),
+    DEFINE_INT_OP(aten::__lshift__, a << b),
+    DEFINE_INT_OP(aten::__rshift__, a >> b),
 
     DEFINE_UNARY_OP(aten::floor, floor(a), int, int),
     DEFINE_UNARY_OP(aten::ceil, ceil(a), int, int),

--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -398,6 +398,8 @@ class ExprBuilder(Builder):
         ast.BitAnd: '&',
         ast.BitXor: '^',
         ast.BitOr: '|',
+        ast.LShift: '<<',
+        ast.RShift: '>>',
     }
 
     if not PY2:


### PR DESCRIPTION
With this PR, we can now support left and right shift operators in the JIT engine for <int, int> and <Tensor, int>.

Updated tests pass as expected:
```
> python test/test_jit.py
...
Ran 2427 tests in 84.861s

OK (skipped=139, expected failures=1)
```

Running the following code with Python results in the output below:
```
> cat ~/expressions.py
import torch

@torch.jit.script
def fn(a, b):
    # type: (int, int)
    return (
        a << b,  # supported
        b >> a,  # supported
        a & b,
        a | b,
        a ^ b
    )
print(fn.graph)
```

```
> python ~/expressions.py
graph(%a.1 : int,
      %b.1 : int):
  %4 : int = aten::leftshift(%a.1, %b.1) # /home/ince/expressions.py:7:8
  %7 : int = aten::rightshift(%b.1, %a.1) # /home/ince/expressions.py:8:8
  %10 : int = aten::__and__(%a.1, %b.1) # /home/ince/expressions.py:9:8
  %13 : int = aten::__or__(%a.1, %b.1) # /home/ince/expressions.py:10:8
  %16 : int = aten::__xor__(%a.1, %b.1) # /home/ince/expressions.py:11:8
  %17 : (int, int, int, int, int) = prim::TupleConstruct(%4, %7, %10, %13, %16)
  return (%17)
```