### PR TITLE
Add's workaround for ScalarType::Byte for cuda

### DIFF
--- a/c10/core/ScalarType.h
+++ b/c10/core/ScalarType.h
@@ -109,6 +109,17 @@ struct ScalarTypeToCPPType<c10::ScalarType::Bool> {
 };
 
 template<>
+struct ScalarTypeToCPPType<c10::ScalarType::Byte> {
+  using type = uint8_t;
+
+  // This is a workaround for the CUDA bug which prevents ::detail::ScalarTypeToCType<T>::type being used directly
+  // due to ambiguous reference which can't to be resolved. For some reason it cant pick between at::detail and at::cuda::detail.
+  // For repro example, please see: https://gist.github.com/izdeby/952ae7cf256ddb740a73776d39a7e7ba
+  // TODO: remove once the bug is fixed.
+  static type t;
+};
+
+template<>
 struct ScalarTypeToCPPType<c10::ScalarType::Long> {
   using type = int64_t;
 


### PR DESCRIPTION
This PR add's a workaround for `cuda` for `ScalarType::Byte` for the `AT_DISPATCH_*` macros. 
As discussed here: 
https://github.com/pytorch/pytorch/issues/34826