### PR TITLE
[autograd] fix engine flakiness

### DIFF
--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -796,13 +796,7 @@ auto Engine::execute(const edge_list& roots,
     graph_task->init_to_execute(*graph_root, outputs);
   }
 
-  variable_list results = execute_with_graph_task(graph_task, graph_root)->wait();
-  // If it's owning thread backward call (not reentrant), local_ready_queue must
-  // be empty when we finish Engine::execute
-  if (not_reentrant_backward_call) {
-    TORCH_INTERNAL_ASSERT(local_ready_queue->empty());
-  }
-  return results;
+  return execute_with_graph_task(graph_task, graph_root)->wait();
 }
 
 void Engine::initialize_device_threads_pool() {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#35599 [autograd] fix engine flakiness**

We don't check if the ready queue was empty before
https://github.com/pytorch/pytorch/pull/33157 because the CPU worker's
queue might not be empty, but after #33157, we try to check if the owner
thread's ready_queue empty after inline exeuction.

This might not always hold true, imagine the following case:

The CPU thread that calls backward() and the GPU device thread, the Graph is like:

GraphRoot(CPU) -> ComputeNode(GPU)

in both thread_main, they are decrementing `--local_graph_task->outstanding_tasks_` to zero together, and then both thread will enter `if (graph_task_completed(local_graph_task))`,  CPU thread will break out and finish and check if local_ready_queue is empty, the GPU thread will send a dummy task to CPU thread ready queue as it think the graph_task finished on its own thread (it actually finished on both threads together). So there will be cases that there's a dummy task remains in the queue.

This happens very rare and non-deterministic, but it might get triggered when we run many jobs in the CI. Remove the check to fix the flakiness

Differential Revision: [D20739778](https://our.internmc.facebook.com/intern/diff/D20739778)