### PR TITLE
Fix backward compatibility check test for schemas containing

### DIFF
--- a/test/backward_compatibility/check_backward_compatibility.py
+++ b/test/backward_compatibility/check_backward_compatibility.py
@@ -109,9 +109,6 @@ if __name__ == '__main__':
             line = f.readline()
             if not line:
                 break
-            if "torch.classes" in line:
-                # TODO Fix type __torch__.torch.classes.xxx
-                continue
 
             s = parse_schema(line.strip())
             slist = new_schema_dict.get(s.name, [])


### PR DESCRIPTION
"torch.classes".

Summary:
BC check tests skips adding torch.classes based schemas to existing
schemas. Removed the skip.

Test Plan:
cd test/backward_compatibility
python dump_all_function_schemas.py --filename new_schemas.txt
python check_backward_compatibility.py --new-schemas new_schemas.txt

Before this PR fails with:
```
Mar 15 11:12:20 Broken ops: [
Mar 15 11:12:20 	_xnnpack::conv2d_packed(Tensor X, __torch__.torch.classes.XNNPackConv2dOpContext W_prepack) -> (Tensor Y)
Mar 15 11:12:20 	_xnnpack::conv2d_prepack(Tensor W, Tensor? B, int[2] stride, int[2] padding, int[2] dilation, int groups) -> (__torch__.torch.classes.XNNPackConv2dOpContext)
Mar 15 11:12:20 	_xnnpack::linear_packed(Tensor X, __torch__.torch.classes.XNNPackLinearOpContext W_prepack) -> (Tensor Y)
Mar 15 11:12:20 	_xnnpack::linear_prepack(Tensor W, Tensor? B=None) -> (__torch__.torch.classes.XNNPackLinearOpContext)
Mar 15 11:12:20 ]
```
After this PR, it passes.

Reviewers:

Subscribers:

Tasks:

Tags:

