### PR TITLE
pop warning message for multiprocessing and cuda module when asan is built in

### DIFF
--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -422,6 +422,15 @@ static void bindCudaDeviceProperties(PyObject* module) {
 // Callback for python part. Used for additional initialization of python classes
 static PyObject * THCPModule_initExtension(PyObject *self, PyObject *noargs)
 {
+#if defined(__has_feature)
+#if __has_feature(address_sanitizer)
+  TORCH_WARN(
+    "torch.cuda: your pytorch binary has address sanitizer (asan) built in, "
+    "asan is currently not compatiable with torch.cuda module, "
+    "you might get unexpected behavior (eg. out of memory, crash, etc.), "
+    "please rebuild pytorch without asan if you need to use this module");
+#endif
+#endif
   HANDLE_TH_ERRORS
   TORCH_INTERNAL_ASSERT(!in_bad_fork);  // Handled at python level
   poison_fork();

--- a/torch/csrc/multiprocessing/init.cpp
+++ b/torch/csrc/multiprocessing/init.cpp
@@ -19,6 +19,15 @@ namespace multiprocessing {
 namespace {
 
 PyObject* multiprocessing_init(PyObject* _unused, PyObject *noargs) {
+#if defined(__has_feature)
+#if __has_feature(address_sanitizer)
+  TORCH_WARN(
+    "torch.multiprocessing: your pytorch binary has address sanitizer (asan) built in, "
+    "asan is currently not compatiable with spawn-based (start method is 'spawn') multiprocessing "
+    "which is provided in this module, you might get unexpected behavior (eg. missing attribute, crash, etc.), "
+    "please rebuild pytorch without asan if you need spawn-based multiprocessing");
+#endif
+#endif
   auto multiprocessing_module =
       THPObjectPtr(PyImport_ImportModule("torch.multiprocessing"));
   if (!multiprocessing_module) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#34759 pop warning message for multiprocessing and cuda module when asan is built in**

Differential Revision: [D20454594](https://our.internmc.facebook.com/intern/diff/D20454594)