### PR TITLE
remove the slow path(NCHW) for avg_pool3d

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/q_avgpool3d.cpp
+++ b/aten/src/ATen/native/quantized/cpu/q_avgpool3d.cpp
@@ -20,104 +20,6 @@ DEFINE_DISPATCH(qavg_pool3d_nhwc_stub);
 
 namespace {
 
-template <typename scalar_t>
-static void avg_pool3d_out_frame(
-    const Tensor& input,
-    Tensor& output,
-    int64_t b,
-    int64_t nInputPlane,
-    int64_t inputWidth,
-    int64_t inputHeight,
-    int64_t inputDepth,
-    int64_t outputWidth,
-    int64_t outputHeight,
-    int64_t outputDepth,
-    int kW,
-    int kH,
-    int kD,
-    int dW,
-    int dH,
-    int dD,
-    int padW,
-    int padH,
-    int padD,
-    bool count_include_pad,
-    c10::optional<int64_t> divisor_override) {
-  at::parallel_for(0, nInputPlane, 0, [&](int64_t start, int64_t end) {
-    for (auto k = start; k < end; k++) {
-      int64_t od, oh, ow;
-      /* For all output pixels... */
-      auto input_data = input.contiguous().data_ptr<scalar_t>();
-      auto output_data = output.data_ptr<scalar_t>();
-      scalar_t* ptr_output = output_data +
-          b * nInputPlane * outputWidth * outputHeight * outputDepth +
-          k * outputWidth * outputHeight * outputDepth;
-      const scalar_t* ptr_input = input_data +
-          b * nInputPlane * inputWidth * inputHeight * inputDepth +
-          k * inputWidth * inputHeight * inputDepth;
-      auto minimum =
-          std::numeric_limits<typename scalar_t::underlying>::lowest();
-      auto maximum = std::numeric_limits<typename scalar_t::underlying>::max();
-
-      for (od = 0; od < outputDepth; od++) {
-        for (oh = 0; oh < outputHeight; oh++) {
-          for (ow = 0; ow < outputWidth; ow++) {
-            /* Compute the mean of the input image... */
-            int64_t dstart = od * dD - padD;
-            int64_t hstart = oh * dH - padH;
-            int64_t wstart = ow * dW - padW;
-            int64_t dend = std::min(dstart + kD, inputDepth + padD);
-            int64_t hend = std::min(hstart + kH, inputHeight + padH);
-            int64_t wend = std::min(wstart + kW, inputWidth + padW);
-            int64_t pool_size = (dend - dstart) * (hend - hstart) * (wend - wstart);
-            dstart = std::max(dstart, static_cast<int64_t>(0));
-            hstart = std::max(hstart, static_cast<int64_t>(0));
-            wstart = std::max(wstart, static_cast<int64_t>(0));
-            dend = std::min(dend, inputDepth);
-            hend = std::min(hend, inputHeight);
-            wend = std::min(wend, inputWidth);
-
-            int sum_int = 0;
-            ptr_output->val_ = 0;
-
-            int64_t divide_factor;
-            int64_t size = (dend - dstart) * (hend - hstart) * (wend - wstart);
-            if (divisor_override.has_value()) {
-              divide_factor = divisor_override.value();
-            } else {
-              if (count_include_pad) {
-                divide_factor = pool_size;
-              } else {
-                divide_factor = (dend - dstart) * (hend - hstart) * (wend - wstart);
-              }
-            }
-
-            int64_t kx, ky, kz;
-            for (kz = dstart; kz < dend; kz++) {
-              for (ky = hstart; ky < hend; ky++) {
-                for (kx = wstart; kx < wend; kx++)
-                  sum_int += (ptr_input + kz * inputHeight * inputWidth + ky * inputWidth + kx)->val_;
-              }
-            }
-            float multiplier = input.q_scale() / output.q_scale() / divide_factor;
-
-            sum_int -= size * input.q_zero_point();
-            float sum = sum_int * 1.0;
-            /* Update output by requantizing the result */
-            ptr_output->val_ =
-                static_cast<typename scalar_t::underlying>(std::min<int32_t>(
-                    std::max<int32_t>(
-                        std::nearbyint(sum * multiplier + output.q_zero_point()),
-                        minimum),
-                    maximum));
-            ptr_output++;
-          }
-        }
-      }
-    }
-  });
-}
-
 inline std::tuple<int, int, int> get_kernel(IntArrayRef kernel_size) {
   TORCH_CHECK(
       kernel_size.size() == 1 || kernel_size.size() == 3,
@@ -217,124 +119,69 @@ Tensor q_avg_pool3d(
   const int64_t outputHeight = output_shape[output_shape.size() - 2];
   const int64_t outputWidth = output_shape[output_shape.size() - 1];
 
-  if (input.is_contiguous(c10::MemoryFormat::ChannelsLast3d)) {
-    auto output = at::_empty_affine_quantized(
-        output_shape,
-        input.options(),
-        input.q_scale(),
-        input.q_zero_point(),
-        input.suggest_memory_format());
-    // fast path for channel last: qavg_pool_2d_nhwc_stub
-    if (output_shape.size() == 4) {
-      qavg_pool3d_nhwc_stub(
-          input.device().type(),
-          input,
-          output,
-          0,
-          nInputPlane,
-          inputWidth,
-          inputHeight,
-          inputDepth,
-          outputWidth,
-          outputHeight,
-          outputDepth,
-          kW,
-          kH,
-          kD,
-          dW,
-          dH,
-          dD,
-          padW,
-          padH,
-          padD,
-          count_include_pad,
-          divisor_override);
-    } else {
-      at::parallel_for(0, nbatch, 0, [&](int64_t start, int64_t end) {
-        for (auto b = start; b < end; b++) {
-          qavg_pool3d_nhwc_stub(
-              input.device().type(),
-              input,
-              output,
-              b,
-              nInputPlane,
-              inputWidth,
-              inputHeight,
-              inputDepth,
-              outputWidth,
-              outputHeight,
-              outputDepth,
-              kW,
-              kH,
-              kD,
-              dW,
-              dH,
-              dD,
-              padW,
-              padH,
-              padD,
-              count_include_pad,
-              divisor_override);
-        }
-      });
-    }
-    return output;
+  auto input_nhwc = input.contiguous(MemoryFormat::ChannelsLast3d);
+
+  auto output = at::_empty_affine_quantized(
+      output_shape,
+      input_nhwc.options(),
+      input_nhwc.q_scale(),
+      input_nhwc.q_zero_point(),
+      input_nhwc.suggest_memory_format());
+  // fast path for channel last: qavg_pool_2d_nhwc_stub
+  if (output_shape.size() == 4) {
+    qavg_pool3d_nhwc_stub(
+        input_nhwc.device().type(),
+        input_nhwc,
+        output,
+        0,
+        nInputPlane,
+        inputWidth,
+        inputHeight,
+        inputDepth,
+        outputWidth,
+        outputHeight,
+        outputDepth,
+        kW,
+        kH,
+        kD,
+        dW,
+        dH,
+        dD,
+        padW,
+        padH,
+        padD,
+        count_include_pad,
+        divisor_override);
   } else {
-    auto output = at::_empty_affine_quantized(
-        output_shape, input.options(), input.q_scale(), input.q_zero_point());
-    if (output_shape.size() == 4) {
-      avg_pool3d_out_frame<scalar_t>(
-          input,
-          output,
-          0,
-          nInputPlane,
-          inputWidth,
-          inputHeight,
-          inputDepth,
-          outputWidth,
-          outputHeight,
-          outputDepth,
-          kW,
-          kH,
-          kD,
-          dW,
-          dH,
-          dD,
-          padW,
-          padH,
-          padD,
-          count_include_pad,
-          divisor_override);
-    } else {
-      at::parallel_for(0, nbatch, 0, [&](int64_t start, int64_t end) {
-        for (auto b = start; b < end; b++) {
-          avg_pool3d_out_frame<scalar_t>(
-              input,
-              output,
-              b,
-              nInputPlane,
-              inputWidth,
-              inputHeight,
-              inputDepth,
-              outputWidth,
-              outputHeight,
-              outputDepth,
-              kW,
-              kH,
-              kD,
-              dW,
-              dH,
-              dD,
-              padW,
-              padH,
-              padD,
-              count_include_pad,
-              divisor_override);
-        }
-      });
-    }
-    return output;
+    at::parallel_for(0, nbatch, 0, [&](int64_t start, int64_t end) {
+      for (auto b = start; b < end; b++) {
+        qavg_pool3d_nhwc_stub(
+            input_nhwc.device().type(),
+            input_nhwc,
+            output,
+            b,
+            nInputPlane,
+            inputWidth,
+            inputHeight,
+            inputDepth,
+            outputWidth,
+            outputHeight,
+            outputDepth,
+            kW,
+            kH,
+            kD,
+            dW,
+            dH,
+            dD,
+            padW,
+            padH,
+            padD,
+            count_include_pad,
+            divisor_override);
+      }
+    });
   }
+  return output;
 }
 
 } // namespace

--- a/test/test_quantized.py
+++ b/test/test_quantized.py
@@ -827,7 +827,7 @@ class TestQuantizedOps(TestCase):
                              message=error_message.format(name + '.zero_point', scale,
                              X_hat.q_zero_point()))
 
-    @given(X=hu.tensor(shapes=hu.array_shapes(min_dims=4, max_dims=5,
+    @given(X=hu.tensor(shapes=hu.array_shapes(min_dims=5, max_dims=5,
                                               min_side=5, max_side=10),
                        qparams=hu.qparams(dtypes=torch.quint8)),
            kernel=st.sampled_from((3, 5)),
@@ -860,6 +860,7 @@ class TestQuantizedOps(TestCase):
         X_ref = torch.nn.functional.avg_pool3d(
             X, kernel_size=kernel, stride=stride, padding=padding,
             ceil_mode=ceil_mode, count_include_pad=count_include_pad, divisor_override=divisor_override)
+
         ops_under_test = {
             "nn.functional": torch.nn.functional.avg_pool3d,
             "nn.quantized.functional": torch.nn.quantized.functional.avg_pool3d
@@ -870,7 +871,6 @@ class TestQuantizedOps(TestCase):
                         count_include_pad=count_include_pad, divisor_override=divisor_override)
             qX_ref = torch.quantize_per_tensor(X_ref, scale=qX_hat.q_scale(), zero_point=qX_hat.q_zero_point(),
                                                dtype=torch_type)
-
             self.assertEqual(qX_ref.int_repr().to(torch.double), qX_hat.int_repr().to(torch.double), prec=1.0,
                              message=error_message.format(name, qX_hat.int_repr(), qX_ref.int_repr()))
             self.assertEqual(scale, qX_hat.q_scale(),


### PR DESCRIPTION
Summary: Use the fast path for NCHW input tensor

Test Plan: run the pool unit tests

Differential Revision: D20522082

