### PR TITLE
[JIT] Add support for with statements

### DIFF
--- a/aten/src/ATen/core/interned_strings.h
+++ b/aten/src/ATen/core/interned_strings.h
@@ -69,6 +69,9 @@ namespace c10 {
   _(prim, StringIndex)               \
   _(prim, NumToTensor)               \
   _(prim, Uninitialized)             \
+  _(prim, With)                      \
+  _(prim, Enter)                     \
+  _(prim, Exit)                      \
   _(aten, Bool)                      \
   _(aten, Int)                       \
   _(aten, FloatImplicit)             \

--- a/docs/source/jit_python_reference.rst
+++ b/docs/source/jit_python_reference.rst
@@ -395,7 +395,7 @@ support in TorchScript. The categorizations are as follows:
      - Not Supported
      -
    * - `8.5. The with statement <https://docs.python.org/3/reference/compound_stmts.html#the-with-statement>`_
-     - Not Supported
+     - Supported
      -
    * - `8.6. Function definitions <https://docs.python.org/3/reference/compound_stmts.html#function-definitions>`_
      - Not Supported
@@ -430,4 +430,3 @@ support in TorchScript. The categorizations are as follows:
    * - `9.4. Expression input <https://docs.python.org/3/reference/toplevel_components.html#expression-input>`_
      - Not Relevant
      -
-

--- a/test/jit/test_with.py
+++ b/test/jit/test_with.py
@@ -1,0 +1,550 @@
+import os
+import sys
+
+from typing import Any
+
+import torch
+from torch.testing._internal.jit_utils import JitTestCase
+
+
+# Make the helper files in test/ importable
+pytorch_test_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+sys.path.append(pytorch_test_dir)
+
+if __name__ == "__main__":
+    raise RuntimeError(
+        "This test file is not meant to be run directly, use:\n\n"
+        "\tpython test/test_jit.py TESTNAME\n\n"
+        "instead."
+    )
+
+
+class TestWith(JitTestCase):
+    """
+    A suite of tests for with statements.
+    """
+
+    def test_with_as(self):
+        """
+        Check that with statements that use the 'as' keyword to bind expressions
+        to targets work as expected.
+        """
+        global Context
+
+        @torch.jit.script
+        class Context(object):
+            """
+            This class implements a basic context manager interface for use in
+            the unit tests. Unlike Context, the stateful part of this class
+            is a Tensor that is mutated in-place so that modifications made in the
+            JIT interpreter are visible outside of it.
+            """
+
+            def __init__(self, start: int):
+                self.count = torch.tensor([start], dtype=torch.double)
+
+            def __enter__(self):
+                self.count.add_(0.3)
+                return self.count
+
+            def __exit__(self, type: Any, value: Any, tb: Any):
+                self.count.sub_(0.3)
+
+        def test_basic(x):
+            # type: (Tensor) -> Tensor
+            """Basic test with one with-statement."""
+
+            c = Context(1)
+
+            with c as mult:
+                y = x + mult
+
+            y *= c.count
+            return y
+
+        def test_pass(x):
+            # type: (Tensor) -> Tensor
+            """
+            Test with a pass statement inside a with-statement. Although
+            the body of the with is empty, __enter__ and __exit__ should
+            still be called.
+            """
+            c = Context(1)
+
+            with c as mult:
+                pass
+
+            x *= c.count
+            return x
+
+        def test_early_return(x, c):
+            # type: (Tensor, Context) -> Tensor
+            """
+            Test that returning early from inside a with-statement works
+            as expected.
+            """
+            with c as mult:
+                y = x + mult
+                return y
+
+            x = y + y
+            return x
+
+        def test_conditional_early_return(x, c):
+            # type: (Tensor, Context) -> Tensor
+            """
+            Test that conditionally returning early from inside a with-statement works
+            as expected.
+            """
+            with c as mult:
+                y = x + mult
+                if mult > 0:
+                    return y
+
+            x = y + y
+            return x
+
+        def test_break(x, c, l):
+            # type: (Tensor, Context, List[int]) -> Tensor
+            """
+            Test that breaking early from inside a with-statement works
+            as expected.
+            """
+            with c as mult:
+                for a in l:
+                    if a == 0:
+                        break
+                    x += a * mult
+
+            return x
+
+        def test_continue(x, c, l):
+            # type: (Tensor, Context, List[int]) -> Tensor
+            """
+            Test that using continue inside a with-statement works
+            as expected.
+            """
+            with c as mult:
+                for a in l:
+                    if a == 0:
+                        continue
+                    x += a * mult
+
+            return x
+
+        def test_serial(x):
+            # type: (Tensor) -> Tensor
+            """
+            Test two with-statements in a row.
+            """
+            c = Context(1)
+
+            with c as mult:
+                y = x + mult
+
+            with c as mult:
+                y *= mult
+
+            return y
+
+        def test_nested(x):
+            # type: (Tensor) -> Tensor
+            """
+            Test nested with-statements.
+            """
+            c = Context(1)
+
+            with c as m:
+                with c as n:
+                    y = x + n
+
+                y *= m
+
+            return y
+
+        def test_combined(x):
+            # type: (Tensor) -> Tensor
+            """
+            Test a with-statement with multiple with items.
+            """
+            c = Context(1)
+            d = Context(2)
+
+            with c as m, d as n:
+                y = x + (m + n)
+
+            return y
+
+        test_input = torch.randn(2, 2)
+        test_context = Context(2)
+        test_list = [2, 0, 1, 3, 0, 2]
+
+        self.checkScript(test_basic, (test_input,))
+        self.checkScript(test_pass, (test_input,))
+        self.checkScript(test_early_return, (test_input, test_context))
+        self.checkScript(test_break, (test_input, test_context, test_list))
+        self.checkScript(test_continue, (test_input, test_context, test_list))
+        self.assertEqual(test_context.count, 2)
+        self.checkScript(test_serial, (test_input,))
+        self.checkScript(test_nested, (test_input,))
+        self.checkScript(test_combined, (test_input,))
+
+    def test_with_no_as(self):
+        """
+        Check that with statements that do not use the 'as' keyword to bind expressions
+        to targets work as expected.
+        """
+        global Context
+
+        @torch.jit.script
+        class Context(object):
+            """
+            This class implements a basic context manager interface for use in
+            the unit tests. Unlike Context, the stateful part of this class
+            is a Tensor that is mutated in-place so that modifications made in the
+            JIT interpreter are visible outside of it.
+            """
+
+            def __init__(self, start: int):
+                self.count = torch.tensor([start], dtype=torch.double)
+
+            def __enter__(self):
+                self.count.add_(0.3)
+                return self.count
+
+            def __exit__(self, type: Any, value: Any, tb: Any):
+                self.count.sub_(0.3)
+
+        def test_basic(x):
+            # type: (Tensor) -> Tensor
+            """Basic test with one with-statement."""
+
+            c = Context(1)
+
+            with c:
+                y = x + c.count
+
+            y *= c.count
+            return y
+
+        def test_pass(x):
+            # type: (Tensor) -> Tensor
+            """
+            Test with a pass statement inside a with-statement. Although
+            the body of the with is empty, __enter__ and __exit__ should
+            still be called.
+            """
+            c = Context(1)
+
+            with c:
+                pass
+
+            x *= c.count
+            return x
+
+        def test_early_return(x, c):
+            # type: (Tensor, Context) -> Tensor
+            """
+            Test that returning early from inside a with-statement works
+            as expected.
+            """
+            with c:
+                y = x + c.count
+                return y
+
+            x = y + y
+            return x
+
+        def test_conditional_early_return(x, c):
+            # type: (Tensor, Context) -> Tensor
+            """
+            Test that conditionally returning early from inside a with-statement works
+            as expected.
+            """
+            with c:
+                y = x + c.count
+                if c.count > 0:
+                    return y
+
+            x = y + y
+            return x
+
+        def test_break(x, c, l):
+            # type: (Tensor, Context, List[int]) -> Tensor
+            """
+            Test that breaking early from inside a with-statement works
+            as expected.
+            """
+            with c:
+                for a in l:
+                    if a == 0:
+                        break
+                    x += a * c.count
+
+            return x
+
+        def test_continue(x, c, l):
+            # type: (Tensor, Context, List[int]) -> Tensor
+            """
+            Test that using continue inside a with-statement works
+            as expected.
+            """
+            with c:
+                for a in l:
+                    if a == 0:
+                        continue
+                    x += a * c.count
+
+            return x
+
+        def test_serial(x):
+            # type: (Tensor) -> Tensor
+            """
+            Test two with-statements in a row.
+            """
+            c = Context(1)
+
+            with c:
+                y = x + c.count
+
+            with c:
+                y *= c.count
+
+            return y
+
+        def test_nested(x):
+            # type: (Tensor) -> Tensor
+            """
+            Test nested with-statements.
+            """
+            c = Context(1)
+
+            with c:
+                with c:
+                    y = x + c.count
+
+                y *= c.count
+
+            return y
+
+        def test_combined(x):
+            # type: (Tensor) -> Tensor
+            """
+            Test a with-statement with multiple with items.
+            """
+            c = Context(1)
+            d = Context(2)
+
+            with c, d:
+                y = x + (c.count + d.count)
+
+            return y
+
+        test_input = torch.randn(2, 2)
+        test_context = Context(2)
+        test_list = [2, 0, 1, 3, 0, 2]
+
+        self.checkScript(test_basic, (test_input,))
+        self.checkScript(test_pass, (test_input,))
+        self.checkScript(test_early_return, (test_input, test_context))
+        self.checkScript(test_break, (test_input, test_context, test_list))
+        self.checkScript(test_continue, (test_input, test_context, test_list))
+        self.assertEqual(test_context.count, 2)
+        self.checkScript(test_serial, (test_input,))
+        self.checkScript(test_nested, (test_input,))
+        self.checkScript(test_combined, (test_input,))
+
+    def test_with_exceptions(self):
+        """
+        Check that exceptions thrown in the bodies of with-statements are
+        handled correctly.
+        """
+
+        @torch.jit.script
+        class Context(object):
+            """
+            This class implements a basic context manager interface for use in
+            the unit tests. Unlike Context, the stateful part of this class
+            is a Tensor that is mutated in-place so that modifications made in the
+            JIT interpreter are visible outside of it.
+            """
+
+            def __init__(self, start: int):
+                self.count = torch.tensor([start], dtype=torch.double)
+
+            def __enter__(self):
+                self.count.add_(0.3)
+                return self.count
+
+            def __exit__(self, type: Any, value: Any, tb: Any):
+                self.count.sub_(0.3)
+
+        def method_that_raises():
+            # type: () -> Tensor
+            raise Exception()
+
+        def test_exception(x, c):
+            # type: (Tensor, Context) -> Tensor
+            """
+            Test the case in which an exception is thrown while executing the body of a with-statement.
+            """
+            with c as _:
+                x += method_that_raises()
+
+            return x
+
+        def test_exception_nested(x, c):
+            # type: (Tensor, Context) -> Tensor
+            """
+            Test the case in which an exception is thrown while executing the body of a nested with-statement.
+            """
+            with c as _:
+                with c as _:
+                    x += method_that_raises()
+
+            return x
+
+        def with_that_raises(c):
+            # type: (Context) -> Tensor
+            a = torch.tensor([1])
+
+            with c as _:
+                a += method_that_raises()
+
+            return a
+
+        def test_exception_fn_call(x, c):
+            # type: (Tensor, Context) -> Tensor
+            """
+            Test the case in which an exception is thrown while there are active with-statements in two different
+            frames.
+            """
+            with c as _:
+                x += with_that_raises(c)
+
+            return x
+
+        c = Context(1)
+
+        with self.assertRaises(Exception):
+            test_exception(torch.randn(2), c)
+        self.assertEqual(c.count, 1)
+
+        with self.assertRaises(Exception):
+            test_exception_nested(torch.randn(2), c)
+        self.assertEqual(c.count, 1)
+
+        with self.assertRaises(Exception):
+            test_exception_fn_call(torch.randn(2), c)
+        self.assertEqual(c.count, 1)
+
+    def test_with_errors(self):
+        """
+        Check that errors related to with-statements are detected and reported correctly.
+        """
+
+        @torch.jit.script
+        class NoEnterNoExit(object):
+            """
+            This class is missing __enter__ and __exit__ methods.
+            """
+
+            def __init__(self):
+                self.count = 1
+
+        @torch.jit.script
+        class BadEnter(object):
+            """
+            This class is has an __enter__ method with an incorrect signature.
+            """
+
+            def __init__(self):
+                self.count = 1
+
+            def __enter__(self, incr: int):
+                self.count += incr
+
+            def __exit__(self, type: Any, value: Any, tb: Any):
+                pass
+
+        @torch.jit.script
+        class BadExit(object):
+            """
+            This class is has an __exit__ method with an incorrect signature.
+            """
+
+            def __init__(self):
+                self.count = 1
+
+            def __enter__(self):
+                self.count += 1
+
+            def __exit__(self, type: Any, value: Any):
+                pass
+
+        @torch.jit.script
+        class ExitIncorrectTypes(object):
+            """
+            This class is has an __exit__ method with unsupported argument types.
+            """
+
+            def __init__(self):
+                self.count = 1
+
+            def __enter__(self):
+                self.count += 1
+
+            def __exit__(self, type: Any, value: int, tb: int):
+                pass
+
+        def test_no_enter_no_exit(x, c):
+            # type: (Tensor, NoEnterNoExit) -> Tensor
+            with c as _:
+                pass
+
+            return x
+
+        def test_bad_enter(x, c):
+            # type: (Tensor, BadEnter) -> Tensor
+            with c as _:
+                pass
+
+            return x
+
+        def test_bad_exit(x, c):
+            # type: (Tensor, BadExit) -> Tensor
+            with c as _:
+                pass
+
+            return x
+
+        def test_exit_incorrect_types(x, c):
+            # type: (Tensor, ExitIncorrectTypes) -> Tensor
+            with c as _:
+                pass
+
+            return x
+
+        test_tensor = torch.randn(5, dtype=torch.double)
+
+        with self.assertRaisesRegex(
+            RuntimeError, r"does not define __enter__ and __exit__ methods"
+        ):
+            self.checkScript(test_no_enter_no_exit, (test_tensor, NoEnterNoExit()))
+
+        with self.assertRaisesRegex(
+            RuntimeError, r"__enter__ must have only one argument and one return value"
+        ):
+            self.checkScript(test_bad_enter, (test_tensor, BadEnter()))
+
+        with self.assertRaisesRegex(
+            RuntimeError, r"__exit__ must have four arguments and no return value"
+        ):
+            self.checkScript(test_bad_exit, (test_tensor, BadExit()))
+
+        with self.assertRaisesRegex(
+            RuntimeError, r"argument 2 of __exit__ must have Any type"
+        ):
+            self.checkScript(
+                test_exit_incorrect_types, (test_tensor, ExitIncorrectTypes())
+            )

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -28,6 +28,7 @@ from jit.test_torchbind import TestTorchbind  # noqa: F401
 from jit.test_op_normalization import TestOpNormalization  # noqa: F401
 from jit.test_module_interface import TestModuleInterface  # noqa: F401
 from jit.test_onnx_export import TestONNXExport  # noqa: F401
+from jit.test_with import TestWith  # noqa: F401
 
 # Torch
 from torch import Tensor

--- a/torch/csrc/jit/frontend/lexer.h
+++ b/torch/csrc/jit/frontend/lexer.h
@@ -107,7 +107,10 @@ namespace jit {
   _(TK_DELETE, "del", "del")                     \
   _(TK_PASS, "pass", "pass")                     \
   _(TK_CLASS_DEF, "class", "class")              \
-  _(TK_IMPORT, "import", "import")
+  _(TK_IMPORT, "import", "import")               \
+  _(TK_WITH, "with", "with")                     \
+  _(TK_WITH_ITEM, "withitem", "")                \
+  _(TK_AS, "as", "as")
 
 enum TokenKind {
   // we use characters to represent themselves so skip all valid characters

--- a/torch/csrc/jit/ir/alias_analysis.cpp
+++ b/torch/csrc/jit/ir/alias_analysis.cpp
@@ -534,6 +534,8 @@ void AliasDb::analyzeImpl(Node* node) {
       return;
     case prim::CallFunction:
     case prim::CallMethod:
+    case prim::Enter:
+    case prim::Exit:
       // TODO: this can be improved with summarizes of what the function does
       // for now we assume the worst
       // NB: update safeToChangeAliasingRelationship if changed

--- a/torch/csrc/jit/ir/ir.cpp
+++ b/torch/csrc/jit/ir/ir.cpp
@@ -1052,6 +1052,8 @@ bool Node::hasSideEffects() const {
     case prim::BailOut:
     case prim::rpc_async: // It represents RPC message sent.
     case aten::wait: // It can represent RPC message received.
+    case prim::Enter:
+    case prim::Exit:
       return true;
   }
 

--- a/torch/csrc/jit/python/python_tree_views.cpp
+++ b/torch/csrc/jit/python/python_tree_views.cpp
@@ -172,6 +172,11 @@ void initTreeViewBindings(PyObject* module) {
     return Delete::create(expr);
   }));
 
+  py::class_<WithItem, Expr>(m, "WithItem")
+      .def(py::init([](const SourceRange& range, const Expr& target, Var* var) {
+        return WithItem::create(range, target, wrap_maybe(range, var));
+      }));
+
   py::class_<Assign, Stmt>(m, "Assign")
       .def(py::init([](std::vector<Expr> lhs, const Expr& rhs) {
         auto li = wrap_list(rhs.range(), std::move(lhs));
@@ -235,6 +240,15 @@ void initTreeViewBindings(PyObject* module) {
                        const Expr& cond,
                        std::vector<Stmt> body) {
         return While::create(range, cond, wrap_list(range, std::move(body)));
+      }));
+  py::class_<With, Stmt>(m, "With").def(
+      py::init([](const SourceRange& range,
+                  std::vector<WithItem> targets,
+                  std::vector<Stmt> body) {
+        return With::create(
+            range,
+            wrap_list(range, std::move(targets)),
+            wrap_list(range, std::move(body)));
       }));
   py::class_<For, Stmt>(m, "For").def(py::init([](const SourceRange range,
                                                   std::vector<Expr>& targets,

--- a/torch/csrc/jit/runtime/instruction.h
+++ b/torch/csrc/jit/runtime/instruction.h
@@ -51,7 +51,9 @@ namespace jit {
   _(ISINSTANCE, "TI") /* check object is one of  types[X:X+N]  */           \
   _(TUPLE_SLICE, "II") /* slice tup[X:(X+N)] */                             \
   _(FORK, "CN") /* launch a thread to run code entry x with N inputs  */    \
-  _(WARN, "") /* emit a warning with line information */
+  _(WARN, "") /* emit a warning with line information */                    \
+  _(ENTER, "EN") /* enter scope of a contextmanager */                      \
+  _(EXIT, "EX") /* exit the last entered contextmanager */
 
 enum OpCode : uint8_t {
 #define DEFINE_OP(op, _) op,

--- a/torch/csrc/jit/runtime/operator.cpp
+++ b/torch/csrc/jit/runtime/operator.cpp
@@ -277,6 +277,8 @@ bool aliasAnalysisHasSpecialCaseFor(Symbol symbol) {
       prim::unchecked_cast,
       prim::tolist,
       prim::rpc_async,
+      prim::Enter,
+      prim::Exit,
   };
 
   // Operators that should not be used by alias analysis


### PR DESCRIPTION
**Summary**
This commit adds support for with statements to PyTorch JIT. Each
of the with items in a with statement is represented in the JIT IR
as a pair of `prim::Enter` and `prim::Exit` nodes that call the
`__enter__` and `__exit__` methods defined on the context manager objects
returned by the expressions in the with item.

**Testing**
This commit adds unit tests for with statements with named with items,
nameless with items, and with statements that encounter exceptions.
```
$ python test/test_jit.py TestWith.test_with_as
Fail to import hypothesis in common_utils, tests are not derandomized
.
----------------------------------------------------------------------
Ran 1 test in 0.430s

OK
```

```
$ python test/test_jit.py TestWith.test_with_no_as
Fail to import hypothesis in common_utils, tests are not derandomized
.
----------------------------------------------------------------------
Ran 1 test in 0.264s

OK
```

```
$ python test/test_jit.py TestWith.test_with_exceptions
Fail to import hypothesis in common_utils, tests are not derandomized
Couldn't download test skip set, leaving all tests enabled...
.
----------------------------------------------------------------------
Ran 1 test in 1.053s

OK
```