### PR TITLE
fix barrier in jit test

### DIFF
--- a/torch/testing/_internal/distributed/rpc/jit/rpc_test.py
+++ b/torch/testing/_internal/distributed/rpc/jit/rpc_test.py
@@ -5,7 +5,11 @@ import torch
 import torch.distributed as dist
 import torch.distributed.rpc as rpc
 from torch import Tensor
-from torch.testing._internal.dist_utils import dist_init, worker_name
+from torch.testing._internal.dist_utils import (
+    dist_init,
+    worker_name,
+    initialize_pg,
+)
 from torch.testing._internal.distributed.rpc.rpc_agent_test_fixture import (
     RpcAgentTestFixture,
 )
@@ -578,6 +582,7 @@ class JitRpcTest(LocalRRefTest, JitRpcAsyncOpTest, RpcAgentTestFixture):
         # wait for local MyScriptModule instantiation to finish,
         # otherwise it could instantiate MyScriptModule in parallel with
         # server thread in the below
+        initialize_pg(self.init_method, self.rank, self.world_size)
         dist.barrier()
 
         # rpc_sync still accepts script class and run it in


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#34901 fix barrier in jit test**

init_pg is needed for dist.barrier call, otherwise default process group may not be found for some rpc backend

Differential Revision: [D20495321](https://our.internmc.facebook.com/intern/diff/D20495321/)