### PR TITLE
Fix another case of float2::x and float2::y may not be the same on ROCm"

### DIFF
--- a/caffe2/operators/relu_op.cu
+++ b/caffe2/operators/relu_op.cu
@@ -109,8 +109,14 @@ __global__ void ReluGradientCUDAKernel<half2>(
 #else
     const float2 dy = __half22float2(dY[i]);
     const float2 yy = __half22float2(Y[i]);
-    dX[i] =
-        __floats2half2_rn(yy.x > 0.0f ? dy.x : 0.0f, yy.y > 0.0f ? dy.y : 0.0f);
+    // There are explicit cast to float here, because it may otherwise cause ambiguity on ROCm and can be triggered
+    // sometimes:
+    //
+    //   error: conditional expression is ambiguous; 'const hip_impl::Scalar_accessor<float, Native_vec_, 1>' can be
+    //   converted to 'float' and vice versa
+
+     dX[i] = __floats2half2_rn(yy.x > 0.0f ? static_cast<float>(dy.x) : 0.0f,
+                               yy.y > 0.0f ? static_cast<float>(dy.y) : 0.0f);
 #endif
   }
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#35817 Fix another case of float2::x and float2::y may not be the same on ROCm"**
* #35816 Make test_leaky_relu_inplace_with_neg_slope device-generic and skipIfRocm.

This is another case of the issue fixed in https://github.com/pytorch/pytorch/pull/35783,
but it triggers reliably on the 1.5.0 branch.

Differential Revision: [D20796779](https://our.internmc.facebook.com/intern/diff/D20796779)