### PR TITLE
[NOT_FOR_COMMIT][android] Pytorch android build with USE_LAPACK and QML lib

### DIFF
--- a/android/pytorch_android/CMakeLists.txt
+++ b/android/pytorch_android/CMakeLists.txt
@@ -89,6 +89,23 @@ if (ANDROID_ABI)
   import_static_lib(libcpuinfo)
   import_static_lib(libclog)
 
+  add_library(libQML STATIC IMPORTED)
+  if (${ANDROID_ABI} STREQUAL "arm64-v8a")
+    set(libQML_path ${CMAKE_CURRENT_LIST_DIR}/../libs/QML-1.4.0-android/opt/Qualcomm/QML/1.4.0/arm64/lp64/lib/libQML-1.4.0.so)
+  elseif  (${ANDROID_ABI} STREQUAL "armeabi-v7a")
+    set(libQML_path ${CMAKE_CURRENT_LIST_DIR}/../libs/QML-1.4.0-android/opt/Qualcomm/QML/1.4.0/arm32/lp64/lib/libQML-1.4.0.so)
+  else()
+    message(FATAL_ERROR "ERROR: No LAPACK implementation for android x86, x86_64, need for USE_LAPACK")
+  endif()
+
+  message(STATUS "ANDROID_ABI:" ${ANDROID_ABI})
+  message(STATUS "libQML_path:" ${libQML_path})
+
+  set_property(
+      TARGET libQML
+      PROPERTY IMPORTED_LOCATION
+      ${libQML_path})
+
     # Link most things statically on Android.
   target_link_libraries(pytorch_jni
       fbjni
@@ -104,6 +121,7 @@ if (ANDROID_ABI)
       libeigen_blas
       libcpuinfo
       libclog
+      libQML
   )
 
 else()

--- a/scripts/build_android.sh
+++ b/scripts/build_android.sh
@@ -117,6 +117,8 @@ if [ "${ANDROID_DEBUG_SYMBOLS:-}" == '1' ]; then
   CMAKE_ARGS+=("-DANDROID_DEBUG_SYMBOLS=1")
 fi
 
+CMAKE_ARGS+=("-DUSE_LAPACK=ON")
+
 # Use-specified CMake arguments go last to allow overridding defaults
 CMAKE_ARGS+=($@)
 


### PR DESCRIPTION
Just as an experiment and follow up for https://discuss.pytorch.org/t/problems-with-lapack-on-android/73111

0.Changes:
0.1 `scripts/build_android.sh` turn on USE_LAPACK in 
`CMAKE_ARGS+=("-DUSE_LAPACK=ON")`

0.2 `android/pytorch_android/CMakeLists.txt` - Linking Qualcomm Math Library into pytorch_android

1. Download Qualcomm Math Library https://developer.qualcomm.com/software/qualcomm-math-library (You might need to register new user to download it)
2. Unpack it in `${PYTORCH_ROOT}/android/libs`

QML can be used for armeabi-v7a, arm64-v8a android abis

3. sh ./scripts/build_pytorch_android.sh arm64-v8a,armeabi-v7a

