### PR TITLE
Autocasting for 1.5

### DIFF
--- a/aten/src/ATen/autocast_VS2017_helper.h
+++ b/aten/src/ATen/autocast_VS2017_helper.h
@@ -1,0 +1,152 @@
+#pragma once
+
+// This file only exists to provide a workaround for a Visual Studio 2017 (version < 15.8) bug.
+// Apparently, VS2017<15.8 has a hard time templating on functions,
+// and a workaround is to define them in an anonymous namespace near the point of instantiation:
+// https://developercommunity.visualstudio.com/content/problem/25334/error-code-c2971-when-specifying-a-function-as-the.html
+// This file uses macros to define wrappers for each autocasted op.
+// When #included in the anonymous namespace next to the op registrations in autocast_mode.cpp,
+// this file provides the local definitions that VS2017 seems to need.
+// It's an ugly workaround and unnecessary except for that particular VS version.
+
+namespace autocastVS2017Helper {
+
+#define UPTOa(RET, OP, SIG) RET OP SIG { return at::OP(A                           ); }
+#define UPTOb(RET, OP, SIG) RET OP SIG { return at::OP(A, B                        ); }
+#define UPTOc(RET, OP, SIG) RET OP SIG { return at::OP(A, B, C                     ); }
+#define UPTOd(RET, OP, SIG) RET OP SIG { return at::OP(A, B, C, D                  ); }
+#define UPTOe(RET, OP, SIG) RET OP SIG { return at::OP(A, B, C, D, E               ); }
+#define UPTOf(RET, OP, SIG) RET OP SIG { return at::OP(A, B, C, D, E, F            ); }
+#define UPTOg(RET, OP, SIG) RET OP SIG { return at::OP(A, B, C, D, E, F, G         ); }
+#define UPTOh(RET, OP, SIG) RET OP SIG { return at::OP(A, B, C, D, E, F, G, H      ); }
+#define UPTOi(RET, OP, SIG) RET OP SIG { return at::OP(A, B, C, D, E, F, G, H, I   ); }
+#define UPTOj(RET, OP, SIG) RET OP SIG { return at::OP(A, B, C, D, E, F, G, H, I, J); }
+#define UPTOl(RET, OP, SIG) RET OP SIG { return at::OP(A, B, C, D, E, F, G, H, I, J, K, L); }
+
+UPTOl( Tensor, _convolution               , (const Tensor &A, const Tensor &B, const Tensor &C, IntArrayRef   D, IntArrayRef E, IntArrayRef F, bool        G, IntArrayRef H, int64_t I, bool J, bool K, bool L) )
+UPTOh( Tensor, _convolution_nogroup       , (const Tensor &A, const Tensor &B, const Tensor &C, IntArrayRef   D, IntArrayRef E, IntArrayRef F, bool        G, IntArrayRef H) )
+UPTOg( Tensor, conv1d                     , (const Tensor &A, const Tensor &B, const Tensor &C, IntArrayRef   D, IntArrayRef E, IntArrayRef F, int64_t     G) )
+UPTOg( Tensor, conv2d                     , (const Tensor &A, const Tensor &B, const Tensor &C, IntArrayRef   D, IntArrayRef E, IntArrayRef F, int64_t     G) )
+UPTOg( Tensor, conv3d                     , (const Tensor &A, const Tensor &B, const Tensor &C, IntArrayRef   D, IntArrayRef E, IntArrayRef F, int64_t     G) )
+UPTOd( Tensor, conv_tbc                   , (const Tensor &A, const Tensor &B, const Tensor &C, int64_t       D) )
+UPTOh( Tensor, conv_transpose1d           , (const Tensor &A, const Tensor &B, const Tensor &C, IntArrayRef   D, IntArrayRef E, IntArrayRef F, int64_t     G, IntArrayRef H) )
+UPTOh( Tensor, conv_transpose2d           , (const Tensor &A, const Tensor &B, const Tensor &C, IntArrayRef   D, IntArrayRef E, IntArrayRef F, int64_t     G, IntArrayRef H) )
+UPTOh( Tensor, conv_transpose3d           , (const Tensor &A, const Tensor &B, const Tensor &C, IntArrayRef   D, IntArrayRef E, IntArrayRef F, int64_t     G, IntArrayRef H) )
+UPTOi( Tensor, convolution                , (const Tensor &A, const Tensor &B, const Tensor &C, IntArrayRef   D, IntArrayRef E, IntArrayRef F, bool        G, IntArrayRef H, int64_t I) )
+UPTOi( Tensor, cudnn_convolution          , (const Tensor &A, const Tensor &B, const Tensor &C, IntArrayRef   D, IntArrayRef E, IntArrayRef F, int64_t     G, bool        H, bool    I) )
+UPTOj( Tensor, cudnn_convolution_transpose, (const Tensor &A, const Tensor &B, const Tensor &C, IntArrayRef   D, IntArrayRef E, IntArrayRef F, IntArrayRef G, int64_t     H, bool    I, bool J) )
+UPTOh( Tensor, cudnn_convolution          , (const Tensor &A, const Tensor &B, IntArrayRef   C, IntArrayRef   D, IntArrayRef E, int64_t     F, bool        G, bool        H) )
+UPTOi( Tensor, cudnn_convolution_transpose, (const Tensor &A, const Tensor &B, IntArrayRef   C, IntArrayRef   D, IntArrayRef E, IntArrayRef F, int64_t     G, bool        H, bool    I) )
+UPTOb( Tensor, prelu                      , (const Tensor &A, const Tensor &B) )
+UPTOe( Tensor, addmm                      , (const Tensor &A, const Tensor &B, const Tensor &C, Scalar        D, Scalar      E) )
+UPTOe( Tensor, addmv                      , (const Tensor &A, const Tensor &B, const Tensor &C, Scalar        D, Scalar      E) )
+UPTOe( Tensor, addr                       , (const Tensor &A, const Tensor &B, const Tensor &C, Scalar        D, Scalar      E) )
+UPTOb( Tensor, matmul                     , (const Tensor &A, const Tensor &B) )
+UPTOb( Tensor, mm                         , (const Tensor &A, const Tensor &B) )
+UPTOb( Tensor, mv                         , (const Tensor &A, const Tensor &B) )
+UPTOc( Tensor, linear                     , (const Tensor &A, const Tensor &B, const Tensor &C) )
+UPTOe( Tensor, addbmm                     , (const Tensor &A, const Tensor &B, const Tensor &C, Scalar        D, Scalar      E) )
+UPTOe( Tensor, baddbmm                    , (const Tensor &A, const Tensor &B, const Tensor &C, Scalar        D, Scalar      E) )
+UPTOb( Tensor, bmm                        , (const Tensor &A, const Tensor &B) )
+UPTOa( Tensor, chain_matmul               , (TensorList    A) )
+
+// fp32
+UPTOa( Tensor, acos                            , (const Tensor &A) )
+UPTOa( Tensor, asin                            , (const Tensor &A) )
+UPTOa( Tensor, cosh                            , (const Tensor &A) )
+UPTOa( Tensor, erfinv                          , (const Tensor &A) )
+UPTOa( Tensor, exp                             , (const Tensor &A) )
+UPTOa( Tensor, expm1                           , (const Tensor &A) )
+UPTOa( Tensor, log                             , (const Tensor &A) )
+UPTOa( Tensor, log10                           , (const Tensor &A) )
+UPTOa( Tensor, log2                            , (const Tensor &A) )
+UPTOa( Tensor, log1p                           , (const Tensor &A) )
+UPTOa( Tensor, reciprocal                      , (const Tensor &A) )
+UPTOa( Tensor, rsqrt                           , (const Tensor &A) )
+UPTOa( Tensor, sinh                            , (const Tensor &A) )
+UPTOa( Tensor, tan                             , (const Tensor &A) )
+UPTOb( Tensor, pow                             , (const Tensor &A, Scalar        B) )
+UPTOb( Tensor, pow                             , (const Tensor &A, const Tensor &B) )
+UPTOb( Tensor, pow                             , (Scalar        A, const Tensor &B) )
+UPTOc( Tensor, softplus                        , (const Tensor &A, Scalar        B, Scalar        C) )
+UPTOa( Tensor, gelu                            , (const Tensor &A) )
+UPTOf( Tensor, layer_norm                      , (const Tensor &A, IntArrayRef   B, const Tensor &C, const Tensor &         D, double        E, bool    F) )
+UPTOf( Tensor, group_norm                      , (const Tensor &A, int64_t       B, const Tensor &C, const Tensor &         D, double        E, bool    F) )
+UPTOa( Tensor, frobenius_norm                  , (const Tensor &A) )
+UPTOc( Tensor, frobenius_norm                  , (const Tensor &A, IntArrayRef   B, bool          C) )
+UPTOb( Tensor, nuclear_norm                    , (const Tensor &A, bool          B) )
+UPTOc( Tensor, nuclear_norm                    , (const Tensor &A, IntArrayRef   B, bool          C) )
+UPTOd( Tensor, cosine_similarity               , (const Tensor &A, const Tensor &B, int64_t       C, double                 D) )
+UPTOf( Tensor, poisson_nll_loss                , (const Tensor &A, const Tensor &B, bool          C, bool                   D, double        E, int64_t F) )
+UPTOe( Tensor, cosine_embedding_loss           , (const Tensor &A, const Tensor &B, const Tensor &C, double                 D, int64_t       E) )
+UPTOe( Tensor, nll_loss                        , (const Tensor &A, const Tensor &B, const Tensor &C, int64_t                D, int64_t       E) )
+UPTOe( Tensor, nll_loss2d                      , (const Tensor &A, const Tensor &B, const Tensor &C, int64_t                D, int64_t       E) )
+UPTOd( Tensor, hinge_embedding_loss            , (const Tensor &A, const Tensor &B, double        C, int64_t                D) )
+UPTOc( Tensor, kl_div                          , (const Tensor &A, const Tensor &B, int64_t       C) )
+UPTOc( Tensor, l1_loss                         , (const Tensor &A, const Tensor &B, int64_t       C) )
+UPTOc( Tensor, smooth_l1_loss                  , (const Tensor &A, const Tensor &B, int64_t       C) )
+UPTOc( Tensor, mse_loss                        , (const Tensor &A, const Tensor &B, int64_t       C) )
+UPTOe( Tensor, margin_ranking_loss             , (const Tensor &A, const Tensor &B, const Tensor &C, double                 D, int64_t       E) )
+UPTOc( Tensor, multilabel_margin_loss          , (const Tensor &A, const Tensor &B, int64_t       C) )
+UPTOc( Tensor, soft_margin_loss                , (const Tensor &A, const Tensor &B, int64_t       C) )
+UPTOh( Tensor, triplet_margin_loss             , (const Tensor &A, const Tensor &B, const Tensor &C, double                 D, double        E, double  F, bool G, int64_t H) )
+UPTOf( Tensor, multi_margin_loss               , (const Tensor &A, const Tensor &B, Scalar        C, Scalar                 D, const Tensor &E, int64_t F) )
+UPTOe( Tensor, binary_cross_entropy_with_logits, (const Tensor &A, const Tensor &B, const Tensor &C, const Tensor &         D, int64_t       E) )
+UPTOc( Tensor, dist                            , (const Tensor &A, const Tensor &B, Scalar        C) )
+UPTOb( Tensor, pdist                           , (const Tensor &A, double        B) )
+UPTOd( Tensor, cdist                           , (const Tensor &A, const Tensor &B, double        C, c10::optional<int64_t> D) )
+UPTOd( Tensor, renorm                          , (const Tensor &A, Scalar        B, int64_t       C, Scalar                 D) )
+// The macro doesn't like this one so I had to write it manually.
+std::tuple<Tensor,Tensor,Tensor> native_layer_norm(const Tensor &A, const Tensor &B, const Tensor &C, int64_t D, int64_t E, double F) {
+  return at::native_layer_norm(A, B, C, D, E, F);
+}
+
+// fp32_set_opt_dtype
+UPTOb( Tensor, prod       , (const Tensor &A, c10::optional<ScalarType> B) )
+UPTOd( Tensor, prod       , (const Tensor &A, int64_t                   B, bool                      C, c10::optional<ScalarType> D) )
+UPTOd( Tensor, prod       , (const Tensor &A, Dimname                   B, bool                      C, c10::optional<ScalarType> D) )
+UPTOc( Tensor, softmax    , (const Tensor &A, int64_t                   B, c10::optional<ScalarType> C) )
+UPTOc( Tensor, softmax    , (const Tensor &A, Dimname                   B, c10::optional<ScalarType> C) )
+UPTOc( Tensor, log_softmax, (const Tensor &A, int64_t                   B, c10::optional<ScalarType> C) )
+UPTOc( Tensor, log_softmax, (const Tensor &A, Dimname                   B, c10::optional<ScalarType> C) )
+UPTOc( Tensor, cumprod    , (const Tensor &A, int64_t                   B, c10::optional<ScalarType> C) )
+UPTOc( Tensor, cumprod    , (const Tensor &A, Dimname                   B, c10::optional<ScalarType> C) )
+UPTOc( Tensor, cumsum     , (const Tensor &A, int64_t                   B, c10::optional<ScalarType> C) )
+UPTOc( Tensor, cumsum     , (const Tensor &A, Dimname                   B, c10::optional<ScalarType> C) )
+UPTOb( Tensor, sum        , (const Tensor &A, c10::optional<ScalarType> B) )
+UPTOd( Tensor, sum        , (const Tensor &A, IntArrayRef               B, bool                      C, c10::optional<ScalarType> D) )
+UPTOd( Tensor, sum        , (const Tensor &A, DimnameList               B, bool                      C, c10::optional<ScalarType> D) )
+
+// fp32_append_dtype
+// The wrapper for templating wraps the REDISPATCH_FUNC, so must match REDISPATCH_SIGNATURE.
+UPTOc( Tensor, norm, (const Tensor &A, c10::optional<Scalar> B, ScalarType  C) )
+UPTOe( Tensor, norm, (const Tensor &A, c10::optional<Scalar> B, IntArrayRef C, bool D, ScalarType E) )
+UPTOe( Tensor, norm, (const Tensor &A, c10::optional<Scalar> B, DimnameList C, bool D, ScalarType E) )
+
+// promote
+UPTOd( Tensor, addcdiv  , (const Tensor &A, const Tensor &B, const Tensor &         C, Scalar        D) )
+UPTOd( Tensor, addcmul  , (const Tensor &A, const Tensor &B, const Tensor &         C, Scalar        D) )
+UPTOb( Tensor, atan2    , (const Tensor &A, const Tensor &B) )
+UPTOc( Tensor, cross    , (const Tensor &A, const Tensor &B, c10::optional<int64_t> C) )
+UPTOd( Tensor, bilinear , (const Tensor &A, const Tensor &B, const Tensor &         C, const Tensor &D) )
+UPTOd( Tensor, tensordot, (const Tensor &A, const Tensor &B, IntArrayRef            C, IntArrayRef   D) )
+UPTOb( Tensor, dot      , (const Tensor &A, const Tensor &B) )
+UPTOb( bool  , equal    , (const Tensor &A, const Tensor &B) )
+UPTOb( Tensor, cat      , (TensorList    A, int64_t       B) )
+UPTOb( Tensor, cat      , (TensorList    A, Dimname       B) )
+UPTOb( Tensor, _cat     , (TensorList    A, int64_t       B) )
+UPTOb( Tensor, stack    , (TensorList    A, int64_t       B) )
+
+#undef UPTOa
+#undef UPTOb
+#undef UPTOc
+#undef UPTOd
+#undef UPTOe
+#undef UPTOf
+#undef UPTOg
+#undef UPTOh
+#undef UPTOi
+#undef UPTOj
+#undef UPTOl
+
+} // namespace autocastVS2017Helper

--- a/aten/src/ATen/autocast_mode.cpp
+++ b/aten/src/ATen/autocast_mode.cpp
@@ -1,0 +1,518 @@
+#include <ATen/ATen.h>
+#include <ATen/core/op_registration/op_registration.h>
+#include <ATen/NativeFunctions.h>
+#include <ATen/autocast_mode.h>
+
+#include <c10/util/intrusive_ptr.h>
+#include <c10/core/impl/LocalDispatchKeySet.h>
+
+#include <iostream>
+#include <exception>
+
+namespace at {
+namespace autocast {
+
+bool is_enabled() {
+  return c10::impl::tls_is_dispatch_key_included(DispatchKey::AutocastTensorId);
+}
+
+void set_enabled(bool new_enabled) {
+  c10::impl::tls_set_dispatch_key_included(DispatchKey::AutocastTensorId, new_enabled);
+}
+
+namespace {
+// Imitate Apex and cache some of the casts to streamline parameter reuse.
+// Our heuristic is to cache fp16 casts of fp32 model weights (see cached_cast below).
+//
+// After discussion with @ezyang, the cache uses the following structure:
+// The key is the source tensor's TensorImpl*, a proxy for a Tensor uuid that's unchanged
+// across shallow copies.  The value is a tuple with a weakref to the source tensor's
+// TensorImpl as the first element and the casted tensor as the second element.
+//
+// The weakref keeps the source's TensorImpl from being deleted.  We need to because we're
+// using the source TensorImpl* as the key.  If it were deleted, another random Tensor could
+// be allocated whose TensorImpl* happened to have the same value.  This TensorImpl* would
+// then mistakenly hit in cache:  a rare, intermittent, unpredictable bug.
+//
+// I'm not using the weak_intrusive_ptr as the key because it's more difficult to compare
+// directly against incoming TensorImpl*s.
+using weakref_type = c10::weak_intrusive_ptr<TensorImpl, UndefinedTensorImpl>;
+using val_type = std::tuple<weakref_type, Tensor>;
+thread_local std::unordered_map<TensorImpl*, val_type> cached_casts;
+
+// nesting tracks the nesting depth of the Python-side context manager.
+// When the autocast context manager exits to a nesting level that's outside
+// any instance of autocast (which should occur at the end of each forward pass)
+// it calls clear_cache() to ensure cached Tensors don't leak outside the autocasting region.
+thread_local int nesting = 0;
+}
+
+void clear_cache() {
+  cached_casts.clear();
+}
+
+int increment_nesting() {
+  return ++nesting;
+}
+
+int decrement_nesting() {
+  return --nesting;
+}
+
+// Policies correspond to op categories that need code-divergent handling.
+// Wrapper templates below are specialized based on a policy template parameter.
+enum class CastPolicy : uint8_t {
+  fp16 = 0, // Cast all inputs to at::kHalf before running the op.
+  fp32, // Cast all inputs to at::kFloat before running the op.
+  fp32_set_opt_dtype, // Treats functions (like softmax) that
+                      //   1. we'd like to run in fp32 and
+                      //   2. have a c10::optional<ScalarType> arg that controls the output type.
+                      // fp32_set_opt_dtype wrappers' policy is:  if the output type is already set,
+                      // don't touch it, otherwise, set it to at::kFloat.
+  fp32_append_dtype, // Treats functions (like norm) that
+                     //   1. we'd like to run in fp32 and
+                     //   2. have some overloads that accept an output type and other overloads that don't.
+                     // fp32_append_dtype wrappers wrap the overloads that don't have an output dtype.
+                     // The wrapper policy is:  append at::kFloat to the args, and redispatch to the
+                     // type-aware overload.
+  promote, // Run in the widest dtype among several args.
+};
+
+/********************************************************************
+Logic to extract the promote type from any Tensor or TensorList args.
+********************************************************************/
+
+// Overload to catch Tensor args.
+// If nextArg is floating-point, compare its scalar_type with our
+// current best guess for the promote type, and update if necessary.
+inline at::ScalarType prioritize(at::ScalarType current, const Tensor& nextArg) {
+  if (current == at::kDouble) {
+    AT_ERROR("promote type is double in at::autocast::prioritize");
+    return current;
+  }
+  if (nextArg.is_cuda() && nextArg.is_floating_point()) {
+    auto next = nextArg.scalar_type();
+    if (next == at::kDouble) {
+      return current; // ignores double tensors
+    } else if (current == at::kFloat || next == at::kFloat) {
+      return at::kFloat; // prioritizes float over half
+    } else if (current == at::kHalf && next == at::kHalf) {
+      return at::kHalf;
+    } else {
+      AT_ERROR("Unexpected floating ScalarType in at::autocast::prioritize");
+      return current;
+    }
+  } else {
+    return current;
+  }
+}
+
+// Overload to catch TensorList args (for e.g. cat, stack).
+// Reuses the overload above to process each Tensor in the list.
+inline at::ScalarType prioritize(at::ScalarType current, const TensorList& list) {
+  for (const auto& tensor : list) {
+    current = prioritize(current, tensor);
+  }
+  return current;
+}
+
+// Template to catch non-Tensor args (no-op that returns current best guess)
+template<typename T>
+inline at::ScalarType prioritize(at::ScalarType current, T nextArg) {
+  return current;
+}
+
+// Overload for the tail case.
+inline at::ScalarType promote_type(at::ScalarType current) {
+  return current;
+}
+
+// Unpack args and determine if incoming float16 tensors need to be promoted to float32.
+// Non-Tensor arguments are ignored.
+template<typename Arg0, typename... Args>
+inline at::ScalarType promote_type(at::ScalarType current, Arg0 arg0, Args... args) {
+  auto new_current = prioritize(current, arg0);
+  return promote_type(new_current, args...);
+}
+
+/****************************************************
+Logic to apply cached casting to any Tensor argument.
+****************************************************/
+inline bool is_eligible(const Tensor& arg) {
+  return (arg.is_cuda() && arg.is_floating_point() && (arg.scalar_type() != at::kDouble));
+}
+
+// Overload to catch Tensor args
+inline Tensor cached_cast(at::ScalarType to_type, const Tensor& arg) {
+  if (is_eligible(arg) && (arg.scalar_type() != to_type)) {
+    // Heuristic:  Do what Apex does, and cache fp16 casts of fp32 model weights (leaves).
+    // See cached_casts declaration above for detailed strategy.
+    bool can_try_cache = (to_type == at::kHalf && arg.scalar_type() == at::kFloat && arg.requires_grad() && arg.is_leaf());
+    if (can_try_cache) {
+      auto it = cached_casts.find(arg.unsafeGetTensorImpl());
+      if (it != cached_casts.end()) {
+        return std::get<1>(it->second);
+      } else {
+        auto casted_arg = arg.to(to_type);
+        cached_casts.emplace(arg.unsafeGetTensorImpl(), val_type{weakref_type(arg.getIntrusivePtr()), casted_arg});
+        return casted_arg;
+      }
+    } else {
+      return arg.to(to_type);
+    }
+  } else {
+    return arg;
+  }
+}
+
+// Overload to process TensorLists
+std::vector<Tensor> cached_cast(at::ScalarType to_type, const TensorList& arg) {
+  std::vector<Tensor> vec;
+  vec.reserve(arg.size());
+  for (const auto& t : arg) {
+    vec.push_back(cached_cast(to_type, t));
+  }
+  return vec;
+}
+
+// Template to catch non-Tensor args.
+template<typename T>
+inline T cached_cast(at::ScalarType to_type, T arg) {
+  return arg;
+}
+
+/*******************************************************
+Logic to flip an output dtype flag.
+Keep it simple for now by assuming only one such flag is
+present in the argument list.  If I ever need a function
+with more than flag I'll figure out something else.
+The policy is:
+If the user has explicity specified a dtype, respect it.
+Otherwise, set it to the autocast type.
+********************************************************/
+
+// Overload to catch dtype flags
+inline c10::optional<ScalarType> set_opt_dtype(at::ScalarType to_type, const c10::optional<ScalarType>& dtype) {
+  return dtype.has_value() ? dtype : to_type;
+}
+
+// Template to catch other args
+template<typename T>
+inline T set_opt_dtype(at::ScalarType to_type, T arg) {
+  return arg;
+}
+
+template<typename... Args>
+inline bool firstarg_is_eligible(const Tensor& arg, Args... args) {
+  return is_eligible(arg);
+}
+
+template<typename... Args>
+inline at::ScalarType type_from_firstarg(at::ScalarType to_type, const Tensor& arg, Args... args) {
+  return (is_eligible(arg) ? to_type : arg.scalar_type());
+}
+
+/********************************************************************************************************
+Templates to provide wrapper functions
+
+I'm copying the pattern used in core/boxing/kernel_function.h to extract args and return type.
+(see also https://stackoverflow.com/questions/46533698/how-to-deduce-argument-list-from-function-pointer)
+
+This strategy uses an exterior "WrapFunction" that extracts arguments on behalf of
+(in my case several specializations of) an interior "WrapFunction_".
+Interior WrapFunction_ specializations are defined for each CastPolicy.
+********************************************************************************************************/
+
+// Base template for WrapFunction_, which is specialized to contain a "call" method each CastPolicy
+template<CastPolicy policy, class Redispatch, Redispatch* F, class Ret, class ArgList> struct WrapFunction_ {};
+
+// CastPolicy::fp16
+template<class Redispatch, Redispatch* F, class Ret, class... Args>
+struct WrapFunction_<CastPolicy::fp16, Redispatch, F, Ret, guts::typelist::typelist<Args...>> {
+  static Ret call(Args... args) {
+    c10::impl::ExcludeDispatchKeyGuard no_autocasting(DispatchKey::AutocastTensorId);
+    return (*F)(cached_cast(at::kHalf, args)...);
+  }
+};
+
+// CastPolicy::fp32
+template<class Redispatch, Redispatch* F, class Ret, class... Args>
+struct WrapFunction_<CastPolicy::fp32, Redispatch, F, Ret, guts::typelist::typelist<Args...>> {
+  static Ret call(Args... args) {
+    c10::impl::ExcludeDispatchKeyGuard no_autocasting(DispatchKey::AutocastTensorId);
+    return (*F)(cached_cast(at::kFloat, args)...);
+  }
+};
+
+// CastPolicy::fp32_set_opt_dtype
+template<class Redispatch, Redispatch* F, class Ret, class... Args>
+struct WrapFunction_<CastPolicy::fp32_set_opt_dtype, Redispatch, F, Ret, guts::typelist::typelist<Args...>> {
+  static Ret call(Args... args) {
+    c10::impl::ExcludeDispatchKeyGuard no_autocasting(DispatchKey::AutocastTensorId);
+    if (firstarg_is_eligible(args...)) {
+      return (*F)(set_opt_dtype(at::kFloat, args)...);
+    } else {
+      // If ineligible, calls F with unaltered args.  Does not set opt dtype, because setting
+      // opt dtype explicitly may interfere with internal implicit promotion decisions.
+      return (*F)(args...);
+    }
+  }
+};
+
+// CastPolicy::fp32_append_dtype
+template<class Redispatch, Redispatch* F, class Ret, class... Args>
+struct WrapFunction_<CastPolicy::fp32_append_dtype, Redispatch, F, Ret, guts::typelist::typelist<Args...>> {
+  static Ret call(Args... args) {
+    c10::impl::ExcludeDispatchKeyGuard no_autocasting(DispatchKey::AutocastTensorId);
+    at::ScalarType out_type = type_from_firstarg(at::kFloat, args...);
+    return (*F)(args..., out_type);
+  }
+};
+
+// CastPolicy::promote
+template<class Redispatch, Redispatch* F, class Ret, class... Args>
+struct WrapFunction_<CastPolicy::promote, Redispatch, F, Ret, guts::typelist::typelist<Args...>> {
+  static Ret call(Args... args) {
+    c10::impl::ExcludeDispatchKeyGuard no_autocasting(DispatchKey::AutocastTensorId);
+    auto to_type = promote_type(at::kHalf, args...);
+    return (*F)(cached_cast(to_type, args)...);
+  }
+};
+
+// Wrapper to infer return_type and parameter_types for WrapFunction_ (imitating core/boxing/kernel_function.h)
+template<CastPolicy policy,
+         class Registered, // The signature for which we're registering.  The dispatcher's calling code invokes our
+                           // registered functions with arguments matching Registered, so we register
+                           // WrapFunction_::call methods with a matching signature to properly field those arguments.
+                           // guts::function_traits below extracts return_type and parameter_types from Registered,
+                           // which WrapFunction_ templates above use to declare their call methods.
+         class Redispatch, // The signature for the function we're redispatching to.  In most cases this is the same
+                           // as Registered, but for some ops (for example, ops where we append a dtype) it's useful
+                           // to redispatch to a function with a different signature.
+         Redispatch* F>    // The actual function we're redispatching to.
+struct WrapFunction final {
+  using type = WrapFunction_<policy,
+                             Redispatch,
+                             F,
+                             typename guts::function_traits<Registered>::return_type,
+                             typename guts::function_traits<Registered>::parameter_types>;
+};
+
+/*******************************
+Banned functions
+*******************************/
+
+Tensor binary_cross_entropy_banned(const Tensor &, const Tensor &, const Tensor &, int64_t) {
+  AT_ERROR("torch.nn.functional.binary_cross_entropy and torch.nn.BCELoss are unsafe to autocast.\n"
+           "Many models use a sigmoid layer right before the binary cross entropy layer.\n"
+           "In this case, combine the two layers using torch.nn.functional.binary_cross_entropy_with_logits\n"
+           "or torch.nn.BCEWithLogitsLoss.  binary_cross_entropy_with_logits and BCEWithLogits are\n"
+           "safe to autocast.");
+}
+
+#ifndef USE_STATIC_DISPATCH
+namespace {
+/*****************************************************************************************************************
+This section performs load-time registration for autocast wrappers.
+
+It's debatable at what level operations should be patched.  We'd like casts to be autograd-exposed
+and precede autograd history recording, so that for fp16 ops, input tensors are saved for backward
+in fp16 rather than fp32.  Saving inputs in fp16 can significantly reduce a model's memory footprint.
+
+Option 1 (strawman):  Patch only at the level of explicit calls into cudnn/cublas (cudnn_convolution, etc),
+because those are the code paths that are guaranteed to use Tensor Cores, therefore they're the ones that
+will benefit most from fp16.   Potential pitfall:  convolutions (and other ops) are wrapped in several
+layers of at::* calls.  If one of those happens to record autograd history, then we've lost the
+opportunity to save inputs in fp16.
+
+Option 2:  Patch the Python-exposed surface of calls, to make 100% sure autograd history
+recording can't sneak in ahead of autocast.  This mirrors Apex most closely.
+
+I think Option 2 is the right answer for all ops, not just convolutions.  Option 2 is what I implement here.
+*****************************************************************************************************************/
+
+auto register_fallthrough = c10::Dispatcher::singleton()
+  .registerBackendFallbackKernel(DispatchKey::AutocastTensorId,
+                                 KernelFunction::makeFallthrough());
+
+/********************************************************************************************************************
+Explicit registration for out-of-place ops
+
+The stuff below could be codegenned.  Ed said
+> you are going to have to write the function definition at some point, I wouldn't try to get clever about it
+Therefore, for the moment, this is all copy pasted in from VariableTypeEverything.cpp with appropriate substitutions.
+********************************************************************************************************************/
+
+// Workaround for a compiler bug in VS 2017 (versions < 15.8).  See comments in autocast_VS2017_helper.h.
+#ifdef _MSC_VER
+  #if _MSC_VER >= 1915
+    // With VS 15.8+, template directly on at:: functions.
+    #define ADD_NS(RAW_OP) at::RAW_OP
+  #else
+    // If we're compiling with the buggy VS, pull in local wrappers to template on.
+    #include <ATen/autocast_VS2017_helper.h>
+    #define ADD_NS(RAW_OP) autocastVS2017Helper::RAW_OP
+  #endif
+#else
+  // With other compilers, template directly on at:: functions.
+  #define ADD_NS(RAW_OP) at::RAW_OP
+#endif
+
+// Common cases where registration signature matches redispatch signature
+// (that's why SIGNATURE is repeated in the WrapFunction instantiation)
+#define KERNEL(FUNC, REGISTER_SCHEMA, SIGNATURE, POLICY) \
+  .op(torch::RegisterOperators::options() \
+    .schema(REGISTER_SCHEMA) \
+    .kernel<SIGNATURE>(DispatchKey::AutocastTensorId, \
+    &WrapFunction<CastPolicy::POLICY, SIGNATURE, SIGNATURE, &FUNC>::type::call))
+
+#define KERNEL_UNBOXED_ONLY(FUNC, REGISTER_SCHEMA, SIGNATURE, POLICY) \
+  .op(torch::RegisterOperators::options() \
+    .schema(REGISTER_SCHEMA) \
+    .impl_unboxedOnlyKernel<SIGNATURE, \
+    &WrapFunction<CastPolicy::POLICY, SIGNATURE, SIGNATURE, &FUNC>::type::call \
+    >(DispatchKey::AutocastTensorId))
+
+// Less-common but still useful case: redispatching to a function with a new signature (e.g. appending a dtype)
+#define KERNEL_UNBOXED_ONLY_DIFFERENT_REDISPATCH_SIGNATURE(REDISPATCH_FUNC, REGISTER_SCHEMA, REGISTER_SIGNATURE, REDISPATCH_SIGNATURE, POLICY) \
+  .op(torch::RegisterOperators::options() \
+    .schema(REGISTER_SCHEMA) \
+    .impl_unboxedOnlyKernel<REGISTER_SIGNATURE, \
+    &WrapFunction<CastPolicy::POLICY, REGISTER_SIGNATURE, REDISPATCH_SIGNATURE, &REDISPATCH_FUNC>::type::call \
+    >(DispatchKey::AutocastTensorId))
+
+/*****************************************
+Explicit registration for out-of-place ops
+*****************************************/
+auto register_out_of_place = torch::RegisterOperators()
+  // fp16
+  KERNEL_UNBOXED_ONLY(ADD_NS(_convolution), "aten::_convolution(Tensor input, Tensor weight, Tensor? bias, int[] stride, int[] padding, int[] dilation, bool transposed, int[] output_padding, int groups, bool benchmark, bool deterministic, bool cudnn_enabled) -> Tensor", Tensor (const Tensor &, const Tensor &, const Tensor &, IntArrayRef, IntArrayRef, IntArrayRef, bool, IntArrayRef, int64_t, bool, bool, bool), fp16)
+  KERNEL_UNBOXED_ONLY(ADD_NS(_convolution_nogroup), "aten::_convolution_nogroup(Tensor input, Tensor weight, Tensor? bias, int[] stride, int[] padding, int[] dilation, bool transposed, int[] output_padding) -> Tensor", Tensor (const Tensor &, const Tensor &, const Tensor &, IntArrayRef, IntArrayRef, IntArrayRef, bool, IntArrayRef), fp16)
+  KERNEL_UNBOXED_ONLY(ADD_NS(conv1d), "aten::conv1d(Tensor input, Tensor weight, Tensor? bias=None, int[1] stride=1, int[1] padding=0, int[1] dilation=1, int groups=1) -> Tensor", Tensor (const Tensor &, const Tensor &, const Tensor &, IntArrayRef, IntArrayRef, IntArrayRef, int64_t), fp16)
+  KERNEL_UNBOXED_ONLY(ADD_NS(conv2d), "aten::conv2d(Tensor input, Tensor weight, Tensor? bias=None, int[2] stride=1, int[2] padding=0, int[2] dilation=1, int groups=1) -> Tensor", Tensor (const Tensor &, const Tensor &, const Tensor &, IntArrayRef, IntArrayRef, IntArrayRef, int64_t), fp16)
+  KERNEL_UNBOXED_ONLY(ADD_NS(conv3d), "aten::conv3d(Tensor input, Tensor weight, Tensor? bias=None, int[3] stride=1, int[3] padding=0, int[3] dilation=1, int groups=1) -> Tensor", Tensor (const Tensor &, const Tensor &, const Tensor &, IntArrayRef, IntArrayRef, IntArrayRef, int64_t), fp16)
+  KERNEL_UNBOXED_ONLY(ADD_NS(conv_tbc), "aten::conv_tbc(Tensor self, Tensor weight, Tensor bias, int pad=0) -> Tensor", Tensor (const Tensor &, const Tensor &, const Tensor &, int64_t), fp16)
+  KERNEL_UNBOXED_ONLY(ADD_NS(conv_transpose1d), "aten::conv_transpose1d(Tensor input, Tensor weight, Tensor? bias=None, int[1] stride=1, int[1] padding=0, int[1] output_padding=0, int groups=1, int[1] dilation=1) -> Tensor", Tensor (const Tensor &, const Tensor &, const Tensor &, IntArrayRef, IntArrayRef, IntArrayRef, int64_t, IntArrayRef), fp16)
+  KERNEL_UNBOXED_ONLY(ADD_NS(conv_transpose2d), "aten::conv_transpose2d.input(Tensor input, Tensor weight, Tensor? bias=None, int[2] stride=1, int[2] padding=0, int[2] output_padding=0, int groups=1, int[2] dilation=1) -> Tensor", Tensor (const Tensor &, const Tensor &, const Tensor &, IntArrayRef, IntArrayRef, IntArrayRef, int64_t, IntArrayRef), fp16)
+  KERNEL_UNBOXED_ONLY(ADD_NS(conv_transpose3d), "aten::conv_transpose3d.input(Tensor input, Tensor weight, Tensor? bias=None, int[3] stride=1, int[3] padding=0, int[3] output_padding=0, int groups=1, int[3] dilation=1) -> Tensor", Tensor (const Tensor &, const Tensor &, const Tensor &, IntArrayRef, IntArrayRef, IntArrayRef, int64_t, IntArrayRef), fp16)
+  KERNEL_UNBOXED_ONLY(ADD_NS(convolution), "aten::convolution(Tensor input, Tensor weight, Tensor? bias, int[] stride, int[] padding, int[] dilation, bool transposed, int[] output_padding, int groups) -> Tensor", Tensor (const Tensor &, const Tensor &, const Tensor &, IntArrayRef, IntArrayRef, IntArrayRef, bool, IntArrayRef, int64_t), fp16)
+  KERNEL_UNBOXED_ONLY(ADD_NS(cudnn_convolution), "aten::cudnn_convolution.deprecated(Tensor self, Tensor weight, Tensor? bias, int[] padding, int[] stride, int[] dilation, int groups, bool benchmark, bool deterministic) -> Tensor", Tensor (const Tensor &, const Tensor &, const Tensor &, IntArrayRef, IntArrayRef, IntArrayRef, int64_t, bool, bool), fp16)
+  KERNEL_UNBOXED_ONLY(ADD_NS(cudnn_convolution_transpose), "aten::cudnn_convolution_transpose.deprecated(Tensor self, Tensor weight, Tensor? bias, int[] padding, int[] output_padding, int[] stride, int[] dilation, int groups, bool benchmark, bool deterministic) -> Tensor", Tensor (const Tensor &, const Tensor &, const Tensor &, IntArrayRef, IntArrayRef, IntArrayRef, IntArrayRef, int64_t, bool, bool), fp16)
+  KERNEL_UNBOXED_ONLY(ADD_NS(cudnn_convolution), "aten::cudnn_convolution(Tensor self, Tensor weight, int[] padding, int[] stride, int[] dilation, int groups, bool benchmark, bool deterministic) -> Tensor", Tensor (const Tensor &, const Tensor &, IntArrayRef, IntArrayRef, IntArrayRef, int64_t, bool, bool), fp16)
+  KERNEL_UNBOXED_ONLY(ADD_NS(cudnn_convolution_transpose), "aten::cudnn_convolution_transpose(Tensor self, Tensor weight, int[] padding, int[] output_padding, int[] stride, int[] dilation, int groups, bool benchmark, bool deterministic) -> Tensor", Tensor (const Tensor &, const Tensor &, IntArrayRef, IntArrayRef, IntArrayRef, IntArrayRef, int64_t, bool, bool), fp16)
+  KERNEL(ADD_NS(prelu), "aten::prelu(Tensor self, Tensor weight) -> Tensor", Tensor (const Tensor &, const Tensor &), fp16)
+  KERNEL(ADD_NS(addmm), "aten::addmm(Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor", Tensor (const Tensor &, const Tensor &, const Tensor &, Scalar, Scalar), fp16)
+  KERNEL(ADD_NS(addmv), "aten::addmv(Tensor self, Tensor mat, Tensor vec, *, Scalar beta=1, Scalar alpha=1) -> Tensor", Tensor (const Tensor &, const Tensor &, const Tensor &, Scalar, Scalar), fp16)
+  KERNEL(ADD_NS(addr), "aten::addr(Tensor self, Tensor vec1, Tensor vec2, *, Scalar beta=1, Scalar alpha=1) -> Tensor", Tensor (const Tensor &, const Tensor &, const Tensor &, Scalar, Scalar), fp16)
+  KERNEL(ADD_NS(matmul), "aten::matmul(Tensor self, Tensor other) -> Tensor", Tensor (const Tensor &, const Tensor &), fp16)
+  KERNEL(ADD_NS(mm), "aten::mm(Tensor self, Tensor mat2) -> Tensor", Tensor (const Tensor &, const Tensor &), fp16)
+  KERNEL(ADD_NS(mv), "aten::mv(Tensor self, Tensor vec) -> Tensor", Tensor (const Tensor &, const Tensor &), fp16)
+  KERNEL_UNBOXED_ONLY(ADD_NS(linear), "aten::linear(Tensor input, Tensor weight, Tensor? bias=None) -> Tensor", Tensor (const Tensor &, const Tensor &, const Tensor &), fp16)
+  KERNEL(ADD_NS(addbmm), "aten::addbmm(Tensor self, Tensor batch1, Tensor batch2, *, Scalar beta=1, Scalar alpha=1) -> Tensor", Tensor (const Tensor &, const Tensor &, const Tensor &, Scalar, Scalar), fp16)
+  KERNEL(ADD_NS(baddbmm), "aten::baddbmm(Tensor self, Tensor batch1, Tensor batch2, *, Scalar beta=1, Scalar alpha=1) -> Tensor", Tensor (const Tensor &, const Tensor &, const Tensor &, Scalar, Scalar), fp16)
+  KERNEL(ADD_NS(bmm), "aten::bmm(Tensor self, Tensor mat2) -> Tensor", Tensor (const Tensor &, const Tensor &), fp16)
+  KERNEL_UNBOXED_ONLY(ADD_NS(chain_matmul), "aten::chain_matmul(Tensor[] matrices) -> Tensor", Tensor (TensorList), fp16)
+  // fp32
+  KERNEL(ADD_NS(acos), "aten::acos(Tensor self) -> Tensor", Tensor (const Tensor &), fp32)
+  KERNEL(ADD_NS(asin), "aten::asin(Tensor self) -> Tensor", Tensor (const Tensor &), fp32)
+  KERNEL(ADD_NS(cosh), "aten::cosh(Tensor self) -> Tensor", Tensor (const Tensor &), fp32)
+  KERNEL(ADD_NS(erfinv), "aten::erfinv(Tensor self) -> Tensor", Tensor (const Tensor &), fp32)
+  KERNEL(ADD_NS(exp), "aten::exp(Tensor self) -> Tensor", Tensor (const Tensor &), fp32)
+  KERNEL(ADD_NS(expm1), "aten::expm1(Tensor self) -> Tensor", Tensor (const Tensor &), fp32)
+  KERNEL(ADD_NS(log), "aten::log(Tensor self) -> Tensor", Tensor (const Tensor &), fp32)
+  KERNEL(ADD_NS(log10), "aten::log10(Tensor self) -> Tensor", Tensor (const Tensor &), fp32)
+  KERNEL(ADD_NS(log2), "aten::log2(Tensor self) -> Tensor", Tensor (const Tensor &), fp32)
+  KERNEL(ADD_NS(log1p), "aten::log1p(Tensor self) -> Tensor", Tensor (const Tensor &), fp32)
+  KERNEL(ADD_NS(reciprocal), "aten::reciprocal(Tensor self) -> Tensor", Tensor (const Tensor &), fp32)
+  KERNEL(ADD_NS(rsqrt), "aten::rsqrt(Tensor self) -> Tensor", Tensor (const Tensor &), fp32)
+  KERNEL(ADD_NS(sinh), "aten::sinh(Tensor self) -> Tensor", Tensor (const Tensor &), fp32)
+  KERNEL(ADD_NS(tan), "aten::tan(Tensor self) -> Tensor", Tensor (const Tensor &), fp32)
+  KERNEL(ADD_NS(pow), "aten::pow.Tensor_Scalar(Tensor self, Scalar exponent) -> Tensor", Tensor (const Tensor &, Scalar), fp32)
+  KERNEL(ADD_NS(pow), "aten::pow.Tensor_Tensor(Tensor self, Tensor exponent) -> Tensor", Tensor (const Tensor &, const Tensor &), fp32)
+  KERNEL(ADD_NS(pow), "aten::pow.Scalar(Scalar self, Tensor exponent) -> Tensor", Tensor (Scalar, const Tensor &), fp32)
+  KERNEL(ADD_NS(softplus), "aten::softplus(Tensor self, Scalar beta=1, Scalar threshold=20) -> Tensor", Tensor (const Tensor &, Scalar, Scalar), fp32)
+  KERNEL(ADD_NS(gelu), "aten::gelu(Tensor self) -> Tensor", Tensor (const Tensor &), fp32)
+  KERNEL_UNBOXED_ONLY(ADD_NS(layer_norm), "aten::layer_norm(Tensor input, int[] normalized_shape, Tensor? weight=None, Tensor? bias=None, float eps=1e-05, bool cudnn_enable=True) -> Tensor", Tensor (const Tensor &, IntArrayRef, const Tensor &, const Tensor &, double, bool), fp32)
+  // The macro doesn't like this one so I had to write it out manually.
+  .op(torch::RegisterOperators::options()
+    .schema("aten::native_layer_norm(Tensor input, Tensor? weight, Tensor? bias, int M, int N, float eps) -> (Tensor, Tensor, Tensor)")
+    .impl_unboxedOnlyKernel<std::tuple<Tensor,Tensor,Tensor> (const Tensor &, const Tensor &, const Tensor &, int64_t, int64_t, double),
+    &WrapFunction<CastPolicy::fp32, std::tuple<Tensor,Tensor,Tensor> (const Tensor &, const Tensor &, const Tensor &, int64_t, int64_t, double), std::tuple<Tensor,Tensor,Tensor> (const Tensor &, const Tensor &, const Tensor &, int64_t, int64_t, double), &ADD_NS(native_layer_norm)>::type::call
+    >(DispatchKey::AutocastTensorId)
+    .aliasAnalysis(c10::AliasAnalysisKind::FROM_SCHEMA))
+  KERNEL_UNBOXED_ONLY(ADD_NS(group_norm), "aten::group_norm(Tensor input, int num_groups, Tensor? weight=None, Tensor? bias=None, float eps=1e-05, bool cudnn_enabled=True) -> Tensor", Tensor (const Tensor &, int64_t, const Tensor &, const Tensor &, double, bool), fp32)
+  KERNEL_UNBOXED_ONLY(ADD_NS(frobenius_norm), "aten::frobenius_norm(Tensor self) -> Tensor", Tensor (const Tensor &), fp32)
+  KERNEL_UNBOXED_ONLY(ADD_NS(frobenius_norm), "aten::frobenius_norm.dim(Tensor self, int[1] dim, bool keepdim=False) -> Tensor", Tensor (const Tensor &, IntArrayRef, bool), fp32)
+  KERNEL_UNBOXED_ONLY(ADD_NS(nuclear_norm), "aten::nuclear_norm(Tensor self, bool keepdim=False) -> Tensor", Tensor (const Tensor &, bool), fp32)
+  KERNEL_UNBOXED_ONLY(ADD_NS(nuclear_norm), "aten::nuclear_norm.dim(Tensor self, int[2] dim, bool keepdim=False) -> Tensor", Tensor (const Tensor &, IntArrayRef, bool), fp32)
+  KERNEL(ADD_NS(cosine_similarity), "aten::cosine_similarity(Tensor x1, Tensor x2, int dim=1, float eps=1e-08) -> Tensor", Tensor (const Tensor &, const Tensor &, int64_t, double), fp32)
+  KERNEL(ADD_NS(poisson_nll_loss), "aten::poisson_nll_loss(Tensor input, Tensor target, bool log_input, bool full, float eps, int reduction) -> Tensor", Tensor (const Tensor &, const Tensor &, bool, bool, double, int64_t), fp32)
+  KERNEL(ADD_NS(cosine_embedding_loss), "aten::cosine_embedding_loss(Tensor input1, Tensor input2, Tensor target, float margin=0.0, int reduction=Mean) -> Tensor", Tensor (const Tensor &, const Tensor &, const Tensor &, double, int64_t), fp32)
+  KERNEL_UNBOXED_ONLY(ADD_NS(nll_loss), "aten::nll_loss(Tensor self, Tensor target, Tensor? weight=None, int reduction=Mean, int ignore_index=-100) -> Tensor", Tensor (const Tensor &, const Tensor &, const Tensor &, int64_t, int64_t), fp32)
+  KERNEL_UNBOXED_ONLY(ADD_NS(nll_loss2d), "aten::nll_loss2d(Tensor self, Tensor target, Tensor? weight=None, int reduction=Mean, int ignore_index=-100) -> Tensor", Tensor (const Tensor &, const Tensor &, const Tensor &, int64_t, int64_t), fp32)
+  KERNEL(ADD_NS(hinge_embedding_loss), "aten::hinge_embedding_loss(Tensor self, Tensor target, float margin=1.0, int reduction=Mean) -> Tensor", Tensor (const Tensor &, const Tensor &, double, int64_t), fp32)
+  KERNEL(ADD_NS(kl_div), "aten::kl_div(Tensor self, Tensor target, int reduction=Mean) -> Tensor", Tensor (const Tensor &, const Tensor &, int64_t), fp32)
+  KERNEL(ADD_NS(l1_loss), "aten::l1_loss(Tensor self, Tensor target, int reduction=Mean) -> Tensor", Tensor (const Tensor &, const Tensor &, int64_t), fp32)
+  KERNEL(ADD_NS(smooth_l1_loss), "aten::smooth_l1_loss(Tensor self, Tensor target, int reduction=Mean) -> Tensor", Tensor (const Tensor &, const Tensor &, int64_t), fp32)
+  KERNEL(ADD_NS(mse_loss), "aten::mse_loss(Tensor self, Tensor target, int reduction=Mean) -> Tensor", Tensor (const Tensor &, const Tensor &, int64_t), fp32)
+  KERNEL(ADD_NS(margin_ranking_loss), "aten::margin_ranking_loss(Tensor input1, Tensor input2, Tensor target, float margin=0.0, int reduction=Mean) -> Tensor", Tensor (const Tensor &, const Tensor &, const Tensor &, double, int64_t), fp32)
+  KERNEL(ADD_NS(multilabel_margin_loss), "aten::multilabel_margin_loss(Tensor self, Tensor target, int reduction=Mean) -> Tensor", Tensor (const Tensor &, const Tensor &, int64_t), fp32)
+  KERNEL(ADD_NS(soft_margin_loss), "aten::soft_margin_loss(Tensor self, Tensor target, int reduction=Mean) -> Tensor", Tensor (const Tensor &, const Tensor &, int64_t), fp32)
+  KERNEL(ADD_NS(triplet_margin_loss), "aten::triplet_margin_loss(Tensor anchor, Tensor positive, Tensor negative, float margin=1.0, float p=2, float eps=1e-06, bool swap=False, int reduction=Mean) -> Tensor", Tensor (const Tensor &, const Tensor &, const Tensor &, double, double, double, bool, int64_t), fp32)
+  KERNEL_UNBOXED_ONLY(ADD_NS(multi_margin_loss), "aten::multi_margin_loss(Tensor self, Tensor target, Scalar p=1, Scalar margin=1, Tensor? weight=None, int reduction=Mean) -> Tensor", Tensor (const Tensor &, const Tensor &, Scalar, Scalar, const Tensor &, int64_t), fp32)
+  KERNEL_UNBOXED_ONLY(ADD_NS(binary_cross_entropy_with_logits), "aten::binary_cross_entropy_with_logits(Tensor self, Tensor target, Tensor? weight=None, Tensor? pos_weight=None, int reduction=Mean) -> Tensor", Tensor (const Tensor &, const Tensor &, const Tensor &, const Tensor &, int64_t), fp32)
+  KERNEL(ADD_NS(dist), "aten::dist(Tensor self, Tensor other, Scalar p=2) -> Tensor", Tensor (const Tensor &, const Tensor &, Scalar), fp32)
+  KERNEL(ADD_NS(pdist), "aten::pdist(Tensor self, float p=2) -> Tensor", Tensor (const Tensor &, double), fp32)
+  KERNEL(ADD_NS(cdist), "aten::cdist(Tensor x1, Tensor x2, float p=2, int? compute_mode=None) -> Tensor", Tensor (const Tensor &, const Tensor &, double, c10::optional<int64_t>), fp32)
+  KERNEL(ADD_NS(renorm), "aten::renorm(Tensor self, Scalar p, int dim, Scalar maxnorm) -> Tensor", Tensor (const Tensor &, Scalar, int64_t, Scalar), fp32)
+  // fp32_set_opt_dtype
+  KERNEL_UNBOXED_ONLY(ADD_NS(prod), "aten::prod(Tensor self, *, ScalarType? dtype=None) -> Tensor", Tensor (const Tensor &, c10::optional<ScalarType>), fp32_set_opt_dtype)
+  KERNEL_UNBOXED_ONLY(ADD_NS(prod), "aten::prod.dim_int(Tensor self, int dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor", Tensor (const Tensor &, int64_t, bool, c10::optional<ScalarType>), fp32_set_opt_dtype)
+  KERNEL_UNBOXED_ONLY(ADD_NS(prod), "aten::prod.dim_Dimname(Tensor self, Dimname dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor", Tensor (const Tensor &, Dimname, bool, c10::optional<ScalarType>), fp32_set_opt_dtype)
+  KERNEL_UNBOXED_ONLY(ADD_NS(softmax), "aten::softmax.int(Tensor self, int dim, ScalarType? dtype=None) -> Tensor", Tensor (const Tensor &, int64_t, c10::optional<ScalarType>), fp32_set_opt_dtype)
+  KERNEL_UNBOXED_ONLY(ADD_NS(softmax), "aten::softmax.Dimname(Tensor self, Dimname dim, *, ScalarType? dtype=None) -> Tensor", Tensor (const Tensor &, Dimname, c10::optional<ScalarType>), fp32_set_opt_dtype)
+  KERNEL_UNBOXED_ONLY(ADD_NS(log_softmax), "aten::log_softmax.int(Tensor self, int dim, ScalarType? dtype=None) -> Tensor", Tensor (const Tensor &, int64_t, c10::optional<ScalarType>), fp32_set_opt_dtype)
+  KERNEL_UNBOXED_ONLY(ADD_NS(log_softmax), "aten::log_softmax.Dimname(Tensor self, Dimname dim, *, ScalarType? dtype=None) -> Tensor", Tensor (const Tensor &, Dimname, c10::optional<ScalarType>), fp32_set_opt_dtype)
+  KERNEL_UNBOXED_ONLY(ADD_NS(cumprod), "aten::cumprod(Tensor self, int dim, *, ScalarType? dtype=None) -> Tensor", Tensor (const Tensor &, int64_t, c10::optional<ScalarType>), fp32_set_opt_dtype)
+  KERNEL_UNBOXED_ONLY(ADD_NS(cumprod), "aten::cumprod.dimname(Tensor self, Dimname dim, *, ScalarType? dtype=None) -> Tensor", Tensor (const Tensor &, Dimname, c10::optional<ScalarType>), fp32_set_opt_dtype)
+  KERNEL_UNBOXED_ONLY(ADD_NS(cumsum), "aten::cumsum(Tensor self, int dim, *, ScalarType? dtype=None) -> Tensor", Tensor (const Tensor &, int64_t, c10::optional<ScalarType>), fp32_set_opt_dtype)
+  KERNEL_UNBOXED_ONLY(ADD_NS(cumsum), "aten::cumsum.dimname(Tensor self, Dimname dim, *, ScalarType? dtype=None) -> Tensor", Tensor (const Tensor &, Dimname, c10::optional<ScalarType>), fp32_set_opt_dtype)
+  // commenting these out because they accept an explicit (not-optional) dtype, and we shouldn't try to flip that even
+  // when autocasting.
+  // KERNEL_UNBOXED_ONLY(ADD_NS(norm), "aten::norm.ScalarOpt_dtype(Tensor self, Scalar? p, *, ScalarType dtype) -> Tensor", Tensor (const Tensor &, c10::optional<Scalar>, ScalarType), fp32_set_opt_dtype)
+  // KERNEL_UNBOXED_ONLY(ADD_NS(norm), "aten::norm.ScalarOpt_dim_dtype(Tensor self, Scalar? p, int[1] dim, bool keepdim, *, ScalarType dtype) -> Tensor", Tensor (const Tensor &, c10::optional<Scalar>, IntArrayRef, bool, ScalarType), fp32_set_opt_dtype)
+  // KERNEL_UNBOXED_ONLY(ADD_NS(norm), "aten::norm.names_ScalarOpt_dim_dtype(Tensor self, Scalar? p, Dimname[1] dim, bool keepdim, *, ScalarType dtype) -> Tensor", Tensor (const Tensor &, c10::optional<Scalar>, DimnameList, bool, ScalarType), fp32_set_opt_dtype)
+  KERNEL_UNBOXED_ONLY(ADD_NS(sum), "aten::sum(Tensor self, *, ScalarType? dtype=None) -> Tensor", Tensor (const Tensor &, c10::optional<ScalarType>), fp32_set_opt_dtype)
+  KERNEL_UNBOXED_ONLY(ADD_NS(sum), "aten::sum.dim_IntList(Tensor self, int[1] dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor", Tensor (const Tensor &, IntArrayRef, bool, c10::optional<ScalarType>), fp32_set_opt_dtype)
+  KERNEL_UNBOXED_ONLY(ADD_NS(sum), "aten::sum.dim_DimnameList(Tensor self, Dimname[1] dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor", Tensor (const Tensor &, DimnameList, bool, c10::optional<ScalarType>), fp32_set_opt_dtype)
+  // fp32_append_dtype
+  // The fp32_append_dtype wrapper overrides implicit promotion behavior.
+  // norm does not implicitly promote, but be aware when adding new ops to this policy.
+  KERNEL_UNBOXED_ONLY_DIFFERENT_REDISPATCH_SIGNATURE(ADD_NS(norm), "aten::norm.Scalar(Tensor self, Scalar p=2) -> Tensor", Tensor (const Tensor &, Scalar), Tensor (const Tensor &, c10::optional<Scalar>, ScalarType), fp32_append_dtype)
+  KERNEL_UNBOXED_ONLY_DIFFERENT_REDISPATCH_SIGNATURE(ADD_NS(norm), "aten::norm.ScalarOpt_dim(Tensor self, Scalar? p, int[1] dim, bool keepdim=False) -> Tensor", Tensor (const Tensor &, c10::optional<Scalar>, IntArrayRef, bool), Tensor (const Tensor &, c10::optional<Scalar>, IntArrayRef, bool, ScalarType), fp32_append_dtype)
+  KERNEL_UNBOXED_ONLY_DIFFERENT_REDISPATCH_SIGNATURE(ADD_NS(norm), "aten::norm.names_ScalarOpt_dim(Tensor self, Scalar? p, Dimname[1] dim, bool keepdim=False) -> Tensor", Tensor (const Tensor &, c10::optional<Scalar>, DimnameList, bool), Tensor (const Tensor &, c10::optional<Scalar>, DimnameList, bool, ScalarType), fp32_append_dtype)
+  // promote
+  KERNEL(ADD_NS(addcdiv), "aten::addcdiv(Tensor self, Tensor tensor1, Tensor tensor2, *, Scalar value=1) -> Tensor", Tensor (const Tensor &, const Tensor &, const Tensor &, Scalar), promote)
+  KERNEL(ADD_NS(addcmul), "aten::addcmul(Tensor self, Tensor tensor1, Tensor tensor2, *, Scalar value=1) -> Tensor", Tensor (const Tensor &, const Tensor &, const Tensor &, Scalar), promote)
+  KERNEL(ADD_NS(atan2), "aten::atan2(Tensor self, Tensor other) -> Tensor", Tensor (const Tensor &, const Tensor &), promote)
+  KERNEL(ADD_NS(cross), "aten::cross(Tensor self, Tensor other, int? dim=None) -> Tensor", Tensor (const Tensor &, const Tensor &, c10::optional<int64_t>), promote)
+  KERNEL_UNBOXED_ONLY(ADD_NS(bilinear), "aten::bilinear(Tensor input1, Tensor input2, Tensor weight, Tensor? bias) -> Tensor", Tensor (const Tensor &, const Tensor &, const Tensor &, const Tensor &), promote)
+  KERNEL_UNBOXED_ONLY(ADD_NS(tensordot), "aten::tensordot(Tensor self, Tensor other, int[] dims_self, int[] dims_other) -> Tensor", Tensor (const Tensor &, const Tensor &, IntArrayRef, IntArrayRef), promote)
+  KERNEL_UNBOXED_ONLY(ADD_NS(dot), "aten::dot(Tensor self, Tensor tensor) -> Tensor", Tensor (const Tensor &, const Tensor &), promote)
+  KERNEL(ADD_NS(equal), "aten::equal(Tensor self, Tensor other) -> bool", bool (const Tensor &, const Tensor &), promote)
+  KERNEL_UNBOXED_ONLY(ADD_NS(cat), "aten::cat(Tensor[] tensors, int dim=0) -> Tensor", Tensor (TensorList, int64_t), promote)
+  KERNEL_UNBOXED_ONLY(ADD_NS(cat), "aten::cat.names(Tensor[] tensors, Dimname dim) -> Tensor", Tensor (TensorList, Dimname), promote)
+  KERNEL_UNBOXED_ONLY(ADD_NS(_cat), "aten::_cat(Tensor[] tensors, int dim=0) -> Tensor", Tensor (TensorList, int64_t), promote)
+  KERNEL_UNBOXED_ONLY(ADD_NS(stack), "aten::stack(Tensor[] tensors, int dim=0) -> Tensor", Tensor (TensorList, int64_t), promote)
+  ;
+
+auto register_banned = torch::RegisterOperators()
+  .op(torch::RegisterOperators::options()
+    .schema("aten::binary_cross_entropy(Tensor self, Tensor target, Tensor? weight=None, int reduction=Mean) -> Tensor")
+    .impl_unboxedOnlyKernel<Tensor (const Tensor &, const Tensor &, const Tensor &, int64_t), &at::autocast::binary_cross_entropy_banned>(DispatchKey::AutocastTensorId)
+    .aliasAnalysis(c10::AliasAnalysisKind::FROM_SCHEMA));
+}
+#endif
+
+} // namespace autocast
+} // namespace at

--- a/aten/src/ATen/autocast_mode.h
+++ b/aten/src/ATen/autocast_mode.h
@@ -1,0 +1,13 @@
+#pragma once
+
+namespace at {
+namespace autocast {
+
+TORCH_API bool is_enabled();
+TORCH_API void set_enabled(bool enabled);
+TORCH_API void clear_cache();
+TORCH_API int increment_nesting();
+TORCH_API int decrement_nesting();
+
+} // namespace autocast
+} // namespace at

--- a/c10/core/DispatchKey.cpp
+++ b/c10/core/DispatchKey.cpp
@@ -40,6 +40,8 @@ const char* toString(DispatchKey t) {
       return "BackendSelect";
     case DispatchKey::TESTING_ONLY_GenericModeTensorId:
       return "TESTING_ONLY_GenericModeTensorId";
+    case DispatchKey::AutocastTensorId:
+      return "AutocastTensorId";
     case DispatchKey::TESTING_ONLY_GenericWrapperTensorId:
       return "TESTING_ONLY_GenericWrapperTensorId";
     default:

--- a/c10/core/DispatchKey.h
+++ b/c10/core/DispatchKey.h
@@ -127,6 +127,10 @@ enum class DispatchKey : uint8_t {
   // operators which support autograd.
   XLAPreAutograd,
 
+  // Autocasting precedes VariableTypeId, to ensure casts are autograd-exposed
+  // and inputs are saved for backward in the post-autocast type.
+  AutocastTensorId,
+
   // Here are some reserved pre-autograd keys for user-defined backends, see Note [Private use TensorId]
   PrivateUse1_PreAutogradTensorId,
   PrivateUse2_PreAutogradTensorId,

--- a/c10/core/impl/LocalDispatchKeySet.cpp
+++ b/c10/core/impl/LocalDispatchKeySet.cpp
@@ -108,7 +108,6 @@ void tls_set_dispatch_key_excluded(DispatchKey x, bool desired_state) {
 
 bool tls_is_dispatch_key_included(DispatchKey x) {
   return raw_local_dispatch_key_set.included().has(x);
-
 }
 
 void tls_set_dispatch_key_included(DispatchKey x, bool desired_state) {

--- a/docs/source/amp.rst
+++ b/docs/source/amp.rst
@@ -7,22 +7,38 @@ Automatic Mixed Precision package - torch.cuda.amp
 .. automodule:: torch.cuda.amp
 .. currentmodule:: torch.cuda.amp
 
-``torch.cuda.amp`` provides convenience methods for running networks with mixed precision,
+``torch.cuda.amp`` provides convenience methods for mixed precision,
 where some operations use the ``torch.float32`` (``float``) datatype and other operations
-use ``torch.float16`` (``half``). Some operations, like linear layers and convolutions,
-are much faster in ``float16``. Other operations, like reductions, often require the dynamic
-range of ``float32``. Networks running in mixed precision try to match each operation to its appropriate datatype.
+use ``torch.float16`` (``half``). Some ops, like linear layers and convolutions,
+are much faster in ``float16``. Other ops, like reductions, often require the dynamic
+range of ``float32``.  Mixed precision tries to match each op to its appropriate datatype.
+
+Ordinarily, "automatic mixed precision training" uses :class:`torch.cuda.amp.autocast` and
+:class:`torch.cuda.amp.GradScaler` together, as shown in the :ref:`Automatic Mixed Precision examples<amp-examples>`.
+However, :class:`autocast` and :class:`GradScaler` are modular, and may be used separately if desired.
 
 .. contents:: :local:
+
+.. _autocasting:
+
+Autocasting
+^^^^^^^^^^^
+
+.. autoclass:: autocast
+    :members:
+
+.. autofunction::  custom_fwd
+
+.. autofunction::  custom_bwd
 
 .. _gradient-scaling:
 
 Gradient Scaling
 ^^^^^^^^^^^^^^^^
 
-When training a network with mixed precision, if the forward pass for a particular op has
-``torch.float16`` inputs, the backward pass for that op will produce ``torch.float16`` gradients.
-Gradient values with small magnitudes may not be representable in ``torch.float16``.
+If the forward pass for a particular op has ``float16`` inputs, the backward pass for
+that op will produce ``float16`` gradients.
+Gradient values with small magnitudes may not be representable in ``float16``.
 These values will flush to zero ("underflow"), so the update for the corresponding parameters will be lost.
 
 To prevent underflow, "gradient scaling" multiplies the network's loss(es) by a scale factor and
@@ -30,8 +46,163 @@ invokes a backward pass on the scaled loss(es).  Gradients flowing backward thro
 then scaled by the same factor.  In other words, gradient values have a larger magnitude,
 so they don't flush to zero.
 
-The parameters' gradients (``.grad`` attributes) should be unscaled before the optimizer uses them
-to update the parameters, so the scale factor does not interfere with the learning rate.
+Each parameter's gradient (``.grad`` attribute) should be unscaled before the optimizer
+updates the parameters, so the scale factor does not interfere with the learning rate.
 
 .. autoclass:: GradScaler
     :members:
+
+.. _autocast-op-reference:
+
+Autocast Op Reference
+^^^^^^^^^^^^^^^^^^^^^
+
+.. _autocast-eligibility:
+
+Op Eligibility
+--------------
+Only CUDA ops are eligible for autocasting.
+
+Ops that run in ``float64`` or non-floating-point dtypes are not eligible, and will
+run in these types whether or not autocast is enabled.
+
+Only out-of-place ops and Tensor methods are eligible.
+In-place variants and calls that explicitly supply an ``out=...`` Tensor
+are allowed in autocast-enabled regions, but won't go through autocasting.
+For example, in an autocast-enabled region ``a.addmm(b, c)`` can autocast,
+but ``a.addmm_(b, c)`` and ``a.addmm(b, c, out=d)`` cannot.
+For best performance and stability, prefer out-of-place ops in autocast-enabled
+regions.
+
+Ops called with an explicit `dtype=...` argument are not eligible,
+and will produce output that respects the `dtype` argument.
+
+Op-Specific Behavior
+--------------------
+The following lists describe the behavior of eligible ops in autocast-enabled regions.
+These ops always go through autocasting whether they are invoked as part of a :class:`torch.nn.Module`,
+as a function, or as a :class:`torch.Tensor` method. If functions are exposed in multiple namespaces,
+they go through autocasting regardless of the namespace.
+
+Ops not listed below do not go through autocasting.  They run in the type
+defined by their inputs.  However, autocasting may still change the type
+in which unlisted ops run if they're downstream from autocasted ops.
+
+If an op is unlisted, we assume it's numerically stable in ``float16``.
+If you believe an unlisted op is numerically unstable in ``float16``,
+please file an issue.
+
+Ops that can autocast to ``float16``
+""""""""""""""""""""""""""""""""""""
+
+``__matmul__``,
+``addbmm``,
+``addmm``,
+``addmv``,
+``addr``,
+``baddbmm``,
+``bmm``,
+``chain_matmul``,
+``conv1d``,
+``conv2d``,
+``conv3d``,
+``conv_transpose1d``,
+``conv_transpose2d``,
+``conv_transpose3d``,
+``linear``,
+``matmul``,
+``mm``,
+``mv``,
+``prelu``
+
+Ops that can autocast to ``float32``
+""""""""""""""""""""""""""""""""""""
+
+``__pow__``,
+``__rdiv__``,
+``__rpow__``,
+``__rtruediv__``,
+``acos``,
+``asin``,
+``binary_cross_entropy_with_logits``,
+``cosh``,
+``cosine_embedding_loss``,
+``cdist``,
+``cosine_similarity``,
+``cross_entropy``,
+``cumprod``,
+``cumsum``,
+``dist``,
+``erfinv``,
+``exp``,
+``expm1``,
+``gelu``,
+``group_norm``,
+``hinge_embedding_loss``,
+``kl_div``,
+``l1_loss``,
+``layer_norm``,
+``log``,
+``log_softmax``,
+``log10``,
+``log1p``,
+``log2``,
+``margin_ranking_loss``,
+``mse_loss``,
+``multilabel_margin_loss``,
+``multi_margin_loss``,
+``nll_loss``,
+``norm``,
+``normalize``,
+``pdist``,
+``poisson_nll_loss``,
+``pow``,
+``prod``,
+``reciprocal``,
+``rsqrt``,
+``sinh``,
+``smooth_l1_loss``,
+``soft_margin_loss``,
+``softmax``,
+``softmin``,
+``softplus``,
+``sum``,
+``renorm``,
+``tan``,
+``triplet_margin_loss``
+
+Ops that promote to the widest input type
+"""""""""""""""""""""""""""""""""""""""""
+These ops don't require a particular dtype for stability, but take multiple inputs
+and require that the inputs' dtypes match.  If all of the inputs are
+``float16``, the op runs in ``float16``.  If any of the inputs is ``float32``,
+autocast casts all inputs to ``float32`` and runs the op in ``float32``.
+
+``addcdiv``,
+``addcmul``,
+``atan2``,
+``bilinear``,
+``cat``,
+``cross``,
+``dot``,
+``equal``,
+``stack``,
+``tensordot``
+
+Some ops not listed here (e.g., binary ops like ``add``) natively promote
+inputs without autocasting's intervention.  If inputs are a mixture of ``float16``
+and ``float32``, these ops run in ``float32`` and produce ``float32`` output,
+regardless of whether autocast is enabled.
+
+Prefer ``binary_cross_entropy_with_logits`` over ``binary_cross_entropy``
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+The backward passes of :func:`torch.nn.functional.binary_cross_entropy` (and :mod:`torch.nn.BCELoss`, which wraps it)
+can produce gradients that aren't representable in ``float16``.  In autocast-enabled regions, the forward input
+may be ``float16``, which means the backward gradient must be representable in ``float16`` (autocasting ``float16``
+forward inputs to ``float32`` doesn't help, because that cast must be reversed in backward).
+Therefore, ``binary_cross_entropy`` and ``BCELoss`` raise an error in autocast-enabled regions.
+
+Many models use a sigmoid layer right before the binary cross entropy layer.
+In this case, combine the two layers using :func:`torch.nn.functional.binary_cross_entropy_with_logits`
+or :mod:`torch.nn.BCEWithLogitsLoss`.  ``binary_cross_entropy_with_logits`` and ``BCEWithLogits``
+are safe to autocast.

--- a/docs/source/amp.rst
+++ b/docs/source/amp.rst
@@ -74,8 +74,8 @@ but ``a.addmm_(b, c)`` and ``a.addmm(b, c, out=d)`` cannot.
 For best performance and stability, prefer out-of-place ops in autocast-enabled
 regions.
 
-Ops called with an explicit `dtype=...` argument are not eligible,
-and will produce output that respects the `dtype` argument.
+Ops called with an explicit ``dtype=...`` argument are not eligible,
+and will produce output that respects the ``dtype`` argument.
 
 Op-Specific Behavior
 --------------------

--- a/docs/source/notes/amp_examples.rst
+++ b/docs/source/notes/amp_examples.rst
@@ -5,24 +5,30 @@ Automatic Mixed Precision examples
 
 .. currentmodule:: torch.cuda.amp
 
-.. contents:: :local:
+Ordinarily, "automatic mixed precision training" means training with
+:class:`torch.cuda.amp.autocast` and :class:`torch.cuda.amp.GradScaler` together.
 
-.. _gradient-scaling-examples:
-
-Gradient Scaling
-^^^^^^^^^^^^^^^^
-
-Gradient scaling helps prevent gradient underflow when training with mixed precision,
-as explained :ref:`here<gradient-scaling>`.
+Instances of :class:`torch.cuda.amp.autocast` enable autocasting for chosen regions.
+Autocasting automatically chooses the precision for GPU operations to improve performance
+while maintaining accuracy.
 
 Instances of :class:`torch.cuda.amp.GradScaler` help perform the steps of
-gradient scaling conveniently, as shown in the following code snippets.
+gradient scaling conveniently.  Gradient scaling improves convergence for networks with ``float16``
+gradients by minimizing gradient underflow, as explained :ref:`here<gradient-scaling>`.
 
+:class:`torch.cuda.amp.autocast` and :class:`torch.cuda.amp.GradScaler` are modular.
+In the samples below, each is used as its individual documentation suggests.
 
-Typical Use
------------
+.. contents:: :local:
+
+Typical Mixed Precision Training
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 ::
+
+    # Creates model and optimizer in default precision
+    model = Net().cuda()
+    optimizer = optim.SGD(model.parameters(), ...)
 
     # Creates a GradScaler once at the beginning of training.
     scaler = GradScaler()
@@ -30,10 +36,15 @@ Typical Use
     for epoch in epochs:
         for input, target in data:
             optimizer.zero_grad()
-            output = model(input)
-            loss = loss_fn(output, target)
 
-            # Scales the loss, and calls backward() on the scaled loss to create scaled gradients.
+            # Runs the forward pass with autocasting.
+            with autocast():
+                output = model(input)
+                loss = loss_fn(output, target)
+
+            # Scales loss.  Calls backward() on scaled loss to create scaled gradients.
+            # Backward passes under autocast are not recommended.
+            # Backward ops run in the same precision that autocast used for corresponding forward ops.
             scaler.scale(loss).backward()
 
             # scaler.step() first unscales the gradients of the optimizer's assigned params.
@@ -47,7 +58,7 @@ Typical Use
 .. _working-with-unscaled-gradients:
 
 Working with Unscaled Gradients
--------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 All gradients produced by ``scaler.scale(loss).backward()`` are scaled.  If you wish to modify or inspect
 the parameters' ``.grad`` attributes between ``backward()`` and ``scaler.step(optimizer)``,  you should
@@ -63,7 +74,7 @@ If your model or models contain other parameters that were assigned to another o
 parameters' gradients as well.
 
 Gradient clipping
-"""""""""""""""""
+-----------------
 
 Calling ``scaler.unscale_(optimizer)`` before clipping enables you to clip unscaled gradients as usual::
 
@@ -72,8 +83,9 @@ Calling ``scaler.unscale_(optimizer)`` before clipping enables you to clip unsca
     for epoch in epochs:
         for input, target in data:
             optimizer.zero_grad()
-            output = model(input)
-            loss = loss_fn(output, target)
+            with autocast():
+                output = model(input)
+                loss = loss_fn(output, target)
             scaler.scale(loss).backward()
 
             # Unscales the gradients of optimizer's assigned params in-place
@@ -93,25 +105,30 @@ Calling ``scaler.unscale_(optimizer)`` before clipping enables you to clip unsca
 this iteration, so ``scaler.step(optimizer)`` knows not to redundantly unscale gradients before
 (internally) calling ``optimizer.step()``.
 
+.. currentmodule:: torch.cuda.amp.GradScaler
+
 .. warning::
     :meth:`unscale_` should only be called once per optimizer per :meth:`step` call,
     and only after all gradients for that optimizer's assigned parameters have been accumulated.
     Calling :meth:`unscale_` twice for a given optimizer between each :meth:`step` triggers a RuntimeError.
 
+
 Working with Scaled Gradients
------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 For some operations, you may need to work with scaled gradients in a setting where
-``scaler.unscale_`` is unsuitable.
+:meth:`unscale_` is unsuitable.
+
+.. currentmodule:: torch.cuda.amp
 
 Gradient penalty
-""""""""""""""""
+----------------
 
-A gradient penalty implementation typically creates gradients out-of-place using
+A gradient penalty implementation commonly creates gradients using
 :func:`torch.autograd.grad`, combines them to create the penalty value,
 and adds the penalty value to the loss.
 
-Here's an ordinary example of an L2 penalty without gradient scaling::
+Here's an ordinary example of an L2 penalty without gradient scaling or autocasting::
 
     for epoch in epochs:
         for input, target in data:
@@ -119,7 +136,7 @@ Here's an ordinary example of an L2 penalty without gradient scaling::
             output = model(input)
             loss = loss_fn(output, target)
 
-            # Creates some gradients out-of-place
+            # Creates gradients
             grad_params = torch.autograd.grad(loss, model.parameters(), create_graph=True)
 
             # Computes the penalty term and adds it to the loss
@@ -133,9 +150,12 @@ Here's an ordinary example of an L2 penalty without gradient scaling::
             optimizer.step()
 
 To implement a gradient penalty *with* gradient scaling, the loss passed to
-:func:`torch.autograd.grad` should be scaled.  The resulting out-of-place gradients
+:func:`torch.autograd.grad` should be scaled.  The resulting gradients
 will therefore be scaled, and should be unscaled before being combined to create the
 penalty value.
+
+Also, the penalty term computation is part of the forward pass, and therefore should be
+inside an :class:`autocast` context.
 
 Here's how that looks for the same L2 penalty::
 
@@ -144,25 +164,28 @@ Here's how that looks for the same L2 penalty::
     for epoch in epochs:
         for input, target in data:
             optimizer.zero_grad()
-            output = model(input)
-            loss = loss_fn(output, target)
+            with autocast():
+                output = model(input)
+                loss = loss_fn(output, target)
 
-            # Scales the loss for the out-of-place backward pass, resulting in scaled grad_params
+            # Scales the loss for autograd.grad's backward pass, resulting in scaled grad_params
             scaled_grad_params = torch.autograd.grad(scaler.scale(loss), model.parameters(), create_graph=True)
 
-            # Unscales grad_params before computing the penalty.  grad_params are not owned
-            # by any optimizer, so ordinary division is used instead of scaler.unscale_:
+            # Creates unscaled grad_params before computing the penalty. scaled_grad_params are
+            # not owned by any optimizer, so ordinary division is used instead of scaler.unscale_:
             inv_scale = 1./scaler.get_scale()
-            grad_params = [p*inv_scale for p in scaled_grad_params]
+            grad_params = [p * inv_scale for p in scaled_grad_params]
 
             # Computes the penalty term and adds it to the loss
-            grad_norm = 0
-            for grad in grad_params:
-                grad_norm += grad.pow(2).sum()
-            grad_norm = grad_norm.sqrt()
-            loss = loss + grad_norm
+            with autocast():
+                grad_norm = 0
+                for grad in grad_params:
+                    grad_norm += grad.pow(2).sum()
+                grad_norm = grad_norm.sqrt()
+                loss = loss + grad_norm
 
-            # Applies scaling to the backward call as usual.  Accumulates leaf gradients that are correctly scaled.
+            # Applies scaling to the backward call as usual.
+            # Accumulates leaf gradients that are correctly scaled.
             scaler.scale(loss).backward()
 
             # step() and update() proceed as usual.
@@ -170,14 +193,16 @@ Here's how that looks for the same L2 penalty::
             scaler.update()
 
 
-Working with Multiple Losses and Optimizers
--------------------------------------------
+Working with Multiple Models, Losses, and Optimizers
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If your network has multiple losses, you must call ``scaler.scale`` on each of them individually.
-If your network has multiple optimizers, you may call ``scaler.unscale_`` on any of them individually,
-and you must call ``scaler.step`` on each of them individually.
+.. currentmodule:: torch.cuda.amp.GradScaler
 
-However, ``scaler.update()`` should only be called once,
+If your network has multiple losses, you must call :meth:`scaler.scale<scale>` on each of them individually.
+If your network has multiple optimizers, you may call :meth:`scaler.unscale_<unscale_>` on any of them individually,
+and you must call :meth:`scaler.step<step>` on each of them individually.
+
+However, :meth:`scaler.update<update>` should only be called once,
 after all optimizers used this iteration have been stepped::
 
     scaler = torch.cuda.amp.GradScaler()
@@ -186,10 +211,11 @@ after all optimizers used this iteration have been stepped::
         for input, target in data:
             optimizer0.zero_grad()
             optimizer1.zero_grad()
-            output0 = model0(input)
-            output1 = model1(input)
-            loss0 = loss_fn(2 * output0 + 3 * output1, target)
-            loss1 = loss_fn(3 * output0 - 5 * output1, target)
+            with autocast():
+                output0 = model0(input)
+                output1 = model1(input)
+                loss0 = loss_fn(2 * output0 + 3 * output1, target)
+                loss1 = loss_fn(3 * output0 - 5 * output1, target)
 
             scaler.scale(loss0).backward(retain_graph=True)
             scaler.scale(loss1).backward()
@@ -203,8 +229,155 @@ after all optimizers used this iteration have been stepped::
 
             scaler.update()
 
-Each optimizer independently checks its gradients for infs/NaNs, and therefore makes an independent decision
+Each optimizer checks its gradients for infs/NaNs and makes an independent decision
 whether or not to skip the step.  This may result in one optimizer skipping the step
 while the other one does not.  Since step skipping occurs rarely (every several hundred iterations)
 this should not impede convergence.  If you observe poor convergence after adding gradient scaling
-to a multiple-optimizer model, please file an issue.
+to a multiple-optimizer model, please report a bug.
+
+.. currentmodule:: torch.cuda.amp
+
+.. _amp-multigpu:
+
+Working with Multiple GPUs
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The issues described here only affect :class:`autocast`.  :class:`GradScaler`\ 's usage is unchanged.
+
+.. _amp-dataparallel:
+
+DataParallel in a single process
+--------------------------------
+
+:class:`torch.nn.DataParallel` spawns threads to run the forward pass on each device.
+The autocast state is thread local, so the following will not work::
+
+    model = MyModel()
+    dp_model = nn.DataParallel(model)
+
+    # Sets autocast in the main thread
+    with autocast():
+        # dp_model's internal threads won't autocast.  The main thread's autocast state has no effect.
+        output = dp_model(input)
+        # loss_fn still autocasts, but it's too late...
+        loss = loss_fn(output)
+
+The fix is simple.  Enable autocast as part of ``MyModel.forward``::
+
+    MyModel(nn.Module):
+        ...
+        @autocast()
+        def forward(self, input):
+           ...
+
+    # Alternatively
+    MyModel(nn.Module):
+        ...
+        def forward(self, input):
+            with autocast():
+                ...
+
+The following now autocasts in ``dp_model``'s threads (which execute ``forward``) and the main thread
+(which executes ``loss_fn``)::
+
+    model = MyModel()
+    dp_model = nn.DataParallel(model)
+
+    with autocast():
+        output = dp_model(input)
+        loss = loss_fn(output)
+
+DistributedDataParallel, one GPU per process
+--------------------------------------------
+
+:class:`torch.nn.parallel.DistributedDataParallel`'s documentation recommends one GPU per process for best
+performance.  In this case, ``DistributedDataParallel`` does not spawn threads internally,
+so usages of :class:`autocast` and :class:`GradScaler` are not affected.
+
+DistributedDataParallel, multiple GPUs per process
+--------------------------------------------------
+
+Here :class:`torch.nn.parallel.DistributedDataParallel` may spawn a side thread to run the forward pass on each
+device, like :class:`torch.nn.DataParallel`.  :ref:`The fix is the same<amp-dataparallel>`:
+apply autocast as part of your model's ``forward`` method to ensure it's enabled in side threads.
+
+.. _amp-custom-examples:
+
+Autocast and Custom Autograd Functions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If your network uses :ref:`custom autograd functions<extending-autograd>`
+(subclasses of :class:`torch.autograd.Function`), changes are required for
+autocast compatibility if any function
+
+* takes multiple floating-point Tensor inputs,
+* wraps any autocastable op (see the :ref:`Autocast Op Reference<autocast-op-reference>`), or
+* requires a particular ``dtype`` (for example, if it wraps
+  `CUDA extensions <https://pytorch.org/tutorials/advanced/cpp_extension.html>`_
+  that were only compiled for ``dtype``).
+
+In all cases, if you're importing the function and can't alter its definition, a safe fallback
+is to disable autocast and force execution in ``float32`` ( or ``dtype``) at any points of use where errors occur::
+
+    with autocast():
+        ...
+        with autocast(enabled=False):
+            output = imported_function(input1.float(), input2.float())
+
+If you're the function's author (or can alter its definition) a better solution is to use the
+:func:`torch.cuda.amp.custom_fwd` and :func:`torch.cuda.amp.custom_bwd` decorators as shown in
+the relevant case below.
+
+Functions with multiple inputs or autocastable ops
+--------------------------------------------------
+
+Apply :func:`custom_fwd` and :func:`custom_bwd` (with no arguments) to ``forward`` and ``backward``
+respectively.  These ensure ``forward`` executes with the current autocast state and ``backward``
+executes with the same autocast state as ``forward`` (which can prevent type mismatch errors)::
+
+    class MyMM(torch.autograd.Function):
+        @staticmethod
+        @custom_fwd
+        def forward(ctx, a, b):
+            ctx.save_for_backward(a, b)
+            return a.mm(b)
+        @staticmethod
+        @custom_bwd
+        def backward(ctx, grad):
+            a, b = ctx.saved_tensors
+            return grad.mm(b.t()), a.t().mm(grad)
+
+Now ``MyMM`` can be invoked anywhere, without disabling autocast or manually casting inputs::
+
+    mymm = MyMM.apply
+
+    with autocast():
+        output = mymm(input1, input2)
+
+Functions that need a particular dtype
+--------------------------------------
+
+Apply :func:`custom_fwd(cast_inputs=torch.float32)<custom_fwd>` to ``forward``
+and :func:`custom_bwd<custom_bwd>` (with no arguments) to ``backward``.
+With ``cast_inputs=torch.float32``, these disable autocast in ``forward`` and ``backward``,
+and ``forward`` casts incoming floating-point CUDA Tensors to ``float32``::
+
+    class MyFloat32Func(torch.autograd.Function):
+        @staticmethod
+        @custom_fwd(cast_inputs=torch.float32)
+        def forward(ctx, input):
+            ctx.save_for_backward(input)
+            ...
+            return fwd_output
+        @staticmethod
+        @custom_bwd
+        def backward(ctx, grad):
+            ...
+
+Now ``MyFloat32Func`` can be invoked anywhere, without disabling autocast or manually casting inputs::
+
+    func = MyFloat32Func.apply
+
+    with autocast():
+        # func will run in float32, regardless of the surrounding autocast state
+        output = func(input)

--- a/docs/source/notes/amp_examples.rst
+++ b/docs/source/notes/amp_examples.rst
@@ -44,7 +44,7 @@ Typical Mixed Precision Training
 
             # Scales loss.  Calls backward() on scaled loss to create scaled gradients.
             # Backward passes under autocast are not recommended.
-            # Backward ops run in the same precision that autocast used for corresponding forward ops.
+            # Backward ops run in the same dtype that autocast used for corresponding forward ops.
             scaler.scale(loss).backward()
 
             # scaler.step() first unscales the gradients of the optimizer's assigned params.
@@ -331,7 +331,7 @@ the relevant case below.
 Functions with multiple inputs or autocastable ops
 --------------------------------------------------
 
-Apply :func:`custom_fwd` and :func:`custom_bwd` (with no arguments) to ``forward`` and ``backward``
+Apply :func:`custom_fwd<custom_fwd>` and :func:`custom_bwd<custom_bwd>` (with no arguments) to ``forward`` and ``backward``
 respectively.  These ensure ``forward`` executes with the current autocast state and ``backward``
 executes with the same autocast state as ``forward`` (which can prevent type mismatch errors)::
 

--- a/docs/source/notes/extending.rst
+++ b/docs/source/notes/extending.rst
@@ -5,6 +5,8 @@ In this note we'll cover ways of extending :mod:`torch.nn`,
 :mod:`torch.autograd`, :mod:`torch`, and writing custom C extensions utilizing our C
 libraries.
 
+.. _extending-autograd:
+
 Extending :mod:`torch.autograd`
 -------------------------------
 

--- a/test/distributed/test_data_parallel.py
+++ b/test/distributed/test_data_parallel.py
@@ -10,6 +10,7 @@ from torch.testing._internal.common_cuda import TEST_MULTIGPU, TEST_CUDA
 from torch.testing._internal.common_utils import run_tests, TestCase, repeat_test_for_types, ALL_TENSORTYPES, PY3
 from torch.testing._internal.common_utils import _assertGradAndGradgradChecks
 from torch.testing._internal.common_utils import dtype2prec_DONTUSE
+from torch.testing._internal.common_utils import skipIfRocm
 import torch.nn.functional as F
 
 torch.set_default_dtype(torch.double)
@@ -651,6 +652,21 @@ class TestDataParallel(TestCase):
         module = Net(self).cuda()
         dpm = dp.DataParallel(module)
         dpm(torch.rand(4, 3, 6, 5))
+
+    @unittest.skipIf(not TEST_MULTIGPU, "multi-GPU not supported")
+    @skipIfRocm
+    def test_autocast(self):
+        class Model(torch.nn.Linear):
+            def __init__(self):
+                super(Model, self).__init__(8, 8)
+
+            @torch.cuda.amp.autocast()
+            def forward(self, input):
+                return super(Model, self).forward(input)
+
+        model = dp.DataParallel(Model().cuda().to(dtype=torch.float32))
+        input = torch.randn((8, 8), dtype=torch.float32, device="cuda")
+        self.assertTrue(model(input).dtype is torch.float16)
 
 
 if __name__ == '__main__':

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -17,7 +17,7 @@ import torch
 import torch.cuda
 import torch.cuda.comm as comm
 from torch import multiprocessing as mp
-from torch._six import inf, nan
+from torch._six import inf, nan, container_abcs
 
 from test_torch import _TestTorchMixin
 
@@ -26,6 +26,7 @@ from torch.testing._internal.common_methods_invocations import tri_tests_args, t
 from torch.testing._internal.common_utils import TestCase, get_gpu_type, freeze_rng_state, run_tests, \
     PY3, IS_WINDOWS, NO_MULTIPROCESSING_SPAWN, skipIfRocm, \
     load_tests, slowTest, skipCUDANonDefaultStreamIf, TEST_WITH_ROCM, TEST_NUMPY
+from torch.testing._internal.autocast_test_lists import AutocastTestLists
 
 # load_tests from common_utils is used to automatically filter tests for
 # sharding on sandcastle. This line silences flake warnings
@@ -96,6 +97,13 @@ class TestCuda(TestCase):
     _do_cuda_non_default_stream = True
     FIFTY_MIL_CYCLES = 50000000
 
+    def setUp(self):
+        super(TestCuda, self).setUp()
+        self.autocast_lists = AutocastTestLists(torch.device('cuda:0'))
+
+    def tearDown(self):
+        del self.autocast_lists
+        super(TestCuda, self).tearDown()
 
     def _check_memory_stat_consistency(self):
         snapshot = torch.cuda.memory_snapshot()
@@ -2115,7 +2123,7 @@ t2.start()
         return self._create_scaling_models_optimizers(device=device) + (data, loss_fn, skip_iter)
 
     # _run_scaling_case generalizes some single-optimizer test logic to avoid too much copy-pasting below.
-    def _run_scaling_case(self, run, unskipped, skipped):
+    def _run_scaling_case(self, run, unskipped, skipped, atol=1e-7):
         # Ensure scaling can be disabled without changing user control flow.
         for enabled in True, False:
             mod_control, mod_scaling, opt_control, opt_scaling, data, loss_fn, skip_iter = self._create_scaling_case()
@@ -2137,7 +2145,29 @@ t2.start()
                 self.assertTrue(scaler.get_scale() == 1.0)
 
             for c, s in zip(mod_control.parameters(), mod_scaling.parameters()):
-                self.assertTrue(torch.allclose(c, s, atol=1e-7))
+                self.assertTrue(torch.allclose(c, s, atol=atol))
+
+    # Compares no scaling + no autocasting against scaling + autocasting.
+    def test_grad_scaling_autocast(self):
+        def run(data, model, optimizer, scaler, loss_fn, skip_iter, try_scaling_api):
+            for i, (input, target) in enumerate(data):
+                optimizer.zero_grad()
+                with torch.cuda.amp.autocast(enabled=try_scaling_api):
+                    output = model(input)
+                    loss = loss_fn(output, target)
+                if try_scaling_api:
+                    scaler.scale(loss).backward()
+                    if i == skip_iter and scaler.is_enabled():
+                        model[1].weight.grad.data.fill_(float('inf'))
+                    scaler.step(optimizer)
+                    scaler.update()
+                else:
+                    loss.backward()
+                    if (not scaler.is_enabled()) or (i != skip_iter):
+                        optimizer.step()
+
+        # sets atol=1e-3 because we're comparing pure fp32 arithmetic vs a mixture of fp16 and fp32
+        self._run_scaling_case(run, unskipped=3, skipped=1, atol=1e-3)
 
     def test_grad_scaling_clipping(self):
         def run(data, model, optimizer, scaler, loss_fn, skip_iter, try_scaling_api):
@@ -2520,6 +2550,246 @@ t2.start()
 
             for t in range(num_threads):
                 self.assertEqual(results[t].sum().item(), size * size)
+
+    def _run_autocast_outofplace(self, op, args, run_as_type, out_type=None, module=torch, add_kwargs=None):
+        # helper to cast args
+        def cast(val, to_type):
+            if isinstance(val, torch.Tensor):
+                return val.to(to_type) if val.is_floating_point() else val
+            elif isinstance(val, container_abcs.Iterable):
+                return type(val)(cast(v, to_type) for v in val)
+            else:
+                return val
+
+        if add_kwargs is None:
+            add_kwargs = {}
+
+        self.assertFalse(torch.is_autocast_enabled())
+        with torch.cuda.amp.autocast():
+            self.assertTrue(torch.is_autocast_enabled())
+
+            out_type = out_type if out_type is not None else run_as_type
+            output = output_method = None
+
+            # Try module.* variant, if requested:
+            if module is not None and hasattr(module, op):
+                output = getattr(module, op)(*args, **add_kwargs)
+                if isinstance(output, torch.Tensor):
+                    self.assertTrue(out_type == output.dtype,
+                                    "autocast for torch.{} produced {}, should produce {}"
+                                    .format(op, output.dtype, out_type))
+
+            # Try Tensor.* variant:
+            if hasattr(torch.Tensor, op):
+                output_method = getattr(args[0], op)(*args[1:], **add_kwargs)
+                if isinstance(output_method, torch.Tensor):
+                    self.assertTrue(out_type == output_method.dtype,
+                                    "autocast for torch.{} produced {}, should produce torch.{}"
+                                    .format(op, output_method.dtype, out_type))
+
+            self.assertTrue((output is not None) or (output_method is not None),
+                            "{} not found as an attribute on either Tensor or the requested module {}".format(
+                            op, module))
+
+            # If both torch.* and Tensor.* variants were found, check outputs are identical
+            if (output is not None) and (output_method is not None):
+                self.assertTrue(type(output) == type(output_method))
+                comparison = torch.equal(output, output_method) if isinstance(output, torch.Tensor) \
+                    else (output == output_method)
+                self.assertTrue(comparison, "torch.{0} result did not match Tensor.{0} result".format(op))
+
+            # Compare numerics to Python-side "autocasting" that (we expect) does the same thing
+            # as the C++-side autocasting, and should be bitwise accurate.
+            output_to_compare = output if output is not None else output_method
+            with torch.cuda.amp.autocast(enabled=False):
+                self.assertFalse(torch.is_autocast_enabled())
+
+                if module is not None and hasattr(module, op):
+                    control = getattr(module, op)(*cast(args, run_as_type), **add_kwargs)
+                else:
+                    control = getattr(args[0].to(run_as_type), op)(*cast(args[1:], run_as_type), **add_kwargs)
+                self.assertTrue(type(output_to_compare) == type(control))
+                comparison = torch.equal(output_to_compare, control) if isinstance(control, torch.Tensor) \
+                    else (output_to_compare == control)
+                self.assertTrue(comparison, "torch.{} result did not match control".format(op))
+            self.assertTrue(torch.is_autocast_enabled())
+        self.assertFalse(torch.is_autocast_enabled())
+
+    def args_maybe_kwargs(self, op_with_args):
+        if len(op_with_args) == 2:
+            return op_with_args[0], op_with_args[1], {}
+        else:
+            return op_with_args[0], op_with_args[1], op_with_args[2]
+
+    @skipIfRocm
+    @unittest.skipIf(not TEST_CUDNN, 'CUDNN not available')
+    def test_autocast_torch_fp16(self):
+        with torch.backends.cudnn.flags(deterministic=True):
+            for op, args in self.autocast_lists.torch_fp16:
+                self._run_autocast_outofplace(op, args, torch.float16)
+
+    @skipIfRocm
+    @unittest.skipIf(not TEST_CUDNN, 'CUDNN not available')
+    def test_autocast_torch_fp32(self):
+        for op_with_args in self.autocast_lists.torch_fp32:
+            op, args, maybe_kwargs = self.args_maybe_kwargs(op_with_args)
+            self._run_autocast_outofplace(op, args, torch.float32, add_kwargs=maybe_kwargs)
+
+    @skipIfRocm
+    @unittest.skipIf(not TEST_CUDNN, 'CUDNN not available')
+    def test_autocast_torch_need_autocast_promote(self):
+        for op, args in self.autocast_lists.torch_need_autocast_promote:
+            self._run_autocast_outofplace(op, args, torch.float32)
+
+    @skipIfRocm
+    @unittest.skipIf(not TEST_CUDNN, 'CUDNN not available')
+    def test_autocast_torch_expect_builtin_promote(self):
+        for op, args, out_type in self.autocast_lists.torch_expect_builtin_promote:
+            self._run_autocast_outofplace(op, args, torch.float32, out_type=out_type)
+
+    @skipIfRocm
+    @unittest.skipIf(not TEST_CUDNN, 'CUDNN not available')
+    def test_autocast_nn_fp16(self):
+        with torch.backends.cudnn.flags(deterministic=True):
+            for op, args in self.autocast_lists.nn_fp16:
+                self._run_autocast_outofplace(op, args, torch.float16, module=torch._C._nn)
+
+    @skipIfRocm
+    @unittest.skipIf(not TEST_CUDNN, 'CUDNN not available')
+    def test_autocast_nn_fp32(self):
+        for op, args in self.autocast_lists.nn_fp32:
+            self._run_autocast_outofplace(op, args, torch.float32, module=torch._C._nn)
+
+    @skipIfRocm
+    @unittest.skipIf(not TEST_CUDNN, 'CUDNN not available')
+    def test_autocast_methods_fp16(self):
+        with torch.backends.cudnn.flags(deterministic=True):
+            for op, args in self.autocast_lists.methods_fp16:
+                self._run_autocast_outofplace(op, args, torch.float16, module=None)
+
+    @skipIfRocm
+    @unittest.skipIf(not TEST_CUDNN, 'CUDNN not available')
+    def test_autocast_methods_fp32(self):
+        for op, args in self.autocast_lists.methods_fp32:
+            self._run_autocast_outofplace(op, args, torch.float32, module=None)
+
+    @skipIfRocm
+    @unittest.skipIf(not TEST_CUDNN, 'CUDNN not available')
+    def test_autocast_methods_expect_builtin_promote(self):
+        for op, args, out_type in self.autocast_lists.methods_expect_builtin_promote:
+            self._run_autocast_outofplace(op, args, torch.float32, module=None, out_type=out_type)
+
+    @skipIfRocm
+    def test_autocast_banned(self):
+        with torch.cuda.amp.autocast():
+            for op, args, module in self.autocast_lists.banned:
+                with self.assertRaises(RuntimeError):
+                    getattr(module, op)(*args)
+
+    @skipIfRocm
+    def test_autocast_ignored_types(self):
+        with torch.cuda.amp.autocast():
+            for ignore_type in (torch.double, torch.int32):
+                a_ignore = torch.ones((8, 8), dtype=ignore_type, device="cuda:0")
+                b_ignore = torch.ones((8, 8), dtype=ignore_type, device="cuda:0")
+                c_16 = torch.ones((8, 8), dtype=torch.float16, device="cuda:0")
+
+                # Tests if CastPolicy::fp16 ops ignore double and int
+                # Currently, no ops belonging to this policy support integer inputs.
+                if ignore_type is torch.double:
+                    with self.assertRaises(RuntimeError):
+                        torch.mm(a_ignore, c_16)
+                    with torch.cuda.amp.autocast(enabled=False):
+                        type_no_autocast = torch.mm(a_ignore, b_ignore).dtype
+                    self.assertTrue(torch.mm(a_ignore, b_ignore).dtype is type_no_autocast)
+
+                # Tests if CastPolicy::fp32 ops ignore double and int
+                with torch.cuda.amp.autocast(enabled=False):
+                    type_no_autocast = torch.pow(a_ignore, 2.0).dtype
+                self.assertTrue(torch.pow(a_ignore, 2.0).dtype is type_no_autocast)
+
+                # Tests if CastPolicy::fp32_set_opt_dtype ops ignore double and int
+                with torch.cuda.amp.autocast(enabled=False):
+                    type_no_autocast = torch.sum(a_ignore).dtype
+                self.assertTrue(torch.sum(a_ignore).dtype is type_no_autocast)
+
+                # Tests if CastPolicy::fp32_append_dtype ops ignore double and int
+                # Currently, no ops belonging to this policy support integer inputs.
+                if ignore_type is torch.double:
+                    with torch.cuda.amp.autocast(enabled=False):
+                        type_no_autocast = torch.norm(a_ignore).dtype
+                    self.assertTrue(torch.norm(a_ignore).dtype is type_no_autocast)
+
+                # Tests if CastPolicy::promote ops ignore double and int
+                with self.assertRaises(RuntimeError):
+                    torch.cat((a_ignore, c_16))
+                with torch.cuda.amp.autocast(enabled=False):
+                    type_no_autocast = torch.cat((a_ignore, b_ignore)).dtype
+                self.assertTrue(torch.cat((a_ignore, b_ignore)).dtype is type_no_autocast)
+
+    @skipIfRocm
+    def test_autocast_custom_enabled(self):
+        class MyMM(torch.autograd.Function):
+            @staticmethod
+            @torch.cuda.amp.custom_fwd
+            def forward(ctx, a, b):
+                self.assertTrue(a.dtype is torch.float32)
+                self.assertTrue(b.dtype is torch.float32)
+                self.assertTrue(torch.is_autocast_enabled())
+                ctx.save_for_backward(a, b)
+                return a.mm(b)
+
+            @staticmethod
+            @torch.cuda.amp.custom_bwd
+            def backward(ctx, grad):
+                self.assertTrue(torch.is_autocast_enabled())
+                a, b = ctx.saved_tensors
+                return grad.mm(b.t()), a.t().mm(grad)
+
+        mymm = MyMM.apply
+
+        x = torch.randn((8, 8), device="cuda", dtype=torch.float32, requires_grad=True)
+        y = torch.randn((8, 8), device="cuda", dtype=torch.float32, requires_grad=True)
+
+        with torch.cuda.amp.autocast():
+            output = mymm(x, y)
+            self.assertTrue(output.dtype is torch.float16)
+            loss = output.sum()
+        loss.backward()
+
+    @skipIfRocm
+    def test_autocast_custom_disabled(self):
+        class MyMM(torch.autograd.Function):
+            @staticmethod
+            @torch.cuda.amp.custom_fwd(cast_inputs=torch.float32)
+            def forward(ctx, a, container):
+                b = container[1][0]
+                self.assertTrue(a.dtype is torch.float32)
+                self.assertTrue(b.dtype is torch.float32)
+                self.assertFalse(torch.is_autocast_enabled())
+                ctx.save_for_backward(a, b)
+                return a.mm(b)
+
+            @staticmethod
+            @torch.cuda.amp.custom_bwd
+            def backward(ctx, grad):
+                self.assertFalse(torch.is_autocast_enabled())
+                a, b = ctx.saved_tensors
+                return grad.mm(b.t()), None
+
+        mymm = MyMM.apply
+
+        x = torch.randn((8, 8), device="cuda", dtype=torch.float16, requires_grad=True)
+        # Puts one input tensor in a nested container.  y's contained Tensor won't receive a gradient,
+        # because torch.autograd.Function can't hand gradients back to non-Tensor forward arguments.
+        # Sets requires_grad=False explicitly so we don't lie about expecting a gradient.
+        y = (0, {0: torch.randn((8, 8), device="cuda", dtype=torch.float16, requires_grad=False)})
+
+        with torch.cuda.amp.autocast():
+            output = mymm(x, y)
+            self.assertTrue(output.dtype is torch.float32)
+            loss = output.sum()
+        loss.backward()
 
     @slowTest
     @unittest.skipIf(not TEST_LARGE_TENSOR, "not enough memory")

--- a/torch/_overrides.py
+++ b/torch/_overrides.py
@@ -128,6 +128,11 @@ def get_ignored_functions():
         torch.nn.functional.sigmoid,
         torch.nn.functional.hardsigmoid,
         torch.nn.functional.tanh,
+        torch.set_autocast_enabled,
+        torch.is_autocast_enabled,
+        torch.clear_autocast_cache,
+        torch.autocast_increment_nesting,
+        torch.autocast_decrement_nesting,
     )
 
 def get_testing_overrides():

--- a/torch/csrc/autograd/init.cpp
+++ b/torch/csrc/autograd/init.cpp
@@ -3,6 +3,7 @@
 #include <torch/csrc/Exceptions.h>
 #include <torch/csrc/utils/pybind.h>
 #include <torch/csrc/autograd/grad_mode.h>
+#include <ATen/autocast_mode.h>
 #include <torch/csrc/autograd/profiler.h>
 #include <torch/csrc/autograd/python_function.h>
 #include <torch/csrc/autograd/function.h>
@@ -64,6 +65,45 @@ PyObject* THPAutograd_initExtension(PyObject* _unused, PyObject *unused) {
 
 namespace torch { namespace autograd {
 
+static PyObject * set_autocast_enabled(PyObject* _unused, PyObject *arg) {
+  HANDLE_TH_ERRORS
+  if (!PyBool_Check(arg)) {
+    throw TypeError("enabled must be a bool (got %s)", Py_TYPE(arg)->tp_name);
+  }
+  at::autocast::set_enabled(arg == Py_True);
+  Py_RETURN_NONE;
+  END_HANDLE_TH_ERRORS
+}
+
+static PyObject * is_autocast_enabled(PyObject* _unused, PyObject *arg) {
+  HANDLE_TH_ERRORS
+  if (at::autocast::is_enabled()) {
+    Py_RETURN_TRUE;
+  } else {
+    Py_RETURN_FALSE;
+  }
+  END_HANDLE_TH_ERRORS
+}
+
+static PyObject * clear_autocast_cache(PyObject* _unused, PyObject *arg) {
+  HANDLE_TH_ERRORS
+  at::autocast::clear_cache();
+  Py_RETURN_NONE;
+  END_HANDLE_TH_ERRORS
+}
+
+static PyObject * autocast_increment_nesting(PyObject* _unused, PyObject *arg) {
+  HANDLE_TH_ERRORS
+  return THPUtils_packInt64(at::autocast::increment_nesting());
+  END_HANDLE_TH_ERRORS
+}
+
+static PyObject * autocast_decrement_nesting(PyObject* _unused, PyObject *arg) {
+  HANDLE_TH_ERRORS
+  return THPUtils_packInt64(at::autocast::decrement_nesting());
+  END_HANDLE_TH_ERRORS
+}
+
 static PyObject * set_grad_enabled(PyObject* _unused, PyObject *arg) {
   HANDLE_TH_ERRORS
   if (!PyBool_Check(arg)) {
@@ -108,6 +148,11 @@ static PyObject * is_anomaly_mode_enabled(PyObject* _unused, PyObject *arg) {
 static PyMethodDef methods[] = {
   {"set_grad_enabled", (PyCFunction)set_grad_enabled, METH_O, nullptr},
   {"is_grad_enabled", (PyCFunction)is_grad_enabled, METH_NOARGS, nullptr},
+  {"set_autocast_enabled", (PyCFunction)set_autocast_enabled, METH_O, nullptr},
+  {"is_autocast_enabled", (PyCFunction)is_autocast_enabled, METH_NOARGS, nullptr},
+  {"clear_autocast_cache", (PyCFunction)clear_autocast_cache, METH_NOARGS, nullptr},
+  {"autocast_increment_nesting", (PyCFunction)autocast_increment_nesting, METH_NOARGS, nullptr},
+  {"autocast_decrement_nesting", (PyCFunction)autocast_decrement_nesting, METH_NOARGS, nullptr},
   {"set_anomaly_enabled", (PyCFunction)set_anomaly_mode_enabled, METH_O, nullptr},
   {"is_anomaly_enabled", (PyCFunction)is_anomaly_mode_enabled, METH_NOARGS, nullptr},
   {nullptr, nullptr, 0, nullptr}

--- a/torch/cuda/amp/__init__.py
+++ b/torch/cuda/amp/__init__.py
@@ -1,1 +1,2 @@
+from .autocast_mode import autocast, custom_fwd, custom_bwd  # noqa: F401
 from .grad_scaler import GradScaler  # noqa: F401

--- a/torch/cuda/amp/autocast_mode.py
+++ b/torch/cuda/amp/autocast_mode.py
@@ -1,0 +1,217 @@
+import torch
+import functools
+import warnings
+import numpy as np
+from torch._six import container_abcs, string_classes
+
+
+class autocast(object):
+    r"""
+    Instances of :class:`autocast` serve as context managers or decorators that
+    allow regions of your script to run in mixed precision.
+
+    In these regions, CUDA ops run in an op-specific dtype chosen by autocast
+    to improve performance while maintaining accuracy.
+    See the :ref:`Autocast Op Reference<autocast-op-reference>` for details.
+
+    When entering an autocast-enabled region, Tensors may be any type.
+    You should not call ``.half()`` on your model(s) or inputs when using autocasting.
+
+    :class:`autocast` should wrap only the forward pass(es) of your network, including the loss
+    computation(s).  Backward passes under autocast are not recommended.
+    Backward ops run in the same type that autocast used for corresponding forward ops.
+
+    Example::
+
+        # Creates model and optimizer in default precision
+        model = Net().cuda()
+        optimizer = optim.SGD(model.parameters(), ...)
+
+        for input, target in data:
+            optimizer.zero_grad()
+
+            # Enables autocasting for the forward pass (model + loss)
+            with autocast():
+                output = model(input)
+                loss = loss_fn(output, target)
+
+            # Exits the context manager before backward()
+            loss.backward()
+            optimizer.step()
+
+    See the :ref:`Automatic Mixed Precision examples<amp-examples>` for usage (along with gradient scaling)
+    in more complex scenarios (e.g., gradient penalty, multiple models/losses, custom autograd functions).
+
+    :class:`autocast` can also be used as a decorator, e.g., on the ``forward`` method of your model::
+
+        class AutocastModel(nn.Module):
+            ...
+            @autocast()
+            def forward(self, input):
+                ...
+
+    Floating-point Tensors produced in an autocast-enabled region may be ``float16``.
+    After returning to an autocast-disabled region, using them with floating-point
+    Tensors of different dtypes may cause type mismatch errors.  If so, cast the Tensor(s)
+    produced in the autocast region back to ``float32`` (or other dtype if desired).
+    If a Tensor from the autocast region is already ``float32``, the cast is a no-op,
+    and incurs no additional overhead.  Example::
+
+        # Creates some tensors in default dtype (here assumed to be float32)
+        a_float32 = torch.rand((8, 8), device="cuda")
+        b_float32 = torch.rand((8, 8), device="cuda")
+        c_float32 = torch.rand((8, 8), device="cuda")
+        d_float32 = torch.rand((8, 8), device="cuda")
+
+        with autocast():
+            # torch.mm is on autocast's list of ops that should run in float16.
+            # Inputs are float32, but the op runs in float16 and produces float16 output.
+            # No manual casts are required.
+            e_float16 = torch.mm(a_float32, b_float32)
+            # Also handles mixed input types
+            f_float16 = torch.mm(d_float32, e_float16)
+
+        # After exiting autocast, calls f_float16.float() to use with d_float32
+        g_float32 = torch.mm(d_float32, f_float16.float())
+
+    Type mismatch errors *in* an autocast-enabled region are a bug; if this is what you observe,
+    please file an issue.
+
+    ``autocast(enabled=False)`` subregions can be nested in autocast-enabled regions.
+    Locally disabling autocast can be useful, for example, if you want to force a subregion
+    to run in a particular ``dtype``.  Disabling autocast gives you explicit control over
+    the execution type.  In the subregion, inputs from the surrounding region
+    should be cast to ``dtype`` before use::
+
+        # Creates some tensors in default dtype (here assumed to be float32)
+        a_float32 = torch.rand((8, 8), device="cuda")
+        b_float32 = torch.rand((8, 8), device="cuda")
+        c_float32 = torch.rand((8, 8), device="cuda")
+        d_float32 = torch.rand((8, 8), device="cuda")
+
+        with autocast():
+            e_float16 = torch.mm(a_float32, b_float32)
+
+            with autocast(enabled=False):
+                # Calls e_float16.float() to ensure float32 execution
+                # (necessary because e_float16 was created in an autocasted region)
+                f_float32 = torch.mm(c_float32, e_float16.float())
+
+            # No manual casts are required when re-entering the autocast-enabled region.
+            # torch.mm again runs in float16 and produces float16 output, regardless of input types.
+            g_float16 = torch.mm(d_float32, f_float32)
+
+    The autocast state is thread-local.  If you want it enabled in a new thread, the context manager or decorator
+    must be invoked in that thread.  This affects :class:`torch.nn.DataParallel` and
+    :class:`torch.nn.parallel.DistributedDataParallel` when used with more than one GPU per process
+    (see :ref:`Working with Multiple GPUs<amp-multigpu>`).
+
+    Arguments:
+        enabled(bool, optional, default=True):  Whether autocasting should be enabled in the region.
+    """
+    def __init__(self, enabled=True):
+        if enabled and not torch.cuda.is_available():
+            warnings.warn("torch.cuda.amp.autocast only affects CUDA ops, but CUDA is not available.  Disabling.")
+            self._enabled = False
+        else:
+            self._enabled = enabled
+
+    def __enter__(self):
+        self.prev = torch.is_autocast_enabled()
+        torch.set_autocast_enabled(self._enabled)
+        torch.autocast_increment_nesting()
+
+    def __exit__(self, *args):
+        # Drop the cache when we exit to a nesting level that's outside any instance of autocast.
+        if torch.autocast_decrement_nesting() == 0:
+            torch.clear_autocast_cache()
+        torch.set_autocast_enabled(self.prev)
+        return False
+
+    def __call__(self, func):
+        @functools.wraps(func)
+        def decorate_autocast(*args, **kwargs):
+            with self:
+                return func(*args, **kwargs)
+        return decorate_autocast
+
+
+# Casts Tensors and containers of Tensors.  Special-cases passthroughs for strings and np.ndarrays, which
+# may be falsely detected as "Iterables."
+def _cast(value, dtype):
+    if isinstance(value, torch.Tensor):
+        return value.to(dtype) if (value.is_floating_point() and value.is_cuda) else value
+    elif isinstance(value, string_classes):
+        return value
+    elif isinstance(value, np.ndarray):
+        return value
+    elif isinstance(value, container_abcs.Mapping):
+        return {_cast(k, dtype): _cast(v, dtype) for k, v in value.items()}
+    elif isinstance(value, container_abcs.Iterable):
+        return type(value)(_cast(v, dtype) for v in value)
+    else:
+        return value
+
+
+# custom_fwd is a decorator that may or may not be used with arguments, following
+# https://github.com/dabeaz/python-cookbook/tree/master/src/9/defining_a_decorator_that_takes_an_optional_argument.
+# this works:
+#     @custom_fwd
+#     def forward(...):
+# this also works:
+#     @custom_fwd(cast_inputs=torch.float)
+#     def forward(...):
+# TODO:  when python 2 support is dropped, change the signature to
+# def custom_fwd(fwd=None, *, cast_inputs=None) with internal changes following the link above.
+def custom_fwd(fwd=None, **kwargs):
+    """
+    Helper decorator for ``forward`` methods of custom autograd functions (subclasses of
+    :class:`torch.autograd.Function`).  See the :ref:`example page<amp-custom-examples>` for more detail.
+
+    Arguments:
+        cast_inputs (:class:`torch.dtype` or None, optional, default=None):  If not ``None``, casts incoming
+            floating-point Tensors to the target dtype (non-floating-point Tensors are not affected),
+            and causes ``forward`` to execute with autocast disabled.
+            If ``None``, ``forward``'s internal ops execute with the current autocast state.
+    """
+    if fwd is None:
+        if len(kwargs) == 0:
+            cast_inputs = None
+        else:
+            assert len(kwargs) == 1
+            cast_inputs = kwargs["cast_inputs"]
+        return functools.partial(custom_fwd, cast_inputs=cast_inputs)
+
+    if len(kwargs) == 0:
+        cast_inputs = None
+    else:
+        assert len(kwargs) == 1
+        cast_inputs = kwargs["cast_inputs"]
+
+    @functools.wraps(fwd)
+    def decorate_fwd(*args, **kwargs):
+        if cast_inputs is None:
+            args[0]._fwd_used_autocast = torch.is_autocast_enabled()
+            return fwd(*args, **kwargs)
+        else:
+            args[0]._fwd_used_autocast = False
+            with autocast(enabled=False):
+                return fwd(*_cast(args, cast_inputs), **_cast(kwargs, cast_inputs))
+    return decorate_fwd
+
+
+# Autograd ensures incoming gradients are the same type as forward outputs.  Allowing a separate
+# cast_inputs argument on custom_bwd is unnecessary and could cause errors if it doesn't match
+# cast_inputs supplied to custom_fwd.
+def custom_bwd(bwd):
+    """
+    Helper decorator for backward methods of custom autograd functions (subclasses of
+    :class:`torch.autograd.Function`).
+    Ensures that ``backward`` executes with the same autocast state as ``forward``.
+    See the :ref:`example page<amp-custom-examples>` for more detail.
+    """
+    @functools.wraps(bwd)
+    def decorate_bwd(*args, **kwargs):
+        with autocast(args[0]._fwd_used_autocast):
+            return bwd(*args, **kwargs)
+    return decorate_bwd

--- a/torch/testing/_internal/autocast_test_lists.py
+++ b/torch/testing/_internal/autocast_test_lists.py
@@ -1,0 +1,189 @@
+import torch
+
+
+class AutocastTestLists(object):
+    # Supplies ops and arguments for test_autocast_* in test/test_cuda.py
+    def __init__(self, dev):
+        super(AutocastTestLists, self).__init__()
+        n = 8
+        # Utility arguments, created as one-element tuples
+        pointwise0_fp16 = (torch.randn(n, dtype=torch.float16, device=dev),)
+        pointwise1_fp16 = (torch.randn(n, dtype=torch.float16, device=dev),)
+        pointwise2_fp16 = (torch.randn(n, dtype=torch.float16, device=dev),)
+        mat0_fp16 = (torch.randn((n, n), dtype=torch.float16, device=dev),)
+        mat1_fp16 = (torch.randn((n, n), dtype=torch.float16, device=dev),)
+        mat2_fp16 = (torch.randn((n, n), dtype=torch.float16, device=dev),)
+
+        dimsets = ((n, n, n), (n, n, n, n), (n, n, n, n, n))
+        conv_args_fp32 = [(torch.randn(dimset, dtype=torch.float32, device=dev),
+                           torch.randn(dimset, dtype=torch.float32, device=dev))
+                          for dimset in dimsets]
+        bias_fp32 = (torch.randn((n,), dtype=torch.float32, device=dev),)
+        element0_fp32 = (torch.randn(1, dtype=torch.float32, device=dev),)
+        pointwise0_fp32 = (torch.randn(n, dtype=torch.float32, device=dev),)
+        pointwise1_fp32 = (torch.randn(n, dtype=torch.float32, device=dev),)
+        mat0_fp32 = (torch.randn((n, n), dtype=torch.float32, device=dev),)
+        mat1_fp32 = (torch.randn((n, n), dtype=torch.float32, device=dev),)
+        mat2_fp32 = (torch.randn((n, n), dtype=torch.float32, device=dev),)
+        mat3_fp32 = (torch.randn((n, n), dtype=torch.float32, device=dev),)
+
+        # The lists below organize ops that autocast needs to test.
+        # self.list_name corresponds to test_autocast_list_name in test/test_cuda.py.
+        # Each op is associated with a tuple of valid arguments.
+
+        # Some ops implement built-in type promotion.  These don't need autocasting,
+        # but autocasting relies on their promotion, so we include tests to double-check.
+        self.torch_expect_builtin_promote = [
+            ("eq", pointwise0_fp32 + pointwise1_fp16, torch.bool),
+            ("ge", pointwise0_fp32 + pointwise1_fp16, torch.bool),
+            ("gt", pointwise0_fp32 + pointwise1_fp16, torch.bool),
+            ("le", pointwise0_fp32 + pointwise1_fp16, torch.bool),
+            ("lt", pointwise0_fp32 + pointwise1_fp16, torch.bool),
+            ("ne", pointwise0_fp32 + pointwise1_fp16, torch.bool),
+            ("add", pointwise0_fp32 + pointwise1_fp16, torch.float32),
+            ("div", pointwise0_fp32 + pointwise1_fp16, torch.float32),
+            ("mul", pointwise0_fp32 + pointwise1_fp16, torch.float32),
+        ]
+        self.methods_expect_builtin_promote = [
+            ("__eq__", pointwise0_fp32 + pointwise1_fp16, torch.bool),
+            ("__ge__", pointwise0_fp32 + pointwise1_fp16, torch.bool),
+            ("__gt__", pointwise0_fp32 + pointwise1_fp16, torch.bool),
+            ("__le__", pointwise0_fp32 + pointwise1_fp16, torch.bool),
+            ("__lt__", pointwise0_fp32 + pointwise1_fp16, torch.bool),
+            ("__ne__", pointwise0_fp32 + pointwise1_fp16, torch.bool),
+            ("__add__", pointwise0_fp32 + pointwise1_fp16, torch.float32),
+            ("__div__", pointwise0_fp32 + pointwise1_fp16, torch.float32),
+            ("__mul__", pointwise0_fp32 + pointwise1_fp16, torch.float32),
+        ]
+
+        # The remaining lists organize ops that autocast treats explicitly.
+        self.torch_fp16 = [
+            ("_convolution", conv_args_fp32[1] + bias_fp32 + ((1, 1), (0, 0), (1, 1), False,
+                                                              (0, 0), 1, False, True, True)),
+            ("_convolution_nogroup", conv_args_fp32[1] + bias_fp32 + ((1, 1), (0, 0), (1, 1), False, (0, 0))),
+            ("conv1d", conv_args_fp32[0]),
+            ("conv2d", conv_args_fp32[1]),
+            ("conv3d", conv_args_fp32[2]),
+            ("conv_tbc", conv_args_fp32[0] + bias_fp32),
+            ("conv_transpose1d", conv_args_fp32[0]),
+            ("conv_transpose2d", conv_args_fp32[1]),
+            ("conv_transpose3d", conv_args_fp32[2]),
+            ("convolution", conv_args_fp32[1] + bias_fp32 + ((1, 1), (0, 0), (1, 1), False, (0, 0), 1)),
+            # cudnn_convolutions with bias
+            ("cudnn_convolution", conv_args_fp32[1] + bias_fp32 + ((0, 0), (1, 1), (1, 1), 1, False, True)),
+            ("cudnn_convolution_transpose", conv_args_fp32[1] + bias_fp32 + ((0, 0), (0, 0), (1, 1),
+                                                                             (1, 1), 1, False, True)),
+            # cudnn_convolutions with no bias
+            ("cudnn_convolution", conv_args_fp32[1] + ((0, 0), (1, 1), (1, 1), 1, False, True)),
+            ("cudnn_convolution_transpose", conv_args_fp32[1] + ((0, 0), (0, 0), (1, 1), (1, 1), 1, False, True)),
+            ("prelu", pointwise0_fp32 + element0_fp32),
+            ("addmm", mat1_fp32 + mat2_fp32 + mat3_fp32),
+            ("addmv", pointwise0_fp32 + mat2_fp32 + pointwise1_fp32),
+            ("addr", mat0_fp32 + pointwise0_fp32 + pointwise1_fp32),
+            ("matmul", mat0_fp32 + mat1_fp32),
+            ("mm", mat0_fp32 + mat1_fp32),
+            ("mv", mat0_fp32 + pointwise0_fp32),
+            ("chain_matmul", mat0_fp32 + mat1_fp32 + mat2_fp32),
+            ("addbmm", mat0_fp32 + (torch.randn((n, n, n), device=dev, dtype=torch.float32),
+                                    torch.randn((n, n, n), device=dev, dtype=torch.float32))),
+            ("baddbmm", (torch.randn((n, n, n), device=dev, dtype=torch.float32),
+                         torch.randn((n, n, n), device=dev, dtype=torch.float32),
+                         torch.randn((n, n, n), device=dev, dtype=torch.float32))),
+            ("bmm", (torch.randn((n, n, n), device=dev, dtype=torch.float32),
+                     torch.randn((n, n, n), device=dev, dtype=torch.float32))),
+        ]
+        self.torch_fp32 = [
+            ("acos", (pointwise0_fp16[0].clamp(-.9, 0.9),)),
+            ("asin", (pointwise0_fp16[0].clamp(-.9, 0.9),)),
+            ("cosh", pointwise0_fp16),
+            ("erfinv", (pointwise0_fp16[0].clamp(-.9, .9),)),
+            ("exp", pointwise0_fp16),
+            ("expm1", pointwise0_fp16),
+            ("log", (pointwise0_fp16[0].clamp(0.1, 100.0),)),
+            ("log10", (pointwise0_fp16[0].clamp(0.1, 100.0),)),
+            ("log2", (pointwise0_fp16[0].clamp(0.1, 100.0),)),
+            ("log1p", (pointwise0_fp16[0].clamp(-0.9, 100.0),)),
+            ("reciprocal", pointwise0_fp16),
+            ("rsqrt", (pointwise0_fp16[0].clamp(0.0, 100.0),)),
+            ("sinh", pointwise0_fp16),
+            ("tan", (pointwise0_fp16[0].clamp(-3.1 / 2, 3.1 / 2),)),
+            ("pow", ((pointwise0_fp16[0] + 1.).clamp(0.0, 100.0),) + pointwise1_fp16),
+            ("pow", ((pointwise0_fp16[0] + 1.).clamp(0.0, 100.0),) + (1.7,)),
+            # ("pow", (1.7,) + pointwise0_fp16), # This variant has a backend, but is not documented in the API.
+            ("softmax", pointwise0_fp16 + (0,)),
+            ("log_softmax", pointwise0_fp16 + (0,)),
+            ("layer_norm", pointwise0_fp16 + ((pointwise0_fp16[0].numel(),),)),
+            ("group_norm", mat0_fp16 + (1,)),
+            ("norm", pointwise0_fp16),
+            ("norm", pointwise0_fp16, {"dim": 0}),
+            # these need magma
+            # ("norm", mat0_fp16, {"p": "nuc"}),
+            # ("norm", mat0_fp16, {"p": "nuc", "dim": 0}),
+            ("norm", pointwise0_fp16, {"p": 1}),
+            ("norm", pointwise0_fp16, {"p": 1, "dim": 0}),
+            ("cosine_similarity", mat0_fp16 + mat1_fp16),
+            ("poisson_nll_loss", mat0_fp16 + mat1_fp16 + (True, False, 1.e-8,
+                                                          torch.nn.functional._Reduction.get_enum('mean'))),
+            ("cosine_embedding_loss", (torch.tensor([[1, 2, 3]], device=dev, dtype=torch.float16),
+                                       torch.tensor([[1, 3, 4]], device=dev, dtype=torch.float16),
+                                       torch.tensor([1], device=dev, dtype=torch.int))),
+            ("hinge_embedding_loss", mat0_fp16 + (torch.ones(n, device=dev, dtype=torch.int),)),
+            ("kl_div", mat0_fp16 + (torch.rand((n, n), device=dev, dtype=torch.float16),)),
+            ("margin_ranking_loss", mat0_fp16 + mat1_fp16 + (torch.ones((n,), device=dev, dtype=torch.float16),)),
+            ("triplet_margin_loss", mat0_fp16 + mat1_fp16 + mat2_fp16),
+            ("binary_cross_entropy_with_logits", mat0_fp16 + (torch.rand((n, n), device=dev, dtype=torch.float16),)),
+            ("cumprod", pointwise0_fp16 + (0,)),
+            ("cumsum", pointwise0_fp16 + (0,)),
+            ("dist", pointwise0_fp16 + pointwise1_fp16),
+            ("pdist", mat0_fp16),
+            ("cdist", mat0_fp16 + mat1_fp16),
+            ("prod", pointwise0_fp16),
+            ("prod", pointwise0_fp16 + (0,)),
+            ("renorm", mat0_fp16 + (2, 0, 1.0)),
+            ("sum", pointwise0_fp16),
+            ("sum", mat0_fp16 + (1,)),
+        ]
+        self.torch_need_autocast_promote = [
+            ("addcdiv", pointwise0_fp32 + pointwise1_fp16 + (pointwise2_fp16[0].clamp(0.1, 100),)),
+            ("addcmul", pointwise0_fp32 + pointwise1_fp16 + pointwise2_fp16),
+            ("atan2", pointwise0_fp32 + (pointwise1_fp16[0].clamp(0.1, 100),)),
+            ("cross", (torch.randn(3, dtype=torch.float32, device=dev),
+                       torch.randn(3, dtype=torch.float16, device=dev))),
+            ("bilinear", (torch.randn((1, 2), dtype=torch.float16, device=dev),
+                          torch.randn((1, 2), dtype=torch.float32, device=dev),
+                          torch.randn((1, 2, 2), dtype=torch.float16, device=dev),
+                          torch.randn((1,), dtype=torch.float32, device=dev))),
+            ("dot", pointwise0_fp16 + pointwise1_fp32),
+            ("tensordot", (torch.randn((2, 2, 2), dtype=torch.float32, device=dev),
+                           torch.randn((2, 2, 2), dtype=torch.float16, device=dev))),
+            ("equal", pointwise0_fp32 + pointwise1_fp16),
+            ("cat", (pointwise0_fp16 + pointwise1_fp32,)),
+            ("stack", (pointwise0_fp16 + pointwise1_fp32,)),
+        ]
+        self.nn_fp16 = [
+            ("linear", mat0_fp32 + mat1_fp32 + mat2_fp32),
+        ]
+        self.nn_fp32 = [
+            ("softplus", pointwise0_fp16),
+            ("gelu", pointwise0_fp16),
+            ("nll_loss", (torch.rand((n, n), device=dev, dtype=torch.float),
+                          torch.zeros((n,), device=dev, dtype=torch.long))),
+            ("nll_loss2d", (torch.rand((n, n, n, n), device=dev, dtype=torch.half),
+                            torch.zeros((n, n, n), device=dev, dtype=torch.long))),
+            ("l1_loss", mat0_fp16 + mat1_fp16),
+            ("smooth_l1_loss", mat0_fp16 + mat1_fp16),
+            ("mse_loss", mat0_fp16 + mat1_fp16),
+            ("multilabel_margin_loss", mat0_fp16 + (torch.ones((n, n), device=dev, dtype=torch.long),)),
+            ("soft_margin_loss", mat0_fp16 + (torch.ones((n, n), device=dev, dtype=torch.long),)),
+            ("multi_margin_loss", mat0_fp16 + (torch.ones((n,), device=dev, dtype=torch.long),)),
+        ]
+        self.methods_fp16 = [
+            ("__matmul__", mat0_fp32 + mat1_fp32)
+        ]
+        self.methods_fp32 = [
+            ("__pow__", (torch.rand(n, device=dev, dtype=torch.float16), 1.5)),
+        ]
+        self.banned = [
+            ("binary_cross_entropy", (torch.rand((n, n), device=dev, dtype=torch.float32),
+                                      torch.rand((n, n), device=dev, dtype=torch.float32)), torch._C._nn),
+        ]


### PR DESCRIPTION
Update:  closed following Greg's edit https://github.com/pytorch/pytorch/issues/35009#issuecomment-601394199.  Autocasting and gradient scaling are fully usable in current master and nightly pip/conda packages.

Autocasting is the second and final major component of the native mixed precision API (the first is the gradient scaling API that's been merged for several weeks already).  With autocasting added, Pytorch will have full mixed precision support.  Autocasting has thorough documentation and test coverage.   @dstosic used it to converge 40ish models in local tests, including several with Fairseq and Detectron.  It was approved by @ezyang, @ngimel, and @mruberry and is merged in current master.

Autocasting was first merged before the 1.5 branch fork (at least the most recent divergence between master and release/1.5 that I can see), but reverted temporarily for minor fixes.  The [remerged master PR](https://github.com/pytorch/pytorch/pull/35102) explains the history.  The present PR cherry-picks those diffs, which (so far) have stuck the landing in master.

If autocast can't be included, it's not the end of the world, just let me know what you think is feasible.