### PR TITLE
Set USE_RCCL cmake option (dependent on USE_NCCL) [REDUX]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,6 +173,8 @@ option(USE_NATIVE_ARCH "Use -march=native" OFF)
 cmake_dependent_option(
     USE_NCCL "Use NCCL" ON
     "USE_CUDA OR USE_ROCM;UNIX;NOT APPLE" OFF)
+cmake_dependent_option(USE_RCCL "Use RCCL" ON
+    USE_NCCL OFF)
 cmake_dependent_option(
     USE_STATIC_NCCL "Use static NCCL" OFF
     "USE_NCCL" OFF)

--- a/tools/amd_build/build_amd.py
+++ b/tools/amd_build/build_amd.py
@@ -132,17 +132,18 @@ if is_hip_clang():
         print("%s updated" % gloo_cmake_file)
 
 gloo_cmake_file = "third_party/gloo/cmake/Modules/Findrccl.cmake"
-do_write = False
-with open(gloo_cmake_file, "r") as sources:
-    lines = sources.readlines()
-newlines = [line.replace('RCCL_LIBRARY', 'RCCL_LIBRARY_PATH') for line in lines]
-if lines == newlines:
-    print("%s skipped" % gloo_cmake_file)
-else:
-    with open(gloo_cmake_file, "w") as sources:
-        for line in newlines:
-            sources.write(line)
-    print("%s updated" % gloo_cmake_file)
+if os.path.exists(gloo_cmake_file):
+    do_write = False
+    with open(gloo_cmake_file, "r") as sources:
+        lines = sources.readlines()
+    newlines = [line.replace('RCCL_LIBRARY', 'RCCL_LIBRARY_PATH') for line in lines]
+    if lines == newlines:
+        print("%s skipped" % gloo_cmake_file)
+    else:
+        with open(gloo_cmake_file, "w") as sources:
+            for line in newlines:
+                sources.write(line)
+        print("%s updated" % gloo_cmake_file)
 
 hipify_python.hipify(
     project_directory=proj_dir,

--- a/tools/amd_build/build_amd.py
+++ b/tools/amd_build/build_amd.py
@@ -131,18 +131,18 @@ if is_hip_clang():
                 sources.write(line)
         print("%s updated" % gloo_cmake_file)
 
-    gloo_cmake_file = "third_party/gloo/cmake/Modules/Findrccl.cmake"
-    do_write = False
-    with open(gloo_cmake_file, "r") as sources:
-        lines = sources.readlines()
-    newlines = [line.replace('RCCL_LIBRARY', 'RCCL_LIBRARY_PATH') for line in lines]
-    if lines == newlines:
-        print("%s skipped" % gloo_cmake_file)
-    else:
-        with open(gloo_cmake_file, "w") as sources:
-            for line in newlines:
-                sources.write(line)
-        print("%s updated" % gloo_cmake_file)
+gloo_cmake_file = "third_party/gloo/cmake/Modules/Findrccl.cmake"
+do_write = False
+with open(gloo_cmake_file, "r") as sources:
+    lines = sources.readlines()
+newlines = [line.replace('RCCL_LIBRARY', 'RCCL_LIBRARY_PATH') for line in lines]
+if lines == newlines:
+    print("%s skipped" % gloo_cmake_file)
+else:
+    with open(gloo_cmake_file, "w") as sources:
+        for line in newlines:
+            sources.write(line)
+    print("%s updated" % gloo_cmake_file)
 
 hipify_python.hipify(
     project_directory=proj_dir,

--- a/tools/amd_build/build_amd.py
+++ b/tools/amd_build/build_amd.py
@@ -131,6 +131,19 @@ if is_hip_clang():
                 sources.write(line)
         print("%s updated" % gloo_cmake_file)
 
+    gloo_cmake_file = "third_party/gloo/cmake/Modules/Findrccl.cmake"
+    do_write = False
+    with open(gloo_cmake_file, "r") as sources:
+        lines = sources.readlines()
+    newlines = [line.replace('RCCL_LIBRARY', 'RCCL_LIBRARY_PATH') for line in lines]
+    if lines == newlines:
+        print("%s skipped" % gloo_cmake_file)
+    else:
+        with open(gloo_cmake_file, "w") as sources:
+            for line in newlines:
+                sources.write(line)
+        print("%s updated" % gloo_cmake_file)
+
 hipify_python.hipify(
     project_directory=proj_dir,
     output_directory=out_dir,


### PR DESCRIPTION
Refiled duplicate of #31341 which was reverted in commit 63964175b52197a75e03b73c59bd2573df66b398.

This PR enables RCCL support when building Gloo as part of PyTorch for ROCm.