### PR TITLE
Deprecates current torch.full integral type inference, adds torch.full complex type inference

### DIFF
--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -134,6 +134,7 @@ Tensor empty_cpu(IntArrayRef size, const TensorOptions& options_, c10::optional<
 
   auto memory_format = options.memory_format_opt().value_or(MemoryFormat::Contiguous);
   tensor.unsafeGetTensorImpl()->empty_tensor_restride(memory_format);
+
   return tensor;
 }
 
@@ -346,6 +347,15 @@ Tensor full(IntArrayRef size, Scalar fill_value, const TensorOptions& options) {
   if (options.layout() == kSparse) {
     AT_ERROR("full(...) is not implemented for sparse layout");
   }
+
+  if (!options.has_dtype() && fill_value.isIntegral(true)) {
+    TORCH_WARN_ONCE(
+      "Deprecation warning: In PyTorch 1.6 full will return a LongTensor when ",
+      "given an integer fill_value. Use the optional dtype argument to ",
+      "specify the desired dtype explicitly and suppress this warning."
+    );
+  }
+
   auto result = at::empty(size, options);
   return result.fill_(fill_value);
 }
@@ -354,6 +364,7 @@ Tensor& full_out(Tensor& result, IntArrayRef size, Scalar fill_value) {
   if (result.is_sparse()) {
     AT_ERROR("full(...) is not implemented for sparse layout");
   }
+
   result.resize_(size);
   return result.fill_(fill_value);
 }
@@ -960,6 +971,19 @@ Tensor full(
     Scalar fill_value,
     optional<DimnameList> names,
     const TensorOptions& options) {
+
+  if (options.layout() == kSparse) {
+    AT_ERROR("full(...) is not implemented for sparse layout");
+  }
+
+  if (!options.has_dtype() && fill_value.isIntegral(true)) {
+    TORCH_WARN_ONCE(
+      "Deprecation warning: In PyTorch 1.6 full will return a LongTensor when ",
+      "given an integer fill_value. Use the optional dtype argument to ",
+      "specify the desired dtype explicitly and suppress this warning."
+    );
+  }
+
   auto result = at::empty(size, names, options);
   return result.fill_(fill_value);
 }

--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -436,11 +436,11 @@ Tensor logspace(
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ones ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Tensor ones(IntArrayRef size, const TensorOptions& options) {
-  return native::full(size, /*fill_value=*/1, options);
+  return native::full(size, /*fill_value=*/1., options);
 }
 
 Tensor& ones_out(Tensor& result, IntArrayRef size) {
-  return native::full_out(result, size, /*fill_value=*/1);
+  return native::full_out(result, size, /*fill_value=*/1.);
 }
 
 Tensor ones_like(
@@ -448,7 +448,7 @@ Tensor ones_like(
     const TensorOptions& options,
     c10::optional<c10::MemoryFormat> optional_memory_format) {
   auto result = at::empty_like(self, options, optional_memory_format);
-  return result.fill_(1);
+  return result.fill_(1.);
 }
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ scalar_tensor ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -778,7 +778,7 @@ Tensor zeros(IntArrayRef size, const TensorOptions& options) {
 
 Tensor& zeros_out(Tensor& result, IntArrayRef size) {
   if (result.is_sparse()) {
-    result.sparse_resize_and_clear_(size, size.size(), 0);
+    result.sparse_resize_and_clear_(size, size.size(), 0.);
     return result;
   } else {
     result.resize_(size);
@@ -1005,14 +1005,14 @@ Tensor ones(
     IntArrayRef size,
     optional<DimnameList> names,
     const TensorOptions& options) {
-  return native::full(size, /*fill_value=*/1, names, options);
+  return native::full(size, /*fill_value=*/1., names, options);
 }
 
 Tensor zeros(
     IntArrayRef size,
     optional<DimnameList> names,
     const TensorOptions& options) {
-  return native::full(size, /*fill_value=*/0, names, options);
+  return native::full(size, /*fill_value=*/0., names, options);
 }
 
 Tensor randn(

--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -353,13 +353,11 @@ TensorOptions infer_full_options(
   if (!options.has_dtype()) {
     if (fill_value.isIntegral(true)) {
       TORCH_WARN_ONCE(
-        "Deprecation warning: In PyTorch 1.6 torch.full with a bool or ",
-        "integral fill_value will require a dtype or out argument. ",
-        "In PyTorch 1.7, when `out` and `dtype` are not set a bool fill_value ",
-        "will return a tensor of torch.bool dtype, ",
-        "and an integral fill_value will return a tensor of torch.long ",
-        "dtype. ",
-        "Set the optional dtype or out arguments to suppress this warning. "
+        "Deprecation warning: In a future PyTorch release torch.full ",
+        "will no longer return tensors of floating dtype by default. ",
+        "Instead, a bool fill_value will return a tensor of torch.bool dtype, ",
+        "and an integral fill_value will return a tensor of torch.long dtype. ",
+        "Set the optional `dtype` or `out` arguments to suppress this warning."
       );
     } else if (fill_value.isComplex()) {
       auto scalar_type = (get_default_dtype() == ScalarType::Double) ?

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1764,6 +1764,14 @@ class _TestTorchMixin(object):
             self.assertIs(torch.int64, torch.randint(*args, size=size, out=out).dtype)
             self.assertIs(torch.int64, torch.randint(*args, size=size, out=out, dtype=torch.int64).dtype)
 
+    def test_full_inference(self):
+        size = (1, 2)
+        with self.maybeWarnsRegex(UserWarning, 'Deprecation warning: .+'):
+            torch.full(size, 1)
+
+        with self.maybeWarnsRegex(UserWarning, 'Deprecation warning: .+|Named tensors .+'):
+            torch.full(size, 1, names=('a', 'b'))
+
     def test_broadcast_empty(self):
         # empty + empty
         self.assertRaises(RuntimeError, lambda: torch.randn(5, 0) + torch.randn(0, 5))
@@ -12999,11 +13007,19 @@ class TestTorchDeviceType(TestCase):
                 # successful albeit with a singular input. Therefore,
                 # we require info.min() >= 0
                 self.assertGreaterEqual(info_.min(), 0)
+                print("DEBUG")
+                print(a)
                 a_LU, pivots = a.lu(pivot=pivot)
+                print(a_LU)
                 self.assertEqual(a_LU, a_LU_info)
                 self.assertEqual(pivots_info, pivots)
 
+                # print(a_LU)
                 P, L, U = torch.lu_unpack(a_LU, pivots)
+                # print(L)
+                # print(U)
+                # print(a)
+                # print(P.matmul(L.matmul(U)))
                 self.assertEqual(P.matmul(L.matmul(U)), a)
 
                 if self.device_type == 'cuda':
@@ -15695,7 +15711,7 @@ _types = [
     torch.uint8
 ]
 
-# _types2 adds bfloat16 type to  _types only on ROCm. Should eventually be unified 
+# _types2 adds bfloat16 type to  _types only on ROCm. Should eventually be unified
 # with _types when bfloat16 bringup is complete on all platforms.
 _types2 = _types + [torch.bfloat16] if TEST_WITH_ROCM else _types
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -31,7 +31,7 @@ from multiprocessing.reduction import ForkingPickler
 from torch.testing._internal.common_device_type import instantiate_device_type_tests, \
     skipCPUIfNoLapack, skipCUDAIfNoMagma, skipCUDAIfRocm, skipCUDAIfNotRocm, onlyCUDA, onlyCPU, \
     dtypes, dtypesIfCUDA, deviceCountAtLeast, skipCUDAIf, precisionOverride, \
-    PYTORCH_CUDA_MEMCHECK, largeCUDATensorTest
+    PYTORCH_CUDA_MEMCHECK, largeCUDATensorTest, onlyOnCPUAndCUDA
 import torch.backends.quantized
 import torch.testing._internal.data
 
@@ -13756,7 +13756,7 @@ class TestTorchDeviceType(TestCase):
 
             # classical eigenvalue problem, smallest eigenvalues
             E, V = lobpcg(A, k=k, n=n, largest=False)
-            self.assertEqual(E, e_smallest)            
+            self.assertEqual(E, e_smallest)
             self.assertEqual(matmul(A, V), mm(V, E.diag_embed()), prec=prec)
 
             # classical eigenvalue problem, largest eigenvalues
@@ -15049,6 +15049,7 @@ scipy_lobpcg  | {:10.2e}  | {:10.2e}  | {:6} | N/A
             dt = torch.full(size, 1, names=('a', 'b'), dtype=torch.long).dtype
             self.assertEqual(dt, torch.long)
 
+    @onlyOnCPUAndCUDA
     @dtypes(torch.half, torch.float, torch.double)
     def test_full_inference(self, device, dtype):
         size = (2, 2)
@@ -15077,8 +15078,9 @@ scipy_lobpcg  | {:10.2e}  | {:10.2e}  | {:6} | N/A
 
         torch.set_default_dtype(prev_default)
 
-    # Full-like precendence is the explicit dtype then the dtype of the "like"
+    # Full-like precedence is the explicit dtype then the dtype of the "like"
     # tensor.
+    @onlyOnCPUAndCUDA
     def test_full_like_inference(self, device):
         size = (2, 2)
         like = torch.empty((5,), device=device, dtype=torch.long)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -15021,6 +15021,83 @@ scipy_lobpcg  | {:10.2e}  | {:10.2e}  | {:6} | N/A
             self.assertRaises(RuntimeError,
                               lambda: torch.min(a, 0, out=(values, indices)))
 
+    def test_full_deprecation_warning(self, device):
+        size = (2, 2)
+        # Tests bool and integer fill_values deprecated without specific dtype set
+        with self.maybeWarnsRegex(UserWarning, 'Deprecation warning: .+'):
+            self.assertEqual(torch.full(size, True).dtype, torch.float)
+        with self.maybeWarnsRegex(UserWarning, 'Deprecation warning: .+'):
+            self.assertEqual(torch.full(size, 1).dtype, torch.float)
+
+        # Explicitly setting the dtype doesn't warn
+        with self.maybeWarnsRegex(UserWarning, ''):
+            self.assertEqual(torch.full(size, 1, dtype=torch.long).dtype, torch.long)
+        with self.maybeWarnsRegex(UserWarning, ''):
+            self.assertEqual(torch.full(size, True, dtype=torch.bool).dtype,
+                             torch.bool)
+
+        # Performs same tests with named tensor
+        with self.maybeWarnsRegex(UserWarning, 'Deprecation warning: .+|Named tensors .+'):
+            self.assertEqual(torch.full(size, True, names=('a', 'b')).dtype, torch.float)
+        with self.maybeWarnsRegex(UserWarning, 'Deprecation warning: .+|Named tensors .+'):
+            self.assertEqual(torch.full(size, 1, names=('a', 'b')).dtype, torch.float)
+
+        with self.maybeWarnsRegex(UserWarning, 'Named tensors .+'):
+            dt = torch.full(size, True, names=('a', 'b'), dtype=torch.bool).dtype
+            self.assertEqual(dt, torch.bool)
+        with self.maybeWarnsRegex(UserWarning, 'Named tensors .+'):
+            dt = torch.full(size, 1, names=('a', 'b'), dtype=torch.long).dtype
+            self.assertEqual(dt, torch.long)
+
+    @dtypes(torch.half, torch.float, torch.double)
+    def test_full_inference(self, device, dtype):
+        size = (2, 2)
+
+        prev_default = torch.get_default_dtype()
+        torch.set_default_dtype(dtype)
+
+        # Tests bool fill value inference
+        # Note: in the future this will return a tensor of torch.bool dtype
+        t = torch.full(size, True)
+        self.assertEqual(t.dtype, dtype)
+
+        # Tests integer fill value inference
+        # Note: in the future this will return a tensor of torch.long dtype
+        t = torch.full(size, 1)
+        self.assertEqual(t.dtype, dtype)
+
+        # Tests float fill value inference
+        t = torch.full(size, 1.)
+        self.assertEqual(t.dtype, dtype)
+
+        # Tests complex inference
+        t = torch.full(size, (1 + 1j))
+        ctype = torch.complex128 if dtype is torch.double else torch.complex64
+        self.assertEqual(t.dtype, ctype)
+
+        torch.set_default_dtype(prev_default)
+
+    # Full-like precendence is the explicit dtype then the dtype of the "like"
+    # tensor.
+    def test_full_like_inference(self, device):
+        size = (2, 2)
+        like = torch.empty((5,), device=device, dtype=torch.long)
+
+        self.assertEqual(torch.full_like(like, 1.).dtype, torch.long)
+        self.assertEqual(torch.full_like(like, 1., dtype=torch.complex64).dtype,
+                         torch.complex64)
+
+    def test_full_out(self, device):
+        o = torch.empty((5,), device=device, dtype=torch.long)
+
+        # verifies dtype/out conflict throws a RuntimeError
+        with self.assertRaises(RuntimeError):
+            torch.full(o.shape, 1., dtype=torch.float, out=o)
+
+        # verifies out dtype overrides inference
+        self.assertEqual(torch.full(o.shape, 1., out=o).dtype, o.dtype)
+
+
 # NOTE [Linspace+Logspace precision override]
 # Our Linspace and logspace torch.half CUDA kernels are not very precise.
 # Since linspace/logspace are deterministic, we can compute an expected
@@ -15422,47 +15499,6 @@ class TestDevicePrecision(TestCase):
         x = torch.randn(100, 100, device=devices[1], dtype=torch.float32)
         output = torch.ones_like(x)
         self.assertEqual(output, expected)
-
-    def test_full_deprecation_warning(self, device):
-        size = (1, 2)
-        # Tests integer fill_values deprecated without specific dtype set
-        with self.maybeWarnsRegex(UserWarning, 'Deprecation warning: .+'):
-            torch.full(size, 1)
-        torch.full(size, 1, dtype=torch.int)
-
-        # Tests integer fill_values deprecated with named tensors, too
-        with self.maybeWarnsRegex(UserWarning, 'Deprecation warning: .+|Named tensors .+'):
-            torch.full(size, 1, names=('a', 'b'))
-        with self.maybeWarnsRegex(UserWarning, 'Named tensors .+'):
-            torch.full(size, 1, names=('a', 'b'), dtype=torch.float)
-
-    @dtypes(torch.half, torch.float, torch.double)
-    def test_full_inference(self, device, dtype):
-        size = (1, 2)
-
-        prev_default = torch.get_default_dtype()
-        torch.set_default_dtype(dtype)
-
-        # Tests bool fill value inference
-        # Note: in the future this will return a tensor of torch.bool dtype
-        t = torch.full(size, True)
-        self.assertEqual(t.dtype, dtype)
-
-        # Tests integer fill value inference
-        # Note: in the future this will return a tensor of torch.long dtype
-        t = torch.full(size, 1)
-        self.assertEqual(t.dtype, dtype)
-
-        # Tests float fill value inference
-        t = torch.full(size, 1.)
-        self.assertEqual(t.dtype, dtype)
-
-        # Tests complex inference
-        t = torch.full(size, (1 + 1j))
-        ctype = torch.complex128 if dtype is torch.double else torch.complex64
-        self.assertEqual(t.dtype, ctype)
-
-        torch.set_default_dtype(prev_default)
 
 
 # Tests ops and indexing to ensure they return views (and new tensors) as

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -61,7 +61,7 @@ SKIP_PYTHON_BINDINGS = [
     '_cumsum.*', '_cumprod.*', '_sum.*', '_prod.*',
     '_th_.*', '_thnn_.*',
     'arange.*', 'range.*', '_solve.*', '_inverse.*',
-    'full.names', 'full.out', 'full',
+    'full(_out)?',
     '_cholesky.*', '_triangular_solve.*', '_qr.*', '_symeig.*', '_svd.*',
     'slice', 'randint(_out)?',
     'item', '_local_scalar_dense', 'to',

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -61,6 +61,7 @@ SKIP_PYTHON_BINDINGS = [
     '_cumsum.*', '_cumprod.*', '_sum.*', '_prod.*',
     '_th_.*', '_thnn_.*',
     'arange.*', 'range.*', '_solve.*', '_inverse.*',
+    'full.names', 'full.out', 'full',
     '_cholesky.*', '_triangular_solve.*', '_qr.*', '_symeig.*', '_svd.*',
     'slice', 'randint(_out)?',
     'item', '_local_scalar_dense', 'to',

--- a/tools/autograd/templates/python_torch_functions.cpp
+++ b/tools/autograd/templates/python_torch_functions.cpp
@@ -267,7 +267,8 @@ static PyObject * THPVariable_full(PyObject* self, PyObject* args, PyObject* kwa
     }
 
     // Converts from c10::optional<std:vector...> to c10::optional<ArrayRef...>
-    c10::optional<DimnameList> names(*r.toDimnameListOptional(2));
+    auto raw_names = r.toDimnameListOptional(2);
+    c10::optional<DimnameList> names(*raw_names);
     return wrap(dispatch_full(size, fill_val, names, options).set_requires_grad(r.toBool(7)));
   }
 

--- a/tools/pyi/gen_pyi.py
+++ b/tools/pyi/gen_pyi.py
@@ -449,10 +449,10 @@ def gen_pyi(declarations_path, out):
                     .format(FACTORY_PARAMS),
                     'def randint(high: _int, size: _size, *, {}) -> Tensor: ...'
                     .format(FACTORY_PARAMS)],
-        'full': ['def full(size: IntArrayRef, fill_value: Number, *,'
+        'full': ['def full(size: _size, fill_value: Number, *,'
                  ' out: Optional[Tensor]=None, {}) -> Tensor: ...'
                  .format(FACTORY_PARAMS),
-                 'def full(size: IntArrayRef, fill_value: Number, *,'
+                 'def full(size: _size, fill_value: Number, *,'
                  ' names: List[Union[str, None]], {}) -> Tensor: ...'
                  .format(FACTORY_PARAMS)],
         'is_grad_enabled': ['def is_grad_enabled() -> _bool: ...']

--- a/tools/pyi/gen_pyi.py
+++ b/tools/pyi/gen_pyi.py
@@ -449,6 +449,12 @@ def gen_pyi(declarations_path, out):
                     .format(FACTORY_PARAMS),
                     'def randint(high: _int, size: _size, *, {}) -> Tensor: ...'
                     .format(FACTORY_PARAMS)],
+        'full': ['def full(size: IntArrayRef, fill_value: Number, *,'
+                 ' out: Optional[Tensor]=None, {}) -> Tensor: ...'
+                 .format(FACTORY_PARAMS),
+                 'def full(size: IntArrayRef, fill_value: Number, *,'
+                 ' names: List[Union[str, None]], {}) -> Tensor: ...'
+                 .format(FACTORY_PARAMS)],
         'is_grad_enabled': ['def is_grad_enabled() -> _bool: ...']
     })
     for binop in ['mul', 'div']:
@@ -456,7 +462,7 @@ def gen_pyi(declarations_path, out):
             'def {}(input: Union[Tensor, Number],'
             ' other: Union[Tensor, Number],'
             ' *, out: Optional[Tensor]=None) -> Tensor: ...'.format(binop))
-    for binop in ['add', 'sub']: 
+    for binop in ['add', 'sub']:
         unsorted_function_hints[binop].append(
             'def {}(input: Union[Tensor, Number],'
             ' other: Union[Tensor, Number],'
@@ -543,8 +549,8 @@ def gen_pyi(declarations_path, out):
             unsorted_tensor_method_hints[binop].append(
                 'def {}(self, other: Union[Tensor, Number]{})'
                 ' -> Tensor: ...'.format(binop, out_suffix))
-    for binop in ['add', 'sub']: 
-        for inplace in [False, True]: 
+    for binop in ['add', 'sub']:
+        for inplace in [False, True]:
             out_suffix = ', out: Optional[Tensor]=None'
             if inplace:
                 binop += '_'

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -6486,9 +6486,9 @@ full(size, fill_value, out=None, dtype=None, layout=torch.strided, device=None, 
 Returns a tensor of size :attr:`size` filled with :attr:`fill_value`.
 
 .. warning::
-    In PyTorch 1.5 integral ``fill_value`s will produce a warning if `out`
+    In PyTorch 1.5 integral `fill_value`s will produce a warning if `out`
     or `dtype` are not set, and in PyTorch 1.6 this will produce an error.
-    In PyTorch 1.7, integral ``fill_value`s will return LongTensors by default.
+    In PyTorch 1.7, integral `fill_value`s will return LongTensors by default.
 
 Args:
     size (int...): a list, tuple, or :class:`torch.Size` of integers defining the

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -6485,6 +6485,11 @@ full(size, fill_value, out=None, dtype=None, layout=torch.strided, device=None, 
 
 Returns a tensor of size :attr:`size` filled with :attr:`fill_value`.
 
+.. warning::
+    In PyTorch 1.5 integral ``fill_value`s will produce a warning if `out`
+    or `dtype` are not set, and in PyTorch 1.6 this will produce an error.
+    In PyTorch 1.7, integral ``fill_value`s will return LongTensors by default.
+
 Args:
     size (int...): a list, tuple, or :class:`torch.Size` of integers defining the
         shape of the output tensor.

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -6486,9 +6486,11 @@ full(size, fill_value, out=None, dtype=None, layout=torch.strided, device=None, 
 Returns a tensor of size :attr:`size` filled with :attr:`fill_value`.
 
 .. warning::
-    In PyTorch 1.5 integral `fill_value`s will produce a warning if `out`
+    In PyTorch 1.5 bool or integral `fill_value`s will produce a warning if `out`
     or `dtype` are not set, and in PyTorch 1.6 this will produce an error.
-    In PyTorch 1.7, integral `fill_value`s will return LongTensors by default.
+    In PyTorch 1.7, when `out` and `dtype` are not set a bool `fill_value` will
+    return a tensor of torch.bool dtype, and an integral `fill_value` will
+    return a tensor of torch.long dtype.
 
 Args:
     size (int...): a list, tuple, or :class:`torch.Size` of integers defining the

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -6486,11 +6486,11 @@ full(size, fill_value, out=None, dtype=None, layout=torch.strided, device=None, 
 Returns a tensor of size :attr:`size` filled with :attr:`fill_value`.
 
 .. warning::
-    In PyTorch 1.5 bool or integral `fill_value`s will produce a warning if `out`
-    or `dtype` are not set, and in PyTorch 1.6 this will produce an error.
-    In PyTorch 1.7, when `out` and `dtype` are not set a bool `fill_value` will
-    return a tensor of torch.bool dtype, and an integral `fill_value` will
-    return a tensor of torch.long dtype.
+    In PyTorch 1.5 bool or integral :attr:`fill_value`s will produce a warning if
+    :attr:`dtype` or :attr:`out` are not set.
+    In a future PyTorch release, when :attr:`dtype` and :attr:`out` are not set
+    a bool :attr:`fill_value` will return a tensor of torch.bool dtype,
+    and an integral :attr:`fill_value` will return a tensor of torch.long dtype.
 
 Args:
     size (int...): a list, tuple, or :class:`torch.Size` of integers defining the

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -1421,14 +1421,14 @@ def ones_like(g, input, dtype=None, layout=None, device=None, pin_memory=False, 
 
 
 def full(g, sizes, value, dtype, layout, device, pin_memory=False):
-    if dtype is None:
-        dtype = 6  # float
     const_value = sym_help._maybe_get_const(value, 't')
     if sym_help._is_value(const_value):
+        dtype = 6 if dtype is None else dtype
         tmp = zeros(g, sizes, dtype, layout, device)
         return add(g, tmp, value, g.op("Constant", value_t=torch.tensor(1)))
     else:
         dtype = sym_help._get_const(dtype, 'i', 'dtype')
+        dtype = 6 if dtype is None else dtype
         return g.op("ConstantOfShape", sizes,
                     value_t=torch.tensor([const_value], dtype=sym_help.scalar_type_to_pytorch_type[dtype]))
 


### PR DESCRIPTION
UPDATE

BC-breaking release note info:

In a future PyTorch release, torch.full will infer its dtype from its fill value when the optional dtype and out parameters are unspecified. For example, torch.full(size, 1) will return a tensor of torch.long dtype, unlike today where it returns a tensor of torch.float dtype. 

// ------- (PR info below) ------- // 

Per title.

Currently torch.full will always (attempt to) produce a float tensor. This is inconsistent with NumPy in (at least) two cases:

- When integral fill values (including bool) are given
- When complex fill values are given

For example:

```
np.full((1, 2), 1).dtype
: dtype('int64')

np.full((1, 2), (1 + 1j)).dtype
: dtype('complex128')
```

Whereas in PyTorch 

```
torch.full((1, 2), 1).dtype
: torch.float32

torch.full((1, 2), (1 + 1j)).dtype
: RuntimeError: value cannot be converted to type float without overflow: (1,1)
```

This PR begins the process of deprecating our current behavior of returning float tensors (by default) when given integer fill values by warning the user that integer fill values will require explicitly specifying the dtype or out kwargs in 1.6, and in 1.7 the behavior will change to return a LongTensor by default (BoolTensor for bool values). The intermediate 1.6 release is to prevent changing the behavior silently and unexpectedly.

The PR also implements inference for complex types. So that with it:

```
torch.full((1, 2), (1 + 1j)).dtype
: torch.complex64
```

The complex type inference returns a ComplexFloat tensor when given a complex fill value (and no dtype or out kwarg is specified), unless the default dtype is Double, in which case a ComplexDouble tensor is returned. 

A test for these behaviors is added to test_torch.py. 

Implementation note:

This PR required customizing full's dispatch because currently in eager codegen the TensorOptions object passed to functions improperly sets has_dtype() to true, even if the user did not explicitly provide a dtype. torch.arange already worked around this issue with its own custom implementation. The JIT, however, does pass a properly constructed TensorOptions object. 

Future Work:

This PR does not extend torch.full's complex type inference to ONNX. This seems unlikely to come up and will be a clear error if it does. When integer type inference is added to torch.full, however, then porting the behavior to ONNX may be warranted. torch.arange ported its complex type promotion logic to ONNX, for example. 

Additionally, this PR mostly leaves existing call sites in PyTorch that would trigger this warning intact. This is to be more minimal (since the PR is BC breaking). I will submit a separate PR fixing PyTorch's call sites. 