### PR TITLE
[jit] small cleanups after script:: removal

### DIFF
--- a/torch/csrc/jit/api/module.h
+++ b/torch/csrc/jit/api/module.h
@@ -557,6 +557,7 @@ namespace script {
 // We once had a `script::` namespace that was deleted. This is for backcompat
 // of the public API; new code should not use this type alias.
 using Module = ::torch::jit::Module;
+using ExtraFilesMap = ::torch::jit::ExtraFilesMap;
 }
 
 } // namespace jit

--- a/torch/csrc/jit/passes/quantization.cpp
+++ b/torch/csrc/jit/passes/quantization.cpp
@@ -731,7 +731,7 @@ ModuleMethodVector InsertObserversHelper::getInvokedMethods(
 void InsertObserversHelper::insertObserverFor(
     Value* v,
     Module& module,
-    const script::Module& observer_module,
+    const Module& observer_module,
     NameModuleVector& observer_name_and_modules) {
   if (observed_values_.count(v)) {
     return;
@@ -2007,12 +2007,12 @@ void FoldQuantNodesIntoInputsOutputs(std::shared_ptr<Graph>& graph) {
   throw std::runtime_error("Pass not implemented yet!");
 }
 
-void SwapFunctionalLinear(script::Module& module) {
+void SwapFunctionalLinear(Module& module) {
   for (auto& method : module.get_methods()) {
     std::shared_ptr<Graph> g = method.graph();
     SwapFunctionalLinear(g);
   }
-  for (script::Module m : module.children()) {
+  for (Module m : module.children()) {
     SwapFunctionalLinear(m);
   }
 }

--- a/torch/csrc/jit/passes/quantization.h
+++ b/torch/csrc/jit/passes/quantization.h
@@ -92,7 +92,7 @@ TORCH_API Module InsertQuantDeQuant(
 TORCH_API void SwapFunctionalLinear(std::shared_ptr<Graph>& graph);
 /** Swap all functional linear CallFunctions in module
  */
-TORCH_API void SwapFunctionalLinear(script::Module& module);
+TORCH_API void SwapFunctionalLinear(Module& module);
 
 /** Replicate dequantize node for each use, so that we can match
  *  quantization patterns

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -219,7 +219,7 @@ void initJITBindings(PyObject* module) {
              SwapFunctionalLinear(graph);
            })
       .def("_jit_pass_swap_functional_linear",
-           [](script::Module& module) {
+           [](Module& module) {
              SwapFunctionalLinear(module);
            })
       .def(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #34678 [jit] Deprecate old script:: typedefs
* **#34677 [jit] small cleanups after script:: removal**

1. Remove remaining uses of `script::` namespace from the codebase,
2. Add one more typedef for `script::ExtraFilesMap` which is part of the
public interface.

Pull Request resolved: #34580

Differential Revision: [D20431739](https://our.internmc.facebook.com/intern/diff/D20431739)