### PR TITLE
Pass the missed "non_blocking" argument for to() 

### DIFF
--- a/aten/src/ATen/native/TensorConversions.cpp
+++ b/aten/src/ATen/native/TensorConversions.cpp
@@ -33,7 +33,7 @@ static inline Tensor to_impl(const Tensor& self, const TensorOptions& options, b
     if (self.is_non_overlapping_and_dense()) {
       // Copy all strides
       auto r = at::empty_strided(self.sizes(), self.strides(), options.memory_format(c10::nullopt));
-      r.copy_(self);
+      r.copy_(self, non_blocking);
       return r;
     } else {
       memory_format = self.suggest_memory_format();

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -477,20 +477,20 @@ class TestCuda(TestCase):
         x = torch.zeros(10000000, dtype=torch.uint8).pin_memory()
         y = torch.ones(10000000, dtype=torch.uint8).cuda()
         _test_copy_non_blocking(x, y)
-    
-    def test_to_non_blocking(self): 
-        def _test_to_non_blocking(a, non_blocking): 
+
+    def test_to_non_blocking(self):
+        def _test_to_non_blocking(a, non_blocking):
             stream = torch.cuda.current_stream()
             with torch.cuda.stream(stream):
                 b = a.to('cuda', non_blocking=non_blocking)
                 self.assertEqual(stream.query(), not non_blocking)
                 stream.synchronize()
                 self.assertEqual(a, b)
-        
+
         # 10MB copies
         x = torch.ones(10000000, dtype=torch.uint8)
         _test_to_non_blocking(x, True)
-        
+
         y = torch.ones(10000000, dtype=torch.uint8)
         _test_to_non_blocking(y, False)
 

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -478,6 +478,7 @@ class TestCuda(TestCase):
         y = torch.ones(10000000, dtype=torch.uint8).cuda()
         _test_copy_non_blocking(x, y)
 
+    @unittest.skip("skipped because test could be flaky, see #35144")
     def test_to_non_blocking(self):
         def _test_to_non_blocking(a, non_blocking):
             stream = torch.cuda.current_stream()

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -477,6 +477,22 @@ class TestCuda(TestCase):
         x = torch.zeros(10000000, dtype=torch.uint8).pin_memory()
         y = torch.ones(10000000, dtype=torch.uint8).cuda()
         _test_copy_non_blocking(x, y)
+    
+    def test_to_non_blocking(self): 
+        def _test_to_non_blocking(a, non_blocking): 
+            stream = torch.cuda.current_stream()
+            with torch.cuda.stream(stream):
+                b = a.to('cuda', non_blocking=non_blocking)
+                self.assertEqual(stream.query(), not non_blocking)
+                stream.synchronize()
+                self.assertEqual(a, b)
+        
+        # 10MB copies
+        x = torch.ones(10000000, dtype=torch.uint8)
+        _test_to_non_blocking(x, True)
+        
+        y = torch.ones(10000000, dtype=torch.uint8)
+        _test_to_non_blocking(y, False)
 
     def test_serialization_array_with_storage(self):
         x = torch.randn(5, 5).cuda()


### PR DESCRIPTION
The following code
```python 
a = torch.randn(42,) 
b = a.cuda(non_blocking=True)
```
will be **blocked** in the current master, and will **not be blocked** in pytorch 1.4 release. This can be verified by a `nvprof --print-api-trace python script.py` profiling. It is causing performance issue. 

I isolated the problem, and @jjsjann123 & @ptrblck pointed out the fix. Thanks! 

cc @csarofeen @ptrblck @jjsjann123 @VitalyFedyunin @ngimel 