### PR TITLE
Add promotion pipeline for S3 and conda artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -326,6 +326,20 @@ binary_mac_params: &binary_mac_params
   environment:
     BUILD_ENVIRONMENT: << parameters.build_environment >>
 
+
+promote_common: &promote_common
+  docker:
+    - image: pytorch/release
+  parameters:
+    package_name:
+      description: "package name to promote"
+      type: string
+      default: ""
+  environment:
+    PACKAGE_NAME: << parameters.package_name >>
+    ANACONDA_API_TOKEN: ${CONDA_PYTORCHBOT_TOKEN}
+    AWS_ACCESS_KEY_ID: ${PYTORCH_BINARY_AWS_ACCESS_KEY_ID}
+    AWS_SECRET_ACCESS_KEY: ${PYTORCH_BINARY_AWS_SECRET_ACCESS_KEY}
 ##############################################################################
 # Job specs
 ##############################################################################
@@ -1527,6 +1541,24 @@ jobs:
             cd ${PROJ_ROOT}/ios/TestApp
             instruments -s -devices
             fastlane scan
+
+  promote_s3:
+    <<: *promote_common
+    steps:
+      - checkout
+      - run:
+          name: Running promote script
+          command: |
+            scripts/release/promote/wheel_to_s3.sh
+
+  promote_conda:
+    <<: *promote_common
+    steps:
+      - checkout
+      - run:
+          name: Running promote script
+          command: |
+            scripts/release/promote/conda_to_conda.sh
 
   # update_s3_htmls job
   # These jobs create html files for every cpu/cu## folder in s3. The html
@@ -6958,3 +6990,49 @@ workflows:
       - docker_hub_index_job
 
 
+  # Promotion workflow
+  promote:
+    jobs:
+      # Requires manual approval by someone in org-member
+      # CircleCI security context
+      - promote_approval:
+          context: org-member
+          type: approval
+          filters:
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*/
+            branches:
+                ignore: /.*/
+      - promote_s3:
+          context: org-member
+          name: promote_s3_libtorch
+          package_name: libtorch
+          requires:
+            - promote_approval
+          filters:
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*/
+            branches:
+                ignore: /.*/
+      - promote_s3:
+          context: org-member
+          name: promote_s3_torch
+          package_name: torch
+          requires:
+            - promote_approval
+          filters:
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*/
+            branches:
+                ignore: /.*/
+      - promote_conda:
+          context: org-member
+          name: promote_conda_pytorch
+          package_name: pytorch
+          requires:
+            - promote_approval
+          filters:
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*/
+            branches:
+                ignore: /.*/

--- a/.circleci/generate_config_yml.py
+++ b/.circleci/generate_config_yml.py
@@ -80,12 +80,14 @@ YAML_SOURCES = [
     File("pytorch-build-params.yml"),
     File("caffe2-build-params.yml"),
     File("binary-build-params.yml"),
+    File("promote-build-params.yml"),
     Header("Job specs"),
     File("pytorch-job-specs.yml"),
     File("caffe2-job-specs.yml"),
     File("binary-job-specs.yml"),
     File("job-specs-setup.yml"),
     File("job-specs-custom.yml"),
+    File("job-specs-promote.yml"),
     File("binary_update_htmls.yml"),
     File("binary-build-tests.yml"),
     File("docker_jobs.yml"),
@@ -112,6 +114,7 @@ YAML_SOURCES = [
     File("workflows-s3-html.yml"),
     File("workflows-docker-builder.yml"),
     File("workflows-ecr-gc.yml"),
+    File("workflows-promote.yml")
 ]
 
 

--- a/.circleci/verbatim-sources/job-specs-promote.yml
+++ b/.circleci/verbatim-sources/job-specs-promote.yml
@@ -1,0 +1,18 @@
+
+  promote_s3:
+    <<: *promote_common
+    steps:
+      - checkout
+      - run:
+          name: Running promote script
+          command: |
+            scripts/release/promote/wheel_to_s3.sh
+
+  promote_conda:
+    <<: *promote_common
+    steps:
+      - checkout
+      - run:
+          name: Running promote script
+          command: |
+            scripts/release/promote/conda_to_conda.sh

--- a/.circleci/verbatim-sources/promote-build-params.yml
+++ b/.circleci/verbatim-sources/promote-build-params.yml
@@ -1,0 +1,14 @@
+
+promote_common: &promote_common
+  docker:
+    - image: pytorch/release
+  parameters:
+    package_name:
+      description: "package name to promote"
+      type: string
+      default: ""
+  environment:
+    PACKAGE_NAME: << parameters.package_name >>
+    ANACONDA_API_TOKEN: ${CONDA_PYTORCHBOT_TOKEN}
+    AWS_ACCESS_KEY_ID: ${PYTORCH_BINARY_AWS_ACCESS_KEY_ID}
+    AWS_SECRET_ACCESS_KEY: ${PYTORCH_BINARY_AWS_SECRET_ACCESS_KEY}

--- a/.circleci/verbatim-sources/workflows-promote.yml
+++ b/.circleci/verbatim-sources/workflows-promote.yml
@@ -1,0 +1,46 @@
+  # Promotion workflow
+  promote:
+    jobs:
+      # Requires manual approval by someone in org-member
+      # CircleCI security context
+      - promote_approval:
+          context: org-member
+          type: approval
+          filters:
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*/
+            branches:
+                ignore: /.*/
+      - promote_s3:
+          context: org-member
+          name: promote_s3_libtorch
+          package_name: libtorch
+          requires:
+            - promote_approval
+          filters:
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*/
+            branches:
+                ignore: /.*/
+      - promote_s3:
+          context: org-member
+          name: promote_s3_torch
+          package_name: torch
+          requires:
+            - promote_approval
+          filters:
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*/
+            branches:
+                ignore: /.*/
+      - promote_conda:
+          context: org-member
+          name: promote_conda_pytorch
+          package_name: pytorch
+          requires:
+            - promote_approval
+          filters:
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*/
+            branches:
+                ignore: /.*/

--- a/scripts/release/promote/conda_to_conda.sh
+++ b/scripts/release/promote/conda_to_conda.sh
@@ -29,19 +29,19 @@ for platform in ${CONDA_PLATFORMS}; do
     ))
 done
 
-my_wget() {
+my_curl() {
     local dl_url=$1
     local start=$(date +%s)
-    wget -c -q "${dl_url}"
+    curl -fsSL -O "${dl_url}"
     local end=$(date +%s)
     local diff=$(( end - start ))
     echo "+ ${dl_url} took ${diff}s"
 }
-export -f my_wget
+export -f my_curl
 
 # Download all packages in parallel
 printf '%s\n' "${pkgs_to_download[@]}" \
-    | xargs -P 10 -I % bash -c '(declare -t my_wget); my_wget %'
+    | xargs -P 10 -I % bash -c '(declare -t my_curl); my_curl %'
 
 # dry run by default
 DRY_RUN=${DRY_RUN:-enabled}


### PR DESCRIPTION
Adds a new promotion pipeline for both our wheel packages hosted on S3
as well as our conda packages hosted on anaconda.

Promotion is only run on tags that that match the following regex:

    /v[0-9]+(\.[0-9]+)*/

Example:

    v1.5.0

The promotion pipeline is also only run after a manual approval from
someone within the CircleCI security context "org-member"

> NOTE: This promotion pipeline does not cover promotion of packages that
>      are published to PyPI, this is an intentional choice as those
>      packages cannot be reverted after they have been published.

TODO: Write a proper testing pipeline for this

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>