### PR TITLE
[Windows] Fix torch_cuda's forced link

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -752,7 +752,7 @@ if(NOT INTERN_BUILD_MOBILE OR NOT BUILD_CAFFE2_MOBILE)
       target_include_directories(torch_cuda PUBLIC "${NVTOOLEXT_HOME}/include")
       # -INCLUDE is used to ensure torch_cuda is linked against in a project that relies on it.
       # Related issue: https://github.com/pytorch/pytorch/issues/31611
-      target_link_libraries(torch_cuda INTERFACE "-INCLUDE:\"?warp_size@cuda@at@@YAHXZ\"")
+      target_link_libraries(torch_cuda INTERFACE "-INCLUDE:?warp_size@cuda@at@@YAHXZ")
 
     elseif(APPLE)
       set(TORCH_CUDA_LIBRARIES

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -1222,7 +1222,7 @@ def _prepare_ldflags(extra_ldflags, with_cuda, verbose):
             extra_ldflags.append('torch_cuda.lib')
             # /INCLUDE is used to ensure torch_cuda is linked against in a project that relies on it.
             # Related issue: https://github.com/pytorch/pytorch/issues/31611
-            extra_ldflags.append('/INCLUDE:\"?warp_size@cuda@at@@YAHXZ\"')
+            extra_ldflags.append('-INCLUDE:?warp_size@cuda@at@@YAHXZ')
         extra_ldflags.append('torch.lib')
         extra_ldflags.append('torch_python.lib')
         extra_ldflags.append('/LIBPATH:{}'.format(python_lib_path))


### PR DESCRIPTION
The current config on `master` yields the following errors when build from source on Windows with CMake and Visual Studio 2019.
```
Severity	Code	Description	Project	File	Line	Suppression State
Error	LNK2001	unresolved external symbol \?warp_size@cuda@at@@YAHXZ\	torch	D:\AI\pytorch\build_libtorch\caffe2\LINK	1	
Severity	Code	Description	Project	File	Line	Suppression State
Error	LNK1120	1 unresolved externals	torch	D:\AI\pytorch\build_libtorch\bin\Release\torch.dll	1	
Severity	Code	Description	Project	File	Line	Suppression State
Error	LNK2001	unresolved external symbol \?warp_size@cuda@at@@YAHXZ\	caffe2_observers	D:\AI\pytorch\build_libtorch\modules\observers\LINK	1	
Severity	Code	Description	Project	File	Line	Suppression State
Error	LNK1120	1 unresolved externals	caffe2_observers	D:\AI\pytorch\build_libtorch\bin\Release\caffe2_observers.dll	1	
Severity	Code	Description	Project	File	Line	Suppression State
Error	LNK2001	unresolved external symbol \?warp_size@cuda@at@@YAHXZ\	caffe2_detectron_ops_gpu	D:\AI\pytorch\build_libtorch\modules\detectron\LINK	1	
Severity	Code	Description	Project	File	Line	Suppression State
Error	LNK1120	1 unresolved externals	caffe2_detectron_ops_gpu	D:\AI\pytorch\build_libtorch\bin\Release\caffe2_detectron_ops_gpu.dll	1	
```

This change at least fixes the above errors in that specific setting. Do you think it makes sense to get this merged or will it break other settings? 