### PR TITLE
Optimize index_select for 1D inputs

### DIFF
--- a/aten/src/ATen/native/Repeat.cpp
+++ b/aten/src/ATen/native/Repeat.cpp
@@ -38,19 +38,7 @@ Tensor repeat_interleave(const Tensor &self, const Tensor &repeats, c10::optiona
         AT_ERROR("repeats must be 0-dim or 1-dim tensor");
     }
 
-    /* This has the same semantics as:
-     *   `input.index_select(dim.value(), at::repeat_interleave(repeats_))`,
-     * but implementing with gather is faster than `input.index_select`
-     */
-    Tensor indices = at::repeat_interleave(repeats_);
-
-    SmallVector<int64_t, 4> indices_sizes(/*n=*/input.dim(), /*value=*/1);
-    indices_sizes[dim.value()] = indices.size(0);
-    auto input_sizes = input.sizes();
-    SmallVector<int64_t, 4> expand_sizes(input_sizes.begin(), input_sizes.end());
-    expand_sizes[dim.value()] = indices.size(0);
-
-    return input.gather(dim.value(), indices.view(indices_sizes).expand(expand_sizes));
+    return input.index_select(dim.value(), at::repeat_interleave(repeats_);
 }
 
 Tensor repeat_interleave(const Tensor &self, int64_t repeats, c10::optional<int64_t> dim) {

--- a/aten/src/ATen/native/Repeat.cpp
+++ b/aten/src/ATen/native/Repeat.cpp
@@ -1,7 +1,6 @@
 #include <ATen/ATen.h>
 #include <ATen/native/Repeat.h>
 #include <ATen/Parallel.h>
-#include <c10/util/SmallVector.h>
 
 static void compute_cpu(int64_t *repeat_ptr, int64_t *cumsum_ptr, int64_t *result_ptr, int64_t size) {
     at::parallel_for(0, size, 1, [&](int64_t i_begin, int64_t i_end) {
@@ -38,7 +37,7 @@ Tensor repeat_interleave(const Tensor &self, const Tensor &repeats, c10::optiona
         AT_ERROR("repeats must be 0-dim or 1-dim tensor");
     }
 
-    return input.index_select(dim.value(), at::repeat_interleave(repeats_);
+    return input.index_select(dim.value(), at::repeat_interleave(repeats_));
 }
 
 Tensor repeat_interleave(const Tensor &self, int64_t repeats, c10::optional<int64_t> dim) {

--- a/aten/src/ATen/native/Repeat.cpp
+++ b/aten/src/ATen/native/Repeat.cpp
@@ -17,6 +17,12 @@ static void compute_cpu(int64_t *repeat_ptr, int64_t *cumsum_ptr, int64_t *resul
 
 namespace at { namespace native {
 
+static inline IntArrayRef to_intarrayref(const Tensor& t){
+    TORCH_CHECK(t.dim() == 1, "shape tensor should be a vector");
+    TORCH_CHECK(t.scalar_type() == at::kLong, "shape has to be Long tensor");
+    return IntArrayRef(t.data_ptr<int64_t>(), t.size(0));
+}
+
 Tensor repeat_interleave_cpu(const Tensor &repeat) {
     return repeat_interleave_common<compute_cpu>(repeat);
 }
@@ -37,7 +43,17 @@ Tensor repeat_interleave(const Tensor &self, const Tensor &repeats, c10::optiona
         AT_ERROR("repeats must be 0-dim or 1-dim tensor");
     }
 
-    return input.index_select(dim.value(), at::repeat_interleave(repeats_));
+    Tensor indices = at::repeat_interleave(repeats_);
+
+    Tensor indices_sizes = at::ones({self.dim()}, TensorOptions(at::kLong));
+    indices_sizes[dim.value()] = indices.size(0);
+    indices = indices.reshape(to_intarrayref(indices_sizes));
+
+    Tensor expanded_indices_shape = at::_shape_as_tensor(self).clone();
+    expanded_indices_shape[dim.value()] = -1;
+    indices = indices.expand(to_intarrayref(expanded_indices_shape));
+
+    return input.gather(dim.value(), indices);
 }
 
 Tensor repeat_interleave(const Tensor &self, int64_t repeats, c10::optional<int64_t> dim) {

--- a/aten/src/ATen/native/Repeat.cpp
+++ b/aten/src/ATen/native/Repeat.cpp
@@ -39,6 +39,10 @@ Tensor repeat_interleave(const Tensor &self, const Tensor &repeats, c10::optiona
         AT_ERROR("repeats must be 0-dim or 1-dim tensor");
     }
 
+    /* This has the same semantics as:
+     *   `input.index_select(dim.value(), at::repeat_interleave(repeats_))`,
+     * but implementing with gather is faster than `input.index_select`
+     */
     Tensor indices = at::repeat_interleave(repeats_);
 
     std::vector<int64_t> indices_sizes(/*n=*/self.dim(), /*value=*/1);

--- a/aten/src/ATen/native/Repeat.cpp
+++ b/aten/src/ATen/native/Repeat.cpp
@@ -44,10 +44,10 @@ Tensor repeat_interleave(const Tensor &self, const Tensor &repeats, c10::optiona
      */
     Tensor indices = at::repeat_interleave(repeats_);
 
-    SmallVector<int64_t, 4> indices_sizes(/*n=*/self.dim(), /*value=*/1);
+    SmallVector<int64_t, 4> indices_sizes(/*n=*/input.dim(), /*value=*/1);
     indices_sizes[dim.value()] = indices.size(0);
-    auto self_sizes = self.sizes();
-    SmallVector<int64_t, 4> expand_sizes(self_sizes.begin(), self_sizes.end());
+    auto input_sizes = input.sizes();
+    SmallVector<int64_t, 4> expand_sizes(input_sizes.begin(), input_sizes.end());
     expand_sizes[dim.value()] = indices.size(0);
 
     return input.gather(dim.value(), indices.view(indices_sizes).expand(expand_sizes));

--- a/aten/src/ATen/native/Repeat.cpp
+++ b/aten/src/ATen/native/Repeat.cpp
@@ -49,9 +49,8 @@ Tensor repeat_interleave(const Tensor &self, const Tensor &repeats, c10::optiona
     auto self_sizes = self.sizes();
     SmallVector<int64_t, 4> expand_sizes(self_sizes.begin(), self_sizes.end());
     expand_sizes[dim.value()] = indices.size(0);
-    indices = indices.view(indices_sizes).expand(expand_sizes);
 
-    return input.gather(dim.value(), indices);
+    return input.gather(dim.value(), indices.view(indices_sizes).expand(expand_sizes));
 }
 
 Tensor repeat_interleave(const Tensor &self, int64_t repeats, c10::optional<int64_t> dim) {

--- a/aten/src/ATen/native/TensorAdvancedIndexing.cpp
+++ b/aten/src/ATen/native/TensorAdvancedIndexing.cpp
@@ -461,11 +461,15 @@ Tensor & index_select_out_cpu_(Tensor & result, const Tensor & self, int64_t dim
     AT_DISPATCH_ALL_TYPES_AND(at::ScalarType::Bool, self.scalar_type(), "index_select", [&] {
       auto self_stride = self.dim() == 0 ? 1 : self.stride(dim);
       auto result_stride = result.dim() == 0 ? 1 : result.stride(dim);
+
+      auto self_data_ptr = self.data_ptr<scalar_t>();
+      auto result_data_ptr = result.data_ptr<scalar_t>();
+      auto self_numel = self.numel();
       for (auto i = 0; i < numel; i++) {
         auto self_i = index_data[i];
-        TORCH_CHECK_INDEX((self_i >= 0) && (self_i < self.numel()), "index out of range in self");
-        scalar_t *self_ip = self.data_ptr<scalar_t>() + self_i * self_stride;
-        *(result.data_ptr<scalar_t>() + i * result_stride) = *self_ip;
+        TORCH_CHECK_INDEX((self_i >= 0) && (self_i < self_numel), "index out of range in self");
+        scalar_t *self_ip = self_data_ptr + self_i * self_stride;
+        *(result_data_ptr + i * result_stride) = *self_ip;
       }
     });
   }


### PR DESCRIPTION
`gather` turns out to be much faster than `index_select` for this function. (Anywhere from 2-10x faster across my testing.) We do have to match the shape for the generated indices, however this does not affect performance since `.expand` does not copy the underlying buffer.

I experimented with a custom kernel, but the improvement over this implementation didn't justify the approach since it would have added significant complexity and reduced the use of shared infrastructure in the PyTorch codebase.