### PR TITLE
Add a warning for RRef serialization

### DIFF
--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -122,6 +122,11 @@ PyObject* rpc_init(PyObject* /* unused */) {
           offers best-effort error detection, and applications should not use
           ``UserRRef``s after ``rpc.shutdown()``.
 
+          .. warning::
+              RRefs can only be serialized and deserialized by the RPC module.
+              Serializing and deserializing RRefs without RPC will lead to
+              errors.
+
           Example::
               Following examples skip RPC initialization and shutdown code
               for simplicity. Refer to RPC docs for those details.

--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -124,8 +124,10 @@ PyObject* rpc_init(PyObject* /* unused */) {
 
           .. warning::
               RRefs can only be serialized and deserialized by the RPC module.
-              Serializing and deserializing RRefs without RPC will lead to
-              errors.
+              Serializing and deserializing RRefs without RPC (e.g., Python
+              pickle, :meth:`~torch.save`, :meth:`~torch.load`,
+              :meth:`~torch.jit.save`, :meth:`~torch.jit.load`, etc.) will lead
+              to errors.
 
           Example::
               Following examples skip RPC initialization and shutdown code

--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -125,9 +125,9 @@ PyObject* rpc_init(PyObject* /* unused */) {
           .. warning::
               RRefs can only be serialized and deserialized by the RPC module.
               Serializing and deserializing RRefs without RPC (e.g., Python
-              pickle, :meth:`~torch.save`, :meth:`~torch.load`,
-              :meth:`~torch.jit.save`, :meth:`~torch.jit.load`, etc.) will lead
-              to errors.
+              pickle, torch :meth:`~torch.save` / :meth:`~torch.load`,
+              JIT :meth:`~torch.jit.save` / :meth:`~torch.jit.load`, etc.) will
+              lead to errors.
 
           Example::
               Following examples skip RPC initialization and shutdown code


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #34931 Support using self as the destination in rpc.remote for builtin operators
* #34921 Fix dist autograd context Example block format
* #34919 Fix example block format in Distributed Optimizer API doc
* #34914 Fix example format in Distributed Autograd doc
* #34890 Minor fixes for RPC API docs
* #34888 Update descriptions for transmitting CUDA tensors
* #34887 Removing experimental tag in for RPC and adding experimental tag for RPC+TorchScript
* #34885 Adding warnings for async Tensor serialization in remote and rpc_async
* **#34884 Add a warning for RRef serialization**

Differential Revision: [D20491278](https://our.internmc.facebook.com/intern/diff/D20491278)