### PR TITLE
[workflows] Don't pipe clang_format.py output to a file

### DIFF
--- a/.github/workflows/clang_format.yml
+++ b/.github/workflows/clang_format.yml
@@ -31,5 +31,4 @@ jobs:
         run: |
           set -eux
           echo "Run tools/clang_format.py to fix formatting errors"
-          tools/clang_format.py --verbose --diff > ${GITHUB_WORKSPACE}/clang-format-output.txt
-          cat ${GITHUB_WORKSPACE}/clang-format-output.txt
+          tools/clang_format.py --verbose --diff


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #35497 [JIT] Fix formatting in changes made by reverting D20657271
* **#35496 [workflows] Don't pipe clang_format.py output to a file**

Summary:
This commit modifies the clang-format workflow so that it prints
the output of `tools/clang_format.py` to stdout instead of piping
it to a file. This way, the issues encountered by the script
(e.g. which files are not formatted correctly) will be visible
in the CI window.

Testing:
CI

Differential Revision: [D20678729](https://our.internmc.facebook.com/intern/diff/D20678729)