### PR TITLE
[SigridHashOp] Fix converter

### DIFF
--- a/caffe2/opt/custom/converter.cc
+++ b/caffe2/opt/custom/converter.cc
@@ -279,6 +279,7 @@ class SigridHashConverter : public Converter {
     auto c = dyn_cast<repr::SigridHash>(nnOp.get());
     c->setSalt(args.GetSingleArgument<int64_t>("salt", 0));
     c->setMaxValue(args.GetSingleArgument<int64_t>("maxValue", 0));
+    c->setHashIntoInt32(args.GetSingleArgument<bool>("hashIntoInt32", false));
     return nnOp;
   }
 
@@ -291,6 +292,8 @@ class SigridHashConverter : public Converter {
         caffe2::MakeArgument<int64_t>("salt", sigridHash->getSalt()));
     op.add_arg()->CopyFrom(
         caffe2::MakeArgument<int64_t>("maxValue", sigridHash->getMaxValue()));
+    op.add_arg()->CopyFrom(
+        caffe2::MakeArgument<bool>("hashIntoInt32", sigridHash->getHashIntoInt32()));
     return op;
   }
 


### PR DESCRIPTION
Summary: Once SigridHashOp argument is supplied, I realized the shape inference is still wrong because the argument is not supplied in the debug_ssa. Thanks to yinghai, I didn't fix the converter, fixing it in this diff

Test Plan:
Run the binary, and checked the exported op

  op {
		input: "sequential_250/parallel/normalization/dper_feature_normalization/sparse_features_processor/sparse_feature_transform/gather_ranges_GSF_IDLIST_COOCCUR_APP_ID_NEKO_ORGANIC_1D_7D_INSTALL_V1/gathered_values_0"
		output: "sequential_250/parallel/normalization/dper_feature_normalization/sparse_features_processor/sparse_feature_transform/sequential_1/hash_feature_ids/SigridHash:0_0"
		type: "SigridHash"
		arg {
			name: "salt"
			i: 0
		}
		arg {
			name: "maxValue"
			i: 100000
		}
		arg {
			name: "hashIntoInt32"
			i: 1
		}
		arg {
			name: "net_pos"
			i: 3
		}
	}

it now have hashIntInt32

Reviewed By: yinghai

Differential Revision: D20457057

