### PR TITLE
copy_ fixed on cuda so removing the workaround in test_many_promotions

### DIFF
--- a/test/test_type_promotion.py
+++ b/test/test_type_promotion.py
@@ -257,15 +257,7 @@ class TestTypePromotion(TestCase):
                 self.assertEqual(not first.is_contiguous(), non_contiguous)
                 self.assertEqual(not second.is_contiguous(), non_contiguous)
                 result = op(first, second)
-                # TODO: copy_() for complex on cuda issues on github: #33567 #35284
-                if common_dtype.is_complex and first.is_cuda:
-                    first_ = torch.zeros(first.size(), dtype=common_dtype, device=device)
-                    second_ = torch.zeros(second.size(), dtype=common_dtype, device=device)
-                    first_.add_(first)
-                    second_.add_(second)
-                    expected = op(first_, second_)
-                else:
-                    expected = op(first.to(common_dtype), second.to(common_dtype))
+                expected = op(first.to(common_dtype), second.to(common_dtype))
                 self.assertEqual(result.dtype, expected.dtype, message='{} with {}, {}'.format(op.__name__, dt1, dt2))
                 self.assertEqual(result, expected, message='{} with {}, {}'.format(op.__name__, dt1, dt2))
 


### PR DESCRIPTION
copy_() launch failure fixed on cuda for complex #35344  so removing the workaround added in PR #34093 