### PR TITLE
[JIT] EliminateDeadCode shouldn't remove custom operator node that has untracked mutation

### DIFF
--- a/torch/csrc/jit/passes/dead_code_elimination.cpp
+++ b/torch/csrc/jit/passes/dead_code_elimination.cpp
@@ -287,11 +287,6 @@ class DeadCodeEliminator {
 
   bool hasUntrackedMutation(Node* node) {
     if (!aliasDb_) {
-      // If we don't have alias information, all mutable ops have unknown
-      // effects and can't be considered for elimination.
-      if (!node->kind().is_aten() && !node->kind().is_prim()) {
-        return false;
-      }
       // onnx export calls EliminateDeadCode but sometimes passes invalid
       // aten operators. So we call maybeSchema so we handle the cases when
       // there is no valid schema for a node

--- a/torch/csrc/jit/passes/dead_code_elimination.cpp
+++ b/torch/csrc/jit/passes/dead_code_elimination.cpp
@@ -287,6 +287,9 @@ class DeadCodeEliminator {
 
   bool hasUntrackedMutation(Node* node) {
     if (!aliasDb_) {
+      // If we don't have alias information, all mutable ops have unknown
+      // effects and can't be considered for elimination.
+      
       // onnx export calls EliminateDeadCode but sometimes passes invalid
       // aten operators. So we call maybeSchema so we handle the cases when
       // there is no valid schema for a node


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#34635 [JIT] EliminateDeadCode shouldn't remove custom operator node that has untracked mutation**

For custom op, it's removed in EliminateDeadCode IR optimization step, causing wrong training result.

EliminateDeadCode decides to remove it, because it has no output, so output is used. Also, it has no side effect, and has no untracked mutation, which is not true, custom op can have untracked mutation.

The if statement here only allows aten and prim operator to have untracked mutation, which should be removed.

Differential Revision: [D7440221](https://our.internmc.facebook.com/intern/diff/D7440221/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D7440221/)!