### PR TITLE
[workflows] Add clang-format workflow

### DIFF
--- a/.github/workflows/clang_format.yml
+++ b/.github/workflows/clang_format.yml
@@ -1,0 +1,35 @@
+name: Clang Format
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+
+jobs:
+  clang-format:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.x
+          architecture: x64
+      - name: Fetch PyTorch
+        uses: actions/checkout@v1
+      - name: Checkout PR tip
+        run: |
+          set -eux
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            # We are on a PR, so actions/checkout leaves us on a merge commit.
+            # Check out the actual tip of the branch.
+            git checkout ${{ github.event.pull_request.head.sha }}
+          fi
+          echo ::set-output name=commit_sha::$(git rev-parse HEAD)
+        id: get_pr_tip
+      - name: Run clang-format
+        run: |
+          set -eux
+          echo "Run tools/clang_format.py to fix formatting errors"
+          tools/clang_format.py --verbose --diff > ${GITHUB_WORKSPACE}/clang-format-output.txt
+          cat ${GITHUB_WORKSPACE}/clang-format-output.txt

--- a/tools/clang_format.py
+++ b/tools/clang_format.py
@@ -150,6 +150,8 @@ async def run_clang_format(max_processes, diff=False, verbose=False):
     else:
         await asyncio.gather(*[run_clang_format_on_file(f, semaphore, verbose) for f in get_whitelisted_files()])
 
+    return ok
+
 
 def report_download_progress(chunk_number, chunk_size, file_size):
     """


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#35239 [workflows] Add clang-format workflow**
* #35115 [JIT] clang-format JIT code
* #35114 [tools] Replace clang_format.py with clang_format_new.py

Summary:
This commit adds a new GitHub workflow that checks if a pull request
has any formatting issues using `tools/clang_format.py`.

Testing:
Literally in prod.

Differential Revision: [D20605802](https://our.internmc.facebook.com/intern/diff/D20605802)