### PR TITLE
Fix linter warning: replace f-strings with str.format for Py2 compat

### DIFF
--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -376,6 +376,12 @@ def init_process_group(backend,
     backend = Backend(backend)
 
     if backend == Backend.MPI:
+        if world_size != -1 or rank != -1:
+            warnings.warn(
+                "For MPI backend, world_size ({}) and rank ({}) "
+                "are ignored since they are assigned by the "
+                "MPI runtime.".format(world_size, rank))
+
         _default_pg = _new_process_group_helper(
             -1,
             -1,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#35492 Fix linter warning: replace f-strings with str.format for Py2 compat**

Differential Revision: [D20998727](https://our.internmc.facebook.com/intern/diff/D20998727)