### PR TITLE
Fix problem in NHWC max_pool2d; use accumulate type in NHWC max_pool2d

### DIFF
--- a/aten/src/ATen/native/cuda/DilatedMaxPool2d.cu
+++ b/aten/src/ATen/native/cuda/DilatedMaxPool2d.cu
@@ -272,7 +272,7 @@ __global__ void max_pool_backward_nhwc(const int nthreads, const scalar_t* top_d
         int cached_index = threadIdx.x; 
         for (int c = channel_offset; c < channels; c += blockDim.x*kernel_stride_C) {
           ptr_bottom_diff[c] = out_cached[cached_index];
-          out_cached[c] = scalar_t(0.0);
+          out_cached[cached_index] = scalar_t(0.0);
           cached_index += blockDim.x; 
         }
       } else {

--- a/aten/src/ATen/native/cuda/DilatedMaxPool2d.cu
+++ b/aten/src/ATen/native/cuda/DilatedMaxPool2d.cu
@@ -219,7 +219,7 @@ __global__ void max_pool_backward_nhwc(const int nthreads, const scalar_t* top_d
                                     const int kernel_stride_C, const int kernel_size_C, 
                                     scalar_t* bottom_diff) {
   extern __shared__ int smem[];
-  scalar_t *out_cached = reinterpret_cast<scalar_t*>(smem);
+  accscalar_t *out_cached = reinterpret_cast<accscalar_t*>(smem);
 
   int thread_id = threadIdx.x + blockDim.x * (threadIdx.y + blockDim.y * threadIdx.z);
   int block_size = blockDim.x * blockDim.y * blockDim.z;
@@ -229,7 +229,7 @@ __global__ void max_pool_backward_nhwc(const int nthreads, const scalar_t* top_d
   int channel_offset = threadIdx.x + channel_id * blockDim.x; 
 
   for (int i = thread_id; i < kernel_size_C*blockDim.x*blockDim.y*blockDim.z; i+= block_size) {
-    out_cached[i] = scalar_t(0.0);
+    out_cached[i] = accscalar_t(0.0);
   }
 
   __syncthreads();
@@ -262,7 +262,7 @@ __global__ void max_pool_backward_nhwc(const int nthreads, const scalar_t* top_d
             for (int c = channel_offset; c < channels; c += blockDim.x*kernel_stride_C) {
               if (ptr_top_mask[c*out_stride_c] == index_shift) {
                 out_cached[cached_index] += 
-                  scalar_cast<scalar_t>(top_diff[oh * out_stride_h + ow * out_stride_w + c*out_stride_c]);
+                  scalar_cast<accscalar_t>(top_diff[oh * out_stride_h + ow * out_stride_w + c*out_stride_c]);
               }
               cached_index += blockDim.x; 
             }
@@ -271,8 +271,8 @@ __global__ void max_pool_backward_nhwc(const int nthreads, const scalar_t* top_d
         scalar_t *ptr_bottom_diff = bottom_diff + index_shift * channels;
         int cached_index = threadIdx.x; 
         for (int c = channel_offset; c < channels; c += blockDim.x*kernel_stride_C) {
-          ptr_bottom_diff[c] = out_cached[cached_index];
-          out_cached[cached_index] = scalar_t(0.0);
+          ptr_bottom_diff[c] = scalar_cast<scalar_t>(out_cached[cached_index]);
+          out_cached[cached_index] = accscalar_t(0.0);
           cached_index += blockDim.x; 
         }
       } else {
@@ -574,7 +574,7 @@ void max_pool2d_with_indices_backward_out_cuda_template(
                 cuda::ATenCeilDiv(safe_downcast<int, int64_t>(inputHeight), block_z*BLOCK_STRIDE));
             const dim3 grid(grid_x, grid_y, grid_z);
 
-            size_t shmem_size = (kernel_size_C * block_x*block_y*block_z) * sizeof(scalar_t);
+            size_t shmem_size = (kernel_size_C * block_x*block_y*block_z) * sizeof(accscalar_t);
             AT_ASSERT(shmem_size <= at::cuda::getCurrentDeviceProperties()->sharedMemPerBlock); 
 
             // The backward kernel is launched on input instead output. 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9370,12 +9370,12 @@ class TestNNDeviceType(NNTestCase):
     @dtypesIfCUDA(torch.half, torch.float, torch.double)
     def test_max_pool2d_nhwc(self, device, dtype):
         def helper(n, c, h, w, kernel_size, stride=None):
-            if stride == None:
+            if stride is None:
                 stride = kernel_size
             input = torch.randn(n, c, h, w, dtype=dtype, device=device)
             input = input.contiguous(memory_format=torch.channels_last).requires_grad_()
             grad = torch.randn(n, c, (h - kernel_size) // stride + 1, (w - kernel_size) // stride + 1,
-                dtype=dtype, device=device)
+                               dtype=dtype, device=device)
             pool = torch.nn.MaxPool2d(kernel_size, stride).to(device)
 
             ref_input = input.detach().clone().contiguous().requires_grad_(True)
@@ -9394,9 +9394,9 @@ class TestNNDeviceType(NNTestCase):
 
         helper(4, 8, 8, 8, 7)
         helper(200, 512, 28, 28, 2)
-        helper(4, 8, 7, 7, 3, stride = 1)
-        helper(10, 512, 31, 31, 3, stride = 2)
-        helper(1, 129, 8, 8, 3, stride = 2)
+        helper(4, 8, 7, 7, 3, stride=1)
+        helper(10, 512, 31, 31, 3, stride=2)
+        helper(1, 129, 8, 8, 3, stride=2)
 
     def test_embedding_dense_grad(self, device):
         embd = nn.Embedding(20, 20).to(device)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9369,7 +9369,7 @@ class TestNNDeviceType(NNTestCase):
     @onlyCUDA
     @dtypesIfCUDA(torch.half, torch.float, torch.double)
     def test_max_pool2d_nhwc(self, device, dtype):
-        def helper(n, c, h, w, kernel_size, stride = None):
+        def helper(n, c, h, w, kernel_size, stride=None):
             if stride == None:
                 stride = kernel_size
             input = torch.randn(n, c, h, w, dtype=dtype, device=device)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9368,14 +9368,14 @@ class TestNNDeviceType(NNTestCase):
 
     @onlyCUDA
     @dtypesIfCUDA(torch.half, torch.float, torch.double)
-    def test_max_pool2d_nhwc(self, device, dtypes):
+    def test_max_pool2d_nhwc(self, device, dtype):
         def helper(n, c, h, w, kernel_size, stride = None):
             if stride == None:
                 stride = kernel_size
-            input = torch.randn(n, c, h, w, dtype=dtypes, device=device)
+            input = torch.randn(n, c, h, w, dtype=dtype, device=device)
             input = input.contiguous(memory_format=torch.channels_last).requires_grad_()
             grad = torch.randn(n, c, (h - kernel_size) // stride + 1, (w - kernel_size) // stride + 1,
-                dtype=dtypes, device=device)
+                dtype=dtype, device=device)
             pool = torch.nn.MaxPool2d(kernel_size, stride).to(device)
 
             ref_input = input.detach().clone().contiguous().requires_grad_(True)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9366,19 +9366,21 @@ class TestNNDeviceType(NNTestCase):
         test('threshold', 3, 2)
         test('threshold', 3, 2, inplace=True)
 
-    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
+    @onlyCUDA
     @dtypesIfCUDA(torch.half, torch.float, torch.double)
-    @dtypes(torch.float, torch.double)
     def test_max_pool2d_nhwc(self, device, dtypes):
-        def helper(n, c, h, w, kernel_size):
-            input = torch.randn(n, c, h, w, dtype=dtypes, device="cuda")
+        def helper(n, c, h, w, kernel_size, stride = None):
+            if stride == None:
+                stride = kernel_size
+            input = torch.randn(n, c, h, w, dtype=dtypes, device=device)
             input = input.contiguous(memory_format=torch.channels_last).requires_grad_()
-            grad = torch.randn(n, c, h // kernel_size, w // kernel_size, dtype=dtypes, device="cuda")
-            pool = torch.nn.MaxPool2d(kernel_size).cuda()
+            grad = torch.randn(n, c, (h - kernel_size) // stride + 1, (w - kernel_size) // stride + 1,
+                dtype=dtypes, device=device)
+            pool = torch.nn.MaxPool2d(kernel_size, stride).to(device)
 
             ref_input = input.detach().clone().contiguous().requires_grad_(True)
             ref_grad = grad.detach().clone().contiguous()
-            ref_pool = torch.nn.MaxPool2d(kernel_size).cuda()
+            ref_pool = torch.nn.MaxPool2d(kernel_size, stride).to(device)
 
             out = pool(input)
             out.backward(grad)
@@ -9392,6 +9394,9 @@ class TestNNDeviceType(NNTestCase):
 
         helper(4, 8, 8, 8, 7)
         helper(200, 512, 28, 28, 2)
+        helper(4, 8, 7, 7, 3, stride = 1)
+        helper(10, 512, 31, 31, 3, stride = 2)
+        helper(1, 129, 8, 8, 3, stride = 2)
 
     def test_embedding_dense_grad(self, device):
         embd = nn.Embedding(20, 20).to(device)


### PR DESCRIPTION
This PR would fix #34736. Both code snippet in that issue can now execute normally. More tests are also added. 

This PR is a follow-up on #34519, where one variable was mistakenly missed when updating the max_pool2d kernel. 

This PR also uses accumulate type of scalar_t in the backward kernel, which resolves the numerical precision issue when stride < kernel_size on fp16. 

cc @csarofeen @ptrblck @jjsjann123 @VitalyFedyunin @ngimel 