### PR TITLE
Fixes the Conv2d batch_norm folding for various cases.

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1555,28 +1555,34 @@ graph(%packed_params_module, %a, %a_scale, %a_zero_point, %a_dtype, %r_scale, %r
                 x = self.bn(x)
                 return x
 
-        eager = TestModule()
-        scripted = torch.jit.script(eager)
-        eager.eval()
-        scripted.eval()
-
-        # Check that in the original script module's forward we have two
-        # CallMethod nodes. One of them should be for conv.forward and the other
-        # for bn.forward.
-        FileCheck().check_count("prim::CallMethod[name=\"forward\"]", 2, exactly=True) \
-            .run(str(get_forward(scripted._c).graph))
-
-        # Run FoldConvBatchnorm2d pass.
-        scripted = wrap_cpp_module(torch._C._jit_pass_fold_convbn(scripted._c))
-
-        # Check that after the pass one of the CallMethods is gone (supposedly,
-        # the bn.forward).
-        FileCheck().check_count("prim::CallMethod[name=\"forward\"]", 1, exactly=True) \
-            .run(str(get_forward_graph(scripted._c)))
-
         # Check that the transformation doesn't change numerics
-        x = torch.rand(1, 1, 6, 6)
-        self.assertEqual(eager(x), scripted(x))
+        for tracing_mode in [True, False]:
+            eager = TestModule()
+            if tracing_mode:
+                x = torch.rand(1, 1, 6, 6)
+                scripted_or_traced = torch.jit.trace(eager, x)
+            else:
+                scripted_or_traced = torch.jit.script(eager)
+            eager.eval()
+            scripted_or_traced.eval()
+
+            # Check that in the original script module's forward we have two
+            # CallMethod nodes. One of them should be for conv.forward and the other
+            # for bn.forward.
+            FileCheck().check_count("prim::CallMethod[name=\"forward\"]", 2, exactly=True) \
+                .run(str(get_forward(scripted_or_traced._c).graph))
+
+            # Run FoldConvBatchnorm2d pass.
+            scripted_or_traced = wrap_cpp_module(torch._C._jit_pass_fold_convbn(scripted_or_traced._c))
+
+            # Check that after the pass one of the CallMethods is gone (supposedly,
+            # the bn.forward).
+            FileCheck().check_count("prim::CallMethod[name=\"forward\"]", 1, exactly=True) \
+                .run(str(get_forward_graph(scripted_or_traced._c)))
+
+            # Check that the transformation doesn't change numerics
+            x = torch.rand(1, 1, 6, 6)
+            self.assertEqual(eager(x), scripted_or_traced(x))
 
     def test_foldbn_trivial_nobias(self):
         # Test trivial case
@@ -1594,28 +1600,33 @@ graph(%packed_params_module, %a, %a_scale, %a_zero_point, %a_dtype, %r_scale, %r
                 x = self.bn(x)
                 return x
 
-        eager = TestModule()
-        scripted = torch.jit.script(eager)
-        eager.eval()
-        scripted.eval()
+        for tracing_mode in [True, False]:
+            eager = TestModule()
+            if tracing_mode:
+                x = torch.rand(1, 1, 6, 6)
+                scripted_or_traced = torch.jit.trace(eager, x)
+            else:
+                scripted_or_traced = torch.jit.script(eager)
+            eager.eval()
+            scripted_or_traced.eval()
 
-        # Check that in the original script module's forward we have two
-        # CallMethod nodes. One of them should be for conv.forward and the other
-        # for bn.forward.
-        FileCheck().check_count("prim::CallMethod[name=\"forward\"]", 2, exactly=True) \
-            .run(str(get_forward_graph(scripted._c)))
+            # Check that in the original script module's forward we have two
+            # CallMethod nodes. One of them should be for conv.forward and the other
+            # for bn.forward.
+            FileCheck().check_count("prim::CallMethod[name=\"forward\"]", 2, exactly=True) \
+                .run(str(get_forward_graph(scripted_or_traced._c)))
 
-        # Run FoldConvBatchnorm2d pass.
-        scripted = wrap_cpp_module(torch._C._jit_pass_fold_convbn(scripted._c))
+            # Run FoldConvBatchnorm2d pass.
+            scripted_or_traced = wrap_cpp_module(torch._C._jit_pass_fold_convbn(scripted_or_traced._c))
 
-        # Check that after the pass one of the CallMethods is gone (supposedly,
-        # the bn.forward).
-        FileCheck().check_count("prim::CallMethod[name=\"forward\"]", 1, exactly=True) \
-            .run(str(get_forward_graph(scripted._c)))
+            # Check that after the pass one of the CallMethods is gone (supposedly,
+            # the bn.forward).
+            FileCheck().check_count("prim::CallMethod[name=\"forward\"]", 1, exactly=True) \
+                .run(str(get_forward_graph(scripted_or_traced._c)))
 
-        # Check that the transformation doesn't change numerics
-        x = torch.rand(1, 1, 6, 6)
-        self.assertEqual(eager(x), scripted(x))
+            # Check that the transformation doesn't change numerics
+            x = torch.rand(1, 1, 6, 6)
+            self.assertEqual(eager(x), scripted_or_traced(x))
 
     def test_foldbn_in_submodule(self):
         # Test that we find Conv-BN patterns in submodules
@@ -1639,21 +1650,26 @@ graph(%packed_params_module, %a, %a_scale, %a_zero_point, %a_dtype, %r_scale, %r
                 x = self.sub(x)
                 return x
 
-        eager = TestModule()
-        scripted = torch.jit.script(eager)
-        eager.eval()
-        scripted.eval()
+        for tracing_mode in [True, False]:
+            eager = TestModule()
+            if tracing_mode:
+                x = torch.rand(1, 1, 10, 10)
+                scripted_or_traced = torch.jit.trace(eager, x)
+            else:
+                scripted_or_traced = torch.jit.script(eager)
+            eager.eval()
+            scripted_or_traced.eval()
 
-        FileCheck().check_count("prim::CallMethod[name=\"forward\"]", 2, exactly=True) \
-            .run(str(get_forward_graph(scripted.sub._c)))
+            FileCheck().check_count("prim::CallMethod[name=\"forward\"]", 2, exactly=True) \
+                .run(str(get_forward_graph(scripted_or_traced.sub._c)))
 
-        scripted = wrap_cpp_module(torch._C._jit_pass_fold_convbn(scripted._c))
+            scripted_or_traced = wrap_cpp_module(torch._C._jit_pass_fold_convbn(scripted_or_traced._c))
 
-        FileCheck().check_count("prim::CallMethod[name=\"forward\"]", 1, exactly=True) \
-            .run(str(get_forward_graph(scripted.sub._c)))
+            FileCheck().check_count("prim::CallMethod[name=\"forward\"]", 1, exactly=True) \
+                .run(str(get_forward_graph(scripted_or_traced.sub._c)))
 
-        x = torch.rand(1, 1, 10, 10)
-        self.assertEqual(eager(x), scripted(x))
+            x = torch.rand(1, 1, 10, 10)
+            self.assertEqual(eager(x), scripted_or_traced(x))
 
     def test_foldbn_shared_classtype(self):
         class TestModule(torch.nn.Module):
@@ -1678,14 +1694,124 @@ graph(%packed_params_module, %a, %a_scale, %a_zero_point, %a_dtype, %r_scale, %r
                 x = self.bn2(x)
                 x = self.relu(x)
                 return x
-        for bias in [True, False]:
-            eager = TestModule(bias).eval()
-            scripted = torch.jit.script(eager).copy()
-            torch._C._jit_pass_dedup_module_uses(scripted._c)
 
-            folded = wrap_cpp_module(torch._C._jit_pass_fold_convbn(scripted._c))
-            x = torch.rand(1, 5, 6, 6)
-            self.assertEqual(eager(x), scripted(x))
+        for tracing_mode in [True, False]:
+            for bias in [True, False]:
+                eager = TestModule(bias).eval()
+                if tracing_mode:
+                    x = torch.rand(1, 5, 6, 6)
+                    scripted_or_traced = torch.jit.trace(eager, x).copy()
+                else:
+                    scripted_or_traced = torch.jit.script(eager).copy()
+                torch._C._jit_pass_dedup_module_uses(scripted_or_traced ._c)
+                folded = wrap_cpp_module(torch._C._jit_pass_fold_convbn(scripted_or_traced ._c))
+                x = torch.rand(1, 5, 6, 6)
+                self.assertEqual(eager(x), scripted_or_traced (x))
+
+    def test_foldbn_complex_cases(self):
+        # Test that we find Conv-BN patterns in submodules
+        class SubModule(torch.nn.Module):
+            def __init__(self, num_blocks, enable_bias, enable_affine):
+                super(SubModule, self).__init__()
+                layers = []
+                for i in range(num_blocks):
+                    layers.append(torch.nn.Conv2d(20, 20, 5, 1, bias=enable_bias))
+                    bn_obj = torch.nn.BatchNorm2d(num_features=20, affine=enable_affine)
+                    if enable_affine:
+                        bn_obj.weight = torch.nn.Parameter(torch.rand_like(bn_obj.weight))
+                        bn_obj.bias = torch.nn.Parameter(torch.rand_like(bn_obj.bias))
+                    bn_obj.running_mean = torch.rand_like(bn_obj.running_mean)
+                    bn_obj.running_var = torch.rand_like(bn_obj.running_var)
+                    layers.append(bn_obj)
+                self.layers = nn.Sequential(*layers)
+
+            def forward(self, x):
+                return self.layers(x)
+
+        class TestModule(torch.nn.Module):
+            def __init__(self, num_blocks, enable_bias, enable_affine):
+                super(TestModule, self).__init__()
+                self.sub = SubModule(num_blocks, enable_bias, enable_affine)
+
+            def forward(self, x):
+                x = self.sub(x)
+                return x
+
+        bias_affine_options = itertools.product([True, False], [True, False], [True, False], [1, 2])
+        for (tracing_mode, enable_bias, enable_bn_affine, num_layers) in bias_affine_options:
+            eager = TestModule(num_layers, enable_bias, enable_bn_affine)
+            eager.eval()
+
+            if tracing_mode:
+                x = torch.rand(1, 20, 10, 10)
+                scripted_or_traced = torch.jit.trace(eager, x)
+            else:
+                scripted_or_traced = torch.jit.script(eager)
+            scripted_or_traced.eval()
+
+            FileCheck().check_count("prim::CallMethod[name=\"forward\"]", num_layers * 2, exactly=True) \
+                .run(str(get_forward_graph(scripted_or_traced.sub.layers._c)))
+
+            scripted_or_traced = wrap_cpp_module(torch._C._jit_pass_fold_convbn(scripted_or_traced._c))
+
+            FileCheck().check_count("prim::CallMethod[name=\"forward\"]", num_layers, exactly=True) \
+                .run(str(get_forward_graph(scripted_or_traced.sub.layers._c)))
+
+            x = torch.rand(1, 20, 10, 10)
+            self.assertEqual(eager(x), scripted_or_traced(x))
+
+    def test_nofoldbn_complex_cases(self):
+        # Test that we find Conv-BN patterns in submodules
+        class SubModule(torch.nn.Module):
+            def __init__(self, num_blocks, enable_bias, enable_affine):
+                super(SubModule, self).__init__()
+                layers = []
+                for i in range(num_blocks):
+                    layers.append(torch.nn.Conv2d(20, 20, 5, 1, bias=enable_bias))
+                    layers.append(torch.nn.ReLU())
+                    bn_obj = torch.nn.BatchNorm2d(num_features=20, affine=enable_affine)
+                    if enable_affine:
+                        bn_obj.weight = torch.nn.Parameter(torch.rand_like(bn_obj.weight))
+                        bn_obj.bias = torch.nn.Parameter(torch.rand_like(bn_obj.bias))
+                    bn_obj.running_mean = torch.rand_like(bn_obj.running_mean)
+                    bn_obj.running_var = torch.rand_like(bn_obj.running_var)
+                    layers.append(bn_obj)
+                self.layers = nn.Sequential(*layers)
+
+            def forward(self, x):
+                return self.layers(x)
+
+        class TestModule(torch.nn.Module):
+            def __init__(self, num_blocks, enable_bias, enable_affine):
+                super(TestModule, self).__init__()
+                self.sub = SubModule(num_blocks, enable_bias, enable_affine)
+
+            def forward(self, x):
+                x = self.sub(x)
+                return x
+
+        bias_affine_options = itertools.product([True, False], [True, False], [True, False], [1, 2])
+        for (tracing_mode, enable_bias, enable_bn_affine, num_layers) in bias_affine_options:
+            eager = TestModule(num_layers, enable_bias, enable_bn_affine)
+            eager.eval()
+
+            if tracing_mode:
+                x = torch.rand(1, 20, 10, 10)
+                scripted_or_traced = torch.jit.trace(eager, x)
+            else:
+                scripted_or_traced = torch.jit.script(eager)
+            scripted_or_traced.eval()
+
+            FileCheck().check_count("prim::CallMethod[name=\"forward\"]", num_layers * 3, exactly=True) \
+                .run(str(get_forward_graph(scripted_or_traced.sub.layers._c)))
+
+            scripted_or_traced = wrap_cpp_module(torch._C._jit_pass_fold_convbn(scripted_or_traced._c))
+
+            FileCheck().check_count("prim::CallMethod[name=\"forward\"]", num_layers * 3, exactly=True) \
+                .run(str(get_forward_graph(scripted_or_traced.sub.layers._c)))
+
+            x = torch.rand(1, 20, 10, 10)
+            self.assertEqual(eager(x), scripted_or_traced(x))
 
     def test_fuse_linear(self):
         input_strs = ["""

--- a/torch/csrc/jit/passes/quantization.cpp
+++ b/torch/csrc/jit/passes/quantization.cpp
@@ -1758,22 +1758,83 @@ std::tuple<at::Tensor, at::Tensor> FoldConvBatchNorm2dHelper::
   return std::make_tuple(new_w, new_b);
 }
 
+c10::optional<IValue> extractIValueFromGraph(
+    const script::Module& m,
+    const std::string& aten_op_name,
+    const size_t input_index) {
+  auto graph = m.get_method("forward").graph();
+
+  std::stack<Block*> blocks_to_visit;
+  blocks_to_visit.push(graph->block());
+  while (!blocks_to_visit.empty()) {
+    Block* b = blocks_to_visit.top();
+    blocks_to_visit.pop();
+    for (Node* n : b->nodes()) {
+      if (n->kind() == Symbol::aten(aten_op_name)) {
+        return toIValue(n->input(input_index));
+      }
+    }
+  }
+  return {};
+}
+
 bool FoldConvBatchNorm2dHelper::tryExtractingConvBNParameters(
     Module& conv,
     Module& bn,
     ConvBNParameters& r) {
   if (!hastensor(conv, "weight") || !conv.hasattr("bias") ||
-      !hastensor(bn, "weight") || !hastensor(bn, "bias") ||
-      !hastensor(bn, "running_mean") || !hastensor(bn, "running_var") ||
-      !bn.hasattr("eps")) {
+      !hastensor(bn, "running_mean") || !hastensor(bn, "running_var")) {
     return false;
   }
 
+  static constexpr size_t bn_weight_index = 1;
+  static constexpr size_t bn_bias_index = 2;
+  static constexpr size_t bn_running_mean_index = 3;
+  static constexpr size_t bn_running_var_index  = 4;
+  static constexpr size_t bn_eps_index = 7;
+  static constexpr size_t conv_bias_index = 2;
+
+  std::string bn_op_name("batch_norm");
+
   r.bn_rm = bn.attr("running_mean").toTensor();
   r.bn_rv = bn.attr("running_var").toTensor();
-  r.bn_eps = bn.attr("eps").toDouble();
-  r.bn_w = bn.attr("weight").toTensor();
-  r.bn_b = bn.attr("bias").toTensor();
+  if (bn.hasattr("eps")) {
+    r.bn_eps = bn.attr("eps").toDouble();
+  } else {
+    auto optional_eps = extractIValueFromGraph(bn, bn_op_name, bn_eps_index);
+    if (!optional_eps) {
+      return false;
+    }
+    r.bn_eps = optional_eps.value().toDouble();
+  }
+  r.bn_w = at::ones_like(r.bn_rm);
+  if (bn.hasattr("weight")) {
+    if (!bn.attr("weight").isNone()) {
+      r.bn_w = bn.attr("weight").toTensor();
+    }
+  } else {
+    auto optional_bn_weight = extractIValueFromGraph(bn, bn_op_name, bn_weight_index);
+    if (!optional_bn_weight) {
+      return false;
+    }
+    if (!optional_bn_weight.value().isNone()) {
+      r.bn_w = optional_bn_weight.value().toTensor();
+    }
+  }
+  r.bn_b = at::zeros_like(r.bn_rm);
+  if (bn.hasattr("bias")) {
+    if (!bn.attr("bias").isNone()) {
+      r.bn_b = bn.attr("bias").toTensor();
+    }
+  } else {
+    auto optional_bn_bias = extractIValueFromGraph(bn, bn_op_name, bn_bias_index);
+    if (!optional_bn_bias) {
+      return false;
+    }
+    if (!optional_bn_bias.value().isNone()) {
+      r.bn_w = optional_bn_bias.value().toTensor();
+    }
+  }
 
   r.conv_w = conv.attr("weight").toTensor();
   r.conv_b = at::zeros_like(r.bn_rm);
@@ -1918,6 +1979,57 @@ void FoldConvBatchNorm2dHelper::transform() {
   }
   for (auto n : nodes_to_delete_) {
     n->destroy();
+  }
+}
+
+void replaceConv2dBiasWithGetAttr(Module& module) {
+  auto graph = module.get_method("forward").graph();
+  // Only looks fors _convolution pattern.
+  // Thus assumes that tracing will have always gotten rid of aten::conv2d.
+  // If it did not, BN folding will fail.
+  const PatternInfo& pattern_convolution = PatternInfo::parse_from_str(R"(
+      graph(%a, %w, %b, %stride:int[], %padding:int[], %dilation:int[],
+          %transposed:bool, %output_padding:int[], %groups:int, %benchmark:bool,
+          %deterministic:bool, %cudnn_enabled:bool):
+        %conv_out = aten::_convolution(%a, %w, %b, %stride, %padding, %dilation,
+            %transposed, %output_padding, %groups, %benchmark, %deterministic, %cudnn_enabled)
+        return (%conv_out) )");
+  const Graph& pattern_convolution_graph = *pattern_convolution.pattern_graph;
+  const auto& convolution_vmap = pattern_convolution.vmap;
+
+  const auto& matches = findPatternMatches(pattern_convolution_graph, *graph);
+  for (const auto& match : matches) {
+    // We come here only if the bias was not present in the module.
+    // In that case, the corresponding graph will not have getAttr("bias")
+    // Insert that in the graph.
+    // And change _convolution to take the new value.
+    auto conv_node = match.values_map.at(convolution_vmap.at("conv_out"))->node();
+    WithInsertPoint ins(conv_node);
+    Value* bias_attr_val =
+      graph->insertGetAttr(graph->inputs()[0], "bias")
+          ->setType(TensorType::get());
+    constexpr size_t conv_bias_index = 2;
+    conv_node->replaceInput(conv_bias_index, bias_attr_val);
+  }
+}
+
+void addBiasForConv2dIfNone(Module& module) {
+  auto t = module.type()->expect<ClassType>();
+  auto real_typename = t->name()->qualifiedName();
+  const std::string pattern_name("Conv2d");
+  if (real_typename.size() >= pattern_name.size() &&
+      (0 == real_typename.compare(real_typename.size() - pattern_name.size(),
+                                  pattern_name.size(), pattern_name))) {
+    if (!t->hasAttribute("bias")) {
+      auto optional_tensor_type = OptionalType::create(TensorType::get());
+      t->addAttribute("bias", optional_tensor_type, true);
+      auto optional_tensor = c10::optional<at::Tensor>();
+      module.setattr("bias", optional_tensor);
+      replaceConv2dBiasWithGetAttr(module);
+    }
+  }
+  for (Module m : module.children()) {
+    addBiasForConv2dIfNone(m);
   }
 }
 
@@ -2083,6 +2195,7 @@ void QuantFusion(std::shared_ptr<Graph>& graph) {
 Module FoldConvBatchNorm2d(const Module& module) {
   FoldConvBatchNorm2dHelper h;
   Module m = module.clone();
+  addBiasForConv2dIfNone(m);
   h.analyze(m);
   h.transform();
   return m;

--- a/torch/csrc/jit/passes/quantization.cpp
+++ b/torch/csrc/jit/passes/quantization.cpp
@@ -1761,7 +1761,8 @@ std::tuple<at::Tensor, at::Tensor> FoldConvBatchNorm2dHelper::
 bool extractOptionalBNParams(
     const script::Module& bn,
     ConvBNParameters& r) {
-  auto graph = bn.get_method("forward").graph();
+  auto bn_forward = bn.get_method("forward");
+  auto graph = bn_forward.graph();
   const PatternInfo& pattern_bn = PatternInfo::parse_from_str(R"(
       graph(%a, %weight, %bias, %running_mean, %running_var,
           %training, %momentum, %eps, %cudnn_enabled):


### PR DESCRIPTION
Summary:
This PR adds a preprocessing step in Conv2dBatchNorm folding.
It traverses the module to check if the bias of Conv2d module is set to
None. If it is, it assume that this a traced module and insert
Optional[Tensor] type bias.
Furthermore it insert getAttr for bias in the forward graph and fixes
_convolution op to take values from getAttr.
It also fixes parametere extraction from BN module which may not
have weight and bias attributes if affine was set to False. In scripted
mode such a BN module will get weight and bias attributes set to None.
For the case of eps it gets const propagated in tracing. This is also
fixed.
Few tests cases are added.

Test Plan:
python test/test_jit.py TestJit.test_foldbn_trivial
python test/test_jit.py TestJit.test_foldbn_trivial_nobias
python test/test_jit.py TestJit.test_foldbn_in_submodule
python test/test_jit.py TestJit.test_foldbn_shared_classtype
python test/test_jit.py TestJit.test_foldbn_complex_cases
python test/test_jit.py TestJit.test_foldbn_in_customConv2D

Reviewers:

Subscribers:

Tasks:

Tags:

