### PR TITLE
Fix grid_sample out of boundary when grid contains large numbers 

### DIFF
--- a/aten/src/ATen/native/cuda/GridSampler.cuh
+++ b/aten/src/ATen/native/cuda/GridSampler.cuh
@@ -148,8 +148,6 @@ scalar_t safe_downgrade_to_int_range(scalar_t x){
   // -100.0 does not have special meaning. This is just to make sure 
   // it's not within_bounds_2d or within_bounds_3d, and does not cause 
   // undefined behavior. See #35506.  
-  if (std::is_same<at::Half, scalar_t>::value && !::isfinite(static_cast<double>(x)))
-    return static_cast<at::Half>(-100.0); 
   if (x > INT_MAX-1 || x < INT_MIN || !::isfinite(static_cast<double>(x))) 
     return static_cast<scalar_t>(-100.0); 
   return x;

--- a/aten/src/ATen/native/cuda/GridSampler.cuh
+++ b/aten/src/ATen/native/cuda/GridSampler.cuh
@@ -3,6 +3,8 @@
 #include <ATen/cuda/CUDAApplyUtils.cuh>
 #include <THC/THCAtomics.cuh>
 
+#define GRIDSAMPLER_NOINLINE __attribute__((noinline))
+
 namespace at { namespace native {
 
 namespace detail {
@@ -199,12 +201,12 @@ scalar_t grid_sampler_compute_source_index_set_grad(
   return coord;
 }
 
-static __forceinline__ __device__
+static GRIDSAMPLER_NOINLINE __device__
 bool within_bounds_2d(int h, int w, int H, int W) {
   return h >= 0 && h < H && w >= 0 && w < W;
 }
 
-static __forceinline__ __device__
+static GRIDSAMPLER_NOINLINE __device__
 bool within_bounds_3d(int d, int h, int w, int D, int H, int W) {
   return d >= 0 && d < D && h >= 0 && h < H && w >= 0 && w < W;
 }

--- a/aten/src/ATen/native/cuda/GridSampler.cuh
+++ b/aten/src/ATen/native/cuda/GridSampler.cuh
@@ -148,9 +148,9 @@ scalar_t safe_downgrade_to_int_range(scalar_t x){
   // -100.0 does not have special meaning. This is just to make sure 
   // it's not within_bounds_2d or within_bounds_3d, and does not cause 
   // undefined behavior. See #35506.  
-  if (std::is_same<at::Half, scalar_t>::value && !std::isfinite(static_cast<double>(x)))
+  if (std::is_same<at::Half, scalar_t>::value && !::isfinite(static_cast<double>(x)))
     return static_cast<at::Half>(-100.0); 
-  if (x > INT_MAX-1 || x < INT_MIN || !std::isfinite(static_cast<double>(x))) 
+  if (x > INT_MAX-1 || x < INT_MIN || !::isfinite(static_cast<double>(x))) 
     return static_cast<scalar_t>(-100.0); 
   return x;
 }

--- a/aten/src/ATen/native/cuda/GridSampler.cuh
+++ b/aten/src/ATen/native/cuda/GridSampler.cuh
@@ -3,7 +3,12 @@
 #include <ATen/cuda/CUDAApplyUtils.cuh>
 #include <THC/THCAtomics.cuh>
 
+#ifdef _MSC_VER
+#define GRIDSAMPLER_NOINLINE __declspec(noinline)
+#else 
 #define GRIDSAMPLER_NOINLINE __attribute__((noinline))
+#endif
+
 
 namespace at { namespace native {
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -6413,8 +6413,8 @@ class TestNN(NNTestCase):
             grid[:, 1, 1, 1, 0] = float('inf')
             result = torch.nn.functional.grid_sample(image, grid, padding_mode='zeros')
             self.assertEqual(result, torch.tensor([[[[[27., 26., 25.], [24., 23., 22.], [21., 20., 19.]],
-                                                     [[18., 17., 16.], [15.,  0., 13.], [12., 11., 10.]],
-                                                     [[ 9.,  8.,  7.], [ 6.,  5.,  4.], [ 3.,  2.,  1.]]]]], 
+                                                     [[18., 17., 16.], [15., 0., 13.], [12., 11., 10.]],
+                                                     [[9., 8., 7.], [6., 5., 4.], [3., 2., 1.]]]]], 
                                                   device='cuda', dtype=torch.float))
         issue_24823_1()
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -6395,7 +6395,6 @@ class TestNN(NNTestCase):
         with self.assertRaisesRegex(NotImplementedError, "affine_grid only supports 4D and 5D sizes"):
             F.affine_grid(theta, torch.Size([1, 1, 2, 2, 2, 2]), align_corners=False)
 
-
     def test_grid_sample(self):
         def test(N, C, H, W, mode, padding_mode, align_corners):
             def test_shape(N, C, IH, IW, H, W, mode, padding_mode, align_corners):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9388,7 +9388,6 @@ class TestNNDeviceType(NNTestCase):
             # just to make sure this does not crash
         issue_24823_3()
 
-
     @largeCUDATensorTest('12GB')
     def test_conv_transposed_large(self, device):
         dtype = torch.half if self.device_type == 'cuda' else torch.float

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9349,44 +9349,54 @@ class TestNNDeviceType(NNTestCase):
             self.assertEqual(out1, out2)
 
     @onlyCUDA
-    def test_grid_sample_large(self, device):
+    @dtypesIfCUDA(torch.half, torch.float, torch.double)
+    def test_grid_sample_large(self, device, dtype):
         def issue_35202():
-            input_tensor = torch.rand(1, 1, 480, 640, dtype=torch.float, device=device)
+            input_tensor = torch.rand(1, 1, 480, 640, dtype=torch.float, device=device, requires_grad=True)
             coords = torch.tensor([[-10059144, 67680944], [67680944, 67680944]], dtype=torch.float, device=device)
             coords = coords.unsqueeze(0).unsqueeze(0).repeat(1, 1, 1, 1)
             result = torch.nn.functional.grid_sample(input_tensor, coords)
             self.assertEqual(result, torch.tensor([[[[0., 0.]]]], dtype=torch.float, device=device))
+            result.backward(torch.ones_like(result))
+            torch.cuda.synchronize()
         issue_35202()
 
         def issue_24823_1():
-            image = torch.arange(27, 0, -1, dtype=torch.float, device=device).view(1, 1, 3, 3, 3)
+            image = torch.arange(27, 0, -1, dtype=dtype, device=device).view(1, 1, 3, 3, 3)
+            image.requires_grad_()
             grid = torch.nn.functional.affine_grid(
-                torch.tensor([[[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0]]], dtype=torch.float, device=device),
+                torch.tensor([[[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0]]], dtype=dtype, device=device),
                 (1, 1, 3, 3, 3))
             grid[:, 1, 1, 1, 0] = float('inf')
             result = torch.nn.functional.grid_sample(image, grid, padding_mode='zeros')
             self.assertEqual(result, torch.tensor([[[[[27., 26., 25.], [24., 23., 22.], [21., 20., 19.]],
                                                      [[18., 17., 16.], [15., 0., 13.], [12., 11., 10.]],
                                                      [[9., 8., 7.], [6., 5., 4.], [3., 2., 1.]]]]], 
-                                                  device=device, dtype=torch.float))
+                                                  device=device, dtype=dtype))
+
+            result.backward(torch.ones_like(result))
+            expected_grad = torch.ones_like(image)
+            expected_grad[0, 0, 1, 1, 1] = 0
+            self.assertTrue(torch.allclose(image.grad, expected_grad, atol=1e-3))
         issue_24823_1()
 
         def issue_24823_2():
             param = torch.tensor([[[-1.0e+20, 0.0, 0.0], [0.0, -1.0e+20, 0.0]]], dtype=torch.float, device=device)
-            img = torch.zeros((1, 1, 4, 4), dtype=torch.float, device=device)
+            img = torch.zeros((1, 1, 4, 4), dtype=torch.float, device=device, requires_grad=True)
             grid = torch.nn.functional.affine_grid(param, img.size())
             result = torch.nn.functional.grid_sample(img, grid)
             self.assertEqual(result, torch.zeros(1, 1, 4, 4, device=device, dtype=torch.float))
+            result.backward(torch.ones_like(result))
+            torch.cuda.synchronize()
         issue_24823_2()
 
         def issue_24823_3():
-            x = torch.randn(8, 3, 1024, 1024, dtype=torch.float, device=device)
-            w = torch.randn(8, 1024, 1024, 2, dtype=torch.float, device=device)
+            x = torch.randn(8, 3, 1024, 1024, dtype=dtype, device=device, requires_grad=True)
+            w = torch.randn(8, 1024, 1024, 2, dtype=dtype, device=device)
             w[:, 64, 64] = float("inf")
-            torch.nn.functional.grid_sample(x, w)
-            if self.device_type == 'cuda':
-                torch.cuda.synchronize()
-            # just to make sure this does not crash
+            result = torch.nn.functional.grid_sample(x, w)
+            result.backward(torch.ones_like(result))
+            torch.cuda.synchronize()
         issue_24823_3()
 
     @largeCUDATensorTest('12GB')

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9348,6 +9348,7 @@ class TestNNDeviceType(NNTestCase):
             out2 = conv1(input_c)
             self.assertEqual(out1, out2)
 
+    @onlyCUDA
     def test_grid_sample_large(self, device):
         def issue_35202():
             input_tensor = torch.rand(1, 1, 480, 640, dtype=torch.float, device=device)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9354,7 +9354,6 @@ class TestNNDeviceType(NNTestCase):
             coords = torch.tensor([[-10059144, 67680944], [67680944, 67680944]], dtype=torch.float, device=device)
             coords = coords.unsqueeze(0).unsqueeze(0).repeat(1, 1, 1, 1)
             result = torch.nn.functional.grid_sample(input_tensor, coords)
-            torch.cuda.synchronize()
             self.assertEqual(result, torch.tensor([[[[0., 0.]]]], dtype=torch.float, device=device))
         issue_35202()
 
@@ -9384,7 +9383,8 @@ class TestNNDeviceType(NNTestCase):
             w = torch.randn(8, 1024, 1024, 2, dtype=torch.float, device=device)
             w[:, 64, 64] = float("inf")
             torch.nn.functional.grid_sample(x, w)
-            torch.cuda.synchronize()
+            if self.device_type == 'cuda':
+                torch.cuda.synchronize()
             # just to make sure this does not crash
         issue_24823_3()
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -6395,6 +6395,42 @@ class TestNN(NNTestCase):
         with self.assertRaisesRegex(NotImplementedError, "affine_grid only supports 4D and 5D sizes"):
             F.affine_grid(theta, torch.Size([1, 1, 2, 2, 2, 2]), align_corners=False)
 
+    def test_grid_sample_large(self):
+        def issue_35202():
+            input_tensor = torch.rand(1, 1, 480, 640, dtype=torch.float, device='cuda')
+            coords = torch.tensor([[-10059144, 67680944], [67680944, 67680944]], dtype=torch.float, device='cuda').unsqueeze(0).unsqueeze(0).repeat(1, 1, 1, 1)
+            result = torch.nn.functional.grid_sample(input_tensor, coords)
+            torch.cuda.synchronize()
+            self.assertEqual(result, torch.tensor([[[[0., 0.]]]], dtype=torch.float, device='cuda'))
+        issue_35202()
+
+        def issue_24823_1():
+            image = torch.arange(27, 0, -1, dtype=torch.float, device='cuda').view(1,1,3,3,3)
+            grid = torch.nn.functional.affine_grid(torch.tensor([[[1.,0.,0.,0.],[0.,1.,0.,0.],[0.,0.,1.,0.]]], dtype=torch.float, device='cuda'), (1,1,3,3,3))
+            grid[:,1,1,1,0] = float('inf')
+            result = torch.nn.functional.grid_sample(image, grid, padding_mode='zeros')
+            self.assertEqual(result, torch.tensor([[[[[27., 26., 25.], [24., 23., 22.], [21., 20., 19.]],
+                                                     [[18., 17., 16.], [15.,  0., 13.], [12., 11., 10.]],
+                                                     [[ 9.,  8.,  7.], [ 6.,  5.,  4.], [ 3.,  2.,  1.]]]]], device='cuda', dtype=torch.float))
+        issue_24823_1()
+
+        def issue_24823_2():
+            param = torch.tensor([[[-1.0e+20, 0.0, 0.0], [0.0, -1.0e+20, 0.0]]], dtype=torch.float, device='cuda')
+            img = torch.zeros((1,1,4,4), dtype=torch.float, device='cuda')
+            grid = torch.nn.functional.affine_grid(param, img.size())
+            result = torch.nn.functional.grid_sample(img,grid)
+            self.assertEqual(result, torch.zeros(1,1,4,4, device='cuda', dtype=torch.float))
+        issue_24823_2()
+
+        def issue_24823_3():
+            x = torch.randn(8, 3, 1024, 1024, dtype=torch.float, device='cuda')
+            w = torch.randn(8, 1024, 1024, 2, dtype=torch.float, device='cuda')
+            w[:, 64, 64] = float("inf")
+            torch.nn.functional.grid_sample(x, w)
+            torch.cuda.synchronize()
+            # just to make sure this does not crash
+        issue_24823_3()
+
     def test_grid_sample(self):
         def test(N, C, H, W, mode, padding_mode, align_corners):
             def test_shape(N, C, IH, IW, H, W, mode, padding_mode, align_corners):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -6395,45 +6395,6 @@ class TestNN(NNTestCase):
         with self.assertRaisesRegex(NotImplementedError, "affine_grid only supports 4D and 5D sizes"):
             F.affine_grid(theta, torch.Size([1, 1, 2, 2, 2, 2]), align_corners=False)
 
-    def test_grid_sample_large(self):
-        def issue_35202():
-            input_tensor = torch.rand(1, 1, 480, 640, dtype=torch.float, device='cuda')
-            coords = torch.tensor([[-10059144, 67680944], [67680944, 67680944]], dtype=torch.float, device='cuda')
-            coords = coords.unsqueeze(0).unsqueeze(0).repeat(1, 1, 1, 1)
-            result = torch.nn.functional.grid_sample(input_tensor, coords)
-            torch.cuda.synchronize()
-            self.assertEqual(result, torch.tensor([[[[0., 0.]]]], dtype=torch.float, device='cuda'))
-        issue_35202()
-
-        def issue_24823_1():
-            image = torch.arange(27, 0, -1, dtype=torch.float, device='cuda').view(1, 1, 3, 3, 3)
-            grid = torch.nn.functional.affine_grid(
-                torch.tensor([[[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0]]], dtype=torch.float, device='cuda'),
-                (1, 1, 3, 3, 3))
-            grid[:, 1, 1, 1, 0] = float('inf')
-            result = torch.nn.functional.grid_sample(image, grid, padding_mode='zeros')
-            self.assertEqual(result, torch.tensor([[[[[27., 26., 25.], [24., 23., 22.], [21., 20., 19.]],
-                                                     [[18., 17., 16.], [15., 0., 13.], [12., 11., 10.]],
-                                                     [[9., 8., 7.], [6., 5., 4.], [3., 2., 1.]]]]], 
-                                                  device='cuda', dtype=torch.float))
-        issue_24823_1()
-
-        def issue_24823_2():
-            param = torch.tensor([[[-1.0e+20, 0.0, 0.0], [0.0, -1.0e+20, 0.0]]], dtype=torch.float, device='cuda')
-            img = torch.zeros((1, 1, 4, 4), dtype=torch.float, device='cuda')
-            grid = torch.nn.functional.affine_grid(param, img.size())
-            result = torch.nn.functional.grid_sample(img, grid)
-            self.assertEqual(result, torch.zeros(1, 1, 4, 4, device='cuda', dtype=torch.float))
-        issue_24823_2()
-
-        def issue_24823_3():
-            x = torch.randn(8, 3, 1024, 1024, dtype=torch.float, device='cuda')
-            w = torch.randn(8, 1024, 1024, 2, dtype=torch.float, device='cuda')
-            w[:, 64, 64] = float("inf")
-            torch.nn.functional.grid_sample(x, w)
-            torch.cuda.synchronize()
-            # just to make sure this does not crash
-        issue_24823_3()
 
     def test_grid_sample(self):
         def test(N, C, H, W, mode, padding_mode, align_corners):
@@ -9387,6 +9348,47 @@ class TestNNDeviceType(NNTestCase):
                 conv1.bias = nn.Parameter(bias_c)
             out2 = conv1(input_c)
             self.assertEqual(out1, out2)
+
+    def test_grid_sample_large(self, device):
+        def issue_35202():
+            input_tensor = torch.rand(1, 1, 480, 640, dtype=torch.float, device=device)
+            coords = torch.tensor([[-10059144, 67680944], [67680944, 67680944]], dtype=torch.float, device=device)
+            coords = coords.unsqueeze(0).unsqueeze(0).repeat(1, 1, 1, 1)
+            result = torch.nn.functional.grid_sample(input_tensor, coords)
+            torch.cuda.synchronize()
+            self.assertEqual(result, torch.tensor([[[[0., 0.]]]], dtype=torch.float, device=device))
+        issue_35202()
+
+        def issue_24823_1():
+            image = torch.arange(27, 0, -1, dtype=torch.float, device=device).view(1, 1, 3, 3, 3)
+            grid = torch.nn.functional.affine_grid(
+                torch.tensor([[[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0]]], dtype=torch.float, device=device),
+                (1, 1, 3, 3, 3))
+            grid[:, 1, 1, 1, 0] = float('inf')
+            result = torch.nn.functional.grid_sample(image, grid, padding_mode='zeros')
+            self.assertEqual(result, torch.tensor([[[[[27., 26., 25.], [24., 23., 22.], [21., 20., 19.]],
+                                                     [[18., 17., 16.], [15., 0., 13.], [12., 11., 10.]],
+                                                     [[9., 8., 7.], [6., 5., 4.], [3., 2., 1.]]]]], 
+                                                  device=device, dtype=torch.float))
+        issue_24823_1()
+
+        def issue_24823_2():
+            param = torch.tensor([[[-1.0e+20, 0.0, 0.0], [0.0, -1.0e+20, 0.0]]], dtype=torch.float, device=device)
+            img = torch.zeros((1, 1, 4, 4), dtype=torch.float, device=device)
+            grid = torch.nn.functional.affine_grid(param, img.size())
+            result = torch.nn.functional.grid_sample(img, grid)
+            self.assertEqual(result, torch.zeros(1, 1, 4, 4, device=device, dtype=torch.float))
+        issue_24823_2()
+
+        def issue_24823_3():
+            x = torch.randn(8, 3, 1024, 1024, dtype=torch.float, device=device)
+            w = torch.randn(8, 1024, 1024, 2, dtype=torch.float, device=device)
+            w[:, 64, 64] = float("inf")
+            torch.nn.functional.grid_sample(x, w)
+            torch.cuda.synchronize()
+            # just to make sure this does not crash
+        issue_24823_3()
+
 
     @largeCUDATensorTest('12GB')
     def test_conv_transposed_large(self, device):


### PR DESCRIPTION
This PR would fix #35202, fix GPU part of #24823, be related to #24870. 

Here is the origin of this problem. 
1. Like those in #35202, with large numbers in grid like `grid.min() == -10059144 grid.max()==67680944`; or `nan, inf, 1.0E20` in #24823, 
https://github.com/pytorch/pytorch/blob/4d39aeec271fde5a89aa68c7588023205c5ca8a9/aten/src/ATen/native/cuda/GridSampler.cu#L309-L321
`ix, iy` will be unnormalized to very large numbers, exceed the bound of INT_MAX. 
Then, those `ix_nw, iy_nw` variables will be cast to INT_MAX, and some other variables with "+1" will be INT_MIN. 

2. However, these INT_MAX, INT_MIN should not big problems, because
https://github.com/pytorch/pytorch/blob/4d39aeec271fde5a89aa68c7588023205c5ca8a9/aten/src/ATen/native/cuda/GridSampler.cu#L358-L362
https://github.com/pytorch/pytorch/blob/4d39aeec271fde5a89aa68c7588023205c5ca8a9/aten/src/ATen/native/cuda/GridSampler.cuh#L202-L205
these `within_bounds_2d` functions are supposed to guard the if-statement, prevent the illegal memory access, and leave those output values as zero (padding_modes='zeros'). 

3. Now here comes the problem, `within_bounds_2d` is set to "inline". We found that those `+1` statement and `>=0` statement may cause compiler to "optimize" the code, that is: 
```cpp
int B = something; 

int a = something; 
int b = a + 1; 
bool r = (b >= 0 && b < B); 
```
will be compiled into assembly code like 
```cpp
int B = something; 

int a = something; 
bool r1 = (a > -2)
int b = a + 1; 
bool r2 = (b < B); 
bool r = r1 && r2; 
```
This looks nice, but when a = INT_MAX, `a+1` causes Undefined Behavior. Typically, we get b = INT_MIN, then the boolean result from compiled assembly will be true. The `within_bounds_2d` no longer guards us from the illegal memory access.  

4. There could be different ways to fix this bug. For example, we may set all of the "ix_nw, iy_nw" values to `int64_t`. That would be a potential performance issue, and doesn't prevent those examples in #24823 with 1E20 in grid. 

One minimal fix that I found is to restrict `within_bounds_2d` from being inlined. Thus, compiler won't optimize those `a+1` and `a>=0` code together. 

I did a short performace test, just to make sure this forced noinline solution won't cause regression. The performance script can be found at 
https://github.com/xwang233/code-snippet/blob/a6f8bce52222cd1c5270e22a87a4699b65741686/grid-sample/grid-sample.ipynb. 

For this `__attribute__((noinline))` macro, I have tested that on nvcc, and there was no problem. I'm not sure if that also works on clang. 

cc @csarofeen @ptrblck @ngimel @bnehoran @zasdfgbnm @SsnL 