### PR TITLE
[C++ API Parity] [Optimizers] added closure to optimizers

### DIFF
--- a/test/cpp/api/optim.cpp
+++ b/test/cpp/api/optim.cpp
@@ -168,7 +168,7 @@ TEST(OptimTest, OptimizerAccessors) {
 TEST(OptimTest, BasicInterface) {
   struct MyOptimizer : Optimizer {
     using Optimizer::Optimizer;
-    void step() override {}
+    torch::Tensor step(LossClosure closure = nullptr) override { return {};}
   };
   std::vector<torch::Tensor> parameters = {
       torch::ones({2, 3}), torch::zeros({2, 3}), torch::rand({2, 3})};

--- a/test/cpp/api/serialize.cpp
+++ b/test/cpp/api/serialize.cpp
@@ -100,7 +100,8 @@ void test_serialize_optimizer(DerivedOptimizerOptions options) {
     optimizer.zero_grad();
     auto y = model->forward(x).sum();
     y.backward();
-    optimizer.step();
+    auto closure = []() { return torch::tensor({10}); };
+    optimizer.step(closure);
   };
 
   // Do 2 steps of model1

--- a/torch/csrc/api/include/torch/optim/adagrad.h
+++ b/torch/csrc/api/include/torch/optim/adagrad.h
@@ -68,7 +68,7 @@ class TORCH_API Adagrad : public Optimizer {
       std::vector<Tensor> params,
       AdagradOptions defaults) : Adagrad({std::move(OptimizerParamGroup(params))}, defaults) {}
 
-  void step() override;
+  torch::Tensor step(LossClosure closure = nullptr) override;
 
   /// Adds the given vector of parameters to the optimizer's parameter list.
   void add_parameters(const std::vector<Tensor>& parameters) override;

--- a/torch/csrc/api/include/torch/optim/adam.h
+++ b/torch/csrc/api/include/torch/optim/adam.h
@@ -61,7 +61,7 @@ class TORCH_API Adam : public Optimizer {
        std::vector<Tensor> params,
        AdamOptions defaults) : Adam({std::move(OptimizerParamGroup(params))}, defaults) {}
 
-  void step() override;
+  torch::Tensor step(LossClosure closure = nullptr) override;
   void save(serialize::OutputArchive& archive) const override;
   void load(serialize::InputArchive& archive) override;
 

--- a/torch/csrc/api/include/torch/optim/optimizer.h
+++ b/torch/csrc/api/include/torch/optim/optimizer.h
@@ -199,8 +199,9 @@ TORCH_API serialize::InputArchive& operator>>(
 /// according to the concrete optimization algorithm.
 class Optimizer : public detail::OptimizerBase {
  public:
-  using detail::OptimizerBase::OptimizerBase;
-  virtual void step() = 0;
+   using LossClosure = std::function<Tensor()>;
+   using detail::OptimizerBase::OptimizerBase;
+   virtual Tensor step(LossClosure closure = nullptr) = 0;
 };
 
 /// Optimizer that requires the loss function to be supplied to the `step()`

--- a/torch/csrc/api/include/torch/optim/optimizer.h
+++ b/torch/csrc/api/include/torch/optim/optimizer.h
@@ -194,11 +194,12 @@ TORCH_API serialize::InputArchive& operator>>(
     OptimizerBase& optimizer);
 } // namespace detail
 
-/// Optimizer that defines a required `step()` method that takes no arguments
-/// and produces no values. The only side effect is that parameters are updated
+/// Optimizer that can optionally take a loss function in `step()` method
+/// and returns the loss value. The only side effect is that parameters are updated
 /// according to the concrete optimization algorithm.
 class Optimizer : public detail::OptimizerBase {
  public:
+   /// A loss function closure, which is expected to return the loss value.
    using LossClosure = std::function<Tensor()>;
    using detail::OptimizerBase::OptimizerBase;
    virtual Tensor step(LossClosure closure = nullptr) = 0;

--- a/torch/csrc/api/include/torch/optim/rmsprop.h
+++ b/torch/csrc/api/include/torch/optim/rmsprop.h
@@ -65,7 +65,7 @@ class TORCH_API RMSprop : public Optimizer {
   explicit RMSprop(std::vector<Tensor> params,
       RMSpropOptions defaults) : RMSprop({std::move(OptimizerParamGroup(params))}, defaults) {}
 
-  void step() override;
+  torch::Tensor step(LossClosure closure = nullptr) override;
 
   /// Returns the number of parameters referenced by the optimizer.
   size_t size() const noexcept override;

--- a/torch/csrc/api/include/torch/optim/sgd.h
+++ b/torch/csrc/api/include/torch/optim/sgd.h
@@ -58,7 +58,7 @@ class TORCH_API SGD : public Optimizer {
   explicit SGD(std::vector<Tensor> params,
       SGDOptions defaults) : SGD({std::move(OptimizerParamGroup(params))}, defaults) {}
 
-  void step() override;
+  torch::Tensor step(LossClosure closure = nullptr) override;
 
   /// Adds the given vector of parameters to the optimizer's parameter list.
   void add_parameters(const std::vector<Tensor>& parameters) override;

--- a/torch/csrc/api/src/optim/adagrad.cpp
+++ b/torch/csrc/api/src/optim/adagrad.cpp
@@ -55,8 +55,13 @@ void AdagradParamState::serialize(torch::serialize::InputArchive& archive) {
 
 /// Adapted from
 /// https://github.com/pytorch/pytorch/blob/master/torch/optim/adagrad.py
-void Adagrad::step() {
+Tensor Adagrad::step(LossClosure closure) {
   NoGradGuard no_grad;
+  Tensor loss = {};
+  if (closure != nullptr) {
+    at::AutoGradMode enable_grad(true);
+    loss = closure();
+  }
   for (auto& group : param_groups_) {
     for (auto& p : group.params()) {
       if (!p.grad().defined()) {
@@ -101,6 +106,7 @@ void Adagrad::step() {
       }
     }
   }
+  return loss;
 }
 
 void Adagrad::add_parameters(const std::vector<Tensor>& parameters) {

--- a/torch/csrc/api/src/optim/rmsprop.cpp
+++ b/torch/csrc/api/src/optim/rmsprop.cpp
@@ -68,8 +68,13 @@ void RMSpropParamState::serialize(torch::serialize::InputArchive& archive) {
 
 /// Adapted from
 /// https://github.com/pytorch/pytorch/blob/master/torch/optim/rmsprop.py
-void RMSprop::step() {
+Tensor RMSprop::step(LossClosure closure)  {
   NoGradGuard no_grad;
+  Tensor loss = {};
+  if (closure != nullptr) {
+    at::AutoGradMode enable_grad(true);
+    loss = closure();
+  }
   for (auto& group : param_groups_) {
     for (auto& p : group.params()) {
       if (!p.grad().defined()) {
@@ -126,6 +131,7 @@ void RMSprop::step() {
       }
     }
   }
+  return loss;
 }
 
 void RMSprop::add_parameters(const std::vector<Tensor>& parameters) {

--- a/torch/csrc/api/src/optim/sgd.cpp
+++ b/torch/csrc/api/src/optim/sgd.cpp
@@ -52,8 +52,13 @@ void SGDParamState::serialize(torch::serialize::InputArchive& archive) {
   _TORCH_OPTIM_DESERIALIZE_TORCH_ARG(Tensor, momentum_buffer);
 }
 
-void SGD::step() {
+Tensor SGD::step(LossClosure closure)  {
   NoGradGuard no_grad;
+  Tensor loss = {};
+  if (closure != nullptr) {
+    at::AutoGradMode enable_grad(true);
+    loss = closure();
+  }
   for (auto& group : param_groups_) {
     auto& options = static_cast<SGDOptions&>(group.options());
     auto weight_decay = options.weight_decay();
@@ -90,6 +95,7 @@ void SGD::step() {
       p.data().add_(d_p, -1 * options.lr());
     }
   }
+  return loss;
 }
 
 void SGD::add_parameters(const std::vector<Tensor>& parameters) {


### PR DESCRIPTION
This PR is BC breaking in the following way:
`step` function in `Optimizer` class now takes an optional `LossClosure` closure function and returns a `Tensor`. If you had a custom optimizer class defined as:
```cpp
struct MyOptimizer : Optimizer {
  using Optimizer::Optimizer;
  void step() override {...}
};
```
you would need to change the class definition to conform to the new signature of step function and update your class definition as follows:

```cpp
struct MyOptimizer : Optimizer {
  using Optimizer::Optimizer;
  torch::Tensor step(LossClosure closure = nullptr) override { ... }
};
```