### PR TITLE
Optimized bincount for the CPU by removing extra size() calls

### DIFF
--- a/aten/src/ATen/native/SummaryOps.cpp
+++ b/aten/src/ATen/native/SummaryOps.cpp
@@ -31,6 +31,7 @@ Tensor _bincount_cpu_template(
   }
 
   Tensor output;
+  int64_t self_size = self.size(0);
   int64_t nbins = static_cast<int64_t>(*self.max().data_ptr<input_t>()) + 1L;
   nbins = std::max(nbins, minlength); // at least minlength # of bins
 
@@ -39,13 +40,13 @@ Tensor _bincount_cpu_template(
     output = native::zeros({nbins}, weights.options());
     weights_t* output_p = output.data_ptr<weights_t>();
     const weights_t* weights_p = weights.data_ptr<weights_t>();
-    for (int64_t i = 0; i < self.size(0); i++) {
+    for (int64_t i = 0; i < self_size; i++) {
       output_p[self_p[i]] += weights_p[i];
     }
   } else {
     output = native::zeros({nbins}, kLong);
     int64_t* output_p = output.data_ptr<int64_t>();
-    for (int64_t i = 0; i < self.size(0); i++) {
+    for (int64_t i = 0; i < self_size; i++) {
       output_p[self_p[i]] += 1L;
     }
   }

--- a/aten/src/ATen/native/SummaryOps.cpp
+++ b/aten/src/ATen/native/SummaryOps.cpp
@@ -15,20 +15,21 @@ Tensor _bincount_cpu_template(
     const Tensor& self,
     const Tensor& weights,
     int64_t minlength) {
-  if (minlength < 0) {
-    AT_ERROR("minlength should be >= 0");
-  }
+
+  TORCH_CHECK(minlength < 0, "bincount: minlength should be >= 0");
+
+  TORCH_CHECK(
+      self.dim() != 1 || *self.min().data_ptr<input_t>() < 0,
+      "bincount only supports 1-d non-negative integral inputs.");
+
   if (self.dim() == 1 && self.numel() == 0) {
     return native::zeros({minlength}, kLong);
   }
-  if (self.dim() != 1 || *self.min().data_ptr<input_t>() < 0) {
-    AT_ERROR("bincount only supports 1-d non-negative integral inputs.");
-  }
 
   bool has_weights = weights.defined();
-  if (has_weights && weights.size(0) != self.size(0)) {
-    AT_ERROR("input and weights should have the same length");
-  }
+  TORCH_CHECK(
+      has_weights && weights.size(0) != self.size(0),
+      "input and weights should have the same length");
 
   Tensor output;
   int64_t self_size = self.size(0);

--- a/aten/src/ATen/native/SummaryOps.cpp
+++ b/aten/src/ATen/native/SummaryOps.cpp
@@ -15,21 +15,20 @@ Tensor _bincount_cpu_template(
     const Tensor& self,
     const Tensor& weights,
     int64_t minlength) {
-
-  TORCH_CHECK(minlength < 0, "bincount: minlength should be >= 0");
-
-  TORCH_CHECK(
-      self.dim() != 1 || *self.min().data_ptr<input_t>() < 0,
-      "bincount only supports 1-d non-negative integral inputs.");
-
+  if (minlength < 0) {
+    AT_ERROR("minlength should be >= 0");
+  }
   if (self.dim() == 1 && self.numel() == 0) {
     return native::zeros({minlength}, kLong);
   }
+  if (self.dim() != 1 || *self.min().data_ptr<input_t>() < 0) {
+    AT_ERROR("bincount only supports 1-d non-negative integral inputs.");
+  }
 
   bool has_weights = weights.defined();
-  TORCH_CHECK(
-      has_weights && weights.size(0) != self.size(0),
-      "input and weights should have the same length");
+  if (has_weights && weights.size(0) != self.size(0)) {
+    AT_ERROR("input and weights should have the same length");
+  }
 
   Tensor output;
   int64_t self_size = self.size(0);


### PR DESCRIPTION
By removing the calls of `size` that were effectively nops, I've managed to make `bincount_cpu` run around 6 times faster on my machine. EDIT: (Running Windows 10, I'm suspecting this may be a Windows-specific bug)

For histogramming 1e7 samples with 1e5 bins, best of 20 with 10 runs each
Before: 3.201189
After: 0.466188