### PR TITLE
[TensorExpr] Use `const Expr*` instead of `ExprHandle&` in Range.

### DIFF
--- a/torch/csrc/jit/tensorexpr/function.h
+++ b/torch/csrc/jit/tensorexpr/function.h
@@ -14,18 +14,17 @@ namespace tensorexpr {
 class Range {
  public:
   Range() {}
-  Range(const ExprHandle& start, const ExprHandle& stop)
-      : start_(start), stop_(stop) {}
-  const ExprHandle& start() const {
+  Range(const Expr* start, const Expr* stop) : start_(start), stop_(stop) {}
+  const Expr* start() const {
     return start_;
   }
-  const ExprHandle& stop() const {
+  const Expr* stop() const {
     return stop_;
   }
 
  private:
-  ExprHandle start_;
-  ExprHandle stop_;
+  const Expr* start_;
+  const Expr* stop_;
 };
 
 class Function : public KernelScopedObject {

--- a/torch/csrc/jit/tensorexpr/loopnest.cpp
+++ b/torch/csrc/jit/tensorexpr/loopnest.cpp
@@ -660,8 +660,8 @@ Stmt* LoopNest::LowerToStmt(Tensor* t) {
   for (size_t i = 0; i < f->ndim(); i++) {
     // Going in reverse order: from innermost loop to the outermost
     size_t dim_index = f->ndim() - i - 1;
-    Range r(0, ExprHandle(f->dim(dim_index)));
-    body = For::make(VarHandle(f->arg(dim_index)), r.start(), r.stop(), body);
+    Range r(new IntImm(0), f->dim(dim_index));
+    body = new For(f->arg(dim_index), r.start(), r.stop(), body);
   }
   return body;
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #35120 [NOT READY][TensorExpr] Bounds inference
* #35129 [TensorExpr] Cleanup includes in loopnest.h, use forward declarations when possible.
* #35126 [TensorExpr] Nuke tensorexpr::schedule namespace.
* **#35125 [TensorExpr] Use `const Expr*` instead of `ExprHandle&` in Range.**
* #35119 [TensorExpr] Rename schedule.{cpp,h} to loopnest.{cpp,h}.

Differential Revision: [D20568555](https://our.internmc.facebook.com/intern/diff/D20568555)