### PR TITLE
Move libtorch to py3 and cleanup other CircleCI config

### DIFF
--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -71,9 +71,9 @@ A **binary configuration** is a collection of
 * release or nightly
     * releases are stable, nightlies are beta and built every night
 * python version
-    * linux: 2.7m, 2.7mu, 3.5m, 3.6m 3.7m (mu is wide unicode or something like that. It usually doesn't matter but you should know that it exists)
-    * macos: 2.7, 3.5, 3.6, 3.7
-    * windows: 3.5, 3.6, 3.7
+    * linux: 3.5m, 3.6m 3.7m (mu is wide unicode or something like that. It usually doesn't matter but you should know that it exists)
+    * macos: 3.6, 3.7, 3.8
+    * windows: 3.6, 3.7, 3.8
 * cpu version
     * cpu, cuda 9.0, cuda 10.0
     * The supported cuda versions occasionally change

--- a/.circleci/cimodel/data/binary_build_data.py
+++ b/.circleci/cimodel/data/binary_build_data.py
@@ -34,14 +34,13 @@ def get_processor_arch_name(cuda_version):
 
 LINUX_PACKAGE_VARIANTS = OrderedDict(
     manywheel=[
-        "3.5m",
         "3.6m",
         "3.7m",
         "3.8m",
     ],
     conda=dimensions.STANDARD_PYTHON_VERSIONS,
     libtorch=[
-        "2.7m",
+        "3.6m",
     ],
 )
 
@@ -51,7 +50,7 @@ CONFIG_TREE_DATA = OrderedDict(
         wheel=dimensions.STANDARD_PYTHON_VERSIONS,
         conda=dimensions.STANDARD_PYTHON_VERSIONS,
         libtorch=[
-            "2.7",
+            "3.6",
         ],
     )),
 )

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1670,15 +1670,15 @@ jobs:
 
 
 # There is currently no testing for libtorch TODO
-#  binary_linux_libtorch_2.7m_cpu_test:
+#  binary_linux_libtorch_3.6m_cpu_test:
 #    environment:
-#      BUILD_ENVIRONMENT: "libtorch 2.7m cpu"
+#      BUILD_ENVIRONMENT: "libtorch 3.6m cpu"
 #    resource_class: gpu.medium
 #    <<: *binary_linux_test
 #
-#  binary_linux_libtorch_2.7m_cu90_test:
+#  binary_linux_libtorch_3.6m_cu90_test:
 #    environment:
-#      BUILD_ENVIRONMENT: "libtorch 2.7m cu90"
+#      BUILD_ENVIRONMENT: "libtorch 3.6m cu90"
 #    resource_class: gpu.medium
 #    <<: *binary_linux_test
 #
@@ -2453,23 +2453,22 @@ workflows:
                 - master
       # This binary build is currently broken, see https://github_com/pytorch/pytorch/issues/16710
       # - binary_linux_conda_3_6_cu90_devtoolset7_build
-      # TODO rename to remove python version for libtorch
       - binary_linux_build:
-          name: binary_linux_libtorch_2_7m_cpu_devtoolset7_shared-with-deps_build
-          build_environment: "libtorch 2.7m cpu devtoolset7"
+          name: binary_linux_libtorch_3_6m_cpu_devtoolset7_shared-with-deps_build
+          build_environment: "libtorch 3.6m cpu devtoolset7"
           requires:
             - setup
           libtorch_variant: "shared-with-deps"
           docker_image: "pytorch/manylinux-cuda102"
       - binary_linux_build:
-          name: binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_shared-with-deps_build
-          build_environment: "libtorch 2.7m cpu gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_3_6m_cpu_gcc5_4_cxx11-abi_shared-with-deps_build
+          build_environment: "libtorch 3.6m cpu gcc5.4_cxx11-abi"
           requires:
             - setup
           libtorch_variant: "shared-with-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
       # TODO we should test a libtorch cuda build, but they take too long
-      # - binary_linux_libtorch_2_7m_cu90_devtoolset7_static-without-deps_build
+      # - binary_linux_libtorch_3_6m_cu90_devtoolset7_static-without-deps_build
       - binary_mac_build:
           name: binary_macos_wheel_3_6_cpu_build
           build_environment: "wheel 3.6 cpu"
@@ -2481,10 +2480,9 @@ workflows:
                 - master
       # This job has an average run time of 3 hours o.O
       # Now only running this on master to reduce overhead
-      # TODO rename to remove python version for libtorch
       - binary_mac_build:
-          name: binary_macos_libtorch_2_7_cpu_build
-          build_environment: "libtorch 2.7 cpu"
+          name: binary_macos_libtorch_3_6_cpu_build
+          build_environment: "libtorch 3.6 cpu"
           requires:
             - setup
           filters:
@@ -2506,35 +2504,23 @@ workflows:
                 - master
       # This binary build is currently broken, see https://github_com/pytorch/pytorch/issues/16710
       # - binary_linux_conda_3_6_cu90_devtoolset7_test:
-      # TODO rename to remove python version for libtorch
       - binary_linux_test:
-          name: binary_linux_libtorch_2_7m_cpu_devtoolset7_shared-with-deps_test
-          build_environment: "libtorch 2.7m cpu devtoolset7"
+          name: binary_linux_libtorch_3_6m_cpu_devtoolset7_shared-with-deps_test
+          build_environment: "libtorch 3.6m cpu devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_2_7m_cpu_devtoolset7_shared-with-deps_build
+            - binary_linux_libtorch_3_6m_cpu_devtoolset7_shared-with-deps_build
           libtorch_variant: "shared-with-deps"
           docker_image: "pytorch/manylinux-cuda102"
       - binary_linux_test:
-          name: binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_shared-with-deps_test
-          build_environment: "libtorch 2.7m cpu gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_3_6m_cpu_gcc5_4_cxx11-abi_shared-with-deps_test
+          build_environment: "libtorch 3.6m cpu gcc5.4_cxx11-abi"
           requires:
             - setup
-            - binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_shared-with-deps_build
+            - binary_linux_libtorch_3_6m_cpu_gcc5_4_cxx11-abi_shared-with-deps_build
           libtorch_variant: "shared-with-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
 
-      - smoke_linux_test:
-          name: smoke_linux_manywheel_3_5m_cpu_devtoolset7_nightly
-          build_environment: "manywheel 3.5m cpu devtoolset7"
-          requires:
-            - setup
-            - update_s3_htmls_for_nightlies
-            - update_s3_htmls_for_nightlies_devtoolset7
-          filters:
-            branches:
-              only: postnightly
-          docker_image: "pytorch/manylinux-cuda102"
       - smoke_linux_test:
           name: smoke_linux_manywheel_3_6m_cpu_devtoolset7_nightly
           build_environment: "manywheel 3.6m cpu devtoolset7"
@@ -2568,19 +2554,6 @@ workflows:
             branches:
               only: postnightly
           docker_image: "pytorch/manylinux-cuda102"
-      - smoke_linux_test:
-          name: smoke_linux_manywheel_3_5m_cu92_devtoolset7_nightly
-          build_environment: "manywheel 3.5m cu92 devtoolset7"
-          requires:
-            - setup
-            - update_s3_htmls_for_nightlies
-            - update_s3_htmls_for_nightlies_devtoolset7
-          filters:
-            branches:
-              only: postnightly
-          docker_image: "pytorch/manylinux-cuda92"
-          use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
       - smoke_linux_test:
           name: smoke_linux_manywheel_3_6m_cu92_devtoolset7_nightly
           build_environment: "manywheel 3.6m cu92 devtoolset7"
@@ -2621,19 +2594,6 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
-          name: smoke_linux_manywheel_3_5m_cu101_devtoolset7_nightly
-          build_environment: "manywheel 3.5m cu101 devtoolset7"
-          requires:
-            - setup
-            - update_s3_htmls_for_nightlies
-            - update_s3_htmls_for_nightlies_devtoolset7
-          filters:
-            branches:
-              only: postnightly
-          docker_image: "pytorch/manylinux-cuda101"
-          use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
-      - smoke_linux_test:
           name: smoke_linux_manywheel_3_6m_cu101_devtoolset7_nightly
           build_environment: "manywheel 3.6m cu101 devtoolset7"
           requires:
@@ -2670,19 +2630,6 @@ workflows:
             branches:
               only: postnightly
           docker_image: "pytorch/manylinux-cuda101"
-          use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
-      - smoke_linux_test:
-          name: smoke_linux_manywheel_3_5m_cu102_devtoolset7_nightly
-          build_environment: "manywheel 3.5m cu102 devtoolset7"
-          requires:
-            - setup
-            - update_s3_htmls_for_nightlies
-            - update_s3_htmls_for_nightlies_devtoolset7
-          filters:
-            branches:
-              only: postnightly
-          docker_image: "pytorch/manylinux-cuda102"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
@@ -2925,8 +2872,8 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
-          name: smoke_linux_libtorch_2_7m_cpu_devtoolset7_nightly_shared-with-deps
-          build_environment: "libtorch 2.7m cpu devtoolset7"
+          name: smoke_linux_libtorch_3_6m_cpu_devtoolset7_nightly_shared-with-deps
+          build_environment: "libtorch 3.6m cpu devtoolset7"
           requires:
             - setup
             - update_s3_htmls_for_nightlies
@@ -2937,8 +2884,8 @@ workflows:
           libtorch_variant: "shared-with-deps"
           docker_image: "pytorch/manylinux-cuda102"
       - smoke_linux_test:
-          name: smoke_linux_libtorch_2_7m_cpu_devtoolset7_nightly_shared-without-deps
-          build_environment: "libtorch 2.7m cpu devtoolset7"
+          name: smoke_linux_libtorch_3_6m_cpu_devtoolset7_nightly_shared-without-deps
+          build_environment: "libtorch 3.6m cpu devtoolset7"
           requires:
             - setup
             - update_s3_htmls_for_nightlies
@@ -2949,8 +2896,8 @@ workflows:
           libtorch_variant: "shared-without-deps"
           docker_image: "pytorch/manylinux-cuda102"
       - smoke_linux_test:
-          name: smoke_linux_libtorch_2_7m_cpu_devtoolset7_nightly_static-with-deps
-          build_environment: "libtorch 2.7m cpu devtoolset7"
+          name: smoke_linux_libtorch_3_6m_cpu_devtoolset7_nightly_static-with-deps
+          build_environment: "libtorch 3.6m cpu devtoolset7"
           requires:
             - setup
             - update_s3_htmls_for_nightlies
@@ -2961,8 +2908,8 @@ workflows:
           libtorch_variant: "static-with-deps"
           docker_image: "pytorch/manylinux-cuda102"
       - smoke_linux_test:
-          name: smoke_linux_libtorch_2_7m_cpu_devtoolset7_nightly_static-without-deps
-          build_environment: "libtorch 2.7m cpu devtoolset7"
+          name: smoke_linux_libtorch_3_6m_cpu_devtoolset7_nightly_static-without-deps
+          build_environment: "libtorch 3.6m cpu devtoolset7"
           requires:
             - setup
             - update_s3_htmls_for_nightlies
@@ -2973,8 +2920,8 @@ workflows:
           libtorch_variant: "static-without-deps"
           docker_image: "pytorch/manylinux-cuda102"
       - smoke_linux_test:
-          name: smoke_linux_libtorch_2_7m_cu92_devtoolset7_nightly_shared-with-deps
-          build_environment: "libtorch 2.7m cu92 devtoolset7"
+          name: smoke_linux_libtorch_3_6m_cu92_devtoolset7_nightly_shared-with-deps
+          build_environment: "libtorch 3.6m cu92 devtoolset7"
           requires:
             - setup
             - update_s3_htmls_for_nightlies
@@ -2987,8 +2934,8 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
-          name: smoke_linux_libtorch_2_7m_cu92_devtoolset7_nightly_shared-without-deps
-          build_environment: "libtorch 2.7m cu92 devtoolset7"
+          name: smoke_linux_libtorch_3_6m_cu92_devtoolset7_nightly_shared-without-deps
+          build_environment: "libtorch 3.6m cu92 devtoolset7"
           requires:
             - setup
             - update_s3_htmls_for_nightlies
@@ -3001,8 +2948,8 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
-          name: smoke_linux_libtorch_2_7m_cu92_devtoolset7_nightly_static-with-deps
-          build_environment: "libtorch 2.7m cu92 devtoolset7"
+          name: smoke_linux_libtorch_3_6m_cu92_devtoolset7_nightly_static-with-deps
+          build_environment: "libtorch 3.6m cu92 devtoolset7"
           requires:
             - setup
             - update_s3_htmls_for_nightlies
@@ -3015,8 +2962,8 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
-          name: smoke_linux_libtorch_2_7m_cu92_devtoolset7_nightly_static-without-deps
-          build_environment: "libtorch 2.7m cu92 devtoolset7"
+          name: smoke_linux_libtorch_3_6m_cu92_devtoolset7_nightly_static-without-deps
+          build_environment: "libtorch 3.6m cu92 devtoolset7"
           requires:
             - setup
             - update_s3_htmls_for_nightlies
@@ -3029,8 +2976,8 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
-          name: smoke_linux_libtorch_2_7m_cu101_devtoolset7_nightly_shared-with-deps
-          build_environment: "libtorch 2.7m cu101 devtoolset7"
+          name: smoke_linux_libtorch_3_6m_cu101_devtoolset7_nightly_shared-with-deps
+          build_environment: "libtorch 3.6m cu101 devtoolset7"
           requires:
             - setup
             - update_s3_htmls_for_nightlies
@@ -3043,8 +2990,8 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
-          name: smoke_linux_libtorch_2_7m_cu101_devtoolset7_nightly_shared-without-deps
-          build_environment: "libtorch 2.7m cu101 devtoolset7"
+          name: smoke_linux_libtorch_3_6m_cu101_devtoolset7_nightly_shared-without-deps
+          build_environment: "libtorch 3.6m cu101 devtoolset7"
           requires:
             - setup
             - update_s3_htmls_for_nightlies
@@ -3057,8 +3004,8 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
-          name: smoke_linux_libtorch_2_7m_cu101_devtoolset7_nightly_static-with-deps
-          build_environment: "libtorch 2.7m cu101 devtoolset7"
+          name: smoke_linux_libtorch_3_6m_cu101_devtoolset7_nightly_static-with-deps
+          build_environment: "libtorch 3.6m cu101 devtoolset7"
           requires:
             - setup
             - update_s3_htmls_for_nightlies
@@ -3071,8 +3018,8 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
-          name: smoke_linux_libtorch_2_7m_cu101_devtoolset7_nightly_static-without-deps
-          build_environment: "libtorch 2.7m cu101 devtoolset7"
+          name: smoke_linux_libtorch_3_6m_cu101_devtoolset7_nightly_static-without-deps
+          build_environment: "libtorch 3.6m cu101 devtoolset7"
           requires:
             - setup
             - update_s3_htmls_for_nightlies
@@ -3085,8 +3032,8 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
-          name: smoke_linux_libtorch_2_7m_cu102_devtoolset7_nightly_shared-with-deps
-          build_environment: "libtorch 2.7m cu102 devtoolset7"
+          name: smoke_linux_libtorch_3_6m_cu102_devtoolset7_nightly_shared-with-deps
+          build_environment: "libtorch 3.6m cu102 devtoolset7"
           requires:
             - setup
             - update_s3_htmls_for_nightlies
@@ -3099,8 +3046,8 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
-          name: smoke_linux_libtorch_2_7m_cu102_devtoolset7_nightly_shared-without-deps
-          build_environment: "libtorch 2.7m cu102 devtoolset7"
+          name: smoke_linux_libtorch_3_6m_cu102_devtoolset7_nightly_shared-without-deps
+          build_environment: "libtorch 3.6m cu102 devtoolset7"
           requires:
             - setup
             - update_s3_htmls_for_nightlies
@@ -3113,8 +3060,8 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
-          name: smoke_linux_libtorch_2_7m_cu102_devtoolset7_nightly_static-with-deps
-          build_environment: "libtorch 2.7m cu102 devtoolset7"
+          name: smoke_linux_libtorch_3_6m_cu102_devtoolset7_nightly_static-with-deps
+          build_environment: "libtorch 3.6m cu102 devtoolset7"
           requires:
             - setup
             - update_s3_htmls_for_nightlies
@@ -3127,8 +3074,8 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
-          name: smoke_linux_libtorch_2_7m_cu102_devtoolset7_nightly_static-without-deps
-          build_environment: "libtorch 2.7m cu102 devtoolset7"
+          name: smoke_linux_libtorch_3_6m_cu102_devtoolset7_nightly_static-without-deps
+          build_environment: "libtorch 3.6m cu102 devtoolset7"
           requires:
             - setup
             - update_s3_htmls_for_nightlies
@@ -3141,8 +3088,8 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
-          name: smoke_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_nightly_shared-with-deps
-          build_environment: "libtorch 2.7m cpu gcc5.4_cxx11-abi"
+          name: smoke_linux_libtorch_3_6m_cpu_gcc5_4_cxx11-abi_nightly_shared-with-deps
+          build_environment: "libtorch 3.6m cpu gcc5.4_cxx11-abi"
           requires:
             - setup
             - update_s3_htmls_for_nightlies
@@ -3153,8 +3100,8 @@ workflows:
           libtorch_variant: "shared-with-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
       - smoke_linux_test:
-          name: smoke_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_nightly_shared-without-deps
-          build_environment: "libtorch 2.7m cpu gcc5.4_cxx11-abi"
+          name: smoke_linux_libtorch_3_6m_cpu_gcc5_4_cxx11-abi_nightly_shared-without-deps
+          build_environment: "libtorch 3.6m cpu gcc5.4_cxx11-abi"
           requires:
             - setup
             - update_s3_htmls_for_nightlies
@@ -3165,8 +3112,8 @@ workflows:
           libtorch_variant: "shared-without-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
       - smoke_linux_test:
-          name: smoke_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_nightly_static-with-deps
-          build_environment: "libtorch 2.7m cpu gcc5.4_cxx11-abi"
+          name: smoke_linux_libtorch_3_6m_cpu_gcc5_4_cxx11-abi_nightly_static-with-deps
+          build_environment: "libtorch 3.6m cpu gcc5.4_cxx11-abi"
           requires:
             - setup
             - update_s3_htmls_for_nightlies
@@ -3177,8 +3124,8 @@ workflows:
           libtorch_variant: "static-with-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
       - smoke_linux_test:
-          name: smoke_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_nightly_static-without-deps
-          build_environment: "libtorch 2.7m cpu gcc5.4_cxx11-abi"
+          name: smoke_linux_libtorch_3_6m_cpu_gcc5_4_cxx11-abi_nightly_static-without-deps
+          build_environment: "libtorch 3.6m cpu gcc5.4_cxx11-abi"
           requires:
             - setup
             - update_s3_htmls_for_nightlies
@@ -3189,8 +3136,8 @@ workflows:
           libtorch_variant: "static-without-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
       - smoke_linux_test:
-          name: smoke_linux_libtorch_2_7m_cu92_gcc5_4_cxx11-abi_nightly_shared-with-deps
-          build_environment: "libtorch 2.7m cu92 gcc5.4_cxx11-abi"
+          name: smoke_linux_libtorch_3_6m_cu92_gcc5_4_cxx11-abi_nightly_shared-with-deps
+          build_environment: "libtorch 3.6m cu92 gcc5.4_cxx11-abi"
           requires:
             - setup
             - update_s3_htmls_for_nightlies
@@ -3203,8 +3150,8 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
-          name: smoke_linux_libtorch_2_7m_cu92_gcc5_4_cxx11-abi_nightly_shared-without-deps
-          build_environment: "libtorch 2.7m cu92 gcc5.4_cxx11-abi"
+          name: smoke_linux_libtorch_3_6m_cu92_gcc5_4_cxx11-abi_nightly_shared-without-deps
+          build_environment: "libtorch 3.6m cu92 gcc5.4_cxx11-abi"
           requires:
             - setup
             - update_s3_htmls_for_nightlies
@@ -3217,8 +3164,8 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
-          name: smoke_linux_libtorch_2_7m_cu92_gcc5_4_cxx11-abi_nightly_static-with-deps
-          build_environment: "libtorch 2.7m cu92 gcc5.4_cxx11-abi"
+          name: smoke_linux_libtorch_3_6m_cu92_gcc5_4_cxx11-abi_nightly_static-with-deps
+          build_environment: "libtorch 3.6m cu92 gcc5.4_cxx11-abi"
           requires:
             - setup
             - update_s3_htmls_for_nightlies
@@ -3231,64 +3178,8 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
-          name: smoke_linux_libtorch_2_7m_cu92_gcc5_4_cxx11-abi_nightly_static-without-deps
-          build_environment: "libtorch 2.7m cu92 gcc5.4_cxx11-abi"
-          requires:
-            - setup
-            - update_s3_htmls_for_nightlies
-            - update_s3_htmls_for_nightlies_devtoolset7
-          filters:
-            branches:
-              only: postnightly
-          libtorch_variant: "static-without-deps"
-          docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
-          use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
-      - smoke_linux_test:
-          name: smoke_linux_libtorch_2_7m_cu101_gcc5_4_cxx11-abi_nightly_shared-with-deps
-          build_environment: "libtorch 2.7m cu101 gcc5.4_cxx11-abi"
-          requires:
-            - setup
-            - update_s3_htmls_for_nightlies
-            - update_s3_htmls_for_nightlies_devtoolset7
-          filters:
-            branches:
-              only: postnightly
-          libtorch_variant: "shared-with-deps"
-          docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
-          use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
-      - smoke_linux_test:
-          name: smoke_linux_libtorch_2_7m_cu101_gcc5_4_cxx11-abi_nightly_shared-without-deps
-          build_environment: "libtorch 2.7m cu101 gcc5.4_cxx11-abi"
-          requires:
-            - setup
-            - update_s3_htmls_for_nightlies
-            - update_s3_htmls_for_nightlies_devtoolset7
-          filters:
-            branches:
-              only: postnightly
-          libtorch_variant: "shared-without-deps"
-          docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
-          use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
-      - smoke_linux_test:
-          name: smoke_linux_libtorch_2_7m_cu101_gcc5_4_cxx11-abi_nightly_static-with-deps
-          build_environment: "libtorch 2.7m cu101 gcc5.4_cxx11-abi"
-          requires:
-            - setup
-            - update_s3_htmls_for_nightlies
-            - update_s3_htmls_for_nightlies_devtoolset7
-          filters:
-            branches:
-              only: postnightly
-          libtorch_variant: "static-with-deps"
-          docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
-          use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
-      - smoke_linux_test:
-          name: smoke_linux_libtorch_2_7m_cu101_gcc5_4_cxx11-abi_nightly_static-without-deps
-          build_environment: "libtorch 2.7m cu101 gcc5.4_cxx11-abi"
+          name: smoke_linux_libtorch_3_6m_cu92_gcc5_4_cxx11-abi_nightly_static-without-deps
+          build_environment: "libtorch 3.6m cu92 gcc5.4_cxx11-abi"
           requires:
             - setup
             - update_s3_htmls_for_nightlies
@@ -3301,8 +3192,8 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
-          name: smoke_linux_libtorch_2_7m_cu102_gcc5_4_cxx11-abi_nightly_shared-with-deps
-          build_environment: "libtorch 2.7m cu102 gcc5.4_cxx11-abi"
+          name: smoke_linux_libtorch_3_6m_cu101_gcc5_4_cxx11-abi_nightly_shared-with-deps
+          build_environment: "libtorch 3.6m cu101 gcc5.4_cxx11-abi"
           requires:
             - setup
             - update_s3_htmls_for_nightlies
@@ -3315,8 +3206,8 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
-          name: smoke_linux_libtorch_2_7m_cu102_gcc5_4_cxx11-abi_nightly_shared-without-deps
-          build_environment: "libtorch 2.7m cu102 gcc5.4_cxx11-abi"
+          name: smoke_linux_libtorch_3_6m_cu101_gcc5_4_cxx11-abi_nightly_shared-without-deps
+          build_environment: "libtorch 3.6m cu101 gcc5.4_cxx11-abi"
           requires:
             - setup
             - update_s3_htmls_for_nightlies
@@ -3329,8 +3220,8 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
-          name: smoke_linux_libtorch_2_7m_cu102_gcc5_4_cxx11-abi_nightly_static-with-deps
-          build_environment: "libtorch 2.7m cu102 gcc5.4_cxx11-abi"
+          name: smoke_linux_libtorch_3_6m_cu101_gcc5_4_cxx11-abi_nightly_static-with-deps
+          build_environment: "libtorch 3.6m cu101 gcc5.4_cxx11-abi"
           requires:
             - setup
             - update_s3_htmls_for_nightlies
@@ -3343,8 +3234,64 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - smoke_linux_test:
-          name: smoke_linux_libtorch_2_7m_cu102_gcc5_4_cxx11-abi_nightly_static-without-deps
-          build_environment: "libtorch 2.7m cu102 gcc5.4_cxx11-abi"
+          name: smoke_linux_libtorch_3_6m_cu101_gcc5_4_cxx11-abi_nightly_static-without-deps
+          build_environment: "libtorch 3.6m cu101 gcc5.4_cxx11-abi"
+          requires:
+            - setup
+            - update_s3_htmls_for_nightlies
+            - update_s3_htmls_for_nightlies_devtoolset7
+          filters:
+            branches:
+              only: postnightly
+          libtorch_variant: "static-without-deps"
+          docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
+          use_cuda_docker_runtime: "1"
+          resource_class: gpu.medium
+      - smoke_linux_test:
+          name: smoke_linux_libtorch_3_6m_cu102_gcc5_4_cxx11-abi_nightly_shared-with-deps
+          build_environment: "libtorch 3.6m cu102 gcc5.4_cxx11-abi"
+          requires:
+            - setup
+            - update_s3_htmls_for_nightlies
+            - update_s3_htmls_for_nightlies_devtoolset7
+          filters:
+            branches:
+              only: postnightly
+          libtorch_variant: "shared-with-deps"
+          docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
+          use_cuda_docker_runtime: "1"
+          resource_class: gpu.medium
+      - smoke_linux_test:
+          name: smoke_linux_libtorch_3_6m_cu102_gcc5_4_cxx11-abi_nightly_shared-without-deps
+          build_environment: "libtorch 3.6m cu102 gcc5.4_cxx11-abi"
+          requires:
+            - setup
+            - update_s3_htmls_for_nightlies
+            - update_s3_htmls_for_nightlies_devtoolset7
+          filters:
+            branches:
+              only: postnightly
+          libtorch_variant: "shared-without-deps"
+          docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
+          use_cuda_docker_runtime: "1"
+          resource_class: gpu.medium
+      - smoke_linux_test:
+          name: smoke_linux_libtorch_3_6m_cu102_gcc5_4_cxx11-abi_nightly_static-with-deps
+          build_environment: "libtorch 3.6m cu102 gcc5.4_cxx11-abi"
+          requires:
+            - setup
+            - update_s3_htmls_for_nightlies
+            - update_s3_htmls_for_nightlies_devtoolset7
+          filters:
+            branches:
+              only: postnightly
+          libtorch_variant: "static-with-deps"
+          docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
+          use_cuda_docker_runtime: "1"
+          resource_class: gpu.medium
+      - smoke_linux_test:
+          name: smoke_linux_libtorch_3_6m_cu102_gcc5_4_cxx11-abi_nightly_static-without-deps
+          build_environment: "libtorch 3.6m cu102 gcc5.4_cxx11-abi"
           requires:
             - setup
             - update_s3_htmls_for_nightlies
@@ -3437,8 +3384,8 @@ workflows:
             branches:
               only: postnightly
       - smoke_mac_test:
-          name: smoke_macos_libtorch_2_7_cpu_nightly
-          build_environment: "libtorch 2.7 cpu"
+          name: smoke_macos_libtorch_3_6_cpu_nightly
+          build_environment: "libtorch 3.6 cpu"
           requires:
             - setup
             - update_s3_htmls_for_nightlies
@@ -3446,17 +3393,6 @@ workflows:
           filters:
             branches:
               only: postnightly
-      - binary_linux_build:
-          name: binary_linux_manywheel_3_5m_cpu_devtoolset7_nightly_build
-          build_environment: "manywheel 3.5m cpu devtoolset7"
-          requires:
-            - setup
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          docker_image: "pytorch/manylinux-cuda102"
       - binary_linux_build:
           name: binary_linux_manywheel_3_6m_cpu_devtoolset7_nightly_build
           build_environment: "manywheel 3.6m cpu devtoolset7"
@@ -3491,17 +3427,6 @@ workflows:
               only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
           docker_image: "pytorch/manylinux-cuda102"
       - binary_linux_build:
-          name: binary_linux_manywheel_3_5m_cu92_devtoolset7_nightly_build
-          build_environment: "manywheel 3.5m cu92 devtoolset7"
-          requires:
-            - setup
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          docker_image: "pytorch/manylinux-cuda92"
-      - binary_linux_build:
           name: binary_linux_manywheel_3_6m_cu92_devtoolset7_nightly_build
           build_environment: "manywheel 3.6m cu92 devtoolset7"
           requires:
@@ -3535,17 +3460,6 @@ workflows:
               only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
           docker_image: "pytorch/manylinux-cuda92"
       - binary_linux_build:
-          name: binary_linux_manywheel_3_5m_cu101_devtoolset7_nightly_build
-          build_environment: "manywheel 3.5m cu101 devtoolset7"
-          requires:
-            - setup
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          docker_image: "pytorch/manylinux-cuda101"
-      - binary_linux_build:
           name: binary_linux_manywheel_3_6m_cu101_devtoolset7_nightly_build
           build_environment: "manywheel 3.6m cu101 devtoolset7"
           requires:
@@ -3578,17 +3492,6 @@ workflows:
             tags:
               only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
           docker_image: "pytorch/manylinux-cuda101"
-      - binary_linux_build:
-          name: binary_linux_manywheel_3_5m_cu102_devtoolset7_nightly_build
-          build_environment: "manywheel 3.5m cu102 devtoolset7"
-          requires:
-            - setup
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          docker_image: "pytorch/manylinux-cuda102"
       - binary_linux_build:
           name: binary_linux_manywheel_3_6m_cu102_devtoolset7_nightly_build
           build_environment: "manywheel 3.6m cu102 devtoolset7"
@@ -3799,8 +3702,8 @@ workflows:
               only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
           docker_image: "pytorch/conda-cuda"
       - binary_linux_build:
-          name: binary_linux_libtorch_2_7m_cpu_devtoolset7_nightly_shared-with-deps_build
-          build_environment: "libtorch 2.7m cpu devtoolset7"
+          name: binary_linux_libtorch_3_6m_cpu_devtoolset7_nightly_shared-with-deps_build
+          build_environment: "libtorch 3.6m cpu devtoolset7"
           requires:
             - setup
           filters:
@@ -3811,8 +3714,8 @@ workflows:
           libtorch_variant: "shared-with-deps"
           docker_image: "pytorch/manylinux-cuda102"
       - binary_linux_build:
-          name: binary_linux_libtorch_2_7m_cpu_devtoolset7_nightly_shared-without-deps_build
-          build_environment: "libtorch 2.7m cpu devtoolset7"
+          name: binary_linux_libtorch_3_6m_cpu_devtoolset7_nightly_shared-without-deps_build
+          build_environment: "libtorch 3.6m cpu devtoolset7"
           requires:
             - setup
           filters:
@@ -3823,8 +3726,8 @@ workflows:
           libtorch_variant: "shared-without-deps"
           docker_image: "pytorch/manylinux-cuda102"
       - binary_linux_build:
-          name: binary_linux_libtorch_2_7m_cpu_devtoolset7_nightly_static-with-deps_build
-          build_environment: "libtorch 2.7m cpu devtoolset7"
+          name: binary_linux_libtorch_3_6m_cpu_devtoolset7_nightly_static-with-deps_build
+          build_environment: "libtorch 3.6m cpu devtoolset7"
           requires:
             - setup
           filters:
@@ -3835,8 +3738,8 @@ workflows:
           libtorch_variant: "static-with-deps"
           docker_image: "pytorch/manylinux-cuda102"
       - binary_linux_build:
-          name: binary_linux_libtorch_2_7m_cpu_devtoolset7_nightly_static-without-deps_build
-          build_environment: "libtorch 2.7m cpu devtoolset7"
+          name: binary_linux_libtorch_3_6m_cpu_devtoolset7_nightly_static-without-deps_build
+          build_environment: "libtorch 3.6m cpu devtoolset7"
           requires:
             - setup
           filters:
@@ -3847,8 +3750,8 @@ workflows:
           libtorch_variant: "static-without-deps"
           docker_image: "pytorch/manylinux-cuda102"
       - binary_linux_build:
-          name: binary_linux_libtorch_2_7m_cu92_devtoolset7_nightly_shared-with-deps_build
-          build_environment: "libtorch 2.7m cu92 devtoolset7"
+          name: binary_linux_libtorch_3_6m_cu92_devtoolset7_nightly_shared-with-deps_build
+          build_environment: "libtorch 3.6m cu92 devtoolset7"
           requires:
             - setup
           filters:
@@ -3859,8 +3762,8 @@ workflows:
           libtorch_variant: "shared-with-deps"
           docker_image: "pytorch/manylinux-cuda92"
       - binary_linux_build:
-          name: binary_linux_libtorch_2_7m_cu92_devtoolset7_nightly_shared-without-deps_build
-          build_environment: "libtorch 2.7m cu92 devtoolset7"
+          name: binary_linux_libtorch_3_6m_cu92_devtoolset7_nightly_shared-without-deps_build
+          build_environment: "libtorch 3.6m cu92 devtoolset7"
           requires:
             - setup
           filters:
@@ -3871,8 +3774,8 @@ workflows:
           libtorch_variant: "shared-without-deps"
           docker_image: "pytorch/manylinux-cuda92"
       - binary_linux_build:
-          name: binary_linux_libtorch_2_7m_cu92_devtoolset7_nightly_static-with-deps_build
-          build_environment: "libtorch 2.7m cu92 devtoolset7"
+          name: binary_linux_libtorch_3_6m_cu92_devtoolset7_nightly_static-with-deps_build
+          build_environment: "libtorch 3.6m cu92 devtoolset7"
           requires:
             - setup
           filters:
@@ -3883,8 +3786,8 @@ workflows:
           libtorch_variant: "static-with-deps"
           docker_image: "pytorch/manylinux-cuda92"
       - binary_linux_build:
-          name: binary_linux_libtorch_2_7m_cu92_devtoolset7_nightly_static-without-deps_build
-          build_environment: "libtorch 2.7m cu92 devtoolset7"
+          name: binary_linux_libtorch_3_6m_cu92_devtoolset7_nightly_static-without-deps_build
+          build_environment: "libtorch 3.6m cu92 devtoolset7"
           requires:
             - setup
           filters:
@@ -3895,8 +3798,8 @@ workflows:
           libtorch_variant: "static-without-deps"
           docker_image: "pytorch/manylinux-cuda92"
       - binary_linux_build:
-          name: binary_linux_libtorch_2_7m_cu101_devtoolset7_nightly_shared-with-deps_build
-          build_environment: "libtorch 2.7m cu101 devtoolset7"
+          name: binary_linux_libtorch_3_6m_cu101_devtoolset7_nightly_shared-with-deps_build
+          build_environment: "libtorch 3.6m cu101 devtoolset7"
           requires:
             - setup
           filters:
@@ -3907,8 +3810,8 @@ workflows:
           libtorch_variant: "shared-with-deps"
           docker_image: "pytorch/manylinux-cuda101"
       - binary_linux_build:
-          name: binary_linux_libtorch_2_7m_cu101_devtoolset7_nightly_shared-without-deps_build
-          build_environment: "libtorch 2.7m cu101 devtoolset7"
+          name: binary_linux_libtorch_3_6m_cu101_devtoolset7_nightly_shared-without-deps_build
+          build_environment: "libtorch 3.6m cu101 devtoolset7"
           requires:
             - setup
           filters:
@@ -3919,8 +3822,8 @@ workflows:
           libtorch_variant: "shared-without-deps"
           docker_image: "pytorch/manylinux-cuda101"
       - binary_linux_build:
-          name: binary_linux_libtorch_2_7m_cu101_devtoolset7_nightly_static-with-deps_build
-          build_environment: "libtorch 2.7m cu101 devtoolset7"
+          name: binary_linux_libtorch_3_6m_cu101_devtoolset7_nightly_static-with-deps_build
+          build_environment: "libtorch 3.6m cu101 devtoolset7"
           requires:
             - setup
           filters:
@@ -3931,8 +3834,8 @@ workflows:
           libtorch_variant: "static-with-deps"
           docker_image: "pytorch/manylinux-cuda101"
       - binary_linux_build:
-          name: binary_linux_libtorch_2_7m_cu101_devtoolset7_nightly_static-without-deps_build
-          build_environment: "libtorch 2.7m cu101 devtoolset7"
+          name: binary_linux_libtorch_3_6m_cu101_devtoolset7_nightly_static-without-deps_build
+          build_environment: "libtorch 3.6m cu101 devtoolset7"
           requires:
             - setup
           filters:
@@ -3943,8 +3846,8 @@ workflows:
           libtorch_variant: "static-without-deps"
           docker_image: "pytorch/manylinux-cuda101"
       - binary_linux_build:
-          name: binary_linux_libtorch_2_7m_cu102_devtoolset7_nightly_shared-with-deps_build
-          build_environment: "libtorch 2.7m cu102 devtoolset7"
+          name: binary_linux_libtorch_3_6m_cu102_devtoolset7_nightly_shared-with-deps_build
+          build_environment: "libtorch 3.6m cu102 devtoolset7"
           requires:
             - setup
           filters:
@@ -3955,8 +3858,8 @@ workflows:
           libtorch_variant: "shared-with-deps"
           docker_image: "pytorch/manylinux-cuda102"
       - binary_linux_build:
-          name: binary_linux_libtorch_2_7m_cu102_devtoolset7_nightly_shared-without-deps_build
-          build_environment: "libtorch 2.7m cu102 devtoolset7"
+          name: binary_linux_libtorch_3_6m_cu102_devtoolset7_nightly_shared-without-deps_build
+          build_environment: "libtorch 3.6m cu102 devtoolset7"
           requires:
             - setup
           filters:
@@ -3967,8 +3870,8 @@ workflows:
           libtorch_variant: "shared-without-deps"
           docker_image: "pytorch/manylinux-cuda102"
       - binary_linux_build:
-          name: binary_linux_libtorch_2_7m_cu102_devtoolset7_nightly_static-with-deps_build
-          build_environment: "libtorch 2.7m cu102 devtoolset7"
+          name: binary_linux_libtorch_3_6m_cu102_devtoolset7_nightly_static-with-deps_build
+          build_environment: "libtorch 3.6m cu102 devtoolset7"
           requires:
             - setup
           filters:
@@ -3979,8 +3882,8 @@ workflows:
           libtorch_variant: "static-with-deps"
           docker_image: "pytorch/manylinux-cuda102"
       - binary_linux_build:
-          name: binary_linux_libtorch_2_7m_cu102_devtoolset7_nightly_static-without-deps_build
-          build_environment: "libtorch 2.7m cu102 devtoolset7"
+          name: binary_linux_libtorch_3_6m_cu102_devtoolset7_nightly_static-without-deps_build
+          build_environment: "libtorch 3.6m cu102 devtoolset7"
           requires:
             - setup
           filters:
@@ -3991,8 +3894,8 @@ workflows:
           libtorch_variant: "static-without-deps"
           docker_image: "pytorch/manylinux-cuda102"
       - binary_linux_build:
-          name: binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_nightly_shared-with-deps_build
-          build_environment: "libtorch 2.7m cpu gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_3_6m_cpu_gcc5_4_cxx11-abi_nightly_shared-with-deps_build
+          build_environment: "libtorch 3.6m cpu gcc5.4_cxx11-abi"
           requires:
             - setup
           filters:
@@ -4003,8 +3906,8 @@ workflows:
           libtorch_variant: "shared-with-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
       - binary_linux_build:
-          name: binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_nightly_shared-without-deps_build
-          build_environment: "libtorch 2.7m cpu gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_3_6m_cpu_gcc5_4_cxx11-abi_nightly_shared-without-deps_build
+          build_environment: "libtorch 3.6m cpu gcc5.4_cxx11-abi"
           requires:
             - setup
           filters:
@@ -4015,8 +3918,8 @@ workflows:
           libtorch_variant: "shared-without-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
       - binary_linux_build:
-          name: binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_nightly_static-with-deps_build
-          build_environment: "libtorch 2.7m cpu gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_3_6m_cpu_gcc5_4_cxx11-abi_nightly_static-with-deps_build
+          build_environment: "libtorch 3.6m cpu gcc5.4_cxx11-abi"
           requires:
             - setup
           filters:
@@ -4027,8 +3930,8 @@ workflows:
           libtorch_variant: "static-with-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
       - binary_linux_build:
-          name: binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_nightly_static-without-deps_build
-          build_environment: "libtorch 2.7m cpu gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_3_6m_cpu_gcc5_4_cxx11-abi_nightly_static-without-deps_build
+          build_environment: "libtorch 3.6m cpu gcc5.4_cxx11-abi"
           requires:
             - setup
           filters:
@@ -4039,8 +3942,8 @@ workflows:
           libtorch_variant: "static-without-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
       - binary_linux_build:
-          name: binary_linux_libtorch_2_7m_cu92_gcc5_4_cxx11-abi_nightly_shared-with-deps_build
-          build_environment: "libtorch 2.7m cu92 gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_3_6m_cu92_gcc5_4_cxx11-abi_nightly_shared-with-deps_build
+          build_environment: "libtorch 3.6m cu92 gcc5.4_cxx11-abi"
           requires:
             - setup
           filters:
@@ -4051,8 +3954,8 @@ workflows:
           libtorch_variant: "shared-with-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
       - binary_linux_build:
-          name: binary_linux_libtorch_2_7m_cu92_gcc5_4_cxx11-abi_nightly_shared-without-deps_build
-          build_environment: "libtorch 2.7m cu92 gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_3_6m_cu92_gcc5_4_cxx11-abi_nightly_shared-without-deps_build
+          build_environment: "libtorch 3.6m cu92 gcc5.4_cxx11-abi"
           requires:
             - setup
           filters:
@@ -4063,8 +3966,8 @@ workflows:
           libtorch_variant: "shared-without-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
       - binary_linux_build:
-          name: binary_linux_libtorch_2_7m_cu92_gcc5_4_cxx11-abi_nightly_static-with-deps_build
-          build_environment: "libtorch 2.7m cu92 gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_3_6m_cu92_gcc5_4_cxx11-abi_nightly_static-with-deps_build
+          build_environment: "libtorch 3.6m cu92 gcc5.4_cxx11-abi"
           requires:
             - setup
           filters:
@@ -4075,8 +3978,8 @@ workflows:
           libtorch_variant: "static-with-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
       - binary_linux_build:
-          name: binary_linux_libtorch_2_7m_cu92_gcc5_4_cxx11-abi_nightly_static-without-deps_build
-          build_environment: "libtorch 2.7m cu92 gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_3_6m_cu92_gcc5_4_cxx11-abi_nightly_static-without-deps_build
+          build_environment: "libtorch 3.6m cu92 gcc5.4_cxx11-abi"
           requires:
             - setup
           filters:
@@ -4087,8 +3990,8 @@ workflows:
           libtorch_variant: "static-without-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
       - binary_linux_build:
-          name: binary_linux_libtorch_2_7m_cu101_gcc5_4_cxx11-abi_nightly_shared-with-deps_build
-          build_environment: "libtorch 2.7m cu101 gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_3_6m_cu101_gcc5_4_cxx11-abi_nightly_shared-with-deps_build
+          build_environment: "libtorch 3.6m cu101 gcc5.4_cxx11-abi"
           requires:
             - setup
           filters:
@@ -4099,8 +4002,8 @@ workflows:
           libtorch_variant: "shared-with-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
       - binary_linux_build:
-          name: binary_linux_libtorch_2_7m_cu101_gcc5_4_cxx11-abi_nightly_shared-without-deps_build
-          build_environment: "libtorch 2.7m cu101 gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_3_6m_cu101_gcc5_4_cxx11-abi_nightly_shared-without-deps_build
+          build_environment: "libtorch 3.6m cu101 gcc5.4_cxx11-abi"
           requires:
             - setup
           filters:
@@ -4111,8 +4014,8 @@ workflows:
           libtorch_variant: "shared-without-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
       - binary_linux_build:
-          name: binary_linux_libtorch_2_7m_cu101_gcc5_4_cxx11-abi_nightly_static-with-deps_build
-          build_environment: "libtorch 2.7m cu101 gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_3_6m_cu101_gcc5_4_cxx11-abi_nightly_static-with-deps_build
+          build_environment: "libtorch 3.6m cu101 gcc5.4_cxx11-abi"
           requires:
             - setup
           filters:
@@ -4123,8 +4026,8 @@ workflows:
           libtorch_variant: "static-with-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
       - binary_linux_build:
-          name: binary_linux_libtorch_2_7m_cu101_gcc5_4_cxx11-abi_nightly_static-without-deps_build
-          build_environment: "libtorch 2.7m cu101 gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_3_6m_cu101_gcc5_4_cxx11-abi_nightly_static-without-deps_build
+          build_environment: "libtorch 3.6m cu101 gcc5.4_cxx11-abi"
           requires:
             - setup
           filters:
@@ -4135,8 +4038,8 @@ workflows:
           libtorch_variant: "static-without-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
       - binary_linux_build:
-          name: binary_linux_libtorch_2_7m_cu102_gcc5_4_cxx11-abi_nightly_shared-with-deps_build
-          build_environment: "libtorch 2.7m cu102 gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_3_6m_cu102_gcc5_4_cxx11-abi_nightly_shared-with-deps_build
+          build_environment: "libtorch 3.6m cu102 gcc5.4_cxx11-abi"
           requires:
             - setup
           filters:
@@ -4147,8 +4050,8 @@ workflows:
           libtorch_variant: "shared-with-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
       - binary_linux_build:
-          name: binary_linux_libtorch_2_7m_cu102_gcc5_4_cxx11-abi_nightly_shared-without-deps_build
-          build_environment: "libtorch 2.7m cu102 gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_3_6m_cu102_gcc5_4_cxx11-abi_nightly_shared-without-deps_build
+          build_environment: "libtorch 3.6m cu102 gcc5.4_cxx11-abi"
           requires:
             - setup
           filters:
@@ -4159,8 +4062,8 @@ workflows:
           libtorch_variant: "shared-without-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
       - binary_linux_build:
-          name: binary_linux_libtorch_2_7m_cu102_gcc5_4_cxx11-abi_nightly_static-with-deps_build
-          build_environment: "libtorch 2.7m cu102 gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_3_6m_cu102_gcc5_4_cxx11-abi_nightly_static-with-deps_build
+          build_environment: "libtorch 3.6m cu102 gcc5.4_cxx11-abi"
           requires:
             - setup
           filters:
@@ -4171,8 +4074,8 @@ workflows:
           libtorch_variant: "static-with-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
       - binary_linux_build:
-          name: binary_linux_libtorch_2_7m_cu102_gcc5_4_cxx11-abi_nightly_static-without-deps_build
-          build_environment: "libtorch 2.7m cu102 gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_3_6m_cu102_gcc5_4_cxx11-abi_nightly_static-without-deps_build
+          build_environment: "libtorch 3.6m cu102 gcc5.4_cxx11-abi"
           requires:
             - setup
           filters:
@@ -4263,8 +4166,8 @@ workflows:
             tags:
               only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
       - binary_mac_build:
-          name: binary_macos_libtorch_2_7_cpu_nightly_build
-          build_environment: "libtorch 2.7 cpu"
+          name: binary_macos_libtorch_3_6_cpu_nightly_build
+          build_environment: "libtorch 3.6 cpu"
           requires:
             - setup
           filters:
@@ -4365,18 +4268,6 @@ workflows:
 # Nightly tests
 ##############################################################################
       - binary_linux_test:
-          name: binary_linux_manywheel_3_5m_cpu_devtoolset7_nightly_test
-          build_environment: "manywheel 3.5m cpu devtoolset7"
-          requires:
-            - setup
-            - binary_linux_manywheel_3_5m_cpu_devtoolset7_nightly_build
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          docker_image: "pytorch/manylinux-cuda102"
-      - binary_linux_test:
           name: binary_linux_manywheel_3_6m_cpu_devtoolset7_nightly_test
           build_environment: "manywheel 3.6m cpu devtoolset7"
           requires:
@@ -4412,20 +4303,6 @@ workflows:
             tags:
               only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
           docker_image: "pytorch/manylinux-cuda102"
-      - binary_linux_test:
-          name: binary_linux_manywheel_3_5m_cu92_devtoolset7_nightly_test
-          build_environment: "manywheel 3.5m cu92 devtoolset7"
-          requires:
-            - setup
-            - binary_linux_manywheel_3_5m_cu92_devtoolset7_nightly_build
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          docker_image: "pytorch/manylinux-cuda92"
-          use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
       - binary_linux_test:
           name: binary_linux_manywheel_3_6m_cu92_devtoolset7_nightly_test
           build_environment: "manywheel 3.6m cu92 devtoolset7"
@@ -4469,20 +4346,6 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
-          name: binary_linux_manywheel_3_5m_cu101_devtoolset7_nightly_test
-          build_environment: "manywheel 3.5m cu101 devtoolset7"
-          requires:
-            - setup
-            - binary_linux_manywheel_3_5m_cu101_devtoolset7_nightly_build
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          docker_image: "pytorch/manylinux-cuda101"
-          use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
-      - binary_linux_test:
           name: binary_linux_manywheel_3_6m_cu101_devtoolset7_nightly_test
           build_environment: "manywheel 3.6m cu101 devtoolset7"
           requires:
@@ -4522,20 +4385,6 @@ workflows:
             tags:
               only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
           docker_image: "pytorch/manylinux-cuda101"
-          use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
-      - binary_linux_test:
-          name: binary_linux_manywheel_3_5m_cu102_devtoolset7_nightly_test
-          build_environment: "manywheel 3.5m cu102 devtoolset7"
-          requires:
-            - setup
-            - binary_linux_manywheel_3_5m_cu102_devtoolset7_nightly_build
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          docker_image: "pytorch/manylinux-cuda102"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
@@ -4797,11 +4646,11 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
-          name: binary_linux_libtorch_2_7m_cpu_devtoolset7_nightly_shared-with-deps_test
-          build_environment: "libtorch 2.7m cpu devtoolset7"
+          name: binary_linux_libtorch_3_6m_cpu_devtoolset7_nightly_shared-with-deps_test
+          build_environment: "libtorch 3.6m cpu devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_2_7m_cpu_devtoolset7_nightly_shared-with-deps_build
+            - binary_linux_libtorch_3_6m_cpu_devtoolset7_nightly_shared-with-deps_build
           filters:
             branches:
               only: nightly
@@ -4810,11 +4659,11 @@ workflows:
           libtorch_variant: "shared-with-deps"
           docker_image: "pytorch/manylinux-cuda102"
       - binary_linux_test:
-          name: binary_linux_libtorch_2_7m_cpu_devtoolset7_nightly_shared-without-deps_test
-          build_environment: "libtorch 2.7m cpu devtoolset7"
+          name: binary_linux_libtorch_3_6m_cpu_devtoolset7_nightly_shared-without-deps_test
+          build_environment: "libtorch 3.6m cpu devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_2_7m_cpu_devtoolset7_nightly_shared-without-deps_build
+            - binary_linux_libtorch_3_6m_cpu_devtoolset7_nightly_shared-without-deps_build
           filters:
             branches:
               only: nightly
@@ -4823,11 +4672,11 @@ workflows:
           libtorch_variant: "shared-without-deps"
           docker_image: "pytorch/manylinux-cuda102"
       - binary_linux_test:
-          name: binary_linux_libtorch_2_7m_cpu_devtoolset7_nightly_static-with-deps_test
-          build_environment: "libtorch 2.7m cpu devtoolset7"
+          name: binary_linux_libtorch_3_6m_cpu_devtoolset7_nightly_static-with-deps_test
+          build_environment: "libtorch 3.6m cpu devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_2_7m_cpu_devtoolset7_nightly_static-with-deps_build
+            - binary_linux_libtorch_3_6m_cpu_devtoolset7_nightly_static-with-deps_build
           filters:
             branches:
               only: nightly
@@ -4836,11 +4685,11 @@ workflows:
           libtorch_variant: "static-with-deps"
           docker_image: "pytorch/manylinux-cuda102"
       - binary_linux_test:
-          name: binary_linux_libtorch_2_7m_cpu_devtoolset7_nightly_static-without-deps_test
-          build_environment: "libtorch 2.7m cpu devtoolset7"
+          name: binary_linux_libtorch_3_6m_cpu_devtoolset7_nightly_static-without-deps_test
+          build_environment: "libtorch 3.6m cpu devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_2_7m_cpu_devtoolset7_nightly_static-without-deps_build
+            - binary_linux_libtorch_3_6m_cpu_devtoolset7_nightly_static-without-deps_build
           filters:
             branches:
               only: nightly
@@ -4849,11 +4698,11 @@ workflows:
           libtorch_variant: "static-without-deps"
           docker_image: "pytorch/manylinux-cuda102"
       - binary_linux_test:
-          name: binary_linux_libtorch_2_7m_cu92_devtoolset7_nightly_shared-with-deps_test
-          build_environment: "libtorch 2.7m cu92 devtoolset7"
+          name: binary_linux_libtorch_3_6m_cu92_devtoolset7_nightly_shared-with-deps_test
+          build_environment: "libtorch 3.6m cu92 devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_2_7m_cu92_devtoolset7_nightly_shared-with-deps_build
+            - binary_linux_libtorch_3_6m_cu92_devtoolset7_nightly_shared-with-deps_build
           filters:
             branches:
               only: nightly
@@ -4864,11 +4713,11 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
-          name: binary_linux_libtorch_2_7m_cu92_devtoolset7_nightly_shared-without-deps_test
-          build_environment: "libtorch 2.7m cu92 devtoolset7"
+          name: binary_linux_libtorch_3_6m_cu92_devtoolset7_nightly_shared-without-deps_test
+          build_environment: "libtorch 3.6m cu92 devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_2_7m_cu92_devtoolset7_nightly_shared-without-deps_build
+            - binary_linux_libtorch_3_6m_cu92_devtoolset7_nightly_shared-without-deps_build
           filters:
             branches:
               only: nightly
@@ -4879,11 +4728,11 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
-          name: binary_linux_libtorch_2_7m_cu92_devtoolset7_nightly_static-with-deps_test
-          build_environment: "libtorch 2.7m cu92 devtoolset7"
+          name: binary_linux_libtorch_3_6m_cu92_devtoolset7_nightly_static-with-deps_test
+          build_environment: "libtorch 3.6m cu92 devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_2_7m_cu92_devtoolset7_nightly_static-with-deps_build
+            - binary_linux_libtorch_3_6m_cu92_devtoolset7_nightly_static-with-deps_build
           filters:
             branches:
               only: nightly
@@ -4894,11 +4743,11 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
-          name: binary_linux_libtorch_2_7m_cu92_devtoolset7_nightly_static-without-deps_test
-          build_environment: "libtorch 2.7m cu92 devtoolset7"
+          name: binary_linux_libtorch_3_6m_cu92_devtoolset7_nightly_static-without-deps_test
+          build_environment: "libtorch 3.6m cu92 devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_2_7m_cu92_devtoolset7_nightly_static-without-deps_build
+            - binary_linux_libtorch_3_6m_cu92_devtoolset7_nightly_static-without-deps_build
           filters:
             branches:
               only: nightly
@@ -4909,11 +4758,11 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
-          name: binary_linux_libtorch_2_7m_cu101_devtoolset7_nightly_shared-with-deps_test
-          build_environment: "libtorch 2.7m cu101 devtoolset7"
+          name: binary_linux_libtorch_3_6m_cu101_devtoolset7_nightly_shared-with-deps_test
+          build_environment: "libtorch 3.6m cu101 devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_2_7m_cu101_devtoolset7_nightly_shared-with-deps_build
+            - binary_linux_libtorch_3_6m_cu101_devtoolset7_nightly_shared-with-deps_build
           filters:
             branches:
               only: nightly
@@ -4924,11 +4773,11 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
-          name: binary_linux_libtorch_2_7m_cu101_devtoolset7_nightly_shared-without-deps_test
-          build_environment: "libtorch 2.7m cu101 devtoolset7"
+          name: binary_linux_libtorch_3_6m_cu101_devtoolset7_nightly_shared-without-deps_test
+          build_environment: "libtorch 3.6m cu101 devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_2_7m_cu101_devtoolset7_nightly_shared-without-deps_build
+            - binary_linux_libtorch_3_6m_cu101_devtoolset7_nightly_shared-without-deps_build
           filters:
             branches:
               only: nightly
@@ -4939,11 +4788,11 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
-          name: binary_linux_libtorch_2_7m_cu101_devtoolset7_nightly_static-with-deps_test
-          build_environment: "libtorch 2.7m cu101 devtoolset7"
+          name: binary_linux_libtorch_3_6m_cu101_devtoolset7_nightly_static-with-deps_test
+          build_environment: "libtorch 3.6m cu101 devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_2_7m_cu101_devtoolset7_nightly_static-with-deps_build
+            - binary_linux_libtorch_3_6m_cu101_devtoolset7_nightly_static-with-deps_build
           filters:
             branches:
               only: nightly
@@ -4954,11 +4803,11 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
-          name: binary_linux_libtorch_2_7m_cu101_devtoolset7_nightly_static-without-deps_test
-          build_environment: "libtorch 2.7m cu101 devtoolset7"
+          name: binary_linux_libtorch_3_6m_cu101_devtoolset7_nightly_static-without-deps_test
+          build_environment: "libtorch 3.6m cu101 devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_2_7m_cu101_devtoolset7_nightly_static-without-deps_build
+            - binary_linux_libtorch_3_6m_cu101_devtoolset7_nightly_static-without-deps_build
           filters:
             branches:
               only: nightly
@@ -4969,11 +4818,11 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
-          name: binary_linux_libtorch_2_7m_cu102_devtoolset7_nightly_shared-with-deps_test
-          build_environment: "libtorch 2.7m cu102 devtoolset7"
+          name: binary_linux_libtorch_3_6m_cu102_devtoolset7_nightly_shared-with-deps_test
+          build_environment: "libtorch 3.6m cu102 devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_2_7m_cu102_devtoolset7_nightly_shared-with-deps_build
+            - binary_linux_libtorch_3_6m_cu102_devtoolset7_nightly_shared-with-deps_build
           filters:
             branches:
               only: nightly
@@ -4984,11 +4833,11 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
-          name: binary_linux_libtorch_2_7m_cu102_devtoolset7_nightly_shared-without-deps_test
-          build_environment: "libtorch 2.7m cu102 devtoolset7"
+          name: binary_linux_libtorch_3_6m_cu102_devtoolset7_nightly_shared-without-deps_test
+          build_environment: "libtorch 3.6m cu102 devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_2_7m_cu102_devtoolset7_nightly_shared-without-deps_build
+            - binary_linux_libtorch_3_6m_cu102_devtoolset7_nightly_shared-without-deps_build
           filters:
             branches:
               only: nightly
@@ -4999,11 +4848,11 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
-          name: binary_linux_libtorch_2_7m_cu102_devtoolset7_nightly_static-with-deps_test
-          build_environment: "libtorch 2.7m cu102 devtoolset7"
+          name: binary_linux_libtorch_3_6m_cu102_devtoolset7_nightly_static-with-deps_test
+          build_environment: "libtorch 3.6m cu102 devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_2_7m_cu102_devtoolset7_nightly_static-with-deps_build
+            - binary_linux_libtorch_3_6m_cu102_devtoolset7_nightly_static-with-deps_build
           filters:
             branches:
               only: nightly
@@ -5014,11 +4863,11 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
-          name: binary_linux_libtorch_2_7m_cu102_devtoolset7_nightly_static-without-deps_test
-          build_environment: "libtorch 2.7m cu102 devtoolset7"
+          name: binary_linux_libtorch_3_6m_cu102_devtoolset7_nightly_static-without-deps_test
+          build_environment: "libtorch 3.6m cu102 devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_2_7m_cu102_devtoolset7_nightly_static-without-deps_build
+            - binary_linux_libtorch_3_6m_cu102_devtoolset7_nightly_static-without-deps_build
           filters:
             branches:
               only: nightly
@@ -5029,11 +4878,11 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
-          name: binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_nightly_shared-with-deps_test
-          build_environment: "libtorch 2.7m cpu gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_3_6m_cpu_gcc5_4_cxx11-abi_nightly_shared-with-deps_test
+          build_environment: "libtorch 3.6m cpu gcc5.4_cxx11-abi"
           requires:
             - setup
-            - binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_nightly_shared-with-deps_build
+            - binary_linux_libtorch_3_6m_cpu_gcc5_4_cxx11-abi_nightly_shared-with-deps_build
           filters:
             branches:
               only: nightly
@@ -5042,11 +4891,11 @@ workflows:
           libtorch_variant: "shared-with-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
       - binary_linux_test:
-          name: binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_nightly_shared-without-deps_test
-          build_environment: "libtorch 2.7m cpu gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_3_6m_cpu_gcc5_4_cxx11-abi_nightly_shared-without-deps_test
+          build_environment: "libtorch 3.6m cpu gcc5.4_cxx11-abi"
           requires:
             - setup
-            - binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_nightly_shared-without-deps_build
+            - binary_linux_libtorch_3_6m_cpu_gcc5_4_cxx11-abi_nightly_shared-without-deps_build
           filters:
             branches:
               only: nightly
@@ -5055,11 +4904,11 @@ workflows:
           libtorch_variant: "shared-without-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
       - binary_linux_test:
-          name: binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_nightly_static-with-deps_test
-          build_environment: "libtorch 2.7m cpu gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_3_6m_cpu_gcc5_4_cxx11-abi_nightly_static-with-deps_test
+          build_environment: "libtorch 3.6m cpu gcc5.4_cxx11-abi"
           requires:
             - setup
-            - binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_nightly_static-with-deps_build
+            - binary_linux_libtorch_3_6m_cpu_gcc5_4_cxx11-abi_nightly_static-with-deps_build
           filters:
             branches:
               only: nightly
@@ -5068,11 +4917,11 @@ workflows:
           libtorch_variant: "static-with-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
       - binary_linux_test:
-          name: binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_nightly_static-without-deps_test
-          build_environment: "libtorch 2.7m cpu gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_3_6m_cpu_gcc5_4_cxx11-abi_nightly_static-without-deps_test
+          build_environment: "libtorch 3.6m cpu gcc5.4_cxx11-abi"
           requires:
             - setup
-            - binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_nightly_static-without-deps_build
+            - binary_linux_libtorch_3_6m_cpu_gcc5_4_cxx11-abi_nightly_static-without-deps_build
           filters:
             branches:
               only: nightly
@@ -5081,71 +4930,11 @@ workflows:
           libtorch_variant: "static-without-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
       - binary_linux_test:
-          name: binary_linux_libtorch_2_7m_cu92_gcc5_4_cxx11-abi_nightly_shared-with-deps_test
-          build_environment: "libtorch 2.7m cu92 gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_3_6m_cu92_gcc5_4_cxx11-abi_nightly_shared-with-deps_test
+          build_environment: "libtorch 3.6m cu92 gcc5.4_cxx11-abi"
           requires:
             - setup
-            - binary_linux_libtorch_2_7m_cu92_gcc5_4_cxx11-abi_nightly_shared-with-deps_build
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          libtorch_variant: "shared-with-deps"
-          docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
-          use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
-      - binary_linux_test:
-          name: binary_linux_libtorch_2_7m_cu92_gcc5_4_cxx11-abi_nightly_shared-without-deps_test
-          build_environment: "libtorch 2.7m cu92 gcc5.4_cxx11-abi"
-          requires:
-            - setup
-            - binary_linux_libtorch_2_7m_cu92_gcc5_4_cxx11-abi_nightly_shared-without-deps_build
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          libtorch_variant: "shared-without-deps"
-          docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
-          use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
-      - binary_linux_test:
-          name: binary_linux_libtorch_2_7m_cu92_gcc5_4_cxx11-abi_nightly_static-with-deps_test
-          build_environment: "libtorch 2.7m cu92 gcc5.4_cxx11-abi"
-          requires:
-            - setup
-            - binary_linux_libtorch_2_7m_cu92_gcc5_4_cxx11-abi_nightly_static-with-deps_build
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          libtorch_variant: "static-with-deps"
-          docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
-          use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
-      - binary_linux_test:
-          name: binary_linux_libtorch_2_7m_cu92_gcc5_4_cxx11-abi_nightly_static-without-deps_test
-          build_environment: "libtorch 2.7m cu92 gcc5.4_cxx11-abi"
-          requires:
-            - setup
-            - binary_linux_libtorch_2_7m_cu92_gcc5_4_cxx11-abi_nightly_static-without-deps_build
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          libtorch_variant: "static-without-deps"
-          docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
-          use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
-      - binary_linux_test:
-          name: binary_linux_libtorch_2_7m_cu101_gcc5_4_cxx11-abi_nightly_shared-with-deps_test
-          build_environment: "libtorch 2.7m cu101 gcc5.4_cxx11-abi"
-          requires:
-            - setup
-            - binary_linux_libtorch_2_7m_cu101_gcc5_4_cxx11-abi_nightly_shared-with-deps_build
+            - binary_linux_libtorch_3_6m_cu92_gcc5_4_cxx11-abi_nightly_shared-with-deps_build
           filters:
             branches:
               only: nightly
@@ -5156,11 +4945,11 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
-          name: binary_linux_libtorch_2_7m_cu101_gcc5_4_cxx11-abi_nightly_shared-without-deps_test
-          build_environment: "libtorch 2.7m cu101 gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_3_6m_cu92_gcc5_4_cxx11-abi_nightly_shared-without-deps_test
+          build_environment: "libtorch 3.6m cu92 gcc5.4_cxx11-abi"
           requires:
             - setup
-            - binary_linux_libtorch_2_7m_cu101_gcc5_4_cxx11-abi_nightly_shared-without-deps_build
+            - binary_linux_libtorch_3_6m_cu92_gcc5_4_cxx11-abi_nightly_shared-without-deps_build
           filters:
             branches:
               only: nightly
@@ -5171,11 +4960,11 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
-          name: binary_linux_libtorch_2_7m_cu101_gcc5_4_cxx11-abi_nightly_static-with-deps_test
-          build_environment: "libtorch 2.7m cu101 gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_3_6m_cu92_gcc5_4_cxx11-abi_nightly_static-with-deps_test
+          build_environment: "libtorch 3.6m cu92 gcc5.4_cxx11-abi"
           requires:
             - setup
-            - binary_linux_libtorch_2_7m_cu101_gcc5_4_cxx11-abi_nightly_static-with-deps_build
+            - binary_linux_libtorch_3_6m_cu92_gcc5_4_cxx11-abi_nightly_static-with-deps_build
           filters:
             branches:
               only: nightly
@@ -5186,11 +4975,11 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
-          name: binary_linux_libtorch_2_7m_cu101_gcc5_4_cxx11-abi_nightly_static-without-deps_test
-          build_environment: "libtorch 2.7m cu101 gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_3_6m_cu92_gcc5_4_cxx11-abi_nightly_static-without-deps_test
+          build_environment: "libtorch 3.6m cu92 gcc5.4_cxx11-abi"
           requires:
             - setup
-            - binary_linux_libtorch_2_7m_cu101_gcc5_4_cxx11-abi_nightly_static-without-deps_build
+            - binary_linux_libtorch_3_6m_cu92_gcc5_4_cxx11-abi_nightly_static-without-deps_build
           filters:
             branches:
               only: nightly
@@ -5201,11 +4990,11 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
-          name: binary_linux_libtorch_2_7m_cu102_gcc5_4_cxx11-abi_nightly_shared-with-deps_test
-          build_environment: "libtorch 2.7m cu102 gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_3_6m_cu101_gcc5_4_cxx11-abi_nightly_shared-with-deps_test
+          build_environment: "libtorch 3.6m cu101 gcc5.4_cxx11-abi"
           requires:
             - setup
-            - binary_linux_libtorch_2_7m_cu102_gcc5_4_cxx11-abi_nightly_shared-with-deps_build
+            - binary_linux_libtorch_3_6m_cu101_gcc5_4_cxx11-abi_nightly_shared-with-deps_build
           filters:
             branches:
               only: nightly
@@ -5216,11 +5005,11 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
-          name: binary_linux_libtorch_2_7m_cu102_gcc5_4_cxx11-abi_nightly_shared-without-deps_test
-          build_environment: "libtorch 2.7m cu102 gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_3_6m_cu101_gcc5_4_cxx11-abi_nightly_shared-without-deps_test
+          build_environment: "libtorch 3.6m cu101 gcc5.4_cxx11-abi"
           requires:
             - setup
-            - binary_linux_libtorch_2_7m_cu102_gcc5_4_cxx11-abi_nightly_shared-without-deps_build
+            - binary_linux_libtorch_3_6m_cu101_gcc5_4_cxx11-abi_nightly_shared-without-deps_build
           filters:
             branches:
               only: nightly
@@ -5231,11 +5020,11 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
-          name: binary_linux_libtorch_2_7m_cu102_gcc5_4_cxx11-abi_nightly_static-with-deps_test
-          build_environment: "libtorch 2.7m cu102 gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_3_6m_cu101_gcc5_4_cxx11-abi_nightly_static-with-deps_test
+          build_environment: "libtorch 3.6m cu101 gcc5.4_cxx11-abi"
           requires:
             - setup
-            - binary_linux_libtorch_2_7m_cu102_gcc5_4_cxx11-abi_nightly_static-with-deps_build
+            - binary_linux_libtorch_3_6m_cu101_gcc5_4_cxx11-abi_nightly_static-with-deps_build
           filters:
             branches:
               only: nightly
@@ -5246,11 +5035,11 @@ workflows:
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - binary_linux_test:
-          name: binary_linux_libtorch_2_7m_cu102_gcc5_4_cxx11-abi_nightly_static-without-deps_test
-          build_environment: "libtorch 2.7m cu102 gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_3_6m_cu101_gcc5_4_cxx11-abi_nightly_static-without-deps_test
+          build_environment: "libtorch 3.6m cu101 gcc5.4_cxx11-abi"
           requires:
             - setup
-            - binary_linux_libtorch_2_7m_cu102_gcc5_4_cxx11-abi_nightly_static-without-deps_build
+            - binary_linux_libtorch_3_6m_cu101_gcc5_4_cxx11-abi_nightly_static-without-deps_build
           filters:
             branches:
               only: nightly
@@ -5260,26 +5049,74 @@ workflows:
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
-      #- binary_linux_libtorch_2.7m_cpu_test:
+      - binary_linux_test:
+          name: binary_linux_libtorch_3_6m_cu102_gcc5_4_cxx11-abi_nightly_shared-with-deps_test
+          build_environment: "libtorch 3.6m cu102 gcc5.4_cxx11-abi"
+          requires:
+            - setup
+            - binary_linux_libtorch_3_6m_cu102_gcc5_4_cxx11-abi_nightly_shared-with-deps_build
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          libtorch_variant: "shared-with-deps"
+          docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
+          use_cuda_docker_runtime: "1"
+          resource_class: gpu.medium
+      - binary_linux_test:
+          name: binary_linux_libtorch_3_6m_cu102_gcc5_4_cxx11-abi_nightly_shared-without-deps_test
+          build_environment: "libtorch 3.6m cu102 gcc5.4_cxx11-abi"
+          requires:
+            - setup
+            - binary_linux_libtorch_3_6m_cu102_gcc5_4_cxx11-abi_nightly_shared-without-deps_build
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          libtorch_variant: "shared-without-deps"
+          docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
+          use_cuda_docker_runtime: "1"
+          resource_class: gpu.medium
+      - binary_linux_test:
+          name: binary_linux_libtorch_3_6m_cu102_gcc5_4_cxx11-abi_nightly_static-with-deps_test
+          build_environment: "libtorch 3.6m cu102 gcc5.4_cxx11-abi"
+          requires:
+            - setup
+            - binary_linux_libtorch_3_6m_cu102_gcc5_4_cxx11-abi_nightly_static-with-deps_build
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          libtorch_variant: "static-with-deps"
+          docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
+          use_cuda_docker_runtime: "1"
+          resource_class: gpu.medium
+      - binary_linux_test:
+          name: binary_linux_libtorch_3_6m_cu102_gcc5_4_cxx11-abi_nightly_static-without-deps_test
+          build_environment: "libtorch 3.6m cu102 gcc5.4_cxx11-abi"
+          requires:
+            - setup
+            - binary_linux_libtorch_3_6m_cu102_gcc5_4_cxx11-abi_nightly_static-without-deps_build
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          libtorch_variant: "static-without-deps"
+          docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
+          use_cuda_docker_runtime: "1"
+          resource_class: gpu.medium
+      #- binary_linux_libtorch_3.6m_cpu_test:
       #    requires:
-      #      - binary_linux_libtorch_2.7m_cpu_build
-      #- binary_linux_libtorch_2.7m_cu90_test:
+      #      - binary_linux_libtorch_3.6m_cpu_build
+      #- binary_linux_libtorch_3.6m_cu90_test:
       #    requires:
-      #      - binary_linux_libtorch_2.7m_cu90_build
+      #      - binary_linux_libtorch_3.6m_cu90_build
 
       # Nightly uploads
-      - binary_linux_upload:
-          name: binary_linux_manywheel_3_5m_cpu_devtoolset7_nightly_upload
-          build_environment: "manywheel 3.5m cpu devtoolset7"
-          requires:
-            - setup
-            - binary_linux_manywheel_3_5m_cpu_devtoolset7_nightly_test
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          context: org-member
       - binary_linux_upload:
           name: binary_linux_manywheel_3_6m_cpu_devtoolset7_nightly_upload
           build_environment: "manywheel 3.6m cpu devtoolset7"
@@ -5310,18 +5147,6 @@ workflows:
           requires:
             - setup
             - binary_linux_manywheel_3_8m_cpu_devtoolset7_nightly_test
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          context: org-member
-      - binary_linux_upload:
-          name: binary_linux_manywheel_3_5m_cu92_devtoolset7_nightly_upload
-          build_environment: "manywheel 3.5m cu92 devtoolset7"
-          requires:
-            - setup
-            - binary_linux_manywheel_3_5m_cu92_devtoolset7_nightly_test
           filters:
             branches:
               only: nightly
@@ -5365,18 +5190,6 @@ workflows:
               only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_manywheel_3_5m_cu101_devtoolset7_nightly_upload
-          build_environment: "manywheel 3.5m cu101 devtoolset7"
-          requires:
-            - setup
-            - binary_linux_manywheel_3_5m_cu101_devtoolset7_nightly_test
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          context: org-member
-      - binary_linux_upload:
           name: binary_linux_manywheel_3_6m_cu101_devtoolset7_nightly_upload
           build_environment: "manywheel 3.6m cu101 devtoolset7"
           requires:
@@ -5406,18 +5219,6 @@ workflows:
           requires:
             - setup
             - binary_linux_manywheel_3_8m_cu101_devtoolset7_nightly_test
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          context: org-member
-      - binary_linux_upload:
-          name: binary_linux_manywheel_3_5m_cu102_devtoolset7_nightly_upload
-          build_environment: "manywheel 3.5m cu102 devtoolset7"
-          requires:
-            - setup
-            - binary_linux_manywheel_3_5m_cu102_devtoolset7_nightly_test
           filters:
             branches:
               only: nightly
@@ -5653,11 +5454,11 @@ workflows:
               only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_libtorch_2_7m_cpu_devtoolset7_nightly_shared-with-deps_upload
-          build_environment: "libtorch 2.7m cpu devtoolset7"
+          name: binary_linux_libtorch_3_6m_cpu_devtoolset7_nightly_shared-with-deps_upload
+          build_environment: "libtorch 3.6m cpu devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_2_7m_cpu_devtoolset7_nightly_shared-with-deps_test
+            - binary_linux_libtorch_3_6m_cpu_devtoolset7_nightly_shared-with-deps_test
           filters:
             branches:
               only: nightly
@@ -5666,11 +5467,11 @@ workflows:
           libtorch_variant: "shared-with-deps"
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_libtorch_2_7m_cpu_devtoolset7_nightly_shared-without-deps_upload
-          build_environment: "libtorch 2.7m cpu devtoolset7"
+          name: binary_linux_libtorch_3_6m_cpu_devtoolset7_nightly_shared-without-deps_upload
+          build_environment: "libtorch 3.6m cpu devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_2_7m_cpu_devtoolset7_nightly_shared-without-deps_test
+            - binary_linux_libtorch_3_6m_cpu_devtoolset7_nightly_shared-without-deps_test
           filters:
             branches:
               only: nightly
@@ -5679,11 +5480,11 @@ workflows:
           libtorch_variant: "shared-without-deps"
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_libtorch_2_7m_cpu_devtoolset7_nightly_static-with-deps_upload
-          build_environment: "libtorch 2.7m cpu devtoolset7"
+          name: binary_linux_libtorch_3_6m_cpu_devtoolset7_nightly_static-with-deps_upload
+          build_environment: "libtorch 3.6m cpu devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_2_7m_cpu_devtoolset7_nightly_static-with-deps_test
+            - binary_linux_libtorch_3_6m_cpu_devtoolset7_nightly_static-with-deps_test
           filters:
             branches:
               only: nightly
@@ -5692,11 +5493,11 @@ workflows:
           libtorch_variant: "static-with-deps"
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_libtorch_2_7m_cpu_devtoolset7_nightly_static-without-deps_upload
-          build_environment: "libtorch 2.7m cpu devtoolset7"
+          name: binary_linux_libtorch_3_6m_cpu_devtoolset7_nightly_static-without-deps_upload
+          build_environment: "libtorch 3.6m cpu devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_2_7m_cpu_devtoolset7_nightly_static-without-deps_test
+            - binary_linux_libtorch_3_6m_cpu_devtoolset7_nightly_static-without-deps_test
           filters:
             branches:
               only: nightly
@@ -5705,11 +5506,11 @@ workflows:
           libtorch_variant: "static-without-deps"
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_libtorch_2_7m_cu92_devtoolset7_nightly_shared-with-deps_upload
-          build_environment: "libtorch 2.7m cu92 devtoolset7"
+          name: binary_linux_libtorch_3_6m_cu92_devtoolset7_nightly_shared-with-deps_upload
+          build_environment: "libtorch 3.6m cu92 devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_2_7m_cu92_devtoolset7_nightly_shared-with-deps_test
+            - binary_linux_libtorch_3_6m_cu92_devtoolset7_nightly_shared-with-deps_test
           filters:
             branches:
               only: nightly
@@ -5718,11 +5519,11 @@ workflows:
           libtorch_variant: "shared-with-deps"
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_libtorch_2_7m_cu92_devtoolset7_nightly_shared-without-deps_upload
-          build_environment: "libtorch 2.7m cu92 devtoolset7"
+          name: binary_linux_libtorch_3_6m_cu92_devtoolset7_nightly_shared-without-deps_upload
+          build_environment: "libtorch 3.6m cu92 devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_2_7m_cu92_devtoolset7_nightly_shared-without-deps_test
+            - binary_linux_libtorch_3_6m_cu92_devtoolset7_nightly_shared-without-deps_test
           filters:
             branches:
               only: nightly
@@ -5731,11 +5532,11 @@ workflows:
           libtorch_variant: "shared-without-deps"
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_libtorch_2_7m_cu92_devtoolset7_nightly_static-with-deps_upload
-          build_environment: "libtorch 2.7m cu92 devtoolset7"
+          name: binary_linux_libtorch_3_6m_cu92_devtoolset7_nightly_static-with-deps_upload
+          build_environment: "libtorch 3.6m cu92 devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_2_7m_cu92_devtoolset7_nightly_static-with-deps_test
+            - binary_linux_libtorch_3_6m_cu92_devtoolset7_nightly_static-with-deps_test
           filters:
             branches:
               only: nightly
@@ -5744,11 +5545,11 @@ workflows:
           libtorch_variant: "static-with-deps"
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_libtorch_2_7m_cu92_devtoolset7_nightly_static-without-deps_upload
-          build_environment: "libtorch 2.7m cu92 devtoolset7"
+          name: binary_linux_libtorch_3_6m_cu92_devtoolset7_nightly_static-without-deps_upload
+          build_environment: "libtorch 3.6m cu92 devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_2_7m_cu92_devtoolset7_nightly_static-without-deps_test
+            - binary_linux_libtorch_3_6m_cu92_devtoolset7_nightly_static-without-deps_test
           filters:
             branches:
               only: nightly
@@ -5757,11 +5558,11 @@ workflows:
           libtorch_variant: "static-without-deps"
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_libtorch_2_7m_cu101_devtoolset7_nightly_shared-with-deps_upload
-          build_environment: "libtorch 2.7m cu101 devtoolset7"
+          name: binary_linux_libtorch_3_6m_cu101_devtoolset7_nightly_shared-with-deps_upload
+          build_environment: "libtorch 3.6m cu101 devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_2_7m_cu101_devtoolset7_nightly_shared-with-deps_test
+            - binary_linux_libtorch_3_6m_cu101_devtoolset7_nightly_shared-with-deps_test
           filters:
             branches:
               only: nightly
@@ -5770,11 +5571,11 @@ workflows:
           libtorch_variant: "shared-with-deps"
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_libtorch_2_7m_cu101_devtoolset7_nightly_shared-without-deps_upload
-          build_environment: "libtorch 2.7m cu101 devtoolset7"
+          name: binary_linux_libtorch_3_6m_cu101_devtoolset7_nightly_shared-without-deps_upload
+          build_environment: "libtorch 3.6m cu101 devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_2_7m_cu101_devtoolset7_nightly_shared-without-deps_test
+            - binary_linux_libtorch_3_6m_cu101_devtoolset7_nightly_shared-without-deps_test
           filters:
             branches:
               only: nightly
@@ -5783,11 +5584,11 @@ workflows:
           libtorch_variant: "shared-without-deps"
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_libtorch_2_7m_cu101_devtoolset7_nightly_static-with-deps_upload
-          build_environment: "libtorch 2.7m cu101 devtoolset7"
+          name: binary_linux_libtorch_3_6m_cu101_devtoolset7_nightly_static-with-deps_upload
+          build_environment: "libtorch 3.6m cu101 devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_2_7m_cu101_devtoolset7_nightly_static-with-deps_test
+            - binary_linux_libtorch_3_6m_cu101_devtoolset7_nightly_static-with-deps_test
           filters:
             branches:
               only: nightly
@@ -5796,11 +5597,11 @@ workflows:
           libtorch_variant: "static-with-deps"
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_libtorch_2_7m_cu101_devtoolset7_nightly_static-without-deps_upload
-          build_environment: "libtorch 2.7m cu101 devtoolset7"
+          name: binary_linux_libtorch_3_6m_cu101_devtoolset7_nightly_static-without-deps_upload
+          build_environment: "libtorch 3.6m cu101 devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_2_7m_cu101_devtoolset7_nightly_static-without-deps_test
+            - binary_linux_libtorch_3_6m_cu101_devtoolset7_nightly_static-without-deps_test
           filters:
             branches:
               only: nightly
@@ -5809,11 +5610,11 @@ workflows:
           libtorch_variant: "static-without-deps"
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_libtorch_2_7m_cu102_devtoolset7_nightly_shared-with-deps_upload
-          build_environment: "libtorch 2.7m cu102 devtoolset7"
+          name: binary_linux_libtorch_3_6m_cu102_devtoolset7_nightly_shared-with-deps_upload
+          build_environment: "libtorch 3.6m cu102 devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_2_7m_cu102_devtoolset7_nightly_shared-with-deps_test
+            - binary_linux_libtorch_3_6m_cu102_devtoolset7_nightly_shared-with-deps_test
           filters:
             branches:
               only: nightly
@@ -5822,11 +5623,11 @@ workflows:
           libtorch_variant: "shared-with-deps"
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_libtorch_2_7m_cu102_devtoolset7_nightly_shared-without-deps_upload
-          build_environment: "libtorch 2.7m cu102 devtoolset7"
+          name: binary_linux_libtorch_3_6m_cu102_devtoolset7_nightly_shared-without-deps_upload
+          build_environment: "libtorch 3.6m cu102 devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_2_7m_cu102_devtoolset7_nightly_shared-without-deps_test
+            - binary_linux_libtorch_3_6m_cu102_devtoolset7_nightly_shared-without-deps_test
           filters:
             branches:
               only: nightly
@@ -5835,11 +5636,11 @@ workflows:
           libtorch_variant: "shared-without-deps"
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_libtorch_2_7m_cu102_devtoolset7_nightly_static-with-deps_upload
-          build_environment: "libtorch 2.7m cu102 devtoolset7"
+          name: binary_linux_libtorch_3_6m_cu102_devtoolset7_nightly_static-with-deps_upload
+          build_environment: "libtorch 3.6m cu102 devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_2_7m_cu102_devtoolset7_nightly_static-with-deps_test
+            - binary_linux_libtorch_3_6m_cu102_devtoolset7_nightly_static-with-deps_test
           filters:
             branches:
               only: nightly
@@ -5848,11 +5649,11 @@ workflows:
           libtorch_variant: "static-with-deps"
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_libtorch_2_7m_cu102_devtoolset7_nightly_static-without-deps_upload
-          build_environment: "libtorch 2.7m cu102 devtoolset7"
+          name: binary_linux_libtorch_3_6m_cu102_devtoolset7_nightly_static-without-deps_upload
+          build_environment: "libtorch 3.6m cu102 devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_2_7m_cu102_devtoolset7_nightly_static-without-deps_test
+            - binary_linux_libtorch_3_6m_cu102_devtoolset7_nightly_static-without-deps_test
           filters:
             branches:
               only: nightly
@@ -5861,11 +5662,11 @@ workflows:
           libtorch_variant: "static-without-deps"
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_nightly_shared-with-deps_upload
-          build_environment: "libtorch 2.7m cpu gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_3_6m_cpu_gcc5_4_cxx11-abi_nightly_shared-with-deps_upload
+          build_environment: "libtorch 3.6m cpu gcc5.4_cxx11-abi"
           requires:
             - setup
-            - binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_nightly_shared-with-deps_test
+            - binary_linux_libtorch_3_6m_cpu_gcc5_4_cxx11-abi_nightly_shared-with-deps_test
           filters:
             branches:
               only: nightly
@@ -5874,11 +5675,11 @@ workflows:
           libtorch_variant: "shared-with-deps"
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_nightly_shared-without-deps_upload
-          build_environment: "libtorch 2.7m cpu gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_3_6m_cpu_gcc5_4_cxx11-abi_nightly_shared-without-deps_upload
+          build_environment: "libtorch 3.6m cpu gcc5.4_cxx11-abi"
           requires:
             - setup
-            - binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_nightly_shared-without-deps_test
+            - binary_linux_libtorch_3_6m_cpu_gcc5_4_cxx11-abi_nightly_shared-without-deps_test
           filters:
             branches:
               only: nightly
@@ -5887,11 +5688,11 @@ workflows:
           libtorch_variant: "shared-without-deps"
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_nightly_static-with-deps_upload
-          build_environment: "libtorch 2.7m cpu gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_3_6m_cpu_gcc5_4_cxx11-abi_nightly_static-with-deps_upload
+          build_environment: "libtorch 3.6m cpu gcc5.4_cxx11-abi"
           requires:
             - setup
-            - binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_nightly_static-with-deps_test
+            - binary_linux_libtorch_3_6m_cpu_gcc5_4_cxx11-abi_nightly_static-with-deps_test
           filters:
             branches:
               only: nightly
@@ -5900,11 +5701,11 @@ workflows:
           libtorch_variant: "static-with-deps"
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_nightly_static-without-deps_upload
-          build_environment: "libtorch 2.7m cpu gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_3_6m_cpu_gcc5_4_cxx11-abi_nightly_static-without-deps_upload
+          build_environment: "libtorch 3.6m cpu gcc5.4_cxx11-abi"
           requires:
             - setup
-            - binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_nightly_static-without-deps_test
+            - binary_linux_libtorch_3_6m_cpu_gcc5_4_cxx11-abi_nightly_static-without-deps_test
           filters:
             branches:
               only: nightly
@@ -5913,11 +5714,11 @@ workflows:
           libtorch_variant: "static-without-deps"
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_libtorch_2_7m_cu92_gcc5_4_cxx11-abi_nightly_shared-with-deps_upload
-          build_environment: "libtorch 2.7m cu92 gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_3_6m_cu92_gcc5_4_cxx11-abi_nightly_shared-with-deps_upload
+          build_environment: "libtorch 3.6m cu92 gcc5.4_cxx11-abi"
           requires:
             - setup
-            - binary_linux_libtorch_2_7m_cu92_gcc5_4_cxx11-abi_nightly_shared-with-deps_test
+            - binary_linux_libtorch_3_6m_cu92_gcc5_4_cxx11-abi_nightly_shared-with-deps_test
           filters:
             branches:
               only: nightly
@@ -5926,11 +5727,11 @@ workflows:
           libtorch_variant: "shared-with-deps"
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_libtorch_2_7m_cu92_gcc5_4_cxx11-abi_nightly_shared-without-deps_upload
-          build_environment: "libtorch 2.7m cu92 gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_3_6m_cu92_gcc5_4_cxx11-abi_nightly_shared-without-deps_upload
+          build_environment: "libtorch 3.6m cu92 gcc5.4_cxx11-abi"
           requires:
             - setup
-            - binary_linux_libtorch_2_7m_cu92_gcc5_4_cxx11-abi_nightly_shared-without-deps_test
+            - binary_linux_libtorch_3_6m_cu92_gcc5_4_cxx11-abi_nightly_shared-without-deps_test
           filters:
             branches:
               only: nightly
@@ -5939,11 +5740,11 @@ workflows:
           libtorch_variant: "shared-without-deps"
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_libtorch_2_7m_cu92_gcc5_4_cxx11-abi_nightly_static-with-deps_upload
-          build_environment: "libtorch 2.7m cu92 gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_3_6m_cu92_gcc5_4_cxx11-abi_nightly_static-with-deps_upload
+          build_environment: "libtorch 3.6m cu92 gcc5.4_cxx11-abi"
           requires:
             - setup
-            - binary_linux_libtorch_2_7m_cu92_gcc5_4_cxx11-abi_nightly_static-with-deps_test
+            - binary_linux_libtorch_3_6m_cu92_gcc5_4_cxx11-abi_nightly_static-with-deps_test
           filters:
             branches:
               only: nightly
@@ -5952,11 +5753,11 @@ workflows:
           libtorch_variant: "static-with-deps"
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_libtorch_2_7m_cu92_gcc5_4_cxx11-abi_nightly_static-without-deps_upload
-          build_environment: "libtorch 2.7m cu92 gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_3_6m_cu92_gcc5_4_cxx11-abi_nightly_static-without-deps_upload
+          build_environment: "libtorch 3.6m cu92 gcc5.4_cxx11-abi"
           requires:
             - setup
-            - binary_linux_libtorch_2_7m_cu92_gcc5_4_cxx11-abi_nightly_static-without-deps_test
+            - binary_linux_libtorch_3_6m_cu92_gcc5_4_cxx11-abi_nightly_static-without-deps_test
           filters:
             branches:
               only: nightly
@@ -5965,11 +5766,11 @@ workflows:
           libtorch_variant: "static-without-deps"
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_libtorch_2_7m_cu101_gcc5_4_cxx11-abi_nightly_shared-with-deps_upload
-          build_environment: "libtorch 2.7m cu101 gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_3_6m_cu101_gcc5_4_cxx11-abi_nightly_shared-with-deps_upload
+          build_environment: "libtorch 3.6m cu101 gcc5.4_cxx11-abi"
           requires:
             - setup
-            - binary_linux_libtorch_2_7m_cu101_gcc5_4_cxx11-abi_nightly_shared-with-deps_test
+            - binary_linux_libtorch_3_6m_cu101_gcc5_4_cxx11-abi_nightly_shared-with-deps_test
           filters:
             branches:
               only: nightly
@@ -5978,11 +5779,11 @@ workflows:
           libtorch_variant: "shared-with-deps"
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_libtorch_2_7m_cu101_gcc5_4_cxx11-abi_nightly_shared-without-deps_upload
-          build_environment: "libtorch 2.7m cu101 gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_3_6m_cu101_gcc5_4_cxx11-abi_nightly_shared-without-deps_upload
+          build_environment: "libtorch 3.6m cu101 gcc5.4_cxx11-abi"
           requires:
             - setup
-            - binary_linux_libtorch_2_7m_cu101_gcc5_4_cxx11-abi_nightly_shared-without-deps_test
+            - binary_linux_libtorch_3_6m_cu101_gcc5_4_cxx11-abi_nightly_shared-without-deps_test
           filters:
             branches:
               only: nightly
@@ -5991,11 +5792,11 @@ workflows:
           libtorch_variant: "shared-without-deps"
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_libtorch_2_7m_cu101_gcc5_4_cxx11-abi_nightly_static-with-deps_upload
-          build_environment: "libtorch 2.7m cu101 gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_3_6m_cu101_gcc5_4_cxx11-abi_nightly_static-with-deps_upload
+          build_environment: "libtorch 3.6m cu101 gcc5.4_cxx11-abi"
           requires:
             - setup
-            - binary_linux_libtorch_2_7m_cu101_gcc5_4_cxx11-abi_nightly_static-with-deps_test
+            - binary_linux_libtorch_3_6m_cu101_gcc5_4_cxx11-abi_nightly_static-with-deps_test
           filters:
             branches:
               only: nightly
@@ -6004,11 +5805,11 @@ workflows:
           libtorch_variant: "static-with-deps"
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_libtorch_2_7m_cu101_gcc5_4_cxx11-abi_nightly_static-without-deps_upload
-          build_environment: "libtorch 2.7m cu101 gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_3_6m_cu101_gcc5_4_cxx11-abi_nightly_static-without-deps_upload
+          build_environment: "libtorch 3.6m cu101 gcc5.4_cxx11-abi"
           requires:
             - setup
-            - binary_linux_libtorch_2_7m_cu101_gcc5_4_cxx11-abi_nightly_static-without-deps_test
+            - binary_linux_libtorch_3_6m_cu101_gcc5_4_cxx11-abi_nightly_static-without-deps_test
           filters:
             branches:
               only: nightly
@@ -6017,11 +5818,11 @@ workflows:
           libtorch_variant: "static-without-deps"
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_libtorch_2_7m_cu102_gcc5_4_cxx11-abi_nightly_shared-with-deps_upload
-          build_environment: "libtorch 2.7m cu102 gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_3_6m_cu102_gcc5_4_cxx11-abi_nightly_shared-with-deps_upload
+          build_environment: "libtorch 3.6m cu102 gcc5.4_cxx11-abi"
           requires:
             - setup
-            - binary_linux_libtorch_2_7m_cu102_gcc5_4_cxx11-abi_nightly_shared-with-deps_test
+            - binary_linux_libtorch_3_6m_cu102_gcc5_4_cxx11-abi_nightly_shared-with-deps_test
           filters:
             branches:
               only: nightly
@@ -6030,11 +5831,11 @@ workflows:
           libtorch_variant: "shared-with-deps"
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_libtorch_2_7m_cu102_gcc5_4_cxx11-abi_nightly_shared-without-deps_upload
-          build_environment: "libtorch 2.7m cu102 gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_3_6m_cu102_gcc5_4_cxx11-abi_nightly_shared-without-deps_upload
+          build_environment: "libtorch 3.6m cu102 gcc5.4_cxx11-abi"
           requires:
             - setup
-            - binary_linux_libtorch_2_7m_cu102_gcc5_4_cxx11-abi_nightly_shared-without-deps_test
+            - binary_linux_libtorch_3_6m_cu102_gcc5_4_cxx11-abi_nightly_shared-without-deps_test
           filters:
             branches:
               only: nightly
@@ -6043,11 +5844,11 @@ workflows:
           libtorch_variant: "shared-without-deps"
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_libtorch_2_7m_cu102_gcc5_4_cxx11-abi_nightly_static-with-deps_upload
-          build_environment: "libtorch 2.7m cu102 gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_3_6m_cu102_gcc5_4_cxx11-abi_nightly_static-with-deps_upload
+          build_environment: "libtorch 3.6m cu102 gcc5.4_cxx11-abi"
           requires:
             - setup
-            - binary_linux_libtorch_2_7m_cu102_gcc5_4_cxx11-abi_nightly_static-with-deps_test
+            - binary_linux_libtorch_3_6m_cu102_gcc5_4_cxx11-abi_nightly_static-with-deps_test
           filters:
             branches:
               only: nightly
@@ -6056,11 +5857,11 @@ workflows:
           libtorch_variant: "static-with-deps"
           context: org-member
       - binary_linux_upload:
-          name: binary_linux_libtorch_2_7m_cu102_gcc5_4_cxx11-abi_nightly_static-without-deps_upload
-          build_environment: "libtorch 2.7m cu102 gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_3_6m_cu102_gcc5_4_cxx11-abi_nightly_static-without-deps_upload
+          build_environment: "libtorch 3.6m cu102 gcc5.4_cxx11-abi"
           requires:
             - setup
-            - binary_linux_libtorch_2_7m_cu102_gcc5_4_cxx11-abi_nightly_static-without-deps_test
+            - binary_linux_libtorch_3_6m_cu102_gcc5_4_cxx11-abi_nightly_static-without-deps_test
           filters:
             branches:
               only: nightly
@@ -6165,11 +5966,11 @@ workflows:
               only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
           context: org-member
       - binary_mac_upload:
-          name: binary_macos_libtorch_2_7_cpu_nightly_upload
-          build_environment: "libtorch 2.7 cpu"
+          name: binary_macos_libtorch_3_6_cpu_nightly_upload
+          build_environment: "libtorch 3.6 cpu"
           requires:
             - setup
-            - binary_macos_libtorch_2_7_cpu_nightly_build
+            - binary_macos_libtorch_3_6_cpu_nightly_build
           filters:
             branches:
               only: nightly

--- a/.circleci/docker/build.sh
+++ b/.circleci/docker/build.sh
@@ -41,18 +41,6 @@ case "$image" in
     LLVMDEV=yes
     PROTOBUF=yes
     ;;
-  pytorch-linux-xenial-py2.7.9)
-    TRAVIS_PYTHON_VERSION=2.7.9
-    GCC_VERSION=7
-    # Do not install PROTOBUF, DB, and VISION as a test
-    ;;
-  pytorch-linux-xenial-py2.7)
-    TRAVIS_PYTHON_VERSION=2.7
-    GCC_VERSION=7
-    PROTOBUF=yes
-    DB=yes
-    VISION=yes
-    ;;
   pytorch-linux-xenial-py3.8)
     # TODO: This is a hack, get rid of this as soon as you get rid of the travis downloads
     TRAVIS_DL_URL_PREFIX="https://s3.amazonaws.com/travis-python-archives/binaries/ubuntu/16.04/x86_64"
@@ -90,14 +78,6 @@ case "$image" in
   pytorch-linux-xenial-pynightly)
     TRAVIS_PYTHON_VERSION=nightly
     GCC_VERSION=7
-    PROTOBUF=yes
-    DB=yes
-    VISION=yes
-    ;;
-  pytorch-linux-xenial-cuda9-cudnn7-py2)
-    CUDA_VERSION=9.0
-    CUDNN_VERSION=7
-    ANACONDA_PYTHON_VERSION=2.7
     PROTOBUF=yes
     DB=yes
     VISION=yes

--- a/.circleci/scripts/binary_linux_test.sh
+++ b/.circleci/scripts/binary_linux_test.sh
@@ -9,8 +9,6 @@ set -eux -o pipefail
 if [[ "$PACKAGE_TYPE" == conda ]]; then
   retry conda create -qyn testenv python="$DESIRED_PYTHON"
   source activate testenv >/dev/null
-elif [[ "$DESIRED_PYTHON" == 2.7mu ]]; then
-  export PATH="/opt/python/cp27-cp27mu/bin:\$PATH"
 elif [[ "$PACKAGE_TYPE" != libtorch ]]; then
   python_nodot="\$(echo $DESIRED_PYTHON | tr -d m.u)"
   python_path="/opt/python/cp\$python_nodot-cp\${python_nodot}"

--- a/.circleci/verbatim-sources/binary-build-tests.yml
+++ b/.circleci/verbatim-sources/binary-build-tests.yml
@@ -1,14 +1,14 @@
 
 # There is currently no testing for libtorch TODO
-#  binary_linux_libtorch_2.7m_cpu_test:
+#  binary_linux_libtorch_3.6m_cpu_test:
 #    environment:
-#      BUILD_ENVIRONMENT: "libtorch 2.7m cpu"
+#      BUILD_ENVIRONMENT: "libtorch 3.6m cpu"
 #    resource_class: gpu.medium
 #    <<: *binary_linux_test
 #
-#  binary_linux_libtorch_2.7m_cu90_test:
+#  binary_linux_libtorch_3.6m_cu90_test:
 #    environment:
-#      BUILD_ENVIRONMENT: "libtorch 2.7m cu90"
+#      BUILD_ENVIRONMENT: "libtorch 3.6m cu90"
 #    resource_class: gpu.medium
 #    <<: *binary_linux_test
 #

--- a/.circleci/verbatim-sources/workflows-binary-builds-smoke-subset.yml
+++ b/.circleci/verbatim-sources/workflows-binary-builds-smoke-subset.yml
@@ -19,23 +19,22 @@
                 - master
       # This binary build is currently broken, see https://github_com/pytorch/pytorch/issues/16710
       # - binary_linux_conda_3_6_cu90_devtoolset7_build
-      # TODO rename to remove python version for libtorch
       - binary_linux_build:
-          name: binary_linux_libtorch_2_7m_cpu_devtoolset7_shared-with-deps_build
-          build_environment: "libtorch 2.7m cpu devtoolset7"
+          name: binary_linux_libtorch_3_6m_cpu_devtoolset7_shared-with-deps_build
+          build_environment: "libtorch 3.6m cpu devtoolset7"
           requires:
             - setup
           libtorch_variant: "shared-with-deps"
           docker_image: "pytorch/manylinux-cuda102"
       - binary_linux_build:
-          name: binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_shared-with-deps_build
-          build_environment: "libtorch 2.7m cpu gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_3_6m_cpu_gcc5_4_cxx11-abi_shared-with-deps_build
+          build_environment: "libtorch 3.6m cpu gcc5.4_cxx11-abi"
           requires:
             - setup
           libtorch_variant: "shared-with-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
       # TODO we should test a libtorch cuda build, but they take too long
-      # - binary_linux_libtorch_2_7m_cu90_devtoolset7_static-without-deps_build
+      # - binary_linux_libtorch_3_6m_cu90_devtoolset7_static-without-deps_build
       - binary_mac_build:
           name: binary_macos_wheel_3_6_cpu_build
           build_environment: "wheel 3.6 cpu"
@@ -47,10 +46,9 @@
                 - master
       # This job has an average run time of 3 hours o.O
       # Now only running this on master to reduce overhead
-      # TODO rename to remove python version for libtorch
       - binary_mac_build:
-          name: binary_macos_libtorch_2_7_cpu_build
-          build_environment: "libtorch 2.7 cpu"
+          name: binary_macos_libtorch_3_6_cpu_build
+          build_environment: "libtorch 3.6 cpu"
           requires:
             - setup
           filters:
@@ -72,21 +70,20 @@
                 - master
       # This binary build is currently broken, see https://github_com/pytorch/pytorch/issues/16710
       # - binary_linux_conda_3_6_cu90_devtoolset7_test:
-      # TODO rename to remove python version for libtorch
       - binary_linux_test:
-          name: binary_linux_libtorch_2_7m_cpu_devtoolset7_shared-with-deps_test
-          build_environment: "libtorch 2.7m cpu devtoolset7"
+          name: binary_linux_libtorch_3_6m_cpu_devtoolset7_shared-with-deps_test
+          build_environment: "libtorch 3.6m cpu devtoolset7"
           requires:
             - setup
-            - binary_linux_libtorch_2_7m_cpu_devtoolset7_shared-with-deps_build
+            - binary_linux_libtorch_3_6m_cpu_devtoolset7_shared-with-deps_build
           libtorch_variant: "shared-with-deps"
           docker_image: "pytorch/manylinux-cuda102"
       - binary_linux_test:
-          name: binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_shared-with-deps_test
-          build_environment: "libtorch 2.7m cpu gcc5.4_cxx11-abi"
+          name: binary_linux_libtorch_3_6m_cpu_gcc5_4_cxx11-abi_shared-with-deps_test
+          build_environment: "libtorch 3.6m cpu gcc5.4_cxx11-abi"
           requires:
             - setup
-            - binary_linux_libtorch_2_7m_cpu_gcc5_4_cxx11-abi_shared-with-deps_build
+            - binary_linux_libtorch_3_6m_cpu_gcc5_4_cxx11-abi_shared-with-deps_build
           libtorch_variant: "shared-with-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
 

--- a/.circleci/verbatim-sources/workflows-nightly-uploads-header.yml
+++ b/.circleci/verbatim-sources/workflows-nightly-uploads-header.yml
@@ -1,8 +1,8 @@
-      #- binary_linux_libtorch_2.7m_cpu_test:
+      #- binary_linux_libtorch_3.6m_cpu_test:
       #    requires:
-      #      - binary_linux_libtorch_2.7m_cpu_build
-      #- binary_linux_libtorch_2.7m_cu90_test:
+      #      - binary_linux_libtorch_3.6m_cpu_build
+      #- binary_linux_libtorch_3.6m_cu90_test:
       #    requires:
-      #      - binary_linux_libtorch_2.7m_cu90_build
+      #      - binary_linux_libtorch_3.6m_cu90_build
 
       # Nightly uploads


### PR DESCRIPTION
This moves libtorch to Python 3.6 and cleans up other CircleCI config for the removal of python2.

Going to see if all tests pass on this and will also land before https://github.com/pytorch/pytorch/pull/35677