### PR TITLE
Enforce type promotion in `torch.cat`

### DIFF
--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -109,15 +109,6 @@ Tensor & _cat_out_cpu(Tensor& result, TensorList tensors, int64_t dim) {
         "output memory locations. Found overlap in input tensor ", i);
   }
 
-  // Dtypes should be the same
-  const auto first_in_cat = tensors[0];
-  for (int64_t i = 1; i < tensors.size(); i++) {
-    TORCH_CHECK(first_in_cat.dtype() == tensors[i].dtype(),
-              "Expected object of scalar type ", first_in_cat.dtype(),
-              " but got scalar type ", tensors[i].dtype(),
-              " for sequence element ", i, ".");
-  }
-
   auto should_skip = [](const Tensor& t) { return t.numel() == 0 && t.dim() == 1; };
   for (auto const &tensor : tensors) {
     if (should_skip(tensor)) {

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -224,7 +224,7 @@ Tensor & _cat_out_cpu(Tensor& result, TensorList tensors, int64_t dim) {
 
 Tensor _cat_cpu(TensorList tensors, int64_t dim) {
   ScalarType high_type = result_type(tensors);
-  Tensor result = at::empty({0}, tensors[0].options()).toType(high_type);
+  Tensor result = at::empty({0}, tensors[0].options().dtype(high_type));
   return native::_cat_out_cpu(result, tensors, dim);
 }
 

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -13,6 +13,7 @@
 #include <ATen/quantized/QTensorImpl.h>
 #include <ATen/NamedTensorUtils.h>
 #include <ATen/native/TensorIterator.h>
+#include <ATen/native/TypeProperties.h>
 #include <ATen/native/cpu/CatKernel.h>
 #include <ATen/native/Copy.h>
 #include <ATen/MemoryOverlap.h>
@@ -377,10 +378,7 @@ static Tensor cat_sparse(TensorList tensors, int64_t dim) {
 Tensor cat(TensorList tensors, int64_t dim) {
   std::vector<Tensor> temp_promote;
   if (tensors.size() > 1) { 
-    ScalarType high_type = tensors[0].scalar_type();
-    for (size_t i = 1; i < tensors.size(); ++i) {
-      high_type = promoteTypes(high_type, tensors[i].scalar_type());
-    }
+    ScalarType high_type = result_type(tensors);
     temp_promote.reserve(tensors.size());
     for (size_t i = 0; i < tensors.size(); ++i) {
       temp_promote.push_back(tensors[i].toType(high_type));

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -375,10 +375,15 @@ static Tensor cat_sparse(TensorList tensors, int64_t dim) {
 }
 
 Tensor cat(TensorList tensors, int64_t dim) {
+  for (size_t i = 0; i < tensors.size()-1; ++i) {
+    TORCH_CHECK(tensors[i].dtype() == tensors[i+1].dtype(), "cat expects all tensors to have the same dtype");
+  }
+
   if (tensors.size() > 0 &&
         tensors[0].is_sparse()) {
     return cat_sparse(tensors, dim);
   }
+
   check_cat_no_zero_dim(tensors);
   dim = legacy_cat_wrap_dim(dim, tensors);
   auto maybe_outnames = namedinference::compute_cat_outnames(tensors);

--- a/aten/src/ATen/native/TypeProperties.h
+++ b/aten/src/ATen/native/TypeProperties.h
@@ -12,6 +12,7 @@ struct ResultTypeState {
 
 CAFFE2_API ResultTypeState update_result_type_state(const Tensor& tensor, const ResultTypeState& in_state);
 CAFFE2_API ScalarType result_type(const ResultTypeState& state);
+
 CAFFE2_API ScalarType result_type(TensorList tensors);
 
 }}

--- a/aten/src/ATen/native/cuda/Shape.cu
+++ b/aten/src/ATen/native/cuda/Shape.cu
@@ -380,11 +380,9 @@ Tensor& cat_out_cuda(Tensor& out, TensorList inputs, int64_t dimension) {
   if (!allSameType) {
     // Since we are not using the iterator here, we need to enforce type promotion 
     // compatibility ourselves
-    for(auto input : inputs) {
-      TORCH_CHECK(canCast(input.scalar_type(), out.scalar_type()), "input type ", input.scalar_type(),
+    TORCH_CHECK(canCast(result_type(inputs), out.scalar_type()), "input types ",
           " can't be cast to the desired output type ",
           out.scalar_type());
-    }
   }
   if (inputs.size() > 1 &&
       !hasSkippedInput &&

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -2746,12 +2746,6 @@ t2.start()
                         type_no_autocast = torch.norm(a_ignore).dtype
                     self.assertTrue(torch.norm(a_ignore).dtype is type_no_autocast)
 
-                # Tests if CastPolicy::promote ops ignore double and int
-                torch.cat((a_ignore, c_16))
-                with torch.cuda.amp.autocast(enabled=False):
-                    type_no_autocast = torch.cat((a_ignore, b_ignore)).dtype
-                self.assertTrue(torch.cat((a_ignore, b_ignore)).dtype is type_no_autocast)
-
     @skipIfRocm
     def test_autocast_custom_enabled(self):
         class MyMM(torch.autograd.Function):

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -2747,8 +2747,7 @@ t2.start()
                     self.assertTrue(torch.norm(a_ignore).dtype is type_no_autocast)
 
                 # Tests if CastPolicy::promote ops ignore double and int
-                with self.assertRaises(RuntimeError):
-                    torch.cat((a_ignore, c_16))
+                torch.cat((a_ignore, c_16))
                 with torch.cuda.amp.autocast(enabled=False):
                     type_no_autocast = torch.cat((a_ignore, b_ignore)).dtype
                 self.assertTrue(torch.cat((a_ignore, b_ignore)).dtype is type_no_autocast)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -15194,7 +15194,6 @@ scipy_lobpcg  | {:10.2e}  | {:10.2e}  | {:6} | N/A
         self.assertRaises(RuntimeError, lambda: torch.cat([]))
         self.assertRaisesRegex(TypeError, 'got None', lambda: torch.cat([x, None]))
 
-    @onlyCPU
     def test_cat_different_dtypes(self, device):
         x = torch.tensor([1, 2, 3], device=device, dtype=torch.int8)
         y = torch.tensor([4, 5, 6], device=device, dtype=torch.int32)
@@ -15205,7 +15204,7 @@ scipy_lobpcg  | {:10.2e}  | {:10.2e}  | {:6} | N/A
         expected_out = torch.tensor([1, 2, 3, 4, 5, 6, 7, 8, 9],
                                     device=device, dtype=torch.int32)
         out = torch.cat([x, y, z])
-        self.assertEqual(out, expected_out) 
+        self.assertEqual(out, expected_out, exact_dtype=True) 
 
     @onlyCPU
     def test_cat_scalars(self, device):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -15195,6 +15195,12 @@ scipy_lobpcg  | {:10.2e}  | {:10.2e}  | {:6} | N/A
         self.assertRaisesRegex(TypeError, 'got None', lambda: torch.cat([x, None]))
 
     @onlyCPU
+    def test_cat_different_dtypes(self, device):
+        x = torch.tensor(0, device=device, dtype=torch.int8)
+        y = torch.tensor(0, device=device, dtype=torch.int32)
+        self.assertRaisesRegex(RuntimeError, 'same dtype', lambda: torch.cat([x, y]))
+
+    @onlyCPU
     def test_cat_scalars(self, device):
         x = torch.tensor(0, device=device)
         y = torch.tensor(1, device=device)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -15206,6 +15206,20 @@ scipy_lobpcg  | {:10.2e}  | {:10.2e}  | {:6} | N/A
         out = torch.cat([x, y, z])
         self.assertEqual(out, expected_out, exact_dtype=True) 
 
+    def test_cat_out_different_dtypes(self, device):
+        out = torch.zeros(6, device=device, dtype=torch.int16)
+        x = torch.tensor([1, 2, 3], device=device, dtype=torch.int8)
+        y = torch.tensor([4, 5, 6], device=device, dtype=torch.int32)
+        expected_out = torch.tensor([1, 2, 3, 4, 5, 6], device=device, dtype=torch.int16)
+        torch.cat([x, y], out=out)
+        self.assertEqual(out, expected_out, exact_dtype=True) 
+        z = torch.tensor([7, 8, 9], device=device, dtype=torch.int16)
+        out = torch.zeros(9, device=device, dtype=torch.int64)
+        expected_out = torch.tensor([1, 2, 3, 4, 5, 6, 7, 8, 9],
+                                    device=device, dtype=torch.int64)
+        out = torch.cat([x, y, z], out=out)
+        self.assertEqual(out, expected_out, exact_dtype=True) 
+
     @onlyCPU
     def test_cat_scalars(self, device):
         x = torch.tensor(0, device=device)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -15196,9 +15196,16 @@ scipy_lobpcg  | {:10.2e}  | {:10.2e}  | {:6} | N/A
 
     @onlyCPU
     def test_cat_different_dtypes(self, device):
-        x = torch.tensor(0, device=device, dtype=torch.int8)
-        y = torch.tensor(0, device=device, dtype=torch.int32)
-        self.assertRaisesRegex(RuntimeError, 'same dtype', lambda: torch.cat([x, y]))
+        x = torch.tensor([1, 2, 3], device=device, dtype=torch.int8)
+        y = torch.tensor([4, 5, 6], device=device, dtype=torch.int32)
+        expected_out = torch.tensor([1, 2, 3, 4, 5, 6], device=device, dtype=torch.int32)
+        out = torch.cat([x, y])
+        self.assertEqual(out, expected_out) 
+        z = torch.tensor([7, 8, 9], device=device, dtype=torch.int16)
+        expected_out = torch.tensor([1, 2, 3, 4, 5, 6, 7, 8, 9],
+                                    device=device, dtype=torch.int32)
+        out = torch.cat([x, y, z])
+        self.assertEqual(out, expected_out) 
 
     @onlyCPU
     def test_cat_scalars(self, device):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -15194,32 +15194,6 @@ scipy_lobpcg  | {:10.2e}  | {:10.2e}  | {:6} | N/A
         self.assertRaises(RuntimeError, lambda: torch.cat([]))
         self.assertRaisesRegex(TypeError, 'got None', lambda: torch.cat([x, None]))
 
-    def test_cat_different_dtypes(self, device):
-        x = torch.tensor([1, 2, 3], device=device, dtype=torch.int8)
-        y = torch.tensor([4, 5, 6], device=device, dtype=torch.int32)
-        expected_out = torch.tensor([1, 2, 3, 4, 5, 6], device=device, dtype=torch.int32)
-        out = torch.cat([x, y])
-        self.assertEqual(out, expected_out) 
-        z = torch.tensor([7, 8, 9], device=device, dtype=torch.int16)
-        expected_out = torch.tensor([1, 2, 3, 4, 5, 6, 7, 8, 9],
-                                    device=device, dtype=torch.int32)
-        out = torch.cat([x, y, z])
-        self.assertEqual(out, expected_out, exact_dtype=True) 
-
-    def test_cat_out_different_dtypes(self, device):
-        out = torch.zeros(6, device=device, dtype=torch.int16)
-        x = torch.tensor([1, 2, 3], device=device, dtype=torch.int8)
-        y = torch.tensor([4, 5, 6], device=device, dtype=torch.int32)
-        expected_out = torch.tensor([1, 2, 3, 4, 5, 6], device=device, dtype=torch.int16)
-        torch.cat([x, y], out=out)
-        self.assertEqual(out, expected_out, exact_dtype=True) 
-        z = torch.tensor([7, 8, 9], device=device, dtype=torch.int16)
-        out = torch.zeros(9, device=device, dtype=torch.int64)
-        expected_out = torch.tensor([1, 2, 3, 4, 5, 6, 7, 8, 9],
-                                    device=device, dtype=torch.int64)
-        out = torch.cat([x, y, z], out=out)
-        self.assertEqual(out, expected_out, exact_dtype=True) 
-
     @onlyCPU
     def test_cat_scalars(self, device):
         x = torch.tensor(0, device=device)
@@ -15257,32 +15231,6 @@ scipy_lobpcg  | {:10.2e}  | {:10.2e}  | {:6} | N/A
         concat_list.append(torch.ones((SIZE2, 1024 * 512), dtype=torch.uint8, device=device))
         result = torch.cat(concat_list)
         self.assertEqual(result.size(0), SIZE1 + SIZE2)
-
-    @onlyOnCPUAndCUDA
-    def test_cat_bad_dtypes(self, device):
-        def cross_product(a, b, skip_same=True):
-            result = []
-            for dtype_a in a:
-                for dtype_b in b:
-                    if skip_same and (dtype_a == dtype_b):
-                        continue
-                    result.append((dtype_a, dtype_b))
-            return result
-
-        in_shape = (1, 2, 3)
-        out_shape = (2, 2, 3)
-
-        all_dtypes = (torch.uint8, torch.int8, torch.int16, torch.int32,
-                      torch.int64, torch.float, torch.double, torch.half,
-                      torch.bfloat16)
-        all_dtype_combinations = cross_product(all_dtypes, all_dtypes,
-                                               skip_same=True)
-        out = torch.empty(out_shape)
-        for (dtype_a, dtype_b) in all_dtype_combinations:
-            a = torch.ones(in_shape, dtype=dtype_a).to(device)
-            b = torch.ones(in_shape, dtype=dtype_b).to(device)
-            self.assertRaises(RuntimeError, lambda: torch.cat([a, b]))
-            self.assertRaises(RuntimeError, lambda: torch.cat([a, b], out=out))
 
 
     @onlyCPU

--- a/test/test_type_promotion.py
+++ b/test/test_type_promotion.py
@@ -787,7 +787,7 @@ class TestTypePromotion(TestCase):
         y = torch.tensor([4, 5, 6], device=device, dtype=torch.int32)
         expected_out = torch.tensor([1, 2, 3, 4, 5, 6], device=device, dtype=torch.int32)
         out = torch.cat([x, y])
-        self.assertEqual(out, expected_out) 
+        self.assertEqual(out, expected_out, exact_dtype=True) 
         z = torch.tensor([7, 8, 9], device=device, dtype=torch.int16)
         expected_out = torch.tensor([1, 2, 3, 4, 5, 6, 7, 8, 9],
                                     device=device, dtype=torch.int32)

--- a/test/test_type_promotion.py
+++ b/test/test_type_promotion.py
@@ -691,6 +691,7 @@ class TestTypePromotion(TestCase):
         with self.maybeWarnsRegex(UserWarning, '^Integer division.+is deprecated.+'):
             torch.addcdiv(a, b, b, out=o)
 
+
     @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
     @float_double_default_dtype
     @onlyCPU
@@ -779,6 +780,43 @@ class TestTypePromotion(TestCase):
                                                               np_first,
                                                               torch.get_default_dtype())
                         self.fail(msg)
+
+
+    @onlyOnCPUAndCUDA
+    def test_cat_different_dtypes(self, device):
+        x = torch.tensor([1, 2, 3], device=device, dtype=torch.int8)
+        y = torch.tensor([4, 5, 6], device=device, dtype=torch.int32)
+        expected_out = torch.tensor([1, 2, 3, 4, 5, 6], device=device, dtype=torch.int32)
+        out = torch.cat([x, y])
+        self.assertEqual(out, expected_out) 
+        z = torch.tensor([7, 8, 9], device=device, dtype=torch.int16)
+        expected_out = torch.tensor([1, 2, 3, 4, 5, 6, 7, 8, 9],
+                                    device=device, dtype=torch.int32)
+        out = torch.cat([x, y, z])
+        self.assertEqual(out, expected_out, exact_dtype=True) 
+
+    @onlyOnCPUAndCUDA
+    def test_cat_out_different_dtypes(self, device):
+        out = torch.zeros(6, device=device, dtype=torch.int16)
+        x = torch.tensor([1, 2, 3], device=device, dtype=torch.int8)
+        y = torch.tensor([4, 5, 6], device=device, dtype=torch.int32)
+        expected_out = torch.tensor([1, 2, 3, 4, 5, 6], device=device, dtype=torch.int16)
+        torch.cat([x, y], out=out)
+        self.assertEqual(out, expected_out, exact_dtype=True) 
+        z = torch.tensor([7, 8, 9], device=device, dtype=torch.int16)
+        out = torch.zeros(9, device=device, dtype=torch.int64)
+        expected_out = torch.tensor([1, 2, 3, 4, 5, 6, 7, 8, 9],
+                                    device=device, dtype=torch.int64)
+        torch.cat([x, y, z], out=out)
+        self.assertEqual(out, expected_out, exact_dtype=True) 
+
+    @onlyOnCPUAndCUDA
+    def test_cat_invalid_dtype_promotion(self, device):
+        out = torch.zeros(6, device=device, dtype=torch.int16)
+        x = torch.tensor([1, 2, 3], device=device, dtype=torch.int16)
+        y = torch.tensor([4, 5, 6], device=device, dtype=torch.float)
+        with self.assertRaisesRegex(RuntimeError, 'can\'t be cast'):
+            torch.cat([x, y], out=out)
 
 
 instantiate_device_type_tests(TestTypePromotion, globals())

--- a/test/test_type_promotion.py
+++ b/test/test_type_promotion.py
@@ -691,7 +691,6 @@ class TestTypePromotion(TestCase):
         with self.maybeWarnsRegex(UserWarning, '^Integer division.+is deprecated.+'):
             torch.addcdiv(a, b, b, out=o)
 
-
     @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
     @float_double_default_dtype
     @onlyCPU


### PR DESCRIPTION
Fixes #35014 

CUDA `cat` implementation doesn't use `TensorIterator` so there is the need of manually doing some checks in the code.