### PR TITLE
[REMOVED]

### DIFF
--- a/test/cpp/api/functional.cpp
+++ b/test/cpp/api/functional.cpp
@@ -1875,7 +1875,7 @@ TEST_F(FunctionalTest, Interpolate) {
     // 1D interpolation
     auto input = torch::ones({1, 1, 2});
     auto options = F::InterpolateFuncOptions()
-                       .size({4})
+                       .size(std::vector<int64_t>({4}))
                        .mode(torch::kNearest);
     auto output = F::interpolate(input, options);
     auto expected = torch::ones({1, 1, 4});
@@ -1889,7 +1889,7 @@ TEST_F(FunctionalTest, Interpolate) {
       for (const auto scale_factor : {0.5, 1.5, 2.0}) {
         auto input = torch::ones({1, 1, 2, 2});
         auto options = F::InterpolateFuncOptions()
-                           .scale_factor({scale_factor, scale_factor})
+                           .scale_factor(std::vector<double>({scale_factor, scale_factor}))
                            .mode(torch::kBilinear)
                            .align_corners(align_corners);
         auto output = F::interpolate(input, options);
@@ -1908,7 +1908,7 @@ TEST_F(FunctionalTest, Interpolate) {
         auto input = torch::ones({1, 1, 2, 2, 2});
         auto options =
             F::InterpolateFuncOptions()
-                .scale_factor({scale_factor, scale_factor, scale_factor})
+                .scale_factor(std::vector<double>({scale_factor, scale_factor, scale_factor}))
                 .mode(torch::kTrilinear)
                 .align_corners(align_corners);
         auto output = F::interpolate(input, options);
@@ -1924,13 +1924,13 @@ TEST_F(FunctionalTest, Interpolate) {
   {
     auto input = torch::randn({3, 2, 2});
     ASSERT_THROWS_WITH(
-        F::interpolate(input[0], F::InterpolateFuncOptions().size({4, 4})),
+        F::interpolate(input[0], F::InterpolateFuncOptions().size(std::vector<int64_t>({4, 4}))),
         "Input Error: Only 3D, 4D and 5D input Tensors supported (got 2D) "
         "for the modes: nearest | linear | bilinear | bicubic | trilinear (got kNearest)");
     ASSERT_THROWS_WITH(
         F::interpolate(
             torch::reshape(input, {1, 1, 1, 3, 2, 2}),
-            F::InterpolateFuncOptions().size({1, 1, 1, 3, 4, 4})),
+            F::InterpolateFuncOptions().size(std::vector<int64_t>({1, 1, 1, 3, 4, 4}))),
         "Input Error: Only 3D, 4D and 5D input Tensors supported (got 6D) "
         "for the modes: nearest | linear | bilinear | bicubic | trilinear (got kNearest)");
     ASSERT_THROWS_WITH(
@@ -1939,12 +1939,12 @@ TEST_F(FunctionalTest, Interpolate) {
     ASSERT_THROWS_WITH(
         F::interpolate(
             input,
-            F::InterpolateFuncOptions().size({3, 4, 4}).scale_factor({0.5})),
+            F::InterpolateFuncOptions().size(std::vector<int64_t>({3, 4, 4})).scale_factor(std::vector<double>({0.5}))),
         "only one of size or scale_factor should be defined");
     ASSERT_THROWS_WITH(
-        F::interpolate(input, F::InterpolateFuncOptions().scale_factor({3, 2})),
+        F::interpolate(input, F::InterpolateFuncOptions().scale_factor(std::vector<double>({3, 2}))),
         "scale_factor shape must match input shape. "
-        "Input is 1D, scale_factor size is 2");
+        "Input is 1D, scale_factor size is [3, 2]");
     ASSERT_THROWS_WITH(
         F::interpolate(
             input,

--- a/test/cpp/api/functional.cpp
+++ b/test/cpp/api/functional.cpp
@@ -293,7 +293,7 @@ TEST_F(FunctionalTest, MultiLabelSoftMarginLossWeightedNoReduction) {
   auto input = torch::tensor({{0., 2., 2., 0.}, {2., 1., 0., 1.}}, torch::dtype(torch::kFloat).requires_grad(true));
   auto target = torch::tensor({{0., 0., 1., 0.}, {1., 0., 1., 1.}}, torch::kFloat);
   auto weight = torch::tensor({0.1, 0.6, 0.4, 0.8}, torch::kFloat);
-  auto options = F::MultiLabelSoftMarginLossFuncOptions().reduction(torch::kNone).weight(weight);
+  auto options = F::MultilabelSoftMarginLossFuncOptions().reduction(torch::kNone).weight(weight);
   auto output =
       F::multilabel_soft_margin_loss(input, target, options);
   auto expected = torch::tensor({0.4876902, 0.3321295}, torch::kFloat);

--- a/test/cpp/api/functional.cpp
+++ b/test/cpp/api/functional.cpp
@@ -2328,9 +2328,15 @@ TEST_F(FunctionalTest, AlphaDropout) {
   auto input_std = input.std();
 
   for (const auto rate : {0.2, 0.5, 0.8}) {
-    auto output = F::alpha_dropout(input, F::AlphaDropoutFuncOptions().p(rate).training(false));
-    ASSERT_TRUE(torch::allclose(input_mean, output.mean(), 0.1));
-    ASSERT_TRUE(torch::allclose(input_std, output.std(), 0.1));
+    for (const auto inplace : {false, true}) {
+      auto input_ = input.clone();
+      auto output = F::alpha_dropout(input_, F::AlphaDropoutFuncOptions().p(rate).training(false).inplace(inplace));
+      ASSERT_TRUE(torch::allclose(input_mean, output.mean(), 0.1));
+      ASSERT_TRUE(torch::allclose(input_std, output.std(), 0.1));
+      if (inplace) {
+        ASSERT_TRUE(torch::allclose(input_, output));
+      }
+    }
   }
   auto output = F::detail::alpha_dropout(input, 0.5, false, false);
   ASSERT_TRUE(torch::allclose(input_mean, output.mean(), 0.1));
@@ -2343,9 +2349,15 @@ TEST_F(FunctionalTest, FeatureAlphaDropout) {
   auto input_std = input.std();
 
   for (const auto rate : {0.2, 0.5, 0.8}) {
-    auto output = F::feature_alpha_dropout(input, F::FeatureAlphaDropoutFuncOptions().p(rate).training(false));
-    ASSERT_TRUE(torch::allclose(input_mean, output.mean(), 0.1));
-    ASSERT_TRUE(torch::allclose(input_std, output.std(), 0.1));
+    for (const auto inplace : {false, true}) {
+      auto input_ = input.clone();
+      auto output = F::feature_alpha_dropout(input_, F::FeatureAlphaDropoutFuncOptions().p(rate).training(false).inplace(inplace));
+      ASSERT_TRUE(torch::allclose(input_mean, output.mean(), 0.1));
+      ASSERT_TRUE(torch::allclose(input_std, output.std(), 0.1));
+      if (inplace) {
+        ASSERT_TRUE(torch::allclose(input_, output));
+      }
+    }
   }
   auto output = F::feature_alpha_dropout(input);
   ASSERT_TRUE(torch::allclose(input_mean, output.mean(), 0.1));

--- a/test/cpp/api/modules.cpp
+++ b/test/cpp/api/modules.cpp
@@ -2611,7 +2611,7 @@ TEST_F(ModulesTest, Threshold) {
 TEST_F(ModulesTest, Upsampling1D) {
   {
     Upsample model(UpsampleOptions()
-                       .size({4})
+                       .size(std::vector<int64_t>({4}))
                        .mode(torch::kNearest));
     auto input = torch::ones({1, 1, 2}, torch::requires_grad());
     auto output = model->forward(input);
@@ -2627,7 +2627,7 @@ TEST_F(ModulesTest, Upsampling1D) {
       // test float scale factor up & down sampling
       for (const auto scale_factor : {0.5, 1.5, 2.0}) {
         Upsample model(UpsampleOptions()
-                           .scale_factor({scale_factor})
+                           .scale_factor(std::vector<double>({scale_factor}))
                            .mode(torch::kLinear)
                            .align_corners(align_corners));
         auto input = torch::ones({1, 1, 2}, torch::requires_grad());
@@ -2646,7 +2646,7 @@ TEST_F(ModulesTest, Upsampling1D) {
   {
     // linear (1D) upsampling spatial invariance
     Upsample model(UpsampleOptions()
-                       .scale_factor({3})
+                       .scale_factor(std::vector<double>({3}))
                        .mode(torch::kLinear)
                        .align_corners(false));
     auto input = torch::zeros({1, 1, 9});
@@ -2661,7 +2661,7 @@ TEST_F(ModulesTest, Upsampling1D) {
 TEST_F(ModulesTest, Upsampling2D) {
   {
     Upsample model(UpsampleOptions()
-                       .size({4, 4})
+                       .size(std::vector<int64_t>({4, 4}))
                        .mode(torch::kNearest));
     auto input = torch::ones({1, 1, 2, 2}, torch::requires_grad());
     auto output = model->forward(input);
@@ -2677,7 +2677,7 @@ TEST_F(ModulesTest, Upsampling2D) {
       // test float scale factor up & down sampling
       for (const auto scale_factor : {0.5, 1.5, 2.0}) {
         Upsample model(UpsampleOptions()
-                           .scale_factor({scale_factor, scale_factor})
+                           .scale_factor(std::vector<double>({scale_factor, scale_factor}))
                            .mode(torch::kBilinear)
                            .align_corners(align_corners));
         auto input = torch::ones({1, 1, 2, 2}, torch::requires_grad());
@@ -2698,7 +2698,7 @@ TEST_F(ModulesTest, Upsampling2D) {
       // test float scale factor up & down sampling
       for (const auto scale_factor : {0.5, 1.5, 2.0}) {
         Upsample model(UpsampleOptions()
-                           .scale_factor({scale_factor, scale_factor})
+                           .scale_factor(std::vector<double>({scale_factor, scale_factor}))
                            .mode(torch::kBicubic)
                            .align_corners(align_corners));
         auto input = torch::ones({1, 1, 2, 2}, torch::requires_grad());
@@ -2719,7 +2719,7 @@ TEST_F(ModulesTest, Upsampling2D) {
 TEST_F(ModulesTest, Upsampling3D) {
   {
     Upsample model(UpsampleOptions()
-                       .size({4, 4, 4})
+                       .size(std::vector<int64_t>({4, 4, 4}))
                        .mode(torch::kNearest));
     auto input = torch::ones({1, 1, 2, 2, 2}, torch::requires_grad());
     auto output = model->forward(input);
@@ -2736,7 +2736,7 @@ TEST_F(ModulesTest, Upsampling3D) {
       for (const auto scale_factor : {0.5, 1.5, 2.0}) {
         Upsample model(
             UpsampleOptions()
-                .scale_factor({scale_factor, scale_factor, scale_factor})
+                .scale_factor(std::vector<double>({scale_factor, scale_factor, scale_factor}))
                 .mode(torch::kTrilinear)
                 .align_corners(align_corners));
         auto input = torch::ones({1, 1, 2, 2, 2}, torch::requires_grad());
@@ -3876,10 +3876,10 @@ TEST_F(ModulesTest, PrettyPrintConvTranspose) {
 
 TEST_F(ModulesTest, PrettyPrintUpsample) {
   ASSERT_EQ(
-      c10::str(Upsample(UpsampleOptions().size({2, 4, 4}))),
+      c10::str(Upsample(UpsampleOptions().size(std::vector<int64_t>({2, 4, 4})))),
       "torch::nn::Upsample(size=[2, 4, 4], mode=kNearest)");
   ASSERT_EQ(
-      c10::str(Upsample(UpsampleOptions().scale_factor({0.5, 1.5}).mode(torch::kBilinear))),
+      c10::str(Upsample(UpsampleOptions().scale_factor(std::vector<double>({0.5, 1.5})).mode(torch::kBilinear))),
       "torch::nn::Upsample(scale_factor=[0.5, 1.5], mode=kBilinear)");
 }
 

--- a/test/cpp/api/modules.cpp
+++ b/test/cpp/api/modules.cpp
@@ -3987,15 +3987,27 @@ TEST_F(ModulesTest, PrettyPrintAdaptiveMaxPool) {
       c10::str(AdaptiveMaxPool2d(5)),
       "torch::nn::AdaptiveMaxPool2d(output_size=[5, 5])");
   ASSERT_EQ(
-      c10::str(AdaptiveMaxPool2d(std::vector<int64_t>{5, 6})),
+      c10::str(AdaptiveMaxPool2d(AdaptiveMaxPool2dOptions({5, 6}))),
       "torch::nn::AdaptiveMaxPool2d(output_size=[5, 6])");
+  ASSERT_EQ(
+      c10::str(AdaptiveMaxPool2d(AdaptiveMaxPool2dOptions({5, c10::nullopt}))),
+      "torch::nn::AdaptiveMaxPool2d(output_size=[5, None])");
+  ASSERT_EQ(
+      c10::str(AdaptiveMaxPool2d(AdaptiveMaxPool2dOptions({c10::nullopt, c10::nullopt}))),
+      "torch::nn::AdaptiveMaxPool2d(output_size=[None, None])");
 
   ASSERT_EQ(
       c10::str(AdaptiveMaxPool3d(5)),
       "torch::nn::AdaptiveMaxPool3d(output_size=[5, 5, 5])");
   ASSERT_EQ(
-      c10::str(AdaptiveMaxPool3d(std::vector<int64_t>{5, 6, 7})),
+      c10::str(AdaptiveMaxPool3d(AdaptiveMaxPool3dOptions({5, 6, 7}))),
       "torch::nn::AdaptiveMaxPool3d(output_size=[5, 6, 7])");
+  ASSERT_EQ(
+      c10::str(AdaptiveMaxPool3d(AdaptiveMaxPool3dOptions({5, c10::nullopt, 7}))),
+      "torch::nn::AdaptiveMaxPool3d(output_size=[5, None, 7])");
+  ASSERT_EQ(
+      c10::str(AdaptiveMaxPool3d(AdaptiveMaxPool3dOptions({c10::nullopt, c10::nullopt, c10::nullopt}))),
+      "torch::nn::AdaptiveMaxPool3d(output_size=[None, None, None])");
 }
 
 TEST_F(ModulesTest, PrettyPrintAdaptiveAvgPool) {
@@ -4007,15 +4019,27 @@ TEST_F(ModulesTest, PrettyPrintAdaptiveAvgPool) {
       c10::str(AdaptiveAvgPool2d(5)),
       "torch::nn::AdaptiveAvgPool2d(output_size=[5, 5])");
   ASSERT_EQ(
-      c10::str(AdaptiveAvgPool2d(std::vector<int64_t>{5, 6})),
+      c10::str(AdaptiveAvgPool2d(AdaptiveAvgPool2dOptions({5, 6}))),
       "torch::nn::AdaptiveAvgPool2d(output_size=[5, 6])");
+  ASSERT_EQ(
+      c10::str(AdaptiveAvgPool2d(AdaptiveAvgPool2dOptions({5, c10::nullopt}))),
+      "torch::nn::AdaptiveAvgPool2d(output_size=[5, None])");
+  ASSERT_EQ(
+      c10::str(AdaptiveAvgPool2d(AdaptiveAvgPool2dOptions({c10::nullopt, c10::nullopt}))),
+      "torch::nn::AdaptiveAvgPool2d(output_size=[None, None])");
 
   ASSERT_EQ(
       c10::str(AdaptiveAvgPool3d(5)),
       "torch::nn::AdaptiveAvgPool3d(output_size=[5, 5, 5])");
   ASSERT_EQ(
-      c10::str(AdaptiveAvgPool3d(std::vector<int64_t>{5, 6, 7})),
+      c10::str(AdaptiveAvgPool3d(AdaptiveAvgPool3dOptions({5, 6, 7}))),
       "torch::nn::AdaptiveAvgPool3d(output_size=[5, 6, 7])");
+  ASSERT_EQ(
+      c10::str(AdaptiveAvgPool3d(AdaptiveAvgPool3dOptions({5, c10::nullopt, 7}))),
+      "torch::nn::AdaptiveAvgPool3d(output_size=[5, None, 7])");
+  ASSERT_EQ(
+      c10::str(AdaptiveAvgPool3d(AdaptiveAvgPool3dOptions({c10::nullopt, c10::nullopt, c10::nullopt}))),
+      "torch::nn::AdaptiveAvgPool3d(output_size=[None, None, None])");
 }
 
 TEST_F(ModulesTest, PrettyPrintMaxUnpool) {

--- a/torch/csrc/api/include/torch/expanding_array.h
+++ b/torch/csrc/api/include/torch/expanding_array.h
@@ -2,11 +2,13 @@
 
 #include <c10/util/ArrayRef.h>
 #include <c10/util/Exception.h>
+#include <c10/util/Optional.h>
 
 #include <algorithm>
 #include <array>
 #include <cstdint>
 #include <initializer_list>
+#include <string>
 #include <vector>
 
 namespace torch {
@@ -84,7 +86,7 @@ class ExpandingArray {
     return D;
   }
 
- private:
+ protected:
   /// The backing array.
   std::array<T, D> values_;
 };
@@ -98,4 +100,73 @@ std::ostream& operator<<(
   }
   return stream << static_cast<at::ArrayRef<T>>(expanding_array);
 }
+
+/// A utility class that accepts either a container of `D`-many `c10::optional<T>` values,
+/// or a single `c10::optional<T>` value, which is internally repeated `D` times.
+/// It has the additional ability to accept containers of the underlying type `T` and
+/// convert them to a container of `c10::optional<T>`.
+template <size_t D, typename T = int64_t>
+class ExpandingArrayWithOptionalElem : public ExpandingArray<D, c10::optional<T>> {
+ public:
+  using ExpandingArray<D, c10::optional<T>>::ExpandingArray;
+
+  /// Constructs an `ExpandingArrayWithOptionalElem` from an `initializer_list` of the underlying type `T`.
+  /// The extent of the length is checked against the `ExpandingArrayWithOptionalElem`'s extent parameter `D`
+  /// at runtime.
+  /*implicit*/ ExpandingArrayWithOptionalElem(std::initializer_list<T> list)
+      : ExpandingArrayWithOptionalElem(at::ArrayRef<T>(list)) {}
+
+  /// Constructs an `ExpandingArrayWithOptionalElem` from an `std::vector` of the underlying type `T`.
+  /// The extent of the length is checked against the `ExpandingArrayWithOptionalElem`'s extent parameter `D`
+  /// at runtime.
+  /*implicit*/ ExpandingArrayWithOptionalElem(std::vector<T> vec)
+      : ExpandingArrayWithOptionalElem(at::ArrayRef<T>(vec)) {}
+
+  /// Constructs an `ExpandingArrayWithOptionalElem` from an `at::ArrayRef` of the underlying type `T`.
+  /// The extent of the length is checked against the `ExpandingArrayWithOptionalElem`'s extent parameter `D`
+  /// at runtime.
+  /*implicit*/ ExpandingArrayWithOptionalElem(at::ArrayRef<T> values) : ExpandingArray<D, c10::optional<T>>(0) {
+    // clang-format off
+    TORCH_CHECK(
+        values.size() == D,
+        "Expected ", D, " values, but instead got ", values.size());
+    // clang-format on
+    for (size_t i = 0; i < this->values_.size(); i++) {
+      this->values_[i] = values[i];
+    }
+  }
+
+  /// Constructs an `ExpandingArrayWithOptionalElem` from a single value of the underlying type `T`,
+  /// which is repeated `D` times (where `D` is the extent parameter of the `ExpandingArrayWithOptionalElem`).
+  /*implicit*/ ExpandingArrayWithOptionalElem(T single_size) : ExpandingArray<D, c10::optional<T>>(0) {
+    for (size_t i = 0; i < this->values_.size(); i++) {
+      this->values_[i] = single_size;
+    }
+  }
+
+  /// Constructs an `ExpandingArrayWithOptionalElem` from a correctly sized `std::array` of the underlying type `T`.
+  /*implicit*/ ExpandingArrayWithOptionalElem(const std::array<T, D>& values) : ExpandingArray<D, c10::optional<T>>(0) {
+    for (size_t i = 0; i < this->values_.size(); i++) {
+      this->values_[i] = values[i];
+    }
+  }
+};
+
+template <size_t D, typename T>
+std::ostream& operator<<(
+    std::ostream& stream,
+    const ExpandingArrayWithOptionalElem<D, T>& expanding_array_with_opt_elem) {
+  if (expanding_array_with_opt_elem.size() == 1) {
+    const auto& elem = expanding_array_with_opt_elem->at(0);
+    stream << (elem.has_value() ? c10::str(elem.value()) : "None");
+  } else {
+    std::vector<std::string> str_array;
+    for (const auto& elem : *expanding_array_with_opt_elem) {
+      str_array.emplace_back(elem.has_value() ? c10::str(elem.value()) : "None");
+    }
+    stream << at::ArrayRef<std::string>(str_array);
+  }
+  return stream;
+}
+
 } // namespace torch

--- a/torch/csrc/api/include/torch/nn/functional/activation.h
+++ b/torch/csrc/api/include/torch/nn/functional/activation.h
@@ -15,7 +15,7 @@ namespace functional {
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 namespace detail {
-inline Tensor elu(Tensor& input, double alpha, bool inplace) {
+inline Tensor elu(Tensor input, double alpha, bool inplace) {
   if (inplace) {
     return torch::elu_(input, alpha);
   } else {
@@ -44,7 +44,7 @@ inline Tensor elu(Tensor input, const ELUFuncOptions& options = {}) {
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 namespace detail {
-inline Tensor selu(Tensor& input, bool inplace) {
+inline Tensor selu(Tensor input, bool inplace) {
   if (inplace) {
     return torch::selu_(input);
   } else {
@@ -100,7 +100,7 @@ inline Tensor hardshrink(const Tensor& input,
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 namespace detail {
-inline Tensor hardtanh(Tensor& input,
+inline Tensor hardtanh(Tensor input,
                        double min_val,
                        double max_val,
                        bool inplace) {
@@ -132,7 +132,7 @@ inline Tensor hardtanh(Tensor input, const HardtanhFuncOptions& options = {}) {
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 namespace detail {
-inline Tensor leaky_relu(Tensor& input,
+inline Tensor leaky_relu(Tensor input,
                          double negative_slope,
                          bool inplace) {
   if (inplace) {
@@ -350,7 +350,7 @@ inline Tensor prelu(const Tensor& input, const Tensor& weight) {
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 namespace detail {
-inline Tensor relu(Tensor& input, bool inplace) {
+inline Tensor relu(Tensor input, bool inplace) {
   if (inplace) {
     return torch::relu_(input);
   } else {
@@ -379,7 +379,7 @@ inline Tensor relu(Tensor input, const ReLUFuncOptions& options = {}) {
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 namespace detail {
-inline Tensor relu6(Tensor& input, bool inplace) {
+inline Tensor relu6(Tensor input, bool inplace) {
   return detail::hardtanh(input, /*min_val=*/0, /*max_val=*/6, /*inplace=*/inplace);
 }
 } // namespace detail
@@ -404,7 +404,7 @@ inline Tensor relu6(Tensor input, const ReLU6FuncOptions& options = {}) {
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 namespace detail {
-inline Tensor rrelu(Tensor& input,
+inline Tensor rrelu(Tensor input,
                     double lower,
                     double upper,
                     bool training,
@@ -437,7 +437,7 @@ inline Tensor rrelu(Tensor input, const RReLUFuncOptions& options = {}) {
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 namespace detail {
-inline Tensor celu(Tensor& input,
+inline Tensor celu(Tensor input,
                    double alpha,
                    bool inplace) {
   if (inplace) {
@@ -536,7 +536,7 @@ inline Tensor tanhshrink(const Tensor& input) {
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 namespace detail {
-inline Tensor threshold(Tensor& input,
+inline Tensor threshold(Tensor input,
                         double threshold,
                         double value,
                         bool inplace) {

--- a/torch/csrc/api/include/torch/nn/functional/dropout.h
+++ b/torch/csrc/api/include/torch/nn/functional/dropout.h
@@ -9,7 +9,7 @@ namespace functional {
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 namespace detail {
 
-inline Tensor dropout(Tensor& input, double p, bool training, bool inplace) {
+inline Tensor dropout(Tensor input, double p, bool training, bool inplace) {
   TORCH_CHECK(
     p >= 0. && p <= 1.,
     "dropout probability has to be between 0 and 1, but got ",
@@ -46,7 +46,7 @@ inline Tensor dropout(Tensor input,
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 namespace detail {
 
-inline Tensor dropout2d(Tensor& input, double p, bool training, bool inplace) {
+inline Tensor dropout2d(Tensor input, double p, bool training, bool inplace) {
   TORCH_CHECK(
     p >= 0. && p <= 1.,
     "dropout probability has to be between 0 and 1, but got ",
@@ -83,7 +83,7 @@ inline Tensor dropout2d(Tensor input,
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 namespace detail {
 
-inline Tensor dropout3d(Tensor& input, double p, bool training, bool inplace) {
+inline Tensor dropout3d(Tensor input, double p, bool training, bool inplace) {
   TORCH_CHECK(
     p >= 0. && p <= 1.,
     "dropout probability has to be between 0 and 1, but got ",

--- a/torch/csrc/api/include/torch/nn/functional/loss.h
+++ b/torch/csrc/api/include/torch/nn/functional/loss.h
@@ -377,7 +377,7 @@ namespace detail {
 inline Tensor multilabel_margin_loss(
     const Tensor& input,
     const Tensor& target,
-    MultiLabelMarginLossFuncOptions::reduction_t reduction) {
+    MultilabelMarginLossFuncOptions::reduction_t reduction) {
   return torch::multilabel_margin_loss(
     input,
     target,
@@ -389,18 +389,18 @@ inline Tensor multilabel_margin_loss(
 /// See https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.multilabel_margin_loss
 /// about the exact behavior of this functional.
 ///
-/// See the documentation for `torch::nn::functional::MultiLabelMarginLossFuncOptions` class to learn what
+/// See the documentation for `torch::nn::functional::MultilabelMarginLossFuncOptions` class to learn what
 /// optional arguments are supported for this functional.
 ///
 /// Example:
 /// ```
 /// namespace F = torch::nn::functional;
-/// F::multilabel_margin_loss(input, target, F::MultiLabelMarginLossFuncOptions(torch::kNone));
+/// F::multilabel_margin_loss(input, target, F::MultilabelMarginLossFuncOptions(torch::kNone));
 /// ```
 inline Tensor multilabel_margin_loss(
     const Tensor& input,
     const Tensor& target,
-    const MultiLabelMarginLossFuncOptions& options = {}) {
+    const MultilabelMarginLossFuncOptions& options = {}) {
   return detail::multilabel_margin_loss(input, target, options.reduction());
 }
 
@@ -446,7 +446,7 @@ inline Tensor multilabel_soft_margin_loss(
     const Tensor& input,
     const Tensor& target,
     const Tensor& weight,
-    MultiLabelSoftMarginLossFuncOptions::reduction_t reduction) {
+    MultilabelSoftMarginLossFuncOptions::reduction_t reduction) {
   auto loss = -(target * torch::log_sigmoid(input) + (1 - target) * torch::log_sigmoid(-input));
   if (weight.defined()) {
     loss = loss * weight;
@@ -477,18 +477,18 @@ inline Tensor multilabel_soft_margin_loss(
 /// See https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.multilabel_soft_margin_loss
 /// about the exact behavior of this functional.
 ///
-/// See the documentation for `torch::nn::functional::MultiLabelSoftMarginLossFuncOptions` class to learn what
+/// See the documentation for `torch::nn::functional::MultilabelSoftMarginLossFuncOptions` class to learn what
 /// optional arguments are supported for this functional.
 ///
 /// Example:
 /// ```
 /// namespace F = torch::nn::functional;
-/// F::multilabel_soft_margin_loss(input, target, F::MultiLabelSoftMarginLossFuncOptions().reduction(torch::kNone).weight(weight));
+/// F::multilabel_soft_margin_loss(input, target, F::MultilabelSoftMarginLossFuncOptions().reduction(torch::kNone).weight(weight));
 /// ```
 inline Tensor multilabel_soft_margin_loss(
     const Tensor& input,
     const Tensor& target,
-    const MultiLabelSoftMarginLossFuncOptions& options = {}) {
+    const MultilabelSoftMarginLossFuncOptions& options = {}) {
   return detail::multilabel_soft_margin_loss(input, target, options.weight(), options.reduction());
 }
 

--- a/torch/csrc/api/include/torch/nn/functional/pooling.h
+++ b/torch/csrc/api/include/torch/nn/functional/pooling.h
@@ -857,7 +857,7 @@ inline std::tuple<Tensor, Tensor> fractional_max_pool3d_with_indices(
   if (!_random_samples_.defined()) {
     _random_samples_ = torch::rand({input.size(0), input.size(1), 3}, torch::TensorOptions().dtype(input.dtype()).device(input.device()));
   }
-  return torch::fractional_max_pool3d(input, kernel_size, *output_size, _random_samples_);
+  return torch::fractional_max_pool3d(input, kernel_size, *output_size_, _random_samples_);
 }
 } // namespace detail
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */

--- a/torch/csrc/api/include/torch/nn/functional/pooling.h
+++ b/torch/csrc/api/include/torch/nn/functional/pooling.h
@@ -2,6 +2,7 @@
 
 #include <torch/nn/functional/activation.h>
 #include <torch/nn/options/pooling.h>
+#include <torch/nn/modules/utils.h>
 
 namespace torch {
 namespace nn {
@@ -373,9 +374,29 @@ inline std::tuple<Tensor, Tensor> max_pool3d_with_indices(const Tensor& input, c
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 namespace detail {
+inline std::tuple<Tensor, Tensor> adaptive_max_pool1d_with_indices(
+    const Tensor& input, ExpandingArray<1> output_size) {
+  return torch::adaptive_max_pool1d(input, output_size);
+}
+} // namespace detail
+
+/// See the documentation for `torch::nn::functional::AdaptiveMaxPool1dFuncOptions` class to learn what
+/// optional arguments are supported for this functional.
+///
+/// Example:
+/// ```
+/// namespace F = torch::nn::functional;
+/// F::adaptive_max_pool1d_with_indices(x, F::AdaptiveMaxPool1dFuncOptions(3));
+/// ```
+inline std::tuple<Tensor, Tensor> adaptive_max_pool1d_with_indices(
+    const Tensor& input, const AdaptiveMaxPool1dFuncOptions& options) {
+  return detail::adaptive_max_pool1d_with_indices(input, options.output_size());
+}
+
+namespace detail {
 inline Tensor adaptive_max_pool1d(const Tensor& input,
-  ExpandingArray<1> output_size) {
-   return std::get<0>(torch::adaptive_max_pool1d(input, output_size));
+    ExpandingArray<1> output_size) {
+  return std::get<0>(adaptive_max_pool1d_with_indices(input, output_size));
 }
 } // namespace detail
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
@@ -392,37 +413,38 @@ inline Tensor adaptive_max_pool1d(const Tensor& input,
 /// F::adaptive_max_pool1d(x, F::AdaptiveMaxPool1dFuncOptions(3));
 /// ```
 inline Tensor adaptive_max_pool1d(const Tensor& input,
-  const AdaptiveMaxPool1dFuncOptions& options) {
-   return detail::adaptive_max_pool1d(input, options.output_size());
+    const AdaptiveMaxPool1dFuncOptions& options) {
+  return detail::adaptive_max_pool1d(input, options.output_size());
 }
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 namespace detail {
-inline std::tuple<Tensor, Tensor> adaptive_max_pool1d_with_indices(
-  const Tensor& input, ExpandingArray<1> output_size) {
-   return torch::adaptive_max_pool1d(input, output_size);
+inline std::tuple<Tensor, Tensor> adaptive_max_pool2d_with_indices(
+    const Tensor& input, ExpandingArrayWithOptionalElem<2> output_size) {
+  auto output_size_ = torch::nn::modules::utils::_list_with_default(output_size, input.sizes());
+  return torch::adaptive_max_pool2d(input, output_size_);
 }
 } // namespace detail
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
-/// See the documentation for `torch::nn::functional::AdaptiveMaxPool1dFuncOptions` class to learn what
+/// See the documentation for `torch::nn::functional::AdaptiveMaxPool2dFuncOptions` class to learn what
 /// optional arguments are supported for this functional.
 ///
 /// Example:
 /// ```
 /// namespace F = torch::nn::functional;
-/// F::adaptive_max_pool1d_with_indices(x, F::AdaptiveMaxPool1dFuncOptions(3));
+/// F::adaptive_max_pool2d_with_indices(x, F::AdaptiveMaxPool2dFuncOptions(3));
 /// ```
-inline std::tuple<Tensor, Tensor> adaptive_max_pool1d_with_indices(
-  const Tensor& input, const AdaptiveMaxPool1dFuncOptions& options) {
-   return detail::adaptive_max_pool1d_with_indices(input, options.output_size());
+inline std::tuple<Tensor, Tensor> adaptive_max_pool2d_with_indices(
+    const Tensor& input, const AdaptiveMaxPool2dFuncOptions& options) {
+  return detail::adaptive_max_pool2d_with_indices(input, options.output_size());
 }
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 namespace detail {
 inline Tensor adaptive_max_pool2d(const Tensor& input,
-  ExpandingArray<2> output_size) {
-   return std::get<0>(torch::adaptive_max_pool2d(input, output_size));
+    ExpandingArrayWithOptionalElem<2> output_size) {
+  return std::get<0>(adaptive_max_pool2d_with_indices(input, output_size));
 }
 } // namespace detail
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
@@ -439,37 +461,38 @@ inline Tensor adaptive_max_pool2d(const Tensor& input,
 /// F::adaptive_max_pool2d(x, F::AdaptiveMaxPool2dFuncOptions(3));
 /// ```
 inline Tensor adaptive_max_pool2d(const Tensor& input,
-  const AdaptiveMaxPool2dFuncOptions& options) {
-   return detail::adaptive_max_pool2d(input, options.output_size());
+    const AdaptiveMaxPool2dFuncOptions& options) {
+  return detail::adaptive_max_pool2d(input, options.output_size());
 }
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 namespace detail {
-inline std::tuple<Tensor, Tensor> adaptive_max_pool2d_with_indices(
-  const Tensor& input, ExpandingArray<2> output_size) {
-   return torch::adaptive_max_pool2d(input, output_size);
+inline std::tuple<Tensor, Tensor> adaptive_max_pool3d_with_indices(
+    const Tensor& input, ExpandingArrayWithOptionalElem<3> output_size) {
+  auto output_size_ = torch::nn::modules::utils::_list_with_default(output_size, input.sizes());
+  return torch::adaptive_max_pool3d(input, output_size_);
 }
 } // namespace detail
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
-/// See the documentation for `torch::nn::functional::AdaptiveMaxPool2dFuncOptions` class to learn what
+/// See the documentation for `torch::nn::functional::AdaptiveMaxPool3dFuncOptions` class to learn what
 /// optional arguments are supported for this functional.
 ///
 /// Example:
 /// ```
 /// namespace F = torch::nn::functional;
-/// F::adaptive_max_pool2d_with_indices(x, F::AdaptiveMaxPool2dFuncOptions(3));
+/// F::adaptive_max_pool3d_with_indices(x, F::AdaptiveMaxPool3dFuncOptions(3));
 /// ```
-inline std::tuple<Tensor, Tensor> adaptive_max_pool2d_with_indices(
-  const Tensor& input, const AdaptiveMaxPool2dFuncOptions& options) {
-   return detail::adaptive_max_pool2d_with_indices(input, options.output_size());
+inline std::tuple<Tensor, Tensor> adaptive_max_pool3d_with_indices(
+    const Tensor& input, const AdaptiveMaxPool3dFuncOptions& options) {
+  return detail::adaptive_max_pool3d_with_indices(input, options.output_size());
 }
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 namespace detail {
 inline Tensor adaptive_max_pool3d(const Tensor& input,
-  ExpandingArray<3> output_size) {
-   return std::get<0>(torch::adaptive_max_pool3d(input, output_size));
+    ExpandingArrayWithOptionalElem<3> output_size) {
+  return std::get<0>(adaptive_max_pool3d_with_indices(input, output_size));
 }
 } // namespace detail
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
@@ -490,35 +513,13 @@ inline Tensor adaptive_max_pool3d(const Tensor& input,
    return detail::adaptive_max_pool3d(input, options.output_size());
 }
 
-#ifndef DOXYGEN_SHOULD_SKIP_THIS
-namespace detail {
-inline std::tuple<Tensor, Tensor> adaptive_max_pool3d_with_indices(
-  const Tensor& input, ExpandingArray<3> output_size) {
-   return torch::adaptive_max_pool3d(input, output_size);
-}
-} // namespace detail
-#endif /* DOXYGEN_SHOULD_SKIP_THIS */
-
-/// See the documentation for `torch::nn::functional::AdaptiveMaxPool3dFuncOptions` class to learn what
-/// optional arguments are supported for this functional.
-///
-/// Example:
-/// ```
-/// namespace F = torch::nn::functional;
-/// F::adaptive_max_pool3d_with_indices(x, F::AdaptiveMaxPool3dFuncOptions(3));
-/// ```
-inline std::tuple<Tensor, Tensor> adaptive_max_pool3d_with_indices(
-  const Tensor& input, const AdaptiveMaxPool3dFuncOptions& options) {
-   return detail::adaptive_max_pool3d_with_indices(input, options.output_size());
-}
-
 // ============================================================================
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 namespace detail {
 inline Tensor adaptive_avg_pool1d(const Tensor& input,
-  ExpandingArray<1> output_size) {
-   return torch::adaptive_avg_pool1d(input, output_size);
+    ExpandingArray<1> output_size) {
+  return torch::adaptive_avg_pool1d(input, output_size);
 }
 } // namespace detail
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
@@ -535,15 +536,16 @@ inline Tensor adaptive_avg_pool1d(const Tensor& input,
 /// F::adaptive_avg_pool1d(x, F::AdaptiveAvgPool1dFuncOptions(3));
 /// ```
 inline Tensor adaptive_avg_pool1d(const Tensor& input,
-  const AdaptiveAvgPool1dFuncOptions& options) {
-   return detail::adaptive_avg_pool1d(input, options.output_size());
+    const AdaptiveAvgPool1dFuncOptions& options) {
+  return detail::adaptive_avg_pool1d(input, options.output_size());
 }
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 namespace detail {
 inline Tensor adaptive_avg_pool2d(const Tensor& input,
-  ExpandingArray<2> output_size) {
-   return torch::adaptive_avg_pool2d(input, output_size);
+    ExpandingArrayWithOptionalElem<2> output_size) {
+  auto output_size_ = torch::nn::modules::utils::_list_with_default(output_size, input.sizes());
+  return torch::adaptive_avg_pool2d(input, output_size_);
 }
 } // namespace detail
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
@@ -560,15 +562,16 @@ inline Tensor adaptive_avg_pool2d(const Tensor& input,
 /// F::adaptive_avg_pool2d(x, F::AdaptiveAvgPool2dFuncOptions(3));
 /// ```
 inline Tensor adaptive_avg_pool2d(const Tensor& input,
-  const AdaptiveAvgPool2dFuncOptions& options) {
-   return detail::adaptive_avg_pool2d(input, options.output_size());
+    const AdaptiveAvgPool2dFuncOptions& options) {
+  return detail::adaptive_avg_pool2d(input, options.output_size());
 }
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 namespace detail {
 inline Tensor adaptive_avg_pool3d(const Tensor& input,
-  ExpandingArray<3> output_size) {
-   return torch::adaptive_avg_pool3d(input, output_size);
+    ExpandingArrayWithOptionalElem<3> output_size) {
+  auto output_size_ = torch::nn::modules::utils::_list_with_default(output_size, input.sizes());
+  return torch::adaptive_avg_pool3d(input, output_size_);
 }
 } // namespace detail
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
@@ -585,8 +588,8 @@ inline Tensor adaptive_avg_pool3d(const Tensor& input,
 /// F::adaptive_avg_pool3d(x, F::AdaptiveAvgPool3dFuncOptions(3));
 /// ```
 inline Tensor adaptive_avg_pool3d(const Tensor& input,
-  const AdaptiveAvgPool3dFuncOptions& options) {
-   return detail::adaptive_avg_pool3d(input, options.output_size());
+    const AdaptiveAvgPool3dFuncOptions& options) {
+  return detail::adaptive_avg_pool3d(input, options.output_size());
 }
 
 // ============================================================================

--- a/torch/csrc/api/include/torch/nn/functional/upsampling.h
+++ b/torch/csrc/api/include/torch/nn/functional/upsampling.h
@@ -9,46 +9,74 @@ namespace torch {
 namespace nn {
 namespace functional {
 
+inline std::vector<int64_t> _interp_output_size(
+  int64_t dim,
+  std::tuple<
+    Tensor,
+    c10::optional<std::vector<int64_t>>,
+    c10::optional<std::vector<double>>,
+    c10::optional<bool>> closed_over_args) {
+  Tensor input;
+  c10::optional<std::vector<int64_t>> size;
+  c10::optional<std::vector<double>> scale_factor;
+  c10::optional<bool> recompute_scale_factor;
+  std::tie(input, size, scale_factor, recompute_scale_factor) = closed_over_args;
+  if (size == c10::nullopt && scale_factor == c10::nullopt) {
+    TORCH_CHECK(false, "either size or scale_factor should be defined");
+  }
+  if (size != c10::nullopt && scale_factor != c10::nullopt) {
+    TORCH_CHECK(false, "only one of size or scale_factor should be defined");
+  }
+  if (scale_factor != c10::nullopt) {
+    if (static_cast<int64_t>(scale_factor.value().size()) != dim) {
+      TORCH_CHECK(
+        false,
+        "scale_factor shape must match input shape. ",
+        "Input is ", dim, "D, scale_factor size is ", torch::ArrayRef<double>(*scale_factor));
+    }
+  }
+  if (size != c10::nullopt) {
+    return *size;
+  }
+
+  TORCH_INTERNAL_ASSERT(scale_factor != c10::nullopt);
+  auto scale_factors = *scale_factor;
+
+  if (recompute_scale_factor == c10::nullopt) {
+    // only warn when the scales have floating values since
+    // the result for ints is the same with/without recompute_scale_factor
+    bool is_float_scale_factor = false;
+    for (double scale : scale_factors) {
+      is_float_scale_factor = floor(scale) == scale;
+      if (is_float_scale_factor) {
+        break;
+      }
+    }
+    if (is_float_scale_factor) {
+      TORCH_WARN("The default behavior for interpolate/upsample with float scale_factor will change "
+                 "in 1.6.0 to align with other frameworks/libraries, and use scale_factor directly, "
+                 "instead of relying on the computed output size. "
+                 "If you wish to keep the old behavior, please set recompute_scale_factor=True. "
+                 "See the documentation of nn.Upsample for details. ");
+    }
+  }
+
+  std::vector<int64_t> ret;
+  for (int64_t i = 0; i < dim; i++) {
+    ret.emplace_back(static_cast<int64_t>(floor(input.size(i + 2) * scale_factors[i])));
+  }
+  return ret;
+}
+
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 namespace detail {
 inline Tensor interpolate(
   const Tensor& input,
-  const std::vector<int64_t>& size,
-  const std::vector<double>& scale_factor,
+  const c10::optional<std::vector<int64_t>>& size,
+  const c10::optional<std::vector<double>>& scale_factor,
   InterpolateFuncOptions::mode_t mode,
-  c10::optional<bool> align_corners) {
-  auto _check_size_scale_factor = [&](size_t dim) {
-    if (size.empty() && scale_factor.empty()) {
-      TORCH_CHECK(false, "either size or scale_factor should be defined");
-    }
-    if (!size.empty() && !scale_factor.empty()) {
-      TORCH_CHECK(false, "only one of size or scale_factor should be defined");
-    }
-    if (!scale_factor.empty() &&
-        scale_factor.size() != dim) {
-      TORCH_CHECK(
-          false,
-          "scale_factor shape must match input shape. "
-          "Input is ", dim, "D, scale_factor size is ",
-          scale_factor.size());
-    }
-  };
-
-  auto _output_size = [&](size_t dim) {
-    _check_size_scale_factor(dim);
-    if (!size.empty()) {
-      return size;
-    }
-    auto scale_factors = scale_factor;
-
-    std::vector<int64_t> sizes;
-    for (size_t i = 0; i < dim; ++i) {
-      sizes.push_back(static_cast<int64_t>(std::floor(
-          static_cast<double>(input.size(i + 2)) * scale_factors[i])));
-    }
-    return sizes;
-  };
-
+  c10::optional<bool> align_corners,
+  c10::optional<bool> recompute_scale_factor) {
   if (c10::get_if<enumtype::kNearest>(&mode) ||
       c10::get_if<enumtype::kArea>(&mode)) {
     if (align_corners != c10::nullopt) {
@@ -60,28 +88,42 @@ inline Tensor interpolate(
   } else {
     if (align_corners == c10::nullopt) {
       TORCH_WARN(
-          "Default upsampling behavior when mode is linear, bilinear, bicubic, "
-          "or trilinear, has changed to align_corners=False since 0.4.0. "
-          "Please specify align_corners=True if the old behavior is desired. "
+          "Default upsampling behavior when mode=", enumtype::get_enum_name(mode), " is changed "
+          "to align_corners=False since 0.4.0. Please specify "
+          "align_corners=True if the old behavior is desired. "
           "See the documentation of nn.Upsample for details.");
       align_corners = false;
     }
   }
 
+  auto scale_factor_len = input.dim() - 2;
+  std::vector<c10::optional<double>> scale_factor_list(scale_factor_len, c10::nullopt);
+  if (scale_factor != c10::nullopt && recompute_scale_factor.has_value() && !recompute_scale_factor.value()) {
+    auto _scale_factor_repeated = *scale_factor;
+    scale_factor_list = {};
+    for (const auto& elem : _scale_factor_repeated) {
+      scale_factor_list.emplace_back(elem);
+    }
+  }
+
+  auto closed_over_args = std::make_tuple(input, size, scale_factor, recompute_scale_factor);
   if (input.dim() == 3 && c10::get_if<enumtype::kNearest>(&mode)) {
-    return torch::upsample_nearest1d(input, _output_size(1));
+    return torch::upsample_nearest1d(input, _interp_output_size(1, closed_over_args), scale_factor_list.at(0));
   } else if (input.dim() == 4 && c10::get_if<enumtype::kNearest>(&mode)) {
-    return torch::upsample_nearest2d(input, _output_size(2));
+    return torch::upsample_nearest2d(input, _interp_output_size(2, closed_over_args), 
+                                     scale_factor_list.at(0), scale_factor_list.at(1));
   } else if (input.dim() == 5 && c10::get_if<enumtype::kNearest>(&mode)) {
-    return torch::upsample_nearest3d(input, _output_size(3));
+    return torch::upsample_nearest3d(input, _interp_output_size(3, closed_over_args),
+                                     scale_factor_list.at(0), scale_factor_list.at(1), scale_factor_list.at(2));
   } else if (input.dim() == 3 && c10::get_if<enumtype::kArea>(&mode)) {
-    return detail::adaptive_avg_pool1d(input, _output_size(1));
+    return detail::adaptive_avg_pool1d(input, _interp_output_size(1, closed_over_args));
   } else if (input.dim() == 4 && c10::get_if<enumtype::kArea>(&mode)) {
-    return detail::adaptive_avg_pool2d(input, _output_size(2));
+    return detail::adaptive_avg_pool2d(input, _interp_output_size(2, closed_over_args));
   } else if (input.dim() == 5 && c10::get_if<enumtype::kArea>(&mode)) {
-    return detail::adaptive_avg_pool3d(input, _output_size(3));
+    return detail::adaptive_avg_pool3d(input, _interp_output_size(3, closed_over_args));
   } else if (input.dim() == 3 && c10::get_if<enumtype::kLinear>(&mode)) {
-    return torch::upsample_linear1d(input, _output_size(1), *align_corners);
+    TORCH_INTERNAL_ASSERT(align_corners != c10::nullopt);
+    return torch::upsample_linear1d(input, _interp_output_size(1, closed_over_args), *align_corners, scale_factor_list.at(0));
   } else if (input.dim() == 3 && c10::get_if<enumtype::kBilinear>(&mode)) {
     TORCH_CHECK(false, "Got 3D input, but bilinear mode needs 4D input");
   } else if (input.dim() == 3 && c10::get_if<enumtype::kTrilinear>(&mode)) {
@@ -89,7 +131,9 @@ inline Tensor interpolate(
   } else if (input.dim() == 4 && c10::get_if<enumtype::kLinear>(&mode)) {
     TORCH_CHECK(false, "Got 4D input, but linear mode needs 3D input");
   } else if (input.dim() == 4 && c10::get_if<enumtype::kBilinear>(&mode)) {
-    return torch::upsample_bilinear2d(input, _output_size(2), *align_corners);
+    TORCH_INTERNAL_ASSERT(align_corners != c10::nullopt);
+    return torch::upsample_bilinear2d(input, _interp_output_size(2, closed_over_args), *align_corners, 
+                                      scale_factor_list.at(0), scale_factor_list.at(1));
   } else if (input.dim() == 4 && c10::get_if<enumtype::kTrilinear>(&mode)) {
     TORCH_CHECK(false, "Got 4D input, but trilinear mode needs 5D input");
   } else if (input.dim() == 5 && c10::get_if<enumtype::kLinear>(&mode)) {
@@ -97,9 +141,13 @@ inline Tensor interpolate(
   } else if (input.dim() == 5 && c10::get_if<enumtype::kBilinear>(&mode)) {
     TORCH_CHECK(false, "Got 5D input, but bilinear mode needs 4D input");
   } else if (input.dim() == 5 && c10::get_if<enumtype::kTrilinear>(&mode)) {
-    return torch::upsample_trilinear3d(input, _output_size(3), *align_corners);
+    TORCH_INTERNAL_ASSERT(align_corners != c10::nullopt);
+    return torch::upsample_trilinear3d(input, _interp_output_size(3, closed_over_args), *align_corners,
+                                       scale_factor_list.at(0), scale_factor_list.at(1), scale_factor_list.at(2));
   } else if (input.dim() == 4 && c10::get_if<enumtype::kBicubic>(&mode)) {
-    return torch::upsample_bicubic2d(input, _output_size(2), *align_corners);
+    TORCH_INTERNAL_ASSERT(align_corners != c10::nullopt);
+    return torch::upsample_bicubic2d(input, _interp_output_size(2, closed_over_args), *align_corners, 
+                                     scale_factor_list.at(0), scale_factor_list.at(1));
   } else {
     TORCH_CHECK(
         false,
@@ -128,7 +176,8 @@ inline Tensor interpolate(const Tensor& input, const InterpolateFuncOptions& opt
     options.size(),
     options.scale_factor(),
     options.mode(),
-    options.align_corners());
+    options.align_corners(),
+    options.recompute_scale_factor());
 }
 
 } // namespace functional

--- a/torch/csrc/api/include/torch/nn/modules/conv.h
+++ b/torch/csrc/api/include/torch/nn/modules/conv.h
@@ -4,6 +4,7 @@
 #include <torch/nn/cloneable.h>
 #include <torch/nn/init.h>
 #include <torch/nn/modules/common.h>
+#include <torch/nn/modules/utils.h>
 #include <torch/nn/options/conv.h>
 #include <torch/nn/pimpl.h>
 #include <torch/types.h>
@@ -31,6 +32,8 @@ class ConvNdImpl : public torch::nn::Cloneable<Derived> {
     TORCH_CHECK(
       options.out_channels() % options.groups() == 0,
       "out_channels must be divisible by groups");
+
+    _padding_repeated_twice = torch::nn::modules::utils::_repeat_vector(options.padding(), 2);
 
     if (options.transposed()) {
       std::vector<int64_t> weight_sizes = {
@@ -106,6 +109,9 @@ class ConvNdImpl : public torch::nn::Cloneable<Derived> {
 
   /// The learned bias. Only defined if the `bias` option was true.
   Tensor bias;
+
+ protected:
+  std::vector<int64_t> _padding_repeated_twice;
 };
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Conv1d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -163,6 +169,9 @@ class TORCH_API Conv2dImpl : public ConvNdImpl<2, Conv2dImpl> {
   }
   explicit Conv2dImpl(Conv2dOptions options_);
   Tensor forward(const Tensor& input);
+
+ protected:
+  Tensor _conv_forward(const Tensor& input, const Tensor& weight);
 };
 
 /// A `ModuleHolder` subclass for `Conv2dImpl`.

--- a/torch/csrc/api/include/torch/nn/modules/padding.h
+++ b/torch/csrc/api/include/torch/nn/modules/padding.h
@@ -11,7 +11,7 @@ namespace nn {
 
 /// Base class for all (dimension-specialized) ReflectionPad modules.
 template <size_t D, typename Derived>
-class TORCH_API ReflectionPadImpl : public torch::nn::Cloneable<Derived> {
+class ReflectionPadImpl : public torch::nn::Cloneable<Derived> {
  public:
   ReflectionPadImpl(ExpandingArray<D*2> padding)
       : ReflectionPadImpl(ReflectionPadOptions<D>(padding)) {}
@@ -82,7 +82,7 @@ TORCH_MODULE(ReflectionPad2d);
 
 /// Base class for all (dimension-specialized) ReplicationPad modules.
 template <size_t D, typename Derived>
-class TORCH_API ReplicationPadImpl : public torch::nn::Cloneable<Derived> {
+class ReplicationPadImpl : public torch::nn::Cloneable<Derived> {
  public:
   ReplicationPadImpl(ExpandingArray<D*2> padding)
       : ReplicationPadImpl(ReplicationPadOptions<D>(padding)) {}
@@ -215,7 +215,7 @@ TORCH_MODULE(ZeroPad2d);
 
 /// Base class for all (dimension-specialized) ConstantPad modules.
 template <size_t D, typename Derived>
-class TORCH_API ConstantPadImpl : public torch::nn::Cloneable<Derived> {
+class ConstantPadImpl : public torch::nn::Cloneable<Derived> {
  public:
   ConstantPadImpl(ExpandingArray<D*2> padding, double value)
       : ConstantPadImpl(ConstantPadOptions<D>(padding, value)) {}

--- a/torch/csrc/api/include/torch/nn/modules/pooling.h
+++ b/torch/csrc/api/include/torch/nn/modules/pooling.h
@@ -218,20 +218,24 @@ TORCH_MODULE(MaxPool3d);
 // ============================================================================
 
 /// Base class for all (dimension-specialized) adaptive maxpool modules.
-template <size_t D, typename Derived>
+template <size_t D, typename output_size_t, typename Derived>
 class TORCH_API AdaptiveMaxPoolImpl : public torch::nn::Cloneable<Derived> {
  public:
-  AdaptiveMaxPoolImpl(ExpandingArray<D> output_size)
-      : AdaptiveMaxPoolImpl(AdaptiveMaxPoolOptions<D>(output_size)) {}
-  explicit AdaptiveMaxPoolImpl(const AdaptiveMaxPoolOptions<D>& options_);
+  AdaptiveMaxPoolImpl(output_size_t output_size)
+      : AdaptiveMaxPoolImpl(AdaptiveMaxPoolOptions<output_size_t>(output_size)) {}
+  explicit AdaptiveMaxPoolImpl(
+    const AdaptiveMaxPoolOptions<output_size_t>& options_) : options(options_) {}
 
-  void reset() override;
+  void reset() override {};
 
   /// Pretty prints the `AdaptiveMaxPool{1,2,3}d` module into the given `stream`.
-  void pretty_print(std::ostream& stream) const override;
+  void pretty_print(std::ostream& stream) const override {
+    stream << "torch::nn::AdaptiveMaxPool" << D << "d"
+           << "(output_size=" << options.output_size() << ")";
+  }
 
   /// The options with which this `Module` was constructed.
-  AdaptiveMaxPoolOptions<D> options;
+  AdaptiveMaxPoolOptions<output_size_t> options;
 };
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~ AdaptiveMaxPool1d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -248,9 +252,9 @@ class TORCH_API AdaptiveMaxPoolImpl : public torch::nn::Cloneable<Derived> {
 /// AdaptiveMaxPool1d model(AdaptiveMaxPool1dOptions(3));
 /// ```
 class TORCH_API AdaptiveMaxPool1dImpl :
-  public AdaptiveMaxPoolImpl<1, AdaptiveMaxPool1dImpl> {
+  public AdaptiveMaxPoolImpl<1, ExpandingArray<1>, AdaptiveMaxPool1dImpl> {
  public:
-  using AdaptiveMaxPoolImpl<1, AdaptiveMaxPool1dImpl>::AdaptiveMaxPoolImpl;
+  using AdaptiveMaxPoolImpl<1, ExpandingArray<1>, AdaptiveMaxPool1dImpl>::AdaptiveMaxPoolImpl;
 
   Tensor forward(const Tensor& input);
 
@@ -280,9 +284,9 @@ TORCH_MODULE(AdaptiveMaxPool1d);
 /// AdaptiveMaxPool2d model(AdaptiveMaxPool2dOptions({3, 2}));
 /// ```
 class TORCH_API AdaptiveMaxPool2dImpl :
-  public AdaptiveMaxPoolImpl<2, AdaptiveMaxPool2dImpl> {
+  public AdaptiveMaxPoolImpl<2, ExpandingArrayWithOptionalElem<2>, AdaptiveMaxPool2dImpl> {
  public:
-  using AdaptiveMaxPoolImpl<2, AdaptiveMaxPool2dImpl>::AdaptiveMaxPoolImpl;
+  using AdaptiveMaxPoolImpl<2, ExpandingArrayWithOptionalElem<2>, AdaptiveMaxPool2dImpl>::AdaptiveMaxPoolImpl;
 
   Tensor forward(const Tensor& input);
 
@@ -312,9 +316,9 @@ TORCH_MODULE(AdaptiveMaxPool2d);
 /// AdaptiveMaxPool3d model(AdaptiveMaxPool3dOptions(3));
 /// ```
 class TORCH_API AdaptiveMaxPool3dImpl :
-  public AdaptiveMaxPoolImpl<3, AdaptiveMaxPool3dImpl> {
+  public AdaptiveMaxPoolImpl<3, ExpandingArrayWithOptionalElem<3>, AdaptiveMaxPool3dImpl> {
  public:
-  using AdaptiveMaxPoolImpl<3, AdaptiveMaxPool3dImpl>::AdaptiveMaxPoolImpl;
+  using AdaptiveMaxPoolImpl<3, ExpandingArrayWithOptionalElem<3>, AdaptiveMaxPool3dImpl>::AdaptiveMaxPoolImpl;
 
   Tensor forward(const Tensor& input);
 
@@ -333,20 +337,24 @@ TORCH_MODULE(AdaptiveMaxPool3d);
 // ============================================================================
 
 /// Base class for all (dimension-specialized) adaptive avgpool modules.
-template <size_t D, typename Derived>
+template <size_t D, typename output_size_t, typename Derived>
 class TORCH_API AdaptiveAvgPoolImpl : public torch::nn::Cloneable<Derived> {
  public:
-  AdaptiveAvgPoolImpl(ExpandingArray<D> output_size)
-      : AdaptiveAvgPoolImpl(AdaptiveAvgPoolOptions<D>(output_size)) {}
-  explicit AdaptiveAvgPoolImpl(const AdaptiveAvgPoolOptions<D>& options_);
+  AdaptiveAvgPoolImpl(output_size_t output_size)
+      : AdaptiveAvgPoolImpl(AdaptiveAvgPoolOptions<output_size_t>(output_size)) {}
+  explicit AdaptiveAvgPoolImpl(
+    const AdaptiveAvgPoolOptions<output_size_t>& options_) : options(options_) {}
 
-  void reset() override;
+  void reset() override {}
 
   /// Pretty prints the `AdaptiveAvgPool{1,2,3}d` module into the given `stream`.
-  void pretty_print(std::ostream& stream) const override;
+  void pretty_print(std::ostream& stream) const override {
+    stream << "torch::nn::AdaptiveAvgPool" << D << "d"
+           << "(output_size=" << options.output_size() << ")";
+  }
 
   /// The options with which this `Module` was constructed.
-  AdaptiveAvgPoolOptions<D> options;
+  AdaptiveAvgPoolOptions<output_size_t> options;
 };
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~ AdaptiveAvgPool1d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -363,9 +371,9 @@ class TORCH_API AdaptiveAvgPoolImpl : public torch::nn::Cloneable<Derived> {
 /// AdaptiveAvgPool1d model(AdaptiveAvgPool1dOptions(5));
 /// ```
 class TORCH_API AdaptiveAvgPool1dImpl :
-  public AdaptiveAvgPoolImpl<1, AdaptiveAvgPool1dImpl> {
+  public AdaptiveAvgPoolImpl<1, ExpandingArray<1>, AdaptiveAvgPool1dImpl> {
  public:
-  using AdaptiveAvgPoolImpl<1, AdaptiveAvgPool1dImpl>::AdaptiveAvgPoolImpl;
+  using AdaptiveAvgPoolImpl<1, ExpandingArray<1>, AdaptiveAvgPool1dImpl>::AdaptiveAvgPoolImpl;
 
   Tensor forward(const Tensor& input);
 };
@@ -391,9 +399,9 @@ TORCH_MODULE(AdaptiveAvgPool1d);
 /// AdaptiveAvgPool2d model(AdaptiveAvgPool2dOptions({3, 2}));
 /// ```
 class TORCH_API AdaptiveAvgPool2dImpl :
-  public AdaptiveAvgPoolImpl<2, AdaptiveAvgPool2dImpl> {
+  public AdaptiveAvgPoolImpl<2, ExpandingArrayWithOptionalElem<2>, AdaptiveAvgPool2dImpl> {
  public:
-  using AdaptiveAvgPoolImpl<2, AdaptiveAvgPool2dImpl>::AdaptiveAvgPoolImpl;
+  using AdaptiveAvgPoolImpl<2, ExpandingArrayWithOptionalElem<2>, AdaptiveAvgPool2dImpl>::AdaptiveAvgPoolImpl;
 
   Tensor forward(const Tensor& input);
 };
@@ -419,9 +427,9 @@ TORCH_MODULE(AdaptiveAvgPool2d);
 /// AdaptiveAvgPool3d model(AdaptiveAvgPool3dOptions(3));
 /// ```
 class TORCH_API AdaptiveAvgPool3dImpl :
-  public AdaptiveAvgPoolImpl<3, AdaptiveAvgPool3dImpl> {
+  public AdaptiveAvgPoolImpl<3, ExpandingArrayWithOptionalElem<3>, AdaptiveAvgPool3dImpl> {
  public:
-  using AdaptiveAvgPoolImpl<3, AdaptiveAvgPool3dImpl>::AdaptiveAvgPoolImpl;
+  using AdaptiveAvgPoolImpl<3, ExpandingArrayWithOptionalElem<3>, AdaptiveAvgPool3dImpl>::AdaptiveAvgPoolImpl;
 
   Tensor forward(const Tensor& input);
 };

--- a/torch/csrc/api/include/torch/nn/modules/pooling.h
+++ b/torch/csrc/api/include/torch/nn/modules/pooling.h
@@ -13,7 +13,7 @@ namespace nn {
 
 /// Base class for all (dimension-specialized) avgpool modules.
 template <size_t D, typename Derived>
-class TORCH_API AvgPoolImpl : public torch::nn::Cloneable<Derived> {
+class AvgPoolImpl : public torch::nn::Cloneable<Derived> {
  public:
   AvgPoolImpl(ExpandingArray<D> kernel_size)
       : AvgPoolImpl(AvgPoolOptions<D>(kernel_size)) {}
@@ -110,7 +110,7 @@ TORCH_MODULE(AvgPool3d);
 
 /// Base class for all (dimension-specialized) maxpool modules.
 template <size_t D, typename Derived>
-class TORCH_API MaxPoolImpl : public torch::nn::Cloneable<Derived> {
+class MaxPoolImpl : public torch::nn::Cloneable<Derived> {
  public:
   MaxPoolImpl(ExpandingArray<D> kernel_size)
       : MaxPoolImpl(MaxPoolOptions<D>(kernel_size)) {}
@@ -219,7 +219,7 @@ TORCH_MODULE(MaxPool3d);
 
 /// Base class for all (dimension-specialized) adaptive maxpool modules.
 template <size_t D, typename output_size_t, typename Derived>
-class TORCH_API AdaptiveMaxPoolImpl : public torch::nn::Cloneable<Derived> {
+class AdaptiveMaxPoolImpl : public torch::nn::Cloneable<Derived> {
  public:
   AdaptiveMaxPoolImpl(output_size_t output_size)
       : AdaptiveMaxPoolImpl(AdaptiveMaxPoolOptions<output_size_t>(output_size)) {}
@@ -338,7 +338,7 @@ TORCH_MODULE(AdaptiveMaxPool3d);
 
 /// Base class for all (dimension-specialized) adaptive avgpool modules.
 template <size_t D, typename output_size_t, typename Derived>
-class TORCH_API AdaptiveAvgPoolImpl : public torch::nn::Cloneable<Derived> {
+class AdaptiveAvgPoolImpl : public torch::nn::Cloneable<Derived> {
  public:
   AdaptiveAvgPoolImpl(output_size_t output_size)
       : AdaptiveAvgPoolImpl(AdaptiveAvgPoolOptions<output_size_t>(output_size)) {}
@@ -445,7 +445,7 @@ TORCH_MODULE(AdaptiveAvgPool3d);
 
 /// Base class for all (dimension-specialized) maxunpool modules.
 template <size_t D, typename Derived>
-class TORCH_API MaxUnpoolImpl : public torch::nn::Cloneable<Derived> {
+class MaxUnpoolImpl : public torch::nn::Cloneable<Derived> {
  public:
   MaxUnpoolImpl(ExpandingArray<D> kernel_size)
       : MaxUnpoolImpl(MaxUnpoolOptions<D>(kernel_size)) {}
@@ -637,7 +637,7 @@ TORCH_MODULE(FractionalMaxPool3d);
 
 /// Base class for all (dimension-specialized) lppool modules.
 template <size_t D, typename Derived>
-class TORCH_API LPPoolImpl : public torch::nn::Cloneable<Derived> {
+class LPPoolImpl : public torch::nn::Cloneable<Derived> {
  public:
   LPPoolImpl(double norm_type, ExpandingArray<D> kernel_size)
       : LPPoolImpl(LPPoolOptions<D>(norm_type, kernel_size)) {}

--- a/torch/csrc/api/include/torch/nn/modules/rnn.h
+++ b/torch/csrc/api/include/torch/nn/modules/rnn.h
@@ -24,7 +24,7 @@ namespace nn {
 namespace detail {
 /// Base class for all RNN implementations (intended for code sharing).
 template <typename Derived>
-class TORCH_API RNNImplBase : public torch::nn::Cloneable<Derived> {
+class RNNImplBase : public torch::nn::Cloneable<Derived> {
  public:
   explicit RNNImplBase(const RNNOptionsBase& options_);
 
@@ -226,7 +226,7 @@ TORCH_MODULE(GRU);
 namespace detail {
 /// Base class for all RNNCell implementations (intended for code sharing).
 template <typename Derived>
-class TORCH_API RNNCellImplBase : public torch::nn::Cloneable<Derived> {
+class RNNCellImplBase : public torch::nn::Cloneable<Derived> {
  public:
   explicit RNNCellImplBase(const RNNCellOptionsBase& options_);
 

--- a/torch/csrc/api/include/torch/nn/modules/utils.h
+++ b/torch/csrc/api/include/torch/nn/modules/utils.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <c10/util/ArrayRef.h>
 #include <c10/util/Optional.h>
 
@@ -7,6 +9,21 @@ namespace torch {
 namespace nn {
 namespace modules {
 namespace utils {
+
+// Repeat each element of `t` for `n` times.
+// This can be used to translate padding arg used by Conv and Pooling modules
+// to the ones used by `F::pad`.
+//
+// This mirrors `_repeat_tuple` in `torch/nn/modules/utils.py`.
+inline std::vector<int64_t> _repeat_vector(at::ArrayRef<int64_t> t, int64_t n) {
+  std::vector<int64_t> ret;
+  for (int64_t elem : t) {
+    for (int64_t i = 0; i < n; i++) {
+      ret.emplace_back(elem);
+    }
+  }
+  return ret;
+}
 
 inline std::vector<int64_t> _list_with_default(
   torch::ArrayRef<c10::optional<int64_t>> out_size, torch::IntArrayRef defaults) {

--- a/torch/csrc/api/include/torch/nn/modules/utils.h
+++ b/torch/csrc/api/include/torch/nn/modules/utils.h
@@ -1,0 +1,29 @@
+#include <c10/util/ArrayRef.h>
+#include <c10/util/Optional.h>
+
+#include <vector>
+
+namespace torch {
+namespace nn {
+namespace modules {
+namespace utils {
+
+inline std::vector<int64_t> _list_with_default(
+  torch::ArrayRef<c10::optional<int64_t>> out_size, torch::IntArrayRef defaults) {
+  TORCH_CHECK(
+    defaults.size() > out_size.size(),
+    "Input dimension should be at least ", out_size.size() + 1);
+  std::vector<int64_t> ret;
+  torch::IntArrayRef defaults_slice = defaults.slice(defaults.size() - out_size.size(), out_size.size());
+  for (size_t i = 0; i < out_size.size(); i++) {
+    auto v = out_size.at(i);
+    auto d = defaults_slice.at(i);
+    ret.emplace_back(v.has_value() ? v.value() : d);
+  }
+  return ret;
+}
+
+} // namespace utils
+} // namespace modules
+} // namespace nn
+} // namespace torch

--- a/torch/csrc/api/include/torch/nn/options/conv.h
+++ b/torch/csrc/api/include/torch/nn/options/conv.h
@@ -11,7 +11,12 @@ namespace nn {
 
 namespace detail {
 
-typedef c10::variant<enumtype::kZeros, enumtype::kCircular> conv_padding_mode_t;
+typedef c10::variant<
+  enumtype::kZeros,
+  enumtype::kReflect,
+  enumtype::kReplicate,
+  enumtype::kCircular
+> conv_padding_mode_t;
 
 /// Options for a `D`-dimensional convolution or convolution transpose module.
 template <size_t D>
@@ -75,7 +80,7 @@ struct ConvNdOptions {
   /// Changing this parameter after construction __has no effect__.
   TORCH_ARG(bool, bias) = true;
 
-  /// Accepted values `zeros` and `circular` Default: `zeros`
+  /// Accepted values `torch::kZeros`, `torch::kReflect`, `torch::kReplicate` or `torch::kCircular`. Default: `torch::kZeros`
   TORCH_ARG(conv_padding_mode_t, padding_mode) = torch::kZeros;
 };
 
@@ -136,7 +141,7 @@ struct ConvOptions {
   /// Changing this parameter after construction __has no effect__.
   TORCH_ARG(bool, bias) = true;
 
-  /// Accepted values `zeros` and `circular` Default: `zeros`
+  /// Accepted values `torch::kZeros`, `torch::kReflect`, `torch::kReplicate` or `torch::kCircular`. Default: `torch::kZeros`
   TORCH_ARG(padding_mode_t, padding_mode) = torch::kZeros;
 };
 
@@ -283,7 +288,7 @@ struct ConvTransposeOptions {
   /// This parameter __can__ be changed after construction.
   TORCH_ARG(ExpandingArray<D>, dilation) = 1;
 
-  /// Accepted values `zeros` and `circular` Default: `zeros`
+  /// Accepted values `torch::kZeros`, `torch::kReflect`, `torch::kReplicate` or `torch::kCircular`. Default: `torch::kZeros`
   TORCH_ARG(padding_mode_t, padding_mode) = torch::kZeros;
 };
 

--- a/torch/csrc/api/include/torch/nn/options/loss.h
+++ b/torch/csrc/api/include/torch/nn/options/loss.h
@@ -268,9 +268,9 @@ namespace functional {
 /// Example:
 /// ```
 /// namespace F = torch::nn::functional;
-/// F::multilabel_margin_loss(input, target, F::MultiLabelMarginLossFuncOptions(torch::kNone));
+/// F::multilabel_margin_loss(input, target, F::MultilabelMarginLossFuncOptions(torch::kNone));
 /// ```
-using MultiLabelMarginLossFuncOptions = MultiLabelMarginLossOptions;
+using MultilabelMarginLossFuncOptions = MultiLabelMarginLossOptions;
 } // namespace functional
 
 // ============================================================================
@@ -339,9 +339,9 @@ namespace functional {
 /// Example:
 /// ```
 /// namespace F = torch::nn::functional;
-/// F::multilabel_soft_margin_loss(input, target, F::MultiLabelSoftMarginLossFuncOptions().reduction(torch::kNone).weight(weight));
+/// F::multilabel_soft_margin_loss(input, target, F::MultilabelSoftMarginLossFuncOptions().reduction(torch::kNone).weight(weight));
 /// ```
-using MultiLabelSoftMarginLossFuncOptions = MultiLabelSoftMarginLossOptions;
+using MultilabelSoftMarginLossFuncOptions = MultiLabelSoftMarginLossOptions;
 } // namespace functional
 
 // ============================================================================

--- a/torch/csrc/api/include/torch/nn/options/padding.h
+++ b/torch/csrc/api/include/torch/nn/options/padding.h
@@ -12,7 +12,7 @@ namespace nn {
 
 /// Options for a `D`-dimensional ReflectionPad module.
 template <size_t D>
-struct TORCH_API ReflectionPadOptions {
+struct ReflectionPadOptions {
   ReflectionPadOptions(ExpandingArray<D*2> padding) : padding_(padding) {}
 
   /// The size of the padding.
@@ -42,7 +42,7 @@ using ReflectionPad2dOptions = ReflectionPadOptions<2>;
 
 /// Options for a `D`-dimensional ReplicationPad module.
 template <size_t D>
-struct TORCH_API ReplicationPadOptions {
+struct ReplicationPadOptions {
   ReplicationPadOptions(ExpandingArray<D*2> padding) : padding_(padding) {}
 
   /// The size of the padding.
@@ -99,7 +99,7 @@ struct TORCH_API ZeroPad2dOptions {
 
 /// Options for a `D`-dimensional ConstantPad module.
 template <size_t D>
-struct TORCH_API ConstantPadOptions {
+struct ConstantPadOptions {
   ConstantPadOptions(ExpandingArray<D*2> padding, double value) : padding_(padding), value_(value) {}
 
   /// The size of the padding.

--- a/torch/csrc/api/include/torch/nn/options/pooling.h
+++ b/torch/csrc/api/include/torch/nn/options/pooling.h
@@ -183,13 +183,13 @@ using MaxPool3dFuncOptions = MaxPool3dOptions;
 // ============================================================================
 
 /// Options for a `D`-dimensional adaptive maxpool module.
-template <size_t D>
+template <typename output_size_t>
 struct AdaptiveMaxPoolOptions {
-  AdaptiveMaxPoolOptions(ExpandingArray<D> output_size)
+  AdaptiveMaxPoolOptions(output_size_t output_size)
       : output_size_(output_size) {}
 
   /// the target output size
-  TORCH_ARG(ExpandingArray<D>, output_size);
+  TORCH_ARG(output_size_t, output_size);
 };
 
 /// `AdaptiveMaxPoolOptions` specialized for the `AdaptiveMaxPool1d` module.
@@ -198,7 +198,7 @@ struct AdaptiveMaxPoolOptions {
 /// ```
 /// AdaptiveMaxPool1d model(AdaptiveMaxPool1dOptions(3));
 /// ```
-using AdaptiveMaxPool1dOptions = AdaptiveMaxPoolOptions<1>;
+using AdaptiveMaxPool1dOptions = AdaptiveMaxPoolOptions<ExpandingArray<1>>;
 
 /// `AdaptiveMaxPoolOptions` specialized for the `AdaptiveMaxPool2d` module.
 ///
@@ -206,7 +206,7 @@ using AdaptiveMaxPool1dOptions = AdaptiveMaxPoolOptions<1>;
 /// ```
 /// AdaptiveMaxPool2d model(AdaptiveMaxPool2dOptions({3, 2}));
 /// ```
-using AdaptiveMaxPool2dOptions = AdaptiveMaxPoolOptions<2>;
+using AdaptiveMaxPool2dOptions = AdaptiveMaxPoolOptions<ExpandingArrayWithOptionalElem<2>>;
 
 /// `AdaptiveMaxPoolOptions` specialized for the `AdaptiveMaxPool3d` module.
 ///
@@ -214,7 +214,7 @@ using AdaptiveMaxPool2dOptions = AdaptiveMaxPoolOptions<2>;
 /// ```
 /// AdaptiveMaxPool3d model(AdaptiveMaxPool3dOptions(3));
 /// ```
-using AdaptiveMaxPool3dOptions = AdaptiveMaxPoolOptions<3>;
+using AdaptiveMaxPool3dOptions = AdaptiveMaxPoolOptions<ExpandingArrayWithOptionalElem<3>>;
 
 namespace functional {
 /// Options for `torch::nn::functional::adaptive_max_pool1d` and `torch::nn::functional::adaptive_max_pool1d_with_indices`
@@ -252,13 +252,13 @@ using AdaptiveMaxPool3dFuncOptions = AdaptiveMaxPool3dOptions;
 // ============================================================================
 
 /// Options for a `D`-dimensional adaptive avgpool module.
-template <size_t D>
+template <typename output_size_t>
 struct AdaptiveAvgPoolOptions {
-  AdaptiveAvgPoolOptions(ExpandingArray<D> output_size)
+  AdaptiveAvgPoolOptions(output_size_t output_size)
       : output_size_(output_size) {}
 
   /// the target output size
-  TORCH_ARG(ExpandingArray<D>, output_size);
+  TORCH_ARG(output_size_t, output_size);
 };
 
 /// `AdaptiveAvgPoolOptions` specialized for the `AdaptiveAvgPool1d` module.
@@ -267,7 +267,7 @@ struct AdaptiveAvgPoolOptions {
 /// ```
 /// AdaptiveAvgPool1d model(AdaptiveAvgPool1dOptions(5));
 /// ```
-using AdaptiveAvgPool1dOptions = AdaptiveAvgPoolOptions<1>;
+using AdaptiveAvgPool1dOptions = AdaptiveAvgPoolOptions<ExpandingArray<1>>;
 
 /// `AdaptiveAvgPoolOptions` specialized for the `AdaptiveAvgPool2d` module.
 ///
@@ -275,7 +275,7 @@ using AdaptiveAvgPool1dOptions = AdaptiveAvgPoolOptions<1>;
 /// ```
 /// AdaptiveAvgPool2d model(AdaptiveAvgPool2dOptions({3, 2}));
 /// ```
-using AdaptiveAvgPool2dOptions = AdaptiveAvgPoolOptions<2>;
+using AdaptiveAvgPool2dOptions = AdaptiveAvgPoolOptions<ExpandingArrayWithOptionalElem<2>>;
 
 /// `AdaptiveAvgPoolOptions` specialized for the `AdaptiveAvgPool3d` module.
 ///
@@ -283,7 +283,7 @@ using AdaptiveAvgPool2dOptions = AdaptiveAvgPoolOptions<2>;
 /// ```
 /// AdaptiveAvgPool3d model(AdaptiveAvgPool3dOptions(3));
 /// ```
-using AdaptiveAvgPool3dOptions = AdaptiveAvgPoolOptions<3>;
+using AdaptiveAvgPool3dOptions = AdaptiveAvgPoolOptions<ExpandingArrayWithOptionalElem<3>>;
 
 namespace functional {
 /// Options for `torch::nn::functional::adaptive_avg_pool1d`.

--- a/torch/csrc/api/include/torch/nn/options/upsampling.h
+++ b/torch/csrc/api/include/torch/nn/options/upsampling.h
@@ -16,14 +16,14 @@ namespace nn {
 ///
 /// Example:
 /// ```
-/// Upsample model(UpsampleOptions().scale_factor({3}).mode(torch::kLinear).align_corners(false));
+/// Upsample model(UpsampleOptions().scale_factor(std::vector<double>({3})).mode(torch::kLinear).align_corners(false));
 /// ```
 struct TORCH_API UpsampleOptions {
   /// output spatial sizes.
-  TORCH_ARG(std::vector<int64_t>, size) = {};
+  TORCH_ARG(c10::optional<std::vector<int64_t>>, size) = c10::nullopt;
 
   /// multiplier for spatial size.
-  TORCH_ARG(std::vector<double>, scale_factor) = {};
+  TORCH_ARG(c10::optional<std::vector<double>>, scale_factor) = c10::nullopt;
 
   /// the upsampling algorithm: one of "nearest", "linear", "bilinear",
   /// "bicubic" and "trilinear". Default: "nearest"
@@ -49,7 +49,7 @@ namespace functional {
 /// Example:
 /// ```
 /// namespace F = torch::nn::functional;
-/// F::interpolate(input, F::InterpolateFuncOptions().size({4}).mode(torch::kNearest));
+/// F::interpolate(input, F::InterpolateFuncOptions().size(std::vector<int64_t>({4})).mode(torch::kNearest));
 /// ```
 struct TORCH_API InterpolateFuncOptions {
   typedef c10::variant<
@@ -61,10 +61,10 @@ struct TORCH_API InterpolateFuncOptions {
       enumtype::kArea> mode_t;
 
   /// output spatial sizes.
-  TORCH_ARG(std::vector<int64_t>, size) = {};
+  TORCH_ARG(c10::optional<std::vector<int64_t>>, size) = c10::nullopt;
 
   /// multiplier for spatial size.
-  TORCH_ARG(std::vector<double>, scale_factor) = {};
+  TORCH_ARG(c10::optional<std::vector<double>>, scale_factor) = c10::nullopt;
 
   /// the upsampling algorithm: one of "nearest", "linear", "bilinear",
   /// "bicubic", "trilinear", and "area". Default: "nearest"
@@ -80,6 +80,17 @@ struct TORCH_API InterpolateFuncOptions {
   /// kept the same. This only has an effect when :attr:`mode` is "linear",
   /// "bilinear", "bicubic" or "trilinear". Default: "False"
   TORCH_ARG(c10::optional<bool>, align_corners) = c10::nullopt;
+
+  /// recompute the scale_factor for use in the
+  /// interpolation calculation.  When `scale_factor` is passed as a parameter, it is used
+  /// to compute the `output_size`.  If `recompute_scale_factor` is `true` or not specified,
+  /// a new `scale_factor` will be computed based on the output and input sizes for use in the
+  /// interpolation computation (i.e. the computation will be identical to if the computed
+  /// `output_size` were passed-in explicitly).  Otherwise, the passed-in `scale_factor` will
+  /// be used in the interpolation computation.  Note that when `scale_factor` is floating-point,
+  /// the recomputed scale_factor may differ from the one passed in due to rounding and precision
+  /// issues.
+  TORCH_ARG(c10::optional<bool>, recompute_scale_factor) = c10::nullopt;
 };
 
 } // namespace functional

--- a/torch/csrc/api/src/nn/modules/pooling.cpp
+++ b/torch/csrc/api/src/nn/modules/pooling.cpp
@@ -144,19 +144,6 @@ template class MaxPoolImpl<3, MaxPool3dImpl>;
 
 // ============================================================================
 
-template <size_t D, typename Derived>
-AdaptiveMaxPoolImpl<D, Derived>::AdaptiveMaxPoolImpl(
-  const AdaptiveMaxPoolOptions<D>& options_) : options(options_) {}
-
-template <size_t D, typename Derived>
-void AdaptiveMaxPoolImpl<D, Derived>::reset() {}
-
-template <size_t D, typename Derived>
-void AdaptiveMaxPoolImpl<D, Derived>::pretty_print(std::ostream& stream) const {
-  stream << "torch::nn::AdaptiveMaxPool" << D << "d"
-         << "(output_size=" << options.output_size() << ")";
-}
-
 Tensor AdaptiveMaxPool1dImpl::forward(const Tensor& input) {
   return F::detail::adaptive_max_pool1d(input, options.output_size());
 }
@@ -181,24 +168,11 @@ std::tuple<Tensor, Tensor> AdaptiveMaxPool3dImpl::forward_with_indices(const Ten
   return F::detail::adaptive_max_pool3d_with_indices(input, options.output_size());
 }
 
-template class AdaptiveMaxPoolImpl<1, AdaptiveMaxPool1dImpl>;
-template class AdaptiveMaxPoolImpl<2, AdaptiveMaxPool2dImpl>;
-template class AdaptiveMaxPoolImpl<3, AdaptiveMaxPool3dImpl>;
+template class AdaptiveMaxPoolImpl<1, ExpandingArray<1>, AdaptiveMaxPool1dImpl>;
+template class AdaptiveMaxPoolImpl<2, ExpandingArrayWithOptionalElem<2>, AdaptiveMaxPool2dImpl>;
+template class AdaptiveMaxPoolImpl<3, ExpandingArrayWithOptionalElem<3>, AdaptiveMaxPool3dImpl>;
 
 // ============================================================================
-
-template <size_t D, typename Derived>
-AdaptiveAvgPoolImpl<D, Derived>::AdaptiveAvgPoolImpl(
-  const AdaptiveAvgPoolOptions<D>& options_) : options(options_) {}
-
-template <size_t D, typename Derived>
-void AdaptiveAvgPoolImpl<D, Derived>::reset() {}
-
-template <size_t D, typename Derived>
-void AdaptiveAvgPoolImpl<D, Derived>::pretty_print(std::ostream& stream) const {
-  stream << "torch::nn::AdaptiveAvgPool" << D << "d"
-         << "(output_size=" << options.output_size() << ")";
-}
 
 Tensor AdaptiveAvgPool1dImpl::forward(const Tensor& input) {
   return F::detail::adaptive_avg_pool1d(input, options.output_size());
@@ -212,9 +186,9 @@ Tensor AdaptiveAvgPool3dImpl::forward(const Tensor& input) {
   return F::detail::adaptive_avg_pool3d(input, options.output_size());
 }
 
-template class AdaptiveAvgPoolImpl<1, AdaptiveAvgPool1dImpl>;
-template class AdaptiveAvgPoolImpl<2, AdaptiveAvgPool2dImpl>;
-template class AdaptiveAvgPoolImpl<3, AdaptiveAvgPool3dImpl>;
+template class AdaptiveAvgPoolImpl<1, ExpandingArray<1>, AdaptiveAvgPool1dImpl>;
+template class AdaptiveAvgPoolImpl<2, ExpandingArrayWithOptionalElem<2>, AdaptiveAvgPool2dImpl>;
+template class AdaptiveAvgPoolImpl<3, ExpandingArrayWithOptionalElem<3>, AdaptiveAvgPool3dImpl>;
 
 // ============================================================================
 

--- a/torch/csrc/api/src/nn/modules/upsampling.cpp
+++ b/torch/csrc/api/src/nn/modules/upsampling.cpp
@@ -14,10 +14,10 @@ void UpsampleImpl::reset() {}
 
 void UpsampleImpl::pretty_print(std::ostream& stream) const {
   stream << "torch::nn::Upsample(";
-  if (!options.scale_factor().empty()) {
-    stream << "scale_factor=" << at::ArrayRef<double>(options.scale_factor());
+  if (options.scale_factor() != c10::nullopt) {
+    stream << "scale_factor=" << at::ArrayRef<double>(*options.scale_factor());
   } else {
-    stream << "size=" << at::ArrayRef<int64_t>(options.size());
+    stream << "size=" << at::ArrayRef<int64_t>(*options.size());
   }
   stream << ", mode=" << enumtype::get_enum_name(options.mode()) << ")";
 }
@@ -41,7 +41,8 @@ Tensor UpsampleImpl::forward(const Tensor& input) {
       options.size(),
       options.scale_factor(),
       mode,
-      options.align_corners());
+      options.align_corners(),
+      c10::nullopt);
 }
 
 } // namespace nn

--- a/torch/csrc/api/src/nn/options/pooling.cpp
+++ b/torch/csrc/api/src/nn/options/pooling.cpp
@@ -11,13 +11,13 @@ template struct MaxPoolOptions<1>;
 template struct MaxPoolOptions<2>;
 template struct MaxPoolOptions<3>;
 
-template struct AdaptiveMaxPoolOptions<1>;
-template struct AdaptiveMaxPoolOptions<2>;
-template struct AdaptiveMaxPoolOptions<3>;
+template struct AdaptiveMaxPoolOptions<ExpandingArray<1>>;
+template struct AdaptiveMaxPoolOptions<ExpandingArrayWithOptionalElem<2>>;
+template struct AdaptiveMaxPoolOptions<ExpandingArrayWithOptionalElem<3>>;
 
-template struct AdaptiveAvgPoolOptions<1>;
-template struct AdaptiveAvgPoolOptions<2>;
-template struct AdaptiveAvgPoolOptions<3>;
+template struct AdaptiveAvgPoolOptions<ExpandingArray<1>>;
+template struct AdaptiveAvgPoolOptions<ExpandingArrayWithOptionalElem<2>>;
+template struct AdaptiveAvgPoolOptions<ExpandingArrayWithOptionalElem<3>>;
 
 template struct MaxUnpoolOptions<1>;
 template struct MaxUnpoolOptions<2>;


### PR DESCRIPTION
This PR is a combination of the following PRs:
- #35022 Fix AdaptiveAvgPool{2,3}d and AdaptiveMaxPool{2,3}d implementation 
- #35023 Fix Conv and ConvTranspose implementation
- #35024 Fix fractional_max_pool3d_with_indices implementation
- #35025 Fix F::interpolate and torch::nn::Upsample implementation
- #35147 Add inplace tests for several torch::nn modules / functionals
- #35163 Renaming: MultiLabelMarginLossFuncOptions -> MultilabelMarginLossFuncOptions, MultiLabelSoftMarginLossFuncOptions -> MultilabelSoftMarginLossFuncOptions
- #35377 Remove TORCH_API from torch::nn template classes