### PR TITLE
Add THP_API to THPGenerator_Wrap

### DIFF
--- a/aten/src/ATen/native/Math.h
+++ b/aten/src/ATen/native/Math.h
@@ -82,7 +82,7 @@ Date:  February 1996
   if(y_abs > 1.0) return std::numeric_limits<T>::quiet_NaN();
 #ifdef _WIN32
   if(y_abs == 1.0) return copysign(std::numeric_limits<T>::infinity(), y);
-#elif
+#else
   if(y_abs == 1.0) return std::copysign(std::numeric_limits<T>::infinity(), y);
 #endif
   if(y_abs <= static_cast<T>(CENTRAL_RANGE)) {
@@ -97,7 +97,7 @@ Date:  February 1996
     dem = (d[1]*z + d[0])*z + static_cast<T>(1.0);
 #ifdef _WIN32
     x = copysign(num, y) / dem;
-#elif
+#else
     x = std::copysign(num, y) / dem;
 #endif
   }

--- a/aten/src/ATen/native/Math.h
+++ b/aten/src/ATen/native/Math.h
@@ -2,6 +2,7 @@
 
 #include <cstdlib>
 #include <cmath>
+#include <cfloat>
 #include <limits>
 #include <type_traits>
 #include <c10/util/math_compat.h>

--- a/aten/src/ATen/native/Math.h
+++ b/aten/src/ATen/native/Math.h
@@ -80,7 +80,11 @@ Date:  February 1996
   T d[2]={ 3.543889200,  1.637067800};
   T y_abs = std::abs(y);
   if(y_abs > 1.0) return std::numeric_limits<T>::quiet_NaN();
+#ifdef _WIN32
+  if(y_abs == 1.0) return copysign(std::numeric_limits<T>::infinity(), y);
+#elif
   if(y_abs == 1.0) return std::copysign(std::numeric_limits<T>::infinity(), y);
+#endif
   if(y_abs <= static_cast<T>(CENTRAL_RANGE)) {
     z = y * y;
     num = (((a[3]*z + a[2])*z + a[1])*z + a[0]);
@@ -91,7 +95,11 @@ Date:  February 1996
     z = std::sqrt(-std::log((static_cast<T>(1.0)-y_abs)/static_cast<T>(2.0)));
     num = ((c[3]*z + c[2])*z + c[1]) * z + c[0];
     dem = (d[1]*z + d[0])*z + static_cast<T>(1.0);
+#ifdef _WIN32
+    x = copysign(num, y) / dem;
+#elif
     x = std::copysign(num, y) / dem;
+#endif
   }
   /* Two steps of Newton-Raphson correction */
   x = x - (std::erf(x) - y) / ((static_cast<T>(2.0)/static_cast<T>(std::sqrt(M_PI)))*std::exp(-x*x));

--- a/torch/csrc/Generator.h
+++ b/torch/csrc/Generator.h
@@ -22,7 +22,7 @@ THP_API PyObject *THPGeneratorClass;
 
 bool THPGenerator_init(PyObject *module);
 
-PyObject * THPGenerator_Wrap(at::Generator gen);
+THP_API PyObject * THPGenerator_Wrap(at::Generator gen);
 
 // Creates a new Python object for a Generator. The Generator must not already
 // have a PyObject* associated with it.


### PR DESCRIPTION
Fixes:
```
error LNK2001: unresolved external symbol "struct _object * __cdecl THPGenerator_Wrap(struct at::Generator)" (?THPGenerator_Wrap@@YAPEAU_object@@UGenerator@at@@@Z)
build\lib.win-amd64-3.6\torch_test_cpp_extension\rng.cp36-win_amd64.pyd : fatal error LNK1120: 1 unresolved externals
```

I forgot it, my fault

Stack from [ghstack](https://github.com/ezyang/ghstack):
* #35167 Move normal() to DistributionTemplates
* #35199 Fix  _copysign is not a member of std (Windows)
* **#35194 Add THP_API to THPGenerator_Wrap**

Differential Revision: [D20591604](https://our.internmc.facebook.com/intern/diff/D20591604)