### PR TITLE
[Onnxifi] Blacklist ops in the partitions that are supposed to run on CPU

### DIFF
--- a/caffe2/opt/onnxifi_transformer.h
+++ b/caffe2/opt/onnxifi_transformer.h
@@ -113,6 +113,12 @@ class CAFFE2_API OnnxifiTransformer final : public BackendTransformerBase {
       const ShapeInfoMap& shape_hints,
       std::unordered_set<int>* blacklisted_ops) const;
 
+  // For net with partitioning info, blacklist ops that are supposed to run on
+  // CPU, whose partition info will contain empty device_id list.
+  void blacklistCpuPartition(
+      const NetDef& net,
+      std::unordered_set<int>* blacklisted_ops) const;
+
   // Rule based filtering
   void applyFilteringRules(
       const NetDef& net,

--- a/caffe2/opt/onnxifi_transformer.h
+++ b/caffe2/opt/onnxifi_transformer.h
@@ -122,6 +122,9 @@ class CAFFE2_API OnnxifiTransformer final : public BackendTransformerBase {
   // Determine backend id
   void getBackendId();
 
+  // Extract partition info from the original net
+  void extractPartitionInfo(const NetDef& net);
+
   // Options
   OnnxifiTransformerOptions opts_;
 
@@ -145,5 +148,8 @@ class CAFFE2_API OnnxifiTransformer final : public BackendTransformerBase {
 
   // A cache for ONNX shape hints
   std::unordered_map<std::string, TensorShape> shape_hints_onnx_;
+
+  // Partition info
+  std::vector<PartitionInfo> partition_infos_;
 };
 } // namespace caffe2


### PR DESCRIPTION
Summary:
The definition for the partition to be run on CPU is that it will contain an empty device_id list. We chose this over an op with no partitioning info because
1. Backward compatible with models that don't have partitioning info
2. Being explicit can flush out issues in earlier stage.

Test Plan:
```
LD_LIBRARY_PATH=third-party-buck/platform007/build/fb-nnpi/lib ./sigrid/predictor/tests/scripts/launch_ads_test_predictor.sh -g --nnpi --force_models=175742819_0 --sigrid_force_model_dir=$HOME/models/ --smc_server_port=7447 --glow-num-devices=1 --glow_interpreter_memory=$((256<<20)) --caffe2_fbgemm_fake_fp16_clamp --glow_global_fp16 --glow_clip_fp16 --glow_global_fused_scale_offset_fp16 --fbgemm_deserialize_to_original_format --caffe2_dump_input_of_type=Onnxifi --caffe2_logging_print_tensor --caffe2_predictor_use_memonger=no --onnxifi_debug_mode=true --caffe2_dump_input_with_recordio --caffe2_predictor_onnxifi_max_batch_size=32 --caffe2_predictor_onnxifi_max_seq_size=9600  --glow_onnxifi_backend=Interpreter  --onnxifi_blacklist_ops=SparseLengthsSum,SparseLengthsWeightedSum --glow_dump_graph
```

Now it hits a new error.

Reviewed By: ipiszy

Differential Revision: D20503167

