### PR TITLE
[modules][caffe2/aten] Fix `#include` inside of namespace error

### DIFF
--- a/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
@@ -26,6 +26,10 @@
 #include <mkl.h>
 #endif
 
+#ifdef __AVX2__
+#include <ATen/native/cpu/avx_mathfun.h>
+#endif
+
 namespace at { namespace native {
 namespace {
 
@@ -352,7 +356,6 @@ static void log_normal_kernel(TensorIterator& iter, double mean, double std, Gen
 }
 
 #ifdef __AVX2__
-#include <ATen/native/cpu/avx_mathfun.h>
 
 static void normal_fill_16_AVX2(float *data,
                          const __m256* two_pi,


### PR DESCRIPTION
Summary: This is an error in modular builds.

Test Plan: CI

Differential Revision: D20591224

