### PR TITLE
[quant][graphmode] Fold quantized prepacking ops

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2208,7 +2208,9 @@ graph(%input, %weight):
         qconfig_dict = {'': default_qconfig}
         model = torch.jit.script(M()).eval()
         model = quantize_script(model, qconfig_dict, _test_only_eval_fn, [data], inplace=False)
-        FileCheck().check("quantized::conv2d") \
+        FileCheck().check_count("aten::quantize_per_tensor", 1, exactly=True) \
+                   .check_not("quantized::conv2d_prepack") \
+                   .check("quantized::conv2d") \
                    .run(model.graph)
 
     def test_finalize_for_linear(self):
@@ -2224,7 +2226,9 @@ graph(%input, %weight):
         qconfig_dict = {'': default_qconfig}
         model = torch.jit.script(M()).eval()
         model = quantize_script(model, qconfig_dict, _test_only_eval_fn, [data], inplace=False)
-        FileCheck().check("quantized::linear") \
+        FileCheck().check_count("aten::quantize_per_tensor", 1, exactly=True) \
+                   .check_not("quantized::linear_prepack") \
+                   .check("quantized::linear") \
                    .run(model.graph)
 
     def test_finalize_debug(self):
@@ -2241,7 +2245,9 @@ graph(%input, %weight):
         model = torch.jit.script(M()).eval()
         model = quantize_script(model, qconfig_dict, _test_only_eval_fn, [data], inplace=False, debug=True)
         FileCheck().check_not("quantized::conv2d") \
+                   .check("aten::quantize_per_tensor") \
                    .check("CallMethod") \
+                   .check("aten::quantize_per_tensor") \
                    .run(model.graph)
 
     def test_pattern_based_rewrite(self):

--- a/torch/csrc/jit/passes/quantization.cpp
+++ b/torch/csrc/jit/passes/quantization.cpp
@@ -7,6 +7,7 @@
 #include <torch/csrc/jit/passes/subgraph_rewrite.h>
 #include <torch/csrc/jit/passes/inliner.h>
 #include <torch/csrc/jit/passes/freeze_module.h>
+#include <torch/csrc/jit/passes/prepack_folding.h>
 
 #include <torch/csrc/jit/ir/ir.h>
 #include <torch/csrc/jit/ir/irparser.h>
@@ -2560,6 +2561,15 @@ void DedupModuleUses(Module& module) {
   d.dedup();
 }
 
+void FoldQuantizedPrepackingOps(Module& module) {
+  auto filter_fn = [](const Node* n) -> bool {
+    return (
+        (n->kind() == Symbol::fromQualString("quantized::linear_prepack")) ||
+        n->kind() == Symbol::fromQualString("quantized::conv2d_prepack"));
+  };
+  FoldPrePackingOps(module, filter_fn, "quantized");
+}
+
 script::Module Finalize(script::Module& module) {
   SwapFunctionalLinear(module);
   auto graph = module.get_method("forward").graph();
@@ -2571,7 +2581,9 @@ script::Module Finalize(script::Module& module) {
   InsertPrepackUnpack(graph);
   ConstantPropagation(graph);
   QuantFusion(graph);
-  return freeze_module(module);
+  auto frozen = freeze_module(module);
+  FoldQuantizedPrepackingOps(frozen);
+  return frozen;
 }
 
 } // namespace jit

--- a/torch/csrc/jit/passes/quantization.h
+++ b/torch/csrc/jit/passes/quantization.h
@@ -194,5 +194,7 @@ TORCH_API void DedupModuleUses(Module& module);
 
 TORCH_API script::Module Finalize(script::Module& module);
 
+TORCH_API void FoldQuantizedPrepackingOps(Module& module);
+
 } // namespace jit
 } // namespace torch


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #33650 [not4land] debugging
* **#35072 [quant][graphmode] Fold quantized prepacking ops**
* #35073 [quant] Make quantize_per_tensor/quantize_per_channel pure
* #34855 [quant][graphmode] propagate observed property for user defined prim::CallFunction
* #34346 [quant][graphmode] Add quantization support for aten::cat
* #34345 [quant][graphmode] Add prim::ListConstruct to general op handling
* #34854 [quant][graphmode] quantization support for view, transpose, contiguos
* #34806 [quant][graphmode] quantization support for aten::chunk
* #34807 [quant][graphmode] quantization support for prim::ListUnpack
* #34804 [quant][graphmode] Replicate quantize node for prim::If
* #34572 [quant][graphmode] quantization support for aten::add
* #34518 [quant][graphmode] quantization work for prim::If
* #34571 [quant][graphmode][fix] use observed_values_ to check values are observed
* #34414 [quant][graphmode][refactor] insertObservers for Block
* #34411 [quant][graphmode][fix] Insert dequantize before use node
* #34349 [quant][graphmode][fix] preserve the type of original value when inserting dequant node
* #34348 [quant] Add dequantize.tensors

Summary:
Fold the prepack ops, `quantized::linear_prepack` and `quantized::conv2d_prepack` after
`freeze`

Test Plan:
python test/test_jit.py

Reviewers:
.

Subscribers:

Tasks:

Tags: