### PR TITLE
Break circular dependency between ATen.h and TensorIndexing.h

### DIFF
--- a/aten/src/ATen/TensorIndexing.h
+++ b/aten/src/ATen/TensorIndexing.h
@@ -2,8 +2,8 @@
 
 #include <c10/util/Optional.h>
 #include <ATen/core/TensorBody.h>
-#include <ATen/ATen.h>
 #include <ATen/ExpandUtils.h>
+#include <ATen/Functions.h>
 
 namespace at {
 namespace indexing {


### PR DESCRIPTION
This is mostly just so VS Code will stop yelling at me.