### PR TITLE
[WIP]: Add polar method for complex tensors.

### DIFF
--- a/aten/src/ATen/cpu/vec256/vec256_base.h
+++ b/aten/src/ATen/cpu/vec256/vec256_base.h
@@ -322,7 +322,7 @@ public:
     return ret;
   }
   Vec256<T> polar() const {
-    return *this;
+    return abs();
   }
   Vec256<T> log() const {
     return map(std::log);

--- a/aten/src/ATen/cpu/vec256/vec256_base.h
+++ b/aten/src/ATen/cpu/vec256/vec256_base.h
@@ -324,6 +324,9 @@ public:
   Vec256<T> polar() const {
     return abs();
   }
+  Vec256<T> cart() const {
+    return abs();
+  }
   Vec256<T> log() const {
     return map(std::log);
   }

--- a/aten/src/ATen/cpu/vec256/vec256_base.h
+++ b/aten/src/ATen/cpu/vec256/vec256_base.h
@@ -321,6 +321,9 @@ public:
     }
     return ret;
   }
+  Vec256<T> polar() const {
+    return *this;
+  }
   Vec256<T> log() const {
     return map(std::log);
   }

--- a/aten/src/ATen/cpu/vec256/vec256_complex_double.h
+++ b/aten/src/ATen/cpu/vec256/vec256_complex_double.h
@@ -131,6 +131,18 @@ public:
     auto angle = _mm256_permute_pd(angle_(), 0x05); // angle    90-angle
     return _mm256_and_pd(angle, real_mask);         // angle    0
   }
+  __m256d polar_() const {
+    const __m256d real_mask = _mm256_castsi256_pd(_mm256_setr_epi64x(0xFFFFFFFFFFFFFFFF, 0x0000000000000000,
+                                                                     0xFFFFFFFFFFFFFFFF, 0x0000000000000000));
+    const __m256d imag_mask = _mm256_castsi256_pd(_mm256_setr_epi64x(0x0000000000000000, 0xFFFFFFFFFFFFFFFF,
+                                                                     0x0000000000000000, 0xFFFFFFFFFFFFFFFF));
+    auto angle = _mm256_and_pd(angle_(), imag_mask); // 0     angle
+    auto abs = _mm256_and_pd(abs_(), real_mask);     // abs   0
+    return _mm256_add_pd(abs, angle);
+  }
+  Vec256<std::complex<double>> polar() const {
+    return polar_();
+  }
   __m256d real_() const {
     const __m256d real_mask = _mm256_castsi256_pd(_mm256_setr_epi64x(0xFFFFFFFFFFFFFFFF, 0x0000000000000000,
                                                                      0xFFFFFFFFFFFFFFFF, 0x0000000000000000));

--- a/aten/src/ATen/cpu/vec256/vec256_complex_double.h
+++ b/aten/src/ATen/cpu/vec256/vec256_complex_double.h
@@ -132,13 +132,7 @@ public:
     return _mm256_and_pd(angle, real_mask);         // angle    0
   }
   __m256d polar_() const {
-    const __m256d real_mask = _mm256_castsi256_pd(_mm256_setr_epi64x(0xFFFFFFFFFFFFFFFF, 0x0000000000000000,
-                                                                     0xFFFFFFFFFFFFFFFF, 0x0000000000000000));
-    const __m256d imag_mask = _mm256_castsi256_pd(_mm256_setr_epi64x(0x0000000000000000, 0xFFFFFFFFFFFFFFFF,
-                                                                     0x0000000000000000, 0xFFFFFFFFFFFFFFFF));
-    auto angle = _mm256_and_pd(angle_(), imag_mask); // 0     angle
-    auto abs = _mm256_and_pd(abs_(), real_mask);     // abs   0
-    return _mm256_add_pd(abs, angle);
+    return _mm256_blend_pd(abs_(), angle_(), 0xA);
   }
   Vec256<std::complex<double>> polar() const {
     return polar_();

--- a/aten/src/ATen/cpu/vec256/vec256_complex_double.h
+++ b/aten/src/ATen/cpu/vec256/vec256_complex_double.h
@@ -137,6 +137,16 @@ public:
   Vec256<std::complex<double>> polar() const {
     return polar_();
   }
+  __m256d cart_() const {
+    auto sin_cos = Sleef_sincosd4_u10(values);                        // [sin(a), cos(a)] [sin(b), cos(b)]
+    auto cos_sin = _mm256_blend_pd(_mm256_permute_pd(sin_cos.y, 0x05),
+                                   sin_cos.x, 0x0A);                  // cos(b)           sin(b)
+    auto rr = _mm256_permute_pd(values, 0x0);                         // r                r
+    return _mm256_mul_pd(cos_sin, rr);
+  }
+  Vec256<std::complex<double>> cart() const {
+    return cart_();
+  }
   __m256d real_() const {
     const __m256d real_mask = _mm256_castsi256_pd(_mm256_setr_epi64x(0xFFFFFFFFFFFFFFFF, 0x0000000000000000,
                                                                      0xFFFFFFFFFFFFFFFF, 0x0000000000000000));

--- a/aten/src/ATen/cpu/vec256/vec256_complex_float.h
+++ b/aten/src/ATen/cpu/vec256/vec256_complex_float.h
@@ -174,6 +174,16 @@ public:
   Vec256<std::complex<float>> polar() const {
     return polar_();
   }
+  __m256 cart_() const {
+    auto sin_cos = Sleef_sincosf8_u10(values);                        //[ sin(a), cos(a)] [sin(b), cos(b)]
+    auto cos_sin = _mm256_blend_ps(_mm256_permute_ps(sin_cos.y, 0xB1),
+                                   sin_cos.x, 0xAA);                  // cos(b)           sin(b)
+    auto rr = _mm256_permute_ps(values, 0xA0);                         // r                r
+    return _mm256_mul_ps(cos_sin, rr);
+  }
+  Vec256<std::complex<float>> cart() const {
+    return cart_();
+  }
   __m256 real_() const {
     const __m256 real_mask = _mm256_castsi256_ps(_mm256_setr_epi32(0xFFFFFFFF, 0x00000000, 0xFFFFFFFF, 0x00000000,
                                                                    0xFFFFFFFF, 0x00000000, 0xFFFFFFFF, 0x00000000));

--- a/aten/src/ATen/cpu/vec256/vec256_complex_float.h
+++ b/aten/src/ATen/cpu/vec256/vec256_complex_float.h
@@ -168,6 +168,18 @@ public:
     auto angle = _mm256_permute_ps(angle_(), 0xB1); // angle    90-angle
     return _mm256_and_ps(angle, real_mask);         // angle    0
   }
+  __m256 polar_() const {
+    const __m256 real_mask = _mm256_castsi256_ps(_mm256_setr_epi32(0xFFFFFFFF, 0x00000000, 0xFFFFFFFF, 0x00000000,
+                                                                   0xFFFFFFFF, 0x00000000, 0xFFFFFFFF, 0x00000000));
+    const __m256 imag_mask = _mm256_castsi256_ps(_mm256_setr_epi32(0x00000000, 0xFFFFFFFF, 0x00000000, 0xFFFFFFFF,
+                                                                   0x00000000, 0xFFFFFFFF, 0x00000000, 0xFFFFFFFF));
+    auto angle = _mm256_and_ps(angle_(), imag_mask); // 0     angle
+    auto abs = _mm256_and_ps(abs_(), real_mask);     // abs   0
+    return _mm256_add_ps(abs, angle);
+  }
+  Vec256<std::complex<float>> polar() const {
+    return polar_();
+  }
   __m256 real_() const {
     const __m256 real_mask = _mm256_castsi256_ps(_mm256_setr_epi32(0xFFFFFFFF, 0x00000000, 0xFFFFFFFF, 0x00000000,
                                                                    0xFFFFFFFF, 0x00000000, 0xFFFFFFFF, 0x00000000));

--- a/aten/src/ATen/cpu/vec256/vec256_complex_float.h
+++ b/aten/src/ATen/cpu/vec256/vec256_complex_float.h
@@ -169,13 +169,7 @@ public:
     return _mm256_and_ps(angle, real_mask);         // angle    0
   }
   __m256 polar_() const {
-    const __m256 real_mask = _mm256_castsi256_ps(_mm256_setr_epi32(0xFFFFFFFF, 0x00000000, 0xFFFFFFFF, 0x00000000,
-                                                                   0xFFFFFFFF, 0x00000000, 0xFFFFFFFF, 0x00000000));
-    const __m256 imag_mask = _mm256_castsi256_ps(_mm256_setr_epi32(0x00000000, 0xFFFFFFFF, 0x00000000, 0xFFFFFFFF,
-                                                                   0x00000000, 0xFFFFFFFF, 0x00000000, 0xFFFFFFFF));
-    auto angle = _mm256_and_ps(angle_(), imag_mask); // 0     angle
-    auto abs = _mm256_and_ps(abs_(), real_mask);     // abs   0
-    return _mm256_add_ps(abs, angle);
+    return _mm256_blend_ps(abs_(), angle_(), 0xAA);
   }
   Vec256<std::complex<float>> polar() const {
     return polar_();

--- a/aten/src/ATen/native/UnaryOps.cpp
+++ b/aten/src/ATen/native/UnaryOps.cpp
@@ -236,9 +236,14 @@ Tensor& sinh_(Tensor& self) { return unary_op_impl_(self, at::sinh_out); }
 Tensor& cosh_out(Tensor& result, const Tensor& self) { return unary_op_impl_out(result, self, cosh_stub); }
 Tensor cosh(const Tensor& self) { return unary_op_impl(self, at::cosh_out); }
 Tensor& cosh_(Tensor& self) { return unary_op_impl_(self, at::cosh_out); }
+
 Tensor& polar_out(Tensor& result, const Tensor& self) { return unary_op_impl_out(result, self, polar_stub); }
 Tensor polar(const Tensor& self) { return unary_op_impl(self, at::polar_out); }
 Tensor& polar_(Tensor& self) { return unary_op_impl_(self, at::polar_out); }
+
+Tensor& cart_out(Tensor& result, const Tensor& self) { return unary_op_impl_out(result, self, cart_stub); }
+Tensor cart(const Tensor& self) { return unary_op_impl(self, at::cart_out); }
+Tensor& cart_(Tensor& self) { return unary_op_impl_(self, at::cart_out); }
 
 Tensor& sqrt_out(Tensor& result, const Tensor& self) { return unary_op_impl_out(result, self, sqrt_stub); }
 Tensor sqrt(const Tensor& self) { return unary_op_impl(self, at::sqrt_out); }
@@ -465,6 +470,7 @@ DEFINE_DISPATCH(acos_stub);
 DEFINE_DISPATCH(asin_stub);
 DEFINE_DISPATCH(atan_stub);
 DEFINE_DISPATCH(bitwise_not_stub);
+DEFINE_DISPATCH(cart_stub);
 DEFINE_DISPATCH(ceil_stub);
 DEFINE_DISPATCH(clamp_stub);
 DEFINE_DISPATCH(clamp_max_stub);

--- a/aten/src/ATen/native/UnaryOps.cpp
+++ b/aten/src/ATen/native/UnaryOps.cpp
@@ -236,6 +236,9 @@ Tensor& sinh_(Tensor& self) { return unary_op_impl_(self, at::sinh_out); }
 Tensor& cosh_out(Tensor& result, const Tensor& self) { return unary_op_impl_out(result, self, cosh_stub); }
 Tensor cosh(const Tensor& self) { return unary_op_impl(self, at::cosh_out); }
 Tensor& cosh_(Tensor& self) { return unary_op_impl_(self, at::cosh_out); }
+Tensor& polar_out(Tensor& result, const Tensor& self) { return unary_op_impl_out(result, self, polar_stub); }
+Tensor polar(const Tensor& self) { return unary_op_impl(self, at::polar_out); }
+Tensor& polar_(Tensor& self) { return unary_op_impl_(self, at::polar_out); }
 
 Tensor& sqrt_out(Tensor& result, const Tensor& self) { return unary_op_impl_out(result, self, sqrt_stub); }
 Tensor sqrt(const Tensor& self) { return unary_op_impl(self, at::sqrt_out); }
@@ -482,6 +485,7 @@ DEFINE_DISPATCH(log1p_stub);
 DEFINE_DISPATCH(log2_stub);
 DEFINE_DISPATCH(logical_not_stub);
 DEFINE_DISPATCH(neg_stub);
+DEFINE_DISPATCH(polar_stub);
 DEFINE_DISPATCH(polygamma_stub);
 DEFINE_DISPATCH(reciprocal_stub);
 DEFINE_DISPATCH(round_stub);

--- a/aten/src/ATen/native/UnaryOps.h
+++ b/aten/src/ATen/native/UnaryOps.h
@@ -22,6 +22,7 @@ DECLARE_DISPATCH(unary_fn, asin_stub);
 DECLARE_DISPATCH(unary_fn, atan_stub);
 DECLARE_DISPATCH(unary_fn, bitwise_not_stub);
 DECLARE_DISPATCH(unary_fn, logical_not_stub);
+DECLARE_DISPATCH(unary_fn, cart_stub);
 DECLARE_DISPATCH(unary_fn, ceil_stub);
 DECLARE_DISPATCH(unary_fn_with_scalar, clamp_max_stub);
 DECLARE_DISPATCH(unary_fn_with_scalar, clamp_min_stub);

--- a/aten/src/ATen/native/UnaryOps.h
+++ b/aten/src/ATen/native/UnaryOps.h
@@ -40,6 +40,7 @@ DECLARE_DISPATCH(unary_fn, log10_stub);
 DECLARE_DISPATCH(unary_fn, log1p_stub);
 DECLARE_DISPATCH(unary_fn, log2_stub);
 DECLARE_DISPATCH(unary_fn, neg_stub);
+DECLARE_DISPATCH(unary_fn, polar_stub);
 DECLARE_DISPATCH(unary_fn, reciprocal_stub);
 DECLARE_DISPATCH(unary_fn, round_stub);
 DECLARE_DISPATCH(unary_fn, rsqrt_stub);

--- a/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
@@ -72,6 +72,15 @@ static void polar_kernel(TensorIterator& iter) {
   });
 }
 
+static void cart_kernel(TensorIterator& iter) {
+  AT_DISPATCH_COMPLEX_TYPES(iter.dtype(), "cart_cpu", [&]() {
+    cpu_kernel_vec(
+        iter,
+        [=](scalar_t a) -> scalar_t { return cart_impl(a); },
+        [=](Vec256<scalar_t> a) { return a.cart(); });
+  });
+}
+
 static void angle_kernel(TensorIterator& iter) {
   AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(kBFloat16, kHalf, iter.dtype(), "angle_cpu", [&]() {
     cpu_kernel_vec(
@@ -460,6 +469,7 @@ REGISTER_DISPATCH(random_full_64_bits_range_stub, &random_full_64_bits_range_ker
 REGISTER_DISPATCH(random_stub, &random_kernel);
 REGISTER_DISPATCH(abs_stub, &abs_kernel);
 REGISTER_DISPATCH(polar_stub, &polar_kernel);
+REGISTER_DISPATCH(cart_stub, &cart_kernel);
 REGISTER_DISPATCH(angle_stub, &angle_kernel);
 REGISTER_DISPATCH(real_stub, &real_kernel);
 REGISTER_DISPATCH(imag_stub, &imag_kernel);

--- a/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
@@ -63,6 +63,15 @@ static void abs_kernel(TensorIterator& iter) {
   });
 }
 
+static void polar_kernel(TensorIterator& iter) {
+  AT_DISPATCH_COMPLEX_TYPES(iter.dtype(), "polar_cpu", [&]() {
+    cpu_kernel_vec(
+        iter,
+        [=](scalar_t a) -> scalar_t { return polar_impl(a); },
+        [=](Vec256<scalar_t> a) { return a.polar(); });
+  });
+}
+
 static void angle_kernel(TensorIterator& iter) {
   AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(kBFloat16, kHalf, iter.dtype(), "angle_cpu", [&]() {
     cpu_kernel_vec(
@@ -450,6 +459,7 @@ REGISTER_DISPATCH(random_from_to_stub, &random_from_to_kernel);
 REGISTER_DISPATCH(random_full_64_bits_range_stub, &random_full_64_bits_range_kernel);
 REGISTER_DISPATCH(random_stub, &random_kernel);
 REGISTER_DISPATCH(abs_stub, &abs_kernel);
+REGISTER_DISPATCH(polar_stub, &polar_kernel);
 REGISTER_DISPATCH(angle_stub, &angle_kernel);
 REGISTER_DISPATCH(real_stub, &real_kernel);
 REGISTER_DISPATCH(imag_stub, &imag_kernel);

--- a/aten/src/ATen/native/cpu/zmath.h
+++ b/aten/src/ATen/native/cpu/zmath.h
@@ -238,5 +238,15 @@ inline TYPE min_impl (TYPE a, TYPE b) {
   }
 }
 
+template <typename TYPE, std::enable_if_t<!c10::is_complex_t<TYPE>::value, int> = 0>
+inline std::complex<TYPE> polar_impl (TYPE a) {
+  return std::complex<TYPE> (std::abs(a), std::arg(a));
+}
+
+template <typename TYPE, std::enable_if_t<c10::is_complex_t<TYPE>::value, int> = 0>
+inline TYPE polar_impl (TYPE a) {
+  return TYPE(std::abs(a), std::arg(a));
+}
+
 } // end namespace
 }} //end at::native

--- a/aten/src/ATen/native/cpu/zmath.h
+++ b/aten/src/ATen/native/cpu/zmath.h
@@ -248,5 +248,10 @@ inline TYPE polar_impl (TYPE a) {
   return TYPE(std::abs(a), std::arg(a));
 }
 
+template <typename TYPE, std::enable_if_t<c10::is_complex_t<TYPE>::value, int> = 0>
+inline TYPE cart_impl (TYPE a) {
+  return std::polar(a.real(), a.imag());
+}
+
 } // end namespace
 }} //end at::native

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2644,6 +2644,18 @@
 - func: polar.out(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
   supports_named_tensor: True
 
+- func: cart(Tensor self) -> Tensor
+  use_c10_dispatcher: full
+  supports_named_tensor: True
+  variants: function, method
+
+- func: cart_(Tensor(a!) self) -> Tensor(a!)
+  supports_named_tensor: True
+  variants: function, method
+
+- func: cart.out(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
+  supports_named_tensor: True
+
 # Returns a copy of this `Variable` that is detached from its autograd graph.
 # This method is OK to call if the `Variable` is a view.
 #

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2632,6 +2632,18 @@
 - func: sinh.out(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
   supports_named_tensor: True
 
+- func: polar(Tensor self) -> Tensor
+  use_c10_dispatcher: full
+  supports_named_tensor: True
+  variants: function, method
+
+- func: polar_(Tensor(a!) self) -> Tensor(a!)
+  supports_named_tensor: True
+  variants: function, method
+
+- func: polar.out(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
+  supports_named_tensor: True
+
 # Returns a copy of this `Variable` that is detached from its autograd graph.
 # This method is OK to call if the `Variable` is a view.
 #

--- a/docs/source/tensors.rst
+++ b/docs/source/tensors.rst
@@ -208,6 +208,8 @@ view of a storage and defines numeric operations on it.
    .. automethod:: bmm
    .. automethod:: bool
    .. automethod:: byte
+   .. automethod:: cart
+   .. automethod:: cart_
    .. automethod:: cauchy_
    .. automethod:: ceil
    .. automethod:: ceil_

--- a/docs/source/tensors.rst
+++ b/docs/source/tensors.rst
@@ -396,6 +396,8 @@ view of a storage and defines numeric operations on it.
    .. automethod:: permute
    .. automethod:: pin_memory
    .. automethod:: pinverse
+   .. automethod:: polar
+   .. automethod:: polar_
    .. automethod:: polygamma
    .. automethod:: polygamma_
    .. automethod:: pow

--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -237,6 +237,7 @@ Pointwise Ops
 .. autofunction:: mul
 .. autofunction:: mvlgamma
 .. autofunction:: neg
+.. autofunction:: polar
 .. autofunction:: polygamma
 .. autofunction:: pow
 .. autofunction:: real

--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -207,6 +207,7 @@ Pointwise Ops
 .. autofunction:: bitwise_and
 .. autofunction:: bitwise_or
 .. autofunction:: bitwise_xor
+.. autofunction:: cart
 .. autofunction:: ceil
 .. autofunction:: clamp
 .. autofunction:: conj

--- a/test/test_complex.py
+++ b/test/test_complex.py
@@ -49,5 +49,21 @@ class TestComplexTensor(TestCase):
         polar_fn(torch.complex64)
         polar_fn(torch.complex128)
 
+    def test_cart(self):
+        def cart_fn(dtype):
+            torch.manual_seed(123456)
+            a = torch.rand(5, 5, dtype=dtype)
+            res1 = a.cart()
+            res2 = torch.tensor([], dtype=dtype)
+            torch.cart(a, out=res2)
+            self.assertEqual(res1, res2)
+
+            b = a.polar()
+            cart_tensor = b.cart()
+            self.assertEqual(torch.isclose(cart_tensor, a).all(), True)
+
+        cart_fn(torch.complex64)
+        cart_fn(torch.complex128)
+
 if __name__ == '__main__':
     run_tests()

--- a/test/test_complex.py
+++ b/test/test_complex.py
@@ -35,32 +35,34 @@ class TestComplexTensor(TestCase):
 
     def test_polar(self):
         def polar_fn(dtype):
-            torch.manual_seed(123456)
-            a = torch.rand(5, 5, dtype=dtype)
+            a = torch.tensor([1. + 1j, 2. + 0j, 3. + 0j,
+                              -4. + 0j, -5. + 0j], dtype=dtype)
             res1 = a.polar()
             res2 = torch.tensor([], dtype=dtype)
             torch.polar(a, out=res2)
             self.assertEqual(res1, res2)
 
             polar_tensor = a.polar()
-            self.assertEqual(polar_tensor.copy_real(), a.abs())
-            self.assertEqual(polar_tensor.copy_imag(), a.angle())
+            expected = torch.tensor([math.sqrt(2) + 0.25j * math.pi, 2. + 0j, 3. + 0j,
+                                     4. + 1j * math.pi, 5. + 1j * math.pi], dtype=dtype)
+            self.assertEqual(polar_tensor, expected)
 
         polar_fn(torch.complex64)
         polar_fn(torch.complex128)
 
     def test_cart(self):
         def cart_fn(dtype):
-            torch.manual_seed(123456)
-            a = torch.rand(5, 5, dtype=dtype)
+            a = torch.tensor([math.sqrt(2) + 0.25j * math.pi, 2. + 0j,
+                              3. + 0j, 4. + 1j * math.pi, 5. + 1j * math.pi], dtype=dtype)
             res1 = a.cart()
             res2 = torch.tensor([], dtype=dtype)
             torch.cart(a, out=res2)
             self.assertEqual(res1, res2)
 
-            b = a.polar()
-            cart_tensor = b.cart()
-            self.assertEqual(torch.isclose(cart_tensor, a).all(), True)
+            cart_tensor = a.cart()
+            expected = torch.tensor([1. + 1j, 2. + 0j, 3. + 0j,
+                                     -4. + 0j, -5. + 0j], dtype=dtype)
+            self.assertEqual(cart_tensor, expected)
 
         cart_fn(torch.complex64)
         cart_fn(torch.complex128)

--- a/test/test_complex.py
+++ b/test/test_complex.py
@@ -33,5 +33,21 @@ class TestComplexTensor(TestCase):
         self.assertEqual(complex_tensor.copy_real(), real)
         self.assertEqual(complex_tensor.copy_imag(), imag)
 
+    def test_polar(self):
+        def polar_fn(dtype):
+            torch.manual_seed(123456)
+            a = torch.rand(5, 5, dtype=dtype)
+            res1 = a.polar()
+            res2 = torch.tensor([], dtype=dtype)
+            torch.polar(a, out=res2)
+            self.assertEqual(res1, res2)
+
+            polar_tensor = a.polar()
+            self.assertEqual(polar_tensor.copy_real(), a.abs())
+            self.assertEqual(polar_tensor.copy_imag(), a.angle())
+
+        polar_fn(torch.complex64)
+        polar_fn(torch.complex128)
+
 if __name__ == '__main__':
     run_tests()

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -16402,6 +16402,22 @@ scipy_lobpcg  | {:10.2e}  | {:10.2e}  | {:6} | N/A
         test_output_dtype(torch.int64, True)
 
 
+    @onlyCPU
+    @dtypes(torch.complex64, torch.complex128)
+    def test_polar(self, device, dtype):
+        torch.manual_seed(123456)
+        a = torch.rand(SIZE, SIZE, dtype=dtype)
+        res1 = a.polar()
+        res2 = torch.tensor([], dtype=dtype)
+        torch.polar(a, out=res2)
+        self.assertEqual(res1, res2)
+
+        torch.manual_seed(123456)
+        a = torch.rand(SIZE, SIZE, dtype=dtype)
+        polar_tensor = a.polar()
+        self.assertEqual(polar_tensor, a.abs() + 1j * a.angle())
+
+
 # NOTE [Linspace+Logspace precision override]
 # Our Linspace and logspace torch.half CUDA kernels are not very precise.
 # Since linspace/logspace are deterministic, we can compute an expected

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -16402,22 +16402,6 @@ scipy_lobpcg  | {:10.2e}  | {:10.2e}  | {:6} | N/A
         test_output_dtype(torch.int64, True)
 
 
-    @onlyCPU
-    @dtypes(torch.complex64, torch.complex128)
-    def test_polar(self, device, dtype):
-        torch.manual_seed(123456)
-        a = torch.rand(SIZE, SIZE, dtype=dtype)
-        res1 = a.polar()
-        res2 = torch.tensor([], dtype=dtype)
-        torch.polar(a, out=res2)
-        self.assertEqual(res1, res2)
-
-        torch.manual_seed(123456)
-        a = torch.rand(SIZE, SIZE, dtype=dtype)
-        polar_tensor = a.polar()
-        self.assertEqual(polar_tensor, a.abs() + 1j * a.angle())
-
-
 # NOTE [Linspace+Logspace precision override]
 # Our Linspace and logspace torch.half CUDA kernels are not very precise.
 # Since linspace/logspace are deterministic, we can compute an expected

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -707,6 +707,9 @@
 - name: poisson(Tensor self, Generator? generator=None) -> Tensor
   self: zeros_like(self)
 
+- name: polar(Tensor self) -> Tensor
+  self: grad.to(self.scalar_type()) * self.sign() + grad.to(self.scalar_type()) * (self*Scalar(std::complex<double>{0.0, 1.0})).conj() / self.abs().pow(2)
+
 - name: pow.Tensor_Scalar(Tensor self, Scalar exponent) -> Tensor
   self: pow_backward(grad, self, exponent)
 

--- a/torch/_overrides.py
+++ b/torch/_overrides.py
@@ -539,6 +539,7 @@ def get_testing_overrides():
         torch.pixel_shuffle: lambda input, upscale_factor: -1,
         torch.poisson: lambda input, generator=None: -1,
         torch.poisson_nll_loss: lambda input, target, log_input, full, eps, reduction: -1,
+        torch.polar: lambda input: -1,
         torch.polygamma: lambda input, n, out=None: -1,
         torch.prelu: lambda input, weight: -1,
         torch.ones_like: lambda input, dtype=None, layout=None, device=None, requires_grad=False: -1,

--- a/torch/_overrides.py
+++ b/torch/_overrides.py
@@ -207,6 +207,7 @@ def get_testing_overrides():
         torch.bmm: lambda input, mat2, out=None: -1,
         torch.broadcast_tensors: lambda *tensors: -1,
         torch.bucketize: lambda input, boundaries, out_int32=False, right=False, out=None: -1,
+        torch.cart: lambda input: -1,
         torch.cartesian_prod: lambda *tensors: -1,
         torch.cat: lambda tensors, dim=0, out=None: -1,
         torch.cdist: lambda x1, c2, p=2, compute_mode=None: -1,

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -688,6 +688,20 @@ bmm(batch2) -> Tensor
 See :func:`torch.bmm`
 """)
 
+add_docstr_all('cart',
+               r"""
+cart() -> Tensor
+
+See :func:`torch.cart`
+""")
+
+add_docstr_all('cart_',
+               r"""
+cart_(n) -> Tensor
+
+In-place version of :meth:`~Tensor.cart`
+""")
+
 add_docstr_all('cauchy_',
                r"""
 cauchy_(median=0, sigma=1, *, generator=None) -> Tensor

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -2056,6 +2056,20 @@ Example:
     torch.Size([5, 2, 3])
 """)
 
+add_docstr_all('polar',
+               r"""
+polar() -> Tensor
+
+See :func:`torch.polar`
+""")
+
+add_docstr_all('polar_',
+               r"""
+polar_(n) -> Tensor
+
+In-place version of :meth:`~Tensor.polar`
+""")
+
 add_docstr_all('polygamma',
                r"""
 polygamma(n) -> Tensor

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -1002,6 +1002,27 @@ Example::
              -0.5790,  0.1497]])
 """.format(**common_args))
 
+add_docstr(torch.cart,
+           r"""
+cart(input, out=None) -> Tensor
+
+Takes complex tensor in polar form and computes cartesian coordinates.
+
+Args:
+    {input}
+    {out}
+
+Example::
+
+    >>> a = torch.rand(5, dtype=torch.complex64)
+    >>> a
+    tensor([(0.5987+0.6589j), (0.3539+0.4639j), (0.5569+0.9351j), (0.4098+0.9458j),
+            (0.6055+0.1625j)], dtype=torch.complex64)
+    >>> a.cart()
+    tensor([(0.4734+0.3665j), (0.3165+0.1584j), (0.3306+0.4481j), (0.2398+0.3323j),
+            (0.5975+0.0979j)], dtype=torch.complex64)
+""".format(**common_args))
+
 add_docstr(torch.ceil,
            r"""
 ceil(input, out=None) -> Tensor

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -4370,7 +4370,7 @@ add_docstr(torch.polar,
 polar(input, out=None) -> Tensor
 
 Returns a new tensor in the polar form of the elements of
-:attr:`input`. Magnitude is stored in real value and angle in imageniry.
+:attr:`input`. Magnitude is stored in real value and angle in imaginary.
 
 Args:
     {input}

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -4365,6 +4365,32 @@ Example::
             [2., 1., 4., 2.]])
 """.format(**common_args))
 
+add_docstr(torch.polar,
+           r"""
+polar(input, out=None) -> Tensor
+
+Returns a new tensor in the polar form of the elements of
+:attr:`input`. Magnitude is stored in real value and angle in imageniry.
+
+Args:
+    {input}
+    {out}
+
+Example::
+
+    >>> a = torch.randn(4, dtype=torch.complex64)
+    >>> a
+    tensor([                       (-1.1573 - 1.0926j),
+                                    (0.0899 + 0.3232j),
+                                    (0.9718 + 0.1947j),
+                                    (0.2349 + 0.1463j)], dtype=torch.complex64)
+    >>> a.polar()
+    tensor([                       (1.5916 - 2.3849j),
+                                   (0.3354 + 1.2995j),
+                                   (0.9911 + 0.1977j),
+                                   (0.2767 + 0.5571j)], dtype=torch.complex64)
+""".format(**common_args))
+
 add_docstr(torch.polygamma,
            r"""
 polygamma(n, input, out=None) -> Tensor


### PR DESCRIPTION
Hi @dylanbespalko its still work in progress but I would like to ask for your opinion. I was trying to follow your instruction and started with method `polar`. So from input it is producing its polar form. Currently magnitude is stored as real value and angle as imaginary. First I would like to ask you if this is like you imagined it should be? Some problems that I run into and not sure how to tackle them. Polar form makes sense not only for complex type tensor but also for other like float or double but it is hard implement it because I understand it like that if tensor is computed by kernel function its dtype will match dtype of tensor that was used as input to kernel. I was thinking of casting such tensors to complex in file `aten/src/ATen/native/UnaryOps.cpp` before passing them to polar implementations. Also I had to add function polar in `vec256_base.h` which is just a placeholder to make it compile, not sure how to do it better here. 

Related to #35312