### PR TITLE
[caffe2] explicitly pass use_offsets=false when calling fbgemm embedding kernels

### DIFF
--- a/caffe2/operators/lengths_reducer_fused_8bit_rowwise_ops.h
+++ b/caffe2/operators/lengths_reducer_fused_8bit_rowwise_ops.h
@@ -76,14 +76,18 @@ class SparseLengthsFused8BitRowwiseOp : public Operator<Context> {
             block_size,
             with_weights,
             is_mean,
-            /*prefetch distance*/ 16);
+            /*prefetch distance*/ 16,
+            /*is_weight_positional*/ false,
+            /*use_offsets*/ false);
       } else {
         CAFFE_ENFORCE((std::is_same<IndexType, std::int64_t>::value));
         kernel64_ = fbgemm::GenerateEmbeddingSpMDM<std::uint8_t, std::int64_t>(
             block_size,
             with_weights,
             is_mean,
-            /*prefetch distance*/ 16);
+            /*prefetch distance*/ 16,
+            /*is_weight_positional*/ false,
+            /*use_offsets*/ false);
       }
     }
 

--- a/caffe2/operators/lengths_reducer_fused_nbit_rowwise_ops.h
+++ b/caffe2/operators/lengths_reducer_fused_nbit_rowwise_ops.h
@@ -92,7 +92,9 @@ class SparseLengthsFusedNBitRowwiseOp final : public Operator<Context> {
             block_size,
             weights != nullptr,
             is_mean,
-            /*prefetch distance*/ 16);
+            /*prefetch distance*/ 16,
+            /*is_weight_positional*/ false,
+            /*use_offsets*/ false);
       } else {
         CAFFE_ENFORCE((std::is_same<IndexType, std::int64_t>::value));
         kernel64_ = fbgemm::GenerateEmbeddingSpMDMNBit<std::int64_t>(
@@ -100,7 +102,9 @@ class SparseLengthsFusedNBitRowwiseOp final : public Operator<Context> {
             block_size,
             weights != nullptr,
             is_mean,
-            /*prefetch distance*/ 16);
+            /*prefetch distance*/ 16,
+            /*is_weight_positional*/ false,
+            /*use_offsets*/ false);
       }
     }
 
@@ -408,7 +412,9 @@ class SparseLengthsNBitRowwiseSparseOp final : public Operator<CPUContext> {
                     block_size,
                     weights != nullptr,
                     is_mean,
-                    /*prefetch distance*/ 16);
+                    /*prefetch distance*/ 16,
+                    /*is_weight_positional*/ false,
+                    /*use_offsets*/ false);
           } else {
             kernel32_ =
                 fbgemm::GenerateEmbeddingSpMDMNBitRowWiseSparse<std::int32_t>(
@@ -416,7 +422,9 @@ class SparseLengthsNBitRowwiseSparseOp final : public Operator<CPUContext> {
                     block_size,
                     weights != nullptr,
                     is_mean,
-                    /*prefetch distance*/ 16);
+                    /*prefetch distance*/ 16,
+                    /*is_weight_positional*/ false,
+                    /*use_offsets*/ false);
           }
         } else {
           CAFFE_ENFORCE((std::is_same<IndexType, std::int64_t>::value));
@@ -426,7 +434,9 @@ class SparseLengthsNBitRowwiseSparseOp final : public Operator<CPUContext> {
                     block_size,
                     weights != nullptr,
                     is_mean,
-                    /*prefetch distance*/ 16);
+                    /*prefetch distance*/ 16,
+                    /*is_weight_positional*/ false,
+                    /*use_offsets*/ false);
           } else {
             kernel64_ =
                 fbgemm::GenerateEmbeddingSpMDMNBitRowWiseSparse<std::int64_t>(
@@ -434,7 +444,9 @@ class SparseLengthsNBitRowwiseSparseOp final : public Operator<CPUContext> {
                     block_size,
                     weights != nullptr,
                     is_mean,
-                    /*prefetch distance*/ 16);
+                    /*prefetch distance*/ 16,
+                    /*is_weight_positional*/ false,
+                    /*use_offsets*/ false);
           }
         }
       } else { // fallback_to_no_sparse == true
@@ -446,7 +458,9 @@ class SparseLengthsNBitRowwiseSparseOp final : public Operator<CPUContext> {
                     block_size,
                     with_weights,
                     is_mean,
-                    /*prefetch distance*/ 16);
+                    /*prefetch distance*/ 16,
+                    /*is_weight_positional*/ false,
+                    /*use_offsets*/ false);
           } else {
             kernel32_no_sparse_ =
                 fbgemm::GenerateEmbeddingSpMDMNBit<std::int32_t>(
@@ -454,7 +468,9 @@ class SparseLengthsNBitRowwiseSparseOp final : public Operator<CPUContext> {
                     block_size,
                     weights != nullptr,
                     is_mean,
-                    /*prefetch distance*/ 16);
+                    /*prefetch distance*/ 16,
+                    /*is_weight_positional*/ false,
+                    /*use_offsets*/ false);
           }
         } else {
           CAFFE_ENFORCE((std::is_same<IndexType, std::int64_t>::value));
@@ -464,7 +480,9 @@ class SparseLengthsNBitRowwiseSparseOp final : public Operator<CPUContext> {
                     block_size,
                     with_weights,
                     is_mean,
-                    /*prefetch distance*/ 16);
+                    /*prefetch distance*/ 16,
+                    /*is_weight_positional*/ false,
+                    /*use_offsets*/ false);
           } else {
             kernel64_no_sparse_ =
                 fbgemm::GenerateEmbeddingSpMDMNBit<std::int64_t>(
@@ -472,7 +490,9 @@ class SparseLengthsNBitRowwiseSparseOp final : public Operator<CPUContext> {
                     block_size,
                     weights != nullptr,
                     is_mean,
-                    /*prefetch distance*/ 16);
+                    /*prefetch distance*/ 16,
+                    /*is_weight_positional*/ false,
+                    /*use_offsets*/ false);
           }
         }
       }

--- a/caffe2/operators/lengths_reducer_ops.h
+++ b/caffe2/operators/lengths_reducer_ops.h
@@ -100,7 +100,8 @@ class CPUSparseLengthsReductionOp : public Operator<CPUContext> {
                   USE_WEIGHT,
                   USE_MEAN,
                   /*prefetch distance*/ 16,
-                  USE_POSITIONAL_WEIGHT);
+                  USE_POSITIONAL_WEIGHT,
+                  /*use_offsets*/ false);
         } else {
           CAFFE_ENFORCE((std::is_same<IndexType, std::int64_t>::value));
           kernel_fp32_i64_ =
@@ -109,7 +110,8 @@ class CPUSparseLengthsReductionOp : public Operator<CPUContext> {
                   USE_WEIGHT,
                   USE_MEAN,
                   /*prefetch distance*/ 16,
-                  USE_POSITIONAL_WEIGHT);
+                  USE_POSITIONAL_WEIGHT,
+                  /*use_offsets*/ false);
         }
       } else {
         CAFFE_ENFORCE((std::is_same<InputType, at::Half>::value));
@@ -120,7 +122,8 @@ class CPUSparseLengthsReductionOp : public Operator<CPUContext> {
                   USE_WEIGHT,
                   USE_MEAN,
                   /*prefetch distance*/ 16,
-                  USE_POSITIONAL_WEIGHT);
+                  USE_POSITIONAL_WEIGHT,
+                  /*use_offsets*/ false);
         } else {
           CAFFE_ENFORCE((std::is_same<IndexType, std::int64_t>::value));
           kernel_fp16_i64_ =
@@ -129,7 +132,8 @@ class CPUSparseLengthsReductionOp : public Operator<CPUContext> {
                   USE_WEIGHT,
                   USE_MEAN,
                   /*prefetch distance*/ 16,
-                  USE_POSITIONAL_WEIGHT);
+                  USE_POSITIONAL_WEIGHT,
+                  /*use_offsets*/ false);
         }
       }
     }


### PR DESCRIPTION
Summary: As title

Test Plan: CI

Differential Revision: D20747290

