### PR TITLE
Do not throw from CUDAContext destructor

### DIFF
--- a/caffe2/core/context_gpu.h
+++ b/caffe2/core/context_gpu.h
@@ -169,18 +169,7 @@ class CAFFE2_CUDA_API CUDAContext final : public BaseContext {
   explicit CUDAContext(Device device)
       : CUDAContext(DeviceToOption(device)) {}
 
-  ~CUDAContext() override {
-    if (curand_generator_) {
-      CURAND_CHECK(curandDestroyGenerator(curand_generator_));
-    }
-    // CUDAContext is used in 2 cases now:
-    // - long-lived instance inside OperatorBase in which case what happens in
-    //   destructor doesn't really matter
-    // - short-lived on-the-fly instances that are utilized as CUDAGuard - in
-    //   this case there's only one stream id (passed to SwitchToDevice) and
-    //   it's preferrable to synchronize in the destructor
-    FinishDeviceComputation();
-  }
+  ~CUDAContext() override;
 
   inline void SwitchToDevice(StreamId stream_id) override {
     getCudaObjects().SetCurrentStreamId(gpu_id_, stream_id);


### PR DESCRIPTION
Throwing from destructor leads to undefined behaviour (most often to segault)
So it's better to leak memory then segault

Test Plan: Run `test_pytorch_onnx_caffe2`

