### PR TITLE
Printed rank and world_size in the warning when initializing MPI

### DIFF
--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -378,7 +378,8 @@ def init_process_group(backend,
     if backend == Backend.MPI:
         if world_size != -1 or rank != -1:
             warnings.warn(
-                "For MPI backend, world_size and rank are ignored "
+                f"For MPI backend, world_size ({world_size}) "
+                f"and rank ({rank}) are ignored "
                 "since they are assigned by the MPI runtime.")
 
         _default_pg = _new_process_group_helper(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#35481 Printed rank and world_size in the warning when initializing MPI**
* #35479 Add warning when initializing an MPI process group with explicit rank and work size

