### PR TITLE
Revert "Load torch_global_deps for Windows (#35177)"

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -74,11 +74,10 @@ if platform.system() == 'Windows':
 
 # See Note [Global dependencies]
 def _load_global_deps():
-    ext_dict = {'Darwin': '.dylib', 'Windows': '.dll'}
-    cur_platform = platform.system()
-    lib_name_prefix = '' if cur_platform == 'Windows' else 'lib'
-    lib_name_suffix = ext_dict.get(cur_platform, '.so')
-    lib_name = lib_name_prefix + 'torch_global_deps' + lib_name_suffix
+    if platform.system() == 'Windows':
+        return
+
+    lib_name = 'libtorch_global_deps' + ('.dylib' if platform.system() == 'Darwin' else '.so')
     here = os.path.abspath(__file__)
     lib_path = os.path.join(os.path.dirname(here), 'lib', lib_name)
 


### PR DESCRIPTION
This reverts commit d7a7bcb0428273fa54a836b52e750608ebe7e4de.

The previous commit is not useful because torch_global_deps doesn't include any external dependencies.