### PR TITLE
unit test to make sure parent node is not blocked reentrant child node on different device

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -5751,6 +5751,63 @@ class TestAutogradDeviceType(TestCase):
         # gpu thread ReadyQueue
         out.sum().backward()
 
+    @onlyCUDA
+    def test_reentrant_none_blocking_parent(self, device):
+        # Typically parent node will run after child reentrant node. However if the reentrant
+        # node runs on a different device, it's possible for the parent node to run ahead of the
+        # reentrant node.
+        q = queue.Queue()
+        order = []
+
+        class ParentFunc(Function):
+
+            @staticmethod
+            def forward(ctx, inp):
+                return 2 * inp
+
+            @staticmethod
+            def backward(ctx, grad):
+                order.append("Parent")
+                q.put(0)
+                return 2 * grad
+
+        class ChildFunc(Function):
+
+            @staticmethod
+            def forward(ctx, inp):
+                ctx.save_for_backward(inp)
+                return inp * inp
+
+            @staticmethod
+            def backward(ctx, grad):
+                q.get(block=True)
+                order.append("Child")
+                inp, = ctx.saved_tensors
+                return grad * 2 * inp
+
+        a0 = torch.randn(3, 3, requires_grad=True)
+        a1 = ParentFunc.apply(a0)
+
+        re_input = torch.rand(3, 3, requires_grad=True, device=device)
+        re_loss = ChildFunc.apply(re_input).sum()
+
+        class ReentrantFunc(Function):
+
+            @staticmethod
+            def forward(ctx, inp):
+                return inp
+
+            @staticmethod
+            def backward(ctx, grad):
+                re_loss.backward()
+                return grad
+
+        b0 = torch.rand(3, 3, requires_grad=True, device=device)
+        b1 = ReentrantFunc.apply(b0)
+        loss = torch.sum(a1 + b1.to("cpu"))
+        loss.backward()
+        self.assertEqual(order, ["Parent", "Child"])
+
 
 for test in method_tests():
     add_test(*test)


### PR DESCRIPTION
add unit test for autograd to make sure parent node can run ahead of the
reentrant node if reentrant node is on a different device

Test Plan:
unit test

