### PR TITLE
[pytorch-rpc] WireSerializer should check has_storage()

### DIFF
--- a/test/cpp/rpc/test_wire_serialization.cpp
+++ b/test/cpp/rpc/test_wire_serialization.cpp
@@ -49,3 +49,12 @@ TEST(WireSerialize, RecopySparseTensors) {
   EXPECT_TRUE(torch::equal(tiny, deser.second[0]));
   EXPECT_LT(ser.size(), (tiny.element_size() * k1K) + k1K);
 }
+
+// Enable this once JIT Pickler supports sparse tensors.
+TEST(WireSerialize, DISABLED_Sparse) {
+  at::Tensor main =
+      at::empty({2, 3}, at::dtype<float>().layout(at::kSparse));
+  auto ser = torch::distributed::rpc::wireSerialize({}, {main.to(at::kSparse)});
+  auto deser = torch::distributed::rpc::wireDeserialize(ser.data(), ser.size());
+  EXPECT_TRUE(torch::equal(main, deser.second[0]));
+}

--- a/test/cpp/rpc/test_wire_serialization.cpp
+++ b/test/cpp/rpc/test_wire_serialization.cpp
@@ -50,6 +50,24 @@ TEST(WireSerialize, RecopySparseTensors) {
   EXPECT_LT(ser.size(), (tiny.element_size() * k1K) + k1K);
 }
 
+TEST(WireSerialize, CloneSparseTensors) {
+  constexpr size_t k1K = 1024;
+  at::Tensor big = torch::randn({k1K, k1K});
+  auto v1 = torch::distributed::rpc::cloneSparseTensors({big});
+  EXPECT_EQ(v1.get(0).storage(), big.storage()); // Not cloned
+
+  at::Tensor tiny = big.select(0, 2); // Select a row in the middle
+  auto v2 = torch::distributed::rpc::cloneSparseTensors({tiny});
+  EXPECT_NE(&v2.get(0).storage(), &tiny.storage()); // Cloned.
+  EXPECT_TRUE(torch::equal(v2.get(0), tiny));
+
+  at::Tensor sparse =
+      at::empty({2, 3}, at::dtype<float>().layout(at::kSparse));
+  auto v3 = torch::distributed::rpc::cloneSparseTensors({sparse});
+  // There is no storage() to compare, but at least confirm equality.
+  EXPECT_TRUE(v3.get(0).is_same(sparse));
+}
+
 // Enable this once JIT Pickler supports sparse tensors.
 TEST(WireSerialize, DISABLED_Sparse) {
   at::Tensor main =

--- a/torch/csrc/distributed/rpc/utils.cpp
+++ b/torch/csrc/distributed/rpc/utils.cpp
@@ -220,6 +220,9 @@ c10::List<at::Tensor> cloneSparseTensors(
   // force a clone(). Some Tensors are effectively small views, only using
   // ~1% of the underlying Storage.
   auto worthRecopying = [](const at::Tensor& t) -> bool {
+    if (!t.has_storage()) {
+      return false;  // avoid throwing below.
+    }
     auto storageSize = t.storage().elementSize() * t.storage().numel();
     auto usefulSize = t.element_size() * t.numel();
     constexpr size_t kMinMultiple = 2;

--- a/torch/csrc/distributed/rpc/utils.cpp
+++ b/torch/csrc/distributed/rpc/utils.cpp
@@ -221,7 +221,7 @@ c10::List<at::Tensor> cloneSparseTensors(
   // ~1% of the underlying Storage.
   auto worthRecopying = [](const at::Tensor& t) -> bool {
     if (!t.has_storage()) {
-      return false;  // avoid throwing below.
+      return false; // avoid throwing below.
     }
     auto storageSize = t.storage().elementSize() * t.storage().numel();
     auto usefulSize = t.element_size() * t.numel();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#34626 [pytorch-rpc] WireSerializer should check has_storage()**

We need to check has_storage() before looking at it in
cloneSparseTensors(), to avoid gratuitously throwing.

Add some basic test coverage (though some work work until
Pickler supports sparse tensors)

Differential Revision: [D20399971](https://our.internmc.facebook.com/intern/diff/D20399971/)