### PR TITLE
Do not link BLAS into torch_cuda/torch_hip

### DIFF
--- a/aten/src/ATen/CMakeLists.txt
+++ b/aten/src/ATen/CMakeLists.txt
@@ -142,22 +142,8 @@ if(BLAS_FOUND)
     message(STATUS "TH_BINARY_BUILD detected. Enabling special linkage.")
     list(APPEND ATen_CPU_DEPENDENCY_LIBS
       "${BLAS_LIBRARIES};${BLAS_LIBRARIES};${BLAS_LIBRARIES}")
-    if(USE_CUDA)
-      list(APPEND ATen_CUDA_DEPENDENCY_LIBS
-        "${BLAS_LIBRARIES};${BLAS_LIBRARIES};${BLAS_LIBRARIES}")
-    endif()
-    if(USE_ROCM)
-      list(APPEND ATen_HIP_DEPENDENCY_LIBS
-        "${BLAS_LIBRARIES};${BLAS_LIBRARIES};${BLAS_LIBRARIES}")
-    endif()
   else($ENV{TH_BINARY_BUILD})
     list(APPEND ATen_CPU_DEPENDENCY_LIBS ${BLAS_LIBRARIES})
-    if(USE_CUDA)
-      list(APPEND ATen_CUDA_DEPENDENCY_LIBS "${BLAS_LIBRARIES}")
-    endif()
-    if(USE_ROCM)
-      list(APPEND ATen_HIP_DEPENDENCY_LIBS "${BLAS_LIBRARIES}")
-    endif()
   endif($ENV{TH_BINARY_BUILD})
 endif(BLAS_FOUND)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#35724 Do not link BLAS into torch_cuda/torch_hip**

When statically linking BLAS, this results in a second useless copy of
MKL in libtorch_cuda.so

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D20758165](https://our.internmc.facebook.com/intern/diff/D20758165)