### PR TITLE
Turn on Python 3.5 CI by default

### DIFF
--- a/.circleci/cimodel/data/pytorch_build_data.py
+++ b/.circleci/cimodel/data/pytorch_build_data.py
@@ -4,7 +4,7 @@ from cimodel.lib.conf_tree import ConfigNode, X, XImportant
 CONFIG_TREE_DATA = [
     ("xenial", [
         (None, [
-            X("3.5"),
+            XImportant("3.5"),
             X("nightly"),
         ]),
         ("gcc", [

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1923,11 +1923,6 @@ workflows:
           name: pytorch_linux_xenial_py3_5_build
           requires:
             - setup
-          filters:
-            branches:
-              only:
-                - master
-                - /ci-all\/.*/
           build_environment: "pytorch-linux-xenial-py3.5-build"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3.5:f990c76a-a798-42bb-852f-5be5006f8026"
       - pytorch_linux_test:
@@ -1935,11 +1930,6 @@ workflows:
           requires:
             - setup
             - pytorch_linux_xenial_py3_5_build
-          filters:
-            branches:
-              only:
-                - master
-                - /ci-all\/.*/
           build_environment: "pytorch-linux-xenial-py3.5-test"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3.5:f990c76a-a798-42bb-852f-5be5006f8026"
           resource_class: large


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#35466 Turn on Python 3.5 CI by default**

We are getting close to turning off Python 2 CI, which means
that Python 3.5 is our new "oldest supported version of PyTorch".
This means we should be running it by default to catch use of
Python features that aren't present in Python 3.6.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>