### PR TITLE
fix min max zero element

### DIFF
--- a/aten/src/ATen/native/ReduceOpsUtils.h
+++ b/aten/src/ATen/native/ReduceOpsUtils.h
@@ -81,7 +81,7 @@ inline bool _dimreduce_return_trivial_no_ident(Tensor &result, const Tensor &sel
     return true;
   }
 
-  if (self.numel() == 0) {
+  if (self.numel() == 0 && self.ndimension() < 2) {
     AT_ERROR("cannot perform reduction function ", fn_name,
              " on tensor with no elements because the operation does not have an identity");
   }

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -14226,6 +14226,23 @@ scipy_lobpcg  | {:10.2e}  | {:10.2e}  | {:6} | N/A
             self.assertFalse(torch.isnan(ma[i]), "max(a, b): {}, a: {}, b: {}".format(ma[i], a[i], b[i]))
             self.assertFalse(torch.isnan(mi[i]), "min(a, b): {}, a: {}, b: {}".format(mi[i], a[i], b[i]))
 
+    @dtypesIfCUDA(torch.half, torch.float, torch.double)
+    @dtypes(torch.float, torch.double)(
+    def test_min_max_empty_element(self, device, dtype):
+        a = torch.rand(0, dtype=dtype, device=device)
+        b = torch.rand(0, 5, dtype=dtype, device=device)
+        c = torch.rand(0, 5, 10, dtype=dtype, device=device)
+        d = torch.rand(0, 5, 10, 15, dtype=dtype, device=device)
+        e = torch.rand(0, 5, 10, 15, 20, dtype=dtype, device=device)
+
+        ident_err = 'operation does not have an identity'
+        self.assertRaisesRegex(RuntimeError, ident_err, a.max())
+        
+        self.assertEqual(b.max(1).values.nelement(), 0)
+        self.assertEqual(c.max(1).values.nelement(), 0)
+        self.assertEqual(d.max(2).values.nelement(), 0)
+        self.assertEqual(e.max(3).values.nelement(), 0)
+        
     @onlyCPU
     @dtypes(*torch.testing.get_all_math_dtypes('cpu'))
     def test_threshold(self, device, dtype):


### PR DESCRIPTION
Fixing: [#34907](https://github.com/pytorch/pytorch/issues/34907)

Test script:
```
import torch
a = torch.rand(0, 4)
print(a.max(1))
print(a.min(1))
```

## Before:
`RuntimeError: cannot perform reduction function max on tensor with no elements because the operation does not have an identity`

## After:
```
torch.return_types.max(
values=tensor([]),
indices=tensor([], dtype=torch.int64))
torch.return_types.max(
values=tensor([]),
indices=tensor([], dtype=torch.int64))
```

### Convert in numpy then back into tensor again:
```
import torch
a = torch.rand(0, 4)
torch.from_numpy(a.max(1).values.numpy())
```

return:
`tensor([])`