### PR TITLE
Adjust ProtoBufPatch to protobuf-3.11.x

### DIFF
--- a/cmake/ProtoBufPatch.cmake
+++ b/cmake/ProtoBufPatch.cmake
@@ -4,9 +4,18 @@
 
 file(READ ${FILENAME} content)
 
+# protobuf-3.6.0 pattern
 string(
   REPLACE
   "::google::protobuf::internal::GetEmptyStringAlreadyInited"
+  "GetEmptyStringAlreadyInited"
+  content
+  "${content}")
+
+# protobuf-3.8.0+ pattern
+string(
+  REPLACE
+  "::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited"
   "GetEmptyStringAlreadyInited"
   content
   "${content}")


### PR DESCRIPTION
`GetEmptyStringAlreadyInited` invocation pattern in protobuf generated header files chanegd to
 `:PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited`, where `PROTOBUF_NAMESPACE_ID` is defined in `protobuf/port_def.inc` as `google::protobuf`

This likely to have changed around protobuf-3.8.x time, but I've only tested it using protobuf-3.11.4

Test Plan: Update `third-party/protobuf` submodule to 3.11.4, compile and run `pattern_net_transform_test`

