### PR TITLE
[quant][mobile] Not use qnnpack max_pool2d if ceil_mode is true

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qpool.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qpool.cpp
@@ -402,7 +402,7 @@ class QMaxPool2D_arr_args final : public torch::OperatorKernel {
       std::vector<int64_t> dilation,
       bool ceil_mode) {
     #ifdef USE_PYTORCH_QNNPACK
-    if (at::globalContext().qEngine() == at::QEngine::QNNPACK && qx.scalar_type() == kQUInt8) {
+    if (at::globalContext().qEngine() == at::QEngine::QNNPACK && qx.scalar_type() == kQUInt8 && !ceil_mode) {
       return qnnpack_maxpool(qx, kernel_size, stride, padding, dilation, ceil_mode);
     }
     #endif


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#34844 [quant][mobile] Not use qnnpack max_pool2d if ceil_mode is true**

Summary:
QNNPACK max_pool2d operator does not support ceil_mode so this can cause crashes in the kernel when it is set to true.
We default to the server implementation when ceil_mode is set to true

Test Plan:
python test/test_quantized.py

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D20478701](https://our.internmc.facebook.com/intern/diff/D20478701)