### PR TITLE
[ONNX] Enable onnx model tests for opset 11

### DIFF
--- a/test/onnx/test_models_onnxruntime.py
+++ b/test/onnx/test_models_onnxruntime.py
@@ -11,9 +11,10 @@ from test_pytorch_onnx_onnxruntime import run_model_test
 
 
 def exportTest(self, model, inputs, rtol=1e-2, atol=1e-7, opset_versions=None):
-    opset_versions = opset_versions if opset_versions else [7, 8, 9, 10]
+    opset_versions = opset_versions if opset_versions else [7, 8, 9, 10, 11]
     for opset_version in opset_versions:
         self.opset_version = opset_version
+        self.keep_initializers_as_inputs = True
         run_model_test(self, model, False,
                        input=inputs, rtol=rtol, atol=atol)
 


### PR DESCRIPTION
Add default value for flag `keep_initializers_as_inputs`. This is required for opset 11 tests.