### PR TITLE
[JIT] remove const

### DIFF
--- a/torch/csrc/jit/ir/alias_analysis.cpp
+++ b/torch/csrc/jit/ir/alias_analysis.cpp
@@ -70,7 +70,7 @@ AliasDb::AliasDb(std::shared_ptr<Graph> graph, bool isFrozen)
   GRAPH_DEBUG(toString());
 }
 
-bool AliasDb::isMutable(Node* n) const {
+bool AliasDb::isMutable(Node* n) {
   ValueSet vs;
   for (const auto input : n->inputs()) {
     vs.insert(input);
@@ -78,7 +78,7 @@ bool AliasDb::isMutable(Node* n) const {
   return writesToAlias(n, vs);
 }
 
-bool AliasDb::hasInputWriters(const Node* n) const {
+bool AliasDb::hasInputWriters(const Node* n) {
   for (const auto input : n->inputs()) {
     if (hasWriters(input)) {
       return true;
@@ -87,7 +87,7 @@ bool AliasDb::hasInputWriters(const Node* n) const {
   return false;
 }
 
-bool AliasDb::hasOutputWriters(const Node* n) const {
+bool AliasDb::hasOutputWriters(const Node* n) {
   for (const auto output : n->outputs()) {
     if (hasWriters(output)) {
       return true;
@@ -96,11 +96,11 @@ bool AliasDb::hasOutputWriters(const Node* n) const {
   return false;
 }
 
-bool AliasDb::hasWriters(const Node* n) const {
+bool AliasDb::hasWriters(const Node* n) {
   return hasInputWriters(n) || hasOutputWriters(n);
 }
 
-bool AliasDb::hasWriters(const Value* v) const {
+bool AliasDb::hasWriters(const Value* v) {
   if (v->mustBeNone()) {
     return false;
   }
@@ -117,7 +117,7 @@ bool AliasDb::hasWriters(const Value* v) const {
   return writeCache_.intersects(el->getMemoryLocations());
 }
 
-void AliasDb::getWritesImpl(Node* n, MemoryLocations& ret) const {
+void AliasDb::getWritesImpl(Node* n, MemoryLocations& ret) {
   if (writeIndex_.count(n)) {
     const auto& writes = writeIndex_.at(n);
     ret |= writes;
@@ -131,7 +131,7 @@ void AliasDb::getWritesImpl(Node* n, MemoryLocations& ret) const {
 }
 
 // Does `n` write to an alias of one of the values in `vs`?
-bool AliasDb::writesToAlias(Node* n, const ValueSet& vs) const {
+bool AliasDb::writesToAlias(Node* n, const ValueSet& vs) {
   const auto writtenTo = getWrites(n);
   if (writtenTo.empty()) {
     return false;
@@ -151,13 +151,13 @@ bool AliasDb::writesToAlias(Node* n, const ValueSet& vs) const {
   return false;
 }
 
-MemoryLocations AliasDb::getWrites(Node* n) const {
+MemoryLocations AliasDb::getWrites(Node* n) {
   MemoryLocations writes;
   getWritesImpl(n, writes);
   return writes;
 }
 
-void AliasDb::getReadsImpl(Node* n, MemoryLocations& ret) const {
+void AliasDb::getReadsImpl(Node* n, MemoryLocations& ret) {
   for (const auto input : n->inputs()) {
     auto it = elementMap_.find(input);
     if (it != elementMap_.end()) {
@@ -181,13 +181,13 @@ void AliasDb::getReadsImpl(Node* n, MemoryLocations& ret) const {
   }
 }
 
-MemoryLocations AliasDb::getReads(Node* n) const {
+MemoryLocations AliasDb::getReads(Node* n) {
   MemoryLocations reads;
   getReadsImpl(n, reads);
   return reads;
 }
 
-std::string AliasDb::getElementName(const Element* e) const {
+std::string AliasDb::getElementName(const Element* e) {
   if (e->value == nullptr) {
     // not the most efficient way, but given the fact there are
     // not too many types and even fewer of them will end up in
@@ -204,11 +204,11 @@ std::string AliasDb::getElementName(const Element* e) const {
   }
 }
 
-void AliasDb::dump() const {
+void AliasDb::dump() {
   std::cout << toString();
 }
 
-std::string AliasDb::toString() const {
+std::string AliasDb::toString() {
   std::stringstream ss{};
 
   ss << "\n===1. GRAPH===\n";
@@ -776,7 +776,7 @@ void AliasDb::analyzeBroadcastingChunk(Node* node) {
   }
 }
 
-bool AliasDb::nonAliasingValue(const Value* elem) const {
+bool AliasDb::nonAliasingValue(const Value* elem) {
   // these are values which can point to aliasing types in the graph,
   // as with a None value pointing to an optional if node output,
   // but will never alias themselves
@@ -836,7 +836,7 @@ void AliasDb::addToContainedElements(
   memoryDAG_->addToContainedElements(elemEl, contEl);
 }
 
-bool AliasDb::mayAlias(const Value* a, const Value* b) const {
+bool AliasDb::mayAlias(const Value* a, const Value* b) {
   if (!mutableType(a) || !mutableType(b)) {
     return false;
   }
@@ -844,7 +844,7 @@ bool AliasDb::mayAlias(const Value* a, const Value* b) const {
   return memoryDAG_->mayAlias(elementMap_.at(a), elementMap_.at(b));
 }
 
-bool AliasDb::mayAlias(const ValueSet& a, const ValueSet& b) const {
+bool AliasDb::mayAlias(const ValueSet& a, const ValueSet& b) {
   if (a.empty() || b.empty()) {
     return false;
   }
@@ -871,14 +871,14 @@ bool AliasDb::mayAlias(const ValueSet& a, const ValueSet& b) const {
   return false;
 }
 
-bool AliasDb::mayContainAlias(Value* a, Value* b) const {
+bool AliasDb::mayContainAlias(Value* a, Value* b) {
   const std::vector<Value*> a_vec = {a};
   const std::vector<Value*> b_vec = {b};
 
   return mayContainAlias(a_vec, b_vec);
 }
 
-std::vector<Element*> AliasDb::getElements(at::ArrayRef<Value*> vs) const {
+std::vector<Element*> AliasDb::getElements(at::ArrayRef<Value*> vs) {
   std::vector<Element*> elements;
   for (const auto& val : vs) {
     if (mutableType(val)) {
@@ -890,7 +890,7 @@ std::vector<Element*> AliasDb::getElements(at::ArrayRef<Value*> vs) const {
 
 bool AliasDb::mayContainAlias(
     const at::ArrayRef<Value*> a,
-    const at::ArrayRef<Value*> b) const {
+    const at::ArrayRef<Value*> b) {
   auto a_elems = getElements(a);
   return a_elems.size() == 0 ? false : memoryDAG_->mayContainAlias(a_elems, getElements(b));
 }
@@ -950,13 +950,13 @@ bool AliasDb::couldMoveBeforeTopologically(Node* n, Node* movePoint) {
   return tryMove(n, movePoint, MoveSide::BEFORE, /*dryRun=*/true);
 }
 
-bool AliasDb::hasWriters(const at::ArrayRef<Value*>& values) const {
+bool AliasDb::hasWriters(const at::ArrayRef<Value*>& values) {
   return std::any_of(values.begin(), values.end(), [&](Value* value) {
     return hasWriters(value);
   });
 }
 
-bool AliasDb::escapesScope(const at::ArrayRef<Value*>& vs) const {
+bool AliasDb::escapesScope(const at::ArrayRef<Value*>& vs) {
   return mayContainAlias(graph_->inputs(), vs) ||
       mayContainAlias(graph_->outputs(), vs) || mayAliasWildcard(vs);
 }
@@ -967,7 +967,7 @@ bool AliasDb::escapesScope(const at::ArrayRef<Value*>& vs) const {
 // by aliasing a graph output or input, or by aliasing the wildcard set.
 bool AliasDb::safeToChangeAliasingRelationship(
     const at::ArrayRef<Value*>& a,
-    const at::ArrayRef<Value*>& b) const {
+    const at::ArrayRef<Value*>& b) {
   if (hasWriters(a) || hasWriters(b)) {
     return false;
   }
@@ -978,7 +978,7 @@ bool AliasDb::safeToChangeAliasingRelationship(
 // Helper for topologically-safe node moves. See `tryMove()` for details.
 class AliasDb::WorkingSet {
  public:
-  explicit WorkingSet(Node* mover, const AliasDb& aliasDb) : aliasDb_(aliasDb) {
+  explicit WorkingSet(Node* mover, AliasDb& aliasDb) : aliasDb_(aliasDb) {
     mover_ = mover;
     for (const auto user : getUsersSameBlock(mover_)) {
       moverUsers_.insert(user);
@@ -1010,7 +1010,7 @@ class AliasDb::WorkingSet {
   }
 
   // Does the working set depend on `n`?
-  bool dependsOn(Node* n) const {
+  bool dependsOn(Node* n) {
     if (!mover_ && nodes_.empty()) {
       return false;
     }
@@ -1019,7 +1019,7 @@ class AliasDb::WorkingSet {
   }
 
  private:
-  bool hasDataDependency(Node* n) const {
+  bool hasDataDependency(Node* n) {
     if (!mover_ && nodes_.empty()) {
       return false;
     }
@@ -1031,7 +1031,7 @@ class AliasDb::WorkingSet {
     }
   }
 
-  bool hasMutabilityDependency(Node* n) const {
+  bool hasMutabilityDependency(Node* n) {
     // Check that `n` does not write to anything used by the working set
     const auto& nWrites = aliasDb_.getWrites(n);
     if (reads_.intersects(nWrites)) {
@@ -1053,7 +1053,7 @@ class AliasDb::WorkingSet {
   }
 
   // Does the working set produce any values consumed by `n`?
-  bool producesFor(Node* n) const {
+  bool producesFor(Node* n) {
     // This equivalent to asking: does the total use-set of all the nodes in the
     // working set include `n`?
     if (mover_ && moverUsers_.count(n)) {
@@ -1063,7 +1063,7 @@ class AliasDb::WorkingSet {
   }
 
   // Does the working set consume any values produced by `n`?
-  bool consumesFrom(Node* n) const {
+  bool consumesFrom(Node* n) {
     const auto users = getUsersSameBlock(n);
 
     if (mover_ && users.count(mover_)) {
@@ -1077,7 +1077,7 @@ class AliasDb::WorkingSet {
   // Get all users of outputs of `n`, in the same block as `n`.
   // This means if there is an `if` node that uses an output of `n` in some
   // inner sub-block, we will consider the whole `if` node a user of `n`.
-  std::unordered_set<Node*> getUsersSameBlock(Node* n) const {
+  std::unordered_set<Node*> getUsersSameBlock(Node* n) {
     std::unordered_set<Node*> users;
     for (const auto output : n->outputs()) {
       for (const auto& use : output->uses()) {
@@ -1113,7 +1113,7 @@ class AliasDb::WorkingSet {
     }
   }
 
-  const AliasDb& aliasDb_;
+  AliasDb& aliasDb_;
   std::vector<Node*> nodes_;
 
   // Mover dependencies. We track these separately since we may erase the mover
@@ -1247,7 +1247,7 @@ void AliasDb::move(Node* toMove, Node* movePoint, MoveSide moveSide) {
   }
 }
 
-bool AliasDb::writesToWildcard(Node* n) const {
+bool AliasDb::writesToWildcard(Node* n) {
   if (!writeIndex_.count(n)) {
     return false;
   }
@@ -1263,7 +1263,7 @@ bool AliasDb::writesToWildcard(Node* n) const {
   return false;
 }
 
-bool AliasDb::mayAliasWildcard(const Value* v) const {
+bool AliasDb::mayAliasWildcard(const Value* v) {
   if (auto e = getWildcard(v->type())) {
     return memoryDAG_->mayAlias(elementMap_.at(v), e);
   }
@@ -1271,7 +1271,7 @@ bool AliasDb::mayAliasWildcard(const Value* v) const {
   return false;
 }
 
-bool AliasDb::mayAliasWildcard(const at::ArrayRef<Value*> vs) const {
+bool AliasDb::mayAliasWildcard(const at::ArrayRef<Value*> vs) {
   return std::any_of(
       vs.begin(), vs.end(), [&](Value* v) { return mayAliasWildcard(v); });
 }
@@ -1306,7 +1306,7 @@ void AliasDb::addContainedTypesToFreshElement(
 
 // Search the wildcard index for an element that corresponds to the given type.
 // Const version returns nullptr
-Element* AliasDb::getWildcard(const TypePtr& type) const {
+Element* AliasDb::getWildcard(const TypePtr& type) {
   auto maybe_mut_type = getMutableTypePtr(type);
   if (!maybe_mut_type) {
     return nullptr;
@@ -1349,11 +1349,11 @@ c10::optional<Element*> AliasDb::setWildcard(const Value* v) {
   return wildcardElement;
 }
 
-void AliasDb::rebuildWriteCache() const {
+void AliasDb::rebuildWriteCache() {
   for (const auto& pr : writeIndex_) {
     const auto& writtenLocs = pr.second;
       writeCache_ |= writtenLocs;
-    }
+  }
   isWriteCacheStale_ = false;
 }
 } // namespace jit

--- a/torch/csrc/jit/ir/alias_analysis.h
+++ b/torch/csrc/jit/ir/alias_analysis.h
@@ -49,50 +49,50 @@ class AliasDb {
   //
   // These nodes are considered not safe to eliminate or mutate under any
   // circumstances.
-  bool writesToWildcard(Node* n) const;
+  bool writesToWildcard(Node* n);
 
   // Does `n` write to an alias of one of the values in `vs`?
   // if `recurseBlocks` is true, consider writes on the nodes in `n`s sub-blocks
-  TORCH_API bool writesToAlias(Node* n, const ValueSet& vs) const;
+  TORCH_API bool writesToAlias(Node* n, const ValueSet& vs);
 
   // Does `a` and `b` potentially share a memory location or do either
   // hold in memory any element that exists in the other
-  TORCH_API bool mayContainAlias(Value* a, Value* b) const;
+  TORCH_API bool mayContainAlias(Value* a, Value* b);
 
   // Do any values in group `a` share a memory location or hold in memory
   // any element that exists in group `b`
   TORCH_API bool mayContainAlias(
       const at::ArrayRef<Value*> a,
-      const at::ArrayRef<Value*> b) const;
+      const at::ArrayRef<Value*> b);
 
   // Do `a` and `b` potentially share a memory location?
-  TORCH_API bool mayAlias(const Value* a, const Value* b) const;
+  TORCH_API bool mayAlias(const Value* a, const Value* b);
   // Do any values in group `a` potentially share a memory location with any
   // value in group `b`? i.e. may they overlap?
-  TORCH_API bool mayAlias(const ValueSet& a, const ValueSet& b) const;
+  TORCH_API bool mayAlias(const ValueSet& a, const ValueSet& b);
 
   // Do any nodes write to an alias set input to `n`?
-  TORCH_API bool hasInputWriters(const Node* n) const;
+  TORCH_API bool hasInputWriters(const Node* n);
 
   // Do any nodes write to an alias set output by `n`?
-  TORCH_API bool hasOutputWriters(const Node* n) const;
+  TORCH_API bool hasOutputWriters(const Node* n);
 
   // Do any nodes write to an alias set inputed/outputed by `n`?
-  TORCH_API bool hasWriters(const Node* n) const;
+  TORCH_API bool hasWriters(const Node* n);
 
   // Do any nodes write to `v`s memory location?
-  TORCH_API bool hasWriters(const Value* v) const;
+  TORCH_API bool hasWriters(const Value* v);
 
   // Is the operation in-place? i.e. doesn't write anywhere but locations it
   // reads from.
-  TORCH_API bool isMutable(Node* n) const;
+  TORCH_API bool isMutable(Node* n);
 
-  TORCH_API bool escapesScope(const at::ArrayRef<Value*>& vs) const;
+  TORCH_API bool escapesScope(const at::ArrayRef<Value*>& vs);
 
   // Is it safe to change whether `a` and `b` alias each other ?
   TORCH_API bool safeToChangeAliasingRelationship(
       const at::ArrayRef<Value*>& a,
-      const at::ArrayRef<Value*>& b) const;
+      const at::ArrayRef<Value*>& b);
 
   // Move 'n' (already in the graph) after 'movePoint' in the topological order.
   //
@@ -110,8 +110,8 @@ class AliasDb {
   bool couldMoveBeforeTopologically(Node* n, Node* movePoint);
 
   // For debugging: print alias db state to stdout
-  TORCH_API void dump() const;
-  TORCH_API std::string toString() const;
+  TORCH_API void dump();
+  TORCH_API std::string toString();
 
   static bool mutableType(const Value* v);
   static bool mutableType(const TypePtr& type);
@@ -122,7 +122,7 @@ class AliasDb {
   enum class MoveSide { BEFORE, AFTER };
   bool tryMove(Node* toMove, Node* movePoint, MoveSide moveSide, bool dryRun);
   void move(Node* toMove, Node* movePoint, MoveSide moveSide);
-  bool isBeforeOrAfter(const Node* n, MoveSide moveSide) const;
+  bool isBeforeOrAfter(const Node* n, MoveSide moveSide);
 
   /**
    * Write and read internal API
@@ -131,15 +131,15 @@ class AliasDb {
   // NOTE: this only returns values directly written to, not aliases thereof
   //
   // if `recurseBlocks` is true, gather writes on the nodes in `n`s sub-blocks
-  MemoryLocations getWrites(Node* n) const;
-  void getWritesImpl(Node* n, MemoryLocations& ret) const;
+  MemoryLocations getWrites(Node* n);
+  void getWritesImpl(Node* n, MemoryLocations& ret);
   // Register the fact that `n` writes to `v`.
   void registerWrite(const Value* v, Node* n);
   void registerWrite(const Element* e, Node* n);
   // Get all the values that `n` reads from.
   // if `recurseBlocks` is true, gather reads on the nodes in `n`s sub-blocks
-  MemoryLocations getReads(Node* n) const;
-  void getReadsImpl(Node* n, MemoryLocations& ret) const;
+  MemoryLocations getReads(Node* n);
+  void getReadsImpl(Node* n, MemoryLocations& ret);
 
   /**
    * Wildcard methods
@@ -148,7 +148,7 @@ class AliasDb {
   c10::optional<Element*> setWildcard(const Value* v);
 
   // Is this a value which will not alias
-  bool nonAliasingValue(const Value* elem) const;
+  bool nonAliasingValue(const Value* elem);
 
   /**
    * Special analysis methods
@@ -202,16 +202,16 @@ class AliasDb {
   ska::flat_hash_map<const Value*, Element*> elementMap_;
   // All wildcard elements (one for each unique mutable type).
   std::unordered_map<TypePtr, Element*, HashType, EqualType> wildcardIndex_;
-  Element* getWildcard(const TypePtr& type) const;
+  Element* getWildcard(const TypePtr& type);
   c10::optional<Element*> tryGetOrCreateWildcard(const TypePtr& type);
   void addContainedTypesToFreshElement(
       Element* container_elem,
       const TypePtr& mut_type);
 
-  std::vector<Element*> getElements(at::ArrayRef<Value*> vs) const;
-  bool mayAliasWildcard(const Value* v) const;
-  bool mayAliasWildcard(const at::ArrayRef<Value*> vs) const;
-  bool hasWriters(const at::ArrayRef<Value*>& values) const;
+  std::vector<Element*> getElements(at::ArrayRef<Value*> vs);
+  bool mayAliasWildcard(const Value* v);
+  bool mayAliasWildcard(const at::ArrayRef<Value*> vs);
+  bool hasWriters(const at::ArrayRef<Value*>& values);
 
   /**
    * State for tracking write info.
@@ -221,8 +221,8 @@ class AliasDb {
   // Set of all memory locations that may have been written to.
   mutable MemoryLocations writeCache_;
   mutable bool isWriteCacheStale_ = true;
-  void rebuildWriteCache() const;
-  std::string getElementName(const Element* e) const;
+  void rebuildWriteCache();
+  std::string getElementName(const Element* e);
 };
 
 } // namespace jit

--- a/torch/csrc/jit/passes/common_subexpression_elimination.cpp
+++ b/torch/csrc/jit/passes/common_subexpression_elimination.cpp
@@ -15,7 +15,7 @@ namespace {
 // Since the nodes are visited in topological order, one pass is enough.
 void EliminateCommonSubexpression(
     Block* block,
-    const AliasDb& aliasDb,
+    AliasDb& aliasDb,
     std::function<Node*(Node*)> parent_lookup_fn) {
   std::unordered_set<Node*, HashNode, EqualNode> subexprs;
   for (auto it = block->nodes().begin(); it != block->nodes().end(); ++it) {

--- a/torch/csrc/jit/passes/constant_pooling.cpp
+++ b/torch/csrc/jit/passes/constant_pooling.cpp
@@ -15,7 +15,7 @@ namespace {
 void ConstantPooling(
     Block* block,
     std::unordered_set<Node*, HashNode, EqualNode>& constants,
-    const AliasDb& aliasDb) {
+    AliasDb& aliasDb) {
   for (auto it = block->nodes().begin(); it != block->nodes().end();) {
     auto node = *it;
     // node may be moved to a different block so advance iterator now

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -87,7 +87,7 @@ class ShapePropagator {
 
  private:
   ValueSet resized_alias_set;
-  const AliasDb aliasDb_;
+  AliasDb aliasDb_;
 
   bool resizesInput(Node* n) {
     static std::unordered_set<Symbol> resize_ops{


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #35474 optimize mutableType calls
* **#35473 remove const**

In this next PR i add caching, so pretty much no method is really const. Previously many of the const functions actually mutated internal state, such as rebuildWriteCache. 
