### PR TITLE
[WIP] [Future] Add intrusive_target to utils::Future

### DIFF
--- a/torch/csrc/distributed/autograd/context/context.cpp
+++ b/torch/csrc/distributed/autograd/context/context.cpp
@@ -118,7 +118,7 @@ void DistAutogradContext::resetGraphTask() {
 }
 
 void DistAutogradContext::addOutstandingRpc(
-    const std::shared_ptr<rpc::FutureMessage>& futureMessage) {
+    const rpc::FutureMessagePtr& futureMessage) {
   futureMessage->addCallback(
       [this](
           const rpc::Message& /* unused */,
@@ -147,7 +147,7 @@ void DistAutogradContext::clearOutstandingRpcs() {
   outStandingRpcs_.clear();
 }
 
-std::shared_ptr<rpc::FutureMessage> DistAutogradContext::
+rpc::FutureMessagePtr DistAutogradContext::
     clearAndWaitForOutstandingRpcsAsync() {
   std::unique_lock<std::mutex> lock(lock_);
   auto outStandingRpcs = std::move(outStandingRpcs_);
@@ -155,8 +155,8 @@ std::shared_ptr<rpc::FutureMessage> DistAutogradContext::
 
   struct State {
     explicit State(int32_t count)
-        : future(std::make_shared<rpc::FutureMessage>()), remaining(count) {}
-    std::shared_ptr<rpc::FutureMessage> future;
+        : future(rpc::FutureMessagePtr::make()), remaining(count) {}
+    rpc::FutureMessagePtr future;
     std::atomic<int32_t> remaining;
     std::atomic<bool> alreadySentError{false};
   };

--- a/torch/csrc/distributed/autograd/context/context.h
+++ b/torch/csrc/distributed/autograd/context/context.h
@@ -47,8 +47,7 @@ class TORCH_API DistAutogradContext {
       const;
 
   // Adds a future message recording an outstanding RPC.
-  void addOutstandingRpc(
-      const std::shared_ptr<rpc::FutureMessage>& futureMessage);
+  void addOutstandingRpc(const rpc::FutureMessagePtr& futureMessage);
 
   // Returns all gradients.
   const c10::Dict<torch::Tensor, torch::Tensor> getGradients() const;
@@ -92,7 +91,7 @@ class TORCH_API DistAutogradContext {
 
   // Waits for all outstanding RPCs for this context to finish and clears all
   // outstanding rpcs held in this context. This should be called only once.
-  std::shared_ptr<rpc::FutureMessage> clearAndWaitForOutstandingRpcsAsync();
+  rpc::FutureMessagePtr clearAndWaitForOutstandingRpcsAsync();
 
   void clearOutstandingRpcs();
 
@@ -122,7 +121,7 @@ class TORCH_API DistAutogradContext {
   // List of futures for RPCs initiated by this node to propagate gradients to
   // other nodes. The distributed autograd engine on this node can return
   // successfully only if all these futures are done and are successful.
-  std::vector<std::shared_ptr<rpc::FutureMessage>> outStandingRpcs_;
+  std::vector<rpc::FutureMessagePtr> outStandingRpcs_;
 
   // Lock to protect concurrent modification of the context.
   mutable std::mutex lock_;

--- a/torch/csrc/distributed/autograd/utils.cpp
+++ b/torch/csrc/distributed/autograd/utils.cpp
@@ -111,7 +111,7 @@ Message getMessageWithAutograd(
   return std::move(*rpcWithAutograd).toMessage();
 }
 
-std::shared_ptr<FutureMessage> sendMessageWithAutograd(
+rpc::FutureMessagePtr sendMessageWithAutograd(
     RpcAgent& agent,
     const WorkerInfo& dst,
     torch::distributed::rpc::Message&& wrappedRpcMsg,

--- a/torch/csrc/distributed/autograd/utils.h
+++ b/torch/csrc/distributed/autograd/utils.h
@@ -43,8 +43,7 @@ TORCH_API rpc::Message getMessageWithAutograd(
     bool forceGradRecording = false);
 
 // Send message after autograd checking
-TORCH_API std::shared_ptr<torch::distributed::rpc::FutureMessage>
-sendMessageWithAutograd(
+TORCH_API rpc::FutureMessagePtr sendMessageWithAutograd(
     rpc::RpcAgent& agent,
     const rpc::WorkerInfo& dst,
     rpc::Message&& wrappedRpcMsg,

--- a/torch/csrc/distributed/rpc/message.h
+++ b/torch/csrc/distributed/rpc/message.h
@@ -129,6 +129,7 @@ TORCH_API Message
 createExceptionResponse(const std::string& exceptionStr, int64_t id);
 
 typedef torch::utils::Future<Message> FutureMessage;
+using FutureMessagePtr = c10::intrusive_ptr<FutureMessage>;
 
 } // namespace rpc
 } // namespace distributed

--- a/torch/csrc/distributed/rpc/process_group_agent.h
+++ b/torch/csrc/distributed/rpc/process_group_agent.h
@@ -87,8 +87,7 @@ class ProcessGroupAgent : public RpcAgent {
   // This method wraps the destination information and the message into a
   // SendWork object, and put the SendWork into a queue. Another thread will
   // consume SendWork from the queue and send it out.
-  std::shared_ptr<FutureMessage> send(const WorkerInfo& to, Message&& message)
-      override;
+  FutureMessagePtr send(const WorkerInfo& to, Message&& message) override;
 
  private:
   using steady_clock_time_point =
@@ -127,12 +126,12 @@ class ProcessGroupAgent : public RpcAgent {
   // additional information to manage timeouts and destination information,
   // which is needed for termination detection.
   struct FutureInfo {
-    std::shared_ptr<FutureMessage> future_;
+    FutureMessagePtr future_;
     steady_clock_time_point endTime_;
     int dstRank_;
     std::chrono::milliseconds timeout_;
     FutureInfo(
-        const std::shared_ptr<FutureMessage>& future,
+        const FutureMessagePtr& future,
         const steady_clock_time_point& endTime,
         int dstRank,
         const std::chrono::milliseconds timeout)

--- a/torch/csrc/distributed/rpc/python_functions.cpp
+++ b/torch/csrc/distributed/rpc/python_functions.cpp
@@ -59,7 +59,7 @@ std::shared_ptr<Operator> matchBuiltinOp(
       ") to a builtin operator");
 }
 
-std::shared_ptr<FutureMessage> sendPythonRemoteCall(
+FutureMessagePtr sendPythonRemoteCall(
     const WorkerInfo& dst,
     SerializedPyObj serializedPyObj,
     const IValue& rrefId,
@@ -116,7 +116,7 @@ py::object toPyObj(const Message& message) {
   return toPyObjInternal(*response, msgType);
 }
 
-std::shared_ptr<FutureMessage> pyRpcBuiltin(
+FutureMessagePtr pyRpcBuiltin(
     const WorkerInfo& dst,
     const std::string& opName,
     const std::shared_ptr<torch::autograd::profiler::RecordFunction>& rf,
@@ -176,7 +176,7 @@ PyRRef pyRemoteBuiltin(
   }
 }
 
-std::shared_ptr<FutureMessage> pyRpcPythonUdf(
+FutureMessagePtr pyRpcPythonUdf(
     const WorkerInfo& dst,
     std::string& pickledPythonUDF,
     std::vector<torch::Tensor>& tensors,

--- a/torch/csrc/distributed/rpc/python_functions.h
+++ b/torch/csrc/distributed/rpc/python_functions.h
@@ -11,14 +11,14 @@ namespace rpc {
 
 py::object toPyObj(const Message& message);
 
-std::shared_ptr<FutureMessage> pyRpcBuiltin(
+FutureMessagePtr pyRpcBuiltin(
     const WorkerInfo& dst,
     const std::string& opName,
     const std::shared_ptr<torch::autograd::profiler::RecordFunction>& rf,
     const py::args& args,
     const py::kwargs& kwargs);
 
-std::shared_ptr<FutureMessage> pyRpcPythonUdf(
+FutureMessagePtr pyRpcPythonUdf(
     const WorkerInfo& dst,
     std::string& pickledPythonUDF,
     std::vector<torch::Tensor>& tensors,

--- a/torch/csrc/distributed/rpc/request_callback.cpp
+++ b/torch/csrc/distributed/rpc/request_callback.cpp
@@ -9,8 +9,7 @@ namespace rpc {
 
 using namespace torch::distributed::autograd;
 
-std::shared_ptr<FutureMessage> RequestCallback::operator()(
-    Message& request) const {
+FutureMessagePtr RequestCallback::operator()(Message& request) const {
   // NB: cannot clear autograd context id here because the processMessage method
   // might pause waiting for all RRefs in the arguments to be confirmed by their
   // owners and resumne processing in a different thread. Hence, the

--- a/torch/csrc/distributed/rpc/request_callback.h
+++ b/torch/csrc/distributed/rpc/request_callback.h
@@ -12,7 +12,7 @@ namespace rpc {
 class TORCH_API RequestCallback {
  public:
   // Invoke the callback.
-  std::shared_ptr<FutureMessage> operator()(Message& request) const;
+  FutureMessagePtr operator()(Message& request) const;
 
   virtual ~RequestCallback() {}
 
@@ -24,8 +24,7 @@ class TORCH_API RequestCallback {
   // message containing an exception. Different rpc agent implementations are
   // expected to ensure delivery of the response/exception based on their
   // implementation specific mechanisms.
-  virtual std::shared_ptr<FutureMessage> processMessage(
-      Message& request) const = 0;
+  virtual FutureMessagePtr processMessage(Message& request) const = 0;
 };
 
 } // namespace rpc

--- a/torch/csrc/distributed/rpc/request_callback_impl.cpp
+++ b/torch/csrc/distributed/rpc/request_callback_impl.cpp
@@ -107,7 +107,7 @@ void RequestCallbackImpl::processRpc(
     RpcCommandBase& rpc,
     const MessageType& messageType,
     const int64_t messageId,
-    const std::shared_ptr<FutureMessage>& responseFuture) const {
+    const FutureMessagePtr& responseFuture) const {
   auto markComplete = [messageId, &responseFuture](Message m) {
     m.setId(messageId);
     responseFuture->markCompleted(std::move(m));
@@ -363,7 +363,7 @@ void RequestCallbackImpl::processRpc(
       // Process the original RPC.
       auto wrappedMessageType = rpcWithAutograd.wrappedMessageType();
       // Make an overall future for the wrapped response.
-      auto wrappedRpcResponseFuture = std::make_shared<FutureMessage>();
+      auto wrappedRpcResponseFuture = FutureMessagePtr::make();
       // Kick off processing for the nested future and get a Future<T> to the
       // result.
       processRpc(
@@ -448,13 +448,12 @@ void RequestCallbackImpl::processRpc(
   }
 }
 
-std::shared_ptr<FutureMessage> RequestCallbackImpl::processMessage(
-    Message& request) const {
+FutureMessagePtr RequestCallbackImpl::processMessage(Message& request) const {
   // We need two futures here because it could pause twice when processing a
   // RPC message:
   //  1) waiting for all RRefs in the arguments to become confirmed;
   //  2) waiting for processRpc to finish.
-  auto retFuture = std::make_shared<FutureMessage>();
+  auto retFuture = FutureMessagePtr::make();
   auto& rrefContext = RRefContext::getInstance();
   try {
     rrefContext.recordThreadLocalPendingRRefs();

--- a/torch/csrc/distributed/rpc/request_callback_impl.h
+++ b/torch/csrc/distributed/rpc/request_callback_impl.h
@@ -10,15 +10,14 @@ namespace rpc {
 
 class TORCH_API RequestCallbackImpl : public RequestCallback {
  public:
-  std::shared_ptr<FutureMessage> processMessage(
-      Message& request) const override;
+  FutureMessagePtr processMessage(Message& request) const override;
 
  private:
   void processRpc(
       RpcCommandBase& rpc,
       const MessageType& messageType,
       const int64_t messageId,
-      const std::shared_ptr<FutureMessage>& retFutureMessagge) const;
+      const FutureMessagePtr& retFutureMessagge) const;
 
   Message handleError(
       const std::exception& e,

--- a/torch/csrc/distributed/rpc/rpc_agent.cpp
+++ b/torch/csrc/distributed/rpc/rpc_agent.cpp
@@ -36,7 +36,7 @@ void RpcAgent::cleanup() {
   rpcRetryThread_.join();
 }
 
-std::shared_ptr<FutureMessage> RpcAgent::sendWithRetries(
+FutureMessagePtr RpcAgent::sendWithRetries(
     const WorkerInfo& to,
     Message&& message,
     RpcRetryOptions retryOptions) {
@@ -48,7 +48,7 @@ std::shared_ptr<FutureMessage> RpcAgent::sendWithRetries(
       retryOptions.rpcRetryDuration.count() >= 0,
       "rpcRetryDuration cannot be negative.");
 
-  auto originalFuture = std::make_shared<FutureMessage>();
+  auto originalFuture = FutureMessagePtr::make();
   steady_clock_time_point newTime =
       computeNewRpcRetryTime(retryOptions, /* retryCount */ 0);
   // Making a copy of the message so it can be retried after the first send.

--- a/torch/csrc/distributed/rpc/rpc_agent.h
+++ b/torch/csrc/distributed/rpc/rpc_agent.h
@@ -93,7 +93,7 @@ struct TORCH_API RpcRetryInfo {
   RpcRetryInfo(
       const WorkerInfo& to,
       Message&& message,
-      std::shared_ptr<FutureMessage> originalFuture,
+      FutureMessagePtr originalFuture,
       int retryCount,
       RpcRetryOptions options)
       : to_(to),
@@ -105,7 +105,7 @@ struct TORCH_API RpcRetryInfo {
   const WorkerInfo& to_;
   Message message_;
   // Future that is returned to the caller of sendWithRetries().
-  std::shared_ptr<FutureMessage> originalFuture_;
+  FutureMessagePtr originalFuture_;
   // Number of send attempts completed so far.
   int retryCount_;
   RpcRetryOptions options_;
@@ -145,9 +145,7 @@ class TORCH_API RpcAgent {
   // If ``message.isRequest()`` is true, the ``FutureMessage`` will be
   // completed when the response arrives. For other message types, the Future
   // should be ignored by the caller.
-  virtual std::shared_ptr<FutureMessage> send(
-      const WorkerInfo& to,
-      Message&& message) = 0;
+  virtual FutureMessagePtr send(const WorkerInfo& to, Message&& message) = 0;
 
   // Retries sending the message up to maxRetries times until an ACK is
   // receieved. The duration between consecutive sends is increased over
@@ -161,7 +159,7 @@ class TORCH_API RpcAgent {
   // executing a method twice on the remote end (it does not guarantee
   // exactly-once semantics). Therefore, the user must ensure their requests
   // are idempotent.
-  std::shared_ptr<FutureMessage> sendWithRetries(
+  FutureMessagePtr sendWithRetries(
       const WorkerInfo& to,
       Message&& message,
       RpcRetryOptions retryOptions = RpcRetryOptions());
@@ -299,8 +297,7 @@ class TORCH_API RpcAgent {
   std::atomic<bool> rpcAgentRunning_;
 
   // storing futures before adding callback
-  std::vector<
-      std::pair<std::shared_ptr<FutureMessage>, std::shared_ptr<RpcRetryInfo>>>
+  std::vector<std::pair<FutureMessagePtr, std::shared_ptr<RpcRetryInfo>>>
       futures;
 
   // Condition Variable to signal when the rpcRetryMap_ has been populated.

--- a/torch/csrc/utils/future.h
+++ b/torch/csrc/utils/future.h
@@ -26,7 +26,7 @@ class TORCH_API FutureError final : public std::exception {
 // Most implementation is copied from FutureMessage and
 // c10::ivalue::Future
 template <typename T>
-class TORCH_API Future final {
+class TORCH_API Future final : public c10::intrusive_ptr_target {
  public:
   using Callback =
       std::function<void(const T&, const c10::optional<FutureError>&)>;


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #35089 [Future] Add addCallback API that takes callbacks that don't take value/error&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D20166971/)
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#35087 [Future] Add intrusive_target to utils::Future**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D17403584/)

For `utils::Future` to be used as `ivalue::Future`, this class needs to support `intrusive_ptr`, so make it an `intrusive_ptr_target`.

This is a step for https://github.com/pytorch/pytorch/issues/34997.

Differential Revision: [D17403584](https://our.internmc.facebook.com/intern/diff/D17403584/)