### PR TITLE
Fix dist autograd context Example block format

### DIFF
--- a/torch/distributed/autograd/__init__.py
+++ b/torch/distributed/autograd/__init__.py
@@ -22,13 +22,12 @@ class context(object):
     autograd pass.
 
     Example::
-
-        >> import torch.distributed.autograd as dist_autograd
-        >> with dist_autograd.context() as context_id:
-        >>   t1 = torch.rand((3, 3), requires_grad=True)
-        >>   t2 = torch.rand((3, 3), requires_grad=True)
-        >>   loss = rpc.rpc_sync("worker1", torch.add, args=(t1, t2)).sum()
-        >>   dist_autograd.backward(context_id, [loss])
+        >>> import torch.distributed.autograd as dist_autograd
+        >>> with dist_autograd.context() as context_id:
+        >>>   t1 = torch.rand((3, 3), requires_grad=True)
+        >>>   t2 = torch.rand((3, 3), requires_grad=True)
+        >>>   loss = rpc.rpc_sync("worker1", torch.add, args=(t1, t2)).sum()
+        >>>   dist_autograd.backward(context_id, [loss])
     '''
     def __enter__(self):
         self.autograd_context = _new_context()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #34931 Support using self as the destination in rpc.remote for builtin operators
* **#34921 Fix dist autograd context Example block format**
* #34919 Fix example block format in Distributed Optimizer API doc
* #34914 Fix example format in Distributed Autograd doc
* #34890 Minor fixes for RPC API docs
* #34888 Update descriptions for transmitting CUDA tensors
* #34887 Removing experimental tag in for RPC and adding experimental tag for RPC+TorchScript
* #34885 Adding warnings for async Tensor serialization in remote and rpc_async
* #34884 Add a warning for RRef serialization

Differential Revision: [D20500012](https://our.internmc.facebook.com/intern/diff/D20500012)