### PR TITLE
[pytorch] revert register c10 ops for static dispatch

### DIFF
--- a/aten/src/ATen/templates/BackendSelectRegister.cpp
+++ b/aten/src/ATen/templates/BackendSelectRegister.cpp
@@ -9,6 +9,8 @@
 #include <ATen/core/op_registration/op_registration.h>
 #include <c10/core/TensorOptions.h>
 
+
+#ifndef USE_STATIC_DISPATCH
 namespace at {
 
 namespace {
@@ -21,3 +23,4 @@ static auto registry = torch::RegisterOperators()
 
 } // namespace
 } // at
+#endif

--- a/aten/src/ATen/templates/PerOpRegistration.cpp
+++ b/aten/src/ATen/templates/PerOpRegistration.cpp
@@ -7,9 +7,11 @@ $extra_headers
 
 namespace at {
 
+#ifndef USE_STATIC_DISPATCH
 namespace {
 auto registerer = torch::import()
   ${function_registrations};
 }
+#endif
 
 }  // namespace at

--- a/aten/src/ATen/templates/SparseTypeDerived.cpp
+++ b/aten/src/ATen/templates/SparseTypeDerived.cpp
@@ -42,9 +42,11 @@ ${type_derived_method_definitions}
 
 }  // namespace ${Type}
 
+#ifndef USE_STATIC_DISPATCH
 namespace {
 static auto registerer = torch::import()
   ${function_registrations};
 }
+#endif
 
 }

--- a/aten/src/ATen/templates/TypeDefault.cpp
+++ b/aten/src/ATen/templates/TypeDefault.cpp
@@ -29,9 +29,11 @@ ${type_method_definitions}
 
 }  // namespace TypeDefault
 
+#ifndef USE_STATIC_DISPATCH
 namespace {
 auto registerer = torch::import()
   ${function_registrations};
 }
+#endif
 
 }  // namespace at

--- a/aten/src/ATen/templates/TypeDerived.cpp
+++ b/aten/src/ATen/templates/TypeDerived.cpp
@@ -53,9 +53,11 @@ ${type_derived_method_definitions}
 
 }  // namespace ${Type}
 
+#ifndef USE_STATIC_DISPATCH
 namespace {
 auto registerer = torch::import()
   ${function_registrations};
 }
+#endif
 
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#35148 [pytorch] revert register c10 ops for static dispatch**

Summary:
PR #34275 (commit 064c47845380715e290eb335919a18fe3821ee83) causes size
regression for BUCK build before BUCK selective build is enabled.

This PR reverts partially (adding back #ifndef USE_STATIC_DISPATCH) to
fix the size regression. Will wait for BUCK selective build change to
land and soak then revert this revert.

Differential Revision: [D20578316](https://our.internmc.facebook.com/intern/diff/D20578316)