### PR TITLE
Get rid of unneeded declaration in generic/THCTensor.hpp

### DIFF
--- a/aten/src/THC/generic/THCTensor.hpp
+++ b/aten/src/THC/generic/THCTensor.hpp
@@ -15,6 +15,5 @@ THC_API THCTensor *THCTensor_(newWithStorage)(THCState *state, THCStorage *stora
                                               at::IntArrayRef sizes, at::IntArrayRef strides);
 
 THC_API void THCTensor_(resize)(THCState *state, THCTensor *self, at::IntArrayRef size, at::IntArrayRef stride);
-THC_API THCTensor *THCTensor_(newWithSize)(THCState *state, at::IntArrayRef size, at::IntArrayRef stride);
 
 #endif

--- a/aten/src/THC/generic/THCTensor.hpp
+++ b/aten/src/THC/generic/THCTensor.hpp
@@ -15,5 +15,7 @@ THC_API THCTensor *THCTensor_(newWithStorage)(THCState *state, THCStorage *stora
                                               at::IntArrayRef sizes, at::IntArrayRef strides);
 
 THC_API void THCTensor_(resize)(THCState *state, THCTensor *self, at::IntArrayRef size, at::IntArrayRef stride);
+// this is not an actual function, but removing it seems to cause compilationproblems on Windows + CUDA.
+THC_API THCTensor *THCTensor_(newWithSize)(THCState *state);
 
 #endif


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#34617 Get rid of unneeded declaration in generic/THCTensor.hpp**
* #34616 Remove unneeded declaration from generic/THCTensor.hpp

Differential Revision: [D20443440](https://our.internmc.facebook.com/intern/diff/D20443440)