### PR TITLE
[caffe2] open source 2/4-bit SLS operators

### DIFF
--- a/caffe2/operators/fused_rowwise_nbit_conversion_ops.cc
+++ b/caffe2/operators/fused_rowwise_nbit_conversion_ops.cc
@@ -1,0 +1,303 @@
+#include "caffe2/operators/fused_rowwise_nbit_conversion_ops.h"
+#include <fp16.h>
+#include "c10/util/Registry.h"
+
+namespace caffe2 {
+
+using std::uint16_t;
+using std::vector;
+
+namespace internal {
+void convertfp32fp16(at::Half* dst, const float* src, size_t N) {
+  for (size_t i = 0; i < N; i++) {
+    dst[i] = src[i];
+  }
+}
+
+} // namespace internal
+
+REGISTER_CPU_OPERATOR(
+    FloatToFused4BitRowwiseQuantized,
+    FloatToFusedNBitRowwiseQuantizedOp<4, float, internal::convertfp32fp32>);
+OPERATOR_SCHEMA(FloatToFused4BitRowwiseQuantized)
+    .NumInputs(1)
+    .NumOutputs(1)
+    .TensorInferenceFunction([](const OperatorDef& /* def */,
+                                const vector<TensorShape>& in) {
+      vector<TensorShape> out;
+      TensorShape X = in[0];
+      // divide over 2 and round up, add 4 for the extra scale and bias
+      X.set_dims(
+          X.dims().size() - 1,
+          (X.dims(X.dims().size() - 1) + 1) / 2 + 2 * sizeof(at::Half));
+      out.push_back(std::move(X));
+      out[0].set_data_type(TensorProto_DataType_UINT8);
+      return out;
+    })
+    .SetDoc(R"DOC(
+Applies 4-bit row-wise quantization by determining the range
+(maximum - minimum) and offset (minimum value) of each row in the input
+matrix, and then scaling each element to an 4-bit number between 0 and
+15. To later de-quantize values, the scale (range / 15) and zero_point
+are stored alongside the data. More precisely, each row first has quantized
+values, and then 2-byte fp16 scale and 2-byte zero_offset.)
+)DOC")
+    .Input(0, "input", "Float32 input data")
+    .Output(0, "output", "Fused scale, bias and quantized data");
+NO_GRADIENT(FloatToFused4BitRowwiseQuantized);
+
+REGISTER_CPU_OPERATOR(
+    HalfToFused4BitRowwiseQuantized,
+    FloatToFusedNBitRowwiseQuantizedOp<4, at::Half, internal::convertfp16fp32>);
+OPERATOR_SCHEMA(HalfToFused4BitRowwiseQuantized)
+    .NumInputs(1)
+    .NumOutputs(1)
+    .TensorInferenceFunction([](const OperatorDef& /* def */,
+                                const vector<TensorShape>& in) {
+      vector<TensorShape> out;
+      TensorShape X = in[0];
+      X.set_dims(
+          X.dims().size() - 1,
+          (X.dims(X.dims().size() - 1) + 1) / 2 + 2 * sizeof(at::Half));
+      out.push_back(std::move(X));
+      out[0].set_data_type(TensorProto_DataType_UINT8);
+      return out;
+    })
+    .SetDoc(R"DOC(
+Applies 4-bit row-wise quantization by determining the range
+(maximum - minimum) and offset (minimum value) of each row in the input
+matrix, and then scaling each element to an 4-bit number between 0 and
+15. To later de-quantize values, the scale (range / 15) and zero_point
+are stored alongside the data. More precisely, each row first has quantized
+values, and then 2-byte fp16 scale and 2-byte zero_offset.)
+)DOC")
+    .Input(0, "input", "Float16 input data")
+    .Output(0, "output", "Fused scale, bias and quantized data");
+NO_GRADIENT(HalfToFused4BitRowwiseQuantized);
+
+REGISTER_CPU_OPERATOR(
+    Fused4BitRowwiseQuantizedToFloat,
+    FusedNBitRowwiseQuantizedToFloatOp<4, float, internal::convertfp32fp32>);
+OPERATOR_SCHEMA(Fused4BitRowwiseQuantizedToFloat)
+    .NumInputs(1)
+    .NumOutputs(1)
+    .TensorInferenceFunction([](const OperatorDef& /* def */,
+                                const vector<TensorShape>& in) {
+      vector<TensorShape> out;
+      TensorShape X = in[0];
+      X.set_dims(
+          X.dims().size() - 1,
+          (X.dims(X.dims().size() - 1) - 2 * sizeof(at::Half)) * 2);
+      out.push_back(std::move(X));
+      out[0].set_data_type(TensorProto_DataType_FLOAT);
+      return out;
+    })
+    .SetDoc(R"DOC(
+De-quantizes the result of the
+FloatToFused4BitRowwiseQuantized operator. The input is expected to first have
+quantized values, then 2-byte fp16 scale and 1-byte zero_offset. The output is a
+matrix containing only the values, but de-quantized. De-quantization is
+performed by multiplying each value by its row's scale and zero_point
+parameters. The de-quantized values will thus not be exactly equal to
+the original, un-quantized floating point values.
+)DOC")
+    .Input(
+        0,
+        "scale_bias_quantized_input",
+        "Fused scale, bias and quantized data")
+    .Output(0, "float_output", "Float32 data");
+NO_GRADIENT(Fused4BitRowwiseQuantizedToFloat);
+
+REGISTER_CPU_OPERATOR(
+    Fused4BitRowwiseQuantizedToHalf,
+    FusedNBitRowwiseQuantizedToFloatOp<4, at::Half, internal::convertfp32fp16>);
+OPERATOR_SCHEMA(Fused4BitRowwiseQuantizedToHalf)
+    .NumInputs(1)
+    .NumOutputs(1)
+    .TensorInferenceFunction([](const OperatorDef& /* def */,
+                                const vector<TensorShape>& in) {
+      vector<TensorShape> out;
+      TensorShape X = in[0];
+      X.set_dims(
+          X.dims().size() - 1,
+          (X.dims(X.dims().size() - 1) - 2 * sizeof(at::Half)) * 2);
+      out.push_back(std::move(X));
+      out[0].set_data_type(TensorProto_DataType_FLOAT16);
+      return out;
+    })
+    .SetDoc(R"DOC(
+De-quantizes the result of the
+FloatToFused4BitRowwiseQuantized operator. The input is expected to first have
+quantized values, then 2-byte fp16 scale and 1-byte zero_offset. The output is a
+matrix containing only the values, but de-quantized. De-quantization is
+performed by multiplying each value by its row's scale and zero_point
+parameters. The de-quantized values will thus not be exactly equal to
+the original, un-quantized floating point values.
+)DOC")
+    .Input(
+        0,
+        "scale_bias_quantized_input",
+        "Fused scale, bias and quantized data")
+    .Output(0, "float16_output", "Float16 data");
+NO_GRADIENT(Fused4BitRowwiseQuantizedToHalf);
+
+REGISTER_CPU_OPERATOR_WITH_ENGINE(
+    FloatToFused4BitRowwiseQuantized,
+    GREEDY,
+    FloatToFusedNBitRowwiseQuantizedOp<
+        4,
+        float,
+        internal::convertfp32fp32,
+        true /*GREEDY*/>);
+REGISTER_CPU_OPERATOR_WITH_ENGINE(
+    HalfToFused4BitRowwiseQuantized,
+    GREEDY,
+    FloatToFusedNBitRowwiseQuantizedOp<
+        4,
+        at::Half,
+        internal::convertfp16fp32,
+        true /*GREEDY*/>);
+
+REGISTER_CPU_OPERATOR(
+    FloatToFused2BitRowwiseQuantized,
+    FloatToFusedNBitRowwiseQuantizedOp<2, float, internal::convertfp32fp32>);
+OPERATOR_SCHEMA(FloatToFused2BitRowwiseQuantized)
+    .NumInputs(1)
+    .NumOutputs(1)
+    .TensorInferenceFunction([](const OperatorDef& /* def */,
+                                const vector<TensorShape>& in) {
+      vector<TensorShape> out;
+      TensorShape X = in[0];
+      // divide over 4 and round up, add 4 for the extra scale and bias
+      X.set_dims(
+          X.dims().size() - 1,
+          (X.dims(X.dims().size() - 1) + 3) / 4 + 2 * sizeof(at::Half));
+      out.push_back(std::move(X));
+      out[0].set_data_type(TensorProto_DataType_UINT8);
+      return out;
+    })
+    .SetDoc(R"DOC(
+Applies 2-bit row-wise quantization by determining the range
+(maximum - minimum) and offset (minimum value) of each row in the input
+matrix, and then scaling each element to an 2-bit number between 0 and
+3. To later de-quantize values, the scale (range / 3) and zero_point
+are stored alongside the data. More precisely, each row first has quantized
+values, and then 2-byte fp16 scale and 2-byte zero_offset.)
+)DOC")
+    .Input(0, "input", "Float32 input data")
+    .Output(0, "output", "Fused scale, bias and quantized data");
+NO_GRADIENT(FloatToFused2BitRowwiseQuantized);
+
+REGISTER_CPU_OPERATOR(
+    HalfToFused2BitRowwiseQuantized,
+    FloatToFusedNBitRowwiseQuantizedOp<2, at::Half, internal::convertfp16fp32>);
+OPERATOR_SCHEMA(HalfToFused2BitRowwiseQuantized)
+    .NumInputs(1)
+    .NumOutputs(1)
+    .TensorInferenceFunction([](const OperatorDef& /* def */,
+                                const vector<TensorShape>& in) {
+      vector<TensorShape> out;
+      TensorShape X = in[0];
+      X.set_dims(
+          X.dims().size() - 1,
+          (X.dims(X.dims().size() - 1) + 3) / 4 + 2 * sizeof(at::Half));
+      out.push_back(std::move(X));
+      out[0].set_data_type(TensorProto_DataType_UINT8);
+      return out;
+    })
+    .SetDoc(R"DOC(
+Applies 2-bit row-wise quantization by determining the range
+(maximum - minimum) and offset (minimum value) of each row in the input
+matrix, and then scaling each element to an 2-bit number between 0 and
+3. To later de-quantize values, the scale (range / 3) and zero_point
+are stored alongside the data. More precisely, each row first has quantized
+values, and then 2-byte fp16 scale and 2-byte zero_offset.)
+)DOC")
+    .Input(0, "input", "Float16 input data")
+    .Output(0, "output", "Fused scale, bias and quantized data");
+NO_GRADIENT(HalfToFused2BitRowwiseQuantized);
+
+REGISTER_CPU_OPERATOR(
+    Fused2BitRowwiseQuantizedToFloat,
+    FusedNBitRowwiseQuantizedToFloatOp<2, float, internal::convertfp32fp32>);
+OPERATOR_SCHEMA(Fused2BitRowwiseQuantizedToFloat)
+    .NumInputs(1)
+    .NumOutputs(1)
+    .TensorInferenceFunction([](const OperatorDef& /* def */,
+                                const vector<TensorShape>& in) {
+      vector<TensorShape> out;
+      TensorShape X = in[0];
+      X.set_dims(
+          X.dims().size() - 1,
+          (X.dims(X.dims().size() - 1) - 2 * sizeof(at::Half)) * 4);
+      out.push_back(std::move(X));
+      out[0].set_data_type(TensorProto_DataType_FLOAT);
+      return out;
+    })
+    .SetDoc(R"DOC(
+De-quantizes the result of the
+FloatToFused2BitRowwiseQuantized operator. The input is expected to first have
+quantized values, then 2-byte fp16 scale and 1-byte zero_offset. The output is a
+matrix containing only the values, but de-quantized. De-quantization is
+performed by multiplying each value by its row's scale and zero_point
+parameters. The de-quantized values will thus not be exactly equal to
+the original, un-quantized floating point values.
+)DOC")
+    .Input(
+        0,
+        "scale_bias_quantized_input",
+        "Fused scale, bias and quantized data")
+    .Output(0, "float_output", "Float32 data");
+NO_GRADIENT(Fused2BitRowwiseQuantizedToFloat);
+
+REGISTER_CPU_OPERATOR(
+    Fused2BitRowwiseQuantizedToHalf,
+    FusedNBitRowwiseQuantizedToFloatOp<2, at::Half, internal::convertfp32fp16>);
+OPERATOR_SCHEMA(Fused2BitRowwiseQuantizedToHalf)
+    .NumInputs(1)
+    .NumOutputs(1)
+    .TensorInferenceFunction([](const OperatorDef& /* def */,
+                                const vector<TensorShape>& in) {
+      vector<TensorShape> out;
+      TensorShape X = in[0];
+      X.set_dims(
+          X.dims().size() - 1,
+          (X.dims(X.dims().size() - 1) - 2 * sizeof(at::Half)) * 4);
+      out.push_back(std::move(X));
+      out[0].set_data_type(TensorProto_DataType_FLOAT16);
+      return out;
+    })
+    .SetDoc(R"DOC(
+De-quantizes the result of the
+FloatToFused2BitRowwiseQuantized operator. The input is expected to first have
+quantized values, then 2-byte fp16 scale and 1-byte zero_offset. The output is a
+matrix containing only the values, but de-quantized. De-quantization is
+performed by multiplying each value by its row's scale and zero_point
+parameters. The de-quantized values will thus not be exactly equal to
+the original, un-quantized floating point values.
+)DOC")
+    .Input(
+        0,
+        "scale_bias_quantized_input",
+        "Fused scale, bias and quantized data")
+    .Output(0, "float16_output", "Float16 data");
+NO_GRADIENT(Fused2BitRowwiseQuantizedToHalf);
+
+REGISTER_CPU_OPERATOR_WITH_ENGINE(
+    FloatToFused2BitRowwiseQuantized,
+    GREEDY,
+    FloatToFusedNBitRowwiseQuantizedOp<
+        2,
+        float,
+        internal::convertfp32fp32,
+        true /*GREEDY*/>);
+REGISTER_CPU_OPERATOR_WITH_ENGINE(
+    HalfToFused2BitRowwiseQuantized,
+    GREEDY,
+    FloatToFusedNBitRowwiseQuantizedOp<
+        2,
+        at::Half,
+        internal::convertfp16fp32,
+        true /*GREEDY*/>);
+
+} // namespace caffe2

--- a/caffe2/operators/fused_rowwise_nbit_conversion_ops.h
+++ b/caffe2/operators/fused_rowwise_nbit_conversion_ops.h
@@ -1,0 +1,203 @@
+#pragma once
+
+#include <algorithm>
+#include <vector>
+
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+#include "caffe2/core/context.h"
+#include "caffe2/core/logging.h"
+#include "caffe2/core/operator.h"
+// for param_search_greedy
+#include "caffe2/operators/fused_rowwise_nbitfake_conversion_ops.h"
+
+namespace caffe2 {
+
+template <
+    int BIT_RATE,
+    typename T,
+    void (*convert)(float* dst, const T* src, size_t N),
+    bool GREEDY = false>
+class FloatToFusedNBitRowwiseQuantizedOp final : public Operator<CPUContext> {
+ public:
+  FloatToFusedNBitRowwiseQuantizedOp(const OperatorDef& def, Workspace* ws)
+      : Operator<CPUContext>(def, ws) {}
+  ~FloatToFusedNBitRowwiseQuantizedOp() override {}
+
+  bool RunOnDevice() override {
+    CAFFE_ENFORCE(internal::is_little_endian(), "Unsupported endianness");
+
+    const auto& input = Input(DATA_FLOAT);
+
+    CAFFE_ENFORCE_GT(input.dim(), 0, "Input's dimension must be at least 1");
+    const auto input_rows = input.size_to_dim(input.dim() - 1);
+    const auto input_columns = input.size(input.dim() - 1);
+    static_assert(8 % BIT_RATE == 0, "BIT_RATE must divide 8");
+    constexpr int NUM_ELEM_PER_BYTE = 8 / BIT_RATE;
+    CAFFE_ENFORCE_EQ(
+        input.dim(input.dim() - 1) % NUM_ELEM_PER_BYTE,
+        0,
+        "FloatToFused" + std::to_string(BIT_RATE) +
+            "BitRowwiseQuantizedOp only works for the number of "
+            "columns a multiple of " +
+            std::to_string(NUM_ELEM_PER_BYTE));
+
+    // The "fused" representation stores the scale and bias with the
+    // row-wise quantized data in one tensor.
+    // Since we represent the scale and bias in 16-bit float, we'll use the
+    // last 4 bytes of each row for scale (2 bytes) and bias (2 bytes).
+    // | ... quantized data ... | scale | bias |
+    // |    number_of_columns   |  2B   |  2B  |
+    auto output_dimensions = input.sizes().vec();
+    output_dimensions[input.dim() - 1] = static_cast<std::int64_t>(
+        (input_columns + NUM_ELEM_PER_BYTE - 1) / NUM_ELEM_PER_BYTE +
+        2 * sizeof(at::Half));
+    auto* output = Output(
+        DATA_FUSED_SCALE_BIAS, output_dimensions, at::dtype<std::uint8_t>());
+
+    const auto* input_data = input.template data<T>();
+    auto* output_data = output->template mutable_data<std::uint8_t>();
+    const auto output_columns = output->size(output->dim() - 1);
+
+#ifdef _OPENMP
+    vector<float> tmp_vec(input_columns * (GREEDY ? omp_get_max_threads() : 1));
+#else
+    vector<float> tmp_vec(input_columns);
+#endif
+
+#pragma omp parallel for if (GREEDY)
+    for (int row = 0; row < input_rows; ++row) {
+      float* tmp = tmp_vec.data();
+#ifdef _OPENMP
+      if (GREEDY) {
+        tmp = &tmp_vec[omp_get_thread_num() * input_columns];
+      }
+#endif
+      convert(tmp, input_data + row * input_columns, input_columns);
+
+      std::uint8_t* output_row = output_data + row * output_columns;
+      at::Half* output_row_scale = reinterpret_cast<at::Half*>(
+          output_row +
+          (input_columns + NUM_ELEM_PER_BYTE - 1) / NUM_ELEM_PER_BYTE);
+      at::Half* output_row_bias = reinterpret_cast<at::Half*>(
+          output_row +
+          (input_columns + NUM_ELEM_PER_BYTE - 1) / NUM_ELEM_PER_BYTE +
+          sizeof(at::Half));
+
+      float Xmin = *std::min_element(tmp, tmp + input_columns);
+      float Xmax = *std::max_element(tmp, tmp + input_columns);
+
+      if (GREEDY) {
+        C10_LOG_EVERY_N(INFO, 100) << "Running the GREEDY engine!";
+        internal::param_search_greedy(
+            tmp, input_columns, 200, 0.16, Xmin, Xmax, BIT_RATE);
+      }
+
+      // Round Xmin to fp16 to match with dequantization that will use fp16
+      // for Xmin.
+      Xmin = static_cast<at::Half>(Xmin);
+      const float range = Xmax - Xmin;
+      // Round scale to fp16 to match with dequantization that will use fp16
+      // for scale.
+      // Set scale to 1.0f for the corner case of Xmax == Xmin .
+      // Any non-zero scale would work because during quantization
+      // (X - Xmin) / scale will be 0 for all X unless scale is 0.
+      at::Half scale = range == 0 ? 1.0f : range / ((1 << BIT_RATE) - 1);
+      if (scale == 0) {
+        // Corner case handling when Xmax == Xmin
+        // Any scale would work because X - Xmin will be 0 for all X
+        scale = 1.0f;
+      }
+
+      *output_row_scale = scale;
+      *output_row_bias = Xmin;
+
+      for (int col = 0; col < input_columns; ++col) {
+        float X = tmp[col];
+        std::uint8_t quantized = std::max(
+            0,
+            std::min<int>(
+                std::lrintf((X - Xmin) / scale), (1 << BIT_RATE) - 1));
+        if (col % NUM_ELEM_PER_BYTE == 0) {
+          // LSB
+          output_row[col / NUM_ELEM_PER_BYTE] = quantized;
+        } else {
+          output_row[col / NUM_ELEM_PER_BYTE] |=
+              (quantized << ((col % NUM_ELEM_PER_BYTE) * BIT_RATE));
+        }
+      }
+    }
+
+    return true;
+  }
+
+ private:
+  INPUT_TAGS(DATA_FLOAT);
+  OUTPUT_TAGS(DATA_FUSED_SCALE_BIAS);
+};
+
+template <
+    int BIT_RATE,
+    typename T,
+    void (*convert)(T* dst, const float* src, size_t N)>
+class FusedNBitRowwiseQuantizedToFloatOp final : public Operator<CPUContext> {
+ public:
+  FusedNBitRowwiseQuantizedToFloatOp(const OperatorDef& def, Workspace* ws)
+      : Operator<CPUContext>(def, ws) {}
+  ~FusedNBitRowwiseQuantizedToFloatOp() override {}
+
+  bool RunOnDevice() override {
+    CAFFE_ENFORCE(internal::is_little_endian(), "Unsupported endianness");
+
+    const auto& input = Input(DATA_FUSED_SCALE_BIAS);
+
+    CAFFE_ENFORCE_GT(input.dim(), 0, "Input's dimension must be at least 1");
+    const auto input_rows = input.size_to_dim(input.dim() - 1);
+    const auto input_columns = input.size(input.dim() - 1);
+
+    static_assert(8 % BIT_RATE == 0, "BIT_RATE must divide 8");
+    constexpr int NUM_ELEM_PER_BYTE = 8 / BIT_RATE;
+
+    // The last 4 bytes per row are two fp16 scale and bias.
+    // The rest of input_columns is the number of values in the original row.
+    auto output_dimensions = input.sizes().vec();
+    output_dimensions[input.dim() - 1] =
+        static_cast<std::int64_t>(input_columns - 2 * sizeof(at::Half)) *
+        NUM_ELEM_PER_BYTE;
+    auto* output = Output(DATA_FLOAT, output_dimensions, at::dtype<T>());
+    const auto output_columns = output->size(output->dim() - 1);
+
+    const auto* input_data = input.template data<std::uint8_t>();
+    T* output_data = output->template mutable_data<T>();
+
+    std::vector<float> tmp(output_columns);
+
+    for (size_t row = 0; row < input_rows; ++row) {
+      const std::uint8_t* input_row = input_data + row * input_columns;
+      float scale = *reinterpret_cast<const at::Half*>(
+          input_row +
+          (output_columns + NUM_ELEM_PER_BYTE - 1) / NUM_ELEM_PER_BYTE);
+      float bias = *reinterpret_cast<const at::Half*>(
+          input_row +
+          (output_columns + NUM_ELEM_PER_BYTE - 1) / NUM_ELEM_PER_BYTE +
+          sizeof(at::Half));
+
+      for (int col = 0; col < output_columns; ++col) {
+        std::uint8_t quantized = input_row[col / NUM_ELEM_PER_BYTE];
+        quantized >>= (col % NUM_ELEM_PER_BYTE) * BIT_RATE;
+        quantized &= (1 << BIT_RATE) - 1;
+        tmp[col] = scale * quantized + bias;
+      }
+
+      convert(output_data + row * output_columns, tmp.data(), output_columns);
+    }
+    return true;
+  }
+
+ private:
+  INPUT_TAGS(DATA_FUSED_SCALE_BIAS);
+  OUTPUT_TAGS(DATA_FLOAT);
+};
+} // namespace caffe2

--- a/caffe2/operators/fused_rowwise_nbitfake_conversion_ops.cc
+++ b/caffe2/operators/fused_rowwise_nbitfake_conversion_ops.cc
@@ -1,0 +1,270 @@
+#include "caffe2/operators/fused_rowwise_nbitfake_conversion_ops.h"
+#include <fp16.h>
+#include <immintrin.h>
+#include "c10/util/Registry.h"
+
+namespace caffe2 {
+
+namespace {
+float compress_uniform_simplified_(
+    const float* X,
+    int N,
+    float xmin,
+    float xmax,
+    float* Xq,
+    int bit_rate) {
+  xmin = static_cast<at::Half>(xmin);
+  float data_range = xmax - xmin;
+  float qmax = (1 << bit_rate) - 1;
+  float scale = data_range == 0
+      ? 1.0
+      : static_cast<float>(static_cast<at::Half>(data_range / qmax));
+  float inverse_scale = 1.0f / scale;
+
+  float norm = 0.0f;
+  constexpr int VLEN = 8;
+  int i = 0;
+
+#ifdef __AVX__
+  // vectorized loop
+  __m256 norm_v = _mm256_setzero_ps();
+  for (; i < N / VLEN * VLEN; i += VLEN) {
+    __m256 X_v = _mm256_loadu_ps(X + i);
+    // Affine
+    __m256 Xq_v = _mm256_mul_ps(
+        _mm256_sub_ps(X_v, _mm256_set1_ps(xmin)),
+        _mm256_set1_ps(inverse_scale));
+    // Round
+    // Use _MM_FROUND_CUR_DIRECTION to match the behavior with the remainder
+    // code. In most cases, the rounding mode is round-to-nearest-even.
+    Xq_v = _mm256_round_ps(Xq_v, _MM_FROUND_CUR_DIRECTION);
+    // Clip
+    Xq_v = _mm256_max_ps(
+        _mm256_setzero_ps(), _mm256_min_ps(Xq_v, _mm256_set1_ps(qmax)));
+    // Inverse affine
+    Xq_v = _mm256_add_ps(
+        _mm256_mul_ps(Xq_v, _mm256_set1_ps(scale)), _mm256_set1_ps(xmin));
+    __m256 err_v = _mm256_sub_ps(X_v, Xq_v);
+    norm_v = _mm256_add_ps(_mm256_mul_ps(err_v, err_v), norm_v);
+  }
+  alignas(64) float temp[VLEN];
+  _mm256_store_ps(temp, norm_v);
+  for (int j = 0; j < VLEN; ++j) {
+    norm += temp[j];
+  }
+#endif // __AVX__
+
+  // remainder loop
+  for (; i < N; i++) {
+    Xq[i] = std::max(
+        0.0f, std::min<float>(nearbyint((X[i] - xmin) * inverse_scale), qmax));
+    Xq[i] = Xq[i] * scale + xmin;
+    norm += (X[i] - Xq[i]) * (X[i] - Xq[i]);
+  }
+
+  return std::sqrt(norm);
+}
+} // namespace
+
+namespace internal {
+void convertfp32fp32(float* dst, const float* src, size_t N) {
+  memcpy(dst, src, sizeof(float) * N);
+}
+
+void convertfp16fp32(float* dst, const at::Half* src, size_t N) {
+  for (size_t i = 0; i < N; i++) {
+    dst[i] = src[i];
+  }
+}
+
+void param_search_greedy(
+    const float* X,
+    int N,
+    const int n_bins, // = 200,
+    const float ratio, // = 0.16,
+    float& Xmin,
+    float& Xmax,
+    int bit_rate) {
+  float stepsize = (Xmax - Xmin) / n_bins;
+  int min_bins = n_bins * (1 - ratio);
+
+  vector<float> Xq(N);
+
+  float loss =
+      compress_uniform_simplified_(X, N, Xmin, Xmax, Xq.data(), bit_rate);
+  float best_loss = loss;
+
+  float cur_min = Xmin;
+  float cur_max = Xmax;
+  float cur_loss = loss;
+
+  float thr = min_bins * stepsize;
+  while (cur_min + thr < cur_max) {
+    // move left
+    float loss1 = compress_uniform_simplified_(
+        X, N, cur_min + stepsize, cur_max, Xq.data(), bit_rate);
+    // move right
+    float loss2 = compress_uniform_simplified_(
+        X, N, cur_min, cur_max - stepsize, Xq.data(), bit_rate);
+    if (cur_loss < loss1 && cur_loss < loss2 && cur_loss < best_loss) {
+      // found a local optima
+      best_loss = cur_loss;
+      Xmin = cur_min;
+      Xmax = cur_max;
+    }
+    if (loss1 < loss2) {
+      cur_min = cur_min + stepsize;
+      cur_loss = loss1;
+    } else {
+      cur_max = cur_max - stepsize;
+      cur_loss = loss2;
+    }
+  }
+}
+} // namespace internal
+
+REGISTER_CPU_OPERATOR(
+    FloatToFused4BitFakeRowwiseQuantized,
+    FloatToFusedNBitFakeRowwiseQuantizedOp<
+        4,
+        float,
+        internal::convertfp32fp32>);
+OPERATOR_SCHEMA(FloatToFused4BitFakeRowwiseQuantized)
+    .NumInputs(1)
+    .NumOutputs(1)
+    .TensorInferenceFunction([](const OperatorDef& /* def */,
+                                const vector<TensorShape>& in) {
+      vector<TensorShape> out;
+      TensorShape X = in[0];
+      X.set_dims(1, X.dims(1) + 8);
+      out.push_back(std::move(X));
+      out[0].set_data_type(TensorProto_DataType_UINT8);
+      return out;
+    })
+    .SetDoc(R"DOC(
+Applies 4-bit row-wise fake quantization to a tensor of floats.
+The output looks like an int8 rowwise quantized blob with
+scale and biases in half float.
+)DOC")
+    .Input(0, "input", "Float32 input data")
+    .Output(0, "output", "Fused scale, bias and quantized data");
+NO_GRADIENT(FloatToFused4BitFakeRowwiseQuantized);
+
+REGISTER_CPU_OPERATOR(
+    HalfToFused4BitFakeRowwiseQuantized,
+    FloatToFusedNBitFakeRowwiseQuantizedOp<
+        4,
+        at::Half,
+        internal::convertfp16fp32>);
+OPERATOR_SCHEMA(HalfToFused4BitFakeRowwiseQuantized)
+    .NumInputs(1)
+    .NumOutputs(1)
+    .TensorInferenceFunction([](const OperatorDef& /* def */,
+                                const vector<TensorShape>& in) {
+      vector<TensorShape> out;
+      TensorShape X = in[0];
+      X.set_dims(1, X.dims(1) + 8);
+      out.push_back(std::move(X));
+      out[0].set_data_type(TensorProto_DataType_UINT8);
+      return out;
+    })
+    .SetDoc(R"DOC(
+Applies 4-bit row-wise fake quantization to a tensor of half floats.
+The output looks like an int8 rowwise quantized blob with
+scale and biases in half float.
+)DOC")
+    .Input(0, "input", "Float16 input data")
+    .Output(0, "output", "Fused scale, bias and quantized data");
+NO_GRADIENT(HalfToFused4BitFakeRowwiseQuantized);
+
+REGISTER_CPU_OPERATOR_WITH_ENGINE(
+    FloatToFused4BitFakeRowwiseQuantized,
+    GREEDY,
+    FloatToFusedNBitFakeRowwiseQuantizedOp<
+        4,
+        float,
+        internal::convertfp32fp32,
+        true /* GREEDY */>);
+
+REGISTER_CPU_OPERATOR_WITH_ENGINE(
+    HalfToFused4BitFakeRowwiseQuantized,
+    GREEDY,
+    FloatToFusedNBitFakeRowwiseQuantizedOp<
+        4,
+        at::Half,
+        internal::convertfp16fp32,
+        true /* GREEDY */>);
+
+REGISTER_CPU_OPERATOR(
+    FloatToFused2BitFakeRowwiseQuantized,
+    FloatToFusedNBitFakeRowwiseQuantizedOp<
+        2,
+        float,
+        internal::convertfp32fp32>);
+OPERATOR_SCHEMA(FloatToFused2BitFakeRowwiseQuantized)
+    .NumInputs(1)
+    .NumOutputs(1)
+    .TensorInferenceFunction([](const OperatorDef& /* def */,
+                                const vector<TensorShape>& in) {
+      vector<TensorShape> out;
+      TensorShape X = in[0];
+      X.set_dims(1, X.dims(1) + 8);
+      out.push_back(std::move(X));
+      out[0].set_data_type(TensorProto_DataType_UINT8);
+      return out;
+    })
+    .SetDoc(R"DOC(
+Applies 2-bit row-wise fake quantization to a tensor of floats.
+The output looks like an int8 rowwise quantized blob with
+scale and biases in half float.
+)DOC")
+    .Input(0, "input", "Float32 input data")
+    .Output(0, "output", "Fused scale, bias and quantized data");
+NO_GRADIENT(FloatToFused2BitFakeRowwiseQuantized);
+
+REGISTER_CPU_OPERATOR(
+    HalfToFused2BitFakeRowwiseQuantized,
+    FloatToFusedNBitFakeRowwiseQuantizedOp<
+        2,
+        at::Half,
+        internal::convertfp16fp32>);
+OPERATOR_SCHEMA(HalfToFused2BitFakeRowwiseQuantized)
+    .NumInputs(1)
+    .NumOutputs(1)
+    .TensorInferenceFunction([](const OperatorDef& /* def */,
+                                const vector<TensorShape>& in) {
+      vector<TensorShape> out;
+      TensorShape X = in[0];
+      X.set_dims(1, X.dims(1) + 8);
+      out.push_back(std::move(X));
+      out[0].set_data_type(TensorProto_DataType_UINT8);
+      return out;
+    })
+    .SetDoc(R"DOC(
+Applies 2-bit row-wise fake quantization to a tensor of half floats.
+The output looks like an int8 rowwise quantized blob with
+scale and biases in half float.
+)DOC")
+    .Input(0, "input", "Float16 input data")
+    .Output(0, "output", "Fused scale, bias and quantized data");
+NO_GRADIENT(HalfToFused2BitFakeRowwiseQuantized);
+
+REGISTER_CPU_OPERATOR_WITH_ENGINE(
+    FloatToFused2BitFakeRowwiseQuantized,
+    GREEDY,
+    FloatToFusedNBitFakeRowwiseQuantizedOp<
+        2,
+        float,
+        internal::convertfp32fp32,
+        true /* GREEDY */>);
+
+REGISTER_CPU_OPERATOR_WITH_ENGINE(
+    HalfToFused2BitFakeRowwiseQuantized,
+    GREEDY,
+    FloatToFusedNBitFakeRowwiseQuantizedOp<
+        2,
+        at::Half,
+        internal::convertfp16fp32,
+        true /* GREEDY */>);
+
+} // namespace caffe2

--- a/caffe2/operators/fused_rowwise_nbitfake_conversion_ops.h
+++ b/caffe2/operators/fused_rowwise_nbitfake_conversion_ops.h
@@ -1,0 +1,139 @@
+#pragma once
+
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+#include "caffe2/core/context.h"
+#include "caffe2/core/logging.h"
+#include "caffe2/core/operator.h"
+#include "caffe2/operators/reducer_functors.h"
+#include "caffe2/utils/math.h"
+
+namespace caffe2 {
+
+namespace internal {
+inline bool is_little_endian() {
+  constexpr std::int32_t kValue = 1;
+  return reinterpret_cast<const std::uint8_t*>(&kValue)[0] == 1;
+}
+
+void convertfp32fp32(float* dst, const float* src, size_t N);
+void convertfp16fp32(float* dst, const at::Half* src, size_t N);
+
+/**
+ * @params Xmin initial solution passed and potentiall better solution returns
+ * @params Xmax initial solution passed and potentiall better solution returns
+ */
+void param_search_greedy(
+    const float* X,
+    int N,
+    const int n_bins, // = 200,
+    const float ratio, // = 0.16,
+    float& Xmin,
+    float& Xmax,
+    int bit_rate);
+} // namespace internal
+
+// Fake 2/4 bit quantization
+// Creeates a 2/4bit rowwise quantized blob with scales and biases in fp16
+// The storage format is 8 bit rowwise with scales and biases in fp32
+template <
+    int BIT_RATE,
+    typename T,
+    void (*convert)(float* dst, const T* src, size_t N),
+    bool GREEDY = false>
+class FloatToFusedNBitFakeRowwiseQuantizedOp final
+    : public Operator<CPUContext> {
+ public:
+  FloatToFusedNBitFakeRowwiseQuantizedOp(const OperatorDef& def, Workspace* ws)
+      : Operator<CPUContext>(def, ws) {}
+  ~FloatToFusedNBitFakeRowwiseQuantizedOp() override {}
+
+  bool RunOnDevice() override {
+    CAFFE_ENFORCE(internal::is_little_endian(), "Unsupported endianness");
+
+    const auto& input = Input(DATA_FLOAT);
+
+    const auto input_rows = input.size(0);
+    const auto input_columns = input.size(1);
+    CAFFE_ENFORCE_EQ(input.dim(), 2, "Expect input to be a matrix");
+
+    const std::vector<int64_t> output_dimensions = {input_rows,
+                                                    input_columns + 8};
+    auto* output = Output(
+        DATA_FUSED_SCALE_BIAS_INT8, output_dimensions, at::dtype<uint8_t>());
+
+    const auto* input_data = input.template data<T>();
+    auto* output_data = output->template mutable_data<uint8_t>();
+    const auto output_columns = output->size(1);
+
+    if (!std::is_same<T, float>::value && !std::is_same<T, at::Half>::value) {
+      CAFFE_THROW("Unsupported data type");
+    }
+
+    bool use_openmp = GREEDY;
+#ifdef _OPENMP
+    vector<float> tmp_vec(input_columns * (GREEDY ? omp_get_max_threads() : 1));
+#else
+    vector<float> tmp_vec(input_columns);
+#endif
+
+#pragma omp parallel for if (GREEDY)
+    for (int row = 0; row < input_rows; ++row) {
+      float* tmp = tmp_vec.data();
+#ifdef _OPENMP
+      if (GREEDY) {
+        tmp = &tmp_vec[omp_get_thread_num() * input_columns];
+      }
+#endif
+      convert(tmp, input_data + row * input_columns, input_columns);
+      uint8_t* output_row = output_data + row * output_columns;
+      float* output_row_scale_bias =
+          reinterpret_cast<float*>(output_row + input_columns);
+
+      float minimum_element = *std::min_element(tmp, tmp + input_columns);
+      float maximum_element = *std::max_element(tmp, tmp + input_columns);
+
+      if (GREEDY) {
+        internal::param_search_greedy(
+            tmp,
+            input_columns,
+            200,
+            0.16,
+            minimum_element,
+            maximum_element,
+            BIT_RATE);
+      }
+
+      minimum_element = static_cast<at::Half>(minimum_element);
+      const float range = maximum_element - minimum_element;
+
+      const float scale = range == 0
+          ? 1.0f
+          : static_cast<float>(static_cast<at::Half>(
+                range / static_cast<float>((1 << BIT_RATE) - 1)));
+      const float inverse_scale = 1.0f / scale;
+
+      output_row_scale_bias[0] = scale;
+      output_row_scale_bias[1] = minimum_element;
+
+      for (size_t col = 0; col < input_columns; ++col) {
+        output_row[col] = std::max(
+            0,
+            std::min<int>(
+                std::lrintf((tmp[col] - minimum_element) * inverse_scale),
+                (1 << BIT_RATE) - 1));
+      }
+    }
+
+    return true;
+  }
+
+ private:
+  INPUT_TAGS(DATA_FLOAT);
+  // INT8 suffix because this is a fake quantization operator whose output
+  // type is always 8-bit regardless of BIT_RATE.
+  OUTPUT_TAGS(DATA_FUSED_SCALE_BIAS_INT8);
+};
+} // namespace caffe2

--- a/caffe2/operators/lengths_reducer_fused_nbit_rowwise_ops.cc
+++ b/caffe2/operators/lengths_reducer_fused_nbit_rowwise_ops.cc
@@ -1,0 +1,578 @@
+#include "caffe2/operators/lengths_reducer_fused_nbit_rowwise_ops.h"
+#include "c10/util/Registry.h"
+
+namespace caffe2 {
+
+REGISTER_CPU_OPERATOR(
+    SparseLengthsSumFused4BitRowwise,
+    SparseLengthsFusedNBitRowwiseOp<4, CPUContext>);
+OPERATOR_SCHEMA(SparseLengthsSumFused4BitRowwise)
+    .NumInputs(3)
+    .NumOutputs(1)
+    .ValueKeyLengthInputFillers(
+        SparseLengthsFusedNBitRowwiseOp<4, CPUContext>::DATA,
+        SparseLengthsFusedNBitRowwiseOp<4, CPUContext>::INDICES,
+        SparseLengthsFusedNBitRowwiseOp<4, CPUContext>::LENGTHS)
+    .SetDoc(R"DOC(
+Performs the same operation as SparseLengthsSum, but operating on
+4-bit rowwise quantized matrices with fused storage (where each row
+stores quantized values, and then 2-byte fp16 scale and bias).
+)DOC")
+    .Input(
+        0,
+        "DATA",
+        "uint8 tensor obtained with "
+        "operator FloatToFused4BitRowwiseQuantized")
+    .Input(
+        1,
+        "INDICES",
+        "Integer vector containing indices of the first "
+        "dimension of DATA for the slices that are being aggregated")
+    .Input(
+        2,
+        "LENGTHS",
+        "Vector with the same sum of elements as the first dimension of DATA")
+    .Output(0, "output", "output")
+    .InheritOnnxSchema();
+NO_GRADIENT(SparseLengthsSumFused4BitRowwise);
+
+REGISTER_CPU_OPERATOR(
+    SparseLengthsWeightedSumFused4BitRowwise,
+    SparseLengthsFusedNBitRowwiseOp<4, CPUContext, /*with_weights=*/true>);
+OPERATOR_SCHEMA(SparseLengthsWeightedSumFused4BitRowwise)
+    .NumInputs(4)
+    .NumOutputs(1)
+    .WeightedValueKeyLengthInputFillers(
+        SparseLengthsFusedNBitRowwiseOp<4, CPUContext, true>::DATA,
+        SparseLengthsFusedNBitRowwiseOp<4, CPUContext, true>::INDICES,
+        SparseLengthsFusedNBitRowwiseOp<4, CPUContext, true>::LENGTHS,
+        SparseLengthsFusedNBitRowwiseOp<4, CPUContext, true>::WEIGHTS)
+    .SetDoc(R"DOC(
+Performs the same operation as SparseLengthsWeightedSum,
+but operating on 4-bit rowwise quantized matrices with fused storage
+(where each row stores quantized values, and then 2-byte fp16 scale and bias).
+)DOC")
+    .Input(
+        0,
+        "DATA",
+        "uint8 tensor obtained with "
+        "operator FloatToFused4BitRowwiseQuantized")
+    .Input(
+        1,
+        "INDICES",
+        "Integer vector containing indices of the first "
+        "dimension of DATA for the slices that are being aggregated")
+    .Input(
+        2,
+        "LENGTHS",
+        "Vector with the same sum of elements as the first dimension of DATA")
+    .Input(
+        3,
+        "WEIGHTS",
+        "Vector of weights to scale rows of DATA with before reduction")
+    .Output(0, "output", "output");
+NO_GRADIENT(SparseLengthsWeightedSumFused4BitRowwise);
+
+REGISTER_CPU_OPERATOR(
+    SparseLengthsMeanFused4BitRowwise,
+    SparseLengthsFusedNBitRowwiseOp<
+        4,
+        CPUContext,
+        /*with_weights=*/false,
+        /*is_mean=*/true>);
+OPERATOR_SCHEMA(SparseLengthsMeanFused4BitRowwise)
+    .NumInputs(3)
+    .NumOutputs(1)
+    .ValueKeyLengthInputFillers(
+        SparseLengthsFusedNBitRowwiseOp<4, CPUContext, false, true>::DATA,
+        SparseLengthsFusedNBitRowwiseOp<4, CPUContext, false, true>::INDICES,
+        SparseLengthsFusedNBitRowwiseOp<4, CPUContext, false, true>::LENGTHS)
+    .SetDoc(R"DOC(
+Performs the same operation as SparseLengthsMean, but
+operating on 4-bit rowwise quantized matrices with fused storage
+(where each row stores quantized values, and then 2-byte fp16 scale and bias).
+)DOC")
+    .Input(
+        0,
+        "DATA",
+        "uint8 tensor obtained with "
+        "operator FloatToFused4BitRowwiseQuantized")
+    .Input(
+        1,
+        "INDICES",
+        "Integer vector containing indices of the first "
+        "dimension of DATA for the slices that are being aggregated")
+    .Input(
+        2,
+        "LENGTHS",
+        "Vector with the same sum of elements as the first dimension of DATA")
+    .Output(0, "output", "output");
+NO_GRADIENT(SparseLengthsMeanFused4BitRowwise);
+
+REGISTER_CPU_OPERATOR(
+    SparseLengthsSumFused2BitRowwise,
+    SparseLengthsFusedNBitRowwiseOp<2, CPUContext>);
+OPERATOR_SCHEMA(SparseLengthsSumFused2BitRowwise)
+    .NumInputs(3)
+    .NumOutputs(1)
+    .ValueKeyLengthInputFillers(
+        SparseLengthsFusedNBitRowwiseOp<2, CPUContext>::DATA,
+        SparseLengthsFusedNBitRowwiseOp<2, CPUContext>::INDICES,
+        SparseLengthsFusedNBitRowwiseOp<2, CPUContext>::LENGTHS)
+    .SetDoc(R"DOC(
+Performs the same operation as SparseLengthsSum, but operating on
+2-bit rowwise quantized matrices with fused storage (where each row
+stores quantized values, and then 2-byte fp16 scale and bias).
+)DOC")
+    .Input(
+        0,
+        "DATA",
+        "uint8 tensor obtained with "
+        "operator FloatToFused2BitRowwiseQuantized")
+    .Input(
+        1,
+        "INDICES",
+        "Integer vector containing indices of the first "
+        "dimension of DATA for the slices that are being aggregated")
+    .Input(
+        2,
+        "LENGTHS",
+        "Vector with the same sum of elements as the first dimension of DATA")
+    .Output(0, "output", "output")
+    .InheritOnnxSchema();
+NO_GRADIENT(SparseLengthsSumFused2BitRowwise);
+
+REGISTER_CPU_OPERATOR(
+    SparseLengthsWeightedSumFused2BitRowwise,
+    SparseLengthsFusedNBitRowwiseOp<2, CPUContext, /*with_weights=*/true>);
+OPERATOR_SCHEMA(SparseLengthsWeightedSumFused2BitRowwise)
+    .NumInputs(4)
+    .NumOutputs(1)
+    .WeightedValueKeyLengthInputFillers(
+        SparseLengthsFusedNBitRowwiseOp<2, CPUContext, true>::DATA,
+        SparseLengthsFusedNBitRowwiseOp<2, CPUContext, true>::INDICES,
+        SparseLengthsFusedNBitRowwiseOp<2, CPUContext, true>::LENGTHS,
+        SparseLengthsFusedNBitRowwiseOp<2, CPUContext, true>::WEIGHTS)
+    .SetDoc(R"DOC(
+Performs the same operation as SparseLengthsWeightedSum,
+but operating on 2-bit rowwise quantized matrices with fused storage
+(where each row stores quantized values, and then 2-byte fp16 scale and bias).
+)DOC")
+    .Input(
+        0,
+        "DATA",
+        "uint8 tensor obtained with "
+        "operator FloatToFused2BitRowwiseQuantized")
+    .Input(
+        1,
+        "INDICES",
+        "Integer vector containing indices of the first "
+        "dimension of DATA for the slices that are being aggregated")
+    .Input(
+        2,
+        "LENGTHS",
+        "Vector with the same sum of elements as the first dimension of DATA")
+    .Input(
+        3,
+        "WEIGHTS",
+        "Vector of weights to scale rows of DATA with before reduction")
+    .Output(0, "output", "output");
+NO_GRADIENT(SparseLengthsWeightedSumFused2BitRowwise);
+
+REGISTER_CPU_OPERATOR(
+    SparseLengthsMeanFused2BitRowwise,
+    SparseLengthsFusedNBitRowwiseOp<
+        2,
+        CPUContext,
+        /*with_weights=*/false,
+        /*is_mean=*/true>);
+OPERATOR_SCHEMA(SparseLengthsMeanFused2BitRowwise)
+    .NumInputs(3)
+    .NumOutputs(1)
+    .ValueKeyLengthInputFillers(
+        SparseLengthsFusedNBitRowwiseOp<2, CPUContext, false, true>::DATA,
+        SparseLengthsFusedNBitRowwiseOp<2, CPUContext, false, true>::INDICES,
+        SparseLengthsFusedNBitRowwiseOp<2, CPUContext, false, true>::LENGTHS)
+    .SetDoc(R"DOC(
+Performs the same operation as SparseLengthsMean, but
+operating on 2-bit rowwise quantized matrices with fused storage
+(where each row stores quantized values, and then 2-byte fp16 scale and bias).
+)DOC")
+    .Input(
+        0,
+        "DATA",
+        "uint8 tensor obtained with "
+        "operator FloatToFused2BitRowwiseQuantized")
+    .Input(
+        1,
+        "INDICES",
+        "Integer vector containing indices of the first "
+        "dimension of DATA for the slices that are being aggregated")
+    .Input(
+        2,
+        "LENGTHS",
+        "Vector with the same sum of elements as the first dimension of DATA")
+    .Output(0, "output", "output");
+NO_GRADIENT(SparseLengthsMeanFused2BitRowwise);
+
+REGISTER_CPU_OPERATOR(
+    SparseLengthsSum4BitRowwiseSparse,
+    SparseLengthsNBitRowwiseSparseOp<4>);
+OPERATOR_SCHEMA(SparseLengthsSum4BitRowwiseSparse)
+    .NumInputs(4)
+    .NumOutputs(1)
+    .ValueKeyLengthInputFillers(
+        SparseLengthsNBitRowwiseSparseOp<4>::COMPRESSED_INDICES_MAPPING,
+        SparseLengthsNBitRowwiseSparseOp<4>::INDICES,
+        SparseLengthsNBitRowwiseSparseOp<4>::LENGTHS)
+    .SetDoc(R"DOC(
+Performs SparseLengthsSum, but operating on 4-bit rowwise quantized matrices
+with fused storage (where each row stores quantized values, and then 2-byte
+fp16 scale and 2-byte fp16 bias), and where rows are pruned.
+)DOC")
+    .Input(
+        0,
+        "DATA",
+        "uint8 tensor obtained with "
+        "operator FloatToFused4BitRowwiseQuantized")
+    .Input(
+        1,
+        "INDICES",
+        "Integer vector containing indices of the first "
+        "dimension of DATA for the slices that are being aggregated")
+    .Input(
+        2,
+        "LENGTHS",
+        "Vector with the same sum of elements as the first dimension of DATA")
+    .Input(
+        3,
+        "COMPRESSED_INDICES_MAPPING",
+        "Integer vector mapping uncompressed indices to compressed indices")
+    .Output(0, "output", "output")
+    .InheritOnnxSchema();
+NO_GRADIENT(SparseLengthsSum4BitRowwiseSparse);
+
+REGISTER_CPU_OPERATOR(
+    SparseLengthsWeightedSum4BitRowwiseSparse,
+    SparseLengthsNBitRowwiseSparseOp<
+        4,
+        /*with_weights=*/true>);
+OPERATOR_SCHEMA(SparseLengthsWeightedSum4BitRowwiseSparse)
+    .NumInputs(5)
+    .NumOutputs(1)
+    .WeightedValueKeyLengthInputFillers(
+        SparseLengthsNBitRowwiseSparseOp<4, true>::COMPRESSED_INDICES_MAPPING,
+        SparseLengthsNBitRowwiseSparseOp<4, true>::INDICES,
+        SparseLengthsNBitRowwiseSparseOp<4, true>::LENGTHS,
+        SparseLengthsNBitRowwiseSparseOp<4, true>::WEIGHTS)
+    .SetDoc(R"DOC(
+Performs SparseLengthsWeightedSum, but operating on 4-bit rowwise quantized
+matrices with fused storage (where each row stores quantized values, and then
+2-byte fp16 scale and bias), and where rows are pruned.
+)DOC")
+    .Input(
+        0,
+        "DATA",
+        "uint8 tensor obtained with "
+        "operator FloatToFused4BitRowwiseQuantized")
+    .Input(
+        1,
+        "INDICES",
+        "Integer vector containing indices of the first "
+        "dimension of DATA for the slices that are being aggregated")
+    .Input(
+        2,
+        "LENGTHS",
+        "Vector with the same sum of elements as the first dimension of DATA")
+    .Input(
+        3,
+        "WEIGHTS",
+        "Vector of weights to scale rows of DATA with before reduction")
+    .Input(
+        4,
+        "COMPRESSED_INDICES_MAPPING",
+        "Integer vector mapping uncompressed indices to compressed indices")
+    .Output(0, "output", "output");
+NO_GRADIENT(SparseLengthsWeightedSum4BitRowwiseSparse);
+
+REGISTER_CPU_OPERATOR(
+    SparseLengthsMean4BitRowwiseSparse,
+    SparseLengthsNBitRowwiseSparseOp<
+        4,
+        /*with_weights=*/false,
+        /*is_mean=*/true>);
+OPERATOR_SCHEMA(SparseLengthsMean4BitRowwiseSparse)
+    .NumInputs(4)
+    .NumOutputs(1)
+    .ValueKeyLengthInputFillers(
+        SparseLengthsNBitRowwiseSparseOp<4, false, true>::
+            COMPRESSED_INDICES_MAPPING,
+        SparseLengthsNBitRowwiseSparseOp<4, false, true>::INDICES,
+        SparseLengthsNBitRowwiseSparseOp<4, false, true>::LENGTHS)
+    .SetDoc(R"DOC(
+Performs SparseLengthsMean, but operating on 4-bit rowwise quantized matrices
+with fused storage (where each row stores quantized values, and then 2-byte
+fp16 scale and bias), and where rows are pruned.
+)DOC")
+    .Input(
+        0,
+        "DATA",
+        "uint8 tensor obtained with "
+        "operator FloatToFused4BitRowwiseQuantized")
+    .Input(
+        1,
+        "INDICES",
+        "Integer vector containing indices of the first "
+        "dimension of DATA for the slices that are being aggregated")
+    .Input(
+        2,
+        "LENGTHS",
+        "Vector with the same sum of elements as the first dimension of DATA")
+    .Input(
+        3,
+        "COMPRESSED_INDICES_MAPPING",
+        "Integer vector mapping uncompressed indices to compressed indices")
+    .Output(0, "output", "output");
+NO_GRADIENT(SparseLengthsMean4BitRowwiseSparse);
+
+REGISTER_CPU_OPERATOR(
+    SparseLengthsSum8BitRowwiseSparse,
+    SparseLengthsNBitRowwiseSparseOp<8>);
+OPERATOR_SCHEMA(SparseLengthsSum8BitRowwiseSparse)
+    .NumInputs(4)
+    .NumOutputs(1)
+    .ValueKeyLengthInputFillers(
+        SparseLengthsNBitRowwiseSparseOp<8>::COMPRESSED_INDICES_MAPPING,
+        SparseLengthsNBitRowwiseSparseOp<8>::INDICES,
+        SparseLengthsNBitRowwiseSparseOp<8>::LENGTHS)
+    .SetDoc(R"DOC(
+Performs SparseLengthsSum, but operating on 8-bit rowwise quantized matrices
+with fused storage (where each row stores quantized values, and then 4-byte
+fp32 scale and 4-byte fp32 bias), and where rows are pruned.
+)DOC")
+    .Input(
+        0,
+        "DATA",
+        "uint8 tensor obtained with "
+        "operator FloatToFused4BitRowwiseQuantized")
+    .Input(
+        1,
+        "INDICES",
+        "Integer vector containing indices of the first "
+        "dimension of DATA for the slices that are being aggregated")
+    .Input(
+        2,
+        "LENGTHS",
+        "Vector with the same sum of elements as the first dimension of DATA")
+    .Input(
+        3,
+        "COMPRESSED_INDICES_MAPPING",
+        "Integer vector mapping uncompressed indices to compressed indices")
+    .Output(0, "output", "output")
+    .InheritOnnxSchema();
+NO_GRADIENT(SparseLengthsSum8BitRowwiseSparse);
+
+REGISTER_CPU_OPERATOR(
+    SparseLengthsWeightedSum8BitRowwiseSparse,
+    SparseLengthsNBitRowwiseSparseOp<
+        8,
+        /*with_weights=*/true>);
+OPERATOR_SCHEMA(SparseLengthsWeightedSum8BitRowwiseSparse)
+    .NumInputs(5)
+    .NumOutputs(1)
+    .WeightedValueKeyLengthInputFillers(
+        SparseLengthsNBitRowwiseSparseOp<8, true>::COMPRESSED_INDICES_MAPPING,
+        SparseLengthsNBitRowwiseSparseOp<8, true>::INDICES,
+        SparseLengthsNBitRowwiseSparseOp<8, true>::LENGTHS,
+        SparseLengthsNBitRowwiseSparseOp<8, true>::WEIGHTS)
+    .SetDoc(R"DOC(
+Performs SparseLengthsWeightedSum, but operating on 8-bit rowwise quantized
+matrices with fused storage (where each row stores quantized values, and then
+4-byte fp32 scale and bias), and where rows are pruned.
+)DOC")
+    .Input(
+        0,
+        "DATA",
+        "uint8 tensor obtained with "
+        "operator FloatToFused4BitRowwiseQuantized")
+    .Input(
+        1,
+        "INDICES",
+        "Integer vector containing indices of the first "
+        "dimension of DATA for the slices that are being aggregated")
+    .Input(
+        2,
+        "LENGTHS",
+        "Vector with the same sum of elements as the first dimension of DATA")
+    .Input(
+        3,
+        "WEIGHTS",
+        "Vector of weights to scale rows of DATA with before reduction")
+    .Input(
+        4,
+        "COMPRESSED_INDICES_MAPPING",
+        "Integer vector mapping uncompressed indices to compressed indices")
+    .Output(0, "output", "output");
+NO_GRADIENT(SparseLengthsWeightedSum8BitRowwiseSparse);
+
+REGISTER_CPU_OPERATOR(
+    SparseLengthsMean8BitRowwiseSparse,
+    SparseLengthsNBitRowwiseSparseOp<
+        8,
+        /*with_weights=*/false,
+        /*is_mean=*/true>);
+OPERATOR_SCHEMA(SparseLengthsMean8BitRowwiseSparse)
+    .NumInputs(4)
+    .NumOutputs(1)
+    .ValueKeyLengthInputFillers(
+        SparseLengthsNBitRowwiseSparseOp<8, false, true>::
+            COMPRESSED_INDICES_MAPPING,
+        SparseLengthsNBitRowwiseSparseOp<8, false, true>::INDICES,
+        SparseLengthsNBitRowwiseSparseOp<8, false, true>::LENGTHS)
+    .SetDoc(R"DOC(
+Performs SparseLengthsMean, but operating on 8-bit rowwise quantized matrices
+with fused storage (where each row stores quantized values, and then 4-byte
+fp32 scale and bias), and where rows are pruned.
+)DOC")
+    .Input(
+        0,
+        "DATA",
+        "uint8 tensor obtained with "
+        "operator FloatToFused4BitRowwiseQuantized")
+    .Input(
+        1,
+        "INDICES",
+        "Integer vector containing indices of the first "
+        "dimension of DATA for the slices that are being aggregated")
+    .Input(
+        2,
+        "LENGTHS",
+        "Vector with the same sum of elements as the first dimension of DATA")
+    .Input(
+        3,
+        "COMPRESSED_INDICES_MAPPING",
+        "Integer vector mapping uncompressed indices to compressed indices")
+    .Output(0, "output", "output");
+NO_GRADIENT(SparseLengthsMean8BitRowwiseSparse);
+
+REGISTER_CPU_OPERATOR(
+    SparseLengthsSum2BitRowwiseSparse,
+    SparseLengthsNBitRowwiseSparseOp<2>);
+OPERATOR_SCHEMA(SparseLengthsSum2BitRowwiseSparse)
+    .NumInputs(4)
+    .NumOutputs(1)
+    .ValueKeyLengthInputFillers(
+        SparseLengthsNBitRowwiseSparseOp<2>::COMPRESSED_INDICES_MAPPING,
+        SparseLengthsNBitRowwiseSparseOp<2>::INDICES,
+        SparseLengthsNBitRowwiseSparseOp<2>::LENGTHS)
+    .SetDoc(R"DOC(
+Performs SparseLengthsSum, but operating on 2-bit rowwise quantized matrices
+with fused storage (where each row stores quantized values, and then 2-byte
+fp16 scale and 2-byte fp16 bias), and where rows are pruned.
+)DOC")
+    .Input(
+        0,
+        "DATA",
+        "uint8 tensor obtained with "
+        "operator FloatToFused2BitRowwiseQuantized")
+    .Input(
+        1,
+        "INDICES",
+        "Integer vector containing indices of the first "
+        "dimension of DATA for the slices that are being aggregated")
+    .Input(
+        2,
+        "LENGTHS",
+        "Vector with the same sum of elements as the first dimension of DATA")
+    .Input(
+        3,
+        "COMPRESSED_INDICES_MAPPING",
+        "Integer vector mapping uncompressed indices to compressed indices")
+    .Output(0, "output", "output")
+    .InheritOnnxSchema();
+NO_GRADIENT(SparseLengthsSum2BitRowwiseSparse);
+
+REGISTER_CPU_OPERATOR(
+    SparseLengthsWeightedSum2BitRowwiseSparse,
+    SparseLengthsNBitRowwiseSparseOp<
+        2,
+        /*with_weights=*/true>);
+OPERATOR_SCHEMA(SparseLengthsWeightedSum2BitRowwiseSparse)
+    .NumInputs(5)
+    .NumOutputs(1)
+    .WeightedValueKeyLengthInputFillers(
+        SparseLengthsNBitRowwiseSparseOp<2, true>::COMPRESSED_INDICES_MAPPING,
+        SparseLengthsNBitRowwiseSparseOp<2, true>::INDICES,
+        SparseLengthsNBitRowwiseSparseOp<2, true>::LENGTHS,
+        SparseLengthsNBitRowwiseSparseOp<2, true>::WEIGHTS)
+    .SetDoc(R"DOC(
+Performs SparseLengthsWeightedSum, but operating on 2-bit rowwise quantized
+matrices with fused storage (where each row stores quantized values, and then
+2-byte fp16 scale and bias), and where rows are pruned.
+)DOC")
+    .Input(
+        0,
+        "DATA",
+        "uint8 tensor obtained with "
+        "operator FloatToFused2BitRowwiseQuantized")
+    .Input(
+        1,
+        "INDICES",
+        "Integer vector containing indices of the first "
+        "dimension of DATA for the slices that are being aggregated")
+    .Input(
+        2,
+        "LENGTHS",
+        "Vector with the same sum of elements as the first dimension of DATA")
+    .Input(
+        3,
+        "WEIGHTS",
+        "Vector of weights to scale rows of DATA with before reduction")
+    .Input(
+        4,
+        "COMPRESSED_INDICES_MAPPING",
+        "Integer vector mapping uncompressed indices to compressed indices")
+    .Output(0, "output", "output");
+NO_GRADIENT(SparseLengthsWeightedSum2BitRowwiseSparse);
+
+REGISTER_CPU_OPERATOR(
+    SparseLengthsMean2BitRowwiseSparse,
+    SparseLengthsNBitRowwiseSparseOp<
+        2,
+        /*with_weights=*/false,
+        /*is_mean=*/true>);
+OPERATOR_SCHEMA(SparseLengthsMean2BitRowwiseSparse)
+    .NumInputs(4)
+    .NumOutputs(1)
+    .ValueKeyLengthInputFillers(
+        SparseLengthsNBitRowwiseSparseOp<2, false, true>::
+            COMPRESSED_INDICES_MAPPING,
+        SparseLengthsNBitRowwiseSparseOp<2, false, true>::INDICES,
+        SparseLengthsNBitRowwiseSparseOp<2, false, true>::LENGTHS)
+    .SetDoc(R"DOC(
+Performs SparseLengthsMean, but operating on 2-bit rowwise quantized matrices
+with fused storage (where each row stores quantized values, and then 2-byte
+fp16 scale and bias), and where rows are pruned.
+)DOC")
+    .Input(
+        0,
+        "DATA",
+        "uint8 tensor obtained with "
+        "operator FloatToFused2BitRowwiseQuantized")
+    .Input(
+        1,
+        "INDICES",
+        "Integer vector containing indices of the first "
+        "dimension of DATA for the slices that are being aggregated")
+    .Input(
+        2,
+        "LENGTHS",
+        "Vector with the same sum of elements as the first dimension of DATA")
+    .Input(
+        3,
+        "COMPRESSED_INDICES_MAPPING",
+        "Integer vector mapping uncompressed indices to compressed indices")
+    .Output(0, "output", "output");
+NO_GRADIENT(SparseLengthsMean2BitRowwiseSparse);
+
+} // namespace caffe2

--- a/caffe2/operators/lengths_reducer_fused_nbit_rowwise_ops.h
+++ b/caffe2/operators/lengths_reducer_fused_nbit_rowwise_ops.h
@@ -1,0 +1,562 @@
+#ifndef CAFFE2_OPERATORS_LENGTHS_REDUCER_FUSED_8BIT_ROWWISE_OPS_H_
+#define CAFFE2_OPERATORS_LENGTHS_REDUCER_FUSED_8BIT_ROWWISE_OPS_H_
+
+#include "caffe2/core/context.h"
+#include "caffe2/core/logging.h"
+#include "caffe2/core/operator.h"
+#include "caffe2/operators/fused_rowwise_nbit_conversion_ops.h"
+#include "caffe2/operators/reducer_functors.h"
+#include "caffe2/utils/math.h"
+#ifdef USE_FBGEMM
+#include "fbgemm/FbgemmEmbedding.h"
+#endif
+
+namespace caffe2 {
+
+template <
+    int BIT_RATE,
+    class Context,
+    bool with_weights = false,
+    bool is_mean = false>
+class SparseLengthsFusedNBitRowwiseOp final : public Operator<Context> {
+ public:
+  static_assert(
+      !(with_weights && is_mean),
+      "Cannot have with_weights and is_mean a the same time");
+
+  USE_OPERATOR_CONTEXT_FUNCTIONS;
+  SparseLengthsFusedNBitRowwiseOp(const OperatorDef& def, Workspace* ws)
+      : Operator<Context>(def, ws) {}
+  ~SparseLengthsFusedNBitRowwiseOp() override {}
+
+  bool RunOnDevice() override {
+    return DispatchHelper<TensorTypes<int32_t, int64_t>>::call(
+        this, Input(INDICES));
+  }
+
+  template <typename IndexType>
+  bool DoRunWithType() {
+    const auto& data = Input(DATA);
+    const auto& indices = Input(INDICES);
+    const auto& lengths = Input(LENGTHS);
+
+    CAFFE_ENFORCE_EQ(indices.dim(), 1, "INDICES must be a vector");
+    CAFFE_ENFORCE_EQ(lengths.dim(), 1, "LENGTHS must be a vector");
+
+    const float* weights = nullptr;
+    if (with_weights) {
+      const auto& weights_input = Input(WEIGHTS);
+      CAFFE_ENFORCE_EQ(weights_input.dim(), 1, "WEIGHTS must be a vector");
+      CAFFE_ENFORCE_EQ(
+          weights_input.numel(),
+          indices.numel(),
+          "WEIGHTS should have the same length as INDICES.");
+      weights = weights_input.template data<float>();
+    }
+
+    CAFFE_ENFORCE_GT(
+        data.size(1),
+        sizeof(at::Half) + sizeof(at::Half),
+        "DATA must have more than 4 columns");
+    static_assert(8 % BIT_RATE == 0, "BIT_RATE must divide 8");
+    constexpr int NUM_ELEM_PER_BYTE = 8 / BIT_RATE;
+    // Subtract 4 from the #columns of data for the 2 bytes for fp16 scale and 2
+    // byte for bias that we use in the fused representation (per row).
+    const std::vector<int64_t> shape = {
+        lengths.size(0),
+        static_cast<int64_t>(data.size(1) - 2 * sizeof(at::Half)) *
+            NUM_ELEM_PER_BYTE};
+    auto* output = Output(0, shape, at::dtype<float>());
+
+    int output_size = output->size(0);
+    int block_size = output->size(1);
+    CAFFE_ENFORCE_EQ(
+        block_size % NUM_ELEM_PER_BYTE,
+        0,
+        "block size must be divisible by " + std::to_string(NUM_ELEM_PER_BYTE));
+    int index_size = indices.numel();
+    auto data_size = data.size(0);
+    const uint8_t* input_data = data.template data<uint8_t>();
+    const IndexType* indices_data = indices.template data<IndexType>();
+    const int* lengths_data = lengths.template data<int>();
+    float* output_data = output->template mutable_data<float>();
+
+#ifdef USE_FBGEMM
+    // If this is the first call or block size has changed (should never happen
+    // actually), generate a kernel.
+    if (block_size != last_block_size) {
+      last_block_size = block_size;
+      if (std::is_same<IndexType, std::int32_t>::value) {
+        kernel32_ = fbgemm::GenerateEmbeddingSpMDMNBit<std::int32_t>(
+            BIT_RATE,
+            block_size,
+            weights != nullptr,
+            is_mean,
+            /*prefetch distance*/ 16);
+      } else {
+        CAFFE_ENFORCE((std::is_same<IndexType, std::int64_t>::value));
+        kernel64_ = fbgemm::GenerateEmbeddingSpMDMNBit<std::int64_t>(
+            BIT_RATE,
+            block_size,
+            weights != nullptr,
+            is_mean,
+            /*prefetch distance*/ 16);
+      }
+    }
+
+    bool success;
+    if (std::is_same<IndexType, std::int32_t>::value) {
+      success = kernel32_(
+          output_size,
+          index_size,
+          data_size,
+          input_data,
+          reinterpret_cast<const std::int32_t*>(indices_data),
+          lengths_data,
+          weights,
+          output_data);
+    } else {
+      success = kernel64_(
+          output_size,
+          index_size,
+          data_size,
+          input_data,
+          reinterpret_cast<const std::int64_t*>(indices_data),
+          lengths_data,
+          weights,
+          output_data);
+    }
+
+    if (success) {
+      return true;
+    }
+
+    // Error handling
+    int64_t current = 0;
+    for (int m = 0; m < output_size; ++m) {
+      for (int i = 0; i < lengths_data[m]; ++i) {
+        CAFFE_ENFORCE_LT(current, index_size);
+        IndexType idx = indices_data[current];
+        CAFFE_ENFORCE(
+            0 <= idx && idx < data_size,
+            "Index ",
+            current,
+            " is out of bounds: ",
+            idx,
+            ", range 0 to ",
+            data_size);
+        ++current;
+      }
+    }
+    CAFFE_ENFORCE_EQ(
+        current,
+        index_size,
+        "Your input seems to be incorrect: the sum of lengths values should be "
+        "the size of the indices tensor, but it appears not.");
+
+    return false;
+#else
+    C10_LOG_EVERY_N(WARNING, 10)
+        << "Running slow path because FBGEMM is not available";
+
+    int64_t current = 0;
+    for (int m = 0; m < output_size; ++m) {
+      memset(output_data, 0, block_size * sizeof(float));
+      if (current + lengths_data[m] > index_size) {
+        return false;
+      }
+      for (int i = 0; i < lengths_data[m]; ++i, ++current) {
+        IndexType idx = indices_data[current];
+        if (idx < 0 || idx >= data_size) {
+          return false;
+        }
+
+        const at::Half* scale_bias = reinterpret_cast<const at::Half*>(
+            input_data + (idx + 1) * data.size(1) - 2 * sizeof(at::Half));
+
+        float weight = 1.0f;
+        if (with_weights) {
+          weight = weights[current];
+        }
+        const float scale = weight * scale_bias[0];
+        const float bias = weight * scale_bias[1];
+
+        for (int j = 0; j < block_size; ++j) {
+          uint8_t quantized =
+              input_data[idx * data.size(1) + j / NUM_ELEM_PER_BYTE];
+          quantized >>= (j % NUM_ELEM_PER_BYTE) * BIT_RATE;
+          quantized &= (1 << BIT_RATE) - 1;
+
+          output_data[j] = std::fma(scale, quantized, output_data[j] + bias);
+        }
+      } // for each i
+      if (is_mean && lengths_data[m]) {
+        float scale = 1.0f / lengths_data[m];
+        for (int j = 0; j < block_size; ++j) {
+          output_data[j] *= scale;
+        }
+      }
+      output_data += block_size;
+    } // for each m
+
+    return current == index_size;
+#endif // USE_FBGEMM
+  }
+
+  enum {
+    DATA = 0,
+    WEIGHTS = 1,
+    INDICES = 1 + with_weights,
+    LENGTHS = 2 + with_weights,
+  };
+
+#ifdef USE_FBGEMM
+ private:
+  std::int64_t last_block_size{-1};
+  fbgemm::EmbeddingSpMDMKernelSignature<std::uint8_t, std::int32_t>::Type
+      kernel32_;
+  fbgemm::EmbeddingSpMDMKernelSignature<std::uint8_t, std::int64_t>::Type
+      kernel64_;
+#endif
+}; // class SparseLengthsFusedNBitRowwiseOp
+
+template <int BIT_RATE, bool with_weights = false, bool is_mean = false>
+class SparseLengthsNBitRowwiseSparseOp final : public Operator<CPUContext> {
+ public:
+  static_assert(
+      !(with_weights && is_mean),
+      "Cannot have with_weights and is_mean a the same time");
+
+  SparseLengthsNBitRowwiseSparseOp(const OperatorDef& def, Workspace* ws)
+      : Operator<CPUContext>(def, ws) {}
+  ~SparseLengthsNBitRowwiseSparseOp() override {}
+
+  bool RunOnDevice() override {
+    return DispatchHelper<TensorTypes<int32_t, int64_t>>::call(
+        this, Input(INDICES));
+  }
+
+  template <typename IndexType>
+  bool DoRunWithType() {
+    const auto& data = Input(DATA);
+    const auto& indices = Input(INDICES);
+    const auto& lengths = Input(LENGTHS);
+    const auto& compressed_indices_mapping = Input(COMPRESSED_INDICES_MAPPING);
+    CAFFE_ENFORCE_EQ(indices.dim(), 1, "INDICES must be a vector");
+    CAFFE_ENFORCE_EQ(lengths.dim(), 1, "LENGTHS must be a vector");
+
+    const float* weights = nullptr;
+    if (with_weights) {
+      const auto& weights_input = Input(WEIGHTS);
+      CAFFE_ENFORCE_EQ(weights_input.dim(), 1, "WEIGHTS must be a vector");
+      CAFFE_ENFORCE_EQ(
+          weights_input.numel(),
+          indices.numel(),
+          "WEIGHTS should have the same length as INDICES.");
+      weights = weights_input.template data<float>();
+    }
+
+    CAFFE_ENFORCE_GT(
+        data.size(1),
+        sizeof(at::Half) + sizeof(at::Half),
+        "DATA must have more than 4 columns");
+    static_assert(8 % BIT_RATE == 0, "BIT_RATE must divide 8");
+    constexpr int NUM_ELEM_PER_BYTE = 8 / BIT_RATE;
+    // Subtract 4 (or 8 for BIT_RATE == 8) from the #columns of data for the
+    // fp16 (or fp32 for BIT_RATE == 8) scale and bias that we use in the fused
+    // representation (per row).
+    const std::vector<int64_t> shape = {
+        lengths.size(0),
+        static_cast<int64_t>(
+            data.size(1) -
+            2 * (BIT_RATE == 8 ? sizeof(float) : sizeof(at::Half))) *
+            NUM_ELEM_PER_BYTE};
+    auto* output = Output(0, shape, at::dtype<float>());
+
+    int output_size = output->size(0);
+    int block_size = output->size(1);
+    CAFFE_ENFORCE_EQ(
+        block_size % NUM_ELEM_PER_BYTE,
+        0,
+        "block size must be divisible by " + std::to_string(NUM_ELEM_PER_BYTE));
+    auto data_size = data.size(0);
+    int index_size = indices.numel();
+    const uint8_t* input_data = data.template data<uint8_t>();
+    const IndexType* indices_data = indices.template data<IndexType>();
+    const int* lengths_data = lengths.template data<int>();
+    float* output_data = output->template mutable_data<float>();
+    const std::int32_t* compressed_indices_mapping_data =
+        compressed_indices_mapping.template data<std::int32_t>();
+
+    // if compressed_indices_mapping is [0], it is a indicator that
+    // we should fallback to normal SLS, which is also a valid fallback if
+    // the LUT is pruned.
+    const bool fallback_to_no_sparse =
+        (compressed_indices_mapping.numel() == 1 &&
+         compressed_indices_mapping_data[0] == 0);
+
+#ifdef USE_FBGEMM
+    // If this is the first call or block size has changed (should never happen
+    // actually), generate a kernel.
+    if (block_size != last_block_size) {
+      if (!fallback_to_no_sparse) {
+        last_block_size = block_size;
+        if (std::is_same<IndexType, std::int32_t>::value) {
+          if (BIT_RATE == 8) {
+            kernel32_ = fbgemm::
+                GenerateEmbeddingSpMDMRowWiseSparse<std::uint8_t, std::int32_t>(
+                    block_size,
+                    weights != nullptr,
+                    is_mean,
+                    /*prefetch distance*/ 16);
+          } else {
+            kernel32_ =
+                fbgemm::GenerateEmbeddingSpMDMNBitRowWiseSparse<std::int32_t>(
+                    BIT_RATE,
+                    block_size,
+                    weights != nullptr,
+                    is_mean,
+                    /*prefetch distance*/ 16);
+          }
+        } else {
+          CAFFE_ENFORCE((std::is_same<IndexType, std::int64_t>::value));
+          if (BIT_RATE == 8) {
+            kernel64_ = fbgemm::
+                GenerateEmbeddingSpMDMRowWiseSparse<std::uint8_t, std::int64_t>(
+                    block_size,
+                    weights != nullptr,
+                    is_mean,
+                    /*prefetch distance*/ 16);
+          } else {
+            kernel64_ =
+                fbgemm::GenerateEmbeddingSpMDMNBitRowWiseSparse<std::int64_t>(
+                    BIT_RATE,
+                    block_size,
+                    weights != nullptr,
+                    is_mean,
+                    /*prefetch distance*/ 16);
+          }
+        }
+      } else { // fallback_to_no_sparse == true
+        last_block_size = block_size;
+        if (std::is_same<IndexType, std::int32_t>::value) {
+          if (BIT_RATE == 8) {
+            kernel32_no_sparse_ =
+                fbgemm::GenerateEmbeddingSpMDM<std::uint8_t, std::int32_t>(
+                    block_size,
+                    with_weights,
+                    is_mean,
+                    /*prefetch distance*/ 16);
+          } else {
+            kernel32_no_sparse_ =
+                fbgemm::GenerateEmbeddingSpMDMNBit<std::int32_t>(
+                    BIT_RATE,
+                    block_size,
+                    weights != nullptr,
+                    is_mean,
+                    /*prefetch distance*/ 16);
+          }
+        } else {
+          CAFFE_ENFORCE((std::is_same<IndexType, std::int64_t>::value));
+          if (BIT_RATE == 8) {
+            kernel64_no_sparse_ =
+                fbgemm::GenerateEmbeddingSpMDM<std::uint8_t, std::int64_t>(
+                    block_size,
+                    with_weights,
+                    is_mean,
+                    /*prefetch distance*/ 16);
+          } else {
+            kernel64_no_sparse_ =
+                fbgemm::GenerateEmbeddingSpMDMNBit<std::int64_t>(
+                    BIT_RATE,
+                    block_size,
+                    weights != nullptr,
+                    is_mean,
+                    /*prefetch distance*/ 16);
+          }
+        }
+      }
+    } // end if (block_size != last_block_size)
+
+    bool success;
+    if (!fallback_to_no_sparse) {
+      if (std::is_same<IndexType, std::int32_t>::value) {
+        success = kernel32_(
+            output_size,
+            index_size,
+            compressed_indices_mapping.size(),
+            input_data,
+            reinterpret_cast<const std::int32_t*>(indices_data),
+            lengths_data,
+            weights,
+            output_data,
+            compressed_indices_mapping_data);
+      } else {
+        success = kernel64_(
+            output_size,
+            index_size,
+            compressed_indices_mapping.size(),
+            input_data,
+            reinterpret_cast<const std::int64_t*>(indices_data),
+            lengths_data,
+            weights,
+            output_data,
+            compressed_indices_mapping_data);
+      }
+    } else { // fallback_to_no_sparse == true
+      if (std::is_same<IndexType, std::int32_t>::value) {
+        success = kernel32_no_sparse_(
+            output_size,
+            index_size,
+            data_size,
+            input_data,
+            reinterpret_cast<const std::int32_t*>(indices_data),
+            lengths_data,
+            weights,
+            output_data);
+      } else {
+        success = kernel64_no_sparse_(
+            output_size,
+            index_size,
+            data_size,
+            input_data,
+            reinterpret_cast<const std::int64_t*>(indices_data),
+            lengths_data,
+            weights,
+            output_data);
+      }
+    }
+
+    if (success) {
+      return true;
+    }
+
+    // Error handling
+    int64_t current = 0;
+    for (int m = 0; m < output_size; ++m) {
+      for (int i = 0; i < lengths_data[m]; ++i) {
+        CAFFE_ENFORCE_LT(current, index_size);
+        IndexType idx = indices_data[current];
+        if (!fallback_to_no_sparse) {
+          CAFFE_ENFORCE(
+              0 <= idx && idx < compressed_indices_mapping.size(),
+              "Index ",
+              current,
+              " is out of bounds: ",
+              idx,
+              ", range 0 to ",
+              compressed_indices_mapping.size());
+        } else {
+          CAFFE_ENFORCE(
+              0 <= idx && idx < data_size,
+              "Index ",
+              current,
+              " is out of bounds: ",
+              idx,
+              ", range 0 to ",
+              data_size);
+        }
+        ++current;
+      }
+    }
+    CAFFE_ENFORCE_EQ(
+        current,
+        index_size,
+        "Your input seems to be incorrect: the sum of lengths values should be "
+        "the size of the indices tensor, but it appears not.");
+
+    return false;
+#else
+    C10_LOG_EVERY_N(WARNING, 10)
+        << "Running slow path because FBGEMM is not available";
+
+    int64_t current = 0;
+    for (int m = 0; m < output_size; ++m) {
+      memset(output_data, 0, block_size * sizeof(float));
+      if (current + lengths_data[m] > index_size) {
+        return false;
+      }
+      for (int i = 0; i < lengths_data[m]; ++i, ++current) {
+        IndexType idx;
+        if (fallback_to_no_sparse) {
+          idx = indices_data[current];
+          if (idx < 0 || idx >= data_size) {
+            return false;
+          }
+        } else {
+          IndexType uncompressed_idx = indices_data[current];
+          if (uncompressed_idx < 0 ||
+              uncompressed_idx >= compressed_indices_mapping.size()) {
+            return false;
+          }
+          idx = compressed_indices_mapping_data[uncompressed_idx];
+          if (idx == -1) {
+            continue;
+          }
+        }
+
+        const uint8_t* scale_bias = input_data + (idx + 1) * data.size(1) -
+            2 * (BIT_RATE == 8 ? sizeof(float) : sizeof(at::Half));
+
+        float weight = 1.0f;
+        if (with_weights) {
+          weight = weights[current];
+        }
+        float scale, bias;
+        if (BIT_RATE == 8) {
+          scale = weight * reinterpret_cast<const float*>(scale_bias)[0];
+          bias = weight * reinterpret_cast<const float*>(scale_bias)[1];
+        } else {
+          scale = weight * reinterpret_cast<const at::Half*>(scale_bias)[0];
+          bias = weight * reinterpret_cast<const at::Half*>(scale_bias)[1];
+        }
+
+        for (int j = 0; j < block_size; ++j) {
+          uint8_t quantized =
+              input_data[idx * data.size(1) + j / NUM_ELEM_PER_BYTE];
+          quantized >>= (j % NUM_ELEM_PER_BYTE) * BIT_RATE;
+          quantized &= (1 << BIT_RATE) - 1;
+
+          output_data[j] = std::fma(scale, quantized, output_data[j] + bias);
+        }
+      } // for each i
+      if (is_mean && lengths_data[m]) {
+        float scale = 1.0f / lengths_data[m];
+        for (int j = 0; j < block_size; ++j) {
+          output_data[j] *= scale;
+        }
+      }
+      output_data += block_size;
+    } // for each m
+
+    return current == index_size;
+#endif // USE_FBGEMM
+  }
+
+  enum {
+    DATA = 0,
+    WEIGHTS = 1,
+    INDICES = 1 + with_weights,
+    LENGTHS = 2 + with_weights,
+    COMPRESSED_INDICES_MAPPING = 3 + with_weights,
+  };
+
+#ifdef USE_FBGEMM
+ private:
+  std::int64_t last_block_size{-1};
+  fbgemm::EmbeddingSpMDMRowWiseSparseKernelSignature<
+      std::uint8_t,
+      std::int32_t>::Type kernel32_;
+  fbgemm::EmbeddingSpMDMRowWiseSparseKernelSignature<
+      std::uint8_t,
+      std::int64_t>::Type kernel64_;
+  fbgemm::EmbeddingSpMDMKernelSignature<std::uint8_t, std::int32_t>::Type
+      kernel32_no_sparse_;
+  fbgemm::EmbeddingSpMDMKernelSignature<std::uint8_t, std::int64_t>::Type
+      kernel64_no_sparse_;
+#endif
+}; // class SparseLengthsNBitRowwiseSparseOp
+
+} // namespace caffe2
+
+#endif // CAFFE2_OPERATORS_LENGTHS_REDUCER_FUSED_8BIT_ROWWISE_OPS_H_

--- a/caffe2/python/benchmarks/fused_rowwise_nbit_conversion_bench.py
+++ b/caffe2/python/benchmarks/fused_rowwise_nbit_conversion_bench.py
@@ -1,0 +1,65 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import argparse
+import datetime
+
+import numpy as np
+from caffe2.fb.python.operator_test.fused_nbit_rowwise_test_helper import (
+    _compress_uniform_simplified,
+    param_search_greedy,
+)
+from caffe2.python import core, dyndep, workspace
+
+
+def main(bit_rate):
+    # uncomment for debugging
+    # np.random.seed(0)
+    batchsize = 10 * 1000
+    blocksize = 64
+    print(batchsize, blocksize)
+    input_data = np.random.rand(batchsize, blocksize).astype(np.float32)
+
+    workspace.FeedBlob("input_data", input_data)
+
+    net = core.Net("bench")
+    op = core.CreateOperator(
+        "FloatToFused" + str(bit_rate) + "BitRowwiseQuantized",
+        "input_data",
+        "quantized_data",
+        engine="GREEDY",
+    )
+    net.Proto().op.extend([op])
+    workspace.GlobalInit(["caffe2", "--caffe2_log_level=0"])
+    workspace.CreateNet(net)
+    iterations = 10
+    workspace.BenchmarkNet(net.Proto().name, 1, iterations, True)
+
+    net2 = core.Net("bench2")
+    op = core.CreateOperator(
+        "FloatToFused" + str(bit_rate) + "BitRowwiseQuantized",
+        "input_data",
+        "quantized_data",
+    )
+    net2.Proto().op.extend([op])
+
+    workspace.CreateNet(net2)
+    workspace.BenchmarkNet(net2.Proto().name, 1, iterations, True)
+
+    start = datetime.datetime.now()
+    for n in range(10):
+        for i in range(input_data.shape[0]):
+            xmin, xmax = param_search_greedy(
+                input_data[i, :], 4, n_bins=200, ratio=0.16
+            )
+            X_q_ref = _compress_uniform_simplified(input_data[i, :], 4, xmin, xmax)
+    end = datetime.datetime.now()
+    print((end - start).total_seconds())
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="benchmark for row-wise 2/4-bit quantization."
+    )
+    parser.add_argument("--bit-rate", type=int, default=4)
+    args = parser.parse_args()
+    main(args.bit_rate)

--- a/caffe2/python/benchmarks/sparse_lengths_sum_nbit_benchmark.py
+++ b/caffe2/python/benchmarks/sparse_lengths_sum_nbit_benchmark.py
@@ -1,0 +1,117 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import argparse
+import datetime
+
+import hypothesis.strategies as st
+import numpy as np
+from caffe2.python import core, dyndep, workspace
+
+
+def benchmark_sparse_lengths_sum(
+    categorical_limit,
+    embedding_size,
+    average_len,
+    batch_size,
+    iterations,
+    flush_cache,
+    bit_rate=st.sampled_from([2, 4]),
+):
+    print("Preparing lookup table. " + str(datetime.datetime.now()))
+
+    # We will use a constant, but non-trivial value so we save initialization
+    # time.
+    data = np.ones([categorical_limit, embedding_size], dtype=np.float32)
+    data *= 17.01
+
+    init_net = core.Net("init_net")
+    op = core.CreateOperator(
+        "FloatToFused" + str(bit_rate) + "BitRowwiseQuantized", "X", "X_q"
+    )
+    init_net.Proto().op.extend([op])
+    workspace.FeedBlob("X", data)
+
+    print("Data has shape {} {}".format(data.shape, datetime.datetime.now()))
+
+    # In order to produce truly random lengths and indices, we will embed a
+    # Python operator in the net to generate them.
+    def f(_, outputs):
+        lengths = np.random.randint(
+            int(average_len * 0.75), int(average_len * 1.25), batch_size
+        ).astype(np.int32)
+        indices = np.random.randint(0, categorical_limit, np.sum(lengths)).astype(
+            np.int64
+        )
+        outputs[0].feed(indices)
+        outputs[1].feed(lengths)
+
+    init_net.Python(f)([], ["indices", "lengths"])
+    workspace.RunNetOnce(init_net)
+
+    net = core.Net("mynet")
+    if flush_cache:
+        l3_cache_size = 30 * 2 ** 20 // 4
+        workspace.FeedBlob(
+            "huge_blob", np.random.randn(l3_cache_size).astype(np.float32)
+        )
+        net.Scale("huge_blob", "huge_blob_2x", value=2.0)
+    op = core.CreateOperator(
+        "SparseLengthsSumFused" + str(bit_rate) + "BitRowwise",
+        ["X_q", "indices", "lengths"],
+        "Y",
+    )
+    net.Proto().op.extend([op])
+    workspace.CreateNet(net)
+
+    # Set random seed, so that repeated runs will keep the same sequence of
+    # random indices.
+    np.random.seed(1701)
+
+    print("Preparation finished. " + str(datetime.datetime.now()))
+
+    runtimes = workspace.BenchmarkNet(net.Name(), 1, iterations, True)
+    print(
+        "{} billion sums per sec".format(
+            embedding_size
+            * workspace.FetchBlob("indices").size
+            / runtimes[2 if flush_cache else 1]
+            / 1e6
+        )
+    )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="minimal benchmark for sparse lengths sum."
+    )
+    parser.add_argument(
+        "-e", "--embedding-size", type=int, default=6000000, help="Lookup table size."
+    )
+    parser.add_argument(
+        "--embedding-dim", type=int, default=128, help="Embedding dimension."
+    )
+    parser.add_argument(
+        "--average_len",
+        type=int,
+        default=27,
+        help="Sparse feature average lengths, default is 27",
+    )
+    parser.add_argument("--batch_size", type=int, default=100, help="The batch size.")
+    parser.add_argument(
+        "-i", "--iteration", type=int, default=100000, help="The number of iterations."
+    )
+    parser.add_argument(
+        "--flush-cache", action="store_true", help="If true, flush cache"
+    )
+    parser.add_argument("--bit-rate", type=int, default=4)
+    args, extra_args = parser.parse_known_args()
+    core.GlobalInit(["python"] + extra_args)
+    benchmark_sparse_lengths_sum(
+        args.embedding_size,
+        args.embedding_dim,
+        args.average_len,
+        args.batch_size,
+        args.iteration,
+        args.flush_cache,
+        args.bit_rate,
+    )

--- a/caffe2/python/operator_test/fused_nbit_rowwise_conversion_ops_test.py
+++ b/caffe2/python/operator_test/fused_nbit_rowwise_conversion_ops_test.py
@@ -1,0 +1,340 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import struct
+
+import caffe2.python.hypothesis_test_util as hu
+import hypothesis.strategies as st
+import numpy as np
+from caffe2.python.operator_test.fused_nbit_rowwise_test_helper import (
+    _compress_uniform_simplified,
+    param_search_greedy,
+)
+from caffe2.python import core, dyndep, workspace
+from hypothesis import assume, given
+
+
+# Eigen/Python round 0.5 away from 0, Numpy rounds to even
+round_to_nearest = np.vectorize(round)
+
+
+def bytes_to_half_floats(byte_matrix):
+    floats = np.empty([np.shape(byte_matrix)[0], 1], dtype=np.float16)
+    for i, byte_values in enumerate(byte_matrix):
+        floats[i], = np.frombuffer(memoryview(byte_values).tobytes(), dtype=np.float16)
+    return floats
+
+
+def half_floats_to_bytes(floats):
+    byte_matrix = np.empty([np.shape(floats)[0], 2], dtype=np.uint8)
+    for i, value in enumerate(floats):
+        assert isinstance(value, np.float16), (value, floats)
+        byte_matrix[i] = np.frombuffer(
+            memoryview(np.array([value])).tobytes(), dtype=np.uint8
+        )
+    return byte_matrix
+
+
+def int8_to_bytes(int8s):
+    byte_matrix = np.empty([np.shape(int8s)[0], 1], dtype=np.uint8)
+    for i, value in enumerate(int8s):
+        assert isinstance(value, np.int8), (value, int8s)
+        as_bytes = struct.pack("b", value)
+        # In Python3 bytes will be a list of int, in Python2 a list of string
+        if isinstance(as_bytes[0], int):
+            byte_matrix[i] = list(as_bytes)
+        else:
+            byte_matrix[i] = list(map(ord, as_bytes))
+    return byte_matrix
+
+
+def fused_rowwise_nbit_quantize_reference(data, bit):
+    minimum = np.min(data, axis=1).astype(np.float16).astype(np.float32)
+    maximum = np.max(data, axis=1)
+    span = maximum - minimum
+    qmax = (1 << bit) - 1
+    scale = (span / qmax).astype(np.float16).astype(np.float32)
+    bias = np.zeros(data.shape[0])
+    quantized_data = np.zeros(data.shape).astype(np.uint8)
+
+    for i in range(data.shape[0]):
+        bias[i] = minimum[i]
+        if scale[i] == 0.0:
+            scale[i] = 1.0
+        quantized_data[i] = np.clip(
+            np.round((data[i, :] - minimum[i]) / scale[i]), 0, qmax
+        )
+
+    # pack
+    assert 8 % bit == 0
+    num_elem_per_byte = 8 // bit
+    packed_dim = (data.shape[1] + num_elem_per_byte - 1) // num_elem_per_byte
+    packed_data = np.zeros([data.shape[0], packed_dim]).astype(np.uint8)
+    for i in range(data.shape[0]):
+        for j in range(data.shape[1]):
+            if j % num_elem_per_byte == 0:
+                packed_data[i, j // num_elem_per_byte] = quantized_data[i, j]
+            else:
+                packed_data[i, j // num_elem_per_byte] += quantized_data[i, j] << (
+                    (j % num_elem_per_byte) * bit
+                )
+
+    scale_bytes = half_floats_to_bytes(scale.astype(np.float16))
+    bias_bytes = half_floats_to_bytes(bias.astype(np.float16))
+    return np.concatenate([packed_data, scale_bytes, bias_bytes], axis=1)
+
+
+def fused_rowwise_nbit_quantize_dequantize_reference(data, bit):
+    fused_quantized = fused_rowwise_nbit_quantize_reference(data, bit)
+    scale = bytes_to_half_floats(fused_quantized[:, -4:-2].astype(np.uint8)).astype(
+        np.float32
+    )
+    bias = bytes_to_half_floats(fused_quantized[:, -2:].astype(np.uint8)).astype(
+        np.float32
+    )
+    quantized_data = fused_quantized[:, :-4]
+
+    # unpack
+    packed_dim = fused_quantized.shape[1] - 4
+    assert 8 % bit == 0
+    num_elem_per_byte = 8 // bit
+    assert packed_dim == ((data.shape[1] + num_elem_per_byte - 1) // num_elem_per_byte)
+    unpacked_data = np.zeros(data.shape).astype(np.uint8)
+    for i in range(data.shape[0]):
+        for j in range(data.shape[1]):
+            unpacked_data[i, j] = (
+                quantized_data[i, j // num_elem_per_byte]
+                >> ((j % num_elem_per_byte) * bit)
+            ) & ((1 << bit) - 1)
+
+    return scale * unpacked_data + bias
+
+
+class TestFusedNBitRowwiseQuantizationConversion(hu.HypothesisTestCase):
+    @given(input_data=hu.tensor(min_dim=2, max_dim=2), bit_rate=st.sampled_from([2, 4]))
+    def test_quantize_op(self, input_data, bit_rate):
+        assert 8 % bit_rate == 0
+        num_elem_per_byte = 8 // bit_rate
+        assume(input_data.shape[1] % num_elem_per_byte == 0)
+        quantize = core.CreateOperator(
+            "FloatToFused" + str(bit_rate) + "BitRowwiseQuantized",
+            ["input_data"],
+            ["quantized_data"],
+        )
+        workspace.FeedBlob("input_data", input_data)
+        workspace.RunOperatorOnce(quantize)
+
+        quantized_data = workspace.FetchBlob("quantized_data")
+
+        reference = fused_rowwise_nbit_quantize_reference(
+            input_data.astype(np.float32), bit_rate
+        )
+
+        interleaved_dim = input_data.shape[1] // num_elem_per_byte
+        # compare quantized data
+        np.testing.assert_array_equal(
+            quantized_data[:, :interleaved_dim], reference[:, :interleaved_dim]
+        )
+        # compare scales
+        np.testing.assert_array_almost_equal(
+            bytes_to_half_floats(
+                quantized_data[:, interleaved_dim : interleaved_dim + 2]
+            ),
+            bytes_to_half_floats(reference[:, interleaved_dim : interleaved_dim + 2]),
+        )
+        # compare zero points
+        np.testing.assert_array_equal(
+            quantized_data[:, interleaved_dim + 2], reference[:, interleaved_dim + 2]
+        )
+
+    @given(input_data=hu.tensor(min_dim=2, max_dim=2), bit_rate=st.sampled_from([2, 4]))
+    def test_quantize_and_dequantize_op(self, input_data, bit_rate):
+        assert 8 % bit_rate == 0
+        num_elem_per_byte = 8 // bit_rate
+        assume(input_data.shape[1] % num_elem_per_byte == 0)
+        quantize = core.CreateOperator(
+            "FloatToFused" + str(bit_rate) + "BitRowwiseQuantized",
+            ["input_data"],
+            ["quantized_data"],
+        )
+        workspace.FeedBlob("input_data", input_data)
+        workspace.RunOperatorOnce(quantize)
+
+        quantized_data = workspace.FetchBlob("quantized_data")
+
+        dequantize = core.CreateOperator(
+            "Fused" + str(bit_rate) + "BitRowwiseQuantizedToFloat",
+            ["quantized_data"],
+            ["dequantized_data"],
+        )
+        workspace.FeedBlob("quantized_data", quantized_data)
+        workspace.RunOperatorOnce(dequantize)
+
+        dequantized_data = workspace.FetchBlob("dequantized_data")
+
+        reference = fused_rowwise_nbit_quantize_dequantize_reference(
+            input_data, bit_rate
+        )
+        np.testing.assert_array_almost_equal(dequantized_data, reference)
+
+
+def ErrorThresholdRow(X, bit_rate):
+    # minimum representable error in bit_rate per row
+    min_elem = np.min(X, axis=1)
+    max_elem = np.max(X, axis=1)
+
+    bias = np.float16(min_elem)
+    scale = np.float16((max_elem - bias) / ((1 << bit_rate) - 1))
+
+    max_round_error = scale / 2
+    max_clip_error = np.maximum(np.abs(min_elem - bias), np.abs(scale * ((1 << bit_rate) - 1) + bias - max_elem))
+    thres = np.maximum(max_round_error, max_clip_error) * 1.1
+    return thres
+
+
+class TestNBitFakeFused(hu.HypothesisTestCase):
+    @given(bit_rate=st.sampled_from([2, 4]))
+    def testNBit(self, bit_rate):
+        # uncomment for debugging
+        # np.random.seed(0)
+        net = core.Net("bench")
+        batchsize = np.random.randint(2, 1000)
+        blocksize = np.random.randint(2, 1000)
+        input_data = np.random.rand(batchsize, blocksize).astype(np.float32)
+        op = core.CreateOperator(
+            "FloatToFused" + str(bit_rate) + "BitFakeRowwiseQuantized",
+            "input_data",
+            "minmax_quantized_data",
+        )
+        net.Proto().op.extend([op])
+        net.Fused8BitRowwiseQuantizedToFloat(
+            "minmax_quantized_data", "minmax_dequantized_data"
+        )
+        op = core.CreateOperator(
+            "FloatToFused" + str(bit_rate) + "BitFakeRowwiseQuantized",
+            "input_data",
+            "greedy_quantized_data",
+            engine="GREEDY",
+        )
+        net.Proto().op.extend([op])
+        net.Fused8BitRowwiseQuantizedToFloat(
+            "greedy_quantized_data", "greedy_dequantized_data"
+        )
+        workspace.FeedBlob("input_data", input_data)
+
+        workspace.GlobalInit(["caffe2", "--caffe2_log_level=0"])
+        workspace.RunNetOnce(net)
+
+        minmax_dequantized_data = workspace.FetchBlob("minmax_dequantized_data")
+        greedy_dequantized_data = workspace.FetchBlob("greedy_dequantized_data")
+
+        err_thres = ErrorThresholdRow(input_data, bit_rate)
+        diff_minmax = np.abs(input_data - minmax_dequantized_data)
+        diff_greedy = np.abs(input_data - greedy_dequantized_data)
+        for i in range(err_thres.size):
+            # Check error from minmax quantization is within the bound derived from the range
+            assert (
+                np.sum(diff_minmax[i, :] > err_thres[i]) == 0
+            ), "error at row {} too high (diff_minmax[i, :] {} diff_minmax[i, :] > err_thres[i] {} err_thres[i] {}".format(
+                i, diff_minmax[i, :], diff_minmax[i, :] > err_thres[i], err_thres[i],
+            )
+
+            # Check error from greedy quantization is smaller than minmax quantization
+            # Multiply by a margin 1.03 to consider inexactness of
+            # floating-point operations and from binning (in exact math,
+            # l2_greedy should be no less than l2_minmax).
+            l2_minmax_err = np.linalg.norm(diff_minmax[i, :])
+            l2_greedy_err = np.linalg.norm(diff_greedy[i, :])
+            assert (
+                l2_greedy_err <= l2_minmax_err * 1.03
+            ), "L2 quantization error using greedy algorithm {} at row {} is bigger than error using minmax {} (input_data[i,:] {} minmax_dequantized_data[i,:] {} greedy_dequantized_data[i,:] {}".format(  # noqa
+                l2_greedy_err,
+                i,
+                l2_minmax_err,
+                input_data[i, :],
+                minmax_dequantized_data[i, :],
+                greedy_dequantized_data[i, :],
+            )
+
+
+class TestNBitGreedyFused(hu.HypothesisTestCase):
+    @given(bit_rate=st.sampled_from([2, 4]))
+    def testNBit(self, bit_rate):
+        # uncomment for debugging
+        # np.random.seed(0)
+        net = core.Net("bench")
+        batchsize = np.random.randint(2, 1000)
+        assert 8 % bit_rate == 0
+        num_elem_per_byte = 8 // bit_rate
+        blocksize = np.random.randint(2, 500) * num_elem_per_byte
+        input_data = np.random.rand(batchsize, blocksize).astype(np.float32)
+
+        op = core.CreateOperator(
+            "FloatToFused" + str(bit_rate) + "BitRowwiseQuantized",
+            "input_data",
+            "minmax_quantized_data",
+        )
+        net.Proto().op.extend([op])
+        op = core.CreateOperator(
+            "Fused" + str(bit_rate) + "BitRowwiseQuantizedToFloat",
+            "minmax_quantized_data",
+            "minmax_dequantized_data",
+        )
+        net.Proto().op.extend([op])
+        op = core.CreateOperator(
+            "FloatToFused" + str(bit_rate) + "BitRowwiseQuantized",
+            "input_data",
+            "greedy_quantized_data",
+            engine="GREEDY",
+        )
+        net.Proto().op.extend([op])
+        op = core.CreateOperator(
+            "Fused" + str(bit_rate) + "BitRowwiseQuantizedToFloat",
+            "greedy_quantized_data",
+            "greedy_dequantized_data",
+        )
+        net.Proto().op.extend([op])
+        workspace.FeedBlob("input_data", input_data)
+
+        workspace.GlobalInit(["caffe2", "--caffe2_log_level=0"])
+        workspace.RunNetOnce(net)
+
+        minmax_dequantized_data = workspace.FetchBlob("minmax_dequantized_data")
+        greedy_dequantized_data = workspace.FetchBlob("greedy_dequantized_data")
+
+        diff_minmax = np.abs(input_data - minmax_dequantized_data)
+        l2_minmax = np.linalg.norm(input_data - minmax_dequantized_data, axis=1)
+        diff_greedy = np.abs(input_data - greedy_dequantized_data)
+        l2_greedy = np.linalg.norm(input_data - greedy_dequantized_data, axis=1)
+
+        for i in range(input_data.shape[0]):
+            # Compare with Python reference greedy search implementation
+            xmin, xmax = param_search_greedy(
+                input_data[i, :], bit_rate, n_bins=200, ratio=0.16
+            )
+            X_q_ref, l2_greedy_ref = _compress_uniform_simplified(
+                input_data[i, :], bit_rate, xmin, xmax, fp16_scale_bias=True
+            )
+            l2_discrepancy = np.abs(l2_greedy[i] - l2_greedy_ref) / input_data.shape[1]
+            # C++ implementation has a different accumulation order when
+            # computing norm in compress_uniform_simplified_ so we shouldn't
+            # use too small tolerance.
+            assert (
+                l2_discrepancy < 1e-5
+            ), "l2_discrepancy between C++ and Python greedy algorithm {} at row {} is too high (actual l2 err {} ref l2 err {} actual {} ref {})".format(  # noqa
+                l2_discrepancy,
+                i,
+                l2_greedy[i],
+                l2_greedy_ref,
+                greedy_dequantized_data[i, :],
+                X_q_ref,
+            )
+
+            # Check error from greedy quantization is smaller than minmax quantization
+            # Multiply by a margin 1.03 to consider inexactness of
+            # floating-point operations and from binning (in exact math,
+            # l2_greedy should be no less than l2_minmax).
+            assert (
+                l2_greedy[i] <= l2_minmax[i] * 1.03
+            ), "L2 quantization error using greedy algorithm {} at row {} is bigger than error using minmax {}".format(
+                l2_greedy[i], i, l2_minmax[i]
+            )

--- a/caffe2/python/operator_test/fused_nbit_rowwise_test.cc
+++ b/caffe2/python/operator_test/fused_nbit_rowwise_test.cc
@@ -1,0 +1,110 @@
+#include "caffe2/core/logging.h"
+#include "caffe2/core/operator.h"
+#include "caffe2/core/operator_schema.h"
+#include "caffe2/utils/proto_utils.h"
+
+#include <gtest/gtest.h>
+
+namespace caffe2 {
+
+TEST(OperatorSchemaTest, TensorInferenceNbit) {
+  for (int bit_rate : {2, 4}) {
+    const OpSchema* schema = OpSchemaRegistry::Schema(
+        "FloatToFused" + std::to_string(bit_rate) + "BitRowwiseQuantized");
+    EXPECT_TRUE(schema != nullptr);
+
+    OperatorDef def = CreateOperatorDef(
+        "FloatToFused" + std::to_string(bit_rate) + "BitRowwiseQuantized",
+        "",
+        vector<string>{"in"},
+        vector<string>{"out"});
+    vector<TensorShape> in_shapes(1);
+    in_shapes[0].set_data_type(TensorProto::FLOAT);
+    in_shapes[0].add_dims(20000);
+    in_shapes[0].add_dims(64);
+
+    vector<TensorShape> out = schema->InferTensor(def, in_shapes);
+    EXPECT_EQ(out.size(), 1);
+    EXPECT_EQ(out[0].data_type(), TensorProto::UINT8);
+    EXPECT_EQ(out[0].dims_size(), 2);
+    EXPECT_EQ(out[0].dims(0), 20000);
+    EXPECT_EQ(out[0].dims(1), 64 / (8 / bit_rate) + 4);
+  }
+}
+
+TEST(OperatorSchemaTest, TensorInferenceNbitHalf) {
+  for (int bit_rate : {2, 4}) {
+    const OpSchema* schema = OpSchemaRegistry::Schema(
+        "HalfToFused" + std::to_string(bit_rate) + "BitRowwiseQuantized");
+    EXPECT_TRUE(schema != nullptr);
+
+    OperatorDef def = CreateOperatorDef(
+        "HalfToFused" + std::to_string(bit_rate) + "BitRowwiseQuantized",
+        "",
+        vector<string>{"in"},
+        vector<string>{"out"});
+    vector<TensorShape> in_shapes(1);
+    in_shapes[0].set_data_type(TensorProto::FLOAT16);
+    in_shapes[0].add_dims(20000);
+    in_shapes[0].add_dims(64);
+
+    vector<TensorShape> out = schema->InferTensor(def, in_shapes);
+    EXPECT_EQ(out.size(), 1);
+    EXPECT_EQ(out[0].data_type(), TensorProto::UINT8);
+    EXPECT_EQ(out[0].dims_size(), 2);
+    EXPECT_EQ(out[0].dims(0), 20000);
+    EXPECT_EQ(out[0].dims(1), 64 / (8 / bit_rate) + 4);
+  }
+}
+
+TEST(OperatorSchemaTest, TensorInferenceNbitBack) {
+  for (int bit_rate : {2, 4}) {
+    const OpSchema* schema = OpSchemaRegistry::Schema(
+        "Fused" + std::to_string(bit_rate) + "BitRowwiseQuantizedToFloat");
+    EXPECT_TRUE(schema != nullptr);
+
+    OperatorDef def = CreateOperatorDef(
+        "Fused" + std::to_string(bit_rate) + "BitRowwiseQuantizedToFloat",
+        "",
+        vector<string>{"in"},
+        vector<string>{"out"});
+    vector<TensorShape> in_shapes(1);
+    in_shapes[0].set_data_type(TensorProto::UINT8);
+    in_shapes[0].add_dims(20000);
+    in_shapes[0].add_dims(36);
+
+    vector<TensorShape> out = schema->InferTensor(def, in_shapes);
+    EXPECT_EQ(out.size(), 1);
+    EXPECT_EQ(out[0].data_type(), TensorProto::FLOAT);
+    EXPECT_EQ(out[0].dims_size(), 2);
+    EXPECT_EQ(out[0].dims(0), 20000);
+    EXPECT_EQ(out[0].dims(1), (36 - 4) * (8 / bit_rate));
+  }
+}
+
+TEST(OperatorSchemaTest, TensorInferenceNbitHalfBack) {
+  for (int bit_rate : {2, 4}) {
+    const OpSchema* schema = OpSchemaRegistry::Schema(
+        "Fused" + std::to_string(bit_rate) + "BitRowwiseQuantizedToHalf");
+    EXPECT_TRUE(schema != nullptr);
+
+    OperatorDef def = CreateOperatorDef(
+        "Fused" + std::to_string(bit_rate) + "BitRowwiseQuantizedToHalf",
+        "",
+        vector<string>{"in"},
+        vector<string>{"out"});
+    vector<TensorShape> in_shapes(1);
+    in_shapes[0].set_data_type(TensorProto::UINT8);
+    in_shapes[0].add_dims(20000);
+    in_shapes[0].add_dims(36);
+
+    vector<TensorShape> out = schema->InferTensor(def, in_shapes);
+    EXPECT_EQ(out.size(), 1);
+    EXPECT_EQ(out[0].data_type(), TensorProto::FLOAT16);
+    EXPECT_EQ(out[0].dims_size(), 2);
+    EXPECT_EQ(out[0].dims(0), 20000);
+    EXPECT_EQ(out[0].dims(1), (36 - 4) * (8 / bit_rate));
+  }
+}
+
+} // namespace caffe2

--- a/caffe2/python/operator_test/fused_nbit_rowwise_test_helper.py
+++ b/caffe2/python/operator_test/fused_nbit_rowwise_test_helper.py
@@ -1,0 +1,73 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import numpy as np
+
+
+# Note we explicitly cast variables to np.float32 in a couple of places to avoid
+# the default casting in Python often resuling in double precision and to make
+# sure we're doing the same numerics as C++ code.
+def param_search_greedy(x, bit_rate, n_bins=200, ratio=0.16):
+    xmin, xmax = np.min(x), np.max(x)
+    stepsize = (xmax - xmin) / np.float32(n_bins)
+    min_bins = np.float32(n_bins) * (np.float32(1) - np.float32(ratio))
+    xq, loss = _compress_uniform_simplified(x, bit_rate, xmin, xmax)
+
+    solutions = []  # [(left, right, loss)] # local optima solution
+
+    cur_min, cur_max, cur_loss = xmin, xmax, loss
+    thr = min_bins * stepsize
+    while cur_min + thr < cur_max:
+        # move left
+        xq, loss1 = _compress_uniform_simplified(
+            x, bit_rate, cur_min + stepsize, cur_max
+        )
+        # move right
+        xq, loss2 = _compress_uniform_simplified(
+            x, bit_rate, cur_min, cur_max - stepsize
+        )
+
+        if cur_loss < loss1 and cur_loss < loss2:
+            # found a local optima
+            solutions.append((cur_min, cur_max, cur_loss))
+        if loss1 < loss2:
+            cur_min, cur_max, cur_loss = cur_min + stepsize, cur_max, loss1
+        else:
+            cur_min, cur_max, cur_loss = cur_min, cur_max - stepsize, loss2
+    if len(solutions):
+        best = solutions[0]
+        for solution in solutions:
+            if solution[-1] < best[-1]:
+                best = solution
+        return best[0], best[1]
+    return xmin, xmax
+
+
+def _compress_uniform_simplified(X, bit_rate, xmin, xmax, fp16_scale_bias=True):
+    # affine transform to put Xq in [0,2**bit_rate - 1]
+    # Xq = (2 ** bit_rate - 1) * (Xq - xmin) / data_range
+    if fp16_scale_bias:
+        xmin = xmin.astype(np.float16).astype(np.float32)
+    data_range = xmax - xmin
+    scale = np.where(
+        data_range == 0, np.float32(1), data_range / np.float32(2 ** bit_rate - 1)
+    )
+    if fp16_scale_bias:
+        scale = scale.astype(np.float16).astype(np.float32)
+    inverse_scale = np.float32(1) / scale
+    Xq = np.clip(np.round((X - xmin) * inverse_scale), 0, np.float32(2 ** bit_rate - 1))
+    Xq = Xq * scale + xmin
+
+    # Manually compute loss instead of using np.linalg.norm to use the same
+    # accumulation order used by C++ code
+    vlen = 8
+    loss_v = np.zeros(vlen).astype(np.float32)
+    for i in range(len(Xq) // vlen * vlen):
+        loss_v[i % vlen] += (X[i] - Xq[i]) * (X[i] - Xq[i])
+    loss = np.float32(0)
+    for i in range(vlen):
+        loss += loss_v[i]
+    for i in range(len(Xq) // vlen * vlen, len(Xq)):
+        loss += (X[i] - Xq[i]) * (X[i] - Xq[i])
+    loss = np.sqrt(loss)
+
+    return Xq, loss

--- a/caffe2/python/operator_test/lengths_reducer_fused_nbit_rowwise_ops_test.py
+++ b/caffe2/python/operator_test/lengths_reducer_fused_nbit_rowwise_ops_test.py
@@ -1,0 +1,381 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import caffe2.python.hypothesis_test_util as hu
+import hypothesis.strategies as st
+import numpy as np
+from caffe2.python import core, dyndep, workspace
+from hypothesis import given
+
+
+class TestLengthsReducerOpsFusedNBitRowwise(hu.HypothesisTestCase):
+    @given(
+        num_rows=st.integers(1, 20),
+        blocksize=st.sampled_from([8, 12, 16, 32, 64, 96, 128]),
+        weighted=st.booleans(),
+        seed=st.integers(0, 2 ** 32 - 1),
+        empty_indices=st.booleans(),
+        engine=st.sampled_from(["", "GREEDY"]),
+        bit_rate=st.sampled_from([2, 4]),
+    )
+    def test_sparse_lengths_sum(
+        self, num_rows, blocksize, weighted, seed, empty_indices, engine, bit_rate
+    ):
+        net = core.Net("bench")
+
+        np.random.seed(seed)
+
+        input_data = np.random.rand(num_rows, blocksize).astype(np.float32)
+        if empty_indices:
+            lengths = np.zeros(num_rows, dtype=np.int32)
+            num_indices = 0
+        else:
+            num_indices = np.random.randint(len(input_data))
+            # the number of indices per sample
+            lengths_split = np.clip(num_indices // 2, 1, 10)
+            lengths = (
+                np.ones([num_indices // lengths_split], dtype=np.int32) * lengths_split
+            )
+            # readjust num_indices when lengths_split doesn't divide num_indices
+            num_indices = num_indices // lengths_split * lengths_split
+        indices = np.random.randint(
+            low=0, high=len(input_data), size=[num_indices], dtype=np.int64
+        )
+        weights = np.random.uniform(size=[len(indices)]).astype(np.float32)
+
+        op = core.CreateOperator(
+            "FloatToFused" + str(bit_rate) + "BitRowwiseQuantized",
+            "input_data",
+            "quantized_data",
+            engine=engine,
+        )
+        net.Proto().op.extend([op])
+        op = core.CreateOperator(
+            "Fused" + str(bit_rate) + "BitRowwiseQuantizedToFloat",
+            "quantized_data",
+            "dequantized_data",
+        )
+        net.Proto().op.extend([op])
+        op = core.CreateOperator(
+            "FloatToFused" + str(bit_rate) + "BitFakeRowwiseQuantized",
+            "input_data",
+            "fake_quantized_data",
+            engine=engine,
+        )
+        net.Proto().op.extend([op])
+
+        if weighted:
+            net.SparseLengthsWeightedSum(
+                ["dequantized_data", "weights", "indices", "lengths"], "sum_reference"
+            )
+            net.SparseLengthsWeightedSumFused8BitRowwise(
+                ["fake_quantized_data", "weights", "indices", "lengths"],
+                "sum_fake_quantized",
+            )
+            op = core.CreateOperator(
+                "SparseLengthsWeightedSumFused" + str(bit_rate) + "BitRowwise",
+                ["quantized_data", "weights", "indices", "lengths"],
+                "sum_quantized",
+            )
+            net.Proto().op.extend([op])
+        else:
+            net.SparseLengthsSum(
+                ["dequantized_data", "indices", "lengths"], "sum_reference"
+            )
+            net.SparseLengthsSumFused8BitRowwise(
+                ["fake_quantized_data", "indices", "lengths"], "sum_fake_quantized"
+            )
+            op = core.CreateOperator(
+                "SparseLengthsSumFused" + str(bit_rate) + "BitRowwise",
+                ["quantized_data", "indices", "lengths"],
+                "sum_quantized",
+            )
+            net.Proto().op.extend([op])
+        net.Proto().external_input.extend(["input_data"])
+
+        workspace.FeedBlob("input_data", input_data)
+        workspace.FeedBlob("weights", weights)
+        workspace.FeedBlob("indices", indices)
+        workspace.FeedBlob("lengths", lengths)
+
+        workspace.GlobalInit(["caffe2", "--caffe2_log_level=0"])
+        workspace.RunNetOnce(net)
+
+        sum_reference = workspace.FetchBlob("sum_reference")
+        sum_fake_quantized = workspace.FetchBlob("sum_fake_quantized")
+        sum_quantized = workspace.FetchBlob("sum_quantized")
+
+        np.testing.assert_array_almost_equal(sum_reference, sum_quantized)
+        np.testing.assert_array_equal(sum_fake_quantized, sum_quantized)
+
+    @given(
+        num_rows=st.integers(1, 20),
+        blocksize=st.sampled_from([8, 12, 16, 32, 64, 96, 128]),
+        seed=st.integers(0, 2 ** 32 - 1),
+        empty_indices=st.booleans(),
+        engine=st.sampled_from(["", "GREEDY"]),
+        bit_rate=st.sampled_from([2, 4]),
+    )
+    def test_sparse_lengths_mean(
+        self, num_rows, blocksize, seed, empty_indices, engine, bit_rate
+    ):
+        net = core.Net("bench")
+
+        np.random.seed(seed)
+
+        input_data = np.random.rand(num_rows, blocksize).astype(np.float32)
+        if empty_indices:
+            lengths = np.zeros(num_rows, dtype=np.int32)
+            num_indices = 0
+        else:
+            num_indices = np.random.randint(len(input_data))
+            # the number of indices per sample
+            lengths_split = np.clip(num_indices // 2, 1, 10)
+            lengths = (
+                np.ones([num_indices // lengths_split], dtype=np.int32) * lengths_split
+            )
+            # readjust num_indices when lengths_split doesn't divide num_indices
+            num_indices = num_indices // lengths_split * lengths_split
+        #  Use int32 here because int64 is covered by test_sparse_lengths_sum
+        indices = np.random.randint(
+            low=0, high=len(input_data), size=[num_indices], dtype=np.int32
+        )
+
+        op = core.CreateOperator(
+            "FloatToFused" + str(bit_rate) + "BitRowwiseQuantized",
+            "input_data",
+            "quantized_data",
+            engine=engine,
+        )
+        net.Proto().op.extend([op])
+        op = core.CreateOperator(
+            "Fused" + str(bit_rate) + "BitRowwiseQuantizedToFloat",
+            "quantized_data",
+            "dequantized_data",
+        )
+        net.Proto().op.extend([op])
+        op = core.CreateOperator(
+            "FloatToFused" + str(bit_rate) + "BitFakeRowwiseQuantized",
+            "input_data",
+            "fake_quantized_data",
+            engine=engine,
+        )
+        net.Proto().op.extend([op])
+
+        net.SparseLengthsMean(
+            ["dequantized_data", "indices", "lengths"], "mean_reference"
+        )
+        net.SparseLengthsMeanFused8BitRowwise(
+            ["fake_quantized_data", "indices", "lengths"], "mean_fake_quantized"
+        )
+        op = core.CreateOperator(
+            "SparseLengthsMeanFused" + str(bit_rate) + "BitRowwise",
+            ["quantized_data", "indices", "lengths"],
+            "mean_quantized",
+        )
+        net.Proto().op.extend([op])
+        net.Proto().external_input.extend(["input_data"])
+
+        workspace.FeedBlob("input_data", input_data)
+        workspace.FeedBlob("indices", indices)
+        workspace.FeedBlob("lengths", lengths)
+
+        workspace.GlobalInit(["caffe2", "--caffe2_log_level=0"])
+        workspace.RunNetOnce(net)
+
+        mean_reference = workspace.FetchBlob("mean_reference")
+        mean_fake_quantized = workspace.FetchBlob("mean_fake_quantized")
+        mean_quantized = workspace.FetchBlob("mean_quantized")
+
+        np.testing.assert_array_almost_equal(mean_reference, mean_quantized)
+        np.testing.assert_array_equal(mean_fake_quantized, mean_quantized)
+
+    @given(
+        num_rows=st.integers(1, 20),
+        blocksize=st.sampled_from([8, 12, 16, 32, 64, 96, 128]),
+        weighted=st.booleans(),
+        empty_indices=st.booleans(),
+        bit_rate=st.sampled_from([2, 4, 8]),
+        indices_64bit=st.booleans(),
+    )
+    def test_sparse_lengths_sum_rowwise_sparse(
+        self, num_rows, blocksize, weighted, empty_indices, bit_rate, indices_64bit
+    ):
+        net = core.Net("bench")
+
+        input_data = np.random.rand(num_rows, blocksize).astype(np.float32)
+        if empty_indices:
+            lengths = np.zeros(num_rows, dtype=np.int32)
+            num_indices = 0
+        else:
+            num_indices = np.random.randint(len(input_data))
+            # the number of indices per sample
+            lengths_split = np.clip(num_indices // 2, 1, 10)
+            lengths = (
+                np.ones([num_indices // lengths_split], dtype=np.int32) * lengths_split
+            )
+            # readjust num_indices when lengths_split doesn't divide num_indices
+            num_indices = num_indices // lengths_split * lengths_split
+        #  Use int32 here because int64 is covered by test_sparse_lengths_sum
+        index_type = np.int64 if indices_64bit else np.int32
+        indices = np.random.randint(
+            low=0, high=len(input_data), size=[num_indices], dtype=index_type
+        )
+        weights = np.random.uniform(size=[len(indices)]).astype(np.float32)
+
+        op = core.CreateOperator(
+            "FloatToFused" + str(bit_rate) + "BitRowwiseQuantized",
+            "input_data",
+            "quantized_data",
+        )
+        workspace.FeedBlob("input_data", input_data)
+        workspace.RunOperatorOnce(op)
+        quantized_data = workspace.FetchBlob("quantized_data")
+
+        # Prune and generate mapping table
+        sparsity = 0.7
+        mapping_table = np.zeros(num_rows, dtype=np.int32)
+        num_compressed_rows = 0
+        unpruned_ids = []
+        for i in range(num_rows):
+            if np.random.uniform() < sparsity:
+                mapping_table[i] = -1
+                quantized_data[i, :] = 0
+            else:
+                mapping_table[i] = num_compressed_rows
+                num_compressed_rows += 1
+                unpruned_ids.append(i)
+
+        pruned_quantized_data = quantized_data[unpruned_ids]
+
+        inputs = (
+            ["quantized_data"]
+            + (["weights"] if weighted else [])
+            + ["indices", "lengths"]
+        )
+        op = core.CreateOperator(
+            "SparseLengths"
+            + ("Weighted" if weighted else "")
+            + "SumFused"
+            + str(bit_rate)
+            + "BitRowwise",
+            inputs,
+            "sum_reference",
+        )
+        net.Proto().op.extend([op])
+
+        inputs[0] = "pruned_quantized_data"
+        op = core.CreateOperator(
+            "SparseLengths"
+            + ("Weighted" if weighted else "")
+            + "Sum"
+            + str(bit_rate)
+            + "BitRowwiseSparse",
+            inputs + ["mapping_table"],
+            "sum_pruned",
+        )
+        net.Proto().op.extend([op])
+
+        workspace.FeedBlob("quantized_data", quantized_data)
+        workspace.FeedBlob("pruned_quantized_data", pruned_quantized_data)
+        workspace.FeedBlob("weights", weights)
+        workspace.FeedBlob("indices", indices)
+        workspace.FeedBlob("lengths", lengths)
+        workspace.FeedBlob("mapping_table", mapping_table)
+
+        workspace.RunNetOnce(net)
+
+        sum_reference = workspace.FetchBlob("sum_reference")
+        sum_pruned = workspace.FetchBlob("sum_pruned")
+
+        np.testing.assert_array_equal(sum_reference, sum_pruned)
+
+    @given(
+        num_rows=st.integers(1, 20),
+        blocksize=st.sampled_from([8, 12, 16, 32, 64, 96, 128]),
+        seed=st.integers(0, 2 ** 32 - 1),
+        empty_indices=st.booleans(),
+        engine=st.sampled_from(["", "GREEDY"]),
+        bit_rate=st.sampled_from([2, 4]),
+    )
+    def test_sparse_lengths_mean_rowwise_sparse_with_skipped_pruning(
+        self, num_rows, blocksize, seed, empty_indices, engine, bit_rate
+    ):
+        net = core.Net("bench")
+
+        np.random.seed(seed)
+
+        input_data = np.random.rand(num_rows, blocksize).astype(np.float32)
+        if empty_indices:
+            lengths = np.zeros(num_rows, dtype=np.int32)
+            num_indices = 0
+        else:
+            num_indices = np.random.randint(len(input_data))
+            # the number of indices per sample
+            lengths_split = np.clip(num_indices // 2, 1, 10)
+            lengths = (
+                np.ones([num_indices // lengths_split], dtype=np.int32) * lengths_split
+            )
+            # readjust num_indices when lengths_split doesn't divide num_indices
+            num_indices = num_indices // lengths_split * lengths_split
+        #  Use int32 here because int64 is covered by test_sparse_lengths_sum
+        indices = np.random.randint(
+            low=0, high=len(input_data), size=[num_indices], dtype=np.int32
+        )
+
+        op = core.CreateOperator(
+            "FloatToFused" + str(bit_rate) + "BitRowwiseQuantized",
+            "input_data",
+            "quantized_data",
+            engine=engine,
+        )
+        net.Proto().op.extend([op])
+        op = core.CreateOperator(
+            "Fused" + str(bit_rate) + "BitRowwiseQuantizedToFloat",
+            "quantized_data",
+            "dequantized_data",
+        )
+        net.Proto().op.extend([op])
+        op = core.CreateOperator(
+            "FloatToFused" + str(bit_rate) + "BitFakeRowwiseQuantized",
+            "input_data",
+            "fake_quantized_data",
+            engine=engine,
+        )
+        net.Proto().op.extend([op])
+
+        net.SparseLengthsMean(
+            ["dequantized_data", "indices", "lengths"], "mean_reference"
+        )
+        net.SparseLengthsMeanFused8BitRowwise(
+            ["fake_quantized_data", "indices", "lengths"], "mean_fake_quantized"
+        )
+        op1 = core.CreateOperator(
+            "SparseLengthsMeanFused" + str(bit_rate) + "BitRowwise",
+            ["quantized_data", "indices", "lengths"],
+            "mean_quantized",
+        )
+        op2 = core.CreateOperator(
+            "SparseLengthsMean" + str(bit_rate) + "BitRowwiseSparse",
+            ["quantized_data", "indices", "lengths"] + ["mapping_table"],
+            "mean_quantized_pruned",
+        )
+        net.Proto().op.extend([op1, op2])
+        net.Proto().external_input.extend(["input_data", "mapping_table"])
+
+        workspace.FeedBlob("input_data", input_data)
+        workspace.FeedBlob("indices", indices)
+        workspace.FeedBlob("lengths", lengths)
+        mapping_table = np.array([0]).astype(dtype=np.int32)
+        workspace.FeedBlob("mapping_table", mapping_table)
+
+        workspace.GlobalInit(["caffe2", "--caffe2_log_level=0"])
+        workspace.RunNetOnce(net)
+
+        mean_reference = workspace.FetchBlob("mean_reference")
+        mean_fake_quantized = workspace.FetchBlob("mean_fake_quantized")
+        mean_quantized = workspace.FetchBlob("mean_quantized")
+        mean_quantized_pruned = workspace.FetchBlob("mean_quantized_pruned")
+
+        np.testing.assert_array_almost_equal(mean_reference, mean_quantized)
+        np.testing.assert_array_equal(mean_fake_quantized, mean_quantized)
+        np.testing.assert_array_equal(mean_quantized_pruned, mean_quantized)


### PR DESCRIPTION
Summary:
Reattempt of D20461609

Moving 2/4-bit SLS and row-wise 2/4-bit conversion operator to open source to be used by DLRM

Test Plan: CI

Differential Revision: D20495304

