### PR TITLE
[ci] try to fix rocm builds

### DIFF
--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -37,6 +37,7 @@ fi
 
 if [[ "$BUILD_ENVIRONMENT" == *rocm* ]]; then
   # TODO: Move this to Docker
+  sudo apt-get -qq install --no-install-recommends apt-transport-https ca-certificates
   sudo apt-get -qq update
   sudo apt-get -qq install --no-install-recommends libsndfile1
 fi


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#34600 [ci] try to fix rocm builds**

They are failing with:
```
E: The method driver /usr/lib/apt/methods/https could not be found.
```

Trying the solution recommended in: https://unix.stackexchange.com/questions/263801/apt-get-fails-the-method-driver-usr-lib-apt-methods-https-could-not-be-found

The long-term solution is to move all this to be pre-installed in the
docker image.

Differential Revision: [D20391153](https://our.internmc.facebook.com/intern/diff/D20391153)