### PR TITLE
Best-effort Error Detection for Using Deleted UserRRefs

### DIFF
--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -115,7 +115,12 @@ PyObject* rpc_init(PyObject* /* unused */) {
       shared_ptr_class_<PyRRef>(module, "RRef", R"(
           A class encapsulating a reference to a value of some type on a remote
           worker. This handle will keep the referenced remote value alive on the
-          worker.
+          worker. An ``UserRRef`` will be deleted when 1) no references to it in
+          both the application code and in the local RRef context, or 2) the
+          application has called shutdown. Invoking methods on a deleted RRef
+          leads to undefined behaviors. RRef implementation only offers
+          best-effort error detection, and applications should not use
+          ``UserRRef``s after ``rpc.shutdown()``.
 
           Example::
               Following examples skip RPC initialization and shutdown code

--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -115,11 +115,11 @@ PyObject* rpc_init(PyObject* /* unused */) {
       shared_ptr_class_<PyRRef>(module, "RRef", R"(
           A class encapsulating a reference to a value of some type on a remote
           worker. This handle will keep the referenced remote value alive on the
-          worker. An ``UserRRef`` will be deleted when 1) no references to it in
+          worker. A ``UserRRef`` will be deleted when 1) no references to it in
           both the application code and in the local RRef context, or 2) the
-          application has called shutdown. Invoking methods on a deleted RRef
-          leads to undefined behaviors. RRef implementation only offers
-          best-effort error detection, and applications should not use
+          application has called a graceful shutdown. Invoking methods on a
+          deleted RRef leads to undefined behaviors. RRef implementation only
+          offers best-effort error detection, and applications should not use
           ``UserRRef``s after ``rpc.shutdown()``.
 
           Example::

--- a/torch/csrc/distributed/rpc/rref_impl.cpp
+++ b/torch/csrc/distributed/rpc/rref_impl.cpp
@@ -105,6 +105,15 @@ const ForkId& UserRRef::forkId() const {
 }
 
 IValue UserRRef::toHere() {
+  // see Note [Best-Effort Check on Deleted UserRRefs]
+  TORCH_CHECK(
+      !deletedOnOwner_,
+        "User RRef with RRefId=",
+        rrefId(),
+        " and ForkId=",
+        forkId(),
+        " has been deleted. Cannot call to_here() on it after deletion.");
+
   auto agent = RpcAgent::getCurrentRpcAgent();
 
   // ScriptRRefFetchCall message always carries autograd context id even if
@@ -141,6 +150,38 @@ IValue UserRRef::toHere() {
   } else {
     return rrefFetchRet.values().front();
   }
+}
+
+RRefForkData UserRRef::fork() const {
+  // Note [Best-Effort Check on Deleted UserRRefs]
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  // This check does not guarantee correctness, as there could be another thread
+  // trying to delete this UserRRef concurrently. Passing this check does not
+  // mean this RRef will be alive throughout this function. This is just our
+  // best-effort attempt to raise proper error messages. The behavior of using
+  // deleted UserRRefs is undefined.
+  //
+  // The reason for not implementing strict checks are:
+  // 1. This would need to acquire lock on deletedOnOwnerMutex_, which would
+  //    introduce unnecessary overhead for most normal use cases.
+  // 2. This would introduce a lot of complexities to get the behavior correct.
+  //    Assume we acquired the lock here, and there is another thread X block
+  //    waiting in tryDel() on the lock. Exiting this fork function would
+  //    unblock thread X. However, while X proceeds with deleting this UserRRef,
+  //    the call site of fork() might have added the UserRRef to
+  //    pendingChildren_ map, but up to this point, nothing prevents X from
+  //    deleting this RRef even if it shouldn't do so due to the state change
+  //    in pendingChildren_. We might be able to get to right for now by locking
+  //    and checking pendingChildren_ in X, but the complexity does not seem to
+  //    worth the gain.
+  TORCH_CHECK(
+      !deletedOnOwner_,
+        "User RRef with RRefId=",
+        rrefId(),
+        " and ForkId=",
+        forkId(),
+        " has been deleted. Cannot call fork an UserRRef after deletion.");
+  return RRef::fork();
 }
 
 //////////////////////////  OwnerRRef  /////////////////////////////////////

--- a/torch/csrc/distributed/rpc/rref_impl.cpp
+++ b/torch/csrc/distributed/rpc/rref_impl.cpp
@@ -171,7 +171,7 @@ RRefForkData UserRRef::fork() const {
   //    the call site of fork() might have added the UserRRef to
   //    pendingChildren_ map, but up to this point, nothing prevents X from
   //    deleting this RRef even if it shouldn't do so due to the state change
-  //    in pendingChildren_. We might be able to get to right for now by locking
+  //    in pendingChildren_. We might be able to get it right for now by locking
   //    and checking pendingChildren_ in X, but the complexity does not seem to
   //    worth the gain.
   TORCH_CHECK(

--- a/torch/csrc/distributed/rpc/rref_impl.cpp
+++ b/torch/csrc/distributed/rpc/rref_impl.cpp
@@ -172,8 +172,8 @@ RRefForkData UserRRef::fork() const {
   //    pendingChildren_ map, but up to this point, nothing prevents X from
   //    deleting this RRef even if it shouldn't do so due to the state change
   //    in pendingChildren_. We might be able to get it right for now by locking
-  //    and checking pendingChildren_ in X, but the complexity does not seem to
-  //    worth the gain.
+  //    and checking pendingChildren_ in X, but the gain does not seem to
+  //    worth the complexity.
   TORCH_CHECK(
       !deletedOnOwner_,
       "User RRef with RRefId=",

--- a/torch/csrc/distributed/rpc/rref_impl.h
+++ b/torch/csrc/distributed/rpc/rref_impl.h
@@ -226,7 +226,7 @@ class TORCH_API RRef : public RRefInterface {
 
   RRef(worker_id_t ownerId, const RRefId& rrefId, TypePtr type);
 
-  RRefForkData fork() const;
+  virtual RRefForkData fork() const;
 
   const worker_id_t ownerId_;
   const RRefId rrefId_;
@@ -278,6 +278,8 @@ class TORCH_API UserRRef final : public RRef {
 
  private:
   friend class RRefContext;
+
+  RRefForkData fork() const override;
 
   const ForkId forkId_;
 

--- a/torch/distributed/rpc/api.py
+++ b/torch/distributed/rpc/api.py
@@ -205,7 +205,9 @@ def shutdown(graceful=True):
 
     Arguments:
         graceful (bool): Whether to do a graceful shutdown or not. If True,
-                         this will block until all local and remote RPC
+                         this will 1) delete all local waiting until there is no
+                         pending system messages for ``UserRRef``s and delete
+                         them; 2) block until all local and remote RPC
                          processes have reached this method and wait for all
                          outstanding work to complete.
 

--- a/torch/distributed/rpc/api.py
+++ b/torch/distributed/rpc/api.py
@@ -205,11 +205,11 @@ def shutdown(graceful=True):
 
     Arguments:
         graceful (bool): Whether to do a graceful shutdown or not. If True,
-                         this will 1) delete all local waiting until there is no
-                         pending system messages for ``UserRRef``s and delete
-                         them; 2) block until all local and remote RPC
-                         processes have reached this method and wait for all
-                         outstanding work to complete.
+                         this will 1) wait until there is no pending system
+                         messages for ``UserRRef``s and delete them; 2) block
+                         until all local and remote RPC processes have reached
+                         this method and wait for all outstanding work to
+                         complete.
 
     Example::
         Make sure that ``MASTER_ADDRESS`` and ``MASTER_PORT`` are set properly

--- a/torch/testing/_internal/distributed/rpc/rpc_test.py
+++ b/torch/testing/_internal/distributed/rpc/rpc_test.py
@@ -1679,3 +1679,34 @@ class RpcTest(RpcAgentTestFixture):
             torch.add,
             args=(torch.ones(n, n), 2)
         )
+
+    @dist_init(setup_rpc=False)
+    def test_use_rref_after_shutdown(self):
+        # test that we can start RPC, send RPCs, and then run local shutdown.
+        rpc.init_rpc(
+            name="worker%d" % self.rank,
+            backend=self.rpc_backend,
+            rank=self.rank,
+            world_size=self.world_size,
+            rpc_backend_options=self.rpc_backend_options,
+        )
+        n = self.rank + 1
+        dst_rank = n % self.world_size
+        rref = rpc.remote(
+            worker_name(dst_rank),
+            torch.add,
+            args=(torch.ones(n, n), torch.ones(n, n)),
+        )
+        # pass in graceful=False to ensure that we don't wait for other workers.
+        rpc.shutdown(graceful=True)
+
+        with self.assertRaisesRegex(
+            RuntimeError, "Cannot call to_here\\(\\) on it after deletion."
+        ):
+            rref.to_here()
+
+        with self.assertRaisesRegex(
+            RuntimeError, "Cannot call fork an UserRRef after deletion."
+        ):
+            import torch.distributed.rpc.internal as internal
+            internal.serialize(rref)

--- a/torch/testing/_internal/distributed/rpc/rpc_test.py
+++ b/torch/testing/_internal/distributed/rpc/rpc_test.py
@@ -1682,7 +1682,6 @@ class RpcTest(RpcAgentTestFixture):
 
     @dist_init(setup_rpc=False)
     def test_use_rref_after_shutdown(self):
-        # test that we can start RPC, send RPCs, and then run local shutdown.
         rpc.init_rpc(
             name="worker%d" % self.rank,
             backend=self.rpc_backend,
@@ -1697,7 +1696,7 @@ class RpcTest(RpcAgentTestFixture):
             torch.add,
             args=(torch.ones(n, n), torch.ones(n, n)),
         )
-        # pass in graceful=False to ensure that we don't wait for other workers.
+        # pass in graceful=True to ensure that local UserRRefs are deleted.
         rpc.shutdown(graceful=True)
 
         with self.assertRaisesRegex(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#34673 Best-effort Error Detection for Using Deleted UserRRefs**
* #34681 Use c10::str in py_rref.cpp
* #34679 Use c10::str in process_group_agent.cpp

Differential Revision: [D20427839](https://our.internmc.facebook.com/intern/diff/D20427839)