### PR TITLE
Fix missing header

### DIFF
--- a/caffe2/quantization/server/fbgemm_pack_blob.h
+++ b/caffe2/quantization/server/fbgemm_pack_blob.h
@@ -4,6 +4,7 @@
 
 #include <fbgemm/Fbgemm.h>
 
+#include <caffe2/core/tensor.h>
 #include "caffe2/quantization/server/dnnlowp.h"
 
 namespace caffe2 {


### PR DESCRIPTION
Summary: So far it's by luck that we somehow include "caffe2/core/tensor.h" before including "caffe2/caffe2/quantization/server/fbgemm_pack_blob.h". This is not safe and this diff fixes it.

Test Plan: unittest

Differential Revision: D20455352

