### PR TITLE
Don't change global executor state in test_jit.py - rather do that in setUp and tearDown.

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -160,13 +160,6 @@ def doAutodiffCheck(testname):
         return False
     return True
 
-torch._C._jit_set_profiling_executor(GRAPH_EXECUTOR != ProfilingMode.LEGACY)
-# even though FULL_PROFILER should be our default
-# we haven't tested every single test in this file
-# but we enable FULL_PROFILER for a large subset
-# of the tests with "with enable_profiling_mode"
-torch._C._jit_set_profiling_mode(False)
-
 def LSTMCell(input, hidden, w_ih, w_hh, b_ih=None, b_hh=None):
     hx, cx = hidden
     gates = F.linear(input, w_ih, b_ih) + F.linear(hx, w_hh, b_hh)
@@ -303,6 +296,20 @@ class FooToPickle(torch.nn.Module):  # noqa T484
         self.bar = torch.jit.ScriptModule()
 
 class TestJit(JitTestCase):
+    def setUp(self):
+        super(JitTestCase, self).setUp()
+        self.old_prof_exec_state = torch._C._jit_set_profiling_executor(GRAPH_EXECUTOR != ProfilingMode.LEGACY)
+        # even though FULL_PROFILER should be our default
+        # we haven't tested every single test in this file
+        # but we enable FULL_PROFILER for a large subset
+        # of the tests with "with enable_profiling_mode"
+        self.old_prof_mode_state = torch._C._jit_set_profiling_mode(False)
+
+    def tearDown(self):
+        super(JitTestCase, self).tearDown()
+        torch._C._jit_set_profiling_executor(self.old_prof_exec_state)
+        torch._C._jit_set_profiling_mode(self.old_prof_mode_state)
+
     @unittest.skipIf(not RUN_CUDA, "requires CUDA")
     def test_large_nbr_kernel_args(self):
         class Recurrence(nn.Module):
@@ -4332,6 +4339,20 @@ class TestFrontend(JitTestCase):
 
 
 class TestScript(JitTestCase):
+    def setUp(self):
+        super(JitTestCase, self).setUp()
+        self.old_prof_exec_state = torch._C._jit_set_profiling_executor(GRAPH_EXECUTOR != ProfilingMode.LEGACY)
+        # even though FULL_PROFILER should be our default
+        # we haven't tested every single test in this file
+        # but we enable FULL_PROFILER for a large subset
+        # of the tests with "with enable_profiling_mode"
+        self.old_prof_mode_state = torch._C._jit_set_profiling_mode(False)
+
+    def tearDown(self):
+        super(JitTestCase, self).tearDown()
+        torch._C._jit_set_profiling_executor(self.old_prof_exec_state)
+        torch._C._jit_set_profiling_mode(self.old_prof_mode_state)
+
     def test_inlined_graph(self):
         """
         Check that the `inlined_graph` property correctly returns an inlined
@@ -18266,14 +18287,56 @@ def check_against_reference(self, func, reference_func, args, kwargs=None,
             self.assertTrue(torch.allclose(g2, g2_test, atol=5e-4, rtol=1e-4))
 
 class TestJitGeneratedAutograd(JitTestCase):
+    def setUp(self):
+        super(JitTestCase, self).setUp()
+        self.old_prof_exec_state = torch._C._jit_set_profiling_executor(GRAPH_EXECUTOR != ProfilingMode.LEGACY)
+        # even though FULL_PROFILER should be our default
+        # we haven't tested every single test in this file
+        # but we enable FULL_PROFILER for a large subset
+        # of the tests with "with enable_profiling_mode"
+        self.old_prof_mode_state = torch._C._jit_set_profiling_mode(False)
+
+    def tearDown(self):
+        super(JitTestCase, self).tearDown()
+        torch._C._jit_set_profiling_executor(self.old_prof_exec_state)
+        torch._C._jit_set_profiling_mode(self.old_prof_mode_state)
+
     pass
 
 
 class TestJitGeneratedModule(JitTestCase):
+    def setUp(self):
+        super(JitTestCase, self).setUp()
+        self.old_prof_exec_state = torch._C._jit_set_profiling_executor(GRAPH_EXECUTOR != ProfilingMode.LEGACY)
+        # even though FULL_PROFILER should be our default
+        # we haven't tested every single test in this file
+        # but we enable FULL_PROFILER for a large subset
+        # of the tests with "with enable_profiling_mode"
+        self.old_prof_mode_state = torch._C._jit_set_profiling_mode(False)
+
+    def tearDown(self):
+        super(JitTestCase, self).tearDown()
+        torch._C._jit_set_profiling_executor(self.old_prof_exec_state)
+        torch._C._jit_set_profiling_mode(self.old_prof_mode_state)
+
     pass
 
 
 class TestJitGeneratedFunctional(JitTestCase):
+    def setUp(self):
+        super(JitTestCase, self).setUp()
+        self.old_prof_exec_state = torch._C._jit_set_profiling_executor(GRAPH_EXECUTOR != ProfilingMode.LEGACY)
+        # even though FULL_PROFILER should be our default
+        # we haven't tested every single test in this file
+        # but we enable FULL_PROFILER for a large subset
+        # of the tests with "with enable_profiling_mode"
+        self.old_prof_mode_state = torch._C._jit_set_profiling_mode(False)
+
+    def tearDown(self):
+        super(JitTestCase, self).tearDown()
+        torch._C._jit_set_profiling_executor(self.old_prof_exec_state)
+        torch._C._jit_set_profiling_mode(self.old_prof_mode_state)
+
     pass
 
 

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -126,6 +126,16 @@ if args.ge_config == 'legacy':
 elif args.ge_config == 'simple':
     GRAPH_EXECUTOR = ProfilingMode.SIMPLE
 
+if GRAPH_EXECUTOR == ProfilingMode.PROFILING:
+    torch._C._jit_set_profiling_executor(True)
+    torch._C._jit_set_profiling_mode(True)
+if GRAPH_EXECUTOR == ProfilingMode.SIMPLE:
+    torch._C._jit_set_profiling_executor(True)
+    torch._C._jit_set_profiling_mode(False)
+if GRAPH_EXECUTOR == ProfilingMode.LEGACY:
+    torch._C._jit_set_profiling_executor(False)
+
+
 TEST_BAILOUTS = args.test_bailouts
 TEST_IN_SUBPROCESS = args.subprocess
 SEED = args.seed


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #34983 Refactor test_jit_fuser legacy tests.
* **#34982 Don't change global executor state in test_jit.py - rather do that in setUp and tearDown.**
* #34981 Query graph executor mode in test fixture rather than relying on a global variable.
* #34980 Fix warnings in test/test_jit_fuser.py



Differential Revision: [D20520370](https://our.internmc.facebook.com/intern/diff/D20520370)