### PR TITLE
[clang-format] Replace asyncio.run with approximation supported in python 3.6

### DIFF
--- a/tools/clang_format.py
+++ b/tools/clang_format.py
@@ -292,7 +292,8 @@ def main(args):
     ok = get_and_check_clang_format(options.verbose)
     # Invoke clang-format on all files in the directories in the whitelist.
     if ok:
-        ok = asyncio.run(run_clang_format(options.max_processes, options.diff, options.verbose))
+        loop = asyncio.get_event_loop()
+        ok = loop.run_until_complete(run_clang_format(options.max_processes, options.diff, options.verbose))
 
     # We have to invert because False -> 0, which is the code to be returned if everything is okay.
     return not ok


### PR DESCRIPTION
**Summary**
`asyncio.run` is supported only after 3.7 and that too, provisionally so.
This commit replaces the use of `asyncio.run` in `tools/clang_format.py`
with an approximation that works in both 3.6 and 3.7.

**Testing**
Ran the script with both `python3.6` and `python3.7`.

```
$ python3.6 tools/clang_format.py --diff
...
Some files not formatted correctly
$
```

```
$ python3.7 tools/clang_format.py --diff
...
Some files not formatted correctly
$
```