### PR TITLE
fix missing comma in activation benchmarks

### DIFF
--- a/benchmarks/operator_benchmark/pt/qactivation_test.py
+++ b/benchmarks/operator_benchmark/pt/qactivation_test.py
@@ -45,7 +45,7 @@ qactivation_ops = op_bench.op_list(
         ('relu', nnq.ReLU),
         ('relu6', nnq.ReLU6),
         ('functional.hardtanh', nnq.functional.hardtanh),
-        ('functional.elu', nnq.functional.elu)
+        ('functional.elu', nnq.functional.elu),
         ('functional.hardsigmoid', nnq.functional.hardsigmoid),
     ),
     attr_names=('op_name', 'op_func'),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#35104 fix missing comma in activation benchmarks**

Summary:

I missed this in https://github.com/pytorch/pytorch/pull/34959
after a rebase, fixing.

Test Plan:

running benchmarks no longer crashes
CI

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D20560908](https://our.internmc.facebook.com/intern/diff/D20560908)