### PR TITLE
[noland] [pytorch] aten codegen to filter backward ops / backends for inference-only mobile build

### DIFF
--- a/cmake/Codegen.cmake
+++ b/cmake/Codegen.cmake
@@ -152,6 +152,15 @@ if (INTERN_BUILD_ATEN_OPS)
   endif()
 
   set(CUSTOM_BUILD_FLAG)
+
+  if(INTERN_BUILD_MOBILE)
+    list(APPEND CUSTOM_BUILD_FLAG --backend_whitelist CPU QuantizedCPU)
+  endif()
+
+  if(INTERN_DISABLE_AUTOGRAD)
+    list(APPEND CUSTOM_BUILD_FLAG --disable-autograd)
+  endif()
+
   if (SELECTED_OP_LIST)
     if (NOT USE_STATIC_DISPATCH AND NOT OP_DEPENDENCY)
       message(FATAL_ERROR "Must provide op dependency graph .yaml file for custom build with dynamic dispatch!")
@@ -165,7 +174,7 @@ if (INTERN_BUILD_ATEN_OPS)
     )
     separate_arguments(OP_REGISTRATION_WHITELIST)
     message(STATUS "Custom build with op registration whitelist: ${OP_REGISTRATION_WHITELIST}")
-    set(CUSTOM_BUILD_FLAG
+    list(APPEND CUSTOM_BUILD_FLAG
       --op_registration_whitelist ${OP_REGISTRATION_WHITELIST})
   endif()
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

This is to address the mobile build size regression caused by moving c10
registers out of `#ifndef USE_STATIC_DISPATCH` in ATen/gen.py.

To measure Android AAR build size:
```
scripts/build_pytorch_android.sh armeabi-v7a
```

This PR improved: 6.4M -> 5.8M
Baseline (before enabling c10 registers for static dispatch): 5.5M

Differential Revision: [D20374731](https://our.internmc.facebook.com/intern/diff/D20374731/)