### PR TITLE
[TensorExpr] Nuke tensorexpr::schedule namespace.

### DIFF
--- a/test/cpp/tensorexpr/test_cuda.cpp
+++ b/test/cpp/tensorexpr/test_cuda.cpp
@@ -18,7 +18,7 @@
 namespace torch {
 namespace jit {
 using namespace torch::jit::tensorexpr;
-using namespace torch::jit::tensorexpr::schedule;
+using namespace torch::jit::tensorexpr;
 
 template <typename ctype>
 void testCudaTestVectorAdd01_impl() {

--- a/test/cpp/tensorexpr/test_llvm.cpp
+++ b/test/cpp/tensorexpr/test_llvm.cpp
@@ -17,7 +17,7 @@
 namespace torch {
 namespace jit {
 using namespace torch::jit::tensorexpr;
-using namespace torch::jit::tensorexpr::schedule;
+using namespace torch::jit::tensorexpr;
 
 using LLVMExprEval = ExprEval<LLVMCodeGen>;
 

--- a/test/cpp/tensorexpr/test_loopnest.cpp
+++ b/test/cpp/tensorexpr/test_loopnest.cpp
@@ -17,7 +17,7 @@ namespace torch {
 namespace jit {
 
 using namespace torch::jit::tensorexpr;
-using namespace torch::jit::tensorexpr::schedule;
+using namespace torch::jit::tensorexpr;
 
 void testExprSimple01() {
   KernelScope kernel_scope;

--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -990,7 +990,7 @@ void TensorExprKernel::lowerToBackend(BackendType backendType) {
     }
   }
 
-  torch::jit::tensorexpr::schedule::LoopNest l(tensorOutputs);
+  torch::jit::tensorexpr::LoopNest l(tensorOutputs);
 
   // Compute non-output tensors_ inline
   for (auto& p : tensors_) {

--- a/torch/csrc/jit/tensorexpr/loopnest.cpp
+++ b/torch/csrc/jit/tensorexpr/loopnest.cpp
@@ -14,7 +14,6 @@
 namespace torch {
 namespace jit {
 namespace tensorexpr {
-namespace schedule {
 
 namespace {
 
@@ -870,7 +869,6 @@ bool LoopNest::hasLoopBodyFor(Tensor* t) const {
   return tensor_to_stmt_.count(t) > 0;
 }
 
-} // namespace schedule
 } // namespace tensorexpr
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/tensorexpr/loopnest.h
+++ b/torch/csrc/jit/tensorexpr/loopnest.h
@@ -11,7 +11,6 @@
 namespace torch {
 namespace jit {
 namespace tensorexpr {
-namespace schedule {
 
 class TORCH_API LoopNest {
  public:
@@ -48,7 +47,6 @@ class TORCH_API LoopNest {
   std::unordered_set<Tensor*> output_tensors_;
   std::unordered_set<Tensor*> intermediate_tensors_;
 };
-} // namespace schedule
 } // namespace tensorexpr
 } // namespace jit
 } // namespace torch


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #35120 [NOT READY][TensorExpr] Bounds inference
* #35129 [TensorExpr] Cleanup includes in loopnest.h, use forward declarations when possible.
* **#35126 [TensorExpr] Nuke tensorexpr::schedule namespace.**
* #35125 [TensorExpr] Use `const Expr*` instead of `ExprHandle&` in Range.
* #35119 [TensorExpr] Rename schedule.{cpp,h} to loopnest.{cpp,h}.

Differential Revision: [D20569364](https://our.internmc.facebook.com/intern/diff/D20569364)