### PR TITLE
Remove unneeded declaration from generic/THCTensor.hpp

### DIFF
--- a/aten/src/THC/generic/THCTensor.hpp
+++ b/aten/src/THC/generic/THCTensor.hpp
@@ -10,7 +10,6 @@
 
 THC_API void THCTensor_(setStorage)(THCState *state, THCTensor *self, THCStorage *storage_, ptrdiff_t storageOffset_,
                                     at::IntArrayRef size_, at::IntArrayRef stride_);
-THC_API THCTensor *THCTensor_(newView)(THCState *state, THCTensor *tensor, at::IntArrayRef size);
 /* strides.data() might be nullptr */
 THC_API THCTensor *THCTensor_(newWithStorage)(THCState *state, THCStorage *storage, ptrdiff_t storageOffset,
                                               at::IntArrayRef sizes, at::IntArrayRef strides);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #34617 Get rid of unneeded declaration in generic/THCTensor.hpp
* **#34616 Remove unneeded declaration from generic/THCTensor.hpp**

I had some trouble landing changes to this file (on Windows) over in https://github.com/pytorch/pytorch/pull/34387,
so just trying to make some minimal changes to track down what the issue is.

Differential Revision: [D20443438](https://our.internmc.facebook.com/intern/diff/D20443438)