### PR TITLE
Delete AT_WARN and replace all AT_WARN with TORCH_WARN

### DIFF
--- a/aten/src/ATen/native/DispatchStub.cpp
+++ b/aten/src/ATen/native/DispatchStub.cpp
@@ -20,7 +20,7 @@ static CPUCapability compute_cpu_capability() {
     if (strcmp(envar, "default") == 0) {
       return CPUCapability::DEFAULT;
     }
-    AT_WARN("ignoring invalid value for ATEN_CPU_CAPABILITY: ", envar);
+    TORCH_WARN("ignoring invalid value for ATEN_CPU_CAPABILITY: ", envar);
   }
 
 #if !defined(__powerpc__) && !defined(__s390x__)

--- a/aten/src/ATen/native/IndexingUtils.h
+++ b/aten/src/ATen/native/IndexingUtils.h
@@ -16,7 +16,7 @@ static std::vector<Tensor> expandTensors(const Tensor & self, TensorList indices
   for (const auto & index : indices) {
     if (index.scalar_type() == kByte || index.scalar_type() == kBool) {
       if (index.scalar_type() == kByte) {
-        AT_WARN("indexing with dtype torch.uint8 is now deprecated," \
+        TORCH_WARN("indexing with dtype torch.uint8 is now deprecated," \
         " please use a dtype torch.bool instead.");
       }
       // The sizes of the ByteTensor mask or bool tensor must match the sizes of the

--- a/aten/src/ATen/native/LegacyDefinitions.cpp
+++ b/aten/src/ATen/native/LegacyDefinitions.cpp
@@ -14,7 +14,7 @@ Tensor & masked_scatter__cpu(Tensor& self, const Tensor & mask, const Tensor & s
   // As we dispatch on self and TH is type-checked, we need different definitions.
   // This can be fixed by moving to ATen.
   if (b_mask.dtype() == at::ScalarType::Byte) {
-    AT_WARN("masked_scatter_ received a mask with dtype torch.uint8, this behavior is now deprecated," \
+    TORCH_WARN("masked_scatter_ received a mask with dtype torch.uint8, this behavior is now deprecated," \
             "please use a mask with dtype torch.bool instead.");
     return legacy::cpu::_th_masked_scatter_(self, b_mask, source);
   } else {
@@ -25,7 +25,7 @@ Tensor & masked_scatter__cpu(Tensor& self, const Tensor & mask, const Tensor & s
 Tensor masked_select_cpu(const Tensor & self, const Tensor & mask) {
   namedinference::compute_broadcast_outnames(self, mask);
   if (mask.dtype() == at::ScalarType::Byte) {
-    AT_WARN("masked_select received a mask with dtype torch.uint8, this behavior is now deprecated," \
+    TORCH_WARN("masked_select received a mask with dtype torch.uint8, this behavior is now deprecated," \
             "please use a mask with dtype torch.bool instead.");
     return legacy::cpu::_th_masked_select(self, mask);
   } else {

--- a/aten/src/ATen/native/TensorAdvancedIndexing.cpp
+++ b/aten/src/ATen/native/TensorAdvancedIndexing.cpp
@@ -539,7 +539,7 @@ Tensor masked_scatter(const Tensor & self, const Tensor & mask, const Tensor & s
 static Tensor & masked_fill_impl_cpu(Tensor & self, const Tensor & mask, Scalar value) {
   NoNamesGuard guard;
   if (mask.dtype() == ScalarType::Byte) {
-    AT_WARN("masked_fill_ received a mask with dtype torch.uint8, this behavior is now deprecated," \
+    TORCH_WARN("masked_fill_ received a mask with dtype torch.uint8, this behavior is now deprecated," \
             "please use a mask with dtype torch.bool instead.");
   }
 

--- a/aten/src/ATen/native/cuda/LegacyDefinitions.cpp
+++ b/aten/src/ATen/native/cuda/LegacyDefinitions.cpp
@@ -15,7 +15,7 @@ Tensor & masked_fill__cuda(Tensor& self, const Tensor & mask, Scalar value) {
   // As we dispatch on self and TH is type-checked, we need different definitions.
   // This can be fixed by moving to ATen.
   if (b_mask.dtype() == at::ScalarType::Byte) {
-    AT_WARN("masked_fill_ received a mask with dtype torch.uint8, this behavior is now deprecated," \
+    TORCH_WARN("masked_fill_ received a mask with dtype torch.uint8, this behavior is now deprecated," \
             "please use a mask with dtype torch.bool instead.");
     legacy::cuda::_th_masked_fill_(self, b_mask, value);
   } else {
@@ -35,7 +35,7 @@ Tensor & masked_fill__cuda(Tensor& self, const Tensor & mask, const Tensor & val
   // As we dispatch on self and TH is type-checked, we need different definitions.
   // This can be fixed by moving to ATen.
   if (b_mask.dtype() == at::ScalarType::Byte) {
-    AT_WARN("masked_fill_ received a mask with dtype torch.uint8, this behavior is now deprecated," \
+    TORCH_WARN("masked_fill_ received a mask with dtype torch.uint8, this behavior is now deprecated," \
             "please use a mask with dtype torch.bool instead.");
     legacy::cuda::_th_masked_fill_(self, b_mask, value.item());
   } else {
@@ -51,7 +51,7 @@ Tensor & masked_scatter__cuda(Tensor& self, const Tensor & mask, const Tensor & 
   // As we dispatch on self and TH is type-checked, we need different definitions.
   // This can be fixed by moving to ATen.
   if (b_mask.dtype() == at::ScalarType::Byte) {
-    AT_WARN("masked_scatter_ received a mask with dtype torch.uint8, this behavior is now deprecated," \
+    TORCH_WARN("masked_scatter_ received a mask with dtype torch.uint8, this behavior is now deprecated," \
             "please use a mask with dtype torch.bool instead.");
     return legacy::cuda::_th_masked_scatter_(self, b_mask, source);
   } else {
@@ -62,7 +62,7 @@ Tensor & masked_scatter__cuda(Tensor& self, const Tensor & mask, const Tensor & 
 Tensor masked_select_cuda(const Tensor & self, const Tensor & mask) {
   namedinference::compute_broadcast_outnames(self, mask);
   if (mask.dtype() == at::ScalarType::Byte) {
-    AT_WARN("masked_select received a mask with dtype torch.uint8, this behavior is now deprecated," \
+    TORCH_WARN("masked_select received a mask with dtype torch.uint8, this behavior is now deprecated," \
             "please use a mask with dtype torch.bool instead.");
     return legacy::cuda::_th_masked_select(self, mask);
   } else {

--- a/aten/src/ATen/native/cudnn/RNN.cpp
+++ b/aten/src/ATen/native/cudnn/RNN.cpp
@@ -1219,7 +1219,7 @@ Tensor try_get_weight_buf(
   return weight_buf;
 }
 
-const char * WEIGHT_FORMAT_WARN = "RNN module weights are not part of single contiguous "
+const char * WEIGHT_FORMTORCH_WARN = "RNN module weights are not part of single contiguous "
                                   "chunk of memory. This means they need to be compacted "
                                   "at every call, possibly greatly increasing memory usage. "
                                   "To compact weights again call flatten_parameters().";
@@ -1236,7 +1236,7 @@ std::pair<Tensor, hidden_type> _cudnn_impl(
   auto weight_buf = try_get_weight_buf(
       input, params, has_biases, mode, hidden_size, num_layers, bidirectional);
   if (!weight_buf.defined()) {
-    AT_WARN(WEIGHT_FORMAT_WARN);
+    TORCH_WARN(WEIGHT_FORMTORCH_WARN);
   }
 
   TORCH_CHECK(_batch_sizes.dim() == 1, "batch_sizes tensor should be 1D");
@@ -1266,7 +1266,7 @@ std::pair<Tensor, hidden_type> _cudnn_impl(
   auto weight_buf = try_get_weight_buf(
       input, params, has_biases, mode, hidden_size, num_layers, bidirectional);
   if (!weight_buf.defined()) {
-    AT_WARN(WEIGHT_FORMAT_WARN);
+    TORCH_WARN(WEIGHT_FORMTORCH_WARN);
   }
 
   auto & dropout_state = get_dropout_state(dropout_p, train, input.options());

--- a/c10/util/Exception.h
+++ b/c10/util/Exception.h
@@ -369,12 +369,6 @@ C10_DEPRECATED_MESSAGE("AT_INDEX_ERROR(msg) is deprecated, use TORCH_CHECK_INDEX
 */
 inline void deprecated_AT_INDEX_ERROR() {}
 
-/*
-// Deprecation disabled until we fix sites in our codebase
-C10_DEPRECATED_MESSAGE("AT_WARN is deprecated, use TORCH_WARN instead.")
-*/
-inline void deprecated_AT_WARN() {}
-
 C10_DEPRECATED_MESSAGE("AT_CHECK is deprecated, use TORCH_CHECK instead.")
 inline void deprecated_AT_CHECK() {}
 
@@ -444,15 +438,5 @@ inline void deprecated_AT_ASSERTM() {}
     ::c10::detail::deprecated_AT_INDEX_ERROR();                                     \
     C10_EXPAND_MSVC_WORKAROUND(TORCH_CHECK_INDEX(false, ::c10::str(__VA_ARGS__)));  \
   } while (false)
-
-// Deprecated alias; this alias was deprecated because it wasn't clear to
-// people that you should use a macro with AT_ prefix inside the torch/csrc
-// directory.  Use TORCH_WARN instead.
-#define AT_WARN(...)                                      \
-  do {                                                    \
-    ::c10::detail::deprecated_AT_WARN();                  \
-    C10_EXPAND_MSVC_WORKAROUND(TORCH_WARN(__VA_ARGS__));  \
-  } while (false)
-
 
 #endif // C10_UTIL_EXCEPTION_H_

--- a/torch/csrc/autograd/functions/comm.cpp
+++ b/torch/csrc/autograd/functions/comm.cpp
@@ -85,7 +85,7 @@ variable_list Gather::apply(variable_list&& inputs) {
 
   const bool unsqueeze_scalars = all_are_zero_dim && dim_ == 0;
   if (unsqueeze_scalars) {
-    AT_WARN(
+    TORCH_WARN(
         "Was asked to gather along dimension 0, but all "
         "input tensors were scalars; will instead unsqueeze "
         "and return a vector.");

--- a/torch/csrc/autograd/python_anomaly_mode.cpp
+++ b/torch/csrc/autograd/python_anomaly_mode.cpp
@@ -37,7 +37,7 @@ void PyAnomalyMetadata::print_stack(const std::string& current_node_name) {
   // PyDict_GetItemString returns a borrowed reference
   PyObject* stack(PyDict_GetItemString(dict(), ANOMALY_TRACE_KEY));
   if (!stack) {
-    AT_WARN("Error detected in ", current_node_name, ". ",
+    TORCH_WARN("Error detected in ", current_node_name, ". ",
             "No forward pass information available. Enable detect anomaly "
             "during forward pass for more information.");
     return;
@@ -55,7 +55,7 @@ void PyAnomalyMetadata::print_stack(const std::string& current_node_name) {
     throw python_error();
   }
 
-  AT_WARN("Error detected in ", current_node_name, ". ",
+  TORCH_WARN("Error detected in ", current_node_name, ". ",
           "Traceback of forward call that caused the error:\n",
           THPUtils_unpackString(msg.get()));
 }

--- a/torch/csrc/jit/api/compilation_unit.h
+++ b/torch/csrc/jit/api/compilation_unit.h
@@ -71,13 +71,13 @@ struct TORCH_API CompilationUnit {
   }
 
   void set_optimized(bool o) {
-    AT_WARN(
+    TORCH_WARN(
         "CompilationUnit::set_optimized() is deprecated and has no effect. "
         "Please use setGraphExecutorOptimize()");
   }
 
    bool is_optimized() const {
-    AT_WARN(
+    TORCH_WARN(
         "CompilationUnit::is_optimized() is deprecated and always returns true. "
         "Please use getGraphExecutorOptimize()");
     return true;

--- a/torch/csrc/jit/api/function_impl.h
+++ b/torch/csrc/jit/api/function_impl.h
@@ -76,7 +76,7 @@ struct TORCH_API GraphFunction : public Function {
   }
 
   bool is_optimized() const {
-    AT_WARN(
+    TORCH_WARN(
         "GraphFunction::is_optimized() is deprecated and always returns true. "
         "Please use getGraphExecutorOptimize()");
     return true;

--- a/torch/csrc/jit/api/module.h
+++ b/torch/csrc/jit/api/module.h
@@ -97,13 +97,13 @@ struct TORCH_API Module : public Object {
   ~Module() {}
 
   void set_optimized(bool o) {
-    AT_WARN(
+    TORCH_WARN(
         "Module::set_optimized() is deprecated and has no effect. "
         "Please use setGraphExecutorOptimize()");
   }
 
   bool is_optimized() const {
-    AT_WARN(
+    TORCH_WARN(
         "Module::is_optimized() is deprecated and always returns true. "
         "Please use getGraphExecutorOptimize()");
     return true;

--- a/torch/csrc/jit/frontend/tracer.cpp
+++ b/torch/csrc/jit/frontend/tracer.cpp
@@ -813,7 +813,7 @@ void setRecordSourceLocation(void (*v)(Node*)) {
 }
 
 void defaultWarn(const std::string& str) {
-  AT_WARN(str);
+  TORCH_WARN(str);
 }
 std::atomic<warn_fn_type> warn_callback{defaultWarn};
 

--- a/torch/csrc/jit/mobile/interpreter.cpp
+++ b/torch/csrc/jit/mobile/interpreter.cpp
@@ -141,7 +141,7 @@ bool InterpreterState::run(Stack& stack) {
       } break;
       case WARN: {
         drop(stack, 1);
-        AT_WARN(pop(stack).toStringRef());
+        TORCH_WARN(pop(stack).toStringRef());
         ++pc;
       } break;
       default:

--- a/torch/csrc/jit/runtime/interpreter.cpp
+++ b/torch/csrc/jit/runtime/interpreter.cpp
@@ -1292,7 +1292,7 @@ struct InterpreterStateImpl : c10::intrusive_ptr_target {
                   "", range->filename()->c_str(), uint32_t(line)};
               c10::Warning::warn(location, pop(stack).toStringRef());
             } else {
-              AT_WARN(pop(stack).toStringRef());
+              TORCH_WARN(pop(stack).toStringRef());
             }
             ++af.pc;
           } break;

--- a/torch/csrc/jit/runtime/register_prim_ops.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops.cpp
@@ -3218,7 +3218,7 @@ at::Tensor interpolate(
     }
   } else {
     if (align_corners == c10::nullopt) {
-      AT_WARN(
+      TORCH_WARN(
           "Default upsampling behavior when mode=",
           mode,
           " is changed "
@@ -3256,7 +3256,7 @@ at::Tensor interpolate(
     }
 
     if(warn_recompute_scale_factor) {
-      AT_WARN(
+      TORCH_WARN(
         "The default behavior for interpolate/upsample with float scale_factor will change "
         "in 1.5.0 to align with other frameworks/libraries, and use scale_factor directly, "
         "instead of relying on the computed output size. "

--- a/torch/csrc/jit/runtime/register_special_ops.cpp
+++ b/torch/csrc/jit/runtime/register_special_ops.cpp
@@ -169,7 +169,7 @@ int createTensorFromList(Stack& stack) {
 
     if (dtype.isNone() && tensor.scalar_type() != default_type &&
         tensor.numel() == 0) {
-      AT_WARN(
+      TORCH_WARN(
           "Creating a tensor from an empty ",
           elem_type->python_str(),
           "list will create a tensor of default floating point type  (currently ",

--- a/torch/csrc/jit/runtime/vararg_functions.cpp
+++ b/torch/csrc/jit/runtime/vararg_functions.cpp
@@ -18,7 +18,7 @@ void format(Stack& stack, size_t num_inputs) {
   // // "StdRegexIsAwful" internal Lint error, to prevent sev
   // // of std::regex from PT mobile.
   // if (std::regex_search(format, unsupported_options)) {
-  //   AT_WARN("Format options are not supported.");
+  //   TORCH_WARN("Format options are not supported.");
   // }
 
   auto args = last(stack, num_inputs - 1);

--- a/torch/csrc/jit/serialization/export.cpp
+++ b/torch/csrc/jit/serialization/export.cpp
@@ -602,7 +602,7 @@ GraphEncoder::GraphEncoder(
 
   for (auto const& custom_opset : custom_opsets){
     if (!std::count(domains_.begin(), domains_.end(), custom_opset.first)) {
-      AT_WARN("Custom opset domain: '", custom_opset.first, "' provided is not used in the model. ",
+      TORCH_WARN("Custom opset domain: '", custom_opset.first, "' provided is not used in the model. ",
       "Please verify custom opset domain names.");
     }
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#34623 Delete AT_WARN and replace all AT_WARN with TORCH_WARN**

The bandaid of "AT_WARN" keeps introducing new warnings. Let's get rid
of it entirely.

Close #34502

Differential Revision: [D20420112](https://our.internmc.facebook.com/intern/diff/D20420112)