### PR TITLE
PyTorch should always depend on `future`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -352,10 +352,10 @@ def build_deps():
 ################################################################################
 
 # the list of runtime dependencies required by this built package
-install_requires = []
+install_requires = ['future']
 
 if sys.version_info <= (2, 7):
-    install_requires += ['future', 'typing']
+    install_requires += ['typing']
 
 missing_pydep = '''
 Missing build dependency: Unable to `import {importname}`.


### PR DESCRIPTION
Because `past` is used in `caffe2.python.core`
    
Test Plan: CI
