### PR TITLE
Also vectorize complex types in fill.

### DIFF
--- a/aten/src/ATen/native/cpu/FillKernel.cpp
+++ b/aten/src/ATen/native/cpu/FillKernel.cpp
@@ -28,15 +28,8 @@ void fill_kernel(TensorIterator& iter, Scalar value_scalar) {
     fill_non_native_type<at::Half>(iter, value_scalar);
   } else if (iter.dtype() == ScalarType::BFloat16) {
     fill_non_native_type<at::BFloat16>(iter, value_scalar);
-  } else if (isComplexType(iter.dtype())) {
-    AT_DISPATCH_COMPLEX_TYPES(iter.dtype(), "fill_cpu", [&]() {
-      scalar_t value = value_scalar.to<scalar_t>();
-      cpu_kernel(
-          iter,
-          [=]() -> scalar_t { return value; });
-    });
   } else {
-    AT_DISPATCH_ALL_TYPES_AND(at::ScalarType::Bool, iter.dtype(), "fill_cpu", [&]() {
+    AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND(at::ScalarType::Bool, iter.dtype(), "fill_cpu", [&]() {
       scalar_t value = value_scalar.to<scalar_t>();
       cpu_kernel_vec(
           iter,


### PR DESCRIPTION
Given that complex types have also been vectorized, there is no need to
handle complex types differently in fill.

