### PR TITLE
Fix non-deterministic RNG behavior in dist_optimizer tests

### DIFF
--- a/torch/testing/_internal/distributed/rpc/dist_optimizer_test.py
+++ b/torch/testing/_internal/distributed/rpc/dist_optimizer_test.py
@@ -18,11 +18,12 @@ class MyModule:
     lock = threading.Lock()
 
     def __init__(self):
-        # avoid race where 2 modules could be initialized
-        # concurrently thus changing the order random numbers are drawn.
-        with MyModule.lock:
-            torch.manual_seed(0)
-            self.w = torch.rand((3, 3), requires_grad=True)
+        # cannot directly use torch.manual_seed(0) as all threads share the same
+        # same default generator. The race from multiple RPC threads could mess
+        # up the draw order from the RNG, leading to non-deterministic behavior.
+        g_cpu = torch.Generator()
+        g_cpu.manual_seed(0)
+        self.w = torch.rand((3, 3), requires_grad=True, generator=g_cpu)
 
     def forward(self, t1):
         return torch.mm(self.w, t1)
@@ -112,9 +113,10 @@ class DistOptimizerTest(RpcAgentTestFixture):
         )
 
         with dist_autograd.context() as context_id:
-            torch.manual_seed(0)
-            t1 = torch.rand((3, 3), requires_grad=True)
-            t2 = torch.rand((3, 3), requires_grad=True)
+            g_cpu = torch.Generator()
+            g_cpu.manual_seed(0)
+            t1 = torch.rand((3, 3), requires_grad=True, generator=g_cpu)
+            t2 = torch.rand((3, 3), requires_grad=True, generator=g_cpu)
             output1 = rpc_async_method(MyModule.forward, remote_module1, t2)
             output2 = rpc_async_method(MyModule.forward, remote_module2, output1.wait())
             loss = torch.add(output2.wait(), t1).sum()
@@ -150,9 +152,10 @@ class DistOptimizerTest(RpcAgentTestFixture):
         old_w1 = module1.w.clone().detach()
         old_w2 = module2.w.clone().detach()
 
-        torch.manual_seed(0)
-        t1 = torch.rand((3, 3), requires_grad=True)
-        t2 = torch.rand((3, 3), requires_grad=True)
+        g_cpu = torch.Generator()
+        g_cpu.manual_seed(0)
+        t1 = torch.rand((3, 3), requires_grad=True, generator=g_cpu)
+        t2 = torch.rand((3, 3), requires_grad=True, generator=g_cpu)
         output1 = module1.forward(t2)
         output2 = module2.forward(output1)
         loss = torch.add(output2, t1).sum()
@@ -180,9 +183,9 @@ class DistOptimizerTest(RpcAgentTestFixture):
         )
 
         with dist_autograd.context() as context_id:
-            torch.manual_seed(0)
-            t1 = torch.rand((3, 3), requires_grad=True)
-            t2 = torch.rand((3, 3), requires_grad=True)
+            g_cpu.manual_seed(0)
+            t1 = torch.rand((3, 3), requires_grad=True, generator=g_cpu)
+            t2 = torch.rand((3, 3), requires_grad=True, generator=g_cpu)
             output1 = rpc_async_method(MyModule.forward, remote_module1, t2)
             output2 = rpc_async_method(MyModule.forward, remote_module2, output1.wait())
             loss = torch.add(output2.wait(), t1)

--- a/torch/testing/_internal/distributed/rpc/dist_optimizer_test.py
+++ b/torch/testing/_internal/distributed/rpc/dist_optimizer_test.py
@@ -19,8 +19,9 @@ class MyModule:
 
     def __init__(self):
         # cannot directly use torch.manual_seed(0) as all threads share the same
-        # same default generator. The race from multiple RPC threads could mess
-        # up the draw order from the RNG, leading to non-deterministic behavior.
+        # default generator. The race from multiple RPC threads could mess up
+        # the draw order from the default RNG instance, leading to
+        # non-deterministic behavior. Hence, create a dedicated RNG here.
         g_cpu = torch.Generator()
         g_cpu.manual_seed(0)
         self.w = torch.rand((3, 3), requires_grad=True, generator=g_cpu)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#35425 Fix non-deterministic RNG behavior in dist_optimizer tests**

Prior to this commit, dist_optimizer_test.py uses torch.manual_seed(0)
to set RNG state. However, multiple RPC threads from the same
process share the same RNG instance. Therefore, even though we
reset the RNG state before every torch.rand usage, background RPC
thread could still mess up draw order in the RNG, leading to
non-deterministic behavior. This commit address this problem by
avoid using the default RNG.

Closes #34141

Differential Revision: [D20657589](https://our.internmc.facebook.com/intern/diff/D20657589)