### PR TITLE
[pytorch] deprecate code analyzer -closure option

### DIFF
--- a/.jenkins/pytorch/build-mobile-code-analysis.sh
+++ b/.jenkins/pytorch/build-mobile-code-analysis.sh
@@ -22,4 +22,4 @@ echo "LLVM_DIR: ${LLVM_DIR}"
 time ANALYZE_TEST=1 CHECK_RESULT=1 tools/code_analyzer/build.sh
 
 # 2. Run code analysis on mobile LibTorch
-time ANALYZE_TORCH=1 tools/code_analyzer/build.sh -closure=false
+time ANALYZE_TORCH=1 tools/code_analyzer/build.sh

--- a/test/mobile/custom_build/build.sh
+++ b/test/mobile/custom_build/build.sh
@@ -47,7 +47,7 @@ generate_op_dependency_graph() {
   if [ ! -f "${OP_DEPENDENCY}" ]; then
     BUILD_ROOT="${ANALYZER_BUILD_ROOT}" \
       ANALYZE_TORCH=1 \
-      "${SRC_ROOT}/tools/code_analyzer/build.sh" -closure=false
+      "${SRC_ROOT}/tools/code_analyzer/build.sh"
   fi
 }
 

--- a/test/mobile/op_deps/expected_deps.yaml
+++ b/test/mobile/op_deps/expected_deps.yaml
@@ -1,42 +1,32 @@
 - name: aten::AA
   depends:
-  - name: aten::AA
   - name: aten::BB
 - name: aten::BB
   depends:
   - name: aten::AA
-  - name: aten::BB
 - name: aten::CC
   depends:
   - name: aten::AA
-  - name: aten::BB
 - name: aten::DD
   depends:
   - name: aten::AA
-  - name: aten::BB
   - name: aten::EE
-  - name: aten::FF
 - name: aten::EE
   depends:
-  - name: aten::EE
   - name: aten::FF
 - name: aten::FF
   depends:
   - name: aten::EE
-  - name: aten::FF
 - name: aten::GG
   depends:
-  - name: aten::EE
   - name: aten::FF
 - name: aten::HH
 - name: quantized::t_add
   depends:
   - name: quantized::t_helper1
-  - name: quantized::t_helper3
 - name: quantized::t_add_relu
   depends:
   - name: quantized::t_helper2
-  - name: quantized::t_helper4
 - name: quantized::t_helper1
   depends:
   - name: quantized::t_helper3

--- a/tools/code_analyzer/build.sh
+++ b/tools/code_analyzer/build.sh
@@ -15,7 +15,7 @@
 #
 # 3. Analyze torch and generate yaml file of op dependency with debug path:
 # LLVM_DIR=${HOME}/src/llvm8/build/install \
-# ANALYZE_TORCH=1 tools/code_analyzer/build.sh -closure=false -debug_path=true
+# ANALYZE_TORCH=1 tools/code_analyzer/build.sh -debug_path=true
 
 set -ex
 
@@ -100,7 +100,7 @@ analyze_torch_mobile() {
     cat > ${DEST} <<- EOM
 # Generated for selective build without using static dispatch.
 # Manually run the script to update:
-# ANALYZE_TORCH=1 FORMAT=py DEPLOY=1 tools/code_analyzer/build.sh -closure=false
+# ANALYZE_TORCH=1 FORMAT=py DEPLOY=1 tools/code_analyzer/build.sh
 EOM
     printf "TORCH_DEPS = " >> ${DEST}
     cat "${OUTPUT}" >> ${DEST}

--- a/tools/code_analyzer/op_dependency.cpp
+++ b/tools/code_analyzer/op_dependency.cpp
@@ -137,7 +137,7 @@ cl::opt<OutputFormatType> OutputFormat(
 cl::opt<bool> TransitiveClosure(
     "closure",
     cl::desc("Output transitive closure."),
-    cl::init(true));
+    cl::init(false));
 
 cl::opt<int> Verbose(
     "v",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#35179 [pytorch] deprecate code analyzer -closure option**

Transitive dependencies are calculated in python script for both OSS custom build and BUCK selective build, so change the c++ analyzer to take -closure=false by default and remove the param from callsites.

Differential Revision: [D20586462](https://our.internmc.facebook.com/intern/diff/D20586462/)