### PR TITLE
[JIT] add copmlexity tests

### DIFF
--- a/test/jit/test_complexity.py
+++ b/test/jit/test_complexity.py
@@ -1,0 +1,89 @@
+import os
+import sys
+
+import torch
+
+# as with test_jit tests, requires global dtype set
+torch.set_default_dtype(torch.double)
+
+# Make the helper files in test/ importable
+pytorch_test_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+sys.path.append(pytorch_test_dir)
+from torch.testing._internal.jit_utils import JitTestCase, enable_profiling_mode, try_get_nn_module_compiled_mod_and_inputs, \
+    get_nn_module_name_from_kwargs
+from torch.testing._internal.common_utils import run_tests, suppress_warnings
+import torch.testing._internal.jit_utils as jit_utils
+
+
+def num_ifs_loops(graph):
+    graph_str = str(graph)
+    # only look at body of graph
+    graph_body = graph_str[0:graph_str.find("return")]
+    return graph_body.count("prim::Loop") + graph_body.count("prim::If")
+
+def num_non_tensor_nodes(block):
+    num_non_tensor = 0
+    for node in block.nodes():
+        kind = node.kind()
+        # GetAttr don't provide useful signal here, since they are non-optimizable except with freezing
+        # Constant is not executed, bailouts should be a separate tests, don't provide useful signal here
+        if kind == "prim::Constant" or "prim::Bailout" in kind or "GetAttr" in kind:
+            continue
+        for b in node.blocks():
+            num_non_tensor += num_non_tensor_nodes(b)
+        tensor_out = False
+        for out in node.outputs():
+            if "Tensor" in str(out.type()):
+                tensor_out = True
+                break
+        num_non_tensor += int(not tensor_out)
+    return num_non_tensor
+
+class TestComplexity(JitTestCase):
+    def setUp(self):
+        super(TestComplexity, self).setUp()
+        self.grad_enabled = torch.is_grad_enabled()
+        torch.set_grad_enabled(False)
+
+    def tearDown(self):
+        super(TestComplexity, self).tearDown()
+        torch.set_grad_enabled(self.grad_enabled)
+
+    @suppress_warnings 
+    def test_generated_functional_tests(self):
+        with enable_profiling_mode():
+            stats = [("Name", "Ifs/Loops", "non-tensor ops")]
+            for test in jit_utils.nn_functional_tests:
+                test_name = test[0]
+
+                fn, inputs = jit_utils.get_nn_functional_compiled_fn_and_inputs(*test)
+                for _ in range(6):
+                    fn(*inputs)
+
+                g = torch.jit.last_executed_optimized_graph()
+                stats.append((test_name, num_ifs_loops(g), num_non_tensor_nodes(g)))
+        for line in stats:
+            print(line)
+
+    @suppress_warnings 
+    def test_nn_module_tests(self):
+        with enable_profiling_mode():
+            stats = [("Name", "Ifs/Loops", "non-tensor ops")]
+            for test in jit_utils.get_all_nn_module_tests():
+                out = try_get_nn_module_compiled_mod_and_inputs(**test)
+                if not out:
+                    continue
+
+                mod, inputs = out
+                test_name = get_nn_module_name_from_kwargs(**test)
+                for _ in range(6):
+                    mod(*inputs)
+
+                g = torch.jit.last_executed_optimized_graph()
+                stats.append((test_name, num_ifs_loops(g), num_non_tensor_nodes(g)))
+
+            for line in stats:
+                print(line)
+
+if __name__ == '__main__':
+    run_tests()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#34915 [JIT] add copmlexity tests**
* #34905 separate nn module tests
* #34694 [JIT] Move functional graph creation to testing utils

I'm going to set this up as a continuous test that runs internally in FB, but soliciting reviews externally first. 

I think that benchmarking complexity of our nn module & functional tests is useful because these modules/functions are the building blocks of user code, so they should be pretty representative of user code. This also separates out our complexity tests into tests that are easily debuggable given a regression, instead of a 50K node resnet graph. We also already have nice infrastructure for generating the tests. 

For each test, i am testing the profiled graph with consistent shapes, and I am testing 
- Number of If & loop statements
- Number of non-tensor nodes


Current output:
Functional tests:
```
('Name', 'Ifs/Loops', 'non-tensor ops')
('conv1d', 0, 0)
('conv2d', 0, 0)
('conv3d', 0, 0)
('conv_transpose1d', 0, 0)
('conv_transpose2d', 0, 0)
('conv_transpose3d', 0, 0)
('conv_tbc', 0, 0)
('avg_pool1d', 0, 0)
('avg_pool2d', 0, 0)
('avg_pool3d', 0, 0)
('fractional_max_pool2d', 0, 3)
('max_pool1d', 0, 0)
('max_pool1d', 0, 0)
('max_pool2d', 0, 0)
('max_pool2d', 0, 0)
('max_pool3d', 0, 0)
('max_unpool1d', 0, 12)
('max_unpool2d', 0, 22)
('max_unpool3d', 0, 33)
('lp_pool1d', 0, 0)
('lp_pool2d', 0, 0)
('adaptive_max_pool1d', 0, 0)
('adaptive_max_pool2d', 0, 6)
('adaptive_max_pool3d', 0, 9)
('adaptive_avg_pool1d', 0, 0)
('adaptive_avg_pool2d', 0, 6)
('adaptive_avg_pool3d', 0, 9)
('dropout', 0, 0)
('alpha_dropout', 0, 0)
('dropout2d', 0, 0)
('dropout3d', 0, 0)
('feature_alpha_dropout', 0, 0)
('threshold', 0, 0)
('threshold', 0, 0)
('relu', 0, 0)
('relu', 0, 0)
('glu', 0, 0)
('hardtanh', 0, 0)
('hardtanh', 0, 0)
('relu6', 0, 0)
('relu6', 0, 0)
('elu', 0, 0)
('elu', 0, 0)
('selu', 0, 0)
('selu', 0, 0)
('celu', 0, 0)
('celu', 0, 0)
('leaky_relu', 0, 0)
('leaky_relu', 0, 0)
('rrelu', 0, 0)
('rrelu', 0, 0)
('hardshrink', 0, 0)
('tanhshrink', 0, 0)
('softsign', 0, 0)
('softplus', 0, 0)
('softmin', 0, 0)
('softmax', 0, 0)
('softmax', 0, 0)
('tanh', 0, 1)
('sigmoid', 0, 1)
('log_softmax', 0, 0)
('linear', 0, 0)
('linear', 0, 0)
('bilinear', 0, 0)
('embedding', 0, 0)
('embedding_bag', 0, 0)
('batch_norm', 0, 0)
('instance_norm', 1, 6)
('layer_norm', 0, 0)
('layer_norm', 0, 0)
('layer_norm', 0, 0)
('layer_norm', 0, 0)
('group_norm', 3, 53)
('local_response_norm', 0, 0)
('nll_loss', 1, 5)
('poisson_nll_loss', 0, 0)
('poisson_nll_loss', 0, 0)
('kl_div', 0, 1)
('cross_entropy', 1, 5)
('binary_cross_entropy_with_logits', 0, 0)
('smooth_l1_loss', 1, 1)
('l1_loss', 1, 1)
('mse_loss', 1, 1)
('smooth_l1_loss', 1, 1)
('l1_loss', 1, 1)
('mse_loss', 1, 1)
('margin_ranking_loss', 0, 0)
('hinge_embedding_loss', 0, 0)
('soft_margin_loss', 0, 0)
('multilabel_soft_margin_loss', 0, 1)
('cosine_embedding_loss', 0, 0)
('pixel_shuffle', 0, 0)
('affine_grid', 3, 14)
('pad', 0, 0)
('pairwise_distance', 0, 0)
('pdist', 0, 0)
('cosine_similarity', 0, 0)
('triplet_margin_loss', 0, 0)
('normalize', 0, 0)
('unfold', 0, 0)
('fold', 0, 0)
('grid_sample', 0, 1)
('gumbel_softmax', 0, 0)
('gumbel_softmax', 0, 0)
('multilabel_margin_loss', 0, 0)
('multi_margin_loss', 0, 0)
('binary_cross_entropy', 1, 5)
('binary_cross_entropy', 1, 5)
('ctc_loss', 0, 0)
('upsample', 13, 71)
('upsample', 13, 71)
('interpolate', 14, 71)
('interpolate', 13, 70)
('interpolate', 14, 71)
('interpolate', 14, 71)
('interpolate', 13, 70)
('interpolate', 14, 71)
('interpolate', 14, 71)
('interpolate', 13, 70)
('interpolate', 14, 71)
('interpolate', 14, 71)
('interpolate', 13, 70)
('interpolate', 14, 71)
('interpolate', 14, 60)
('interpolate', 13, 58)
('interpolate', 14, 60)
('interpolate', 14, 60)
('interpolate', 13, 58)
('interpolate', 14, 60)
('interpolate', 14, 60)
('interpolate', 13, 58)
('interpolate', 14, 60)
('interpolate', 13, 82)
('interpolate', 14, 82)
('interpolate', 14, 82)
('interpolate', 13, 82)
('interpolate', 14, 82)
('interpolate', 14, 82)
('interpolate', 13, 82)
('interpolate', 14, 82)
('interpolate', 14, 71)
('interpolate', 14, 71)
('interpolate', 15, 106)
('interpolate', 14, 73)
('interpolate', 15, 106)
('interpolate', 14, 73)
('interpolate', 15, 92)
('interpolate', 14, 60)
('interpolate', 15, 94)
('interpolate', 14, 62)
('interpolate', 15, 116)
('interpolate', 14, 82)
('interpolate', 15, 118)
('interpolate', 14, 84)
```
nn module tests:
```
('Name', 'Ifs/Loops', 'non-tensor ops')
('Linear', 0, 0)
('Linear', 0, 0)
('Threshold', 0, 0)
('Threshold', 0, 0)
('ReLU', 0, 0)
('ReLU6', 0, 0)
('RReLU', 0, 0)
('RReLU', 0, 0)
('Hardtanh', 0, 0)
('Sigmoid', 0, 0)
('Tanh', 0, 0)
('Flatten', 0, 0)
('Softmax', 0, 0)
('Softmax2d', 0, 0)
('LogSoftmax', 0, 0)
('LogSoftmax', 0, 0)
('ELU', 0, 0)
('Hardshrink', 0, 0)
('LeakyReLU', 0, 0)
('LeakyReLU', 0, 0)
('LogSigmoid', 0, 0)
('Softplus', 0, 0)
('Softplus', 0, 0)
('Softplus', 0, 0)
('Softshrink', 0, 0)
('Softshrink', 0, 0)
('PReLU', 0, 0)
('PReLU', 0, 0)
('PReLU', 0, 0)
('PReLU', 0, 0)
('PReLU', 0, 0)
('PReLU', 0, 0)
('Softsign', 0, 0)
('Softmin', 0, 0)
('Softmin', 0, 0)
('Tanhshrink', 0, 0)
('FractionalMaxPool2d_ratio', 0, 7)
('FractionalMaxPool2d_size', 0, 0)
('FractionalMaxPool3d_ratio', 0, 10)
('FractionalMaxPool3d_size', 0, 0)
('FractionalMaxPool3d_asymsize', 0, 0)
('BatchNorm1d', 2, 3)
('BatchNorm1d', 3, 9)
('BatchNorm1d', 2, 5)
('BatchNorm1d', 2, 3)
('BatchNorm1d', 0, 0)
('BatchNorm1d', 3, 9)
('BatchNorm1d', 3, 9)
('BatchNorm2d', 3, 13)
('BatchNorm2d', 3, 15)
('BatchNorm2d', 3, 13)
('BatchNorm2d', 3, 13)
('BatchNorm2d', 1, 10)
('BatchNorm2d', 3, 13)
('BatchNorm3d', 3, 17)
('BatchNorm3d', 3, 19)
('BatchNorm3d', 3, 17)
('BatchNorm3d', 3, 17)
('BatchNorm3d', 1, 14)
('BatchNorm3d', 3, 17)
('InstanceNorm1d', 1, 6)
('InstanceNorm1d', 1, 6)
('InstanceNorm2d', 1, 10)
('InstanceNorm2d', 1, 10)
('InstanceNorm3d', 1, 14)
('InstanceNorm3d', 1, 14)
('LayerNorm', 0, 0)
('LayerNorm', 0, 0)
('LayerNorm', 0, 0)
('LayerNorm', 0, 0)
('LayerNorm', 0, 0)
('GroupNorm', 3, 53)
('GroupNorm', 3, 53)
('GroupNorm', 3, 53)
('GroupNorm', 3, 53)
('GroupNorm', 3, 53)
('GroupNorm', 3, 53)
('Conv1d', 0, 0)
('Conv1d', 0, 0)
('Conv1d', 0, 0)
('Conv1d', 0, 0)
('Conv1d', 0, 0)
('Conv1d', 0, 0)
('Conv1d', 0, 0)
('Conv1d_dilated', 0, 0)
('Conv1d_groups', 0, 0)
('ConvTranspose1d', 0, 0)
('ConvTranspose1d', 0, 0)
('ConvTranspose1d', 0, 0)
('ConvTranspose1d_groups', 0, 0)
('MaxPool1d', 0, 0)
('MaxPool1d', 0, 0)
('Conv2d', 0, 0)
('Conv2d', 0, 0)
('Conv2d', 0, 0)
('Conv2d', 0, 0)
('Conv2d', 0, 0)
('Conv2d', 0, 0)
('Conv2d_groups', 0, 0)
('Conv2d_groups_thnn', 0, 0)
('ConvTranspose2d', 0, 0)
('ConvTranspose2d', 0, 0)
('ConvTranspose2d', 0, 0)
('ConvTranspose2d_groups', 0, 0)
('Conv2d_depthwise', 0, 0)
('Conv2d_depthwise_with_multiplier', 0, 0)
('Conv2d_depthwise_strided', 0, 0)
('Conv2d_depthwise_padded', 0, 0)
('Conv2d_depthwise_dilated', 0, 0)
('MaxPool2d', 0, 0)
('AvgPool1d', 0, 0)
('AvgPool1d', 0, 0)
('AvgPool1d', 0, 0)
('AvgPool2d', 0, 0)
('AvgPool2d', 0, 0)
('AvgPool2d', 0, 0)
('AvgPool2d_divisor', 0, 0)
('AvgPool2d_divisor_stride', 0, 0)
('AvgPool2d_divisor_stride_pad', 0, 0)
('LPPool2d', 0, 0)
('LPPool2d', 0, 0)
('LPPool1d', 0, 0)
('LPPool1d', 0, 0)
('LocalResponseNorm', 0, 0)
('LocalResponseNorm', 0, 0)
('LocalResponseNorm', 0, 0)
('ReflectionPad1d', 0, 0)
('ReflectionPad2d', 0, 0)
('ReplicationPad1d', 0, 0)
('ReplicationPad2d', 0, 0)
('ZeroPad2d', 0, 0)
('ZeroPad2d', 0, 0)
('ConstantPad1d', 0, 0)
('ConstantPad2d', 0, 0)
('ConstantPad3d', 0, 0)
('Conv3d', 0, 0)
('Conv3d', 0, 0)
('Conv3d', 0, 0)
('Conv3d', 0, 0)
('Conv3d', 0, 0)
('Conv3d_groups', 0, 0)
('Conv3d_dilated', 0, 0)
('Conv3d_dilated_strided', 0, 0)
('ConvTranspose3d', 0, 0)
('ConvTranspose3d', 0, 0)
('MaxPool3d', 0, 0)
('MaxPool3d', 0, 0)
('MaxPool3d', 0, 0)
('AvgPool3d', 0, 0)
('AvgPool3d', 0, 0)
('AvgPool3d', 0, 0)
('AvgPool3d', 0, 0)
('AvgPool3d', 0, 0)
('AvgPool3d', 0, 0)
('AvgPool3d', 0, 0)
('AvgPool3d_divisor', 0, 0)
('AvgPool3d_divisor_stride', 0, 0)
('AvgPool3d_divisor_stride_pad', 0, 0)
('AvgPool3d_divisor_stride_pad_gpu_fixedkw_output', 0, 0)
('AvgPool3d_divisor_stride_pad_gpu_general_output', 0, 0)
('AvgPool3d_divisor_stride1_pad0_gpu_input', 0, 0)
('AvgPool3d_divisor_stride_pad_gpu_input_nooverlap', 0, 0)
('ReplicationPad3d', 0, 0)
('Embedding', 0, 0)
('EmbeddingBag', 0, 2)
('EmbeddingBag', 0, 2)
('EmbeddingBag', 0, 2)
('EmbeddingBag_sparse', 0, 2)
('Embedding_sparse', 0, 0)
('PixelShuffle', 0, 0)
('AdaptiveMaxPool1d', 0, 0)
('AdaptiveMaxPool2d', 0, 6)
('AdaptiveMaxPool2d', 0, 6)
('AdaptiveMaxPool3d', 0, 9)
('AdaptiveMaxPool3d', 0, 9)
('AdaptiveMaxPool3d', 0, 9)
('AdaptiveMaxPool3d', 0, 9)
('AdaptiveAvgPool1d', 0, 0)
('AdaptiveAvgPool1d', 0, 0)
('AdaptiveAvgPool2d', 0, 6)
('AdaptiveAvgPool2d', 0, 6)
('AdaptiveAvgPool2d', 0, 6)
('AdaptiveAvgPool3d', 0, 9)
('AdaptiveAvgPool3d', 0, 9)
('SELU', 0, 0)
('SELU', 0, 0)
('CELU', 0, 0)
('CELU', 0, 0)
('GLU', 0, 0)
('GLU', 0, 0)
('GELU', 0, 0)
('GELU', 0, 0)
('Unfold', 0, 0)
('Fold', 0, 0)
('Unfold_int_input', 0, 0)
('Fold_int_input', 0, 0)
('Threshold', 0, 0)
('ReLU', 0, 0)
('ReLU6', 0, 0)
('RReLU', 0, 0)
('Hardtanh', 0, 0)
('Sigmoid', 0, 0)
('Tanh', 0, 0)
('Softmax', 0, 0)
('LogSoftmax', 0, 0)
('ELU', 0, 0)
('Hardshrink', 0, 0)
('LeakyReLU', 0, 0)
('LogSigmoid', 0, 0)
('Softplus', 0, 0)
('Softshrink', 0, 0)
('PReLU', 0, 0)
('Softsign', 0, 0)
('Softmin', 0, 0)
('Tanhshrink', 0, 0)
('Conv1d', 3, 14)
('Conv2d', 3, 14)
('Conv1d', 5, 31)
('Conv2d', 5, 31)
('Conv3d', 5, 31)
('Conv1d', 3, 14)
('Conv2d', 3, 14)
('Conv3d', 3, 14)
('Conv1d', 0, 0)
('Conv2d', 0, 0)
('Conv3d', 0, 0)
('Bilinear', 0, 0)
('RNNCell', 3, 14)
('LSTMCell', 5, 22)
('GRUCell', 3, 14)
('MultiheadAttention', 40, 160)
('Transformer', 128, 499)
```

