### PR TITLE
[Tensorpipe/RPC] tensorpipe RPC agent

### DIFF
--- a/test/cpp/rpc/CMakeLists.txt
+++ b/test/cpp/rpc/CMakeLists.txt
@@ -2,10 +2,14 @@ set(TORCH_RPC_TEST_DIR "${TORCH_ROOT}/test/cpp/rpc")
 set(TORCH_RPC_TEST_SOURCES
   ${TORCH_ROOT}/test/cpp/common/main.cpp
   ${TORCH_RPC_TEST_DIR}/test_wire_serialization.cpp
+  ${TORCH_RPC_TEST_DIR}/test_tensorpipe_serialization.cpp
 )
 
 add_executable(test_cpp_rpc ${TORCH_RPC_TEST_SOURCES})
-target_include_directories(test_cpp_rpc PRIVATE ${ATen_CPU_INCLUDE})
+target_include_directories(
+    test_cpp_rpc PRIVATE
+    ${ATen_CPU_INCLUDE}
+    ${TORCH_ROOT}/third_party/tensorpipe)
 target_link_libraries(test_cpp_rpc PRIVATE torch gtest)
 
 if(USE_CUDA)

--- a/test/cpp/rpc/test_tensorpipe_serialization.cpp
+++ b/test/cpp/rpc/test_tensorpipe_serialization.cpp
@@ -1,0 +1,136 @@
+#include <gtest/gtest.h>
+
+#include <tensorpipe/core/message.h>
+#include <torch/torch.h>
+#include <torch/csrc/distributed/rpc/utils.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+
+TEST(TensorpipeSerialize, Base) {
+  // Sender serializes
+  at::Tensor t1 = torch::ones({1024}, at::ScalarType::Int);
+  at::Tensor t2 = torch::ones({1024}, at::ScalarType::Float);
+  std::vector<at::Tensor> tensors{t1, t2};
+  std::vector<char> payload = {'1', '2', '3'};
+  std::vector<char> payloadCopy = payload; // for testing
+  torch::distributed::rpc::MessageType mtype =
+      torch::distributed::rpc::MessageType::UNKNOWN;
+  int64_t mId = 100;
+  torch::distributed::rpc::Message sendingRpcMessage(
+      std::move(payload), std::move(tensors), mtype);
+  sendingRpcMessage.setId(mId);
+  torch::distributed::rpc::TensorPipeEntry tpEntry =
+      torch::distributed::rpc::tensorpipeSerialize(sendingRpcMessage);
+  tensorpipe::Message sendingTpMessage = std::move(tpEntry.message);
+  EXPECT_EQ(sendingTpMessage.tensors.size(), 2);
+
+  // Mimic receiving message descriptor
+  tensorpipe::Message recvingTpMessage;
+  recvingTpMessage.length = sendingTpMessage.length;
+  recvingTpMessage.metadata = sendingTpMessage.metadata;
+  recvingTpMessage.tensors.reserve(sendingTpMessage.tensors.size());
+  for (auto& tpTensor : sendingTpMessage.tensors) {
+    tensorpipe::Message::Tensor t;
+    t.length = tpTensor.length;
+    t.metadata = tpTensor.metadata;
+    recvingTpMessage.tensors.push_back(std::move(t));
+  }
+  EXPECT_EQ(
+      recvingTpMessage.tensors.size(), sendingTpMessage.tensors.size());
+
+  // Mimic readDescriptor() callback:
+  // 1. Allocate rpc message
+  // 2. Fill pointers to tensorpipe message
+  torch::distributed::rpc::Message recvingRpcMessage =
+      torch::distributed::rpc::tensorpipeAllocateMessage(recvingTpMessage);
+  EXPECT_EQ(
+      recvingRpcMessage.tensors().size(), recvingTpMessage.tensors.size());
+  recvingTpMessage.data = (uint8_t*)(recvingRpcMessage.payload().data());
+  for (int i = 0; i < recvingRpcMessage.tensors().size(); i++) {
+    auto& rpcTensor = recvingRpcMessage.tensors()[i];
+    auto& tpTensor = recvingTpMessage.tensors[i];
+    tpTensor.data = (uint8_t*)(rpcTensor.data_ptr());
+  }
+
+  // Mimic tensorpipe data transfer
+  for (int i = 0; i < recvingTpMessage.tensors.size(); i++) {
+    auto& srcTensor = sendingTpMessage.tensors[i];
+    auto& dstTensor = recvingTpMessage.tensors[i];
+    memcpy(dstTensor.data, srcTensor.data, srcTensor.length);
+  }
+  memcpy(recvingTpMessage.data, sendingTpMessage.data, sendingTpMessage.length);
+  recvingTpMessage.metadata = sendingTpMessage.metadata;
+
+  // Data is ready
+  EXPECT_EQ(mtype, recvingRpcMessage.type());
+  EXPECT_EQ(payloadCopy, recvingRpcMessage.payload());
+  EXPECT_EQ(mId, recvingRpcMessage.id());
+  EXPECT_TRUE(torch::equal(t1, recvingRpcMessage.tensors()[0]));
+  EXPECT_TRUE(torch::equal(t2, recvingRpcMessage.tensors()[1]));
+}
+
+TEST(TensorpipeSerialize, RecopySparseTensors) {
+  // Take a 1K row of a 1M tensors, and make sure we don't send across 1M rows.
+  constexpr size_t k1K = 1024;
+  at::Tensor main = torch::randn({k1K, k1K});
+  at::Tensor tiny = main.select(0, 2); // Select a row in the middle
+  EXPECT_EQ(tiny.numel(), k1K);
+  EXPECT_EQ(tiny.storage().numel(), k1K * k1K);
+
+  std::vector<at::Tensor> tensors{main, tiny};
+  std::vector<char> payload = {'1', '2', '3'};
+  torch::distributed::rpc::MessageType mtype =
+      torch::distributed::rpc::MessageType::UNKNOWN;
+  torch::distributed::rpc::Message sendingRpcMessage(
+      std::move(payload), std::move(tensors), mtype);
+
+  torch::distributed::rpc::TensorPipeEntry tpEntry =
+      torch::distributed::rpc::tensorpipeSerialize(sendingRpcMessage);
+  tensorpipe::Message sendingTpMessage = std::move(tpEntry.message);
+
+  EXPECT_EQ(tpEntry.reservedTensors.size(), 2);
+  EXPECT_EQ(sendingTpMessage.tensors.size(), 2);
+  EXPECT_TRUE(torch::equal(main, tpEntry.reservedTensors[0]));
+  EXPECT_TRUE(torch::equal(tiny, tpEntry.reservedTensors[1]));
+  // Test cloned storage
+  EXPECT_EQ(main.storage().data(), sendingTpMessage.tensors[0].data);
+  EXPECT_NE(tiny.storage().data(), sendingTpMessage.tensors[1].data);
+  EXPECT_EQ(tiny.element_size() * k1K, sendingTpMessage.tensors[1].length);
+}
+
+TEST(TensorpipeSerialize, NoDeleterTensors) {
+  std::vector<float> blob1{.8, .2};
+  std::vector<float> blob2{.7, .5, .9};
+  at::Tensor t1 = torch::from_blob((float*)(blob1.data()), blob1.size());
+  at::Tensor t2 = torch::from_blob((float*)(blob2.data()), blob2.size());
+  std::vector<at::Tensor> tensors{t1, t2};
+  std::vector<char> payload = {'1', '2', '3'};
+  torch::distributed::rpc::MessageType mtype =
+      torch::distributed::rpc::MessageType::UNKNOWN;
+  torch::distributed::rpc::Message sendingRpcMessage(
+      std::move(payload), std::move(tensors), mtype);
+
+  torch::distributed::rpc::TensorPipeEntry tpEntry =
+      torch::distributed::rpc::tensorpipeSerialize(sendingRpcMessage);
+  tensorpipe::Message sendingTpMessage = std::move(tpEntry.message);
+
+  EXPECT_EQ(tpEntry.copiedTensors.size(), 2);
+  EXPECT_EQ(sendingTpMessage.tensors.size(), 2);
+  EXPECT_EQ(tpEntry.copiedTensors[0].size(), sendingTpMessage.tensors[0].length);
+  EXPECT_EQ(tpEntry.copiedTensors[1].size(), sendingTpMessage.tensors[1].length);
+  EXPECT_EQ(tpEntry.copiedTensors[0].data(), sendingTpMessage.tensors[0].data);
+  EXPECT_EQ(tpEntry.copiedTensors[1].data(), sendingTpMessage.tensors[1].data);
+  EXPECT_TRUE(
+      memcmp(
+          tpEntry.copiedTensors[0].data(),
+          t1.storage().data(),
+          sendingTpMessage.tensors[0].length) == 0);
+  EXPECT_TRUE(
+      memcmp(
+          tpEntry.copiedTensors[1].data(),
+          t2.storage().data(),
+          sendingTpMessage.tensors[1].length) == 0);
+}

--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -440,6 +440,7 @@ libtorch_python_distributed_sources = [
     "torch/csrc/distributed/rpc/python_functions.cpp",
     "torch/csrc/distributed/rpc/python_rpc_handler.cpp",
     "torch/csrc/distributed/rpc/request_callback_impl.cpp",
+    "torch/csrc/distributed/rpc/tensorpipe_agent.cpp",
     "torch/csrc/distributed/rpc/testing/faulty_process_group_agent.cpp",
     "torch/csrc/distributed/rpc/testing/init.cpp",
     "torch/csrc/distributed/rpc/unpickled_python_call.cpp",

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -70,6 +70,7 @@ set(TORCH_PYTHON_INCLUDE_DIRECTORIES
 
     ${TORCH_ROOT}/third_party/gloo
     ${TORCH_ROOT}/third_party/onnx
+    ${TORCH_ROOT}/third_party/tensorpipe
     ${pybind11_INCLUDE_DIRS}
 
     ${TORCH_SRC_DIR}/csrc

--- a/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
@@ -1,0 +1,411 @@
+#include <torch/csrc/distributed/rpc/tensorpipe_agent.h>
+
+#include <torch/csrc/distributed/rpc/request_callback_impl.h>
+#include <torch/csrc/distributed/rpc/utils.h>
+
+#include <tensorpipe/channel/basic/context.h>
+#ifdef TP_ENABLE_CMA
+#include <tensorpipe/channel/cma/context.h>
+#endif
+#ifdef TP_ENABLE_SHM
+#include <tensorpipe/transport/shm/context.h>
+#include <unistd.h>
+#endif
+#include <tensorpipe/transport/uv/context.h>
+
+namespace torch {
+namespace distributed {
+namespace rpc {
+
+constexpr long kToMilliseconds = 1000;
+
+TensorPipeAgent::TensorPipeAgent(
+    worker_id_t selfId,
+    std::string selfName,
+    std::shared_ptr<::c10d::Store> addressStore,
+    TensorPipeRpcBackendOptions opts)
+    : RpcAgent(
+          WorkerInfo(std::move(selfName), selfId),
+          std::make_unique<RequestCallbackImpl>(),
+          std::chrono::milliseconds(
+              (long)(opts.rpcTimeoutSeconds * kToMilliseconds))),
+      context_(std::make_shared<tensorpipe::Context>()),
+      addressStore_(std::move(addressStore)),
+      opts_(std::move(opts)) {
+  // Generate the maps for once.
+  for (const auto& kv : opts_.workerNameToId) {
+    const string& workerName = kv.first;
+    worker_id_t workerId = kv.second;
+    workerIdToInfo_.emplace(workerId, WorkerInfo(workerName, workerId));
+    workerNameToInfo_.emplace(workerName, WorkerInfo(workerName, workerId));
+  }
+}
+
+TensorPipeAgent::~TensorPipeAgent() {
+  shutdownImpl();
+}
+
+void TensorPipeAgent::startImpl() {
+  context_->registerTransport(
+      1, "tcp", std::make_shared<tensorpipe::transport::uv::Context>());
+#ifdef TP_ENABLE_SHM
+  context_->registerTransport(
+      0, "shm", std::make_shared<tensorpipe::transport::shm::Context>());
+#endif
+  context_->registerChannel(
+      1, "basic", std::make_shared<tensorpipe::channel::basic::Context>());
+#ifdef TP_ENABLE_CMA
+  context_->registerChannel(
+      0, "cma", std::make_shared<tensorpipe::channel::cma::Context>());
+#endif
+
+  // TODO: We currently hardcoded localhost as pipes handshake IP address.
+  // Ideally tensorpipe could provide a helper to get IP address for given
+  // device interface or host names, or return the IP address of the default
+  // host name. https://github.com/pytorch/pytorch/issues/36715
+  std::vector<std::string> addresses = {"tcp://127.0.0.1"};
+#ifdef TP_ENABLE_SHM
+  addresses.push_back(createUniqueShmAddr());
+#endif
+
+  listener_ = context_->listen(addresses);
+
+  // Store our own url.
+  const auto address = listener_->url("tcp");
+  const std::vector<uint8_t> selfAddrData(address.begin(), address.end());
+  addressStore_->set(workerInfo_.name_, selfAddrData);
+
+  for (const auto& p : workerNameToInfo_) {
+    const auto& name = p.first;
+    auto nodeAddrData = addressStore_->get(name);
+    auto nodeAddrStr =
+        std::string((const char*)nodeAddrData.data(), nodeAddrData.size());
+    workerNameToURL_.insert({name, nodeAddrStr});
+  }
+
+  listener_->accept([this](
+                        const tensorpipe::Error& error,
+                        std::shared_ptr<tensorpipe::Pipe> pipe) {
+    onListenerAccepted(error, pipe);
+  });
+}
+
+void TensorPipeAgent::onListenerAccepted(
+    const tensorpipe::Error& error,
+    std::shared_ptr<tensorpipe::Pipe>& pipe) {
+  if (error) {
+    LOG(WARNING) << "got error from listener: " << error.what();
+    return;
+  }
+
+  // Accept the next connection request
+  listener_->accept([this](
+                        const tensorpipe::Error& error,
+                        std::shared_ptr<tensorpipe::Pipe> pipe) {
+    onListenerAccepted(error, pipe);
+  });
+
+  // Arm for server read
+  respond(pipe);
+}
+
+void TensorPipeAgent::pipeRead(
+    const std::shared_ptr<tensorpipe::Pipe>& pipe,
+    std::function<void(const tensorpipe::Error&, Message&&)> fn) {
+  pipe->readDescriptor([fn{std::move(fn)}, pipe](
+                           const tensorpipe::Error& error,
+                           tensorpipe::Message&& tpMessage) mutable {
+    if (error) {
+      fn(error, Message());
+      return;
+    }
+
+    // Allocate memory and fill in pointers
+    Message rpcMessage = tensorpipeAllocateMessage(tpMessage);
+    TORCH_INTERNAL_ASSERT(
+        rpcMessage.tensors().size() == tpMessage.tensors.size(),
+        "Tensor num mismatch");
+    tpMessage.data = (uint8_t*)(rpcMessage.payload().data());
+    for (size_t i = 0; i < rpcMessage.tensors().size(); i++) {
+      auto& rpcTensor = rpcMessage.tensors()[i];
+      auto& tpTensor = tpMessage.tensors[i];
+      tpTensor.data = (uint8_t*)(rpcTensor.data_ptr());
+    }
+
+    pipe->read(
+        std::move(tpMessage),
+        [fn{std::move(fn)}, rpcMessage{std::move(rpcMessage)}](
+            const tensorpipe::Error& error,
+            tensorpipe::Message&& /* unused */) mutable {
+          fn(error, std::move(rpcMessage));
+        });
+  });
+}
+
+void TensorPipeAgent::pipeWrite(
+    const std::shared_ptr<tensorpipe::Pipe>& pipe,
+    Message&& rpcMessage,
+    std::function<void(const tensorpipe::Error&)> fn) {
+  TensorPipeEntry tpEntry = tensorpipeSerialize(rpcMessage);
+  tensorpipe::Message tpMessage = std::move(tpEntry.message);
+  pipe->write(
+      std::move(tpMessage),
+      // Note: keep payload and tensors of rpcMessage alive.
+      [rpcMessage{std::move(rpcMessage)},
+       reservedTensors{std::move(tpEntry.reservedTensors)},
+       copiedTensors{std::move(tpEntry.copiedTensors)},
+       fn{std::move(fn)}](
+          const tensorpipe::Error& error,
+          tensorpipe::Message&& /* unused */) mutable { fn(error); });
+}
+
+void TensorPipeAgent::sendCompletedResponseMessage(
+    std::shared_ptr<tensorpipe::Pipe>& pipe,
+    std::shared_ptr<FutureMessage>& futureResponseMessage,
+    uint64_t messageId) {
+  if (!rpcAgentRunning_.load()) {
+    LOG(WARNING) << "RPC agent is being closed. Skip sending rpc response";
+    return;
+  }
+
+  const c10::optional<utils::FutureError> error =
+      futureResponseMessage->error();
+  Message&& responseMessage = std::move(*futureResponseMessage).moveValue();
+  responseMessage.setId(messageId);
+  if (!error) {
+    pipeWrite(
+        pipe, std::move(responseMessage), [](const tensorpipe::Error& error) {
+          if (error) {
+            LOG(WARNING) << "sending response failed: " << error.what();
+            return;
+          }
+        });
+  } else {
+    pipeWrite(
+        pipe,
+        createExceptionResponse(error->what(), responseMessage.id()),
+        [](const tensorpipe::Error& error) {
+          if (error) {
+            LOG(WARNING) << "sending error response failed: " << error.what();
+            return;
+          }
+        });
+  }
+}
+
+void TensorPipeAgent::respond(std::shared_ptr<tensorpipe::Pipe>& pipe) {
+  pipeRead(
+      pipe,
+      [this, pipe](
+          const tensorpipe::Error& error, Message&& requestMessage) mutable {
+        // TODO: Handle server pipe read error
+        if (error) {
+          LOG(WARNING) << "Server read message: " << error.what();
+          return;
+        }
+
+        // Arm for next read
+        respond(pipe);
+
+        uint64_t messageId = requestMessage.id();
+
+        // Defer user RPC UDF run to thread pool
+        threadPool_.run([this,
+                         pipe,
+                         messageId,
+                         requestMessage{std::move(requestMessage)}]() mutable {
+          std::shared_ptr<FutureMessage> futureResponseMessage;
+          try {
+            futureResponseMessage = cb_->operator()(requestMessage);
+          } catch (const std::exception& e) {
+            futureResponseMessage = std::make_shared<FutureMessage>();
+            futureResponseMessage->setError(e.what());
+          }
+
+          // Shortcut if immediately done
+          if (futureResponseMessage->completed()) {
+            sendCompletedResponseMessage(
+                pipe, futureResponseMessage, messageId);
+          } else {
+            // Not complete yet
+            futureResponseMessage->addCallback(
+                [this, pipe, futureResponseMessage, messageId]() mutable {
+                  // Done
+                  sendCompletedResponseMessage(
+                      pipe, futureResponseMessage, messageId);
+                });
+          }
+        });
+      });
+}
+
+std::shared_ptr<FutureMessage> TensorPipeAgent::send(
+    const WorkerInfo& toWorkerInfo,
+    Message&& requestMessage,
+    const float /* unused */) {
+  TORCH_CHECK(
+      requestMessage.isRequest(),
+      "TensorPipeAgent::send(..) is only for sending requests.");
+
+  if (!rpcAgentRunning_.load()) {
+    auto err = c10::str(
+        "Node ",
+        RpcAgent::getWorkerInfo().id_,
+        "tried to send() a message of type ",
+        requestMessage.type(),
+        " but RPC is no longer running on this node.");
+    throw std::runtime_error(err);
+  }
+
+  const auto& url = findWorkerURL(toWorkerInfo);
+
+  std::unique_lock<std::mutex> lock(mutex_);
+
+  // See if we already have a connection to this address or not
+  auto it = connectedPipes_.find(toWorkerInfo.id_);
+  if (it == connectedPipes_.end()) {
+    std::tie(it, std::ignore) = connectedPipes_.emplace(
+        toWorkerInfo.id_, ClientPipe(context_->connect(url)));
+  }
+  ClientPipe& clientPipe = it->second;
+  auto& pendingResponseMessage = clientPipe.pendingResponseMessage_;
+
+  std::shared_ptr<FutureMessage> futureResponseMessage =
+      std::make_shared<FutureMessage>();
+  requestMessage.setId(nextMessageID_++);
+  pendingResponseMessage[requestMessage.id()] = futureResponseMessage;
+
+  // Don't need to hold lock while calling tensorpipe API.
+  lock.unlock();
+
+  pipeWrite(
+      clientPipe.pipe_,
+      std::move(requestMessage),
+      [this, &clientPipe, futureResponseMessage](
+          const tensorpipe::Error& error) {
+        if (error) {
+          LOG(WARNING) << "client write error: " << error.what();
+          futureResponseMessage->setError(error.what());
+          return;
+        }
+
+        pipeRead(
+            clientPipe.pipe_,
+            [this, &clientPipe](
+                const tensorpipe::Error& error, Message&& responseMessage) {
+              if (error) {
+                LOG(WARNING) << "Read response error: " << error.what();
+                std::lock_guard<std::mutex> lock(mutex_);
+                // We may get garbage content in responseMessage upon error.
+                // Flushing all future messages belonging to this pipe due to
+                // error state.
+                for (auto& p : clientPipe.pendingResponseMessage_) {
+                  std::shared_ptr<FutureMessage>& futureMessage = p.second;
+                  futureMessage->setError(error.what());
+                }
+                clientPipe.pendingResponseMessage_.clear();
+                clientPipe.readError_ = true;
+                return;
+              }
+
+              // Identify future response message by message ID
+              uint64_t messageId = responseMessage.id();
+              std::shared_ptr<FutureMessage> futureResponseMessage;
+              {
+                std::lock_guard<std::mutex> lock(mutex_);
+                // A read error will lead all following callbacks to be
+                // invoked with error, and shouldn't reach here.
+                TORCH_INTERNAL_ASSERT(
+                    !clientPipe.readError_, "Shouldn't in error state");
+                auto it = clientPipe.pendingResponseMessage_.find(messageId);
+                TORCH_INTERNAL_ASSERT(
+                    it != clientPipe.pendingResponseMessage_.end(),
+                    "message ID ",
+                    messageId,
+                    " is not recognized");
+                futureResponseMessage = std::move(it->second);
+                clientPipe.pendingResponseMessage_.erase(it);
+              }
+
+              threadPool_.run(
+                  [this,
+                   futureResponseMessage,
+                   responseMessage{std::move(responseMessage)}]() mutable {
+                    if (responseMessage.type() == MessageType::EXCEPTION) {
+                      futureResponseMessage->setError(std::string(
+                          responseMessage.payload().begin(),
+                          responseMessage.payload().end()));
+                    } else {
+                      futureResponseMessage->markCompleted(
+                          std::move(responseMessage));
+                    }
+                  });
+            });
+      });
+
+  return futureResponseMessage;
+}
+
+// TODO: Remove sync()
+void TensorPipeAgent::sync() {}
+
+// TODO: Remove join()
+void TensorPipeAgent::join() {
+  shutdownImpl();
+}
+
+void TensorPipeAgent::shutdownImpl() {
+  threadPool_.waitWorkComplete();
+  // TODO: context_->join() is not absolutely ready yet.
+  // NOTE: context_->join() will wait for available RPC message to be
+  //       read or written, and wait for the remaining unavailable ones
+  //       to be called with error by invoking callbacks.
+}
+
+const WorkerInfo& TensorPipeAgent::getWorkerInfo(
+    const std::string& workerName) const {
+  const auto& it = workerNameToInfo_.find(workerName);
+  TORCH_CHECK(
+      it != workerNameToInfo_.end(), "Unknown destination worker ", workerName);
+  return it->second;
+}
+
+const WorkerInfo& TensorPipeAgent::getWorkerInfo(worker_id_t workerId) const {
+  const auto& it = workerIdToInfo_.find(workerId);
+  TORCH_CHECK(
+      it != workerIdToInfo_.end(), "Unknown destination worker ", workerId);
+  return it->second;
+}
+
+std::vector<WorkerInfo> TensorPipeAgent::getWorkerInfos() const {
+  std::vector<WorkerInfo> workerInfos;
+  for (auto& item : workerNameToInfo_) {
+    workerInfos.emplace_back(item.second);
+  }
+  return workerInfos;
+}
+
+const std::string& TensorPipeAgent::findWorkerURL(
+    const WorkerInfo& worker) const {
+  const auto it = workerNameToURL_.find(worker.name_);
+  TORCH_CHECK(
+      it != workerNameToURL_.end(), "Unknown worker name: ", worker.name_);
+  return it->second;
+}
+
+#ifdef TP_ENABLE_SHM
+std::string TensorPipeAgent::createUniqueShmAddr() {
+  thread_local uint32_t threadLocalId = 0;
+  return c10::str(
+      "shm://tensorpipe_rpc_agent_",
+      std::this_thread::get_id(),
+      "_",
+      ::getpid(),
+      "_",
+      threadLocalId++);
+}
+#endif
+
+} // namespace rpc
+} // namespace distributed
+} // namespace torch

--- a/torch/csrc/distributed/rpc/tensorpipe_agent.h
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.h
@@ -1,0 +1,127 @@
+#pragma once
+
+#include <c10/core/thread_pool.h>
+#include <c10d/Store.hpp>
+#include <tensorpipe/core/context.h>
+#include <tensorpipe/core/listener.h>
+#include <tensorpipe/core/pipe.h>
+#include <torch/csrc/distributed/rpc/rpc_agent.h>
+
+#include <atomic>
+#include <thread>
+
+namespace torch {
+namespace distributed {
+namespace rpc {
+
+struct TensorPipeRpcBackendOptions : public RpcBackendOptions {
+  std::map<std::string, worker_id_t> workerNameToId;
+};
+
+// TensorPipeAgent leverages tensorpipe (https://github.com/pytorch/tensorpipe)
+// to move tensors and payload through fatested transport and channel
+// transparently. We can see it as a hybrid RPC transport, providing
+// shared memory (linux) and tcp (linux & mac). CUDA will be supported next.
+class TensorPipeAgent : public RpcAgent {
+ public:
+  TensorPipeAgent(
+      worker_id_t selfId,
+      std::string selfName,
+      std::shared_ptr<::c10d::Store> addressStore,
+      TensorPipeRpcBackendOptions opts);
+
+  TensorPipeAgent(const TensorPipeAgent&) = delete;
+  TensorPipeAgent& operator=(const TensorPipeAgent&) = delete;
+
+  std::shared_ptr<FutureMessage> send(
+      const WorkerInfo& to,
+      Message&& message,
+      const float rpcTimeoutSeconds = kUnsetRpcTimeout) override;
+
+  // join() and sync() would be deprecated -
+  // https://github.com/pytorch/pytorch/issues/27647
+  void join() override;
+  void sync() override;
+  void startImpl() override;
+  void shutdownImpl() override;
+
+  ~TensorPipeAgent() override;
+
+  const WorkerInfo& getWorkerInfo(const std::string& workerName) const override;
+  const WorkerInfo& getWorkerInfo(worker_id_t workerId) const override;
+  std::vector<WorkerInfo> getWorkerInfos() const override;
+
+  std::unordered_map<std::string, std::string> getMetrics() override {
+    std::unordered_map<std::string, std::string> metrics;
+    return metrics;
+  }
+
+  void addGilWaitTime(const std::chrono::microseconds /* unused */) override {}
+
+ private:
+  const std::string& findWorkerURL(const WorkerInfo& worker) const;
+
+#ifdef TP_ENABLE_SHM
+  std::string createUniqueShmAddr();
+#endif
+
+  // TensorPipe read function that could be used to read response messages
+  // by client, and read request messages by server.
+  void pipeRead(
+      const std::shared_ptr<tensorpipe::Pipe>&,
+      std::function<void(const tensorpipe::Error&, Message&&)>);
+
+  // TensorPipe write function that could be used to write response
+  // messages by server, and write request messages by client.
+  void pipeWrite(
+      const std::shared_ptr<tensorpipe::Pipe>&,
+      Message&& message,
+      std::function<void(const tensorpipe::Error&)>);
+
+  // Callback of listener accept()
+  void onListenerAccepted(
+      const tensorpipe::Error& error,
+      std::shared_ptr<tensorpipe::Pipe>& pipe);
+
+  // Respond to a call from a peer
+  void respond(std::shared_ptr<tensorpipe::Pipe>& pipe);
+
+  void sendCompletedResponseMessage(
+      std::shared_ptr<tensorpipe::Pipe>& pipe,
+      std::shared_ptr<FutureMessage>& futureResponseMessage,
+      uint64_t messageId);
+
+  // State per client pipe to keep tracking of pending response message
+  // and error sate. pendingResponseMessage_ should be protected by
+  // mutex since it can be raced with user send() call.
+  // TODO: To achieve better performance we can have a pipe pool per
+  // client and work together with RpcBackendOptions to configure.
+  struct ClientPipe {
+    explicit ClientPipe(std::shared_ptr<tensorpipe::Pipe> pipe) : pipe_(pipe) {}
+    std::shared_ptr<tensorpipe::Pipe> pipe_;
+    bool readError_{false};
+    std::unordered_map<uint64_t, std::shared_ptr<FutureMessage>>
+        pendingResponseMessage_;
+  };
+
+  // TODO: configure thread pool size through RpcBackendOptions.
+  ThreadPool threadPool_{16};
+  std::shared_ptr<tensorpipe::Context> context_;
+  std::shared_ptr<tensorpipe::Listener> listener_;
+  std::unordered_map<worker_id_t, ClientPipe> connectedPipes_;
+
+  // We need map one keyed on name and one on id for easy lookup.
+  std::unordered_map<worker_id_t, WorkerInfo> workerIdToInfo_;
+  std::unordered_map<std::string, WorkerInfo> workerNameToInfo_;
+  std::unordered_map<std::string, std::string> workerNameToURL_;
+
+  const std::shared_ptr<::c10d::Store> addressStore_;
+  const TensorPipeRpcBackendOptions opts_;
+
+  mutable std::mutex mutex_;
+  uint64_t nextMessageID_{0};
+};
+
+} // namespace rpc
+} // namespace distributed
+} // namespace torch

--- a/torch/csrc/distributed/rpc/utils.cpp
+++ b/torch/csrc/distributed/rpc/utils.cpp
@@ -353,6 +353,112 @@ std::pair<std::vector<char>, std::vector<at::Tensor>> wireDeserialize(
   return {std::move(payload), std::move(tensors)};
 }
 
+TensorPipeEntry tensorpipeSerialize(const Message& rpcMessage) {
+  tensorpipe::Message tpMessage;
+  std::vector<torch::Tensor> reservedTensors;
+  std::vector<std::vector<uint8_t>> copiedTensors;
+
+  const std::vector<char>& payload = rpcMessage.payload();
+  c10::List<at::Tensor> tensors = cloneSparseTensors(rpcMessage.tensors());
+
+  // Payload
+  tpMessage.data = (uint8_t*)(payload.data());
+  tpMessage.length = payload.size();
+
+  // Metadata - encode rpc message type and message id into
+  // 8 bytes respectively
+  tpMessage.metadata.resize(2 * sizeof(int64_t));
+  int64_t mType = static_cast<int>(rpcMessage.type());
+  int64_t mId = rpcMessage.id();
+  memcpy((void*)tpMessage.metadata.data(), &mType, sizeof(int64_t));
+  memcpy(
+      (void*)(tpMessage.metadata.data() + sizeof(int64_t)),
+      &mId,
+      sizeof(int64_t));
+
+  // Tensors
+  tpMessage.tensors.reserve(tensors.size());
+  for (at::Tensor tensor : tensors) {
+    // Keep original user tensors and cloned sparse tensors
+    reservedTensors.push_back(tensor);
+    tensorpipe::Message::Tensor tpTensor;
+    torch::jit::Pickler pickler([&](const void* buf, size_t sz) -> size_t {
+      tpTensor.metadata.append(static_cast<const char*>(buf), sz);
+      return sz;
+    });
+    pickler.protocol();
+    pickler.pushIValue(tensor);
+    pickler.stop();
+    const auto& tensorDataVec = pickler.tensorData();
+    TORCH_INTERNAL_ASSERT(
+        tensorDataVec.size() == 1, "There should be single pickled tensor");
+    const auto& tensorData = tensorDataVec.front();
+    // Enforce memory copy if tensor is created from torch::from_blob, means
+    // that the tensor doesn't own the memory.
+    if (!tensorData.storageHasDeleter()) {
+      std::vector<uint8_t> storageData(tensorData.sizeInBytes());
+      memcpy(storageData.data(), tensorData.data(), storageData.size());
+      tpTensor.data = storageData.data();
+      copiedTensors.push_back(std::move(storageData));
+    } else {
+      tpTensor.data = (uint8_t*)(tensorData.data());
+    }
+    tpTensor.length = tensorData.sizeInBytes();
+    tpMessage.tensors.push_back(std::move(tpTensor));
+  }
+
+  return TensorPipeEntry{std::move(tpMessage),
+                         std::move(reservedTensors),
+                         std::move(copiedTensors)};
+}
+
+Message tensorpipeAllocateMessage(const tensorpipe::Message& tpMessage) {
+  // Payload, message type and message id
+  std::vector<char> payload(tpMessage.length);
+  TORCH_INTERNAL_ASSERT(
+      tpMessage.metadata.size() == 2 * sizeof(int64_t),
+      "message metadata must be ",
+      2 * sizeof(int64_t),
+      " bytes, whereas it is ",
+      tpMessage.metadata.size(),
+      " bytes");
+  int64_t mtypei, mId;
+  memcpy(&mtypei, tpMessage.metadata.data(), sizeof(int64_t));
+  memcpy(&mId, tpMessage.metadata.data() + sizeof(int64_t), sizeof(int64_t));
+  MessageType mType = static_cast<MessageType>(mtypei);
+
+  // Tensors
+  std::vector<torch::Tensor> tensors;
+  tensors.reserve(tpMessage.tensors.size());
+  for (const tensorpipe::Message::Tensor& tpTensor : tpMessage.tensors) {
+    const std::string& metadata = tpTensor.metadata;
+    size_t metadataPos = 0;
+    auto metaDataReadFunc = [&](char* buf, size_t n) -> size_t {
+      if (metadataPos >= metadata.size() || n == 0) {
+        return 0;
+      }
+      size_t toCopy = std::min(n, metadata.size() - metadataPos);
+      memcpy(buf, metadata.data() + metadataPos, toCopy);
+      metadataPos += toCopy;
+      return toCopy;
+    };
+
+    auto sectionReadFunc = [&](const std::string& ename) -> at::DataPtr {
+      TORCH_INTERNAL_ASSERT(ename == "0", "single tensor ename must be \"0\"");
+      // TODO: CUDA memory allocation
+      return at::getCPUAllocator()->allocate(tpTensor.length);
+    };
+
+    torch::jit::Unpickler unpickler(
+        metaDataReadFunc, nullptr, nullptr, sectionReadFunc, {});
+    auto ival = unpickler.parse_ivalue();
+    auto&& t = ival.toTensor();
+    tensors.emplace_back(std::move(t));
+  }
+
+  return Message(std::move(payload), std::move(tensors), mType, mId);
+}
+
 } // namespace rpc
 } // namespace distributed
 } // namespace torch

--- a/torch/distributed/rpc/backend_registry.py
+++ b/torch/distributed/rpc/backend_registry.py
@@ -152,3 +152,49 @@ register_backend(
     _process_group_construct_rpc_backend_options_handler,
     _process_group_init_backend_handler,
 )
+
+def _tensorpipe_construct_rpc_backend_options_handler(
+    rpc_timeout,
+    init_method,
+    worker_name_to_id=None,
+    **kwargs
+):
+    from . import TensorPipeRpcBackendOptions
+
+    assert (
+        worker_name_to_id is not None
+    ), "worker_name_to_id must be provided as a kwargs."
+    rpc_backend_options = TensorPipeRpcBackendOptions()
+    rpc_backend_options.rpc_timeout = rpc_timeout
+    rpc_backend_options.init_method = init_method
+    rpc_backend_options.worker_name_to_id = worker_name_to_id
+    return rpc_backend_options
+
+
+def _tensorpipe_init_backend_handler(store, name, rank, world_size, rpc_backend_options):
+    from . import TensorPipeRpcBackendOptions
+    from . import TensorPipeAgent
+
+    if not isinstance(store, dist.Store):
+        raise RuntimeError("`store` must be a c10d::Store. {}".format(store))
+
+    if not isinstance(
+        rpc_backend_options, TensorPipeRpcBackendOptions
+    ):
+        raise RuntimeError(
+            "`rpc_backend_options` must be a `TensorPipeRpcBackendOptions`. {}".format(
+                rpc_backend_options
+            )
+        )
+
+    agent = TensorPipeAgent(
+        rank, name, store, rpc_backend_options
+    )
+    return agent
+
+
+register_backend(
+    "TENSORPIPE",
+    _tensorpipe_construct_rpc_backend_options_handler,
+    _tensorpipe_init_backend_handler,
+)


### PR DESCRIPTION
Implement the initial version of TensorPipe RPC agent, and register to RPC registry to expose to Python interface. As a starter, it utilizes all available TensorPipe transports (shm, uv) and channels (basic, cma).

