### PR TITLE
Update descriptions for transmitting CUDA tensors

### DIFF
--- a/docs/source/rpc.rst
+++ b/docs/source/rpc.rst
@@ -85,10 +85,11 @@ for communication.
 The following APIs allow users to remotely execute functions as well as create
 references (RRefs) to remote data objects. In these APIs, when passing a
 ``Tensor`` as an argument or a return value, the destination worker will try to
-create a ``Tensor`` with the same meta (i.e., device, stride, etc.), which might
-crash if the device lists on source and destination workers are different. In
-such cases, applications can always feed in CPU tensors and manually move it
-to appropriate devices if necessary.
+create a ``Tensor`` with the same meta (i.e., shape, stride, etc.). We
+intentionally disallow transmitting CUDA tensors because it might crash if the
+device lists on source and destination workers do not match. In such cases,
+applications can always explicitly move the input tensors to CPU on the caller
+and move it to the desired devices on the callee if necessary.
 
 .. warning::
   TorchScript support in RPC is experimental and subject to change.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #34931 Support using self as the destination in rpc.remote for builtin operators
* #34921 Fix dist autograd context Example block format
* #34919 Fix example block format in Distributed Optimizer API doc
* #34914 Fix example format in Distributed Autograd doc
* #34890 Minor fixes for RPC API docs
* **#34888 Update descriptions for transmitting CUDA tensors**
* #34887 Removing experimental tag in for RPC and adding experimental tag for RPC+TorchScript
* #34885 Adding warnings for async Tensor serialization in remote and rpc_async
* #34884 Add a warning for RRef serialization

Differential Revision: [D20491408](https://our.internmc.facebook.com/intern/diff/D20491408)