### PR TITLE
Fix Tensor __radd__ type hint issue

### DIFF
--- a/tools/pyi/gen_pyi.py
+++ b/tools/pyi/gen_pyi.py
@@ -179,7 +179,7 @@ def arg_to_type_hint(arg):
 
 
 binary_ops = ('add', 'sub', 'mul', 'div', 'pow', 'lshift', 'rshift', 'mod', 'truediv',
-              'matmul', 'floordiv', 'floor_divide'
+              'matmul', 'floordiv', 'floor_divide',
               'radd', 'rsub', 'rmul', 'rtruediv', 'rfloordiv', 'rpow',          # reverse arithmetic
               'and', 'or', 'xor',                   # logic
               'iadd', 'iand', 'idiv', 'ilshift', 'imul',


### PR DESCRIPTION
Fixes #35213

Test plan: `mypy -c "import torch; ten = torch.tensor([1.0, 2.0, 3.0]); print(7 + ten)"` should not produce any warnings

Stack from [ghstack](https://github.com/ezyang/ghstack):
* #35167 Move normal() to DistributionTemplates
* **#35231 Fix Tensor __radd__ type hint issue**

Differential Revision: [D20604924](https://our.internmc.facebook.com/intern/diff/D20604924)