### PR TITLE
[caffe2] remove quant options of SparseAdagrad from OSS

### DIFF
--- a/caffe2/sgd/adagrad_op.cc
+++ b/caffe2/sgd/adagrad_op.cc
@@ -66,9 +66,9 @@ static OpSchema::Cost CostInferenceForSparseAdagrad(
   return c;
 }
 
-REGISTER_CPU_OPERATOR(SparseAdagrad, SparseAdagradOp<>);
+REGISTER_CPU_OPERATOR(SparseAdagrad, SparseAdagradOp);
 // For backward compatibility
-REGISTER_CPU_OPERATOR_WITH_ENGINE(SparseAdagrad, SIMD, SparseAdagradOp<>);
+REGISTER_CPU_OPERATOR_WITH_ENGINE(SparseAdagrad, SIMD, SparseAdagradOp);
 OPERATOR_SCHEMA(SparseAdagrad)
     .NumInputs(5)
     .NumOutputs(2)


### PR DESCRIPTION
Summary:
Various quantization options in SparseAdagradOp is only for experimental purposes and was unnecessarily complicating the code.
Moving these options back to internal code, merge into SparseSimdAdagradStochasticQuantOp, and change the name to SparseSimdAdagradFakeQuantOp

Test Plan: CI

Differential Revision: D20720426

