### PR TITLE
[quant][onnx] Add aten::max_pool2d to jit pass

### DIFF
--- a/torch/csrc/jit/passes/onnx/unpack_quantized_weights.cpp
+++ b/torch/csrc/jit/passes/onnx/unpack_quantized_weights.cpp
@@ -31,6 +31,7 @@ double getScaleFromInput(Node* input_node) {
   c10::optional<IValue> scale;
   std::string input_name = input_node->kind().toQualString();
   std::unordered_set<std::string> noscale_ops = {"quantized::max_pool2d",
+                                                 "aten::max_pool2d",
                                                  "aten::relu",
                                                  "prim::ListUnpack",
                                                  "aten::split_with_sizes",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#34912 [quant][onnx] Add aten::max_pool2d to jit pass**

Summary: max_pool2d quantized op actually shows up as aten::max_pool2d

Test Plan:
python test/test_pytorch_onnx_caffe2_quantized.py

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D20497780](https://our.internmc.facebook.com/intern/diff/D20497780)