### PR TITLE
[JIT] Make RPC RRef Owner WorkerInfo.name available to TorchScript

### DIFF
--- a/aten/src/ATen/core/rref_interface.h
+++ b/aten/src/ATen/core/rref_interface.h
@@ -24,6 +24,9 @@ class C10_EXPORT RRefInterface : public c10::intrusive_ptr_target {
   // returns the worker id of the owner
   virtual worker_id_t owner() const = 0;
 
+  // returns the worker name of the owner
+  virtual std::string ownerName() const = 0;
+
   // Returns true if this is the ``OwnerRRef``
   virtual bool isOwner() const = 0;
 

--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -184,6 +184,13 @@ PyObject* rpc_init(PyObject* /* unused */) {
                   Returns worker information of the node that owns this ``RRef``.
               )")
           .def(
+              // not releasing GIL here to avoid context switch on getters
+              "owner_name",
+              &PyRRef::ownerName,
+              R"(
+                  Returns worker name of the node that owns this ``RRef``.
+              )")
+          .def(
               "to_here",
               &PyRRef::toHere,
               py::call_guard<py::gil_scoped_release>(),

--- a/torch/csrc/distributed/rpc/py_rref.cpp
+++ b/torch/csrc/distributed/rpc/py_rref.cpp
@@ -121,6 +121,10 @@ WorkerInfo PyRRef::owner() const {
   return RRefContext::getInstance().agent()->getWorkerInfo(rref_->owner());
 }
 
+std::string PyRRef::ownerName() const {
+  return rref_->ownerName();
+}
+
 py::object PyRRef::toHere() {
   if (rref_->isOwner()) {
     return localValue();

--- a/torch/csrc/distributed/rpc/py_rref.h
+++ b/torch/csrc/distributed/rpc/py_rref.h
@@ -18,6 +18,7 @@ class PyRRef {
   bool isOwner() const;
   bool confirmedByOwner() const;
   WorkerInfo owner() const;
+  std::string ownerName() const;
   py::object toHere();
   py::object localValue();
   std::string str() const;

--- a/torch/csrc/distributed/rpc/rref_impl.h
+++ b/torch/csrc/distributed/rpc/rref_impl.h
@@ -201,6 +201,11 @@ class TORCH_API RRef : public RRefInterface {
     return ownerId_;
   }
 
+  // returns the worker name of the owner
+  inline std::string ownerName() const override {
+    return RpcAgent::getCurrentRpcAgent()->getWorkerInfo(ownerId_).name_;
+  }
+
   // Returns the globally unique RRefId of this RRef
   inline const RRefId& rrefId() const {
     return rrefId_;

--- a/torch/csrc/jit/runtime/register_distributed_ops.cpp
+++ b/torch/csrc/jit/runtime/register_distributed_ops.cpp
@@ -64,13 +64,29 @@ RegisterOperators reg_rpc_ops({
         },
         aliasAnalysisFromSchema()),
      Operator(
-         "aten::confirmed_by_owner(RRef(t) self) -> bool",
-         [](Stack& stack) {
-           auto rref = pop(stack).toRRef();
-           push(stack, rref->confirmedByOwner());
-           return 0;
-         },
-         aliasAnalysisFromSchema()),
+       "aten::owner(RRef(t) self) -> int",
+       [](Stack& stack) {
+         auto rref = pop(stack).toRRef();
+         push(stack, rref->owner());
+         return 0;
+       },
+       aliasAnalysisFromSchema()),
+     Operator(
+        "aten::owner_name(RRef(t) self) -> str",
+        [](Stack& stack) {
+          auto rref = pop(stack).toRRef();
+          push(stack, rref->ownerName());
+          return 0;
+        },
+        aliasAnalysisFromSchema()),
+     Operator(
+        "aten::confirmed_by_owner(RRef(t) self) -> bool",
+        [](Stack& stack) {
+          auto rref = pop(stack).toRRef();
+          push(stack, rref->confirmedByOwner());
+          return 0;
+        },
+        aliasAnalysisFromSchema()),
      Operator(
          prim::rpc_async,
          [](const Node* node) -> Operation {

--- a/torch/testing/_internal/distributed/rpc/jit/rpc_test.py
+++ b/torch/testing/_internal/distributed/rpc/jit/rpc_test.py
@@ -120,10 +120,24 @@ class LocalRRefTest(RpcAgentTestFixture):
 
         # Create a local RRef<MyScripClass> remotely in Python.
         rref = rpc.rpc_sync(dst_worker_name, owner_create_rref_my_script_class, args=(self.rank,))
-        # Use RRef<MyScripClass> remotely in Script.
-        ret = rpc.rpc_sync(
-            rref.owner(), script_run_get_value_rref_my_script_class, args=(rref,)
-        )
+
+        def use_rref_on_owner(rref):
+            # type: (RRef[MyScriptClass]) -> int
+            args = (rref,)
+            kwargs: Dict[str, Any] = {}  # noqa
+            fut = rpc.rpc_async(
+                rref.owner(), script_run_get_value_rref_my_script_class, args, kwargs
+            )
+            ret = fut.wait()
+            return ret
+
+        # Use RRef<MyScripClass> in local Python RPC and remote Script run.
+        ret = use_rref_on_owner(rref)
+        self.assertEqual(ret, self.rank)
+
+        # Use RRef<MyScriptClass> in local Script RPC and remote Script run.
+        use_rref_on_owner_script = torch.jit.script(use_rref_on_owner)
+        ret = use_rref_on_owner(rref)
         self.assertEqual(ret, self.rank)
 
     @dist_init
@@ -135,12 +149,25 @@ class LocalRRefTest(RpcAgentTestFixture):
 
         # Create a local RRef<MyModuleInterface> remotely in Python.
         rref = rpc.rpc_sync(dst_worker_name, owner_create_rref_my_script_module, args=(self.rank,))
-        # Use RRef<MyModuleInterface> remotely in Script.
-        ret = rpc.rpc_sync(
-            rref.owner(), script_run_forward_rref_my_script_module, args=(rref,)
-        )
+
+        def use_rref_on_owner(rref):
+            # type: (RRef[MyModuleInterface]) -> int
+            args = (rref,)
+            kwargs: Dict[str, Any] = {}
+            fut = rpc.rpc_async(
+                rref.owner_name(), script_run_forward_rref_my_script_module, args, kwargs
+            )
+            ret = fut.wait()
+            return ret
+
+        # Use RRef<MyScripClass> in local Python RPC and remote Script run.
+        ret = use_rref_on_owner(rref)
         self.assertEqual(ret, torch.ones(self.rank))
 
+        # Use RRef<MyScriptClass> in local Script RPC and remote Script run.
+        use_rref_on_owner_script = torch.jit.script(use_rref_on_owner)
+        ret = use_rref_on_owner(rref)
+        self.assertEqual(ret, torch.ones(self.rank))
 
 def python_function():
     return 0


### PR DESCRIPTION
Summary: Make TorchScript support calling ref.owner() to get owner worker id and calling ref.owner_name() to get owner worker name.

Differential Revision: D7652208

