### PR TITLE
[quant][graph] Update dynamic quant tests to use new qconfig

### DIFF
--- a/test/test_quantization.py
+++ b/test/test_quantization.py
@@ -1370,6 +1370,7 @@ class ObserverTest(QuantizationTestCase):
         ref = torch._choose_qparams_per_tensor(x, reduce_range)
 
         self.assertEqual(ref[0], qparams[0])
+        print("scale zp ", ref[0], ref[1])
         self.assertEqual(ref[1], qparams[1])
 
 

--- a/test/test_quantize_script.py
+++ b/test/test_quantize_script.py
@@ -3,7 +3,7 @@ import torch.jit
 
 from torch.quantization._quantize_script import script_qconfig
 from torch.quantization._quantize_script import prepare_dynamic_script
-from torch.quantization import default_qconfig
+from torch.quantization import default_dynamic_qconfig
 
 from torch.testing._internal.common_utils import run_tests
 from torch.testing import FileCheck
@@ -21,13 +21,13 @@ class TestScript(JitTestCase):
                 return self.fc(x)
 
         m = torch.jit.script(M())
-        m = prepare_dynamic_script(m, {'': script_qconfig(default_qconfig)})
+        m = prepare_dynamic_script(m, {'': script_qconfig(default_dynamic_qconfig)})
 
         # for input of FC for dynamic quant
         assert len(attrs_with_prefix(m, '_observer_')) == 1
         # for weight
         assert len(attrs_with_prefix(m.fc, '_observer_')) == 1
-        FileCheck().check('Observer = prim::GetAttr[name="_observer_') \
+        FileCheck().check('DynamicQuantObserver = prim::GetAttr[name="_observer_') \
                    .check('prim::GetAttr[name="fc"]') \
                    .check('prim::CallMethod') \
                    .check_not('Observer = prim::GetAttr[name="_observer_') \
@@ -54,7 +54,7 @@ class TestScript(JitTestCase):
 
         m = torch.jit.script(M())
         # only quantize child module.
-        m = prepare_dynamic_script(m, {'sub.fc': script_qconfig(default_qconfig)})
+        m = prepare_dynamic_script(m, {'sub.fc': script_qconfig(default_dynamic_qconfig)})
 
         # input of sub for dynamic quant
         assert len(attrs_with_prefix(m, '_observer_')) == 1
@@ -66,7 +66,7 @@ class TestScript(JitTestCase):
         assert len(attrs_with_prefix(m.sub.fc, '_observer_')) == 1
         FileCheck().check('prim::GetAttr[name="sub') \
                    .check('prim::CallMethod') \
-                   .check('Observer = prim::GetAttr[name="_observer_') \
+                   .check('DynamicQuantObserver = prim::GetAttr[name="_observer_') \
                    .check('prim::CallMethod') \
                    .check_not('Observer = prim::GetAttr[name="_observer_') \
                    .run(m.graph)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#35451 [quant][graph] Update dynamic quant tests to use new qconfig**
* #35455 [quant][graph] Add a new observer type for dynamic quantization

Summary:
default_dynamic_qconfig now holds activation observer

Test Plan:
python test/test_quantize_script.py

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D20664585](https://our.internmc.facebook.com/intern/diff/D20664585)