### PR TITLE
[caffe2] Header path in byte_order.h

### DIFF
--- a/torch/csrc/utils/byte_order.h
+++ b/torch/csrc/utils/byte_order.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <THHalf.h>
+#include <TH/THHalf.h>
 #include <c10/util/BFloat16.h>
 #include <torch/csrc/WindowsTorchApiMacro.h>
 #include <cstddef>


### PR DESCRIPTION
Summary: Fix include of THHalf.h to be TH/THHalf.h. Makes the include consistent with the rest of caffe2.

Test Plan: CI

Differential Revision: D20685997

