### PR TITLE
[RPC] Avoid polluting Python root logger on importing "torch" module

### DIFF
--- a/torch/distributed/rpc/api.py
+++ b/torch/distributed/rpc/api.py
@@ -37,8 +37,10 @@ from .internal import (
 )
 
 
-logging.basicConfig()
 logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+logger.addHandler(logging.StreamHandler(sys.stdout))
+
 
 # NB: Ignoring RRef leaks during shutdown. Without this, applications have to
 # make sure there is no references to any RRef in the application code and


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#34871 [RPC] Avoid polluting Python root logger on importing "torch" module**

We used to configure root logger in RPC module. A stream handler is added to `root.handlers`. This is not desired behavior for pytorch users. We should instead keep the root logger handler list untouched.

We can configure the logger local to the rpc module, set it's log level, so it doesn't use it's ancestor, which is usually the root which has no stream handlers in most cases.
https://docs.python.org/3/library/logging.html#logging.Logger.setLevel

And add a stream handler to make it output to stdout, even if the root handlers is not configured and has an empty list.
https://docs.python.org/3/library/logging.html#logging.Logger.addHandler
https://docs.python.org/3/library/logging.handlers.html#logging.StreamHandler

Differential Revision: [D7677493](https://our.internmc.facebook.com/intern/diff/D7677493/)