### PR TITLE
[nomnigraph] Copy device option when customize the op conversion

### DIFF
--- a/caffe2/opt/converter.cc
+++ b/caffe2/opt/converter.cc
@@ -96,6 +96,19 @@ OperatorDef Converter::convertToOperatorDef(
   return op;
 }
 
+DeviceOption Converter::getDeviceOption(
+    const nom::repr::NeuralNetOperator* nnOp) const {
+  auto* annotation = nnOp->getAnnotation();
+  // Default to using the stored operator.
+  if (annotation && isa<Caffe2Annotation>(annotation)) {
+    return dyn_cast<Caffe2Annotation>(annotation)
+        ->getOperatorDef()
+        .device_option();
+  }
+  caffe2::DeviceOption opt;
+  return opt;
+}
+
 std::vector<int> getKernelShape(
     std::map<std::string, caffe2::Argument> argMap) {
   // There are literally three ways to define shapes in Conv in Caffe2

--- a/caffe2/opt/converter.h
+++ b/caffe2/opt/converter.h
@@ -29,11 +29,13 @@ CAFFE2_API caffe2::NetDef convertToCaffe2Proto(nom::repr::NNModule&);
 // Pass in an oldNet to copy all the attributes of that network.
 // Be warned that transformations that modify the graph's inputs or outputs
 // are not reflected in changes to external_input or external_output.
-CAFFE2_API caffe2::NetDef convertToCaffe2Proto(nom::repr::NNModule&, const caffe2::NetDef& oldNet);
+CAFFE2_API caffe2::NetDef convertToCaffe2Proto(
+    nom::repr::NNModule&,
+    const caffe2::NetDef& oldNet);
 
 // Use these functions instead of the registry directly.
-CAFFE2_API std::unique_ptr<nom::repr::NeuralNetOperator> convertToNeuralNetOperator(
-    const caffe2::OperatorDef& op);
+CAFFE2_API std::unique_ptr<nom::repr::NeuralNetOperator>
+convertToNeuralNetOperator(const caffe2::OperatorDef& op);
 
 CAFFE2_API caffe2::OperatorDef convertToOperatorDef(
     const nom::repr::NNGraph::NodeRef& instrNode);
@@ -52,6 +54,10 @@ class CAFFE2_API Converter {
       caffe2::OperatorDef op);
 
   virtual ~Converter() {}
+
+ protected:
+  caffe2::DeviceOption getDeviceOption(
+      const nom::repr::NeuralNetOperator* nnOp) const;
 };
 
 C10_DECLARE_REGISTRY(ConverterRegistry, Converter);
@@ -68,6 +74,5 @@ C10_DECLARE_REGISTRY(ConverterRegistry, Converter);
   };
 
 } // namespace caffe2
-
 
 #endif // CAFFE2_OPT_CONVERTER_H

--- a/caffe2/opt/converter_nomigraph_test.cc
+++ b/caffe2/opt/converter_nomigraph_test.cc
@@ -35,6 +35,16 @@ TEST(Converter, UnknownType) {
   auto new_netdef = caffe2::convertToCaffe2Proto(nn);
 }
 
+TEST(Converter, SpecializeConverter) {
+  using namespace caffe2::testing;
+  caffe2::NetDef net;
+  NetMutator(&net).newOp("Slice", {"X"}, {"X"}).setDeviceOptionName("abc");
+  EXPECT_EQ(net.op(0).device_option().node_name(), "abc");
+  auto nn = caffe2::convertToNNModule(net);
+  auto new_netdef = caffe2::convertToCaffe2Proto(nn);
+  EXPECT_EQ(new_netdef.op(0).device_option().node_name(), "abc");
+}
+
 caffe2::NetDef fakeNet() {
   using namespace caffe2::testing;
   caffe2::NetDef net;

--- a/caffe2/opt/custom/converter.cc
+++ b/caffe2/opt/custom/converter.cc
@@ -152,6 +152,7 @@ class ConcatAddMulReplaceNaNClipConverter : public Converter {
     auto max_arg = op.add_arg();
     max_arg->set_name("clip_max");
     max_arg->set_f(cc_amrc->getClipMax());
+    op.mutable_device_option()->CopyFrom(getDeviceOption(nnOp));
     return op;
   }
   ~ConcatAddMulReplaceNaNClipConverter() override {}
@@ -186,6 +187,7 @@ class SliceConverter : public Converter {
         caffe2::MakeArgument<vector<int64_t>>("starts", slice->getStarts()));
     op.add_arg()->CopyFrom(
         caffe2::MakeArgument<vector<int64_t>>("ends", slice->getEnds()));
+    op.mutable_device_option()->CopyFrom(getDeviceOption(nnOp));
     return op;
   }
 
@@ -236,6 +238,7 @@ class ClipRangesGatherSigridHashConverter : public Converter {
         "max_values", fuse->getMaxValues()));
     op.add_arg()->CopyFrom(caffe2::MakeArgument<bool>(
         "hash_into_int32", fuse->getHashIntoInt32()));
+    op.mutable_device_option()->CopyFrom(getDeviceOption(nnOp));
     return op;
   }
 
@@ -263,6 +266,7 @@ class ClipRangesConverter : public Converter {
     op.set_type("ClipRanges");
     op.add_arg()->CopyFrom(caffe2::MakeArgument<int64_t>(
         "max_length", clipRanges->getMaxLength()));
+    op.mutable_device_option()->CopyFrom(getDeviceOption(nnOp));
     return op;
   }
 
@@ -291,6 +295,7 @@ class SigridHashConverter : public Converter {
         caffe2::MakeArgument<int64_t>("salt", sigridHash->getSalt()));
     op.add_arg()->CopyFrom(
         caffe2::MakeArgument<int64_t>("maxValue", sigridHash->getMaxValue()));
+    op.mutable_device_option()->CopyFrom(getDeviceOption(nnOp));
     return op;
   }
 

--- a/caffe2/opt/onnxifi_transformer.h
+++ b/caffe2/opt/onnxifi_transformer.h
@@ -113,6 +113,12 @@ class CAFFE2_API OnnxifiTransformer final : public BackendTransformerBase {
       const ShapeInfoMap& shape_hints,
       std::unordered_set<int>* blacklisted_ops) const;
 
+  // For net with partitioning info, blacklist ops that are supposed to run on
+  // CPU, whose partition info will contain empty device_id list.
+  void blacklistCpuPartition(
+      const NetDef& net,
+      std::unordered_set<int>* blacklisted_ops) const;
+
   // Rule based filtering
   void applyFilteringRules(
       const NetDef& net,

--- a/caffe2/opt/onnxifi_transformer.h
+++ b/caffe2/opt/onnxifi_transformer.h
@@ -122,6 +122,9 @@ class CAFFE2_API OnnxifiTransformer final : public BackendTransformerBase {
   // Determine backend id
   void getBackendId();
 
+  // Extract partition info from the original net
+  void extractPartitionInfo(const NetDef& net);
+
   // Options
   OnnxifiTransformerOptions opts_;
 
@@ -145,5 +148,8 @@ class CAFFE2_API OnnxifiTransformer final : public BackendTransformerBase {
 
   // A cache for ONNX shape hints
   std::unordered_map<std::string, TensorShape> shape_hints_onnx_;
+
+  // Partition info
+  std::vector<PartitionInfo> partition_infos_;
 };
 } // namespace caffe2


### PR DESCRIPTION
Summary: Previously, we are dropping the original device option info when we override the operator conversion function.

Test Plan:
```
buck test caffe2/caffe2/opt:converter_nomigraph_test
```

Reviewed By: ipiszy

Differential Revision: D20507277

