### PR TITLE
[pytorch] reduce memory footprint in fused conv QAT ops

### DIFF
--- a/torch/nn/intrinsic/qat/modules/conv_fused.py
+++ b/torch/nn/intrinsic/qat/modules/conv_fused.py
@@ -114,18 +114,18 @@ class _ConvBnNd(nn.modules.conv._ConvNd):
             unbiased_batch_var = batch_var * (n / (n - 1))
             batch_rstd = torch.ones_like(batch_var, memory_format=torch.contiguous_format) / torch.sqrt(batch_var + self.eps)
 
-            conv = (self.gamma * batch_rstd).reshape([1, -1, 1, 1]) * conv_orig + \
-                (self.beta - self.gamma * batch_rstd * batch_mean).reshape([1, -1, 1, 1])
+            conv = (self.gamma * batch_rstd).reshape([1, -1, 1, 1]) * conv_orig
+            conv += (self.beta - self.gamma * batch_rstd * batch_mean).reshape([1, -1, 1, 1])
             self.running_mean = exponential_average_factor * batch_mean.detach() + \
                 (1 - exponential_average_factor) * self.running_mean
             self.running_var = exponential_average_factor * unbiased_batch_var.detach() + \
                 (1 - exponential_average_factor) * self.running_var
         else:
             if self.bias is None:
-                conv = conv + (self.beta - self.gamma * self.running_mean /
+                conv += (self.beta - self.gamma * self.running_mean /
                                running_std).reshape([1, -1, 1, 1])
             else:
-                conv = conv + (self.gamma * (self.bias - self.running_mean) / running_std + self.beta).reshape([1, -1, 1, 1])
+                conv += (self.gamma * (self.bias - self.running_mean) / running_std + self.beta).reshape([1, -1, 1, 1])
         return conv
 
     def extra_repr(self):
@@ -252,7 +252,7 @@ class ConvBnReLU2d(ConvBn2d):
                                            qconfig)
 
     def forward(self, input):
-        return self.activation_post_process(F.relu(ConvBn2d._forward(self, input)))
+        return self.activation_post_process(F.relu(ConvBn2d._forward(self, input), inplace=True))
 
     @classmethod
     def from_float(cls, mod, qconfig=None):
@@ -289,7 +289,7 @@ class ConvReLU2d(nnqat.Conv2d):
 
     def forward(self, input):
         return self.activation_post_process(F.relu(
-            self._conv_forward(input, self.weight_fake_quant(self.weight))))
+            self._conv_forward(input, self.weight_fake_quant(self.weight)), inplace=True))
 
     @classmethod
     def from_float(cls, mod, qconfig=None):


### PR DESCRIPTION
Summary: I was running into some memory issues once I enabled QAT and I found some opportunities to in-place operations.  In particular, looks like we can do the ReLUs in-place and the bias addition seems to also work inline.  The multiplication operation right above the bias addition is *not* eligible because there's a bifurcation to produce conv_orig.

Differential Revision: D20523080

