### PR TITLE
[iOS] Enable selective build for testing FBNet in PyTorchPlayground

### DIFF
--- a/test/backward_compatibility/check_backward_compatibility.py
+++ b/test/backward_compatibility/check_backward_compatibility.py
@@ -83,6 +83,7 @@ white_list = [
     ('aten::asinh', datetime.date(2020, 4, 1)),
     ('aten::floordiv', datetime.date(2020, 4, 1)),
     ('prim::NumToTensor', datetime.date(2020, 4, 1)),
+    ('prim::NumToTensor.Scalar', datetime.date(2020, 4, 1)),
     ('aten::sin', datetime.date(2020, 4, 1)),
     ('aten::round', datetime.date(2020, 4, 1)),
     ('aten::remainder', datetime.date(2020, 4, 1)),

--- a/torch/csrc/jit/mobile/register_mobile_ops.cpp
+++ b/torch/csrc/jit/mobile/register_mobile_ops.cpp
@@ -402,6 +402,11 @@ static auto registry =
                 [](at::Scalar s) -> at::Tensor {
                   return at::scalar_to_tensor(s);
                 }))
+        .op("_prim::NumToTensor.Scalar",
+            torch::RegisterOperators::options().catchAllKernel(
+                [](at::Scalar s) -> at::Tensor {
+                  return at::scalar_to_tensor(s);
+                }))
         .op(
             // Dummy operator that does nothing. Used to reserve a location of
             // an operator table.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#35645 [iOS] Enable selective build for testing FBNet in PyTorchPlayground**

Since we have enabled the unit test for FBNet on iOS, it'll block people from landing due to the missing support for selective build. This PR adds the missing ops in PyTorchPlaygronud to support FBNet.

Differential Revision: [D20723020](https://our.internmc.facebook.com/intern/diff/D20723020/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D20723020/)!