### PR TITLE
implement L2 regularization for Adagrad

### DIFF
--- a/caffe2/perfkernels/adagrad.cc
+++ b/caffe2/perfkernels/adagrad.cc
@@ -15,8 +15,10 @@ void adagrad_update__base(
     float* nh,
     float epsilon,
     float decay,
-    const float lr) {
-  internal::adagrad_update_base_inlined(N, w, g, h, nw, nh, decay, epsilon, lr);
+    const float lr,
+    const float weight_decay = 0.f) {
+  internal::adagrad_update_base_inlined(
+      N, w, g, h, nw, nh, decay, epsilon, lr, weight_decay);
 }
 
 void adagrad_update_prefetch__base(
@@ -36,8 +38,9 @@ void adagrad_update_prefetch__base(
     float* /* nh_n */, // prefetch ptr
 
     float epsilon,
-    float lr) {
-  adagrad_update__base(N, w, g, h, nw, nh, epsilon, 1.0f, lr);
+    float lr,
+    float weight_decay = 0.f) {
+  adagrad_update__base(N, w, g, h, nw, nh, epsilon, 1.0f, lr, weight_decay);
 }
 
 void adagrad_fp16_update_prefetch__base(
@@ -52,8 +55,10 @@ void adagrad_fp16_update_prefetch__base(
     at::Half* nh,
     at::Half* /* nh_n */, // prefetch ptr
     float epsilon,
-    float lr) {
-  internal::adagrad_update_base_inlined(N, w, g, h, nw, nh, 1.0f, epsilon, lr);
+    float lr,
+    float weight_decay = 0.f) {
+  internal::adagrad_update_base_inlined(
+      N, w, g, h, nw, nh, 1.0f, epsilon, lr, weight_decay);
 }
 
 // version without prefetching
@@ -67,9 +72,10 @@ void adagrad_update(
     float* nh,
     float epsilon,
     float decay,
-    float lr) {
-  AVX_F16C_DO(adagrad_update, N, w, g, h, nw, nh, epsilon, decay, lr);
-  BASE_DO(adagrad_update, N, w, g, h, nw, nh, epsilon, decay, lr);
+    float lr,
+    float weight_decay) {
+  AVX_F16C_DO(adagrad_update, N, w, g, h, nw, nh, epsilon, decay, lr, weight_decay);
+  BASE_DO(adagrad_update, N, w, g, h, nw, nh, epsilon, decay, lr, weight_decay);
 }
 
 decltype(adagrad_update_prefetch__base) adagrad_update_prefetch__avx_f16c;
@@ -90,7 +96,8 @@ void adagrad_update_prefetch(
     float* nh_n, // prefetch ptr
 
     float epsilon,
-    float lr) {
+    float lr,
+    float weight_decay) {
   AVX_F16C_DO(
       adagrad_update_prefetch,
       N,
@@ -104,7 +111,8 @@ void adagrad_update_prefetch(
       nh,
       nh_n,
       epsilon,
-      lr);
+      lr,
+      weight_decay);
   BASE_DO(
       adagrad_update_prefetch,
       N,
@@ -118,7 +126,8 @@ void adagrad_update_prefetch(
       nh,
       nh_n,
       epsilon,
-      lr);
+      lr,
+      weight_decay);
 }
 
 // Version with prefetching for embeddings and
@@ -137,7 +146,8 @@ void adagrad_fp16_update_prefetch(
     at::Half* nh,
     at::Half* nh_n, // prefetch ptr
     float epsilon,
-    float lr) {
+    float lr,
+    float weight_decay) {
   AVX_F16C_DO(
       adagrad_fp16_update_prefetch,
       N,
@@ -151,7 +161,8 @@ void adagrad_fp16_update_prefetch(
       nh,
       nh_n,
       epsilon,
-      lr);
+      lr,
+      weight_decay);
   BASE_DO(
       adagrad_fp16_update_prefetch,
       N,
@@ -165,7 +176,8 @@ void adagrad_fp16_update_prefetch(
       nh,
       nh_n,
       epsilon,
-      lr);
+      lr,
+      weight_decay);
 }
 
 } // namespace caffe2

--- a/caffe2/sgd/adagrad_op.h
+++ b/caffe2/sgd/adagrad_op.h
@@ -73,7 +73,10 @@ class AdagradOp final : public Operator<Context> {
   AdagradOp(const OperatorDef& operator_def, Workspace* ws)
       : Operator<Context>(operator_def, ws),
         epsilon_(this->template GetSingleArgument<T>("epsilon", 1e-5f)),
-        decay_(this->template GetSingleArgument<T>("decay", 1.0f)) {}
+        decay_(this->template GetSingleArgument<T>("decay", 1.0f)) {
+    LOG(INFO) << "gradient optimization operator in use: "
+              << "AdagradOp";
+  }
 
   bool RunOnDevice() override {
     CAFFE_ENFORCE_EQ(
@@ -155,7 +158,10 @@ class SparseAdagradOp final : public Operator<Context> {
   USE_OPERATOR_CONTEXT_FUNCTIONS;
   SparseAdagradOp(const OperatorDef& operator_def, Workspace* ws)
       : Operator<Context>(operator_def, ws),
-        epsilon_(this->template GetSingleArgument<float>("epsilon", 1e-5f)) {}
+        epsilon_(this->template GetSingleArgument<float>("epsilon", 1e-5f)) {
+    LOG(INFO) << "gradient optimization operator in use: "
+              << "SparseAdagradOp";
+  }
 
   bool RunOnDevice() override {
     // Enforce shapes
@@ -243,7 +249,10 @@ class RowWiseSparseAdagradOp final : public Operator<Context> {
   USE_OPERATOR_CONTEXT_FUNCTIONS;
   RowWiseSparseAdagradOp(const OperatorDef& operator_def, Workspace* ws)
       : Operator<Context>(operator_def, ws),
-        epsilon_(this->template GetSingleArgument<float>("epsilon", 1e-5f)) {}
+        epsilon_(this->template GetSingleArgument<float>("epsilon", 1e-5f)) {
+    LOG(INFO) << "gradient optimization operator in use: "
+              << "RowWiseSparseAdagradOp";
+  }
 
   bool RunOnDevice() override {
     // Enforce shapes
@@ -330,4 +339,4 @@ class RowWiseSparseAdagradOp final : public Operator<Context> {
   INPUT_TAGS(PARAM, MOMENT_1, INDICES, GRAD, LR);
   OUTPUT_TAGS(OUTPUT_PARAM, OUTPUT_MOMENT_1);
 };
-}
+} // namespace caffe2


### PR DESCRIPTION
Summary:
**Problem formulation**

L(w) = J(w) + lambda/2 * ||w||^2
J(w) is the empirical loss, and ||w||^2 is the squared L2 norm of the parameters, a.k.a. L2 regularizer.

dL(w)/ dw_i = dJ(w)/dw_i + lambda w_i
dL(w)/ dw_i is the gradient of L(w) w.r.t. w_i.

To implement the L2 regularizer, the gradient of J(w) w.r.t. w_i is added with w_i. lambda is called as weight decay in this implementation.

**Code changes**
* In the initialization method of AdagradOptimizer, a new input argument, weight_decay, is added.
* In the _run function of AdagradOptimizer, the weight decay will be skipped for 1d bias vectors.
* In the parameter update functions of Adagrad, the gradient is updated by weight_decay * w_i. The default value for weight_decay is zero.

Test Plan:
`buck build caffe2/caffe2/fb/dper/layer_models/tests/split_1:sparse_nn_test`

`./buck-out/gen/caffe2/caffe2/fb/dper/layer_models/tests/split_1/sparse_nn_test#binary.par`

Differential Revision: D20288548

