### PR TITLE
[fix] at::print for quantized Tensor

### DIFF
--- a/aten/src/ATen/core/Formatting.cpp
+++ b/aten/src/ATen/core/Formatting.cpp
@@ -240,7 +240,7 @@ std::ostream& print(std::ostream& stream, const Tensor & tensor_, int64_t linesi
   } else {
     Tensor tensor;
     if (tensor_.is_quantized()) {
-      Tensor tensor = tensor_.dequantize().to(kCPU, kDouble).contiguous();
+      tensor = tensor_.dequantize().to(kCPU, kDouble).contiguous();
     } else {
       tensor = tensor_.to(kCPU, kDouble).contiguous();
     }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #35509 [quant][graphmode] Quantization support for `quantized::add_scalar_relu` and `quantized::add_scalar_relu_out`
* #35385 [quant][graphmode] Remove unused patterns
* #35347 [quant][graphmode] Quantization support for `aten::conv3d`
* #35345 [quant][graphmode][fix] Add filter for `quantized::add`
* #35336 [quant][graphmode] qconfig_dict support None
* #35420 [quant][graphmode] Make `aten::relu` a general op
* #35335 [quant][graphmode] `prepare_script` takes original qconfig_dict
* #35334 [quant][graphmode] Quantization support for `quantized::add_scalar`
* #35333 [quant][graphmode][refactor] Support filter function in quant fusion patterns
* #35332 [quant][graphmode] Quantization support for permute and repeat_interleave
* #35130 [quant][graphmode] Make interpolate/upsample work again
* #35142 [quant][graphmode] SwapDeQuant support prim::If
* #35141 [quant][graphmode][refactor] getGeneralOpTensorInputIndexes -> getGeneralOpTensorInputs
* #35135 [quant][graphmode][refactor] swapDeQuant takes block as arugment
* #35077 [quant][graphmode] Fold quantized prepacking ops
* #35073 [quant] Make conv2d_prepack and linear_prepack pure
* **#35545 [fix] at::print for quantized Tensor**

Summary:
Looks like we have never printed a quantized Tensor in cpp before

Test Plan:
.

Reviewers:
.

Subscribers:

Tasks:

Tags:

Differential Revision: [D20699748](https://our.internmc.facebook.com/intern/diff/D20699748)