### PR TITLE
Fix Parameters and Example block title indention in RPC API doc

### DIFF
--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -113,55 +113,55 @@ PyObject* rpc_init(PyObject* /* unused */) {
 
   auto pyRRef =
       shared_ptr_class_<PyRRef>(module, "RRef", R"(
-          A class encapsulating a reference to a value of some type on a remote
-          worker. This handle will keep the referenced remote value alive on the
-          worker. A ``UserRRef`` will be deleted when 1) no references to it in
-          both the application code and in the local RRef context, or 2) the
-          application has called a graceful shutdown. Invoking methods on a
-          deleted RRef leads to undefined behaviors. RRef implementation only
-          offers best-effort error detection, and applications should not use
-          ``UserRRef``s after ``rpc.shutdown()``.
+A class encapsulating a reference to a value of some type on a remote
+worker. This handle will keep the referenced remote value alive on the
+worker. A ``UserRRef`` will be deleted when 1) no references to it in
+both the application code and in the local RRef context, or 2) the
+application has called a graceful shutdown. Invoking methods on a
+deleted RRef leads to undefined behaviors. RRef implementation only
+offers best-effort error detection, and applications should not use
+``UserRRef``s after ``rpc.shutdown()``.
 
-          .. warning::
-              RRefs can only be serialized and deserialized by the RPC module.
-              Serializing and deserializing RRefs without RPC (e.g., Python
-              pickle, torch :meth:`~torch.save` / :meth:`~torch.load`,
-              JIT :meth:`~torch.jit.save` / :meth:`~torch.jit.load`, etc.) will
-              lead to errors.
+.. warning::
+    RRefs can only be serialized and deserialized by the RPC module.
+    Serializing and deserializing RRefs without RPC (e.g., Python
+    pickle, torch :meth:`~torch.save` / :meth:`~torch.load`,
+    JIT :meth:`~torch.jit.save` / :meth:`~torch.jit.load`, etc.) will
+    lead to errors.
 
-          Example::
-              Following examples skip RPC initialization and shutdown code
-              for simplicity. Refer to RPC docs for those details.
+Example::
+    Following examples skip RPC initialization and shutdown code
+    for simplicity. Refer to RPC docs for those details.
 
-              1. Create an RRef using rpc.remote
+    1. Create an RRef using rpc.remote
 
-              >>> import torch
-              >>> import torch.distributed.rpc as rpc
-              >>> rref = rpc.remote("worker1", torch.add, args=(torch.ones(2), 3))
-              >>> # get a copy of value from the RRef
-              >>> x = rref.to_here()
+    >>> import torch
+    >>> import torch.distributed.rpc as rpc
+    >>> rref = rpc.remote("worker1", torch.add, args=(torch.ones(2), 3))
+    >>> # get a copy of value from the RRef
+    >>> x = rref.to_here()
 
-              2. Create an RRef from a local object
+    2. Create an RRef from a local object
 
-              >>> import torch
-              >>> from torch.distributed.rpc import RRef
-              >>> x = torch.zeros(2, 2)
-              >>> rref = RRef(x)
+    >>> import torch
+    >>> from torch.distributed.rpc import RRef
+    >>> x = torch.zeros(2, 2)
+    >>> rref = RRef(x)
 
-              3. Share an RRef with other workers
+    3. Share an RRef with other workers
 
-              >>> # On both worker0 and worker1:
-              >>> def f(rref):
-              >>>   return rref.to_here() + 1
+    >>> # On both worker0 and worker1:
+    >>> def f(rref):
+    >>>   return rref.to_here() + 1
 
-              >>> # On worker0:
-              >>> import torch
-              >>> import torch.distributed.rpc as rpc
-              >>> from torch.distributed.rpc import RRef
-              >>> rref = RRef(torch.zeros(2, 2))
-              >>> # the following RPC shares the rref with worker1, reference
-              >>> # count is automatically updated.
-              >>> rpc.rpc_sync("worker1", f, args(rref,))
+    >>> # On worker0:
+    >>> import torch
+    >>> import torch.distributed.rpc as rpc
+    >>> from torch.distributed.rpc import RRef
+    >>> rref = RRef(torch.zeros(2, 2))
+    >>> # the following RPC shares the rref with worker1, reference
+    >>> # count is automatically updated.
+    >>> rpc.rpc_sync("worker1", f, args(rref,))
           )")
           .def(
               py::init<const py::object&, const py::object&>(),
@@ -240,35 +240,35 @@ If the future completes with an error, an exception is thrown.
       "ProcessGroupRpcBackendOptions",
       rpcBackendOptions,
       R"(
-          The backend options class for ``ProcessGroupAgent``, which is derived
-          from ``RpcBackendOptions``.
+The backend options class for ``ProcessGroupAgent``, which is derived
+from ``RpcBackendOptions``.
 
-          Arguments:
-              num_send_recv_threads (int, optional): The number of threads in
-                  the thread-pool used by ``ProcessGroupAgent`` (default: 4).
-              rpc_timeout (datetime.timedelta, optional): The timeout for RPC
-                  requests (default: ``timedelta(seconds=60)``).
-              init_method (str, optional): The URL to initialize
-                  ``ProcessGroupGloo`` (default: ``env://``).
+Arguments:
+    num_send_recv_threads (int, optional): The number of threads in
+        the thread-pool used by ``ProcessGroupAgent`` (default: 4).
+    rpc_timeout (datetime.timedelta, optional): The timeout for RPC
+        requests (default: ``timedelta(seconds=60)``).
+    init_method (str, optional): The URL to initialize
+        ``ProcessGroupGloo`` (default: ``env://``).
 
 
-          Example::
-              >>> import datetime, os
-              >>> from torch.distributed import rpc
-              >>> os.environ['MASTER_ADDR'] = 'localhost'
-              >>> os.environ['MASTER_PORT'] = '29500'
-              >>>
-              >>> rpc.init_rpc(
-              >>>     "worker1",
-              >>>     rank=0,
-              >>>     world_size=2,
-              >>>     rpc_backend_options=rpc.ProcessGroupRpcBackendOptions(
-              >>>         num_send_recv_threads=16,
-              >>>         datetime.timedelta(seconds=20)
-              >>>     )
-              >>> )
-              >>>
-              >>> # omitting init_rpc invocation on worker2
+Example::
+    >>> import datetime, os
+    >>> from torch.distributed import rpc
+    >>> os.environ['MASTER_ADDR'] = 'localhost'
+    >>> os.environ['MASTER_PORT'] = '29500'
+    >>>
+    >>> rpc.init_rpc(
+    >>>     "worker1",
+    >>>     rank=0,
+    >>>     world_size=2,
+    >>>     rpc_backend_options=rpc.ProcessGroupRpcBackendOptions(
+    >>>         num_send_recv_threads=16,
+    >>>         datetime.timedelta(seconds=20)
+    >>>     )
+    >>> )
+    >>>
+    >>> # omitting init_rpc invocation on worker2
       )")
       .def(
           py::init<int, std::chrono::milliseconds, std::string>(),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #34921 Fix dist autograd context Example block format
* **#34920 Fix Parameters and Example block title indention in RPC API doc**
* #34919 Fix example block format in Distributed Optimizer API doc
* #34914 Fix example format in Distributed Autograd doc
* #34890 Minor fixes for RPC API docs
* #34888 Update descriptions for transmitting CUDA tensors
* #34887 Removing experimental tag in for RPC and adding experimental tag for RPC+TorchScript
* #34885 Adding warnings for async Tensor serialization in remote and rpc_async
* #34884 Add a warning for RRef serialization

