### PR TITLE
[jit] Add lazy script decorator

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -4641,6 +4641,34 @@ def foo(x):
         # shouldn't throw a type error
         torch.jit.script(MyMod())
 
+    @_tmp_donotuse_dont_inline_everything
+    def test_lazy_script(self):
+        def untraceable(x):
+            if x.ndim > 2:
+                print("hello")
+            else:
+                print("goodbye")
+            return x + 2
+
+        # Non-working example
+        def fn(x):
+            return untraceable(x)
+
+        with self.capture_stdout():
+            traced_bad = torch.jit.trace(fn, [torch.ones(2, 2)])
+
+        FileCheck().check_not("goodbye").check_not("hello").run(traced_bad.graph)
+
+        # Working example
+        untraceable = torch.jit._lazy_script_while_tracing(untraceable)
+        def fn2(x):
+            return untraceable(x)
+
+        with self.capture_stdout():
+            traced = torch.jit.trace(fn, [torch.ones(2, 2)])
+
+        FileCheck().check_not("goodbye").check_not("hello").run(traced.graph)
+
     def test_big_int_literals(self):
         def ok():
             # signed 64 bit max

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -4641,7 +4641,7 @@ def foo(x):
         # shouldn't throw a type error
         torch.jit.script(MyMod())
 
-    @_tmp_donotuse_dont_inline_everything
+    @_inline_everything
     def test_lazy_script(self):
         def untraceable(x):
             if x.ndim > 2:
@@ -4660,7 +4660,7 @@ def foo(x):
         FileCheck().check_not("goodbye").check_not("hello").run(traced_bad.graph)
 
         # Working example
-        untraceable = torch.jit._lazy_script_while_tracing(untraceable)
+        untraceable = torch.jit._script_if_tracing(untraceable)
 
         def fn2(x):
             return untraceable(x)
@@ -4668,7 +4668,7 @@ def foo(x):
         with self.capture_stdout():
             traced = torch.jit.trace(fn, [torch.ones(2, 2)])
 
-        FileCheck().check_not("goodbye").check_not("hello").run(traced.graph)
+        FileCheck().check("goodbye").check("hello").run(traced.graph)
 
     def test_big_int_literals(self):
         def ok():

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -4661,6 +4661,7 @@ def foo(x):
 
         # Working example
         untraceable = torch.jit._lazy_script_while_tracing(untraceable)
+
         def fn2(x):
             return untraceable(x)
 

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -734,6 +734,7 @@ void initJITBindings(PyObject* module) {
       return op->schema();
     });
   });
+  m.def("_is_tracing", []() { return jit::tracer::isTracing(); });
 
   struct PythonFutureWrapper {
     explicit PythonFutureWrapper(c10::intrusive_ptr<c10::ivalue::Future> fut)

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -734,7 +734,7 @@ void initJITBindings(PyObject* module) {
       return op->schema();
     });
   });
-  m.def("is_tracing", []() { return jit::tracer::isTracing(); });
+  m.def("_is_tracing", []() { return jit::tracer::isTracing(); });
 
   struct PythonFutureWrapper {
     explicit PythonFutureWrapper(c10::intrusive_ptr<c10::ivalue::Future> fut)

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -734,7 +734,7 @@ void initJITBindings(PyObject* module) {
       return op->schema();
     });
   });
-  m.def("_is_tracing", []() { return jit::tracer::isTracing(); });
+  m.def("is_tracing", []() { return jit::tracer::isTracing(); });
 
   struct PythonFutureWrapper {
     explicit PythonFutureWrapper(c10::intrusive_ptr<c10::ivalue::Future> fut)

--- a/torch/distributions/von_mises.py
+++ b/torch/distributions/von_mises.py
@@ -51,7 +51,7 @@ def _log_modified_bessel_fn(x, order=0):
     return result
 
 
-@torch.jit._lazy_script_while_tracing
+@torch.jit.script
 def _rejection_sample(loc, concentration, proposal_r, x):
     done = torch.zeros(x.shape, dtype=torch.bool, device=loc.device)
     while not done.all():

--- a/torch/distributions/von_mises.py
+++ b/torch/distributions/von_mises.py
@@ -51,7 +51,7 @@ def _log_modified_bessel_fn(x, order=0):
     return result
 
 
-@torch.jit.script
+@torch.jit._lazy_script_while_tracing
 def _rejection_sample(loc, concentration, proposal_r, x):
     done = torch.zeros(x.shape, dtype=torch.bool, device=loc.device)
     while not done.all():

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1322,14 +1322,14 @@ def interface(obj):
     return obj
 
 
-def _lazy_script_while_tracing(fn):
+def _script_if_tracing(fn):
     """
     Compiles ``fn`` when it is first called during tracing. ``torch.jit.script``
     has a non-negligible start up time when it is first called due to
     lazy-initializations of many compiler builtins. Therefore you should not use
     it in library code. However, you may want to have parts of your library work
     in tracing even if they use control flow. In these cases, you should use
-    ``@torch.jit._lazy_script_while_tracing`` to substitute for
+    ``@torch.jit._script_if_tracing`` to substitute for
     ``torch.jit.script``.
     """
     # You can't modify closed-over variables in Python 2, so make this a dict and
@@ -1338,15 +1338,13 @@ def _lazy_script_while_tracing(fn):
 
     @functools.wraps(fn)
     def wrapper(*args):
-        if not torch._C._is_tracing():
+        if not torch._C.is_tracing():
             # Not tracing, don't do anything
             return fn(*args)
 
         if 'fn' not in compiled_fn:
             compiled_fn['fn'] = script(fn, _frames_up=1)
         return compiled_fn['fn'](*args)
-
-    wrapper._torchscript_original_fn = fn
 
     return wrapper
 

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1322,6 +1322,34 @@ def interface(obj):
     return obj
 
 
+def _lazy_script_while_tracing(fn):
+    """
+    Compiles ``fn`` when it is first called during tracing. ``torch.jit.script``
+    has a non-negligible start up time when it is first called due to
+    lazy-initializations of many compiler builtins. Therefore you should not use
+    it in library code. However, you may want to have parts of your library work
+    in tracing even if they use control flow. In these cases, you should use
+    ``@torch.jit._lazy_script_while_tracing`` to substitute for
+    ``torch.jit.script``.
+    """
+    # You can't modify closed-over variables in Python 2, so make this a dict and
+    # mutate it
+    compiled_fn = {}
+
+    @functools.wraps(fn)
+    def wrapper(*args):
+        if not torch._C._is_tracing():
+            # Not tracing, don't do anything
+            return fn(*args)
+
+        if 'fn' not in compiled_fn:
+            compiled_fn['fn'] = script(fn, _frames_up=1)
+        return compiled_fn['fn'](*args)
+
+    wrapper._torchscript_original_fn = fn
+
+    return wrapper
+
 
 def script_method(fn):
     if not _enabled:

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1338,7 +1338,7 @@ def _script_if_tracing(fn):
 
     @functools.wraps(fn)
     def wrapper(*args):
-        if not torch._C.is_tracing():
+        if not is_tracing():
             # Not tracing, don't do anything
             return fn(*args)
 
@@ -1966,6 +1966,14 @@ def is_scripting():
               return unsupported_linear_op(x)
     """
     return False
+
+
+def is_tracing():
+    """
+    Returns ``True`` in tracing (if a function is called during the tracing of
+    code with ``torch.jit.trace``) and ``False`` otherwise.
+    """
+    return torch._C._is_tracing
 
 def _unwrap_optional(x):
     assert x is not None, "Unwrapping null optional"


### PR DESCRIPTION
Stacked PRs
 * #34938 - [jit] Remove stray `@script`
 * **#34935 - [jit] Add lazy script decorator**

Some users maintain libraries of code that is largely trace-able but not
script-able. However, some functions may need to be `@torch.jit.script`ed if
they contain control flow so the tracer will use the compiler version.
This however impacts library start up time as in #33418, so this PR adds
a workaround in the form of a `@torch.jit. _script_if_tracing `
that will only initialize the compiler if the function is called while
actually tracing.

Differential Revision: [D20569778](https://our.internmc.facebook.com/intern/diff/20569778/)