### PR TITLE
Add TORCH_API to getOperatorForLiteral

### DIFF
--- a/torch/csrc/jit/runtime/operator.h
+++ b/torch/csrc/jit/runtime/operator.h
@@ -180,7 +180,7 @@ TORCH_API std::vector<Symbol> findSimilarOperators(Symbol input_op);
 TORCH_API void registerOperator(Operator&& op);
 
 // XXX: this function is meant to be used with string literals only!
-std::shared_ptr<Operator> getOperatorForLiteral(const char* signature);
+TORCH_API std::shared_ptr<Operator> getOperatorForLiteral(const char* signature);
 
 // Ensure the thing that registers c10 ops is defined.
 // Otherwise, our registry will not have c10 ops. You can run into this


### PR DESCRIPTION
Exposing getOperatorForLiteral in torch_cpu build. Allows torch_gpu to search for operator via String literal as well.