### PR TITLE
Optimize LayerNorm performance on CPU both forward and backward

### DIFF
--- a/aten/src/ATen/cpu/vec256/functional.h
+++ b/aten/src/ATen/cpu/vec256/functional.h
@@ -128,6 +128,42 @@ inline scalar_t map2_reduce_all(
   return vec_reduce_all(red_fun, acc_vec, Vec::size());
 }
 
+template <typename scalar_t, typename MapOp, typename ReduceOp>
+inline scalar_t map3_reduce_all(
+    const MapOp& map_fun,
+    const ReduceOp& red_fun,
+    const scalar_t* data,
+    const scalar_t* data2,
+    const scalar_t* data3,
+    int64_t size) {
+  using Vec = vec256::Vec256<scalar_t>;
+  if (size < Vec::size()) {
+    Vec data_vec = Vec::loadu(data, size);
+    Vec data2_vec = Vec::loadu(data2, size);
+    Vec data3_vec = Vec::loadu(data3, size);
+    data_vec = map_fun(data_vec, data2_vec, data3_vec);
+    return vec_reduce_all(red_fun, data_vec, size);
+  }
+
+  int64_t d = Vec::size();
+  Vec acc_vec = map_fun(Vec::loadu(data), Vec::loadu(data2), Vec::loadu(data3));
+  for (; d < size - (size % Vec::size()); d += Vec::size()) {
+    Vec data_vec = Vec::loadu(data + d);
+    Vec data2_vec = Vec::loadu(data2 + d);
+    Vec data3_vec = Vec::loadu(data3 + d);
+    data_vec = map_fun(data_vec, data2_vec, data3_vec);
+    acc_vec = red_fun(acc_vec, data_vec);
+  }
+  if (size - d > 0) {
+    Vec data_vec = Vec::loadu(data + d, size - d);
+    Vec data2_vec = Vec::loadu(data2 + d, size - d);
+    Vec data3_vec = Vec::loadu(data3 + d, size - d);
+    data_vec = map_fun(data_vec, data2_vec, data3_vec);
+    acc_vec = Vec::set(acc_vec, red_fun(acc_vec, data_vec), size - d);
+  }
+  return vec_reduce_all(red_fun, acc_vec, Vec::size());
+}
+
 template <typename scalar_t, typename Op>
 inline void map(
     const Op& vec_fun,
@@ -165,6 +201,32 @@ inline void map2(
     Vec data_vec = Vec::loadu(input_data + d, size - d);
     Vec data_vec2 = Vec::loadu(input_data2 + d, size - d);
     Vec output_vec = vec_fun(data_vec, data_vec2);
+    output_vec.store(output_data + d, size - d);
+  }
+}
+
+template <typename scalar_t, typename Op>
+inline void map3(
+    const Op& vec_fun,
+    scalar_t* output_data,
+    scalar_t* input_data1,
+    scalar_t* input_data2,
+    scalar_t* input_data3,
+    int64_t size) {
+  using Vec = vec256::Vec256<scalar_t>;
+  int64_t d = 0;
+  for (; d < size - (size % Vec::size()); d += Vec::size()) {
+    Vec data_vec1 = Vec::loadu(input_data1 + d);
+    Vec data_vec2 = Vec::loadu(input_data2 + d);
+    Vec data_vec3 = Vec::loadu(input_data3 + d);
+    Vec output_vec = vec_fun(data_vec1, data_vec2, data_vec3);
+    output_vec.store(output_data + d);
+  }
+  if (size - d > 0) {
+    Vec data_vec1 = Vec::loadu(input_data1 + d, size - d);
+    Vec data_vec2 = Vec::loadu(input_data2 + d, size - d);
+    Vec data_vec3 = Vec::loadu(input_data3 + d, size - d);
+    Vec output_vec = vec_fun(data_vec1, data_vec2, data_vec3);
     output_vec.store(output_data + d, size - d);
   }
 }

--- a/aten/src/ATen/cpu/vec256/functional.h
+++ b/aten/src/ATen/cpu/vec256/functional.h
@@ -27,7 +27,7 @@ inline scalar_t vec_reduce_all(
 }
 
 template <typename scalar_t, typename Op>
-inline scalar_t reduce_all(const Op& vec_fun, scalar_t* data, int64_t size) {
+inline scalar_t reduce_all(const Op& vec_fun, const scalar_t* data, int64_t size) {
   using Vec = vec256::Vec256<scalar_t>;
   if (size < Vec::size())
     return vec_reduce_all(vec_fun, Vec::loadu(data, size), size);
@@ -47,7 +47,7 @@ inline scalar_t reduce_all(const Op& vec_fun, scalar_t* data, int64_t size) {
 // similar to reduce_all, but reduces into two outputs
 template <typename scalar_t, typename Op1, typename Op2>
 inline std::pair<scalar_t, scalar_t> reduce2_all(const Op1& vec_fun1, const Op2& vec_fun2,
-    scalar_t* data, int64_t size) {
+    const scalar_t* data, int64_t size) {
   using Vec = vec256::Vec256<scalar_t>;
   if (size < Vec::size()) {
     auto loaded_data = Vec::loadu(data, size);
@@ -186,8 +186,8 @@ template <typename scalar_t, typename Op>
 inline void map2(
     const Op& vec_fun,
     scalar_t* output_data,
-    scalar_t* input_data,
-    scalar_t* input_data2,
+    const scalar_t* input_data,
+    const scalar_t* input_data2,
     int64_t size) {
   using Vec = vec256::Vec256<scalar_t>;
   int64_t d = 0;
@@ -209,9 +209,9 @@ template <typename scalar_t, typename Op>
 inline void map3(
     const Op& vec_fun,
     scalar_t* output_data,
-    scalar_t* input_data1,
-    scalar_t* input_data2,
-    scalar_t* input_data3,
+    const scalar_t* input_data1,
+    const scalar_t* input_data2,
+    const scalar_t* input_data3,
     int64_t size) {
   using Vec = vec256::Vec256<scalar_t>;
   int64_t d = 0;

--- a/aten/src/ATen/native/cpu/layer_norm_kernel.cpp
+++ b/aten/src/ATen/native/cpu/layer_norm_kernel.cpp
@@ -147,6 +147,8 @@ void LayerNormBackwardKernelImplInternal(
   // First path of dgamma/dbeta and dX
   at::parallel_for(0, M, 1, [&](int64_t start, int64_t end) {
     int tid = at::get_thread_num();
+    TORCH_CHECK(tid < num_threads,
+                "expect thread id smaller than ", num_threads, ", got thread id ", tid);
     T* dgamma_buffer_ptr = dgamma_null ? nullptr : buffer_data + tid * N;
     T* dbeta_buffer_ptr = dbeta_null ? nullptr : buffer_data + num_threads * N + tid * N;
     for (int64_t i = start; i < end; ++i) {

--- a/aten/src/ATen/native/cpu/layer_norm_kernel.cpp
+++ b/aten/src/ATen/native/cpu/layer_norm_kernel.cpp
@@ -7,6 +7,7 @@
 #include <ATen/Dispatch.h>
 #include <ATen/cpu/vec256/functional.h>
 #include <ATen/cpu/vec256/vec256.h>
+#include <ATen/Parallel.h>
 
 namespace at {
 namespace native {
@@ -29,8 +30,8 @@ void LayerNormKernelImplInternal(
   DCHECK(!gamma.defined() || gamma.numel() == N);
   DCHECK(!beta.defined() || beta.numel() == N);
   T* X_data = X.data_ptr<T>();
-  const T* gamma_data = gamma.defined() ? gamma.data_ptr<T>() : nullptr;
-  const T* beta_data = beta.defined() ? beta.data_ptr<T>() : nullptr;
+  T* gamma_data = gamma.defined() ? gamma.data_ptr<T>() : nullptr;
+  T* beta_data = beta.defined() ? beta.data_ptr<T>() : nullptr;
   T* Y_data = Y->data_ptr<T>();
   T* mean_data = mean->data_ptr<T>();
   T* rstd_data = rstd->data_ptr<T>();
@@ -55,10 +56,22 @@ void LayerNormKernelImplInternal(
       rstd_val = T(1) / std::sqrt(rstd_val + eps);
       const T scale = rstd_val;
       const T bias = -rstd_val * mean_val;
-      for (int64_t j = 0; j < N; ++j) {
-        const T gamma_v = gamma_null ? T(1) : gamma_data[j];
-        const T beta_v = beta_null ? T(0) : beta_data[j];
-        Y_ptr[j] = (X_ptr[j] * scale + bias) * gamma_v + beta_v;
+      if (gamma_null || beta_null) {
+        for (int64_t j = 0; j < N; ++j) {
+          const T gamma_v = gamma_null ? T(1) : gamma_data[j];
+          const T beta_v = beta_null ? T(0) : beta_data[j];
+          Y_ptr[j] = (X_ptr[j] * scale + bias) * gamma_v + beta_v;
+        }
+      } else {
+        vec256::map3<T>(
+            [scale, bias](Vec x, Vec gamma, Vec beta) {
+              return (x * Vec(scale) + Vec(bias)) * gamma + beta;
+            },
+            Y_ptr,
+            X_ptr,
+            gamma_data,
+            beta_data,
+            N);
       }
       mean_data[i] = mean_val;
       rstd_data[i] = rstd_val;
@@ -94,60 +107,159 @@ void LayerNormBackwardKernelImplInternal(
     Tensor* dX,
     Tensor* dgamma,
     Tensor* dbeta) {
+  using Vec = vec256::Vec256<T>;
   DCHECK_EQ(dY.numel(), M * N);
   DCHECK_EQ(X.numel(), M * N);
   DCHECK_EQ(mean.numel(), M);
   DCHECK_EQ(rstd.numel(), M);
   DCHECK(!gamma.defined() || gamma.numel() == N);
-  const T* dY_data = dY.template data_ptr<T>();
-  const T* X_data = X.template data_ptr<T>();
-  const T* mean_data = mean.template data_ptr<T>();
-  const T* rstd_data = rstd.template data_ptr<T>();
-  const T* gamma_data =
-      gamma.defined() ? gamma.template data_ptr<T>() : nullptr;
+  T* dY_data = dY.template data_ptr<T>();
+  T* X_data = X.template data_ptr<T>();
+  T* mean_data = mean.template data_ptr<T>();
+  T* rstd_data = rstd.template data_ptr<T>();
+  T* gamma_data = gamma.defined() ? gamma.template data_ptr<T>() : nullptr;
   T* dX_data = dX->defined() ? dX->template data_ptr<T>() : nullptr;
   T* dgamma_data = dgamma->defined() ? dgamma->template data_ptr<T>() : nullptr;
-  if (dgamma_data != nullptr) {
-    std::memset(dgamma_data, 0, N * sizeof(T));
-  }
   T* dbeta_data = dbeta->defined() ? dbeta->template data_ptr<T>() : nullptr;
-  if (dbeta_data != nullptr) {
-    std::memset(dbeta_data, 0, N * sizeof(T));
-  }
   const T scale = T(1) / static_cast<T>(N);
   const bool gamma_null = gamma_data == nullptr;
-  for (int64_t i = 0; i < M; ++i) {
-    const T* dY_ptr = dY_data + i * N;
-    const T* X_ptr = X_data + i * N;
-    if (dX_data != nullptr) {
-      T* dX_ptr = dX_data + i * N;
-      T ds = 0;
-      T db = 0;
-      for (int64_t j = 0; j < N; ++j) {
-        const T gamma_v = gamma_null ? T(1) : gamma_data[j];
-        ds += dY_ptr[j] * X_ptr[j] * gamma_v;
-        db += dY_ptr[j] * gamma_v;
+  const bool dX_null = dX_data == nullptr;
+  const bool dgamma_null = dgamma_data == nullptr;
+  const bool dbeta_null = dbeta_data == nullptr;
+
+  // 1. Use two path parallel reduction for dgamma and dbeta:
+  //    First path: allocate an immediate buffer of size {2, max_threads, N},
+  //        dgamma_buffer = buffer[0], dbeta_buffer = buffer[1]
+  //    Parallel along dim0 and reduce dY and X along dim0 to buffer.
+  //    Second path: parallel along dim1 and reduce buffer to dgamma and dbeta.
+  //
+  // 2. Fuse first path of dgamma/dbeta with dX to reuse X[i] and dY[i] in L1 cache.
+  //
+  int num_threads = at::get_num_threads();
+  Tensor buffer = at::empty({0}, X.options());
+  T* buffer_data = nullptr;
+  if (!dgamma_null || !dbeta_null) {
+    buffer.resize_({2, num_threads, N}).zero_();
+    buffer_data = buffer.template data_ptr<T>();
+  }
+
+  // First path of dgamma/dbeta and dX
+  at::parallel_for(0, M, 1, [&](int64_t start, int64_t end) {
+    int tid = at::get_thread_num();
+    T* dgamma_buffer_ptr = dgamma_null ? nullptr : buffer_data + tid * N;
+    T* dbeta_buffer_ptr = dbeta_null ? nullptr : buffer_data + num_threads * N + tid * N;
+    for (int64_t i = start; i < end; ++i) {
+      T* dY_ptr = dY_data + i * N;
+      T* X_ptr = X_data + i * N;
+      if (!dgamma_null) {
+        const T a = rstd_data[i];
+        const T b = -a * mean_data[i];
+        // Scalar math:
+        // for (int64_t j = 0; j < N; ++j) {
+        //   dgamma_data[j] += dY_ptr[j] * (a * X_ptr[j] + b);
+        // }
+        vec256::map3<T>(
+            [a, b](Vec dgamma, Vec dy, Vec x) { return dgamma + dy * (Vec(a) * x + Vec(b)); },
+            dgamma_buffer_ptr,
+            dgamma_buffer_ptr,
+            dY_ptr,
+            X_ptr,
+            N);
       }
-      const T a = rstd_data[i];
-      const T b = (db * mean_data[i] - ds) * a * a * a * scale;
-      const T c = -b * mean_data[i] - db * a * scale;
-      for (int64_t j = 0; j < N; ++j) {
-        const T gamma_v = gamma_null ? T(1) : gamma_data[j];
-        dX_ptr[j] = a * dY_ptr[j] * gamma_v + b * X_ptr[j] + c;
+      if (!dbeta_null) {
+        // Scalar math:
+        // for (int64_t j = 0; j < N; ++j) {
+        //   dbeta_data[j] += dY_ptr[j];
+        // }
+        vec256::map2<T>(
+            [](Vec dbeta, Vec dy) { return dbeta + dy; },
+            dbeta_buffer_ptr,
+            dbeta_buffer_ptr,
+            dY_ptr,
+            N);
+      }
+      if (!dX_null) {
+        T* dX_ptr = dX_data + i * N;
+        T ds = T(0);
+        T db = T(0);
+        // Scalar math:
+        // for (int64_t j = 0; j < N; ++j) {
+        //   const T gamma_v = gamma_null ? T(1) : gamma_data[j];
+        //   ds += dY_ptr[j] * X_ptr[j] * gamma_v;
+        //   db += dY_ptr[j] * gamma_v;
+        // }
+        if (gamma_null) {
+          ds = vec256::map2_reduce_all<T>(
+              [](Vec x, Vec y) { return x * y; },
+              [](Vec x, Vec y) { return x + y; },
+              dY_ptr,
+              X_ptr,
+              N);
+          db = vec256::reduce_all<T>(
+              [](Vec& x, Vec& y) { return x + y; },
+              dY_ptr,
+              N);
+        } else {
+          ds = vec256::map3_reduce_all<T>(
+              [](Vec x, Vec y, Vec z) { return x * y * z; },
+              [](Vec x, Vec y) { return x + y; },
+              dY_ptr,
+              X_ptr,
+              gamma_data,
+              N);
+          db = vec256::map2_reduce_all<T>(
+              [](Vec x, Vec y) { return x * y; },
+              [](Vec x, Vec y) { return x + y; },
+              dY_ptr,
+              gamma_data,
+              N);
+        }
+        const T a = rstd_data[i];
+        const T b = (db * mean_data[i] - ds) * a * a * a * scale;
+        const T c = -b * mean_data[i] - db * a * scale;
+        // Scalar math:
+        // for (int64_t j = 0; j < N; ++j) {
+        //   const T gamma_v = gamma_null ? T(1) : gamma_data[j];
+        //   dX_ptr[j] = a * dY_ptr[j] * gamma_v + b * X_ptr[j] + c;
+        // }
+        if (gamma_null) {
+          vec256::map2<T>(
+              [a, b, c](Vec dy, Vec x) { return Vec(a) * dy + Vec(b) * x + Vec(c); },
+              dX_ptr,
+              dY_ptr,
+              X_ptr,
+              N);
+        } else {
+          vec256::map3<T>(
+              [a, b, c](Vec dy, Vec gamma, Vec x) { return Vec(a) * dy * gamma + Vec(b) * x + Vec(c); },
+              dX_ptr,
+              dY_ptr,
+              gamma_data,
+              X_ptr,
+              N);
+        }
       }
     }
-    if (dgamma_data != nullptr) {
-      const T a = rstd_data[i];
-      const T b = -a * mean_data[i];
-      for (int64_t j = 0; j < N; ++j) {
-        dgamma_data[j] += dY_ptr[j] * (a * X_ptr[j] + b);
+  });
+
+  // Second path of dgamma/dbeta
+  if (buffer_data != nullptr) {
+    parallel_for(0, N, 1, [&](int64_t start, int64_t end) {
+      for (int64_t j = start; j < end; ++j) {
+        T dgamma_v = T(0);
+        T dbeta_v = T(0);
+        for (int64_t i = 0; i < num_threads; ++i) {
+          dgamma_v += buffer_data[i * N + j];
+          dbeta_v += buffer_data[num_threads * N + i * N + j];
+        }
+        if (!dgamma_null) {
+          dgamma_data[j] = dgamma_v;
+        }
+        if (!dbeta_null) {
+          dbeta_data[j] = dbeta_v;
+        }
       }
-    }
-    if (dbeta_data != nullptr) {
-      for (int64_t j = 0; j < N; ++j) {
-        dbeta_data[j] += dY_ptr[j];
-      }
-    }
+    });
   }
 }
 

--- a/aten/src/ATen/native/cpu/layer_norm_kernel.cpp
+++ b/aten/src/ATen/native/cpu/layer_norm_kernel.cpp
@@ -30,8 +30,8 @@ void LayerNormKernelImplInternal(
   DCHECK(!gamma.defined() || gamma.numel() == N);
   DCHECK(!beta.defined() || beta.numel() == N);
   T* X_data = X.data_ptr<T>();
-  T* gamma_data = gamma.defined() ? gamma.data_ptr<T>() : nullptr;
-  T* beta_data = beta.defined() ? beta.data_ptr<T>() : nullptr;
+  const T* gamma_data = gamma.defined() ? gamma.data_ptr<T>() : nullptr;
+  const T* beta_data = beta.defined() ? beta.data_ptr<T>() : nullptr;
   T* Y_data = Y->data_ptr<T>();
   T* mean_data = mean->data_ptr<T>();
   T* rstd_data = rstd->data_ptr<T>();

--- a/aten/src/ATen/native/layer_norm.cpp
+++ b/aten/src/ATen/native/layer_norm.cpp
@@ -24,7 +24,7 @@ std::tuple<Tensor, Tensor, Tensor> layer_norm_cpu(
     int64_t M,
     int64_t N,
     double eps) {
-  Tensor Y = at::native::empty_like(X, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+  Tensor Y = at::native::empty_like(X, at::MemoryFormat::Contiguous);
   Tensor mean = at::empty({M}, X.options());
   Tensor rstd = at::empty({M}, X.options());
   if (M > 0) {
@@ -46,13 +46,13 @@ std::tuple<Tensor, Tensor, Tensor> layer_norm_backward_cpu(
   Tensor dgamma;
   Tensor dbeta;
   if (grad_input_mask[0]) {
-    dX = at::native::empty_like(X, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+    dX = at::native::empty_like(X, at::MemoryFormat::Contiguous);
   }
   if (grad_input_mask[1]) {
-    dgamma = M > 0 ? at::native::empty_like(gamma, LEGACY_CONTIGUOUS_MEMORY_FORMAT) : at::native::zeros_like(gamma, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+    dgamma = M > 0 ? at::native::empty_like(gamma, at::MemoryFormat::Contiguous) : at::native::zeros_like(gamma, at::MemoryFormat::Contiguous);
   }
   if (grad_input_mask[2]) {
-    dbeta = M > 0 ? at::native::empty_like(gamma, LEGACY_CONTIGUOUS_MEMORY_FORMAT) : at::native::zeros_like(gamma, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+    dbeta = M > 0 ? at::native::empty_like(gamma, at::MemoryFormat::Contiguous) : at::native::zeros_like(gamma, at::MemoryFormat::Contiguous);
   }
   if (M > 0) {
     LayerNormBackwardKernel(


### PR DESCRIPTION
This PR aims at improving `LayerNorm` performance on CPU for both forward and backward.

Results on Xeon 6248:
1. single socket inference **1.14x** improvement
2. single core inference **1.77x** improvement
3. single socket training **6.27x** improvement

The fine tuning of GPT2 on WikiTest2 dataset time per iteration on dual socket reduced from **4.69s/it** to **3.16s/it**, **1.48x** improvement.