### PR TITLE
Add python excepiton handling catch block to resolve deadlock

### DIFF
--- a/torch/csrc/distributed/rpc/request_callback_impl.cpp
+++ b/torch/csrc/distributed/rpc/request_callback_impl.cpp
@@ -477,6 +477,16 @@ std::shared_ptr<FutureMessage> RequestCallbackImpl::processMessage(
             // processMessage().
             ClearAutogradContextGuard guard;
             processRpc(*rpc, messageType, id, retFuture);
+          } catch (py::error_already_set& e) {
+            retFuture->markCompleted(handleError(e, messageType, id));
+            // There are request callback impls in Python, where Python
+            // exceptions could be thrown. For releasing Python exception
+            // py::objects, GIL must be held.
+            py::gil_scoped_acquire acquire;
+            e.restore(); // Release ownership on py::objects and also restore
+                         // Python Error Indicator.
+            PyErr_Clear(); // Clear the Python Error Indicator as we has
+                           // recorded the exception in the response message.
           } catch (std::exception& e) {
             retFuture->markCompleted(handleError(e, messageType, id));
           }


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#35283 Add python excepiton handling catch block to resolve deadlock**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D7753253/)

https://github.com/pytorch/pytorch/issues/34260

Deadlock on destructing py::error_already_set.

There are request callback impls in Python, where Python exceptions could be thrown. For releasing Python exception py::objects, GIL must be held.

Differential Revision: [D7753253](https://our.internmc.facebook.com/intern/diff/D7753253/)