### PR TITLE
add test_tensorexpr.py

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -71,6 +71,7 @@ TESTS = [
     'test_function_schema',
     'test_overrides',
     'test_jit_fuser_te',
+    'test_tensorexpr',
 ]
 
 # skip < 3.3 because mock is added in 3.3 and is used in rpc_spawn

--- a/test/te_utils.py
+++ b/test/te_utils.py
@@ -9,7 +9,7 @@ class ExecutionCounter(object):
     def try_get_trigger_value(self):
         try:
             return torch._C._jit_get_trigger_value(self.name)
-        except:
+        except Exception:
             return 0
 
     def __init__(self, name):

--- a/test/te_utils.py
+++ b/test/te_utils.py
@@ -5,36 +5,36 @@ from __future__ import unicode_literals
 
 import torch
 
-
 class ExecutionCounter(object):
+    def try_get_trigger_value(self):
+        try:
+            return torch._C._jit_get_trigger_value(self.name)
+        except:
+            return 0
+
     def __init__(self, name):
         self.name = name
-        self.start_value = torch._C._jit_get_trigger_value(self.name)
+        self.start_value = self.try_get_trigger_value()
 
     def elapsed_value(self):
-        value = torch._C._jit_get_trigger_value(self.name)
+        value = self.try_get_trigger_value()
         return value - self.start_value
-
 
 class CudaCodeGenCreated(ExecutionCounter):
     def __init__(self):
         super(CudaCodeGenCreated, self).__init__("cuda_codegen_created")
 
-
 class CudaCodeGenExecuted(ExecutionCounter):
     def __init__(self):
         super(CudaCodeGenExecuted, self).__init__("cuda_codegen_executed")
-
 
 class LLVMCodeGenCreated(ExecutionCounter):
     def __init__(self):
         super(LLVMCodeGenCreated, self).__init__("llvm_codegen_created")
 
-
 class LLVMCodeGenExecuted(ExecutionCounter):
     def __init__(self):
         super(LLVMCodeGenExecuted, self).__init__("llvm_codegen_executed")
-
 
 class SimpleIREvalExecuted(ExecutionCounter):
     def __init__(self):

--- a/test/test_tensorexpr.py
+++ b/test/test_tensorexpr.py
@@ -1010,6 +1010,7 @@ class TestTensorExprFuser(BaseTestClass):
             r = test(x, y, z, a, b)
             xn, yn, zn = [t.numpy() for t in (x, y, z)]
             np.testing.assert_allclose(r.numpy(), xn + yn * a + zn * b)
+            # FIXME: interp.elapsed_value() also increments due to simplifier
             assert llvm.elapsed_value() == 1 or interp.elapsed_value() > 1
 
 # FIXME: Blocked on profiling executor changes
@@ -1046,6 +1047,7 @@ class TestTensorExprFuser(BaseTestClass):
         npr = a[0:512:2]
         npr = npr + npr
         np.testing.assert_allclose(npr.numpy(), x.numpy())
+        # FIXME: interp.elapsed_value() also increments due to simplifier
         assert llvm.elapsed_value() == 1 or interp.elapsed_value() > 1
 
 
@@ -1065,6 +1067,7 @@ class TestTensorExprFuser(BaseTestClass):
         npr = np.expand_dims(a, 0)
         npr = npr + npr
         np.testing.assert_allclose(npr, x.numpy())
+        # FIXME: interp.elapsed_value() also increments due to simplifier
         assert llvm.elapsed_value() == 1 or interp.elapsed_value() > 1
 
 
@@ -1080,6 +1083,7 @@ class TestTensorExprFuser(BaseTestClass):
         ref = test(x, y, z)
         res = test(x, y, z)
         np.testing.assert_allclose(ref.numpy(), res.numpy())
+        # FIXME: interp.elapsed_value() also increments due to simplifier
         assert llvm.elapsed_value() == 1 or interp.elapsed_value() > 1
 
 
@@ -1095,6 +1099,7 @@ class TestTensorExprFuser(BaseTestClass):
         ref = test(x, y, z)
         res = test(x, y, z)
         np.testing.assert_allclose(ref.numpy(), res.numpy())
+        # FIXME: interp.elapsed_value() also increments due to simplifier
         assert llvm.elapsed_value() == 1 or interp.elapsed_value() > 1
 
 

--- a/test/test_tensorexpr.py
+++ b/test/test_tensorexpr.py
@@ -1010,7 +1010,7 @@ class TestTensorExprFuser(BaseTestClass):
             r = test(x, y, z, a, b)
             xn, yn, zn = [t.numpy() for t in (x, y, z)]
             np.testing.assert_allclose(r.numpy(), xn + yn * a + zn * b)
-            assert llvm.elapsed_value() == 1 or interp.elapsed_value() == 1
+            assert llvm.elapsed_value() == 1 or interp.elapsed_value() > 1
 
 # FIXME: Blocked on profiling executor changes
 # def test_loop():
@@ -1028,7 +1028,7 @@ class TestTensorExprFuser(BaseTestClass):
 #    x, y, z = (torch.zeros(32, 32), torch.ones(32, 32), 4)
 #    test(x, y, z)
 #    r = test(x, y, z)
-#    assert llvm.elapsed_value == 1 or interp.elapsed_value() == 1
+#    assert llvm.elapsed_value == 1 or interp.elapsed_value() > 1
 
     def test_slice(self):
         def easy(x, y):
@@ -1046,7 +1046,7 @@ class TestTensorExprFuser(BaseTestClass):
         npr = a[0:512:2]
         npr = npr + npr
         np.testing.assert_allclose(npr.numpy(), x.numpy())
-        assert llvm.elapsed_value() == 1 or interp.elapsed_value() == 1
+        assert llvm.elapsed_value() == 1 or interp.elapsed_value() > 1
 
 
     def test_unsqueeze(self):
@@ -1065,7 +1065,7 @@ class TestTensorExprFuser(BaseTestClass):
         npr = np.expand_dims(a, 0)
         npr = npr + npr
         np.testing.assert_allclose(npr, x.numpy())
-        assert llvm.elapsed_value() == 1 or interp.elapsed_value() == 1
+        assert llvm.elapsed_value() == 1 or interp.elapsed_value() > 1
 
 
     def test_transpose(self):
@@ -1080,7 +1080,7 @@ class TestTensorExprFuser(BaseTestClass):
         ref = test(x, y, z)
         res = test(x, y, z)
         np.testing.assert_allclose(ref.numpy(), res.numpy())
-        assert llvm.elapsed_value() == 1 or interp.elapsed_value() == 1
+        assert llvm.elapsed_value() == 1 or interp.elapsed_value() > 1
 
 
     def test_sliced_stride(self):
@@ -1095,7 +1095,7 @@ class TestTensorExprFuser(BaseTestClass):
         ref = test(x, y, z)
         res = test(x, y, z)
         np.testing.assert_allclose(ref.numpy(), res.numpy())
-        assert llvm.elapsed_value() == 1 or interp.elapsed_value() == 1
+        assert llvm.elapsed_value() == 1 or interp.elapsed_value() > 1
 
 
     @unittest.skipIf(not torch.cuda.is_available(), "requires CUDA")


### PR DESCRIPTION
Adding `test_tensorexpr.py` to our CI. There's a few complications: the first one is that we now always run `SimpleIREVal` as a part of simplifier, so the counts will always be greater than one. We can potentially invest some effort to differentiate between a real codegen call to `SimpleIREval` and calls in simplifier, but it's probably not that important and the second change to turn not being able to retrieve a counter into a default value of 0 since the test are structured to test for either an llvm or simpleireval backends, so it only seems appropriate to not fail the test too early.