### PR TITLE
[4] register quantized ops for lite interpreter

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qadd.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qadd.cpp
@@ -254,6 +254,11 @@ static auto registry = c10::RegisterOperators()
     c10::RegisterOperators::options()
       .aliasAnalysis(at::AliasAnalysisKind::FROM_SCHEMA)
       .kernel<QAdd</*ReLUFused=*/false>>(DispatchKey::QuantizedCPUTensorId))
+.op("_quantized::add(Tensor qa, Tensor qb, float scale, int zero_point)"
+     "-> Tensor qc",
+    c10::RegisterOperators::options()
+      .aliasAnalysis(at::AliasAnalysisKind::FROM_SCHEMA)
+      .kernel<QAdd</*ReLUFused=*/false>>(DispatchKey::QuantizedCPUTensorId))
 .op("quantized::add_relu(Tensor qa, Tensor qb, float scale, int zero_point)"
      "-> Tensor qc",
     c10::RegisterOperators::options()

--- a/aten/src/ATen/native/quantized/cpu/qconv.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv.cpp
@@ -642,7 +642,13 @@ static auto registry =
         .op("quantized::conv2d",
             c10::RegisterOperators::options().kernel<QConvInt8<2, false>>(
                 DispatchKey::QuantizedCPUTensorId))
+        .op("_quantized::conv2d",
+            c10::RegisterOperators::options().kernel<QConvInt8<2, false>>(
+                DispatchKey::QuantizedCPUTensorId))
         .op("quantized::conv2d_relu",
+            c10::RegisterOperators::options().kernel<QConvInt8<2, true>>(
+                DispatchKey::QuantizedCPUTensorId))
+        .op("_quantized::conv2d_relu",
             c10::RegisterOperators::options().kernel<QConvInt8<2, true>>(
                 DispatchKey::QuantizedCPUTensorId))
         .op("quantized::conv3d",

--- a/aten/src/ATen/native/quantized/cpu/qconv_prepack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv_prepack.cpp
@@ -311,6 +311,10 @@ static auto registry =
                                          // consistent with conv3d_prepack
             c10::RegisterOperators::options().kernel<QConvPackWeightInt8<2>>(
                 DispatchKey::QuantizedCPUTensorId))
+        .op("_quantized::conv2d_prepack", // We use  conv2d_prepack to be
+                                         // consistent with conv3d_prepack
+            c10::RegisterOperators::options().kernel<QConvPackWeightInt8<2>>(
+                DispatchKey::QuantizedCPUTensorId))
         .op("quantized::conv3d_prepack",
             c10::RegisterOperators::options().kernel<QConvPackWeightInt8<3>>(
                 DispatchKey::QuantizedCPUTensorId));

--- a/aten/src/ATen/native/quantized/cpu/qlinear.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear.cpp
@@ -357,6 +357,9 @@ static auto registry =
         .op("quantized::linear(Tensor X, Tensor W_prepack, float Y_scale_i, int Y_zero_point_i) -> Tensor Y",
             torch::RegisterOperators::options().kernel<QLinearInt8<false>>(
                 DispatchKey::QuantizedCPUTensorId))
+        .op("_quantized::linear(Tensor X, Tensor W_prepack, float Y_scale_i, int Y_zero_point_i) -> Tensor Y",
+            torch::RegisterOperators::options().kernel<QLinearInt8<false>>(
+                DispatchKey::QuantizedCPUTensorId))
         .op("quantized::linear_relu(Tensor X, Tensor W_prepack, float Y_scale_i, int Y_zero_point_i) -> Tensor Y",
             torch::RegisterOperators::options().kernel<QLinearInt8<true>>(
                 DispatchKey::QuantizedCPUTensorId));


### PR DESCRIPTION
Summary:
add a leading "_" to register quantized ops for lite interpreter. They are needed by d2go model

(Note: this ignores all push blocking failures!)

Test Plan:
(whole stack)
buck build -c user.ndk_cxxflags='-g1' -c caffe2.expose_op_to_c10=1 //xplat/caffe2/fb/pytorch_predictor:maskrcnnAndroid#android-armv7

Reviewed By: iseeyuan

Differential Revision: D20528760

