### PR TITLE
Fix naming of "strides" method in TensorType

### DIFF
--- a/test/jit/test_python_ir.py
+++ b/test/jit/test_python_ir.py
@@ -1,0 +1,22 @@
+import torch
+from torch.testing._internal.jit_utils import JitTestCase
+
+from torch.testing import FileCheck
+
+import io
+
+if __name__ == '__main__':
+    raise RuntimeError("This test file is not meant to be run directly, use:\n\n"
+                       "\tpython test/test_jit.py TESTNAME\n\n"
+                       "instead.")
+
+class TestPythonIr(JitTestCase):
+    def test_param_strides(self):
+        def trace_me(arg):
+            return arg
+        t = torch.zeros(1,3,16,16)
+        traced = torch.jit.trace(trace_me, t)
+        value = list(traced.graph.param_node().outputs())[0]
+        real_strides = list(t.stride())
+        type_strides = value.type().strides()
+        self.assertEqual(real_strides, type_strides)

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -23,6 +23,7 @@ from jit.test_class_type import TestClassType  # noqa: F401
 from jit.test_builtins import TestBuiltins, TestTensorBuiltins  # noqa: F401
 from jit.test_unsupported_ops import TestUnsupportedOps  # noqa: F401
 from jit.test_freezing import TestFreezing  # noqa: F401
+from jit.test_python_ir import TestPythonIr  # noqa: F401
 
 # Torch
 from torch import Tensor

--- a/torch/csrc/jit/python/python_ir.cpp
+++ b/torch/csrc/jit/python/python_ir.cpp
@@ -666,7 +666,7 @@ void initPythonIRBindings(PyObject* module_) {
             return py::none();
           })
       .def(
-          "sizes",
+          "strides",
           [](Type& t) -> py::object {
             if (auto ptt = t.expect<TensorType>()) {
               if (auto cs = ptt->strides().concrete_sizes()) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#35170 Fix naming of "strides" method in TensorType**

Summary:
Looks like this was renamed by accident in 0cbd7fa46f2

Test Plan:
Unit test.

Reviewers: zdevito

Differential Revision: [D20783298](https://our.internmc.facebook.com/intern/diff/D20783298)