### PR TITLE
[pytorch] add fallthrough variable kernel for C10_MOBILE

### DIFF
--- a/aten/src/ATen/core/VariableFallbackKernel.cpp
+++ b/aten/src/ATen/core/VariableFallbackKernel.cpp
@@ -34,7 +34,41 @@ void variable_fallback_kernel(const OperatorHandle& op, Stack* stack) {
 
 static auto registry = Dispatcher::singleton().registerBackendFallbackKernel(
     DispatchKey::VariableTensorId,
+#ifdef C10_MOBILE
+    // As custom mobile build might not include variable kernels, we need
+    // leverage variable fallback mechanism as well. The goals are:
+    // 1) don't break forward pass for inference-only mobile build;
+    // 2) don't break forward/backward pass for mobile build with necessary
+    // variable kernels registered;
+    //
+    // This `fallthrough` kernel is for #1 - because not all kernels support
+    // boxed call yet, registering `variable_fallback_kernel` might fail.
+    // When an op has variable kernel registered explicitly dispatcher will
+    // call it instead of `fallthrough`, so `fallthrough` won't break
+    // dispatching to real variable kernels for case #2.
+    //
+    // The substantial difference between fallback and fallthrough is whether
+    // AutoNonVariableTypeMode guard is applied. There are two downstream
+    // effects of the guard:
+    // a) stop calling variable kernels of other ops called by the current op;
+    //    For case #1, there is no difference because no variable kernels are
+    //    registered. For case #2, there is no difference as long as ALL used
+    //    ops have real variable kernels registered, where the guard will be
+    //    set properly in real variable kernels. There is potential issue only
+    //    when variable kernels are partially registered for used ops.
+    // b) `variable_excluded_from_dispatch()` method returns the state of the
+    //    NonVariableTypeMode. As of when this diff is written, the callers of
+    //    the method are ALL asserting it returns true; the only exception is
+    //    the deprecated `is_variable()` method. So we make the method to always
+    //    return true for mobile builds. It shouldn't break case #1/#2 as long
+    //    as `is_variable()` is not used.
+    //
+    // We can remove this `fallthrough` kernel when all kernels support boxed
+    // call.
+    KernelFunction::makeFallthrough()
+#else
     KernelFunction::makeFromBoxedFunction<&variable_fallback_kernel>()
+#endif
 );
 
 }

--- a/aten/src/ATen/templates/TensorBody.h
+++ b/aten/src/ATen/templates/TensorBody.h
@@ -56,7 +56,12 @@ using ConstQuantizerPtr = const c10::intrusive_ptr<Quantizer>&;
 
 namespace impl {
 inline bool variable_excluded_from_dispatch() {
+#ifdef C10_MOBILE
+  // Please read the comment in `VariableFallbackKernel.cpp` about the background of this change.
+  return true;
+#else
   return c10::impl::tls_local_dispatch_key_set().excluded_.has(DispatchKey::VariableTensorId);
+#endif
 }
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#35491 [pytorch] add fallthrough variable kernel for C10_MOBILE**

The goal of this diff is to avoid having to set AutoNonVariableTypeMode guard
in client code that uses custom mobile build. The guard was necessary because
custom mobile build might not include variable kernels, in which AutoNonVariableTypeMode
guard is usually set. It's hard to enforce all callsites to follow this rule, so
we make this change to simplify it.
Another goal of the diff is to not break FL where real variable kernels are
registered.

Differential Revision: [D20643627](https://our.internmc.facebook.com/intern/diff/D20643627/)