### PR TITLE
Enable Constant Folding for ONNX Opset 12

### DIFF
--- a/test/onnx/test_utility_funs.py
+++ b/test/onnx/test_utility_funs.py
@@ -355,5 +355,10 @@ TestUtilityFuns_opset11 = type(str("TestUtilityFuns_opset11"),
                                dict(TestUtilityFuns.__dict__, opset_version=11))
 
 
+# opset 12tests
+TestUtilityFuns_opset12 = type(str("TestUtilityFuns_opset12"),
+                               (TestCase,),
+                               dict(TestUtilityFuns.__dict__, opset_version=12))
+
 if __name__ == '__main__':
     run_tests()

--- a/torch/csrc/jit/passes/onnx/constant_fold.cpp
+++ b/torch/csrc/jit/passes/onnx/constant_fold.cpp
@@ -189,7 +189,9 @@ c10::optional<at::Tensor> runTorchBackendForOnnx(
     if (opset_version == ONNX_OPSET_9) {
       return runTorchSlice_opset9(node, inputTensorValues);
     }
-    else if (opset_version == ONNX_OPSET_10 || opset_version == ONNX_OPSET_11) {
+    else if (opset_version == ONNX_OPSET_10 ||
+             opset_version == ONNX_OPSET_11 ||
+             opset_version == ONNX_OPSET_12) {
       return runTorchSlice_opset10(node, inputTensorValues);
     }
     else {
@@ -341,7 +343,7 @@ std::vector<Node*> getOnnxConstParentsToRemove(Node* node) {
 // known.
 void ConstantFoldONNX(Block* b, ParamMap& paramsDict, int opset_version) {
   if (opset_version != ONNX_OPSET_9 && opset_version != ONNX_OPSET_10 &&
-      opset_version != ONNX_OPSET_11) {
+      opset_version != ONNX_OPSET_11 && opset_version != ONNX_OPSET_12) {
     // Number of elements of 'axes' and 'ends' 1-D input tensors should be the same
     std::cerr << "Warning: Constant folding supported for only opsets 9, 10, and 11. "
               << "Constant folding not applied." << std::endl;

--- a/torch/csrc/jit/passes/onnx/constant_fold.h
+++ b/torch/csrc/jit/passes/onnx/constant_fold.h
@@ -8,6 +8,7 @@ namespace jit {
 const int ONNX_OPSET_9 = 9;
 const int ONNX_OPSET_10 = 10;
 const int ONNX_OPSET_11 = 11;
+const int ONNX_OPSET_12 = 12;
 void ConstantFoldONNX(Block* b, std::map<std::string, at::Tensor>& paramDict, int opset_version);
 
 }

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -12,6 +12,7 @@ ONNX_ARCHIVE_MODEL_PROTO_NAME = "__MODEL_PROTO"
 ir_version = _C._onnx.IR_VERSION
 producer_name = "pytorch"
 producer_version = _C._onnx.PRODUCER_VERSION
+constant_folding_opset_versions = [9, 10, 11, 12]
 
 
 class ExportTypes:

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -371,7 +371,7 @@ def _model_to_graph(model, args, verbose=False, training=False,
     param_names = input_and_param_names[len(input_and_param_names) - len(params):]
     params_dict = dict(zip(param_names, params))
 
-    if do_constant_folding and _export_onnx_opset_version in [9, 10, 11]:
+    if do_constant_folding and _export_onnx_opset_version in torch.onnx.constant_folding_opset_versions:
         params_dict = torch._C._jit_pass_onnx_constant_fold(graph, params_dict,
                                                             _export_onnx_opset_version)
         torch._C._jit_pass_dce_allow_deleting_nodes_with_side_effects(graph)


### PR DESCRIPTION
Currently constant folding is only enabled for ONNX opset versions 9 to 11. This PR enables it for the new ONNX opset 12.