### PR TITLE
Remove `pytorch_linux_xenial_py3_5` build and test jobs

### DIFF
--- a/.circleci/cimodel/data/pytorch_build_data.py
+++ b/.circleci/cimodel/data/pytorch_build_data.py
@@ -4,7 +4,6 @@ from cimodel.lib.conf_tree import ConfigNode, X, XImportant
 CONFIG_TREE_DATA = [
     ("xenial", [
         (None, [
-            X("3.5"),
             X("nightly"),
         ]),
         ("gcc", [

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1920,30 +1920,6 @@ workflows:
             - setup
             - pytorch_windows_vs2019_py36_cuda10.1_build
       - pytorch_linux_build:
-          name: pytorch_linux_xenial_py3_5_build
-          requires:
-            - setup
-          filters:
-            branches:
-              only:
-                - master
-                - /ci-all\/.*/
-          build_environment: "pytorch-linux-xenial-py3.5-build"
-          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3.5:f990c76a-a798-42bb-852f-5be5006f8026"
-      - pytorch_linux_test:
-          name: pytorch_linux_xenial_py3_5_test
-          requires:
-            - setup
-            - pytorch_linux_xenial_py3_5_build
-          filters:
-            branches:
-              only:
-                - master
-                - /ci-all\/.*/
-          build_environment: "pytorch-linux-xenial-py3.5-test"
-          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3.5:f990c76a-a798-42bb-852f-5be5006f8026"
-          resource_class: large
-      - pytorch_linux_build:
           name: pytorch_linux_xenial_pynightly_build
           requires:
             - setup
@@ -6247,9 +6223,6 @@ workflows:
       - docker_build_job:
           name: "pytorch-linux-xenial-py3-clang5-asan"
           image_name: "pytorch-linux-xenial-py3-clang5-asan"
-      - docker_build_job:
-          name: "pytorch-linux-xenial-py3.5"
-          image_name: "pytorch-linux-xenial-py3.5"
       - docker_build_job:
           name: "pytorch-linux-xenial-py3.8"
           image_name: "pytorch-linux-xenial-py3.8"

--- a/.circleci/docker/build.sh
+++ b/.circleci/docker/build.sh
@@ -53,11 +53,6 @@ case "$image" in
     DB=yes
     VISION=yes
     ;;
-  pytorch-linux-xenial-py3.5)
-    TRAVIS_PYTHON_VERSION=3.5
-    GCC_VERSION=7
-    # Do not install PROTOBUF, DB, and VISION as a test
-    ;;
   pytorch-linux-xenial-py3.8)
     # TODO: This is a hack, get rid of this as soon as you get rid of the travis downloads
     TRAVIS_DL_URL_PREFIX="https://s3.amazonaws.com/travis-python-archives/binaries/ubuntu/16.04/x86_64"

--- a/.circleci/verbatim-sources/workflows-docker-builder.yml
+++ b/.circleci/verbatim-sources/workflows-docker-builder.yml
@@ -33,9 +33,6 @@
           name: "pytorch-linux-xenial-py3-clang5-asan"
           image_name: "pytorch-linux-xenial-py3-clang5-asan"
       - docker_build_job:
-          name: "pytorch-linux-xenial-py3.5"
-          image_name: "pytorch-linux-xenial-py3.5"
-      - docker_build_job:
           name: "pytorch-linux-xenial-py3.8"
           image_name: "pytorch-linux-xenial-py3.8"
       - docker_build_job:


### PR DESCRIPTION
Because Python-3.5 is no longer supported on master