### PR TITLE
[caffe2] Explicit vectorization of LSTM operator

### DIFF
--- a/caffe2/operators/lstm_unit_op.h
+++ b/caffe2/operators/lstm_unit_op.h
@@ -3,68 +3,31 @@
 
 #include "caffe2/core/context.h"
 #include "caffe2/core/operator.h"
+#include "caffe2/perfkernels/lstm_unit_cpu.h"
 #include "caffe2/utils/conversions.h"
 
 namespace caffe2 {
 namespace detail {
-template <typename T>
-inline T sigmoid(T x) {
-  return 1. / (1. + exp(-x));
-}
-
-template <typename T>
-inline T host_tanh(T x) {
-  return 2. * sigmoid(2. * x) - 1.;
-}
-
 template <typename T, typename Context>
-void LSTMUnit(
-    int N,
-    int D,
-    int t,
+inline void LSTMUnit(
+    const int N,
+    const int D,
+    const int t,
     const T* H_prev,
     const T* C_prev,
     const T* X,
     const int32_t* seqLengths,
-    bool drop_states,
+    const bool drop_states,
     T* C,
     T* H,
     const float forget_bias,
     Context* /*context*/) {
-  for (int n = 0; n < N; ++n) {
-    const bool valid = seqLengths == nullptr || t < seqLengths[n];
-
-    for (int d = 0; d < D; ++d) {
-      if (!valid) {
-        if (drop_states) {
-          H[d] = 0;
-          C[d] = 0;
-        } else {
-          H[d] = H_prev[d];
-          C[d] = C_prev[d];
-        }
-      } else {
-        const T i = sigmoid(X[d]);
-        const T f = sigmoid(X[1 * D + d] + convert::To<float, T>(forget_bias));
-        const T o = sigmoid(X[2 * D + d]);
-        const T g = host_tanh(X[3 * D + d]);
-        const T c_prev = C_prev[d];
-        const T c = f * c_prev + i * g;
-        C[d] = c;
-        const T host_tanh_c = host_tanh(c);
-        H[d] = o * host_tanh_c;
-      }
-    }
-    H_prev += D;
-    C_prev += D;
-    X += 4 * D;
-    C += D;
-    H += D;
-  }
+  LstmUnitCpu<T>(
+      N, D, t, H_prev, C_prev, X, seqLengths, drop_states, C, H, forget_bias);
 }
 
 template <typename T, typename Context>
-void LSTMUnitGradient(
+inline void LSTMUnitGradient(
     int N,
     int D,
     int t,
@@ -81,57 +44,24 @@ void LSTMUnitGradient(
     T* X_diff,
     const float forget_bias,
     Context* /*context*/) {
-  for (int n = 0; n < N; ++n) {
-    const bool valid = seqLengths == nullptr || t < seqLengths[n];
-
-    for (int d = 0; d < D; ++d) {
-      T* c_prev_diff = C_prev_diff + d;
-      T* h_prev_diff = H_prev_diff + d;
-      T* i_diff = X_diff + d;
-      T* f_diff = X_diff + 1 * D + d;
-      T* o_diff = X_diff + 2 * D + d;
-      T* g_diff = X_diff + 3 * D + d;
-
-      if (!valid) {
-        if (drop_states) {
-          *h_prev_diff = 0;
-          *c_prev_diff = 0;
-        } else {
-          *h_prev_diff = H_diff[d];
-          *c_prev_diff = C_diff[d];
-        }
-        *i_diff = 0;
-        *f_diff = 0;
-        *o_diff = 0;
-        *g_diff = 0;
-      } else {
-        const T i = sigmoid(X[d]);
-        const T f = sigmoid(X[1 * D + d] + convert::To<float, T>(forget_bias));
-        const T o = sigmoid(X[2 * D + d]);
-        const T g = host_tanh(X[3 * D + d]);
-        const T c_prev = C_prev[d];
-        const T c = C[d];
-        const T host_tanh_c = host_tanh(c);
-        const T c_term_diff = C_diff[d] + H_diff[d] * o * (1 - host_tanh_c * host_tanh_c);
-        *c_prev_diff = c_term_diff * f;
-        *h_prev_diff = 0; // not used in 'valid' case
-        *i_diff = c_term_diff * g * i * (1 - i);
-        *f_diff = c_term_diff * c_prev * f * (1 - f);
-        *o_diff = H_diff[d] * host_tanh_c * o * (1 - o);
-        *g_diff = c_term_diff * i * (1 - g * g);
-      }
-    }
-    C_prev += D;
-    X += 4 * D;
-    C += D;
-    H += D;
-    C_diff += D;
-    H_diff += D;
-    X_diff += 4 * D;
-    H_prev_diff += D;
-    C_prev_diff += D;
-  }
+  LstmUnitGradientCpu<T>(
+      N,
+      D,
+      t,
+      C_prev,
+      X,
+      seqLengths,
+      C,
+      H,
+      C_diff,
+      H_diff,
+      drop_states,
+      H_prev_diff,
+      C_prev_diff,
+      X_diff,
+      forget_bias);
 }
+
 } // namespace detail
 
 template <typename Context>

--- a/caffe2/perfkernels/common.h
+++ b/caffe2/perfkernels/common.h
@@ -70,23 +70,32 @@ In foo.cc, do:
 #define BASE_DO(funcname, ...) return funcname##__base(__VA_ARGS__);
 
 #ifdef CAFFE2_PERF_WITH_AVX512
-#define AVX512_DO(funcname, ...)                       \
-  if (GetCpuId().avx512f() && GetCpuId().avx512dq() && \
-      GetCpuId().avx512vl()) {                         \
-    return funcname##__avx512(__VA_ARGS__);            \
+#define AVX512_DO(funcname, ...)                                              \
+  {                                                                           \
+    static const bool isDo = GetCpuId().avx512f() && GetCpuId().avx512dq() && \
+        GetCpuId().avx512vl();                                                \
+    if (isDo) {                                                               \
+      return funcname##__avx512(__VA_ARGS__);                                 \
+    }                                                                         \
   }
 #else // CAFFE2_PERF_WITH_AVX512
 #define AVX512_DO(funcname, ...)
 #endif // CAFFE2_PERF_WITH_AVX512
 
 #ifdef CAFFE2_PERF_WITH_AVX2
-#define AVX2_DO(funcname, ...)            \
-  if (GetCpuId().avx2()) {                \
-    return funcname##__avx2(__VA_ARGS__); \
+#define AVX2_DO(funcname, ...)                  \
+  {                                             \
+    static const bool isDo = GetCpuId().avx2(); \
+    if (isDo) {                                 \
+      return funcname##__avx2(__VA_ARGS__);     \
+    }                                           \
   }
-#define AVX2_FMA_DO(funcname, ...)             \
-  if (GetCpuId().avx2() && GetCpuId().fma()) { \
-    return funcname##__avx2_fma(__VA_ARGS__);  \
+#define AVX2_FMA_DO(funcname, ...)                                  \
+  {                                                                 \
+    static const bool isDo = GetCpuId().avx2() && GetCpuId().fma(); \
+    if (isDo) {                                                     \
+      return funcname##__avx2_fma(__VA_ARGS__);                     \
+    }                                                               \
   }
 #else // CAFFE2_PERF_WITH_AVX2
 #define AVX2_DO(funcname, ...)
@@ -94,13 +103,19 @@ In foo.cc, do:
 #endif // CAFFE2_PERF_WITH_AVX2
 
 #ifdef CAFFE2_PERF_WITH_AVX
-#define AVX_DO(funcname, ...)            \
-  if (GetCpuId().avx()) {                \
-    return funcname##__avx(__VA_ARGS__); \
+#define AVX_DO(funcname, ...)                  \
+  {                                            \
+    static const bool isDo = GetCpuId().avx(); \
+    if (isDo) {                                \
+      return funcname##__avx(__VA_ARGS__);     \
+    }                                          \
   }
-#define AVX_F16C_DO(funcname, ...)             \
-  if (GetCpuId().avx() && GetCpuId().f16c()) { \
-    return funcname##__avx_f16c(__VA_ARGS__);  \
+#define AVX_F16C_DO(funcname, ...)                                  \
+  {                                                                 \
+    static const bool isDo = GetCpuId().avx() && GetCpuId().f16c(); \
+    if (isDo) {                                                     \
+      return funcname##__avx_f16c(__VA_ARGS__);                     \
+    }                                                               \
   }
 #else // CAFFE2_PERF_WITH_AVX
 #define AVX_DO(funcname, ...)

--- a/caffe2/perfkernels/lstm_unit_cpu-impl.h
+++ b/caffe2/perfkernels/lstm_unit_cpu-impl.h
@@ -1,0 +1,158 @@
+#pragma once
+#include <cmath>
+#include "caffe2/utils/conversions.h"
+
+#if (ENABLE_VECTORIZATION > 0) && !defined(_DEBUG) && !defined(DEBUG)
+#if defined(__clang__) && (__clang_major__ > 7)
+#define IS_SANITIZER                          \
+  ((__has_feature(address_sanitizer) == 1) || \
+   (__has_feature(memory_sanitizer) == 1) ||  \
+   (__has_feature(thread_sanitizer) == 1) ||  \
+   (__has_feature(undefined_sanitizer) == 1))
+
+#if IS_SANITIZER == 0
+#define VECTOR_LOOP _Pragma("clang loop vectorize(enable)")
+#endif
+#elif defined(_OPENMP) && (_OPENMP >= 201511)
+// Support with OpenMP4.5 and above
+#define VECTOR_LOOP _Pragma("omp for simd")
+#endif
+#endif
+
+#ifndef VECTOR_LOOP
+// Not supported
+#define VECTOR_LOOP
+#endif
+
+namespace caffe2 {
+namespace perfkernels {
+namespace {
+template <typename T>
+inline T sigmoid(T x) {
+  return 1 / (1 + std::exp(-x));
+}
+
+template <typename T>
+inline T host_tanh(T x) {
+  return 2 * sigmoid(2 * x) - 1;
+}
+
+template <typename T>
+inline void LstmUnitImpl(
+    const int N,
+    const int D,
+    const int t,
+    const T* H_prev,
+    const T* C_prev,
+    const T* X,
+    const int32_t* seqLengths,
+    const bool drop_states,
+    T* C,
+    T* H,
+    const float forget_bias) {
+  const T forgetBias = convert::To<float, T>(forget_bias);
+  for (int n = 0; n < N; ++n) {
+    const bool valid = seqLengths == nullptr || t < seqLengths[n];
+    if (!valid) {
+      if (drop_states) {
+        memset(H, 0, sizeof(T) * D);
+        memset(C, 0, sizeof(T) * D);
+      } else {
+        memcpy(H, H_prev, sizeof(T) * D);
+        memcpy(C, C_prev, sizeof(T) * D);
+      }
+    } else {
+      const T* X_D = &X[D];
+      const T* X_2D = &X[2 * D];
+      const T* X_3D = &X[3 * D];
+      VECTOR_LOOP for (int d = 0; d < D; ++d) {
+        const T i = sigmoid(X[d]);
+        const T f = sigmoid(X_D[d] + forgetBias);
+        const T o = sigmoid(X_2D[d]);
+        const T g = host_tanh(X_3D[d]);
+        const T c_prev = C_prev[d];
+        const T c = f * c_prev + i * g;
+        C[d] = c;
+        const T host_tanh_c = host_tanh(c);
+        H[d] = o * host_tanh_c;
+      }
+    }
+    H_prev += D;
+    C_prev += D;
+    X += 4 * D;
+    C += D;
+    H += D;
+  }
+}
+
+template <typename T>
+inline void LstmUnitGradientImpl(
+    int N,
+    int D,
+    int t,
+    const T* C_prev,
+    const T* X,
+    const int32_t* seqLengths,
+    const T* C,
+    const T* H,
+    const T* C_diff,
+    const T* H_diff,
+    bool drop_states,
+    T* H_prev_diff,
+    T* C_prev_diff,
+    T* X_diff,
+    const float forget_bias) {
+  const T localForgetBias = convert::To<float, T>(forget_bias);
+  for (int n = 0; n < N; ++n) {
+    const bool valid = seqLengths == nullptr || t < seqLengths[n];
+
+    if (!valid) {
+      if (drop_states) {
+        memset(C_prev_diff, 0, sizeof(T) * D);
+        memset(H_prev_diff, 0, sizeof(T) * D);
+      } else {
+        memcpy(H_prev_diff, H_diff, sizeof(T) * D);
+        memcpy(C_prev_diff, C_diff, sizeof(T) * D);
+      }
+      memset(X_diff, 0, 4 * sizeof(T) * D);
+    } else {
+      VECTOR_LOOP for (int d = 0; d < D; ++d) {
+        T* c_prev_diff = C_prev_diff + d;
+        T* h_prev_diff = H_prev_diff + d;
+        T* i_diff = X_diff + d;
+        T* f_diff = X_diff + 1 * D + d;
+        T* o_diff = X_diff + 2 * D + d;
+        T* g_diff = X_diff + 3 * D + d;
+
+        const T i = sigmoid(X[d]);
+        const T f = sigmoid(X[1 * D + d] + localForgetBias);
+        const T o = sigmoid(X[2 * D + d]);
+        const T g = host_tanh(X[3 * D + d]);
+        const T c_prev = C_prev[d];
+        const T c = C[d];
+        const T host_tanh_c = host_tanh(c);
+        const T c_term_diff =
+            C_diff[d] + H_diff[d] * o * (1 - host_tanh_c * host_tanh_c);
+        *c_prev_diff = c_term_diff * f;
+        *h_prev_diff = 0; // not used in 'valid' case
+        *i_diff = c_term_diff * g * i * (1 - i);
+        *f_diff = c_term_diff * c_prev * f * (1 - f);
+        *o_diff = H_diff[d] * host_tanh_c * o * (1 - o);
+        *g_diff = c_term_diff * i * (1 - g * g);
+      }
+    }
+    C_prev += D;
+    X += 4 * D;
+    C += D;
+    H += D;
+    C_diff += D;
+    H_diff += D;
+    X_diff += 4 * D;
+    H_prev_diff += D;
+    C_prev_diff += D;
+  }
+}
+
+} // namespace
+} // namespace perfkernels
+} // namespace caffe2

--- a/caffe2/perfkernels/lstm_unit_cpu.h
+++ b/caffe2/perfkernels/lstm_unit_cpu.h
@@ -1,0 +1,73 @@
+#pragma once
+#include <cstdint>
+
+namespace caffe2 {
+namespace detail {
+
+// Forward declration of the LSTMUnit templated
+// implementation
+template <typename T>
+void LstmUnitCpu(
+    const int N,
+    const int D,
+    const int t,
+    const T* H_prev,
+    const T* C_prev,
+    const T* X,
+    const int32_t* seqLengths,
+    const bool drop_states,
+    T* C,
+    T* H,
+    const float forget_bias);
+
+// Forward specialization
+extern template void LstmUnitCpu<float>(
+    const int N,
+    const int D,
+    const int t,
+    const float* H_prev,
+    const float* C_prev,
+    const float* X,
+    const int32_t* seqLengths,
+    const bool drop_states,
+    float* C,
+    float* H,
+    const float forget_bias);
+
+template <typename T>
+void LstmUnitGradientCpu(
+    int N,
+    int D,
+    int t,
+    const T* C_prev,
+    const T* X,
+    const int32_t* seqLengths,
+    const T* C,
+    const T* H,
+    const T* C_diff,
+    const T* H_diff,
+    bool drop_states,
+    T* H_prev_diff,
+    T* C_prev_diff,
+    T* X_diff,
+    const float forget_bias);
+
+extern template void LstmUnitGradientCpu<float>(
+    int N,
+    int D,
+    int t,
+    const float* C_prev,
+    const float* X,
+    const int32_t* seqLengths,
+    const float* C,
+    const float* H,
+    const float* C_diff,
+    const float* H_diff,
+    bool drop_states,
+    float* H_prev_diff,
+    float* C_prev_diff,
+    float* X_diff,
+    const float forget_bias);
+
+} // namespace detail
+} // namespace caffe2

--- a/caffe2/perfkernels/lstm_unit_cpu_avx2.cc
+++ b/caffe2/perfkernels/lstm_unit_cpu_avx2.cc
@@ -1,0 +1,123 @@
+#include "caffe2/perfkernels/lstm_unit_cpu-impl.h"
+
+namespace caffe2 {
+namespace perfkernels {
+namespace {
+// Explicit initialize for float and AVX2 vectorization
+template void LstmUnitImpl<float>(
+    const int N,
+    const int D,
+    const int t,
+    const float* H_prev,
+    const float* C_prev,
+    const float* X,
+    const int32_t* seqLengths,
+    const bool drop_states,
+    float* C,
+    float* H,
+    const float forget_bias);
+
+template void LstmUnitGradientImpl<float>(
+    int N,
+    int D,
+    int t,
+    const float* C_prev,
+    const float* X,
+    const int32_t* seqLengths,
+    const float* C,
+    const float* H,
+    const float* C_diff,
+    const float* H_diff,
+    bool drop_states,
+    float* H_prev_diff,
+    float* C_prev_diff,
+    float* X_diff,
+    const float forget_bias);
+} // namespace
+
+// Define templated implementation fo LSTM kernels on CPU supporting AVX2
+template <typename T>
+void LstmUnitImpl__avx2_fma(
+    const int N,
+    const int D,
+    const int t,
+    const T* H_prev,
+    const T* C_prev,
+    const T* X,
+    const int32_t* seqLengths,
+    const bool drop_states,
+    T* C,
+    T* H,
+    const float forget_bias) {
+  LstmUnitImpl(
+      N, D, t, H_prev, C_prev, X, seqLengths, drop_states, C, H, forget_bias);
+}
+
+template <typename T>
+void LstmUnitGradientImpl__avx2_fma(
+    int N,
+    int D,
+    int t,
+    const T* C_prev,
+    const T* X,
+    const int32_t* seqLengths,
+    const T* C,
+    const T* H,
+    const T* C_diff,
+    const T* H_diff,
+    bool drop_states,
+    T* H_prev_diff,
+    T* C_prev_diff,
+    T* X_diff,
+    const float forget_bias) {
+  LstmUnitGradientImpl(
+      N,
+      D,
+      t,
+      C_prev,
+      X,
+      seqLengths,
+      C,
+      H,
+      C_diff,
+      H_diff,
+      drop_states,
+      H_prev_diff,
+      C_prev_diff,
+      X_diff,
+      forget_bias);
+}
+
+// Explicit initialize for float
+template void LstmUnitImpl__avx2_fma<float>(
+    const int N,
+    const int D,
+    const int t,
+    const float* H_prev,
+    const float* C_prev,
+    const float* X,
+    const int32_t* seqLengths,
+    const bool drop_states,
+    float* C,
+    float* H,
+    const float forget_bias);
+
+template void LstmUnitGradientImpl__avx2_fma<float>(
+    int N,
+    int D,
+    int t,
+    const float* C_prev,
+    const float* X,
+    const int32_t* seqLengths,
+    const float* C,
+    const float* H,
+    const float* C_diff,
+    const float* H_diff,
+    bool drop_states,
+    float* H_prev_diff,
+    float* C_prev_diff,
+    float* X_diff,
+    const float forget_bias);
+
+} // namespace perfkernels
+} // namespace caffe2

--- a/caffe2/perfkernels/lstm_unit_cpu_common.cc
+++ b/caffe2/perfkernels/lstm_unit_cpu_common.cc
@@ -1,0 +1,125 @@
+#include "caffe2/perfkernels/lstm_unit_cpu_common.h"
+#include "caffe2/perfkernels/common.h"
+#include "caffe2/perfkernels/lstm_unit_cpu-impl.h"
+
+namespace caffe2 {
+namespace detail {
+
+// Define templated implementation fo LSTM kernels on CPU
+template <typename T>
+void LstmUnitCpu(
+    const int N,
+    const int D,
+    const int t,
+    const T* H_prev,
+    const T* C_prev,
+    const T* X,
+    const int32_t* seqLengths,
+    const bool drop_states,
+    T* C,
+    T* H,
+    const float forget_bias) {
+  // Do CPU dispatching
+  AVX2_FMA_DO(
+      perfkernels::LstmUnitImpl,
+      N,
+      D,
+      t,
+      H_prev,
+      C_prev,
+      X,
+      seqLengths,
+      drop_states,
+      C,
+      H,
+      forget_bias);
+  perfkernels::LstmUnitImpl(
+      N, D, t, H_prev, C_prev, X, seqLengths, drop_states, C, H, forget_bias);
+}
+
+template <typename T>
+void LstmUnitGradientCpu(
+    int N,
+    int D,
+    int t,
+    const T* C_prev,
+    const T* X,
+    const int32_t* seqLengths,
+    const T* C,
+    const T* H,
+    const T* C_diff,
+    const T* H_diff,
+    bool drop_states,
+    T* H_prev_diff,
+    T* C_prev_diff,
+    T* X_diff,
+    const float forget_bias) {
+  // Do CPU dispatching
+  AVX2_FMA_DO(
+      perfkernels::LstmUnitGradientImpl,
+      N,
+      D,
+      t,
+      C_prev,
+      X,
+      seqLengths,
+      C,
+      H,
+      C_diff,
+      H_diff,
+      drop_states,
+      H_prev_diff,
+      C_prev_diff,
+      X_diff,
+      forget_bias);
+  perfkernels::LstmUnitGradientImpl(
+      N,
+      D,
+      t,
+      C_prev,
+      X,
+      seqLengths,
+      C,
+      H,
+      C_diff,
+      H_diff,
+      drop_states,
+      H_prev_diff,
+      C_prev_diff,
+      X_diff,
+      forget_bias);
+}
+
+// Explicit initialize for float
+template void LstmUnitCpu<float>(
+    const int N,
+    const int D,
+    const int t,
+    const float* H_prev,
+    const float* C_prev,
+    const float* X,
+    const int32_t* seqLengths,
+    const bool drop_states,
+    float* C,
+    float* H,
+    const float forget_bias);
+
+template void LstmUnitGradientCpu<float>(
+    int N,
+    int D,
+    int t,
+    const float* C_prev,
+    const float* X,
+    const int32_t* seqLengths,
+    const float* C,
+    const float* H,
+    const float* C_diff,
+    const float* H_diff,
+    bool drop_states,
+    float* H_prev_diff,
+    float* C_prev_diff,
+    float* X_diff,
+    const float forget_bias);
+
+} // namespace detail
+} // namespace caffe2

--- a/caffe2/perfkernels/lstm_unit_cpu_common.h
+++ b/caffe2/perfkernels/lstm_unit_cpu_common.h
@@ -1,0 +1,71 @@
+#pragma once
+#include <cstdint>
+
+namespace caffe2 {
+namespace perfkernels {
+
+template <typename T>
+void LstmUnitImpl__avx2_fma(
+    const int N,
+    const int D,
+    const int t,
+    const T* H_prev,
+    const T* C_prev,
+    const T* X,
+    const int32_t* seqLengths,
+    const bool drop_states,
+    T* C,
+    T* H,
+    const float forget_bias);
+
+template <typename T>
+void LstmUnitGradientImpl__avx2_fma(
+    int N,
+    int D,
+    int t,
+    const T* C_prev,
+    const T* X,
+    const int32_t* seqLengths,
+    const T* C,
+    const T* H,
+    const T* C_diff,
+    const T* H_diff,
+    bool drop_states,
+    T* H_prev_diff,
+    T* C_prev_diff,
+    T* X_diff,
+    const float forget_bias);
+
+// Forward declaration of specialized functions
+extern template void LstmUnitImpl__avx2_fma(
+    const int N,
+    const int D,
+    const int t,
+    const float* H_prev,
+    const float* C_prev,
+    const float* X,
+    const int32_t* seqLengths,
+    const bool drop_states,
+    float* C,
+    float* H,
+    const float forget_bias);
+
+extern template void LstmUnitGradientImpl__avx2_fma(
+    int N,
+    int D,
+    int t,
+    const float* C_prev,
+    const float* X,
+    const int32_t* seqLengths,
+    const float* C,
+    const float* H,
+    const float* C_diff,
+    const float* H_diff,
+    bool drop_states,
+    float* H_prev_diff,
+    float* C_prev_diff,
+    float* X_diff,
+    const float forget_bias);
+
+} // namespace perfkernels
+} // namespace caffe2


### PR DESCRIPTION
Summary:
Apply explicit vectorization to lstm_unit operator.
Enabled by -DENABLE_VECTORIZATION=1

This optimization requires vector library support and was tested with Intel SVML & clang.
However, compiler which support OpenMP4.5 with omp simd extention should also benefit.

After the code changes
In file included from caffe2/caffe2/operators/lstm_unit_op.cc:1:
caffe2/caffe2/operators/lstm_unit_op.h:60:1: remark: vectorized loop (vectorization width: 8, interleaved count: 1) [-Rpass=loop-vectorize]
VECTOR_LOOP for (int d = 0; d < D; ++d) {

caffe2/caffe2/operators/lstm_unit_op.h:60:1: remark: vectorized loop (vectorization width: 8, interleaved count: 1) [-Rpass=loop-vectorize]
caffe2/caffe2/operators/lstm_unit_op.h:112:1: remark: vectorized loop (vectorization width: 8, interleaved count: 1) [-Rpass=loop-vectorize]
VECTOR_LOOP for (int d = 0; d < D; ++d) {

Differential Revision: D20484640

