### PR TITLE
[release/1.5] circleci: Remove python 2 binary builds

### DIFF
--- a/.circleci/cimodel/data/binary_build_data.py
+++ b/.circleci/cimodel/data/binary_build_data.py
@@ -34,8 +34,6 @@ def get_processor_arch_name(cuda_version):
 
 LINUX_PACKAGE_VARIANTS = OrderedDict(
     manywheel=[
-        "2.7m",
-        "2.7mu",
         "3.5m",
         "3.6m",
         "3.7m",

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2545,28 +2545,6 @@ workflows:
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
 
       - smoke_linux_test:
-          name: smoke_linux_manywheel_2_7m_cpu_devtoolset7_nightly
-          build_environment: "manywheel 2.7m cpu devtoolset7"
-          requires:
-            - setup
-            - update_s3_htmls_for_nightlies
-            - update_s3_htmls_for_nightlies_devtoolset7
-          filters:
-            branches:
-              only: postnightly
-          docker_image: "pytorch/manylinux-cuda102"
-      - smoke_linux_test:
-          name: smoke_linux_manywheel_2_7mu_cpu_devtoolset7_nightly
-          build_environment: "manywheel 2.7mu cpu devtoolset7"
-          requires:
-            - setup
-            - update_s3_htmls_for_nightlies
-            - update_s3_htmls_for_nightlies_devtoolset7
-          filters:
-            branches:
-              only: postnightly
-          docker_image: "pytorch/manylinux-cuda102"
-      - smoke_linux_test:
           name: smoke_linux_manywheel_3_5m_cpu_devtoolset7_nightly
           build_environment: "manywheel 3.5m cpu devtoolset7"
           requires:
@@ -2610,32 +2588,6 @@ workflows:
             branches:
               only: postnightly
           docker_image: "pytorch/manylinux-cuda102"
-      - smoke_linux_test:
-          name: smoke_linux_manywheel_2_7m_cu92_devtoolset7_nightly
-          build_environment: "manywheel 2.7m cu92 devtoolset7"
-          requires:
-            - setup
-            - update_s3_htmls_for_nightlies
-            - update_s3_htmls_for_nightlies_devtoolset7
-          filters:
-            branches:
-              only: postnightly
-          docker_image: "pytorch/manylinux-cuda92"
-          use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
-      - smoke_linux_test:
-          name: smoke_linux_manywheel_2_7mu_cu92_devtoolset7_nightly
-          build_environment: "manywheel 2.7mu cu92 devtoolset7"
-          requires:
-            - setup
-            - update_s3_htmls_for_nightlies
-            - update_s3_htmls_for_nightlies_devtoolset7
-          filters:
-            branches:
-              only: postnightly
-          docker_image: "pytorch/manylinux-cuda92"
-          use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
       - smoke_linux_test:
           name: smoke_linux_manywheel_3_5m_cu92_devtoolset7_nightly
           build_environment: "manywheel 3.5m cu92 devtoolset7"
@@ -2689,32 +2641,6 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
-          name: smoke_linux_manywheel_2_7m_cu101_devtoolset7_nightly
-          build_environment: "manywheel 2.7m cu101 devtoolset7"
-          requires:
-            - setup
-            - update_s3_htmls_for_nightlies
-            - update_s3_htmls_for_nightlies_devtoolset7
-          filters:
-            branches:
-              only: postnightly
-          docker_image: "pytorch/manylinux-cuda101"
-          use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
-      - smoke_linux_test:
-          name: smoke_linux_manywheel_2_7mu_cu101_devtoolset7_nightly
-          build_environment: "manywheel 2.7mu cu101 devtoolset7"
-          requires:
-            - setup
-            - update_s3_htmls_for_nightlies
-            - update_s3_htmls_for_nightlies_devtoolset7
-          filters:
-            branches:
-              only: postnightly
-          docker_image: "pytorch/manylinux-cuda101"
-          use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
-      - smoke_linux_test:
           name: smoke_linux_manywheel_3_5m_cu101_devtoolset7_nightly
           build_environment: "manywheel 3.5m cu101 devtoolset7"
           requires:
@@ -2764,32 +2690,6 @@ workflows:
             branches:
               only: postnightly
           docker_image: "pytorch/manylinux-cuda101"
-          use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
-      - smoke_linux_test:
-          name: smoke_linux_manywheel_2_7m_cu102_devtoolset7_nightly
-          build_environment: "manywheel 2.7m cu102 devtoolset7"
-          requires:
-            - setup
-            - update_s3_htmls_for_nightlies
-            - update_s3_htmls_for_nightlies_devtoolset7
-          filters:
-            branches:
-              only: postnightly
-          docker_image: "pytorch/manylinux-cuda102"
-          use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
-      - smoke_linux_test:
-          name: smoke_linux_manywheel_2_7mu_cu102_devtoolset7_nightly
-          build_environment: "manywheel 2.7mu cu102 devtoolset7"
-          requires:
-            - setup
-            - update_s3_htmls_for_nightlies
-            - update_s3_htmls_for_nightlies_devtoolset7
-          filters:
-            branches:
-              only: postnightly
-          docker_image: "pytorch/manylinux-cuda102"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
@@ -3637,28 +3537,6 @@ workflows:
             branches:
               only: postnightly
       - binary_linux_build:
-          name: binary_linux_manywheel_2_7m_cpu_devtoolset7_nightly_build
-          build_environment: "manywheel 2.7m cpu devtoolset7"
-          requires:
-            - setup
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          docker_image: "pytorch/manylinux-cuda102"
-      - binary_linux_build:
-          name: binary_linux_manywheel_2_7mu_cpu_devtoolset7_nightly_build
-          build_environment: "manywheel 2.7mu cpu devtoolset7"
-          requires:
-            - setup
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          docker_image: "pytorch/manylinux-cuda102"
-      - binary_linux_build:
           name: binary_linux_manywheel_3_5m_cpu_devtoolset7_nightly_build
           build_environment: "manywheel 3.5m cpu devtoolset7"
           requires:
@@ -3702,28 +3580,6 @@ workflows:
             tags:
               only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
           docker_image: "pytorch/manylinux-cuda102"
-      - binary_linux_build:
-          name: binary_linux_manywheel_2_7m_cu92_devtoolset7_nightly_build
-          build_environment: "manywheel 2.7m cu92 devtoolset7"
-          requires:
-            - setup
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          docker_image: "pytorch/manylinux-cuda92"
-      - binary_linux_build:
-          name: binary_linux_manywheel_2_7mu_cu92_devtoolset7_nightly_build
-          build_environment: "manywheel 2.7mu cu92 devtoolset7"
-          requires:
-            - setup
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          docker_image: "pytorch/manylinux-cuda92"
       - binary_linux_build:
           name: binary_linux_manywheel_3_5m_cu92_devtoolset7_nightly_build
           build_environment: "manywheel 3.5m cu92 devtoolset7"
@@ -3769,28 +3625,6 @@ workflows:
               only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
           docker_image: "pytorch/manylinux-cuda92"
       - binary_linux_build:
-          name: binary_linux_manywheel_2_7m_cu101_devtoolset7_nightly_build
-          build_environment: "manywheel 2.7m cu101 devtoolset7"
-          requires:
-            - setup
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          docker_image: "pytorch/manylinux-cuda101"
-      - binary_linux_build:
-          name: binary_linux_manywheel_2_7mu_cu101_devtoolset7_nightly_build
-          build_environment: "manywheel 2.7mu cu101 devtoolset7"
-          requires:
-            - setup
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          docker_image: "pytorch/manylinux-cuda101"
-      - binary_linux_build:
           name: binary_linux_manywheel_3_5m_cu101_devtoolset7_nightly_build
           build_environment: "manywheel 3.5m cu101 devtoolset7"
           requires:
@@ -3834,28 +3668,6 @@ workflows:
             tags:
               only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
           docker_image: "pytorch/manylinux-cuda101"
-      - binary_linux_build:
-          name: binary_linux_manywheel_2_7m_cu102_devtoolset7_nightly_build
-          build_environment: "manywheel 2.7m cu102 devtoolset7"
-          requires:
-            - setup
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          docker_image: "pytorch/manylinux-cuda102"
-      - binary_linux_build:
-          name: binary_linux_manywheel_2_7mu_cu102_devtoolset7_nightly_build
-          build_environment: "manywheel 2.7mu cu102 devtoolset7"
-          requires:
-            - setup
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          docker_image: "pytorch/manylinux-cuda102"
       - binary_linux_build:
           name: binary_linux_manywheel_3_5m_cu102_devtoolset7_nightly_build
           build_environment: "manywheel 3.5m cu102 devtoolset7"
@@ -4707,30 +4519,6 @@ workflows:
 # Nightly tests
 ##############################################################################
       - binary_linux_test:
-          name: binary_linux_manywheel_2_7m_cpu_devtoolset7_nightly_test
-          build_environment: "manywheel 2.7m cpu devtoolset7"
-          requires:
-            - setup
-            - binary_linux_manywheel_2_7m_cpu_devtoolset7_nightly_build
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          docker_image: "pytorch/manylinux-cuda102"
-      - binary_linux_test:
-          name: binary_linux_manywheel_2_7mu_cpu_devtoolset7_nightly_test
-          build_environment: "manywheel 2.7mu cpu devtoolset7"
-          requires:
-            - setup
-            - binary_linux_manywheel_2_7mu_cpu_devtoolset7_nightly_build
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          docker_image: "pytorch/manylinux-cuda102"
-      - binary_linux_test:
           name: binary_linux_manywheel_3_5m_cpu_devtoolset7_nightly_test
           build_environment: "manywheel 3.5m cpu devtoolset7"
           requires:
@@ -4778,34 +4566,6 @@ workflows:
             tags:
               only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
           docker_image: "pytorch/manylinux-cuda102"
-      - binary_linux_test:
-          name: binary_linux_manywheel_2_7m_cu92_devtoolset7_nightly_test
-          build_environment: "manywheel 2.7m cu92 devtoolset7"
-          requires:
-            - setup
-            - binary_linux_manywheel_2_7m_cu92_devtoolset7_nightly_build
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          docker_image: "pytorch/manylinux-cuda92"
-          use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
-      - binary_linux_test:
-          name: binary_linux_manywheel_2_7mu_cu92_devtoolset7_nightly_test
-          build_environment: "manywheel 2.7mu cu92 devtoolset7"
-          requires:
-            - setup
-            - binary_linux_manywheel_2_7mu_cu92_devtoolset7_nightly_build
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          docker_image: "pytorch/manylinux-cuda92"
-          use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
       - binary_linux_test:
           name: binary_linux_manywheel_3_5m_cu92_devtoolset7_nightly_test
           build_environment: "manywheel 3.5m cu92 devtoolset7"
@@ -4863,34 +4623,6 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
-          name: binary_linux_manywheel_2_7m_cu101_devtoolset7_nightly_test
-          build_environment: "manywheel 2.7m cu101 devtoolset7"
-          requires:
-            - setup
-            - binary_linux_manywheel_2_7m_cu101_devtoolset7_nightly_build
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          docker_image: "pytorch/manylinux-cuda101"
-          use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
-      - binary_linux_test:
-          name: binary_linux_manywheel_2_7mu_cu101_devtoolset7_nightly_test
-          build_environment: "manywheel 2.7mu cu101 devtoolset7"
-          requires:
-            - setup
-            - binary_linux_manywheel_2_7mu_cu101_devtoolset7_nightly_build
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          docker_image: "pytorch/manylinux-cuda101"
-          use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
-      - binary_linux_test:
           name: binary_linux_manywheel_3_5m_cu101_devtoolset7_nightly_test
           build_environment: "manywheel 3.5m cu101 devtoolset7"
           requires:
@@ -4944,34 +4676,6 @@ workflows:
             tags:
               only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
           docker_image: "pytorch/manylinux-cuda101"
-          use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
-      - binary_linux_test:
-          name: binary_linux_manywheel_2_7m_cu102_devtoolset7_nightly_test
-          build_environment: "manywheel 2.7m cu102 devtoolset7"
-          requires:
-            - setup
-            - binary_linux_manywheel_2_7m_cu102_devtoolset7_nightly_build
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          docker_image: "pytorch/manylinux-cuda102"
-          use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
-      - binary_linux_test:
-          name: binary_linux_manywheel_2_7mu_cu102_devtoolset7_nightly_test
-          build_environment: "manywheel 2.7mu cu102 devtoolset7"
-          requires:
-            - setup
-            - binary_linux_manywheel_2_7mu_cu102_devtoolset7_nightly_build
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          docker_image: "pytorch/manylinux-cuda102"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
@@ -5773,30 +5477,6 @@ workflows:
 
       # Nightly uploads
       - binary_linux_upload:
-          name: binary_linux_manywheel_2_7m_cpu_devtoolset7_nightly_upload
-          build_environment: "manywheel 2.7m cpu devtoolset7"
-          requires:
-            - setup
-            - binary_linux_manywheel_2_7m_cpu_devtoolset7_nightly_test
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          context: org-member
-      - binary_linux_upload:
-          name: binary_linux_manywheel_2_7mu_cpu_devtoolset7_nightly_upload
-          build_environment: "manywheel 2.7mu cpu devtoolset7"
-          requires:
-            - setup
-            - binary_linux_manywheel_2_7mu_cpu_devtoolset7_nightly_test
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          context: org-member
-      - binary_linux_upload:
           name: binary_linux_manywheel_3_5m_cpu_devtoolset7_nightly_upload
           build_environment: "manywheel 3.5m cpu devtoolset7"
           requires:
@@ -5838,30 +5518,6 @@ workflows:
           requires:
             - setup
             - binary_linux_manywheel_3_8m_cpu_devtoolset7_nightly_test
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          context: org-member
-      - binary_linux_upload:
-          name: binary_linux_manywheel_2_7m_cu92_devtoolset7_nightly_upload
-          build_environment: "manywheel 2.7m cu92 devtoolset7"
-          requires:
-            - setup
-            - binary_linux_manywheel_2_7m_cu92_devtoolset7_nightly_test
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          context: org-member
-      - binary_linux_upload:
-          name: binary_linux_manywheel_2_7mu_cu92_devtoolset7_nightly_upload
-          build_environment: "manywheel 2.7mu cu92 devtoolset7"
-          requires:
-            - setup
-            - binary_linux_manywheel_2_7mu_cu92_devtoolset7_nightly_test
           filters:
             branches:
               only: nightly
@@ -5917,30 +5573,6 @@ workflows:
               only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_manywheel_2_7m_cu101_devtoolset7_nightly_upload
-          build_environment: "manywheel 2.7m cu101 devtoolset7"
-          requires:
-            - setup
-            - binary_linux_manywheel_2_7m_cu101_devtoolset7_nightly_test
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          context: org-member
-      - binary_linux_upload:
-          name: binary_linux_manywheel_2_7mu_cu101_devtoolset7_nightly_upload
-          build_environment: "manywheel 2.7mu cu101 devtoolset7"
-          requires:
-            - setup
-            - binary_linux_manywheel_2_7mu_cu101_devtoolset7_nightly_test
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          context: org-member
-      - binary_linux_upload:
           name: binary_linux_manywheel_3_5m_cu101_devtoolset7_nightly_upload
           build_environment: "manywheel 3.5m cu101 devtoolset7"
           requires:
@@ -5982,30 +5614,6 @@ workflows:
           requires:
             - setup
             - binary_linux_manywheel_3_8m_cu101_devtoolset7_nightly_test
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          context: org-member
-      - binary_linux_upload:
-          name: binary_linux_manywheel_2_7m_cu102_devtoolset7_nightly_upload
-          build_environment: "manywheel 2.7m cu102 devtoolset7"
-          requires:
-            - setup
-            - binary_linux_manywheel_2_7m_cu102_devtoolset7_nightly_test
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          context: org-member
-      - binary_linux_upload:
-          name: binary_linux_manywheel_2_7mu_cu102_devtoolset7_nightly_upload
-          build_environment: "manywheel 2.7mu cu102 devtoolset7"
-          requires:
-            - setup
-            - binary_linux_manywheel_2_7mu_cu102_devtoolset7_nightly_test
           filters:
             branches:
               only: nightly


### PR DESCRIPTION
Python 2 is EOL soon so we're dropping support as of v1.5.0

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

