### PR TITLE
Move all warn logic for overwriting registration to OperatorEntry

### DIFF
--- a/aten/src/ATen/core/dispatch/DispatchTable.h
+++ b/aten/src/ATen/core/dispatch/DispatchTable.h
@@ -108,9 +108,6 @@ class DispatchTable final {
   void setKernel(DispatchKey dispatchKey, KernelFunction kernel) {
     auto result = kernels_.setKernel(dispatchKey, std::move(kernel));
     dispatchKeyExtractor_.setOperatorHasKernelForBackend(dispatchKey, true);
-    if (result == impl::KernelFunctionTable::SetKernelResult::OVERWROTE_EXISTING_KERNEL) {
-      TORCH_WARN("Registered a kernel for operator ", operatorName_, " with dispatch key ", dispatchKey, " that overwrote a previously registered kernel with the same dispatch key for the same operator.");
-    }
   }
 
   /**
@@ -130,9 +127,6 @@ class DispatchTable final {
    * dispatch keys, not both.
    */
   void setCatchallKernel(KernelFunction kernel) {
-    if (catchallKernel_.isValid()) {
-      TORCH_WARN("Registered a catch-all kernel for operator ", operatorName_," that overwrote a previously registered catch-all kernel for the same operator.");
-    }
     catchallKernel_ = std::move(kernel);
   }
 
@@ -140,7 +134,6 @@ class DispatchTable final {
    * Remove the catch-all kernel.
    */
   void removeCatchallKernel() {
-    TORCH_INTERNAL_ASSERT(catchallKernel_.isValid(), "Tried to remove the catch-all kernel for operator ", operatorName_," but there is no catch-all kernel registered.");
     catchallKernel_ = {};
   }
 

--- a/aten/src/ATen/core/dispatch/DispatchTable.h
+++ b/aten/src/ATen/core/dispatch/DispatchTable.h
@@ -31,30 +31,21 @@ public:
   : kernels_()
   , kernelCount_(0) {}
 
-  enum class SetKernelResult : uint8_t {ADDED_NEW_KERNEL, OVERWROTE_EXISTING_KERNEL};
-  C10_NODISCARD SetKernelResult setKernel(DispatchKey dispatchKey, KernelFunction kernel) {
+  void setKernel(DispatchKey dispatchKey, KernelFunction kernel) {
     TORCH_INTERNAL_ASSERT(dispatchKey != DispatchKey::Undefined);
     auto& slot = kernels_[static_cast<uint8_t>(dispatchKey)];
-    SetKernelResult result;;
-    if (slot.isValid()) {
-      result = SetKernelResult::OVERWROTE_EXISTING_KERNEL;
-    } else {
-      result = SetKernelResult::ADDED_NEW_KERNEL;
+    if (!slot.isValid()) {
       ++kernelCount_;
     }
     slot = std::move(kernel);
-    return result;
   }
 
-  enum class RemoveKernelIfExistsResult : uint8_t {REMOVED_KERNEL, KERNEL_DIDNT_EXIST};
-  RemoveKernelIfExistsResult removeKernelIfExists(DispatchKey dispatchKey) {
+  void removeKernelIfExists(DispatchKey dispatchKey) {
     auto& slot = kernels_[static_cast<uint8_t>(dispatchKey)];
     if (slot.isValid()) {
       --kernelCount_;
       slot = {};
-      return RemoveKernelIfExistsResult::REMOVED_KERNEL;
     } else {
-      return RemoveKernelIfExistsResult::KERNEL_DIDNT_EXIST;
     }
   }
 

--- a/aten/src/ATen/core/dispatch/DispatchTable.h
+++ b/aten/src/ATen/core/dispatch/DispatchTable.h
@@ -106,7 +106,7 @@ class DispatchTable final {
    * @param kernel Concrete kernel function implementation to register
    */
   void setKernel(DispatchKey dispatchKey, KernelFunction kernel) {
-    auto result = kernels_.setKernel(dispatchKey, std::move(kernel));
+    kernels_.setKernel(dispatchKey, std::move(kernel));
     dispatchKeyExtractor_.setOperatorHasKernelForBackend(dispatchKey, true);
   }
 

--- a/aten/src/ATen/core/dispatch/Dispatcher.cpp
+++ b/aten/src/ATen/core/dispatch/Dispatcher.cpp
@@ -218,8 +218,9 @@ void Dispatcher::cleanup(const OperatorHandle& op, const OperatorName& op_name) 
 }
 
 RegistrationHandleRAII Dispatcher::registerFallback(DispatchKey dispatchKey, KernelFunction kernel) {
-  auto inserted = backendFallbackKernels_.setKernel(dispatchKey, std::move(kernel));
-  TORCH_CHECK(inserted == impl::KernelFunctionTable::SetKernelResult::ADDED_NEW_KERNEL, "Tried to register a backend fallback kernel for ", dispatchKey, " but there was already one registered.");
+  // TODO: fallbacks clobber each other completely unsafely, unlike regular
+  // kernels
+  backendFallbackKernels_.setKernel(dispatchKey, std::move(kernel));
   if (kernel.isFallthrough()) {
     backendsWithoutFallthrough_ = backendsWithoutFallthrough_.remove(dispatchKey);
   }
@@ -230,9 +231,8 @@ RegistrationHandleRAII Dispatcher::registerFallback(DispatchKey dispatchKey, Ker
 }
 
 void Dispatcher::deregisterFallback_(DispatchKey dispatchKey) {
-  auto result = backendFallbackKernels_.removeKernelIfExists(dispatchKey);
+  backendFallbackKernels_.removeKernelIfExists(dispatchKey);
   backendsWithoutFallthrough_ = backendsWithoutFallthrough_.add(dispatchKey);
-  TORCH_INTERNAL_ASSERT(result == impl::KernelFunctionTable::RemoveKernelIfExistsResult::REMOVED_KERNEL, "Tried to deregister a backend fallback kernel for ", dispatchKey, " but there was none registered.");
 }
 
 

--- a/aten/src/ATen/core/dispatch/OperatorEntry.cpp
+++ b/aten/src/ATen/core/dispatch/OperatorEntry.cpp
@@ -94,6 +94,11 @@ std::list<OperatorEntry::KernelEntry>::iterator OperatorEntry::registerKernel(
   // Add the kernel to the kernels list,
   // possibly creating the list if this is the first kernel.
   auto& k = kernels_[dispatch_key];
+
+  if (k.size() > 0) {
+    TORCH_WARN("Registering a kernel (", debug, ") for operator ", name_, " for dispatch key ", toString(dispatch_key), " that overwrote a previously registered kernel with the same dispatch key for the same operator.");
+  }
+
   k.emplace_front(std::move(kernel), std::move(inferred_function_schema), std::move(debug));
   std::list<OperatorEntry::KernelEntry>::iterator inserted = k.begin();
   // update the dispatch table, i.e. re-establish the invariant

--- a/aten/src/ATen/core/op_registration/op_registration_test.cpp
+++ b/aten/src/ATen/core/op_registration/op_registration_test.cpp
@@ -302,7 +302,9 @@ TEST(OperatorRegistrationTest, givenMultipleKernelsWithSameDispatchKey_whenRegis
   testing::internal::CaptureStderr();
   c10::RegisterOperators().op("_test::dummy(Tensor dummy) -> ()", c10::RegisterOperators::options().kernel<DummyKernel>(c10::DispatchKey::CPUTensorId));
   std::string output = testing::internal::GetCapturedStderr();
-  EXPECT_THAT(output, testing::HasSubstr("Warning: Registered a kernel for operator _test::dummy with dispatch key CPUTensorId that overwrote a previously registered kernel with the same dispatch key for the same operator."));
+  EXPECT_THAT(output, testing::HasSubstr("_test::dummy"));
+  EXPECT_THAT(output, testing::HasSubstr("CPUTensorId"));
+  EXPECT_THAT(output, testing::HasSubstr("overwrote a previously registered kernel with the same dispatch key for the same operator"));
 }
 
 TEST(OperatorRegistrationTest, givenMultipleKernelsWithSameDispatchKey_whenRegisteringInSameOpCall_thenFails) {
@@ -338,7 +340,9 @@ TEST(OperatorRegistrationTest, givenMultipleCatchallKernels_whenRegistering_then
   testing::internal::CaptureStderr();
   c10::RegisterOperators().op("_test::dummy(Tensor dummy) -> ()", c10::RegisterOperators::options().catchAllKernel<DummyKernel>());
   std::string output = testing::internal::GetCapturedStderr();
-  EXPECT_THAT(output, testing::HasSubstr("Warning: Registered a catch-all kernel for operator _test::dummy that overwrote a previously registered catch-all kernel for the same operator."));
+  EXPECT_THAT(output, testing::HasSubstr("_test::dummy"));
+  EXPECT_THAT(output, testing::HasSubstr("catch all"));
+  EXPECT_THAT(output, testing::HasSubstr("overwrote a previously registered kernel with the same dispatch key for the same operator"));
 }
 
 TEST(OperatorRegistrationTest, givenMultipleCatchallKernels_whenRegisteringInSameOpCall_thenFails) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#35769 Move all warn logic for overwriting registration to OperatorEntry**

This fixes a bug where correct end user API usage can still trigger
a warning because we don't preserve the invariants DispatchTable
was previously expecting to be done.  So now, OperatorEntry is
the source of truth, and it just whacks DispatchTable until its
the correct state.  OperatorEntry does the user-facing checking.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D20772383](https://our.internmc.facebook.com/intern/diff/D20772383)