### PR TITLE
Fix AVX detection with clang-cl

### DIFF
--- a/caffe2/perfkernels/CMakeLists.txt
+++ b/caffe2/perfkernels/CMakeLists.txt
@@ -28,7 +28,7 @@ if(CAFFE2_COMPILER_SUPPORTS_AVX2_EXTENSIONS)
   add_dependencies(Caffe2_perfkernels_avx2 Caffe2_PROTO)
   target_link_libraries(Caffe2_perfkernels_avx PRIVATE c10)
   target_link_libraries(Caffe2_perfkernels_avx2 PRIVATE c10)
-  if(MSVC)
+  if(MSVC AND NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     target_compile_options(Caffe2_perfkernels_avx
         PRIVATE "/arch:AVX"
         PRIVATE "/D__F16C__")
@@ -61,7 +61,7 @@ if(CAFFE2_COMPILER_SUPPORTS_AVX2_EXTENSIONS)
     add_library(Caffe2_perfkernels_avx512 STATIC ${avx512_srcs})
     add_dependencies(Caffe2_perfkernels_avx512 Caffe2_PROTO)
     target_link_libraries(Caffe2_perfkernels_avx512 PRIVATE c10)
-    if(MSVC)
+    if(MSVC AND NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
       target_compile_options(Caffe2_perfkernels_avx512
           PRIVATE "/D__AVX512F__"
           PRIVATE "/D__AVX512DQ__"

--- a/cmake/MiscCheck.cmake
+++ b/cmake/MiscCheck.cmake
@@ -134,7 +134,7 @@ cmake_pop_check_state()
 # ---[ Check if the compiler has AVX/AVX2 support. We only check AVX2.
 if(NOT INTERN_BUILD_MOBILE)
   cmake_push_check_state(RESET)
-  if(MSVC)
+  if(MSVC AND NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     set(CMAKE_REQUIRED_FLAGS "/arch:AVX2")
   else()
     set(CMAKE_REQUIRED_FLAGS "-mavx2")
@@ -160,7 +160,7 @@ if(NOT INTERN_BUILD_MOBILE)
 endif()
 # ---[ Check if the compiler has AVX512 support.
 cmake_push_check_state(RESET)
-if(MSVC)
+if(MSVC AND NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   # We could've used MSVC's hidden option /arch:AVX512 that defines __AVX512F__,
   # __AVX512DQ__, and __AVX512VL__, and /arch:AVX512F that defines __AVX512F__.
   # But, we chose not to do that not to rely on hidden options.


### PR DESCRIPTION
Defining macros `/D__F16C__` or sth similar won't work on clang-cl.