### PR TITLE
add fmt

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -122,3 +122,7 @@
     ignore = dirty
     path = third_party/XNNPACK
     url = https://github.com/google/XNNPACK.git
+[submodule "third_party/fmt"]
+    ignore = dirty
+    path = third_party/fmt
+    url = https://github.com/fmtlib/fmt.git

--- a/c10/CMakeLists.txt
+++ b/c10/CMakeLists.txt
@@ -67,6 +67,8 @@ if(ANDROID)
     target_link_libraries(c10 PRIVATE log)
 endif()
 
+target_link_libraries(c10 PUBLIC fmt::fmt-header-only)
+
 target_include_directories(
     c10 PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../>

--- a/c10/util/Exception.h
+++ b/c10/util/Exception.h
@@ -11,6 +11,7 @@
 #include <sstream>
 #include <string>
 #include <vector>
+#include <fmt/format.h>
 
 #if defined(_MSC_VER) && _MSC_VER <= 1900
 #define __func__ __FUNCTION__
@@ -257,6 +258,13 @@ inline std::string if_empty_then(std::string x, std::string y) {
         __FILE__                              \
     );                                        \
   }
+#define TORCH_CHECK_FMT(cond, ...)            \
+  if (C10_UNLIKELY_OR_CONST(!(cond))) {       \
+    C10_THROW_ERROR(Error,                    \
+        #cond " CHECK FAILED at "             \
+        __FILE__                              \
+    );                                        \
+  }
 #else
 #define TORCH_CHECK_WITH(error_t, cond, ...)                \
   if (C10_UNLIKELY_OR_CONST(!(cond))) {                     \
@@ -267,6 +275,16 @@ inline std::string if_empty_then(std::string x, std::string y) {
         "(Could this error message be improved?  If so, "   \
         "please report an enhancement request to PyTorch.)" \
       )                                                     \
+    );                                                      \
+  }
+
+// Like TORCH_CHECK, but use Python-like format strings for the error message.
+// Usage:
+//    TORCH_CHECK(should_be_true, "{} had an error: {}", arg1, arg2);
+#define TORCH_CHECK_FMT(cond, fmt_str, ...)                 \
+  if (C10_UNLIKELY_OR_CONST(!(cond))) {                     \
+    C10_THROW_ERROR(Error,                                  \
+      fmt::format(fmt_str, __VA_ARGS__)                     \
     );                                                      \
   }
 #endif

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -814,7 +814,6 @@ endif()
   target_include_directories(torch_cpu PRIVATE
     ${TORCH_ROOT}/third_party/miniz-2.0.8)
 
-
   install(DIRECTORY "${TORCH_SRC_DIR}/csrc"
     DESTINATION ${TORCH_INSTALL_INCLUDE_DIR}/torch
     FILES_MATCHING PATTERN "*.h")

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1537,3 +1537,6 @@ endif()
 #
 # End ATen checks
 #
+
+set(FMT_INSTALL ON CACHE BOOL " " FORCE)
+add_subdirectory(${CMAKE_SOURCE_DIR}/third_party/fmt)

--- a/torch/csrc/jit/frontend/ir_emitter.cpp
+++ b/torch/csrc/jit/frontend/ir_emitter.cpp
@@ -372,11 +372,12 @@ struct Environment {
       std::stringstream why_not;
       if (!as_simple_value->type()->isSubtypeOfExt(parent_type, &why_not)) {
         auto error = ErrorReport(loc);
-        error << "Variable '" << name << "' previously has type "
-              << simple_parent->type()->python_str()
-              << " but is now being assigned to a value of type "
-              << as_simple_value->type()->python_str();
-
+        error << fmt::format(
+            "Variable '{}' previously had type '{}', "
+            "but is now being assigned to a value of type '{}'",
+            name,
+            simple_parent->type()->python_str(),
+            as_simple_value->type()->python_str());
         // Special-cased error msg if we're trying to assign to a tensor list.
         if (simple_parent->type()->kind() == TypeKind::ListType &&
             as_simple_value->type()->kind() == TypeKind::ListType) {

--- a/torch/csrc/jit/serialization/import.cpp
+++ b/torch/csrc/jit/serialization/import.cpp
@@ -42,14 +42,12 @@ void postSetStateValidate(const IValue& v) {
     // Verify that all the non-optional attributes have been initialized
     // TODO: Issue #20497
     if (attrType->kind() != TypeKind::OptionalType) {
-      TORCH_CHECK(
+      TORCH_CHECK_FMT(
           !slot.isNone(),
-          "The field '",
+          "The field '{}' was left uninitialized after '__setstate__', "
+          "but expected a value of type '{}'",
           attrName,
-          "' was left unitialized after __setstate__, but expected a ",
-          "value of type '",
-          attrType->python_str(),
-          "'");
+          attrType->python_str());
     }
   }
 }


### PR DESCRIPTION
corona-inspired respin of https://github.com/pytorch/pytorch/pull/28289

fmt is a formatting library for C++. It has several properties that make it nice
for inclusion in PyTorch:
- Widely used
- Basically copies how Python does it
- Support for all the compilers and platforms we care about
- Standards track (C++20)
- Small code size
- We "know" the author (hi @vitaut).

This PR includes it as a submodule and sets up the build. It also
provides some example usage, including a `TORCH_CHECK_FMT` macro in c10
that should test all the builds we care about.