### PR TITLE
[JIT] Fix formatting in changes made by reverting D20657271

### DIFF
--- a/torch/csrc/jit/runtime/operator.cpp
+++ b/torch/csrc/jit/runtime/operator.cpp
@@ -76,10 +76,10 @@ struct OperatorRegistry {
     // Remove operator from symbol map
     auto op_it = operators.find(sym);
     TORCH_CHECK(
-      op_it != operators.end(),
-      "operator with signature ",
-      sig,
-      " is missing from symbol registry");
+        op_it != operators.end(),
+        "operator with signature ",
+        sig,
+        " is missing from symbol registry");
 
     auto& op_vec = op_it->second;
     auto it = op_vec.begin();
@@ -321,8 +321,7 @@ void registerOperator(Operator&& op) {
   getRegistry().registerOperator(std::move(op));
 }
 
-void deregisterOperator(const FunctionSchema& schema)
-{
+void deregisterOperator(const FunctionSchema& schema) {
   getRegistry().deregisterOperator(schema);
 }
 

--- a/torch/csrc/jit/runtime/register_c10_ops.cpp
+++ b/torch/csrc/jit/runtime/register_c10_ops.cpp
@@ -159,7 +159,7 @@ class RegistrationListener final : public c10::OpRegistrationListener {
   }
 
   void onOperatorDeregistered(const c10::OperatorHandle& op) override {
-    if(at::is_aten_op(op.schema().operator_name())) {
+    if (at::is_aten_op(op.schema().operator_name())) {
       return;
     }
     torch::jit::deregisterOperator(op.schema());
@@ -167,12 +167,11 @@ class RegistrationListener final : public c10::OpRegistrationListener {
 };
 
 struct Registerer final {
-    // this immediately calls the listener on all existing ops,
-    // and calls it in future whenever a new op is registered
-  Registerer(): listenerRAII(c10::Dispatcher::singleton().addRegistrationListener(
-      std::make_unique<RegistrationListener>()
-    )) {
-  }
+  // this immediately calls the listener on all existing ops,
+  // and calls it in future whenever a new op is registered
+  Registerer()
+      : listenerRAII(c10::Dispatcher::singleton().addRegistrationListener(
+            std::make_unique<RegistrationListener>())) {}
   c10::RegistrationHandleRAII listenerRAII;
 };
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#35497 [JIT] Fix formatting in changes made by reverting D20657271**
* #35496 [workflows] Don't pipe clang_format.py output to a file

Summary:
This commit fixes formatting changes necessitated by reverting
D20657271.

Testing:
CI.

Differential Revision: [D20678754](https://our.internmc.facebook.com/intern/diff/D20678754)