### PR TITLE
cmake: Grab TORCH_DEFAULT_VERSION from version.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -363,7 +363,13 @@ include(cmake/Utils.cmake)
 include(cmake/public/utils.cmake)
 
 # ---[ Version numbers for generated libraries
-set(TORCH_DEFAULT_VERSION "1.1.0")
+file(READ version.txt TORCH_DEFAULT_VERSION)
+if("${TORCH_DEFAULT_VERSION} " STREQUAL " ")
+  message(WARNING "Could not get version from base 'version.txt'")
+  # If we can't get the version from the version file we should probably
+  # set it to something non-sensical like 0.0.0
+  set(TORCH_DEFAULT_VERSION, "0.0.0")
+endif()
 set(TORCH_BUILD_VERSION "${TORCH_DEFAULT_VERSION}" CACHE STRING "Torch build version")
 if(DEFINED ENV{PYTORCH_BUILD_VERSION})
   set(TORCH_BUILD_VERSION "$ENV{PYTORCH_BUILD_VERSION}"


### PR DESCRIPTION
This variable hasn't been updated in a long time since it usually just
gets overwritten by whatever is in the setup.py but let's set the
default to something a bit more in-line with what we're actually
building.

Closes https://github.com/pytorch/pytorch/issues/35210

cc @ksasso1028

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

