### PR TITLE
[caffe2] Refactor out common util functions from tvm_transformer

### DIFF
--- a/caffe2/opt/backend_transformer_base.h
+++ b/caffe2/opt/backend_transformer_base.h
@@ -64,10 +64,10 @@ class BackendTransformerBase {
 
   static void annotateOpIndex(NetDef* net);
 
- protected:
   // Get model ID from the NetDef
-  std::string getModelId(const NetDef& net);
+  static std::string getModelId(const NetDef& net);
 
+ protected:
   // add shape info to the net
   void addShapeToNet(NetDef& shape_net, const ShapeInfoMap& shape_hints) const;
 

--- a/caffe2/opt/tvm_transformer.h
+++ b/caffe2/opt/tvm_transformer.h
@@ -39,6 +39,12 @@ class CAFFE2_API TvmTransformer final : public BackendTransformerBase {
       const ShapeInfoMap& shape_hints,
       const std::unordered_set<int>& blacklisted_ops) override;
 
+  static const std::unordered_set<std::string>& getSupportedOps();
+
+  static bool canConvertFullGraph(
+      const caffe2::NetDef& net,
+      const std::unordered_set<int>& blacklisted_ops);
+
  private:
   // Given TVM runnable subnets, contract them into one TVMJitOp
   NetDef buildTvmOp(
@@ -75,5 +81,11 @@ CAFFE2_API void tvmTransform(
     size_t max_batch_size,
     size_t max_seq_size,
     bool debug);
+
+CAFFE2_API void cleanUpPredictNet(
+    NetDef* net,
+    const std::vector<std::string>& input_names,
+    const std::vector<std::string>& output_names,
+    const std::vector<std::string>& weight_names);
 
 } // namespace caffe2


### PR DESCRIPTION
Summary: Split from D20006007 because it needs to synced to open source and also for easy testing & landing.

Test Plan:
```
buck test caffe2/caffe2/fb/tvm:test_tvm_transform
```
CI

Reviewed By: yinghai

Differential Revision: D20414037

