### PR TITLE
Fixes default dtype value for onnx hardtanh export (opset11)

### DIFF
--- a/torch/onnx/symbolic_opset11.py
+++ b/torch/onnx/symbolic_opset11.py
@@ -21,7 +21,7 @@ from torch.nn.modules.utils import _single, _pair, _triple
 @parse_args('v', 'f', 'f')
 def hardtanh(g, self, min_val, max_val):
     dtype = self.type().scalarType()
-    if dtype is not None:
+    if dtype is None:
         dtype = 6  # float
     else:
         dtype = sym_help.scalar_type_to_onnx.index(sym_help.cast_pytorch_to_onnx[dtype])


### PR DESCRIPTION
Oneline fix to @lara-hdr 's PR https://github.com/pytorch/pytorch/pull/30169.

Default `dtype` value should be set when `dtype is None` rather than when `dtype is not None`. 

I didn't make an issue for this as such a small change but I have been using this locally in order to export a model with opset 11 (opset 10 still works). 