### PR TITLE
[3] register caffe2 mask rcnn ops in lite interpreter

### DIFF
--- a/caffe2/core/operator.h
+++ b/caffe2/core/operator.h
@@ -32,6 +32,7 @@
     !defined(CAFFE2_IS_XPLAT_BUILD) && !defined(C10_MOBILE)
 #include <ATen/core/TensorBody.h>
 #include <ATen/core/ivalue.h>
+#include <ATen/core/function_schema.h>
 #endif
 
 C10_DECLARE_bool(caffe2_operator_throw_if_fp_exceptions);

--- a/caffe2/operators/bbox_transform_op.cc
+++ b/caffe2/operators/bbox_transform_op.cc
@@ -205,4 +205,24 @@ C10_EXPORT_CAFFE2_OP_TO_C10_CPU(
       "Tensor output_1"
     ")",
     BBoxTransformOpFloatCPU);
+
+  C10_EXPORT_CAFFE2_OP_TO_C10_CPU(
+      BBoxTransform2,
+      "__caffe2::BBoxTransform("
+        "Tensor rois, "
+        "Tensor deltas, "
+        "Tensor im_info, "
+        "float[] weights, "
+        "bool apply_scale, "
+        "bool rotated, "
+        "bool angle_bound_on, "
+        "int angle_bound_lo, "
+        "int angle_bound_hi, "
+        "float clip_angle_thresh, "
+        "bool legacy_plus_one"
+      ") -> ("
+        "Tensor output_0, "
+        "Tensor output_1"
+      ")",
+      BBoxTransformOpFloatCPU);
 // clang-format on

--- a/caffe2/operators/box_with_nms_limit_op.cc
+++ b/caffe2/operators/box_with_nms_limit_op.cc
@@ -335,4 +335,32 @@ C10_EXPORT_CAFFE2_OP_TO_C10_CPU(
       "Tensor keeps_size"
     ")",
     caffe2::BoxWithNMSLimitOp<caffe2::CPUContext>);
+
+C10_EXPORT_CAFFE2_OP_TO_C10_CPU(
+    BoxWithNMSLimit2,
+    "__caffe2::BoxWithNMSLimit("
+      "Tensor scores, "
+      "Tensor boxes, "
+      "Tensor batch_splits, "
+      "float score_thresh, "
+      "float nms, "
+      "int detections_per_im, "
+      "bool soft_nms_enabled, "
+      "str soft_nms_method, "
+      "float soft_nms_sigma, "
+      "float soft_nms_min_score_thres, "
+      "bool rotated, "
+      "bool cls_agnostic_bbox_reg, "
+      "bool input_boxes_include_bg_cls, "
+      "bool output_classes_include_bg_cls, "
+      "bool legacy_plus_one "
+    ") -> ("
+      "Tensor scores, "
+      "Tensor boxes, "
+      "Tensor classes, "
+      "Tensor batch_splits, "
+      "Tensor keeps, "
+      "Tensor keeps_size"
+    ")",
+    caffe2::BoxWithNMSLimitOp<caffe2::CPUContext>);
 // clang-format on

--- a/caffe2/operators/generate_proposals_op.cc
+++ b/caffe2/operators/generate_proposals_op.cc
@@ -416,8 +416,27 @@ SHOULD_NOT_DO_GRADIENT(GenerateProposalsCPP);
 
 // clang-format off
 C10_EXPORT_CAFFE2_OP_TO_C10_CPU(
-    GenerateProposals,
+    GenerateProposals2,
     "_caffe2::GenerateProposals("
+      "Tensor scores, "
+      "Tensor bbox_deltas, "
+      "Tensor im_info, "
+      "Tensor anchors, "
+      "float spatial_scale, "
+      "int pre_nms_topN, "
+      "int post_nms_topN, "
+      "float nms_thresh, "
+      "float min_size, "
+      "bool angle_bound_on, "
+      "int angle_bound_lo, "
+      "int angle_bound_hi, "
+      "float clip_angle_thresh, "
+      "bool legacy_plus_one"
+    ") -> (Tensor output_0, Tensor output_1)",
+    caffe2::GenerateProposalsOp<caffe2::CPUContext>);
+C10_EXPORT_CAFFE2_OP_TO_C10_CPU(
+    GenerateProposals,
+    "__caffe2::GenerateProposals("
       "Tensor scores, "
       "Tensor bbox_deltas, "
       "Tensor im_info, "

--- a/caffe2/operators/heatmap_max_keypoint_op.cc
+++ b/caffe2/operators/heatmap_max_keypoint_op.cc
@@ -171,4 +171,13 @@ C10_EXPORT_CAFFE2_OP_TO_C10_CPU(
       "bool should_output_softmax = True"
     ") -> Tensor keypoints",
     HeatmapMaxKeypointOpFloatCPU);
+
+C10_EXPORT_CAFFE2_OP_TO_C10_CPU(
+    HeatmapMaxKeypoint2,
+    "__caffe2::HeatmapMaxKeypoint("
+      "Tensor heatmaps, "
+      "Tensor bboxes_in, "
+      "bool should_output_softmax = True"
+    ") -> Tensor keypoints",
+    HeatmapMaxKeypointOpFloatCPU);
 // clang-format on

--- a/caffe2/operators/roi_align_op.cc
+++ b/caffe2/operators/roi_align_op.cc
@@ -398,4 +398,18 @@ C10_EXPORT_CAFFE2_OP_TO_C10_CPU(
       "bool aligned"
     ") -> Tensor",
     RoIAlignOpFloatCPU);
+
+C10_EXPORT_CAFFE2_OP_TO_C10_CPU(
+    RoIAlign2,
+    "__caffe2::RoIAlign("
+      "Tensor features, "
+      "Tensor rois, "
+      "str order, "
+      "float spatial_scale, "
+      "int pooled_h, "
+      "int pooled_w, "
+      "int sampling_ratio, "
+      "bool aligned"
+    ") -> Tensor",
+    RoIAlignOpFloatCPU);
 // clang-format on


### PR DESCRIPTION
Summary:
register caffe2 mask-rcnn ops in lite interpreter. It requires a leading "_" in the name.

(Note: this ignores all push blocking failures!)

Test Plan: buck build -c caffe2.expose_op_to_c10=1 //xplat/caffe2:mask_rcnn_opsAndroid

Reviewed By: iseeyuan

Differential Revision: D20528758

