### PR TITLE
Fix thread_local initializtion in C10 WarningHandler.

### DIFF
--- a/c10/util/Exception.cpp
+++ b/c10/util/Exception.cpp
@@ -66,30 +66,44 @@ void Error::AppendMessage(const std::string& new_msg) {
 namespace Warning {
 
 namespace {
-  WarningHandler* getHandler() {
+  WarningHandler* getBaseHandler() {
     static WarningHandler base_warning_handler_ = WarningHandler();
     return &base_warning_handler_;
   };
-  static thread_local WarningHandler* warning_handler_ = nullptr;
+
+  class ThreadWarningHandler {
+    public:
+      ThreadWarningHandler() = delete;
+
+      static WarningHandler* get_handler() {
+        if (!warning_handler_) {
+          warning_handler_ = getBaseHandler();
+        }
+        return warning_handler_;
+      }
+
+      static void set_handler(WarningHandler* handler) {
+        warning_handler_ = handler;
+      }
+
+    private:
+      static thread_local WarningHandler* warning_handler_;
+  };
+
+  thread_local WarningHandler* ThreadWarningHandler::warning_handler_ = nullptr;
 
 }
 
 void warn(SourceLocation source_location, const std::string& msg) {
-  if (!warning_handler_) {
-    warning_handler_ = getHandler();
-  }
-  warning_handler_->process(source_location, msg);
+  ThreadWarningHandler::get_handler()->process(source_location, msg);
 }
 
 void set_warning_handler(WarningHandler* handler) noexcept(true) {
-  warning_handler_ = handler;
+  ThreadWarningHandler::set_handler(handler);
 }
 
 WarningHandler* get_warning_handler() noexcept(true) {
-  if (!warning_handler_) {
-    warning_handler_ = getHandler();
-  }
-  return warning_handler_;
+  return ThreadWarningHandler::get_handler();
 }
 
 } // namespace Warning

--- a/c10/util/Exception.cpp
+++ b/c10/util/Exception.cpp
@@ -70,11 +70,14 @@ namespace {
     static WarningHandler base_warning_handler_ = WarningHandler();
     return &base_warning_handler_;
   };
-  static thread_local WarningHandler* warning_handler_ = getHandler();
+  static thread_local WarningHandler* warning_handler_ = nullptr;
 
 }
 
 void warn(SourceLocation source_location, const std::string& msg) {
+  if (!warning_handler_) {
+    warning_handler_ = getHandler();
+  }
   warning_handler_->process(source_location, msg);
 }
 
@@ -83,6 +86,9 @@ void set_warning_handler(WarningHandler* handler) noexcept(true) {
 }
 
 WarningHandler* get_warning_handler() noexcept(true) {
+  if (!warning_handler_) {
+    warning_handler_ = getHandler();
+  }
   return warning_handler_;
 }
 


### PR DESCRIPTION
The Windows + MSVC-specific bug discussed here: #19394 and fixed here: #22405 still appears in C10's warning handler class. This results in a crash if a user attempts to run code which would print a warning when that code is running inside a thread created by a DLL. This PR applies a similar fix to that of #22405.