### PR TITLE
custom class method holder should hold a unique_ptr

### DIFF
--- a/aten/src/ATen/core/custom_class.cpp
+++ b/aten/src/ATen/core/custom_class.cpp
@@ -28,12 +28,12 @@ bool isCustomClass(const c10::IValue& v) {
       getCustomClass(v.toObject()->type()->name()->qualifiedName());
 }
 
-std::vector<std::shared_ptr<jit::Function>>& customClassMethods() {
-  static std::vector<std::shared_ptr<jit::Function>> customClassMethods;
+std::vector<std::unique_ptr<jit::Function>>& customClassMethods() {
+  static std::vector<std::unique_ptr<jit::Function>> customClassMethods;
   return customClassMethods;
 }
 
-void registerCustomClassMethod(std::shared_ptr<jit::Function> fn) {
+void registerCustomClassMethod(std::unique_ptr<jit::Function> fn) {
   customClassMethods().emplace_back(std::move(fn));
 }
 

--- a/torch/custom_class.h
+++ b/torch/custom_class.h
@@ -219,15 +219,15 @@ class class_ {
           typename c10::guts::infer_function_traits_t<Func>::return_type;
       detail::BoxedProxy<RetType, Func>()(stack, func);
     };
-    auto method = std::make_shared<jit::BuiltinOpFunction>(
+    auto method = std::make_unique<jit::BuiltinOpFunction>(
         qualMethodName, std::move(schema), std::move(wrapped_func));
 
     // Register the method here to keep the Method alive.
     // ClassTypes do not hold ownership of their methods (normally it
     // those are held by the CompilationUnit), so we need a proxy for
     // that behavior here.
-    registerCustomClassMethod(method);
     classTypePtr->addMethod(method.get());
+    registerCustomClassMethod(std::move(method));
   }
 
   std::string className;

--- a/torch/custom_class_detail.h
+++ b/torch/custom_class_detail.h
@@ -122,7 +122,7 @@ struct BoxedProxy<void, Func> {
 } // namespace detail
 
 TORCH_API void registerCustomClass(at::ClassTypePtr class_type);
-TORCH_API void registerCustomClassMethod(std::shared_ptr<jit::Function> method);
+TORCH_API void registerCustomClassMethod(std::unique_ptr<jit::Function> method);
 
 // Given a qualified name (e.g. __torch__.torch.classes.Foo), return
 // the ClassType pointer to the Type that describes that custom class,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#35218 custom class method holder should hold a unique_ptr**

We should express the ownership semantics directly here. Using
`shared_ptr` makes it too easy to leak ownership by inadvertently
storing a copy.

Differential Revision: [D20682673](https://our.internmc.facebook.com/intern/diff/D20682673)