### PR TITLE
Refactor test_jit_fuser legacy tests.

### DIFF
--- a/test/test_jit_fuser.py
+++ b/test/test_jit_fuser.py
@@ -9,7 +9,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch.testing import FileCheck
 
-from torch.testing._internal.common_utils import run_tests, IS_SANDCASTLE, ProfilingMode, GRAPH_EXECUTOR, \
+from torch.testing._internal.common_utils import run_tests, IS_SANDCASTLE, ProfilingMode, \
     enable_profiling_mode, graph_executor_mode
 from textwrap import dedent
 from itertools import product, permutations
@@ -17,11 +17,6 @@ from itertools import product, permutations
 from test_jit import JitTestCase, enable_cpu_fuser, RUN_CUDA, RUN_CUDA_HALF, RUN_CUDA_MULTI_GPU, \
     backward_graph, all_backward_graphs, get_lstm_inputs, get_milstm_inputs, \
     LSTMCellC, LSTMCellF, LSTMCellS, MiLSTMCell, _inline_everything
-
-if GRAPH_EXECUTOR == ProfilingMode.PROFILING:
-    torch._C._jit_set_profiling_executor(True)
-    torch._C._jit_set_profiling_mode(True)
-
 
 def strip_profiling_nodes(nodes):
     profiling_opcodes = set(['prim::BailoutTemplate', 'prim::BailOut'])

--- a/test/test_jit_fuser_legacy.py
+++ b/test/test_jit_fuser_legacy.py
@@ -5,33 +5,10 @@ from __future__ import unicode_literals
 
 import unittest
 import torch
-import torch.nn as nn
-import torch.nn.functional as F
-from torch.testing import FileCheck
 
-from torch.testing._internal.common_utils import run_tests, IS_SANDCASTLE, ProfilingMode, GRAPH_EXECUTOR, \
-    enable_profiling_mode, graph_executor_mode
-from textwrap import dedent
-from itertools import product, permutations
+from torch.testing._internal.common_utils import run_tests, ProfilingMode, graph_executor_mode
 
-from test_jit import JitTestCase, enable_cpu_fuser, RUN_CUDA, RUN_CUDA_HALF, RUN_CUDA_MULTI_GPU, \
-    backward_graph, all_backward_graphs, get_lstm_inputs, get_milstm_inputs, \
-    LSTMCellC, LSTMCellF, LSTMCellS, MiLSTMCell, _inline_everything
 import test_jit_fuser
-
-class TestFuserProfiling(test_jit_fuser.TestFuser):
-    def setUp(self):
-        super(test_jit_fuser.TestFuser, self).setUp()
-        self.old_prof_exec_state = torch._C._jit_set_profiling_executor(True)
-        self.old_prof_mode_state = torch._C._jit_set_profiling_mode(True)
-
-    def tearDown(self):
-        super(test_jit_fuser.TestFuser, self).tearDown()
-        torch._C._jit_set_profiling_executor(self.old_prof_exec_state)
-        torch._C._jit_set_profiling_mode(self.old_prof_mode_state)
-    def test_graph_executor_mode(self):
-        assert(graph_executor_mode() == ProfilingMode.PROFILING)
-
 
 class TestFuserLegacy(test_jit_fuser.TestFuser):
     def setUp(self):

--- a/test/test_jit_fuser_legacy.py
+++ b/test/test_jit_fuser_legacy.py
@@ -1,6 +1,47 @@
-import sys
-sys.argv.append("--ge_config=legacy")
-from test_jit_fuser import *
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import unittest
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.testing import FileCheck
+
+from torch.testing._internal.common_utils import run_tests, IS_SANDCASTLE, ProfilingMode, GRAPH_EXECUTOR, \
+    enable_profiling_mode, graph_executor_mode
+from textwrap import dedent
+from itertools import product, permutations
+
+from test_jit import JitTestCase, enable_cpu_fuser, RUN_CUDA, RUN_CUDA_HALF, RUN_CUDA_MULTI_GPU, \
+    backward_graph, all_backward_graphs, get_lstm_inputs, get_milstm_inputs, \
+    LSTMCellC, LSTMCellF, LSTMCellS, MiLSTMCell, _inline_everything
+import test_jit_fuser
+
+class TestFuserProfiling(test_jit_fuser.TestFuser):
+    def setUp(self):
+        super(test_jit_fuser.TestFuser, self).setUp()
+        self.old_prof_exec_state = torch._C._jit_set_profiling_executor(True)
+        self.old_prof_mode_state = torch._C._jit_set_profiling_mode(True)
+
+    def tearDown(self):
+        super(test_jit_fuser.TestFuser, self).tearDown()
+        torch._C._jit_set_profiling_executor(self.old_prof_exec_state)
+        torch._C._jit_set_profiling_mode(self.old_prof_mode_state)
+    def test_graph_executor_mode(self):
+        assert(graph_executor_mode() == ProfilingMode.PROFILING)
+
+
+class TestFuserLegacy(test_jit_fuser.TestFuser):
+    def setUp(self):
+        super(test_jit_fuser.TestFuser, self).setUp()
+        self.old_prof_exec_state = torch._C._jit_set_profiling_executor(False)
+    def tearDown(self):
+        super(test_jit_fuser.TestFuser, self).tearDown()
+        torch._C._jit_set_profiling_executor(self.old_prof_exec_state)
+    def test_graph_executor_mode(self):
+        assert(graph_executor_mode() == ProfilingMode.LEGACY)
 
 if __name__ == '__main__':
     run_tests()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#34983 Refactor test_jit_fuser legacy tests.**
* #34982 Don't change global executor state in test_jit.py - rather do that in setUp and tearDown.
* #34981 Query graph executor mode in test fixture rather than relying on a global variable.
* #34980 Fix warnings in test/test_jit_fuser.py

Previously we relied on global setting to specify, which executor to
use. However, it didn't work as we expected, which can be demonstrated
by the difference between the following two test runs:
```
 # Run in the standard order
 > pytest test/test_jit_fuser.py test/test_jit_fuser_legacy.py

test/test_jit_fuser.py ..................ss..sss.s.....s.............
test/test_jit_fuser_legacy.py ..................ss..sss.sF....s.............

 # Run in the reversed order
 > pytest test/test_jit_fuser_legacy.py test/test_jit_fuser.py

test/test_jit_fuser_legacy.py ............F.....s....ss.......s...FF........
test/test_jit_fuser.py ............F.....s....ss..F....s...FF........
```

This PR actually makes the tests run with the desired executor and
disables tests that happen to be failing.

With this change:
```
 # Run in the standard order
 > pytest test/test_jit_fuser.py test/test_jit_fuser_legacy.py

test/test_jit_fuser.py ..................ss..sss.s.....s.............
test/test_jit_fuser_legacy.py ..................s...ssssss....s...ss........

 # Run in the reversed order
 > pytest test/test_jit_fuser_legacy.py test/test_jit_fuser.py

test/test_jit_fuser_legacy.py ..................s...ssssss....s...ss........
test/test_jit_fuser.py ..................ss..sss.s.....s.............
```

Differential Revision: [D20520367](https://our.internmc.facebook.com/intern/diff/D20520367)