### PR TITLE
Add warnings that amp is incomplete in 1.5

### DIFF
--- a/docs/source/amp.rst
+++ b/docs/source/amp.rst
@@ -13,6 +13,13 @@ use ``torch.float16`` (``half``). Some operations, like linear layers and convol
 are much faster in ``float16``. Other operations, like reductions, often require the dynamic
 range of ``float32``. Networks running in mixed precision try to match each operation to its appropriate datatype.
 
+.. warning::
+    :class:`torch.cuda.amp.GradScaler` is not a complete implementation of automatic mixed precision.
+    :class:`GradScaler` is only useful if you manually run regions of your model in ``float16``.
+    If you aren't sure how to choose op precision manually, the master branch and nightly pip/conda
+    builds include a context manager that chooses op precision automatically wherever it's enabled.
+    See the `master documentation<https://pytorch.org/docs/master/amp.html>`_ for details.
+
 .. contents:: :local:
 
 .. _gradient-scaling:

--- a/docs/source/notes/amp_examples.rst
+++ b/docs/source/notes/amp_examples.rst
@@ -5,6 +5,13 @@ Automatic Mixed Precision examples
 
 .. currentmodule:: torch.cuda.amp
 
+.. warning::
+    :class:`torch.cuda.amp.GradScaler` is not a complete implementation of automatic mixed precision.
+    :class:`GradScaler` is only useful if you manually run regions of your model in ``float16``.
+    If you aren't sure how to choose op precision manually, the master branch and nightly pip/conda
+    builds include a context manager that chooses op precision automatically wherever it's enabled.
+    See the `master documentation<https://pytorch.org/docs/master/amp.html>`_ for details.
+
 .. contents:: :local:
 
 .. _gradient-scaling-examples:


### PR DESCRIPTION
If autocast isn't going to make 1.5, we should add a warning that `GradScaler` by itself isn't a complete automatic mixed precision recipe, and point people to master/nightlies which do have the complete recipe.

I'm super ambivalent about how this should be phrased.  I'm also ambivalent about whether we should include docs for `GradScaler` in the 1.5 doctree at all, since `GradScaler` is not generally useful without autocast.  PRing so @gchanan @ngimel and Nvidia people can comment.