### PR TITLE
fp16 include not needed

### DIFF
--- a/caffe2/operators/fused_rowwise_nbit_conversion_ops.cc
+++ b/caffe2/operators/fused_rowwise_nbit_conversion_ops.cc
@@ -1,5 +1,4 @@
 #include "caffe2/operators/fused_rowwise_nbit_conversion_ops.h"
-#include <fp16.h>
 #include "c10/util/Registry.h"
 
 namespace caffe2 {

--- a/caffe2/operators/fused_rowwise_nbitfake_conversion_ops.cc
+++ b/caffe2/operators/fused_rowwise_nbitfake_conversion_ops.cc
@@ -1,5 +1,4 @@
 #include "caffe2/operators/fused_rowwise_nbitfake_conversion_ops.h"
-#include <fp16.h>
 #ifdef __AVX__
 #include <immintrin.h>
 #endif


### PR DESCRIPTION
Summary: these are not actually needed and it breaks the normal include guard that selects correct Half implementation

Test Plan: CI green

Differential Revision: D20744681

