### PR TITLE
Ports true_divide method variant to 1.5

### DIFF
--- a/aten/src/ATen/native/BinaryOps.cpp
+++ b/aten/src/ATen/native/BinaryOps.cpp
@@ -138,6 +138,10 @@ Tensor true_divide(const Tensor& self, const Tensor& divisor) {
   return iter.output();
 }
 
+Tensor& true_divide_(Tensor& self, const Tensor& divisor) {
+  return native::true_divide_out(self, self, divisor);
+}
+
 Tensor& floor_divide_out(Tensor& result, const Tensor& self, const Tensor& other) {
   auto iter = TensorIterator::binary_op(result, self, other,
     /*check_mem_overlap=*/true);
@@ -731,7 +735,11 @@ Tensor& fmod_(Tensor& self, Scalar other) {
 }
 
 Tensor true_divide(const Tensor& self, Scalar divisor) {
-  return at::true_divide(self, wrapped_scalar_tensor(divisor)); // redispatch!
+  return self.true_divide(wrapped_scalar_tensor(divisor)); // redispatch!
+}
+
+Tensor& true_divide_(Tensor& self, Scalar divisor) {
+  return self.true_divide_(wrapped_scalar_tensor(divisor)); // redispatch!
 }
 
 }

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2872,12 +2872,21 @@
 
 - func: true_divide.Tensor(Tensor self, Tensor other) -> Tensor
   use_c10_dispatcher: full
-  variants: function
+  variants: function, method
   dispatch:
     CPU: true_divide
     CUDA: true_divide
     SparseCPU: true_divide_sparse
     SparseCUDA: true_divide_sparse
+  supports_named_tensor: True
+
+- func: true_divide_.Tensor(Tensor(a!) self, Tensor other) -> Tensor(a!)
+  variants: method
+  dispatch:
+    CPU: true_divide_
+    CUDA: true_divide_
+    SparseCPU: true_divide_sparse_
+    SparseCUDA: true_divide_sparse_
   supports_named_tensor: True
 
 - func: true_divide.out(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
@@ -2890,7 +2899,11 @@
 
 - func: true_divide.Scalar(Tensor self, Scalar other) -> Tensor
   use_c10_dispatcher: full
-  variants: function
+  variants: function, method
+  supports_named_tensor: True
+
+- func: true_divide_.Scalar(Tensor(a!) self, Scalar other) -> Tensor(a!)
+  variants: method
   supports_named_tensor: True
 
 - func: trunc(Tensor self) -> Tensor

--- a/aten/src/ATen/native/sparse/SparseTensorMath.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensorMath.cpp
@@ -272,6 +272,10 @@ SparseTensor& true_divide_out_sparse_scalar(
   return true_divide_out_sparse_zerodim(result, dividend, wrapped_scalar_tensor(divisor));
 }
 
+Tensor& true_divide_sparse_(Tensor& self, const Tensor& divisor) {
+  return true_divide_out_sparse_zerodim(self, self, divisor);
+}
+
 // --------------------------------------------------------------------
 // floor_divide(SparseTensor, Scalar)
 // --------------------------------------------------------------------

--- a/docs/source/tensors.rst
+++ b/docs/source/tensors.rst
@@ -495,6 +495,8 @@ view of a storage and defines numeric operations on it.
    .. automethod:: tril_
    .. automethod:: triu
    .. automethod:: triu_
+   .. automethod:: true_divide
+   .. automethod:: true_divide_
    .. automethod:: trunc
    .. automethod:: trunc_
    .. automethod:: type

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -1200,11 +1200,13 @@ class TestSparse(TestCase):
         self.assertEqual(self.safeToDense(y1), expected)
         self.assertEqual(self.safeToDense(y2), expected)
 
-        # Note: true_divide does not have a method variant
         y1 = torch.true_divide(x1, 37.5)
         y2 = x1.clone()
+        if y2.dtype.is_floating_point or y2.dtype.is_complex:
+            y2.true_divide_(37.5)
         expected = torch.true_divide(self.safeToDense(x1), 37.5)
         self.assertEqual(self.safeToDense(y1), expected)
+        self.assertEqual(self.safeToDense(y2), expected)
 
         y1 = x1 // 37.5
         y2 = x1.clone()

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -15966,9 +15966,16 @@ tensor_op_tests = [
     ('div', '', _small_3d, lambda t, d: [_number(3.14, 3, t)], 1e-1),
     ('div', 'tensor', _small_3d,
         lambda t, d: [_small_3d(t, d, has_zeros=False)], 1e-1),
-    # Note: precision for floor_divide is 1 since a small (1e-5, for example)
-    # error in division can lead to an difference of 1 post-truncation
-    # (e.g. .9999 vs 1 post truncation is 0 vs 1)
+    ('true_divide', '', _small_3d, lambda t, d: [_number(3.14, 3, t)], 1e-1,
+        1e-5, 1e-5, _types, False),
+    ('true_divide', 'with_inplace', _small_3d, lambda t, d: [_number(3.14, 3, t)], 1e-1,
+        1e-5, 1e-5, _float_types),
+    ('true_divide', 'tensor', _small_3d,
+        lambda t, d: [_small_3d(t, d, has_zeros=False)], 1e-1,
+        1e-5, 1e-5, _types, False),
+    ('true_divide', 'tensor_with_inplace', _small_3d,
+        lambda t, d: [_small_3d(t, d, has_zeros=False)], 1e-1,
+        1e-5, 1e-5, _float_types),
     ('floor_divide', '', _small_3d, lambda t, d: [_number(3.14, 3, t)], 1, 1e-5, 1e-5, _types),
     ('floor_divide', 'tensor', _small_3d,
         lambda t, d: [_small_3d(t, d, has_zeros=False)], 1, 1e-5, 1e-5, _types),

--- a/test/test_type_promotion.py
+++ b/test/test_type_promotion.py
@@ -439,29 +439,62 @@ class TestTypePromotion(TestCase):
         a = torch.tensor([[True, True], [False, True]], device=device)
         self.assertEqual(a.t() == 0, a.t() == False)  # noqa: E712
 
-    @dtypes(torch.bool, torch.short, torch.uint8, torch.int, torch.long)
+    @onlyOnCPUAndCUDA
+    @dtypes(torch.bool, torch.uint8, torch.int8, torch.int16, torch.int32, torch.int64)
     @float_double_default_dtype
     def test_true_divide(self, device, dtype):
-        dividend = torch.randn(5, device=device).to(dtype)
+        dividend = (torch.randn(5, device=device) * 100).to(dtype)
         divisor = torch.arange(1, 6, device=device).to(dtype)
+
+        # Tests tensor/tensor division
         casting_result = dividend.to(torch.get_default_dtype()) / divisor.to(torch.get_default_dtype())
         self.assertEqual(casting_result, torch.true_divide(dividend, divisor))
 
+        # Tests tensor/scalar division
+        casting_result = dividend.to(torch.get_default_dtype()) / 2
+        self.assertEqual(casting_result, torch.true_divide(dividend, 2.))
+
     @onlyOnCPUAndCUDA
-    @dtypes(torch.bool, torch.short, torch.uint8, torch.int, torch.long)
+    @dtypes(torch.float, torch.double,
+            torch.bool, torch.uint8, torch.int8, torch.int16, torch.int32, torch.int64)
     def test_true_divide_out(self, device, dtype):
-        dividend = torch.randn(5, device=device).to(dtype)
+        dividend = (torch.randn(5, device=device) * 100).to(dtype)
         divisor = torch.arange(1, 6, device=device).to(dtype)
 
         # Tests that requests for an integer quotient fail
-        integral_quotient = torch.empty(5, device=device, dtype=dtype)
-        with self.assertRaises(RuntimeError):
-            torch.true_divide(dividend, divisor, out=integral_quotient)
+        if not dtype.is_floating_point:
+            integral_quotient = torch.empty(5, device=device, dtype=dtype)
+            with self.assertRaises(RuntimeError):
+                torch.true_divide(dividend, divisor, out=integral_quotient)
+            with self.assertRaises(RuntimeError):
+                torch.true_divide(dividend, 2, out=integral_quotient)
+        else:
+            # Tests that requests for a floating quotient succeed
+            floating_quotient = torch.empty(5, device=device, dtype=dtype)
+            div_result = dividend / divisor
+            self.assertEqual(div_result,
+                             torch.true_divide(dividend, divisor, out=floating_quotient))
+            self.assertEqual(dividend / 2,
+                             torch.true_divide(dividend, 2, out=floating_quotient))
 
-        # Tests that requests for a floating quotient succeed
-        floating_quotient = torch.empty(5, device=device, dtype=torch.get_default_dtype())
-        casting_result = dividend.to(torch.get_default_dtype()) / divisor.to(torch.get_default_dtype())
-        self.assertEqual(casting_result, torch.true_divide(dividend, divisor, out=floating_quotient))
+    @onlyOnCPUAndCUDA
+    @dtypes(torch.float, torch.double,
+            torch.bool, torch.uint8, torch.int8, torch.int16, torch.int32, torch.int64)
+    def test_true_divide_inplace(self, device, dtype):
+        dividend = (torch.randn(5, device=device) * 100).to(dtype)
+        divisor = torch.arange(1, 6, device=device).to(dtype)
+
+        # Tests that requests for an integer quotient fail
+        if not dtype.is_floating_point:
+            with self.assertRaises(RuntimeError):
+                dividend.true_divide_(divisor)
+            with self.assertRaises(RuntimeError):
+                dividend.true_divide_(2)
+        else:
+            # Tests that requests for a floating quotient succeed
+            div_result = dividend.clone().div_(divisor)
+            self.assertEqual(div_result, dividend.clone().true_divide_(divisor))
+            self.assertEqual(dividend.clone().div_(2), dividend.clone().true_divide_(2))
 
     def _test_sparse_op_input_tensors(self, device, dtype, coalesced, zeros=True):
         t = self._get_test_tensor(device, dtype, not zeros)

--- a/tools/pyi/gen_pyi.py
+++ b/tools/pyi/gen_pyi.py
@@ -91,6 +91,7 @@ blacklist = [
     'div',
     'div_',
     'div_out',
+    'true_divide', 'true_divide_', 'true_divide_out',
     'floor_divide', 'floor_divide_', 'floor_divide_out',
 ]
 
@@ -176,7 +177,7 @@ def arg_to_type_hint(arg):
 
 
 binary_ops = ('add', 'sub', 'mul', 'div', 'pow', 'lshift', 'rshift', 'mod', 'truediv',
-              'matmul', 'floordiv', 'floor_divide'
+              'matmul', 'floordiv',
               'radd', 'rsub', 'rmul', 'rtruediv', 'rfloordiv', 'rpow',          # reverse arithmetic
               'and', 'or', 'xor',                   # logic
               'iadd', 'iand', 'idiv', 'ilshift', 'imul',
@@ -458,7 +459,7 @@ def gen_pyi(declarations_path, out):
                  .format(FACTORY_PARAMS)],
         'is_grad_enabled': ['def is_grad_enabled() -> _bool: ...']
     })
-    for binop in ['mul', 'div', 'floor_divide']:
+    for binop in ['mul', 'div', 'true_divide', 'floor_divide']:
         unsorted_function_hints[binop].append(
             'def {}(input: Union[Tensor, Number],'
             ' other: Union[Tensor, Number],'
@@ -541,7 +542,7 @@ def gen_pyi(declarations_path, out):
                ],
         'item': ["def item(self) -> Number: ..."],
     })
-    for binop in ['mul', 'div', 'floor_divide']:
+    for binop in ['mul', 'div', 'true_divide', 'floor_divide']:
         for inplace in [False, True]:
             out_suffix = ', *, out: Optional[Tensor]=None'
             if inplace:

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -3087,6 +3087,21 @@ triu_(k=0) -> Tensor
 In-place version of :meth:`~Tensor.triu`
 """)
 
+add_docstr_all('true_divide',
+               r"""
+true_divide(value) -> Tensor
+
+See :func:`torch.true_divide`
+""")
+
+add_docstr_all('true_divide_',
+               r"""
+true_divide_(value) -> Tensor
+
+In-place version of :meth:`~Tensor.true_divide_`
+""")
+
+
 add_docstr_all('trunc',
                r"""
 trunc() -> Tensor

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -6508,7 +6508,7 @@ full(size, fill_value, out=None, dtype=None, layout=torch.strided, device=None, 
 Returns a tensor of size :attr:`size` filled with :attr:`fill_value`.
 
 .. warning::
-    In PyTorch 1.5 bool or integral :attr:`fill_value`s will produce a warning if
+    In PyTorch 1.5 a bool or integral :attr:`fill_value` will produce a warning if
     :attr:`dtype` or :attr:`out` are not set.
     In a future PyTorch release, when :attr:`dtype` and :attr:`out` are not set
     a bool :attr:`fill_value` will return a tensor of torch.bool dtype,

--- a/torch/csrc/utils/python_arg_parser.cpp
+++ b/torch/csrc/utils/python_arg_parser.cpp
@@ -74,6 +74,7 @@ static bool should_allow_numbers_as_tensors(const std::string& name) {
     "div", "div_", "div_out",
     "mul", "mul_", "mul_out",
     "sub", "sub_", "sub_out",
+    "true_divide", "true_divide_", "true_divide_out",
     "floor_divide", "floor_divide_", "floor_divide_out"
   };
   return allowed.find(name) != allowed.end();


### PR DESCRIPTION
Ports https://github.com/pytorch/pytorch/pull/34794 to the 1.5 release branch.