### PR TITLE
Add the 3d upsample quantized op for video model

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -6325,6 +6325,7 @@
   dispatch:
     CPU: upsample_nearest3d_cpu
     CUDA: upsample_nearest3d_cuda
+    QuantizedCPU: quantized_upsample_nearest3d_cpu
 
 - func: upsample_nearest3d_backward.grad_input(Tensor grad_output, int[3] output_size, int[5] input_size, float? scales_d=None, float? scales_h=None, float? scales_w=None, *, Tensor(a!) grad_input) -> Tensor(a!)
   python_module: nn

--- a/aten/src/ATen/native/quantized/cpu/qupsample_nearest3d.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qupsample_nearest3d.cpp
@@ -1,0 +1,200 @@
+#include <ATen/ATen.h>
+#include <ATen/native/UpSample.h>
+#include <ATen/native/cpu/Loops.h>
+#include <ATen/native/quantized/cpu/quantized_ops.h>
+#include <ATen/quantized/Quantizer.h>
+#include <cstring>
+
+
+namespace at {
+namespace native {
+
+// at::native functions for the native_functions.yaml
+template <typename scalar_t>
+static void upsample_nearest3d_out_frame(
+    scalar_t* odata,
+    scalar_t* idata,
+    int64_t input_depth,
+    int64_t input_height,
+    int64_t input_width,
+    int64_t output_depth,
+    int64_t output_height,
+    int64_t output_width,
+    int64_t nbatch,
+    int64_t channels,
+    c10::optional<double> scales_d,
+    c10::optional<double> scales_h,
+    c10::optional<double> scales_w) {
+  float depth_scale = compute_scales_value<float>(scales_d, input_depth, output_depth);
+  float height_scale = compute_scales_value<float>(scales_h, input_height, output_height);
+  float width_scale = compute_scales_value<float>(scales_w, input_width, output_width);
+
+  channels = channels * nbatch;
+  auto* i_p = reinterpret_cast<typename scalar_t::underlying*>(idata);
+  auto* o_p = reinterpret_cast<typename scalar_t::underlying*>(odata);
+
+  // special case: just copy
+  if (input_depth == output_depth && input_height == output_height && input_width == output_width) {
+    std::memcpy(o_p, i_p, channels * input_depth * input_height * input_width * sizeof(typename scalar_t::underlying));
+    return;
+  }
+
+  for (int64_t d2 = 0; d2 < output_depth; ++d2) {
+    const int64_t d1 =
+          nearest_neighbor_compute_source_index(depth_scale, d2, input_depth);
+
+    for (int64_t h2 = 0; h2 < output_height; ++h2) {
+      const int64_t h1 =
+          nearest_neighbor_compute_source_index(height_scale, h2, input_height);
+
+      for (int64_t w2 = 0; w2 < output_width; ++w2) {
+        const int64_t w1 =
+            nearest_neighbor_compute_source_index(width_scale, w2, input_width);
+
+        const auto* pos1 = &i_p[d1 * input_height * input_width + h1 * input_width + w1];
+        auto* pos2 = &o_p[d2 * output_height * output_width + h2 * output_width + w2];
+
+        for (int64_t c = 0; c < channels; ++c) {
+          pos2[0] = pos1[0];
+          pos1 += input_depth * input_height * input_width;
+          pos2 += output_depth * output_height * output_width;
+        }
+      }
+    }
+  }
+}
+
+template <typename scalar_t>
+static void upsample_nearest3d_out_frame_nhwc(
+    scalar_t* odata,
+    scalar_t* idata,
+    int64_t input_depth,
+    int64_t input_height,
+    int64_t input_width,
+    int64_t output_depth,
+    int64_t output_height,
+    int64_t output_width,
+    int64_t nbatch,
+    int64_t channels,
+    c10::optional<double> scales_d,
+    c10::optional<double> scales_h,
+    c10::optional<double> scales_w) {
+  float depth_scale = compute_scales_value<float>(scales_d, input_depth, output_depth);
+  float height_scale = compute_scales_value<float>(scales_h, input_height, output_height);
+  float width_scale = compute_scales_value<float>(scales_w, input_width, output_width);
+
+  for (int b = 0; b < nbatch; b++) {
+    auto* i_p = reinterpret_cast<typename scalar_t::underlying*>(idata + b * input_depth * input_height * input_width * channels);
+    auto* o_p = reinterpret_cast<typename scalar_t::underlying*>(odata + b * output_depth * output_height * output_width * channels);
+    // special case: just copy
+    if (input_depth == output_depth && input_height == output_height && input_width == output_width) {
+      std::memcpy(o_p, i_p, channels * input_depth * input_height * input_width * sizeof(typename scalar_t::underlying));
+      return;
+    }
+
+    for (int64_t d2 = 0; d2 < output_depth; ++d2) {
+      const int64_t d1 =
+          nearest_neighbor_compute_source_index(depth_scale, d2, input_depth);
+      for (int64_t h2 = 0; h2 < output_height; ++h2) {
+        const int64_t h1 =
+            nearest_neighbor_compute_source_index(height_scale, h2, input_height);
+
+        for (int64_t w2 = 0; w2 < output_width; ++w2) {
+          const int64_t w1 =
+              nearest_neighbor_compute_source_index(width_scale, w2, input_width);
+
+          const auto* pos1 = &i_p[(d1 * input_height * input_width + h1 * input_width + w1)*channels];
+          auto* pos2 = &o_p[(d2 * output_height * output_width + h2 * output_width + w2)*channels];
+          std::memcpy(pos2, pos1, channels * sizeof(typename scalar_t::underlying));
+        }
+      }
+    }
+  }
+}
+
+Tensor quantized_upsample_nearest3d_cpu(
+    const Tensor& input,
+    IntArrayRef output_size,
+    c10::optional<double> scales_d,
+    c10::optional<double> scales_h,
+    c10::optional<double> scales_w) {
+  TORCH_CHECK(
+      output_size.size() == 3,
+      "It is expected output_size equals to 3, but got size ",
+      output_size.size());
+
+  TORCH_CHECK(
+      input.numel() != 0 && input.dim() == 5,
+      "Non-empty 5D data tensor expected but got a tensor with sizes ",
+      input.sizes());
+
+  int64_t output_depth = output_size[0];
+  int64_t output_height = output_size[1];
+  int64_t output_width = output_size[2];
+
+  int64_t nbatch = input.size(0);
+  int64_t channels = input.size(1);
+  int64_t input_depth = input.size(2);
+  int64_t input_height = input.size(3);
+  int64_t input_width = input.size(4);
+  AT_ASSERT(input_width > 0 && output_width > 0);
+  if (input.is_contiguous(c10::MemoryFormat::ChannelsLast3d)) {
+    Tensor output = at::_empty_affine_quantized(
+        {nbatch, channels, output_depth, output_height, output_width},
+        input.options(),
+        input.q_scale(),
+        input.q_zero_point(),
+        input.suggest_memory_format());
+
+    AT_DISPATCH_QINT_TYPES(input.scalar_type(), "upsample_nearest3d", [&] {
+      auto* idata = static_cast<scalar_t*>(input.data_ptr());
+      auto* odata = static_cast<scalar_t*>(output.data_ptr());
+      upsample_nearest3d_out_frame_nhwc<scalar_t>(
+          odata,
+          idata,
+          input_depth,
+          input_height,
+          input_width,
+          output_depth,
+          output_height,
+          output_width,
+          nbatch,
+          channels,
+          scales_d,
+          scales_h,
+          scales_w);
+    });
+    return output;
+  } else {
+    Tensor output = at::_empty_affine_quantized(
+        {nbatch, channels, output_depth, output_height, output_width},
+        input.options(),
+        input.q_scale(),
+        input.q_zero_point());
+
+    auto input_contig = input.contiguous();
+
+    AT_DISPATCH_QINT_TYPES(input_contig.scalar_type(), "upsample_nearest3d", [&] {
+      auto* idata = static_cast<scalar_t*>(input_contig.data_ptr());
+      auto* odata = static_cast<scalar_t*>(output.data_ptr());
+      upsample_nearest3d_out_frame<scalar_t>(
+          odata,
+          idata,
+          input_depth,
+          input_height,
+          input_width,
+          output_depth,
+          output_height,
+          output_width,
+          nbatch,
+          channels,
+          scales_d,
+          scales_h,
+          scales_w);
+    });
+    return output;
+  }
+}
+
+} // namespace native
+} // namespace at

--- a/test/test_quantized.py
+++ b/test/test_quantized.py
@@ -1192,6 +1192,59 @@ class TestQuantizedOps(TestCase):
                              message=error_message.format(name + '.zero_point', scale,
                                                           qX_hat.q_zero_point()))
 
+    @given(X=hu.tensor(shapes=hu.array_shapes(min_dims=5, max_dims=5,
+                                              min_side=5, max_side=10),
+                       qparams=hu.qparams()),
+           size=st.sampled_from((1, 3, 5, 5, 10)),
+           scale_factor=st.sampled_from((None, 1.5, 2.0)),
+           align_corners=st.sampled_from((True, False)),
+           nhwc_layout=st.sampled_from((True, False)))
+    def test_interpolate3d(self, X, size, scale_factor, align_corners, nhwc_layout):
+        """
+        This test cover upsample_nearest2d and upsample_bilinear2d
+        """
+        X, (scale, zero_point, torch_type) = X
+        D, H, W = X.shape[-3:]
+        mode = "nearest"
+        if scale_factor is not None:
+            size = None
+        if mode == "nearest":
+            align_corners = None
+
+        if nhwc_layout:
+            if X.shape[1] < 176:
+                X = np.repeat(X, 176 / X.shape[1], 1)
+
+            X_nchw = np.ascontiguousarray(X.transpose([0, 2, 3, 4, 1]))
+            X = torch.from_numpy(X_nchw).permute([0, 4, 1, 2, 3])
+
+            qX = torch.quantize_per_tensor(X, scale=scale, zero_point=zero_point,
+                                           dtype=torch_type).permute([0, 4, 1, 2, 3])
+        else:
+            X = torch.from_numpy(X)
+            qX = torch.quantize_per_tensor(X, scale=scale, zero_point=zero_point,
+                                           dtype=torch_type)
+        X_ref = torch.nn.functional.interpolate(
+            qX.int_repr().to(torch.float), size=size, scale_factor=scale_factor,
+            mode=mode, align_corners=align_corners)
+
+        ops_under_test = {
+            "nn.functional": torch.nn.functional.interpolate,
+            "nn.quantized.functional": torch.nn.quantized.functional.interpolate
+        }
+
+        error_message = r"Results are off for {}:\n\tExpected:\n{}\n\tGot:\n{}"
+        for name, op in ops_under_test.items():
+            qX_hat = op(qX, size=size, scale_factor=scale_factor,
+                        mode=mode, align_corners=align_corners)
+            self.assertEqual(X_ref, qX_hat.int_repr(), prec=1.0,
+                             message="{} results are off".format(name, qX_hat.int_repr(), X_ref))
+            self.assertEqual(scale, qX_hat.q_scale(),
+                             message=error_message.format(name + '.scale', scale, qX_hat.q_scale()))
+            self.assertEqual(zero_point, qX_hat.q_zero_point(),
+                             message=error_message.format(name + '.zero_point', scale,
+                                                          qX_hat.q_zero_point()))
+
     """Tests quantize concatenation (both fused and not)."""
     @given(X=hu.tensor(shapes=hu.array_shapes(min_dims=4, max_dims=4,
                                               min_side=1, max_side=10),

--- a/torch/nn/quantized/functional.py
+++ b/torch/nn/quantized/functional.py
@@ -226,7 +226,7 @@ def interpolate(input, size=None, scale_factor=None, mode='nearest', align_corne
 
     .. note:: The input quantization parameters propagate to the output.
 
-    .. note:: Only 2D input is supported for quantized inputs
+    .. note:: Only 2D/3D input is supported for quantized inputs
 
     .. note:: Only the following modes are supported for the quantized inputs:
 


### PR DESCRIPTION
as title, we are currently missing this 3d op, which is required for video related model.

Performance benchmark:
```
import torch, time

for dtype in [torch.qint8, torch.quint8, torch.qint32]:
    print('****', str(dtype), '*****')
    x = torch.rand(1, 56, 64, 56, 256)

    q_x = torch.quantize_per_tensor(x, 0.5, 1, dtype)
    q_x = q_x.permute([0, 4, 1, 2, 3])

    x = x.permute([0, 4, 1, 2, 3])

    NITER = 100

    s = time.time()
    for i in range(NITER):
        float_out = torch.nn.functional.interpolate(x, size=30, scale_factor=None, mode="nearest", align_corners=None)
    time_per_iter_float = (time.time() - s) / NITER

    s = time.time()
    for i in range(NITER):
        quant_out = torch.nn.functional.interpolate(q_x, size=30, scale_factor=None, mode="nearest", align_corners=None)
    time_per_iter_quant = (time.time() - s) / NITER

    ref_quantized = torch.quantize_per_tensor(float_out, 0.5, 1, dtype)
    torch.testing.assert_allclose(ref_quantized.dequantize(), quant_out.dequantize())

    print('time/iter ms (float)', 'time/iter ms (quant)', 'quant/float', sep='\t')
    print(time_per_iter_float * 1000, time_per_iter_quant * 1000, time_per_iter_quant / time_per_iter_float, sep='\t')

    bytes_float = (x.numel() + float_out.numel()) * x.element_size()
    bytes_quant = (q_x.numel() + quant_out.numel()) * q_x.element_size()

    float_bw_gbps = bytes_float / time_per_iter_float / 1e9
    quant_bw_gbps = bytes_quant / time_per_iter_quant / 1e9

    print('GB/s float', 'GB/s quant', sep='\t')
    print(float_bw_gbps, quant_bw_gbps, sep='\t')
```


```
**** torch.qint8 *****
time/iter ms (float)  time/iter ms (quant)  quant/float
1136.8209528923035  1.294245719909668 0.0011384780660638283
GB/s float  GB/s quant
0.20510608588517917 45.03953391792442
**** torch.quint8 *****
time/iter ms (float)  time/iter ms (quant)  quant/float
827.9890131950378 1.11464262008667  0.0013462046021426
GB/s float  GB/s quant
0.28160868355034036 52.29678369508914
**** torch.qint32 *****
time/iter ms (float)  time/iter ms (quant)  quant/float
834.6958303451538 7.481417655944824 0.008963046638020456
GB/s float  GB/s quant
0.2793459455806586  31.16640544920269
```


