### PR TITLE
Fix example block format in Distributed Optimizer API doc

### DIFF
--- a/torch/distributed/optim/optimizer.py
+++ b/torch/distributed/optim/optimizer.py
@@ -82,28 +82,27 @@ class DistributedOptimizer:
         kwargs: arguments to pass to the optimizer constructor on each worker.
 
     Example::
-
-        >> import torch.distributed.autograd as dist_autograd
-        >> import torch.distributed.rpc as rpc
-        >> from torch import optim
-        >> from torch.distributed.optim import DistributedOptimizer
-        >>
-        >> with dist_autograd.context() as context_id:
-        >>   # Forward pass.
-        >>   rref1 = rpc.remote("worker1", torch.add, args=(torch.ones(2), 3))
-        >>   rref2 = rpc.remote("worker1", torch.add, args=(torch.ones(2), 1))
-        >>   loss = rref1.to_here() + rref2.to_here()
-        >>
-        >>   # Backward pass.
-        >>   dist_autograd.backward(context_id, [loss.sum()])
-        >>
-        >>   # Optimizer.
-        >>   dist_optim = DistributedOptimizer(
-        >>      optim.SGD,
-        >>      [rref1, rref2],
-        >>      lr=0.05,
-        >>   )
-        >>   dist_optim.step(context_id)
+        >>> import torch.distributed.autograd as dist_autograd
+        >>> import torch.distributed.rpc as rpc
+        >>> from torch import optim
+        >>> from torch.distributed.optim import DistributedOptimizer
+        >>>
+        >>> with dist_autograd.context() as context_id:
+        >>>   # Forward pass.
+        >>>   rref1 = rpc.remote("worker1", torch.add, args=(torch.ones(2), 3))
+        >>>   rref2 = rpc.remote("worker1", torch.add, args=(torch.ones(2), 1))
+        >>>   loss = rref1.to_here() + rref2.to_here()
+        >>>
+        >>>   # Backward pass.
+        >>>   dist_autograd.backward(context_id, [loss.sum()])
+        >>>
+        >>>   # Optimizer.
+        >>>   dist_optim = DistributedOptimizer(
+        >>>      optim.SGD,
+        >>>      [rref1, rref2],
+        >>>      lr=0.05,
+        >>>   )
+        >>>   dist_optim.step(context_id)
     """
     def __init__(self, optimizer_class, params_rref, *args, **kwargs):
         per_worker_params_rref = defaultdict(list)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #34931 Support using self as the destination in rpc.remote for builtin operators
* #34921 Fix dist autograd context Example block format
* **#34919 Fix example block format in Distributed Optimizer API doc**
* #34914 Fix example format in Distributed Autograd doc
* #34890 Minor fixes for RPC API docs
* #34888 Update descriptions for transmitting CUDA tensors
* #34887 Removing experimental tag in for RPC and adding experimental tag for RPC+TorchScript
* #34885 Adding warnings for async Tensor serialization in remote and rpc_async
* #34884 Add a warning for RRef serialization

Differential Revision: [D20500013](https://our.internmc.facebook.com/intern/diff/D20500013)