### PR TITLE
Report results of python unit tests during window test runs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -600,11 +600,14 @@ jobs:
           no_output_timeout: "30m"
           command: |
             set -e
+            export IN_CIRCLECI=1
             set +x
             export AWS_ACCESS_KEY_ID=${CIRCLECI_AWS_ACCESS_KEY_FOR_WIN_BUILD_V1}
             export AWS_SECRET_ACCESS_KEY=${CIRCLECI_AWS_SECRET_KEY_FOR_WIN_BUILD_V1}
             set -x
             .jenkins/pytorch/win-test.sh
+      - store_test_results:
+          path: test/test-reports
   caffe2_linux_build:
     <<: *caffe2_params
     machine:

--- a/.circleci/verbatim-sources/pytorch-job-specs.yml
+++ b/.circleci/verbatim-sources/pytorch-job-specs.yml
@@ -255,8 +255,11 @@ jobs:
           no_output_timeout: "30m"
           command: |
             set -e
+            export IN_CIRCLECI=1
             set +x
             export AWS_ACCESS_KEY_ID=${CIRCLECI_AWS_ACCESS_KEY_FOR_WIN_BUILD_V1}
             export AWS_SECRET_ACCESS_KEY=${CIRCLECI_AWS_SECRET_KEY_FOR_WIN_BUILD_V1}
             set -x
             .jenkins/pytorch/win-test.sh
+      - store_test_results:
+          path: test/test-reports

--- a/.jenkins/pytorch/win-test-helpers/setup_pytorch_env.bat
+++ b/.jenkins/pytorch/win-test-helpers/setup_pytorch_env.bat
@@ -24,7 +24,7 @@ if NOT "%BUILD_ENVIRONMENT%"=="" (
     call conda install -y -q -c conda-forge cmake
 )
 :: The version is fixed to avoid flakiness: https://github.com/pytorch/pytorch/issues/31136
-pip install ninja future "hypothesis==4.53.2" "librosa>=0.6.2" psutil pillow
+pip install ninja future "hypothesis==4.53.2" "librosa>=0.6.2" psutil pillow unittest-xml-reporting
 :: No need to install faulthandler since we only test Python >= 3.6 on Windows
 :: faulthandler is builtin since Python 3.3
 

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -212,6 +212,8 @@ def run_tests(argv=UNITTEST_ARGS):
                 if not os.path.exists(test_report_path):
                     os.makedirs(test_report_path)
             verbose = '--verbose' in argv or '-v' in argv
+            if verbose:
+                print('Test results will be stored in {}'.format(test_report_path))
             unittest.main(argv=argv, testRunner=xmlrunner.XMLTestRunner(output=test_report_path, verbosity=2 if verbose else 1))
         else:
             unittest.main(argv=argv)


### PR DESCRIPTION
Define `store_test_results` attribute in CircleCI yamls
Install `unittest-xml-reporting` and define `IN_CIRCLECI` environment variable to trigger test runners to save results to XML

