### PR TITLE
[V1.5.0] Add TORCH_CUDA_API to FilterDescriptor (#35131)

### DIFF
--- a/aten/src/ATen/cudnn/Descriptors.h
+++ b/aten/src/ATen/cudnn/Descriptors.h
@@ -145,7 +145,7 @@ private:
 
 std::ostream& operator<<(std::ostream & out, const TensorDescriptor& d);
 
-class FilterDescriptor
+class TORCH_CUDA_API FilterDescriptor
   : public Descriptor<cudnnFilterStruct,
                       &cudnnCreateFilterDescriptor,
                       &cudnnDestroyFilterDescriptor>


### PR DESCRIPTION
Summary:
    `FilterDescriptor` is missing a `TORCH_CUDA_API`, so this symbol is not exported from `torch_cuda.so`, and users could have trouble building cpp_extension when using cudnn.

    cc: ptrblck
    Pull Request resolved: https://github.com/pytorch/pytorch/pull/35131

    Differential Revision: D20604439

    Pulled By: ezyang

    fbshipit-source-id: c57414fc8a9df9cb1e910e2ec0a48cfdbe7d1779