### PR TITLE
[rpc][easy] remove code duplication on ProcessGroupAgent::enqueueSend

### DIFF
--- a/torch/csrc/distributed/rpc/process_group_agent.cpp
+++ b/torch/csrc/distributed/rpc/process_group_agent.cpp
@@ -475,15 +475,13 @@ void ProcessGroupAgent::enqueueSend(SendWork work) {
         } catch (std::exception& e) {
           auto errorStr = c10::str(
               "Encountered exception in ProcessGroupAgent::enqueueSend: ",
-              e.what());
+              e.what(),
+              " on node: ",
+              RpcAgent::getWorkerInfo().id_);
           auto exceptionMsg =
               rpc::createExceptionResponse(errorStr, work.message_.id());
           if (work.message_.isRequest()) {
-            auto err = c10::str(
-                "Encountered exception in ProcessGroupAgent::enqueueSend: ",
-                e.what());
-            auto exceptionMsg =
-                rpc::createExceptionResponse(err, work.message_.id());
+            // Mark the future with corresponding to this request with an error.
             markFutureWithError(exceptionMsg);
           } else if (work.message_.isResponse()) {
             // Try sending the error along.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#35311 [rpc][easy] remove code duplication on ProcessGroupAgent::enqueueSend**

This must have snuck in since a couple PRs updated this same area and
the merge conflict was not resolved properly.

Also contains a slight improvement to the message to include the node id of the failure

Differential Revision: [D20602683](https://our.internmc.facebook.com/intern/diff/D20602683/)