### PR TITLE
Remove CUDA 9.0 builds entirely.

### DIFF
--- a/.circleci/cimodel/data/pytorch_build_data.py
+++ b/.circleci/cimodel/data/pytorch_build_data.py
@@ -29,16 +29,6 @@ CONFIG_TREE_DATA = [
             ]),
         ]),
         ("cuda", [
-            ("9", [
-                # Note there are magic strings here
-                # https://github.com/pytorch/pytorch/blob/master/.jenkins/pytorch/build.sh#L21
-                # and
-                # https://github.com/pytorch/pytorch/blob/master/.jenkins/pytorch/build.sh#L143
-                # and
-                # https://github.com/pytorch/pytorch/blob/master/.jenkins/pytorch/build.sh#L153
-                # (from https://github.com/pytorch/pytorch/pull/17323#discussion_r259453144)
-                X("3.6"),
-            ]),
             ("9.2", [X("3.6")]),
             ("10.1", [X("3.6")]),
             ("10.2", [

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2096,31 +2096,6 @@ workflows:
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3.6-clang7:f990c76a-a798-42bb-852f-5be5006f8026"
           resource_class: large
       - pytorch_linux_build:
-          name: pytorch_linux_xenial_cuda9_cudnn7_py3_build
-          requires:
-            - setup
-          filters:
-            branches:
-              only:
-                - master
-                - /ci-all\/.*/
-          build_environment: "pytorch-linux-xenial-cuda9-cudnn7-py3-build"
-          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py3:f990c76a-a798-42bb-852f-5be5006f8026"
-      - pytorch_linux_test:
-          name: pytorch_linux_xenial_cuda9_cudnn7_py3_test
-          requires:
-            - setup
-            - pytorch_linux_xenial_cuda9_cudnn7_py3_build
-          filters:
-            branches:
-              only:
-                - master
-                - /ci-all\/.*/
-          build_environment: "pytorch-linux-xenial-cuda9-cudnn7-py3-test"
-          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py3:f990c76a-a798-42bb-852f-5be5006f8026"
-          use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
-      - pytorch_linux_build:
           name: pytorch_linux_xenial_cuda9_2_cudnn7_py3_gcc7_build
           requires:
             - setup


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#35480 Remove CUDA 9.0 builds entirely.**

They were previuosly only being run on master.  We don't support CUDA
9.0 anymore.  9.2 only.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>