### PR TITLE
Disable unit test failing on Windows

### DIFF
--- a/aten/src/ATen/test/pow_test.cpp
+++ b/aten/src/ATen/test/pow_test.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <ATen/native/Pow.h>
+#include <c10/test/util/Macros.h>
 
 #include <torch/types.h>
 #include <torch/utils.h>
@@ -228,7 +229,8 @@ TEST(PowTest, IntTensorPowAllScalars) {
   tensor_pow_scalar(ints, c10::kInt, doubles, c10::kDouble);
 }
 
-TEST(PowTest, LongTensorPowAllScalars) {
+// See https://github.com/pytorch/pytorch/issues/35548
+TEST(PowTest, DISABLED_ON_WINDOWS(LongTensorPowAllScalars)) {
   tensor_pow_scalar(longs, c10::kLong, non_neg_ints, c10::kInt);
   tensor_pow_scalar(longs, c10::kLong, non_neg_longs, c10::kLong);
   tensor_pow_scalar(longs, c10::kLong, floats, c10::kFloat);

--- a/c10/test/util/Macros.h
+++ b/c10/test/util/Macros.h
@@ -1,0 +1,9 @@
+#ifndef C10_TEST_CORE_MACROS_MACROS_H_
+
+#ifdef _WIN32
+#define DISABLED_ON_WINDOWS(x) DISABLED_##x
+#else
+#define DISABLED_ON_WINDOWS(x) x
+#endif
+
+#endif // C10_MACROS_MACROS_H_

--- a/c10/test/util/Metaprogramming_test.cpp
+++ b/c10/test/util/Metaprogramming_test.cpp
@@ -1,5 +1,7 @@
 #include <c10/util/Metaprogramming.h>
+#include <c10/test/util/Macros.h>
 #include <gtest/gtest.h>
+
 
 using namespace c10::guts;
 
@@ -161,7 +163,8 @@ namespace test_filter_map {
         EXPECT_EQ(expected, result);
     }
 
-    TEST(MetaprogrammingTest, FilterMap_onlyCopiesIfNecessary) {
+    // See https://github.com/pytorch/pytorch/issues/35546
+    TEST(MetaprogrammingTest, DISABLED_ON_WINDOWS(FilterMap_onlyCopiesIfNecessary)) {
         struct map_copy_counting_by_copy {
           CopyCounting operator()(CopyCounting v) const {
             return v;
@@ -180,7 +183,7 @@ namespace test_filter_map {
         EXPECT_EQ(2, result[2].move_count);
     }
 
-    TEST(MetaprogrammingTest, FilterMap_onlyMovesIfNecessary_1) {
+    TEST(MetaprogrammingTest, DISABLED_ON_WINDOWS(FilterMap_onlyMovesIfNecessary_1)) {
         struct map_copy_counting_by_move {
           CopyCounting operator()(CopyCounting&& v) const {
             return std::move(v);

--- a/caffe2/operators/roi_align_op_gpu_test.cc
+++ b/caffe2/operators/roi_align_op_gpu_test.cc
@@ -1,12 +1,12 @@
-#include "caffe2/utils/eigen_utils.h"
 #include "caffe2/operators/roi_align_op.h"
+#include "caffe2/utils/eigen_utils.h"
 
+#include <c10/test/util/Macros.h>
 #include "caffe2/core/context_gpu.h"
 #include "caffe2/core/flags.h"
 #include "caffe2/utils/eigen_utils.h"
 #include "caffe2/utils/math.h"
 #include "gtest/gtest.h"
-
 namespace caffe2 {
 namespace {
 
@@ -195,7 +195,8 @@ void CreateAndRun(
 
 } // namespace
 
-TEST(RoiAlignTest, CheckCPUGPUEqual) {
+// See https://github.com/pytorch/pytorch/issues/35547
+TEST(RoiAlignTest, DISABLED_ON_WINDOWS(CheckCPUGPUEqual)) {
   if (!caffe2::HasCudaGPU())
     return;
 

--- a/caffe2/opt/bound_shape_inference_test.cc
+++ b/caffe2/opt/bound_shape_inference_test.cc
@@ -1,3 +1,4 @@
+#include <c10/test/util/Macros.h>
 #include <gtest/gtest.h>
 #include "caffe2/core/common.h"
 #include "caffe2/core/logging.h"
@@ -296,7 +297,10 @@ TEST(BoundShapeInference, ConcatMissingInput) {
       {spec.max_batch_size, 2, 60});
 }
 
-TEST(BoundShapeInference, Int8QuantizeInferInputBackwards) {
+// See https://github.com/pytorch/pytorch/issues/35544
+TEST(
+    BoundShapeInference,
+    DISABLED_ON_WINDOWS(Int8QuantizeInferInputBackwards)) {
   NetDef net;
   net.add_op()->CopyFrom(CreateOperatorDef(
       "Int8Quantize",


### PR DESCRIPTION
Introduce DISABLED_ON_WINDOWS macro, that adds `DISABLED_` prefix to string if compiled for Win32

Test Plan: CI

