### PR TITLE
fixing pytorch benchmarking unit typo

### DIFF
--- a/binaries/speed_benchmark_torch.cc
+++ b/binaries/speed_benchmark_torch.cc
@@ -177,7 +177,7 @@ int main(int argc, char** argv) {
   millis = timer.MilliSeconds();
   if (FLAGS_report_pep) {
     for (auto t : times) {
-      std::cout << "PyTorchObserver {\"type\": \"NET\", \"unit\": \"us\", \"metric\": \"latency\", \"value\": \"" << t << "\"}" << std::endl;
+      std::cout << "PyTorchObserver {\"type\": \"NET\", \"unit\": \"ms\", \"metric\": \"latency\", \"value\": \"" << t << "\"}" << std::endl;
     }
   }
   std::cout << "Main run finished. Milliseconds per iter: "


### PR DESCRIPTION
Summary: Looks like the pytorch benchmarking binary was giving the wrong unit for time. I got really happy for a second but then nothing made sense.

Test Plan: sandcastle

Reviewed By: kimishpatel

Differential Revision: D20721228

