### PR TITLE
[JIT] BC shim for TorchBind classes

### DIFF
--- a/torch/csrc/jit/serialization/import_source.cpp
+++ b/torch/csrc/jit/serialization/import_source.cpp
@@ -262,6 +262,22 @@ struct SourceImporterImpl : public Resolver,
       const QualifiedName& qualified_classname,
       const ClassDef& class_def,
       bool is_module) {
+    // BC for TorchBind classes
+    //
+    // Previously we would serialize TorchBind classes as actual
+    // classes with methods that delegate to things in the
+    // torch.ops.* namespace. We've switched away from this and
+    // now just rely on those classes being present in the class
+    // and emitting code for them based on the ClassType in memory.
+    //
+    // TODO: remove this once we no longer have old TorchBind code
+    // in production models
+    {
+      QualifiedName torch_classes_qualname("__torch__.torch.classes");
+      if (torch_classes_qualname.isPrefixOf(qualified_classname)) {
+        return;
+      }
+    }
     auto class_type = ClassType::create(
         c10::QualifiedName(qualified_classname), cu_, is_module);
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #35254 [reapply][JIT] Namespaces for TorchBind
* **#35240 [JIT] BC shim for TorchBind classes**

This makes it so that if we have an old serialized TorchBind class, we don't try to load it in and instead rely on the ClassType that's in memory.

Differential Revision: [D20605681](https://our.internmc.facebook.com/intern/diff/D20605681/)