### PR TITLE
fix exact_dtype attribute setting in test_optim.py

### DIFF
--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -32,9 +32,7 @@ def drosenbrock(tensor):
 
 
 class TestOptim(TestCase):
-    def setUp(self):
-        super(TestOptim, self).setUp()
-        self.exact_dtype = True
+    exact_dtype = True
 
     def _test_rosenbrock_sparse(self, constructor, scheduler_constructors=None,
                                 sparse_only=False):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#34841 fix exact_dtype attribute setting in test_optim.py**
* #34825 Turn on exact_dtype by default on test_optim.py

