### PR TITLE
Match case of package name to suppress warning

### DIFF
--- a/cmake/TorchConfig.cmake.in
+++ b/cmake/TorchConfig.cmake.in
@@ -127,4 +127,4 @@ if (TORCH_CXX_FLAGS)
   set_property(TARGET torch PROPERTY INTERFACE_COMPILE_OPTIONS "${TORCH_CXX_FLAGS}")
 endif()
 
-find_package_handle_standard_args(torch DEFAULT_MSG TORCH_LIBRARY TORCH_INCLUDE_DIRS)
+find_package_handle_standard_args(Torch DEFAULT_MSG TORCH_LIBRARY TORCH_INCLUDE_DIRS)


### PR DESCRIPTION
https://github.com/Kitware/CMake/commit/ee4673c1ae1e4a1aa4687412717567c2ffbb501b

`find_package(Torch)` is used most of the time: https://pytorch.org/cppdocs/installing.html

