### PR TITLE
[release/1.5] .circleci: Fix unbound CIRCLE_TAG variable

### DIFF
--- a/.circleci/scripts/binary_populate_env.sh
+++ b/.circleci/scripts/binary_populate_env.sh
@@ -6,7 +6,7 @@ tagged_version() {
   # Grabs version from either the env variable CIRCLE_TAG
   # or the pytorch git described version
   GIT_DESCRIBE="git --git-dir ${workdir}/pytorch/.git describe"
-  if [[ -n ${CIRCLE_TAG} ]]; then
+  if [[ -n "${CIRCLE_TAG:-}" ]]; then
     echo "${CIRCLE_TAG}"
   elif ${GIT_DESCRIBE} --exact --tags >/dev/null; then
     ${GIT_DESCRIBE} --tags


### PR DESCRIPTION
Was failing when trying to execute this script on a non-tag

Original commit can be found here: https://github.com/pytorch/pytorch/pull/35065

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

