### PR TITLE
[aibench] added support for measuring memory on AI Bench for Caffe2 Models

### DIFF
--- a/binaries/benchmark_helper.h
+++ b/binaries/benchmark_helper.h
@@ -123,6 +123,12 @@ void writeOutput(
     const bool text_output,
     const int index,
     const int num_blobs);
+void logBenchmarkResult(
+    const std::string& type,
+    const std::string& metric,
+    const std::string& unit,
+    const int value);
+long getVirtualMemoryIfOptionEnabled(bool FLAGS_measure_memory);
 void runNetwork(
     shared_ptr<caffe2::Workspace> workspace,
     caffe2::NetBase* net,


### PR DESCRIPTION
Summary: Exposing the helper functions in benchmark_helper.h

Reviewed By: geof90

Differential Revision: D20528983

