### PR TITLE
Fix torch complex exp implementation (#35532)

### DIFF
--- a/aten/src/ATen/cpu/vec256/vec256_complex_double.h
+++ b/aten/src/ATen/cpu/vec256/vec256_complex_double.h
@@ -210,7 +210,8 @@ public:
     exp = _mm256_blend_pd(exp, _mm256_permute_pd(exp, 0x05), 0x0A);   //exp(a)           exp(a)
 
     auto sin_cos = Sleef_sincosd4_u10(values);                        //[sin(a), cos(a)] [sin(b), cos(b)]
-    auto cos_sin = _mm256_blend_pd(sin_cos.y, sin_cos.x, 0x0A);       //cos(b)           sin(b)
+    auto cos_sin = _mm256_blend_pd(_mm256_permute_pd(sin_cos.y, 0x05),
+                                   sin_cos.x, 0x0A);                  //cos(b)           sin(b)
     return _mm256_mul_pd(exp, cos_sin);
   }
   Vec256<std::complex<double>> expm1() const {

--- a/aten/src/ATen/cpu/vec256/vec256_complex_float.h
+++ b/aten/src/ATen/cpu/vec256/vec256_complex_float.h
@@ -248,7 +248,8 @@ public:
     exp = _mm256_blend_ps(exp, _mm256_permute_ps(exp, 0xB1), 0xAA);   //exp(a)           exp(a)
 
     auto sin_cos = Sleef_sincosf8_u10(values);                        //[sin(a), cos(a)] [sin(b), cos(b)]
-    auto cos_sin = _mm256_blend_ps(sin_cos.y, sin_cos.x, 0xAA);       //cos(b)           sin(b)
+    auto cos_sin = _mm256_blend_ps(_mm256_permute_ps(sin_cos.y, 0xB1),
+                                   sin_cos.x, 0xAA);                  //cos(b)           sin(b)
     return _mm256_mul_ps(exp, cos_sin);
   }
   Vec256<std::complex<float>> expm1() const {

--- a/test/test_complex.py
+++ b/test/test_complex.py
@@ -1,13 +1,10 @@
 import math
 import torch
-from torch.testing._internal.common_utils import TestCase, run_tests
+from torch.testing._internal.common_utils import TestCase, run_tests, TEST_NUMPY
 import unittest
 
-TEST_NUMPY = True
-try:
+if TEST_NUMPY:
     import numpy as np
-except ImportError:
-    TEST_NUMPY = False
 
 devices = (torch.device('cpu'), torch.device('cuda:0'))
 
@@ -21,8 +18,7 @@ class TestComplexTensor(TestCase):
     @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
     def test_exp(self):
         def exp_fn(dtype):
-            a = (1j * torch.tensor([0, 1 + 1j, 2 + 2j, 3 + 3j], dtype=dtype) /
-                 3 * math.pi)
+            a = torch.tensor(1j, dtype=dtype) * torch.arange(4) / 3 * math.pi
             expected = np.exp(a.numpy())
             actual = torch.exp(a)
             self.assertEqual(actual, torch.from_numpy(expected))

--- a/test/test_complex.py
+++ b/test/test_complex.py
@@ -11,6 +11,7 @@ except ImportError:
 
 devices = (torch.device('cpu'), torch.device('cuda:0'))
 
+
 class TestComplexTensor(TestCase):
     def test_to_list_with_complex_64(self):
         # test that the complex float tensor has expected values and

--- a/test/test_complex.py
+++ b/test/test_complex.py
@@ -9,5 +9,62 @@ class TestComplexTensor(TestCase):
         # there's no garbage value in the resultant list
         self.assertEqual(torch.zeros((2, 2), dtype=torch.complex64).tolist(), [[0j, 0j], [0j, 0j]])
 
+    def test_exp_with_complex_64(self):
+        import numpy as np
+
+        w = torch.tensor([0 + 0j, 1 + 1j, 2 + 2j, 3 + 3j], dtype=torch.complex64)
+        w = torch.exp(w)
+
+        x = np.array([0 + 0j, 1 + 1j, 2 + 2j, 3 + 3j], dtype=np.complex64)
+        x = np.exp(x)
+
+        self.assertEqual(w * 2j, x * 2j)
+
+    def test_exp_with_complex_128(self):
+        import numpy as np
+
+        w = torch.tensor([0 + 0j, 1 + 1j, 2 + 2j, 3 + 3j], dtype=torch.complex128)
+        w = torch.exp(w)
+
+        x = np.array([0 + 0j, 1 + 1j, 2 + 2j, 3 + 3j], dtype=np.complex128)
+        x = np.exp(x)
+
+        self.assertEqual(w * 2j, x * 2j)
+
+    def test_addition_and_mult_with_complex_64(self):
+        import numpy as np
+
+        w = torch.tensor([3 + 3j], dtype=torch.complex64)
+        w = 1.323j * w + 1.0
+
+        x = np.array([3 + 3j], dtype=np.complex64)
+        x = 1.323j * x + 1.0
+
+        self.assertEqual(w, x)
+
+    def test_exp_and_addition_with_complex_64(self):
+        import numpy as np
+
+        w = torch.tensor([3 + 3j], dtype=torch.complex64)
+        w = torch.exp(w + 1.0)
+
+        x = np.array([3 + 3j], dtype=np.complex64)
+        x = np.exp(x + 1.0)
+
+        self.assertEqual(w, x)
+
+    def test_exp_and_addition_with_complex_128(self):
+        import numpy as np
+
+        w = torch.tensor([3 + 3j], dtype=torch.complex128)
+        w = torch.exp(w + 1.0)
+
+        x = np.array([3 + 3j], dtype=np.complex128)
+        x = np.exp(x + 1.0)
+
+        self.assertEqual(w, x)
+
+
+
 if __name__ == '__main__':
     run_tests()

--- a/test/test_complex.py
+++ b/test/test_complex.py
@@ -1,5 +1,13 @@
+import math
 import torch
 from torch.testing._internal.common_utils import TestCase, run_tests
+import unittest
+
+TEST_NUMPY = True
+try:
+    import numpy as np
+except ImportError:
+    TEST_NUMPY = False
 
 devices = (torch.device('cpu'), torch.device('cuda:0'))
 
@@ -9,61 +17,17 @@ class TestComplexTensor(TestCase):
         # there's no garbage value in the resultant list
         self.assertEqual(torch.zeros((2, 2), dtype=torch.complex64).tolist(), [[0j, 0j], [0j, 0j]])
 
-    def test_exp_with_complex_64(self):
-        import numpy as np
-
-        w = torch.tensor([0 + 0j, 1 + 1j, 2 + 2j, 3 + 3j], dtype=torch.complex64)
-        w = torch.exp(w)
-
-        x = np.array([0 + 0j, 1 + 1j, 2 + 2j, 3 + 3j], dtype=np.complex64)
-        x = np.exp(x)
-
-        self.assertEqual(w * 2j, x * 2j)
-
-    def test_exp_with_complex_128(self):
-        import numpy as np
-
-        w = torch.tensor([0 + 0j, 1 + 1j, 2 + 2j, 3 + 3j], dtype=torch.complex128)
-        w = torch.exp(w)
-
-        x = np.array([0 + 0j, 1 + 1j, 2 + 2j, 3 + 3j], dtype=np.complex128)
-        x = np.exp(x)
-
-        self.assertEqual(w * 2j, x * 2j)
-
-    def test_addition_and_mult_with_complex_64(self):
-        import numpy as np
-
-        w = torch.tensor([3 + 3j], dtype=torch.complex64)
-        w = 1.323j * w + 1.0
-
-        x = np.array([3 + 3j], dtype=np.complex64)
-        x = 1.323j * x + 1.0
-
-        self.assertEqual(w, x)
-
-    def test_exp_and_addition_with_complex_64(self):
-        import numpy as np
-
-        w = torch.tensor([3 + 3j], dtype=torch.complex64)
-        w = torch.exp(w + 1.0)
-
-        x = np.array([3 + 3j], dtype=np.complex64)
-        x = np.exp(x + 1.0)
-
-        self.assertEqual(w, x)
-
-    def test_exp_and_addition_with_complex_128(self):
-        import numpy as np
-
-        w = torch.tensor([3 + 3j], dtype=torch.complex128)
-        w = torch.exp(w + 1.0)
-
-        x = np.array([3 + 3j], dtype=np.complex128)
-        x = np.exp(x + 1.0)
-
-        self.assertEqual(w, x)
-
+    @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
+    def test_exp(self):
+        def exp_fn(dtype):
+            a = (1j * torch.tensor([0, 1 + 1j, 2 + 2j, 3 + 3j], dtype=dtype) /
+                 3 * math.pi)
+            expected = np.exp(a.numpy())
+            actual = torch.exp(a)
+            self.assertEqual(actual, torch.from_numpy(expected))
+        
+        exp_fn(torch.complex64)
+        exp_fn(torch.complex128)
 
 
 if __name__ == '__main__':

--- a/test/test_complex.py
+++ b/test/test_complex.py
@@ -18,7 +18,7 @@ class TestComplexTensor(TestCase):
     @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
     def test_exp(self):
         def exp_fn(dtype):
-            a = torch.tensor(1j, dtype=dtype) * torch.arange(4) / 3 * math.pi
+            a = torch.tensor(1j, dtype=dtype) * torch.arange(18) / 3 * math.pi
             expected = np.exp(a.numpy())
             actual = torch.exp(a)
             self.assertEqual(actual, torch.from_numpy(expected))

--- a/test/test_complex.py
+++ b/test/test_complex.py
@@ -26,7 +26,7 @@ class TestComplexTensor(TestCase):
             expected = np.exp(a.numpy())
             actual = torch.exp(a)
             self.assertEqual(actual, torch.from_numpy(expected))
-        
+
         exp_fn(torch.complex64)
         exp_fn(torch.complex128)
 


### PR DESCRIPTION
There was a permutation operation missing in each of the complex vector files. I also added some test cases, the last two of which fail under the current implementation. This PR fixes that: all the testcases pass.

Fixes #35532

@dylanbespalko 