### PR TITLE
Mark PyTorch incompatible with python-3.6.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -875,7 +875,7 @@ if __name__ == '__main__':
         download_url='https://github.com/pytorch/pytorch/tags',
         author='PyTorch Team',
         author_email='packages@pytorch.org',
-        python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
+        python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.6.0',
         # PyPI package information.
         classifiers=[
             'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Per https://github.com/pytorch/pytorch/issues/19161 PyTorch is incompatible with 3.6.0 due to the missing `PySlice_Unpack`

Test Plan: CI + try to load pytorch binary using python-3.6.0

