### PR TITLE
[dt] [caffe2] add/fix shape inference for StumpFunc, SliceGradient and ResizeLike

### DIFF
--- a/caffe2/operators/slice_op.cc
+++ b/caffe2/operators/slice_op.cc
@@ -112,7 +112,13 @@ Y:
     .Output(0, "Y", "(*Tensor*): sliced output tensor")
     .InheritOnnxSchema();
 
-GRADIENT_OPERATOR_SCHEMA(SliceGradient);
+GRADIENT_OPERATOR_SCHEMA(SliceGradient)
+    .TensorInferenceFunction([](const OperatorDef& /*def*/,
+                                const vector<TensorShape>& in) {
+      vector<TensorShape> out(1);
+      out.at(0) = in.at(0);
+      return out;
+    });
 
 namespace {
 struct GetSliceGradient : public GradientMakerBase {
@@ -133,6 +139,6 @@ struct GetSliceGradient : public GradientMakerBase {
     }
   }
 };
-}
+} // namespace
 REGISTER_GRADIENT(Slice, GetSliceGradient);
 } // namespace caffe2

--- a/caffe2/operators/stump_func_op.cc
+++ b/caffe2/operators/stump_func_op.cc
@@ -63,6 +63,13 @@ OPERATOR_SCHEMA(StumpFunc)
     .NumOutputs(1)
     .Input(0, "X", "tensor of float")
     .Output(0, "Y", "tensor of float")
+    .TensorInferenceFunction([](const OperatorDef&,
+                                const vector<TensorShape>& input_types) {
+      vector<TensorShape> out(1);
+      out.at(0) = input_types.at(0);
+      out.at(0).set_data_type(TensorProto_DataType::TensorProto_DataType_FLOAT);
+      return out;
+    })
     .SetDoc(R"DOC(
 Converts each input element into either high_ or low_value
 based on the given threshold.
@@ -92,4 +99,4 @@ Split the elements and return the indices based on the given threshold.
 
 NO_GRADIENT(StumpFuncIndex);
 
-} // caffe2
+} // namespace caffe2

--- a/caffe2/operators/utility_ops.cc
+++ b/caffe2/operators/utility_ops.cc
@@ -86,9 +86,7 @@ OPERATOR_SCHEMA(Print)
         "limit",
         "(int, default 0) If set, prints the first `limit` elements of tensor. "
         "If 0, prints the first `k_limit_default`(1000) elements of tensor")
-    .Arg(
-        "every_n",
-        "(int, default 1) Print tensor every `every_n` runs")
+    .Arg("every_n", "(int, default 1) Print tensor every `every_n` runs")
     .Input(0, "tensor", "The tensor to print.");
 
 OPERATOR_SCHEMA(LengthsToShape)
@@ -222,7 +220,10 @@ output:
 
 )DOC")
     .Input(0, "input", "A tensor of rank >= 1.")
-    .Output(0, "output", "A tensor of rank 1 (vector) with the contents of the input tensor.");
+    .Output(
+        0,
+        "output",
+        "A tensor of rank 1 (vector) with the contents of the input tensor.");
 
 OPERATOR_SCHEMA(Alias)
     .NumInputs(1)
@@ -247,11 +248,11 @@ similar to multi-thread computation before you use it explicitly.
 OPERATOR_SCHEMA(ResizeLike)
     .NumInputs(2)
     .NumOutputs(1)
-    .TensorInferenceFunction([](const OperatorDef& /*def*/,
+    .TensorInferenceFunction([](const OperatorDef& def,
                                 const vector<TensorShape>& in) {
       vector<TensorShape> out(1);
-      out.push_back(in[1]);
-      out[0].set_data_type(in[0].data_type());
+      out.at(0) = in.at(1);
+      out.at(0).set_data_type(in.at(0).data_type());
       return out;
     })
     .SetDoc(R"DOC(
@@ -399,9 +400,7 @@ Currently only works on CPU because of access to INDICES.
         "UPDATES",
         "Update slices, with shape len(INDICES) + shape(X_0)[1:]")
     .Output(0, "OUTPUT", "The updated output.")
-    .Arg(
-        "axis",
-        "*(type: int; default: 1)* Which dimension to scatter on.");
+    .Arg("axis", "*(type: int; default: 1)* Which dimension to scatter on.");
 
 OPERATOR_SCHEMA(HasElements)
     .NumInputs(1, INT_MAX)
@@ -682,8 +681,6 @@ weights derived by lengths. i.e 1/pow(length, power)
     .Input(0, "lengths", "1-D int32_t or int64_t tensor of lengths")
     .Output(0, "a vector of weights", "1-D float tensor of weights by length");
 
-
-
 SHOULD_NOT_DO_GRADIENT(WallClockTime);
 
 OPERATOR_SCHEMA(EnsureDense)
@@ -878,9 +875,13 @@ REGISTER_CPU_OPERATOR(IsNaN, IsNanOp<CPUContext>);
 OPERATOR_SCHEMA(IsNaN)
     .NumInputs(1)
     .NumOutputs(1)
-    .SetDoc("Returns a new tensor with boolean elements representing if each element is NaN or not.")
+    .SetDoc(
+        "Returns a new tensor with boolean elements representing if each element is NaN or not.")
     .Input(0, "tensor", "Tensor to check for nan")
-    .Output(0, "output", "Tensor containing a 1 at each location of NaN elements."); 
+    .Output(
+        0,
+        "output",
+        "Tensor containing a 1 at each location of NaN elements.");
 
 OPERATOR_SCHEMA(Size)
     .NumInputs(1)
@@ -944,7 +945,10 @@ size: 24
 </details>
 
       )DOC")
-    .Input(0, "X", "*(type: Tensor)* Input tensor to calculate number of elements.")
+    .Input(
+        0,
+        "X",
+        "*(type: Tensor)* Input tensor to calculate number of elements.")
     .Output(
         0,
         "size",
@@ -1025,8 +1029,14 @@ output: [ 4  6  8 10 12 14 16]
         0,
         "start",
         "(*Tensor*): [OPTIONAL] scalar or 1-element tensor containing the start of the interval (inclusive) (default=0)")
-    .Input(1, "stop", "(*Tensor*): scalar or 1-element tensor containing the end of the interval (exclusive)")
-    .Input(2, "step", "(*Tensor*): [OPTIONAL] scalar or 1-element tensor specifying the spacing between values (default=1)")
+    .Input(
+        1,
+        "stop",
+        "(*Tensor*): scalar or 1-element tensor containing the end of the interval (exclusive)")
+    .Input(
+        2,
+        "step",
+        "(*Tensor*): [OPTIONAL] scalar or 1-element tensor specifying the spacing between values (default=1)")
     .Output(
         0,
         "output",

--- a/caffe2/python/hypothesis_test_util.py
+++ b/caffe2/python/hypothesis_test_util.py
@@ -619,7 +619,7 @@ class HypothesisTestCase(test_util.TestCase):
                 # Temporarily catch runtime errors when inferring shape
                 # and type info
                 logging.warning(str(e))
-                if os.getenv('CAFFE2_ASSERT_SHAPEINFERENCE') == '1':
+                if os.getenv('CAFFE2_ASSERT_SHAPEINFERENCE') == '1' or ensure_outputs_are_inferred:
                     raise e
             workspace.RunNetOnce(net)
             reference_outputs = reference(*inputs)

--- a/caffe2/python/operator_test/concat_split_op_test.py
+++ b/caffe2/python/operator_test/concat_split_op_test.py
@@ -124,7 +124,7 @@ class TestConcatSplitOps(serial.SerializedTestCase):
                 for i in range(len(split))
             ]
         outputs_with_grad = range(len(split_info))
-        self.assertReferenceChecks(gc, op, input_tensors, split_ref)
+        self.assertReferenceChecks(gc, op, input_tensors, split_ref, ensure_outputs_are_inferred=True)
         self.assertDeviceChecks(dc, op, input_tensors, outputs_with_grad)
         self.assertGradientChecks(gc, op, input_tensors, 0, outputs_with_grad)
 


### PR DESCRIPTION
Summary:
This fixes and adds tests for several commonly used operators.

There's some formatting differences due to running clang-format on one of the files.

Test Plan: buck test //caffe2/caffe2/fb/operators:hypothesis_test //caffe2/caffe2/python/operator_test:utility_ops_test //caffe2/caffe2/python/operator_test:concat_split_op_test

Differential Revision: D20657405

