### PR TITLE
Fix some incorrect annotations found by clang-cl

### DIFF
--- a/c10/test/util/typeid_test.cpp
+++ b/c10/test/util/typeid_test.cpp
@@ -10,8 +10,8 @@ class TypeMetaTestFoo {};
 class TypeMetaTestBar {};
 }
 
-CAFFE_KNOWN_TYPE(TypeMetaTestFoo);
-CAFFE_KNOWN_TYPE(TypeMetaTestBar);
+CAFFE_KNOWN_TYPE_NOEXPORT(TypeMetaTestFoo);
+CAFFE_KNOWN_TYPE_NOEXPORT(TypeMetaTestBar);
 
 namespace {
 
@@ -88,8 +88,8 @@ class ClassNoAssignment {
 };
 }
 
-CAFFE_KNOWN_TYPE(ClassAllowAssignment);
-CAFFE_KNOWN_TYPE(ClassNoAssignment);
+CAFFE_KNOWN_TYPE_NOEXPORT(ClassAllowAssignment);
+CAFFE_KNOWN_TYPE_NOEXPORT(ClassNoAssignment);
 
 namespace {
 

--- a/c10/util/Exception.h
+++ b/c10/util/Exception.h
@@ -110,19 +110,19 @@ C10_API WarningHandler* get_warning_handler() noexcept(true);
 // Used in ATen for out-of-bound indices that can reasonably only be detected
 // lazily inside a kernel (See: advanced indexing).  These turn into
 // IndexError when they cross to Python.
-class C10_API IndexError : public Error {
+class IndexError : public Error {
   using Error::Error;
 };
 
 // Used in ATen for invalid values.  These turn into
 // ValueError when they cross to Python.
-class C10_API ValueError : public Error {
+class ValueError : public Error {
   using Error::Error;
 };
 
 // Used in ATen for non finite indices.  These turn into
 // ExitException when they cross to Python.
-class C10_API EnforceFiniteError : public Error {
+class EnforceFiniteError : public Error {
   using Error::Error;
 };
 

--- a/c10/util/typeid.h
+++ b/c10/util/typeid.h
@@ -508,4 +508,14 @@ inline std::ostream& operator<<(
     return &singleton;                                             \
   }
 
+// A variant for not exporting the type in an anonymous namespace
+#define CAFFE_KNOWN_TYPE_NOEXPORT(T)                               \
+  template <>                                                      \
+  const detail::TypeMetaData*                                      \
+  TypeMeta::_typeMetaDataInstance<T>() noexcept {                  \
+    static C10_TYPENAME_CONSTEXPR detail::TypeMetaData singleton = \
+        detail::_makeTypeMetaDataInstance<T>();                    \
+    return &singleton;                                             \
+  }
+
 } // namespace caffe2

--- a/caffe2/core/blob_test.cc
+++ b/caffe2/core/blob_test.cc
@@ -39,9 +39,9 @@ class BlobTestNonDefaultConstructible {
 };
 } // namespace
 
-CAFFE_KNOWN_TYPE(BlobTestFoo);
-CAFFE_KNOWN_TYPE(BlobTestBar);
-CAFFE_KNOWN_TYPE(BlobTestNonDefaultConstructible);
+CAFFE_KNOWN_TYPE_NOEXPORT(BlobTestFoo);
+CAFFE_KNOWN_TYPE_NOEXPORT(BlobTestBar);
+CAFFE_KNOWN_TYPE_NOEXPORT(BlobTestNonDefaultConstructible);
 
 class BlobTestFooSerializer : public BlobSerializerBase {
  public:
@@ -975,7 +975,7 @@ class DummyTypeDeserializer : public BlobDeserializerBase {
 };
 } // namespace
 
-CAFFE_KNOWN_TYPE(DummyType);
+CAFFE_KNOWN_TYPE_NOEXPORT(DummyType);
 
 namespace {
 REGISTER_BLOB_SERIALIZER((TypeMeta::Id<DummyType>()), DummyTypeSerializer);

--- a/caffe2/core/operator.h
+++ b/caffe2/core/operator.h
@@ -1396,6 +1396,12 @@ struct CAFFE2_API DeviceTypeRegisterer {
       DeviceType)(type, &registry_function);                \
   }
 
+#if defined(_MSC_VER)
+#define IMPORT_IF_NOT_MSVC
+#else
+#define IMPORT_IF_NOT_MSVC C10_IMPORT
+#endif
+
 // The operator registry. Since we are not expecting a great number of devices,
 // we will simply have an if-then type command and allocate the actual
 // generation to device-specific registerers.
@@ -1410,11 +1416,11 @@ C10_DECLARE_REGISTRY(
     Workspace*);
 #define REGISTER_CPU_OPERATOR_CREATOR(key, ...) \
   C10_REGISTER_CREATOR(CPUOperatorRegistry, key, __VA_ARGS__)
-#define REGISTER_CPU_OPERATOR(name, ...)                           \
-  C10_IMPORT void CAFFE2_PLEASE_ADD_OPERATOR_SCHEMA_FOR_##name();  \
-  static void CAFFE2_UNUSED CAFFE_ANONYMOUS_VARIABLE_CPU##name() { \
-    CAFFE2_PLEASE_ADD_OPERATOR_SCHEMA_FOR_##name();                \
-  }                                                                \
+#define REGISTER_CPU_OPERATOR(name, ...)                                   \
+  IMPORT_IF_NOT_MSVC void CAFFE2_PLEASE_ADD_OPERATOR_SCHEMA_FOR_##name();  \
+  static void CAFFE2_UNUSED CAFFE_ANONYMOUS_VARIABLE_CPU##name() {         \
+    CAFFE2_PLEASE_ADD_OPERATOR_SCHEMA_FOR_##name();                        \
+  }                                                                        \
   C10_REGISTER_CLASS(CPUOperatorRegistry, name, __VA_ARGS__)
 #define REGISTER_CPU_OPERATOR_STR(str_name, ...) \
   C10_REGISTER_TYPED_CLASS(CPUOperatorRegistry, str_name, __VA_ARGS__)
@@ -1445,11 +1451,11 @@ C10_DECLARE_REGISTRY(
     Workspace*);
 #define REGISTER_CUDA_OPERATOR_CREATOR(key, ...) \
   C10_REGISTER_CREATOR(CUDAOperatorRegistry, key, __VA_ARGS__)
-#define REGISTER_CUDA_OPERATOR(name, ...)                           \
-  C10_IMPORT void CAFFE2_PLEASE_ADD_OPERATOR_SCHEMA_FOR_##name();   \
-  static void CAFFE2_UNUSED CAFFE_ANONYMOUS_VARIABLE_CUDA##name() { \
-    CAFFE2_PLEASE_ADD_OPERATOR_SCHEMA_FOR_##name();                 \
-  }                                                                 \
+#define REGISTER_CUDA_OPERATOR(name, ...)                                  \
+  IMPORT_IF_NOT_MSVC void CAFFE2_PLEASE_ADD_OPERATOR_SCHEMA_FOR_##name();  \
+  static void CAFFE2_UNUSED CAFFE_ANONYMOUS_VARIABLE_CUDA##name() {        \
+    CAFFE2_PLEASE_ADD_OPERATOR_SCHEMA_FOR_##name();                        \
+  }                                                                        \
   C10_REGISTER_CLASS(CUDAOperatorRegistry, name, __VA_ARGS__)
 #define REGISTER_CUDA_OPERATOR_STR(str_name, ...) \
   C10_REGISTER_TYPED_CLASS(CUDAOperatorRegistry, str_name, __VA_ARGS__)
@@ -1469,11 +1475,11 @@ C10_DECLARE_REGISTRY(
     Workspace*);
 #define REGISTER_HIP_OPERATOR_CREATOR(key, ...) \
   C10_REGISTER_CREATOR(HIPOperatorRegistry, key, __VA_ARGS__)
-#define REGISTER_HIP_OPERATOR(name, ...)                           \
-  C10_IMPORT void CAFFE2_PLEASE_ADD_OPERATOR_SCHEMA_FOR_##name();  \
-  static void CAFFE2_UNUSED CAFFE_ANONYMOUS_VARIABLE_HIP##name() { \
-    CAFFE2_PLEASE_ADD_OPERATOR_SCHEMA_FOR_##name();                \
-  }                                                                \
+#define REGISTER_HIP_OPERATOR(name, ...)                                   \
+  IMPORT_IF_NOT_MSVC void CAFFE2_PLEASE_ADD_OPERATOR_SCHEMA_FOR_##name();  \
+  static void CAFFE2_UNUSED CAFFE_ANONYMOUS_VARIABLE_HIP##name() {         \
+    CAFFE2_PLEASE_ADD_OPERATOR_SCHEMA_FOR_##name();                        \
+  }                                                                        \
   C10_REGISTER_CLASS(HIPOperatorRegistry, name, __VA_ARGS__)
 #define REGISTER_HIP_OPERATOR_STR(str_name, ...) \
   C10_REGISTER_TYPED_CLASS(HIPOperatorRegistry, str_name, __VA_ARGS__)

--- a/caffe2/core/operator_schema.h
+++ b/caffe2/core/operator_schema.h
@@ -600,27 +600,33 @@ OpSchema::Cost PointwiseCostInference(
 
 } // namespace caffe2
 
+#if defined(_MSC_VER)
+#define EXPORT_IF_NOT_MSVC
+#else
+#define EXPORT_IF_NOT_MSVC C10_EXPORT
+#endif
+
 #ifndef CAFFE2_NO_OPERATOR_SCHEMA
 
-#define OPERATOR_SCHEMA(name)                                       \
-  C10_EXPORT void CAFFE2_PLEASE_ADD_OPERATOR_SCHEMA_FOR_##name(){}; \
-  static OpSchema* C10_ANONYMOUS_VARIABLE(name) CAFFE2_UNUSED =     \
+#define OPERATOR_SCHEMA(name)                                                \
+  EXPORT_IF_NOT_MSVC void CAFFE2_PLEASE_ADD_OPERATOR_SCHEMA_FOR_##name(){};  \
+  static OpSchema* C10_ANONYMOUS_VARIABLE(name) CAFFE2_UNUSED =              \
       &OpSchemaRegistry::NewSchema(#name, __FILE__, __LINE__)
 
 #else // CAFFE2_NO_OPERATOR_SCHEMA
 
-#define OPERATOR_SCHEMA(name)                                       \
-  C10_EXPORT void CAFFE2_PLEASE_ADD_OPERATOR_SCHEMA_FOR_##name(){}; \
-  static OpSchema* C10_ANONYMOUS_VARIABLE(name) CAFFE2_UNUSED =     \
+#define OPERATOR_SCHEMA(name)                                                \
+  EXPORT_IF_NOT_MSVC void CAFFE2_PLEASE_ADD_OPERATOR_SCHEMA_FOR_##name(){};  \
+  static OpSchema* C10_ANONYMOUS_VARIABLE(name) CAFFE2_UNUSED =              \
       1 ? nullptr : &OpSchemaRegistry::NewSchema(#name, __FILE__, __LINE__)
 
 #endif // CAFFE2_NO_OPERATOR_SCHEMA
 
 #ifdef CAFFE2_NO_GRADIENT_OPS
 
-#define GRADIENT_OPERATOR_SCHEMA(name)                              \
-  C10_EXPORT void CAFFE2_PLEASE_ADD_OPERATOR_SCHEMA_FOR_##name(){}; \
-  static OpSchema* C10_ANONYMOUS_VARIABLE(name) CAFFE2_UNUSED =     \
+#define GRADIENT_OPERATOR_SCHEMA(name)                                       \
+  EXPORT_IF_NOT_MSVC void CAFFE2_PLEASE_ADD_OPERATOR_SCHEMA_FOR_##name(){};  \
+  static OpSchema* C10_ANONYMOUS_VARIABLE(name) CAFFE2_UNUSED =              \
       1 ? nullptr : &OpSchemaRegistry::NewSchema(#name, __FILE__, __LINE__)
 
 #else

--- a/torch/csrc/autograd/custom_function.h
+++ b/torch/csrc/autograd/custom_function.h
@@ -64,7 +64,7 @@ using forward_t = decltype(X::forward(nullptr, std::declval<Args>()...));
 // Example backward call:
 // y[0].sum().backward();
 template <class T>
-struct TORCH_API Function {
+struct Function {
   // We need to use a different template parameter than T here because T will
   // inherit from Function, and when Function<T> is instantiated, T::forward
   // is not declared yet.


### PR DESCRIPTION
Fixes incorrect usages of symbol annotations including:
1. Exporting or importing a function/class in an anonymous namespace.
2. Exporting or importing a function/class implementation in a header file. However, by removing the symbol annotations, they are now local symbols. If they need to be remain global, I can move the implementations to the source file.