### PR TITLE
[jit] Improve error message when setting nonexistent attribute

### DIFF
--- a/test/jit/test_class_type.py
+++ b/test/jit/test_class_type.py
@@ -941,3 +941,11 @@ class TestClassType(JitTestCase):
             self.assertEqual(m(input), m_loaded(input))
             # Make sure class constant is accessible from module
             self.assertEqual(m.w, m_loaded.w)
+
+    def test_nonexistent_attribute(self):
+        class MyCoolModule(torch.nn.Module):
+            def forward(self):
+                self.not_here = 1
+
+        with self.assertRaisesRegex(RuntimeError, "nonexistent.*not_here.*MyCoolModule"):
+            torch.jit.script(MyCoolModule())

--- a/torch/csrc/jit/frontend/sugared_value.cpp
+++ b/torch/csrc/jit/frontend/sugared_value.cpp
@@ -258,7 +258,8 @@ void SimpleValue::setAttr(
       }
     } else {
       throw ErrorReport(loc)
-          << "Tried to set nonexistent attribute: " << field
+          << "Tried to set nonexistent attribute "
+          << "\"" << field << "\" of type \"" << classType->str() << "\""
           << ". Did you forget to initialize it in __init__()?";
     }
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#35166 [jit] Improve error message when setting nonexistent attribute**

Summary:
I was confused by this message while doing some weird stuff with traced
modules.  Adding the class name to the message made it more clear what
was going on.

Test Plan:
Unit test.

Reviewers: suo