### PR TITLE
[release/1.5] Trying pinning pyyaml and setuptools on macos to older version

### DIFF
--- a/.jenkins/pytorch/macos-common.sh
+++ b/.jenkins/pytorch/macos-common.sh
@@ -18,7 +18,7 @@ if [ ! -d "${WORKSPACE_DIR}/miniconda3" ]; then
 fi
 export PATH="${WORKSPACE_DIR}/miniconda3/bin:$PATH"
 source ${WORKSPACE_DIR}/miniconda3/bin/activate
-retry conda install -y mkl mkl-include numpy pyyaml setuptools cmake cffi ninja
+retry conda install -y mkl mkl-include numpy pyyaml=5.3 setuptools=46.0.0 cmake cffi ninja
 
 # The torch.hub tests make requests to GitHub.
 #


### PR DESCRIPTION
Should hopefully resolve macOS timeouts

Cherry picked from https://github.com/pytorch/pytorch/pull/35296

(cherry picked from commit 4d36b8187b0a3e8696d67ba9729cdfd972a3640e, )
Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

