### PR TITLE
Fix topk for at::Half and at::BFloat16

### DIFF
--- a/aten/src/ATen/native/cuda/SortingRadixSelect.cuh
+++ b/aten/src/ATen/native/cuda/SortingRadixSelect.cuh
@@ -125,7 +125,7 @@ struct TopKTypeConfig<at::Half> {
   static inline __device__ RadixType convert(at::Half v) {
 #if defined(__CUDA_ARCH__) || defined(__HIP_PLATFORM_HCC__)
     RadixType x = __half_as_ushort(v);
-    RadixType mask = -((x >> 15)) | 0x8000;
+    RadixType mask = (x & 0x00008000) ? 0x0000ffff : 0x00008000;
     return (v == v) ? (x ^ mask) : 0xffff;
 #else
     assert(false);
@@ -135,7 +135,7 @@ struct TopKTypeConfig<at::Half> {
 
   static inline __device__ at::Half deconvert(RadixType v) {
 #if defined(__CUDA_ARCH__) || defined(__HIP_PLATFORM_HCC__)
-    RadixType mask = ((v >> 15) - 1) | 0x8000;
+    RadixType mask = (v & 0x00008000) ? 0x00008000 : 0x0000ffff;
     return __ushort_as_half(v ^ mask);
 #else
     assert(false);

--- a/aten/src/ATen/native/cuda/SortingRadixSelect.cuh
+++ b/aten/src/ATen/native/cuda/SortingRadixSelect.cuh
@@ -150,12 +150,12 @@ struct TopKTypeConfig<at::BFloat16> {
 
   static inline __device__ RadixType convert(at::BFloat16 v) {
     RadixType x = v.x;
-    RadixType mask = -((x >> 15)) | 0x8000;
+    RadixType mask = (x & 0x00008000) ? 0x0000ffff : 0x00008000;
     return (v == v) ? (x ^ mask) : 0xffff;
   }
 
   static inline __device__ at::BFloat16 deconvert(RadixType v) {
-    RadixType mask = ((v >> 15) - 1) | 0x8000;
+    RadixType mask = (v & 0x00008000) ? 0x00008000 : 0x0000ffff;
     at::BFloat16 r;
     r.x = (v ^ mask);
     return r;

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -12671,16 +12671,25 @@ class TestTorchDeviceType(TestCase):
         self.assertEqual(top1, top2)
         self.assertEqual(idx1, idx2)
 
+    @dtypes(torch.int8, torch.uint8, torch.int16, torch.int32, torch.int64)
+    def test_topk_integral(self, device, dtype):
+        a = torch.randint(torch.iinfo(dtype).min, torch.iinfo(dtype).max, size=(10,),
+                          dtype=dtype, device=device)
+        sort_topk = a.sort()[0][-5:].flip(0)
+        topk = a.topk(5)
+        self.assertEqual(sort_topk, topk[0])      # check values
+        self.assertEqual(sort_topk, a[topk[1]])   # check indices
+
     def test_topk_nonfinite(self, device):
         for dtype in (torch.half, torch.float, torch.double):
-            x = torch.tensor([float('nan'), float('inf'), 1e4, 0, -1e4, -float('inf')], device=device)
+            x = torch.tensor([float('nan'), float('inf'), 1e4, 0, -1e4, -float('inf')], device=device, dtype=dtype)
             val, idx = x.topk(4)
-            expect = torch.tensor([float('nan'), float('inf'), 1e4, 0], device=device)
+            expect = torch.tensor([float('nan'), float('inf'), 1e4, 0], device=device, dtype=dtype)
             self.assertEqual(val, expect, allow_inf=True)
             self.assertEqual(idx, [0, 1, 2, 3])
 
             val, idx = x.topk(4, largest=False)
-            expect = torch.tensor([-float('inf'), -1e4, 0, 1e4], device=device)
+            expect = torch.tensor([-float('inf'), -1e4, 0, 1e4], device=device, dtype=dtype)
             self.assertEqual(val, expect, allow_inf=True)
             self.assertEqual(idx, [5, 4, 3, 2])
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -12680,9 +12680,12 @@ class TestTorchDeviceType(TestCase):
         self.assertEqual(sort_topk, topk[0])      # check values
         self.assertEqual(sort_topk, a[topk[1]])   # check indices
 
-    @dtypesIfCUDA(torch.half, torch.float, torch.double)
+    @dtypesIfCUDA(torch.bfloat16, torch.half, torch.float, torch.double)
     @dtypes(torch.float, torch.double)
     def test_topk_nonfinite(self, device, dtype):
+        if torch.device(device).type == 'cuda' and dtype == torch.bfloat16:
+            raise unittest.SkipTest('bfloat16 not supported wih cuda')
+
         x = torch.tensor([float('nan'), float('inf'), 1e4, 0, -1e4, -float('inf')], device=device, dtype=dtype)
         val, idx = x.topk(4)
         expect = torch.tensor([float('nan'), float('inf'), 1e4, 0], device=device, dtype=dtype)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -12680,18 +12680,19 @@ class TestTorchDeviceType(TestCase):
         self.assertEqual(sort_topk, topk[0])      # check values
         self.assertEqual(sort_topk, a[topk[1]])   # check indices
 
-    def test_topk_nonfinite(self, device):
-        for dtype in (torch.half, torch.float, torch.double):
-            x = torch.tensor([float('nan'), float('inf'), 1e4, 0, -1e4, -float('inf')], device=device, dtype=dtype)
-            val, idx = x.topk(4)
-            expect = torch.tensor([float('nan'), float('inf'), 1e4, 0], device=device, dtype=dtype)
-            self.assertEqual(val, expect, allow_inf=True)
-            self.assertEqual(idx, [0, 1, 2, 3])
+    @dtypesIfCUDA(torch.half, torch.float, torch.double)
+    @dtypes(torch.float, torch.double)
+    def test_topk_nonfinite(self, device, dtype):
+        x = torch.tensor([float('nan'), float('inf'), 1e4, 0, -1e4, -float('inf')], device=device, dtype=dtype)
+        val, idx = x.topk(4)
+        expect = torch.tensor([float('nan'), float('inf'), 1e4, 0], device=device, dtype=dtype)
+        self.assertEqual(val, expect, allow_inf=True)
+        self.assertEqual(idx, [0, 1, 2, 3])
 
-            val, idx = x.topk(4, largest=False)
-            expect = torch.tensor([-float('inf'), -1e4, 0, 1e4], device=device, dtype=dtype)
-            self.assertEqual(val, expect, allow_inf=True)
-            self.assertEqual(idx, [5, 4, 3, 2])
+        val, idx = x.topk(4, largest=False)
+        expect = torch.tensor([-float('inf'), -1e4, 0, 1e4], device=device, dtype=dtype)
+        self.assertEqual(val, expect, allow_inf=True)
+        self.assertEqual(idx, [5, 4, 3, 2])
 
     def test_is_signed(self, device):
         self.assertEqual(torch.IntTensor(5).to(device).is_signed(), True)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -12672,15 +12672,15 @@ class TestTorchDeviceType(TestCase):
         self.assertEqual(idx1, idx2)
 
     def test_topk_nonfinite(self, device):
-        for dtype in (torch.float, torch.double):
-            x = torch.tensor([float('nan'), float('inf'), 1e10, 0, -1e10, -float('inf')], device=device)
+        for dtype in (torch.half, torch.float, torch.double):
+            x = torch.tensor([float('nan'), float('inf'), 1e4, 0, -1e4, -float('inf')], device=device)
             val, idx = x.topk(4)
-            expect = torch.tensor([float('nan'), float('inf'), 1e10, 0], device=device)
+            expect = torch.tensor([float('nan'), float('inf'), 1e4, 0], device=device)
             self.assertEqual(val, expect, allow_inf=True)
             self.assertEqual(idx, [0, 1, 2, 3])
 
             val, idx = x.topk(4, largest=False)
-            expect = torch.tensor([-float('inf'), -1e10, 0, 1e10], device=device)
+            expect = torch.tensor([-float('inf'), -1e4, 0, 1e4], device=device)
             self.assertEqual(val, expect, allow_inf=True)
             self.assertEqual(idx, [5, 4, 3, 2])
 


### PR DESCRIPTION
Addresses https://github.com/pytorch/pytorch/issues/35584.

https://github.com/pytorch/pytorch/pull/35253 exposed unrelated bad logic in [aten/native/cuda/SortingRadixSelect.cuh](https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/cuda/SortingRadixSelect.cuh)'s `TopKTypeConfig<at::Half>` and `TopKTypeConfig<at::BFloat16>`.  The present PR fixes that logic.

(Also PRed against 1.5 https://github.com/pytorch/pytorch/pull/35738)

(An alternative patch was proposed [here](https://github.com/pytorch/pytorch/compare/master...gchanan:float16_topk#diff-f43cb0c884ec2d6293ed19cbd267b6b0R128).  Stashing a reference here in case someone prefers a different option in the future.)