### PR TITLE
Add inplace tests for several torch::nn modules / functionals

### DIFF
--- a/test/cpp/api/functional.cpp
+++ b/test/cpp/api/functional.cpp
@@ -2328,9 +2328,15 @@ TEST_F(FunctionalTest, AlphaDropout) {
   auto input_std = input.std();
 
   for (const auto rate : {0.2, 0.5, 0.8}) {
-    auto output = F::alpha_dropout(input, F::AlphaDropoutFuncOptions().p(rate).training(false));
-    ASSERT_TRUE(torch::allclose(input_mean, output.mean(), 0.1));
-    ASSERT_TRUE(torch::allclose(input_std, output.std(), 0.1));
+    for (const auto inplace : {false, true}) {
+      auto input_ = input.clone();
+      auto output = F::alpha_dropout(input_, F::AlphaDropoutFuncOptions().p(rate).training(false).inplace(inplace));
+      ASSERT_TRUE(torch::allclose(input_mean, output.mean(), 0.1));
+      ASSERT_TRUE(torch::allclose(input_std, output.std(), 0.1));
+      if (inplace) {
+        ASSERT_TRUE(torch::allclose(input_, output));
+      }
+    }
   }
   auto output = F::detail::alpha_dropout(input, 0.5, false, false);
   ASSERT_TRUE(torch::allclose(input_mean, output.mean(), 0.1));
@@ -2343,9 +2349,15 @@ TEST_F(FunctionalTest, FeatureAlphaDropout) {
   auto input_std = input.std();
 
   for (const auto rate : {0.2, 0.5, 0.8}) {
-    auto output = F::feature_alpha_dropout(input, F::FeatureAlphaDropoutFuncOptions().p(rate).training(false));
-    ASSERT_TRUE(torch::allclose(input_mean, output.mean(), 0.1));
-    ASSERT_TRUE(torch::allclose(input_std, output.std(), 0.1));
+    for (const auto inplace : {false, true}) {
+      auto input_ = input.clone();
+      auto output = F::feature_alpha_dropout(input_, F::FeatureAlphaDropoutFuncOptions().p(rate).training(false).inplace(inplace));
+      ASSERT_TRUE(torch::allclose(input_mean, output.mean(), 0.1));
+      ASSERT_TRUE(torch::allclose(input_std, output.std(), 0.1));
+      if (inplace) {
+        ASSERT_TRUE(torch::allclose(input_, output));
+      }
+    }
   }
   auto output = F::feature_alpha_dropout(input);
   ASSERT_TRUE(torch::allclose(input_mean, output.mean(), 0.1));

--- a/torch/csrc/api/include/torch/nn/functional/activation.h
+++ b/torch/csrc/api/include/torch/nn/functional/activation.h
@@ -15,7 +15,7 @@ namespace functional {
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 namespace detail {
-inline Tensor elu(Tensor& input, double alpha, bool inplace) {
+inline Tensor elu(Tensor input, double alpha, bool inplace) {
   if (inplace) {
     return torch::elu_(input, alpha);
   } else {
@@ -44,7 +44,7 @@ inline Tensor elu(Tensor input, const ELUFuncOptions& options = {}) {
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 namespace detail {
-inline Tensor selu(Tensor& input, bool inplace) {
+inline Tensor selu(Tensor input, bool inplace) {
   if (inplace) {
     return torch::selu_(input);
   } else {
@@ -100,7 +100,7 @@ inline Tensor hardshrink(const Tensor& input,
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 namespace detail {
-inline Tensor hardtanh(Tensor& input,
+inline Tensor hardtanh(Tensor input,
                        double min_val,
                        double max_val,
                        bool inplace) {
@@ -132,7 +132,7 @@ inline Tensor hardtanh(Tensor input, const HardtanhFuncOptions& options = {}) {
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 namespace detail {
-inline Tensor leaky_relu(Tensor& input,
+inline Tensor leaky_relu(Tensor input,
                          double negative_slope,
                          bool inplace) {
   if (inplace) {
@@ -350,7 +350,7 @@ inline Tensor prelu(const Tensor& input, const Tensor& weight) {
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 namespace detail {
-inline Tensor relu(Tensor& input, bool inplace) {
+inline Tensor relu(Tensor input, bool inplace) {
   if (inplace) {
     return torch::relu_(input);
   } else {
@@ -379,7 +379,7 @@ inline Tensor relu(Tensor input, const ReLUFuncOptions& options = {}) {
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 namespace detail {
-inline Tensor relu6(Tensor& input, bool inplace) {
+inline Tensor relu6(Tensor input, bool inplace) {
   return detail::hardtanh(input, /*min_val=*/0, /*max_val=*/6, /*inplace=*/inplace);
 }
 } // namespace detail
@@ -404,7 +404,7 @@ inline Tensor relu6(Tensor input, const ReLU6FuncOptions& options = {}) {
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 namespace detail {
-inline Tensor rrelu(Tensor& input,
+inline Tensor rrelu(Tensor input,
                     double lower,
                     double upper,
                     bool training,
@@ -437,7 +437,7 @@ inline Tensor rrelu(Tensor input, const RReLUFuncOptions& options = {}) {
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 namespace detail {
-inline Tensor celu(Tensor& input,
+inline Tensor celu(Tensor input,
                    double alpha,
                    bool inplace) {
   if (inplace) {
@@ -536,7 +536,7 @@ inline Tensor tanhshrink(const Tensor& input) {
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 namespace detail {
-inline Tensor threshold(Tensor& input,
+inline Tensor threshold(Tensor input,
                         double threshold,
                         double value,
                         bool inplace) {

--- a/torch/csrc/api/include/torch/nn/functional/dropout.h
+++ b/torch/csrc/api/include/torch/nn/functional/dropout.h
@@ -9,7 +9,7 @@ namespace functional {
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 namespace detail {
 
-inline Tensor dropout(Tensor& input, double p, bool training, bool inplace) {
+inline Tensor dropout(Tensor input, double p, bool training, bool inplace) {
   TORCH_CHECK(
     p >= 0. && p <= 1.,
     "dropout probability has to be between 0 and 1, but got ",
@@ -46,7 +46,7 @@ inline Tensor dropout(Tensor input,
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 namespace detail {
 
-inline Tensor dropout2d(Tensor& input, double p, bool training, bool inplace) {
+inline Tensor dropout2d(Tensor input, double p, bool training, bool inplace) {
   TORCH_CHECK(
     p >= 0. && p <= 1.,
     "dropout probability has to be between 0 and 1, but got ",
@@ -83,7 +83,7 @@ inline Tensor dropout2d(Tensor input,
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 namespace detail {
 
-inline Tensor dropout3d(Tensor& input, double p, bool training, bool inplace) {
+inline Tensor dropout3d(Tensor input, double p, bool training, bool inplace) {
   TORCH_CHECK(
     p >= 0. && p <= 1.,
     "dropout probability has to be between 0 and 1, but got ",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#35147 Add inplace tests for several torch::nn modules / functionals**
* #35025 Fix F::interpolate and torch::nn::Upsample implementation
* #35024 Fix fractional_max_pool3d_with_indices implementation
* #35023 Fix Conv and ConvTranspose implementation
* #35022 Fix AdaptiveAvgPool{2,3}d and AdaptiveMaxPool{2,3}d implementation

Differential Revision: [D20578217](https://our.internmc.facebook.com/intern/diff/D20578217)