### PR TITLE
[dist autograd] profile the amount of time spent executing
dist_autograd.backward()

### DIFF
--- a/torch/testing/_internal/distributed/rpc/dist_autograd_test.py
+++ b/torch/testing/_internal/distributed/rpc/dist_autograd_test.py
@@ -820,6 +820,31 @@ class DistAutogradTest(RpcAgentTestFixture):
             self.assertEqual(worker_ids, dst_ranks)
 
     @dist_init
+    def test_dist_autograd_profiling(self):
+        with dist_autograd.context() as context_id:
+            t1 = torch.rand(3, 3, requires_grad=True)
+            t2 = torch.rand(3, 3, requires_grad=True)
+            loss = rpc.rpc_sync(worker_name(self._next_rank()), torch.add, args=(t1, t2)).sum()
+            with torch.autograd.profiler.profile() as p:
+                dist_autograd.backward(context_id, [loss])
+
+        function_events = p.function_events
+
+        def get_event(partial_key):
+            return [event for event in function_events if partial_key in event.name][0]
+
+        send_event = get_event("SendRpcBackward")
+        recv_event = get_event("RecvRpcBackward")
+        backward_event = get_event("torch::distributed::autograd::backward")
+        # There should be at least 1 send and recv_events each, corresponding to send/recv functions executed.
+        self.assertEqual(send_event.count, 1)
+        self.assertEqual(recv_event.count, 1)
+        # The CPU total for backward event should be great than send and recv, since
+        # applying those functions in the backwards pass is a subset of the entire backward pass.
+        self.assertGreater(backward_event.cpu_time_total, send_event.cpu_time_total)
+        self.assertGreater(backward_event.cpu_time_total, recv_event.cpu_time_total)
+
+    @dist_init
     def test_error_in_context(self):
         with dist_autograd.context() as context_id:
             t1 = torch.rand(3, 3, requires_grad=True)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#35261 [dist autograd] profile the amount of time spent executing
dist_autograd.backward()**

Uses the `RECORD_FUNCTION` macro to profile the amount of time in
`dist_autograd.backward` and ensure that it shows up in the profiler output. Since
`dist_autograd.backward()` is blocking, we can avoid stuffing the RecordFunction
into a callback. This does not support profiling the RPCs that are created when
gradients are forwarded over to other nodes; this can be added in a follow up
diff.

Example profiler output:
```
> Name                                               Self CPU total %  Self CPU total   CPU total %      CPU total        CPU time avg     Number of Calls
> -------------------------------------------------  ---------------  ---------------  ---------------  ---------------  ---------------  ---------------
> torch::distributed::autograd::backward             96.36%           30.086ms         96.58%           30.158ms         30.158ms         1
> ones_like                                          0.10%            30.203us         0.23%            71.264us         71.264us         1
> empty_like                                         0.06%            19.786us         0.10%            32.257us         32.257us         1
> empty                                              0.35%            108.691us        0.35%            108.691us        21.738us         5
> fill_                                              0.43%            133.097us        0.43%            133.097us        7.829us          17
> torch::autograd::GraphRoot                         0.06%            20.135us         0.06%            20.135us         20.135us         1
> SumBackward0                                       0.04%            12.744us         0.25%            79.130us         79.130us         1
> expand                                             0.21%            66.386us         0.21%            66.386us         66.386us         1
> torch::distributed::autograd::RecvRpcBackward      0.49%            154.228us        0.49%            154.228us        77.114us         2
> select                                             1.10%            342.145us        1.10%            342.145us        21.384us         16
> to                                                 0.07%            22.096us         0.07%            22.096us         5.524us          4
> set_                                               0.09%            29.306us         0.09%            29.306us         14.653us         2
> torch::distributed::autograd::SendRpcBackward      0.02%            6.413us          0.02%            6.413us          3.207us          2
> AddBackward0                                       0.01%            2.628us          0.01%            2.628us          2.628us          1
> clone                                              0.61%            189.775us        0.61%            189.775us        94.888us         2
> -------------------------------------------------  ---------------  ---------------  ---------------  ---------------  ---------------  ---------------
> Self CPU time total: 31.224ms
```

One issue is that the profile may show output such as the execution of a `SendRpcBackward` that is not part of this request, but instead in response to another node. Created https://github.com/pytorch/pytorch/issues/35266 to track that issue.
Differential Revision: [D20611653](https://our.internmc.facebook.com/intern/diff/D20611653/)