### PR TITLE
Use reduced range in dynamic linear to avoid instruction overflow

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp
@@ -63,7 +63,8 @@ class QLinearDynamicInt8 final : public torch::OperatorKernel {
         /*len=*/input.numel());
 
     // Input tensor is quantized as 8-bit unsigned values
-    static constexpr int precision = 8;
+    static constexpr int precision =
+        7; // Use the reduced range to avoid instruction overflow.
     static constexpr bool is_signed = false;
 
     // Calculate scale and zero point for quantization of input tensor


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#34691 Use reduced range in dynamic linear to avoid instruction overflow**

We evaluated the accuracy based on the OSS tutorial:
https://pytorch.org/tutorials/intermediate/dynamic_quantization_bert_tutorial.html


Original (no "reduce_range" + per tensor):
 ```
03/08/2020 22:08:20 - INFO - __main__ -   ***** Eval results  *****
03/08/2020 22:08:20 - INFO - __main__ -     acc = 0.8455882352941176
03/08/2020 22:08:20 - INFO - __main__ -     acc_and_f1 = 0.869494625261272
03/08/2020 22:08:20 - INFO - __main__ -     f1 = 0.8934010152284263
 ```



After the “reduce_range” change ("reduce_range" + per tensor, this PR):
 ```
03/08/2020 22:21:26 - INFO - __main__ -   ***** Eval results  *****
03/08/2020 22:21:26 - INFO - __main__ -     acc = 0.8480392156862745
03/08/2020 22:21:26 - INFO - __main__ -     acc_and_f1 = 0.8707550030321407
03/08/2020 22:21:26 - INFO - __main__ -     f1 = 0.8934707903780068
 ```


"reduce_range" + per-channel quant:
 ```
03/08/2020 22:33:15 - INFO - __main__ -   ***** Eval results  *****
03/08/2020 22:33:15 - INFO - __main__ -     acc = 0.8602941176470589
03/08/2020 22:33:15 - INFO - __main__ -     acc_and_f1 = 0.8812619816365654
03/08/2020 22:33:15 - INFO - __main__ -     f1 = 0.902229845626072
 ```


Before "reduce-range" change (no "reduce_range" + per-channel quant, only per channel quant):
```
03/08/2020 22:55:03 - INFO - __main__ -   ***** Eval results  *****
03/08/2020 22:55:03 - INFO - __main__ -     acc = 0.3161764705882353
03/08/2020 22:55:03 - INFO - __main__ -     acc_and_f1 = 0.15808823529411764
03/08/2020 22:55:03 - INFO - __main__ -     f1 = 0.0
```

Differential Revision: [D20358944](https://our.internmc.facebook.com/intern/diff/D20358944/)