### PR TITLE
[WIP] Fix topk sorting for torch.half.

### DIFF
--- a/aten/src/ATen/native/cuda/SortingRadixSelect.cuh
+++ b/aten/src/ATen/native/cuda/SortingRadixSelect.cuh
@@ -124,7 +124,7 @@ struct TopKTypeConfig<at::Half> {
 
   static inline __device__ RadixType convert(at::Half v) {
 #if defined(__CUDA_ARCH__) || defined(__HIP_PLATFORM_HCC__)
-    RadixType x = __half_as_ushort(v);
+    RadixType x = __half_as_short(v);
     RadixType mask = -((x >> 15)) | 0x8000;
     return (v == v) ? (x ^ mask) : 0xffff;
 #else
@@ -136,7 +136,7 @@ struct TopKTypeConfig<at::Half> {
   static inline __device__ at::Half deconvert(RadixType v) {
 #if defined(__CUDA_ARCH__) || defined(__HIP_PLATFORM_HCC__)
     RadixType mask = ((v >> 15) - 1) | 0x8000;
-    return __ushort_as_half(v ^ mask);
+    return __short_as_half(v ^ mask);
 #else
     assert(false);
     return static_cast<at::Half>(0);


### PR DESCRIPTION
I don't know if this is the correct fix, but I do notice for (float32, float64):
deconvert(convert(-inf)) -> -inf

But before this patch for float16:
deconvert(convert(-inf)) -> nan

This patch fixes that behavior.

