### PR TITLE
Use c10::str in py_rref.cpp

### DIFF
--- a/torch/csrc/distributed/rpc/py_rref.cpp
+++ b/torch/csrc/distributed/rpc/py_rref.cpp
@@ -162,14 +162,16 @@ py::object PyRRef::localValue() {
 }
 
 std::string PyRRef::str() const {
-  std::ostringstream ss;
   if (rref_->isOwner()) {
-    ss << "OwnerRRef(" << rref_->rrefId() << ")";
+    return c10::str("OwnerRRef(", rref_->rrefId(), ")");
   } else {
-    ss << "UserRRef(RRefId = " << rref_->rrefId() << ", ForkId = "
-       << c10::static_intrusive_pointer_cast<UserRRef>(rref_)->forkId() << ")";
+    return c10::str(
+        "UserRRef(RRefId = ",
+        rref_->rrefId(),
+        ", ForkId = ",
+        c10::static_intrusive_pointer_cast<UserRRef>(rref_)->forkId(),
+        ")");
   }
-  return ss.str();
 }
 
 py::tuple PyRRef::pickle() const {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #34673 Best-effort Error Detection for Using Deleted UserRRefs
* **#34681 Use c10::str in py_rref.cpp**
* #34679 Use c10::str in process_group_agent.cpp

Differential Revision: [D20428827](https://our.internmc.facebook.com/intern/diff/D20428827)