### PR TITLE
Add weight_scale in Adagrad

### DIFF
--- a/caffe2/sgd/weight_scale_op.cc
+++ b/caffe2/sgd/weight_scale_op.cc
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "weight_scale_op.h"
+
+namespace caffe2 {
+
+REGISTER_CPU_OPERATOR(WeightScale, WeightScaleOp<float, CPUContext>);
+OPERATOR_SCHEMA(WeightScale)
+    .NumInputs(2)
+    .NumOutputs(1)
+    .AllowInplace({{0, 0}, {1, 1}})
+    .SetDoc(R"DOC(
+Every `stepsize` iterations, multiply the weights by a constant `scale`:
+    nw = w * scale
+)DOC")
+    .Input(0, "w", "Current weights")
+    .Input(1, "iter", "Training Iteration")
+    .Output(0, "nw", "Updated weights")
+    .Arg("stepsize", "Every iteration number to do weight scaling")
+    .Arg(
+        "upper_bound_iter",
+        "After iter passes this bound, do not perform the weight rescaling")
+    .Arg("scale", "The multiplicative factor applied to weights.");
+
+SHOULD_NOT_DO_GRADIENT(WeightScale);
+} // namespace caffe2

--- a/caffe2/sgd/weight_scale_op.h
+++ b/caffe2/sgd/weight_scale_op.h
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "caffe2/core/operator.h"
+
+#include <stdlib.h>
+#include <time.h>
+
+namespace caffe2 {
+
+template <typename Context>
+void weight_scale_update(
+    int N,
+    const float* w,
+    const float scale,
+    int64_t iter,
+    int64_t stepsize,
+    int64_t update_upper_bound,
+    float* nw,
+    Context* /*context*/) {
+  const auto w_size = N * sizeof(float);
+  if (iter % stepsize != 0 || iter >= update_upper_bound) {
+    memcpy(nw, w, w_size);
+    return;
+  }
+  // perform the weight scaling
+  for (int i = 0; i < N; ++i) {
+    nw[i] = w[i] * scale;
+  }
+}
+
+template <typename T, class Context>
+class WeightScaleOp final : public Operator<Context> {
+ public:
+  USE_OPERATOR_CONTEXT_FUNCTIONS;
+  WeightScaleOp(const OperatorDef& operator_def, Workspace* ws)
+      : Operator<Context>(operator_def, ws),
+        stepsize_(OperatorBase::GetSingleArgument<int64_t>(
+            "stepsize",
+            std::numeric_limits<int64_t>::max())),
+        update_upper_bound_(OperatorBase::GetSingleArgument<int64_t>(
+            "upper_bound_iter",
+            std::numeric_limits<int64_t>::max())),
+        scale_(this->template GetSingleArgument<T>("scale", 1.0f)) {}
+
+  bool RunOnDevice() override {
+    Output(OUTPUT_WEIGHTS)->ResizeLike(Input(WEIGHTS));
+
+    const auto iter =
+        OperatorBase::Input<Tensor>(ITER, CPU).template data<int64_t>()[0] + 1;
+
+    weight_scale_update<Context>(
+        Input(WEIGHTS).size(),
+        Input(WEIGHTS).template data<T>(),
+        scale_,
+        iter,
+        stepsize_,
+        update_upper_bound_,
+        Output(OUTPUT_WEIGHTS)->template mutable_data<T>(),
+        &context_);
+    return true;
+  }
+
+ protected:
+  int64_t stepsize_;
+  int64_t update_upper_bound_;
+  T scale_;
+  INPUT_TAGS(WEIGHTS, ITER);
+  OUTPUT_TAGS(OUTPUT_WEIGHTS);
+};
+} // namespace caffe2


### PR DESCRIPTION
Summary:
Add weight scale operator in caffe2 and in dper2.

Will use it to support multi pass training.

Test Plan: Sample job: f175220929

Differential Revision: D20506032

