### PR TITLE
Delete OperatorOptions, absorb AliasAnalysisKind into FunctionSchema.

### DIFF
--- a/aten/src/ATen/core/dispatch/Dispatcher.h
+++ b/aten/src/ATen/core/dispatch/Dispatcher.h
@@ -37,8 +37,8 @@ class SchemaRegistrationHandleRAII;
 class CAFFE2_API Dispatcher final {
 private:
   struct OperatorDef final {
-    explicit OperatorDef(FunctionSchema&& schema, OperatorOptions&& options)
-    : op(std::move(schema), std::move(options)), refcount(0) {}
+    explicit OperatorDef(FunctionSchema&& schema)
+    : op(std::move(schema)), refcount(0) {}
 
     impl::OperatorEntry op;
     size_t refcount;
@@ -116,7 +116,7 @@ public:
    *         object that manages the lifetime of the registration. Once that
    *         object is destructed, the kernel will be deregistered.
    */
-  std::pair<RegistrationHandleRAII, OperatorHandle> registerSchema(FunctionSchema schema, OperatorOptions options);
+  std::pair<RegistrationHandleRAII, OperatorHandle> registerSchema(FunctionSchema schema);
 
   /**
    * Register a kernel to the dispatch table for an operator.
@@ -152,7 +152,7 @@ public:
 private:
   Dispatcher();
 
-  OperatorHandle findOrRegisterSchema_(FunctionSchema&& schema, OperatorOptions&& options);
+  OperatorHandle findOrRegisterSchema_(FunctionSchema&& schema);
 
   void deregisterSchema_(const OperatorHandle& op, const OperatorName& op_name);
   void deregisterBackendFallbackKernel_(DispatchKey dispatchKey);
@@ -185,10 +185,6 @@ public:
 
   const FunctionSchema& schema() const {
     return operatorIterator_->op.schema();
-  }
-
-  const OperatorOptions& options() const {
-    return operatorIterator_->op.options();
   }
 
   template<class Return, class... Args>

--- a/aten/src/ATen/core/dispatch/OperatorEntry.cpp
+++ b/aten/src/ATen/core/dispatch/OperatorEntry.cpp
@@ -26,11 +26,10 @@ namespace {
   }
 }
 
-OperatorEntry::OperatorEntry(FunctionSchema&& schema, OperatorOptions&& options)
+OperatorEntry::OperatorEntry(FunctionSchema&& schema)
 : schema_(std::move(schema))
 , dispatchTable_(schema_)
-, kernels_()
-, options_(std::move(options)) {
+, kernels_() {
 }
 
 void OperatorEntry::prepareForDeregistration() {

--- a/aten/src/ATen/core/dispatch/OperatorEntry.h
+++ b/aten/src/ATen/core/dispatch/OperatorEntry.h
@@ -16,7 +16,7 @@ namespace impl {
 // and its dispatch table. This is not part of the public API.
 class OperatorEntry final {
 public:
-  explicit OperatorEntry(FunctionSchema&& schema, OperatorOptions&& options);
+  explicit OperatorEntry(FunctionSchema&& schema);
 
   OperatorEntry(const OperatorEntry&) = delete;
   OperatorEntry(OperatorEntry&&) noexcept = delete;
@@ -35,12 +35,8 @@ public:
 
   RegistrationHandleRAII registerKernel(c10::optional<DispatchKey> dispatch_key, KernelFunction kernel);
 
-  const OperatorOptions& options() {
-    return options_;
-  }
-
-  void updateOptionsAliasAnalysis(AliasAnalysisKind a) {
-    options_.setAliasAnalysis(a);
+  void updateSchemaAliasAnalysis(AliasAnalysisKind a) {
+    schema_.setAliasAnalysis(a);
   }
 
 private:
@@ -83,9 +79,6 @@ private:
   // is already registered, but that's a lot of effort to implement and
   // currently not high-pri.
   ska::flat_hash_map<c10::optional<DispatchKey>, std::list<KernelFunction>> kernels_;
-
-  // Some metadata about the operator
-  OperatorOptions options_;
 
   std::mutex kernelsMutex_; // protects kernels_
 

--- a/aten/src/ATen/core/dispatch/OperatorOptions.h
+++ b/aten/src/ATen/core/dispatch/OperatorOptions.h
@@ -3,9 +3,6 @@
 #include <cstdint>
 
 namespace c10 {
-namespace impl {
-class OperatorEntry;
-}
 
 enum class AliasAnalysisKind : uint8_t {
   INTERNAL_SPECIAL_CASE,
@@ -29,33 +26,5 @@ inline const char* toString(AliasAnalysisKind aliasAnalysisKind) {
                   ? "INTERNAL_SPECIAL_CASE"
                   : "UNKNOWN";
 }
-
-struct OperatorOptions final {
-public:
-  bool isDefaultAliasAnalysisKind() const {
-    return aliasAnalysisKind_ == c10::nullopt;
-  }
-
-  AliasAnalysisKind aliasAnalysis() const {
-    return !isDefaultAliasAnalysisKind()
-      ? *aliasAnalysisKind_
-      : AliasAnalysisKind::CONSERVATIVE;
-  }
-
-  void setAliasAnalysis(AliasAnalysisKind v) {
-    aliasAnalysisKind_ = v;
-  }
-
-  friend bool operator==(const OperatorOptions& lhs, const OperatorOptions& rhs) {
-    return lhs.aliasAnalysisKind_ == rhs.aliasAnalysisKind_;
-  }
-
-  friend bool operator!=(const OperatorOptions& lhs, const OperatorOptions& rhs) {
-    return !(lhs == rhs);
-  }
-
-private:
- c10::optional<AliasAnalysisKind> aliasAnalysisKind_;
-};
 
 } // namespace c10

--- a/aten/src/ATen/core/op_registration/op_registration.h
+++ b/aten/src/ATen/core/op_registration/op_registration.h
@@ -582,9 +582,8 @@ private:
   static c10::FunctionSchema inferSchemaFromKernels_(const OperatorName& opNameStr, const Options& options);
   void checkNoDuplicateKernels_(const Options& options);
   void registerOp_(Options&& options);
-  void registerSchemaAndKernel_(FunctionSchema schema, Options::KernelRegistrationConfig&& config, OperatorOptions&& options);
-  void registerSchemaOnly_(FunctionSchema&& schema, OperatorOptions&& options);
-  static OperatorOptions makeOperatorOptions_(const Options& options);
+  void registerSchemaAndKernel_(FunctionSchema schema, Options::KernelRegistrationConfig&& config);
+  void registerSchemaOnly_(FunctionSchema&& schema);
 
   class OperatorRegistrar;
 

--- a/aten/src/ATen/core/op_registration/op_registration_test.cpp
+++ b/aten/src/ATen/core/op_registration/op_registration_test.cpp
@@ -46,7 +46,7 @@ TEST(OperatorRegistrationTest, whenRegisteringSameSchemaWithAliasAnalysisAfterRe
 
     auto op = Dispatcher::singleton().findSchema({"_test::dummy", ""});
     ASSERT_TRUE(op.has_value());
-    EXPECT_EQ(op->options().aliasAnalysis(), at::AliasAnalysisKind::PURE_FUNCTION);
+    EXPECT_EQ(op->schema().aliasAnalysis(), at::AliasAnalysisKind::PURE_FUNCTION);
   }
   {
     auto registrar1 = c10::RegisterOperators().op("_test::dummy(Tensor dummy) -> ()", c10::RegisterOperators::options().kernel<DummyKernel>(c10::DispatchKey::XLATensorId).aliasAnalysis(at::AliasAnalysisKind::PURE_FUNCTION));
@@ -54,7 +54,7 @@ TEST(OperatorRegistrationTest, whenRegisteringSameSchemaWithAliasAnalysisAfterRe
 
     auto op = Dispatcher::singleton().findSchema({"_test::dummy", ""});
     ASSERT_TRUE(op.has_value());
-    EXPECT_EQ(op->options().aliasAnalysis(), at::AliasAnalysisKind::PURE_FUNCTION);
+    EXPECT_EQ(op->schema().aliasAnalysis(), at::AliasAnalysisKind::PURE_FUNCTION);
   }
 }
 
@@ -64,7 +64,7 @@ TEST(OperatorRegistrationTest, whenRegisteringSameSchemaWithSameAliasAnalysis_th
 
   auto op = Dispatcher::singleton().findSchema({"_test::dummy", ""});
   ASSERT_TRUE(op.has_value());
-  EXPECT_EQ(op->options().aliasAnalysis(), at::AliasAnalysisKind::PURE_FUNCTION);
+  EXPECT_EQ(op->schema().aliasAnalysis(), at::AliasAnalysisKind::PURE_FUNCTION);
 }
 
 TEST(OperatorRegistrationTest, whenRegisteringSameSchemaWithNoAliasAnalysis_thenCanBeCalled) {
@@ -73,15 +73,15 @@ TEST(OperatorRegistrationTest, whenRegisteringSameSchemaWithNoAliasAnalysis_then
 
   auto op = Dispatcher::singleton().findSchema({"_test::dummy", ""});
   ASSERT_TRUE(op.has_value());
-  EXPECT_TRUE(op->options().isDefaultAliasAnalysisKind());
-  EXPECT_EQ(op->options().aliasAnalysis(), at::AliasAnalysisKind::CONSERVATIVE);
+  EXPECT_TRUE(op->schema().isDefaultAliasAnalysisKind());
+  EXPECT_EQ(op->schema().aliasAnalysis(), at::AliasAnalysisKind::CONSERVATIVE);
 }
 
 TEST(OperatorRegistrationTest, whenRegisteringSameSchemaWithDifferentAliasAnalysis_thenShouldThrow) {
   expectThrows<c10::Error>([] {
     auto registrar1 = c10::RegisterOperators().op("_test::dummy(Tensor dummy) -> ()", c10::RegisterOperators::options().kernel<DummyKernel>(c10::DispatchKey::CPUTensorId).aliasAnalysis(at::AliasAnalysisKind::PURE_FUNCTION));
     auto registrar2 = c10::RegisterOperators().op("_test::dummy(Tensor dummy) -> ()", c10::RegisterOperators::options().kernel<DummyKernel>(c10::DispatchKey::XLATensorId).aliasAnalysis(at::AliasAnalysisKind::CONSERVATIVE));
-  }, "Tried to register multiple operators with the same schema but different options:");
+  }, "Tried to register multiple operators with the same schema but different alias analysis kind:");
 }
 
 TEST(OperatorRegistrationTest, whenRegisteringWithSchemaBeforeKernelInOptionsObject_thenCanBeCalled) {

--- a/test/cpp/jit/test_alias_analysis.cpp
+++ b/test/cpp/jit/test_alias_analysis.cpp
@@ -9,10 +9,8 @@
 namespace torch {
 namespace jit {
 
-inline c10::OperatorOptions aliasAnalysisFromSchema() {
-  c10::OperatorOptions result;
-  result.setAliasAnalysis(c10::AliasAnalysisKind::FROM_SCHEMA);
-  return result;
+inline c10::AliasAnalysisKind aliasAnalysisFromSchema() {
+  return c10::AliasAnalysisKind::FROM_SCHEMA;
 }
 
 // Fixture to set up a graph and make assertions clearer

--- a/test/cpp/jit/test_base.cpp
+++ b/test/cpp/jit/test_base.cpp
@@ -5,10 +5,8 @@
 
 namespace torch {
 namespace jit {
-inline c10::OperatorOptions aliasAnalysisFromSchema() {
-  c10::OperatorOptions result;
-  result.setAliasAnalysis(c10::AliasAnalysisKind::FROM_SCHEMA);
-  return result;
+inline c10::AliasAnalysisKind aliasAnalysisFromSchema() {
+  return c10::AliasAnalysisKind::FROM_SCHEMA;
 }
 
 RegisterOperators reg({

--- a/test/cpp/jit/test_misc.cpp
+++ b/test/cpp/jit/test_misc.cpp
@@ -69,10 +69,8 @@
 
 namespace torch {
 namespace jit {
-inline c10::OperatorOptions aliasAnalysisFromSchema() {
-  c10::OperatorOptions result;
-  result.setAliasAnalysis(c10::AliasAnalysisKind::FROM_SCHEMA);
-  return result;
+inline c10::AliasAnalysisKind aliasAnalysisFromSchema() {
+  return c10::AliasAnalysisKind::FROM_SCHEMA;
 }
 
 

--- a/test/cpp/jit/test_schema_matching.cpp
+++ b/test/cpp/jit/test_schema_matching.cpp
@@ -21,7 +21,7 @@ void testSchemaMatching() {
                 pop(stack, list, a);
                 push(stack, a);
                 return 0;
-            }),
+            }, c10::AliasAnalysisKind::FROM_SCHEMA),
     });
     script::Module m("m");
     m.define(R"(
@@ -57,7 +57,7 @@ void testSchemaMatching() {
               pop(stack, a, list);
               push(stack, a);
               return 0;
-            }),
+            }, AliasAnalysisKind::FROM_SCHEMA),
     });
     script::Module m("m");
     m.define(R"JIT(

--- a/tools/jit/templates/register_aten_ops.cpp
+++ b/tools/jit/templates/register_aten_ops.cpp
@@ -80,10 +80,8 @@ std::array<bool, N> as_bool_array(const c10::List<bool>& list) {
   return res;
 }
 
-c10::OperatorOptions atenOperatorOptions() {
-  c10::OperatorOptions result;
-  result.setAliasAnalysis(c10::AliasAnalysisKind::FROM_SCHEMA);
-  return result;
+c10::AliasAnalysisKind atenOperatorOptions() {
+  return c10::AliasAnalysisKind::FROM_SCHEMA;
 }
 
 int (*DUMMY_OPERATION)(Stack&) = [](Stack& stack) -> int {

--- a/torch/csrc/jit/codegen/fuser/fallback.cpp
+++ b/torch/csrc/jit/codegen/fuser/fallback.cpp
@@ -14,10 +14,8 @@ namespace jit {
 namespace fuser {
 
 namespace {
-c10::OperatorOptions aliasAnalysisIsSpecialCase() {
-  c10::OperatorOptions options;
-  options.setAliasAnalysis(AliasAnalysisKind::INTERNAL_SPECIAL_CASE);
-  return options;
+c10::AliasAnalysisKind aliasAnalysisIsSpecialCase() {
+  return AliasAnalysisKind::INTERNAL_SPECIAL_CASE;
 }
 } // namespace
 

--- a/torch/csrc/jit/ir/constants.cpp
+++ b/torch/csrc/jit/ir/constants.cpp
@@ -9,10 +9,8 @@ namespace torch {
 namespace jit {
 
 namespace {
-c10::OperatorOptions aliasAnalysisInternalSpecialCase() {
-  c10::OperatorOptions options;
-  options.setAliasAnalysis(AliasAnalysisKind::INTERNAL_SPECIAL_CASE);
-  return options;
+c10::AliasAnalysisKind aliasAnalysisInternalSpecialCase() {
+  return AliasAnalysisKind::INTERNAL_SPECIAL_CASE;
 }
 } // namespace
 

--- a/torch/csrc/jit/passes/batch_mm.cpp
+++ b/torch/csrc/jit/passes/batch_mm.cpp
@@ -17,10 +17,8 @@ namespace torch {
 namespace jit {
 
 namespace {
-c10::OperatorOptions aliasAnalysisIsSpecialCase() {
-  c10::OperatorOptions options;
-  options.setAliasAnalysis(AliasAnalysisKind::INTERNAL_SPECIAL_CASE);
-  return options;
+c10::AliasAnalysisKind aliasAnalysisIsSpecialCase() {
+  return AliasAnalysisKind::INTERNAL_SPECIAL_CASE;
 }
 } // namespace
 

--- a/torch/csrc/jit/passes/decompose_ops.cpp
+++ b/torch/csrc/jit/passes/decompose_ops.cpp
@@ -11,10 +11,8 @@ namespace torch {
 namespace jit {
 
 namespace {
-c10::OperatorOptions aliasAnalysisFromSchema() {
-  c10::OperatorOptions result;
-  result.setAliasAnalysis(c10::AliasAnalysisKind::FROM_SCHEMA);
-  return result;
+c10::AliasAnalysisKind aliasAnalysisFromSchema() {
+  return c10::AliasAnalysisKind::FROM_SCHEMA;
 }
 } // namespace
 

--- a/torch/csrc/jit/passes/tensorexpr_fuser.cpp
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.cpp
@@ -128,10 +128,8 @@ Operation createTensorExprOp(const Node* node) {
   };
 }
 
-c10::OperatorOptions getAliasAnalysisOption(AliasAnalysisKind k) {
-  auto options = c10::OperatorOptions();
-  options.setAliasAnalysis(k);
-  return options;
+c10::AliasAnalysisKind getAliasAnalysisOption(AliasAnalysisKind k) {
+  return k;
 }
 
 RegisterOperators TensorExprOps({

--- a/torch/csrc/jit/python/python_interpreter.cpp
+++ b/torch/csrc/jit/python/python_interpreter.cpp
@@ -72,10 +72,8 @@ Operation createPythonOperation(const Node* op_) {
   };
 }
 
-c10::OperatorOptions aliasAnalysisIsSpecialCase() {
-  c10::OperatorOptions options;
-  options.setAliasAnalysis(AliasAnalysisKind::INTERNAL_SPECIAL_CASE);
-  return options;
+c10::AliasAnalysisKind aliasAnalysisIsSpecialCase() {
+  return AliasAnalysisKind::INTERNAL_SPECIAL_CASE;
 }
 
 RegisterOperators reg({Operator(

--- a/torch/csrc/jit/runtime/graph_executor.cpp
+++ b/torch/csrc/jit/runtime/graph_executor.cpp
@@ -53,10 +53,8 @@ namespace torch {
 namespace jit {
 
 namespace {
-c10::OperatorOptions aliasAnalysisInternalSpecialCase() {
-  c10::OperatorOptions options;
-  options.setAliasAnalysis(AliasAnalysisKind::INTERNAL_SPECIAL_CASE);
-  return options;
+c10::AliasAnalysisKind aliasAnalysisInternalSpecialCase() {
+  return AliasAnalysisKind::INTERNAL_SPECIAL_CASE;
 }
 } // namespace
 

--- a/torch/csrc/jit/runtime/register_distributed_ops.cpp
+++ b/torch/csrc/jit/runtime/register_distributed_ops.cpp
@@ -30,16 +30,12 @@ at::Tensor optional_to_tensor(c10::optional<at::Tensor> v) {
   return v.has_value() ? *v : at::Tensor();
 }
 
-c10::OperatorOptions aliasAnalysisFromSchema() {
-  c10::OperatorOptions result;
-  result.setAliasAnalysis(c10::AliasAnalysisKind::FROM_SCHEMA);
-  return result;
+c10::AliasAnalysisKind aliasAnalysisFromSchema() {
+  return c10::AliasAnalysisKind::FROM_SCHEMA;
 }
 
-c10::OperatorOptions aliasAnalysisSpecialCase() {
-  c10::OperatorOptions result;
-  result.setAliasAnalysis(c10::AliasAnalysisKind::INTERNAL_SPECIAL_CASE);
-  return result;
+c10::AliasAnalysisKind aliasAnalysisSpecialCase() {
+  return c10::AliasAnalysisKind::INTERNAL_SPECIAL_CASE;
 }
 
 RegisterOperators reg_rpc_ops({

--- a/torch/csrc/jit/runtime/register_prim_ops.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops.cpp
@@ -65,22 +65,16 @@ int noop(Stack& n) {
   return 0;
 }
 
-c10::OperatorOptions aliasAnalysisFromSchema() {
-  c10::OperatorOptions result;
-  result.setAliasAnalysis(c10::AliasAnalysisKind::FROM_SCHEMA);
-  return result;
+c10::AliasAnalysisKind aliasAnalysisFromSchema() {
+  return c10::AliasAnalysisKind::FROM_SCHEMA;
 }
 
-c10::OperatorOptions aliasAnalysisConservative() {
-  c10::OperatorOptions result;
-  result.setAliasAnalysis(c10::AliasAnalysisKind::CONSERVATIVE);
-  return result;
+c10::AliasAnalysisKind aliasAnalysisConservative() {
+  return c10::AliasAnalysisKind::CONSERVATIVE;
 }
 
-c10::OperatorOptions aliasAnalysisSpecialCase() {
-  c10::OperatorOptions result;
-  result.setAliasAnalysis(c10::AliasAnalysisKind::INTERNAL_SPECIAL_CASE);
-  return result;
+c10::AliasAnalysisKind aliasAnalysisSpecialCase() {
+  return c10::AliasAnalysisKind::INTERNAL_SPECIAL_CASE;
 }
 
 // using the rules from python_arg_parser FunctionParameter::check

--- a/torch/csrc/jit/runtime/register_special_ops.cpp
+++ b/torch/csrc/jit/runtime/register_special_ops.cpp
@@ -21,10 +21,8 @@ namespace jit {
 
 namespace {
 
-c10::OperatorOptions aliasAnalysisFromSchema() {
-  c10::OperatorOptions result;
-  result.setAliasAnalysis(c10::AliasAnalysisKind::FROM_SCHEMA);
-  return result;
+c10::AliasAnalysisKind aliasAnalysisFromSchema() {
+  return c10::AliasAnalysisKind::FROM_SCHEMA;
 }
 
 void checkListInputType(const c10::TypePtr& elem_type, bool empty_list) {

--- a/torch/csrc/jit/runtime/register_string_ops.cpp
+++ b/torch/csrc/jit/runtime/register_string_ops.cpp
@@ -5,10 +5,8 @@ namespace torch {
 namespace jit {
 namespace {
 
-c10::OperatorOptions aliasAnalysisFromSchema() {
-  c10::OperatorOptions result;
-  result.setAliasAnalysis(c10::AliasAnalysisKind::FROM_SCHEMA);
-  return result;
+c10::AliasAnalysisKind aliasAnalysisFromSchema() {
+  return c10::AliasAnalysisKind::FROM_SCHEMA;
 }
 
 // Convert an python index (which may be negative) into an index usable for a


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #34620 Minor OperatorName cleanup
* #34618 Improved error checking
* #34601 Implement schema matching inside Dispatcher
* #34456 Finish implementing schema-less impl, switch all internal registrations to it
* #34455 Add torch::jit::parseName (mirroring parseSchema/parseSchemaOrName)
* #34221 Relax internal invariants of Dispatcher in preparation for schema-less registration
* **#34588 Delete OperatorOptions, absorb AliasAnalysisKind into FunctionSchema.**

I constructed the patch by deleting OperatorOptions and then rerouting
all queries for AliasAnalysisKind to FunctionSchema.  Some of the
behavior is kind of bogus: we really shouldn't be mutating FunctionSchema
after the fact, but that won't get fixed until we actually switch to
true schema merging.

Reland of https://github.com/pytorch/pytorch/pull/34160

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D20387079](https://our.internmc.facebook.com/intern/diff/D20387079)