### PR TITLE
[quant][graph] Add pass to insert quant dequant for dynamic quantization

### DIFF
--- a/test/test_quantize_script.py
+++ b/test/test_quantize_script.py
@@ -8,8 +8,9 @@ from torch.quantization import default_dynamic_qconfig
 from torch.testing._internal.common_utils import run_tests
 from torch.testing import FileCheck
 from torch.testing._internal.jit_utils import attrs_with_prefix
-from torch.testing._internal.jit_utils import JitTestCase
+from torch.testing._internal.jit_utils import JitTestCase, get_forward, get_forward_graph, get_module_method
 
+from torch.jit._recursive import wrap_cpp_module
 class TestScript(JitTestCase):
     def test_prepare_dynamic(self):
         class M(torch.nn.Module):
@@ -70,6 +71,54 @@ class TestScript(JitTestCase):
                    .check('prim::CallMethod') \
                    .check_not('Observer = prim::GetAttr[name="_observer_') \
                    .run(m.graph)
+
+
+    def test_insert_quant_dequant_dynamic(self):
+        class M(torch.nn.Module):
+            def __init__(self):
+                super(M, self).__init__()
+                self.conv = torch.nn.Conv2d(3, 5, 3).float()
+
+            def forward(self, x):
+                return self.conv(x)
+
+        m = torch.jit.script(M())
+        qconfig = default_dynamic_qconfig
+        qconfig_dict = {
+            '': script_qconfig(qconfig)
+        }
+        m = wrap_cpp_module(torch._C._jit_pass_insert_observers(m._c, "forward", qconfig_dict, False, True))
+        data = torch.randn(1, 3, 10, 10, dtype=torch.float)
+
+        get_forward(m._c)(data)
+        print("After insert obs ", m.graph)
+        m = wrap_cpp_module(torch._C._jit_pass_insert_quant_dequant(m._c, "forward", False, True))
+        print(m.graph)
+        assert len(m._modules._c.items()) == 1, \
+            'Expected to have single submodule of conv'
+
+        get_forward(m._c)(data)
+        quant_func = "aten::quantize_per_tensor"
+
+        # quantizing activations
+        FileCheck().check("aten::_choose_qparams_per_tensor") \
+                   .check(quant_func) \
+                   .check("prim::CallMethod[name=\"forward\"]") \
+                   .check_not(quant_func) \
+                   .check("return") \
+                   .run(str(get_forward_graph(m._c)))
+        # quantizing weight in forward function of conv module
+        FileCheck().check(quant_func) \
+                   .check("prim::CallMethod[name=\"_conv_forward\"]") \
+                   .check_not(quant_func) \
+                   .check("return") \
+                   .run(str(get_forward_graph(m.conv._c)))
+        # shouldn't have quant/dequant in _conv_foward function
+        FileCheck().check_not(quant_func) \
+                   .check("aten::conv2d") \
+                   .check_not(quant_func) \
+                   .check("return") \
+                   .run(str(get_module_method(m, 'conv', '_conv_forward').graph))
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/csrc/jit/passes/quantization.h
+++ b/torch/csrc/jit/passes/quantization.h
@@ -85,7 +85,8 @@ TORCH_API Module InsertObservers(
 TORCH_API Module InsertQuantDeQuant(
     Module& module,
     const std::string& method_name,
-    bool inplace = false);
+    bool inplace = false,
+    bool is_dynamic = false);
 
 /** Swap functional linear CallFunctions to aten::linear
  *  so that it can survive inline, since quant fusion need to

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -188,12 +188,14 @@ void initJITBindings(PyObject* module) {
           "_jit_pass_insert_quant_dequant",
           [](Module& module,
              const std::string& method_name,
-             bool inplace) {
-            return InsertQuantDeQuant(module, method_name, inplace);
+             bool inplace,
+             bool is_dynamic) {
+            return InsertQuantDeQuant(module, method_name, inplace, is_dynamic);
           },
           py::arg("module"),
           py::arg("method_name"),
-          py::arg("inplace") = false)
+          py::arg("inplace") = false,
+          py::arg("is_dynamic") = false)
       .def(
           "_jit_pass_insert_prepack_unpack",
           [](std::shared_ptr<Graph>& g) { return InsertPrepackUnpack(g); })


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#35366 [quant][graph] Add pass to insert quant dequant for dynamic quantization**
* #35325 [quant][graph] Update dynamic quant tests to use new qconfig
* #35265 [quant][graph] Add a new observer type for dynamic quantization
* #35235 [quant][graph] Add _choose_qparams function for graph mode

Summary:
Add _choose_qparams_per_tensor which returns scale and zero_point similar to the dynamic quantization in the operator

Test Plan:
python test/test_quantize_script.py
Reviewers:

Subscribers:

Tasks:

Tags: