### PR TITLE
Skip `TestNN.test_spectral_norm_load_state_` if PyTorch is compiled w…

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2882,6 +2882,7 @@ class TestNN(NNTestCase):
 
                     torch.autograd.gradcheck(fn, (m.weight_orig,))
 
+    @skipIfNoLapack
     def test_spectral_norm_load_state_dict(self):
         inp = torch.randn(2, 3)
         for activate_times in (0, 3):


### PR DESCRIPTION
…ithout lapack

LAPACK is needed for `at::svd``, which is called from `pinverse()`

Test Plan: CI + local run

