### PR TITLE
Add's missing dependency in the README for build from source.

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ If you are building for NVIDIA's Jetson platforms (Jetson Nano, TX1, TX2, AGX Xa
 
 Common (only install `typing` for Python <3.5)
 ```
-conda install numpy ninja pyyaml mkl mkl-include setuptools cmake cffi typing
+conda install numpy ninja pyyaml mkl mkl-include setuptools cmake cffi typing pybind11
 ```
 
 On Linux


### PR DESCRIPTION
Compilation will fail without pybind11

