### PR TITLE
Fix example format in Distributed Autograd doc

### DIFF
--- a/torch/csrc/distributed/autograd/init.cpp
+++ b/torch/csrc/distributed/autograd/init.cpp
@@ -158,12 +158,11 @@ Arguments:
                   to True to run backward multiple times.
 
 Example::
-
-    >> import torch.distributed.autograd as dist_autograd
-    >> with dist_autograd.context() as context_id:
-    >>      pred = model.forward()
-    >>      loss = loss_func(pred, loss)
-    >>      dist_autograd.backward(context_id, loss)
+    >>> import torch.distributed.autograd as dist_autograd
+    >>> with dist_autograd.context() as context_id:
+    >>>      pred = model.forward()
+    >>>      loss = loss_func(pred, loss)
+    >>>      dist_autograd.backward(context_id, loss)
 )",
       py::arg("contextId"),
       py::arg("roots"),
@@ -189,19 +188,19 @@ Arguments:
                      gradients.
 
 Returns:
-    A map where the key is the Tensor and the value is the associated gradient for that Tensor.
+    A map where the key is the Tensor and the value is the associated gradient
+    for that Tensor.
 
 Example::
-
-    >> import torch.distributed.autograd as dist_autograd
-    >> with dist_autograd.context() as context_id:
-    >>      t1 = torch.rand((3, 3), requires_grad=True)
-    >>      t2 = torch.rand((3, 3), requires_grad=True)
-    >>      loss = t1 + t2
-    >>      dist_autograd.backward(context_id, [loss.sum()])
-    >>      grads = dist_autograd.get_gradients(context_id)
-    >>      print(grads[t1])
-    >>      print(grads[t2])
+    >>> import torch.distributed.autograd as dist_autograd
+    >>> with dist_autograd.context() as context_id:
+    >>>      t1 = torch.rand((3, 3), requires_grad=True)
+    >>>      t2 = torch.rand((3, 3), requires_grad=True)
+    >>>      loss = t1 + t2
+    >>>      dist_autograd.backward(context_id, [loss.sum()])
+    >>>      grads = dist_autograd.get_gradients(context_id)
+    >>>      print(grads[t1])
+    >>>      print(grads[t2])
 )",
       py::arg("context_id"));
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #34931 Support using self as the destination in rpc.remote for builtin operators
* #34921 Fix dist autograd context Example block format
* #34919 Fix example block format in Distributed Optimizer API doc
* **#34914 Fix example format in Distributed Autograd doc**
* #34890 Minor fixes for RPC API docs
* #34888 Update descriptions for transmitting CUDA tensors
* #34887 Removing experimental tag in for RPC and adding experimental tag for RPC+TorchScript
* #34885 Adding warnings for async Tensor serialization in remote and rpc_async
* #34884 Add a warning for RRef serialization

Differential Revision: [D20500015](https://our.internmc.facebook.com/intern/diff/D20500015)