### PR TITLE
Selective build for JIT code generation

### DIFF
--- a/tools/jit/gen_jit_dispatch.py
+++ b/tools/jit/gen_jit_dispatch.py
@@ -278,7 +278,14 @@ def load_op_list(path):
     return op_list
 
 
-def gen_jit_dispatch(declarations, out, template_path, disable_autograd=False, selected_op_list_path=None):
+def gen_jit_dispatch(
+    declarations,
+    out,
+    template_path,
+    disable_autograd=False,
+    selected_op_list_path=None,
+    selected_op_list=[],
+):
     REGISTER_ATEN_OPS_CPP = CodeTemplate.from_file(template_path + '/register_aten_ops.cpp')
 
     ops = []
@@ -452,7 +459,7 @@ def gen_jit_dispatch(declarations, out, template_path, disable_autograd=False, s
             additional_jit_decls.append(hacked_twin(decl))
 
     jit_decls.extend(additional_jit_decls)
-    selected_op_list = load_op_list(selected_op_list_path) if selected_op_list_path else None
+    selected_op_list += load_op_list(selected_op_list_path) if selected_op_list_path else []
     jit_decls = filter_decls(jit_decls, disable_autograd, selected_op_list)
 
     # generation is deterministic

--- a/tools/setup_helpers/generate_code.py
+++ b/tools/setup_helpers/generate_code.py
@@ -26,6 +26,7 @@ def generate_code(ninja_global=None,
                   subset=None,
                   disable_autograd=False,
                   selected_op_list_path=None,
+                  selected_op_list=[],
                   disable_trace=False):
     # cwrap depends on pyyaml, so we can't import it earlier
     root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -44,6 +45,7 @@ def generate_code(ninja_global=None,
         gen_autograd_python(declarations_path or DECLARATIONS_PATH, autograd_gen_dir, 'tools/autograd')
 
     if subset == "libtorch" or not subset:
+        # TODO: add selected op mechanism in augotrad to save learning size
         gen_autograd(
             declarations_path or DECLARATIONS_PATH,
             autograd_gen_dir,
@@ -56,6 +58,7 @@ def generate_code(ninja_global=None,
             jit_gen_dir,
             'tools/jit/templates',
             disable_autograd=disable_autograd,
+            selected_op_list=selected_op_list,
             selected_op_list_path=selected_op_list_path)
 
 
@@ -80,6 +83,14 @@ def main():
         help='Path to the yaml file that contains the list of operators to include for custom build.',
     )
     parser.add_argument(
+        '--selected-op-list',
+        default=[],
+        nargs="*",
+        type=str,
+        help="""List of operator names to include for custom build, in addition to those in selected-op-list-path.
+        For example, ["aten::add.Tensor", "aten::_convolution"]""",
+    )
+    parser.add_argument(
         '--disable_gen_tracing',
         default=False,
         action='store_true',
@@ -94,6 +105,7 @@ def main():
         options.subset,
         options.disable_autograd,
         options.selected_op_list_path,
+        options.selected_op_list,
         options.disable_gen_tracing,
     )
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#35427 Selective build for JIT code generation**
* #35426 [Lite Interpreter] Add aten op registration and use op names without "_" prefix

Lite interpreter relies on JIT operator dispatch. In future we still need JIT operator dispatch dispatch ops that are not registered in c10.

Currently the selective build is for c10/aten dispatch in BUCK. There is JIT selective code-gen in OSS but not ported to BUCK yet.

This diff is porting the selective code-gen in BUCK.

* The selected op list is passed to gen_jit_dispatch.py.
* The list passed to gen_jit_dispatch is the top-level ops (USED_PT_OPS) only, because the selective c10/aten dispatch already registered other ops that are called from the top-level ops.

Differential Revision: [D20584872](https://our.internmc.facebook.com/intern/diff/D20584872/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D20584872/)!