### PR TITLE
[jit] Deprecate old script:: typedefs

### DIFF
--- a/c10/util/Deprecated.h
+++ b/c10/util/Deprecated.h
@@ -32,8 +32,8 @@
 # define C10_DEPRECATED_MESSAGE(message) __attribute__((deprecated))
 
 #elif defined(_MSC_VER)
-# define C10_DEPRECATED __declspec(deprecated)
-# define C10_DEPRECATED_MESSAGE(message) __declspec(deprecated(message))
+# define C10_DEPRECATED [[deprecated]]
+# define C10_DEPRECATED_MESSAGE(message) [[deprecated(message)]]
 #else
 # warning "You need to implement C10_DEPRECATED for this compiler"
 # define C10_DEPRECATED

--- a/torch/csrc/jit/api/compilation_unit.h
+++ b/torch/csrc/jit/api/compilation_unit.h
@@ -298,7 +298,9 @@ struct StrongFunctionPtr {
 namespace script {
 // We once had a `script::` namespace that was deleted. This is for backcompat
 // of the public API; new code should not use this type alias.
-using CompilationUnit = ::torch::jit::CompilationUnit;
+using CompilationUnit C10_DEPRECATED_MESSAGE(
+    "torch::jit::script namespace is deprecated, "
+    "use just torch::jit instead") = ::torch::jit::CompilationUnit;
 }
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/api/method.h
+++ b/torch/csrc/jit/api/method.h
@@ -63,7 +63,9 @@ struct TORCH_API Method {
 namespace script {
 // We once had a `script::` namespace that was deleted. This is for backcompat
 // of the public API; new code should not use this type alias.
-using Method = ::torch::jit::Method;
+using Method C10_DEPRECATED_MESSAGE(
+    "torch::jit::script namespace is deprecated, "
+    "use just torch::jit instead") = ::torch::jit::Method;
 }
 
 } // namespace jit

--- a/torch/csrc/jit/api/module.h
+++ b/torch/csrc/jit/api/module.h
@@ -556,8 +556,12 @@ TORCH_API bool& getInlineEverythingMode();
 namespace script {
 // We once had a `script::` namespace that was deleted. This is for backcompat
 // of the public API; new code should not use this type alias.
-using Module = ::torch::jit::Module;
-using ExtraFilesMap = ::torch::jit::ExtraFilesMap;
+using Module C10_DEPRECATED_MESSAGE(
+    "torch::jit::script namespace is deprecated, "
+    "use just torch::jit instead") = ::torch::jit::Module;
+using ExtraFilesMap C10_DEPRECATED_MESSAGE(
+    "torch::jit::script namespace is deprecated, "
+    "use just torch::jit instead") = ::torch::jit::ExtraFilesMap;
 }
 
 } // namespace jit

--- a/torch/csrc/jit/api/object.h
+++ b/torch/csrc/jit/api/object.h
@@ -134,7 +134,9 @@ struct TORCH_API Object {
 namespace script {
 // We once had a `script::` namespace that was deleted. This is for backcompat
 // of the public API; new code should not use this type alias.
-using Object = ::torch::jit::Object;
+using Object C10_DEPRECATED_MESSAGE(
+    "torch::jit::script namespace is deprecated, "
+    "use just torch::jit instead") = ::torch::jit::Object;
 }
 } // namespace jit
 } // namespace torch


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#34678 [jit] Deprecate old script:: typedefs**
* #34677 [jit] small cleanups after script:: removal

