### PR TITLE
Trying pinning pyyaml and setuptools on macos to older version

### DIFF
--- a/.jenkins/pytorch/macos-common.sh
+++ b/.jenkins/pytorch/macos-common.sh
@@ -18,7 +18,7 @@ if [ ! -d "${WORKSPACE_DIR}/miniconda3" ]; then
 fi
 export PATH="${WORKSPACE_DIR}/miniconda3/bin:$PATH"
 source ${WORKSPACE_DIR}/miniconda3/bin/activate
-retry conda install -y mkl mkl-include numpy pyyaml setuptools cmake cffi ninja
+retry conda install -y mkl mkl-include numpy pyyaml=5.3 setuptools=46.0.0 cmake cffi ninja
 
 # The torch.hub tests make requests to GitHub.
 #


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #35297 Print run_test.py command
* **#35296 Trying pinning pyyaml and setuptools on macos to older version**

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D20624843](https://our.internmc.facebook.com/intern/diff/D20624843)