### PR TITLE
[Autograd Testing] Add a test where child reentrant task fails.

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -2142,6 +2142,42 @@ class TestAutograd(TestCase):
         out.sum().backward()
         self.assertEqual(x.grad, y_data)
 
+    def test_reentrant_child_error(self):
+        class BackwardError(Function):
+            @staticmethod
+            def forward(ctx, inp):
+                return inp
+
+            @staticmethod
+            def backward(ctx, grad):
+                raise Exception('simulate error')
+
+        # Parent graph.
+        a = torch.rand(3, 3, requires_grad=True)
+        b = torch.rand(3, 3, requires_grad=True)
+        c = a * a
+
+        # Reentrant child graph.
+        e = b * b
+        f = BackwardError.apply(e)
+        reentrant_root = f.sum()
+
+        class ReentrantFunc(Function):
+
+            @staticmethod
+            def forward(ctx, inp):
+                return inp
+
+            @staticmethod
+            def backward(ctx, grad):
+                # Reentrant backward in child will throw an error.
+                reentrant_root.backward()
+                return grad
+
+        d = ReentrantFunc.apply(c)
+        with self.assertRaisesRegex(RuntimeError, 'simulate error'):
+            d.sum().backward()
+
     def test_broadcast_tensors(self):
         f_args_variable = (torch.randn(3, requires_grad=True),
                            torch.randn(1, 2, 1, requires_grad=True),

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -2154,10 +2154,10 @@ class TestAutograd(TestCase):
 
         # Parent graph.
         a = torch.rand(3, 3, requires_grad=True)
-        b = torch.rand(3, 3, requires_grad=True)
         c = a * a
 
         # Reentrant child graph.
+        b = torch.rand(3, 3, requires_grad=True)
         e = b * b
         f = BackwardError.apply(e)
         reentrant_root = f.sum()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#35223 [Autograd Testing] Add a test where child reentrant task fails.**
finishes.
* **#35223 [Autograd Testing] Add a test where child reentrant task fails.**

Adding tests as part of
https://github.com/pytorch/pytorch/issues/34367.

This test covers
"Mixed with errors" ->
"Reentrant on same device" ->
"Make child error before parent finishes"

Differential Revision: [D20603127](https://our.internmc.facebook.com/intern/diff/D20603127/)