### PR TITLE
SNIFAE Template Constructors of IValue (#34647)

### DIFF
--- a/aten/src/ATen/core/boxing/boxing.h
+++ b/aten/src/ATen/core/boxing/boxing.h
@@ -16,26 +16,13 @@ namespace impl {
 
 // Assume T is decayed
 template <typename T>
-using not_ok_to_box =
-  guts::disjunction<
-    guts::negation<
-      guts::disjunction<
-        std::is_constructible<IValue, T>,
-        // TensorOptions are not directly constructible into IValue,
-        // but torch::jit::push knows how to handle them
-        std::is_same<TensorOptions, T>,
-        // void returns are ok
-        std::is_same<void, T>
-      >>
-    ,
-    // some constructors are templated (and therefore pass
-    // is_constructible), but do not actually work with all
-    // template arguments, so we must blacklist them explicitly
-    // TODO: The correct fix is to sfinae based on is_constructible of T
-    std::is_same<optional<ArrayRef<at::Dimname>>, T>,
-    std::is_same<ArrayRef<at::Dimname>, T>
-
-  >;
+using not_ok_to_box = guts::negation<guts::disjunction<
+    std::is_constructible<IValue, T>,
+    // TensorOptions are not directly constructible into IValue,
+    // but torch::jit::push knows how to handle them
+    std::is_same<TensorOptions, T>,
+    // void returns are ok
+    std::is_same<void, T>>>;
 
 // TODO boxing should be ok for all kernels. Then remove not_ok_to_box and supports_boxing.
 

--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -323,7 +323,10 @@ struct CAFFE2_API IValue final {
 
   template<class T>
   IValue(c10::List<T> v);
-  template<class T>
+  template <
+      class T,
+      std::enable_if_t<!std::is_same<at::Dimname, T>::value, std::nullptr_t> =
+          nullptr>
   IValue(at::ArrayRef<T> v);
   template<class T>
   IValue(const std::vector<T>& v);
@@ -343,7 +346,11 @@ struct CAFFE2_API IValue final {
   /// \endcond
   IValue(std::unordered_map<Key, Value> v);
 
-  template<class T>
+  template <
+      class T,
+      std::enable_if_t<
+          !std::is_same<ArrayRef<at::Dimname>, T>::value,
+          std::nullptr_t> = nullptr>
   IValue(c10::optional<T> v);
   IValue(c10::nullopt_t);
 

--- a/aten/src/ATen/core/ivalue_inl.h
+++ b/aten/src/ATen/core/ivalue_inl.h
@@ -724,8 +724,10 @@ inline IValue::IValue(c10::impl::GenericList v)
 
 template<class T> inline IValue::IValue(c10::List<T> v)
 : IValue(impl::toList<T>(std::move(v))) {}
-template<class T> inline IValue::IValue(at::ArrayRef<T> v)
-: IValue(c10::List<T>()) {
+template <
+    class T,
+    std::enable_if_t<!std::is_same<at::Dimname, T>::value, std::nullptr_t>>
+inline IValue::IValue(at::ArrayRef<T> v) : IValue(c10::List<T>()) {
   auto list = to<c10::List<T>>();
   list.reserve(v.size());
   for (const auto& e : v) {
@@ -758,7 +760,10 @@ template<class Key, class Value> inline IValue::IValue(std::unordered_map<Key, V
   }
 }
 
-template<class T> inline IValue::IValue(c10::optional<T> v): IValue() {
+template <
+    class T,
+    std::enable_if_t<!std::is_same<ArrayRef<at::Dimname>, T>::value, std::nullptr_t>>
+inline IValue::IValue(c10::optional<T> v) : IValue() {
   if (v.has_value()) {
     *this = IValue(std::move(*v));
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#34813 SNIFAE Template Constructors of IValue (#34647)**

Summary:
Currently, we use `not_ok_to_boxing` to filter `Dimname` that can not be
converted/constructed to IValue. The correct way should be SNIFAE the
constructor of IValue.

Test Plan:
PyTorch compiled after the code change.

All unit test passed

Reviewers:

Subscribers:

Tasks:

Tags: