### PR TITLE
[JIT] alias analysis speedup

### DIFF
--- a/test/cpp/jit/test_alias_analysis.cpp
+++ b/test/cpp/jit/test_alias_analysis.cpp
@@ -1000,7 +1000,7 @@ void testWildcards() {
         &*graph,
         vmap);
     AliasDb aliasDb(graph);
-    AT_ASSERT(aliasDb.mayAlias(vmap["float_3D"], vmap["float_2D"]));
+    AT_ASSERT(aliasDb.mayContainAlias(vmap["float_3D"], vmap["float_2D"]));
   }
 
   {
@@ -1008,15 +1008,13 @@ void testWildcards() {
     std::unordered_map<std::string, Value*> vmap;
     parseIR(
         R"IR(
-  graph(%float_3D_list : Float(*, *, *)[], %float_2D_list : Float(*, *)[], %ten: Tensor):
+  graph(%ten_list : Tensor[], %float_2d: Float(*, *)):
     return ()
     )IR",
         &*graph,
         vmap);
     AliasDb aliasDb(graph);
-    AT_ASSERT(aliasDb.mayAlias(vmap["float_3D_list"], vmap["float_2D_list"]));
-    AT_ASSERT(aliasDb.mayContainAlias(vmap["float_3D_list"], vmap["ten"]));
-    AT_ASSERT(aliasDb.mayContainAlias(vmap["float_2D_list"], vmap["ten"]));
+    AT_ASSERT(aliasDb.mayContainAlias(vmap["float_2d"], vmap["ten_list"]));
   }
 }
 

--- a/torch/csrc/jit/ir/alias_analysis.cpp
+++ b/torch/csrc/jit/ir/alias_analysis.cpp
@@ -32,7 +32,7 @@ c10::optional<TypePtr> getMutableTypePtr(const TypePtr& type) {
       // these types never contain refined tensor types
       // recursing through nested types adds noticeable runtime overhead
       // in the first pass, so make check debug only
-      TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
+      TORCH_INTERNAL_ASSERT(
           assertNoRefinedTensorTypes(type),
           "These types should not contained refined tensor types",
           type->str());

--- a/torch/csrc/jit/ir/alias_analysis.cpp
+++ b/torch/csrc/jit/ir/alias_analysis.cpp
@@ -41,6 +41,9 @@ c10::optional<TypePtr> getMutableTypePtr(const TypePtr& type) {
     case TypeKind::TensorType:
       return unshapedType(type);
     case TypeKind::TupleType: {
+      // Refined tensor types are created in shape_analysis, constant insertion,
+      // maybe others.
+      // TODO: revisit removing  those locations
       std::vector<TypePtr> mutable_types;
       for (const auto& elem : type->expect<TupleType>()->elements()) {
         if (auto mut_elem = getMutableTypePtr(elem)) {

--- a/torch/csrc/jit/ir/alias_analysis.cpp
+++ b/torch/csrc/jit/ir/alias_analysis.cpp
@@ -29,7 +29,6 @@ c10::optional<TypePtr> getMutableTypePtr(const TypePtr& type) {
     case TypeKind::ListType:
     case TypeKind::DictType:
     case TypeKind::ClassType:
-    case TypeKind::FutureType:
       // these types never contain refined tensor types
       // recursing through nested types adds noticeable runtime overhead
       // in the first pass, so make check debug only
@@ -38,6 +37,13 @@ c10::optional<TypePtr> getMutableTypePtr(const TypePtr& type) {
           "These types should not contained refined tensor types",
           type->str());
       return type;
+    case TypeKind::FutureType: {
+      if (auto elem =
+              getMutableTypePtr(type->cast<FutureType>()->getElementType())) {
+        return FutureType::create(*elem);
+      }
+      return c10::nullopt;
+    }
     case TypeKind::TensorType:
       return unshapedType(type);
     case TypeKind::TupleType: {

--- a/torch/csrc/jit/ir/alias_analysis.cpp
+++ b/torch/csrc/jit/ir/alias_analysis.cpp
@@ -36,7 +36,7 @@ c10::optional<TypePtr> getMutableTypePtr(const TypePtr& type) {
       TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
           assertNoRefinedTensorTypes(type),
           "These types should not contained refined tensor types",
-          type);
+          type->str());
       return type;
     case TypeKind::TensorType:
       return unshapedType(type);

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -609,27 +609,6 @@ class ShapePropagator {
         }
         return propagateTorchTensorShape(node);
       }
-      case prim::TupleConstruct: {
-        // We refresh the tuple type, because the input types could have been
-        // refined.
-        auto orig_type = node->output()->type()->expect<TupleType>();
-        auto new_types =
-            fmap(node->inputs(), [](Value* v) { return v->type(); });
-        node->output()->setType(
-            orig_type->createWithContained(std::move(new_types)));
-        return;
-      }
-      case prim::TupleUnpack: {
-        auto tuple_type = node->input()->type()->cast<TupleType>();
-        AT_ASSERT(
-            tuple_type &&
-            tuple_type->elements().size() == node->outputs().size());
-        auto elems = tuple_type->elements();
-        for (size_t i = 0; i < node->outputs().size(); ++i) {
-          node->output(i)->setType(elems[i]);
-        }
-        return;
-      }
       case prim::Constant: {
         if (node->output()->type()->isSubtypeOf(TensorType::get())) {
           node->output()->inferTypeFrom(node->t(attr::value));


### PR DESCRIPTION
1. Lazily build write cache instead of eagerly in `setWildcard`. EDIT: this caused failures, not sure why. taking it out of this PR.

2. Optional & TupleType is the only container type that can contain a refined tensor type in the runtime. We don't need to recursively unshape type any other type but Optional and Tensor in alias analysis. This recursion was shown to add non-trivial overhead in first pass of FairSeq mode (~12%).

