### PR TITLE
[v1.5.0 patch] enforce rref JIT pickling to be in the scope of rpc calls

### DIFF
--- a/torch/csrc/distributed/autograd/rpc_messages/cleanup_autograd_context_req.cpp
+++ b/torch/csrc/distributed/autograd/rpc_messages/cleanup_autograd_context_req.cpp
@@ -13,7 +13,7 @@ int64_t CleanupAutogradContextReq::getContextId() {
   return context_id_;
 }
 
-rpc::Message CleanupAutogradContextReq::toMessage() && {
+rpc::Message CleanupAutogradContextReq::toMessageImpl() && {
   // pickle context_id using JIT pickler.
   std::vector<torch::Tensor> tensorTable;
   std::vector<char> payload =

--- a/torch/csrc/distributed/autograd/rpc_messages/cleanup_autograd_context_req.h
+++ b/torch/csrc/distributed/autograd/rpc_messages/cleanup_autograd_context_req.h
@@ -14,7 +14,7 @@ class TORCH_API CleanupAutogradContextReq : public rpc::RpcCommandBase {
  public:
   explicit CleanupAutogradContextReq(int64_t context_id);
   // Serialization and deserialization methods.
-  rpc::Message toMessage() && override;
+  rpc::Message toMessageImpl() && override;
   static std::unique_ptr<CleanupAutogradContextReq> fromMessage(
       const rpc::Message& message);
 

--- a/torch/csrc/distributed/autograd/rpc_messages/cleanup_autograd_context_resp.cpp
+++ b/torch/csrc/distributed/autograd/rpc_messages/cleanup_autograd_context_resp.cpp
@@ -4,7 +4,7 @@ namespace torch {
 namespace distributed {
 namespace autograd {
 
-rpc::Message CleanupAutogradContextResp::toMessage() && {
+rpc::Message CleanupAutogradContextResp::toMessageImpl() && {
   std::vector<torch::Tensor> tensors;
   std::vector<char> payload;
   return rpc::Message(

--- a/torch/csrc/distributed/autograd/rpc_messages/cleanup_autograd_context_resp.h
+++ b/torch/csrc/distributed/autograd/rpc_messages/cleanup_autograd_context_resp.h
@@ -14,7 +14,7 @@ class TORCH_API CleanupAutogradContextResp : public rpc::RpcCommandBase {
  public:
   CleanupAutogradContextResp() = default;
   // Serialization and deserialization methods.
-  rpc::Message toMessage() && override;
+  rpc::Message toMessageImpl() && override;
   static std::unique_ptr<CleanupAutogradContextResp> fromMessage(
       const rpc::Message& message);
 };

--- a/torch/csrc/distributed/autograd/rpc_messages/propagate_gradients_req.cpp
+++ b/torch/csrc/distributed/autograd/rpc_messages/propagate_gradients_req.cpp
@@ -18,7 +18,7 @@ PropagateGradientsReq::PropagateGradientsReq(
       grads_(std::move(grads)),
       retainGraph_(retainGraph) {}
 
-Message PropagateGradientsReq::toMessage() && {
+Message PropagateGradientsReq::toMessageImpl() && {
   std::vector<at::IValue> ivalues;
   // Add all the grad tensors.
   for (const auto& grad : grads_) {

--- a/torch/csrc/distributed/autograd/rpc_messages/propagate_gradients_req.h
+++ b/torch/csrc/distributed/autograd/rpc_messages/propagate_gradients_req.h
@@ -24,7 +24,7 @@ class TORCH_API PropagateGradientsReq : public rpc::RpcCommandBase {
   const std::vector<torch::autograd::Variable>& getGrads();
 
   // Serialization and deserialization methods.
-  rpc::Message toMessage() && override;
+  rpc::Message toMessageImpl() && override;
   static std::unique_ptr<PropagateGradientsReq> fromMessage(
       const rpc::Message& message);
 

--- a/torch/csrc/distributed/autograd/rpc_messages/propagate_gradients_resp.cpp
+++ b/torch/csrc/distributed/autograd/rpc_messages/propagate_gradients_resp.cpp
@@ -4,7 +4,7 @@ namespace torch {
 namespace distributed {
 namespace autograd {
 
-rpc::Message PropagateGradientsResp::toMessage() && {
+rpc::Message PropagateGradientsResp::toMessageImpl() && {
   return rpc::Message({}, {}, rpc::MessageType::BACKWARD_AUTOGRAD_RESP);
 }
 

--- a/torch/csrc/distributed/autograd/rpc_messages/propagate_gradients_resp.h
+++ b/torch/csrc/distributed/autograd/rpc_messages/propagate_gradients_resp.h
@@ -14,7 +14,7 @@ namespace autograd {
 class TORCH_API PropagateGradientsResp : public rpc::RpcCommandBase {
  public:
   PropagateGradientsResp() = default;
-  rpc::Message toMessage() && override;
+  rpc::Message toMessageImpl() && override;
   static std::unique_ptr<PropagateGradientsResp> fromMessage(
       const rpc::Message& message);
 };

--- a/torch/csrc/distributed/autograd/rpc_messages/rpc_with_autograd.cpp
+++ b/torch/csrc/distributed/autograd/rpc_messages/rpc_with_autograd.cpp
@@ -49,7 +49,7 @@ RpcWithAutograd::RpcWithAutograd(
       messageType_ == MessageType::FORWARD_AUTOGRAD_RESP);
 }
 
-Message RpcWithAutograd::toMessage() && {
+Message RpcWithAutograd::toMessageImpl() && {
   auto messageId = wrappedMessage_.id();
   auto messageType = wrappedMessage_.type();
 

--- a/torch/csrc/distributed/autograd/rpc_messages/rpc_with_autograd.h
+++ b/torch/csrc/distributed/autograd/rpc_messages/rpc_with_autograd.h
@@ -29,7 +29,7 @@ class TORCH_API RpcWithAutograd final : public rpc::RpcCommandBase {
       rpc::MessageType wrappedMessageType,
       std::vector<torch::Tensor> tensors);
 
-  rpc::Message toMessage() && override;
+  rpc::Message toMessageImpl() && override;
 
   static std::unique_ptr<RpcWithAutograd> fromMessage(
       const rpc::Message& message);

--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -217,13 +217,27 @@ PyObject* rpc_init(PyObject* /* unused */) {
           .def(
               py::pickle(
                   [](const PyRRef& self) {
+                    TORCH_CHECK(
+                        false,
+                        "Can not pickle rref in python pickler, rref can only be pickled when using RPC");
                     // __getstate__
                     return self.pickle();
                   },
                   [](py::tuple t) { // NOLINT
+                    TORCH_CHECK(
+                        false,
+                        "Can not unpickle rref in python pickler, rref can only be unpickled when using RPC");
                     // __setstate__
                     return PyRRef::unpickle(t);
                   }),
+              py::call_guard<py::gil_scoped_release>())
+          .def(
+              "_serialize",
+              &PyRRef::pickle,
+              py::call_guard<py::gil_scoped_release>())
+          .def_static(
+              "_deserialize",
+              &PyRRef::unpickle,
               py::call_guard<py::gil_scoped_release>())
           // not releasing GIL to avoid context switch
           .def("__str__", &PyRRef::str);

--- a/torch/csrc/distributed/rpc/py_rref.cpp
+++ b/torch/csrc/distributed/rpc/py_rref.cpp
@@ -184,10 +184,6 @@ std::string PyRRef::str() const {
 
 py::tuple PyRRef::pickle() const {
   auto& ctx = RRefContext::getInstance();
-  // TODO: use a dispatch table to pickle/unpickle an RRef, and only only
-  // install the dispatch table only when there are indeed RPC activities. As
-  // a counter example, checkpointing a model with RRefs should not trigger
-  // forks to be added as a fork or a child.
   auto rrefForkData = ctx.prepareChildFork(rref_);
   return toPyTuple(rrefForkData);
 }

--- a/torch/csrc/distributed/rpc/python_call.cpp
+++ b/torch/csrc/distributed/rpc/python_call.cpp
@@ -9,7 +9,7 @@ namespace rpc {
 PythonCall::PythonCall(SerializedPyObj&& serializedPyObj)
     : serializedPyObj_(std::move(serializedPyObj)) {}
 
-Message PythonCall::toMessage() && {
+Message PythonCall::toMessageImpl() && {
   auto payload = std::vector<char>(
       serializedPyObj_.payload_.begin(), serializedPyObj_.payload_.end());
   return Message(

--- a/torch/csrc/distributed/rpc/python_call.h
+++ b/torch/csrc/distributed/rpc/python_call.h
@@ -12,7 +12,7 @@ class TORCH_API PythonCall final : public RpcCommandBase {
  public:
   explicit PythonCall(SerializedPyObj&& serializedPyObj);
 
-  Message toMessage() && override;
+  Message toMessageImpl() && override;
 
   static std::unique_ptr<PythonCall> fromMessage(const Message& message);
 

--- a/torch/csrc/distributed/rpc/python_remote_call.cpp
+++ b/torch/csrc/distributed/rpc/python_remote_call.cpp
@@ -14,7 +14,7 @@ PythonRemoteCall::PythonRemoteCall(
       retRRefId_(std::move(retRRefId)),
       retForkId_(std::move(retForkId)) {}
 
-Message PythonRemoteCall::toMessage() && {
+Message PythonRemoteCall::toMessageImpl() && {
   std::vector<IValue> ivalues = std::move(serializedPyObj_).toIValues();
   ivalues.emplace_back(retRRefId_);
   ivalues.emplace_back(retForkId_);

--- a/torch/csrc/distributed/rpc/python_remote_call.h
+++ b/torch/csrc/distributed/rpc/python_remote_call.h
@@ -29,7 +29,7 @@ class TORCH_API PythonRemoteCall : public RpcCommandBase {
     return retForkId_;
   }
 
-  Message toMessage() && override;
+  Message toMessageImpl() && override;
   static std::unique_ptr<PythonRemoteCall> fromMessage(const Message& message);
 
  private:

--- a/torch/csrc/distributed/rpc/python_resp.cpp
+++ b/torch/csrc/distributed/rpc/python_resp.cpp
@@ -9,7 +9,7 @@ namespace rpc {
 PythonResp::PythonResp(SerializedPyObj&& serializedPyObj)
     : serializedPyObj_(std::move(serializedPyObj)) {}
 
-Message PythonResp::toMessage() && {
+Message PythonResp::toMessageImpl() && {
   auto payload = std::vector<char>(
       serializedPyObj_.payload_.begin(), serializedPyObj_.payload_.end());
   return Message(

--- a/torch/csrc/distributed/rpc/python_resp.h
+++ b/torch/csrc/distributed/rpc/python_resp.h
@@ -12,7 +12,7 @@ class TORCH_API PythonResp final : public RpcCommandBase {
  public:
   explicit PythonResp(SerializedPyObj&& serializedPyObj);
 
-  Message toMessage() && override;
+  Message toMessageImpl() && override;
 
   static std::unique_ptr<PythonResp> fromMessage(const Message& message);
 

--- a/torch/csrc/distributed/rpc/rpc_command_base.h
+++ b/torch/csrc/distributed/rpc/rpc_command_base.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <torch/csrc/distributed/rpc/message.h>
+#include <torch/csrc/distributed/rpc/types.h>
 
 namespace torch {
 namespace distributed {
@@ -11,7 +12,11 @@ class RpcCommandBase {
  public:
   // Need to override this to serialize the RPC. This should destructively
   // create a message for the RPC (Hence the &&).
-  virtual Message toMessage() && = 0;
+  Message toMessage() && {
+    JitRRefPickleGuard jitPickleGuard;
+    return std::move(*this).toMessageImpl();
+  }
+  virtual Message toMessageImpl() && = 0;
   virtual ~RpcCommandBase() = 0;
 };
 

--- a/torch/csrc/distributed/rpc/rref_proto.cpp
+++ b/torch/csrc/distributed/rpc/rref_proto.cpp
@@ -43,7 +43,7 @@ const RRefId& RRefMessageBase::rrefId() {
   return rrefId_;
 }
 
-Message RRefMessageBase::toMessage() && {
+Message RRefMessageBase::toMessageImpl() && {
   return fromIValues({rrefId_.toIValue()}, type_);
 }
 
@@ -63,7 +63,7 @@ const ForkId& ForkMessageBase::forkId() {
   return forkId_;
 }
 
-Message ForkMessageBase::toMessage() && {
+Message ForkMessageBase::toMessageImpl() && {
   return fromIValues({rrefId_.toIValue(), forkId_.toIValue()}, type_);
 }
 
@@ -81,7 +81,7 @@ std::pair<RRefId, ForkId> ForkMessageBase::fromMessage(
 
 /////////////////////////// RRef Protocol //////////////////////////////////
 
-Message ScriptRRefFetchCall::toMessage() && {
+Message ScriptRRefFetchCall::toMessageImpl() && {
   std::vector<at::IValue> ivalues;
   ivalues.reserve(2);
   ivalues.emplace_back(rrefId_.toIValue());
@@ -103,7 +103,7 @@ std::unique_ptr<ScriptRRefFetchCall> ScriptRRefFetchCall::fromMessage(
       worker_id_t(id), RRefId::fromIValue(values[0]));
 }
 
-Message PythonRRefFetchCall::toMessage() && {
+Message PythonRRefFetchCall::toMessageImpl() && {
   std::vector<at::IValue> ivalues;
   ivalues.reserve(2);
   ivalues.emplace_back(rrefId_.toIValue());
@@ -129,12 +129,11 @@ const std::vector<at::IValue>& RRefFetchRet::values() {
   return values_;
 }
 
-Message RRefFetchRet::toMessage() && {
+Message RRefFetchRet::toMessageImpl() && {
   std::vector<at::IValue> ivalues = values_;
   std::vector<torch::Tensor> tensor_table;
   auto payload =
       jit::pickle(c10::ivalue::Tuple::create(ivalues), &tensor_table);
-
   return Message(std::move(payload), std::move(tensor_table), type_);
 }
 
@@ -171,7 +170,7 @@ const ForkId& RRefChildAccept::forkId() const {
   return forkId_;
 }
 
-Message RRefChildAccept::toMessage() && {
+Message RRefChildAccept::toMessageImpl() && {
   return fromIValues({forkId_.toIValue()}, MessageType::RREF_CHILD_ACCEPT);
 }
 
@@ -190,7 +189,7 @@ std::unique_ptr<RRefForkRequest> RRefForkRequest::fromMessage(
   return std::make_unique<RRefForkRequest>(pair.first, pair.second);
 }
 
-Message RRefAck::toMessage() && {
+Message RRefAck::toMessageImpl() && {
   return Message({}, {}, MessageType::RREF_ACK);
 }
 

--- a/torch/csrc/distributed/rpc/rref_proto.h
+++ b/torch/csrc/distributed/rpc/rref_proto.h
@@ -22,7 +22,7 @@ class TORCH_API RRefMessageBase : public RpcCommandBase {
 
   const RRefId& rrefId();
 
-  virtual Message toMessage() && override;
+  virtual Message toMessageImpl() && override;
   static at::IValue fromMessage(const Message& message, MessageType type);
 
  protected:
@@ -39,7 +39,7 @@ class TORCH_API ForkMessageBase : public RRefMessageBase {
 
   const ForkId& forkId();
 
-  virtual Message toMessage() && override;
+  virtual Message toMessageImpl() && override;
   static std::pair<RRefId, ForkId> fromMessage(
       const Message& message,
       MessageType type);
@@ -59,7 +59,7 @@ class TORCH_API ScriptRRefFetchCall final : public RRefMessageBase {
     return fromWorkerId_;
   }
 
-  Message toMessage() && override;
+  Message toMessageImpl() && override;
   static std::unique_ptr<ScriptRRefFetchCall> fromMessage(
       const Message& message);
 
@@ -73,7 +73,7 @@ class TORCH_API PythonRRefFetchCall final : public RRefMessageBase {
       : RRefMessageBase(rrefId, MessageType::PYTHON_RREF_FETCH_CALL),
         fromWorkerId_(fromWorkerId) {}
 
-  Message toMessage() && override;
+  Message toMessageImpl() && override;
   static std::unique_ptr<PythonRRefFetchCall> fromMessage(
       const Message& message);
 
@@ -88,7 +88,7 @@ class TORCH_API RRefFetchRet : public RpcCommandBase {
       : values_(std::move(values)), type_(type) {}
 
   const std::vector<at::IValue>& values();
-  Message toMessage() && override;
+  Message toMessageImpl() && override;
 
  private:
   std::vector<at::IValue> values_;
@@ -139,7 +139,7 @@ class TORCH_API RRefChildAccept final : public RpcCommandBase {
 
   const ForkId& forkId() const;
 
-  Message toMessage() && override;
+  Message toMessageImpl() && override;
   static std::unique_ptr<RRefChildAccept> fromMessage(const Message& message);
 
  private:
@@ -159,7 +159,7 @@ class TORCH_API RRefAck final : public RpcCommandBase {
  public:
   RRefAck() {}
 
-  Message toMessage() && override;
+  Message toMessageImpl() && override;
   static std::unique_ptr<RRefAck> fromMessage(const Message& message);
 };
 

--- a/torch/csrc/distributed/rpc/script_call.cpp
+++ b/torch/csrc/distributed/rpc/script_call.cpp
@@ -100,7 +100,7 @@ std::unique_ptr<ScriptCall> ScriptCall::fromIValues(
   }
 }
 
-Message ScriptCall::toMessage() && {
+Message ScriptCall::toMessageImpl() && {
   std::vector<IValue> ivalues;
   toIValues(ivalues);
 

--- a/torch/csrc/distributed/rpc/script_call.h
+++ b/torch/csrc/distributed/rpc/script_call.h
@@ -35,7 +35,7 @@ class TORCH_API ScriptCall : public RpcCommandBase {
   const std::vector<at::IValue>& stack() const;
   std::vector<at::IValue>& stackRef();
 
-  Message toMessage() && override;
+  Message toMessageImpl() && override;
   static std::unique_ptr<ScriptCall> fromMessage(const Message& message);
 
   virtual ~ScriptCall() = default;

--- a/torch/csrc/distributed/rpc/script_remote_call.cpp
+++ b/torch/csrc/distributed/rpc/script_remote_call.cpp
@@ -48,7 +48,7 @@ std::unique_ptr<ScriptRemoteCall> ScriptRemoteCall::fromIValues(
   }
 }
 
-Message ScriptRemoteCall::toMessage() && {
+Message ScriptRemoteCall::toMessageImpl() && {
   std::vector<IValue> ivalues;
   ScriptCall::toIValues(ivalues);
   ivalues.emplace_back(retRRefId_.toIValue());

--- a/torch/csrc/distributed/rpc/script_remote_call.h
+++ b/torch/csrc/distributed/rpc/script_remote_call.h
@@ -43,7 +43,7 @@ class TORCH_API ScriptRemoteCall final : public ScriptCall {
   static std::unique_ptr<ScriptRemoteCall> fromIValues(
       std::vector<at::IValue>& ivalues);
 
-  Message toMessage() && override;
+  Message toMessageImpl() && override;
   static std::unique_ptr<ScriptRemoteCall> fromMessage(const Message& message);
 
  private:

--- a/torch/csrc/distributed/rpc/script_resp.cpp
+++ b/torch/csrc/distributed/rpc/script_resp.cpp
@@ -22,10 +22,9 @@ const at::IValue& ScriptResp::value() {
   return value_;
 }
 
-Message ScriptResp::toMessage() && {
+Message ScriptResp::toMessageImpl() && {
   std::vector<torch::Tensor> tensor_table;
   auto payload = jit::pickle(value_, &tensor_table);
-  ;
   return Message(
       std::move(payload), std::move(tensor_table), MessageType::SCRIPT_RET);
 }

--- a/torch/csrc/distributed/rpc/script_resp.h
+++ b/torch/csrc/distributed/rpc/script_resp.h
@@ -14,7 +14,7 @@ class TORCH_API ScriptResp final : public RpcCommandBase {
   explicit ScriptResp(at::IValue&& values);
 
   const at::IValue& value();
-  Message toMessage() && override;
+  Message toMessageImpl() && override;
   static std::unique_ptr<ScriptResp> fromMessage(const Message& message);
 
  private:

--- a/torch/csrc/distributed/rpc/types.h
+++ b/torch/csrc/distributed/rpc/types.h
@@ -10,6 +10,13 @@ namespace rpc {
 using worker_id_t = int16_t;
 using local_id_t = int64_t;
 
+bool getAllowJitRRefPickle();
+
+struct TORCH_API JitRRefPickleGuard {
+  JitRRefPickleGuard();
+  ~JitRRefPickleGuard();
+};
+
 struct TORCH_API GloballyUniqueId final {
   GloballyUniqueId(worker_id_t createdOn, local_id_t localId);
   GloballyUniqueId(const GloballyUniqueId& other) = default;

--- a/torch/csrc/distributed/rpc/unpickled_python_call.cpp
+++ b/torch/csrc/distributed/rpc/unpickled_python_call.cpp
@@ -14,7 +14,7 @@ UnpickledPythonCall::UnpickledPythonCall(
   pythonUdf_ = pythonRpcHandler.deserialize(serializedPyObj);
 }
 
-Message UnpickledPythonCall::toMessage() && {
+Message UnpickledPythonCall::toMessageImpl() && {
   TORCH_INTERNAL_ASSERT(
       false, "UnpickledPythonCall does not support toMessage().");
 }

--- a/torch/csrc/distributed/rpc/unpickled_python_call.h
+++ b/torch/csrc/distributed/rpc/unpickled_python_call.h
@@ -21,7 +21,7 @@ class TORCH_API UnpickledPythonCall : public RpcCommandBase {
 
   // toMessage() method is not implemented, as objects of this class should
   // never be directly converted into a Message object.
-  Message toMessage() && override;
+  Message toMessageImpl() && override;
   py::object movePythonUdf() &&;
 
  private:

--- a/torch/csrc/jit/serialization/pickler.cpp
+++ b/torch/csrc/jit/serialization/pickler.cpp
@@ -136,6 +136,9 @@ void Pickler::pushIValueImpl(const IValue& ivalue) {
     AT_ERROR(err.str());
   } else if (ivalue.isRRef()) {
 #ifdef USE_DISTRIBUTED
+    TORCH_CHECK(
+        torch::distributed::rpc::getAllowJitRRefPickle() == true,
+        "RRef jit pickling is only allowed inside RPC calls.");
     pushRRef(ivalue);
 #else
     TORCH_CHECK(

--- a/torch/testing/_internal/distributed/rpc/rpc_test.py
+++ b/torch/testing/_internal/distributed/rpc/rpc_test.py
@@ -26,6 +26,7 @@ from torch.testing._internal.dist_utils import (
 from torch.testing._internal.distributed.rpc.rpc_agent_test_fixture import (
     RpcAgentTestFixture,
 )
+from torch.testing._internal.common_utils import TemporaryFileName
 
 
 def foo_add():
@@ -1827,3 +1828,10 @@ class RpcTest(RpcAgentTestFixture):
             args=(rref,)
         )
         self.assertEqual(ret_rref.to_here(), True)
+
+    @dist_init
+    def test_rref_py_pickle_not_supported(self):
+        local_rref = RRef(35)
+        with TemporaryFileName() as fname:
+            with self.assertRaisesRegex(RuntimeError, "Can not pickle rref in python pickler"):
+                torch.save(local_rref, fname)


### PR DESCRIPTION
Note: This PR has been merged into master at a4afac6 after the 1.5 branch cut (see original PR: #34689). This PR is to merge it into the 1.5 branch.

---- Original Commit Description Follows ---
Pull Request resolved: #34689

rref JIT pickling is only allowed inside rpc calls. enforcing this by adding a thread local variable isInRpcCall and set it as True when converting rpc requests or responses to message, before calling JIT::pickle(). Inside JIT::pickle(), it allowes to pickle RRef only when the isInRpcCall is true.
ghstack-source-id: 100481001

Test Plan: unit tests

Differential Revision: D20429826
fbshipit-source-id: dbc04612ed15de5d6c7d75a4732041ccd4ef3f8c