### PR TITLE
.circleci: Specify setup job to run on everything

### DIFF
--- a/.circleci/cimodel/data/pytorch_build_definitions.py
+++ b/.circleci/cimodel/data/pytorch_build_definitions.py
@@ -288,7 +288,7 @@ def get_workflow_jobs():
 
     config_list = instantiate_configs()
 
-    x = ["setup"]
+    x = []
     for conf_options in config_list:
 
         phases = conf_options.restrict_phases or dimensions.PHASES

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1732,6 +1732,14 @@ jobs:
 workflows:
   build:
     jobs:
+      - setup:
+          # Run this job on everything since it is
+          # the dependency for everything.
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              only: /.*/
       # Warning: indentation here matters!
 
       - pytorch_windows_build:
@@ -1866,7 +1874,6 @@ workflows:
           requires:
             - setup
             - pytorch_windows_vs2019_py36_cuda10.1_build
-      - setup
       - pytorch_linux_build:
           name: pytorch_linux_xenial_py3_5_build
           requires:

--- a/.circleci/generate_config_yml.py
+++ b/.circleci/generate_config_yml.py
@@ -91,6 +91,7 @@ YAML_SOURCES = [
     File("docker_jobs.yml"),
     File("workflows.yml"),
 
+    File("workflows-setup-job.yml"),
     File("windows-build-test.yml"),
     Listgen(pytorch_build_definitions.get_workflow_jobs, 3),
     File("workflows-pytorch-macos-builds.yml"),

--- a/.circleci/verbatim-sources/workflows-setup-job.yml
+++ b/.circleci/verbatim-sources/workflows-setup-job.yml
@@ -1,0 +1,8 @@
+      - setup:
+          # Run this job on everything since it is
+          # the dependency for everything.
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              only: /.*/


### PR DESCRIPTION
CircleCI by default, chooses to run 0 jobs on tags meaning that when we
tag a build that no job is run if a dependent job does not contain the
correct filters.

This adds an explicit configuration to run the setup job on every branch
and every tag that CircleCI can run on.

For more information on CircleCI filters and what they do (and more
importantly what they do not do) visit:

https://circleci.com/docs/2.0/configuration-reference/#filters-1

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

