### PR TITLE
[quant][graphmode] weight/bias of linear/conv can be reused for multiple ops

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1171,6 +1171,22 @@ graph(%x : Tensor,
         assert list(activation_dtypes)[0] != list(weight_dtypes)[0], 'Expected activation dtype to '
         ' be different from wegiht dtype'
 
+    def test_insert_observers_for_reused_weight(self):
+        class M(torch.nn.Module):
+            def __init__(self):
+                super(M, self).__init__()
+
+            def forward(self, x, y, weight):
+                x = F.conv2d(x, weight)
+                y = F.conv2d(y, weight)
+                return x + y
+
+        m = torch.jit.script(M()).eval()
+        qconfig_dict = {'' : script_qconfig(default_qconfig)}
+        m = prepare_script(m, qconfig_dict, False)
+        # 3 for x, y, weight, one for output of each F.conv2d
+        assert len(attrs_with_prefix(m, '_observer')) == 5
+
     def test_insert_observers_shared_class_type(self):
         class M(torch.nn.Module):
             def __init__(self):

--- a/torch/csrc/jit/passes/quantization.cpp
+++ b/torch/csrc/jit/passes/quantization.cpp
@@ -641,12 +641,6 @@ bool isBiasOfConvOrLinear(Value* v) {
       v,
       AtenFuncArgs({{"conv2d", 2}, {"linear", 2}}),
       CallFuncArgs({{"linear", 3}}));
-  if (result) {
-    TORCH_CHECK(
-        v->uses().size() == 1,
-        "Graph mode quantization only supports conv/linear bias being used by"
-        " one node.");
-  }
   return result;
 }
 
@@ -655,12 +649,6 @@ bool isWeightOfConvOrLinear(Value* v) {
       v,
       AtenFuncArgs({{"conv2d", 1}, {"linear", 1}}),
       CallFuncArgs({{"linear", 2}}));
-  if (result) {
-    TORCH_CHECK(
-        v->uses().size() == 1,
-        "Graph mode quantization only supports conv/linear weight being used by"
-        " one node.");
-  }
   return result;
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #35130 [quant][graphmode] Make interpolate/upsample work again
* #35142 [quant][graphmode] SwapDeQuant support prim::If
* #35141 [quant][graphmode][refactor] getGeneralOpTensorInputIndexes -> getGeneralOpTensorInputs
* #35135 [quant][graphmode][refactor] swapDeQuant takes block as arugment
* #35077 [quant][graphmode] Fold quantized prepacking ops
* #35073 [quant] Make conv2d_prepack and linear_prepack pure
* #34855 [quant][graphmode] quantization support for prim::CallFunction
* #34346 [quant][graphmode] Add quantization support for aten::cat
* #34345 [quant][graphmode] Add prim::ListConstruct to general op handling
* #34854 [quant][graphmode] quantization support for view, transpose, contiguos
* #34806 [quant][graphmode] quantization support for aten::chunk
* #34807 [quant][graphmode] quantization support for prim::ListUnpack
* #34804 [quant][graphmode] Replicate quantize node for prim::If
* #34572 [quant][graphmode] quantization support for aten::add
* **#35221 [quant][graphmode] weight/bias of linear/conv can be reused for multiple ops**

Summary:
When weight is reused, we only need to insert one observer for the weight

Test Plan:
python test/test_jit.py

Reviewers:
.

Subscribers:

Tasks:

Tags:

Differential Revision: [D20602492](https://our.internmc.facebook.com/intern/diff/D20602492)