### PR TITLE
Reduce binary size of assertion macros

### DIFF
--- a/c10/macros/Macros.h
+++ b/c10/macros/Macros.h
@@ -42,6 +42,9 @@
 
 #define C10_MACRO_EXPAND(args) args
 
+#define C10_STRINGIZE_IMPL(x) #x
+#define C10_STRINGIZE(x) C10_STRINGIZE_IMPL(x)
+
 /**
  * C10_ANONYMOUS_VARIABLE(str) introduces an identifier starting with
  * str and ending with a number that varies with the line.

--- a/c10/util/Exception.h
+++ b/c10/util/Exception.h
@@ -212,17 +212,17 @@ inline std::string if_empty_then(std::string x, std::string y) {
   if (C10_UNLIKELY_OR_CONST(!(cond))) {       \
     C10_THROW_ERROR(Error,                    \
         #cond " INTERNAL ASSERT FAILED at"    \
-        __FILE__                              \
+        C10_STRINGIZE(__FILE__)               \
     );                                        \
   }
 #else
 #define TORCH_INTERNAL_ASSERT(cond, ...)      \
   if (C10_UNLIKELY_OR_CONST(!(cond))) {       \
     C10_THROW_ERROR(Error, ::c10::str(        \
-        #cond " INTERNAL ASSERT FAILED at ",  \
-        __FILE__,                             \
-        ":",                                  \
-        __LINE__,                             \
+        #cond " INTERNAL ASSERT FAILED at "   \
+        C10_STRINGIZE(__FILE__)               \
+        ":"                                   \
+        C10_STRINGIZE(__LINE__)               \
         ", please report a bug to PyTorch. ", \
         ::c10::str(__VA_ARGS__)               \
     ));                                       \
@@ -254,7 +254,7 @@ inline std::string if_empty_then(std::string x, std::string y) {
   if (C10_UNLIKELY_OR_CONST(!(cond))) {       \
     C10_THROW_ERROR(error_t,                  \
         #cond " CHECK FAILED at "             \
-        __FILE__                              \
+        C10_STRINGIZE(__FILE__)               \
     );                                        \
   }
 #else
@@ -295,7 +295,7 @@ inline std::string if_empty_then(std::string x, std::string y) {
   if (C10_UNLIKELY_OR_CONST(!(cond))) {       \
     C10_THROW_ERROR(Error,                    \
         #cond " INDEX CHECK FAILED at "       \
-        __FILE__                              \
+        C10_STRINGIZE(__FILE__)               \
     );                                        \
   }
 #else
@@ -318,7 +318,7 @@ inline std::string if_empty_then(std::string x, std::string y) {
   if (C10_UNLIKELY_OR_CONST(!(cond))) {       \
     C10_THROW_ERROR(Error,                    \
         #cond " VALUE CHECK FAILED at "       \
-        __FILE__                              \
+        C10_STRINGIZE(__FILE__)               \
     );                                        \
   }
 #else

--- a/c10/util/Logging.h
+++ b/c10/util/Logging.h
@@ -185,12 +185,12 @@ class C10_API EnforceFailMessage {
   inline bool bad() const {
     return msg_ != nullptr;
   }
-  std::string get_message_and_free(std::string&& extra) const {
+  std::string get_message_and_free(const std::string& extra) const {
     std::string r;
     if (extra.empty()) {
       r = std::move(*msg_);
     } else {
-      r = ::c10::str(std::move(*msg_), ". ", std::move(extra));
+      r = ::c10::str(std::move(*msg_), ". ", extra);
     }
     delete msg_;
     return r;

--- a/c10/util/StringUtil.h
+++ b/c10/util/StringUtil.h
@@ -43,28 +43,48 @@ inline std::ostream& _str(std::ostream& ss, const T& t, const Args&... args) {
   return _str(_str(ss, t), args...);
 }
 
-template <typename... Args>
-inline std::string _str_wrapper(const Args&... args) {
+template<typename... Args>
+struct _str_wrapper final {
+  static std::string call(const Args&... args) {
     std::ostringstream ss;
     _str(ss, args...);
     return ss.str();
-}
+  }
+};
+
+// Specializations for already-a-string types.
+template<>
+struct _str_wrapper<std::string> final {
+  // return by reference to avoid the binary size of a string copy
+  static const std::string& call(const std::string& str) {
+    return str;
+  }
+};
+
+template<>
+struct _str_wrapper<const char*> final {
+  static std::string call(const char* str) {
+    return str;
+  }
+};
+
+// For c10::str() with an empty argument list (which is common in our assert macros),
+// we don't want to pay the binary size for constructing and destructing a stringstream
+// or even constructing a string. Let's just return a reference to a global empty string.
+const std::string empty_string_literal;
+template<>
+struct _str_wrapper<> final {
+  static const std::string& call() {
+    return empty_string_literal;
+  }
+};
 
 } // namespace detail
 
 // Convert a list of string-like arguments into a single string.
 template <typename... Args>
-inline std::string str(const Args&... args) {
-  return detail::_str_wrapper<typename detail::CanonicalizeStrTypes<Args>::type...>(args...);
-}
-
-// Specializations for already-a-string types.
-template <>
-inline std::string str(const std::string& str) {
-  return str;
-}
-inline std::string str(const char* c_str) {
-  return c_str;
+inline decltype(auto) str(const Args&... args) {
+  return detail::_str_wrapper<typename detail::CanonicalizeStrTypes<Args>::type...>::call(args...);
 }
 
 template <class Container>


### PR DESCRIPTION
Optimize binary size of assert macros, through two ideas:
- Concatenate string literals with `__FILE__` and `__LINE__` at compile time into one literal instead of keeping them in separate literals and combining them with `c10::str`
- Optimize binary size of `c10::str` for some scenarios, especially for the scenario where it is called with an empty parameter list, this is actually a common call scenario in assert macros.

In server oss builds, this PR reduces binary size from 118.05 MB to 117.05 MB