### PR TITLE
lshift and rshift on CUDA should match the behavior on CPU

### DIFF
--- a/aten/src/ATen/native/cuda/BinaryShiftOpsKernels.cu
+++ b/aten/src/ATen/native/cuda/BinaryShiftOpsKernels.cu
@@ -23,7 +23,7 @@ void lshift_kernel_cuda(TensorIterator& iter) {
     AT_DISPATCH_INTEGRAL_TYPES(iter.dtype(), "lshift_cuda", [&]() {
       gpu_kernel_with_scalars(iter,
         []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
-          return a << b;
+          return static_cast<std::make_unsigned_t<scalar_t>>(a) << b;
       });
     });
   }
@@ -42,7 +42,7 @@ void rshift_kernel_cuda(TensorIterator& iter) {
     AT_DISPATCH_INTEGRAL_TYPES(iter.dtype(), "rshift_cuda", [&]() {
       gpu_kernel_with_scalars(iter,
         []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
-          return a >> b;
+          return static_cast<std::make_unsigned_t<scalar_t>>(a) >> b;
       });
     });
   }

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6205,6 +6205,15 @@ class TestTorchDeviceType(TestCase):
         expected_inv = torch.as_tensor(inv(matrices.cpu().numpy()))
         self.assertEqual(matrices_inverse, expected_inv.to(device))
 
+    @dtypes(torch.int8, torch.int16, torch.int32, torch.int64)
+    def test_signed_shift(self, device, dtype):
+        "Ensure that signed integer bit shifting works as expected."
+        a = torch.tensor([-10, 10], device=device, dtype=dtype)  # [11...1110110, 1010]
+        expected_l = torch.tensor([-40, 40], device=device, dtype=dtype)  # [11...11011000, 101000]
+        self.assertEqual(a << 2, expected_l)
+        expected_r = torch.tensor([torch.iinfo(dtype).max - 4, 5], device=device, dtype=dtype) # [1111...111011, 101]
+        self.assertEqual(a >> 1, expected_r)
+
     def test_bitwise_not(self, device):
         res = 0xffff - torch.arange(127, dtype=torch.int8, device=device)
         for dtype in (torch.bool, torch.uint8, torch.int8, torch.int16, torch.int32, torch.int64):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6211,7 +6211,7 @@ class TestTorchDeviceType(TestCase):
         a = torch.tensor([-10, 10], device=device, dtype=dtype)  # [11...1110110, 1010]
         expected_l = torch.tensor([-40, 40], device=device, dtype=dtype)  # [11...11011000, 101000]
         self.assertEqual(a << 2, expected_l)
-        expected_r = torch.tensor([torch.iinfo(dtype).max - 4, 5], device=device, dtype=dtype) # [1111...111011, 101]
+        expected_r = torch.tensor([torch.iinfo(dtype).max - 4, 5], device=device, dtype=dtype)  # [1111...111011, 101]
         self.assertEqual(a >> 1, expected_r)
 
     def test_bitwise_not(self, device):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #35422 Make intdiv_256 a more generic binary operator template
* **#35339 lshift and rshift on CUDA should match the behavior on CPU**
* #35323 Utilize std::make_unsigned_t instead of wrapping lshift

CPU version converts integers to their unsigned version first. The CUDA
version should also do it.

Also added tests for this.

Differential Revision: [D20826862](https://our.internmc.facebook.com/intern/diff/D20826862)