### PR TITLE
Use omp_get_num_threads instead of omp_get_max_threads in OpenMP parallel_for

### DIFF
--- a/aten/src/ATen/ParallelOpenMP.h
+++ b/aten/src/ATen/ParallelOpenMP.h
@@ -21,21 +21,22 @@ inline void parallel_for(
   TORCH_CHECK(grain_size >= 0);
   if (begin >= end) {
     return;
-  } else if (in_parallel_region() || get_num_threads() == 1) {
-    return f(begin, end);
-  } else {
-    std::atomic_flag err_flag = ATOMIC_FLAG_INIT;
-    std::exception_ptr eptr;
-#pragma omp parallel if ((end - begin) > grain_size)
+  }
+#ifdef _OPENMP
+  std::atomic_flag err_flag = ATOMIC_FLAG_INIT;
+  std::exception_ptr eptr;
+
+  if (!omp_in_parallel() && ((end - begin) > grain_size) && get_num_threads() > 1) {
+#pragma omp parallel
     {
       // choose number of tasks based on grain size and number of threads
       // can't use num_threads clause due to bugs in GOMP's thread pool (See #32008)
-      int64_t num_threads = get_num_threads();
+      int64_t num_threads = omp_get_num_threads();
       if (grain_size > 0) {
         num_threads = std::min(num_threads, divup((end - begin), grain_size));
       }
 
-      int64_t tid = get_thread_num();
+      int64_t tid = omp_get_thread_num();
       int64_t chunk_size = divup((end - begin), num_threads);
       int64_t begin_tid = begin + tid * chunk_size;
       if (begin_tid < end) {
@@ -51,6 +52,11 @@ inline void parallel_for(
     if (eptr) {
       std::rethrow_exception(eptr);
     }
+  }
+  else
+#endif
+  {
+    f(begin, end);
   }
 }
 


### PR DESCRIPTION
Summary: In the previous diff D20638734, omp_get_num_threads was replaced with get_num_threads which returns omp_get_max_threads and it leads to seg fault in some tests. This diff changes that to use the correct num of threads in the parallel loop.

Test Plan: buck test mode/opt //papaya/integration/service/test/mnist:mnist_loop_test -- 'MnistFederatedLoopTest\.test'

Differential Revision: D20661416

