### PR TITLE
enable testing bailouts on nightly

### DIFF
--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -150,6 +150,11 @@ test_python_ge_config_legacy() {
   assert_git_not_dirty
 }
 
+test_python_ge_config_bailouts() {
+  time python test_jit_bailouts.py --verbose
+  assert_git_not_dirty
+}
+
 test_python_all_except_nn() {
   time python test/run_test.py --exclude test_nn test_jit_simple test_jit_legacy test_jit_fuser_legacy --verbose --bring-to-front test_quantization test_quantized test_quantized_tensor test_quantized_nn_mods --determine-from="$DETERMINE_FROM"
   assert_git_not_dirty
@@ -283,4 +288,7 @@ else
   test_aten
   test_libtorch
   test_custom_script_ops
+  if [[ "${BUILD_ENVIRONMENT}" == *pynightly_test* ]]; then
+    test_python_ge_config_bailouts
+  fi
 fi

--- a/test/test_jit_bailouts.py
+++ b/test/test_jit_bailouts.py
@@ -1,0 +1,10 @@
+import sys
+sys.argv.append("--test_bailouts")
+from test_jit import *
+
+if __name__ == '__main__':
+    run_tests()
+    if not PY2:
+        import test_jit_py3
+        suite = unittest.findTestCases(test_jit_py3)
+        unittest.TextTestRunner().run(suite)


### PR DESCRIPTION
Bailouts are an integral part of profiling executor that trigger when we are seeing inputs whose properties (e.g. shape, requires_grad) violate assumptions (based on profiling information) used for optimizing a graph.
Most of our tests don't trigger bailouts as we use the same inputs, this PR will run add a special mode to our nightly that stress-tests every bailout we insert for anything that's being tested with `checkScript`. I want to enable this in our nightly only so we don't overburden our CI too much. The first part of this change is in https://github.com/pytorch/pytorch/pull/32802