### PR TITLE
C++ smoketests for the API.

### DIFF
--- a/aten/src/ATen/core/dispatch/Dispatcher.h
+++ b/aten/src/ATen/core/dispatch/Dispatcher.h
@@ -80,7 +80,7 @@ public:
 
   /**
    * Looks for an operator schema with the given name and overload name
-   * and returns it if it is registered.
+   * and returns it if it is registered WITH A SCHEMA.
    * Returns nullopt otherwise.
    */
   c10::optional<OperatorHandle> findSchema(const OperatorName& operator_name);
@@ -99,6 +99,9 @@ public:
    * it does throw exceptions.
    */
   OperatorHandle findSchemaOrThrow(const char* name, const char* overload_name);
+
+  // Like findSchema, but also returns OperatorHandle even if there is no schema
+  c10::optional<OperatorHandle> findOperatorByName(const OperatorName& operator_name);
 
   // ------------------------------------------------------------------------
   //
@@ -206,6 +209,10 @@ public:
 
   const OperatorName& operator_name() const {
     return operatorIterator_->op.operator_name();
+  }
+
+  bool hasSchema() const {
+    return operatorIterator_->op.hasSchema();
   }
 
   const FunctionSchema& schema() const {

--- a/aten/src/ATen/core/dispatch/OperatorEntry.cpp
+++ b/aten/src/ATen/core/dispatch/OperatorEntry.cpp
@@ -63,7 +63,7 @@ void OperatorEntry::registerSchema(FunctionSchema&& schema) {
   TORCH_INTERNAL_ASSERT(!schema_.has_value());
   for (auto i = kernels_.begin(); i != kernels_.end(); ++i) {
     for (auto j = i->second.begin(); j != i->second.end(); ++j) {
-      if (j->inferred_function_schema) {
+      if (j->inferred_function_schema != nullptr) {
         checkSchema(name_, schema, *j->inferred_function_schema);
       }
     }

--- a/aten/src/ATen/core/dispatch/OperatorEntry.h
+++ b/aten/src/ATen/core/dispatch/OperatorEntry.h
@@ -16,7 +16,7 @@ namespace impl {
 // and its dispatch table. This is not part of the public API.
 class CAFFE2_API OperatorEntry final {
 public:
-  struct KernelEntry {
+  struct KernelEntry final {
     KernelEntry(KernelFunction k, std::unique_ptr<FunctionSchema> s, std::string d)
       : kernel(std::move(k))
       , inferred_function_schema(std::move(s))
@@ -41,6 +41,9 @@ public:
   const FunctionSchema& schema() const {
     TORCH_INTERNAL_ASSERT(schema_.has_value());
     return *schema_;
+  }
+  bool hasSchema() const {
+    return schema_.has_value();
   }
 
   // An OperatorEntry may be initialized with only an OperatorName.

--- a/aten/src/ATen/core/function_schema.h
+++ b/aten/src/ATen/core/function_schema.h
@@ -333,13 +333,7 @@ public:
   }
 
   void setNamespaceIfNotSet(const char* ns) {
-    // TODO: slow!  Fix internal data structures so I don't have to paste the
-    // names together
-    std::ostringstream oss;
-    if (name_.name.find("::") == std::string::npos) {
-      oss << ns << "::" << name_.name;
-      name_.name = oss.str();
-    }
+    name_.setNamespaceIfNotSet(ns);
   }
 
   // can a function with this schema be substituted for a function of rhs's

--- a/aten/src/ATen/core/operator_name.h
+++ b/aten/src/ATen/core/operator_name.h
@@ -13,6 +13,16 @@ struct OperatorName final {
   std::string overload_name;
   OperatorName(std::string name, std::string overload_name)
       : name(std::move(name)), overload_name(std::move(overload_name)) {}
+
+  void setNamespaceIfNotSet(const char* ns) {
+    // TODO: slow!  Fix internal data structures so I don't have to paste the
+    // names together
+    std::ostringstream oss;
+    if (name.find("::") == std::string::npos) {
+      oss << ns << "::" << name;
+      name = oss.str();
+    }
+  }
 };
 
 inline bool operator==(const OperatorName& lhs, const OperatorName& rhs) {

--- a/torch/csrc/utils/python_dispatch.cpp
+++ b/torch/csrc/utils/python_dispatch.cpp
@@ -138,7 +138,7 @@ void initDispatchBindings(PyObject* module) {
   });
 
   m.def("_dispatch_dump", [](const char* name) -> std::string {
-    auto op = c10::Dispatcher::singleton().findSchema(torch::jit::parseName(name));
+    auto op = c10::Dispatcher::singleton().findOperatorByName(torch::jit::parseName(name));
     if (!op) {
       return "";
     } else {
@@ -147,7 +147,7 @@ void initDispatchBindings(PyObject* module) {
   });
 
   m.def("_dispatch_check_invariants", [](const char* name) {
-    auto op = c10::Dispatcher::singleton().findSchema(torch::jit::parseName(name));
+    auto op = c10::Dispatcher::singleton().findOperatorByName(torch::jit::parseName(name));
     if (!op) {
     } else {
       return op->checkInvariants();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#35058 C++ smoketests for the API.**
* #34668 Python-driven testing for the new operator registration API
* #34620 Minor OperatorName cleanup
* #34618 Improved error checking
* #34601 Implement schema matching inside Dispatcher
* #34456 Finish implementing schema-less impl, switch all internal registrations to it
* #34455 Add torch::jit::parseName (mirroring parseSchema/parseSchemaOrName)
* #34221 Relax internal invariants of Dispatcher in preparation for schema-less registration

These tests comprehensively cover the C++ API surface of the new
operator registration API, but don't check very hard if the API
does the right thing (that's what test_dispatch.py is for)

There's also some CR fixes in this diff.

- Rename findSchema to findOperatorByName, and make findSchema
  only return an entry if there is schema
- Simplify implementation of registerDef per bhosmer's advice
- Explicitly test for nullptr rather than rely on bool conversion
- Make KernelEntry final
- Make it possible to test if an OperatorHandle hasSchema
- Add setNamespaceIfSet to OperatorName.  This fixes behavior
  for torch::import("a").impl("b::test") (now b properly
  overrides a)
- Rename some tests

Signed-off-by: Edward Z. Yang <ezyang@fb.com>