### PR TITLE
Enabled conv2d batch norm fusion for traced modules.

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -396,6 +396,7 @@ if (NOT INTERN_BUILD_MOBILE OR NOT BUILD_CAFFE2_MOBILE)
     ${TORCH_SRC_DIR}/csrc/jit/passes/clear_undefinedness.cpp
     ${TORCH_SRC_DIR}/csrc/jit/passes/constant_propagation.cpp
     ${TORCH_SRC_DIR}/csrc/jit/passes/constant_pooling.cpp
+    ${TORCH_SRC_DIR}/csrc/jit/passes/conv2d_batch_norm_folding.cpp
     ${TORCH_SRC_DIR}/csrc/jit/passes/common_subexpression_elimination.cpp
     ${TORCH_SRC_DIR}/csrc/jit/passes/create_autodiff_subgraphs.cpp
     ${TORCH_SRC_DIR}/csrc/jit/passes/inline_autodiff_subgraphs.cpp

--- a/test/jit/test_frozen_traced_mod_convbn_folding.py
+++ b/test/jit/test_frozen_traced_mod_convbn_folding.py
@@ -1,0 +1,184 @@
+import torch
+import torch.nn as nn
+from torch.testing._internal.jit_utils import JitTestCase
+
+from torch.testing import FileCheck
+
+import itertools
+
+if __name__ == '__main__':
+    raise RuntimeError("This test file is not meant to be run directly, use:\n\n"
+                       "\tpython test/test_jit.py TESTNAME\n\n"
+                       "instead.")
+
+class TestFrozenTracedModuleConv2dBNFolding(JitTestCase):
+    def test_folding(self):
+        # Test that we find Conv-BN patterns in submodules
+        class SubModule(torch.nn.Module):
+            def __init__(self, num_blocks, enable_bias, enable_affine):
+                super(SubModule, self).__init__()
+                layers = []
+                for i in range(num_blocks):
+                    layers.append(torch.nn.Conv2d(20, 20, 5, 1, bias=enable_bias))
+                    bn_obj = torch.nn.BatchNorm2d(num_features=20, affine=enable_affine)
+                    if enable_affine:
+                        bn_obj.weight = torch.nn.Parameter(torch.rand_like(bn_obj.weight))
+                        bn_obj.bias = torch.nn.Parameter(torch.rand_like(bn_obj.bias))
+                    bn_obj.running_mean = torch.rand_like(bn_obj.running_mean)
+                    bn_obj.running_var = torch.rand_like(bn_obj.running_var)
+                    layers.append(bn_obj)
+                self.layers = nn.Sequential(*layers)
+
+            def forward(self, x):
+                return self.layers(x)
+
+        class TestModule(torch.nn.Module):
+            def __init__(self, num_blocks, enable_bias, enable_affine):
+                super(TestModule, self).__init__()
+                self.sub = SubModule(num_blocks, enable_bias, enable_affine)
+
+            def forward(self, x):
+                x = self.sub(x)
+                return x
+
+        bias_affine_options = itertools.product([True, False], [True, False], [1, 2])
+        for (enable_bias, enable_bn_affine, num_layers) in bias_affine_options:
+            eager = TestModule(num_layers, enable_bias, enable_bn_affine)
+            eager.eval()
+
+            x = torch.rand(1, 20, 10, 10)
+            traced = torch.jit.trace(eager, x)
+            traced.eval()
+
+            traced_copy = traced.copy()
+            torch._C._jit_pass_inline(traced_copy.graph)
+
+            FileCheck().check_count("aten::batch_norm", num_layers, exactly=True) \
+                .run(traced_copy.graph)
+
+            traced._c = torch._C._freeze_module(traced._c)
+            torch._C._jit_pass_fold_convbn_in_frozen_traced_module_graph(traced.graph)
+
+            FileCheck().check_not("aten::batch_norm").run(traced.graph)
+
+            x = torch.rand(1, 20, 10, 10)
+            self.assertEqual(eager(x), traced(x))
+
+    def test_no_folding(self):
+        # Test that we find Conv-BN patterns in submodules
+        class SubModule(torch.nn.Module):
+            def __init__(self, num_blocks, enable_bias, enable_affine):
+                super(SubModule, self).__init__()
+                layers = []
+                for i in range(num_blocks):
+                    layers.append(torch.nn.Conv2d(20, 20, 5, 1, bias=enable_bias))
+                    layers.append(torch.nn.ReLU())
+                    bn_obj = torch.nn.BatchNorm2d(num_features=20, affine=enable_affine)
+                    if enable_affine:
+                        bn_obj.weight = torch.nn.Parameter(torch.rand_like(bn_obj.weight))
+                        bn_obj.bias = torch.nn.Parameter(torch.rand_like(bn_obj.bias))
+                    bn_obj.running_mean = torch.rand_like(bn_obj.running_mean)
+                    bn_obj.running_var = torch.rand_like(bn_obj.running_var)
+                    layers.append(bn_obj)
+                self.layers = nn.Sequential(*layers)
+
+            def forward(self, x):
+                return self.layers(x)
+
+        class TestModule(torch.nn.Module):
+            def __init__(self, num_blocks, enable_bias, enable_affine):
+                super(TestModule, self).__init__()
+                self.sub = SubModule(num_blocks, enable_bias, enable_affine)
+
+            def forward(self, x):
+                x = self.sub(x)
+                return x
+
+        bias_affine_options = itertools.product([True, False], [True, False], [1, 2])
+        for (enable_bias, enable_bn_affine, num_layers) in bias_affine_options:
+            eager = TestModule(num_layers, enable_bias, enable_bn_affine)
+            eager.eval()
+
+            x = torch.rand(1, 20, 10, 10)
+            traced = torch.jit.trace(eager, x)
+            traced.eval()
+
+            traced_copy = traced.copy()
+            torch._C._jit_pass_inline(traced_copy.graph)
+
+            FileCheck().check_count("aten::batch_norm", num_layers, exactly=True) \
+                .run(traced_copy.graph)
+
+            traced._c = torch._C._freeze_module(traced._c)
+            torch._C._jit_pass_fold_convbn_in_frozen_traced_module_graph(traced.graph)
+
+            FileCheck().check_count("aten::batch_norm", num_layers, exactly=True) \
+                .run(traced_copy.graph)
+
+            x = torch.rand(1, 20, 10, 10)
+            self.assertEqual(eager(x), traced(x))
+
+    def test_mixing_scripted_and_frozen_traced_module_folding(self):
+        # Test that we find Conv-BN patterns in submodules
+        class SubModule(torch.nn.Module):
+            def __init__(self, num_blocks, enable_bias, enable_affine):
+                super(SubModule, self).__init__()
+                layers = []
+                for i in range(num_blocks):
+                    layers.append(torch.nn.Conv2d(20, 20, 5, 1, bias=enable_bias))
+                    bn_obj = torch.nn.BatchNorm2d(num_features=20, affine=enable_affine)
+                    if enable_affine:
+                        bn_obj.weight = torch.nn.Parameter(torch.rand_like(bn_obj.weight))
+                        bn_obj.bias = torch.nn.Parameter(torch.rand_like(bn_obj.bias))
+                    bn_obj.running_mean = torch.rand_like(bn_obj.running_mean)
+                    bn_obj.running_var = torch.rand_like(bn_obj.running_var)
+                    layers.append(bn_obj)
+                self.layers = nn.Sequential(*layers)
+
+            def forward(self, x):
+                return self.layers(x)
+
+        class TestModule(torch.nn.Module):
+            def __init__(self, num_blocks, enable_bias, enable_affine):
+                super(TestModule, self).__init__()
+                self.sub = SubModule(num_blocks, enable_bias, enable_affine)
+
+            def forward(self, x):
+                x = self.sub(x)
+                return x
+
+        bias_affine_options = itertools.product([True, False], [True, False], [True, False], [1, 2])
+        for (enable_scripting, enable_bias, enable_bn_affine, num_layers) in bias_affine_options:
+            eager = TestModule(num_layers, enable_bias, enable_bn_affine)
+            eager.eval()
+
+            if enable_scripting:
+                traced_or_scripted = torch.jit.script(eager)
+            else:
+                x = torch.rand(1, 20, 10, 10)
+                traced_or_scripted = torch.jit.trace(eager, x)
+                traced_or_scripted.eval()
+
+            traced_or_scripted_copy = traced_or_scripted.copy()
+            torch._C._jit_pass_inline(traced_or_scripted_copy.graph)
+
+            FileCheck().check_count("aten::batch_norm", num_layers, exactly=True) \
+                .run(traced_or_scripted_copy.graph)
+
+            # The use case to test is, we dont know if the model is traced or script.
+            # So we apply both forms of folding.
+            # 1. Apply batch norm folding that works for scripted modules.
+            # 2. Freeze module.
+            # 3. Apply batch norm folding that works for frozen traced modules.
+            # Regardless of the input model being scripted or traced, we should have
+            # eliminated batch_norm.
+
+            traced_or_scripted._c = torch._C._jit_pass_fold_convbn(traced_or_scripted._c)
+            traced_or_scripted._c = torch._C._freeze_module(traced_or_scripted._c)
+            torch._C._jit_pass_fold_convbn_in_frozen_traced_module_graph(traced_or_scripted.graph)
+
+            FileCheck().check_not("aten::batch_norm").run(traced_or_scripted.graph)
+
+            x = torch.rand(1, 20, 10, 10)
+            self.assertEqual(eager(x), traced_or_scripted(x))
+

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -23,6 +23,7 @@ from jit.test_class_type import TestClassType  # noqa: F401
 from jit.test_builtins import TestBuiltins, TestTensorBuiltins  # noqa: F401
 from jit.test_unsupported_ops import TestUnsupportedOps  # noqa: F401
 from jit.test_freezing import TestFreezing  # noqa: F401
+from jit.test_frozen_traced_mod_convbn_folding import TestFrozenTracedModuleConv2dBNFolding # noqa: F401
 
 # Torch
 from torch import Tensor

--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -115,6 +115,7 @@ libtorch_sources = [
     "torch/csrc/jit/passes/common_subexpression_elimination.cpp",
     "torch/csrc/jit/passes/constant_propagation.cpp",
     "torch/csrc/jit/passes/constant_pooling.cpp",
+    "torch/csrc/jit/passes/conv2d_batch_norm_folding.cpp",
     "torch/csrc/jit/passes/create_autodiff_subgraphs.cpp",
     "torch/csrc/jit/passes/dead_code_elimination.cpp",
     "torch/csrc/jit/passes/erase_number_types.cpp",

--- a/torch/csrc/jit/passes/conv2d_batch_norm_folding.cpp
+++ b/torch/csrc/jit/passes/conv2d_batch_norm_folding.cpp
@@ -1,0 +1,200 @@
+#include <tuple>
+
+#include <torch/csrc/jit/ir/alias_analysis.h>
+#include <torch/csrc/jit/ir/ir.h>
+#include <torch/csrc/jit/ir/subgraph_matcher.h>
+#include <torch/csrc/jit/passes/constant_pooling.h>
+#include <torch/csrc/jit/passes/constant_propagation.h>
+#include <torch/csrc/jit/passes/conv2d_batch_norm_folding.h>
+#include <torch/csrc/jit/passes/fuse_linear.h>
+#include <torch/csrc/jit/passes/graph_rewrite_helper.h>
+#include <torch/csrc/jit/passes/subgraph_rewrite.h>
+
+namespace torch {
+namespace jit {
+
+using graph_rewrite_helper::computeUpdatedConvWeightAndBias;
+using graph_rewrite_helper::ConvBNParameters;
+using graph_rewrite_helper::PatternInfo;
+
+namespace {
+
+ConvBNParameters extractConvBNParams(
+    Value* conv_weight,
+    Value* conv_bias,
+    Value* bn_weight,
+    Value* bn_bias,
+    Value* bn_running_mean,
+    Value* bn_running_var,
+    Value* eps) {
+  ConvBNParameters params;
+  params.bn_rm = toIValue(bn_running_mean)->toTensor();
+  params.bn_rv = toIValue(bn_running_var)->toTensor();
+  params.bn_eps = toIValue(eps)->toDouble();
+  auto val = toIValue(bn_weight);
+  if (val && !val->isNone()) {
+    params.bn_w = val->toTensor();
+  } else {
+    params.bn_w = at::ones_like(params.bn_rm);
+  }
+  val = toIValue(bn_bias);
+  if (val && !val->isNone()) {
+    params.bn_b = val->toTensor();
+  } else {
+    params.bn_b = at::zeros_like(params.bn_rm);
+  }
+
+  params.conv_w = toIValue(conv_weight)->toTensor();
+  val = toIValue(conv_bias);
+  if (val && !val->isNone()) {
+    params.conv_b = val->toTensor();
+  } else {
+    params.conv_b = at::zeros_like(params.bn_rm);
+  }
+  return params;
+}
+
+void removeBatchNormNodes(std::unordered_set<Node*>& batch_norm_nodes) {
+  std::vector<Value*> values_to_remove;
+  for (auto n : batch_norm_nodes) {
+    // at::ArrayRef<Value*> input_vals = n->inputs();
+    // Remove batch norm's weight, bias, mean, variance.
+    n->removeAllInputs();
+  }
+  for (auto n : batch_norm_nodes) {
+    n->destroy();
+  }
+  for (Value* val : values_to_remove) {
+    val->node()->removeAllInputs();
+    val->node()->destroy();
+  }
+}
+
+void transformAndCopyConvWeightAndBias(
+    const std::shared_ptr<Graph>& graph_ptr,
+    Value* conv_weight,
+    Value* conv_bias,
+    Node* conv_node,
+    const ConvBNParameters& params) {
+  std::unique_ptr<AliasDb> aliasDb = torch::make_unique<AliasDb>(graph_ptr);
+  Graph& graph = *graph_ptr;
+  const auto& new_weight_bias = computeUpdatedConvWeightAndBias(params);
+  auto weight_tensor = toIValue(conv_weight)->toTensor();
+  auto new_weight_val =
+      *(tryInsertConstant(graph, std::get<0>(new_weight_bias)));
+  Node* weight_node = conv_weight->node();
+  conv_weight->replaceAllUsesWith(new_weight_val);
+  aliasDb->moveBeforeTopologicallyValid(new_weight_val->node(), conv_node);
+  weight_node->removeAllInputs();
+  weight_node->destroy();
+
+  auto optional_val = toIValue(conv_bias);
+  TORCH_CHECK(optional_val, "Bias for conv2d module must exist");
+  auto bias_tensor = std::get<1>(new_weight_bias);
+  if (optional_val->isNone()) {
+    Value* new_bias_val = *(tryInsertConstant(graph, bias_tensor));
+    constexpr size_t conv_bias_index = 2;
+    conv_node->replaceInput(conv_bias_index, new_bias_val);
+    aliasDb->moveBeforeTopologicallyValid(new_bias_val->node(), conv_node);
+  } else {
+    TORCH_CHECK(conv_bias->uses().size() == 1,
+        "Bias of conv should have only one use.");
+    auto orig_bias_tensor = toIValue(conv_bias)->toTensor();
+    Value* new_bias_val = *(tryInsertConstant(graph, bias_tensor));
+    Node* bias_node = conv_bias->node();
+    bias_node->output(0)->replaceAllUsesWith(new_bias_val);
+    aliasDb->moveBeforeTopologicallyValid(new_bias_val->node(), conv_node);
+    bias_node->removeAllInputs();
+    bias_node->destroy();
+  }
+}
+
+void foldBatchNorm2dInConv2d(std::shared_ptr<Graph>& graph) {
+  // Replace _convolution with conv2d
+  graph_rewrite_helper::replaceConvolutionWithConv2d(graph);
+  std::unordered_set<Node*> nodes_to_delete;
+
+  std::string conv2d_bn_pattern = R"(
+    graph(%input, %conv_weight, %conv_bias, %stride:int[],
+        %padding:int[], %dilation:int[], %groups:int,
+        %bn_weight, %bn_bias, %bn_running_mean, %bn_running_var,
+        %training, %momentum, %eps, %cudnn_enabled):
+        %conv_out = aten::conv2d(%input, %conv_weight, %conv_bias, %stride,
+            %padding, %dilation, %groups)
+        %bn_out = aten::batch_norm(%conv_out, %bn_weight, %bn_bias,
+            %bn_running_mean, %bn_running_var, %training, %momentum,
+            %eps, %cudnn_enabled)
+        return (%bn_out) )";
+  const PatternInfo& pattern = PatternInfo::parse_from_str(conv2d_bn_pattern);
+  const Graph& pattern_graph = *pattern.pattern_graph;
+  const auto& vmap = pattern.vmap;
+  Value* pattern_conv_weight = vmap.at("conv_weight");
+  Value* pattern_conv_bias = vmap.at("conv_bias");
+  Value* pattern_bn_weight = vmap.at("bn_weight");
+  Value* pattern_bn_bias = vmap.at("bn_bias");
+  Value* pattern_bn_running_mean = vmap.at("bn_running_mean");
+  Value* pattern_bn_running_var = vmap.at("bn_running_var");
+  Value* pattern_bn_eps = vmap.at("eps");
+  Value* pattern_training = vmap.at("training");
+  Value* conv_out = vmap.at("conv_out");
+  Value* bn_out = vmap.at("bn_out");
+
+  const auto& matches = findPatternMatches(pattern_graph, *graph);
+  for (const auto& match : matches) {
+    Value* matched_conv_weight = match.values_map.at(pattern_conv_weight);
+    Value* matched_conv_bias = match.values_map.at(pattern_conv_bias);
+    Value* matched_bn_weight = match.values_map.at(pattern_bn_weight);
+    Value* matched_bn_bias = match.values_map.at(pattern_bn_bias);
+    Value* matched_bn_running_mean =
+        match.values_map.at(pattern_bn_running_mean);
+    Value* matched_bn_running_var = match.values_map.at(pattern_bn_running_var);
+    Value* matched_bn_eps = match.values_map.at(pattern_bn_eps);
+    Value* matched_training = match.values_map.at(pattern_training);
+    Value* matched_conv_out = match.values_map.at(conv_out);
+    Value* matched_bn_out = match.values_map.at(bn_out);
+
+    if (matched_conv_out->uses().size() > 1) {
+      continue;
+    }
+
+    TORCH_CHECK(
+        !(toIValue(matched_training)->toBool()),
+        "Training must be set to false for batch norm folding");
+    const auto params = extractConvBNParams(
+        matched_conv_weight,
+        matched_conv_bias,
+        matched_bn_weight,
+        matched_bn_bias,
+        matched_bn_running_mean,
+        matched_bn_running_var,
+        matched_bn_eps);
+    transformAndCopyConvWeightAndBias(
+        graph,
+        matched_conv_weight,
+        matched_conv_bias,
+        matched_conv_out->node(),
+        params);
+    matched_bn_out->replaceAllUsesWith(matched_conv_out);
+    nodes_to_delete.insert(matched_bn_out->node());
+  }
+  removeBatchNormNodes(nodes_to_delete);
+}
+
+} // namespace
+
+// This pass depends on freezing to convert attributes to constants.
+// It also depends on not having inserted XNNPACK ops since those ops
+// pack weights and bias into a custom class.
+void FoldConvBatchNorm2dOfFrozenTracedModuleGraph(
+    std::shared_ptr<Graph>& graph) {
+  ConstantPooling(graph);
+  ConstantPropagation(graph);
+  graph_rewrite_helper::replaceConvolutionWithConv2d(graph);
+  foldBatchNorm2dInConv2d(graph);
+  LOG(INFO)
+      << "Finished FoldConv2dBatchNorm pass. If you did not get"
+         " expected result, you may not have run the freeze_module pass prior\n";
+}
+
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/passes/conv2d_batch_norm_folding.h
+++ b/torch/csrc/jit/passes/conv2d_batch_norm_folding.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <torch/csrc/jit/ir/ir.h>
+#include <torch/csrc/jit/api/module.h>
+
+namespace torch {
+namespace jit {
+TORCH_API void FoldConvBatchNorm2dOfFrozenTracedModuleGraph(std::shared_ptr<Graph>& graph);
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/passes/graph_rewrite_helper.cpp
+++ b/torch/csrc/jit/passes/graph_rewrite_helper.cpp
@@ -6,6 +6,14 @@ namespace torch {
 namespace jit {
 namespace graph_rewrite_helper {
 
+std::tuple<at::Tensor, at::Tensor>
+  computeUpdatedConvWeightAndBias(const ConvBNParameters& p) {
+  at::Tensor bn_var_rsqrt = at::rsqrt(p.bn_rv + p.bn_eps);
+  at::Tensor new_w = p.conv_w * (p.bn_w * bn_var_rsqrt).reshape({-1, 1, 1, 1});
+  at::Tensor new_b = (p.conv_b - p.bn_rm) * bn_var_rsqrt * p.bn_w + p.bn_b;
+  return std::make_tuple(new_w, new_b);
+}
+
 std::string getFuncName(Value* func_value) {
   auto func_node = func_value->node();
   auto func = func_node->output()->type()->expect<FunctionType>()->function();

--- a/torch/csrc/jit/passes/graph_rewrite_helper.h
+++ b/torch/csrc/jit/passes/graph_rewrite_helper.h
@@ -1,10 +1,31 @@
 #pragma once
 
 #include <torch/csrc/jit/ir/ir.h>
+#include <torch/csrc/jit/ir/irparser.h>
 
 namespace torch {
 namespace jit {
 namespace graph_rewrite_helper {
+
+struct ConvBNParameters {
+  at::Tensor conv_w;
+  at::Tensor conv_b;
+  at::Tensor bn_rm;
+  at::Tensor bn_rv;
+  double bn_eps = 0.0;
+  at::Tensor bn_w;
+  at::Tensor bn_b;
+};
+
+/**
+ * Given the current weight and bias tensors of a Conv2d module and parameters
+ * of the BatchNorm2d module we're folding with, compute the updated values
+ * for the weight and bias.
+ *
+ * The function is basically copied from torch/nn/utils/fusion.py
+ */
+std::tuple<at::Tensor, at::Tensor>
+  computeUpdatedConvWeightAndBias(const ConvBNParameters& p);
 
 std::string getFuncName(Value* func_value);
 Value* getValue(
@@ -16,6 +37,25 @@ c10::optional<IValue> getIValue(
     const std::unordered_map<const Value*, Value*>& match_vmap,
     const std::unordered_map<std::string, Value*>& vmap);
 void replaceConvolutionWithConv2d(std::shared_ptr<Graph>& graph);
+
+// This struct contains a compiled IR pattens slated for use in the
+// findPatternMatches function. The struct encapsulates the common
+// information from parseIR that is used in conjunction with the
+// pattern matching facility. A const instance of this struct can
+// also be stored away to cache the compiled IR pattern and reduce
+// runtime cost
+struct PatternInfo {
+  std::string pattern_string;
+  std::unique_ptr<Graph> pattern_graph;
+  std::unordered_map<std::string, Value*> vmap;
+
+  static PatternInfo parse_from_str(std::string pattern_string) {
+    PatternInfo rv{
+        std::move(pattern_string), std::make_unique<Graph>(), decltype(vmap){}};
+    parseIR(rv.pattern_string, rv.pattern_graph.get(), rv.vmap);
+    return rv;
+  }
+};
 
 } // namespace graph_rewrite_helper
 } // namespace jit

--- a/torch/csrc/jit/passes/xnnpack_rewrite.cpp
+++ b/torch/csrc/jit/passes/xnnpack_rewrite.cpp
@@ -1,6 +1,7 @@
 #include <ATen/core/jit_type.h>
 #include <ATen/native/xnnpack/OpContext.h>
 
+#include <torch/csrc/jit/ir/alias_analysis.h>
 #include <torch/csrc/jit/ir/ir.h>
 #include <torch/csrc/jit/ir/subgraph_matcher.h>
 #include <torch/csrc/jit/passes/constant_pooling.h>
@@ -15,6 +16,10 @@ namespace torch {
 namespace jit {
 
 #ifdef USE_XNNPACK
+
+using graph_rewrite_helper::PatternInfo;
+using graph_rewrite_helper::ConvBNParameters;
+using graph_rewrite_helper::computeUpdatedConvWeightAndBias;
 
 namespace {
 

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -14,6 +14,7 @@
 #include <torch/csrc/jit/passes/common_subexpression_elimination.h>
 #include <torch/csrc/jit/passes/constant_pooling.h>
 #include <torch/csrc/jit/passes/constant_propagation.h>
+#include <torch/csrc/jit/passes/conv2d_batch_norm_folding.h>
 #include <torch/csrc/jit/passes/create_autodiff_subgraphs.h>
 #include <torch/csrc/jit/passes/dead_code_elimination.h>
 #include <torch/csrc/jit/passes/decompose_ops.h>
@@ -200,6 +201,10 @@ void initJITBindings(PyObject* module) {
           "_jit_pass_quant_fusion",
           [](std::shared_ptr<Graph>& g) { return QuantFusion(g); })
       .def("_jit_pass_fold_convbn", &FoldConvBatchNorm2d)
+      .def("_jit_pass_fold_convbn_in_frozen_traced_module_graph",
+          [](std::shared_ptr<Graph>& graph) {
+          FoldConvBatchNorm2dOfFrozenTracedModuleGraph(graph);
+          })
       .def("_freeze_module",
           [](Module& module) {
             return freeze_module(module);
@@ -611,7 +616,7 @@ void initJITBindings(PyObject* module) {
           std::ostringstream docstring;
           docstring << "Automatically bound operator '" << op_name
                     << "' with schema(s):\n";
-                    
+
           for (const auto& op : operations) {
             docstring << "  " << op->schema() << "\n";
           }


### PR DESCRIPTION
Summary:
This pass enabled fusion of conv2d with batch norm for traced modules.
It requires that the module be preprocessed with freeze_module pass,
which inlines the graph constant propgates all attributes.
This pass work on top of such a graph.
However, at the moment it does not work with scripted module.
For some reason subgraph matcher is not able to find the fusion pattern,
when it operates on scripted module.

Test Plan:
python test/test_jit.py TestJit.test_foldbn_graph_mode

Reviewers:

Subscribers:

Tasks:

Tags:

