### PR TITLE
[Docs] Fix typo in RPC docs

### DIFF
--- a/docs/source/rpc/index.rst
+++ b/docs/source/rpc/index.rst
@@ -13,7 +13,7 @@ The distributed autograd design note covers the design of the RPC-based distribu
 
 -  :ref:`distributed-autograd-design`
 
-The RRef design note convers the design of the :ref:`rref` (Remote REFerence) protocol used to refer to values on remote workers by the framework.
+The RRef design note covers the design of the :ref:`rref` (Remote REFerence) protocol used to refer to values on remote workers by the framework.
 
 -  :ref:`remote-reference-protocol`
 


### PR DESCRIPTION
It's also fixed in the cherry pick PR https://github.com/pytorch/pytorch/pull/35808