### PR TITLE
[ROCm] Properly blacklist

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -117,6 +117,9 @@ ROCM_BLACKLIST = [
     'test_cpp_extensions_jit',
     'test_determination',
     'test_multiprocessing',
+    'test_jit_simple',
+    'test_jit_legacy',
+    'test_jit_fuser_legacy',
 ]
 
 # These tests are slow enough that it's worth calculating whether the patch


### PR DESCRIPTION
test_python_all_except_nn
+ /usr/bin/python3.6 test/run_test.py --exclude test_nn test_jit_simple
test_jit_legacy test_jit_fuser_legacy --verbose --bring-to-front
test_quantization test_quantized test_quantized_tensor
test_quantized_nn_mods --determine-from=

test_nn continues to be run as part of test1 target

This will allows us to run run_test.py and correctly disabling these sets for ROCm.

