### PR TITLE
Adding warnings for async Tensor serialization in remote and rpc_async

### DIFF
--- a/torch/distributed/rpc/api.py
+++ b/torch/distributed/rpc/api.py
@@ -374,8 +374,8 @@ def remote(to, func, args=None, kwargs=None):
         The ``remote`` API does not copy storages of argument tensors until
         sending them over the wire, which could be done by a different thread
         depending on the RPC backend type. The caller should make sure that the
-        content of those tensors stay intact until the returned Future
-        completes.
+        contents of those tensors stay intact until the returned RRef is
+        confirmed by the owner.
 
     Example::
         Make sure that ``MASTER_ADDRESS`` and ``MASTER_PORT`` are set properly
@@ -580,7 +580,7 @@ def rpc_async(to, func, args=None, kwargs=None):
         The ``rpc_async`` API does not copy storages of argument tensors until
         sending them over the wire, which could be done by a different thread
         depending on the RPC backend type. The caller should make sure that the
-        content of those tensors stay intact until the returned Future
+        contents of those tensors stay intact until the returned Future
         completes.
 
     Example::

--- a/torch/distributed/rpc/api.py
+++ b/torch/distributed/rpc/api.py
@@ -370,6 +370,13 @@ def remote(to, func, args=None, kwargs=None):
         need to explicitly copy GPU tensors to CPU before using them as
         arguments or return values of ``func``.
 
+    .. warning ::
+        The ``remote`` API does not copy storages of argument tensors until
+        sending them over the wire, which could be done by a different thread
+        depending on the RPC backend type. The caller should make sure that the
+        content of those tensors stay intact until the returned Future
+        completes.
+
     Example::
         Make sure that ``MASTER_ADDRESS`` and ``MASTER_PORT`` are set properly
         on both workers. Refer to :meth:`~torch.distributed.init_process_group`
@@ -568,6 +575,13 @@ def rpc_async(to, func, args=None, kwargs=None):
         supported since we don't support sending GPU tensors over the wire. You
         need to explicitly copy GPU tensors to CPU before using them as
         arguments or return values of ``func``.
+
+    .. warning ::
+        The ``rpc_async`` API does not copy storages of argument tensors until
+        sending them over the wire, which could be done by a different thread
+        depending on the RPC backend type. The caller should make sure that the
+        content of those tensors stay intact until the returned Future
+        completes.
 
     Example::
         Make sure that ``MASTER_ADDRESS`` and ``MASTER_PORT`` are set properly


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #34931 Support using self as the destination in rpc.remote for builtin operators
* #34921 Fix dist autograd context Example block format
* #34919 Fix example block format in Distributed Optimizer API doc
* #34914 Fix example format in Distributed Autograd doc
* #34890 Minor fixes for RPC API docs
* #34888 Update descriptions for transmitting CUDA tensors
* #34887 Removing experimental tag in for RPC and adding experimental tag for RPC+TorchScript
* **#34885 Adding warnings for async Tensor serialization in remote and rpc_async**
* #34884 Add a warning for RRef serialization

Differential Revision: [D20491279](https://our.internmc.facebook.com/intern/diff/D20491279)