### PR TITLE
Skip test_mm on XLA

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -14625,6 +14625,7 @@ scipy_lobpcg  | {:10.2e}  | {:10.2e}  | {:6} | N/A
         self.assertEqual(r.dtype, a.dtype)
 
     @slowTest
+    @onlyOnCPUAndCUDA
     @dtypes(torch.float32, torch.float64, torch.bfloat16, torch.int32, torch.int64)
     @dtypesIfCUDA(torch.float32, torch.float64)
     def test_mm(self, device, dtype):


### PR DESCRIPTION
Summary:

#34891 caused a 15 minute regression in XLA test timing when it inadvertently added this test to XLA -- I think it was intended to only add this test to CUDA.

Test plan:

The XLA test job should return from ~75 to ~60 minutes.