### PR TITLE
Removing references to PYTHON3COMPATIMPORTS.

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -1,4 +1,3 @@
-# @lint-ignore-every PYTHON3COMPATIMPORTS
 
 r"""
 The torch package contains data structures for multi-dimensional

--- a/torch/nn/intrinsic/__init__.py
+++ b/torch/nn/intrinsic/__init__.py
@@ -1,4 +1,3 @@
-# @lint-ignore-every PYTHON3COMPATIMPORTS
 
 from .modules import ConvBn2d
 from .modules import ConvBn3d

--- a/torch/nn/intrinsic/modules/__init__.py
+++ b/torch/nn/intrinsic/modules/__init__.py
@@ -1,4 +1,3 @@
-# @lint-ignore-every PYTHON3COMPATIMPORTS
 
 from .fused import ConvBn2d
 from .fused import ConvBn3d

--- a/torch/nn/intrinsic/quantized/modules/__init__.py
+++ b/torch/nn/intrinsic/quantized/modules/__init__.py
@@ -1,4 +1,3 @@
-# @lint-ignore-every PYTHON3COMPATIMPORTS
 
 from .linear_relu import LinearReLU
 from .conv_relu import ConvReLU2d, ConvReLU3d

--- a/torch/nn/qat/modules/__init__.py
+++ b/torch/nn/qat/modules/__init__.py
@@ -1,4 +1,3 @@
-# @lint-ignore-every PYTHON3COMPATIMPORTS
 
 from .linear import Linear
 from .conv import Conv2d

--- a/torch/nn/quantized/dynamic/modules/__init__.py
+++ b/torch/nn/quantized/dynamic/modules/__init__.py
@@ -1,4 +1,3 @@
-# @lint-ignore-every PYTHON3COMPATIMPORTS
 
 from .linear import Linear
 from .rnn import LSTM

--- a/torch/nn/quantized/modules/__init__.py
+++ b/torch/nn/quantized/modules/__init__.py
@@ -1,4 +1,3 @@
-# @lint-ignore-every PYTHON3COMPATIMPORTS
 
 import torch
 from torch.nn.modules.pooling import MaxPool2d


### PR DESCRIPTION
Summary:
Removing references to PYTHON3COMPATIMPORTS, mostly suppressions but
removed one instance of usage in a bash script.

Fixed errors arc lint uncovered.

Test Plan:
arc lint
Sandcastle tests

Reviewed By: zertosh

Differential Revision: D20635401

