### PR TITLE
Prohibit copying autograd engines

### DIFF
--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -860,12 +860,12 @@ void Engine::graph_task_exec_post_processing(
 // note that when python is present, this base engine will be overriden
 // with a PythonEngine. Because this typically happens before get_default_engine
 // is called, this base engine will never be created.
-static Engine& get_base_engine() {
+Engine& Engine::get_base_engine() {
   static Engine engine;
   return engine;
 }
 
-std::atomic<EngineStub> engine_stub(get_base_engine);
+std::atomic<EngineStub> engine_stub(Engine::get_base_engine);
 
 void set_default_engine_stub(EngineStub stub) {
   engine_stub.store(stub);

--- a/torch/csrc/autograd/engine.h
+++ b/torch/csrc/autograd/engine.h
@@ -160,7 +160,10 @@ struct TORCH_API Engine {
   /// Returns a reference to a static `Engine` instance.
   static Engine& get_default_engine();
 
-  Engine();
+  static Engine& get_base_engine();
+
+  Engine(const Engine&) = delete;
+  Engine(Engine&&) = delete;
   virtual ~Engine();
 
   using ready_queue_type = std::deque<std::pair<std::shared_ptr<Node>, InputBuffer>>;
@@ -207,6 +210,7 @@ struct TORCH_API Engine {
   size_t ready_queue_size(at::Device device);
 
  protected:
+  Engine();
   void compute_dependencies(Node* root, GraphTask& task);
   void evaluate_function(
       std::shared_ptr<GraphTask>& graph_task,

--- a/torch/csrc/autograd/python_engine.cpp
+++ b/torch/csrc/autograd/python_engine.cpp
@@ -23,13 +23,27 @@ struct THPEngine {
     PyObject_HEAD
 };
 
-static torch::autograd::python::PythonEngine engine;
-
-static Engine& get_python_engine() {
-  return engine;
-}
+static bool _reinitialize_engine = false;
 
 namespace torch { namespace autograd { namespace python {
+
+PythonEngine::PythonEngine() = default;
+
+Engine& PythonEngine::get_python_engine() {
+  static PythonEngine engine;
+  // This is "probably" thread-safe because the flag is set in a fork handler
+  // before any threads are created, and this function is only called with the
+  // GIL held. However, using fork + threads is playing with fire so this is
+  // more of a "best effort" thing. For example, if the fork occurs while the
+  // backwards threads hold a lock, we'll probably deadlock in the engine
+  // destructor.
+  if (_reinitialize_engine) {
+    engine.~PythonEngine();
+    new (&engine) torch::autograd::python::PythonEngine();
+    _reinitialize_engine = false;
+  }
+  return engine;
+}
 
 void PythonEngine::thread_init(int device) {
   // Create a PyThreadState, but release the GIL. This lets pybind11::gil_scoped_acquire calls
@@ -91,27 +105,10 @@ std::shared_ptr<FutureVariableList> PythonEngine::execute_with_graph_task(
 
 PyObject *THPEngineClass = nullptr;
 
-static bool _reinitialize_engine = false;
-
-static void _maybe_reinitialize_engine_after_fork() {
-  // This is "probably" thread-safe because the flag is set in a fork handler
-  // before any threads are created, and this function is only called with the
-  // GIL held. However, using fork + threads is playing with fire so this is
-  // more of a "best effort" thing. For example, if the fork occurs while the
-  // backwards threads hold a lock, we'll probably deadlock in the engine
-  // destructor.
-  if (_reinitialize_engine) {
-    engine.~PythonEngine();
-    new (&engine) torch::autograd::python::PythonEngine();
-    _reinitialize_engine = false;
-  }
-}
-
 // Implementation of torch._C._EngineBase.run_backward
 PyObject *THPEngine_run_backward(THPEngine *self, PyObject *args, PyObject *kwargs)
 {
   HANDLE_TH_ERRORS
-  _maybe_reinitialize_engine_after_fork();
   PyObject *tensors = nullptr;
   PyObject *grad_tensors = nullptr;
   unsigned char keep_graph = 0;
@@ -196,6 +193,7 @@ PyObject *THPEngine_run_backward(THPEngine *self, PyObject *args, PyObject *kwar
   variable_list outputs;
   {
     pybind11::gil_scoped_release no_gil;
+    auto& engine = python::PythonEngine::get_python_engine();
     outputs = engine.execute(roots, grads, keep_graph, create_graph, output_edges);
   }
 
@@ -219,7 +217,7 @@ PyObject *THPEngine_run_backward(THPEngine *self, PyObject *args, PyObject *kwar
 
 PyObject* THPEngine_queue_callback(PyObject *self, PyObject *_callback) {
   HANDLE_TH_ERRORS
-  _maybe_reinitialize_engine_after_fork();
+  auto& engine = python::PythonEngine::get_python_engine();
   std::shared_ptr<PyObject> callback(_callback, [](PyObject *obj) { pybind11::gil_scoped_acquire gil; Py_DECREF(obj); });
   Py_INCREF(_callback);
   engine.queue_callback([callback]() {
@@ -233,6 +231,7 @@ PyObject* THPEngine_queue_callback(PyObject *self, PyObject *_callback) {
 
 PyObject* THPEngine_is_checkpoint_valid(PyObject *self, PyObject *noargs) {
   HANDLE_TH_ERRORS
+  auto& engine = python::PythonEngine::get_python_engine();
   if(engine.is_checkpoint_valid()) {
     Py_RETURN_TRUE;
   } else {
@@ -310,6 +309,6 @@ bool THPEngine_initModule(PyObject *module)
     return false;
   Py_INCREF(&THPEngineType);
   PyModule_AddObject(module, "_ImperativeEngine", (PyObject *)&THPEngineType);
-  set_default_engine_stub(get_python_engine);
+  set_default_engine_stub(python::PythonEngine::get_python_engine);
   return true;
 }

--- a/torch/csrc/autograd/python_engine.h
+++ b/torch/csrc/autograd/python_engine.h
@@ -10,6 +10,7 @@ bool THPEngine_initModule(PyObject *module);
 namespace torch { namespace autograd { namespace python {
 
 struct PythonEngine : public Engine {
+  static Engine& get_python_engine();
   void thread_init(int device) override;
   void thread_on_exception(
       std::shared_ptr<GraphTask> graph_task,
@@ -26,6 +27,8 @@ struct PythonEngine : public Engine {
       const std::shared_ptr<GraphTask>& graph_task,
       std::shared_ptr<Node> graph_root) override;
   std::unique_ptr<AnomalyMetadata> make_anomaly_metadata() override;
+  private:
+    PythonEngine();
 };
 
 }}} // namespace torch::autograd::python


### PR DESCRIPTION
Make sure that there could not be more than one instance of either `torch::autograd::Engine` or `torch::autograd::python::PythonEngine`