### PR TITLE
Transform pass to split SparseLengthsSumSparse

### DIFF
--- a/caffe2/operators/lengths_reducer_fused_nbit_rowwise_ops.cc
+++ b/caffe2/operators/lengths_reducer_fused_nbit_rowwise_ops.cc
@@ -216,6 +216,41 @@ operating on 2-bit rowwise quantized matrices with fused storage
 NO_GRADIENT(SparseLengthsMeanFused2BitRowwise);
 
 REGISTER_CPU_OPERATOR(
+    SparseLengthsSumSparseLookup,
+    SparseLengthsSumSparseLookupOp);
+OPERATOR_SCHEMA(SparseLengthsSumSparseLookup)
+    .NumInputs(3, 4)
+    .NumOutputs(2, 3)
+    .SetDoc(R"DOC(
+This op converts compressed indices of SparseLengthsSum*Sparse to
+uncompressed indices of SparseLengthsSum*. For compressed indices that maps
+to -1. It means it will correspond to a zero row in the uncompressed data.
+Therefore we will remove this indices and adjust the lengths.
+)DOC")
+    .Input(
+        0,
+        "INDICES",
+        "Integer vector containing compressed indices of the first "
+        "dimension of DATA for the slices that are being aggregated")
+    .Input(
+        1,
+        "LENGTHS",
+        "Vector with the same sum of elements as the first dimension of DATA")
+    .Input(
+        2,
+        "COMPRESSED_INDICES_MAPPING",
+        "Integer vector mapping uncompressed indices to compressed indices")
+    .Input(
+        3,
+        "WEIGHTS",
+        "Vector of weights to scale rows of DATA with before reduction")
+    .Output(0, "output_indices", "Uncompressed indices")
+    .Output(1, "output_lengths", "Adjusted lengths")
+    .Output(2, "output_weights", "Adjusted weights")
+    .InheritOnnxSchema();
+NO_GRADIENT(SparseLengthsSumSparseLookup);
+
+REGISTER_CPU_OPERATOR(
     SparseLengthsSum4BitRowwiseSparse,
     SparseLengthsNBitRowwiseSparseOp<4>);
 OPERATOR_SCHEMA(SparseLengthsSum4BitRowwiseSparse)

--- a/caffe2/operators/lengths_reducer_fused_nbit_rowwise_ops.h
+++ b/caffe2/operators/lengths_reducer_fused_nbit_rowwise_ops.h
@@ -220,6 +220,106 @@ class SparseLengthsFusedNBitRowwiseOp final : public Operator<Context> {
 #endif
 }; // class SparseLengthsFusedNBitRowwiseOp
 
+class SparseLengthsSumSparseLookupOp final : public Operator<CPUContext> {
+ public:
+  SparseLengthsSumSparseLookupOp(const OperatorDef& def, Workspace* ws)
+      : Operator<CPUContext>(def, ws) {}
+
+  ~SparseLengthsSumSparseLookupOp() override {}
+
+  bool RunOnDevice() override {
+    return DispatchHelper<TensorTypes<int32_t, int64_t>>::call(
+        this, Input(INDICES));
+  }
+
+  template <typename IndexType>
+  bool DoRunWithType() {
+    const auto& indices = Input(INDICES);
+    const auto& lengths = Input(LENGTHS);
+    const auto& compressed_indices_mapping = Input(COMPRESSED_INDICES_MAPPING);
+    thread_local static std::vector<float> dummy_weight;
+    CAFFE_ENFORCE_EQ(indices.dim(), 1, "INDICES must be a vector");
+    CAFFE_ENFORCE_EQ(lengths.dim(), 1, "LENGTHS must be a vector");
+    CAFFE_ENFORCE_EQ(
+        compressed_indices_mapping.dim(), 1, "LENGTHS must be a vector");
+    const int32_t* lengths_data = lengths.template data<int32_t>();
+    const IndexType* indices_data = indices.template data<IndexType>();
+    const int32_t* compressed_indices_mapping_data =
+        compressed_indices_mapping.template data<std::int32_t>();
+    dummy_weight.resize(indices.size(0));
+    const float* weights = dummy_weight.data();
+    bool has_weights = (InputSize() > 3);
+    if (has_weights) {
+      const auto& weights_input = Input(WEIGHTS);
+      CAFFE_ENFORCE_EQ(weights_input.dim(), 1, "WEIGHTS must be a vector");
+      CAFFE_ENFORCE_EQ(
+          weights_input.numel(),
+          indices.numel(),
+          "WEIGHTS should have the same length as INDICES.");
+      weights = weights_input.template data<float>();
+    }
+
+    // Allocate for the max possible size for now and later we may shrink the
+    // indices size.
+    auto* output_indices =
+        Output(INDICES, indices.sizes(), at::dtype<IndexType>());
+    auto* output_lengths =
+        Output(LENGTHS, lengths.sizes(), at::dtype<int32_t>());
+    Tensor* output_weights = nullptr;
+    float* output_weights_data = dummy_weight.data();
+    if (has_weights) {
+      output_weights = Output(2, indices.sizes(), at::dtype<float>());
+      output_weights_data = output_weights->template mutable_data<float>();
+    }
+    int32_t* output_lengths_data =
+        output_lengths->template mutable_data<int32_t>();
+    IndexType* output_indices_data =
+        output_indices->template mutable_data<IndexType>();
+    const int32_t output_size = lengths.size(0);
+    const IndexType index_size = indices.size(0);
+    const IndexType compressed_data_size = compressed_indices_mapping.size(0);
+    IndexType current = 0;
+    IndexType current_output = 0;
+    for (int m = 0; m < output_size; ++m) {
+      const auto current_length = lengths_data[m];
+      if (current + current_length > index_size) {
+        return false;
+      }
+      int32_t skipped = 0;
+      for (int i = 0; i < current_length; ++i) {
+        IndexType compressed_idx = indices_data[current];
+        if (compressed_idx < 0 || compressed_idx >= compressed_data_size) {
+          return false;
+        }
+        IndexType idx = compressed_indices_mapping_data[compressed_idx];
+        if (idx == -1) {
+          ++skipped;
+        } else {
+          output_weights_data[current_output] = weights[current];
+          output_indices_data[current_output++] = idx;
+        }
+        ++current;
+      }
+      output_lengths_data[m] = current_length - skipped;
+    }
+
+    if (current_output < index_size) {
+      output_indices->ShrinkTo(current_output);
+      if (output_weights) {
+        output_weights->ShrinkTo(current_output);
+      }
+    }
+    return true;
+  }
+
+  enum {
+    INDICES = 0,
+    LENGTHS = 1,
+    COMPRESSED_INDICES_MAPPING = 2,
+    WEIGHTS = 3
+  };
+};
+
 template <int BIT_RATE, bool with_weights = false, bool is_mean = false>
 class SparseLengthsNBitRowwiseSparseOp final : public Operator<CPUContext> {
  public:

--- a/caffe2/opt/onnxifi_transformer.cc
+++ b/caffe2/opt/onnxifi_transformer.cc
@@ -567,6 +567,84 @@ NetDef buildLoopTestNet(
 
 } // namespace
 
+void splitSparseLengthsSumSparse(NetDef* net, const Workspace& ws) {
+  const static std::unordered_map<string, string> slss = {
+      {"SparseLengthsSum4BitRowwiseSparse", "SparseLengthsSumFused4BitRowwise"},
+      {"SparseLengthsWeightedSum4BitRowwiseSparse",
+       "SparseLengthsWeightedSumFused4BitRowwise"},
+      {"SparseLengthsSum8BitRowwiseSparse", "SparseLengthsSum8FusedBitRowwise"},
+      {"SparseLengthsWeightedSum8BitRowwiseSparse",
+       "SparseLengthsWeightedSumFused8BitRowwise"},
+      {"SparseLengthsSum2BitRowwiseSparse", "SparseLengthsSumFused2BitRowwise"},
+      {"SparseLengthsWeightedSum2BitRowwiseSparse",
+       "SparseLengthsWeightedSumFused2BitRowwise"}};
+  NetDef new_net;
+  new_net.CopyFrom(*net);
+  new_net.mutable_op()->Clear();
+  for (const auto& op : net->op()) {
+    const auto it = slss.find(op.type());
+    if (it == slss.end()) {
+      new_net.add_op()->CopyFrom(op);
+    } else {
+      const bool is_weighted =
+          (op.type().find("Weighted") != std::string::npos);
+      const auto& compressed_mapping = op.input(is_weighted ? 4 : 3);
+      const auto* b = ws.GetBlob(compressed_mapping);
+      bool fallback = false;
+      if (b && b->IsType<Tensor>()) {
+        const auto& t = BlobGetTensor(*b, CPU);
+        fallback = ((t.numel() == 1) && (t.template data<int32_t>()[0] == 0));
+      }
+
+      if (fallback) {
+        // If fallback, we just replace the original slss op with a normal sls
+        // op
+        OperatorDef new_op;
+        new_op.CopyFrom(op);
+        new_op.set_type(it->second);
+        new_op.mutable_input()->RemoveLast();
+        new_net.add_op()->CopyFrom(new_op);
+      } else {
+        // Otherwise, we replace slss with slss_lookup followed by a normal sls
+        OperatorDef new_op;
+        new_op.CopyFrom(op);
+        new_op.set_type("SparseLengthsSumSparseLookup");
+        new_op.clear_input();
+        const auto& indices_in = is_weighted ? op.input(2) : op.input(1);
+        const auto& lengths_in = is_weighted ? op.input(3) : op.input(2);
+        const auto& compress_mapping = is_weighted ? op.input(4) : op.input(3);
+        const auto& weights_in = is_weighted ? op.input(1) : "";
+        new_op.add_input(indices_in);
+        new_op.add_input(lengths_in);
+        new_op.add_input(compress_mapping);
+        const auto indices_out = indices_in + "_decomp";
+        const auto lengths_out = lengths_in + "_decomp";
+        const auto weights_out = weights_in + "_decomp";
+        new_op.clear_output();
+        new_op.add_output(indices_out);
+        new_op.add_output(lengths_out);
+        if (is_weighted) {
+          new_op.add_input(weights_in);
+          new_op.add_output(weights_out);
+        }
+        new_net.add_op()->CopyFrom(new_op);
+
+        new_op.CopyFrom(op);
+        new_op.set_type(it->second);
+        new_op.mutable_input()->RemoveLast();
+        *new_op.mutable_input()->Mutable(is_weighted ? 2 : 1) = indices_out;
+        *new_op.mutable_input()->Mutable(is_weighted ? 3 : 2) = lengths_out;
+        if (is_weighted) {
+          *new_op.mutable_input()->Mutable(1) = weights_out;
+        }
+        new_net.add_op()->CopyFrom(new_op);
+      }
+    }
+  }
+
+  new_net.Swap(net);
+}
+
 OnnxifiTransformer::OnnxifiTransformer(const OnnxifiTransformerOptions& opts)
     : BackendTransformerBase(), opts_(opts) {
   lib_ = onnx::initOnnxifiLibrary();

--- a/caffe2/opt/onnxifi_transformer.h
+++ b/caffe2/opt/onnxifi_transformer.h
@@ -16,6 +16,10 @@ namespace onnx {
 class OnnxExporter;
 }
 
+// Split SparseLengthsSumSparse into SparseLengthsSumSparseLookup +
+// SparseLengthsSum
+CAFFE2_API void splitSparseLengthsSumSparse(NetDef* net, const Workspace& ws);
+
 struct OnnxifiTransformerOptions final : public BackendTransformOptions {
   explicit OnnxifiTransformerOptions() : BackendTransformOptions() {}
 

--- a/caffe2/opt/split_slss_test.cc
+++ b/caffe2/opt/split_slss_test.cc
@@ -1,0 +1,105 @@
+#include <caffe2/core/common.h>
+#include <caffe2/core/test_utils.h>
+#include <caffe2/core/workspace.h>
+#include <caffe2/opt/onnxifi_transformer.h>
+#include <caffe2/utils/proto_utils.h>
+
+#include <gtest/gtest.h>
+
+using namespace caffe2::testing;
+using namespace caffe2;
+
+namespace {
+NetDef createTest(
+    const std::string& op_type,
+    Workspace* ws,
+    bool has_weight,
+    bool fallback) {
+  NetDef net;
+  std::vector<std::string> inputs{
+      "Data", "Weight", "Idx", "Lengths", "Compressed"};
+  if (!has_weight) {
+    inputs = {"Data", "Idx", "Lengths", "Compressed"};
+  }
+  NetMutator(&net).newOp(op_type, inputs, {"Out"});
+  auto* b = ws->CreateBlob("Compressed");
+  auto* t = BlobGetMutableTensor(b, {1}, at::dtype<int32_t>());
+  auto* comp = t->template mutable_data<int32_t>();
+  *comp = fallback ? 0 : 1;
+  return net;
+}
+
+void check(
+    const NetDef& net,
+    const std::string& op_type,
+    bool has_weight,
+    bool fallback) {
+  const static std::unordered_map<string, string> slss = {
+      {"SparseLengthsSum4BitRowwiseSparse", "SparseLengthsSumFused4BitRowwise"},
+      {"SparseLengthsWeightedSum4BitRowwiseSparse",
+       "SparseLengthsWeightedSumFused4BitRowwise"},
+      {"SparseLengthsSum8BitRowwiseSparse", "SparseLengthsSum8FusedBitRowwise"},
+      {"SparseLengthsWeightedSum8BitRowwiseSparse",
+       "SparseLengthsWeightedSumFused8BitRowwise"},
+      {"SparseLengthsSum2BitRowwiseSparse", "SparseLengthsSumFused2BitRowwise"},
+      {"SparseLengthsWeightedSum2BitRowwiseSparse",
+       "SparseLengthsWeightedSumFused2BitRowwise"}};
+  if (fallback) {
+    EXPECT_EQ(net.op_size(), 1);
+    EXPECT_EQ(net.op(0).type(), slss.at(op_type));
+    EXPECT_EQ(net.op(0).input_size(), has_weight ? 4 : 3);
+    EXPECT_EQ(net.op(0).output_size(), 1);
+    EXPECT_EQ(net.op(0).input(0), "Data");
+    EXPECT_EQ(net.op(0).input(has_weight ? 2 : 1), "Idx");
+    EXPECT_EQ(net.op(0).input(has_weight ? 3 : 2), "Lengths");
+    if (has_weight) {
+      EXPECT_EQ(net.op(0).input(1), "Weight");
+    }
+    EXPECT_EQ(net.op(0).output(0), "Out");
+  } else {
+    EXPECT_EQ(net.op_size(), 2);
+    EXPECT_EQ(net.op(0).type(), "SparseLengthsSumSparseLookup");
+    EXPECT_EQ(net.op(0).input_size(), has_weight ? 4 : 3);
+    EXPECT_EQ(net.op(0).output_size(), has_weight ? 3 : 2);
+    EXPECT_EQ(net.op(0).input(0), "Idx");
+    EXPECT_EQ(net.op(0).input(1), "Lengths");
+    EXPECT_EQ(net.op(0).input(2), "Compressed");
+    EXPECT_EQ(net.op(0).output(0), "Idx_decomp");
+    EXPECT_EQ(net.op(0).output(1), "Lengths_decomp");
+    if (has_weight) {
+      EXPECT_EQ(net.op(0).input(3), "Weight");
+      EXPECT_EQ(net.op(0).output(2), "Weight_decomp");
+    }
+    EXPECT_EQ(net.op(1).type(), slss.at(op_type));
+    EXPECT_EQ(net.op(1).input_size(), has_weight ? 4 : 3);
+    EXPECT_EQ(net.op(1).output_size(), 1);
+    EXPECT_EQ(net.op(1).input(0), "Data");
+    EXPECT_EQ(net.op(1).input(has_weight ? 2 : 1), "Idx_decomp");
+    EXPECT_EQ(net.op(1).input(has_weight ? 3 : 2), "Lengths_decomp");
+    if (has_weight) {
+      EXPECT_EQ(net.op(1).input(1), "Weight_decomp");
+    }
+    EXPECT_EQ(net.op(1).output(0), "Out");
+  }
+}
+} // namespace
+
+TEST(splitSparseLengthsSumSparse, sweep) {
+  std::vector<bool> has_weights = {true, false};
+  std::vector<bool> fallbacks = {true, false};
+  std::vector<int> bits = {2, 4, 8};
+  for (const auto has_weight : has_weights) {
+    for (const auto bit : bits) {
+      std::string op_type = "SparseLengths";
+      op_type += (has_weight ? "WeightedSum" : "Sum");
+      op_type += caffe2::to_string(bit);
+      op_type += "BitRowwiseSparse";
+      for (const auto fallback : fallbacks) {
+        Workspace ws;
+        auto net = createTest(op_type, &ws, has_weight, fallback);
+        splitSparseLengthsSumSparse(&net, ws);
+        check(net, op_type, has_weight, fallback);
+      }
+    }
+  }
+}


### PR DESCRIPTION
Summary: We will need to apply this transform pass onto the net before lowering to Glow.

Test Plan:
```
buck test caffe2/caffe2/opt/custom:split_slss_test
```

Differential Revision: D20688451

