### PR TITLE
[7] add missing roi_align_rotated op to lite interpreter

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qadd.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qadd.cpp
@@ -254,6 +254,11 @@ static auto registry = c10::RegisterOperators()
     c10::RegisterOperators::options()
       .aliasAnalysis(at::AliasAnalysisKind::FROM_SCHEMA)
       .kernel<QAdd</*ReLUFused=*/false>>(DispatchKey::QuantizedCPUTensorId))
+.op("_quantized::add(Tensor qa, Tensor qb, float scale, int zero_point)"
+     "-> Tensor qc",
+    c10::RegisterOperators::options()
+      .aliasAnalysis(at::AliasAnalysisKind::FROM_SCHEMA)
+      .kernel<QAdd</*ReLUFused=*/false>>(DispatchKey::QuantizedCPUTensorId))
 .op("quantized::add_relu(Tensor qa, Tensor qb, float scale, int zero_point)"
      "-> Tensor qc",
     c10::RegisterOperators::options()

--- a/aten/src/ATen/native/quantized/cpu/qconv.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv.cpp
@@ -642,7 +642,13 @@ static auto registry =
         .op("quantized::conv2d",
             c10::RegisterOperators::options().kernel<QConvInt8<2, false>>(
                 DispatchKey::QuantizedCPUTensorId))
+        .op("_quantized::conv2d",
+            c10::RegisterOperators::options().kernel<QConvInt8<2, false>>(
+                DispatchKey::QuantizedCPUTensorId))
         .op("quantized::conv2d_relu",
+            c10::RegisterOperators::options().kernel<QConvInt8<2, true>>(
+                DispatchKey::QuantizedCPUTensorId))
+        .op("_quantized::conv2d_relu",
             c10::RegisterOperators::options().kernel<QConvInt8<2, true>>(
                 DispatchKey::QuantizedCPUTensorId))
         .op("quantized::conv3d",

--- a/aten/src/ATen/native/quantized/cpu/qconv_prepack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv_prepack.cpp
@@ -311,6 +311,10 @@ static auto registry =
                                          // consistent with conv3d_prepack
             c10::RegisterOperators::options().kernel<QConvPackWeightInt8<2>>(
                 DispatchKey::QuantizedCPUTensorId))
+        .op("_quantized::conv2d_prepack", // We use  conv2d_prepack to be
+                                         // consistent with conv3d_prepack
+            c10::RegisterOperators::options().kernel<QConvPackWeightInt8<2>>(
+                DispatchKey::QuantizedCPUTensorId))
         .op("quantized::conv3d_prepack",
             c10::RegisterOperators::options().kernel<QConvPackWeightInt8<3>>(
                 DispatchKey::QuantizedCPUTensorId));

--- a/aten/src/ATen/native/quantized/cpu/qlinear.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear.cpp
@@ -357,6 +357,9 @@ static auto registry =
         .op("quantized::linear(Tensor X, Tensor W_prepack, float Y_scale_i, int Y_zero_point_i) -> Tensor Y",
             torch::RegisterOperators::options().kernel<QLinearInt8<false>>(
                 DispatchKey::QuantizedCPUTensorId))
+        .op("_quantized::linear(Tensor X, Tensor W_prepack, float Y_scale_i, int Y_zero_point_i) -> Tensor Y",
+            torch::RegisterOperators::options().kernel<QLinearInt8<false>>(
+                DispatchKey::QuantizedCPUTensorId))
         .op("quantized::linear_relu(Tensor X, Tensor W_prepack, float Y_scale_i, int Y_zero_point_i) -> Tensor Y",
             torch::RegisterOperators::options().kernel<QLinearInt8<true>>(
                 DispatchKey::QuantizedCPUTensorId));

--- a/caffe2/core/operator.h
+++ b/caffe2/core/operator.h
@@ -32,6 +32,7 @@
     !defined(CAFFE2_IS_XPLAT_BUILD) && !defined(C10_MOBILE)
 #include <ATen/core/TensorBody.h>
 #include <ATen/core/ivalue.h>
+#include <ATen/core/function_schema.h>
 #endif
 
 C10_DECLARE_bool(caffe2_operator_throw_if_fp_exceptions);

--- a/caffe2/operators/bbox_transform_op.cc
+++ b/caffe2/operators/bbox_transform_op.cc
@@ -205,4 +205,24 @@ C10_EXPORT_CAFFE2_OP_TO_C10_CPU(
       "Tensor output_1"
     ")",
     BBoxTransformOpFloatCPU);
+
+  C10_EXPORT_CAFFE2_OP_TO_C10_CPU(
+      BBoxTransform2,
+      "__caffe2::BBoxTransform("
+        "Tensor rois, "
+        "Tensor deltas, "
+        "Tensor im_info, "
+        "float[] weights, "
+        "bool apply_scale, "
+        "bool rotated, "
+        "bool angle_bound_on, "
+        "int angle_bound_lo, "
+        "int angle_bound_hi, "
+        "float clip_angle_thresh, "
+        "bool legacy_plus_one"
+      ") -> ("
+        "Tensor output_0, "
+        "Tensor output_1"
+      ")",
+      BBoxTransformOpFloatCPU);
 // clang-format on

--- a/caffe2/operators/box_with_nms_limit_op.cc
+++ b/caffe2/operators/box_with_nms_limit_op.cc
@@ -335,4 +335,32 @@ C10_EXPORT_CAFFE2_OP_TO_C10_CPU(
       "Tensor keeps_size"
     ")",
     caffe2::BoxWithNMSLimitOp<caffe2::CPUContext>);
+
+C10_EXPORT_CAFFE2_OP_TO_C10_CPU(
+    BoxWithNMSLimit2,
+    "__caffe2::BoxWithNMSLimit("
+      "Tensor scores, "
+      "Tensor boxes, "
+      "Tensor batch_splits, "
+      "float score_thresh, "
+      "float nms, "
+      "int detections_per_im, "
+      "bool soft_nms_enabled, "
+      "str soft_nms_method, "
+      "float soft_nms_sigma, "
+      "float soft_nms_min_score_thres, "
+      "bool rotated, "
+      "bool cls_agnostic_bbox_reg, "
+      "bool input_boxes_include_bg_cls, "
+      "bool output_classes_include_bg_cls, "
+      "bool legacy_plus_one "
+    ") -> ("
+      "Tensor scores, "
+      "Tensor boxes, "
+      "Tensor classes, "
+      "Tensor batch_splits, "
+      "Tensor keeps, "
+      "Tensor keeps_size"
+    ")",
+    caffe2::BoxWithNMSLimitOp<caffe2::CPUContext>);
 // clang-format on

--- a/caffe2/operators/generate_proposals_op.cc
+++ b/caffe2/operators/generate_proposals_op.cc
@@ -416,8 +416,27 @@ SHOULD_NOT_DO_GRADIENT(GenerateProposalsCPP);
 
 // clang-format off
 C10_EXPORT_CAFFE2_OP_TO_C10_CPU(
-    GenerateProposals,
+    GenerateProposals2,
     "_caffe2::GenerateProposals("
+      "Tensor scores, "
+      "Tensor bbox_deltas, "
+      "Tensor im_info, "
+      "Tensor anchors, "
+      "float spatial_scale, "
+      "int pre_nms_topN, "
+      "int post_nms_topN, "
+      "float nms_thresh, "
+      "float min_size, "
+      "bool angle_bound_on, "
+      "int angle_bound_lo, "
+      "int angle_bound_hi, "
+      "float clip_angle_thresh, "
+      "bool legacy_plus_one"
+    ") -> (Tensor output_0, Tensor output_1)",
+    caffe2::GenerateProposalsOp<caffe2::CPUContext>);
+C10_EXPORT_CAFFE2_OP_TO_C10_CPU(
+    GenerateProposals,
+    "__caffe2::GenerateProposals("
       "Tensor scores, "
       "Tensor bbox_deltas, "
       "Tensor im_info, "

--- a/caffe2/operators/heatmap_max_keypoint_op.cc
+++ b/caffe2/operators/heatmap_max_keypoint_op.cc
@@ -171,4 +171,13 @@ C10_EXPORT_CAFFE2_OP_TO_C10_CPU(
       "bool should_output_softmax = True"
     ") -> Tensor keypoints",
     HeatmapMaxKeypointOpFloatCPU);
+
+C10_EXPORT_CAFFE2_OP_TO_C10_CPU(
+    HeatmapMaxKeypoint2,
+    "__caffe2::HeatmapMaxKeypoint("
+      "Tensor heatmaps, "
+      "Tensor bboxes_in, "
+      "bool should_output_softmax = True"
+    ") -> Tensor keypoints",
+    HeatmapMaxKeypointOpFloatCPU);
 // clang-format on

--- a/caffe2/operators/roi_align_op.cc
+++ b/caffe2/operators/roi_align_op.cc
@@ -398,4 +398,18 @@ C10_EXPORT_CAFFE2_OP_TO_C10_CPU(
       "bool aligned"
     ") -> Tensor",
     RoIAlignOpFloatCPU);
+
+C10_EXPORT_CAFFE2_OP_TO_C10_CPU(
+    RoIAlign2,
+    "__caffe2::RoIAlign("
+      "Tensor features, "
+      "Tensor rois, "
+      "str order, "
+      "float spatial_scale, "
+      "int pooled_h, "
+      "int pooled_w, "
+      "int sampling_ratio, "
+      "bool aligned"
+    ") -> Tensor",
+    RoIAlignOpFloatCPU);
 // clang-format on

--- a/caffe2/operators/roi_align_rotated_op.cc
+++ b/caffe2/operators/roi_align_rotated_op.cc
@@ -423,4 +423,18 @@ C10_EXPORT_CAFFE2_OP_TO_C10_CPU(
       "bool aligned"
     ") -> Tensor",
     RoIAlignRotatedOpFloatCPU);
+
+C10_EXPORT_CAFFE2_OP_TO_C10_CPU(
+    RoIAlignRotated2,
+    "__caffe2::RoIAlignRotated("
+      "Tensor features, "
+      "Tensor rois, "
+      "str order, "
+      "float spatial_scale, "
+      "int pooled_h, "
+      "int pooled_w, "
+      "int sampling_ratio, "
+      "bool aligned"
+    ") -> Tensor",
+    RoIAlignRotatedOpFloatCPU);
 // clang-format on

--- a/torch/csrc/jit/mobile/register_mobile_ops.cpp
+++ b/torch/csrc/jit/mobile/register_mobile_ops.cpp
@@ -113,6 +113,18 @@ void log_softmax_kernel(const c10::OperatorHandle& op, Stack* stack) {
   pack(*stack, std::move(result_));
 }
 
+void quantize_per_tensor_kernel(const c10::OperatorHandle& op, Stack* stack) {
+  auto result_ = at::quantize_per_tensor(
+    (std::move(peek(*stack, 0, 4))).toTensor(),
+    (std::move(peek(*stack, 1, 4))).toDouble(),
+    (std::move(peek(*stack, 2, 4))).toInt(),
+    (std::move(peek(*stack, 3, 4))).to<c10::ScalarType>()
+  );
+  drop(*stack, 4);
+  pack(*stack, std::move(result_));
+}
+
+
 void softmax_kernel(const c10::OperatorHandle& op, Stack* stack) {
   auto result_ = at::softmax(
     (std::move(peek(*stack, 0, 3))).toTensor(),
@@ -181,6 +193,35 @@ void to_dtype_kernel(const c10::OperatorHandle& op, Stack* stack) {
   pack(*stack, std::move(result_));
 }
 
+void to_device_kernel(const c10::OperatorHandle& op, Stack* stack) {
+  auto result_ = ((std::move(peek(*stack, 0, 6))).toTensor()).to(
+     (std::move(peek(*stack, 1, 6))).toDevice(),
+     (std::move(peek(*stack, 2, 6))).toScalarType(),
+     (std::move(peek(*stack, 3, 6))).toBool(),
+     (std::move(peek(*stack, 4, 6))).toBool(),
+     (std::move(peek(*stack, 5, 6))).toOptional<c10::MemoryFormat>()
+  );
+  drop(*stack, 6);
+  pack(*stack, std::move(result_));
+}
+
+void full_op_kernel(const c10::OperatorHandle& op, Stack* stack) {
+  const auto options = c10::TensorOptions()
+      .dtype((std::move(peek(*stack, 2, 6))).toOptional<c10::ScalarType>())
+      .layout((std::move(peek(*stack, 3, 6))).toOptional<c10::Layout>())
+      .device((std::move(peek(*stack, 4, 6))).toOptional<c10::Device>())
+      .pinned_memory((std::move(peek(*stack, 5, 6))).toOptional<bool>());
+    #ifdef USE_STATIC_DISPATCH
+    auto result_ = at::full((std::move(peek(*stack, 0, 6))).toIntVector(),
+      (std::move(peek(*stack, 1, 6))).toScalar(), options);
+    #else
+      auto result_ = torch::full((std::move(peek(*stack, 0, 6))).toIntVector(),
+      (std::move(peek(*stack, 1, 6))).toScalar(), options);
+    #endif
+    drop(*stack, 6);
+    pack(*stack, std::move(result_));
+}
+
 int64_t normalizeIndex(int64_t idx, int64_t list_size) {
   if (idx < 0) {
     // Handle negative indexing
@@ -239,7 +280,7 @@ static auto registry = torch::RegisterOperators().op(
                                            })
 ).op(
   "_aten::adaptive_avg_pool2d",
-  torch::RegisterOperators::options().kernel(c10::DispatchKey::CPUTensorId,
+  torch::RegisterOperators::options().catchAllKernel(
   [](at::Tensor a, c10::List<int64_t> b) -> at::Tensor {
   #ifdef USE_STATIC_DISPATCH
    at::AutoNonVariableTypeMode non_var_type_mode(true);
@@ -322,7 +363,7 @@ static auto registry = torch::RegisterOperators().op(
   }).aliasAnalysis(c10::AliasAnalysisKind::FROM_SCHEMA)
 ).op(
   "_aten::size.int",
-  torch::RegisterOperators::options().kernel(c10::DispatchKey::CPUTensorId,
+  torch::RegisterOperators::options().catchAllKernel(
   [](at::Tensor a, int64_t dim) -> int64_t {
    return at::size(a, dim);
   })
@@ -355,6 +396,12 @@ static auto registry = torch::RegisterOperators().op(
       return a == b;
     })
 ).op(
+  "_aten::eq.int",
+  torch::RegisterOperators::options().catchAllKernel(
+    [](int64_t a, int64_t b) -> bool {
+      return a == b;
+    })
+).op(
   "_aten::log_softmax",
   torch::RegisterOperators::options().kernel(c10::DispatchKey::CPUTensorId,
   [](at::Tensor a, int64_t b, c10::optional<int64_t> c) -> at::Tensor {
@@ -366,7 +413,7 @@ static auto registry = torch::RegisterOperators().op(
   })
 ).op(
   "_aten::flatten.using_ints(Tensor self, int start_dim=0, int end_dim=-1) -> Tensor",
-  torch::RegisterOperators::options().kernel(c10::DispatchKey::CPUTensorId,
+  torch::RegisterOperators::options().catchAllKernel(
   [](const Tensor & self, int64_t start_dim, int64_t end_dim) {
   #ifdef USE_STATIC_DISPATCH
      at::AutoNonVariableTypeMode non_var_type_mode(true);
@@ -375,6 +422,12 @@ static auto registry = torch::RegisterOperators().op(
   })
 ).op(
   "_prim::NumToTensor",
+  torch::RegisterOperators::options().catchAllKernel(
+  [](at::Scalar s) -> at::Tensor {
+      return at::scalar_to_tensor(s);
+  })
+).op(
+  "_prim::NumToTensor.Scalar",
   torch::RegisterOperators::options().catchAllKernel(
   [](at::Scalar s) -> at::Tensor {
       return at::scalar_to_tensor(s);
@@ -444,7 +497,7 @@ static auto registry = torch::RegisterOperators().op(
   })
 ).op(
   "_aten::upsample_nearest2d(Tensor self, int[2] output_size, float? scales_h=None, float? scales_w=None) -> Tensor",
-  torch::RegisterOperators::options().kernel<&upsample_nearest2d_kernel>(c10::DispatchKey::CPUTensorId)
+  torch::RegisterOperators::options().catchAllKernel<&upsample_nearest2d_kernel>()
 ).op(
   "_aten::tanh(Tensor self) -> Tensor",
   torch::RegisterOperators::options().kernel(c10::DispatchKey::CPUTensorId,
@@ -502,6 +555,15 @@ static auto registry = torch::RegisterOperators().op(
   "_aten::append.Tensor(Tensor self) -> void",
   torch::RegisterOperators::options().kernel<&listAppend<at::Tensor>>(c10::DispatchKey::CPUTensorId)
 ).op(
+  "_aten::div.Tensor(Tensor self, Tensor other) -> Tensor",
+  torch::RegisterOperators::options().kernel(c10::DispatchKey::CPUTensorId,
+  [](const Tensor & self, const Tensor & other) {
+     return at::div(self, other);
+  })
+).op(
+  "_aten::quantize_per_tensor(Tensor self, float scale, int zero_point, ScalarType dtype) -> Tensor",
+  torch::RegisterOperators::options().kernel<&quantize_per_tensor_kernel>(c10::DispatchKey::CPUTensorId)
+).op(
   "_aten::append.int(int self) -> void",
   torch::RegisterOperators::options().catchAllKernel<&listAppend<int64_t>>()
   // Segmentation
@@ -511,9 +573,47 @@ static auto registry = torch::RegisterOperators().op(
   [](const Tensor & self) {
      return at::sigmoid(self);
   })
+).op(
+  "_aten::floor(Tensor self) -> Tensor",
+  torch::RegisterOperators::options().kernel(c10::DispatchKey::CPUTensorId,
+  [](const Tensor & self) {
+     return at::floor(self);
+  })
+).op(
+  "_aten::slice.Tensor(Tensor self, int dim, int start, int end, int step) -> Tensor",
+  torch::RegisterOperators::options().kernel(c10::DispatchKey::CPUTensorId,
+  [](const Tensor & self, int64_t dim, int64_t start, int64_t end, int64_t step) {
+     return at::slice(self, dim, start, end, step);
+  })
+).op(
+  "_aten::detach(Tensor self) -> Tensor",
+  torch::RegisterOperators::options().kernel(c10::DispatchKey::CPUTensorId,
+  [](const Tensor & self) {
+     return at::detach(self);
+  })
+).op(
+  "_aten::dequantize(Tensor self) -> Tensor",
+  torch::RegisterOperators::options().catchAllKernel(
+  [](const Tensor & self) {
+     return at::dequantize(self);
+  })
+).op(
+  "_aten::select.int(Tensor self, int dim, int index) -> Tensor",
+  torch::RegisterOperators::options().kernel(c10::DispatchKey::CPUTensorId,
+  [](const Tensor & self, int64_t dim, int64_t index) {
+     return at::select(self, dim, index);
+  })
 ).op(torch::RegisterOperators::options()
     .schema("_aten::to.dtype(Tensor self, ScalarType dtype, bool non_blocking=False, bool copy=False, MemoryFormat? memory_format=None) -> Tensor")
     .kernel<&to_dtype_kernel>(c10::DispatchKey::CPUTensorId)
+    .aliasAnalysis(c10::AliasAnalysisKind::FROM_SCHEMA))
+.op(torch::RegisterOperators::options()
+    .schema("_aten::to.device(Tensor self, Device device, ScalarType dtype, bool non_blocking=False, bool copy=False, MemoryFormat? memory_format=None) -> Tensor")
+    .catchAllKernel<&to_device_kernel>()
+    .aliasAnalysis(c10::AliasAnalysisKind::FROM_SCHEMA))
+.op(torch::RegisterOperators::options()
+    .schema("_aten::full(int[] size, Scalar fill_value, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor")
+    .catchAllKernel<&full_op_kernel>()
     .aliasAnalysis(c10::AliasAnalysisKind::FROM_SCHEMA))
 .op(torch::RegisterOperators::options()
     .schema("_prim::TupleIndex(any self, int index) -> any")


### PR DESCRIPTION
Summary:
add roi_align_rotated op to lite interpreter for detectron2go model

(Note: this ignores all push blocking failures!)

Test Plan: try to run model in https://home.fburl.com/~stzpz/text_det/fbnet_300_20/

Reviewed By: iseeyuan

Differential Revision: D20560485

