### PR TITLE
[1.5 cherrypick] [C++ API Parity] [Optimizers] Merged Optimizer and LossClosureOptimizer

### DIFF
--- a/test/cpp/api/optim.cpp
+++ b/test/cpp/api/optim.cpp
@@ -166,30 +166,66 @@ TEST(OptimTest, OptimizerAccessors) {
   optimizer_.state();
 }
 
-TEST(OptimTest, BasicInterface) {
+#define OLD_INTERFACE_WARNING_CHECK(func) \
+{ \
+  std::stringstream buffer;\
+  torch::test::CerrRedirect cerr_redirect(buffer.rdbuf());\
+  func;\
+  ASSERT_EQ(\
+    torch::test::count_substr_occurrences(\
+      buffer.str(),\
+      "will be removed"\
+    ),\
+  1);\
+}
+
+struct MyOptimizerOptions : public OptimizerCloneableOptions<MyOptimizerOptions> {
+  MyOptimizerOptions(double lr = 1.0) : lr_(lr) {};
+  TORCH_ARG(double, lr) = 1.0;
+};
+
+TEST(OptimTest, OldInterface) {
   struct MyOptimizer : Optimizer {
     using Optimizer::Optimizer;
     torch::Tensor step(LossClosure closure = nullptr) override { return {};}
+    explicit MyOptimizer(
+        std::vector<at::Tensor> params, MyOptimizerOptions defaults = {}) :
+          Optimizer({std::move(OptimizerParamGroup(params))}, std::make_unique<MyOptimizerOptions>(defaults)) {}
   };
   std::vector<torch::Tensor> parameters = {
       torch::ones({2, 3}), torch::zeros({2, 3}), torch::rand({2, 3})};
   {
     MyOptimizer optimizer(parameters);
-    ASSERT_EQ(optimizer.size(), parameters.size());
+    size_t size;
+    OLD_INTERFACE_WARNING_CHECK(size = optimizer.size());
+    ASSERT_EQ(size, parameters.size());
   }
   {
-    MyOptimizer optimizer;
-    ASSERT_EQ(optimizer.size(), 0);
-    optimizer.add_parameters(parameters);
-    ASSERT_EQ(optimizer.size(), parameters.size());
-    for (size_t p = 0; p < parameters.size(); ++p) {
-      ASSERT_TRUE(optimizer.parameters()[p].allclose(parameters[p]));
+    std::vector<at::Tensor> params;
+    MyOptimizer optimizer(params);
+
+    size_t size;
+    OLD_INTERFACE_WARNING_CHECK(size = optimizer.size());
+    ASSERT_EQ(size, 0);
+
+    OLD_INTERFACE_WARNING_CHECK(optimizer.add_parameters(parameters));
+
+    OLD_INTERFACE_WARNING_CHECK(size = optimizer.size());
+    ASSERT_EQ(size, parameters.size());
+
+    std::vector<torch::Tensor> params_;
+    OLD_INTERFACE_WARNING_CHECK(params_ = optimizer.parameters());
+    for (size_t p = 0; p < size; ++p) {
+      ASSERT_TRUE(params_[p].allclose(parameters[p]));
     }
   }
   {
     Linear linear(3, 4);
     MyOptimizer optimizer(linear->parameters());
-    ASSERT_EQ(optimizer.size(), linear->parameters().size());
+
+    size_t size;
+    OLD_INTERFACE_WARNING_CHECK(size = optimizer.size());
+    ASSERT_EQ(size, linear->parameters().size());
   }
 }
 
@@ -375,7 +411,7 @@ TEST(OptimTest, AddParameter_LBFGS) {
   }
 
   LBFGS optimizer(std::vector<torch::Tensor>{}, 1.0);
-  optimizer.add_parameters(parameters);
+  OLD_INTERFACE_WARNING_CHECK(optimizer.add_parameters(parameters));
 
   optimizer.step([]() { return torch::tensor(1); });
 

--- a/torch/csrc/api/include/torch/optim/adagrad.h
+++ b/torch/csrc/api/include/torch/optim/adagrad.h
@@ -47,7 +47,7 @@ public:
 class TORCH_API Adagrad : public Optimizer {
  public:
   explicit Adagrad(std::vector<OptimizerParamGroup> param_groups,
-      AdagradOptions defaults) : Optimizer(std::move(param_groups), std::make_unique<AdagradOptions>(defaults)) {
+      AdagradOptions defaults = {}) : Optimizer(std::move(param_groups), std::make_unique<AdagradOptions>(defaults)) {
     TORCH_CHECK(defaults.lr() >= 0, "Invalid learning rate: ", defaults.lr());
     TORCH_CHECK(defaults.lr_decay() >= 0, "Invalid lr_decay value: ", defaults.lr_decay());
     TORCH_CHECK(defaults.weight_decay() >= 0, "Invalid weight_decay value: ", defaults.weight_decay());
@@ -66,22 +66,9 @@ class TORCH_API Adagrad : public Optimizer {
 
   explicit Adagrad(
       std::vector<Tensor> params,
-      AdagradOptions defaults) : Adagrad({std::move(OptimizerParamGroup(params))}, defaults) {}
+      AdagradOptions defaults = {}) : Adagrad({std::move(OptimizerParamGroup(params))}, defaults) {}
 
   torch::Tensor step(LossClosure closure = nullptr) override;
-
-  /// Adds the given vector of parameters to the optimizer's parameter list.
-  void add_parameters(const std::vector<Tensor>& parameters) override;
-
-  /// Provides a const reference to the parameters this optimizer holds.
-  const std::vector<Tensor>& parameters() const noexcept override;
-
-  /// Provides a reference to the parameters this optimizer holds.
-  std::vector<Tensor>& parameters() noexcept override;
-
-  /// Returns the number of parameters referenced by the optimizer.
-  size_t size() const noexcept override;
-
   void save(serialize::OutputArchive& archive) const override;
   void load(serialize::InputArchive& archive) override;
 

--- a/torch/csrc/api/include/torch/optim/adam.h
+++ b/torch/csrc/api/include/torch/optim/adam.h
@@ -49,7 +49,7 @@ public:
 class TORCH_API Adam : public Optimizer {
  public:
    explicit Adam(std::vector<OptimizerParamGroup> param_groups,
-       AdamOptions defaults) : Optimizer(std::move(param_groups), std::make_unique<AdamOptions>(defaults)) {
+       AdamOptions defaults = {}) : Optimizer(std::move(param_groups), std::make_unique<AdamOptions>(defaults)) {
      TORCH_CHECK(defaults.lr() >= 0, "Invalid learning rate: ", defaults.lr());
      TORCH_CHECK(defaults.eps() >= 0, "Invalid epsilon value: ", defaults.eps());
      auto betas = defaults.betas();
@@ -59,16 +59,11 @@ class TORCH_API Adam : public Optimizer {
    }
    explicit Adam(
        std::vector<Tensor> params,
-       AdamOptions defaults) : Adam({std::move(OptimizerParamGroup(params))}, defaults) {}
+       AdamOptions defaults = {}) : Adam({std::move(OptimizerParamGroup(params))}, defaults) {}
 
   torch::Tensor step(LossClosure closure = nullptr) override;
   void save(serialize::OutputArchive& archive) const override;
   void load(serialize::InputArchive& archive) override;
-
-  void add_parameters(const std::vector<Tensor>& parameters) override;
-  const std::vector<Tensor>& parameters() const noexcept override;
-  std::vector<Tensor>& parameters() noexcept override;
-  size_t size() const noexcept override;
 
  private:
   template <typename Self, typename Archive>

--- a/torch/csrc/api/include/torch/optim/lbfgs.h
+++ b/torch/csrc/api/include/torch/optim/lbfgs.h
@@ -50,10 +50,10 @@ struct TORCH_API LBFGSParamState : public OptimizerCloneableParamState<LBFGSPara
   ~LBFGSParamState() = default;
 };
 
-class TORCH_API LBFGS : public LossClosureOptimizer {
+class TORCH_API LBFGS : public Optimizer {
  public:
    explicit LBFGS(std::vector<OptimizerParamGroup> param_groups,
-       LBFGSOptions defaults) : LossClosureOptimizer(std::move(param_groups), std::make_unique<LBFGSOptions>(defaults)) {
+       LBFGSOptions defaults = {}) : Optimizer(std::move(param_groups), std::make_unique<LBFGSOptions>(defaults)) {
      TORCH_CHECK(param_groups_.size() == 1, "LBFGS doesn't support per-parameter options (parameter groups)");
      if (defaults.max_eval() == c10::nullopt) {
        auto max_eval_val = (defaults.max_iter() * 5) / 4;
@@ -64,13 +64,9 @@ class TORCH_API LBFGS : public LossClosureOptimizer {
    }
    explicit LBFGS(
        std::vector<Tensor> params,
-       LBFGSOptions defaults) : LBFGS({std::move(OptimizerParamGroup(params))}, defaults) {}
+       LBFGSOptions defaults = {}) : LBFGS({std::move(OptimizerParamGroup(params))}, defaults) {}
 
   Tensor step(LossClosure closure) override;
-  void add_parameters(const std::vector<Tensor>& parameters) override;
-  const std::vector<Tensor>& parameters() const noexcept override;
-  std::vector<Tensor>& parameters() noexcept override;
-  size_t size() const noexcept override;
   void save(serialize::OutputArchive& archive) const override;
   void load(serialize::InputArchive& archive) override;
 

--- a/torch/csrc/api/include/torch/optim/optimizer.h
+++ b/torch/csrc/api/include/torch/optim/optimizer.h
@@ -40,7 +40,7 @@ class TORCH_API OptimizerParamState {
 };
 
 template <typename Derived>
-class TORCH_API OptimizerCloneableParamState : public OptimizerParamState {
+class OptimizerCloneableParamState : public OptimizerParamState {
   std::unique_ptr<OptimizerParamState> clone() const override {
     return std::make_unique<Derived>(static_cast<const Derived&>(*this));
   }
@@ -55,7 +55,7 @@ class TORCH_API OptimizerOptions {
 };
 
 template <typename Derived>
-class TORCH_API OptimizerCloneableOptions : public OptimizerOptions {
+class OptimizerCloneableOptions : public OptimizerOptions {
   std::unique_ptr<OptimizerOptions> clone() const override {
     return std::make_unique<Derived>(static_cast<const Derived&>(*this));
   }
@@ -81,58 +81,45 @@ class TORCH_API OptimizerParamGroup {
   std::unique_ptr<OptimizerOptions> options_;
 };
 
-namespace detail {
-
-/// Base class for all optimizers, that does not yet define a `step()`
-/// mechanism. All it specifies is that optimizers must be supplied with a
-/// vector of parameters. It also defines certain methods that all optimizers
-/// shall have, such as `zero_grad`.
-class TORCH_API OptimizerBase {
+class TORCH_API Optimizer {
  public:
   // The copy constructor is deleted, because the user should use the
   // `state_dict` / `load_state_dict` API to copy an optimizer instead.
-  OptimizerBase(const OptimizerBase& optimizer_base) = delete;
-  OptimizerBase(OptimizerBase&& optimizer_base) = default;
+  Optimizer(const Optimizer& optimizer) = delete;
+  Optimizer(Optimizer&& optimizer) = default;
 
-  /// Constructs the `Optimizer` from a vector of parameters.
-  explicit OptimizerBase(std::vector<Tensor> parameters);
-
-  explicit OptimizerBase(std::vector<OptimizerParamGroup> param_groups, std::unique_ptr<OptimizerOptions> defaults) : defaults_(std::move(defaults)) {
+  explicit Optimizer(std::vector<OptimizerParamGroup> param_groups, std::unique_ptr<OptimizerOptions> defaults) : defaults_(std::move(defaults)) {
     for (const auto& param_group : param_groups) {
       add_param_group(param_group);
     }
   }
 
+  /// Constructs the `Optimizer` from a vector of parameters.
+  explicit Optimizer(std::vector<Tensor> parameters, std::unique_ptr<OptimizerOptions> defaults) : Optimizer({std::move(OptimizerParamGroup(parameters))}, std::move(defaults)) {};
+
   /// Adds the given param_group to the optimizer's param_group list.
   void add_param_group(const OptimizerParamGroup& param_group);
 
-  virtual ~OptimizerBase() = default;
+  virtual ~Optimizer() = default;
 
-  // TODO: when all optimizers use the new design, we can devirtualize some of the following methods
-  // such as add_parameters() / parameters() / size()
+  using LossClosure = std::function<Tensor()>;
+  /// A loss function closure, which is expected to return the loss value.
+  virtual Tensor step(LossClosure closure = nullptr) = 0;
 
   /// Adds the given vector of parameters to the optimizer's parameter list.
-  virtual void add_parameters(const std::vector<Tensor>& parameters);
-
-  virtual void _add_parameters_new_design(const std::vector<Tensor>& parameters);
+  void add_parameters(const std::vector<Tensor>& parameters);
 
   /// Zeros out the gradients of all parameters.
-  virtual void zero_grad();
+  void zero_grad();
 
-  /// Provides a const reference to the parameters this optimizer holds.
-  virtual const std::vector<Tensor>& parameters() const noexcept;
+  /// Provides a const reference to the parameters in the first param_group this optimizer holds.
+  const std::vector<Tensor>& parameters() const noexcept;
 
-  virtual const std::vector<Tensor>& _parameters_new_design() const noexcept;
-
-  /// Provides a reference to the parameters this optimizer holds.
-  virtual std::vector<Tensor>& parameters() noexcept;
-
-  virtual std::vector<Tensor>& _parameters_new_design() noexcept;
+  /// Provides a reference to the parameters in the first param_group this optimizer holds.
+  std::vector<Tensor>& parameters() noexcept;
 
   /// Returns the number of parameters referenced by the optimizer.
-  virtual size_t size() const noexcept;
-
-  virtual size_t _size_new_design() const noexcept;
+  size_t size() const noexcept;
 
   OptimizerOptions& defaults() noexcept;
 
@@ -160,27 +147,6 @@ class TORCH_API OptimizerBase {
    std::vector<OptimizerParamGroup> param_groups_;
    ska::flat_hash_map<std::string, std::unique_ptr<OptimizerParamState>> state_;
    std::unique_ptr<OptimizerOptions> defaults_;
-   OptimizerBase() = default;
-
-  /// Accesses a buffer at the given index.
-  /// Additionally, zeros out the buffers when this is called on the index
-  template <typename T>
-  T& buffer_at(std::vector<T>& buffers, size_t index) {
-    if (buffers.size() <= index) {
-      const auto old_size = buffers.size();
-      buffers.resize(index + 1);
-      std::fill(buffers.begin() + old_size, buffers.end(), T{0});
-    }
-    return buffers[index];
-  }
-
-  /// Accesses a buffer at the given index, converts it to the type of the
-  /// parameter at the corresponding index (a no-op if they match).
-  /// Additionally, zeros out the buffers when this is called on the index
-  Tensor& buffer_at(std::vector<Tensor>& buffers, size_t index);
-
-  /// The parameters this optimizer optimizes.
-  std::vector<Tensor> parameters_;
 };
 
 /* How do we decide whether to serialize undefined tensors or
@@ -201,39 +167,15 @@ b) For c10::nullopt value: in param state, c10::nullopt value in C++ impl is equ
    missing key in Python impl. Since we don't serialize missing keys in Python API,
    we skip c10::nullopt values when serializing the param state. */
 
-/// Serializes an `OptimizerBase` into an `OutputArchive`.
+/// Serializes an `Optimizer` into an `OutputArchive`.
 TORCH_API serialize::OutputArchive& operator<<(
     serialize::OutputArchive& archive,
-    const OptimizerBase& optimizer);
+    const Optimizer& optimizer);
 
 /// Deserializes a `Tensor` from an `InputArchive`.
 TORCH_API serialize::InputArchive& operator>>(
     serialize::InputArchive& archive,
-    OptimizerBase& optimizer);
-} // namespace detail
-
-/// Optimizer that can optionally take a loss function in `step()` method
-/// and returns the loss value. The only side effect is that parameters are updated
-/// according to the concrete optimization algorithm.
-class Optimizer : public detail::OptimizerBase {
- public:
-   /// A loss function closure, which is expected to return the loss value.
-   using LossClosure = std::function<Tensor()>;
-   using detail::OptimizerBase::OptimizerBase;
-   virtual Tensor step(LossClosure closure = nullptr) = 0;
-};
-
-/// Optimizer that requires the loss function to be supplied to the `step()`
-/// function, as it may evaluate the loss function multiple times per step.
-/// Examples of such algorithms are conjugate gradient and LBFGS. The `step()`
-/// function also returns the loss value.
-class LossClosureOptimizer : public detail::OptimizerBase {
- public:
-  /// A loss function closure, which is expected to return the loss value.
-  using LossClosure = std::function<Tensor()>;
-  using detail::OptimizerBase::OptimizerBase;
-  virtual Tensor step(LossClosure closure) = 0;
-};
+    Optimizer& optimizer);
 
 } // namespace optim
 } // namespace torch

--- a/torch/csrc/api/include/torch/optim/rmsprop.h
+++ b/torch/csrc/api/include/torch/optim/rmsprop.h
@@ -54,7 +54,7 @@ struct TORCH_API RMSpropParamState : public OptimizerCloneableParamState<RMSprop
 class TORCH_API RMSprop : public Optimizer {
  public:
   explicit RMSprop(std::vector<OptimizerParamGroup> param_groups,
-      RMSpropOptions defaults) : Optimizer(std::move(param_groups), std::make_unique<RMSpropOptions>(defaults)) {
+      RMSpropOptions defaults = {}) : Optimizer(std::move(param_groups), std::make_unique<RMSpropOptions>(defaults)) {
     TORCH_CHECK(defaults.lr() >= 0, "Invalid learning rate: ", defaults.lr());
     TORCH_CHECK(defaults.eps() >= 0, "Invalid epsilon value: ", defaults.eps());
     TORCH_CHECK(defaults.momentum() >= 0, "Invalid momentum value: ", defaults.momentum());
@@ -63,22 +63,9 @@ class TORCH_API RMSprop : public Optimizer {
   }
 
   explicit RMSprop(std::vector<Tensor> params,
-      RMSpropOptions defaults) : RMSprop({std::move(OptimizerParamGroup(params))}, defaults) {}
+      RMSpropOptions defaults = {}) : RMSprop({std::move(OptimizerParamGroup(params))}, defaults) {}
 
   torch::Tensor step(LossClosure closure = nullptr) override;
-
-  /// Returns the number of parameters referenced by the optimizer.
-  size_t size() const noexcept override;
-
-  /// Adds the given vector of parameters to the optimizer's parameter list.
-  void add_parameters(const std::vector<Tensor>& parameters) override;
-
-  /// Provides a const reference to the parameters this optimizer holds.
-  const std::vector<Tensor>& parameters() const noexcept override;
-
-  /// Provides a reference to the parameters this optimizer holds.
-  std::vector<Tensor>& parameters() noexcept override;
-
   void save(serialize::OutputArchive& archive) const override;
   void load(serialize::InputArchive& archive) override;
 

--- a/torch/csrc/api/include/torch/optim/serialize.h
+++ b/torch/csrc/api/include/torch/optim/serialize.h
@@ -131,7 +131,7 @@ void serialize(
 template <typename DerivedOptimizerParamState, typename DerivedOptimizerParamOptions>
 void serialize(
     serialize::OutputArchive& archive,
-    const detail::OptimizerBase& optimizer) {
+    const Optimizer& optimizer) {
   archive.write("pytorch_version", IValue("1.5.0"));
   serialize::OutputArchive state_archive(archive.compilation_unit());
   detail::serialize<DerivedOptimizerParamState>(state_archive, optimizer.state());
@@ -146,7 +146,7 @@ void serialize(
 template <typename DerivedOptimizerParamState, typename DerivedOptimizerParamOptions>
 void serialize(
     serialize::InputArchive& archive,
-    detail::OptimizerBase& optimizer) {
+    Optimizer& optimizer) {
 
     IValue pytorch_version;
     archive.read("pytorch_version", pytorch_version);

--- a/torch/csrc/api/include/torch/optim/sgd.h
+++ b/torch/csrc/api/include/torch/optim/sgd.h
@@ -22,7 +22,7 @@ namespace torch {
 namespace optim {
 
 struct TORCH_API SGDOptions : public OptimizerCloneableOptions<SGDOptions> {
-  /* implicit */ SGDOptions(double lr);
+  SGDOptions(double lr);
   TORCH_ARG(double, lr);
   TORCH_ARG(double, momentum) = 0;
   TORCH_ARG(double, dampening) = 0;
@@ -59,18 +59,6 @@ class TORCH_API SGD : public Optimizer {
       SGDOptions defaults) : SGD({std::move(OptimizerParamGroup(params))}, defaults) {}
 
   torch::Tensor step(LossClosure closure = nullptr) override;
-
-  /// Adds the given vector of parameters to the optimizer's parameter list.
-  void add_parameters(const std::vector<Tensor>& parameters) override;
-
-  /// Provides a const reference to the parameters this optimizer holds.
-  const std::vector<Tensor>& parameters() const noexcept override;
-
-  /// Provides a reference to the parameters this optimizer holds.
-  std::vector<Tensor>& parameters() noexcept override;
-
-  /// Returns the number of parameters referenced by the optimizer.
-  size_t size() const noexcept override;
 
   void save(serialize::OutputArchive& archive) const override;
   void load(serialize::InputArchive& archive) override;

--- a/torch/csrc/api/src/optim/adagrad.cpp
+++ b/torch/csrc/api/src/optim/adagrad.cpp
@@ -109,22 +109,6 @@ Tensor Adagrad::step(LossClosure closure) {
   return loss;
 }
 
-void Adagrad::add_parameters(const std::vector<Tensor>& parameters) {
-  return _add_parameters_new_design(parameters);
-}
-
-const std::vector<Tensor>& Adagrad::parameters() const noexcept {
-  return _parameters_new_design();
-}
-
-std::vector<Tensor>& Adagrad::parameters() noexcept {
-  return _parameters_new_design();
-}
-
-size_t Adagrad::size() const noexcept {
-  return _size_new_design();
-}
-
 void Adagrad::save(serialize::OutputArchive& archive) const {
   serialize(*this, archive);
 }

--- a/torch/csrc/api/src/optim/adam.cpp
+++ b/torch/csrc/api/src/optim/adam.cpp
@@ -12,6 +12,7 @@
 
 namespace torch {
 namespace optim {
+
 AdamOptions::AdamOptions(double lr) : lr_(lr) {}
 
 bool operator==(const AdamOptions& lhs, const AdamOptions& rhs) {
@@ -127,22 +128,6 @@ Tensor Adam::step(LossClosure closure)  {
     }
   }
   return loss;
-}
-
-void Adam::add_parameters(const std::vector<Tensor>& parameters) {
-  return _add_parameters_new_design(parameters);
-}
-
-const std::vector<Tensor>& Adam::parameters() const noexcept {
-  return _parameters_new_design();
-}
-
-std::vector<Tensor>& Adam::parameters() noexcept {
-  return _parameters_new_design();
-}
-
-size_t Adam::size() const noexcept {
-  return _size_new_design();
 }
 
 void Adam::save(serialize::OutputArchive& archive) const {

--- a/torch/csrc/api/src/optim/lbfgs.cpp
+++ b/torch/csrc/api/src/optim/lbfgs.cpp
@@ -552,22 +552,6 @@ Tensor LBFGS::step(LossClosure closure) {
   return orig_loss;
 }
 
-void LBFGS::add_parameters(const std::vector<Tensor>& parameters) {
-  return _add_parameters_new_design(parameters);
-}
-
-const std::vector<Tensor>& LBFGS::parameters() const noexcept {
-  return _parameters_new_design();
-}
-
-std::vector<Tensor>& LBFGS::parameters() noexcept {
-  return _parameters_new_design();
-}
-
-size_t LBFGS::size() const noexcept {
-  return _size_new_design();
-}
-
 void LBFGS::save(serialize::OutputArchive& archive) const {
   serialize(*this, archive);
 }

--- a/torch/csrc/api/src/optim/optimizer.cpp
+++ b/torch/csrc/api/src/optim/optimizer.cpp
@@ -75,14 +75,11 @@ void OptimizerOptions::serialize(torch::serialize::OutputArchive& archive) const
     "You must override it in your subclass of torch::optim::OptimizerCloneableOptions<YourOptimizerOptions>.");
 }
 
-namespace detail {
-OptimizerBase::OptimizerBase(std::vector<Tensor> parameters)
-    : parameters_(std::move(parameters)) {}
-
-void OptimizerBase::add_param_group(const OptimizerParamGroup& param_group) {
+void Optimizer::add_param_group(const OptimizerParamGroup& param_group) {
   for (const auto& param : param_group.params()) {
     TORCH_CHECK(param.is_leaf(), "can't optimize a non-leaf Tensor");
   }
+  TORCH_INTERNAL_ASSERT(defaults_ != nullptr);
   OptimizerParamGroup param_group_(param_group.params());
   if (!param_group.has_options()) {
     param_group_.set_options(defaults_->clone());
@@ -96,22 +93,13 @@ void OptimizerBase::add_param_group(const OptimizerParamGroup& param_group) {
   param_groups_.emplace_back(std::move(param_group_));
 }
 
-void OptimizerBase::add_parameters(const std::vector<Tensor>& parameters) {
-  parameters_.insert(parameters_.end(), parameters.begin(), parameters.end());
-}
-
-void OptimizerBase::_add_parameters_new_design(const std::vector<Tensor>& parameters) {
+void Optimizer::add_parameters(const std::vector<Tensor>& parameters) {
+  TORCH_WARN("Optimizer::add_parameters() will be removed in PyTorch 1.6");
   auto& parameters_ = param_groups_[0].params();
   parameters_.insert(parameters_.end(), parameters.begin(), parameters.end());
 }
 
-void OptimizerBase::zero_grad() {
-  for (auto& parameter : parameters_) {
-    if (parameter.grad().defined()) {
-      parameter.grad().detach_();
-      parameter.grad().zero_();
-    }
-  }
+void Optimizer::zero_grad() {
   for (auto& group : param_groups_) {
     for (auto& p : group.params()) {
       if (p.grad().defined()) {
@@ -122,30 +110,18 @@ void OptimizerBase::zero_grad() {
   }
 }
 
-// TODO: remove this function after all the optimizers use the new design
-const std::vector<Tensor>& OptimizerBase::parameters() const noexcept {
-  return parameters_;
-}
-
-const std::vector<Tensor>& OptimizerBase::_parameters_new_design() const noexcept {
+const std::vector<Tensor>& Optimizer::parameters() const noexcept {
+   TORCH_WARN("Optimizer::parameters() will be removed in PyTorch 1.6");
    return param_groups_.at(0).params();
 }
 
-// TODO: remove this function after all the optimizers use the new design
-std::vector<Tensor>& OptimizerBase::parameters() noexcept {
-  return parameters_;
-}
-
-std::vector<Tensor>& OptimizerBase::_parameters_new_design() noexcept {
+std::vector<Tensor>& Optimizer::parameters() noexcept {
+   TORCH_WARN("Optimizer::parameters() will be removed in PyTorch 1.6");
    return param_groups_.at(0).params();
 }
 
-// TODO: update size to return the sum of #params in all param_groups
-size_t OptimizerBase::size() const noexcept {
-  return parameters_.size();
-}
-
-size_t OptimizerBase::_size_new_design() const noexcept {
+size_t Optimizer::size() const noexcept {
+  TORCH_WARN("Optimizer::size() will be removed in PyTorch 1.6");
   size_t count = 0;
   for (const auto& group : param_groups_) {
     count += group.params().size();
@@ -153,54 +129,37 @@ size_t OptimizerBase::_size_new_design() const noexcept {
   return count;
 }
 
-OptimizerOptions& OptimizerBase::defaults() noexcept {
+OptimizerOptions& Optimizer::defaults() noexcept {
   return *defaults_.get();
 }
 
-const OptimizerOptions& OptimizerBase::defaults() const noexcept {
+const OptimizerOptions& Optimizer::defaults() const noexcept {
   return *defaults_.get();
 }
 
-std::vector<OptimizerParamGroup>& OptimizerBase::param_groups() noexcept {
+std::vector<OptimizerParamGroup>& Optimizer::param_groups() noexcept {
   return param_groups_;
 }
 
-const std::vector<OptimizerParamGroup>& OptimizerBase::param_groups() const noexcept {
+const std::vector<OptimizerParamGroup>& Optimizer::param_groups() const noexcept {
   return param_groups_;
 }
 
-ska::flat_hash_map<std::string, std::unique_ptr<OptimizerParamState>>& OptimizerBase::state() noexcept {
+ska::flat_hash_map<std::string, std::unique_ptr<OptimizerParamState>>& Optimizer::state() noexcept {
   return state_;
 }
 
-const ska::flat_hash_map<std::string, std::unique_ptr<OptimizerParamState>>& OptimizerBase::state() const noexcept {
+const ska::flat_hash_map<std::string, std::unique_ptr<OptimizerParamState>>& Optimizer::state() const noexcept {
   return state_;
 }
 
-Tensor& OptimizerBase::buffer_at(std::vector<Tensor>& buffers, size_t index) {
-  if (buffers.size() <= index) {
-    buffers.reserve(index);
-    for (auto i = buffers.size(); i <= index; ++i) {
-      buffers.emplace_back(torch::zeros_like(parameters_.at(i)));
-    }
-  }
-  // Copy the buffer to the device and dtype of the parameter.
-  const auto& parameter = parameters_.at(index);
-  const auto& buffer = buffers.at(index);
-  if (buffer.device() != parameter.device() ||
-      buffer.dtype() != parameter.dtype()) {
-    buffers[index] = buffer.to(parameter.device(), parameter.scalar_type());
-  }
-  return buffers[index];
-}
+void Optimizer::save(serialize::OutputArchive& archive) const {}
+void Optimizer::load(serialize::InputArchive& archive) {}
 
-void OptimizerBase::save(serialize::OutputArchive& archive) const {}
-void OptimizerBase::load(serialize::InputArchive& archive) {}
-
-/// Serializes an `OptimizerBase` into an `OutputArchive`.
+/// Serializes an `Optimizer` into an `OutputArchive`.
 serialize::OutputArchive& operator<<(
     serialize::OutputArchive& archive,
-    const OptimizerBase& optimizer) {
+    const Optimizer& optimizer) {
   optimizer.save(archive);
   return archive;
 }
@@ -208,10 +167,10 @@ serialize::OutputArchive& operator<<(
 /// Deserializes a `Tensor` from an `InputArchive`.
 serialize::InputArchive& operator>>(
     serialize::InputArchive& archive,
-    OptimizerBase& optimizer) {
+    Optimizer& optimizer) {
   optimizer.load(archive);
   return archive;
 }
-} // namespace detail
+
 } // namespace optim
 } // namespace torch

--- a/torch/csrc/api/src/optim/rmsprop.cpp
+++ b/torch/csrc/api/src/optim/rmsprop.cpp
@@ -129,22 +129,6 @@ Tensor RMSprop::step(LossClosure closure)  {
   return loss;
 }
 
-void RMSprop::add_parameters(const std::vector<Tensor>& parameters) {
-  return _add_parameters_new_design(parameters);
-}
-
-const std::vector<Tensor>& RMSprop::parameters() const noexcept {
-  return _parameters_new_design();
-}
-
-std::vector<Tensor>& RMSprop::parameters() noexcept {
-  return _parameters_new_design();
-}
-
-size_t RMSprop::size() const noexcept {
-  return _size_new_design();
-}
-
 void RMSprop::save(serialize::OutputArchive& archive) const {
   serialize(*this, archive);
 }

--- a/torch/csrc/api/src/optim/sgd.cpp
+++ b/torch/csrc/api/src/optim/sgd.cpp
@@ -98,22 +98,6 @@ Tensor SGD::step(LossClosure closure)  {
   return loss;
 }
 
-void SGD::add_parameters(const std::vector<Tensor>& parameters) {
-  return _add_parameters_new_design(parameters);
-}
-
-const std::vector<Tensor>& SGD::parameters() const noexcept {
-  return _parameters_new_design();
-}
-
-std::vector<Tensor>& SGD::parameters() noexcept {
-  return _parameters_new_design();
-}
-
-size_t SGD::size() const noexcept {
-  return _size_new_design();
-}
-
 void SGD::save(serialize::OutputArchive& archive) const {
   serialize(*this, archive);
 }


### PR DESCRIPTION
PR on master: https://github.com/pytorch/pytorch/pull/34957

1. Removed LossClosureOptimizer, and merged Optimizer into OptimizerBase (and renamed the merged class to Optimizer)
2. Merged the LBFGS-specific serialize test function and the generic test_serialize_optimizer function.
3. BC-compatibility serialization test for LBFGS
4. Removed mentions of parameters_ in optimizer.cpp, de-virtualize all functions
5. Made defaults_ optional argument in all optimizers except SGD

TODO: add BC-breaking notes for this PR