### PR TITLE
[ROCm] Enable BFloat16 type for EmbeddingBag ops et al

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -129,6 +129,7 @@
 [[
   name: _th_index_select
   cuda_bool: True
+  cuda_bfloat16: True
   cname: indexSelect
   variants:
     - function

--- a/aten/src/ATen/native/cuda/BinaryMiscBackwardOpsKernels.cu
+++ b/aten/src/ATen/native/cuda/BinaryMiscBackwardOpsKernels.cu
@@ -10,9 +10,11 @@
 namespace at { namespace native {
 
 void sigmoid_backward_kernel_cuda(TensorIterator& iter) {
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(iter.dtype(), "sigmoid_backward_cuda", [&]() {
-    gpu_kernel(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
-      return a * (scalar_t(1.) - b) * b;
+  AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, iter.dtype(), "sigmoid_backward_cuda", [&]() {
+    AT_SKIP_BFLOAT16_IF_NOT_ROCM(scalar_t, "sigmoid_backward_cuda", [&] {
+      gpu_kernel(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
+        return a * (scalar_t(1.) - b) * b;
+      });
     });
   });
 }

--- a/aten/src/ATen/native/cuda/CompareEQKernel.cu
+++ b/aten/src/ATen/native/cuda/CompareEQKernel.cu
@@ -12,10 +12,12 @@
 namespace at { namespace native {
 
 void eq_kernel_cuda(TensorIterator& iter) {
-  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(kHalf, kBool, iter.common_dtype(), "eq_cuda", [&]() {
-    using thrust_t = typename ztype_cuda<scalar_t>::thrust_t;
-    gpu_kernel_with_scalars(iter, []GPU_LAMBDA(thrust_t a, thrust_t b) -> bool {
-      return a == b;
+  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(kHalf, kBFloat16, kBool, iter.common_dtype(), "eq_cuda", [&]() {
+    AT_SKIP_BFLOAT16_IF_NOT_ROCM(scalar_t, "eq_cuda", [&] {
+      using thrust_t = typename ztype_cuda<scalar_t>::thrust_t;
+      gpu_kernel_with_scalars(iter, []GPU_LAMBDA(thrust_t a, thrust_t b) -> bool {
+        return a == b;
+      });
     });
   });
 }

--- a/aten/src/ATen/native/cuda/CompareGEKernel.cu
+++ b/aten/src/ATen/native/cuda/CompareGEKernel.cu
@@ -11,9 +11,11 @@
 namespace at { namespace native {
 
 void ge_kernel_cuda(TensorIterator& iter) {
-  AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBool, iter.common_dtype(), "ge_cuda", [&]() {
-    gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> bool {
-      return a >= b;
+  AT_DISPATCH_ALL_TYPES_AND3(kHalf, kBFloat16, kBool, iter.common_dtype(), "ge_cuda", [&]() {
+    AT_SKIP_BFLOAT16_IF_NOT_ROCM(scalar_t, "ge_cuda", [&] {
+      gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> bool {
+        return a >= b;
+      });
     });
   });
 }

--- a/aten/src/ATen/native/cuda/CompareGTKernel.cu
+++ b/aten/src/ATen/native/cuda/CompareGTKernel.cu
@@ -11,9 +11,11 @@
 namespace at { namespace native {
 
 void gt_kernel_cuda(TensorIterator& iter) {
-  AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBool, iter.common_dtype(), "gt_cuda", [&]() {
-    gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> bool {
-      return a > b;
+  AT_DISPATCH_ALL_TYPES_AND3(kHalf, kBFloat16, kBool, iter.common_dtype(), "gt_cuda", [&]() {
+    AT_SKIP_BFLOAT16_IF_NOT_ROCM(scalar_t, "gt_cuda", [&] {
+      gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> bool {
+        return a > b;
+      });
     });
   });
 }

--- a/aten/src/ATen/native/cuda/CompareLEKernel.cu
+++ b/aten/src/ATen/native/cuda/CompareLEKernel.cu
@@ -11,9 +11,11 @@
 namespace at { namespace native {
 
 void le_kernel_cuda(TensorIterator& iter) {
-  AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBool, iter.common_dtype(), "le_cuda", [&]() {
-    gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> bool {
-      return a <= b;
+  AT_DISPATCH_ALL_TYPES_AND3(kHalf, kBFloat16, kBool, iter.common_dtype(), "le_cuda", [&]() {
+    AT_SKIP_BFLOAT16_IF_NOT_ROCM(scalar_t, "le_cuda", [&] {
+      gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> bool {
+        return a <= b;
+      });
     });
   });
 }

--- a/aten/src/ATen/native/cuda/CompareLTKernel.cu
+++ b/aten/src/ATen/native/cuda/CompareLTKernel.cu
@@ -11,9 +11,11 @@
 namespace at { namespace native {
 
 void lt_kernel_cuda(TensorIterator& iter) {
-  AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBool, iter.common_dtype(), "lt_cuda", [&]() {
-    gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> bool {
-      return a < b;
+  AT_DISPATCH_ALL_TYPES_AND3(kHalf, kBFloat16, kBool, iter.common_dtype(), "lt_cuda", [&]() {
+    AT_SKIP_BFLOAT16_IF_NOT_ROCM(scalar_t, "lt_cuda", [&] {
+      gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> bool {
+        return a < b;
+      });
     });
   });
 }

--- a/aten/src/ATen/native/cuda/CompareNEKernel.cu
+++ b/aten/src/ATen/native/cuda/CompareNEKernel.cu
@@ -12,10 +12,12 @@
 namespace at { namespace native {
 
 void ne_kernel_cuda(TensorIterator& iter) {
-  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(kHalf, kBool, iter.common_dtype(), "ne_cuda", [&]() {
-    using thrust_t = typename ztype_cuda<scalar_t>::thrust_t;
-    gpu_kernel_with_scalars(iter, []GPU_LAMBDA(thrust_t a, thrust_t b) -> bool {
-      return a != b;
+  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(kHalf, kBFloat16, kBool, iter.common_dtype(), "ne_cuda", [&]() {
+    AT_SKIP_BFLOAT16_IF_NOT_ROCM(scalar_t, "ne_cuda", [&] {
+      using thrust_t = typename ztype_cuda<scalar_t>::thrust_t;
+      gpu_kernel_with_scalars(iter, []GPU_LAMBDA(thrust_t a, thrust_t b) -> bool {
+        return a != b;
+      });
     });
   });
 }

--- a/aten/src/ATen/native/cuda/Embedding.cu
+++ b/aten/src/ATen/native/cuda/Embedding.cu
@@ -242,23 +242,26 @@ Tensor embedding_dense_backward_cuda(const Tensor & grad_, const Tensor & indice
     dim3 grid(THCCeilDiv(stride, (int64_t)C10_WARP_SIZE));
     dim3 block(C10_WARP_SIZE, BLOCKDIMY);
 
-    AT_DISPATCH_FLOATING_TYPES_AND_HALF
-      (grad.scalar_type(),
+    AT_DISPATCH_FLOATING_TYPES_AND2(
+      at::ScalarType::Half, at::ScalarType::BFloat16,
+      grad.scalar_type(),
        "embedding_backward",
        [&]
        {
-         using accscalar_t = acc_type<scalar_t, true>;
-         embedding_backward_feature_kernel<scalar_t, accscalar_t>
-           <<<grid,
-              block,
-              sizeof(accscalar_t)*C10_WARP_SIZE*BLOCKDIMY + sizeof(int)*C10_WARP_SIZE*BLOCKDIMY,
-              stream>>>
-           (indices_contig.data_ptr<int64_t>(),
-            grad.data_ptr<scalar_t>(),
-            grad_weight.data_ptr<scalar_t>(),
-            static_cast<int>(num_indices),
-            static_cast<int64_t>(stride),
-            static_cast<int>(padding_idx));
+         AT_SKIP_BFLOAT16_IF_NOT_ROCM(scalar_t, "embedding_backward", [&] {
+           using accscalar_t = acc_type<scalar_t, true>;
+           embedding_backward_feature_kernel<scalar_t, accscalar_t>
+             <<<grid,
+                block,
+                sizeof(accscalar_t)*C10_WARP_SIZE*BLOCKDIMY + sizeof(int)*C10_WARP_SIZE*BLOCKDIMY,
+                stream>>>
+             (indices_contig.data_ptr<int64_t>(),
+              grad.data_ptr<scalar_t>(),
+              grad_weight.data_ptr<scalar_t>(),
+              static_cast<int>(num_indices),
+              static_cast<int64_t>(stride),
+              static_cast<int>(padding_idx));
+         });
        });
 
     THCudaCheck(cudaGetLastError());
@@ -356,14 +359,16 @@ Tensor & embedding_renorm_cuda_(Tensor & self, const Tensor & indices,
   dim3 block(128);
   int dim = self.stride(0);
 
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(self.scalar_type(), "embedding_backward", [&] {
-    using accscalar_t = acc_type<scalar_t, true>;
-    renorm_kernel<<<grid, block, 128 * sizeof(accscalar_t), stream>>>(
-      self.data_ptr<scalar_t>(),
-      unique_indices.data_ptr<int64_t>(),
-      static_cast<accscalar_t>(max_norm),
-      static_cast<accscalar_t>(norm_type),
-      dim, self.stride(0), self.stride(1));
+  AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, self.scalar_type(), "embedding_backward", [&] {
+    AT_SKIP_BFLOAT16_IF_NOT_ROCM(scalar_t, "embedding_backward", [&] {
+      using accscalar_t = acc_type<scalar_t, true>;
+      renorm_kernel<<<grid, block, 128 * sizeof(accscalar_t), stream>>>(
+        self.data_ptr<scalar_t>(),
+        unique_indices.data_ptr<int64_t>(),
+        static_cast<accscalar_t>(max_norm),
+        static_cast<accscalar_t>(norm_type),
+        dim, self.stride(0), self.stride(1));
+    });
   });
   THCudaCheck(cudaGetLastError());
 

--- a/aten/src/ATen/native/cuda/EmbeddingBag.cu
+++ b/aten/src/ATen/native/cuda/EmbeddingBag.cu
@@ -299,15 +299,17 @@ _embedding_bag_cuda(const Tensor &weight, const Tensor &indices,
   dim3 block = dim3(32, 8);
 #endif
   int grid = 1024;
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(weight.scalar_type(), "embedding_bag_cuda", [&] {
-    EmbeddingBag_updateOutputKernel<scalar_t><<<grid, block, 0, stream>>>(
-        indices.data_ptr<int64_t>(), offsets.data_ptr<int64_t>(),
-        weight.data_ptr<scalar_t>(), output.data_ptr<scalar_t>(),
-        offset2bag.data_ptr<int64_t>(), numIndices, numBags, featureSize,
-        weight.stride(0), weight.stride(1), mode, bag_size.data_ptr<int64_t>(),
-        mode == MODE_MAX ? max_indices.data_ptr<int64_t>() : NULL,
-        per_sample_weights.defined() ? per_sample_weights.data_ptr<scalar_t>() : NULL,
-        per_sample_weights.defined() ? per_sample_weights.stride(0) : 0);
+  AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, weight.scalar_type(), "embedding_bag_cuda", [&] {
+    AT_SKIP_BFLOAT16_IF_NOT_ROCM(scalar_t, "embedding_bag_cuda", [&] {
+      EmbeddingBag_updateOutputKernel<scalar_t><<<grid, block, 0, stream>>>(
+          indices.data_ptr<int64_t>(), offsets.data_ptr<int64_t>(),
+          weight.data_ptr<scalar_t>(), output.data_ptr<scalar_t>(),
+          offset2bag.data_ptr<int64_t>(), numIndices, numBags, featureSize,
+          weight.stride(0), weight.stride(1), mode, bag_size.data_ptr<int64_t>(),
+          mode == MODE_MAX ? max_indices.data_ptr<int64_t>() : NULL,
+          per_sample_weights.defined() ? per_sample_weights.data_ptr<scalar_t>() : NULL,
+          per_sample_weights.defined() ? per_sample_weights.stride(0) : 0);
+    });
   });
 
   THCudaCheck(cudaGetLastError());

--- a/aten/src/ATen/native/cuda/Indexing.cu
+++ b/aten/src/ATen/native/cuda/Indexing.cu
@@ -225,8 +225,9 @@ void index_put_accum_kernel(Tensor & self, TensorList indices, const Tensor & va
            std::min(std::max<int>(1,nElemBefore), at::cuda::getCurrentDeviceProperties()->maxGridSize[2]));
       dim3 block(C10_WARP_SIZE, indices_per_block);
 
-      AT_DISPATCH_ALL_TYPES_AND2(at::ScalarType::Half, at::ScalarType::Bool,
+      AT_DISPATCH_ALL_TYPES_AND3(at::ScalarType::Half, at::ScalarType::Bool, at::ScalarType::BFloat16,
       value_.scalar_type(), "indexing_backward", [&] {
+      AT_SKIP_BFLOAT16_IF_NOT_ROCM(scalar_t, "indeing_backward", [&] {
       indexing_backward_kernel<scalar_t, UNROLL><<<grid, block, 0, stream>>>(
         sorted_indices.data_ptr<int64_t>(),
         orig_indices.data_ptr<int64_t>(),
@@ -236,6 +237,7 @@ void index_put_accum_kernel(Tensor & self, TensorList indices, const Tensor & va
         sliceSize,
         strideBefore,
         nElemBefore);
+      });
       });
       THCudaCheck(cudaGetLastError());
       if (permuted)
@@ -487,72 +489,76 @@ Tensor& index_add_cuda_(Tensor & self, int64_t dim, const Tensor & index, const 
   if (cuda::detail::canUse32BitIndexMath(self) &&
       cuda::detail::canUse32BitIndexMath(source) &&
       cuda::detail::canUse32BitIndexMath(index)) {
-    AT_DISPATCH_ALL_TYPES_AND(at::ScalarType::Half, self.scalar_type(), "index_add", [&] {
-      cuda::detail::TensorInfo<scalar_t, unsigned int> selfInfo =
-          cuda::detail::getTensorInfo<scalar_t, unsigned int>(self_);
-      int selfAddDim = selfInfo.collapseDims(dim);
-      selfInfo.reduceDim(selfAddDim);
+    AT_DISPATCH_ALL_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, self.scalar_type(), "index_add", [&] {
+      AT_SKIP_BFLOAT16_IF_NOT_ROCM(scalar_t, "index_add", [&] {
+        cuda::detail::TensorInfo<scalar_t, unsigned int> selfInfo =
+            cuda::detail::getTensorInfo<scalar_t, unsigned int>(self_);
+        int selfAddDim = selfInfo.collapseDims(dim);
+        selfInfo.reduceDim(selfAddDim);
 
-      auto sourceInfo =
-        cuda::detail::getTensorInfo<scalar_t, unsigned int>(source_);
-      int sourceAddDim = sourceInfo.collapseDims(dim);
-      sourceInfo.reduceDim(sourceAddDim);
+        auto sourceInfo =
+          cuda::detail::getTensorInfo<scalar_t, unsigned int>(source_);
+        int sourceAddDim = sourceInfo.collapseDims(dim);
+        sourceInfo.reduceDim(sourceAddDim);
 
-      auto indexInfo =
-       cuda::detail::getTensorInfo<int64_t, unsigned int>(index);
-      indexInfo.collapseDims();
+        auto indexInfo =
+         cuda::detail::getTensorInfo<int64_t, unsigned int>(index);
+        indexInfo.collapseDims();
 
-      // A reasonable choice for when to have each thread iterate over
-      // index to choose
-      if (numIndex <= 16) {
-        if (selfInfo.dims == 1 && sourceInfo.dims == 1 && indContig) {
-          SMALL_INDEX(scalar_t, unsigned int, 1, 1, -2);
-        } else if (selfInfo.dims == 2 && sourceInfo.dims == 2 && indContig) {
-          SMALL_INDEX(scalar_t, unsigned int, 2, 2, -2);
-        } else if (selfInfo.dims == 3 && sourceInfo.dims == 3 && indContig) {
-          SMALL_INDEX(scalar_t, unsigned int, 3, 3, -2);
-        } else {
-          SMALL_INDEX(scalar_t, unsigned int, -1, -1, -1);
-        }
-      } else {
-        bool indexIsMajor = indexShouldBeMajor(selfInfo, selfAddDim);
-
-        if (selfInfo.dims == 1 && sourceInfo.dims == 1 && indContig) {
-          LARGE_INDEX(scalar_t, unsigned int, 1, 1, -2, true);
-        } else if (selfInfo.dims == 2 && sourceInfo.dims == 2 && indContig) {
-          if (indexIsMajor) {
-            LARGE_INDEX(scalar_t, unsigned int, 2, 2, -2, true);
+        // A reasonable choice for when to have each thread iterate over
+        // index to choose
+        if (numIndex <= 16) {
+          if (selfInfo.dims == 1 && sourceInfo.dims == 1 && indContig) {
+            SMALL_INDEX(scalar_t, unsigned int, 1, 1, -2);
+          } else if (selfInfo.dims == 2 && sourceInfo.dims == 2 && indContig) {
+            SMALL_INDEX(scalar_t, unsigned int, 2, 2, -2);
+          } else if (selfInfo.dims == 3 && sourceInfo.dims == 3 && indContig) {
+            SMALL_INDEX(scalar_t, unsigned int, 3, 3, -2);
           } else {
-            LARGE_INDEX(scalar_t, unsigned int, 2, 2, -2, false);
-          }
-        } else if (selfInfo.dims == 3 && sourceInfo.dims == 3 && indContig) {
-          if (indexIsMajor) {
-            LARGE_INDEX(scalar_t, unsigned int, 3, 3, -2, true);
-          } else {
-            LARGE_INDEX(scalar_t, unsigned int, 3, 3, -2, false);
+            SMALL_INDEX(scalar_t, unsigned int, -1, -1, -1);
           }
         } else {
-          LARGE_INDEX(scalar_t, unsigned int, -1, -1, -1, true);
+          bool indexIsMajor = indexShouldBeMajor(selfInfo, selfAddDim);
+
+          if (selfInfo.dims == 1 && sourceInfo.dims == 1 && indContig) {
+            LARGE_INDEX(scalar_t, unsigned int, 1, 1, -2, true);
+          } else if (selfInfo.dims == 2 && sourceInfo.dims == 2 && indContig) {
+            if (indexIsMajor) {
+              LARGE_INDEX(scalar_t, unsigned int, 2, 2, -2, true);
+            } else {
+              LARGE_INDEX(scalar_t, unsigned int, 2, 2, -2, false);
+            }
+          } else if (selfInfo.dims == 3 && sourceInfo.dims == 3 && indContig) {
+            if (indexIsMajor) {
+              LARGE_INDEX(scalar_t, unsigned int, 3, 3, -2, true);
+            } else {
+              LARGE_INDEX(scalar_t, unsigned int, 3, 3, -2, false);
+            }
+          } else {
+            LARGE_INDEX(scalar_t, unsigned int, -1, -1, -1, true);
+          }
         }
-      }
+      });
     });
   } else {
-    AT_DISPATCH_ALL_TYPES_AND(at::ScalarType::Half, self.scalar_type(), "index_add", [&] {
-      cuda::detail::TensorInfo<scalar_t, uint64_t> selfInfo =
-        cuda::detail::getTensorInfo<scalar_t, uint64_t>(self_);
-      int selfAddDim = selfInfo.collapseDims(dim);
-      selfInfo.reduceDim(selfAddDim);
+    AT_DISPATCH_ALL_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, self.scalar_type(), "index_add", [&] {
+      AT_SKIP_BFLOAT16_IF_NOT_ROCM(scalar_t, "index_add", [&] {
+        cuda::detail::TensorInfo<scalar_t, uint64_t> selfInfo =
+          cuda::detail::getTensorInfo<scalar_t, uint64_t>(self_);
+        int selfAddDim = selfInfo.collapseDims(dim);
+        selfInfo.reduceDim(selfAddDim);
 
-      cuda::detail::TensorInfo<scalar_t, uint64_t> sourceInfo =
-        cuda::detail::getTensorInfo<scalar_t, uint64_t>(source_);
-      int sourceAddDim = sourceInfo.collapseDims(dim);
-      sourceInfo.reduceDim(sourceAddDim);
+        cuda::detail::TensorInfo<scalar_t, uint64_t> sourceInfo =
+          cuda::detail::getTensorInfo<scalar_t, uint64_t>(source_);
+        int sourceAddDim = sourceInfo.collapseDims(dim);
+        sourceInfo.reduceDim(sourceAddDim);
 
-      cuda::detail::TensorInfo<int64_t, uint64_t> indexInfo =
-        cuda::detail::getTensorInfo<int64_t, uint64_t>(index);
-      indexInfo.collapseDims();
+        cuda::detail::TensorInfo<int64_t, uint64_t> indexInfo =
+          cuda::detail::getTensorInfo<int64_t, uint64_t>(index);
+        indexInfo.collapseDims();
 
-      LARGE_INDEX(scalar_t, uint64_t, -1, -1, -1, true);
+        LARGE_INDEX(scalar_t, uint64_t, -1, -1, -1, true);
+      });
     });
   }
 

--- a/aten/src/ATen/native/cuda/Indexing.cu
+++ b/aten/src/ATen/native/cuda/Indexing.cu
@@ -227,7 +227,7 @@ void index_put_accum_kernel(Tensor & self, TensorList indices, const Tensor & va
 
       AT_DISPATCH_ALL_TYPES_AND3(at::ScalarType::Half, at::ScalarType::Bool, at::ScalarType::BFloat16,
       value_.scalar_type(), "indexing_backward", [&] {
-      AT_SKIP_BFLOAT16_IF_NOT_ROCM(scalar_t, "indeing_backward", [&] {
+      AT_SKIP_BFLOAT16_IF_NOT_ROCM(scalar_t, "indexing_backward", [&] {
       indexing_backward_kernel<scalar_t, UNROLL><<<grid, block, 0, stream>>>(
         sorted_indices.data_ptr<int64_t>(),
         orig_indices.data_ptr<int64_t>(),

--- a/aten/src/ATen/native/cuda/RangeFactories.cu
+++ b/aten/src/ATen/native/cuda/RangeFactories.cu
@@ -179,62 +179,63 @@ Tensor& range_cuda_out(Tensor& result, Scalar start, Scalar end, Scalar step) {
 }
 
 Tensor& arange_cuda_out(Tensor& result, Scalar start, Scalar end, Scalar step) {
-  AT_DISPATCH_ALL_TYPES_AND(at::ScalarType::Half, result.scalar_type(), "arange_cuda", [&]() {
-    using accscalar_t = at::acc_type<scalar_t, true>;
-    auto xstart = start.to<accscalar_t>();
-    auto xend = end.to<accscalar_t>();
-    auto xstep = step.to<accscalar_t>();
+  AT_DISPATCH_ALL_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, result.scalar_type(), "arange_cuda", [&]() {
+    AT_SKIP_BFLOAT16_IF_NOT_ROCM(scalar_t, "arange_cuda", [&] {
+      using accscalar_t = at::acc_type<scalar_t, true>;
+      auto xstart = start.to<accscalar_t>();
+      auto xend = end.to<accscalar_t>();
+      auto xstep = step.to<accscalar_t>();
 
-    // we use double precision for (start - end) / step
-    // to compute size_d for consistency across devices.
-    // The problem with using accscalar_t is that accscalar_t might be float32 on gpu for a float32 scalar_t,
-    // but double on cpu for the same,
-    // and the effective output size starts differing on CPU vs GPU because of precision issues, which
-    // we dont want.
-    // the corner-case we do want to take into account is int64_t, which has higher precision than double
-    double size_d;
-    if (std::is_same<scalar_t, int64_t>::value) {
-      size_d = std::ceil(static_cast<double>(end.to<accscalar_t>() - start.to<accscalar_t>())
-                         / step.to<accscalar_t>());
-    } else {
-      size_d = std::ceil(static_cast<double>(end.to<double>() - start.to<double>())
-                         / step.to<double>());
-    }
-
-    TORCH_CHECK(xstep > 0 || xstep < 0, "step must be nonzero");
-    TORCH_CHECK(std::isfinite(static_cast<double>(xstart)) &&
-             std::isfinite(static_cast<double>(xend)),
-             "unsupported range: ", xstart, " -> ", xend);
-    TORCH_CHECK(((xstep > 0) && (xend >= xstart)) || ((xstep < 0) && (xend <= xstart)),
-             "upper bound and larger bound inconsistent with step sign");
-
-    TORCH_CHECK(size_d >= 0 && size_d <= static_cast<double>(std::numeric_limits<int64_t>::max()),
-             "invalid size, possible overflow?");
-    int64_t size = static_cast<int64_t>(size_d);
-    int64_t numel = result.numel();
-
-    if (numel != size) {
-      if(numel > 0){
-        TORCH_WARN("The number of elements in the out tensor of shape ", result.sizes(),
-                    " is ", numel, " which does not match the computed number of elements ", size,
-                    ". Note that this may occur as a result of rounding error. "
-                    "The out tensor will be resized to a tensor of shape (", size, ",).");
+      // we use double precision for (start - end) / step
+      // to compute size_d for consistency across devices.
+      // The problem with using accscalar_t is that accscalar_t might be float32 on gpu for a float32 scalar_t,
+      // but double on cpu for the same,
+      // and the effective output size starts differing on CPU vs GPU because of precision issues, which
+      // we dont want.
+      // the corner-case we do want to take into account is int64_t, which has higher precision than double
+      double size_d;
+      if (std::is_same<scalar_t, int64_t>::value) {
+        size_d = std::ceil(static_cast<double>(end.to<accscalar_t>() - start.to<accscalar_t>())
+                           / step.to<accscalar_t>());
+      } else {
+        size_d = std::ceil(static_cast<double>(end.to<double>() - start.to<double>())
+                           / step.to<double>());
       }
-      result.resize_({size});
-    }
-    bool is_contiguous = result.is_contiguous();
-    Tensor r = !is_contiguous ? at::empty_like(result, LEGACY_CONTIGUOUS_MEMORY_FORMAT) : result;
 
-    gpu_kernel_with_index(r, [xstart, xstep]GPU_LAMBDA(int64_t ind) -> scalar_t {
-        accscalar_t inc = xstep * static_cast<accscalar_t>(ind);
-        accscalar_t val = xstart + inc;
-        return static_cast<scalar_t>(val);
+      TORCH_CHECK(xstep > 0 || xstep < 0, "step must be nonzero");
+      TORCH_CHECK(std::isfinite(static_cast<double>(xstart)) &&
+               std::isfinite(static_cast<double>(xend)),
+               "unsupported range: ", xstart, " -> ", xend);
+      TORCH_CHECK(((xstep > 0) && (xend >= xstart)) || ((xstep < 0) && (xend <= xstart)),
+               "upper bound and larger bound inconsistent with step sign");
+
+      TORCH_CHECK(size_d >= 0 && size_d <= static_cast<double>(std::numeric_limits<int64_t>::max()),
+               "invalid size, possible overflow?");
+      int64_t size = static_cast<int64_t>(size_d);
+      int64_t numel = result.numel();
+
+      if (numel != size) {
+        if(numel > 0){
+          TORCH_WARN("The number of elements in the out tensor of shape ", result.sizes(),
+                      " is ", numel, " which does not match the computed number of elements ", size,
+                      ". Note that this may occur as a result of rounding error. "
+                      "The out tensor will be resized to a tensor of shape (", size, ",).");
+        }
+        result.resize_({size});
+      }
+      bool is_contiguous = result.is_contiguous();
+      Tensor r = !is_contiguous ? at::empty_like(result, LEGACY_CONTIGUOUS_MEMORY_FORMAT) : result;
+
+      gpu_kernel_with_index(r, [xstart, xstep]GPU_LAMBDA(int64_t ind) -> scalar_t {
+          accscalar_t inc = xstep * static_cast<accscalar_t>(ind);
+          accscalar_t val = xstart + inc;
+          return static_cast<scalar_t>(val);
+      });
+
+      if(!is_contiguous) {
+        result.copy_(r);
+      }
     });
-
-    if(!is_contiguous) {
-      result.copy_(r);
-    }
-
   });
 
   AT_CUDA_CHECK(cudaGetLastError());

--- a/aten/src/ATen/native/cuda/UnaryOpsKernel.cu
+++ b/aten/src/ATen/native/cuda/UnaryOpsKernel.cu
@@ -76,10 +76,12 @@ void sqrt_kernel_cuda(TensorIterator& iter) {
 }
 
 void sigmoid_kernel_cuda(TensorIterator& iter) {
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(iter.dtype(), "sigmoid_cuda", [&]() {
-    gpu_kernel(iter, []GPU_LAMBDA(scalar_t a) -> scalar_t {
-      scalar_t one = scalar_t(1);
-      return  one / (one + std::exp(- a));
+  AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, iter.dtype(), "sigmoid_cuda", [&]() {
+    AT_SKIP_BFLOAT16_IF_NOT_ROCM(scalar_t, "sigmoid_cuda", [&] {
+      gpu_kernel(iter, []GPU_LAMBDA(scalar_t a) -> scalar_t {
+        scalar_t one = scalar_t(1);
+        return  one / (one + std::exp(- a));
+      });
     });
   });
 }

--- a/aten/src/ATen/native/sparse/cuda/SparseCUDATensorMath.cu
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDATensorMath.cu
@@ -330,13 +330,15 @@ Tensor& add_out_dense_sparse_cuda(Tensor& r_, const Tensor& dense, const SparseT
     if (sparse.dense_dim() == 0) {
       TORCH_CHECK(cuda::getApplyGrid(nnz, grid, curDevice), "add: Argument #0: tensor too large or too many dimensions");
 
-      AT_DISPATCH_ALL_TYPES_AND(
-        at::ScalarType::Half, commonDtype, "add_out_dense_sparse_cuda", [&] {
+      AT_DISPATCH_ALL_TYPES_AND2(
+        at::ScalarType::Half, at::ScalarType::BFloat16, commonDtype, "add_out_dense_sparse_cuda", [&] {
+          AT_SKIP_BFLOAT16_IF_NOT_ROCM(scalar_t, "add_out_dense_sparse_cuda", [&] {
             apply::sparseElementwiseKernelScalar<TensorCAddOp<scalar_t>, uint64_t, scalar_t>
               <<<grid, block, 0, stream>>>(
                 TensorCAddOp<scalar_t>(value.to<scalar_t>()),
                 V_INFO(r), I_INFO(indices), V_INFO(values),
                 static_cast<uint64_t>(nnz));
+            });
           });
     } else {
       TORCH_CHECK(cuda::getApplyGrid(nnz * block.x, grid, curDevice), "add: Argument #0: tensor too large or too many dimensions");
@@ -344,13 +346,15 @@ Tensor& add_out_dense_sparse_cuda(Tensor& r_, const Tensor& dense, const SparseT
       // sparseElementwiseKernel needs values to be contiguous too
       values = values.contiguous();
 
-      AT_DISPATCH_ALL_TYPES_AND(
-        at::ScalarType::Half, commonDtype, "add_out_dense_sparse_cuda", [&] {
+      AT_DISPATCH_ALL_TYPES_AND2(
+        at::ScalarType::Half, at::ScalarType::BFloat16, commonDtype, "add_out_dense_sparse_cuda", [&] {
+          AT_SKIP_BFLOAT16_IF_NOT_ROCM(scalar_t, "add_out_dense_sparse_cuda", [&] {
             apply::sparseElementwiseKernel<TensorCAddOp<scalar_t>, uint64_t, scalar_t>
               <<<grid, block, 0, stream>>>(
                 TensorCAddOp<scalar_t>(value.to<scalar_t>()),
                 V_INFO(r), I_INFO(indices), V_INFO(values),
                 static_cast<uint64_t>(nnz));
+            });
           });
     }
   } else {
@@ -359,12 +363,14 @@ Tensor& add_out_dense_sparse_cuda(Tensor& r_, const Tensor& dense, const SparseT
 
     // FIXME: at some point we can wrap the scale into indexAdd
     // NB: Purposely not inplace!
-    AT_DISPATCH_ALL_TYPES_AND(
-      at::ScalarType::Half, commonDtype, "add_out_dense_sparse_cuda", [&] {
+    AT_DISPATCH_ALL_TYPES_AND2(
+      at::ScalarType::Half, at::ScalarType::BFloat16, commonDtype, "add_out_dense_sparse_cuda", [&] {
+        AT_SKIP_BFLOAT16_IF_NOT_ROCM(scalar_t, "add_out_dense_sparse_cuda", [&] {
           if (value.to<scalar_t>() != static_cast<scalar_t>(1)) {
             values = values.mul(value);
           }
         });
+      });
 
     int64_t view_rows = 1;
     int64_t view_columns = 1;

--- a/aten/src/THC/THCTensorIndex.cu
+++ b/aten/src/THC/THCTensorIndex.cu
@@ -394,3 +394,6 @@ void dispatchTakePut(THCState *state, TensorType *a, TensorType *b, THCudaLongTe
 
 #include <THC/generic/THCTensorIndex.cu>
 #include <THC/THCGenerateBoolType.h>
+
+#include <THC/generic/THCTensorIndex.cu>
+#include <THC/THCGenerateBFloat16Type.h>

--- a/aten/src/THC/THCTensorMath.h
+++ b/aten/src/THC/THCTensorMath.h
@@ -67,6 +67,9 @@
 #include <THC/generic/THCTensorIndex.h>
 #include <THC/THCGenerateBoolType.h>
 
+#include <THC/generic/THCTensorIndex.h>
+#include <THC/THCGenerateBFloat16Type.h>
+
 #include <THC/generic/THCTensorMasked.h>
 #include <THC/THCGenerateBFloat16Type.h>
 

--- a/aten/src/THC/generic/THCTensorIndex.cu
+++ b/aten/src/THC/generic/THCTensorIndex.cu
@@ -397,6 +397,9 @@ void THCTensor_(indexFill)(THCState *state, THCTensor *dst, int dim, THCudaLongT
 
 void THCTensor_(indexSelect)(THCState *state, THCTensor *dst, THCTensor *src, int dim, THCudaLongTensor *indices)
 {
+#if defined(THC_REAL_IS_BFLOAT16) && !defined(__HIP_PLATFORM_HCC__)
+  TORCH_CHECK(false, "indexSelect not suppported with BFloat16");
+#else
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 3, dst, src, indices));
 
   dim = at::maybe_wrap_dim(dim, src);
@@ -533,6 +536,7 @@ void THCTensor_(indexSelect)(THCState *state, THCTensor *dst, THCTensor *src, in
 
 #undef SMALL_INDEX
 #undef LARGE_INDEX
+#endif // THC_REAL_IS_BFLOAT16 && !__HIP_PLATFORM_HCC__
 }
 
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9822,7 +9822,7 @@ class TestNNDeviceType(NNTestCase):
             torch.__future__.set_overwrite_module_params_on_conversion(False)
 
     @onlyCUDA
-    @dtypes(torch.half, torch.float, torch.double)
+    @dtypes(*ALL_TENSORTYPES2)
     def test_embedding_max_norm_device(self, device, dtype):
         embedding = nn.Embedding(22, 5, max_norm=1.0).to(device, dtype=dtype)
         # nn.Embedding only takes LongTensor as input
@@ -10262,6 +10262,13 @@ class TestNNDeviceType(NNTestCase):
 
         self._test_EmbeddingBag(device, 'sum', True, dtype, test_backward=test_backward)
         self._test_EmbeddingBag(device, 'mean', True, dtype, test_backward=test_backward)
+
+
+    @onlyCUDA
+    @skipCUDAIfNotRocm
+    def test_embedding_bag_bfloat16(self, device):
+        self._test_EmbeddingBag(device, 'sum', True, dtype=torch.bfloat16, test_backward=True)
+        self._test_EmbeddingBag(device, 'mean', True, dtype=torch.bfloat16, test_backward=True)
 
     @onlyCUDA
     @dtypes(torch.half, torch.float, torch.double)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -14688,7 +14688,7 @@ class TestDevicePrecision(TestCase):
         bfloat16_tensor = torch.arange(0, 4, dtype=torch.bfloat16, device=device)
         self.assertEqual(ref_tensor, bfloat16_tensor)
 
-        #step=2
+        # step=2
         ref_tensor = torch.tensor([0, 2, 4], dtype=torch.bfloat16, device=device)
         bfloat16_tensor = torch.arange(0, 6, step=2, dtype=torch.bfloat16, device=device)
         self.assertEqual(ref_tensor, bfloat16_tensor)
@@ -14696,7 +14696,7 @@ class TestDevicePrecision(TestCase):
     @onlyCUDA
     @skipCUDAIfNotRocm
     def test_index_add_bfloat16(self, device):
-        inp_tensor = torch.randn(5,3, device='cpu').bfloat16()
+        inp_tensor = torch.randn(5, 3, device='cpu').bfloat16()
         t = torch.tensor([[1, 2, 3], [4, 5, 6], [7, 8, 9]], dtype=torch.bfloat16, device='cpu')
         index = torch.tensor([0, 4, 2], device='cpu')
         out_cpu = inp_tensor.index_add(0, index, t)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -14708,7 +14708,6 @@ class TestDevicePrecision(TestCase):
 
         self.assertEqual(out_cpu, out_gpu, prec=1e-2)
 
-
     @skipCUDAIfRocm
     @dtypes(torch.double)
     def test_sum_noncontig(self, device, dtype):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -10776,15 +10776,6 @@ class TestTorchDeviceType(TestCase):
                 # in this test
                 continue
 
-            if self.device_type == 'cuda' and dt == torch.bfloat16:
-                self.assertRaises(RuntimeError, lambda: x > b)
-                self.assertRaises(RuntimeError, lambda: x < b)
-                self.assertRaises(RuntimeError, lambda: x == b)
-                self.assertRaises(RuntimeError, lambda: x != b)
-                self.assertRaises(RuntimeError, lambda: x >= b)
-                self.assertRaises(RuntimeError, lambda: x <= b)
-                continue
-
             self.assertEqual(x.lt(2), torch.tensor([True, False, False, False]))
             self.assertEqual(x.le(2), torch.tensor([True, True, False, False]))
             self.assertEqual(x.ge(2), torch.tensor([False, True, True, True]))

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -10776,6 +10776,15 @@ class TestTorchDeviceType(TestCase):
                 # in this test
                 continue
 
+            if self.device_type == 'cuda' and dt == torch.bfloat16 and not TEST_WITH_ROCM:
+                self.assertRaises(RuntimeError, lambda: x > b)
+                self.assertRaises(RuntimeError, lambda: x < b)
+                self.assertRaises(RuntimeError, lambda: x == b)
+                self.assertRaises(RuntimeError, lambda: x != b)
+                self.assertRaises(RuntimeError, lambda: x >= b)
+                self.assertRaises(RuntimeError, lambda: x <= b)
+                continue
+
             self.assertEqual(x.lt(2), torch.tensor([True, False, False, False]))
             self.assertEqual(x.le(2), torch.tensor([True, True, False, False]))
             self.assertEqual(x.ge(2), torch.tensor([False, True, True, True]))

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -15191,15 +15191,17 @@ _types = [
     torch.uint8
 ]
 
-# to be used to test op with bfloat16 on ROCm. Should eventually be unified with _types
-# when bfloat16 bringup is complete on all platforms.
-_types_with_bfloat16 = _types + [torch.bfloat16] if TEST_WITH_ROCM else _types
+# _types2 adds bfloat16 type to  _types only on ROCm. Should eventually be unified 
+# with _types when bfloat16 bringup is complete on all platforms.
+_types2 = _types + [torch.bfloat16] if TEST_WITH_ROCM else _types
 
 _float_types = [torch.half, torch.float, torch.double]
 
 _float_types_no_half = [torch.float, torch.double]
 
-_float_types_with_bfloat16 = [torch.half, torch.float, torch.double, torch.bfloat16] if TEST_WITH_ROCM else _float_types
+# _float_types2 adds bfloat16 type to _float_types only on ROCm. Should eventually be unified
+# with _float_types when bfloat16 bringup is complete on all platforms
+_float_types2 = _float_types + [ torch.bfloat16] if TEST_WITH_ROCM else _float_types
 
 _signed_types = [
     torch.half, torch.float, torch.double,
@@ -15246,7 +15248,7 @@ def _make_tensor(shape, dtype, device, fill_ones=False):
         return torch.ones(*shape, dtype=_convert_t(dtype, device), device=device)
 
     # Returns a tensor with random integer values
-    if dtype not in _float_types_with_bfloat16:
+    if dtype not in _float_types2:
         t = torch.randint(0, 10, shape, device=device)
         return t.to(_convert_t(dtype, device))
 
@@ -15349,20 +15351,20 @@ tensor_op_tests = [
     ('pow', 'tensor', _small_3d, lambda t, d: [_small_3d(t, d).abs()],
         1e-1, 1e-5, 1e-5, _float_types),
     ('addbmm', '', _small_2d, lambda t, d: [_small_3d(t, d), _small_3d(t, d)],
-        1e-1, 1e-1, 1e-4, _float_types_with_bfloat16),
+        1e-1, 1e-1, 1e-4, _float_types2),
     ('addbmm', 'scalar', _small_2d, lambda t, d: [_number(0.4, 2, t), _small_3d(t, d), _small_3d(t, d)],
-        1e-1, 1e-1, 1e-4, _float_types_with_bfloat16, True,
+        1e-1, 1e-1, 1e-4, _float_types2, True,
         [_wrap_maybe_warns("This overload of addbmm_? is deprecated")]),
     ('addbmm', 'two_scalars', _small_2d, lambda t, d: [_number(0.5, 3, t), _number(0.4, 2, t), _small_3d(t, d), _small_3d(t, d)],
-        1e-1, 1e-1, 1e-4, _float_types_with_bfloat16, True,
+        1e-1, 1e-1, 1e-4, _float_types2, True,
         [_wrap_maybe_warns("This overload of addbmm_? is deprecated")]),
     ('baddbmm', '', _small_3d, lambda t, d: [_small_3d(t, d), _small_3d(t, d)],
-        1e-2, 1e-1, 1e-4, _float_types_with_bfloat16),
+        1e-2, 1e-1, 1e-4, _float_types2),
     ('baddbmm', 'scalar', _small_3d, lambda t, d: [_number(0.4, 2, t), _small_3d(t, d), _small_3d(t, d)],
-        1e-2, 1e-1, 1e-4, _float_types_with_bfloat16, True,
+        1e-2, 1e-1, 1e-4, _float_types2, True,
         [_wrap_maybe_warns("This overload of baddbmm_? is deprecated")]),
     ('baddbmm', 'two_scalars', _small_3d, lambda t, d: [_number(0.5, 3, t), _number(0.4, 2, t), _small_3d(t, d), _small_3d(t, d)],
-        1e-2, 1e-1, 1e-4, _float_types_with_bfloat16, True,
+        1e-2, 1e-1, 1e-4, _float_types2, True,
         [_wrap_maybe_warns("This overload of baddbmm_? is deprecated")]),
     ('bmm', '', _small_3d, lambda t, d: [_small_3d(t, d)],
         1e-5, 1e-5, 1e-5, _float_types_no_half, False),
@@ -15380,34 +15382,34 @@ tensor_op_tests = [
         1e-5, 1e-5, _types, True,
         [_wrap_maybe_warns("This overload of addcmul_? is deprecated")]),
     ('addmm', '', _medium_2d, lambda t, d: [_medium_2d(t, d), _medium_2d(t, d)],
-        1e-1, 1e-1, 1e-4, _float_types_with_bfloat16),
+        1e-1, 1e-1, 1e-4, _float_types2),
     ('addmm', 'scalar', _medium_2d,
         lambda t, d: [_number(0.4, 2, t), _medium_2d(t, d), _medium_2d(t, d)],
-        1e-1, 1e-1, 1e-4, _float_types_with_bfloat16, True,
+        1e-1, 1e-1, 1e-4, _float_types2, True,
         [_wrap_maybe_warns("This overload of addmm_? is deprecated")]),
     ('addmm', 'two_scalars', _medium_2d,
         lambda t, d: [_number(0.5, 3, t), _number(0.4, 2, t), _medium_2d(t, d), _medium_2d(t, d)],
-        1e-1, 1e-1, 1e-4, _float_types_with_bfloat16, True,
+        1e-1, 1e-1, 1e-4, _float_types2, True,
         [_wrap_maybe_warns("This overload of addmm_? is deprecated")]),
     ('addmv', '', _medium_1d, lambda t, d: [_medium_2d(t, d), _medium_1d(t, d)],
-        1e-2, 1e-1, 1e-4, _float_types_with_bfloat16),
+        1e-2, 1e-1, 1e-4, _float_types2),
     ('addmv', 'scalar', _medium_1d,
         lambda t, d: [_number(0.4, 2, t), _medium_2d(t, d), _medium_1d(t, d)],
-        1e-2, 1e-1, 1e-4, _float_types_with_bfloat16, True,
+        1e-2, 1e-1, 1e-4, _float_types2, True,
         [_wrap_maybe_warns("This overload of addmv_? is deprecated")]),
     ('addmv', 'two_scalars', _medium_1d,
         lambda t, d: [_number(0.5, 3, t), _number(0.4, 2, t), _medium_2d(t, d), _medium_1d(t, d)],
-        1e-2, 1e-1, 1e-4, _float_types_with_bfloat16, True,
+        1e-2, 1e-1, 1e-4, _float_types2, True,
         [_wrap_maybe_warns("This overload of addmv_? is deprecated")]),
     ('addr', '', _medium_2d, lambda t, d: [_medium_1d(t, d), _medium_1d(t, d)],
-        1e-2, 1e-1, 1e-4, _float_types_with_bfloat16),
+        1e-2, 1e-1, 1e-4, _float_types2),
     ('addr', 'scalar', _medium_2d,
         lambda t, d: [_number(0.4, 2, t), _medium_1d(t, d), _medium_1d(t, d)],
-        1e-2, 1e-1, 1e-4, _float_types_with_bfloat16, True,
+        1e-2, 1e-1, 1e-4, _float_types2, True,
         [_wrap_maybe_warns("This overload of addr_? is deprecated")]),
     ('addr', 'two_scalars', _medium_2d,
         lambda t, d: [_number(0.5, 3, t), _number(0.4, 2, t), _medium_1d(t, d), _medium_1d(t, d)],
-        1e-2, 1e-1, 1e-4, _float_types_with_bfloat16, True,
+        1e-2, 1e-1, 1e-4, _float_types2, True,
         [_wrap_maybe_warns("This overload of addr_? is deprecated")]),
     ('atan2', '', _medium_2d, lambda t, d: [_medium_2d(t, d)], 1e-2, 1e-5, 1e-5, _float_types),
     ('fmod', 'value', _small_3d, lambda t, d: [3], 1e-3),
@@ -15475,9 +15477,9 @@ tensor_op_tests = [
     ('min', 'neg_dim', _small_3d_unique, lambda t, d: [-1], 1e-5, 1e-5, 1e-5, _types, False),
     ('min', 'elementwise', _medium_2d, lambda t, d: [_medium_2d(t, d)],
         1e-5, 1e-5, 1e-5, _types, False),
-    ('mean', '', _small_3d, lambda t, d: [], 1e-3, 1e-2, 1e-5, _float_types_with_bfloat16, False),
-    ('mean', 'neg_dim', _small_3d, lambda t, d: [-1], 1e-3, 1e-2, 1e-5, _float_types_with_bfloat16, False),
-    ('mean', 'dim', _small_3d, lambda t, d: [1], 1e-3, 1e-2, 1e-2, _float_types_with_bfloat16, False),
+    ('mean', '', _small_3d, lambda t, d: [], 1e-3, 1e-2, 1e-5, _float_types2, False),
+    ('mean', 'neg_dim', _small_3d, lambda t, d: [-1], 1e-3, 1e-2, 1e-5, _float_types2, False),
+    ('mean', 'dim', _small_3d, lambda t, d: [1], 1e-3, 1e-2, 1e-2, _float_types2, False),
     # Double here because the CPU result will be wrong otherwise
     ('mean', '64bit_indexing', _giant_1d, lambda t, d: [],
         1e-3, 1e-5, 1e-5, [torch.double], False, [slowTest]),
@@ -15508,10 +15510,10 @@ tensor_op_tests = [
     ('narrow', '', _small_3d, lambda t, d: [1, 3, 2], 1e-5, 1e-5, 1e-5, _types, False),
     ('narrow', 'neg_dim', _small_3d, lambda t, d: [-1, 3, 2], 1e-5, 1e-5, 1e-5, _types, False),
     ('nonzero', '', _small_3d, lambda t, d: [], 1e-5, 1e-5, 1e-5, _types, False),
-    ('norm', '', _small_3d, lambda t, d: [], 1e-1, 1e-1, 1e-5, _float_types_with_bfloat16, False),
-    ('norm', '3_norm', _small_3d, lambda t, d: [3], 1e-1, 1e-1, 1e-5, _float_types_with_bfloat16, False),
-    ('norm', '3_norm_dim', _small_3d, lambda t, d: [3, 0], 1e-1, 1e-1, 1e-5, _float_types_with_bfloat16, False),
-    ('norm', '3_norm_neg_dim', _small_3d, lambda t, d: [3, -2], 1e-1, 1e-1, 1e-5, _float_types_with_bfloat16, False),
+    ('norm', '', _small_3d, lambda t, d: [], 1e-1, 1e-1, 1e-5, _float_types2, False),
+    ('norm', '3_norm', _small_3d, lambda t, d: [3], 1e-1, 1e-1, 1e-5, _float_types2, False),
+    ('norm', '3_norm_dim', _small_3d, lambda t, d: [3, 0], 1e-1, 1e-1, 1e-5, _float_types2, False),
+    ('norm', '3_norm_neg_dim', _small_3d, lambda t, d: [3, -2], 1e-1, 1e-1, 1e-5, _float_types2, False),
     ('new_ones', '', _small_3d, lambda t, d: [1, 2, 3, 4, 5], 1e-5, 1e-5, 1e-5, _types, False),
     ('permute', '', _new_t((1, 2, 3, 4)), lambda t, d: [2, 1, 3, 0], 1e-5, 1e-5, 1e-5, _types, False),
     ('put_', '', _new_t((2, 5, 3)),
@@ -15527,11 +15529,11 @@ tensor_op_tests = [
                       True],
         1e-5, 1e-5, 1e-5, _types, False),
     ('prod', '', lambda t, d: _small_2d(t, d, oneish=True),
-        lambda t, d: [], 1e-2, 1e-1, 1e-5, _types_with_bfloat16, False),
-    ('prod', 'dim', _small_3d, lambda t, d: [1], 1e-3, 1e-1, 1e-5, _types_with_bfloat16, False),
-    ('prod', 'neg_dim', _small_3d, lambda t, d: [-1], 1e-3, 1e-1, 1e-5, _types_with_bfloat16, False),
-    ('sum', '', _small_2d, lambda t, d: [], 1e-2, 1e-2, 1e-5, _types_with_bfloat16, False),
-    ('sum', 'dim', _small_3d, lambda t, d: [1], 1e-2, 1e-2, 1e-5, _types_with_bfloat16, False),
+        lambda t, d: [], 1e-2, 1e-1, 1e-5, _types2, False),
+    ('prod', 'dim', _small_3d, lambda t, d: [1], 1e-3, 1e-1, 1e-5, _types2, False),
+    ('prod', 'neg_dim', _small_3d, lambda t, d: [-1], 1e-3, 1e-1, 1e-5, _types2, False),
+    ('sum', '', _small_2d, lambda t, d: [], 1e-2, 1e-2, 1e-5, _types2, False),
+    ('sum', 'dim', _small_3d, lambda t, d: [1], 1e-2, 1e-2, 1e-5, _types2, False),
     ('sum', 'neg_dim', _small_3d, lambda t, d: [-1], 1e-2, 1e-5, 1e-5, _types, False),
     ('renorm', '2_norm', _small_3d, lambda t, d: [2, 1, 1], 1e-3, 1e-5, 1e-5, _float_types),
     ('renorm', '2_norm_neg_dim', _small_3d, lambda t, d: [2, -1, 1], 1e-3, 1e-5, 1e-5, _float_types),
@@ -15615,11 +15617,11 @@ tensor_op_tests = [
         1e-5, 1e-5, 1e-5, _float_types_no_half, False, [skipCUDAIfNoMagma]),
     ('abs', '', _small_3d, lambda t, d: []),
     ('sign', '', _small_3d, lambda t, d: []),
-    ('log', '', _small_3d, lambda t, d: [], 1e-2, 1e-1, 1e-5, _float_types_with_bfloat16),
-    ('log10', '', _small_3d, lambda t, d: [], 1e-2, 1e-1, 1e-5, _float_types_with_bfloat16),
+    ('log', '', _small_3d, lambda t, d: [], 1e-2, 1e-1, 1e-5, _float_types2),
+    ('log10', '', _small_3d, lambda t, d: [], 1e-2, 1e-1, 1e-5, _float_types2),
     ('log1p', '', _small_3d, lambda t, d: [], 1e-3, 1e-1, 1e-5, _float_types_no_half),
-    ('log2', '', _small_3d, lambda t, d: [], 1e-2, 1e-1, 1e-5, _float_types_with_bfloat16),
-    ('sigmoid', '', _small_3d, lambda t, d: [], 1e-3, 1e-5, 1e-5, _float_types),
+    ('log2', '', _small_3d, lambda t, d: [], 1e-2, 1e-1, 1e-5, _float_types2),
+    ('sigmoid', '', _small_3d, lambda t, d: [], 1e-3, 1e-2, 1e-5, _float_types2),
     ('sin', '', _small_3d, lambda t, d: [], 1e-3, 1e-5, 1e-5, _float_types),
     ('sqrt', '', _small_3d, lambda t, d: [], 1e-3, 1e-5, 1e-5, _float_types),
     ('tanh', '', _small_3d, lambda t, d: [], 1e-3, 1e-5, 1e-5, _float_types),
@@ -15635,7 +15637,7 @@ tensor_op_tests = [
     ('reciprocal', '', _small_3d, lambda t, d: [], 1e-1, 1e-5, 1e-5, _float_types),
     ('floor', '', _small_3d, lambda t, d: [], 1e-5, 1e-5, 1e-5, _float_types),
     ('frac', '', _small_3d, lambda t, d: [], 1e-5, 1e-5, 1e-5, _float_types),
-    ('neg', '', _small_3d, lambda t, d: [], 1e-5, 1e-5, 1e-5, _float_types_with_bfloat16),
+    ('neg', '', _small_3d, lambda t, d: [], 1e-5, 1e-5, 1e-5, _float_types2),
     ('round', '', _small_3d, lambda t, d: [], 1e-5, 1e-5, 1e-5, _float_types),
     ('trunc', '', _small_3d, lambda t, d: [], 1e-5, 1e-5, 1e-5, _float_types),
     ('ceil', '', _small_3d, lambda t, d: [], 1e-5, 1e-5, 1e-5, _float_types),


### PR DESCRIPTION
This PR enables bfloat16 type for

- Embedding, Index, Sigmoid Ops used in [DLRM](https://github.com/facebookresearch/dlrm)
- Miscellaneous ops like comparison ops, arange op used in unit tests
- Rename types list with the pattern `*_with_bfloat16` in `test_torch.py` to avoid confusion

@iotamudelta @ezyang 