### PR TITLE
[RPC] Add to confirmed users immediately if the fork is shared from owner, instead of adding nothing to pending users

### DIFF
--- a/torch/csrc/distributed/rpc/rref_context.cpp
+++ b/torch/csrc/distributed/rpc/rref_context.cpp
@@ -510,7 +510,7 @@ void RRefContext::addConfirmedUser(
     const ForkId& forkId,
     const c10::intrusive_ptr<RRef>& rref) {
   // Notice, caller need to hold the mutex for confirmedUsers_.
-  std::lock_guard<std::mutex> lock(mutex_);
+  // std::lock_guard<std::mutex> lock(mutex_);
   confirmedUsers_.emplace(
       std::piecewise_construct,
       std::forward_as_tuple(forkId),

--- a/torch/csrc/distributed/rpc/rref_context.h
+++ b/torch/csrc/distributed/rpc/rref_context.h
@@ -147,6 +147,9 @@ class TORCH_API RRefContext {
       const ForkId& forkId,
       const c10::intrusive_ptr<RRef>& rref);
   void delPendingUser(const ForkId& forkId);
+  void addConfirmedUser(
+      const ForkId& forkId,
+      const c10::intrusive_ptr<RRef>& rref);
 
   // Start recroding new pending UserRRefs. All pending UserRRefs introduced
   // after this point will be put into the thread_local userTable_, which will


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#34988 [RPC] Add to confirmed users immediately if the fork is shared from owner, instead of adding nothing to pending users**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D7735909/)

In https://github.com/pytorch/pytorch/pull/31893, we introduced a confirmedUsers_ map in RRefContext.

For the case that the fork is shared from the owner,  there is no `pendingUsers_` intermediate phase for this fork, we should put this fork into `confirmedUsers_` immediately.

Differential Revision: [D7735909](https://our.internmc.facebook.com/intern/diff/D7735909/)