### PR TITLE
Fix a bug in subgraph rewriters.

### DIFF
--- a/torch/csrc/jit/passes/subgraph_rewrite.cpp
+++ b/torch/csrc/jit/passes/subgraph_rewrite.cpp
@@ -120,6 +120,7 @@ void SubgraphRewriter::rewriteSinglePatternOnGraph(
   for (auto n : nodes_to_delete_) {
     n->destroy();
   }
+  nodes_to_delete_.clear();
 }
 
 bool SubgraphRewriter::overlapsWithPreviousMatches(const Match* match) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #35705 Enable relu fusion with prepacked linear/conv.
* **#35704 Fix a bug in subgraph rewriters.**

Summary:
Due to not clearing nodes_to_delete_, when we try to write graph rewrite
pass with multiple patterns, this is observed:
IndexError: vector::_M_range_check: __n (which is 0) >= this->size() (which is 0)

Test Plan:
The PR stacked on top of this run into this error in the unit test.

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D20746593](https://our.internmc.facebook.com/intern/diff/D20746593)